### PR TITLE
补齐子智能体运行时边界

### DIFF
--- a/src/agents/agent-tool-executor.ts
+++ b/src/agents/agent-tool-executor.ts
@@ -1,4 +1,5 @@
 import { Tool, ToolDefinition, ToolCall, ToolResult, ToolExecutionContext, ToolExecutor, ToolExecutionResult } from '../types/tool';
+import { mergeToolExecutionContext } from '../utils/tool-context';
 
 const TOOL_NAME_ALIASES: Record<string, string> = {
   Bash: 'execute_shell',
@@ -49,13 +50,12 @@ export class AgentToolExecutor implements ToolExecutor {
     }
 
     try {
-      const mergedContext: Partial<ToolExecutionContext> = {
+      const mergedContext = mergeToolExecutionContext({
         workingDirectory: this.workingDirectory,
         workspaceRoot: this.workingDirectory,
         conversationHistory: conversationHistory || [],
         ...this.contextDefaults,
-        ...contextOverrides,
-      };
+      }, contextOverrides);
       const context: ToolExecutionContext = {
         ...mergedContext,
         workingDirectory: mergedContext.getCurrentDirectory?.() || mergedContext.workingDirectory || this.workingDirectory,

--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -24,6 +24,7 @@ import { TurnContextBuilder } from './turn-context-builder';
 import { AgentTurnController } from './agent-turn-controller';
 import { SessionLifecycleManager } from './session-lifecycle-manager';
 import { PlanRuntime } from './plan-runtime';
+import { SubAgentManager } from './sub-agent-manager';
 import type { PendingUserInputProvider } from './conversation-runner';
 
 export type { RuntimeFeedbackInput, RuntimeFeedbackOptions } from './runtime-feedback-inbox';
@@ -77,6 +78,11 @@ export interface HandleMessageResult {
   newMessages?: import('../types').Message[];
 }
 
+export interface SessionCleanupOptions {
+  stopSubAgents?: boolean;
+  subAgentStopReason?: string;
+}
+
 // ─── AgentSession 核心类 ────────────────────────────────
 
 /**
@@ -97,6 +103,7 @@ export class AgentSession {
   private systemPromptOverride?: SystemPromptProvider;
   /** 外部请求中断当前 run（例如用户在 busy 时发送"停止"） */
   private interruptRequested = false;
+  private activeAbortController: AbortController | null = null;
   lastActiveAt: number = Date.now();
   private sessionTurnLogger: SessionTurnLogger;
   private turnLogRecorder: TurnLogRecorder;
@@ -138,6 +145,21 @@ export class AgentSession {
       getCurrentDirectory: () => this.currentDirectory,
       updateCurrentDirectory: directory => this.updateCurrentDirectory(directory),
     });
+
+    const runtimeFeedbackInbox = this.runtimeFeedbackInbox;
+    const subAgentManager = SubAgentManager.getInstance();
+    subAgentManager.registerPlatformCallbacks(key, {
+      injectMessage: async (text: string) => {
+        runtimeFeedbackInbox.enqueue('subagent_feedback', text, {
+          maxLength: 2400,
+        });
+      },
+    });
+    if (typeof (subAgentManager as any).registerEventLogger === 'function') {
+      subAgentManager.registerEventLogger(key, (event, info) => {
+        this.sessionTurnLogger.logSubAgentEvent(event, info);
+      });
+    }
   }
 
   private resolveDefaultDirectory(): string {
@@ -322,6 +344,7 @@ export class AgentSession {
 
       this.busy = true;
       this.interruptRequested = false;
+      this.activeAbortController = new AbortController();
       this.lastActiveAt = Date.now();
 
       this.messages = await this.contextWindowManager.compactIfNeeded(this.messages, {
@@ -338,6 +361,7 @@ export class AgentSession {
           callbacks,
           channel,
           pendingUserInputProvider,
+          abortSignal: this.activeAbortController.signal,
           shouldContinue: () => !this.interruptRequested,
         });
         this.messages = result.messages;
@@ -369,6 +393,7 @@ export class AgentSession {
       } finally {
         this.planRuntime.clear();
         this.busy = false;
+        this.activeAbortController = null;
       }
     });
   }
@@ -429,6 +454,7 @@ export class AgentSession {
   /** 重置会话状态（仅清内存，保留历史文件） */
   reset(): void {
     this.planRuntime.clear();
+    this.stopSubAgents('父会话 reset');
     this.messages = [];
     this.resetCurrentDirectory();
     const state = this.lifecycleManager.reset();
@@ -439,6 +465,7 @@ export class AgentSession {
   /** 清空历史（同时删除文件） */
   clear(): void {
     this.planRuntime.clear();
+    this.stopSubAgents('父会话 clear');
     this.messages = [];
     const state = this.lifecycleManager.clear();
     this.resetCurrentDirectory();
@@ -449,6 +476,7 @@ export class AgentSession {
   async summarizeAndDestroy(): Promise<boolean> {
     return this.withLogContext(async () => {
       this.planRuntime.clear();
+      this.stopSubAgents('父会话退出');
       if (this.messages.length === 0) return false;
       this.messages = [];
       return true;
@@ -456,8 +484,16 @@ export class AgentSession {
   }
 
   /** 过期或退出时清理内存（保存完整 context） */
-  async cleanup(): Promise<void> {
+  async cleanup(options: SessionCleanupOptions = {}): Promise<void> {
     return this.withLogContext(async () => {
+      if (options.stopSubAgents) {
+        this.stopSubAgents(options.subAgentStopReason || '父会话清理');
+      }
+      const subAgentManager = SubAgentManager.getInstance();
+      if (typeof (subAgentManager as any).unregisterEventLogger === 'function') {
+        subAgentManager.unregisterEventLogger(this.key);
+      }
+      subAgentManager.unregisterPlatformCallbacks(this.key);
       if (this.messages.length === 0) return;
 
       try {
@@ -480,8 +516,10 @@ export class AgentSession {
 
   /** 请求中断当前运行中的对话回合 */
   requestInterrupt(): void {
+    this.stopSubAgents('用户请求中止');
     if (!this.busy) return;
     this.interruptRequested = true;
+    this.activeAbortController?.abort();
   }
 
   /** 从 DB 恢复消息（进程重启后调用） */
@@ -495,6 +533,13 @@ export class AgentSession {
 
   private consumeRuntimeFeedback(inputs: RuntimeFeedbackInput[] = []): string[] {
     return this.runtimeFeedbackInbox.consume(inputs);
+  }
+
+  private stopSubAgents(reason: string): void {
+    const result = SubAgentManager.getInstance().stopAllForParent(this.key, reason);
+    if (result.stopped > 0) {
+      Logger.info(`[会话 ${this.key}] ${reason}，已停止 ${result.stopped} 个后台子任务`);
+    }
   }
 
   private enforceInjectedContextLimit(): void {

--- a/src/core/agent-turn-controller.ts
+++ b/src/core/agent-turn-controller.ts
@@ -34,6 +34,7 @@ export interface RunAgentTurnParams {
   callbacks?: AgentTurnCallbacks;
   channel?: ChannelCallbacks;
   pendingUserInputProvider?: PendingUserInputProvider;
+  abortSignal?: AbortSignal;
   shouldContinue: () => boolean;
 }
 
@@ -77,6 +78,7 @@ export class AgentTurnController {
     const runner = this.createRunner({
       channel: params.channel,
       pendingUserInputProvider: params.pendingUserInputProvider,
+      abortSignal: params.abortSignal,
       shouldContinue: params.shouldContinue,
     });
 
@@ -106,6 +108,7 @@ export class AgentTurnController {
   private createRunner(options: {
     channel?: ChannelCallbacks;
     pendingUserInputProvider?: PendingUserInputProvider;
+    abortSignal?: AbortSignal;
     shouldContinue: () => boolean;
   }): ConversationRunner {
     const surface = resolveSessionSurface(this.options.sessionKey, this.options.sessionType);
@@ -127,6 +130,11 @@ export class AgentTurnController {
           getCurrentDirectory: this.options.getCurrentDirectory,
           updateCurrentDirectory: this.options.updateCurrentDirectory,
           planRuntime: this.options.planRuntime,
+          runtimeServices: {
+            aiService: this.options.services.aiService,
+            skillManager: this.options.services.skillManager,
+          },
+          abortSignal: options.abortSignal,
           channel: options.channel,
         },
       },
@@ -136,6 +144,7 @@ export class AgentTurnController {
   private toRunnerCallbacks(callbacks?: AgentTurnCallbacks): RunnerCallbacks {
     return {
       onText: callbacks?.onText,
+      onThinking: callbacks?.onThinking,
       onToolStart: callbacks?.onToolStart,
       onToolEnd: callbacks?.onToolEnd,
       onToolDisplay: callbacks?.onToolDisplay,

--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -84,6 +84,8 @@ interface ToolExecutionRecord {
 
 /** ConversationRunner 构造选项 */
 export interface RunnerOptions {
+  /** Optional safety cap for autonomous tool loops. Undefined means no runner-level cap. */
+  maxTurns?: number;
   maxContextTokens?: number;
   /** false 时用 aiService.chat() 代替 chatStream()（默认 true） */
   stream?: boolean;
@@ -110,6 +112,7 @@ export class ConversationRunner {
   private enableCompression: boolean;
   private toolExecutionContext?: Partial<ToolExecutionContext>;
   private maxPromptTokens: number;
+  private maxTurns?: number;
   private sessionLabel: string;
   private pendingUserInputProvider?: PendingUserInputProvider;
 
@@ -134,6 +137,7 @@ export class ConversationRunner {
     this.enableCompression = options?.enableCompression ?? true;
     this.toolExecutionContext = options?.toolExecutionContext;
     this.pendingUserInputProvider = options?.pendingUserInputProvider;
+    this.maxTurns = options?.maxTurns;
 
     this.maxPromptTokens = this.resolvePromptBudget(options?.maxContextTokens);
     this.sessionLabel = this.toolExecutionContext?.sessionId
@@ -166,6 +170,15 @@ export class ConversationRunner {
       turns++;
       if (this.shouldContinue && !this.shouldContinue()) {
         break;
+      }
+      if (this.maxTurns && turns > this.maxTurns) {
+        Logger.warning(`[${this.sessionLabel}] 已达到最大推理轮次 ${this.maxTurns}，正在收束`);
+        return {
+          response: `已达到本次后台任务的轮次预算（${this.maxTurns} 轮），我先基于已完成的信息收束。`,
+          finalResponseVisible: true,
+          messages,
+          newMessages,
+        };
       }
 
       if (this.enableCompression) {

--- a/src/core/message-session-manager.ts
+++ b/src/core/message-session-manager.ts
@@ -1,6 +1,7 @@
 import { AgentSession, AgentServices, SystemPromptProvider } from './agent-session';
 import { Logger } from '../utils/logger';
 import { composeSessionSystemPromptProvider } from './session-system-prompt';
+import { SubAgentManager } from './sub-agent-manager';
 
 /** 默认会话过期时间：60 分钟 */
 const DEFAULT_SESSION_TTL = 60 * 60 * 1000;
@@ -49,6 +50,15 @@ export class MessageSessionManager {
 
   static getManager(sessionType: string): MessageSessionManager | null {
     return this.managers.get(sessionType) || null;
+  }
+
+  /** 获取已存在的会话；不会因为查询而新建会话 */
+  get(key: string): AgentSession | null {
+    const session = this.sessions.get(key) || null;
+    if (session) {
+      session.lastActiveAt = Date.now();
+    }
+    return session;
   }
 
   /** 设置上下文注入器，新建 session 时自动调用 */
@@ -102,12 +112,20 @@ export class MessageSessionManager {
     for (const [key, session] of this.sessions) {
       if (this.destroying.has(key)) continue;
       if (now - session.lastActiveAt <= this.ttl) continue;
+      if (SubAgentManager.getInstance().hasActiveForParent(key)) {
+        session.lastActiveAt = now;
+        session.runWithLogContext(() => Logger.info(`会话仍有后台子任务运行，跳过过期清理: ${key}`));
+        continue;
+      }
 
       this.destroying.add(key);
       this.sessions.delete(key);
       session.runWithLogContext(() => Logger.info(`会话已过期清理: ${key}`));
       cleanupPromises.push(
-        session.cleanup()
+        session.cleanup({
+          stopSubAgents: true,
+          subAgentStopReason: '父会话过期清理',
+        })
           .catch(err => session.runWithLogContext(() => Logger.warning(`会话 ${key} 清理失败: ${err}`)))
           .finally(() => this.destroying.delete(key)),
       );
@@ -124,7 +142,10 @@ export class MessageSessionManager {
 
     // 保存所有活跃会话
     const cleanupPromises = Array.from(this.sessions.values()).map(session =>
-      session.cleanup().catch(err =>
+      session.cleanup({
+        stopSubAgents: true,
+        subAgentStopReason: '会话管理器销毁',
+      }).catch(err =>
         session.runWithLogContext(() => Logger.warning(`会话 ${session.key} 清理失败: ${err}`))
       )
     );

--- a/src/core/sub-agent-events.ts
+++ b/src/core/sub-agent-events.ts
@@ -1,0 +1,180 @@
+import { randomUUID } from 'crypto';
+
+export type SubAgentEventType =
+  | 'agent_spawned'
+  | 'agent_progress'
+  | 'agent_tool_start'
+  | 'agent_tool_end'
+  | 'agent_waiting'
+  | 'agent_completed'
+  | 'agent_failed'
+  | 'agent_stopped'
+  | 'artifact_update';
+
+export interface SubAgentRuntimeEvent {
+  id: string;
+  parentSessionKey: string;
+  subAgentId: string;
+  subAgentName?: string;
+  type: SubAgentEventType;
+  timestamp: number;
+  seq: number;
+  summary: string;
+  payload?: Record<string, unknown>;
+}
+
+export interface AppendSubAgentEventInput {
+  parentSessionKey: string;
+  subAgentId: string;
+  subAgentName?: string;
+  type: SubAgentEventType;
+  summary: string;
+  payload?: Record<string, unknown>;
+  timestamp?: number;
+}
+
+export interface SubAgentEventStoreOptions {
+  maxEventsPerParent?: number;
+  maxEventsPerAgent?: number;
+  retentionMs?: number;
+}
+
+const DEFAULT_MAX_EVENTS_PER_PARENT = 120;
+const DEFAULT_RETENTION_MS = 30 * 60 * 1000;
+
+export class SubAgentEventStore {
+  private eventsByParent = new Map<string, SubAgentRuntimeEvent[]>();
+  private seqByAgent = new Map<string, number>();
+  private maxEventsPerParent: number;
+  private maxEventsPerAgent: number;
+  private retentionMs: number;
+
+  constructor(options: SubAgentEventStoreOptions = {}) {
+    this.maxEventsPerParent = options.maxEventsPerParent ?? DEFAULT_MAX_EVENTS_PER_PARENT;
+    this.maxEventsPerAgent = options.maxEventsPerAgent ?? 0;
+    this.retentionMs = options.retentionMs ?? DEFAULT_RETENTION_MS;
+  }
+
+  append(input: AppendSubAgentEventInput): SubAgentRuntimeEvent {
+    const timestamp = input.timestamp ?? Date.now();
+    const seqKey = `${input.parentSessionKey}:${input.subAgentId}`;
+    const seq = (this.seqByAgent.get(seqKey) ?? 0) + 1;
+    this.seqByAgent.set(seqKey, seq);
+
+    const event: SubAgentRuntimeEvent = {
+      id: `evt-${randomUUID()}`,
+      parentSessionKey: input.parentSessionKey,
+      subAgentId: input.subAgentId,
+      subAgentName: input.subAgentName,
+      type: input.type,
+      timestamp,
+      seq,
+      summary: input.summary,
+      payload: input.payload,
+    };
+
+    const events = this.eventsByParent.get(input.parentSessionKey) ?? [];
+    events.push(event);
+    this.eventsByParent.set(input.parentSessionKey, events);
+    this.prune(input.parentSessionKey, timestamp);
+    return event;
+  }
+
+  listByParent(parentSessionKey: string, limit?: number): SubAgentRuntimeEvent[] {
+    this.prune(parentSessionKey, Date.now());
+    const events = this.eventsByParent.get(parentSessionKey) ?? [];
+    if (!limit || events.length <= limit) return [...events];
+    return events.slice(-limit);
+  }
+
+  listByAgent(parentSessionKey: string, subAgentId: string, limit?: number): SubAgentRuntimeEvent[] {
+    const events = this.listByParent(parentSessionKey).filter(event => event.subAgentId === subAgentId);
+    if (!limit || events.length <= limit) return events;
+    return events.slice(-limit);
+  }
+
+  removeAgent(parentSessionKey: string, subAgentId: string): void {
+    const events = this.eventsByParent.get(parentSessionKey);
+    if (!events) return;
+    this.eventsByParent.set(
+      parentSessionKey,
+      events.filter(event => event.subAgentId !== subAgentId),
+    );
+    this.seqByAgent.delete(`${parentSessionKey}:${subAgentId}`);
+  }
+
+  clearParent(parentSessionKey: string): void {
+    this.eventsByParent.delete(parentSessionKey);
+    for (const key of this.seqByAgent.keys()) {
+      if (key.startsWith(`${parentSessionKey}:`)) {
+        this.seqByAgent.delete(key);
+      }
+    }
+  }
+
+  private prune(parentSessionKey: string, now: number): void {
+    const events = this.eventsByParent.get(parentSessionKey);
+    if (!events || events.length === 0) return;
+
+    const cutoff = now - this.retentionMs;
+    let pruned = events.filter(event => event.timestamp >= cutoff);
+    const dynamicLimit = this.effectiveLimit(pruned);
+    if (pruned.length > dynamicLimit) {
+      pruned = pruned.slice(-dynamicLimit);
+    }
+
+    if (pruned.length === 0) {
+      this.eventsByParent.delete(parentSessionKey);
+    } else {
+      this.eventsByParent.set(parentSessionKey, pruned);
+    }
+  }
+
+  private effectiveLimit(events: SubAgentRuntimeEvent[]): number {
+    if (this.maxEventsPerAgent <= 0 || events.length === 0) {
+      return this.maxEventsPerParent;
+    }
+    const agentCount = new Set(events.map(event => event.subAgentId)).size;
+    return Math.max(this.maxEventsPerParent, agentCount * this.maxEventsPerAgent);
+  }
+}
+
+export function formatSubAgentEventLine(event: SubAgentRuntimeEvent): string {
+  const label = eventTypeLabel(event.type);
+  const age = formatEventAge(Date.now() - event.timestamp);
+  const agentLabel = event.subAgentName || event.subAgentId;
+  return `- [${agentLabel} #${event.seq}] ${label}: ${event.summary} (${age})`;
+}
+
+function eventTypeLabel(type: SubAgentEventType): string {
+  switch (type) {
+    case 'agent_spawned':
+      return '已派遣';
+    case 'agent_progress':
+      return '进度';
+    case 'agent_tool_start':
+      return '工具开始';
+    case 'agent_tool_end':
+      return '工具完成';
+    case 'agent_waiting':
+      return '等待输入';
+    case 'agent_completed':
+      return '已完成';
+    case 'agent_failed':
+      return '失败';
+    case 'agent_stopped':
+      return '已停止';
+    case 'artifact_update':
+      return '产物更新';
+    default:
+      return type;
+  }
+}
+
+function formatEventAge(ms: number): string {
+  const seconds = Math.max(0, Math.round(ms / 1000));
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  return `${Math.round(minutes / 60)}h ago`;
+}

--- a/src/core/sub-agent-manager.ts
+++ b/src/core/sub-agent-manager.ts
@@ -1,17 +1,54 @@
 import { AIService } from '../utils/ai-service';
 import { SkillManager } from '../skills/skill-manager';
 import { Logger } from '../utils/logger';
-import { SubAgentSession, SubAgentInfo, SubAgentSpawnOptions } from './sub-agent-session';
+import {
+  SubAgentSession,
+  SubAgentInfo,
+  SubAgentSpawnOptions,
+  SubAgentType,
+  SubAgentToolScope,
+} from './sub-agent-session';
+import {
+  formatSubAgentEventLine,
+  SubAgentEventStore,
+  SubAgentEventType,
+  SubAgentRuntimeEvent,
+} from './sub-agent-events';
 import { randomUUID } from 'crypto';
 
 // ─── 平台回调注册 ───────────────────────────────────────
 
 export interface PlatformCallbacks {
-  /** 向主会话投递消息，触发主 agent 新一轮推理 */
+  /**
+   * 向主会话投递后台结果 observation，触发主 agent 新一轮推理。
+   * 这是 result 通道，不用于 WORKING/UI 进度事件。
+   */
   injectMessage: (text: string) => Promise<void>;
+  /**
+   * 向平台发送子智能体 runtime event，用于 WORKING/UI 可视化。
+   * 这是 event 通道，不应被当作最终结果回流给主 agent。
+   */
+  onSubAgentEvent?: (event: SubAgentRuntimeEvent, info?: SubAgentInfo) => Promise<void> | void;
 }
 
 export type StopSubAgentResult = 'stopped' | 'not_found' | 'forbidden' | 'not_running';
+export type SubAgentEventLogger = (event: SubAgentRuntimeEvent, info?: SubAgentInfo) => void;
+
+export interface SpawnSubAgentRequest {
+  skillName?: string;
+  agentType?: SubAgentType;
+  toolScope?: SubAgentToolScope;
+  subAgentPrompt?: string;
+  allowedTools?: readonly string[];
+  maxTurns?: number;
+  taskDescription: string;
+  userMessage: string;
+}
+
+export interface StopAllSubAgentsResult {
+  stopped: number;
+  active: number;
+}
 
 // ─── SubAgentManager ────────────────────────────────────
 
@@ -19,21 +56,34 @@ export type StopSubAgentResult = 'stopped' | 'not_found' | 'forbidden' | 'not_ru
  * SubAgentManager - 子智能体管理器（单例）
  *
  * 管理所有后台运行的 SubAgentSession 的生命周期。
- * 按 parentSessionKey 隔离，每个主会话最多同时运行 MAX_CONCURRENT 个子任务。
+ * 按 parentSessionKey 隔离；是否拆分、派发多少个子任务由主 agent 判断。
  */
 export class SubAgentManager {
   private static instance: SubAgentManager;
 
   /** 所有子智能体，key = subagent id */
   private subAgents = new Map<string, SubAgentSession>();
+  /** 已结束子智能体的轻量状态快照，key = subagent id */
+  private completedSubAgents = new Map<string, SubAgentInfo>();
   /** 子智能体 → 父会话 key 的映射 */
   private parentMap = new Map<string, string>();
   /** 持久化的平台回调，key = 父会话 sessionKey */
   private platformCallbacks = new Map<string, PlatformCallbacks>();
+  /** 会话日志回调，key = 父会话 sessionKey */
+  private eventLoggers = new Map<string, SubAgentEventLogger>();
+  /** 子智能体展示名，便于日志/UI 使用 子agent1/子agent2 这类稳定标签 */
+  private displayNameByAgent = new Map<string, string>();
+  private displayCounterByParent = new Map<string, number>();
+  /** runtime 事件流，按父会话隔离 */
+  private eventStore = new SubAgentEventStore({
+    maxEventsPerParent: 120,
+    maxEventsPerAgent: 80,
+    retentionMs: SubAgentManager.RETENTION_MS,
+  });
 
-  private static readonly MAX_CONCURRENT_PER_SESSION = 3;
   /** 完成后保留信息的时间（ms） */
   private static readonly RETENTION_MS = 30 * 60 * 1000;
+  private static readonly PARENT_RESULT_MAX_CHARS = 1800;
 
   private constructor() { }
 
@@ -54,33 +104,48 @@ export class SubAgentManager {
     this.platformCallbacks.set(sessionKey, callbacks);
   }
 
+  registerEventLogger(sessionKey: string, logger: SubAgentEventLogger): void {
+    this.eventLoggers.set(sessionKey, logger);
+  }
+
+  unregisterEventLogger(sessionKey: string): void {
+    this.eventLoggers.delete(sessionKey);
+  }
+
+  unregisterPlatformCallbacks(sessionKey: string): void {
+    this.platformCallbacks.delete(sessionKey);
+  }
+
   // ─── 子智能体生命周期 ─────────────────────────────────
 
   /**
    * 派遣子智能体执行任务
    */
-  spawn(
+  async spawn(
     parentSessionKey: string,
-    skillName: string,
-    taskDescription: string,
-    userMessage: string,
+    request: SpawnSubAgentRequest,
     workingDirectory: string,
     aiService: AIService,
     skillManager: SkillManager,
-  ): SubAgentInfo | { error: string } {
-    // 并发限制
-    const running = this.listByParent(parentSessionKey).filter(s => s.status === 'running');
-    if (running.length >= SubAgentManager.MAX_CONCURRENT_PER_SESSION) {
-      return { error: `最多同时运行 ${SubAgentManager.MAX_CONCURRENT_PER_SESSION} 个子任务，当前已有 ${running.length} 个在运行` };
-    }
+  ): Promise<SubAgentInfo | { error: string }> {
+    const skillName = request.skillName?.trim();
+    const agentType = request.agentType || (skillName ? 'skill' : 'worker');
+    const toolScope = request.toolScope;
+    const subAgentPrompt = request.subAgentPrompt?.trim();
+    const allowedTools = request.allowedTools;
+    const maxTurns = request.maxTurns;
+    const taskDescription = request.taskDescription.trim();
+    const userMessage = request.userMessage.trim();
 
     // 检查 skill 是否存在
-    const skill = skillManager.getSkill(skillName);
-    if (!skill) {
+    const skill = skillName ? skillManager.getSkill(skillName) : null;
+    if (skillName && !skill) {
       return { error: `Skill "${skillName}" 不存在` };
     }
 
     const id = `sub-${randomUUID()}`;
+    const displayName = this.nextDisplayName(parentSessionKey);
+    this.displayNameByAgent.set(id, displayName);
 
     // 获取平台回调（子智能体需要 injectMessage 向主 Agent 报告）
     const platform = this.platformCallbacks.get(parentSessionKey);
@@ -89,12 +154,22 @@ export class SubAgentManager {
     }
 
     const options: SubAgentSpawnOptions = {
+      displayName,
+      agentType,
+      toolScope,
       skillName,
+      subAgentPrompt,
+      allowedTools,
+      maxTurns,
       taskDescription,
       userMessage,
       workingDirectory,
+      emitEvent: (type, summary, payload) => {
+        this.recordEvent(parentSessionKey, id, type, summary, payload);
+      },
+      // ask_parent 通道：子 agent 需要主 agent/用户补信息时才注入父会话。
       notifyParent: async (subAgentId, taskDesc, question) => {
-        const msg = `[子智能体 ${subAgentId} 反馈]\n任务：${taskDesc}\n需要你的指示：${question}`;
+        const msg = `[${displayName} 反馈]\nID：${subAgentId}\n任务：${taskDesc}\n需要你的指示：${question}`;
         await platform.injectMessage(msg);
       },
     };
@@ -102,31 +177,30 @@ export class SubAgentManager {
     const session = new SubAgentSession(id, aiService, skillManager, options);
     this.subAgents.set(id, session);
     this.parentMap.set(id, parentSessionKey);
+    const spawnedEvent = this.recordEvent(parentSessionKey, id, 'agent_spawned', `派遣 ${displayName} (${agentType}) 执行：${taskDescription}`, {
+      agentType,
+      skillName,
+      toolScope: session.toolScope,
+      allowedTools: session.allowedTools,
+    }, { notifyPlatform: false });
+    await this.notifyPlatformEvent(parentSessionKey, id, spawnedEvent);
 
-    // fire-and-forget
-    session.run().finally(() => {
-      // 通知主 agent 子智能体已完成（stopped 不通知）
-      if (session.status !== 'stopped') {
-        const info = session.getInfo();
-        const statusLabel = info.status === 'completed' ? '已完成' : '失败';
-        const fileList = info.outputFiles.length > 0
-          ? `\n产出文件：\n${info.outputFiles.map(f => `- ${f}`).join('\n')}`
-          : '';
-        const msg = `[子智能体 ${id} ${statusLabel}]\n任务：${taskDescription}\n结果：${info.resultSummary || '（无结果）'}${fileList}`;
-        platform.injectMessage(msg).catch(err => {
-          Logger.warning(`[SubAgentManager] 通知主 agent 失败: ${err.message}`);
-        });
-      }
+    // fire-and-forget：manager.spawn() 只负责创建并启动后台 session。
+    // 这里不 return/await session.run()，所以 spawn_subagent 工具不会等子 agent 跑完。
+    // 子 agent 完成后会在 finalizeSession() 里通过 result observation 回流父会话。
+    void session.run()
+      .catch(err => {
+        session.status = 'failed';
+        session.completedAt = Date.now();
+        session.resultSummary = `执行失败: ${err?.message || err}`;
+        Logger.error(`[SubAgentManager] ${id} 未捕获失败: ${err?.message || err}`);
+      })
+      .finally(() => {
+        void this.finalizeSession(parentSessionKey, id, session, platform, taskDescription);
+      });
 
-      // 完成后保留一段时间供查询，然后清理
-      setTimeout(() => {
-        this.subAgents.delete(id);
-        this.parentMap.delete(id);
-      }, SubAgentManager.RETENTION_MS);
-    });
-
-    Logger.info(`[SubAgentManager] 派遣 ${id} 执行 "${skillName}" (父会话: ${parentSessionKey})`);
-    return session.getInfo();
+    Logger.info(`[SubAgentManager] 派遣 ${id} 执行 "${skillName || agentType}" (父会话: ${parentSessionKey})`);
+    return this.decorateInfo(parentSessionKey, session.getInfo());
   }
 
   /**
@@ -134,7 +208,7 @@ export class SubAgentManager {
    */
   stop(subAgentId: string): boolean {
     const session = this.subAgents.get(subAgentId);
-    if (!session || session.status !== 'running') {
+    if (!session || !isActiveSubAgentStatus(session.status)) {
       return false;
     }
     session.stop();
@@ -146,7 +220,11 @@ export class SubAgentManager {
    * 按父会话停止子智能体（防止跨会话越权）
    */
   stopForParent(parentSessionKey: string, subAgentId: string): StopSubAgentResult {
-    const owner = this.parentMap.get(subAgentId);
+    const targetId = this.resolveSubAgentIdForParent(parentSessionKey, subAgentId);
+    if (!targetId) {
+      return 'not_found';
+    }
+    const owner = targetId ? this.parentMap.get(targetId) : undefined;
     if (!owner) {
       return 'not_found';
     }
@@ -154,32 +232,77 @@ export class SubAgentManager {
       return 'forbidden';
     }
 
-    const session = this.subAgents.get(subAgentId);
+    const session = this.subAgents.get(targetId);
     if (!session) {
-      return 'not_found';
+      return this.completedSubAgents.has(targetId) ? 'not_running' : 'not_found';
     }
-    if (session.status !== 'running') {
+    if (!isActiveSubAgentStatus(session.status)) {
       return 'not_running';
     }
 
     session.stop();
-    Logger.info(`[SubAgentManager] 已停止 ${subAgentId} (父会话: ${parentSessionKey})`);
+    Logger.info(`[SubAgentManager] 已停止 ${targetId} (父会话: ${parentSessionKey})`);
     return 'stopped';
+  }
+
+  stopAllForParent(parentSessionKey: string, reason = '父会话生命周期结束'): StopAllSubAgentsResult {
+    let stopped = 0;
+    let active = 0;
+
+    for (const [id, session] of this.subAgents) {
+      if (this.parentMap.get(id) !== parentSessionKey) continue;
+      if (isActiveSubAgentStatus(session.status)) {
+        active += 1;
+        session.stop();
+        stopped += 1;
+      }
+    }
+
+    if (stopped > 0) {
+      Logger.info(`[SubAgentManager] 已停止父会话 ${parentSessionKey} 下 ${stopped} 个子智能体`);
+    }
+    return { stopped, active };
+  }
+
+  hasActiveForParent(parentSessionKey: string): boolean {
+    for (const [id, session] of this.subAgents) {
+      if (this.parentMap.get(id) !== parentSessionKey) continue;
+      if (isActiveSubAgentStatus(session.status)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  shutdown(reason = 'runtime shutdown'): StopAllSubAgentsResult {
+    let stopped = 0;
+    let active = 0;
+    const parents = new Set(this.parentMap.values());
+
+    for (const parentSessionKey of parents) {
+      const result = this.stopAllForParent(parentSessionKey, reason);
+      stopped += result.stopped;
+      active += result.active;
+    }
+
+    return { stopped, active };
   }
 
   /**
    * 恢复挂起的子智能体（主 agent 提供答案）
    */
   resumeForParent(parentSessionKey: string, subAgentId: string, answer: string): 'resumed' | 'not_found' | 'forbidden' | 'not_waiting' {
-    const owner = this.parentMap.get(subAgentId);
+    const targetId = this.resolveSubAgentIdForParent(parentSessionKey, subAgentId);
+    if (!targetId) return 'not_found';
+    const owner = targetId ? this.parentMap.get(targetId) : undefined;
     if (!owner) return 'not_found';
     if (owner !== parentSessionKey) return 'forbidden';
 
-    const session = this.subAgents.get(subAgentId);
-    if (!session) return 'not_found';
+    const session = this.subAgents.get(targetId);
+    if (!session) return this.completedSubAgents.has(targetId) ? 'not_waiting' : 'not_found';
     if (!session.resume(answer)) return 'not_waiting';
 
-    Logger.info(`[SubAgentManager] 已恢复 ${subAgentId} (父会话: ${parentSessionKey})`);
+    Logger.info(`[SubAgentManager] 已恢复 ${targetId} (父会话: ${parentSessionKey})`);
     return 'resumed';
   }
 
@@ -187,18 +310,27 @@ export class SubAgentManager {
    * 查询单个子智能体状态
    */
   getInfo(subAgentId: string): SubAgentInfo | undefined {
-    return this.subAgents.get(subAgentId)?.getInfo();
+    const session = this.subAgents.get(subAgentId);
+    const parentSessionKey = this.parentMap.get(subAgentId);
+    if (!parentSessionKey) return undefined;
+    const info = session?.getInfo() ?? this.completedSubAgents.get(subAgentId);
+    return info ? this.decorateInfo(parentSessionKey, info) : undefined;
   }
 
   /**
    * 按父会话查询子智能体（防止跨会话越权）
    */
   getInfoForParent(parentSessionKey: string, subAgentId: string): SubAgentInfo | undefined {
-    const owner = this.parentMap.get(subAgentId);
+    const targetId = this.resolveSubAgentIdForParent(parentSessionKey, subAgentId);
+    if (!targetId) return undefined;
+
+    const owner = this.parentMap.get(targetId);
     if (!owner || owner !== parentSessionKey) {
       return undefined;
     }
-    return this.subAgents.get(subAgentId)?.getInfo();
+    const session = this.subAgents.get(targetId);
+    const info = session?.getInfo() ?? this.completedSubAgents.get(targetId);
+    return info ? this.decorateInfo(parentSessionKey, info) : undefined;
   }
 
   /**
@@ -208,9 +340,214 @@ export class SubAgentManager {
     const result: SubAgentInfo[] = [];
     for (const [id, session] of this.subAgents) {
       if (this.parentMap.get(id) === parentSessionKey) {
-        result.push(session.getInfo());
+        result.push(this.decorateInfo(parentSessionKey, session.getInfo()));
+      }
+    }
+    for (const [id, info] of this.completedSubAgents) {
+      if (this.parentMap.get(id) === parentSessionKey && !this.subAgents.has(id)) {
+        result.push(this.decorateInfo(parentSessionKey, info));
       }
     }
     return result;
   }
+
+  recordEvent(
+    parentSessionKey: string,
+    subAgentId: string,
+    type: SubAgentEventType,
+    summary: string,
+    payload?: Record<string, unknown>,
+    options: { notifyPlatform?: boolean } = {},
+  ): SubAgentRuntimeEvent {
+    // Event 通道：写内存事件流、日志和平台 UI。不要在这里唤醒主 agent。
+    // 主 agent 唤醒只走 finalizeSession()/notifyParent 的 result observation 通道。
+    const event = this.eventStore.append({
+      parentSessionKey,
+      subAgentId,
+      subAgentName: this.displayNameByAgent.get(subAgentId),
+      type,
+      summary,
+      payload,
+    });
+    const eventAgentLabel = event.subAgentName ? `${event.subAgentName}(${subAgentId})` : subAgentId;
+    Logger.info(`[SubAgentEvent] ${parentSessionKey}/${eventAgentLabel} ${type}: ${summary}`);
+    this.logSubAgentEvent(parentSessionKey, subAgentId, event);
+    if (options.notifyPlatform !== false) {
+      void this.notifyPlatformEvent(parentSessionKey, subAgentId, event);
+    }
+    return event;
+  }
+
+  listEventsByParent(parentSessionKey: string, limit = 20): SubAgentRuntimeEvent[] {
+    return this.eventStore.listByParent(parentSessionKey, limit);
+  }
+
+  buildObservationForParent(parentSessionKey: string, limit = 12): string {
+    const events = this.listEventsByParent(parentSessionKey, limit);
+    if (events.length === 0) return '';
+    return events.map(formatSubAgentEventLine).join('\n');
+  }
+
+  private decorateInfo(parentSessionKey: string, info: SubAgentInfo): SubAgentInfo {
+    const recentEvents = this.eventStore.listByAgent(parentSessionKey, info.id, 8);
+    return {
+      ...info,
+      displayName: info.displayName || this.displayNameByAgent.get(info.id),
+      recentEvents,
+      eventCount: this.eventStore.listByAgent(parentSessionKey, info.id).length,
+      lastEventAt: recentEvents[recentEvents.length - 1]?.timestamp,
+    };
+  }
+
+  private async finalizeSession(
+    parentSessionKey: string,
+    id: string,
+    session: SubAgentSession,
+    platform: PlatformCallbacks,
+    taskDescription: string,
+  ): Promise<void> {
+    let info = session.getInfo();
+    this.subAgents.delete(id);
+    this.completedSubAgents.set(id, info);
+
+    try {
+      await session.close();
+      info = session.getInfo();
+      this.completedSubAgents.set(id, info);
+    } catch (error: any) {
+      Logger.warning(`[SubAgentManager] 关闭 ${id} 失败: ${error.message}`);
+    }
+
+    // 通知主 agent 子智能体已完成（stopped 不通知）
+    if (info.status !== 'stopped') {
+      const statusLabel = info.status === 'completed' ? '已完成' : '失败';
+      const displayName = info.displayName || this.displayNameByAgent.get(id) || id;
+      const fileList = info.outputFiles.length > 0
+        ? `\n产出文件：\n${info.outputFiles.map(f => `- ${f}`).join('\n')}`
+        : '';
+      const resultSummary = compactForParentNotification(
+        info.resultSummary || '（无结果）',
+        SubAgentManager.PARENT_RESULT_MAX_CHARS,
+      );
+      const resultObservation = [
+        `[${displayName} ${statusLabel}]`,
+        `ID：${id}`,
+        `任务：${taskDescription}`,
+        `结果摘要：${resultSummary}`,
+        '说明：这是压缩后的子 agent 结果。需要更多细节时先用 check_subagent 查看，再按需重新读取具体文件或更小范围。',
+        fileList.trim() ? fileList.trim() : '',
+      ].filter(Boolean).join('\n');
+      await this.injectResultObservationWithRetry(parentSessionKey, id, platform, resultObservation);
+    }
+
+    // 完成后只保留轻量快照和事件一段时间，便于用户追问和 check_subagent。
+    const retentionTimer = setTimeout(() => {
+      this.completedSubAgents.delete(id);
+      this.eventStore.removeAgent(parentSessionKey, id);
+      this.parentMap.delete(id);
+      this.displayNameByAgent.delete(id);
+      this.cleanupParentCachesIfIdle(parentSessionKey);
+    }, SubAgentManager.RETENTION_MS);
+    retentionTimer.unref?.();
+  }
+
+  private cleanupParentCachesIfIdle(parentSessionKey: string): void {
+    for (const owner of this.parentMap.values()) {
+      if (owner === parentSessionKey) return;
+    }
+    this.displayCounterByParent.delete(parentSessionKey);
+    this.eventStore.clearParent(parentSessionKey);
+  }
+
+  private nextDisplayName(parentSessionKey: string): string {
+    const next = (this.displayCounterByParent.get(parentSessionKey) ?? 0) + 1;
+    this.displayCounterByParent.set(parentSessionKey, next);
+    return `子agent${next}`;
+  }
+
+  private async injectResultObservationWithRetry(
+    parentSessionKey: string,
+    subAgentId: string,
+    platform: PlatformCallbacks,
+    observation: string,
+  ): Promise<void> {
+    const maxAttempts = 3;
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      try {
+        await platform.injectMessage(observation);
+        return;
+      } catch (error: any) {
+        const suffix = attempt < maxAttempts ? '，准备重试' : '，已放弃';
+        Logger.warning(`[SubAgentManager] 通知主 agent 失败 (${attempt}/${maxAttempts})${suffix}: ${error.message}`);
+        if (attempt < maxAttempts) {
+          await new Promise(resolve => setTimeout(resolve, 1000 * attempt));
+        }
+      }
+    }
+
+    this.recordEvent(parentSessionKey, subAgentId, 'agent_progress', '完成通知投递失败，请用 check_subagent 查看结果', undefined, {
+      notifyPlatform: false,
+    });
+  }
+
+  private resolveSubAgentIdForParent(parentSessionKey: string, rawRef: string): string | undefined {
+    const ref = String(rawRef || '').trim();
+    if (!ref) return undefined;
+
+    const owner = this.parentMap.get(ref);
+    if (owner) return ref;
+
+    for (const [id, ownerKey] of this.parentMap) {
+      if (ownerKey !== parentSessionKey) continue;
+      if (this.displayNameByAgent.get(id) === ref) return id;
+    }
+    return undefined;
+  }
+
+  private logSubAgentEvent(
+    parentSessionKey: string,
+    subAgentId: string,
+    event: SubAgentRuntimeEvent,
+  ): void {
+    const logger = this.eventLoggers.get(parentSessionKey);
+    if (!logger) return;
+
+    const session = this.subAgents.get(subAgentId);
+    const info = session?.getInfo() ?? this.completedSubAgents.get(subAgentId);
+    try {
+      logger(event, info ? this.decorateInfo(parentSessionKey, info) : undefined);
+    } catch (error: any) {
+      Logger.warning(`[SubAgentManager] 写入子智能体事件日志失败: ${error.message}`);
+    }
+  }
+
+  private async notifyPlatformEvent(
+    parentSessionKey: string,
+    subAgentId: string,
+    event: SubAgentRuntimeEvent,
+  ): Promise<void> {
+    const platform = this.platformCallbacks.get(parentSessionKey);
+    if (!platform?.onSubAgentEvent) return;
+
+    const session = this.subAgents.get(subAgentId);
+    const info = session?.getInfo() ?? this.completedSubAgents.get(subAgentId);
+    try {
+      await platform.onSubAgentEvent(
+        event,
+        info ? this.decorateInfo(parentSessionKey, info) : undefined,
+      );
+    } catch (error: any) {
+      Logger.warning(`[SubAgentManager] 平台子智能体事件通知失败: ${error.message}`);
+    }
+  }
+}
+
+function isActiveSubAgentStatus(status: SubAgentInfo['status']): boolean {
+  return status === 'running' || status === 'waiting_for_input';
+}
+
+function compactForParentNotification(text: string, maxChars: number): string {
+  const normalized = String(text || '').replace(/\s+/g, ' ').trim();
+  if (normalized.length <= maxChars) return normalized;
+  return `${normalized.slice(0, maxChars)}... [已压缩，原始 ${normalized.length} 字符]`;
 }

--- a/src/core/sub-agent-observation.ts
+++ b/src/core/sub-agent-observation.ts
@@ -1,0 +1,71 @@
+import { Message } from '../types';
+import { SubAgentManager } from './sub-agent-manager';
+
+export const TRANSIENT_SUBAGENT_STATUS_PREFIX = '[transient_subagent_status]';
+
+export function buildSubAgentStatusMessage(
+  sessionKey: string,
+  manager = SubAgentManager.getInstance(),
+): Message | null {
+  const subAgents = manager
+    .listByParent(sessionKey)
+    .filter(subAgent => isActiveStatus(subAgent.status));
+  if (subAgents.length === 0) return null;
+
+  const sections: string[] = [];
+  const statusLines = subAgents.map(s => {
+    const latest = compactInline(s.progressLog[s.progressLog.length - 1] ?? '', 120);
+    const summary = s.status === 'completed' && s.resultSummary
+      ? `\n  结果摘要: ${compactInline(s.resultSummary, 220)}`
+      : '';
+    const pending = s.status === 'waiting_for_input' && s.pendingQuestion
+      ? `\n  待回复: ${compactInline(s.pendingQuestion, 180)}`
+      : '';
+    return `- [${s.id}] ${s.taskDescription} (${statusLabel(s.status)}, ${s.agentType}/${s.toolScope}) ${latest}${pending}${summary}`;
+  }).join('\n');
+
+  if (statusLines) {
+    sections.push(`当前后台子任务：\n${statusLines}`);
+  }
+
+  return {
+    role: 'system',
+    content: [
+      TRANSIENT_SUBAGENT_STATUS_PREFIX,
+      sections.join('\n\n'),
+      [
+        '这些是 runtime observation，不是用户新需求。',
+        '只整合真实列出的子任务；不要编造 sub-... ID。',
+        '子 agent 是侧路加速，主 agent 仍要继续能独立推进的主线。',
+        '需要细节时用 check_subagent；用户要求停止时用 stop_subagent。',
+      ].join('\n'),
+    ].join('\n\n'),
+  };
+}
+
+function statusLabel(status: string): string {
+  switch (status) {
+    case 'running':
+      return '运行中';
+    case 'completed':
+      return '已完成';
+    case 'failed':
+      return '失败';
+    case 'waiting_for_input':
+      return '等待主 agent 回复';
+    case 'stopped':
+      return '已停止';
+    default:
+      return status;
+  }
+}
+
+function isActiveStatus(status: string): boolean {
+  return status === 'running' || status === 'waiting_for_input';
+}
+
+function compactInline(text: string, maxChars: number): string {
+  const normalized = String(text || '').replace(/\s+/g, ' ').trim();
+  if (normalized.length <= maxChars) return normalized;
+  return `${normalized.slice(0, maxChars)}...`;
+}

--- a/src/core/sub-agent-session.ts
+++ b/src/core/sub-agent-session.ts
@@ -7,15 +7,32 @@ import { SkillExecutor } from '../skills/skill-executor';
 import { ConversationRunner, RunnerCallbacks } from './conversation-runner';
 import { PromptManager } from '../utils/prompt-manager';
 import { Logger } from '../utils/logger';
-import { isToolAllowed } from '../utils/safety';
+import { SubAgentEventType, SubAgentRuntimeEvent } from './sub-agent-events';
+import * as fs from 'fs';
+import * as path from 'path';
 
 // ─── 类型定义 ───────────────────────────────────────────
 
 export type SubAgentStatus = 'running' | 'completed' | 'failed' | 'stopped' | 'waiting_for_input';
+export type SubAgentType = 'skill' | 'explorer' | 'reviewer' | 'worker' | 'tester';
+export type SubAgentToolScope = 'read_only' | 'workspace_write' | 'test_only';
+export const SAFE_SUB_AGENT_TOOL_NAMES = [
+  'read_file',
+  'glob',
+  'grep',
+  'ask_parent',
+  'write_file',
+  'edit_file',
+  'execute_shell',
+] as const;
+export type SafeSubAgentToolName = typeof SAFE_SUB_AGENT_TOOL_NAMES[number];
 
 export interface SubAgentInfo {
   id: string;
+  displayName?: string;
+  agentType: SubAgentType;
   skillName: string;
+  toolScope: SubAgentToolScope;
   taskDescription: string;
   status: SubAgentStatus;
   createdAt: number;
@@ -26,17 +43,38 @@ export interface SubAgentInfo {
   resultSummary?: string;
   /** 子智能体挂起时的待确认问题 */
   pendingQuestion?: string;
+  /** 子智能体开始等待主 agent 回复的时间 */
+  pendingQuestionSince?: number;
   /** 子智能体执行期间创建的产出文件路径 */
   outputFiles: string[];
+  /** 子智能体实际可用工具，由主 agent 显式限制或 runtime 默认解析 */
+  allowedTools: string[];
+  /** 最近 runtime 事件（由 SubAgentManager 注入） */
+  recentEvents?: SubAgentRuntimeEvent[];
+  eventCount?: number;
+  lastEventAt?: number;
 }
 
 export interface SubAgentSpawnOptions {
-  skillName: string;
+  displayName?: string;
+  skillName?: string;
+  agentType?: SubAgentType;
+  toolScope?: SubAgentToolScope;
   taskDescription: string;
   userMessage: string;
+  /** 主 agent 额外指定的子 agent 行为/角色指令 */
+  subAgentPrompt?: string;
+  /** 主 agent 显式指定的工具白名单；runtime 仍会过滤危险工具 */
+  allowedTools?: readonly string[];
+  /** 主 agent 显式指定的子 agent 工具推理轮次预算；不指定则不使用 runner 轮次上限 */
+  maxTurns?: number;
   workingDirectory: string;
-  /** 向主 agent 投递消息（子智能体挂起时触发主 agent 推理） */
+  /** 子智能体可使用的临时 scratch 目录，完成后会自动清理 */
+  temporaryDirectory?: string;
+  /** ask_parent 通道：子智能体挂起时向主 agent 投递问题，触发主 agent 推理 */
   notifyParent?: (subAgentId: string, taskDescription: string, question: string) => Promise<void>;
+  /** event 通道：向 runtime 事件流写入结构化事件，供 UI/日志/状态 observation 消费 */
+  emitEvent?: (type: SubAgentEventType, summary: string, payload?: Record<string, unknown>) => void;
 }
 
 // ─── SubAgentSession ────────────────────────────────────
@@ -45,13 +83,21 @@ export interface SubAgentSpawnOptions {
  * SubAgentSession - 独立运行的后台子智能体
  *
  * 拥有自己的 messages[]、ConversationRunner、skill 上下文。
- * 不直接和用户通信，仅通过 injectMessage 向主 Agent 报告状态。
+ * 不直接和用户通信：
+ * - 运行过程通过 event 通道给 UI/日志/状态 observation；
+ * - ask_parent 通过 notifyParent 向主 agent 提问；
+ * - 最终 result observation 由 SubAgentManager.finalizeSession() 回流父会话。
  * 主会话不 await 它，fire-and-forget。
  */
 export class SubAgentSession {
   readonly id: string;
+  readonly displayName?: string;
   readonly skillName: string;
+  readonly agentType: SubAgentType;
+  readonly toolScope: SubAgentToolScope;
   readonly taskDescription: string;
+  readonly temporaryDirectory: string;
+  readonly allowedTools: string[];
   status: SubAgentStatus = 'running';
   progressLog: string[] = [];
   resultSummary?: string;
@@ -64,12 +110,18 @@ export class SubAgentSession {
   private outputFiles: string[] = [];
   /** 挂起等待主 agent 回答的问题 */
   private pendingQuestion: string | null = null;
+  private pendingQuestionSince: number | null = null;
   private pendingResolve: ((answer: string) => void) | null = null;
   private pendingWaitPromise: Promise<string> | null = null;
+  private pendingReminderTimer: NodeJS.Timeout | null = null;
+  private closed = false;
+  private abortController: AbortController | null = null;
+  private terminalEventEmitted = false;
 
   // ─── 会话级重试配置 ──────────────────────────────────
   private static readonly SESSION_MAX_RETRIES = 2;
   private static readonly SESSION_RETRY_BASE_DELAY_MS = 5000;
+  private static readonly PARENT_INPUT_REMINDER_MS = 60_000;
 
   private static isRetryableError(err: any): boolean {
     const msg = String(err?.message || '').toLowerCase();
@@ -85,8 +137,13 @@ export class SubAgentSession {
     private options: SubAgentSpawnOptions,
   ) {
     this.id = id;
-    this.skillName = options.skillName;
+    this.displayName = normalizeOptionalString(options.displayName);
+    this.agentType = resolveAgentType(options);
+    this.skillName = options.skillName || this.agentType;
+    this.toolScope = resolveToolScope(this.agentType, options.toolScope);
     this.taskDescription = options.taskDescription;
+    this.temporaryDirectory = resolveTemporaryDirectory(options.workingDirectory, id, options.temporaryDirectory);
+    this.allowedTools = resolveAllowedTools(this.toolScope, options.allowedTools);
   }
 
   /**
@@ -99,6 +156,7 @@ export class SubAgentSession {
       if (this.stopped) {
         this.status = 'stopped';
         this.completedAt = Date.now();
+        this.emitTerminalEvent('agent_stopped', `任务已停止：${this.taskDescription}`);
         return;
       }
 
@@ -108,6 +166,12 @@ export class SubAgentSession {
         Logger.warning(`[SubAgent ${this.id}] 第 ${attempt} 次重试，${delay}ms 后开始`);
         this.reportProgress(`第 ${attempt} 次重试（${lastError?.message}）`);
         await new Promise(resolve => setTimeout(resolve, delay));
+        if (this.stopped) {
+          this.status = 'stopped';
+          this.completedAt = Date.now();
+          this.emitTerminalEvent('agent_stopped', `任务已停止：${this.taskDescription}`);
+          return;
+        }
         this.messages = [];
         this.outputFiles = [];
       }
@@ -129,6 +193,7 @@ export class SubAgentSession {
     this.status = this.stopped ? 'stopped' : 'failed';
     this.completedAt = Date.now();
     this.resultSummary = `执行失败: ${lastError?.message}`;
+    this.emitTerminalEvent(this.stopped ? 'agent_stopped' : 'agent_failed', this.resultSummary);
     Logger.error(`[SubAgent ${this.id}] ${this.stopped ? '已停止' : '失败'}: ${lastError?.message}`);
   }
 
@@ -136,41 +201,54 @@ export class SubAgentSession {
    * 单次执行核心逻辑（不含重试）
    */
   private async _executeOnce(): Promise<void> {
+    this.abortController = new AbortController();
+
     // 1. 构建独立的 system prompt
     const systemPrompt = await PromptManager.buildSystemPrompt();
-    this.messages.push({ role: 'system', content: systemPrompt });
+    this.messages.push({
+      role: 'system',
+      content: [
+        systemPrompt,
+        buildSubAgentSystemPrompt(this.agentType, this.toolScope, this.temporaryDirectory, this.allowedTools, this.options.subAgentPrompt, this.options.maxTurns),
+      ].filter(Boolean).join('\n\n'),
+    });
+    await fs.promises.mkdir(this.temporaryDirectory, { recursive: true });
 
-    // 2. 以 tool_result 形式注入 skill 内容，避免写入 system prompt
-    const skill = this.skillManager.getSkill(this.skillName);
-    if (!skill) {
-      throw new Error(`Skill "${this.skillName}" 未找到`);
+    // 2. 以 tool_result 形式注入 skill 内容（兼容旧 spawn_subagent(skill_name) 形式）
+    const skill = this.options.skillName
+      ? this.skillManager.getSkill(this.options.skillName)
+      : null;
+    if (this.options.skillName && !skill) {
+      throw new Error(`Skill "${this.options.skillName}" 未找到`);
     }
 
-    const invocationContext: SkillInvocationContext = {
-      skillName: this.skillName,
-      arguments: [],
-      rawArguments: '',
-      userMessage: this.options.userMessage,
-    };
-    const skillToolCallId = `subagent-skill-${this.id}`;
-    this.messages.push({
-      role: 'assistant',
-      content: null,
-      tool_calls: [{
-        id: skillToolCallId,
-        type: 'function',
-        function: {
-          name: 'skill',
-          arguments: JSON.stringify({ skill: this.skillName, args: '' }),
-        },
-      }],
-    });
-    this.messages.push({
-      role: 'tool',
-      content: SkillExecutor.execute(skill, invocationContext),
-      tool_call_id: skillToolCallId,
-      name: 'skill',
-    });
+    if (skill) {
+      const invocationContext: SkillInvocationContext = {
+        skillName: this.options.skillName!,
+        arguments: [],
+        rawArguments: '',
+        userMessage: this.options.userMessage,
+      };
+      const skillToolCallId = `subagent-skill-${this.id}`;
+      this.messages.push({
+        role: 'assistant',
+        content: null,
+        tool_calls: [{
+          id: skillToolCallId,
+          type: 'function',
+          function: {
+            name: 'skill',
+            arguments: JSON.stringify({ skill: this.options.skillName, args: '' }),
+          },
+        }],
+      });
+      this.messages.push({
+        role: 'tool',
+        content: SkillExecutor.execute(skill, invocationContext),
+        tool_call_id: skillToolCallId,
+        name: 'skill',
+      });
+    }
 
     // 3. 注入用户消息
     this.messages.push({ role: 'user', content: this.options.userMessage });
@@ -180,33 +258,54 @@ export class SubAgentSession {
       sessionId: `subagent:${this.id}`,
       surface: 'agent',
       permissionProfile: 'strict',
+    }, {
+      enabledToolNames: this.allowedTools,
     });
 
     // 创建独立的 ConversationRunner（不注入 channel，子智能体不直接和用户通信）
     const runner = new ConversationRunner(this.aiService, toolManager, {
+      maxTurns: this.options.maxTurns,
       enableCompression: true,
       shouldContinue: () => !this.stopped,
       toolExecutionContext: {
         sessionId: `subagent:${this.id}`,
         surface: 'agent',
         permissionProfile: 'strict',
+        abortSignal: this.abortController.signal,
+        requestParentInput: (question: string) => this.waitForParentInput(question),
       },
     });
 
-    // 7. 用 callbacks 捕获进度
+    // 7. 用 callbacks 捕获进度。这里产生的是 runtime event，不是主 agent 最终结果。
     const callbacks: RunnerCallbacks = {
-      onToolEnd: (name, result) => {
+      onToolStart: (name) => {
+        this.emitEvent('agent_tool_start', `开始执行工具 ${name}`, { toolName: name });
+      },
+      onToolEnd: (name, _toolUseId, result) => {
+        this.emitEvent('agent_tool_end', `工具 ${name} 完成：${truncateForEvent(result, 180)}`, {
+          toolName: name,
+        });
         this.detectAndReportProgress(name, result);
       },
     };
 
     this.reportProgress(`开始执行：${this.taskDescription}`);
     const runResult = await runner.run(this.messages, callbacks);
+    if (this.stopped) {
+      this.status = 'stopped';
+      this.completedAt = Date.now();
+      this.resultSummary = '任务已停止';
+      this.emitTerminalEvent('agent_stopped', `任务已停止：${this.taskDescription}`);
+      return;
+    }
 
-    // 8. 完成（不直接发文件，由主 Agent 根据 outputFiles 决定）
+    // 8. 完成（不直接发用户消息/文件；只记录 resultSummary，由 Manager 压缩后回流主 agent）
     this.status = 'completed';
     this.completedAt = Date.now();
-    this.resultSummary = runResult.response;
+    this.resultSummary = compactResultSummary(buildResultSummary(runResult.response, this.messages, this.progressLog));
+    this.emitTerminalEvent('agent_completed', truncateForEvent(this.resultSummary || '任务已完成', 600), {
+      outputFiles: [...this.outputFiles],
+    });
 
     Logger.success(`[SubAgent ${this.id}] 完成: ${this.taskDescription}`);
   }
@@ -215,13 +314,17 @@ export class SubAgentSession {
     this.stopped = true;
     this.status = 'stopped';
     this.completedAt = Date.now();
+    this.abortController?.abort();
+    this.emitTerminalEvent('agent_stopped', `任务已停止：${this.taskDescription}`);
     // 如果正在挂起等待，解除阻塞
     if (this.pendingResolve) {
       this.pendingResolve('（任务已被停止）');
       this.pendingResolve = null;
       this.pendingQuestion = null;
+      this.pendingQuestionSince = null;
       this.pendingWaitPromise = null;
     }
+    this.clearParentInputReminder();
   }
 
   /**
@@ -235,6 +338,8 @@ export class SubAgentSession {
     const resolve = this.pendingResolve;
     this.pendingResolve = null;
     this.pendingQuestion = null;
+    this.pendingQuestionSince = null;
+    this.clearParentInputReminder();
     this.status = 'running';
     this.reportProgress(`收到回复，继续执行`);
     resolve(answer);
@@ -244,24 +349,115 @@ export class SubAgentSession {
   getInfo(): SubAgentInfo {
     return {
       id: this.id,
+      displayName: this.displayName,
       skillName: this.skillName,
       taskDescription: this.taskDescription,
       status: this.status,
       createdAt: this.createdAt,
       completedAt: this.completedAt,
+      agentType: this.agentType,
+      toolScope: this.toolScope,
       progressLog: [...this.progressLog],
       resultSummary: this.resultSummary,
       pendingQuestion: this.pendingQuestion ?? undefined,
+      pendingQuestionSince: this.pendingQuestionSince ?? undefined,
       outputFiles: [...this.outputFiles],
+      allowedTools: [...this.allowedTools],
     };
+  }
+
+  private async waitForParentInput(question: string): Promise<string> {
+    const normalizedQuestion = String(question || '').trim();
+    if (!normalizedQuestion) {
+      throw new Error('ask_parent question 不能为空');
+    }
+    if (!this.options.notifyParent) {
+      throw new Error('当前平台未注册主 agent 通知回调，无法等待补充信息');
+    }
+    if (this.pendingWaitPromise) {
+      throw new Error('已有一个等待中的 ask_parent 问题');
+    }
+
+    this.pendingQuestion = normalizedQuestion;
+    this.pendingQuestionSince = Date.now();
+    this.status = 'waiting_for_input';
+    this.emitEvent('agent_waiting', `等待主 agent 回复：${truncateForEvent(normalizedQuestion, 180)}`, {
+      question: normalizedQuestion,
+    });
+    this.startParentInputReminder(normalizedQuestion);
+
+    this.pendingWaitPromise = new Promise<string>((resolve) => {
+      this.pendingResolve = resolve;
+    });
+
+    try {
+      await this.options.notifyParent(this.id, this.taskDescription, normalizedQuestion);
+      const answer = await this.pendingWaitPromise;
+      if (this.stopped) {
+        throw new Error('任务已停止');
+      }
+      this.status = 'running';
+      this.pendingQuestionSince = null;
+      this.clearParentInputReminder();
+      return answer;
+    } catch (error) {
+      if (!this.stopped) {
+        this.status = 'running';
+      }
+      this.pendingResolve = null;
+      this.pendingQuestion = null;
+      this.pendingQuestionSince = null;
+      this.pendingWaitPromise = null;
+      this.clearParentInputReminder();
+      throw error;
+    }
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+
+    await this.cleanupTemporaryDirectory();
+    this.messages = [];
+    this.pendingResolve = null;
+    this.pendingQuestion = null;
+    this.pendingQuestionSince = null;
+    this.pendingWaitPromise = null;
+    this.clearParentInputReminder();
+    this.abortController = null;
   }
 
   // ─── 私有方法 ──────────────────────────────────────
 
   private reportProgress(message: string): void {
     this.progressLog.push(message);
+    this.emitEvent('agent_progress', message);
     // 仅记录到 progressLog，不推飞书
     // 主 agent 通过 check_subagent 查看进度后自行决定是否告知用户
+  }
+
+  private startParentInputReminder(question: string): void {
+    this.clearParentInputReminder();
+    this.pendingReminderTimer = setInterval(() => {
+      if (this.closed || this.stopped || this.status !== 'waiting_for_input') {
+        this.clearParentInputReminder();
+        return;
+      }
+      const waitingMs = this.pendingQuestionSince ? Date.now() - this.pendingQuestionSince : 0;
+      this.emitEvent('agent_waiting', `仍在等待主 agent 回复：${truncateForEvent(question, 180)}`, {
+        question,
+        waitingMs,
+        reminder: true,
+      });
+    }, SubAgentSession.PARENT_INPUT_REMINDER_MS);
+    this.pendingReminderTimer.unref?.();
+  }
+
+  private clearParentInputReminder(): void {
+    if (this.pendingReminderTimer) {
+      clearInterval(this.pendingReminderTimer);
+      this.pendingReminderTimer = null;
+    }
   }
 
   private detectAndReportProgress(toolName: string, result: string): void {
@@ -270,6 +466,10 @@ export class SubAgentSession {
       const filePath = this.extractFilePath(toolName, result);
       if (filePath) {
         this.outputFiles.push(filePath);
+        this.emitEvent('artifact_update', `产出文件：${filePath}`, {
+          filePath,
+          toolName,
+        });
       }
     }
 
@@ -299,5 +499,261 @@ export class SubAgentSession {
     // write_file 返回格式: "成功创建文件: <path>\n..."
     const match = result.match(/成功(?:创建|覆盖)文件:\s*(.+?)(?:\n|$)/);
     return match ? match[1].trim() : null;
+  }
+
+  private emitEvent(type: SubAgentEventType, summary: string, payload?: Record<string, unknown>): void {
+    this.options.emitEvent?.(type, truncateForEvent(summary, 800), payload);
+  }
+
+  private emitTerminalEvent(type: SubAgentEventType, summary: string, payload?: Record<string, unknown>): void {
+    if (this.terminalEventEmitted) return;
+    this.terminalEventEmitted = true;
+    this.emitEvent(type, summary, payload);
+  }
+
+  private async cleanupTemporaryDirectory(): Promise<void> {
+    const tempDir = path.resolve(this.temporaryDirectory);
+    if (!isSafeSubAgentTempDirectory(this.options.workingDirectory, tempDir, this.id)) {
+      Logger.warning(`[SubAgent ${this.id}] 跳过临时目录清理，路径不在安全范围内: ${tempDir}`);
+      return;
+    }
+
+    try {
+      await fs.promises.access(tempDir);
+    } catch {
+      return;
+    }
+
+    const preservedOutputs = this.outputFiles
+      .map(filePath => path.resolve(this.options.workingDirectory, filePath))
+      .filter(filePath => isSameOrInside(tempDir, filePath));
+
+    try {
+      if (preservedOutputs.length === 0) {
+        await fs.promises.rm(tempDir, { recursive: true, force: true, maxRetries: 2, retryDelay: 100 });
+        this.emitEvent('agent_progress', '临时目录已清理', { temporaryDirectory: tempDir });
+        return;
+      }
+
+      const stats = await removeTemporaryEntriesExceptOutputs(tempDir, preservedOutputs);
+      this.emitEvent('agent_progress', `临时目录已清理，保留 ${stats.preservedFiles} 个产出文件`, {
+        temporaryDirectory: tempDir,
+        deletedFiles: stats.deletedFiles,
+        deletedDirectories: stats.deletedDirectories,
+        preservedFiles: stats.preservedFiles,
+      });
+    } catch (error: any) {
+      Logger.warning(`[SubAgent ${this.id}] 临时目录清理失败: ${error.message}`);
+      this.emitEvent('agent_progress', `临时目录清理失败：${error.message}`, {
+        temporaryDirectory: tempDir,
+      });
+    }
+  }
+}
+
+function resolveAgentType(options: SubAgentSpawnOptions): SubAgentType {
+  if (options.agentType) return options.agentType;
+  return options.skillName ? 'skill' : 'worker';
+}
+
+function normalizeOptionalString(value: unknown): string | undefined {
+  const text = String(value || '').trim();
+  return text || undefined;
+}
+
+function resolveToolScope(agentType: SubAgentType, explicit?: SubAgentToolScope): SubAgentToolScope {
+  if (explicit) return explicit;
+  if (agentType === 'worker' || agentType === 'skill') return 'workspace_write';
+  if (agentType === 'tester') return 'test_only';
+  return 'read_only';
+}
+
+function defaultToolsForScope(scope: SubAgentToolScope): string[] {
+  const readOnly = ['read_file', 'glob', 'grep', 'ask_parent'];
+  if (scope === 'read_only') return readOnly;
+  if (scope === 'test_only') return [...readOnly, 'execute_shell'];
+  return [...readOnly, 'write_file', 'edit_file', 'execute_shell'];
+}
+
+function resolveAllowedTools(scope: SubAgentToolScope, requestedTools?: readonly string[]): string[] {
+  const tools = requestedTools ?? defaultToolsForScope(scope);
+  const safeTools = new Set<string>(SAFE_SUB_AGENT_TOOL_NAMES);
+  const scopedTools = new Set(defaultToolsForScope(scope));
+  return Array.from(new Set(
+    tools
+      .map(tool => String(tool).trim())
+      .filter(tool => safeTools.has(tool) && scopedTools.has(tool))
+  ));
+}
+
+function buildSubAgentSystemPrompt(
+  agentType: SubAgentType,
+  toolScope: SubAgentToolScope,
+  temporaryDirectory: string,
+  allowedTools: readonly string[],
+  subAgentPrompt?: string,
+  maxTurns?: number,
+): string {
+  const roleLine = agentRoleLine(agentType);
+  return [
+    '[subagent_runtime]',
+    roleLine,
+    '你只会看到主 agent 传入的任务和上下文，不会自动继承主会话完整历史；不要假设有未提供的信息。',
+    '你是后台子智能体，不直接面向用户输出消息，也不调用 send_text/send_file。',
+    '把高噪音探索、工具输出和中间推理保留在你自己的上下文里；最终只输出简明结果、关键证据、风险和产物路径。',
+    `临时 scratch 目录: ${temporaryDirectory}。中间文件放这里；需要长期保留或交付给用户的产物不要只放在 scratch 目录中。`,
+    allowedTools.includes('ask_parent')
+      ? '如果信息不足，先基于可用工具自行调查；只有真正需要主 agent 或用户决策时才用 ask_parent 明确提出问题并等待恢复。'
+      : '如果信息不足，先基于可用工具自行调查；本次未授权 ask_parent，请在最终结果里说明缺口和需要主 agent 判断的事项。',
+    `工具权限范围: ${toolScope}。实际可用工具: ${allowedTools.length > 0 ? allowedTools.join(', ') : '无'}。不要尝试派生新的子智能体。`,
+    maxTurns
+      ? `本次主 agent 设置的工具推理轮次预算: ${maxTurns}。接近预算时请优先总结已知结论和缺口。`
+      : '本次没有固定的类型轮次上限；由你自己在信息足够时及时总结结束。',
+    subAgentPrompt ? `主 agent 额外指令:\n${subAgentPrompt.trim()}` : '',
+  ].join('\n');
+}
+
+function agentRoleLine(agentType: SubAgentType): string {
+  switch (agentType) {
+    case 'explorer':
+      return '角色: explorer。只读探索代码和事实，输出路径、证据和结论，不修改文件。';
+    case 'reviewer':
+      return '角色: reviewer。审查风险、缺陷、测试缺口和可维护性问题，不修改文件。';
+    case 'tester':
+      return '角色: tester。运行必要测试或检查命令，聚焦失败原因和可复现输出，不修改源码。';
+    case 'worker':
+      return '角色: worker。可以在授权范围内做小而清晰的实现改动，并说明改了哪些文件。';
+    case 'skill':
+      return '角色: skill worker。按照已激活 skill 的流程完成任务，并给出压缩结果。';
+    default:
+      return '角色: background worker。完成独立子任务并返回压缩结果。';
+  }
+}
+
+function truncateForEvent(text: string, maxLength: number): string {
+  const normalized = String(text || '').replace(/\s+/g, ' ').trim();
+  if (normalized.length <= maxLength) return normalized;
+  return `${normalized.slice(0, maxLength)}... [truncated]`;
+}
+
+function compactResultSummary(text: string, maxLength = 4000): string {
+  const normalized = String(text || '').trim();
+  if (normalized.length <= maxLength) return normalized;
+  return `${normalized.slice(0, maxLength)}\n...[已压缩，原始 ${normalized.length} 字符；需要细节请让主 agent 用 check_subagent 或重新读取相关文件]`;
+}
+
+function buildResultSummary(response: string, messages: Message[], progressLog: string[]): string {
+  const direct = String(response || '').trim();
+  if (direct) return direct;
+
+  const lastAssistantMessage = [...messages].reverse().find(message => (
+    message.role === 'assistant'
+    && typeof message.content === 'string'
+    && message.content.trim()
+    && (!message.tool_calls || message.tool_calls.length === 0)
+  ));
+  const lastAssistantText = typeof lastAssistantMessage?.content === 'string'
+    ? lastAssistantMessage.content.trim()
+    : '';
+  if (lastAssistantText) {
+    return lastAssistantText;
+  }
+
+  const recentProgress = progressLog.slice(-5).map(item => item.trim()).filter(Boolean);
+  if (recentProgress.length > 0) {
+    return [
+      '未形成最终摘要，可能是在停止、错误或仍在探索时结束。',
+      '最近进度：',
+      ...recentProgress.map(item => `- ${item}`),
+      '建议主 agent 用 check_subagent 查看最近事件，或派发更小范围的子任务。',
+    ].join('\n');
+  }
+
+  return '未形成最终摘要，可能是在停止、错误或仍在探索时结束。建议主 agent 用 check_subagent 查看最近事件，或重新派发更小范围的子任务。';
+}
+
+function resolveTemporaryDirectory(workingDirectory: string, subAgentId: string, explicit?: string): string {
+  if (explicit) {
+    return path.resolve(explicit);
+  }
+  return path.resolve(workingDirectory, 'tmp', 'subagents', subAgentId);
+}
+
+function isSafeSubAgentTempDirectory(workingDirectory: string, tempDir: string, subAgentId: string): boolean {
+  const expectedRoot = path.resolve(workingDirectory, 'tmp', 'subagents');
+  return path.basename(tempDir) === subAgentId && isSameOrInside(expectedRoot, tempDir);
+}
+
+function isSameOrInside(parent: string, child: string): boolean {
+  const resolvedParent = path.resolve(parent);
+  const resolvedChild = path.resolve(child);
+  const relative = path.relative(resolvedParent, resolvedChild);
+  return relative === '' || (!!relative && !relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+interface TempCleanupStats {
+  deletedFiles: number;
+  deletedDirectories: number;
+  preservedFiles: number;
+}
+
+async function removeTemporaryEntriesExceptOutputs(
+  targetPath: string,
+  preservedOutputs: string[],
+): Promise<TempCleanupStats> {
+  const stats: TempCleanupStats = {
+    deletedFiles: 0,
+    deletedDirectories: 0,
+    preservedFiles: 0,
+  };
+  await removeTemporaryPath(targetPath, preservedOutputs.map(filePath => path.resolve(filePath)), stats);
+  return stats;
+}
+
+async function removeTemporaryPath(
+  targetPath: string,
+  preservedOutputs: string[],
+  stats: TempCleanupStats,
+): Promise<void> {
+  const resolvedTarget = path.resolve(targetPath);
+  const isPreservedFile = preservedOutputs.some(filePath => path.resolve(filePath) === resolvedTarget);
+  const containsPreservedOutput = preservedOutputs.some(filePath => isSameOrInside(resolvedTarget, filePath));
+
+  let entryStats: fs.Stats;
+  try {
+    entryStats = await fs.promises.lstat(resolvedTarget);
+  } catch {
+    return;
+  }
+
+  if (isPreservedFile) {
+    stats.preservedFiles += 1;
+    return;
+  }
+
+  if (!entryStats.isDirectory() || entryStats.isSymbolicLink()) {
+    await fs.promises.rm(resolvedTarget, { force: true });
+    stats.deletedFiles += 1;
+    return;
+  }
+
+  if (!containsPreservedOutput) {
+    await fs.promises.rm(resolvedTarget, { recursive: true, force: true, maxRetries: 2, retryDelay: 100 });
+    stats.deletedDirectories += 1;
+    return;
+  }
+
+  const entries = await fs.promises.readdir(resolvedTarget);
+  for (const entry of entries) {
+    await removeTemporaryPath(path.join(resolvedTarget, entry), preservedOutputs, stats);
+  }
+
+  try {
+    await fs.promises.rmdir(resolvedTarget);
+    stats.deletedDirectories += 1;
+  } catch (error: any) {
+    if (error?.code !== 'ENOTEMPTY') {
+      throw error;
+    }
   }
 }

--- a/src/core/turn-context-builder.ts
+++ b/src/core/turn-context-builder.ts
@@ -4,10 +4,12 @@ import {
   TRANSIENT_SKILLS_LIST_PREFIX,
 } from '../skills/session-skill-runtime';
 import { isRuntimeFeedbackContent } from './runtime-feedback';
-import { SubAgentManager } from './sub-agent-manager';
 import { PlanRuntime } from './plan-runtime';
+import {
+  TRANSIENT_SUBAGENT_STATUS_PREFIX,
+  buildSubAgentStatusMessage,
+} from './sub-agent-observation';
 
-const TRANSIENT_SUBAGENT_STATUS_PREFIX = '[transient_subagent_status]';
 const TRANSIENT_PLAN_STATUS_PREFIX = '[transient_plan_status]';
 const TRANSIENT_RUNNER_HINT_PREFIX = '[transient_runner_hint]';
 const TRANSIENT_SOFT_CHECK_PREFIX = '[transient_soft_check]';
@@ -84,29 +86,9 @@ export class TurnContextBuilder {
   }
 
   private injectSubAgentStatus(messages: Message[], sessionKey: string): void {
-    const subAgentManager = SubAgentManager.getInstance();
-    const runningSubAgents = subAgentManager.listByParent(sessionKey);
-    if (runningSubAgents.length === 0) return;
-
-    const statusLines = runningSubAgents.map(s => {
-      const statusLabel = s.status === 'running'
-        ? '运行中'
-        : s.status === 'completed'
-          ? '已完成'
-          : s.status === 'failed'
-            ? '失败'
-            : '已停止';
-      const latest = s.progressLog[s.progressLog.length - 1] ?? '';
-      const summary = s.status === 'completed' && s.resultSummary
-        ? `\n  结果: ${s.resultSummary.slice(0, 200)}`
-        : '';
-      return `- [${s.id}] ${s.taskDescription} (${statusLabel}) ${latest}${summary}`;
-    }).join('\n');
-
-    this.insertBeforeLastUser(messages, {
-      role: 'system',
-      content: `${TRANSIENT_SUBAGENT_STATUS_PREFIX}\n当前有 ${runningSubAgents.length} 个后台子任务：\n${statusLines}\n\n用户如果询问任务进度，请基于以上信息回答。如果用户要求停止任务，使用 stop_subagent 工具。`,
-    });
+    const statusMessage = buildSubAgentStatusMessage(sessionKey);
+    if (!statusMessage) return;
+    this.insertBeforeLastUser(messages, statusMessage);
   }
 
   private extractRuntimeFeedback(messages: Message[]): string[] {

--- a/src/tools/ask-parent-tool.ts
+++ b/src/tools/ask-parent-tool.ts
@@ -1,0 +1,40 @@
+import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
+
+/**
+ * ask_parent - 子智能体专用协作工具
+ *
+ * 子智能体信息不足、需要主 agent 或用户做判断时使用。普通主会话不会注册该工具。
+ */
+export class AskParentTool implements Tool {
+  definition: ToolDefinition = {
+    name: 'ask_parent',
+    description: '子智能体专用：向主 agent 提问并挂起等待 resume_subagent。先自行调查，只有确实需要补充信息或决策时使用。',
+    parameters: {
+      type: 'object',
+      properties: {
+        question: {
+          type: 'string',
+          description: '需要主 agent 或用户补充的信息/决策问题，说明你为什么需要它。',
+        },
+      },
+      required: ['question'],
+    },
+  };
+
+  async execute(args: any, context: ToolExecutionContext): Promise<ToolExecutionResult> {
+    const question = String(args?.question || '').trim();
+    if (!question) {
+      return { ok: false, errorCode: 'INVALID_TOOL_ARGUMENTS', message: '错误：question 不能为空' };
+    }
+    if (!context.requestParentInput) {
+      return {
+        ok: false,
+        errorCode: 'PERMISSION_DENIED',
+        message: 'ask_parent 只能在子智能体 runtime 中使用。',
+      };
+    }
+
+    const answer = await context.requestParentInput(question);
+    return { ok: true, content: `主 agent 回复：\n${answer}` };
+  }
+}

--- a/src/tools/bash-tool.ts
+++ b/src/tools/bash-tool.ts
@@ -52,6 +52,10 @@ export class ShellTool implements Tool {
   async execute(args: any, context: ToolExecutionContext): Promise<ToolExecutionResult> {
     const { command, description, timeout = 30000 } = args;
 
+    if (context.abortSignal?.aborted) {
+      return { ok: false, errorCode: 'EXECUTION_TIMEOUT', message: `命令已取消，未开始执行:\n$ ${command}` };
+    }
+
     const toolPermission = isToolAllowed(this.definition.name);
     if (!toolPermission.allowed) {
       return { ok: false, errorCode: 'PERMISSION_DENIED', message: `执行被阻止: ${toolPermission.reason}` };
@@ -81,6 +85,7 @@ export class ShellTool implements Tool {
         context.workingDirectory,
         runtimeEnvironment.env,
         timeout,
+        context.abortSignal,
       );
 
       const parsedStdout = this.extractDirectoryProbe(stdout || '', wrapped.marker);
@@ -118,6 +123,14 @@ export class ShellTool implements Tool {
       const parsedStdout = this.extractDirectoryProbe(error.stdout || '', wrapped.marker);
       const parsedStderr = this.extractDirectoryProbe(error.stderr || '', wrapped.marker);
       this.updateCurrentDirectory(parsedStdout.directory || parsedStderr.directory, context);
+      if (context.abortSignal?.aborted || /aborted|abort/i.test(String(error.message || ''))) {
+        Logger.warning(`命令已取消 (耗时: ${executionTime}ms)`);
+        return {
+          ok: false,
+          errorCode: 'EXECUTION_TIMEOUT',
+          message: `命令已取消:\n$ ${command}\n\n执行时间: ${executionTime}ms`,
+        };
+      }
       const errorOutput = [
         parsedStderr.output,
         parsedStdout.output,
@@ -173,6 +186,7 @@ export class ShellTool implements Tool {
     cwd: string,
     env: NodeJS.ProcessEnv,
     timeout: number,
+    signal?: AbortSignal,
   ): Promise<ShellOutput> {
     if (process.platform !== 'win32') {
       if (!wrapped.command) {
@@ -183,11 +197,13 @@ export class ShellTool implements Tool {
         env,
         encoding: 'utf-8',
         timeout,
+        signal,
+        killSignal: 'SIGTERM',
         maxBuffer: 10 * 1024 * 1024,
       });
     }
 
-    return this.executeWindowsStdinScript(wrapped, cwd, env, timeout);
+    return this.executeWindowsStdinScript(wrapped, cwd, env, timeout, signal);
   }
 
   private executeWindowsStdinScript(
@@ -195,9 +211,13 @@ export class ShellTool implements Tool {
     cwd: string,
     env: NodeJS.ProcessEnv,
     timeout: number,
+    signal?: AbortSignal,
   ): Promise<ShellOutput> {
     if (!wrapped.stdinScript) {
       return Promise.reject(new Error('Internal error: missing Windows stdin script'));
+    }
+    if (signal?.aborted) {
+      return Promise.reject(new Error('Command aborted by user'));
     }
 
     return new Promise((resolve, reject) => {
@@ -215,11 +235,15 @@ export class ShellTool implements Tool {
       let stdoutBytes = 0;
       let stderrBytes = 0;
       const maxBuffer = 10 * 1024 * 1024;
+      let timer: NodeJS.Timeout;
 
       const finish = (fn: () => void) => {
         if (settled) return;
         settled = true;
         clearTimeout(timer);
+        if (signal && abortHandler) {
+          signal.removeEventListener('abort', abortHandler);
+        }
         fn();
       };
 
@@ -232,10 +256,14 @@ export class ShellTool implements Tool {
         });
       };
 
-      const timer = setTimeout(() => {
+      timer = setTimeout(() => {
         timedOut = true;
         fail(new Error(`Command timed out after ${timeout}ms`));
       }, timeout);
+      const abortHandler = () => {
+        fail(new Error('Command aborted by user'));
+      };
+      signal?.addEventListener('abort', abortHandler, { once: true });
 
       child.stdout.on('data', chunk => {
         const buffer = Buffer.from(chunk);

--- a/src/tools/check-subagent-tool.ts
+++ b/src/tools/check-subagent-tool.ts
@@ -1,5 +1,6 @@
 import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import { SubAgentManager } from '../core/sub-agent-manager';
+import { formatSubAgentEventLine } from '../core/sub-agent-events';
 
 /**
  * check_subagent - 查看子智能体状态
@@ -10,16 +11,13 @@ import { SubAgentManager } from '../core/sub-agent-manager';
 export class CheckSubagentTool implements Tool {
   definition: ToolDefinition = {
     name: 'check_subagent',
-    description: `查看当前会话下后台子智能体的运行状态和进度。
-
-可以查看特定子智能体，也可以列出所有子智能体。
-当用户询问"论文读得怎么样了"、"任务进度"等问题时使用。`,
+    description: '查看当前会话下后台子智能体的状态、最近事件、结果摘要和产出文件。用户问进度或回流摘要不够时使用。',
     parameters: {
       type: 'object',
       properties: {
         subagent_id: {
           type: 'string',
-          description: '子智能体 ID（如 sub-1）。不填则列出当前会话所有子智能体',
+          description: '子智能体 ID 或展示名（如 sub-... 或 子agent1）。不填则列出当前会话所有子智能体',
         },
       },
       required: [],
@@ -56,6 +54,7 @@ export class CheckSubagentTool implements Tool {
       completed: '✅ 已完成',
       failed: '❌ 失败',
       stopped: '⏹️ 已停止',
+      waiting_for_input: '⏸️ 等待主 agent 回复',
     };
 
     const elapsed = info.completedAt
@@ -63,15 +62,26 @@ export class CheckSubagentTool implements Tool {
       : Math.round((Date.now() - info.createdAt) / 1000);
 
     const lines = [
-      `[${info.id}] ${info.taskDescription}`,
+      `[${info.displayName || info.id}] ${info.taskDescription}`,
+      info.displayName ? `ID: ${info.id}` : '',
       `状态: ${statusMap[info.status] || info.status}`,
+      `类型: ${info.agentType || 'skill'}`,
+      `工具范围: ${info.toolScope || 'unknown'}`,
+      `工具: ${info.allowedTools?.length ? info.allowedTools.join(', ') : '无'}`,
       `Skill: ${info.skillName}`,
       `耗时: ${elapsed}s`,
-    ];
+    ].filter(Boolean);
 
     if (info.progressLog.length > 0) {
       const recent = info.progressLog.slice(-3);
       lines.push(`最近进度: ${recent.join(' → ')}`);
+    }
+
+    if (info.pendingQuestion) {
+      const waitingFor = info.pendingQuestionSince
+        ? `（已等待 ${Math.round((Date.now() - info.pendingQuestionSince) / 1000)}s）`
+        : '';
+      lines.push(`待回复问题${waitingFor}: ${info.pendingQuestion}`);
     }
 
     if (info.resultSummary) {
@@ -80,6 +90,10 @@ export class CheckSubagentTool implements Tool {
 
     if (info.outputFiles && info.outputFiles.length > 0) {
       lines.push(`产出文件:\n${info.outputFiles.map((f: string) => `  - ${f}`).join('\n')}`);
+    }
+
+    if (info.recentEvents && info.recentEvents.length > 0) {
+      lines.push(`最近事件:\n${info.recentEvents.slice(-5).map(formatSubAgentEventLine).join('\n')}`);
     }
 
     return lines.join('\n');

--- a/src/tools/resume-subagent-tool.ts
+++ b/src/tools/resume-subagent-tool.ts
@@ -10,16 +10,13 @@ import { Logger } from '../utils/logger';
 export class ResumeSubagentTool implements Tool {
   definition: ToolDefinition = {
     name: 'resume_subagent',
-    description: `恢复一个处于 waiting_for_input 状态的子智能体。
-
-当子智能体遇到需要确认的问题时会挂起，通过 check_subagent 可以看到它的 pendingQuestion。
-你可以自己判断如何回答，也可以先问用户再回答。用此工具把答案传给子智能体，让它继续执行。`,
+    description: '恢复当前会话下等待输入的子智能体。先确认 pendingQuestion，再把主 agent 或用户的答案传给它继续执行。',
     parameters: {
       type: 'object',
       properties: {
         subagent_id: {
           type: 'string',
-          description: '要恢复的子智能体 ID',
+          description: '要恢复的子智能体 ID 或展示名（如 sub-... 或 子agent1）',
         },
         answer: {
           type: 'string',
@@ -43,11 +40,20 @@ export class ResumeSubagentTool implements Tool {
 
     switch (result) {
       case 'resumed':
-        Logger.info(`[ResumeSubagent] 已恢复 ${subagent_id}`);
-        return { ok: true, content: `子智能体 ${subagent_id} 已恢复执行。` };
+        {
+          const info = manager.getInfoForParent(sessionKey, subagent_id);
+          const label = info?.displayName ? `${info.displayName} (${info.id})` : subagent_id;
+          Logger.info(`[ResumeSubagent] 已恢复 ${label}`);
+          return { ok: true, content: `${label} 已恢复执行。` };
+        }
       case 'not_waiting':
-        return { ok: true, content: `子智能体 ${subagent_id} 当前未处于等待状态，无需恢复。` };
+        {
+          const info = manager.getInfoForParent(sessionKey, subagent_id);
+          const label = info?.displayName ? `${info.displayName} (${info.id})` : subagent_id;
+          return { ok: true, content: `${label} 当前未处于等待状态，无需恢复。` };
+        }
       case 'forbidden':
+        return { ok: false, errorCode: 'PERMISSION_DENIED', message: `无权恢复子智能体 ${subagent_id}。它不属于当前会话。` };
       case 'not_found':
         return { ok: false, errorCode: 'TOOL_NOT_FOUND', message: `未找到子智能体 ${subagent_id}。` };
     }

--- a/src/tools/spawn-subagent-tool.ts
+++ b/src/tools/spawn-subagent-tool.ts
@@ -1,77 +1,121 @@
 import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import { SubAgentManager } from '../core/sub-agent-manager';
+import { SAFE_SUB_AGENT_TOOL_NAMES } from '../core/sub-agent-session';
 import { AIService } from '../utils/ai-service';
 import { SkillManager } from '../skills/skill-manager';
 import { Logger } from '../utils/logger';
 import { styles } from '../theme/colors';
 
 /**
- * spawn_subagent - 派遣子智能体后台执行 skill
+ * spawn_subagent - 派遣子智能体后台执行隔离任务
  *
- * 主 agent 像"甩活给小弟"一样使用这个工具：
+ * 主 agent 用它派出可并行的侧路任务：
  * 调用后立即返回，子智能体在后台独立运行，
  * 主会话不阻塞，可以继续和用户对话。
  */
 export class SpawnSubagentTool implements Tool {
   definition: ToolDefinition = {
     name: 'spawn_subagent',
-    description: `派遣一个子智能体在后台独立执行某个 skill 任务。
-
-调用后立即返回，不会阻塞当前对话。子智能体完成后会通知你（主 agent），并附上产出文件列表。
-由你决定是否将结果和文件转发给用户。
-
-使用场景：
-- 用户要求执行耗时较长的 skill（如论文精读、文献综述等）
-- 你判断任务需要大量工具调用轮次（>10轮），不适合在当前对话中同步执行
-- 用户可能还有其他事情要聊，你不想让他等
-
-注意：
-- 每个会话最多同时运行 3 个子任务
-- 子智能体不会直接给用户发消息或文件
-- 任务完成后你会收到包含结果摘要和产出文件路径的通知
-- 你可以用 check_subagent 查看进度，用 stop_subagent 停止任务
-- 收到完成通知后，在最终回复里告知用户结果；如需发送文件，使用 send_file 发送相关文件`,
+    description: [
+      '派遣一个后台子智能体执行独立任务；调用成功后立即返回，不等待任务完成。',
+      '适合耗时、高噪音、可并行的探索/审查/测试/小块实现；简单问答、短链路排查和很快能完成的小任务不要用。',
+      '子智能体不会直接回复用户，只看到你传入的 context/user_message；完成后会以后台结果通知回到主会话。',
+      '你仍负责主线推进和最终回复。只有本工具成功返回的展示名和 ID 才算真实已派出，不要编造子智能体或 sub-... ID。',
+    ].join('\n'),
     parameters: {
       type: 'object',
       properties: {
         skill_name: {
           type: 'string',
-          description: '要执行的 skill 名称（如 paper-analysis, literature-review 等）',
+          description: '可选。要执行的已注册 skill 名称。通常优先使用 agent_type；只有确实需要某个现有 skill 流程时再提供。',
+        },
+        agent_type: {
+          type: 'string',
+          enum: ['explorer', 'reviewer', 'worker', 'tester'],
+          description: '可选。内置子 agent 类型。explorer/reviewer 默认只读，tester 可执行测试命令，worker 可在工作区写文件。',
+        },
+        tool_scope: {
+          type: 'string',
+          enum: ['read_only', 'workspace_write', 'test_only'],
+          description: '可选。覆盖子 agent 工具权限范围。默认由 agent_type 决定。',
+        },
+        allowed_tools: {
+          type: 'array',
+          items: {
+            type: 'string',
+            enum: [...SAFE_SUB_AGENT_TOOL_NAMES],
+          },
+          description: '可选。显式指定子 agent 可用工具白名单。只允许 read_file/glob/grep/ask_parent/write_file/edit_file/execute_shell；不允许 send、spawn、skill 管理类工具。',
+        },
+        max_turns: {
+          type: 'number',
+          description: '可选。由主 agent 判断的子 agent 工具推理轮次预算。适合给边界清晰的子任务设置收束点；不传则不使用 runner 轮次上限，由子 agent 自行在信息足够时结束。',
+        },
+        subagent_prompt: {
+          type: 'string',
+          description: '可选。主 agent 给子 agent 的额外 system-level 行为指令，例如审查重点、输出格式、禁止改动范围。',
+        },
+        task: {
+          type: 'string',
+          description: '任务的简短描述。新格式推荐用 task。',
         },
         task_description: {
           type: 'string',
-          description: '任务的简短描述，用于进度通知（如"精读 attention is all you need"）',
+          description: '任务的简短描述，用于进度通知（兼容旧参数）',
+        },
+        context: {
+          type: 'string',
+          description: '传递给子智能体的完整上下文/用户指令。新格式推荐用 context。',
         },
         user_message: {
           type: 'string',
-          description: '传递给子智能体的完整用户指令（包含文件路径等必要信息）',
+          description: '传递给子智能体的完整用户指令（兼容旧参数，包含文件路径等必要信息）',
         },
       },
-      required: ['skill_name', 'task_description', 'user_message'],
+      required: [],
     },
   };
 
   async execute(args: any, context: ToolExecutionContext): Promise<ToolExecutionResult> {
-    const { skill_name, task_description, user_message } = args;
+    const skillName = normalizeString(args?.skill_name);
+    const agentType = normalizeAgentType(args?.agent_type);
+    const toolScope = normalizeToolScope(args?.tool_scope);
+    const subAgentPrompt = normalizeString(args?.subagent_prompt);
+    const allowedToolsResult = normalizeAllowedTools(args?.allowed_tools);
+    const maxTurnsResult = normalizeMaxTurns(args?.max_turns);
+    const taskDescription = normalizeString(args?.task_description) || normalizeString(args?.task);
+    const userMessage = normalizeString(args?.user_message) || normalizeString(args?.context) || taskDescription;
 
-    if (!skill_name || !task_description || !user_message) {
-      return { ok: false, errorCode: 'INVALID_TOOL_ARGUMENTS', message: '错误：skill_name、task_description、user_message 均为必填参数' };
+    if (!taskDescription || !userMessage) {
+      return { ok: false, errorCode: 'INVALID_TOOL_ARGUMENTS', message: '错误：task/task_description 和 context/user_message 为必填参数' };
+    }
+    if (!skillName && !agentType) {
+      return { ok: false, errorCode: 'INVALID_TOOL_ARGUMENTS', message: '错误：请提供 agent_type，或在确实需要现有 skill 流程时提供 skill_name' };
+    }
+    if (!allowedToolsResult.ok) {
+      return { ok: false, errorCode: 'INVALID_TOOL_ARGUMENTS', message: allowedToolsResult.message };
+    }
+    if (!maxTurnsResult.ok) {
+      return { ok: false, errorCode: 'INVALID_TOOL_ARGUMENTS', message: maxTurnsResult.message };
     }
 
     const manager = SubAgentManager.getInstance();
     const sessionKey = context.sessionId || 'unknown';
 
-    // 需要 AIService 和 SkillManager 实例
-    // AIService 使用默认配置创建，SkillManager 动态加载
-    const aiService = new AIService();
-    const skillManager = new SkillManager();
-    await skillManager.loadSkills();
+    const { aiService, skillManager } = await resolveSubAgentServices(context, Boolean(skillName));
 
-    const result = manager.spawn(
+    const result = await manager.spawn(
       sessionKey,
-      skill_name,
-      task_description,
-      user_message,
+      {
+        skillName,
+        agentType,
+        toolScope,
+        subAgentPrompt,
+        allowedTools: allowedToolsResult.value,
+        maxTurns: maxTurnsResult.value,
+        taskDescription,
+        userMessage,
+      },
       context.workingDirectory,
       aiService,
       skillManager,
@@ -81,17 +125,107 @@ export class SpawnSubagentTool implements Tool {
       return { ok: false, errorCode: 'TOOL_EXECUTION_ERROR', message: `派遣失败：${result.error}` };
     }
 
-    console.log('\n' + styles.highlight(`🚀 派遣子智能体: ${task_description}`));
+    console.log('\n' + styles.highlight(`🚀 派遣子智能体: ${taskDescription}`));
+    if (result.displayName) {
+      console.log(styles.text(`   Name: ${result.displayName}`));
+    }
     console.log(styles.text(`   ID: ${result.id}`));
-    console.log(styles.text(`   Skill: ${skill_name}\n`));
+    const displayAgentType = result.agentType || agentType || (skillName ? 'skill' : 'worker');
+    const displayToolScope = result.toolScope || toolScope || defaultToolScopeFor(displayAgentType);
+    const effectiveAllowedTools = result.allowedTools ?? allowedToolsResult.value;
+
+    console.log(styles.text(`   Type: ${displayAgentType}`));
+    console.log(styles.text(`   Scope: ${displayToolScope}\n`));
 
     return { ok: true, content: [
-      `子智能体 ${result.id} 已派遣，正在后台执行「${task_description}」。`,
-      `Skill: ${skill_name}`,
+      `已派遣 ${result.displayName || '子智能体'} (${result.id})。`,
+      `任务: ${taskDescription}`,
+      `类型: ${displayAgentType}`,
+      `工具范围: ${displayToolScope}`,
+      effectiveAllowedTools ? `工具: ${effectiveAllowedTools.length > 0 ? effectiveAllowedTools.join(', ') : '无'}` : '',
+      maxTurnsResult.value ? `轮次预算: ${maxTurnsResult.value}` : '轮次预算: 未设置',
+      skillName ? `Skill: ${skillName}` : '',
       `状态: running`,
-      ``,
-      `子智能体完成后会通知你结果和产出文件列表。届时请在最终回复里告知用户结果，并按需用 send_file 发送文件。`,
-      `你可以用 check_subagent 查看进度，用 stop_subagent 停止任务。`,
-    ].join('\n') };
+      `完成后会以后台结果通知回到主会话；你仍负责主线推进和最终回复。`,
+    ].filter(Boolean).join('\n') };
   }
+}
+
+function normalizeMaxTurns(value: unknown): { ok: true; value?: number } | { ok: false; message: string } {
+  if (value === undefined || value === null || value === '') {
+    return { ok: true, value: undefined };
+  }
+
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return { ok: false, message: '错误：max_turns 必须是正整数' };
+  }
+  return { ok: true, value: parsed };
+}
+
+function normalizeString(value: unknown): string {
+  return String(value || '').trim();
+}
+
+function normalizeAgentType(value: unknown): 'explorer' | 'reviewer' | 'worker' | 'tester' | undefined {
+  const text = normalizeString(value);
+  if (text === 'explorer' || text === 'reviewer' || text === 'worker' || text === 'tester') {
+    return text;
+  }
+  return undefined;
+}
+
+function normalizeToolScope(value: unknown): 'read_only' | 'workspace_write' | 'test_only' | undefined {
+  const text = normalizeString(value);
+  if (text === 'read_only' || text === 'workspace_write' || text === 'test_only') {
+    return text;
+  }
+  return undefined;
+}
+
+function normalizeAllowedTools(value: unknown): { ok: true; value?: string[] } | { ok: false; message: string } {
+  if (value === undefined || value === null || value === '') {
+    return { ok: true, value: undefined };
+  }
+
+  const rawTools = Array.isArray(value)
+    ? value
+    : String(value).split(',').map(item => item.trim()).filter(Boolean);
+  const safeTools = new Set<string>(SAFE_SUB_AGENT_TOOL_NAMES);
+  const normalized = Array.from(new Set(rawTools.map(tool => String(tool || '').trim()).filter(Boolean)));
+  const invalid = normalized.filter(tool => !safeTools.has(tool));
+  if (invalid.length > 0) {
+    return {
+      ok: false,
+      message: `错误：allowed_tools 包含不允许的工具：${invalid.join(', ')}。允许值：${SAFE_SUB_AGENT_TOOL_NAMES.join(', ')}`,
+    };
+  }
+  return { ok: true, value: normalized };
+}
+
+async function resolveSubAgentServices(
+  context: ToolExecutionContext,
+  needsSkills: boolean,
+): Promise<{ aiService: AIService; skillManager: SkillManager }> {
+  const runtimeServices = context.runtimeServices;
+  if (runtimeServices) {
+    return runtimeServices;
+  }
+
+  const aiService = new AIService();
+  const skillManager = new SkillManager();
+  if (needsSkills) {
+    await skillManager.loadSkills();
+  }
+  return { aiService, skillManager };
+}
+
+function defaultToolScopeFor(agentType: string): 'read_only' | 'workspace_write' | 'test_only' {
+  if (agentType === 'worker' || agentType === 'skill') {
+    return 'workspace_write';
+  }
+  if (agentType === 'tester') {
+    return 'test_only';
+  }
+  return 'read_only';
 }

--- a/src/tools/stop-subagent-tool.ts
+++ b/src/tools/stop-subagent-tool.ts
@@ -10,16 +10,13 @@ import { Logger } from '../utils/logger';
 export class StopSubagentTool implements Tool {
   definition: ToolDefinition = {
     name: 'stop_subagent',
-    description: `停止一个正在后台运行的子智能体。
-
-当用户要求取消或停止某个后台任务时使用。
-如果不确定 ID，先用 check_subagent 查看列表。`,
+    description: '停止当前会话下正在运行的后台子智能体。用户要求取消后台任务时使用；不确定 ID 时先用 check_subagent。',
     parameters: {
       type: 'object',
       properties: {
         subagent_id: {
           type: 'string',
-          description: '要停止的子智能体 ID（如 sub-1）',
+          description: '要停止的子智能体 ID 或展示名（如 sub-... 或 子agent1）',
         },
       },
       required: ['subagent_id'],
@@ -38,12 +35,18 @@ export class StopSubagentTool implements Tool {
     const result = manager.stopForParent(sessionKey, subagent_id);
 
     if (result === 'stopped') {
-      Logger.info(`[StopSubagent] 已停止 ${subagent_id}`);
-      return { ok: true, content: `子智能体 ${subagent_id} 已停止。` };
+      const info = manager.getInfoForParent(sessionKey, subagent_id);
+      const label = info?.displayName ? `${info.displayName} (${info.id})` : subagent_id;
+      Logger.info(`[StopSubagent] 已停止 ${label}`);
+      return { ok: true, content: `${label} 已停止。` };
     }
     if (result === 'not_running') {
       const info = manager.getInfoForParent(sessionKey, subagent_id);
-      return { ok: true, content: `子智能体 ${subagent_id} 当前状态为 ${info?.status || 'unknown'}，无法停止。` };
+      const label = info?.displayName ? `${info.displayName} (${info.id})` : subagent_id;
+      return { ok: true, content: `${label} 当前状态为 ${info?.status || 'unknown'}，无法停止。` };
+    }
+    if (result === 'forbidden') {
+      return { ok: false, errorCode: 'PERMISSION_DENIED', message: `无权停止子智能体 ${subagent_id}。它不属于当前会话。` };
     }
 
     return { ok: false, errorCode: 'TOOL_NOT_FOUND', message: `未找到子智能体 ${subagent_id}。` };

--- a/src/tools/tool-manager.ts
+++ b/src/tools/tool-manager.ts
@@ -15,7 +15,11 @@ import { StopSubagentTool } from './stop-subagent-tool';
 import { ResumeSubagentTool } from './resume-subagent-tool';
 import { UpdatePlanTool } from './update-plan-tool';
 import { RecordDecisionTool } from './record-decision-tool';
+import { AskParentTool } from './ask-parent-tool';
 import { DEFAULT_TOOL_NAMES } from './default-tool-names';
+import { mergeToolExecutionContext } from '../utils/tool-context';
+
+const INTERNAL_TOOL_NAMES = ['ask_parent'] as const;
 
 /**
  * 工具名别名映射（Claude Code 工具名 → CatsCo 内部注册名）
@@ -93,8 +97,15 @@ export class ToolManager implements ToolExecutor {
     }
 
     if (enabled) {
+      if (enabled.has('ask_parent')) {
+        this.registerTool(new AskParentTool());
+      }
+      const knownTools = new Set<string>([
+        ...(DEFAULT_TOOL_NAMES as readonly string[]),
+        ...(INTERNAL_TOOL_NAMES as readonly string[]),
+      ]);
       for (const toolName of enabled) {
-        if (!(DEFAULT_TOOL_NAMES as readonly string[]).includes(toolName)) {
+        if (!knownTools.has(toolName)) {
           Logger.warning(`未知工具已被忽略: ${toolName}`);
         }
       }
@@ -147,13 +158,12 @@ export class ToolManager implements ToolExecutor {
     }
 
     try {
-      const mergedContext: Partial<ToolExecutionContext> = {
+      const mergedContext = mergeToolExecutionContext({
         workingDirectory: this.workingDirectory,
         workspaceRoot: this.workingDirectory,
         conversationHistory: conversationHistory || [],
         ...this.contextDefaults,
-        ...contextOverrides,
-      };
+      }, contextOverrides);
       const context: ToolExecutionContext = {
         ...mergedContext,
         workingDirectory: mergedContext.getCurrentDirectory?.() || mergedContext.workingDirectory || this.workingDirectory,

--- a/src/types/tool.ts
+++ b/src/types/tool.ts
@@ -1,5 +1,7 @@
 import { ContentBlock } from './index';
 import type { PlanRuntime, RuntimePlanSnapshot } from '../core/plan-runtime';
+import type { AIService } from '../utils/ai-service';
+import type { SkillManager } from '../skills/skill-manager';
 
 /**
  * 工具参数定义
@@ -111,6 +113,11 @@ export interface ChannelCallbacks {
 /** @deprecated Use ChannelCallbacks instead */
 export type FeishuChannelCallbacks = ChannelCallbacks;
 
+export interface RuntimeToolServices {
+  aiService: AIService;
+  skillManager: SkillManager;
+}
+
 /**
  * 工具执行上下文
  */
@@ -128,6 +135,10 @@ export interface ToolExecutionContext {
   planRuntime?: PlanRuntime;
   getCurrentDirectory?: () => string;
   updateCurrentDirectory?: (directory: string) => void;
+  /** 子智能体需要主 agent 补充信息时使用；仅 subagent runtime 注入 */
+  requestParentInput?: (question: string) => Promise<string>;
+  /** 当前 runtime 已创建的共享服务，供调度类工具复用，避免重复初始化 */
+  runtimeServices?: RuntimeToolServices;
   /** 平台通道回调（飞书/CatsCompany 等聊天会话时由平台层注入） */
   channel?: ChannelCallbacks;
 }

--- a/src/utils/session-log-schema.ts
+++ b/src/utils/session-log-schema.ts
@@ -38,11 +38,30 @@ export interface SessionRuntimeLogEntry {
   message: string;
 }
 
+export interface SessionSubAgentEventLogEntry {
+  entry_type: 'subagent_event';
+  timestamp: string;
+  session_id: string;
+  session_type: string;
+  subagent: {
+    id: string;
+    name?: string;
+    type?: string;
+    status?: string;
+    seq: number;
+  };
+  event: {
+    type: string;
+    summary: string;
+    payload?: Record<string, unknown>;
+  };
+}
+
 export interface LegacySessionTurnLogEntry extends Omit<SessionTurnLogEntry, 'entry_type'> {
   entry_type?: undefined;
 }
 
-export type SessionLogEntry = SessionTurnLogEntry | SessionRuntimeLogEntry;
+export type SessionLogEntry = SessionTurnLogEntry | SessionRuntimeLogEntry | SessionSubAgentEventLogEntry;
 export type ParsedSessionLogEntry = SessionLogEntry | LegacySessionTurnLogEntry;
 
 export function parseSessionLogContent(content: string): ParsedSessionLogEntry[] {

--- a/src/utils/session-turn-logger.ts
+++ b/src/utils/session-turn-logger.ts
@@ -4,15 +4,19 @@ import { Message, ContentBlock } from '../types';
 import type {
   SessionLogEntry,
   SessionRuntimeLogEntry,
+  SessionSubAgentEventLogEntry,
   SessionToolCallLog,
   SessionTurnLogEntry,
 } from './session-log-schema';
+import type { SubAgentRuntimeEvent } from '../core/sub-agent-events';
+import type { SubAgentInfo } from '../core/sub-agent-session';
 
 export type {
   LegacySessionTurnLogEntry,
   ParsedSessionLogEntry,
   SessionLogEntry,
   SessionRuntimeLogEntry,
+  SessionSubAgentEventLogEntry,
   SessionToolCallLog,
   SessionTurnLogEntry,
 } from './session-log-schema';
@@ -105,6 +109,28 @@ export class SessionTurnLogger {
       message,
     };
     this.appendLog(runtimeEntry);
+  }
+
+  logSubAgentEvent(event: SubAgentRuntimeEvent, info?: SubAgentInfo): void {
+    const entry: SessionSubAgentEventLogEntry = {
+      entry_type: 'subagent_event',
+      timestamp: new Date(event.timestamp).toISOString(),
+      session_id: this.sessionId,
+      session_type: this.sessionType,
+      subagent: {
+        id: event.subAgentId,
+        ...(event.subAgentName && { name: event.subAgentName }),
+        ...(info?.agentType && { type: info.agentType }),
+        ...(info?.status && { status: info.status }),
+        seq: event.seq,
+      },
+      event: {
+        type: event.type,
+        summary: this.truncate(event.summary, MAX_RUNTIME_FEEDBACK_LENGTH),
+        ...(event.payload && { payload: event.payload }),
+      },
+    };
+    this.appendLog(entry);
   }
 
   private extractText(content: string | ContentBlock[]): string {

--- a/src/utils/tool-context.ts
+++ b/src/utils/tool-context.ts
@@ -1,0 +1,22 @@
+import { ToolExecutionContext } from '../types/tool';
+
+/**
+ * Merge tool execution context without letting undefined override a live value.
+ *
+ * This keeps cancellation and channel callbacks intact when a caller passes a
+ * partial override object with optional fields left undefined.
+ */
+export function mergeToolExecutionContext(
+  base: Partial<ToolExecutionContext>,
+  overrides?: Partial<ToolExecutionContext>,
+): ToolExecutionContext {
+  const merged: Record<string, unknown> = { ...base };
+  if (overrides) {
+    for (const [key, value] of Object.entries(overrides)) {
+      if (value !== undefined) {
+        merged[key] = value;
+      }
+    }
+  }
+  return merged as unknown as ToolExecutionContext;
+}

--- a/tests/agent-session-interrupt-subagents.test.ts
+++ b/tests/agent-session-interrupt-subagents.test.ts
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+const agentSessionSource = readFileSync(join(process.cwd(), 'src/core/agent-session.ts'), 'utf-8');
+
+test('AgentSession interrupt also stops background subagents', () => {
+  const interruptBlock = agentSessionSource.match(/requestInterrupt\(\): void \{[\s\S]*?\n  \}/)?.[0] || '';
+  assert.match(interruptBlock, /this\.stopSubAgents\('用户请求中止'\)/);
+  assert.match(interruptBlock, /this\.activeAbortController\?\.abort\(\)/);
+});

--- a/tests/agent-turn-controller-callbacks.test.ts
+++ b/tests/agent-turn-controller-callbacks.test.ts
@@ -1,0 +1,10 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+const source = readFileSync(join(process.cwd(), 'src/core/agent-turn-controller.ts'), 'utf-8');
+
+test('AgentTurnController forwards thinking callbacks to ConversationRunner', () => {
+  assert.match(source, /onThinking:\s*callbacks\?\.onThinking/);
+});

--- a/tests/message-session-manager.test.ts
+++ b/tests/message-session-manager.test.ts
@@ -154,6 +154,27 @@ describe('MessageSessionManager', () => {
     }
   });
 
+  test('ttl cleanup keeps sessions with active subagents', async () => {
+    const { MessageSessionManager, SubAgentManager } = loadSessionManagerModules();
+    const manager = new MessageSessionManager(buildMockServices(), 'ttl-active-subagent-test', { ttl: 10 });
+    const subAgentManager = SubAgentManager.getInstance();
+    const originalHasActiveForParent = subAgentManager.hasActiveForParent.bind(subAgentManager);
+    (subAgentManager as any).hasActiveForParent = (key: string) => key === 'user:ttl-active-subagent';
+
+    try {
+      const session = manager.getOrCreate('user:ttl-active-subagent');
+      session.lastActiveAt = 100;
+
+      await (manager as any).cleanupExpiredSessions(111);
+
+      assert.equal((manager as any).sessions.has('user:ttl-active-subagent'), true);
+      assert.equal(session.lastActiveAt, 111);
+    } finally {
+      (subAgentManager as any).hasActiveForParent = originalHasActiveForParent;
+      await manager.destroy();
+    }
+  });
+
   test('ttl cleanup does not remove a new same-key session created while old cleanup is pending', async () => {
     const { MessageSessionManager } = loadSessionManagerModules();
     const manager = new MessageSessionManager(buildMockServices(), 'ttl-race-test', { ttl: 10 });
@@ -189,6 +210,7 @@ function loadSessionManagerModules(): any {
   for (const modulePath of [
     '../src/core/message-session-manager',
     '../src/core/agent-session',
+    '../src/core/sub-agent-manager',
     '../src/core/session-lifecycle-manager',
     '../src/utils/session-store',
   ]) {
@@ -196,6 +218,7 @@ function loadSessionManagerModules(): any {
   }
   return {
     MessageSessionManager: require('../src/core/message-session-manager').MessageSessionManager,
+    SubAgentManager: require('../src/core/sub-agent-manager').SubAgentManager,
     SessionStore: require('../src/utils/session-store').SessionStore,
   };
 }

--- a/tests/prompt-copy-regression.test.ts
+++ b/tests/prompt-copy-regression.test.ts
@@ -14,6 +14,10 @@ describe('prompt copy regression', () => {
     assert.doesNotMatch(descriptions, /reply 工具/);
     assert.doesNotMatch(descriptions, /用 reply/);
     assert.doesNotMatch(descriptions, /reply 和 send_file/);
+    assert.match(descriptions, /调用成功后立即返回，不等待任务完成/);
+    assert.match(descriptions, /只有本工具成功返回的展示名和 ID 才算真实已派出/);
+    assert.match(descriptions, /不要编造子智能体或 sub-\.\.\. ID/);
+    assert.match(descriptions, /简单问答、短链路排查和很快能完成的小任务不要用/);
   });
 
   test('spawn_subagent handoff result does not instruct the model to use a reply tool', async () => {
@@ -48,6 +52,10 @@ describe('prompt copy regression', () => {
       assert.doesNotMatch(content, /reply 工具/);
       assert.doesNotMatch(content, /用 reply/);
       assert.doesNotMatch(content, /reply 和 send_file/);
+      assert.match(content, /已派遣 子智能体 \(sub-test\)/);
+      assert.match(content, /完成后会以后台结果通知回到主会话/);
+      assert.match(content, /你仍负责主线推进和最终回复/);
+      assert.doesNotMatch(content, /可以继续调用 spawn_subagent 派发/);
     } finally {
       (SubAgentManager as any).getInstance = originalGetInstance;
     }

--- a/tests/subagent-runtime-events.test.ts
+++ b/tests/subagent-runtime-events.test.ts
@@ -1,0 +1,962 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { formatSubAgentEventLine, SubAgentEventStore } from '../src/core/sub-agent-events';
+import { ConversationRunner } from '../src/core/conversation-runner';
+import { SubAgentManager } from '../src/core/sub-agent-manager';
+import { SubAgentSession } from '../src/core/sub-agent-session';
+import { TurnContextBuilder } from '../src/core/turn-context-builder';
+import { SpawnSubagentTool } from '../src/tools/spawn-subagent-tool';
+
+describe('subagent runtime events', () => {
+  test('event store keeps bounded per-parent event streams with per-agent sequence numbers', () => {
+    const store = new SubAgentEventStore({ maxEventsPerParent: 2, retentionMs: Number.MAX_SAFE_INTEGER });
+
+    store.append({
+      parentSessionKey: 'parent-a',
+      subAgentId: 'sub-a',
+      subAgentName: '子agent1',
+      type: 'agent_spawned',
+      summary: 'spawned',
+      timestamp: 1000,
+    });
+    store.append({
+      parentSessionKey: 'parent-a',
+      subAgentId: 'sub-a',
+      subAgentName: '子agent1',
+      type: 'agent_progress',
+      summary: 'progress 1',
+      timestamp: 1001,
+    });
+    store.append({
+      parentSessionKey: 'parent-a',
+      subAgentId: 'sub-b',
+      type: 'agent_progress',
+      summary: 'progress 2',
+      timestamp: 1002,
+    });
+
+    const events = store.listByParent('parent-a');
+    assert.equal(events.length, 2);
+    assert.equal(events[0].summary, 'progress 1');
+    assert.equal(events[0].seq, 2);
+    assert.equal(events[1].summary, 'progress 2');
+    assert.equal(events[1].seq, 1);
+    assert.match(formatSubAgentEventLine(events[0]), /子agent1/);
+  });
+
+  test('event store can expand capacity based on active subagent count', () => {
+    const store = new SubAgentEventStore({
+      maxEventsPerParent: 2,
+      maxEventsPerAgent: 2,
+      retentionMs: Number.MAX_SAFE_INTEGER,
+    });
+
+    for (let i = 0; i < 6; i += 1) {
+      store.append({
+        parentSessionKey: 'parent-dynamic',
+        subAgentId: `sub-${i % 3}`,
+        type: 'agent_progress',
+        summary: `event ${i}`,
+        timestamp: 1000 + i,
+      });
+    }
+
+    const events = store.listByParent('parent-dynamic');
+    assert.equal(events.length, 6);
+    assert.equal(events[0].summary, 'event 0');
+    assert.equal(events[5].summary, 'event 5');
+  });
+
+  test('manager formats runtime observation from recent subagent events', () => {
+    const manager = SubAgentManager.getInstance();
+    const parentSessionKey = `test-parent:${Date.now()}:manager`;
+
+    manager.recordEvent(parentSessionKey, 'sub-test', 'agent_spawned', '派遣 explorer 扫描登录链路');
+    manager.recordEvent(parentSessionKey, 'sub-test', 'agent_progress', '已定位 /api/cats/status');
+
+    const observation = manager.buildObservationForParent(parentSessionKey, 5);
+    assert.match(observation, /sub-test/);
+    assert.match(observation, /派遣 explorer/);
+    assert.match(observation, /已定位/);
+  });
+
+  test('turn context injects compact subagent status before the latest user message', async () => {
+    const originalGetInstance = SubAgentManager.getInstance;
+    const parentSessionKey = `test-parent:${Date.now()}:turn`;
+    (SubAgentManager as any).getInstance = () => ({
+      listByParent: () => [{
+        id: 'sub-running',
+        displayName: '子agent1',
+        agentType: 'explorer',
+        skillName: 'explorer',
+        toolScope: 'read_only',
+        taskDescription: 'dashboard 账号链路审查',
+        status: 'running',
+        createdAt: Date.now(),
+        progressLog: ['完成 dashboard 账号链路审查'],
+        outputFiles: [],
+        allowedTools: ['read_file', 'grep'],
+      }],
+      buildObservationForParent: () => '子agent1/sub-running #1 agent_tool_end: read_file 完成',
+    });
+    const builder = new TurnContextBuilder();
+    try {
+      const result = await builder.build({
+        sessionKey: parentSessionKey,
+        durableMessages: [
+          { role: 'system', content: 'base system' },
+          { role: 'user', content: '用户新问题' },
+        ],
+        runtimeFeedback: [],
+        skillRuntime: {
+          reloadSkills: async () => undefined,
+          buildSkillsListMessage: () => null,
+        } as any,
+      });
+
+      const eventIndex = result.messages.findIndex(message => (
+        message.role === 'system'
+        && typeof message.content === 'string'
+        && message.content.startsWith('[transient_subagent_status]')
+      ));
+      const userIndex = result.messages.findIndex(message => message.role === 'user' && message.content === '用户新问题');
+
+      assert.ok(eventIndex >= 0, 'subagent status observation should be injected');
+      assert.ok(eventIndex < userIndex, 'subagent observation should appear before latest user message');
+      assert.match(String(result.messages[eventIndex].content), /完成 dashboard 账号链路审查/);
+      assert.doesNotMatch(
+        String(result.messages[eventIndex].content),
+        /agent_tool_end|最近 runtime 事件|read_file 完成/,
+        'automatic current-turn observation should not include noisy runtime event details',
+      );
+
+      const durable = builder.removeTransientMessages(result.messages);
+      assert.equal(durable.some(message => (
+        typeof message.content === 'string'
+        && message.content.includes('完成 dashboard 账号链路审查')
+      )), false);
+    } finally {
+      (SubAgentManager as any).getInstance = originalGetInstance;
+    }
+  });
+
+  test('turn context does not inject subagent status for sessions without subagents', async () => {
+    const builder = new TurnContextBuilder();
+    const result = await builder.build({
+      sessionKey: `test-parent:${Date.now()}:empty`,
+      durableMessages: [
+        { role: 'system', content: 'base system' },
+        { role: 'user', content: '普通问题' },
+      ],
+      runtimeFeedback: [],
+      skillRuntime: {
+        reloadSkills: async () => undefined,
+        buildSkillsListMessage: () => null,
+      } as any,
+    });
+
+    assert.equal(result.messages.some(message => (
+      message.role === 'system'
+      && typeof message.content === 'string'
+      && message.content.startsWith('[transient_subagent_status]')
+    )), false);
+  });
+
+  test('turn context does not repeat completed subagent status after result handoff', async () => {
+    const originalGetInstance = SubAgentManager.getInstance;
+    (SubAgentManager as any).getInstance = () => ({
+      listByParent: () => [{
+        id: 'sub-completed',
+        displayName: '子agent1',
+        agentType: 'explorer',
+        skillName: 'explorer',
+        toolScope: 'read_only',
+        taskDescription: '完成项',
+        status: 'completed',
+        createdAt: Date.now(),
+        progressLog: ['已完成'],
+        resultSummary: '完成摘要',
+        outputFiles: [],
+        allowedTools: ['read_file'],
+      }],
+      buildObservationForParent: () => '子agent1/sub-completed #2 agent_completed: 已完成',
+    });
+    const builder = new TurnContextBuilder();
+    try {
+      const result = await builder.build({
+        sessionKey: `test-parent:${Date.now()}:completed-only`,
+        durableMessages: [
+          { role: 'system', content: 'base system' },
+          { role: 'user', content: '普通问题' },
+        ],
+        runtimeFeedback: [],
+        skillRuntime: {
+          reloadSkills: async () => undefined,
+          buildSkillsListMessage: () => null,
+        } as any,
+      });
+
+      assert.equal(result.messages.some(message => (
+        message.role === 'system'
+        && typeof message.content === 'string'
+        && message.content.startsWith('[transient_subagent_status]')
+      )), false);
+    } finally {
+      (SubAgentManager as any).getInstance = originalGetInstance;
+    }
+  });
+
+  test('subagent tool-end events summarize tool result instead of tool use id', async () => {
+    const originalRun = ConversationRunner.prototype.run;
+    const workingDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-subagent-tool-end-'));
+    const events: Array<{ type: string; summary: string }> = [];
+
+    (ConversationRunner.prototype as any).run = async function runMock(messages: any[], callbacks: any) {
+      callbacks?.onToolEnd?.('read_file', 'call_function_fake_id', '真实工具结果：找到 src/core/sub-agent-session.ts');
+      return {
+        response: 'done',
+        finalResponseVisible: true,
+        messages,
+        newMessages: [],
+      };
+    };
+
+    try {
+      const session = new SubAgentSession('sub-tool-end', {} as any, { getSkill: () => undefined } as any, {
+        agentType: 'explorer',
+        taskDescription: 'check tool end',
+        userMessage: 'check tool end',
+        workingDirectory,
+        emitEvent: (type, summary) => {
+          events.push({ type, summary });
+        },
+      });
+
+      await session.run();
+
+      const toolEndEvent = events.find(event => event.type === 'agent_tool_end');
+      assert.ok(toolEndEvent, 'expected an agent_tool_end event');
+      assert.match(toolEndEvent.summary, /真实工具结果/);
+      assert.doesNotMatch(toolEndEvent.summary, /call_function_fake_id/);
+
+      await session.close();
+    } finally {
+      ConversationRunner.prototype.run = originalRun;
+      fs.rmSync(workingDirectory, { recursive: true, force: true });
+    }
+  });
+
+  test('subagent result summary falls back to recent progress when final response is empty', async () => {
+    const originalRun = ConversationRunner.prototype.run;
+    const workingDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-subagent-empty-result-'));
+
+    (ConversationRunner.prototype as any).run = async function runMock(messages: any[], callbacks: any) {
+      callbacks?.onToolEnd?.('grep', 'call_function_fake_id', '找到 dashboard/index.html 中的 renderCatsWorkingBlocks');
+      return {
+        response: '',
+        finalResponseVisible: false,
+        messages,
+        newMessages: [],
+      };
+    };
+
+    try {
+      const session = new SubAgentSession('sub-empty-result', {} as any, { getSkill: () => undefined } as any, {
+        agentType: 'explorer',
+        taskDescription: 'check empty result fallback',
+        userMessage: 'check empty result fallback',
+        workingDirectory,
+      });
+
+      await session.run();
+
+      const summary = session.getInfo().resultSummary || '';
+      assert.match(summary, /未形成最终摘要/);
+      assert.match(summary, /最近进度/);
+      assert.notEqual(summary, '（无结果）');
+    } finally {
+      ConversationRunner.prototype.run = originalRun;
+      fs.rmSync(workingDirectory, { recursive: true, force: true });
+    }
+  });
+
+  test('subagent result summary ignores assistant preamble attached to tool calls', async () => {
+    const originalRun = ConversationRunner.prototype.run;
+    const workingDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-subagent-tool-preamble-'));
+
+    (ConversationRunner.prototype as any).run = async function runMock(messages: any[], callbacks: any) {
+      messages.push({
+        role: 'assistant',
+        content: '我来读取这些核心文件，分析完整消息链路。',
+        tool_calls: [{
+          id: 'call_function_fake_id',
+          type: 'function',
+          function: { name: 'grep', arguments: '{}' },
+        }],
+      });
+      callbacks?.onToolEnd?.('grep', 'call_function_fake_id', '找到 server/wshandler.go');
+      return {
+        response: '',
+        finalResponseVisible: false,
+        messages,
+        newMessages: [],
+      };
+    };
+
+    try {
+      const session = new SubAgentSession('sub-tool-preamble', {} as any, { getSkill: () => undefined } as any, {
+        agentType: 'explorer',
+        taskDescription: 'check tool preamble fallback',
+        userMessage: 'check tool preamble fallback',
+        workingDirectory,
+      });
+
+      await session.run();
+
+      const summary = session.getInfo().resultSummary || '';
+      assert.match(summary, /未形成最终摘要/);
+      assert.doesNotMatch(summary, /我来读取这些核心文件/);
+    } finally {
+      ConversationRunner.prototype.run = originalRun;
+      fs.rmSync(workingDirectory, { recursive: true, force: true });
+    }
+  });
+
+  test('ask_parent puts a subagent into waiting state and resume continues it', async () => {
+    const originalRun = ConversationRunner.prototype.run;
+    const workingDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-subagent-ask-parent-'));
+    const notifications: Array<{ id: string; task: string; question: string }> = [];
+    const events: Array<{ type: string; summary: string }> = [];
+    let session: SubAgentSession;
+
+    (ConversationRunner.prototype as any).run = async function runMock(messages: any[]) {
+      const requestParentInput = (this as any).toolExecutionContext?.requestParentInput;
+      assert.equal(typeof requestParentInput, 'function');
+      const answer = await requestParentInput('需要确认 CatsCompany 源码路径');
+      return {
+        response: `收到主 agent 回复：${answer}`,
+        finalResponseVisible: true,
+        messages,
+        newMessages: [],
+      };
+    };
+
+    try {
+      session = new SubAgentSession('sub-ask-parent', {} as any, { getSkill: () => undefined } as any, {
+        agentType: 'explorer',
+        taskDescription: 'ask parent',
+        userMessage: 'ask parent',
+        workingDirectory,
+        notifyParent: async (id, task, question) => {
+          notifications.push({ id, task, question });
+        },
+        emitEvent: (type, summary) => {
+          events.push({ type, summary });
+        },
+      });
+
+      const runPromise = session.run();
+      await waitFor(() => session.getInfo().status === 'waiting_for_input' && notifications.length === 1);
+
+      assert.equal(notifications[0].id, 'sub-ask-parent');
+      assert.match(notifications[0].question, /CatsCompany 源码路径/);
+      assert.equal(session.getInfo().pendingQuestion, '需要确认 CatsCompany 源码路径');
+      assert.ok(session.getInfo().pendingQuestionSince);
+      assert.equal(events.some(event => event.type === 'agent_waiting'), true);
+      assert.equal(session.resume('E:\\work\\cats\\cats-company'), true);
+
+      await runPromise;
+
+      assert.equal(session.getInfo().status, 'completed');
+      assert.match(session.getInfo().resultSummary || '', /E:\\work\\cats\\cats-company/);
+    } finally {
+      ConversationRunner.prototype.run = originalRun;
+      fs.rmSync(workingDirectory, { recursive: true, force: true });
+    }
+  });
+
+  test('spawn_subagent reuses runtime services and does not load skills for built-in agents', async () => {
+    const originalGetInstance = SubAgentManager.getInstance;
+    let loadSkillsCalled = false;
+    let capturedAiService: unknown;
+    let capturedSkillManager: unknown;
+
+    (SubAgentManager as any).getInstance = () => ({
+      spawn(
+        _parentSessionKey: string,
+        request: any,
+        _workingDirectory: string,
+        aiService: unknown,
+        skillManager: unknown,
+      ) {
+        capturedAiService = aiService;
+        capturedSkillManager = skillManager;
+        assert.deepEqual(request.allowedTools, ['read_file', 'grep']);
+        assert.equal(request.subAgentPrompt, '只输出文件路径和结论');
+        assert.equal(request.maxTurns, 9);
+        return {
+          id: 'sub-runtime-services',
+          agentType: request.agentType,
+          skillName: request.agentType,
+          toolScope: 'read_only',
+          allowedTools: request.allowedTools,
+          taskDescription: request.taskDescription,
+          status: 'running',
+          createdAt: Date.now(),
+          progressLog: [],
+          outputFiles: [],
+        };
+      },
+    });
+
+    const runtimeServices = {
+      aiService: { marker: 'shared-ai' },
+      skillManager: {
+        marker: 'shared-skills',
+        async loadSkills() {
+          loadSkillsCalled = true;
+        },
+      },
+    };
+
+    try {
+      const result = await new SpawnSubagentTool().execute({
+        agent_type: 'explorer',
+        allowed_tools: ['read_file', 'grep'],
+        max_turns: 9,
+        subagent_prompt: '只输出文件路径和结论',
+        task: '扫描登录链路',
+        context: '只读查看登录链路',
+      }, {
+        workingDirectory: process.cwd(),
+        conversationHistory: [],
+        sessionId: 'cc_user:test',
+        runtimeServices: runtimeServices as any,
+      });
+
+      assert.equal(result.ok, true);
+      assert.equal(loadSkillsCalled, false);
+      assert.equal(capturedAiService, runtimeServices.aiService);
+      assert.equal(capturedSkillManager, runtimeServices.skillManager);
+    } finally {
+      (SubAgentManager as any).getInstance = originalGetInstance;
+    }
+  });
+
+  test('spawn_subagent rejects unsafe tools before creating a subagent', async () => {
+    const result = await new SpawnSubagentTool().execute({
+      agent_type: 'worker',
+      allowed_tools: ['read_file', 'send_text'],
+      task: '尝试越权',
+      context: '不应该派遣',
+    }, {
+      workingDirectory: process.cwd(),
+      conversationHistory: [],
+      sessionId: 'cc_user:test',
+      runtimeServices: {
+        aiService: {} as any,
+        skillManager: {} as any,
+      },
+    });
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.match(result.message, /send_text/);
+    }
+  });
+
+  test('explicit allowed tools cannot exceed the selected tool scope', () => {
+    const readOnlySession = new SubAgentSession(
+      'sub-scope-readonly',
+      {} as any,
+      { getSkill: () => undefined } as any,
+      {
+        agentType: 'explorer',
+        toolScope: 'read_only',
+        allowedTools: ['read_file', 'write_file', 'execute_shell'],
+        taskDescription: 'scope check',
+        userMessage: 'scope check',
+        workingDirectory: process.cwd(),
+      },
+    );
+
+    assert.deepStrictEqual(readOnlySession.allowedTools, ['read_file']);
+
+    const testerSession = new SubAgentSession(
+      'sub-scope-tester',
+      {} as any,
+      { getSkill: () => undefined } as any,
+      {
+        agentType: 'tester',
+        toolScope: 'test_only',
+        allowedTools: ['grep', 'write_file', 'execute_shell'],
+        taskDescription: 'scope check',
+        userMessage: 'scope check',
+        workingDirectory: process.cwd(),
+      },
+    );
+
+    assert.deepStrictEqual(testerSession.allowedTools, ['grep', 'execute_shell']);
+  });
+
+  test('manager closes finished sessions immediately while keeping lightweight status', async () => {
+    const manager = SubAgentManager.getInstance();
+    const parentSessionKey = `test-parent:${Date.now()}:finalize`;
+    const injectedMessages: string[] = [];
+    const closedIds: string[] = [];
+    const eventLogs: Array<{ event: any; info?: any }> = [];
+    const platformEvents: Array<{ event: any; info?: any }> = [];
+
+    manager.registerPlatformCallbacks(parentSessionKey, {
+      injectMessage: async (text: string) => {
+        injectedMessages.push(text);
+      },
+      onSubAgentEvent: (event: any, info?: any) => {
+        platformEvents.push({ event, info });
+      },
+    });
+    manager.registerEventLogger(parentSessionKey, (event, info) => {
+      eventLogs.push({ event, info });
+    });
+
+    const originalRun = SubAgentSession.prototype.run;
+    const originalClose = SubAgentSession.prototype.close;
+    (SubAgentSession.prototype as any).run = async function runMock() {
+      this.status = 'completed';
+      this.completedAt = Date.now();
+      this.resultSummary = 'done';
+    };
+    (SubAgentSession.prototype as any).close = async function closeMock() {
+      closedIds.push(this.id);
+    };
+
+    try {
+      const spawned = await manager.spawn(
+        parentSessionKey,
+        {
+          agentType: 'explorer',
+          taskDescription: 'scan',
+          userMessage: 'scan context',
+        },
+        process.cwd(),
+        {} as any,
+        { getSkill: () => undefined } as any,
+      );
+      assert.ok(!('error' in spawned));
+      assert.match(spawned.displayName || '', /^子agent\d+$/);
+
+      await waitFor(() => closedIds.includes(spawned.id));
+      const info = manager.getInfoForParent(parentSessionKey, spawned.id);
+      assert.equal(info?.status, 'completed');
+      assert.equal(info?.resultSummary, 'done');
+      assert.equal(manager.stopForParent(parentSessionKey, spawned.id), 'not_running');
+
+      await waitFor(() => injectedMessages.length > 0);
+      assert.match(injectedMessages[0], /已完成/);
+      assert.match(injectedMessages[0], /子agent\d+/);
+      assert.equal(eventLogs[0].event.subAgentName, spawned.displayName);
+      assert.equal(eventLogs[0].info.displayName, spawned.displayName);
+      assert.equal(platformEvents[0].event.type, 'agent_spawned');
+      assert.equal(platformEvents[0].info.displayName, spawned.displayName);
+    } finally {
+      SubAgentSession.prototype.run = originalRun;
+      SubAgentSession.prototype.close = originalClose;
+      manager.unregisterEventLogger(parentSessionKey);
+      manager.unregisterPlatformCallbacks(parentSessionKey);
+    }
+  });
+
+  test('manager unrefs completed subagent retention timer', async () => {
+    const manager = SubAgentManager.getInstance();
+    const parentSessionKey = `test-parent:${Date.now()}:retention-unref`;
+    let unrefCalled = false;
+    let closed = false;
+
+    manager.registerPlatformCallbacks(parentSessionKey, {
+      injectMessage: async () => undefined,
+    });
+
+    const originalRun = SubAgentSession.prototype.run;
+    const originalClose = SubAgentSession.prototype.close;
+    const originalSetTimeout = globalThis.setTimeout;
+    (SubAgentSession.prototype as any).run = async function runMock() {
+      this.status = 'completed';
+      this.completedAt = Date.now();
+      this.resultSummary = 'done';
+    };
+    (SubAgentSession.prototype as any).close = async function closeMock() {
+      closed = true;
+    };
+    (globalThis as any).setTimeout = ((handler: TimerHandler, timeout?: number, ...args: any[]) => {
+      if (timeout === 30 * 60 * 1000) {
+        return {
+          unref() {
+            unrefCalled = true;
+            return this;
+          },
+        };
+      }
+      return originalSetTimeout(handler, timeout, ...args);
+    }) as typeof setTimeout;
+
+    try {
+      const spawned = await manager.spawn(
+        parentSessionKey,
+        {
+          agentType: 'explorer',
+          taskDescription: 'retention unref',
+          userMessage: 'retention unref',
+        },
+        process.cwd(),
+        {} as any,
+        { getSkill: () => undefined } as any,
+      );
+
+      assert.ok(!('error' in spawned));
+      await waitFor(() => closed);
+      await waitFor(() => unrefCalled);
+    } finally {
+      globalThis.setTimeout = originalSetTimeout;
+      SubAgentSession.prototype.run = originalRun;
+      SubAgentSession.prototype.close = originalClose;
+      manager.unregisterPlatformCallbacks(parentSessionKey);
+    }
+  });
+
+  test('manager injects compact subagent completion summaries into the parent session', async () => {
+    const manager = SubAgentManager.getInstance();
+    const parentSessionKey = `test-parent:${Date.now()}:compact-completion`;
+    const injectedMessages: string[] = [];
+    const longSummary = '这是很长的子 agent 审查结果。'.repeat(400);
+
+    manager.registerPlatformCallbacks(parentSessionKey, {
+      injectMessage: async (text: string) => {
+        injectedMessages.push(text);
+      },
+    });
+
+    const originalRun = SubAgentSession.prototype.run;
+    const originalClose = SubAgentSession.prototype.close;
+    (SubAgentSession.prototype as any).run = async function runMock() {
+      this.status = 'completed';
+      this.completedAt = Date.now();
+      this.resultSummary = longSummary;
+    };
+    (SubAgentSession.prototype as any).close = async function closeMock() {};
+
+    try {
+      const spawned = await manager.spawn(
+        parentSessionKey,
+        {
+          agentType: 'explorer',
+          taskDescription: 'compact result',
+          userMessage: 'compact result',
+        },
+        process.cwd(),
+        {} as any,
+        { getSkill: () => undefined } as any,
+      );
+      assert.ok(!('error' in spawned));
+
+      await waitFor(() => injectedMessages.length > 0);
+      assert.match(injectedMessages[0], /结果摘要/);
+      assert.match(injectedMessages[0], /已压缩/);
+      assert.ok(injectedMessages[0].length < longSummary.length / 2);
+      assert.match(injectedMessages[0], /check_subagent/);
+    } finally {
+      SubAgentSession.prototype.run = originalRun;
+      SubAgentSession.prototype.close = originalClose;
+      manager.unregisterPlatformCallbacks(parentSessionKey);
+    }
+  });
+
+  test('manager unregisters platform callbacks so expired sessions cannot leak callbacks', async () => {
+    const manager = SubAgentManager.getInstance();
+    const parentSessionKey = `test-parent:${Date.now()}:unregister-platform`;
+
+    manager.registerPlatformCallbacks(parentSessionKey, {
+      injectMessage: async () => undefined,
+    });
+    manager.unregisterPlatformCallbacks(parentSessionKey);
+
+    const spawned = await manager.spawn(
+      parentSessionKey,
+      {
+        agentType: 'explorer',
+        taskDescription: 'should not spawn',
+        userMessage: 'should not spawn',
+      },
+      process.cwd(),
+      {} as any,
+      { getSkill: () => undefined } as any,
+    );
+
+    assert.ok('error' in spawned);
+    assert.match(spawned.error, /平台回调未注册/);
+  });
+
+  test('manager retries final parent notification before giving up', async () => {
+    const manager = SubAgentManager.getInstance();
+    const parentSessionKey = `test-parent:${Date.now()}:notify-retry`;
+    let attempts = 0;
+    const closedIds: string[] = [];
+
+    manager.registerPlatformCallbacks(parentSessionKey, {
+      injectMessage: async () => {
+        attempts += 1;
+        if (attempts < 3) {
+          throw new Error('temporary inject failure');
+        }
+      },
+    });
+
+    const originalRun = SubAgentSession.prototype.run;
+    const originalClose = SubAgentSession.prototype.close;
+    (SubAgentSession.prototype as any).run = async function runMock() {
+      this.status = 'completed';
+      this.completedAt = Date.now();
+      this.resultSummary = 'done after retry';
+    };
+    (SubAgentSession.prototype as any).close = async function closeMock() {
+      closedIds.push(this.id);
+    };
+
+    try {
+      const spawned = await manager.spawn(
+        parentSessionKey,
+        {
+          agentType: 'explorer',
+          taskDescription: 'notify retry',
+          userMessage: 'notify retry',
+        },
+        process.cwd(),
+        {} as any,
+        { getSkill: () => undefined } as any,
+      );
+
+      assert.ok(!('error' in spawned));
+      await waitFor(() => closedIds.includes(spawned.id));
+      await waitFor(() => attempts === 3, 400);
+    } finally {
+      SubAgentSession.prototype.run = originalRun;
+      SubAgentSession.prototype.close = originalClose;
+      manager.unregisterPlatformCallbacks(parentSessionKey);
+    }
+  });
+
+  test('manager waits for platform spawn event before returning from spawn', async () => {
+    const manager = SubAgentManager.getInstance();
+    const parentSessionKey = `test-parent:${Date.now()}:spawn-order`;
+    let spawnEventDelivered = false;
+
+    manager.registerPlatformCallbacks(parentSessionKey, {
+      injectMessage: async () => undefined,
+      onSubAgentEvent: async (event) => {
+        if (event.type !== 'agent_spawned') return;
+        await new Promise(resolve => setTimeout(resolve, 10));
+        spawnEventDelivered = true;
+      },
+    });
+
+    const originalRun = SubAgentSession.prototype.run;
+    (SubAgentSession.prototype as any).run = async function runMock() {
+      this.status = 'stopped';
+      this.completedAt = Date.now();
+    };
+
+    try {
+      const spawned = await manager.spawn(
+        parentSessionKey,
+        {
+          agentType: 'explorer',
+          taskDescription: 'ordered spawn',
+          userMessage: 'ordered spawn',
+        },
+        process.cwd(),
+        {} as any,
+        { getSkill: () => undefined } as any,
+      );
+
+      assert.ok(!('error' in spawned));
+      assert.equal(spawnEventDelivered, true);
+    } finally {
+      SubAgentSession.prototype.run = originalRun;
+      manager.unregisterPlatformCallbacks(parentSessionKey);
+    }
+  });
+
+  test('manager resolves display names when stopping active subagents', () => {
+    const manager = SubAgentManager.getInstance();
+    const parentSessionKey = `test-parent:${Date.now()}:stop-all`;
+    let stopped = 0;
+    const fakeSession = {
+      status: 'running',
+      stop() {
+        stopped += 1;
+        this.status = 'stopped';
+      },
+      getInfo() {
+        return {
+          id: 'sub-stop-all',
+          agentType: 'worker',
+          skillName: 'worker',
+          toolScope: 'workspace_write',
+          allowedTools: ['read_file'],
+          taskDescription: 'long task',
+          status: this.status,
+          createdAt: Date.now(),
+          progressLog: [],
+          outputFiles: [],
+        };
+      },
+    };
+
+    (manager as any).subAgents.set('sub-stop-all', fakeSession);
+    (manager as any).parentMap.set('sub-stop-all', parentSessionKey);
+    (manager as any).displayNameByAgent.set('sub-stop-all', '子agent1');
+
+    try {
+      assert.equal(manager.hasActiveForParent(parentSessionKey), true);
+      assert.equal(manager.stopForParent(parentSessionKey, '子agent1'), 'stopped');
+      assert.equal(stopped, 1);
+      assert.equal(manager.hasActiveForParent(parentSessionKey), false);
+    } finally {
+      (manager as any).subAgents.delete('sub-stop-all');
+      (manager as any).parentMap.delete('sub-stop-all');
+      (manager as any).displayNameByAgent.delete('sub-stop-all');
+    }
+  });
+
+  test('manager stops all active subagents for a parent episode', () => {
+    const manager = SubAgentManager.getInstance();
+    const parentSessionKey = `test-parent:${Date.now()}:stop-all`;
+    let stopped = 0;
+    const fakeSession = {
+      status: 'running',
+      stop() {
+        stopped += 1;
+        this.status = 'stopped';
+      },
+      getInfo() {
+        return {
+          id: 'sub-stop-all-episode',
+          agentType: 'worker',
+          skillName: 'worker',
+          toolScope: 'workspace_write',
+          allowedTools: ['read_file'],
+          taskDescription: 'long task',
+          status: this.status,
+          createdAt: Date.now(),
+          progressLog: [],
+          outputFiles: [],
+        };
+      },
+    };
+
+    (manager as any).subAgents.set('sub-stop-all-episode', fakeSession);
+    (manager as any).parentMap.set('sub-stop-all-episode', parentSessionKey);
+
+    try {
+      assert.equal(manager.hasActiveForParent(parentSessionKey), true);
+      const result = manager.stopAllForParent(parentSessionKey, '测试停止 episode');
+      assert.equal(result.stopped, 1);
+      assert.equal(stopped, 1);
+      assert.equal(manager.hasActiveForParent(parentSessionKey), false);
+    } finally {
+      (manager as any).subAgents.delete('sub-stop-all-episode');
+      (manager as any).parentMap.delete('sub-stop-all-episode');
+    }
+  });
+
+  test('subagent stop aborts in-flight tool execution signal', () => {
+    const session = new SubAgentSession('sub-abort', {} as any, {} as any, {
+      agentType: 'worker',
+      taskDescription: 'abort',
+      userMessage: 'abort',
+      workingDirectory: process.cwd(),
+    });
+    const controller = new AbortController();
+    (session as any).abortController = controller;
+
+    session.stop();
+
+    assert.equal(controller.signal.aborted, true);
+    assert.equal(session.status, 'stopped');
+  });
+
+  test('subagent runner uses maxTurns only when the main agent specifies it', async () => {
+    const observedMaxTurns: Array<number | undefined> = [];
+    const originalRun = ConversationRunner.prototype.run;
+    (ConversationRunner.prototype as any).run = async function runMock() {
+      observedMaxTurns.push((this as any).maxTurns);
+      return {
+        response: 'done',
+        finalResponseVisible: true,
+        messages: [],
+        newMessages: [],
+      };
+    };
+
+    try {
+      const bounded = new SubAgentSession('sub-max-bounded', {} as any, {} as any, {
+        agentType: 'explorer',
+        taskDescription: 'bounded',
+        userMessage: 'bounded',
+        workingDirectory: process.cwd(),
+        maxTurns: 7,
+      });
+      await bounded.run();
+
+      const unbounded = new SubAgentSession('sub-max-unbounded', {} as any, {} as any, {
+        agentType: 'explorer',
+        taskDescription: 'unbounded',
+        userMessage: 'unbounded',
+        workingDirectory: process.cwd(),
+      });
+      await unbounded.run();
+
+      assert.deepEqual(observedMaxTurns, [7, undefined]);
+    } finally {
+      ConversationRunner.prototype.run = originalRun;
+    }
+  });
+
+  test('subagent close cleans temporary scratch files while preserving output files', async () => {
+    const workingDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-subagent-cleanup-'));
+    try {
+      const subAgentId = 'sub-cleanup';
+      const tempDir = path.join(workingDirectory, 'tmp', 'subagents', subAgentId);
+      const junkFile = path.join(tempDir, 'junk.txt');
+      const outputFile = path.join(tempDir, 'keep.txt');
+      fs.mkdirSync(tempDir, { recursive: true });
+      fs.writeFileSync(junkFile, 'delete me');
+      fs.writeFileSync(outputFile, 'keep me');
+
+      const session = new SubAgentSession(subAgentId, {} as any, {} as any, {
+        agentType: 'worker',
+        taskDescription: 'cleanup',
+        userMessage: 'cleanup',
+        workingDirectory,
+      });
+      (session as any).outputFiles = [path.join('tmp', 'subagents', subAgentId, 'keep.txt')];
+
+      await session.close();
+
+      assert.equal(fs.existsSync(junkFile), false);
+      assert.equal(fs.existsSync(outputFile), true);
+    } finally {
+      fs.rmSync(workingDirectory, { recursive: true, force: true });
+    }
+  });
+});
+
+async function waitFor(predicate: () => boolean, maxAttempts = 40): Promise<void> {
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    if (predicate()) return;
+    await new Promise(resolve => setTimeout(resolve, 10));
+  }
+  assert.fail('condition was not met in time');
+}

--- a/tests/subagent-stop-terminal-event.test.ts
+++ b/tests/subagent-stop-terminal-event.test.ts
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+const source = readFileSync(join(process.cwd(), 'src/core/sub-agent-session.ts'), 'utf-8');
+
+test('SubAgentSession emits terminal events only once and does not complete after stop', () => {
+  assert.match(source, /private terminalEventEmitted = false/);
+  assert.match(source, /private emitTerminalEvent\(type: SubAgentEventType, summary: string, payload\?: Record<string, unknown>\): void \{/);
+  assert.match(source, /if \(this\.terminalEventEmitted\) return/);
+  assert.match(source, /if \(this\.stopped\) \{[\s\S]*?this\.status = 'stopped'[\s\S]*?this\.emitTerminalEvent\('agent_stopped'/);
+  assert.doesNotMatch(source, /this\.emitEvent\('agent_stopped'/);
+});

--- a/tests/tool-manager.test.ts
+++ b/tests/tool-manager.test.ts
@@ -41,4 +41,32 @@ describe('ToolManager', () => {
     assert.equal(result.errorCode, 'TOOL_NOT_FOUND');
     assert.match(result.content, /未找到工具 "write_file"/);
   });
+
+  test('registers ask_parent only when explicitly enabled for subagents', async () => {
+    const defaultManager = new ToolManager('/tmp/xiaoba-tool-manager');
+    assert.equal(defaultManager.getTool('ask_parent'), undefined);
+
+    const subAgentManager = new ToolManager('/tmp/xiaoba-tool-manager', {}, {
+      enabledToolNames: ['read_file', 'ask_parent'],
+    });
+
+    assert.deepStrictEqual(
+      subAgentManager.getToolDefinitions().map(definition => definition.name),
+      ['read_file', 'ask_parent'],
+    );
+
+    const result = await subAgentManager.executeTool({
+      id: 'call-ask-parent',
+      type: 'function',
+      function: {
+        name: 'ask_parent',
+        arguments: JSON.stringify({ question: '继续吗？' }),
+      },
+    }, [], {
+      requestParentInput: async question => `收到问题：${question}`,
+    });
+
+    assert.equal(result.ok, true);
+    assert.match(result.content, /收到问题：继续吗/);
+  });
 });

--- a/tests/tool-result-tool-manager.test.ts
+++ b/tests/tool-result-tool-manager.test.ts
@@ -257,6 +257,34 @@ describe('ToolManager - ToolExecutionResult 统一处理', () => {
     assert.ok(result.content?.includes('hello'));
   });
 
+  test('context overrides do not clear an existing AbortSignal with undefined', async () => {
+    const controller = new AbortController();
+    const scopedManager = new ToolManager(testRoot, { abortSignal: controller.signal }, {
+      enabledToolNames: [],
+    });
+    let capturedSignal: AbortSignal | undefined;
+    scopedManager.registerTool({
+      definition: {
+        name: 'capture_signal',
+        description: 'capture signal',
+        parameters: { type: 'object', properties: {} },
+      },
+      async execute(_args, context) {
+        capturedSignal = context.abortSignal;
+        return { ok: true, content: 'ok' };
+      },
+    });
+
+    const result = await scopedManager.executeTool(
+      { id: 't19_context_merge', type: 'function', function: { name: 'capture_signal', arguments: '{}' } },
+      [],
+      { abortSignal: undefined },
+    );
+
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(capturedSignal, controller.signal);
+  });
+
   test('Write 别名映射到 write_file 成功', async () => {
     const result = await manager.executeTool(
       { id: 't20', type: 'function', function: { name: 'Write', arguments: JSON.stringify({ file_path: 'alias.txt', content: 'via alias' }) } },


### PR DESCRIPTION
## 背景

从原来的异步子 agent 大 PR 中拆出的 runtime 边界部分。这个 PR 只负责“子 agent 作为独立后台运行时”的核心能力，不包含 Plan UI、CatsCo 桌面 WORKING UI、provider abort、工作目录提示等后续切片。

## 主要改动

- 新增 `SubAgentManager` / `SubAgentSession` / `SubAgentEventStore` / `sub-agent-observation`，按父会话隔离管理后台子 agent。
- 新增 `spawn_subagent`、`check_subagent`、`stop_subagent`、`resume_subagent`、`ask_parent` 工具。
- `spawn_subagent` 是 fire-and-forget：工具调用成功后立即返回，子 agent 后台运行，完成后以 runtime observation 回流父会话。
- 子 agent 拥有独立上下文、工具白名单、临时目录和输出文件收集；默认不允许继续 spawn 子 agent。
- `AgentSession` cleanup/reset/clear/interrupt 会停止或清理关联子 agent，并注册 fallback callback，避免 CLI/local surface 没平台 callback 时直接失败。
- `MessageSessionManager` TTL 清理会跳过仍有 active subagent 的父会话。
- 保留主 agent 责任边界：子 agent 是侧路加速，主 agent 仍负责主线推进和最终答复。

## Review comment 已处理

- 已 rebase 到最新 `main`，避开 #63/#64 合并后的冲突。
- retention timer 已 `unref()`，避免 CLI/local fallback 成功派遣后短生命周期进程被 30 分钟保留计时器挂住。
- 补了 retention timer unref 回归测试。
- 补了 `AgentTurnController` 转发 `onThinking` 的回归测试。
- 补了 `spawn_subagent` 文案回归，确保不引导模型编造子 agent / sub id，也不误导它继续派发。

## 测试

- `npm.cmd run build`
- `node --import tsx --test tests\subagent-runtime-events.test.ts tests\subagent-stop-terminal-event.test.ts tests\agent-session-interrupt-subagents.test.ts tests\agent-turn-controller-callbacks.test.ts tests\message-session-manager.test.ts tests\tool-manager.test.ts tests\tool-result-tool-manager.test.ts tests\prompt-copy-regression.test.ts`
- `git diff --check` 仅 CRLF warning