### PR TITLE
修复模型中转超时后的上下文恢复

### DIFF
--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -21,7 +21,7 @@ import {
 } from './runtime-feedback-inbox';
 import { TurnLogRecorder } from './turn-log-recorder';
 import { TurnContextBuilder } from './turn-context-builder';
-import { AgentTurnController } from './agent-turn-controller';
+import { AgentTurnController, AgentTurnRunError } from './agent-turn-controller';
 import { SessionLifecycleManager } from './session-lifecycle-manager';
 import { PlanRuntime } from './plan-runtime';
 import { SubAgentManager } from './sub-agent-manager';
@@ -31,6 +31,7 @@ export type { RuntimeFeedbackInput, RuntimeFeedbackOptions } from './runtime-fee
 
 export const BUSY_MESSAGE = '正在处理上一条消息，请稍候...';
 export const ERROR_MESSAGE = '不好意思，刚才处理出了点问题，你再试一次？';
+export const MODEL_TIMEOUT_MESSAGE = '模型中转请求超时了，我已经保留本轮已完成的工具结果和上下文。你可以直接说“继续”，我会从这里接上。';
 
 // ─── 接口定义 ───────────────────────────────────────────
 
@@ -405,6 +406,11 @@ export class AgentSession {
           return { text: '已停止当前请求。', visibleToUser: true };
         }
 
+        const recoveredMessages = this.getPartialMessagesFromError(err);
+        if (recoveredMessages) {
+          this.messages = recoveredMessages;
+        }
+
         // 不删除用户消息，而是添加一个错误回复，保持上下文连贯
         // 这样用户说"继续"时可以接上
         Logger.error(`[会话 ${this.key}] 处理失败: ${err.message}`);
@@ -412,16 +418,19 @@ export class AgentSession {
         // 识别多模态相关错误
         const errorMsg = err.message || String(err);
         const isVisionError = errorMsg.match(/image|vision|multimodal|media_type|base64.*not supported/i);
+        const isModelTimeoutError = this.isModelTimeoutError(err);
 
         let errorReply = ERROR_MESSAGE;
         if (isVisionError) {
           errorReply = '当前模型不支持图片识别。请使用支持多模态的模型（如 Claude 3.5 Sonnet 或 GPT-4V），或者用文字描述图片内容。';
+        } else if (isModelTimeoutError) {
+          errorReply = MODEL_TIMEOUT_MESSAGE;
         }
 
         // 添加错误回复到上下文，保持对话连贯性
         this.messages.push({
           role: 'assistant',
-          content: `[处理失败: ${err.message}]`
+          content: this.formatErrorContextMessage(err, isModelTimeoutError),
         });
         this.messages = this.turnContextBuilder.removeTransientMessages(this.messages);
         this.lifecycleManager.saveContext(this.messages);
@@ -590,6 +599,42 @@ export class AgentSession {
     return error?.name === 'AbortError'
       || error?.code === 'ERR_CANCELED'
       || /请求已取消|aborted|aborterror|canceled|cancelled/i.test(String(error?.message || ''));
+  }
+
+  private getPartialMessagesFromError(error: AgentTurnRunError): Message[] | null {
+    const partialMessages = error?.partialMessages;
+    if (!Array.isArray(partialMessages) || partialMessages.length === 0) {
+      return null;
+    }
+    return this.turnContextBuilder.removeTransientMessages(partialMessages);
+  }
+
+  private isModelTimeoutError(error: any): boolean {
+    const text = String(error?.message || error || '');
+    return /API错误\s*\(504\)|request_timed_out|request timed out|default_request_timeout_in_seconds|upstream request timeout|gateway timeout/i.test(text);
+  }
+
+  private formatErrorContextMessage(error: any, isModelTimeoutError: boolean): string {
+    const detail = this.sanitizeErrorMessage(error?.message || String(error));
+    if (isModelTimeoutError) {
+      return `[处理中断: 模型中转请求超时。已保留本轮已完成的工具结果和上下文；如果用户要求继续，请基于当前上下文继续，避免重复已经完成的工具步骤。错误摘要: ${detail}]`;
+    }
+    return `[处理失败: ${detail}]`;
+  }
+
+  private sanitizeErrorMessage(message: string): string {
+    const normalized = String(message || 'unknown error')
+      .replace(/Bearer\s+[A-Za-z0-9._-]+/gi, 'Bearer [redacted]')
+      .replace(/\bsk-[A-Za-z0-9_-]{8,}\b/g, 'sk-[redacted]')
+      .replace(/("?api_?key"?\s*[:=]\s*)"?[^"\s,}]+/gi, '$1[redacted]')
+      .replace(/("?authorization"?\s*[:=]\s*)"?[^"\s,}]+/gi, '$1[redacted]')
+      .replace(/\s+/g, ' ')
+      .trim();
+    const maxLength = 600;
+    if (normalized.length <= maxLength) {
+      return normalized;
+    }
+    return `${normalized.slice(0, maxLength)}...(已截断)`;
   }
 
 }

