### PR TITLE
feat: add skill setup hook in entrypoint

### DIFF
--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -11,4 +11,12 @@ mkdir -p \
   /app/docs/ppt \
   /app/audit
 
+# Run skill setup scripts (if any)
+for f in /app/skills/*/setup.sh; do
+  [ -f "$f" ] && [ -x "$f" ] && {
+    echo "Running skill setup: $f"
+    "$f" || echo "Warning: $f exited with code $?"
+  }
+done
+
 exec "$@"


### PR DESCRIPTION
容器启动时自动执行 `/app/skills/*/setup.sh`，让 skill 可以在挂载后自行初始化环境（装工具、写配置等），不需要改 runtime 代码。

改动只有 `deploy/docker/entrypoint.sh`，在 `exec "$@"` 前加了一个 for 循环扫描 setup 脚本。

用途示例：deploy skill 的 `setup.sh` 在启动时检测 docker.sock 是否可用。