### PR TITLE
feat: add execution scoped outbound gateway

### DIFF
--- a/src/tools/outbound-gateway.ts
+++ b/src/tools/outbound-gateway.ts
@@ -1,0 +1,96 @@
+import type { ToolErrorCode, ToolExecutionContext } from '../types/tool';
+
+export type OutboundOperation = 'send_text' | 'send_file';
+
+export type OutboundTargetDecision =
+  | { ok: true; chatId: string }
+  | { ok: false; errorCode: ToolErrorCode; message: string };
+
+interface ResolveOutboundTargetOptions {
+  operation: OutboundOperation;
+  missingChannelMessage: string;
+}
+
+const UNKNOWN_TOPIC_ID = 'unknown_topic';
+
+export function resolveOutboundTarget(
+  context: ToolExecutionContext,
+  options: ResolveOutboundTargetOptions,
+): OutboundTargetDecision {
+  const channel = context.channel;
+  if (!channel) {
+    return {
+      ok: false,
+      errorCode: 'TOOL_EXECUTION_ERROR',
+      message: options.missingChannelMessage,
+    };
+  }
+
+  const channelChatId = normalizeId(channel.chatId);
+  const scope = context.executionScope;
+  if (!scope) {
+    if (!channelChatId) {
+      return {
+        ok: false,
+        errorCode: 'TOOL_EXECUTION_ERROR',
+        message: '当前聊天会话缺少目标 chatId，无法发送消息',
+      };
+    }
+    return { ok: true, chatId: channelChatId };
+  }
+
+  const scopeTopicId = normalizeId(scope.topicId);
+  const scopeSessionKey = normalizeId(scope.sessionKey);
+  const contextSessionId = normalizeId(context.sessionId);
+  if (context.surface === 'catscompany'
+    && scopeSessionKey
+    && contextSessionId
+    && scopeSessionKey !== contextSessionId) {
+    return {
+      ok: false,
+      errorCode: 'PERMISSION_DENIED',
+      message: [
+        '执行会话与当前执行身份不一致，已停止发送以避免串线。',
+        `Scope session: ${scopeSessionKey}`,
+        `Context session: ${contextSessionId}`,
+      ].join('\n'),
+    };
+  }
+
+  const hasKnownScopeTopic = Boolean(scopeTopicId && scopeTopicId !== UNKNOWN_TOPIC_ID);
+  if (hasKnownScopeTopic && channelChatId && channelChatId !== scopeTopicId) {
+    return {
+      ok: false,
+      errorCode: 'PERMISSION_DENIED',
+      message: [
+        '外发目标与当前执行身份不一致，已停止发送以避免串线。',
+        `Scope topic: ${scopeTopicId}`,
+        `Channel chatId: ${channelChatId}`,
+      ].join('\n'),
+    };
+  }
+
+  if (options.operation === 'send_file' && scope.identityTrust === 'untrusted') {
+    return {
+      ok: false,
+      errorCode: 'PERMISSION_DENIED',
+      message: '当前消息身份未通过服务端一致性校验，暂不允许发送文件。',
+    };
+  }
+
+  const targetChatId = hasKnownScopeTopic ? scopeTopicId : channelChatId;
+  if (!targetChatId) {
+    return {
+      ok: false,
+      errorCode: 'TOOL_EXECUTION_ERROR',
+      message: '当前执行身份和聊天通道都缺少目标 topic，无法发送消息',
+    };
+  }
+
+  return { ok: true, chatId: targetChatId };
+}
+
+function normalizeId(value: unknown): string {
+  if (typeof value !== 'string') return '';
+  return value.trim();
+}

--- a/src/tools/send-file-tool.ts
+++ b/src/tools/send-file-tool.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import { Logger } from '../utils/logger';
 import { resolveToolPath } from '../utils/tool-path-resolver';
