### PR TITLE
添加运行时软编排提示

### DIFF
--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -6,6 +6,20 @@ import { Logger } from '../utils/logger';
 import { Metrics } from '../utils/metrics';
 import { ContextCompressor } from './context-compressor';
 import { estimateMessagesTokens, estimateToolsTokens } from './token-estimator';
+import {
+  buildExplicitPlanRequestHintIfUseful,
+  buildInitialDecisionHintIfUseful,
+  buildPlanSoftNudge,
+  buildSubagentSoftNudge,
+  nextPlanNudgeToolCount,
+  nextSubagentNudgeToolCount,
+  PLAN_TOOL_NAME,
+  RECORD_DECISION_TOOL_NAME,
+  shouldAddPlanSoftNudge,
+  shouldAddSubagentSoftNudge,
+  SUBAGENT_TOOL_NAME,
+  TRANSIENT_RUNNER_HINT_PREFIX,
+} from './runner-orchestration-policy';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -32,7 +46,6 @@ const DEFAULT_PROMPT_BUDGET = 120000;
 const ANTHROPIC_PROMPT_BUDGET = 200000;
 const MIN_MESSAGE_BUDGET = 2000;
 const OVERFLOW_REDUCTION_RATIO = 0.6;
-const TRANSIENT_RUNNER_HINT_PREFIX = '[transient_runner_hint]';
 const TRANSIENT_CURRENT_DIRECTORY_PREFIX = '[transient_current_directory]';
 
 /**
@@ -161,6 +174,15 @@ export class ConversationRunner {
     let observationSinceLastOutbound = false;
     const deliveredOutboundFiles = new Set<string>();
     let turns = 0;
+    let executedToolCalls = 0;
+    let hasUpdatedPlan = false;
+    let hasSpawnedSubagent = false;
+    let hasRecordedDecision = false;
+    let hasShownInitialOrchestrationHint = false;
+    let planSoftNudgeCount = 0;
+    let subagentSoftNudgeCount = 0;
+    let nextPlanNudgeAt = nextPlanNudgeToolCount(0);
+    let nextSubagentNudgeAt = nextSubagentNudgeToolCount(0);
 
     while (true) {
       turns++;
@@ -186,7 +208,29 @@ export class ConversationRunner {
       }
 
       const activeTools = allTools;
-      const requestMessages = this.buildProviderInputMessages(messages, nextTurnTransientHints);
+      const orchestrationHints: Message[] = [];
+      if (turns === 1 && !hasShownInitialOrchestrationHint) {
+        const explicitPlanHint = buildExplicitPlanRequestHintIfUseful(messages, activeTools);
+        const decisionHint = buildInitialDecisionHintIfUseful(messages, activeTools);
+        if (explicitPlanHint) orchestrationHints.push(explicitPlanHint);
+        if (decisionHint) orchestrationHints.push(decisionHint);
+        hasShownInitialOrchestrationHint = orchestrationHints.length > 0;
+      }
+      if (shouldAddPlanSoftNudge(activeTools, turns, executedToolCalls, hasUpdatedPlan || hasRecordedDecision, nextPlanNudgeAt)) {
+        orchestrationHints.push(buildPlanSoftNudge(turns, executedToolCalls, planSoftNudgeCount));
+        planSoftNudgeCount++;
+        nextPlanNudgeAt = nextPlanNudgeToolCount(executedToolCalls);
+      }
+      if (shouldAddSubagentSoftNudge(activeTools, turns, executedToolCalls, hasSpawnedSubagent || hasRecordedDecision, nextSubagentNudgeAt)) {
+        orchestrationHints.push(buildSubagentSoftNudge(turns, executedToolCalls, subagentSoftNudgeCount));
+        subagentSoftNudgeCount++;
+        nextSubagentNudgeAt = nextSubagentNudgeToolCount(executedToolCalls);
+      }
+
+      const requestMessages = this.buildProviderInputMessages(messages, [
+        ...nextTurnTransientHints,
+        ...orchestrationHints,
+      ]);
       nextTurnTransientHints = [];
       this.ensurePromptBudget(requestMessages, activeTools);
       this.logProviderMessagesForDebug(requestMessages, activeTools, turns);
@@ -311,6 +355,14 @@ export class ConversationRunner {
             this.toolExecutionContext || {},
             turns,
           );
+        executedToolCalls++;
+        if (toolName === PLAN_TOOL_NAME) {
+          hasUpdatedPlan = true;
+        } else if (toolName === SUBAGENT_TOOL_NAME) {
+          hasSpawnedSubagent = true;
+        } else if (toolName === RECORD_DECISION_TOOL_NAME) {
+          hasRecordedDecision = true;
+        }
         const toolDuration = Date.now() - toolStart;
         Metrics.recordToolCall(toolName, toolDuration);
         Logger.info(`[${this.sessionLabel}Turn ${turns}] 工具完成: ${toolName} | 耗时: ${toolDuration}ms | 结果: ${ConversationRunner.truncateForLog(result.content, 300)}`);

--- a/src/core/runner-orchestration-policy.ts
+++ b/src/core/runner-orchestration-policy.ts
@@ -1,0 +1,205 @@
+import { ContentBlock, Message } from '../types';
+import { ToolDefinition } from '../types/tool';
+
+export const TRANSIENT_RUNNER_HINT_PREFIX = '[transient_runner_hint]';
+export const SUBAGENT_TOOL_NAME = 'spawn_subagent';
+export const PLAN_TOOL_NAME = 'update_plan';
+export const RECORD_DECISION_TOOL_NAME = 'record_decision';
+
+const SUBAGENT_COMPLEX_REQUEST_MIN_CHARS = 90;
+const SEMANTIC_WORK_REQUEST_MIN_CHARS = 20;
+const PLAN_SOFT_NUDGE_MIN_TURNS = 3;
+const PLAN_SOFT_NUDGE_MIN_TOOL_CALLS = 4;
+const PLAN_SOFT_NUDGE_TOOL_INTERVAL = 8;
+const SUBAGENT_SOFT_NUDGE_MIN_TURNS = 6;
+const SUBAGENT_SOFT_NUDGE_MIN_TOOL_CALLS = 8;
+const SUBAGENT_SOFT_NUDGE_TOOL_INTERVAL = 10;
+
+export interface OrchestrationState {
+  hasUpdatedPlan: boolean;
+  hasSpawnedSubagent: boolean;
+  hasRecordedDecision: boolean;
+}
+
+export function contentToString(content: string | ContentBlock[] | null): string {
+  if (!content) return '';
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '[图片]';
+  return content.map(block => block.type === 'text' ? block.text : '[图片]').join('');
+}
+
+export function buildInitialDecisionHintIfUseful(messages: Message[], tools: ToolDefinition[]): Message | null {
+  const userText = getLastUserText(messages);
+  if (looksLikeOrchestrationMetaQuestion(userText)) return null;
+  if (!looksLikeWorkRequest(userText)) return null;
+
+  const available = getAvailableOrchestrationTools(tools);
+  if (available.length === 0) return null;
+
+  const lines = looksLikeComplexDelegationCandidate(userText)
+    ? [
+      '语义编排提示：这看起来是多阶段、多维度或可能等待较久的任务。',
+      '先判断是否需要运行时计划、后台子任务，以及主线/支线如何拆分。',
+      '子 agent 是侧路加速，不替代主线；派出后主线仍应继续推进不依赖结果的工作。',
+    ]
+    : [
+      '语义编排提示：先判断这轮是简单单点、主线可直接推进，还是多阶段/可并行任务。',
+      '简单任务直接做，不要为了形式调用 plan/subagent。',
+    ];
+
+  return makeRunnerHint([
+    ...lines,
+    buildAvailableToolHint(available),
+  ]);
+}
+
+export function buildExplicitPlanRequestHintIfUseful(messages: Message[], tools: ToolDefinition[]): Message | null {
+  if (!hasTool(tools, PLAN_TOOL_NAME)) return null;
+
+  const userText = getLastUserText(messages);
+  if (!looksLikeExplicitPlanRequest(userText)) return null;
+
+  return makeRunnerHint([
+    '用户明确要求列计划/plan。若这是执行路线图，请优先调用 update_plan 更新计划卡片。',
+    '不要只在普通回复或 markdown 清单里写计划；那不会更新 Plan UI。',
+    '如果用户是在问 plan 机制而不是让你执行计划，可以直接解释。',
+  ]);
+}
+
+export function shouldAddPlanSoftNudge(
+  tools: ToolDefinition[],
+  turns: number,
+  executedToolCalls: number,
+  hasUpdatedPlan: boolean,
+  nextToolCount: number,
+): boolean {
+  if (hasUpdatedPlan) return false;
+  if (!hasTool(tools, PLAN_TOOL_NAME)) return false;
+  return turns >= PLAN_SOFT_NUDGE_MIN_TURNS
+    && executedToolCalls >= nextToolCount;
+}
+
+export function buildPlanSoftNudge(turns: number, executedToolCalls: number, nudgeCount: number): Message {
+  return makeRunnerHint([
+    `已进行 ${turns} 轮、${executedToolCalls} 次工具执行，还没有维护运行时计划。`,
+    nudgeCount === 0
+      ? '如果任务仍较大或用户会等较久，考虑调用 update_plan 更新临时计划。'
+      : '如果任务仍多阶段或多方向，重新评估是否需要调用 update_plan。',
+    '这不是硬性要求；如果单线推进更快，可以继续执行。',
+  ]);
+}
+
+export function shouldAddSubagentSoftNudge(
+  tools: ToolDefinition[],
+  turns: number,
+  executedToolCalls: number,
+  hasSpawnedSubagent: boolean,
+  nextToolCount: number,
+): boolean {
+  if (hasSpawnedSubagent) return false;
+  if (!hasTool(tools, SUBAGENT_TOOL_NAME)) return false;
+  return turns >= SUBAGENT_SOFT_NUDGE_MIN_TURNS
+    && executedToolCalls >= nextToolCount;
+}
+
+export function buildSubagentSoftNudge(turns: number, executedToolCalls: number, nudgeCount: number): Message {
+  return makeRunnerHint([
+    `已进行 ${turns} 轮、${executedToolCalls} 次工具执行，还没有派出子 agent。`,
+    nudgeCount === 0
+      ? '如果剩余工作有独立、耗时、可并行支线，考虑派出一个或多个子 agent。'
+      : '如果仍在单线程处理多个独立维度，重新评估是否拆出子 agent。',
+    '这不是硬性要求；如果主线自己做更快，可以继续主线工作。',
+  ]);
+}
+
+export function nextPlanNudgeToolCount(current: number): number {
+  return Math.max(current + PLAN_SOFT_NUDGE_TOOL_INTERVAL, PLAN_SOFT_NUDGE_MIN_TOOL_CALLS);
+}
+
+export function nextSubagentNudgeToolCount(current: number): number {
+  return Math.max(current + SUBAGENT_SOFT_NUDGE_TOOL_INTERVAL, SUBAGENT_SOFT_NUDGE_MIN_TOOL_CALLS);
+}
+
+export function makeRunnerHint(lines: string[]): Message {
+  return {
+    role: 'system',
+    content: [TRANSIENT_RUNNER_HINT_PREFIX, ...lines].join('\n'),
+  };
+}
+
+function getAvailableOrchestrationTools(tools: ToolDefinition[]): string[] {
+  return [PLAN_TOOL_NAME, SUBAGENT_TOOL_NAME, RECORD_DECISION_TOOL_NAME]
+    .filter(name => hasTool(tools, name));
+}
+
+function buildAvailableToolHint(available: string[]): string {
+  const parts: string[] = [];
+  if (available.includes(PLAN_TOOL_NAME)) {
+    parts.push('需要展示真实执行路线时调用 update_plan');
+  }
+  if (available.includes(SUBAGENT_TOOL_NAME)) {
+    parts.push('有独立支线时调用 spawn_subagent');
+  }
+  if (available.includes(RECORD_DECISION_TOOL_NAME)) {
+    parts.push('决定不拆分时可用 record_decision 简记理由');
+  }
+  return `可用编排动作：${parts.join('；')}。`;
+}
+
+function hasTool(tools: ToolDefinition[], name: string): boolean {
+  return tools.some(tool => tool.name === name);
+}
+
+function getLastUserText(messages: Message[]): string {
+  const lastUserMessage = [...messages].reverse().find(message => message.role === 'user');
+  return contentToString(lastUserMessage?.content ?? '').trim();
+}
+
+function looksLikeWorkRequest(text: string): boolean {
+  if (!text.trim()) return false;
+  if (looksLikeOrchestrationMetaQuestion(text)) return false;
+  if (looksLikeComplexDelegationCandidate(text)) return true;
+  if (text.length >= SEMANTIC_WORK_REQUEST_MIN_CHARS) return true;
+
+  return /继续|再看看|看看|看下|查|检查|排查|分析|梳理|修|改|优化|测试|跑|启动|上线|提交|合并|发版|发布|读|找/.test(text);
+}
+
+function looksLikeComplexDelegationCandidate(text: string): boolean {
+  if (looksLikeOrchestrationMetaQuestion(text)) return false;
+  if (text.length < SUBAGENT_COMPLEX_REQUEST_MIN_CHARS) return false;
+
+  const signals = [
+    /全面|完整|整体|发布前|正式|可用性|质量|审查|检查|评估|梳理|排查|优化|风险|清单/,
+    /多个|多维|重点|链路|模块|体验|测试|日志|上下文|性能|设置|停止|中断|状态/,
+    /最后|结论|证据|建议|必须|优先级|不要改代码|先不要改|必要时跑/,
+  ];
+  const score = signals.reduce((total, pattern) => total + (pattern.test(text) ? 1 : 0), 0);
+  const lineBreaks = (text.match(/\n/g) || []).length;
+  return score >= 2 || (score >= 1 && lineBreaks >= 2);
+}
+
+function looksLikeExplicitPlanRequest(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed) return false;
+
+  const explicitPlanAction = /列(个|一下)?\s*(计划|plan)|做(个|一下)?\s*(计划|plan)|先\s*(计划|规划|plan)|规划一下|计划一下|plan\s*一下|给我.*(计划|路线图)|执行计划|工作计划|路线图/i.test(trimmed);
+  if (!explicitPlanAction) return false;
+
+  const metaQuestion = /为什么|为啥|怎么|如何|是什么|啥意思|什么意思|区别|链路|触发|判断|是不是|会不会|能不能|有没有|我想知道|解释|讲讲|回顾|复盘/.test(trimmed);
+  const directWorkRequest = /帮我|给我|列|做|先|开始|直接|看看|看下|检查|排查|分析|梳理|整理|改|修|优化|测试|跑/.test(trimmed);
+  return !metaQuestion || directWorkRequest;
+}
+
+function looksLikeOrchestrationMetaQuestion(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed) return false;
+
+  const mentionsOrchestration = /plan|update_plan|子\s*agent|sub[-_ ]?agent|spawn_subagent|record_decision|checkpoint|编排|任务拆分|复杂任务|并行|主\s*agent/i.test(trimmed);
+  if (!mentionsOrchestration) return false;
+
+  const asksAboutBehavior = /为什么|为啥|怎么|如何|是什么|啥意思|什么意思|区别|链路|触发|判断|是不是|会不会|能不能|有没有|我想知道|解释|讲讲|回顾|复盘/.test(trimmed);
+  if (!asksAboutBehavior) return false;
+
+  const asksToDoWork = /帮我(做|看|看下|检查|排查|分析|梳理|整理|改|修|实现|加|优化|测试|跑|启动|提交|合并|上线)|先只读|不要改代码|要把|最后按|开始做|直接改|修一下|改一下|优化下|测试下|跑一下|启动起来/.test(trimmed);
+  return !asksToDoWork;
+}

--- a/tests/runner-orchestration-policy.test.ts
+++ b/tests/runner-orchestration-policy.test.ts
@@ -1,0 +1,62 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import {
+  buildExplicitPlanRequestHintIfUseful,
+  buildInitialDecisionHintIfUseful,
+  buildPlanSoftNudge,
+  buildSubagentSoftNudge,
+  shouldAddPlanSoftNudge,
+  shouldAddSubagentSoftNudge,
+  TRANSIENT_RUNNER_HINT_PREFIX,
+} from '../src/core/runner-orchestration-policy';
+import type { Message } from '../src/types';
+import type { ToolDefinition } from '../src/types/tool';
+
+const tools = [
+  { name: 'update_plan', description: '', parameters: { type: 'object', properties: {} } },
+  { name: 'spawn_subagent', description: '', parameters: { type: 'object', properties: {} } },
+] as ToolDefinition[];
+
+function user(content: string): Message[] {
+  return [{ role: 'user', content }];
+}
+
+describe('runner orchestration policy', () => {
+  test('adds a semantic hint for complex work without forcing a tool call', () => {
+    const hint = buildInitialDecisionHintIfUseful(user([
+      '帮我全面检查当前项目发布前的质量风险，重点看设置页、停止按钮、日志链路和测试覆盖。',
+      '先不要改代码，最后给我结论、证据和建议。',
+    ].join('\n')), tools);
+
+    assert.ok(hint);
+    assert.equal(hint?.role, 'system');
+    assert.match(String(hint?.content), new RegExp(TRANSIENT_RUNNER_HINT_PREFIX));
+    assert.match(String(hint?.content), /语义编排提示/);
+    assert.match(String(hint?.content), /不是硬性要求|可用编排动作/);
+  });
+
+  test('does not inject orchestration hints for meta questions about plan/subagent', () => {
+    const hint = buildInitialDecisionHintIfUseful(user('为什么刚才没有触发 plan 和子 agent？'), tools);
+    assert.equal(hint, null);
+  });
+
+  test('recognizes explicit plan requests as update_plan hints', () => {
+    const hint = buildExplicitPlanRequestHintIfUseful(user('先给我列个执行计划，然后再开始检查。'), tools);
+
+    assert.ok(hint);
+    assert.match(String(hint?.content), /update_plan/);
+    assert.match(String(hint?.content), /普通回复/);
+  });
+
+  test('soft nudges are threshold based and stop after the relevant action', () => {
+    assert.equal(shouldAddPlanSoftNudge(tools, 2, 10, false, 4), false);
+    assert.equal(shouldAddPlanSoftNudge(tools, 3, 4, false, 4), true);
+    assert.equal(shouldAddPlanSoftNudge(tools, 3, 20, true, 4), false);
+    assert.match(String(buildPlanSoftNudge(3, 4, 0).content), /不是硬性要求/);
+
+    assert.equal(shouldAddSubagentSoftNudge(tools, 5, 20, false, 8), false);
+    assert.equal(shouldAddSubagentSoftNudge(tools, 6, 8, false, 8), true);
+    assert.equal(shouldAddSubagentSoftNudge(tools, 6, 20, true, 8), false);
+    assert.match(String(buildSubagentSoftNudge(6, 8, 0).content), /不是硬性要求/);
+  });
+});


### PR DESCRIPTION
## 背景

从原来的异步子 agent 大 PR 中拆出的“软编排提示”切片。这个 PR 只做提示，不做 workflow 硬限制。

## 主要改动

- 新增 `runner-orchestration-policy`，根据用户语义和运行中工具轮次，向当前 turn 注入 transient system hint。
- 明确 plan/subagent 的触发仍由主模型判断：简单任务直接做，不强迫调用 `update_plan` 或 `spawn_subagent`。
- 对明确要求 plan 的用户消息，提示模型优先用 `update_plan` 更新计划卡片，而不是只在正文写 markdown 清单。
- 对多阶段/多维度/可能等待较久的任务，提示模型先判断是否需要计划、子 agent，以及主线/支线如何拆分。
- 长工具循环中按阈值给软提醒，提醒模型评估是否需要 plan/subagent；已经 `update_plan`、`spawn_subagent` 或 `record_decision` 后不再重复提醒。
- 所有提示都是 transient，不进入持久 session history。

## 特别说明

- 这版没有带回旧大 PR 里“强制 checkpoint / 只开放编排工具 / 阻断探索工具 / 拦截最终回复”的做法。
- 它只是让模型更容易意识到“该规划/该拆支线”的可能性，最终仍由模型自己决定。

## 测试

- `npm.cmd run build`
- `node --import tsx --test tests\runner-orchestration-policy.test.ts tests\conversation-runner-transcript-normalization.test.ts`
- `git diff --check` 仅 CRLF warning