### PR TITLE
Fix/cats image attachment reader routing

### DIFF
--- a/skills/advanced-reader/SKILL.md
+++ b/skills/advanced-reader/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: advanced-reader
-description: 通用附件读取兜底技能。仅当用户需要读取图片、截图、扫描件或 PDF，而当前主模型无法可靠理解附件内容时使用。它会调用 Cats reader proxy 提取内容，再让主模型继续回答。
+description: 图片读取兜底技能。仅当用户需要读取图片、截图或扫描图，而当前主模型无法可靠理解图片内容时使用。它会调用 Cats reader proxy 提取可见内容，再让主模型继续回答。
 category: tools
 invocable: both
 argument-hint: "<file_path_or_url> [analysis_prompt]"
@@ -9,22 +9,22 @@ max-turns: 8
 
 # Advanced Reader
 
-这是一个保守的附件读取兜底技能，用于“必须打开附件才能回答”的场景。
+这是一个保守的图片读取兜底技能，用于“必须看图才能回答”的场景。
 
 它的职责很窄：
 
-1. 把附件发送到 Cats 后端的 `POST /api/reader/analyze` 代理接口。
-2. 返回文本提取、版面结构或必要的附件理解结果。
+1. 把图片发送到 Cats 后端的 `POST /api/reader/analyze` 代理接口。
+2. 返回图片中的可见文字、版面结构或必要的图像理解结果。
 3. 让 XiaoBa 的主模型基于读取结果继续推理和最终回答。
 
 ## 核心规则
 
-- 如果不读取附件也能回答，不要调用这个技能。
+- 如果不读取图片也能回答，不要调用这个技能。
 - 不要根据文件名、路径、缩略图猜内容。
 - 把这个技能当作“读取器”，不要把它当成最终回答生成器。
 - 优先做提取，不要主动做诊断、推断、总结背景。
-- PDF 默认保守读取；只有用户明确要求完整覆盖时，才使用更大范围读取。
-- 如果接口失败，说明附件解析失败，并请用户重试或补充文本上下文。
+- 不要用这个技能读取普通文档、表格或演示文件；文档附件后续应由单独的文档读取技能处理。
+- 如果接口失败，说明图片解析失败，并请用户重试或补充文本上下文。
 
 ## 默认调用
 
@@ -49,53 +49,40 @@ https://app.catsco.cc/api/reader
 
 这个技能不会直连上游大模型。Cats 后端负责服务间转发、鉴权和上游签名。
 
-## 扩展调用
-
-只有用户明确需要更完整覆盖时才使用：
-
-```bash
-python "<SKILL_DIR>/scripts/invoke_reader_api.py" --full "<file_path_or_url>" "<analysis_prompt>"
-python "<SKILL_DIR>/scripts/invoke_reader_api.py" --force-vision "<file_path_or_url>" "<analysis_prompt>"
-```
-
 ## 推荐 Prompt
 
-- 通用提取：
-  `Extract the visible text and structure from this file. If there is little text, describe only the clearly visible content without adding conclusions.`
 - 截图读取：
   `Extract the visible text, UI labels, error messages, and layout from this screenshot. Do not diagnose yet.`
-- PDF 提取：
-  `Extract the document text and preserve section structure as much as possible.`
 - OCR 风格读取：
-  `Read all visible text from this file and keep the original order and hierarchy as much as possible.`
+  `Read all visible text from this image and keep the original order and hierarchy as much as possible.`
 
 ## 什么时候使用
 
 - 用户问图片、截图、扫描件里写了什么。
-- 用户上传 PDF，并希望后续基于内容总结或分析。
 - 用户要求读取 OCR 类图片或截图文字。
-- 回答依赖附件内容，而当前主模型无法可靠读取附件。
+- 回答依赖图片内容，而当前主模型无法可靠读取图片。
 
 ## 什么时候不要使用
 
-- 用户问题是纯文本问题，不依赖附件。
+- 用户问题是纯文本问题，不依赖图片。
 - 用户已经把关键内容贴到对话里。
-- 当前模型已经成功读取附件。
+- 当前模型已经成功读取图片。
 - 用户只问不需要打开文件的元信息问题。
+- 用户上传的是普通文档、表格或演示文件，而不是图片或截图。
 
 ## 处理流程
 
-1. 找到本地附件路径或远程附件 URL。
+1. 找到本地图片路径或远程图片 URL。
 2. 构造偏“提取”的 prompt，而不是偏“解释/推断”的 prompt。
 3. 调用 helper 脚本。
 4. 读取接口返回结果。
-5. 把读取结果作为附件上下文，交给主模型继续回答。
+5. 把读取结果作为图片上下文，交给主模型继续回答。
 
 ## 输出规则
 
-- 把 API 结果当作“附件上下文”，不是天然最终答案。
+- 把 API 结果当作“图片上下文”，不是天然最终答案。
 - 除非用户明确要原始提取结果，否则不要直接把 API 输出当最终回答。
-- 如果确实需要读附件，不要在尝试这个兜底前说“我看不到图片”。
+- 如果确实需要读图片，不要在尝试这个兜底前说“我看不到图片”。
 
 ## 实现说明
 

