### PR TITLE
优化运行时工作目录提示

### DIFF
--- a/src/runtime/prompt-composer.ts
+++ b/src/runtime/prompt-composer.ts
@@ -65,6 +65,9 @@ export class PromptComposer {
       platform ? `当前平台：${platform}` : '',
       `当前日期：${today}`,
       'Current directory is provided in a transient message for each model request. Use that current directory for relative file and shell paths.',
+      'If the user asks you to inspect a project, repository, or source code, treat the current directory as the likely project root first.',
+      'Do not mistake Electron userData, AppData, logs, or cache directories for the source repository unless the user explicitly asks about those runtime files.',
+      'If the current directory does not appear to contain the requested product or service, do a small path check or ask for the correct repository instead of repeatedly scanning the wrong directory.',
     ].filter(Boolean).join('\n');
 
     return [basePrompt, runtimeInfo].filter(Boolean).join('\n\n');

--- a/src/runtime/runtime-profile.ts
+++ b/src/runtime/runtime-profile.ts
@@ -73,7 +73,7 @@ export function resolveDefaultRuntimeProfile(
     id: options.id ?? `xiaoba-${surface}`,
     displayName,
     surface,
-    workingDirectory: path.resolve(options.workingDirectory ?? process.cwd()),
+    workingDirectory: resolveDefaultWorkingDirectory(options, env),
     model: options.model ?? {},
     prompt: {
       source: 'prompt-manager',
@@ -91,6 +91,27 @@ export function resolveDefaultRuntimeProfile(
       uploadEnabled: options.logging?.uploadEnabled,
     },
   };
+}
+
+function resolveDefaultWorkingDirectory(
+  options: ResolveRuntimeProfileOptions,
+  env: NodeJS.ProcessEnv,
+): string {
+  if (options.workingDirectory) {
+    return path.resolve(options.workingDirectory);
+  }
+
+  const appRoot = (env.XIAOBA_APP_ROOT || '').trim();
+  const isPackaged = (env.XIAOBA_IS_PACKAGED || '').trim();
+
+  // Electron dev may run from userData so app config/logs are colocated, but
+  // the source project root remains XIAOBA_APP_ROOT. Use it as the default tool
+  // cwd only for dev; packaged apps should not default to the installed bundle.
+  if (appRoot && isPackaged === '0') {
+    return path.resolve(appRoot);
+  }
+
+  return path.resolve(process.cwd());
 }
 
 export function validateRuntimeProfile(profile: RuntimeProfile): RuntimeProfileValidationIssue[] {

--- a/tests/prompt-composer.test.ts
+++ b/tests/prompt-composer.test.ts
@@ -42,6 +42,9 @@ describe('PromptComposer', () => {
         '当前平台：feishu',
         '当前日期：2026-05-01',
         'Current directory is provided in a transient message for each model request. Use that current directory for relative file and shell paths.',
+        'If the user asks you to inspect a project, repository, or source code, treat the current directory as the likely project root first.',
+        'Do not mistake Electron userData, AppData, logs, or cache directories for the source repository unless the user explicitly asks about those runtime files.',
+        'If the current directory does not appear to contain the requested product or service, do a small path check or ask for the correct repository instead of repeatedly scanning the wrong directory.',
       ].join('\n'),
     ].join('\n\n'));
   });
@@ -62,6 +65,9 @@ describe('PromptComposer', () => {
       [
         '当前日期：2026-05-01',
         'Current directory is provided in a transient message for each model request. Use that current directory for relative file and shell paths.',
+        'If the user asks you to inspect a project, repository, or source code, treat the current directory as the likely project root first.',
+        'Do not mistake Electron userData, AppData, logs, or cache directories for the source repository unless the user explicitly asks about those runtime files.',
+        'If the current directory does not appear to contain the requested product or service, do a small path check or ask for the correct repository instead of repeatedly scanning the wrong directory.',
       ].join('\n'),
     ].join('\n\n'));
     assert.doesNotMatch(prompt, /Legacy behavior prompt/);
