### PR TITLE
支持取消大模型请求并优化 CatsCo 桌面运行态展示

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -6747,6 +6747,12 @@
       return uid && topic ? uid+'|'+topic : '';
     }
 
+    function isCatsMessageRequestCurrent(ownerKey, topicId){
+      return ownerKey
+        && ownerKey===catsMessageOwnerKey(catsState)
+        && String(topicId||'')===String(catsState.topicId||'');
+    }
+
     function resetCatsMessageCache(ownerKey=''){
       catsMessagesCache=[];
       catsMessagesHasOlder=true;
@@ -7733,8 +7739,8 @@
       updatePetFromCatsMessages(messages);
     }
 
-    async function fetchCatsMessagesPage(offset, limit=CATS_MESSAGES_PAGE_SIZE){
-      return parseCatsResponse(await fetch(API+'/api/cats/messages?topic='+encodeURIComponent(catsState.topicId)+'&limit='+encodeURIComponent(limit)+'&offset='+encodeURIComponent(offset)));
+    async function fetchCatsMessagesPage(offset, limit=CATS_MESSAGES_PAGE_SIZE, topicId=catsState.topicId){
+      return parseCatsResponse(await fetch(API+'/api/cats/messages?topic='+encodeURIComponent(topicId)+'&limit='+encodeURIComponent(limit)+'&offset='+encodeURIComponent(offset)));
     }
 
     async function loadCatsMessages(showErrors=true, options={}){
@@ -7751,14 +7757,17 @@
       if(!catsState.topicId)return;
       if(catsMessagesLoading)return;
       catsMessagesLoading=true;
+      const requestOwnerKey=ownerKey;
+      const requestTopicId=catsState.topicId;
       try{
-        if(catsMessagesTopicId!==catsState.topicId){
-          catsMessagesTopicId=catsState.topicId;
+        if(catsMessagesTopicId!==requestTopicId){
+          catsMessagesTopicId=requestTopicId;
           catsMessagesCache=[];
           catsMessagesHasOlder=true;
           options=Object.assign({}, options, {reset:true, forceBottom:true});
         }
-        const data=await fetchCatsMessagesPage(0);
+        const data=await fetchCatsMessagesPage(0, CATS_MESSAGES_PAGE_SIZE, requestTopicId);
+        if(!isCatsMessageRequestCurrent(requestOwnerKey, requestTopicId))return;
         const incoming=data.messages||[];
         if(options.reset || !catsMessagesCache.length){
           catsMessagesCache=incoming;
@@ -7780,10 +7789,16 @@
 
     async function loadOlderCatsMessages(){
       if(!catsState.topicId || catsMessagesLoadingOlder || !catsMessagesHasOlder || !catsMessagesCache.length)return;
+      const requestOwnerKey=catsMessageOwnerKey(catsState);
+      const requestTopicId=catsState.topicId;
       catsMessagesLoadingOlder=true;
       renderCatsMessages(catsMessagesCache, {preserveViewport:true});
       try{
-        const data=await fetchCatsMessagesPage(catsMessagesCache.length);
+        const data=await fetchCatsMessagesPage(catsMessagesCache.length, CATS_MESSAGES_PAGE_SIZE, requestTopicId);
+        if(!isCatsMessageRequestCurrent(requestOwnerKey, requestTopicId)){
+          catsMessagesLoadingOlder=false;
+          return;
+        }
         const incoming=data.messages||[];
         if(incoming.length<CATS_MESSAGES_PAGE_SIZE)catsMessagesHasOlder=false;
         if(incoming.length){

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -2336,6 +2336,19 @@
       justify-content: flex-end;
     }
 
+    .update-actions #update-check-btn {
+      border-color: rgba(59, 130, 246, 0.42);
+      background: rgba(59, 130, 246, 0.12);
+      color: #1d4ed8;
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.85);
+    }
+
+    .update-actions #update-check-btn:hover:not(:disabled) {
+      border-color: rgba(59, 130, 246, 0.58);
+      background: rgba(59, 130, 246, 0.18);
+      box-shadow: 0 12px 24px rgba(59, 130, 246, 0.16);
+    }
+
     #update-modal .modal {
       width: min(540px, 100%);
       max-height: min(70vh, 620px);
@@ -2359,13 +2372,15 @@
       min-height: 36px;
       font-size: 12px;
       font-weight: 700;
-      background: rgba(255,255,255,0.12);
-      border: 1px solid rgba(255,255,255,0.16);
-      color: #e8ebff;
+      background: linear-gradient(135deg, rgba(59,130,246,0.92), rgba(96,165,250,0.82));
+      border: 1px solid rgba(147,197,253,0.5);
+      color: #ffffff;
+      box-shadow: 0 12px 28px rgba(59, 130, 246, 0.22), inset 0 1px 0 rgba(255,255,255,0.28);
     }
 
     .sidebar-update-btn:hover {
-      background: rgba(255,255,255,0.2);
+      background: linear-gradient(135deg, rgba(37,99,235,0.98), rgba(59,130,246,0.92));
+      box-shadow: 0 16px 34px rgba(59, 130, 246, 0.30), inset 0 1px 0 rgba(255,255,255,0.34);
       transform: none;
     }
 

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -3205,6 +3205,19 @@
       font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
     }
 
+    .chat-history-note {
+      margin: 4px auto 18px;
+      width: fit-content;
+      max-width: 100%;
+      padding: 5px 10px;
+      border-radius: 999px;
+      border: 1px solid rgba(255,255,255,0.08);
+      color: var(--text3);
+      background: rgba(255,255,255,0.035);
+      font-size: 12px;
+      font-weight: 700;
+    }
+
     .chat-runtime-plan {
       margin: 8px 0 4px;
       border: 1px solid var(--border-light);
@@ -4723,9 +4736,16 @@
     let catsNextAction = 'none';
     let catsPollTimer = null;
     let catsScrollPinnedToBottom = true;
+    let catsMessagesCache = [];
+    let catsMessagesHasOlder = true;
+    let catsMessagesLoading = false;
+    let catsMessagesLoadingOlder = false;
+    let catsMessagesTopicId = '';
     let catsConnectCollapsed = true;
     let catsConnectManualOverride = false;
+    const CATS_MESSAGES_PAGE_SIZE = 50;
     const CATS_SCROLL_BOTTOM_THRESHOLD = 80;
+    const CATS_SCROLL_TOP_THRESHOLD = 96;
     let catsAttachmentQueue = [];
     let catsAttachmentSeq = 0;
     const CATS_ATTACHMENT_BROWSER_MESSAGE = '普通浏览器不能直接上传本地附件；请在 CatsCo 桌面客户端使用 + 选择文件，或把文件路径作为文字说明发给 Agent。';
@@ -6836,7 +6856,7 @@
         setCatsAction('已连接。可以直接开始对话。');
         pulsePetState('success', '已连接', 2200);
         fetchStatus();
-        await loadCatsMessages(true);
+        await loadCatsMessages(true, {reset:true, forceBottom:true});
       }catch(e){
         setCatsAction('绑定失败：'+e.message,true);
       }finally{
@@ -6850,6 +6870,9 @@
         await parseCatsResponse(await fetch(API+'/api/cats/auth/logout',{method:'POST'}));
         catsState={};
         catsWorkingActive=false;
+        catsMessagesCache=[];
+        catsMessagesHasOlder=true;
+        catsMessagesTopicId='';
         lastCatsMessageSignature='';
         catsScrollPinnedToBottom=true;
         document.getElementById('cats-account').value='';
@@ -6866,7 +6889,7 @@
 
     function extractCatsMessageText(message){
       if(!message)return '';
-      if((message.type||message.msg_type)==='runtime_plan')return '';
+      if(catsMessageType(message)==='runtime_plan')return '';
       if(typeof message.content==='string')return message.content;
       if(Array.isArray(message.content_blocks)){
         return message.content_blocks.map(b=>b.text||b.content||'').filter(Boolean).join('\n');
@@ -7040,6 +7063,55 @@
       return null;
     }
 
+    function parseCatsRuntimePlanValue(value){
+      const parsed=parseCatsContent(value);
+      if(!parsed || typeof parsed!=='object')return null;
+      const steps=Array.isArray(parsed.steps)?parsed.steps:null;
+      if(!steps)return null;
+      const looksLikePlan=steps.every(step=>
+        step && typeof step==='object' &&
+        typeof step.text==='string' &&
+        (!step.status || ['pending','in_progress','completed'].includes(String(step.status)))
+      );
+      if(!looksLikePlan)return null;
+      if(parsed.runtime_plan || parsed.revision!=null || parsed.updatedAt!=null || parsed.updated_at!=null)return parsed;
+      return null;
+    }
+
+    function catsMessageKey(message){
+      if(!message)return '';
+      if(message.id!=null)return 'id:'+message.id;
+      if(message.seq_id!=null)return 'seq:'+message.seq_id;
+      const created=message.created_at||'';
+      const from=message.from_uid||message.from||'';
+      const content=typeof message.content==='string'?message.content:JSON.stringify(message.content||'');
+      return 'fallback:'+catsStableHash([created,from,content].join('|'));
+    }
+
+    function isCatsMessageMine(message){
+      const uid=String(catsState.user?.uid||'');
+      const from=String(message?.from_uid || message?.from || '');
+      return Boolean(uid && (from===uid || from===('usr'+uid)));
+    }
+
+    function mergeCatsMessages(existing,incoming){
+      const map=new Map();
+      (existing||[]).forEach(message=>{
+        const key=catsMessageKey(message);
+        if(key)map.set(key,message);
+      });
+      (incoming||[]).forEach(message=>{
+        const key=catsMessageKey(message);
+        if(key)map.set(key,message);
+      });
+      return [...map.values()].sort((a,b)=>{
+        const ta=Date.parse(a.created_at||'')||0;
+        const tb=Date.parse(b.created_at||'')||0;
+        if(ta!==tb)return ta-tb;
+        return Number(a.id||a.seq_id||0)-Number(b.id||b.seq_id||0);
+      });
+    }
+
     function normalizeMediaUrl(url){
       if(!url)return '';
       if(/^https?:\/\//i.test(url))return url;
@@ -7105,25 +7177,19 @@
     }
 
     function catsMessageType(message){
-      const type=message?.type||'';
-      if(type)return type;
-      const msgType=message?.msg_type||'';
-      return CATS_WORKING_TYPES.has(msgType)?msgType:'';
+      const type=String(message?.type||'');
+      const msgType=String(message?.msg_type||'');
+      const metadata=message?.metadata||{};
+      if(type==='runtime_plan' || msgType==='runtime_plan' || metadata.runtime_plan)return 'runtime_plan';
+      if(!isCatsMessageMine(message) && parseCatsRuntimePlanValue(message?.content))return 'runtime_plan';
+      if(type && type!=='text')return type;
+      if(CATS_WORKING_TYPES.has(msgType))return msgType;
+      return type || msgType || '';
     }
 
     function catsRuntimePlanSnapshot(message){
       if(catsMessageType(message)!=='runtime_plan')return null;
-      const content=message?.content;
-      if(content && typeof content==='object')return content;
-      if(typeof content==='string'){
-        try{
-          const parsed=JSON.parse(content);
-          return parsed && typeof parsed==='object'?parsed:null;
-        }catch(_e){
-          return null;
-        }
-      }
-      return null;
+      return parseCatsRuntimePlanValue(message?.content || message?.metadata?.snapshot);
     }
 
     function catsRuntimePlanKey(message,snapshot){
@@ -7150,7 +7216,8 @@
       const steps=Array.isArray(snapshot?.steps)?snapshot.steps:[];
       if(!steps.length)return '';
       const key=catsRuntimePlanKey(message,snapshot);
-      const open=catsRuntimePlanOpenState.has(key)?catsRuntimePlanOpenState.get(key):true;
+      const allDone=steps.every(step=>step?.status==='completed');
+      const open=catsRuntimePlanOpenState.has(key)?catsRuntimePlanOpenState.get(key):!allDone;
       const done=steps.filter(step=>step?.status==='completed').length;
       const statusLabels={pending:'待处理',in_progress:'进行中',completed:'已完成'};
       const body=steps.map(step=>{
@@ -7483,6 +7550,14 @@
       catsScrollPinnedToBottom=isCatsMessageScrollNearBottom(box);
     }
 
+    function handleCatsMessagesScroll(){
+      const box=document.getElementById('cats-messages');
+      updateCatsMessageScrollIntent();
+      if(box && box.scrollTop<=CATS_SCROLL_TOP_THRESHOLD){
+        loadOlderCatsMessages();
+      }
+    }
+
     function scrollCatsMessagesToBottom(box){
       if(!box)return;
       box.scrollTop=box.scrollHeight;
@@ -7492,14 +7567,37 @@
     function groupCatsTimelineMessages(messages, uid){
       const groups=[];
       let currentWorking=null;
+      let pendingRuntimePlan=null;
       let prevSender='';
       let prevTime=0;
+      const flushWorking=()=>{
+        if(currentWorking){
+          groups.push(currentWorking);
+          currentWorking=null;
+        }
+      };
+      const flushRuntimePlan=()=>{
+        if(pendingRuntimePlan){
+          groups.push(pendingRuntimePlan);
+          pendingRuntimePlan=null;
+        }
+      };
       (messages||[]).forEach(message=>{
-        if(isCatsRuntimePlanClearMessage(message))return;
+        if(isCatsRuntimePlanClearMessage(message)){
+          pendingRuntimePlan=null;
+          return;
+        }
         const from=String(message.from_uid || message.from || '');
         const created=message.created_at?new Date(message.created_at):null;
         const time=created && !Number.isNaN(created.getTime()) ? created.getTime() : Date.now();
         const consecutive=prevSender===from && time-prevTime < 5*60*1000;
+        if(isCatsRuntimePlanMessage(message)){
+          flushWorking();
+          pendingRuntimePlan={type:'runtime_plan', message, from, isConsecutive:consecutive};
+          prevSender=from;
+          prevTime=time;
+          return;
+        }
         if(isCatsWorkingMessage(message)){
           if(!currentWorking){
             currentWorking={type:'working', messages:[], from, isConsecutive:consecutive};
@@ -7509,15 +7607,14 @@
           prevTime=time;
           return;
         }
-        if(currentWorking){
-          groups.push(currentWorking);
-          currentWorking=null;
-        }
+        flushRuntimePlan();
+        flushWorking();
         groups.push({type:'text', message, from, isConsecutive:consecutive});
         prevSender=from;
         prevTime=time;
       });
-      if(currentWorking)groups.push(currentWorking);
+      flushRuntimePlan();
+      flushWorking();
       return groups;
     }
 
@@ -7546,10 +7643,13 @@
       '</div>';
     }
 
-    function renderCatsMessages(messages){
+    function renderCatsMessages(messages, options={}){
       const box=document.getElementById('cats-messages');
       const uid=String(catsState.user?.uid||'');
-      const shouldStickToBottom=catsScrollPinnedToBottom || !box.scrollHeight || isCatsMessageScrollNearBottom(box);
+      const oldScrollTop=box.scrollTop;
+      const oldScrollHeight=box.scrollHeight;
+      const preserveViewport=Boolean(options.preserveViewport);
+      const shouldStickToBottom=Boolean(options.forceBottom) || (!preserveViewport && (catsScrollPinnedToBottom || !box.scrollHeight || isCatsMessageScrollNearBottom(box)));
       const openDetails=captureCatsOpenDetails(box);
       const workingScrollPositions=captureCatsWorkingScrollPositions(box);
       if(!messages || !messages.length){
@@ -7558,27 +7658,83 @@
       }
       const groups=groupCatsTimelineMessages(messages, uid);
       const html=groups.map(group=>{
+        if(group.type==='runtime_plan'){
+          return renderCatsMessageShell(group.message, renderCatsRuntimePlan(group.message), {isConsecutive:group.isConsecutive});
+        }
         if(group.type==='working'){
           const first=group.messages[0]||{};
           return renderCatsMessageShell(first, renderCatsWorkingMessagesBody(group.messages), {working:true, isConsecutive:group.isConsecutive});
         }
         return renderCatsMessageShell(group.message, renderCatsMessageBody(group.message), {isConsecutive:group.isConsecutive});
       }).join('');
-      box.innerHTML='<div class="chat-timeline-inner">'+html+'</div>';
+      const historyNote=catsMessagesLoadingOlder
+        ? '<div class="chat-history-note">正在加载更早消息...</div>'
+        : (!catsMessagesHasOlder?'<div class="chat-history-note">已到最早消息</div>':'');
+      box.innerHTML='<div class="chat-timeline-inner">'+historyNote+html+'</div>';
       restoreCatsOpenDetails(box, openDetails);
       restoreCatsWorkingScrollPositions(box, workingScrollPositions);
-      if(shouldStickToBottom)scrollCatsMessagesToBottom(box);
+      if(preserveViewport){
+        const delta=options.prepended ? box.scrollHeight-oldScrollHeight : 0;
+        box.scrollTop=Math.max(0, oldScrollTop+delta);
+        catsScrollPinnedToBottom=isCatsMessageScrollNearBottom(box);
+      }else if(shouldStickToBottom){
+        scrollCatsMessagesToBottom(box);
+      }
       updatePetFromCatsMessages(messages);
     }
 
-    async function loadCatsMessages(showErrors=true){
+    async function fetchCatsMessagesPage(offset, limit=CATS_MESSAGES_PAGE_SIZE){
+      return parseCatsResponse(await fetch(API+'/api/cats/messages?topic='+encodeURIComponent(catsState.topicId)+'&limit='+encodeURIComponent(limit)+'&offset='+encodeURIComponent(offset)));
+    }
+
+    async function loadCatsMessages(showErrors=true, options={}){
       if(!catsState.topicId)return;
+      if(catsMessagesLoading)return;
+      catsMessagesLoading=true;
       try{
-        const data=await parseCatsResponse(await fetch(API+'/api/cats/messages?topic='+encodeURIComponent(catsState.topicId)+'&limit=50&offset=0'));
-        renderCatsMessages(data.messages||[]);
+        if(catsMessagesTopicId!==catsState.topicId){
+          catsMessagesTopicId=catsState.topicId;
+          catsMessagesCache=[];
+          catsMessagesHasOlder=true;
+          options=Object.assign({}, options, {reset:true, forceBottom:true});
+        }
+        const data=await fetchCatsMessagesPage(0);
+        const incoming=data.messages||[];
+        if(options.reset || !catsMessagesCache.length){
+          catsMessagesCache=incoming;
+          catsMessagesHasOlder=incoming.length>=CATS_MESSAGES_PAGE_SIZE;
+        }else{
+          catsMessagesCache=mergeCatsMessages(catsMessagesCache,incoming);
+        }
+        renderCatsMessages(catsMessagesCache, {
+          forceBottom: Boolean(options.forceBottom),
+          preserveViewport: Boolean(options.preserveViewport) || (!catsScrollPinnedToBottom && !options.forceBottom),
+        });
         if(showErrors) pulsePetState('success','消息已刷新',1400);
       }catch(e){
         if(showErrors)setCatsAction('加载消息失败：'+e.message,true);
+      }finally{
+        catsMessagesLoading=false;
+      }
+    }
+
+    async function loadOlderCatsMessages(){
+      if(!catsState.topicId || catsMessagesLoadingOlder || !catsMessagesHasOlder || !catsMessagesCache.length)return;
+      catsMessagesLoadingOlder=true;
+      renderCatsMessages(catsMessagesCache, {preserveViewport:true});
+      try{
+        const data=await fetchCatsMessagesPage(catsMessagesCache.length);
+        const incoming=data.messages||[];
+        if(incoming.length<CATS_MESSAGES_PAGE_SIZE)catsMessagesHasOlder=false;
+        if(incoming.length){
+          catsMessagesCache=mergeCatsMessages(incoming,catsMessagesCache);
+        }
+        catsMessagesLoadingOlder=false;
+        renderCatsMessages(catsMessagesCache, {preserveViewport:true, prepended:incoming.length>0});
+      }catch(e){
+        setCatsAction('加载更早消息失败：'+e.message,true);
+        catsMessagesLoadingOlder=false;
+        renderCatsMessages(catsMessagesCache, {preserveViewport:true});
       }
     }
 
@@ -7751,7 +7907,7 @@
         catsScrollPinnedToBottom=true;
         if(failed)setCatsAction(failed+' 个附件发送失败，请重新选择文件或检查 CatsCo 连接。',true);
         else pulsePetState('success', '已发送', 1800);
-        await loadCatsMessages(true);
+        await loadCatsMessages(true, {forceBottom:true});
       }catch(e){
         setCatsAction('发送失败：'+e.message,true);
       }finally{
@@ -7798,7 +7954,7 @@
     if(document.getElementById('page-chat')?.classList.contains('active') && !catsPollTimer) catsPollTimer = setInterval(fetchCatsStatus, 5000);
     setInterval(fetchStatus,5000);setInterval(fetchSkills,30000);setInterval(()=>fetchUpdateStatus(true),5000);
     const catsMessagesBox = document.getElementById('cats-messages');
-    catsMessagesBox.addEventListener('scroll', updateCatsMessageScrollIntent, { passive: true });
+    catsMessagesBox.addEventListener('scroll', handleCatsMessagesScroll, { passive: true });
     const catsMessageInput = document.getElementById('cats-message-input');
     catsMessageInput.addEventListener('keydown',e=>{if(e.key==='Enter'&&!e.shiftKey){e.preventDefault();sendCatsMessage();}});
     catsMessageInput.addEventListener('paste',e=>{

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -4741,6 +4741,7 @@
     let catsMessagesLoading = false;
     let catsMessagesLoadingOlder = false;
     let catsMessagesTopicId = '';
+    let catsMessagesOwnerKey = '';
     let catsConnectCollapsed = true;
     let catsConnectManualOverride = false;
     const CATS_MESSAGES_PAGE_SIZE = 50;
@@ -6723,10 +6724,44 @@
       if(details)details.open=true;
     }
 
+    function catsMessageOwnerKey(state){
+      const uid=String(state?.user?.uid||'').trim();
+      const topic=String(state?.topicId||'').trim();
+      return uid && topic ? uid+'|'+topic : '';
+    }
+
+    function resetCatsMessageCache(ownerKey=''){
+      catsMessagesCache=[];
+      catsMessagesHasOlder=true;
+      catsMessagesLoading=false;
+      catsMessagesLoadingOlder=false;
+      catsMessagesTopicId='';
+      catsMessagesOwnerKey=ownerKey;
+      catsScrollPinnedToBottom=true;
+    }
+
+    function showCatsMessagePlaceholder(text){
+      const box=document.getElementById('cats-messages');
+      if(box)box.innerHTML='<div class="loading">'+escapeHtml(text)+'</div>';
+      catsWorkingActive=false;
+      applyPetBaseline();
+    }
+
     async function fetchCatsStatus(){
       try{
+        const previousOwnerKey=catsMessagesOwnerKey;
         const data=await parseCatsResponse(await fetch(API+'/api/cats/status'));
         catsState=data||{};
+        const nextOwnerKey=catsMessageOwnerKey(catsState);
+        if(!nextOwnerKey){
+          resetCatsMessageCache();
+          showCatsMessagePlaceholder('登录 CatsCo 后查看当前账号消息');
+        }else if(previousOwnerKey && previousOwnerKey!==nextOwnerKey){
+          resetCatsMessageCache(nextOwnerKey);
+          showCatsMessagePlaceholder('正在加载当前账号消息...');
+        }else if(!previousOwnerKey){
+          catsMessagesOwnerKey=nextOwnerKey;
+        }
         renderCatsStatus();
         if((dashboardSettingsSnapshot.fields||[]).length && !shouldDeferModelSourceRender())renderModelSource(dashboardSettingsSnapshot);
         if(catsState.topicId) loadCatsMessages(false);
@@ -6870,9 +6905,7 @@
         await parseCatsResponse(await fetch(API+'/api/cats/auth/logout',{method:'POST'}));
         catsState={};
         catsWorkingActive=false;
-        catsMessagesCache=[];
-        catsMessagesHasOlder=true;
-        catsMessagesTopicId='';
+        resetCatsMessageCache();
         lastCatsMessageSignature='';
         catsScrollPinnedToBottom=true;
         document.getElementById('cats-account').value='';
@@ -7688,6 +7721,16 @@
     }
 
     async function loadCatsMessages(showErrors=true, options={}){
+      const ownerKey=catsMessageOwnerKey(catsState);
+      if(!ownerKey){
+        resetCatsMessageCache();
+        showCatsMessagePlaceholder('登录 CatsCo 后查看当前账号消息');
+        return;
+      }
+      if(catsMessagesOwnerKey!==ownerKey){
+        resetCatsMessageCache(ownerKey);
+        options=Object.assign({}, options, {reset:true, forceBottom:true});
+      }
       if(!catsState.topicId)return;
       if(catsMessagesLoading)return;
       catsMessagesLoading=true;

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -3496,6 +3496,8 @@
 
     .chat-input-bar textarea:focus {
       border: 0;
+      background: transparent;
+      color: #f8fafc;
       box-shadow: none;
     }
 

--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -267,6 +267,7 @@ export class AgentSession {
       this.messages = await this.contextWindowManager.compactIfNeeded(this.messages, {
         sessionKey: this.key,
         reason: '恢复后',
+        signal: this.activeAbortController?.signal,
       });
     }
 
@@ -377,6 +378,7 @@ export class AgentSession {
       this.messages = await this.contextWindowManager.compactIfNeeded(this.messages, {
         sessionKey: this.key,
         reason: '处理前',
+        signal: this.activeAbortController.signal,
       });
 
       try {
@@ -396,6 +398,13 @@ export class AgentSession {
         this.lifecycleManager.saveContext(this.messages);
         return result;
       } catch (err: any) {
+        if (this.isAbortError(err) || this.interruptRequested || this.activeAbortController.signal.aborted) {
+          Logger.info(`[会话 ${this.key}] 当前请求已取消`);
+          this.messages = this.turnContextBuilder.removeTransientMessages(this.messages);
+          this.lifecycleManager.saveContext(this.messages);
+          return { text: '已停止当前请求。', visibleToUser: true };
+        }
+
         // 不删除用户消息，而是添加一个错误回复，保持上下文连贯
         // 这样用户说"继续"时可以接上
         Logger.error(`[会话 ${this.key}] 处理失败: ${err.message}`);
@@ -575,6 +584,12 @@ export class AgentSession {
     if (injectedCount <= AgentSession.MAX_INJECTED_CONTEXT) return;
     const idx = this.messages.findIndex(m => m.__injected);
     if (idx >= 0) this.messages.splice(idx, 1);
+  }
+
+  private isAbortError(error: any): boolean {
+    return error?.name === 'AbortError'
+      || error?.code === 'ERR_CANCELED'
+      || /请求已取消|aborted|aborterror|canceled|cancelled/i.test(String(error?.message || ''));
   }
 
 }

--- a/src/core/context-compressor.ts
+++ b/src/core/context-compressor.ts
@@ -290,6 +290,11 @@ export function parseCompactSummary(raw: string): string {
   return match ? match[1].trim() : raw.trim();
 }
 
+export interface CompactOptions {
+  customInstructions?: string;
+  signal?: AbortSignal;
+}
+
 // ─── ContextCompressor ──────────────────────────────────────
 
 /**
@@ -352,8 +357,11 @@ export class ContextCompressor {
    */
   async compact(
     messages: Message[],
-    customInstructions?: string,
+    optionsOrCustomInstructions?: string | CompactOptions,
   ): Promise<Message[]> {
+    const options: CompactOptions = typeof optionsOrCustomInstructions === 'string'
+      ? { customInstructions: optionsOrCustomInstructions }
+      : (optionsOrCustomInstructions || {});
     const before = estimateMessagesTokens(messages);
 
     const system = messages.filter(m => m.role === 'system');
@@ -370,7 +378,7 @@ export class ContextCompressor {
       const summaryMessages: Message[] = [
         {
           role: 'system',
-          content: buildCompactSystemPrompt(customInstructions),
+          content: buildCompactSystemPrompt(options.customInstructions),
         },
         {
           role: 'user',
@@ -385,7 +393,8 @@ export class ContextCompressor {
         undefined, // 不需要 tools
         {
           onText: (text) => { fullContent += text; },
-        }
+        },
+        { signal: options.signal },
       );
       const rawSummary = fullContent;
 

--- a/src/core/context-window-manager.ts
+++ b/src/core/context-window-manager.ts
@@ -11,6 +11,7 @@ export interface ContextWindowManagerOptions {
 export interface CompactIfNeededOptions {
   sessionKey: string;
   reason?: string;
+  signal?: AbortSignal;
 }
 
 /**
@@ -40,7 +41,7 @@ export class ContextWindowManager {
     Logger.info(`[${options.sessionKey}] ${reason}上下文即将压缩: ${usage.usedTokens}/${usage.maxTokens} tokens (${usage.usagePercent}%)`);
 
     try {
-      const compacted = await this.compressor.compact(durable);
+      const compacted = await this.compressor.compact(durable, { signal: options.signal });
       const result = [...compacted, ...transient];
       Logger.info(`[${options.sessionKey}] 压缩完成，当前消息数: ${result.length}`);
       return result;

--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -213,7 +213,9 @@ export class ConversationRunner {
         const threshold = this.maxPromptTokens * 0.5;
         if (totalTokens > threshold) {
           Logger.info(`上下文使用率 ${usagePercent}%，触发压缩...`);
-          const compacted = await this.compressor.compact(messages);
+          const compacted = await this.compressor.compact(messages, {
+            signal: this.toolExecutionContext?.abortSignal,
+          });
           messages.length = 0;
           messages.push(...compacted);
         }

--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -886,15 +886,18 @@ export class ConversationRunner {
     activeTools: ToolDefinition[],
     callbacks?: RunnerCallbacks,
   ) {
+    const requestOptions = {
+      signal: this.toolExecutionContext?.abortSignal,
+    };
     try {
       if (this.stream) {
         const streamCallbacks: StreamCallbacks = {
           onText: (text) => callbacks?.onText?.(text),
           onRetry: (attempt, maxRetries) => callbacks?.onRetry?.(attempt, maxRetries),
         };
-        return await this.aiService.chatStream(messages, activeTools, streamCallbacks);
+        return await this.aiService.chatStream(messages, activeTools, streamCallbacks, requestOptions);
       }
-      return await this.aiService.chat(messages, activeTools);
+      return await this.aiService.chat(messages, activeTools, requestOptions);
     } catch (error: any) {
       if (!this.isPromptTooLongError(error)) {
         throw error;
@@ -908,9 +911,9 @@ export class ConversationRunner {
         const streamCallbacks: StreamCallbacks = {
           onText: (text) => callbacks?.onText?.(text),
         };
-        return await this.aiService.chatStream(messages, activeTools, streamCallbacks);
+        return await this.aiService.chatStream(messages, activeTools, streamCallbacks, requestOptions);
       }
-      return await this.aiService.chat(messages, activeTools);
+      return await this.aiService.chat(messages, activeTools, requestOptions);
     }
   }
 

--- a/src/core/sub-agent-session.ts
+++ b/src/core/sub-agent-session.ts
@@ -189,6 +189,15 @@ export class SubAgentSession {
       }
     }
 
+    if (this.stopped) {
+      this.status = 'stopped';
+      this.completedAt = Date.now();
+      this.resultSummary = '任务已停止';
+      this.emitTerminalEvent('agent_stopped', `任务已停止：${this.taskDescription}`);
+      Logger.info(`[SubAgent ${this.id}] 已停止: ${this.taskDescription}`);
+      return;
+    }
+
     // 最终失败
     this.status = this.stopped ? 'stopped' : 'failed';
     this.completedAt = Date.now();

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -75,6 +75,22 @@ function p2pTopicId(uid1: string | number, uid2: string | number): string {
   return `p2p_${left}_${right}`;
 }
 
+function httpError(message: string, status: number): Error {
+  const error = new Error(message);
+  (error as any).status = status;
+  return error;
+}
+
+function assertCurrentCatsTopic(state: CatsAuthState, topicId: string): void {
+  const expectedTopic = state.uid && state.botUid ? p2pTopicId(state.uid, state.botUid) : '';
+  if (!expectedTopic) {
+    throw httpError('CatsCo account binding is incomplete', 409);
+  }
+  if (topicId !== expectedTopic) {
+    throw httpError('topic does not belong to the current CatsCo account', 403);
+  }
+}
+
 function hostLabel(value: string): string {
   try {
     return new URL(value).host || value;
@@ -169,62 +185,62 @@ export function getCatsAuthState(overrides: Record<string, unknown> = {}): CatsA
   return {
     token: firstNonEmpty(
       overrides.token,
-      env.CATSCO_USER_TOKEN,
       process.env.CATSCO_USER_TOKEN,
-      env.CATSCOMPANY_USER_TOKEN,
+      env.CATSCO_USER_TOKEN,
       process.env.CATSCOMPANY_USER_TOKEN,
+      env.CATSCOMPANY_USER_TOKEN,
     ),
     uid: firstNonEmpty(
       overrides.uid,
-      env.CATSCO_USER_UID,
       process.env.CATSCO_USER_UID,
-      env.CATSCOMPANY_USER_UID,
+      env.CATSCO_USER_UID,
       process.env.CATSCOMPANY_USER_UID,
+      env.CATSCOMPANY_USER_UID,
     ),
     username: firstNonEmpty(
-      env.CATSCO_USER_NAME,
       process.env.CATSCO_USER_NAME,
-      env.CATSCOMPANY_USER_NAME,
+      env.CATSCO_USER_NAME,
       process.env.CATSCOMPANY_USER_NAME,
+      env.CATSCOMPANY_USER_NAME,
     ),
     displayName: firstNonEmpty(
-      env.CATSCO_USER_DISPLAY_NAME,
       process.env.CATSCO_USER_DISPLAY_NAME,
-      env.CATSCOMPANY_USER_DISPLAY_NAME,
+      env.CATSCO_USER_DISPLAY_NAME,
       process.env.CATSCOMPANY_USER_DISPLAY_NAME,
+      env.CATSCOMPANY_USER_DISPLAY_NAME,
     ),
     httpBaseUrl: normalizeBaseUrl(
       firstNonEmpty(
         overrides.httpBaseUrl,
-        env.CATSCO_HTTP_BASE_URL,
         process.env.CATSCO_HTTP_BASE_URL,
-        env.CATSCOMPANY_HTTP_BASE_URL,
+        env.CATSCO_HTTP_BASE_URL,
         process.env.CATSCOMPANY_HTTP_BASE_URL,
+        env.CATSCOMPANY_HTTP_BASE_URL,
       ),
       DEFAULT_CATSCO_HTTP_BASE_URL,
     ),
     serverUrl: normalizeBaseUrl(
       firstNonEmpty(
         overrides.serverUrl,
-        env.CATSCO_SERVER_URL,
         process.env.CATSCO_SERVER_URL,
-        env.CATSCOMPANY_SERVER_URL,
+        env.CATSCO_SERVER_URL,
         process.env.CATSCOMPANY_SERVER_URL,
+        env.CATSCOMPANY_SERVER_URL,
       ),
       DEFAULT_CATSCO_WS_URL,
     ),
     botUid: firstNonEmpty(
       overrides.botUid,
-      env.CATSCO_BOT_UID,
       process.env.CATSCO_BOT_UID,
-      env.CATSCOMPANY_BOT_UID,
+      env.CATSCO_BOT_UID,
       process.env.CATSCOMPANY_BOT_UID,
+      env.CATSCOMPANY_BOT_UID,
     ),
     apiKey: firstNonEmpty(
-      env.CATSCO_API_KEY,
       process.env.CATSCO_API_KEY,
-      env.CATSCOMPANY_API_KEY,
+      env.CATSCO_API_KEY,
       process.env.CATSCOMPANY_API_KEY,
+      env.CATSCOMPANY_API_KEY,
     ),
   };
 }
@@ -1096,10 +1112,7 @@ export function createApiRouter(serviceManager: ServiceManager, updateController
       if (!state.token) return res.status(401).json({ error: 'CatsCo user token is missing' });
       const topic = String(req.query.topic || '').trim();
       if (!topic) return res.status(400).json({ error: 'topic required' });
-      const expectedTopic = state.uid && state.botUid ? p2pTopicId(state.uid, state.botUid) : '';
-      if (expectedTopic && topic !== expectedTopic) {
-        return res.status(403).json({ error: 'topic does not belong to the current CatsCo account' });
-      }
+      assertCurrentCatsTopic(state, topic);
       const limit = String(req.query.limit || '50');
       const offset = String(req.query.offset || '0');
       const data = await catsRequest('GET', state.httpBaseUrl, `/api/messages?topic_id=${encodeURIComponent(topic)}&limit=${encodeURIComponent(limit)}&offset=${encodeURIComponent(offset)}&latest=1`, undefined, state.token);
@@ -1116,6 +1129,7 @@ export function createApiRouter(serviceManager: ServiceManager, updateController
       const topicId = String(req.body?.topic_id || '').trim();
       const content = String(req.body?.content || '').trim();
       if (!topicId || !content) return res.status(400).json({ error: 'topic_id and content are required' });
+      assertCurrentCatsTopic(state, topicId);
       const data = await catsRequest('POST', state.httpBaseUrl, '/api/messages/send', {
         topic_id: topicId,
         type: 'text',
@@ -1135,6 +1149,7 @@ export function createApiRouter(serviceManager: ServiceManager, updateController
       const topicId = String(req.body?.topic_id || '').trim();
       const fileToken = String(req.body?.file_token || '').trim();
       if (!topicId || !fileToken) return res.status(400).json({ error: 'topic_id and file_token are required' });
+      assertCurrentCatsTopic(state, topicId);
 
       const grant = consumeLocalFileGrant(fileToken);
       const stat = validateLocalFileGrant(grant);

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -1096,6 +1096,10 @@ export function createApiRouter(serviceManager: ServiceManager, updateController
       if (!state.token) return res.status(401).json({ error: 'CatsCo user token is missing' });
       const topic = String(req.query.topic || '').trim();
       if (!topic) return res.status(400).json({ error: 'topic required' });
+      const expectedTopic = state.uid && state.botUid ? p2pTopicId(state.uid, state.botUid) : '';
+      if (expectedTopic && topic !== expectedTopic) {
+        return res.status(403).json({ error: 'topic does not belong to the current CatsCo account' });
+      }
       const limit = String(req.query.limit || '50');
       const offset = String(req.query.offset || '0');
       const data = await catsRequest('GET', state.httpBaseUrl, `/api/messages?topic_id=${encodeURIComponent(topic)}&limit=${encodeURIComponent(limit)}&offset=${encodeURIComponent(offset)}&latest=1`, undefined, state.token);

--- a/src/providers/anthropic-provider.ts
+++ b/src/providers/anthropic-provider.ts
@@ -1,7 +1,7 @@
 import Anthropic from '@anthropic-ai/sdk';
 import { Message, ChatConfig, ChatResponse, ContentBlock } from '../types';
 import { ToolDefinition } from '../types/tool';
-import { AIProvider, StreamCallbacks } from './provider';
+import { AIProvider, AIRequestOptions, StreamCallbacks } from './provider';
 import { ContextDebugLogger } from '../utils/context-debug-logger';
 
 /**
@@ -229,7 +229,7 @@ export class AnthropicProvider implements AIProvider {
   /**
    * 普通调用
    */
-  async chat(messages: Message[], tools?: ToolDefinition[]): Promise<ChatResponse> {
+  async chat(messages: Message[], tools?: ToolDefinition[], options?: AIRequestOptions): Promise<ChatResponse> {
     const { system, messages: transformed } = this.transformMessages(messages);
 
     const params: Anthropic.MessageCreateParamsNonStreaming = {
@@ -248,7 +248,7 @@ export class AnthropicProvider implements AIProvider {
       params
     });
 
-    const response = await this.client.messages.create(params);
+    const response = await this.client.messages.create(params, { signal: options?.signal } as any);
 
     // [CONTEXT_DEBUG] SDK 调用后：记录完整的响应
     ContextDebugLogger.dumpSdkBoundary('after', undefined, { response });
@@ -259,7 +259,12 @@ export class AnthropicProvider implements AIProvider {
   /**
    * 流式调用
    */
-  async chatStream(messages: Message[], tools?: ToolDefinition[], callbacks?: StreamCallbacks): Promise<ChatResponse> {
+  async chatStream(
+    messages: Message[],
+    tools?: ToolDefinition[],
+    callbacks?: StreamCallbacks,
+    options?: AIRequestOptions,
+  ): Promise<ChatResponse> {
     const { system, messages: transformed } = this.transformMessages(messages);
 
     const params: Anthropic.MessageCreateParamsStreaming = {
@@ -280,7 +285,7 @@ export class AnthropicProvider implements AIProvider {
         params
       });
 
-      const stream = this.client.messages.stream(params);
+      const stream = this.client.messages.stream(params, { signal: options?.signal } as any);
 
       // 逐 token 回调文本
       stream.on('text', (text) => {

--- a/src/providers/openai-provider.ts
+++ b/src/providers/openai-provider.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { Message, ChatConfig, ChatResponse, ContentBlock } from '../types';
 import { ToolDefinition } from '../types/tool';
-import { AIProvider, StreamCallbacks } from './provider';
+import { AIProvider, AIRequestOptions, StreamCallbacks } from './provider';
 import { ContextDebugLogger } from '../utils/context-debug-logger';
 import { normalizeOpenAIChatCompletionsUrl } from './openai-url';
 
@@ -107,13 +107,16 @@ export class OpenAIProvider implements AIProvider {
   /**
    * 普通调用
    */
-  async chat(messages: Message[], tools?: ToolDefinition[]): Promise<ChatResponse> {
+  async chat(messages: Message[], tools?: ToolDefinition[], options?: AIRequestOptions): Promise<ChatResponse> {
     const body = this.buildRequestBody(messages, tools, false);
     ContextDebugLogger.dumpSdkBoundary('before', undefined, {
       apiUrl: this.chatCompletionsUrl,
       body,
     });
-    const response = await axios.post(this.chatCompletionsUrl, body, { headers: this.headers });
+    const response = await axios.post(this.chatCompletionsUrl, body, {
+      headers: this.headers,
+      signal: options?.signal,
+    });
     const message = response.data.choices[0].message;
     const usage = response.data.usage;
 
@@ -135,7 +138,12 @@ export class OpenAIProvider implements AIProvider {
   /**
    * 流式调用（SSE）
    */
-  async chatStream(messages: Message[], tools?: ToolDefinition[], callbacks?: StreamCallbacks): Promise<ChatResponse> {
+  async chatStream(
+    messages: Message[],
+    tools?: ToolDefinition[],
+    callbacks?: StreamCallbacks,
+    options?: AIRequestOptions,
+  ): Promise<ChatResponse> {
     const body = this.buildRequestBody(messages, tools, true);
 
     ContextDebugLogger.dumpSdkBoundary('before', undefined, {
@@ -146,6 +154,7 @@ export class OpenAIProvider implements AIProvider {
     const response = await axios.post(this.chatCompletionsUrl, body, {
       headers: this.headers,
       responseType: 'stream',
+      signal: options?.signal,
     });
 
     return new Promise<ChatResponse>((resolve, reject) => {
@@ -155,6 +164,14 @@ export class OpenAIProvider implements AIProvider {
       let streamUsage: ChatResponse['usage'] = undefined;
 
       const stream = response.data;
+      const onAbort = () => {
+        stream.destroy(createAbortError());
+      };
+      if (options?.signal?.aborted) {
+        onAbort();
+      } else {
+        options?.signal?.addEventListener('abort', onAbort, { once: true });
+      }
 
       stream.on('data', (chunk: Buffer) => {
         buffer += chunk.toString();
@@ -213,6 +230,7 @@ export class OpenAIProvider implements AIProvider {
       });
 
       stream.on('end', () => {
+        options?.signal?.removeEventListener('abort', onAbort);
         const toolCalls = toolCallsMap.size > 0
           ? Array.from(toolCallsMap.values())
           : undefined;
@@ -232,9 +250,16 @@ export class OpenAIProvider implements AIProvider {
       });
 
       stream.on('error', (err: Error) => {
+        options?.signal?.removeEventListener('abort', onAbort);
         callbacks?.onError?.(err);
         reject(err);
       });
     });
   }
+}
+
+function createAbortError(): Error {
+  const err = new Error('请求已取消');
+  err.name = 'AbortError';
+  return err;
 }

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -15,13 +15,17 @@ export interface StreamCallbacks {
   onRetry?: (attempt: number, maxRetries: number) => void;
 }
 
+export interface AIRequestOptions {
+  signal?: AbortSignal;
+}
+
 /**
  * AI Provider 统一接口
  * 抽象不同 AI 服务商的调用差异
  */
 export interface AIProvider {
   /** 普通（非流式）调用 */
-  chat(messages: Message[], tools?: ToolDefinition[]): Promise<ChatResponse>;
+  chat(messages: Message[], tools?: ToolDefinition[], options?: AIRequestOptions): Promise<ChatResponse>;
   /** 流式调用 */
-  chatStream(messages: Message[], tools?: ToolDefinition[], callbacks?: StreamCallbacks): Promise<ChatResponse>;
+  chatStream(messages: Message[], tools?: ToolDefinition[], callbacks?: StreamCallbacks, options?: AIRequestOptions): Promise<ChatResponse>;
 }

--- a/src/utils/ai-service.ts
+++ b/src/utils/ai-service.ts
@@ -1,7 +1,7 @@
 import { Message, ChatConfig, ChatResponse } from '../types';
 import { ConfigManager } from './config';
 import { ToolDefinition } from '../types/tool';
-import { AIProvider, StreamCallbacks } from '../providers/provider';
+import { AIProvider, AIRequestOptions, StreamCallbacks } from '../providers/provider';
 import { AnthropicProvider } from '../providers/anthropic-provider';
 import { OpenAIProvider } from '../providers/openai-provider';
 import { Logger } from './logger';
@@ -68,13 +68,13 @@ export class AIService {
   /**
    * 普通调用（非流式），带自动重试
    */
-  async chat(messages: Message[], tools?: ToolDefinition[]): Promise<ChatResponse> {
+  async chat(messages: Message[], tools?: ToolDefinition[], options: AIRequestOptions = {}): Promise<ChatResponse> {
     if (!this.config.apiKey) {
       throw new Error('API密钥未配置。请先运行: catsco config');
     }
 
     try {
-      return await this.withRetry(() => this.provider.chat(messages, tools));
+      return await this.withRetry(() => this.provider.chat(messages, tools, options), undefined, options.signal);
     } catch (error: any) {
       throw this.wrapError(error);
     }
@@ -85,7 +85,12 @@ export class AIService {
    * 默认不重试，避免部分 token 已输出后出现重复文本。
    * 如需强制开启重试，可设置 GAUZ_STREAM_RETRY=true（需自行保证幂等）。
    */
-  async chatStream(messages: Message[], tools?: ToolDefinition[], callbacks?: StreamCallbacks): Promise<ChatResponse> {
+  async chatStream(
+    messages: Message[],
+    tools?: ToolDefinition[],
+    callbacks?: StreamCallbacks,
+    options: AIRequestOptions = {},
+  ): Promise<ChatResponse> {
     if (!this.config.apiKey) {
       throw new Error('API密钥未配置。请先运行: catsco config');
     }
@@ -96,11 +101,13 @@ export class AIService {
     try {
       if (allowStreamRetry) {
         return await this.withRetry(
-          () => this.provider.chatStream(messages, tools, providerCallbacks),
-          callbacks
+          () => this.provider.chatStream(messages, tools, providerCallbacks, options),
+          callbacks,
+          options.signal,
         );
       }
-      return await this.provider.chatStream(messages, tools, providerCallbacks);
+      this.throwIfAborted(options.signal);
+      return await this.provider.chatStream(messages, tools, providerCallbacks, options);
     } catch (error: any) {
       const wrapped = this.wrapError(error);
       callbacks?.onError?.(wrapped);
@@ -123,6 +130,10 @@ export class AIService {
    * 统一错误处理
    */
   private wrapError(error: any): Error {
+    if (this.isAbortError(error)) {
+      return this.createAbortError();
+    }
+
     const provider = this.config.provider;
     const model = this.config.model;
 
@@ -148,6 +159,10 @@ export class AIService {
    * 判断错误是否可重试
    */
   private isRetryable(error: any): boolean {
+    if (this.isAbortError(error)) {
+      return false;
+    }
+
     // HTTP 状态码可重试
     const status = this.extractStatus(error);
     if (status && RETRYABLE_STATUS_CODES.has(status)) {
@@ -199,14 +214,19 @@ export class AIService {
   /**
    * 带指数退避的重试包装器
    */
-  private async withRetry<T>(fn: () => Promise<T>, callbacks?: StreamCallbacks): Promise<T> {
+  private async withRetry<T>(fn: () => Promise<T>, callbacks?: StreamCallbacks, signal?: AbortSignal): Promise<T> {
     let lastError: any;
 
     for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
       try {
+        this.throwIfAborted(signal);
         return await fn();
       } catch (error: any) {
         lastError = error;
+
+        if (this.isAbortError(error) || signal?.aborted) {
+          throw this.createAbortError();
+        }
 
         if (attempt >= MAX_RETRIES || !this.isRetryable(error)) {
           throw error;
@@ -229,10 +249,46 @@ export class AIService {
           + `[${this.config.provider}/${this.config.model || 'default'}]`
         );
 
-        await new Promise(resolve => setTimeout(resolve, delay));
+        await this.sleepWithAbort(delay, signal);
       }
     }
 
     throw lastError;
+  }
+
+  private throwIfAborted(signal?: AbortSignal): void {
+    if (signal?.aborted) {
+      throw this.createAbortError();
+    }
+  }
+
+  private sleepWithAbort(ms: number, signal?: AbortSignal): Promise<void> {
+    if (!signal) {
+      return new Promise(resolve => setTimeout(resolve, ms));
+    }
+    this.throwIfAborted(signal);
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        signal.removeEventListener('abort', onAbort);
+        resolve();
+      }, ms);
+      const onAbort = () => {
+        clearTimeout(timer);
+        reject(this.createAbortError());
+      };
+      signal.addEventListener('abort', onAbort, { once: true });
+    });
+  }
+
+  private isAbortError(error: any): boolean {
+    return error?.name === 'AbortError'
+      || error?.code === 'ERR_CANCELED'
+      || /aborted|aborterror|canceled|cancelled/i.test(String(error?.message || ''));
+  }
+
+  private createAbortError(): Error {
+    const err = new Error('请求已取消');
+    err.name = 'AbortError';
+    return err;
   }
 }

--- a/tests/agent-session-abort-signal.test.ts
+++ b/tests/agent-session-abort-signal.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { AgentSession, ERROR_MESSAGE } from '../src/core/agent-session';
+import { AgentSession } from '../src/core/agent-session';
 
 test('AgentSession requestInterrupt aborts an in-flight model request', async () => {
   let observedSignal: AbortSignal | undefined;
@@ -24,7 +24,7 @@ test('AgentSession requestInterrupt aborts an in-flight model request', async ()
   const result = await runPromise;
 
   assert.equal(observedSignal?.aborted, true);
-  assert.equal(result.text, ERROR_MESSAGE);
+  assert.equal(result.text, '已停止当前请求。');
 });
 
 function buildMockServices(overrides: any = {}): any {

--- a/tests/agent-session-abort-signal.test.ts
+++ b/tests/agent-session-abort-signal.test.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { AgentSession, ERROR_MESSAGE } from '../src/core/agent-session';
+
+test('AgentSession requestInterrupt aborts an in-flight model request', async () => {
+  let observedSignal: AbortSignal | undefined;
+
+  const session = new AgentSession('user:abort-main-model', buildMockServices({
+    aiService: {
+      async chatStream(_messages: any[], _tools: any[], _callbacks: any, options: any = {}) {
+        observedSignal = options.signal;
+        return await new Promise((_resolve, reject) => {
+          options.signal?.addEventListener('abort', () => reject(new Error('aborted by test')), { once: true });
+        });
+      },
+    },
+  }), 'feishu');
+  session.setSystemPromptProvider(() => 'system prompt');
+
+  const runPromise = session.handleMessage('开始一个会被停止的任务');
+  await waitFor(() => Boolean(observedSignal));
+
+  session.requestInterrupt();
+  const result = await runPromise;
+
+  assert.equal(observedSignal?.aborted, true);
+  assert.equal(result.text, ERROR_MESSAGE);
+});
+
+function buildMockServices(overrides: any = {}): any {
+  return {
+    aiService: overrides.aiService ?? {},
+    toolManager: overrides.toolManager ?? {
+      getToolDefinitions() { return []; },
+      executeTool() { throw new Error('not expected'); },
+      getWorkspaceRoot() { return process.cwd(); },
+    },
+    skillManager: {
+      getSkill() { return undefined; },
+      getUserInvocableSkills() { return []; },
+      getAutoInvocableSkills() { return []; },
+      findAutoInvocableSkillByText() { return undefined; },
+      loadSkills: async () => {},
+    },
+  };
+}
+
+async function waitFor(predicate: () => boolean, maxAttempts = 50): Promise<void> {
+  for (let i = 0; i < maxAttempts; i++) {
+    if (predicate()) return;
+    await new Promise(resolve => setTimeout(resolve, 10));
+  }
+  assert.fail('condition was not met in time');
+}

--- a/tests/ai-service.test.ts
+++ b/tests/ai-service.test.ts
@@ -74,6 +74,47 @@ test('AIService does not surface transient stream errors when retry succeeds', a
   assert.deepStrictEqual(chunks, ['ok']);
 });
 
+test('AIService passes AbortSignal to chatStream provider calls', async () => {
+  const service = createTestService();
+  const controller = new AbortController();
+  let capturedSignal: AbortSignal | undefined;
+  const finalResponse: ChatResponse = { content: 'ok' };
+  (service as any).provider = {
+    chat: async () => ({ content: null }),
+    chatStream: async (_messages: unknown, _tools: unknown, _callbacks?: StreamCallbacks, options?: { signal?: AbortSignal }) => {
+      capturedSignal = options?.signal;
+      return finalResponse;
+    },
+  };
+
+  const result = await service.chatStream([], undefined, undefined, { signal: controller.signal });
+  assert.equal(result, finalResponse);
+  assert.equal(capturedSignal, controller.signal);
+});
+
+test('AIService cancels before provider call when signal is already aborted', async () => {
+  const service = createTestService();
+  const controller = new AbortController();
+  let called = false;
+  (service as any).provider = {
+    chat: async () => {
+      called = true;
+      return { content: null };
+    },
+    chatStream: async () => {
+      called = true;
+      return { content: null };
+    },
+  };
+
+  controller.abort();
+  await assert.rejects(
+    () => service.chat([], undefined, { signal: controller.signal }),
+    /请求已取消/,
+  );
+  assert.equal(called, false);
+});
+
 function createTestService(): AIService {
   return new AIService({
     provider: 'openai',

--- a/tests/conversation-runner-abort-signal.test.ts
+++ b/tests/conversation-runner-abort-signal.test.ts
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { ConversationRunner } from '../src/core/conversation-runner';
+import { Message } from '../src/types';
+import { ToolDefinition, ToolExecutor, ToolCall, ToolResult } from '../src/types/tool';
+
+class EmptyToolExecutor implements ToolExecutor {
+  getToolDefinitions(): ToolDefinition[] {
+    return [];
+  }
+
+  async executeTool(toolCall: ToolCall): Promise<ToolResult> {
+    throw new Error(`unexpected tool call: ${toolCall.function.name}`);
+  }
+}
+
+test('ConversationRunner passes AbortSignal to streamed model requests', async () => {
+  const controller = new AbortController();
+  let observedSignal: AbortSignal | undefined;
+
+  const aiService = {
+    async chatStream(_messages: Message[], _tools: ToolDefinition[], _callbacks: any, options: any = {}) {
+      observedSignal = options.signal;
+      return await new Promise((_resolve, reject) => {
+        options.signal?.addEventListener('abort', () => reject(new Error('aborted by test')), { once: true });
+      });
+    },
+  };
+
+  const runner = new ConversationRunner(aiService as any, new EmptyToolExecutor(), {
+    enableCompression: false,
+    toolExecutionContext: { abortSignal: controller.signal },
+  });
+
+  const runPromise = runner.run([{ role: 'user', content: 'wait' }]);
+  await waitFor(() => observedSignal === controller.signal);
+  controller.abort();
+
+  await assert.rejects(runPromise, /aborted by test/);
+  assert.equal(observedSignal?.aborted, true);
+});
+
+test('ConversationRunner reuses AbortSignal after prompt-too-long trim retry', async () => {
+  const controller = new AbortController();
+  const observedSignals: Array<AbortSignal | undefined> = [];
+  let calls = 0;
+
+  const aiService = {
+    async chat(_messages: Message[], _tools: ToolDefinition[], options: any = {}) {
+      observedSignals.push(options.signal);
+      calls++;
+      if (calls === 1) {
+        throw new Error('maximum context length exceeded');
+      }
+      return {
+        content: 'done',
+        toolCalls: [],
+        usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+      };
+    },
+  };
+
+  const runner = new ConversationRunner(aiService as any, new EmptyToolExecutor(), {
+    stream: false,
+    enableCompression: false,
+    toolExecutionContext: { abortSignal: controller.signal },
+  });
+
+  const result = await runner.run([{ role: 'user', content: 'x'.repeat(2000) }]);
+
+  assert.equal(result.response, 'done');
+  assert.equal(calls, 2);
+  assert.deepEqual(observedSignals, [controller.signal, controller.signal]);
+});
+
+async function waitFor(predicate: () => boolean, maxAttempts = 50): Promise<void> {
+  for (let i = 0; i < maxAttempts; i++) {
+    if (predicate()) return;
+    await new Promise(resolve => setTimeout(resolve, 10));
+  }
+  assert.fail('condition was not met in time');
+}

--- a/tests/dashboard-catsco-attachments-api.test.ts
+++ b/tests/dashboard-catsco-attachments-api.test.ts
@@ -82,6 +82,8 @@ describe('dashboard CatsCo attachment API', () => {
 
     process.env.CATSCO_HTTP_BASE_URL = serverUrl(catsServer);
     process.env.CATSCO_USER_TOKEN = 'user-token';
+    process.env.CATSCO_USER_UID = '1';
+    process.env.CATSCO_BOT_UID = '2';
     process.env.CATSCO_API_KEY = 'agent-key';
 
     const dashboardApp = express();
@@ -163,6 +165,59 @@ describe('dashboard CatsCo attachment API', () => {
     assert.equal(data.error, 'topic does not belong to the current CatsCo account');
   });
 
+  test('rejects text sends for a topic outside the current account', async () => {
+    process.env.CATSCO_USER_TOKEN = 'user-token';
+    process.env.CATSCO_USER_UID = '38';
+    process.env.CATSCO_BOT_UID = '110';
+
+    const dashboardApp = express();
+    dashboardApp.use(express.json());
+    dashboardApp.use('/api', createApiRouter({ getAll: () => [] } as any));
+    dashboardServer = await listen(dashboardApp);
+
+    const response = await fetch(`${serverUrl(dashboardServer)}/api/cats/messages/send`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        topic_id: 'p2p_1_110',
+        content: 'hello',
+      }),
+    });
+    const data = await response.json() as any;
+
+    assert.equal(response.status, 403);
+    assert.equal(data.error, 'topic does not belong to the current CatsCo account');
+  });
+
+  test('rejects file sends for a topic outside the current account before consuming file grants', async () => {
+    process.env.CATSCO_USER_TOKEN = 'user-token';
+    process.env.CATSCO_USER_UID = '38';
+    process.env.CATSCO_BOT_UID = '110';
+
+    const dashboardApp = express();
+    dashboardApp.use(express.json());
+    dashboardApp.use('/api', createApiRouter({ getAll: () => [] } as any));
+    dashboardServer = await listen(dashboardApp);
+
+    const filePath = path.join(testRoot, 'report.pdf');
+    fs.writeFileSync(filePath, 'hello world');
+    const grant = createLocalFileGrant(filePath);
+
+    const response = await fetch(`${serverUrl(dashboardServer)}/api/cats/messages/send-file`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        topic_id: 'p2p_1_110',
+        file_token: grant.token,
+      }),
+    });
+    const data = await response.json() as any;
+
+    assert.equal(response.status, 403);
+    assert.equal(data.error, 'topic does not belong to the current CatsCo account');
+    assert.equal(consumeLocalFileGrant(grant.token).name, 'report.pdf');
+  });
+
   test('local file grants are one-time tokens', () => {
     const filePath = path.join(testRoot, 'one-time.txt');
     fs.writeFileSync(filePath, 'hello world');
@@ -218,6 +273,8 @@ describe('dashboard CatsCo attachment API', () => {
 
     process.env.CATSCO_HTTP_BASE_URL = serverUrl(catsServer);
     process.env.CATSCO_USER_TOKEN = 'user-token';
+    process.env.CATSCO_USER_UID = '1';
+    process.env.CATSCO_BOT_UID = '2';
     process.env.CATSCO_API_KEY = 'agent-key';
 
     const dashboardApp = express();
@@ -262,6 +319,8 @@ describe('dashboard CatsCo attachment API', () => {
 
     process.env.CATSCO_HTTP_BASE_URL = serverUrl(catsServer);
     process.env.CATSCO_USER_TOKEN = 'user-token';
+    process.env.CATSCO_USER_UID = '1';
+    process.env.CATSCO_BOT_UID = '2';
     process.env.CATSCO_API_KEY = 'agent-key';
 
     const dashboardApp = express();

--- a/tests/dashboard-catsco-attachments-api.test.ts
+++ b/tests/dashboard-catsco-attachments-api.test.ts
@@ -32,7 +32,7 @@ describe('dashboard CatsCo attachment API', () => {
   let originalCwd: string;
   let dashboardServer: Server | undefined;
   let catsServer: Server | undefined;
-  const envKeys = ['CATSCO_HTTP_BASE_URL', 'CATSCO_USER_TOKEN', 'CATSCO_API_KEY'];
+  const envKeys = ['CATSCO_HTTP_BASE_URL', 'CATSCO_USER_TOKEN', 'CATSCO_USER_UID', 'CATSCO_BOT_UID', 'CATSCO_API_KEY'];
   const originalEnv: Record<string, string | undefined> = {};
 
   beforeEach(() => {
@@ -144,6 +144,23 @@ describe('dashboard CatsCo attachment API', () => {
 
     assert.equal(response.status, 400);
     assert.equal(data.error, 'topic_id and file_token are required');
+  });
+
+  test('rejects message history for a topic outside the current account', async () => {
+    process.env.CATSCO_USER_TOKEN = 'user-token';
+    process.env.CATSCO_USER_UID = '38';
+    process.env.CATSCO_BOT_UID = '110';
+
+    const dashboardApp = express();
+    dashboardApp.use(express.json());
+    dashboardApp.use('/api', createApiRouter({ getAll: () => [] } as any));
+    dashboardServer = await listen(dashboardApp);
+
+    const response = await fetch(`${serverUrl(dashboardServer)}/api/cats/messages?topic=p2p_1_110&limit=1&offset=0`);
+    const data = await response.json() as any;
+
+    assert.equal(response.status, 403);
+    assert.equal(data.error, 'topic does not belong to the current CatsCo account');
   });
 
   test('local file grants are one-time tokens', () => {

--- a/tests/dashboard-productization-html.test.ts
+++ b/tests/dashboard-productization-html.test.ts
@@ -124,11 +124,12 @@ test('CatsCo Chat preserves scroll position while reading history', () => {
   assert.match(dashboardHtml, /function updateCatsMessageScrollIntent\(\)/);
   assert.match(dashboardHtml, /function handleCatsMessagesScroll\(\)/);
   assert.match(dashboardHtml, /function catsMessageOwnerKey\(state\)/);
+  assert.match(dashboardHtml, /function isCatsMessageRequestCurrent\(ownerKey, topicId\)/);
   assert.match(dashboardHtml, /function resetCatsMessageCache\(ownerKey=''\)/);
   assert.match(dashboardHtml, /登录 CatsCo 后查看当前账号消息/);
   assert.match(dashboardHtml, /function scrollCatsMessagesToBottom\(box\)/);
   assert.match(dashboardHtml, /function loadOlderCatsMessages\(\)/);
-  assert.match(dashboardHtml, /fetchCatsMessagesPage\(catsMessagesCache\.length\)/);
+  assert.match(dashboardHtml, /fetchCatsMessagesPage\(catsMessagesCache\.length, CATS_MESSAGES_PAGE_SIZE, requestTopicId\)/);
   assert.match(dashboardHtml, /addEventListener\('scroll', handleCatsMessagesScroll, \{ passive: true \}\)/);
 
   const renderBlock = dashboardHtml.match(/function renderCatsMessages\(messages, options=\{\}\)\{[\s\S]*?async function fetchCatsMessagesPage/)?.[0] || '';

--- a/tests/dashboard-productization-html.test.ts
+++ b/tests/dashboard-productization-html.test.ts
@@ -116,12 +116,16 @@ test('custom model save refreshes readiness before Chat remains locked', () => {
 test('CatsCo Chat preserves scroll position while reading history', () => {
   assert.match(dashboardHtml, /let catsScrollPinnedToBottom = true/);
   assert.match(dashboardHtml, /let catsMessagesCache = \[\]/);
+  assert.match(dashboardHtml, /let catsMessagesOwnerKey = ''/);
   assert.match(dashboardHtml, /const CATS_MESSAGES_PAGE_SIZE = 50/);
   assert.match(dashboardHtml, /const CATS_SCROLL_BOTTOM_THRESHOLD = 80/);
   assert.match(dashboardHtml, /const CATS_SCROLL_TOP_THRESHOLD = 96/);
   assert.match(dashboardHtml, /function isCatsMessageScrollNearBottom\(box\)/);
   assert.match(dashboardHtml, /function updateCatsMessageScrollIntent\(\)/);
   assert.match(dashboardHtml, /function handleCatsMessagesScroll\(\)/);
+  assert.match(dashboardHtml, /function catsMessageOwnerKey\(state\)/);
+  assert.match(dashboardHtml, /function resetCatsMessageCache\(ownerKey=''\)/);
+  assert.match(dashboardHtml, /登录 CatsCo 后查看当前账号消息/);
   assert.match(dashboardHtml, /function scrollCatsMessagesToBottom\(box\)/);
   assert.match(dashboardHtml, /function loadOlderCatsMessages\(\)/);
   assert.match(dashboardHtml, /fetchCatsMessagesPage\(catsMessagesCache\.length\)/);

--- a/tests/dashboard-productization-html.test.ts
+++ b/tests/dashboard-productization-html.test.ts
@@ -172,6 +172,13 @@ test('CatsCo Chat composer supports local attachments', () => {
   assert.match(dashboardHtml, /\/api\/cats\/messages\/send-file/);
 });
 
+test('CatsCo Chat composer keeps focused text readable on dark input surface', () => {
+  assert.match(
+    dashboardHtml,
+    /\.chat-input-bar textarea:focus \{[\s\S]*?background: transparent;[\s\S]*?color: #f8fafc;[\s\S]*?box-shadow: none;[\s\S]*?\}/,
+  );
+});
+
 test('CatsCo Chat preserves fallback tool metadata for WORKING rendering', () => {
   const fallbackBlock = dashboardHtml.match(/function catsContentBlocksFromMessage\(message\)\{[\s\S]*?function groupCatsWorkingBlocks/)?.[0] || '';
   assert.match(fallbackBlock, /type:'tool_use'[\s\S]*metadata:message\.metadata\|\|\{\}/);

--- a/tests/dashboard-productization-html.test.ts
+++ b/tests/dashboard-productization-html.test.ts
@@ -115,16 +115,36 @@ test('custom model save refreshes readiness before Chat remains locked', () => {
 
 test('CatsCo Chat preserves scroll position while reading history', () => {
   assert.match(dashboardHtml, /let catsScrollPinnedToBottom = true/);
+  assert.match(dashboardHtml, /let catsMessagesCache = \[\]/);
+  assert.match(dashboardHtml, /const CATS_MESSAGES_PAGE_SIZE = 50/);
   assert.match(dashboardHtml, /const CATS_SCROLL_BOTTOM_THRESHOLD = 80/);
+  assert.match(dashboardHtml, /const CATS_SCROLL_TOP_THRESHOLD = 96/);
   assert.match(dashboardHtml, /function isCatsMessageScrollNearBottom\(box\)/);
   assert.match(dashboardHtml, /function updateCatsMessageScrollIntent\(\)/);
+  assert.match(dashboardHtml, /function handleCatsMessagesScroll\(\)/);
   assert.match(dashboardHtml, /function scrollCatsMessagesToBottom\(box\)/);
-  assert.match(dashboardHtml, /addEventListener\('scroll', updateCatsMessageScrollIntent, \{ passive: true \}\)/);
+  assert.match(dashboardHtml, /function loadOlderCatsMessages\(\)/);
+  assert.match(dashboardHtml, /fetchCatsMessagesPage\(catsMessagesCache\.length\)/);
+  assert.match(dashboardHtml, /addEventListener\('scroll', handleCatsMessagesScroll, \{ passive: true \}\)/);
 
-  const renderBlock = dashboardHtml.match(/function renderCatsMessages\(messages\)\{[\s\S]*?async function loadCatsMessages/)?.[0] || '';
+  const renderBlock = dashboardHtml.match(/function renderCatsMessages\(messages, options=\{\}\)\{[\s\S]*?async function fetchCatsMessagesPage/)?.[0] || '';
   assert.match(renderBlock, /const shouldStickToBottom=/);
-  assert.match(renderBlock, /if\(shouldStickToBottom\)scrollCatsMessagesToBottom\(box\)/);
+  assert.match(renderBlock, /const preserveViewport=Boolean\(options\.preserveViewport\)/);
+  assert.match(renderBlock, /box\.scrollTop=Math\.max\(0, oldScrollTop\+delta\)/);
+  assert.match(renderBlock, /else if\(shouldStickToBottom\)\{\s*scrollCatsMessagesToBottom\(box\)/);
   assert.doesNotMatch(renderBlock, /box\.scrollTop=box\.scrollHeight;\s*updatePetFromCatsMessages/);
+});
+
+test('CatsCo Chat recognizes persisted runtime plan snapshots instead of rendering raw JSON', () => {
+  assert.match(dashboardHtml, /function parseCatsRuntimePlanValue\(value\)/);
+  assert.match(dashboardHtml, /parsed\.revision!=null/);
+  assert.match(dashboardHtml, /function isCatsMessageMine\(message\)/);
+  assert.match(dashboardHtml, /!isCatsMessageMine\(message\) && parseCatsRuntimePlanValue\(message\?\.content\)/);
+  assert.match(dashboardHtml, /parseCatsRuntimePlanValue\(message\?\.content\)/);
+  assert.match(dashboardHtml, /const flushRuntimePlan=\(\)=>/);
+  assert.match(dashboardHtml, /pendingRuntimePlan=\{type:'runtime_plan'/);
+  assert.match(dashboardHtml, /group\.type==='runtime_plan'/);
+  assert.match(dashboardHtml, /renderCatsMessageShell\(group\.message, renderCatsRuntimePlan\(group\.message\)/);
 });
 
 test('CatsCo Chat composer supports local attachments', () => {

--- a/tests/subagent-model-abort-signal.test.ts
+++ b/tests/subagent-model-abort-signal.test.ts
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import test from 'node:test';
+import { SubAgentSession } from '../src/core/sub-agent-session';
+
+test('SubAgentSession stop aborts an in-flight model request', async () => {
+  const workingDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-subagent-model-abort-'));
+  let observedSignal: AbortSignal | undefined;
+
+  const session = new SubAgentSession('sub-model-abort', {
+    async chatStream(_messages: any[], _tools: any[], _callbacks: any, options: any = {}) {
+      observedSignal = options.signal;
+      return await new Promise((_resolve, reject) => {
+        options.signal?.addEventListener('abort', () => reject(new Error('aborted by test')), { once: true });
+      });
+    },
+  } as any, {
+    getSkill() { return undefined; },
+    loadSkills: async () => {},
+  } as any, {
+    agentType: 'explorer',
+    taskDescription: 'abort model request',
+    userMessage: 'abort model request',
+    workingDirectory,
+  });
+
+  try {
+    const runPromise = session.run();
+    await waitFor(() => Boolean(observedSignal));
+
+    session.stop();
+    await runPromise;
+
+    assert.equal(observedSignal?.aborted, true);
+    assert.equal(session.status, 'stopped');
+  } finally {
+    await session.close();
+    fs.rmSync(workingDirectory, { recursive: true, force: true });
+  }
+});
+
+async function waitFor(predicate: () => boolean, maxAttempts = 50): Promise<void> {
+  for (let i = 0; i < maxAttempts; i++) {
+    if (predicate()) return;
+    await new Promise(resolve => setTimeout(resolve, 10));
+  }
+  assert.fail('condition was not met in time');
+}


### PR DESCRIPTION
## 这次改动

- 支持取消正在进行的大模型请求，并把 AbortSignal 打穿主会话、ConversationRunner、AIService、Provider 以及上下文压缩链路。
- 用户点停止后返回明确的“已停止当前请求”，不再把取消当普通失败写入会话历史。
- 子 agent 被停止时记录为“任务已停止”，避免显示成失败摘要。
- 修复 CatsCo 桌面聊天历史异步加载的账号/会话竞态，避免切换账号或 topic 后旧请求回写旧消息。
- 加固 CatsCo 桌面消息发送和文件发送的 topic 归属校验，文件 grant 会在校验通过后才消费。
- 优化桌面聊天输入框、运行态展示、检查更新按钮等可读性。

## 针对 review comment 的处理

- `AgentSession -> AgentTurnController -> ConversationRunner -> AIService` 取消信号链路已补齐。
- context compression 也接入 AbortSignal，避免压缩阶段无法停止。
- cancel 不再落成普通错误消息或 `[处理失败]` 历史。
- subagent stop 不再显示 `执行失败: 请求已取消`。
- dashboard 历史加载增加 owner/topic stale guard。
- `/api/cats/messages/send` 和 `/api/cats/messages/send-file` 增加当前账号 topic 校验。
- send-file 在校验 topic 前不会消费本地文件授权。

## 验证

- `npm.cmd run build`
- `npm.cmd run release:check`
- `npm.cmd run test:all`（370 pass, 2 skipped）
- `git diff --check`（仅 CRLF warning）
