### PR TITLE
fix(core): 修复 send_file 上下文记录与 cwd 注入位置

### DIFF
--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -176,7 +176,6 @@ export class ConversationRunner {
     let hasDeliveredMessageOutThisRun = false;
     let lastOutboundContent: string | null = null;
     let observationSinceLastOutbound = false;
-    const deliveredOutboundFiles = new Set<string>();
     let turns = 0;
     let executedToolCalls = 0;
     let hasUpdatedPlan = false;
@@ -357,17 +356,12 @@ export class ConversationRunner {
         Logger.info(`[${this.sessionLabel}Turn ${turns}] 执行工具: ${toolName} | 参数: ${ConversationRunner.truncateForLog(toolCall.function.arguments, 500)}`);
         const activeToolNames = allTools.map(tool => tool.name);
         const toolStart = Date.now();
-        const outboundFileKey = transcriptMode === 'outbound_file'
-          ? this.buildOutboundFileKey(toolCall)
-          : null;
-        const result = outboundFileKey && deliveredOutboundFiles.has(outboundFileKey)
-          ? this.buildDuplicateOutboundFileResult(toolCall)
-          : await this.executeToolWithRetry(
-            toolCall,
-            messages,
-            this.toolExecutionContext || {},
-            turns,
-          );
+        const result = await this.executeToolWithRetry(
+          toolCall,
+          messages,
+          this.toolExecutionContext || {},
+          turns,
+        );
         executedToolCalls++;
         if (toolName === PLAN_TOOL_NAME) {
           hasUpdatedPlan = true;
@@ -387,9 +381,6 @@ export class ConversationRunner {
           && !result.errorCode
         ) {
           hasDeliveredMessageOutThisRun = true;
-          if (outboundFileKey) {
-            deliveredOutboundFiles.add(outboundFileKey);
-          }
         }
 
         const toolContent = result.content;
@@ -425,8 +416,6 @@ export class ConversationRunner {
           if (content) {
             if (lastOutboundContent === content && !observationSinceLastOutbound) {
               nextTurnTransientHints = [this.buildDuplicateOutboundHint(content)];
-            } else if (transcriptMode === 'outbound_file') {
-              nextTurnTransientHints = [this.buildOutboundFileDeliveredHint(record)];
             }
             lastOutboundContent = content;
             observationSinceLastOutbound = false;
@@ -616,7 +605,13 @@ export class ConversationRunner {
 
   private buildProviderInputMessages(messages: Message[], transientHints: Message[]): Message[] {
     const sanitizedBase = messages.filter(message => {
-      if (message.role !== 'system' || typeof message.content !== 'string') {
+      if (typeof message.content !== 'string') {
+        return true;
+      }
+      if (message.content.startsWith(TRANSIENT_CURRENT_DIRECTORY_PREFIX)) {
+        return false;
+      }
+      if (message.role !== 'system') {
         return true;
       }
       return !message.content.startsWith(TRANSIENT_RUNNER_HINT_PREFIX)
@@ -643,11 +638,62 @@ export class ConversationRunner {
     }
 
     const currentDirectoryHint = this.buildCurrentDirectoryHint();
+    return this.insertCurrentDirectoryHint(
+      [
+        ...collapsed,
+        ...transientHints,
+      ],
+      currentDirectoryHint,
+    );
+  }
+
+  private insertCurrentDirectoryHint(messages: Message[], hint: Message | null): Message[] {
+    if (!hint) return messages;
+
+    const insertIndex = this.findCurrentDirectoryHintInsertIndex(messages);
     return [
-      ...collapsed,
-      ...transientHints,
-      ...(currentDirectoryHint ? [currentDirectoryHint] : []),
+      ...messages.slice(0, insertIndex),
+      hint,
+      ...messages.slice(insertIndex),
     ];
+  }
+
+  private findCurrentDirectoryHintInsertIndex(messages: Message[]): number {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const message = messages[i];
+      if (message.role !== 'assistant' || !message.tool_calls?.length) {
+        continue;
+      }
+
+      const suffix = messages.slice(i + 1);
+      const suffixBelongsToToolExchange = suffix.length > 0 && suffix.every(item => {
+        if (item.role === 'tool') return true;
+        return this.isTransientRunnerHint(item);
+      });
+
+      if (suffixBelongsToToolExchange) {
+        return i;
+      }
+    }
+
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].role === 'user' && !this.isCurrentDirectoryHint(messages[i])) {
+        return i;
+      }
+    }
+
+    return messages.length;
+  }
+
+  private isTransientRunnerHint(message: Message): boolean {
+    return message.role === 'system'
+      && typeof message.content === 'string'
+      && message.content.startsWith(TRANSIENT_RUNNER_HINT_PREFIX);
+  }
+
+  private isCurrentDirectoryHint(message: Message): boolean {
+    return typeof message.content === 'string'
+      && message.content.startsWith(TRANSIENT_CURRENT_DIRECTORY_PREFIX);
   }
 
   private buildCurrentDirectoryHint(): Message | null {
@@ -659,10 +705,9 @@ export class ConversationRunner {
       role: 'user',
       content: [
         TRANSIENT_CURRENT_DIRECTORY_PREFIX,
-        `Current directory: ${currentDirectory}`,
-        'Relative paths in regular file tools and shell commands resolve from this directory.',
-        'Each execute_shell call runs in a fresh shell process. Only the final current directory is persisted across calls; environment variables, aliases, functions, and activated virtual environments are not persisted.',
-        'When sending or referencing delivered files, prefer the absolute path returned by the tool result.',
+        'Runtime context only. Not a user request. Do not answer.',
+        `cwd: ${currentDirectory}`,
+        'Use only for relative file paths.',
       ].join('\n'),
       __injected: true,
     };
@@ -690,7 +735,7 @@ export class ConversationRunner {
       return false;
     }
 
-    return transcriptMode === 'outbound_message' || transcriptMode === 'outbound_file';
+    return transcriptMode === 'outbound_message';
   }
 
   private buildOutboundAssistantMessage(
@@ -714,17 +759,6 @@ export class ConversationRunner {
       return {
         role: 'assistant',
         content: text,
-      };
-    }
-
-    if (transcriptMode === 'outbound_file') {
-      const fileName = typeof args.file_name === 'string' ? args.file_name.trim() : '';
-      if (!fileName) {
-        return null;
-      }
-      return {
-        role: 'assistant',
-        content: fileName,
       };
     }
 
@@ -761,68 +795,6 @@ export class ConversationRunner {
     return {
       role: 'system',
       content: `${TRANSIENT_RUNNER_HINT_PREFIX}\n你刚刚连续发送了与上一条相同的内容：“${content}”。如果这是用户真正需要的重复确认，可以继续；否则请避免无意义重复，必要时调用 pause_turn 收束。`,
-    };
-  }
-
-  private buildOutboundFileDeliveredHint(record: ToolExecutionRecord): Message {
-    let args: Record<string, unknown> = {};
-    try {
-      args = JSON.parse(record.toolCall.function.arguments || '{}');
-    } catch {}
-
-    const fileName = typeof args.file_name === 'string' ? args.file_name.trim() : '';
-    const filePath = typeof args.file_path === 'string' ? args.file_path.trim() : '';
-    const details = [
-      fileName ? `File name: ${fileName}` : '',
-      filePath ? `File path: ${filePath}` : '',
-    ].filter(Boolean).join('\n');
-
-    return {
-      role: 'system',
-      content: [
-        TRANSIENT_RUNNER_HINT_PREFIX,
-        'The previous send_file call already sent the file to the current chat successfully.',
-        details,
-        'Do not call send_file again for the same file unless the user explicitly asks to resend it.',
-        'Now continue normally and give the user a short confirmation or any necessary next-step note.',
-      ].filter(Boolean).join('\n'),
-    };
-  }
-
-  private buildOutboundFileKey(toolCall: ToolCall): string | null {
-    try {
-      const args = JSON.parse(toolCall.function.arguments || '{}');
-      const filePath = typeof args.file_path === 'string' ? args.file_path.trim() : '';
-      const fileName = typeof args.file_name === 'string' ? args.file_name.trim() : '';
-      if (!filePath && !fileName) return null;
-      return `${filePath}\n${fileName}`.toLowerCase();
-    } catch {
-      return null;
-    }
-  }
-
-  private buildDuplicateOutboundFileResult(toolCall: ToolCall): ToolResult {
-    let args: Record<string, unknown> = {};
-    try {
-      args = JSON.parse(toolCall.function.arguments || '{}');
-    } catch {}
-
-    const filePath = typeof args.file_path === 'string' ? args.file_path.trim() : '';
-    const fileName = typeof args.file_name === 'string' ? args.file_name.trim() : '';
-
-    return {
-      tool_call_id: toolCall.id,
-      role: 'tool',
-      name: toolCall.function.name,
-      ok: false,
-      errorCode: 'DUPLICATE_OUTBOUND_FILE',
-      retryable: false,
-      content: [
-        'This file was already sent earlier in the current agent run.',
-        filePath ? `Path: ${filePath}` : '',
-        fileName ? `Name: ${fileName}` : '',
-        'Do not call send_file again for the same file. Give the user a short confirmation instead.',
-      ].filter(Boolean).join('\n'),
     };
   }
 

--- a/tests/conversation-runner-transcript-normalization.test.ts
+++ b/tests/conversation-runner-transcript-normalization.test.ts
@@ -153,6 +153,66 @@ test('runner normalizes send_text tool into assistant transcript without tool_re
   );
 });
 
+test('runner injects current directory before the active request context without becoming the final message', async () => {
+  const responses = [
+    makeToolResponse(makeToolCall('call_read', 'read_file', { file_path: 'notes.txt' })),
+    makeFinalResponse('done'),
+  ];
+  const mock = createMockAI(responses);
+  const toolExecutor = new MockToolExecutor(
+    [{
+      name: 'read_file',
+      description: 'read file',
+      parameters: {
+        type: 'object',
+        properties: {
+          file_path: { type: 'string' },
+        },
+        required: ['file_path'],
+      },
+    }],
+    { read_file: 'file contents' },
+  );
+  const runner = new ConversationRunner(mock.aiService, toolExecutor, {
+    stream: true,
+    enableCompression: false,
+    toolExecutionContext: {
+      workingDirectory: 'C:\\Users\\test\\workspace',
+      getCurrentDirectory: () => 'C:\\Users\\test\\workspace',
+    },
+  });
+
+  await runner.run([{ role: 'user', content: 'read notes' }]);
+
+  const firstCallMessages = mock.getReceivedMessages()[0];
+  assert.match(String(firstCallMessages[0].content), /^\[transient_current_directory\]/);
+  assert.equal(firstCallMessages[0].role, 'user');
+  assert.equal(firstCallMessages[1].role, 'user');
+  assert.equal(firstCallMessages[1].content, 'read notes');
+
+  const secondCallMessages = mock.getReceivedMessages()[1];
+  const cwdIndex = secondCallMessages.findIndex(
+    message => typeof message.content === 'string'
+      && message.content.startsWith('[transient_current_directory]'),
+  );
+  const assistantToolIndex = secondCallMessages.findIndex(
+    message => message.role === 'assistant'
+      && message.tool_calls?.some(toolCall => toolCall.id === 'call_read'),
+  );
+
+  assert.equal(cwdIndex, assistantToolIndex - 1);
+  assert.equal(secondCallMessages[assistantToolIndex + 1].role, 'tool');
+  assert.match(
+    String(secondCallMessages[cwdIndex].content),
+    /^\[transient_current_directory\]\nRuntime context only\. Not a user request\. Do not answer\.\ncwd: C:\\Users\\test\\workspace\nUse only for relative file paths\.$/,
+  );
+  assert.equal(
+    secondCallMessages[secondCallMessages.length - 1].role,
+    'tool',
+    'after a tool exchange, the tool_result should remain the final message instead of the cwd hint',
+  );
+});
+
 test('runner does not persist assistant draft content when send_text already delivered the same turn', async () => {
   const responses = [
     {
@@ -315,7 +375,12 @@ test('runner pauses only when pause_turn is called explicitly', async () => {
   );
 });
 
-test('runner continues after an outbound file and blocks duplicate file sends in the same run', async () => {
+test('runner records outbound file sends as normal tool_result transcript for later turns', async () => {
+  const sentFileResult = [
+    'File sent to current chat.',
+    'Path: C:\\Users\\test\\Desktop\\report.docx',
+    'Name: report.docx',
+  ].join('\n');
   const responses = [
     makeToolResponse(makeToolCall('call_file', 'send_file', {
       file_path: 'C:\\Users\\test\\Desktop\\report.docx',
@@ -325,7 +390,7 @@ test('runner continues after an outbound file and blocks duplicate file sends in
       file_path: 'C:\\Users\\test\\Desktop\\report.docx',
       file_name: 'report.docx',
     })),
-    makeFinalResponse('已发送 report.docx。'),
+    makeFinalResponse('sent report.docx'),
   ];
   const mock = createMockAI(responses);
   const toolExecutor = new MockToolExecutor(
@@ -344,13 +409,7 @@ test('runner continues after an outbound file and blocks duplicate file sends in
         },
       },
     ],
-    {
-      send_file: [
-        'File sent to current chat.',
-        'Path: C:\\Users\\test\\Desktop\\report.docx',
-        'Name: report.docx',
-      ].join('\n'),
-    },
+    { send_file: sentFileResult },
   );
 
   const runner = new ConversationRunner(mock.aiService, toolExecutor, {
@@ -366,33 +425,68 @@ test('runner continues after an outbound file and blocks duplicate file sends in
   );
   assert.equal(
     toolExecutor.getExecutionCount('send_file'),
-    1,
-    'duplicate send_file calls for the same file should not execute the upload again',
+    2,
+    'send_file calls should execute normally; repeated sends are handled by model-visible tool results',
   );
-  const thirdCallMessages = mock.getReceivedMessages()[2];
-  assert.ok(
-    thirdCallMessages.some(
-      message => message.role === 'tool'
-        && typeof message.content === 'string'
-        && message.content.includes('already sent earlier in the current agent run'),
-    ),
-    'the model should see a tool_result explaining that the duplicate send was blocked',
+
+  const secondCallMessages = mock.getReceivedMessages()[1];
+  const secondAssistantIndex = secondCallMessages.findIndex(
+    message => message.role === 'assistant'
+      && message.tool_calls?.some(toolCall => toolCall.id === 'call_file'),
   );
-  assert.equal(result.response, '已发送 report.docx。');
+  assert.notEqual(secondAssistantIndex, -1);
   assert.deepEqual(
-    result.messages
-      .filter(message => message.role !== 'tool')
-      .map(message => ({ role: message.role, content: message.content })),
+    secondCallMessages[secondAssistantIndex + 1],
+    {
+      role: 'tool',
+      content: sentFileResult,
+      tool_call_id: 'call_file',
+      name: 'send_file',
+    },
+    'the model should see send_file as a normal tool_result immediately after its assistant tool_call',
+  );
+
+  const thirdCallMessages = mock.getReceivedMessages()[2];
+  const thirdToolResults = thirdCallMessages.filter(
+    message => message.role === 'tool' && message.name === 'send_file',
+  );
+  assert.equal(thirdToolResults.length, 2);
+  assert.deepEqual(
+    thirdToolResults.map(message => message.tool_call_id),
+    ['call_file', 'call_file_again'],
+    'each successful send_file call should have its own legal tool_result',
+  );
+  assert.ok(
+    !thirdCallMessages.some(
+      message => typeof message.content === 'string' && message.content.includes('[outbound_file_sent]'),
+    ),
+    'send_file should not inject assistant state markers into provider input',
+  );
+  assert.equal(result.response, 'sent report.docx');
+  assert.deepEqual(
+    result.messages.map(message => ({
+      role: message.role,
+      content: message.content,
+      tool_call_id: message.tool_call_id,
+      name: message.name,
+    })),
     [
-      { role: 'user', content: 'send the desktop docx' },
-      { role: 'assistant', content: 'report.docx' },
-      { role: 'assistant', content: null },
-      { role: 'assistant', content: '已发送 report.docx。' },
+      { role: 'user', content: 'send the desktop docx', tool_call_id: undefined, name: undefined },
+      { role: 'assistant', content: null, tool_call_id: undefined, name: undefined },
+      { role: 'tool', content: sentFileResult, tool_call_id: 'call_file', name: 'send_file' },
+      { role: 'assistant', content: null, tool_call_id: undefined, name: undefined },
+      { role: 'tool', content: sentFileResult, tool_call_id: 'call_file_again', name: 'send_file' },
+      { role: 'assistant', content: 'sent report.docx', tool_call_id: undefined, name: undefined },
     ],
   );
 });
 
-test('runner keeps legal transcript order for duplicate send_file calls in the same assistant response', async () => {
+test('runner keeps repeated send_file calls in the same assistant response as legal tool_results', async () => {
+  const sentFileResult = [
+    'File sent to current chat.',
+    'Path: C:\\Users\\test\\Desktop\\report.docx',
+    'Name: report.docx',
+  ].join('\n');
   const responses = [
     {
       content: null,
@@ -431,13 +525,7 @@ test('runner keeps legal transcript order for duplicate send_file calls in the s
         },
       },
     ],
-    {
-      send_file: [
-        'File sent to current chat.',
-        'Path: C:\\Users\\test\\Desktop\\report.docx',
-        'Name: report.docx',
-      ].join('\n'),
-    },
+    { send_file: sentFileResult },
   );
 
   const runner = new ConversationRunner(mock.aiService, toolExecutor, {
@@ -446,21 +534,40 @@ test('runner keeps legal transcript order for duplicate send_file calls in the s
   });
   await runner.run([{ role: 'user', content: 'send the desktop docx twice' }]);
 
-  assert.equal(toolExecutor.getExecutionCount('send_file'), 1);
+  assert.equal(toolExecutor.getExecutionCount('send_file'), 2);
   const secondCallMessages = mock.getReceivedMessages()[1];
-  const assistantIndex = secondCallMessages.findIndex(message => message.role === 'assistant' && Boolean(message.tool_calls?.length));
-  const firstToolIndex = secondCallMessages.findIndex(message => message.role === 'tool' && message.tool_call_id === 'call_file_1');
-  const secondToolIndex = secondCallMessages.findIndex(message => message.role === 'tool' && message.tool_call_id === 'call_file_2');
-  const outboundAssistantBetween = secondCallMessages
-    .slice(assistantIndex + 1, firstToolIndex)
-    .some(message => message.role === 'assistant');
-
-  assert.ok(assistantIndex >= 0);
-  assert.equal(secondCallMessages[assistantIndex].tool_calls?.length, 2);
-  assert.equal(firstToolIndex, assistantIndex + 1);
-  assert.equal(secondToolIndex, assistantIndex + 2);
-  assert.equal(outboundAssistantBetween, false);
-  assert.match(String(secondCallMessages[secondToolIndex].content), /already sent earlier/);
+  const assistantIndex = secondCallMessages.findIndex(
+    message => message.role === 'assistant' && message.tool_calls?.length === 2,
+  );
+  assert.notEqual(assistantIndex, -1);
+  assert.deepEqual(
+    secondCallMessages[assistantIndex].tool_calls?.map(toolCall => toolCall.id),
+    ['call_file_1', 'call_file_2'],
+  );
+  assert.deepEqual(
+    secondCallMessages.slice(assistantIndex + 1, assistantIndex + 3),
+    [
+      {
+        role: 'tool',
+        content: sentFileResult,
+        tool_call_id: 'call_file_1',
+        name: 'send_file',
+      },
+      {
+        role: 'tool',
+        content: sentFileResult,
+        tool_call_id: 'call_file_2',
+        name: 'send_file',
+      },
+    ],
+    'each send_file result should immediately follow the assistant message that requested it',
+  );
+  assert.ok(
+    !secondCallMessages.some(
+      message => typeof message.content === 'string' && message.content.includes('[outbound_file_sent]'),
+    ),
+    'send_file should not inject assistant state markers for repeated sends',
+  );
 });
 
 test('runner does not locally retry failed outbound file sends unless the failure is rate limited', async () => {


### PR DESCRIPTION
## 背景

本次修改主要处理对话 loop 中两个会影响模型后续判断的问题：

1. `send_file` 成功后没有以普通 `tool_result` 形式进入上下文。
2. `[transient_current_directory]` 每次被追加到 provider input 最底部，容易被模型误认为最新用户输入。

这两个问题在 CatsCo / IM 对话场景中会比较明显：

- 文件已经发送成功，但模型后续不一定能通过标准工具结果理解“刚刚确实执行过 send_file”。
- 模型可能把内部 cwd 提示当作用户消息来回复，例如输出“收到，当前工作目录是 ...”。
- 之前的重复发送阻拦属于系统硬拦截，虽然能避免部分重复上传，但会影响用户明确要求重复发送文件的场景，也会让上下文表达不够自然。

## 问题原因

### send_file 的上下文表达不稳定

原逻辑里 `send_file` 使用 `transcriptMode: outbound_file`，成功后会被 `ConversationRunner` 特殊处理：

- 不按普通工具调用链路保留 `assistant(tool_calls) -> tool_result`
- 而是折叠为 assistant 文本状态，例如文件名或内部状态提示
- 同一 run 内还存在基于 `file_path + file_name` 的重复发送硬拦截

这导致模型看到的上下文和真实工具执行链路不完全一致。尤其在多轮 React 中，模型容易重新发起 `send_file`，或者误解内部状态文本。

### cwd transient context 抢占最新用户消息位置

当前目录提示本身是 runtime metadata，不是用户请求。但旧逻辑每次把它 append 到 provider input 最后：

user: 真实用户请求
assistant/tool...
user: [transient_current_directory] ...

这样模型在最后看到的是一个 `user` role 消息，容易把它当成最新用户意图来响应。

如果改成 `system` role，又会在 Anthropic provider 中被合并进 top-level system prompt，影响 system prompt cache 命中。因此本次没有采用 system 注入方案。

## 修改内容

### 1. send_file 成功结果保留为标准 tool_result

`outbound_file` 不再被归一化为 assistant 文本消息。

成功发送文件后，上下文保留标准工具链路：

assistant(tool_calls=[send_file])
tool_result(name=send_file, content="File sent to current chat...")

这样模型能明确看到：

- 哪个 assistant tool_call 触发了发送
- 对应的 tool_result 内容是什么
- 文件是否发送成功
- 发送的路径和文件名是什么

同时也保证 provider transcript 顺序合法。

### 2. 移除 send_file 的本地重复发送硬拦截

删除同一 run 内基于 `file_path + file_name` 的 duplicate block。

也就是说，如果模型或用户明确要求重复发送同一个文件，系统不会再直接伪造：

This file was already sent earlier in the current agent run.

而是让 `send_file` 正常执行，并把真实工具结果交给模型判断。

这么做的原因是：重复发送是否合理应尽量由上下文和模型判断，而不是在 runner 层硬编码拦截。硬拦截容易误伤用户明确要求“连续发送三次”等场景。

### 3. 移除 send_file 的 assistant 状态提示

删除 send_file 成功后额外构造的 outbound file delivered hint / assistant 状态文本。

不再生成类似 `[outbound_file_sent]` 或其他可能被模型误当作最终回复模板的内部状态。

### 4. 调整 transient current directory 的注入位置

`[transient_current_directory]` 仍然保持为短 `user` block，避免污染 Anthropic system prompt cache。

但不再 append 到最底部，而是按结构插入：

- 如果当前 provider input 中存在最新的 `assistant(tool_calls)` + `tool_result...` 工具交换段：
  - cwd context 插入到这条 `assistant(tool_calls)` 前面。
  - 不按 tool_result 数量猜位置，而是从尾部反向定位最近的 assistant tool_call 消息。
  - 因此多个 tool_calls / 多个 tool_results 时不会插入到 tool_result 中间。

- 如果当前还没有工具交换段：
  - cwd context 插入到最后一条真实 user input 前面。

效果示例：

首轮：

user: [transient_current_directory] ...
user: 真实用户请求

工具后：

user: 真实用户请求
user: [transient_current_directory] ...
assistant(tool_calls=[...])
tool_result(...)

这样 cwd 仍然是当前 request 可见的 runtime context，但不会成为最后一条消息，也不会抢占模型对最新 tool_result 或真实用户请求的注意力。

### 5. 压缩 cwd 提示词

cwd context 改为短提示，减少干扰：

[transient_current_directory]
Runtime context only. Not a user request. Do not answer.
cwd: <current-directory>
Use only for relative file paths.

保留必要信息：

- 这是 runtime context
- 不是用户请求
- 不要直接回复它
- 当前 cwd 是什么
- 仅用于相对路径解析

## 设计取舍

### 为什么不改成 system message？

Anthropic provider 当前会把所有 `role: system` 消息合并成一个 system prompt。

如果 cwd 每轮变化且作为 system 注入，会导致 system prompt 动态变化，影响缓存命中。

所以本次保留 cwd 为 transient user block，但通过插入位置和短提示降低模型误读概率。

### 为什么不继续硬拦截重复 send_file？

硬拦截能减少部分重复发送，但会引入新的语义问题：

- 用户明确要求重复发送时会被误拦截。
- 模型看到的是伪造失败 tool_result，而不是真实执行结果。
- runner 层需要维护文件去重状态，容易和路径解析、相对/绝对路径、文件名变化产生边界问题。

本次改为保留真实 tool_result，让模型基于上下文自行判断是否继续发送。

## 测试

已覆盖：

- `send_text` 仍然保持 outbound message 折叠，不产生 tool_result 污染。
- `send_file` 成功后按普通 `assistant(tool_calls) -> tool_result` 进入上下文。
- 同一 assistant response 中多个 `send_file` tool_calls 时，多个 tool_results 顺序合法。
- `send_file` 非重试类失败不会被本地自动重试。
- cwd transient context 首轮插入到真实 user input 前。
- cwd transient context 在工具交换后插入到最新 assistant tool_call 前，而不是最后。
- cwd transient context 不进入长期 session messages。
- TypeScript 类型检查通过。

运行命令：

- `node --import tsx --test --test-concurrency=1 tests\conversation-runner-transcript-normalization.test.ts tests\tool-result-send-file-tool.test.ts tests\runtime-characterization.test.ts`
- `npx tsc --noEmit`

## 影响范围

- 修改 `ConversationRunner` 的 provider input 构造和 outbound_file transcript 处理。
- 不修改 `send_text` 的现有折叠行为。
- 不修改 `SendFileTool` 的文件发送逻辑。
- 不修改 provider 协议适配层。
- 不修改长期 session 存储逻辑。