### PR TITLE
feat: 添加 CatsCo MessageEnvelope 与 ExecutionScope 契约层

### DIFF
--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -2,6 +2,7 @@ import { CatsClient, MessageContext } from './client';
 import { CatsCompanyConfig, ParsedCatsMessage, CatsFileInfo } from './types';
 import { MessageSender } from './message-sender';
 import { extractContentBlocks } from './content-blocks';
+import { createCatsCoMessageEnvelope, createExecutionScope } from './message-envelope';
 import { MessageSessionManager } from '../core/message-session-manager';
 import { AgentServices, BUSY_MESSAGE, RuntimeFeedbackInput, SessionCallbacks } from '../core/agent-session';
 import { Logger } from '../utils/logger';
@@ -35,6 +36,7 @@ interface QueuedMessage {
   topic: string;
   senderId: string;
   seq: number;
+  executionScope: ParsedCatsMessage['executionScope'];
   receivedAt: number;
   source?: 'user' | 'subagent_feedback';
   runtimeFeedback?: RuntimeFeedbackInput[];
@@ -281,9 +283,7 @@ export class CatsCompanyBot {
     // 过滤 bot 自己发出的消息，防止循环
     if (this.botUid && msg.senderId === this.botUid) return;
 
-    const key = msg.chatType === 'group'
-      ? `cc_group:${msg.topic}`
-      : `cc_user:${msg.senderId}`;
+    const key = msg.envelope.sessionKey;
 
     // ── 拦截：如果当前 session 正在等待回答，按 sender 精确匹配 ──
     const pendingId = this.pendingAnswerBySession.get(key);
@@ -312,7 +312,7 @@ export class CatsCompanyBot {
     const subAgentManager = SubAgentManager.getInstance();
     subAgentManager.registerPlatformCallbacks(key, {
       injectMessage: async (text: string) => {
-        await this.handleSubAgentFeedback(key, msg.topic, msg.senderId, text);
+        await this.handleSubAgentFeedback(key, msg.topic, msg.senderId, text, msg.executionScope);
       },
       onSubAgentEvent: async (event: any, info?: SubAgentInfo) => {
         await this.handleSubAgentRuntimeEvent(msg.topic, event, info);
@@ -387,6 +387,7 @@ export class CatsCompanyBot {
         topic: msg.topic,
         senderId: msg.senderId,
         seq: msg.seq,
+        executionScope: msg.executionScope,
         receivedAt: Date.now(),
         source: 'user',
         runtimeFeedback,
@@ -407,6 +408,7 @@ export class CatsCompanyBot {
     try {
       const result = await session.handleMessage(userMessage, {
         channel,
+        executionScope: msg.executionScope,
         runtimeFeedback,
         pendingUserInputProvider: () => this.consumeQueuedUserInput(key),
         callbacks: this.buildSessionCallbacks(msg.topic),
@@ -504,14 +506,30 @@ export class CatsCompanyBot {
     const blockText = blockTextParts.join('\n\n');
     const mergedText = blockText || text;
     if (!mergedText && files.length === 0) return null;
+    const messageText = mergedText
+      || (files.length > 0
+        ? files.map(item => `[${item.type === 'image' ? '图片' : '文件'}] ${item.fileName}`).join('\n')
+        : '');
+    const envelope = createCatsCoMessageEnvelope({
+      topic: ctx.topic,
+      isGroup: ctx.isGroup,
+      senderId: ctx.senderId,
+      seq: ctx.seq,
+      text: messageText,
+      metadata: ctx.metadata,
+      botUid: this.botUid,
+    });
 
     return {
       topic: ctx.topic,
       chatType,
       senderId: ctx.senderId,
       seq: ctx.seq ?? 0,
-      text: mergedText || (files.length > 0 ? files.map(item => `[${item.type === 'image' ? '图片' : '文件'}] ${item.fileName}`).join('\n') : ''),
+      text: messageText,
       rawContent: ctx.content,
+      metadata: ctx.metadata,
+      envelope,
+      executionScope: createExecutionScope(envelope),
       file: files[0],
       files,
     };
@@ -525,11 +543,12 @@ export class CatsCompanyBot {
     topic: string,
     senderId: string,
     text: string,
+    executionScope?: ParsedCatsMessage['executionScope'],
   ): Promise<void> {
     const session = this.sessionManager.getOrCreate(sessionKey);
 
     if (session.isBusy()) {
-      this.enqueueSubAgentFeedback(sessionKey, topic, senderId, text);
+      this.enqueueSubAgentFeedback(sessionKey, topic, senderId, text, executionScope);
       Logger.info(`[${sessionKey}] 主会话忙，子智能体反馈已入队`);
       return;
     }
@@ -552,9 +571,10 @@ export class CatsCompanyBot {
         channel,
         callbacks: this.buildSessionCallbacks(topic),
         source: 'subagent_result',
+        executionScope,
       });
       if (result.text === BUSY_MESSAGE) {
-        this.enqueueSubAgentFeedback(sessionKey, topic, senderId, text);
+        this.enqueueSubAgentFeedback(sessionKey, topic, senderId, text, executionScope);
         Logger.info(`[${sessionKey}] 主会话竞态忙碌，子智能体反馈已入队`);
         return;
       }
@@ -579,13 +599,24 @@ export class CatsCompanyBot {
     }
   }
 
-  private enqueueSubAgentFeedback(sessionKey: string, topic: string, senderId: string, text: string): void {
+  private enqueueSubAgentFeedback(
+    sessionKey: string,
+    topic: string,
+    senderId: string,
+    text: string,
+    executionScope?: ParsedCatsMessage['executionScope'],
+  ): void {
     const queue = this.messageQueue.get(sessionKey) ?? [];
     queue.push({
       userMessage: text,
       topic,
       senderId,
       seq: 0,
+      executionScope: executionScope ?? createExecutionScope(createCatsCoMessageEnvelope({
+        topic,
+        senderId,
+        text,
+      })),
       receivedAt: Date.now(),
       source: 'subagent_feedback',
     });
@@ -736,9 +767,11 @@ export class CatsCompanyBot {
           channel,
           callbacks: this.buildSessionCallbacks(msg.topic),
           source: 'subagent_result',
+          executionScope: msg.executionScope,
         })
         : await session.handleMessage(msg.userMessage, {
           channel,
+          executionScope: msg.executionScope,
           runtimeFeedback: msg.runtimeFeedback,
           pendingUserInputProvider: () => this.consumeQueuedUserInput(sessionKey),
           callbacks: this.buildSessionCallbacks(msg.topic),

--- a/src/catscompany/message-envelope.ts
+++ b/src/catscompany/message-envelope.ts
@@ -1,0 +1,181 @@
+import type { ExecutionScope, IdentityTrustLevel, MessageEnvelope, MessageTopicType } from '../types/session-identity';
+
+type UnknownRecord = Record<string, unknown>;
+
+export interface CatsCoEnvelopeInput {
+  topic: string;
+  isGroup?: boolean;
+  senderId: string;
+  seq?: number;
+  text: string;
+  metadata?: Record<string, unknown>;
+  botUid?: string | null;
+}
+
+export function createCatsCoMessageEnvelope(input: CatsCoEnvelopeInput): MessageEnvelope {
+  const topicId = safeString(input.topic) || 'unknown_topic';
+  const senderId = safeString(input.senderId) || 'unknown';
+  const topicType = inferTopicType(topicId, input.isGroup);
+  const metadata = input.metadata;
+  const catscoIdentity = asRecord(metadata?.catsco_identity);
+  const warnings: string[] = [];
+
+  const actor = asRecord(catscoIdentity?.actor);
+  const agent = asRecord(catscoIdentity?.agent);
+  const identityTopic = asRecord(catscoIdentity?.topic);
+  const permissions = asRecord(catscoIdentity?.permissions);
+
+  const canonicalActorId = stringField(actor, 'user_id');
+  const canonicalTopicId = stringField(identityTopic, 'topic_id');
+  const canonicalTopicType = normalizeTopicType(stringField(identityTopic, 'type'));
+  const permissionsSource = stringField(permissions, 'source');
+  const canonicalChannelSeq = numberField(identityTopic, 'channel_seq');
+  const metadataLooksCanonical = permissionsSource === 'server_canonical_message';
+
+  if (catscoIdentity && !metadataLooksCanonical) {
+    warnings.push('catsco_identity permissions.source is not server_canonical_message');
+  }
+  if (metadataLooksCanonical && canonicalTopicId && canonicalTopicId !== topicId) {
+    warnings.push('catsco_identity topic_id does not match message topic');
+  }
+  if (metadataLooksCanonical && canonicalActorId && senderId !== 'unknown' && canonicalActorId !== senderId) {
+    warnings.push('catsco_identity actor.user_id does not match message sender');
+  }
+
+  const isCanonicalTrusted = Boolean(
+    catscoIdentity
+    && metadataLooksCanonical
+    && canonicalActorId
+    && canonicalTopicId === topicId
+    && (senderId === 'unknown' || canonicalActorId === senderId),
+  );
+
+  const actorUserId = isCanonicalTrusted ? canonicalActorId! : senderId;
+  const resolvedTopicType = isCanonicalTrusted && canonicalTopicType !== 'unknown'
+    ? canonicalTopicType
+    : topicType;
+  const agentId = isCanonicalTrusted
+    ? firstNonEmpty(stringField(agent, 'agent_id'), safeString(input.botUid))
+    : safeString(input.botUid);
+  const agentBodyId = isCanonicalTrusted ? stringField(agent, 'body_id') : undefined;
+  const channelSeq = isCanonicalTrusted
+    ? canonicalChannelSeq ?? normalizeSeq(input.seq)
+    : normalizeSeq(input.seq);
+  const identityTrust: IdentityTrustLevel = isCanonicalTrusted
+    ? 'server_canonical'
+    : catscoIdentity
+      ? 'untrusted'
+      : 'legacy_context';
+  const sessionKey = buildCatsCoSessionKey(resolvedTopicType, topicId, actorUserId);
+
+  return {
+    source: 'catscompany',
+    sessionKey,
+    messageId: buildMessageId(topicId, channelSeq, metadata),
+    topicId,
+    topicType: resolvedTopicType,
+    actorUserId,
+    agentId,
+    agentBodyId,
+    channelSeq,
+    rawText: input.text,
+    rawMetadata: metadata,
+    permissionsSource: isCanonicalTrusted ? permissionsSource : undefined,
+    identityTrust,
+    identitySource: isCanonicalTrusted ? 'metadata.catsco_identity' : undefined,
+    warnings: warnings.length > 0 ? warnings : undefined,
+  };
+}
+
+export function createExecutionScope(envelope: MessageEnvelope): ExecutionScope {
+  return {
+    source: envelope.source,
+    sessionKey: envelope.sessionKey,
+    topicId: envelope.topicId,
+    topicType: envelope.topicType,
+    actorUserId: envelope.actorUserId,
+    agentId: envelope.agentId,
+    agentBodyId: envelope.agentBodyId,
+    channelSeq: envelope.channelSeq,
+    permissionsSource: envelope.permissionsSource,
+    identityTrust: envelope.identityTrust,
+    isTrusted: envelope.identityTrust === 'server_canonical',
+  };
+}
+
+export function buildCatsCoSessionKey(
+  topicType: MessageTopicType,
+  topicId: string,
+  actorUserId: string,
+): string {
+  if (topicType === 'group') {
+    return `cc_group:${topicId}`;
+  }
+  return `cc_user:${actorUserId || 'unknown'}`;
+}
+
+function buildMessageId(
+  topicId: string,
+  channelSeq: number | undefined,
+  metadata?: UnknownRecord,
+): string | undefined {
+  const clientMessageId = firstNonEmpty(
+    stringField(metadata, 'client_msg_id'),
+    stringField(metadata, 'clientMessageId'),
+    stringField(metadata, 'client_message_id'),
+  );
+  if (clientMessageId) return clientMessageId;
+  if (channelSeq && channelSeq > 0) return `${topicId}:${channelSeq}`;
+  return undefined;
+}
+
+function inferTopicType(topicId: string, isGroup?: boolean): MessageTopicType {
+  if (isGroup || topicId.startsWith('grp_')) return 'group';
+  if (topicId.startsWith('p2p_')) return 'p2p';
+  return 'unknown';
+}
+
+function normalizeTopicType(value?: string): MessageTopicType {
+  if (value === 'p2p' || value === 'group') return value;
+  return 'unknown';
+}
+
+function asRecord(value: unknown): UnknownRecord | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  return value as UnknownRecord;
+}
+
+function stringField(record: UnknownRecord | undefined, key: string): string | undefined {
+  const value = record?.[key];
+  if (typeof value !== 'string') return undefined;
+  const text = value.trim();
+  return text || undefined;
+}
+
+function numberField(record: UnknownRecord | undefined, key: string): number | undefined {
+  const value = record?.[key];
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+
+function normalizeSeq(value: unknown): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return undefined;
+  return value;
+}
+
+function safeString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const text = value.trim();
+  return text || undefined;
+}
+
+function firstNonEmpty(...values: Array<string | undefined>): string | undefined {
+  for (const value of values) {
+    if (value) return value;
+  }
+  return undefined;
+}

--- a/src/catscompany/types.ts
+++ b/src/catscompany/types.ts
@@ -1,3 +1,5 @@
+import type { ExecutionScope, MessageEnvelope } from '../types/session-identity';
+
 /**
  * CatsCo agent 连接配置
  */
@@ -32,6 +34,12 @@ export interface ParsedCatsMessage {
   text: string;
   /** 原始 content（可能是 string 或 RichContent） */
   rawContent: unknown;
+  /** 原始 metadata，由 CatsCo 服务端透传/注入 */
+  metadata?: Record<string, unknown>;
+  /** 标准化后的消息信封 */
+  envelope: MessageEnvelope;
+  /** 当前 turn 的执行身份 */
+  executionScope: ExecutionScope;
   /** 文件附件信息（rich content file/image 时存在） */
   file?: CatsFileInfo;
   /** 同一条消息里的全部附件（content_blocks 或 rich content） */

--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -1,4 +1,5 @@
 import { Message } from '../types';
+import type { ExecutionScope } from '../types/session-identity';
 import * as fs from 'fs';
 import * as path from 'path';
 import { AIService } from '../utils/ai-service';
@@ -69,6 +70,8 @@ export interface HandleMessageOptions {
   callbacks?: SessionCallbacks;
   /** 平台通道回调，注入到 ToolExecutionContext 供工具使用 */
   channel?: ChannelCallbacks;
+  /** 当前 turn 的可信执行身份 */
+  executionScope?: ExecutionScope;
   /** 当前 turn 专属、给 agent 可见的运行时反馈 */
   runtimeFeedback?: RuntimeFeedbackInput[];
   /** Pulls user messages that arrived while this session was busy. */
@@ -360,12 +363,14 @@ export class AgentSession {
       // 兼容旧签名：如果传入的对象有 onText/onToolStart 等字段，视为 SessionCallbacks
       let callbacks: SessionCallbacks | undefined;
       let channel: ChannelCallbacks | undefined;
+      let executionScope: ExecutionScope | undefined;
       let runtimeFeedbackInputs: RuntimeFeedbackInput[] = [];
       let pendingUserInputProvider: PendingUserInputProvider | undefined;
 
       if (callbacksOrOptions) {
         if (
           'channel' in callbacksOrOptions
+          || 'executionScope' in callbacksOrOptions
           || 'callbacks' in callbacksOrOptions
           || 'runtimeFeedback' in callbacksOrOptions
           || 'pendingUserInputProvider' in callbacksOrOptions
@@ -374,6 +379,7 @@ export class AgentSession {
           const opts = callbacksOrOptions as HandleMessageOptions;
           callbacks = opts.callbacks;
           channel = opts.channel;
+          executionScope = opts.executionScope;
           runtimeFeedbackInputs = opts.runtimeFeedback || [];
           pendingUserInputProvider = opts.pendingUserInputProvider;
         } else {
@@ -415,6 +421,7 @@ export class AgentSession {
           runtimeObservationSource,
           callbacks,
           channel,
+          executionScope,
           pendingUserInputProvider,
           abortSignal: this.activeAbortController.signal,
           shouldContinue: () => !this.interruptRequested,

--- a/src/core/agent-turn-controller.ts
+++ b/src/core/agent-turn-controller.ts
@@ -1,4 +1,5 @@
 import { ContentBlock, Message } from '../types';
+import type { ExecutionScope } from '../types/session-identity';
 import { ChannelCallbacks } from '../types/tool';
 import { AIService } from '../utils/ai-service';
 import { ToolManager } from '../tools/tool-manager';
@@ -35,6 +36,7 @@ export interface RunAgentTurnParams {
   runtimeObservationSource?: string;
   callbacks?: AgentTurnCallbacks;
   channel?: ChannelCallbacks;
+  executionScope?: ExecutionScope;
   pendingUserInputProvider?: PendingUserInputProvider;
   abortSignal?: AbortSignal;
   shouldContinue: () => boolean;
@@ -90,6 +92,7 @@ export class AgentTurnController {
 
     const runner = this.createRunner({
       channel: params.channel,
+      executionScope: params.executionScope,
       pendingUserInputProvider: params.pendingUserInputProvider,
       abortSignal: params.abortSignal,
       shouldContinue: params.shouldContinue,
@@ -136,6 +139,7 @@ export class AgentTurnController {
 
   private createRunner(options: {
     channel?: ChannelCallbacks;
+    executionScope?: ExecutionScope;
     pendingUserInputProvider?: PendingUserInputProvider;
     abortSignal?: AbortSignal;
     shouldContinue: () => boolean;
@@ -165,6 +169,7 @@ export class AgentTurnController {
           },
           abortSignal: options.abortSignal,
           channel: options.channel,
+          executionScope: options.executionScope,
         },
       },
     );

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -98,3 +98,4 @@ export interface CommandOptions {
 export * from './agent';
 export * from './tool';
 export * from './skill';
+export * from './session-identity';

--- a/src/types/session-identity.ts
+++ b/src/types/session-identity.ts
@@ -1,0 +1,40 @@
+export type MessageSource = 'catscompany' | 'feishu' | 'weixin' | 'cli' | 'unknown';
+
+export type MessageTopicType = 'p2p' | 'group' | 'unknown';
+
+export type IdentityTrustLevel =
+  | 'server_canonical'
+  | 'legacy_context'
+  | 'untrusted';
+
+export interface MessageEnvelope {
+  source: MessageSource;
+  sessionKey: string;
+  messageId?: string;
+  topicId: string;
+  topicType: MessageTopicType;
+  actorUserId: string;
+  agentId?: string;
+  agentBodyId?: string;
+  channelSeq?: number;
+  rawText: string;
+  rawMetadata?: Record<string, unknown>;
+  permissionsSource?: string;
+  identityTrust: IdentityTrustLevel;
+  identitySource?: string;
+  warnings?: string[];
+}
+
+export interface ExecutionScope {
+  source: MessageSource;
+  sessionKey: string;
+  topicId: string;
+  topicType: MessageTopicType;
+  actorUserId: string;
+  agentId?: string;
+  agentBodyId?: string;
+  channelSeq?: number;
+  permissionsSource?: string;
+  identityTrust: IdentityTrustLevel;
+  isTrusted: boolean;
+}

--- a/src/types/tool.ts
+++ b/src/types/tool.ts
@@ -1,4 +1,5 @@
 import { ContentBlock } from './index';
+import type { ExecutionScope } from './session-identity';
 import type { PlanRuntime, RuntimePlanSnapshot } from '../core/plan-runtime';
 import type { AIService } from '../utils/ai-service';
 import type { SkillManager } from '../skills/skill-manager';
@@ -141,6 +142,8 @@ export interface ToolExecutionContext {
   runtimeServices?: RuntimeToolServices;
   /** 平台通道回调（飞书/CatsCompany 等聊天会话时由平台层注入） */
   channel?: ChannelCallbacks;
+  /** 当前 turn 的可信执行身份；后续 ToolGateway/设备授权会基于它做权限判断。 */
+  executionScope?: ExecutionScope;
 }
 
 /**

--- a/tests/agent-turn-execution-scope.test.ts
+++ b/tests/agent-turn-execution-scope.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const agentSessionSource = readFileSync(join(process.cwd(), 'src/core/agent-session.ts'), 'utf-8');
+const agentTurnSource = readFileSync(join(process.cwd(), 'src/core/agent-turn-controller.ts'), 'utf-8');
+const toolTypesSource = readFileSync(join(process.cwd(), 'src/types/tool.ts'), 'utf-8');
+
+test('AgentSession accepts executionScope in HandleMessageOptions', () => {
+  assert.match(agentSessionSource, /executionScope\?:\s*ExecutionScope/);
+  assert.match(agentSessionSource, /executionScope\s*=\s*opts\.executionScope/);
+  assert.match(agentSessionSource, /executionScope,\s*\n\s*pendingUserInputProvider/);
+});
+
+test('AgentTurnController forwards executionScope into ToolExecutionContext', () => {
+  assert.match(agentTurnSource, /executionScope\?:\s*ExecutionScope/);
+  assert.match(agentTurnSource, /executionScope:\s*params\.executionScope/);
+  assert.match(agentTurnSource, /executionScope:\s*options\.executionScope/);
+});
+
+test('ToolExecutionContext exposes executionScope for future ToolGateway checks', () => {
+  assert.match(toolTypesSource, /executionScope\?:\s*ExecutionScope/);
+});

--- a/tests/catscompany-execution-scope-flow.test.ts
+++ b/tests/catscompany-execution-scope-flow.test.ts
@@ -1,0 +1,125 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import { CatsCompanyBot } from '../src/catscompany';
+
+function canonicalMetadata(actorUserId: string, topicId: string, agentId = 'usr43', bodyId = 'body-main') {
+  return {
+    catsco_identity: {
+      actor: { user_id: actorUserId },
+      agent: { agent_id: agentId, body_id: bodyId },
+      topic: { topic_id: topicId, type: topicId.startsWith('grp_') ? 'group' : 'p2p', channel_seq: 12 },
+      permissions: { source: 'server_canonical_message' },
+    },
+  };
+}
+
+function createHarness(options: { busy?: boolean } = {}) {
+  const bot = Object.create(CatsCompanyBot.prototype) as any;
+  const handledTurns: Array<{ userMessage: unknown; options: any }> = [];
+  const sessionKeys: string[] = [];
+  let busy = options.busy ?? false;
+
+  const session = {
+    isBusy: () => busy,
+    setBusy: (next: boolean) => {
+      busy = next;
+    },
+    handleMessage: async (userMessage: unknown, handleOptions: any) => {
+      handledTurns.push({ userMessage, options: handleOptions });
+      return { visibleToUser: false, text: '' };
+    },
+    handleRuntimeObservation: async () => ({ visibleToUser: false, text: '' }),
+  };
+
+  bot.sessionManager = {
+    getOrCreate: (key: string) => {
+      sessionKeys.push(key);
+      return session;
+    },
+    get: () => session,
+  };
+  bot.sender = {
+    downloadFile: async () => null,
+    sendTyping: () => undefined,
+    reply: async () => undefined,
+    sendFile: async () => undefined,
+    sendText: async () => undefined,
+    sendThinking: async () => undefined,
+    sendToolUse: async () => undefined,
+    sendToolResult: async () => undefined,
+  };
+  bot.pendingAnswers = new Map();
+  bot.pendingAnswerBySession = new Map();
+  bot.pendingAttachments = new Map();
+  bot.messageQueue = new Map();
+  bot.botUid = 'usr43';
+
+  return { bot, handledTurns, sessionKeys, session };
+}
+
+describe('CatsCompany execution scope flow', () => {
+  test('passes canonical execution scope from websocket message into session turn', async () => {
+    const { bot, handledTurns, sessionKeys } = createHarness();
+
+    await (bot as any).onMessage({
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      text: '查合同',
+      content: '查合同',
+      metadata: canonicalMetadata('usr7', 'p2p_7_43'),
+      isGroup: false,
+      seq: 12,
+    });
+
+    assert.deepEqual(sessionKeys, ['cc_user:usr7']);
+    assert.equal(handledTurns.length, 1);
+    assert.equal(handledTurns[0].options.executionScope.actorUserId, 'usr7');
+    assert.equal(handledTurns[0].options.executionScope.agentId, 'usr43');
+    assert.equal(handledTurns[0].options.executionScope.agentBodyId, 'body-main');
+    assert.equal(handledTurns[0].options.executionScope.isTrusted, true);
+  });
+
+  test('keeps execution scope when a busy CatsCompany turn is queued then drained', async () => {
+    const { bot, handledTurns, sessionKeys, session } = createHarness({ busy: true });
+
+    await (bot as any).onMessage({
+      topic: 'p2p_8_43',
+      senderId: 'usr8',
+      text: '继续查',
+      content: '继续查',
+      metadata: canonicalMetadata('usr8', 'p2p_8_43'),
+      isGroup: false,
+      seq: 12,
+    });
+
+    assert.equal(handledTurns.length, 0);
+    session.setBusy(false);
+    await (bot as any).drainMessageQueue('cc_user:usr8');
+
+    assert.deepEqual(sessionKeys, ['cc_user:usr8', 'cc_user:usr8']);
+    assert.equal(handledTurns.length, 1);
+    assert.equal(handledTurns[0].options.executionScope.actorUserId, 'usr8');
+    assert.equal(handledTurns[0].options.executionScope.topicId, 'p2p_8_43');
+    assert.equal(handledTurns[0].options.executionScope.isTrusted, true);
+  });
+
+  test('group turn uses group session key while preserving actor in scope', async () => {
+    const { bot, handledTurns, sessionKeys } = createHarness();
+
+    await (bot as any).onMessage({
+      topic: 'grp_80',
+      senderId: 'usr7',
+      text: '@usr43 看一下',
+      content: '@usr43 看一下',
+      metadata: canonicalMetadata('usr7', 'grp_80'),
+      isGroup: true,
+      seq: 12,
+    });
+
+    assert.deepEqual(sessionKeys, ['cc_group:grp_80']);
+    assert.equal(handledTurns.length, 1);
+    assert.equal(handledTurns[0].options.executionScope.topicType, 'group');
+    assert.equal(handledTurns[0].options.executionScope.topicId, 'grp_80');
+    assert.equal(handledTurns[0].options.executionScope.actorUserId, 'usr7');
+  });
+});

--- a/tests/catscompany-message-envelope.test.ts
+++ b/tests/catscompany-message-envelope.test.ts
@@ -1,0 +1,156 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import { CatsClient } from '../src/catscompany/client';
+import {
+  createCatsCoMessageEnvelope,
+  createExecutionScope,
+} from '../src/catscompany/message-envelope';
+
+describe('CatsCompany MessageEnvelope and ExecutionScope', () => {
+  test('keeps two p2p users scoped separately when they message the same agent', () => {
+    const alice = createCatsCoMessageEnvelope({
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      seq: 21,
+      text: 'alice task',
+      botUid: 'usr43',
+      metadata: {
+        catsco_identity: {
+          actor: { user_id: 'usr7', display_name: 'Alice' },
+          agent: { agent_id: 'usr43', body_id: 'body-mac' },
+          topic: { topic_id: 'p2p_7_43', type: 'p2p', channel_seq: 21 },
+          permissions: { source: 'server_canonical_message' },
+        },
+      },
+    });
+    const bob = createCatsCoMessageEnvelope({
+      topic: 'p2p_8_43',
+      senderId: 'usr8',
+      seq: 22,
+      text: 'bob task',
+      botUid: 'usr43',
+      metadata: {
+        catsco_identity: {
+          actor: { user_id: 'usr8', display_name: 'Bob' },
+          agent: { agent_id: 'usr43', body_id: 'body-mac' },
+          topic: { topic_id: 'p2p_8_43', type: 'p2p', channel_seq: 22 },
+          permissions: { source: 'server_canonical_message' },
+        },
+      },
+    });
+
+    assert.equal(alice.sessionKey, 'cc_user:usr7');
+    assert.equal(bob.sessionKey, 'cc_user:usr8');
+    assert.equal(alice.identityTrust, 'server_canonical');
+    assert.equal(bob.identityTrust, 'server_canonical');
+    assert.equal(createExecutionScope(alice).actorUserId, 'usr7');
+    assert.equal(createExecutionScope(bob).actorUserId, 'usr8');
+  });
+
+  test('creates a trusted group scope with recipient agent body identity', () => {
+    const envelope = createCatsCoMessageEnvelope({
+      topic: 'grp_80',
+      isGroup: true,
+      senderId: 'usr7',
+      seq: 31,
+      text: '@usr43 请看一下',
+      metadata: {
+        catsco_identity: {
+          actor: { user_id: 'usr7', username: 'alice' },
+          agent: { agent_id: 'usr43', body_id: 'body-review' },
+          topic: { topic_id: 'grp_80', type: 'group', channel_seq: 31 },
+          permissions: { source: 'server_canonical_message' },
+        },
+      },
+    });
+    const scope = createExecutionScope(envelope);
+
+    assert.equal(envelope.sessionKey, 'cc_group:grp_80');
+    assert.equal(scope.topicType, 'group');
+    assert.equal(scope.actorUserId, 'usr7');
+    assert.equal(scope.agentId, 'usr43');
+    assert.equal(scope.agentBodyId, 'body-review');
+    assert.equal(scope.isTrusted, true);
+  });
+
+  test('does not trust spoofed catsco_identity when it conflicts with sender', () => {
+    const envelope = createCatsCoMessageEnvelope({
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      seq: 40,
+      text: 'hello',
+      metadata: {
+        catsco_identity: {
+          actor: { user_id: 'usr999' },
+          agent: { agent_id: 'usr43', body_id: 'wrong-body' },
+          topic: { topic_id: 'p2p_7_43', type: 'p2p', channel_seq: 40 },
+          permissions: { source: 'server_canonical_message' },
+        },
+      },
+    });
+    const scope = createExecutionScope(envelope);
+
+    assert.equal(envelope.identityTrust, 'untrusted');
+    assert.equal(scope.isTrusted, false);
+    assert.equal(scope.actorUserId, 'usr7');
+    assert.equal(scope.agentBodyId, undefined);
+    assert.ok(envelope.warnings?.some(warning => warning.includes('actor.user_id')));
+  });
+
+  test('marks missing canonical identity as legacy context instead of trusted', () => {
+    const envelope = createCatsCoMessageEnvelope({
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      seq: 41,
+      text: 'legacy hello',
+      botUid: 'usr43',
+      metadata: { client_msg_id: 'catsco-legacy-1' },
+    });
+    const scope = createExecutionScope(envelope);
+
+    assert.equal(envelope.identityTrust, 'legacy_context');
+    assert.equal(envelope.messageId, 'catsco-legacy-1');
+    assert.equal(scope.isTrusted, false);
+    assert.equal(scope.actorUserId, 'usr7');
+    assert.equal(scope.agentId, 'usr43');
+    assert.equal(scope.agentBodyId, undefined);
+  });
+
+  test('client forwards inbound metadata into MessageContext', async () => {
+    const client = new CatsClient({
+      serverUrl: 'ws://127.0.0.1:1',
+      apiKey: 'cc-test',
+      bodyId: 'body-test',
+    });
+
+    const messagePromise = new Promise<any>(resolve => {
+      client.once('message', resolve);
+    });
+
+    (client as any).handleMessage({
+      data: {
+        topic: 'p2p_7_43',
+        from: 'usr7',
+        seq: 51,
+        content: 'hello',
+        type: 'text',
+        metadata: {
+          catsco_identity: {
+            actor: { user_id: 'usr7' },
+            agent: { agent_id: 'usr43', body_id: 'body-test' },
+            topic: { topic_id: 'p2p_7_43', type: 'p2p', channel_seq: 51 },
+            permissions: { source: 'server_canonical_message' },
+          },
+        },
+      },
+    });
+
+    const ctx = await messagePromise;
+    assert.equal(ctx.topic, 'p2p_7_43');
+    assert.equal(ctx.senderId, 'usr7');
+    assert.deepEqual((ctx.metadata as any).catsco_identity.agent, {
+      agent_id: 'usr43',
+      body_id: 'body-test',
+    });
+  });
+});


### PR DESCRIPTION
﻿## 背景

这是多用户虚拟员工能力的第一个基础 PR，只在 XiaoBa-CLI 侧建立身份契约层，不改 CatsCo 服务端，也不在本 PR 中重构 ToolGateway。

## 本次修改

- 新增 MessageEnvelope / ExecutionScope 公共类型，用于描述一条进入 XiaoBa 的消息和本轮执行身份。
- 新增 CatsCo 专用解析器，从 metadata.catsco_identity 读取服务端 canonical 身份。
- 对服务端 canonical 身份做基础一致性校验：actor、topic、permissions.source 必须匹配，否则降级为 untrusted。
- 缺少 catsco_identity 的旧消息继续走 legacy_context，保证兼容现有 CatsCo 消息流。
- 将 executionScope 从 CatsCo 消息入口传入 AgentSession、AgentTurnController，并最终进入 ToolExecutionContext，为后续 ToolGateway / 设备授权 / 文件授权提供可信输入。
- 保持当前 session key 兼容：P2P 仍为 cc_user:<actor>，群聊仍为 cc_group:<topic>。

## 测试覆盖

- P2P 多用户同时和同一个 agent 对话时，actor scope 不串线。
- 群聊场景下 sessionKey 绑定群 topic，但 executionScope 仍保留真实发言用户。
- 客户端伪造 catsco_identity 时降级为 untrusted，不把 agent body 写入可信 scope。
- 缺失 catsco_identity 时走 legacy_context。
- CatsCo WebSocket metadata 能进入 MessageContext。
- 忙时入队后 drainMessageQueue 仍保留 executionScope。
- AgentSession -> AgentTurnController -> ToolExecutionContext 的 scope 传递链。

## 验证

- npm.cmd run build -- --noEmit
- npm.cmd run test:runtime

结果：499 个 runtime 测试，497 通过，2 跳过，0 失败。

## 非目标

- 本 PR 不改 ToolGateway 权限策略。
- 本 PR 不改 send_text / send_file 的外发网关。
- 本 PR 不迁移历史会话或消息存储。
- 本 PR 不修改 cats-company 仓库。
