### PR TITLE
Codex/dashboard responsive layout

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -3644,6 +3644,7 @@
       --radius-sm: 10px;
       --radius-xs: 8px;
       --dashboard-page-gutter: clamp(24px, 2.6vw, 48px);
+      --dashboard-ui-zoom: 1;
     }
 
     html {
@@ -3658,6 +3659,7 @@
     }
 
     .sidebar {
+      zoom: var(--dashboard-ui-zoom);
       left: 0;
       top: 0;
       bottom: 0;
@@ -3748,6 +3750,7 @@
     }
 
     .main-wrapper {
+      zoom: var(--dashboard-ui-zoom);
       margin-left: 240px;
       padding: 32px var(--dashboard-page-gutter);
     }
@@ -6396,7 +6399,8 @@
       const effectiveScale=Math.min(scale, dashboardFontScaleLimit());
       document.documentElement.dataset.fontScale=String(scale);
       document.documentElement.dataset.effectiveFontScale=String(effectiveScale);
-      document.body.style.zoom=effectiveScale / 100;
+      document.documentElement.style.setProperty('--dashboard-ui-zoom', String(effectiveScale / 100));
+      document.body.style.zoom='';
       if(persist){
         try{localStorage.setItem(DASHBOARD_FONT_SCALE_KEY, String(scale));}catch(_e){}
       }

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -3748,6 +3748,50 @@
       margin-top: 10px;
     }
 
+    .font-scale-control {
+      margin-top: 12px;
+      padding: 10px;
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      background: var(--surface-muted);
+    }
+
+    .font-scale-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+      color: var(--text2);
+      font-size: 12px;
+      font-weight: 800;
+      margin-bottom: 8px;
+    }
+
+    .font-scale-row output {
+      color: var(--text);
+      font-variant-numeric: tabular-nums;
+    }
+
+    .font-scale-slider {
+      width: 100%;
+      accent-color: var(--accent);
+      cursor: pointer;
+    }
+
+    .font-scale-control.mini {
+      display: none;
+      padding: 0;
+      border: 0;
+      background: transparent;
+    }
+
+    .font-scale-btn {
+      width: 100%;
+      min-height: 34px;
+      padding: 0;
+      border-radius: 8px;
+    }
+
     .main-wrapper {
       margin-left: 240px;
       padding: 32px var(--dashboard-page-gutter);
@@ -4212,6 +4256,14 @@
         min-height: calc(100vh - 32px);
       }
 
+      body.chat-active .font-scale-control {
+        display: none;
+      }
+
+      body.chat-active .font-scale-control.mini {
+        display: block;
+      }
+
       .sidebar {
         border-right: 0;
         border-bottom: 1px solid var(--border);
@@ -4232,6 +4284,58 @@
         width: min(292px, calc(100vw - 24px));
       }
     }
+
+    .sidebar-brand-text { font-size: 0.9375rem; }
+    .sidebar-brand-ver,
+    .sidebar-footer-info,
+    .chat-code-label { font-size: 0.6875rem; }
+    .nav-item,
+    .btn,
+    .config-input,
+    .config-select,
+    .runtime-note,
+    .runtime-field-label,
+    .runtime-field-value,
+    .settings-meta,
+    .settings-step-title,
+    .profile-summary-value,
+    .model-source-copy,
+    .status-dot,
+    .tag { font-size: 0.8125rem; }
+    .font-scale-row,
+    .chat-muted,
+    .chat-step-row,
+    .chat-step-row strong,
+    .chat-status-row,
+    .chat-status-row strong,
+    .readiness-summary,
+    .readiness-check,
+    .skill-meta,
+    .skill-desc,
+    .skill-files,
+    .status-card .label,
+    .run-summary-label { font-size: 0.75rem; }
+    .section-title,
+    .section-header h2 { font-size: 1.375rem; }
+    .run-summary-title { font-size: 1.5rem; }
+    .status-card .value,
+    .overview-card .ov-value { font-size: 1.25rem; }
+    .svc-name,
+    .chat-connect h3,
+    .chat-window-title { font-size: 1rem; }
+    .readiness-title,
+    .settings-setup-title,
+    .model-source-title,
+    .config-group-title { font-size: 0.9375rem; }
+    .chat-message { font-size: 1rem; }
+    .chat-message-meta,
+    .chat-upload-info small { font-size: 0.75rem; }
+    .chat-markdown h1 { font-size: 1.25rem; }
+    .chat-markdown h2 { font-size: 1.125rem; }
+    .chat-markdown h3 { font-size: 1rem; }
+    .chat-markdown pre code { font-size: 0.8125rem; }
+    .chat-markdown table { font-size: 0.875rem; }
+    .chat-input-bar textarea { font-size: 0.9375rem; }
 
   </style>
 </head>