--- a/skills/vision-analysis/SKILL.md
+++ b/skills/vision-analysis/SKILL.md
@@ -74,4 +74,4 @@ python "<SKILL_DIR>/scripts/invoke_reader_api.py" "<file_path_or_url>" "<analysi
 skills/advanced-reader/scripts/invoke_reader_api.py
 ```
 
-这样图片入口和通用附件入口都保留，但 reader proxy 鉴权、上传和错误处理只维护一份。
+这样图片入口和共享 reader 实现都保留，但 reader proxy 鉴权、上传和错误处理只维护一份。

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -12,12 +12,12 @@ import { Logger } from '../utils/logger';
 import { SubAgentManager } from '../core/sub-agent-manager';
 import { ChannelCallbacks } from '../types/tool';
 import { randomUUID } from 'crypto';
-import * as fs from 'fs/promises';
 
 interface PendingAttachment {
   fileName: string;
   localPath: string;
   type: 'file' | 'image';
+  senderId: string;
   receivedAt: number;
 }
 
@@ -32,6 +32,8 @@ interface PendingAnswer {
 
 interface QueuedMessage {
   userMessage: string | ContentBlock[];
+  currentUserText: string;
+  currentTurnAttachments: PendingAttachment[];
   topic: string;
   senderId: string;
   seq: number;
@@ -46,17 +48,7 @@ interface PendingTextMerge {
 
 const PENDING_ANSWER_TIMEOUT_MS = 120_000;
 const TEXT_ATTACHMENT_MERGE_WINDOW_MS = 1200;
-const READER_ANALYZE_TIMEOUT_MS = 60_000;
-const STRICT_IMAGE_READER_PROMPT = [
-  'Read this image conservatively and do not guess.',
-  'Only report text or structure that is directly visible.',
-  'If any text is blurry, cropped, tiny, or uncertain, write [unclear] instead of inferring.',
-  'Preserve the original visible language.',
-  'Do not infer the document type, app name, business meaning, or context unless the exact words are visible.',
-  'Output in three sections: Visible text, Layout/structure, and Only clearly visible colors/icons.',
-  'Do not add conclusions, diagnosis, or background knowledge.',
-  'Primary task: extract all visible text from this image in reading order as much as possible.',
-].join(' ');
+const PENDING_ATTACHMENT_TTL_MS = 5000;
 
 /**
  * CatsCompanyBot 主类
@@ -69,8 +61,6 @@ export class CatsCompanyBot {
   private sender: MessageSender;
   private sessionManager: MessageSessionManager;
   private agentServices: AgentServices;
-  private readonly readerProxyBaseUrl: string;
-  private readonly readerProxyApiKey: string;
   /** key = pendingAnswerId */
   private pendingAnswers = new Map<string, PendingAnswer>();
   /** key = sessionKey, value = pendingAnswerId */
@@ -84,8 +74,8 @@ export class CatsCompanyBot {
   private botUid: string | null = null;
 
   constructor(config: CatsCompanyConfig) {
-    this.readerProxyBaseUrl = (config.httpBaseUrl || 'https://app.catsco.cc').replace(/\/$/, '');
-    this.readerProxyApiKey = config.apiKey;
+    process.env.CATSCOMPANY_HTTP_BASE_URL ||= (config.httpBaseUrl || 'https://app.catsco.cc').replace(/\/$/, '');
+    process.env.CATSCOMPANY_API_KEY ||= config.apiKey;
     this.bot = new CatsClient({
       serverUrl: config.serverUrl,
       apiKey: config.apiKey,
@@ -260,6 +250,7 @@ export class CatsCompanyBot {
     Logger.info(`[${key}] 收到消息: ${msg.text.slice(0, 50)}...`);
 
     let userMessage: string | import('../types').ContentBlock[] = msg.text;
+    let currentTurnAttachments: PendingAttachment[] = [];
 
     if (msg.file) {
       const localPath = await this.sender.downloadFile(msg.file.url, msg.file.fileName);
@@ -276,31 +267,38 @@ export class CatsCompanyBot {
         fileName: msg.file.fileName,
         localPath,
         type: msg.file.type,
+        senderId: msg.senderId,
         receivedAt: Date.now(),
       });
       if (this.hasPendingTextMerge(key, msg.senderId)) {
         Logger.info(`[${key}] 附件已缓存，等待与刚到的文本合并`);
         return;
       }
-      const queuedAttachments = this.consumePendingAttachments(key);
-      userMessage = await this.buildMultimodalMessage(
-        msg.text,
-        queuedAttachments,
-        session.getRecentTextContext(),
-      );
-      Logger.info(`[${key}] 附件消息（attachments=${queuedAttachments.length})`);
+      if (await this.waitForTextToConsumeAttachment(key, msg.senderId, localPath)) {
+        Logger.info(`[${key}] 附件已被后续文本合并处理: ${msg.file.fileName}`);
+        return;
+      }
+      const queuedAttachments = this.consumePendingAttachments(key, {
+        senderId: msg.senderId,
+        since: Date.now() - PENDING_ATTACHMENT_TTL_MS,
+      });
+      const selectedAttachments = this.selectCurrentTurnAttachments(msg.text, queuedAttachments, key);
+      currentTurnAttachments = selectedAttachments;
+      userMessage = await this.buildMultimodalMessage(msg.text, selectedAttachments);
+      Logger.info(`[${key}] 附件消息（attachments=${selectedAttachments.length})`);
     } else {
-      let queuedAttachments = this.consumePendingAttachments(key);
+      let queuedAttachments = this.consumePendingAttachments(key, {
+        senderId: msg.senderId,
+        since: Date.now() - TEXT_ATTACHMENT_MERGE_WINDOW_MS,
+      });
       if (queuedAttachments.length === 0 && this.shouldWaitForTrailingAttachment(msg.text)) {
         queuedAttachments = await this.waitForTrailingAttachments(key, msg.senderId, msg.text);
       }
       if (queuedAttachments.length > 0) {
-        userMessage = await this.buildMultimodalMessage(
-          msg.text,
-          queuedAttachments,
-          session.getRecentTextContext(),
-        );
-        Logger.info(`[${key}] 追加 ${queuedAttachments.length} 个附件`);
+        const selectedAttachments = this.selectCurrentTurnAttachments(msg.text, queuedAttachments, key);
+        currentTurnAttachments = selectedAttachments;
+        userMessage = await this.buildMultimodalMessage(msg.text, selectedAttachments);
+        Logger.info(`[${key}] 追加 ${selectedAttachments.length} 个附件`);
       }
     }
 
@@ -309,6 +307,8 @@ export class CatsCompanyBot {
       const queue = this.messageQueue.get(key) ?? [];
       queue.push({
         userMessage,
+        currentUserText: msg.text,
+        currentTurnAttachments,
         topic: msg.topic,
         senderId: msg.senderId,
         seq: msg.seq,
@@ -332,6 +332,12 @@ export class CatsCompanyBot {
       const result = await session.handleMessage(userMessage, {
         channel,
         pendingUserInputProvider: () => this.consumeQueuedUserInput(key),
+        skipAutoSkillActivation: currentTurnAttachments.length > 0,
+        toolExecutionContext: {
+          supportsDirectImageInput: this.agentServices.aiService.supportsDirectImageInput(),
+          currentUserText: msg.text,
+          currentTurnAttachments,
+        },
         callbacks: {
           onRetry: async (attempt, maxRetries) => {
             try {
@@ -546,6 +552,12 @@ export class CatsCompanyBot {
       const result = await session.handleMessage(msg.userMessage, {
         channel,
         pendingUserInputProvider: () => this.consumeQueuedUserInput(sessionKey),
+        skipAutoSkillActivation: msg.currentTurnAttachments.length > 0,
+        toolExecutionContext: {
+          supportsDirectImageInput: this.agentServices.aiService.supportsDirectImageInput(),
+          currentUserText: msg.currentUserText,
+          currentTurnAttachments: msg.currentTurnAttachments,
+        },
       });
       if (result.text !== BUSY_MESSAGE && result.visibleToUser && result.text) {
         try {
@@ -633,22 +645,74 @@ export class CatsCompanyBot {
   }
 
   private enqueuePendingAttachment(sessionKey: string, attachment: PendingAttachment): number {
-    const queue = this.pendingAttachments.get(sessionKey) ?? [];
+    const queue = this.prunePendingAttachments(sessionKey);
     queue.push(attachment);
     const trimmed = queue.slice(-5);
     this.pendingAttachments.set(sessionKey, trimmed);
     return trimmed.length;
   }
 
-  private consumePendingAttachments(sessionKey: string): PendingAttachment[] {
+  private consumePendingAttachments(
+    sessionKey: string,
+    opts: {
+      senderId?: string;
+      since?: number;
+    } = {},
+  ): PendingAttachment[] {
+    const queue = this.prunePendingAttachments(sessionKey);
+    const matched: PendingAttachment[] = [];
+    const remaining: PendingAttachment[] = [];
+
+    for (const attachment of queue) {
+      const sameSender = !opts.senderId || attachment.senderId === opts.senderId;
+      const recentEnough = !opts.since || attachment.receivedAt >= opts.since;
+
+      if (sameSender && recentEnough) {
+        matched.push(attachment);
+      } else {
+        remaining.push(attachment);
+      }
+    }
+
+    if (remaining.length > 0) {
+      this.pendingAttachments.set(sessionKey, remaining);
+    } else {
+      this.pendingAttachments.delete(sessionKey);
+    }
+
+    return matched;
+  }
+
+  private prunePendingAttachments(sessionKey: string): PendingAttachment[] {
+    const now = Date.now();
     const queue = this.pendingAttachments.get(sessionKey) ?? [];
-    this.pendingAttachments.delete(sessionKey);
-    return queue;
+    const fresh = queue.filter(attachment => now - attachment.receivedAt <= PENDING_ATTACHMENT_TTL_MS);
+
+    if (fresh.length > 0) {
+      this.pendingAttachments.set(sessionKey, fresh);
+    } else {
+      this.pendingAttachments.delete(sessionKey);
+    }
+
+    return fresh;
   }
 
   private hasPendingTextMerge(sessionKey: string, senderId: string): boolean {
     const pending = this.pendingTextMerges.get(sessionKey);
     return Boolean(pending && pending.senderId === senderId);
+  }
+
+  private async waitForTextToConsumeAttachment(
+    sessionKey: string,
+    senderId: string,
+    localPath: string,
+  ): Promise<boolean> {
+    await new Promise(resolve => setTimeout(resolve, TEXT_ATTACHMENT_MERGE_WINDOW_MS));
+
+    const queue = this.prunePendingAttachments(sessionKey);
+    return !queue.some(attachment => {
+      return attachment.senderId === senderId && attachment.localPath === localPath;
+    });
   }
 
   private async waitForTrailingAttachments(
@@ -670,7 +734,10 @@ export class CatsCompanyBot {
       this.pendingTextMerges.delete(sessionKey);
     }
 
-    return this.consumePendingAttachments(sessionKey);
+    return this.consumePendingAttachments(sessionKey, {
+      senderId,
+      since: Date.now() - TEXT_ATTACHMENT_MERGE_WINDOW_MS,
+    });
   }
 
   private shouldWaitForTrailingAttachment(text: string): boolean {
@@ -686,7 +753,6 @@ export class CatsCompanyBot {
   private async buildMultimodalMessage(
     text: string,
     attachments: PendingAttachment[],
-    sessionContext = '',
   ): Promise<import('../types').ContentBlock[]> {
     const canModelReadImagesDirectly = this.agentServices.aiService.supportsDirectImageInput();
     const blocks: import('../types').ContentBlock[] = [];
@@ -716,13 +782,14 @@ export class CatsCompanyBot {
           Logger.warning(`[多模态] 图片块创建失败，回退到 reader: ${att.fileName} at ${att.localPath}`);
         }
 
-        const fallbackBlock = await this.buildReaderFallbackBlock(att, text, sessionContext);
-        blocks.push(fallbackBlock);
-        if (fallbackBlock.text.startsWith('[Reader result')) {
-          Logger.info(`[多模态] 已注入 reader 结果: ${att.fileName} (${fallbackBlock.text.length} chars)`);
-        } else {
-          Logger.warning(`[多模态] reader 结果缺失，已禁止主模型猜图: ${att.fileName}`);
-        }
+        blocks.push({
+          type: 'text',
+          text: [
+            `[图片] ${att.fileName}`,
+            `[路径] ${att.localPath}`,
+            '[读取要求] 当前主模型不能直接可靠读取图片。请先调用 read_file 读取这个路径；如果 read_file 提示需要 reader skill，请按已激活的 vision-analysis/advanced-reader skill 调用 reader 后再回答。',
+          ].join('\n'),
+        });
       } else {
         blocks.push({ type: 'text', text: `[文件] ${att.fileName}\n[路径] ${att.localPath}` });
       }
@@ -730,118 +797,6 @@ export class CatsCompanyBot {
 
     Logger.info(`[多模态] 构建完成，共 ${blocks.length} 个块: ${blocks.map(b => b.type).join(', ')}`);
     return blocks;
-  }
-
-  private async buildReaderFallbackBlock(
-    attachment: PendingAttachment,
-    userText: string,
-    sessionContext: string,
-  ): Promise<{ type: 'text'; text: string }> {
-    const analysis = await this.readImageAttachment(attachment, userText, sessionContext);
-    if (analysis) {
-      return {
-        type: 'text',
-        text: [
-          `[Reader result for image: ${attachment.fileName}]`,
-          analysis,
-        ].join('\n'),
-      };
-    }
-
-    return {
-      type: 'text',
-      text: [
-        `[Reader unavailable for image: ${attachment.fileName}]`,
-        'The current model did not receive a reliable image parse result.',
-        'Do not guess the image content. Tell the user the image could not be read reliably right now.',
-      ].join('\n'),
-    };
-  }
-
-  private async readImageAttachment(
-    attachment: PendingAttachment,
-    userText: string,
-    sessionContext: string,
-  ): Promise<string | null> {
-    if (!this.readerProxyApiKey) {
-      Logger.warning(`[多模态] reader proxy API key missing, skip image pre-read: ${attachment.fileName}`);
-      return null;
-    }
-
-    try {
-      const fileBytes = await fs.readFile(attachment.localPath);
-      const formData = new FormData();
-      const contentType = this.guessContentType(attachment.fileName);
-      const fileBlob = new Blob([fileBytes], { type: contentType });
-      formData.append('prompt', this.buildReaderAnalyzePrompt(userText, sessionContext));
-      formData.append('file', fileBlob, attachment.fileName);
-
-      const response = await fetch(`${this.readerProxyBaseUrl}/api/reader/analyze`, {
-        method: 'POST',
-        headers: {
-          Authorization: `ApiKey ${this.readerProxyApiKey}`,
-        },
-        body: formData,
-        signal: AbortSignal.timeout(READER_ANALYZE_TIMEOUT_MS),
-      });
-
-      if (!response.ok) {
-        const errorText = await response.text();
-        Logger.warning(
-          `[多模态] reader proxy failed for ${attachment.fileName}: HTTP ${response.status} ${errorText}`,
-        );
-        return null;
-      }
-
-      const payload = await response.json() as { analysis?: unknown };
-      if (typeof payload.analysis === 'string' && payload.analysis.trim()) {
-        return payload.analysis.trim();
-      }
-
-      Logger.warning(`[多模态] reader proxy returned empty analysis for ${attachment.fileName}`);
-      return null;
-    } catch (error: any) {
-      Logger.warning(`[多模态] reader proxy request error for ${attachment.fileName}: ${error.message}`);
-      return null;
-    }
-  }
-
-  private buildReaderAnalyzePrompt(userText: string, sessionContext: string): string {
-    const trimmedText = (userText || '').trim();
-    const trimmedContext = (sessionContext || '').trim();
-    const contextRules = [
-      'Use the user text and session background only to decide what visible parts of the image deserve attention.',
-      'Do not invent image content from the background. If something is not visible in the image, say it is not visible.',
-      'Prefer the current turn image over any earlier image or attachment mentioned in the session.',
-    ];
-
-    return [
-      STRICT_IMAGE_READER_PROMPT,
-      '[CURRENT USER TEXT]',
-      trimmedText || '[none]',
-      '[RECENT SESSION BACKGROUND]',
-      trimmedContext || '[none]',
-      '[CONTEXT RULES]',
-      ...contextRules,
-    ].join('\n');
-  }
-
-  private guessContentType(fileName: string): string {
-    const normalized = fileName.toLowerCase();
-    if (normalized.endsWith('.png')) return 'image/png';
-    if (normalized.endsWith('.jpg') || normalized.endsWith('.jpeg')) return 'image/jpeg';
-    if (normalized.endsWith('.webp')) return 'image/webp';
-    if (normalized.endsWith('.gif')) return 'image/gif';
-    if (normalized.endsWith('.bmp')) return 'image/bmp';
-    if (normalized.endsWith('.svg')) return 'image/svg+xml';
-    return 'application/octet-stream';
-  }
-
-  private formatAttachmentSummary(attachments: PendingAttachment[]): string {
-    const lines = attachments.map((attachment, index) => {
-      return `[附件${index + 1}] ${attachment.fileName} (${attachment.type})`;
-    });
-    return `[用户本轮新上传的附件]\n${lines.join('\n')}`;
   }
 
   private formatAttachmentContext(attachments: PendingAttachment[]): string {
@@ -861,7 +816,7 @@ export class CatsCompanyBot {
     const trimmedText = (text || '').trim();
     const imageRoutingRule = canModelReadImagesDirectly
       ? 'The current primary model appears vision-capable, so image attachments from this turn may be read directly.'
-      : 'The current primary model does not appear vision-capable, so image attachments from this turn were pre-read by the reader service before reaching you.';
+      : 'The current primary model does not appear vision-capable. For image attachments from this turn, first call read_file on the exact current file path. If the answer depends on image pixels, decide as an agent to call the skill tool with vision-analysis or advanced-reader, then answer from that reader result.';
 
     return [
       '[CURRENT TURN HAS NEW ATTACHMENTS]',
@@ -870,12 +825,12 @@ export class CatsCompanyBot {
       'Do not continue, reuse, or paraphrase descriptions from earlier images, screenshots, or attachments unless the user explicitly asks for a comparison.',
       'If the user text is vague, such as "answer this", "look at this", or "what is in the image", treat it as referring to the attachments from this turn.',
       imageRoutingRule,
-      'If a reader result is present, prefer it over any visual guess. If the image is still uncertain, say so instead of inventing details.',
+      'Do not answer image-dependent questions from the file name alone.',
+      'Prefer the current turn attachment over any earlier image or attachment in the session.',
       trimmedText
         ? `[USER TEXT IN THIS TURN]\n${trimmedText}`
         : '[USER TEXT IN THIS TURN]\n[none]',
-      this.formatAttachmentSummary(attachments),
-      'Do not answer from the file name alone.',
+      this.formatAttachmentContext(attachments),
     ].join('\n');
   }
 
@@ -887,6 +842,37 @@ export class CatsCompanyBot {
       '如果任务不明确，先提出一个最小澄清问题；如果任务足够明确，再自行执行。',
       this.formatAttachmentContext(attachments),
     ].join('\n');
+  }
+
+  private selectCurrentTurnAttachments(
+    text: string,
+    attachments: PendingAttachment[],
+    sessionKey: string,
+  ): PendingAttachment[] {
+    const images = attachments.filter(attachment => attachment.type === 'image');
+    if (images.length <= 1 || this.hasMultiImageIntent(text)) {
+      return attachments;
+    }
+
+    const latestImage = images.reduce((latest, attachment) => {
+      return attachment.receivedAt > latest.receivedAt ? attachment : latest;
+    });
+    const selected = attachments.filter(attachment => attachment.type !== 'image' || attachment === latestImage);
+    const dropped = images
+      .filter(attachment => attachment !== latestImage)
+      .map(attachment => attachment.fileName)
+      .join(', ');
+
+    Logger.info(
+      `[${sessionKey}] 合并到多张图片，但用户未表达多图意图；仅保留最近图片: ${latestImage.fileName}` +
+      (dropped ? `，忽略: ${dropped}` : ''),
+    );
+    return selected;
+  }
+
+  private hasMultiImageIntent(text: string): boolean {
+    const input = (text || '').toLowerCase();
+    return /这些|所有|全部|多张|几张|两张|每张|每个|对比|比较|一起看|all|both|multiple|each|compare/.test(input);
   }
 
   private registerPendingAnswer(

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -283,7 +283,11 @@ export class CatsCompanyBot {
         return;
       }
       const queuedAttachments = this.consumePendingAttachments(key);
-      userMessage = await this.buildMultimodalMessage(msg.text, queuedAttachments);
+      userMessage = await this.buildMultimodalMessage(
+        msg.text,
+        queuedAttachments,
+        session.getRecentTextContext(),
+      );
       Logger.info(`[${key}] 附件消息（attachments=${queuedAttachments.length})`);
     } else {
       let queuedAttachments = this.consumePendingAttachments(key);
@@ -291,7 +295,11 @@ export class CatsCompanyBot {
         queuedAttachments = await this.waitForTrailingAttachments(key, msg.senderId, msg.text);
       }
       if (queuedAttachments.length > 0) {
-        userMessage = await this.buildMultimodalMessage(msg.text, queuedAttachments);
+        userMessage = await this.buildMultimodalMessage(
+          msg.text,
+          queuedAttachments,
+          session.getRecentTextContext(),
+        );
         Logger.info(`[${key}] 追加 ${queuedAttachments.length} 个附件`);
       }
     }
@@ -670,10 +678,16 @@ export class CatsCompanyBot {
     if (!input) return false;
     if (input.startsWith('/')) return false;
 
-    return /(图片|图里|看图|识图|截图|照片|附图|附件|文件|pdf|文档|ocr|界面|页面)/i.test(input);
+    // Cats web composer sends text and attachment as two nearby messages.
+    // Any text typed while an attachment is pending should be treated as the attachment caption/question.
+    return true;
   }
 
-  private async buildMultimodalMessage(text: string, attachments: PendingAttachment[]): Promise<import('../types').ContentBlock[]> {
+  private async buildMultimodalMessage(
+    text: string,
+    attachments: PendingAttachment[],
+    sessionContext = '',
+  ): Promise<import('../types').ContentBlock[]> {
     const canModelReadImagesDirectly = this.agentServices.aiService.supportsDirectImageInput();
     const blocks: import('../types').ContentBlock[] = [];
 
@@ -702,7 +716,7 @@ export class CatsCompanyBot {
           Logger.warning(`[多模态] 图片块创建失败，回退到 reader: ${att.fileName} at ${att.localPath}`);
         }
 
-        const fallbackBlock = await this.buildReaderFallbackBlock(att);
+        const fallbackBlock = await this.buildReaderFallbackBlock(att, text, sessionContext);
         blocks.push(fallbackBlock);
         if (fallbackBlock.text.startsWith('[Reader result')) {
           Logger.info(`[多模态] 已注入 reader 结果: ${att.fileName} (${fallbackBlock.text.length} chars)`);
@@ -718,8 +732,12 @@ export class CatsCompanyBot {
     return blocks;
   }
 
-  private async buildReaderFallbackBlock(attachment: PendingAttachment): Promise<{ type: 'text'; text: string }> {
-    const analysis = await this.readImageAttachment(attachment);
+  private async buildReaderFallbackBlock(
+    attachment: PendingAttachment,
+    userText: string,
+    sessionContext: string,
+  ): Promise<{ type: 'text'; text: string }> {
+    const analysis = await this.readImageAttachment(attachment, userText, sessionContext);
     if (analysis) {
       return {
         type: 'text',
@@ -740,7 +758,11 @@ export class CatsCompanyBot {
     };
   }
 
-  private async readImageAttachment(attachment: PendingAttachment): Promise<string | null> {
+  private async readImageAttachment(
+    attachment: PendingAttachment,
+    userText: string,
+    sessionContext: string,
+  ): Promise<string | null> {
     if (!this.readerProxyApiKey) {
       Logger.warning(`[多模态] reader proxy API key missing, skip image pre-read: ${attachment.fileName}`);
       return null;
@@ -751,7 +773,7 @@ export class CatsCompanyBot {
       const formData = new FormData();
       const contentType = this.guessContentType(attachment.fileName);
       const fileBlob = new Blob([fileBytes], { type: contentType });
-      formData.append('prompt', STRICT_IMAGE_READER_PROMPT);
+      formData.append('prompt', this.buildReaderAnalyzePrompt(userText, sessionContext));
       formData.append('file', fileBlob, attachment.fileName);
 
       const response = await fetch(`${this.readerProxyBaseUrl}/api/reader/analyze`, {
@@ -782,6 +804,26 @@ export class CatsCompanyBot {
       Logger.warning(`[多模态] reader proxy request error for ${attachment.fileName}: ${error.message}`);
       return null;
     }
+  }
+
+  private buildReaderAnalyzePrompt(userText: string, sessionContext: string): string {
+    const trimmedText = (userText || '').trim();
+    const trimmedContext = (sessionContext || '').trim();
+    const contextRules = [
+      'Use the user text and session background only to decide what visible parts of the image deserve attention.',
+      'Do not invent image content from the background. If something is not visible in the image, say it is not visible.',
+      'Prefer the current turn image over any earlier image or attachment mentioned in the session.',
+    ];
+
+    return [
+      STRICT_IMAGE_READER_PROMPT,
+      '[CURRENT USER TEXT]',
+      trimmedText || '[none]',
+      '[RECENT SESSION BACKGROUND]',
+      trimmedContext || '[none]',
+      '[CONTEXT RULES]',
+      ...contextRules,
+    ].join('\n');
   }
 
   private guessContentType(fileName: string): string {

--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -3,7 +3,7 @@ import { AIService } from '../utils/ai-service';
 import { ToolManager } from '../tools/tool-manager';
 import { SkillManager } from '../skills/skill-manager';
 import { SkillActivationSignal, SkillInvocationContext } from '../types/skill';
-import { ChannelCallbacks } from '../types/tool';
+import { ChannelCallbacks, ToolExecutionContext } from '../types/tool';
 import {
   buildSkillActivationSignal,
   upsertSkillSystemMessage,
@@ -51,6 +51,10 @@ export interface HandleMessageOptions {
   channel?: ChannelCallbacks;
   /** 当前 run 忙碌期间新到的用户消息，在 turn 边界合并进上下文。 */
   pendingUserInputProvider?: PendingUserInputProvider;
+  /** 平台层补充的工具上下文，例如当前模型是否能直接读图。 */
+  toolExecutionContext?: Partial<ToolExecutionContext>;
+  /** 禁用文本命中 skill 名称时的自动激活，让模型必须显式调用 skill 工具。 */
+  skipAutoSkillActivation?: boolean;
 }
 
 /** 命令处理结果 */
@@ -281,6 +285,8 @@ export class AgentSession {
       let callbacks: SessionCallbacks | undefined;
       let channel: ChannelCallbacks | undefined;
       let pendingUserInputProvider: PendingUserInputProvider | undefined;
+      let extraToolExecutionContext: Partial<ToolExecutionContext> | undefined;
+      let skipAutoSkillActivation = false;
 
       if (callbacksOrOptions) {
         if ('channel' in callbacksOrOptions || 'callbacks' in callbacksOrOptions) {
@@ -289,6 +295,8 @@ export class AgentSession {
           callbacks = opts.callbacks;
           channel = opts.channel;
           pendingUserInputProvider = opts.pendingUserInputProvider;
+          extraToolExecutionContext = opts.toolExecutionContext;
+          skipAutoSkillActivation = opts.skipAutoSkillActivation === true;
         } else {
           // 旧签名 SessionCallbacks
           callbacks = callbacksOrOptions as SessionCallbacks;
@@ -322,12 +330,12 @@ export class AgentSession {
         await this.init();
         await this.services.skillManager.loadSkills();
 
-        this.tryAutoActivateAttachmentSkill(text);
-
         const textContent = typeof text === 'string'
           ? text
           : this.extractTextFromContentBlocks(text);
-        this.tryAutoActivateSkill(textContent);
+        if (!skipAutoSkillActivation) {
+          this.tryAutoActivateSkill(textContent);
+        }
         this.messages.push({ role: 'user', content: text });
 
 
@@ -390,6 +398,7 @@ export class AgentSession {
             shouldContinue: () => !this.interruptRequested,
             pendingUserInputProvider,
             toolExecutionContext: {
+              ...(extraToolExecutionContext || {}),
               sessionId: this.key,
               surface,
               permissionProfile: 'strict',

--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -124,6 +124,34 @@ export class AgentSession {
     this.wakeupReply = callback;
   }
 
+  getRecentTextContext(maxMessages = 6, maxChars = 1600): string {
+    const lines: string[] = [];
+
+    for (let i = this.messages.length - 1; i >= 0 && lines.length < maxMessages; i--) {
+      const msg = this.messages[i];
+      if (msg.role === 'system' || msg.role === 'tool') continue;
+
+      const text = this.extractTextFromMessageContent(msg.content);
+      if (!text) continue;
+
+      lines.unshift(`${msg.role}: ${text}`);
+    }
+
+    const context = lines.join('\n').trim();
+    if (context.length <= maxChars) return context;
+    return context.slice(context.length - maxChars).trimStart();
+  }
+
+  private extractTextFromMessageContent(content: Message['content']): string {
+    if (typeof content === 'string') return content.trim();
+    if (!Array.isArray(content)) return '';
+
+    return content
+      .map(block => block.type === 'text' ? block.text : '[image]')
+      .join('\n')
+      .trim();
+  }
+
   // ─── 初始化 ─────────────────────────────────────────
 
   /** 构建系统提示词（幂等，仅首次生效） */

--- a/src/tools/bash-tool.ts
+++ b/src/tools/bash-tool.ts
@@ -37,6 +37,21 @@ export class ShellTool implements Tool {
   async execute(args: any, context: ToolExecutionContext): Promise<ToolExecutionResult> {
     const { command, description, timeout = 30000 } = args;
 
+    const requiredReaderSkill = this.detectReaderSkillCommand(command);
+    if (requiredReaderSkill && context.activeSkillName !== requiredReaderSkill) {
+      return {
+        ok: false,
+        errorCode: 'SKILL_NOT_ACTIVATED',
+        retryable: false,
+        message: [
+          `Reader script "${requiredReaderSkill}" must be activated through the native skill tool before execute_shell can run it.`,
+          'Call the `skill` tool first, for example:',
+          JSON.stringify({ skill: requiredReaderSkill, args: '<current image path> <current user question>' }),
+          'After the skill tool returns that the skill is activated, retry the reader command from the activated skill context.',
+        ].join('\n'),
+      };
+    }
+
     const toolPermission = isToolAllowed(this.definition.name);
     if (!toolPermission.allowed) {
       return { ok: false, errorCode: 'PERMISSION_DENIED', message: `执行被阻止: ${toolPermission.reason}` };
@@ -63,7 +78,11 @@ export class ShellTool implements Tool {
     try {
       const { stdout, stderr } = await execAsync(command, {
         cwd: context.workingDirectory,
-        env: runtimeEnvironment.env,
+        env: {
+          ...runtimeEnvironment.env,
+          PYTHONIOENCODING: 'utf-8',
+          PYTHONUTF8: '1',
+        },
         encoding: 'utf-8',
         timeout: timeout,
         maxBuffer: 10 * 1024 * 1024, // 10MB
@@ -103,4 +122,18 @@ export class ShellTool implements Tool {
       return { ok: false, errorCode: 'TOOL_EXECUTION_ERROR', message: `命令执行失败:\n$ ${command}\n\n执行时间: ${executionTime}ms\n错误信息:\n${errorOutput}` };
     }
   }
+
+  private detectReaderSkillCommand(command?: string): 'advanced-reader' | 'vision-analysis' | null {
+    if (!command) return null;
+
+    const normalized = command.replace(/\\/g, '/').toLowerCase();
+    if (normalized.includes('/skills/vision-analysis/scripts/invoke_reader_api.py')) {
+      return 'vision-analysis';
+    }
+    if (normalized.includes('/skills/advanced-reader/scripts/invoke_reader_api.py')) {
+      return 'advanced-reader';
+    }
+    return null;
+  }
+
 }

--- a/src/tools/read-tool.ts
+++ b/src/tools/read-tool.ts
@@ -29,6 +29,10 @@ export class ReadTool implements Tool {
         pages: {
           type: 'string',
           description: 'PDF 文件的页码范围，如 "1-5" 或 "3"（仅适用于 PDF 文件）'
+        },
+        analysis_prompt: {
+          type: 'string',
+          description: '图片或附件读取时的用户问题/分析目标（可选）。如果不填，聊天平台会使用本轮用户文字。'
         }
       },
       required: ['file_path']
@@ -36,7 +40,7 @@ export class ReadTool implements Tool {
   };
 
   async execute(args: any, context: ToolExecutionContext): Promise<ToolExecutionResult> {
-    const { file_path, offset = 0, limit, pages } = args;
+    const { file_path, offset = 0, limit, pages, analysis_prompt } = args;
 
     // 解析文件路径
     const absolutePath = path.isAbsolute(file_path)
@@ -61,6 +65,22 @@ export class ReadTool implements Tool {
       const content = this.readPDF(absolutePath, file_path, pages);
       return { ok: true, content };
     } else if (['.png', '.jpg', '.jpeg', '.gif', '.bmp', '.webp'].includes(ext)) {
+      const currentAttachmentCheck = this.checkCurrentTurnImageAttachment(absolutePath, context);
+      if (!currentAttachmentCheck.allowed) {
+        return { ok: true, content: currentAttachmentCheck.message };
+      }
+
+      if (context.supportsDirectImageInput === false) {
+        return {
+          ok: true,
+          content: this.buildImageReaderGuidance(
+            absolutePath,
+            file_path,
+            String(analysis_prompt || context.currentUserText || '').trim(),
+          ),
+        };
+      }
+
       const result = await this.readImage(absolutePath, file_path);
       // readImage 成功时会返回特殊对象表示图片消息
       if (result && typeof result === 'object' && '_imageForNewMessage' in result) {
@@ -166,6 +186,72 @@ export class ReadTool implements Tool {
     }
 
     return result;
+  }
+
+  private checkCurrentTurnImageAttachment(
+    absolutePath: string,
+    context: ToolExecutionContext,
+  ): { allowed: true } | { allowed: false; message: string } {
+    const currentImages = (context.currentTurnAttachments || [])
+      .filter(attachment => attachment.type === 'image');
+
+    if (currentImages.length === 0) {
+      return { allowed: true };
+    }
+
+    const normalizedTarget = this.normalizePath(absolutePath);
+    const matched = currentImages.some(attachment => {
+      return this.normalizePath(attachment.localPath) === normalizedTarget;
+    });
+
+    if (matched) {
+      return { allowed: true };
+    }
+
+    const candidates = currentImages
+      .map((attachment, index) => `${index + 1}. ${attachment.fileName}: ${attachment.localPath}`)
+      .join('\n');
+
+    return {
+      allowed: false,
+      message: [
+        'The requested image is not one of the images attached in the current user turn.',
+        'Do not analyze this file for the current question, because it may be an older image from conversation history.',
+        '',
+        'Use one of the current-turn image paths below instead:',
+        candidates,
+      ].join('\n'),
+    };
+  }
+
+  private normalizePath(filePath: string): string {
+    return path.resolve(filePath).replace(/\\/g, '/').toLowerCase();
+  }
+
+  private buildImageReaderGuidance(absolutePath: string, file_path: string, userPrompt: string): string {
+    const stats = fs.statSync(absolutePath);
+    const sizeKB = (stats.size / 1024).toFixed(2);
+
+    return [
+      `文件: ${file_path}`,
+      '类型: 图片文件',
+      `大小: ${sizeKB} KB`,
+      '',
+      'This is the image attached in the current user turn.',
+      userPrompt
+        ? `Current user text / analysis prompt: ${userPrompt}`
+        : 'Current user text / analysis prompt: [none]',
+      '',
+      'read_file can confirm the file and path, but it cannot decode image pixels for this non-vision primary model.',
+      'Do not guess from the file name, old images, or prior conversation context.',
+      'If the answer depends on this image, the next step MUST be a native tool call to the `skill` tool. Do not call any reader Python script directly from execute_shell.',
+      'Recommended tool call:',
+      JSON.stringify({
+        skill: 'vision-analysis',
+        args: `${absolutePath}${userPrompt ? ` ${userPrompt}` : ''}`,
+      }),
+      'After the skill is activated, follow that skill guidance to run the reader script and answer from the reader result plus the current user text.',
+    ].join('\n');
   }
 
 }

--- a/src/types/tool.ts
+++ b/src/types/tool.ts
@@ -120,6 +120,13 @@ export interface ToolExecutionContext {
   runId?: string;
   abortSignal?: AbortSignal;
   activeSkillName?: string;
+  supportsDirectImageInput?: boolean;
+  currentUserText?: string;
+  currentTurnAttachments?: Array<{
+    fileName: string;
+    localPath: string;
+    type: 'file' | 'image';
+  }>;
   /** 平台通道回调（飞书/CatsCompany 等聊天会话时由平台层注入） */
   channel?: ChannelCallbacks;
 }

--- a/src/utils/ai-service.ts
+++ b/src/utils/ai-service.ts
@@ -236,8 +236,12 @@ export class AIService {
     }
 
     const isOfficialOpenAI = apiUrl.includes('api.openai.com');
-    const isExplicitVisionModel = /(vision|multimodal|\bvl\b|-vl\b|vl-)/.test(model);
-    return isExplicitVisionModel || (isOfficialOpenAI && this.isLikelyVisionCapableOpenAIModel(model));
+    const isExplicitVisionModel = this.hasExplicitVisionMarker(model);
+    if (!isOfficialOpenAI) {
+      return isExplicitVisionModel;
+    }
+
+    return this.isLikelyVisionCapableOpenAIModel(model);
   }
 
   private isLikelyVisionCapableAnthropicModel(model: string): boolean {
@@ -246,6 +250,10 @@ export class AIService {
 
   private isLikelyVisionCapableOpenAIModel(model: string): boolean {
     return /(gpt-4o|gpt-4\.1|gpt-4-turbo|gpt-4-vision|gpt-4v|o1|o3|o4|vision|multimodal|\bvl\b|-vl\b|vl-)/.test(model);
+  }
+
+  private hasExplicitVisionMarker(model: string): boolean {
+    return /(vision|multimodal|image|\bvl\b|-vl\b|vl-)/.test(model);
   }
 
   /**

--- a/tests/ai-service-vision-routing.test.ts
+++ b/tests/ai-service-vision-routing.test.ts
@@ -1,0 +1,74 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { AIService } from '../src/utils/ai-service';
+
+function withDirectImageOverride(value: string | undefined, fn: () => void): void {
+  const previous = process.env.XIAOBA_DIRECT_IMAGE_INPUT;
+  if (value === undefined) {
+    delete process.env.XIAOBA_DIRECT_IMAGE_INPUT;
+  } else {
+    process.env.XIAOBA_DIRECT_IMAGE_INPUT = value;
+  }
+
+  try {
+    fn();
+  } finally {
+    if (previous === undefined) {
+      delete process.env.XIAOBA_DIRECT_IMAGE_INPUT;
+    } else {
+      process.env.XIAOBA_DIRECT_IMAGE_INPUT = previous;
+    }
+  }
+}
+
+test('does not trust generic OpenAI-compatible endpoints as direct image models', () => {
+  withDirectImageOverride(undefined, () => {
+    const aiService = new AIService({
+      provider: 'openai',
+      apiUrl: 'https://example-proxy.local/v1',
+      apiKey: 'test-key',
+      model: 'gpt-4.1',
+    });
+
+    assert.equal(aiService.supportsDirectImageInput(), false);
+  });
+});
+
+test('allows known OpenAI vision-capable models on official OpenAI endpoint', () => {
+  withDirectImageOverride(undefined, () => {
+    const aiService = new AIService({
+      provider: 'openai',
+      apiUrl: 'https://api.openai.com/v1',
+      apiKey: 'test-key',
+      model: 'gpt-4.1',
+    });
+
+    assert.equal(aiService.supportsDirectImageInput(), true);
+  });
+});
+
+test('allows custom endpoints only when the model name explicitly advertises vision', () => {
+  withDirectImageOverride(undefined, () => {
+    const aiService = new AIService({
+      provider: 'openai',
+      apiUrl: 'https://example-proxy.local/v1',
+      apiKey: 'test-key',
+      model: 'my-model-vl',
+    });
+
+    assert.equal(aiService.supportsDirectImageInput(), true);
+  });
+});
+
+test('explicit false override forces reader fallback', () => {
+  withDirectImageOverride('false', () => {
+    const aiService = new AIService({
+      provider: 'openai',
+      apiUrl: 'https://api.openai.com/v1',
+      apiKey: 'test-key',
+      model: 'gpt-4o',
+    });
+
+    assert.equal(aiService.supportsDirectImageInput(), false);
+  });
+});

--- a/tests/read-tool-image-routing.test.ts
+++ b/tests/read-tool-image-routing.test.ts
@@ -1,0 +1,95 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ReadTool } from '../src/tools/read-tool';
+import { ShellTool } from '../src/tools/bash-tool';
+
+test('read_file returns agent-directed reader guidance for current-turn images', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-read-image-'));
+  const imagePath = path.join(tmpDir, 'current.png');
+  fs.writeFileSync(imagePath, Buffer.from('not-a-real-image'));
+
+  try {
+    const tool = new ReadTool();
+    const result = await tool.execute(
+      { file_path: imagePath },
+      {
+        workingDirectory: tmpDir,
+        conversationHistory: [],
+        supportsDirectImageInput: false,
+        currentUserText: '帮我看看图里都是什么东西',
+        currentTurnAttachments: [
+          { fileName: 'current.png', localPath: imagePath, type: 'image' },
+        ],
+      },
+    );
+
+    assert.equal(result.ok, true);
+    assert.equal(typeof result.content, 'string');
+    assert.match(String(result.content), /image attached in the current user turn/);
+    assert.match(String(result.content), /帮我看看图里都是什么东西/);
+    assert.match(String(result.content), /vision-analysis|advanced-reader/);
+    assert.match(String(result.content), /native tool call to the `skill` tool/);
+    assert.match(String(result.content), /Do not call any reader Python script directly/);
+    assert.match(String(result.content), /Do not guess from the file name/);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('read_file refuses older images when current-turn image context is available', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-read-image-'));
+  const currentPath = path.join(tmpDir, 'current.png');
+  const oldPath = path.join(tmpDir, 'old.png');
+  fs.writeFileSync(currentPath, Buffer.from('current'));
+  fs.writeFileSync(oldPath, Buffer.from('old'));
+
+  try {
+    const tool = new ReadTool();
+    const result = await tool.execute(
+      { file_path: oldPath },
+      {
+        workingDirectory: tmpDir,
+        conversationHistory: [],
+        supportsDirectImageInput: false,
+        currentUserText: '看这张图',
+        currentTurnAttachments: [
+          { fileName: 'current.png', localPath: currentPath, type: 'image' },
+        ],
+      },
+    );
+
+    assert.equal(result.ok, true);
+    assert.match(String(result.content), /not one of the images attached in the current user turn/);
+    assert.match(String(result.content), /current\.png/);
+    assert.match(String(result.content), /older image from conversation history/);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('execute_shell blocks reader scripts unless the matching skill is active', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-reader-shell-'));
+
+  try {
+    const tool = new ShellTool();
+    const result = await tool.execute(
+      {
+        command: 'python "C:/Users/test/AppData/Roaming/xiaoba-cli/skills/vision-analysis/scripts/invoke_reader_api.py" "image.png"',
+      },
+      {
+        workingDirectory: tmpDir,
+        conversationHistory: [],
+      },
+    );
+
+    assert.equal(result.ok, false);
+    assert.equal(result.errorCode, 'SKILL_NOT_ACTIVATED');
+    assert.match(result.message, /native skill tool/);
+    assert.match(result.message, /"vision-analysis"/);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## 标题

修复 Cats 图片附件读图路由

## 内容

### 改动说明

本次修复 Cats 聊天场景下图片附件和用户文字不同步导致的读图误判问题。

主要改动：

- 将 Cats 同一轮中的文字和图片附件合并处理，避免文字先进入模型、图片后到导致模型误读历史图片。
- 为工具执行上下文补充当前轮用户文字、当前轮附件、模型是否支持直接读图等信息。
- `read_file` 在非视觉主模型下读取图片时，不再尝试直接解析图片，而是明确引导模型通过原生 `skill` 工具调用 `vision-analysis`。
- 阻止模型绕过原生 skill 机制直接用 `execute_shell` 调 reader 脚本，保证 Working 中能看到实际使用的 skill。
- 限制当前轮图片优先级，避免模型读取历史图片或旧下载文件。
- 收窄 `advanced-reader` / `vision-analysis` skill 文档职责，只保留读图场景，不再诱导处理 PDF、DOCX 等普通文档。
- 增加读图路由相关测试。

### 影响

- 用户文字和图片一起发送时，模型会更稳定地围绕当前图片回答。
- 减少幻读历史图片、误用旧附件路径的问题。
- Working 过程里能更清楚地体现读图 skill 的调用链路。
- 普通文档附件暂不绑定读图 reader，后续可单独设计文档读取 skill。

### 验证

已本地通过：

- `git diff --check`
- `npx tsx --test tests/read-tool-image-routing.test.ts tests/ai-service-vision-routing.test.ts`
- `npm.cmd run build`
