### PR TITLE
feat(runtime): auto ingest session logs to AutoDev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,13 @@
 # .env example
 
+# AutoDev runtime log archive
+AUTODEV_SERVER_URL=http://127.0.0.1:8090
+AUTODEV_API_KEY=
+LOG_INGEST_AUTO_ENABLED=true
+LOG_INGEST_AUTO_TIME=20:00
+LOG_INGEST_STABLE_MINUTES=5
+LOG_INGEST_AUTO_MAX_FILES=12
+
 # Inspector runtime upload settings
 INSPECTOR_SERVER_URL=http://your-inspector-host:3800
 INSPECTOR_SERVER_API_KEY=replace-me

--- a/src/utils/autodev-config.ts
+++ b/src/utils/autodev-config.ts
@@ -1,0 +1,15 @@
+export function getAutoDevServerUrl(): string {
+  return String(
+    process.env.AUTODEV_SERVER_URL
+    || process.env.XIAOBA_AUTODEV_SERVER_URL
+    || '',
+  ).trim().replace(/\/+$/, '');
+}
+
+export function getAutoDevApiKey(): string {
+  return String(process.env.AUTODEV_API_KEY || '').trim();
+}
+
+export function isAutoDevConfigured(): boolean {
+  return !!getAutoDevServerUrl();
+}

--- a/src/utils/autodev-log-client.ts
+++ b/src/utils/autodev-log-client.ts
@@ -1,0 +1,64 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { getAutoDevApiKey, getAutoDevServerUrl } from './autodev-config';
+
+export interface AutoDevIngestLogResponse {
+  log_id: string;
+  session_type: string;
+  session_id: string;
+  log_date: string;
+  size_bytes: number;
+}
+
+export class AutoDevLogClient {
+  constructor(
+    private readonly baseUrl: string = getAutoDevServerUrl(),
+    private readonly apiKey: string = getAutoDevApiKey(),
+  ) {}
+
+  isConfigured(): boolean {
+    return !!this.baseUrl;
+  }
+
+  async ingestLog(input: {
+    filePath: string;
+    sessionType: string;
+    sessionId: string;
+    logDate: string;
+  }): Promise<AutoDevIngestLogResponse> {
+    const form = new FormData();
+    form.append('session_type', input.sessionType);
+    form.append('session_id', input.sessionId);
+    form.append('log_date', input.logDate);
+
+    const fileBuffer = fs.readFileSync(input.filePath);
+    const fileName = path.basename(input.filePath);
+    form.append('file', new Blob([fileBuffer], { type: 'application/x-ndjson' }), fileName);
+
+    const response = await fetch(this.buildUrl('/api/logs/ingest'), {
+      method: 'POST',
+      headers: this.buildHeaders(),
+      body: form,
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`AutoDev ingest failed (${response.status}): ${errorText}`);
+    }
+
+    return response.json() as Promise<AutoDevIngestLogResponse>;
+  }
+
+  private buildUrl(requestPath: string): string {
+    if (!this.baseUrl) {
+      throw new Error('AUTODEV_SERVER_URL is not configured');
+    }
+    return `${this.baseUrl}${requestPath.startsWith('/') ? requestPath : `/${requestPath}`}`;
+  }
+
+  private buildHeaders(): Record<string, string> {
+    return this.apiKey
+      ? { 'x-autodev-key': this.apiKey }
+      : {};
+  }
+}