@@ -4268,6 +4372,13 @@
         <span id="footer-platform">-</span><br/>
         <span id="footer-node">-</span>
         <button class="btn sidebar-update-btn" id="sidebar-update-btn" onclick="showUpdateModal(true)">检查更新</button>
+        <div class="font-scale-control">
+          <div class="font-scale-row"><span>字号</span><output id="font-scale-value">100%</output></div>
+          <input class="font-scale-slider" id="font-scale-slider" type="range" min="85" max="150" step="5" value="100" aria-label="调整字号" oninput="setDashboardFontScale(this.value)" />
+        </div>
+        <div class="font-scale-control mini">
+          <button class="btn font-scale-btn" type="button" onclick="cycleDashboardFontScale()" title="调整字号" aria-label="调整字号">A</button>
+        </div>
       </div>
     </div>
   </aside>
@@ -4666,6 +4777,11 @@
     const PET_PROFILE_KEY = 'xiaoba.petProfile';
     const PET_PROCESS_KEY = 'xiaoba.petProcess';
     const PET_POSITION_KEY = 'xiaoba.petPosition';
+    const DASHBOARD_FONT_SCALE_KEY = 'xiaoba.dashboardFontScale';
+    const DASHBOARD_FONT_SCALE_MIN = 85;
+    const DASHBOARD_FONT_SCALE_MAX = 150;
+    const DASHBOARD_FONT_SCALE_STEP = 5;
+    const DASHBOARD_FONT_SCALE_DEFAULT = 100;
     const petUnlocks = [
       { level: 2, title: '专注表情', meta: '更多 thinking 动态' },
       { level: 4, title: 'CatsCo 皮肤', meta: '浅色工作台主题' },
@@ -6289,6 +6405,72 @@
       try{const r=await fetch(API+'/api/config',{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify(updates)});const d=await r.json();if(d.ok){const s=document.getElementById('config-saved');s.classList.add('show');setTimeout(()=>s.classList.remove('show'),2000);}}catch(e){alert('保存失败: '+e.message);}
     }
 
