### PR TITLE
fix: refine runtime log uploads to inspector

### DIFF
--- a/src/tools/send-to-inspector-tool.ts
+++ b/src/tools/send-to-inspector-tool.ts
@@ -389,6 +389,8 @@ export class SendToInspectorTool implements Tool {
       await this.uploadFile(`${endpoint}/${encodeURIComponent(caseId)}/files`, file, process.env.INSPECTOR_SERVER_API_KEY?.trim());
     }
 
+    await this.postJson(`${endpoint}/${encodeURIComponent(caseId)}/complete`, {}, process.env.INSPECTOR_SERVER_API_KEY?.trim());
+
     fs.writeFileSync(path.join(bundleDir, 'upload-result.json'), JSON.stringify(response, null, 2), 'utf-8');
     return response;
   }

--- a/src/utils/inspector-upload-scheduler.ts
+++ b/src/utils/inspector-upload-scheduler.ts
@@ -90,36 +90,30 @@ export class InspectorUploadScheduler {
 
     this.running = true;
     try {
-      let uploadedCount = 0;
-      while (!this.stopped) {
-        const pendingLogPaths = await this.collectPendingLogPaths();
-        if (pendingLogPaths.length === 0) {
-          if (uploadedCount === 0) {
-            Logger.info(`[InspectorAutoUpload] no pending stable logs (${reason})`);
-          }
-          break;
-        }
-
-        const batch = pendingLogPaths.slice(0, this.getMaxBatchFiles());
-        const result = await this.tool.executeWithResult(
-          {
-            analysis_type: 'runtime',
-            user_request: this.buildAutoUploadRequest(reason, batch.length),
-            log_paths: batch,
-            max_files: batch.length,
-          },
-          this.createToolContext(),
-        );
-
-        if (!result.uploaded) {
-          Logger.warning(`[InspectorAutoUpload] upload skipped/failed (${reason}): ${result.message}`);
-          break;
-        }
-
-        this.markUploaded(result.selectedFiles, result.caseId);
-        uploadedCount += result.selectedFiles.length;
-        Logger.info(`[InspectorAutoUpload] uploaded ${result.selectedFiles.length} files (${reason}) -> ${result.caseId || 'unknown-case'}`);
+      const pendingLogPaths = await this.collectPendingLogPaths();
+      if (pendingLogPaths.length === 0) {
+        Logger.info(`[InspectorAutoUpload] no pending stable logs (${reason})`);
+        return;
       }
+
+      const batch = pendingLogPaths.slice(0, this.getMaxBatchFiles());
+      const result = await this.tool.executeWithResult(
+        {
+          analysis_type: 'runtime',
+          user_request: this.buildAutoUploadRequest(reason, batch.length),
+          log_paths: batch,
+          max_files: batch.length,
+        },
+        this.createToolContext(),
+      );
+
+      if (!result.uploaded) {
+        Logger.warning(`[InspectorAutoUpload] upload skipped/failed (${reason}): ${result.message}`);
+        return;
+      }
+
+      this.markUploaded(result.selectedFiles, result.caseId);
+      Logger.info(`[InspectorAutoUpload] uploaded ${result.selectedFiles.length} files (${reason}) -> ${result.caseId || 'unknown-case'}`);
     } catch (error: any) {
       Logger.warning(`[InspectorAutoUpload] cycle failed (${reason}): ${error.message}`);
     } finally {
@@ -193,7 +187,7 @@ export class InspectorUploadScheduler {
       absolute: false,
       nodir: true,
       windowsPathsNoEscape: true,
-      ignore: ['**/inspector-review*.jsonl'],
+      ignore: ['**/*inspector-review*.jsonl'],
     });
 
     return candidates
@@ -202,7 +196,7 @@ export class InspectorUploadScheduler {
       .sort((a, b) => {
         const aStats = fs.statSync(path.join(this.logsRoot, a));
         const bStats = fs.statSync(path.join(this.logsRoot, b));
-        return aStats.mtimeMs - bStats.mtimeMs;
+        return bStats.mtimeMs - aStats.mtimeMs;
       })
       .map(relativePath => path.join('logs', relativePath).replace(/\\/g, '/'));
   }

--- a/tests/inspector-upload-scheduler.test.ts
+++ b/tests/inspector-upload-scheduler.test.ts
@@ -51,16 +51,24 @@ describe('InspectorUploadScheduler', () => {
     const stableRuntimeLog = path.join(runtimeLogDir, 'stable.log');
     const freshRuntimeLog = path.join(runtimeLogDir, 'fresh.log');
     const stableSessionLog = path.join(sessionLogDir, 'user_demo.jsonl');
+    const reviewSessionLog = path.join(sessionLogDir, 'group_demo_inspector-review_case-1.jsonl');
+    const oldRuntimeLog = path.join(runtimeLogDir, 'older.log');
     fs.writeFileSync(stableRuntimeLog, '[INFO] stable runtime', 'utf-8');
     fs.writeFileSync(freshRuntimeLog, '[INFO] fresh runtime', 'utf-8');
     fs.writeFileSync(stableSessionLog, '{"turn":1}', 'utf-8');
+    fs.writeFileSync(reviewSessionLog, '{"turn":1,"role":"assistant"}', 'utf-8');
+    fs.writeFileSync(oldRuntimeLog, '[INFO] old runtime', 'utf-8');
 
     const oldDate = new Date(Date.now() - 10 * 60 * 1000);
     fs.utimesSync(stableRuntimeLog, oldDate, oldDate);
     fs.utimesSync(stableSessionLog, oldDate, oldDate);
+    fs.utimesSync(reviewSessionLog, oldDate, oldDate);
+    const olderDate = new Date(Date.now() - 30 * 60 * 1000);
+    fs.utimesSync(oldRuntimeLog, olderDate, olderDate);
 
     const receivedBodies: any[] = [];
     const uploadedFiles: Array<{ path?: string; kind?: string }> = [];
+    const completedCases: string[] = [];
     server = http.createServer((req, res) => {
       const chunks: Buffer[] = [];
       req.on('data', chunk => {
@@ -71,7 +79,7 @@ describe('InspectorUploadScheduler', () => {
         if (req.url === '/api/inspector/cases') {
           receivedBodies.push(JSON.parse(bodyBuffer.toString('utf-8') || '{}'));
           res.writeHead(200, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ caseId: `case-${receivedBodies.length}`, status: 'received' }));
+          res.end(JSON.stringify({ caseId: `case-${receivedBodies.length}`, status: 'uploading' }));
           return;
         }
 
@@ -83,6 +91,14 @@ describe('InspectorUploadScheduler', () => {
           });
           res.writeHead(201, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ ok: true }));
+          return;
+        }
+
+        const completeMatch = String(req.url).match(/^\/api\/inspector\/cases\/(case-\d+)\/complete$/);
+        if (completeMatch) {
+          completedCases.push(completeMatch[1]);
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ ok: true, caseId: completeMatch[1], status: 'received' }));
           return;
         }
 
@@ -99,30 +115,37 @@ describe('InspectorUploadScheduler', () => {
     process.env.INSPECTOR_SERVER_API_KEY = 'demo-key';
     process.env.INSPECTOR_AUTO_UPLOAD_ENABLED = 'true';
     process.env.INSPECTOR_AUTO_UPLOAD_STABLE_MINUTES = '5';
-    process.env.INSPECTOR_AUTO_UPLOAD_MAX_FILES = '12';
+    process.env.INSPECTOR_AUTO_UPLOAD_MAX_FILES = '2';
     delete process.env.XIAOBA_ROLE;
 
     const scheduler = new InspectorUploadScheduler(testRoot);
     await scheduler.start();
 
-    await waitFor(() => uploadedFiles.length === 2);
+    await waitFor(() => completedCases.length === 1);
     assert.strictEqual(receivedBodies.length, 1);
     assert.deepStrictEqual(
       uploadedFiles.map(file => file.path).sort(),
       ['2026-04-14/stable.log', 'sessions/feishu/2026-04-14/user_demo.jsonl'],
     );
+    assert.strictEqual(completedCases.length, 1);
+    assert.ok(!uploadedFiles.some(file => file.path === '2026-04-14/older.log'));
+    assert.ok(!uploadedFiles.some(file => String(file.path).includes('inspector-review')));
 
     await scheduler.runPendingUploadCycle('manual');
-    assert.strictEqual(receivedBodies.length, 1);
+    assert.strictEqual(receivedBodies.length, 2);
+    assert.deepStrictEqual(
+      uploadedFiles.slice(2).map(file => file.path),
+      ['2026-04-14/older.log'],
+    );
 
     fs.writeFileSync(stableSessionLog, '{"turn":1}\n{"turn":2}', 'utf-8');
     const newerOldDate = new Date(Date.now() - 10 * 60 * 1000);
     fs.utimesSync(stableSessionLog, newerOldDate, newerOldDate);
 
     await scheduler.runPendingUploadCycle('manual');
-    assert.strictEqual(receivedBodies.length, 2);
+    assert.strictEqual(receivedBodies.length, 3);
     assert.deepStrictEqual(
-      uploadedFiles.slice(2).map(file => file.path),
+      uploadedFiles.slice(3).map(file => file.path),
       ['sessions/feishu/2026-04-14/user_demo.jsonl'],
     );
 
@@ -138,6 +161,11 @@ function restoreEnv(key: string, value: string | undefined): void {
   }
 }
 
+function extractMultipartField(raw: string, fieldName: string): string | undefined {
+  const match = raw.match(new RegExp(`name="${fieldName}"\\r\\n\\r\\n([^\\r]+)`));
+  return match?.[1];
+}
+
 async function waitFor(predicate: () => boolean, maxAttempts: number = 40, delayMs: number = 50): Promise<void> {
   for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
     if (predicate()) {
@@ -146,9 +174,4 @@ async function waitFor(predicate: () => boolean, maxAttempts: number = 40, delay
     await new Promise(resolve => setTimeout(resolve, delayMs));
   }
   throw new Error('waitFor timeout');
-}
-
-function extractMultipartField(raw: string, fieldName: string): string | undefined {
-  const match = raw.match(new RegExp(`name="${fieldName}"\\r\\n\\r\\n([^\\r]+)`));
-  return match?.[1];
 }

--- a/tests/send-to-inspector-tool.test.ts
+++ b/tests/send-to-inspector-tool.test.ts
@@ -54,6 +54,7 @@ describe('SendToInspectorTool', () => {
     );
 
     let receivedBody: any;
+    let completionCount = 0;
     const uploadedFiles: Array<{ path?: string; kind?: string; raw: string }> = [];
     const server = http.createServer((req, res) => {
       const chunks: Buffer[] = [];
@@ -78,6 +79,13 @@ describe('SendToInspectorTool', () => {
           });
           res.writeHead(201, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ ok: true }));
+          return;
+        }
+
+        if (req.url === '/api/inspector/cases/case-demo-1/complete') {
+          completionCount += 1;
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ ok: true, caseId: 'case-demo-1', status: 'received' }));
           return;
         }
 
@@ -123,6 +131,7 @@ describe('SendToInspectorTool', () => {
         uploadedFiles.map(file => file.kind).sort(),
         ['runtime_log', 'session_jsonl'],
       );
+      assert.strictEqual(completionCount, 1);
       assert.ok(fs.existsSync(path.join(testRoot, 'files', 'inspector-cases')));
     } finally {
       server.close();


### PR DESCRIPTION
## Summary
- keep runtime auto-upload to a single batch per cycle instead of draining the full backlog in one startup
- prioritize newer stable logs first and ignore inspector review logs when selecting files
- finalize runtime uploads with a completion call after all files are sent
- add runtime-only regression coverage for upload completion and batch selection

## Scope
- runtime log upload behavior only
- excludes role design and role-specific mechanism changes

## Validation
- node ..\\node_modules\\typescript\\bin\\tsc --noEmit
- node ..\\node_modules\\tsx\\dist\\cli.mjs --test tests\\send-to-inspector-tool.test.ts tests\\inspector-upload-scheduler.test.ts