--- a/src/core/agent-turn-controller.ts
+++ b/src/core/agent-turn-controller.ts
@@ -46,6 +46,10 @@ export interface RunAgentTurnResult {
   messages: Message[];
 }
 
+export interface AgentTurnRunError extends Error {
+  partialMessages?: Message[];
+}
+
 export interface AgentTurnControllerOptions {
   sessionKey: string;
   sessionType?: string;
@@ -90,7 +94,17 @@ export class AgentTurnController {
       shouldContinue: params.shouldContinue,
     });
 
-    const result = await runner.run(turnContext.messages, this.toRunnerCallbacks(params.callbacks));
+    let result;
+    try {
+      result = await runner.run(turnContext.messages, this.toRunnerCallbacks(params.callbacks));
+    } catch (error: any) {
+      const partialMessages = this.options.turnContextBuilder.removeTransientMessages(turnContext.messages);
+      this.replaceBase64Images(partialMessages);
+      if (partialMessages.length > 0) {
+        (error as AgentTurnRunError).partialMessages = partialMessages;
+      }
+      throw error;
+    }
     const nextMessages = this.options.turnContextBuilder.removeTransientMessages(result.messages);
 
     const metrics = Metrics.getSummary();

--- a/src/core/sub-agent-manager.ts
+++ b/src/core/sub-agent-manager.ts
@@ -84,6 +84,7 @@ export class SubAgentManager {
   /** 完成后保留信息的时间（ms） */
   private static readonly RETENTION_MS = 30 * 60 * 1000;
   private static readonly PARENT_RESULT_MAX_CHARS = 1800;
+  private static readonly MIN_ID_PREFIX_LENGTH = 'sub-'.length + 4;
 
   private constructor() { }
 
@@ -351,6 +352,23 @@ export class SubAgentManager {
     return result;
   }
 
+  formatRefsForParent(parentSessionKey: string, limit = 6): string {
+    const all = this.listByParent(parentSessionKey);
+    const refs = all.slice(0, limit).map(info => {
+      const label = info.displayName ? `${info.displayName} (${info.id})` : info.id;
+      return `- ${label}: ${info.status}`;
+    });
+    if (refs.length === 0) return '';
+    const suffix = all.length > limit
+      ? `\n- ...还有 ${all.length - limit} 个`
+      : '';
+    return [
+      '当前会话可用子任务：',
+      refs.join('\n') + suffix,
+      '可使用完整 ID、唯一短前缀或展示名（如 子agent1）。',
+    ].join('\n');
+  }
+
   recordEvent(
     parentSessionKey: string,
     subAgentId: string,
@@ -497,11 +515,18 @@ export class SubAgentManager {
     const owner = this.parentMap.get(ref);
     if (owner) return ref;
 
+    let prefixMatch: string | undefined;
     for (const [id, ownerKey] of this.parentMap) {
       if (ownerKey !== parentSessionKey) continue;
       if (this.displayNameByAgent.get(id) === ref) return id;
+      if (ref.length >= SubAgentManager.MIN_ID_PREFIX_LENGTH && id.startsWith(ref)) {
+        if (prefixMatch && prefixMatch !== id) {
+          return undefined;
+        }
+        prefixMatch = id;
+      }
     }
-    return undefined;
+    return prefixMatch;
   }
 
   private logSubAgentEvent(

--- a/src/tools/check-subagent-tool.ts
+++ b/src/tools/check-subagent-tool.ts
@@ -33,7 +33,11 @@ export class CheckSubagentTool implements Tool {
     if (subagent_id) {
       const info = manager.getInfoForParent(sessionKey, subagent_id);
       if (!info) {
-        return { ok: false, errorCode: 'TOOL_NOT_FOUND', message: `未找到子智能体 ${subagent_id}` };
+        return {
+          ok: false,
+          errorCode: 'TOOL_NOT_FOUND',
+          message: [`未找到子智能体 ${subagent_id}。`, manager.formatRefsForParent(sessionKey)].filter(Boolean).join('\n'),
+        };
       }
       return { ok: true, content: this.formatInfo(info) };
     }

--- a/src/tools/resume-subagent-tool.ts
+++ b/src/tools/resume-subagent-tool.ts
@@ -55,7 +55,11 @@ export class ResumeSubagentTool implements Tool {
       case 'forbidden':
         return { ok: false, errorCode: 'PERMISSION_DENIED', message: `无权恢复子智能体 ${subagent_id}。它不属于当前会话。` };
       case 'not_found':
-        return { ok: false, errorCode: 'TOOL_NOT_FOUND', message: `未找到子智能体 ${subagent_id}。` };
+        return {
+          ok: false,
+          errorCode: 'TOOL_NOT_FOUND',
+          message: [`未找到子智能体 ${subagent_id}。`, manager.formatRefsForParent(sessionKey)].filter(Boolean).join('\n'),
+        };
     }
   }
 }

--- a/src/tools/stop-subagent-tool.ts
+++ b/src/tools/stop-subagent-tool.ts
@@ -49,6 +49,10 @@ export class StopSubagentTool implements Tool {
       return { ok: false, errorCode: 'PERMISSION_DENIED', message: `无权停止子智能体 ${subagent_id}。它不属于当前会话。` };
     }
 
-    return { ok: false, errorCode: 'TOOL_NOT_FOUND', message: `未找到子智能体 ${subagent_id}。` };
+    return {
+      ok: false,
+      errorCode: 'TOOL_NOT_FOUND',
+      message: [`未找到子智能体 ${subagent_id}。`, manager.formatRefsForParent(sessionKey)].filter(Boolean).join('\n'),
+    };
   }
 }

