### PR TITLE
[codex] 修复 max_tokens 空回复处理

### DIFF
--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -286,15 +286,7 @@ export class ConversationRunner {
             continue;
           }
 
-          const finalAssistantMessage: Message = { role: 'assistant', content: EMPTY_MAX_TOKENS_MESSAGE };
-          messages.push(finalAssistantMessage);
-          newMessages.push(finalAssistantMessage);
-          return {
-            response: EMPTY_MAX_TOKENS_MESSAGE,
-            finalResponseVisible: true,
-            messages,
-            newMessages,
-          };
+          response = { ...response, content: EMPTY_MAX_TOKENS_MESSAGE, toolCalls: [] };
         }
 
         Logger.info(`[${this.sessionLabel}Turn ${turns}] AI最终回复: ${ConversationRunner.truncateForLog(response.content || '', 300)}`);

--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -1,4 +1,4 @@
-import { Message, ContentBlock } from '../types';
+import { Message, ContentBlock, ChatResponse } from '../types';
 import { AIService } from '../utils/ai-service';
 import { ToolCall, ToolDefinition, ToolExecutionContext, ToolExecutor, ToolResult, ToolTranscriptMode } from '../types/tool';
 import { StreamCallbacks } from '../providers/provider';
@@ -47,6 +47,8 @@ const ANTHROPIC_PROMPT_BUDGET = 200000;
 const MIN_MESSAGE_BUDGET = 2000;
 const OVERFLOW_REDUCTION_RATIO = 0.6;
 const TRANSIENT_CURRENT_DIRECTORY_PREFIX = '[transient_current_directory]';
