### PR TITLE
feat：支持 CatsCompany 原子多附件消息并优化设置页

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -164,7 +164,7 @@
       font-size: 16px;
       font-weight: 700;
       color: #fff;
-      letter-spacing: -0.02em;
+      letter-spacing: 0;
       margin-bottom: 2px;
     }
 
@@ -268,7 +268,7 @@
     .topbar-title {
       font-size: 18px;
       font-weight: 700;
-      letter-spacing: -0.03em;
+      letter-spacing: 0;
       color: var(--text);
     }
 
@@ -420,7 +420,7 @@
     .overview-card .ov-value {
       font-size: 22px;
       font-weight: 800;
-      letter-spacing: -0.04em;
+      letter-spacing: 0;
       color: var(--text);
       word-break: break-word;
     }
@@ -478,7 +478,7 @@
       font-size: 16px;
       font-weight: 700;
       margin-bottom: 8px;
-      letter-spacing: -0.02em;
+      letter-spacing: 0;
     }
 
     .svc-meta {
@@ -641,6 +641,78 @@
     .settings-meta {
       color: var(--text2);
       font-size: 13px;
+      line-height: 1.5;
+      margin-top: 6px;
+    }
+
+    .settings-setup-card {
+      border: 1px solid rgba(59, 130, 246, 0.18);
+      background: rgba(59, 130, 246, 0.06);
+      border-radius: 18px;
+      padding: 16px;
+    }
+
+    .settings-setup-head {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 12px;
+      margin-bottom: 12px;
+    }
+
+    .settings-setup-title {
+      color: var(--text);
+      font-size: 15px;
+      font-weight: 800;
+      line-height: 1.35;
+    }
+
+    .settings-setup-copy {
+      color: var(--text2);
+      font-size: 13px;
+      line-height: 1.55;
+      margin-top: 5px;
+    }
+
+    .settings-step-grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 10px;
+    }
+
+    .settings-step {
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      background: rgba(255, 255, 255, 0.64);
+      padding: 12px;
+      min-width: 0;
+      width: 100%;
+      color: inherit;
+      font: inherit;
+      text-align: left;
+      cursor: pointer;
+      transition: border-color 0.18s ease, background 0.18s ease;
+    }
+
+    .settings-step:hover {
+      border-color: var(--border-strong);
+      background: rgba(255, 255, 255, 0.88);
+    }
+
+    .settings-step-title {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+      color: var(--text);
+      font-size: 13px;
+      font-weight: 800;
+      line-height: 1.35;
+    }
+
+    .settings-step-meta {
+      color: var(--text2);
+      font-size: 12px;
       line-height: 1.5;
       margin-top: 6px;
     }
@@ -926,6 +998,12 @@
       margin-top: 16px;
     }
 
+    .advanced-muted {
+      color: var(--text3);
+      font-size: 12px;
+      font-weight: 700;
+    }
+
     .config-group {
       border-radius: 24px;
       padding: 24px;
@@ -967,7 +1045,8 @@
     .config-group-title {
       font-size: 15px;
       font-weight: 700;
-      letter-spacing: -0.02em;
+      letter-spacing: 0;
+      gap: 10px;
     }
 
     .config-row {
@@ -1106,7 +1185,7 @@
       font-size: 15px;
       font-weight: 700;
       margin-bottom: 2px;
-      letter-spacing: -0.02em;
+      letter-spacing: 0;
       word-break: break-word;
     }
 
@@ -1236,7 +1315,7 @@
     .modal-header h3 {
       font-size: 16px;
       font-weight: 700;
-      letter-spacing: -0.02em;
+      letter-spacing: 0;
     }
 
     .modal-body {
@@ -1284,7 +1363,7 @@
     .section-title {
       font-size: 22px;
       font-weight: 800;
-      letter-spacing: -0.04em;
+      letter-spacing: 0;
       margin-bottom: 18px;
       display: flex;
       align-items: center;
@@ -1330,7 +1409,7 @@
       gap: 10px;
       font-size: 18px;
       font-weight: 800;
-      letter-spacing: -0.03em;
+      letter-spacing: 0;
       color: var(--text);
     }
 
@@ -1393,7 +1472,7 @@
     .section-header h2 {
       font-size: 22px;
       font-weight: 800;
-      letter-spacing: -0.04em;
+      letter-spacing: 0;
       color: var(--text);
     }
 
@@ -1431,7 +1510,7 @@
     .status-card .value {
       font-size: 20px;
       font-weight: 800;
-      letter-spacing: -0.03em;
+      letter-spacing: 0;
       color: var(--text);
       word-break: break-word;
     }
@@ -1470,7 +1549,7 @@
       font-size: 24px;
       font-weight: 850;
       color: var(--text);
-      letter-spacing: -0.04em;
+      letter-spacing: 0;
     }
 
     .run-summary-meta {
@@ -2006,6 +2085,7 @@
       }
 
       .profile-summary-grid,
+      .settings-step-grid,
       .model-source-grid,
       .runtime-field-row {
         grid-template-columns: 1fr;
@@ -2096,8 +2176,11 @@
     }
 
     /* Collapsible config groups */
-    .config-group-title { cursor: pointer; user-select: none; display: flex; align-items: center; justify-content: space-between; }
+    .config-group-title { cursor: pointer; user-select: none; display: flex; align-items: center; justify-content: flex-start; gap: 12px; }
+    .config-group-title-main { flex: 1; min-width: 0; display: inline-flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+    .config-group-title-actions { display: inline-flex; align-items: center; gap: 8px; margin-left: auto; }
     .config-group-title::after { content: ''; display: inline-block; width: 8px; height: 8px; border-right: 2px solid var(--text3); border-bottom: 2px solid var(--text3); transform: rotate(45deg); transition: transform 0.2s ease; flex-shrink: 0; }
+    .config-group:not(.collapsed) .config-group-title::after { transform: rotate(225deg); }
     
     .config-group-body { transition: max-height 0.3s ease, opacity 0.2s ease; overflow: hidden; }
     
@@ -3552,7 +3635,7 @@
             <div class="chat-connect-header">
               <div>
                 <h3>CatsCo 连接</h3>
-                <div class="chat-muted chat-connect-intro">Dashboard Chat 连接同一个 CatsCo webapp 会话；本地 agent 通过 connector 回复。</div>
+                <div class="chat-muted chat-connect-intro">Dashboard Chat 连接同一个 CatsCompany 网页会话；本地 agent 通过 CatsCompany connector 回复。</div>
               </div>
               <span class="status-dot stopped" id="cats-chat-state">checking</span>
             </div>
@@ -3560,7 +3643,7 @@
             <div class="chat-state-card warning" id="cats-state-card">
               <div>
                 <div class="chat-state-title" id="cats-state-title">正在检查 CatsCo Chat</div>
-                <div class="chat-muted" id="cats-state-copy">检查模型来源、CatsCo 账号、agent 绑定和本地 connector。</div>
+                <div class="chat-muted" id="cats-state-copy">检查模型来源、CatsCo 账号、agent 绑定和 CatsCompany connector。</div>
               </div>
               <button class="btn btn-primary" id="cats-state-action" onclick="runCatsNextAction()">查看</button>
             </div>
@@ -3647,6 +3730,18 @@
             <div class="settings-meta">优先使用 CatsCo 托管模型；自定义模型和本地环境变量保留在高级区域。</div>
           </div>
           <button class="btn" onclick="refreshSettingsPage()">刷新</button>
+        </div>
+        <div class="config-section settings-setup-card" id="settings-setup-panel">
+          <div class="settings-setup-head">
+            <div>
+              <div class="settings-setup-title">先完成关键配置</div>
+              <div class="settings-setup-copy">普通使用只需要确认 CatsCo 登录和模型来源；Runtime Profile、.env、adapter endpoint 都放在高级折叠区。</div>
+            </div>
+            <span class="tag warm">setup</span>
+          </div>
+          <div class="settings-step-grid">
+            <div class="settings-step"><div class="settings-step-title">加载中 <span class="tag gray">...</span></div><div class="settings-step-meta">正在读取 readiness。</div></div>
+          </div>
         </div>
         <div class="config-section" id="model-source-panel"><div class="loading">加载模型来源...</div></div>
         <div class="config-section" id="runtime-config-panel"><div class="loading">加载 runtime 配置...</div></div>
@@ -4014,6 +4109,8 @@
       if (name === 'chat') {
         fetchCatsStatus();
         if (!catsPollTimer) catsPollTimer = setInterval(fetchCatsStatus, 5000);
+      } else if (name === 'config') {
+        refreshSettingsPage();
       } else if (name === 'companion') {
         setPetState(petState);
       }
@@ -4055,12 +4152,14 @@
         appReadinessLoaded = true;
         appReadinessError = '';
         renderReadiness(appReadinessSnapshot);
+        renderSettingsSetupSummary();
         if (document.getElementById('page-chat')?.classList.contains('active')) renderCatsStatus();
       } catch (e) {
         appReadinessSnapshot = {};
         appReadinessLoaded = false;
         appReadinessError = e && e.message ? e.message : 'Readiness API 暂不可用';
         renderReadinessError(e);
+        renderSettingsSetupSummary();
         if (document.getElementById('page-chat')?.classList.contains('active')) renderCatsStatus();
       }
     }
