### PR TITLE
修复 CatsCo 账号登录态校验

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -2550,6 +2550,11 @@
       max-width: 420px;
     }
 
+    .chat-form .config-input {
+      width: 100%;
+      box-sizing: border-box;
+    }
+
     .chat-form-row {
       display: flex;
       gap: 8px;
@@ -3747,6 +3752,7 @@
 
             <div class="chat-form" id="cats-auth-panel">
               <div id="cats-login-fields">
+                <div class="chat-muted" id="cats-login-copy" style="margin-bottom:10px">使用 CatsCo webapp（CatsCompany）同一账号登录。</div>
                 <input class="config-input" id="cats-account" type="text" placeholder="邮箱或用户名" style="margin-bottom:10px" />
                 <input class="config-input" id="cats-password" type="password" placeholder="密码" />
                 <button class="btn btn-primary" onclick="submitCatsAuth()" id="cats-auth-btn" style="width:100%;margin-top:12px">登录并连接</button>
@@ -4940,7 +4946,7 @@
         return;
       }
       const user=catsState.user||{};
-      const catsConnected=Boolean(catsState.connected||catsState.tokenPresent);
+      const catsConnected=isCatsLoggedIn();
       const managedStatus=catsConnected?'待后端接入':'需要登录';
       const managedTone=catsConnected?'warm':'gray';
       const managedCopy=catsConnected
@@ -5500,9 +5506,19 @@
       return active?.message || section?.summary || '';
     }
 
+    function isCatsLoggedIn(){
+      return Boolean(catsState.connected && catsState.user && catsState.user.uid);
+    }
+
+    function catsAuthHelpText(){
+      if(catsState.authStatus==='invalid')return catsState.authError||'本地登录态已失效，请重新登录。';
+      if(catsState.authStatus==='unchecked'&&catsState.authError)return catsState.authError;
+      return '使用 CatsCo webapp（CatsCompany）同一账号登录。';
+    }
+
     function buildCatsChatStage(){
       const service=catsState.service||{};
-      const connected=Boolean(catsState.connected || catsState.tokenPresent);
+      const connected=isCatsLoggedIn();
       const configured=Boolean(catsState.configured);
       const running=service.status==='running';
       const topicReady=connected && configured && Boolean(catsState.topicId);
@@ -5520,6 +5536,18 @@
           inputPlaceholder:'等待启动状态检查',
         };
       }
