### PR TITLE
[codex] 接入 CatsCo 中转模型配置

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -2465,6 +2465,7 @@
       border-radius: 18px;
       box-shadow: var(--shadow-sm), var(--glow);
       overflow: hidden;
+      min-height: 0;
     }
 
     .chat-connect {
@@ -2473,9 +2474,13 @@
       gap: 12px;
       align-content: start;
       min-width: 0;
+      height: 100%;
+      min-height: 0;
       max-height: 100%;
       overflow-x: hidden;
       overflow-y: auto;
+      overscroll-behavior: contain;
+      scrollbar-gutter: stable;
       transition: padding 0.18s ease;
     }
 
@@ -2773,7 +2778,7 @@
       border: 1px solid var(--border-light);
       border-radius: 8px;
       background: rgba(255,255,255,0.54);
-      overflow: hidden;
+      overflow: visible;
     }
 
     .chat-diagnostics summary {
@@ -2800,6 +2805,7 @@
       margin-top: 0;
       border-radius: 8px;
       background: rgba(247, 249, 252, 0.9);
+      overflow: visible;
     }
 
     .chat-connect.needs-auth,
@@ -2826,7 +2832,13 @@
     .chat-advanced-body {
       display: grid;
       gap: 10px;
-      padding: 0 12px 12px;
+      padding: 0 12px 14px;
+    }
+
+    .chat-advanced-body .config-input {
+      width: 100%;
+      min-width: 0;
+      box-sizing: border-box;
     }
 
     .chat-advanced-note {
@@ -4644,7 +4656,7 @@
           <div class="settings-heading">
             <div class="settings-kicker">Settings</div>
             <div class="section-title" style="margin-bottom:0">模型来源与 Runtime Profile</div>
-            <div class="settings-meta">优先使用 CatsCo 托管模型；自定义模型和本地环境变量保留在高级区域。</div>
+            <div class="settings-meta">优先使用 CatsCo 中转模型；自定义模型和本地环境变量保留在高级区域。</div>
           </div>
           <button class="btn" onclick="refreshSettingsPage()">刷新</button>
         </div>
@@ -6205,7 +6217,7 @@
         ? firstReadinessProblem(runtimeSection)||runtimeSection.summary
         : '仅在要改显示名、工作目录或工具开关时需要打开';
       const next = modelSection?.status==='blocked'
-        ? '先补齐模型来源；当前托管模型未接入前，自定义模型是启动本地 agent 的必要配置。'
+        ? '先补齐模型来源；可登录 CatsCo 启用中转模型，或手动填写自定义模型。'
         : catscoSection?.status==='blocked'
           ? '模型已就绪后，继续登录并绑定 CatsCo Chat。'
           : catscoSection?.status==='warning'
@@ -6326,16 +6338,19 @@
       }
       const user=catsState.user||{};
       const catsConnected=isCatsLoggedIn();
-      const managedStatus=catsConnected?'待后端接入':'需要登录';
-      const managedTone=catsConnected?'warm':'gray';
-      const managedCopy=catsConnected
-        ? 'CatsCo 已登录。托管模型目录和用量服务还没有接入当前本地版本，当前请使用自定义模型启动本地 agent。'
-        : '登录 CatsCo 后，后续将直接使用 CatsCo 提供的模型目录。当前版本需要先在高级区配置自定义模型。';
       const keyField=settingField('model.apiKey');
       const credentialMeta=keyField.present
         ? '已配置访问凭证'
         : '未配置访问凭证';
       const apiBaseValue=settingValue('model.apiBase');
+      const relayConfigured=isCatsRelayModelGateway(apiBaseValue)&&keyField.present;
+      const managedStatus=relayConfigured?'已启用':catsConnected?'可启用':'需要登录';
+      const managedTone=relayConfigured?'green':catsConnected?'warm':'gray';
+      const managedCopy=relayConfigured
+        ? '当前已使用 CatsCo 中转模型。默认推荐 Anthropic-compatible，和 CatsCo runtime 的工具调用链路更贴近。'
+        : catsConnected
+          ? '已登录 CatsCo。可以一键生成或复用你的中转 Key，并写入本机模型配置；也可以继续使用下方自定义模型。'
+          : '登录 CatsCo 后，可以一键启用 CatsCo 中转模型。当前版本仍可先在高级区配置自定义模型。';
       const hideInternalGateway=isInternalModelGateway(apiBaseValue);
       const apiBaseDisplayValue=hideInternalGateway?'':apiBaseValue;
       const apiBasePlaceholder=hideInternalGateway?'已配置 CatsCo 内部兼容网关（隐藏）':'https://example.com/v1/messages';
@@ -6349,26 +6364,29 @@
           </span>
         </div>
         <div class="config-group-body model-source-layout">
-          <div class="runtime-note">普通用户优先确认这里：托管模型后端接入前，自定义模型是当前可运行路径；保存后影响新 session 或下一次启动的 connector。</div>
+          <div class="runtime-note">普通用户优先确认这里：推荐启用 CatsCo 中转模型；也可以手动填写第三方自定义模型。保存后影响新 session 或下一次启动的 connector。</div>
           <div class="model-source-grid">
             <div class="model-source-card primary">
               <div class="model-source-head">
                 <div>
-                  <div class="model-source-title">CatsCo 托管模型</div>
+                  <div class="model-source-title">CatsCo 中转模型</div>
                   <div class="model-source-copy">${managedCopy}</div>
                 </div>
                 ${runtimeTag(managedStatus, managedTone)}
               </div>
               <div class="model-source-actions">
                 <button class="btn" onclick="switchPage('chat')">${catsConnected?'查看 CatsCo 连接':'登录 CatsCo'}</button>
+                <button class="btn btn-primary" ${catsConnected?'':'disabled'} onclick="enableCatsRelayModel('anthropic')">启用 CatsCo 中转</button>
+                <button class="btn" ${catsConnected?'':'disabled'} onclick="enableCatsRelayModel('openai')">改用 OpenAI 兼容</button>
               </div>
+              <div id="relay-model-status" style="color:var(--text2);font-size:13px;margin-top:10px">${relayConfigured?'当前中转配置已写入本机。':'启用后会写入本机 .env，保存后新 session 或下一次启动 connector 生效。'}</div>
             </div>
             <details class="model-source-card warning" id="custom-model-settings"${customModelSettingsOpen?' open':''}>
               <summary>
                 <div class="model-source-head">
                   <div>
-                    <div class="model-source-title">自定义模型（当前需要）</div>
-                    <div class="model-source-copy">托管模型未接入前，启动本地 agent 需要这里的模型地址、模型名称和访问凭证。修改会自动保存，访问凭证只保存 presence，不会回显。</div>
+                    <div class="model-source-title">自定义模型（手动配置）</div>
+                    <div class="model-source-copy">手动接入第三方模型时填写这里的模型地址、模型名称和访问凭证。修改会自动保存，访问凭证只保存 presence，不会回显。</div>
                   </div>
                   ${runtimeTag(credentialMeta, keyField.present?'green':'red')}
                 </div>
