### PR TITLE
修复 CatsCompany 回传兜底

### DIFF
--- a/src/catscompany/client.ts
+++ b/src/catscompany/client.ts
@@ -27,11 +27,58 @@ export interface UploadResult {
   size: number;
 }
 
+export interface CatsOutgoingMessage {
+  topic_id?: string;
+  topic?: string;
+  type?: string;
+  msg_type?: string;
+  content?: unknown;
+  metadata?: Record<string, unknown>;
+  content_blocks?: unknown[];
+  mode?: string;
+  role?: string;
+  reply_to?: number;
+}
+
+interface PendingAck {
+  resolve: (seq: number) => void;
+  reject: (err: Error) => void;
+  timer: NodeJS.Timeout;
+}
+
+export type CatsSendErrorKind = 'transport' | 'ack' | 'timeout';
+
+export class CatsSendError extends Error {
+  constructor(
+    public readonly kind: CatsSendErrorKind,
+    message: string,
+    public readonly code?: number
+  ) {
+    super(message);
+    this.name = 'CatsSendError';
+  }
+}
+
+function describeReadyState(ws: WebSocket | null): string {
+  switch (ws?.readyState) {
+    case WebSocket.CONNECTING:
+      return 'CONNECTING';
+    case WebSocket.OPEN:
+      return 'OPEN';
+    case WebSocket.CLOSING:
+      return 'CLOSING';
+    case WebSocket.CLOSED:
+      return 'CLOSED';
+    default:
+      return 'NO_SOCKET';
+  }
+}
+
 export class CatsClient extends EventEmitter {
   private ws: WebSocket | null = null;
   private msgId = 0;
   private closed = false;
-  private pendingAcks = new Map<string, any>();
+  private pendingAcks = new Map<string, PendingAck>();
   private pingTimer: NodeJS.Timeout | null = null;
   private pongTimer: NodeJS.Timeout | null = null;
   private reconnectAttempts = 0;
@@ -86,12 +133,20 @@ export class CatsClient extends EventEmitter {
         this.emit('ready', { uid: this.uid, name: this.name });
         this.autoAcceptFriendRequests().catch(console.error);
         this.resubscribeTopics();
-      } else if (msg.ctrl.id && msg.ctrl.code === 200) {
+      } else if (msg.ctrl.id) {
         const pending = this.pendingAcks.get(msg.ctrl.id);
         if (pending) {
           clearTimeout(pending.timer);
-          pending.resolve(msg.ctrl.params?.seq || 0);
           this.pendingAcks.delete(msg.ctrl.id);
+          if (msg.ctrl.code >= 200 && msg.ctrl.code < 300) {
+            pending.resolve(Number(msg.ctrl.params?.seq || 0));
+          } else {
+            pending.reject(new CatsSendError(
+              'ack',
+              `CatsCompany ack ${msg.ctrl.code}: ${msg.ctrl.text || 'request failed'}`,
+              msg.ctrl.code
+            ));
+          }
         }
       }
     } else if (msg.data) {
@@ -117,16 +172,53 @@ export class CatsClient extends EventEmitter {
   }
 
   async sendMessage(topic: string, text: string): Promise<number> {
+    return this.sendStructuredMessage({ topic_id: topic, type: 'text', content: text });
+  }
+
+  private buildPubMessage(msgId: string, payload: CatsOutgoingMessage): Record<string, unknown> {
+    const topic = payload.topic_id || payload.topic;
+    if (!topic) {
+      throw new Error('CatsCompany topic is required');
+    }
+
+    const pub: Record<string, unknown> = {
+      id: msgId,
+      topic,
+    };
+
+    if (payload.content !== undefined) pub.content = payload.content;
+    if (payload.content_blocks !== undefined) pub.content_blocks = payload.content_blocks;
+    if (payload.metadata !== undefined) pub.metadata = payload.metadata;
+    if (payload.type !== undefined) pub.type = payload.type;
+    if (payload.msg_type !== undefined) pub.msg_type = payload.msg_type;
+    if (payload.mode !== undefined) pub.mode = payload.mode;
+    if (payload.role !== undefined) pub.role = payload.role;
+    if (payload.reply_to !== undefined) pub.reply_to = payload.reply_to;
+
+    return pub;
+  }
+
+  async sendStructuredMessage(payload: CatsOutgoingMessage): Promise<number> {
     const msgId = `${++this.msgId}`;
+    const pub = this.buildPubMessage(msgId, payload);
 
     return new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
         this.pendingAcks.delete(msgId);
-        reject(new Error('Ack timeout'));
+        reject(new CatsSendError(
+          'timeout',
+          'WebSocket 已发送消息，但 10 秒内没有收到 CatsCompany 服务器确认'
+        ));
       }, 10000);
 
       this.pendingAcks.set(msgId, { resolve, reject, timer });