--- a/tests/session-lifecycle-manager.test.ts
+++ b/tests/session-lifecycle-manager.test.ts
@@ -168,6 +168,78 @@ describe('AgentSession lifecycle', () => {
     );
   });
 
+  test('handleMessage preserves completed tool context when model relay times out', async () => {
+    const { AgentSession, SessionStore, MODEL_TIMEOUT_MESSAGE } = loadSessionModules();
+    let aiCalls = 0;
+    const toolCall = {
+      id: 'call_read',
+      type: 'function',
+      function: {
+        name: 'read_file',
+        arguments: JSON.stringify({ file_path: 'notes.txt' }),
+      },
+    };
+    const session = new AgentSession('catscompany:lifecycle-timeout-recovery', buildMockServices({
+      aiService: {
+        async chatStream() {
+          aiCalls++;
+          if (aiCalls === 1) {
+            return {
+              content: null,
+              toolCalls: [toolCall],
+              usage: { promptTokens: 10, completionTokens: 2, totalTokens: 12 },
+            };
+          }
+          throw new Error('API错误 (504): 504 {"type":"error","error":{"type":"request_timed_out","message":"request timed out (default is 30 seconds)"}}');
+        },
+      },
+      toolManager: {
+        getToolDefinitions() {
+          return [{
+            name: 'read_file',
+            description: 'read file',
+            parameters: {
+              type: 'object',
+              properties: {
+                file_path: { type: 'string' },
+              },
+              required: ['file_path'],
+            },
+          }];
+        },
+        async executeTool() {
+          return {
+            tool_call_id: 'call_read',
+            role: 'tool',
+            name: 'read_file',
+            content: 'notes content',
+            ok: true,
+          };
+        },
+      },
+    }), 'catscompany');
+    session.setSystemPromptProvider(() => 'system prompt');
+
+    const result = await session.handleMessage('read notes then continue');
+
+    assert.equal(result.text, MODEL_TIMEOUT_MESSAGE);
+    assert.equal(aiCalls, 2);
+
+    const retainedMessages = (session as any).messages as any[];
+    assert.equal(retainedMessages.some(message => message.content === 'notes content'), true);
+    assert.equal(retainedMessages.some(message =>
+      typeof message.content === 'string'
+      && message.content.includes('模型中转请求超时')
+    ), true);
+
+    const restored = SessionStore.getInstance().loadContext('catscompany:lifecycle-timeout-recovery');
+    assert.equal(restored.some(message => message.content === 'notes content'), true);
+    assert.equal(restored.some(message =>
+      typeof message.content === 'string'
+      && message.content.includes('避免重复已经完成的工具步骤')
+    ), true);
+  });
+
   test('cleanup persists without invoking hidden AI wakeup checks', async () => {
     const { AgentSession, SessionStore } = loadSessionModules();
     let aiCalls = 0;
@@ -234,6 +306,7 @@ function loadSessionModules(): any {
   }
   return {
     AgentSession: require('../src/core/agent-session').AgentSession,
+    MODEL_TIMEOUT_MESSAGE: require('../src/core/agent-session').MODEL_TIMEOUT_MESSAGE,
     SessionStore: require('../src/utils/session-store').SessionStore,
   };
 }

--- a/tests/subagent-runtime-events.test.ts
+++ b/tests/subagent-runtime-events.test.ts
@@ -830,6 +830,93 @@ describe('subagent runtime events', () => {
     }
   });
 
