### PR TITLE
区分 macOS 安装包架构命名

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -5414,7 +5414,10 @@
       if (!baseUrl || !version || !platform) return "";
 
       if (platform === "win32") return `${baseUrl}/CatsCo-${version}-win.exe`;
-      if (platform === "darwin") return `${baseUrl}/CatsCo-${version}-mac.dmg`;
+      if (platform === "darwin") {
+        const arch = appStatusSnapshot.arch || "";
+        return arch ? `${baseUrl}/CatsCo-${version}-mac-${arch}.dmg` : "";
+      }
       if (platform === "linux") return `${baseUrl}/CatsCo-${version}-linux.AppImage`;
       return "";
     }

--- a/package.json
+++ b/package.json
@@ -148,8 +148,8 @@
       "target": [
         "dmg"
       ],
-      "icon": "build-resources/icon.png",
-      "artifactName": "${productName}-${version}-mac.${ext}"
+      "icon": "build-resources/icons/icon.icns",
+      "artifactName": "${productName}-${version}-mac-${arch}.${ext}"
     },
     "win": {
       "target": [

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -352,6 +352,7 @@ export function createApiRouter(serviceManager: ServiceManager, updateController
       version: APP_VERSION,
       hostname: os.hostname(),
       platform: os.platform(),
+      arch: os.arch(),
       nodeVersion: process.version,
       model: config.model,
       provider: config.provider,


### PR DESCRIPTION
## 这次改动

- macOS 安装包 artifact 名称加入架构后缀：`CatsCo-${version}-mac-${arch}.dmg`。
- `/api/status` 返回当前运行架构 `arch`，桌面端手动安装包地址可以区分 x64 / arm64。
- dashboard 手动安装包 fallback URL 改为按当前架构生成，避免新命名下找不到 mac 下载包。

## 针对 review comment 的处理

- 修复 artifactName 改名后，手动安装包 fallback 仍指向 `CatsCo-${version}-mac.dmg` 的问题。
- 补充 `arch` 给前端，避免前端只能猜 mac 包名。

## 验证

- `npm.cmd run build`
- `npm.cmd run release:check`
- `git diff --check`（仅 CRLF warning）