-      this.send({ pub: { id: msgId, topic, content: text } });
+      try {
+        this.sendOrThrow({ pub });
+      } catch (err: any) {
+        clearTimeout(timer);
+        this.pendingAcks.delete(msgId);
+        reject(err);
+      }
     });
   }
 
@@ -207,7 +299,7 @@ export class CatsClient extends EventEmitter {
         size: upload.size,
       },
     };
-    return this.sendRichContent(topic, content);
+    return this.sendStructuredMessage({ topic_id: topic, type: 'image', content });
   }
 
   async sendFile(topic: string, upload: UploadResult): Promise<number> {
@@ -219,26 +311,29 @@ export class CatsClient extends EventEmitter {
         size: upload.size,
       },
     };
-    return this.sendRichContent(topic, content);
-  }
-
-  private async sendRichContent(topic: string, content: any): Promise<number> {
-    const msgId = `${++this.msgId}`;
-
-    return new Promise((resolve, reject) => {
-      const timer = setTimeout(() => {
-        this.pendingAcks.delete(msgId);
-        reject(new Error('Ack timeout'));
-      }, 10000);
-
-      this.pendingAcks.set(msgId, { resolve, reject, timer });
-      this.send({ pub: { id: msgId, topic, content } });
-    });
+    return this.sendStructuredMessage({ topic_id: topic, type: 'file', content });
   }
 
   private send(data: any): void {
     if (this.ws?.readyState === WebSocket.OPEN) {
       this.ws.send(JSON.stringify(data));
+    }
+  }
+
+  private sendOrThrow(data: any): void {
+    if (this.ws?.readyState !== WebSocket.OPEN) {
+      throw new CatsSendError(
+        'transport',
+        `小八到 CatsCompany 的 WebSocket 未连接，当前状态: ${describeReadyState(this.ws)}`
+      );
+    }
+    try {
+      this.ws.send(JSON.stringify(data));
+    } catch (err: any) {
+      throw new CatsSendError(
+        'transport',
+        `WebSocket 写入失败: ${err?.message || 'unknown error'}`
+      );
     }
   }
 

--- a/src/catscompany/message-sender.ts
+++ b/src/catscompany/message-sender.ts
@@ -1,9 +1,91 @@
-import { CatsClient } from './client';
+import { CatsClient, CatsSendError } from './client';
 import * as fs from 'fs';
 import * as path from 'path';
 import { Logger } from '../utils/logger';
 
 const MAX_MSG_LENGTH = 4000;