@@ -4584,15 +4683,87 @@
     let customModelAutoSaveQueued=false;
     let customModelAutoSaveLastSignature='';
     const CUSTOM_MODEL_AUTO_SAVE_DELAY=900;
+    const settingsCollapseState={
+      modelSource:false,
+      runtimeStatus:true,
+      runtimeEditor:true,
+    };
     const configGroups=[
       {title:'自定义模型兼容配置', collapsed:true, keys:[{key:'GAUZ_LLM_PROVIDER',label:'兼容类型',type:'select',options:['anthropic','openai']},{key:'GAUZ_LLM_API_BASE',label:'模型地址'},{key:'GAUZ_LLM_API_KEY',label:'访问凭证',sensitive:true},{key:'GAUZ_LLM_MODEL',label:'模型名称'}]},
       {title:'CatsCo webapp（高级）', collapsed:true, keys:[{key:'CATSCOMPANY_API_KEY',label:'Agent 访问凭证',sensitive:true}]},
-      {title:'飞书', collapsed:false, keys:[{key:'FEISHU_APP_ID',label:'App ID'},{key:'FEISHU_APP_SECRET',label:'App Secret',sensitive:true},{key:'FEISHU_BOT_OPEN_ID',label:'Bot Open ID'},{key:'FEISHU_BOT_ALIASES',label:'Bot Aliases'}]},
-      {title:'微信', collapsed:false, keys:[{key:'WEIXIN_TOKEN',label:'Token',sensitive:true}]},
+      {title:'飞书（高级）', collapsed:true, keys:[{key:'FEISHU_APP_ID',label:'App ID'},{key:'FEISHU_APP_SECRET',label:'App Secret',sensitive:true},{key:'FEISHU_BOT_OPEN_ID',label:'Bot Open ID'},{key:'FEISHU_BOT_ALIASES',label:'Bot Aliases'}]},
+      {title:'微信（高级）', collapsed:true, keys:[{key:'WEIXIN_TOKEN',label:'Token',sensitive:true}]},
     ];
 
     async function refreshSettingsPage(){
-      await Promise.all([fetchDashboardSettings(), fetchRuntimeConfig()]);
+      await Promise.all([fetchDashboardSettings(), fetchRuntimeConfig(), fetchReadiness()]);
+      renderSettingsSetupSummary();
+    }
+
+    function settingsCollapsedClass(key, fallback){
+      if(settingsCollapseState[key]===undefined)settingsCollapseState[key]=Boolean(fallback);
+      return settingsCollapseState[key]?' collapsed':'';
+    }
+
+    function toggleSettingsGroup(id, key){
+      const el=document.getElementById(id);
+      if(!el)return;
+      el.classList.toggle('collapsed');
+      settingsCollapseState[key]=el.classList.contains('collapsed');
+    }
+
+    function settingsStepHtml(title, status, meta, action){
+      const tone=status==='ready'?'green':status==='warning'?'warm':status==='blocked'?'red':'gray';
+      const label=status==='ready'?(title==='CatsCo Chat'?'运行中':'完成'):status==='warning'?(title==='CatsCo Chat'?'未启动':'需处理'):status==='blocked'?'待配置':'等待';
+      return '<button class="settings-step" type="button" onclick="'+action+'"><div class="settings-step-title">'+escapeHtml(title)+' '+runtimeTag(label,tone)+'</div><div class="settings-step-meta">'+escapeHtml(meta||'')+'</div></button>';
+    }
+
+    function renderSettingsSetupSummary(){
+      const panel=document.getElementById('settings-setup-panel');
+      if(!panel)return;
+      const modelSection=getReadinessSection('model');
+      const catscoSection=getReadinessSection('catsco');
+      const runtimeSection=getReadinessSection('runtimeProfile');
+      const modelMeta=appReadinessLoaded && modelSection
+        ? firstReadinessProblem(modelSection)||modelSection.summary
+        : (appReadinessError||'等待模型来源检查完成');
+      const catsMeta=appReadinessLoaded && catscoSection
+        ? firstReadinessProblem(catscoSection)||catscoSection.summary
+        : '等待 CatsCompany connector 检查完成';
+      const runtimeMeta=appReadinessLoaded && runtimeSection
+        ? firstReadinessProblem(runtimeSection)||runtimeSection.summary
+        : '仅在要改显示名、工作目录或工具开关时需要打开';
+      const next = modelSection?.status==='blocked'
+        ? '先补齐模型来源；当前托管模型未接入前，自定义模型是启动本地 agent 的必要配置。'
+        : catscoSection?.status==='blocked'
+          ? '模型已就绪后，继续登录并绑定 CatsCo Chat。'
+          : catscoSection?.status==='warning'
+            ? 'CatsCompany connector 还未启动；这只影响网页 Chat，飞书和微信在运行页独立启动。'
+            : '关键配置看起来可用；高级区保持折叠，按需诊断。';
+      panel.innerHTML=`<div class="settings-setup-head">
+        <div>
+          <div class="settings-setup-title">先完成关键配置</div>
+          <div class="settings-setup-copy">${escapeHtml(next)}</div>
+        </div>
+        ${runtimeTag('setup','warm')}
+      </div>
+      <div class="settings-step-grid">
+        ${settingsStepHtml('模型来源', modelSection?.status||'unknown', modelMeta, "openCustomModelSettings()")}
+        ${settingsStepHtml('CatsCo Chat', catscoSection?.status||'unknown', catsMeta, "switchPage('chat')")}
+        ${settingsStepHtml('Runtime Profile', runtimeSection?.status||'unknown', runtimeMeta, "toggleSettingsGroup('runtime-config-group','runtimeStatus')")}
+      </div>`;
+    }
+
+    function openCustomModelSettings(){
+      settingsCollapseState.modelSource=false;
+      const group=document.getElementById('model-source-group');
+      if(group)group.classList.remove('collapsed');
+      const details=document.getElementById('custom-model-settings');
+      if(details){
+        details.open=true;
+        customModelSettingsOpen=true;
+        details.scrollIntoView({behavior:'smooth',block:'start'});
+      }
     }
 
     async function fetchDashboardSettings(){
@@ -4601,6 +4772,7 @@
         const data=await r.json();
         if(!r.ok||data.error)throw new Error(data.error||'settings 加载失败');
         dashboardSettingsSnapshot=data;
+        renderSettingsSetupSummary();
         if(!shouldDeferModelSourceRender()) renderModelSource(data);
       }catch(e){
         const p=document.getElementById('model-source-panel');
@@ -4698,13 +4870,15 @@
       const apiBasePlaceholder=hideInternalGateway?'已配置 CatsCo 内部兼容网关（隐藏）':'https://example.com/v1/messages';
       const draft=captureCustomModelDraft();
 
-      p.innerHTML=`<div class="config-group" id="model-source-group">
-        <div class="config-group-title" onclick="document.getElementById('model-source-group').classList.toggle('collapsed')">
-          <span>模型来源</span>
-          <span class="tag warm" style="margin-left:8px">CatsCo 托管模型优先</span>
+      p.innerHTML=`<div class="config-group${settingsCollapsedClass('modelSource', false)}" id="model-source-group">
+        <div class="config-group-title" onclick="toggleSettingsGroup('model-source-group','modelSource')">
+          <span class="config-group-title-main">
+            <span>模型来源</span>
+            <span class="tag warm">当前关键配置</span>
+          </span>
         </div>
         <div class="config-group-body model-source-layout">
-          <div class="runtime-note">普通用户只需要登录 CatsCo。托管模型后端接入前，自定义模型是当前可运行路径；保存后影响新 session 或下一次启动的 connector。</div>
+          <div class="runtime-note">普通用户优先确认这里：托管模型后端接入前，自定义模型是当前可运行路径；保存后影响新 session 或下一次启动的 connector。</div>
           <div class="model-source-grid">
             <div class="model-source-card primary">
               <div class="model-source-head">
@@ -4722,8 +4896,8 @@
               <summary>
                 <div class="model-source-head">
                   <div>
-                    <div class="model-source-title">自定义模型（高级）</div>
-                    <div class="model-source-copy">用于开发、自有模型或托管模型未接入前。修改会自动保存，访问凭证只保存 presence，不会回显。</div>
+                    <div class="model-source-title">自定义模型（当前需要）</div>
+                    <div class="model-source-copy">托管模型未接入前，启动本地 agent 需要这里的模型地址、模型名称和访问凭证。修改会自动保存，访问凭证只保存 presence，不会回显。</div>
                   </div>
                   ${runtimeTag(credentialMeta, keyField.present?'green':'red')}
                 </div>
@@ -4903,7 +5077,25 @@
         envConfigLoading=false;
       }
     }
