### PR TITLE
feat(tools): 优化常用目录解析与 Windows shell 执行

### DIFF
--- a/src/tools/bash-tool.ts
+++ b/src/tools/bash-tool.ts
@@ -17,6 +17,7 @@ interface WrappedCommand {
   marker: string;
   cwdFilePath?: string;
   powershellScript?: string;
+  cmdScript?: string;
 }
 
 interface ShellOutput {
@@ -142,7 +143,7 @@ export class ShellTool implements Tool {
       const errorOutput = [
         parsedStderr.output,
         parsedStdout.output,
-        this.stripAnyDirectoryProbe(error.message),
+        this.formatExecutionError(error),
       ].filter(Boolean).join('\n').trim();
 
       Logger.error(`Command failed (elapsed: ${executionTime}ms)`);
@@ -167,6 +168,7 @@ export class ShellTool implements Tool {
         marker,
         cwdFilePath,
         powershellScript: this.buildPowerShellScript(command, cwdFilePath),
+        cmdScript: this.buildCmdScript(command, cwdFilePath),
       };
     }
 
@@ -188,6 +190,7 @@ export class ShellTool implements Tool {
       '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8',
       '$OutputEncoding = [System.Text.Encoding]::UTF8',
       '$ErrorActionPreference = "Stop"',
+      '$ProgressPreference = "SilentlyContinue"',
       '$env:PYTHONIOENCODING = "utf-8"',
       '$env:PYTHONUTF8 = "1"',
       '$__xiaoba_status = 0',
@@ -201,6 +204,17 @@ export class ShellTool implements Tool {
       `  (Get-Location).ProviderPath | Set-Content -LiteralPath '${escapedCwdFilePath}' -Encoding UTF8`,
       '}',
       'exit $__xiaoba_status',
+    ].join('\r\n');
+  }
+
+  private buildCmdScript(command: string, cwdFilePath: string): string {
+    return [
+      '@echo off',
+      'chcp 65001 >nul',
+      command,
+      'set "__XIAOBA_STATUS__=%ERRORLEVEL%"',
+      `cd > "${cwdFilePath.replace(/"/g, '""')}"`,
+      'exit /b %__XIAOBA_STATUS__%',
     ].join('\r\n');
   }
 
@@ -348,12 +362,91 @@ export class ShellTool implements Tool {
     env: NodeJS.ProcessEnv,
     timeout: number,
   ): Promise<ShellOutput> {
-    return execAsync(wrapped.command, {
-      cwd,
-      env,
-      encoding: 'utf-8',
-      timeout,
-      maxBuffer: 10 * 1024 * 1024,
+    const cmdScript = wrapped.cmdScript;
+    if (!cmdScript) {
+      return Promise.reject(new Error('Internal error: missing Windows cmd script'));
+    }
+
+    return new Promise((resolve, reject) => {
+      const child = spawn('cmd.exe', ['/d', '/q'], {
+        cwd,
+        env,
+        windowsHide: true,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+
+      const stdoutChunks: Buffer[] = [];
+      const stderrChunks: Buffer[] = [];
+      let settled = false;
+      let timedOut = false;
+      let stdoutBytes = 0;
+      let stderrBytes = 0;
+      const maxBuffer = 10 * 1024 * 1024;
+
+      const finish = (fn: () => void) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        fn();
+      };
+
+      const fail = (error: any) => {
+        finish(() => {
+          try { child.kill(); } catch {}
+          error.stdout = this.stripCmdSessionNoise(this.decodeWindowsOutput(Buffer.concat(stdoutChunks)));
+          error.stderr = this.stripCmdSessionNoise(this.decodeWindowsOutput(Buffer.concat(stderrChunks)));
+          reject(error);
+        });
+      };
+
+      const timer = setTimeout(() => {
+        timedOut = true;
+        fail(new Error(`Command timed out after ${timeout}ms`));
+      }, timeout);
+
+      child.stdout?.on('data', (chunk: Buffer) => {
+        const buffer = Buffer.from(chunk);
+        stdoutBytes += buffer.length;
+        if (stdoutBytes > maxBuffer) {
+          fail(new Error(`stdout maxBuffer exceeded (${maxBuffer} bytes)`));
+          return;
+        }
+        stdoutChunks.push(buffer);
+      });
+
+      child.stderr?.on('data', (chunk: Buffer) => {
+        const buffer = Buffer.from(chunk);
+        stderrBytes += buffer.length;
+        if (stderrBytes > maxBuffer) {
+          fail(new Error(`stderr maxBuffer exceeded (${maxBuffer} bytes)`));
+          return;
+        }
+        stderrChunks.push(buffer);
+      });
+
+      child.on('error', (error: Error) => {
+        fail(error);
+      });
+
+      child.on('close', (code: number | null) => {
+        if (settled) return;
+        const stdout = this.stripCmdSessionNoise(this.decodeWindowsOutput(Buffer.concat(stdoutChunks)));
+        const stderr = this.stripCmdSessionNoise(this.decodeWindowsOutput(Buffer.concat(stderrChunks)));
+        finish(() => {
+          if (timedOut) return;
+          if (code === 0) {
+            resolve({ stdout, stderr });
+            return;
+          }
+          const error: any = new Error(`Command failed with exit code ${code}`);
+          error.code = code;
+          error.stdout = stdout;
+          error.stderr = stderr;
+          reject(error);
+        });
+      });
+
+      child.stdin.end(cmdScript + '\r\n');
     });
   }
 
@@ -381,6 +474,21 @@ export class ShellTool implements Tool {
 
   private countReplacementChars(value: string): number {
     return (value.match(/\uFFFD/g) || []).length;
+  }
+
+  private stripCmdSessionNoise(output: string): string {
+    return String(output || '')
+      .split(/\r?\n/)
+      .map(line => line.replace(/^[A-Za-z]:\\[^>\r\n]*>/, ''))
+      .filter(line => {
+        const trimmed = line.trim();
+        if (!trimmed) return false;
+        if (/^Microsoft Windows \[/.test(trimmed)) return false;
+        if (/Microsoft Corporation/i.test(trimmed)) return false;
+        return true;
+      })
+      .join('\n')
+      .replace(/\n+$/, '');
   }
 
   private cleanupWrappedCommand(wrapped: WrappedCommand): void {
@@ -423,6 +531,19 @@ export class ShellTool implements Tool {
       .filter(line => !line.startsWith(CWD_MARKER_PREFIX))
       .join('\n')
       .replace(/\n+$/, '');
+  }
+
+  private formatExecutionError(error: any): string {
+    if (typeof error?.code === 'number') {
+      return `Command failed with exit code ${error.code}`;
+    }
+    if (error?.code) {
+      return `Command failed: ${error.code}`;
+    }
+    if (error?.signal) {
+      return `Command terminated by signal ${error.signal}`;
+    }
+    return this.stripAnyDirectoryProbe(String(error?.message || error || 'Command failed'));
   }
 
   private updateCurrentDirectory(directory: string | undefined, context: ToolExecutionContext): void {

--- a/src/tools/bash-tool.ts
+++ b/src/tools/bash-tool.ts
@@ -1,6 +1,8 @@
 import { exec, spawn } from 'child_process';
 import { promisify } from 'util';
+import { TextDecoder } from 'util';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import { Logger } from '../utils/logger';
@@ -11,10 +13,10 @@ const execAsync = promisify(exec);
 const CWD_MARKER_PREFIX = '__XIAOBA_CWD_MARKER__';
 
 interface WrappedCommand {
-  command?: string;
+  command: string;
   marker: string;
-  stdinScript?: string;
-  scriptPath?: string;
+  cwdFilePath?: string;
+  powershellScript?: string;
 }
 
 interface ShellOutput {
@@ -26,23 +28,23 @@ export class ShellTool implements Tool {
   definition: ToolDefinition = {
     name: 'execute_shell',
     description: [
-      '使用系统默认 shell 执行单条命令。可以运行 git、npm、ls 等命令行工具。',
-      '命令会从当前目录启动。每次调用都是新的 shell 进程；只有命令结束时的当前目录会被会话继承，环境变量、alias、函数和虚拟环境激活状态不会跨调用持久化。',
+      'Execute a single command in the system shell. On Windows this tool uses PowerShell when available and falls back to cmd.exe only if PowerShell cannot start.',
+      'Commands start from the current directory. Each call uses a fresh shell process; only the final current directory is persisted across calls. Environment variables, aliases, functions, and activated virtual environments are not persisted.',
     ].join('\n'),
     parameters: {
       type: 'object',
       properties: {
         command: {
           type: 'string',
-          description: '要执行的命令',
+          description: 'Command to execute',
         },
         description: {
           type: 'string',
-          description: '命令描述（可选），用于说明命令的作用',
+          description: 'Optional short description of what the command does',
         },
         timeout: {
           type: 'number',
-          description: '超时时间（毫秒），默认 30000ms',
+          description: 'Timeout in milliseconds, default 30000ms',
         },
       },
       required: ['command'],
@@ -58,19 +60,19 @@ export class ShellTool implements Tool {
 
     const toolPermission = isToolAllowed(this.definition.name);
     if (!toolPermission.allowed) {
-      return { ok: false, errorCode: 'PERMISSION_DENIED', message: `执行被阻止: ${toolPermission.reason}` };
+      return { ok: false, errorCode: 'PERMISSION_DENIED', message: `Execution blocked: ${toolPermission.reason}` };
     }
 
     const commandPermission = isBashCommandAllowed(command);
     if (!commandPermission.allowed) {
-      return { ok: false, errorCode: 'PERMISSION_DENIED', message: `执行被阻止: ${commandPermission.reason}` };
+      return { ok: false, errorCode: 'PERMISSION_DENIED', message: `Execution blocked: ${commandPermission.reason}` };
     }
 
     if (description) {
-      Logger.info(`执行命令: ${description}`);
+      Logger.info(`Executing command: ${description}`);
     }
     Logger.info(`$ ${command}`);
-    Logger.info(`当前目录: ${context.workingDirectory}`);
+    Logger.info(`Current directory: ${context.workingDirectory}`);
 
     const startTime = Date.now();
     const runtimeEnvironment = resolveRuntimeEnvironment({
@@ -90,7 +92,10 @@ export class ShellTool implements Tool {
 
       const parsedStdout = this.extractDirectoryProbe(stdout || '', wrapped.marker);
       const parsedStderr = this.extractDirectoryProbe(stderr || '', wrapped.marker);
-      this.updateCurrentDirectory(parsedStdout.directory || parsedStderr.directory, context);
+      this.updateCurrentDirectory(
+        this.readDirectoryProbe(wrapped) || parsedStdout.directory || parsedStderr.directory,
+        context,
+      );
 
       const output = parsedStdout.output || '';
       if (parsedStderr.output) {
@@ -101,28 +106,31 @@ export class ShellTool implements Tool {
       const outputLines = output ? output.split('\n').length : 0;
       const outputSize = Buffer.byteLength(output, 'utf-8');
 
-      Logger.success(`✓ 命令执行成功 (耗时: ${executionTime}ms)`);
-      Logger.info(`  输出: ${outputLines} 行 | ${(outputSize / 1024).toFixed(2)} KB`);
+      Logger.success(`Command succeeded (elapsed: ${executionTime}ms)`);
+      Logger.info(`  Output: ${outputLines} lines | ${(outputSize / 1024).toFixed(2)} KB`);
 
       if (outputLines > 20) {
         const previewLines = output.split('\n').slice(0, 10);
-        Logger.info('  输出预览（前10行）:');
+        Logger.info('  Output preview (first 10 lines):');
         previewLines.forEach(line => {
           const displayLine = line.length > 100 ? line.substring(0, 97) + '...' : line;
           Logger.info(`    ${displayLine}`);
         });
-        Logger.info(`    ... (还有 ${outputLines - 10} 行)`);
+        Logger.info(`    ... (${outputLines - 10} more lines)`);
       }
 
       return {
         ok: true,
-        content: `命令执行成功:\n$ ${command}\n\n执行时间: ${executionTime}ms\n输出行数: ${outputLines}\n\n${output}`,
+        content: `Command succeeded:\n$ ${command}\n\nElapsed: ${executionTime}ms\nOutput lines: ${outputLines}\n\n${output}`,
       };
     } catch (error: any) {
       const executionTime = Date.now() - startTime;
       const parsedStdout = this.extractDirectoryProbe(error.stdout || '', wrapped.marker);
       const parsedStderr = this.extractDirectoryProbe(error.stderr || '', wrapped.marker);
-      this.updateCurrentDirectory(parsedStdout.directory || parsedStderr.directory, context);
+      this.updateCurrentDirectory(
+        this.readDirectoryProbe(wrapped) || parsedStdout.directory || parsedStderr.directory,
+        context,
+      );
       if (context.abortSignal?.aborted || /aborted|abort/i.test(String(error.message || ''))) {
         Logger.warning(`命令已取消 (耗时: ${executionTime}ms)`);
         return {
@@ -137,13 +145,13 @@ export class ShellTool implements Tool {
         this.stripAnyDirectoryProbe(error.message),
       ].filter(Boolean).join('\n').trim();
 
-      Logger.error(`✗ 命令执行失败 (耗时: ${executionTime}ms)`);
-      Logger.error(`  错误: ${error.message}`);
+      Logger.error(`Command failed (elapsed: ${executionTime}ms)`);
+      Logger.error(`  Error: ${error.message}`);
 
       return {
         ok: false,
         errorCode: 'TOOL_EXECUTION_ERROR',
-        message: `命令执行失败:\n$ ${command}\n\n执行时间: ${executionTime}ms\n错误信息:\n${errorOutput}`,
+        message: `Command failed:\n$ ${command}\n\nElapsed: ${executionTime}ms\nError:\n${errorOutput}`,
       };
     } finally {
       this.cleanupWrappedCommand(wrapped);
@@ -153,24 +161,16 @@ export class ShellTool implements Tool {
   private wrapCommandWithDirectoryProbe(command: string): WrappedCommand {
     const marker = `${CWD_MARKER_PREFIX}${Date.now().toString(36)}_${Math.random().toString(36).slice(2)}`;
     if (process.platform === 'win32') {
-      // Feed commands through stdin instead of writing a .cmd file. This keeps
-      // normal cmd.exe command-line semantics such as `for %f in (...) do ...`
-      // while still letting us append a cwd probe and preserve the exit code.
+      const cwdFilePath = path.join(os.tmpdir(), `xiaoba-shell-cwd-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.txt`);
       return {
-        marker,
-        stdinScript: [
-        '@echo off',
         command,
-        'set "__XIAOBA_STATUS__=%ERRORLEVEL%"',
-        `echo ${marker}`,
-        'cd',
-        'exit /b %__XIAOBA_STATUS__%',
-        ].join('\r\n'),
+        marker,
+        cwdFilePath,
+        powershellScript: this.buildPowerShellScript(command, cwdFilePath),
       };
     }
 
     return {
-      marker,
       command: [
         command,
         'status=$?',
@@ -178,7 +178,30 @@ export class ShellTool implements Tool {
         `printf '\\n${marker}=%s\\n' "$PWD"`,
         'exit "$status"',
       ].join('\n'),
+      marker,
     };
+  }
+
+  private buildPowerShellScript(command: string, cwdFilePath: string): string {
+    const escapedCwdFilePath = cwdFilePath.replace(/'/g, "''");
+    return [
+      '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8',
+      '$OutputEncoding = [System.Text.Encoding]::UTF8',
+      '$ErrorActionPreference = "Stop"',
+      '$env:PYTHONIOENCODING = "utf-8"',
+      '$env:PYTHONUTF8 = "1"',
+      '$__xiaoba_status = 0',
+      'try {',
+      command,
+      '  if ($global:LASTEXITCODE -is [int]) { $__xiaoba_status = $global:LASTEXITCODE }',
+      '} catch {',
+      '  [Console]::Error.WriteLine([string]$_)',
+      '  $__xiaoba_status = 1',
+      '} finally {',
+      `  (Get-Location).ProviderPath | Set-Content -LiteralPath '${escapedCwdFilePath}' -Encoding UTF8`,
+      '}',
+      'exit $__xiaoba_status',
+    ].join('\r\n');
   }
 
   private async executeWrappedCommand(
@@ -189,9 +212,6 @@ export class ShellTool implements Tool {
     signal?: AbortSignal,
   ): Promise<ShellOutput> {
     if (process.platform !== 'win32') {
-      if (!wrapped.command) {
-        throw new Error('Internal error: missing shell command');
-      }
       return execAsync(wrapped.command, {
         cwd,
         env,
@@ -203,30 +223,43 @@ export class ShellTool implements Tool {
       });
     }
 
-    return this.executeWindowsStdinScript(wrapped, cwd, env, timeout, signal);
+    try {
+      return await this.executeWindowsPowerShellScript(wrapped, cwd, env, timeout, signal);
+    } catch (error) {
+      if (!this.isPowerShellLaunchFailure(error)) throw error;
+      return this.executeWindowsCmdFallback(wrapped, cwd, env, timeout);
+    }
   }
 
-  private executeWindowsStdinScript(
+  private executeWindowsPowerShellScript(
     wrapped: WrappedCommand,
     cwd: string,
     env: NodeJS.ProcessEnv,
     timeout: number,
     signal?: AbortSignal,
   ): Promise<ShellOutput> {
-    if (!wrapped.stdinScript) {
-      return Promise.reject(new Error('Internal error: missing Windows stdin script'));
+    const powershellScript = wrapped.powershellScript;
+    if (!powershellScript) {
+      return Promise.reject(new Error('Internal error: missing Windows PowerShell script'));
     }
     if (signal?.aborted) {
       return Promise.reject(new Error('Command aborted by user'));
     }
 
     return new Promise((resolve, reject) => {
-      const child = spawn('cmd.exe', ['/d', '/q'], {
+      const child = spawn('powershell.exe', [
+        '-NoProfile',
+        '-NonInteractive',
+        '-ExecutionPolicy',
+        'Bypass',
+        '-EncodedCommand',
+        Buffer.from(powershellScript, 'utf16le').toString('base64'),
+      ], {
         cwd,
         env,
         windowsHide: true,
-        stdio: ['pipe', 'pipe', 'pipe'],
-      });
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }) as ReturnType<typeof spawn>;
 
       const stdoutChunks: Buffer[] = [];
       const stderrChunks: Buffer[] = [];
@@ -250,8 +283,8 @@ export class ShellTool implements Tool {
       const fail = (error: any) => {
         finish(() => {
           try { child.kill(); } catch {}
-          error.stdout = Buffer.concat(stdoutChunks).toString('utf8');
-          error.stderr = Buffer.concat(stderrChunks).toString('utf8');
+          error.stdout = this.decodeWindowsOutput(Buffer.concat(stdoutChunks));
+          error.stderr = this.decodeWindowsOutput(Buffer.concat(stderrChunks));
           reject(error);
         });
       };
@@ -265,7 +298,7 @@ export class ShellTool implements Tool {
       };
       signal?.addEventListener('abort', abortHandler, { once: true });
 
-      child.stdout.on('data', chunk => {
+      child.stdout?.on('data', (chunk: Buffer) => {
         const buffer = Buffer.from(chunk);
         stdoutBytes += buffer.length;
         if (stdoutBytes > maxBuffer) {
@@ -275,7 +308,7 @@ export class ShellTool implements Tool {
         stdoutChunks.push(buffer);
       });
 
-      child.stderr.on('data', chunk => {
+      child.stderr?.on('data', (chunk: Buffer) => {
         const buffer = Buffer.from(chunk);
         stderrBytes += buffer.length;
         if (stderrBytes > maxBuffer) {
@@ -285,14 +318,14 @@ export class ShellTool implements Tool {
         stderrChunks.push(buffer);
       });
 
-      child.on('error', error => {
+      child.on('error', (error: Error) => {
         fail(error);
       });
 
-      child.on('close', code => {
+      child.on('close', (code: number | null) => {
         if (settled) return;
-        const stdout = Buffer.concat(stdoutChunks).toString('utf8');
-        const stderr = Buffer.concat(stderrChunks).toString('utf8');
+        const stdout = this.decodeWindowsOutput(Buffer.concat(stdoutChunks));
+        const stderr = this.decodeWindowsOutput(Buffer.concat(stderrChunks));
         finish(() => {
           if (timedOut) return;
           if (code === 0) {
@@ -306,41 +339,80 @@ export class ShellTool implements Tool {
           reject(error);
         });
       });
-
-      child.stdin.end(wrapped.stdinScript + '\r\n');
     });
   }
 
-  private cleanupWrappedCommand(wrapped: WrappedCommand): void {
-    if (!wrapped.scriptPath) return;
+  private executeWindowsCmdFallback(
+    wrapped: WrappedCommand,
+    cwd: string,
+    env: NodeJS.ProcessEnv,
+    timeout: number,
+  ): Promise<ShellOutput> {
+    return execAsync(wrapped.command, {
+      cwd,
+      env,
+      encoding: 'utf-8',
+      timeout,
+      maxBuffer: 10 * 1024 * 1024,
+    });
+  }
+
+  private isPowerShellLaunchFailure(error: any): boolean {
+    const code = String(error?.code || '');
+    const message = String(error?.message || '');
+    return code === 'ENOENT' || message.includes('ENOENT') || message.includes('spawn powershell.exe');
+  }
+
+  private decodeWindowsOutput(buffer: Buffer): string {
+    const utf8 = new TextDecoder('utf-8').decode(buffer);
+    if (!utf8.includes('\uFFFD')) return utf8;
+
     try {
-      if (fs.existsSync(wrapped.scriptPath)) fs.unlinkSync(wrapped.scriptPath);
+      const gb18030 = new TextDecoder('gb18030').decode(buffer);
+      if (this.countReplacementChars(gb18030) < this.countReplacementChars(utf8)) {
+        return gb18030;
+      }
     } catch {
-      // Best-effort cleanup only.
+      return utf8;
+    }
+
+    return utf8;
+  }
+
+  private countReplacementChars(value: string): number {
+    return (value.match(/\uFFFD/g) || []).length;
+  }
+
+  private cleanupWrappedCommand(wrapped: WrappedCommand): void {
+    if (wrapped.cwdFilePath) {
+      try {
+        if (fs.existsSync(wrapped.cwdFilePath)) fs.unlinkSync(wrapped.cwdFilePath);
+      } catch {
+        // Best-effort cleanup only.
+      }
+    }
+  }
+
+  private readDirectoryProbe(wrapped: WrappedCommand): string | undefined {
+    if (!wrapped.cwdFilePath) return undefined;
+    try {
+      if (!fs.existsSync(wrapped.cwdFilePath)) return undefined;
+      return fs.readFileSync(wrapped.cwdFilePath, 'utf8').replace(/^\uFEFF/, '').trim();
+    } catch {
+      return undefined;
     }
   }
 
   private extractDirectoryProbe(output: string, marker: string): { output: string; directory?: string } {
     const lines = output.split(/\r?\n/);
     let directory: string | undefined;
-    let takeNextLineAsDirectory = false;
     const visibleLines = lines.filter(line => {
-      if (takeNextLineAsDirectory) {
-        directory = line.trim();
-        takeNextLineAsDirectory = false;
-        return false;
-      }
-      const markerIndex = line.indexOf(marker);
-      if (markerIndex >= 0 && line.slice(markerIndex).trim() === marker) {
-        takeNextLineAsDirectory = true;
-        return false;
-      }
       if (!line.startsWith(`${marker}=`)) return true;
       directory = line.slice(marker.length + 1).trim();
       return false;
     });
     return {
-      output: visibleLines.join('\n').replace(/\n+$/, ''),
+      output: visibleLines.join('\n').replace(/^\n+/, '').replace(/\n+$/, ''),
       directory,
     };
   }

--- a/src/tools/common-directory-tool.ts
+++ b/src/tools/common-directory-tool.ts
@@ -1,0 +1,244 @@
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
+
+export type CommonDirectoryKind =
+  | 'desktop'
+  | 'downloads'
+  | 'documents'
+  | 'pictures'
+  | 'videos'
+  | 'music'
+  | 'home'
+  | 'temp';
+
+interface DirectoryResolution {
+  kind: CommonDirectoryKind;
+  path: string;
+  source: string;
+  exists: boolean;
+  platform: NodeJS.Platform;
+}
+
+const DIRECTORY_ALIASES: Record<string, CommonDirectoryKind> = {
+  desktop: 'desktop',
+  mydesktop: 'desktop',
+  desktopfolder: 'desktop',
+  '\u684c\u9762': 'desktop',
+
+  downloads: 'downloads',
+  download: 'downloads',
+  mydownloads: 'downloads',
+  downloadsfolder: 'downloads',
+  downloadfolder: 'downloads',
+  '\u4e0b\u8f7d': 'downloads',
+  '\u4e0b\u8f7d\u6587\u4ef6\u5939': 'downloads',
+
+  documents: 'documents',
+  document: 'documents',
+  docs: 'documents',
+  mydocuments: 'documents',
+  documentsfolder: 'documents',
+  '\u6587\u6863': 'documents',
+
+  pictures: 'pictures',
+  picture: 'pictures',
+  photos: 'pictures',
+  photo: 'pictures',
+  images: 'pictures',
+  image: 'pictures',
+  mypictures: 'pictures',
+  picturesfolder: 'pictures',
+  '\u56fe\u7247': 'pictures',
+  '\u7167\u7247': 'pictures',
+
+  videos: 'videos',
+  video: 'videos',
+  movies: 'videos',
+  movie: 'videos',
+  myvideos: 'videos',
+  videosfolder: 'videos',
+  '\u89c6\u9891': 'videos',
+
+  music: 'music',
+  mymusic: 'music',
+  musicfolder: 'music',
+  '\u97f3\u4e50': 'music',
+
+  home: 'home',
+  user: 'home',
+  userhome: 'home',
+  homedir: 'home',
+  '\u7528\u6237\u76ee\u5f55': 'home',
+  '\u4e3b\u76ee\u5f55': 'home',
+
+  temp: 'temp',
+  tmp: 'temp',
+  '\u4e34\u65f6\u76ee\u5f55': 'temp',
+  '\u4e34\u65f6\u6587\u4ef6\u5939': 'temp',
+};
+
+const WINDOWS_REGISTRY_VALUES: Partial<Record<CommonDirectoryKind, string>> = {
+  desktop: 'Desktop',
+  downloads: '{374DE290-123F-4565-9164-39C4925E467B}',
+  documents: 'Personal',
+  pictures: 'My Pictures',
+  videos: 'My Video',
+  music: 'My Music',
+};
+
+const STANDARD_SUBDIRECTORIES: Record<Exclude<CommonDirectoryKind, 'home' | 'temp'>, string> = {
+  desktop: 'Desktop',
+  downloads: 'Downloads',
+  documents: 'Documents',
+  pictures: 'Pictures',
+  videos: process.platform === 'darwin' ? 'Movies' : 'Videos',
+  music: 'Music',
+};
+
+const XDG_KEYS: Partial<Record<CommonDirectoryKind, string>> = {
+  desktop: 'XDG_DESKTOP_DIR',
+  downloads: 'XDG_DOWNLOAD_DIR',
+  documents: 'XDG_DOCUMENTS_DIR',
+  pictures: 'XDG_PICTURES_DIR',
+  videos: 'XDG_VIDEOS_DIR',
+  music: 'XDG_MUSIC_DIR',
+};
+
+export function normalizeCommonDirectory(input: string): CommonDirectoryKind | null {
+  const normalized = input.trim().toLowerCase().replace(/[\s_-]+/g, '');
+  return DIRECTORY_ALIASES[normalized] ?? null;
+}
+
+export function resolveCommonDirectory(kind: CommonDirectoryKind): DirectoryResolution {
+  if (kind === 'home') {
+    return buildResolution(kind, os.homedir(), 'os_homedir');
+  }
+  if (kind === 'temp') {
+    return buildResolution(kind, os.tmpdir(), 'os_tmpdir');
+  }
+
+  if (process.platform === 'win32') {
+    const registryPath = readWindowsKnownFolder(kind);
+    if (registryPath) {
+      return buildResolution(kind, registryPath, 'windows_user_shell_folders');
+    }
+  }
+
+  if (process.platform === 'linux') {
+    const xdgPath = readLinuxXdgUserDir(kind);
+    if (xdgPath) {
+      return buildResolution(kind, xdgPath, 'linux_xdg_user_dirs');
+    }
+  }
+
+  return buildResolution(kind, path.join(os.homedir(), STANDARD_SUBDIRECTORIES[kind]), 'home_fallback');
+}
+
+export class CommonDirectoryTool implements Tool {
+  definition: ToolDefinition = {
+    name: 'resolve_common_directory',
+    description: [
+      'Resolve a common user directory to the real local path for the current operating system.',
+      'Use this before accessing files when the user refers to a common OS directory by natural language, such as Desktop, Downloads, Documents, or their Chinese names.',
+      'Do not guess paths like C:\\Users\\...\\Desktop, ~/Desktop, or /Users/.../Downloads before calling this tool.',
+      'This tool returns one best path using OS-level directory settings when available.',
+      'It does not search arbitrary project folders, app-specific folders, browser-specific download folders, or semantic folders such as company projects or chat files.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        directory: {
+          type: 'string',
+          description: 'Common directory to resolve. Supported: desktop, downloads, documents, pictures, videos, music, home, temp. Chinese aliases such as desktop/downloads/documents are also accepted.',
+        },
+      },
+      required: ['directory'],
+    },
+  };
+
+  async execute(args: any, _context: ToolExecutionContext): Promise<ToolExecutionResult> {
+    const input = typeof args?.directory === 'string' ? args.directory : '';
+    const kind = normalizeCommonDirectory(input);
+    if (!kind) {
+      return {
+        ok: false,
+        errorCode: 'INVALID_TOOL_ARGUMENTS',
+        message: `Unknown common directory: ${input || '(empty)'}\nSupported: desktop, downloads, documents, pictures, videos, music, home, temp`,
+      };
+    }
+
+    const result = resolveCommonDirectory(kind);
+    return {
+      ok: true,
+      content: [
+        'Resolved common directory:',
+        `kind: ${result.kind}`,
+        `path: ${result.path}`,
+        `source: ${result.source}`,
+        `exists: ${result.exists}`,
+        `platform: ${result.platform}`,
+        '',
+        'Use this exact path as the base directory for follow-up file operations.',
+      ].join('\n'),
+    };
+  }
+}
+
+function buildResolution(kind: CommonDirectoryKind, directoryPath: string, source: string): DirectoryResolution {
+  const resolvedPath = path.resolve(directoryPath);
+  return {
+    kind,
+    path: resolvedPath,
+    source,
+    exists: fs.existsSync(resolvedPath),
+    platform: process.platform,
+  };
+}
+
+function readWindowsKnownFolder(kind: CommonDirectoryKind): string | null {
+  const valueName = WINDOWS_REGISTRY_VALUES[kind];
+  if (!valueName) return null;
+
+  const command = [
+    '[Console]::OutputEncoding=[System.Text.Encoding]::UTF8',
+    '$key = "HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\User Shell Folders"',
+    `$value = (Get-ItemProperty -LiteralPath $key -Name '${valueName}' -ErrorAction SilentlyContinue).'${valueName}'`,
+    'if ($value) { [Environment]::ExpandEnvironmentVariables([string]$value) }',
+  ].join('; ');
+
+  try {
+    const output = execFileSync('powershell.exe', ['-NoProfile', '-Command', command], {
+      encoding: 'utf8',
+      windowsHide: true,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    return output || null;
+  } catch {
+    return null;
+  }
+}
+
+function readLinuxXdgUserDir(kind: CommonDirectoryKind): string | null {
+  const key = XDG_KEYS[kind];
+  if (!key) return null;
+
+  const configPath = path.join(os.homedir(), '.config', 'user-dirs.dirs');
+  if (!fs.existsSync(configPath)) return null;
+
+  try {
+    const content = fs.readFileSync(configPath, 'utf8');
+    const match = content.match(new RegExp(`^${key}=(?:"([^"]*)"|'([^']*)'|([^\\n#]*))`, 'm'));
+    const rawValue = match?.[1] ?? match?.[2] ?? match?.[3];
+    if (!rawValue) return null;
+    const expanded = rawValue
+      .trim()
+      .replace(/^\$HOME(?=\/|$)/, os.homedir())
+      .replace(/^\$\{HOME\}(?=\/|$)/, os.homedir());
+    return expanded || null;
+  } catch {
+    return null;
+  }
+}

--- a/src/tools/default-tool-names.ts
+++ b/src/tools/default-tool-names.ts
@@ -4,6 +4,7 @@ export const DEFAULT_TOOL_NAMES = [
   'edit_file',
   'glob',
   'grep',
+  'resolve_common_directory',
   'execute_shell',
   'send_text',
   'send_file',

--- a/src/tools/tool-manager.ts
+++ b/src/tools/tool-manager.ts
@@ -6,6 +6,7 @@ import { ShellTool } from './bash-tool';
 import { EditTool } from './edit-tool';
 import { GlobTool } from './glob-tool';
 import { GrepTool } from './grep-tool';
+import { CommonDirectoryTool } from './common-directory-tool';
 import { SkillTool } from './skill-tool';
 import { SendFileTool } from './send-file-tool';
 import { SendTextTool } from './send-text-tool';
@@ -79,6 +80,7 @@ export class ToolManager implements ToolExecutor {
       new EditTool(),
       new GlobTool(),
       new GrepTool(),
+      new CommonDirectoryTool(),
       new ShellTool(),
       new SendTextTool(),
       new SendFileTool(),

--- a/tests/common-directory-tool.test.ts
+++ b/tests/common-directory-tool.test.ts
@@ -1,0 +1,52 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert/strict';
+import * as os from 'os';
+import { CommonDirectoryTool, normalizeCommonDirectory, resolveCommonDirectory } from '../src/tools/common-directory-tool';
+
+describe('CommonDirectoryTool', () => {
+  test('normalizes English and Chinese common directory aliases', () => {
+    assert.equal(normalizeCommonDirectory('desktop'), 'desktop');
+    assert.equal(normalizeCommonDirectory('my desktop'), 'desktop');
+    assert.equal(normalizeCommonDirectory('\u684c\u9762'), 'desktop');
+    assert.equal(normalizeCommonDirectory('Downloads'), 'downloads');
+    assert.equal(normalizeCommonDirectory('downloads folder'), 'downloads');
+    assert.equal(normalizeCommonDirectory('\u4e0b\u8f7d\u6587\u4ef6\u5939'), 'downloads');
+    assert.equal(normalizeCommonDirectory('\u7167\u7247'), 'pictures');
+    assert.equal(normalizeCommonDirectory('\u7528\u6237\u76ee\u5f55'), 'home');
+  });
+
+  test('rejects unsupported semantic folders instead of guessing', async () => {
+    const tool = new CommonDirectoryTool();
+    const result = await tool.execute({ directory: '\u516c\u53f8\u9879\u76ee' }, {
+      workingDirectory: os.homedir(),
+      conversationHistory: [],
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.errorCode, 'INVALID_TOOL_ARGUMENTS');
+    assert.match(result.message, /Unknown common directory/);
+  });
+
+  test('resolves home and temp to existing platform paths', async () => {
+    const home = resolveCommonDirectory('home');
+    const temp = resolveCommonDirectory('temp');
+
+    assert.equal(home.path, os.homedir());
+    assert.equal(home.exists, true);
+    assert.equal(temp.path, os.tmpdir());
+    assert.equal(temp.exists, true);
+  });
+
+  test('returns a concise path result for agent follow-up file operations', async () => {
+    const tool = new CommonDirectoryTool();
+    const result = await tool.execute({ directory: 'home' }, {
+      workingDirectory: os.homedir(),
+      conversationHistory: [],
+    });
+
+    assert.equal(result.ok, true);
+    assert.match(result.content as string, /Resolved common directory:/);
+    assert.match(result.content as string, /kind: home/);
+    assert.match(result.content as string, /Use this exact path as the base directory/);
+  });
+});

--- a/tests/runtime-characterization.test.ts
+++ b/tests/runtime-characterization.test.ts
@@ -63,6 +63,7 @@ describe('runtime characterization', () => {
         'grep',
         'read_file',
         'record_decision',
+        'resolve_common_directory',
         'resume_subagent',
         'send_file',
         'send_text',

--- a/tests/shell-current-directory.test.ts
+++ b/tests/shell-current-directory.test.ts
@@ -40,7 +40,7 @@ describe('ShellTool current directory probe', () => {
     });
 
     assert.strictEqual(result.ok, true);
-    assert.strictEqual(currentDirectory, path.join(testRoot, 'sub'));
+    assertSameDirectory(currentDirectory, path.join(testRoot, 'sub'));
     assert.ok(!(result.content as string).includes('__XIAOBA_CWD_MARKER__'));
   });
 
@@ -55,7 +55,7 @@ describe('ShellTool current directory probe', () => {
     });
 
     assert.strictEqual(result.ok, true);
-    assert.strictEqual(currentDirectory, path.join(testRoot, 'sub'));
+    assertSameDirectory(currentDirectory, path.join(testRoot, 'sub'));
     assert.ok((result.content as string).includes('ok'));
     assert.ok(!(result.content as string).includes('__XIAOBA_CWD_MARKER__'));
   });
@@ -70,6 +70,9 @@ describe('ShellTool current directory probe', () => {
     assert.strictEqual(result.ok, false);
     assert.strictEqual(currentDirectory, testRoot);
     assert.ok(!result.message.includes('__XIAOBA_CWD_MARKER__'));
+    assert.ok(!result.message.includes('status=$?'));
+    assert.ok(!result.message.includes('printf'));
+    assert.ok(!result.message.includes('exit "$status"'));
   });
 
   test('successful cd is persisted even when a later command fails', async () => {
@@ -83,8 +86,11 @@ describe('ShellTool current directory probe', () => {
     });
 
     assert.strictEqual(result.ok, false);
-    assert.strictEqual(currentDirectory, path.join(testRoot, 'sub'));
+    assertSameDirectory(currentDirectory, path.join(testRoot, 'sub'));
     assert.ok(!result.message.includes('__XIAOBA_CWD_MARKER__'));
+    assert.ok(!result.message.includes('status=$?'));
+    assert.ok(!result.message.includes('printf'));
+    assert.ok(!result.message.includes('exit "$status"'));
   });
 
   test('Windows PowerShell command output is decoded as UTF-8', {
@@ -127,7 +133,56 @@ describe('ShellTool current directory probe', () => {
 
     assert.strictEqual(result.ok, true);
     assert.ok((result.content as string).includes('visible-output'));
-    assert.strictEqual(currentDirectory, path.join(testRoot, 'sub'));
+    assertSameDirectory(currentDirectory, path.join(testRoot, 'sub'));
+  });
+
+  test('Windows cmd fallback preserves cwd and strips session noise', {
+    skip: process.platform !== 'win32',
+  }, async () => {
+    const tool = new ShellTool();
+    (tool as any).executeWindowsPowerShellScript = async () => {
+      const error: any = new Error('spawn powershell.exe ENOENT');
+      error.code = 'ENOENT';
+      throw error;
+    };
+
+    const result = await tool.execute({ command: 'cd sub && echo ok' }, {
+      ...context,
+      workingDirectory: currentDirectory,
+    });
+
+    assert.strictEqual(result.ok, true);
+    assert.ok((result.content as string).includes('ok'));
+    assert.ok(!(result.content as string).includes('Microsoft Windows'));
+    assert.ok(!/[A-Z]:\\.*>/.test(result.content as string));
+    assertSameDirectory(currentDirectory, path.join(testRoot, 'sub'));
+  });
+
+  test('Windows cmd fallback persists cwd even when a later command fails', {
+    skip: process.platform !== 'win32',
+  }, async () => {
+    const tool = new ShellTool();
+    (tool as any).executeWindowsPowerShellScript = async () => {
+      const error: any = new Error('spawn powershell.exe ENOENT');
+      error.code = 'ENOENT';
+      throw error;
+    };
+
+    const result = await tool.execute({ command: 'cd sub && definitely_missing_xiaoba_command' }, {
+      ...context,
+      workingDirectory: currentDirectory,
+    });
+
+    assert.strictEqual(result.ok, false);
+    assertSameDirectory(currentDirectory, path.join(testRoot, 'sub'));
+    assert.ok(!result.message.includes('__XIAOBA_STATUS__'));
+    assert.ok(!result.message.includes('cd >'));
+    assert.ok(!result.message.includes('exit /b'));
+    assert.ok(!/[A-Z]:\\.*>/.test(result.message));
   });
 
 });
+
+function assertSameDirectory(actual: string, expected: string): void {
+  assert.strictEqual(fs.realpathSync(actual), fs.realpathSync(expected));
+}

--- a/tests/shell-current-directory.test.ts
+++ b/tests/shell-current-directory.test.ts
@@ -46,7 +46,10 @@ describe('ShellTool current directory probe', () => {
 
   test('successful cd at the start of a compound command persists the final directory', async () => {
     const tool = new ShellTool();
-    const result = await tool.execute({ command: 'cd sub && echo ok' }, {
+    const command = process.platform === 'win32'
+      ? 'Set-Location sub; Write-Output ok'
+      : 'cd sub && echo ok';
+    const result = await tool.execute({ command }, {
       ...context,
       workingDirectory: currentDirectory,
     });
@@ -72,7 +75,7 @@ describe('ShellTool current directory probe', () => {
   test('successful cd is persisted even when a later command fails', async () => {
     const tool = new ShellTool();
     const failingCommand = process.platform === 'win32'
-      ? 'cd sub && definitely_missing_xiaoba_command'
+      ? 'Set-Location sub; definitely_missing_xiaoba_command'
       : 'cd sub && definitely_missing_xiaoba_command';
     const result = await tool.execute({ command: failingCommand }, {
       ...context,
@@ -84,18 +87,47 @@ describe('ShellTool current directory probe', () => {
     assert.ok(!result.message.includes('__XIAOBA_CWD_MARKER__'));
   });
 
-  test('Windows for loop keeps cmd command-line percent syntax', {
+  test('Windows PowerShell command output is decoded as UTF-8', {
     skip: process.platform !== 'win32',
   }, async () => {
-    fs.writeFileSync(path.join(testRoot, 'loop-target.txt'), 'ok');
     const tool = new ShellTool();
-    const result = await tool.execute({ command: 'for %f in (*.txt) do @echo %f' }, {
+    const result = await tool.execute({ command: 'Write-Output "\u4e2d\u6587\u8f93\u51fa"' }, {
       ...context,
       workingDirectory: currentDirectory,
     });
 
     assert.strictEqual(result.ok, true);
-    assert.ok((result.content as string).includes('loop-target.txt'));
+    assert.ok((result.content as string).includes('\u4e2d\u6587\u8f93\u51fa'));
+  });
+
+  test('Windows PowerShell lists names without cmd banner or prompt pollution', {
+    skip: process.platform !== 'win32',
+  }, async () => {
+    fs.writeFileSync(path.join(testRoot, 'visible-file.txt'), 'ok');
+    const tool = new ShellTool();
+    const result = await tool.execute({ command: 'Get-ChildItem -Name' }, {
+      ...context,
+      workingDirectory: currentDirectory,
+    });
+
+    assert.strictEqual(result.ok, true);
+    assert.ok((result.content as string).includes('visible-file.txt'));
+    assert.ok(!(result.content as string).includes('Microsoft Windows'));
+    assert.ok(!(result.content as string).includes('__XIAOBA_CWD_MARKER__'));
+  });
+
+  test('Windows PowerShell cwd survives prompt changes', {
+    skip: process.platform !== 'win32',
+  }, async () => {
+    const tool = new ShellTool();
+    const result = await tool.execute({ command: 'Set-Location sub; function prompt { "USER> " }; Write-Output visible-output' }, {
+      ...context,
+      workingDirectory: currentDirectory,
+    });
+
+    assert.strictEqual(result.ok, true);
+    assert.ok((result.content as string).includes('visible-output'));
+    assert.strictEqual(currentDirectory, path.join(testRoot, 'sub'));
   });
 
 });


### PR DESCRIPTION
## 背景

本次修改解决两个路径/命令执行相关问题：

- 用户描述“桌面、下载、文档”等常用目录时，agent 缺少系统级目录解析能力，容易猜错路径。
- Windows 下 execute_shell 默认 cmd.exe 容易出现中文输出乱码、命令提示符污染，以及 cwd 探针受 stdout/prompt 干扰的问题。

## 修改内容

### 1. 新增 resolve_common_directory 工具

新增常用目录解析工具，用于把用户自然语言中的常用系统目录解析为真实本机路径。

支持的目录类型包括：

- home
- desktop
- downloads
- documents
- pictures
- music
- videos
- temp

Windows 下优先读取系统 Known Folder / User Shell Folders 配置，可覆盖桌面、下载等目录被迁移到其他盘的情况。

macOS / Linux 下使用平台常见目录规则，并在 Linux 上兼容 `~/.config/user-dirs.dirs`。

### 2. 注册常用目录工具

将 `resolve_common_directory` 加入默认工具列表，并在 ToolManager 中注册，使 agent 可以在需要定位桌面、下载等目录时主动调用。

### 3. 优化 Windows execute_shell

Windows 下 `execute_shell` 改为优先使用 PowerShell：

- 使用 `powershell.exe -EncodedCommand` 执行，减少命令/路径编码问题。
- 设置 PowerShell 输出为 UTF-8。
- 为 Python 子进程设置 UTF-8 环境变量。
- PowerShell 不可启动时再 fallback 到 cmd.exe。

macOS / Linux 执行路径保持原有 POSIX shell 逻辑。

### 4. 改进 cwd 继承机制

Windows 下不再依赖 stdout marker 解析当前目录，而是通过临时文件记录命令结束时的最终目录。

这样可以避免：

- cmd / PowerShell banner 污染输出
- prompt 修改影响 cwd 探针
- 用户命令输出与 cwd marker 混杂

命令失败时，如果前面的目录切换已经成功，也会尽量继承最终 cwd。

## 测试

已通过：

```powershell
node --test --import tsx tests\shell-current-directory.test.ts tests\common-directory-tool.test.ts
npx tsc --noEmit