+
+type CatsMessageType = 'thinking' | 'tool_use' | 'tool_result' | 'text' | 'image' | 'file';
+
+interface CatsSendBody {
+  topic_id: string;
+  type: CatsMessageType;
+  content: unknown;
+  metadata?: any;
+}
+
+function describeMessage(body: CatsSendBody): string {
+  return `topic=${body.topic_id}, type=${body.type}`;
+}
+
+function describeAckFailure(err: CatsSendError): string {
+  switch (err.code) {
+    case 400:
+      return `服务器拒绝消息：请求格式或消息协议不符合要求。${err.message}`;
+    case 401:
+      return `服务器拒绝消息：API Key 无效或未登录。请检查 Cats Company 配置里的 API Key。${err.message}`;
+    case 403:
+      return `服务器拒绝消息：权限不足，可能是不在该会话/群组、已被禁言，或机器人没有发送权限。${err.message}`;
+    case 404:
+      return `服务器拒绝消息：目标会话不存在或已经被删除。${err.message}`;
+    case 429:
+      return `服务器拒绝消息：触发限流或机器人循环保护，请稍后再试。${err.message}`;
+    default:
+      if (err.code && err.code >= 500) {
+        return `服务器处理消息失败：Cats Company 服务端异常。${err.message}`;
+      }
+      return `服务器拒绝消息：${err.message}`;
+  }
+}
+
+function describeCatsSendFailure(err: unknown): string {
+  if (err instanceof CatsSendError) {
+    if (err.kind === 'transport') {
+      return `小八本机到 Cats Company 的 WebSocket 链路不可用，可能是本机网络、代理、防火墙、服务器地址或连接重连中的问题。${err.message}`;
+    }
+    if (err.kind === 'timeout') {
+      return `WebSocket 消息已写出，但服务器确认超时。可能是服务器处理慢、网络抖动或连接半断开；为避免重复消息，不会自动改用 HTTP 重发。${err.message}`;
+    }
+    if (err.kind === 'ack') {
+      return describeAckFailure(err);
+    }
+  }
+
+  const message = err instanceof Error ? err.message : String(err);
+  return `未知发送错误：${message}`;
+}
+
+function describeHttpFailure(status: number, body: string): string {
+  const trimmed = body.trim();
+  const detail = trimmed ? ` 响应: ${trimmed.slice(0, 500)}` : '';
+  switch (status) {
+    case 400:
+      return `HTTP 兜底失败：请求格式不符合服务器要求。${detail}`;
+    case 401:
+      return `HTTP 兜底失败：API Key 无效或未授权，请检查 Cats Company 配置。${detail}`;
+    case 403:
+      return `HTTP 兜底失败：权限不足，可能是不在会话/群组、被禁言或机器人没有发送权限。${detail}`;
+    case 404:
+      return `HTTP 兜底失败：目标会话或接口不存在，请检查 HTTP Base URL 和 topic。${detail}`;
+    case 429:
+      return `HTTP 兜底失败：服务端限流，请稍后重试。${detail}`;
+    default:
+      if (status >= 500) {
+        return `HTTP 兜底失败：Cats Company 服务端异常，状态码 ${status}。${detail}`;
+      }
+      return `HTTP 兜底失败：状态码 ${status}。${detail}`;
+  }
+}
+
+function describeHttpException(err: any): string {
+  if (err?.name === 'AbortError' || err?.name === 'TimeoutError') {
+    return `HTTP 请求超时：小八到 Cats Company 服务器的 HTTP 链路不可用或服务器响应过慢。${err.message || ''}`;
+  }
+  if (err?.cause?.code) {
+    return `HTTP 网络连接失败：${err.cause.code}。可能是本机网络、DNS、代理、防火墙或服务器不可达。`;
+  }
+  return err?.message || String(err);
+}
 
 export class MessageSender {
   private readonly baseUrl: string;
@@ -14,24 +96,39 @@ export class MessageSender {
     this.apiKey = apiKey || '';
   }
 
-  /**
-   * 统一的消息发送接口
-   */
   private async send(
     topic: string,
-    type: 'thinking' | 'tool_use' | 'tool_result' | 'text',
-    content: string,
+    type: CatsMessageType,
+    content: unknown,
     metadata?: any
   ): Promise<{ seq_id: number }> {
+    const body: CatsSendBody = {
+      topic_id: topic,
+      type,
+      content,
+    };
+    if (metadata !== undefined) {
+      body.metadata = metadata;
+    }
+
+    try {
+      const seq = await this.bot.sendStructuredMessage(body);
+      return { seq_id: seq };
+    } catch (err: any) {
+      if (err instanceof CatsSendError && err.kind === 'transport') {
+        Logger.warning(`WebSocket 链路不可用，准备使用 HTTP 兜底发送（${describeMessage(body)}）：${describeCatsSendFailure(err)}`);
+        const result = await this.sendViaHttp(body);
+        Logger.info(`HTTP 兜底发送成功（${describeMessage(body)}, seq_id=${result.seq_id}）`);
+        return result;
+      }
+      Logger.error(`WebSocket 消息发送失败，未使用 HTTP 兜底（${describeMessage(body)}）：${describeCatsSendFailure(err)}`);
+      throw err;
+    }
+  }
+
+  private async sendViaHttp(body: CatsSendBody): Promise<{ seq_id: number }> {
     try {
       const url = `${this.baseUrl}/api/messages/send`;
-      const body = {
-        topic_id: topic,
-        type,
-        content,
-        metadata,
-      };
-
       const res = await fetch(url, {
         method: 'POST',
         headers: {
@@ -39,42 +136,32 @@ export class MessageSender {
           'Authorization': `ApiKey ${this.apiKey}`,
         },
         body: JSON.stringify(body),
-        signal: AbortSignal.timeout(10000), // 10秒超时
+        signal: AbortSignal.timeout(10000),
       });
 
       if (!res.ok) {
         const errText = await res.text();
-        Logger.error(`消息发送失败: HTTP ${res.status} - ${errText}`);
-        throw new Error(`Failed to send message: ${res.status}`);
+        throw new Error(describeHttpFailure(res.status, errText));
       }
 
       const result = await res.json() as { seq_id: number };
       return result;
     } catch (err: any) {
-      Logger.error(`消息发送失败: ${err.message}`);
+      Logger.error(`HTTP 兜底发送失败（${describeMessage(body)}）：${describeHttpException(err)}`);
       throw err;
     }
   }
 
-  /**
-   * 发送 thinking
-   */
   async sendThinking(topic: string, thinking: string): Promise<void> {
     await this.send(topic, 'thinking', thinking);
     Logger.info(`Thinking 已发送: ${thinking.slice(0, 50)}...`);
   }
 
-  /**
-   * 发送 tool_use
-   */
   async sendToolUse(topic: string, toolUseId: string, name: string, input: any): Promise<void> {
     await this.send(topic, 'tool_use', name, { id: toolUseId, input });
     Logger.info(`Tool use 已发送: ${name}, id=${toolUseId}`);
   }
 
-  /**
-   * 发送 tool_result
-   */
   async sendToolResult(
     topic: string,
     toolUseId: string,
@@ -88,9 +175,6 @@ export class MessageSender {
     Logger.info(`Tool result 已发送: tool_use_id=${toolUseId}`);
   }
 
-  /**
-   * 发送普通文本消息
-   */
   async sendText(topic: string, text: string): Promise<void> {
     await this.send(topic, 'text', text);
     Logger.info(`Text 已发送: ${text.slice(0, 50)}...`);
@@ -108,7 +192,6 @@ export class MessageSender {
       this.bot.sendTyping(topic);
     } catch {}
   }
-
 
   private splitText(text: string, maxLen: number): string[] {
     if (text.length <= maxLen) return [text];
@@ -149,11 +232,14 @@ export class MessageSender {
       const uploadResult = await this.bot.uploadFile(filePath, uploadType);
       Logger.info(`文件上传成功: ${uploadResult.url}`);
 
-      if (isImage) {
-        await this.bot.sendImage(topic, uploadResult);
-      } else {
-        await this.bot.sendFile(topic, uploadResult);
-      }
+      await this.send(topic, uploadType, {
+        type: uploadType,
+        payload: {
+          url: uploadResult.url,
+          name: uploadResult.name,
+          size: uploadResult.size,
+        },
+      });
 
       Logger.info(`CatsCompany 文件已发送: ${fileName}`);
     } catch (err: any) {
@@ -168,9 +254,7 @@ export class MessageSender {
       const tmpDir = path.join(process.cwd(), 'tmp', 'downloads');
       fs.mkdirSync(tmpDir, { recursive: true });
 
-      // 处理相对路径，拼接完整 URL
       const fullUrl = url.startsWith('http') ? url : `${this.baseUrl}${url}`;
-
       const localPath = path.join(tmpDir, `${Date.now()}_${fileName}`);
       const res = await fetch(fullUrl);
       if (!res.ok) {
@@ -180,12 +264,11 @@ export class MessageSender {
 
       const buffer = Buffer.from(await res.arrayBuffer());
       fs.writeFileSync(localPath, buffer);
-      Logger.info(`文件已下载: ${fileName} → ${localPath} (${buffer.length} bytes)`);
+      Logger.info(`文件已下载: ${fileName} -> ${localPath} (${buffer.length} bytes)`);
       return localPath;
     } catch (err: any) {
       Logger.error(`文件下载失败: ${err.message}`);
       return null;
     }
   }
-
 }


### PR DESCRIPTION
## 变更说明

修复 XiaoBa 向 CatsCompany 网页回传消息时偶发发送失败的问题。

- 优先通过 WebSocket 回传消息
- WebSocket 未连接或写入失败时，自动降级到 REST `/api/messages/send`
- 保留结构化消息字段：`type / metadata / content_blocks / mode / role`
- 附件、图片、工具消息、thinking、tool result 统一走同一套发送入口
- 补充更清晰的错误日志，区分本机网络、WebSocket 链路、HTTP 兜底、鉴权、权限、限流、服务端异常等情况
- WebSocket ack 被服务端拒绝或确认超时时不盲目 HTTP 重发，避免重复消息

## 验证

- 已执行 `npm.cmd run build`
- TypeScript 编译通过