+    function normalizeDashboardFontScale(value){
+      const numeric=Number(value);
+      const safe=Number.isFinite(numeric)?numeric:DASHBOARD_FONT_SCALE_DEFAULT;
+      const stepped=Math.round(safe/DASHBOARD_FONT_SCALE_STEP)*DASHBOARD_FONT_SCALE_STEP;
+      return Math.min(DASHBOARD_FONT_SCALE_MAX, Math.max(DASHBOARD_FONT_SCALE_MIN, stepped));
+    }
+
+    function applyDashboardFontScale(value, persist=true){
+      const scale=normalizeDashboardFontScale(value);
+      document.documentElement.style.fontSize=scale+'%';
+      document.documentElement.dataset.fontScale=String(scale);
+      const slider=document.getElementById('font-scale-slider');
+      const output=document.getElementById('font-scale-value');
+      const mini=document.querySelector('.font-scale-btn');
+      if(slider)slider.value=String(scale);
+      if(output)output.textContent=scale+'%';
+      if(mini){
+        mini.title='调整字号：'+scale+'%';
+        mini.setAttribute('aria-label','调整字号：'+scale+'%');
+      }
+      if(persist){
+        try{localStorage.setItem(DASHBOARD_FONT_SCALE_KEY, String(scale));}catch(_e){}
+      }
+      return scale;
+    }
+
+    function loadDashboardFontScale(){
+      let stored='';
+      try{stored=localStorage.getItem(DASHBOARD_FONT_SCALE_KEY)||'';}catch(_e){}
+      return applyDashboardFontScale(stored||DASHBOARD_FONT_SCALE_DEFAULT, false);
+    }
+
+    function setDashboardFontScale(value){
+      applyDashboardFontScale(value, true);
+    }
+
+    function stepDashboardFontScale(direction){
+      const current=normalizeDashboardFontScale(document.documentElement.dataset.fontScale||DASHBOARD_FONT_SCALE_DEFAULT);
+      return applyDashboardFontScale(current + direction * DASHBOARD_FONT_SCALE_STEP, true);
+    }
+
+    function cycleDashboardFontScale(){
+      const current=normalizeDashboardFontScale(document.documentElement.dataset.fontScale||DASHBOARD_FONT_SCALE_DEFAULT);
+      const next=current>=140?DASHBOARD_FONT_SCALE_DEFAULT:current+10;
+      applyDashboardFontScale(next, true);
+    }
+
+    function handleDashboardFontScaleShortcut(event){
+      if(!event.ctrlKey || event.altKey || event.metaKey)return;
+      const key=event.key;
+      if(key==='+' || key==='=' || key==='Add'){
+        event.preventDefault();
+        stepDashboardFontScale(1);
+        return;
+      }
+      if(key==='-' || key==='_' || key==='Subtract'){
+        event.preventDefault();
+        stepDashboardFontScale(-1);
+        return;
+      }
+      if(key==='0' || key===')'){
+        event.preventDefault();
+        applyDashboardFontScale(DASHBOARD_FONT_SCALE_DEFAULT, true);
+      }
+    }
+
     // === CatsCo Chat ===
     function escapeHtml(value){
       return String(value ?? '').replace(/[&<>"']/g, ch => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[ch]));
@@ -7636,6 +7818,7 @@
     }
 
     // Init
+    loadDashboardFontScale();
     preloadPetFrames();renderPetProfile();renderPetProcess();initFloatingPetDrag();setPetState('idle');
     setupEnvConfigLazyLoad();fetchStatus();fetchSkills();fetchDashboardSettings();fetchRuntimeConfig();fetchUpdateStatus(true);fetchCatsStatus();
     if(document.getElementById('page-chat')?.classList.contains('active') && !catsPollTimer) catsPollTimer = setInterval(fetchCatsStatus, 5000);
@@ -7655,6 +7838,7 @@
     catsMessageInput.addEventListener('focus',()=>setPetState('typing', { message:'准备输入' }));
     catsMessageInput.addEventListener('blur',()=>{if(!catsMessageInput.value.trim()) setPetAutoBaseline(petAutoBaseline);});
     setupCatsAttachmentInputs();
+    document.addEventListener('keydown',handleDashboardFontScaleShortcut);
     document.addEventListener('keydown',e=>{if(e.key==='Escape'){closeLogs();closeUpdateModal();closeCatsMediaPreview();}});
     document.addEventListener('click',e=>{const shell=document.getElementById('floating-pet');if(shell && !shell.contains(e.target)) closeFloatingPetMenu();});
   </script>

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -2828,9 +2828,7 @@
 
     .chat-timeline-inner {
       width: 100%;
-      max-width: 1120px;
-      margin: 0 auto;
-      padding: 18px 24px 24px;
+      padding: 20px clamp(24px, 3vw, 56px) 28px;
       display: flex;
       flex-direction: column;
       gap: 2px;
@@ -2841,7 +2839,7 @@
       gap: 14px;
       max-width: 100%;
       padding: 10px 18px;
-      font-size: 15px;
+      font-size: 16px;
       line-height: 1.62;
       word-break: break-word;
       color: #d8dbe2;
@@ -2902,12 +2900,12 @@
       display: flex;
       flex-direction: column;
       align-items: flex-start;
-      max-width: min(1040px, calc(100% - 50px));
+      max-width: min(1360px, calc(100% - 50px));
     }
 
     .chat-message.mine .chat-message-body {
       align-items: flex-end;
-      max-width: min(760px, 86%);
+      max-width: min(920px, 78%);
     }
 
     .chat-message-content {
@@ -2965,9 +2963,9 @@
       line-height: 1.3;
     }
 
-    .chat-markdown h1 { font-size: 18px; }
-    .chat-markdown h2 { font-size: 16px; }
-    .chat-markdown h3 { font-size: 15px; }
+    .chat-markdown h1 { font-size: 20px; }
+    .chat-markdown h2 { font-size: 18px; }
+    .chat-markdown h3 { font-size: 16px; }
 
     .chat-markdown ul,
     .chat-markdown ol {
@@ -3010,7 +3008,7 @@
       background: transparent;
       padding: 0;
       color: inherit;
-      font-size: 12px;
+      font-size: 13px;
       line-height: 1.55;
     }
 
@@ -3044,7 +3042,7 @@
       width: 100%;
       min-width: 360px;
       border-collapse: collapse;
-      font-size: 13px;
+      font-size: 14px;
       line-height: 1.45;
     }
 
@@ -3645,6 +3643,8 @@
       --radius: 12px;
       --radius-sm: 10px;
       --radius-xs: 8px;
+      --dashboard-content-max: 1680px;
+      --dashboard-page-gutter: clamp(24px, 2.6vw, 48px);
     }
 
     html {
@@ -3750,11 +3750,11 @@
 
     .main-wrapper {
       margin-left: 240px;
-      padding: 32px 24px;
+      padding: 32px var(--dashboard-page-gutter);
     }
 
     .page-content {
-      width: min(1120px, 100%);
+      width: min(var(--dashboard-content-max), 100%);
       margin: 0 auto;
       padding: 0 0 32px;
     }

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -3748,50 +3748,6 @@
       margin-top: 10px;
     }
 