+  test('manager resolves unique short subagent id prefixes', () => {
+    const manager = SubAgentManager.getInstance();
+    const parentSessionKey = `test-parent:${Date.now()}:short-id`;
+    const subAgentId = 'sub-de0f25a1-291d-425c-9e34-c3ca17b8a9c3';
+    let resumedAnswer = '';
+    const fakeSession = {
+      status: 'waiting_for_input',
+      resume(answer: string) {
+        resumedAnswer = answer;
+        this.status = 'running';
+        return true;
+      },
+      getInfo() {
+        return {
+          id: subAgentId,
+          agentType: 'explorer',
+          skillName: 'explorer',
+          toolScope: 'read_only',
+          allowedTools: ['read_file', 'ask_parent'],
+          taskDescription: 'github search',
+          status: this.status,
+          createdAt: Date.now(),
+          progressLog: [],
+          pendingQuestion: this.status === 'waiting_for_input' ? 'need github data' : undefined,
+          pendingQuestionSince: Date.now(),
+          outputFiles: [],
+        };
+      },
+    };
+
+    (manager as any).subAgents.set(subAgentId, fakeSession);
+    (manager as any).parentMap.set(subAgentId, parentSessionKey);
+    (manager as any).displayNameByAgent.set(subAgentId, '子agent1');
+
+    try {
+      assert.equal(manager.getInfoForParent(parentSessionKey, 'sub-de0f25a1')?.id, subAgentId);
+      assert.equal(manager.resumeForParent(parentSessionKey, 'sub-de0f25a1', 'search results'), 'resumed');
+      assert.equal(resumedAnswer, 'search results');
+      assert.equal(fakeSession.status, 'running');
+    } finally {
+      (manager as any).subAgents.delete(subAgentId);
+      (manager as any).parentMap.delete(subAgentId);
+      (manager as any).displayNameByAgent.delete(subAgentId);
+    }
+  });
+
+  test('manager does not resolve ambiguous short subagent id prefixes', () => {
+    const manager = SubAgentManager.getInstance();
+    const parentSessionKey = `test-parent:${Date.now()}:ambiguous-short-id`;
+    const ids = [
+      'sub-abcdef01-1111-425c-9e34-c3ca17b8a9c3',
+      'sub-abcdef01-2222-425c-9e34-c3ca17b8a9c3',
+    ];
+    const makeSession = (id: string) => ({
+      status: 'running',
+      getInfo() {
+        return {
+          id,
+          agentType: 'explorer',
+          skillName: 'explorer',
+          toolScope: 'read_only',
+          allowedTools: ['read_file'],
+          taskDescription: 'ambiguous',
+          status: this.status,
+          createdAt: Date.now(),
+          progressLog: [],
+          outputFiles: [],
+        };
+      },
+    });
+
+    for (const id of ids) {
+      (manager as any).subAgents.set(id, makeSession(id));
+      (manager as any).parentMap.set(id, parentSessionKey);
+    }
+
+    try {
+      assert.equal(manager.getInfoForParent(parentSessionKey, 'sub-abcdef01'), undefined);
+      assert.equal(manager.stopForParent(parentSessionKey, 'sub-abcdef01'), 'not_found');
+    } finally {
+      for (const id of ids) {
+        (manager as any).subAgents.delete(id);
+        (manager as any).parentMap.delete(id);
+      }
+    }
+  });
+
   test('manager stops all active subagents for a parent episode', () => {
     const manager = SubAgentManager.getInstance();
     const parentSessionKey = `test-parent:${Date.now()}:stop-all`;


### PR DESCRIPTION
## 背景

本地日志里的 504 来自 relay/Bifrost 的 provider network timeout：`request_timed_out` 在约 30 秒触发。长上下文、多轮工具任务里，一旦第二次/后续模型请求超时，CatsCo 之前只返回通用错误，且本轮已经完成的工具 transcript 可能没有落回 durable session，用户说“继续”时容易断上下文。

## 改动

- 在 `AgentTurnController` 捕获模型/runner 异常时，把本轮已构造的非 transient 消息作为 partial context 挂到错误上。
- 在 `AgentSession` 处理异常时优先恢复 partial context，再写入错误消息并保存本地上下文。
- 专门识别 504 / `request_timed_out` / `default_request_timeout_in_seconds` 等中转超时错误，给用户返回可继续的明确提示。
- 对写入上下文的错误摘要做基础脱敏和长度截断。
- 子 agent 工具支持唯一短 ID 前缀，并在找不到子任务时提示当前会话可用子任务，避免用户只拿日志里的短 ID 无法恢复。

## 验证

- `npm.cmd run build`
- `node node_modules\tsx\dist\cli.mjs --test tests\session-lifecycle-manager.test.ts tests\subagent-runtime-events.test.ts`
- `npm.cmd run test:runtime`
- `npm.cmd run release:check`
- `git diff --check`

说明：按要求尝试启动了两个只读子 agent 做独立复核，但两个 agent 都未在限定时间内返回，已关闭，未采用其输出。

## 后续线上配置

代码侧只能让 CatsCo 在超时时保留工作现场并可继续。线上 relay 仍建议把 Bifrost anthropic provider 的 `network_config.default_request_timeout_in_seconds` 从 30 秒调大，并评估是否开启少量 retry；这部分不在本 PR 改动范围内。
