### PR TITLE
fix(skills): 在 Skill 激活输出中注入目录上下文

### DIFF
--- a/src/skills/skill-executor.ts
+++ b/src/skills/skill-executor.ts
@@ -33,6 +33,15 @@ export class SkillExecutor {
     // 清理未替换的占位符
     content = content.replace(/\$\d+/g, '');
 
-    return content;
+    return [
+      `[skill:${skill.metadata.name}]`,
+      `Skill file: ${skill.filePath}`,
+      `Skill directory: ${skillDir}`,
+      'Resolve relative paths mentioned in this skill relative to Skill directory.',
+      'When running scripts or reading referenced files, prefer absolute paths under Skill directory.',
+      '',
+      '--- SKILL.md ---',
+      content,
+    ].join('\n');
   }
 }

--- a/tests/skill-tool-direct-content.test.ts
+++ b/tests/skill-tool-direct-content.test.ts
@@ -40,6 +40,11 @@ describe('skill tool direct content mode', () => {
 
     assert.equal(result.ok, true);
     assert.equal(typeof result.content, 'string');
+    assert.match(String(result.content), /\[skill:demo\]/);
+    assert.match(String(result.content), new RegExp(`Skill file: ${escapeRegExp(path.join(testRoot, 'skills', 'demo', 'SKILL.md'))}`));
+    assert.match(String(result.content), new RegExp(`Skill directory: ${escapeRegExp(path.join(testRoot, 'skills', 'demo'))}`));
+    assert.match(String(result.content), /Resolve relative paths mentioned in this skill relative to Skill directory\./);
+    assert.match(String(result.content), /--- SKILL\.md ---/);
     assert.match(String(result.content), /Use demo from /);
     assert.match(String(result.content), /with alpha beta \/ alpha \/ beta \//);
     assert.doesNotMatch(String(result.content), /skill_activation/);
@@ -56,3 +61,7 @@ describe('skill tool direct content mode', () => {
     assert.doesNotMatch(String(result.content), /__reload_skills__/);
   });
 });
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}


### PR DESCRIPTION
## 背景

当前 SkillManager 已经在内部记录了每个 Skill 的 `filePath`，但实际通过 `skill` tool 激活 Skill 时，只会把渲染后的 `SKILL.md` 正文返回给模型。

这会导致一个问题：如果公开可迁移 Skill 在 `SKILL.md` 中使用 `scripts/foo.py`、`references/bar.md`、`memory-search.py` 等相对路径，模型无法稳定知道这些路径应该相对哪个 Skill 目录解析，进而影响 Skill 附带脚本和参考文件的命中率。

## 修改内容

- 在 `SkillExecutor.execute()` 返回的 Skill 内容前增加统一上下文头：
  - `[skill:<name>]`
  - `Skill file: .../SKILL.md`
  - `Skill directory: ...`
  - 相对路径应基于 `Skill directory` 解析的说明
- 保留原有 `<SKILL_DIR>`、`$ARGUMENTS`、`$1` 等占位符替换逻辑。
- 更新 `skill-tool-direct-content` 测试，覆盖 Skill file、Skill directory 和路径解析说明的输出。

## 效果

激活 Skill 后，模型可以直接知道当前 Skill 的真实目录位置，从而更稳定地读取或执行 Skill 包内的脚本、references、assets 等文件。

这不要求修改已有公开 Skill 的 `SKILL.md`，也兼容已经使用 `<SKILL_DIR>` 的 Skill。

## 验证

已通过：

```bash
npm run build
node node_modules/tsx/dist/cli.mjs --test tests/skill-tool-direct-content.test.ts tests/session-skill-runtime.test.ts