@@ -6406,8 +6424,23 @@
       }
     }
 
+    function isCatsRelayModelGateway(value){
+      try{
+        return new URL(value).hostname.toLowerCase()==='relay.catsco.cc';
+      }catch(_e){
+        return String(value||'').toLowerCase().includes('relay.catsco.cc');
+      }
+    }
+
     function setModelSourceStatus(message, tone){
       const status=document.getElementById('model-source-status');
+      if(!status)return;
+      status.style.color=tone==='error'?'var(--red)':tone==='success'?'var(--green)':'var(--text2)';
+      status.textContent=message;
+    }
+
+    function setRelayModelStatus(message, tone){
+      const status=document.getElementById('relay-model-status');
       if(!status)return;
       status.style.color=tone==='error'?'var(--red)':tone==='success'?'var(--green)':'var(--text2)';
       status.textContent=message;
@@ -6448,6 +6481,39 @@
         model:settings['model.model'],
         secretAction:secret.action,
       });
+    }
+
+    async function enableCatsRelayModel(protocol, options={}){
+      if(!isCatsLoggedIn()){
+        switchPage('chat');
+        return;
+      }
+      const selectedProtocol=protocol==='openai'?'openai':'anthropic';
+      const label=selectedProtocol==='openai'?'OpenAI-compatible':'Anthropic-compatible';
+      try{
+        setRelayModelStatus('正在启用 CatsCo 中转模型（'+label+'）...','muted');
+        const r=await fetch(API+'/api/cats/relay/model-config/apply',{
+          method:'POST',
+          headers:{'Content-Type':'application/json'},
+          body:JSON.stringify({
+            protocol:selectedProtocol,
+            rotateExisting:Boolean(options.rotateExisting),
+          })
+        });
+        const data=await r.json();
+        if(r.status===409&&data.action==='rotate_required'){
+          const ok=confirm('你的 CatsCo 中转 Key 已存在，但明文不会再次返回。要重新生成并写入 CatsCo 桌面端吗？旧 Key 会立即失效。');
+          if(ok)return enableCatsRelayModel(selectedProtocol,{rotateExisting:true});
+          setRelayModelStatus('已取消。你也可以在 CatsCompany 中转站页面复制现有配置后手动填写。','muted');
+          return;
+        }
+        if(!r.ok||data.error)throw new Error(data.error||'启用中转失败');
+        await Promise.all([fetchDashboardSettings(),fetchStatus(),fetchRuntimeConfig(),fetchReadiness(),fetchCatsStatus()]);
+        setRelayModelStatus(data.message||('已启用 CatsCo 中转模型：'+label),'success');
+        setModelSourceStatus('已写入 CatsCo 中转模型配置。新 session 或下一次启动 connector 后生效。','success');
+      }catch(e){
+        setRelayModelStatus('启用失败：'+(e.message||String(e)),'error');
+      }
     }
 
     function bindCustomModelAutoSave(){
@@ -6496,17 +6562,21 @@
       }
       const sensitive=secretUpdate.action!=='keep';
       const message=sensitive
-        ? '保存自定义模型设置？访问凭证会写入本地 .env，仅用于本机 runtime。保存后新 session 或下一次启动的 connector 生效。'
-        : '保存自定义模型设置？保存后新 session 或下一次启动的 connector 生效。';
+        ? '保存自定义模型设置？访问凭证会写入本地 .env，仅用于本机 runtime。若 CatsCo agent 正在运行，会请求重启以使用新配置。'
+        : '保存自定义模型设置？若 CatsCo agent 正在运行，会请求重启以使用新配置。';
       if(!auto && !confirm(message))return;
       try{
         customModelAutoSaveInFlight=true;
         setModelSourceStatus(auto?'自动保存中...':'保存中...','muted');
-        const r=await fetch(API+'/api/settings',{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload)});
+        const requestPayload={...payload,restartConnector:!auto};
+        const r=await fetch(API+'/api/settings',{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify(requestPayload)});
         const d=await r.json();
         if(!r.ok||d.error)throw new Error(d.error||'保存失败');
         customModelAutoSaveLastSignature=signature;
