### PR TITLE
优化 CatsCo 桌面聊天工作态展示

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -2791,6 +2791,15 @@
       display: flex;
       flex-direction: column;
       min-height: 0;
+      background: #181b20;
+      color: #e8eaed;
+    }
+
+    .chat-panel.chat-window {
+      border-color: rgba(255,255,255,0.08);
+      background: #181b20;
+      box-shadow: 0 18px 42px rgba(15, 23, 42, 0.16);
+      overflow: hidden;
     }
 
     .chat-window-header {
@@ -2799,7 +2808,13 @@
       justify-content: space-between;
       gap: 12px;
       padding: 18px 20px;
-      border-bottom: 1px solid var(--border-light);
+      border-bottom: 1px solid rgba(255,255,255,0.08);
+      background: #181b20;
+      color: #f3f4f6;
+    }
+
+    .chat-window-header .muted {
+      color: #8da0bc;
     }
 
     .chat-messages {
@@ -2807,36 +2822,46 @@
       min-height: 0;
       padding: 0;
       overflow-y: auto;
-      background: rgba(250, 251, 255, 0.68);
+      background: #181b20;
+      color: #d8dbe2;
     }
 
     .chat-timeline-inner {
       width: 100%;
-      max-width: 980px;
+      max-width: 1120px;
       margin: 0 auto;
-      padding: 20px 24px 28px;
+      padding: 18px 24px 24px;
       display: flex;
       flex-direction: column;
-      gap: 8px;
+      gap: 2px;
     }
 
     .chat-message {
-      display: grid;
-      grid-template-columns: 36px minmax(0, 1fr);
-      gap: 12px;
+      display: flex;
+      gap: 14px;
       max-width: 100%;
-      padding: 8px 0;
-      font-size: 14px;
-      line-height: 1.55;
+      padding: 10px 18px;
+      font-size: 15px;
+      line-height: 1.62;
       word-break: break-word;
-      color: var(--text);
+      color: #d8dbe2;
       border: 0;
       background: transparent;
+      border-radius: 0;
+      transition: background 0.12s ease;
+    }
+
+    .chat-message.grouped {
+      padding-top: 2px;
+    }
+
+    .chat-message:not(.mine):hover {
+      background: rgba(255,255,255,0.025);
     }
 
     .chat-message.mine {
-      grid-template-columns: minmax(0, 1fr) 36px;
-      color: var(--text);
+      justify-content: flex-end;
+      color: #f8fafc;
     }
 
     .chat-avatar {
@@ -2855,15 +2880,21 @@
     }
 
     .chat-message.peer .chat-avatar {
-      background: linear-gradient(135deg, #f59e0b, #2563eb);
-      color: #fff;
+      background: #b7790a;
+      color: #18202b;
+      font-size: 0;
+    }
+
+    .chat-message.peer .chat-avatar::after {
+      content: "X";
+      font-size: 17px;
+      font-weight: 900;
     }
 
     .chat-message.mine .chat-avatar {
-      grid-column: 2;
-      grid-row: 1;
       background: var(--accent);
       color: #fff;
+      order: 2;
     }
 
     .chat-message-body {
@@ -2871,45 +2902,42 @@
       display: flex;
       flex-direction: column;
       align-items: flex-start;
-      max-width: min(860px, 92%);
+      max-width: min(1040px, calc(100% - 50px));
     }
 
     .chat-message.mine .chat-message-body {
-      grid-column: 1;
-      grid-row: 1;
-      justify-self: end;
       align-items: flex-end;
-      max-width: min(720px, 88%);
+      max-width: min(760px, 86%);
     }
 
     .chat-message-content {
       width: fit-content;
       max-width: 100%;
       min-width: 0;
-      color: var(--text);
+      color: #d8dbe2;
       border-radius: 8px;
     }
 
     .chat-message.peer .chat-message-content {
-      padding: 10px 12px;
-      background: #fff;
-      border: 1px solid var(--border-light);
-      box-shadow: var(--shadow-sm);
+      padding: 0;
+      background: transparent;
+      border: 0;
+      box-shadow: none;
     }
 
     .chat-message.mine .chat-message-content {
       padding: 10px 12px;
       background: var(--accent);
       color: #fff;
-      border: 1px solid rgba(59, 130, 246, 0.22);
+      border: 0;
       border-radius: 10px;
     }
 
     .chat-message-meta {
-      font-size: 11px;
-      margin-bottom: 4px;
+      font-size: 12px;
+      margin-bottom: 6px;
       font-weight: 700;
-      color: var(--text2);
+      color: #aeb8c9;
       display: flex;
       gap: 6px;
       align-items: baseline;
@@ -2922,6 +2950,7 @@
     .chat-markdown {
       white-space: normal;
       line-height: 1.62;
+      color: inherit;
     }
 
     .chat-markdown p {
@@ -2953,26 +2982,28 @@
     .chat-markdown blockquote {
       margin: 8px 0;
       padding-left: 10px;
-      border-left: 3px solid rgba(59, 130, 246, 0.28);
-      color: var(--text2);
+      border-left: 3px solid rgba(125, 211, 252, 0.3);
+      color: #b6c0cf;
     }
 
     .chat-markdown code {
       font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
       font-size: 0.9em;
-      background: rgba(31, 34, 50, 0.07);
+      background: rgba(255,255,255,0.09);
       border-radius: 4px;
       padding: 2px 4px;
+      color: #e5e7eb;
     }
 
     .chat-markdown pre {
       margin: 10px 0;
       padding: 10px 12px;
       border-radius: 8px;
-      background: #171923;
+      background: #101318;
       color: #eef2ff;
       overflow-x: auto;
       max-width: 100%;
+      border: 1px solid rgba(255,255,255,0.08);
     }
 
     .chat-markdown pre code {
@@ -2988,14 +3019,14 @@
       margin: 8px 0 -6px;
       padding: 2px 6px;
       border-radius: 6px 6px 0 0;
-      background: #111827;
+      background: #101318;
       color: #b8c2d8;
       font-size: 11px;
       font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
     }
 
     .chat-markdown a {
-      color: var(--accent);
+      color: #7dd3fc;
       text-decoration: underline;
       text-underline-offset: 2px;
     }
@@ -3004,9 +3035,9 @@
       max-width: 100%;
       overflow-x: auto;
       margin: 8px 0;
-      border: 1px solid var(--border-light);
+      border: 1px solid rgba(255,255,255,0.08);
       border-radius: 8px;
-      background: #fff;
+      background: rgba(255,255,255,0.03);
     }
 
     .chat-markdown table {
@@ -3020,15 +3051,15 @@
     .chat-markdown th,
     .chat-markdown td {
       padding: 8px 10px;
-      border-bottom: 1px solid var(--border-light);
+      border-bottom: 1px solid rgba(255,255,255,0.08);
       text-align: left;
       vertical-align: top;
       white-space: nowrap;
     }
 
     .chat-markdown th {
-      background: var(--surface-muted);
-      color: var(--text);
+      background: rgba(255,255,255,0.05);
+      color: #f8fafc;
       font-weight: 800;
     }
 
@@ -3062,25 +3093,25 @@
 
     .chat-working {
       margin: 8px 0 2px;
-      border: 0;
-      border-radius: 0;
-      background: transparent;
-      color: var(--text2);
+      border: 1px solid rgba(16, 185, 129, 0.26);
+      border-radius: 8px;
+      background: rgba(16, 185, 129, 0.03);
+      color: #b9c3d5;
       overflow: hidden;
     }
 
     .chat-working summary {
       cursor: pointer;
-      padding: 5px 8px;
-      font-size: 11px;
+      padding: 8px 11px;
+      font-size: 12px;
       font-weight: 800;
-      color: var(--text2);
+      color: #d1d5db;
       display: inline-flex;
       align-items: center;
       gap: 6px;
-      border: 1px solid var(--border-light);
-      border-radius: 7px;
-      background: var(--surface-muted);
+      border: 0;
+      border-radius: 0;
+      background: transparent;
       list-style: none;
       text-transform: uppercase;
       letter-spacing: 0;
@@ -3100,7 +3131,13 @@
     }
 
     .chat-working-hint {
-      color: var(--text3);
+      color: #7f8da6;
+      font-weight: 700;
+      text-transform: none;
+    }
+
+    .chat-working-summary-meta {
+      color: #8da0bc;
       font-weight: 700;
       text-transform: none;
     }
@@ -3108,14 +3145,19 @@
     .chat-working-body {
       display: grid;
       gap: 10px;
-      margin: 8px 0 0 7px;
-      padding: 2px 0 2px 14px;
-      border-left: 2px solid var(--border-light);
+      margin: 0 0 10px 9px;
+      padding: 2px 10px 2px 14px;
+      border-left: 2px solid rgba(16, 185, 129, 0.25);
       font-size: 12px;
+      max-height: 420px;
+      overflow: auto;
     }
 
     .chat-working-step {
       min-width: 0;
+      border-radius: 7px;
+      padding: 6px 8px;
+      background: rgba(255,255,255,0.025);
     }
 
     .chat-working-step-title {
@@ -3123,7 +3165,7 @@
       align-items: center;
       gap: 6px;
       font-weight: 800;
-      color: var(--accent);
+      color: #10b981;
       margin-bottom: 4px;
       font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
       font-size: 12px;
@@ -3134,18 +3176,24 @@
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
-      color: var(--text3);
+      color: #8da0bc;
       font-family: inherit;
       font-size: 11px;
       font-weight: 700;
     }
 
+    .chat-working-note {
+      color: #8da0bc;
+      font-size: 11px;
+      margin-top: 4px;
+    }
+
     .chat-working-code {
       max-width: 100%;
       overflow: hidden;
-      border: 1px solid var(--border-light);
+      border: 1px solid rgba(255,255,255,0.08);
       border-radius: 7px;
-      background: #111827;
+      background: #101318;
     }
 
     .chat-working-code pre {
@@ -3256,7 +3304,7 @@
       max-height: 320px;
       border-radius: 8px;
       object-fit: cover;
-      border: 1px solid var(--border-light);
+      border: 1px solid rgba(255,255,255,0.08);
     }
 
     .chat-attachment {
@@ -3266,13 +3314,13 @@
       margin-top: 6px;
       padding: 10px 12px;
       border-radius: 8px;
-      border: 1px solid var(--border-light);
-      background: #fff;
+      border: 1px solid rgba(255,255,255,0.08);
+      background: rgba(255,255,255,0.04);
       color: inherit;
       text-decoration: none;
       width: max-content;
       max-width: 100%;
-      box-shadow: var(--shadow-sm);
+      box-shadow: none;
     }
 
     .chat-attachment-icon {
@@ -3296,7 +3344,7 @@
 
     .chat-attachment-meta {
       font-size: 12px;
-      color: var(--text3);
+      color: #8da0bc;
       overflow: hidden;
       text-overflow: ellipsis;
     }
@@ -3317,21 +3365,22 @@
     }
 
     .chat-composer {
-      padding: 12px 14px 14px;
-      border-top: 1px solid var(--border-light);
-      background: var(--surface-strong);
+      padding: 0 20px 20px;
+      border-top: 1px solid rgba(255,255,255,0.08);
+      background: #181b20;
     }
 
     .chat-attachment-tray {
       display: flex;
       flex-wrap: wrap;
       gap: 8px;
+      padding-top: 12px;
       margin-bottom: 10px;
     }
 
     .chat-attach-note {
       margin-bottom: 10px;
-      color: var(--text3);
+      color: #8da0bc;
       font-size: 12px;
       line-height: 1.5;
     }
@@ -3342,19 +3391,20 @@
       gap: 8px;
       max-width: min(420px, 100%);
       padding: 8px 10px;
-      border: 1px solid var(--border-light);
+      border: 1px solid rgba(255,255,255,0.08);
       border-radius: 8px;
-      background: white;
+      background: rgba(255,255,255,0.04);
+      color: #e5e7eb;
     }
 
     .chat-upload-chip.sending {
       border-color: rgba(37, 99, 235, 0.35);
-      background: rgba(37, 99, 235, 0.06);
+      background: rgba(37, 99, 235, 0.12);
     }
 
     .chat-upload-chip.error {
       border-color: rgba(239, 68, 68, 0.35);
-      background: rgba(239, 68, 68, 0.06);
+      background: rgba(239, 68, 68, 0.12);
     }
 
     .chat-upload-icon {
@@ -3384,7 +3434,7 @@
     }
 
     .chat-upload-info small {
-      color: var(--text3);
+      color: #8da0bc;
       font-size: 12px;
       margin-top: 2px;
     }
@@ -3396,25 +3446,55 @@
     }
 
     .chat-input-bar {
-      display: flex;
-      gap: 10px;
+      display: grid;
+      grid-template-columns: 44px minmax(0, 1fr) auto;
+      gap: 8px;
       align-items: stretch;
+      border: 1px solid rgba(255,255,255,0.1);
+      border-radius: 8px;
+      background: #222529;
+      padding: 8px;
     }
 
     .chat-attach-btn {
-      width: 44px;
-      min-width: 44px;
-      height: 44px;
+      width: 40px;
+      min-width: 40px;
+      height: 40px;
       padding: 0;
       font-size: 20px;
       line-height: 1;
+      border-color: rgba(255,255,255,0.1);
+      background: rgba(255,255,255,0.04);
+      color: #aeb8c9;
     }
 
     .chat-input-bar textarea {
-      flex: 1;
-      min-height: 44px;
-      max-height: 120px;
-      resize: vertical;
+      width: 100%;
+      min-height: 40px;
+      max-height: 160px;
+      resize: none;
+      border: 0;
+      box-shadow: none;
+      background: transparent;
+      color: #f3f4f6;
+      padding: 8px;
+      font-size: 15px;
+      line-height: 1.5;
+      outline: none;
+    }
+
+    .chat-input-bar textarea:focus {
+      border: 0;
+      box-shadow: none;
+    }
+
+    .chat-input-bar textarea::placeholder {
+      color: #7f8da6;
+    }
+
+    .chat-input-bar .btn-primary {
+      min-height: 40px;
+      border-radius: 8px;
     }
 
     body.chat-active .floating-pet {
@@ -3422,11 +3502,11 @@
     }
 
     .chat-window.locked .chat-composer {
-      background: rgba(247, 249, 252, 0.92);
+      background: #181b20;
     }
 
     .chat-window.locked .chat-input-bar textarea {
-      color: var(--text2);
+      color: #8da0bc;
     }
 
     #media-preview-modal .modal {
@@ -6957,6 +7037,7 @@
           id:message.metadata?.id || message.metadata?.tool_call_id || message.metadata?.tool_use_id,
           name:extractCatsMessageText(message)||'Tool',
           input:message.metadata?.input,
+          metadata:message.metadata||{},
         }];
       }
       if(type==='tool_result'){
@@ -6965,6 +7046,7 @@
           tool_use_id:message.metadata?.tool_use_id || message.metadata?.id || message.metadata?.tool_call_id,
           content:extractCatsMessageText(message),
           is_error:Boolean(message.metadata?.is_error),
+          metadata:message.metadata||{},
         }];
       }
       if(isCatsWorkingTextMessage(message)){
@@ -7025,6 +7107,71 @@
       return String(message?.seq_id || message?.id || message?.created_at || '');
     }
 