--- a/src/utils/log-ingest-config.ts
+++ b/src/utils/log-ingest-config.ts
@@ -1,0 +1,41 @@
+import { getAutoDevServerUrl } from './autodev-config';
+
+const DEFAULT_AUTO_INGEST_TIME = '23:59';
+const DEFAULT_STABLE_MINUTES = 5;
+const DEFAULT_MAX_FILES = 12;
+
+function readEnv(primaryName: string, legacyName: string): string | undefined {
+  return process.env[primaryName] ?? process.env[legacyName];
+}
+
+export function getLogIngestServerUrl(): string {
+  return getAutoDevServerUrl();
+}
+
+export function isLogIngestAutoEnabled(): boolean {
+  const raw = readEnv('LOG_INGEST_AUTO_ENABLED', 'INSPECTOR_AUTO_UPLOAD_ENABLED');
+  if (raw == null || raw === '') {
+    return true;
+  }
+  return String(raw).trim().toLowerCase() === 'true';
+}
+
+export function getLogIngestAutoTime(): string {
+  return String(readEnv('LOG_INGEST_AUTO_TIME', 'INSPECTOR_AUTO_UPLOAD_TIME') || DEFAULT_AUTO_INGEST_TIME).trim() || DEFAULT_AUTO_INGEST_TIME;
+}
+
+export function getLogIngestStableMinutes(): number {
+  const parsed = Number(readEnv('LOG_INGEST_STABLE_MINUTES', 'INSPECTOR_AUTO_UPLOAD_STABLE_MINUTES') || DEFAULT_STABLE_MINUTES);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return DEFAULT_STABLE_MINUTES;
+  }
+  return parsed;
+}
+
+export function getLogIngestAutoMaxFiles(): number {
+  const parsed = Number(readEnv('LOG_INGEST_AUTO_MAX_FILES', 'INSPECTOR_AUTO_UPLOAD_MAX_FILES') || DEFAULT_MAX_FILES);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_MAX_FILES;
+  }
+  return Math.min(Math.floor(parsed), DEFAULT_MAX_FILES);
+}