-        setModelSourceStatus((auto?'已自动保存。':'已保存。')+'新 session 或下一次启动 connector 后生效。','success');
+        const appliedMessage=!auto&&d.connectorRestarted
+          ? '已保存，并已请求重启 CatsCo agent 使用新配置。'
+          : (auto?'已自动保存。':'已保存。')+'新 session 或下一次启动 connector 后生效。';
+        setModelSourceStatus(appliedMessage,'success');
         const secretInput=document.getElementById('model-secret-setting');
         const clearInput=document.getElementById('model-secret-clear-setting');
         if(secretInput && secretUpdate.action==='replace'){
@@ -6519,7 +6589,7 @@
         if(!auto){
           setModelSourceStatus('已保存，正在刷新启动状态...','muted');
           await Promise.all([fetchDashboardSettings(),fetchStatus(),fetchRuntimeConfig(),fetchReadiness(),fetchCatsStatus()]);
-          setModelSourceStatus('已保存。新 session 或下一次启动 connector 后生效。','success');
+          setModelSourceStatus(d.connectorRestarted?'已保存，并已请求重启 CatsCo agent 使用新配置。':'已保存。新 session 或下一次启动 connector 后生效。','success');
         }
       }catch(e){
         setModelSourceStatus('保存失败：'+(e.message||String(e)),'error');

--- a/src/dashboard/readiness.ts
+++ b/src/dashboard/readiness.ts
@@ -160,13 +160,16 @@ function buildModelSection(
   const customReady = checks
     .filter(check => check.id.startsWith('model.custom.'))
     .every(check => check.status === 'pass');
+  const relayReady = checks.some(check => check.id === 'model.managed.relay' && check.status === 'pass');
   return {
     id: 'model',
     label: '模型来源',
     status,
-    summary: customReady
-      ? '当前使用自定义模型启动本地 agent；CatsCo 托管模型等待后端接入'
-      : 'CatsCo 托管模型尚未接入；当前需要配置自定义模型',
+    summary: relayReady
+      ? '当前使用 CatsCo 中转模型启动本地 agent'
+      : customReady
+      ? '当前使用自定义模型启动本地 agent；也可以一键切换 CatsCo 中转'
+      : '当前需要配置模型来源，可登录 CatsCo 后启用中转模型',
     checks,
     action: status === 'ready' ? undefined : { label: '打开设置', target: 'settings' },
   };
@@ -182,20 +185,27 @@ function buildModelChecks(
   const apiKey = firstNonEmpty(env.GAUZ_LLM_API_KEY, config.apiKey);
   const catsCoToken = firstNonEmpty(env.CATSCO_USER_TOKEN, env.CATSCOMPANY_USER_TOKEN);
   const catsCoUserUid = firstNonEmpty(env.CATSCO_USER_UID, env.CATSCOMPANY_USER_UID);
+  const relayConfigured = isCatsRelayModelConfigured(provider, apiBase, model, apiKey);
 
   return [
-    catsCoToken && catsCoUserUid
-      ? failCheck(
-        'model.managed.backend',
-        'CatsCo 托管模型',
-        'CatsCo 托管模型后端尚未接入；当前请使用自定义模型',
-        'warning',
-        { label: '打开设置', target: 'settings' },
+    relayConfigured
+      ? passCheck(
+        'model.managed.relay',
+        'CatsCo 中转模型',
+        `已启用 CatsCo 中转：${provider} / ${model}`,
       )
-      : failCheck(
+      : catsCoToken && catsCoUserUid
+        ? failCheck(
+          'model.managed.relay',
+          'CatsCo 中转模型',
+          '已登录 CatsCo，可在设置里一键启用 CatsCo 中转模型',
+          'warning',
+          { label: '打开设置', target: 'settings' },
+        )
+        : failCheck(
         'model.managed.account',
-        'CatsCo 托管模型',
-        '登录 CatsCo 后才可使用托管模型；当前请使用自定义模型',
+        'CatsCo 中转模型',
+        '登录 CatsCo 后才可使用中转模型；当前请使用自定义模型',
         'warning',
         { label: '打开 CatsCo', target: 'catsco' },
       ),
@@ -509,6 +519,23 @@ function resolveModelApiBase(env: NodeJS.ProcessEnv, config: ChatConfig): string
 
 function resolveModelName(env: NodeJS.ProcessEnv, config: ChatConfig): string {
   return firstNonEmpty(env.GAUZ_LLM_MODEL, config.model) || DEFAULT_MODEL_NAME;
+}
+
+function isCatsRelayModelConfigured(
+  provider: string,
+  apiBase: string,
+  model: string,
+  apiKey?: string,
+): boolean {
+  if (!apiKey || !model) return false;
+  if (provider !== 'anthropic' && provider !== 'openai') return false;
+
+  try {
+    const parsed = new URL(apiBase);
+    return parsed.hostname.toLowerCase() === 'relay.catsco.cc';
+  } catch {
+    return apiBase.toLowerCase().includes('relay.catsco.cc');
+  }
 }
 
 function summarizeRuntimeValidationIssue(issue: { path: string; message: string }): string {

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -361,11 +361,39 @@ function relayEndpointForProtocol(config: any, protocol: RelayModelProtocol): st
   return normalizeBaseUrl(endpoint?.base_url, fallback);
 }
 
+function isCatsRelayApiBase(value: unknown): boolean {
+  const text = String(value || '').trim();
+  if (!text) return false;
+  try {
+    return new URL(text).hostname.toLowerCase() === 'relay.catsco.cc';
+  } catch {
+    return text.toLowerCase().includes('relay.catsco.cc');
+  }
+}
+
 function sanitizeRelayKeyInfo(key: any): any {
   if (!key || typeof key !== 'object') return key || null;
-  const copy = { ...key };
-  delete copy.key;
-  return copy;
+  const safe: Record<string, unknown> = {};
+  for (const field of [
+    'id',
+    'name',
+    'prefix',
+    'state',
+    'created_at',
+    'createdAt',
+    'updated_at',
+    'updatedAt',
+    'revoked_at',
+    'revokedAt',
+    'last_used_at',
+    'lastUsedAt',
+  ]) {
+    const value = key[field];
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean' || value === null) {
+      safe[field] = value;
+    }
+  }
+  return safe;
 }
 
 async function fetchCatsRelayConfig(state: CatsAuthState): Promise<any> {
@@ -387,6 +415,11 @@ async function ensureCatsRelayPlainKey(
 
   if (active && currentPlainKey) {
     return { response: current, plainKey: currentPlainKey, created: false, rotated: false };
+  }
+
+  const reusableLocalKey = active ? findReusableLocalRelayKey(currentKey) : undefined;
+  if (reusableLocalKey) {
+    return { response: current, plainKey: reusableLocalKey, created: false, rotated: false };
   }
 
   if (active && !options.rotateExisting) {
@@ -412,6 +445,31 @@ async function ensureCatsRelayPlainKey(
     created: !active,
     rotated: active,
   };
+}
+
+function findReusableLocalRelayKey(currentKey: any): string | undefined {
+  const fileEnv = readEnvFile();
+  const currentConfig = ConfigManager.getConfigReadonly();
+  const apiKey = firstNonEmpty(
+    process.env.GAUZ_LLM_API_KEY,
+    fileEnv.GAUZ_LLM_API_KEY,
+    currentConfig.apiKey,
+  );
+  const apiBase = firstNonEmpty(
+    process.env.GAUZ_LLM_API_BASE,
+    fileEnv.GAUZ_LLM_API_BASE,
+    currentConfig.apiUrl,
+  );
+  if (!apiKey || !isCatsRelayApiBase(apiBase)) {
+    return undefined;
+  }
+
+  const prefix = String(currentKey?.prefix || '').trim();
+  if (prefix && !apiKey.startsWith(prefix)) {
+    return undefined;
+  }
+
+  return apiKey;
 }
 
 function sanitizeCatsErrorData(data: unknown): unknown {

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -63,6 +63,8 @@ interface CatsRequestOptions {
   timeoutMs?: number;
 }
 
+type RelayModelProtocol = 'anthropic' | 'openai';
+
 function normalizeBaseUrl(value: unknown, fallback: string): string {
   const text = String(value || '').trim().replace(/\/+$/, '');
   return text || fallback;
@@ -339,6 +341,146 @@ async function catsApiKeyRequest(
   return data;
 }
 
+function normalizeRelayModelProtocol(value: unknown): RelayModelProtocol {
+  const text = String(value || '').trim().toLowerCase();
+  return text === 'openai' ? 'openai' : 'anthropic';
+}
+
+function relayProviderForProtocol(protocol: RelayModelProtocol): 'anthropic' | 'openai' {
+  return protocol === 'openai' ? 'openai' : 'anthropic';
+}
+
+function relayEndpointForProtocol(config: any, protocol: RelayModelProtocol): string {
+  const endpoints = Array.isArray(config?.endpoints) ? config.endpoints : [];
+  const endpoint = endpoints.find((item: any) => {
+    const label = String(item?.protocol || '').toLowerCase();
+    return protocol === 'openai' ? label.includes('openai') : label.includes('anthropic');
+  });
+  const baseUrl = normalizeBaseUrl(config?.base_url, 'https://relay.catsco.cc');
+  const fallback = protocol === 'openai' ? `${baseUrl}/v1` : `${baseUrl}/anthropic`;
+  return normalizeBaseUrl(endpoint?.base_url, fallback);
+}
+
+function sanitizeRelayKeyInfo(key: any): any {
+  if (!key || typeof key !== 'object') return key || null;
+  const copy = { ...key };
+  delete copy.key;
+  return copy;
+}
+
+async function fetchCatsRelayConfig(state: CatsAuthState): Promise<any> {
+  return catsRequest('GET', state.httpBaseUrl, '/api/relay/config', undefined, state.token);
+}
+
+async function fetchCatsRelayKey(state: CatsAuthState): Promise<any> {
+  return catsRequest('GET', state.httpBaseUrl, '/api/relay/key', undefined, state.token);
+}
+
+async function ensureCatsRelayPlainKey(
+  state: CatsAuthState,
+  options: { rotateExisting?: boolean } = {},
+): Promise<{ response: any; plainKey: string; created: boolean; rotated: boolean }> {
+  const current = await fetchCatsRelayKey(state);
+  const currentKey = current?.key;
+  const active = currentKey && String(currentKey.state || 'active') === 'active';
+  const currentPlainKey = String(currentKey?.key || '').trim();
+
+  if (active && currentPlainKey) {
+    return { response: current, plainKey: currentPlainKey, created: false, rotated: false };
+  }
+
+  if (active && !options.rotateExisting) {
+    throw httpError(
+      '已有 CatsCo 中转 Key，但明文不会再次返回。请确认是否重新生成后再启用中转模型。',
+      409,
+    );
+  }
+
+  const next = active
+    ? await catsRequest('POST', state.httpBaseUrl, '/api/relay/key/rotate', {}, state.token)
+    : await catsRequest('POST', state.httpBaseUrl, '/api/relay/key', {
+      name: state.displayName || state.username || (state.uid ? `CatsCo user ${state.uid}` : 'CatsCo desktop'),
+    }, state.token);
+  const plainKey = String(next?.key?.key || '').trim();
+  if (!plainKey) {
+    throw httpError('CatsCo 中转 Key 创建成功但没有返回明文，请在 CatsCompany 中转站页面复制。', 502);
+  }
+
+  return {
+    response: next,
+    plainKey,
+    created: !active,
+    rotated: active,
+  };
+}
+
+function sanitizeCatsErrorData(data: unknown): unknown {
+  if (!data || typeof data !== 'object') return undefined;
+  const safe: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(data as Record<string, unknown>)) {
+    const lower = key.toLowerCase();
+    if (
+      lower.includes('key')
+      || lower.includes('token')
+      || lower.includes('secret')
+      || lower.includes('authorization')
+      || lower.includes('password')
+    ) {
+      continue;
+    }
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+      safe[key] = value;
+    }
+  }
+  return Object.keys(safe).length > 0 ? safe : undefined;
+}
+
+function sanitizeCatsErrorMessage(value: unknown): string {
+  return String(value || '请求失败')
+    .replace(/cats_svc_[A-Za-z0-9_-]+/g, '[redacted-token]')
+    .replace(/sk-[A-Za-z0-9_-]{8,}/g, '[redacted-key]')
+    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer [redacted-token]');
+}
+
+function catsErrorResponse(error: any): { status: number; body: Record<string, unknown> } {
+  const body: Record<string, unknown> = { error: sanitizeCatsErrorMessage(error.message) };
+  const data = sanitizeCatsErrorData(error.data);
+  if (data) body.data = data;
+  return { status: error.status || 500, body };
+}
+
+function restartCatsCompanyIfRunning(serviceManager: ServiceManager): {
+  wasRunning: boolean;
+  restartRequested: boolean;
+  restartError?: string;
+} {
+  const getService = typeof (serviceManager as any).getService === 'function'
+    ? serviceManager.getService.bind(serviceManager)
+    : undefined;
+  const restart = typeof (serviceManager as any).restart === 'function'
+    ? serviceManager.restart.bind(serviceManager)
+    : undefined;
+  if (!getService || !restart) {
+    return { wasRunning: false, restartRequested: false };
+  }
+
+  const service = getService('catscompany');
+  if (service?.status !== 'running') {
+    return { wasRunning: false, restartRequested: false };
+  }
+
+  try {
+    restart('catscompany');
+    return { wasRunning: true, restartRequested: true };
+  } catch (error: any) {
+    return {
+      wasRunning: true,
+      restartRequested: false,
+      restartError: error?.message || String(error),
+    };
+  }
+}
+
 function persistCatsUserSession(state: CatsAuthState, login: any): void {
   writeEnvUpdates({
     CATSCO_HTTP_BASE_URL: state.httpBaseUrl,
@@ -595,7 +737,17 @@ export function createApiRouter(serviceManager: ServiceManager, updateController
 
   router.put('/settings', (req, res) => {
     try {
-      res.json(updateDashboardSettings(req.body, { runtimeRoot: process.cwd() }));
+      const result = updateDashboardSettings(req.body, { runtimeRoot: process.cwd() });
+      const changedModelSettings = result.updated.some(key => key.startsWith('GAUZ_LLM_'))
+        || result.cleared.some(key => key.startsWith('GAUZ_LLM_'));
+      const restartInfo = req.body?.restartConnector === true && changedModelSettings
+        ? restartCatsCompanyIfRunning(serviceManager)
+        : { wasRunning: false, restartRequested: false };
+      res.json({
+        ...result,
+        connectorRestarted: restartInfo.restartRequested,
+        restartError: restartInfo.restartError,
+      });
     } catch (e: any) {
       res.status(400).json({ error: e.message });
     }
@@ -1095,6 +1247,111 @@ export function createApiRouter(serviceManager: ServiceManager, updateController
       });
     } catch (e: any) {
       res.status(e.status || 500).json({ error: e.message, data: e.data });
+    }
+  });
+
+  router.get('/cats/relay/model-config', async (req, res) => {
+    try {
+      const state = getCatsAuthState();
+      if (!state.token) return res.status(401).json({ error: 'CatsCo user token is missing' });
+
+      const protocol = normalizeRelayModelProtocol(req.query.protocol);
+      const config = await fetchCatsRelayConfig(state);
+      const keyResponse = config?.self_service_enabled ? await fetchCatsRelayKey(state) : { key: null };
+      const apiBase = relayEndpointForProtocol(config, protocol);
+      const provider = relayProviderForProtocol(protocol);
+      const model = String(config?.default_model || 'MiniMax-M2.7').trim() || 'MiniMax-M2.7';
+      const currentConfig = ConfigManager.getConfigReadonly();
+      const currentApiBase = String(currentConfig.apiUrl || '').replace(/\/+$/, '');
+
+      res.json({
+        ok: true,
+        protocol,
+        provider,
+        apiBase,
+        model,
+        configured: Boolean(
+          currentConfig.apiKey
+          && currentConfig.provider === provider
+          && currentApiBase === apiBase
+          && currentConfig.model === model
+        ),
+        relay: {
+          baseUrl: config?.base_url,
+          docsUrl: config?.docs_url,
+          selfServiceEnabled: Boolean(config?.self_service_enabled),
+        },
+        key: sanitizeRelayKeyInfo(keyResponse?.key),
+      });
+    } catch (e: any) {
+      const payload = catsErrorResponse(e);
+      res.status(payload.status).json(payload.body);
+    }
+  });
+
+  router.post('/cats/relay/model-config/apply', async (req, res) => {
+    try {
+      const state = getCatsAuthState();
+      if (!state.token) return res.status(401).json({ error: 'CatsCo user token is missing' });
+
+      const protocol = normalizeRelayModelProtocol(req.body?.protocol);
+      const config = await fetchCatsRelayConfig(state);
+      if (config?.self_service_enabled === false) {
+        return res.status(503).json({ error: 'CatsCo 中转自助 Key 尚未启用' });
+      }
+
+      let ensured;
+      try {
+        ensured = await ensureCatsRelayPlainKey(state, {
+          rotateExisting: req.body?.rotateExisting === true,
+        });
+      } catch (error: any) {
+        if (error?.status === 409) {
+          return res.status(409).json({
+            error: error.message,
+            action: 'rotate_required',
+            protocol,
+            key: sanitizeRelayKeyInfo((await fetchCatsRelayKey(state))?.key),
+          });
+        }
+        throw error;
+      }
+
+      const apiBase = relayEndpointForProtocol(config, protocol);
+      const provider = relayProviderForProtocol(protocol);
+      const model = String(config?.default_model || 'MiniMax-M2.7').trim() || 'MiniMax-M2.7';
+      const settingsResult = updateDashboardSettings({
+        settings: {
+          'model.provider': provider,
+          'model.apiBase': apiBase,
+          'model.model': model,
+          'model.apiKey': { action: 'replace', value: ensured.plainKey },
+        },
+      }, { runtimeRoot: process.cwd() });
+      const restartInfo = restartCatsCompanyIfRunning(serviceManager);
+
+      res.json({
+        ok: true,
+        protocol,
+        provider,
+        apiBase,
+        model,
+        updated: settingsResult.updated,
+        key: sanitizeRelayKeyInfo(ensured.response?.key),
+        createdKey: ensured.created,
+        rotatedKey: ensured.rotated,
+        restartRequired: restartInfo.wasRunning && !restartInfo.restartRequested,
+        connectorRestarted: restartInfo.restartRequested,
+        restartError: restartInfo.restartError,
+        message: restartInfo.restartRequested
+          ? '已启用 CatsCo 中转模型，并已请求重启 CatsCo agent 以使用新配置。'
+          : restartInfo.wasRunning
+          ? '已启用 CatsCo 中转模型；但 CatsCo agent 自动重启失败，请手动重启后使用新配置。'
+          : '已启用 CatsCo 中转模型；下次启动 connector 会使用新配置。',
+      });
+    } catch (e: any) {
+      const payload = catsErrorResponse(e);
+      res.status(payload.status).json(payload.body);
     }
   });
 

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -465,11 +465,22 @@ function findReusableLocalRelayKey(currentKey: any): string | undefined {
   }
 
   const prefix = String(currentKey?.prefix || '').trim();
-  if (prefix && !apiKey.startsWith(prefix)) {
+  if (!prefix || !matchesRelayKeyPrefix(apiKey, prefix)) {
     return undefined;
   }
 
   return apiKey;
+}
+
+function matchesRelayKeyPrefix(apiKey: string, prefix: string): boolean {
+  const marker = '...';
+  const markerIndex = prefix.indexOf(marker);
+  if (markerIndex >= 0) {
+    const start = prefix.slice(0, markerIndex);
+    const end = prefix.slice(markerIndex + marker.length);
+    return (!start || apiKey.startsWith(start)) && (!end || apiKey.endsWith(end));
+  }
+  return apiKey.startsWith(prefix);
 }
 
 function sanitizeCatsErrorData(data: unknown): unknown {

--- a/tests/dashboard-productization-html.test.ts
+++ b/tests/dashboard-productization-html.test.ts
@@ -16,9 +16,12 @@ test('dashboard settings page uses model source before Runtime Profile', () => {
   assert.match(dashboardHtml, /\/api\/settings/);
   assert.match(dashboardHtml, /id="settings-setup-panel"/);
   assert.match(dashboardHtml, /先完成关键配置/);
-  assert.match(dashboardHtml, /CatsCo 托管模型/);
-  assert.match(dashboardHtml, /自定义模型（当前需要）/);
-  assert.match(dashboardHtml, /托管模型目录和用量服务还没有接入当前本地版本/);
+  assert.match(dashboardHtml, /CatsCo 中转模型/);
+  assert.match(dashboardHtml, /自定义模型（手动配置）/);
+  assert.match(dashboardHtml, /启用 CatsCo 中转/);
+  assert.match(dashboardHtml, /默认推荐 Anthropic-compatible/);
+  assert.match(dashboardHtml, /function enableCatsRelayModel\(protocol, options=\{\}\)/);
+  assert.match(dashboardHtml, /\/api\/cats\/relay\/model-config\/apply/);
   assert.match(dashboardHtml, /访问凭证只保存 presence，不会回显/);
   assert.match(dashboardHtml, /保存自定义模型设置？访问凭证会写入本地 \.env，仅用于本机 runtime。/);
   assert.match(dashboardHtml, /Runtime Profile 状态/);

--- a/tests/dashboard-readiness.test.ts
+++ b/tests/dashboard-readiness.test.ts
@@ -151,7 +151,7 @@ describe('dashboard readiness and service preflight API', () => {
     assert.equal(preflight.status, 'warning');
     assert.equal(preflight.canStart, true);
     assert.deepStrictEqual(preflight.blockingChecks, []);
-    assert.equal(preflight.warningChecks.includes('model.managed.backend'), true);
+    assert.equal(preflight.warningChecks.includes('model.managed.relay'), true);
     assert.equal(preflightText.includes('sk-readiness-secret'), false);
     assert.equal(preflightText.includes('catsco-agent-secret'), false);
     assert.equal(preflightText.includes(testRoot), false);

--- a/tests/dashboard-settings-api.test.ts
+++ b/tests/dashboard-settings-api.test.ts
@@ -316,6 +316,8 @@ describe('dashboard typed settings API', () => {
           prefix: 'sk-bf-d0',
           state: 'active',
           key: 'sk-bf-secret-created-once',
+          api_key: 'sk-bf-secondary-secret',
+          secret: 'relay-secret-value',
         },
       });
     });
@@ -347,7 +349,11 @@ describe('dashboard typed settings API', () => {
       assert.equal(data.model, 'MiniMax-M2.7');
       assert.equal(data.createdKey, true);
       assert.equal(data.key.key, undefined);
+      assert.equal(data.key.api_key, undefined);
+      assert.equal(data.key.secret, undefined);
       assert.equal(text.includes('sk-bf-secret-created-once'), false);
+      assert.equal(text.includes('sk-bf-secondary-secret'), false);
+      assert.equal(text.includes('relay-secret-value'), false);
       assert.equal(createCount, 1);
       assert.equal(parsed.GAUZ_LLM_PROVIDER, 'anthropic');
       assert.equal(parsed.GAUZ_LLM_API_BASE, 'https://relay.catsco.cc/anthropic');
@@ -471,6 +477,85 @@ describe('dashboard typed settings API', () => {
       assert.deepStrictEqual(data.data, { error: 'upstream failure', reason: 'test-only' });
       assert.equal(text.includes('sk-bf-should-not-leak'), false);
       assert.equal(text.includes('user-token-should-not-leak'), false);
+    } finally {
+      await new Promise<void>(resolve => catsServer.close(() => resolve()));
+    }
+  });
+
+  test('POST /cats/relay/model-config/apply reuses local relay key when switching protocols', async () => {
+    const catsApp = express();
+    catsApp.use(express.json());
+    let createCalled = false;
+    let rotateCalled = false;
+
+    catsApp.get('/api/relay/config', (_req, res) => {
+      res.json({
+        base_url: 'https://relay.catsco.cc',
+        default_model: 'MiniMax-M2.7',
+        self_service_enabled: true,
+        endpoints: [
+          { protocol: 'OpenAI-compatible', base_url: 'https://relay.catsco.cc/v1' },
+          { protocol: 'Anthropic-compatible', base_url: 'https://relay.catsco.cc/anthropic' },
+        ],
+      });
+    });
+    catsApp.get('/api/relay/key', (_req, res) => {
+      res.json({
+        configured: true,
+        key: {
+          id: 'vk-existing',
+          name: 'existing',
+          prefix: 'sk-bf-old',
+          state: 'active',
+        },
+      });
+    });
+    catsApp.post('/api/relay/key', (_req, res) => {
+      createCalled = true;
+      res.status(500).json({ error: 'create should not be called' });
+    });
+    catsApp.post('/api/relay/key/rotate', (_req, res) => {
+      rotateCalled = true;
+      res.status(500).json({ error: 'rotate should not be called' });
+    });
+    const catsServer = await listen(catsApp);
+    const address = catsServer.address();
+    if (!address || typeof address === 'string') throw new Error('cats server did not bind');
+
+    try {
+      fs.writeFileSync(path.join(testRoot, '.env'), [
+        'GAUZ_LLM_PROVIDER=anthropic',
+        'GAUZ_LLM_API_BASE=https://relay.catsco.cc/anthropic',
+        'GAUZ_LLM_API_KEY=sk-bf-old-local-secret',
+        'GAUZ_LLM_MODEL=MiniMax-M2.7',
+        '',
+      ].join('\n'));
+      process.env.CATSCO_USER_TOKEN = 'user-token';
+      process.env.CATSCO_USER_UID = '38';
+      process.env.CATSCO_HTTP_BASE_URL = `http://127.0.0.1:${address.port}`;
+
+      const response = await fetch(`${baseUrl}/api/cats/relay/model-config/apply`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ protocol: 'openai' }),
+      });
+      const text = await response.text();
+      const data = JSON.parse(text) as any;
+      const parsed = dotenv.parse(fs.readFileSync(path.join(testRoot, '.env'), 'utf-8'));
+
+      assert.equal(response.status, 200, text);
+      assert.equal(data.provider, 'openai');
+      assert.equal(data.apiBase, 'https://relay.catsco.cc/v1');
+      assert.equal(data.createdKey, false);
+      assert.equal(data.rotatedKey, false);
+      assert.equal(data.key.prefix, 'sk-bf-old');
+      assert.equal(createCalled, false);
+      assert.equal(rotateCalled, false);
+      assert.equal(parsed.GAUZ_LLM_PROVIDER, 'openai');
+      assert.equal(parsed.GAUZ_LLM_API_BASE, 'https://relay.catsco.cc/v1');
+      assert.equal(parsed.GAUZ_LLM_MODEL, 'MiniMax-M2.7');
+      assert.equal(parsed.GAUZ_LLM_API_KEY, 'sk-bf-old-local-secret');
+      assert.equal(text.includes('sk-bf-old-local-secret'), false);
     } finally {
       await new Promise<void>(resolve => catsServer.close(() => resolve()));
     }

--- a/tests/dashboard-settings-api.test.ts
+++ b/tests/dashboard-settings-api.test.ts
@@ -20,6 +20,10 @@ describe('dashboard typed settings API', () => {
     'GAUZ_LLM_MODEL',
     'CATSCO_HTTP_BASE_URL',
     'CATSCO_SERVER_URL',
+    'CATSCO_USER_TOKEN',
+    'CATSCO_USER_UID',
+    'CATSCO_USER_NAME',
+    'CATSCO_USER_DISPLAY_NAME',
   ];
   const originalEnv: Record<string, string | undefined> = {};
 
@@ -279,6 +283,244 @@ describe('dashboard typed settings API', () => {
     assert.equal(backupWriteResponse.status, 400);
     assert.match(backupWrite.error, /Unknown config key/);
     assert.equal(fs.readFileSync(path.join(testRoot, '.env'), 'utf-8').includes('new-backup-secret'), false);
+  });
+
+  test('POST /cats/relay/model-config/apply creates a relay key and writes Anthropic settings', async () => {
+    const catsApp = express();
+    catsApp.use(express.json());
+    let createCount = 0;
+
+    catsApp.get('/api/relay/config', (req, res) => {
+      assert.equal(req.headers.authorization, 'Bearer user-token');
+      res.json({
+        base_url: 'https://relay.catsco.cc',
+        default_model: 'MiniMax-M2.7',
+        self_service_enabled: true,
+        endpoints: [
+          { protocol: 'OpenAI-compatible', base_url: 'https://relay.catsco.cc/v1' },
+          { protocol: 'Anthropic-compatible', base_url: 'https://relay.catsco.cc/anthropic' },
+        ],
+      });
+    });
+    catsApp.get('/api/relay/key', (_req, res) => {
+      res.json({ configured: true });
+    });
+    catsApp.post('/api/relay/key', (req, res) => {
+      createCount += 1;
+      assert.equal(req.body.name, 'CatsCo user 38');
+      res.json({
+        configured: true,
+        key: {
+          id: 'vk-test',
+          name: req.body.name,
+          prefix: 'sk-bf-d0',
+          state: 'active',
+          key: 'sk-bf-secret-created-once',
+        },
+      });
+    });
+    const catsServer = await listen(catsApp);
+    const address = catsServer.address();
+    if (!address || typeof address === 'string') throw new Error('cats server did not bind');
+
+    try {
+      process.env.CATSCO_USER_TOKEN = 'user-token';
+      process.env.CATSCO_USER_UID = '38';
+      process.env.CATSCO_HTTP_BASE_URL = `http://127.0.0.1:${address.port}`;
+
+      const response = await fetch(`${baseUrl}/api/cats/relay/model-config/apply`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          token: 'evil-token-ignored',
+          httpBaseUrl: 'http://127.0.0.1:1',
+        }),
+      });
+      const text = await response.text();
+      const data = JSON.parse(text) as any;
+      const parsed = dotenv.parse(fs.readFileSync(path.join(testRoot, '.env'), 'utf-8'));
+
+      assert.equal(response.status, 200, text);
+      assert.equal(data.ok, true);
+      assert.equal(data.provider, 'anthropic');
+      assert.equal(data.apiBase, 'https://relay.catsco.cc/anthropic');
+      assert.equal(data.model, 'MiniMax-M2.7');
+      assert.equal(data.createdKey, true);
+      assert.equal(data.key.key, undefined);
+      assert.equal(text.includes('sk-bf-secret-created-once'), false);
+      assert.equal(createCount, 1);
+      assert.equal(parsed.GAUZ_LLM_PROVIDER, 'anthropic');
+      assert.equal(parsed.GAUZ_LLM_API_BASE, 'https://relay.catsco.cc/anthropic');
+      assert.equal(parsed.GAUZ_LLM_MODEL, 'MiniMax-M2.7');
+      assert.equal(parsed.GAUZ_LLM_API_KEY, 'sk-bf-secret-created-once');
+      assert.equal(process.env.GAUZ_LLM_PROVIDER, 'anthropic');
+
+      const customResponse = await fetch(`${baseUrl}/api/settings`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          settings: {
+            'model.provider': 'openai',
+            'model.apiBase': 'https://api.deepseek.com/v1',
+            'model.model': 'deepseek-chat',
+            'model.apiKey': { action: 'replace', value: 'sk-custom-model-key' },
+          },
+        }),
+      });
+      assert.equal(customResponse.status, 200);
+      const switched = dotenv.parse(fs.readFileSync(path.join(testRoot, '.env'), 'utf-8'));
+      assert.equal(switched.GAUZ_LLM_PROVIDER, 'openai');
+      assert.equal(switched.GAUZ_LLM_API_BASE, 'https://api.deepseek.com/v1');
+      assert.equal(switched.GAUZ_LLM_MODEL, 'deepseek-chat');
+      assert.equal(switched.GAUZ_LLM_API_KEY, 'sk-custom-model-key');
+    } finally {
+      await new Promise<void>(resolve => catsServer.close(() => resolve()));
+    }
+  });
+
+  test('POST /cats/relay/model-config/apply writes OpenAI-compatible relay settings', async () => {
+    const catsApp = express();
+    catsApp.use(express.json());
+    catsApp.get('/api/relay/config', (req, res) => {
+      assert.equal(req.headers.authorization, 'Bearer user-token');
+      res.json({
+        base_url: 'https://relay.catsco.cc',
+        default_model: 'MiniMax-M2.7',
+        self_service_enabled: true,
+        endpoints: [
+          { protocol: 'OpenAI-compatible', base_url: 'https://relay.catsco.cc/v1' },
+          { protocol: 'Anthropic-compatible', base_url: 'https://relay.catsco.cc/anthropic' },
+        ],
+      });
+    });
+    catsApp.get('/api/relay/key', (_req, res) => {
+      res.json({ configured: false });
+    });
+    catsApp.post('/api/relay/key', (_req, res) => {
+      res.json({
+        key: {
+          id: 'vk-openai',
+          name: 'CatsCo user 38',
+          prefix: 'sk-bf-o1',
+          state: 'active',
+          key: 'sk-bf-openai-compatible',
+        },
+      });
+    });
+    const catsServer = await listen(catsApp);
+    const address = catsServer.address();
+    if (!address || typeof address === 'string') throw new Error('cats server did not bind');
+
+    try {
+      process.env.CATSCO_USER_TOKEN = 'user-token';
+      process.env.CATSCO_USER_UID = '38';
+      process.env.CATSCO_HTTP_BASE_URL = `http://127.0.0.1:${address.port}`;
+
+      const response = await fetch(`${baseUrl}/api/cats/relay/model-config/apply`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ protocol: 'openai' }),
+      });
+      const text = await response.text();
+      const data = JSON.parse(text) as any;
+      const parsed = dotenv.parse(fs.readFileSync(path.join(testRoot, '.env'), 'utf-8'));
+
+      assert.equal(response.status, 200, text);
+      assert.equal(data.provider, 'openai');
+      assert.equal(data.apiBase, 'https://relay.catsco.cc/v1');
+      assert.equal(parsed.GAUZ_LLM_PROVIDER, 'openai');
+      assert.equal(parsed.GAUZ_LLM_API_BASE, 'https://relay.catsco.cc/v1');
+      assert.equal(parsed.GAUZ_LLM_MODEL, 'MiniMax-M2.7');
+      assert.equal(parsed.GAUZ_LLM_API_KEY, 'sk-bf-openai-compatible');
+      assert.equal(text.includes('sk-bf-openai-compatible'), false);
+    } finally {
+      await new Promise<void>(resolve => catsServer.close(() => resolve()));
+    }
+  });
+
+  test('POST /cats/relay/model-config/apply sanitizes upstream error payloads', async () => {
+    const catsApp = express();
+    catsApp.use(express.json());
+    catsApp.get('/api/relay/config', (_req, res) => {
+      res.status(500).json({
+        error: 'upstream failure',
+        key: 'sk-bf-should-not-leak',
+        token: 'user-token-should-not-leak',
+        reason: 'test-only',
+      });
+    });
+    const catsServer = await listen(catsApp);
+    const address = catsServer.address();
+    if (!address || typeof address === 'string') throw new Error('cats server did not bind');
+
+    try {
+      process.env.CATSCO_USER_TOKEN = 'user-token';
+      process.env.CATSCO_USER_UID = '38';
+      process.env.CATSCO_HTTP_BASE_URL = `http://127.0.0.1:${address.port}`;
+
+      const response = await fetch(`${baseUrl}/api/cats/relay/model-config/apply`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ protocol: 'anthropic' }),
+      });
+      const text = await response.text();
+      const data = JSON.parse(text) as any;
+
+      assert.equal(response.status, 500);
+      assert.equal(data.error, 'upstream failure');
+      assert.deepStrictEqual(data.data, { error: 'upstream failure', reason: 'test-only' });
+      assert.equal(text.includes('sk-bf-should-not-leak'), false);
+      assert.equal(text.includes('user-token-should-not-leak'), false);
+    } finally {
+      await new Promise<void>(resolve => catsServer.close(() => resolve()));
+    }
+  });
+
+  test('POST /cats/relay/model-config/apply refuses to overwrite existing relay key without rotation', async () => {
+    const catsApp = express();
+    catsApp.use(express.json());
+    catsApp.get('/api/relay/config', (_req, res) => {
+      res.json({
+        base_url: 'https://relay.catsco.cc',
+        default_model: 'MiniMax-M2.7',
+        self_service_enabled: true,
+        endpoints: [{ protocol: 'Anthropic-compatible', base_url: 'https://relay.catsco.cc/anthropic' }],
+      });
+    });
+    catsApp.get('/api/relay/key', (_req, res) => {
+      res.json({
+        configured: true,
+        key: {
+          id: 'vk-existing',
+          name: 'existing',
+          prefix: 'sk-bf-old',
+          state: 'active',
+        },
+      });
+    });
+    const catsServer = await listen(catsApp);
+    const address = catsServer.address();
+    if (!address || typeof address === 'string') throw new Error('cats server did not bind');
+
+    try {
+      process.env.CATSCO_USER_TOKEN = 'user-token';
+      process.env.CATSCO_USER_UID = '38';
+      process.env.CATSCO_HTTP_BASE_URL = `http://127.0.0.1:${address.port}`;
+
+      const response = await fetch(`${baseUrl}/api/cats/relay/model-config/apply`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ protocol: 'anthropic' }),
+      });
+      const data = await response.json() as any;
+
+      assert.equal(response.status, 409);
+      assert.equal(data.action, 'rotate_required');
+      assert.equal(data.key.prefix, 'sk-bf-old');
+      assert.equal(fs.existsSync(path.join(testRoot, '.env')), false);
+    } finally {
+      await new Promise<void>(resolve => catsServer.close(() => resolve()));
+    }
   });
 });
 

