### PR TITLE
feat: add CatsCo chat local attachments

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -3235,12 +3235,98 @@
       color: rgba(255,255,255,0.74);
     }
 
+    .chat-composer {
+      padding: 12px 14px 14px;
+      border-top: 1px solid var(--border-light);
+      background: var(--surface-strong);
+    }
+
+    .chat-attachment-tray {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-bottom: 10px;
+    }
+
+    .chat-attach-note {
+      margin-bottom: 10px;
+      color: var(--text3);
+      font-size: 12px;
+      line-height: 1.5;
+    }
+
+    .chat-upload-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      max-width: min(420px, 100%);
+      padding: 8px 10px;
+      border: 1px solid var(--border-light);
+      border-radius: 8px;
+      background: white;
+    }
+
+    .chat-upload-chip.sending {
+      border-color: rgba(37, 99, 235, 0.35);
+      background: rgba(37, 99, 235, 0.06);
+    }
+
+    .chat-upload-chip.error {
+      border-color: rgba(239, 68, 68, 0.35);
+      background: rgba(239, 68, 68, 0.06);
+    }
+
+    .chat-upload-icon {
+      width: 32px;
+      height: 32px;
+      border-radius: 8px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      flex: 0 0 auto;
+      color: var(--accent);
+      background: var(--accent-light);
+      font-size: 11px;
+      font-weight: 800;
+    }
+
+    .chat-upload-info {
+      min-width: 0;
+    }
+
+    .chat-upload-info strong,
+    .chat-upload-info small {
+      display: block;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .chat-upload-info small {
+      color: var(--text3);
+      font-size: 12px;
+      margin-top: 2px;
+    }
+
+    .chat-upload-remove {
+      min-width: 0;
+      height: 28px;
+      padding: 0 8px;
+    }
+
     .chat-input-bar {
       display: flex;
       gap: 10px;
-      padding: 14px;
-      border-top: 1px solid var(--border-light);
-      background: var(--surface-strong);
+      align-items: stretch;
+    }
+
+    .chat-attach-btn {
+      width: 44px;
+      min-width: 44px;
+      height: 44px;
+      padding: 0;
+      font-size: 20px;
+      line-height: 1;
     }
 
     .chat-input-bar textarea {
@@ -3254,7 +3340,7 @@
       bottom: 92px;
     }
 
-    .chat-window.locked .chat-input-bar {
+    .chat-window.locked .chat-composer {
       background: rgba(247, 249, 252, 0.92);
     }
 
@@ -4225,9 +4311,14 @@
             <div class="chat-messages" id="cats-messages">
               <div class="loading">连接 CatsCo 后开始对话</div>
             </div>
-            <div class="chat-input-bar">
-              <textarea class="config-input" id="cats-message-input" placeholder="等待 CatsCo Chat 检查完成" disabled></textarea>
-              <button class="btn btn-primary" onclick="sendCatsMessage()" id="cats-send-btn" disabled>发送</button>
+            <div class="chat-composer" id="cats-composer">
+              <div class="chat-attachment-tray" id="cats-attachment-tray" hidden></div>
+              <div class="chat-attach-note" id="cats-attach-note" hidden>浏览器无法直接添加本地附件；请在 CatsCo 桌面客户端使用 + 选择文件，或把文件路径作为普通文本发给 Agent。</div>
+              <div class="chat-input-bar">
+                <button class="btn chat-attach-btn" type="button" onclick="chooseCatsFiles()" id="cats-attach-btn" title="添加本地文件" disabled>+</button>
+                <textarea class="config-input" id="cats-message-input" placeholder="等待 CatsCo Chat 检查完成" disabled></textarea>
+                <button class="btn btn-primary" onclick="sendCatsMessage()" id="cats-send-btn" disabled>发送</button>
+              </div>
             </div>
           </div>
         </div>
@@ -4387,6 +4478,9 @@
     let catsConnectCollapsed = true;
     let catsConnectManualOverride = false;
     const CATS_SCROLL_BOTTOM_THRESHOLD = 80;
+    let catsAttachmentQueue = [];
+    let catsAttachmentSeq = 0;
+    const CATS_ATTACHMENT_BROWSER_MESSAGE = '浏览器无法直接添加本地附件；请在 CatsCo 桌面客户端使用 + 选择文件，或把文件路径作为普通文本发给 Agent。';
     const CATS_DEFAULT_HTTP_BASE = 'https://app.catsco.cc';
     const CATS_DEFAULT_WS_URL = 'wss://app.catsco.cc/v0/channels';
     const CATS_WORKING_TEXT_PREFIX = 'AI文本:';
@@ -6260,12 +6354,20 @@
       if(details)details.textContent=stage.key==='ready'?'ready':'needs attention';
       const input=document.getElementById('cats-message-input');
       const send=document.getElementById('cats-send-btn');
+      const attach=document.getElementById('cats-attach-btn');
       const locked=stage.key!=='ready';
       if(input){
         input.disabled=locked;
         input.placeholder=stage.inputPlaceholder||'连接 CatsCo 后开始对话';
       }
       if(send)send.disabled=locked;
+      if(attach){
+        const desktopPickerReady=catsDesktopFilePickerAvailable();
+        attach.disabled=locked || !desktopPickerReady;
+        attach.title=desktopPickerReady?'添加本地文件':CATS_ATTACHMENT_BROWSER_MESSAGE;
+      }
+      const attachNote=document.getElementById('cats-attach-note');
+      if(attachNote)attachNote.hidden=locked || catsDesktopFilePickerAvailable();
       const chatWindow=document.querySelector('.chat-window');
       if(chatWindow)chatWindow.classList.toggle('locked', locked);
     }
@@ -7009,10 +7111,144 @@
       }
     }
 
