### PR TITLE
修复 CatsCompany 图片上传 MIME 类型

### DIFF
--- a/src/catscompany/client.ts
+++ b/src/catscompany/client.ts
@@ -48,6 +48,14 @@ interface PendingAck {
 
 export type CatsSendErrorKind = 'transport' | 'ack' | 'timeout';
 
+const MIME_BY_EXT: Record<string, string> = {
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+};
+
 export class CatsSendError extends Error {
   constructor(
     public readonly kind: CatsSendErrorKind,
@@ -259,12 +267,13 @@ export class CatsClient extends EventEmitter {
 
     const buffer = fs.readFileSync(filePath);
     const filename = path.basename(filePath);
+    const mimeType = MIME_BY_EXT[path.extname(filename).toLowerCase()] || 'application/octet-stream';
 
     try {
-      console.log(`[DEBUG] 开始上传文件到: ${url}, 大小: ${buffer.length} bytes`);
+      console.log(`[DEBUG] 开始上传文件到: ${url}, 大小: ${buffer.length} bytes, MIME: ${mimeType}`);
 
       const formData = new FormData();
-      formData.append('file', new Blob([buffer]), filename);
+      formData.append('file', new Blob([buffer], { type: mimeType }), filename);
 
       const res = await fetch(url, {
         method: 'POST',


### PR DESCRIPTION
﻿## 改动

修复 CatsCompany 图片/文件上传时 multipart Blob 没有 MIME 类型的问题。

## 原因

当前上传逻辑直接使用 `new Blob([buffer])`，浏览器/Node fetch 生成 multipart 时不会带 `image/jpeg`、`image/png` 等文件类型。Cats 服务端在 `/api/upload?type=image` 会校验图片 MIME，导致 `.jpg` 等图片上传被拒绝为 `invalid image type`。

## 影响

- `.jpg` / `.jpeg` / `.png` / `.gif` / `.webp` 上传会带正确 MIME。
- 未识别扩展名继续按 `application/octet-stream` 处理。
- 不改变 WebSocket/HTTP 消息回传协议。

## 验证

- `npm run build` 通过。