+const MAX_EMPTY_MAX_TOKEN_RECOVERIES = 1;
+const EMPTY_MAX_TOKENS_MESSAGE = '模型这轮输出达到了 max_tokens 上限，但没有生成可见回复或工具调用。已保留当前上下文；请回复“继续”，我会从刚才的位置继续推进。';
 
 /**
  * 对话运行回调
@@ -186,6 +188,7 @@ export class ConversationRunner {
     let subagentSoftNudgeCount = 0;
     let nextPlanNudgeAt = nextPlanNudgeToolCount(0);
     let nextSubagentNudgeAt = nextSubagentNudgeToolCount(0);
+    let emptyMaxTokenRecoveries = 0;
 
     while (true) {
       turns++;
@@ -275,6 +278,25 @@ export class ConversationRunner {
       }
 
       if (!response.toolCalls || response.toolCalls.length === 0) {
+        if (this.isEmptyMaxTokensResponse(response)) {
+          Logger.warning(`[${this.sessionLabel}Turn ${turns}] 模型输出达到 max_tokens 且没有可见内容或工具调用`);
+          if (emptyMaxTokenRecoveries < MAX_EMPTY_MAX_TOKEN_RECOVERIES) {
+            emptyMaxTokenRecoveries++;
+            nextTurnTransientHints = [this.buildEmptyMaxTokensRecoveryHint()];
+            continue;
+          }
+
+          const finalAssistantMessage: Message = { role: 'assistant', content: EMPTY_MAX_TOKENS_MESSAGE };
+          messages.push(finalAssistantMessage);
+          newMessages.push(finalAssistantMessage);
+          return {
+            response: EMPTY_MAX_TOKENS_MESSAGE,
+            finalResponseVisible: true,
+            messages,
+            newMessages,
+          };
+        }
+
         Logger.info(`[${this.sessionLabel}Turn ${turns}] AI最终回复: ${ConversationRunner.truncateForLog(response.content || '', 300)}`);
 
         if (response.content) {
@@ -797,6 +819,25 @@ export class ConversationRunner {
     return {
       role: 'system',
       content: `${TRANSIENT_RUNNER_HINT_PREFIX}\n你刚刚连续发送了与上一条相同的内容：“${content}”。如果这是用户真正需要的重复确认，可以继续；否则请避免无意义重复，必要时调用 pause_turn 收束。`,
+    };
+  }
+
+  private isEmptyMaxTokensResponse(response: ChatResponse): boolean {
+    const stopReason = String(response.stopReason || '').toLowerCase();
+    const content = typeof response.content === 'string' ? response.content.trim() : '';
+    return !content
+      && (!response.toolCalls || response.toolCalls.length === 0)
+      && (stopReason === 'max_tokens' || stopReason === 'length');
+  }
+
+  private buildEmptyMaxTokensRecoveryHint(): Message {
+    return {
+      role: 'system',
+      content: [
+        TRANSIENT_RUNNER_HINT_PREFIX,
+        '上一轮模型响应因为输出 max_tokens 上限被截断，而且没有生成可见文本或工具调用。',
+        '不要继续展开隐藏推理。请立即二选一：调用下一步必要工具，或输出简短可见回复说明当前进展和下一步。',
+      ].join('\n'),
     };
   }
 

--- a/src/providers/anthropic-provider.ts
+++ b/src/providers/anthropic-provider.ts
@@ -3,6 +3,7 @@ import { Message, ChatConfig, ChatResponse, ContentBlock } from '../types';
 import { ToolDefinition } from '../types/tool';
 import { AIProvider, AIRequestOptions, StreamCallbacks } from './provider';
 import { ContextDebugLogger } from '../utils/context-debug-logger';
+import { resolveMaxTokens } from './output-limits';
 
 /**
  * Anthropic Provider
@@ -31,7 +32,7 @@ export class AnthropicProvider implements AIProvider {
     });
     this.model = config.model || 'claude-sonnet-4-20250514';
     this.temperature = config.temperature ?? 0.7;
-    this.maxTokens = config.maxTokens ?? 8192;
+    this.maxTokens = resolveMaxTokens(config);
   }
 
   /**
@@ -197,12 +198,12 @@ export class AnthropicProvider implements AIProvider {
    * 从 Anthropic 响应中提取统一格式
    */
   private parseResponse(response: Anthropic.Message): ChatResponse {
-    let textContent: string | null = null;
+    const textParts: string[] = [];
     let toolCalls: ChatResponse['toolCalls'] = undefined;
 
     for (const block of response.content) {
       if (block.type === 'text') {
-        textContent = block.text;
+        textParts.push(block.text);
       } else if (block.type === 'tool_use') {
         if (!toolCalls) toolCalls = [];
         toolCalls.push({
@@ -223,7 +224,12 @@ export class AnthropicProvider implements AIProvider {
       totalTokens: (response.usage.input_tokens ?? 0) + (response.usage.output_tokens ?? 0),
     } : undefined;
 
-    return { content: textContent, toolCalls, usage };
+    return {
+      content: textParts.length > 0 ? textParts.join('') : null,
+      toolCalls,
+      usage,
+      stopReason: response.stop_reason || undefined,
+    };
   }
 
   /**

--- a/src/providers/openai-provider.ts
+++ b/src/providers/openai-provider.ts
@@ -4,6 +4,7 @@ import { ToolDefinition } from '../types/tool';
 import { AIProvider, AIRequestOptions, StreamCallbacks } from './provider';
 import { ContextDebugLogger } from '../utils/context-debug-logger';
 import { normalizeOpenAIChatCompletionsUrl } from './openai-url';
+import { resolveMaxTokens } from './output-limits';
 
 /**
  * OpenAI Provider
@@ -24,7 +25,7 @@ export class OpenAIProvider implements AIProvider {
     this.apiKey = config.apiKey!;
     this.model = config.model || 'gpt-4o';
     this.temperature = config.temperature ?? 0.7;
-    this.maxTokens = config.maxTokens ?? 8192;
+    this.maxTokens = resolveMaxTokens(config);
   }
 
   /**
@@ -117,7 +118,8 @@ export class OpenAIProvider implements AIProvider {
       headers: this.headers,
       signal: options?.signal,
     });
-    const message = response.data.choices[0].message;
+    const choice = response.data.choices[0];
+    const message = choice.message;
     const usage = response.data.usage;
 
     ContextDebugLogger.dumpSdkBoundary('after', undefined, {
@@ -127,6 +129,7 @@ export class OpenAIProvider implements AIProvider {
     return {
       content: message.content || null,
       toolCalls: message.tool_calls,
+      stopReason: choice.finish_reason || undefined,
       usage: usage ? {
         promptTokens: usage.prompt_tokens ?? 0,
         completionTokens: usage.completion_tokens ?? 0,
@@ -162,6 +165,7 @@ export class OpenAIProvider implements AIProvider {
       const toolCallsMap = new Map<number, { id: string; type: 'function'; function: { name: string; arguments: string } }>();
       let buffer = '';
       let streamUsage: ChatResponse['usage'] = undefined;
+      let finishReason: string | undefined;
 
       const stream = response.data;
       const onAbort = () => {
@@ -187,6 +191,10 @@ export class OpenAIProvider implements AIProvider {
 
           try {
             const parsed = JSON.parse(data);
+            const choice = parsed.choices?.[0];
+            if (choice?.finish_reason) {
+              finishReason = choice.finish_reason;
+            }
 
             // 提取 usage（stream_options.include_usage 时在最后一个 chunk 返回）
             if (parsed.usage) {
@@ -197,7 +205,7 @@ export class OpenAIProvider implements AIProvider {
               };
             }
 
-            const delta = parsed.choices?.[0]?.delta;
+            const delta = choice?.delta;
             if (!delta) continue;
 
             // 文本内容
@@ -239,6 +247,7 @@ export class OpenAIProvider implements AIProvider {
           content: fullContent || null,
           toolCalls,
           usage: streamUsage,
+          stopReason: finishReason,
         };
 
         ContextDebugLogger.dumpSdkBoundary('after', undefined, {

--- a/src/providers/output-limits.ts
+++ b/src/providers/output-limits.ts
@@ -1,0 +1,18 @@
+import { ChatConfig } from '../types';
+
+const DEFAULT_MAX_TOKENS = 8192;
+const DEFAULT_RELAY_MAX_TOKENS = 32768;
+
+export function resolveMaxTokens(config: ChatConfig): number {
+  if (Number.isFinite(config.maxTokens) && Number(config.maxTokens) > 0) {
+    return Math.floor(Number(config.maxTokens));
+  }
+
+  const apiUrl = (config.apiUrl || '').toLowerCase();
+  const model = (config.model || '').toLowerCase();
+  if (apiUrl.includes('relay.catsco.cc') || model.includes('minimax-m2.7')) {
+    return DEFAULT_RELAY_MAX_TOKENS;
+  }
+
+  return DEFAULT_MAX_TOKENS;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -76,6 +76,8 @@ export interface ChatResponse {
     };
   }>;
   usage?: TokenUsage;
+  /** Provider stop/finish reason, e.g. max_tokens/length/tool_use/stop. */
+  stopReason?: string;
 }
 
 export interface CommandOptions {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -122,6 +122,10 @@ export class ConfigManager {
     const apiUrl = process.env.GAUZ_LLM_API_BASE?.trim();
     const apiKey = process.env.GAUZ_LLM_API_KEY?.trim();
     const model = process.env.GAUZ_LLM_MODEL?.trim();
+    const maxTokens = this.parsePositiveIntegerEnv(
+      process.env.GAUZ_LLM_MAX_OUTPUT_TOKENS,
+      process.env.GAUZ_LLM_MAX_TOKENS,
+    );
 
     if (provider === 'openai' || provider === 'anthropic') {
       override.provider = provider;
@@ -135,7 +139,22 @@ export class ConfigManager {
     if (model) {
       override.model = model;
     }
+    if (maxTokens !== undefined) {
+      override.maxTokens = maxTokens;
+    }
 
     return override;
+  }
+
+  private static parsePositiveIntegerEnv(...values: Array<string | undefined>): number | undefined {
+    for (const value of values) {
+      const text = value?.trim();
+      if (!text) continue;
+      const parsed = Number(text);
+      if (Number.isFinite(parsed) && parsed > 0) {
+        return Math.floor(parsed);
+      }
+    }
+    return undefined;
   }
 }

--- a/tests/anthropic-provider-runtime-feedback.test.ts
+++ b/tests/anthropic-provider-runtime-feedback.test.ts
@@ -41,4 +41,29 @@ describe('AnthropicProvider runtime feedback boundary', () => {
     assert.equal(JSON.stringify(transformed).includes('runtimeObservationSource'), false);
     assert.equal(JSON.stringify(transformed).includes('must not leak'), false);
   });
+
+  test('preserves stop reason and joins multiple text blocks', () => {
+    const provider = new AnthropicProvider({
+      apiKey: 'test-key',
+      apiUrl: 'https://relay.catsco.cc/anthropic/v1/messages',
+      model: 'MiniMax-M2.7',
+    });
+
+    const result = (provider as any).parseResponse({
+      content: [
+        { type: 'text', text: 'hello ' },
+        { type: 'text', text: 'world' },
+      ],
+      stop_reason: 'max_tokens',
+      usage: {
+        input_tokens: 10,
+        output_tokens: 20,
+      },
+    });
+
+    assert.equal(result.content, 'hello world');
+    assert.equal(result.stopReason, 'max_tokens');
+    assert.equal(result.usage.totalTokens, 30);
+    assert.equal((provider as any).maxTokens, 32768);
+  });
 });

--- a/tests/config-manager-merge.test.ts
+++ b/tests/config-manager-merge.test.ts
@@ -105,6 +105,7 @@ test('ConfigManager merges env-backed LLM config with partial user config file',
       'GAUZ_LLM_API_BASE=https://api.deepseek.com/v1/chat/completions',
       'GAUZ_LLM_API_KEY=test-key',
       'GAUZ_LLM_MODEL=deepseek-chat',
+      'GAUZ_LLM_MAX_OUTPUT_TOKENS=32768',
     ].join('\n'),
   );
   fs.writeFileSync(
@@ -123,6 +124,7 @@ test('ConfigManager merges env-backed LLM config with partial user config file',
   assert.equal(config.apiUrl, 'https://api.deepseek.com/v1/chat/completions');
   assert.equal(config.apiKey, 'test-key');
   assert.equal(config.model, 'deepseek-chat');
+  assert.equal(config.maxTokens, 32768);
   assert.equal(config.catscompany.serverUrl, 'ws://example.com/v0/channels');
   assert.equal(config.catscompany.apiKey, 'cc_test_key');
 });

--- a/tests/conversation-runner-transcript-normalization.test.ts
+++ b/tests/conversation-runner-transcript-normalization.test.ts
@@ -213,6 +213,68 @@ test('runner injects current directory before the active request context without
   );
 });
 