+    function catsAttachmentKind(name, type){
+      if(/^image\//i.test(String(type||'')))return 'IMG';
+      return /\.(png|jpe?g|gif|webp|bmp|svg)$/i.test(String(name||''))?'IMG':'FILE';
+    }
+
+    function catsAttachmentStatus(item){
+      if(item.status==='sending')return '上传中';
+      if(item.status==='sent')return '已发送';
+      if(item.status==='error')return item.error||'附件授权无效';
+      return '待发送';
+    }
+
+    function catsDesktopFilePickerAvailable(){
+      return Boolean(window.catscoDesktop && typeof window.catscoDesktop.selectFiles==='function');
+    }
+
+    function renderCatsAttachments(){
+      const tray=document.getElementById('cats-attachment-tray');
+      if(!tray)return;
+      tray.hidden=catsAttachmentQueue.length===0;
+      tray.innerHTML=catsAttachmentQueue.map(item=>{
+        const cls='chat-upload-chip '+(item.status||'queued');
+        const meta=[formatBytes(item.size), catsAttachmentStatus(item)].filter(Boolean).join(' · ');
+        const remove=item.status==='sending'
+          ? ''
+          : '<button class="btn chat-upload-remove" type="button" onclick="removeCatsAttachment('+item.id+')">移除</button>';
+        return '<div class="'+cls+'">'+
+          '<span class="chat-upload-icon">'+escapeHtml(catsAttachmentKind(item.name,item.type))+'</span>'+
+          '<span class="chat-upload-info"><strong>'+escapeHtml(item.name)+'</strong><small title="'+escapeHtml(item.error||item.name||'')+'">'+escapeHtml(meta)+'</small></span>'+
+          remove+
+        '</div>';
+      }).join('');
+    }
+
+    function removeCatsAttachment(id){
+      catsAttachmentQueue=catsAttachmentQueue.filter(item=>item.id!==id || item.status==='sending');
+      renderCatsAttachments();
+    }
+
+    function normalizeCatsFileItem(file){
+      const token=String(file?.token || file?.file_token || '').trim();
+      const name=String(file?.name || '本地文件').trim() || '本地文件';
+      const size=Number(file?.size || 0);
+      const type=String(file?.type || '');
+      return {
+        id: ++catsAttachmentSeq,
+        name,
+        size,
+        type,
+        token,
+        status: token?'queued':'error',
+        error: token?'':'附件没有经过客户端文件选择器授权，请重新使用 + 按钮选择文件。',
+      };
+    }
+
+    function queueCatsFiles(files){
+      const list=Array.from(files||[]).filter(Boolean);
+      if(!list.length)return;
+      catsAttachmentQueue.push(...list.map(normalizeCatsFileItem));
+      renderCatsAttachments();
+      const invalid=catsAttachmentQueue.filter(item=>!item.token).length;
+      if(invalid)setCatsAction('有附件没有客户端授权，请重新使用 + 按钮选择文件。', true);
+      else pulsePetState('typing','已添加附件',1200);
+    }
+
+    async function chooseCatsFiles(){
+      const stage=buildCatsChatStage();
+      if(stage.key!=='ready'){
+        renderCatsStatus();
+        setCatsAction(stage.copy||'请先完成 CatsCo Chat 检查项',true);
+        return;
+      }
+
+      if(!catsDesktopFilePickerAvailable()){
+        setCatsAction(CATS_ATTACHMENT_BROWSER_MESSAGE, true);
+        return;
+      }
+
+      try{
+        const files=await window.catscoDesktop.selectFiles();
+        queueCatsFiles(files);
+      }catch(e){
+        setCatsAction('打开文件选择失败：'+e.message,true);
+      }
+    }
+
+    async function sendCatsAttachment(item){
+      item.status='sending';
+      item.error='';
+      renderCatsAttachments();
+      try{
+        await parseCatsResponse(await fetch(API+'/api/cats/messages/send-file',{
+          method:'POST',
+          headers:{'Content-Type':'application/json'},
+          body:JSON.stringify({
+            topic_id:catsState.topicId,
+            file_token:item.token,
+            file_name:item.name,
+          }),
+        }));
+        item.status='sent';
+      }catch(e){
+        item.status='error';
+        item.error=e.message;
+        throw e;
+      }finally{
+        renderCatsAttachments();
+      }
+    }
+
+    function setupCatsAttachmentInputs(){
+      const chatWindow=document.querySelector('.chat-window');
+      if(chatWindow){
+        ['dragenter','dragover'].forEach(eventName=>{
+          chatWindow.addEventListener(eventName,e=>{
+            if(!e.dataTransfer?.types || !Array.from(e.dataTransfer.types).includes('Files'))return;
+            e.preventDefault();
+          });
+        });
+        chatWindow.addEventListener('drop',e=>{
+          if(!e.dataTransfer?.files?.length)return;
+          e.preventDefault();
+          setCatsAction(CATS_ATTACHMENT_BROWSER_MESSAGE, true);
+        });
+      }
+    }
+
     async function sendCatsMessage(){
       const input=document.getElementById('cats-message-input');
       const content=input.value.trim();
-      if(!content)return;
+      const attachments=catsAttachmentQueue.filter(item=>item.status!=='sent');
+      const invalid=attachments.filter(item=>!item.token);
+      const sendable=attachments.filter(item=>item.token && item.status!=='sending');
+      if(!content && !sendable.length)return;
+      if(invalid.length){
+        setCatsAction('有附件没有客户端授权，请移除后重新选择。',true);
+        return;
+      }
       const stage=buildCatsChatStage();
       if(stage.key!=='ready'){
         renderCatsStatus();
@@ -7021,18 +7257,34 @@
       }
       if(!catsState.topicId){setCatsAction('请先完成 CatsCo 连接和 agent 绑定',true);return;}
       const btn=document.getElementById('cats-send-btn');
+      const attach=document.getElementById('cats-attach-btn');
       btn.disabled=true;
-      pulsePetState('typing', '发送中...', 1400);
+      if(attach)attach.disabled=true;
+      pulsePetState('typing', sendable.length?'上传中...':'发送中...', 1400);
       try{
-        await parseCatsResponse(await fetch(API+'/api/cats/messages/send',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({topic_id:catsState.topicId,content})}));
-        input.value='';
+        if(content){
+          await parseCatsResponse(await fetch(API+'/api/cats/messages/send',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({topic_id:catsState.topicId,content})}));
+          input.value='';
+        }
+        let failed=0;
+        for(const item of sendable){
+          try{
+            await sendCatsAttachment(item);
+          }catch(_e){
+            failed+=1;
+          }
+        }
+        catsAttachmentQueue=catsAttachmentQueue.filter(item=>item.status!=='sent');
+        renderCatsAttachments();
         catsScrollPinnedToBottom=true;
-        pulsePetState('success', '已发送', 1800);
+        if(failed)setCatsAction(failed+' 个附件发送失败，请重新选择文件或检查 CatsCo 连接。',true);
+        else pulsePetState('success', '已发送', 1800);
         await loadCatsMessages(true);
       }catch(e){
         setCatsAction('发送失败：'+e.message,true);
       }finally{
-        btn.disabled=false;
+        btn.disabled=buildCatsChatStage().key!=='ready';
+        if(attach)attach.disabled=buildCatsChatStage().key!=='ready' || !catsDesktopFilePickerAvailable();
       }
     }
 
@@ -7076,9 +7328,17 @@
     catsMessagesBox.addEventListener('scroll', updateCatsMessageScrollIntent, { passive: true });
     const catsMessageInput = document.getElementById('cats-message-input');
     catsMessageInput.addEventListener('keydown',e=>{if(e.key==='Enter'&&!e.shiftKey){e.preventDefault();sendCatsMessage();}});
+    catsMessageInput.addEventListener('paste',e=>{
+      const files=e.clipboardData?.files;
+      if(files && files.length){
+        e.preventDefault();
+        setCatsAction(CATS_ATTACHMENT_BROWSER_MESSAGE, true);
+      }
+    });
     catsMessageInput.addEventListener('input',()=>{if(catsMessageInput.value.trim()) setPetState('typing', { message:'输入中...' }); else setPetAutoBaseline(petAutoBaseline);});
     catsMessageInput.addEventListener('focus',()=>setPetState('typing', { message:'准备输入' }));
     catsMessageInput.addEventListener('blur',()=>{if(!catsMessageInput.value.trim()) setPetAutoBaseline(petAutoBaseline);});