--- a/tests/dashboard-settings-api.test.ts
+++ b/tests/dashboard-settings-api.test.ts
@@ -505,7 +505,7 @@ describe('dashboard typed settings API', () => {
         key: {
           id: 'vk-existing',
           name: 'existing',
-          prefix: 'sk-bf-old',
+          prefix: 'sk-bf-old...cret',
           state: 'active',
         },
       });
@@ -548,7 +548,7 @@ describe('dashboard typed settings API', () => {
       assert.equal(data.apiBase, 'https://relay.catsco.cc/v1');
       assert.equal(data.createdKey, false);
       assert.equal(data.rotatedKey, false);
-      assert.equal(data.key.prefix, 'sk-bf-old');
+      assert.equal(data.key.prefix, 'sk-bf-old...cret');
       assert.equal(createCalled, false);
       assert.equal(rotateCalled, false);
       assert.equal(parsed.GAUZ_LLM_PROVIDER, 'openai');
@@ -556,6 +556,74 @@ describe('dashboard typed settings API', () => {
       assert.equal(parsed.GAUZ_LLM_MODEL, 'MiniMax-M2.7');
       assert.equal(parsed.GAUZ_LLM_API_KEY, 'sk-bf-old-local-secret');
       assert.equal(text.includes('sk-bf-old-local-secret'), false);
+    } finally {
+      await new Promise<void>(resolve => catsServer.close(() => resolve()));
+    }
+  });
+
+  test('POST /cats/relay/model-config/apply requires a verifiable relay key prefix before reusing local key', async () => {
+    const catsApp = express();
+    catsApp.use(express.json());
+    let createCalled = false;
+    let rotateCalled = false;
+
+    catsApp.get('/api/relay/config', (_req, res) => {
+      res.json({
+        base_url: 'https://relay.catsco.cc',
+        default_model: 'MiniMax-M2.7',
+        self_service_enabled: true,
+        endpoints: [{ protocol: 'Anthropic-compatible', base_url: 'https://relay.catsco.cc/anthropic' }],
+      });
+    });
+    catsApp.get('/api/relay/key', (_req, res) => {
+      res.json({
+        configured: true,
+        key: {
+          id: 'vk-existing',
+          name: 'existing',
+          state: 'active',
+        },
+      });
+    });
+    catsApp.post('/api/relay/key', (_req, res) => {
+      createCalled = true;
+      res.status(500).json({ error: 'create should not be called' });
+    });
+    catsApp.post('/api/relay/key/rotate', (_req, res) => {
+      rotateCalled = true;
+      res.status(500).json({ error: 'rotate should not be called' });
+    });
+    const catsServer = await listen(catsApp);
+    const address = catsServer.address();
+    if (!address || typeof address === 'string') throw new Error('cats server did not bind');
+
+    try {
+      fs.writeFileSync(path.join(testRoot, '.env'), [
+        'GAUZ_LLM_PROVIDER=anthropic',
+        'GAUZ_LLM_API_BASE=https://relay.catsco.cc/anthropic',
+        'GAUZ_LLM_API_KEY=sk-bf-old-local-secret',
+        'GAUZ_LLM_MODEL=MiniMax-M2.7',
+        '',
+      ].join('\n'));
+      process.env.CATSCO_USER_TOKEN = 'user-token';
+      process.env.CATSCO_USER_UID = '38';
+      process.env.CATSCO_HTTP_BASE_URL = `http://127.0.0.1:${address.port}`;
+
+      const response = await fetch(`${baseUrl}/api/cats/relay/model-config/apply`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ protocol: 'anthropic' }),
+      });
+      const data = await response.json() as any;
+      const parsed = dotenv.parse(fs.readFileSync(path.join(testRoot, '.env'), 'utf-8'));
+
+      assert.equal(response.status, 409);
+      assert.equal(data.action, 'rotate_required');
+      assert.equal(data.key.prefix, undefined);
+      assert.equal(createCalled, false);
+      assert.equal(rotateCalled, false);
+      assert.equal(parsed.GAUZ_LLM_API_KEY, 'sk-bf-old-local-secret');
+      assert.equal(parsed.GAUZ_LLM_API_BASE, 'https://relay.catsco.cc/anthropic');
     } finally {
       await new Promise<void>(resolve => catsServer.close(() => resolve()));
     }


