### PR TITLE
feat(runtime): add session-aware runtime logging

### DIFF
--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -109,6 +109,14 @@ export class AgentSession {
     return 'chat';
   }
 
+  runWithLogContext<T>(fn: () => T): T {
+    return Logger.withSessionContext(this.key, this.sessionTurnLogger, fn);
+  }
+
+  private withLogContext<T>(fn: () => T): T {
+    return this.runWithLogContext(fn);
+  }
+
   /** 注入主动唤醒回调（由平台 SessionManager 在创建/获取 session 时调用） */
   setWakeupReply(callback: (text: string) => Promise<void>): void {
     this.wakeupReply = callback;
@@ -188,25 +196,27 @@ export class AgentSession {
    * 用于 --skill 参数，在会话开始前绑定 skill 上下文。
    */
   async activateSkill(skillName: string): Promise<boolean> {
-    const skill = this.services.skillManager.getSkill(skillName);
-    if (!skill) {
-      Logger.warning(`Skill "${skillName}" 未找到`);
-      return false;
-    }
+    return this.withLogContext(async () => {
+      const skill = this.services.skillManager.getSkill(skillName);
+      if (!skill) {
+        Logger.warning(`Skill "${skillName}" 未找到`);
+        return false;
+      }
 
-    await this.init();
+      await this.init();
 
-    const context: SkillInvocationContext = {
-      skillName,
-      arguments: [],
-      rawArguments: '',
-      userMessage: '',
-    };
-    const activation = buildSkillActivationSignal(skill, context);
-    this.applySkillActivation(activation);
+      const context: SkillInvocationContext = {
+        skillName,
+        arguments: [],
+        rawArguments: '',
+        userMessage: '',
+      };
+      const activation = buildSkillActivationSignal(skill, context);
+      this.applySkillActivation(activation);
 
-    Logger.info(`[${this.key}] 启动时激活 skill: ${skill.metadata.name}${skill.metadata.maxTurns ? ` (maxTurns=${skill.metadata.maxTurns})` : ''}`);
-    return true;
+      Logger.info(`[${this.key}] 启动时激活 skill: ${skill.metadata.name}${skill.metadata.maxTurns ? ` (maxTurns=${skill.metadata.maxTurns})` : ''}`);
+      return true;
+    });
   }
 
   // ─── 消息处理 ───────────────────────────────────────
@@ -236,229 +246,231 @@ export class AgentSession {
     text: string | import('../types').ContentBlock[],
     callbacksOrOptions?: SessionCallbacks | HandleMessageOptions,
   ): Promise<HandleMessageResult> {
-    // 兼容旧签名：如果传入的对象有 onText/onToolStart 等字段，视为 SessionCallbacks
-    let callbacks: SessionCallbacks | undefined;
-    let channel: ChannelCallbacks | undefined;
+    return this.withLogContext(async () => {
+      // 兼容旧签名：如果传入的对象有 onText/onToolStart 等字段，视为 SessionCallbacks
+      let callbacks: SessionCallbacks | undefined;
+      let channel: ChannelCallbacks | undefined;
 
-    if (callbacksOrOptions) {
-      if ('channel' in callbacksOrOptions || 'callbacks' in callbacksOrOptions) {
-        // 新签名 HandleMessageOptions
-        const opts = callbacksOrOptions as HandleMessageOptions;
-        callbacks = opts.callbacks;
-        channel = opts.channel;
-      } else {
-        // 旧签名 SessionCallbacks
-        callbacks = callbacksOrOptions as SessionCallbacks;
+      if (callbacksOrOptions) {
+        if ('channel' in callbacksOrOptions || 'callbacks' in callbacksOrOptions) {
+          // 新签名 HandleMessageOptions
+          const opts = callbacksOrOptions as HandleMessageOptions;
+          callbacks = opts.callbacks;
+          channel = opts.channel;
+        } else {
+          // 旧签名 SessionCallbacks
+          callbacks = callbacksOrOptions as SessionCallbacks;
+        }
       }
-    }
 
-    if (this.busy) {
-      return { text: BUSY_MESSAGE, visibleToUser: true };
-    }
+      if (this.busy) {
+        return { text: BUSY_MESSAGE, visibleToUser: true };
+      }
 
-    // 按"单次消息"统计 metrics，避免跨轮次累积导致定位困难
-    Metrics.reset();
+      // 按"单次消息"统计 metrics，避免跨轮次累积导致定位困难
+      Metrics.reset();
 
-    this.busy = true;
-    this.interruptRequested = false;
-    this.lastActiveAt = Date.now();
+      this.busy = true;
+      this.interruptRequested = false;
+      this.lastActiveAt = Date.now();
 
-    // 检查是否需要压缩上下文
-    if (this.compressor.needsCompaction(this.messages)) {
-      const usage = this.compressor.getUsageInfo(this.messages);
-      Logger.info(`[${this.key}] 上下文即将压缩: ${usage.usedTokens}/${usage.maxTokens} tokens (${usage.usagePercent}%)`);
+      // 检查是否需要压缩上下文
+      if (this.compressor.needsCompaction(this.messages)) {
+        const usage = this.compressor.getUsageInfo(this.messages);
+        Logger.info(`[${this.key}] 上下文即将压缩: ${usage.usedTokens}/${usage.maxTokens} tokens (${usage.usagePercent}%)`);
+        try {
+          this.messages = await this.compressor.compact(this.messages);
+          Logger.info(`[${this.key}] 压缩完成，当前消息数: ${this.messages.length}`);
+        } catch (err) {
+          Logger.error(`[${this.key}] 压缩失败: ${err}`);
+        }
+      }
+
       try {
-        this.messages = await this.compressor.compact(this.messages);
-        Logger.info(`[${this.key}] 压缩完成，当前消息数: ${this.messages.length}`);
-      } catch (err) {
-        Logger.error(`[${this.key}] 压缩失败: ${err}`);
-      }
-    }
-
-    try {
-      await this.init();
-      const textContent = typeof text === 'string' ? text : '';
-      this.tryAutoActivateSkill(textContent);
-      this.messages.push({ role: 'user', content: text });
+        await this.init();
+        const textContent = typeof text === 'string' ? text : '';
+        this.tryAutoActivateSkill(textContent);
+        this.messages.push({ role: 'user', content: text });
 
 
-      // 构建上下文消息
-      let contextMessages: Message[] = [...this.messages];
+        // 构建上下文消息
+        let contextMessages: Message[] = [...this.messages];
 
-      // 注入后台子智能体状态（临时上下文，不持久化）
-      const subAgentManager = SubAgentManager.getInstance();
-      const runningSubAgents = subAgentManager.listByParent(this.key);
-      if (runningSubAgents.length > 0) {
-        const statusLines = runningSubAgents.map(s => {
-          const statusLabel = s.status === 'running' ? '运行中' : s.status === 'completed' ? '已完成' : s.status === 'failed' ? '失败' : '已停止';
-          const latest = s.progressLog[s.progressLog.length - 1] ?? '';
-          const summary = s.status === 'completed' && s.resultSummary ? `\n  结果: ${s.resultSummary.slice(0, 200)}` : '';
-          return `- [${s.id}] ${s.taskDescription} (${statusLabel}) ${latest}${summary}`;
-        }).join('\n');
+        // 注入后台子智能体状态（临时上下文，不持久化）
+        const subAgentManager = SubAgentManager.getInstance();
+        const runningSubAgents = subAgentManager.listByParent(this.key);
+        if (runningSubAgents.length > 0) {
+          const statusLines = runningSubAgents.map(s => {
+            const statusLabel = s.status === 'running' ? '运行中' : s.status === 'completed' ? '已完成' : s.status === 'failed' ? '失败' : '已停止';
+            const latest = s.progressLog[s.progressLog.length - 1] ?? '';
+            const summary = s.status === 'completed' && s.resultSummary ? `\n  结果: ${s.resultSummary.slice(0, 200)}` : '';
+            return `- [${s.id}] ${s.taskDescription} (${statusLabel}) ${latest}${summary}`;
+          }).join('\n');
 
-        const subagentStatusMsg: Message = {
-          role: 'system',
-          content: `${TRANSIENT_SUBAGENT_STATUS_PREFIX}\n当前有 ${runningSubAgents.length} 个后台子任务：\n${statusLines}\n\n用户如果询问任务进度，请基于以上信息回答。如果用户要求停止任务，使用 stop_subagent 工具。`,
-        };
-        // 插入到最后一条用户消息之前
-        const lastUserIdx = contextMessages.length - 1;
-        contextMessages.splice(lastUserIdx, 0, subagentStatusMsg);
-      }
-
-      // 动态注入当前可用 skills 列表（临时上下文，不持久化）
-      // 每次处理消息时重新从磁盘加载 skills，确保 Dashboard 的禁用/启用/安装/删除立即生效
-      await this.services.skillManager.loadSkills();
-
-      const skills = this.services.skillManager.getUserInvocableSkills();
-      if (skills.length > 0) {
-        const skillList = skills.map(s => `- ${s.metadata.name}: ${s.metadata.description}`).join('\n');
-        const skillsListMsg: Message = {
-          role: 'system',
-          content: `${TRANSIENT_SKILLS_LIST_PREFIX}\n你可以使用以下skills（通过skill工具调用）：\n\n${skillList}`,
-        };
-        const lastUserIdx = contextMessages.length - 1;
-        contextMessages.splice(lastUserIdx, 0, skillsListMsg);
-      }
-
-      // 运行对话循环（优先用显式设置的 maxTurns，否则从 messages 中检测已激活 skill）
-      const detectedSkillName = this.activeSkillName ?? this.detectActiveSkillName();
-      if (detectedSkillName) {
-        const detectedSkill = this.services.skillManager.getSkill(detectedSkillName);
-        this.activeSkillName = detectedSkillName;
-        this.activeSkillMaxTurns = detectedSkill?.metadata.maxTurns;
-      }
-
-      const effectiveMaxTurns = this.activeSkillMaxTurns ?? this.detectSkillMaxTurns();
-      const surface = this.isCatsCompanySession()
-        ? 'catscompany'
-        : this.isFeishuSession()
-          ? 'feishu'
-          : 'cli';
-      const runner = new ConversationRunner(
-        this.services.aiService,
-        this.services.toolManager,
-        {
-          ...(effectiveMaxTurns ? { maxTurns: effectiveMaxTurns } : {}),
-          initialSkillName: this.activeSkillName,
-          shouldContinue: () => !this.interruptRequested,
-          toolExecutionContext: {
-            sessionId: this.key,
-            surface,
-            permissionProfile: 'strict',
-            channel,
-          },
-        },
-      );
-      const runnerCallbacks: RunnerCallbacks = {
-        onText: callbacks?.onText,
-        onToolStart: callbacks?.onToolStart,
-        onToolEnd: callbacks?.onToolEnd,
-        onToolDisplay: callbacks?.onToolDisplay,
-        onRetry: callbacks?.onRetry,
-      };
-
-      const result = await runner.run(contextMessages, runnerCallbacks);
-      const persistedMessages = this.removeTransientMessages(result.messages);
-      this.messages = [...persistedMessages];
-
-      // 同步 skill 激活状态
-      for (const msg of result.newMessages) {
-        const activation = this.parseActivationFromSystemMessage(msg);
-        if (activation) {
-          this.applySkillActivation(activation);
-        }
-      }
-
-      // 输出本次请求的 metrics 摘要
-      const metrics = Metrics.getSummary();
-      if (metrics.aiCalls > 0 || metrics.toolCalls > 0) {
-        Logger.info(
-          `[Metrics] AI调用: ${metrics.aiCalls}次, ` +
-          `tokens: ${metrics.totalPromptTokens}+${metrics.totalCompletionTokens}=${metrics.totalTokens}, ` +
-          `工具调用: ${metrics.toolCalls}次, 工具耗时: ${metrics.toolDurationMs}ms`
-        );
-      }
-
-      // 替换 base64 图片数据为路径占位符，避免撑爆 context
-      for (const msg of this.messages) {
-        if (Array.isArray(msg.content)) {
-          msg.content = msg.content.map(block => {
-            if (block.type === 'image' && block.source?.data) {
-              const filePath = (block as any).filePath || '未知路径';
-              return { type: 'text' as const, text: `[图片: ${filePath}]` };
-            }
-            return block;
-          });
-        }
-      }
-
-      // 清除 skill 激活状态（turn-scoped，避免状态泄漏到下一轮）
-      this.activeSkillName = undefined;
-      this.activeSkillMaxTurns = undefined;
-
-      // 移除 skill 系统消息（下一轮需要时会重新注入）
-      this.messages = this.messages.filter(m => {
-        if (m.role === 'system' && typeof m.content === 'string') {
-          return !m.content.match(/^\[skill:[^\]]+\]/);
-        }
-        return true;
-      });
-
-      // 记录本轮对话到 session log
-      const toolCalls = result.newMessages
-        .filter(m => m.role === 'assistant' && m.tool_calls)
-        .flatMap(m => m.tool_calls || [])
-        .map(tc => {
-          const resultMsg = result.newMessages.find(m => m.role === 'tool' && m.tool_call_id === tc.id);
-          const resultContent = resultMsg?.content || '';
-          const resultStr = typeof resultContent === 'string'
-            ? resultContent
-            : resultContent.map(b => b.type === 'text' ? (b as any).text : '[非文本内容]').join('');
-
-          return {
-            id: tc.id,
-            name: tc.function.name,
-            arguments: tc.function.arguments,
-            result: resultStr,
+          const subagentStatusMsg: Message = {
+            role: 'system',
+            content: `${TRANSIENT_SUBAGENT_STATUS_PREFIX}\n当前有 ${runningSubAgents.length} 个后台子任务：\n${statusLines}\n\n用户如果询问任务进度，请基于以上信息回答。如果用户要求停止任务，使用 stop_subagent 工具。`,
           };
+          // 插入到最后一条用户消息之前
+          const lastUserIdx = contextMessages.length - 1;
+          contextMessages.splice(lastUserIdx, 0, subagentStatusMsg);
+        }
+
+        // 动态注入当前可用 skills 列表（临时上下文，不持久化）
+        // 每次处理消息时重新从磁盘加载 skills，确保 Dashboard 的禁用/启用/安装/删除立即生效
+        await this.services.skillManager.loadSkills();
+
+        const skills = this.services.skillManager.getUserInvocableSkills();
+        if (skills.length > 0) {
+          const skillList = skills.map(s => `- ${s.metadata.name}: ${s.metadata.description}`).join('\n');
+          const skillsListMsg: Message = {
+            role: 'system',
+            content: `${TRANSIENT_SKILLS_LIST_PREFIX}\n你可以使用以下skills（通过skill工具调用）：\n\n${skillList}`,
+          };
+          const lastUserIdx = contextMessages.length - 1;
+          contextMessages.splice(lastUserIdx, 0, skillsListMsg);
+        }
+
+        // 运行对话循环（优先用显式设置的 maxTurns，否则从 messages 中检测已激活 skill）
+        const detectedSkillName = this.activeSkillName ?? this.detectActiveSkillName();
+        if (detectedSkillName) {
+          const detectedSkill = this.services.skillManager.getSkill(detectedSkillName);
+          this.activeSkillName = detectedSkillName;
+          this.activeSkillMaxTurns = detectedSkill?.metadata.maxTurns;
+        }
+
+        const effectiveMaxTurns = this.activeSkillMaxTurns ?? this.detectSkillMaxTurns();
+        const surface = this.isCatsCompanySession()
+          ? 'catscompany'
+          : this.isFeishuSession()
+            ? 'feishu'
+            : 'cli';
+        const runner = new ConversationRunner(
+          this.services.aiService,
+          this.services.toolManager,
+          {
+            ...(effectiveMaxTurns ? { maxTurns: effectiveMaxTurns } : {}),
+            initialSkillName: this.activeSkillName,
+            shouldContinue: () => !this.interruptRequested,
+            toolExecutionContext: {
+              sessionId: this.key,
+              surface,
+              permissionProfile: 'strict',
+              channel,
+            },
+          },
+        );
+        const runnerCallbacks: RunnerCallbacks = {
+          onText: callbacks?.onText,
+          onToolStart: callbacks?.onToolStart,
+          onToolEnd: callbacks?.onToolEnd,
+          onToolDisplay: callbacks?.onToolDisplay,
+          onRetry: callbacks?.onRetry,
+        };
+
+        const result = await runner.run(contextMessages, runnerCallbacks);
+        const persistedMessages = this.removeTransientMessages(result.messages);
+        this.messages = [...persistedMessages];
+
+        // 同步 skill 激活状态
+        for (const msg of result.newMessages) {
+          const activation = this.parseActivationFromSystemMessage(msg);
+          if (activation) {
+            this.applySkillActivation(activation);
+          }
+        }
+
+        // 输出本次请求的 metrics 摘要
+        const metrics = Metrics.getSummary();
+        if (metrics.aiCalls > 0 || metrics.toolCalls > 0) {
+          Logger.info(
+            `[Metrics] AI调用: ${metrics.aiCalls}次, ` +
+            `tokens: ${metrics.totalPromptTokens}+${metrics.totalCompletionTokens}=${metrics.totalTokens}, ` +
+            `工具调用: ${metrics.toolCalls}次, 工具耗时: ${metrics.toolDurationMs}ms`
+          );
+        }
+
+        // 替换 base64 图片数据为路径占位符，避免撑爆 context
+        for (const msg of this.messages) {
+          if (Array.isArray(msg.content)) {
+            msg.content = msg.content.map(block => {
+              if (block.type === 'image' && block.source?.data) {
+                const filePath = (block as any).filePath || '未知路径';
+                return { type: 'text' as const, text: `[图片: ${filePath}]` };
+              }
+              return block;
+            });
+          }
+        }
+
+        // 清除 skill 激活状态（turn-scoped，避免状态泄漏到下一轮）
+        this.activeSkillName = undefined;
+        this.activeSkillMaxTurns = undefined;
+
+        // 移除 skill 系统消息（下一轮需要时会重新注入）
+        this.messages = this.messages.filter(m => {
+          if (m.role === 'system' && typeof m.content === 'string') {
+            return !m.content.match(/^\[skill:[^\]]+\]/);
+          }
+          return true;
         });
 
-      this.sessionTurnLogger.logTurn(
-        text,
-        result.response || '',
-        toolCalls,
-        { prompt: metrics.totalPromptTokens, completion: metrics.totalCompletionTokens }
-      );
+        // 记录本轮对话到 session log
+        const toolCalls = result.newMessages
+          .filter(m => m.role === 'assistant' && m.tool_calls)
+          .flatMap(m => m.tool_calls || [])
+          .map(tc => {
+            const resultMsg = result.newMessages.find(m => m.role === 'tool' && m.tool_call_id === tc.id);
+            const resultContent = resultMsg?.content || '';
+            const resultStr = typeof resultContent === 'string'
+              ? resultContent
+              : resultContent.map(b => b.type === 'text' ? (b as any).text : '[非文本内容]').join('');
 
-      return {
-        text: result.finalResponseVisible ? (result.response || '[无回复]') : '',
-        visibleToUser: result.finalResponseVisible,
-        newMessages: result.newMessages,
-      };
-    } catch (err: any) {
-      // 不删除用户消息，而是添加一个错误回复，保持上下文连贯
-      // 这样用户说"继续"时可以接上
-      Logger.error(`[会话 ${this.key}] 处理失败: ${err.message}`);
+            return {
+              id: tc.id,
+              name: tc.function.name,
+              arguments: tc.function.arguments,
+              result: resultStr,
+            };
+          });
 
-      // 识别多模态相关错误
-      const errorMsg = err.message || String(err);
-      const isVisionError = errorMsg.match(/image|vision|multimodal|media_type|base64.*not supported/i);
+        this.sessionTurnLogger.logTurn(
+          text,
+          result.response || '',
+          toolCalls,
+          { prompt: metrics.totalPromptTokens, completion: metrics.totalCompletionTokens }
+        );
 
-      let errorReply = ERROR_MESSAGE;
-      if (isVisionError) {
-        errorReply = '当前模型不支持图片识别。请使用支持多模态的模型（如 Claude 3.5 Sonnet 或 GPT-4V），或者用文字描述图片内容。';
+        return {
+          text: result.finalResponseVisible ? (result.response || '[无回复]') : '',
+          visibleToUser: result.finalResponseVisible,
+          newMessages: result.newMessages,
+        };
+      } catch (err: any) {
+        // 不删除用户消息，而是添加一个错误回复，保持上下文连贯
+        // 这样用户说"继续"时可以接上
+        Logger.error(`[会话 ${this.key}] 处理失败: ${err.message}`);
+
+        // 识别多模态相关错误
+        const errorMsg = err.message || String(err);
+        const isVisionError = errorMsg.match(/image|vision|multimodal|media_type|base64.*not supported/i);
+
+        let errorReply = ERROR_MESSAGE;
+        if (isVisionError) {
+          errorReply = '当前模型不支持图片识别。请使用支持多模态的模型（如 Claude 3.5 Sonnet 或 GPT-4V），或者用文字描述图片内容。';
+        }
+
+        // 添加错误回复到上下文，保持对话连贯性
+        this.messages.push({
+          role: 'assistant',
+          content: `[处理失败: ${err.message}]`
+        });
+
+        return { text: errorReply, visibleToUser: true };
+      } finally {
+        this.busy = false;
       }
-
-      // 添加错误回复到上下文，保持对话连贯性
-      this.messages.push({
-        role: 'assistant',
-        content: `[处理失败: ${err.message}]`
-      });
-
-      return { text: errorReply, visibleToUser: true };
-    } finally {
-      this.busy = false;
-    }
+    });
   }
 
   // ─── 命令处理 ───────────────────────────────────────
@@ -469,46 +481,48 @@ export class AgentSession {
     args: string[],
     callbacks?: SessionCallbacks,
   ): Promise<CommandResult> {
-    const commandName = command.toLowerCase();
+    return this.withLogContext(async () => {
+      const commandName = command.toLowerCase();
 
-    // /stop - 中断当前正在运行的请求
-    if (commandName === 'stop') {
-      this.requestInterrupt();
-      return { handled: true, reply: '正在停止当前请求...' };
-    }
-
-    // /clear
-    if (commandName === 'clear') {
-      if (args.includes('--all')) {
-        this.clear();
-        return { handled: true, reply: '历史已清空，文件已删除' };
+      // /stop - 中断当前正在运行的请求
+      if (commandName === 'stop') {
+        this.requestInterrupt();
+        return { handled: true, reply: '正在停止当前请求...' };
       }
-      this.reset();
-      return { handled: true, reply: '历史已清空' };
-    }
 
-    // /skills
-    if (commandName === 'skills') {
-      return this.handleSkillsCommand();
-    }
+      // /clear
+      if (commandName === 'clear') {
+        if (args.includes('--all')) {
+          this.clear();
+          return { handled: true, reply: '历史已清空，文件已删除' };
+        }
+        this.reset();
+        return { handled: true, reply: '历史已清空' };
+      }
 
-    // /history
-    if (commandName === 'history') {
-      return {
-        handled: true,
-        reply: `对话历史信息:\n当前历史长度: ${this.messages.length} 条消息\n上下文压缩: 由 ConversationRunner 自动管理`,
-      };
-    }
+      // /skills
+      if (commandName === 'skills') {
+        return this.handleSkillsCommand();
+      }
 
-    // /exit
-    if (commandName === 'exit') {
-      await this.summarizeAndDestroy();
-      return { handled: true, reply: '再见！期待下次与你对话。' };
-    }
+      // /history
+      if (commandName === 'history') {
+        return {
+          handled: true,
+          reply: `对话历史信息:\n当前历史长度: ${this.messages.length} 条消息\n上下文压缩: 由 ConversationRunner 自动管理`,
+        };
+      }
+
+      // /exit
+      if (commandName === 'exit') {
+        await this.summarizeAndDestroy();
+        return { handled: true, reply: '再见！期待下次与你对话。' };
+      }
 
 
-    // skill 斜杠命令
-    return this.handleSkillCommand(commandName, args, callbacks);
+      // skill 斜杠命令
+      return this.handleSkillCommand(commandName, args, callbacks);
+    });
   }
 
   // ─── 生命周期 ──────────────────────────────────────
@@ -529,16 +543,17 @@ export class AgentSession {
   }
 
   async summarizeAndDestroy(): Promise<boolean> {
-    const hasUserMessages = this.messages.some(m => m.role === 'user');
-    if (this.messages.length === 0 || !hasUserMessages) {
-      return false;
-    }
+    return this.withLogContext(async () => {
+      const hasUserMessages = this.messages.some(m => m.role === 'user');
+      if (this.messages.length === 0 || !hasUserMessages) {
+        return false;
+      }
 
-    try {
-      const conversationText = this.messages
-        .filter(m => m.role === 'user' || m.role === 'assistant')
-        .map(m => `${m.role === 'user' ? '\u7528\u6237' : 'AI'}: ${m.content}`)
-        .join('\n');
+      try {
+        const conversationText = this.messages
+          .filter(m => m.role === 'user' || m.role === 'assistant')
+          .map(m => `${m.role === 'user' ? '\u7528\u6237' : 'AI'}: ${m.content}`)
+          .join('\n');
 
       // \u540c\u65f6\u751f\u6210\u6458\u8981 + \u5224\u65ad\u662f\u5426\u9700\u8981\u4e3b\u52a8\u5524\u9192\uff08\u4e0d\u589e\u52a0\u989d\u5916 AI \u8c03\u7528\uff09
       const summaryPrompt = this.wakeupReply
@@ -566,15 +581,15 @@ ${conversationText}
 
 \u8bf7\u751f\u6210\u6458\u8981\uff1a`;
 
-      const result = await this.services.aiService.chat([
-        { role: 'user', content: summaryPrompt },
-      ]);
+        const result = await this.services.aiService.chat([
+          { role: 'user', content: summaryPrompt },
+        ]);
 
       // \u89e3\u6790 AI \u8fd4\u56de\u7684\u7ed3\u679c
-      let summaryText: string;
-      let wakeupMessage: string | null = null;
+        let summaryText: string;
+        let wakeupMessage: string | null = null;
 
-      if (this.wakeupReply) {
+        if (this.wakeupReply) {
         // \u5c1d\u8bd5\u89e3\u6790 JSON \u683c\u5f0f
         try {
           const raw = result.content || '{}';
@@ -588,46 +603,48 @@ ${conversationText}
           summaryText = `[\u5bf9\u8bdd\u6458\u8981 - ${new Date().toISOString()}]\n${result.content || ''}`;
           Logger.warning(`[\u4f1a\u8bdd ${this.key}] \u6458\u8981+\u5524\u9192 JSON \u89e3\u6790\u5931\u8d25\uff0c\u964d\u7ea7\u4e3a\u7eaf\u6458\u8981`);
         }
-      } else {
-        summaryText = `[\u5bf9\u8bdd\u6458\u8981 - ${new Date().toISOString()}]\n${result.content || ''}`;
-      }
+        } else {
+          summaryText = `[\u5bf9\u8bdd\u6458\u8981 - ${new Date().toISOString()}]\n${result.content || ''}`;
+        }
 
       // \u4e3b\u52a8\u5524\u9192\uff1a\u5982\u679c AI \u5224\u65ad\u9700\u8981\u901a\u77e5\u7528\u6237\uff0c\u4e14\u6709\u56de\u8c03\u53ef\u7528
-      if (wakeupMessage && this.wakeupReply) {
-        try {
-          await this.wakeupReply(wakeupMessage);
-          Logger.info(`[\u4f1a\u8bdd ${this.key}] \u4e3b\u52a8\u5524\u9192\u7528\u6237: ${wakeupMessage.slice(0, 100)}`);
-        } catch (err: any) {
-          Logger.warning(`[\u4f1a\u8bdd ${this.key}] \u4e3b\u52a8\u5524\u9192\u5931\u8d25: ${err.message}`);
+        if (wakeupMessage && this.wakeupReply) {
+          try {
+            await this.wakeupReply(wakeupMessage);
+            Logger.info(`[\u4f1a\u8bdd ${this.key}] \u4e3b\u52a8\u5524\u9192\u7528\u6237: ${wakeupMessage.slice(0, 100)}`);
+          } catch (err: any) {
+            Logger.warning(`[\u4f1a\u8bdd ${this.key}] \u4e3b\u52a8\u5524\u9192\u5931\u8d25: ${err.message}`);
+          }
         }
-      }
 
 
       // \u5f52\u6863\u6301\u4e45\u5316\u6587\u4ef6
 
-      this.messages = [];
-      return true;
-    } catch (error) {
-      Logger.error('\u538b\u7f29\u5386\u53f2\u5931\u8d25: ' + String(error));
-      return false;
-      return false;
-    }
+        this.messages = [];
+        return true;
+      } catch (error) {
+        Logger.error('\u538b\u7f29\u5386\u53f2\u5931\u8d25: ' + String(error));
+        return false;
+        return false;
+      }
+    });
   }
 
   /** 过期或退出时清理内存（保存完整 context） */
   async cleanup(options?: { checkWakeup?: boolean }): Promise<void> {
-    if (this.messages.length === 0) return;
+    return this.withLogContext(async () => {
+      if (this.messages.length === 0) return;
 
-    try {
-      // 判断是否需要主动唤醒用户（仅在会话过期时）
-      if (options?.checkWakeup && this.wakeupReply) {
-        const hasUserMessages = this.messages.some(m => m.role === 'user');
-        if (hasUserMessages) {
-          const conversationText = this.messages
-            .filter(m => m.role === 'user' || m.role === 'assistant')
-            .slice(-10)
-            .map(m => `${m.role === 'user' ? '用户' : 'AI'}: ${m.content}`)
-            .join('\n');
+      try {
+        // 判断是否需要主动唤醒用户（仅在会话过期时）
+        if (options?.checkWakeup && this.wakeupReply) {
+          const hasUserMessages = this.messages.some(m => m.role === 'user');
+          if (hasUserMessages) {
+            const conversationText = this.messages
+              .filter(m => m.role === 'user' || m.role === 'assistant')
+              .slice(-10)
+              .map(m => `${m.role === 'user' ? '用户' : 'AI'}: ${m.content}`)
+              .join('\n');
 
           const wakeupPrompt = `请判断以下对话是否需要主动唤醒用户。返回 JSON 格式（不要包含 markdown 代码块）：
 { "wakeup": null 或 "一条自然的消息" }
@@ -641,34 +658,34 @@ ${conversationText}
 对话内容：
 ${conversationText}`;
 
-          try {
-            const result = await this.services.aiService.chat([
-              { role: 'user', content: wakeupPrompt },
-            ]);
+            try {
+              const result = await this.services.aiService.chat([
+                { role: 'user', content: wakeupPrompt },
+              ]);
 
-            const raw = result.content || '{}';
-            const jsonStr = raw.replace(/^```(?:json)?\s*\n?/i, '').replace(/\n?\s*```$/i, '').trim();
-            const parsed = JSON.parse(jsonStr);
+              const raw = result.content || '{}';
+              const jsonStr = raw.replace(/^```(?:json)?\s*\n?/i, '').replace(/\n?\s*```$/i, '').trim();
+              const parsed = JSON.parse(jsonStr);
 
-            if (parsed && parsed.wakeup && this.wakeupReply) {
-              await this.wakeupReply(parsed.wakeup);
-              Logger.info(`[会话 ${this.key}] 主动唤醒用户: ${parsed.wakeup.slice(0, 100)}`);
+              if (parsed && parsed.wakeup && this.wakeupReply) {
+                await this.wakeupReply(parsed.wakeup);
+                Logger.info(`[会话 ${this.key}] 主动唤醒用户: ${parsed.wakeup.slice(0, 100)}`);
+              }
+            } catch (err: any) {
+              Logger.warning(`[会话 ${this.key}] 唤醒判断失败: ${err.message}`);
             }
-          } catch (err: any) {
-            Logger.warning(`[会话 ${this.key}] 唤醒判断失败: ${err.message}`);
           }
         }
+        // 保存完整 context 到 SessionStore
+        SessionStore.getInstance().saveContext(this.key, this.messages);
+        Logger.info(`会话已保存: ${this.key}, ${this.messages.length} 条消息`);
+
+        // 清理内存
+        this.messages = [];
+      } catch (error) {
+        Logger.error(`清理会话失败: ${error}`);
       }
-
-      // 保存完整 context 到 SessionStore
-      SessionStore.getInstance().saveContext(this.key, this.messages);
-      Logger.info(`会话已保存: ${this.key}, ${this.messages.length} 条消息`);
-
-      // 清理内存
-      this.messages = [];
-    } catch (error) {
-      Logger.error(`清理会话失败: ${error}`);
-    }
+    });
   }
 
   // ─── 查询方法 ──────────────────────────────────────
@@ -685,13 +702,15 @@ ${conversationText}`;
 
   /** 从 DB 恢复消息（进程重启后调用） */
   restoreFromStore(): boolean {
-    const store = SessionStore.getInstance();
-    if (!store.hasSession(this.key)) return false;
-    const msgs = store.loadContext(this.key);
-    if (msgs.length === 0) return false;
-    this.pendingRestore = msgs;
-    Logger.info(`[会话 ${this.key}] 标记从 DB 恢复 ${msgs.length} 条消息`);
-    return true;
+    return this.withLogContext(() => {
+      const store = SessionStore.getInstance();
+      if (!store.hasSession(this.key)) return false;
+      const msgs = store.loadContext(this.key);
+      if (msgs.length === 0) return false;
+      this.pendingRestore = msgs;
+      Logger.info(`[会话 ${this.key}] 标记从 DB 恢复 ${msgs.length} 条消息`);
+      return true;
+    });
   }
 
   // ─── 私有方法 ──────────────────────────────────────

--- a/src/core/message-session-manager.ts
+++ b/src/core/message-session-manager.ts
@@ -20,6 +20,7 @@ export type WakeupSendFn = (channelId: string, text: string) => Promise<void>;
  * - 群聊和私聊独立
  */
 export class MessageSessionManager {
+  private static managers = new Map<string, MessageSessionManager>();
   private sessions = new Map<string, AgentSession>();
   private destroying = new Set<string>();
   private cleanupTimer: ReturnType<typeof setInterval> | null = null;
@@ -37,7 +38,12 @@ export class MessageSessionManager {
   ) {
     this.sessionType = sessionType;
     this.ttl = ttl ?? DEFAULT_SESSION_TTL;
+    MessageSessionManager.managers.set(sessionType, this);
     this.startCleanup();
+  }
+
+  static getManager(sessionType: string): MessageSessionManager | null {
+    return this.managers.get(sessionType) || null;
   }
 
   /** 注入唤醒发送函数（用于过期时主动唤醒） */
@@ -64,7 +70,7 @@ export class MessageSessionManager {
         this.contextInjector(session);
       }
       this.sessions.set(key, session);
-      Logger.info(`新建会话: ${key}`);
+      session.runWithLogContext(() => Logger.info(`新建会话: ${key}`));
     }
 
     if (channelId) {
@@ -76,6 +82,11 @@ export class MessageSessionManager {
     return session;
   }
 
+  injectContext(key: string, text: string, channelId?: string): void {
+    const session = this.getOrCreate(key, channelId);
+    session.injectContext(text);
+  }
+
   /** 为 session 注入主动唤醒回调 */
   private injectWakeupReply(session: AgentSession, key: string): void {
     if (!this.wakeupSendFn) return;
@@ -83,7 +94,7 @@ export class MessageSessionManager {
     session.setWakeupReply(async (text: string) => {
       const channelId = this.lastChannelIdMap.get(key);
       if (!channelId) {
-        Logger.warning(`[${key}] 主动唤醒失败: 无 channelId`);
+        session.runWithLogContext(() => Logger.warning(`[${key}] 主动唤醒失败: 无 channelId`));
         return;
       }
       await sendFn(channelId, text);
@@ -99,9 +110,9 @@ export class MessageSessionManager {
         if (now - session.lastActiveAt > this.ttl) {
           this.destroying.add(key);
           this.sessions.delete(key);
-          Logger.info(`会话已过期清理: ${key}`);
+          session.runWithLogContext(() => Logger.info(`会话已过期清理: ${key}`));
           session.cleanup({ checkWakeup: true })
-            .catch(err => Logger.warning(`会话 ${key} 清理失败: ${err}`))
+            .catch(err => session.runWithLogContext(() => Logger.warning(`会话 ${key} 清理失败: ${err}`)))
             .finally(() => this.destroying.delete(key));
         }
       }
@@ -118,11 +129,12 @@ export class MessageSessionManager {
     // 保存所有活跃会话
     const cleanupPromises = Array.from(this.sessions.values()).map(session =>
       session.cleanup().catch(err =>
-        Logger.warning(`会话 ${session.key} 清理失败: ${err}`)
+        session.runWithLogContext(() => Logger.warning(`会话 ${session.key} 清理失败: ${err}`))
       )
     );
     await Promise.all(cleanupPromises);
 
     this.sessions.clear();
+    MessageSessionManager.managers.delete(this.sessionType);
   }
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,13 +1,21 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { styles } from '../theme/colors';
 import ora, { Ora } from 'ora';
+import type { SessionTurnLogger } from './session-turn-logger';
+
+interface LoggerContextStore {
+  sessionId?: string;
+  sessionLogger?: SessionTurnLogger;
+}
 
 export class Logger {
   private static spinner: Ora | null = null;
   private static logStream: fs.WriteStream | null = null;
   private static logFilePath: string | null = null;
   private static silentMode: boolean = false;
+  private static logContext = new AsyncLocalStorage<LoggerContextStore>();
 
   private static stripAnsi(str: string): string {
     // eslint-disable-next-line no-control-regex
@@ -15,18 +23,40 @@ export class Logger {
   }
 
   private static writeToFile(level: string, message: string): void {
-    if (!this.logStream) return;
+    const store = this.logContext.getStore();
+    if (store?.sessionLogger) {
+      store.sessionLogger.logRuntime(level, this.stripAnsi(message));
+      return;
+    }
+
+    if (!this.logStream) {
+      return;
+    }
+
     const now = new Date();
-    const Y = now.getFullYear();
-    const M = String(now.getMonth() + 1).padStart(2, '0');
-    const D = String(now.getDate()).padStart(2, '0');
-    const h = String(now.getHours()).padStart(2, '0');
-    const m = String(now.getMinutes()).padStart(2, '0');
-    const s = String(now.getSeconds()).padStart(2, '0');
-    const ms = String(now.getMilliseconds()).padStart(3, '0');
-    const ts = `${Y}-${M}-${D} ${h}:${m}:${s}.${ms}`;
-    const clean = this.stripAnsi(message);
-    this.logStream.write(`[${ts}] [${level}] ${clean}\n`);
+    const ts = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')} ${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}:${String(now.getSeconds()).padStart(2, '0')}.${String(now.getMilliseconds()).padStart(3, '0')}`;
+    this.logStream.write(`[${ts}] [${level}] ${this.stripAnsi(message)}\n`);
+  }
+
+  static withSessionContext<T>(sessionId: string | undefined, fn: () => T): T;
+  static withSessionContext<T>(sessionId: string | undefined, sessionLogger: SessionTurnLogger, fn: () => T): T;
+  static withSessionContext<T>(
+    sessionId: string | undefined,
+    sessionLoggerOrFn: SessionTurnLogger | (() => T),
+    maybeFn?: () => T,
+  ): T {
+    const normalizedSessionId = typeof sessionId === 'string'
+      ? sessionId.replace(/\s+/g, ' ').trim()
+      : '';
+    const sessionLogger = typeof sessionLoggerOrFn === 'function' ? undefined : sessionLoggerOrFn;
+    const fn = typeof sessionLoggerOrFn === 'function' ? sessionLoggerOrFn : maybeFn;
+    if (!fn) {
+      throw new Error('Logger.withSessionContext missing callback');
+    }
+    if (!normalizedSessionId) {
+      return fn();
+    }
+    return this.logContext.run({ sessionId: normalizedSessionId, sessionLogger }, fn);
   }
 
   static openLogFile(sessionType: string, sessionKey?: string, silent: boolean = false): void {
@@ -38,12 +68,11 @@ export class Logger {
     const ss = String(now.getSeconds()).padStart(2, '0');
     const suffix = sessionKey ? `${sessionType}_${sessionKey}` : sessionType;
     const fileName = `${hh}-${mm}-${ss}_${suffix}.log`;
-
     const dir = path.resolve('logs', dateDir);
-    fs.mkdirSync(dir, { recursive: true });
 
+    fs.mkdirSync(dir, { recursive: true });
     this.logFilePath = path.join(dir, fileName);
-    this.logStream = fs.createWriteStream(path.join(dir, fileName), { flags: 'a' });
+    this.logStream = fs.createWriteStream(this.logFilePath, { flags: 'a' });
   }
 
   static closeLogFile(): void {

--- a/src/utils/session-turn-logger.ts
+++ b/src/utils/session-turn-logger.ts
@@ -5,7 +5,8 @@ import { Message, ContentBlock } from '../types';
 const SESSION_LOG_DIR = path.resolve('logs/sessions');
 const MAX_TOOL_RESULT_LENGTH = Number(process.env.XIAOBA_SESSION_TOOL_RESULT_LIMIT || 10000);
 
-interface TurnLog {
+export interface SessionTurnLogEntry {
+  entry_type: 'turn';
   turn: number;
   timestamp: string;
   session_id: string;
@@ -23,6 +24,17 @@ interface TurnLog {
     completion: number;
   };
 }
+
+export interface SessionRuntimeLogEntry {
+  entry_type: 'runtime';
+  timestamp: string;
+  session_id: string;
+  session_type: string;
+  level: string;
+  message: string;
+}
+
+export type SessionLogEntry = SessionTurnLogEntry | SessionRuntimeLogEntry;
 
 interface ToolCallLog {
   id: string;
@@ -53,7 +65,11 @@ export class SessionTurnLogger {
 
     fs.mkdirSync(dir, { recursive: true });
     const safeSessionId = sessionId.replace(/[:<>"|?*]/g, '_');
-    this.logFilePath = path.join(dir, `${safeSessionId}.jsonl`);
+    this.logFilePath = path.join(dir, `${sessionType}_${safeSessionId}.jsonl`);
+  }
+
+  getLogFilePath(): string {
+    return this.logFilePath;
   }
 
   /**
@@ -70,7 +86,8 @@ export class SessionTurnLogger {
     const userText = this.extractText(userInput);
     const userImages = this.extractImages(userInput);
 
-    const turnLog: TurnLog = {
+    const turnLog: SessionTurnLogEntry = {
+      entry_type: 'turn',
       turn: this.turnCounter,
       timestamp: new Date().toISOString(),
       session_id: this.sessionId,
@@ -90,6 +107,18 @@ export class SessionTurnLogger {
     };
 
     this.appendLog(turnLog);
+  }
+
+  logRuntime(level: string, message: string): void {
+    const runtimeEntry: SessionRuntimeLogEntry = {
+      entry_type: 'runtime',
+      timestamp: new Date().toISOString(),
+      session_id: this.sessionId,
+      session_type: this.sessionType,
+      level,
+      message,
+    };
+    this.appendLog(runtimeEntry);
   }
 
   private extractText(content: string | ContentBlock[]): string {
@@ -112,7 +141,7 @@ export class SessionTurnLogger {
     return text.slice(0, maxLength) + '... [truncated]';
   }
 
-  private appendLog(entry: any): void {
+  private appendLog(entry: SessionLogEntry): void {
     try {
       fs.appendFileSync(this.logFilePath, JSON.stringify(entry) + '\n');
     } catch (error) {

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { Logger } from '../src/utils/logger';
+import { SessionTurnLogger } from '../src/utils/session-turn-logger';
+
+describe('Logger', () => {
+  let testRoot: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-logger-'));
+    process.chdir(testRoot);
+  });
+
+  afterEach(async () => {
+    Logger.closeLogFile();
+    await waitForFlush();
+    process.chdir(originalCwd);
+    if (testRoot && fs.existsSync(testRoot)) {
+      fs.rmSync(testRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('runtime log lines include session_id from async context', async () => {
+    Logger.openLogFile('test', undefined, true);
+    const sessionLogger = new SessionTurnLogger('feishu', 'user:ou_demo');
+
+    Logger.info('outside context');
+    await Logger.withSessionContext('user:ou_demo', sessionLogger, async () => {
+      Logger.info('inside context');
+      await Promise.resolve();
+      Logger.info('still inside context');
+    });
+
+    const globalLogPath = Logger.getLogFilePath();
+    const sessionLogPath = sessionLogger.getLogFilePath();
+    assert.ok(globalLogPath);
+    assert.ok(sessionLogPath);
+
+    Logger.closeLogFile();
+    await waitForFlush();
+
+    const globalContent = fs.readFileSync(globalLogPath, 'utf-8');
+    assert.match(globalContent, /\[INFO\] outside context/);
+    assert.doesNotMatch(globalContent, /inside context/);
+    assert.doesNotMatch(globalContent, /still inside context/);
+
+    const sessionEntries = fs.readFileSync(sessionLogPath, 'utf-8')
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map(line => JSON.parse(line));
+    assert.deepStrictEqual(
+      sessionEntries.map(entry => ({
+        entry_type: entry.entry_type,
+        level: entry.level,
+        message: entry.message,
+        session_id: entry.session_id,
+      })),
+      [
+        {
+          entry_type: 'runtime',
+          level: 'INFO',
+          message: 'inside context',
+          session_id: 'user:ou_demo',
+        },
+        {
+          entry_type: 'runtime',
+          level: 'INFO',
+          message: 'still inside context',
+          session_id: 'user:ou_demo',
+        },
+      ],
+    );
+  });
+});
+
+function waitForFlush(): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, 20));
+}


### PR DESCRIPTION
## Summary
- add session-aware runtime logging via AsyncLocalStorage
- write runtime log lines into per-session jsonl files alongside turn logs
- add focused logger coverage for session-context routing

## Scope
- runtime logging only
- no roles or src/roles changes
- no AutoDev ingest changes (covered separately in #31)

## Validation
- npm run build
- npx tsx --test tests/logger.test.ts