@@ -104,6 +110,7 @@ describe('PromptComposer', () => {
     assert.doesNotMatch(blankDisplayNamePrompt, /你在这个平台上的名字是/);
     assert.match(blankDisplayNamePrompt, /当前平台： feishu /);
     assert.match(blankDisplayNamePrompt, /Current directory is provided in a transient message/);
+    assert.match(blankDisplayNamePrompt, /Do not mistake Electron userData/);
   });
 
   test('PromptManager delegates to PromptComposer without changing output', async () => {
@@ -161,6 +168,7 @@ describe('PromptComposer', () => {
     assert.match(prompt, /你在这个平台上的名字是：Desk Bot/);
     assert.match(prompt, /当前平台：feishu/);
     assert.match(prompt, /Current directory is provided in a transient message/);
+    assert.match(prompt, /likely project root first/);
     assert.doesNotMatch(prompt.replace(/\\/g, '/'), /\/tmp\/xiaoba-runtime-profile/);
   });
 
@@ -180,6 +188,9 @@ describe('PromptComposer', () => {
       [
         '当前日期：2026-05-01',
         'Current directory is provided in a transient message for each model request. Use that current directory for relative file and shell paths.',
+        'If the user asks you to inspect a project, repository, or source code, treat the current directory as the likely project root first.',
+        'Do not mistake Electron userData, AppData, logs, or cache directories for the source repository unless the user explicitly asks about those runtime files.',
+        'If the current directory does not appear to contain the requested product or service, do a small path check or ask for the correct repository instead of repeatedly scanning the wrong directory.',
       ].join('\n'),
     ].join('\n\n'));
   });
@@ -205,6 +216,7 @@ describe('PromptComposer', () => {
     assert.match(prompt, /你在这个平台上的名字是：Desk Bot/);
     assert.match(prompt, /当前平台： feishu /);
     assert.match(prompt, /Current directory is provided in a transient message/);
+    assert.match(prompt, /logs, or cache directories/);
     assert.doesNotMatch(prompt.replace(/\\/g, '/'), /\/tmp\/xiaoba-runtime-profile/);
   });
 

--- a/tests/runtime-profile.test.ts
+++ b/tests/runtime-profile.test.ts
@@ -117,6 +117,25 @@ describe('RuntimeProfile', () => {
     });
   });
 
+  test('uses app root as default working directory in Electron dev only', () => {
+    const appRoot = path.join(testRoot, 'app-root');
+    const devProfile = resolveDefaultRuntimeProfile({
+      env: {
+        XIAOBA_APP_ROOT: appRoot,
+        XIAOBA_IS_PACKAGED: '0',
+      },
+    });
+    const packagedProfile = resolveDefaultRuntimeProfile({
+      env: {
+        XIAOBA_APP_ROOT: appRoot,
+        XIAOBA_IS_PACKAGED: '1',
+      },
+    });
+
+    assert.equal(devProfile.workingDirectory, appRoot);
+    assert.equal(packagedProfile.workingDirectory, fs.realpathSync(testRoot));
+  });
+
   test('validates unknown and duplicate runtime tool names', () => {
     const profile = resolveDefaultRuntimeProfile({
       tools: ['read_file', 'read_file', 'missing_tool'],


### PR DESCRIPTION
## 背景

从原来的异步子 agent 大 PR 中拆出的 runtime 工作目录提示切片。之前桌面开发态容易把默认工作目录落到 AppData / 用户数据目录，导致 agent 或子 agent 找不到源码、误扫日志/缓存。

## 主要改动

- Electron dev 下默认工作目录优先使用 `XIAOBA_APP_ROOT`，指向源码仓库；打包态不默认使用 app bundle 作为工作目录。
- runtime prompt 中加入当前目录/source repo 边界提示，提醒模型不要把 AppData、日志、缓存当源码目录。
- 保持 runtime profile/env 的覆盖关系，不把 secret 字段应用或泄漏到 prompt。

## 测试

- `npm.cmd run build`
- `node --import tsx --test tests\prompt-composer.test.ts tests\runtime-profile.test.ts tests\prompt-copy-regression.test.ts`
- `git diff --check` 仅 CRLF warning