--- a/src/utils/log-ingest-scheduler.ts
+++ b/src/utils/log-ingest-scheduler.ts
@@ -1,0 +1,299 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { glob } from 'glob';
+import { Logger } from './logger';
+import { AutoDevLogClient } from './autodev-log-client';
+import {
+  getLogIngestAutoMaxFiles,
+  getLogIngestAutoTime,
+  getLogIngestServerUrl,
+  getLogIngestStableMinutes,
+  isLogIngestAutoEnabled,
+} from './log-ingest-config';
+
+interface IngestedLogState {
+  size: number;
+  mtimeMs: number;
+  ingestedAt: string;
+}
+
+interface IngestStateFile {
+  files: Record<string, IngestedLogState>;
+}
+
+type IngestReason = 'startup' | 'scheduled' | 'manual';
+
+export class LogIngestScheduler {
+  private readonly workingDirectory: string;
+  private readonly logsRoot: string;
+  private readonly stateFilePath: string;
+  private timer: NodeJS.Timeout | null = null;
+  private running = false;
+  private started = false;
+  private stopped = false;
+
+  constructor(workingDirectory: string = process.cwd()) {
+    this.workingDirectory = workingDirectory;
+    this.logsRoot = path.resolve(this.workingDirectory, 'logs');
+    this.stateFilePath = path.resolve(this.workingDirectory, 'data', 'log-ingest-state.json');
+  }
+
+  static isEnabled(): boolean {
+    return isLogIngestAutoEnabled();
+  }
+
+  static shouldStartForCurrentRuntime(): boolean {
+    const normalizedRole = String(process.env.XIAOBA_ROLE || '')
+      .trim()
+      .toLowerCase()
+      .replace(/[\s_]+/g, '-');
+    return LogIngestScheduler.isEnabled()
+      && normalizedRole !== 'inspector-cat'
+      && !!getLogIngestServerUrl();
+  }
+
+  async start(): Promise<void> {
+    if (this.started || !LogIngestScheduler.shouldStartForCurrentRuntime()) {
+      return;
+    }
+
+    this.started = true;
+    this.stopped = false;
+    Logger.info('[LogIngest] scheduler started');
+
+    void this.runPendingIngestCycle('startup');
+    this.scheduleNextRun();
+  }
+
+  async stop(): Promise<void> {
+    this.stopped = true;
+    this.started = false;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    Logger.info('[LogIngest] scheduler stopped');
+  }
+
+  async runPendingIngestCycle(reason: IngestReason = 'manual'): Promise<void> {
+    if (this.running || this.stopped || !LogIngestScheduler.shouldStartForCurrentRuntime()) {
+      return;
+    }
+
+    if (!fs.existsSync(this.logsRoot) || !fs.statSync(this.logsRoot).isDirectory()) {
+      return;
+    }
+
+    this.running = true;
+    try {
+      const pendingLogPaths = await this.collectPendingLogPaths();
+      if (pendingLogPaths.length === 0) {
+        Logger.info(`[LogIngest] no pending stable logs (${reason})`);
+        return;
+      }
+
+      const client = new AutoDevLogClient();
+      if (!client.isConfigured()) {
+        Logger.warning('[LogIngest] AUTODEV_SERVER_URL not set, skipping');
+        return;
+      }
+
+      const batch = pendingLogPaths.slice(0, this.getMaxBatchFiles());
+      const ingested: Array<{ relativePath: string; size: number; absolutePath: string }> = [];
+
+      for (const relativePath of batch) {
+        const absolutePath = path.resolve(this.workingDirectory, relativePath);
+        try {
+          const { sessionType, sessionId, logDate } = this.parseLogPath(relativePath, absolutePath);
+          await client.ingestLog({ filePath: absolutePath, sessionType, sessionId, logDate });
+          ingested.push({ relativePath, size: fs.statSync(absolutePath).size, absolutePath });
+        } catch (err: any) {
+          Logger.warning(`[LogIngest] failed to ingest ${relativePath}: ${err.message}`);
+        }
+      }
+
+      if (ingested.length > 0) {
+        this.markIngested(ingested);
+        Logger.info(`[LogIngest] ingested ${ingested.length} files (${reason})`);
+      }
+    } catch (error: any) {
+      Logger.warning(`[LogIngest] cycle failed (${reason}): ${error.message}`);
+    } finally {
+      this.running = false;
+    }
+  }
+
+  private parseLogPath(relativePath: string, absolutePath: string): { sessionType: string; sessionId: string; logDate: string } {
+    const parts = relativePath.replace(/\\/g, '/').split('/');
+    const sessionType = parts[2] || 'unknown';
+    const logDate = parts[3] || '';
+    const filename = parts[4] || '';
+    const sessionId = this.readSessionIdFromJsonl(absolutePath) || this.parseSessionIdFromFilename(filename) || filename.replace(/\.jsonl$/i, '');
+    return { sessionType, sessionId, logDate };
+  }
+
+  private readSessionIdFromJsonl(filePath: string): string | undefined {
+    try {
+      const firstLine = fs.readFileSync(filePath, 'utf-8')
+        .split(/\r?\n/)
+        .map(line => line.trim())
+        .find(Boolean);
+      if (!firstLine) {
+        return undefined;
+      }
+      const parsed = JSON.parse(firstLine);
+      return typeof parsed?.session_id === 'string' ? parsed.session_id : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private parseSessionIdFromFilename(filename: string): string | undefined {
+    const basename = filename.replace(/\.jsonl$/i, '');
+    const userMatch = basename.match(/(?:^|_)user_(.+)$/);
+    if (userMatch) {
+      return `user:${userMatch[1]}`;
+    }
+    const groupMatch = basename.match(/(?:^|_)group_(.+)$/);
+    if (groupMatch) {
+      return `group:${groupMatch[1]}`;
+    }
+    return undefined;
+  }
+
+  private getMaxBatchFiles(): number {
+    return getLogIngestAutoMaxFiles();
+  }
+
+  private getStableAgeMs(): number {
+    const minutes = getLogIngestStableMinutes();
+    return minutes * 60 * 1000;
+  }
+
+  private scheduleNextRun(): void {
+    if (this.stopped) {
+      return;
+    }
+
+    const uploadTime = getLogIngestAutoTime();
+    const [hoursRaw, minutesRaw] = uploadTime.split(':');
+    const hours = Number(hoursRaw);
+    const minutes = Number(minutesRaw);
+    const now = new Date();
+    const next = new Date(now);
+
+    if (!Number.isFinite(hours) || !Number.isFinite(minutes)) {
+      next.setHours(20, 0, 0, 0);
+    } else {
+      next.setHours(hours, minutes, 0, 0);
+    }
+
+    if (next.getTime() <= now.getTime()) {
+      next.setDate(next.getDate() + 1);
+    }
+
+    const delay = Math.max(1000, next.getTime() - now.getTime());
+    this.timer = setTimeout(async () => {
+      await this.runPendingIngestCycle('scheduled');
+      this.scheduleNextRun();
+    }, delay);
+
+    Logger.info(`[LogIngest] next run scheduled at ${next.toISOString()}`);
+  }
+
+  private async collectPendingLogPaths(): Promise<string[]> {
+    const stableBefore = Date.now() - this.getStableAgeMs();
+    const state = this.loadState();
+    const candidates = await glob(['sessions/**/*.jsonl'], {
+      cwd: this.logsRoot,
+      absolute: false,
+      nodir: true,
+      windowsPathsNoEscape: true,
+      ignore: ['**/*inspector-review*.jsonl'],
+    });
+
+    return candidates
+      .map(relativePath => relativePath.replace(/\\/g, '/'))
+      .filter(relativePath => this.isStableAndPending(
+        relativePath,
+        stableBefore,
+        state.files[this.toStateKey(relativePath)] || state.files[relativePath],
+      ))
+      .sort((a, b) => {
+        const aStats = fs.statSync(path.join(this.logsRoot, a));
+        const bStats = fs.statSync(path.join(this.logsRoot, b));
+        return bStats.mtimeMs - aStats.mtimeMs;
+      })
+      .map(relativePath => path.join('logs', relativePath).replace(/\\/g, '/'));
+  }
+
+  private isStableAndPending(relativePath: string, stableBefore: number, ingestedState?: IngestedLogState): boolean {
+    const absolutePath = path.join(this.logsRoot, relativePath);
+    if (!fs.existsSync(absolutePath) || !fs.statSync(absolutePath).isFile()) {
+      return false;
+    }
+
+    const stats = fs.statSync(absolutePath);
+    if (stats.mtimeMs > stableBefore) {
+      return false;
+    }
+
+    if (!ingestedState) {
+      return true;
+    }
+
+    return ingestedState.size !== stats.size || ingestedState.mtimeMs !== stats.mtimeMs;
+  }
+
+  private markIngested(files: Array<{ relativePath: string; size: number; absolutePath: string }>): void {
+    const state = this.loadState();
+    for (const file of files) {
+      const stats = fs.statSync(file.absolutePath);
+      state.files[this.normalizeStateKey(file.relativePath)] = {
+        size: stats.size,
+        mtimeMs: stats.mtimeMs,
+        ingestedAt: new Date().toISOString(),
+      };
+    }
+    this.saveState(state);
+  }
+
+  private loadState(): IngestStateFile {
+    try {
+      if (!fs.existsSync(this.stateFilePath)) {
+        return { files: {} };
+      }
+      const rawState = JSON.parse(fs.readFileSync(this.stateFilePath, 'utf-8')) as IngestStateFile;
+      const normalizedFiles = Object.entries(rawState.files || {}).reduce<Record<string, IngestedLogState>>((acc, [key, value]) => {
+        acc[this.normalizeStateKey(key)] = value;
+        return acc;
+      }, {});
+      return { files: normalizedFiles };
+    } catch {
+      return { files: {} };
+    }
+  }
+
+  private saveState(state: IngestStateFile): void {
+    fs.mkdirSync(path.dirname(this.stateFilePath), { recursive: true });
+    fs.writeFileSync(this.stateFilePath, JSON.stringify(state, null, 2), 'utf-8');
+  }
+
+  private toStateKey(relativePath: string): string {
+    return path.join('logs', relativePath).replace(/\\/g, '/');
+  }
+
+  private normalizeStateKey(key: string): string {
+    const normalized = key.replace(/\\/g, '/').trim();
+    if (!normalized) {
+      return normalized;
+    }
+    if (normalized.startsWith('logs/')) {
+      return normalized;
+    }
+    if (normalized.startsWith('sessions/')) {
+      return `logs/${normalized}`;
+    }
+    return normalized;
+  }
+}

--- a/src/utils/runtime-command-support.ts
+++ b/src/utils/runtime-command-support.ts
@@ -1,7 +1,9 @@
 import { InspectorUploadScheduler } from './inspector-upload-scheduler';
+import { LogIngestScheduler } from './log-ingest-scheduler';
 
 interface ActiveRuntimeSupport {
-  uploadScheduler: InspectorUploadScheduler | null;
+  autoDevLogIngestScheduler: LogIngestScheduler | null;
+  inspectorUploadScheduler: InspectorUploadScheduler | null;
   stop(): Promise<void>;
 }
 
@@ -15,19 +17,29 @@ export async function startRuntimeCommandSupport(): Promise<ActiveRuntimeSupport
 
   if (!startPromise) {
     startPromise = (async () => {
-      const uploadScheduler = InspectorUploadScheduler.shouldStartForCurrentRuntime()
+      const autoDevLogIngestScheduler = LogIngestScheduler.shouldStartForCurrentRuntime()
+        ? new LogIngestScheduler(process.cwd())
+        : null;
+      const inspectorUploadScheduler = !autoDevLogIngestScheduler && InspectorUploadScheduler.shouldStartForCurrentRuntime()
         ? new InspectorUploadScheduler(process.cwd())
         : null;
 
-      if (uploadScheduler) {
-        await uploadScheduler.start();
+      if (autoDevLogIngestScheduler) {
+        await autoDevLogIngestScheduler.start();
+      }
+      if (inspectorUploadScheduler) {
+        await inspectorUploadScheduler.start();
       }
 
       const support: ActiveRuntimeSupport = {
-        uploadScheduler,
+        autoDevLogIngestScheduler,
+        inspectorUploadScheduler,
         async stop() {
-          if (uploadScheduler) {
-            await uploadScheduler.stop();
+          if (autoDevLogIngestScheduler) {
+            await autoDevLogIngestScheduler.stop();
+          }
+          if (inspectorUploadScheduler) {
+            await inspectorUploadScheduler.stop();
           }
         },
       };

--- a/tests/log-ingest-scheduler.test.ts
+++ b/tests/log-ingest-scheduler.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as http from 'http';
+import { LogIngestScheduler } from '../src/utils/log-ingest-scheduler';
+
+describe('LogIngestScheduler', () => {
+  let testRoot: string;
+  let server: http.Server | null = null;
+  const originalEnv = {
+    autoDevServerUrl: process.env.AUTODEV_SERVER_URL,
+    autoDevApiKey: process.env.AUTODEV_API_KEY,
+    autoEnabled: process.env.LOG_INGEST_AUTO_ENABLED,
+    autoTime: process.env.LOG_INGEST_AUTO_TIME,
+    stableMinutes: process.env.LOG_INGEST_STABLE_MINUTES,
+    maxFiles: process.env.LOG_INGEST_AUTO_MAX_FILES,
+    xiaobaRole: process.env.XIAOBA_ROLE,
+  };
+
+  beforeEach(() => {
+    testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-log-ingest-'));
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise(resolve => server?.close(resolve));
+      server = null;
+    }
+
+    if (testRoot && fs.existsSync(testRoot)) {
+      fs.rmSync(testRoot, { recursive: true, force: true });
+    }
+
+    restoreEnv('AUTODEV_SERVER_URL', originalEnv.autoDevServerUrl);
+    restoreEnv('AUTODEV_API_KEY', originalEnv.autoDevApiKey);
+    restoreEnv('LOG_INGEST_AUTO_ENABLED', originalEnv.autoEnabled);
+    restoreEnv('LOG_INGEST_AUTO_TIME', originalEnv.autoTime);
+    restoreEnv('LOG_INGEST_STABLE_MINUTES', originalEnv.stableMinutes);
+    restoreEnv('LOG_INGEST_AUTO_MAX_FILES', originalEnv.maxFiles);
+    restoreEnv('XIAOBA_ROLE', originalEnv.xiaobaRole);
+  });
+
+  test('启动补传只 ingest 稳定且未上传过的 session 日志，并在文件变化后再次 ingest', async () => {
+    const sessionLogDir = path.join(testRoot, 'logs', 'sessions', 'feishu', '2026-04-14');
+    fs.mkdirSync(sessionLogDir, { recursive: true });
+
+    const stableSessionLog = path.join(sessionLogDir, 'feishu_user_demo.jsonl');
+    const olderSessionLog = path.join(sessionLogDir, 'feishu_group_demo.jsonl');
+    const freshSessionLog = path.join(sessionLogDir, 'feishu_user_fresh.jsonl');
+    const reviewSessionLog = path.join(sessionLogDir, 'group_demo_inspector-review_case-1.jsonl');
+    fs.writeFileSync(stableSessionLog, '{"entry_type":"turn","turn":1,"session_id":"user:demo","session_type":"feishu","timestamp":"2026-04-14T09:00:00.000Z","user":{"text":"a"},"assistant":{"text":"b","tool_calls":[]},"tokens":{"prompt":1,"completion":1}}', 'utf-8');
+    fs.writeFileSync(olderSessionLog, '{"entry_type":"turn","turn":1,"session_id":"group:demo","session_type":"feishu","timestamp":"2026-04-14T08:00:00.000Z","user":{"text":"a"},"assistant":{"text":"b","tool_calls":[]},"tokens":{"prompt":1,"completion":1}}', 'utf-8');
+    fs.writeFileSync(freshSessionLog, '{"entry_type":"turn","turn":1,"session_id":"user:fresh","session_type":"feishu","timestamp":"2026-04-14T11:00:00.000Z","user":{"text":"a"},"assistant":{"text":"b","tool_calls":[]},"tokens":{"prompt":1,"completion":1}}', 'utf-8');
+    fs.writeFileSync(reviewSessionLog, '{"turn":1,"role":"assistant"}', 'utf-8');
+
+    const oldDate = new Date(Date.now() - 10 * 60 * 1000);
+    const stableLaterDate = new Date(Date.now() - 8 * 60 * 1000);
+    fs.utimesSync(stableSessionLog, oldDate, oldDate);
+    fs.utimesSync(freshSessionLog, stableLaterDate, stableLaterDate);
+    fs.utimesSync(reviewSessionLog, oldDate, oldDate);
+    const olderDate = new Date(Date.now() - 30 * 60 * 1000);
+    fs.utimesSync(olderSessionLog, olderDate, olderDate);
+
+    const ingestedLogs: any[] = [];
+    server = http.createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', chunk => {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      });
+      req.on('end', () => {
+        const bodyBuffer = Buffer.concat(chunks);
+        if (req.url === '/api/logs/ingest') {
+          const raw = bodyBuffer.toString('latin1');
+          ingestedLogs.push({
+            session_type: extractMultipartField(raw, 'session_type'),
+            session_id: extractMultipartField(raw, 'session_id'),
+            log_date: extractMultipartField(raw, 'log_date'),
+            filename: extractFileName(raw),
+          });
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ log_id: `log-${ingestedLogs.length}`, size_bytes: bodyBuffer.length }));
+          return;
+        }
+
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'not found' }));
+      });
+    });
+
+    await new Promise<void>(resolve => server!.listen(0, '127.0.0.1', () => resolve()));
+    const address = server.address();
+    assert.ok(address && typeof address === 'object');
+
+    process.env.AUTODEV_SERVER_URL = `http://127.0.0.1:${address.port}`;
+    process.env.AUTODEV_API_KEY = 'demo-key';
+    process.env.LOG_INGEST_AUTO_ENABLED = 'true';
+    process.env.LOG_INGEST_STABLE_MINUTES = '5';
+    process.env.LOG_INGEST_AUTO_MAX_FILES = '2';
+    delete process.env.XIAOBA_ROLE;
+
+    const scheduler = new LogIngestScheduler(testRoot);
+    await scheduler.start();
+
+    await waitFor(() => ingestedLogs.length === 2);
+    assert.deepStrictEqual(
+      ingestedLogs.map(item => item.filename).sort(),
+      ['feishu_user_demo.jsonl', 'feishu_user_fresh.jsonl'],
+    );
+    assert.ok(!ingestedLogs.some(item => item.filename === 'feishu_group_demo.jsonl'));
+    assert.ok(!ingestedLogs.some(item => String(item.filename).includes('inspector-review')));
+    assert.ok(ingestedLogs.some(item => item.session_id === 'user:demo'));
+    assert.ok(ingestedLogs.some(item => item.session_id === 'user:fresh'));
+
+    await scheduler.runPendingIngestCycle('manual');
+    assert.strictEqual(ingestedLogs.length, 3);
+    assert.strictEqual(ingestedLogs[2].filename, 'feishu_group_demo.jsonl');
+    assert.strictEqual(ingestedLogs[2].session_id, 'group:demo');
+
+    fs.writeFileSync(stableSessionLog, '{"entry_type":"turn","turn":1,"session_id":"user:demo","session_type":"feishu","timestamp":"2026-04-14T09:00:00.000Z","user":{"text":"a"},"assistant":{"text":"b","tool_calls":[]},"tokens":{"prompt":1,"completion":1}}\n{"entry_type":"runtime","timestamp":"2026-04-14T09:05:00.000Z","session_id":"user:demo","session_type":"feishu","level":"ERROR","message":"tool failed"}', 'utf-8');
+    const newerOldDate = new Date(Date.now() - 10 * 60 * 1000);
+    fs.utimesSync(stableSessionLog, newerOldDate, newerOldDate);
+
+    await scheduler.runPendingIngestCycle('manual');
+    assert.strictEqual(ingestedLogs.length, 4);
+    assert.strictEqual(ingestedLogs[3].filename, 'feishu_user_demo.jsonl');
+
+    await scheduler.stop();
+  });
+});
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (typeof value === 'string') {
+    process.env[key] = value;
+  } else {
+    delete process.env[key];
+  }
+}
+
+function extractMultipartField(raw: string, fieldName: string): string | undefined {
+  const match = raw.match(new RegExp(`name="${fieldName}"\\r\\n\\r\\n([^\\r]+)`));
+  return match?.[1];
+}
+
+function extractFileName(raw: string): string | undefined {
+  const match = raw.match(/filename="([^"]+)"/);
+  return match?.[1];
+}
+
+async function waitFor(predicate: () => boolean, maxAttempts: number = 40, delayMs: number = 50): Promise<void> {
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    if (predicate()) {
+      return;
+    }
+    await new Promise(resolve => setTimeout(resolve, delayMs));
+  }
+  throw new Error('waitFor timeout');
+}


### PR DESCRIPTION
## Summary
- add a runtime-only AutoDev log ingest client and scheduler
- start AutoDev session-log ingest automatically from runtime command support when AUTODEV_SERVER_URL is configured
- document the new env vars and add focused scheduler coverage

## Scope
- runtime only
- no oles/ or src/roles/ changes
- no Engineer/Reviewer/Inspector case-worker logic

## Validation
- 
pm run build
- 
px tsx --test tests/log-ingest-scheduler.test.ts

## Notes
- this keeps the existing Inspector upload path intact as a fallback/compatibility path
- when AutoDev is configured, runtime logs are ingested into /api/logs/ingest instead of requiring manual upload