+import { resolveOutboundTarget } from './outbound-gateway';
 
 export class SendFileTool implements Tool {
   definition: ToolDefinition = {
@@ -83,12 +84,20 @@ CatsCo file selection rules:
     }
 
     const channel = context.channel;
-    if (!channel) {
-      return { ok: false, errorCode: 'TOOL_EXECUTION_ERROR', message: '当前不在聊天会话中，无法发送文件' };
+    const target = resolveOutboundTarget(context, {
+      operation: 'send_file',
+      missingChannelMessage: '当前不在聊天会话中，无法发送文件',
+    });
+    if (!target.ok) {
+      return {
+        ok: false,
+        errorCode: target.errorCode,
+        message: target.message,
+      };
     }
 
     try {
-      await channel.sendFile(channel.chatId, resolved.absolutePath, file_name);
+      await channel!.sendFile(target.chatId, resolved.absolutePath, file_name);
       Logger.info(`[send_file] 已发送: ${file_name} (${resolved.absolutePath})`);
       return {
         ok: true,

--- a/src/tools/send-text-tool.ts
+++ b/src/tools/send-text-tool.ts
@@ -1,4 +1,5 @@
 import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
+import { resolveOutboundTarget } from './outbound-gateway';
 
 /**
  * send_text 工具
@@ -24,16 +25,23 @@ export class SendTextTool implements Tool {
   async execute(args: { text: string }, context: ToolExecutionContext): Promise<ToolExecutionResult> {
     const { text } = args;
 
-    if (!context.channel) {
-      throw new Error('send_text 需要 channel 上下文');
-    }
-
     if (!text || !text.trim()) {
       throw new Error('text 不能为空');
     }
 
-    const chatId = context.channel.chatId;
-    await context.channel.reply(chatId, text.trim());
+    const target = resolveOutboundTarget(context, {
+      operation: 'send_text',
+      missingChannelMessage: 'send_text 需要 channel 上下文',
+    });
+    if (!target.ok) {
+      return {
+        ok: false,
+        errorCode: target.errorCode,
+        message: target.message,
+      };
+    }
+
+    await context.channel!.reply(target.chatId, text.trim());
 
     return { ok: true, content: '已发送' };
   }

--- a/tests/outbound-gateway.test.ts
+++ b/tests/outbound-gateway.test.ts
@@ -1,0 +1,137 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import { resolveOutboundTarget } from '../src/tools/outbound-gateway';
+import type { ExecutionScope } from '../src/types/session-identity';
+import type { ToolExecutionContext, ToolSurface } from '../src/types/tool';
+
+function scope(overrides: Partial<ExecutionScope> = {}): ExecutionScope {
+  return {
+    source: 'catscompany',
+    sessionKey: 'cc_user:usr7',
+    topicId: 'p2p_7_43',
+    topicType: 'p2p',
+    actorUserId: 'usr7',
+    agentId: 'usr43',
+    agentBodyId: 'body-main',
+    channelSeq: 12,
+    permissionsSource: 'server_canonical_message',
+    identityTrust: 'server_canonical',
+    isTrusted: true,
+    ...overrides,
+  };
+}
+
+function context(options: {
+  chatId?: string;
+  sessionId?: string;
+  surface?: ToolSurface;
+  executionScope?: ExecutionScope;
+} = {}): ToolExecutionContext {
+  return {
+    workingDirectory: process.cwd(),
+    workspaceRoot: process.cwd(),
+    conversationHistory: [],
+    sessionId: options.sessionId ?? 'cc_user:usr7',
+    surface: options.surface ?? 'catscompany',
+    executionScope: options.executionScope,
+    channel: {
+      chatId: options.chatId ?? 'p2p_7_43',
+      reply: async () => undefined,
+      sendFile: async () => undefined,
+    },
+  };
+}
+
+describe('resolveOutboundTarget', () => {
+  test('allows trusted CatsCo text when channel, session, and scope match', () => {
+    const result = resolveOutboundTarget(context({ executionScope: scope() }), {
+      operation: 'send_text',
+      missingChannelMessage: 'missing channel',
+    });
+
+    assert.deepEqual(result, { ok: true, chatId: 'p2p_7_43' });
+  });
+
+  test('rejects CatsCo outbound when channel chatId conflicts with scope topic', () => {
+    const result = resolveOutboundTarget(context({ chatId: 'p2p_8_43', executionScope: scope() }), {
+      operation: 'send_text',
+      missingChannelMessage: 'missing channel',
+    });
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.errorCode, 'PERMISSION_DENIED');
+      assert.match(result.message, /外发目标与当前执行身份不一致/);
+    }
+  });
+
+  test('rejects CatsCo outbound when sessionId conflicts with scope sessionKey', () => {
+    const result = resolveOutboundTarget(context({
+      sessionId: 'cc_user:usr8',
+      executionScope: scope(),
+    }), {
+      operation: 'send_text',
+      missingChannelMessage: 'missing channel',
+    });
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.errorCode, 'PERMISSION_DENIED');
+      assert.match(result.message, /执行会话与当前执行身份不一致/);
+    }
+  });
+
+  test('keeps legacy channel-only behavior when executionScope is missing', () => {
+    const result = resolveOutboundTarget(context({
+      chatId: 'legacy-chat',
+      sessionId: undefined,
+      surface: 'feishu',
+    }), {
+      operation: 'send_file',
+      missingChannelMessage: 'missing channel',
+    });
+
+    assert.deepEqual(result, { ok: true, chatId: 'legacy-chat' });
+  });
+
+  test('allows legacy CatsCo file sends when topic still matches', () => {
+    const result = resolveOutboundTarget(context({
+      executionScope: scope({
+        identityTrust: 'legacy_context',
+        isTrusted: false,
+        permissionsSource: undefined,
+        agentBodyId: undefined,
+      }),
+    }), {
+      operation: 'send_file',
+      missingChannelMessage: 'missing channel',
+    });
+
+    assert.deepEqual(result, { ok: true, chatId: 'p2p_7_43' });
+  });
+
+  test('allows untrusted CatsCo text but blocks untrusted file sends', () => {
+    const untrustedScope = scope({
+      identityTrust: 'untrusted',
+      isTrusted: false,
+      permissionsSource: undefined,
+      agentBodyId: undefined,
+    });
+
+    const textResult = resolveOutboundTarget(context({ executionScope: untrustedScope }), {
+      operation: 'send_text',
+      missingChannelMessage: 'missing channel',
+    });
+    assert.deepEqual(textResult, { ok: true, chatId: 'p2p_7_43' });
+
+    const fileResult = resolveOutboundTarget(context({ executionScope: untrustedScope }), {
+      operation: 'send_file',
+      missingChannelMessage: 'missing channel',
+    });
+    assert.equal(fileResult.ok, false);
+    if (!fileResult.ok) {
+      assert.equal(fileResult.errorCode, 'PERMISSION_DENIED');
+      assert.match(fileResult.message, /身份未通过服务端一致性校验/);
+    }
+  });
+});

--- a/tests/tool-result-send-file-tool.test.ts
+++ b/tests/tool-result-send-file-tool.test.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import * as os from 'os';
 import * as fs from 'fs';
 import { SendFileTool } from '../src/tools/send-file-tool';
+import type { ExecutionScope } from '../src/types/session-identity';
 import { ToolExecutionContext } from '../src/types/tool';
 
 describe('SendFileTool - ToolExecutionResult', () => {
@@ -22,6 +23,22 @@ describe('SendFileTool - ToolExecutionResult', () => {
       fs.rmSync(testRoot, { recursive: true, force: true });
     }
   });
+
+  function scope(overrides: Partial<ExecutionScope> = {}): ExecutionScope {
+    return {
+      source: 'catscompany',
+      sessionKey: 'cc_user:usr7',
+      topicId: 'chat-1',
+      topicType: 'p2p',
+      actorUserId: 'usr7',
+      agentId: 'usr43',
+      agentBodyId: 'body-main',
+      permissionsSource: 'server_canonical_message',
+      identityTrust: 'server_canonical',
+      isTrusted: true,
+      ...overrides,
+    };
+  }
 
   test('definition marks sent files as outbound transcript messages', () => {
     assert.strictEqual(tool.definition.transcriptMode, 'outbound_file');
@@ -83,6 +100,96 @@ describe('SendFileTool - ToolExecutionResult', () => {
     assert.strictEqual(sentPath, filePath);
     assert.ok((result.content as string).includes('File sent to current chat.'));
     assert.ok((result.content as string).includes(`Path: ${filePath}`));
+  });
+
+  test('uses executionScope topic for file sends when scope is present', async () => {
+    const filePath = path.join(testRoot, 'scoped.md');
+    fs.writeFileSync(filePath, 'hello');
+    let sentChatId = '';
+    context.executionScope = scope({ topicId: 'chat-1' });
+    context.channel = {
+      chatId: 'chat-1',
+      reply: async () => {},
+      sendFile: async (chatId) => {
+        sentChatId = chatId;
+      },
+    };
+
+    const result = await tool.execute({ file_path: filePath, file_name: 'scoped.md' }, context);
+
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(sentChatId, 'chat-1');
+  });
+
+  test('blocks file send when channel chatId conflicts with executionScope topic', async () => {
+    const filePath = path.join(testRoot, 'secret.md');
+    fs.writeFileSync(filePath, 'hello');
+    let sendCalled = false;
+    context.executionScope = scope({ topicId: 'chat-1' });
+    context.channel = {
+      chatId: 'chat-2',
+      reply: async () => {},
+      sendFile: async () => {
+        sendCalled = true;
+      },
+    };
+
+    const result = await tool.execute({ file_path: filePath, file_name: 'secret.md' }, context);
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.errorCode, 'PERMISSION_DENIED');
+    assert.match(result.message, /外发目标与当前执行身份不一致/);
+    assert.strictEqual(sendCalled, false);
+  });
+
+  test('blocks file send for untrusted CatsCo scope', async () => {
+    const filePath = path.join(testRoot, 'report.md');
+    fs.writeFileSync(filePath, 'hello');
+    let sendCalled = false;
+    context.executionScope = scope({
+      identityTrust: 'untrusted',
+      isTrusted: false,
+      agentBodyId: undefined,
+      permissionsSource: undefined,
+    });
+    context.channel = {
+      chatId: 'chat-1',
+      reply: async () => {},
+      sendFile: async () => {
+        sendCalled = true;
+      },
+    };
+
+    const result = await tool.execute({ file_path: filePath, file_name: 'report.md' }, context);
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.errorCode, 'PERMISSION_DENIED');
+    assert.match(result.message, /身份未通过服务端一致性校验/);
+    assert.strictEqual(sendCalled, false);
+  });
+
+  test('allows file send for legacy CatsCo scope when topic matches', async () => {
+    const filePath = path.join(testRoot, 'legacy.md');
+    fs.writeFileSync(filePath, 'hello');
+    let sentChatId = '';
+    context.executionScope = scope({
+      identityTrust: 'legacy_context',
+      isTrusted: false,
+      agentBodyId: undefined,
+      permissionsSource: undefined,
+    });
+    context.channel = {
+      chatId: 'chat-1',
+      reply: async () => {},
+      sendFile: async (chatId) => {
+        sentChatId = chatId;
+      },
+    };
+
+    const result = await tool.execute({ file_path: filePath, file_name: 'legacy.md' }, context);
+
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(sentChatId, 'chat-1');
   });
 
   test('directory path is rejected before send', async () => {

--- a/tests/tool-result-send-text-tool.test.ts
+++ b/tests/tool-result-send-text-tool.test.ts
@@ -1,0 +1,90 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import { SendTextTool } from '../src/tools/send-text-tool';
+import type { ExecutionScope } from '../src/types/session-identity';
+import type { ToolExecutionContext } from '../src/types/tool';
+
+function scope(overrides: Partial<ExecutionScope> = {}): ExecutionScope {
+  return {
+    source: 'catscompany',
+    sessionKey: 'cc_user:usr7',
+    topicId: 'p2p_7_43',
+    topicType: 'p2p',
+    actorUserId: 'usr7',
+    agentId: 'usr43',
+    agentBodyId: 'body-main',
+    channelSeq: 12,
+    permissionsSource: 'server_canonical_message',
+    identityTrust: 'server_canonical',
+    isTrusted: true,
+    ...overrides,
+  };
+}
+
+function contextWithChannel(chatId: string, executionScope?: ExecutionScope) {
+  const sent: Array<{ chatId: string; text: string }> = [];
+  const context: ToolExecutionContext = {
+    workingDirectory: process.cwd(),
+    workspaceRoot: process.cwd(),
+    conversationHistory: [],
+    surface: 'catscompany',
+    executionScope,
+    channel: {
+      chatId,
+      reply: async (targetChatId, text) => {
+        sent.push({ chatId: targetChatId, text });
+      },
+      sendFile: async () => undefined,
+    },
+  };
+  return { context, sent };
+}
+
+describe('SendTextTool outbound scope checks', () => {
+  test('uses executionScope topic as the outbound target when scope is present', async () => {
+    const tool = new SendTextTool();
+    const { context, sent } = contextWithChannel('p2p_7_43', scope());
+
+    const result = await tool.execute({ text: '  合同已查到  ' }, context);
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(sent, [{ chatId: 'p2p_7_43', text: '合同已查到' }]);
+  });
+
+  test('keeps legacy channel-only behavior when executionScope is missing', async () => {
+    const tool = new SendTextTool();
+    const { context, sent } = contextWithChannel('legacy-chat');
+
+    const result = await tool.execute({ text: 'hello' }, context);
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(sent, [{ chatId: 'legacy-chat', text: 'hello' }]);
+  });
+
+  test('blocks text send when channel chatId conflicts with executionScope topic', async () => {
+    const tool = new SendTextTool();
+    const { context, sent } = contextWithChannel('p2p_8_43', scope());
+
+    const result = await tool.execute({ text: 'should not send' }, context);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.errorCode, 'PERMISSION_DENIED');
+    assert.match(result.message, /外发目标与当前执行身份不一致/);
+    assert.deepEqual(sent, []);
+  });
+
+  test('allows basic text replies for untrusted scope when topic still matches', async () => {
+    const tool = new SendTextTool();
+    const { context, sent } = contextWithChannel('p2p_7_43', scope({
+      identityTrust: 'untrusted',
+      isTrusted: false,
+      agentBodyId: undefined,
+      permissionsSource: undefined,
+    }));
+
+    const result = await tool.execute({ text: '请重新发送一下' }, context);
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(sent, [{ chatId: 'p2p_7_43', text: '请重新发送一下' }]);
+  });
+});

--- a/tests/tool-result-tool-manager.test.ts
+++ b/tests/tool-result-tool-manager.test.ts
@@ -7,6 +7,7 @@ import * as path from 'path';
 import * as os from 'os';
 import * as fs from 'fs';
 import { ToolManager } from '../src/tools/tool-manager';
+import type { ExecutionScope } from '../src/types/session-identity';
 
 describe('ToolManager - ToolExecutionResult 统一处理', () => {
   let manager: ToolManager;
@@ -283,6 +284,42 @@ describe('ToolManager - ToolExecutionResult 统一处理', () => {
 
     assert.strictEqual(result.ok, true);
     assert.strictEqual(capturedSignal, controller.signal);
+  });
+
+  test('context overrides do not clear an existing executionScope with undefined', async () => {
+    const executionScope: ExecutionScope = {
+      source: 'catscompany',
+      sessionKey: 'cc_user:usr7',
+      topicId: 'p2p_7_43',
+      topicType: 'p2p',
+      actorUserId: 'usr7',
+      identityTrust: 'server_canonical',
+      isTrusted: true,
+    };
+    const scopedManager = new ToolManager(testRoot, { executionScope }, {
+      enabledToolNames: [],
+    });
+    let capturedScope: ExecutionScope | undefined;
+    scopedManager.registerTool({
+      definition: {
+        name: 'capture_scope',
+        description: 'capture scope',
+        parameters: { type: 'object', properties: {} },
+      },
+      async execute(_args, context) {
+        capturedScope = context.executionScope;
+        return { ok: true, content: 'ok' };
+      },
+    });
+
+    const result = await scopedManager.executeTool(
+      { id: 't19_scope_merge', type: 'function', function: { name: 'capture_scope', arguments: '{}' } },
+      [],
+      { executionScope: undefined },
+    );
+
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(capturedScope, executionScope);
   });
 
   test('Write 别名映射到 write_file 成功', async () => {


### PR DESCRIPTION
## 背景

PR1 已经把 CatsCo 的 MessageEnvelope / ExecutionScope 从入口消息传递到工具执行上下文。本 PR 在此基础上补上第一层外发保护：当机器人准备通过 `send_text` 或 `send_file` 发消息/文件时，先用 ExecutionScope 校验外发目标，避免多用户、多会话、群聊场景下串线。

这是一个轻量网关，不做复杂权限配置，不要求用户每次确认，也不阻断 Feishu / Weixin / CLI 等旧通道。

## 主要改动

- 新增 `src/tools/outbound-gateway.ts`，集中解析外发目标。
- `send_text` / `send_file` 接入 outbound gateway，不再直接只信任 `channel.chatId`。
- 当 `executionScope.topicId` 与 `channel.chatId` 明确不一致时，返回 `PERMISSION_DENIED`，阻止外发。
- 当 CatsCo `context.sessionId` 与 `executionScope.sessionKey` 明确不一致时，返回 `PERMISSION_DENIED`，阻止外发。
- `identityTrust: untrusted` 时仍允许文本回复当前会话，避免机器人沉默；但默认拒绝文件外发。
- `legacy_context` 和缺少 `executionScope` 的旧路径保持可用，降低接入成本和误伤。
- 补充 outbound gateway 策略单测、send_text/send_file 集成测试，以及 ToolManager 不被 undefined override 清空 executionScope 的回归测试。

## 产品形态

完成后，虚拟员工外发消息时会多一层“当前执行身份”校验：

- 普通聊天仍然顺滑，不需要额外配置或确认。
- 多用户同时和同一个机器人对话时，外发目标必须和当前 turn 的 ExecutionScope 对得上。
- 群聊/私聊都按当前 topic 外发，不支持模型随意指定别的目标。
- 身份异常时，机器人仍可发文本说明问题，但不会把文件发出去。
- 旧 CatsCo 消息、Feishu、Weixin、CLI 不会因为还没接入完整 ExecutionScope 就被硬拦。

## 验证

- `npm.cmd run build -- --noEmit`
- `npm.cmd exec -- tsx --test tests\outbound-gateway.test.ts tests\tool-result-send-text-tool.test.ts tests\tool-result-send-file-tool.test.ts tests\tool-result-tool-manager.test.ts tests\tool-manager.test.ts tests\catscompany-execution-scope-flow.test.ts`
- 之前完整跑过 `npm.cmd run test:runtime`：514 tests，512 passed，2 skipped，0 failed。

## 说明

这是 stacked PR，base 暂时指向 `codex/message-envelope-execution-scope`。PR1 合并后可以把本 PR retarget 到 `main`，若 GitHub diff 不干净再 rebase。