### PR TITLE
feat: 添加 /stop 和改进 /clear 命令

### DIFF
--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -157,8 +157,10 @@ async function interactiveChat(session: AgentSession): Promise<void> {
   console.log(
     styles.text('开始对话吧！输入消息后按回车发送。\n输入 ') +
     styles.highlight('/exit') + styles.text(' 退出对话，输入 ') +
-    styles.highlight('/skills') + styles.text(' 查看可用技能。\n输入 ') +
+    styles.highlight('/stop') + styles.text(' 暂停会话，输入 ') +
     styles.highlight('/clear') + styles.text(' 清空历史，输入 ') +
+    styles.highlight('/clear --all') + styles.text(' 清空历史并删除文件，输入 ') +
+    styles.highlight('/skills') + styles.text(' 查看可用技能。\n输入 ') +
     styles.highlight('/history') + styles.text(' 查看历史信息。\n'),
   );
 

--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -471,10 +471,20 @@ export class AgentSession {
   ): Promise<CommandResult> {
     const commandName = command.toLowerCase();
 
+    // /stop - 中断当前正在运行的请求
+    if (commandName === 'stop') {
+      this.requestInterrupt();
+      return { handled: true, reply: '正在停止当前请求...' };
+    }
+
     // /clear
     if (commandName === 'clear') {
-      this.clear();
-      return { handled: true, reply: '会话已清空' };
+      if (args.includes('--all')) {
+        this.clear();
+        return { handled: true, reply: '历史已清空，文件已删除' };
+      }
+      this.reset();
+      return { handled: true, reply: '历史已清空' };
     }
 
     // /skills
@@ -503,14 +513,19 @@ export class AgentSession {
 
   // ─── 生命周期 ──────────────────────────────────────
 
-  /** 清空历史 */
-  clear(): void {
-    SessionStore.getInstance().deleteSession(this.key);
+  /** 重置会话状态（仅清内存，保留历史文件） */
+  reset(): void {
     this.messages = [];
     this.initialized = false;
     this.activeSkillName = undefined;
     this.activeSkillMaxTurns = undefined;
     this.lastActiveAt = Date.now();
+  }
+
+  /** 清空历史（同时删除文件） */
+  clear(): void {
+    SessionStore.getInstance().deleteSession(this.key);
+    this.reset();
   }
 
   async summarizeAndDestroy(): Promise<boolean> {


### PR DESCRIPTION
## 功能说明

### 新增 /stop 命令
- 中断当前正在运行的 AI 请求
- 用于用户想要停止长时间运行的对话

### 改进 /clear 命令
- **`/clear`**：仅清空内存历史，保留持久化文件（下次可恢复）
- **`/clear --all`**：清空内存并删除持久化的 context 文件（彻底清除）

### 代码重构
- 拆分 `clear()` 和 `reset()` 方法，职责更清晰：
  - `reset()`：仅清空内存状态
  - `clear()`：删除持久化文件 + 调用 reset()
- 更新帮助文本，添加新命令说明

## 修改文件
- `src/core/agent-session.ts`：添加命令处理逻辑和生命周期方法
- `src/commands/chat.ts`：更新帮助文本

## 测试建议
- 测试 `/stop` 能否中断正在运行的请求
- 测试 `/clear` 清空内存但保留文件
- 测试 `/clear --all` 彻底删除持久化文件