### PR TITLE
[codex] 增强 CatsCompany WebSocket 确认重试

### DIFF
--- a/src/catscompany/client.ts
+++ b/src/catscompany/client.ts
@@ -1,6 +1,7 @@
 // CatsCo 服务器 WebSocket 客户端
 import WebSocket from 'ws';
 import { EventEmitter } from 'events';
+import crypto from 'crypto';
 import { Logger } from '../utils/logger';
 import { uploadCatsLocalFile, type UploadResult } from './upload';
 
@@ -30,6 +31,7 @@ export interface MessageContext {
 export interface CatsOutgoingMessage {
   topic_id?: string;
   topic?: string;
+  client_msg_id?: string;
   type?: string;
   msg_type?: string;
   content?: unknown;
@@ -44,6 +46,7 @@ interface PendingAck {
   resolve: (seq: number) => void;
   reject: (err: Error) => void;
   timer: NodeJS.Timeout;
+  clientMsgID?: string;
 }
 
 export type CatsSendErrorKind = 'transport' | 'ack' | 'timeout';
@@ -58,13 +61,19 @@ function maskSecret(value: string): string {
 }
 
 export class CatsSendError extends Error {
+  public readonly clientMsgID?: string;
+  public readonly retryableWithHttp: boolean;
+
   constructor(
     public readonly kind: CatsSendErrorKind,
     message: string,
-    public readonly code?: number
+    public readonly code?: number,
+    options: { clientMsgID?: string; retryableWithHttp?: boolean } = {}
   ) {
     super(message);
     this.name = 'CatsSendError';
+    this.clientMsgID = options.clientMsgID;
+    this.retryableWithHttp = options.retryableWithHttp ?? false;
   }
 }
 
@@ -92,6 +101,7 @@ export class CatsClient extends EventEmitter {
   private pongTimer: NodeJS.Timeout | null = null;
   private reconnectAttempts = 0;
   private subscribedTopics = new Set<string>();
+  private supportsClientMessageDedupe = false;
 
   public uid = '';
   public name = '';
@@ -104,6 +114,7 @@ export class CatsClient extends EventEmitter {
     if (this.ws) return;
 
     Logger.info(`[CatsCompany] 正在连接: ${this.config.serverUrl}, apiKey=${maskSecret(this.config.apiKey)}`);
+    this.supportsClientMessageDedupe = false;
     this.ws = new WebSocket(this.config.serverUrl, {
       headers: { 'X-API-Key': this.config.apiKey }
     });
@@ -125,9 +136,16 @@ export class CatsClient extends EventEmitter {
     });
 
     this.ws.on('error', (err: Error) => this.emit('error', err));
-    this.ws.on('close', () => {
+    this.ws.on('close', (code: number, reason: Buffer) => {
+      Logger.warning(`[CatsCompany] WebSocket 已关闭: code=${code}, reason=${reason.toString() || '-'}`);
       this.stopHeartbeat();
       this.ws = null;
+      this.rejectPendingAcks(new CatsSendError(
+        'timeout',
+        'WebSocket 在收到 CatsCompany 服务器确认前关闭',
+        undefined,
+        { retryableWithHttp: this.supportsClientMessageDedupe }
+      ));
       if (!this.closed) this.scheduleReconnect();
     });
   }
@@ -141,6 +159,11 @@ export class CatsClient extends EventEmitter {
           `[CatsCompany] 握手成功: uid=${this.uid}, name=${this.name}, ` +
           `protocol=${CATSCOMPANY_PROTOCOL_VERSION}, serverProtocol=${msg.ctrl.params?.ver || 'unknown'}`
         );
+        this.supportsClientMessageDedupe = Array.isArray(msg.ctrl.params?.features)
+          && msg.ctrl.params.features.includes('client_msg_id');
+        if (this.supportsClientMessageDedupe) {
+          Logger.info('[CatsCompany] 服务端支持 client_msg_id 幂等发送');
+        }
         this.emit('ready', { uid: this.uid, name: this.name });
         this.autoAcceptFriendRequests().catch(console.error);
         this.resubscribeTopics();
@@ -208,6 +231,7 @@ export class CatsClient extends EventEmitter {
       topic,
     };
 
+    if (payload.client_msg_id !== undefined) pub.client_msg_id = payload.client_msg_id;
     if (payload.content !== undefined) pub.content = payload.content;
     if (payload.content_blocks !== undefined) pub.content_blocks = payload.content_blocks;
     if (payload.metadata !== undefined) pub.metadata = payload.metadata;
@@ -222,18 +246,29 @@ export class CatsClient extends EventEmitter {
 
   async sendStructuredMessage(payload: CatsOutgoingMessage): Promise<number> {
     const msgId = `${++this.msgId}`;
-    const pub = this.buildPubMessage(msgId, payload);
+    const clientMsgID = payload.client_msg_id || buildClientMessageID();
+    const pub = this.buildPubMessage(msgId, {
+      ...payload,
+      client_msg_id: clientMsgID,
+      metadata: {
+        ...(payload.metadata || {}),
+        client_msg_id: clientMsgID,
+      },
+    });
 
     return new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
         this.pendingAcks.delete(msgId);
+        this.forceReconnect('ack timeout');
         reject(new CatsSendError(
           'timeout',
-          'WebSocket 已发送消息，但 10 秒内没有收到 CatsCompany 服务器确认'
+          'WebSocket 已发送消息，但 10 秒内没有收到 CatsCompany 服务器确认',
+          undefined,
+          { clientMsgID, retryableWithHttp: this.supportsClientMessageDedupe }
         ));
       }, 10000);
 
-      this.pendingAcks.set(msgId, { resolve, reject, timer });
+      this.pendingAcks.set(msgId, { resolve, reject, timer, clientMsgID });
       try {
         this.sendOrThrow({ pub });
       } catch (err: any) {
@@ -331,6 +366,29 @@ export class CatsClient extends EventEmitter {
     }
   }
 
+  private rejectPendingAcks(err: CatsSendError): void {
+    for (const [msgId, pending] of this.pendingAcks.entries()) {
+      clearTimeout(pending.timer);
+      this.pendingAcks.delete(msgId);
+      pending.reject(new CatsSendError(
+        err.kind,
+        err.message,
+        err.code,
+        {
+          clientMsgID: pending.clientMsgID,
+          retryableWithHttp: err.retryableWithHttp,
+        }
+      ));
+    }
+  }
+
+  private forceReconnect(reason: string): void {
+    Logger.warning(`[CatsCompany] ${reason}，主动重建 WebSocket 连接`);
+    if (this.ws?.readyState === WebSocket.OPEN || this.ws?.readyState === WebSocket.CONNECTING) {
+      this.ws.terminate();
+    }
+  }
+
   private startHeartbeat(): void {
     this.stopHeartbeat();
     this.pingTimer = setInterval(() => {
@@ -381,4 +439,11 @@ export class CatsClient extends EventEmitter {
     this.stopHeartbeat();
     this.ws?.close();
   }
+}
+
+function buildClientMessageID(): string {
+  if (typeof crypto.randomUUID === 'function') {
+    return `catsco-${crypto.randomUUID()}`;
+  }
+  return `catsco-${Date.now()}-${crypto.randomBytes(8).toString('hex')}`;
 }

--- a/src/catscompany/message-sender.ts
+++ b/src/catscompany/message-sender.ts
@@ -10,6 +10,7 @@ type CatsMessageType = 'thinking' | 'tool_use' | 'tool_result' | 'runtime_plan' 
 
 interface CatsSendBody {
   topic_id: string;
+  client_msg_id?: string;
   type: CatsMessageType;
   content: unknown;
   metadata?: any;
@@ -45,7 +46,10 @@ function describeCatsSendFailure(err: unknown): string {
       return `CatsCo 桌面端到 CatsCo 服务器的 WebSocket 链路不可用，可能是本机网络、代理、防火墙、服务器地址或连接重连中的问题。${err.message}`;
     }
     if (err.kind === 'timeout') {
-      return `WebSocket 消息已写出，但服务器确认超时。可能是服务器处理慢、网络抖动或连接半断开；为避免重复消息，不会自动改用 HTTP 重发。${err.message}`;
+      const retryNote = err.retryableWithHttp
+        ? '本次消息带有 client_msg_id，可安全使用 HTTP 兜底重试。'
+        : '当前服务端未确认支持消息去重，为避免重复消息，不会自动改用 HTTP 重发。';
+      return `WebSocket 消息已写出，但服务器确认超时。可能是服务器处理慢、网络抖动或连接半断开；${retryNote}${err.message}`;
     }
     if (err.kind === 'ack') {
       return describeAckFailure(err);
@@ -105,19 +109,28 @@ export class MessageSender {
   ): Promise<{ seq_id: number }> {
     const body: CatsSendBody = {
       topic_id: topic,
+      client_msg_id: buildClientMessageID(),
       type,
       content,
     };
-    if (metadata !== undefined) {
-      body.metadata = metadata;
-    }
+    body.metadata = {
+      ...(metadata || {}),
+      client_msg_id: body.client_msg_id,
+    };
 
     try {
       const seq = await this.bot.sendStructuredMessage(body);
       return { seq_id: seq };
     } catch (err: any) {
-      if (err instanceof CatsSendError && err.kind === 'transport') {
-        Logger.warning(`WebSocket 链路不可用，准备使用 HTTP 兜底发送（${describeMessage(body)}）：${describeCatsSendFailure(err)}`);
+      if (err instanceof CatsSendError && (err.kind === 'transport' || err.retryableWithHttp)) {
+        if (err.clientMsgID) {
+          body.client_msg_id = err.clientMsgID;
+          body.metadata = {
+            ...(body.metadata || {}),
+            client_msg_id: err.clientMsgID,
+          };
+        }
+        Logger.warning(`WebSocket 链路不可用或确认超时，准备使用 HTTP 兜底发送（${describeMessage(body)}）：${describeCatsSendFailure(err)}`);
         const result = await this.sendViaHttp(body);
         Logger.info(`HTTP 兜底发送成功（${describeMessage(body)}, seq_id=${result.seq_id}）`);
         return result;
@@ -287,4 +300,9 @@ export class MessageSender {
       return null;
     }
   }
+}
+
+function buildClientMessageID(): string {
+  const random = Math.random().toString(36).slice(2, 10);
+  return `catsco-${Date.now()}-${random}`;
 }

--- a/tests/catscompany-message-sender.test.ts
+++ b/tests/catscompany-message-sender.test.ts
@@ -1,0 +1,87 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import { CatsSendError } from '../src/catscompany/client';
+import { MessageSender } from '../src/catscompany/message-sender';
+
+describe('CatsCompany MessageSender retry behavior', () => {
+  test('falls back to HTTP after retryable ack timeout with the same client_msg_id', async () => {
+    const requests: any[] = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (_url: string, init: any) => {
+      requests.push(JSON.parse(init.body));
+      return {
+        ok: true,
+        json: async () => ({ seq_id: 123 }),
+      } as any;
+    }) as any;
+
+    try {
+      const sender = new MessageSender({
+        sendStructuredMessage: async () => {
+          throw new CatsSendError('timeout', 'ack timeout', undefined, {
+            clientMsgID: 'catsco-test-1',
+            retryableWithHttp: true,
+          });
+        },
+      } as any, 'https://app.example.test', 'cc_test');
+
+      await sender.sendText('p2p_1_2', 'hello');
+
+      assert.strictEqual(requests.length, 1);
+      assert.strictEqual(requests[0].client_msg_id, 'catsco-test-1');
+      assert.strictEqual(requests[0].metadata.client_msg_id, 'catsco-test-1');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test('does not HTTP retry ack timeout without server dedupe support', async () => {
+    const originalFetch = globalThis.fetch;
+    let fetchCalled = false;
+    globalThis.fetch = (async () => {
+      fetchCalled = true;
+      throw new Error('should not fetch');
+    }) as any;
+
+    try {
+      const sender = new MessageSender({
+        sendStructuredMessage: async () => {
+          throw new CatsSendError('timeout', 'ack timeout');
+        },
+      } as any, 'https://app.example.test', 'cc_test');
+
+      await assert.rejects(() => sender.sendText('p2p_1_2', 'hello'), /ack timeout/);
+      assert.strictEqual(fetchCalled, false);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test('still HTTP retries transport errors before a WebSocket write', async () => {
+    const requests: any[] = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (_url: string, init: any) => {
+      requests.push(JSON.parse(init.body));
+      return {
+        ok: true,
+        json: async () => ({ seq_id: 456 }),
+      } as any;
+    }) as any;
+
+    try {
+      const sender = new MessageSender({
+        sendStructuredMessage: async () => {
+          throw new CatsSendError('transport', 'socket not open');
+        },
+      } as any, 'https://app.example.test', 'cc_test');
+
+      await sender.sendText('p2p_1_2', 'hello');
+
+      assert.strictEqual(requests.length, 1);
+      assert.match(requests[0].client_msg_id, /^catsco-/);
+      assert.strictEqual(requests[0].metadata.client_msg_id, requests[0].client_msg_id);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
## 改动
- 为 CatsCompany WS 发送增加 `client_msg_id`，在服务端声明幂等能力后，ack timeout 可安全 HTTP 兜底。
- ack timeout 会主动重建 WebSocket，close-before-ack 在旧服务端上不会误当普通 transport 重发。
- HTTP 兜底复用同一个 `client_msg_id`，避免服务端已保存但客户端没收到 ack 时重复消息。
- 增加发送重试行为测试。

## 背景
线上出现“WebSocket 消息已写出但 10 秒内没有收到服务器确认”，最终回复已经生成，但发送确认丢失。这个 PR 配合 CatsCompany 服务端的幂等保存能力，解决半断开/ack 丢失时 final text 无法落到会话的问题。

## 验证
- `npm.cmd run build` 通过
- `node .\\node_modules\\tsx\\dist\\cli.mjs --test tests/catscompany-message-sender.test.ts` 通过，3/3
- `npm.cmd run release:check` 通过
- `git diff --check` 通过，仅 CRLF warning
- `npm.cmd run test:runtime` 中本次改动相关测试通过，但 Node test runner 偶发 `Unable to deserialize cloned data` 落在 `tests/dashboard-catsco-attachments-api.test.ts`；该文件单独复跑通过，11/11