-    .font-scale-control {
-      margin-top: 12px;
-      padding: 10px;
-      border: 1px solid var(--border);
-      border-radius: 10px;
-      background: var(--surface-muted);
-    }
-
-    .font-scale-row {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 8px;
-      color: var(--text2);
-      font-size: 12px;
-      font-weight: 800;
-      margin-bottom: 8px;
-    }
-
-    .font-scale-row output {
-      color: var(--text);
-      font-variant-numeric: tabular-nums;
-    }
-
-    .font-scale-slider {
-      width: 100%;
-      accent-color: var(--accent);
-      cursor: pointer;
-    }
-
-    .font-scale-control.mini {
-      display: none;
-      padding: 0;
-      border: 0;
-      background: transparent;
-    }
-
-    .font-scale-btn {
-      width: 100%;
-      min-height: 34px;
-      padding: 0;
-      border-radius: 8px;
-    }
-
     .main-wrapper {
       margin-left: 240px;
       padding: 32px var(--dashboard-page-gutter);
@@ -4256,14 +4212,6 @@
         min-height: calc(100vh - 32px);
       }
 
-      body.chat-active .font-scale-control {
-        display: none;
-      }
-
-      body.chat-active .font-scale-control.mini {
-        display: block;
-      }
-
       .sidebar {
         border-right: 0;
         border-bottom: 1px solid var(--border);
@@ -4302,7 +4250,6 @@
     .model-source-copy,
     .status-dot,
     .tag { font-size: 0.8125rem; }
-    .font-scale-row,
     .chat-muted,
     .chat-step-row,
     .chat-step-row strong,
@@ -4372,13 +4319,6 @@
         <span id="footer-platform">-</span><br/>
         <span id="footer-node">-</span>
         <button class="btn sidebar-update-btn" id="sidebar-update-btn" onclick="showUpdateModal(true)">检查更新</button>
-        <div class="font-scale-control">
-          <div class="font-scale-row"><span>字号</span><output id="font-scale-value">100%</output></div>
-          <input class="font-scale-slider" id="font-scale-slider" type="range" min="85" max="150" step="5" value="100" aria-label="调整字号" oninput="setDashboardFontScale(this.value)" />
-        </div>
-        <div class="font-scale-control mini">
-          <button class="btn font-scale-btn" type="button" onclick="cycleDashboardFontScale()" title="调整字号" aria-label="调整字号">A</button>
-        </div>
       </div>
     </div>
   </aside>
@@ -6416,15 +6356,6 @@
       const scale=normalizeDashboardFontScale(value);
       document.documentElement.style.fontSize=scale+'%';
       document.documentElement.dataset.fontScale=String(scale);
-      const slider=document.getElementById('font-scale-slider');
-      const output=document.getElementById('font-scale-value');
-      const mini=document.querySelector('.font-scale-btn');
-      if(slider)slider.value=String(scale);
-      if(output)output.textContent=scale+'%';
-      if(mini){
-        mini.title='调整字号：'+scale+'%';
-        mini.setAttribute('aria-label','调整字号：'+scale+'%');
-      }
       if(persist){
         try{localStorage.setItem(DASHBOARD_FONT_SCALE_KEY, String(scale));}catch(_e){}
       }
@@ -6437,19 +6368,9 @@
       return applyDashboardFontScale(stored||DASHBOARD_FONT_SCALE_DEFAULT, false);
     }
 