-    async function fetchRuntimeConfig(){try{const r=await fetch(API+'/api/runtime/config');renderRuntimeConfig(await r.json());}catch(e){document.getElementById('runtime-config-panel').innerHTML='<div class="loading">runtime 配置加载失败</div>';}}
+    async function fetchRuntimeConfig(options){
+      try{
+        const r=await fetch(API+'/api/runtime/config');
+        const data=await r.json();
+        runtimeConfigSnapshot=data;
+        if(!(options&&options.force) && shouldDeferRuntimeConfigRender())return;
+        renderRuntimeConfig(data);
+      }catch(e){
+        document.getElementById('runtime-config-panel').innerHTML='<div class="loading">runtime 配置加载失败</div>';
+      }
+    }
+
+    function shouldDeferRuntimeConfigRender(){
+      const page=document.getElementById('page-config');
+      const editor=document.getElementById('runtime-profile-editor');
+      const active=document.activeElement;
+      if(!page || !page.classList.contains('active') || !editor || !active)return false;
+      return editor.contains(active) && active.matches('input, select, textarea');
+    }
 
     function renderRuntimeConfig(snapshot){
       const p=document.getElementById('runtime-config-panel');
@@ -4948,10 +5140,16 @@
         ? '<div class="runtime-issue-row"><strong>skills.loadError</strong> · '+escapeHtml(skills.loadError)+'</div>'
         : '';
 
-      p.innerHTML=`<div class="config-group" id="runtime-config-group">
-        <div class="config-group-title" onclick="document.getElementById('runtime-config-group').classList.toggle('collapsed')">
-          <span>Runtime Profile 状态</span>
-          <button class="btn btn-ghost" onclick="event.stopPropagation();fetchRuntimeConfig()" style="font-size:12px;padding:4px 10px">刷新</button>
+      if(!valid)settingsCollapseState.runtimeStatus=false;
+      p.innerHTML=`<div class="config-group${settingsCollapsedClass('runtimeStatus', valid)}" id="runtime-config-group">
+        <div class="config-group-title" onclick="toggleSettingsGroup('runtime-config-group','runtimeStatus')">
+          <span class="config-group-title-main">
+            <span>Runtime Profile 状态</span>
+            <span class="advanced-muted">高级诊断</span>
+          </span>
+          <span class="config-group-title-actions">
+            <button class="btn btn-ghost" onclick="event.stopPropagation();fetchRuntimeConfig()" style="font-size:12px;padding:4px 10px">刷新</button>
+          </span>
         </div>
         <div class="config-group-body">
           <div class="profile-status-line">
@@ -5007,8 +5205,13 @@
     function renderRuntimeProfileEditor(profile, registeredTools, skills){
       const enabledTools=new Set((profile.tools&&profile.tools.enabled)||[]);
       const toolControls=(registeredTools||[]).map(t=>'<label class="runtime-check-row"><input type="checkbox" data-runtime-tool="'+escapeHtml(t.name)+'" '+(enabledTools.has(t.name)?'checked':'')+' /> <span>'+escapeHtml(t.name)+'</span></label>').join('');
-      return `<div class="config-group" id="runtime-profile-editor">
-        <div class="config-group-title">受控编辑 <span class="tag warm" style="margin-left:8px">保存后新 session 生效</span></div>
+      return `<div class="config-group${settingsCollapsedClass('runtimeEditor', true)}" id="runtime-profile-editor">
+        <div class="config-group-title" onclick="toggleSettingsGroup('runtime-profile-editor','runtimeEditor')">
+          <span class="config-group-title-main">
+            <span>受控编辑</span>
+            <span class="tag warm">保存后新 session 生效</span>
+          </span>
+        </div>
         <div class="config-group-body">
           <div class="runtime-note">只保存显示名、默认工作目录、启用工具和 skills 开关。访问凭证、token、secret 不会写入 Runtime Profile。</div>
           <div class="config-row"><label class="config-label">Agent 显示名</label><input class="config-input" id="runtime-profile-display-name" value="${escapeHtml(profile.displayName||'')}" placeholder="例如 CatsCo Assistant" /></div>
@@ -5079,7 +5282,7 @@
           const s=document.getElementById('runtime-profile-edit-saved');
           s.classList.add('show');
           setTimeout(()=>s.classList.remove('show'),2000);
-          await fetchRuntimeConfig();
+          await fetchRuntimeConfig({force:true});
         }
       }catch(e){
         status.textContent='失败：'+e.message;
@@ -5107,7 +5310,7 @@
         if(!r.ok||d.error)throw new Error(d.error||'回滚失败');
         status.style.color='var(--green)';
         status.textContent=d.deleted?'已删除新建的 profile 文件。':'已恢复上一次 profile 文件。';
-        await fetchRuntimeConfig();
+        await fetchRuntimeConfig({force:true});
       }catch(e){
         status.style.color='var(--red)';
         status.textContent='回滚失败：'+e.message;
@@ -5148,7 +5351,7 @@
           const extraBtn = (i.key==='WEIXIN_TOKEN')?'<button class="btn btn-primary" onclick="getWeixinToken()" style="margin-left:8px">获取Token</button>':'';
           return '<div class="config-row"><label class="config-label">'+escapeHtml(i.label)+'</label><input class="config-input" data-key="'+escapeHtml(i.key)+'" type="'+(i.sensitive?'password':'text')+'" value="'+escapeHtml(v)+'" placeholder="'+escapeHtml(i.key)+'" />'+extraBtn+'</div>';
         }).join('');