+    function truncateCatsWorkingText(value, limit=1200){
+      const text=String(value||'');
+      if(text.length<=limit)return {text, truncated:false};
+      return {text:text.slice(0,limit).trimEnd()+'\n...', truncated:true};
+    }
+
+    function catsStableHash(value){
+      const text=typeof value==='string'?value:JSON.stringify(value||'');
+      let hash=0;
+      for(let i=0;i<text.length;i++){
+        hash=((hash<<5)-hash)+text.charCodeAt(i);
+        hash|=0;
+      }
+      return Math.abs(hash).toString(36);
+    }
+
+    function catsWorkingDetailKey(groups){
+      return catsStableHash((groups||[]).map(group=>{
+        const block=group.tool||group.block||group.result||{};
+        return [
+          group.type,
+          block.id,
+          block.tool_use_id,
+          block.call_id,
+          block.name,
+          block.metadata?.subagent_id,
+          block.metadata?.display_name,
+          catsWorkingSummary(block).slice(0,120),
+        ].filter(Boolean).join('|');
+      }).join('||'));
+    }
+
+    function captureCatsOpenDetails(root){
+      const keys=new Set();
+      if(!root)return keys;
+      root.querySelectorAll('details.chat-working[data-cats-detail-key]').forEach(item=>{
+        if(item.open)keys.add(item.dataset.catsDetailKey);
+      });
+      return keys;
+    }
+
+    function restoreCatsOpenDetails(root, keys){
+      if(!root || !keys)return;
+      root.querySelectorAll('details.chat-working[data-cats-detail-key]').forEach(item=>{
+        item.open=keys.has(item.dataset.catsDetailKey);
+      });
+    }
+
+    function captureCatsWorkingScrollPositions(root){
+      const positions=new Map();
+      if(!root)return positions;
+      root.querySelectorAll('.chat-working-body[data-cats-scroll-key]').forEach(item=>{
+        if(item.scrollTop>0)positions.set(item.dataset.catsScrollKey,item.scrollTop);
+      });
+      return positions;
+    }
+
+    function restoreCatsWorkingScrollPositions(root, positions){
+      if(!root || !positions)return;
+      root.querySelectorAll('.chat-working-body[data-cats-scroll-key]').forEach(item=>{
+        const value=positions.get(item.dataset.catsScrollKey);
+        if(typeof value==='number')item.scrollTop=value;
+      });
+    }
+
     function updatePetFromCatsMessages(messages){
       const items=Array.isArray(messages)?messages:[];
       if(!items.length){
@@ -7077,29 +7224,49 @@
     function renderCatsWorkingBlocks(blocks){
       if(!blocks.length)return '';
       const groups=groupCatsWorkingBlocks(blocks);
+      const detailKey=catsWorkingDetailKey(groups);
+      let subAgentCount=0;
       const steps=groups.map(group=>{
         if(group.type==='tool'){
           const tool=group.tool||{};
           const result=group.result||{};
-          const title='Tool: '+(tool.name||tool.tool_name||'Tool');
-          const inputSummary=catsWorkingSummary(tool);
-          const input=catsWorkingCode(tool.input||tool.arguments);
-          const output=catsWorkingCode(result.content||result.text||result.output||result.result);
+          const metadata=Object.assign({}, tool.metadata||{}, result.metadata||{});
+          const toolId=String(tool.id||tool.tool_use_id||tool.call_id||result.tool_use_id||'');
+          const inputKind=tool.input && typeof tool.input==='object' ? String(tool.input.kind||'') : '';
+          const isSubAgent=metadata.kind==='subagent_event' || inputKind==='subagent' || toolId.startsWith('subagent:');
+          if(isSubAgent)subAgentCount++;
+          const displayName=metadata.display_name||metadata.displayName||metadata.subagent_name||tool.input?.display_name||tool.input?.name||'子agent';
+          const agentType=metadata.agent_type||tool.input?.agent_type||tool.input?.type||'';
+          const status=metadata.status||tool.input?.status||'';
+          const title=isSubAgent ? displayName : 'Tool: '+(tool.name||tool.tool_name||'Tool');
+          const metaParts=isSubAgent
+            ? [agentType,status,metadata.step_count?metadata.step_count+' 步':''].filter(Boolean)
+            : [];
+          const inputSummary=isSubAgent
+            ? (metadata.task||tool.input?.task||metadata.summary||catsWorkingSummary(tool))
+            : catsWorkingSummary(tool);
+          const input=truncateCatsWorkingText(catsWorkingCode(tool.input||tool.arguments));
+          const output=truncateCatsWorkingText(catsWorkingCode(result.content||result.text||result.output||result.result));
           return '<div class="chat-working-step"><div class="chat-working-step-title">'+escapeHtml(title)+(inputSummary?'<span class="chat-working-step-meta">'+escapeHtml(inputSummary)+'</span>':'')+'</div>'+
-            (input?'<div class="chat-working-code"><pre>'+escapeHtml(input)+'</pre></div>':'')+
-            (output?'<div class="chat-working-code" style="margin-top:6px"><pre>'+escapeHtml(output)+'</pre></div>':'')+
+            (metaParts.length?'<div class="chat-working-summary-meta">'+escapeHtml(metaParts.join(' · '))+'</div>':'')+
+            (input.text?'<div class="chat-working-code"><pre>'+escapeHtml(input.text)+'</pre></div>'+(input.truncated?'<div class="chat-working-note">输入较长，已在 WORKING 中截断，完整内容请看日志。</div>':''):'')+
+            (output.text?'<div class="chat-working-code" style="margin-top:6px"><pre>'+escapeHtml(output.text)+'</pre></div>'+(output.truncated?'<div class="chat-working-note">输出较长，已在 WORKING 中截断，完整内容请看日志。</div>':''):'')+
             '</div>';
         }
         const block=group.block||group.result||{};
         const type=group.type||block.type||'Working';
         const title=type==='thinking'?'Thinking':type==='assistant_text'?'Assistant':type==='tool_result'?'Tool Result':type;
+        const text=type==='tool_result'
+          ? truncateCatsWorkingText(catsWorkingCode(block.content||block.text||block.output||block.result))
+          : truncateCatsWorkingText(catsWorkingSummary(block),900);
         const body=type==='tool_result'
-          ? '<div class="chat-working-code"><pre>'+escapeHtml(catsWorkingCode(block.content||block.text||block.output||block.result))+'</pre></div>'
-          : '<div class="chat-markdown">'+renderMarkdown(catsWorkingSummary(block))+'</div>';
-        return '<div class="chat-working-step"><div class="chat-working-step-title">'+escapeHtml(title)+'</div>'+body+'</div>';
+          ? '<div class="chat-working-code"><pre>'+escapeHtml(text.text)+'</pre></div>'
+          : '<div class="chat-markdown">'+renderMarkdown(text.text)+'</div>';
+        const note=text.truncated?'<div class="chat-working-note">内容较长，已在 WORKING 中截断，完整内容请看日志。</div>':'';
+        return '<div class="chat-working-step"><div class="chat-working-step-title">'+escapeHtml(title)+'</div>'+body+note+'</div>';
       }).join('');
-      const countLabel=groups.length===1?'1 step':(groups.length+' steps');
-      return '<details class="chat-working"><summary><span class="chat-working-chevron">&gt;</span><span>WORKING...</span><span class="chat-working-hint">'+escapeHtml(countLabel)+'</span></summary><div class="chat-working-body">'+steps+'</div></details>';
+      const countLabel=(groups.length===1?'1 step':(groups.length+' steps'))+(subAgentCount?' · '+subAgentCount+' subagent':'');
+      return '<details class="chat-working" data-cats-detail-key="'+escapeHtml(detailKey)+'"><summary><span class="chat-working-chevron">&gt;</span><span>WORKING...</span><span class="chat-working-hint">'+escapeHtml(countLabel)+'</span></summary><div class="chat-working-body" data-cats-scroll-key="'+escapeHtml(detailKey)+'">'+steps+'</div></details>';
     }
 
     function renderCatsMessageBody(message){
@@ -7227,6 +7394,8 @@
       const box=document.getElementById('cats-messages');
       const uid=String(catsState.user?.uid||'');
       const shouldStickToBottom=catsScrollPinnedToBottom || !box.scrollHeight || isCatsMessageScrollNearBottom(box);
+      const openDetails=captureCatsOpenDetails(box);
+      const workingScrollPositions=captureCatsWorkingScrollPositions(box);
       if(!messages || !messages.length){
         box.innerHTML='<div class="loading">暂无消息</div>';
         return;
@@ -7240,6 +7409,8 @@
         return renderCatsMessageShell(group.message, renderCatsMessageBody(group.message), {isConsecutive:group.isConsecutive});
       }).join('');
       box.innerHTML='<div class="chat-timeline-inner">'+html+'</div>';
+      restoreCatsOpenDetails(box, openDetails);
+      restoreCatsWorkingScrollPositions(box, workingScrollPositions);
       if(shouldStickToBottom)scrollCatsMessagesToBottom(box);
       updatePetFromCatsMessages(messages);
     }

--- a/src/catscompany/client.ts
+++ b/src/catscompany/client.ts
@@ -18,6 +18,10 @@ export interface MessageContext {
   text: string;
   content?: any;
   content_blocks?: unknown[];
+  type?: string;
+  msg_type?: string;
+  metadata?: Record<string, unknown>;
+  mode?: string;
   isGroup: boolean;
   from?: string;  // 原始 Cats 发送方字段，供兼容和排查使用
   seq?: number;   // Cats 服务端消息序号，用于排序和补充消息合并
@@ -168,17 +172,23 @@ export class CatsClient extends EventEmitter {
         text: typeof msg.data.content === 'string' ? msg.data.content : '',
         content: msg.data.content,
         content_blocks: Array.isArray(msg.data.content_blocks) ? msg.data.content_blocks : undefined,
+        type: typeof msg.data.type === 'string' ? msg.data.type : undefined,
+        msg_type: typeof msg.data.msg_type === 'string' ? msg.data.msg_type : undefined,
+        metadata: msg.data.metadata && typeof msg.data.metadata === 'object' ? msg.data.metadata : undefined,
+        mode: typeof msg.data.mode === 'string' ? msg.data.mode : undefined,
         isGroup: msg.data.topic?.startsWith('grp_') ?? false,
         seq: Number(msg.data.seq || 0),
       };
       this.emit('message', ctx);
     } else if (msg.pres) {
-      Logger.info(`[CatsCompany] 收到 presence: what=${msg.pres.what || '-'}, src=${msg.pres.src || '-'}`);
       if (msg.pres.what === 'friend_request') {
+        Logger.info(`[CatsCompany] 收到好友请求通知: src=${msg.pres.src || '-'}`);
         const fromUserId = msg.pres.src;
         if (fromUserId) {
           this.acceptFriendRequest(fromUserId).catch(console.error);
         }
+      } else if (msg.pres.what && msg.pres.what !== 'on' && msg.pres.what !== 'off') {
+        Logger.info(`[CatsCompany] 收到 presence: what=${msg.pres.what}, src=${msg.pres.src || '-'}`);
       }
     }
   }

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -6,6 +6,7 @@ import { MessageSessionManager } from '../core/message-session-manager';
 import { AgentServices, BUSY_MESSAGE, RuntimeFeedbackInput } from '../core/agent-session';
 import { Logger } from '../utils/logger';
 import { SubAgentManager } from '../core/sub-agent-manager';
