### PR TITLE
feat(skills): support external skill package readiness

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -4403,18 +4403,31 @@
       return '<div class="skill-actions">'+actions.join('')+'</div>';
     }
 
+    function renderSkillPackageMeta(sk) {
+      const info = sk.packageInfo;
+      if (!info || !info.hasManifest) return '<span class="tag">prompt-only</span>';
+      const status = (info.readiness && info.readiness.status) || 'unknown';
+      const color = status === 'ready' ? 'active' : '';
+      const manifest = info.manifest || {};
+      const missing = info.readiness && info.readiness.missingEnv && info.readiness.missingEnv.length
+        ? ' · 缺少 '+info.readiness.missingEnv.join(', ')
+        : '';
+      const tools = typeof manifest.toolCount === 'number' ? ' · tools '+manifest.toolCount : '';
+      return '<span class="tag '+color+'" title="'+escapeHtml((info.readiness && (info.readiness.reasons||[]).join('; ')) || '')+'">package '+escapeHtml(status)+tools+missing+'</span>';
+    }
+
     function renderSkills(skills) {
       document.getElementById('skill-count').textContent = skills.length;
       const g = document.getElementById('skills-grid');
       if (!skills.length) { g.innerHTML = '<div class="loading">暂无 Skills</div>'; return; }
-      g.innerHTML = skills.map(sk => '<div class="skill-card'+(sk.enabled===false?' disabled':'')+'"><div class="skill-name">'+sk.name+renderSkillSourceTag(sk)+(sk.enabled===false?' <span class="tag" style="background:rgba(220,93,115,0.12);color:var(--red)">已禁用</span>':'')+'</div><div class="skill-desc">'+(sk.description||'')+'</div><div class="skill-meta">'+(sk.userInvocable?'<span class="tag active">用户调用</span>':'')+(sk.autoInvocable?'<span class="tag active">自动调用</span>':'')+(sk.maxTurns?'<span class="tag">max '+sk.maxTurns+' turns</span>':'')+'</div>'+renderSkillGrowth(sk.name)+(sk.files?'<div class="skill-files">'+sk.files.join(', ')+'</div>':'')+renderSkillActionButtons(sk)+'</div>').join('');
+      g.innerHTML = skills.map(sk => '<div class="skill-card'+(sk.enabled===false?' disabled':'')+'"><div class="skill-name">'+sk.name+renderSkillSourceTag(sk)+(sk.enabled===false?' <span class="tag" style="background:rgba(220,93,115,0.12);color:var(--red)">已禁用</span>':'')+'</div><div class="skill-desc">'+(sk.description||'')+'</div><div class="skill-meta">'+(sk.userInvocable?'<span class="tag active">用户调用</span>':'')+(sk.autoInvocable?'<span class="tag active">自动调用</span>':'')+(sk.maxTurns?'<span class="tag">max '+sk.maxTurns+' turns</span>':'')+renderSkillPackageMeta(sk)+'</div>'+renderSkillGrowth(sk.name)+(sk.files?'<div class="skill-files">'+sk.files.join(', ')+'</div>':'')+renderSkillActionButtons(sk)+'</div>').join('');
     }
 
     function renderLocalSkillStore(skills) {
       const g = document.getElementById('store-grid');
       if (!g) return;
       if (!skills.length) { g.innerHTML = '<div class="loading">暂无 Skills</div>'; return; }
-      g.innerHTML = skills.map(sk => '<div class="skill-card'+(sk.enabled===false?' disabled':'')+'"><div class="skill-name">'+sk.name+renderSkillSourceTag(sk)+(sk.enabled===false?' <span class="tag" style="background:rgba(220,93,115,0.12);color:var(--red)">已禁用</span>':'')+'</div><div class="skill-desc">'+(sk.description||'')+'</div><div class="skill-meta">'+(sk.userInvocable?'<span class="tag active">用户调用</span>':'')+(sk.autoInvocable?'<span class="tag active">自动调用</span>':'')+(sk.maxTurns?'<span class="tag">max '+sk.maxTurns+' turns</span>':'')+'</div>'+(sk.files?'<div class="skill-files">'+sk.files.join(', ')+'</div>':'')+renderSkillActionButtons(sk)+'</div>').join('');
+      g.innerHTML = skills.map(sk => '<div class="skill-card'+(sk.enabled===false?' disabled':'')+'"><div class="skill-name">'+sk.name+renderSkillSourceTag(sk)+(sk.enabled===false?' <span class="tag" style="background:rgba(220,93,115,0.12);color:var(--red)">已禁用</span>':'')+'</div><div class="skill-desc">'+(sk.description||'')+'</div><div class="skill-meta">'+(sk.userInvocable?'<span class="tag active">用户调用</span>':'')+(sk.autoInvocable?'<span class="tag active">自动调用</span>':'')+(sk.maxTurns?'<span class="tag">max '+sk.maxTurns+' turns</span>':'')+renderSkillPackageMeta(sk)+'</div>'+(sk.files?'<div class="skill-files">'+sk.files.join(', ')+'</div>':'')+renderSkillActionButtons(sk)+'</div>').join('');
     }
 
     async function svcAction(n,a) {

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -3,11 +3,40 @@ import { Logger } from '../utils/logger';
 import { styles } from '../theme/colors';
 import { SkillManager } from '../skills/skill-manager';
 import { PathResolver } from '../utils/path-resolver';
-import { execSync } from 'child_process';
+import { execFileSync, execSync } from 'child_process';
 import chalk from 'chalk';
 import * as path from 'path';
 import * as fs from 'fs';
 import inquirer from 'inquirer';
+import { SkillParser } from '../skills/skill-parser';
+import { validateInstalledSkillPackage } from '../skills/skill-package';
+
+const BUNDLED_SKILL_MARKER = '.xiaoba-bundled-skill.json';
+const SYSTEM_SKILL_DIRS = new Set(['_tool-skills']);
+const WINDOWS_RESERVED_NAMES = new Set([
+  'con',
+  'prn',
+  'aux',
+  'nul',
+  'com1',
+  'com2',
+  'com3',
+  'com4',
+  'com5',
+  'com6',
+  'com7',
+  'com8',
+  'com9',
+  'lpt1',
+  'lpt2',
+  'lpt3',
+  'lpt4',
+  'lpt5',
+  'lpt6',
+  'lpt7',
+  'lpt8',
+  'lpt9',
+]);
 
 /**
  * Skill 命令处理器
@@ -45,9 +74,18 @@ export function registerSkillCommand(program: Command): void {
   // skill install-github - 从 GitHub 安装 skill
   skillCmd
     .command('install-github <repo>')
-    .description('从 GitHub 仓库安装 skill (格式: owner/repo)')
-    .action(async (repo: string) => {
-      await installGithubSkill(repo);
+    .description('从 GitHub 仓库安装 skill (支持 owner/repo 或 GitHub URL)')
+    .option('-n, --name <name>', '自定义安装目录名')
+    .action(async (repo: string, options: { name?: string }) => {
+      await installGithubSkill(repo, options.name);
+    });
+
+  skillCmd
+    .command('install-local <dir>')
+    .description('从本地目录安装外部 skill 包')
+    .option('-n, --name <name>', '自定义安装目录名')
+    .action(async (dir: string, options: { name?: string }) => {
+      await installLocalSkill(dir, options.name);
     });
 
   // skill remove - 移除 skill
@@ -93,6 +131,7 @@ async function listSkills(): Promise<void> {
       Logger.info(`  ${chalk.gray('参数:')} ${skill.metadata.argumentHint}`);
     }
     Logger.info(`  ${chalk.gray('调用:')} ${invocable.join(', ')}`);
+    logPackageSummary(skill.packageInfo, '  ');
     Logger.info(`  ${chalk.gray('路径:')} ${skill.filePath}`);
     Logger.info('');
   }
@@ -157,6 +196,7 @@ async function showSkillInfo(name: string): Promise<void> {
   Logger.info(`${chalk.gray('用户可调用:')} ${skill.metadata.userInvocable ? '是' : '否'}`);
   Logger.info(`${chalk.gray('自动可调用:')} ${skill.metadata.autoInvocable ? '是' : '否'}`);
   Logger.info(`${chalk.gray('文件路径:')} ${skill.filePath}`);
+  logPackageSummary(skill.packageInfo);
 
   Logger.info(`\n${chalk.gray('提示词内容:')}`);
   Logger.info(chalk.gray('─'.repeat(50)));
@@ -167,25 +207,17 @@ async function showSkillInfo(name: string): Promise<void> {
 /**
  * 从 GitHub 安装 skill
  */
-async function installGithubSkill(repo: string): Promise<void> {
+async function installGithubSkill(repo: string, requestedName?: string): Promise<void> {
   Logger.title(`从 GitHub 安装 Skill: ${repo}`);
 
-  // 解析仓库地址
-  const repoMatch = repo.match(/^([^\/]+)\/([^\/]+)$/);
-  if (!repoMatch) {
-    Logger.error('仓库地址格式错误，应为: owner/repo');
-    Logger.info('例如: obra/superpowers');
-    process.exit(1);
-  }
+  const resolved = resolveGithubRepo(repo);
+  const githubUrl = resolved.cloneUrl;
+  const installName = sanitizeInstallName(requestedName || resolved.repoName);
 
-  const [, owner, repoName] = repoMatch;
-  const githubUrl = `https://github.com/${owner}/${repoName}.git`;
-
-  // 统一安装到 ~/.xiaoba/skills/
   const targetDir = PathResolver.getSkillsPath();
   PathResolver.ensureDir(targetDir);
 
-  const skillPath = path.join(targetDir, repoName);
+  const skillPath = path.join(targetDir, installName);
 
   // 检查目录是否已存在
   if (fs.existsSync(skillPath)) {
@@ -198,13 +230,13 @@ async function installGithubSkill(repo: string): Promise<void> {
     Logger.info(`\n克隆仓库: ${chalk.gray(githubUrl)}`);
     Logger.info(`目标目录: ${chalk.gray(skillPath)} (项目 skills 目录)\n`);
 
-    // 克隆仓库
-    execSync(`git clone ${githubUrl} "${skillPath}"`, {
+    execFileSync('git', ['clone', githubUrl, skillPath], {
       stdio: 'inherit',
-      cwd: targetDir
+      cwd: targetDir,
     });
 
-    Logger.success(`\n✓ Skill ${styles.highlight(repoName)} 安装成功！`);
+    reportInstalledPackage(skillPath);
+    Logger.success(`\n✓ Skill ${styles.highlight(installName)} 安装成功！`);
     Logger.info(`安装位置: ${skillPath}`);
     Logger.info('\n使用 catsco skill list 查看已安装的 skills');
   } catch (error: any) {
@@ -219,6 +251,57 @@ async function installGithubSkill(repo: string): Promise<void> {
       }
     }
 
+    process.exit(1);
+  }
+}
+
+async function installLocalSkill(sourceDir: string, requestedName?: string): Promise<void> {
+  const resolvedSource = path.resolve(sourceDir);
+  Logger.title(`从本地目录安装 Skill: ${resolvedSource}`);
+  if (!fs.existsSync(resolvedSource) || !fs.statSync(resolvedSource).isDirectory()) {
+    Logger.error(`目录不存在: ${resolvedSource}`);
+    process.exit(1);
+  }
+  if (!fs.existsSync(path.join(resolvedSource, 'SKILL.md'))) {
+    Logger.error(`目录缺少 SKILL.md: ${resolvedSource}`);
+    process.exit(1);
+  }
+
+  let parsedName = path.basename(resolvedSource);
+  try {
+    parsedName = SkillParser.parse(path.join(resolvedSource, 'SKILL.md')).metadata.name || parsedName;
+  } catch {
+    // 复制前仍会在 validateInstalledSkillPackage 阶段报出明确错误。
+  }
+
+  const installName = sanitizeInstallName(requestedName || parsedName);
+  const targetDir = PathResolver.getSkillsPath();
+  PathResolver.ensureDir(targetDir);
+  const skillPath = path.join(targetDir, installName);
+
+  if (fs.existsSync(skillPath)) {
+    Logger.warning(`Skill 目录已存在: ${skillPath}`);
+    Logger.info('如需重新安装，请先删除该目录');
+    process.exit(1);
+  }
+
+  try {
+    fs.cpSync(resolvedSource, skillPath, {
+      recursive: true,
+      filter: copiedPath => !shouldSkipLocalInstallPath(copiedPath, resolvedSource),
+    });
+    reportInstalledPackage(skillPath);
+    Logger.success(`\n✓ Skill ${styles.highlight(installName)} 安装成功！`);
+    Logger.info(`安装位置: ${skillPath}`);
+  } catch (error: any) {
+    Logger.error(`安装失败: ${error.message}`);
+    if (fs.existsSync(skillPath)) {
+      try {
+        fs.rmSync(skillPath, { recursive: true, force: true });
+      } catch {
+        // ignore cleanup errors
+      }
+    }
     process.exit(1);
   }
 }
@@ -296,10 +379,15 @@ async function removeLocalSkill(name: string, force?: boolean): Promise<void> {
   }
 
   const skillDir = path.dirname(skill.filePath);
+  const management = getCliSkillManagementInfo(skill.filePath);
 
   Logger.info(`\n${chalk.gray('名称:')} ${styles.highlight(skill.metadata.name)}`);
   Logger.info(`${chalk.gray('描述:')} ${skill.metadata.description}`);
   Logger.info(`${chalk.gray('路径:')} ${skillDir}`);
+  if (!management.canDelete) {
+    Logger.error(formatCliSkillDeleteBlockedMessage(management.source));
+    process.exit(1);
+  }
 
   if (!force) {
     const { confirmed } = await inquirer.prompt([
@@ -326,4 +414,136 @@ async function removeLocalSkill(name: string, force?: boolean): Promise<void> {
     Logger.error(`移除失败: ${error.message}`);
     process.exit(1);
   }
+}
+
+function resolveGithubRepo(input: string): { cloneUrl: string; repoName: string } {
+  const trimmed = input.trim();
+  const shorthand = trimmed.match(/^([^/\s]+)\/([^/\s]+)$/);
+  if (shorthand) {
+    return {
+      cloneUrl: `https://github.com/${shorthand[1]}/${stripGitSuffix(shorthand[2])}.git`,
+      repoName: stripGitSuffix(shorthand[2]),
+    };
+  }
+
+  const https = trimmed.match(/^https:\/\/github\.com\/([^/\s]+)\/([^/\s#?]+)(?:\.git)?(?:[/?#].*)?$/i);
+  if (https) {
+    return {
+      cloneUrl: `https://github.com/${https[1]}/${stripGitSuffix(https[2])}.git`,
+      repoName: stripGitSuffix(https[2]),
+    };
+  }
+
+  const ssh = trimmed.match(/^git@github\.com:([^/\s]+)\/([^/\s]+?)(?:\.git)?$/i);
+  if (ssh) {
+    return {
+      cloneUrl: `git@github.com:${ssh[1]}/${stripGitSuffix(ssh[2])}.git`,
+      repoName: stripGitSuffix(ssh[2]),
+    };
+  }
+
+  Logger.error('仓库地址格式错误，应为 owner/repo、GitHub HTTPS URL 或 GitHub SSH URL');
+  Logger.info('例如: owner/example-skill-package');
+  process.exit(1);
+}
+
+function stripGitSuffix(value: string): string {
+  return value.replace(/\.git$/i, '');
+}
+
+function sanitizeInstallName(value: string): string {
+  const cleaned = value.trim().toLowerCase().replace(/[^a-z0-9_-]+/g, '-').replace(/^-+|-+$/g, '');
+  if (!cleaned) {
+    Logger.error('Skill 安装目录名不能为空');
+    process.exit(1);
+  }
+  if (cleaned === '.' || cleaned === '..' || cleaned.includes('..')) {
+    Logger.error(`非法 skill 安装目录名: ${value}`);
+    process.exit(1);
+  }
+  if (WINDOWS_RESERVED_NAMES.has(cleaned)) {
+    Logger.error(`非法 skill 安装目录名: ${value}`);
+    process.exit(1);
+  }
+  return cleaned;
+}
+
+function shouldSkipLocalInstallPath(copiedPath: string, sourceRoot: string): boolean {
+  const relative = path.relative(sourceRoot, copiedPath);
+  if (!relative) return false;
+  const parts = relative.split(path.sep).map(part => part.toLowerCase());
+  const basename = path.basename(copiedPath).toLowerCase();
+  return parts.some(part => part === '.git' || part === '__pycache__' || part === 'output' || part === 'node_modules')
+    || basename === '.env'
+    || basename.startsWith('.env.')
+    || basename.endsWith('.pyc');
+}
+
+function reportInstalledPackage(skillPath: string): void {
+  const validation = validateInstalledSkillPackage(skillPath);
+  const skill = SkillParser.parse(validation.skillFile);
+  Logger.info(`\n${chalk.gray('Skill:')} ${styles.highlight(skill.metadata.name)}`);
+  Logger.info(`${chalk.gray('描述:')} ${skill.metadata.description}`);
+  logPackageSummary(validation.packageInfo);
+  if (!validation.ok) {
+    throw new Error(validation.packageInfo.readiness.reasons.join('; ') || 'skill package is invalid');
+  }
+}
+
+function logPackageSummary(packageInfo: import('../types/skill').SkillPackageInfo | undefined, indent = ''): void {
+  if (!packageInfo) return;
+  if (!packageInfo.hasManifest) {
+    Logger.info(`${indent}${chalk.gray('包状态:')} prompt-only`);
+    return;
+  }
+
+  const readiness = packageInfo.readiness.status;
+  const label = readiness === 'ready'
+    ? chalk.green('ready')
+    : readiness === 'not_configured'
+      ? chalk.yellow('not_configured')
+      : chalk.red('invalid');
+  const manifest = packageInfo.manifest;
+  Logger.info(`${indent}${chalk.gray('包状态:')} ${label}`);
+  if (manifest) {
+    Logger.info(`${indent}${chalk.gray('Manifest:')} ${manifest.schemaVersion || 'unknown'}${manifest.packageVersion ? ` (${manifest.packageVersion})` : ''}`);
+    Logger.info(`${indent}${chalk.gray('工具声明:')} ${manifest.toolCount}${manifest.providerSafeToolNames.length ? ` [${manifest.providerSafeToolNames.join(', ')}]` : ''}`);
+  }
+  if (packageInfo.readiness.missingEnv.length > 0) {
+    Logger.info(`${indent}${chalk.gray('缺少环境变量:')} ${packageInfo.readiness.missingEnv.join(', ')}`);
+  }
+  if (packageInfo.readiness.reasons.length > 0) {
+    Logger.info(`${indent}${chalk.gray('状态说明:')} ${packageInfo.readiness.reasons.join('; ')}`);
+  }
+  if (!packageInfo.hasReadme || !packageInfo.hasLicense) {
+    const missing = [
+      !packageInfo.hasReadme ? 'README' : '',
+      !packageInfo.hasLicense ? 'LICENSE' : '',
+    ].filter(Boolean);
+    Logger.info(`${indent}${chalk.gray('包提示:')} 缺少 ${missing.join(', ')}`);
+  }
+}
+
+type CliSkillSource = 'system' | 'bundled' | 'user';
+
+function getCliSkillManagementInfo(skillFilePath: string): { source: CliSkillSource; canDelete: boolean } {
+  const dir = path.dirname(skillFilePath);
+  const skillsRoot = PathResolver.getSkillsPath();
+  const relative = path.relative(skillsRoot, dir);
+  const parts = relative.split(path.sep).filter(Boolean);
+  const source: CliSkillSource = parts.some(part => SYSTEM_SKILL_DIRS.has(part))
+    ? 'system'
+    : fs.existsSync(path.join(dir, BUNDLED_SKILL_MARKER))
+      ? 'bundled'
+      : 'user';
+  return {
+    source,
+    canDelete: source === 'user',
+  };
+}
+
+function formatCliSkillDeleteBlockedMessage(source: CliSkillSource): string {
+  if (source === 'system') return '系统 Skill 不能删除。';
+  if (source === 'bundled') return '内置 Skill 不能删除，可在界面中禁用。';
+  return '该 Skill 当前不能删除。';
 }

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -28,6 +28,7 @@ import {
   rollbackRuntimeProfileEdit,
   saveRuntimeProfileEdit,
 } from '../../runtime/runtime-profile-editor';
+import { inspectSkillPackage } from '../../skills/skill-package';
 // import { ReportGenerator } from '../../utils/report-generator';
 // import { LogUploader } from '../../utils/log-uploader';
 
@@ -631,6 +632,7 @@ export function createApiRouter(serviceManager: ServiceManager, updateController
         content: skill.content,
         path: skill.filePath,
         files: getSkillFiles(skill.filePath),
+        packageInfo: skill.packageInfo || null,
         ...management,
       });
     } catch (e: any) {
@@ -1115,6 +1117,7 @@ function skillToDashboardPayload(skill: Skill): any {
     maxTurns: skill.metadata.maxTurns || null,
     path: skill.filePath,
     files: getSkillFiles(skill.filePath),
+    packageInfo: skill.packageInfo || null,
     enabled: true,
     ...getSkillManagementInfo(skill.filePath),
   };
@@ -1183,6 +1186,7 @@ function findAllDisabledSkills(basePath: string): any[] {
         enabled: false,
         path: disabledFile,
         files: getSkillFiles(disabledFile),
+        packageInfo: inspectSkillPackage(disabledFile),
         ...management,
       });
     }

--- a/src/skills/skill-package.ts
+++ b/src/skills/skill-package.ts
@@ -1,0 +1,168 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import type { SkillPackageInfo } from '../types/skill';
+
+interface ManifestEnvEntry {
+  name?: unknown;
+}
+
+interface AgentToolsManifest {
+  name?: unknown;
+  schema_version?: unknown;
+  package_version?: unknown;
+  tools?: unknown;
+  environment?: {
+    required?: unknown;
+    optional?: unknown;
+  };
+}
+
+export interface SkillPackageValidation {
+  ok: boolean;
+  skillFile: string;
+  packageInfo: SkillPackageInfo;
+}
+
+export function inspectSkillPackage(skillFilePath: string, env: NodeJS.ProcessEnv = process.env): SkillPackageInfo {
+  const directory = path.dirname(skillFilePath);
+  const manifestPath = path.join(directory, 'agent_tools.json');
+  const hasManifest = fs.existsSync(manifestPath);
+  const hasReadme = fileExistsAnyCase(directory, 'README.md');
+  const hasLicense = fileExistsAnyCase(directory, 'LICENSE');
+  const reasons: string[] = [];
+  let invalidManifest: string | undefined;
+  let manifestInfo: SkillPackageInfo['manifest'];
+  let missingEnv: string[] = [];
+  let hasManifestShapeError = false;
+
+  if (hasManifest) {
+    try {
+      const manifest = JSON.parse(stripBom(fs.readFileSync(manifestPath, 'utf-8'))) as AgentToolsManifest;
+      const requiredEnv = readEnvNames(manifest.environment?.required);
+      const optionalEnv = readEnvNames(manifest.environment?.optional);
+      missingEnv = requiredEnv.filter(key => !String(env[key] || '').trim());
+      const tools = Array.isArray(manifest.tools) ? manifest.tools : [];
+      manifestInfo = {
+        name: typeof manifest.name === 'string' ? manifest.name : undefined,
+        schemaVersion: typeof manifest.schema_version === 'string' ? manifest.schema_version : undefined,
+        packageVersion: typeof manifest.package_version === 'string' ? manifest.package_version : undefined,
+        toolCount: tools.length,
+        providerSafeToolNames: tools
+          .map((tool: any) => typeof tool?.provider_safe_name === 'string' ? tool.provider_safe_name : '')
+          .filter(Boolean),
+        requiredEnv,
+        optionalEnv,
+      };
+
+      if (!manifestInfo.schemaVersion) {
+        hasManifestShapeError = true;
+        reasons.push('agent_tools.json missing schema_version');
+      }
+      if (tools.length === 0) {
+        hasManifestShapeError = true;
+        reasons.push('agent_tools.json declares no tools');
+      }
+      const invalidToolReasons = validateToolDeclarations(tools);
+      if (invalidToolReasons.length > 0) {
+        hasManifestShapeError = true;
+        reasons.push(...invalidToolReasons);
+      }
+    } catch (error: any) {
+      invalidManifest = error?.message || String(error);
+      reasons.push(`agent_tools.json is invalid: ${invalidManifest}`);
+    }
+  }
+
+  if (missingEnv.length > 0) {
+    reasons.push(`missing required env: ${missingEnv.join(', ')}`);
+  }
+
+  const status = invalidManifest || hasManifestShapeError
+    ? 'invalid'
+    : missingEnv.length > 0
+      ? 'not_configured'
+      : 'ready';
+
+  return {
+    directory,
+    hasReadme,
+    hasLicense,
+    hasManifest,
+    ...(hasManifest ? { manifestPath } : {}),
+    ...(manifestInfo ? { manifest: manifestInfo } : {}),
+    readiness: {
+      status,
+      reasons,
+      missingEnv,
+      ...(invalidManifest ? { invalidManifest } : {}),
+    },
+  };
+}
+
+function validateToolDeclarations(tools: unknown[]): string[] {
+  const reasons: string[] = [];
+  tools.forEach((tool, index) => {
+    if (!isRecord(tool)) {
+      reasons.push(`tools[${index}] must be an object`);
+      return;
+    }
+    for (const key of ['name', 'provider_safe_name', 'command']) {
+      if (typeof tool[key] !== 'string' || !tool[key].trim()) {
+        reasons.push(`tools[${index}] missing ${key}`);
+      }
+    }
+    if (!isRecord(tool.parameters_schema)) {
+      reasons.push(`tools[${index}] missing parameters_schema`);
+    }
+    if (!isRecord(tool.output_schema)) {
+      reasons.push(`tools[${index}] missing output_schema`);
+    }
+    if (typeof tool.timeout_seconds !== 'number' || !Number.isFinite(tool.timeout_seconds) || tool.timeout_seconds <= 0) {
+      reasons.push(`tools[${index}] missing timeout_seconds`);
+    }
+  });
+  return reasons;
+}
+
+export function validateInstalledSkillPackage(skillDir: string, env: NodeJS.ProcessEnv = process.env): SkillPackageValidation {
+  const skillFile = path.join(skillDir, 'SKILL.md');
+  if (!fs.existsSync(skillFile)) {
+    throw new Error(`Installed skill package is missing SKILL.md: ${skillDir}`);
+  }
+  const packageInfo = inspectSkillPackage(skillFile, env);
+  return {
+    ok: packageInfo.readiness.status !== 'invalid',
+    skillFile,
+    packageInfo,
+  };
+}
+
+function readEnvNames(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map(entry => {
+      if (typeof entry === 'string') return entry;
+      if (isRecord(entry)) {
+        const envEntry = entry as ManifestEnvEntry;
+        return typeof envEntry.name === 'string' ? envEntry.name : '';
+      }
+      return '';
+    })
+    .map(item => item.trim())
+    .filter(Boolean);
+}
+
+function fileExistsAnyCase(directory: string, filename: string): boolean {
+  if (fs.existsSync(path.join(directory, filename))) return true;
+  if (!fs.existsSync(directory)) return false;
+  const target = filename.toLowerCase();
+  return fs.readdirSync(directory).some(entry => entry.toLowerCase() === target);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+function stripBom(text: string): string {
+  return text.charCodeAt(0) === 0xfeff ? text.slice(1) : text;
+}

--- a/src/skills/skill-parser.ts
+++ b/src/skills/skill-parser.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import matter from 'gray-matter';
 import { Skill, SkillMetadata } from '../types/skill';
+import { inspectSkillPackage } from './skill-package';
 
 /**
  * Skill 解析器
@@ -60,6 +61,7 @@ export class SkillParser {
       metadata,
       content: content.trim(),
       filePath,
+      packageInfo: inspectSkillPackage(filePath),
     };
   }
 
@@ -88,6 +90,7 @@ export class SkillParser {
       metadata,
       content: content.trim(),
       filePath,
+      packageInfo: inspectSkillPackage(filePath),
     };
   }
 

--- a/src/types/skill.ts
+++ b/src/types/skill.ts
@@ -10,6 +10,37 @@ export interface SkillMetadata {
   maxTurns?: number;               // 最大工具调用轮次（覆盖默认值）
 }
 
+export type SkillPackageReadinessStatus = 'ready' | 'not_configured' | 'invalid';
+
+/**
+ * 外部 skill 包信息。
+ *
+ * 这只描述安装包是否完整、是否已配置到可用状态；
+ * 不代表平台已经把包内工具动态注册为模型工具。
+ */
+export interface SkillPackageInfo {
+  directory: string;
+  hasReadme: boolean;
+  hasLicense: boolean;
+  hasManifest: boolean;
+  manifestPath?: string;
+  manifest?: {
+    name?: string;
+    schemaVersion?: string;
+    packageVersion?: string;
+    toolCount: number;
+    providerSafeToolNames: string[];
+    requiredEnv: string[];
+    optionalEnv: string[];
+  };
+  readiness: {
+    status: SkillPackageReadinessStatus;
+    reasons: string[];
+    missingEnv: string[];
+    invalidManifest?: string;
+  };
+}
+
 /**
  * Skill 完整定义
  */
@@ -17,6 +48,7 @@ export interface Skill {
   metadata: SkillMetadata;         // 元数据
   content: string;                 // Markdown 内容（提示词）
   filePath: string;                // 文件路径
+  packageInfo?: SkillPackageInfo;  // 外部 skill 包信息
 }
 
 /**

--- a/tests/dashboard-skills-api.test.ts
+++ b/tests/dashboard-skills-api.test.ts
@@ -19,6 +19,7 @@ describe('dashboard skills API', () => {
     process.chdir(testRoot);
 
     writeSkill('skills/user-tool/SKILL.md', 'user-tool', 'User managed skill');
+    writePackagedSkill('skills/example-tool-skill', 'example-tool-skill', 'Example packaged skill');
     writeSkill('skills/bundled-tool/SKILL.md', 'bundled-tool', 'Bundled skill');
     fs.writeFileSync(
       path.join(testRoot, 'skills/bundled-tool/.xiaoba-bundled-skill.json'),
@@ -70,6 +71,10 @@ describe('dashboard skills API', () => {
       canDisable: false,
       canDelete: false,
     });
+    assert.equal(byName.get('example-tool-skill').packageInfo.hasManifest, true);
+    assert.equal(byName.get('example-tool-skill').packageInfo.readiness.status, 'not_configured');
+    assert.deepEqual(byName.get('example-tool-skill').packageInfo.readiness.missingEnv, ['XIAOBA_TEST_TOOL_URL']);
+    assert.deepEqual(byName.get('example-tool-skill').packageInfo.manifest.providerSafeToolNames, ['example_health']);
   });
 
   test('protects system skills and allows user skill removal', async () => {
@@ -98,6 +103,20 @@ describe('dashboard skills API', () => {
     assert.equal(fs.existsSync(path.join(testRoot, 'skills/bundled-tool')), true);
   });
 
+  test('keeps package info visible for disabled packaged skills', async () => {
+    const disable = await fetch(`${baseUrl}/api/skills/example-tool-skill/disable`, { method: 'POST' });
+    assert.equal(disable.status, 200);
+
+    const response = await fetch(`${baseUrl}/api/skills-all`);
+    const skills = await response.json() as any[];
+    const disabledSkill = skills.find(skill => skill.name === 'example-tool-skill');
+
+    assert.equal(disabledSkill.enabled, false);
+    assert.equal(disabledSkill.packageInfo.hasManifest, true);
+    assert.equal(disabledSkill.packageInfo.readiness.status, 'not_configured');
+    assert.deepEqual(disabledSkill.packageInfo.readiness.missingEnv, ['XIAOBA_TEST_TOOL_URL']);
+  });
+
   function writeSkill(relativePath: string, name: string, description: string): void {
     const filePath = path.join(testRoot, relativePath);
     fs.mkdirSync(path.dirname(filePath), { recursive: true });
@@ -110,6 +129,29 @@ describe('dashboard skills API', () => {
       `# ${name}`,
       '',
     ].join('\n'));
+  }
+
+  function writePackagedSkill(relativeDir: string, name: string, description: string): void {
+    const dir = path.join(testRoot, relativeDir);
+    writeSkill(path.join(relativeDir, 'SKILL.md'), name, description);
+    fs.writeFileSync(path.join(dir, 'README.md'), '# Packaged skill\n');
+    fs.writeFileSync(path.join(dir, 'LICENSE'), 'Test license\n');
+    fs.writeFileSync(path.join(dir, 'agent_tools.json'), JSON.stringify({
+      schema_version: 'example.agent-tools.v1',
+      package_version: '0.2.0',
+      name,
+      environment: {
+        required: [{ name: 'XIAOBA_TEST_TOOL_URL' }],
+      },
+      tools: [{
+        name: 'example.health',
+        provider_safe_name: 'example_health',
+        command: 'health',
+        parameters_schema: { type: 'object', additionalProperties: false, properties: {} },
+        output_schema: { type: 'object', properties: {} },
+        timeout_seconds: 60,
+      }],
+    }));
   }
 });
 

--- a/tests/skill-package.test.ts
+++ b/tests/skill-package.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { SkillParser } from '../src/skills/skill-parser';
+import { inspectSkillPackage, validateInstalledSkillPackage } from '../src/skills/skill-package';
+
+describe('skill package inspection', () => {
+  let testRoot: string;
+
+  beforeEach(() => {
+    testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-skill-package-'));
+  });
+
+  afterEach(() => {
+    if (testRoot && fs.existsSync(testRoot)) {
+      fs.rmSync(testRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('attaches manifest readiness to parsed skills', () => {
+    const skillDir = writePackagedSkill('example-tool-skill', {
+      requiredEnv: ['XIAOBA_TEST_TOOL_URL'],
+    });
+
+    const skill = SkillParser.parse(path.join(skillDir, 'SKILL.md'));
+
+    assert.equal(skill.metadata.name, 'example-tool-skill');
+    assert.equal(skill.packageInfo?.hasManifest, true);
+    assert.equal(skill.packageInfo?.manifest?.schemaVersion, 'example.agent-tools.v1');
+    assert.equal(skill.packageInfo?.manifest?.toolCount, 1);
+    assert.deepEqual(skill.packageInfo?.manifest?.providerSafeToolNames, ['example_health']);
+    assert.equal(skill.packageInfo?.readiness.status, 'not_configured');
+    assert.deepEqual(skill.packageInfo?.readiness.missingEnv, ['XIAOBA_TEST_TOOL_URL']);
+  });
+
+  test('reports ready when required manifest env is present', () => {
+    const skillDir = writePackagedSkill('example-tool-skill', {
+      requiredEnv: ['XIAOBA_TEST_TOOL_URL'],
+    });
+
+    const info = inspectSkillPackage(path.join(skillDir, 'SKILL.md'), {
+      XIAOBA_TEST_TOOL_URL: 'https://example.test/tool',
+    } as any);
+
+    assert.equal(info.readiness.status, 'ready');
+    assert.deepEqual(info.readiness.missingEnv, []);
+  });
+
+  test('invalid manifest is not install-ready', () => {
+    const skillDir = writePromptOnlySkill('broken-skill');
+    fs.writeFileSync(path.join(skillDir, 'agent_tools.json'), '{ not-json');
+
+    const validation = validateInstalledSkillPackage(skillDir);
+
+    assert.equal(validation.ok, false);
+    assert.equal(validation.packageInfo.readiness.status, 'invalid');
+    assert.ok(validation.packageInfo.readiness.invalidManifest);
+  });
+
+  test('manifest with incomplete tool declaration is invalid', () => {
+    const skillDir = writePromptOnlySkill('incomplete-tool-skill');
+    fs.writeFileSync(path.join(skillDir, 'agent_tools.json'), JSON.stringify({
+      schema_version: 'example.agent-tools.v1',
+      tools: [{}],
+    }));
+
+    const validation = validateInstalledSkillPackage(skillDir);
+
+    assert.equal(validation.ok, false);
+    assert.equal(validation.packageInfo.readiness.status, 'invalid');
+    assert.match(validation.packageInfo.readiness.reasons.join('\n'), /missing provider_safe_name/);
+    assert.match(validation.packageInfo.readiness.reasons.join('\n'), /missing parameters_schema/);
+  });
+
+  test('prompt-only skills remain ready and loadable', () => {
+    const skillDir = writePromptOnlySkill('prompt-only');
+
+    const skill = SkillParser.parse(path.join(skillDir, 'SKILL.md'));
+
+    assert.equal(skill.packageInfo?.hasManifest, false);
+    assert.equal(skill.packageInfo?.readiness.status, 'ready');
+  });
+
+  function writePackagedSkill(name: string, options: { requiredEnv: string[] }): string {
+    const skillDir = writePromptOnlySkill(name);
+    fs.writeFileSync(path.join(skillDir, 'README.md'), '# Skill\n');
+    fs.writeFileSync(path.join(skillDir, 'LICENSE'), 'Test license\n');
+    fs.writeFileSync(path.join(skillDir, 'agent_tools.json'), JSON.stringify({
+      schema_version: 'example.agent-tools.v1',
+      package_version: '0.2.0',
+      name,
+      environment: {
+        required: options.requiredEnv.map(envName => ({ name: envName, secret: false })),
+      },
+      tools: [{
+        name: 'example.health',
+        provider_safe_name: 'example_health',
+        command: 'health',
+        parameters_schema: { type: 'object', additionalProperties: false, properties: {} },
+        output_schema: { type: 'object', properties: {} },
+        timeout_seconds: 60,
+      }],
+    }, null, 2));
+    return skillDir;
+  }
+
+  function writePromptOnlySkill(name: string): string {
+    const skillDir = path.join(testRoot, name);
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'), [
+      '---',
+      `name: ${name}`,
+      `description: ${name} description`,
+      '---',
+      '',
+      `Use ${name}.`,
+      '',
+    ].join('\n'));
+    return skillDir;
+  }
+});


### PR DESCRIPTION
## 概述

本 PR 增加外部 Skill 包的安装、识别和状态展示能力，为后续接入公开发布的工程读图 Skill 等外部 Skill 包打基础。


## 主要改动

- 新增外部 Skill 包检查逻辑，支持识别可选的 `agent_tools.json`
- 增加 Skill 包状态：
  - `ready`：包结构有效，必需环境变量已配置
  - `not_configured`：包结构有效，但缺少必需环境变量
  - `invalid`：manifest 无效或工具声明不完整
- `catsco skill install-github` 支持：
  - `owner/repo`
  - GitHub HTTPS URL
  - GitHub SSH URL
  - 自定义安装目录名
- 新增 `catsco skill install-local <dir>`，用于从本地目录安装外部 Skill 包
- CLI 中展示 Skill 包状态、manifest 版本、声明工具数量、provider-safe 工具名和缺失环境变量
- Dashboard Skill API 和页面展示 `packageInfo`
- disabled 状态下的 packaged skill 也保留并展示 `packageInfo`
- CLI 删除 Skill 时补充 system/bundled skill 保护，避免误删平台内置 Skill
- 本地安装时过滤 `.env*`、`.git`、`node_modules`、`__pycache__` 等不应复制的目录或文件

## 测试

已完成以下验证：

- `npm.cmd run build`
- `node node_modules\tsx\dist\cli.mjs --test tests\skill-package.test.ts tests\dashboard-skills-api.test.ts`
- `npm.cmd test -- --test tests\skill-package.test.ts tests\dashboard-skills-api.test.ts`
- 使用 `E:\cad-reader-skill-public` 做手动 CLI 安装验证，确认可以正确显示：
  - `包状态: not_configured`
  - manifest schema/package version
  - 声明工具数量和 provider-safe 工具名
  - 缺失环境变量 `CADLIST_REMOTE_BRICSCAD_URL`