+    setupCatsAttachmentInputs();
     document.addEventListener('keydown',e=>{if(e.key==='Escape'){closeLogs();closeUpdateModal();closeCatsMediaPreview();}});
     document.addEventListener('click',e=>{const shell=document.getElementById('floating-pet');if(shell && !shell.contains(e.target)) closeFloatingPetMenu();});
   </script>

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -4313,7 +4313,7 @@
             </div>
             <div class="chat-composer" id="cats-composer">
               <div class="chat-attachment-tray" id="cats-attachment-tray" hidden></div>
-              <div class="chat-attach-note" id="cats-attach-note" hidden>浏览器无法直接添加本地附件；请在 CatsCo 桌面客户端使用 + 选择文件，或把文件路径作为普通文本发给 Agent。</div>
+              <div class="chat-attach-note" id="cats-attach-note" hidden>普通浏览器不能直接上传本地附件；请在 CatsCo 桌面客户端使用 + 选择文件，或把文件路径作为文字说明发给 Agent。</div>
               <div class="chat-input-bar">
                 <button class="btn chat-attach-btn" type="button" onclick="chooseCatsFiles()" id="cats-attach-btn" title="添加本地文件" disabled>+</button>
                 <textarea class="config-input" id="cats-message-input" placeholder="等待 CatsCo Chat 检查完成" disabled></textarea>
@@ -4480,7 +4480,7 @@
     const CATS_SCROLL_BOTTOM_THRESHOLD = 80;
     let catsAttachmentQueue = [];
     let catsAttachmentSeq = 0;
-    const CATS_ATTACHMENT_BROWSER_MESSAGE = '浏览器无法直接添加本地附件；请在 CatsCo 桌面客户端使用 + 选择文件，或把文件路径作为普通文本发给 Agent。';
+    const CATS_ATTACHMENT_BROWSER_MESSAGE = '普通浏览器不能直接上传本地附件；请在 CatsCo 桌面客户端使用 + 选择文件，或把文件路径作为文字说明发给 Agent。';
     const CATS_DEFAULT_HTTP_BASE = 'https://app.catsco.cc';
     const CATS_DEFAULT_WS_URL = 'wss://app.catsco.cc/v0/channels';
     const CATS_WORKING_TEXT_PREFIX = 'AI文本:';
@@ -7155,6 +7155,7 @@
       const name=String(file?.name || '本地文件').trim() || '本地文件';
       const size=Number(file?.size || 0);
       const type=String(file?.type || '');
+      const error=String(file?.error || '').trim();
       return {
         id: ++catsAttachmentSeq,
         name,
@@ -7162,7 +7163,7 @@
         type,
         token,
         status: token?'queued':'error',
-        error: token?'':'附件没有经过客户端文件选择器授权，请重新使用 + 按钮选择文件。',
+        error: token?'':(error||'附件没有经过客户端文件选择器授权，请重新使用 + 按钮选择文件。'),
       };
     }
 
@@ -7171,8 +7172,8 @@
       if(!list.length)return;
       catsAttachmentQueue.push(...list.map(normalizeCatsFileItem));
       renderCatsAttachments();
-      const invalid=catsAttachmentQueue.filter(item=>!item.token).length;
-      if(invalid)setCatsAction('有附件没有客户端授权，请重新使用 + 按钮选择文件。', true);
+      const invalid=catsAttachmentQueue.filter(item=>!item.token);
+      if(invalid.length)setCatsAction(invalid[0].error||'有附件没有客户端授权，请重新使用 + 按钮选择文件。', true);
       else pulsePetState('typing','已添加附件',1200);
     }
 

--- a/electron/main.js
+++ b/electron/main.js
@@ -452,6 +452,8 @@ function isTrustedDashboardUrl(value) {
   }
 }
 