-    function setDashboardFontScale(value){
-      applyDashboardFontScale(value, true);
-    }
-
     function stepDashboardFontScale(direction){
       const current=normalizeDashboardFontScale(document.documentElement.dataset.fontScale||DASHBOARD_FONT_SCALE_DEFAULT);
       return applyDashboardFontScale(current + direction * DASHBOARD_FONT_SCALE_STEP, true);
-    }
-
-    function cycleDashboardFontScale(){
-      const current=normalizeDashboardFontScale(document.documentElement.dataset.fontScale||DASHBOARD_FONT_SCALE_DEFAULT);
-      const next=current>=140?DASHBOARD_FONT_SCALE_DEFAULT:current+10;
-      applyDashboardFontScale(next, true);
     }
 
     function handleDashboardFontScaleShortcut(event){

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -3643,7 +3643,6 @@
       --radius: 12px;
       --radius-sm: 10px;
       --radius-xs: 8px;
-      --dashboard-content-max: 1680px;
       --dashboard-page-gutter: clamp(24px, 2.6vw, 48px);
     }
 
@@ -3754,8 +3753,9 @@
     }
 
     .page-content {
-      width: min(var(--dashboard-content-max), 100%);
-      margin: 0 auto;
+      width: 100%;
+      max-width: none;
+      margin: 0;
       padding: 0 0 32px;
     }
 
@@ -4175,6 +4175,14 @@
       background: var(--surface-muted);
     }
 
