### PR TITLE
区分运行时观察回流

### DIFF
--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -41,6 +41,7 @@ interface QueuedMessage {
   senderId: string;
   seq: number;
   receivedAt: number;
+  source?: 'user' | 'subagent_feedback';
   runtimeFeedback?: RuntimeFeedbackInput[];
 }
 
@@ -305,6 +306,7 @@ export class CatsCompanyBot {
         senderId: msg.senderId,
         seq: msg.seq,
         receivedAt: Date.now(),
+        source: 'user',
         runtimeFeedback,
       });
       this.messageQueue.set(key, queue);
@@ -573,47 +575,53 @@ export class CatsCompanyBot {
     senderId: string,
     text: string,
   ): Promise<void> {
-    const MAX_RETRIES = 10;
-    const RETRY_DELAY_MS = 5000;
+    const session = this.sessionManager.getOrCreate(sessionKey);
 
-    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-      if (attempt > 0) {
-        await new Promise(resolve => setTimeout(resolve, RETRY_DELAY_MS));
-      }
-
-      const session = this.sessionManager.getOrCreate(sessionKey);
-
-      if (session.isBusy()) {
-        Logger.info(`[${sessionKey}] 主会话忙，等待重试注入子智能体反馈 (${attempt + 1}/${MAX_RETRIES + 1})`);
-        continue;
-      }
-
-      const channel = this.buildChannel(topic, {
-        sessionKey,
-        senderId,
-      });
-
-      try {
-        const result = await session.handleMessage(text, { channel });
-        if (result.text === BUSY_MESSAGE) {
-          Logger.info(`[${sessionKey}] 主会话竞态忙碌，将重试`);
-          continue;
-        }
-        if (result.text.startsWith('处理消息时出错:')) {
-          try {
-            await this.sender.reply(topic, result.text);
-          } catch (err: any) {
-            Logger.warning(`错误消息发送失败: ${err.message}`);
-          }
-        }
-        await this.drainMessageQueue(sessionKey);
-        return;
-      } finally {
-        this.clearPendingAnswerBySession(sessionKey);
-      }
+    if (session.isBusy()) {
+      this.enqueueSubAgentFeedback(sessionKey, topic, senderId, text);
+      Logger.info(`[${sessionKey}] 主会话忙，子智能体反馈已入队`);
+      return;
     }
 
-    Logger.warning(`[${sessionKey}] 子智能体反馈注入失败：主会话持续忙碌`);
+    const channel = this.buildChannel(topic, {
+      sessionKey,
+      senderId,
+    });
+
+    try {
+      const result = await session.handleRuntimeObservation(text, {
+        channel,
+        source: 'subagent_result',
+      });
+      if (result.text === BUSY_MESSAGE) {
+        this.enqueueSubAgentFeedback(sessionKey, topic, senderId, text);
+        Logger.info(`[${sessionKey}] 主会话竞态忙碌，子智能体反馈已入队`);
+        return;
+      }
+      if (result.text.startsWith('处理消息时出错:')) {
+        try {
+          await this.sender.reply(topic, result.text);
+        } catch (err: any) {
+          Logger.warning(`错误消息发送失败: ${err.message}`);
+        }
+      }
+      await this.drainMessageQueue(sessionKey);
+    } finally {
+      this.clearPendingAnswerBySession(sessionKey);
+    }
+  }
+
+  private enqueueSubAgentFeedback(sessionKey: string, topic: string, senderId: string, text: string): void {
+    const queue = this.messageQueue.get(sessionKey) ?? [];
+    queue.push({
+      userMessage: text,
+      topic,
+      senderId,
+      seq: 0,
+      receivedAt: Date.now(),
+      source: 'subagent_feedback',
+    });
+    this.messageQueue.set(sessionKey, queue);
   }
 
   /**
@@ -635,11 +643,16 @@ export class CatsCompanyBot {
     });
 
     try {
-      const result = await session.handleMessage(msg.userMessage, {
-        channel,
-        runtimeFeedback: msg.runtimeFeedback,
-        pendingUserInputProvider: () => this.consumeQueuedUserInput(sessionKey),
-      });
+      const result = msg.source === 'subagent_feedback'
+        ? await session.handleRuntimeObservation(msg.userMessage as string, {
+          channel,
+          source: 'subagent_result',
+        })
+        : await session.handleMessage(msg.userMessage, {
+          channel,
+          runtimeFeedback: msg.runtimeFeedback,
+          pendingUserInputProvider: () => this.consumeQueuedUserInput(sessionKey),
+        });
       if (result.text !== BUSY_MESSAGE && result.visibleToUser && result.text) {
         try {
           await this.sender.sendText(msg.topic, result.text);
@@ -665,8 +678,16 @@ export class CatsCompanyBot {
     const queue = this.messageQueue.get(sessionKey);
     if (!queue || queue.length === 0) return null;
 
-    this.messageQueue.delete(sessionKey);
-    const messages = [...queue].sort((a, b) => {
+    const userMessages = queue.filter(item => item.source !== 'subagent_feedback');
+    const runtimeMessages = queue.filter(item => item.source === 'subagent_feedback');
+    if (runtimeMessages.length > 0) {
+      this.messageQueue.set(sessionKey, runtimeMessages);
+    } else {
+      this.messageQueue.delete(sessionKey);
+    }
+    if (userMessages.length === 0) return null;
+
+    const messages = [...userMessages].sort((a, b) => {
       if (a.seq > 0 && b.seq > 0 && a.seq !== b.seq) return a.seq - b.seq;
       return a.receivedAt - b.receivedAt;
     });

--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -64,6 +64,11 @@ export interface HandleMessageOptions {
   pendingUserInputProvider?: PendingUserInputProvider;
 }
 
+export interface HandleRuntimeObservationOptions extends HandleMessageOptions {
+  /** 内部 observation 来源，例如 subagent_result */
+  source?: string;
+}
+
 /** 命令处理结果 */
 export interface CommandResult {
   handled: boolean;
@@ -285,6 +290,28 @@ export class AgentSession {
     text: string | import('../types').ContentBlock[],
     callbacksOrOptions?: SessionCallbacks | HandleMessageOptions,
   ): Promise<HandleMessageResult> {
+    return this.handleInput(text, callbacksOrOptions);
+  }
+
+  /**
+   * 处理 runtime observation（例如子 agent 完成结果）。
+   *
+   * 对外部模型 API 来说它仍是 role=user 的一轮输入；CatsCo 内部保留
+   * __runtimeObservation/runtimeObservationSource 标记，避免和真实用户追加消息混淆。
+   */
+  async handleRuntimeObservation(
+    text: string,
+    options: HandleRuntimeObservationOptions = {},
+  ): Promise<HandleMessageResult> {
+    const { source = 'runtime_observation', ...handleOptions } = options;
+    return this.handleInput(text, handleOptions, source);
+  }
+
+  private async handleInput(
+    text: string | import('../types').ContentBlock[],
+    callbacksOrOptions?: SessionCallbacks | HandleMessageOptions,
+    runtimeObservationSource?: string,
+  ): Promise<HandleMessageResult> {
     return this.withLogContext(async () => {
       // 兼容旧签名：如果传入的对象有 onText/onToolStart 等字段，视为 SessionCallbacks
       let callbacks: SessionCallbacks | undefined;
@@ -335,6 +362,7 @@ export class AgentSession {
           input: text,
           messages: this.messages,
           runtimeFeedback,
+          runtimeObservationSource,
           callbacks,
           channel,
           pendingUserInputProvider,

--- a/src/core/agent-turn-controller.ts
+++ b/src/core/agent-turn-controller.ts
@@ -31,6 +31,7 @@ export interface RunAgentTurnParams {
   input: string | ContentBlock[];
   messages: Message[];
   runtimeFeedback: string[];
+  runtimeObservationSource?: string;
   callbacks?: AgentTurnCallbacks;
   channel?: ChannelCallbacks;
   pendingUserInputProvider?: PendingUserInputProvider;
@@ -64,7 +65,14 @@ export class AgentTurnController {
   constructor(private readonly options: AgentTurnControllerOptions) {}
 
   async run(params: RunAgentTurnParams): Promise<RunAgentTurnResult> {
-    params.messages.push({ role: 'user', content: params.input });
+    params.messages.push({
+      role: 'user',
+      content: params.input,
+      ...(params.runtimeObservationSource && {
+        __runtimeObservation: true,
+        runtimeObservationSource: params.runtimeObservationSource,
+      }),
+    });
 
     const turnContext = await this.options.turnContextBuilder.build({
       sessionKey: this.options.sessionKey,
@@ -93,6 +101,7 @@ export class AgentTurnController {
       result,
       tokens: { prompt: metrics.totalPromptTokens, completion: metrics.totalCompletionTokens },
       runtimeFeedback: turnContext.runtimeFeedbackForLog,
+      runtimeObservationSource: params.runtimeObservationSource,
     });
 
     return {

--- a/src/core/runtime-feedback-inbox.ts
+++ b/src/core/runtime-feedback-inbox.ts
@@ -16,7 +16,11 @@ export interface RuntimeFeedbackInput extends RuntimeFeedbackOptions {
 }
 
 /**
- * Turn-scoped inbox for runtime feedback that should be visible to the agent.
+ * Turn-scoped inbox for runtime observation that should be visible to the agent.
+ *
+ * The public type names still use "Feedback" for compatibility with existing
+ * adapters/tests, but the boundary is: runtime/platform facts in, transient
+ * model-visible observation out. It is not a user feedback feature.
  *
  * It owns buffering and dedupe only. Callers still decide when feedback is
  * consumed and where it is inserted into the provider input.

--- a/src/core/runtime-feedback.ts
+++ b/src/core/runtime-feedback.ts
@@ -1,4 +1,12 @@
+/**
+ * Legacy wire/model prefix kept for transcript compatibility.
+ *
+ * Semantically this is a runtime observation: an external/runtime fact injected
+ * into the next model turn. Keep the old "feedback" name in persisted text for
+ * now so existing logs/tests/session history remain readable.
+ */
 export const RUNTIME_FEEDBACK_PREFIX = '[运行时反馈]';
+export const RUNTIME_OBSERVATION_PREFIX = RUNTIME_FEEDBACK_PREFIX;
 
 const DEFAULT_MAX_MESSAGE_LENGTH = 2000;
 const DEFAULT_MAX_HINT_LENGTH = 500;
@@ -7,6 +15,8 @@ export interface RuntimeFeedbackFormatOptions {
   actionHint?: string;
   maxLength?: number;
 }
+
+export type RuntimeObservationFormatOptions = RuntimeFeedbackFormatOptions;
 
 export function formatRuntimeFeedback(
   source: string,
@@ -40,6 +50,10 @@ export function fingerprintRuntimeFeedback(source: string, message: string): str
 export function isRuntimeFeedbackContent(content: unknown): content is string {
   return typeof content === 'string' && content.startsWith(RUNTIME_FEEDBACK_PREFIX);
 }
+
+export const formatRuntimeObservation = formatRuntimeFeedback;
+export const fingerprintRuntimeObservation = fingerprintRuntimeFeedback;
+export const isRuntimeObservationContent = isRuntimeFeedbackContent;
 
 function normalizeFeedbackText(text: string): string {
   return text.replace(/\s+/g, ' ').trim();

--- a/src/core/turn-log-recorder.ts
+++ b/src/core/turn-log-recorder.ts
@@ -13,6 +13,7 @@ export interface RecordTurnParams {
     completion: number;
   };
   runtimeFeedback?: string[];
+  runtimeObservationSource?: string;
 }
 
 /**
@@ -27,7 +28,10 @@ export class TurnLogRecorder {
       params.result.response || '',
       this.extractToolCalls(params.result.newMessages),
       params.tokens,
-      { runtimeFeedback: params.runtimeFeedback },
+      {
+        runtimeFeedback: params.runtimeFeedback,
+        runtimeObservationSource: params.runtimeObservationSource,
+      },
     );
   }
 

--- a/src/feishu/index.ts
+++ b/src/feishu/index.ts
@@ -35,6 +35,7 @@ interface QueuedMessage {
   userText: string;
   chatId: string;
   senderId: string;
+  source?: 'user' | 'subagent_feedback';
   runtimeFeedback?: RuntimeFeedbackInput[];
 }
 
@@ -354,7 +355,7 @@ export class FeishuBot {
         Logger.warning(`[${key}] 检测到用户中断请求，已请求中止当前回合`);
       }
       const queue = this.messageQueue.get(key) ?? [];
-      queue.push({ userText, chatId: msg.chatId, senderId: msg.senderId, runtimeFeedback });
+      queue.push({ userText, chatId: msg.chatId, senderId: msg.senderId, source: 'user', runtimeFeedback });
       this.messageQueue.set(key, queue);
       Logger.info(`[${key}] 主会话忙，消息已入队 (队列长度: ${queue.length})`);
       return;
@@ -389,44 +390,47 @@ export class FeishuBot {
     senderId: string,
     text: string,
   ): Promise<void> {
-    const MAX_RETRIES = 10;
-    const RETRY_DELAY_MS = 5000;
+    const session = this.sessionManager.getOrCreate(sessionKey);
 
-    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-      if (attempt > 0) {
-        await new Promise(resolve => setTimeout(resolve, RETRY_DELAY_MS));
-      }
-
-      const session = this.sessionManager.getOrCreate(sessionKey);
-
-      // 等待主会话空闲
-      if (session.isBusy()) {
-        Logger.info(`[${sessionKey}] 主会话忙，等待重试注入子智能体反馈 (${attempt + 1}/${MAX_RETRIES + 1})`);
-        continue;
-      }
-
-      const channel = this.buildChannel(chatId, {
-        sessionKey,
-        senderId,
-      });
-
-      try {
-        const result = await session.handleMessage(text, { channel });
-        if (result.text === BUSY_MESSAGE) {
-          Logger.info(`[${sessionKey}] 主会话竞态忙碌，将重试`);
-          continue;
-        }
-        if (result.text === ERROR_MESSAGE) {
-          await this.sender.reply(chatId, result.text);
-        }
-        await this.drainMessageQueue(sessionKey);
-        return;
-      } finally {
-        this.clearPendingAnswerBySession(sessionKey);
-      }
+    if (session.isBusy()) {
+      this.enqueueSubAgentFeedback(sessionKey, chatId, senderId, text);
+      Logger.info(`[${sessionKey}] 主会话忙，子智能体反馈已入队`);
+      return;
     }
 
-    Logger.warning(`[${sessionKey}] 子智能体反馈注入失败：主会话持续忙碌`);
+    const channel = this.buildChannel(chatId, {
+      sessionKey,
+      senderId,
+    });
+
+    try {
+      const result = await session.handleRuntimeObservation(text, {
+        channel,
+        source: 'subagent_result',
+      });
+      if (result.text === BUSY_MESSAGE) {
+        this.enqueueSubAgentFeedback(sessionKey, chatId, senderId, text);
+        Logger.info(`[${sessionKey}] 主会话竞态忙碌，子智能体反馈已入队`);
+        return;
+      }
+      if (result.text === ERROR_MESSAGE) {
+        await this.sender.reply(chatId, result.text);
+      }
+      await this.drainMessageQueue(sessionKey);
+    } finally {
+      this.clearPendingAnswerBySession(sessionKey);
+    }
+  }
+
+  private enqueueSubAgentFeedback(sessionKey: string, chatId: string, senderId: string, text: string): void {
+    const queue = this.messageQueue.get(sessionKey) ?? [];
+    queue.push({
+      userText: text,
+      chatId,
+      senderId,
+      source: 'subagent_feedback',
+    });
+    this.messageQueue.set(sessionKey, queue);
   }
 
   /**
@@ -436,27 +440,29 @@ export class FeishuBot {
     const queue = this.messageQueue.get(sessionKey);
     if (!queue || queue.length === 0) return;
 
-    // 一次性取出所有积压消息
-    const messages = queue.splice(0);
-    this.messageQueue.delete(sessionKey);
+    const msg = queue.shift()!;
+    if (queue.length === 0) {
+      this.messageQueue.delete(sessionKey);
+    }
 
-    // 合并为单条文本
-    const mergedText = messages.length === 1
-      ? messages[0].userText
-      : messages.map((m, i) => `[队列消息 ${i + 1}] ${m.userText}`).join('\n');
-    const runtimeFeedback = messages.flatMap(message => message.runtimeFeedback || []);
-
-    const last = messages[messages.length - 1];
     const session = this.sessionManager.getOrCreate(sessionKey);
-    const channel = this.buildChannel(last.chatId, {
+    const channel = this.buildChannel(msg.chatId, {
       sessionKey,
-      senderId: last.senderId,
+      senderId: msg.senderId,
     });
 
     try {
-      const result = await session.handleMessage(mergedText, { channel, runtimeFeedback });
+      const result = msg.source === 'subagent_feedback'
+        ? await session.handleRuntimeObservation(msg.userText, {
+          channel,
+          source: 'subagent_result',
+        })
+        : await session.handleMessage(msg.userText, {
+          channel,
+          runtimeFeedback: msg.runtimeFeedback,
+        });
       if (result.text === ERROR_MESSAGE) {
-        await this.sender.reply(last.chatId, result.text);
+        await this.sender.reply(msg.chatId, result.text);
       }
     } finally {
       this.clearPendingAnswerBySession(sessionKey);
@@ -545,7 +551,7 @@ export class FeishuBot {
 
     if (session.isBusy()) {
       const queue = this.messageQueue.get(sessionKey) ?? [];
-      queue.push({ userText: messageText, chatId: msg.chat_id, senderId: '' });
+      queue.push({ userText: messageText, chatId: msg.chat_id, senderId: '', source: 'user' });
       this.messageQueue.set(sessionKey, queue);
       return;
     }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,6 +19,9 @@ export interface Message {
   __injected?: boolean;
   /** 标记注入给 agent 看的运行时反馈，仅供内部清理和日志记录使用 */
   __runtimeFeedback?: boolean;
+  /** 标记内部 runtime observation，例如子 agent 完成结果；对模型仍以 user role 承载 */
+  __runtimeObservation?: boolean;
+  runtimeObservationSource?: string;
 }
 
 export interface ChatConfig {

--- a/src/utils/session-log-schema.ts
+++ b/src/utils/session-log-schema.ts
@@ -18,6 +18,7 @@ export interface SessionTurnLogEntry {
     text: string;
     images?: string[];
     runtime_feedback?: string[];
+    runtime_observation_source?: string;
   };
   assistant: {
     text: string;

--- a/src/utils/session-turn-logger.ts
+++ b/src/utils/session-turn-logger.ts
@@ -23,6 +23,7 @@ const MAX_RUNTIME_FEEDBACK_LENGTH = Number(process.env.XIAOBA_SESSION_RUNTIME_FE
 
 export interface LogTurnOptions {
   runtimeFeedback?: string[];
+  runtimeObservationSource?: string;
 }
 
 /**
@@ -81,6 +82,7 @@ export class SessionTurnLogger {
         text: userText,
         ...(userImages.length > 0 && { images: userImages }),
         ...(runtimeFeedback.length > 0 && { runtime_feedback: runtimeFeedback }),
+        ...(options.runtimeObservationSource && { runtime_observation_source: options.runtimeObservationSource }),
       },
       assistant: {
         text: assistantText,

--- a/src/weixin/index.ts
+++ b/src/weixin/index.ts
@@ -3,7 +3,8 @@ import { WeixinConfig, WeixinMessage } from './types';
 import { MessageHandler } from './message-handler';
 import { MessageSender } from './message-sender';
 import { MessageSessionManager } from '../core/message-session-manager';
-import { AgentServices, RuntimeFeedbackInput } from '../core/agent-session';
+import { AgentServices, BUSY_MESSAGE, ERROR_MESSAGE, RuntimeFeedbackInput } from '../core/agent-session';
+import { SubAgentManager } from '../core/sub-agent-manager';
 import { Logger } from '../utils/logger';
 import { ChannelCallbacks } from '../types/tool';
 import { AdapterRuntimeBundle, createAdapterRuntime } from '../runtime/adapter-runtime';
@@ -12,6 +13,13 @@ import path from 'path';
 
 const CHANNEL_VERSION = 'xiaoba-weixin/1.0';
 const DEFAULT_LONGPOLL_MS = 30000;
+
+interface QueuedMessage {
+  userText: string;
+  chatId: string;
+  source?: 'user' | 'subagent_feedback';
+  runtimeFeedback?: RuntimeFeedbackInput[];
+}
 
 export function createWeixinRuntime(): AdapterRuntimeBundle {
   return createAdapterRuntime({
@@ -28,6 +36,7 @@ export class WeixinBot {
   private agentServices: AgentServices;
   private runtime: AdapterRuntimeBundle;
   private contextTokens = new Map<string, string>();
+  private messageQueue = new Map<string, QueuedMessage[]>();
   private isRunning = false;
   private getUpdatesBuf = '';
   private stateDir: string;
@@ -178,6 +187,11 @@ export class WeixinBot {
 
     const session = this.sessionManager.getOrCreate(sessionKey);
     const channel = this.buildChannel(msg.to_user_id, sessionKey);
+    SubAgentManager.getInstance().registerPlatformCallbacks(sessionKey, {
+      injectMessage: async (text: string) => {
+        await this.handleSubAgentFeedback(sessionKey, msg.to_user_id, text);
+      },
+    });
     const expectedMediaCount = (parsed.item_list || []).filter(item =>
       (item.type === 2 && item.image_item?.media)
       || (item.type === 4 && item.file_item?.media)
@@ -212,11 +226,96 @@ export class WeixinBot {
       userText = '[用户发送了媒体消息，但平台未能下载附件]';
     }
 
-    await session.handleMessage(userText, { channel, runtimeFeedback });
+    if (session.isBusy()) {
+      const queue = this.messageQueue.get(sessionKey) ?? [];
+      queue.push({
+        userText,
+        chatId: msg.to_user_id,
+        source: 'user',
+        runtimeFeedback,
+      });
+      this.messageQueue.set(sessionKey, queue);
+      Logger.info(`[${sessionKey}] 主会话忙，微信消息已入队 (队列长度: ${queue.length})`);
+      return;
+    }
+
+    const result = await session.handleMessage(userText, { channel, runtimeFeedback });
+    if (result.text === BUSY_MESSAGE || result.text === ERROR_MESSAGE) {
+      await channel.reply(msg.to_user_id, result.text);
+    }
+    await this.drainMessageQueue(sessionKey);
+  }
+
+  private async handleSubAgentFeedback(sessionKey: string, chatId: string, text: string): Promise<void> {
+    const session = this.sessionManager.getOrCreate(sessionKey);
+
+    if (session.isBusy()) {
+      this.enqueueSubAgentFeedback(sessionKey, chatId, text);
+      Logger.info(`[${sessionKey}] 主会话忙，微信子智能体反馈已入队`);
+      return;
+    }
+
+    const channel = this.buildChannel(chatId, sessionKey);
+    const result = await session.handleRuntimeObservation(text, {
+      channel,
+      source: 'subagent_result',
+    });
+    if (result.text === BUSY_MESSAGE) {
+      this.enqueueSubAgentFeedback(sessionKey, chatId, text);
+      return;
+    }
+    if (result.text === ERROR_MESSAGE) {
+      await channel.reply(chatId, result.text);
+    }
+    await this.drainMessageQueue(sessionKey);
+  }
+
+  private enqueueSubAgentFeedback(sessionKey: string, chatId: string, text: string): void {
+    const queue = this.messageQueue.get(sessionKey) ?? [];
+    queue.push({
+      userText: text,
+      chatId,
+      source: 'subagent_feedback',
+    });
+    this.messageQueue.set(sessionKey, queue);
+  }
+
+  private async drainMessageQueue(sessionKey: string): Promise<void> {
+    const queue = this.messageQueue.get(sessionKey);
+    if (!queue || queue.length === 0) return;
+
+    const msg = queue.shift()!;
+    if (queue.length === 0) {
+      this.messageQueue.delete(sessionKey);
+    }
+
+    const session = this.sessionManager.getOrCreate(sessionKey);
+    if (session.isBusy()) {
+      queue.unshift(msg);
+      this.messageQueue.set(sessionKey, queue);
+      return;
+    }
+
+    const channel = this.buildChannel(msg.chatId, sessionKey);
+    const result = msg.source === 'subagent_feedback'
+      ? await session.handleRuntimeObservation(msg.userText, {
+        channel,
+        source: 'subagent_result',
+      })
+      : await session.handleMessage(msg.userText, {
+        channel,
+        runtimeFeedback: msg.runtimeFeedback,
+      });
+
+    if (result.text === ERROR_MESSAGE) {
+      await channel.reply(msg.chatId, result.text);
+    }
+    await this.drainMessageQueue(sessionKey);
   }
 
   destroy(): void {
     this.isRunning = false;
+    this.messageQueue.clear();
     Logger.info('[微信] 机器人已停止');
   }
 }

--- a/tests/anthropic-provider-runtime-feedback.test.ts
+++ b/tests/anthropic-provider-runtime-feedback.test.ts
@@ -22,6 +22,8 @@ describe('AnthropicProvider runtime feedback boundary', () => {
         content: '[运行时反馈] weixin.media_download\n错误: 媒体下载不完整',
         __injected: true,
         __runtimeFeedback: true,
+        __runtimeObservation: true,
+        runtimeObservationSource: 'subagent_result',
         extra: 'must not leak',
       } as any,
     ];
@@ -35,6 +37,8 @@ describe('AnthropicProvider runtime feedback boundary', () => {
     }]);
     assert.equal(JSON.stringify(transformed).includes('__injected'), false);
     assert.equal(JSON.stringify(transformed).includes('__runtimeFeedback'), false);
+    assert.equal(JSON.stringify(transformed).includes('__runtimeObservation'), false);
+    assert.equal(JSON.stringify(transformed).includes('runtimeObservationSource'), false);
     assert.equal(JSON.stringify(transformed).includes('must not leak'), false);
   });
 });

--- a/tests/openai-provider-runtime-feedback.test.ts
+++ b/tests/openai-provider-runtime-feedback.test.ts
@@ -17,6 +17,8 @@ describe('OpenAIProvider runtime feedback boundary', () => {
         content: '[运行时反馈] feishu.file_download\n错误: 文件下载失败',
         __injected: true,
         __runtimeFeedback: true,
+        __runtimeObservation: true,
+        runtimeObservationSource: 'subagent_result',
         extra: 'must not leak',
       } as any,
       {
@@ -45,6 +47,8 @@ describe('OpenAIProvider runtime feedback boundary', () => {
     assert.deepStrictEqual(Object.keys(body.messages[2]).sort(), ['content', 'name', 'role', 'tool_call_id']);
     assert.equal(JSON.stringify(body.messages).includes('__injected'), false);
     assert.equal(JSON.stringify(body.messages).includes('__runtimeFeedback'), false);
+    assert.equal(JSON.stringify(body.messages).includes('__runtimeObservation'), false);
+    assert.equal(JSON.stringify(body.messages).includes('runtimeObservationSource'), false);
     assert.equal(JSON.stringify(body.messages).includes('must not leak'), false);
   });
 });

--- a/tests/runtime-feedback.test.ts
+++ b/tests/runtime-feedback.test.ts
@@ -106,6 +106,52 @@ describe('runtime feedback', () => {
     assert.match(turnEntries[0].user.runtime_feedback[0], /feishu\.file_download/);
   });
 
+  test('AgentSession records runtime observations without treating them as runtime feedback', async () => {
+    const { AgentSession } = loadAgentSessionModules();
+    let capturedMessages: any[] = [];
+
+    const session = new AgentSession('user:runtime-observation-demo', buildMockServices({
+      aiService: {
+        async chatStream(messages: any[]) {
+          capturedMessages = messages.map(message => ({ ...message }));
+          return {
+            content: '已整合子任务结果',
+            toolCalls: [],
+            usage: { promptTokens: 7, completionTokens: 5, totalTokens: 12 },
+          };
+        },
+      },
+    }), 'catscompany');
+    session.setSystemPromptProvider(() => 'system prompt');
+
+    const result = await session.handleRuntimeObservation('[子智能体完成]\n结果：ok', {
+      source: 'subagent_result',
+    });
+
+    assert.equal(result.text, '已整合子任务结果');
+    const capturedRuntimeMessage = capturedMessages.find(message => message.content === '[子智能体完成]\n结果：ok');
+    assert.equal(capturedRuntimeMessage?.role, 'user');
+
+    const retainedMessages = (session as any).messages as any[];
+    const runtimeMessage = retainedMessages.find(message => message.content === '[子智能体完成]\n结果：ok');
+    assert.equal(runtimeMessage?.__runtimeObservation, true);
+    assert.equal(runtimeMessage?.runtimeObservationSource, 'subagent_result');
+    assert.equal(retainedMessages.some(message => message.__runtimeFeedback), false);
+
+    const logPath = (session as any).sessionTurnLogger.getLogFilePath();
+    const entries = fs.readFileSync(logPath, 'utf-8')
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map(line => JSON.parse(line));
+
+    const turnEntries = entries.filter(entry => entry.entry_type === 'turn');
+    assert.equal(turnEntries.length, 1);
+    assert.equal(turnEntries[0].user.text, '[子智能体完成]\n结果：ok');
+    assert.equal(turnEntries[0].user.runtime_observation_source, 'subagent_result');
+    assert.equal(turnEntries[0].user.runtime_feedback, undefined);
+  });
+
   test('HandleMessageOptions runtime feedback does not mutate session state while busy', async () => {
     const { AgentSession, BUSY_MESSAGE } = loadAgentSessionModules();
     const session = new AgentSession('user:busy-feedback-demo', buildMockServices(), 'feishu');

--- a/tests/session-log-schema.test.ts
+++ b/tests/session-log-schema.test.ts
@@ -30,7 +30,11 @@ describe('session-log-schema', () => {
       timestamp: '2026-05-01T08:00:00.000Z',
       session_id: 'user:current',
       session_type: 'chat',
-      user: { text: 'current', runtime_feedback: ['[运行时反馈] runtime\n错误: failed'] },
+      user: {
+        text: 'current',
+        runtime_feedback: ['[运行时反馈] runtime\n错误: failed'],
+        runtime_observation_source: 'subagent_result',
+      },
       assistant: { text: 'ok', tool_calls: [] },
       tokens: { prompt: 1, completion: 2 },
     };
@@ -67,6 +71,7 @@ describe('session-log-schema', () => {
     assert.equal(entries.length, 4);
     assert.deepStrictEqual(entries.map(entry => isSessionTurnEntry(entry)), [true, false, true, false]);
     assert.deepStrictEqual((entries[0] as any).user.runtime_feedback, ['[运行时反馈] runtime\n错误: failed']);
+    assert.equal((entries[0] as any).user.runtime_observation_source, 'subagent_result');
   });
 
   test('resolves session id from content and falls back when content has no session id', () => {


### PR DESCRIPTION
## 背景

从原来的异步子 agent 大 PR 中拆出的 runtime observation 边界部分。这个 PR 不重新实现子 agent runtime，只负责把“后台结果/平台事实”与真实用户输入区分开。

## 主要改动

- 新增 `AgentSession.handleRuntimeObservation()`，用于处理子 agent 完成结果、平台 runtime 事实等非用户输入。
- runtime observation 进入同一个 CatsCo session，但 durable message 会带 `__runtimeObservation` 和 `runtimeObservationSource` 标记。
- provider 输入仍保持普通 `role=user` 文本，避免破坏 OpenAI/Anthropic SDK 消息格式。
- `TurnLogRecorder` / session log schema 记录 `runtime_observation_source`，便于后续排查这轮输入来自子 agent 回流还是用户追加消息。
- CatsCompany / Feishu / Weixin 的 subagent feedback queue 都走 `handleRuntimeObservation(..., source: 'subagent_result')`，避免和普通用户 follow-up 混在一起。
- 保留旧 `[运行时反馈]` 文本前缀兼容历史日志，同时增加 runtime observation 命名别名，明确这是 runtime observation，不是用户反馈功能。

## Review comment 已处理

- 已 rebase 到最新 `main`。
- 已补 `runtimeObservationSource` 的 session log 记录和 schema 测试。
- 已补 provider boundary 测试，确认 `__runtimeObservation` / `runtimeObservationSource` 不会泄漏到 API 请求体。
- 当前 scope 不再只是 CatsCompany direct path，Feishu / Weixin subagent feedback 路径也已对应。

## 测试

- `npm.cmd run build`
- `node --import tsx --test tests\runtime-feedback.test.ts tests\session-log-schema.test.ts tests\anthropic-provider-runtime-feedback.test.ts tests\openai-provider-runtime-feedback.test.ts tests\catscompany-content-blocks.test.ts tests\message-session-manager.test.ts`
- 上面组合测试曾遇到 Windows temp dir `EPERM` 抖动；失败的 `tests\runtime-feedback.test.ts` 和 `tests\message-session-manager.test.ts` 单独重跑均通过。
- `git diff --check` 仅 CRLF warning