### PR TITLE
兼容 OpenAI SDK 风格模型地址

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -6064,7 +6064,11 @@
         if(clearInput && secretUpdate.action==='clear')clearInput.checked=false;
         const saved=document.getElementById('model-source-saved');
         if(saved){saved.classList.add('show');setTimeout(()=>saved.classList.remove('show'),2000);}
-        if(!auto)await Promise.all([fetchDashboardSettings(),fetchStatus(),fetchRuntimeConfig()]);
+        if(!auto){
+          setModelSourceStatus('已保存，正在刷新启动状态...','muted');
+          await Promise.all([fetchDashboardSettings(),fetchStatus(),fetchRuntimeConfig(),fetchReadiness(),fetchCatsStatus()]);
+          setModelSourceStatus('已保存。新 session 或下一次启动 connector 后生效。','success');
+        }
       }catch(e){
         setModelSourceStatus('保存失败：'+(e.message||String(e)),'error');
       }finally{

--- a/src/dashboard/readiness.ts
+++ b/src/dashboard/readiness.ts
@@ -63,7 +63,7 @@ export interface DashboardReadinessOptions {
   now?: Date;
 }
 
-const DEFAULT_MODEL_API_BASE = 'https://api.openai.com/v1/chat/completions';
+const DEFAULT_MODEL_API_BASE = 'https://api.openai.com/v1';
 const DEFAULT_MODEL_NAME = 'gpt-3.5-turbo';
 const SUPPORTED_PROVIDERS = new Set(['openai', 'anthropic']);
 type SupportedProvider = 'openai' | 'anthropic';

--- a/src/dashboard/settings.ts
+++ b/src/dashboard/settings.ts
@@ -71,7 +71,7 @@ export const DASHBOARD_SETTING_DEFINITIONS: DashboardSettingDefinition[] = [
     id: 'model.apiBase',
     group: 'model',
     label: 'API 地址',
-    description: '主模型 API base URL。',
+    description: '主模型 API Base URL，兼容 OpenAI SDK 风格，也可填写 chat/completions 完整地址。',
     envKey: 'GAUZ_LLM_API_BASE',
     type: 'url',
     required: true,

--- a/src/providers/openai-provider.ts
+++ b/src/providers/openai-provider.ts
@@ -3,6 +3,7 @@ import { Message, ChatConfig, ChatResponse, ContentBlock } from '../types';
 import { ToolDefinition } from '../types/tool';
 import { AIProvider, StreamCallbacks } from './provider';
 import { ContextDebugLogger } from '../utils/context-debug-logger';
+import { normalizeOpenAIChatCompletionsUrl } from './openai-url';
 
 /**
  * OpenAI Provider
@@ -11,6 +12,7 @@ import { ContextDebugLogger } from '../utils/context-debug-logger';
  */
 export class OpenAIProvider implements AIProvider {
   private apiUrl: string;
+  private chatCompletionsUrl: string;
   private apiKey: string;
   private model: string;
   private temperature: number;
@@ -18,6 +20,7 @@ export class OpenAIProvider implements AIProvider {
 
   constructor(config: ChatConfig) {
     this.apiUrl = config.apiUrl!;
+    this.chatCompletionsUrl = normalizeOpenAIChatCompletionsUrl(this.apiUrl);
     this.apiKey = config.apiKey!;
     this.model = config.model || 'gpt-4o';
     this.temperature = config.temperature ?? 0.7;
@@ -107,10 +110,10 @@ export class OpenAIProvider implements AIProvider {
   async chat(messages: Message[], tools?: ToolDefinition[]): Promise<ChatResponse> {
     const body = this.buildRequestBody(messages, tools, false);
     ContextDebugLogger.dumpSdkBoundary('before', undefined, {
-      apiUrl: this.apiUrl,
+      apiUrl: this.chatCompletionsUrl,
       body,
     });
-    const response = await axios.post(this.apiUrl, body, { headers: this.headers });
+    const response = await axios.post(this.chatCompletionsUrl, body, { headers: this.headers });
     const message = response.data.choices[0].message;
     const usage = response.data.usage;
 
@@ -136,11 +139,11 @@ export class OpenAIProvider implements AIProvider {
     const body = this.buildRequestBody(messages, tools, true);
 
     ContextDebugLogger.dumpSdkBoundary('before', undefined, {
-      apiUrl: this.apiUrl,
+      apiUrl: this.chatCompletionsUrl,
       body,
     });
 
-    const response = await axios.post(this.apiUrl, body, {
+    const response = await axios.post(this.chatCompletionsUrl, body, {
       headers: this.headers,
       responseType: 'stream',
     });

--- a/src/providers/openai-url.ts
+++ b/src/providers/openai-url.ts
@@ -1,0 +1,30 @@
+/**
+ * Normalize OpenAI Chat Completions compatible URLs.
+ *
+ * Many OpenAI-compatible services document a SDK-style baseURL, e.g.
+ * https://api.deepseek.com or https://api.openai.com/v1. This runtime still
+ * sends HTTP requests directly, so it needs the concrete chat completions
+ * endpoint.
+ */
+export function normalizeOpenAIChatCompletionsUrl(rawUrl: string): string {
+  const trimmed = rawUrl.trim();
+  if (!trimmed) {
+    return trimmed;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return trimmed;
+  }
+
+  const path = parsed.pathname.replace(/\/+$/, '');
+  if (/\/chat\/completions$/i.test(path)) {
+    parsed.pathname = path;
+    return parsed.toString();
+  }
+
+  parsed.pathname = `${path || ''}/chat/completions`;
+  return parsed.toString();
+}

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -62,11 +62,17 @@ export class ConfigManager {
 
   static getConfig(): ChatConfig {
     this.ensureConfigDir();
-    return this.mergeConfig(this.getDefaultConfig(), this.loadUserConfigFile());
+    return this.mergeConfig(
+      this.mergeConfig(this.getDefaultConfig(), this.loadUserConfigFile()),
+      this.getExplicitModelEnvConfig(),
+    );
   }
 
   static getConfigReadonly(): ChatConfig {
-    return this.mergeConfig(this.getDefaultConfig(), this.loadUserConfigFile());
+    return this.mergeConfig(
+      this.mergeConfig(this.getDefaultConfig(), this.loadUserConfigFile()),
+      this.getExplicitModelEnvConfig(),
+    );
   }
 
   static saveConfig(config: ChatConfig): void {
@@ -76,7 +82,7 @@ export class ConfigManager {
   }
 
   static getDefaultConfig(): ChatConfig {
-    const apiUrl = process.env.GAUZ_LLM_API_BASE || 'https://api.openai.com/v1/chat/completions';
+    const apiUrl = process.env.GAUZ_LLM_API_BASE || 'https://api.openai.com/v1';
     const model = process.env.GAUZ_LLM_MODEL || 'gpt-3.5-turbo';
 
     // 自动检测 provider
@@ -108,5 +114,28 @@ export class ConfigManager {
         intervalMinutes: parseInt(process.env.CATSCO_LOG_UPLOAD_INTERVAL_MINUTES || '30'),
       },
     };
+  }
+
+  private static getExplicitModelEnvConfig(): Partial<ChatConfig> {
+    const override: Partial<ChatConfig> = {};
+    const provider = process.env.GAUZ_LLM_PROVIDER?.trim();
+    const apiUrl = process.env.GAUZ_LLM_API_BASE?.trim();
+    const apiKey = process.env.GAUZ_LLM_API_KEY?.trim();
+    const model = process.env.GAUZ_LLM_MODEL?.trim();
+
+    if (provider === 'openai' || provider === 'anthropic') {
+      override.provider = provider;
+    }
+    if (apiUrl) {
+      override.apiUrl = apiUrl;
+    }
+    if (apiKey) {
+      override.apiKey = apiKey;
+    }
+    if (model) {
+      override.model = model;
+    }
+
+    return override;
   }
 }

--- a/tests/config-manager-merge.test.ts
+++ b/tests/config-manager-merge.test.ts
@@ -127,6 +127,43 @@ test('ConfigManager merges env-backed LLM config with partial user config file',
   assert.equal(config.catscompany.apiKey, 'cc_test_key');
 });
 
+test('ConfigManager lets explicit env LLM settings override legacy user config', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-config-env-priority-'));
+  const homeDir = path.join(tempRoot, 'home');
+  const configDir = path.join(homeDir, '.xiaoba');
+  const envFile = path.join(tempRoot, '.env');
+
+  fs.mkdirSync(configDir, { recursive: true });
+  fs.writeFileSync(
+    envFile,
+    [
+      'GAUZ_LLM_PROVIDER=openai',
+      'GAUZ_LLM_API_BASE=https://api.deepseek.com',
+      'GAUZ_LLM_MODEL=deepseek-v4-flash',
+      'GAUZ_LLM_API_KEY=test-key',
+    ].join('\n'),
+  );
+  fs.writeFileSync(
+    path.join(configDir, 'config.json'),
+    JSON.stringify({
+      provider: 'anthropic',
+      apiUrl: 'https://api.deepseek.com/anthropic',
+      model: 'legacy-model',
+      catscompany: {
+        serverUrl: 'ws://example.com/v0/channels',
+      },
+    }),
+  );
+
+  const { config } = runConfigProbe(homeDir, envFile);
+
+  assert.equal(config.provider, 'openai');
+  assert.equal(config.apiUrl, 'https://api.deepseek.com');
+  assert.equal(config.model, 'deepseek-v4-flash');
+  assert.equal(config.apiKey, 'test-key');
+  assert.equal(config.catscompany.serverUrl, 'ws://example.com/v0/channels');
+});
+
 test('ConfigManager readonly config does not create user config directory', () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-config-readonly-'));
   const homeDir = path.join(tempRoot, 'home');

--- a/tests/dashboard-productization-html.test.ts
+++ b/tests/dashboard-productization-html.test.ts
@@ -105,6 +105,14 @@ test('CatsCo Chat page is driven by readiness state instead of loose controls', 
   assert.doesNotMatch(dashboardHtml, /末尾 \+/);
 });
 
+test('custom model save refreshes readiness before Chat remains locked', () => {
+  assert.match(
+    dashboardHtml,
+    /fetchDashboardSettings\(\),fetchStatus\(\),fetchRuntimeConfig\(\),fetchReadiness\(\),fetchCatsStatus\(\)/,
+  );
+  assert.match(dashboardHtml, /已保存，正在刷新启动状态/);
+});
+
 test('CatsCo Chat preserves scroll position while reading history', () => {
   assert.match(dashboardHtml, /let catsScrollPinnedToBottom = true/);
   assert.match(dashboardHtml, /const CATS_SCROLL_BOTTOM_THRESHOLD = 80/);

--- a/tests/openai-provider-url.test.ts
+++ b/tests/openai-provider-url.test.ts
@@ -1,0 +1,59 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import axios from 'axios';
+import { normalizeOpenAIChatCompletionsUrl } from '../src/providers/openai-url';
+import { OpenAIProvider } from '../src/providers/openai-provider';
+
+test('normalizeOpenAIChatCompletionsUrl accepts SDK-style base URLs', () => {
+  assert.equal(
+    normalizeOpenAIChatCompletionsUrl('https://api.openai.com/v1'),
+    'https://api.openai.com/v1/chat/completions',
+  );
+  assert.equal(
+    normalizeOpenAIChatCompletionsUrl('https://api.deepseek.com'),
+    'https://api.deepseek.com/chat/completions',
+  );
+  assert.equal(
+    normalizeOpenAIChatCompletionsUrl('https://api.deepseek.com/v1/'),
+    'https://api.deepseek.com/v1/chat/completions',
+  );
+});
+
+test('normalizeOpenAIChatCompletionsUrl keeps complete chat completions endpoints', () => {
+  assert.equal(
+    normalizeOpenAIChatCompletionsUrl('https://api.deepseek.com/chat/completions'),
+    'https://api.deepseek.com/chat/completions',
+  );
+  assert.equal(
+    normalizeOpenAIChatCompletionsUrl('https://example.test/openai/deployments/test/chat/completions?api-version=2024-06-01'),
+    'https://example.test/openai/deployments/test/chat/completions?api-version=2024-06-01',
+  );
+});
+
+test('OpenAIProvider posts to normalized endpoint while preserving configured apiUrl', async () => {
+  const originalPost = axios.post;
+  let seenUrl = '';
+
+  (axios as any).post = async (url: string) => {
+    seenUrl = url;
+    return {
+      data: {
+        choices: [{ message: { content: 'ok' } }],
+      },
+    };
+  };
+
+  try {
+    const provider = new OpenAIProvider({
+      apiUrl: 'https://api.deepseek.com',
+      apiKey: 'test-key',
+      model: 'deepseek-v4-flash',
+    });
+
+    assert.equal((provider as any).apiUrl, 'https://api.deepseek.com');
+    await provider.chat([{ role: 'user', content: 'hello' }]);
+    assert.equal(seenUrl, 'https://api.deepseek.com/chat/completions');
+  } finally {
+    (axios as any).post = originalPost;
+  }
+});


### PR DESCRIPTION
## 背景

当前 CatsCo 的 OpenAI provider 内部直接向 `apiUrl` 发起请求，但桌面设置和多数 OpenAI-compatible 服务（DeepSeek、OpenAI SDK、部分中转服务）的用户心智都是填写 `baseURL`。这会导致用户按官方 SDK 风格填写 `https://api.deepseek.com` 或 `https://api.openai.com/v1` 时，请求没有落到 `/chat/completions`。

另外，旧的用户级 `~/.xiaoba/config.json` 里如果残留了 `provider: anthropic`，会覆盖桌面设置页写入的 `GAUZ_LLM_*`，导致用户明明选择了 OpenAI-compatible，运行时仍走 Anthropic provider。

## 改动

- 新增 OpenAI-compatible URL 归一化：
  - `https://api.openai.com/v1` -> `https://api.openai.com/v1/chat/completions`
  - `https://api.deepseek.com` -> `https://api.deepseek.com/chat/completions`
  - 已经是 `/chat/completions` 的完整地址保持不变
- OpenAIProvider 保留原始配置值，但实际 HTTP 请求使用归一化后的 chat completions endpoint。
- 默认 OpenAI API 地址改为 SDK 风格的 `https://api.openai.com/v1`。
- 桌面设置文案说明支持 “API Base URL 或 chat/completions 完整地址”。
- 配置合并时让显式 `GAUZ_LLM_*` 覆盖旧用户 config，避免旧 `provider` 残留把桌面设置覆盖掉。
- 保存自定义模型后立即刷新 readiness 和 CatsCo Chat 状态，减少输入框等待解锁的延迟。
- 补充 URL 归一化、配置优先级和 Chat 页面刷新行为测试。

## 验证

- `node --import tsx --test tests/config-manager-merge.test.ts tests/openai-provider-url.test.ts tests/dashboard-settings-api.test.ts tests/dashboard-readiness.test.ts`
- `node --import tsx --test tests/dashboard-productization-html.test.ts tests/config-manager-merge.test.ts tests/openai-provider-url.test.ts`
- `npm.cmd run build`
- `git diff --check`（仅 CRLF warning）
- 本地桌面端手测：DeepSeek OpenAI-compatible 与 MiniMax 切换后均可正常回复。

## 后续

这次只处理 OpenAI-compatible baseURL 和配置优先级。DeepSeek thinking / `reasoning_content` + tools 的完整多轮兼容可以后续单独做一个 PR。