+const CATSCOMPANY_FILE_SELECTION_LIMIT = 6;
+
 ipcMain.handle('catsco:select-files', async (event) => {
   const owner = BrowserWindow.fromWebContents(event.sender) || mainWindow || undefined;
   const frameUrl = event.senderFrame?.url || event.sender.getURL();
@@ -465,11 +467,22 @@ ipcMain.handle('catsco:select-files', async (event) => {
 
   const { createLocalFileGrant } = require(path.join(getAppRoot(), 'dist', 'dashboard', 'local-file-grants'));
   return result.filePaths
-    .map((filePath) => {
+    .map((filePath, index) => {
       try {
+        if (index >= CATSCOMPANY_FILE_SELECTION_LIMIT) {
+          return {
+            name: path.basename(filePath),
+            size: 0,
+            error: `一次最多选择 ${CATSCOMPANY_FILE_SELECTION_LIMIT} 个文件。`,
+          };
+        }
         return createLocalFileGrant(filePath);
-      } catch (_error) {
-        return null;
+      } catch (error) {
+        return {
+          name: path.basename(filePath),
+          size: 0,
+          error: error?.message || '文件无法授权，请重新选择。',
+        };
       }
     })
     .filter(Boolean);

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, Tray, Menu, nativeImage } = require('electron');
+const { app, BrowserWindow, Tray, Menu, nativeImage, ipcMain, dialog } = require('electron');
 const path = require('path');
 const fs = require('fs');
 
@@ -423,6 +423,7 @@ function createWindow() {
     webPreferences: {
       nodeIntegration: false,
       contextIsolation: true,
+      preload: path.join(__dirname, 'preload.js'),
     },
   });
 
@@ -439,6 +440,40 @@ function createWindow() {
     mainWindow = null;
   });
 }
+
+function isTrustedDashboardUrl(value) {
+  try {
+    const url = new URL(String(value || ''));
+    return url.protocol === 'http:' &&
+      (url.hostname === 'localhost' || url.hostname === '127.0.0.1') &&
+      url.port === String(DASHBOARD_PORT);
+  } catch (_error) {
+    return false;
+  }
+}
+
+ipcMain.handle('catsco:select-files', async (event) => {
+  const owner = BrowserWindow.fromWebContents(event.sender) || mainWindow || undefined;
+  const frameUrl = event.senderFrame?.url || event.sender.getURL();
+  if (owner !== mainWindow || !isTrustedDashboardUrl(frameUrl)) return [];
+
+  const options = {
+    properties: ['openFile', 'multiSelections'],
+  };
+  const result = await dialog.showOpenDialog(owner, options);
+  if (result.canceled) return [];
+
+  const { createLocalFileGrant } = require(path.join(getAppRoot(), 'dist', 'dashboard', 'local-file-grants'));
+  return result.filePaths
+    .map((filePath) => {
+      try {
+        return createLocalFileGrant(filePath);
+      } catch (_error) {
+        return null;
+      }
+    })
+    .filter(Boolean);
+});
 
 function createTray() {
   const icon = nativeImage.createFromDataURL(

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -1,0 +1,5 @@
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('catscoDesktop', {
+  selectFiles: () => ipcRenderer.invoke('catsco:select-files'),
+});

--- a/src/catscompany/client.ts
+++ b/src/catscompany/client.ts
@@ -1,10 +1,10 @@
 // CatsCo 服务器 WebSocket 客户端
 import WebSocket from 'ws';
 import { EventEmitter } from 'events';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as crypto from 'crypto';
 import { Logger } from '../utils/logger';
+import { uploadCatsLocalFile, type UploadResult } from './upload';
+
+export type { UploadResult } from './upload';
 
 export interface CatsClientConfig {
   serverUrl: string;
@@ -21,12 +21,6 @@ export interface MessageContext {
   isGroup: boolean;
   from?: string;  // 原始 Cats 发送方字段，供兼容和排查使用
   seq?: number;   // Cats 服务端消息序号，用于排序和补充消息合并
-}
-
-export interface UploadResult {
-  url: string;
-  name: string;
-  size: number;
 }
 
 export interface CatsOutgoingMessage {
@@ -50,14 +44,6 @@ interface PendingAck {
 
 export type CatsSendErrorKind = 'transport' | 'ack' | 'timeout';
 
-const MIME_BY_EXT: Record<string, string> = {
-  '.jpg': 'image/jpeg',
-  '.jpeg': 'image/jpeg',
-  '.png': 'image/png',
-  '.gif': 'image/gif',
-  '.webp': 'image/webp',
-};
-
 // Cats 服务端握手协议版本，不是 CatsCo 客户端发布版本。
 const CATSCOMPANY_PROTOCOL_VERSION = '0.1.0';
 const CATSCOMPANY_CLIENT_UA = 'CatsCo/1.0';
@@ -65,10 +51,6 @@ const CATSCOMPANY_CLIENT_UA = 'CatsCo/1.0';
 function maskSecret(value: string): string {
   if (value.length <= 10) return '***';
   return `${value.slice(0, 6)}...${value.slice(-4)}`;
-}
-
-function limitLogText(value: string, maxLength = 500): string {
-  return value.length > maxLength ? `${value.slice(0, maxLength)}...` : value;
 }
 
 export class CatsSendError extends Error {
@@ -284,41 +266,12 @@ export class CatsClient extends EventEmitter {
   }
 
   async uploadFile(filePath: string, type: 'image' | 'file' = 'file'): Promise<UploadResult> {
-    const httpBaseUrl = (this.config.httpBaseUrl || 'https://app.catsco.cc').replace(/\/$/, '');
-    const url = `${httpBaseUrl}/api/upload?type=${type}`;
-
-    const buffer = fs.readFileSync(filePath);
-    const filename = path.basename(filePath);
-    const mimeType = MIME_BY_EXT[path.extname(filename).toLowerCase()] || 'application/octet-stream';
-
-    try {
-      Logger.info(`[CatsCompany] 开始上传文件: ${filename}, type=${type}, size=${buffer.length} bytes, mime=${mimeType}`);
-
-      const formData = new FormData();
-      formData.append('file', new Blob([buffer], { type: mimeType }), filename);
-
-      const res = await fetch(url, {
-        method: 'POST',
-        headers: {
-          'Authorization': `ApiKey ${this.config.apiKey}`,
-        },
-        body: formData,
-        signal: AbortSignal.timeout(60000),
-      });
-
-      if (!res.ok) {
-        const errorText = await res.text();
-        Logger.error(`[CatsCompany] 上传失败: status=${res.status}, body=${limitLogText(errorText)}`);
-        throw new Error(`Upload failed: ${res.status} - ${errorText}`);
-      }
-
-      const result = await res.json() as UploadResult;
-      Logger.info(`[CatsCompany] 上传成功: ${result.name || filename}, size=${result.size || buffer.length} bytes`);
-      return result;
-    } catch (err: any) {
-      Logger.error(`[CatsCompany] 上传异常: ${err.message || 'unknown error'}`);
-      throw new Error(`Upload failed: ${err.message}`);
-    }
+    return uploadCatsLocalFile({
+      httpBaseUrl: this.config.httpBaseUrl || 'https://app.catsco.cc',
+      filePath,
+      type,
+      authHeader: `ApiKey ${this.config.apiKey}`,
+    });
   }
 
   async sendImage(topic: string, upload: UploadResult): Promise<number> {

--- a/src/catscompany/upload.ts
+++ b/src/catscompany/upload.ts
@@ -1,0 +1,125 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+import { Readable } from 'stream';
+import { Logger } from '../utils/logger';
+
+export type CatsUploadType = 'image' | 'file';
+
+export interface UploadResult {
+  url: string;
+  name: string;
+  size: number;
+}
+
+const MIME_BY_EXT: Record<string, string> = {
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.bmp': 'image/bmp',
+  '.svg': 'image/svg+xml',
+};
+
+const IMAGE_EXTS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.svg']);
+
+function limitLogText(value: string, maxLength = 500): string {
+  return value.length > maxLength ? `${value.slice(0, maxLength)}...` : value;
+}
+
+function multipartSafeFilename(filename: string): string {
+  return filename.replace(/[\r\n"]/g, '_');
+}
+
+function uploadTimeoutMs(fileSize: number): number {
+  const mb = Math.ceil(fileSize / (1024 * 1024));
+  return Math.max(60_000, Math.min(30 * 60_000, 60_000 + mb * 10_000));
+}
+
+export function isCatsImageFileName(fileName: string): boolean {
+  return IMAGE_EXTS.has(path.extname(fileName).toLowerCase());
+}
+
+export function inferCatsUploadType(fileName: string): CatsUploadType {
+  return isCatsImageFileName(fileName) ? 'image' : 'file';
+}
+
+export async function uploadCatsLocalFile(options: {
+  httpBaseUrl: string;
+  filePath: string;
+  type?: CatsUploadType;
+  authHeader: string;
+  timeoutMs?: number;
+}): Promise<UploadResult> {
+  const resolvedPath = path.resolve(options.filePath);
+  const stat = fs.statSync(resolvedPath);
+  if (!stat.isFile()) {
+    throw new Error(`不是可上传的文件: ${resolvedPath}`);
+  }
+
+  const httpBaseUrl = options.httpBaseUrl.replace(/\/$/, '');
+  const uploadType = options.type || inferCatsUploadType(resolvedPath);
+  const url = `${httpBaseUrl}/api/upload?type=${uploadType}`;
+  const filename = path.basename(resolvedPath);
+  const mimeType = MIME_BY_EXT[path.extname(filename).toLowerCase()] || 'application/octet-stream';
+  const boundary = `----CatsCoFormBoundary${crypto.randomBytes(16).toString('hex')}`;
+  const head = Buffer.from(
+    `--${boundary}\r\n` +
+    `Content-Disposition: form-data; name="file"; filename="${multipartSafeFilename(filename)}"\r\n` +
+    `Content-Type: ${mimeType}\r\n\r\n`,
+  );
+  const tail = Buffer.from(`\r\n--${boundary}--\r\n`);
+  const contentLength = head.length + stat.size + tail.length;
+
+  async function* multipartBody() {
+    yield head;
+    const fileStream = fs.createReadStream(resolvedPath);
+    try {
+      for await (const chunk of fileStream) {
+        yield chunk as Buffer;
+      }
+    } finally {
+      fileStream.destroy();
+    }
+    yield tail;
+  }
+
+  try {
+    Logger.info(`[CatsCompany] 开始上传文件: ${filename}, type=${uploadType}, size=${stat.size} bytes, mime=${mimeType}`);
+
+    const requestInit: RequestInit & { duplex?: 'half' } = {
+      method: 'POST',
+      headers: {
+        Authorization: options.authHeader,
+        'Content-Type': `multipart/form-data; boundary=${boundary}`,
+        'Content-Length': String(contentLength),
+      },
+      body: Readable.from(multipartBody()) as any,
+      duplex: 'half',
+      signal: AbortSignal.timeout(options.timeoutMs || uploadTimeoutMs(stat.size)),
+    };
+    const res = await fetch(url, requestInit);
+
+    if (!res.ok) {
+      const errorText = await res.text();
+      Logger.error(`[CatsCompany] 上传失败: status=${res.status}, body=${limitLogText(errorText)}`);
+      const error = new Error(`Upload failed: ${res.status} - ${errorText}`);
+      (error as any).status = res.status;
+      throw error;
+    }
+
+    const result = await res.json() as UploadResult;
+    Logger.info(`[CatsCompany] 上传成功: ${result.name || filename}, size=${result.size || stat.size} bytes`);
+    return {
+      url: result.url,
+      name: result.name || filename,
+      size: result.size || stat.size,
+    };
+  } catch (err: any) {
+    Logger.error(`[CatsCompany] 上传异常: ${err.message || 'unknown error'}`);
+    const error = new Error(`Upload failed: ${err.message || 'unknown error'}`);
+    (error as any).status = err.status;
+    throw error;
+  }
+}

--- a/src/dashboard/local-file-grants.ts
+++ b/src/dashboard/local-file-grants.ts
@@ -2,13 +2,17 @@ import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
 
-const LOCAL_FILE_GRANT_TTL_MS = 10 * 60 * 1000;
+export const LOCAL_FILE_GRANT_TTL_MS = 10 * 60 * 1000;
+export const LOCAL_FILE_GRANT_MAX_SIZE_BYTES = 50 * 1024 * 1024;
 
 export interface LocalFileGrant {
   token: string;
   filePath: string;
   name: string;
   size: number;
+  mtimeMs: number;
+  dev: number;
+  ino: number;
   createdAt: number;
 }
 
@@ -35,6 +39,9 @@ export function createLocalFileGrant(filePath: string): Pick<LocalFileGrant, 'to
   if (!stat.isFile()) {
     throw grantError('local file grant must point to a file');
   }
+  if (stat.size > LOCAL_FILE_GRANT_MAX_SIZE_BYTES) {
+    throw grantError(`local file is too large; max size is ${LOCAL_FILE_GRANT_MAX_SIZE_BYTES} bytes`, 413);
+  }
 
   const token = crypto.randomBytes(32).toString('base64url');
   const grant: LocalFileGrant = {
@@ -42,6 +49,9 @@ export function createLocalFileGrant(filePath: string): Pick<LocalFileGrant, 'to
     filePath: resolvedPath,
     name: path.basename(resolvedPath),
     size: stat.size,
+    mtimeMs: stat.mtimeMs,
+    dev: stat.dev,
+    ino: stat.ino,
     createdAt: Date.now(),
   };
   grants.set(token, grant);
@@ -61,4 +71,25 @@ export function consumeLocalFileGrant(token: string): LocalFileGrant {
   }
   grants.delete(token);
   return grant;
+}
+
+export function validateLocalFileGrant(grant: LocalFileGrant): fs.Stats {
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(grant.filePath);
+  } catch (_error) {
+    throw grantError('authorized file is no longer available; please choose it again');
+  }
+  if (!stat.isFile()) {
+    throw grantError('file_token must point to a file');
+  }
+  if (
+    stat.size !== grant.size ||
+    stat.mtimeMs !== grant.mtimeMs ||
+    stat.dev !== grant.dev ||
+    stat.ino !== grant.ino
+  ) {
+    throw grantError('authorized file changed after selection; please choose it again');
+  }
+  return stat;
 }

--- a/src/dashboard/local-file-grants.ts
+++ b/src/dashboard/local-file-grants.ts
@@ -1,0 +1,64 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const LOCAL_FILE_GRANT_TTL_MS = 10 * 60 * 1000;
+
+export interface LocalFileGrant {
+  token: string;
+  filePath: string;
+  name: string;
+  size: number;
+  createdAt: number;
+}
+
+const grants = new Map<string, LocalFileGrant>();
+
+function cleanupExpiredGrants(now = Date.now()): void {
+  for (const [token, grant] of grants.entries()) {
+    if (now - grant.createdAt > LOCAL_FILE_GRANT_TTL_MS) {
+      grants.delete(token);
+    }
+  }
+}
+
+function grantError(message: string, status = 400): Error {
+  const error = new Error(message);
+  (error as any).status = status;
+  return error;
+}
+
+export function createLocalFileGrant(filePath: string): Pick<LocalFileGrant, 'token' | 'name' | 'size'> {
+  cleanupExpiredGrants();
+  const resolvedPath = fs.realpathSync(path.resolve(filePath));
+  const stat = fs.statSync(resolvedPath);
+  if (!stat.isFile()) {
+    throw grantError('local file grant must point to a file');
+  }
+
+  const token = crypto.randomBytes(32).toString('base64url');
+  const grant: LocalFileGrant = {
+    token,
+    filePath: resolvedPath,
+    name: path.basename(resolvedPath),
+    size: stat.size,
+    createdAt: Date.now(),
+  };
+  grants.set(token, grant);
+
+  return {
+    token,
+    name: grant.name,
+    size: grant.size,
+  };
+}
+
+export function consumeLocalFileGrant(token: string): LocalFileGrant {
+  cleanupExpiredGrants();
+  const grant = grants.get(token);
+  if (!grant) {
+    throw grantError('file_token is invalid or expired');
+  }
+  grants.delete(token);
+  return grant;
+}

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -29,7 +29,7 @@ import {
   saveRuntimeProfileEdit,
 } from '../../runtime/runtime-profile-editor';
 import { inferCatsUploadType, uploadCatsLocalFile } from '../../catscompany/upload';
-import { consumeLocalFileGrant } from '../local-file-grants';
+import { consumeLocalFileGrant, validateLocalFileGrant } from '../local-file-grants';
 // import { ReportGenerator } from '../../utils/report-generator';
 // import { LogUploader } from '../../utils/log-uploader';
 
@@ -1133,8 +1133,7 @@ export function createApiRouter(serviceManager: ServiceManager, updateController
       if (!topicId || !fileToken) return res.status(400).json({ error: 'topic_id and file_token are required' });
 
       const grant = consumeLocalFileGrant(fileToken);
-      const stat = fs.statSync(grant.filePath);
-      if (!stat.isFile()) return res.status(400).json({ error: 'file_token must point to a file' });
+      const stat = validateLocalFileGrant(grant);
 
       const fileName = grant.name;
       const uploadType = inferCatsUploadType(fileName);

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -28,6 +28,8 @@ import {
   rollbackRuntimeProfileEdit,
   saveRuntimeProfileEdit,
 } from '../../runtime/runtime-profile-editor';
+import { inferCatsUploadType, uploadCatsLocalFile } from '../../catscompany/upload';
+import { consumeLocalFileGrant } from '../local-file-grants';
 // import { ReportGenerator } from '../../utils/report-generator';
 // import { LogUploader } from '../../utils/log-uploader';
 
@@ -1116,6 +1118,57 @@ export function createApiRouter(serviceManager: ServiceManager, updateController
         content,
       }, state.token);
       res.json(data);
+    } catch (e: any) {
+      res.status(e.status || 500).json({ error: e.message, data: e.data });
+    }
+  });
+
+  router.post('/cats/messages/send-file', async (req, res) => {
+    try {
+      const state = getCatsAuthState();
+      if (!state.token) return res.status(401).json({ error: 'CatsCo user token is missing' });
+
+      const topicId = String(req.body?.topic_id || '').trim();
+      const fileToken = String(req.body?.file_token || '').trim();
+      if (!topicId || !fileToken) return res.status(400).json({ error: 'topic_id and file_token are required' });
+
+      const grant = consumeLocalFileGrant(fileToken);
+      const stat = fs.statSync(grant.filePath);
+      if (!stat.isFile()) return res.status(400).json({ error: 'file_token must point to a file' });
+
+      const fileName = grant.name;
+      const uploadType = inferCatsUploadType(fileName);
+      const upload = await uploadCatsLocalFile({
+        httpBaseUrl: state.httpBaseUrl,
+        filePath: grant.filePath,
+        type: uploadType,
+        authHeader: `Bearer ${state.token}`,
+      });
+
+      const content = {
+        type: uploadType,
+        payload: {
+          url: upload.url,
+          name: upload.name || fileName,
+          size: upload.size || stat.size,
+        },
+      };
+      const data = await catsRequest('POST', state.httpBaseUrl, '/api/messages/send', {
+        topic_id: topicId,
+        type: uploadType,
+        content,
+      }, state.token);
+
+      res.json({
+        ok: true,
+        type: uploadType,
+        file: {
+          name: fileName,
+          size: stat.size,
+        },
+        upload,
+        message: data,
+      });
     } catch (e: any) {
       res.status(e.status || 500).json({ error: e.message, data: e.data });
     }

--- a/tests/dashboard-catsco-attachments-api.test.ts
+++ b/tests/dashboard-catsco-attachments-api.test.ts
@@ -5,7 +5,13 @@ import * as fs from 'fs';
 import type { Server } from 'http';
 import * as os from 'os';
 import * as path from 'path';
-import { createLocalFileGrant } from '../src/dashboard/local-file-grants';
+import {
+  consumeLocalFileGrant,
+  createLocalFileGrant,
+  LOCAL_FILE_GRANT_MAX_SIZE_BYTES,
+  LOCAL_FILE_GRANT_TTL_MS,
+  validateLocalFileGrant,
+} from '../src/dashboard/local-file-grants';
 import { createApiRouter } from '../src/dashboard/routes/api';
 
 async function listen(app: express.Express): Promise<Server> {
@@ -138,6 +144,49 @@ describe('dashboard CatsCo attachment API', () => {
 
     assert.equal(response.status, 400);
     assert.equal(data.error, 'topic_id and file_token are required');
+  });
+
+  test('local file grants are one-time tokens', () => {
+    const filePath = path.join(testRoot, 'one-time.txt');
+    fs.writeFileSync(filePath, 'hello world');
+    const grant = createLocalFileGrant(filePath);
+
+    assert.equal(consumeLocalFileGrant(grant.token).name, 'one-time.txt');
+    assert.throws(() => consumeLocalFileGrant(grant.token), /invalid or expired/);
+  });
+
+  test('local file grants expire', () => {
+    const filePath = path.join(testRoot, 'expires.txt');
+    fs.writeFileSync(filePath, 'hello world');
+    const originalNow = Date.now;
+    let now = originalNow();
+
+    try {
+      (Date as any).now = () => now;
+      const grant = createLocalFileGrant(filePath);
+      now += LOCAL_FILE_GRANT_TTL_MS + 1;
+
+      assert.throws(() => consumeLocalFileGrant(grant.token), /invalid or expired/);
+    } finally {
+      (Date as any).now = originalNow;
+    }
+  });
+
+  test('rejects files that changed after selection', () => {
+    const filePath = path.join(testRoot, 'changed.txt');
+    fs.writeFileSync(filePath, 'hello world');
+    const grant = createLocalFileGrant(filePath);
+
+    fs.writeFileSync(filePath, 'hello world changed');
+    assert.throws(() => validateLocalFileGrant(consumeLocalFileGrant(grant.token)), /changed after selection/);
+  });
+
+  test('rejects oversized local file grants before upload', () => {
+    const filePath = path.join(testRoot, 'too-large.bin');
+    fs.writeFileSync(filePath, '');
+    fs.truncateSync(filePath, LOCAL_FILE_GRANT_MAX_SIZE_BYTES + 1);
+
+    assert.throws(() => createLocalFileGrant(filePath), /too large/);
   });
 
   test('does not retry failed uploads with the agent API key', async () => {

--- a/tests/dashboard-catsco-attachments-api.test.ts
+++ b/tests/dashboard-catsco-attachments-api.test.ts
@@ -1,0 +1,225 @@
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import * as assert from 'node:assert/strict';
+import express from 'express';
+import * as fs from 'fs';
+import type { Server } from 'http';
+import * as os from 'os';
+import * as path from 'path';
+import { createLocalFileGrant } from '../src/dashboard/local-file-grants';
+import { createApiRouter } from '../src/dashboard/routes/api';
+
+async function listen(app: express.Express): Promise<Server> {
+  return await new Promise((resolve, reject) => {
+    const server = app.listen(0, '127.0.0.1', () => resolve(server));
+    server.on('error', reject);
+  });
+}
+
+function serverUrl(server: Server): string {
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('server did not bind to a TCP port');
+  return `http://127.0.0.1:${address.port}`;
+}
+
+describe('dashboard CatsCo attachment API', () => {
+  let testRoot: string;
+  let originalCwd: string;
+  let dashboardServer: Server | undefined;
+  let catsServer: Server | undefined;
+  const envKeys = ['CATSCO_HTTP_BASE_URL', 'CATSCO_USER_TOKEN', 'CATSCO_API_KEY'];
+  const originalEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-dashboard-catsco-attachments-'));
+    process.chdir(testRoot);
+    for (const key of envKeys) {
+      originalEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(async () => {
+    if (dashboardServer) await new Promise<void>(resolve => dashboardServer!.close(() => resolve()));
+    if (catsServer) await new Promise<void>(resolve => catsServer!.close(() => resolve()));
+    dashboardServer = undefined;
+    catsServer = undefined;
+    process.chdir(originalCwd);
+    for (const key of envKeys) {
+      if (originalEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = originalEnv[key];
+    }
+    fs.rmSync(testRoot, { recursive: true, force: true });
+  });
+
+  test('streams a local file to CatsCo and sends the attachment as the user', async () => {
+    const uploaded: { auth?: string; bytes: number } = { bytes: 0 };
+    let sentBody: any;
+    let sentAuth = '';
+
+    const catsApp = express();
+    catsApp.post('/api/upload', (req, res) => {
+      uploaded.auth = String(req.headers.authorization || '');
+      req.on('data', chunk => {
+        uploaded.bytes += Buffer.byteLength(chunk);
+      });
+      req.on('end', () => {
+        res.json({ url: '/uploads/report.pdf', name: 'report.pdf', size: 11 });
+      });
+    });
+    catsApp.post('/api/messages/send', express.json(), (req, res) => {
+      sentAuth = String(req.headers.authorization || '');
+      sentBody = req.body;
+      res.json({ seq_id: 42 });
+    });
+    catsServer = await listen(catsApp);
+
+    process.env.CATSCO_HTTP_BASE_URL = serverUrl(catsServer);
+    process.env.CATSCO_USER_TOKEN = 'user-token';
+    process.env.CATSCO_API_KEY = 'agent-key';
+
+    const dashboardApp = express();
+    dashboardApp.use(express.json());
+    dashboardApp.use('/api', createApiRouter({ getAll: () => [] } as any));
+    dashboardServer = await listen(dashboardApp);
+
+    const filePath = path.join(testRoot, 'report.pdf');
+    fs.writeFileSync(filePath, 'hello world');
+    const grant = createLocalFileGrant(filePath);
+
+    const response = await fetch(`${serverUrl(dashboardServer)}/api/cats/messages/send-file`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        topic_id: 'p2p_1_2',
+        file_token: grant.token,
+        file_name: 'spoof.png',
+      }),
+    });
+    const data = await response.json() as any;
+
+    assert.equal(response.status, 200);
+    assert.equal(data.ok, true);
+    assert.equal(data.type, 'file');
+    assert.equal(data.file.name, 'report.pdf');
+    assert.equal(uploaded.auth, 'Bearer user-token');
+    assert.ok(uploaded.bytes > 11);
+    assert.equal(sentAuth, 'Bearer user-token');
+    assert.deepEqual(sentBody, {
+      topic_id: 'p2p_1_2',
+      type: 'file',
+      content: {
+        type: 'file',
+        payload: {
+          url: '/uploads/report.pdf',
+          name: 'report.pdf',
+          size: 11,
+        },
+      },
+    });
+  });
+
+  test('rejects raw local paths before calling CatsCo', async () => {
+    process.env.CATSCO_USER_TOKEN = 'user-token';
+    const dashboardApp = express();
+    dashboardApp.use(express.json());
+    dashboardApp.use('/api', createApiRouter({ getAll: () => [] } as any));
+    dashboardServer = await listen(dashboardApp);
+
+    const response = await fetch(`${serverUrl(dashboardServer)}/api/cats/messages/send-file`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        topic_id: 'p2p_1_2',
+        file_path: path.join(testRoot, 'missing.txt'),
+      }),
+    });
+    const data = await response.json() as any;
+
+    assert.equal(response.status, 400);
+    assert.equal(data.error, 'topic_id and file_token are required');
+  });
+
+  test('does not retry failed uploads with the agent API key', async () => {
+    const uploadAuthHeaders: string[] = [];
+    const catsApp = express();
+    catsApp.post('/api/upload', (req, res) => {
+      uploadAuthHeaders.push(String(req.headers.authorization || ''));
+      req.resume();
+      res.status(403).json({ error: 'forbidden' });
+    });
+    catsServer = await listen(catsApp);
+
+    process.env.CATSCO_HTTP_BASE_URL = serverUrl(catsServer);
+    process.env.CATSCO_USER_TOKEN = 'user-token';
+    process.env.CATSCO_API_KEY = 'agent-key';
+
+    const dashboardApp = express();
+    dashboardApp.use(express.json());
+    dashboardApp.use('/api', createApiRouter({ getAll: () => [] } as any));
+    dashboardServer = await listen(dashboardApp);
+
+    const filePath = path.join(testRoot, 'report.pdf');
+    fs.writeFileSync(filePath, 'hello world');
+    const grant = createLocalFileGrant(filePath);
+
+    const response = await fetch(`${serverUrl(dashboardServer)}/api/cats/messages/send-file`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        topic_id: 'p2p_1_2',
+        file_token: grant.token,
+        file_name: 'report.pdf',
+      }),
+    });
+    const data = await response.json() as any;
+
+    assert.equal(response.status, 403);
+    assert.match(data.error, /Upload failed/);
+    assert.deepEqual(uploadAuthHeaders, ['Bearer user-token']);
+  });
+
+  test('does not retry failed message sends with the agent API key', async () => {
+    const uploadAuthHeaders: string[] = [];
+    const messageAuthHeaders: string[] = [];
+    const catsApp = express();
+    catsApp.post('/api/upload', (req, res) => {
+      uploadAuthHeaders.push(String(req.headers.authorization || ''));
+      req.resume();
+      res.json({ url: '/uploads/report.pdf', name: 'report.pdf', size: 11 });
+    });
+    catsApp.post('/api/messages/send', express.json(), (req, res) => {
+      messageAuthHeaders.push(String(req.headers.authorization || ''));
+      res.status(403).json({ error: 'message forbidden' });
+    });
+    catsServer = await listen(catsApp);
+
+    process.env.CATSCO_HTTP_BASE_URL = serverUrl(catsServer);
+    process.env.CATSCO_USER_TOKEN = 'user-token';
+    process.env.CATSCO_API_KEY = 'agent-key';
+
+    const dashboardApp = express();
+    dashboardApp.use(express.json());
+    dashboardApp.use('/api', createApiRouter({ getAll: () => [] } as any));
+    dashboardServer = await listen(dashboardApp);
+
+    const filePath = path.join(testRoot, 'report.pdf');
+    fs.writeFileSync(filePath, 'hello world');
+    const grant = createLocalFileGrant(filePath);
+
+    const response = await fetch(`${serverUrl(dashboardServer)}/api/cats/messages/send-file`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        topic_id: 'p2p_1_2',
+        file_token: grant.token,
+      }),
+    });
+    const data = await response.json() as any;
+
+    assert.equal(response.status, 403);
+    assert.equal(data.error, 'message forbidden');
+    assert.deepEqual(uploadAuthHeaders, ['Bearer user-token']);
+    assert.deepEqual(messageAuthHeaders, ['Bearer user-token']);
+  });
+});

--- a/tests/dashboard-productization-html.test.ts
+++ b/tests/dashboard-productization-html.test.ts
@@ -53,9 +53,9 @@ test('run page is driven by readiness instead of raw diagnostics cards', () => {
   assert.match(dashboardHtml, /function renderReadiness\(data\)/);
   assert.match(dashboardHtml, /启动前检查未通过/);
   assert.match(dashboardHtml, /模型来源、CatsCo Chat、Runtime Profile 和 Skills/);
-  assert.match(dashboardHtml, /<details class="run-details">\s*<summary><span>Service details<\/span><span class="tag">connector<\/span><\/summary>/);
+  assert.match(dashboardHtml, /<details class="run-details" open>\s*<summary><span>启动前检查<\/span><span class="tag">readiness<\/span><\/summary>/);
   assert.match(dashboardHtml, /<summary><span>Diagnostics<\/span><span class="tag">version \/ host \/ paths<\/span><\/summary>/);
-  assert.doesNotMatch(dashboardHtml, /<details class="run-details" open>/);
+  assert.doesNotMatch(dashboardHtml, /<summary><span>Service details<\/span><span class="tag">connector<\/span><\/summary>/);
   assert.doesNotMatch(dashboardHtml, /<div class="section-title">系统状态<\/div>/);
   assert.doesNotMatch(dashboardHtml, /<div class="label">Provider<\/div>/);
 });

--- a/tests/dashboard-productization-html.test.ts
+++ b/tests/dashboard-productization-html.test.ts
@@ -97,6 +97,7 @@ test('CatsCo Chat page is driven by readiness state instead of loose controls', 
   assert.match(dashboardHtml, /<summary>高级 endpoint<\/summary>/);
   assert.match(dashboardHtml, /input\.disabled=locked/);
   assert.match(dashboardHtml, /send\.disabled=locked/);
+  assert.match(dashboardHtml, /attach\.disabled=locked/);
   assert.match(dashboardHtml, /id="cats-message-input"[^>]*disabled/);
   assert.match(dashboardHtml, /id="cats-send-btn" disabled/);
   assert.match(dashboardHtml, /needs-readiness/);
@@ -116,4 +117,25 @@ test('CatsCo Chat preserves scroll position while reading history', () => {
   assert.match(renderBlock, /const shouldStickToBottom=/);
   assert.match(renderBlock, /if\(shouldStickToBottom\)scrollCatsMessagesToBottom\(box\)/);
   assert.doesNotMatch(renderBlock, /box\.scrollTop=box\.scrollHeight;\s*updatePetFromCatsMessages/);
+});
+
+test('CatsCo Chat composer supports local attachments', () => {
+  assert.doesNotMatch(dashboardHtml, /id="cats-file-input"/);
+  assert.match(dashboardHtml, /id="cats-attachment-tray"/);
+  assert.match(dashboardHtml, /id="cats-attach-note" hidden/);
+  assert.match(dashboardHtml, /id="cats-attach-btn"/);
+  assert.match(dashboardHtml, /function chooseCatsFiles\(\)/);
+  assert.match(dashboardHtml, /function catsDesktopFilePickerAvailable\(\)/);
+  assert.match(dashboardHtml, /const CATS_ATTACHMENT_BROWSER_MESSAGE =/);
+  assert.match(dashboardHtml, /attach\.disabled=locked \|\| !desktopPickerReady/);
+  assert.match(dashboardHtml, /attachNote\.hidden=locked \|\| catsDesktopFilePickerAvailable\(\)/);
+  assert.match(dashboardHtml, /setCatsAction\(CATS_ATTACHMENT_BROWSER_MESSAGE, true\)/);
+  assert.match(dashboardHtml, /window\.catscoDesktop\.selectFiles/);
+  assert.match(dashboardHtml, /file_token:item\.token/);
+  assert.match(dashboardHtml, /function setupCatsAttachmentInputs\(\)/);
+  assert.doesNotMatch(dashboardHtml, /file_path:item\.path/);
+  assert.doesNotMatch(dashboardHtml, /input\.click\(\)/);
+  assert.doesNotMatch(dashboardHtml, /queueCatsPaths/);
+  assert.match(dashboardHtml, /catsMessageInput\.addEventListener\('paste'/);
+  assert.match(dashboardHtml, /\/api\/cats\/messages\/send-file/);
 });

--- a/tests/electron-catsco-file-picker.test.ts
+++ b/tests/electron-catsco-file-picker.test.ts
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+const electronMain = readFileSync(join(process.cwd(), 'electron/main.js'), 'utf-8');
+const electronPreload = readFileSync(join(process.cwd(), 'electron/preload.js'), 'utf-8');
+
+test('Electron exposes a safe CatsCo file picker bridge', () => {
+  assert.match(electronMain, /ipcMain\.handle\('catsco:select-files'/);
+  assert.match(electronMain, /dialog\.showOpenDialog/);
+  assert.match(electronMain, /function isTrustedDashboardUrl\(value\)/);
+  assert.match(electronMain, /owner !== mainWindow \|\| !isTrustedDashboardUrl\(frameUrl\)/);
+  assert.match(electronMain, /createLocalFileGrant/);
+  assert.doesNotMatch(electronMain, /path:\s*filePath/);
+  assert.match(electronMain, /preload: path\.join\(__dirname, 'preload\.js'\)/);
+  assert.match(electronPreload, /contextBridge\.exposeInMainWorld\('catscoDesktop'/);
+  assert.match(electronPreload, /selectFiles: \(\) => ipcRenderer\.invoke\('catsco:select-files'\)/);
+});


### PR DESCRIPTION
## 背景

CatsCo Dashboard 的 Agent 聊天界面缺少本地附件入口，用户无法像常见聊天工具一样添加本地图片或文件。

## 改动

- 在 CatsCo Chat 输入区新增附件按钮和附件队列。
- 支持选择本地文件、拖拽文件、粘贴本地文件路径。
- Electron 客户端新增安全的文件选择桥接，确保能拿到本地真实文件路径。
- 新增 `/api/cats/messages/send-file` 接口，将本地文件上传后作为用户消息发送到 CatsCo 会话。
- 文件上传改为流式 multipart 上传，避免大文件一次性读入内存。
- 补充 Dashboard、API、Electron 文件选择相关测试。

## 验证

- `npm.cmd run build`
- `npm.cmd test`
