### PR TITLE
[codex] Limit read_file text output by default

### DIFF
--- a/src/tools/read-tool.ts
+++ b/src/tools/read-tool.ts
@@ -1,11 +1,45 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import * as readline from 'readline';
 import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import { isReadPathAllowed } from '../utils/safety';
 import { createImageBlock } from '../utils/image-utils';
 import { ConfigManager } from '../utils/config';
 import { isPrimaryModelVisionCapable } from '../utils/model-capabilities';
 import { analyzeImageWithReaderProxy, ReaderProxyResult } from '../utils/reader-proxy';
+
+export const DEFAULT_TEXT_READ_LIMIT = 200;
+export const MAX_TEXT_READ_LIMIT = 2000;
+export const MAX_TEXT_READ_BYTES = 256 * 1024;
+
+interface TextReadOptions {
+  offset?: unknown;
+  limit?: unknown;
+}
+
+interface NormalizedTextReadOptions {
+  startLine: number;
+  lineLimit?: number;
+  requestedLimit?: number;
+  isDefaultLimit: boolean;
+  isUnlimitedRequest: boolean;
+  limitWasCapped: boolean;
+}
+
+interface TextReadResult {
+  lines: string[];
+  totalLines: number;
+  readLines: number;
+  startLine: number;
+  endLine: number;
+  reachedLineLimit: boolean;
+  reachedByteLimit: boolean;
+  limitWasCapped: boolean;
+  isDefaultLimit: boolean;
+  isUnlimitedRequest: boolean;
+  requestedLimit?: number;
+  nextOffset?: number;
+}
 
 /**
  * Read tool - reads local files and returns content to the model.
@@ -27,11 +61,11 @@ export class ReadTool implements Tool {
         },
         offset: {
           type: 'number',
-          description: '从第几行开始读取，默认从第 1 行开始，仅适用于文本文件。',
+          description: '从第几行开始读取，1-based，默认从第 1 行开始，仅适用于文本文件。',
         },
         limit: {
           type: 'number',
-          description: '最多读取多少行，仅适用于文本文件。',
+          description: `最多读取多少行，仅适用于文本文件。默认 ${DEFAULT_TEXT_READ_LIMIT} 行；设为 0 表示尝试读取全文，但仍受输出字节上限保护。`,
         },
         pages: {
           type: 'string',
@@ -47,7 +81,7 @@ export class ReadTool implements Tool {
   };
 
   async execute(args: any, context: ToolExecutionContext): Promise<ToolExecutionResult> {
-    const { file_path, offset = 0, limit, pages, prompt, analysis_prompt } = args;
+    const { file_path, offset, limit, pages, prompt, analysis_prompt } = args;
 
     const absolutePath = path.isAbsolute(file_path)
       ? file_path
@@ -79,29 +113,183 @@ export class ReadTool implements Tool {
       return { ok: true, content };
     }
 
-    const content = this.readTextFile(absolutePath, file_path, offset, limit);
+    const content = await this.readTextFile(absolutePath, file_path, { offset, limit }, context);
     return { ok: true, content };
   }
 
-  private readTextFile(absolutePath: string, filePath: string, offset: number, limit?: number): string {
-    const content = fs.readFileSync(absolutePath, 'utf-8');
-    const lines = content.split('\n');
-    const startLine = Math.max(0, Number(offset) || 0);
-    const endLine = limit ? startLine + Number(limit) : lines.length;
-    const selectedLines = lines.slice(startLine, endLine);
+  private normalizeTextReadOptions({ offset, limit }: TextReadOptions): NormalizedTextReadOptions {
+    const parsedOffset = Number(offset);
+    const startLine = Number.isFinite(parsedOffset) && parsedOffset > 0
+      ? Math.floor(parsedOffset)
+      : 1;
 
-    const formattedLines = selectedLines.map((line, index) => {
-      const lineNumber = startLine + index + 1;
-      return `${lineNumber.toString().padStart(5, ' ')}→ ${line}`;
-    });
+    if (limit === 0 || limit === '0') {
+      return {
+        startLine,
+        isDefaultLimit: false,
+        isUnlimitedRequest: true,
+        limitWasCapped: false,
+      };
+    }
+
+    const parsedLimit = Number(limit);
+    const hasExplicitLimit = limit !== undefined && limit !== null && limit !== '';
+    const requestedLimit = hasExplicitLimit && Number.isFinite(parsedLimit)
+      ? Math.floor(parsedLimit)
+      : undefined;
+
+    if (!hasExplicitLimit || requestedLimit === undefined || requestedLimit <= 0) {
+      return {
+        startLine,
+        lineLimit: DEFAULT_TEXT_READ_LIMIT,
+        isDefaultLimit: true,
+        isUnlimitedRequest: false,
+        limitWasCapped: false,
+      };
+    }
+
+    return {
+      startLine,
+      lineLimit: Math.min(requestedLimit, MAX_TEXT_READ_LIMIT),
+      requestedLimit,
+      isDefaultLimit: false,
+      isUnlimitedRequest: false,
+      limitWasCapped: requestedLimit > MAX_TEXT_READ_LIMIT,
+    };
+  }
+
+  private trimToUtf8ByteLimit(value: string, maxBytes: number): string {
+    if (maxBytes <= 0) return '';
+    const buffer = Buffer.from(value, 'utf-8');
+    if (buffer.length <= maxBytes) return value;
+    return buffer.subarray(0, maxBytes).toString('utf-8');
+  }
+
+  private async collectTextLines(
+    absolutePath: string,
+    options: NormalizedTextReadOptions,
+    context: ToolExecutionContext,
+  ): Promise<TextReadResult> {
+    const selectedLines: string[] = [];
+    let totalLines = 0;
+    let selectedBytes = 0;
+    let reachedLineLimit = false;
+    let reachedByteLimit = false;
+
+    const input = fs.createReadStream(absolutePath, { encoding: 'utf-8' });
+    const reader = readline.createInterface({ input, crlfDelay: Infinity });
+
+    const abort = () => {
+      input.destroy(new Error('读取已取消'));
+      reader.close();
+    };
+    context.abortSignal?.addEventListener('abort', abort, { once: true });
+
+    try {
+      for await (const line of reader) {
+        if (context.abortSignal?.aborted) {
+          throw new Error('读取已取消');
+        }
+
+        totalLines += 1;
+
+        if (totalLines < options.startLine) continue;
+
+        const relativeLineIndex = totalLines - options.startLine;
+        if (options.lineLimit !== undefined && relativeLineIndex >= options.lineLimit) {
+          reachedLineLimit = true;
+          continue;
+        }
+
+        if (reachedByteLimit) continue;
+
+        const lineBytes = Buffer.byteLength(line, 'utf-8') + 1;
+        const remainingBytes = MAX_TEXT_READ_BYTES - selectedBytes;
+        if (lineBytes > remainingBytes) {
+          const trimmed = this.trimToUtf8ByteLimit(line, Math.max(remainingBytes - 1, 0));
+          if (trimmed) {
+            selectedLines.push(trimmed);
+            selectedBytes = MAX_TEXT_READ_BYTES;
+          }
+          reachedByteLimit = true;
+          continue;
+        }
+
+        selectedLines.push(line);
+        selectedBytes += lineBytes;
+      }
+    } finally {
+      context.abortSignal?.removeEventListener('abort', abort);
+    }
+
+    const readLines = selectedLines.length;
+    const endLine = readLines > 0 ? options.startLine + readLines - 1 : options.startLine - 1;
+    const hasMoreAfterSelection = totalLines > endLine && endLine >= options.startLine;
+    const nextOffset = hasMoreAfterSelection ? endLine + 1 : undefined;
+
+    return {
+      lines: selectedLines,
+      totalLines,
+      readLines,
+      startLine: options.startLine,
+      endLine,
+      reachedLineLimit,
+      reachedByteLimit,
+      limitWasCapped: options.limitWasCapped,
+      isDefaultLimit: options.isDefaultLimit,
+      isUnlimitedRequest: options.isUnlimitedRequest,
+      requestedLimit: options.requestedLimit,
+      nextOffset,
+    };
+  }
+
+  private formatTextReadResult(filePath: string, result: TextReadResult): string {
+    const formattedLines = result.lines
+      .map((line, index) => {
+        const lineNumber = result.startLine + index;
+        return `${lineNumber.toString().padStart(5, ' ')}→ ${line}`;
+      });
+
+    const displayRange = result.readLines > 0
+      ? `${result.startLine}-${result.endLine}`
+      : `无（从第 ${result.startLine} 行开始无内容）`;
+
+    const notes: string[] = [];
+    if (result.limitWasCapped) {
+      notes.push(`请求的 limit=${result.requestedLimit} 已限制为 ${MAX_TEXT_READ_LIMIT} 行。`);
+    }
+    if (result.isDefaultLimit && result.nextOffset) {
+      notes.push(`默认只显示 ${DEFAULT_TEXT_READ_LIMIT} 行，避免超大文件占满上下文。`);
+    }
+    if (result.reachedByteLimit) {
+      notes.push(`输出达到 ${(MAX_TEXT_READ_BYTES / 1024).toFixed(0)} KB 上限，已停止追加内容。`);
+    }
+    if (result.nextOffset) {
+      const nextLimit = result.isUnlimitedRequest
+        ? DEFAULT_TEXT_READ_LIMIT
+        : (result.limitWasCapped ? MAX_TEXT_READ_LIMIT : (result.requestedLimit || DEFAULT_TEXT_READ_LIMIT));
+      notes.push(`继续读取请调用 read_file，参数 offset=${result.nextOffset}, limit=${nextLimit}。`);
+    }
 
     return [
       `文件: ${filePath}`,
-      `总行数: ${lines.length}`,
-      `显示: ${startLine + 1}-${Math.min(endLine, lines.length)}`,
+      `总行数: ${result.totalLines}`,
+      `显示: ${displayRange}`,
       '',
       formattedLines.join('\n'),
-    ].join('\n');
+      notes.length > 0 ? ['', ...notes].join('\n') : '',
+    ].filter(part => part !== '').join('\n');
+  }
+
+  private async readTextFile(
+    absolutePath: string,
+    filePath: string,
+    options: TextReadOptions,
+    context: ToolExecutionContext,
+  ): Promise<string> {
+    const normalizedOptions = this.normalizeTextReadOptions(options);
+    const result = await this.collectTextLines(absolutePath, normalizedOptions, context);
+    return this.formatTextReadResult(filePath, result);
   }
 
   private readPDF(absolutePath: string, filePath: string, pages?: string): string {

--- a/src/tools/read-tool.ts
+++ b/src/tools/read-tool.ts
@@ -29,6 +29,7 @@ interface NormalizedTextReadOptions {
 interface TextReadResult {
   lines: string[];
   totalLines: number;
+  totalLinesKnown: boolean;
   readLines: number;
   startLine: number;
   endLine: number;
@@ -172,6 +173,7 @@ export class ReadTool implements Tool {
   ): Promise<TextReadResult> {
     const selectedLines: string[] = [];
     let totalLines = 0;
+    let totalLinesKnown = true;
     let selectedBytes = 0;
     let reachedLineLimit = false;
     let reachedByteLimit = false;
@@ -198,10 +200,9 @@ export class ReadTool implements Tool {
         const relativeLineIndex = totalLines - options.startLine;
         if (options.lineLimit !== undefined && relativeLineIndex >= options.lineLimit) {
           reachedLineLimit = true;
-          continue;
+          totalLinesKnown = false;
+          break;
         }
-
-        if (reachedByteLimit) continue;
 
         const lineBytes = Buffer.byteLength(line, 'utf-8') + 1;
         const remainingBytes = MAX_TEXT_READ_BYTES - selectedBytes;
@@ -212,7 +213,8 @@ export class ReadTool implements Tool {
             selectedBytes = MAX_TEXT_READ_BYTES;
           }
           reachedByteLimit = true;
-          continue;
+          totalLinesKnown = false;
+          break;
         }
 
         selectedLines.push(line);
@@ -230,6 +232,7 @@ export class ReadTool implements Tool {
     return {
       lines: selectedLines,
       totalLines,
+      totalLinesKnown,
       readLines,
       startLine: options.startLine,
       endLine,
@@ -253,6 +256,9 @@ export class ReadTool implements Tool {
     const displayRange = result.readLines > 0
       ? `${result.startLine}-${result.endLine}`
       : `无（从第 ${result.startLine} 行开始无内容）`;
+    const totalLinesLabel = result.totalLinesKnown
+      ? `${result.totalLines}`
+      : `至少 ${result.totalLines}（已停止继续统计，避免超大文件读取耗时）`;
 
     const notes: string[] = [];
     if (result.limitWasCapped) {
@@ -273,7 +279,7 @@ export class ReadTool implements Tool {
 
     return [
       `文件: ${filePath}`,
-      `总行数: ${result.totalLines}`,
+      `总行数: ${totalLinesLabel}`,
       `显示: ${displayRange}`,
       '',
       formattedLines.join('\n'),

--- a/tests/tool-result-read-tool.test.ts
+++ b/tests/tool-result-read-tool.test.ts
@@ -43,7 +43,23 @@ describe('ReadTool - ToolExecutionResult', () => {
     assert.ok(content.includes(`显示: 1-${DEFAULT_TEXT_READ_LIMIT}`));
     assert.ok(content.includes(`默认只显示 ${DEFAULT_TEXT_READ_LIMIT} 行`));
     assert.ok(content.includes(`offset=${DEFAULT_TEXT_READ_LIMIT + 1}`));
+    assert.ok(content.includes(`总行数: 至少 ${DEFAULT_TEXT_READ_LIMIT + 1}`));
     assert.ok(content.includes('line200'));
+    assert.ok(!content.includes('line201'));
+  });
+
+  test('达到默认窗口后不继续扫描完整文件统计总行数', async () => {
+    const filePath = path.join(testRoot, 'huge.txt');
+    const lines = Array.from({ length: DEFAULT_TEXT_READ_LIMIT + 5000 }, (_, index) => `line${index + 1}`);
+    fs.writeFileSync(filePath, lines.join('\n'));
+
+    const result = await tool.execute({ file_path: filePath }, context);
+
+    assert.strictEqual(result.ok, true);
+    const content = result.content as string;
+    assert.ok(content.includes(`总行数: 至少 ${DEFAULT_TEXT_READ_LIMIT + 1}`));
+    assert.ok(content.includes('已停止继续统计'));
+    assert.ok(!content.includes(`总行数: ${DEFAULT_TEXT_READ_LIMIT + 5000}`));
     assert.ok(!content.includes('line201'));
   });
 

--- a/tests/tool-result-read-tool.test.ts
+++ b/tests/tool-result-read-tool.test.ts
@@ -6,7 +6,7 @@ import * as assert from 'node:assert';
 import * as path from 'path';
 import * as os from 'os';
 import * as fs from 'fs';
-import { ReadTool } from '../src/tools/read-tool';
+import { DEFAULT_TEXT_READ_LIMIT, ReadTool } from '../src/tools/read-tool';
 import { ToolExecutionContext } from '../src/types/tool';
 
 describe('ReadTool - ToolExecutionResult', () => {
@@ -31,13 +31,42 @@ describe('ReadTool - ToolExecutionResult', () => {
     assert.ok(content.includes('line1'));
   });
 
-  test('使用 offset 和 limit 返回 ok=true', async () => {
+  test('默认只读取文本文件开头窗口', async () => {
+    const filePath = path.join(testRoot, 'large.txt');
+    const lines = Array.from({ length: DEFAULT_TEXT_READ_LIMIT + 5 }, (_, index) => `line${index + 1}`);
+    fs.writeFileSync(filePath, lines.join('\n'));
+
+    const result = await tool.execute({ file_path: filePath }, context);
+
+    assert.strictEqual(result.ok, true);
+    const content = result.content as string;
+    assert.ok(content.includes(`显示: 1-${DEFAULT_TEXT_READ_LIMIT}`));
+    assert.ok(content.includes(`默认只显示 ${DEFAULT_TEXT_READ_LIMIT} 行`));
+    assert.ok(content.includes(`offset=${DEFAULT_TEXT_READ_LIMIT + 1}`));
+    assert.ok(content.includes('line200'));
+    assert.ok(!content.includes('line201'));
+  });
+
+  test('使用 1-based offset 和 limit 返回 ok=true', async () => {
     const filePath = path.join(testRoot, 'long.txt');
     fs.writeFileSync(filePath, 'line1\nline2\nline3\nline4\nline5');
-    const result = await tool.execute({ file_path: filePath, offset: 1, limit: 2 }, context);
+    const result = await tool.execute({ file_path: filePath, offset: 2, limit: 2 }, context);
     assert.strictEqual(result.ok, true);
     const content = result.content as string;
     assert.ok(content.includes('显示: 2-3'));
+    assert.ok(content.includes('    2→ line2'));
+    assert.ok(!content.includes('    1→ line1'));
+  });
+
+  test('limit=0 对小文本文件读取全文', async () => {
+    const filePath = path.join(testRoot, 'full.txt');
+    fs.writeFileSync(filePath, 'line1\nline2\nline3');
+    const result = await tool.execute({ file_path: filePath, limit: 0 }, context);
+    assert.strictEqual(result.ok, true);
+    const content = result.content as string;
+    assert.ok(content.includes('显示: 1-3'));
+    assert.ok(content.includes('line3'));
+    assert.ok(!content.includes('默认只显示'));
   });
 
   test('文件不存在返回 ok=false + FILE_NOT_FOUND', async () => {

--- a/tests/tool-result-read-tool.test.ts
+++ b/tests/tool-result-read-tool.test.ts
@@ -74,6 +74,32 @@ describe('ReadTool - ToolExecutionResult', () => {
     assert.ok(!content.includes('    1→ line1'));
   });
 
+  test('显式小 limit 达到窗口后停止扫描并提示至少行数', async () => {
+    const filePath = path.join(testRoot, 'small-window.txt');
+    fs.writeFileSync(filePath, [
+      'before-window',
+      'window-first',
+      'window-second',
+      'after-window',
+      'never-scanned-exact-total',
+    ].join('\n'));
+
+    const result = await tool.execute({ file_path: filePath, offset: 2, limit: 2 }, context);
+
+    assert.strictEqual(result.ok, true);
+    const content = result.content as string;
+    assert.ok(content.includes('显示: 2-3'));
+    assert.ok(content.includes('    2→ window-first'));
+    assert.ok(content.includes('    3→ window-second'));
+    assert.ok(content.includes('总行数: 至少 4'));
+    assert.ok(content.includes('offset=4, limit=2'));
+    assert.ok(content.includes('已停止继续统计'));
+    assert.ok(!content.includes('before-window'));
+    assert.ok(!content.includes('after-window'));
+    assert.ok(!content.includes('never-scanned-exact-total'));
+    assert.ok(!content.includes('总行数: 5'));
+  });
+
   test('limit=0 对小文本文件读取全文', async () => {
     const filePath = path.join(testRoot, 'full.txt');
     fs.writeFileSync(filePath, 'line1\nline2\nline3');


### PR DESCRIPTION
## Summary
- Stream text reads line by line instead of loading the full file into memory.
- Default read_file text output to the first 200 lines and include follow-up offset guidance.
- Add caps for explicit large limits and byte output, while preserving limit=0 for small full-file reads.

## Validation
- npm run build
- node /Users/zhuhanyuan/Documents/XiaoBa-CLI/node_modules/tsx/dist/cli.mjs --test tests/tool-result-read-tool.test.ts tests/tool-result-tool-manager.test.ts

## Notes
The wider runtime test suite still has unrelated gauzmem_search default-tool expectation failures in the current working tree/environment.