+import type { SubAgentInfo } from '../core/sub-agent-session';
 import { ChannelCallbacks } from '../types/tool';
 import { ContentBlock } from '../types';
 import { AdapterRuntimeBundle, createAdapterRuntime } from '../runtime/adapter-runtime';
@@ -46,6 +47,22 @@ interface QueuedMessage {
 
 const PENDING_ANSWER_TIMEOUT_MS = 120_000;
 const TEXT_ATTACHMENT_COALESCE_MS = Number(process.env.CATSCO_TEXT_ATTACHMENT_COALESCE_MS || 1500);
+const HIDDEN_CATS_TOOL_PROGRESS = new Set([
+  'send_text',
+  'send_file',
+  'spawn_subagent',
+]);
+const SUBAGENT_TERMINAL_EVENTS = new Set(['agent_completed', 'agent_failed', 'agent_stopped']);
+
+function shouldHideCatsToolProgress(toolName: string): boolean {
+  return HIDDEN_CATS_TOOL_PROGRESS.has(toolName);
+}
+
+function compactCatsSubAgentSummary(text: string, maxLength = 4000): string {
+  const normalized = text.replace(/\s+\n/g, '\n').trim();
+  if (normalized.length <= maxLength) return normalized;
+  return `${normalized.slice(0, maxLength)}\n\n[内容较长，已截断；完整内容请查看本地日志]`;
+}
 
 export function createCatsCompanyRuntime(sessionTTL?: number): AdapterRuntimeBundle {
   return createAdapterRuntime({
@@ -191,6 +208,11 @@ export class CatsCompanyBot {
    * 处理收到的消息
    */
   private async onMessage(ctx: MessageContext): Promise<void> {
+    if (this.isCancelMessage(ctx)) {
+      this.handleCancelMessage(ctx);
+      return;
+    }
+
     const msg = this.parseMessage(ctx);
     if (!msg) return;
 
@@ -234,7 +256,10 @@ export class CatsCompanyBot {
       injectMessage: async (text: string) => {
         await this.handleSubAgentFeedback(key, msg.topic, msg.senderId, text);
       },
-    });
+      onSubAgentEvent: async (event: any, info?: SubAgentInfo) => {
+        await this.handleSubAgentRuntimeEvent(msg.topic, event, info);
+      },
+    } as any);
 
     // 处理斜杠命令
     if (typeof msg.text === 'string' && msg.text.startsWith('/')) {
@@ -343,7 +368,7 @@ export class CatsCompanyBot {
           },
           onToolStart: async (toolName: string, toolUseId: string, input: any) => {
             // 跳过输出型工具的 WORKING 消息
-            if (toolName === 'send_text' || toolName === 'send_file') {
+            if (shouldHideCatsToolProgress(toolName)) {
               return;
             }
             try {
@@ -354,7 +379,7 @@ export class CatsCompanyBot {
           },
           onToolEnd: async (toolName: string, toolUseId: string, result: string) => {
             // 跳过输出型工具的 WORKING 消息
-            if (toolName === 'send_text' || toolName === 'send_file') {
+            if (shouldHideCatsToolProgress(toolName)) {
               return;
             }
             try {
@@ -614,6 +639,106 @@ export class CatsCompanyBot {
     }
 
     Logger.warning(`[${sessionKey}] 子智能体反馈注入失败：主会话持续忙碌`);
+  }
+
+  private async handleSubAgentRuntimeEvent(
+    topic: string,
+    event: any,
+    info?: SubAgentInfo,
+  ): Promise<void> {
+    const subAgentId = String(event?.subAgentId || info?.id || '');
+    if (!subAgentId) return;
+
+    const displayName = String(event?.subAgentName || (info as any)?.displayName || subAgentId.slice(0, 12));
+    const toolUseId = `subagent:${subAgentId}`;
+    const status = info?.status || 'running';
+
+    try {
+      if (event?.type === 'agent_spawned') {
+        await this.sender.sendToolUse(topic, toolUseId, displayName, {
+          kind: 'subagent',
+          subagent_id: subAgentId,
+          display_name: displayName,
+          agent_type: (info as any)?.agentType || info?.skillName || '',
+          status,
+          task: info?.taskDescription || event?.summary || '',
+        }, this.subAgentEventMetadata(event, info, status));
+        return;
+      }
+
+      if (SUBAGENT_TERMINAL_EVENTS.has(String(event?.type))) {
+        const statusLabel = event.type === 'agent_completed'
+          ? '已完成'
+          : event.type === 'agent_stopped'
+            ? '已停止'
+            : '失败';
+        const summary = [
+          `${displayName} ${statusLabel}`,
+          `任务: ${info?.taskDescription || event?.summary || '（未知）'}`,
+          `结果摘要: ${compactCatsSubAgentSummary(info?.resultSummary || event?.summary || '（无结果）')}`,
+          info?.outputFiles?.length ? `产出文件:\n${info.outputFiles.map(file => `- ${file}`).join('\n')}` : '',
+        ].filter(Boolean).join('\n');
+        await this.sender.sendToolResult(
+          topic,
+          toolUseId,
+          summary,
+          event.type === 'agent_failed',
+          this.subAgentEventMetadata(event, info, status),
+        );
+        return;
+      }
+
+      if (event?.type === 'agent_waiting') {
+        return;
+      }
+
+      if (event?.summary) {
+        await this.sender.sendThinking(
+          topic,
+          `[${displayName}] ${event.summary}`,
+          this.subAgentEventMetadata(event, info, status),
+        );
+      }
+    } catch (err: any) {
+      Logger.warning(`子智能体状态通知发送失败: ${err.message}`);
+    }
+  }
+
+  private subAgentEventMetadata(event: any, info?: SubAgentInfo, status?: SubAgentInfo['status']): Record<string, unknown> {
+    return {
+      kind: 'subagent_event',
+      subagent_id: event?.subAgentId || info?.id,
+      subagent_name: event?.subAgentName || (info as any)?.displayName,
+      display_name: event?.subAgentName || (info as any)?.displayName,
+      subagent_event_type: event?.type,
+      agent_type: (info as any)?.agentType || info?.skillName,
+      status,
+      task: info?.taskDescription,
+      summary: event?.summary,
+      step_count: info?.progressLog?.length,
+    };
+  }
+
+  /** CatsCompany 网页停止按钮发来的轻量取消事件，不落历史消息 */
+  private isCancelMessage(ctx: MessageContext): boolean {
+    const type = String(ctx.type || ctx.msg_type || '').trim();
+    const streamEvent = String(ctx.metadata?.stream_event || '').trim();
+    const control = String(ctx.metadata?.control || '').trim();
+    return type === 'stream_cancel' || streamEvent === 'cancel' || control === 'interrupt';
+  }
+
+  private handleCancelMessage(ctx: MessageContext): void {
+    const key = ctx.isGroup
+      ? `cc_group:${ctx.topic}`
+      : `cc_user:${ctx.senderId}`;
+    const session = (this.sessionManager as any).get?.(key) ?? null;
+    if (!session) {
+      Logger.info(`[${key}] 收到取消事件，但会话不存在`);
+      return;
+    }
+
+    session.requestInterrupt();
+    Logger.info(`[${key}] 收到 CatsCompany 取消事件，已请求中断当前回合`);
   }
 
   /**

--- a/src/catscompany/message-sender.ts
+++ b/src/catscompany/message-sender.ts
@@ -153,13 +153,17 @@ export class MessageSender {
     }
   }
 
-  async sendThinking(topic: string, thinking: string): Promise<void> {
-    await this.send(topic, 'thinking', thinking);
+  async sendThinking(topic: string, thinking: string, metadata?: any): Promise<void> {
+    await this.send(topic, 'thinking', thinking, metadata);
     Logger.info(`Thinking 已发送: ${thinking.slice(0, 50)}...`);
   }
 
-  async sendToolUse(topic: string, toolUseId: string, name: string, input: any): Promise<void> {
-    await this.send(topic, 'tool_use', name, { id: toolUseId, input });
+  async sendToolUse(topic: string, toolUseId: string, name: string, input: any, metadata?: any): Promise<void> {
+    await this.send(topic, 'tool_use', name, {
+      id: toolUseId,
+      input,
+      ...(metadata || {}),
+    });
     Logger.info(`Tool use 已发送: ${name}, id=${toolUseId}`);
   }
 
@@ -167,11 +171,13 @@ export class MessageSender {
     topic: string,
     toolUseId: string,
     content: string,
-    isError = false
+    isError = false,
+    metadata?: any
   ): Promise<void> {
     await this.send(topic, 'tool_result', content, {
       tool_use_id: toolUseId,
       is_error: isError,
+      ...(metadata || {}),
     });
     Logger.info(`Tool result 已发送: tool_use_id=${toolUseId}`);
   }

--- a/tests/catscompany-content-blocks.test.ts
+++ b/tests/catscompany-content-blocks.test.ts
@@ -7,6 +7,9 @@ function createProcessHarness() {
   const downloads: Array<{ url: string; fileName: string }> = [];
   const multimodalCalls: Array<{ text: string; attachments: any[] }> = [];
   const handledTurns: Array<{ userMessage: any; options: any }> = [];
+  const sentThinking: Array<{ text: string; metadata?: any }> = [];
+  const toolUses: Array<{ topic: string; toolUseId: string; name: string; input: any; metadata?: any }> = [];
+  const toolResults: Array<{ topic: string; toolUseId: string; content: string; isError?: boolean; metadata?: any }> = [];
 
   const session = {
     isBusy: () => false,
@@ -18,6 +21,7 @@ function createProcessHarness() {
 
   bot.sessionManager = {
     getOrCreate: () => session,
+    get: () => session,
   };
   bot.sender = {
     downloadFile: async (url: string, fileName: string) => {
@@ -28,6 +32,15 @@ function createProcessHarness() {
     reply: async () => undefined,
     sendFile: async () => undefined,
     sendText: async () => undefined,
+    sendThinking: async (_topic: string, text: string, metadata?: any) => {
+      sentThinking.push({ text, metadata });
+    },
+    sendToolUse: async (topic: string, toolUseId: string, name: string, input: any, metadata?: any) => {
+      toolUses.push({ topic, toolUseId, name, input, metadata });
+    },
+    sendToolResult: async (topic: string, toolUseId: string, content: string, isError?: boolean, metadata?: any) => {
+      toolResults.push({ topic, toolUseId, content, isError, metadata });
+    },
   };
   bot.pendingAnswers = new Map();
   bot.pendingAnswerBySession = new Map();
@@ -45,7 +58,7 @@ function createProcessHarness() {
     ];
   };
 
-  return { bot, downloads, multimodalCalls, handledTurns };
+  return { bot, downloads, multimodalCalls, handledTurns, sentThinking, toolUses, toolResults };
 }
 
 describe('CatsCo content blocks', () => {
@@ -185,5 +198,103 @@ describe('CatsCo content blocks', () => {
       /file type not allowed/,
     );
     assert.strictEqual(channel.hasOutbound, false);
+  });
+
+  test('interrupts active session on CatsCompany stream cancel event', () => {
+    const bot = Object.create(CatsCompanyBot.prototype) as any;
+    let interrupted = 0;
+    bot.sessionManager = {
+      get: (key: string) => key === 'cc_user:usr1'
+        ? {
+          requestInterrupt: () => {
+            interrupted += 1;
+          },
+        }
+        : null,
+    };
+
+    bot.handleCancelMessage({
+      topic: 'p2p_1_2',
+      senderId: 'usr1',
+      text: '',
+      content: '',
+      type: 'stream_cancel',
+      metadata: { stream_event: 'cancel', control: 'interrupt' },
+      isGroup: false,
+      seq: 0,
+    });
+
+    assert.strictEqual(interrupted, 1);
+  });
+
+  test('subagent runtime events are sent as CatsCompany working metadata', async () => {
+    const { bot, sentThinking, toolUses, toolResults } = createProcessHarness();
+    const now = Date.now();
+    const info = {
+      id: 'sub-1',
+      skillName: 'explorer',
+      taskDescription: '扫描登录链路',
+      status: 'running',
+      createdAt: now,
+      progressLog: [],
+      outputFiles: [],
+    };
+
+    await bot.handleSubAgentRuntimeEvent('p2p_1_2', {
+      subAgentId: 'sub-1',
+      subAgentName: '子agent1',
+      type: 'agent_spawned',
+      timestamp: now,
+      summary: '派遣子agent1 扫描登录链路',
+    }, info);
+
+    assert.strictEqual(toolUses.length, 1);
+    assert.strictEqual(toolUses[0].toolUseId, 'subagent:sub-1');
+    assert.strictEqual(toolUses[0].name, '子agent1');
+    assert.strictEqual(toolUses[0].input.kind, 'subagent');
+    assert.strictEqual(toolUses[0].metadata.kind, 'subagent_event');
+    assert.strictEqual(toolUses[0].metadata.subagent_event_type, 'agent_spawned');
+
+    await bot.handleSubAgentRuntimeEvent('p2p_1_2', {
+      subAgentId: 'sub-1',
+      subAgentName: '子agent1',
+      type: 'agent_progress',
+      timestamp: now,
+      summary: '开始执行：扫描登录链路',
+    }, info);
+
+    assert.deepStrictEqual(sentThinking.map(item => item.text), ['[子agent1] 开始执行：扫描登录链路']);
+    assert.strictEqual(sentThinking[0].metadata.kind, 'subagent_event');
+
+    await bot.handleSubAgentRuntimeEvent('p2p_1_2', {
+      subAgentId: 'sub-1',
+      subAgentName: '子agent1',
+      type: 'agent_waiting',
+      timestamp: now,
+      summary: '等待主 agent 回复：需要确认范围',
+    }, info);
+
+    assert.deepStrictEqual(sentThinking.map(item => item.text), ['[子agent1] 开始执行：扫描登录链路']);
+
+    await bot.handleSubAgentRuntimeEvent('p2p_1_2', {
+      subAgentId: 'sub-1',
+      subAgentName: '子agent1',
+      type: 'agent_completed',
+      timestamp: now + 1,
+      summary: '完成',
+    }, {
+      ...info,
+      status: 'completed',
+      resultSummary: '登录链路正常',
+      outputFiles: ['logs/report.md'],
+    });
+
+    assert.strictEqual(toolResults.length, 1);
+    assert.strictEqual(toolResults[0].toolUseId, 'subagent:sub-1');
+    assert.strictEqual(toolResults[0].metadata.kind, 'subagent_event');
+    assert.strictEqual(toolResults[0].metadata.subagent_event_type, 'agent_completed');
+    assert.match(toolResults[0].content, /已完成/);
+    assert.match(toolResults[0].content, /登录链路正常/);
+    assert.match(toolResults[0].content, /logs\/report\.md/);
   });
 });

--- a/tests/dashboard-productization-html.test.ts
+++ b/tests/dashboard-productization-html.test.ts
@@ -139,3 +139,14 @@ test('CatsCo Chat composer supports local attachments', () => {
   assert.match(dashboardHtml, /catsMessageInput\.addEventListener\('paste'/);
   assert.match(dashboardHtml, /\/api\/cats\/messages\/send-file/);
 });
+
+test('CatsCo Chat preserves fallback tool metadata for WORKING rendering', () => {
+  const fallbackBlock = dashboardHtml.match(/function catsContentBlocksFromMessage\(message\)\{[\s\S]*?function groupCatsWorkingBlocks/)?.[0] || '';
+  assert.match(fallbackBlock, /type:'tool_use'[\s\S]*metadata:message\.metadata\|\|\{\}/);
+  assert.match(fallbackBlock, /type:'tool_result'[\s\S]*metadata:message\.metadata\|\|\{\}/);
+
+  const workingBlock = dashboardHtml.match(/function renderCatsWorkingBlocks\(blocks\)\{[\s\S]*?function renderCatsMessageBody/)?.[0] || '';
+  assert.match(workingBlock, /const metadata=Object\.assign\(\{\}, tool\.metadata\|\|\{\}, result\.metadata\|\|\{\}\)/);
+  assert.match(workingBlock, /metadata\.status\|\|tool\.input\?\.status/);
+  assert.match(workingBlock, /metadata\.step_count\?metadata\.step_count\+' 步'/);
+});


### PR DESCRIPTION
## 背景

从原来的异步子 agent 大 PR 中拆出的 CatsCo 桌面聊天 UI 切片。这个 PR 只处理桌面 dashboard / CatsCompany local chat 的 WORKING、runtime plan、subagent metadata 展示，不改变核心 subagent runtime。

## 主要改动

- 重做 CatsCo 桌面聊天区域视觉和输入框，使它更接近 CatsCompany 网页端体验。
- WORKING 默认折叠，展开状态和内部滚动位置在刷新/轮询重渲染中保持，避免几秒自动跳回顶部。
- 长 tool/result 输出在 WORKING 内截断，提示用户完整内容看日志，避免桌面聊天被大段代码/日志刷屏。
- 支持 runtime plan 独立折叠卡片，和 WORKING 分开展示。
- 支持 subagent runtime event 的 metadata 展示：子 agent 名称、类型、状态、步数、任务摘要等。
- CatsCompany adapter 会把 subagent event 映射成 CatsCo UI 可消费的 `tool_use/tool_result/thinking` metadata。
- 支持 CatsCompany cancel/interrupt 事件，避免停止按钮只是 UI 状态。
- 降低 presence on/off 日志噪音。

## Review comment 已处理

- 已 rebase 到最新 `main`。
- fallback 解析普通 `tool_use` / `tool_result` message 时保留 `message.metadata`，避免 completed/failed/stopped 等 terminal metadata 丢失。
- 补了 dashboard regression，确认 fallback metadata 会进入 WORKING 渲染。

## 测试

- `npm.cmd run build`
- `node --import tsx --test tests\dashboard-productization-html.test.ts tests\catscompany-content-blocks.test.ts tests\dashboard-skills-api.test.ts`
- `git diff --check` 仅 CRLF warning