### PR TITLE
拆出运行时计划卡片

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -3159,6 +3159,87 @@
       font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
     }
 
+    .chat-runtime-plan {
+      margin: 8px 0 4px;
+      border: 1px solid var(--border-light);
+      border-radius: 8px;
+      background: var(--surface-muted);
+      overflow: hidden;
+      max-width: min(760px, 100%);
+    }
+
+    .chat-runtime-plan summary {
+      cursor: pointer;
+      padding: 9px 11px;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      list-style: none;
+      font-weight: 850;
+      color: var(--text);
+    }
+
+    .chat-runtime-plan summary::-webkit-details-marker {
+      display: none;
+    }
+
+    .chat-runtime-plan[open] .chat-runtime-plan-chevron {
+      transform: rotate(90deg);
+    }
+
+    .chat-runtime-plan-chevron {
+      display: inline-block;
+      color: var(--accent);
+      transition: transform 0.16s ease;
+    }
+
+    .chat-runtime-plan-hint {
+      margin-left: auto;
+      color: var(--text3);
+      font-size: 11px;
+      font-weight: 750;
+    }
+
+    .chat-runtime-plan-body {
+      display: grid;
+      gap: 7px;
+      padding: 0 11px 11px 29px;
+    }
+
+    .chat-runtime-plan-step {
+      display: grid;
+      grid-template-columns: 74px minmax(0, 1fr);
+      gap: 8px;
+      align-items: start;
+      font-size: 13px;
+      color: var(--text);
+    }
+
+    .chat-runtime-plan-status {
+      border-radius: 999px;
+      padding: 2px 7px;
+      width: fit-content;
+      font-size: 11px;
+      font-weight: 850;
+      background: #eef2ff;
+      color: #3730a3;
+    }
+
+    .chat-runtime-plan-status.completed {
+      background: #dcfce7;
+      color: #166534;
+    }
+
+    .chat-runtime-plan-status.in_progress {
+      background: #ffedd5;
+      color: #c2410c;
+    }
+
+    .chat-runtime-plan-text {
+      min-width: 0;
+      line-height: 1.45;
+    }
+
     .chat-rich-image-button {
       display: block;
       padding: 0;
@@ -4485,6 +4566,7 @@
     const CATS_DEFAULT_WS_URL = 'wss://app.catsco.cc/v0/channels';
     const CATS_WORKING_TEXT_PREFIX = 'AI文本:';
     const CATS_WORKING_TYPES = new Set(['thinking', 'tool_use', 'tool_result']);
+    const catsRuntimePlanOpenState = new Map();
     const petFrames = {
       idle: ['pet/idle/01.png', 'pet/idle/02.png', 'pet/idle/03.png', 'pet/idle/04.png'],
       thinking: ['pet/thinking/01.png', 'pet/thinking/02.png', 'pet/thinking/03.png', 'pet/thinking/04.png'],
@@ -6548,6 +6630,7 @@
 
     function extractCatsMessageText(message){
       if(!message)return '';
+      if((message.type||message.msg_type)==='runtime_plan')return '';
       if(typeof message.content==='string')return message.content;
       if(Array.isArray(message.content_blocks)){
         return message.content_blocks.map(b=>b.text||b.content||'').filter(Boolean).join('\n');
@@ -6792,6 +6875,62 @@
       return CATS_WORKING_TYPES.has(msgType)?msgType:'';
     }
 
+    function catsRuntimePlanSnapshot(message){
+      if(catsMessageType(message)!=='runtime_plan')return null;
+      const content=message?.content;
+      if(content && typeof content==='object')return content;
+      if(typeof content==='string'){
+        try{
+          const parsed=JSON.parse(content);
+          return parsed && typeof parsed==='object'?parsed:null;
+        }catch(_e){
+          return null;
+        }
+      }
+      return null;
+    }
+
+    function catsRuntimePlanKey(message,snapshot){
+      return String(message?.seq_id || message?.id || snapshot?.revision || message?.created_at || 'runtime-plan');
+    }
+
+    function setCatsRuntimePlanOpen(key,open){
+      if(!key)return;
+      catsRuntimePlanOpenState.set(String(key), Boolean(open));
+    }
+    window.setCatsRuntimePlanOpen=setCatsRuntimePlanOpen;
+
+    function isCatsRuntimePlanMessage(message){
+      return Boolean(catsRuntimePlanSnapshot(message));
+    }
+
+    function isCatsRuntimePlanClearMessage(message){
+      const snapshot=catsRuntimePlanSnapshot(message);
+      return Boolean(snapshot && Array.isArray(snapshot.steps) && snapshot.steps.length===0);
+    }
+
+    function renderCatsRuntimePlan(message){
+      const snapshot=catsRuntimePlanSnapshot(message);
+      const steps=Array.isArray(snapshot?.steps)?snapshot.steps:[];
+      if(!steps.length)return '';
+      const key=catsRuntimePlanKey(message,snapshot);
+      const open=catsRuntimePlanOpenState.has(key)?catsRuntimePlanOpenState.get(key):true;
+      const done=steps.filter(step=>step?.status==='completed').length;
+      const statusLabels={pending:'待处理',in_progress:'进行中',completed:'已完成'};
+      const body=steps.map(step=>{
+        const status=String(step?.status||'pending');
+        const label=statusLabels[status]||status;
+        return '<div class="chat-runtime-plan-step">'+
+          '<span class="chat-runtime-plan-status '+escapeHtml(status)+'">'+escapeHtml(label)+'</span>'+
+          '<span class="chat-runtime-plan-text">'+escapeHtml(step?.text||'')+'</span>'+
+        '</div>';
+      }).join('');
+      return '<details class="chat-runtime-plan" data-plan-key="'+escapeHtml(key)+'" '+(open?'open':'')+' ontoggle="setCatsRuntimePlanOpen(this.dataset.planKey,this.open)">'+
+        '<summary><span class="chat-runtime-plan-chevron">&gt;</span><span>Plan</span><span class="chat-runtime-plan-hint">'+done+'/'+steps.length+' 已完成</span></summary>'+
+        '<div class="chat-runtime-plan-body">'+body+'</div>'+
+      '</details>';
+    }
+
     function isCatsWorkingTextMessage(message){
       const type=message?.type || message?.msg_type || '';
       const content=typeof message?.content==='string'?message.content.trim():'';
@@ -6964,6 +7103,10 @@
     }
 
     function renderCatsMessageBody(message){
+      if(isCatsRuntimePlanMessage(message)){
+        return renderCatsRuntimePlan(message);
+      }
+
       const blocks=Array.isArray(message?.content_blocks)?message.content_blocks:[];
       const textBlocks=[];
       const richBlocks=[];
@@ -7029,6 +7172,7 @@
       let prevSender='';
       let prevTime=0;
       (messages||[]).forEach(message=>{
+        if(isCatsRuntimePlanClearMessage(message))return;
         const from=String(message.from_uid || message.from || '');
         const created=message.created_at?new Date(message.created_at):null;
         const time=created && !Number.isNaN(created.getTime()) ? created.getTime() : Date.now();

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -172,6 +172,14 @@ export class CatsCompanyBot {
           throw err;
         }
       },
+      sendRuntimePlan: async (_targetTopic, snapshot) => {
+        try {
+          await this.sender.sendRuntimePlan(topic, snapshot);
+        } catch (err: any) {
+          Logger.warning(`计划卡片发送失败 (sendRuntimePlan): ${err.message}`);
+          throw err;
+        }
+      },
     };
 
     return channel;

--- a/src/catscompany/message-sender.ts
+++ b/src/catscompany/message-sender.ts
@@ -2,10 +2,11 @@ import { CatsClient, CatsSendError } from './client';
 import * as fs from 'fs';
 import * as path from 'path';
 import { Logger } from '../utils/logger';
+import { RuntimePlanSnapshot } from '../core/plan-runtime';
 
 const MAX_MSG_LENGTH = 4000;
 
-type CatsMessageType = 'thinking' | 'tool_use' | 'tool_result' | 'text' | 'image' | 'file';
+type CatsMessageType = 'thinking' | 'tool_use' | 'tool_result' | 'runtime_plan' | 'text' | 'image' | 'file';
 
 interface CatsSendBody {
   topic_id: string;
@@ -173,6 +174,15 @@ export class MessageSender {
       is_error: isError,
     });
     Logger.info(`Tool result 已发送: tool_use_id=${toolUseId}`);
+  }
+
+  async sendRuntimePlan(topic: string, snapshot: RuntimePlanSnapshot): Promise<void> {
+    await this.send(topic, 'runtime_plan', snapshot, {
+      runtime_plan: true,
+      revision: snapshot.revision,
+      cleared: snapshot.steps.length === 0,
+    });
+    Logger.info(`Runtime plan 已发送: revision=${snapshot.revision}, steps=${snapshot.steps.length}`);
   }
 
   async sendText(topic: string, text: string): Promise<void> {

--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -23,6 +23,7 @@ import { TurnLogRecorder } from './turn-log-recorder';
 import { TurnContextBuilder } from './turn-context-builder';
 import { AgentTurnController } from './agent-turn-controller';
 import { SessionLifecycleManager } from './session-lifecycle-manager';
+import { PlanRuntime } from './plan-runtime';
 import type { PendingUserInputProvider } from './conversation-runner';
 
 export type { RuntimeFeedbackInput, RuntimeFeedbackOptions } from './runtime-feedback-inbox';
@@ -104,6 +105,7 @@ export class AgentSession {
   private contextWindowManager: ContextWindowManager;
   private skillRuntime: SessionSkillRuntime;
   private runtimeFeedbackInbox = new RuntimeFeedbackInbox();
+  private planRuntime = new PlanRuntime();
   private lifecycleManager: SessionLifecycleManager;
   private readonly defaultDirectory: string;
   private currentDirectory: string;
@@ -129,6 +131,7 @@ export class AgentSession {
       sessionType,
       services,
       skillRuntime: this.skillRuntime,
+      planRuntime: this.planRuntime,
       turnContextBuilder: this.turnContextBuilder,
       turnLogRecorder: this.turnLogRecorder,
       workspaceRoot: this.defaultDirectory,
@@ -364,6 +367,7 @@ export class AgentSession {
 
         return { text: errorReply, visibleToUser: true };
       } finally {
+        this.planRuntime.clear();
         this.busy = false;
       }
     });
@@ -424,6 +428,7 @@ export class AgentSession {
 
   /** 重置会话状态（仅清内存，保留历史文件） */
   reset(): void {
+    this.planRuntime.clear();
     this.messages = [];
     this.resetCurrentDirectory();
     const state = this.lifecycleManager.reset();
@@ -433,6 +438,7 @@ export class AgentSession {
 
   /** 清空历史（同时删除文件） */
   clear(): void {
+    this.planRuntime.clear();
     this.messages = [];
     const state = this.lifecycleManager.clear();
     this.resetCurrentDirectory();
@@ -442,6 +448,7 @@ export class AgentSession {
 
   async summarizeAndDestroy(): Promise<boolean> {
     return this.withLogContext(async () => {
+      this.planRuntime.clear();
       if (this.messages.length === 0) return false;
       this.messages = [];
       return true;

--- a/src/core/agent-turn-controller.ts
+++ b/src/core/agent-turn-controller.ts
@@ -10,6 +10,7 @@ import { ConversationRunner, RunnerCallbacks, PendingUserInputProvider } from '.
 import { resolveSessionSurface } from './session-surface';
 import { TurnContextBuilder } from './turn-context-builder';
 import { TurnLogRecorder } from './turn-log-recorder';
+import { PlanRuntime } from './plan-runtime';
 
 export interface AgentTurnServices {
   aiService: AIService;
@@ -48,6 +49,7 @@ export interface AgentTurnControllerOptions {
   sessionType?: string;
   services: AgentTurnServices;
   skillRuntime: SessionSkillRuntime;
+  planRuntime: PlanRuntime;
   turnContextBuilder: TurnContextBuilder;
   turnLogRecorder: TurnLogRecorder;
   workspaceRoot: string;
@@ -69,6 +71,7 @@ export class AgentTurnController {
       durableMessages: params.messages,
       runtimeFeedback: params.runtimeFeedback,
       skillRuntime: this.options.skillRuntime,
+      planRuntime: this.options.planRuntime,
     });
 
     const runner = this.createRunner({
@@ -123,6 +126,7 @@ export class AgentTurnController {
           workingDirectory: this.options.getCurrentDirectory(),
           getCurrentDirectory: this.options.getCurrentDirectory,
           updateCurrentDirectory: this.options.updateCurrentDirectory,
+          planRuntime: this.options.planRuntime,
           channel: options.channel,
         },
       },

--- a/src/core/plan-runtime.ts
+++ b/src/core/plan-runtime.ts
@@ -1,0 +1,96 @@
+export type PlanStepStatus = 'pending' | 'in_progress' | 'completed';
+
+export interface RuntimePlanStep {
+  text: string;
+  status: PlanStepStatus;
+}
+
+export interface RuntimePlanSnapshot {
+  revision: number;
+  updatedAt: number;
+  steps: RuntimePlanStep[];
+}
+
+export interface UpdatePlanInput {
+  steps?: RuntimePlanStep[];
+  clear?: boolean;
+}
+
+const VALID_STATUSES = new Set<PlanStepStatus>(['pending', 'in_progress', 'completed']);
+
+export class PlanRuntime {
+  private revision = 0;
+  private updatedAt = 0;
+  private steps: RuntimePlanStep[] = [];
+
+  update(input: UpdatePlanInput): RuntimePlanSnapshot {
+    if (input.clear) {
+      return this.clear();
+    }
+
+    const steps = normalizeSteps(input.steps);
+
+    this.steps = steps;
+    this.revision += 1;
+    this.updatedAt = Date.now();
+    return this.getSnapshot();
+  }
+
+  clear(): RuntimePlanSnapshot {
+    this.steps = [];
+    this.revision += 1;
+    this.updatedAt = Date.now();
+    return this.getSnapshot();
+  }
+
+  getSnapshot(): RuntimePlanSnapshot {
+    return {
+      revision: this.revision,
+      updatedAt: this.updatedAt,
+      steps: this.steps.map(step => ({ ...step })),
+    };
+  }
+
+  hasPlan(): boolean {
+    return this.steps.length > 0;
+  }
+
+  formatForPrompt(): string | undefined {
+    if (this.steps.length === 0) return undefined;
+    const lines = this.steps.map((step, index) => {
+      const marker = step.status === 'completed'
+        ? '[completed]'
+        : step.status === 'in_progress'
+          ? '[in_progress]'
+          : '[pending]';
+      return `${index + 1}. ${marker} ${step.text}`;
+    });
+    return [
+      '当前运行时计划：',
+      ...lines,
+      '',
+      '这是当前任务的临时计划状态，不是用户的新需求。继续推进时请保持计划准确；小任务不需要维护计划。',
+    ].join('\n');
+  }
+}
+
+function normalizeSteps(rawSteps: RuntimePlanStep[] | undefined): RuntimePlanStep[] {
+  if (!Array.isArray(rawSteps) || rawSteps.length === 0) {
+    throw new Error('update_plan 需要提供非空 steps 数组，或设置 clear=true');
+  }
+
+  return rawSteps.map((raw, index) => {
+    const text = String(raw?.text || '').trim();
+    const status = String(raw?.status || 'pending') as PlanStepStatus;
+    if (!text) {
+      throw new Error(`第 ${index + 1} 个计划步骤缺少 text`);
+    }
+    if (!VALID_STATUSES.has(status)) {
+      throw new Error(`第 ${index + 1} 个计划步骤 status 无效：${status}`);
+    }
+    return {
+      text,
+      status,
+    };
+  });
+}

--- a/src/core/turn-context-builder.ts
+++ b/src/core/turn-context-builder.ts
@@ -5,8 +5,10 @@ import {
 } from '../skills/session-skill-runtime';
 import { isRuntimeFeedbackContent } from './runtime-feedback';
 import { SubAgentManager } from './sub-agent-manager';
+import { PlanRuntime } from './plan-runtime';
 
 const TRANSIENT_SUBAGENT_STATUS_PREFIX = '[transient_subagent_status]';
+const TRANSIENT_PLAN_STATUS_PREFIX = '[transient_plan_status]';
 const TRANSIENT_RUNNER_HINT_PREFIX = '[transient_runner_hint]';
 const TRANSIENT_SOFT_CHECK_PREFIX = '[transient_soft_check]';
 
@@ -15,6 +17,7 @@ export interface BuildTurnContextParams {
   durableMessages: Message[];
   runtimeFeedback: string[];
   skillRuntime: SessionSkillRuntime;
+  planRuntime?: PlanRuntime;
 }
 
 export interface BuildTurnContextResult {
@@ -31,6 +34,7 @@ export class TurnContextBuilder {
   async build(params: BuildTurnContextParams): Promise<BuildTurnContextResult> {
     const contextMessages = [...params.durableMessages];
     this.injectRuntimeFeedback(contextMessages, params.runtimeFeedback);
+    this.injectPlanStatus(contextMessages, params.planRuntime);
     this.injectSubAgentStatus(contextMessages, params.sessionKey);
 
     await params.skillRuntime.reloadSkills();
@@ -50,6 +54,7 @@ export class TurnContextBuilder {
       if (msg.__runtimeFeedback) return false;
       if (msg.role !== 'system' || typeof msg.content !== 'string') return true;
       if (msg.content.startsWith(TRANSIENT_SUBAGENT_STATUS_PREFIX)) return false;
+      if (msg.content.startsWith(TRANSIENT_PLAN_STATUS_PREFIX)) return false;
       if (msg.content.startsWith(TRANSIENT_RUNNER_HINT_PREFIX)) return false;
       if (msg.content.startsWith(TRANSIENT_SOFT_CHECK_PREFIX)) return false;
       if (msg.content.startsWith(TRANSIENT_SKILLS_LIST_PREFIX)) return false;
@@ -67,6 +72,15 @@ export class TurnContextBuilder {
       __runtimeFeedback: true,
     }));
     this.insertBeforeLastUser(messages, ...runtimeFeedbackMessages);
+  }
+
+  private injectPlanStatus(messages: Message[], planRuntime?: PlanRuntime): void {
+    const planText = planRuntime?.formatForPrompt();
+    if (!planText) return;
+    this.insertBeforeLastUser(messages, {
+      role: 'system',
+      content: `${TRANSIENT_PLAN_STATUS_PREFIX}\n${planText}`,
+    });
   }
 
   private injectSubAgentStatus(messages: Message[], sessionKey: string): void {

--- a/src/tools/default-tool-names.ts
+++ b/src/tools/default-tool-names.ts
@@ -12,6 +12,8 @@ export const DEFAULT_TOOL_NAMES = [
   'check_subagent',
   'stop_subagent',
   'resume_subagent',
+  'update_plan',
+  'record_decision',
   'skill',
 ] as const;
 

--- a/src/tools/record-decision-tool.ts
+++ b/src/tools/record-decision-tool.ts
@@ -1,0 +1,98 @@
+import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
+import { Logger } from '../utils/logger';
+
+function normalizeText(value: unknown, maxLength = 700): string {
+  const text = String(value || '').replace(/\s+/g, ' ').trim();
+  if (text.length <= maxLength) return text;
+  return `${text.slice(0, maxLength)}...`;
+}
+
+function normalizeList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map(item => normalizeText(item, 180))
+    .filter(Boolean)
+    .slice(0, 8);
+}
+
+/**
+ * Runtime-only decision log.
+ *
+ * This is intentionally not a user-facing message and uses transcriptMode=suppress
+ * so the note does not bloat durable conversation context.
+ */
+export class RecordDecisionTool implements Tool {
+  definition: ToolDefinition = {
+    name: 'record_decision',
+    description: [
+      '把当前简短行动决策写入日志，不发送给用户，成功结果不进入后续 transcript。',
+      '只在复杂任务关键转折点使用；简单任务不要用。写工程摘要，不写隐藏推理链。',
+    ].join('\n'),
+    transcriptMode: 'suppress',
+    parameters: {
+      type: 'object',
+      properties: {
+        summary: {
+          type: 'string',
+          description: '一句话概括当前决策，例如“这轮先用 plan 展示路线，并把设置页和子 agent 链路拆出去并行检查”。',
+        },
+        reason: {
+          type: 'string',
+          description: '简短说明为什么这样做；不需要展开完整推理。',
+        },
+        plan_decision: {
+          type: 'string',
+          enum: ['use_plan', 'skip_plan', 'update_later', 'not_applicable'],
+          description: '本轮对 update_plan 的判断。',
+        },
+        subagent_decision: {
+          type: 'string',
+          enum: ['spawn_now', 'skip_subagent', 'maybe_later', 'not_applicable'],
+          description: '本轮对子 agent 的判断。',
+        },
+        task_split: {
+          type: 'array',
+          items: { type: 'string' },
+          description: '如果有任务拆分，列出主线和子任务分工；没有拆分时可省略。',
+        },
+        next_action: {
+          type: 'string',
+          description: '下一步准备做什么。',
+        },
+      },
+      required: ['summary'],
+    },
+  };
+
+  async execute(args: any, _context: ToolExecutionContext): Promise<ToolExecutionResult> {
+    const summary = normalizeText(args?.summary);
+    if (!summary) {
+      return {
+        ok: false,
+        errorCode: 'INVALID_TOOL_ARGUMENTS',
+        message: 'summary 不能为空',
+      };
+    }
+
+    const parts = [`summary=${summary}`];
+    const reason = normalizeText(args?.reason);
+    if (reason) parts.push(`reason=${reason}`);
+
+    const planDecision = normalizeText(args?.plan_decision, 80);
+    if (planDecision) parts.push(`plan=${planDecision}`);
+
+    const subagentDecision = normalizeText(args?.subagent_decision, 80);
+    if (subagentDecision) parts.push(`subagent=${subagentDecision}`);
+
+    const taskSplit = normalizeList(args?.task_split);
+    if (taskSplit.length > 0) {
+      parts.push(`split=${taskSplit.map((item, index) => `${index + 1}. ${item}`).join(' | ')}`);
+    }
+
+    const nextAction = normalizeText(args?.next_action);
+    if (nextAction) parts.push(`next=${nextAction}`);
+
+    Logger.info(`[decision] ${parts.join(' ; ')}`);
+    return { ok: true, content: '决策说明已记录到日志' };
+  }
+}

--- a/src/tools/tool-manager.ts
+++ b/src/tools/tool-manager.ts
@@ -14,6 +14,8 @@ import { SpawnSubagentTool } from './spawn-subagent-tool';
 import { CheckSubagentTool } from './check-subagent-tool';
 import { StopSubagentTool } from './stop-subagent-tool';
 import { ResumeSubagentTool } from './resume-subagent-tool';
+import { UpdatePlanTool } from './update-plan-tool';
+import { RecordDecisionTool } from './record-decision-tool';
 import { DEFAULT_TOOL_NAMES } from './default-tool-names';
 
 /**
@@ -82,6 +84,8 @@ export class ToolManager implements ToolExecutor {
       new CheckSubagentTool(),
       new StopSubagentTool(),
       new ResumeSubagentTool(),
+      new UpdatePlanTool(),
+      new RecordDecisionTool(),
       new SkillTool(),
     ];
 

--- a/src/tools/update-plan-tool.ts
+++ b/src/tools/update-plan-tool.ts
@@ -1,0 +1,111 @@
+import { PlanStepStatus, RuntimePlanSnapshot } from '../core/plan-runtime';
+import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
+
+const STATUS_LABELS: Record<PlanStepStatus, string> = {
+  pending: '待处理',
+  in_progress: '进行中',
+  completed: '已完成',
+};
+
+export class UpdatePlanTool implements Tool {
+  definition: ToolDefinition = {
+    name: 'update_plan',
+    description: [
+      '维护当前任务的临时运行时计划。只在复杂、多阶段、跨文件修改、实现加验证或多子 agent 编排时使用。',
+      '每次调用都提交完整 steps 列表；状态只能是 pending/in_progress/completed。计划是临时 UI，不是长期历史。',
+      '在普通回复或代码块里写计划清单不会更新计划卡片；需要让用户看到运行时计划时，必须调用本工具。',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        steps: {
+          type: 'array',
+          description: '完整计划步骤列表。每次更新都传完整列表，而不是只传变化项。',
+          items: {
+            type: 'object',
+            properties: {
+              text: {
+                type: 'string',
+                description: '步骤内容，简短具体。',
+              },
+              status: {
+                type: 'string',
+                enum: ['pending', 'in_progress', 'completed'],
+                description: '步骤状态。',
+              },
+            },
+            required: ['text', 'status'],
+          },
+        },
+        clear: {
+          type: 'boolean',
+          description: '清空当前临时计划。通常只有任务取消、重置或明确不再需要计划时使用。',
+        },
+      },
+      required: [],
+    },
+  };
+
+  async execute(args: any, context: ToolExecutionContext): Promise<ToolExecutionResult> {
+    if (!context.planRuntime) {
+      return {
+        ok: false,
+        errorCode: 'TOOL_EXECUTION_ERROR',
+        message: 'update_plan 当前会话没有可用的 plan runtime。',
+      };
+    }
+
+    let snapshot: RuntimePlanSnapshot;
+    try {
+      snapshot = context.planRuntime.update({
+        steps: normalizeInputSteps(args?.steps),
+        clear: Boolean(args?.clear),
+      });
+    } catch (error: any) {
+      return {
+        ok: false,
+        errorCode: 'INVALID_TOOL_ARGUMENTS',
+        message: `计划更新失败：${error.message}`,
+      };
+    }
+
+    let planUiWarning = '';
+    if (context.channel?.sendRuntimePlan) {
+      try {
+        await context.channel.sendRuntimePlan(context.channel.chatId, snapshot);
+      } catch (error: any) {
+        planUiWarning = `\n注意：计划已更新，但计划卡片推送失败：${error.message}`;
+      }
+    }
+
+    return {
+      ok: true,
+      content: `${formatPlanResult(snapshot)}${planUiWarning}`,
+    };
+  }
+}
+
+function normalizeInputSteps(value: unknown): Array<{ text: string; status: PlanStepStatus }> | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (!Array.isArray(value)) {
+    throw new Error('steps 必须是数组');
+  }
+  return value.map(step => ({
+    text: String(step?.text || ''),
+    status: String(step?.status || 'pending') as PlanStepStatus,
+  }));
+}
+
+function formatPlanResult(snapshot: RuntimePlanSnapshot): string {
+  if (snapshot.steps.length === 0) {
+    return '计划已清空';
+  }
+  const completed = snapshot.steps.filter(step => step.status === 'completed').length;
+  const active = snapshot.steps.filter(step => step.status === 'in_progress');
+  const lines = snapshot.steps.map((step, index) => `${index + 1}. ${STATUS_LABELS[step.status]} - ${step.text}`);
+  return [
+    `计划已更新：${completed}/${snapshot.steps.length} 已完成`,
+    active.length > 0 ? `进行中：${active.map(step => step.text).join('；')}` : '',
+    ...lines,
+  ].filter(Boolean).join('\n');
+}

--- a/src/types/tool.ts
+++ b/src/types/tool.ts
@@ -1,4 +1,5 @@
 import { ContentBlock } from './index';
+import type { PlanRuntime, RuntimePlanSnapshot } from '../core/plan-runtime';
 
 /**
  * 工具参数定义
@@ -103,6 +104,8 @@ export interface ChannelCallbacks {
   reply: (chatId: string, text: string) => Promise<void>;
   /** 发送文件 */
   sendFile: (chatId: string, filePath: string, fileName: string) => Promise<void>;
+  /** 发送临时运行时计划。支持实时 UI 的 surface 可实现为卡片展示。 */
+  sendRuntimePlan?: (chatId: string, snapshot: RuntimePlanSnapshot) => Promise<void>;
 }
 
 /** @deprecated Use ChannelCallbacks instead */
@@ -122,6 +125,7 @@ export interface ToolExecutionContext {
   permissionProfile?: ToolPermissionProfile;
   runId?: string;
   abortSignal?: AbortSignal;
+  planRuntime?: PlanRuntime;
   getCurrentDirectory?: () => string;
   updateCurrentDirectory?: (directory: string) => void;
   /** 平台通道回调（飞书/CatsCompany 等聊天会话时由平台层注入） */

--- a/tests/plan-runtime.test.ts
+++ b/tests/plan-runtime.test.ts
@@ -1,0 +1,137 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import { PlanRuntime } from '../src/core/plan-runtime';
+import { ToolManager } from '../src/tools/tool-manager';
+
+describe('PlanRuntime', () => {
+  test('updates and formats a runtime plan', () => {
+    const runtime = new PlanRuntime();
+
+    const snapshot = runtime.update({
+      steps: [
+        { text: '检查链路', status: 'completed' },
+        { text: '实现计划工具', status: 'in_progress' },
+        { text: '跑测试', status: 'pending' },
+      ],
+    });
+
+    assert.equal(snapshot.steps.length, 3);
+    assert.equal(snapshot.steps[1].status, 'in_progress');
+    assert.match(runtime.formatForPrompt() || '', /\[in_progress\] 实现计划工具/);
+  });
+
+  test('allows multiple in-progress steps for parallel work', () => {
+    const runtime = new PlanRuntime();
+
+    const snapshot = runtime.update({
+      steps: [
+        { text: 'A', status: 'in_progress' },
+        { text: 'B', status: 'in_progress' },
+      ],
+    });
+
+    assert.equal(snapshot.steps.length, 2);
+    assert.equal(snapshot.steps.filter(step => step.status === 'in_progress').length, 2);
+  });
+
+  test('allows larger plans when the model decides they are useful', () => {
+    const runtime = new PlanRuntime();
+
+    const snapshot = runtime.update({
+      steps: Array.from({ length: 15 }, (_, index) => ({
+        text: `步骤 ${index + 1}`,
+        status: index < 3 ? 'in_progress' : 'pending',
+      })),
+    });
+
+    assert.equal(snapshot.steps.length, 15);
+    assert.equal(snapshot.steps[2].status, 'in_progress');
+  });
+
+  test('keeps long plan steps intact instead of silently truncating them', () => {
+    const runtime = new PlanRuntime();
+    const longStep = '梳理运行时计划、子 agent 唤醒、停止取消、事件存储和多平台展示之间的完整链路，并标注每个入口、状态转换、边界条件与测试缺口。'.repeat(4);
+
+    const snapshot = runtime.update({
+      steps: [
+        { text: longStep, status: 'in_progress' },
+      ],
+    });
+
+    assert.equal(snapshot.steps[0].text, longStep);
+  });
+
+  test('update_plan tool updates runtime and emits CatsCompany runtime plan event', async () => {
+    const runtime = new PlanRuntime();
+    const sent: any[] = [];
+    const manager = new ToolManager('/tmp/xiaoba-plan-runtime', {}, {
+      enabledToolNames: ['update_plan'],
+    });
+
+    const result = await manager.executeTool({
+      id: 'call-plan',
+      type: 'function',
+      function: {
+        name: 'update_plan',
+        arguments: JSON.stringify({
+          steps: [
+            { text: '确认需求', status: 'completed' },
+            { text: '实现 runtime', status: 'in_progress' },
+          ],
+        }),
+      },
+    }, [], {
+      planRuntime: runtime,
+      channel: {
+        chatId: 'topic-1',
+        reply: async () => {},
+        sendFile: async () => {},
+        sendRuntimePlan: async (chatId, snapshot) => {
+          sent.push({ chatId, snapshot });
+        },
+      },
+    });
+
+    assert.equal(result.ok, true);
+    assert.match(result.content as string, /计划已更新/);
+    assert.equal(runtime.getSnapshot().steps.length, 2);
+    assert.equal(sent.length, 1);
+    assert.equal(sent[0].chatId, 'topic-1');
+    assert.equal(sent[0].snapshot.steps[1].status, 'in_progress');
+  });
+
+  test('update_plan keeps runtime update when UI card push fails', async () => {
+    const runtime = new PlanRuntime();
+    const manager = new ToolManager('/tmp/xiaoba-plan-runtime', {}, {
+      enabledToolNames: ['update_plan'],
+    });
+
+    const result = await manager.executeTool({
+      id: 'call-plan-fail-ui',
+      type: 'function',
+      function: {
+        name: 'update_plan',
+        arguments: JSON.stringify({
+          steps: [
+            { text: '先更新内存计划', status: 'in_progress' },
+          ],
+        }),
+      },
+    }, [], {
+      planRuntime: runtime,
+      channel: {
+        chatId: 'topic-1',
+        reply: async () => {},
+        sendFile: async () => {},
+        sendRuntimePlan: async () => {
+          throw new Error('ui offline');
+        },
+      },
+    });
+
+    assert.equal(result.ok, true);
+    assert.match(result.content as string, /计划已更新/);
+    assert.match(result.content as string, /计划卡片推送失败/);
+    assert.equal(runtime.getSnapshot().steps[0].text, '先更新内存计划');
+  });
+});

--- a/tests/runtime-characterization.test.ts
+++ b/tests/runtime-characterization.test.ts
@@ -62,6 +62,7 @@ describe('runtime characterization', () => {
         'glob',
         'grep',
         'read_file',
+        'record_decision',
         'resume_subagent',
         'send_file',
         'send_text',
@@ -69,6 +70,7 @@ describe('runtime characterization', () => {
         'skill',
         'spawn_subagent',
         'stop_subagent',
+        'update_plan',
         'write_file',
       ],
     );


### PR DESCRIPTION
## 背景

这是原异步子 agent 大 PR 拆出的第二步：只引入运行时计划能力和 CatsCo 计划卡片，不混入子 agent runtime 大改。

## 改动内容

- 新增 `PlanRuntime`，维护当前任务的临时计划状态。
- 新增 `update_plan` 工具：模型需要展示或更新任务计划时调用。
- 新增 `record_decision` 工具：复杂任务关键节点可把简短决策写到日志，不发送给用户，避免污染对话。
- 将 `planRuntime` 注入 `ToolExecutionContext` 和 turn context，使模型下一轮能看到当前临时计划。
- CatsCompany/CatsCo 通道增加 `sendRuntimePlan`，桌面聊天支持独立可折叠 Plan 卡片。
- 计划卡片与 WORKING 分开展示；空 plan 不渲染空气泡。
- `update_plan` 内存更新和 UI 推送解耦：UI 推送失败时不回滚 runtime 计划，只在工具结果里给出警告。
- `AgentSession` 每轮结束后清空临时计划，避免旧 plan 污染下一次用户请求。

## 设计说明

Plan 是当前 work episode 的临时 UI 状态，不是长期记忆，也不是普通用户消息。普通文本里写计划不会更新计划卡片，模型需要展示计划时应该调用 `update_plan`。

## 验证

- `npm.cmd run build`
- `node --import tsx --test tests/plan-runtime.test.ts tests/runtime-characterization.test.ts tests/tool-manager.test.ts`
- `git diff --check`（仅 CRLF warning）