### PR DESCRIPTION
## 变更内容
- 在桌面 Dashboard 增加 CatsCo 中转模型一键配置入口，默认写入 Anthropic-compatible 中转配置，并保留 OpenAI-compatible 手动切换。
- 新增本地接口 `/api/cats/relay/model-config` 和 `/api/cats/relay/model-config/apply`，复用 CatsCompany 的 relay config/key 接口生成或复用用户自己的中转 Key。
- 中转配置和自定义模型配置统一写入 `GAUZ_LLM_*`，显式保存后会请求重启正在运行的 CatsCo agent，避免运行中的 connector 继续使用旧模型配置。
- 加固 relay 配置接口：不允许请求体覆盖本地 CatsCo token/base URL，并对上游错误响应做敏感字段脱敏。
- 修复 CatsCo Chat 连接详情里“高级 endpoint”展开后被裁切、看不到下面输入框的问题。

## 为什么
用户希望桌面端可以一键接入 CatsCo/Bifrost 中转，同时仍能切回自定义模型。之前运行中的 connector 不会自动加载新配置，且连接详情高级 endpoint 在窄面板下会被裁切。

## 影响范围
- 影响桌面端 Dashboard 的模型配置页、CatsCo Chat 连接详情面板和本地 Dashboard API。
- 不改变旧的自定义模型填写方式；用户仍可手动配置 Anthropic/OpenAI-compatible 模型。
- 中转 Key 明文不会通过本地接口回显；如果已有 active key 但本地拿不到明文，会提示用户确认后重新生成。

## 验证
- `npm.cmd run build`
- `node --import tsx --test tests/dashboard-settings-api.test.ts tests/dashboard-productization-html.test.ts tests/dashboard-readiness.test.ts`
- `npm.cmd run test:runtime`
- `git diff --check`（仅有已有 CRLF warning）
- 本地 Dashboard `http://127.0.0.1:3800` 手动验证：展开 `连接详情 -> 高级 endpoint` 后 HTTP/WS 输入框可见