+    @media (max-width: 780px) {
+      body:not(.chat-active) .companion-hero,
+      body:not(.chat-active) .companion-metrics,
+      body:not(.chat-active) .companion-unlocks {
+        grid-template-columns: 1fr;
+      }
+    }
+
     @media (max-width: 900px) {
       .sidebar {
         width: 68px;
@@ -4186,6 +4194,31 @@
     }
 
     @media (max-width: 640px) {
+      body:not(.chat-active) {
+        display: block;
+      }
+
+      body:not(.chat-active) .sidebar {
+        position: static;
+        width: 100%;
+        min-height: auto;
+        padding: 12px;
+        border-right: 0;
+        border-bottom: 1px solid var(--border);
+      }
+
+      body:not(.chat-active) .main-wrapper {
+        margin-left: 0;
+        padding: 16px 12px;
+      }
+
+      body:not(.chat-active) .page-content {
+        width: 100%;
+        max-width: none;
+        margin: 0;
+        min-height: auto;
+      }
+
       body.chat-active .sidebar {
         position: fixed;
         left: 0;
@@ -6352,10 +6385,18 @@
       return Math.min(DASHBOARD_FONT_SCALE_MAX, Math.max(DASHBOARD_FONT_SCALE_MIN, stepped));
     }
 
+    function dashboardFontScaleLimit(){
+      if(window.matchMedia('(max-width: 640px)').matches)return 120;
+      if(window.matchMedia('(max-width: 900px)').matches)return 135;
+      return DASHBOARD_FONT_SCALE_MAX;
+    }
+
     function applyDashboardFontScale(value, persist=true){
       const scale=normalizeDashboardFontScale(value);
-      document.documentElement.style.fontSize=scale+'%';
+      const effectiveScale=Math.min(scale, dashboardFontScaleLimit());
       document.documentElement.dataset.fontScale=String(scale);
+      document.documentElement.dataset.effectiveFontScale=String(effectiveScale);
+      document.body.style.zoom=effectiveScale / 100;
       if(persist){
         try{localStorage.setItem(DASHBOARD_FONT_SCALE_KEY, String(scale));}catch(_e){}
       }
@@ -6390,6 +6431,10 @@
         event.preventDefault();
         applyDashboardFontScale(DASHBOARD_FONT_SCALE_DEFAULT, true);
       }
+    }
+
+    function refreshDashboardFontScaleForViewport(){
+      applyDashboardFontScale(document.documentElement.dataset.fontScale||DASHBOARD_FONT_SCALE_DEFAULT, false);
     }
 
     // === CatsCo Chat ===
@@ -7760,6 +7805,7 @@
     catsMessageInput.addEventListener('blur',()=>{if(!catsMessageInput.value.trim()) setPetAutoBaseline(petAutoBaseline);});
     setupCatsAttachmentInputs();
     document.addEventListener('keydown',handleDashboardFontScaleShortcut);
+    window.addEventListener('resize',refreshDashboardFontScaleForViewport);
     document.addEventListener('keydown',e=>{if(e.key==='Escape'){closeLogs();closeUpdateModal();closeCatsMediaPreview();}});
     document.addEventListener('click',e=>{const shell=document.getElementById('floating-pet');if(shell && !shell.contains(e.target)) closeFloatingPetMenu();});
   </script>

--- a/tests/dashboard-productization-html.test.ts
+++ b/tests/dashboard-productization-html.test.ts
@@ -157,11 +157,21 @@ test('dashboard supports hidden persistent font scaling shortcuts', () => {
   assert.doesNotMatch(dashboardHtml, /font-scale-control/);
   assert.match(dashboardHtml, /DASHBOARD_FONT_SCALE_KEY = 'xiaoba\.dashboardFontScale'/);
   assert.match(dashboardHtml, /function applyDashboardFontScale\(value, persist=true\)/);
-  assert.match(dashboardHtml, /document\.documentElement\.style\.fontSize=scale\+'%'/);
+  assert.match(dashboardHtml, /function dashboardFontScaleLimit\(\)/);
+  assert.match(dashboardHtml, /document\.body\.style\.zoom=effectiveScale \/ 100/);
   assert.match(dashboardHtml, /function handleDashboardFontScaleShortcut\(event\)/);
   assert.match(dashboardHtml, /key==='\+' \|\| key==='=' \|\| key==='Add'/);
   assert.match(dashboardHtml, /key==='-' \|\| key==='_'\s*\|\| key==='Subtract'/);
   assert.match(dashboardHtml, /key==='0' \|\| key==='\)'/);
   assert.match(dashboardHtml, /loadDashboardFontScale\(\);/);
   assert.match(dashboardHtml, /document\.addEventListener\('keydown',handleDashboardFontScaleShortcut\)/);
+  assert.match(dashboardHtml, /window\.addEventListener\('resize',refreshDashboardFontScaleForViewport\)/);
+});
+
+test('dashboard non-chat pages use the full available work area', () => {
+  assert.doesNotMatch(dashboardHtml, /--dashboard-content-max/);
+  assert.match(dashboardHtml, /\.page-content \{\s*width: 100%;\s*max-width: none;\s*margin: 0;/);
+  assert.match(dashboardHtml, /body:not\(\.chat-active\) \.sidebar \{\s*position: static;\s*width: 100%;\s*min-height: auto;/);
+  assert.match(dashboardHtml, /body:not\(\.chat-active\) \.main-wrapper \{\s*margin-left: 0;/);
+  assert.match(dashboardHtml, /@media \(max-width: 780px\) \{\s*body:not\(\.chat-active\) \.companion-hero,/);
 });

--- a/tests/dashboard-productization-html.test.ts
+++ b/tests/dashboard-productization-html.test.ts
@@ -151,9 +151,10 @@ test('CatsCo Chat preserves fallback tool metadata for WORKING rendering', () =>
   assert.match(workingBlock, /metadata\.step_count\?metadata\.step_count\+' 步'/);
 });
 
-test('dashboard exposes persistent font scaling controls and shortcuts', () => {
-  assert.match(dashboardHtml, /id="font-scale-slider"[^>]*min="85"[^>]*max="150"[^>]*oninput="setDashboardFontScale\(this\.value\)"/);
-  assert.match(dashboardHtml, /id="font-scale-value"/);
+test('dashboard supports hidden persistent font scaling shortcuts', () => {
+  assert.doesNotMatch(dashboardHtml, /id="font-scale-slider"/);
+  assert.doesNotMatch(dashboardHtml, /id="font-scale-value"/);
+  assert.doesNotMatch(dashboardHtml, /font-scale-control/);
   assert.match(dashboardHtml, /DASHBOARD_FONT_SCALE_KEY = 'xiaoba\.dashboardFontScale'/);
   assert.match(dashboardHtml, /function applyDashboardFontScale\(value, persist=true\)/);
   assert.match(dashboardHtml, /document\.documentElement\.style\.fontSize=scale\+'%'/);

--- a/tests/dashboard-productization-html.test.ts
+++ b/tests/dashboard-productization-html.test.ts
@@ -158,7 +158,11 @@ test('dashboard supports hidden persistent font scaling shortcuts', () => {
   assert.match(dashboardHtml, /DASHBOARD_FONT_SCALE_KEY = 'xiaoba\.dashboardFontScale'/);
   assert.match(dashboardHtml, /function applyDashboardFontScale\(value, persist=true\)/);
   assert.match(dashboardHtml, /function dashboardFontScaleLimit\(\)/);
-  assert.match(dashboardHtml, /document\.body\.style\.zoom=effectiveScale \/ 100/);
+  assert.match(dashboardHtml, /--dashboard-ui-zoom: 1/);
+  assert.match(dashboardHtml, /\.sidebar \{\s*zoom: var\(--dashboard-ui-zoom\);/);
+  assert.match(dashboardHtml, /\.main-wrapper \{\s*zoom: var\(--dashboard-ui-zoom\);/);
+  assert.match(dashboardHtml, /document\.documentElement\.style\.setProperty\('--dashboard-ui-zoom', String\(effectiveScale \/ 100\)\)/);
+  assert.match(dashboardHtml, /document\.body\.style\.zoom=''/);
   assert.match(dashboardHtml, /function handleDashboardFontScaleShortcut\(event\)/);
   assert.match(dashboardHtml, /key==='\+' \|\| key==='=' \|\| key==='Add'/);
   assert.match(dashboardHtml, /key==='-' \|\| key==='_'\s*\|\| key==='Subtract'/);

--- a/tests/dashboard-productization-html.test.ts
+++ b/tests/dashboard-productization-html.test.ts
@@ -150,3 +150,17 @@ test('CatsCo Chat preserves fallback tool metadata for WORKING rendering', () =>
   assert.match(workingBlock, /metadata\.status\|\|tool\.input\?\.status/);
   assert.match(workingBlock, /metadata\.step_count\?metadata\.step_count\+' 步'/);
 });
+
+test('dashboard exposes persistent font scaling controls and shortcuts', () => {
+  assert.match(dashboardHtml, /id="font-scale-slider"[^>]*min="85"[^>]*max="150"[^>]*oninput="setDashboardFontScale\(this\.value\)"/);
+  assert.match(dashboardHtml, /id="font-scale-value"/);
+  assert.match(dashboardHtml, /DASHBOARD_FONT_SCALE_KEY = 'xiaoba\.dashboardFontScale'/);
+  assert.match(dashboardHtml, /function applyDashboardFontScale\(value, persist=true\)/);
+  assert.match(dashboardHtml, /document\.documentElement\.style\.fontSize=scale\+'%'/);
+  assert.match(dashboardHtml, /function handleDashboardFontScaleShortcut\(event\)/);
+  assert.match(dashboardHtml, /key==='\+' \|\| key==='=' \|\| key==='Add'/);
+  assert.match(dashboardHtml, /key==='-' \|\| key==='_'\s*\|\| key==='Subtract'/);
+  assert.match(dashboardHtml, /key==='0' \|\| key==='\)'/);
+  assert.match(dashboardHtml, /loadDashboardFontScale\(\);/);
+  assert.match(dashboardHtml, /document\.addEventListener\('keydown',handleDashboardFontScaleShortcut\)/);
+});


### PR DESCRIPTION
## 背景
当前 Dashboard 在大屏上内容集中在页面中间的一小块区域：普通功能页被固定在约 1120px 宽度，聊天页的消息时间线也被限制在 1120px，导致字体和聊天内容看起来偏小，页面空间利用不足。

## 改动
- 将 Dashboard 普通页面内容区最大宽度放宽到 1680px。
- 使用响应式页面边距，让功能页在大屏上更像工作台而不是窄阅读栏。
- 移除聊天消息时间线的 1120px 居中限制，让聊天区域随主面板扩展。
- 放宽助手消息和用户消息的最大宽度。
- 稍微放大聊天正文、标题、代码块和表格字号，提升可读性。
- 移除普通功能页的固定最大宽度，让内容铺满主工作区
- 将隐藏的 Ctrl + / Ctrl - / Ctrl 0 缩放改为作用于整个 Dashboard
- 小屏下限制缩放上限，避免放大后横向溢出
- 修复普通页移动端侧栏布局和伙伴页窄屏网格溢出
- 增加布局与隐藏缩放快捷键相关测试

## 验证
- dashboard-productization-html.test.ts：11 项通过
- git diff --check：通过
- 已检查宽屏、窄屏和快捷键放大后的页面尺寸表现