+      if(!connected){
+        return {
+          key:'needs-auth',
+          status:'blocked',
+          badge:'login',
+          title:'登录 CatsCo',
+          copy:catsAuthHelpText(),
+          action:'auth',
+          actionLabel:'登录或注册',
+          inputPlaceholder:'先登录 CatsCo',
+        };
+      }
       const modelBlocked=modelSection?.status==='blocked';
       if(modelBlocked){
         return {
@@ -5531,18 +5559,6 @@
           action:'settings',
           actionLabel:'打开设置',
           inputPlaceholder:'先完成模型来源设置',
-        };
-      }
-      if(!connected){
-        return {
-          key:'needs-auth',
-          status:'blocked',
-          badge:'login',
-          title:'登录 CatsCo',
-          copy:'登录后会绑定同一个 CatsCo webapp 账号，并为本地 agent 准备会话。',
-          action:'auth',
-          actionLabel:'登录或注册',
-          inputPlaceholder:'先登录 CatsCo',
         };
       }
       if(catscoSection.status==='blocked'){
@@ -5610,17 +5626,20 @@
       if(!list)return;
       const service=catsState.service||{};
       const user=catsState.user||{};
-      const connected=Boolean(catsState.connected || catsState.tokenPresent);
+      const connected=isCatsLoggedIn();
       const configured=Boolean(catsState.configured);
       const running=service.status==='running';
       const topicReady=connected && configured && Boolean(catsState.topicId);
+      const accountMeta=connected
+        ? (user.display_name||user.username||'已登录')
+        : (catsState.authStatus==='invalid'?'登录态失效':'未登录');
       const modelSection=getReadinessSection('model');
       const modelStatus=modelSection
         ? (modelSection.status==='blocked'?'fail':modelSection.status==='warning'?'warning':'pass')
         : 'fail';
       const steps=[
         {label:'模型来源', status:modelStatus, meta:modelSection?firstReadinessProblem(modelSection)||modelSection.summary:'等待 readiness'},
-        {label:'CatsCo 账号', status:connected?'pass':'fail', meta:connected?(user.display_name||user.username||'已登录'):'未登录'},
+        {label:'CatsCo 账号', status:connected?'pass':'fail', meta:accountMeta},
         {label:'Agent 绑定', status:configured?'pass':'fail', meta:configured&&catsState.botUid?('uid '+catsState.botUid):'未绑定'},
         {label:'CatsCompany connector', status:running?'pass':(configured?'warning':'fail'), meta:running?'运行中':'未启动'},
         {label:'Chat 会话', status:topicReady?'pass':'fail', meta:topicReady?'已就绪':'等待 topic'},
@@ -5692,7 +5711,7 @@
       if(!panel)return;
       const service=catsState.service||{};
       const user=catsState.user||{};
-      const connected=Boolean(catsState.connected || catsState.tokenPresent);
+      const connected=isCatsLoggedIn();
       const configured=Boolean(catsState.configured);
       const running=service.status==='running';
       panel.classList.toggle('needs-auth', !connected);
@@ -5706,11 +5725,14 @@
       const user=catsState.user||{};
       const status=document.getElementById('cats-status');
       const running=service.status==='running';
-      const connected=Boolean(catsState.connected || catsState.tokenPresent);
+      const connected=isCatsLoggedIn();
       const configured=Boolean(catsState.configured);
       const stage=buildCatsChatStage();
+      const accountMeta=connected
+        ? (user.display_name?escapeHtml(user.display_name):'已登录')
+        : (catsState.authStatus==='invalid'?'登录态失效':'未登录');
       status.innerHTML=
-        '<div class="chat-status-row"><span>账号</span><strong>'+(connected?(user.display_name?escapeHtml(user.display_name):'已登录'):'未登录')+'</strong></div>'+
+        '<div class="chat-status-row"><span>账号</span><strong>'+accountMeta+'</strong></div>'+
         '<div class="chat-status-row"><span>CatsCo Agent</span><strong>'+(catsState.botUid?escapeHtml(catsState.botUid):'未绑定')+'</strong></div>'+
         '<div class="chat-status-row"><span>Topic</span><strong>'+(catsState.topicId?escapeHtml(catsState.topicId):'未就绪')+'</strong></div>'+
         '<div class="chat-status-row"><span>CatsCompany connector</span><strong style="color:'+(running?'var(--green)':'var(--orange)')+'">'+(running?'运行中':'未启动')+'</strong></div>';
@@ -5722,6 +5744,8 @@
       document.getElementById('cats-topic-label').textContent=catsState.topicId?('Topic: '+catsState.topicId):'尚未绑定会话';
       document.getElementById('cats-auth-panel').style.display=connected?'none':'grid';
       document.getElementById('cats-connected-card').style.display=connected?'block':'none';
+      const loginCopy=document.getElementById('cats-login-copy');
+      if(loginCopy)loginCopy.textContent=catsAuthHelpText();
       document.getElementById('cats-connected-copy').textContent=configured
         ? (running?'可以直接开始对话。':'账号和 agent 已绑定，点击“检查并启动”恢复 CatsCompany connector。')
         : '账号已登录，点击“检查并启动”完成 CatsCo agent 绑定。';

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -56,6 +56,10 @@ interface CatsAuthState {
   apiKey?: string;
 }
 
+interface CatsRequestOptions {
+  timeoutMs?: number;
+}
+
 function normalizeBaseUrl(value: unknown, fallback: string): string {
   const text = String(value || '').trim().replace(/\/+$/, '');
   return text || fallback;
@@ -67,6 +71,39 @@ function p2pTopicId(uid1: string | number, uid2: string | number): string {
   if (!Number.isFinite(a) || !Number.isFinite(b)) return '';
   const [left, right] = a < b ? [a, b] : [b, a];
   return `p2p_${left}_${right}`;
+}
+
+function hostLabel(value: string): string {
+  try {
+    return new URL(value).host || value;
+  } catch {
+    return value;
+  }
+}
+
+function createCatsNetworkError(error: any, httpBaseUrl: string): Error {
+  const code = String(error?.cause?.code || error?.code || '').trim();
+  const causeMessage = String(error?.cause?.message || error?.message || '').trim();
+  const host = hostLabel(httpBaseUrl);
+  let reason = `无法连接 CatsCo/CatsCompany 服务 ${host}`;
+
+  if (/ENOTFOUND|EAI_AGAIN/i.test(code) || /getaddrinfo|dns/i.test(causeMessage)) {
+    reason = `无法解析 CatsCo/CatsCompany 服务域名 ${host}`;
+  } else if (/ECONNREFUSED/i.test(code)) {
+    reason = `CatsCo/CatsCompany 服务 ${host} 拒绝连接`;
+  } else if (/ETIMEDOUT|UND_ERR_CONNECT_TIMEOUT/i.test(code) || /timed?out|timeout/i.test(causeMessage)) {
+    reason = `连接 CatsCo/CatsCompany 服务 ${host} 超时`;
+  } else if (/CERT|TLS|SSL/i.test(code) || /certificate|tls|ssl/i.test(causeMessage)) {
+    reason = `CatsCo/CatsCompany 服务 ${host} 的 HTTPS 证书校验失败`;
+  }
+
+  const wrapped = new Error(causeMessage ? `${reason}：${causeMessage}` : reason);
+  (wrapped as any).status = 502;
+  (wrapped as any).data = {
+    reason: code || 'FETCH_FAILED',
+    host,
+  };
+  return wrapped;
 }
 
 function readEnvFile(): Record<string, string> {
@@ -196,15 +233,34 @@ async function catsRequest(
   apiPath: string,
   body?: unknown,
   token?: string,
+  options: CatsRequestOptions = {},
 ): Promise<any> {
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
   if (token) headers.Authorization = `Bearer ${token}`;
 
-  const response = await fetch(`${httpBaseUrl}${apiPath}`, {
-    method,
-    headers,
-    body: body === undefined ? undefined : JSON.stringify(body),
-  });
+  const controller = options.timeoutMs ? new AbortController() : undefined;
+  const timeout = controller
+    ? setTimeout(() => controller.abort(), options.timeoutMs)
+    : undefined;
+  let response: Response;
+
+  try {
+    response = await fetch(`${httpBaseUrl}${apiPath}`, {
+      method,
+      headers,
+      body: body === undefined ? undefined : JSON.stringify(body),
+      signal: controller?.signal,
+    });
+  } catch (error: any) {
+    if (error?.name === 'AbortError') {
+      const timeoutError = new Error(`连接 CatsCo/CatsCompany 服务 ${hostLabel(httpBaseUrl)} 超时`);
+      (timeoutError as any).status = 408;
+      throw timeoutError;
+    }
+    throw createCatsNetworkError(error, httpBaseUrl);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
 
   const text = await response.text();
   let data: any = {};
@@ -266,6 +322,12 @@ async function catsApiKeyRequest(
 
 function persistCatsUserSession(state: CatsAuthState, login: any): void {
   writeEnvUpdates({
+    CATSCO_HTTP_BASE_URL: state.httpBaseUrl,
+    CATSCO_SERVER_URL: state.serverUrl,
+    CATSCO_USER_TOKEN: login.token,
+    CATSCO_USER_UID: String(login.uid || ''),
+    CATSCO_USER_NAME: login.username || '',
+    CATSCO_USER_DISPLAY_NAME: login.display_name || login.username || '',
     CATSCOMPANY_HTTP_BASE_URL: state.httpBaseUrl,
     CATSCOMPANY_SERVER_URL: state.serverUrl,
     CATSCOMPANY_USER_TOKEN: login.token,
@@ -753,20 +815,59 @@ export function createApiRouter(serviceManager: ServiceManager, updateController
 
   // ==================== CatsCo webapp 本地连接器 ====================
 
-  router.get('/cats/status', (_req, res) => {
+  router.get('/cats/status', async (_req, res) => {
     const state = getCatsAuthState();
     const service = serviceManager.getService('catscompany');
+    const tokenPresent = Boolean(state.token);
+    let connected = false;
+    let authStatus: 'missing' | 'valid' | 'invalid' | 'unchecked' = tokenPresent ? 'unchecked' : 'missing';
+    let authError = '';
+    let user = state.uid ? {
+      uid: state.uid,
+      username: state.username || '',
+      display_name: state.displayName || state.username || '',
+    } : null;
+
+    if (state.token) {
+      try {
+        const me = await catsRequest('GET', state.httpBaseUrl, '/api/me', undefined, state.token, {
+          timeoutMs: 4000,
+        });
+        const uid = String(me.uid || state.uid || '').trim();
+        connected = Boolean(uid);
+        authStatus = connected ? 'valid' : 'invalid';
+        user = connected ? {
+          uid,
+          username: me.username || state.username || '',
+          display_name: me.display_name || me.username || state.displayName || state.username || '',
+        } : null;
+        if (!connected) authError = 'CatsCo 账号验证失败，请重新登录';
+      } catch (error: any) {
+        const status = Number(error?.status || 0);
+        if (status === 401 || status === 403) {
+          connected = false;
+          authStatus = 'invalid';
+          authError = '本地登录态已失效，请使用 CatsCo webapp 同一账号重新登录';
+          user = null;
+        } else {
+          connected = Boolean(state.uid);
+          authStatus = 'unchecked';
+          authError = status === 408
+            ? 'CatsCo 账号验证超时，暂时保留本地登录态'
+            : '暂时无法验证 CatsCo 登录态，已保留本地登录态';
+        }
+      }
+    }
+
     res.json({
-      connected: Boolean(state.token),
-      configured: Boolean(state.apiKey && state.serverUrl),
-      tokenPresent: Boolean(state.token),
-      user: state.uid ? {
-        uid: state.uid,
-        username: state.username || '',
-        display_name: state.displayName || state.username || '',
-      } : null,
+      connected,
+      configured: connected && Boolean(state.apiKey && state.serverUrl),
+      tokenPresent,
+      authStatus,
+      authError,
+      user,
       botUid: state.botUid || null,
-      topicId: state.uid && state.botUid ? p2pTopicId(state.uid, state.botUid) : '',
+      topicId: connected && user?.uid && state.botUid ? p2pTopicId(user.uid, state.botUid) : '',
       httpBaseUrl: state.httpBaseUrl,
       serverUrl: state.serverUrl,
       service: service || null,
@@ -925,6 +1026,14 @@ export function createApiRouter(serviceManager: ServiceManager, updateController
       }
 
       const updated = writeEnvUpdates({
+        CATSCO_HTTP_BASE_URL: state.httpBaseUrl,
+        CATSCO_SERVER_URL: state.serverUrl,
+        CATSCO_USER_TOKEN: state.token,
+        CATSCO_USER_UID: userUid,
+        CATSCO_USER_NAME: me.username || state.username || '',
+        CATSCO_USER_DISPLAY_NAME: me.display_name || me.username || state.displayName || '',
+        CATSCO_BOT_UID: botUid,
+        CATSCO_API_KEY: apiKey,
         CATSCOMPANY_HTTP_BASE_URL: state.httpBaseUrl,
         CATSCOMPANY_SERVER_URL: state.serverUrl,
         CATSCOMPANY_USER_TOKEN: state.token,

--- a/tests/dashboard-catsco-auth-status.test.ts
+++ b/tests/dashboard-catsco-auth-status.test.ts
@@ -1,0 +1,223 @@
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as dotenv from 'dotenv';
+import express from 'express';
+import type { Server } from 'http';
+import { createApiRouter } from '../src/dashboard/routes/api';
+
+describe('dashboard CatsCo account status', () => {
+  let testRoot: string;
+  let originalCwd: string;
+  let dashboardServer: Server | undefined;
+  let catsServer: Server | undefined;
+  let dashboardBaseUrl: string;
+  let catsBaseUrl: string;
+  const envKeys = [
+    'CATSCO_HTTP_BASE_URL',
+    'CATSCO_SERVER_URL',
+    'CATSCO_USER_TOKEN',
+    'CATSCO_USER_UID',
+    'CATSCO_USER_NAME',
+    'CATSCO_USER_DISPLAY_NAME',
+    'CATSCO_BOT_UID',
+    'CATSCO_API_KEY',
+    'CATSCOMPANY_HTTP_BASE_URL',
+    'CATSCOMPANY_SERVER_URL',
+    'CATSCOMPANY_USER_TOKEN',
+    'CATSCOMPANY_USER_UID',
+    'CATSCOMPANY_USER_NAME',
+    'CATSCOMPANY_USER_DISPLAY_NAME',
+    'CATSCOMPANY_BOT_UID',
+    'CATSCOMPANY_API_KEY',
+  ];
+  const originalEnv: Record<string, string | undefined> = {};
+
+  beforeEach(async () => {
+    originalCwd = process.cwd();
+    testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-dashboard-catsco-auth-'));
+    process.chdir(testRoot);
+
+    for (const key of envKeys) {
+      originalEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+
+    const app = express();
+    app.use(express.json());
+    app.use('/api', createApiRouter({
+      getAll: () => [],
+      getService: () => null,
+    } as any));
+    dashboardServer = await listen(app);
+    dashboardBaseUrl = serverBaseUrl(dashboardServer);
+  });
+
+  afterEach(async () => {
+    if (dashboardServer) {
+      await close(dashboardServer);
+      dashboardServer = undefined;
+    }
+    if (catsServer) {
+      await close(catsServer);
+      catsServer = undefined;
+    }
+    process.chdir(originalCwd);
+    for (const key of envKeys) {
+      if (originalEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = originalEnv[key];
+      }
+    }
+    if (testRoot && fs.existsSync(testRoot)) {
+      fs.rmSync(testRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('GET /cats/status treats rejected CatsCompany token as logged out', async () => {
+    await startCatsServer((req, res) => {
+      if (req.path === '/api/me') {
+        return res.status(401).json({ error: 'invalid token' });
+      }
+      return res.status(404).json({ error: 'not found' });
+    });
+    writeEnv([
+      `CATSCO_HTTP_BASE_URL=${catsBaseUrl}`,
+      'CATSCO_SERVER_URL=wss://app.catsco.cc/v0/channels',
+      'CATSCO_USER_TOKEN=stale-user-token',
+      'CATSCO_USER_UID=38',
+      'CATSCO_BOT_UID=110',
+      'CATSCO_API_KEY=agent-api-key',
+    ]);
+
+    const response = await fetch(`${dashboardBaseUrl}/api/cats/status`);
+    const data = await response.json() as any;
+
+    assert.equal(response.status, 200);
+    assert.equal(data.tokenPresent, true);
+    assert.equal(data.connected, false);
+    assert.equal(data.configured, false);
+    assert.equal(data.authStatus, 'invalid');
+    assert.match(data.authError, /重新登录/);
+    assert.equal(data.user, null);
+    assert.equal(data.topicId, '');
+  });
+
+  test('GET /cats/status validates the shared CatsCompany account token', async () => {
+    await startCatsServer((req, res) => {
+      assert.equal(req.header('authorization'), 'Bearer valid-user-token');
+      if (req.path === '/api/me') {
+        return res.json({ uid: 42, username: 'webuser', display_name: 'Web User' });
+      }
+      return res.status(404).json({ error: 'not found' });
+    });
+    writeEnv([
+      `CATSCOMPANY_HTTP_BASE_URL=${catsBaseUrl}`,
+      'CATSCOMPANY_SERVER_URL=wss://app.catsco.cc/v0/channels',
+      'CATSCOMPANY_USER_TOKEN=valid-user-token',
+      'CATSCOMPANY_USER_UID=38',
+      'CATSCOMPANY_BOT_UID=110',
+      'CATSCOMPANY_API_KEY=agent-api-key',
+    ]);
+
+    const response = await fetch(`${dashboardBaseUrl}/api/cats/status`);
+    const data = await response.json() as any;
+
+    assert.equal(response.status, 200);
+    assert.equal(data.connected, true);
+    assert.equal(data.configured, true);
+    assert.equal(data.authStatus, 'valid');
+    assert.deepStrictEqual(data.user, {
+      uid: '42',
+      username: 'webuser',
+      display_name: 'Web User',
+    });
+    assert.equal(data.topicId, 'p2p_42_110');
+  });
+
+  test('POST /cats/auth/login writes both CatsCo and CatsCompany env aliases', async () => {
+    await startCatsServer((req, res) => {
+      if (req.path === '/api/auth/login') {
+        assert.deepStrictEqual(req.body, { account: 'demo@example.com', password: 'passw0rd' });
+        return res.json({
+          token: 'new-user-token',
+          uid: 77,
+          username: 'demo',
+          display_name: 'Demo User',
+        });
+      }
+      return res.status(404).json({ error: 'not found' });
+    });
+
+    const response = await fetch(`${dashboardBaseUrl}/api/cats/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        httpBaseUrl: catsBaseUrl,
+        serverUrl: 'wss://app.catsco.cc/v0/channels',
+        account: 'demo@example.com',
+        password: 'passw0rd',
+      }),
+    });
+    const data = await response.json() as any;
+    const env = dotenv.parse(fs.readFileSync(path.join(testRoot, '.env'), 'utf-8'));
+
+    assert.equal(response.status, 200);
+    assert.equal(data.ok, true);
+    assert.equal(env.CATSCO_USER_TOKEN, 'new-user-token');
+    assert.equal(env.CATSCOMPANY_USER_TOKEN, 'new-user-token');
+    assert.equal(env.CATSCO_USER_UID, '77');
+    assert.equal(env.CATSCOMPANY_USER_UID, '77');
+    assert.equal(env.CATSCO_USER_DISPLAY_NAME, 'Demo User');
+    assert.equal(env.CATSCOMPANY_USER_DISPLAY_NAME, 'Demo User');
+  });
+
+  test('POST /cats/auth/login reports remote CatsCompany network failures clearly', async () => {
+    const response = await fetch(`${dashboardBaseUrl}/api/cats/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        httpBaseUrl: 'http://127.0.0.1:9',
+        serverUrl: 'wss://app.catsco.cc/v0/channels',
+        account: 'demo@example.com',
+        password: 'passw0rd',
+      }),
+    });
+    const data = await response.json() as any;
+
+    assert.equal(response.status, 502);
+    assert.match(data.error, /CatsCo\/CatsCompany 服务/);
+    assert.equal(data.data.host, '127.0.0.1:9');
+  });
+
+  async function startCatsServer(handler: express.RequestHandler): Promise<void> {
+    const app = express();
+    app.use(express.json());
+    app.use(handler);
+    catsServer = await listen(app);
+    catsBaseUrl = serverBaseUrl(catsServer);
+  }
+
+  function writeEnv(lines: string[]): void {
+    fs.writeFileSync(path.join(testRoot, '.env'), `${lines.join('\n')}\n`);
+  }
+});
+
+function listen(app: express.Express): Promise<Server> {
+  return new Promise(resolve => {
+    const server = app.listen(0, '127.0.0.1', () => resolve(server));
+  });
+}
+
+function close(server: Server): Promise<void> {
+  return new Promise(resolve => server.close(() => resolve()));
+}
+
+function serverBaseUrl(server: Server): string {
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('server did not bind to a TCP port');
+  return `http://127.0.0.1:${address.port}`;
+}


### PR DESCRIPTION
## 背景

这个 PR 修复 CatsCo 桌面端里的 CatsCompany 账号登录态判断问题：之前本地只要存在 token 就会被视为已登录，过期 token 会让页面误以为已连接，导致用户看不到登录入口或后续连接状态很绕。

## 改动

- `/api/cats/status` 会用本地 token 调 CatsCompany `/api/me` 做登录态校验。
- 401/403 会返回 `authStatus: invalid`，前端显示“登录态失效”并露出登录/注册入口。
- 网络不可达或超时时会保留本地登录态，并返回更清楚的连接错误说明，避免临时网络问题直接把用户踢出。
- 登录/注册/agent 绑定时同时写入新的 `CATSCO_*` 环境变量和旧的 `CATSCOMPANY_*` 兼容变量。
- Dashboard 登录区域补充说明文案和输入框宽度样式，账号状态判断统一使用已验证的 user uid。
- 新增 dashboard CatsCo 账号状态回归测试。

## 验证

- `node --import tsx --test tests/dashboard-catsco-auth-status.test.ts`
- `npm.cmd run build`
- `npm.cmd run test:runtime`
- `npm.cmd run test:all`
- `npm.cmd run release:check`
- `git diff --check`