-        return '<div class="config-group'+collapsedClass+'" id="config-grp-'+idx+'"><div class="config-group-title" onclick="toggleConfigGroup('+idx+')">'+escapeHtml(g.title)+'</div><div class="config-group-body">'+rows+'</div></div>';
+        return '<div class="config-group'+collapsedClass+'" id="config-grp-'+idx+'"><div class="config-group-title" onclick="toggleConfigGroup('+idx+')"><span class="config-group-title-main">'+escapeHtml(g.title)+'</span></div><div class="config-group-body">'+rows+'</div></div>';
       }).join('');
     }
 
@@ -5285,11 +5488,11 @@
           key:'needs-connector',
           status:'warning',
           badge:'start',
-          title:'启动本地 connector',
-          copy:'账号和 agent 已绑定，启动 connector 后 webapp 消息会进入本地 runtime。',
+          title:'启动 CatsCompany connector',
+          copy:'账号和 agent 已绑定，启动后 CatsCompany 网页消息会进入本地 runtime。',
           action:'setup',
           actionLabel:'检查并启动',
-          inputPlaceholder:'先启动本地 connector',
+          inputPlaceholder:'先启动 CatsCompany connector',
         };
       }
       if(!topicReady){
@@ -5309,7 +5512,7 @@
         status:'ready',
         badge:'ready',
         title:'可以直接对话',
-        copy:'消息会发送到 CatsCo webapp 会话，本地 agent 通过 connector 回复。',
+        copy:'消息会发送到 CatsCompany 网页会话，本地 agent 通过 CatsCompany connector 回复。',
         action:'refresh',
         actionLabel:'刷新消息',
         inputPlaceholder:'输入消息，Enter 发送，Shift+Enter 换行',
@@ -5333,7 +5536,7 @@
         {label:'模型来源', status:modelStatus, meta:modelSection?firstReadinessProblem(modelSection)||modelSection.summary:'等待 readiness'},
         {label:'CatsCo 账号', status:connected?'pass':'fail', meta:connected?(user.display_name||user.username||'已登录'):'未登录'},
         {label:'Agent 绑定', status:configured?'pass':'fail', meta:configured&&catsState.botUid?('uid '+catsState.botUid):'未绑定'},
-        {label:'Connector', status:running?'pass':(configured?'warning':'fail'), meta:running?'运行中':'未启动'},
+        {label:'CatsCompany connector', status:running?'pass':(configured?'warning':'fail'), meta:running?'运行中':'未启动'},
         {label:'Chat 会话', status:topicReady?'pass':'fail', meta:topicReady?'已就绪':'等待 topic'},
       ];
       list.innerHTML=steps.map(step=>
@@ -5424,7 +5627,7 @@
         '<div class="chat-status-row"><span>账号</span><strong>'+(connected?(user.display_name?escapeHtml(user.display_name):'已登录'):'未登录')+'</strong></div>'+
         '<div class="chat-status-row"><span>CatsCo Agent</span><strong>'+(catsState.botUid?escapeHtml(catsState.botUid):'未绑定')+'</strong></div>'+
         '<div class="chat-status-row"><span>Topic</span><strong>'+(catsState.topicId?escapeHtml(catsState.topicId):'未就绪')+'</strong></div>'+
-        '<div class="chat-status-row"><span>本地服务</span><strong style="color:'+(running?'var(--green)':'var(--orange)')+'">'+(running?'运行中':'未启动')+'</strong></div>';
+        '<div class="chat-status-row"><span>CatsCompany connector</span><strong style="color:'+(running?'var(--green)':'var(--orange)')+'">'+(running?'运行中':'未启动')+'</strong></div>';
 
       const httpInput=document.getElementById('cats-http-base');
       const wsInput=document.getElementById('cats-ws-url');
@@ -5434,7 +5637,7 @@
       document.getElementById('cats-auth-panel').style.display=connected?'none':'grid';
       document.getElementById('cats-connected-card').style.display=connected?'block':'none';
       document.getElementById('cats-connected-copy').textContent=configured
-        ? (running?'可以直接开始对话。':'账号和 agent 已绑定，点击“检查并启动”恢复本地服务。')
+        ? (running?'可以直接开始对话。':'账号和 agent 已绑定，点击“检查并启动”恢复 CatsCompany connector。')
         : '账号已登录，点击“检查并启动”完成 CatsCo agent 绑定。';
       renderCatsChecklist(stage);
       updateCatsChatGate(stage);
@@ -5488,7 +5691,7 @@
     async function setupCatsBot(){
       const btn=document.getElementById('cats-setup-btn');
       btn.disabled=true;
-      setCatsAction('正在绑定 bot 并启动本地服务...');
+      setCatsAction('正在绑定 bot 并启动 CatsCompany connector...');
       try{
         const data=await parseCatsResponse(await fetch(API+'/api/cats/setup',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(getCatsEndpointFields())}));
         catsState={...catsState,...data, connected:true, configured:true, botUid:data.bot?.uid||data.botUid, topicId:data.topicId, user:data.user, service:data.service};

--- a/src/catscompany/client.ts
+++ b/src/catscompany/client.ts
@@ -17,6 +17,7 @@ export interface MessageContext {
   senderId: string;
   text: string;
   content?: any;
+  content_blocks?: unknown[];
   isGroup: boolean;
   from?: string;  // 原始 Cats 发送方字段，供兼容和排查使用
   seq?: number;   // Cats 服务端消息序号，用于排序和补充消息合并
@@ -184,6 +185,7 @@ export class CatsClient extends EventEmitter {
         senderId: msg.data.from || '',
         text: typeof msg.data.content === 'string' ? msg.data.content : '',
         content: msg.data.content,
+        content_blocks: Array.isArray(msg.data.content_blocks) ? msg.data.content_blocks : undefined,
         isGroup: msg.data.topic?.startsWith('grp_') ?? false,
         seq: Number(msg.data.seq || 0),
       };

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -537,8 +537,10 @@ export class CatsCompanyBot {
       }
     }
 
-    // 纯文本和文件都为空则忽略
-    const mergedText = text || blockTextParts.join('\n\n');
+    // content_blocks 里的 text block 是新协议的 canonical 用户文本；
+    // 顶层 content 可能只是附件摘要，因此只作为没有 text block 时的 fallback。
+    const blockText = blockTextParts.join('\n\n');
+    const mergedText = blockText || text;
     if (!mergedText && files.length === 0) return null;
 
     return {

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -111,7 +111,7 @@ export class CatsCompanyBot {
    */
   async start(): Promise<void> {
     Logger.openLogFile('catscompany');
-    Logger.info('正在启动 CatsCo agent connector...');
+    Logger.info('正在启动 CatsCompany connector...');
 
     // 加载 skills
     await this.runtime.loadSkills();
@@ -252,25 +252,32 @@ export class CatsCompanyBot {
     let userMessage: string | import('../types').ContentBlock[] = msg.text;
     const runtimeFeedback: RuntimeFeedbackInput[] = [];
 
-    if (msg.file) {
-      const localPath = await this.sender.downloadFile(msg.file.url, msg.file.fileName);
-      if (!localPath) {
-        runtimeFeedback.push({
-          source: 'catscompany.file_download',
-          message: `文件下载失败: ${msg.file.fileName}`,
-          actionHint: '请告知用户该附件没有成功读取，并让用户重试上传或改用文字说明。',
-        });
-        userMessage = `[用户上传了文件：${msg.file.fileName}，但平台未能下载该附件]`;
-      } else {
-        this.enqueuePendingAttachment(key, {
-          fileName: msg.file.fileName,
+    const messageFiles = msg.files && msg.files.length > 0 ? msg.files : (msg.file ? [msg.file] : []);
+    if (messageFiles.length > 0) {
+      const attachments: PendingAttachment[] = [];
+      for (const file of messageFiles) {
+        const localPath = await this.sender.downloadFile(file.url, file.fileName);
+        if (!localPath) {
+          runtimeFeedback.push({
+            source: 'catscompany.file_download',
+            message: `文件下载失败: ${file.fileName}`,
+            actionHint: '请告知用户该附件没有成功读取，并让用户重试上传或改用文字说明。',
+          });
+          continue;
+        }
+        attachments.push({
+          fileName: file.fileName,
           localPath,
-          type: msg.file.type,
+          type: file.type,
           receivedAt: Date.now(),
         });
-        const queuedAttachments = this.consumePendingAttachments(key);
-        userMessage = await this.buildMultimodalMessage(msg.text, queuedAttachments);
-        Logger.info(`[${key}] 附件消息（attachments=${queuedAttachments.length})`);
+      }
+
+      if (attachments.length > 0) {
+        userMessage = await this.buildMultimodalMessage(msg.text, attachments);
+        Logger.info(`[${key}] 原子附件消息（attachments=${attachments.length})`);
+      } else {
+        userMessage = `[用户上传了 ${messageFiles.length} 个附件，但平台未能下载这些附件]`;
       }
     } else {
       const queuedAttachments = this.consumePendingAttachments(key);
@@ -393,7 +400,8 @@ export class CatsCompanyBot {
   }
 
   private coalesceIncomingMessage(sessionKey: string, msg: ParsedCatsMessage): ParsedCatsMessage | null {
-    if (msg.file) {
+    const messageFiles = msg.files && msg.files.length > 0 ? msg.files : (msg.file ? [msg.file] : []);
+    if (messageFiles.length > 0) {
       const pendingText = this.pendingTextMessages.get(sessionKey);
       if (
         pendingText
@@ -405,7 +413,7 @@ export class CatsCompanyBot {
 
         const mergedText = pendingText.msg.text.trim() || msg.text;
         Logger.info(
-          `[${sessionKey}] 合并延迟文本与随后到达的附件: ${msg.file.fileName} ` +
+          `[${sessionKey}] 合并延迟文本与随后到达的附件: ${messageFiles.map(file => file.fileName).join(', ')} ` +
           `(wait=${Date.now() - pendingText.receivedAt}ms)`
         );
         return { ...msg, text: mergedText };
@@ -468,7 +476,40 @@ export class CatsCompanyBot {
 
     // 检测 rich content 中的文件/图片
     let file: CatsFileInfo | undefined;
+    const files: CatsFileInfo[] = [];
+    const blockTextParts: string[] = [];
     let content = ctx.content;
+    const seenFileUrls = new Set<string>();
+    const appendFile = (candidate: CatsFileInfo) => {
+      if (typeof candidate.url !== 'string') return;
+      const url = candidate.url.trim();
+      if (!url || seenFileUrls.has(url)) return;
+      seenFileUrls.add(url);
+      const normalized = { ...candidate, url };
+      files.push(normalized);
+      if (!file) file = normalized;
+    };
+
+    if (Array.isArray(ctx.content_blocks)) {
+      for (const block of ctx.content_blocks) {
+        if (!block || typeof block !== 'object') continue;
+        const typedBlock = block as any;
+        if (typedBlock.type === 'text' && typeof typedBlock.text === 'string' && typedBlock.text.trim()) {
+          blockTextParts.push(typedBlock.text);
+          continue;
+        }
+        if ((typedBlock.type === 'file' || typedBlock.type === 'image') && typedBlock.payload) {
+          const payload = typedBlock.payload;
+          const url = typeof payload.url === 'string' ? payload.url : '';
+          if (!url) continue;
+          appendFile({
+            url,
+            fileName: payload.name || payload.file_name || (typedBlock.type === 'image' ? 'image.png' : 'unknown'),
+            type: typedBlock.type === 'image' ? 'image' : 'file',
+          });
+        }
+      }
+    }
 
     // 如果 content 是 JSON 字符串，先解析
     if (typeof content === 'string') {
@@ -482,31 +523,33 @@ export class CatsCompanyBot {
     if (typeof content === 'object' && content !== null) {
       const rich = content as any;
       if (rich.type === 'file' && rich.payload) {
-        file = {
+        appendFile({
           url: rich.payload.url,
           fileName: rich.payload.name || 'unknown',
           type: 'file',
-        };
+        });
       } else if (rich.type === 'image' && rich.payload) {
-        file = {
+        appendFile({
           url: rich.payload.url,
           fileName: rich.payload.name || 'image.png',
           type: 'image',
-        };
+        });
       }
     }
 
     // 纯文本和文件都为空则忽略
-    if (!text && !file) return null;
+    const mergedText = text || blockTextParts.join('\n\n');
+    if (!mergedText && files.length === 0) return null;
 
     return {
       topic: ctx.topic,
       chatType,
       senderId: ctx.senderId,
       seq: ctx.seq ?? 0,
-      text: text || (file ? `[${file.type === 'image' ? '图片' : '文件'}] ${file.fileName}` : ''),
+      text: mergedText || (files.length > 0 ? files.map(item => `[${item.type === 'image' ? '图片' : '文件'}] ${item.fileName}`).join('\n') : ''),
       rawContent: ctx.content,
-      file,
+      file: files[0],
+      files,
     };
   }
 

--- a/src/catscompany/types.ts
+++ b/src/catscompany/types.ts
@@ -30,6 +30,8 @@ export interface ParsedCatsMessage {
   rawContent: unknown;
   /** 文件附件信息（rich content file/image 时存在） */
   file?: CatsFileInfo;
+  /** 同一条消息里的全部附件（content_blocks 或 rich content） */
+  files?: CatsFileInfo[];
 }
 
 /**

--- a/src/commands/catscompany.ts
+++ b/src/commands/catscompany.ts
@@ -50,7 +50,7 @@ export function resolveCatsCoCommandConfig(
 
 /**
  * CLI 命令：catsco connect / catsco catscompany / xiaoba catscompany
- * 启动 CatsCo agent WebSocket 长连接服务
+ * 启动 CatsCompany WebSocket connector
  */
 export async function catscompanyCommand(): Promise<void> {
   const config = ConfigManager.getConfig();

--- a/src/dashboard/readiness.ts
+++ b/src/dashboard/readiness.ts
@@ -314,14 +314,14 @@ function buildCatsCoSection(
   const service = serviceManager.getService('catscompany');
   const checks = buildCatsCoChatChecks(env, config);
   if (service?.status === 'running') {
-    checks.push(passCheck('catsco.connector', '本地 connector', 'CatsCo connector 正在运行'));
+    checks.push(passCheck('catsco.connector', 'CatsCompany connector', 'CatsCompany connector 正在运行'));
   } else if (statusFromChecks(checks) === 'ready') {
-    checks.push(failCheck('catsco.connector', '本地 connector', 'CatsCo connector 尚未启动', 'warning', {
-      label: '启动 CatsCo agent',
+    checks.push(failCheck('catsco.connector', 'CatsCompany connector', 'CatsCompany connector 尚未启动', 'warning', {
+      label: '启动 CatsCompany connector',
       target: 'service',
     }));
   } else {
-    checks.push(failCheck('catsco.connector', '本地 connector', '完成账号和绑定后再启动 connector', 'warning', {
+    checks.push(failCheck('catsco.connector', 'CatsCompany connector', '完成 CatsCo 账号和 agent 绑定后再启动 CatsCompany connector', 'warning', {
       label: '打开 CatsCo',
       target: 'catsco',
     }));

--- a/tests/catscompany-content-blocks.test.ts
+++ b/tests/catscompany-content-blocks.test.ts
@@ -1,0 +1,150 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import { CatsCompanyBot } from '../src/catscompany';
+
+function createProcessHarness() {
+  const bot = Object.create(CatsCompanyBot.prototype) as any;
+  const downloads: Array<{ url: string; fileName: string }> = [];
+  const multimodalCalls: Array<{ text: string; attachments: any[] }> = [];
+  const handledTurns: Array<{ userMessage: any; options: any }> = [];
+
+  const session = {
+    isBusy: () => false,
+    handleMessage: async (userMessage: any, options: any) => {
+      handledTurns.push({ userMessage, options });
+      return { visibleToUser: false, text: '' };
+    },
+  };
+
+  bot.sessionManager = {
+    getOrCreate: () => session,
+  };
+  bot.sender = {
+    downloadFile: async (url: string, fileName: string) => {
+      downloads.push({ url, fileName });
+      return `C:\\tmp\\catsco-test\\${fileName}`;
+    },
+    sendTyping: () => undefined,
+    reply: async () => undefined,
+    sendFile: async () => undefined,
+    sendText: async () => undefined,
+  };
+  bot.pendingAnswers = new Map();
+  bot.pendingAnswerBySession = new Map();
+  bot.pendingAttachments = new Map();
+  bot.pendingTextMessages = new Map();
+  bot.messageQueue = new Map();
+  bot.buildMultimodalMessage = async (text: string, attachments: any[]) => {
+    multimodalCalls.push({ text, attachments });
+    return [
+      { type: 'text', text },
+      ...attachments.map((attachment) => ({
+        type: 'text',
+        text: `[${attachment.type}] ${attachment.fileName} -> ${attachment.localPath}`,
+      })),
+    ];
+  };
+
+  return { bot, downloads, multimodalCalls, handledTurns };
+}
+
+describe('CatsCo content blocks', () => {
+  test('parses text and multiple attachments from one CatsCompany message', () => {
+    const bot = Object.create(CatsCompanyBot.prototype);
+
+    const parsed = (bot as any).parseMessage({
+      topic: 'p2p_1_2',
+      senderId: 'usr1',
+      text: '帮我一起看这两张图',
+      content: '帮我一起看这两张图',
+      content_blocks: [
+        { type: 'text', text: '帮我一起看这两张图' },
+        { type: 'image', payload: { url: '/uploads/images/a.png', name: 'a.png', size: 12 } },
+        { type: 'file', payload: { url: '/uploads/files/b.pdf', name: 'b.pdf', size: 34 } },
+      ],
+      isGroup: false,
+      seq: 7,
+    });
+
+    assert.ok(parsed);
+    assert.strictEqual(parsed.text, '帮我一起看这两张图');
+    assert.strictEqual(parsed.files.length, 2);
+    assert.deepStrictEqual(parsed.files.map((file: any) => file.type), ['image', 'file']);
+    assert.deepStrictEqual(parsed.files.map((file: any) => file.fileName), ['a.png', 'b.pdf']);
+  });
+
+  test('deduplicates attachments when content_blocks and legacy rich content overlap', () => {
+    const bot = Object.create(CatsCompanyBot.prototype);
+
+    const parsed = (bot as any).parseMessage({
+      topic: 'p2p_1_2',
+      senderId: 'usr1',
+      text: '帮我看这两张图',
+      content: {
+        type: 'image',
+        payload: { url: '/uploads/images/a.png', name: 'a.png', size: 12 },
+      },
+      content_blocks: [
+        { type: 'text', text: '帮我看这两张图' },
+        { type: 'image', payload: { url: '/uploads/images/a.png', name: 'a.png', size: 12 } },
+        { type: 'image', payload: { url: '/uploads/images/b.png', name: 'b.png', size: 34 } },
+      ],
+      isGroup: false,
+      seq: 8,
+    });
+
+    assert.ok(parsed);
+    assert.strictEqual(parsed.text, '帮我看这两张图');
+    assert.strictEqual(parsed.files.length, 2);
+    assert.deepStrictEqual(parsed.files.map((file: any) => file.type), ['image', 'image']);
+    assert.deepStrictEqual(parsed.files.map((file: any) => file.fileName), ['a.png', 'b.png']);
+    assert.deepStrictEqual(parsed.files.map((file: any) => file.url), ['/uploads/images/a.png', '/uploads/images/b.png']);
+  });
+
+  test('processes multiple attachments as one user turn', async () => {
+    const { bot, downloads, multimodalCalls, handledTurns } = createProcessHarness();
+
+    await bot.processParsedMessage({
+      topic: 'p2p_1_2',
+      chatType: 'p2p',
+      senderId: 'usr1',
+      seq: 9,
+      text: '一起看这些附件',
+      rawContent: '一起看这些附件',
+      file: { url: '/uploads/images/a.png', fileName: 'a.png', type: 'image' },
+      files: [
+        { url: '/uploads/images/a.png', fileName: 'a.png', type: 'image' },
+        { url: '/uploads/images/c.png', fileName: 'c.png', type: 'image' },
+        { url: '/uploads/files/b.pdf', fileName: 'b.pdf', type: 'file' },
+      ],
+    }, 'cc_user:usr1');
+
+    assert.deepStrictEqual(downloads, [
+      { url: '/uploads/images/a.png', fileName: 'a.png' },
+      { url: '/uploads/images/c.png', fileName: 'c.png' },
+      { url: '/uploads/files/b.pdf', fileName: 'b.pdf' },
+    ]);
+    assert.strictEqual(multimodalCalls.length, 1);
+    assert.strictEqual(multimodalCalls[0].text, '一起看这些附件');
+    assert.deepStrictEqual(
+      multimodalCalls[0].attachments.map((attachment) => ({
+        fileName: attachment.fileName,
+        localPath: attachment.localPath,
+        type: attachment.type,
+      })),
+      [
+        { fileName: 'a.png', localPath: 'C:\\tmp\\catsco-test\\a.png', type: 'image' },
+        { fileName: 'c.png', localPath: 'C:\\tmp\\catsco-test\\c.png', type: 'image' },
+        { fileName: 'b.pdf', localPath: 'C:\\tmp\\catsco-test\\b.pdf', type: 'file' },
+      ],
+    );
+    assert.strictEqual(handledTurns.length, 1);
+    assert.deepStrictEqual(handledTurns[0].userMessage, [
+      { type: 'text', text: '一起看这些附件' },
+      { type: 'text', text: '[image] a.png -> C:\\tmp\\catsco-test\\a.png' },
+      { type: 'text', text: '[image] c.png -> C:\\tmp\\catsco-test\\c.png' },
+      { type: 'text', text: '[file] b.pdf -> C:\\tmp\\catsco-test\\b.pdf' },
+    ]);
+    assert.deepStrictEqual(handledTurns[0].options.runtimeFeedback, []);
+  });
+});

--- a/tests/catscompany-content-blocks.test.ts
+++ b/tests/catscompany-content-blocks.test.ts
@@ -101,6 +101,28 @@ describe('CatsCo content blocks', () => {
     assert.deepStrictEqual(parsed.files.map((file: any) => file.url), ['/uploads/images/a.png', '/uploads/images/b.png']);
   });
 
+  test('prefers content block text over top-level attachment summary', () => {
+    const bot = Object.create(CatsCompanyBot.prototype);
+
+    const parsed = (bot as any).parseMessage({
+      topic: 'p2p_1_2',
+      senderId: 'usr1',
+      text: '[图片] crack.png',
+      content: '[图片] crack.png',
+      content_blocks: [
+        { type: 'text', text: '帮我分析这张图里的裂缝' },
+        { type: 'image', payload: { url: '/uploads/images/crack.png', name: 'crack.png', size: 12 } },
+      ],
+      isGroup: false,
+      seq: 9,
+    });
+
+    assert.ok(parsed);
+    assert.strictEqual(parsed.text, '帮我分析这张图里的裂缝');
+    assert.strictEqual(parsed.files.length, 1);
+    assert.strictEqual(parsed.files[0].fileName, 'crack.png');
+  });
+
   test('processes multiple attachments as one user turn', async () => {
     const { bot, downloads, multimodalCalls, handledTurns } = createProcessHarness();
 

--- a/tests/dashboard-productization-html.test.ts
+++ b/tests/dashboard-productization-html.test.ts
@@ -14,16 +14,36 @@ test('dashboard settings page uses model source before Runtime Profile', () => {
   assert.match(dashboardHtml, /id="model-source-panel"/);
   assert.match(dashboardHtml, /function fetchDashboardSettings\(\)/);
   assert.match(dashboardHtml, /\/api\/settings/);
+  assert.match(dashboardHtml, /id="settings-setup-panel"/);
+  assert.match(dashboardHtml, /先完成关键配置/);
   assert.match(dashboardHtml, /CatsCo 托管模型/);
-  assert.match(dashboardHtml, /自定义模型（高级）/);
+  assert.match(dashboardHtml, /自定义模型（当前需要）/);
   assert.match(dashboardHtml, /托管模型目录和用量服务还没有接入当前本地版本/);
   assert.match(dashboardHtml, /访问凭证只保存 presence，不会回显/);
   assert.match(dashboardHtml, /保存自定义模型设置？访问凭证会写入本地 \.env，仅用于本机 runtime。/);
   assert.match(dashboardHtml, /Runtime Profile 状态/);
   assert.match(dashboardHtml, /受控编辑/);
+  assert.match(dashboardHtml, /config-group-title-main/);
+  assert.match(dashboardHtml, /config-group-title-actions/);
   assert.match(dashboardHtml, /保存后新 session 生效/);
+  assert.match(dashboardHtml, /title==='CatsCo Chat'\?'运行中':'完成'/);
+  assert.match(dashboardHtml, /title==='CatsCo Chat'\?'未启动':'需处理'/);
+  assert.doesNotMatch(dashboardHtml, /status==='warning'\?'注意'/);
   assert.match(dashboardHtml, /当前已运行 session 不会热更新/);
   assert.doesNotMatch(dashboardHtml, /buildsense\.asia/i);
+});
+
+test('dashboard settings collapse state survives refresh-oriented rerenders', () => {
+  assert.match(dashboardHtml, /const settingsCollapseState=\{/);
+  assert.match(dashboardHtml, /function toggleSettingsGroup\(id, key\)/);
+  assert.match(dashboardHtml, /settingsCollapsedClass\('modelSource', false\)/);
+  assert.match(dashboardHtml, /settingsCollapsedClass\('runtimeStatus', valid\)/);
+  assert.match(dashboardHtml, /settingsCollapsedClass\('runtimeEditor', true\)/);
+  assert.match(dashboardHtml, /function shouldDeferRuntimeConfigRender\(\)/);
+  assert.match(dashboardHtml, /editor\.contains\(active\) && active\.matches\('input, select, textarea'\)/);
+  assert.match(dashboardHtml, /fetchRuntimeConfig\(\{force:true\}\)/);
+  assert.match(dashboardHtml, /飞书（高级）/);
+  assert.match(dashboardHtml, /微信（高级）/);
 });
 
 test('run page is driven by readiness instead of raw diagnostics cards', () => {
@@ -70,7 +90,9 @@ test('CatsCo Chat page is driven by readiness state instead of loose controls', 
   assert.match(dashboardHtml, /function renderCatsChecklist\(stage\)/);
   assert.match(dashboardHtml, /function runCatsNextAction\(\)/);
   assert.match(dashboardHtml, /先完成模型来源/);
-  assert.match(dashboardHtml, /Dashboard Chat 连接同一个 CatsCo webapp 会话/);
+  assert.match(dashboardHtml, /Dashboard Chat 连接同一个 CatsCompany 网页会话/);
+  assert.match(dashboardHtml, /CatsCompany connector/);
+  assert.match(dashboardHtml, /恢复 CatsCompany connector/);
   assert.match(dashboardHtml, /<details class="chat-diagnostics" id="cats-connection-details">/);
   assert.match(dashboardHtml, /<summary>高级 endpoint<\/summary>/);
   assert.match(dashboardHtml, /input\.disabled=locked/);

--- a/tests/dashboard-readiness.test.ts
+++ b/tests/dashboard-readiness.test.ts
@@ -162,6 +162,9 @@ describe('dashboard readiness and service preflight API', () => {
     const catsco = readiness.sections.find((section: any) => section.id === 'catsco');
     assert.equal(catsco.status, 'warning');
     assert.equal(catsco.checks.some((check: any) => check.id === 'catsco.connector' && check.status === 'warning'), true);
+    assert.equal(catsco.checks.some((check: any) => check.id === 'catsco.connector' && check.label === 'CatsCompany connector'), true);
+    assert.equal(catsco.checks.some((check: any) => check.id === 'catsco.connector' && check.message === 'CatsCompany connector 尚未启动'), true);
+    assert.equal(catsco.checks.some((check: any) => check.id === 'catsco.connector' && check.action?.label === '启动 CatsCompany connector'), true);
     assert.equal(readinessText.includes('sk-readiness-secret'), false);
     assert.equal(readinessText.includes('catsco-agent-secret'), false);
     assert.equal(readinessText.includes(testRoot), false);


### PR DESCRIPTION
## 背景

CatsCompany 网页端后续会发送新的原子附件协议：一条消息里同时带 `content` 和 `content_blocks`，其中 `content_blocks` 可以包含 text、image、file block。

这个 PR 先在 CatsCo 桌面端补接收侧能力，确保后续 CatsCompany 网页上线“一段文字 + 多张图片/多个文件”时，桌面 agent 能把它们作为同一轮用户消息处理。

注意：CatsCompany 网页端的新协议分支应在 CatsCo 桌面端合并/发布后再上线，否则旧 CatsCo 客户端可能无法完整处理多附件消息。

## 改动

- `MessageContext` 增加 `content_blocks`
- `parseMessage()` 支持解析 CatsCompany `content_blocks`
  - text block 合并为用户文本
  - image/file block 解析为附件列表
  - 兼容旧 rich content 附件格式
  - 如果新旧格式同时带同一个附件，按 URL 去重
- `processParsedMessage()` 支持多附件
  - 下载多个图片/文件
  - 和用户文本一起构造成同一轮 multimodal message
  - 保留旧的 1.5 秒 text + attachment 合并兜底逻辑
- 新增 CatsCompany content_blocks 测试
  - 覆盖 text + image + file 的解析
  - 覆盖 content_blocks 与旧 rich content 重复附件去重
  - 覆盖多个附件下载后作为同一轮消息送进 session
- 优化 CatsCo 设置页
  - 关键配置更明显
  - 高级配置默认折叠
  - Runtime/Profile 编辑区域保存时避免刷新覆盖输入
  - 明确 `CatsCompany connector` 只对应网页 Chat，飞书/微信是独立服务

## CatsCompany 协议说明

CatsCompany 对应分支会在网页发送消息时构造类似结构：

```json
{
  "type": "text",
  "content": "用户输入文本或附件摘要",
  "content_blocks": [
    { "type": "text", "text": "用户输入文本" },
    { "type": "image", "payload": { "url": "...", "name": "a.png" } },
    { "type": "file", "payload": { "url": "...", "name": "b.pdf" } }
  ]
}
