### PR TITLE
准备 v1.1.5 发布

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -4242,7 +4242,7 @@
       <div class="sidebar-brand-icon"><img src="cat-icon.png" style="width:100%;height:100%;object-fit:contain;border-radius:inherit" alt="CatsCo"></div>
       <div>
         <div class="sidebar-brand-text">CatsCo</div>
-        <div class="sidebar-brand-ver">v1.1.4</div>
+        <div class="sidebar-brand-ver">v1.1.5</div>
       </div>
     </div>
     <nav class="sidebar-nav">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xiaoba-cli",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xiaoba-cli",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xiaoba-cli",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "CatsCo - local agent runtime and dashboard",
   "main": "electron/main.js",
   "bin": {

--- a/scripts/check-release-branding.mjs
+++ b/scripts/check-release-branding.mjs
@@ -55,7 +55,11 @@ assertIncludes('electron tray tooltip', readText('electron/main.js'), "tray.setT
 assertIncludes('GitHub release title', readText('.github/workflows/release.yml'), 'name: CatsCo ${{ github.ref_name }}');
 assertIncludes('Windows install shortcut', readText('install.ps1'), 'CatsCo Dashboard');
 assertIncludes('Unix install launcher', readText('install.sh'), 'CatsCo Dashboard');
-assertIncludes('default workspace prompt', readText('src/runtime/prompt-composer.ts'), '~/catsco-workspace/');
+assertIncludes(
+  'runtime current-directory prompt',
+  readText('src/runtime/prompt-composer.ts'),
+  'Current directory is provided in a transient message',
+);
 
 const filesToScan = [
   'package.json',


### PR DESCRIPTION
## 背景

准备发布下一版稳定 tag：`v1.1.5`。

当前主仓库已有 `v1.1.4` tag，源码版本仍是 `1.1.4`，稳定 release tag 需要先把源码版本提交到 main。同步最新 main 后还发现 `release:check` 中的工作目录提示检查仍要求旧的 `~/catsco-workspace/` 文案，但最新运行时提示已经改为每轮注入 transient current directory，因此 release preflight 会失败。

## 改动

- 将源码版本从 `1.1.4` 升到 `1.1.5`
  - `package.json`
  - `package-lock.json`
  - `dashboard/index.html` 侧边栏版本号
- 更新 `scripts/check-release-branding.mjs` 的工作目录提示检查：
  - 从旧的 `~/catsco-workspace/`
  - 改为检查当前 runtime prompt 的 transient current-directory 提示

## 验证

- `npm.cmd run release:check`
- `npm.cmd run release:verify-version -- v1.1.5`
- `npm.cmd run build`
- `git diff --check`（仅 CRLF warning）

## 合并后发 tag

合并本 PR 后，在主仓库 main 最新提交上创建并推送：

```bash
git checkout main
git pull --ff-only upstream main
git tag v1.1.5
git push upstream v1.1.5
```