+test('runner recovers once from empty max_tokens responses before surfacing a fallback', async () => {
+  const responses: ChatResponse[] = [
+    {
+      content: null,
+      toolCalls: [],
+      stopReason: 'max_tokens',
+      usage: {
+        promptTokens: 100,
+        completionTokens: 8192,
+        totalTokens: 8292,
+      },
+    },
+    makeFinalResponse('已继续处理。'),
+  ];
+  const mock = createMockAI(responses);
+  const runner = new ConversationRunner(mock.aiService, new MockToolExecutor([], {}), {
+    stream: true,
+    enableCompression: false,
+  });
+
+  const result = await runner.run([{ role: 'user', content: '继续包装 skill' }]);
+
+  assert.equal(result.response, '已继续处理。');
+  assert.equal(mock.getReceivedMessages().length, 2);
+  assert.ok(
+    mock.getReceivedMessages()[1].some(message =>
+      message.role === 'system'
+      && typeof message.content === 'string'
+      && message.content.includes('输出 max_tokens 上限被截断')
+    ),
+    'second call should include a recovery hint',
+  );
+});
+
+test('runner does not return raw no-reply when empty max_tokens recovery fails', async () => {
+  const responses: ChatResponse[] = [
+    {
+      content: null,
+      toolCalls: [],
+      stopReason: 'max_tokens',
+      usage: { promptTokens: 100, completionTokens: 8192, totalTokens: 8292 },
+    },
+    {
+      content: null,
+      toolCalls: [],
+      stopReason: 'max_tokens',
+      usage: { promptTokens: 100, completionTokens: 8192, totalTokens: 8292 },
+    },
+  ];
+  const mock = createMockAI(responses);
+  const runner = new ConversationRunner(mock.aiService, new MockToolExecutor([], {}), {
+    stream: true,
+    enableCompression: false,
+  });
+
+  const result = await runner.run([{ role: 'user', content: '继续包装 skill' }]);
+
+  assert.match(result.response, /模型这轮输出达到了 max_tokens 上限/);
+  assert.notEqual(result.response, '[无回复]');
+  assert.equal(result.messages[result.messages.length - 1]?.content, result.response);
+});
+
 test('runner does not persist assistant draft content when send_text already delivered the same turn', async () => {
   const responses = [
     {

--- a/tests/conversation-runner-transcript-normalization.test.ts
+++ b/tests/conversation-runner-transcript-normalization.test.ts
@@ -275,6 +275,44 @@ test('runner does not return raw no-reply when empty max_tokens recovery fails',
   assert.equal(result.messages[result.messages.length - 1]?.content, result.response);
 });
 
+test('runner sends empty max_tokens fallback through message surface channel', async () => {
+  const responses: ChatResponse[] = [
+    {
+      content: null,
+      toolCalls: [],
+      stopReason: 'max_tokens',
+      usage: { promptTokens: 100, completionTokens: 8192, totalTokens: 8292 },
+    },
+    {
+      content: null,
+      toolCalls: [],
+      stopReason: 'max_tokens',
+      usage: { promptTokens: 100, completionTokens: 8192, totalTokens: 8292 },
+    },
+  ];
+  const sent: Array<{ chatId: string; text: string }> = [];
+  const mock = createMockAI(responses);
+  const runner = new ConversationRunner(mock.aiService, new MockToolExecutor([], {}), {
+    stream: true,
+    enableCompression: false,
+    toolExecutionContext: {
+      surface: 'feishu',
+      channel: {
+        chatId: 'chat_1',
+        reply: async (chatId: string, text: string) => {
+          sent.push({ chatId, text });
+        },
+        sendFile: async () => {},
+      },
+    },
+  });
+
+  const result = await runner.run([{ role: 'user', content: '继续包装 skill' }]);
+
+  assert.match(result.response, /模型这轮输出达到了 max_tokens 上限/);
+  assert.deepEqual(sent, [{ chatId: 'chat_1', text: result.response }]);
+});
+
 test('runner does not persist assistant draft content when send_text already delivered the same turn', async () => {
   const responses = [
     {

--- a/tests/openai-provider-runtime-feedback.test.ts
+++ b/tests/openai-provider-runtime-feedback.test.ts
@@ -1,5 +1,7 @@
 import { describe, test } from 'node:test';
 import * as assert from 'node:assert';
+import { Readable } from 'node:stream';
+import axios from 'axios';
 import { OpenAIProvider } from '../src/providers/openai-provider';
 import { Message } from '../src/types';
 
@@ -50,5 +52,71 @@ describe('OpenAIProvider runtime feedback boundary', () => {
     assert.equal(JSON.stringify(body.messages).includes('__runtimeObservation'), false);
     assert.equal(JSON.stringify(body.messages).includes('runtimeObservationSource'), false);
     assert.equal(JSON.stringify(body.messages).includes('must not leak'), false);
+  });
+
+  test('preserves finish reason for non-stream responses', async () => {
+    const originalPost = axios.post;
+    (axios as any).post = async () => ({
+      data: {
+        choices: [{
+          finish_reason: 'length',
+          message: { content: 'ok' },
+        }],
+        usage: {
+          prompt_tokens: 1,
+          completion_tokens: 2,
+          total_tokens: 3,
+        },
+      },
+    });
+
+    try {
+      const provider = new OpenAIProvider({
+        apiKey: 'test-key',
+        apiUrl: 'https://example.test/v1/chat/completions',
+        model: 'test-model',
+      });
+
+      const result = await provider.chat([{ role: 'user', content: 'hello' }]);
+
+      assert.equal(result.content, 'ok');
+      assert.equal(result.stopReason, 'length');
+      assert.equal(result.usage?.totalTokens, 3);
+    } finally {
+      (axios as any).post = originalPost;
+    }
+  });
+
+  test('preserves finish reason for stream responses', async () => {
+    const originalPost = axios.post;
+    (axios as any).post = async () => ({
+      data: Readable.from([
+        'data: {"choices":[{"delta":{"content":"hel"}}]}\n\n',
+        'data: {"choices":[{"delta":{"content":"lo"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}}\n\n',
+        'data: [DONE]\n\n',
+      ]),
+    });
+
+    try {
+      const provider = new OpenAIProvider({
+        apiKey: 'test-key',
+        apiUrl: 'https://example.test/v1/chat/completions',
+        model: 'test-model',
+      });
+      const chunks: string[] = [];
+
+      const result = await provider.chatStream(
+        [{ role: 'user', content: 'hello' }],
+        undefined,
+        { onText: chunk => chunks.push(chunk) },
+      );
+
+      assert.equal(result.content, 'hello');
+      assert.equal(result.stopReason, 'stop');
+      assert.equal(result.usage?.totalTokens, 3);
+      assert.deepEqual(chunks, ['hel', 'lo']);
+    } finally {
+      (axios as any).post = originalPost;
+    }
   });
 });

--- a/tests/provider-output-limits.test.ts
+++ b/tests/provider-output-limits.test.ts
@@ -1,0 +1,41 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveMaxTokens } from '../src/providers/output-limits';
+
+test('resolveMaxTokens prefers explicit config value over relay defaults', () => {
+  assert.equal(
+    resolveMaxTokens({
+      apiUrl: 'https://relay.catsco.cc/anthropic/v1/messages',
+      model: 'MiniMax-M2.7',
+      maxTokens: 12345,
+    }),
+    12345,
+  );
+});
+
+test('resolveMaxTokens uses higher default for CatsCo relay and MiniMax M2.7', () => {
+  assert.equal(
+    resolveMaxTokens({
+      apiUrl: 'https://relay.catsco.cc/v1/chat/completions',
+      model: 'other-model',
+    }),
+    32768,
+  );
+  assert.equal(
+    resolveMaxTokens({
+      apiUrl: 'https://example.test/v1/chat/completions',
+      model: 'MiniMax-M2.7',
+    }),
+    32768,
+  );
+});
+
+test('resolveMaxTokens keeps the conservative default for other providers', () => {
+  assert.equal(
+    resolveMaxTokens({
+      apiUrl: 'https://api.openai.com/v1/chat/completions',
+      model: 'gpt-4o',
+    }),
+    8192,
+  );
+});


### PR DESCRIPTION
## 概要
- relay.catsco.cc / MiniMax-M2.7 默认输出上限提升到 32768，仍允许用户配置覆盖
- 支持 `GAUZ_LLM_MAX_OUTPUT_TOKENS` / `GAUZ_LLM_MAX_TOKENS` 环境变量覆盖输出上限
- Anthropic/OpenAI provider 透传 stop/finish reason
- 当模型因为 max_tokens/length 截断且没有可见文本或工具调用时，runner 先注入一次恢复提示；重复失败时返回明确提示，不再落到 `[无回复]`

## 背景
MiniMax-M2.7 经 Bifrost/Anthropic-compatible 返回时，曾出现 completion_tokens 达到 8192、stop_reason=max_tokens，但响应只有 reasoning 内容、没有 text/tool_use 的情况。CatsCo 会把这轮当作成功空回复，最终发送 `[无回复]`，用户感知为工作中断。

## 验证
- `npm.cmd run build`
- `node .\node_modules\tsx\dist\cli.mjs --test tests\conversation-runner-transcript-normalization.test.ts tests\anthropic-provider-runtime-feedback.test.ts tests\config-manager-merge.test.ts`
- `npm.cmd run release:check`
- `git diff --check`
- `npm.cmd run test:runtime`（首次命中 Node test runner IPC 反序列化波动，单测重跑通过，随后完整重跑通过）
- `npm.cmd run test:all`