### PR TITLE
[codex] 修复子 agent 结果回流后可见回复漏发

### DIFF
--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -629,6 +629,12 @@ export class CatsCompanyBot {
         } catch (err: any) {
           Logger.warning(`错误消息发送失败: ${err.message}`);
         }
+      } else if (result.visibleToUser && result.text) {
+        try {
+          await this.sender.sendText(topic, result.text);
+        } catch (err: any) {
+          Logger.warning(`子智能体结果回复发送失败: ${err.message}`);
+        }
       }
       await this.drainMessageQueue(sessionKey);
     } finally {
@@ -778,18 +784,17 @@ export class CatsCompanyBot {
           runtimeFeedback: msg.runtimeFeedback,
           pendingUserInputProvider: () => this.consumeQueuedUserInput(sessionKey),
         });
-      if (result.text !== BUSY_MESSAGE && result.visibleToUser && result.text) {
-        try {
-          await this.sender.sendText(msg.topic, result.text);
-        } catch (err: any) {
-          Logger.warning(`队列消息回复发送失败: ${err.message}`);
-        }
-      }
       if (result.text.startsWith('处理消息时出错:')) {
         try {
           await this.sender.reply(msg.topic, result.text);
         } catch (err: any) {
           Logger.warning(`错误消息发送失败: ${err.message}`);
+        }
+      } else if (result.text !== BUSY_MESSAGE && result.visibleToUser && result.text) {
+        try {
+          await this.sender.sendText(msg.topic, result.text);
+        } catch (err: any) {
+          Logger.warning(`队列消息回复发送失败: ${err.message}`);
         }
       }
     } finally {

--- a/tests/catscompany-content-blocks.test.ts
+++ b/tests/catscompany-content-blocks.test.ts
@@ -7,6 +7,9 @@ function createProcessHarness() {
   const downloads: Array<{ url: string; fileName: string }> = [];
   const multimodalCalls: Array<{ text: string; attachments: any[] }> = [];
   const handledTurns: Array<{ userMessage: any; options: any }> = [];
+  const runtimeObservations: Array<{ text: string; options: any }> = [];
+  const sentTexts: Array<{ topic: string; text: string }> = [];
+  const replies: Array<{ topic: string; text: string }> = [];
   const sentThinking: Array<{ text: string; metadata?: any }> = [];
   const toolUses: Array<{ topic: string; toolUseId: string; name: string; input: any; metadata?: any }> = [];
   const toolResults: Array<{ topic: string; toolUseId: string; content: string; isError?: boolean; metadata?: any }> = [];
@@ -15,6 +18,10 @@ function createProcessHarness() {
     isBusy: () => false,
     handleMessage: async (userMessage: any, options: any) => {
       handledTurns.push({ userMessage, options });
+      return { visibleToUser: false, text: '' };
+    },
+    handleRuntimeObservation: async (text: string, options: any) => {
+      runtimeObservations.push({ text, options });
       return { visibleToUser: false, text: '' };
     },
   };
@@ -29,9 +36,13 @@ function createProcessHarness() {
       return `C:\\tmp\\catsco-test\\${fileName}`;
     },
     sendTyping: () => undefined,
-    reply: async () => undefined,
+    reply: async (topic: string, text: string) => {
+      replies.push({ topic, text });
+    },
     sendFile: async () => undefined,
-    sendText: async () => undefined,
+    sendText: async (topic: string, text: string) => {
+      sentTexts.push({ topic, text });
+    },
     sendThinking: async (_topic: string, text: string, metadata?: any) => {
       sentThinking.push({ text, metadata });
     },
@@ -58,7 +69,7 @@ function createProcessHarness() {
     ];
   };
 
-  return { bot, downloads, multimodalCalls, handledTurns, sentThinking, toolUses, toolResults };
+  return { bot, downloads, multimodalCalls, handledTurns, runtimeObservations, sentTexts, replies, sentThinking, toolUses, toolResults, session };
 }
 
 describe('CatsCo content blocks', () => {
@@ -296,5 +307,49 @@ describe('CatsCo content blocks', () => {
     assert.match(toolResults[0].content, /已完成/);
     assert.match(toolResults[0].content, /登录链路正常/);
     assert.match(toolResults[0].content, /logs\/report\.md/);
+  });
+
+  test('subagent feedback visible reply is sent back to CatsCompany', async () => {
+    const { bot, runtimeObservations, sentTexts, session } = createProcessHarness();
+    session.handleRuntimeObservation = async (text: string, options: any) => {
+      runtimeObservations.push({ text, options });
+      return { visibleToUser: true, text: '已根据子 agent 结果处理完。' };
+    };
+
+    await (bot as any).handleSubAgentFeedback(
+      'cc_user:usr38',
+      'p2p_38_110',
+      'usr38',
+      '[子agent1 已完成]\n结果摘要：审查完成',
+    );
+
+    assert.strictEqual(runtimeObservations.length, 1);
+    assert.strictEqual(runtimeObservations[0].options.source, 'subagent_result');
+    assert.deepStrictEqual(sentTexts, [
+      { topic: 'p2p_38_110', text: '已根据子 agent 结果处理完。' },
+    ]);
+  });
+
+  test('queued subagent error reply is not sent twice', async () => {
+    const { bot, sentTexts, replies, session } = createProcessHarness();
+    session.handleRuntimeObservation = async () => ({
+      visibleToUser: true,
+      text: '处理消息时出错: 子 agent 结果处理失败',
+    });
+    bot.messageQueue.set('cc_user:usr38', [{
+      userMessage: '[子agent1 已完成]\n结果摘要：审查完成',
+      topic: 'p2p_38_110',
+      senderId: 'usr38',
+      seq: 0,
+      receivedAt: Date.now(),
+      source: 'subagent_feedback',
+    }]);
+
+    await (bot as any).drainMessageQueue('cc_user:usr38');
+
+    assert.deepStrictEqual(sentTexts, []);
+    assert.deepStrictEqual(replies, [
+      { topic: 'p2p_38_110', text: '处理消息时出错: 子 agent 结果处理失败' },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- 将子 agent runtime observation 生成的可见回复发送回 CatsCompany
- 错误前缀回复仍走 reply 路径，避免队列场景重复发送
- 增加直接子 agent 回流和队列错误回流的回归测试

## Root Cause
`handleSubAgentFeedback()` 只处理了 `handleRuntimeObservation()` 的错误返回，没有发送正常的 `visibleToUser` 文本，导致最终回复已写入日志/会话，但 CatsCompany 前端只看到 WORKING。

## Validation
- `node --import tsx --test tests/catscompany-content-blocks.test.ts`
- `node --import tsx --test tests/subagent-runtime-events.test.ts`
- `npm.cmd run build`
- `git diff --check`

## Review
- Peirce 和 Pauli 两个子 agent 审查均未发现阻塞问题
- 已按审查意见补上队列错误回复不重复发送的保护
