### PR TITLE
完善 CatsCo 中转模型启用与 M3 工具回放

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -7639,7 +7639,7 @@
         });
         const data=await r.json().catch(()=>({}));
         if(r.status===409&&data.action==='rotate_required'){
-          const ok=confirm('你的 CatsCo 中转 Key 已存在，但明文不会再次返回。要重新生成并写入 CatsCo 桌面端吗？旧 Key 会立即失效。');
+          const ok=confirm('你的 CatsCo 中转 Key 已存在，但当前无法读取明文。要重新生成并写入 CatsCo 桌面端吗？旧 Key 会立即失效。');
           if(ok){
             retrying=true;
             setRelayModelApplyBusy(false);
@@ -8632,7 +8632,7 @@
         }
       }catch(e){
         if(e.status===409 && e.action==='rotate_required'){
-          const ok=confirm('你的 CatsCo 中转 Key 已存在，但明文不会再次返回。要重新生成并写入 CatsCo 桌面端吗？旧 Key 会立即失效。');
+          const ok=confirm('你的 CatsCo 中转 Key 已存在，但当前无法读取明文。要重新生成并写入 CatsCo 桌面端吗？旧 Key 会立即失效。');
           if(ok){
             retrying=true;
             setCatsSetupBusy(false);

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -7099,10 +7099,10 @@
     let catsSetupInFlight=false;
     const CUSTOM_MODEL_AUTO_SAVE_DELAY=900;
     const RELAY_FALLBACK_MODELS=[
-      {id:'minimax-m2.7',label:'MiniMax M2.7',model:'MiniMax-M2.7',provider:'anthropic',base_url:'https://relay.catsco.cc/anthropic',quota_class:'standard',default:true},
-      {id:'minimax-m3',label:'MiniMax M3',model:'MiniMax-M3',provider:'anthropic',base_url:'https://relay.catsco.cc/anthropic',quota_class:'multimodal'},
-      {id:'deepseek-v4-flash',label:'DeepSeek V4 Flash',model:'deepseek-v4-flash',provider:'anthropic',base_url:'https://relay.catsco.cc/anthropic',quota_class:'flash-low'},
-      {id:'glm-5.1',label:'GLM 5.1',model:'glm-5.1',provider:'anthropic',base_url:'https://relay.catsco.cc/anthropic',quota_class:'standard'},
+      {id:'minimax-m2.7',label:'MiniMax M2.7',model:'MiniMax-M2.7',provider:'anthropic',base_url:'https://relay.catsco.cc/anthropic',quota_class:'standard',context_window_tokens:204800,context_label:'204.8K',default:true},
+      {id:'minimax-m3',label:'MiniMax M3',model:'MiniMax-M3',provider:'anthropic',base_url:'https://relay.catsco.cc/anthropic',quota_class:'multimodal',context_window_tokens:1000000,context_label:'1M'},
+      {id:'deepseek-v4-flash',label:'DeepSeek V4 Flash',model:'deepseek-v4-flash',provider:'anthropic',base_url:'https://relay.catsco.cc/anthropic',quota_class:'flash-low',context_window_tokens:1000000,context_label:'1M'},
+      {id:'glm-5.1',label:'GLM 5.1',model:'glm-5.1',provider:'anthropic',base_url:'https://relay.catsco.cc/anthropic',quota_class:'standard',context_window_tokens:200000,context_label:'200K'},
     ];
     const serviceConfigGroups={
       catscompany:{
@@ -7239,6 +7239,21 @@
       return RELAY_FALLBACK_MODELS;
     }
 
+    function formatModelContextLabel(tokens, fallback){
+      if(fallback)return fallback;
+      const n=Number(tokens||0);
+      if(!Number.isFinite(n)||n<=0)return '安全默认';
+      if(n>=1000000){
+        const v=n/1000000;
+        return (Number.isInteger(v)?String(v):v.toFixed(1))+'M';
+      }
+      if(n>=1000){
+        const v=n/1000;
+        return (Number.isInteger(v)?String(v):v.toFixed(1))+'K';
+      }
+      return String(n);
+    }
+
     function modelStartupSnapshot(){
       return dashboardSettingsSnapshot?.modelStartup || {};
     }
@@ -7282,12 +7297,13 @@
     function relayModelChoiceHtml(model, activeId, catsConnected, context='settings'){
       const id=String(model.id||model.model||'');
       const active=id===activeId;
-      const quota=model.quota_class==='flash-low'?'低额度 Flash':'标准额度';
+      const quota=model.quota_class==='flash-low'?'低额度 Flash':model.quota_class==='multimodal'?'多模态':'标准额度';
+      const contextLabel=formatModelContextLabel(model.context_window_tokens, model.context_label);
       const disabled=relayActionBusy() || (context!=='chat' && !catsConnected);
       return '<button class="relay-model-choice'+(active?' active':'')+'" type="button" data-relay-model-id="'+escapeHtml(id)+'" data-relay-model-context="'+escapeHtml(context)+'" '+(disabled?'disabled':'')+' onclick="enableCatsRelayModelFromButton(this)">'
         +'<span class="relay-model-label">'+escapeHtml(model.label||model.model||id)+'</span>'
         +'<span class="relay-model-name">'+escapeHtml(model.model||id)+'</span>'
-        +'<span class="relay-model-meta">'+escapeHtml(quota)+' · Anthropic SDK</span>'
+        +'<span class="relay-model-meta">'+escapeHtml(quota)+' · 上下文 '+escapeHtml(contextLabel)+' · Anthropic SDK</span>'
         +'</button>';
     }
 
@@ -7297,7 +7313,7 @@
       const provider=custom.provider || settingValue('model.provider') || 'anthropic';
       const model=custom.model || settingValue('model.model') || '未配置';
       const meta=configured
-        ? '自定义配置 · '+(provider==='openai'?'OpenAI SDK':'Anthropic SDK')
+        ? '自定义配置 · 安全上下文 128K · '+(provider==='openai'?'OpenAI SDK':'Anthropic SDK')
         : '去设置填写 endpoint / key';
       return '<button class="relay-model-choice '+(active?' active':'')+(configured?'':' needs-config')+'" type="button" data-custom-startup-action="true" data-custom-startup-context="'+escapeHtml(context)+'" '+(relayActionBusy()?'disabled':'')+' onclick="enableCustomStartupModelFromButton(this)">'
         +'<span class="relay-model-label">自定义模型</span>'
@@ -7409,12 +7425,13 @@
       const draft=captureCustomModelDraft();
 
       p.innerHTML=`<div class="model-source-layout">
+        <div class="runtime-note">中转模型和自定义模型会分别保存。CatsCo 中转会按所选模型自动调整上下文；自定义模型默认按 128K 安全上下文运行，若模型实际窗口更小，请减少历史或在高级环境变量里降低 GAUZ_LLM_CONTEXT_WINDOW_TOKENS。</div>
         <details class="model-source-card warning" id="custom-model-settings"${customModelSettingsOpen?' open':''}>
           <summary>
             <div class="model-source-head">
               <div>
                 <div class="model-source-title">自定义模型（第三方）</div>
-                <div class="model-source-copy">只有手动接入第三方模型时需要填写。CatsCo 中转模型请在 CatsCo 页面选择。</div>
+                <div class="model-source-copy">只有手动接入第三方模型时需要填写。CatsCo 中转模型请在 CatsCo 页面选择；自定义模型默认使用 128K 安全上下文。</div>
               </div>
               ${runtimeTag(credentialMeta, keyField.present?'green':'gray')}
             </div>
@@ -7432,7 +7449,7 @@
               <button class="btn btn-primary" onclick="saveCustomModelSettings()">保存自定义模型</button>
               <span class="config-saved" id="model-source-saved">已保存</span>
             </div>
-            <div id="model-source-status" style="color:var(--text2);font-size:13px">凭证仅保存到本地 .env；新 session 或下一次启动 connector 后生效。</div>
+            <div id="model-source-status" style="color:var(--text2);font-size:13px">凭证仅保存到本地 .env；自定义模型默认 128K 安全上下文，新 session 或下一次启动 connector 后生效。</div>
           </div>
         </details>
       </div>`;

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -8464,14 +8464,23 @@
         btn.disabled = true;
         btn.textContent = '绑定中...';
       }
-      setCatsAction(`正在绑定 ${name} 并启动 CatsCompany connector...`);
+      const setupRelayModel=shouldSetupRelayOnCatsSetup();
+      setCatsAction(setupRelayModel?`正在确认中转模型、绑定 ${name} 并启动 connector...`:`正在绑定 ${name} 并按当前自定义模型启动 connector...`);
 
       try {
         const data = await parseCatsResponse(await fetch(API + '/api/cats/bind-bot', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ ...getCatsEndpointFields(), botUid }),
+          body: JSON.stringify({
+            ...getCatsEndpointFields(),
+            botUid,
+            setupRelayModel,
+            relayModelId:setupRelayModel ? (relayModelIdForSetup()||undefined) : undefined,
+            rotateRelayKey:Boolean(options?.rotateRelayKey),
+          }),
         }));
+        pendingStartupSource='';
+        pendingRelayModelId='';
         catsState = {
           ...catsState,
           ...data,
@@ -8485,13 +8494,24 @@
         };
         closeBotSelector();
         await fetchStatus();
-        await fetchCatsStatus();
+        await fetchCatsStatus({priority:true});
         renderCatsStatus();
-        setCatsAction(data.message || `已绑定 ${name}。可以直接开始对话。`);
+        const warningText=catsSetupWarningText(data);
+        const readyMessage=data.message || `已绑定 ${name}。可以直接开始对话。`;
+        setCatsAction(warningText?readyMessage+' 但有提示：'+warningText:readyMessage);
         pulsePetState('success', '已绑定', 1800);
         await loadCatsMessages(true, { reset: true, forceBottom: true });
       } catch (e) {
-        setCatsAction('绑定失败: ' + e.message, true);
+        if(e.status===409 && e.action==='rotate_required'){
+          const ok=confirm('你的 CatsCo 中转 Key 已存在，但当前无法读取明文。要重新生成并写入 CatsCo 桌面端吗？旧 Key 会立即失效。');
+          if(ok){
+            await bindCatsBot(botUid, botName, button, {...options, confirm:false, restoreText, rotateRelayKey:true});
+            return;
+          }
+          setCatsAction('已取消。你也可以在 CatsCompany 中转站页面复制现有配置后手动填写。', true);
+        }else{
+          setCatsAction('绑定失败: ' + formatDashboardApiError(e,'/api/cats/bind-bot'), true);
+        }
       } finally {
         if (btn) {
           btn.disabled = false;

--- a/electron/main.js
+++ b/electron/main.js
@@ -416,6 +416,7 @@ async function startServer() {
 
   // 闂佽崵濮崇粈浣规櫠娴犲鍋柛鈩冾殢閸熷懘鏌曟径鍫濃偓妤冪矙婵犲洦鐓熼柍鍝勶工閺嬫稓绱撳鍛ч柡浣哥Ч瀹曞ジ鎮㈢亸浣稿緧闂備礁鎲￠悧鏇㈠箠鎼淬劌绠栨俊銈呮噺閸嬨劑鏌嶉搹瑙勭erData闂佽瀛╃粙鎺曟懌闂佸搫鍊风欢姘跺箖娴犲惟闁挎洍鍋撻柣鎾存礋閺屸剝鎷呴崫鍕垫毉閻庤鎸风欢姘跺极?
   const userDataPath = app.getPath('userData');
+  // Keep this before createApplicationMenu(): close-to-tray preferences are read from process.cwd()/.xiaoba/catsco.json.
   process.chdir(userDataPath);
 
   // 濠电姷顣介埀顒€鍟块埀顒€缍婇幃妯荤箙缁茬尃rData闂傚倷鐒﹁ぐ鍐嫉椤掑嫭鍎夐柛娑欐綑鐎?env闂備焦瀵х粙鎴炵附閺冨倸鍨濋柣鏇犵％p闂傚倷鐒﹁ぐ鍐嚐椤栫倛鍥蓟閵夈儳顦?env.example

--- a/electron/main.js
+++ b/electron/main.js
@@ -29,6 +29,18 @@ function applyConfiguredUserDataPath() {
   app.setPath('userData', resolvedUserDataDir);
 }
 
+function readCloseToTrayPreference() {
+  try {
+    const configPath = path.join(process.cwd(), '.xiaoba', 'catsco.json');
+    if (!fs.existsSync(configPath)) return true;
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    const value = config?.preferences?.closeToTray;
+    return value !== false;
+  } catch (_error) {
+    return true;
+  }
+}
+
 // 闂佽绻愮换鎴犳崲閸℃稒鍎婃い鏍仜缁€澶愭煟濡厧鍔嬬紒?electron-updater闂備焦瀵х粙鎴︽偋閸℃哎浜归柡灞诲劜閻掕顭块懜鐢点€掔紒鈧?
 try {
   autoUpdater = require('electron-updater').autoUpdater;
@@ -445,7 +457,7 @@ function createWindow() {
   mainWindow.loadURL(`http://127.0.0.1:${DASHBOARD_PORT}`);
 
   mainWindow.on('close', (e) => {
-    if (process.platform === 'darwin' && !app.isQuitting) {
+    if (!app.isQuitting && readCloseToTrayPreference()) {
       e.preventDefault();
       mainWindow.hide();
     }

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, Tray, Menu, nativeImage, ipcMain, dialog } = require('electron');
+const { app, BrowserWindow, Tray, Menu, nativeImage, ipcMain, dialog, shell } = require('electron');
 const path = require('path');
 const fs = require('fs');
 
@@ -6,6 +6,7 @@ const DASHBOARD_PORT = resolveDashboardPort(process.env.XIAOBA_DASHBOARD_PORT);
 let mainWindow = null;
 let tray = null;
 let autoUpdater = null;
+let hideNoticeShown = false;
 const REFRESHABLE_BUNDLED_SKILLS = new Set([]);
 const RETIRED_BUNDLED_SKILLS = new Set(['advanced-reader', 'vision-analysis']);
 const SKILL_SYNC_MARKER = '.xiaoba-bundled-skill.json';
@@ -39,6 +40,74 @@ function readCloseToTrayPreference() {
   } catch (_error) {
     return true;
   }
+}
+
+function writeCloseToTrayPreference(closeToTray) {
+  const configPath = path.join(process.cwd(), '.xiaoba', 'catsco.json');
+  const configDir = path.dirname(configPath);
+  let config = {};
+
+  try {
+    if (fs.existsSync(configPath)) {
+      config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    }
+  } catch (_error) {
+    config = {};
+  }
+
+  const next = {
+    ...config,
+    version: config.version || 1,
+    preferences: {
+      ...config.preferences,
+      autoConnect: config.preferences?.autoConnect ?? true,
+      switchConfirmEnabled: config.preferences?.switchConfirmEnabled ?? true,
+      closeToTray: Boolean(closeToTray),
+    },
+    updatedAt: new Date().toISOString(),
+  };
+
+  fs.mkdirSync(configDir, { recursive: true, mode: 0o700 });
+  fs.writeFileSync(configPath, JSON.stringify(next, null, 2), { encoding: 'utf8', mode: 0o600 });
+}
+
+function showMainWindow() {
+  if (mainWindow) {
+    mainWindow.show();
+    mainWindow.focus();
+  } else {
+    createWindow();
+  }
+}
+
+function createTrayIcon() {
+  const appRoot = getAppRoot();
+  const candidates = process.platform === 'win32'
+    ? ['build-resources/icon.ico', 'build-resources/icons/icon.ico', 'build-resources/icons/32x32.png', 'dashboard/cat-icon.png']
+    : ['build-resources/icons/32x32.png', 'build-resources/icon.png', 'dashboard/cat-icon.png'];
+
+  for (const relativePath of candidates) {
+    const iconPath = path.join(appRoot, relativePath);
+    if (!fs.existsSync(iconPath)) continue;
+    const image = nativeImage.createFromPath(iconPath);
+    if (!image.isEmpty()) {
+      return image.resize({ width: 16, height: 16 });
+    }
+  }
+
+  return nativeImage
+    .createFromDataURL('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAABhSURBVFhH7c6xDQAgDASwkP2XZgEqCgrZwJ+u8Ov1vt+RM0EHHXTQQQcddNBBBx100EEHHXTQQQcddNBBBx100EEHHXTQQQcddNBBBx100EEHHXTQQQcddNBBBx3834kDK+kAIRUXPjcAAAAASUVORK5CYII=')
+    .resize({ width: 16, height: 16 });
+}
+
+function notifyWindowHidden() {
+  if (hideNoticeShown || !tray || process.platform !== 'win32' || typeof tray.displayBalloon !== 'function') return;
+  hideNoticeShown = true;
+  tray.displayBalloon({
+    title: 'CatsCo 已在后台运行',
+    content: '点击右下角 CatsCo 图标可恢复窗口。',
+    icon: createTrayIcon(),
+  });
 }
 
 // 闂佽绻愮换鎴犳崲閸℃稒鍎婃い鏍仜缁€澶愭煟濡厧鍔嬬紒?electron-updater闂備焦瀵х粙鎴︽偋閸℃哎浜归柡灞诲劜閻掕顭块懜鐢点€掔紒鈧?
@@ -460,6 +529,7 @@ function createWindow() {
     if (!app.isQuitting && readCloseToTrayPreference()) {
       e.preventDefault();
       mainWindow.hide();
+      notifyWindowHidden();
     }
   });
 
@@ -515,26 +585,118 @@ ipcMain.handle('catsco:select-files', async (event) => {
     .filter(Boolean);
 });
 
+function createApplicationMenu() {
+  const closeToTray = readCloseToTrayPreference();
+  const quit = () => {
+    app.isQuitting = true;
+    app.quit();
+  };
+
+  const editMenu = [
+    { label: '撤销', role: 'undo' },
+    { label: '重做', role: 'redo' },
+    { type: 'separator' },
+    { label: '剪切', role: 'cut' },
+    { label: '复制', role: 'copy' },
+    { label: '粘贴', role: 'paste' },
+    { label: '全选', role: 'selectAll' },
+  ];
+
+  const template = [
+    ...(process.platform === 'darwin' ? [{
+      label: 'CatsCo',
+      submenu: [
+        { label: '关于 CatsCo', role: 'about' },
+        { type: 'separator' },
+        { label: '隐藏 CatsCo', role: 'hide' },
+        { label: '隐藏其他应用', role: 'hideOthers' },
+        { label: '显示全部', role: 'unhide' },
+        { type: 'separator' },
+        { label: '退出 CatsCo', accelerator: 'Command+Q', click: quit },
+      ],
+    }] : []),
+    {
+      label: '文件',
+      submenu: [
+        { label: '打开 Dashboard', click: showMainWindow },
+        { type: 'separator' },
+        { label: '退出 CatsCo', accelerator: process.platform === 'darwin' ? 'Command+Q' : 'Ctrl+Q', click: quit },
+      ],
+    },
+    {
+      label: '编辑',
+      submenu: editMenu,
+    },
+    {
+      label: '视图',
+      submenu: [
+        { label: '重新加载', role: 'reload' },
+        { label: '强制重新加载', role: 'forceReload' },
+        { label: '开发者工具', role: 'toggleDevTools' },
+        { type: 'separator' },
+        { label: '实际大小', role: 'resetZoom' },
+        { label: '放大', role: 'zoomIn' },
+        { label: '缩小', role: 'zoomOut' },
+        { type: 'separator' },
+        { label: '全屏', role: 'togglefullscreen' },
+      ],
+    },
+    {
+      label: '窗口',
+      submenu: [
+        { label: '显示主窗口', click: showMainWindow },
+        {
+          label: '点 × 后隐藏到后台',
+          type: 'checkbox',
+          checked: closeToTray,
+          click: (menuItem) => {
+            writeCloseToTrayPreference(menuItem.checked);
+          },
+        },
+        { type: 'separator' },
+        { label: '最小化', role: 'minimize' },
+        { label: '关闭窗口', role: 'close' },
+      ],
+    },
+    {
+      label: '帮助',
+      submenu: [
+        {
+          label: '检查更新',
+          enabled: Boolean(autoUpdater),
+          click: () => {
+            updateController.checkForUpdates(true).catch((error) => {
+              console.error('Manual update check failed:', error);
+            });
+          },
+        },
+        {
+          label: '打开发布页',
+          click: () => {
+            const url = updateState.releasePageUrl;
+            if (url) shell.openExternal(url);
+          },
+        },
+      ],
+    },
+  ];
+
+  Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+}
+
 function createTray() {
-  const icon = nativeImage.createFromDataURL(
-    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAABhSURBVFhH7c6xDQAgDASwkP2XZgEqCgrZwJ+u8Ov1vt+RM0EHHXTQQQcddNBBBx100EEHHXTQQQcddNBBBx100EEHHXTQQQcddNBBBx100EEHHXTQQQcddNBBBx3834kDK+kAIRUXPjcAAAAASUVORK5CYII='
-  );
-  tray = new Tray(icon.resize({ width: 16, height: 16 }));
+  tray = new Tray(createTrayIcon());
 
   const contextMenu = Menu.buildFromTemplate([
-    { label: 'Open CatsCo Dashboard', click: () => {
-      if (mainWindow) { mainWindow.show(); mainWindow.focus(); }
-      else createWindow();
-    }},
+    { label: '打开 CatsCo Dashboard', click: showMainWindow },
     { type: 'separator' },
-    { label: 'Quit', click: () => { app.isQuitting = true; app.quit(); }} ,
+    { label: '退出 CatsCo', click: () => { app.isQuitting = true; app.quit(); }} ,
   ]);
 
   tray.setToolTip('CatsCo Dashboard');
   tray.setContextMenu(contextMenu);
   tray.on('click', () => {
-    if (mainWindow) { mainWindow.show(); mainWindow.focus(); }
-    else createWindow();
+    showMainWindow();
   });
 }
 
@@ -609,6 +771,7 @@ if (autoUpdater) {
 app.whenReady().then(async () => {
   try {
     await startServer();
+    createApplicationMenu();
     createWindow();
     createTray();
     

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -540,6 +540,12 @@ export class CatsCompanyBot {
     });
 
     const stopTypingHeartbeat = this.startTypingHeartbeat(topic);
+    let typingHeartbeatStopped = false;
+    const stopTypingHeartbeatOnce = () => {
+      if (typingHeartbeatStopped) return;
+      typingHeartbeatStopped = true;
+      stopTypingHeartbeat();
+    };
 
     try {
       const result = await session.handleRuntimeObservation(text, {
@@ -565,9 +571,10 @@ export class CatsCompanyBot {
           Logger.warning(`子智能体结果回复发送失败: ${err.message}`);
         }
       }
+      stopTypingHeartbeatOnce();
       await this.drainMessageQueue(sessionKey);
     } finally {
-      stopTypingHeartbeat();
+      stopTypingHeartbeatOnce();
       this.clearPendingAnswerBySession(sessionKey);
     }
   }

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -41,6 +41,7 @@ interface QueuedMessage {
 }
 
 const PENDING_ANSWER_TIMEOUT_MS = 120_000;
+const TYPING_HEARTBEAT_INTERVAL_MS = 5_000;
 const HIDDEN_CATS_TOOL_PROGRESS = new Set([
   'send_text',
   'send_file',
@@ -401,8 +402,7 @@ export class CatsCompanyBot {
       senderId: msg.senderId,
     });
 
-    // 发送 typing 指示，让用户知道 bot 正在处理
-    this.sender.sendTyping(msg.topic);
+    const stopTypingHeartbeat = this.startTypingHeartbeat(msg.topic);
 
     try {
       const result = await session.handleMessage(userMessage, {
@@ -421,6 +421,7 @@ export class CatsCompanyBot {
         }
       }
     } finally {
+      stopTypingHeartbeat();
       this.clearPendingAnswerBySession(key);
     }
 
@@ -538,6 +539,8 @@ export class CatsCompanyBot {
       senderId,
     });
 
+    const stopTypingHeartbeat = this.startTypingHeartbeat(topic);
+
     try {
       const result = await session.handleRuntimeObservation(text, {
         channel,
@@ -564,6 +567,7 @@ export class CatsCompanyBot {
       }
       await this.drainMessageQueue(sessionKey);
     } finally {
+      stopTypingHeartbeat();
       this.clearPendingAnswerBySession(sessionKey);
     }
   }
@@ -681,6 +685,24 @@ export class CatsCompanyBot {
     Logger.info(`[${key}] 收到 CatsCompany 取消事件，已请求中断当前回合`);
   }
 
+  private startTypingHeartbeat(topic: string, intervalMs = TYPING_HEARTBEAT_INTERVAL_MS): () => void {
+    let stopped = false;
+    const send = () => {
+      if (!stopped) {
+        this.sender.sendTyping(topic);
+      }
+    };
+
+    send();
+    const interval = setInterval(send, intervalMs);
+    (interval as any).unref?.();
+
+    return () => {
+      stopped = true;
+      clearInterval(interval);
+    };
+  }
+
   /**
    * 排空消息队列：将忙时积压的消息合并为一条，一次性处理
    */
@@ -698,6 +720,8 @@ export class CatsCompanyBot {
       sessionKey,
       senderId: msg.senderId,
     });
+
+    const stopTypingHeartbeat = this.startTypingHeartbeat(msg.topic);
 
     try {
       const result = msg.source === 'subagent_feedback'
@@ -726,6 +750,7 @@ export class CatsCompanyBot {
         }
       }
     } finally {
+      stopTypingHeartbeat();
       this.clearPendingAnswerBySession(sessionKey);
     }
 

--- a/src/catscompany/local-config.ts
+++ b/src/catscompany/local-config.ts
@@ -39,6 +39,7 @@ export interface CatsCoLocalConfig {
   preferences?: {
     autoConnect?: boolean;
     switchConfirmEnabled?: boolean;
+    closeToTray?: boolean;
   };
   updatedAt?: string;
 }
@@ -498,6 +499,7 @@ export class CatsCoLocalConfigService {
     const next = {
       autoConnect: preferences.autoConnect ?? config.preferences?.autoConnect ?? true,
       switchConfirmEnabled: preferences.switchConfirmEnabled ?? config.preferences?.switchConfirmEnabled ?? true,
+      closeToTray: preferences.closeToTray ?? config.preferences?.closeToTray ?? true,
     };
     this.save({
       ...config,
@@ -544,6 +546,7 @@ export class CatsCoLocalConfigService {
       preferences: {
         autoConnect: config.preferences?.autoConnect ?? true,
         switchConfirmEnabled: config.preferences?.switchConfirmEnabled ?? true,
+        closeToTray: config.preferences?.closeToTray ?? true,
       },
     };
   }
@@ -554,6 +557,7 @@ export class CatsCoLocalConfigService {
       preferences: {
         autoConnect: true,
         switchConfirmEnabled: true,
+        closeToTray: true,
       },
     };
   }

--- a/src/catscompany/runtime-config.ts
+++ b/src/catscompany/runtime-config.ts
@@ -40,6 +40,7 @@ export interface CatsCoRuntimeConfigOptions {
   env?: NodeJS.ProcessEnv;
   config?: ChatConfig;
   overrides?: Record<string, unknown>;
+  migrateLegacyEnvBinding?: boolean;
 }
 
 function firstNonEmpty(...values: unknown[]): string | undefined {
@@ -89,8 +90,12 @@ export function resolveCatsCoRuntimeConfig(
     ...env,
   };
   const service = createCatsCoLocalConfigService({ runtimeRoot, env: effectiveEnv });
-  const localConfig = service.load();
-  const auth = service.getAuthState(options.overrides || {});
+  let localConfig = service.load();
+  let auth = service.getAuthState(options.overrides || {});
+  if (options.migrateLegacyEnvBinding && migrateLegacyEnvBinding(service, localConfig, auth)) {
+    localConfig = service.load();
+    auth = service.getAuthState(options.overrides || {});
+  }
 
   const explicitServerUrl = firstNonEmpty(
     options.overrides?.serverUrl,
@@ -166,6 +171,29 @@ export function resolveCatsCoRuntimeConfig(
       botUid,
     }, localConfig),
   };
+}
+
+function migrateLegacyEnvBinding(
+  service: ReturnType<typeof createCatsCoLocalConfigService>,
+  localConfig: CatsCoLocalConfig,
+  auth: CatsCoAuthSnapshot,
+): boolean {
+  if (hasConfirmedLocalBotBinding(localConfig, auth.uid)) return false;
+  const userUid = String(auth.uid || '').trim();
+  const token = String(auth.token || '').trim();
+  const botUid = String(auth.botUid || '').trim();
+  const apiKey = String(auth.apiKey || '').trim();
+  if (!userUid || !token || !botUid || !apiKey) return false;
+  if (/^sk-/i.test(apiKey)) return false;
+  service.writeBotBinding(auth, {
+    userUid,
+    username: auth.username,
+    displayName: auth.displayName,
+    botUid,
+    apiKey,
+    bindingSource: 'legacy-env-migration',
+  });
+  return true;
 }
 
 function hasConfirmedLocalBotBinding(localConfig: CatsCoLocalConfig, userUid?: string): boolean {

--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -26,6 +26,8 @@ import { SessionLifecycleManager } from './session-lifecycle-manager';
 import { PlanRuntime } from './plan-runtime';
 import { SubAgentManager } from './sub-agent-manager';
 import type { PendingUserInputProvider } from './conversation-runner';
+import { ConfigManager } from '../utils/config';
+import { resolveModelContextWindow } from '../utils/model-context-window';
 
 export type { RuntimeFeedbackInput, RuntimeFeedbackOptions } from './runtime-feedback-inbox';
 
@@ -139,7 +141,13 @@ export class AgentSession {
     const type = sessionType || this.extractSessionType(key);
     this.sessionTurnLogger = new SessionTurnLogger(type, key);
     this.turnLogRecorder = new TurnLogRecorder(this.sessionTurnLogger);
-    this.contextWindowManager = new ContextWindowManager(services.aiService);
+    const contextWindow = resolveModelContextWindow(ConfigManager.getConfigReadonly());
+    Logger.info(
+      `[${key}] 模型上下文: ${contextWindow.label} window=${contextWindow.contextWindowTokens}, promptBudget=${contextWindow.promptBudgetTokens}, reserve=${contextWindow.safetyReserveTokens}`,
+    );
+    this.contextWindowManager = new ContextWindowManager(services.aiService, {
+      maxContextTokens: contextWindow.promptBudgetTokens,
+    });
     this.skillRuntime = new SessionSkillRuntime(services.skillManager, key);
     this.lifecycleManager = new SessionLifecycleManager({
       sessionKey: key,

--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -26,7 +26,6 @@ import { SessionLifecycleManager } from './session-lifecycle-manager';
 import { PlanRuntime } from './plan-runtime';
 import { SubAgentManager } from './sub-agent-manager';
 import type { PendingUserInputProvider } from './conversation-runner';
-import { ConfigManager } from '../utils/config';
 import { resolveModelContextWindow } from '../utils/model-context-window';
 
 export type { RuntimeFeedbackInput, RuntimeFeedbackOptions } from './runtime-feedback-inbox';
@@ -141,12 +140,16 @@ export class AgentSession {
     const type = sessionType || this.extractSessionType(key);
     this.sessionTurnLogger = new SessionTurnLogger(type, key);
     this.turnLogRecorder = new TurnLogRecorder(this.sessionTurnLogger);
-    const contextWindow = resolveModelContextWindow(ConfigManager.getConfigReadonly());
+    const modelConfig = typeof (services.aiService as any).getConfig === 'function'
+      ? (services.aiService as any).getConfig()
+      : {};
+    const contextWindow = resolveModelContextWindow(modelConfig);
     Logger.info(
       `[${key}] 模型上下文: ${contextWindow.label} window=${contextWindow.contextWindowTokens}, promptBudget=${contextWindow.promptBudgetTokens}, reserve=${contextWindow.safetyReserveTokens}`,
     );
     this.contextWindowManager = new ContextWindowManager(services.aiService, {
       maxContextTokens: contextWindow.promptBudgetTokens,
+      summaryContentBudget: contextWindow.summaryBudgetTokens,
     });
     this.skillRuntime = new SessionSkillRuntime(services.skillManager, key);
     this.lifecycleManager = new SessionLifecycleManager({

--- a/src/core/context-compressor.ts
+++ b/src/core/context-compressor.ts
@@ -129,6 +129,50 @@ function truncateLongText(text: string, maxChars: number): string {
   return prefix + text.slice(0, maxChars - 30) + `\n...[共 ${text.length} 字符]`;
 }
 
+function fitTextPrefixToTokenBudget(text: string, budget: number): string {
+  const safeBudget = Math.max(0, Math.floor(budget));
+  if (safeBudget <= 0 || !text) return '';
+  if (estimateTokens(text) <= safeBudget) return text;
+
+  let low = 0;
+  let high = text.length;
+  let best = '';
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    const candidate = text.slice(0, mid);
+    if (estimateTokens(candidate) <= safeBudget) {
+      best = candidate;
+      low = mid + 1;
+    } else {
+      high = mid - 1;
+    }
+  }
+  return best;
+}
+
+function truncateTextToTokenBudget(text: string, budget: number): string {
+  const safeBudget = Math.max(0, Math.floor(budget));
+  if (safeBudget <= 0 || !text) return '';
+  if (estimateTokens(text) <= safeBudget) return text;
+
+  const suffix = `\n...[共 ${text.length} 字符]`;
+  let low = 0;
+  let high = text.length;
+  let best = '';
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    const candidate = text.slice(0, mid) + suffix;
+    if (estimateTokens(candidate) <= safeBudget) {
+      best = candidate;
+      low = mid + 1;
+    } else {
+      high = mid - 1;
+    }
+  }
+
+  return best || fitTextPrefixToTokenBudget(text, safeBudget);
+}
+
 /**
  * 按 token 预算从最新消息往前构建摘要文本
  *
@@ -137,30 +181,31 @@ function truncateLongText(text: string, maxChars: number): string {
  * @returns 摘要文本
  */
 export function truncateForSummary(messages: Message[], budget: number = SUMMARY_CONTENT_BUDGET): string {
+  const safeBudget = Math.max(0, Math.floor(budget));
+  if (safeBudget <= 0) return '';
+
   // 反序遍历：从最新到最早
   const reversed = [...messages].reverse();
   const result: string[] = [];
   let usedTokens = 0;
-  let skippedCount = 0;
 
   for (const msg of reversed) {
     const { text, tokens } = messageToSummaryText(msg);
 
-    if (usedTokens + tokens > budget) {
-      // 超出预算
-      if (skippedCount === 0) {
-        // 只有一条消息就超预算了，强制截断
-        const truncated = truncateLongText(text, 500);
-        result.push(truncated);
-      } else {
-        // 多条消息，停止添加
-        break;
+    if (usedTokens + tokens > safeBudget) {
+      const remainingBudget = safeBudget - usedTokens;
+      if (remainingBudget > 0) {
+        const truncated = truncateTextToTokenBudget(text, remainingBudget);
+        if (truncated) {
+          result.push(truncated);
+          usedTokens += estimateTokens(truncated);
+        }
       }
+      break;
     } else {
       result.push(text);
       usedTokens += tokens;
     }
-    skippedCount++;
   }
 
   // 构建最终文本（需要正序）
@@ -169,10 +214,11 @@ export function truncateForSummary(messages: Message[], budget: number = SUMMARY
   // 如果有跳过的消息，添加标记
   const totalSkipped = messages.length - result.length;
   if (totalSkipped > 0) {
-    return `[早期 ${totalSkipped} 条消息已截断，共 ${messages.length} 条消息]\n\n${truncatedText}`;
+    const marked = `[早期 ${totalSkipped} 条消息已截断，共 ${messages.length} 条消息]\n\n${truncatedText}`;
+    return truncateTextToTokenBudget(marked, safeBudget);
   }
 
-  return truncatedText;
+  return truncateTextToTokenBudget(truncatedText, safeBudget);
 }
 
 // ─── 压缩 Prompt ──────────────────────────────────────────

--- a/src/core/context-compressor.ts
+++ b/src/core/context-compressor.ts
@@ -308,15 +308,18 @@ export interface CompactOptions {
 export class ContextCompressor {
   private maxContextTokens: number;
   private compactionThreshold: number;
+  private summaryContentBudget: number;
   private aiService: AIService;
 
   constructor(aiService: AIService, options?: {
     maxContextTokens?: number;
     compactionThreshold?: number;
+    summaryContentBudget?: number;
   }) {
     this.aiService = aiService;
     this.maxContextTokens = options?.maxContextTokens ?? 128000;
     this.compactionThreshold = options?.compactionThreshold ?? 0.7;
+    this.summaryContentBudget = options?.summaryContentBudget ?? SUMMARY_CONTENT_BUDGET;
   }
 
   /**
@@ -372,7 +375,7 @@ export class ContextCompressor {
     }
 
     // 按 token 预算从最新消息往前构建摘要文本
-    const truncated = truncateForSummary(session, SUMMARY_CONTENT_BUDGET);
+    const truncated = truncateForSummary(session, this.summaryContentBudget);
 
     try {
       const summaryMessages: Message[] = [

--- a/src/core/context-window-manager.ts
+++ b/src/core/context-window-manager.ts
@@ -6,6 +6,7 @@ import { ContextCompressor } from './context-compressor';
 export interface ContextWindowManagerOptions {
   maxContextTokens?: number;
   compactionThreshold?: number;
+  summaryContentBudget?: number;
 }
 
 export interface CompactIfNeededOptions {

--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -20,6 +20,7 @@ import {
   SUBAGENT_TOOL_NAME,
   TRANSIENT_RUNNER_HINT_PREFIX,
 } from './runner-orchestration-policy';
+import { resolveModelPromptBudgetTokens } from '../utils/model-context-window';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -42,8 +43,6 @@ function normalizeToolName(name: string): string {
   return TOOL_NAME_ALIASES[name] ?? name;
 }
 
-const DEFAULT_PROMPT_BUDGET = 120000;
-const ANTHROPIC_PROMPT_BUDGET = 200000;
 const MIN_MESSAGE_BUDGET = 2000;
 const OVERFLOW_REDUCTION_RATIO = 0.6;
 const TRANSIENT_CURRENT_DIRECTORY_PREFIX = '[transient_current_directory]';
@@ -958,7 +957,7 @@ export class ConversationRunner {
 
   private ensurePromptBudget(messages: Message[], tools: ToolDefinition[]): void {
     const toolTokens = estimateToolsTokens(tools);
-    const messageBudget = Math.max(MIN_MESSAGE_BUDGET, this.maxPromptTokens - toolTokens);
+    const messageBudget = Math.max(1, this.maxPromptTokens - toolTokens);
     let messageTokens = estimateMessagesTokens(messages);
 
     if (messageTokens <= messageBudget) {
@@ -977,7 +976,7 @@ export class ConversationRunner {
     }
 
     if (messageTokens > messageBudget) {
-      const minimal = this.buildMinimalFallback(messages);
+      const minimal = this.buildMinimalFallback(messages, messageBudget);
       this.replaceMessages(messages, minimal);
       messageTokens = estimateMessagesTokens(messages);
     }
@@ -1025,7 +1024,7 @@ export class ConversationRunner {
     return candidate;
   }
 
-  private buildMinimalFallback(messages: Message[]): Message[] {
+  private buildMinimalFallback(messages: Message[], targetTokens: number): Message[] {
     const system = messages.find(msg => msg.role === 'system');
     const nonSystem = messages.filter(msg => msg.role !== 'system');
     const tail = nonSystem.slice(-2).map(msg => this.shrinkMessage(msg, true));
@@ -1036,7 +1035,43 @@ export class ConversationRunner {
     }
     result.push(...tail);
 
-    return result;
+    return this.fitMessagesToBudget(result, targetTokens);
+  }
+
+  private fitMessagesToBudget(messages: Message[], targetTokens: number): Message[] {
+    let candidate = messages;
+    const caps = [600, 320, 160, 80];
+
+    for (const cap of caps) {
+      if (estimateMessagesTokens(candidate) <= targetTokens) {
+        return candidate;
+      }
+      candidate = candidate.map((message, index) => (
+        this.truncateMessageContent(message, index === 0 ? cap * 2 : cap)
+      ));
+    }
+
+    while (estimateMessagesTokens(candidate) > targetTokens && candidate.length > 1) {
+      candidate.splice(1, 1);
+    }
+
+    if (estimateMessagesTokens(candidate) > targetTokens && candidate.length > 0) {
+      candidate = [this.truncateMessageContent(candidate[0], 80)];
+    }
+
+    return candidate;
+  }
+
+  private truncateMessageContent(message: Message, maxChars: number): Message {
+    const content = contentToString(message.content);
+    if (content.length <= maxChars) {
+      return message;
+    }
+    return {
+      ...message,
+      content: `${content.slice(0, maxChars)}\n...[已截断以适配模型上下文预算，原始 ${content.length} 字符]`,
+      tool_calls: undefined,
+    };
   }
 
   private shrinkMessage(message: Message, aggressive: boolean): Message {
@@ -1087,11 +1122,14 @@ export class ConversationRunner {
       return maxContextTokens;
     }
 
-    const provider = (process.env.GAUZ_LLM_PROVIDER || '').trim().toLowerCase();
-    const model = (process.env.GAUZ_LLM_MODEL || '').trim().toLowerCase();
-    const isAnthropic = provider === 'anthropic' || model.includes('claude');
-
-    return isAnthropic ? ANTHROPIC_PROMPT_BUDGET : DEFAULT_PROMPT_BUDGET;
+    return resolveModelPromptBudgetTokens({
+      provider: process.env.GAUZ_LLM_PROVIDER === 'anthropic' || process.env.GAUZ_LLM_PROVIDER === 'openai'
+        ? process.env.GAUZ_LLM_PROVIDER
+        : undefined,
+      apiUrl: process.env.GAUZ_LLM_API_BASE,
+      model: process.env.GAUZ_LLM_MODEL,
+      maxTokens: Number(process.env.GAUZ_LLM_MAX_OUTPUT_TOKENS || process.env.GAUZ_LLM_MAX_TOKENS) || undefined,
+    }, process.env);
   }
 
   private isPromptTooLongError(error: any): boolean {

--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -378,6 +378,7 @@ export class ConversationRunner {
         role: 'assistant',
         content: response.content,
         tool_calls: response.toolCalls,
+        providerContent: response.providerContent,
       };
       const executionRecords: ToolExecutionRecord[] = [];
       let shouldPauseTurn = false;
@@ -561,6 +562,7 @@ export class ConversationRunner {
     }
 
     const transcriptToolCalls = this.filterToolCallsForTranscript(assistantMsg, transcriptRecords);
+    const providerContent = this.filterProviderContentForTranscript(assistantMsg, transcriptToolCalls);
     const assistant: Message = {
       role: 'assistant',
       content: this.shouldKeepAssistantDraft(assistantMsg, outboundMessages)
@@ -568,6 +570,9 @@ export class ConversationRunner {
         : null,
       ...(transcriptToolCalls?.length
         ? { tool_calls: transcriptToolCalls }
+        : {}),
+      ...(providerContent?.length
+        ? { providerContent }
         : {}),
     };
 
@@ -630,6 +635,31 @@ export class ConversationRunner {
     if (!assistantMsg.tool_calls?.length) return undefined;
     const transcriptToolCallIds = new Set(transcriptRecords.map(record => record.toolCall.id));
     return assistantMsg.tool_calls.filter(toolCall => transcriptToolCallIds.has(toolCall.id));
+  }
+
+  private filterProviderContentForTranscript(
+    assistantMsg: Message,
+    transcriptToolCalls: Message['tool_calls'],
+  ): Message['providerContent'] {
+    if (!Array.isArray(assistantMsg.providerContent) || !transcriptToolCalls?.length) {
+      return undefined;
+    }
+
+    const transcriptToolCallIds = new Set(transcriptToolCalls.map(toolCall => toolCall.id));
+    const blocks: NonNullable<Message['providerContent']> = [];
+    let hasToolUse = false;
+
+    for (const block of assistantMsg.providerContent) {
+      if (!block || typeof block !== 'object') continue;
+      if (block.type === 'tool_use') {
+        const id = typeof block.id === 'string' ? block.id : '';
+        if (!transcriptToolCallIds.has(id)) continue;
+        hasToolUse = true;
+      }
+      blocks.push(block);
+    }
+
+    return hasToolUse ? blocks : undefined;
   }
 
   private shouldKeepAssistantDraft(
@@ -1125,13 +1155,18 @@ export class ConversationRunner {
       }
 
       if (toolCalls.length > 0) {
-        repaired.push({ ...message, tool_calls: toolCalls });
+        const providerContent = this.filterProviderContentForTranscript(message, toolCalls);
+        repaired.push({
+          ...message,
+          tool_calls: toolCalls,
+          providerContent,
+        });
         continue;
       }
 
       const content = contentToString(message.content).trim();
       if (content) {
-        repaired.push({ ...message, tool_calls: undefined });
+        repaired.push({ ...message, tool_calls: undefined, providerContent: undefined });
       }
     }
 
@@ -1150,6 +1185,7 @@ export class ConversationRunner {
       ...message,
       content: `${content.slice(0, maxChars)}\n...[已截断以适配模型上下文预算，原始 ${content.length} 字符]`,
       tool_calls: undefined,
+      providerContent: undefined,
     };
   }
 
@@ -1174,6 +1210,10 @@ export class ConversationRunner {
 
     if (aggressive && next.tool_calls) {
       delete next.tool_calls;
+    }
+
+    if (content.length > maxChars || aggressive) {
+      delete next.providerContent;
     }
 
     return next;

--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -1,4 +1,4 @@
-import { Message, ContentBlock, ChatResponse } from '../types';
+import { Message, ContentBlock, ChatConfig, ChatResponse } from '../types';
 import { AIService } from '../utils/ai-service';
 import { ToolCall, ToolDefinition, ToolExecutionContext, ToolExecutor, ToolResult, ToolTranscriptMode } from '../types/tool';
 import { StreamCallbacks } from '../providers/provider';
@@ -20,7 +20,7 @@ import {
   SUBAGENT_TOOL_NAME,
   TRANSIENT_RUNNER_HINT_PREFIX,
 } from './runner-orchestration-policy';
-import { resolveModelPromptBudgetTokens } from '../utils/model-context-window';
+import { calculateSummaryBudgetTokens, resolveModelPromptBudgetTokens } from '../utils/model-context-window';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -48,6 +48,8 @@ const OVERFLOW_REDUCTION_RATIO = 0.6;
 const TRANSIENT_CURRENT_DIRECTORY_PREFIX = '[transient_current_directory]';
 const MAX_EMPTY_MAX_TOKEN_RECOVERIES = 1;
 const EMPTY_MAX_TOKENS_MESSAGE = '模型这轮输出达到了 max_tokens 上限，但没有生成可见回复或工具调用。已保留当前上下文；请回复“继续”，我会从刚才的位置继续推进。';
+export const PROMPT_BUDGET_TRIM_MESSAGE = '当前上下文超过模型窗口，已裁剪较早的历史内容以继续处理。';
+export const PROMPT_TOOLS_DISABLED_MESSAGE = '当前模型上下文不足以加载全部工具，本轮已先按纯文本继续处理。';
 
 /**
  * 对话运行回调
@@ -160,6 +162,7 @@ export class ConversationRunner {
     this.compressor = new ContextCompressor(this.aiService, {
       maxContextTokens: this.maxPromptTokens,
       compactionThreshold: 0.5,
+      summaryContentBudget: calculateSummaryBudgetTokens(this.maxPromptTokens),
     });
   }
 
@@ -193,6 +196,7 @@ export class ConversationRunner {
     let nextPlanNudgeAt = nextPlanNudgeToolCount(0);
     let nextSubagentNudgeAt = nextSubagentNudgeToolCount(0);
     let emptyMaxTokenRecoveries = 0;
+    let notifiedToolBudgetDisabled = false;
 
     while (true) {
       turns++;
@@ -208,9 +212,16 @@ export class ConversationRunner {
           newMessages,
         };
       }
+      const requestTools = this.fitToolsToPromptBudget(activeTools);
+      if (requestTools.length < activeTools.length && !notifiedToolBudgetDisabled) {
+        notifiedToolBudgetDisabled = true;
+        if (callbacks?.onThinking) {
+          await callbacks.onThinking(PROMPT_TOOLS_DISABLED_MESSAGE);
+        }
+      }
 
       if (this.enableCompression) {
-        const toolTokens = estimateToolsTokens(activeTools);
+        const toolTokens = estimateToolsTokens(requestTools);
         const messageTokens = estimateMessagesTokens(messages);
         const totalTokens = messageTokens + toolTokens;
         const usagePercent = Math.round((totalTokens / this.maxPromptTokens) * 100);
@@ -220,28 +231,34 @@ export class ConversationRunner {
         const threshold = this.maxPromptTokens * 0.5;
         if (totalTokens > threshold) {
           Logger.info(`上下文使用率 ${usagePercent}%，触发压缩...`);
+          if (callbacks?.onThinking) {
+            await callbacks.onThinking('上下文较长，正在压缩后继续处理。');
+          }
           const compacted = await this.compressor.compact(messages, {
             signal: this.toolExecutionContext?.abortSignal,
           });
           messages.length = 0;
           messages.push(...compacted);
+          if (callbacks?.onThinking) {
+            await callbacks.onThinking('上下文压缩完成，继续处理。');
+          }
         }
       }
 
       const orchestrationHints: Message[] = [];
       if (turns === 1 && !hasShownInitialOrchestrationHint) {
-        const explicitPlanHint = buildExplicitPlanRequestHintIfUseful(messages, activeTools);
-        const decisionHint = buildInitialDecisionHintIfUseful(messages, activeTools);
+        const explicitPlanHint = buildExplicitPlanRequestHintIfUseful(messages, requestTools);
+        const decisionHint = buildInitialDecisionHintIfUseful(messages, requestTools);
         if (explicitPlanHint) orchestrationHints.push(explicitPlanHint);
         if (decisionHint) orchestrationHints.push(decisionHint);
         hasShownInitialOrchestrationHint = orchestrationHints.length > 0;
       }
-      if (shouldAddPlanSoftNudge(activeTools, turns, executedToolCalls, hasUpdatedPlan || hasRecordedDecision, nextPlanNudgeAt)) {
+      if (shouldAddPlanSoftNudge(requestTools, turns, executedToolCalls, hasUpdatedPlan || hasRecordedDecision, nextPlanNudgeAt)) {
         orchestrationHints.push(buildPlanSoftNudge(turns, executedToolCalls, planSoftNudgeCount));
         planSoftNudgeCount++;
         nextPlanNudgeAt = nextPlanNudgeToolCount(executedToolCalls);
       }
-      if (shouldAddSubagentSoftNudge(activeTools, turns, executedToolCalls, hasSpawnedSubagent || hasRecordedDecision, nextSubagentNudgeAt)) {
+      if (shouldAddSubagentSoftNudge(requestTools, turns, executedToolCalls, hasSpawnedSubagent || hasRecordedDecision, nextSubagentNudgeAt)) {
         orchestrationHints.push(buildSubagentSoftNudge(turns, executedToolCalls, subagentSoftNudgeCount));
         subagentSoftNudgeCount++;
         nextSubagentNudgeAt = nextSubagentNudgeToolCount(executedToolCalls);
@@ -252,14 +269,17 @@ export class ConversationRunner {
         ...orchestrationHints,
       ]);
       nextTurnTransientHints = [];
-      this.ensurePromptBudget(requestMessages, activeTools);
-      this.logProviderMessagesForDebug(requestMessages, activeTools, turns);
+      const promptTrimmed = this.ensurePromptBudget(requestMessages, requestTools);
+      if (promptTrimmed && callbacks?.onThinking) {
+        await callbacks.onThinking(PROMPT_BUDGET_TRIM_MESSAGE);
+      }
+      this.logProviderMessagesForDebug(requestMessages, requestTools, turns);
       const aiStartTime = Date.now();
-      Logger.info(`[${this.sessionLabel}Turn ${turns}] 调用AI推理 (可用工具: ${activeTools.length}个)`);
+      Logger.info(`[${this.sessionLabel}Turn ${turns}] 调用AI推理 (可用工具: ${requestTools.length}个)`);
 
       let response;
       try {
-        response = await this.requestModelResponse(requestMessages, activeTools, callbacks);
+        response = await this.requestModelResponse(requestMessages, requestTools, callbacks);
         const aiDuration = Date.now() - aiStartTime;
         Logger.info(`[${this.sessionLabel}Turn ${turns}] AI推理完成，耗时: ${aiDuration}ms`);
       } catch (error: any) {
@@ -943,7 +963,10 @@ export class ConversationRunner {
 
       Logger.warning('检测到提示词超长，执行紧急上下文裁剪后重试一次');
       this.forceTrimForOverflow(messages);
-      this.ensurePromptBudget(messages, activeTools);
+      const promptTrimmed = this.ensurePromptBudget(messages, activeTools);
+      if (promptTrimmed && callbacks?.onThinking) {
+        await callbacks.onThinking(PROMPT_BUDGET_TRIM_MESSAGE);
+      }
 
       if (this.stream) {
         const streamCallbacks: StreamCallbacks = {
@@ -955,13 +978,13 @@ export class ConversationRunner {
     }
   }
 
-  private ensurePromptBudget(messages: Message[], tools: ToolDefinition[]): void {
+  private ensurePromptBudget(messages: Message[], tools: ToolDefinition[]): boolean {
     const toolTokens = estimateToolsTokens(tools);
     const messageBudget = Math.max(1, this.maxPromptTokens - toolTokens);
     let messageTokens = estimateMessagesTokens(messages);
 
     if (messageTokens <= messageBudget) {
-      return;
+      return false;
     }
 
     Logger.warning(
@@ -984,6 +1007,24 @@ export class ConversationRunner {
     Logger.info(
       `[上下文守门] 裁剪后: messages=${messageTokens}, tools=${toolTokens}, budget=${this.maxPromptTokens}`
     );
+    return true;
+  }
+
+  private fitToolsToPromptBudget(tools: ToolDefinition[]): ToolDefinition[] {
+    if (tools.length === 0) {
+      return tools;
+    }
+
+    const toolTokens = estimateToolsTokens(tools);
+    const toolBudget = Math.max(1, this.maxPromptTokens - MIN_MESSAGE_BUDGET);
+    if (toolTokens <= toolBudget) {
+      return tools;
+    }
+
+    Logger.warning(
+      `[上下文守门] 工具定义超预算: tools=${toolTokens}, toolBudget=${toolBudget}, promptBudget=${this.maxPromptTokens}; 本轮禁用工具定义`
+    );
+    return [];
   }
 
   private forceTrimForOverflow(messages: Message[]): void {
@@ -1021,7 +1062,7 @@ export class ConversationRunner {
       candidate = [...trimmedSystem, ...old, ...recent];
     }
 
-    return candidate;
+    return this.repairToolExchangeMessages(candidate);
   }
 
   private buildMinimalFallback(messages: Message[], targetTokens: number): Message[] {
@@ -1039,7 +1080,7 @@ export class ConversationRunner {
   }
 
   private fitMessagesToBudget(messages: Message[], targetTokens: number): Message[] {
-    let candidate = messages;
+    let candidate = this.repairToolExchangeMessages(messages);
     const caps = [600, 320, 160, 80];
 
     for (const cap of caps) {
@@ -1049,6 +1090,7 @@ export class ConversationRunner {
       candidate = candidate.map((message, index) => (
         this.truncateMessageContent(message, index === 0 ? cap * 2 : cap)
       ));
+      candidate = this.repairToolExchangeMessages(candidate);
     }
 
     while (estimateMessagesTokens(candidate) > targetTokens && candidate.length > 1) {
@@ -1059,7 +1101,44 @@ export class ConversationRunner {
       candidate = [this.truncateMessageContent(candidate[0], 80)];
     }
 
-    return candidate;
+    return this.repairToolExchangeMessages(candidate);
+  }
+
+  private repairToolExchangeMessages(messages: Message[]): Message[] {
+    const toolResultIds = new Set(
+      messages
+        .filter(message => message.role === 'tool' && message.tool_call_id)
+        .map(message => message.tool_call_id as string),
+    );
+    const retainedToolCallIds = new Set<string>();
+    const repaired: Message[] = [];
+
+    for (const message of messages) {
+      if (message.role !== 'assistant' || !message.tool_calls?.length) {
+        repaired.push(message);
+        continue;
+      }
+
+      const toolCalls = message.tool_calls.filter(toolCall => toolResultIds.has(toolCall.id));
+      for (const toolCall of toolCalls) {
+        retainedToolCallIds.add(toolCall.id);
+      }
+
+      if (toolCalls.length > 0) {
+        repaired.push({ ...message, tool_calls: toolCalls });
+        continue;
+      }
+
+      const content = contentToString(message.content).trim();
+      if (content) {
+        repaired.push({ ...message, tool_calls: undefined });
+      }
+    }
+
+    return repaired.filter(message => {
+      if (message.role !== 'tool') return true;
+      return Boolean(message.tool_call_id && retainedToolCallIds.has(message.tool_call_id));
+    });
   }
 
   private truncateMessageContent(message: Message, maxChars: number): Message {
@@ -1076,8 +1155,8 @@ export class ConversationRunner {
 
   private shrinkMessage(message: Message, aggressive: boolean): Message {
     const maxChars = this.resolveMessageCharLimit(message, aggressive);
-    const content = message.content || '';
-    let nextContent = content;
+    const content = contentToString(message.content);
+    let nextContent = message.content;
 
     if (content.length > maxChars) {
       nextContent = content.slice(0, maxChars) + `\n...[已截断，原始 ${content.length} 字符]`;
@@ -1122,14 +1201,26 @@ export class ConversationRunner {
       return maxContextTokens;
     }
 
-    return resolveModelPromptBudgetTokens({
+    return resolveModelPromptBudgetTokens(this.resolveModelConfig(), process.env);
+  }
+
+  private resolveModelConfig(): Pick<ChatConfig, 'apiUrl' | 'model' | 'provider' | 'maxTokens' | 'contextWindowTokens'> {
+    const serviceConfig = typeof (this.aiService as any).getConfig === 'function'
+      ? (this.aiService as any).getConfig()
+      : undefined;
+    if (serviceConfig && typeof serviceConfig === 'object') {
+      return serviceConfig;
+    }
+
+    return {
       provider: process.env.GAUZ_LLM_PROVIDER === 'anthropic' || process.env.GAUZ_LLM_PROVIDER === 'openai'
         ? process.env.GAUZ_LLM_PROVIDER
         : undefined,
       apiUrl: process.env.GAUZ_LLM_API_BASE,
       model: process.env.GAUZ_LLM_MODEL,
       maxTokens: Number(process.env.GAUZ_LLM_MAX_OUTPUT_TOKENS || process.env.GAUZ_LLM_MAX_TOKENS) || undefined,
-    }, process.env);
+      contextWindowTokens: Number(process.env.GAUZ_LLM_CONTEXT_WINDOW_TOKENS || process.env.GAUZ_LLM_CONTEXT_TOKENS) || undefined,
+    };
   }
 
   private isPromptTooLongError(error: any): boolean {

--- a/src/core/sub-agent-session.ts
+++ b/src/core/sub-agent-session.ts
@@ -287,6 +287,9 @@ export class SubAgentSession {
 
     // 7. 用 callbacks 捕获进度。这里产生的是 runtime event，不是主 agent 最终结果。
     const callbacks: RunnerCallbacks = {
+      onThinking: (thinking) => {
+        this.emitEvent('agent_progress', thinking);
+      },
       onToolStart: (name) => {
         this.emitEvent('agent_tool_start', `开始执行工具 ${name}`, { toolName: name });
       },

--- a/src/core/token-estimator.ts
+++ b/src/core/token-estimator.ts
@@ -43,9 +43,19 @@ export function estimateMessageTokens(message: Message): number {
   let tokens = 4;
 
   if (message.content) {
-    const content = typeof message.content === 'string' ? message.content :
-      Array.isArray(message.content) ? message.content.map(b => b.type === 'text' ? b.text : '[图片]').join('') : '[图片]';
-    tokens += estimateTokens(content);
+    if (typeof message.content === 'string') {
+      tokens += estimateTokens(message.content);
+    } else if (Array.isArray(message.content)) {
+      for (const block of message.content) {
+        if (block.type === 'text') {
+          tokens += estimateTokens(block.text);
+        } else {
+          tokens += estimateImageTokens(block);
+        }
+      }
+    } else {
+      tokens += estimateTokens('[图片]');
+    }
   }
 
   if (message.tool_calls) {
@@ -61,6 +71,13 @@ export function estimateMessageTokens(message: Message): number {
   }
 
   return tokens;
+}
+
+function estimateImageTokens(block: Extract<Message['content'], any[]>[number]): number {
+  if (block?.type !== 'image') return estimateTokens('[图片]');
+  const data = String(block.source?.data || '');
+  if (!data) return estimateTokens('[图片]');
+  return Math.max(estimateTokens('[图片]'), Math.ceil(data.length * 0.125));
 }
 
 /**

--- a/src/core/token-estimator.ts
+++ b/src/core/token-estimator.ts
@@ -66,8 +66,58 @@ export function estimateMessageTokens(message: Message): number {
     }
   }
 
+  tokens += estimateProviderContentTokens(message);
+
   if (message.name) {
     tokens += estimateTokens(message.name);
+  }
+
+  return tokens;
+}
+
+function estimateProviderContentTokens(message: Message): number {
+  const blocks = message.providerContent;
+  if (!Array.isArray(blocks) || blocks.length === 0) return 0;
+
+  const existingToolCallIds = new Set((message.tool_calls || []).map(toolCall => toolCall.id));
+  const hasStringContent = typeof message.content === 'string' && message.content.length > 0;
+  let tokens = 2;
+
+  for (const block of blocks) {
+    if (!block || typeof block !== 'object') continue;
+    const type = typeof block.type === 'string' ? block.type : '';
+    tokens += estimateTokens(type) + 2;
+
+    if (type === 'text' && typeof block.text === 'string') {
+      if (!hasStringContent) tokens += estimateTokens(block.text);
+      continue;
+    }
+
+    if (type === 'thinking' && typeof block.thinking === 'string') {
+      tokens += estimateTokens(block.thinking);
+      if (typeof block.signature === 'string') {
+        tokens += estimateTokens(block.signature);
+      }
+      continue;
+    }
+
+    if (type === 'redacted_thinking') {
+      tokens += estimateJsonTokens(block);
+      continue;
+    }
+
+    if (type === 'tool_use') {
+      const id = typeof block.id === 'string' ? block.id : '';
+      if (existingToolCallIds.has(id)) {
+        continue;
+      }
+      tokens += estimateTokens(id);
+      tokens += estimateTokens(typeof block.name === 'string' ? block.name : '');
+      tokens += estimateJsonTokens(block.input);
+      continue;
+    }
+
+    tokens += estimateJsonTokens(block);
   }
 
   return tokens;

--- a/src/dashboard/readiness.ts
+++ b/src/dashboard/readiness.ts
@@ -159,7 +159,13 @@ function getEffectiveCatsCoRuntimeEnv(
   config: ChatConfig,
   catsCoOverrides?: Record<string, unknown>,
 ): NodeJS.ProcessEnv {
-  const catsCoRuntime = resolveCatsCoRuntimeConfig({ runtimeRoot, env, config, overrides: catsCoOverrides });
+  const catsCoRuntime = resolveCatsCoRuntimeConfig({
+    runtimeRoot,
+    env,
+    config,
+    overrides: catsCoOverrides,
+    migrateLegacyEnvBinding: true,
+  });
   const effectiveEnv = {
     ...env,
     ...catsCoRuntime.envOverlay,

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -13,6 +13,14 @@ import { APP_VERSION } from '../../version';
 import type { ChatConfig } from '../../types';
 import { createRuntimeConfigSnapshot } from '../../runtime/runtime-config-snapshot';
 import {
+  CUSTOM_MODEL_DEFAULT_CONTEXT_WINDOW_TOKENS,
+  calculatePromptBudgetTokens,
+  formatContextWindowTokens,
+  parsePositiveInteger,
+  resolveKnownModelContextWindowTokens,
+  resolveModelContextWindow,
+} from '../../utils/model-context-window';
+import {
   getDashboardReadiness,
   getServicePreflight,
 } from '../readiness';
@@ -143,6 +151,7 @@ interface RelayModelConfig {
   enabled: boolean;
   default: boolean;
   quotaClass?: string;
+  contextWindowTokens?: number;
 }
 
 const MODEL_SOURCE_ENV_KEY = 'CATSCO_MODEL_SOURCE';
@@ -151,18 +160,21 @@ const CUSTOM_MODEL_ENV_KEYS = {
   apiBase: 'CATSCO_CUSTOM_LLM_API_BASE',
   model: 'CATSCO_CUSTOM_LLM_MODEL',
   apiKey: 'CATSCO_CUSTOM_LLM_API_KEY',
+  contextWindowTokens: 'CATSCO_CUSTOM_LLM_CONTEXT_WINDOW_TOKENS',
 } as const;
 const RELAY_MODEL_ENV_KEYS = {
   provider: 'CATSCO_RELAY_LLM_PROVIDER',
   apiBase: 'CATSCO_RELAY_LLM_API_BASE',
   model: 'CATSCO_RELAY_LLM_MODEL',
   apiKey: 'CATSCO_RELAY_LLM_API_KEY',
+  contextWindowTokens: 'CATSCO_RELAY_LLM_CONTEXT_WINDOW_TOKENS',
 } as const;
 const EFFECTIVE_MODEL_ENV_KEYS = {
   provider: 'GAUZ_LLM_PROVIDER',
   apiBase: 'GAUZ_LLM_API_BASE',
   model: 'GAUZ_LLM_MODEL',
   apiKey: 'GAUZ_LLM_API_KEY',
+  contextWindowTokens: 'GAUZ_LLM_CONTEXT_WINDOW_TOKENS',
 } as const;
 
 interface ModelLaunchProfile {
@@ -170,6 +182,7 @@ interface ModelLaunchProfile {
   apiBase?: string;
   model?: string;
   apiKey?: string;
+  contextWindowTokens?: number;
 }
 
 function normalizeBaseUrl(value: unknown, fallback: string): string {
@@ -733,6 +746,9 @@ function normalizeRelayModelConfig(item: any, config: any, index: number): Relay
   const provider: 'anthropic' = 'anthropic';
   const protocol = 'Anthropic-compatible';
   const baseUrl = relayEndpointForProtocol(config, 'anthropic');
+  const contextWindowTokens = parsePositiveInteger(item?.context_window_tokens)
+    ?? parsePositiveInteger(item?.contextWindowTokens)
+    ?? resolveKnownModelContextWindowTokens(model);
   return {
     id: String(item?.id || model || `relay-model-${index}`).trim(),
     label: String(item?.label || model).trim(),
@@ -744,6 +760,7 @@ function normalizeRelayModelConfig(item: any, config: any, index: number): Relay
     enabled: item?.enabled !== false,
     default: item?.default === true,
     quotaClass: String(item?.quota_class || item?.quotaClass || '').trim() || undefined,
+    contextWindowTokens,
   };
 }
 
@@ -761,6 +778,7 @@ function fallbackRelayModelCatalog(config: any): RelayModelConfig[] {
       enabled: true,
       default: true,
       quotaClass: 'standard',
+      contextWindowTokens: 204_800,
     },
     {
       id: 'minimax-m3',
@@ -773,6 +791,7 @@ function fallbackRelayModelCatalog(config: any): RelayModelConfig[] {
       enabled: true,
       default: false,
       quotaClass: 'multimodal',
+      contextWindowTokens: 1_000_000,
     },
     {
       id: 'deepseek-v4-flash',
@@ -785,6 +804,7 @@ function fallbackRelayModelCatalog(config: any): RelayModelConfig[] {
       enabled: true,
       default: false,
       quotaClass: 'flash-low',
+      contextWindowTokens: 1_000_000,
     },
     {
       id: 'glm-5.1',
@@ -797,6 +817,7 @@ function fallbackRelayModelCatalog(config: any): RelayModelConfig[] {
       enabled: true,
       default: false,
       quotaClass: 'standard',
+      contextWindowTokens: 200_000,
     },
   ];
 }
@@ -848,6 +869,9 @@ function selectRelayModel(
 }
 
 function relayModelPayload(model: RelayModelConfig): Record<string, unknown> {
+  const promptBudget = model.contextWindowTokens
+    ? calculatePromptBudgetTokens(model.contextWindowTokens, 32_768).promptBudgetTokens
+    : undefined;
   return {
     id: model.id,
     label: model.label,
@@ -859,6 +883,9 @@ function relayModelPayload(model: RelayModelConfig): Record<string, unknown> {
     enabled: model.enabled,
     default: model.default,
     quota_class: model.quotaClass,
+    context_window_tokens: model.contextWindowTokens,
+    prompt_budget_tokens: promptBudget,
+    context_label: model.contextWindowTokens ? formatContextWindowTokens(model.contextWindowTokens) : undefined,
   };
 }
 
@@ -886,11 +913,13 @@ function writeDashboardEnvAndProcess(updates: Record<string, string | undefined>
 
 function modelProfileFromCurrentConfig(): ModelLaunchProfile {
   const config = getModelConfigReadonly();
+  const fileEnv = readEnvFile();
   return {
     provider: config.provider,
     apiBase: config.apiUrl,
     model: config.model,
     apiKey: config.apiKey,
+    contextWindowTokens: parsePositiveInteger(firstNonEmpty(process.env.GAUZ_LLM_CONTEXT_WINDOW_TOKENS, fileEnv.GAUZ_LLM_CONTEXT_WINDOW_TOKENS)),
   };
 }
 
@@ -904,6 +933,7 @@ function modelProfileFromStoredEnv(
     apiBase: firstNonEmpty(process.env[keys.apiBase], fileEnv[keys.apiBase]),
     model: firstNonEmpty(process.env[keys.model], fileEnv[keys.model]),
     apiKey: firstNonEmpty(process.env[keys.apiKey], fileEnv[keys.apiKey]),
+    contextWindowTokens: parsePositiveInteger(firstNonEmpty(process.env[keys.contextWindowTokens], fileEnv[keys.contextWindowTokens])),
   };
 }
 
@@ -926,13 +956,17 @@ function modelProfileUpdates(
     [keys.apiBase]: profile.apiBase,
     [keys.model]: profile.model,
     [keys.apiKey]: profile.apiKey,
+    [keys.contextWindowTokens]: profile.contextWindowTokens ? String(profile.contextWindowTokens) : undefined,
   };
 }
 
 function preserveCurrentCustomModelBeforeRelay(): string[] {
-  const current = modelProfileFromCurrentConfig();
+  const current = {
+    ...modelProfileFromCurrentConfig(),
+  };
   if (isCatsRelayApiBase(current.apiBase)) return [];
   if (!current.provider && !current.apiBase && !current.model && !current.apiKey) return [];
+  current.contextWindowTokens = current.contextWindowTokens ?? CUSTOM_MODEL_DEFAULT_CONTEXT_WINDOW_TOKENS;
 
   return writeDashboardEnvAndProcess(modelProfileUpdates(CUSTOM_MODEL_ENV_KEYS, current)).updated;
 }
@@ -973,6 +1007,7 @@ function mirrorCurrentModelAsCustomStartup(input: any, previous: ModelLaunchProf
   const custom: ModelLaunchProfile = {
     ...current,
     apiKey,
+    contextWindowTokens: storedCustom.contextWindowTokens ?? CUSTOM_MODEL_DEFAULT_CONTEXT_WINDOW_TOKENS,
   };
 
   if (!isCompleteModelProfile(custom) && (previousSource === 'relay' || isCatsRelayApiBase(previous.apiBase))) {
@@ -992,14 +1027,18 @@ function mirrorCurrentModelAsCustomStartup(input: any, previous: ModelLaunchProf
 }
 
 function writeCustomModelStartupConfig(): { profile: ModelLaunchProfile; updated: string[]; cleared: string[] } {
-  const profile = modelProfileFromStoredEnv(CUSTOM_MODEL_ENV_KEYS);
+  const profile = {
+    ...modelProfileFromStoredEnv(CUSTOM_MODEL_ENV_KEYS),
+  };
   if (!isCompleteModelProfile(profile)) {
     const error: any = new Error('请先在设置里保存完整的自定义模型地址、模型名称和访问凭证。');
     error.status = 400;
     error.reason = 'CUSTOM_MODEL_NOT_CONFIGURED';
     throw error;
   }
+  profile.contextWindowTokens = profile.contextWindowTokens ?? CUSTOM_MODEL_DEFAULT_CONTEXT_WINDOW_TOKENS;
   const result = writeDashboardEnvAndProcess({
+    ...modelProfileUpdates(CUSTOM_MODEL_ENV_KEYS, profile),
     ...modelProfileUpdates(EFFECTIVE_MODEL_ENV_KEYS, profile),
     [MODEL_SOURCE_ENV_KEY]: 'custom',
   });
@@ -1013,6 +1052,7 @@ function writeRelayModelStartupConfig(model: RelayModelConfig, apiKey: string): 
     apiBase: model.baseUrl,
     model: model.model,
     apiKey,
+    contextWindowTokens: model.contextWindowTokens ?? resolveKnownModelContextWindowTokens(model.model),
   };
   const result = writeDashboardEnvAndProcess({
     ...modelProfileUpdates(RELAY_MODEL_ENV_KEYS, profile),
@@ -1383,6 +1423,7 @@ export function createApiRouter(serviceManager: ServiceManager, updateController
   
   router.get('/status', (_req, res) => {
     const config = ConfigManager.getConfigReadonly();
+    const contextWindow = resolveModelContextWindow(config);
     const services = serviceManager.getAll();
     res.json({
       version: APP_VERSION,
@@ -1392,6 +1433,7 @@ export function createApiRouter(serviceManager: ServiceManager, updateController
       nodeVersion: process.version,
       model: config.model,
       provider: config.provider,
+      contextWindow,
       skillsPath: PathResolver.getSkillsPath(),
       services,
     });

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -2302,6 +2302,50 @@ export function createApiRouter(serviceManager: ServiceManager, updateController
       if (!targetBot) return res.status(404).json({ error: 'Bot not found' });
 
       const apiKey = await getCatsBotApiKey(state, botUid, targetBot);
+      const relayState: CatsAuthState = {
+        ...state,
+        uid: userUid,
+        username: me.username || state.username || '',
+        displayName: me.display_name || me.username || state.displayName || '',
+      };
+      let relayModelSetup: Record<string, unknown> | undefined;
+      if (req.body?.setupRelayModel !== false) {
+        try {
+          relayModelSetup = await setupCatsRelayModelForDesktop(
+            relayState,
+            req.body?.relayModelId || req.body?.modelId || req.body?.model,
+            {
+              rotateExisting: req.body?.rotateRelayKey === true || req.body?.rotateExisting === true,
+            },
+          );
+        } catch (relayError: any) {
+          const message = sanitizeCatsErrorMessage(relayError?.message || relayError);
+          const status = relayError?.status || 500;
+          relayModelSetup = {
+            ok: false,
+            error: message,
+            status,
+            action: status === 409 ? 'rotate_required' : undefined,
+          };
+          return res.status(status).json({
+            ok: false,
+            error: message,
+            action: status === 409 ? 'rotate_required' : undefined,
+            relayModelSetup,
+            user: {
+              uid: userUid,
+              username: me.username || state.username || '',
+              display_name: me.display_name || me.username || state.displayName || '',
+            },
+            bot: {
+              uid: botUid,
+              username: targetBot.username || '',
+              display_name: targetBot.display_name || targetBot.username || 'Bot',
+            },
+            topicId: p2pTopicId(userUid, botUid),
+          });
+        }
+      }
       const result = await commitCatsBotBindingAndStartConnector(serviceManager, state, {
         userUid,
         username: me.username || state.username || '',
@@ -2328,6 +2372,7 @@ export function createApiRouter(serviceManager: ServiceManager, updateController
         preflight: result.preflight,
         connectorStarted: result.connectorStarted,
         connectorRestarted: result.connectorRestarted,
+        relayModelSetup,
         warnings: result.warnings.length > 0 ? result.warnings : undefined,
         message: `已绑定机器人 "${botName}"`,
       });

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -1070,27 +1070,41 @@ async function fetchCatsRelayKey(state: CatsAuthState): Promise<any> {
   return catsRequest('GET', state.httpBaseUrl, '/api/relay/key', undefined, state.token);
 }
 
+async function revealCatsRelayKey(state: CatsAuthState): Promise<any> {
+  return catsRequest('POST', state.httpBaseUrl, '/api/relay/key/reveal', {}, state.token);
+}
+
 async function ensureCatsRelayPlainKey(
   state: CatsAuthState,
   options: { rotateExisting?: boolean } = {},
-): Promise<{ response: any; plainKey: string; created: boolean; rotated: boolean }> {
+): Promise<{ response: any; plainKey: string; created: boolean; rotated: boolean; revealed: boolean }> {
   const current = await fetchCatsRelayKey(state);
   const currentKey = current?.key;
   const active = currentKey && String(currentKey.state || 'active') === 'active';
   const currentPlainKey = String(currentKey?.key || '').trim();
 
   if (active && currentPlainKey) {
-    return { response: current, plainKey: currentPlainKey, created: false, rotated: false };
+    return { response: current, plainKey: currentPlainKey, created: false, rotated: false, revealed: false };
   }
 
   const reusableLocalKey = active ? findReusableLocalRelayKey(currentKey) : undefined;
   if (reusableLocalKey) {
-    return { response: current, plainKey: reusableLocalKey, created: false, rotated: false };
+    return { response: current, plainKey: reusableLocalKey, created: false, rotated: false, revealed: false };
   }
 
   if (active && !options.rotateExisting) {
+    try {
+      const revealed = await revealCatsRelayKey(state);
+      const revealedPlainKey = String(revealed?.key?.key || '').trim();
+      if (revealedPlainKey) {
+        return { response: revealed, plainKey: revealedPlainKey, created: false, rotated: false, revealed: true };
+      }
+    } catch {
+      // Older CatsCompany / relay deployments may not expose reveal yet. Fall
+      // through to the explicit rotation prompt instead of failing silently.
+    }
     throw httpError(
-      '已有 CatsCo 中转 Key，但明文不会再次返回。请确认是否重新生成后再启用中转模型。',
+      '已有 CatsCo 中转 Key，但当前无法读取明文。请确认是否重新生成后再启用中转模型。',
       409,
     );
   }
@@ -1110,6 +1124,7 @@ async function ensureCatsRelayPlainKey(
     plainKey,
     created: !active,
     rotated: active,
+    revealed: false,
   };
 }
 
@@ -1199,6 +1214,7 @@ async function setupCatsRelayModelForDesktop(
     key: sanitizeRelayKeyInfo(ensured.response?.key),
     createdKey: ensured.created,
     rotatedKey: ensured.rotated,
+    revealedKey: ensured.revealed,
   };
 }
 
@@ -2446,6 +2462,7 @@ export function createApiRouter(serviceManager: ServiceManager, updateController
         key: sanitizeRelayKeyInfo(ensured.response?.key),
         createdKey: ensured.created,
         rotatedKey: ensured.rotated,
+        revealedKey: ensured.revealed,
         restartRequired: restartInfo.wasRunning && !restartInfo.restartRequested,
         connectorRestarted: restartInfo.restartRequested,
         connectorStarted: restartInfo.startRequested,

--- a/src/dashboard/service-manager.ts
+++ b/src/dashboard/service-manager.ts
@@ -215,6 +215,7 @@ export class ServiceManager extends EventEmitter {
       const catsCoRuntime = resolveCatsCoRuntimeConfig({
         runtimeRoot: spawnCwd,
         env: envVars,
+        migrateLegacyEnvBinding: true,
       });
       envVars = {
         ...envVars,

--- a/src/providers/anthropic-provider.ts
+++ b/src/providers/anthropic-provider.ts
@@ -5,6 +5,10 @@ import { AIProvider, AIRequestOptions, StreamCallbacks } from './provider';
 import { ContextDebugLogger } from '../utils/context-debug-logger';
 import { resolveMaxTokens } from './output-limits';
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
 /**
  * Anthropic Provider
  * 使用官方 SDK 替代 axios 手动调用，支持 streaming
@@ -128,24 +132,8 @@ export class AnthropicProvider implements AIProvider {
 
       if (msg.role === 'assistant') {
         if (msg.tool_calls && msg.tool_calls.length > 0) {
-          const blocks: (Anthropic.TextBlockParam | Anthropic.ToolUseBlockParam)[] = [];
-          if (msg.content && typeof msg.content === 'string' && msg.content.trim()) {
-            blocks.push({ type: 'text', text: msg.content });
-          }
-          for (const toolCall of msg.tool_calls) {
-            let input: Record<string, unknown> = {};
-            try {
-              input = JSON.parse(toolCall.function.arguments || '{}');
-            } catch {
-              input = {};
-            }
-            blocks.push({
-              type: 'tool_use',
-              id: toolCall.id,
-              name: toolCall.function.name,
-              input
-            });
-          }
+          const blocks = this.transformAssistantContentBlocks(msg)
+            || this.transformAssistantToolCallBlocks(msg);
           transformedMessages.push({ role: 'assistant', content: blocks });
         } else {
           // 处理纯文本或 ContentBlock[] 的情况
@@ -194,12 +182,88 @@ export class AnthropicProvider implements AIProvider {
     }));
   }
 
+  private transformAssistantToolCallBlocks(msg: Message): (Anthropic.TextBlockParam | Anthropic.ToolUseBlockParam)[] {
+    const blocks: (Anthropic.TextBlockParam | Anthropic.ToolUseBlockParam)[] = [];
+    if (msg.content && typeof msg.content === 'string' && msg.content.trim()) {
+      blocks.push({ type: 'text', text: msg.content });
+    }
+    for (const toolCall of msg.tool_calls || []) {
+      let input: Record<string, unknown> = {};
+      try {
+        input = JSON.parse(toolCall.function.arguments || '{}');
+      } catch {
+        input = {};
+      }
+      blocks.push({
+        type: 'tool_use',
+        id: toolCall.id,
+        name: toolCall.function.name,
+        input
+      });
+    }
+    return blocks;
+  }
+
+  private transformAssistantContentBlocks(msg: Message): any[] | undefined {
+    if (!Array.isArray(msg.providerContent) || msg.providerContent.length === 0) {
+      return undefined;
+    }
+
+    const retainedToolCallIds = new Set((msg.tool_calls || []).map(toolCall => toolCall.id));
+    const blocks: any[] = [];
+    let hasRetainedToolUse = false;
+
+    for (const block of msg.providerContent) {
+      if (!block || typeof block !== 'object') continue;
+      const type = String((block as any).type || '');
+      if (type === 'text' && typeof (block as any).text === 'string') {
+        blocks.push({ type: 'text', text: (block as any).text });
+        continue;
+      }
+      if (type === 'thinking' && typeof (block as any).thinking === 'string') {
+        const thinkingBlock: Record<string, unknown> = {
+          type: 'thinking',
+          thinking: (block as any).thinking,
+        };
+        if (typeof (block as any).signature === 'string') {
+          thinkingBlock.signature = (block as any).signature;
+        }
+        blocks.push(thinkingBlock);
+        continue;
+      }
+      if (type === 'redacted_thinking') {
+        const redactedBlock: Record<string, unknown> = { type: 'redacted_thinking' };
+        if (typeof (block as any).data === 'string') {
+          redactedBlock.data = (block as any).data;
+        }
+        blocks.push(redactedBlock);
+        continue;
+      }
+      if (
+        type === 'tool_use'
+        && typeof (block as any).id === 'string'
+        && retainedToolCallIds.has((block as any).id)
+      ) {
+        hasRetainedToolUse = true;
+        blocks.push({
+          type: 'tool_use',
+          id: (block as any).id,
+          name: String((block as any).name || ''),
+          input: isRecord((block as any).input) ? (block as any).input : {},
+        });
+      }
+    }
+
+    return hasRetainedToolUse ? blocks : undefined;
+  }
+
   /**
    * 从 Anthropic 响应中提取统一格式
    */
   private parseResponse(response: Anthropic.Message): ChatResponse {
     const textParts: string[] = [];
     let toolCalls: ChatResponse['toolCalls'] = undefined;
+    const providerContent = this.preserveAssistantProviderContent(response.content as any[]);
 
     for (const block of response.content) {
       if (block.type === 'text') {
@@ -229,7 +293,52 @@ export class AnthropicProvider implements AIProvider {
       toolCalls,
       usage,
       stopReason: response.stop_reason || undefined,
+      ...(providerContent.length > 0 ? { providerContent } : {}),
     };
+  }
+
+  private preserveAssistantProviderContent(content: any[]): NonNullable<ChatResponse['providerContent']> {
+    if (!Array.isArray(content) || !content.some(block => block?.type === 'tool_use')) {
+      return [];
+    }
+
+    const blocks: NonNullable<ChatResponse['providerContent']> = [];
+    for (const block of content) {
+      if (!block || typeof block !== 'object') continue;
+      const type = String(block.type || '');
+      if (type === 'text' && typeof block.text === 'string') {
+        blocks.push({ type: 'text', text: block.text });
+        continue;
+      }
+      if (type === 'thinking' && typeof block.thinking === 'string') {
+        const thinkingBlock: Record<string, unknown> & { type: string } = {
+          type: 'thinking',
+          thinking: block.thinking,
+        };
+        if (typeof block.signature === 'string') {
+          thinkingBlock.signature = block.signature;
+        }
+        blocks.push(thinkingBlock);
+        continue;
+      }
+      if (type === 'redacted_thinking') {
+        const redactedBlock: Record<string, unknown> & { type: string } = { type: 'redacted_thinking' };
+        if (typeof block.data === 'string') {
+          redactedBlock.data = block.data;
+        }
+        blocks.push(redactedBlock);
+        continue;
+      }
+      if (type === 'tool_use' && typeof block.id === 'string') {
+        blocks.push({
+          type: 'tool_use',
+          id: block.id,
+          name: String(block.name || ''),
+          input: isRecord(block.input) ? block.input : {},
+        });
+      }
+    }
+    return blocks;
   }
 
   /**

--- a/src/providers/output-limits.ts
+++ b/src/providers/output-limits.ts
@@ -4,15 +4,22 @@ const DEFAULT_MAX_TOKENS = 8192;
 const DEFAULT_RELAY_MAX_TOKENS = 32768;
 
 export function resolveMaxTokens(config: ChatConfig): number {
+  let maxTokens: number;
   if (Number.isFinite(config.maxTokens) && Number(config.maxTokens) > 0) {
-    return Math.floor(Number(config.maxTokens));
+    maxTokens = Math.floor(Number(config.maxTokens));
+  } else {
+    const apiUrl = (config.apiUrl || '').toLowerCase();
+    const model = (config.model || '').toLowerCase();
+    maxTokens = apiUrl.includes('relay.catsco.cc') || model.includes('minimax-m2.7') || model.includes('minimax-m3')
+      ? DEFAULT_RELAY_MAX_TOKENS
+      : DEFAULT_MAX_TOKENS;
   }
 
-  const apiUrl = (config.apiUrl || '').toLowerCase();
-  const model = (config.model || '').toLowerCase();
-  if (apiUrl.includes('relay.catsco.cc') || model.includes('minimax-m2.7') || model.includes('minimax-m3')) {
-    return DEFAULT_RELAY_MAX_TOKENS;
+  const contextWindow = Number(config.contextWindowTokens);
+  if (Number.isFinite(contextWindow) && contextWindow > 0) {
+    const contextBound = Math.max(1, Math.floor(contextWindow * 0.25));
+    return Math.min(maxTokens, contextBound);
   }
 
-  return DEFAULT_MAX_TOKENS;
+  return maxTokens;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,8 @@ export type ContentBlock =
   | { type: 'text'; text: string }
   | { type: 'image'; source: { type: 'base64'; media_type: 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp'; data: string } };
 
+export type ProviderContentBlock = Record<string, unknown> & { type: string };
+
 export interface Message {
   role: 'user' | 'assistant' | 'system' | 'tool';
   content: string | ContentBlock[] | null;
@@ -22,6 +24,8 @@ export interface Message {
   /** 标记内部 runtime observation，例如子 agent 完成结果；对模型仍以 user role 承载 */
   __runtimeObservation?: boolean;
   runtimeObservationSource?: string;
+  /** Provider 原始 assistant content blocks，仅用于下次请求回放，不展示给用户。 */
+  providerContent?: ProviderContentBlock[];
 }
 
 export interface ChatConfig {
@@ -79,6 +83,8 @@ export interface ChatResponse {
   usage?: TokenUsage;
   /** Provider stop/finish reason, e.g. max_tokens/length/tool_use/stop. */
   stopReason?: string;
+  /** Provider 原始 assistant content blocks，仅用于下次请求回放，不展示给用户。 */
+  providerContent?: ProviderContentBlock[];
 }
 
 export interface CommandOptions {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -30,6 +30,7 @@ export interface ChatConfig {
   model?: string;
   temperature?: number;
   maxTokens?: number;
+  contextWindowTokens?: number;
   provider?: 'openai' | 'anthropic';
   feishu?: {
     appId?: string;

--- a/src/utils/ai-service.ts
+++ b/src/utils/ai-service.ts
@@ -6,6 +6,7 @@ import { AnthropicProvider } from '../providers/anthropic-provider';
 import { OpenAIProvider } from '../providers/openai-provider';
 import { Logger } from './logger';
 import { isPrimaryModelToolCallingCapable } from './model-capabilities';
+import { resolveModelContextWindow } from './model-context-window';
 
 /**
  * AI 服务 - 统一的 AI 调用入口
@@ -23,11 +24,15 @@ export class AIService {
   private provider: AIProvider;
 
   constructor(overrides?: Partial<ChatConfig>) {
-    this.config = this.withResolvedProvider({
+    this.config = this.withResolvedContextWindow(this.withResolvedProvider({
       ...ConfigManager.getConfig(),
       ...(overrides || {})
-    });
+    }));
     this.provider = this.createProvider(this.config);
+  }
+
+  getConfig(): ChatConfig {
+    return { ...this.config };
   }
 
   /**
@@ -52,6 +57,15 @@ export class AIService {
     return {
       ...config,
       provider: this.resolveProvider(config),
+    };
+  }
+
+  private withResolvedContextWindow(config: ChatConfig): ChatConfig {
+    const contextWindowTokens = config.contextWindowTokens
+      ?? resolveModelContextWindow(config).contextWindowTokens;
+    return {
+      ...config,
+      contextWindowTokens,
     };
   }
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -126,6 +126,10 @@ export class ConfigManager {
       process.env.GAUZ_LLM_MAX_OUTPUT_TOKENS,
       process.env.GAUZ_LLM_MAX_TOKENS,
     );
+    const contextWindowTokens = this.parsePositiveIntegerEnv(
+      process.env.GAUZ_LLM_CONTEXT_WINDOW_TOKENS,
+      process.env.GAUZ_LLM_CONTEXT_TOKENS,
+    );
 
     if (provider === 'openai' || provider === 'anthropic') {
       override.provider = provider;
@@ -141,6 +145,9 @@ export class ConfigManager {
     }
     if (maxTokens !== undefined) {
       override.maxTokens = maxTokens;
+    }
+    if (contextWindowTokens !== undefined) {
+      override.contextWindowTokens = contextWindowTokens;
     }
 
     return override;

--- a/src/utils/context-debug-logger.ts
+++ b/src/utils/context-debug-logger.ts
@@ -141,9 +141,47 @@ export class ContextDebugLogger {
           timestamp: now.toISOString(),
           stage,
           request_id: requestId,
-          data
+          data: ContextDebugLogger.sanitizeSdkDump(data)
         }, null, 2)
       );
     } catch { /* SDK dump 写入失败不影响主流程 */ }
+  }
+
+  private static sanitizeSdkDump(value: unknown, seen = new WeakSet<object>()): unknown {
+    if (value === null || typeof value !== 'object') return value;
+    if (seen.has(value)) return '[Circular]';
+    seen.add(value);
+
+    if (Array.isArray(value)) {
+      const output = value.map(item => ContextDebugLogger.sanitizeSdkDump(item, seen));
+      seen.delete(value);
+      return output;
+    }
+
+    const source = value as Record<string, unknown>;
+    const type = typeof source.type === 'string' ? source.type : '';
+    const output: Record<string, unknown> = {};
+
+    for (const [key, item] of Object.entries(source)) {
+      if (key === 'thinking' && typeof item === 'string') {
+        output[key] = `[redacted hidden thinking: ${item.length} chars]`;
+        continue;
+      }
+
+      if (key === 'signature' && typeof item === 'string') {
+        output[key] = '[redacted thinking signature]';
+        continue;
+      }
+
+      if (type === 'redacted_thinking' && key === 'data' && typeof item === 'string') {
+        output[key] = `[redacted thinking data: ${item.length} chars]`;
+        continue;
+      }
+
+      output[key] = ContextDebugLogger.sanitizeSdkDump(item, seen);
+    }
+
+    seen.delete(value);
+    return output;
   }
 }

--- a/src/utils/context-debug-logger.ts
+++ b/src/utils/context-debug-logger.ts
@@ -147,7 +147,21 @@ export class ContextDebugLogger {
     } catch { /* SDK dump 写入失败不影响主流程 */ }
   }
 
+  private static sanitizeSecretString(value: string): string {
+    return value
+      .replace(/sk-[A-Za-z0-9_-]{8,}/g, '[redacted-key]')
+      .replace(/cats_svc_[A-Za-z0-9_-]+/g, '[redacted-token]')
+      .replace(/\bAuthorization\s*[:=]\s*(?:[A-Za-z][A-Za-z0-9+.-]*\s+)?[^\s,;'"`<>]+/gi, 'Authorization: [redacted-token]')
+      .replace(/\b(?:Bearer|ApiKey|Token)\s+[A-Za-z0-9._~+/=-]+/gi, match => `${match.split(/\s+/)[0]} [redacted-token]`)
+      .replace(/(["']?)([A-Za-z0-9_.-]*(?:token|api[_-]?key|secret|password)[A-Za-z0-9_.-]*)\1\s*[:=]\s*["']?[^&\s,'"`<>}]+["']?/gi, '$1$2$1=[redacted-token]');
+  }
+
+  private static isSensitiveKey(key: string): boolean {
+    return /(?:authorization|token|api[_-]?key|apikey|secret|password|credential)/i.test(key);
+  }
+
   private static sanitizeSdkDump(value: unknown, seen = new WeakSet<object>()): unknown {
+    if (typeof value === 'string') return ContextDebugLogger.sanitizeSecretString(value);
     if (value === null || typeof value !== 'object') return value;
     if (seen.has(value)) return '[Circular]';
     seen.add(value);
@@ -163,6 +177,13 @@ export class ContextDebugLogger {
     const output: Record<string, unknown> = {};
 
     for (const [key, item] of Object.entries(source)) {
+      if (ContextDebugLogger.isSensitiveKey(key)) {
+        output[key] = typeof item === 'string'
+          ? `[redacted sensitive value: ${item.length} chars]`
+          : '[redacted sensitive value]';
+        continue;
+      }
+
       if (key === 'thinking' && typeof item === 'string') {
         output[key] = `[redacted hidden thinking: ${item.length} chars]`;
         continue;

--- a/src/utils/model-context-window.ts
+++ b/src/utils/model-context-window.ts
@@ -16,12 +16,16 @@ export interface ModelContextWindowResolution {
   promptBudgetTokens: number;
   safetyReserveTokens: number;
   maxOutputTokens: number;
+  summaryBudgetTokens: number;
 }
 
 export const CUSTOM_MODEL_DEFAULT_CONTEXT_WINDOW_TOKENS = 128_000;
 const ESTIMATION_MARGIN_RATIO = 0.06;
 const PROTOCOL_RESERVE_TOKENS = 4_096;
 const MIN_SAFETY_RESERVE_TOKENS = 8_192;
+const MIN_SUMMARY_BUDGET_TOKENS = 50_000;
+const MAX_SUMMARY_BUDGET_TOKENS = 300_000;
+const SUMMARY_BUDGET_RATIO = 0.35;
 
 export const RELAY_MODEL_CONTEXT_WINDOW_SPECS: ModelContextWindowSpec[] = [
   {
@@ -94,11 +98,14 @@ export function isCatsRelayModelConfig(
   config: Pick<ChatConfig, 'apiUrl' | 'model' | 'provider'>,
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
+  const apiUrl = String(config.apiUrl || '').trim().toLowerCase();
+  if (apiUrl) {
+    return apiUrl.includes('relay.catsco.cc');
+  }
   const source = String(env.CATSCO_MODEL_SOURCE || '').trim().toLowerCase();
   if (source === 'relay') return true;
   if (source === 'custom') return false;
-  const apiUrl = String(config.apiUrl || '').trim().toLowerCase();
-  return apiUrl.includes('relay.catsco.cc');
+  return false;
 }
 
 export function resolveConfiguredContextWindowTokens(
@@ -109,18 +116,22 @@ export function resolveConfiguredContextWindowTokens(
 }
 
 export function resolveModelContextWindow(
-  config: Pick<ChatConfig, 'apiUrl' | 'model' | 'provider' | 'maxTokens'>,
+  config: Pick<ChatConfig, 'apiUrl' | 'model' | 'provider' | 'maxTokens' | 'contextWindowTokens'>,
   env: NodeJS.ProcessEnv = process.env,
 ): ModelContextWindowResolution {
   const model = String(config.model || '').trim();
-  const explicitWindow = resolveConfiguredContextWindowTokens(env);
+  const explicitWindow = parsePositiveInteger(config.contextWindowTokens) ?? resolveConfiguredContextWindowTokens(env);
   const knownSpec = findKnownModelContextWindowSpec(model);
   const relay = isCatsRelayModelConfig(config, env);
   const contextWindowTokens = explicitWindow
     ?? (relay ? knownSpec?.contextWindowTokens : undefined)
     ?? CUSTOM_MODEL_DEFAULT_CONTEXT_WINDOW_TOKENS;
-  const maxOutputTokens = resolveMaxTokens(config as ChatConfig);
+  const maxOutputTokens = resolveMaxTokens({
+    ...config,
+    contextWindowTokens,
+  } as ChatConfig);
   const budget = calculatePromptBudgetTokens(contextWindowTokens, maxOutputTokens);
+  const summaryBudgetTokens = calculateSummaryBudgetTokens(budget.promptBudgetTokens);
 
   return {
     source: explicitWindow ? 'explicit' : relay ? 'relay' : 'custom',
@@ -130,14 +141,23 @@ export function resolveModelContextWindow(
     promptBudgetTokens: budget.promptBudgetTokens,
     safetyReserveTokens: budget.safetyReserveTokens,
     maxOutputTokens,
+    summaryBudgetTokens,
   };
 }
 
 export function resolveModelPromptBudgetTokens(
-  config: Pick<ChatConfig, 'apiUrl' | 'model' | 'provider' | 'maxTokens'>,
+  config: Pick<ChatConfig, 'apiUrl' | 'model' | 'provider' | 'maxTokens' | 'contextWindowTokens'>,
   env: NodeJS.ProcessEnv = process.env,
 ): number {
   return resolveModelContextWindow(config, env).promptBudgetTokens;
+}
+
+export function calculateSummaryBudgetTokens(promptBudgetTokens: number): number {
+  const scaled = Math.floor(promptBudgetTokens * SUMMARY_BUDGET_RATIO);
+  return Math.max(
+    Math.min(MIN_SUMMARY_BUDGET_TOKENS, Math.max(1, promptBudgetTokens)),
+    Math.min(MAX_SUMMARY_BUDGET_TOKENS, scaled),
+  );
 }
 
 export function formatContextWindowTokens(tokens: number | undefined): string {

--- a/src/utils/model-context-window.ts
+++ b/src/utils/model-context-window.ts
@@ -26,6 +26,7 @@ const MIN_SAFETY_RESERVE_TOKENS = 8_192;
 const MIN_SUMMARY_BUDGET_TOKENS = 50_000;
 const MAX_SUMMARY_BUDGET_TOKENS = 300_000;
 const SUMMARY_BUDGET_RATIO = 0.35;
+const SUMMARY_WRAPPER_RESERVE_TOKENS = 8_192;
 
 export const RELAY_MODEL_CONTEXT_WINDOW_SPECS: ModelContextWindowSpec[] = [
   {
@@ -153,10 +154,15 @@ export function resolveModelPromptBudgetTokens(
 }
 
 export function calculateSummaryBudgetTokens(promptBudgetTokens: number): number {
-  const scaled = Math.floor(promptBudgetTokens * SUMMARY_BUDGET_RATIO);
+  const wrapperReserveTokens = Math.min(
+    SUMMARY_WRAPPER_RESERVE_TOKENS,
+    Math.max(0, Math.floor(promptBudgetTokens * 0.2)),
+  );
+  const contentCeiling = Math.max(1, promptBudgetTokens - wrapperReserveTokens);
+  const scaled = Math.floor(contentCeiling * SUMMARY_BUDGET_RATIO);
   return Math.max(
-    Math.min(MIN_SUMMARY_BUDGET_TOKENS, Math.max(1, promptBudgetTokens)),
-    Math.min(MAX_SUMMARY_BUDGET_TOKENS, scaled),
+    Math.min(MIN_SUMMARY_BUDGET_TOKENS, contentCeiling),
+    Math.min(MAX_SUMMARY_BUDGET_TOKENS, contentCeiling, scaled),
   );
 }
 

--- a/src/utils/model-context-window.ts
+++ b/src/utils/model-context-window.ts
@@ -1,0 +1,154 @@
+import { ChatConfig } from '../types';
+import { resolveMaxTokens } from '../providers/output-limits';
+
+export interface ModelContextWindowSpec {
+  id: string;
+  label: string;
+  modelPatterns: RegExp[];
+  contextWindowTokens: number;
+}
+
+export interface ModelContextWindowResolution {
+  source: 'relay' | 'custom' | 'explicit' | 'fallback';
+  model?: string;
+  label: string;
+  contextWindowTokens: number;
+  promptBudgetTokens: number;
+  safetyReserveTokens: number;
+  maxOutputTokens: number;
+}
+
+export const CUSTOM_MODEL_DEFAULT_CONTEXT_WINDOW_TOKENS = 128_000;
+const ESTIMATION_MARGIN_RATIO = 0.06;
+const PROTOCOL_RESERVE_TOKENS = 4_096;
+const MIN_SAFETY_RESERVE_TOKENS = 8_192;
+
+export const RELAY_MODEL_CONTEXT_WINDOW_SPECS: ModelContextWindowSpec[] = [
+  {
+    id: 'minimax-m3',
+    label: 'MiniMax M3',
+    modelPatterns: [/^minimax-m3$/i],
+    contextWindowTokens: 1_000_000,
+  },
+  {
+    id: 'minimax-m2.7',
+    label: 'MiniMax M2.7',
+    modelPatterns: [/^minimax-m2\.7(?:-highspeed)?$/i],
+    contextWindowTokens: 204_800,
+  },
+  {
+    id: 'deepseek-v4-flash',
+    label: 'DeepSeek V4 Flash',
+    modelPatterns: [/^deepseek-v4-flash$/i],
+    contextWindowTokens: 1_000_000,
+  },
+  {
+    id: 'glm-5.1',
+    label: 'GLM 5.1',
+    modelPatterns: [/^glm-5\.1$/i],
+    contextWindowTokens: 200_000,
+  },
+];
+
+export function parsePositiveInteger(value: unknown): number | undefined {
+  const text = String(value ?? '').trim();
+  if (!text) return undefined;
+  const parsed = Number(text);
+  if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+  return Math.floor(parsed);
+}
+
+export function findKnownModelContextWindowSpec(model: unknown): ModelContextWindowSpec | undefined {
+  const modelName = String(model || '').trim();
+  if (!modelName) return undefined;
+  return RELAY_MODEL_CONTEXT_WINDOW_SPECS.find(spec => (
+    spec.modelPatterns.some(pattern => pattern.test(modelName))
+  ));
+}
+
+export function resolveKnownModelContextWindowTokens(model: unknown): number | undefined {
+  return findKnownModelContextWindowSpec(model)?.contextWindowTokens;
+}
+
+export function calculatePromptBudgetTokens(
+  contextWindowTokens: number,
+  maxOutputTokens: number,
+): { promptBudgetTokens: number; safetyReserveTokens: number } {
+  const estimationReserve = Math.ceil(contextWindowTokens * ESTIMATION_MARGIN_RATIO);
+  const rawSafetyReserveTokens = Math.max(
+    MIN_SAFETY_RESERVE_TOKENS,
+    maxOutputTokens + PROTOCOL_RESERVE_TOKENS + estimationReserve,
+  );
+  const safetyReserveTokens = Math.min(
+    Math.max(0, contextWindowTokens - 1),
+    rawSafetyReserveTokens,
+  );
+  const promptBudgetTokens = Math.max(1, contextWindowTokens - safetyReserveTokens);
+  return {
+    promptBudgetTokens,
+    safetyReserveTokens,
+  };
+}
+
+export function isCatsRelayModelConfig(
+  config: Pick<ChatConfig, 'apiUrl' | 'model' | 'provider'>,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  const source = String(env.CATSCO_MODEL_SOURCE || '').trim().toLowerCase();
+  if (source === 'relay') return true;
+  if (source === 'custom') return false;
+  const apiUrl = String(config.apiUrl || '').trim().toLowerCase();
+  return apiUrl.includes('relay.catsco.cc');
+}
+
+export function resolveConfiguredContextWindowTokens(
+  env: NodeJS.ProcessEnv = process.env,
+): number | undefined {
+  return parsePositiveInteger(env.GAUZ_LLM_CONTEXT_WINDOW_TOKENS)
+    ?? parsePositiveInteger(env.GAUZ_LLM_CONTEXT_TOKENS);
+}
+
+export function resolveModelContextWindow(
+  config: Pick<ChatConfig, 'apiUrl' | 'model' | 'provider' | 'maxTokens'>,
+  env: NodeJS.ProcessEnv = process.env,
+): ModelContextWindowResolution {
+  const model = String(config.model || '').trim();
+  const explicitWindow = resolveConfiguredContextWindowTokens(env);
+  const knownSpec = findKnownModelContextWindowSpec(model);
+  const relay = isCatsRelayModelConfig(config, env);
+  const contextWindowTokens = explicitWindow
+    ?? (relay ? knownSpec?.contextWindowTokens : undefined)
+    ?? CUSTOM_MODEL_DEFAULT_CONTEXT_WINDOW_TOKENS;
+  const maxOutputTokens = resolveMaxTokens(config as ChatConfig);
+  const budget = calculatePromptBudgetTokens(contextWindowTokens, maxOutputTokens);
+
+  return {
+    source: explicitWindow ? 'explicit' : relay ? 'relay' : 'custom',
+    model,
+    label: knownSpec?.label || model || '自定义模型',
+    contextWindowTokens,
+    promptBudgetTokens: budget.promptBudgetTokens,
+    safetyReserveTokens: budget.safetyReserveTokens,
+    maxOutputTokens,
+  };
+}
+
+export function resolveModelPromptBudgetTokens(
+  config: Pick<ChatConfig, 'apiUrl' | 'model' | 'provider' | 'maxTokens'>,
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  return resolveModelContextWindow(config, env).promptBudgetTokens;
+}
+
+export function formatContextWindowTokens(tokens: number | undefined): string {
+  if (!Number.isFinite(tokens) || !tokens) return '安全默认';
+  if (tokens >= 1_000_000) {
+    const value = tokens / 1_000_000;
+    return `${Number.isInteger(value) ? value.toFixed(0) : value.toFixed(1)}M`;
+  }
+  if (tokens >= 1_000) {
+    const value = tokens / 1_000;
+    return `${Number.isInteger(value) ? value.toFixed(0) : value.toFixed(1)}K`;
+  }
+  return `${tokens}`;
+}

--- a/src/utils/session-store.ts
+++ b/src/utils/session-store.ts
@@ -22,6 +22,69 @@ function stateFilePath(key: string): string {
   return path.join(SESSION_STATE_DIR, keyToFilename(key).replace(/\.jsonl$/, '.json'));
 }
 
+function hasHiddenProviderReplay(message: Message): boolean {
+  return Array.isArray(message.providerContent)
+    && message.providerContent.some(block => (
+      block?.type === 'thinking'
+      || block?.type === 'redacted_thinking'
+    ));
+}
+
+function providerReplaySummary(message: Message): string {
+  const publicText = typeof message.content === 'string' ? message.content.trim() : '';
+  const toolNames = (message.tool_calls || [])
+    .map(toolCall => toolCall.function?.name)
+    .filter(Boolean);
+  const suffix = toolNames.length > 0
+    ? ` 工具调用: ${toolNames.join(', ')}。`
+    : '';
+  return [
+    publicText,
+    `[历史工具调用已完成；provider replay 隐藏内容未写入本地会话。${suffix}]`,
+  ].filter(Boolean).join('\n');
+}
+
+function sanitizeForPersistence(messages: Message[]): Message[] {
+  const hiddenReplayToolCallIds = new Set<string>();
+  const durable: Message[] = [];
+
+  for (const message of messages) {
+    if ((message as any).__injected || message.role === 'system') {
+      continue;
+    }
+
+    if (message.role === 'tool' && message.tool_call_id && hiddenReplayToolCallIds.has(message.tool_call_id)) {
+      continue;
+    }
+
+    if (message.role !== 'assistant') {
+      durable.push({ ...message, providerContent: undefined });
+      continue;
+    }
+
+    if (hasHiddenProviderReplay(message) && message.tool_calls?.length) {
+      for (const toolCall of message.tool_calls) {
+        hiddenReplayToolCallIds.add(toolCall.id);
+      }
+      durable.push({
+        ...message,
+        content: providerReplaySummary(message),
+        tool_calls: undefined,
+        providerContent: undefined,
+      });
+      continue;
+    }
+
+    durable.push({ ...message, providerContent: undefined });
+  }
+
+  return durable;
+}
+
+function serializeMessages(messages: Message[]): string {
+  return messages.map(message => JSON.stringify(message)).join('\n') + '\n';
+}
+
 export interface SessionRuntimeState {
   currentDirectory?: string;
   updatedAt?: string;
@@ -40,9 +103,7 @@ export class SessionStore {
     try {
       ensureDir();
       const fp = filePath(sessionKey);
-      const lines = messages
-        .filter(m => !(m as any).__injected) // 跳过注入的临时消息
-        .filter(m => m.role !== 'system') // 跳过系统消息，恢复时会重新生成
+      const lines = sanitizeForPersistence(messages)
         .map(m => JSON.stringify(m));
       fs.writeFileSync(fp, lines.join('\n') + '\n', 'utf-8');
     } catch (err) {
@@ -62,7 +123,13 @@ export class SessionStore {
         try { msgs.push(JSON.parse(line) as Message); }
         catch { Logger.warning(`跳过损坏的 JSONL 行 [${sessionKey}]: ${line.slice(0, 50)}`); }
       }
-      return msgs;
+      const sanitized = sanitizeForPersistence(msgs);
+      const migratedContent = serializeMessages(sanitized).trim();
+      if (migratedContent !== content) {
+        fs.writeFileSync(fp, serializeMessages(sanitized), 'utf-8');
+        Logger.info(`会话已迁移清理 provider replay: ${sessionKey}`);
+      }
+      return sanitized;
     } catch (err) {
       Logger.error(`加载 context 失败 [${sessionKey}]: ${err}`);
       return [];

--- a/src/utils/session-store.ts
+++ b/src/utils/session-store.ts
@@ -5,6 +5,7 @@ import { Logger } from './logger';
 
 const SESSIONS_DIR = path.resolve(process.cwd(), 'data', 'sessions');
 const SESSION_STATE_DIR = path.resolve(process.cwd(), 'data', 'session-state');
+const TOOL_RESULT_SUMMARY_MAX_CHARS = 800;
 
 function ensureDir(): void {
   if (!fs.existsSync(SESSIONS_DIR)) fs.mkdirSync(SESSIONS_DIR, { recursive: true });
@@ -30,21 +31,48 @@ function hasHiddenProviderReplay(message: Message): boolean {
     ));
 }
 
-function providerReplaySummary(message: Message): string {
+function contentToPersistenceText(content: Message['content']): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  return content.map(block => block.type === 'text' ? block.text : '[图片]').join('');
+}
+
+function truncatePersistenceText(text: string, maxChars = TOOL_RESULT_SUMMARY_MAX_CHARS): string {
+  if (text.length <= maxChars) return text;
+  return `${text.slice(0, Math.max(0, maxChars - 28))}\n...[共 ${text.length} 字符]`;
+}
+
+function collectToolResultSummaries(messages: Message[]): Map<string, string> {
+  const summaries = new Map<string, string>();
+  for (const message of messages) {
+    if (message.role !== 'tool' || !message.tool_call_id) continue;
+    const text = truncatePersistenceText(contentToPersistenceText(message.content).trim());
+    const name = message.name || 'unknown';
+    summaries.set(message.tool_call_id, `[工具 ${name}] ${text || '(无文本输出)'}`);
+  }
+  return summaries;
+}
+
+function providerReplaySummary(message: Message, toolResultSummaries: Map<string, string>): string {
   const publicText = typeof message.content === 'string' ? message.content.trim() : '';
   const toolNames = (message.tool_calls || [])
     .map(toolCall => toolCall.function?.name)
     .filter(Boolean);
+  const toolSummaries = (message.tool_calls || [])
+    .map(toolCall => toolResultSummaries.get(toolCall.id))
+    .filter((summary): summary is string => Boolean(summary));
   const suffix = toolNames.length > 0
     ? ` 工具调用: ${toolNames.join(', ')}。`
     : '';
   return [
     publicText,
     `[历史工具调用已完成；provider replay 隐藏内容未写入本地会话。${suffix}]`,
+    toolSummaries.length > 0 ? `[历史工具结果摘要]\n${toolSummaries.join('\n')}` : '',
   ].filter(Boolean).join('\n');
 }
 
 function sanitizeForPersistence(messages: Message[]): Message[] {
+  const toolResultSummaries = collectToolResultSummaries(messages);
   const hiddenReplayToolCallIds = new Set<string>();
   const durable: Message[] = [];
 
@@ -68,7 +96,7 @@ function sanitizeForPersistence(messages: Message[]): Message[] {
       }
       durable.push({
         ...message,
-        content: providerReplaySummary(message),
+        content: providerReplaySummary(message, toolResultSummaries),
         tool_calls: undefined,
         providerContent: undefined,
       });

--- a/tests/anthropic-provider-runtime-feedback.test.ts
+++ b/tests/anthropic-provider-runtime-feedback.test.ts
@@ -66,4 +66,71 @@ describe('AnthropicProvider runtime feedback boundary', () => {
     assert.equal(result.usage.totalTokens, 30);
     assert.equal((provider as any).maxTokens, 32768);
   });
+
+  test('preserves MiniMax M3 thinking blocks for tool-use replay', () => {
+    const provider = new AnthropicProvider({
+      apiKey: 'test-key',
+      apiUrl: 'https://relay.catsco.cc/anthropic/v1/messages',
+      model: 'MiniMax-M3',
+    });
+
+    const result = (provider as any).parseResponse({
+      content: [
+        { type: 'thinking', thinking: 'hidden chain', signature: 'sig_123' },
+        { type: 'tool_use', id: 'call_1', name: 'execute_shell', input: { command: 'git status' } },
+      ],
+      stop_reason: 'tool_use',
+      usage: {
+        input_tokens: 10,
+        output_tokens: 20,
+      },
+    });
+
+    assert.equal(result.content, null);
+    assert.equal(result.toolCalls.length, 1);
+    assert.deepStrictEqual(result.providerContent, [
+      { type: 'thinking', thinking: 'hidden chain', signature: 'sig_123' },
+      { type: 'tool_use', id: 'call_1', name: 'execute_shell', input: { command: 'git status' } },
+    ]);
+  });
+
+  test('replays preserved thinking blocks before tool_use blocks', () => {
+    const provider = new AnthropicProvider({
+      apiKey: 'test-key',
+      apiUrl: 'https://relay.catsco.cc/anthropic/v1/messages',
+      model: 'MiniMax-M3',
+    });
+
+    const messages: Message[] = [
+      { role: 'user', content: 'clean repo' },
+      {
+        role: 'assistant',
+        content: null,
+        tool_calls: [{
+          id: 'call_1',
+          type: 'function',
+          function: { name: 'execute_shell', arguments: '{"command":"git status"}' },
+        }],
+        providerContent: [
+          { type: 'thinking', thinking: 'hidden chain', signature: 'sig_123' },
+          { type: 'tool_use', id: 'call_1', name: 'execute_shell', input: { command: 'git status' } },
+        ],
+      },
+      {
+        role: 'tool',
+        tool_call_id: 'call_1',
+        name: 'execute_shell',
+        content: 'clean',
+      },
+    ];
+
+    const transformed = (provider as any).transformMessages(messages);
+    assert.deepStrictEqual(transformed.messages[1], {
+      role: 'assistant',
+      content: [
+        { type: 'thinking', thinking: 'hidden chain', signature: 'sig_123' },
+        { type: 'tool_use', id: 'call_1', name: 'execute_shell', input: { command: 'git status' } },
+      ],
+    });
+  });
 });

--- a/tests/catsco-runtime-config.test.ts
+++ b/tests/catsco-runtime-config.test.ts
@@ -283,4 +283,18 @@ describe('CatsCo runtime config resolver', () => {
     assert.equal(config.currentBot?.bindingSource, 'legacy-env-migration');
     assert.equal(Boolean(config.device?.bodyId), true);
   });
+
+  test('defaults close button behavior to hiding in tray and persists overrides', () => {
+    const service = createCatsCoLocalConfigService({ runtimeRoot: tempDir, env: {} as NodeJS.ProcessEnv });
+
+    assert.equal(service.toDashboardConfigPayload().preferences.closeToTray, true);
+
+    const disabled = service.updatePreferences({ closeToTray: false });
+    assert.equal(disabled.closeToTray, false);
+    assert.equal(service.toDashboardConfigPayload().preferences.closeToTray, false);
+
+    const restored = service.updatePreferences({ closeToTray: true });
+    assert.equal(restored.closeToTray, true);
+    assert.equal(service.toDashboardConfigPayload().preferences.closeToTray, true);
+  });
 });

--- a/tests/catsco-runtime-config.test.ts
+++ b/tests/catsco-runtime-config.test.ts
@@ -253,4 +253,34 @@ describe('CatsCo runtime config resolver', () => {
     assert.equal(resolved.envOverlay.CATSCO_API_KEY, undefined);
     assert.equal(resolved.envOverlay.CATSCO_BOT_UID, undefined);
   });
+
+  test('can migrate legacy env-only bot binding for dashboard startup', () => {
+    const resolved = resolveCatsCoRuntimeConfig({
+      runtimeRoot: tempDir,
+      env: {
+        CATSCO_SERVER_URL: 'wss://env.example/v0/channels',
+        CATSCO_HTTP_BASE_URL: 'https://env.example',
+        CATSCO_USER_TOKEN: 'env-user-token',
+        CATSCO_USER_UID: 'user-env',
+        CATSCO_USER_NAME: 'env-user',
+        CATSCO_BOT_UID: 'bot-env',
+        CATSCO_API_KEY: 'cc_env_api_key',
+      },
+      migrateLegacyEnvBinding: true,
+    });
+
+    assert.equal(resolved.bodyConfigured, true);
+    assert.equal(resolved.connector?.apiKey, 'cc_env_api_key');
+    assert.equal(resolved.connector?.bodyId?.startsWith('device_'), true);
+    assert.equal(resolved.auth.botUid, 'bot-env');
+    assert.equal(resolved.envOverlay.CATSCO_API_KEY, 'cc_env_api_key');
+    assert.equal(resolved.envOverlay.CATSCOMPANY_BODY_ID?.startsWith('device_'), true);
+
+    const service = createCatsCoLocalConfigService({ runtimeRoot: tempDir, env: {} as NodeJS.ProcessEnv });
+    const config = service.load();
+    assert.equal(config.currentBot?.uid, 'bot-env');
+    assert.equal(config.currentBot?.boundByUserUid, 'user-env');
+    assert.equal(config.currentBot?.bindingSource, 'legacy-env-migration');
+    assert.equal(Boolean(config.device?.bodyId), true);
+  });
 });

--- a/tests/catscompany-content-blocks.test.ts
+++ b/tests/catscompany-content-blocks.test.ts
@@ -10,6 +10,7 @@ function createProcessHarness() {
   const runtimeObservations: Array<{ text: string; options: any }> = [];
   const sentTexts: Array<{ topic: string; text: string }> = [];
   const replies: Array<{ topic: string; text: string }> = [];
+  const sentTyping: Array<{ topic: string }> = [];
   const sentThinking: Array<{ topic: string; text: string; metadata?: any }> = [];
   const toolUses: Array<{ topic: string; toolUseId: string; name: string; input: any; metadata?: any }> = [];
   const toolResults: Array<{ topic: string; toolUseId: string; content: string; isError?: boolean; metadata?: any }> = [];
@@ -35,7 +36,9 @@ function createProcessHarness() {
       downloads.push({ url, fileName });
       return `C:\\tmp\\catsco-test\\${fileName}`;
     },
-    sendTyping: () => undefined,
+    sendTyping: (topic: string) => {
+      sentTyping.push({ topic });
+    },
     reply: async (topic: string, text: string) => {
       replies.push({ topic, text });
     },
@@ -68,7 +71,7 @@ function createProcessHarness() {
     ];
   };
 
-  return { bot, downloads, multimodalCalls, handledTurns, runtimeObservations, sentTexts, replies, sentThinking, toolUses, toolResults, session };
+  return { bot, downloads, multimodalCalls, handledTurns, runtimeObservations, sentTexts, replies, sentTyping, sentThinking, toolUses, toolResults, session };
 }
 
 describe('CatsCo content blocks', () => {
@@ -278,6 +281,23 @@ describe('CatsCo content blocks', () => {
     assert.deepStrictEqual(
       sentThinking.map(({ topic, text }) => ({ topic, text })),
       [{ topic: 'p2p_1_2', text: '排队压缩状态' }],
+    );
+  });
+
+  test('keeps CatsCompany typing visible while a turn is processing', async () => {
+    const { bot, sentTyping } = createProcessHarness();
+
+    const stopTyping = (bot as any).startTypingHeartbeat('p2p_1_2', 10);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    stopTyping();
+    const countAfterStop = sentTyping.length;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    assert.ok(countAfterStop >= 2);
+    assert.strictEqual(sentTyping.length, countAfterStop);
+    assert.deepStrictEqual(
+      sentTyping.map(({ topic }) => topic),
+      Array(sentTyping.length).fill('p2p_1_2'),
     );
   });
 

--- a/tests/context-compressor.test.ts
+++ b/tests/context-compressor.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, beforeEach } from 'node:test';
 import * as assert from 'node:assert';
 import { ContextCompressor, contentToString, messagesToConversationText, parseCompactSummary, buildCompactSystemPrompt, truncateForSummary } from '../src/core/context-compressor';
+import { estimateTokens } from '../src/core/token-estimator';
 import type { Message } from '../src/types';
 import type { AIService } from '../src/utils/ai-service';
 
@@ -104,6 +105,13 @@ describe('messagesToConversationText', () => {
     const result = truncateForSummary(msgs);
     assert.ok(result.includes('...[共 1000 字符]'), '应包含截断标记');
     assert.ok(!result.includes('中'.repeat(900)), '截断后不应包含900个字符');
+  });
+
+  test('摘要输入中单条超大消息按 token 预算截断', () => {
+    const result = truncateForSummary([user('中'.repeat(1000))], 20);
+
+    assert.ok(estimateTokens(result) <= 20, `summary should fit budget, got ${estimateTokens(result)}`);
+    assert.ok(!result.includes('中'.repeat(100)), '不应保留固定 500 字符的大段内容');
   });
 });
 

--- a/tests/context-debug-logger.test.ts
+++ b/tests/context-debug-logger.test.ts
@@ -1,0 +1,47 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { ContextDebugLogger } from '../src/utils/context-debug-logger';
+
+test('SDK debug dumps redact provider hidden thinking blocks', () => {
+  const previous = process.env.CONTEXT_DEBUG;
+  process.env.CONTEXT_DEBUG = 'true';
+  const requestId = `redact42-${Date.now()}`;
+  const debugDir = path.resolve('logs/context-debug');
+
+  try {
+    ContextDebugLogger.dumpSdkBoundary('before', requestId, {
+      params: {
+        messages: [{
+          role: 'assistant',
+          content: [
+            { type: 'thinking', thinking: 'hidden chain text', signature: 'sig_secret' },
+            { type: 'redacted_thinking', data: 'opaque_secret' },
+          ],
+        }],
+      },
+    });
+
+    const file = fs.readdirSync(debugDir).find(name =>
+      name.includes('_sdk_before_redact42')
+    );
+    assert.ok(file, 'expected SDK debug dump file');
+    const content = fs.readFileSync(path.join(debugDir, file), 'utf-8');
+
+    assert.match(content, /redacted hidden thinking/);
+    assert.match(content, /redacted thinking signature/);
+    assert.match(content, /redacted thinking data/);
+    assert.doesNotMatch(content, /hidden chain text/);
+    assert.doesNotMatch(content, /sig_secret/);
+    assert.doesNotMatch(content, /opaque_secret/);
+
+    fs.unlinkSync(path.join(debugDir, file));
+  } finally {
+    if (previous === undefined) {
+      delete process.env.CONTEXT_DEBUG;
+    } else {
+      process.env.CONTEXT_DEBUG = previous;
+    }
+  }
+});

--- a/tests/context-debug-logger.test.ts
+++ b/tests/context-debug-logger.test.ts
@@ -20,6 +20,11 @@ test('SDK debug dumps redact provider hidden thinking blocks', () => {
             { type: 'redacted_thinking', data: 'opaque_secret' },
           ],
         }],
+        apiKey: 'sk-secret-debug-value',
+        token: 'plain-token-should-not-leak',
+        headers: { Authorization: 'Bearer cats_svc_debug_should_not_leak' },
+        toolInput: { password: 'plain-password-should-not-leak' },
+        toolArgs: 'api_key=tool-secret-token password=debug-pass',
       },
     });
 
@@ -35,6 +40,12 @@ test('SDK debug dumps redact provider hidden thinking blocks', () => {
     assert.doesNotMatch(content, /hidden chain text/);
     assert.doesNotMatch(content, /sig_secret/);
     assert.doesNotMatch(content, /opaque_secret/);
+    assert.doesNotMatch(content, /sk-secret-debug-value/);
+    assert.doesNotMatch(content, /plain-token-should-not-leak/);
+    assert.doesNotMatch(content, /cats_svc_debug_should_not_leak/);
+    assert.doesNotMatch(content, /plain-password-should-not-leak/);
+    assert.doesNotMatch(content, /tool-secret-token/);
+    assert.doesNotMatch(content, /debug-pass/);
 
     fs.unlinkSync(path.join(debugDir, file));
   } finally {

--- a/tests/conversation-runner-context-budget.test.ts
+++ b/tests/conversation-runner-context-budget.test.ts
@@ -1,8 +1,8 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { ConversationRunner } from '../src/core/conversation-runner';
-import { estimateMessagesTokens, estimateToolsTokens } from '../src/core/token-estimator';
-import type { Message } from '../src/types';
+import { ConversationRunner, PROMPT_BUDGET_TRIM_MESSAGE, PROMPT_TOOLS_DISABLED_MESSAGE } from '../src/core/conversation-runner';
+import { estimateMessageTokens, estimateMessagesTokens, estimateToolsTokens } from '../src/core/token-estimator';
+import type { ContentBlock, Message } from '../src/types';
 import type { ToolDefinition, ToolExecutor } from '../src/types/tool';
 
 function makeRunner(maxContextTokens: number): ConversationRunner {
@@ -60,4 +60,126 @@ test('minimal fallback keeps shrinking oversized system prompts until they fit',
   const total = estimateMessagesTokens(messages);
   assert.ok(total <= 1_000, `minimal fallback should fit budget, got ${total}`);
   assert.equal(messages[0].role, 'system');
+});
+
+test('prompt budget guard emits a visible thinking status before mechanical trimming', async () => {
+  const executor: ToolExecutor = {
+    getToolDefinitions: () => [],
+    executeTool: async () => ({ content: 'ok' }),
+  };
+  let capturedMessages: Message[] = [];
+  const aiService = {
+    async chat(messages: Message[]) {
+      capturedMessages = messages;
+      return { content: 'done' };
+    },
+  };
+  const runner = new ConversationRunner(aiService as any, executor, {
+    maxContextTokens: 1_000,
+    stream: false,
+    enableCompression: false,
+  });
+  const thinking: string[] = [];
+
+  const result = await runner.run([
+    { role: 'system', content: '系统提示'.repeat(4_000) },
+    { role: 'user', content: '用户历史'.repeat(4_000) },
+  ], {
+    onThinking: text => thinking.push(text),
+  });
+
+  assert.equal(result.response, 'done');
+  assert.deepEqual(thinking, [PROMPT_BUDGET_TRIM_MESSAGE]);
+  assert.ok(estimateMessagesTokens(capturedMessages) <= 1_000);
+});
+
+test('mechanical prompt trimming removes dangling tool result messages', () => {
+  const runner = makeRunner(1_200);
+  const messages: Message[] = [
+    { role: 'system', content: 'system' },
+    {
+      role: 'assistant',
+      content: null,
+      tool_calls: [{ id: 'old_call', type: 'function', function: { name: 'read_file', arguments: '{}' } }],
+    },
+    { role: 'tool', content: 'old result'.repeat(1_000), tool_call_id: 'old_call', name: 'read_file' },
+    ...Array.from({ length: 10 }, (_, index): Message => ({
+      role: index % 2 === 0 ? 'user' : 'assistant',
+      content: `recent ${index} `.repeat(1_000),
+    })),
+  ];
+
+  (runner as any).ensurePromptBudget(messages, []);
+
+  const toolCallIds = new Set<string>();
+  const toolResultIds = new Set<string>();
+  for (const message of messages) {
+    for (const toolCall of message.tool_calls || []) {
+      toolCallIds.add(toolCall.id);
+    }
+    if (message.role === 'tool' && message.tool_call_id) {
+      toolResultIds.add(message.tool_call_id);
+    }
+  }
+
+  for (const toolResultId of toolResultIds) {
+    assert.ok(toolCallIds.has(toolResultId), `tool result ${toolResultId} should have a matching assistant tool_call`);
+  }
+  for (const toolCallId of toolCallIds) {
+    assert.ok(toolResultIds.has(toolCallId), `assistant tool_call ${toolCallId} should have a matching tool result`);
+  }
+});
+
+test('image content blocks contribute to prompt token estimates', () => {
+  const image: ContentBlock = {
+    type: 'image',
+    source: {
+      type: 'base64',
+      media_type: 'image/png',
+      data: 'a'.repeat(8_000),
+    },
+  };
+
+  assert.ok(estimateMessageTokens({ role: 'user', content: [image] }) >= 1_000);
+});
+
+test('oversized tool schemas are disabled visibly before provider requests', async () => {
+  const hugeTool: ToolDefinition = {
+    name: 'huge_tool_schema',
+    description: '工具说明'.repeat(10_000),
+    parameters: {
+      type: 'object',
+      properties: {
+        payload: {
+          type: 'string',
+          description: '参数说明'.repeat(10_000),
+        },
+      },
+    },
+  };
+  const executor: ToolExecutor = {
+    getToolDefinitions: () => [hugeTool],
+    executeTool: async () => ({ content: 'unused' }),
+  };
+  let capturedTools: ToolDefinition[] | undefined;
+  const aiService = {
+    async chat(_messages: Message[], tools: ToolDefinition[]) {
+      capturedTools = tools;
+      return { content: 'text only' };
+    },
+  };
+  const runner = new ConversationRunner(aiService as any, executor, {
+    maxContextTokens: 1_000,
+    stream: false,
+    enableCompression: false,
+  });
+  const thinking: string[] = [];
+
+  const result = await runner.run([{ role: 'user', content: '继续' }], {
+    onThinking: text => thinking.push(text),
+  });
+
+  assert.equal(result.response, 'text only');
+  assert.deepEqual(capturedTools, []);
+  assert.deepEqual(thinking, [PROMPT_TOOLS_DISABLED_MESSAGE]);
 });

--- a/tests/conversation-runner-context-budget.test.ts
+++ b/tests/conversation-runner-context-budget.test.ts
@@ -172,6 +172,25 @@ test('image content blocks contribute to prompt token estimates', () => {
   assert.ok(estimateMessageTokens({ role: 'user', content: [image] }) >= 1_000);
 });
 
+test('provider replay thinking contributes to prompt token estimates', () => {
+  const hiddenThinking = 'a'.repeat(200_000);
+  const tokens = estimateMessageTokens({
+    role: 'assistant',
+    content: null,
+    tool_calls: [{
+      id: 'call_1',
+      type: 'function',
+      function: { name: 'execute_shell', arguments: '{}' },
+    }],
+    providerContent: [
+      { type: 'thinking', thinking: hiddenThinking, signature: 'sig_1' },
+      { type: 'tool_use', id: 'call_1', name: 'execute_shell', input: {} },
+    ],
+  });
+
+  assert.ok(tokens > 40_000, `hidden provider thinking should be budgeted, got ${tokens}`);
+});
+
 test('oversized tool schemas are disabled visibly before provider requests', async () => {
   const hugeTool: ToolDefinition = {
     name: 'huge_tool_schema',

--- a/tests/conversation-runner-context-budget.test.ts
+++ b/tests/conversation-runner-context-budget.test.ts
@@ -1,0 +1,63 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { ConversationRunner } from '../src/core/conversation-runner';
+import { estimateMessagesTokens, estimateToolsTokens } from '../src/core/token-estimator';
+import type { Message } from '../src/types';
+import type { ToolDefinition, ToolExecutor } from '../src/types/tool';
+
+function makeRunner(maxContextTokens: number): ConversationRunner {
+  const executor: ToolExecutor = {
+    getToolDefinitions: () => [],
+    executeTool: async () => ({ content: 'ok' }),
+  };
+  return new ConversationRunner({} as any, executor, {
+    maxContextTokens,
+    stream: false,
+  });
+}
+
+test('prompt budget guard counts system messages and tool schemas before provider requests', () => {
+  const runner = makeRunner(5_000);
+  const tools: ToolDefinition[] = [
+    {
+      name: 'large_tool',
+      description: '中'.repeat(1_200),
+      parameters: {
+        type: 'object',
+        properties: {
+          payload: {
+            type: 'string',
+            description: '中'.repeat(1_200),
+          },
+        },
+      },
+    },
+  ];
+  const messages: Message[] = [
+    { role: 'system', content: '系统提示'.repeat(3_000) },
+    { role: 'user', content: '用户历史'.repeat(3_000) },
+    { role: 'assistant', content: '助手历史'.repeat(3_000) },
+    { role: 'user', content: '当前问题'.repeat(1_000) },
+  ];
+
+  (runner as any).ensurePromptBudget(messages, tools);
+
+  const total = estimateMessagesTokens(messages) + estimateToolsTokens(tools);
+  assert.ok(total <= 5_000, `trimmed prompt should fit budget, got ${total}`);
+  assert.ok(messages.some(message => message.role === 'system'), 'system prompt should be retained after trimming');
+});
+
+test('minimal fallback keeps shrinking oversized system prompts until they fit', () => {
+  const runner = makeRunner(1_000);
+  const messages: Message[] = [
+    { role: 'system', content: '系统提示'.repeat(5_000) },
+    { role: 'user', content: '当前问题'.repeat(2_000) },
+    { role: 'assistant', content: '助手历史'.repeat(2_000) },
+  ];
+
+  (runner as any).ensurePromptBudget(messages, []);
+
+  const total = estimateMessagesTokens(messages);
+  assert.ok(total <= 1_000, `minimal fallback should fit budget, got ${total}`);
+  assert.equal(messages[0].role, 'system');
+});

--- a/tests/conversation-runner-context-budget.test.ts
+++ b/tests/conversation-runner-context-budget.test.ts
@@ -130,6 +130,35 @@ test('mechanical prompt trimming removes dangling tool result messages', () => {
   }
 });
 
+test('mechanical prompt trimming filters provider replay blocks with retained tool calls', () => {
+  const runner = makeRunner(1_200);
+  const messages: Message[] = [
+    {
+      role: 'assistant',
+      content: null,
+      tool_calls: [
+        { id: 'kept_call', type: 'function', function: { name: 'read_file', arguments: '{}' } },
+        { id: 'dropped_call', type: 'function', function: { name: 'execute_shell', arguments: '{}' } },
+      ],
+      providerContent: [
+        { type: 'thinking', thinking: 'hidden chain', signature: 'sig_1' },
+        { type: 'tool_use', id: 'kept_call', name: 'read_file', input: {} },
+        { type: 'tool_use', id: 'dropped_call', name: 'execute_shell', input: {} },
+      ],
+    },
+    { role: 'tool', content: 'kept result', tool_call_id: 'kept_call', name: 'read_file' },
+  ];
+
+  const repaired = (runner as any).repairToolExchangeMessages(messages) as Message[];
+  const assistant = repaired.find(message => message.role === 'assistant');
+
+  assert.deepEqual(assistant?.tool_calls?.map(toolCall => toolCall.id), ['kept_call']);
+  assert.deepEqual(assistant?.providerContent?.map(block => block.type === 'tool_use' ? block.id : block.type), [
+    'thinking',
+    'kept_call',
+  ]);
+});
+
 test('image content blocks contribute to prompt token estimates', () => {
   const image: ContentBlock = {
     type: 'image',

--- a/tests/dashboard-catsco-auth-status.test.ts
+++ b/tests/dashboard-catsco-auth-status.test.ts
@@ -389,6 +389,135 @@ describe('dashboard CatsCo account status', () => {
     assert.equal(data.service.status, 'running');
   });
 
+  test('POST /cats/bind-bot writes relay model config before starting an existing bot binding', async () => {
+    if (dashboardServer) {
+      await close(dashboardServer);
+      dashboardServer = undefined;
+    }
+
+    const service = {
+      name: 'catscompany',
+      label: 'CatsCo agent',
+      command: process.execPath,
+      args: [],
+      status: 'stopped',
+    };
+    let startCalled = 0;
+    let relayKeyCreated = 0;
+    const dashboardApp = express();
+    dashboardApp.use(express.json());
+    dashboardApp.use('/api', createApiRouter({
+      getAll: () => [service],
+      getService: (name: string) => (name === 'catscompany' ? service : undefined),
+      start: (name: string) => {
+        assert.equal(name, 'catscompany');
+        startCalled += 1;
+        service.status = 'running';
+        return service;
+      },
+    } as any));
+    dashboardServer = await listen(dashboardApp);
+    dashboardBaseUrl = serverBaseUrl(dashboardServer);
+
+    await startCatsServer((req, res) => {
+      if (req.path === '/api/me') {
+        assert.equal(req.header('authorization'), 'Bearer user-token');
+        return res.json({ uid: 88, username: 'fresh', display_name: 'Fresh User' });
+      }
+      if (req.path === '/api/bots' && req.method === 'GET') {
+        return res.json({
+          bots: [{ uid: 188, username: 'catsco_88', display_name: 'CatsCo Existing', api_key: 'cats-agent-key' }],
+        });
+      }
+      if (req.path === '/api/friends/request' || req.path === '/api/friends/accept') {
+        return res.json({ ok: true });
+      }
+      if (req.path === '/api/relay/config') {
+        return res.json({
+          base_url: 'https://relay.catsco.cc',
+          self_service_enabled: true,
+          models: [
+            {
+              id: 'minimax-m2.7',
+              label: 'MiniMax M2.7',
+              model: 'MiniMax-M2.7',
+              provider: 'anthropic',
+              protocol: 'Anthropic-compatible',
+              base_url: 'https://relay.catsco.cc/anthropic',
+              enabled: true,
+              default: true,
+            },
+            {
+              id: 'glm-5.1',
+              label: 'GLM 5.1',
+              model: 'glm-5.1',
+              provider: 'anthropic',
+              protocol: 'Anthropic-compatible',
+              base_url: 'https://relay.catsco.cc/anthropic',
+              enabled: true,
+            },
+          ],
+        });
+      }
+      if (req.path === '/api/relay/key' && req.method === 'GET') {
+        return res.json({ key: null });
+      }
+      if (req.path === '/api/relay/key' && req.method === 'POST') {
+        relayKeyCreated += 1;
+        assert.equal(req.body.name, 'Fresh User');
+        return res.json({
+          key: {
+            id: 'relay-key-existing-bot',
+            name: req.body.name,
+            prefix: 'sk-bf-ex',
+            state: 'active',
+            key: 'sk-bf-existing-bot-secret',
+          },
+        });
+      }
+      return res.status(404).json({ error: 'not found' });
+    });
+    writeEnv([
+      `CATSCO_HTTP_BASE_URL=${catsBaseUrl}`,
+      'CATSCO_SERVER_URL=wss://app.catsco.cc/v0/channels',
+      'CATSCO_USER_TOKEN=user-token',
+      'CATSCO_USER_UID=88',
+      'CATSCO_USER_NAME=fresh',
+      'CATSCO_USER_DISPLAY_NAME=Fresh User',
+    ]);
+
+    const response = await fetch(`${dashboardBaseUrl}/api/cats/bind-bot`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        httpBaseUrl: catsBaseUrl,
+        serverUrl: 'wss://app.catsco.cc/v0/channels',
+        botUid: '188',
+        relayModelId: 'glm-5.1',
+      }),
+    });
+    const text = await response.text();
+    const data = JSON.parse(text) as any;
+    const env = dotenv.parse(fs.readFileSync(path.join(testRoot, '.env'), 'utf-8'));
+
+    assert.equal(response.status, 200, text);
+    assert.equal(data.ok, true);
+    assert.equal(data.relayModelSetup.ok, true);
+    assert.equal(data.relayModelSetup.model, 'glm-5.1');
+    assert.equal(data.relayModelSetup.createdKey, true);
+    assert.equal(text.includes('sk-bf-existing-bot-secret'), false);
+    assert.equal(relayKeyCreated, 1);
+    assert.equal(env.GAUZ_LLM_PROVIDER, 'anthropic');
+    assert.equal(env.GAUZ_LLM_API_BASE, 'https://relay.catsco.cc/anthropic');
+    assert.equal(env.GAUZ_LLM_MODEL, 'glm-5.1');
+    assert.equal(env.GAUZ_LLM_API_KEY, 'sk-bf-existing-bot-secret');
+    assert.equal(env.CATSCO_MODEL_SOURCE, 'relay');
+    assert.equal(env.CATSCO_BOT_UID, '188');
+    assert.equal(env.CATSCO_API_KEY, 'cats-agent-key');
+    assert.equal(startCalled, 1);
+    assert.equal(data.service.status, 'running');
+  });
+
   test('POST /cats/setup restarts a running connector after writing relay model config', async () => {
     if (dashboardServer) {
       await close(dashboardServer);

--- a/tests/dashboard-productization-html.test.ts
+++ b/tests/dashboard-productization-html.test.ts
@@ -176,6 +176,18 @@ test('CatsCo Chat setup refreshes readiness before unlocking the composer', () =
   assert.match(setupBlock, /await loadCatsMessages\(true, \{reset:true, forceBottom:true\}\)/);
 });
 
+test('CatsCo bot binding carries selected relay model setup', () => {
+  const bindBlock = dashboardHtml.match(/async function bindCatsBot\(botUid, botName, button, options\) \{[\s\S]*?function closeBotSelector/)?.[0] || '';
+  assert.match(bindBlock, /const setupRelayModel=shouldSetupRelayOnCatsSetup\(\)/);
+  assert.match(bindBlock, /setupRelayModel,/);
+  assert.match(bindBlock, /relayModelId:setupRelayModel \? \(relayModelIdForSetup\(\)\|\|undefined\) : undefined/);
+  assert.match(bindBlock, /rotateRelayKey:Boolean\(options\?\.rotateRelayKey\)/);
+  assert.match(bindBlock, /pendingStartupSource=''/);
+  assert.match(bindBlock, /pendingRelayModelId=''/);
+  assert.match(bindBlock, /e\.status===409 && e\.action==='rotate_required'/);
+  assert.match(bindBlock, /bindCatsBot\(botUid, botName, button, \{\.\.\.options, confirm:false, restoreText, rotateRelayKey:true\}\)/);
+});
+
 test('CatsCo Chat preserves scroll position while reading history', () => {
   assert.match(dashboardHtml, /let catsScrollPinnedToBottom = true/);
   assert.match(dashboardHtml, /let catsMessagesCache = \[\]/);

--- a/tests/dashboard-productization-html.test.ts
+++ b/tests/dashboard-productization-html.test.ts
@@ -32,6 +32,8 @@ test('Agent Hub keeps connector controls and third-party model config without du
   assert.match(dashboardHtml, /\/api\/cats\/relay\/model-config\/apply/);
   assert.match(dashboardHtml, /service-config/);
   assert.match(dashboardHtml, /CatsCo 中转模型在 CatsCo 页面选择/);
+  assert.match(dashboardHtml, /自定义模型默认使用 128K 安全上下文/);
+  assert.match(dashboardHtml, /上下文 '\+escapeHtml\(contextLabel\)\+'/);
   assert.doesNotMatch(servicesPageHtml, /模型来源与 Runtime Profile/);
   assert.doesNotMatch(servicesPageHtml, /id="settings-setup-panel"/);
   assert.doesNotMatch(servicesPageHtml, /先完成关键配置/);

--- a/tests/dashboard-settings-api.test.ts
+++ b/tests/dashboard-settings-api.test.ts
@@ -1364,6 +1364,80 @@ describe('dashboard typed settings API', () => {
     }
   });
 
+  test('POST /cats/relay/model-config/apply reveals existing relay key before prompting rotation', async () => {
+    const catsApp = express();
+    catsApp.use(express.json());
+    let revealCalled = false;
+    let createCalled = false;
+    let rotateCalled = false;
+
+    catsApp.get('/api/relay/config', (_req, res) => {
+      res.json({
+        base_url: 'https://relay.catsco.cc',
+        default_model: 'MiniMax-M2.7',
+        self_service_enabled: true,
+        endpoints: [{ protocol: 'Anthropic-compatible', base_url: 'https://relay.catsco.cc/anthropic' }],
+      });
+    });
+    catsApp.get('/api/relay/key', (_req, res) => {
+      res.json({
+        configured: true,
+        key: { id: 'vk-existing', name: 'existing', prefix: 'sk-bf-cu...cret', state: 'active' },
+      });
+    });
+    catsApp.post('/api/relay/key/reveal', (_req, res) => {
+      revealCalled = true;
+      res.json({
+        configured: true,
+        key: {
+          id: 'vk-existing',
+          name: 'existing',
+          prefix: 'sk-bf-cu...cret',
+          state: 'active',
+          key: 'sk-bf-current-secret',
+        },
+      });
+    });
+    catsApp.post('/api/relay/key', (_req, res) => {
+      createCalled = true;
+      res.status(500).json({ error: 'create should not be called' });
+    });
+    catsApp.post('/api/relay/key/rotate', (_req, res) => {
+      rotateCalled = true;
+      res.status(500).json({ error: 'rotate should not be called' });
+    });
+    const catsServer = await listen(catsApp);
+    const address = catsServer.address();
+    if (!address || typeof address === 'string') throw new Error('cats server did not bind');
+
+    try {
+      process.env.CATSCO_USER_TOKEN = 'user-token';
+      process.env.CATSCO_USER_UID = '38';
+      process.env.CATSCO_HTTP_BASE_URL = `http://127.0.0.1:${address.port}`;
+
+      const response = await fetch(`${baseUrl}/api/cats/relay/model-config/apply`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ modelId: 'minimax-m2.7' }),
+      });
+      const text = await response.text();
+      const data = JSON.parse(text) as any;
+      const parsed = dotenv.parse(fs.readFileSync(path.join(testRoot, '.env'), 'utf-8'));
+
+      assert.equal(response.status, 200, text);
+      assert.equal(data.createdKey, false);
+      assert.equal(data.rotatedKey, false);
+      assert.equal(data.revealedKey, true);
+      assert.equal(revealCalled, true);
+      assert.equal(createCalled, false);
+      assert.equal(rotateCalled, false);
+      assert.equal(parsed.GAUZ_LLM_API_KEY, 'sk-bf-current-secret');
+      assert.equal(text.includes('sk-bf-current-secret'), false);
+    } finally {
+      await new Promise<void>(resolve => catsServer.close(() => resolve()));
+    }
+  });
+
   test('POST /cats/relay/model-config/apply reuses stored relay key while custom startup is active', async () => {
     const catsApp = express();
     catsApp.use(express.json());

--- a/tests/dashboard-settings-api.test.ts
+++ b/tests/dashboard-settings-api.test.ts
@@ -131,6 +131,26 @@ describe('dashboard typed settings API', () => {
     assert.equal(text.includes('abc'), false);
   });
 
+  test('PUT /cats/config/preferences persists close button behavior', async () => {
+    const initialResponse = await fetch(`${baseUrl}/api/cats/config`);
+    const initial = await initialResponse.json() as any;
+    assert.equal(initialResponse.status, 200);
+    assert.equal(initial.preferences.closeToTray, true);
+
+    const response = await fetch(`${baseUrl}/api/cats/config/preferences`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ closeToTray: false }),
+    });
+    const data = await response.json() as any;
+    assert.equal(response.status, 200);
+    assert.equal(data.ok, true);
+    assert.equal(data.preferences.closeToTray, false);
+
+    const config = createCatsCoLocalConfigService({ runtimeRoot: testRoot }).load();
+    assert.equal(config.preferences?.closeToTray, false);
+  });
+
   test('GET /settings sanitizes URL credentials and query values before display', async () => {
     fs.writeFileSync(path.join(testRoot, '.env'), [
       'GAUZ_LLM_API_BASE=https://user:pass@model.example.test/v1/messages?token=secret#frag',

--- a/tests/dashboard-settings-api.test.ts
+++ b/tests/dashboard-settings-api.test.ts
@@ -264,6 +264,8 @@ describe('dashboard typed settings API', () => {
     assert.equal(parsed.GAUZ_LLM_API_BASE, 'https://api.deepseek.com/v1');
     assert.equal(parsed.GAUZ_LLM_MODEL, 'deepseek-chat');
     assert.equal(parsed.GAUZ_LLM_API_KEY, 'sk-custom-secret');
+    assert.equal(parsed.GAUZ_LLM_CONTEXT_WINDOW_TOKENS, '128000');
+    assert.equal(parsed.CATSCO_CUSTOM_LLM_CONTEXT_WINDOW_TOKENS, '128000');
     assert.equal(parsed.CATSCO_RELAY_LLM_API_KEY, 'sk-bf-relay-secret');
     assert.equal(parsed.CATSCO_RELAY_LLM_MODEL, 'MiniMax-M2.7');
   });
@@ -594,11 +596,13 @@ describe('dashboard typed settings API', () => {
       assert.equal(parsed.GAUZ_LLM_API_BASE, 'https://relay.catsco.cc/anthropic');
       assert.equal(parsed.GAUZ_LLM_MODEL, 'MiniMax-M2.7');
       assert.equal(parsed.GAUZ_LLM_API_KEY, 'sk-bf-secret-created-once');
+      assert.equal(parsed.GAUZ_LLM_CONTEXT_WINDOW_TOKENS, '204800');
       assert.equal(parsed.CATSCO_MODEL_SOURCE, 'relay');
       assert.equal(parsed.CATSCO_RELAY_LLM_PROVIDER, 'anthropic');
       assert.equal(parsed.CATSCO_RELAY_LLM_API_BASE, 'https://relay.catsco.cc/anthropic');
       assert.equal(parsed.CATSCO_RELAY_LLM_MODEL, 'MiniMax-M2.7');
       assert.equal(parsed.CATSCO_RELAY_LLM_API_KEY, 'sk-bf-secret-created-once');
+      assert.equal(parsed.CATSCO_RELAY_LLM_CONTEXT_WINDOW_TOKENS, '204800');
       assert.equal(process.env.GAUZ_LLM_PROVIDER, 'anthropic');
 
       const customResponse = await fetch(`${baseUrl}/api/settings`, {

--- a/tests/dashboard-settings-api.test.ts
+++ b/tests/dashboard-settings-api.test.ts
@@ -19,15 +19,19 @@ describe('dashboard typed settings API', () => {
     'GAUZ_LLM_API_BASE',
     'GAUZ_LLM_API_KEY',
     'GAUZ_LLM_MODEL',
+    'GAUZ_LLM_CONTEXT_WINDOW_TOKENS',
+    'GAUZ_LLM_CONTEXT_TOKENS',
     'CATSCO_MODEL_SOURCE',
     'CATSCO_CUSTOM_LLM_PROVIDER',
     'CATSCO_CUSTOM_LLM_API_BASE',
     'CATSCO_CUSTOM_LLM_API_KEY',
     'CATSCO_CUSTOM_LLM_MODEL',
+    'CATSCO_CUSTOM_LLM_CONTEXT_WINDOW_TOKENS',
     'CATSCO_RELAY_LLM_PROVIDER',
     'CATSCO_RELAY_LLM_API_BASE',
     'CATSCO_RELAY_LLM_API_KEY',
     'CATSCO_RELAY_LLM_MODEL',
+    'CATSCO_RELAY_LLM_CONTEXT_WINDOW_TOKENS',
     'CATSCO_HTTP_BASE_URL',
     'CATSCO_SERVER_URL',
     'CATSCO_USER_TOKEN',
@@ -687,9 +691,9 @@ describe('dashboard typed settings API', () => {
       });
       const text = await response.text();
       const data = JSON.parse(text) as any;
+      assert.equal(response.status, 200, text);
       const parsed = dotenv.parse(fs.readFileSync(path.join(testRoot, '.env'), 'utf-8'));
 
-      assert.equal(response.status, 200, text);
       assert.equal(data.provider, 'anthropic');
       assert.equal(data.apiBase, 'https://relay.catsco.cc/anthropic');
       assert.equal(data.model, 'deepseek-v4-flash');
@@ -698,7 +702,11 @@ describe('dashboard typed settings API', () => {
       assert.equal(parsed.GAUZ_LLM_PROVIDER, 'anthropic');
       assert.equal(parsed.GAUZ_LLM_API_BASE, 'https://relay.catsco.cc/anthropic');
       assert.equal(parsed.GAUZ_LLM_MODEL, 'deepseek-v4-flash');
+      assert.equal(parsed.GAUZ_LLM_CONTEXT_WINDOW_TOKENS, '1000000');
       assert.equal(parsed.GAUZ_LLM_API_KEY, 'sk-bf-openai-compatible');
+      assert.equal(parsed.CATSCO_RELAY_LLM_CONTEXT_WINDOW_TOKENS, '1000000');
+      assert.equal(data.selectedModel.context_window_tokens, 1000000);
+      assert.equal(data.selectedModel.context_label, '1M');
       assert.equal(text.includes('sk-bf-openai-compatible'), false);
     } finally {
       await new Promise<void>(resolve => catsServer.close(() => resolve()));
@@ -748,9 +756,9 @@ describe('dashboard typed settings API', () => {
       });
       const text = await response.text();
       const data = JSON.parse(text) as any;
+      assert.equal(response.status, 200, text);
       const parsed = dotenv.parse(fs.readFileSync(path.join(testRoot, '.env'), 'utf-8'));
 
-      assert.equal(response.status, 200, text);
       assert.equal(data.provider, 'anthropic');
       assert.equal(data.apiBase, 'https://relay.catsco.cc/anthropic');
       assert.equal(data.model, 'glm-5.1');
@@ -758,7 +766,10 @@ describe('dashboard typed settings API', () => {
       assert.equal(parsed.GAUZ_LLM_PROVIDER, 'anthropic');
       assert.equal(parsed.GAUZ_LLM_API_BASE, 'https://relay.catsco.cc/anthropic');
       assert.equal(parsed.GAUZ_LLM_MODEL, 'glm-5.1');
+      assert.equal(parsed.GAUZ_LLM_CONTEXT_WINDOW_TOKENS, '200000');
       assert.equal(parsed.GAUZ_LLM_API_KEY, 'sk-bf-glm-secret');
+      assert.equal(parsed.CATSCO_RELAY_LLM_CONTEXT_WINDOW_TOKENS, '200000');
+      assert.equal(data.selectedModel.context_window_tokens, 200000);
     } finally {
       await new Promise<void>(resolve => catsServer.close(() => resolve()));
     }

--- a/tests/electron-main-dashboard-url.test.ts
+++ b/tests/electron-main-dashboard-url.test.ts
@@ -9,3 +9,31 @@ test('electron opens the local dashboard through stable IPv4 loopback', () => {
   assert.match(electronMain, /mainWindow\.loadURL\(`http:\/\/127\.0\.0\.1:\$\{DASHBOARD_PORT\}`\)/);
   assert.doesNotMatch(electronMain, /mainWindow\.loadURL\(`http:\/\/localhost:\$\{DASHBOARD_PORT\}`\)/);
 });
+
+test('electron uses Chinese menus with close-to-tray control', () => {
+  assert.match(electronMain, /function createApplicationMenu\(\)/);
+  assert.match(electronMain, /Menu\.setApplicationMenu\(Menu\.buildFromTemplate\(template\)\)/);
+  assert.match(electronMain, /label: '文件'/);
+  assert.match(electronMain, /label: '编辑'/);
+  assert.match(electronMain, /label: '视图'/);
+  assert.match(electronMain, /label: '窗口'/);
+  assert.match(electronMain, /label: '帮助'/);
+  assert.match(electronMain, /label: '点 × 后隐藏到后台'/);
+  assert.match(electronMain, /type: 'checkbox'/);
+  assert.match(electronMain, /writeCloseToTrayPreference\(menuItem\.checked\)/);
+  assert.doesNotMatch(electronMain, /label: 'File'/);
+  assert.doesNotMatch(electronMain, /label: 'Edit'/);
+  assert.doesNotMatch(electronMain, /label: 'View'/);
+  assert.doesNotMatch(electronMain, /label: 'Window'/);
+  assert.doesNotMatch(electronMain, /label: 'Help'/);
+});
+
+test('electron tray uses app icons and notifies after background hide', () => {
+  assert.match(electronMain, /function createTrayIcon\(\)/);
+  assert.match(electronMain, /build-resources\/icon\.ico/);
+  assert.match(electronMain, /new Tray\(createTrayIcon\(\)\)/);
+  assert.match(electronMain, /function notifyWindowHidden\(\)/);
+  assert.match(electronMain, /tray\.displayBalloon/);
+  assert.match(electronMain, /CatsCo 已在后台运行/);
+  assert.match(electronMain, /notifyWindowHidden\(\)/);
+});

--- a/tests/electron-main-dashboard-url.test.ts
+++ b/tests/electron-main-dashboard-url.test.ts
@@ -28,6 +28,16 @@ test('electron uses Chinese menus with close-to-tray control', () => {
   assert.doesNotMatch(electronMain, /label: 'Help'/);
 });
 
+test('electron changes cwd to userData before reading close-to-tray menu preference', () => {
+  const chdirIndex = electronMain.indexOf('process.chdir(userDataPath)');
+  const menuCallIndex = electronMain.indexOf('createApplicationMenu();');
+
+  assert.notEqual(chdirIndex, -1);
+  assert.notEqual(menuCallIndex, -1);
+  assert.equal(chdirIndex < menuCallIndex, true);
+  assert.match(electronMain, /close-to-tray preferences are read from process\.cwd\(\)\/\.xiaoba\/catsco\.json/);
+});
+
 test('electron tray uses app icons and notifies after background hide', () => {
   assert.match(electronMain, /function createTrayIcon\(\)/);
   assert.match(electronMain, /build-resources\/icon\.ico/);

--- a/tests/model-context-window.test.ts
+++ b/tests/model-context-window.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import {
   CUSTOM_MODEL_DEFAULT_CONTEXT_WINDOW_TOKENS,
   calculatePromptBudgetTokens,
+  calculateSummaryBudgetTokens,
   resolveModelContextWindow,
 } from '../src/utils/model-context-window';
 
@@ -86,4 +87,12 @@ test('tiny explicit context windows never produce a prompt budget beyond the win
   assert.equal(resolved.promptBudgetTokens, 1);
   assert.equal(resolved.promptBudgetTokens + resolved.maxOutputTokens <= resolved.contextWindowTokens, true);
   assert.equal(resolved.summaryBudgetTokens, 1);
+});
+
+test('summary content budget reserves room for summary wrapper on small prompt budgets', () => {
+  const promptBudget = 30_000;
+  const summaryBudget = calculateSummaryBudgetTokens(promptBudget);
+
+  assert.ok(summaryBudget > 0);
+  assert.ok(summaryBudget < promptBudget);
 });

--- a/tests/model-context-window.test.ts
+++ b/tests/model-context-window.test.ts
@@ -1,0 +1,85 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  CUSTOM_MODEL_DEFAULT_CONTEXT_WINDOW_TOKENS,
+  calculatePromptBudgetTokens,
+  resolveModelContextWindow,
+} from '../src/utils/model-context-window';
+
+test('relay MiniMax M3 uses a 1M official window with output and estimator reserve', () => {
+  const resolved = resolveModelContextWindow({
+    apiUrl: 'https://relay.catsco.cc/anthropic',
+    model: 'MiniMax-M3',
+    provider: 'anthropic',
+  }, { CATSCO_MODEL_SOURCE: 'relay' } as NodeJS.ProcessEnv);
+
+  assert.equal(resolved.contextWindowTokens, 1_000_000);
+  assert.equal(resolved.maxOutputTokens, 32_768);
+  assert.equal(resolved.promptBudgetTokens + resolved.safetyReserveTokens, 1_000_000);
+  assert.ok(resolved.safetyReserveTokens > resolved.maxOutputTokens, 'reserve must include output tokens and protocol margin');
+  assert.ok(resolved.promptBudgetTokens < resolved.contextWindowTokens, 'runtime budget must stay below the official window');
+});
+
+test('relay catalog models resolve to their official context windows', () => {
+  assert.equal(resolveModelContextWindow({
+    apiUrl: 'https://relay.catsco.cc/anthropic',
+    model: 'MiniMax-M2.7',
+    provider: 'anthropic',
+  }, { CATSCO_MODEL_SOURCE: 'relay' } as NodeJS.ProcessEnv).contextWindowTokens, 204_800);
+
+  assert.equal(resolveModelContextWindow({
+    apiUrl: 'https://relay.catsco.cc/anthropic',
+    model: 'deepseek-v4-flash',
+    provider: 'anthropic',
+  }, { CATSCO_MODEL_SOURCE: 'relay' } as NodeJS.ProcessEnv).contextWindowTokens, 1_000_000);
+
+  assert.equal(resolveModelContextWindow({
+    apiUrl: 'https://relay.catsco.cc/anthropic',
+    model: 'glm-5.1',
+    provider: 'anthropic',
+  }, { CATSCO_MODEL_SOURCE: 'relay' } as NodeJS.ProcessEnv).contextWindowTokens, 200_000);
+});
+
+test('custom models keep the safe default even if the model name resembles a known relay model', () => {
+  const resolved = resolveModelContextWindow({
+    apiUrl: 'https://api.minimaxi.com/anthropic',
+    model: 'MiniMax-M3',
+    provider: 'anthropic',
+  }, { CATSCO_MODEL_SOURCE: 'custom' } as NodeJS.ProcessEnv);
+
+  assert.equal(resolved.source, 'custom');
+  assert.equal(resolved.contextWindowTokens, CUSTOM_MODEL_DEFAULT_CONTEXT_WINDOW_TOKENS);
+  assert.ok(resolved.promptBudgetTokens < CUSTOM_MODEL_DEFAULT_CONTEXT_WINDOW_TOKENS);
+});
+
+test('explicit context window override still keeps a safety reserve', () => {
+  const resolved = resolveModelContextWindow({
+    apiUrl: 'https://custom.example.test/anthropic',
+    model: 'custom-long-context',
+    provider: 'anthropic',
+  }, {
+    CATSCO_MODEL_SOURCE: 'custom',
+    GAUZ_LLM_CONTEXT_WINDOW_TOKENS: '256000',
+  } as NodeJS.ProcessEnv);
+  const expected = calculatePromptBudgetTokens(256_000, resolved.maxOutputTokens);
+
+  assert.equal(resolved.source, 'explicit');
+  assert.equal(resolved.contextWindowTokens, 256_000);
+  assert.equal(resolved.promptBudgetTokens, expected.promptBudgetTokens);
+  assert.equal(resolved.safetyReserveTokens, expected.safetyReserveTokens);
+});
+
+test('tiny explicit context windows never produce a prompt budget beyond the window', () => {
+  const resolved = resolveModelContextWindow({
+    apiUrl: 'https://custom.example.test/anthropic',
+    model: 'tiny-window',
+    provider: 'anthropic',
+  }, {
+    CATSCO_MODEL_SOURCE: 'custom',
+    GAUZ_LLM_CONTEXT_WINDOW_TOKENS: '1024',
+  } as NodeJS.ProcessEnv);
+
+  assert.equal(resolved.contextWindowTokens, 1024);
+  assert.equal(resolved.promptBudgetTokens + resolved.safetyReserveTokens, 1024);
+  assert.equal(resolved.promptBudgetTokens, 1);
+});

--- a/tests/model-context-window.test.ts
+++ b/tests/model-context-window.test.ts
@@ -16,6 +16,7 @@ test('relay MiniMax M3 uses a 1M official window with output and estimator reser
   assert.equal(resolved.contextWindowTokens, 1_000_000);
   assert.equal(resolved.maxOutputTokens, 32_768);
   assert.equal(resolved.promptBudgetTokens + resolved.safetyReserveTokens, 1_000_000);
+  assert.equal(resolved.summaryBudgetTokens, 300_000);
   assert.ok(resolved.safetyReserveTokens > resolved.maxOutputTokens, 'reserve must include output tokens and protocol margin');
   assert.ok(resolved.promptBudgetTokens < resolved.contextWindowTokens, 'runtime budget must stay below the official window');
 });
@@ -49,6 +50,7 @@ test('custom models keep the safe default even if the model name resembles a kno
 
   assert.equal(resolved.source, 'custom');
   assert.equal(resolved.contextWindowTokens, CUSTOM_MODEL_DEFAULT_CONTEXT_WINDOW_TOKENS);
+  assert.equal(resolved.summaryBudgetTokens, 50_000);
   assert.ok(resolved.promptBudgetTokens < CUSTOM_MODEL_DEFAULT_CONTEXT_WINDOW_TOKENS);
 });
 
@@ -82,4 +84,6 @@ test('tiny explicit context windows never produce a prompt budget beyond the win
   assert.equal(resolved.contextWindowTokens, 1024);
   assert.equal(resolved.promptBudgetTokens + resolved.safetyReserveTokens, 1024);
   assert.equal(resolved.promptBudgetTokens, 1);
+  assert.equal(resolved.promptBudgetTokens + resolved.maxOutputTokens <= resolved.contextWindowTokens, true);
+  assert.equal(resolved.summaryBudgetTokens, 1);
 });

--- a/tests/provider-output-limits.test.ts
+++ b/tests/provider-output-limits.test.ts
@@ -46,3 +46,23 @@ test('resolveMaxTokens keeps the conservative default for other providers', () =
     8192,
   );
 });
+
+test('resolveMaxTokens clamps output to a quarter of explicit context windows', () => {
+  assert.equal(
+    resolveMaxTokens({
+      apiUrl: 'https://custom.example.test/anthropic',
+      model: 'tiny-window',
+      maxTokens: 8192,
+      contextWindowTokens: 1024,
+    }),
+    256,
+  );
+  assert.equal(
+    resolveMaxTokens({
+      apiUrl: 'https://relay.catsco.cc/anthropic',
+      model: 'MiniMax-M3',
+      contextWindowTokens: 1_000_000,
+    }),
+    32768,
+  );
+});

--- a/tests/session-lifecycle-manager.test.ts
+++ b/tests/session-lifecycle-manager.test.ts
@@ -153,6 +153,74 @@ describe('AgentSession lifecycle', () => {
     );
   });
 
+  test('session persistence strips provider replay hidden thinking from restored history', async () => {
+    const { SessionStore } = loadSessionModules();
+    SessionStore.getInstance().saveContext('user:lifecycle-provider-replay', [
+      { role: 'user', content: '需要读文件' },
+      {
+        role: 'assistant',
+        content: null,
+        tool_calls: [{
+          id: 'toolu_1',
+          type: 'function',
+          function: { name: 'read_file', arguments: '{"path":"notes.md"}' },
+        }],
+        providerContent: [
+          { type: 'thinking', thinking: 'hidden chain text', signature: 'sig_secret' },
+          { type: 'tool_use', id: 'toolu_1', name: 'read_file', input: { path: 'notes.md' } },
+        ],
+      },
+      { role: 'tool', content: 'private tool result', tool_call_id: 'toolu_1', name: 'read_file' },
+      { role: 'assistant', content: '读完了' },
+    ]);
+
+    const restored = SessionStore.getInstance().loadContext('user:lifecycle-provider-replay');
+    const raw = fs.readFileSync(
+      path.join(testRoot, 'data', 'sessions', 'user_lifecycle-provider-replay.jsonl'),
+      'utf-8',
+    );
+
+    assert.equal(restored.some((message: any) => Array.isArray(message.providerContent)), false);
+    assert.equal(restored.some((message: any) => message.role === 'tool'), false);
+    assert.equal(restored.some((message: any) => message.tool_calls?.length), false);
+    assert.match(String(restored[1]?.content || ''), /provider replay 隐藏内容未写入本地会话/);
+    assert.doesNotMatch(raw, /hidden chain text/);
+    assert.doesNotMatch(raw, /sig_secret/);
+    assert.doesNotMatch(raw, /private tool result/);
+  });
+
+  test('loading legacy sessions migrates provider replay hidden thinking off disk', async () => {
+    const { SessionStore } = loadSessionModules();
+    const sessionFile = path.join(testRoot, 'data', 'sessions', 'user_lifecycle-legacy-provider-replay.jsonl');
+    fs.mkdirSync(path.dirname(sessionFile), { recursive: true });
+    fs.writeFileSync(sessionFile, [
+      JSON.stringify({ role: 'user', content: '旧历史' }),
+      JSON.stringify({
+        role: 'assistant',
+        content: null,
+        tool_calls: [{
+          id: 'toolu_legacy',
+          type: 'function',
+          function: { name: 'read_file', arguments: '{"path":"legacy.md"}' },
+        }],
+        providerContent: [
+          { type: 'thinking', thinking: 'legacy hidden chain', signature: 'legacy_sig' },
+          { type: 'tool_use', id: 'toolu_legacy', name: 'read_file', input: { path: 'legacy.md' } },
+        ],
+      }),
+      JSON.stringify({ role: 'tool', content: 'legacy tool result', tool_call_id: 'toolu_legacy', name: 'read_file' }),
+    ].join('\n') + '\n', 'utf-8');
+
+    const restored = SessionStore.getInstance().loadContext('user:lifecycle-legacy-provider-replay');
+    const migratedRaw = fs.readFileSync(sessionFile, 'utf-8');
+
+    assert.equal(restored.some((message: any) => Array.isArray(message.providerContent)), false);
+    assert.equal(restored.some((message: any) => message.role === 'tool'), false);
+    assert.doesNotMatch(migratedRaw, /legacy hidden chain/);
+    assert.doesNotMatch(migratedRaw, /legacy_sig/);
+    assert.doesNotMatch(migratedRaw, /legacy tool result/);
+  });
+
   test('handleMessage persists each completed turn before cleanup', async () => {
     const { AgentSession, SessionStore } = loadSessionModules();
     const session = new AgentSession('catscompany:lifecycle-autosave', buildMockServices(), 'catscompany');

--- a/tests/session-lifecycle-manager.test.ts
+++ b/tests/session-lifecycle-manager.test.ts
@@ -184,9 +184,9 @@ describe('AgentSession lifecycle', () => {
     assert.equal(restored.some((message: any) => message.role === 'tool'), false);
     assert.equal(restored.some((message: any) => message.tool_calls?.length), false);
     assert.match(String(restored[1]?.content || ''), /provider replay 隐藏内容未写入本地会话/);
+    assert.match(String(restored[1]?.content || ''), /private tool result/);
     assert.doesNotMatch(raw, /hidden chain text/);
     assert.doesNotMatch(raw, /sig_secret/);
-    assert.doesNotMatch(raw, /private tool result/);
   });
 
   test('loading legacy sessions migrates provider replay hidden thinking off disk', async () => {
@@ -216,9 +216,9 @@ describe('AgentSession lifecycle', () => {
 
     assert.equal(restored.some((message: any) => Array.isArray(message.providerContent)), false);
     assert.equal(restored.some((message: any) => message.role === 'tool'), false);
+    assert.match(migratedRaw, /legacy tool result/);
     assert.doesNotMatch(migratedRaw, /legacy hidden chain/);
     assert.doesNotMatch(migratedRaw, /legacy_sig/);
-    assert.doesNotMatch(migratedRaw, /legacy tool result/);
   });
 
   test('handleMessage persists each completed turn before cleanup', async () => {


### PR DESCRIPTION
## 变更
- 桌面端启用 CatsCo relay 模型时，如果用户已有 active relay key，会优先通过 CatsCompany reveal 接口取回当前 key，再写入本地 `.env`；reveal 不可用时仍保留重新生成确认兜底。
- local Dashboard 的 relay apply / bind 响应继续只返回脱敏 key 信息，不把 relay key 明文暴露给页面。
- 选择已有 CatsCo bot 的 `/cats/bind-bot` 路径现在和新建 setup 一样，会先写入当前选择的 relay 模型和 key，再启动或重启 CatsCompany connector，避免新用户/已有机器人绕过自动中转配置。
- 兼容最新 main 的 CatsCo bot/body 绑定：Dashboard readiness 和 connector 启动路径会把旧 `.env` 中同账号的 `CATSCO_BOT_UID + CATSCO_API_KEY` 迁移为 `.xiaoba/catsco.json` binding，并自动生成 `bodyId`。
- 迁移仅用于旧 CatsCo bot API key，不会把 `sk-*` relay/model key 当作 connector 凭证，避免切换 MiniMax M3 后 connector 因缺 `apiKey/bodyId` 启动失败。
- 新增窗口行为偏好：默认点击窗口 `×` 隐藏到后台/托盘；入口迁移到桌面应用菜单「窗口 > 点 × 后隐藏到后台」，不再占用 Dashboard 设置页。
- 桌面原生菜单中文化，并使用真实 CatsCo 图标作为托盘图标；Windows 首次隐藏窗口时会弹出托盘提示，方便用户找回窗口。
- CatsCo 中转模型按模型自动写入上下文窗口：MiniMax M3 1M、MiniMax M2.7 204.8K、DeepSeek V4 Flash 1M、GLM 5.1 200K；自定义模型默认使用 128K 安全窗口。
- runtime 会把官方窗口转换成安全 prompt budget，扣除输出 tokens、协议开销和估算误差；ConversationRunner 的守门逻辑会把 system messages、图片 base64、tool schemas 和 provider replay blocks 一起计入。
- prompt 超预算时会在 UI 显示裁剪/压缩状态；子 agent 的压缩和机械裁剪也会通过 `agent_progress` 回流，避免静默等待。
- 工具 schema 本身超出模型上下文时，本轮会可见地降级为纯文本请求，不再把超大工具定义硬塞给 provider。
- 机械裁剪会修复 assistant `tool_calls` 与 tool result 的配对，避免裁剪后留下孤立工具结果。
- MiniMax M3 / Anthropic-compatible 工具回合会在运行内保留 provider 原始 `thinking/tool_use` content blocks 作为隐藏回放元数据，下一轮工具结果请求会原样带回，避免 `content[].thinking` 未传回导致 400。
- 本地 session JSONL 落盘和旧历史恢复会清理 provider replay 隐藏内容：不长期保存 `thinking/signature/redacted_thinking.data`，旧文件在 load 时会迁移回写。
- `CONTEXT_DEBUG=true` 的 SDK 边界 dump 会脱敏 `thinking/signature/redacted_thinking.data`，并按字段名兜底脱敏 `token/apiKey/password/Authorization` 等普通 secret 值。
- summary 压缩输入按 token budget 截断单条超大消息，并为 summary wrapper 保留内容余量，减少小窗口配置下压缩请求继续超预算的风险。
- CatsCompany 用户消息处理期间由 CatsCo 每 5 秒续发 typing 心跳，覆盖长模型调用、排队消息和子 agent 结果回流；子 agent drain 队列前会停止外层心跳，避免重复定时器。
- 已 rebase 到最新 `main`（含 #94 Agent Hub 改版和 #92 SkillHub 快速分享改版）；Dashboard 冲突按新版前端结构保留，中转/自定义模型说明和上下文提示迁入新版页面。

## 验证
- `npm.cmd run build`
- `git diff --check`
- `npx.cmd tsx --test tests\context-debug-logger.test.ts tests\session-lifecycle-manager.test.ts tests\context-compressor.test.ts tests\model-context-window.test.ts`
- `npx.cmd tsx --test tests\dashboard-productization-html.test.ts tests\dashboard-catsco-auth-status.test.ts tests\catscompany-content-blocks.test.ts`
- `npm.cmd run test:runtime`，结果 485 pass / 0 fail / 2 skip。
- 子 agent 复审：Dashboard/relay 绑定链路未发现 P0/P1/P2；providerContent/context 复审提出的问题已在最新提交中修复并补测试。
## 最新评论处理
- 回应 Nobody-ly 的远程 diff 评论：provider replay 落盘时保留每个工具调用对应的短工具结果摘要，同时继续移除原始 tool role、thinking、signature 和 redacted thinking data，避免重启后丢掉关键工具观察事实。
- 给 Electron 启动顺序补注释和测试，固定 `process.chdir(userDataPath)` 必须早于菜单创建，避免未来 close-to-tray 偏好读取路径回退到错误 cwd。
- 追加验证：`npx.cmd tsx --test tests\session-lifecycle-manager.test.ts tests\electron-main-dashboard-url.test.ts`；`npm.cmd run build`；`git diff --check`；`npm.cmd run test:runtime`，结果 486 pass / 0 fail / 2 skip。