### PR TITLE
feat(catsco): add execution boundaries for virtual employees

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,126 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  runtime:
+    name: Build and runtime tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout XiaoBa-CLI
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --prefer-offline --no-audit --fund=false
+
+      - name: Release branding check
+        run: npm run release:check
+
+      - name: Build
+        run: npm run build
+
+      - name: Runtime tests
+        run: npm test
+
+  cross-repo-catsco:
+    name: CatsCo cross-repo smoke and e2e
+    runs-on: ubuntu-latest
+    needs: runtime
+    services:
+      postgres:
+        image: postgres:18-alpine
+        env:
+          POSTGRES_DB: cats_xiaoba_e2e
+          POSTGRES_USER: catsco
+          POSTGRES_PASSWORD: catsco_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U catsco -d cats_xiaoba_e2e"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+
+    steps:
+      - name: Checkout XiaoBa-CLI
+        uses: actions/checkout@v4
+        with:
+          path: XiaoBa-CLI
+
+      - name: Detect cross-repo scripts
+        id: scripts
+        working-directory: XiaoBa-CLI
+        run: |
+          if [ -f scripts/cross-repo-catsco-smoke.mjs ]; then
+            echo "smoke=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "smoke=false" >> "$GITHUB_OUTPUT"
+          fi
+          if [ -f scripts/cross-repo-catsco-e2e.ts ]; then
+            echo "e2e=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "e2e=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout cats-company
+        if: steps.scripts.outputs.smoke == 'true' || steps.scripts.outputs.e2e == 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: buildsense-ai/cats-company
+          ref: ${{ vars.CATSCOMPANY_SMOKE_REF || 'codex/feishu-cloud-oauth-events' }}
+          path: cats-company
+
+      - name: Set up Node.js
+        if: steps.scripts.outputs.smoke == 'true' || steps.scripts.outputs.e2e == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: XiaoBa-CLI/package-lock.json
+
+      - name: Set up Go
+        if: steps.scripts.outputs.smoke == 'true' || steps.scripts.outputs.e2e == 'true'
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: cats-company/go.mod
+          cache-dependency-path: cats-company/go.sum
+
+      - name: Install XiaoBa dependencies
+        if: steps.scripts.outputs.smoke == 'true' || steps.scripts.outputs.e2e == 'true'
+        working-directory: XiaoBa-CLI
+        run: npm ci --prefer-offline --no-audit --fund=false
+
+      - name: Cross-repo CatsCo smoke
+        if: steps.scripts.outputs.smoke == 'true'
+        working-directory: XiaoBa-CLI
+        env:
+          CATSCOMPANY_REPO: ../cats-company
+        run: npm run test:cross-repo:catsco
+
+      - name: Cross-repo CatsCo e2e
+        if: steps.scripts.outputs.e2e == 'true'
+        working-directory: XiaoBa-CLI
+        env:
+          CATSCOMPANY_REPO: ../cats-company
+          CATSCOMPANY_E2E_DB_DSN: postgres://catsco:catsco_test@127.0.0.1:5432/cats_xiaoba_e2e?sslmode=disable
+        run: npm run test:e2e:catsco-cross-repo

--- a/src/catscompany/client.ts
+++ b/src/catscompany/client.ts
@@ -12,7 +12,45 @@ export interface CatsClientConfig {
   apiKey: string;
   bodyId?: string;
   installationId?: string;
+  deviceRegistration?: CatsDeviceRegistration;
   httpBaseUrl?: string;
+}
+
+export interface CatsDeviceRegistration {
+  device_id: string;
+  display_name?: string;
+  body_id?: string;
+  installation_id?: string;
+  status?: 'online' | 'offline';
+  capabilities?: string[];
+}
+
+export interface CatsDeviceRpcError {
+  code: string;
+  message: string;
+}
+
+export interface CatsDeviceRpcMessage {
+  id?: string;
+  type: 'request' | 'result';
+  request_id: string;
+  grant_id?: string;
+  session_key?: string;
+  topic_id?: string;
+  topic_type?: string;
+  actor_user_id?: string;
+  agent_id?: string;
+  agent_body_id?: string;
+  device_id?: string;
+  device_body_id?: string;
+  device_installation_id?: string;
+  operation?: string;
+  tool_name?: string;
+  payload?: Record<string, unknown>;
+  result?: unknown;
+  error?: CatsDeviceRpcError;
+  created_at?: number;
+  expires_at?: number;
 }
 
 export interface MessageContext {
@@ -107,6 +145,7 @@ export class CatsClient extends EventEmitter {
   private msgId = 0;
   private closed = false;
   private pendingAcks = new Map<string, PendingAck>();
+  private pendingDeviceRpc = new Map<string, PendingDeviceRpc>();
   private pingTimer: NodeJS.Timeout | null = null;
   private pongTimer: NodeJS.Timeout | null = null;
   private reconnectAttempts = 0;
@@ -152,7 +191,14 @@ export class CatsClient extends EventEmitter {
 
     this.ws.on('open', () => {
       this.reconnectAttempts = 0;
-      this.send({ hi: { id: '1', ver: CATSCOMPANY_PROTOCOL_VERSION, ua: CATSCOMPANY_CLIENT_UA } });
+      this.send({
+        hi: {
+          id: '1',
+          ver: CATSCOMPANY_PROTOCOL_VERSION,
+          ua: CATSCOMPANY_CLIENT_UA,
+          device: this.config.deviceRegistration,
+        },
+      });
       this.startHeartbeat();
     });
 
@@ -177,6 +223,10 @@ export class CatsClient extends EventEmitter {
         undefined,
         { retryableWithHttp: this.supportsClientMessageDedupe }
       ));
+      this.rejectPendingDeviceRpc(new CatsSendError(
+        'timeout',
+        'WebSocket 在收到 Device RPC 结果前关闭'
+      ));
       if (!this.closed) this.scheduleReconnect();
     });
   }
@@ -194,6 +244,9 @@ export class CatsClient extends EventEmitter {
           && msg.ctrl.params.features.includes('client_msg_id');
         if (this.supportsClientMessageDedupe) {
           Logger.info('[CatsCompany] 服务端支持 client_msg_id 幂等发送');
+        }
+        if (Array.isArray(msg.ctrl.params?.features) && msg.ctrl.params.features.includes('device_rpc')) {
+          Logger.info('[CatsCompany] 服务端支持 device_rpc 远程设备传输');
         }
         this.emit('ready', { uid: this.uid, name: this.name });
         this.autoAcceptFriendRequests().catch(console.error);
@@ -214,6 +267,8 @@ export class CatsClient extends EventEmitter {
           }
         }
       }
+    } else if (msg.device_rpc) {
+      this.handleDeviceRpcMessage(msg.device_rpc);
     } else if (msg.data) {
       Logger.info(
         `[CatsCompany] 收到消息: topic=${msg.data.topic || '-'}, ` +
@@ -245,6 +300,45 @@ export class CatsClient extends EventEmitter {
         Logger.info(`[CatsCompany] 收到 presence: what=${msg.pres.what}, src=${msg.pres.src || '-'}`);
       }
     }
+  }
+
+  private handleDeviceRpcMessage(raw: any): void {
+    const message = normalizeDeviceRpcMessage(raw);
+    if (!message) {
+      Logger.warning('[CatsCompany] 收到无效 device_rpc 消息，已忽略');
+      return;
+    }
+    if (message.type === 'result') {
+      const pending = this.pendingDeviceRpc.get(message.request_id);
+      if (pending) {
+        if (!deviceRpcResultMatchesPending(message, pending.request)) {
+          clearTimeout(pending.timer);
+          this.pendingDeviceRpc.delete(message.request_id);
+          pending.reject(new CatsSendError(
+            'ack',
+            `Device RPC ${message.request_id} result scope does not match pending request`,
+            409
+          ));
+        } else if (pending.acknowledged) {
+          this.resolvePendingDeviceRpc(message.request_id, pending, message);
+        } else {
+          pending.result = message;
+        }
+      }
+      this.emit('device_rpc_result', message);
+      return;
+    }
+    this.emit('device_rpc_request', message);
+  }
+
+  private resolvePendingDeviceRpc(
+    requestID: string,
+    pending: PendingDeviceRpc,
+    result: CatsDeviceRpcMessage
+  ): void {
+    clearTimeout(pending.timer);
+    this.pendingDeviceRpc.delete(requestID);
+    pending.resolve(result);
   }
 
   async sendMessage(topic: string, text: string): Promise<number> {
@@ -287,21 +381,112 @@ export class CatsClient extends EventEmitter {
       },
     });
 
+    return this.sendEnvelopeWithAck(msgId, { pub }, {
+      clientMsgID,
+      retryableWithHttp: this.supportsClientMessageDedupe,
+      timeoutMessage: 'WebSocket 已发送消息，但 10 秒内没有收到 CatsCompany 服务器确认',
+    });
+  }
+
+  async sendDeviceRpcRequest(
+    request: Omit<CatsDeviceRpcMessage, 'id' | 'type'> & { request_id?: string },
+    timeoutMs = 60000
+  ): Promise<CatsDeviceRpcMessage> {
+    const requestID = request.request_id || buildDeviceRpcRequestID();
+    if (this.pendingDeviceRpc.has(requestID)) {
+      throw new CatsSendError('ack', `Device RPC request_id already pending: ${requestID}`, 409);
+    }
+    const msgId = `${++this.msgId}`;
+    const deviceRpc: CatsDeviceRpcMessage = {
+      ...request,
+      id: msgId,
+      type: 'request',
+      request_id: requestID,
+    };
+
+    const resultPromise = new Promise<CatsDeviceRpcMessage>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pendingDeviceRpc.delete(requestID);
+        reject(new CatsSendError(
+          'timeout',
+          `Device RPC ${requestID} 在 ${timeoutMs}ms 内没有收到设备结果`
+        ));
+      }, timeoutMs);
+      this.pendingDeviceRpc.set(requestID, {
+        request: deviceRpc,
+        resolve,
+        reject,
+        timer,
+        acknowledged: false,
+      });
+    });
+
+    try {
+      await this.sendEnvelopeWithAck(msgId, { device_rpc: deviceRpc }, {
+        timeoutMessage: 'WebSocket 已发送 Device RPC 请求，但 10 秒内没有收到 CatsCompany 服务器确认',
+      });
+    } catch (err) {
+      const pending = this.pendingDeviceRpc.get(requestID);
+      if (pending) {
+        clearTimeout(pending.timer);
+        this.pendingDeviceRpc.delete(requestID);
+        throw err;
+      }
+      throw err;
+    }
+
+    const pending = this.pendingDeviceRpc.get(requestID);
+    if (pending) {
+      pending.acknowledged = true;
+      if (pending.result) {
+        this.resolvePendingDeviceRpc(requestID, pending, pending.result);
+      }
+    }
+    return resultPromise;
+  }
+
+  async sendDeviceRpcResult(result: Omit<CatsDeviceRpcMessage, 'id' | 'type'>): Promise<void> {
+    const requestID = String(result.request_id || '').trim();
+    if (!requestID) {
+      throw new Error('Device RPC result request_id is required');
+    }
+    const msgId = `${++this.msgId}`;
+    await this.sendEnvelopeWithAck(msgId, {
+      device_rpc: {
+        ...result,
+        id: msgId,
+        type: 'result',
+        request_id: requestID,
+      },
+    }, {
+      timeoutMessage: 'WebSocket 已发送 Device RPC 结果，但 10 秒内没有收到 CatsCompany 服务器确认',
+    });
+  }
+
+  private sendEnvelopeWithAck(
+    msgId: string,
+    envelope: Record<string, unknown>,
+    options: {
+      clientMsgID?: string;
+      retryableWithHttp?: boolean;
+      timeoutMessage?: string;
+    } = {}
+  ): Promise<number> {
     return new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
         this.pendingAcks.delete(msgId);
         this.forceReconnect('ack timeout');
         reject(new CatsSendError(
           'timeout',
-          'WebSocket 已发送消息，但 10 秒内没有收到 CatsCompany 服务器确认',
+          options.timeoutMessage || 'WebSocket 已发送消息，但 10 秒内没有收到 CatsCompany 服务器确认',
           undefined,
-          { clientMsgID, retryableWithHttp: this.supportsClientMessageDedupe }
+          { clientMsgID: options.clientMsgID, retryableWithHttp: options.retryableWithHttp ?? false }
         ));
       }, 10000);
 
-      this.pendingAcks.set(msgId, { resolve, reject, timer, clientMsgID });
+      this.pendingAcks.set(msgId, { resolve, reject, timer, clientMsgID: options.clientMsgID });
       try {
-        this.sendOrThrow({ pub });
+        this.sendOrThrow(envelope);
       } catch (err: any) {
         clearTimeout(timer);
         this.pendingAcks.delete(msgId);
@@ -343,11 +528,26 @@ export class CatsClient extends EventEmitter {
 
   async uploadFile(filePath: string, type: 'image' | 'file' = 'file'): Promise<UploadResult> {
     return uploadCatsLocalFile({
-      httpBaseUrl: this.config.httpBaseUrl || 'https://app.catsco.cc',
+      httpBaseUrl: this.httpBaseUrl(),
       filePath,
       type,
       authHeader: `ApiKey ${this.config.apiKey}`,
     });
+  }
+
+  async registerDevice(registration: CatsDeviceRegistration): Promise<unknown> {
+    const res = await fetch(`${this.httpBaseUrl()}/api/devices/register`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `ApiKey ${this.config.apiKey}`,
+      },
+      body: JSON.stringify(registration),
+    });
+    if (!res.ok) {
+      throw new Error(`CatsCompany device registration failed: ${res.status}`);
+    }
+    return res.json().catch(() => ({}));
   }
 
   async sendImage(topic: string, upload: UploadResult): Promise<number> {
@@ -413,6 +613,14 @@ export class CatsClient extends EventEmitter {
     }
   }
 
+  private rejectPendingDeviceRpc(err: Error): void {
+    for (const [requestID, pending] of this.pendingDeviceRpc.entries()) {
+      clearTimeout(pending.timer);
+      this.pendingDeviceRpc.delete(requestID);
+      pending.reject(err);
+    }
+  }
+
   private forceReconnect(reason: string): void {
     Logger.warning(`[CatsCompany] ${reason}，主动重建 WebSocket 连接`);
     if (this.ws?.readyState === WebSocket.OPEN || this.ws?.readyState === WebSocket.CONNECTING) {
@@ -465,10 +673,38 @@ export class CatsClient extends EventEmitter {
     }
   }
 
+  private httpBaseUrl(): string {
+    return this.config.httpBaseUrl || inferHttpBaseUrl(this.config.serverUrl) || 'https://app.catsco.cc';
+  }
+
   disconnect(): void {
     this.closed = true;
     this.stopHeartbeat();
     this.ws?.close();
+  }
+}
+
+interface PendingDeviceRpc {
+  request: CatsDeviceRpcMessage;
+  resolve: (message: CatsDeviceRpcMessage) => void;
+  reject: (err: Error) => void;
+  timer: NodeJS.Timeout;
+  acknowledged: boolean;
+  result?: CatsDeviceRpcMessage;
+}
+
+function inferHttpBaseUrl(serverUrl: string): string | undefined {
+  try {
+    const url = new URL(serverUrl);
+    if (url.protocol === 'ws:') url.protocol = 'http:';
+    else if (url.protocol === 'wss:') url.protocol = 'https:';
+    else if (url.protocol !== 'http:' && url.protocol !== 'https:') return undefined;
+    url.pathname = '';
+    url.search = '';
+    url.hash = '';
+    return url.toString().replace(/\/$/, '');
+  } catch {
+    return undefined;
   }
 }
 
@@ -477,4 +713,48 @@ function buildClientMessageID(): string {
     return `catsco-${crypto.randomUUID()}`;
   }
   return `catsco-${Date.now()}-${crypto.randomBytes(8).toString('hex')}`;
+}
+
+function buildDeviceRpcRequestID(): string {
+  if (typeof crypto.randomUUID === 'function') {
+    return `device_rpc_${crypto.randomUUID()}`;
+  }
+  return `device_rpc_${Date.now()}_${crypto.randomBytes(8).toString('hex')}`;
+}
+
+function normalizeDeviceRpcMessage(raw: any): CatsDeviceRpcMessage | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const type = String(raw.type || '').trim();
+  const requestID = String(raw.request_id || '').trim();
+  if ((type !== 'request' && type !== 'result') || !requestID) return undefined;
+  const message: CatsDeviceRpcMessage = {
+    ...raw,
+    type,
+    request_id: requestID,
+  };
+  if (raw.payload && typeof raw.payload === 'object' && !Array.isArray(raw.payload)) {
+    message.payload = raw.payload;
+  }
+  return message;
+}
+
+function deviceRpcResultMatchesPending(result: CatsDeviceRpcMessage, request: CatsDeviceRpcMessage): boolean {
+  return deviceRpcOptionalFieldMatches(result.grant_id, request.grant_id)
+    && deviceRpcOptionalFieldMatches(result.session_key, request.session_key)
+    && deviceRpcOptionalFieldMatches(result.topic_id, request.topic_id)
+    && deviceRpcOptionalFieldMatches(result.topic_type, request.topic_type)
+    && deviceRpcOptionalFieldMatches(result.actor_user_id, request.actor_user_id)
+    && deviceRpcOptionalFieldMatches(result.agent_id, request.agent_id)
+    && deviceRpcOptionalFieldMatches(result.agent_body_id, request.agent_body_id)
+    && deviceRpcOptionalFieldMatches(result.device_id, request.device_id)
+    && deviceRpcOptionalFieldMatches(result.device_body_id, request.device_body_id)
+    && deviceRpcOptionalFieldMatches(result.device_installation_id, request.device_installation_id)
+    && deviceRpcOptionalFieldMatches(result.operation, request.operation)
+    && deviceRpcOptionalFieldMatches(result.tool_name, request.tool_name);
+}
+
+function deviceRpcOptionalFieldMatches(actual: unknown, expected: unknown): boolean {
+  const actualText = typeof actual === 'string' ? actual.trim() : '';
+  const expectedText = typeof expected === 'string' ? expected.trim() : '';
+  return !actualText || !expectedText || actualText === expectedText;
 }

--- a/src/catscompany/device-grants.ts
+++ b/src/catscompany/device-grants.ts
@@ -1,0 +1,162 @@
+import type {
+  DeviceGrantOperation,
+  DeviceGrantStatus,
+  ExecutionScope,
+  IdentityTrustLevel,
+  MessageSource,
+  MessageTopicType,
+  ScopedDeviceGrant,
+} from '../types/session-identity';
+
+type UnknownRecord = Record<string, unknown>;
+
+export function extractCatsCoDeviceGrants(
+  metadata: Record<string, unknown> | undefined,
+  scope: ExecutionScope,
+): ScopedDeviceGrant[] | undefined {
+  if (scope.identityTrust !== 'server_canonical') return undefined;
+  const identity = asRecord(metadata?.catsco_identity);
+  const permissions = asRecord(identity?.permissions);
+  if (stringField(permissions, 'source') !== 'server_canonical_message') return undefined;
+
+  const rawGrants = arrayField(identity, 'device_grants')
+    ?? arrayField(permissions, 'device_grants');
+  if (!rawGrants || rawGrants.length === 0) return undefined;
+
+  const grants = rawGrants
+    .map(normalizeDeviceGrant)
+    .filter((grant): grant is ScopedDeviceGrant => Boolean(grant))
+    .filter(grant => grantMatchesScope(grant, scope));
+
+  return grants.length > 0 ? grants : undefined;
+}
+
+function normalizeDeviceGrant(value: unknown): ScopedDeviceGrant | undefined {
+  const record = asRecord(value);
+  if (!record) return undefined;
+  if (stringField(record, 'kind') !== 'user_device_grant') return undefined;
+  const source = normalizeSource(stringField(record, 'source'));
+  if (source !== 'catscompany') return undefined;
+
+  const grantId = stringField(record, 'grantId') || stringField(record, 'grant_id');
+  const deviceId = stringField(record, 'deviceId') || stringField(record, 'device_id');
+  const ownerUserId = stringField(record, 'ownerUserId') || stringField(record, 'owner_user_id');
+  const sessionKey = stringField(record, 'sessionKey') || stringField(record, 'session_key');
+  const topicId = stringField(record, 'topicId') || stringField(record, 'topic_id');
+  const actorUserId = stringField(record, 'actorUserId') || stringField(record, 'actor_user_id');
+  const operations = normalizeOperations(record.operations);
+  const createdAt = numberField(record, 'createdAt') ?? numberField(record, 'created_at');
+  const expiresAt = numberField(record, 'expiresAt') ?? numberField(record, 'expires_at');
+  if (!grantId || !deviceId || !ownerUserId || !sessionKey || !topicId || !actorUserId) return undefined;
+  if (operations.length === 0 || createdAt === undefined || expiresAt === undefined) return undefined;
+
+  return pruneUndefined({
+    kind: 'user_device_grant',
+    source,
+    grantId,
+    status: normalizeStatus(stringField(record, 'status')),
+    identityTrust: normalizeTrust(stringField(record, 'identityTrust') || stringField(record, 'identity_trust')),
+    identitySource: stringField(record, 'identitySource') || stringField(record, 'identity_source'),
+    deviceId,
+    deviceDisplayName: stringField(record, 'deviceDisplayName') || stringField(record, 'device_display_name'),
+    deviceBodyId: stringField(record, 'deviceBodyId') || stringField(record, 'device_body_id'),
+    deviceInstallationId: stringField(record, 'deviceInstallationId') || stringField(record, 'device_installation_id'),
+    ownerUserId,
+    sessionKey,
+    topicId,
+    topicType: normalizeTopicType(stringField(record, 'topicType') || stringField(record, 'topic_type')),
+    actorUserId,
+    agentId: stringField(record, 'agentId') || stringField(record, 'agent_id'),
+    agentBodyId: stringField(record, 'agentBodyId') || stringField(record, 'agent_body_id'),
+    operations,
+    createdAt,
+    expiresAt,
+  }) as ScopedDeviceGrant;
+}
+
+function grantMatchesScope(grant: ScopedDeviceGrant, scope: ExecutionScope): boolean {
+  return grant.status === 'active'
+    && grant.identityTrust === 'server_canonical'
+    && grant.source === scope.source
+    && grant.sessionKey === scope.sessionKey
+    && grant.topicId === scope.topicId
+    && grant.topicType === scope.topicType
+    && grant.actorUserId === scope.actorUserId
+    && grant.ownerUserId === scope.actorUserId
+    && grant.agentId === scope.agentId
+    && grant.agentBodyId === scope.agentBodyId;
+}
+
+function normalizeOperations(value: unknown): DeviceGrantOperation[] {
+  if (!Array.isArray(value)) return [];
+  const unique = new Set<DeviceGrantOperation>();
+  for (const item of value) {
+    if (isDeviceGrantOperation(item)) unique.add(item);
+  }
+  return [...unique];
+}
+
+function isDeviceGrantOperation(value: unknown): value is DeviceGrantOperation {
+  return value === 'read_file'
+    || value === 'write_file'
+    || value === 'edit_file'
+    || value === 'send_file'
+    || value === 'execute_shell'
+    || value === 'glob'
+    || value === 'grep'
+    || value === 'browser_control'
+    || value === 'desktop_control';
+}
+
+function normalizeSource(value: string | undefined): MessageSource {
+  return value === 'catscompany' ? 'catscompany' : 'unknown';
+}
+
+function normalizeStatus(value: string | undefined): DeviceGrantStatus {
+  return value === 'revoked' ? 'revoked' : 'active';
+}
+
+function normalizeTrust(value: string | undefined): IdentityTrustLevel {
+  return value === 'server_canonical' ? 'server_canonical' : 'untrusted';
+}
+
+function normalizeTopicType(value: string | undefined): MessageTopicType {
+  if (value === 'p2p' || value === 'group') return value;
+  return 'unknown';
+}
+
+function asRecord(value: unknown): UnknownRecord | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  return value as UnknownRecord;
+}
+
+function arrayField(record: UnknownRecord | undefined, key: string): unknown[] | undefined {
+  const value = record?.[key];
+  return Array.isArray(value) ? value : undefined;
+}
+
+function stringField(record: UnknownRecord | undefined, key: string): string | undefined {
+  const value = record?.[key];
+  if (typeof value !== 'string') return undefined;
+  const text = value.trim();
+  return text || undefined;
+}
+
+function numberField(record: UnknownRecord, key: string): number | undefined {
+  const value = record[key];
+  if (typeof value === 'number' && Number.isFinite(value) && value >= 0) return value;
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed) && parsed >= 0) return parsed;
+  }
+  return undefined;
+}
+
+function pruneUndefined<T>(value: T): T {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return value;
+  const record = value as Record<string, unknown>;
+  for (const key of Object.keys(record)) {
+    if (record[key] === undefined) delete record[key];
+  }
+  return value;
+}

--- a/src/catscompany/device-selection.ts
+++ b/src/catscompany/device-selection.ts
@@ -1,0 +1,174 @@
+import type {
+  DeviceGrantOperation,
+  DeviceSelectionCandidate,
+  DeviceSelectionStatus,
+  ExecutionScope,
+  MessageSource,
+  MessageTopicType,
+  ScopedDeviceSelection,
+} from '../types/session-identity';
+
+type UnknownRecord = Record<string, unknown>;
+
+export function extractCatsCoDeviceSelection(
+  metadata: Record<string, unknown> | undefined,
+  scope: ExecutionScope,
+): ScopedDeviceSelection | undefined {
+  if (scope.identityTrust !== 'server_canonical') return undefined;
+  const identity = asRecord(metadata?.catsco_identity);
+  const permissions = asRecord(identity?.permissions);
+  if (stringField(permissions, 'source') !== 'server_canonical_message') return undefined;
+
+  const rawSelection = asRecord(identity?.device_selection) ?? asRecord(permissions?.device_selection);
+  if (!rawSelection) return undefined;
+
+  const selection = normalizeDeviceSelection(rawSelection, scope);
+  if (!selectionMatchesScope(selection, scope)) return undefined;
+  return selection;
+}
+
+function normalizeDeviceSelection(record: UnknownRecord, scope: ExecutionScope): ScopedDeviceSelection | undefined {
+  if (stringField(record, 'kind') !== 'user_device_selection') return undefined;
+  const source = normalizeSource(stringField(record, 'source'));
+  if (source !== 'catscompany') return undefined;
+
+  const selectedDevice = asRecord(record.selectedDevice) ?? asRecord(record.selected_device);
+  const selectedDeviceId = stringField(record, 'selectedDeviceId')
+    || stringField(record, 'selected_device_id')
+    || stringField(selectedDevice, 'deviceId')
+    || stringField(selectedDevice, 'device_id');
+  const status = normalizeStatus(stringField(record, 'status'), selectedDeviceId);
+  if (status === 'selected' && !selectedDeviceId) return undefined;
+
+  const sessionKey = stringField(record, 'sessionKey') || stringField(record, 'session_key');
+  const topicId = stringField(record, 'topicId') || stringField(record, 'topic_id');
+  const actorUserId = stringField(record, 'actorUserId') || stringField(record, 'actor_user_id');
+  if (!sessionKey || !topicId || !actorUserId) return undefined;
+
+  return pruneUndefined({
+    kind: 'user_device_selection',
+    source,
+    status,
+    selectionSource: stringField(record, 'selectionSource') || stringField(record, 'selection_source'),
+    sessionKey,
+    topicId,
+    topicType: normalizeTopicType(stringField(record, 'topicType') || stringField(record, 'topic_type')),
+    actorUserId,
+    agentId: stringField(record, 'agentId') || stringField(record, 'agent_id'),
+    identityTrust: scope.identityTrust,
+    identitySource: 'metadata.catsco_identity',
+    selectedDeviceId,
+    selectedDeviceDisplayName: stringField(record, 'selectedDeviceDisplayName')
+      || stringField(record, 'selected_device_display_name')
+      || stringField(selectedDevice, 'displayName')
+      || stringField(selectedDevice, 'display_name'),
+    selectedDeviceBodyId: stringField(record, 'selectedDeviceBodyId')
+      || stringField(record, 'selected_device_body_id')
+      || stringField(selectedDevice, 'bodyId')
+      || stringField(selectedDevice, 'body_id'),
+    selectedDeviceInstallationId: stringField(record, 'selectedDeviceInstallationId')
+      || stringField(record, 'selected_device_installation_id')
+      || stringField(selectedDevice, 'installationId')
+      || stringField(selectedDevice, 'installation_id'),
+    selectedDeviceOperations: normalizeOperations(selectedDevice?.operations ?? record.selectedDeviceOperations ?? record.selected_device_operations),
+    candidates: normalizeCandidates(record.candidates),
+    candidateCount: numberField(record, 'candidateCount') ?? numberField(record, 'candidate_count'),
+    createdAt: numberField(record, 'createdAt') ?? numberField(record, 'created_at'),
+  }) as ScopedDeviceSelection;
+}
+
+function selectionMatchesScope(selection: ScopedDeviceSelection | undefined, scope: ExecutionScope): selection is ScopedDeviceSelection {
+  return Boolean(selection)
+    && selection!.source === scope.source
+    && selection!.sessionKey === scope.sessionKey
+    && selection!.topicId === scope.topicId
+    && selection!.topicType === scope.topicType
+    && selection!.actorUserId === scope.actorUserId
+    && selection!.agentId === scope.agentId;
+}
+
+function normalizeCandidates(value: unknown): DeviceSelectionCandidate[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const candidates = value
+    .map(item => {
+      const record = asRecord(item);
+      if (!record) return undefined;
+      const deviceId = stringField(record, 'deviceId') || stringField(record, 'device_id');
+      if (!deviceId) return undefined;
+      return pruneUndefined({
+        deviceId,
+        displayName: stringField(record, 'displayName') || stringField(record, 'display_name'),
+        operations: normalizeOperations(record.operations),
+        lastSeenAt: numberField(record, 'lastSeenAt') ?? numberField(record, 'last_seen_at'),
+      }) as DeviceSelectionCandidate;
+    })
+    .filter((item): item is DeviceSelectionCandidate => Boolean(item));
+  return candidates.length > 0 ? candidates : undefined;
+}
+
+function normalizeOperations(value: unknown): DeviceGrantOperation[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const unique = new Set<DeviceGrantOperation>();
+  for (const item of value) {
+    if (isDeviceGrantOperation(item)) unique.add(item);
+  }
+  return unique.size > 0 ? [...unique] : undefined;
+}
+
+function isDeviceGrantOperation(value: unknown): value is DeviceGrantOperation {
+  return value === 'read_file'
+    || value === 'write_file'
+    || value === 'edit_file'
+    || value === 'send_file'
+    || value === 'execute_shell'
+    || value === 'glob'
+    || value === 'grep'
+    || value === 'browser_control'
+    || value === 'desktop_control';
+}
+
+function normalizeStatus(value: string | undefined, selectedDeviceId?: string): DeviceSelectionStatus {
+  if (value === 'needs_selection' || value === 'unavailable') return value;
+  if (value === 'selected' || selectedDeviceId) return 'selected';
+  return 'needs_selection';
+}
+
+function normalizeSource(value: string | undefined): MessageSource {
+  return value === 'catscompany' ? 'catscompany' : 'unknown';
+}
+
+function normalizeTopicType(value: string | undefined): MessageTopicType {
+  if (value === 'p2p' || value === 'group') return value;
+  return 'unknown';
+}
+
+function asRecord(value: unknown): UnknownRecord | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  return value as UnknownRecord;
+}
+
+function stringField(record: UnknownRecord | undefined, key: string): string | undefined {
+  const value = record?.[key];
+  if (typeof value !== 'string') return undefined;
+  const text = value.trim();
+  return text || undefined;
+}
+
+function numberField(record: UnknownRecord | undefined, key: string): number | undefined {
+  const value = record?.[key];
+  if (typeof value === 'number' && Number.isFinite(value) && value >= 0) return value;
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed) && parsed >= 0) return parsed;
+  }
+  return undefined;
+}
+
+function pruneUndefined<T>(value: T): T {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return value;
+  const record = value as Record<string, unknown>;
+  for (const key of Object.keys(record)) {
+    if (record[key] === undefined) delete record[key];
+  }
+  return value;
+}

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -922,20 +922,21 @@ export class CatsCompanyBot {
     const blocks: import('../types').ContentBlock[] = [];
     const config = ConfigManager.getConfigReadonly();
     const primaryModelCanSeeImages = isPrimaryModelVisionCapable(config);
-    const currentImagePaths: string[] = [];
-    const currentFilePaths: string[] = [];
+    const currentImageRefs: string[] = [];
 
     if (text) {
       blocks.push({ type: 'text', text });
     }
 
     for (const att of attachments) {
+      const attachmentReference = this.formatAttachmentReferenceForModel(att);
       if (att.type === 'image') {
         if (!primaryModelCanSeeImages) {
-          currentImagePaths.push(`[Current image] ${att.fileName}\n[Current authorized attachment path] ${att.localPath}`);
+          currentImageRefs.push(attachmentReference);
           continue;
         }
 
+        blocks.push({ type: 'text', text: attachmentReference });
         const imgBlock = await createImageBlock(att.localPath);
         if (imgBlock) {
           blocks.push(imgBlock);
@@ -944,42 +945,48 @@ export class CatsCompanyBot {
           Logger.warning(`[多模态] 图片块创建失败: ${att.fileName} at ${att.localPath}`);
         }
       } else {
-        blocks.push({ type: 'text', text: `[文件] ${att.fileName}\n[授权附件路径] ${att.localPath}` });
+        blocks.push({ type: 'text', text: attachmentReference });
       }
     }
 
     Logger.info(`[多模态] 构建完成，共 ${blocks.length} 个块: ${blocks.map(b => b.type).join(', ')}`);
-    if (currentImagePaths.length > 0) {
+    if (currentImageRefs.length > 0) {
       blocks.push({
         type: 'text',
         text: [
           '[Current user turn contains image attachments]',
           'The primary model cannot directly inspect image pixels in this runtime.',
-          'If the user request depends on image content, call read_file on the current authorized attachment path below.',
-          'Use only the current authorized attachment path(s) listed here. Do not use old tmp/downloads paths, old image URLs, old filenames, or prior image descriptions.',
-          currentImagePaths.join('\n\n'),
+          'If the user request depends on image content, call read_file with file_path set to the current authorized attachment reference below.',
+          'Use only the current authorized attachment reference(s) listed here. Do not use old tmp/downloads paths, old image URLs, old filenames, or prior image descriptions.',
+          currentImageRefs.join('\n\n'),
         ].join('\n'),
       });
-      Logger.info(`[CatsCo] Primary model is text-only; exposed ${currentImagePaths.length} current image path(s) for read_file`);
-    }
-
-    if (currentFilePaths.length > 0) {
-      blocks.push({
-        type: 'text',
-        text: [
-          '[Current user turn contains file attachments]',
-          'If file content is needed, use only the current file path(s) below. Do not reuse historical attachment paths.',
-          currentFilePaths.join('\n\n'),
-        ].join('\n'),
-      });
+      Logger.info(`[CatsCo] Primary model is text-only; exposed ${currentImageRefs.length} current attachment reference(s) for read_file`);
     }
 
     return blocks;
   }
 
+  private formatAttachmentReferenceForModel(attachment: PendingAttachment): string {
+    const label = attachment.type === 'image' ? '图片' : '文件';
+    const attachmentRef = attachment.localFileGrant?.attachmentRef;
+    if (!attachmentRef) {
+      return [
+        `[${label}] ${attachment.fileName}`,
+        '[附件授权状态] 当前消息没有生成可读取的本地附件引用。',
+      ].join('\n');
+    }
+
+    return [
+      `[${label}] ${attachment.fileName}`,
+      `[授权附件引用] ${attachmentRef}`,
+      '[使用方式] 如需读取或转发该附件，将 read_file/send_file 的 file_path 设置为这个引用。',
+    ].join('\n');
+  }
+
   private formatAttachmentContext(attachments: PendingAttachment[]): string {
     const lines = attachments.map((attachment, index) => {
-      return `[附件${index + 1}] ${attachment.fileName} (${attachment.type})\n[附件路径] ${attachment.localPath}`;
+      return `[附件${index + 1}]\n${this.formatAttachmentReferenceForModel(attachment)}`;
     });
     return `[用户已上传附件]\n${lines.join('\n')}`;
   }

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -2,6 +2,7 @@ import { CatsClient, MessageContext } from './client';
 import { CatsCompanyConfig, ParsedCatsMessage, CatsFileInfo } from './types';
 import { MessageSender } from './message-sender';
 import { extractContentBlocks } from './content-blocks';
+import { createCatsCoMessageEnvelope, createExecutionScope } from './message-envelope';
 import { MessageSessionManager } from '../core/message-session-manager';
 import { AgentServices, BUSY_MESSAGE, RuntimeFeedbackInput, SessionCallbacks } from '../core/agent-session';
 import { Logger } from '../utils/logger';
@@ -35,6 +36,7 @@ interface QueuedMessage {
   topic: string;
   senderId: string;
   seq: number;
+  executionScope: ParsedCatsMessage['executionScope'];
   receivedAt: number;
   source?: 'user' | 'subagent_feedback';
   runtimeFeedback?: RuntimeFeedbackInput[];
@@ -281,9 +283,7 @@ export class CatsCompanyBot {
     // 过滤 bot 自己发出的消息，防止循环
     if (this.botUid && msg.senderId === this.botUid) return;
 
-    const key = msg.chatType === 'group'
-      ? `cc_group:${msg.topic}`
-      : `cc_user:${msg.senderId}`;
+    const key = msg.envelope.sessionKey;
 
     // ── 拦截：如果当前 session 正在等待回答，按 sender 精确匹配 ──
     const pendingId = this.pendingAnswerBySession.get(key);
@@ -312,7 +312,7 @@ export class CatsCompanyBot {
     const subAgentManager = SubAgentManager.getInstance();
     subAgentManager.registerPlatformCallbacks(key, {
       injectMessage: async (text: string) => {
-        await this.handleSubAgentFeedback(key, msg.topic, msg.senderId, text);
+        await this.handleSubAgentFeedback(key, msg.topic, msg.senderId, text, msg.executionScope);
       },
       onSubAgentEvent: async (event: any, info?: SubAgentInfo) => {
         await this.handleSubAgentRuntimeEvent(msg.topic, event, info);
@@ -387,6 +387,7 @@ export class CatsCompanyBot {
         topic: msg.topic,
         senderId: msg.senderId,
         seq: msg.seq,
+        executionScope: msg.executionScope,
         receivedAt: Date.now(),
         source: 'user',
         runtimeFeedback,
@@ -407,6 +408,7 @@ export class CatsCompanyBot {
     try {
       const result = await session.handleMessage(userMessage, {
         channel,
+        executionScope: msg.executionScope,
         runtimeFeedback,
         pendingUserInputProvider: () => this.consumeQueuedUserInput(key),
         callbacks: this.buildSessionCallbacks(msg.topic),
@@ -504,14 +506,30 @@ export class CatsCompanyBot {
     const blockText = blockTextParts.join('\n\n');
     const mergedText = blockText || text;
     if (!mergedText && files.length === 0) return null;
+    const messageText = mergedText
+      || (files.length > 0
+        ? files.map(item => `[${item.type === 'image' ? '图片' : '文件'}] ${item.fileName}`).join('\n')
+        : '');
+    const envelope = createCatsCoMessageEnvelope({
+      topic: ctx.topic,
+      isGroup: ctx.isGroup,
+      senderId: ctx.senderId,
+      seq: ctx.seq,
+      text: messageText,
+      metadata: ctx.metadata,
+      botUid: this.botUid,
+    });
 
     return {
       topic: ctx.topic,
       chatType,
       senderId: ctx.senderId,
       seq: ctx.seq ?? 0,
-      text: mergedText || (files.length > 0 ? files.map(item => `[${item.type === 'image' ? '图片' : '文件'}] ${item.fileName}`).join('\n') : ''),
+      text: messageText,
       rawContent: ctx.content,
+      metadata: ctx.metadata,
+      envelope,
+      executionScope: createExecutionScope(envelope),
       file: files[0],
       files,
     };
@@ -525,11 +543,12 @@ export class CatsCompanyBot {
     topic: string,
     senderId: string,
     text: string,
+    executionScope?: ParsedCatsMessage['executionScope'],
   ): Promise<void> {
     const session = this.sessionManager.getOrCreate(sessionKey);
 
     if (session.isBusy()) {
-      this.enqueueSubAgentFeedback(sessionKey, topic, senderId, text);
+      this.enqueueSubAgentFeedback(sessionKey, topic, senderId, text, executionScope);
       Logger.info(`[${sessionKey}] 主会话忙，子智能体反馈已入队`);
       return;
     }
@@ -552,9 +571,10 @@ export class CatsCompanyBot {
         channel,
         callbacks: this.buildSessionCallbacks(topic),
         source: 'subagent_result',
+        executionScope,
       });
       if (result.text === BUSY_MESSAGE) {
-        this.enqueueSubAgentFeedback(sessionKey, topic, senderId, text);
+        this.enqueueSubAgentFeedback(sessionKey, topic, senderId, text, executionScope);
         Logger.info(`[${sessionKey}] 主会话竞态忙碌，子智能体反馈已入队`);
         return;
       }
@@ -579,13 +599,24 @@ export class CatsCompanyBot {
     }
   }
 
-  private enqueueSubAgentFeedback(sessionKey: string, topic: string, senderId: string, text: string): void {
+  private enqueueSubAgentFeedback(
+    sessionKey: string,
+    topic: string,
+    senderId: string,
+    text: string,
+    executionScope?: ParsedCatsMessage['executionScope'],
+  ): void {
     const queue = this.messageQueue.get(sessionKey) ?? [];
     queue.push({
       userMessage: text,
       topic,
       senderId,
       seq: 0,
+      executionScope: executionScope ?? createExecutionScope(createCatsCoMessageEnvelope({
+        topic,
+        senderId,
+        text,
+      })),
       receivedAt: Date.now(),
       source: 'subagent_feedback',
     });
@@ -736,9 +767,11 @@ export class CatsCompanyBot {
           channel,
           callbacks: this.buildSessionCallbacks(msg.topic),
           source: 'subagent_result',
+          executionScope: msg.executionScope,
         })
         : await session.handleMessage(msg.userMessage, {
           channel,
+          executionScope: msg.executionScope,
           runtimeFeedback: msg.runtimeFeedback,
           pendingUserInputProvider: () => this.consumeQueuedUserInput(sessionKey),
           callbacks: this.buildSessionCallbacks(msg.topic),

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -939,7 +939,10 @@ export class CatsCompanyBot {
         blocks.push({ type: 'text', text: attachmentReference });
         const imgBlock = await createImageBlock(att.localPath);
         if (imgBlock) {
-          blocks.push(imgBlock);
+          blocks.push({
+            ...imgBlock,
+            filePath: att.localFileGrant?.attachmentRef || `[CatsCo attachment: ${att.fileName}]`,
+          } as any);
           Logger.info(`[多模态] 已添加图片块: ${att.fileName}, base64长度: ${(imgBlock.source as any)?.data?.length || 0}`);
         } else {
           Logger.warning(`[多模态] 图片块创建失败: ${att.fileName} at ${att.localPath}`);

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -3,6 +3,7 @@ import { CatsCompanyConfig, ParsedCatsMessage, CatsFileInfo } from './types';
 import { MessageSender } from './message-sender';
 import { extractContentBlocks } from './content-blocks';
 import { createCatsCoMessageEnvelope, createExecutionScope } from './message-envelope';
+import { createCatsCoAttachmentGrant, createCatsCoLocalDeviceGrant } from './local-file-grants';
 import { MessageSessionManager } from '../core/message-session-manager';
 import { AgentServices, BUSY_MESSAGE, RuntimeFeedbackInput, SessionCallbacks } from '../core/agent-session';
 import { Logger } from '../utils/logger';
@@ -10,6 +11,8 @@ import { SubAgentManager } from '../core/sub-agent-manager';
 import type { SubAgentInfo } from '../core/sub-agent-session';
 import { ChannelCallbacks } from '../types/tool';
 import { ContentBlock } from '../types';
+import type { PendingUserInput } from '../core/conversation-runner';
+import type { ScopedLocalDeviceGrant, ScopedLocalFileGrant } from '../types/session-identity';
 import { AdapterRuntimeBundle, createAdapterRuntime } from '../runtime/adapter-runtime';
 import { randomUUID } from 'crypto';
 import { ConfigManager } from '../utils/config';
@@ -20,6 +23,7 @@ interface PendingAttachment {
   localPath: string;
   type: 'file' | 'image';
   receivedAt: number;
+  localFileGrant?: ScopedLocalFileGrant;
 }
 
 interface PendingAnswer {
@@ -37,6 +41,7 @@ interface QueuedMessage {
   senderId: string;
   seq: number;
   executionScope: ParsedCatsMessage['executionScope'];
+  localFileGrants?: ScopedLocalFileGrant[];
   receivedAt: number;
   source?: 'user' | 'subagent_feedback';
   runtimeFeedback?: RuntimeFeedbackInput[];
@@ -92,6 +97,7 @@ export class CatsCompanyBot {
   private botUid: string | null = null;
   private runtime: AdapterRuntimeBundle;
   private runtimeProfile: AdapterRuntimeBundle['profile'];
+  private localDeviceGrant?: ScopedLocalDeviceGrant;
 
   constructor(config: CatsCompanyConfig) {
     this.bot = new CatsClient({
@@ -103,6 +109,11 @@ export class CatsCompanyBot {
     });
 
     this.sender = new MessageSender(this.bot, config.httpBaseUrl, config.apiKey);
+    this.localDeviceGrant = createCatsCoLocalDeviceGrant({
+      bodyId: config.bodyId,
+      installationId: config.installationId,
+      deviceId: config.installationId || config.bodyId,
+    });
 
     const runtime = createCatsCompanyRuntime(config.sessionTTL);
     this.runtime = runtime;
@@ -343,6 +354,7 @@ export class CatsCompanyBot {
 
     let userMessage: string | import('../types').ContentBlock[] = msg.text;
     const runtimeFeedback: RuntimeFeedbackInput[] = [];
+    let localFileGrants: ScopedLocalFileGrant[] = [];
 
     const messageFiles = msg.files && msg.files.length > 0 ? msg.files : (msg.file ? [msg.file] : []);
     if (messageFiles.length > 0) {
@@ -362,10 +374,17 @@ export class CatsCompanyBot {
           localPath,
           type: file.type,
           receivedAt: Date.now(),
+          localFileGrant: createCatsCoAttachmentGrant(msg.executionScope, this.localDeviceGrant, {
+            localPath,
+            fileName: file.fileName,
+            type: file.type,
+            workspaceRoot: process.cwd(),
+          }),
         });
       }
 
       if (attachments.length > 0) {
+        localFileGrants = this.collectLocalFileGrants(attachments);
         userMessage = await this.buildMultimodalMessage(msg.text, attachments);
         Logger.info(`[${key}] 原子附件消息（attachments=${attachments.length})`);
       } else {
@@ -374,6 +393,7 @@ export class CatsCompanyBot {
     } else {
       const queuedAttachments = this.consumePendingAttachments(key);
       if (queuedAttachments.length > 0) {
+        localFileGrants = this.collectLocalFileGrants(queuedAttachments);
         userMessage = await this.buildMultimodalMessage(msg.text, queuedAttachments);
         Logger.info(`[${key}] 追加 ${queuedAttachments.length} 个附件`);
       }
@@ -388,6 +408,7 @@ export class CatsCompanyBot {
         senderId: msg.senderId,
         seq: msg.seq,
         executionScope: msg.executionScope,
+        localFileGrants,
         receivedAt: Date.now(),
         source: 'user',
         runtimeFeedback,
@@ -409,6 +430,8 @@ export class CatsCompanyBot {
       const result = await session.handleMessage(userMessage, {
         channel,
         executionScope: msg.executionScope,
+        localDeviceGrant: this.localDeviceGrant,
+        localFileGrants,
         runtimeFeedback,
         pendingUserInputProvider: () => this.consumeQueuedUserInput(key),
         callbacks: this.buildSessionCallbacks(msg.topic),
@@ -768,11 +791,14 @@ export class CatsCompanyBot {
           callbacks: this.buildSessionCallbacks(msg.topic),
           source: 'subagent_result',
           executionScope: msg.executionScope,
+          localDeviceGrant: this.localDeviceGrant,
         })
         : await session.handleMessage(msg.userMessage, {
           channel,
           executionScope: msg.executionScope,
+          localDeviceGrant: this.localDeviceGrant,
           runtimeFeedback: msg.runtimeFeedback,
+          localFileGrants: msg.localFileGrants,
           pendingUserInputProvider: () => this.consumeQueuedUserInput(sessionKey),
           callbacks: this.buildSessionCallbacks(msg.topic),
         });
@@ -797,7 +823,7 @@ export class CatsCompanyBot {
     await this.drainMessageQueue(sessionKey);
   }
 
-  private consumeQueuedUserInput(sessionKey: string): string | ContentBlock[] | null {
+  private consumeQueuedUserInput(sessionKey: string): string | ContentBlock[] | PendingUserInput | null {
     const queue = this.messageQueue.get(sessionKey);
     if (!queue || queue.length === 0) return null;
 
@@ -816,7 +842,10 @@ export class CatsCompanyBot {
     });
 
     Logger.info(`[${sessionKey}] 合并 ${messages.length} 条处理期间新到的用户消息`);
-    return this.mergeQueuedMessages(messages);
+    const content = this.mergeQueuedMessages(messages);
+    const localFileGrants = messages.flatMap(item => item.localFileGrants || []);
+    if (localFileGrants.length === 0) return content;
+    return { content, localFileGrants };
   }
 
   private mergeQueuedMessages(messages: QueuedMessage[]): string | ContentBlock[] {
@@ -882,6 +911,12 @@ export class CatsCompanyBot {
     return queue;
   }
 
+  private collectLocalFileGrants(attachments: PendingAttachment[]): ScopedLocalFileGrant[] {
+    return attachments
+      .map(attachment => attachment.localFileGrant)
+      .filter((grant): grant is ScopedLocalFileGrant => Boolean(grant));
+  }
+
   private async buildMultimodalMessage(text: string, attachments: PendingAttachment[]): Promise<import('../types').ContentBlock[]> {
     const { createImageBlock } = require('../utils/image-utils');
     const blocks: import('../types').ContentBlock[] = [];
@@ -897,7 +932,7 @@ export class CatsCompanyBot {
     for (const att of attachments) {
       if (att.type === 'image') {
         if (!primaryModelCanSeeImages) {
-          currentImagePaths.push(`[Current image] ${att.fileName}\n[Current image path] ${att.localPath}`);
+          currentImagePaths.push(`[Current image] ${att.fileName}\n[Current authorized attachment path] ${att.localPath}`);
           continue;
         }
 
@@ -909,7 +944,7 @@ export class CatsCompanyBot {
           Logger.warning(`[多模态] 图片块创建失败: ${att.fileName} at ${att.localPath}`);
         }
       } else {
-        blocks.push({ type: 'text', text: `[文件] ${att.fileName}\n[路径] ${att.localPath}` });
+        blocks.push({ type: 'text', text: `[文件] ${att.fileName}\n[授权附件路径] ${att.localPath}` });
       }
     }
 
@@ -920,8 +955,8 @@ export class CatsCompanyBot {
         text: [
           '[Current user turn contains image attachments]',
           'The primary model cannot directly inspect image pixels in this runtime.',
-          'If the user request depends on image content, call read_file on the current image path below.',
-          'Use only the current image path(s) listed here. Do not use old tmp/downloads paths, old image URLs, old filenames, or prior image descriptions.',
+          'If the user request depends on image content, call read_file on the current authorized attachment path below.',
+          'Use only the current authorized attachment path(s) listed here. Do not use old tmp/downloads paths, old image URLs, old filenames, or prior image descriptions.',
           currentImagePaths.join('\n\n'),
         ].join('\n'),
       });

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -1,22 +1,34 @@
-import { CatsClient, MessageContext } from './client';
+import { CatsClient, MessageContext, type CatsDeviceRpcMessage } from './client';
 import { CatsCompanyConfig, ParsedCatsMessage, CatsFileInfo } from './types';
 import { MessageSender } from './message-sender';
 import { extractContentBlocks } from './content-blocks';
 import { createCatsCoMessageEnvelope, createExecutionScope } from './message-envelope';
 import { createCatsCoAttachmentGrant, createCatsCoLocalDeviceGrant } from './local-file-grants';
+import { extractCatsCoDeviceGrants } from './device-grants';
+import { extractCatsCoDeviceSelection } from './device-selection';
 import { MessageSessionManager } from '../core/message-session-manager';
 import { AgentServices, BUSY_MESSAGE, RuntimeFeedbackInput, SessionCallbacks } from '../core/agent-session';
 import { Logger } from '../utils/logger';
 import { SubAgentManager } from '../core/sub-agent-manager';
 import type { SubAgentInfo } from '../core/sub-agent-session';
-import { ChannelCallbacks } from '../types/tool';
+import { ChannelCallbacks, DeviceRpcTransport, ToolErrorCode, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import { ContentBlock } from '../types';
 import type { PendingUserInput } from '../core/conversation-runner';
-import type { ScopedLocalDeviceGrant, ScopedLocalFileGrant } from '../types/session-identity';
+import type { DeviceGrantOperation, ExecutionScope, ScopedDeviceGrant, ScopedDeviceSelection, ScopedLocalDeviceGrant, ScopedLocalFileGrant } from '../types/session-identity';
 import { AdapterRuntimeBundle, createAdapterRuntime } from '../runtime/adapter-runtime';
 import { randomUUID } from 'crypto';
+import { hostname } from 'os';
 import { ConfigManager } from '../utils/config';
 import { isPrimaryModelVisionCapable } from '../utils/model-capabilities';
+import { createCatsCoSessionRoute } from '../core/session-router';
+import { ReadTool } from '../tools/read-tool';
+import { GlobTool } from '../tools/glob-tool';
+import { GrepTool } from '../tools/grep-tool';
+import {
+  isRemoteReadonlyTool,
+  normalizeDeviceRpcToolResultForTransport,
+  normalizeDeviceRpcToolResultPayload,
+} from '../tools/device-rpc-tool';
 
 interface PendingAttachment {
   fileName: string;
@@ -41,6 +53,8 @@ interface QueuedMessage {
   senderId: string;
   seq: number;
   executionScope: ParsedCatsMessage['executionScope'];
+  deviceGrants?: ScopedDeviceGrant[];
+  deviceSelection?: ScopedDeviceSelection;
   localFileGrants?: ScopedLocalFileGrant[];
   receivedAt: number;
   source?: 'user' | 'subagent_feedback';
@@ -49,6 +63,8 @@ interface QueuedMessage {
 
 const PENDING_ANSWER_TIMEOUT_MS = 120_000;
 const TYPING_HEARTBEAT_INTERVAL_MS = 5_000;
+const DEVICE_REGISTRATION_REFRESH_MS = 120_000;
+const DEVICE_RPC_DEFAULT_TTL_MS = 60_000;
 const HIDDEN_CATS_TOOL_PROGRESS = new Set([
   'send_text',
   'send_file',
@@ -98,13 +114,35 @@ export class CatsCompanyBot {
   private runtime: AdapterRuntimeBundle;
   private runtimeProfile: AdapterRuntimeBundle['profile'];
   private localDeviceGrant?: ScopedLocalDeviceGrant;
+  private deviceRegistrationTimer?: ReturnType<typeof setInterval>;
+  private readonly deviceRegistration?: {
+    device_id: string;
+    display_name?: string;
+    body_id?: string;
+    installation_id?: string;
+    status: 'online';
+    capabilities: string[];
+  };
 
   constructor(config: CatsCompanyConfig) {
+    const localDeviceId = config.installationId || config.bodyId;
+    const deviceRegistration = localDeviceId
+      ? {
+          device_id: localDeviceId,
+          display_name: config.deviceName || process.env.COMPUTERNAME || process.env.HOSTNAME || hostname() || localDeviceId,
+          body_id: config.bodyId,
+          installation_id: config.installationId || config.bodyId,
+          status: 'online' as const,
+          capabilities: ['read_file', 'glob', 'grep'],
+        }
+      : undefined;
+
     this.bot = new CatsClient({
       serverUrl: config.serverUrl,
       apiKey: config.apiKey,
       bodyId: config.bodyId,
       installationId: config.installationId,
+      deviceRegistration,
       httpBaseUrl: config.httpBaseUrl,
     });
 
@@ -114,6 +152,7 @@ export class CatsCompanyBot {
       installationId: config.installationId,
       deviceId: config.installationId || config.bodyId,
     });
+    this.deviceRegistration = deviceRegistration;
 
     const runtime = createCatsCompanyRuntime(config.sessionTTL);
     this.runtime = runtime;
@@ -149,10 +188,18 @@ export class CatsCompanyBot {
       this.runtimeProfile.prompt.displayName = botName;
       process.env.CURRENT_AGENT_DISPLAY_NAME = botName;
       Logger.success(`CatsCo agent 已连接，uid=${info.uid}, name=${botName}`);
+      this.registerCurrentDevice().catch((err: any) => {
+        Logger.warning(`CatsCo 设备注册失败，继续保持聊天连接: ${err?.message || err}`);
+      });
+      this.startDeviceRegistrationRefresh();
     });
 
     this.bot.on('message', async (ctx: MessageContext) => {
       await this.onMessage(ctx);
+    });
+
+    this.bot.on('device_rpc_request', async (request: CatsDeviceRpcMessage) => {
+      await this.handleDeviceRpcRequest(request);
     });
 
     this.bot.on('error', (err: Error) => {
@@ -161,6 +208,291 @@ export class CatsCompanyBot {
 
     this.bot.connect();
     Logger.success('CatsCo agent 已启动，等待消息...');
+  }
+
+  private async registerCurrentDevice(): Promise<void> {
+    if (!this.deviceRegistration?.device_id) return;
+    await this.bot.registerDevice(this.deviceRegistration);
+    Logger.info(`[CatsCompany] 已注册本机设备能力: device=${this.deviceRegistration.device_id}, capabilities=${this.deviceRegistration.capabilities.join(',')}`);
+  }
+
+  private startDeviceRegistrationRefresh(): void {
+    if (!this.deviceRegistration?.device_id) return;
+    this.stopDeviceRegistrationRefresh();
+    this.deviceRegistrationTimer = setInterval(() => {
+      this.registerCurrentDevice().catch((err: any) => {
+        Logger.warning(`CatsCo 设备状态刷新失败: ${err?.message || err}`);
+      });
+    }, DEVICE_REGISTRATION_REFRESH_MS);
+    (this.deviceRegistrationTimer as any).unref?.();
+  }
+
+  private stopDeviceRegistrationRefresh(): void {
+    if (!this.deviceRegistrationTimer) return;
+    clearInterval(this.deviceRegistrationTimer);
+    this.deviceRegistrationTimer = undefined;
+  }
+
+  private buildDeviceRpcTransport(): DeviceRpcTransport {
+    return {
+      executeTool: async ({ toolName, operation, args, grant, timeoutMs }) => {
+        const response = await this.bot.sendDeviceRpcRequest({
+          request_id: `device_rpc_${randomUUID()}`,
+          grant_id: grant.grantId,
+          session_key: grant.sessionKey,
+          topic_id: grant.topicId,
+          topic_type: grant.topicType,
+          actor_user_id: grant.actorUserId,
+          agent_id: grant.agentId,
+          agent_body_id: grant.agentBodyId,
+          device_id: grant.deviceId,
+          device_body_id: grant.deviceBodyId,
+          device_installation_id: grant.deviceInstallationId,
+          operation,
+          tool_name: toolName,
+          payload: { args },
+          expires_at: grant.expiresAt,
+        }, timeoutMs);
+
+        if (response.error) {
+          return {
+            ok: false,
+            errorCode: this.mapDeviceRpcToolErrorCode(response.error.code),
+            message: response.error.message || response.error.code || '远程设备工具执行失败。',
+            retryable: this.isRetryableDeviceRpcError(response.error.code),
+          };
+        }
+        return normalizeDeviceRpcToolResultPayload(response.result);
+      },
+    };
+  }
+
+  private async handleDeviceRpcRequest(request: CatsDeviceRpcMessage): Promise<void> {
+    const requestID = request.request_id;
+    if (!requestID) return;
+
+    const validationError = this.validateDeviceRpcToolRequest(request);
+    const result = validationError ? undefined : await this.executeLocalDeviceRpcTool(request);
+    const error = validationError || (!result || result.ok
+      ? undefined
+      : {
+          code: result.errorCode || 'tool_execution_error',
+          message: result.message,
+        });
+
+    try {
+      await this.bot.sendDeviceRpcResult({
+        request_id: requestID,
+        grant_id: request.grant_id,
+        session_key: request.session_key,
+        topic_id: request.topic_id,
+        topic_type: request.topic_type,
+        actor_user_id: request.actor_user_id,
+        agent_id: request.agent_id,
+        agent_body_id: request.agent_body_id,
+        device_id: this.localDeviceGrant?.deviceId || request.device_id,
+        device_body_id: this.localDeviceGrant?.bodyId || request.device_body_id,
+        device_installation_id: this.localDeviceGrant?.installationId || request.device_installation_id,
+        operation: request.operation,
+        tool_name: request.tool_name,
+        result: error || !result ? undefined : normalizeDeviceRpcToolResultForTransport(result),
+        error,
+      });
+    } catch (err: any) {
+      Logger.warning(`[CatsCompany] Device RPC result 发送失败: request=${requestID}, error=${err?.message || err}`);
+    }
+  }
+
+  private async executeLocalDeviceRpcTool(request: CatsDeviceRpcMessage): Promise<ToolExecutionResult> {
+    const operation = this.normalizeDeviceRpcReadonlyOperation(request.operation);
+    const toolName = String(request.tool_name || operation || '').trim();
+    if (!operation || !isRemoteReadonlyTool(toolName, operation)) {
+      return {
+        ok: false,
+        errorCode: 'PERMISSION_DENIED',
+        message: `Device RPC 不允许执行 ${toolName || request.operation || 'unknown'}。`,
+      };
+    }
+
+    const context = this.buildDeviceRpcToolContext(request, operation);
+    const args = this.extractDeviceRpcToolArgs(request.payload);
+    switch (operation) {
+      case 'read_file':
+        return new ReadTool().execute(args, context);
+      case 'glob':
+        return new GlobTool().execute(args, context);
+      case 'grep':
+        return new GrepTool().execute(args, context);
+      default:
+        return {
+          ok: false,
+          errorCode: 'PERMISSION_DENIED',
+          message: `Device RPC 不允许执行 ${operation}。`,
+        };
+    }
+  }
+
+  private buildDeviceRpcToolContext(
+    request: CatsDeviceRpcMessage,
+    operation: DeviceGrantOperation,
+  ): ToolExecutionContext {
+    const topicType = request.topic_type === 'group' || request.topic_type === 'p2p'
+      ? request.topic_type
+      : 'unknown';
+    const executionScope: ExecutionScope = {
+      source: 'catscompany',
+      sessionKey: String(request.session_key || ''),
+      topicId: String(request.topic_id || ''),
+      topicType,
+      actorUserId: String(request.actor_user_id || ''),
+      agentId: request.agent_id,
+      agentBodyId: request.agent_body_id,
+      permissionsSource: 'device_rpc_forward',
+      identityTrust: 'server_canonical',
+      isTrusted: true,
+    };
+    const now = Date.now();
+    const grant: ScopedDeviceGrant = {
+      kind: 'user_device_grant',
+      source: 'catscompany',
+      grantId: String(request.grant_id || ''),
+      status: 'active',
+      identityTrust: 'server_canonical',
+      identitySource: 'device_rpc_forward',
+      deviceId: String(request.device_id || this.localDeviceGrant?.deviceId || ''),
+      deviceBodyId: request.device_body_id || this.localDeviceGrant?.bodyId,
+      deviceInstallationId: request.device_installation_id || this.localDeviceGrant?.installationId,
+      ownerUserId: executionScope.actorUserId,
+      sessionKey: executionScope.sessionKey,
+      topicId: executionScope.topicId,
+      topicType,
+      actorUserId: executionScope.actorUserId,
+      agentId: executionScope.agentId,
+      agentBodyId: executionScope.agentBodyId,
+      operations: [operation],
+      createdAt: typeof request.created_at === 'number' ? request.created_at : now,
+      expiresAt: typeof request.expires_at === 'number' ? request.expires_at : now + DEVICE_RPC_DEFAULT_TTL_MS,
+    };
+    const deviceSelection: ScopedDeviceSelection = {
+      kind: 'user_device_selection',
+      source: 'catscompany',
+      status: 'selected',
+      selectionSource: 'device_rpc_forward',
+      sessionKey: executionScope.sessionKey,
+      topicId: executionScope.topicId,
+      topicType,
+      actorUserId: executionScope.actorUserId,
+      agentId: executionScope.agentId,
+      identityTrust: 'server_canonical',
+      identitySource: 'device_rpc_forward',
+      selectedDeviceId: grant.deviceId,
+      selectedDeviceBodyId: grant.deviceBodyId,
+      selectedDeviceInstallationId: grant.deviceInstallationId,
+      selectedDeviceOperations: [operation],
+      createdAt: now,
+    };
+    const workingDirectory = process.cwd();
+    return {
+      workingDirectory,
+      workspaceRoot: workingDirectory,
+      conversationHistory: [],
+      sessionId: executionScope.sessionKey,
+      surface: 'catscompany',
+      permissionProfile: 'strict',
+      executionScope,
+      localDeviceGrant: this.localDeviceGrant,
+      deviceGrants: [grant],
+      deviceSelection,
+    };
+  }
+
+  private validateDeviceRpcToolRequest(request: CatsDeviceRpcMessage): { code: string; message: string } | undefined {
+    const targetError = this.validateDeviceRpcTarget(request);
+    if (targetError) return targetError;
+
+    const operation = this.normalizeDeviceRpcReadonlyOperation(request.operation);
+    const toolName = String(request.tool_name || operation || '').trim();
+    if (!operation || !isRemoteReadonlyTool(toolName, operation)) {
+      return { code: 'unsupported_operation', message: 'Device RPC only allows read_file, glob, and grep.' };
+    }
+
+    const requiredFields: Array<[keyof CatsDeviceRpcMessage, string]> = [
+      ['grant_id', 'grant_id'],
+      ['session_key', 'session_key'],
+      ['topic_id', 'topic_id'],
+      ['topic_type', 'topic_type'],
+      ['actor_user_id', 'actor_user_id'],
+      ['device_id', 'device_id'],
+    ];
+    for (const [field, label] of requiredFields) {
+      if (!String(request[field] || '').trim()) {
+        return { code: 'invalid_request', message: `Device RPC request missing ${label}.` };
+      }
+    }
+    if (typeof request.expires_at === 'number' && Date.now() > request.expires_at) {
+      return { code: 'request_expired', message: 'Device RPC request has expired.' };
+    }
+    return undefined;
+  }
+
+  private normalizeDeviceRpcReadonlyOperation(value: unknown): DeviceGrantOperation | undefined {
+    const operation = String(value || '').trim();
+    if (operation === 'read_file' || operation === 'glob' || operation === 'grep') {
+      return operation;
+    }
+    return undefined;
+  }
+
+  private extractDeviceRpcToolArgs(payload: unknown): Record<string, unknown> {
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return {};
+    const record = payload as Record<string, unknown>;
+    if (record.args && typeof record.args === 'object' && !Array.isArray(record.args)) {
+      return { ...(record.args as Record<string, unknown>) };
+    }
+    return { ...record };
+  }
+
+  private mapDeviceRpcToolErrorCode(code: unknown): ToolErrorCode {
+    const text = String(code || '').toLowerCase();
+    if (text.includes('permission') || text.includes('forbidden') || text.includes('mismatch') || text.includes('unsupported')) {
+      return 'PERMISSION_DENIED';
+    }
+    if (text.includes('timeout') || text.includes('expired')) {
+      return 'EXECUTION_TIMEOUT';
+    }
+    if (text.includes('not_found') || text.includes('offline') || text.includes('unavailable')) {
+      return 'TOOL_EXECUTION_ERROR';
+    }
+    return 'TOOL_EXECUTION_ERROR';
+  }
+
+  private isRetryableDeviceRpcError(code: unknown): boolean {
+    const text = String(code || '').toLowerCase();
+    return text.includes('timeout') || text.includes('offline') || text.includes('unavailable');
+  }
+
+  private validateDeviceRpcTarget(request: CatsDeviceRpcMessage): { code: string; message: string } | undefined {
+    if (!this.localDeviceGrant) {
+      return { code: 'device_not_bound', message: 'Current runtime is not bound to a CatsCo local device.' };
+    }
+    const checks: Array<[unknown, unknown, string]> = [
+      [request.device_id, this.localDeviceGrant.deviceId, 'device_id'],
+      [request.device_installation_id, this.localDeviceGrant.installationId, 'installation_id'],
+      [request.device_body_id, this.localDeviceGrant.bodyId, 'body_id'],
+    ];
+    let matchedAny = false;
+    for (const [requested, local, label] of checks) {
+      const requestedText = String(requested || '').trim();
+      if (!requestedText) continue;
+      const localText = String(local || '').trim();
+      if (!localText || requestedText !== localText) {
+        return { code: 'target_device_mismatch', message: `Device RPC target ${label} does not match this local runtime.` };
+      }
+      matchedAny = true;
+    }
+    return matchedAny
+      ? undefined
+      : { code: 'target_device_mismatch', message: 'Device RPC target does not match this local runtime.' };
   }
 
   // ─── 构建 ChannelCallbacks ──────────────────────
@@ -317,7 +649,8 @@ export class CatsCompanyBot {
   }
 
   private async processParsedMessage(msg: ParsedCatsMessage, key: string): Promise<void> {
-    const session = this.sessionManager.getOrCreate(key);
+    const sessionRoute = msg.envelope ? createCatsCoSessionRoute(msg.envelope) : undefined;
+    const session = this.sessionManager.getOrCreate(sessionRoute && sessionRoute.sessionKey === key ? sessionRoute : key);
 
     // 注册持久化回调到 SubAgentManager
     const subAgentManager = SubAgentManager.getInstance();
@@ -408,6 +741,8 @@ export class CatsCompanyBot {
         senderId: msg.senderId,
         seq: msg.seq,
         executionScope: msg.executionScope,
+        deviceGrants: msg.deviceGrants,
+        deviceSelection: msg.deviceSelection,
         localFileGrants,
         receivedAt: Date.now(),
         source: 'user',
@@ -429,11 +764,15 @@ export class CatsCompanyBot {
     try {
       const result = await session.handleMessage(userMessage, {
         channel,
+        sessionRoute,
         executionScope: msg.executionScope,
         localDeviceGrant: this.localDeviceGrant,
+        deviceGrants: msg.deviceGrants,
+        deviceSelection: msg.deviceSelection,
+        deviceRpc: this.buildDeviceRpcTransport(),
         localFileGrants,
         runtimeFeedback,
-        pendingUserInputProvider: () => this.consumeQueuedUserInput(key),
+        pendingUserInputProvider: () => this.consumeQueuedUserInput(key, msg.executionScope),
         callbacks: this.buildSessionCallbacks(msg.topic),
       });
 
@@ -542,6 +881,7 @@ export class CatsCompanyBot {
       metadata: ctx.metadata,
       botUid: this.botUid,
     });
+    const executionScope = createExecutionScope(envelope);
 
     return {
       topic: ctx.topic,
@@ -552,7 +892,9 @@ export class CatsCompanyBot {
       rawContent: ctx.content,
       metadata: ctx.metadata,
       envelope,
-      executionScope: createExecutionScope(envelope),
+      executionScope,
+      deviceGrants: extractCatsCoDeviceGrants(ctx.metadata, executionScope),
+      deviceSelection: extractCatsCoDeviceSelection(ctx.metadata, executionScope),
       file: files[0],
       files,
     };
@@ -595,6 +937,8 @@ export class CatsCompanyBot {
         callbacks: this.buildSessionCallbacks(topic),
         source: 'subagent_result',
         executionScope,
+        localDeviceGrant: this.localDeviceGrant,
+        deviceRpc: this.buildDeviceRpcTransport(),
       });
       if (result.text === BUSY_MESSAGE) {
         this.enqueueSubAgentFeedback(sessionKey, topic, senderId, text, executionScope);
@@ -733,9 +1077,16 @@ export class CatsCompanyBot {
   }
 
   private handleCancelMessage(ctx: MessageContext): void {
-    const key = ctx.isGroup
-      ? `cc_group:${ctx.topic}`
-      : `cc_user:${ctx.senderId}`;
+    const envelope = createCatsCoMessageEnvelope({
+      topic: ctx.topic,
+      isGroup: ctx.isGroup,
+      senderId: ctx.senderId,
+      seq: ctx.seq,
+      text: '',
+      metadata: ctx.metadata,
+      botUid: this.botUid,
+    });
+    const key = envelope.sessionKey;
     const session = (this.sessionManager as any).get?.(key) ?? null;
     if (!session) {
       Logger.info(`[${key}] 收到取消事件，但会话不存在`);
@@ -792,14 +1143,19 @@ export class CatsCompanyBot {
           source: 'subagent_result',
           executionScope: msg.executionScope,
           localDeviceGrant: this.localDeviceGrant,
+          deviceSelection: msg.deviceSelection,
+          deviceRpc: this.buildDeviceRpcTransport(),
         })
         : await session.handleMessage(msg.userMessage, {
           channel,
           executionScope: msg.executionScope,
           localDeviceGrant: this.localDeviceGrant,
+          deviceGrants: msg.deviceGrants,
+          deviceSelection: msg.deviceSelection,
+          deviceRpc: this.buildDeviceRpcTransport(),
           runtimeFeedback: msg.runtimeFeedback,
           localFileGrants: msg.localFileGrants,
-          pendingUserInputProvider: () => this.consumeQueuedUserInput(sessionKey),
+          pendingUserInputProvider: () => this.consumeQueuedUserInput(sessionKey, msg.executionScope),
           callbacks: this.buildSessionCallbacks(msg.topic),
         });
       if (result.text.startsWith('处理消息时出错:')) {
@@ -823,14 +1179,24 @@ export class CatsCompanyBot {
     await this.drainMessageQueue(sessionKey);
   }
 
-  private consumeQueuedUserInput(sessionKey: string): string | ContentBlock[] | PendingUserInput | null {
+  private consumeQueuedUserInput(
+    sessionKey: string,
+    currentScope?: ParsedCatsMessage['executionScope'],
+  ): string | ContentBlock[] | PendingUserInput | null {
     const queue = this.messageQueue.get(sessionKey);
     if (!queue || queue.length === 0) return null;
 
-    const userMessages = queue.filter(item => item.source !== 'subagent_feedback');
-    const runtimeMessages = queue.filter(item => item.source === 'subagent_feedback');
-    if (runtimeMessages.length > 0) {
-      this.messageQueue.set(sessionKey, runtimeMessages);
+    const userMessages: QueuedMessage[] = [];
+    let firstRemainingIndex = 0;
+    for (; firstRemainingIndex < queue.length; firstRemainingIndex++) {
+      const item = queue[firstRemainingIndex];
+      if (item.source === 'subagent_feedback') break;
+      if (!this.canMergeQueuedMessage(currentScope, item.executionScope)) break;
+      userMessages.push(item);
+    }
+    const remainingMessages = queue.slice(firstRemainingIndex);
+    if (remainingMessages.length > 0) {
+      this.messageQueue.set(sessionKey, remainingMessages);
     } else {
       this.messageQueue.delete(sessionKey);
     }
@@ -844,8 +1210,29 @@ export class CatsCompanyBot {
     Logger.info(`[${sessionKey}] 合并 ${messages.length} 条处理期间新到的用户消息`);
     const content = this.mergeQueuedMessages(messages);
     const localFileGrants = messages.flatMap(item => item.localFileGrants || []);
-    if (localFileGrants.length === 0) return content;
-    return { content, localFileGrants };
+    const deviceGrants = messages.flatMap(item => item.deviceGrants || []);
+    const deviceSelection = [...messages].reverse().find(item => item.deviceSelection)?.deviceSelection;
+    if (localFileGrants.length === 0 && deviceGrants.length === 0 && !deviceSelection) return content;
+    return {
+      content,
+      localFileGrants: localFileGrants.length > 0 ? localFileGrants : undefined,
+      deviceGrants: deviceGrants.length > 0 ? deviceGrants : undefined,
+      deviceSelection,
+    };
+  }
+
+  private canMergeQueuedMessage(
+    currentScope: ParsedCatsMessage['executionScope'] | undefined,
+    queuedScope: ParsedCatsMessage['executionScope'] | undefined,
+  ): boolean {
+    if (!currentScope || !queuedScope) return true;
+    return currentScope.sessionKey === queuedScope.sessionKey
+      && currentScope.topicId === queuedScope.topicId
+      && currentScope.topicType === queuedScope.topicType
+      && currentScope.actorUserId === queuedScope.actorUserId
+      && currentScope.agentId === queuedScope.agentId
+      && currentScope.agentBodyId === queuedScope.agentBodyId
+      && currentScope.identityTrust === queuedScope.identityTrust;
   }
 
   private mergeQueuedMessages(messages: QueuedMessage[]): string | ContentBlock[] {
@@ -886,6 +1273,7 @@ export class CatsCompanyBot {
    * 停止机器人
    */
   async destroy(): Promise<void> {
+    this.stopDeviceRegistrationRefresh();
     this.bot.disconnect();
     await this.sessionManager.destroy();
     for (const pendingId of Array.from(this.pendingAnswers.keys())) {

--- a/src/catscompany/local-file-grants.ts
+++ b/src/catscompany/local-file-grants.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import { randomUUID } from 'crypto';
 import type {
   ExecutionScope,
   LocalFileGrantFileType,
@@ -8,6 +9,7 @@ import type {
 } from '../types/session-identity';
 
 export const CATSCOMPANY_ATTACHMENT_GRANT_TTL_MS = 30 * 60 * 1000;
+export const CATSCOMPANY_ATTACHMENT_REF_PREFIX = 'catsco_attachment:';
 
 export interface CatsCoDeviceGrantInput {
   bodyId?: string;
@@ -62,6 +64,7 @@ export function createCatsCoAttachmentGrant(
   return {
     kind: 'catscompany_attachment',
     source: 'catscompany',
+    attachmentRef: `${CATSCOMPANY_ATTACHMENT_REF_PREFIX}${randomUUID()}`,
     filePath,
     fileName: input.fileName,
     fileType: input.type || 'unknown',

--- a/src/catscompany/local-file-grants.ts
+++ b/src/catscompany/local-file-grants.ts
@@ -1,0 +1,111 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import type {
+  ExecutionScope,
+  LocalFileGrantFileType,
+  ScopedLocalDeviceGrant,
+  ScopedLocalFileGrant,
+} from '../types/session-identity';
+
+export const CATSCOMPANY_ATTACHMENT_GRANT_TTL_MS = 30 * 60 * 1000;
+
+export interface CatsCoDeviceGrantInput {
+  bodyId?: string;
+  installationId?: string;
+  deviceId?: string;
+}
+
+export interface CatsCoAttachmentGrantInput {
+  localPath: string;
+  fileName: string;
+  type?: LocalFileGrantFileType;
+  workspaceRoot?: string;
+}
+
+export function createCatsCoLocalDeviceGrant(input: CatsCoDeviceGrantInput): ScopedLocalDeviceGrant | undefined {
+  const bodyId = safeString(input.bodyId);
+  if (!bodyId) return undefined;
+
+  return {
+    kind: 'catscompany_body',
+    source: 'catscompany',
+    bodyId,
+    installationId: safeString(input.installationId),
+    deviceId: safeString(input.deviceId),
+    createdAt: Date.now(),
+  };
+}
+
+export function createCatsCoAttachmentGrant(
+  scope: ExecutionScope | undefined,
+  localDeviceGrant: ScopedLocalDeviceGrant | undefined,
+  input: CatsCoAttachmentGrantInput,
+): ScopedLocalFileGrant | undefined {
+  if (!scope || scope.source !== 'catscompany') return undefined;
+  if (scope.identityTrust !== 'server_canonical' || !scope.isTrusted) return undefined;
+  if (!scope.agentBodyId) return undefined;
+  if (!localDeviceGrant || localDeviceGrant.source !== 'catscompany') return undefined;
+  if (scope.agentBodyId !== localDeviceGrant.bodyId) return undefined;
+
+  const filePath = normalizeLocalPath(input.localPath);
+  if (!isInsideDownloadsRoot(filePath, input.workspaceRoot)) return undefined;
+
+  let stats: fs.Stats;
+  try {
+    stats = fs.statSync(filePath);
+  } catch {
+    return undefined;
+  }
+  if (!stats.isFile()) return undefined;
+  const createdAt = Date.now();
+
+  return {
+    kind: 'catscompany_attachment',
+    source: 'catscompany',
+    filePath,
+    fileName: input.fileName,
+    fileType: input.type || 'unknown',
+    size: stats.size,
+    mtimeMs: stats.mtimeMs,
+    sessionKey: scope.sessionKey,
+    topicId: scope.topicId,
+    topicType: scope.topicType,
+    actorUserId: scope.actorUserId,
+    agentId: scope.agentId,
+    agentBodyId: scope.agentBodyId,
+    deviceBodyId: localDeviceGrant.bodyId,
+    deviceInstallationId: localDeviceGrant.installationId,
+    identityTrust: scope.identityTrust,
+    operations: ['read_file', 'send_file'],
+    createdAt,
+    expiresAt: createdAt + CATSCOMPANY_ATTACHMENT_GRANT_TTL_MS,
+  };
+}
+
+export function normalizeLocalPath(filePath: string): string {
+  const resolved = path.resolve(filePath);
+  try {
+    return fs.realpathSync(resolved);
+  } catch {
+    return resolved;
+  }
+}
+
+function isInsideDownloadsRoot(filePath: string, workspaceRoot = process.cwd()): boolean {
+  const downloadsRoot = normalizeLocalPath(path.join(workspaceRoot, 'tmp', 'downloads'));
+  const target = normalizeForCompare(filePath);
+  const root = normalizeForCompare(downloadsRoot);
+  if (target === root) return true;
+  const rootWithSep = root.endsWith(path.sep) ? root : `${root}${path.sep}`;
+  return target.startsWith(rootWithSep);
+}
+
+function normalizeForCompare(filePath: string): string {
+  return path.resolve(filePath).toLowerCase();
+}
+
+function safeString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const text = value.trim();
+  return text || undefined;
+}

--- a/src/catscompany/message-envelope.ts
+++ b/src/catscompany/message-envelope.ts
@@ -1,0 +1,181 @@
+import type { ExecutionScope, IdentityTrustLevel, MessageEnvelope, MessageTopicType } from '../types/session-identity';
+
+type UnknownRecord = Record<string, unknown>;
+
+export interface CatsCoEnvelopeInput {
+  topic: string;
+  isGroup?: boolean;
+  senderId: string;
+  seq?: number;
+  text: string;
+  metadata?: Record<string, unknown>;
+  botUid?: string | null;
+}
+
+export function createCatsCoMessageEnvelope(input: CatsCoEnvelopeInput): MessageEnvelope {
+  const topicId = safeString(input.topic) || 'unknown_topic';
+  const senderId = safeString(input.senderId) || 'unknown';
+  const topicType = inferTopicType(topicId, input.isGroup);
+  const metadata = input.metadata;
+  const catscoIdentity = asRecord(metadata?.catsco_identity);
+  const warnings: string[] = [];
+
+  const actor = asRecord(catscoIdentity?.actor);
+  const agent = asRecord(catscoIdentity?.agent);
+  const identityTopic = asRecord(catscoIdentity?.topic);
+  const permissions = asRecord(catscoIdentity?.permissions);
+
+  const canonicalActorId = stringField(actor, 'user_id');
+  const canonicalTopicId = stringField(identityTopic, 'topic_id');
+  const canonicalTopicType = normalizeTopicType(stringField(identityTopic, 'type'));
+  const permissionsSource = stringField(permissions, 'source');
+  const canonicalChannelSeq = numberField(identityTopic, 'channel_seq');
+  const metadataLooksCanonical = permissionsSource === 'server_canonical_message';
+
+  if (catscoIdentity && !metadataLooksCanonical) {
+    warnings.push('catsco_identity permissions.source is not server_canonical_message');
+  }
+  if (metadataLooksCanonical && canonicalTopicId && canonicalTopicId !== topicId) {
+    warnings.push('catsco_identity topic_id does not match message topic');
+  }
+  if (metadataLooksCanonical && canonicalActorId && senderId !== 'unknown' && canonicalActorId !== senderId) {
+    warnings.push('catsco_identity actor.user_id does not match message sender');
+  }
+
+  const isCanonicalTrusted = Boolean(
+    catscoIdentity
+    && metadataLooksCanonical
+    && canonicalActorId
+    && canonicalTopicId === topicId
+    && (senderId === 'unknown' || canonicalActorId === senderId),
+  );
+
+  const actorUserId = isCanonicalTrusted ? canonicalActorId! : senderId;
+  const resolvedTopicType = isCanonicalTrusted && canonicalTopicType !== 'unknown'
+    ? canonicalTopicType
+    : topicType;
+  const agentId = isCanonicalTrusted
+    ? firstNonEmpty(stringField(agent, 'agent_id'), safeString(input.botUid))
+    : safeString(input.botUid);
+  const agentBodyId = isCanonicalTrusted ? stringField(agent, 'body_id') : undefined;
+  const channelSeq = isCanonicalTrusted
+    ? canonicalChannelSeq ?? normalizeSeq(input.seq)
+    : normalizeSeq(input.seq);
+  const identityTrust: IdentityTrustLevel = isCanonicalTrusted
+    ? 'server_canonical'
+    : catscoIdentity
+      ? 'untrusted'
+      : 'legacy_context';
+  const sessionKey = buildCatsCoSessionKey(resolvedTopicType, topicId, actorUserId);
+
+  return {
+    source: 'catscompany',
+    sessionKey,
+    messageId: buildMessageId(topicId, channelSeq, metadata),
+    topicId,
+    topicType: resolvedTopicType,
+    actorUserId,
+    agentId,
+    agentBodyId,
+    channelSeq,
+    rawText: input.text,
+    rawMetadata: metadata,
+    permissionsSource: isCanonicalTrusted ? permissionsSource : undefined,
+    identityTrust,
+    identitySource: isCanonicalTrusted ? 'metadata.catsco_identity' : undefined,
+    warnings: warnings.length > 0 ? warnings : undefined,
+  };
+}
+
+export function createExecutionScope(envelope: MessageEnvelope): ExecutionScope {
+  return {
+    source: envelope.source,
+    sessionKey: envelope.sessionKey,
+    topicId: envelope.topicId,
+    topicType: envelope.topicType,
+    actorUserId: envelope.actorUserId,
+    agentId: envelope.agentId,
+    agentBodyId: envelope.agentBodyId,
+    channelSeq: envelope.channelSeq,
+    permissionsSource: envelope.permissionsSource,
+    identityTrust: envelope.identityTrust,
+    isTrusted: envelope.identityTrust === 'server_canonical',
+  };
+}
+
+export function buildCatsCoSessionKey(
+  topicType: MessageTopicType,
+  topicId: string,
+  actorUserId: string,
+): string {
+  if (topicType === 'group') {
+    return `cc_group:${topicId}`;
+  }
+  return `cc_user:${actorUserId || 'unknown'}`;
+}
+
+function buildMessageId(
+  topicId: string,
+  channelSeq: number | undefined,
+  metadata?: UnknownRecord,
+): string | undefined {
+  const clientMessageId = firstNonEmpty(
+    stringField(metadata, 'client_msg_id'),
+    stringField(metadata, 'clientMessageId'),
+    stringField(metadata, 'client_message_id'),
+  );
+  if (clientMessageId) return clientMessageId;
+  if (channelSeq && channelSeq > 0) return `${topicId}:${channelSeq}`;
+  return undefined;
+}
+
+function inferTopicType(topicId: string, isGroup?: boolean): MessageTopicType {
+  if (isGroup || topicId.startsWith('grp_')) return 'group';
+  if (topicId.startsWith('p2p_')) return 'p2p';
+  return 'unknown';
+}
+
+function normalizeTopicType(value?: string): MessageTopicType {
+  if (value === 'p2p' || value === 'group') return value;
+  return 'unknown';
+}
+
+function asRecord(value: unknown): UnknownRecord | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  return value as UnknownRecord;
+}
+
+function stringField(record: UnknownRecord | undefined, key: string): string | undefined {
+  const value = record?.[key];
+  if (typeof value !== 'string') return undefined;
+  const text = value.trim();
+  return text || undefined;
+}
+
+function numberField(record: UnknownRecord | undefined, key: string): number | undefined {
+  const value = record?.[key];
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+
+function normalizeSeq(value: unknown): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return undefined;
+  return value;
+}
+
+function safeString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const text = value.trim();
+  return text || undefined;
+}
+
+function firstNonEmpty(...values: Array<string | undefined>): string | undefined {
+  for (const value of values) {
+    if (value) return value;
+  }
+  return undefined;
+}

--- a/src/catscompany/message-envelope.ts
+++ b/src/catscompany/message-envelope.ts
@@ -1,4 +1,8 @@
 import type { ExecutionScope, IdentityTrustLevel, MessageEnvelope, MessageTopicType } from '../types/session-identity';
+import {
+  buildLegacyCatsCoSessionKey,
+  createSessionRoute,
+} from '../core/session-router';
 
 type UnknownRecord = Record<string, unknown>;
 
@@ -66,12 +70,26 @@ export function createCatsCoMessageEnvelope(input: CatsCoEnvelopeInput): Message
     : catscoIdentity
       ? 'untrusted'
       : 'legacy_context';
-  const sessionKey = buildCatsCoSessionKey(resolvedTopicType, topicId, actorUserId);
+  const legacySessionKey = buildCatsCoSessionKey(resolvedTopicType, topicId, actorUserId);
+  const route = createSessionRoute({
+    source: 'catscompany',
+    topicId,
+    topicType: resolvedTopicType,
+    actorUserId,
+    agentId,
+    agentBodyId,
+    messageId: buildMessageId(topicId, channelSeq, metadata),
+    channelSeq,
+    identityTrust,
+    identitySource: isCanonicalTrusted ? 'metadata.catsco_identity' : undefined,
+    legacySessionKey,
+  });
 
   return {
     source: 'catscompany',
-    sessionKey,
-    messageId: buildMessageId(topicId, channelSeq, metadata),
+    sessionKey: route.sessionKey,
+    legacySessionKey,
+    messageId: route.messageId,
     topicId,
     topicType: resolvedTopicType,
     actorUserId,
@@ -91,6 +109,7 @@ export function createExecutionScope(envelope: MessageEnvelope): ExecutionScope 
   return {
     source: envelope.source,
     sessionKey: envelope.sessionKey,
+    legacySessionKey: envelope.legacySessionKey,
     topicId: envelope.topicId,
     topicType: envelope.topicType,
     actorUserId: envelope.actorUserId,
@@ -108,10 +127,7 @@ export function buildCatsCoSessionKey(
   topicId: string,
   actorUserId: string,
 ): string {
-  if (topicType === 'group') {
-    return `cc_group:${topicId}`;
-  }
-  return `cc_user:${actorUserId || 'unknown'}`;
+  return buildLegacyCatsCoSessionKey(topicType, topicId, actorUserId);
 }
 
 function buildMessageId(

--- a/src/catscompany/runtime-config.ts
+++ b/src/catscompany/runtime-config.ts
@@ -137,6 +137,7 @@ export function resolveCatsCoRuntimeConfig(
       apiKey,
       bodyId,
       installationId,
+      deviceName: localConfig.device?.name,
       httpBaseUrl,
       sessionTTL: config.catscompany?.sessionTTL,
     }

--- a/src/catscompany/types.ts
+++ b/src/catscompany/types.ts
@@ -1,3 +1,5 @@
+import type { ExecutionScope, MessageEnvelope } from '../types/session-identity';
+
 /**
  * CatsCo agent 连接配置
  */
@@ -32,6 +34,12 @@ export interface ParsedCatsMessage {
   text: string;
   /** 原始 content（可能是 string 或 RichContent） */
   rawContent: unknown;
+  /** 原始 metadata，由 CatsCo 服务端透传/注入 */
+  metadata?: Record<string, unknown>;
+  /** 标准化后的消息信封 */
+  envelope: MessageEnvelope;
+  /** 当前 turn 的执行身份 */
+  executionScope: ExecutionScope;
   /** 文件附件信息（rich content file/image 时存在） */
   file?: CatsFileInfo;
   /** 同一条消息里的全部附件（content_blocks 或 rich content） */

--- a/src/catscompany/types.ts
+++ b/src/catscompany/types.ts
@@ -1,4 +1,4 @@
-import type { ExecutionScope, MessageEnvelope } from '../types/session-identity';
+import type { ExecutionScope, MessageEnvelope, ScopedDeviceGrant, ScopedDeviceSelection } from '../types/session-identity';
 
 /**
  * CatsCo agent 连接配置
@@ -12,6 +12,8 @@ export interface CatsCompanyConfig {
   bodyId?: string;
   /** 当前安装/设备 ID，默认与 bodyId 相同 */
   installationId?: string;
+  /** 用户可见设备名，用于 Dashboard 展示和服务端设备选择 */
+  deviceName?: string;
   /** HTTP 基础地址（用于文件上传），默认从 serverUrl 推导 */
   httpBaseUrl?: string;
   /** 会话过期时间（毫秒），默认 30 分钟 */
@@ -40,6 +42,10 @@ export interface ParsedCatsMessage {
   envelope: MessageEnvelope;
   /** 当前 turn 的执行身份 */
   executionScope: ExecutionScope;
+  /** 服务端签发的当前 turn 用户设备授权 */
+  deviceGrants?: ScopedDeviceGrant[];
+  /** 服务端为当前 turn 选择的用户设备，或要求先选择设备 */
+  deviceSelection?: ScopedDeviceSelection;
   /** 文件附件信息（rich content file/image 时存在） */
   file?: CatsFileInfo;
   /** 同一条消息里的全部附件（content_blocks 或 rich content） */

--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -1,11 +1,18 @@
 import { Message } from '../types';
-import type { ExecutionScope, ScopedLocalDeviceGrant, ScopedLocalFileGrant } from '../types/session-identity';
+import type {
+  ExecutionScope,
+  ScopedDeviceGrant,
+  ScopedDeviceSelection,
+  ScopedLocalDeviceGrant,
+  ScopedLocalFileGrant,
+  SessionRoute,
+} from '../types/session-identity';
 import * as fs from 'fs';
 import * as path from 'path';
 import { AIService } from '../utils/ai-service';
 import { ToolManager } from '../tools/tool-manager';
 import { SkillManager } from '../skills/skill-manager';
-import { ChannelCallbacks } from '../types/tool';
+import { ChannelCallbacks, DeviceRpcTransport } from '../types/tool';
 import {
   SessionSkillRuntime,
   SkillReloadHandler,
@@ -28,6 +35,7 @@ import { PlanRuntime } from './plan-runtime';
 import { SubAgentManager } from './sub-agent-manager';
 import type { PendingUserInputProvider } from './conversation-runner';
 import { resolveModelContextWindow } from '../utils/model-context-window';
+import { parseSessionKeyV2 } from './session-router';
 
 export type { RuntimeFeedbackInput, RuntimeFeedbackOptions } from './runtime-feedback-inbox';
 
@@ -70,10 +78,18 @@ export interface HandleMessageOptions {
   callbacks?: SessionCallbacks;
   /** 平台通道回调，注入到 ToolExecutionContext 供工具使用 */
   channel?: ChannelCallbacks;
+  /** 当前 turn 的会话路由快照，用于模型可见的结构化运行上下文 */
+  sessionRoute?: SessionRoute;
   /** 当前 turn 的可信执行身份 */
   executionScope?: ExecutionScope;
   /** 当前本机运行体授权，例如 CatsCo body/device 绑定。 */
   localDeviceGrant?: ScopedLocalDeviceGrant;
+  /** 当前 turn 已授权的用户设备资源。 */
+  deviceGrants?: ScopedDeviceGrant[];
+  /** 服务端为当前 turn 选定的用户设备。 */
+  deviceSelection?: ScopedDeviceSelection;
+  /** 当前 turn 可用的远程设备 RPC 通道。 */
+  deviceRpc?: DeviceRpcTransport;
   /** 当前 turn 已授权的本地文件资源。 */
   localFileGrants?: ScopedLocalFileGrant[];
   /** 当前 turn 专属、给 agent 可见的运行时反馈 */
@@ -143,6 +159,7 @@ export class AgentSession {
     public readonly key: string,
     private services: AgentServices,
     private sessionType?: string,
+    private readonly sessionRoute?: SessionRoute,
   ) {
     const type = sessionType || this.extractSessionType(key);
     this.sessionTurnLogger = new SessionTurnLogger(type, key);
@@ -161,6 +178,7 @@ export class AgentSession {
     this.skillRuntime = new SessionSkillRuntime(services.skillManager, key);
     this.lifecycleManager = new SessionLifecycleManager({
       sessionKey: key,
+      legacySessionKey: sessionRoute?.legacySessionKey,
       runtimeFeedbackInbox: this.runtimeFeedbackInbox,
     });
     this.defaultDirectory = this.resolveDefaultDirectory();
@@ -168,6 +186,7 @@ export class AgentSession {
     this.turnController = new AgentTurnController({
       sessionKey: key,
       sessionType,
+      sessionRoute,
       services,
       skillRuntime: this.skillRuntime,
       planRuntime: this.planRuntime,
@@ -233,6 +252,12 @@ export class AgentSession {
   }
 
   private extractSessionType(key: string): string {
+    const parsedV2 = parseSessionKeyV2(key);
+    if (parsedV2) {
+      if (parsedV2.source === 'catscompany') return 'catscompany';
+      if (parsedV2.source === 'feishu') return 'feishu';
+      if (parsedV2.source === 'weixin') return 'weixin';
+    }
     if (key.startsWith('catscompany:')) return 'catscompany';
     if (key.startsWith('feishu:')) return 'feishu';
     if (key.startsWith('user:')) return 'weixin';
@@ -367,8 +392,12 @@ export class AgentSession {
       // 兼容旧签名：如果传入的对象有 onText/onToolStart 等字段，视为 SessionCallbacks
       let callbacks: SessionCallbacks | undefined;
       let channel: ChannelCallbacks | undefined;
+      let sessionRoute: SessionRoute | undefined;
       let executionScope: ExecutionScope | undefined;
       let localDeviceGrant: ScopedLocalDeviceGrant | undefined;
+      let deviceGrants: ScopedDeviceGrant[] | undefined;
+      let deviceSelection: ScopedDeviceSelection | undefined;
+      let deviceRpc: DeviceRpcTransport | undefined;
       let localFileGrants: ScopedLocalFileGrant[] | undefined;
       let runtimeFeedbackInputs: RuntimeFeedbackInput[] = [];
       let pendingUserInputProvider: PendingUserInputProvider | undefined;
@@ -376,8 +405,12 @@ export class AgentSession {
       if (callbacksOrOptions) {
         if (
           'channel' in callbacksOrOptions
+          || 'sessionRoute' in callbacksOrOptions
           || 'executionScope' in callbacksOrOptions
           || 'localDeviceGrant' in callbacksOrOptions
+          || 'deviceGrants' in callbacksOrOptions
+          || 'deviceSelection' in callbacksOrOptions
+          || 'deviceRpc' in callbacksOrOptions
           || 'localFileGrants' in callbacksOrOptions
           || 'callbacks' in callbacksOrOptions
           || 'runtimeFeedback' in callbacksOrOptions
@@ -387,8 +420,12 @@ export class AgentSession {
           const opts = callbacksOrOptions as HandleMessageOptions;
           callbacks = opts.callbacks;
           channel = opts.channel;
+          sessionRoute = opts.sessionRoute;
           executionScope = opts.executionScope;
           localDeviceGrant = opts.localDeviceGrant;
+          deviceGrants = opts.deviceGrants;
+          deviceSelection = opts.deviceSelection;
+          deviceRpc = opts.deviceRpc;
           localFileGrants = opts.localFileGrants;
           runtimeFeedbackInputs = opts.runtimeFeedback || [];
           pendingUserInputProvider = opts.pendingUserInputProvider;
@@ -431,8 +468,12 @@ export class AgentSession {
           runtimeObservationSource,
           callbacks,
           channel,
+          sessionRoute,
           executionScope,
           localDeviceGrant,
+          deviceGrants,
+          deviceSelection,
+          deviceRpc,
           localFileGrants,
           pendingUserInputProvider,
           abortSignal: this.activeAbortController.signal,

--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -1,4 +1,5 @@
 import { Message } from '../types';
+import type { ExecutionScope } from '../types/session-identity';
 import * as fs from 'fs';
 import * as path from 'path';
 import { AIService } from '../utils/ai-service';
@@ -69,6 +70,8 @@ export interface HandleMessageOptions {
   callbacks?: SessionCallbacks;
   /** 平台通道回调，注入到 ToolExecutionContext 供工具使用 */
   channel?: ChannelCallbacks;
+  /** 当前 turn 的可信执行身份 */
+  executionScope?: ExecutionScope;
   /** 当前 turn 专属、给 agent 可见的运行时反馈 */
   runtimeFeedback?: RuntimeFeedbackInput[];
   /** Pulls user messages that arrived while this session was busy. */
@@ -360,12 +363,14 @@ export class AgentSession {
       // 兼容旧签名：如果传入的对象有 onText/onToolStart 等字段，视为 SessionCallbacks
       let callbacks: SessionCallbacks | undefined;
       let channel: ChannelCallbacks | undefined;
+      let executionScope: ExecutionScope | undefined;
       let runtimeFeedbackInputs: RuntimeFeedbackInput[] = [];
       let pendingUserInputProvider: PendingUserInputProvider | undefined;
 
       if (callbacksOrOptions) {
         if (
           'channel' in callbacksOrOptions
+          || 'executionScope' in callbacksOrOptions
           || 'callbacks' in callbacksOrOptions
           || 'runtimeFeedback' in callbacksOrOptions
           || 'pendingUserInputProvider' in callbacksOrOptions
@@ -374,6 +379,7 @@ export class AgentSession {
           const opts = callbacksOrOptions as HandleMessageOptions;
           callbacks = opts.callbacks;
           channel = opts.channel;
+          executionScope = opts.executionScope;
           runtimeFeedbackInputs = opts.runtimeFeedback || [];
           pendingUserInputProvider = opts.pendingUserInputProvider;
         } else {
@@ -415,6 +421,7 @@ export class AgentSession {
           runtimeObservationSource,
           callbacks,
           channel,
+          executionScope,
           pendingUserInputProvider,
           abortSignal: this.activeAbortController.signal,
           shouldContinue: () => !this.interruptRequested,

--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -1,5 +1,5 @@
 import { Message } from '../types';
-import type { ExecutionScope } from '../types/session-identity';
+import type { ExecutionScope, ScopedLocalDeviceGrant, ScopedLocalFileGrant } from '../types/session-identity';
 import * as fs from 'fs';
 import * as path from 'path';
 import { AIService } from '../utils/ai-service';
@@ -72,6 +72,10 @@ export interface HandleMessageOptions {
   channel?: ChannelCallbacks;
   /** 当前 turn 的可信执行身份 */
   executionScope?: ExecutionScope;
+  /** 当前本机运行体授权，例如 CatsCo body/device 绑定。 */
+  localDeviceGrant?: ScopedLocalDeviceGrant;
+  /** 当前 turn 已授权的本地文件资源。 */
+  localFileGrants?: ScopedLocalFileGrant[];
   /** 当前 turn 专属、给 agent 可见的运行时反馈 */
   runtimeFeedback?: RuntimeFeedbackInput[];
   /** Pulls user messages that arrived while this session was busy. */
@@ -364,6 +368,8 @@ export class AgentSession {
       let callbacks: SessionCallbacks | undefined;
       let channel: ChannelCallbacks | undefined;
       let executionScope: ExecutionScope | undefined;
+      let localDeviceGrant: ScopedLocalDeviceGrant | undefined;
+      let localFileGrants: ScopedLocalFileGrant[] | undefined;
       let runtimeFeedbackInputs: RuntimeFeedbackInput[] = [];
       let pendingUserInputProvider: PendingUserInputProvider | undefined;
 
@@ -371,6 +377,8 @@ export class AgentSession {
         if (
           'channel' in callbacksOrOptions
           || 'executionScope' in callbacksOrOptions
+          || 'localDeviceGrant' in callbacksOrOptions
+          || 'localFileGrants' in callbacksOrOptions
           || 'callbacks' in callbacksOrOptions
           || 'runtimeFeedback' in callbacksOrOptions
           || 'pendingUserInputProvider' in callbacksOrOptions
@@ -380,6 +388,8 @@ export class AgentSession {
           callbacks = opts.callbacks;
           channel = opts.channel;
           executionScope = opts.executionScope;
+          localDeviceGrant = opts.localDeviceGrant;
+          localFileGrants = opts.localFileGrants;
           runtimeFeedbackInputs = opts.runtimeFeedback || [];
           pendingUserInputProvider = opts.pendingUserInputProvider;
         } else {
@@ -422,6 +432,8 @@ export class AgentSession {
           callbacks,
           channel,
           executionScope,
+          localDeviceGrant,
+          localFileGrants,
           pendingUserInputProvider,
           abortSignal: this.activeAbortController.signal,
           shouldContinue: () => !this.interruptRequested,

--- a/src/core/agent-turn-controller.ts
+++ b/src/core/agent-turn-controller.ts
@@ -1,6 +1,13 @@
 import { ContentBlock, Message } from '../types';
-import type { ExecutionScope, ScopedLocalDeviceGrant, ScopedLocalFileGrant } from '../types/session-identity';
-import { ChannelCallbacks } from '../types/tool';
+import type {
+  ExecutionScope,
+  ScopedDeviceGrant,
+  ScopedDeviceSelection,
+  ScopedLocalDeviceGrant,
+  ScopedLocalFileGrant,
+  SessionRoute,
+} from '../types/session-identity';
+import { ChannelCallbacks, DeviceRpcTransport } from '../types/tool';
 import { AIService } from '../utils/ai-service';
 import { ToolManager } from '../tools/tool-manager';
 import { SkillManager } from '../skills/skill-manager';
@@ -36,8 +43,12 @@ export interface RunAgentTurnParams {
   runtimeObservationSource?: string;
   callbacks?: AgentTurnCallbacks;
   channel?: ChannelCallbacks;
+  sessionRoute?: SessionRoute;
   executionScope?: ExecutionScope;
   localDeviceGrant?: ScopedLocalDeviceGrant;
+  deviceGrants?: ScopedDeviceGrant[];
+  deviceSelection?: ScopedDeviceSelection;
+  deviceRpc?: DeviceRpcTransport;
   localFileGrants?: ScopedLocalFileGrant[];
   pendingUserInputProvider?: PendingUserInputProvider;
   abortSignal?: AbortSignal;
@@ -58,6 +69,7 @@ export interface AgentTurnRunError extends Error {
 export interface AgentTurnControllerOptions {
   sessionKey: string;
   sessionType?: string;
+  sessionRoute?: SessionRoute;
   services: AgentTurnServices;
   skillRuntime: SessionSkillRuntime;
   planRuntime: PlanRuntime;
@@ -86,6 +98,13 @@ export class AgentTurnController {
 
     const turnContext = await this.options.turnContextBuilder.build({
       sessionKey: this.options.sessionKey,
+      sessionType: this.options.sessionType,
+      sessionRoute: params.sessionRoute ?? this.options.sessionRoute,
+      executionScope: params.executionScope,
+      localDeviceGrant: params.localDeviceGrant,
+      deviceGrants: params.deviceGrants,
+      deviceSelection: params.deviceSelection,
+      localFileGrants: params.localFileGrants,
       durableMessages: params.messages,
       runtimeFeedback: params.runtimeFeedback,
       skillRuntime: this.options.skillRuntime,
@@ -96,6 +115,9 @@ export class AgentTurnController {
       channel: params.channel,
       executionScope: params.executionScope,
       localDeviceGrant: params.localDeviceGrant,
+      deviceGrants: params.deviceGrants,
+      deviceSelection: params.deviceSelection,
+      deviceRpc: params.deviceRpc,
       localFileGrants: params.localFileGrants,
       pendingUserInputProvider: params.pendingUserInputProvider,
       abortSignal: params.abortSignal,
@@ -145,6 +167,9 @@ export class AgentTurnController {
     channel?: ChannelCallbacks;
     executionScope?: ExecutionScope;
     localDeviceGrant?: ScopedLocalDeviceGrant;
+    deviceGrants?: ScopedDeviceGrant[];
+    deviceSelection?: ScopedDeviceSelection;
+    deviceRpc?: DeviceRpcTransport;
     localFileGrants?: ScopedLocalFileGrant[];
     pendingUserInputProvider?: PendingUserInputProvider;
     abortSignal?: AbortSignal;
@@ -177,6 +202,9 @@ export class AgentTurnController {
           channel: options.channel,
           executionScope: options.executionScope,
           localDeviceGrant: options.localDeviceGrant,
+          deviceGrants: options.deviceGrants,
+          deviceSelection: options.deviceSelection,
+          deviceRpc: options.deviceRpc,
           localFileGrants: options.localFileGrants,
         },
       },

--- a/src/core/agent-turn-controller.ts
+++ b/src/core/agent-turn-controller.ts
@@ -1,5 +1,5 @@
 import { ContentBlock, Message } from '../types';
-import type { ExecutionScope } from '../types/session-identity';
+import type { ExecutionScope, ScopedLocalDeviceGrant, ScopedLocalFileGrant } from '../types/session-identity';
 import { ChannelCallbacks } from '../types/tool';
 import { AIService } from '../utils/ai-service';
 import { ToolManager } from '../tools/tool-manager';
@@ -37,6 +37,8 @@ export interface RunAgentTurnParams {
   callbacks?: AgentTurnCallbacks;
   channel?: ChannelCallbacks;
   executionScope?: ExecutionScope;
+  localDeviceGrant?: ScopedLocalDeviceGrant;
+  localFileGrants?: ScopedLocalFileGrant[];
   pendingUserInputProvider?: PendingUserInputProvider;
   abortSignal?: AbortSignal;
   shouldContinue: () => boolean;
@@ -93,6 +95,8 @@ export class AgentTurnController {
     const runner = this.createRunner({
       channel: params.channel,
       executionScope: params.executionScope,
+      localDeviceGrant: params.localDeviceGrant,
+      localFileGrants: params.localFileGrants,
       pendingUserInputProvider: params.pendingUserInputProvider,
       abortSignal: params.abortSignal,
       shouldContinue: params.shouldContinue,
@@ -140,6 +144,8 @@ export class AgentTurnController {
   private createRunner(options: {
     channel?: ChannelCallbacks;
     executionScope?: ExecutionScope;
+    localDeviceGrant?: ScopedLocalDeviceGrant;
+    localFileGrants?: ScopedLocalFileGrant[];
     pendingUserInputProvider?: PendingUserInputProvider;
     abortSignal?: AbortSignal;
     shouldContinue: () => boolean;
@@ -170,6 +176,8 @@ export class AgentTurnController {
           abortSignal: options.abortSignal,
           channel: options.channel,
           executionScope: options.executionScope,
+          localDeviceGrant: options.localDeviceGrant,
+          localFileGrants: options.localFileGrants,
         },
       },
     );

--- a/src/core/agent-turn-controller.ts
+++ b/src/core/agent-turn-controller.ts
@@ -1,4 +1,5 @@
 import { ContentBlock, Message } from '../types';
+import type { ExecutionScope } from '../types/session-identity';
 import { ChannelCallbacks } from '../types/tool';
 import { AIService } from '../utils/ai-service';
 import { ToolManager } from '../tools/tool-manager';
@@ -35,6 +36,7 @@ export interface RunAgentTurnParams {
   runtimeObservationSource?: string;
   callbacks?: AgentTurnCallbacks;
   channel?: ChannelCallbacks;
+  executionScope?: ExecutionScope;
   pendingUserInputProvider?: PendingUserInputProvider;
   abortSignal?: AbortSignal;
   shouldContinue: () => boolean;
@@ -90,6 +92,7 @@ export class AgentTurnController {
 
     const runner = this.createRunner({
       channel: params.channel,
+      executionScope: params.executionScope,
       pendingUserInputProvider: params.pendingUserInputProvider,
       abortSignal: params.abortSignal,
       shouldContinue: params.shouldContinue,
@@ -136,6 +139,7 @@ export class AgentTurnController {
 
   private createRunner(options: {
     channel?: ChannelCallbacks;
+    executionScope?: ExecutionScope;
     pendingUserInputProvider?: PendingUserInputProvider;
     abortSignal?: AbortSignal;
     shouldContinue: () => boolean;
@@ -165,6 +169,7 @@ export class AgentTurnController {
           },
           abortSignal: options.abortSignal,
           channel: options.channel,
+          executionScope: options.executionScope,
         },
       },
     );

--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -1,5 +1,5 @@
 import { Message, ContentBlock, ChatConfig, ChatResponse } from '../types';
-import type { ScopedLocalFileGrant } from '../types/session-identity';
+import type { ScopedDeviceGrant, ScopedDeviceSelection, ScopedLocalFileGrant } from '../types/session-identity';
 import { AIService } from '../utils/ai-service';
 import { ToolCall, ToolDefinition, ToolExecutionContext, ToolExecutor, ToolResult, ToolTranscriptMode } from '../types/tool';
 import { StreamCallbacks } from '../providers/provider';
@@ -21,6 +21,10 @@ import {
   SUBAGENT_TOOL_NAME,
   TRANSIENT_RUNNER_HINT_PREFIX,
 } from './runner-orchestration-policy';
+import {
+  TRANSIENT_RUNTIME_CONTEXT_PREFIX,
+  buildRuntimeContextMessage,
+} from './runtime-context-builder';
 import { calculateSummaryBudgetTokens, resolveModelPromptBudgetTokens } from '../utils/model-context-window';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -86,6 +90,8 @@ export interface RunResult {
 
 export interface PendingUserInput {
   content: string | ContentBlock[];
+  deviceGrants?: ScopedDeviceGrant[];
+  deviceSelection?: ScopedDeviceSelection;
   localFileGrants?: ScopedLocalFileGrant[];
 }
 
@@ -514,6 +520,24 @@ export class ConversationRunner {
     if (!pending) return false;
 
     const content = isPendingUserInput(pending) ? pending.content : pending;
+    let shouldRefreshRuntimeContext = false;
+    if (isPendingUserInput(pending) && pending.deviceGrants?.length) {
+      this.toolExecutionContext = {
+        ...(this.toolExecutionContext || {}),
+        deviceGrants: [
+          ...(this.toolExecutionContext?.deviceGrants || []),
+          ...pending.deviceGrants,
+        ],
+      };
+      shouldRefreshRuntimeContext = true;
+    }
+    if (isPendingUserInput(pending) && pending.deviceSelection) {
+      this.toolExecutionContext = {
+        ...(this.toolExecutionContext || {}),
+        deviceSelection: pending.deviceSelection,
+      };
+      shouldRefreshRuntimeContext = true;
+    }
     if (isPendingUserInput(pending) && pending.localFileGrants?.length) {
       this.toolExecutionContext = {
         ...(this.toolExecutionContext || {}),
@@ -522,6 +546,10 @@ export class ConversationRunner {
           ...pending.localFileGrants,
         ],
       };
+      shouldRefreshRuntimeContext = true;
+    }
+    if (shouldRefreshRuntimeContext) {
+      this.refreshRuntimeContextForPendingInput(messages);
     }
 
     const userMessage: Message = { role: 'user', content };
@@ -537,6 +565,35 @@ export class ConversationRunner {
     );
 
     return true;
+  }
+
+  private refreshRuntimeContextForPendingInput(messages: Message[]): void {
+    const sessionKey = this.toolExecutionContext?.sessionId
+      || this.toolExecutionContext?.executionScope?.sessionKey;
+    if (!sessionKey) return;
+
+    const runtimeContext = buildRuntimeContextMessage({
+      sessionKey,
+      sessionType: this.toolExecutionContext?.surface,
+      executionScope: this.toolExecutionContext?.executionScope,
+      localDeviceGrant: this.toolExecutionContext?.localDeviceGrant,
+      deviceGrants: this.toolExecutionContext?.deviceGrants,
+      deviceSelection: this.toolExecutionContext?.deviceSelection,
+      localFileGrants: this.toolExecutionContext?.localFileGrants,
+    });
+    if (!runtimeContext) return;
+
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const message = messages[i];
+      if (
+        message.role === 'system'
+        && typeof message.content === 'string'
+        && message.content.startsWith(TRANSIENT_RUNTIME_CONTEXT_PREFIX)
+      ) {
+        messages.splice(i, 1);
+      }
+    }
+    messages.push(runtimeContext);
   }
 
   /**

--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -1,4 +1,5 @@
 import { Message, ContentBlock, ChatConfig, ChatResponse } from '../types';
+import type { ScopedLocalFileGrant } from '../types/session-identity';
 import { AIService } from '../utils/ai-service';
 import { ToolCall, ToolDefinition, ToolExecutionContext, ToolExecutor, ToolResult, ToolTranscriptMode } from '../types/tool';
 import { StreamCallbacks } from '../providers/provider';
@@ -83,12 +84,25 @@ export interface RunResult {
   newMessages: Message[];
 }
 
+export interface PendingUserInput {
+  content: string | ContentBlock[];
+  localFileGrants?: ScopedLocalFileGrant[];
+}
+
 export type PendingUserInputProvider = () =>
   | string
   | ContentBlock[]
+  | PendingUserInput
   | null
   | undefined
-  | Promise<string | ContentBlock[] | null | undefined>;
+  | Promise<string | ContentBlock[] | PendingUserInput | null | undefined>;
+
+function isPendingUserInput(value: string | ContentBlock[] | PendingUserInput): value is PendingUserInput {
+  return Boolean(value)
+    && typeof value === 'object'
+    && !Array.isArray(value)
+    && 'content' in value;
+}
 
 interface ToolExecutionRecord {
   toolCall: ToolCall;
@@ -499,13 +513,24 @@ export class ConversationRunner {
     const pending = await this.pendingUserInputProvider();
     if (!pending) return false;
 
-    const userMessage: Message = { role: 'user', content: pending };
+    const content = isPendingUserInput(pending) ? pending.content : pending;
+    if (isPendingUserInput(pending) && pending.localFileGrants?.length) {
+      this.toolExecutionContext = {
+        ...(this.toolExecutionContext || {}),
+        localFileGrants: [
+          ...(this.toolExecutionContext?.localFileGrants || []),
+          ...pending.localFileGrants,
+        ],
+      };
+    }
+
+    const userMessage: Message = { role: 'user', content };
     messages.push(userMessage);
     newMessages.push(userMessage);
 
-    const preview = typeof pending === 'string'
-      ? pending
-      : pending.map(block => block.type === 'text' ? block.text : '[image]').join('');
+    const preview = typeof content === 'string'
+      ? content
+      : content.map(block => block.type === 'text' ? block.text : '[image]').join('');
     Logger.info(
       `[${this.sessionLabel}Turn ${turns}] 已合并处理期间新到的用户消息: ` +
       ConversationRunner.truncateForLog(preview, 240)

--- a/src/core/device-grants.ts
+++ b/src/core/device-grants.ts
@@ -1,0 +1,275 @@
+import { randomUUID } from 'crypto';
+import type {
+  DeviceGrantOperation,
+  DeviceGrantStatus,
+  ExecutionScope,
+  MessageSource,
+  ScopedDeviceGrant,
+  UserDevice,
+  UserDeviceStatus,
+} from '../types/session-identity';
+import type { ToolExecutionContext } from '../types/tool';
+
+export const DEFAULT_DEVICE_GRANT_TTL_MS = 10 * 60 * 1000;
+
+export interface CreateUserDeviceInput {
+  source: MessageSource;
+  ownerUserId: string;
+  deviceId: string;
+  displayName?: string;
+  bodyId?: string;
+  installationId?: string;
+  identityTrust?: UserDevice['identityTrust'];
+  identitySource?: string;
+  status?: UserDeviceStatus;
+  registeredAt?: number;
+  lastSeenAt?: number;
+}
+
+export interface CreateDeviceGrantOptions {
+  operations: DeviceGrantOperation[];
+  ttlMs?: number;
+  now?: number;
+  grantId?: string;
+  status?: DeviceGrantStatus;
+  identitySource?: string;
+}
+
+export type DeviceGrantDecision =
+  | { ok: true; grant: ScopedDeviceGrant }
+  | { ok: false; errorCode: 'PERMISSION_DENIED' | 'TOOL_EXECUTION_ERROR'; message: string };
+
+export interface ResolveDeviceGrantOptions {
+  operation: DeviceGrantOperation;
+  deviceId?: string;
+  now?: number;
+}
+
+export function createUserDevice(input: CreateUserDeviceInput): UserDevice | undefined {
+  const source = normalizeSource(input.source);
+  const ownerUserId = normalizeId(input.ownerUserId);
+  const deviceId = normalizeId(input.deviceId);
+  if (!ownerUserId || !deviceId) return undefined;
+  const registeredAt = normalizeTime(input.registeredAt) ?? Date.now();
+
+  return pruneUndefined({
+    kind: 'user_device',
+    source,
+    ownerUserId,
+    deviceId,
+    displayName: normalizeId(input.displayName),
+    bodyId: normalizeId(input.bodyId),
+    installationId: normalizeId(input.installationId),
+    identityTrust: normalizeIdentityTrust(input.identityTrust),
+    identitySource: normalizeId(input.identitySource),
+    status: normalizeStatus(input.status),
+    registeredAt,
+    lastSeenAt: normalizeTime(input.lastSeenAt),
+  }) as UserDevice;
+}
+
+export function createDeviceGrant(
+  scope: ExecutionScope | undefined,
+  device: UserDevice | undefined,
+  options: CreateDeviceGrantOptions,
+): ScopedDeviceGrant | undefined {
+  if (!scope || !device) return undefined;
+  const operations = normalizeOperations(options.operations);
+  if (operations.length === 0) return undefined;
+  if (device.source !== scope.source) return undefined;
+  if (device.ownerUserId !== scope.actorUserId) return undefined;
+  const now = normalizeTime(options.now) ?? Date.now();
+  const ttlMs = normalizeTtl(options.ttlMs);
+
+  return pruneUndefined({
+    kind: 'user_device_grant',
+    source: device.source,
+    grantId: normalizeId(options.grantId) || `device_grant_${randomUUID()}`,
+    status: options.status || 'active',
+    identityTrust: scope.identityTrust,
+    identitySource: normalizeId(options.identitySource) || scope.permissionsSource,
+    deviceId: device.deviceId,
+    deviceDisplayName: device.displayName,
+    deviceBodyId: device.bodyId,
+    deviceInstallationId: device.installationId,
+    ownerUserId: device.ownerUserId,
+    sessionKey: scope.sessionKey,
+    topicId: scope.topicId,
+    topicType: scope.topicType,
+    actorUserId: scope.actorUserId,
+    agentId: scope.agentId,
+    agentBodyId: scope.agentBodyId,
+    operations,
+    createdAt: now,
+    expiresAt: now + ttlMs,
+  }) as ScopedDeviceGrant;
+}
+
+export function resolveDeviceGrant(
+  context: Pick<ToolExecutionContext, 'executionScope' | 'deviceGrants'>,
+  options: ResolveDeviceGrantOptions,
+): DeviceGrantDecision {
+  const grants = context.deviceGrants || [];
+  if (grants.length === 0) {
+    return denied('当前会话没有可用的用户设备授权，无法操作本地设备。');
+  }
+
+  const normalizedDeviceId = normalizeId(options.deviceId);
+  const matchingGrants = grants.filter(candidate => {
+    if (normalizedDeviceId && candidate.deviceId !== normalizedDeviceId) return false;
+    return candidate.operations.includes(options.operation);
+  });
+
+  if (matchingGrants.length === 0) {
+    return denied(
+      normalizedDeviceId
+        ? `当前会话没有允许 ${options.operation} 的设备授权：${normalizedDeviceId}。`
+        : `当前会话没有允许 ${options.operation} 的设备授权。`,
+    );
+  }
+
+  const validDecisions = matchingGrants
+    .map(candidate => validateDeviceGrant(context, candidate, options))
+    .filter((decision): decision is Extract<DeviceGrantDecision, { ok: true }> => decision.ok);
+
+  if (validDecisions.length === 0) {
+    return validateDeviceGrant(context, matchingGrants[0], options);
+  }
+
+  if (!normalizedDeviceId) {
+    const targetDeviceIds = new Set(validDecisions.map(decision => decision.grant.deviceId));
+    if (targetDeviceIds.size > 1) {
+      return denied(`当前会话有多个允许 ${options.operation} 的用户设备授权，请由后端指定目标 deviceId 后再执行。`);
+    }
+  }
+
+  return validDecisions[0];
+}
+
+export function validateDeviceGrant(
+  context: Pick<ToolExecutionContext, 'executionScope'>,
+  grant: ScopedDeviceGrant,
+  options: ResolveDeviceGrantOptions,
+): DeviceGrantDecision {
+  const scope = context.executionScope;
+  if (!scope) {
+    return denied('当前工具调用缺少执行身份，无法校验用户设备授权。');
+  }
+
+  const normalizedDeviceId = normalizeId(options.deviceId);
+  if (normalizedDeviceId && grant.deviceId !== normalizedDeviceId) {
+    return denied(`设备授权与目标设备不一致，已阻止操作：grant=${grant.deviceId} target=${normalizedDeviceId}`);
+  }
+
+  if (grant.status !== 'active') {
+    return denied(`设备授权不是 active 状态，已阻止操作：${grant.status}`);
+  }
+
+  if (grant.identityTrust === 'untrusted') {
+    return denied('设备授权来自未可信身份，已阻止操作。');
+  }
+
+  if (!grant.operations.includes(options.operation)) {
+    return denied(`设备授权不允许执行 ${options.operation}。`);
+  }
+
+  const now = normalizeTime(options.now) ?? Date.now();
+  if (grant.expiresAt <= now) {
+    return denied('设备授权已过期，请让用户重新授权当前设备。');
+  }
+
+  const mismatches = [
+    ['source', grant.source, scope.source],
+    ['sessionKey', grant.sessionKey, scope.sessionKey],
+    ['topicId', grant.topicId, scope.topicId],
+    ['topicType', grant.topicType, scope.topicType],
+    ['actorUserId', grant.actorUserId, scope.actorUserId],
+    ['agentId', grant.agentId, scope.agentId],
+    ['agentBodyId', grant.agentBodyId, scope.agentBodyId],
+  ].filter(([, grantValue, scopeValue]) => grantValue !== scopeValue);
+
+  if (grant.ownerUserId !== scope.actorUserId) {
+    mismatches.push(['ownerUserId', grant.ownerUserId, scope.actorUserId]);
+  }
+
+  if (mismatches.length > 0) {
+    return {
+      ok: false,
+      errorCode: 'PERMISSION_DENIED',
+      message: [
+        '设备授权与当前执行身份不一致，已阻止操作以避免串用户或串设备。',
+        ...mismatches.map(([field, grantValue, scopeValue]) => `${field}: grant=${grantValue || '(empty)'} scope=${scopeValue || '(empty)'}`),
+      ].join('\n'),
+    };
+  }
+
+  return { ok: true, grant };
+}
+
+function denied(message: string): DeviceGrantDecision {
+  return { ok: false, errorCode: 'PERMISSION_DENIED', message };
+}
+
+function normalizeOperations(operations: DeviceGrantOperation[]): DeviceGrantOperation[] {
+  const unique = new Set<DeviceGrantOperation>();
+  for (const operation of operations) {
+    if (isDeviceGrantOperation(operation)) unique.add(operation);
+  }
+  return [...unique];
+}
+
+function isDeviceGrantOperation(value: string): value is DeviceGrantOperation {
+  return value === 'read_file'
+    || value === 'write_file'
+    || value === 'edit_file'
+    || value === 'send_file'
+    || value === 'execute_shell'
+    || value === 'glob'
+    || value === 'grep'
+    || value === 'browser_control'
+    || value === 'desktop_control';
+}
+
+function normalizeSource(value: MessageSource | string | undefined): MessageSource {
+  if (value === 'catscompany' || value === 'feishu' || value === 'weixin' || value === 'cli') {
+    return value;
+  }
+  return 'unknown';
+}
+
+function normalizeStatus(value?: UserDeviceStatus): UserDeviceStatus {
+  if (value === 'online' || value === 'offline') return value;
+  return 'unknown';
+}
+
+function normalizeIdentityTrust(value?: UserDevice['identityTrust']): UserDevice['identityTrust'] {
+  if (value === 'server_canonical' || value === 'legacy_context' || value === 'untrusted') return value;
+  return 'untrusted';
+}
+
+function normalizeId(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const text = value.trim();
+  return text || undefined;
+}
+
+function normalizeTime(value: unknown): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) return undefined;
+  return value;
+}
+
+function normalizeTtl(value: unknown): number {
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) return value;
+  return DEFAULT_DEVICE_GRANT_TTL_MS;
+}
+
+function pruneUndefined<T>(value: T): T {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return value;
+  const record = value as Record<string, unknown>;
+  for (const key of Object.keys(record)) {
+    if (record[key] === undefined) {
+      delete record[key];
+    }
+  }
+  return value;
+}

--- a/src/core/message-session-manager.ts
+++ b/src/core/message-session-manager.ts
@@ -2,6 +2,8 @@ import { AgentSession, AgentServices, SystemPromptProvider } from './agent-sessi
 import { Logger } from '../utils/logger';
 import { composeSessionSystemPromptProvider } from './session-system-prompt';
 import { SubAgentManager } from './sub-agent-manager';
+import type { SessionRoute } from '../types/session-identity';
+import { isSessionRoute } from './session-router';
 
 /** 默认会话过期时间：60 分钟 */
 const DEFAULT_SESSION_TTL = 60 * 60 * 1000;
@@ -11,6 +13,8 @@ export interface MessageSessionManagerOptions {
   systemPromptProviderFactory?: (sessionKey: string) => SystemPromptProvider;
   skillReloadHandler?: () => Promise<void>;
 }
+
+export type SessionKeyInput = string | SessionRoute;
 
 /**
  * MessageSessionManager - 统一的消息会话生命周期管理器
@@ -53,7 +57,8 @@ export class MessageSessionManager {
   }
 
   /** 获取已存在的会话；不会因为查询而新建会话 */
-  get(key: string): AgentSession | null {
+  get(input: SessionKeyInput): AgentSession | null {
+    const { key } = this.normalizeSessionInput(input);
     const session = this.sessions.get(key) || null;
     if (session) {
       session.lastActiveAt = Date.now();
@@ -70,10 +75,11 @@ export class MessageSessionManager {
    * 获取或创建会话
    * @param key - 会话唯一标识（如 cc_user:usr3, feishu_group:chat123）
    */
-  getOrCreate(key: string): AgentSession {
+  getOrCreate(input: SessionKeyInput): AgentSession {
+    const { key, route } = this.normalizeSessionInput(input);
     let session = this.sessions.get(key);
     if (!session) {
-      session = new AgentSession(key, this.agentServices, this.sessionType);
+      session = new AgentSession(key, this.agentServices, this.sessionType, route);
       if (this.systemPromptProviderFactory) {
         session.setSystemPromptProvider(composeSessionSystemPromptProvider(
           this.systemPromptProviderFactory(key),
@@ -98,6 +104,13 @@ export class MessageSessionManager {
   injectContext(key: string, text: string): void {
     const session = this.getOrCreate(key);
     session.injectContext(text);
+  }
+
+  private normalizeSessionInput(input: SessionKeyInput): { key: string; route?: SessionRoute } {
+    if (isSessionRoute(input)) {
+      return { key: input.sessionKey, route: input };
+    }
+    return { key: input };
   }
 
   /** 启动定期清理（每分钟检查一次） */

--- a/src/core/runtime-context-builder.ts
+++ b/src/core/runtime-context-builder.ts
@@ -1,0 +1,248 @@
+import { Message } from '../types';
+import type {
+  ExecutionScope,
+  MessageSource,
+  MessageTopicType,
+  ScopedDeviceGrant,
+  ScopedDeviceSelection,
+  ScopedLocalDeviceGrant,
+  ScopedLocalFileGrant,
+  SessionRoute,
+} from '../types/session-identity';
+import { parseSessionKeyV2 } from './session-router';
+
+export const TRANSIENT_RUNTIME_CONTEXT_PREFIX = '[transient_runtime_context]';
+
+export interface BuildRuntimeContextParams {
+  sessionKey: string;
+  sessionType?: string;
+  sessionRoute?: SessionRoute;
+  executionScope?: ExecutionScope;
+  localDeviceGrant?: ScopedLocalDeviceGrant;
+  deviceGrants?: ScopedDeviceGrant[];
+  deviceSelection?: ScopedDeviceSelection;
+  localFileGrants?: ScopedLocalFileGrant[];
+}
+
+interface RuntimeContextSnapshot {
+  schema: 'xiaoba.runtime_context.v1';
+  session: {
+    key: string;
+    legacyKey?: string;
+    source: MessageSource;
+    topic: {
+      id: string;
+      type: MessageTopicType;
+    };
+    agent?: {
+      id?: string;
+    };
+  };
+  turn: {
+    actorUserId: string;
+    messageId?: string;
+    channelSeq?: number;
+    identityTrust: string;
+    identitySource?: string;
+    permissionsSource?: string;
+    isTrusted?: boolean;
+  };
+  execution: {
+    mode: 'backend_controlled';
+    scopeSource: 'execution_scope' | 'session_route' | 'session_key';
+    toolsUseBackendScope: true;
+    localDevice?: {
+      source: MessageSource;
+      deviceId?: string;
+    };
+    userDevices?: Array<{
+      grantId: string;
+      deviceId: string;
+      displayName?: string;
+      operations: string[];
+      status: string;
+      expiresAt: number;
+    }>;
+    deviceSelection?: {
+      status: string;
+      selectionSource?: string;
+      selectedDevice?: {
+        deviceId: string;
+        displayName?: string;
+        operations?: string[];
+      };
+      candidates?: Array<{
+        deviceId: string;
+        displayName?: string;
+        operations?: string[];
+      }>;
+      candidateCount?: number;
+    };
+    localFiles?: Array<{
+      ref?: string;
+      fileName: string;
+      fileType: string;
+      operations: string[];
+      expiresAt: number;
+    }>;
+  };
+  rules: string[];
+}
+
+export function buildRuntimeContextMessage(params: BuildRuntimeContextParams): Message | null {
+  const snapshot = buildRuntimeContextSnapshot(params);
+  if (!snapshot) return null;
+
+  return {
+    role: 'system',
+    content: `${TRANSIENT_RUNTIME_CONTEXT_PREFIX}\n${JSON.stringify(snapshot, null, 2)}`,
+  };
+}
+
+export function buildRuntimeContextSnapshot(params: BuildRuntimeContextParams): RuntimeContextSnapshot | null {
+  const parsedKey = parseSessionKeyV2(params.sessionKey);
+  const route = params.sessionRoute;
+  const scope = params.executionScope;
+  const source = route?.source
+    ?? scope?.source
+    ?? parsedKey?.source
+    ?? sourceFromSessionType(params.sessionType);
+  const topicId = scope?.topicId
+    ?? route?.topicId
+    ?? parsedKey?.topicId;
+  const topicType = scope?.topicType
+    ?? route?.topicType
+    ?? parsedKey?.topicType;
+
+  if (!source || !topicId || !topicType) {
+    return null;
+  }
+
+  const actorUserId = scope?.actorUserId
+    ?? route?.actorUserId
+    ?? 'unknown_actor';
+  const agentId = scope?.agentId
+    ?? route?.agentId
+    ?? parsedKey?.agentId;
+  const identityTrust = scope?.identityTrust
+    ?? route?.identityTrust
+    ?? 'legacy_context';
+  const scopeSource = scope
+    ? 'execution_scope'
+    : route
+      ? 'session_route'
+      : 'session_key';
+
+  return pruneUndefined({
+    schema: 'xiaoba.runtime_context.v1',
+    session: pruneUndefined({
+      key: params.sessionKey,
+      legacyKey: scope?.legacySessionKey ?? route?.legacySessionKey,
+      source,
+      topic: {
+        id: topicId,
+        type: topicType,
+      },
+      agent: agentId
+        ? pruneUndefined({
+          id: agentId,
+        })
+        : undefined,
+    }),
+    turn: pruneUndefined({
+      actorUserId,
+      messageId: route?.messageId,
+      channelSeq: scope?.channelSeq ?? route?.channelSeq,
+      identityTrust,
+      identitySource: route?.identitySource,
+      permissionsSource: scope?.permissionsSource,
+      isTrusted: scope?.isTrusted,
+    }),
+    execution: pruneUndefined({
+      mode: 'backend_controlled',
+      scopeSource,
+      toolsUseBackendScope: true,
+      localDevice: sanitizeLocalDevice(params.localDeviceGrant),
+      userDevices: sanitizeDeviceGrants(params.deviceGrants),
+      deviceSelection: sanitizeDeviceSelection(params.deviceSelection),
+      localFiles: sanitizeLocalFiles(params.localFileGrants),
+    }),
+    rules: [
+      'Treat session.topic as the current conversation target and turn.actorUserId as the current speaker.',
+      'Do not ask the user to provide internal IDs from this context; use tools and backend scope when needed.',
+      'Use execution.deviceSelection as the backend-selected target when a tool requires a user device.',
+      'If execution.deviceSelection.status is needs_selection or unavailable, ask the user to choose an available device by display name before using device tools.',
+      'Do not infer or expose local filesystem paths. Use attachment refs when a tool requires a file reference.',
+    ],
+  }) as RuntimeContextSnapshot;
+}
+
+function sanitizeLocalDevice(grant?: ScopedLocalDeviceGrant): RuntimeContextSnapshot['execution']['localDevice'] | undefined {
+  if (!grant) return undefined;
+  return pruneUndefined({
+    source: grant.source,
+    deviceId: grant.deviceId,
+  });
+}
+
+function sanitizeDeviceGrants(grants?: ScopedDeviceGrant[]): RuntimeContextSnapshot['execution']['userDevices'] | undefined {
+  if (!grants || grants.length === 0) return undefined;
+  return grants.map(grant => pruneUndefined({
+    grantId: grant.grantId,
+    deviceId: grant.deviceId,
+    displayName: grant.deviceDisplayName,
+    operations: [...grant.operations],
+    status: grant.status,
+    expiresAt: grant.expiresAt,
+  }));
+}
+
+function sanitizeDeviceSelection(selection?: ScopedDeviceSelection): RuntimeContextSnapshot['execution']['deviceSelection'] | undefined {
+  if (!selection) return undefined;
+  return pruneUndefined({
+    status: selection.status,
+    selectionSource: selection.selectionSource,
+    selectedDevice: selection.selectedDeviceId
+      ? pruneUndefined({
+        deviceId: selection.selectedDeviceId,
+        displayName: selection.selectedDeviceDisplayName,
+        operations: selection.selectedDeviceOperations ? [...selection.selectedDeviceOperations] : undefined,
+      })
+      : undefined,
+    candidates: selection.candidates?.map(candidate => pruneUndefined({
+      deviceId: candidate.deviceId,
+      displayName: candidate.displayName,
+      operations: candidate.operations ? [...candidate.operations] : undefined,
+    })),
+    candidateCount: selection.candidateCount,
+  });
+}
+
+function sanitizeLocalFiles(grants?: ScopedLocalFileGrant[]): RuntimeContextSnapshot['execution']['localFiles'] | undefined {
+  if (!grants || grants.length === 0) return undefined;
+  return grants.map(grant => pruneUndefined({
+    ref: grant.attachmentRef,
+    fileName: grant.fileName,
+    fileType: grant.fileType,
+    operations: [...grant.operations],
+    expiresAt: grant.expiresAt,
+  }));
+}
+
+function sourceFromSessionType(sessionType?: string): MessageSource | undefined {
+  if (sessionType === 'catscompany' || sessionType === 'feishu' || sessionType === 'weixin' || sessionType === 'cli') {
+    return sessionType;
+  }
+  return undefined;
+}
+
+function pruneUndefined<T>(value: T): T {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return value;
+  const record = value as Record<string, unknown>;
+  for (const key of Object.keys(record)) {
+    if (record[key] === undefined) {
+      delete record[key];
+    }
+  }
+  return value;
+}

--- a/src/core/session-lifecycle-manager.ts
+++ b/src/core/session-lifecycle-manager.ts
@@ -5,6 +5,7 @@ import { RuntimeFeedbackInbox } from './runtime-feedback-inbox';
 
 export interface SessionLifecycleManagerOptions {
   sessionKey: string;
+  legacySessionKey?: string;
   runtimeFeedbackInbox: RuntimeFeedbackInbox;
   sessionStore?: SessionStore;
 }
@@ -32,17 +33,18 @@ export class SessionLifecycleManager {
   }
 
   markRestoreFromStore(): boolean {
-    if (!this.sessionStore.hasSession(this.options.sessionKey)) {
+    const restoreKey = this.resolveExistingSessionKey();
+    if (!restoreKey) {
       this.pendingRestore = undefined;
       return false;
     }
-    const messages = this.sessionStore.loadContext(this.options.sessionKey);
+    const messages = this.sessionStore.loadContext(restoreKey);
     if (messages.length === 0) {
       this.pendingRestore = undefined;
       return false;
     }
     this.pendingRestore = messages;
-    Logger.info(`[会话 ${this.options.sessionKey}] 标记从 DB 恢复 ${messages.length} 条消息`);
+    Logger.info(`[会话 ${this.options.sessionKey}] 标记从 DB 恢复 ${messages.length} 条消息${restoreKey === this.options.sessionKey ? '' : ` (legacy: ${restoreKey})`}`);
     return true;
   }
 
@@ -64,6 +66,10 @@ export class SessionLifecycleManager {
   clear(): ResetSessionStateResult {
     this.sessionStore.deleteSession(this.options.sessionKey);
     this.sessionStore.deleteRuntimeState(this.options.sessionKey);
+    if (this.options.legacySessionKey && this.options.legacySessionKey !== this.options.sessionKey) {
+      this.sessionStore.deleteSession(this.options.legacySessionKey);
+      this.sessionStore.deleteRuntimeState(this.options.legacySessionKey);
+    }
     return this.reset();
   }
 
@@ -72,7 +78,12 @@ export class SessionLifecycleManager {
   }
 
   loadCurrentDirectory(): string | undefined {
-    return this.sessionStore.loadRuntimeState(this.options.sessionKey).currentDirectory;
+    const current = this.sessionStore.loadRuntimeState(this.options.sessionKey).currentDirectory;
+    if (current) return current;
+    if (!this.options.legacySessionKey || this.options.legacySessionKey === this.options.sessionKey) {
+      return undefined;
+    }
+    return this.sessionStore.loadRuntimeState(this.options.legacySessionKey).currentDirectory;
   }
 
   saveCurrentDirectory(currentDirectory: string): void {
@@ -90,5 +101,16 @@ export class SessionLifecycleManager {
 
   hasPendingRestore(): boolean {
     return !!this.pendingRestore;
+  }
+
+  private resolveExistingSessionKey(): string | undefined {
+    if (this.sessionStore.hasSession(this.options.sessionKey)) {
+      return this.options.sessionKey;
+    }
+    const legacy = this.options.legacySessionKey;
+    if (legacy && legacy !== this.options.sessionKey && this.sessionStore.hasSession(legacy)) {
+      return legacy;
+    }
+    return undefined;
   }
 }

--- a/src/core/session-router.ts
+++ b/src/core/session-router.ts
@@ -1,0 +1,266 @@
+import type {
+  IdentityTrustLevel,
+  ExecutionScope,
+  MessageEnvelope,
+  MessageSource,
+  MessageTopicType,
+  SessionRoute,
+} from '../types/session-identity';
+import type { ParsedFeishuMessage } from '../feishu/types';
+import type { WeixinMessage } from '../weixin/types';
+
+export const SESSION_KEY_V2_PREFIX = 'session:v2';
+
+export interface CreateSessionRouteInput {
+  source: MessageSource;
+  topicId: string;
+  topicType: MessageTopicType;
+  actorUserId: string;
+  agentId?: string;
+  agentBodyId?: string;
+  messageId?: string;
+  channelSeq?: number;
+  identityTrust?: IdentityTrustLevel;
+  identitySource?: string;
+  legacySessionKey?: string;
+}
+
+export interface ParsedSessionKeyV2 {
+  version: 2;
+  source: MessageSource;
+  topicType: MessageTopicType;
+  topicId: string;
+  agentId?: string;
+}
+
+export function createSessionRoute(input: CreateSessionRouteInput): SessionRoute {
+  const source = normalizeSource(input.source);
+  const topicType = normalizeTopicType(input.topicType);
+  const actorUserId = normalizeId(input.actorUserId) || 'unknown_actor';
+  const topicId = normalizeId(input.topicId) || actorUserId;
+  const agentId = normalizeOptionalId(input.agentId);
+  const agentBodyId = normalizeOptionalId(input.agentBodyId);
+  const identityTrust = input.identityTrust || 'legacy_context';
+  const identitySource = normalizeOptionalId(input.identitySource);
+  const sessionKey = buildSessionKeyV2({ source, topicType, topicId, agentId });
+  const legacySessionKey = normalizeOptionalId(input.legacySessionKey);
+
+  return {
+    version: 2,
+    source,
+    sessionKey,
+    legacySessionKey,
+    topicId,
+    topicType,
+    actorUserId,
+    agentId,
+    agentBodyId,
+    messageId: normalizeOptionalId(input.messageId),
+    channelSeq: normalizeSeq(input.channelSeq),
+    identityTrust,
+    identitySource,
+    identity: {
+      source,
+      topicId,
+      topicType,
+      actorUserId,
+      agentId,
+      agentBodyId,
+      identityTrust,
+      identitySource,
+    },
+  };
+}
+
+export function createCatsCoSessionRoute(envelope: MessageEnvelope): SessionRoute {
+  return createSessionRoute({
+    source: 'catscompany',
+    topicId: envelope.topicId,
+    topicType: envelope.topicType,
+    actorUserId: envelope.actorUserId,
+    agentId: envelope.agentId,
+    agentBodyId: envelope.agentBodyId,
+    messageId: envelope.messageId,
+    channelSeq: envelope.channelSeq,
+    identityTrust: envelope.identityTrust,
+    identitySource: envelope.identitySource,
+    legacySessionKey: envelope.legacySessionKey || buildLegacyCatsCoSessionKey(
+      envelope.topicType,
+      envelope.topicId,
+      envelope.actorUserId,
+    ),
+  });
+}
+
+export function createFeishuSessionRoute(message: ParsedFeishuMessage): SessionRoute {
+  const topicType: MessageTopicType = message.chatType === 'group' ? 'group' : 'p2p';
+  const topicId = normalizeId(message.chatId) || normalizeId(message.senderId) || 'unknown_chat';
+  return createSessionRoute({
+    source: 'feishu',
+    topicId,
+    topicType,
+    actorUserId: message.senderId,
+    messageId: message.messageId,
+    identityTrust: 'legacy_context',
+    identitySource: 'feishu.event',
+    legacySessionKey: buildLegacyFeishuSessionKey(topicType, topicId, message.senderId),
+  });
+}
+
+export function createFeishuBridgeSessionRoute(input: {
+  chatId: string;
+  from?: string;
+  messageId?: string;
+}): SessionRoute {
+  const topicId = normalizeId(input.chatId) || 'unknown_chat';
+  const actorUserId = normalizeId(input.from) || 'bridge_peer';
+  return createSessionRoute({
+    source: 'feishu',
+    topicId,
+    topicType: 'group',
+    actorUserId,
+    messageId: input.messageId,
+    identityTrust: 'legacy_context',
+    identitySource: 'feishu.bridge',
+    legacySessionKey: `group:${topicId}`,
+  });
+}
+
+export function createWeixinSessionRoute(message: WeixinMessage): SessionRoute {
+  const actorUserId = normalizeId(message.from?.id) || 'unknown_user';
+  return createSessionRoute({
+    source: 'weixin',
+    topicId: actorUserId,
+    topicType: 'p2p',
+    actorUserId,
+    messageId: message.message_id,
+    identityTrust: 'legacy_context',
+    identitySource: 'weixin.ilink',
+    legacySessionKey: `user:${actorUserId}`,
+  });
+}
+
+export function createExecutionScopeFromRoute(route: SessionRoute): ExecutionScope {
+  return {
+    source: route.source,
+    sessionKey: route.sessionKey,
+    legacySessionKey: route.legacySessionKey,
+    topicId: route.topicId,
+    topicType: route.topicType,
+    actorUserId: route.actorUserId,
+    agentId: route.agentId,
+    agentBodyId: route.agentBodyId,
+    channelSeq: route.channelSeq,
+    identityTrust: route.identityTrust,
+    isTrusted: route.identityTrust === 'server_canonical',
+  };
+}
+
+export function buildSessionKeyV2(input: {
+  source: MessageSource;
+  topicType: MessageTopicType;
+  topicId: string;
+  agentId?: string;
+}): string {
+  const parts = [
+    SESSION_KEY_V2_PREFIX,
+    encodeKeyPart(normalizeSource(input.source)),
+    encodeKeyPart(normalizeTopicType(input.topicType)),
+    encodeKeyPart(normalizeId(input.topicId) || 'unknown_topic'),
+  ];
+  const agentId = normalizeOptionalId(input.agentId);
+  if (agentId) {
+    parts.push('agent', encodeKeyPart(agentId));
+  }
+  return parts.join(':');
+}
+
+export function parseSessionKeyV2(sessionKey: string): ParsedSessionKeyV2 | undefined {
+  const parts = sessionKey.split(':');
+  if (parts.length < 5 || parts[0] !== 'session' || parts[1] !== 'v2') return undefined;
+  const source = normalizeSource(decodeKeyPart(parts[2]));
+  const topicType = normalizeTopicType(decodeKeyPart(parts[3]));
+  const topicId = normalizeId(decodeKeyPart(parts[4]));
+  if (!topicId) return undefined;
+  let agentId: string | undefined;
+  if (parts[5] === 'agent' && parts[6]) {
+    agentId = normalizeOptionalId(decodeKeyPart(parts[6]));
+  }
+  return {
+    version: 2,
+    source,
+    topicType,
+    topicId,
+    agentId,
+  };
+}
+
+export function isSessionRoute(value: unknown): value is SessionRoute {
+  return Boolean(
+    value
+    && typeof value === 'object'
+    && (value as SessionRoute).version === 2
+    && typeof (value as SessionRoute).sessionKey === 'string',
+  );
+}
+
+export function buildLegacyCatsCoSessionKey(
+  topicType: MessageTopicType,
+  topicId: string,
+  actorUserId: string,
+): string {
+  if (topicType === 'group') {
+    return `cc_group:${topicId || 'unknown'}`;
+  }
+  return `cc_user:${actorUserId || 'unknown'}`;
+}
+
+export function buildLegacyFeishuSessionKey(
+  topicType: MessageTopicType,
+  topicId: string,
+  actorUserId: string,
+): string {
+  if (topicType === 'group') {
+    return `group:${topicId || 'unknown'}`;
+  }
+  return `user:${actorUserId || 'unknown'}`;
+}
+
+function normalizeSource(value: MessageSource | string | undefined): MessageSource {
+  if (value === 'catscompany' || value === 'feishu' || value === 'weixin' || value === 'cli') {
+    return value;
+  }
+  return 'unknown';
+}
+
+function normalizeTopicType(value: MessageTopicType | string | undefined): MessageTopicType {
+  if (value === 'p2p' || value === 'group') return value;
+  return 'unknown';
+}
+
+function normalizeId(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const text = value.trim();
+  return text || undefined;
+}
+
+function normalizeOptionalId(value: unknown): string | undefined {
+  return normalizeId(value);
+}
+
+function normalizeSeq(value: unknown): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return undefined;
+  return value;
+}
+
+function encodeKeyPart(value: string): string {
+  return encodeURIComponent(value);
+}
+
+function decodeKeyPart(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}

--- a/src/core/session-surface.ts
+++ b/src/core/session-surface.ts
@@ -15,7 +15,7 @@ const CATSCO_FILE_SELECTION_INSTRUCTION = [
   '- tmp/downloads/... is the local cache for files/images received from chat. It is not the user\'s general local file library.',
   '- If the user asks for a new/local file or says they have not sent it before, do not reuse files from tmp/downloads/... or old conversation paths.',
   '- If the user did not provide an exact path, first ask for the location or search likely local folders such as Desktop, Downloads, Documents, Pictures, or an explicit path the user mentioned.',
-  '- Only use tmp/downloads/... paths that are shown in the current user turn as authorized attachment paths; old attachment paths may be denied by local file grants.',
+  '- Use current catsco_attachment:<id> references for received attachments; local tmp/downloads paths are backend-only and should not be guessed or reused.',
 ].join('\n');
 
 export function resolveSessionSurface(sessionKey: string, sessionType?: string): SessionSurface {

--- a/src/core/session-surface.ts
+++ b/src/core/session-surface.ts
@@ -15,7 +15,7 @@ const CATSCO_FILE_SELECTION_INSTRUCTION = [
   '- tmp/downloads/... is the local cache for files/images received from chat. It is not the user\'s general local file library.',
   '- If the user asks for a new/local file or says they have not sent it before, do not reuse files from tmp/downloads/... or old conversation paths.',
   '- If the user did not provide an exact path, first ask for the location or search likely local folders such as Desktop, Downloads, Documents, Pictures, or an explicit path the user mentioned.',
-  '- Only reuse tmp/downloads/... when the user clearly asks to resend/open an earlier chat attachment.',
+  '- Only use tmp/downloads/... paths that are shown in the current user turn as authorized attachment paths; old attachment paths may be denied by local file grants.',
 ].join('\n');
 
 export function resolveSessionSurface(sessionKey: string, sessionType?: string): SessionSurface {

--- a/src/core/session-surface.ts
+++ b/src/core/session-surface.ts
@@ -1,3 +1,5 @@
+import { parseSessionKeyV2 } from './session-router';
+
 export type SessionSurface = 'cli' | 'feishu' | 'catscompany' | 'weixin';
 
 const AUTO_SEND_MODE_INSTRUCTION = `【消息模式】你的每次文本输出都会立即自动发送给用户。
@@ -19,6 +21,14 @@ const CATSCO_FILE_SELECTION_INSTRUCTION = [
 ].join('\n');
 
 export function resolveSessionSurface(sessionKey: string, sessionType?: string): SessionSurface {
+  const parsedV2 = parseSessionKeyV2(sessionKey);
+  if (parsedV2) {
+    if (parsedV2.source === 'catscompany') return 'catscompany';
+    if (parsedV2.source === 'feishu') return 'feishu';
+    if (parsedV2.source === 'weixin') return 'weixin';
+    return 'cli';
+  }
+
   const normalizedSessionType = (sessionType || '').toLowerCase();
   if (normalizedSessionType === 'weixin') return 'weixin';
   if (normalizedSessionType === 'feishu') return 'feishu';
@@ -35,9 +45,10 @@ export function resolveSessionSurface(sessionKey: string, sessionType?: string):
 
 export function composeSurfacePrompt(sessionKey: string, sessionType?: string): string | undefined {
   const surface = resolveSessionSurface(sessionKey, sessionType);
+  const parsedV2 = parseSessionKeyV2(sessionKey);
 
   if (surface === 'feishu') {
-    const isGroup = sessionKey.startsWith('group:');
+    const isGroup = parsedV2 ? parsedV2.topicType === 'group' : sessionKey.startsWith('group:');
     const chatType = isGroup ? '群聊' : '私聊';
     return `[surface:feishu:${isGroup ? 'group' : 'private'}]\n当前是飞书${chatType}会话。\n${AUTO_SEND_MODE_INSTRUCTION}`;
   }

--- a/src/core/turn-context-builder.ts
+++ b/src/core/turn-context-builder.ts
@@ -1,4 +1,12 @@
 import { Message } from '../types';
+import type {
+  ExecutionScope,
+  ScopedDeviceGrant,
+  ScopedDeviceSelection,
+  ScopedLocalDeviceGrant,
+  ScopedLocalFileGrant,
+  SessionRoute,
+} from '../types/session-identity';
 import {
   SessionSkillRuntime,
   TRANSIENT_SKILLS_LIST_PREFIX,
@@ -9,6 +17,10 @@ import {
   TRANSIENT_SUBAGENT_STATUS_PREFIX,
   buildSubAgentStatusMessage,
 } from './sub-agent-observation';
+import {
+  TRANSIENT_RUNTIME_CONTEXT_PREFIX,
+  buildRuntimeContextMessage,
+} from './runtime-context-builder';
 
 const TRANSIENT_PLAN_STATUS_PREFIX = '[transient_plan_status]';
 const TRANSIENT_RUNNER_HINT_PREFIX = '[transient_runner_hint]';
@@ -16,6 +28,13 @@ const TRANSIENT_SOFT_CHECK_PREFIX = '[transient_soft_check]';
 
 export interface BuildTurnContextParams {
   sessionKey: string;
+  sessionType?: string;
+  sessionRoute?: SessionRoute;
+  executionScope?: ExecutionScope;
+  localDeviceGrant?: ScopedLocalDeviceGrant;
+  deviceGrants?: ScopedDeviceGrant[];
+  deviceSelection?: ScopedDeviceSelection;
+  localFileGrants?: ScopedLocalFileGrant[];
   durableMessages: Message[];
   runtimeFeedback: string[];
   skillRuntime: SessionSkillRuntime;
@@ -35,6 +54,7 @@ export interface BuildTurnContextResult {
 export class TurnContextBuilder {
   async build(params: BuildTurnContextParams): Promise<BuildTurnContextResult> {
     const contextMessages = [...params.durableMessages];
+    this.injectRuntimeContext(contextMessages, params);
     this.injectRuntimeFeedback(contextMessages, params.runtimeFeedback);
     this.injectPlanStatus(contextMessages, params.planRuntime);
     this.injectSubAgentStatus(contextMessages, params.sessionKey);
@@ -60,8 +80,24 @@ export class TurnContextBuilder {
       if (msg.content.startsWith(TRANSIENT_RUNNER_HINT_PREFIX)) return false;
       if (msg.content.startsWith(TRANSIENT_SOFT_CHECK_PREFIX)) return false;
       if (msg.content.startsWith(TRANSIENT_SKILLS_LIST_PREFIX)) return false;
+      if (msg.content.startsWith(TRANSIENT_RUNTIME_CONTEXT_PREFIX)) return false;
       return true;
     });
+  }
+
+  private injectRuntimeContext(messages: Message[], params: BuildTurnContextParams): void {
+    const message = buildRuntimeContextMessage({
+      sessionKey: params.sessionKey,
+      sessionType: params.sessionType,
+      sessionRoute: params.sessionRoute,
+      executionScope: params.executionScope,
+      localDeviceGrant: params.localDeviceGrant,
+      deviceGrants: params.deviceGrants,
+      deviceSelection: params.deviceSelection,
+      localFileGrants: params.localFileGrants,
+    });
+    if (!message) return;
+    this.insertBeforeLastUser(messages, message);
   }
 
   private injectRuntimeFeedback(messages: Message[], runtimeFeedback: string[]): void {

--- a/src/feishu/index.ts
+++ b/src/feishu/index.ts
@@ -14,6 +14,14 @@ import { ChimeInJudge } from '../bridge/chime-in-judge';
 import { ChannelCallbacks } from '../types/tool';
 import { AdapterRuntimeBundle, createAdapterRuntime } from '../runtime/adapter-runtime';
 import { randomUUID } from 'crypto';
+import {
+  createExecutionScopeFromRoute,
+  createFeishuBridgeSessionRoute,
+  createFeishuSessionRoute,
+  createSessionRoute,
+  parseSessionKeyV2,
+} from '../core/session-router';
+import type { SessionRoute } from '../types/session-identity';
 
 interface PendingAttachment {
   fileName: string;
@@ -35,6 +43,7 @@ interface QueuedMessage {
   userText: string;
   chatId: string;
   senderId: string;
+  sessionRoute: SessionRoute;
   source?: 'user' | 'subagent_feedback';
   runtimeFeedback?: RuntimeFeedbackInput[];
 }
@@ -207,6 +216,7 @@ export class FeishuBot {
     opts?: {
       sessionKey?: string;
       senderId?: string;
+      isGroup?: boolean;
       /** 可选的 reply 拦截器（如 bridge 场景需要收集回复文本） */
       replyInterceptor?: (text: string) => void;
     },
@@ -217,7 +227,11 @@ export class FeishuBot {
         opts?.replyInterceptor?.(text);
         await this.sender.reply(targetChatId, text);
         // 广播给所有 bridge peer（仅群聊）
-        const isGroupChat = !opts?.sessionKey || opts.sessionKey.startsWith('group:');
+        const parsedRoute = opts?.sessionKey ? parseSessionKeyV2(opts.sessionKey) : undefined;
+        const inferredGroup = parsedRoute
+          ? parsedRoute.topicType === 'group'
+          : (!opts?.sessionKey || opts.sessionKey.startsWith('group:'));
+        const isGroupChat = opts?.isGroup ?? inferredGroup;
         if (isGroupChat && this.bridgeClient && this.bridgeConfig) {
           this.bridgeClient.broadcast({
             from: this.bridgeConfig.name,
@@ -254,9 +268,9 @@ export class FeishuBot {
     }
 
 
-    const key = msg.chatType === 'group'
-      ? `group:${msg.chatId}`
-      : `user:${msg.senderId}`;
+    const route = createFeishuSessionRoute(msg);
+    const key = route.sessionKey;
+    const isGroup = msg.chatType === 'group';
 
     // ── 拦截：如果当前 session 正在等待回答，按 sender 精确匹配 ──
     const pendingId = this.pendingAnswerBySession.get(key);
@@ -276,14 +290,14 @@ export class FeishuBot {
     }
 
     // 获取或创建会话（传入 chatId 用于过期时主动唤醒）
-    const session = this.sessionManager.getOrCreate(key);
+    const session = this.sessionManager.getOrCreate(route);
 
     // 注册持久化平台回调到 SubAgentManager
     // 子智能体完成后通过 injectMessage 通知主 Agent
     const subAgentManager = SubAgentManager.getInstance();
     subAgentManager.registerPlatformCallbacks(key, {
       injectMessage: async (text: string) => {
-        await this.handleSubAgentFeedback(key, msg.chatId, msg.senderId, text);
+        await this.handleSubAgentFeedback(key, msg.chatId, msg.senderId, text, route);
       },
     });
 
@@ -355,7 +369,7 @@ export class FeishuBot {
         Logger.warning(`[${key}] 检测到用户中断请求，已请求中止当前回合`);
       }
       const queue = this.messageQueue.get(key) ?? [];
-      queue.push({ userText, chatId: msg.chatId, senderId: msg.senderId, source: 'user', runtimeFeedback });
+      queue.push({ userText, chatId: msg.chatId, senderId: msg.senderId, sessionRoute: route, source: 'user', runtimeFeedback });
       this.messageQueue.set(key, queue);
       Logger.info(`[${key}] 主会话忙，消息已入队 (队列长度: ${queue.length})`);
       return;
@@ -365,10 +379,16 @@ export class FeishuBot {
     const channel = this.buildChannel(msg.chatId, {
       sessionKey: key,
       senderId: msg.senderId,
+      isGroup,
     });
 
     try {
-      const result = await session.handleMessage(userText, { channel, runtimeFeedback });
+      const result = await session.handleMessage(userText, {
+        channel,
+        sessionRoute: route,
+        executionScope: createExecutionScopeFromRoute(route),
+        runtimeFeedback,
+      });
       if (result.text === BUSY_MESSAGE || result.text === ERROR_MESSAGE) {
         await this.sender.reply(msg.chatId, result.text);
       }
@@ -389,11 +409,13 @@ export class FeishuBot {
     chatId: string,
     senderId: string,
     text: string,
+    sessionRoute?: SessionRoute,
   ): Promise<void> {
     const session = this.sessionManager.getOrCreate(sessionKey);
+    const route = sessionRoute ?? this.createRouteFromSessionKey(sessionKey, senderId);
 
     if (session.isBusy()) {
-      this.enqueueSubAgentFeedback(sessionKey, chatId, senderId, text);
+      this.enqueueSubAgentFeedback(sessionKey, chatId, senderId, text, route);
       Logger.info(`[${sessionKey}] 主会话忙，子智能体反馈已入队`);
       return;
     }
@@ -406,10 +428,12 @@ export class FeishuBot {
     try {
       const result = await session.handleRuntimeObservation(text, {
         channel,
+        sessionRoute: route,
+        executionScope: createExecutionScopeFromRoute(route),
         source: 'subagent_result',
       });
       if (result.text === BUSY_MESSAGE) {
-        this.enqueueSubAgentFeedback(sessionKey, chatId, senderId, text);
+        this.enqueueSubAgentFeedback(sessionKey, chatId, senderId, text, route);
         Logger.info(`[${sessionKey}] 主会话竞态忙碌，子智能体反馈已入队`);
         return;
       }
@@ -422,12 +446,20 @@ export class FeishuBot {
     }
   }
 
-  private enqueueSubAgentFeedback(sessionKey: string, chatId: string, senderId: string, text: string): void {
+  private enqueueSubAgentFeedback(
+    sessionKey: string,
+    chatId: string,
+    senderId: string,
+    text: string,
+    sessionRoute?: SessionRoute,
+  ): void {
+    const route = sessionRoute ?? this.createRouteFromSessionKey(sessionKey, senderId);
     const queue = this.messageQueue.get(sessionKey) ?? [];
     queue.push({
       userText: text,
       chatId,
       senderId,
+      sessionRoute: route,
       source: 'subagent_feedback',
     });
     this.messageQueue.set(sessionKey, queue);
@@ -449,16 +481,22 @@ export class FeishuBot {
     const channel = this.buildChannel(msg.chatId, {
       sessionKey,
       senderId: msg.senderId,
+      isGroup: msg.sessionRoute.topicType === 'group',
     });
+    const executionScope = createExecutionScopeFromRoute(msg.sessionRoute);
 
     try {
       const result = msg.source === 'subagent_feedback'
         ? await session.handleRuntimeObservation(msg.userText, {
           channel,
+          sessionRoute: msg.sessionRoute,
+          executionScope,
           source: 'subagent_result',
         })
         : await session.handleMessage(msg.userText, {
           channel,
+          sessionRoute: msg.sessionRoute,
+          executionScope,
           runtimeFeedback: msg.runtimeFeedback,
         });
       if (result.text === ERROR_MESSAGE) {
@@ -470,6 +508,22 @@ export class FeishuBot {
 
     // 处理期间可能又有新消息入队，递归排空
     await this.drainMessageQueue(sessionKey);
+  }
+
+  private createRouteFromSessionKey(sessionKey: string, senderId: string): SessionRoute {
+    const parsed = parseSessionKeyV2(sessionKey);
+    const legacyGroupId = sessionKey.startsWith('group:') ? sessionKey.slice('group:'.length) : '';
+    const legacyUserId = sessionKey.startsWith('user:') ? sessionKey.slice('user:'.length) : '';
+    return createSessionRoute({
+      source: parsed?.source || 'feishu',
+      topicId: parsed?.topicId || legacyGroupId || legacyUserId || senderId || 'unknown_chat',
+      topicType: parsed?.topicType || (legacyGroupId ? 'group' : legacyUserId ? 'p2p' : 'unknown'),
+      actorUserId: senderId || legacyUserId || 'unknown_actor',
+      agentId: parsed?.agentId,
+      identityTrust: 'legacy_context',
+      identitySource: 'feishu.runtime',
+      legacySessionKey: parsed ? undefined : sessionKey,
+    });
   }
 
   /** 从 Group/*.md 读取已知 chat_id */
@@ -499,8 +553,12 @@ export class FeishuBot {
       return;
     }
 
-    const sessionKey = `group:${msg.chat_id}`;
-    const session = this.sessionManager.getOrCreate(sessionKey);
+    const route = createFeishuBridgeSessionRoute({
+      chatId: msg.chat_id,
+      from: msg.from,
+    });
+    const sessionKey = route.sessionKey;
+    const session = this.sessionManager.getOrCreate(route);
     const text = `${msg.from}: ${msg.content}`;
 
     // 记录到 chime-in judge 的上下文（无论是否触发推理）
@@ -551,13 +609,21 @@ export class FeishuBot {
 
     if (session.isBusy()) {
       const queue = this.messageQueue.get(sessionKey) ?? [];
-      queue.push({ userText: messageText, chatId: msg.chat_id, senderId: '', source: 'user' });
+      queue.push({ userText: messageText, chatId: msg.chat_id, senderId: msg.from || '', sessionRoute: route, source: 'user' });
       this.messageQueue.set(sessionKey, queue);
       return;
     }
-    const channel = this.buildChannel(msg.chat_id);
+    const channel = this.buildChannel(msg.chat_id, {
+      sessionKey,
+      senderId: msg.from || '',
+      isGroup: true,
+    });
     try {
-      await session.handleMessage(messageText, { channel });
+      await session.handleMessage(messageText, {
+        channel,
+        sessionRoute: route,
+        executionScope: createExecutionScopeFromRoute(route),
+      });
     } finally {
       this.clearPendingAnswerBySession(sessionKey);
     }

--- a/src/tools/bash-tool.ts
+++ b/src/tools/bash-tool.ts
@@ -8,6 +8,7 @@ import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from 
 import { Logger } from '../utils/logger';
 import { resolveRuntimeEnvironment } from '../utils/runtime-environment';
 import { isToolAllowed, isBashCommandAllowed } from '../utils/safety';
+import { resolveToolGatewayAccess } from './tool-gateway';
 
 const execAsync = promisify(exec);
 const CWD_MARKER_PREFIX = '__XIAOBA_CWD_MARKER__';
@@ -67,6 +68,14 @@ export class ShellTool implements Tool {
     const commandPermission = isBashCommandAllowed(command);
     if (!commandPermission.allowed) {
       return { ok: false, errorCode: 'PERMISSION_DENIED', message: `Execution blocked: ${commandPermission.reason}` };
+    }
+
+    const gateway = resolveToolGatewayAccess(context, {
+      toolName: this.definition.name,
+      operation: 'execute_shell',
+    });
+    if (!gateway.ok) {
+      return { ok: false, errorCode: gateway.errorCode, message: gateway.message };
     }
 
     if (description) {

--- a/src/tools/device-rpc-tool.ts
+++ b/src/tools/device-rpc-tool.ts
@@ -1,0 +1,167 @@
+import type { DeviceGrantOperation } from '../types/session-identity';
+import type { ToolErrorCode, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
+import type { ToolGatewayDecision } from './tool-gateway';
+
+const REMOTE_TOOL_TIMEOUT_MS = 60_000;
+export const MAX_DEVICE_RPC_TOOL_CONTENT_CHARS = 48_000;
+
+export function isRemoteReadonlyTool(toolName: string, operation: DeviceGrantOperation): boolean {
+  return (toolName === 'read_file' && operation === 'read_file')
+    || (toolName === 'glob' && operation === 'glob')
+    || (toolName === 'grep' && operation === 'grep');
+}
+
+export async function executeRemoteReadonlyTool(
+  context: ToolExecutionContext,
+  gateway: ToolGatewayDecision,
+  toolName: 'read_file' | 'glob' | 'grep',
+  operation: DeviceGrantOperation,
+  args: Record<string, unknown>,
+): Promise<ToolExecutionResult | undefined> {
+  if (!gateway.ok || gateway.mode !== 'remote') return undefined;
+
+  if (!isRemoteReadonlyTool(toolName, operation)) {
+    return {
+      ok: false,
+      errorCode: 'PERMISSION_DENIED',
+      message: `远程设备 RPC 当前只允许 read_file / glob / grep，已阻止 ${toolName}。`,
+    };
+  }
+
+  if (!context.deviceRpc) {
+    return {
+      ok: false,
+      errorCode: 'PERMISSION_DENIED',
+      message: '后端选定的设备不是当前运行体，但当前上下文没有远程设备 RPC 通道。',
+    };
+  }
+
+  try {
+    return await context.deviceRpc.executeTool({
+      toolName,
+      operation,
+      args,
+      grant: gateway.grant,
+      timeoutMs: timeoutForGrant(gateway.grant.expiresAt),
+    });
+  } catch (error: any) {
+    return {
+      ok: false,
+      errorCode: mapRpcErrorCode(error),
+      message: `远程设备工具执行失败: ${error?.message || error || 'unknown error'}`,
+      retryable: isRetryableRpcError(error),
+    };
+  }
+}
+
+export function normalizeDeviceRpcToolResultPayload(payload: unknown): ToolExecutionResult {
+  if (!payload || typeof payload !== 'object') {
+    return {
+      ok: false,
+      errorCode: 'TOOL_EXECUTION_ERROR',
+      message: '远程设备返回了无效工具结果。',
+    };
+  }
+  const record = payload as Record<string, unknown>;
+  if (record.ok === true) {
+    return {
+      ok: true,
+      content: normalizeDeviceRpcContent(record.content),
+    };
+  }
+  if (record.ok === false) {
+    return {
+      ok: false,
+      errorCode: normalizeErrorCode(record.errorCode),
+      message: truncateText(String(record.message || '远程设备工具执行失败。')),
+      retryable: Boolean(record.retryable),
+    };
+  }
+  return {
+    ok: false,
+    errorCode: 'TOOL_EXECUTION_ERROR',
+    message: '远程设备返回的工具结果缺少 ok 字段。',
+  };
+}
+
+export function normalizeDeviceRpcToolResultForTransport(result: ToolExecutionResult): ToolExecutionResult {
+  if (!result.ok) {
+    return {
+      ok: false,
+      errorCode: normalizeErrorCode(result.errorCode),
+      message: truncateText(result.message),
+      retryable: Boolean(result.retryable),
+    };
+  }
+  return {
+    ok: true,
+    content: normalizeDeviceRpcContent(result.content),
+  };
+}
+
+function timeoutForGrant(expiresAt: number): number {
+  const remaining = expiresAt - Date.now();
+  if (!Number.isFinite(remaining) || remaining <= 0) return 10_000;
+  return Math.max(5_000, Math.min(REMOTE_TOOL_TIMEOUT_MS, remaining));
+}
+
+function normalizeDeviceRpcContent(content: unknown): string {
+  if (typeof content === 'string') return truncateText(content);
+  if (Array.isArray(content)) {
+    const lines: string[] = [];
+    for (const block of content) {
+      if (!block || typeof block !== 'object') continue;
+      const record = block as Record<string, unknown>;
+      if (record.type === 'text' && typeof record.text === 'string') {
+        lines.push(record.text);
+      } else if (record.type === 'image') {
+        lines.push('[远程设备返回了图片内容块；当前 Device RPC 不转发图片二进制，请让用户以附件方式上传该图片。]');
+      }
+    }
+    return truncateText(lines.join('\n'));
+  }
+  if (content && typeof content === 'object') {
+    const record = content as Record<string, unknown>;
+    if (record._imageForNewMessage) {
+      return '[远程设备读取到图片文件；当前 Device RPC 不转发图片二进制，请让用户以附件方式上传该图片。]';
+    }
+  }
+  return truncateText(String(content ?? ''));
+}
+
+function truncateText(value: string): string {
+  if (value.length <= MAX_DEVICE_RPC_TOOL_CONTENT_CHARS) return value;
+  return [
+    value.slice(0, MAX_DEVICE_RPC_TOOL_CONTENT_CHARS),
+    '',
+    `[远程设备结果超过 ${MAX_DEVICE_RPC_TOOL_CONTENT_CHARS} 字符，已截断。请用更精确的 path/pattern/limit/offset 继续读取。]`,
+  ].join('\n');
+}
+
+function normalizeErrorCode(value: unknown): ToolErrorCode {
+  const text = String(value || '').trim();
+  if (
+    text === 'TOOL_NOT_FOUND'
+    || text === 'INVALID_TOOL_ARGUMENTS'
+    || text === 'TOOL_EXECUTION_ERROR'
+    || text === 'RATE_LIMIT'
+    || text === 'PERMISSION_DENIED'
+    || text === 'FILE_NOT_FOUND'
+    || text === 'EXECUTION_TIMEOUT'
+  ) {
+    return text;
+  }
+  return 'TOOL_EXECUTION_ERROR';
+}
+
+function mapRpcErrorCode(error: any): ToolErrorCode {
+  const text = String(error?.code || error?.kind || error?.message || '').toLowerCase();
+  if (text.includes('timeout')) return 'EXECUTION_TIMEOUT';
+  if (text.includes('permission') || text.includes('forbidden') || text.includes('denied')) return 'PERMISSION_DENIED';
+  return 'TOOL_EXECUTION_ERROR';
+}
+
+function isRetryableRpcError(error: any): boolean {
+  const text = String(error?.code || error?.kind || error?.message || '').toLowerCase();
+  return text.includes('timeout') || text.includes('offline') || text.includes('unavailable') || text.includes('transport');
+}

--- a/src/tools/edit-tool.ts
+++ b/src/tools/edit-tool.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import { isToolAllowed, isPathAllowed } from '../utils/safety';
+import { formatCatsCoVisiblePath, resolveToolGatewayAccess } from './tool-gateway';
 
 /**
  * Edit 工具 - 精确字符串替换
@@ -53,9 +54,19 @@ export class EditTool implements Tool {
       return { ok: false, errorCode: 'PERMISSION_DENIED', message: `执行被阻止: ${pathPermission.reason}` };
     }
 
+    const gateway = resolveToolGatewayAccess(context, {
+      toolName: this.definition.name,
+      operation: 'edit_file',
+      targetLabel: file_path,
+    });
+    if (!gateway.ok) {
+      return { ok: false, errorCode: gateway.errorCode, message: gateway.message };
+    }
+    const displayPath = formatCatsCoVisiblePath(context, file_path, { preserveRelative: true });
+
     // 检查文件是否存在
     if (!fs.existsSync(absolutePath)) {
-      return { ok: false, errorCode: 'FILE_NOT_FOUND', message: `错误：文件不存在: ${absolutePath}` };
+      return { ok: false, errorCode: 'FILE_NOT_FOUND', message: `错误：文件不存在: ${displayPath}` };
     }
 
     // 读取文件内容
@@ -63,14 +74,14 @@ export class EditTool implements Tool {
 
     // 检查 old_string 是否存在
     if (!content.includes(old_string)) {
-      return { ok: false, errorCode: 'TOOL_EXECUTION_ERROR', message: `错误：在文件中未找到要替换的字符串。\n文件: ${file_path}\n查找: ${old_string.substring(0, 100)}${old_string.length > 100 ? '...' : ''}` };
+      return { ok: false, errorCode: 'TOOL_EXECUTION_ERROR', message: `错误：在文件中未找到要替换的字符串。\n文件: ${displayPath}\n查找: ${old_string.substring(0, 100)}${old_string.length > 100 ? '...' : ''}` };
     }
 
     // 检查唯一性（如果不是 replace_all）
     if (!replace_all) {
       const occurrences = content.split(old_string).length - 1;
       if (occurrences > 1) {
-        return { ok: false, errorCode: 'TOOL_EXECUTION_ERROR', message: `错误：找到 ${occurrences} 个匹配项，但 replace_all=false。\n请提供更具体的字符串以确保唯一性，或设置 replace_all=true 替换所有匹配项。\n文件: ${file_path}` };
+        return { ok: false, errorCode: 'TOOL_EXECUTION_ERROR', message: `错误：找到 ${occurrences} 个匹配项，但 replace_all=false。\n请提供更具体的字符串以确保唯一性，或设置 replace_all=true 替换所有匹配项。\n文件: ${displayPath}` };
       }
     }
 
@@ -97,6 +108,6 @@ export class EditTool implements Tool {
     const newLines = newContent.split('\n').length;
     const lineDiff = newLines - oldLines;
 
-    return { ok: true, content: `成功编辑文件: ${file_path}\nPath: ${absolutePath}\n替换次数: ${replacedCount}\n原始行数: ${oldLines}\n新行数: ${newLines}${lineDiff !== 0 ? `\n行数变化: ${lineDiff > 0 ? '+' : ''}${lineDiff}` : ''}` };
+    return { ok: true, content: `成功编辑文件: ${displayPath}\nPath: ${displayPath}\n替换次数: ${replacedCount}\n原始行数: ${oldLines}\n新行数: ${newLines}${lineDiff !== 0 ? `\n行数变化: ${lineDiff > 0 ? '+' : ''}${lineDiff}` : ''}` };
   }
 }

--- a/src/tools/glob-tool.ts
+++ b/src/tools/glob-tool.ts
@@ -3,6 +3,8 @@ import * as path from 'path';
 import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import { glob } from 'glob';
 import { isReadPathAllowed } from '../utils/safety';
+import { formatCatsCoVisiblePath, isCatsCoToolGatewayContext, resolveToolGatewayAccess } from './tool-gateway';
+import { executeRemoteReadonlyTool } from './device-rpc-tool';
 
 interface GlobResult {
   numFiles: number;
@@ -43,6 +45,17 @@ export class GlobTool implements Tool {
     const { pattern, path: searchPath, limit = 100 } = args;
     const startTime = Date.now();
 
+    const gateway = resolveToolGatewayAccess(context, {
+      toolName: this.definition.name,
+      operation: 'glob',
+      targetLabel: searchPath || '.',
+    });
+    if (!gateway.ok) {
+      return { ok: false, errorCode: gateway.errorCode, message: gateway.message };
+    }
+    const remoteResult = await executeRemoteReadonlyTool(context, gateway, 'glob', 'glob', args);
+    if (remoteResult) return remoteResult;
+
     // 确定搜索目录
     const cwd = searchPath
       ? (path.isAbsolute(searchPath) ? searchPath : path.join(context.workingDirectory, searchPath))
@@ -53,13 +66,16 @@ export class GlobTool implements Tool {
       return { ok: false, errorCode: 'PERMISSION_DENIED', message: `执行被阻止: ${pathPermission.reason}` };
     }
 
+    const visibleSearchPath = formatCatsCoVisiblePath(context, searchPath || '.', { preserveRelative: true });
+    const visibleCwd = formatCatsCoVisiblePath(context, cwd);
+
     // 检查目录是否存在
     if (!fs.existsSync(cwd)) {
-      return { ok: false, errorCode: 'FILE_NOT_FOUND', message: `目录不存在: ${cwd}` };
+      return { ok: false, errorCode: 'FILE_NOT_FOUND', message: `目录不存在: ${visibleCwd}` };
     }
 
     // 执行 glob 搜索
-    const shouldReturnAbsolutePaths = Boolean(searchPath && path.isAbsolute(searchPath));
+    const shouldReturnAbsolutePaths = !isCatsCoToolGatewayContext(context) && Boolean(searchPath && path.isAbsolute(searchPath));
 
     const files = await glob(pattern, {
       cwd,
@@ -70,7 +86,7 @@ export class GlobTool implements Tool {
     });
 
     if (files.length === 0) {
-      return { ok: true, content: `未找到匹配的文件。\n模式: ${pattern}\n目录: ${searchPath || '.'}\nPath: ${cwd}` };
+      return { ok: true, content: `未找到匹配的文件。\n模式: ${pattern}\n目录: ${visibleSearchPath}\nPath: ${visibleCwd}` };
     }
 
     // 使用Promise.allSettled容错处理stat（文件可能在glob后被删除）
@@ -97,18 +113,18 @@ export class GlobTool implements Tool {
       durationMs: Date.now() - startTime
     };
 
-    return { ok: true, content: this.formatResult(result, pattern, searchPath, cwd) };
+    return { ok: true, content: this.formatResult(result, pattern, visibleSearchPath, visibleCwd) };
   }
 
   private formatResult(
     result: GlobResult,
     pattern: string,
-    searchPath: string | undefined,
-    cwd: string,
+    visibleSearchPath: string,
+    visibleCwd: string,
   ): string {
     const { numFiles, filenames, truncated, durationMs } = result;
 
-    const header = `找到 ${numFiles} 个文件 (${durationMs}ms)${truncated ? ' - 结果已截断，考虑使用更精确的模式' : ''}:\n模式: ${pattern}\n目录: ${searchPath || '.'}\nPath: ${cwd}\n\n`;
+    const header = `找到 ${numFiles} 个文件 (${durationMs}ms)${truncated ? ' - 结果已截断，考虑使用更精确的模式' : ''}:\n模式: ${pattern}\n目录: ${visibleSearchPath}\nPath: ${visibleCwd}\n\n`;
     const fileList = filenames.map((file, i) => `${(i + 1).toString().padStart(4, ' ')}. ${file}`).join('\n');
     
     return header + fileList + (truncated ? '\n\n提示: 结果被限制在前 100 个文件。使用更具体的路径或模式来缩小范围。' : '');

--- a/src/tools/grep-tool.ts
+++ b/src/tools/grep-tool.ts
@@ -3,6 +3,8 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import { isReadPathAllowed } from '../utils/safety';
+import { formatCatsCoVisiblePath, redactCatsCoVisiblePath, resolveToolGatewayAccess } from './tool-gateway';
+import { executeRemoteReadonlyTool } from './device-rpc-tool';
 
 const VCS_DIRECTORIES_TO_EXCLUDE = ['.git', '.svn', '.hg', '.bzr'] as const;
 const DEFAULT_LIMIT = 250;
@@ -100,6 +102,17 @@ export class GrepTool implements Tool {
   async execute(args: any, context: ToolExecutionContext): Promise<ToolExecutionResult> {
     const { pattern, path: searchPath } = args;
 
+    const gateway = resolveToolGatewayAccess(context, {
+      toolName: this.definition.name,
+      operation: 'grep',
+      targetLabel: searchPath || '.',
+    });
+    if (!gateway.ok) {
+      return { ok: false, errorCode: gateway.errorCode, message: gateway.message };
+    }
+    const remoteResult = await executeRemoteReadonlyTool(context, gateway, 'grep', 'grep', args);
+    if (remoteResult) return remoteResult;
+
     const resolvedSearchPath = searchPath
       ? (path.isAbsolute(searchPath) ? searchPath : path.join(context.workingDirectory, searchPath))
       : context.workingDirectory;
@@ -108,12 +121,13 @@ export class GrepTool implements Tool {
     if (!pathPermission.allowed) {
       return { ok: false, errorCode: 'PERMISSION_DENIED', message: `执行被阻止: ${pathPermission.reason}` };
     }
+    const visibleSearchPath = formatCatsCoVisiblePath(context, searchPath || '.', { preserveRelative: true });
 
     // 按优先级尝试各个 fallback
     const fallbacks = [
-      { name: 'ripgrep (rg)', fn: () => this.executeWithRipgrep(args, resolvedSearchPath, context) },
-      { name: 'system grep', fn: () => this.executeWithSystemGrep(args, resolvedSearchPath, context) },
-      { name: 'Node.js glob', fn: () => this.executeWithNodeJS(args, resolvedSearchPath, context) },
+      { name: 'ripgrep (rg)', fn: () => this.executeWithRipgrep(args, resolvedSearchPath, context, visibleSearchPath) },
+      { name: 'system grep', fn: () => this.executeWithSystemGrep(args, resolvedSearchPath, context, visibleSearchPath) },
+      { name: 'Node.js glob', fn: () => this.executeWithNodeJS(args, resolvedSearchPath, context, visibleSearchPath) },
     ];
 
     let lastError: Error | null = null;
@@ -135,11 +149,12 @@ export class GrepTool implements Tool {
     }
 
     // 所有 fallback 都失败
-    const errorMsg = lastError?.message || '所有搜索方法都失败了';
+    const rawErrorMsg = lastError?.message || '所有搜索方法都失败了';
+    const errorMsg = redactCatsCoVisiblePath(context, rawErrorMsg, resolvedSearchPath, visibleSearchPath);
     return { ok: false, errorCode: 'EXECUTION_ERROR', message: errorMsg };
   }
 
-  private async executeWithRipgrep(args: any, searchPath: string, context: ToolExecutionContext): Promise<FallbackResult> {
+  private async executeWithRipgrep(args: any, searchPath: string, context: ToolExecutionContext, visibleSearchPath?: string): Promise<FallbackResult> {
     const { pattern, path: originalPath, glob: globPattern, type: fileType, case_insensitive = false, context: contextLines, output_mode = 'files', limit = DEFAULT_LIMIT, offset = 0 } = args;
     const rgArgs: string[] = ['--color=never', '--no-heading', '--hidden'];
 
@@ -159,11 +174,11 @@ export class GrepTool implements Tool {
 
     try {
       const output = execFileSync('rg', rgArgs, { cwd: context.workingDirectory, encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024, stdio: ['pipe', 'pipe', 'pipe'] }) as string;
-      return { content: this.processOutput(output, args, context) };
+      return { content: this.processOutput(output, args, context, visibleSearchPath) };
     } catch (error: any) {
       if (error.status === 1) {
         // 无匹配，返回格式化的"未找到"
-        return { content: this.formatNoMatch(pattern, originalPath, globPattern, fileType) };
+        return { content: this.formatNoMatch(pattern, visibleSearchPath ?? originalPath, globPattern, fileType) };
       }
       // exit code 2 或其他错误，抛出让 execute 统一处理
       const errorMsg = error.stderr || `rg 执行失败 (exit ${error.status})`;
@@ -171,7 +186,7 @@ export class GrepTool implements Tool {
     }
   }
 
-  private async executeWithSystemGrep(args: any, searchPath: string, context: ToolExecutionContext): Promise<FallbackResult> {
+  private async executeWithSystemGrep(args: any, searchPath: string, context: ToolExecutionContext, visibleSearchPath?: string): Promise<FallbackResult> {
     const { pattern, path: originalPath, glob: globPattern, type: fileType, case_insensitive = false, context: contextLines, output_mode = 'files', limit = DEFAULT_LIMIT, offset = 0 } = args;
     const grepArgs: string[] = [];
 
@@ -194,17 +209,17 @@ export class GrepTool implements Tool {
         processedOutput = lines.filter(line => globRegex.test(path.basename(line.split(':')[0]))).join('\n');
       }
 
-      return { content: this.processOutput(processedOutput, args, context) };
+      return { content: this.processOutput(processedOutput, args, context, visibleSearchPath) };
     } catch (error: any) {
       if (error.status === 1) {
-        return { content: this.formatNoMatch(pattern, originalPath, globPattern, fileType) };
+        return { content: this.formatNoMatch(pattern, visibleSearchPath ?? originalPath, globPattern, fileType) };
       }
       const errorMsg = error.stderr || `grep 执行失败 (exit ${error.status})`;
       throw new Error(errorMsg);
     }
   }
 
-  private async executeWithNodeJS(args: any, searchPath: string, context: ToolExecutionContext): Promise<FallbackResult> {
+  private async executeWithNodeJS(args: any, searchPath: string, context: ToolExecutionContext, visibleSearchPath?: string): Promise<FallbackResult> {
     const { pattern, path: originalPath, glob: globPattern, type: fileType, case_insensitive = false, context: contextLines, output_mode = 'files', limit = DEFAULT_LIMIT, offset = 0 } = args;
 
     if (!fs.existsSync(searchPath)) {
@@ -245,10 +260,10 @@ export class GrepTool implements Tool {
     };
 
     walkDir(searchPath);
-    return { content: this.processOutput(results.join('\n'), args, context) };
+    return { content: this.processOutput(results.join('\n'), args, context, visibleSearchPath) };
   }
 
-  private processOutput(output: string, args: any, context: ToolExecutionContext): string {
+  private processOutput(output: string, args: any, context: ToolExecutionContext, visibleSearchPath?: string): string {
     const { pattern, path: originalPath, glob: globPattern, type: fileType, output_mode = 'files', limit = DEFAULT_LIMIT, offset = 0 } = args;
     const allLines = output.trim().split('\n').filter(Boolean);
     const { items: limitedLines, appliedLimit } = applyHeadLimit(allLines, limit, offset);
@@ -276,7 +291,7 @@ export class GrepTool implements Tool {
       result.numFiles = result.filenames.length;
     }
 
-    return this.formatResult(result, pattern, originalPath, globPattern, fileType);
+    return this.formatResult(result, pattern, visibleSearchPath ?? originalPath, globPattern, fileType);
   }
 
   private formatNoMatch(pattern: string, searchPath: string | undefined, globPattern: string | undefined, fileType: string | undefined): string {

--- a/src/tools/local-file-gateway.ts
+++ b/src/tools/local-file-gateway.ts
@@ -6,7 +6,7 @@ import type { ToolErrorCode, ToolExecutionContext } from '../types/tool';
 export type LocalFileOperation = 'read_file' | 'send_file';
 
 export type LocalFileAccessDecision =
-  | { ok: true; grant?: ScopedLocalFileGrant }
+  | { ok: true; grant?: ScopedLocalFileGrant; displayPath?: string }
   | { ok: false; errorCode: ToolErrorCode; message: string };
 
 export type LocalFileReferenceDecision =
@@ -25,6 +25,7 @@ interface ResolveLocalFileReferenceOptions {
 }
 
 const CATSCOMPANY_ATTACHMENT_REF_PREFIX = 'catsco_attachment:';
+const MANAGED_ATTACHMENT_CACHE_DISPLAY_PATH = '[CatsCo managed attachment cache]';
 
 export function resolveLocalFileAccess(
   context: ToolExecutionContext,
@@ -37,7 +38,10 @@ export function resolveLocalFileAccess(
   const absolutePath = normalizePath(options.absolutePath);
   const matchingGrant = findMatchingGrant(context.localFileGrants, absolutePath);
   if (matchingGrant) {
-    return validateGrant(context, matchingGrant, absolutePath, options.operation);
+    const displayPath = displayPathForGrant(matchingGrant);
+    const access = validateGrant(context, matchingGrant, absolutePath, options.operation, displayPath);
+    if (!access.ok) return access;
+    return { ok: true, grant: matchingGrant, displayPath };
   }
 
   if (!isManagedCatsCoDownloadPath(context, absolutePath)) {
@@ -50,7 +54,7 @@ export function resolveLocalFileAccess(
     message: [
       '该本地附件缓存不属于当前已授权的用户消息，已阻止访问。',
       '请让用户在当前会话重新上传附件，或使用本轮消息中明确提供的授权附件引用。',
-      `Path: ${absolutePath}`,
+      `Path: ${MANAGED_ATTACHMENT_CACHE_DISPLAY_PATH}`,
     ].join('\n'),
   };
 }
@@ -59,10 +63,17 @@ export function resolveLocalFileReference(
   context: ToolExecutionContext,
   options: ResolveLocalFileReferenceOptions,
 ): LocalFileReferenceDecision {
-  if (context.surface !== 'catscompany') return { matched: false };
-
   const attachmentRef = normalizeAttachmentReference(options.inputPath);
   if (!attachmentRef) return { matched: false };
+
+  if (context.surface !== 'catscompany') {
+    return {
+      matched: true,
+      ok: false,
+      errorCode: 'PERMISSION_DENIED',
+      message: 'CatsCo 附件引用只能在当前 CatsCo 会话中使用。',
+    };
+  }
 
   const matchingGrant = findMatchingGrantByReference(context.localFileGrants, attachmentRef);
   if (!matchingGrant) {
@@ -201,6 +212,11 @@ function findMatchingGrantByReference(
 ): ScopedLocalFileGrant | undefined {
   if (!Array.isArray(grants)) return undefined;
   return grants.find(grant => normalizeAttachmentReference(grant.attachmentRef) === attachmentRef);
+}
+
+function displayPathForGrant(grant: ScopedLocalFileGrant): string {
+  return normalizeAttachmentReference(grant.attachmentRef)
+    || (grant.fileName ? `[CatsCo authorized attachment: ${grant.fileName}]` : MANAGED_ATTACHMENT_CACHE_DISPLAY_PATH);
 }
 
 function normalizeAttachmentReference(value: unknown): string | undefined {

--- a/src/tools/local-file-gateway.ts
+++ b/src/tools/local-file-gateway.ts
@@ -1,0 +1,155 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import type { LocalFileGrantOperation, ScopedLocalFileGrant } from '../types/session-identity';
+import type { ToolErrorCode, ToolExecutionContext } from '../types/tool';
+
+export type LocalFileOperation = 'read_file' | 'send_file';
+
+export type LocalFileAccessDecision =
+  | { ok: true; grant?: ScopedLocalFileGrant }
+  | { ok: false; errorCode: ToolErrorCode; message: string };
+
+interface ResolveLocalFileAccessOptions {
+  operation: LocalFileOperation;
+  absolutePath: string;
+}
+
+export function resolveLocalFileAccess(
+  context: ToolExecutionContext,
+  options: ResolveLocalFileAccessOptions,
+): LocalFileAccessDecision {
+  if (context.surface !== 'catscompany') {
+    return { ok: true };
+  }
+
+  const absolutePath = normalizePath(options.absolutePath);
+  const matchingGrant = findMatchingGrant(context.localFileGrants, absolutePath);
+  if (matchingGrant) {
+    return validateGrant(context, matchingGrant, absolutePath, options.operation);
+  }
+
+  if (!isManagedCatsCoDownloadPath(context, absolutePath)) {
+    return { ok: true };
+  }
+
+  return {
+    ok: false,
+    errorCode: 'PERMISSION_DENIED',
+    message: [
+      '该本地附件缓存不属于当前已授权的用户消息，已阻止访问。',
+      '请让用户在当前会话重新上传附件，或使用本轮消息中明确提供的授权附件路径。',
+      `Path: ${absolutePath}`,
+    ].join('\n'),
+  };
+}
+
+function validateGrant(
+  context: ToolExecutionContext,
+  grant: ScopedLocalFileGrant,
+  absolutePath: string,
+  operation: LocalFileGrantOperation,
+): LocalFileAccessDecision {
+  const scope = context.executionScope;
+  if (!scope || scope.source !== 'catscompany') {
+    return denied('当前工具调用缺少 CatsCo 执行身份，无法访问本地附件缓存。', absolutePath);
+  }
+
+  if (scope.identityTrust !== 'server_canonical' || !scope.isTrusted) {
+    return denied('当前消息身份未通过服务端一致性校验，无法访问本地附件缓存。', absolutePath);
+  }
+
+  if (grant.identityTrust !== 'server_canonical' || grant.source !== 'catscompany') {
+    return denied('本地文件授权不是服务端可信 CatsCo 身份生成的授权，已阻止访问。', absolutePath);
+  }
+
+  if (!grant.operations.includes(operation)) {
+    return denied(`本地文件授权不允许执行 ${operation}。`, absolutePath);
+  }
+
+  if (grant.expiresAt <= Date.now()) {
+    return denied('本地文件授权已过期，请让用户在当前会话重新上传附件。', absolutePath);
+  }
+
+  const localDeviceGrant = context.localDeviceGrant;
+  if (!localDeviceGrant || localDeviceGrant.source !== 'catscompany') {
+    return denied('当前本机运行体缺少 CatsCo body 授权，无法访问本地附件缓存。', absolutePath);
+  }
+
+  const mismatches = [
+    ['sessionKey', grant.sessionKey, scope.sessionKey],
+    ['topicId', grant.topicId, scope.topicId],
+    ['actorUserId', grant.actorUserId, scope.actorUserId],
+    ['agentBodyId', grant.agentBodyId, scope.agentBodyId],
+    ['deviceBodyId', grant.deviceBodyId, localDeviceGrant.bodyId],
+  ].filter(([, grantValue, scopeValue]) => grantValue !== scopeValue);
+
+  if (grant.deviceInstallationId
+    && localDeviceGrant.installationId
+    && grant.deviceInstallationId !== localDeviceGrant.installationId) {
+    mismatches.push(['deviceInstallationId', grant.deviceInstallationId, localDeviceGrant.installationId]);
+  }
+
+  if (mismatches.length > 0) {
+    return {
+      ok: false,
+      errorCode: 'PERMISSION_DENIED',
+      message: [
+        '本地文件授权与当前执行身份不一致，已阻止访问以避免串用户或串设备。',
+        ...mismatches.map(([field, grantValue, scopeValue]) => `${field}: grant=${grantValue || '(empty)'} scope=${scopeValue || '(empty)'}`),
+        `Path: ${absolutePath}`,
+      ].join('\n'),
+    };
+  }
+
+  let stats: fs.Stats;
+  try {
+    stats = fs.statSync(absolutePath);
+  } catch {
+    return denied('授权附件文件已不存在，请让用户重新上传。', absolutePath);
+  }
+  if (!stats.isFile()) {
+    return denied('授权附件路径已不再指向文件，请让用户重新上传。', absolutePath);
+  }
+  if (stats.size !== grant.size || stats.mtimeMs !== grant.mtimeMs) {
+    return denied('授权附件文件在授权后发生变化，请让用户重新上传。', absolutePath);
+  }
+
+  return { ok: true, grant };
+}
+
+function denied(reason: string, absolutePath: string): LocalFileAccessDecision {
+  return {
+    ok: false,
+    errorCode: 'PERMISSION_DENIED',
+    message: [reason, `Path: ${absolutePath}`].join('\n'),
+  };
+}
+
+function findMatchingGrant(
+  grants: ScopedLocalFileGrant[] | undefined,
+  absolutePath: string,
+): ScopedLocalFileGrant | undefined {
+  if (!Array.isArray(grants)) return undefined;
+  return grants.find(grant => normalizePath(grant.filePath) === absolutePath);
+}
+
+function isManagedCatsCoDownloadPath(context: ToolExecutionContext, absolutePath: string): boolean {
+  const root = path.resolve(context.workspaceRoot || process.cwd(), 'tmp', 'downloads');
+  return isPathInside(absolutePath, root);
+}
+
+function isPathInside(targetPath: string, rootPath: string): boolean {
+  const normalizedTarget = normalizeForCompare(targetPath);
+  const normalizedRoot = normalizeForCompare(rootPath);
+  if (normalizedTarget === normalizedRoot) return true;
+  const rootWithSep = normalizedRoot.endsWith(path.sep) ? normalizedRoot : `${normalizedRoot}${path.sep}`;
+  return normalizedTarget.startsWith(rootWithSep);
+}
+
+function normalizePath(filePath: string): string {
+  return path.resolve(filePath);
+}
+
+function normalizeForCompare(filePath: string): string {
+  return normalizePath(filePath).toLowerCase();
+}

--- a/src/tools/local-file-gateway.ts
+++ b/src/tools/local-file-gateway.ts
@@ -9,10 +9,22 @@ export type LocalFileAccessDecision =
   | { ok: true; grant?: ScopedLocalFileGrant }
   | { ok: false; errorCode: ToolErrorCode; message: string };
 
+export type LocalFileReferenceDecision =
+  | { matched: false }
+  | { matched: true; ok: true; absolutePath: string; displayPath: string; grant: ScopedLocalFileGrant }
+  | { matched: true; ok: false; errorCode: ToolErrorCode; message: string };
+
 interface ResolveLocalFileAccessOptions {
   operation: LocalFileOperation;
   absolutePath: string;
 }
+
+interface ResolveLocalFileReferenceOptions {
+  operation: LocalFileOperation;
+  inputPath: string;
+}
+
+const CATSCOMPANY_ATTACHMENT_REF_PREFIX = 'catsco_attachment:';
 
 export function resolveLocalFileAccess(
   context: ToolExecutionContext,
@@ -37,9 +49,52 @@ export function resolveLocalFileAccess(
     errorCode: 'PERMISSION_DENIED',
     message: [
       '该本地附件缓存不属于当前已授权的用户消息，已阻止访问。',
-      '请让用户在当前会话重新上传附件，或使用本轮消息中明确提供的授权附件路径。',
+      '请让用户在当前会话重新上传附件，或使用本轮消息中明确提供的授权附件引用。',
       `Path: ${absolutePath}`,
     ].join('\n'),
+  };
+}
+
+export function resolveLocalFileReference(
+  context: ToolExecutionContext,
+  options: ResolveLocalFileReferenceOptions,
+): LocalFileReferenceDecision {
+  if (context.surface !== 'catscompany') return { matched: false };
+
+  const attachmentRef = normalizeAttachmentReference(options.inputPath);
+  if (!attachmentRef) return { matched: false };
+
+  const matchingGrant = findMatchingGrantByReference(context.localFileGrants, attachmentRef);
+  if (!matchingGrant) {
+    return {
+      matched: true,
+      ok: false,
+      errorCode: 'PERMISSION_DENIED',
+      message: [
+        '该附件引用不属于当前已授权的用户消息，已阻止访问。',
+        '请让用户在当前会话重新上传附件，或使用本轮消息中明确提供的授权附件引用。',
+        `Attachment ref: ${attachmentRef}`,
+      ].join('\n'),
+    };
+  }
+
+  const absolutePath = normalizePath(matchingGrant.filePath);
+  const access = validateGrant(context, matchingGrant, absolutePath, options.operation, attachmentRef);
+  if (!access.ok) {
+    return {
+      matched: true,
+      ok: false,
+      errorCode: access.errorCode,
+      message: access.message,
+    };
+  }
+
+  return {
+    matched: true,
+    ok: true,
+    absolutePath,
+    displayPath: attachmentRef,
+    grant: matchingGrant,
   };
 }
 
@@ -48,31 +103,32 @@ function validateGrant(
   grant: ScopedLocalFileGrant,
   absolutePath: string,
   operation: LocalFileGrantOperation,
+  displayPath = absolutePath,
 ): LocalFileAccessDecision {
   const scope = context.executionScope;
   if (!scope || scope.source !== 'catscompany') {
-    return denied('当前工具调用缺少 CatsCo 执行身份，无法访问本地附件缓存。', absolutePath);
+    return denied('当前工具调用缺少 CatsCo 执行身份，无法访问本地附件缓存。', displayPath);
   }
 
   if (scope.identityTrust !== 'server_canonical' || !scope.isTrusted) {
-    return denied('当前消息身份未通过服务端一致性校验，无法访问本地附件缓存。', absolutePath);
+    return denied('当前消息身份未通过服务端一致性校验，无法访问本地附件缓存。', displayPath);
   }
 
   if (grant.identityTrust !== 'server_canonical' || grant.source !== 'catscompany') {
-    return denied('本地文件授权不是服务端可信 CatsCo 身份生成的授权，已阻止访问。', absolutePath);
+    return denied('本地文件授权不是服务端可信 CatsCo 身份生成的授权，已阻止访问。', displayPath);
   }
 
   if (!grant.operations.includes(operation)) {
-    return denied(`本地文件授权不允许执行 ${operation}。`, absolutePath);
+    return denied(`本地文件授权不允许执行 ${operation}。`, displayPath);
   }
 
   if (grant.expiresAt <= Date.now()) {
-    return denied('本地文件授权已过期，请让用户在当前会话重新上传附件。', absolutePath);
+    return denied('本地文件授权已过期，请让用户在当前会话重新上传附件。', displayPath);
   }
 
   const localDeviceGrant = context.localDeviceGrant;
   if (!localDeviceGrant || localDeviceGrant.source !== 'catscompany') {
-    return denied('当前本机运行体缺少 CatsCo body 授权，无法访问本地附件缓存。', absolutePath);
+    return denied('当前本机运行体缺少 CatsCo body 授权，无法访问本地附件缓存。', displayPath);
   }
 
   const mismatches = [
@@ -96,7 +152,7 @@ function validateGrant(
       message: [
         '本地文件授权与当前执行身份不一致，已阻止访问以避免串用户或串设备。',
         ...mismatches.map(([field, grantValue, scopeValue]) => `${field}: grant=${grantValue || '(empty)'} scope=${scopeValue || '(empty)'}`),
-        `Path: ${absolutePath}`,
+        targetLine(displayPath),
       ].join('\n'),
     };
   }
@@ -105,13 +161,13 @@ function validateGrant(
   try {
     stats = fs.statSync(absolutePath);
   } catch {
-    return denied('授权附件文件已不存在，请让用户重新上传。', absolutePath);
+    return denied('授权附件文件已不存在，请让用户重新上传。', displayPath);
   }
   if (!stats.isFile()) {
-    return denied('授权附件路径已不再指向文件，请让用户重新上传。', absolutePath);
+    return denied('授权附件路径已不再指向文件，请让用户重新上传。', displayPath);
   }
   if (stats.size !== grant.size || stats.mtimeMs !== grant.mtimeMs) {
-    return denied('授权附件文件在授权后发生变化，请让用户重新上传。', absolutePath);
+    return denied('授权附件文件在授权后发生变化，请让用户重新上传。', displayPath);
   }
 
   return { ok: true, grant };
@@ -121,8 +177,14 @@ function denied(reason: string, absolutePath: string): LocalFileAccessDecision {
   return {
     ok: false,
     errorCode: 'PERMISSION_DENIED',
-    message: [reason, `Path: ${absolutePath}`].join('\n'),
+    message: [reason, targetLine(absolutePath)].join('\n'),
   };
+}
+
+function targetLine(displayPath: string): string {
+  return normalizeAttachmentReference(displayPath)
+    ? `Attachment ref: ${displayPath}`
+    : `Path: ${displayPath}`;
 }
 
 function findMatchingGrant(
@@ -131,6 +193,22 @@ function findMatchingGrant(
 ): ScopedLocalFileGrant | undefined {
   if (!Array.isArray(grants)) return undefined;
   return grants.find(grant => normalizePath(grant.filePath) === absolutePath);
+}
+
+function findMatchingGrantByReference(
+  grants: ScopedLocalFileGrant[] | undefined,
+  attachmentRef: string,
+): ScopedLocalFileGrant | undefined {
+  if (!Array.isArray(grants)) return undefined;
+  return grants.find(grant => normalizeAttachmentReference(grant.attachmentRef) === attachmentRef);
+}
+
+function normalizeAttachmentReference(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const text = value.trim();
+  if (!text.startsWith(CATSCOMPANY_ATTACHMENT_REF_PREFIX)) return undefined;
+  const id = text.slice(CATSCOMPANY_ATTACHMENT_REF_PREFIX.length).trim();
+  return id ? `${CATSCOMPANY_ATTACHMENT_REF_PREFIX}${id}` : undefined;
 }
 
 function isManagedCatsCoDownloadPath(context: ToolExecutionContext, absolutePath: string): boolean {

--- a/src/tools/local-file-gateway.ts
+++ b/src/tools/local-file-gateway.ts
@@ -143,9 +143,12 @@ function validateGrant(
   }
 
   const mismatches = [
+    ['source', grant.source, scope.source],
     ['sessionKey', grant.sessionKey, scope.sessionKey],
     ['topicId', grant.topicId, scope.topicId],
+    ['topicType', grant.topicType, scope.topicType],
     ['actorUserId', grant.actorUserId, scope.actorUserId],
+    ['agentId', grant.agentId, scope.agentId],
     ['agentBodyId', grant.agentBodyId, scope.agentBodyId],
     ['deviceBodyId', grant.deviceBodyId, localDeviceGrant.bodyId],
   ].filter(([, grantValue, scopeValue]) => grantValue !== scopeValue);

--- a/src/tools/outbound-gateway.ts
+++ b/src/tools/outbound-gateway.ts
@@ -1,0 +1,96 @@
+import type { ToolErrorCode, ToolExecutionContext } from '../types/tool';
+
+export type OutboundOperation = 'send_text' | 'send_file';
+
+export type OutboundTargetDecision =
+  | { ok: true; chatId: string }
+  | { ok: false; errorCode: ToolErrorCode; message: string };
+
+interface ResolveOutboundTargetOptions {
+  operation: OutboundOperation;
+  missingChannelMessage: string;
+}
+
+const UNKNOWN_TOPIC_ID = 'unknown_topic';
+
+export function resolveOutboundTarget(
+  context: ToolExecutionContext,
+  options: ResolveOutboundTargetOptions,
+): OutboundTargetDecision {
+  const channel = context.channel;
+  if (!channel) {
+    return {
+      ok: false,
+      errorCode: 'TOOL_EXECUTION_ERROR',
+      message: options.missingChannelMessage,
+    };
+  }
+
+  const channelChatId = normalizeId(channel.chatId);
+  const scope = context.executionScope;
+  if (!scope) {
+    if (!channelChatId) {
+      return {
+        ok: false,
+        errorCode: 'TOOL_EXECUTION_ERROR',
+        message: '当前聊天会话缺少目标 chatId，无法发送消息',
+      };
+    }
+    return { ok: true, chatId: channelChatId };
+  }
+
+  const scopeTopicId = normalizeId(scope.topicId);
+  const scopeSessionKey = normalizeId(scope.sessionKey);
+  const contextSessionId = normalizeId(context.sessionId);
+  if (context.surface === 'catscompany'
+    && scopeSessionKey
+    && contextSessionId
+    && scopeSessionKey !== contextSessionId) {
+    return {
+      ok: false,
+      errorCode: 'PERMISSION_DENIED',
+      message: [
+        '执行会话与当前执行身份不一致，已停止发送以避免串线。',
+        `Scope session: ${scopeSessionKey}`,
+        `Context session: ${contextSessionId}`,
+      ].join('\n'),
+    };
+  }
+
+  const hasKnownScopeTopic = Boolean(scopeTopicId && scopeTopicId !== UNKNOWN_TOPIC_ID);
+  if (hasKnownScopeTopic && channelChatId && channelChatId !== scopeTopicId) {
+    return {
+      ok: false,
+      errorCode: 'PERMISSION_DENIED',
+      message: [
+        '外发目标与当前执行身份不一致，已停止发送以避免串线。',
+        `Scope topic: ${scopeTopicId}`,
+        `Channel chatId: ${channelChatId}`,
+      ].join('\n'),
+    };
+  }
+
+  if (options.operation === 'send_file' && scope.identityTrust === 'untrusted') {
+    return {
+      ok: false,
+      errorCode: 'PERMISSION_DENIED',
+      message: '当前消息身份未通过服务端一致性校验，暂不允许发送文件。',
+    };
+  }
+
+  const targetChatId = hasKnownScopeTopic ? scopeTopicId : channelChatId;
+  if (!targetChatId) {
+    return {
+      ok: false,
+      errorCode: 'TOOL_EXECUTION_ERROR',
+      message: '当前执行身份和聊天通道都缺少目标 topic，无法发送消息',
+    };
+  }
+
+  return { ok: true, chatId: targetChatId };
+}
+
+function normalizeId(value: unknown): string {
+  if (typeof value !== 'string') return '';
+  return value.trim();
+}

--- a/src/tools/read-tool.ts
+++ b/src/tools/read-tool.ts
@@ -7,7 +7,7 @@ import { createImageBlock } from '../utils/image-utils';
 import { ConfigManager } from '../utils/config';
 import { isPrimaryModelVisionCapable } from '../utils/model-capabilities';
 import { analyzeImageWithReaderProxy, ReaderProxyResult } from '../utils/reader-proxy';
-import { resolveLocalFileAccess } from './local-file-gateway';
+import { resolveLocalFileAccess, resolveLocalFileReference } from './local-file-gateway';
 
 export const DEFAULT_TEXT_READ_LIMIT = 200;
 export const MAX_TEXT_READ_LIMIT = 2000;
@@ -59,7 +59,7 @@ export class ReadTool implements Tool {
       properties: {
         file_path: {
           type: 'string',
-          description: '要读取的文件路径，可以是绝对路径，也可以是相对当前工作目录的路径。',
+          description: '要读取的文件路径或当前 CatsCo 用户轮次中的授权附件引用。可以是绝对路径、相对当前工作目录的路径，或 catsco_attachment:<id>。',
         },
         offset: {
           type: 'number',
@@ -89,17 +89,41 @@ export class ReadTool implements Tool {
       return { ok: false, errorCode: 'TOOL_EXECUTION_ERROR', message: '文件路径不能为空' };
     }
 
-    const absolutePath = path.isAbsolute(file_path)
-      ? file_path
-      : path.join(context.workingDirectory, file_path);
+    let absolutePath: string;
+    let displayPath = file_path;
+    let visiblePath: string;
+    let resolvedFromAttachmentRef = false;
 
-    const pathPermission = isReadPathAllowed(absolutePath, context.workingDirectory);
-    if (!pathPermission.allowed) {
-      return { ok: false, errorCode: 'PERMISSION_DENIED', message: `执行被阻止: ${pathPermission.reason}` };
+    const reference = resolveLocalFileReference(context, {
+      operation: 'read_file',
+      inputPath: file_path,
+    });
+    if (reference.matched) {
+      if (!reference.ok) {
+        return {
+          ok: false,
+          errorCode: reference.errorCode,
+          message: reference.message,
+        };
+      }
+      absolutePath = reference.absolutePath;
+      displayPath = reference.displayPath;
+      visiblePath = reference.displayPath;
+      resolvedFromAttachmentRef = true;
+    } else {
+      absolutePath = path.isAbsolute(file_path)
+        ? file_path
+        : path.join(context.workingDirectory, file_path);
+      visiblePath = absolutePath;
+
+      const pathPermission = isReadPathAllowed(absolutePath, context.workingDirectory);
+      if (!pathPermission.allowed) {
+        return { ok: false, errorCode: 'PERMISSION_DENIED', message: `执行被阻止: ${pathPermission.reason}` };
+      }
     }
 
     if (!fs.existsSync(absolutePath)) {
-      return { ok: false, errorCode: 'FILE_NOT_FOUND', message: `错误：文件不存在: ${absolutePath}` };
+      return { ok: false, errorCode: 'FILE_NOT_FOUND', message: `错误：文件不存在: ${visiblePath}` };
     }
 
     try {
@@ -111,44 +135,46 @@ export class ReadTool implements Tool {
           message: [
             'Path is not a file.',
             `Input path: ${file_path}`,
-            `Resolved path: ${absolutePath}`,
+            `Resolved path: ${visiblePath}`,
           ].join('\n'),
         };
       }
     } catch {
-      return { ok: false, errorCode: 'FILE_NOT_FOUND', message: `错误：文件不存在: ${absolutePath}` };
+      return { ok: false, errorCode: 'FILE_NOT_FOUND', message: `错误：文件不存在: ${visiblePath}` };
     }
 
-    const localAccess = resolveLocalFileAccess(context, {
-      operation: 'read_file',
-      absolutePath,
-    });
-    if (!localAccess.ok) {
-      return {
-        ok: false,
-        errorCode: localAccess.errorCode,
-        message: localAccess.message,
-      };
+    if (!resolvedFromAttachmentRef) {
+      const localAccess = resolveLocalFileAccess(context, {
+        operation: 'read_file',
+        absolutePath,
+      });
+      if (!localAccess.ok) {
+        return {
+          ok: false,
+          errorCode: localAccess.errorCode,
+          message: localAccess.message,
+        };
+      }
     }
 
     const ext = path.extname(absolutePath).toLowerCase();
 
     if (ext === '.pdf') {
-      const content = this.readPDF(absolutePath, file_path, pages);
+      const content = this.readPDF(absolutePath, displayPath, visiblePath, pages);
       return { ok: true, content };
     }
 
     if (this.isImageExt(ext)) {
-      const content = await this.readImage(absolutePath, file_path, context, prompt || analysis_prompt);
+      const content = await this.readImage(absolutePath, displayPath, visiblePath, context, prompt || analysis_prompt);
       return { ok: true, content: content as any };
     }
 
     if (ext === '.ipynb') {
-      const content = this.readNotebook(absolutePath, file_path);
+      const content = this.readNotebook(absolutePath, displayPath, visiblePath);
       return { ok: true, content };
     }
 
-    const content = await this.readTextFile(absolutePath, file_path, { offset, limit }, context);
+    const content = await this.readTextFile(absolutePath, displayPath, visiblePath, { offset, limit }, context);
     return { ok: true, content };
   }
 
@@ -280,7 +306,7 @@ export class ReadTool implements Tool {
     };
   }
 
-  private formatTextReadResult(filePath: string, absolutePath: string, result: TextReadResult): string {
+  private formatTextReadResult(filePath: string, displayPath: string, result: TextReadResult): string {
     const formattedLines = result.lines
       .map((line, index) => {
         const lineNumber = result.startLine + index;
@@ -313,7 +339,7 @@ export class ReadTool implements Tool {
 
     return [
       `文件: ${filePath}`,
-      `Path: ${absolutePath}`,
+      `Path: ${displayPath}`,
       `总行数: ${totalLinesLabel}`,
       `显示: ${displayRange}`,
       '',
@@ -325,21 +351,22 @@ export class ReadTool implements Tool {
   private async readTextFile(
     absolutePath: string,
     filePath: string,
+    visiblePath: string,
     options: TextReadOptions,
     context: ToolExecutionContext,
   ): Promise<string> {
     const normalizedOptions = this.normalizeTextReadOptions(options);
     const result = await this.collectTextLines(absolutePath, normalizedOptions, context);
-    return this.formatTextReadResult(filePath, absolutePath, result);
+    return this.formatTextReadResult(filePath, visiblePath, result);
   }
 
-  private readPDF(absolutePath: string, filePath: string, pages?: string): string {
+  private readPDF(absolutePath: string, filePath: string, visiblePath: string, pages?: string): string {
     const stats = fs.statSync(absolutePath);
     const sizeMB = (stats.size / 1024 / 1024).toFixed(2);
 
     const lines = [
       `文件: ${filePath}`,
-      `Path: ${absolutePath}`,
+      `Path: ${visiblePath}`,
       '类型: PDF',
       `大小: ${sizeMB} MB`,
       '',
@@ -387,10 +414,10 @@ export class ReadTool implements Tool {
     return explicit || this.getLatestUserText(context);
   }
 
-  private formatImageMetadata(absolutePath: string, filePath: string): string {
+  private formatImageMetadata(absolutePath: string, filePath: string, visiblePath: string): string {
     const stats = fs.statSync(absolutePath);
     const sizeKB = (stats.size / 1024).toFixed(2);
-    return [`文件: ${filePath}`, `Path: ${absolutePath}`, '类型: 图片文件', `大小: ${sizeKB} KB`].join('\n');
+    return [`文件: ${filePath}`, `Path: ${visiblePath}`, '类型: 图片文件', `大小: ${sizeKB} KB`].join('\n');
   }
 
   private formatReaderProxyFailure(proxyResult: ReaderProxyResult, visionCapable: boolean): string {
@@ -447,6 +474,7 @@ export class ReadTool implements Tool {
   private async readImage(
     absolutePath: string,
     filePath: string,
+    visiblePath: string,
     context: ToolExecutionContext,
     prompt?: string,
   ): Promise<any> {
@@ -473,7 +501,7 @@ export class ReadTool implements Tool {
 
     if (proxyResult.ok && proxyResult.analysis) {
       return [
-        this.formatImageMetadata(absolutePath, filePath),
+        this.formatImageMetadata(absolutePath, filePath, visiblePath),
         '',
         visionCapable
           ? '主模型图片块生成失败，已自动改用 Cats reader proxy 解析：'
@@ -483,17 +511,17 @@ export class ReadTool implements Tool {
     }
 
     return [
-      this.formatImageMetadata(absolutePath, filePath),
+      this.formatImageMetadata(absolutePath, filePath, visiblePath),
       '',
       this.formatReaderProxyFailure(proxyResult, visionCapable),
     ].join('\n');
   }
 
-  private readNotebook(absolutePath: string, filePath: string): string {
+  private readNotebook(absolutePath: string, filePath: string, visiblePath: string): string {
     const content = fs.readFileSync(absolutePath, 'utf-8');
     const notebook = JSON.parse(content);
 
-    let result = `文件: ${filePath}\nPath: ${absolutePath}\nJupyter Notebook\n单元格数量: ${notebook.cells?.length || 0}\n\n`;
+    let result = `文件: ${filePath}\nPath: ${visiblePath}\nJupyter Notebook\n单元格数量: ${notebook.cells?.length || 0}\n\n`;
 
     if (notebook.cells && Array.isArray(notebook.cells)) {
       notebook.cells.forEach((cell: any, index: number) => {

--- a/src/tools/read-tool.ts
+++ b/src/tools/read-tool.ts
@@ -122,6 +122,24 @@ export class ReadTool implements Tool {
       }
     }
 
+    if (!resolvedFromAttachmentRef) {
+      const localAccess = resolveLocalFileAccess(context, {
+        operation: 'read_file',
+        absolutePath,
+      });
+      if (!localAccess.ok) {
+        return {
+          ok: false,
+          errorCode: localAccess.errorCode,
+          message: localAccess.message,
+        };
+      }
+      if (localAccess.displayPath) {
+        displayPath = localAccess.displayPath;
+        visiblePath = localAccess.displayPath;
+      }
+    }
+
     if (!fs.existsSync(absolutePath)) {
       return { ok: false, errorCode: 'FILE_NOT_FOUND', message: `错误：文件不存在: ${visiblePath}` };
     }
@@ -141,20 +159,6 @@ export class ReadTool implements Tool {
       }
     } catch {
       return { ok: false, errorCode: 'FILE_NOT_FOUND', message: `错误：文件不存在: ${visiblePath}` };
-    }
-
-    if (!resolvedFromAttachmentRef) {
-      const localAccess = resolveLocalFileAccess(context, {
-        operation: 'read_file',
-        absolutePath,
-      });
-      if (!localAccess.ok) {
-        return {
-          ok: false,
-          errorCode: localAccess.errorCode,
-          message: localAccess.message,
-        };
-      }
     }
 
     const ext = path.extname(absolutePath).toLowerCase();
@@ -487,7 +491,7 @@ export class ReadTool implements Tool {
       if (imageBlock) {
         return {
           _imageForNewMessage: true,
-          imageBlock,
+          imageBlock: { ...imageBlock, filePath },
           filePath,
         };
       }

--- a/src/tools/read-tool.ts
+++ b/src/tools/read-tool.ts
@@ -7,6 +7,7 @@ import { createImageBlock } from '../utils/image-utils';
 import { ConfigManager } from '../utils/config';
 import { isPrimaryModelVisionCapable } from '../utils/model-capabilities';
 import { analyzeImageWithReaderProxy, ReaderProxyResult } from '../utils/reader-proxy';
+import { resolveLocalFileAccess } from './local-file-gateway';
 
 export const DEFAULT_TEXT_READ_LIMIT = 200;
 export const MAX_TEXT_READ_LIMIT = 2000;
@@ -84,6 +85,10 @@ export class ReadTool implements Tool {
   async execute(args: any, context: ToolExecutionContext): Promise<ToolExecutionResult> {
     const { file_path, offset, limit, pages, prompt, analysis_prompt } = args;
 
+    if (!file_path || typeof file_path !== 'string') {
+      return { ok: false, errorCode: 'TOOL_EXECUTION_ERROR', message: '文件路径不能为空' };
+    }
+
     const absolutePath = path.isAbsolute(file_path)
       ? file_path
       : path.join(context.workingDirectory, file_path);
@@ -95,6 +100,35 @@ export class ReadTool implements Tool {
 
     if (!fs.existsSync(absolutePath)) {
       return { ok: false, errorCode: 'FILE_NOT_FOUND', message: `错误：文件不存在: ${absolutePath}` };
+    }
+
+    try {
+      const stats = fs.statSync(absolutePath);
+      if (!stats.isFile()) {
+        return {
+          ok: false,
+          errorCode: 'TOOL_EXECUTION_ERROR',
+          message: [
+            'Path is not a file.',
+            `Input path: ${file_path}`,
+            `Resolved path: ${absolutePath}`,
+          ].join('\n'),
+        };
+      }
+    } catch {
+      return { ok: false, errorCode: 'FILE_NOT_FOUND', message: `错误：文件不存在: ${absolutePath}` };
+    }
+
+    const localAccess = resolveLocalFileAccess(context, {
+      operation: 'read_file',
+      absolutePath,
+    });
+    if (!localAccess.ok) {
+      return {
+        ok: false,
+        errorCode: localAccess.errorCode,
+        message: localAccess.message,
+      };
     }
 
     const ext = path.extname(absolutePath).toLowerCase();

--- a/src/tools/read-tool.ts
+++ b/src/tools/read-tool.ts
@@ -8,6 +8,8 @@ import { ConfigManager } from '../utils/config';
 import { isPrimaryModelVisionCapable } from '../utils/model-capabilities';
 import { analyzeImageWithReaderProxy, ReaderProxyResult } from '../utils/reader-proxy';
 import { resolveLocalFileAccess, resolveLocalFileReference } from './local-file-gateway';
+import { formatCatsCoVisiblePath, resolveToolGatewayAccess } from './tool-gateway';
+import { executeRemoteReadonlyTool } from './device-rpc-tool';
 
 export const DEFAULT_TEXT_READ_LIMIT = 200;
 export const MAX_TEXT_READ_LIMIT = 2000;
@@ -92,7 +94,9 @@ export class ReadTool implements Tool {
     let absolutePath: string;
     let displayPath = file_path;
     let visiblePath: string;
+    let visibleInputPath = file_path;
     let resolvedFromAttachmentRef = false;
+    let authorizedByLocalFileGrant = false;
 
     const reference = resolveLocalFileReference(context, {
       operation: 'read_file',
@@ -109,17 +113,14 @@ export class ReadTool implements Tool {
       absolutePath = reference.absolutePath;
       displayPath = reference.displayPath;
       visiblePath = reference.displayPath;
+      visibleInputPath = reference.displayPath;
       resolvedFromAttachmentRef = true;
+      authorizedByLocalFileGrant = true;
     } else {
       absolutePath = path.isAbsolute(file_path)
         ? file_path
         : path.join(context.workingDirectory, file_path);
       visiblePath = absolutePath;
-
-      const pathPermission = isReadPathAllowed(absolutePath, context.workingDirectory);
-      if (!pathPermission.allowed) {
-        return { ok: false, errorCode: 'PERMISSION_DENIED', message: `执行被阻止: ${pathPermission.reason}` };
-      }
     }
 
     if (!resolvedFromAttachmentRef) {
@@ -137,7 +138,34 @@ export class ReadTool implements Tool {
       if (localAccess.displayPath) {
         displayPath = localAccess.displayPath;
         visiblePath = localAccess.displayPath;
+        visibleInputPath = localAccess.displayPath;
       }
+      authorizedByLocalFileGrant = Boolean(localAccess.grant);
+    }
+
+    if (!authorizedByLocalFileGrant) {
+      const gateway = resolveToolGatewayAccess(context, {
+        toolName: this.definition.name,
+        operation: 'read_file',
+        targetLabel: displayPath,
+      });
+      if (!gateway.ok) {
+        return {
+          ok: false,
+          errorCode: gateway.errorCode,
+          message: gateway.message,
+        };
+      }
+      const remoteResult = await executeRemoteReadonlyTool(context, gateway, 'read_file', 'read_file', args);
+      if (remoteResult) return remoteResult;
+
+      const pathPermission = isReadPathAllowed(absolutePath, context.workingDirectory);
+      if (!pathPermission.allowed) {
+        return { ok: false, errorCode: 'PERMISSION_DENIED', message: `执行被阻止: ${pathPermission.reason}` };
+      }
+      displayPath = formatCatsCoVisiblePath(context, displayPath, { preserveRelative: true });
+      visiblePath = formatCatsCoVisiblePath(context, visiblePath);
+      visibleInputPath = formatCatsCoVisiblePath(context, file_path);
     }
 
     if (!fs.existsSync(absolutePath)) {
@@ -152,7 +180,7 @@ export class ReadTool implements Tool {
           errorCode: 'TOOL_EXECUTION_ERROR',
           message: [
             'Path is not a file.',
-            `Input path: ${file_path}`,
+            `Input path: ${visibleInputPath}`,
             `Resolved path: ${visiblePath}`,
           ].join('\n'),
         };

--- a/src/tools/send-file-tool.ts
+++ b/src/tools/send-file-tool.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import { Logger } from '../utils/logger';
 import { resolveToolPath } from '../utils/tool-path-resolver';
+import { resolveLocalFileAccess } from './local-file-gateway';
 import { resolveOutboundTarget } from './outbound-gateway';
 
 export class SendFileTool implements Tool {
@@ -80,6 +81,18 @@ CatsCo file selection rules:
           `Input path: ${resolved.inputPath}`,
           `Resolved path: ${resolved.absolutePath}`,
         ].join('\n'),
+      };
+    }
+
+    const localAccess = resolveLocalFileAccess(context, {
+      operation: 'send_file',
+      absolutePath: resolved.absolutePath,
+    });
+    if (!localAccess.ok) {
+      return {
+        ok: false,
+        errorCode: localAccess.errorCode,
+        message: localAccess.message,
       };
     }
 

--- a/src/tools/send-file-tool.ts
+++ b/src/tools/send-file-tool.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import { Logger } from '../utils/logger';
 import { resolveToolPath } from '../utils/tool-path-resolver';
+import { resolveOutboundTarget } from './outbound-gateway';
 
 export class SendFileTool implements Tool {
   definition: ToolDefinition = {
@@ -83,12 +84,20 @@ CatsCo file selection rules:
     }
 
     const channel = context.channel;
-    if (!channel) {
-      return { ok: false, errorCode: 'TOOL_EXECUTION_ERROR', message: '当前不在聊天会话中，无法发送文件' };
+    const target = resolveOutboundTarget(context, {
+      operation: 'send_file',
+      missingChannelMessage: '当前不在聊天会话中，无法发送文件',
+    });
+    if (!target.ok) {
+      return {
+        ok: false,
+        errorCode: target.errorCode,
+        message: target.message,
+      };
     }
 
     try {
-      await channel.sendFile(channel.chatId, resolved.absolutePath, file_name);
+      await channel!.sendFile(target.chatId, resolved.absolutePath, file_name);
       Logger.info(`[send_file] 已发送: ${file_name} (${resolved.absolutePath})`);
       return {
         ok: true,

--- a/src/tools/send-file-tool.ts
+++ b/src/tools/send-file-tool.ts
@@ -4,6 +4,7 @@ import { Logger } from '../utils/logger';
 import { resolveToolPath } from '../utils/tool-path-resolver';
 import { resolveLocalFileAccess, resolveLocalFileReference } from './local-file-gateway';
 import { resolveOutboundTarget } from './outbound-gateway';
+import { formatCatsCoVisiblePath, resolveToolGatewayAccess } from './tool-gateway';
 
 export class SendFileTool implements Tool {
   definition: ToolDefinition = {
@@ -47,7 +48,9 @@ CatsCo file selection rules:
 
     let absolutePath: string;
     let displayPath: string;
+    let visibleInputPath = file_path;
     let resolvedFromAttachmentRef = false;
+    let authorizedByLocalFileGrant = false;
 
     const reference = resolveLocalFileReference(context, {
       operation: 'send_file',
@@ -63,7 +66,9 @@ CatsCo file selection rules:
       }
       absolutePath = reference.absolutePath;
       displayPath = reference.displayPath;
+      visibleInputPath = reference.displayPath;
       resolvedFromAttachmentRef = true;
+      authorizedByLocalFileGrant = true;
     } else {
       const resolved = resolveToolPath(file_path, context);
       absolutePath = resolved.absolutePath;
@@ -84,7 +89,38 @@ CatsCo file selection rules:
       }
       if (localAccess.displayPath) {
         displayPath = localAccess.displayPath;
+        visibleInputPath = localAccess.displayPath;
       }
+      authorizedByLocalFileGrant = Boolean(localAccess.grant);
+    }
+
+    const earlyTarget = resolveOutboundTarget(context, {
+      operation: 'send_file',
+      missingChannelMessage: '当前不在聊天会话中，无法发送文件',
+    });
+    if (!earlyTarget.ok && /外发目标与当前执行身份不一致/.test(earlyTarget.message)) {
+      return {
+        ok: false,
+        errorCode: earlyTarget.errorCode,
+        message: earlyTarget.message,
+      };
+    }
+
+    if (!authorizedByLocalFileGrant) {
+      const gateway = resolveToolGatewayAccess(context, {
+        toolName: this.definition.name,
+        operation: 'send_file',
+        targetLabel: displayPath,
+      });
+      if (!gateway.ok) {
+        return {
+          ok: false,
+          errorCode: gateway.errorCode,
+          message: gateway.message,
+        };
+      }
+      displayPath = formatCatsCoVisiblePath(context, displayPath, { preserveRelative: true });
+      visibleInputPath = displayPath;
     }
 
     if (!fs.existsSync(absolutePath)) {
@@ -93,7 +129,7 @@ CatsCo file selection rules:
         errorCode: 'FILE_NOT_FOUND',
         message: [
           'File not found.',
-          `Input path: ${file_path}`,
+          `Input path: ${visibleInputPath}`,
           `Resolved path: ${displayPath}`,
         ].join('\n'),
       };
@@ -107,7 +143,7 @@ CatsCo file selection rules:
           errorCode: 'TOOL_EXECUTION_ERROR',
           message: [
             'Path is not a file.',
-            `Input path: ${file_path}`,
+            `Input path: ${visibleInputPath}`,
             `Resolved path: ${displayPath}`,
           ].join('\n'),
         };
@@ -118,7 +154,7 @@ CatsCo file selection rules:
         errorCode: 'FILE_NOT_FOUND',
         message: [
           'File not found.',
-          `Input path: ${file_path}`,
+          `Input path: ${visibleInputPath}`,
           `Resolved path: ${displayPath}`,
         ].join('\n'),
       };
@@ -132,14 +168,14 @@ CatsCo file selection rules:
         errorCode: 'PERMISSION_DENIED',
         message: [
           'File is not readable.',
-          `Input path: ${file_path}`,
+          `Input path: ${visibleInputPath}`,
           `Resolved path: ${displayPath}`,
         ].join('\n'),
       };
     }
 
     const channel = context.channel;
-    const target = resolveOutboundTarget(context, {
+    const target = earlyTarget.ok ? earlyTarget : resolveOutboundTarget(context, {
       operation: 'send_file',
       missingChannelMessage: '当前不在聊天会话中，无法发送文件',
     });

--- a/src/tools/send-file-tool.ts
+++ b/src/tools/send-file-tool.ts
@@ -2,20 +2,20 @@ import * as fs from 'fs';
 import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import { Logger } from '../utils/logger';
 import { resolveToolPath } from '../utils/tool-path-resolver';
-import { resolveLocalFileAccess } from './local-file-gateway';
+import { resolveLocalFileAccess, resolveLocalFileReference } from './local-file-gateway';
 import { resolveOutboundTarget } from './outbound-gateway';
 
 export class SendFileTool implements Tool {
   definition: ToolDefinition = {
     name: 'send_file',
-    description: `Send a local file to the current chat.
+    description: `Send a local file or authorized CatsCo attachment reference to the current chat.
 
-Use this only when file_path points to a real local file that should be sent to the user. file_path can be absolute or relative to the current directory.
+Use this only when file_path points to a real local file that should be sent to the user, or to an authorized CatsCo attachment reference from the current user turn. file_path can be absolute, relative to the current directory, or catsco_attachment:<id>.
 
 CatsCo file selection rules:
-- tmp/downloads/... is the local cache for files/images received from chat. Do not use it when the user asks for a new/local file or a file they have not sent before.
+- tmp/downloads/... is an internal cache for files/images received from chat. Prefer current catsco_attachment:<id> references for chat attachments instead of raw cache paths.
 - If the user did not provide an exact local path, ask for the path or search likely local folders first.
-    - Only resend tmp/downloads/... files when the user explicitly asks to resend/open an earlier chat attachment.
+    - Do not invent or reuse old catsco_attachment:<id> references, old tmp/downloads paths, old URLs, or old filenames.
     - After sending a file, keep the final reply short.`,
     transcriptMode: 'outbound_file',
     parameters: {
@@ -23,7 +23,7 @@ CatsCo file selection rules:
       properties: {
         file_path: {
           type: 'string',
-          description: '要发送的文件路径，可以是绝对路径，也可以是相对当前目录的路径。',
+          description: '要发送的文件路径，或当前 CatsCo 用户轮次中的授权附件引用。可以是绝对路径、相对当前目录的路径，或 catsco_attachment:<id>。',
         },
         file_name: {
           type: 'string',
@@ -45,55 +45,80 @@ CatsCo file selection rules:
       return { ok: false, errorCode: 'TOOL_EXECUTION_ERROR', message: '文件名不能为空' };
     }
 
-    const resolved = resolveToolPath(file_path, context);
-    if (!resolved.exists) {
-      return {
-        ok: false,
-        errorCode: 'FILE_NOT_FOUND',
-        message: [
-          'File not found.',
-          `Input path: ${resolved.inputPath}`,
-          `Resolved path: ${resolved.absolutePath}`,
-        ].join('\n'),
-      };
-    }
+    let absolutePath: string;
+    let displayPath: string;
+    let resolvedFromAttachmentRef = false;
 
-    if (!resolved.isFile) {
-      return {
-        ok: false,
-        errorCode: 'TOOL_EXECUTION_ERROR',
-        message: [
-          'Path is not a file.',
-          `Input path: ${resolved.inputPath}`,
-          `Resolved path: ${resolved.absolutePath}`,
-        ].join('\n'),
-      };
+    const reference = resolveLocalFileReference(context, {
+      operation: 'send_file',
+      inputPath: file_path,
+    });
+    if (reference.matched) {
+      if (!reference.ok) {
+        return {
+          ok: false,
+          errorCode: reference.errorCode,
+          message: reference.message,
+        };
+      }
+      absolutePath = reference.absolutePath;
+      displayPath = reference.displayPath;
+      resolvedFromAttachmentRef = true;
+    } else {
+      const resolved = resolveToolPath(file_path, context);
+      absolutePath = resolved.absolutePath;
+      displayPath = resolved.absolutePath;
+      if (!resolved.exists) {
+        return {
+          ok: false,
+          errorCode: 'FILE_NOT_FOUND',
+          message: [
+            'File not found.',
+            `Input path: ${resolved.inputPath}`,
+            `Resolved path: ${resolved.absolutePath}`,
+          ].join('\n'),
+        };
+      }
+
+      if (!resolved.isFile) {
+        return {
+          ok: false,
+          errorCode: 'TOOL_EXECUTION_ERROR',
+          message: [
+            'Path is not a file.',
+            `Input path: ${resolved.inputPath}`,
+            `Resolved path: ${resolved.absolutePath}`,
+          ].join('\n'),
+        };
+      }
     }
 
     try {
-      fs.accessSync(resolved.absolutePath, fs.constants.R_OK);
+      fs.accessSync(absolutePath, fs.constants.R_OK);
     } catch {
       return {
         ok: false,
         errorCode: 'PERMISSION_DENIED',
         message: [
           'File is not readable.',
-          `Input path: ${resolved.inputPath}`,
-          `Resolved path: ${resolved.absolutePath}`,
+          `Input path: ${file_path}`,
+          `Resolved path: ${displayPath}`,
         ].join('\n'),
       };
     }
 
-    const localAccess = resolveLocalFileAccess(context, {
-      operation: 'send_file',
-      absolutePath: resolved.absolutePath,
-    });
-    if (!localAccess.ok) {
-      return {
-        ok: false,
-        errorCode: localAccess.errorCode,
-        message: localAccess.message,
-      };
+    if (!resolvedFromAttachmentRef) {
+      const localAccess = resolveLocalFileAccess(context, {
+        operation: 'send_file',
+        absolutePath,
+      });
+      if (!localAccess.ok) {
+        return {
+          ok: false,
+          errorCode: localAccess.errorCode,
+          message: localAccess.message,
+        };
+      }
     }
 
     const channel = context.channel;
@@ -110,13 +135,13 @@ CatsCo file selection rules:
     }
 
     try {
-      await channel!.sendFile(target.chatId, resolved.absolutePath, file_name);
-      Logger.info(`[send_file] 已发送: ${file_name} (${resolved.absolutePath})`);
+      await channel!.sendFile(target.chatId, absolutePath, file_name);
+      Logger.info(`[send_file] 已发送: ${file_name} (${absolutePath})`);
       return {
         ok: true,
         content: [
           'File sent to current chat.',
-          `Path: ${resolved.absolutePath}`,
+          `Path: ${displayPath}`,
           `Name: ${file_name}`,
         ].join('\n'),
       };
@@ -127,7 +152,7 @@ CatsCo file selection rules:
         errorCode: 'TOOL_EXECUTION_ERROR',
         message: [
           `File send failed: ${error.message}`,
-          `Path: ${resolved.absolutePath}`,
+          `Path: ${displayPath}`,
           `Name: ${file_name}`,
         ].join('\n'),
       };

--- a/src/tools/send-file-tool.ts
+++ b/src/tools/send-file-tool.ts
@@ -68,43 +68,6 @@ CatsCo file selection rules:
       const resolved = resolveToolPath(file_path, context);
       absolutePath = resolved.absolutePath;
       displayPath = resolved.absolutePath;
-      if (!resolved.exists) {
-        return {
-          ok: false,
-          errorCode: 'FILE_NOT_FOUND',
-          message: [
-            'File not found.',
-            `Input path: ${resolved.inputPath}`,
-            `Resolved path: ${resolved.absolutePath}`,
-          ].join('\n'),
-        };
-      }
-
-      if (!resolved.isFile) {
-        return {
-          ok: false,
-          errorCode: 'TOOL_EXECUTION_ERROR',
-          message: [
-            'Path is not a file.',
-            `Input path: ${resolved.inputPath}`,
-            `Resolved path: ${resolved.absolutePath}`,
-          ].join('\n'),
-        };
-      }
-    }
-
-    try {
-      fs.accessSync(absolutePath, fs.constants.R_OK);
-    } catch {
-      return {
-        ok: false,
-        errorCode: 'PERMISSION_DENIED',
-        message: [
-          'File is not readable.',
-          `Input path: ${file_path}`,
-          `Resolved path: ${displayPath}`,
-        ].join('\n'),
-      };
     }
 
     if (!resolvedFromAttachmentRef) {
@@ -119,6 +82,60 @@ CatsCo file selection rules:
           message: localAccess.message,
         };
       }
+      if (localAccess.displayPath) {
+        displayPath = localAccess.displayPath;
+      }
+    }
+
+    if (!fs.existsSync(absolutePath)) {
+      return {
+        ok: false,
+        errorCode: 'FILE_NOT_FOUND',
+        message: [
+          'File not found.',
+          `Input path: ${file_path}`,
+          `Resolved path: ${displayPath}`,
+        ].join('\n'),
+      };
+    }
+
+    try {
+      const stats = fs.statSync(absolutePath);
+      if (!stats.isFile()) {
+        return {
+          ok: false,
+          errorCode: 'TOOL_EXECUTION_ERROR',
+          message: [
+            'Path is not a file.',
+            `Input path: ${file_path}`,
+            `Resolved path: ${displayPath}`,
+          ].join('\n'),
+        };
+      }
+    } catch {
+      return {
+        ok: false,
+        errorCode: 'FILE_NOT_FOUND',
+        message: [
+          'File not found.',
+          `Input path: ${file_path}`,
+          `Resolved path: ${displayPath}`,
+        ].join('\n'),
+      };
+    }
+
+    try {
+      fs.accessSync(absolutePath, fs.constants.R_OK);
+    } catch {
+      return {
+        ok: false,
+        errorCode: 'PERMISSION_DENIED',
+        message: [
+          'File is not readable.',
+          `Input path: ${file_path}`,
+          `Resolved path: ${displayPath}`,
+        ].join('\n'),
+      };
     }
 
     const channel = context.channel;
@@ -146,16 +163,23 @@ CatsCo file selection rules:
         ].join('\n'),
       };
     } catch (error: any) {
+      const safeErrorMessage = redactToolVisiblePath(error.message, absolutePath, displayPath);
       Logger.error(`文件发送失败 (sendFile): ${error.message}`);
       return {
         ok: false,
         errorCode: 'TOOL_EXECUTION_ERROR',
         message: [
-          `File send failed: ${error.message}`,
+          `File send failed: ${safeErrorMessage}`,
           `Path: ${displayPath}`,
           `Name: ${file_name}`,
         ].join('\n'),
       };
     }
   }
+}
+
+function redactToolVisiblePath(message: unknown, absolutePath: string, displayPath: string): string {
+  const text = String(message || '');
+  if (!absolutePath || !displayPath || absolutePath === displayPath) return text;
+  return text.split(absolutePath).join(displayPath);
 }

--- a/src/tools/send-text-tool.ts
+++ b/src/tools/send-text-tool.ts
@@ -1,4 +1,5 @@
 import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
+import { resolveOutboundTarget } from './outbound-gateway';
 
 /**
  * send_text 工具
@@ -24,16 +25,23 @@ export class SendTextTool implements Tool {
   async execute(args: { text: string }, context: ToolExecutionContext): Promise<ToolExecutionResult> {
     const { text } = args;
 
-    if (!context.channel) {
-      throw new Error('send_text 需要 channel 上下文');
-    }
-
     if (!text || !text.trim()) {
       throw new Error('text 不能为空');
     }
 
-    const chatId = context.channel.chatId;
-    await context.channel.reply(chatId, text.trim());
+    const target = resolveOutboundTarget(context, {
+      operation: 'send_text',
+      missingChannelMessage: 'send_text 需要 channel 上下文',
+    });
+    if (!target.ok) {
+      return {
+        ok: false,
+        errorCode: target.errorCode,
+        message: target.message,
+      };
+    }
+
+    await context.channel!.reply(target.chatId, text.trim());
 
     return { ok: true, content: '已发送' };
   }

--- a/src/tools/spawn-subagent-tool.ts
+++ b/src/tools/spawn-subagent-tool.ts
@@ -5,6 +5,9 @@ import { AIService } from '../utils/ai-service';
 import { SkillManager } from '../skills/skill-manager';
 import { Logger } from '../utils/logger';
 import { styles } from '../theme/colors';
+import { isCatsCoToolGatewayContext } from './tool-gateway';
+
+const CATSCO_SUBAGENT_ALLOWED_TOOLS = ['ask_parent'] as const;
 
 /**
  * spawn_subagent - 派遣子智能体后台执行隔离任务
@@ -98,6 +101,10 @@ export class SpawnSubagentTool implements Tool {
     if (!maxTurnsResult.ok) {
       return { ok: false, errorCode: 'INVALID_TOOL_ARGUMENTS', message: maxTurnsResult.message };
     }
+    const catsCoSubAgentTools = resolveCatsCoSubAgentAllowedTools(context, allowedToolsResult.value);
+    if (!catsCoSubAgentTools.ok) {
+      return { ok: false, errorCode: 'PERMISSION_DENIED', message: catsCoSubAgentTools.message };
+    }
 
     const manager = SubAgentManager.getInstance();
     const sessionKey = context.sessionId || 'unknown';
@@ -111,7 +118,7 @@ export class SpawnSubagentTool implements Tool {
         agentType,
         toolScope,
         subAgentPrompt,
-        allowedTools: allowedToolsResult.value,
+        allowedTools: catsCoSubAgentTools.value,
         maxTurns: maxTurnsResult.value,
         taskDescription,
         userMessage,
@@ -132,7 +139,7 @@ export class SpawnSubagentTool implements Tool {
     console.log(styles.text(`   ID: ${result.id}`));
     const displayAgentType = result.agentType || agentType || (skillName ? 'skill' : 'worker');
     const displayToolScope = result.toolScope || toolScope || defaultToolScopeFor(displayAgentType);
-    const effectiveAllowedTools = result.allowedTools ?? allowedToolsResult.value;
+    const effectiveAllowedTools = result.allowedTools ?? catsCoSubAgentTools.value;
 
     console.log(styles.text(`   Type: ${displayAgentType}`));
     console.log(styles.text(`   Scope: ${displayToolScope}\n`));
@@ -149,6 +156,35 @@ export class SpawnSubagentTool implements Tool {
       `完成后会以后台结果通知回到主会话；你仍负责主线推进和最终回复。`,
     ].filter(Boolean).join('\n') };
   }
+}
+
+function resolveCatsCoSubAgentAllowedTools(
+  context: ToolExecutionContext,
+  requestedTools?: string[],
+): { ok: true; value?: string[] } | { ok: false; message: string } {
+  const hasCatsCoDeviceContext = isCatsCoToolGatewayContext(context)
+    && Boolean(context.executionScope || context.deviceGrants?.length || context.localFileGrants?.length || context.localDeviceGrant);
+  if (!hasCatsCoDeviceContext) {
+    return { ok: true, value: requestedTools };
+  }
+
+  if (!requestedTools) {
+    return { ok: true, value: [...CATSCO_SUBAGENT_ALLOWED_TOOLS] };
+  }
+
+  const deniedTools = requestedTools.filter(tool => !CATSCO_SUBAGENT_ALLOWED_TOOLS.includes(tool as any));
+  if (deniedTools.length > 0) {
+    return {
+      ok: false,
+      message: [
+        'CatsCo 用户设备授权不会传递给子智能体，已阻止子智能体使用本地文件或命令工具。',
+        `被拒绝的工具: ${deniedTools.join(', ')}`,
+        '请在主会话当前 turn 中直接使用已授权工具，或让子智能体通过 ask_parent 请求主会话继续处理。',
+      ].join('\n'),
+    };
+  }
+
+  return { ok: true, value: requestedTools };
 }
 
 function normalizeMaxTurns(value: unknown): { ok: true; value?: number } | { ok: false; message: string } {

--- a/src/tools/tool-gateway.ts
+++ b/src/tools/tool-gateway.ts
@@ -1,0 +1,316 @@
+import type { DeviceGrantOperation, ScopedDeviceGrant, ScopedDeviceSelection, ScopedLocalDeviceGrant } from '../types/session-identity';
+import type { ToolErrorCode, ToolExecutionContext } from '../types/tool';
+import { resolveDeviceGrant } from '../core/device-grants';
+
+export type ToolGatewayDecision =
+  | {
+      ok: true;
+      mode: 'local';
+      grant?: ScopedDeviceGrant;
+      targetDeviceId?: string;
+      targetDeviceDisplayName?: string;
+    }
+  | {
+      ok: true;
+      mode: 'remote';
+      grant: ScopedDeviceGrant;
+      targetDeviceId: string;
+      targetDeviceDisplayName?: string;
+      targetDeviceBodyId?: string;
+      targetDeviceInstallationId?: string;
+    }
+  | { ok: false; errorCode: ToolErrorCode; message: string };
+
+export interface ResolveToolGatewayAccessOptions {
+  toolName: string;
+  operation: DeviceGrantOperation;
+  targetLabel?: string;
+  allowCatsCoShell?: boolean;
+}
+
+export interface CatsCoVisiblePathOptions {
+  fallback?: string;
+  preserveRelative?: boolean;
+}
+
+const REMOTE_READONLY_OPERATIONS = new Set<DeviceGrantOperation>(['read_file', 'glob', 'grep']);
+
+export function isCatsCoToolGatewayContext(context: ToolExecutionContext): boolean {
+  return context.surface === 'catscompany' || context.executionScope?.source === 'catscompany';
+}
+
+export function formatCatsCoVisiblePath(
+  context: ToolExecutionContext,
+  value: string | undefined,
+  options: CatsCoVisiblePathOptions = {},
+): string {
+  const fallback = options.fallback ?? '[current CatsCo device]';
+  const text = String(value || '').trim();
+  if (!isCatsCoToolGatewayContext(context)) {
+    return text || fallback;
+  }
+  if (!text) return fallback;
+  if (/^catsco_attachment:[A-Za-z0-9._:-]+$/.test(text)) return text;
+  if (/^\[CatsCo [^\]]+\]$/.test(text)) return text;
+  if (options.preserveRelative && !looksLikeAbsoluteLocalPath(text)) return text;
+  return fallback;
+}
+
+export function redactCatsCoVisiblePath(
+  context: ToolExecutionContext,
+  message: unknown,
+  rawPath: string,
+  visiblePath?: string,
+): string {
+  const text = String(message || '');
+  if (!isCatsCoToolGatewayContext(context) || !rawPath) return text;
+  const replacement = visiblePath ?? formatCatsCoVisiblePath(context, rawPath);
+  return text.split(rawPath).join(replacement);
+}
+
+export function resolveToolGatewayAccess(
+  context: ToolExecutionContext,
+  options: ResolveToolGatewayAccessOptions,
+): ToolGatewayDecision {
+  if (!isCatsCoToolGatewayContext(context)) {
+    return { ok: true, mode: 'local' };
+  }
+
+  if (options.operation === 'execute_shell' && !options.allowCatsCoShell) {
+    return denied([
+      'CatsCo 会话暂不允许通过 execute_shell 直接操作本机命令行。',
+      '当前 PR 只开放文件级设备授权；命令执行需要后续独立审批和更细的命令策略。',
+    ], options.targetLabel);
+  }
+
+  const scope = context.executionScope;
+  if (!scope || scope.source !== 'catscompany') {
+    return denied(['当前工具调用缺少 CatsCo 执行身份，已阻止本地设备操作。'], options.targetLabel);
+  }
+
+  if (scope.identityTrust !== 'server_canonical' || !scope.isTrusted) {
+    return denied(['当前消息身份未通过服务端一致性校验，已阻止本地设备操作。'], options.targetLabel);
+  }
+
+  const localDevice = context.localDeviceGrant;
+  if (!localDevice || localDevice.source !== 'catscompany') {
+    return denied(['当前运行体缺少 CatsCo 本机设备绑定，已阻止本地设备操作。'], options.targetLabel);
+  }
+
+  const selectionScope = validateSelectionScope(context.deviceSelection, scope, options.targetLabel);
+  if (!selectionScope.ok) return selectionScope;
+
+  const selectedTarget = resolveBackendSelectedDevice(
+    context.deviceSelection,
+    localDevice,
+    options.operation,
+    options.targetLabel,
+  );
+  if (!selectedTarget.ok) return selectedTarget;
+
+  const targetDeviceId = selectedTarget.deviceId || localDevice.deviceId || localDevice.installationId || localDevice.bodyId;
+  const decision = resolveDeviceGrant(context, {
+    operation: options.operation,
+    deviceId: targetDeviceId,
+  });
+  if (!decision.ok) {
+    return denied([
+      `当前会话没有允许当前设备执行 ${options.operation} 的短期授权，已阻止 ${options.toolName}。`,
+      '请确认用户已在对应设备授权，或等待服务端为本轮消息下发匹配的 device_grant。',
+    ], options.targetLabel);
+  }
+
+  const grant = decision.grant;
+  if (selectedTarget.mode === 'remote') {
+    if (!REMOTE_READONLY_OPERATIONS.has(options.operation)) {
+      return denied([
+        `后端选定的用户设备不是当前运行体，但 ${options.operation} 还没有开放远程执行。`,
+        '当前 PR 只开放 read_file / glob / grep 三个只读远程工具。',
+      ], options.targetLabel);
+    }
+    if (!context.deviceRpc) {
+      return denied([
+        '后端选定的用户设备不是当前运行体，且当前运行体没有配置远程设备 RPC 通道。',
+        '已阻止本地 fallback，避免误操作当前设备或串设备。',
+        selectedTarget.displayName ? `Selected device: ${selectedTarget.displayName}` : '',
+      ], options.targetLabel);
+    }
+    return {
+      ok: true,
+      mode: 'remote',
+      grant,
+      targetDeviceId: selectedTarget.deviceId,
+      targetDeviceDisplayName: selectedTarget.displayName,
+      targetDeviceBodyId: selectedTarget.bodyId,
+      targetDeviceInstallationId: selectedTarget.installationId,
+    };
+  }
+
+  const mismatches: string[] = [];
+  if (grant.deviceBodyId && localDevice.bodyId && grant.deviceBodyId !== localDevice.bodyId) {
+    mismatches.push('device body');
+  }
+  if (grant.deviceInstallationId && localDevice.installationId && grant.deviceInstallationId !== localDevice.installationId) {
+    mismatches.push('device installation');
+  }
+  if (mismatches.length > 0) {
+    return denied([
+      '设备授权与当前运行体不一致，已阻止本地设备操作以避免串设备。',
+      `不一致字段: ${mismatches.join(', ')}`,
+    ], options.targetLabel);
+  }
+
+  return {
+    ok: true,
+    mode: 'local',
+    grant,
+    targetDeviceId,
+    targetDeviceDisplayName: selectedTarget.displayName,
+  };
+}
+
+type SelectedDeviceDecision =
+  | {
+      ok: true;
+      mode: 'local';
+      deviceId?: string;
+      displayName?: string;
+    }
+  | {
+      ok: true;
+      mode: 'remote';
+      deviceId: string;
+      displayName?: string;
+      bodyId?: string;
+      installationId?: string;
+    }
+  | { ok: false; errorCode: ToolErrorCode; message: string };
+
+function resolveBackendSelectedDevice(
+  selection: ScopedDeviceSelection | undefined,
+  localDevice: ScopedLocalDeviceGrant,
+  operation: DeviceGrantOperation,
+  targetLabel?: string,
+): SelectedDeviceDecision {
+  if (!selection) {
+    return {
+      ok: true,
+      mode: 'local',
+      deviceId: localDevice.deviceId || localDevice.installationId || localDevice.bodyId,
+    };
+  }
+
+  if (selection.status === 'needs_selection') {
+    return selectedDenied([
+      '后端尚未选定要操作的用户设备，已阻止本地设备操作。',
+      '请让用户从可用设备中选择一个设备名后再继续。',
+    ], targetLabel);
+  }
+  if (selection.status === 'unavailable') {
+    return selectedDenied([
+      '当前用户没有可用的在线设备授权，已阻止本地设备操作。',
+      '请让用户打开并授权目标设备后再继续。',
+    ], targetLabel);
+  }
+
+  const selectedDeviceId = selection.selectedDeviceId;
+  if (!selectedDeviceId) {
+    return selectedDenied(['后端设备选择缺少 selectedDeviceId，已阻止本地设备操作。'], targetLabel);
+  }
+
+  if (Array.isArray(selection.selectedDeviceOperations)
+    && selection.selectedDeviceOperations.length > 0
+    && !selection.selectedDeviceOperations.includes(operation)) {
+    return selectedDenied([
+      `后端选定设备没有声明支持 ${operation}，已阻止设备工具调用。`,
+      selection.selectedDeviceDisplayName ? `Selected device: ${selection.selectedDeviceDisplayName}` : '',
+    ], targetLabel);
+  }
+
+  if (matchesLocalDevice(selection, localDevice)) {
+    return {
+      ok: true,
+      mode: 'local',
+      deviceId: selectedDeviceId,
+      displayName: selection.selectedDeviceDisplayName,
+    };
+  }
+
+  return {
+    ok: true,
+    mode: 'remote',
+    deviceId: selectedDeviceId,
+    displayName: selection.selectedDeviceDisplayName,
+    bodyId: selection.selectedDeviceBodyId,
+    installationId: selection.selectedDeviceInstallationId,
+  };
+}
+
+function selectedDenied(lines: string[], targetLabel?: string): SelectedDeviceDecision {
+  return denied(lines, targetLabel) as Extract<SelectedDeviceDecision, { ok: false }>;
+}
+
+function validateSelectionScope(
+  selection: ScopedDeviceSelection | undefined,
+  scope: NonNullable<ToolExecutionContext['executionScope']>,
+  targetLabel?: string,
+): ToolGatewayDecision {
+  if (!selection) return { ok: true, mode: 'local' };
+  if (selection.identityTrust !== 'server_canonical') {
+    return denied(['后端设备选择不是服务端可信身份生成的，已阻止设备工具调用。'], targetLabel);
+  }
+  const mismatches = [
+    ['source', selection.source, scope.source],
+    ['sessionKey', selection.sessionKey, scope.sessionKey],
+    ['topicId', selection.topicId, scope.topicId],
+    ['topicType', selection.topicType, scope.topicType],
+    ['actorUserId', selection.actorUserId, scope.actorUserId],
+    ['agentId', selection.agentId, scope.agentId],
+  ].filter(([, selectionValue, scopeValue]) => selectionValue !== scopeValue);
+  if (mismatches.length === 0) return { ok: true, mode: 'local' };
+  return denied([
+    '后端设备选择与当前执行身份不一致，已阻止设备工具调用以避免串用户或串会话。',
+    ...mismatches.map(([field, selectionValue, scopeValue]) => `${field}: selection=${selectionValue || '(empty)'} scope=${scopeValue || '(empty)'}`),
+  ], targetLabel);
+}
+
+function matchesLocalDevice(selection: ScopedDeviceSelection, localDevice: ScopedLocalDeviceGrant): boolean {
+  const selectedIds = [
+    selection.selectedDeviceId,
+    selection.selectedDeviceInstallationId,
+    selection.selectedDeviceBodyId,
+  ].filter(Boolean);
+  const localIds = [
+    localDevice.deviceId,
+    localDevice.installationId,
+    localDevice.bodyId,
+  ].filter(Boolean);
+  if (selectedIds.length === 0 || localIds.length === 0) return false;
+  return selectedIds.some(selected => localIds.includes(selected));
+}
+
+function denied(lines: string[], targetLabel?: string): ToolGatewayDecision {
+  return {
+    ok: false,
+    errorCode: 'PERMISSION_DENIED',
+    message: [
+      ...lines,
+      targetLabel ? `Target: ${sanitizeTargetLabel(targetLabel)}` : '',
+    ].filter(Boolean).join('\n'),
+  };
+}
+
+function sanitizeTargetLabel(value: string): string {
+  const text = String(value || '').trim();
+  if (!text) return '[current CatsCo device]';
+  if (/^catsco_attachment:[A-Za-z0-9._:-]+$/.test(text)) return text;
+  if (/^\[CatsCo [^\]]+\]$/.test(text)) return text;
+  return '[current CatsCo device]';
+}
+
+function looksLikeAbsoluteLocalPath(value: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(value)
+    || /^\\\\/.test(value)
+    || /^\//.test(value)
+    || /^~[\\/]/.test(value);
+}

--- a/src/tools/write-tool.ts
+++ b/src/tools/write-tool.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import { Logger } from '../utils/logger';
 import { isToolAllowed, isPathAllowed } from '../utils/safety';
+import { formatCatsCoVisiblePath, resolveToolGatewayAccess } from './tool-gateway';
 
 /**
  * Write 工具 - 写入文件内容
@@ -45,9 +46,19 @@ export class WriteTool implements Tool {
       return { ok: false, errorCode: 'PERMISSION_DENIED', message: `执行被阻止: ${pathPermission.reason}` };
     }
 
+    const gateway = resolveToolGatewayAccess(context, {
+      toolName: this.definition.name,
+      operation: 'write_file',
+      targetLabel: file_path,
+    });
+    if (!gateway.ok) {
+      return { ok: false, errorCode: gateway.errorCode, message: gateway.message };
+    }
+
     // 获取相对路径用于显示
     const relativePath = path.relative(context.workingDirectory, absolutePath);
-    const displayPath = relativePath.startsWith('..') ? absolutePath : relativePath;
+    const rawDisplayPath = relativePath.startsWith('..') ? absolutePath : relativePath;
+    const displayPath = formatCatsCoVisiblePath(context, rawDisplayPath, { preserveRelative: true });
 
     // 检查文件是否已存在
     const fileExists = fs.existsSync(absolutePath);
@@ -89,6 +100,6 @@ export class WriteTool implements Tool {
       }
     }
 
-    return { ok: true, content: `成功${operation}文件: ${file_path}\nPath: ${absolutePath}\n行数: ${lines}\n大小: ${sizeKB} KB (${bytes} bytes)` };
+    return { ok: true, content: `成功${operation}文件: ${displayPath}\nPath: ${displayPath}\n行数: ${lines}\n大小: ${sizeKB} KB (${bytes} bytes)` };
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -98,3 +98,4 @@ export interface CommandOptions {
 export * from './agent';
 export * from './tool';
 export * from './skill';
+export * from './session-identity';

--- a/src/types/session-identity.ts
+++ b/src/types/session-identity.ts
@@ -1,0 +1,40 @@
+export type MessageSource = 'catscompany' | 'feishu' | 'weixin' | 'cli' | 'unknown';
+
+export type MessageTopicType = 'p2p' | 'group' | 'unknown';
+
+export type IdentityTrustLevel =
+  | 'server_canonical'
+  | 'legacy_context'
+  | 'untrusted';
+
+export interface MessageEnvelope {
+  source: MessageSource;
+  sessionKey: string;
+  messageId?: string;
+  topicId: string;
+  topicType: MessageTopicType;
+  actorUserId: string;
+  agentId?: string;
+  agentBodyId?: string;
+  channelSeq?: number;
+  rawText: string;
+  rawMetadata?: Record<string, unknown>;
+  permissionsSource?: string;
+  identityTrust: IdentityTrustLevel;
+  identitySource?: string;
+  warnings?: string[];
+}
+
+export interface ExecutionScope {
+  source: MessageSource;
+  sessionKey: string;
+  topicId: string;
+  topicType: MessageTopicType;
+  actorUserId: string;
+  agentId?: string;
+  agentBodyId?: string;
+  channelSeq?: number;
+  permissionsSource?: string;
+  identityTrust: IdentityTrustLevel;
+  isTrusted: boolean;
+}

--- a/src/types/session-identity.ts
+++ b/src/types/session-identity.ts
@@ -38,3 +38,38 @@ export interface ExecutionScope {
   identityTrust: IdentityTrustLevel;
   isTrusted: boolean;
 }
+
+export type LocalFileGrantKind = 'catscompany_attachment';
+export type LocalFileGrantFileType = 'file' | 'image' | 'unknown';
+export type LocalFileGrantOperation = 'read_file' | 'send_file';
+
+export interface ScopedLocalDeviceGrant {
+  kind: 'catscompany_body';
+  source: MessageSource;
+  bodyId: string;
+  installationId?: string;
+  deviceId?: string;
+  createdAt: number;
+}
+
+export interface ScopedLocalFileGrant {
+  kind: LocalFileGrantKind;
+  source: MessageSource;
+  filePath: string;
+  fileName: string;
+  fileType: LocalFileGrantFileType;
+  size: number;
+  mtimeMs: number;
+  sessionKey: string;
+  topicId: string;
+  topicType: MessageTopicType;
+  actorUserId: string;
+  agentId?: string;
+  agentBodyId: string;
+  deviceBodyId: string;
+  deviceInstallationId?: string;
+  identityTrust: IdentityTrustLevel;
+  operations: LocalFileGrantOperation[];
+  createdAt: number;
+  expiresAt: number;
+}

--- a/src/types/session-identity.ts
+++ b/src/types/session-identity.ts
@@ -10,6 +10,7 @@ export type IdentityTrustLevel =
 export interface MessageEnvelope {
   source: MessageSource;
   sessionKey: string;
+  legacySessionKey?: string;
   messageId?: string;
   topicId: string;
   topicType: MessageTopicType;
@@ -28,6 +29,7 @@ export interface MessageEnvelope {
 export interface ExecutionScope {
   source: MessageSource;
   sessionKey: string;
+  legacySessionKey?: string;
   topicId: string;
   topicType: MessageTopicType;
   actorUserId: string;
@@ -39,9 +41,50 @@ export interface ExecutionScope {
   isTrusted: boolean;
 }
 
+export interface SessionIdentitySnapshot {
+  source: MessageSource;
+  topicId: string;
+  topicType: MessageTopicType;
+  actorUserId: string;
+  agentId?: string;
+  agentBodyId?: string;
+  identityTrust: IdentityTrustLevel;
+  identitySource?: string;
+}
+
+export interface SessionRoute {
+  version: 2;
+  source: MessageSource;
+  sessionKey: string;
+  legacySessionKey?: string;
+  topicId: string;
+  topicType: MessageTopicType;
+  actorUserId: string;
+  agentId?: string;
+  agentBodyId?: string;
+  messageId?: string;
+  channelSeq?: number;
+  identityTrust: IdentityTrustLevel;
+  identitySource?: string;
+  identity: SessionIdentitySnapshot;
+}
+
 export type LocalFileGrantKind = 'catscompany_attachment';
 export type LocalFileGrantFileType = 'file' | 'image' | 'unknown';
 export type LocalFileGrantOperation = 'read_file' | 'send_file';
+export type UserDeviceStatus = 'unknown' | 'online' | 'offline';
+export type DeviceGrantStatus = 'active' | 'revoked';
+export type DeviceSelectionStatus = 'selected' | 'needs_selection' | 'unavailable';
+export type DeviceGrantOperation =
+  | 'read_file'
+  | 'write_file'
+  | 'edit_file'
+  | 'send_file'
+  | 'execute_shell'
+  | 'glob'
+  | 'grep'
+  | 'browser_control'
+  | 'desktop_control';
 
 export interface ScopedLocalDeviceGrant {
   kind: 'catscompany_body';
@@ -50,6 +93,73 @@ export interface ScopedLocalDeviceGrant {
   installationId?: string;
   deviceId?: string;
   createdAt: number;
+}
+
+export interface UserDevice {
+  kind: 'user_device';
+  source: MessageSource;
+  ownerUserId: string;
+  deviceId: string;
+  displayName?: string;
+  bodyId?: string;
+  installationId?: string;
+  identityTrust: IdentityTrustLevel;
+  identitySource?: string;
+  status: UserDeviceStatus;
+  registeredAt: number;
+  lastSeenAt?: number;
+}
+
+export interface ScopedDeviceGrant {
+  kind: 'user_device_grant';
+  source: MessageSource;
+  grantId: string;
+  status: DeviceGrantStatus;
+  identityTrust: IdentityTrustLevel;
+  identitySource?: string;
+  deviceId: string;
+  deviceDisplayName?: string;
+  deviceBodyId?: string;
+  deviceInstallationId?: string;
+  ownerUserId: string;
+  sessionKey: string;
+  topicId: string;
+  topicType: MessageTopicType;
+  actorUserId: string;
+  agentId?: string;
+  agentBodyId?: string;
+  operations: DeviceGrantOperation[];
+  createdAt: number;
+  expiresAt: number;
+}
+
+export interface DeviceSelectionCandidate {
+  deviceId: string;
+  displayName?: string;
+  operations?: DeviceGrantOperation[];
+  lastSeenAt?: number;
+}
+
+export interface ScopedDeviceSelection {
+  kind: 'user_device_selection';
+  source: MessageSource;
+  status: DeviceSelectionStatus;
+  selectionSource?: string;
+  sessionKey: string;
+  topicId: string;
+  topicType: MessageTopicType;
+  actorUserId: string;
+  agentId?: string;
+  identityTrust: IdentityTrustLevel;
+  identitySource?: string;
+  selectedDeviceId?: string;
+  selectedDeviceDisplayName?: string;
+  selectedDeviceBodyId?: string;
+  selectedDeviceInstallationId?: string;
+  selectedDeviceOperations?: DeviceGrantOperation[];
+  candidates?: DeviceSelectionCandidate[];
+  candidateCount?: number;
+  createdAt?: number;
 }
 
 export interface ScopedLocalFileGrant {

--- a/src/types/session-identity.ts
+++ b/src/types/session-identity.ts
@@ -55,6 +55,7 @@ export interface ScopedLocalDeviceGrant {
 export interface ScopedLocalFileGrant {
   kind: LocalFileGrantKind;
   source: MessageSource;
+  attachmentRef?: string;
   filePath: string;
   fileName: string;
   fileType: LocalFileGrantFileType;

--- a/src/types/tool.ts
+++ b/src/types/tool.ts
@@ -1,4 +1,5 @@
 import { ContentBlock } from './index';
+import type { ExecutionScope } from './session-identity';
 import type { PlanRuntime, RuntimePlanSnapshot } from '../core/plan-runtime';
 import type { AIService } from '../utils/ai-service';
 import type { SkillManager } from '../skills/skill-manager';
@@ -141,6 +142,8 @@ export interface ToolExecutionContext {
   runtimeServices?: RuntimeToolServices;
   /** 平台通道回调（飞书/CatsCompany 等聊天会话时由平台层注入） */
   channel?: ChannelCallbacks;
+  /** 当前 turn 的可信执行身份；后续 ToolGateway/设备授权会基于它做权限判断。 */
+  executionScope?: ExecutionScope;
 }
 
 /**

--- a/src/types/tool.ts
+++ b/src/types/tool.ts
@@ -1,5 +1,5 @@
 import { ContentBlock } from './index';
-import type { ExecutionScope } from './session-identity';
+import type { ExecutionScope, ScopedLocalDeviceGrant, ScopedLocalFileGrant } from './session-identity';
 import type { PlanRuntime, RuntimePlanSnapshot } from '../core/plan-runtime';
 import type { AIService } from '../utils/ai-service';
 import type { SkillManager } from '../skills/skill-manager';
@@ -144,6 +144,10 @@ export interface ToolExecutionContext {
   channel?: ChannelCallbacks;
   /** 当前 turn 的可信执行身份；后续 ToolGateway/设备授权会基于它做权限判断。 */
   executionScope?: ExecutionScope;
+  /** 当前本机运行体授权，例如 CatsCo body/device 绑定。 */
+  localDeviceGrant?: ScopedLocalDeviceGrant;
+  /** 当前 turn 已授权的本地文件资源，例如用户本轮上传的 CatsCo 附件缓存。 */
+  localFileGrants?: ScopedLocalFileGrant[];
 }
 
 /**

--- a/src/types/tool.ts
+++ b/src/types/tool.ts
@@ -1,5 +1,11 @@
 import { ContentBlock } from './index';
-import type { ExecutionScope, ScopedLocalDeviceGrant, ScopedLocalFileGrant } from './session-identity';
+import type {
+  ExecutionScope,
+  ScopedDeviceGrant,
+  ScopedDeviceSelection,
+  ScopedLocalDeviceGrant,
+  ScopedLocalFileGrant,
+} from './session-identity';
 import type { PlanRuntime, RuntimePlanSnapshot } from '../core/plan-runtime';
 import type { AIService } from '../utils/ai-service';
 import type { SkillManager } from '../skills/skill-manager';
@@ -84,6 +90,18 @@ export type ToolExecutionResult =
   | { ok: true; content: string | import('./index').ContentBlock[] }
   | { ok: false; errorCode: string; message: string; retryable?: boolean };
 
+export interface DeviceRpcToolRequest {
+  toolName: string;
+  operation: ScopedDeviceGrant['operations'][number];
+  args: Record<string, unknown>;
+  grant: ScopedDeviceGrant;
+  timeoutMs?: number;
+}
+
+export interface DeviceRpcTransport {
+  executeTool(request: DeviceRpcToolRequest): Promise<ToolExecutionResult>;
+}
+
 export type ToolErrorCode =
   | 'TOOL_NOT_FOUND'
   | 'INVALID_TOOL_ARGUMENTS'
@@ -146,6 +164,12 @@ export interface ToolExecutionContext {
   executionScope?: ExecutionScope;
   /** 当前本机运行体授权，例如 CatsCo body/device 绑定。 */
   localDeviceGrant?: ScopedLocalDeviceGrant;
+  /** 当前 turn 已授权的用户设备资源，供未来远程设备工具校验。 */
+  deviceGrants?: ScopedDeviceGrant[];
+  /** 服务端为当前 turn 选定的用户设备，或明确要求先选择设备。 */
+  deviceSelection?: ScopedDeviceSelection;
+  /** CatsCo 远程设备 RPC 通道。工具只能通过窄接口请求后端选定设备执行。 */
+  deviceRpc?: DeviceRpcTransport;
   /** 当前 turn 已授权的本地文件资源，例如用户本轮上传的 CatsCo 附件缓存。 */
   localFileGrants?: ScopedLocalFileGrant[];
 }

--- a/src/utils/context-debug-logger.ts
+++ b/src/utils/context-debug-logger.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { Message } from '../types';
 import { ToolDefinition } from '../types/tool';
 import { estimateMessageTokens, estimateToolsTokens } from '../core/token-estimator';
+import { TRANSIENT_RUNTIME_CONTEXT_PREFIX } from '../core/runtime-context-builder';
 
 const DEBUG_DIR = path.resolve('logs/context-debug');
 
@@ -63,6 +64,7 @@ export class ContextDebugLogger {
 
       if (msg.role === 'system') {
         if (c.startsWith('[surface:')) modules.surface_rule = { tokens: t, content: c };
+        else if (c.startsWith(TRANSIENT_RUNTIME_CONTEXT_PREFIX)) modules.runtime_context = { tokens: t, content: c };
         else if (c.startsWith('[session_context]')) modules.session_context = { tokens: t, content: c };
         else if (c.includes('[long_term_memory]')) modules.recall = { tokens: t, content: c, facts_count: recallMeta?.factsCount ?? 0 };
         else if (c.includes('[transient_subagent_status]')) modules.subagent_status = { tokens: t, content: c };

--- a/src/weixin/index.ts
+++ b/src/weixin/index.ts
@@ -10,6 +10,13 @@ import { ChannelCallbacks } from '../types/tool';
 import { AdapterRuntimeBundle, createAdapterRuntime } from '../runtime/adapter-runtime';
 import { promises as fs } from 'fs';
 import path from 'path';
+import {
+  createExecutionScopeFromRoute,
+  createSessionRoute,
+  createWeixinSessionRoute,
+  parseSessionKeyV2,
+} from '../core/session-router';
+import type { SessionRoute } from '../types/session-identity';
 
 const CHANNEL_VERSION = 'xiaoba-weixin/1.0';
 const DEFAULT_LONGPOLL_MS = 30000;
@@ -17,6 +24,8 @@ const DEFAULT_LONGPOLL_MS = 30000;
 interface QueuedMessage {
   userText: string;
   chatId: string;
+  userId: string;
+  sessionRoute: SessionRoute;
   source?: 'user' | 'subagent_feedback';
   runtimeFeedback?: RuntimeFeedbackInput[];
 }
@@ -90,17 +99,15 @@ export class WeixinBot {
     }
   }
 
-  private buildChannel(chatId: string, sessionKey: string): ChannelCallbacks {
+  private buildChannel(chatId: string, sessionKey: string, userId: string): ChannelCallbacks {
     return {
       chatId,
       reply: async (cid: string, text: string) => {
-        const userId = sessionKey.replace('user:', '');
-        const contextToken = this.contextTokens.get(sessionKey);
+        const contextToken = this.contextTokens.get(sessionKey) || this.contextTokens.get(`user:${userId}`);
         await this.sender.sendText(userId, text, contextToken);
       },
       sendFile: async (cid: string, filePath: string, fileName: string) => {
-        const userId = sessionKey.replace('user:', '');
-        const contextToken = this.contextTokens.get(sessionKey);
+        const contextToken = this.contextTokens.get(sessionKey) || this.contextTokens.get(`user:${userId}`);
         await this.sender.sendFile(userId, filePath, fileName, contextToken);
       },
     };
@@ -176,20 +183,23 @@ export class WeixinBot {
     const from = msg.from_user_id?.trim();
     if (!from) return;
 
-    const sessionKey = `user:${from}`;
-    if (msg.context_token) {
-      this.contextTokens.set(sessionKey, msg.context_token);
-      await this.saveState();
-    }
-
     const parsed = this.handler.parseMessage(msg);
     if (!parsed || this.handler.shouldIgnoreMessage(parsed)) return;
 
-    const session = this.sessionManager.getOrCreate(sessionKey);
-    const channel = this.buildChannel(msg.to_user_id, sessionKey);
+    const route = createWeixinSessionRoute(parsed);
+    const sessionKey = route.sessionKey;
+    const userId = route.actorUserId;
+    if (msg.context_token) {
+      this.contextTokens.set(sessionKey, msg.context_token);
+      this.contextTokens.set(route.legacySessionKey || `user:${userId}`, msg.context_token);
+      await this.saveState();
+    }
+
+    const session = this.sessionManager.getOrCreate(route);
+    const channel = this.buildChannel(route.topicId, sessionKey, userId);
     SubAgentManager.getInstance().registerPlatformCallbacks(sessionKey, {
       injectMessage: async (text: string) => {
-        await this.handleSubAgentFeedback(sessionKey, msg.to_user_id, text);
+        await this.handleSubAgentFeedback(sessionKey, route.topicId, userId, text, route);
       },
     });
     const expectedMediaCount = (parsed.item_list || []).filter(item =>
@@ -230,7 +240,9 @@ export class WeixinBot {
       const queue = this.messageQueue.get(sessionKey) ?? [];
       queue.push({
         userText,
-        chatId: msg.to_user_id,
+        chatId: route.topicId,
+        userId,
+        sessionRoute: route,
         source: 'user',
         runtimeFeedback,
       });
@@ -239,29 +251,43 @@ export class WeixinBot {
       return;
     }
 
-    const result = await session.handleMessage(userText, { channel, runtimeFeedback });
+    const result = await session.handleMessage(userText, {
+      channel,
+      sessionRoute: route,
+      executionScope: createExecutionScopeFromRoute(route),
+      runtimeFeedback,
+    });
     if (result.text === BUSY_MESSAGE || result.text === ERROR_MESSAGE) {
-      await channel.reply(msg.to_user_id, result.text);
+      await channel.reply(route.topicId, result.text);
     }
     await this.drainMessageQueue(sessionKey);
   }
 
-  private async handleSubAgentFeedback(sessionKey: string, chatId: string, text: string): Promise<void> {
+  private async handleSubAgentFeedback(
+    sessionKey: string,
+    chatId: string,
+    userId: string,
+    text: string,
+    sessionRoute?: SessionRoute,
+  ): Promise<void> {
     const session = this.sessionManager.getOrCreate(sessionKey);
+    const route = sessionRoute ?? this.createRouteFromSessionKey(sessionKey, userId);
 
     if (session.isBusy()) {
-      this.enqueueSubAgentFeedback(sessionKey, chatId, text);
+      this.enqueueSubAgentFeedback(sessionKey, chatId, userId, text, route);
       Logger.info(`[${sessionKey}] 主会话忙，微信子智能体反馈已入队`);
       return;
     }
 
-    const channel = this.buildChannel(chatId, sessionKey);
+    const channel = this.buildChannel(chatId, sessionKey, userId);
     const result = await session.handleRuntimeObservation(text, {
       channel,
+      sessionRoute: route,
+      executionScope: createExecutionScopeFromRoute(route),
       source: 'subagent_result',
     });
     if (result.text === BUSY_MESSAGE) {
-      this.enqueueSubAgentFeedback(sessionKey, chatId, text);
+      this.enqueueSubAgentFeedback(sessionKey, chatId, userId, text, route);
       return;
     }
     if (result.text === ERROR_MESSAGE) {
@@ -270,11 +296,20 @@ export class WeixinBot {
     await this.drainMessageQueue(sessionKey);
   }
 
-  private enqueueSubAgentFeedback(sessionKey: string, chatId: string, text: string): void {
+  private enqueueSubAgentFeedback(
+    sessionKey: string,
+    chatId: string,
+    userId: string,
+    text: string,
+    sessionRoute?: SessionRoute,
+  ): void {
+    const route = sessionRoute ?? this.createRouteFromSessionKey(sessionKey, userId);
     const queue = this.messageQueue.get(sessionKey) ?? [];
     queue.push({
       userText: text,
       chatId,
+      userId,
+      sessionRoute: route,
       source: 'subagent_feedback',
     });
     this.messageQueue.set(sessionKey, queue);
@@ -296,14 +331,19 @@ export class WeixinBot {
       return;
     }
 
-    const channel = this.buildChannel(msg.chatId, sessionKey);
+    const channel = this.buildChannel(msg.chatId, sessionKey, msg.userId);
+    const executionScope = createExecutionScopeFromRoute(msg.sessionRoute);
     const result = msg.source === 'subagent_feedback'
       ? await session.handleRuntimeObservation(msg.userText, {
         channel,
+        sessionRoute: msg.sessionRoute,
+        executionScope,
         source: 'subagent_result',
       })
       : await session.handleMessage(msg.userText, {
         channel,
+        sessionRoute: msg.sessionRoute,
+        executionScope,
         runtimeFeedback: msg.runtimeFeedback,
       });
 
@@ -311,6 +351,21 @@ export class WeixinBot {
       await channel.reply(msg.chatId, result.text);
     }
     await this.drainMessageQueue(sessionKey);
+  }
+
+  private createRouteFromSessionKey(sessionKey: string, userId: string): SessionRoute {
+    const parsed = parseSessionKeyV2(sessionKey);
+    const legacyUserId = sessionKey.startsWith('user:') ? sessionKey.slice('user:'.length) : '';
+    return createSessionRoute({
+      source: parsed?.source || 'weixin',
+      topicId: parsed?.topicId || legacyUserId || userId || 'unknown_user',
+      topicType: parsed?.topicType || 'p2p',
+      actorUserId: userId || legacyUserId || 'unknown_user',
+      agentId: parsed?.agentId,
+      identityTrust: 'legacy_context',
+      identitySource: 'weixin.runtime',
+      legacySessionKey: parsed ? (userId ? `user:${userId}` : undefined) : sessionKey,
+    });
   }
 
   destroy(): void {

--- a/tests/agent-turn-execution-scope.test.ts
+++ b/tests/agent-turn-execution-scope.test.ts
@@ -2,6 +2,8 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { AgentTurnController } from '../src/core/agent-turn-controller';
+import type { Message } from '../src/types';
 
 const agentSessionSource = readFileSync(join(process.cwd(), 'src/core/agent-session.ts'), 'utf-8');
 const agentTurnSource = readFileSync(join(process.cwd(), 'src/core/agent-turn-controller.ts'), 'utf-8');
@@ -32,4 +34,31 @@ test('ToolExecutionContext exposes executionScope for future ToolGateway checks'
   assert.match(toolTypesSource, /executionScope\?:\s*ExecutionScope/);
   assert.match(toolTypesSource, /localDeviceGrant\?:\s*ScopedLocalDeviceGrant/);
   assert.match(toolTypesSource, /localFileGrants\?:\s*ScopedLocalFileGrant\[\]/);
+});
+
+test('AgentTurnController image history replacement can preserve opaque attachment references', () => {
+  const controller = new AgentTurnController({} as any);
+  const localPath = 'C:\\tmp\\catsco-secret\\tmp\\downloads\\photo.png';
+  const messages: Message[] = [{
+    role: 'user',
+    content: [{
+      type: 'image',
+      source: {
+        type: 'base64',
+        media_type: 'image/png',
+        data: 'abc',
+      },
+      filePath: 'catsco_attachment:image-ref',
+      originalLocalPathForTest: localPath,
+    } as any],
+  }];
+
+  (controller as any).replaceBase64Images(messages);
+
+  assert.deepEqual(messages[0].content, [{
+    type: 'text',
+    text: '[图片: catsco_attachment:image-ref]',
+  }]);
+  assert.doesNotMatch(JSON.stringify(messages), /catsco-secret/);
+  assert.doesNotMatch(JSON.stringify(messages), /tmp[\\/]+downloads/);
 });

--- a/tests/agent-turn-execution-scope.test.ts
+++ b/tests/agent-turn-execution-scope.test.ts
@@ -14,6 +14,8 @@ test('AgentSession accepts executionScope in HandleMessageOptions', () => {
   assert.match(agentSessionSource, /executionScope\s*=\s*opts\.executionScope/);
   assert.match(agentSessionSource, /localDeviceGrant\?:\s*ScopedLocalDeviceGrant/);
   assert.match(agentSessionSource, /localDeviceGrant\s*=\s*opts\.localDeviceGrant/);
+  assert.match(agentSessionSource, /deviceGrants\?:\s*ScopedDeviceGrant\[\]/);
+  assert.match(agentSessionSource, /deviceGrants\s*=\s*opts\.deviceGrants/);
   assert.match(agentSessionSource, /localFileGrants\?:\s*ScopedLocalFileGrant\[\]/);
   assert.match(agentSessionSource, /localFileGrants\s*=\s*opts\.localFileGrants/);
 });
@@ -21,11 +23,14 @@ test('AgentSession accepts executionScope in HandleMessageOptions', () => {
 test('AgentTurnController forwards executionScope into ToolExecutionContext', () => {
   assert.match(agentTurnSource, /executionScope\?:\s*ExecutionScope/);
   assert.match(agentTurnSource, /localDeviceGrant\?:\s*ScopedLocalDeviceGrant/);
+  assert.match(agentTurnSource, /deviceGrants\?:\s*ScopedDeviceGrant\[\]/);
   assert.match(agentTurnSource, /localFileGrants\?:\s*ScopedLocalFileGrant\[\]/);
   assert.match(agentTurnSource, /executionScope:\s*params\.executionScope/);
   assert.match(agentTurnSource, /executionScope:\s*options\.executionScope/);
   assert.match(agentTurnSource, /localDeviceGrant:\s*params\.localDeviceGrant/);
   assert.match(agentTurnSource, /localDeviceGrant:\s*options\.localDeviceGrant/);
+  assert.match(agentTurnSource, /deviceGrants:\s*params\.deviceGrants/);
+  assert.match(agentTurnSource, /deviceGrants:\s*options\.deviceGrants/);
   assert.match(agentTurnSource, /localFileGrants:\s*params\.localFileGrants/);
   assert.match(agentTurnSource, /localFileGrants:\s*options\.localFileGrants/);
 });
@@ -33,6 +38,7 @@ test('AgentTurnController forwards executionScope into ToolExecutionContext', ()
 test('ToolExecutionContext exposes executionScope for future ToolGateway checks', () => {
   assert.match(toolTypesSource, /executionScope\?:\s*ExecutionScope/);
   assert.match(toolTypesSource, /localDeviceGrant\?:\s*ScopedLocalDeviceGrant/);
+  assert.match(toolTypesSource, /deviceGrants\?:\s*ScopedDeviceGrant\[\]/);
   assert.match(toolTypesSource, /localFileGrants\?:\s*ScopedLocalFileGrant\[\]/);
 });
 

--- a/tests/agent-turn-execution-scope.test.ts
+++ b/tests/agent-turn-execution-scope.test.ts
@@ -10,15 +10,26 @@ const toolTypesSource = readFileSync(join(process.cwd(), 'src/types/tool.ts'), '
 test('AgentSession accepts executionScope in HandleMessageOptions', () => {
   assert.match(agentSessionSource, /executionScope\?:\s*ExecutionScope/);
   assert.match(agentSessionSource, /executionScope\s*=\s*opts\.executionScope/);
-  assert.match(agentSessionSource, /executionScope,\s*\n\s*pendingUserInputProvider/);
+  assert.match(agentSessionSource, /localDeviceGrant\?:\s*ScopedLocalDeviceGrant/);
+  assert.match(agentSessionSource, /localDeviceGrant\s*=\s*opts\.localDeviceGrant/);
+  assert.match(agentSessionSource, /localFileGrants\?:\s*ScopedLocalFileGrant\[\]/);
+  assert.match(agentSessionSource, /localFileGrants\s*=\s*opts\.localFileGrants/);
 });
 
 test('AgentTurnController forwards executionScope into ToolExecutionContext', () => {
   assert.match(agentTurnSource, /executionScope\?:\s*ExecutionScope/);
+  assert.match(agentTurnSource, /localDeviceGrant\?:\s*ScopedLocalDeviceGrant/);
+  assert.match(agentTurnSource, /localFileGrants\?:\s*ScopedLocalFileGrant\[\]/);
   assert.match(agentTurnSource, /executionScope:\s*params\.executionScope/);
   assert.match(agentTurnSource, /executionScope:\s*options\.executionScope/);
+  assert.match(agentTurnSource, /localDeviceGrant:\s*params\.localDeviceGrant/);
+  assert.match(agentTurnSource, /localDeviceGrant:\s*options\.localDeviceGrant/);
+  assert.match(agentTurnSource, /localFileGrants:\s*params\.localFileGrants/);
+  assert.match(agentTurnSource, /localFileGrants:\s*options\.localFileGrants/);
 });
 
 test('ToolExecutionContext exposes executionScope for future ToolGateway checks', () => {
   assert.match(toolTypesSource, /executionScope\?:\s*ExecutionScope/);
+  assert.match(toolTypesSource, /localDeviceGrant\?:\s*ScopedLocalDeviceGrant/);
+  assert.match(toolTypesSource, /localFileGrants\?:\s*ScopedLocalFileGrant\[\]/);
 });

--- a/tests/agent-turn-execution-scope.test.ts
+++ b/tests/agent-turn-execution-scope.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const agentSessionSource = readFileSync(join(process.cwd(), 'src/core/agent-session.ts'), 'utf-8');
+const agentTurnSource = readFileSync(join(process.cwd(), 'src/core/agent-turn-controller.ts'), 'utf-8');
+const toolTypesSource = readFileSync(join(process.cwd(), 'src/types/tool.ts'), 'utf-8');
+
+test('AgentSession accepts executionScope in HandleMessageOptions', () => {
+  assert.match(agentSessionSource, /executionScope\?:\s*ExecutionScope/);
+  assert.match(agentSessionSource, /executionScope\s*=\s*opts\.executionScope/);
+  assert.match(agentSessionSource, /executionScope,\s*\n\s*pendingUserInputProvider/);
+});
+
+test('AgentTurnController forwards executionScope into ToolExecutionContext', () => {
+  assert.match(agentTurnSource, /executionScope\?:\s*ExecutionScope/);
+  assert.match(agentTurnSource, /executionScope:\s*params\.executionScope/);
+  assert.match(agentTurnSource, /executionScope:\s*options\.executionScope/);
+});
+
+test('ToolExecutionContext exposes executionScope for future ToolGateway checks', () => {
+  assert.match(toolTypesSource, /executionScope\?:\s*ExecutionScope/);
+});

--- a/tests/catscompany-client-body-id.test.ts
+++ b/tests/catscompany-client-body-id.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, beforeEach, describe, test } from 'node:test';
 import * as assert from 'node:assert';
+import { createServer, type Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { WebSocketServer } from 'ws';
-import { CatsClient } from '../src/catscompany/client';
+import { CatsClient, type CatsDeviceRpcMessage } from '../src/catscompany/client';
 
 describe('CatsCompany client body identity', () => {
   const servers: WebSocketServer[] = [];
+  const httpServers: Server[] = [];
   const identityEnvKeys = [
     'CATSCO_BODY_ID',
     'CATSCOMPANY_BODY_ID',
@@ -24,6 +26,9 @@ describe('CatsCompany client body identity', () => {
 
   afterEach(() => {
     for (const server of servers.splice(0)) {
+      server.close();
+    }
+    for (const server of httpServers.splice(0)) {
       server.close();
     }
     for (const key of identityEnvKeys) {
@@ -76,5 +81,394 @@ describe('CatsCompany client body identity', () => {
     });
 
     assert.throws(() => client.connect(), /bodyId missing/);
+  });
+
+  test('includes local device registration in websocket hi', async () => {
+    const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    servers.push(server);
+    await new Promise<void>(resolve => server.once('listening', resolve));
+
+    const hiPromise = new Promise<any>(resolve => {
+      server.once('connection', socket => {
+        socket.once('message', data => {
+          resolve(JSON.parse(data.toString()));
+          socket.close();
+        });
+      });
+    });
+
+    const address = server.address() as AddressInfo;
+    const client = new CatsClient({
+      serverUrl: `ws://127.0.0.1:${address.port}`,
+      apiKey: 'cc-test-key',
+      bodyId: 'body-test',
+      installationId: 'install-test',
+      deviceRegistration: {
+        device_id: 'install-test',
+        display_name: 'Test Device',
+        body_id: 'body-test',
+        installation_id: 'install-test',
+        status: 'online',
+        capabilities: ['read_file'],
+      },
+    });
+    client.on('error', () => undefined);
+    client.connect();
+
+    const hi = await hiPromise;
+    client.disconnect();
+
+    assert.deepEqual(hi.hi.device, {
+      device_id: 'install-test',
+      display_name: 'Test Device',
+      body_id: 'body-test',
+      installation_id: 'install-test',
+      status: 'online',
+      capabilities: ['read_file'],
+    });
+  });
+
+  test('registers device capabilities through CatsCompany HTTP API', async () => {
+    const requestPromise = new Promise<{ url?: string; method?: string; headers: Record<string, string | string[] | undefined>; body: any }>((resolve, reject) => {
+      const server = createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on('data', chunk => chunks.push(Buffer.from(chunk)));
+        req.on('end', () => {
+          const body = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+          resolve({ url: req.url, method: req.method, headers: req.headers, body });
+          res.setHeader('Content-Type', 'application/json');
+          res.end(JSON.stringify({ device: { deviceId: body.device_id } }));
+        });
+      });
+      httpServers.push(server);
+      server.listen(0, '127.0.0.1', () => {
+        void (async () => {
+          const address = server.address() as AddressInfo;
+          const client = new CatsClient({
+            serverUrl: 'ws://127.0.0.1:1/v0/channels',
+            httpBaseUrl: `http://127.0.0.1:${address.port}`,
+            apiKey: 'cc-test-key',
+            bodyId: 'body-test',
+            installationId: 'install-test',
+          });
+          await client.registerDevice({
+            device_id: 'install-test',
+            display_name: 'Test Device',
+            body_id: 'body-test',
+            installation_id: 'install-test',
+            status: 'online',
+            capabilities: ['read_file', 'send_file'],
+          });
+        })().catch(reject);
+      });
+    });
+
+    const request = await requestPromise;
+    assert.equal(request.method, 'POST');
+    assert.equal(request.url, '/api/devices/register');
+    assert.equal(request.headers.authorization, 'ApiKey cc-test-key');
+    assert.equal(request.headers['content-type'], 'application/json');
+    assert.deepEqual(request.body, {
+      device_id: 'install-test',
+      display_name: 'Test Device',
+      body_id: 'body-test',
+      installation_id: 'install-test',
+      status: 'online',
+      capabilities: ['read_file', 'send_file'],
+    });
+  });
+
+  test('emits device rpc requests outside the regular message stream', async () => {
+    const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    servers.push(server);
+    await new Promise<void>(resolve => server.once('listening', resolve));
+
+    server.once('connection', socket => {
+      socket.once('message', () => {
+        socket.send(JSON.stringify({
+          device_rpc: {
+            type: 'request',
+            request_id: 'rpc-inbound-1',
+            grant_id: 'grant-1',
+            device_id: 'install-test',
+            operation: 'ping',
+          },
+        }));
+      });
+    });
+
+    const address = server.address() as AddressInfo;
+    const client = new CatsClient({
+      serverUrl: `ws://127.0.0.1:${address.port}`,
+      apiKey: 'cc-test-key',
+      bodyId: 'body-test',
+      installationId: 'install-test',
+    });
+    client.on('error', () => undefined);
+
+    let regularMessageSeen = false;
+    client.on('message', () => {
+      regularMessageSeen = true;
+    });
+    const requestPromise = new Promise<CatsDeviceRpcMessage>(resolve => {
+      client.once('device_rpc_request', resolve);
+    });
+
+    client.connect();
+    const request = await requestPromise;
+    client.disconnect();
+
+    assert.equal(request.request_id, 'rpc-inbound-1');
+    assert.equal(request.operation, 'ping');
+    assert.equal(regularMessageSeen, false);
+  });
+
+  test('sends device rpc requests and resolves matching results', async () => {
+    const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    servers.push(server);
+    await new Promise<void>(resolve => server.once('listening', resolve));
+
+    const requestPromise = new Promise<any>(resolve => {
+      server.once('connection', socket => {
+        socket.on('message', data => {
+          const msg = JSON.parse(data.toString());
+          if (msg.hi) {
+            socket.send(JSON.stringify({
+              ctrl: {
+                id: msg.hi.id,
+                code: 200,
+                params: {
+                  build: 'catscompany',
+                  ver: '0.1.0',
+                  features: ['client_msg_id', 'device_rpc'],
+                  uid: 'usr42',
+                  name: 'Agent',
+                },
+              },
+            }));
+            return;
+          }
+          if (msg.device_rpc?.type === 'request') {
+            resolve(msg.device_rpc);
+            socket.send(JSON.stringify({ ctrl: { id: msg.device_rpc.id, code: 200, text: 'ok' } }));
+            socket.send(JSON.stringify({
+              device_rpc: {
+                type: 'result',
+                request_id: msg.device_rpc.request_id,
+                result: { ok: true },
+              },
+            }));
+          }
+        });
+      });
+    });
+
+    const address = server.address() as AddressInfo;
+    const client = new CatsClient({
+      serverUrl: `ws://127.0.0.1:${address.port}`,
+      apiKey: 'cc-test-key',
+      bodyId: 'body-agent',
+      installationId: 'install-agent',
+    });
+    client.on('error', () => undefined);
+    await new Promise<void>(resolve => {
+      client.once('ready', () => resolve());
+      client.connect();
+    });
+
+    const result = await client.sendDeviceRpcRequest({
+      request_id: 'rpc-outbound-1',
+      grant_id: 'grant-1',
+      device_id: 'install-test',
+      operation: 'ping',
+      payload: { value: 1 },
+    });
+    const request = await requestPromise;
+    client.disconnect();
+
+    assert.equal(request.request_id, 'rpc-outbound-1');
+    assert.equal(request.grant_id, 'grant-1');
+    assert.equal(request.operation, 'ping');
+    assert.deepEqual(result.result, { ok: true });
+  });
+
+  test('rejects device rpc request when ack fails after an early result', async () => {
+    const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    servers.push(server);
+    await new Promise<void>(resolve => server.once('listening', resolve));
+
+    server.once('connection', socket => {
+      socket.on('message', data => {
+        const msg = JSON.parse(data.toString());
+        if (msg.hi) {
+          socket.send(JSON.stringify({
+            ctrl: {
+              id: msg.hi.id,
+              code: 200,
+              params: {
+                build: 'catscompany',
+                ver: '0.1.0',
+                features: ['client_msg_id', 'device_rpc'],
+                uid: 'usr42',
+                name: 'Agent',
+              },
+            },
+          }));
+          return;
+        }
+        if (msg.device_rpc?.type === 'request') {
+          socket.send(JSON.stringify({
+            device_rpc: {
+              type: 'result',
+              request_id: msg.device_rpc.request_id,
+              result: { ok: true },
+            },
+          }));
+          socket.send(JSON.stringify({ ctrl: { id: msg.device_rpc.id, code: 500, text: 'nack after result' } }));
+        }
+      });
+    });
+
+    const address = server.address() as AddressInfo;
+    const client = new CatsClient({
+      serverUrl: `ws://127.0.0.1:${address.port}`,
+      apiKey: 'cc-test-key',
+      bodyId: 'body-agent',
+      installationId: 'install-agent',
+    });
+    client.on('error', () => undefined);
+    await new Promise<void>(resolve => {
+      client.once('ready', () => resolve());
+      client.connect();
+    });
+
+    await assert.rejects(
+      () => client.sendDeviceRpcRequest({
+        request_id: 'rpc-early-result-nack',
+        grant_id: 'grant-1',
+        device_id: 'install-test',
+        operation: 'ping',
+      }),
+      /ack 500/
+    );
+    client.disconnect();
+  });
+
+  test('rejects device rpc results whose scope does not match the pending request', async () => {
+    const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    servers.push(server);
+    await new Promise<void>(resolve => server.once('listening', resolve));
+
+    server.once('connection', socket => {
+      socket.on('message', data => {
+        const msg = JSON.parse(data.toString());
+        if (msg.hi) {
+          socket.send(JSON.stringify({
+            ctrl: {
+              id: msg.hi.id,
+              code: 200,
+              params: {
+                build: 'catscompany',
+                ver: '0.1.0',
+                features: ['client_msg_id', 'device_rpc'],
+                uid: 'usr42',
+                name: 'Agent',
+              },
+            },
+          }));
+          return;
+        }
+        if (msg.device_rpc?.type === 'request') {
+          socket.send(JSON.stringify({ ctrl: { id: msg.device_rpc.id, code: 200, text: 'ok' } }));
+          socket.send(JSON.stringify({
+            device_rpc: {
+              type: 'result',
+              request_id: msg.device_rpc.request_id,
+              grant_id: 'wrong-grant',
+              device_id: msg.device_rpc.device_id,
+              operation: msg.device_rpc.operation,
+              tool_name: msg.device_rpc.tool_name,
+              result: { ok: true },
+            },
+          }));
+        }
+      });
+    });
+
+    const address = server.address() as AddressInfo;
+    const client = new CatsClient({
+      serverUrl: `ws://127.0.0.1:${address.port}`,
+      apiKey: 'cc-test-key',
+      bodyId: 'body-agent',
+      installationId: 'install-agent',
+    });
+    client.on('error', () => undefined);
+    await new Promise<void>(resolve => {
+      client.once('ready', () => resolve());
+      client.connect();
+    });
+
+    await assert.rejects(
+      () => client.sendDeviceRpcRequest({
+        request_id: 'rpc-scope-mismatch',
+        grant_id: 'grant-1',
+        device_id: 'install-test',
+        operation: 'read_file',
+        tool_name: 'read_file',
+      }),
+      /scope does not match/
+    );
+    client.disconnect();
+  });
+
+  test('sends device rpc results with websocket ack', async () => {
+    const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    servers.push(server);
+    await new Promise<void>(resolve => server.once('listening', resolve));
+
+    const resultPromise = new Promise<any>(resolve => {
+      server.once('connection', socket => {
+        socket.on('message', data => {
+          const msg = JSON.parse(data.toString());
+          if (msg.hi) {
+            socket.send(JSON.stringify({
+              ctrl: {
+                id: msg.hi.id,
+                code: 200,
+                params: { build: 'catscompany', features: ['client_msg_id', 'device_rpc'], uid: 'usr7', name: 'Device' },
+              },
+            }));
+            return;
+          }
+          if (msg.device_rpc?.type === 'result') {
+            resolve(msg.device_rpc);
+            socket.send(JSON.stringify({ ctrl: { id: msg.device_rpc.id, code: 200, text: 'ok' } }));
+          }
+        });
+      });
+    });
+
+    const address = server.address() as AddressInfo;
+    const client = new CatsClient({
+      serverUrl: `ws://127.0.0.1:${address.port}`,
+      apiKey: 'cc-test-key',
+      bodyId: 'body-device',
+      installationId: 'install-device',
+    });
+    client.on('error', () => undefined);
+    await new Promise<void>(resolve => {
+      client.once('ready', () => resolve());
+      client.connect();
+    });
+
+    await client.sendDeviceRpcResult({
+      request_id: 'rpc-result-1',
+      result: { ok: true },
+    });
+    const result = await resultPromise;
+    client.disconnect();
+
+    assert.equal(result.request_id, 'rpc-result-1');
+    assert.deepEqual(result.result, { ok: true });
   });
 });

--- a/tests/catscompany-content-blocks.test.ts
+++ b/tests/catscompany-content-blocks.test.ts
@@ -74,6 +74,7 @@ function createProcessHarness() {
   bot.pendingAnswerBySession = new Map();
   bot.pendingAttachments = new Map();
   bot.messageQueue = new Map();
+  bot.botUid = 'usr43';
   bot.buildMultimodalMessage = async (text: string, attachments: any[]) => {
     multimodalCalls.push({ text, attachments });
     return [
@@ -314,7 +315,7 @@ describe('CatsCo content blocks', () => {
       assert.strictEqual(handledTurns.length, 1);
       const grants = handledTurns[0].options.localFileGrants;
       assert.strictEqual(grants.length, 1);
-      assert.strictEqual(grants[0].sessionKey, 'cc_user:usr1');
+      assert.strictEqual(grants[0].sessionKey, 'session:v2:catscompany:p2p:p2p_1_43:agent:usr43');
       assert.strictEqual(grants[0].topicId, 'p2p_1_43');
       assert.strictEqual(grants[0].actorUserId, 'usr1');
       assert.strictEqual(grants[0].agentBodyId, 'body-main');
@@ -466,7 +467,7 @@ describe('CatsCo content blocks', () => {
 
   test('queued CatsCompany turns keep working callbacks for compaction status', async () => {
     const { bot, handledTurns, sentThinking } = createProcessHarness();
-    bot.messageQueue.set('cc_user:usr1', [{
+    bot.messageQueue.set('session:v2:catscompany:p2p:p2p_1_2:agent:usr43', [{
       userMessage: '排队消息也应该显示压缩状态',
       topic: 'p2p_1_2',
       senderId: 'usr1',
@@ -476,7 +477,7 @@ describe('CatsCo content blocks', () => {
       runtimeFeedback: [],
     }]);
 
-    await (bot as any).drainMessageQueue('cc_user:usr1');
+    await (bot as any).drainMessageQueue('session:v2:catscompany:p2p:p2p_1_2:agent:usr43');
 
     assert.strictEqual(handledTurns.length, 1);
     assert.strictEqual(handledTurns[0].userMessage, '排队消息也应该显示压缩状态');
@@ -524,9 +525,10 @@ describe('CatsCo content blocks', () => {
 
   test('interrupts active session on CatsCompany stream cancel event', () => {
     const bot = Object.create(CatsCompanyBot.prototype) as any;
+    bot.botUid = 'usr43';
     let interrupted = 0;
     bot.sessionManager = {
-      get: (key: string) => key === 'cc_user:usr1'
+      get: (key: string) => key === 'session:v2:catscompany:p2p:p2p_1_2:agent:usr43'
         ? {
           requestInterrupt: () => {
             interrupted += 1;
@@ -628,7 +630,7 @@ describe('CatsCo content blocks', () => {
     };
 
     await (bot as any).handleSubAgentFeedback(
-      'cc_user:usr38',
+      'session:v2:catscompany:p2p:p2p_38_110:agent:usr43',
       'p2p_38_110',
       'usr38',
       '[子agent1 已完成]\n结果摘要：审查完成',
@@ -656,7 +658,7 @@ describe('CatsCo content blocks', () => {
       text: '处理消息时出错: 子 agent 结果处理失败',
       };
     };
-    bot.messageQueue.set('cc_user:usr38', [{
+    bot.messageQueue.set('session:v2:catscompany:p2p:p2p_38_110:agent:usr43', [{
       userMessage: '[子agent1 已完成]\n结果摘要：审查完成',
       topic: 'p2p_38_110',
       senderId: 'usr38',
@@ -665,7 +667,7 @@ describe('CatsCo content blocks', () => {
       source: 'subagent_feedback',
     }]);
 
-    await (bot as any).drainMessageQueue('cc_user:usr38');
+    await (bot as any).drainMessageQueue('session:v2:catscompany:p2p:p2p_38_110:agent:usr43');
 
     assert.strictEqual(runtimeObservations.length, 1);
     assert.strictEqual(runtimeObservations[0].options.source, 'subagent_result');

--- a/tests/catscompany-content-blocks.test.ts
+++ b/tests/catscompany-content-blocks.test.ts
@@ -403,6 +403,45 @@ describe('CatsCo content blocks', () => {
     assert.doesNotMatch(text, /授权附件路径/);
   });
 
+  test('sanitizes CatsCo image block metadata to use opaque references', async () => {
+    const bot = Object.create(CatsCompanyBot.prototype) as any;
+    const originalModel = process.env.GAUZ_LLM_MODEL;
+    const testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'catsco-image-ref-'));
+    const localPath = path.join(testRoot, 'tmp', 'downloads', 'secret-image.png');
+
+    try {
+      process.env.GAUZ_LLM_MODEL = 'gpt-4o';
+      fs.mkdirSync(path.dirname(localPath), { recursive: true });
+      fs.writeFileSync(
+        localPath,
+        Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=', 'base64'),
+      );
+
+      const blocks = await bot.buildMultimodalMessage('看看这张图', [{
+        fileName: 'secret-image.png',
+        localPath,
+        type: 'image',
+        receivedAt: Date.now(),
+        localFileGrant: {
+          attachmentRef: 'catsco_attachment:image-ref',
+        },
+      }]);
+
+      const imageBlock = blocks.find((block: any) => block.type === 'image') as any;
+      assert.ok(imageBlock);
+      assert.strictEqual(imageBlock.filePath, 'catsco_attachment:image-ref');
+      assert.doesNotMatch(JSON.stringify(blocks), new RegExp(escapeRegExp(localPath)));
+      assert.doesNotMatch(JSON.stringify(blocks), new RegExp(escapeRegExp(testRoot)));
+    } finally {
+      if (originalModel === undefined) {
+        delete process.env.GAUZ_LLM_MODEL;
+      } else {
+        process.env.GAUZ_LLM_MODEL = originalModel;
+      }
+      fs.rmSync(testRoot, { recursive: true, force: true });
+    }
+  });
+
   test('plain text messages are processed immediately without attachment coalesce wait', async () => {
     const { bot, handledTurns, sentThinking } = createProcessHarness();
 

--- a/tests/catscompany-content-blocks.test.ts
+++ b/tests/catscompany-content-blocks.test.ts
@@ -80,7 +80,7 @@ function createProcessHarness() {
       { type: 'text', text },
       ...attachments.map((attachment) => ({
         type: 'text',
-        text: `[${attachment.type}] ${attachment.fileName} -> ${attachment.localPath}`,
+        text: `[${attachment.type}] ${attachment.fileName} -> ${attachment.localFileGrant?.attachmentRef || '(no authorized attachment reference)'}`,
       })),
     ];
   };
@@ -163,6 +163,29 @@ describe('CatsCo content blocks', () => {
     assert.strictEqual(parsed.files[0].fileName, 'crack.png');
   });
 
+  test('builds CatsCo attachment context with opaque references instead of local paths', async () => {
+    const bot = Object.create(CatsCompanyBot.prototype);
+    const localPath = 'C:\\tmp\\catsco-secret\\tmp\\downloads\\report.pdf';
+    const attachment = {
+      fileName: 'report.pdf',
+      localPath,
+      type: 'file',
+      receivedAt: Date.now(),
+      localFileGrant: {
+        attachmentRef: 'catsco_attachment:visible-ref',
+      },
+    };
+
+    const blocks = await (bot as any).buildMultimodalMessage('请读取这个文件', [attachment]);
+    const prompt = (bot as any).buildAttachmentOnlyPrompt([attachment]);
+    const modelVisible = JSON.stringify(blocks) + '\n' + prompt;
+
+    assert.match(modelVisible, /catsco_attachment:visible-ref/);
+    assert.match(modelVisible, /授权附件引用/);
+    assert.doesNotMatch(modelVisible, /catsco-secret/);
+    assert.doesNotMatch(modelVisible, new RegExp(escapeRegExp(localPath)));
+  });
+
   test('processes multiple attachments as one user turn', async () => {
     const { bot, downloads, multimodalCalls, handledTurns } = createProcessHarness();
 
@@ -203,9 +226,9 @@ describe('CatsCo content blocks', () => {
     assert.strictEqual(handledTurns.length, 1);
     assert.deepStrictEqual(handledTurns[0].userMessage, [
       { type: 'text', text: '一起看这些附件' },
-      { type: 'text', text: '[image] a.png -> C:\\tmp\\catsco-test\\a.png' },
-      { type: 'text', text: '[image] c.png -> C:\\tmp\\catsco-test\\c.png' },
-      { type: 'text', text: '[file] b.pdf -> C:\\tmp\\catsco-test\\b.pdf' },
+      { type: 'text', text: '[image] a.png -> (no authorized attachment reference)' },
+      { type: 'text', text: '[image] c.png -> (no authorized attachment reference)' },
+      { type: 'text', text: '[file] b.pdf -> (no authorized attachment reference)' },
     ]);
     assert.deepStrictEqual(handledTurns[0].options.runtimeFeedback, []);
   });
@@ -247,8 +270,8 @@ describe('CatsCo content blocks', () => {
     assert.strictEqual(handledTurns.length, 1);
     assert.deepStrictEqual(handledTurns[0].userMessage, [
       { type: 'text', text: '非 Dashboard 入口一起看这些附件' },
-      { type: 'text', text: '[image] a.png -> C:\\tmp\\catsco-test\\a.png' },
-      { type: 'text', text: '[file] b.pdf -> C:\\tmp\\catsco-test\\b.pdf' },
+      { type: 'text', text: '[image] a.png -> (no authorized attachment reference)' },
+      { type: 'text', text: '[file] b.pdf -> (no authorized attachment reference)' },
     ]);
   });
 
@@ -298,7 +321,15 @@ describe('CatsCo content blocks', () => {
       assert.strictEqual(grants[0].deviceBodyId, 'body-main');
       assert.strictEqual(grants[0].fileType, 'file');
       assert.strictEqual(grants[0].fileName, 'report.pdf');
+      const attachmentRef = grants[0].attachmentRef;
+      assert.ok(attachmentRef);
+      assert.match(attachmentRef, /^catsco_attachment:/);
       assert.strictEqual(grants[0].filePath, fs.realpathSync(path.join(testRoot, 'tmp', 'downloads', 'report.pdf')));
+      const renderedUserMessage = (handledTurns[0].userMessage as any[])
+        .map(block => block.text || '')
+        .join('\n');
+      assert.match(renderedUserMessage, new RegExp(attachmentRef));
+      assert.doesNotMatch(renderedUserMessage, /tmp[\\/]+downloads/);
     } finally {
       process.chdir(originalCwd);
       fs.rmSync(testRoot, { recursive: true, force: true });
@@ -344,6 +375,32 @@ describe('CatsCo content blocks', () => {
       process.chdir(originalCwd);
       fs.rmSync(testRoot, { recursive: true, force: true });
     }
+  });
+
+  test('builds attachment messages with opaque references instead of local paths', async () => {
+    const bot = Object.create(CatsCompanyBot.prototype) as any;
+    const localPath = 'C:\\tmp\\catsco-test\\secret-report.pdf';
+
+    const blocks = await bot.buildMultimodalMessage('请读取这个文件', [{
+      fileName: 'secret-report.pdf',
+      localPath,
+      type: 'file',
+      receivedAt: Date.now(),
+      localFileGrant: {
+        attachmentRef: 'catsco_attachment:opaque-ref',
+      },
+    }]);
+
+    const text = blocks
+      .filter((block: any) => block.type === 'text')
+      .map((block: any) => block.text)
+      .join('\n');
+
+    assert.match(text, /请读取这个文件/);
+    assert.match(text, /catsco_attachment:opaque-ref/);
+    assert.doesNotMatch(text, /secret-report\.pdf -> C:/);
+    assert.doesNotMatch(text, /C:\\tmp\\catsco-test/);
+    assert.doesNotMatch(text, /授权附件路径/);
   });
 
   test('plain text messages are processed immediately without attachment coalesce wait', async () => {
@@ -585,3 +642,7 @@ describe('CatsCo content blocks', () => {
     ]);
   });
 });
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/tests/catscompany-content-blocks.test.ts
+++ b/tests/catscompany-content-blocks.test.ts
@@ -1,6 +1,20 @@
 import { describe, test } from 'node:test';
 import * as assert from 'node:assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { CatsCompanyBot } from '../src/catscompany';
+
+function canonicalMetadata(actorUserId: string, topicId: string, agentId = 'usr43', bodyId = 'body-main') {
+  return {
+    catsco_identity: {
+      actor: { user_id: actorUserId },
+      agent: { agent_id: agentId, body_id: bodyId },
+      topic: { topic_id: topicId, type: topicId.startsWith('grp_') ? 'group' : 'p2p', channel_seq: 12 },
+      permissions: { source: 'server_canonical_message' },
+    },
+  };
+}
 
 function createProcessHarness() {
   const bot = Object.create(CatsCompanyBot.prototype) as any;
@@ -236,6 +250,100 @@ describe('CatsCo content blocks', () => {
       { type: 'text', text: '[image] a.png -> C:\\tmp\\catsco-test\\a.png' },
       { type: 'text', text: '[file] b.pdf -> C:\\tmp\\catsco-test\\b.pdf' },
     ]);
+  });
+
+  test('passes scoped local file grants from canonical CatsCompany attachments into the session turn', async () => {
+    const originalCwd = process.cwd();
+    const testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'catsco-content-grants-'));
+
+    try {
+      process.chdir(testRoot);
+      const { bot, handledTurns } = createProcessHarness();
+      bot.localDeviceGrant = {
+        kind: 'catscompany_body',
+        source: 'catscompany',
+        bodyId: 'body-main',
+        installationId: 'install-main',
+        deviceId: 'install-main',
+        createdAt: Date.now(),
+      };
+      bot.sender.downloadFile = async (_url: string, fileName: string) => {
+        const localPath = path.join(testRoot, 'tmp', 'downloads', fileName);
+        fs.mkdirSync(path.dirname(localPath), { recursive: true });
+        fs.writeFileSync(localPath, 'hello');
+        return localPath;
+      };
+
+      await (bot as any).onMessage({
+        topic: 'p2p_1_43',
+        senderId: 'usr1',
+        text: '[附件] report.pdf',
+        content: '[附件] report.pdf',
+        metadata: canonicalMetadata('usr1', 'p2p_1_43'),
+        content_blocks: [
+          { type: 'text', text: '请读取这个文件' },
+          { type: 'file', payload: { url: '/uploads/files/report.pdf', name: 'report.pdf', size: 34 } },
+        ],
+        isGroup: false,
+        seq: 12,
+      });
+
+      assert.strictEqual(handledTurns.length, 1);
+      const grants = handledTurns[0].options.localFileGrants;
+      assert.strictEqual(grants.length, 1);
+      assert.strictEqual(grants[0].sessionKey, 'cc_user:usr1');
+      assert.strictEqual(grants[0].topicId, 'p2p_1_43');
+      assert.strictEqual(grants[0].actorUserId, 'usr1');
+      assert.strictEqual(grants[0].agentBodyId, 'body-main');
+      assert.strictEqual(grants[0].deviceBodyId, 'body-main');
+      assert.strictEqual(grants[0].fileType, 'file');
+      assert.strictEqual(grants[0].fileName, 'report.pdf');
+      assert.strictEqual(grants[0].filePath, fs.realpathSync(path.join(testRoot, 'tmp', 'downloads', 'report.pdf')));
+    } finally {
+      process.chdir(originalCwd);
+      fs.rmSync(testRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('does not create local file grants for legacy CatsCompany attachments', async () => {
+    const originalCwd = process.cwd();
+    const testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'catsco-content-grants-'));
+
+    try {
+      process.chdir(testRoot);
+      const { bot, handledTurns } = createProcessHarness();
+      bot.localDeviceGrant = {
+        kind: 'catscompany_body',
+        source: 'catscompany',
+        bodyId: 'body-main',
+        createdAt: Date.now(),
+      };
+      bot.sender.downloadFile = async (_url: string, fileName: string) => {
+        const localPath = path.join(testRoot, 'tmp', 'downloads', fileName);
+        fs.mkdirSync(path.dirname(localPath), { recursive: true });
+        fs.writeFileSync(localPath, 'hello');
+        return localPath;
+      };
+
+      await (bot as any).onMessage({
+        topic: 'p2p_1_43',
+        senderId: 'usr1',
+        text: '[附件] report.pdf',
+        content: '[附件] report.pdf',
+        content_blocks: [
+          { type: 'text', text: '请读取这个文件' },
+          { type: 'file', payload: { url: '/uploads/files/report.pdf', name: 'report.pdf', size: 34 } },
+        ],
+        isGroup: false,
+        seq: 12,
+      });
+
+      assert.strictEqual(handledTurns.length, 1);
+      assert.deepStrictEqual(handledTurns[0].options.localFileGrants, []);
+    } finally {
+      process.chdir(originalCwd);
+      fs.rmSync(testRoot, { recursive: true, force: true });
+    }
   });
 
   test('plain text messages are processed immediately without attachment coalesce wait', async () => {

--- a/tests/catscompany-device-rpc-tools.test.ts
+++ b/tests/catscompany-device-rpc-tools.test.ts
@@ -1,0 +1,204 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import { CatsCompanyBot } from '../src/catscompany';
+import type { CatsDeviceRpcMessage } from '../src/catscompany/client';
+import type { ScopedDeviceGrant } from '../src/types/session-identity';
+
+function botWithDevice(captured: { result?: any }): any {
+  const bot = Object.create(CatsCompanyBot.prototype) as any;
+  bot.localDeviceGrant = {
+    kind: 'catscompany_body',
+    source: 'catscompany',
+    bodyId: 'body-device',
+    installationId: 'install-device',
+    deviceId: 'install-device',
+    createdAt: Date.now(),
+  };
+  bot.bot = {
+    sendDeviceRpcResult: async (result: any) => {
+      captured.result = result;
+    },
+  };
+  return bot;
+}
+
+function request(overrides: Partial<CatsDeviceRpcMessage> = {}): CatsDeviceRpcMessage {
+  return {
+    type: 'request',
+    request_id: 'rpc-read-1',
+    grant_id: 'grant-read-1',
+    session_key: 'session:v2:catscompany:p2p:p2p_7_43:agent:usr43',
+    topic_id: 'p2p_7_43',
+    topic_type: 'p2p',
+    actor_user_id: 'usr7',
+    agent_id: 'usr43',
+    agent_body_id: 'body-agent',
+    device_id: 'install-device',
+    device_body_id: 'body-device',
+    device_installation_id: 'install-device',
+    operation: 'read_file',
+    tool_name: 'read_file',
+    created_at: Date.now(),
+    expires_at: Date.now() + 60_000,
+    payload: {},
+    ...overrides,
+  };
+}
+
+function serverGrant(overrides: Partial<ScopedDeviceGrant> = {}): ScopedDeviceGrant {
+  return {
+    kind: 'user_device_grant',
+    source: 'catscompany',
+    grantId: 'grant-server-readonly',
+    status: 'active',
+    identityTrust: 'server_canonical',
+    identitySource: 'metadata.catsco_identity',
+    deviceId: 'install-remote',
+    deviceDisplayName: 'Remote Laptop',
+    deviceBodyId: 'body-remote',
+    deviceInstallationId: 'install-remote',
+    ownerUserId: 'usr7',
+    sessionKey: 'session:v2:catscompany:p2p:p2p_7_43:agent:usr43',
+    topicId: 'p2p_7_43',
+    topicType: 'p2p',
+    actorUserId: 'usr7',
+    agentId: 'usr43',
+    agentBodyId: 'body-agent',
+    operations: ['read_file', 'glob', 'grep'],
+    createdAt: Date.now(),
+    expiresAt: Date.now() + 60_000,
+    ...overrides,
+  };
+}
+
+describe('CatsCompany Device RPC readonly tools', () => {
+  test('maps CatsCo server grant fields into outbound readonly device_rpc requests', async () => {
+    const captured: Array<{ request: any; timeoutMs?: number }> = [];
+    const bot = Object.create(CatsCompanyBot.prototype) as any;
+    bot.bot = {
+      sendDeviceRpcRequest: async (requestPayload: any, timeoutMs?: number) => {
+        captured.push({ request: requestPayload, timeoutMs });
+        return {
+          type: 'result',
+          request_id: requestPayload.request_id,
+          grant_id: requestPayload.grant_id,
+          session_key: requestPayload.session_key,
+          topic_id: requestPayload.topic_id,
+          topic_type: requestPayload.topic_type,
+          actor_user_id: requestPayload.actor_user_id,
+          agent_id: requestPayload.agent_id,
+          agent_body_id: requestPayload.agent_body_id,
+          device_id: requestPayload.device_id,
+          device_body_id: requestPayload.device_body_id,
+          device_installation_id: requestPayload.device_installation_id,
+          operation: requestPayload.operation,
+          tool_name: requestPayload.tool_name,
+          result: { ok: true, content: `remote ${requestPayload.tool_name}` },
+        };
+      },
+    };
+
+    const transport = bot.buildDeviceRpcTransport();
+    const grant = serverGrant();
+    const read = await transport.executeTool({
+      toolName: 'read_file',
+      operation: 'read_file',
+      args: { file_path: 'catsco_attachment:quote.xlsx', limit: 20 },
+      grant,
+      timeoutMs: 12_345,
+    });
+    const glob = await transport.executeTool({
+      toolName: 'glob',
+      operation: 'glob',
+      args: { pattern: '**/*.xlsx', path: 'catsco_attachment:project' },
+      grant,
+    });
+    const grep = await transport.executeTool({
+      toolName: 'grep',
+      operation: 'grep',
+      args: { pattern: '合同', path: 'catsco_attachment:project', output_mode: 'files' },
+      grant,
+    });
+
+    assert.equal(read.ok, true);
+    assert.equal(glob.ok, true);
+    assert.equal(grep.ok, true);
+    assert.equal(read.ok ? read.content : '', 'remote read_file');
+    assert.equal(glob.ok ? glob.content : '', 'remote glob');
+    assert.equal(grep.ok ? grep.content : '', 'remote grep');
+    assert.deepEqual(captured.map(item => [item.request.tool_name, item.request.operation]), [
+      ['read_file', 'read_file'],
+      ['glob', 'glob'],
+      ['grep', 'grep'],
+    ]);
+
+    const first = captured[0].request;
+    assert.match(first.request_id, /^device_rpc_/);
+    assert.equal(first.grant_id, grant.grantId);
+    assert.equal(first.session_key, grant.sessionKey);
+    assert.equal(first.topic_id, grant.topicId);
+    assert.equal(first.topic_type, grant.topicType);
+    assert.equal(first.actor_user_id, grant.actorUserId);
+    assert.equal(first.agent_id, grant.agentId);
+    assert.equal(first.agent_body_id, grant.agentBodyId);
+    assert.equal(first.device_id, grant.deviceId);
+    assert.equal(first.device_body_id, grant.deviceBodyId);
+    assert.equal(first.device_installation_id, grant.deviceInstallationId);
+    assert.equal(first.expires_at, grant.expiresAt);
+    assert.deepEqual(first.payload, { args: { file_path: 'catsco_attachment:quote.xlsx', limit: 20 } });
+    assert.equal(captured[0].timeoutMs, 12_345);
+  });
+
+  test('executes read_file on the target local device and returns a normalized result', async () => {
+    const captured: { result?: any } = {};
+    const bot = botWithDevice(captured);
+    const tmpRoot = path.join(process.cwd(), 'tmp');
+    fs.mkdirSync(tmpRoot, { recursive: true });
+    const dir = fs.mkdtempSync(path.join(tmpRoot, 'device-rpc-read-'));
+    const filePath = path.join(dir, 'notes.txt');
+    fs.writeFileSync(filePath, 'hello from target device\n');
+
+    await bot.handleDeviceRpcRequest(request({
+      payload: { args: { file_path: filePath, limit: 5 } },
+    }));
+
+    assert.ok(captured.result);
+    assert.equal(captured.result.error, undefined);
+    assert.equal(captured.result.result.ok, true);
+    assert.match(String(captured.result.result.content), /hello from target device/);
+    assert.equal(captured.result.device_id, 'install-device');
+  });
+
+  test('rejects non-readonly Device RPC operations before local tool execution', async () => {
+    const captured: { result?: any } = {};
+    const bot = botWithDevice(captured);
+
+    await bot.handleDeviceRpcRequest(request({
+      request_id: 'rpc-shell-1',
+      operation: 'execute_shell',
+      tool_name: 'execute_shell',
+      payload: { args: { command: 'echo unsafe' } },
+    }));
+
+    assert.ok(captured.result);
+    assert.equal(captured.result.result, undefined);
+    assert.equal(captured.result.error.code, 'unsupported_operation');
+    assert.match(captured.result.error.message, /read_file, glob, and grep/);
+  });
+
+  test('rejects Device RPC requests for another target device', async () => {
+    const captured: { result?: any } = {};
+    const bot = botWithDevice(captured);
+
+    await bot.handleDeviceRpcRequest(request({
+      request_id: 'rpc-wrong-device-1',
+      device_id: 'other-device',
+    }));
+
+    assert.ok(captured.result);
+    assert.equal(captured.result.result, undefined);
+    assert.equal(captured.result.error.code, 'target_device_mismatch');
+  });
+});

--- a/tests/catscompany-execution-scope-flow.test.ts
+++ b/tests/catscompany-execution-scope-flow.test.ts
@@ -1,6 +1,7 @@
 import { describe, test } from 'node:test';
 import * as assert from 'node:assert';
 import { CatsCompanyBot } from '../src/catscompany';
+import { createCatsCoMessageEnvelope, createExecutionScope } from '../src/catscompany/message-envelope';
 
 function canonicalMetadata(actorUserId: string, topicId: string, agentId = 'usr43', bodyId = 'body-main') {
   return {
@@ -13,10 +14,66 @@ function canonicalMetadata(actorUserId: string, topicId: string, agentId = 'usr4
   };
 }
 
+function deviceGrant(overrides: Record<string, unknown> = {}) {
+  return {
+    kind: 'user_device_grant',
+    source: 'catscompany',
+    grantId: 'device-grant-1',
+    status: 'active',
+    identityTrust: 'server_canonical',
+    identitySource: 'metadata.catsco_identity',
+    deviceId: 'alice-laptop',
+    deviceDisplayName: 'Alice Laptop',
+    deviceBodyId: 'body-device',
+    deviceInstallationId: 'install-device',
+    ownerUserId: 'usr7',
+    sessionKey: 'session:v2:catscompany:p2p:p2p_7_43:agent:usr43',
+    topicId: 'p2p_7_43',
+    topicType: 'p2p',
+    actorUserId: 'usr7',
+    agentId: 'usr43',
+    agentBodyId: 'body-main',
+    operations: ['read_file', 'send_file'],
+    createdAt: 1_000,
+    expiresAt: 601_000,
+    ...overrides,
+  };
+}
+
+function metadataWithDeviceGrants(actorUserId: string, topicId: string, grants: unknown[], agentId = 'usr43', bodyId = 'body-main') {
+  const metadata = canonicalMetadata(actorUserId, topicId, agentId, bodyId);
+  (metadata.catsco_identity as any).device_grants = grants;
+  return metadata;
+}
+
+function metadataWithDeviceSelection(actorUserId: string, topicId: string, selection: Record<string, unknown>, agentId = 'usr43', bodyId = 'body-main') {
+  const metadata = metadataWithDeviceGrants(actorUserId, topicId, [deviceGrant()], agentId, bodyId);
+  (metadata.catsco_identity as any).device_selection = {
+    kind: 'user_device_selection',
+    source: 'catscompany',
+    status: 'selected',
+    sessionKey: `session:v2:catscompany:${topicId.startsWith('grp_') ? 'group' : 'p2p'}:${topicId}:agent:${agentId}`,
+    topicId,
+    topicType: topicId.startsWith('grp_') ? 'group' : 'p2p',
+    actorUserId,
+    agentId,
+    selectedDevice: {
+      deviceId: 'alice-laptop',
+      displayName: 'Alice Laptop',
+      bodyId: 'body-device',
+      installationId: 'install-device',
+      operations: ['read_file', 'send_file'],
+    },
+    ...selection,
+  };
+  return metadata;
+}
+
 function createHarness(options: { busy?: boolean } = {}) {
   const bot = Object.create(CatsCompanyBot.prototype) as any;
   const handledTurns: Array<{ userMessage: unknown; options: any }> = [];
   const sessionKeys: string[] = [];
+  const sessionInputs: any[] = [];
   let busy = options.busy ?? false;
 
   const session = {
@@ -32,8 +89,9 @@ function createHarness(options: { busy?: boolean } = {}) {
   };
 
   bot.sessionManager = {
-    getOrCreate: (key: string) => {
-      sessionKeys.push(key);
+    getOrCreate: (input: any) => {
+      sessionInputs.push(input);
+      sessionKeys.push(typeof input === 'string' ? input : input.sessionKey);
       return session;
     },
     get: () => session,
@@ -54,12 +112,12 @@ function createHarness(options: { busy?: boolean } = {}) {
   bot.messageQueue = new Map();
   bot.botUid = 'usr43';
 
-  return { bot, handledTurns, sessionKeys, session };
+  return { bot, handledTurns, sessionKeys, sessionInputs, session };
 }
 
 describe('CatsCompany execution scope flow', () => {
   test('passes canonical execution scope from websocket message into session turn', async () => {
-    const { bot, handledTurns, sessionKeys } = createHarness();
+    const { bot, handledTurns, sessionKeys, sessionInputs } = createHarness();
 
     await (bot as any).onMessage({
       topic: 'p2p_7_43',
@@ -71,8 +129,13 @@ describe('CatsCompany execution scope flow', () => {
       seq: 12,
     });
 
-    assert.deepEqual(sessionKeys, ['cc_user:usr7']);
+    assert.deepEqual(sessionKeys, ['session:v2:catscompany:p2p:p2p_7_43:agent:usr43']);
+    assert.equal(sessionInputs[0].version, 2);
+    assert.equal(sessionInputs[0].legacySessionKey, 'cc_user:usr7');
     assert.equal(handledTurns.length, 1);
+    assert.equal(handledTurns[0].options.sessionRoute.sessionKey, 'session:v2:catscompany:p2p:p2p_7_43:agent:usr43');
+    assert.equal(handledTurns[0].options.executionScope.sessionKey, 'session:v2:catscompany:p2p:p2p_7_43:agent:usr43');
+    assert.equal(handledTurns[0].options.executionScope.legacySessionKey, 'cc_user:usr7');
     assert.equal(handledTurns[0].options.executionScope.actorUserId, 'usr7');
     assert.equal(handledTurns[0].options.executionScope.agentId, 'usr43');
     assert.equal(handledTurns[0].options.executionScope.agentBodyId, 'body-main');
@@ -94,9 +157,12 @@ describe('CatsCompany execution scope flow', () => {
 
     assert.equal(handledTurns.length, 0);
     session.setBusy(false);
-    await (bot as any).drainMessageQueue('cc_user:usr8');
+    await (bot as any).drainMessageQueue('session:v2:catscompany:p2p:p2p_8_43:agent:usr43');
 
-    assert.deepEqual(sessionKeys, ['cc_user:usr8', 'cc_user:usr8']);
+    assert.deepEqual(sessionKeys, [
+      'session:v2:catscompany:p2p:p2p_8_43:agent:usr43',
+      'session:v2:catscompany:p2p:p2p_8_43:agent:usr43',
+    ]);
     assert.equal(handledTurns.length, 1);
     assert.equal(handledTurns[0].options.executionScope.actorUserId, 'usr8');
     assert.equal(handledTurns[0].options.executionScope.topicId, 'p2p_8_43');
@@ -116,10 +182,199 @@ describe('CatsCompany execution scope flow', () => {
       seq: 12,
     });
 
-    assert.deepEqual(sessionKeys, ['cc_group:grp_80']);
+    assert.deepEqual(sessionKeys, ['session:v2:catscompany:group:grp_80:agent:usr43']);
     assert.equal(handledTurns.length, 1);
     assert.equal(handledTurns[0].options.executionScope.topicType, 'group');
     assert.equal(handledTurns[0].options.executionScope.topicId, 'grp_80');
     assert.equal(handledTurns[0].options.executionScope.actorUserId, 'usr7');
+  });
+
+  test('passes server canonical device grants into CatsCompany session turn', async () => {
+    const { bot, handledTurns } = createHarness();
+
+    await (bot as any).onMessage({
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      text: '读一下本机文件',
+      content: '读一下本机文件',
+      metadata: metadataWithDeviceGrants('usr7', 'p2p_7_43', [deviceGrant()]),
+      isGroup: false,
+      seq: 12,
+    });
+
+    assert.equal(handledTurns.length, 1);
+    assert.equal(handledTurns[0].options.deviceGrants?.length, 1);
+    assert.equal(handledTurns[0].options.deviceGrants[0].deviceId, 'alice-laptop');
+    assert.deepEqual(handledTurns[0].options.deviceGrants[0].operations, ['read_file', 'send_file']);
+  });
+
+  test('passes server canonical device selection into CatsCompany session turn', async () => {
+    const { bot, handledTurns } = createHarness();
+
+    await (bot as any).onMessage({
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      text: '读一下本机文件',
+      content: '读一下本机文件',
+      metadata: metadataWithDeviceSelection('usr7', 'p2p_7_43', {
+        selectionSource: 'explicit_mention',
+      }),
+      isGroup: false,
+      seq: 12,
+    });
+
+    assert.equal(handledTurns.length, 1);
+    assert.equal(handledTurns[0].options.deviceSelection?.status, 'selected');
+    assert.equal(handledTurns[0].options.deviceSelection?.selectionSource, 'explicit_mention');
+    assert.equal(handledTurns[0].options.deviceSelection?.selectedDeviceId, 'alice-laptop');
+    assert.equal(handledTurns[0].options.deviceSelection?.selectedDeviceDisplayName, 'Alice Laptop');
+    assert.equal(handledTurns[0].options.deviceSelection?.selectedDeviceBodyId, 'body-device');
+    assert.deepEqual(handledTurns[0].options.deviceSelection?.selectedDeviceOperations, ['read_file', 'send_file']);
+  });
+
+  test('drops device selection that does not match the canonical execution scope', async () => {
+    const { bot, handledTurns } = createHarness();
+
+    await (bot as any).onMessage({
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      text: '读一下本机文件',
+      content: '读一下本机文件',
+      metadata: metadataWithDeviceSelection('usr7', 'p2p_7_43', {
+        actorUserId: 'usr8',
+      }),
+      isGroup: false,
+      seq: 12,
+    });
+
+    assert.equal(handledTurns.length, 1);
+    assert.equal(handledTurns[0].options.deviceSelection, undefined);
+  });
+
+  test('drops device grants that do not match the canonical execution scope', async () => {
+    const { bot, handledTurns } = createHarness();
+
+    await (bot as any).onMessage({
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      text: '读一下本机文件',
+      content: '读一下本机文件',
+      metadata: metadataWithDeviceGrants('usr7', 'p2p_7_43', [
+        deviceGrant({ actorUserId: 'usr8' }),
+        deviceGrant({ agentBodyId: 'body-other' }),
+      ]),
+      isGroup: false,
+      seq: 12,
+    });
+
+    assert.equal(handledTurns.length, 1);
+    assert.equal(handledTurns[0].options.deviceGrants, undefined);
+  });
+
+  test('does not merge queued CatsCo group input from another actor into the current actor scope', () => {
+    const { bot } = createHarness();
+    const sessionKey = 'session:v2:catscompany:group:grp_80:agent:usr43';
+    const aliceScope = createExecutionScope(createCatsCoMessageEnvelope({
+      topic: 'grp_80',
+      isGroup: true,
+      senderId: 'alice',
+      text: 'alice asks',
+      metadata: canonicalMetadata('alice', 'grp_80'),
+      botUid: 'usr43',
+    }));
+    const bobScope = createExecutionScope(createCatsCoMessageEnvelope({
+      topic: 'grp_80',
+      isGroup: true,
+      senderId: 'bob',
+      text: 'bob asks',
+      metadata: canonicalMetadata('bob', 'grp_80'),
+      botUid: 'usr43',
+    }));
+
+    bot.messageQueue.set(sessionKey, [{
+      userMessage: 'bob follow-up',
+      topic: 'grp_80',
+      senderId: 'bob',
+      seq: 13,
+      executionScope: bobScope,
+      receivedAt: Date.now(),
+      source: 'user',
+    }]);
+
+    assert.equal((bot as any).consumeQueuedUserInput(sessionKey, aliceScope), null);
+    assert.equal(bot.messageQueue.get(sessionKey)?.length, 1);
+
+    const pendingForBob = (bot as any).consumeQueuedUserInput(sessionKey, bobScope);
+    assert.equal(pendingForBob, 'bob follow-up');
+    assert.equal(bot.messageQueue.has(sessionKey), false);
+  });
+
+  test('preserves device grants when queued CatsCompany user input is merged', () => {
+    const { bot } = createHarness();
+    const scope = createExecutionScope(createCatsCoMessageEnvelope({
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      text: 'first',
+      metadata: canonicalMetadata('usr7', 'p2p_7_43'),
+      botUid: 'usr43',
+    }));
+
+    bot.messageQueue.set(scope.sessionKey, [{
+      userMessage: '补充读取文件',
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      seq: 13,
+      executionScope: scope,
+      deviceGrants: [deviceGrant()],
+      receivedAt: Date.now(),
+      source: 'user',
+    }]);
+
+    const pending = (bot as any).consumeQueuedUserInput(scope.sessionKey, scope);
+    assert.equal(typeof pending, 'object');
+    assert.equal(pending.content, '补充读取文件');
+    assert.equal(pending.deviceGrants.length, 1);
+    assert.equal(pending.deviceGrants[0].deviceId, 'alice-laptop');
+  });
+
+  test('preserves latest device selection when queued CatsCompany user input is merged', () => {
+    const { bot } = createHarness();
+    const scope = createExecutionScope(createCatsCoMessageEnvelope({
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      text: 'first',
+      metadata: canonicalMetadata('usr7', 'p2p_7_43'),
+      botUid: 'usr43',
+    }));
+
+    const selection = {
+      kind: 'user_device_selection',
+      source: 'catscompany',
+      status: 'selected',
+      sessionKey: scope.sessionKey,
+      topicId: scope.topicId,
+      topicType: scope.topicType,
+      actorUserId: scope.actorUserId,
+      agentId: scope.agentId,
+      identityTrust: 'server_canonical',
+      selectedDeviceId: 'alice-laptop',
+      selectedDeviceDisplayName: 'Alice Laptop',
+    };
+
+    bot.messageQueue.set(scope.sessionKey, [{
+      userMessage: '补充读取文件',
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      seq: 13,
+      executionScope: scope,
+      deviceSelection: selection,
+      receivedAt: Date.now(),
+      source: 'user',
+    }]);
+
+    const pending = (bot as any).consumeQueuedUserInput(scope.sessionKey, scope);
+    assert.equal(typeof pending, 'object');
+    assert.equal(pending.content, '补充读取文件');
+    assert.equal(pending.deviceSelection.selectedDeviceId, 'alice-laptop');
   });
 });

--- a/tests/catscompany-execution-scope-flow.test.ts
+++ b/tests/catscompany-execution-scope-flow.test.ts
@@ -1,0 +1,125 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import { CatsCompanyBot } from '../src/catscompany';
+
+function canonicalMetadata(actorUserId: string, topicId: string, agentId = 'usr43', bodyId = 'body-main') {
+  return {
+    catsco_identity: {
+      actor: { user_id: actorUserId },
+      agent: { agent_id: agentId, body_id: bodyId },
+      topic: { topic_id: topicId, type: topicId.startsWith('grp_') ? 'group' : 'p2p', channel_seq: 12 },
+      permissions: { source: 'server_canonical_message' },
+    },
+  };
+}
+
+function createHarness(options: { busy?: boolean } = {}) {
+  const bot = Object.create(CatsCompanyBot.prototype) as any;
+  const handledTurns: Array<{ userMessage: unknown; options: any }> = [];
+  const sessionKeys: string[] = [];
+  let busy = options.busy ?? false;
+
+  const session = {
+    isBusy: () => busy,
+    setBusy: (next: boolean) => {
+      busy = next;
+    },
+    handleMessage: async (userMessage: unknown, handleOptions: any) => {
+      handledTurns.push({ userMessage, options: handleOptions });
+      return { visibleToUser: false, text: '' };
+    },
+    handleRuntimeObservation: async () => ({ visibleToUser: false, text: '' }),
+  };
+
+  bot.sessionManager = {
+    getOrCreate: (key: string) => {
+      sessionKeys.push(key);
+      return session;
+    },
+    get: () => session,
+  };
+  bot.sender = {
+    downloadFile: async () => null,
+    sendTyping: () => undefined,
+    reply: async () => undefined,
+    sendFile: async () => undefined,
+    sendText: async () => undefined,
+    sendThinking: async () => undefined,
+    sendToolUse: async () => undefined,
+    sendToolResult: async () => undefined,
+  };
+  bot.pendingAnswers = new Map();
+  bot.pendingAnswerBySession = new Map();
+  bot.pendingAttachments = new Map();
+  bot.messageQueue = new Map();
+  bot.botUid = 'usr43';
+
+  return { bot, handledTurns, sessionKeys, session };
+}
+
+describe('CatsCompany execution scope flow', () => {
+  test('passes canonical execution scope from websocket message into session turn', async () => {
+    const { bot, handledTurns, sessionKeys } = createHarness();
+
+    await (bot as any).onMessage({
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      text: '查合同',
+      content: '查合同',
+      metadata: canonicalMetadata('usr7', 'p2p_7_43'),
+      isGroup: false,
+      seq: 12,
+    });
+
+    assert.deepEqual(sessionKeys, ['cc_user:usr7']);
+    assert.equal(handledTurns.length, 1);
+    assert.equal(handledTurns[0].options.executionScope.actorUserId, 'usr7');
+    assert.equal(handledTurns[0].options.executionScope.agentId, 'usr43');
+    assert.equal(handledTurns[0].options.executionScope.agentBodyId, 'body-main');
+    assert.equal(handledTurns[0].options.executionScope.isTrusted, true);
+  });
+
+  test('keeps execution scope when a busy CatsCompany turn is queued then drained', async () => {
+    const { bot, handledTurns, sessionKeys, session } = createHarness({ busy: true });
+
+    await (bot as any).onMessage({
+      topic: 'p2p_8_43',
+      senderId: 'usr8',
+      text: '继续查',
+      content: '继续查',
+      metadata: canonicalMetadata('usr8', 'p2p_8_43'),
+      isGroup: false,
+      seq: 12,
+    });
+
+    assert.equal(handledTurns.length, 0);
+    session.setBusy(false);
+    await (bot as any).drainMessageQueue('cc_user:usr8');
+
+    assert.deepEqual(sessionKeys, ['cc_user:usr8', 'cc_user:usr8']);
+    assert.equal(handledTurns.length, 1);
+    assert.equal(handledTurns[0].options.executionScope.actorUserId, 'usr8');
+    assert.equal(handledTurns[0].options.executionScope.topicId, 'p2p_8_43');
+    assert.equal(handledTurns[0].options.executionScope.isTrusted, true);
+  });
+
+  test('group turn uses group session key while preserving actor in scope', async () => {
+    const { bot, handledTurns, sessionKeys } = createHarness();
+
+    await (bot as any).onMessage({
+      topic: 'grp_80',
+      senderId: 'usr7',
+      text: '@usr43 看一下',
+      content: '@usr43 看一下',
+      metadata: canonicalMetadata('usr7', 'grp_80'),
+      isGroup: true,
+      seq: 12,
+    });
+
+    assert.deepEqual(sessionKeys, ['cc_group:grp_80']);
+    assert.equal(handledTurns.length, 1);
+    assert.equal(handledTurns[0].options.executionScope.topicType, 'group');
+    assert.equal(handledTurns[0].options.executionScope.topicId, 'grp_80');
+    assert.equal(handledTurns[0].options.executionScope.actorUserId, 'usr7');
+  });
+});

--- a/tests/catscompany-local-file-grants.test.ts
+++ b/tests/catscompany-local-file-grants.test.ts
@@ -1,0 +1,119 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  createCatsCoAttachmentGrant,
+  createCatsCoLocalDeviceGrant,
+} from '../src/catscompany/local-file-grants';
+import type { ExecutionScope } from '../src/types/session-identity';
+
+function scope(overrides: Partial<ExecutionScope> = {}): ExecutionScope {
+  return {
+    source: 'catscompany',
+    sessionKey: 'cc_user:usr7',
+    topicId: 'p2p_7_43',
+    topicType: 'p2p',
+    actorUserId: 'usr7',
+    agentId: 'usr43',
+    agentBodyId: 'body-main',
+    permissionsSource: 'server_canonical_message',
+    identityTrust: 'server_canonical',
+    isTrusted: true,
+    ...overrides,
+  };
+}
+
+function workspaceWithAttachment(name = 'report.md'): { root: string; filePath: string } {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'catsco-local-grant-'));
+  const filePath = path.join(root, 'tmp', 'downloads', name);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, 'hello');
+  return { root, filePath };
+}
+
+describe('CatsCo local file grant creation', () => {
+  test('creates a scoped file grant from canonical CatsCo scope and local device grant', () => {
+    const { root, filePath } = workspaceWithAttachment();
+    const device = createCatsCoLocalDeviceGrant({
+      bodyId: 'body-main',
+      installationId: 'install-main',
+    });
+
+    const result = createCatsCoAttachmentGrant(scope(), device, {
+      localPath: path.join(root, 'tmp', 'downloads', '..', 'downloads', 'report.md'),
+      fileName: 'report.md',
+      type: 'file',
+      workspaceRoot: root,
+    });
+
+    assert.ok(result);
+    assert.equal(result.filePath, fs.realpathSync(filePath));
+    assert.equal(result.fileName, 'report.md');
+    assert.equal(result.fileType, 'file');
+    assert.equal(result.sessionKey, 'cc_user:usr7');
+    assert.equal(result.topicId, 'p2p_7_43');
+    assert.equal(result.topicType, 'p2p');
+    assert.equal(result.actorUserId, 'usr7');
+    assert.equal(result.agentId, 'usr43');
+    assert.equal(result.agentBodyId, 'body-main');
+    assert.equal(result.deviceBodyId, 'body-main');
+    assert.equal(result.deviceInstallationId, 'install-main');
+    assert.equal(result.identityTrust, 'server_canonical');
+    assert.deepEqual(result.operations, ['read_file', 'send_file']);
+    assert.ok(result.expiresAt > result.createdAt);
+  });
+
+  test('does not create grants for missing, legacy, untrusted, non-CatsCo, or bodyless scopes', () => {
+    const { root, filePath } = workspaceWithAttachment('blocked.md');
+    const device = createCatsCoLocalDeviceGrant({ bodyId: 'body-main' });
+    const input = {
+      localPath: filePath,
+      fileName: 'blocked.md',
+      type: 'file' as const,
+      workspaceRoot: root,
+    };
+
+    assert.equal(createCatsCoAttachmentGrant(undefined, device, input), undefined);
+    assert.equal(createCatsCoAttachmentGrant(scope({
+      identityTrust: 'legacy_context',
+      isTrusted: false,
+    }), device, input), undefined);
+    assert.equal(createCatsCoAttachmentGrant(scope({
+      identityTrust: 'untrusted',
+      isTrusted: false,
+    }), device, input), undefined);
+    assert.equal(createCatsCoAttachmentGrant(scope({
+      source: 'feishu',
+    }), device, input), undefined);
+    assert.equal(createCatsCoAttachmentGrant(scope({
+      agentBodyId: undefined,
+    }), device, input), undefined);
+  });
+
+  test('does not create grants when the local device body or managed downloads path does not match', () => {
+    const { root, filePath } = workspaceWithAttachment('mismatch.md');
+
+    assert.equal(createCatsCoAttachmentGrant(scope(), createCatsCoLocalDeviceGrant({
+      bodyId: 'body-other',
+    }), {
+      localPath: filePath,
+      fileName: 'mismatch.md',
+      type: 'file',
+      workspaceRoot: root,
+    }), undefined);
+
+    const outsidePath = path.join(root, 'tmp', 'other', 'mismatch.md');
+    fs.mkdirSync(path.dirname(outsidePath), { recursive: true });
+    fs.writeFileSync(outsidePath, 'hello');
+    assert.equal(createCatsCoAttachmentGrant(scope(), createCatsCoLocalDeviceGrant({
+      bodyId: 'body-main',
+    }), {
+      localPath: outsidePath,
+      fileName: 'mismatch.md',
+      type: 'file',
+      workspaceRoot: root,
+    }), undefined);
+  });
+});

--- a/tests/catscompany-local-file-grants.test.ts
+++ b/tests/catscompany-local-file-grants.test.ts
@@ -49,6 +49,7 @@ describe('CatsCo local file grant creation', () => {
     });
 
     assert.ok(result);
+    assert.match(result.attachmentRef || '', /^catsco_attachment:/);
     assert.equal(result.filePath, fs.realpathSync(filePath));
     assert.equal(result.fileName, 'report.md');
     assert.equal(result.fileType, 'file');

--- a/tests/catscompany-message-envelope.test.ts
+++ b/tests/catscompany-message-envelope.test.ts
@@ -39,8 +39,10 @@ describe('CatsCompany MessageEnvelope and ExecutionScope', () => {
       },
     });
 
-    assert.equal(alice.sessionKey, 'cc_user:usr7');
-    assert.equal(bob.sessionKey, 'cc_user:usr8');
+    assert.equal(alice.sessionKey, 'session:v2:catscompany:p2p:p2p_7_43:agent:usr43');
+    assert.equal(alice.legacySessionKey, 'cc_user:usr7');
+    assert.equal(bob.sessionKey, 'session:v2:catscompany:p2p:p2p_8_43:agent:usr43');
+    assert.equal(bob.legacySessionKey, 'cc_user:usr8');
     assert.equal(alice.identityTrust, 'server_canonical');
     assert.equal(bob.identityTrust, 'server_canonical');
     assert.equal(createExecutionScope(alice).actorUserId, 'usr7');
@@ -65,7 +67,8 @@ describe('CatsCompany MessageEnvelope and ExecutionScope', () => {
     });
     const scope = createExecutionScope(envelope);
 
-    assert.equal(envelope.sessionKey, 'cc_group:grp_80');
+    assert.equal(envelope.sessionKey, 'session:v2:catscompany:group:grp_80:agent:usr43');
+    assert.equal(envelope.legacySessionKey, 'cc_group:grp_80');
     assert.equal(scope.topicType, 'group');
     assert.equal(scope.actorUserId, 'usr7');
     assert.equal(scope.agentId, 'usr43');

--- a/tests/catscompany-message-envelope.test.ts
+++ b/tests/catscompany-message-envelope.test.ts
@@ -1,0 +1,156 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import { CatsClient } from '../src/catscompany/client';
+import {
+  createCatsCoMessageEnvelope,
+  createExecutionScope,
+} from '../src/catscompany/message-envelope';
+
+describe('CatsCompany MessageEnvelope and ExecutionScope', () => {
+  test('keeps two p2p users scoped separately when they message the same agent', () => {
+    const alice = createCatsCoMessageEnvelope({
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      seq: 21,
+      text: 'alice task',
+      botUid: 'usr43',
+      metadata: {
+        catsco_identity: {
+          actor: { user_id: 'usr7', display_name: 'Alice' },
+          agent: { agent_id: 'usr43', body_id: 'body-mac' },
+          topic: { topic_id: 'p2p_7_43', type: 'p2p', channel_seq: 21 },
+          permissions: { source: 'server_canonical_message' },
+        },
+      },
+    });
+    const bob = createCatsCoMessageEnvelope({
+      topic: 'p2p_8_43',
+      senderId: 'usr8',
+      seq: 22,
+      text: 'bob task',
+      botUid: 'usr43',
+      metadata: {
+        catsco_identity: {
+          actor: { user_id: 'usr8', display_name: 'Bob' },
+          agent: { agent_id: 'usr43', body_id: 'body-mac' },
+          topic: { topic_id: 'p2p_8_43', type: 'p2p', channel_seq: 22 },
+          permissions: { source: 'server_canonical_message' },
+        },
+      },
+    });
+
+    assert.equal(alice.sessionKey, 'cc_user:usr7');
+    assert.equal(bob.sessionKey, 'cc_user:usr8');
+    assert.equal(alice.identityTrust, 'server_canonical');
+    assert.equal(bob.identityTrust, 'server_canonical');
+    assert.equal(createExecutionScope(alice).actorUserId, 'usr7');
+    assert.equal(createExecutionScope(bob).actorUserId, 'usr8');
+  });
+
+  test('creates a trusted group scope with recipient agent body identity', () => {
+    const envelope = createCatsCoMessageEnvelope({
+      topic: 'grp_80',
+      isGroup: true,
+      senderId: 'usr7',
+      seq: 31,
+      text: '@usr43 请看一下',
+      metadata: {
+        catsco_identity: {
+          actor: { user_id: 'usr7', username: 'alice' },
+          agent: { agent_id: 'usr43', body_id: 'body-review' },
+          topic: { topic_id: 'grp_80', type: 'group', channel_seq: 31 },
+          permissions: { source: 'server_canonical_message' },
+        },
+      },
+    });
+    const scope = createExecutionScope(envelope);
+
+    assert.equal(envelope.sessionKey, 'cc_group:grp_80');
+    assert.equal(scope.topicType, 'group');
+    assert.equal(scope.actorUserId, 'usr7');
+    assert.equal(scope.agentId, 'usr43');
+    assert.equal(scope.agentBodyId, 'body-review');
+    assert.equal(scope.isTrusted, true);
+  });
+
+  test('does not trust spoofed catsco_identity when it conflicts with sender', () => {
+    const envelope = createCatsCoMessageEnvelope({
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      seq: 40,
+      text: 'hello',
+      metadata: {
+        catsco_identity: {
+          actor: { user_id: 'usr999' },
+          agent: { agent_id: 'usr43', body_id: 'wrong-body' },
+          topic: { topic_id: 'p2p_7_43', type: 'p2p', channel_seq: 40 },
+          permissions: { source: 'server_canonical_message' },
+        },
+      },
+    });
+    const scope = createExecutionScope(envelope);
+
+    assert.equal(envelope.identityTrust, 'untrusted');
+    assert.equal(scope.isTrusted, false);
+    assert.equal(scope.actorUserId, 'usr7');
+    assert.equal(scope.agentBodyId, undefined);
+    assert.ok(envelope.warnings?.some(warning => warning.includes('actor.user_id')));
+  });
+
+  test('marks missing canonical identity as legacy context instead of trusted', () => {
+    const envelope = createCatsCoMessageEnvelope({
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      seq: 41,
+      text: 'legacy hello',
+      botUid: 'usr43',
+      metadata: { client_msg_id: 'catsco-legacy-1' },
+    });
+    const scope = createExecutionScope(envelope);
+
+    assert.equal(envelope.identityTrust, 'legacy_context');
+    assert.equal(envelope.messageId, 'catsco-legacy-1');
+    assert.equal(scope.isTrusted, false);
+    assert.equal(scope.actorUserId, 'usr7');
+    assert.equal(scope.agentId, 'usr43');
+    assert.equal(scope.agentBodyId, undefined);
+  });
+
+  test('client forwards inbound metadata into MessageContext', async () => {
+    const client = new CatsClient({
+      serverUrl: 'ws://127.0.0.1:1',
+      apiKey: 'cc-test',
+      bodyId: 'body-test',
+    });
+
+    const messagePromise = new Promise<any>(resolve => {
+      client.once('message', resolve);
+    });
+
+    (client as any).handleMessage({
+      data: {
+        topic: 'p2p_7_43',
+        from: 'usr7',
+        seq: 51,
+        content: 'hello',
+        type: 'text',
+        metadata: {
+          catsco_identity: {
+            actor: { user_id: 'usr7' },
+            agent: { agent_id: 'usr43', body_id: 'body-test' },
+            topic: { topic_id: 'p2p_7_43', type: 'p2p', channel_seq: 51 },
+            permissions: { source: 'server_canonical_message' },
+          },
+        },
+      },
+    });
+
+    const ctx = await messagePromise;
+    assert.equal(ctx.topic, 'p2p_7_43');
+    assert.equal(ctx.senderId, 'usr7');
+    assert.deepEqual((ctx.metadata as any).catsco_identity.agent, {
+      agent_id: 'usr43',
+      body_id: 'body-test',
+    });
+  });
+});

--- a/tests/conversation-runner-pending-input.test.ts
+++ b/tests/conversation-runner-pending-input.test.ts
@@ -2,7 +2,8 @@ import { describe, test } from 'node:test';
 import * as assert from 'node:assert';
 import { ConversationRunner } from '../src/core/conversation-runner';
 import { Message } from '../src/types';
-import { ToolCall, ToolDefinition, ToolExecutor, ToolResult } from '../src/types/tool';
+import type { ScopedLocalFileGrant } from '../src/types/session-identity';
+import { ToolCall, ToolDefinition, ToolExecutionContext, ToolExecutor, ToolResult } from '../src/types/tool';
 
 const usage = { promptTokens: 1, completionTokens: 1, totalTokens: 2 };
 
@@ -22,6 +23,30 @@ function createNoopToolExecutor(): ToolExecutor {
       content: 'ok',
       ok: true,
     }),
+  };
+}
+
+function grant(filePath: string): ScopedLocalFileGrant {
+  const now = Date.now();
+  return {
+    kind: 'catscompany_attachment',
+    source: 'catscompany',
+    filePath,
+    fileName: filePath.split(/[\\/]/).pop() || 'file.txt',
+    fileType: 'file',
+    size: 1,
+    mtimeMs: now,
+    sessionKey: 'cc_user:usr7',
+    topicId: 'p2p_7_43',
+    topicType: 'p2p',
+    actorUserId: 'usr7',
+    agentId: 'usr43',
+    agentBodyId: 'body-main',
+    deviceBodyId: 'body-main',
+    identityTrust: 'server_canonical',
+    operations: ['read_file', 'send_file'],
+    createdAt: now,
+    expiresAt: now + 60_000,
   };
 }
 
@@ -90,5 +115,80 @@ describe('ConversationRunner pending input', () => {
     assert.strictEqual(requests.length, 2);
     assert.ok(requests[1].some(msg => msg.role === 'tool' && msg.content === 'ok'));
     assert.ok(requests[1].some(msg => msg.role === 'user' && msg.content === 'new query after tool turn'));
+  });
+
+  test('merges pending local file grants into later tool execution context without clearing existing grants', async () => {
+    const requests: Message[][] = [];
+    const aiService = {
+      chat: async (messages: Message[]) => {
+        requests.push(messages.map(msg => ({ ...msg })));
+        if (requests.length === 1) {
+          return {
+            content: null,
+            toolCalls: [{
+              id: 'call_1',
+              type: 'function',
+              function: { name: 'noop', arguments: '{}' },
+            }],
+            usage,
+          };
+        }
+        if (requests.length === 2) {
+          return {
+            content: null,
+            toolCalls: [{
+              id: 'call_2',
+              type: 'function',
+              function: { name: 'noop', arguments: '{}' },
+            }],
+            usage,
+          };
+        }
+        return { content: 'done', toolCalls: [], usage };
+      },
+    } as any;
+    const contexts: Array<Partial<ToolExecutionContext> | undefined> = [];
+    const executor: ToolExecutor = {
+      getToolDefinitions: () => [{
+        name: 'noop',
+        description: 'noop',
+        parameters: { type: 'object', properties: {} },
+      }],
+      executeTool: async (toolCall, _history, contextOverrides) => {
+        contexts.push(contextOverrides);
+        return {
+          tool_call_id: toolCall.id,
+          role: 'tool',
+          name: toolCall.function.name,
+          content: 'ok',
+          ok: true,
+        };
+      },
+    };
+
+    let pendingUsed = false;
+    const initialGrant = grant('tmp/downloads/initial.md');
+    const pendingGrant = grant('tmp/downloads/pending.md');
+    const runner = new ConversationRunner(aiService, executor, {
+      stream: false,
+      toolExecutionContext: {
+        localFileGrants: [initialGrant],
+      },
+      pendingUserInputProvider: () => {
+        if (pendingUsed) return null;
+        pendingUsed = true;
+        return {
+          content: 'new attachment while busy',
+          localFileGrants: [pendingGrant],
+        };
+      },
+    });
+
+    const result = await runner.run([{ role: 'user', content: 'run a tool' }]);
+
+    assert.equal(result.response, 'done');
+    assert.equal(contexts.length, 2);
+    assert.deepEqual(contexts[0]?.localFileGrants, [initialGrant]);
+    assert.deepEqual(contexts[1]?.localFileGrants, [initialGrant, pendingGrant]);
   });
 });

--- a/tests/conversation-runner-pending-input.test.ts
+++ b/tests/conversation-runner-pending-input.test.ts
@@ -1,5 +1,6 @@
 import { describe, test } from 'node:test';
 import * as assert from 'node:assert';
+import * as path from 'path';
 import { ConversationRunner } from '../src/core/conversation-runner';
 import { Message } from '../src/types';
 import type { ScopedLocalFileGrant } from '../src/types/session-identity';
@@ -31,6 +32,7 @@ function grant(filePath: string): ScopedLocalFileGrant {
   return {
     kind: 'catscompany_attachment',
     source: 'catscompany',
+    attachmentRef: `catsco_attachment:${filePath.split(/[\\/]/).pop()?.replace(/\.[^.]+$/, '') || 'file'}`,
     filePath,
     fileName: filePath.split(/[\\/]/).pop() || 'file.txt',
     fileType: 'file',

--- a/tests/conversation-runner-pending-input.test.ts
+++ b/tests/conversation-runner-pending-input.test.ts
@@ -2,11 +2,27 @@ import { describe, test } from 'node:test';
 import * as assert from 'node:assert';
 import * as path from 'path';
 import { ConversationRunner } from '../src/core/conversation-runner';
+import { TRANSIENT_RUNTIME_CONTEXT_PREFIX } from '../src/core/runtime-context-builder';
 import { Message } from '../src/types';
-import type { ScopedLocalFileGrant } from '../src/types/session-identity';
+import type { ExecutionScope, ScopedDeviceGrant, ScopedLocalFileGrant } from '../src/types/session-identity';
 import { ToolCall, ToolDefinition, ToolExecutionContext, ToolExecutor, ToolResult } from '../src/types/tool';
 
 const usage = { promptTokens: 1, completionTokens: 1, totalTokens: 2 };
+
+function scope(): ExecutionScope {
+  return {
+    source: 'catscompany',
+    sessionKey: 'cc_user:usr7',
+    topicId: 'p2p_7_43',
+    topicType: 'p2p',
+    actorUserId: 'usr7',
+    agentId: 'usr43',
+    agentBodyId: 'body-main',
+    permissionsSource: 'metadata.catsco_identity',
+    identityTrust: 'server_canonical',
+    isTrusted: true,
+  };
+}
 
 function createNoopToolExecutor(): ToolExecutor {
   const noopTool: ToolDefinition = {
@@ -47,6 +63,32 @@ function grant(filePath: string): ScopedLocalFileGrant {
     deviceBodyId: 'body-main',
     identityTrust: 'server_canonical',
     operations: ['read_file', 'send_file'],
+    createdAt: now,
+    expiresAt: now + 60_000,
+  };
+}
+
+function deviceGrant(deviceId: string): ScopedDeviceGrant {
+  const now = Date.now();
+  return {
+    kind: 'user_device_grant',
+    source: 'catscompany',
+    grantId: `device_grant:${deviceId}`,
+    status: 'active',
+    identityTrust: 'server_canonical',
+    identitySource: 'metadata.catsco_identity',
+    deviceId,
+    deviceDisplayName: deviceId,
+    deviceBodyId: 'body-main',
+    deviceInstallationId: `install:${deviceId}`,
+    ownerUserId: 'usr7',
+    sessionKey: 'cc_user:usr7',
+    topicId: 'p2p_7_43',
+    topicType: 'p2p',
+    actorUserId: 'usr7',
+    agentId: 'usr43',
+    agentBodyId: 'body-main',
+    operations: ['read_file'],
     createdAt: now,
     expiresAt: now + 60_000,
   };
@@ -193,4 +235,103 @@ describe('ConversationRunner pending input', () => {
     assert.deepEqual(contexts[0]?.localFileGrants, [initialGrant]);
     assert.deepEqual(contexts[1]?.localFileGrants, [initialGrant, pendingGrant]);
   });
+
+  test('merges pending device grants into later tool execution context without clearing existing grants', async () => {
+    const requests: Message[][] = [];
+    const aiService = {
+      chat: async (messages: Message[]) => {
+        requests.push(messages.map(msg => ({ ...msg })));
+        if (requests.length === 1) {
+          return {
+            content: null,
+            toolCalls: [{
+              id: 'call_1',
+              type: 'function',
+              function: { name: 'noop', arguments: '{}' },
+            }],
+            usage,
+          };
+        }
+        if (requests.length === 2) {
+          return {
+            content: null,
+            toolCalls: [{
+              id: 'call_2',
+              type: 'function',
+              function: { name: 'noop', arguments: '{}' },
+            }],
+            usage,
+          };
+        }
+        return { content: 'done', toolCalls: [], usage };
+      },
+    } as any;
+    const contexts: Array<Partial<ToolExecutionContext> | undefined> = [];
+    const executor: ToolExecutor = {
+      getToolDefinitions: () => [{
+        name: 'noop',
+        description: 'noop',
+        parameters: { type: 'object', properties: {} },
+      }],
+      executeTool: async (toolCall, _history, contextOverrides) => {
+        contexts.push(contextOverrides);
+        return {
+          tool_call_id: toolCall.id,
+          role: 'tool',
+          name: toolCall.function.name,
+          content: 'ok',
+          ok: true,
+        };
+      },
+    };
+
+    let pendingUsed = false;
+    const initialGrant = deviceGrant('device-initial');
+    const pendingGrant = deviceGrant('device-pending');
+    const runner = new ConversationRunner(aiService, executor, {
+      stream: false,
+      toolExecutionContext: {
+        sessionId: 'cc_user:usr7',
+        surface: 'catscompany',
+        executionScope: scope(),
+        deviceGrants: [initialGrant],
+      },
+      pendingUserInputProvider: () => {
+        if (pendingUsed) return null;
+        pendingUsed = true;
+        return {
+          content: 'new device grant while busy',
+          deviceGrants: [pendingGrant],
+        };
+      },
+    });
+
+    const result = await runner.run([{ role: 'user', content: 'run a tool' }]);
+
+    assert.equal(result.response, 'done');
+    assert.equal(contexts.length, 2);
+    assert.deepEqual(contexts[0]?.deviceGrants, [initialGrant]);
+    assert.deepEqual(contexts[1]?.deviceGrants, [initialGrant, pendingGrant]);
+
+    const refreshedContext = requests[1].find(isRuntimeContextMessage);
+    assert.ok(refreshedContext);
+    const snapshot = parseRuntimeContext(refreshedContext);
+    assert.deepEqual(
+      snapshot.execution.userDevices.map((device: any) => device.deviceId),
+      ['device-initial', 'device-pending'],
+    );
+    assert.doesNotMatch(refreshedContext.content as string, /install:device-/);
+    assert.doesNotMatch(refreshedContext.content as string, /body-main/);
+  });
 });
+
+function isRuntimeContextMessage(message: Message): boolean {
+  return message.role === 'system'
+    && typeof message.content === 'string'
+    && message.content.startsWith(TRANSIENT_RUNTIME_CONTEXT_PREFIX);
+}
+
+function parseRuntimeContext(message: Message): any {
+  const content = String(message.content || '');
+  return JSON.parse(content.slice(TRANSIENT_RUNTIME_CONTEXT_PREFIX.length).trim());
+}

--- a/tests/cross-channel-session-isolation.test.ts
+++ b/tests/cross-channel-session-isolation.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+describe('cross-channel session isolation', () => {
+  let testRoot: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-cross-channel-session-'));
+    process.chdir(testRoot);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    if (testRoot && fs.existsSync(testRoot)) {
+      fs.rmSync(testRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('same raw user id uses separate session files and subagent callbacks per channel', async () => {
+    const { SessionStore, SubAgentManager, createSessionRoute } = loadModules();
+    const store = SessionStore.getInstance();
+    const feishu = createSessionRoute({
+      source: 'feishu',
+      topicType: 'p2p',
+      topicId: 'shared',
+      actorUserId: 'shared',
+      identityTrust: 'legacy_context',
+      legacySessionKey: 'user:shared',
+    });
+    const weixin = createSessionRoute({
+      source: 'weixin',
+      topicType: 'p2p',
+      topicId: 'shared',
+      actorUserId: 'shared',
+      identityTrust: 'legacy_context',
+      legacySessionKey: 'user:shared',
+    });
+
+    store.saveContext(feishu.sessionKey, [{ role: 'user', content: 'feishu history' }]);
+    store.saveContext(weixin.sessionKey, [{ role: 'user', content: 'weixin history' }]);
+
+    assert.deepEqual(store.loadContext(feishu.sessionKey).map((message: any) => message.content), ['feishu history']);
+    assert.deepEqual(store.loadContext(weixin.sessionKey).map((message: any) => message.content), ['weixin history']);
+    assert.notEqual(feishu.sessionKey, weixin.sessionKey);
+
+    const delivered: string[] = [];
+    const manager = SubAgentManager.getInstance();
+    manager.registerPlatformCallbacks(feishu.sessionKey, {
+      injectMessage: async text => { delivered.push(`feishu:${text}`); },
+    });
+    manager.registerPlatformCallbacks(weixin.sessionKey, {
+      injectMessage: async text => { delivered.push(`weixin:${text}`); },
+    });
+
+    try {
+      await (manager as any).platformCallbacks.get(feishu.sessionKey).injectMessage('done');
+      await (manager as any).platformCallbacks.get(weixin.sessionKey).injectMessage('done');
+      assert.deepEqual(delivered, ['feishu:done', 'weixin:done']);
+    } finally {
+      manager.unregisterPlatformCallbacks(feishu.sessionKey);
+      manager.unregisterPlatformCallbacks(weixin.sessionKey);
+    }
+  });
+});
+
+function loadModules(): any {
+  for (const modulePath of [
+    '../src/utils/session-store',
+    '../src/core/session-router',
+    '../src/core/sub-agent-manager',
+  ]) {
+    delete require.cache[require.resolve(modulePath)];
+  }
+  return {
+    SessionStore: require('../src/utils/session-store').SessionStore,
+    SubAgentManager: require('../src/core/sub-agent-manager').SubAgentManager,
+    createSessionRoute: require('../src/core/session-router').createSessionRoute,
+  };
+}

--- a/tests/device-grants.test.ts
+++ b/tests/device-grants.test.ts
@@ -1,0 +1,212 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  type CreateUserDeviceInput,
+  createDeviceGrant,
+  createUserDevice,
+  resolveDeviceGrant,
+  validateDeviceGrant,
+} from '../src/core/device-grants';
+import type {
+  ExecutionScope,
+  ScopedDeviceGrant,
+} from '../src/types/session-identity';
+
+function scope(overrides: Partial<ExecutionScope> = {}): ExecutionScope {
+  return {
+    source: 'catscompany',
+    sessionKey: 'session:v2:catscompany:group:grp_80:agent:usr43',
+    topicId: 'grp_80',
+    topicType: 'group',
+    actorUserId: 'usr7',
+    agentId: 'usr43',
+    agentBodyId: 'body-main',
+    permissionsSource: 'metadata.catsco_identity',
+    identityTrust: 'server_canonical',
+    isTrusted: true,
+    ...overrides,
+  };
+}
+
+function device(overrides: Partial<CreateUserDeviceInput> = {}) {
+  const result = createUserDevice({
+    source: 'catscompany',
+    ownerUserId: ' usr7 ',
+    deviceId: ' device-main ',
+    displayName: ' Alice laptop ',
+    bodyId: ' body-main ',
+    installationId: ' install-main ',
+    identityTrust: 'server_canonical',
+    identitySource: 'device.registry',
+    status: 'online',
+    registeredAt: 100,
+    lastSeenAt: 200,
+    ...overrides,
+  });
+  assert.ok(result);
+  return result;
+}
+
+function grant(overrides: Partial<ScopedDeviceGrant> = {}): ScopedDeviceGrant {
+  const created = createDeviceGrant(scope(), device(), {
+    grantId: 'grant-main',
+    operations: ['read_file', 'send_file'],
+    now: 1_000,
+    ttlMs: 5_000,
+  });
+  assert.ok(created);
+  return { ...created, ...overrides };
+}
+
+describe('device grants', () => {
+  test('creates a normalized user device without exposing local filesystem concepts', () => {
+    const result = device();
+
+    assert.equal(result.ownerUserId, 'usr7');
+    assert.equal(result.deviceId, 'device-main');
+    assert.equal(result.displayName, 'Alice laptop');
+    assert.equal(result.bodyId, 'body-main');
+    assert.equal(result.installationId, 'install-main');
+    assert.equal(result.identityTrust, 'server_canonical');
+    assert.equal(result.status, 'online');
+  });
+
+  test('creates a scoped active grant tied to the current actor, agent, topic, and device', () => {
+    const created = createDeviceGrant(scope(), device(), {
+      grantId: 'grant-main',
+      operations: ['read_file', 'read_file', 'execute_shell', 'invalid' as any],
+      identitySource: 'catsco.device_grant',
+      now: 1_000,
+      ttlMs: 10_000,
+    });
+
+    assert.ok(created);
+    assert.equal(created.kind, 'user_device_grant');
+    assert.equal(created.status, 'active');
+    assert.equal(created.identityTrust, 'server_canonical');
+    assert.equal(created.identitySource, 'catsco.device_grant');
+    assert.equal(created.ownerUserId, 'usr7');
+    assert.equal(created.actorUserId, 'usr7');
+    assert.equal(created.agentId, 'usr43');
+    assert.equal(created.agentBodyId, 'body-main');
+    assert.equal(created.deviceId, 'device-main');
+    assert.equal(created.deviceBodyId, 'body-main');
+    assert.equal(created.deviceInstallationId, 'install-main');
+    assert.deepEqual(created.operations, ['read_file', 'execute_shell']);
+    assert.equal(created.createdAt, 1_000);
+    assert.equal(created.expiresAt, 11_000);
+  });
+
+  test('refuses to create grants for empty operations, source mismatch, or a different owner', () => {
+    assert.equal(createDeviceGrant(scope(), device(), { operations: [] }), undefined);
+    assert.equal(createDeviceGrant(scope(), device({ source: 'feishu' }), { operations: ['read_file'] }), undefined);
+    assert.equal(createDeviceGrant(scope(), device({ ownerUserId: 'usr8' }), { operations: ['read_file'] }), undefined);
+  });
+
+  test('resolves a matching grant by operation and optional target device', () => {
+    const other = grant({
+      grantId: 'grant-other',
+      deviceId: 'device-other',
+      operations: ['execute_shell'],
+    });
+    const result = resolveDeviceGrant({
+      executionScope: scope(),
+      deviceGrants: [other, grant()],
+    }, {
+      operation: 'send_file',
+      deviceId: 'device-main',
+      now: 2_000,
+    });
+
+    assert.equal(result.ok, true);
+    if (result.ok) assert.equal(result.grant.grantId, 'grant-main');
+  });
+
+  test('rejects ambiguous device resolution when multiple target devices can perform the same operation', () => {
+    const result = resolveDeviceGrant({
+      executionScope: scope(),
+      deviceGrants: [
+        grant({ grantId: 'grant-main', deviceId: 'device-main' }),
+        grant({ grantId: 'grant-second', deviceId: 'device-second' }),
+      ],
+    }, {
+      operation: 'read_file',
+      now: 2_000,
+    });
+
+    assert.equal(result.ok, false);
+    if (!result.ok) assert.match(result.message, /多个允许 read_file 的用户设备授权/);
+  });
+
+  test('skips invalid candidates when a later grant for the same target device is valid', () => {
+    const result = resolveDeviceGrant({
+      executionScope: scope(),
+      deviceGrants: [
+        grant({ grantId: 'grant-expired', expiresAt: 2_000 }),
+        grant({ grantId: 'grant-valid', expiresAt: 6_000 }),
+      ],
+    }, {
+      operation: 'read_file',
+      deviceId: 'device-main',
+      now: 2_000,
+    });
+
+    assert.equal(result.ok, true);
+    if (result.ok) assert.equal(result.grant.grantId, 'grant-valid');
+  });
+
+  test('rejects missing, revoked, expired, operation, and target-device mismatches', () => {
+    assert.equal(resolveDeviceGrant({
+      executionScope: scope(),
+      deviceGrants: [],
+    }, {
+      operation: 'read_file',
+      now: 2_000,
+    }).ok, false);
+
+    const cases: Array<[string, ScopedDeviceGrant, RegExp]> = [
+      ['revoked', grant({ status: 'revoked' }), /不是 active/],
+      ['expired', grant({ expiresAt: 2_000 }), /已过期/],
+      ['operation', grant({ operations: ['send_file'] }), /不允许执行 read_file/],
+      ['target device', grant(), /目标设备不一致/],
+      ['untrusted', grant({ identityTrust: 'untrusted' }), /未可信身份/],
+    ];
+
+    for (const [name, candidate, messagePattern] of cases) {
+      const decision = validateDeviceGrant({
+        executionScope: scope(),
+      }, candidate, {
+        operation: 'read_file',
+        deviceId: name === 'target device' ? 'device-other' : undefined,
+        now: 2_000,
+      });
+      assert.equal(decision.ok, false, name);
+      if (!decision.ok) assert.match(decision.message, messagePattern, name);
+    }
+  });
+
+  test('rejects grants from another session, source, actor, topic type, agent, or body', () => {
+    const mismatchCases: Array<[string, Partial<ScopedDeviceGrant>]> = [
+      ['source', { source: 'feishu' }],
+      ['sessionKey', { sessionKey: 'session:v2:catscompany:group:grp_81:agent:usr43' }],
+      ['topicId', { topicId: 'grp_81' }],
+      ['topicType', { topicType: 'p2p' }],
+      ['actorUserId', { actorUserId: 'usr8', ownerUserId: 'usr8' }],
+      ['ownerUserId', { ownerUserId: 'usr8' }],
+      ['agentId', { agentId: 'usr99' }],
+      ['agentBodyId', { agentBodyId: 'body-other' }],
+    ];
+
+    for (const [field, overrides] of mismatchCases) {
+      const decision = validateDeviceGrant({
+        executionScope: scope(),
+      }, grant(overrides), {
+        operation: 'read_file',
+        now: 2_000,
+      });
+
+      assert.equal(decision.ok, false, field);
+      if (!decision.ok) assert.match(decision.message, new RegExp(field), field);
+    }
+  });
+});

--- a/tests/feishu-session-route.test.ts
+++ b/tests/feishu-session-route.test.ts
@@ -1,0 +1,113 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import { FeishuBot } from '../src/feishu';
+import { SubAgentManager } from '../src/core/sub-agent-manager';
+
+describe('Feishu SessionRoute V2', () => {
+  test('routes private messages through a Feishu V2 session key', async () => {
+    const bot = createHarness({
+      message: {
+        messageId: 'msg-1',
+        chatId: 'shared',
+        chatType: 'p2p',
+        senderId: 'shared',
+        text: 'hello',
+        mentionBot: false,
+        msgType: 'text',
+      },
+    });
+
+    try {
+      await (bot as any).onMessage({});
+
+      assert.deepEqual(bot.createdSessions, ['session:v2:feishu:p2p:shared']);
+      assert.equal(bot.handledTurns.length, 1);
+      assert.equal(bot.handledTurns[0].options.channel.chatId, 'shared');
+      assert.equal(bot.handledTurns[0].options.sessionRoute.sessionKey, 'session:v2:feishu:p2p:shared');
+      assert.equal(bot.handledTurns[0].options.executionScope.source, 'feishu');
+      assert.equal(bot.handledTurns[0].options.executionScope.topicType, 'p2p');
+      assert.equal(bot.handledTurns[0].options.executionScope.topicId, 'shared');
+      assert.equal(bot.handledTurns[0].options.executionScope.actorUserId, 'shared');
+      assert.equal(bot.messageQueue.size, 0);
+    } finally {
+      SubAgentManager.getInstance().unregisterPlatformCallbacks('session:v2:feishu:p2p:shared');
+    }
+  });
+
+  test('queues group messages under the same V2 route used for draining', async () => {
+    const bot = createHarness({
+      busy: true,
+      message: {
+        messageId: 'msg-2',
+        chatId: 'oc_group',
+        chatType: 'group',
+        senderId: 'ou_user',
+        text: '@bot 继续',
+        mentionBot: true,
+        msgType: 'text',
+      },
+    });
+
+    try {
+      await (bot as any).onMessage({});
+
+      const sessionKey = 'session:v2:feishu:group:oc_group';
+      assert.equal(bot.messageQueue.has(sessionKey), true);
+      assert.equal(bot.messageQueue.get(sessionKey)?.[0]?.senderId, 'ou_user');
+      assert.equal(bot.messageQueue.get(sessionKey)?.[0]?.sessionRoute.actorUserId, 'ou_user');
+      bot.sessionBusy = false;
+      await (bot as any).drainMessageQueue(sessionKey);
+
+      assert.deepEqual(bot.createdSessions, [sessionKey, sessionKey]);
+      assert.equal(bot.handledTurns.length, 1);
+      assert.equal(bot.handledTurns[0].options.channel.chatId, 'oc_group');
+      assert.equal(bot.handledTurns[0].options.sessionRoute.sessionKey, sessionKey);
+      assert.equal(bot.handledTurns[0].options.executionScope.topicType, 'group');
+      assert.equal(bot.handledTurns[0].options.executionScope.actorUserId, 'ou_user');
+    } finally {
+      SubAgentManager.getInstance().unregisterPlatformCallbacks('session:v2:feishu:group:oc_group');
+    }
+  });
+});
+
+function createHarness(options: { busy?: boolean; message: any }): any {
+  const bot = Object.create(FeishuBot.prototype) as any;
+  bot.sessionBusy = options.busy ?? false;
+  bot.createdSessions = [] as string[];
+  bot.handledTurns = [] as any[];
+  bot.processedMsgIds = new Set();
+  bot.pendingAnswers = new Map();
+  bot.pendingAnswerBySession = new Map();
+  bot.pendingAttachments = new Map();
+  bot.messageQueue = new Map();
+  bot.bridgeClient = null;
+  bot.bridgeConfig = undefined;
+  bot.handler = {
+    parse: () => options.message,
+  };
+  const session = {
+    isBusy: () => bot.sessionBusy,
+    handleCommand: async () => ({ handled: false }),
+    handleMessage: async (userText: string, handleOptions: any) => {
+      bot.handledTurns.push({ userText, options: handleOptions });
+      return { visibleToUser: false, text: '' };
+    },
+    handleRuntimeObservation: async (userText: string, handleOptions: any) => {
+      bot.handledTurns.push({ userText, options: handleOptions });
+      return { visibleToUser: false, text: '' };
+    },
+  };
+  bot.sessionManager = {
+    getOrCreate: (input: any) => {
+      bot.createdSessions.push(typeof input === 'string' ? input : input.sessionKey);
+      return session;
+    },
+  };
+  bot.sender = {
+    reply: async () => undefined,
+    downloadFile: async () => null,
+    fetchMergeForwardTexts: async () => '',
+    sendFile: async () => undefined,
+  };
+  return bot;
+}

--- a/tests/grep-tool.test.ts
+++ b/tests/grep-tool.test.ts
@@ -179,12 +179,17 @@ describe('GrepTool', () => {
 
   describe('安全性检查', () => {
     test('应该处理工作目录外的路径并返回错误', async () => {
+      const outsideMissingPath = path.join(
+        os.tmpdir(),
+        `grep-outside-missing-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+        'missing.txt'
+      );
       const result = await grepTool.execute({
         pattern: 'test',
-        path: '../../etc/passwd'
+        path: outsideMissingPath
       }, context);
 
-      // 由于路径不存在，应该返回错误
+      // 由于路径在工作目录外且不存在，应该返回错误
       assert.ok(!result.ok, '应该返回错误');
       assert.ok(result.message.includes('目录不存在') || result.message.includes('rg') || result.message.includes('grep'),
         `错误信息应该有用，实际: ${result.message}`);

--- a/tests/local-file-gateway.test.ts
+++ b/tests/local-file-gateway.test.ts
@@ -112,6 +112,9 @@ describe('resolveLocalFileAccess', () => {
     });
 
     assert.equal(result.ok, true);
+    if (result.ok) {
+      assert.equal(result.displayPath, 'catsco_attachment:current-grant');
+    }
   });
 
   test('resolves a CatsCo attachment reference without exposing the local path', () => {
@@ -191,6 +194,50 @@ describe('resolveLocalFileAccess', () => {
     }
   });
 
+  test('rejects attachment references when current identity mismatches without leaking the local path', () => {
+    const workspaceRoot = makeWorkspace();
+    const filePath = makeManagedFile(workspaceRoot, 'wrong-actor-ref.md');
+    const result = resolveLocalFileReference(context({
+      workspaceRoot,
+      executionScope: scope({ actorUserId: 'usr8', sessionKey: 'cc_user:usr8' }),
+      localDeviceGrant: deviceGrant(),
+      localFileGrants: [grant(filePath, { attachmentRef: 'catsco_attachment:wrong-actor' })],
+    }), {
+      operation: 'read_file',
+      inputPath: 'catsco_attachment:wrong-actor',
+    });
+
+    assert.equal(result.matched, true);
+    if (result.matched) {
+      assert.equal(result.ok, false);
+      if (!result.ok) {
+        assert.equal(result.errorCode, 'PERMISSION_DENIED');
+        assert.match(result.message, /授权与当前执行身份不一致/);
+        assert.match(result.message, /Attachment ref: catsco_attachment:wrong-actor/);
+        assert.doesNotMatch(result.message, /wrong-actor-ref\.md/);
+        assert.doesNotMatch(result.message, new RegExp(escapeRegExp(workspaceRoot)));
+      }
+    }
+  });
+
+  test('rejects CatsCo attachment references outside CatsCo sessions', () => {
+    const workspaceRoot = makeWorkspace();
+    const result = resolveLocalFileReference(context({
+      workspaceRoot,
+      surface: 'cli',
+    }), {
+      operation: 'read_file',
+      inputPath: 'catsco_attachment:outside-catsco',
+    });
+
+    assert.deepEqual(result, {
+      matched: true,
+      ok: false,
+      errorCode: 'PERMISSION_DENIED',
+      message: 'CatsCo 附件引用只能在当前 CatsCo 会话中使用。',
+    });
+  });
+
   test('rejects a CatsCo managed attachment path without a current grant', () => {
     const workspaceRoot = makeWorkspace();
     const filePath = makeManagedFile(workspaceRoot, 'old-report.md');
@@ -207,6 +254,9 @@ describe('resolveLocalFileAccess', () => {
     if (!result.ok) {
       assert.equal(result.errorCode, 'PERMISSION_DENIED');
       assert.match(result.message, /不属于当前已授权的用户消息/);
+      assert.match(result.message, /\[CatsCo managed attachment cache\]/);
+      assert.doesNotMatch(result.message, /old-report\.md/);
+      assert.doesNotMatch(result.message, new RegExp(escapeRegExp(workspaceRoot)));
     }
   });
 
@@ -224,7 +274,11 @@ describe('resolveLocalFileAccess', () => {
     });
 
     assert.equal(result.ok, false);
-    if (!result.ok) assert.match(result.message, /未通过服务端一致性校验/);
+    if (!result.ok) {
+      assert.match(result.message, /未通过服务端一致性校验/);
+      assert.match(result.message, /catsco_attachment:current-grant/);
+      assert.doesNotMatch(result.message, new RegExp(escapeRegExp(workspaceRoot)));
+    }
   });
 
   test('rejects a grant when actor identity does not match the current execution scope', () => {

--- a/tests/local-file-gateway.test.ts
+++ b/tests/local-file-gateway.test.ts
@@ -303,12 +303,17 @@ describe('resolveLocalFileAccess', () => {
     }
   });
 
-  test('rejects a grant when topic or body identity does not match', () => {
+  test('rejects a grant when topic, agent, or body identity does not match', () => {
     const workspaceRoot = makeWorkspace();
     const filePath = makeManagedFile(workspaceRoot);
     const result = resolveLocalFileAccess(context({
       workspaceRoot,
-      executionScope: scope({ topicId: 'p2p_8_43', agentBodyId: 'body-other' }),
+      executionScope: scope({
+        topicId: 'p2p_8_43',
+        topicType: 'group',
+        agentId: 'usr99',
+        agentBodyId: 'body-other',
+      }),
       localDeviceGrant: deviceGrant({ bodyId: 'body-other' }),
       localFileGrants: [grant(filePath)],
     }), {
@@ -319,8 +324,30 @@ describe('resolveLocalFileAccess', () => {
     assert.equal(result.ok, false);
     if (!result.ok) {
       assert.match(result.message, /topicId/);
+      assert.match(result.message, /topicType/);
+      assert.match(result.message, /agentId/);
       assert.match(result.message, /agentBodyId/);
       assert.match(result.message, /deviceBodyId/);
+    }
+  });
+
+  test('rejects a grant when device installation identity does not match', () => {
+    const workspaceRoot = makeWorkspace();
+    const filePath = makeManagedFile(workspaceRoot);
+    const result = resolveLocalFileAccess(context({
+      workspaceRoot,
+      executionScope: scope(),
+      localDeviceGrant: deviceGrant({ installationId: 'install-other' }),
+      localFileGrants: [grant(filePath, { deviceInstallationId: 'install-main' })],
+    }), {
+      operation: 'read_file',
+      absolutePath: filePath,
+    });
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.match(result.message, /deviceInstallationId/);
+      assert.doesNotMatch(result.message, new RegExp(escapeRegExp(workspaceRoot)));
     }
   });
 

--- a/tests/local-file-gateway.test.ts
+++ b/tests/local-file-gateway.test.ts
@@ -1,0 +1,317 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { resolveLocalFileAccess } from '../src/tools/local-file-gateway';
+import type {
+  ExecutionScope,
+  ScopedLocalDeviceGrant,
+  ScopedLocalFileGrant,
+} from '../src/types/session-identity';
+import type { ToolExecutionContext, ToolSurface } from '../src/types/tool';
+
+function scope(overrides: Partial<ExecutionScope> = {}): ExecutionScope {
+  return {
+    source: 'catscompany',
+    sessionKey: 'cc_user:usr7',
+    topicId: 'p2p_7_43',
+    topicType: 'p2p',
+    actorUserId: 'usr7',
+    agentId: 'usr43',
+    agentBodyId: 'body-main',
+    permissionsSource: 'server_canonical_message',
+    identityTrust: 'server_canonical',
+    isTrusted: true,
+    ...overrides,
+  };
+}
+
+function deviceGrant(overrides: Partial<ScopedLocalDeviceGrant> = {}): ScopedLocalDeviceGrant {
+  return {
+    kind: 'catscompany_body',
+    source: 'catscompany',
+    bodyId: 'body-main',
+    installationId: 'install-main',
+    deviceId: 'install-main',
+    createdAt: Date.now(),
+    ...overrides,
+  };
+}
+
+function grant(filePath: string, overrides: Partial<ScopedLocalFileGrant> = {}): ScopedLocalFileGrant {
+  const stat = fs.statSync(filePath);
+  const now = Date.now();
+  return {
+    kind: 'catscompany_attachment',
+    source: 'catscompany',
+    filePath,
+    fileName: path.basename(filePath),
+    fileType: 'file',
+    size: stat.size,
+    mtimeMs: stat.mtimeMs,
+    sessionKey: 'cc_user:usr7',
+    topicId: 'p2p_7_43',
+    topicType: 'p2p',
+    actorUserId: 'usr7',
+    agentId: 'usr43',
+    agentBodyId: 'body-main',
+    deviceBodyId: 'body-main',
+    deviceInstallationId: 'install-main',
+    identityTrust: 'server_canonical',
+    operations: ['read_file', 'send_file'],
+    createdAt: now,
+    expiresAt: now + 60_000,
+    ...overrides,
+  };
+}
+
+function context(options: {
+  workspaceRoot: string;
+  surface?: ToolSurface;
+  executionScope?: ExecutionScope;
+  localDeviceGrant?: ScopedLocalDeviceGrant;
+  localFileGrants?: ScopedLocalFileGrant[];
+}): ToolExecutionContext {
+  return {
+    workingDirectory: options.workspaceRoot,
+    workspaceRoot: options.workspaceRoot,
+    conversationHistory: [],
+    sessionId: options.executionScope?.sessionKey,
+    surface: options.surface ?? 'catscompany',
+    executionScope: options.executionScope,
+    localDeviceGrant: options.localDeviceGrant,
+    localFileGrants: options.localFileGrants,
+  };
+}
+
+function makeWorkspace(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-local-grant-test-'));
+}
+
+function makeManagedFile(workspaceRoot: string, name = 'report.md'): string {
+  const filePath = path.join(workspaceRoot, 'tmp', 'downloads', name);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, 'hello');
+  return filePath;
+}
+
+describe('resolveLocalFileAccess', () => {
+  test('allows a CatsCo managed attachment path with a matching canonical grant', () => {
+    const workspaceRoot = makeWorkspace();
+    const filePath = makeManagedFile(workspaceRoot);
+    const result = resolveLocalFileAccess(context({
+      workspaceRoot,
+      executionScope: scope(),
+      localDeviceGrant: deviceGrant(),
+      localFileGrants: [grant(filePath)],
+    }), {
+      operation: 'read_file',
+      absolutePath: filePath,
+    });
+
+    assert.equal(result.ok, true);
+  });
+
+  test('rejects a CatsCo managed attachment path without a current grant', () => {
+    const workspaceRoot = makeWorkspace();
+    const filePath = makeManagedFile(workspaceRoot, 'old-report.md');
+    const result = resolveLocalFileAccess(context({
+      workspaceRoot,
+      executionScope: scope(),
+      localDeviceGrant: deviceGrant(),
+    }), {
+      operation: 'read_file',
+      absolutePath: filePath,
+    });
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.errorCode, 'PERMISSION_DENIED');
+      assert.match(result.message, /不属于当前已授权的用户消息/);
+    }
+  });
+
+  test('rejects legacy_context scope even when a matching grant is present', () => {
+    const workspaceRoot = makeWorkspace();
+    const filePath = makeManagedFile(workspaceRoot);
+    const result = resolveLocalFileAccess(context({
+      workspaceRoot,
+      executionScope: scope({ identityTrust: 'legacy_context', isTrusted: false }),
+      localDeviceGrant: deviceGrant(),
+      localFileGrants: [grant(filePath)],
+    }), {
+      operation: 'read_file',
+      absolutePath: filePath,
+    });
+
+    assert.equal(result.ok, false);
+    if (!result.ok) assert.match(result.message, /未通过服务端一致性校验/);
+  });
+
+  test('rejects a grant when actor identity does not match the current execution scope', () => {
+    const workspaceRoot = makeWorkspace();
+    const filePath = makeManagedFile(workspaceRoot);
+    const result = resolveLocalFileAccess(context({
+      workspaceRoot,
+      executionScope: scope({ actorUserId: 'usr8', sessionKey: 'cc_user:usr8' }),
+      localDeviceGrant: deviceGrant(),
+      localFileGrants: [grant(filePath)],
+    }), {
+      operation: 'send_file',
+      absolutePath: filePath,
+    });
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.errorCode, 'PERMISSION_DENIED');
+      assert.match(result.message, /授权与当前执行身份不一致/);
+      assert.match(result.message, /actorUserId/);
+      assert.match(result.message, /sessionKey/);
+    }
+  });
+
+  test('rejects a grant when topic or body identity does not match', () => {
+    const workspaceRoot = makeWorkspace();
+    const filePath = makeManagedFile(workspaceRoot);
+    const result = resolveLocalFileAccess(context({
+      workspaceRoot,
+      executionScope: scope({ topicId: 'p2p_8_43', agentBodyId: 'body-other' }),
+      localDeviceGrant: deviceGrant({ bodyId: 'body-other' }),
+      localFileGrants: [grant(filePath)],
+    }), {
+      operation: 'read_file',
+      absolutePath: filePath,
+    });
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.match(result.message, /topicId/);
+      assert.match(result.message, /agentBodyId/);
+      assert.match(result.message, /deviceBodyId/);
+    }
+  });
+
+  test('rejects local attachment access for untrusted scope even when a path grant is present', () => {
+    const workspaceRoot = makeWorkspace();
+    const filePath = makeManagedFile(workspaceRoot);
+    const result = resolveLocalFileAccess(context({
+      workspaceRoot,
+      executionScope: scope({
+        identityTrust: 'untrusted',
+        isTrusted: false,
+      }),
+      localDeviceGrant: deviceGrant(),
+      localFileGrants: [grant(filePath)],
+    }), {
+      operation: 'read_file',
+      absolutePath: filePath,
+    });
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.errorCode, 'PERMISSION_DENIED');
+      assert.match(result.message, /未通过服务端一致性校验/);
+    }
+  });
+
+  test('rejects grants whose own identity is not canonical CatsCo', () => {
+    const workspaceRoot = makeWorkspace();
+    const filePath = makeManagedFile(workspaceRoot);
+    const result = resolveLocalFileAccess(context({
+      workspaceRoot,
+      executionScope: scope(),
+      localDeviceGrant: deviceGrant(),
+      localFileGrants: [grant(filePath, { identityTrust: 'legacy_context' })],
+    }), {
+      operation: 'read_file',
+      absolutePath: filePath,
+    });
+
+    assert.equal(result.ok, false);
+    if (!result.ok) assert.match(result.message, /不是服务端可信 CatsCo 身份/);
+  });
+
+  test('rejects changed attachment files after grant creation', () => {
+    const workspaceRoot = makeWorkspace();
+    const filePath = makeManagedFile(workspaceRoot);
+    const fileGrant = grant(filePath);
+    fs.writeFileSync(filePath, 'changed');
+
+    const result = resolveLocalFileAccess(context({
+      workspaceRoot,
+      executionScope: scope(),
+      localDeviceGrant: deviceGrant(),
+      localFileGrants: [fileGrant],
+    }), {
+      operation: 'read_file',
+      absolutePath: filePath,
+    });
+
+    assert.equal(result.ok, false);
+    if (!result.ok) assert.match(result.message, /发生变化/);
+  });
+
+  test('rejects expired attachment grants', () => {
+    const workspaceRoot = makeWorkspace();
+    const filePath = makeManagedFile(workspaceRoot);
+    const result = resolveLocalFileAccess(context({
+      workspaceRoot,
+      executionScope: scope(),
+      localDeviceGrant: deviceGrant(),
+      localFileGrants: [grant(filePath, { expiresAt: Date.now() - 1 })],
+    }), {
+      operation: 'read_file',
+      absolutePath: filePath,
+    });
+
+    assert.equal(result.ok, false);
+    if (!result.ok) assert.match(result.message, /已过期/);
+  });
+
+  test('allows normalized paths that still resolve to a matching grant', () => {
+    const workspaceRoot = makeWorkspace();
+    const filePath = makeManagedFile(workspaceRoot);
+    const normalizedVariant = path.join(workspaceRoot, 'tmp', 'downloads', '..', 'downloads', 'report.md');
+    const result = resolveLocalFileAccess(context({
+      workspaceRoot,
+      executionScope: scope(),
+      localDeviceGrant: deviceGrant(),
+      localFileGrants: [grant(filePath)],
+    }), {
+      operation: 'read_file',
+      absolutePath: normalizedVariant,
+    });
+
+    assert.equal(result.ok, true);
+  });
+
+  test('does not treat downloads-old as a managed attachment cache prefix', () => {
+    const workspaceRoot = makeWorkspace();
+    const filePath = path.join(workspaceRoot, 'tmp', 'downloads-old', 'report.md');
+    const result = resolveLocalFileAccess(context({
+      workspaceRoot,
+      executionScope: scope(),
+      localDeviceGrant: deviceGrant(),
+    }), {
+      operation: 'read_file',
+      absolutePath: filePath,
+    });
+
+    assert.deepEqual(result, { ok: true });
+  });
+
+  test('keeps non-CatsCo legacy file access unchanged', () => {
+    const workspaceRoot = makeWorkspace();
+    const filePath = makeManagedFile(workspaceRoot);
+    const result = resolveLocalFileAccess(context({
+      workspaceRoot,
+      surface: 'cli',
+    }), {
+      operation: 'read_file',
+      absolutePath: filePath,
+    });
+
+    assert.deepEqual(result, { ok: true });
+  });
+});

--- a/tests/local-file-gateway.test.ts
+++ b/tests/local-file-gateway.test.ts
@@ -3,7 +3,7 @@ import * as assert from 'node:assert';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { resolveLocalFileAccess } from '../src/tools/local-file-gateway';
+import { resolveLocalFileAccess, resolveLocalFileReference } from '../src/tools/local-file-gateway';
 import type {
   ExecutionScope,
   ScopedLocalDeviceGrant,
@@ -45,6 +45,7 @@ function grant(filePath: string, overrides: Partial<ScopedLocalFileGrant> = {}):
   return {
     kind: 'catscompany_attachment',
     source: 'catscompany',
+    attachmentRef: 'catsco_attachment:current-grant',
     filePath,
     fileName: path.basename(filePath),
     fileType: 'file',
@@ -111,6 +112,83 @@ describe('resolveLocalFileAccess', () => {
     });
 
     assert.equal(result.ok, true);
+  });
+
+  test('resolves a CatsCo attachment reference without exposing the local path', () => {
+    const workspaceRoot = makeWorkspace();
+    const filePath = makeManagedFile(workspaceRoot, 'current-ref.md');
+    const result = resolveLocalFileReference(context({
+      workspaceRoot,
+      executionScope: scope(),
+      localDeviceGrant: deviceGrant(),
+      localFileGrants: [grant(filePath, { attachmentRef: 'catsco_attachment:current-ref' })],
+    }), {
+      operation: 'read_file',
+      inputPath: ' catsco_attachment:current-ref ',
+    });
+
+    assert.equal(result.matched, true);
+    if (result.matched) {
+      assert.equal(result.ok, true);
+      if (result.ok) {
+        assert.equal(result.absolutePath, path.resolve(filePath));
+        assert.equal(result.displayPath, 'catsco_attachment:current-ref');
+      }
+    }
+  });
+
+  test('rejects invalid attachment references without leaking the local path', () => {
+    const workspaceRoot = makeWorkspace();
+    const filePath = makeManagedFile(workspaceRoot, 'expired-ref.md');
+    const result = resolveLocalFileReference(context({
+      workspaceRoot,
+      executionScope: scope(),
+      localDeviceGrant: deviceGrant(),
+      localFileGrants: [grant(filePath, {
+        attachmentRef: 'catsco_attachment:expired-ref',
+        expiresAt: Date.now() - 1,
+      })],
+    }), {
+      operation: 'read_file',
+      inputPath: 'catsco_attachment:expired-ref',
+    });
+
+    assert.equal(result.matched, true);
+    if (result.matched) {
+      assert.equal(result.ok, false);
+      if (!result.ok) {
+        assert.match(result.message, /已过期/);
+        assert.match(result.message, /catsco_attachment:expired-ref/);
+        assert.doesNotMatch(result.message, /expired-ref\.md/);
+        assert.doesNotMatch(result.message, new RegExp(escapeRegExp(workspaceRoot)));
+      }
+    }
+  });
+
+  test('rejects unknown attachment references without leaking any granted local path', () => {
+    const workspaceRoot = makeWorkspace();
+    const filePath = makeManagedFile(workspaceRoot, 'private-ref.md');
+    const result = resolveLocalFileReference(context({
+      workspaceRoot,
+      executionScope: scope(),
+      localDeviceGrant: deviceGrant(),
+      localFileGrants: [grant(filePath, { attachmentRef: 'catsco_attachment:owned-ref' })],
+    }), {
+      operation: 'read_file',
+      inputPath: 'catsco_attachment:unknown-ref',
+    });
+
+    assert.equal(result.matched, true);
+    if (result.matched) {
+      assert.equal(result.ok, false);
+      if (!result.ok) {
+        assert.equal(result.errorCode, 'PERMISSION_DENIED');
+        assert.match(result.message, /附件引用不属于当前已授权/);
+        assert.match(result.message, /catsco_attachment:unknown-ref/);
+        assert.doesNotMatch(result.message, /private-ref\.md/);
+        assert.doesNotMatch(result.message, new RegExp(escapeRegExp(workspaceRoot)));
+      }
+    }
   });
 
   test('rejects a CatsCo managed attachment path without a current grant', () => {
@@ -315,3 +393,7 @@ describe('resolveLocalFileAccess', () => {
     assert.deepEqual(result, { ok: true });
   });
 });
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/tests/message-session-manager.test.ts
+++ b/tests/message-session-manager.test.ts
@@ -90,6 +90,46 @@ describe('MessageSessionManager', () => {
     }
   });
 
+  test('restores legacy session history when creating a V2 routed session', async () => {
+    const { MessageSessionManager, SessionStore, createSessionRoute } = loadSessionManagerModules();
+    SessionStore.getInstance().saveContext('user:legacy-route-demo', [
+      { role: 'user', content: 'legacy user message' },
+      { role: 'assistant', content: 'legacy assistant message' },
+    ]);
+    const route = createSessionRoute({
+      source: 'feishu',
+      topicType: 'p2p',
+      topicId: 'chat-route-demo',
+      actorUserId: 'legacy-route-demo',
+      identityTrust: 'legacy_context',
+      legacySessionKey: 'user:legacy-route-demo',
+    });
+    const manager = new MessageSessionManager(buildMockServices(), 'feishu', {
+      systemPromptProviderFactory: (sessionKey: string) => () => `system prompt for ${sessionKey}`,
+    });
+
+    try {
+      const session = manager.getOrCreate(route);
+      await session.init();
+
+      const messages = (session as any).messages;
+      assert.match(messages[0].content, /^system prompt for session:v2:feishu:p2p:chat-route-demo/);
+      assert.match(messages[0].content, /\[surface:feishu:private\]/);
+      assert.equal(messages[1].content, 'legacy user message');
+      assert.equal(messages[2].content, 'legacy assistant message');
+
+      (session as any).messages.push({ role: 'assistant', content: 'new canonical reply' });
+      await manager.destroy();
+
+      assert.deepEqual(
+        SessionStore.getInstance().loadContext(route.sessionKey).map((message: any) => message.content),
+        ['legacy user message', 'legacy assistant message', 'new canonical reply'],
+      );
+    } finally {
+      await manager.destroy();
+    }
+  });
+
   test('injects skill reload handler into newly created sessions', async () => {
     const { MessageSessionManager } = loadSessionManagerModules();
     let reloadCount = 0;
@@ -220,6 +260,7 @@ function loadSessionManagerModules(): any {
     MessageSessionManager: require('../src/core/message-session-manager').MessageSessionManager,
     SubAgentManager: require('../src/core/sub-agent-manager').SubAgentManager,
     SessionStore: require('../src/utils/session-store').SessionStore,
+    createSessionRoute: require('../src/core/session-router').createSessionRoute,
   };
 }
 

--- a/tests/outbound-gateway.test.ts
+++ b/tests/outbound-gateway.test.ts
@@ -1,0 +1,137 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import { resolveOutboundTarget } from '../src/tools/outbound-gateway';
+import type { ExecutionScope } from '../src/types/session-identity';
+import type { ToolExecutionContext, ToolSurface } from '../src/types/tool';
+
+function scope(overrides: Partial<ExecutionScope> = {}): ExecutionScope {
+  return {
+    source: 'catscompany',
+    sessionKey: 'cc_user:usr7',
+    topicId: 'p2p_7_43',
+    topicType: 'p2p',
+    actorUserId: 'usr7',
+    agentId: 'usr43',
+    agentBodyId: 'body-main',
+    channelSeq: 12,
+    permissionsSource: 'server_canonical_message',
+    identityTrust: 'server_canonical',
+    isTrusted: true,
+    ...overrides,
+  };
+}
+
+function context(options: {
+  chatId?: string;
+  sessionId?: string;
+  surface?: ToolSurface;
+  executionScope?: ExecutionScope;
+} = {}): ToolExecutionContext {
+  return {
+    workingDirectory: process.cwd(),
+    workspaceRoot: process.cwd(),
+    conversationHistory: [],
+    sessionId: options.sessionId ?? 'cc_user:usr7',
+    surface: options.surface ?? 'catscompany',
+    executionScope: options.executionScope,
+    channel: {
+      chatId: options.chatId ?? 'p2p_7_43',
+      reply: async () => undefined,
+      sendFile: async () => undefined,
+    },
+  };
+}
+
+describe('resolveOutboundTarget', () => {
+  test('allows trusted CatsCo text when channel, session, and scope match', () => {
+    const result = resolveOutboundTarget(context({ executionScope: scope() }), {
+      operation: 'send_text',
+      missingChannelMessage: 'missing channel',
+    });
+
+    assert.deepEqual(result, { ok: true, chatId: 'p2p_7_43' });
+  });
+
+  test('rejects CatsCo outbound when channel chatId conflicts with scope topic', () => {
+    const result = resolveOutboundTarget(context({ chatId: 'p2p_8_43', executionScope: scope() }), {
+      operation: 'send_text',
+      missingChannelMessage: 'missing channel',
+    });
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.errorCode, 'PERMISSION_DENIED');
+      assert.match(result.message, /外发目标与当前执行身份不一致/);
+    }
+  });
+
+  test('rejects CatsCo outbound when sessionId conflicts with scope sessionKey', () => {
+    const result = resolveOutboundTarget(context({
+      sessionId: 'cc_user:usr8',
+      executionScope: scope(),
+    }), {
+      operation: 'send_text',
+      missingChannelMessage: 'missing channel',
+    });
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.errorCode, 'PERMISSION_DENIED');
+      assert.match(result.message, /执行会话与当前执行身份不一致/);
+    }
+  });
+
+  test('keeps legacy channel-only behavior when executionScope is missing', () => {
+    const result = resolveOutboundTarget(context({
+      chatId: 'legacy-chat',
+      sessionId: undefined,
+      surface: 'feishu',
+    }), {
+      operation: 'send_file',
+      missingChannelMessage: 'missing channel',
+    });
+
+    assert.deepEqual(result, { ok: true, chatId: 'legacy-chat' });
+  });
+
+  test('allows legacy CatsCo file sends when topic still matches', () => {
+    const result = resolveOutboundTarget(context({
+      executionScope: scope({
+        identityTrust: 'legacy_context',
+        isTrusted: false,
+        permissionsSource: undefined,
+        agentBodyId: undefined,
+      }),
+    }), {
+      operation: 'send_file',
+      missingChannelMessage: 'missing channel',
+    });
+
+    assert.deepEqual(result, { ok: true, chatId: 'p2p_7_43' });
+  });
+
+  test('allows untrusted CatsCo text but blocks untrusted file sends', () => {
+    const untrustedScope = scope({
+      identityTrust: 'untrusted',
+      isTrusted: false,
+      permissionsSource: undefined,
+      agentBodyId: undefined,
+    });
+
+    const textResult = resolveOutboundTarget(context({ executionScope: untrustedScope }), {
+      operation: 'send_text',
+      missingChannelMessage: 'missing channel',
+    });
+    assert.deepEqual(textResult, { ok: true, chatId: 'p2p_7_43' });
+
+    const fileResult = resolveOutboundTarget(context({ executionScope: untrustedScope }), {
+      operation: 'send_file',
+      missingChannelMessage: 'missing channel',
+    });
+    assert.equal(fileResult.ok, false);
+    if (!fileResult.ok) {
+      assert.equal(fileResult.errorCode, 'PERMISSION_DENIED');
+      assert.match(fileResult.message, /身份未通过服务端一致性校验/);
+    }
+  });
+});

--- a/tests/runtime-context-builder.test.ts
+++ b/tests/runtime-context-builder.test.ts
@@ -1,0 +1,284 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { AgentSession } from '../src/core/agent-session';
+import { TurnContextBuilder } from '../src/core/turn-context-builder';
+import { TRANSIENT_RUNTIME_CONTEXT_PREFIX } from '../src/core/runtime-context-builder';
+import { createDeviceGrant, createUserDevice } from '../src/core/device-grants';
+import { createExecutionScopeFromRoute, createSessionRoute } from '../src/core/session-router';
+import type { Message } from '../src/types';
+import type {
+  ExecutionScope,
+  ScopedDeviceGrant,
+  ScopedDeviceSelection,
+  ScopedLocalFileGrant,
+} from '../src/types/session-identity';
+
+describe('runtime context builder', () => {
+  test('injects structured runtime context before the latest user message and removes it from durable history', async () => {
+    const builder = new TurnContextBuilder();
+    const route = createSessionRoute({
+      source: 'catscompany',
+      topicType: 'group',
+      topicId: 'grp_80',
+      actorUserId: 'usr7',
+      agentId: 'usr43',
+      agentBodyId: 'body-main',
+      messageId: 'grp_80:12',
+      channelSeq: 12,
+      identityTrust: 'server_canonical',
+      identitySource: 'metadata.catsco_identity',
+      legacySessionKey: 'cc_group:grp_80',
+    });
+    const executionScope = createExecutionScopeFromRoute(route);
+    const grant = localGrant('C:\\secret\\tmp\\downloads\\contract.pdf');
+    const userDeviceGrant = deviceGrant(executionScope);
+
+    const durableMessages: Message[] = [
+      { role: 'system', content: 'base system' },
+      { role: 'user', content: '帮我查合同' },
+    ];
+
+    const result = await builder.build({
+      sessionKey: route.sessionKey,
+      sessionType: 'catscompany',
+      sessionRoute: route,
+      executionScope,
+      localDeviceGrant: {
+        kind: 'catscompany_body',
+        source: 'catscompany',
+        bodyId: 'body-main',
+        deviceId: 'device-1',
+        createdAt: Date.now(),
+      },
+      deviceGrants: [userDeviceGrant],
+      deviceSelection: deviceSelection(executionScope),
+      localFileGrants: [grant],
+      durableMessages,
+      runtimeFeedback: [],
+      skillRuntime: emptySkillRuntime(),
+    });
+
+    assert.deepEqual(durableMessages.map(message => message.content), ['base system', '帮我查合同']);
+    const runtimeIndex = result.messages.findIndex(isRuntimeContextMessage);
+    const userIndex = result.messages.findIndex(message => message.role === 'user' && message.content === '帮我查合同');
+    assert.ok(runtimeIndex >= 0, 'runtime context should be injected');
+    assert.ok(runtimeIndex < userIndex, 'runtime context should appear before the latest user message');
+
+    const snapshot = parseRuntimeContext(result.messages[runtimeIndex]);
+    assert.equal(snapshot.schema, 'xiaoba.runtime_context.v1');
+    assert.equal(snapshot.session.key, route.sessionKey);
+    assert.equal(snapshot.session.topic.id, 'grp_80');
+    assert.equal(snapshot.session.agent.id, 'usr43');
+    assert.equal('bodyId' in snapshot.session.agent, false);
+    assert.equal(snapshot.turn.actorUserId, 'usr7');
+    assert.equal(snapshot.turn.identityTrust, 'server_canonical');
+    assert.equal(snapshot.execution.scopeSource, 'execution_scope');
+    assert.equal(snapshot.execution.localDevice.source, 'catscompany');
+    assert.equal(snapshot.execution.localDevice.deviceId, 'device-1');
+    assert.equal('bodyId' in snapshot.execution.localDevice, false);
+    assert.equal(snapshot.execution.userDevices[0].grantId, 'device_grant_current');
+    assert.equal(snapshot.execution.userDevices[0].deviceId, 'device-user-1');
+    assert.equal(snapshot.execution.userDevices[0].displayName, 'Alice laptop');
+    assert.deepEqual(snapshot.execution.userDevices[0].operations, ['read_file', 'execute_shell']);
+    assert.equal(snapshot.execution.userDevices[0].status, 'active');
+    assert.equal(snapshot.execution.deviceSelection.status, 'selected');
+    assert.equal(snapshot.execution.deviceSelection.selectionSource, 'single_active_device');
+    assert.equal(snapshot.execution.deviceSelection.selectedDevice.deviceId, 'device-user-1');
+    assert.equal(snapshot.execution.deviceSelection.selectedDevice.displayName, 'Alice laptop');
+    assert.deepEqual(snapshot.execution.deviceSelection.selectedDevice.operations, ['read_file']);
+    assert.equal(snapshot.execution.localFiles[0].ref, 'catsco_attachment:contract');
+    assert.equal(snapshot.execution.localFiles[0].fileName, 'contract.pdf');
+    assert.doesNotMatch(result.messages[runtimeIndex].content as string, /C:\\secret/);
+    assert.doesNotMatch(result.messages[runtimeIndex].content as string, /tmp[\\/]downloads/);
+    assert.doesNotMatch(result.messages[runtimeIndex].content as string, /body-main/);
+    assert.doesNotMatch(result.messages[runtimeIndex].content as string, /body-secret/);
+    assert.doesNotMatch(result.messages[runtimeIndex].content as string, /"bodyId"/);
+    assert.doesNotMatch(result.messages[runtimeIndex].content as string, /installation-main/);
+    assert.doesNotMatch(result.messages[runtimeIndex].content as string, /deviceBodyId/);
+    assert.doesNotMatch(result.messages[runtimeIndex].content as string, /deviceInstallationId/);
+    assert.doesNotMatch(result.messages[runtimeIndex].content as string, /createdAt/);
+    assert.doesNotMatch(result.messages[runtimeIndex].content as string, /mtimeMs/);
+
+    const durable = builder.removeTransientMessages(result.messages);
+    assert.equal(durable.some(isRuntimeContextMessage), false);
+  });
+
+  test('AgentSession sends runtime context to the provider every turn without persisting it', async () => {
+    const testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-runtime-context-'));
+    const originalCwd = process.cwd();
+    process.chdir(testRoot);
+    try {
+      const route = createSessionRoute({
+        source: 'feishu',
+        topicType: 'group',
+        topicId: 'oc_group',
+        actorUserId: 'alice',
+        identityTrust: 'legacy_context',
+        identitySource: 'feishu.event',
+        legacySessionKey: 'group:oc_group',
+      });
+      const capturedRequests: Message[][] = [];
+      const session = new AgentSession(route.sessionKey, buildMockServices({
+        aiService: {
+          async chatStream(messages: Message[]) {
+            capturedRequests.push(messages.map(message => ({ ...message })));
+            return {
+              content: `reply ${capturedRequests.length}`,
+              toolCalls: [],
+              usage: { promptTokens: 3, completionTokens: 2, totalTokens: 5 },
+            };
+          },
+        },
+      }), 'feishu', route);
+      session.setSystemPromptProvider(() => 'system prompt');
+
+      await session.handleMessage('第一条', {
+        sessionRoute: route,
+        executionScope: createExecutionScopeFromRoute(route),
+        deviceGrants: [deviceGrant(createExecutionScopeFromRoute(route), 'alice-device')],
+      });
+
+      const bobRoute = createSessionRoute({
+        source: 'feishu',
+        topicType: 'group',
+        topicId: 'oc_group',
+        actorUserId: 'bob',
+        identityTrust: 'legacy_context',
+        identitySource: 'feishu.event',
+        legacySessionKey: 'group:oc_group',
+      });
+      await session.handleMessage('第二条', {
+        sessionRoute: bobRoute,
+        executionScope: createExecutionScopeFromRoute(bobRoute),
+      });
+
+      assert.equal(capturedRequests.length, 2);
+      const firstContexts = capturedRequests[0].filter(isRuntimeContextMessage);
+      const secondContexts = capturedRequests[1].filter(isRuntimeContextMessage);
+      assert.equal(firstContexts.length, 1);
+      assert.equal(secondContexts.length, 1);
+      assert.equal(parseRuntimeContext(firstContexts[0]).turn.actorUserId, 'alice');
+      assert.equal(parseRuntimeContext(firstContexts[0]).execution.userDevices[0].deviceId, 'alice-device');
+      assert.equal(parseRuntimeContext(secondContexts[0]).turn.actorUserId, 'bob');
+      assert.equal(parseRuntimeContext(secondContexts[0]).session.topic.id, 'oc_group');
+
+      const retainedMessages = (session as any).messages as Message[];
+      assert.equal(retainedMessages.some(isRuntimeContextMessage), false);
+    } finally {
+      process.chdir(originalCwd);
+      fs.rmSync(testRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+function emptySkillRuntime(): any {
+  return {
+    reloadSkills: async () => undefined,
+    buildSkillsListMessage: () => null,
+  };
+}
+
+function isRuntimeContextMessage(message: Message): boolean {
+  return message.role === 'system'
+    && typeof message.content === 'string'
+    && message.content.startsWith(TRANSIENT_RUNTIME_CONTEXT_PREFIX);
+}
+
+function parseRuntimeContext(message: Message): any {
+  const content = String(message.content || '');
+  return JSON.parse(content.slice(TRANSIENT_RUNTIME_CONTEXT_PREFIX.length).trim());
+}
+
+function localGrant(filePath: string): ScopedLocalFileGrant {
+  const now = Date.now();
+  return {
+    kind: 'catscompany_attachment',
+    source: 'catscompany',
+    attachmentRef: 'catsco_attachment:contract',
+    filePath,
+    fileName: 'contract.pdf',
+    fileType: 'file',
+    size: 100,
+    mtimeMs: now,
+    sessionKey: 'session:v2:catscompany:group:grp_80:agent:usr43',
+    topicId: 'grp_80',
+    topicType: 'group',
+    actorUserId: 'usr7',
+    agentId: 'usr43',
+    agentBodyId: 'body-main',
+    deviceBodyId: 'body-main',
+    identityTrust: 'server_canonical',
+    operations: ['read_file', 'send_file'],
+    createdAt: now,
+    expiresAt: now + 60_000,
+  };
+}
+
+function deviceGrant(scope: ExecutionScope, deviceId = 'device-user-1'): ScopedDeviceGrant {
+  const device = createUserDevice({
+    source: scope.source,
+    ownerUserId: scope.actorUserId,
+    deviceId,
+    displayName: 'Alice laptop',
+    bodyId: 'body-secret',
+    installationId: 'installation-main',
+    identityTrust: 'server_canonical',
+    status: 'online',
+    registeredAt: 1_000,
+  });
+  const grant = createDeviceGrant(scope, device, {
+    grantId: 'device_grant_current',
+    operations: ['read_file', 'execute_shell'],
+    now: 2_000,
+    ttlMs: 60_000,
+  });
+  assert.ok(grant);
+  return grant;
+}
+
+function deviceSelection(scope: ExecutionScope): ScopedDeviceSelection {
+  return {
+    kind: 'user_device_selection',
+    source: scope.source,
+    status: 'selected',
+    selectionSource: 'single_active_device',
+    sessionKey: scope.sessionKey,
+    topicId: scope.topicId,
+    topicType: scope.topicType,
+    actorUserId: scope.actorUserId,
+    agentId: scope.agentId,
+    identityTrust: scope.identityTrust,
+    identitySource: 'metadata.catsco_identity',
+    selectedDeviceId: 'device-user-1',
+    selectedDeviceDisplayName: 'Alice laptop',
+    selectedDeviceBodyId: 'body-secret',
+    selectedDeviceInstallationId: 'installation-main',
+    selectedDeviceOperations: ['read_file'],
+    createdAt: 2_000,
+  };
+}
+
+function buildMockServices(overrides: any = {}): any {
+  return {
+    aiService: {
+      ...(overrides.aiService || {}),
+    },
+    toolManager: {
+      getWorkspaceRoot: () => process.cwd(),
+      getToolDefinitions: () => [],
+      executeTool: async () => {
+        throw new Error('not expected');
+      },
+    },
+    skillManager: {
+      getSkill: () => undefined,
+      getUserInvocableSkills: () => [],
+      getAutoInvocableSkills: () => [],
+      findAutoInvocableSkillByText: () => undefined,
+      loadSkills: async () => undefined,
+    },
+  };
+}

--- a/tests/session-route-v2.test.ts
+++ b/tests/session-route-v2.test.ts
@@ -1,0 +1,98 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import {
+  buildSessionKeyV2,
+  createCatsCoSessionRoute,
+  createFeishuBridgeSessionRoute,
+  createFeishuSessionRoute,
+  createWeixinSessionRoute,
+  parseSessionKeyV2,
+} from '../src/core/session-router';
+import { createCatsCoMessageEnvelope } from '../src/catscompany/message-envelope';
+
+describe('SessionRoute V2', () => {
+  test('builds distinct canonical keys for the same raw actor across channels', () => {
+    const catsEnvelope = createCatsCoMessageEnvelope({
+      topic: 'p2p_shared_bot',
+      senderId: 'shared',
+      text: 'cats',
+      botUid: 'bot',
+      metadata: {
+        catsco_identity: {
+          actor: { user_id: 'shared' },
+          agent: { agent_id: 'bot', body_id: 'body-main' },
+          topic: { topic_id: 'p2p_shared_bot', type: 'p2p', channel_seq: 1 },
+          permissions: { source: 'server_canonical_message' },
+        },
+      },
+    });
+    const catsRoute = createCatsCoSessionRoute(catsEnvelope);
+    const feishuRoute = createFeishuSessionRoute({
+      messageId: 'msg-feishu',
+      chatId: 'shared',
+      chatType: 'p2p',
+      senderId: 'shared',
+      text: 'feishu',
+      mentionBot: false,
+      msgType: 'text',
+    });
+    const weixinRoute = createWeixinSessionRoute({
+      message_id: 'msg-weixin',
+      from: { id: 'shared' },
+      chat: { id: 'bot' },
+      text: 'weixin',
+      context_token: 'ctx',
+    });
+
+    assert.notEqual(catsRoute.sessionKey, feishuRoute.sessionKey);
+    assert.notEqual(feishuRoute.sessionKey, weixinRoute.sessionKey);
+    assert.notEqual(catsRoute.sessionKey, weixinRoute.sessionKey);
+    assert.equal(catsRoute.legacySessionKey, 'cc_user:shared');
+    assert.equal(feishuRoute.legacySessionKey, 'user:shared');
+    assert.equal(weixinRoute.legacySessionKey, 'user:shared');
+  });
+
+  test('parses V2 keys without losing source or topic type', () => {
+    const key = buildSessionKeyV2({
+      source: 'feishu',
+      topicType: 'group',
+      topicId: 'oc_group:with:colon',
+    });
+
+    assert.deepEqual(parseSessionKeyV2(key), {
+      version: 2,
+      source: 'feishu',
+      topicType: 'group',
+      topicId: 'oc_group:with:colon',
+      agentId: undefined,
+    });
+  });
+
+  test('keeps CatsCo route trust aligned with the envelope instead of upgrading legacy messages', () => {
+    const envelope = createCatsCoMessageEnvelope({
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      text: 'legacy',
+      botUid: 'usr43',
+    });
+    const route = createCatsCoSessionRoute(envelope);
+
+    assert.equal(route.sessionKey, 'session:v2:catscompany:p2p:p2p_7_43:agent:usr43');
+    assert.equal(route.legacySessionKey, 'cc_user:usr7');
+    assert.equal(route.identityTrust, 'legacy_context');
+    assert.equal(route.identity.identityTrust, 'legacy_context');
+  });
+
+  test('routes Feishu bridge broadcasts as group conversations', () => {
+    const route = createFeishuBridgeSessionRoute({
+      chatId: 'oc_group',
+      from: 'ResearchBot',
+      messageId: 'bridge-1',
+    });
+
+    assert.equal(route.sessionKey, 'session:v2:feishu:group:oc_group');
+    assert.equal(route.legacySessionKey, 'group:oc_group');
+    assert.equal(route.actorUserId, 'ResearchBot');
+    assert.equal(route.topicType, 'group');
+  });
+});

--- a/tests/subagent-runtime-events.test.ts
+++ b/tests/subagent-runtime-events.test.ts
@@ -446,6 +446,113 @@ describe('subagent runtime events', () => {
     }
   });
 
+  test('CatsCo device-scoped spawn_subagent defaults to ask_parent only', async () => {
+    const originalGetInstance = SubAgentManager.getInstance;
+    let capturedAllowedTools: unknown;
+
+    (SubAgentManager as any).getInstance = () => ({
+      spawn(
+        _parentSessionKey: string,
+        request: any,
+      ) {
+        capturedAllowedTools = request.allowedTools;
+        return {
+          id: 'sub-catsco-isolated',
+          agentType: request.agentType,
+          skillName: request.agentType,
+          toolScope: 'read_only',
+          allowedTools: request.allowedTools,
+          taskDescription: request.taskDescription,
+          status: 'running',
+          createdAt: Date.now(),
+          progressLog: [],
+          outputFiles: [],
+        };
+      },
+    });
+
+    try {
+      const result = await new SpawnSubagentTool().execute({
+        agent_type: 'explorer',
+        task: '审查当前问题',
+        context: '只看主会话提供的信息，不操作本机文件',
+      }, {
+        workingDirectory: process.cwd(),
+        conversationHistory: [],
+        sessionId: 'session:v2:catscompany:p2p:p2p_7_43:agent:usr43',
+        surface: 'catscompany',
+        executionScope: {
+          source: 'catscompany',
+          sessionKey: 'session:v2:catscompany:p2p:p2p_7_43:agent:usr43',
+          topicId: 'p2p_7_43',
+          topicType: 'p2p',
+          actorUserId: 'usr7',
+          agentId: 'usr43',
+          agentBodyId: 'body-main',
+          identityTrust: 'server_canonical',
+          isTrusted: true,
+        },
+        localDeviceGrant: {
+          kind: 'catscompany_body',
+          source: 'catscompany',
+          bodyId: 'body-main',
+          createdAt: Date.now(),
+        },
+        runtimeServices: {
+          aiService: {} as any,
+          skillManager: {} as any,
+        },
+      });
+
+      assert.equal(result.ok, true);
+      assert.deepEqual(capturedAllowedTools, ['ask_parent']);
+    } finally {
+      (SubAgentManager as any).getInstance = originalGetInstance;
+    }
+  });
+
+  test('CatsCo device-scoped spawn_subagent rejects local file tool delegation', async () => {
+    const result = await new SpawnSubagentTool().execute({
+      agent_type: 'explorer',
+      allowed_tools: ['read_file', 'ask_parent'],
+      task: '读取本机文件',
+      context: '请读取用户设备文件',
+    }, {
+      workingDirectory: process.cwd(),
+      conversationHistory: [],
+      sessionId: 'session:v2:catscompany:p2p:p2p_7_43:agent:usr43',
+      surface: 'catscompany',
+      executionScope: {
+        source: 'catscompany',
+        sessionKey: 'session:v2:catscompany:p2p:p2p_7_43:agent:usr43',
+        topicId: 'p2p_7_43',
+        topicType: 'p2p',
+        actorUserId: 'usr7',
+        agentId: 'usr43',
+        agentBodyId: 'body-main',
+        identityTrust: 'server_canonical',
+        isTrusted: true,
+      },
+      localDeviceGrant: {
+        kind: 'catscompany_body',
+        source: 'catscompany',
+        bodyId: 'body-main',
+        createdAt: Date.now(),
+      },
+      runtimeServices: {
+        aiService: {} as any,
+        skillManager: {} as any,
+      },
+    });
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.errorCode, 'PERMISSION_DENIED');
+      assert.match(result.message, /不会传递给子智能体/);
+      assert.match(result.message, /read_file/);
+    }
+  });
+
   test('spawn_subagent rejects unsafe tools before creating a subagent', async () => {
     const result = await new SpawnSubagentTool().execute({
       agent_type: 'worker',

--- a/tests/surface-prompt.test.ts
+++ b/tests/surface-prompt.test.ts
@@ -41,6 +41,14 @@ describe('surface prompt', () => {
     assert.equal(resolveSessionSurface('cc_user:shared-prefix', 'catscompany'), 'catscompany');
   });
 
+  test('resolves V2 session keys without relying on sessionType overrides', () => {
+    assert.equal(resolveSessionSurface('session:v2:feishu:p2p:ou_1'), 'feishu');
+    assert.equal(resolveSessionSurface('session:v2:weixin:p2p:ou_1'), 'weixin');
+    assert.equal(resolveSessionSurface('session:v2:catscompany:group:grp_1:agent:usr43'), 'catscompany');
+    assert.match(composeSurfacePrompt('session:v2:feishu:group:oc_1') || '', /\[surface:feishu:group\]/);
+    assert.match(composeSurfacePrompt('session:v2:feishu:p2p:ou_1') || '', /\[surface:feishu:private\]/);
+  });
+
   test('composes current Feishu private and group surface prompts', () => {
     const privatePrompt = composeSurfacePrompt('user:feishu-user');
     const groupPrompt = composeSurfacePrompt('group:feishu-group');

--- a/tests/surface-prompt.test.ts
+++ b/tests/surface-prompt.test.ts
@@ -23,7 +23,7 @@ describe('surface prompt', () => {
     '- tmp/downloads/... is the local cache for files/images received from chat. It is not the user\'s general local file library.',
     '- If the user asks for a new/local file or says they have not sent it before, do not reuse files from tmp/downloads/... or old conversation paths.',
     '- If the user did not provide an exact path, first ask for the location or search likely local folders such as Desktop, Downloads, Documents, Pictures, or an explicit path the user mentioned.',
-    '- Only reuse tmp/downloads/... when the user clearly asks to resend/open an earlier chat attachment.',
+    '- Only use tmp/downloads/... paths that are shown in the current user turn as authorized attachment paths; old attachment paths may be denied by local file grants.',
   ].join('\n');
 
   test('resolves session surface from current session key conventions', () => {

--- a/tests/surface-prompt.test.ts
+++ b/tests/surface-prompt.test.ts
@@ -23,7 +23,7 @@ describe('surface prompt', () => {
     '- tmp/downloads/... is the local cache for files/images received from chat. It is not the user\'s general local file library.',
     '- If the user asks for a new/local file or says they have not sent it before, do not reuse files from tmp/downloads/... or old conversation paths.',
     '- If the user did not provide an exact path, first ask for the location or search likely local folders such as Desktop, Downloads, Documents, Pictures, or an explicit path the user mentioned.',
-    '- Only use tmp/downloads/... paths that are shown in the current user turn as authorized attachment paths; old attachment paths may be denied by local file grants.',
+    '- Use current catsco_attachment:<id> references for received attachments; local tmp/downloads paths are backend-only and should not be guessed or reused.',
   ].join('\n');
 
   test('resolves session surface from current session key conventions', () => {

--- a/tests/tool-gateway-catsco.test.ts
+++ b/tests/tool-gateway-catsco.test.ts
@@ -1,0 +1,427 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ReadTool } from '../src/tools/read-tool';
+import { WriteTool } from '../src/tools/write-tool';
+import { EditTool } from '../src/tools/edit-tool';
+import { GlobTool } from '../src/tools/glob-tool';
+import { GrepTool } from '../src/tools/grep-tool';
+import { SendFileTool } from '../src/tools/send-file-tool';
+import { ShellTool } from '../src/tools/bash-tool';
+import type {
+  ExecutionScope,
+  ScopedDeviceGrant,
+  ScopedDeviceSelection,
+  ScopedLocalDeviceGrant,
+} from '../src/types/session-identity';
+import type { DeviceRpcTransport, ToolExecutionContext } from '../src/types/tool';
+
+function scope(overrides: Partial<ExecutionScope> = {}): ExecutionScope {
+  return {
+    source: 'catscompany',
+    sessionKey: 'session:v2:catscompany:p2p:p2p_7_43:agent:usr43',
+    topicId: 'p2p_7_43',
+    topicType: 'p2p',
+    actorUserId: 'usr7',
+    agentId: 'usr43',
+    agentBodyId: 'body-main',
+    permissionsSource: 'server_canonical_message',
+    identityTrust: 'server_canonical',
+    isTrusted: true,
+    ...overrides,
+  };
+}
+
+function localDevice(overrides: Partial<ScopedLocalDeviceGrant> = {}): ScopedLocalDeviceGrant {
+  return {
+    kind: 'catscompany_body',
+    source: 'catscompany',
+    bodyId: 'body-device',
+    installationId: 'install-device',
+    deviceId: 'install-device',
+    createdAt: Date.now(),
+    ...overrides,
+  };
+}
+
+function deviceGrant(operations: ScopedDeviceGrant['operations'], overrides: Partial<ScopedDeviceGrant> = {}): ScopedDeviceGrant {
+  const currentScope = scope();
+  return {
+    kind: 'user_device_grant',
+    source: 'catscompany',
+    grantId: 'device-grant-main',
+    status: 'active',
+    identityTrust: 'server_canonical',
+    identitySource: 'metadata.catsco_identity',
+    deviceId: 'install-device',
+    deviceDisplayName: 'Test Device',
+    deviceBodyId: 'body-device',
+    deviceInstallationId: 'install-device',
+    ownerUserId: currentScope.actorUserId,
+    sessionKey: currentScope.sessionKey,
+    topicId: currentScope.topicId,
+    topicType: currentScope.topicType,
+    actorUserId: currentScope.actorUserId,
+    agentId: currentScope.agentId,
+    agentBodyId: currentScope.agentBodyId,
+    operations,
+    createdAt: Date.now(),
+    expiresAt: Date.now() + 60_000,
+    ...overrides,
+  };
+}
+
+function deviceSelection(overrides: Partial<ScopedDeviceSelection> = {}): ScopedDeviceSelection {
+  const currentScope = scope();
+  return {
+    kind: 'user_device_selection',
+    source: 'catscompany',
+    status: 'selected',
+    selectionSource: 'single_active_device',
+    sessionKey: currentScope.sessionKey,
+    topicId: currentScope.topicId,
+    topicType: currentScope.topicType,
+    actorUserId: currentScope.actorUserId,
+    agentId: currentScope.agentId,
+    identityTrust: 'server_canonical',
+    identitySource: 'metadata.catsco_identity',
+    selectedDeviceId: 'install-device',
+    selectedDeviceDisplayName: 'Test Device',
+    selectedDeviceBodyId: 'body-device',
+    selectedDeviceInstallationId: 'install-device',
+    selectedDeviceOperations: ['read_file'],
+    ...overrides,
+  };
+}
+
+function context(root: string, options: {
+  executionScope?: ExecutionScope;
+  localDeviceGrant?: ScopedLocalDeviceGrant;
+  deviceGrants?: ScopedDeviceGrant[];
+  deviceSelection?: ScopedDeviceSelection;
+  deviceRpc?: DeviceRpcTransport;
+} = {}): ToolExecutionContext {
+  return {
+    workingDirectory: root,
+    workspaceRoot: root,
+    conversationHistory: [],
+    sessionId: options.executionScope?.sessionKey,
+    surface: 'catscompany',
+    executionScope: options.executionScope ?? scope(),
+    localDeviceGrant: options.localDeviceGrant ?? localDevice(),
+    deviceGrants: options.deviceGrants,
+    deviceSelection: options.deviceSelection,
+    deviceRpc: options.deviceRpc,
+  };
+}
+
+function makeWorkspace(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-tool-gateway-'));
+}
+
+describe('CatsCo ToolGateway', () => {
+  test('blocks regular read_file without a current user device grant', async () => {
+    const root = makeWorkspace();
+    const filePath = path.join(root, 'notes.txt');
+    fs.writeFileSync(filePath, 'secret');
+
+    const result = await new ReadTool().execute({ file_path: filePath }, context(root));
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.errorCode, 'PERMISSION_DENIED');
+      assert.match(result.message, /没有允许当前设备执行 read_file/);
+      assert.doesNotMatch(result.message, new RegExp(escapeRegExp(filePath)));
+    }
+  });
+
+  test('allows regular read_file with a matching CatsCo user device grant', async () => {
+    const root = makeWorkspace();
+    const filePath = path.join(root, 'notes.txt');
+    fs.writeFileSync(filePath, 'allowed content');
+
+    const result = await new ReadTool().execute({ file_path: filePath }, context(root, {
+      deviceGrants: [deviceGrant(['read_file'])],
+    }));
+
+    assert.equal(result.ok, true);
+    assert.match(String(result.content), /allowed content/);
+  });
+
+  test('allows read_file when backend-selected device matches the current CatsCo device', async () => {
+    const root = makeWorkspace();
+    const filePath = path.join(root, 'notes.txt');
+    fs.writeFileSync(filePath, 'selected content');
+
+    const result = await new ReadTool().execute({ file_path: filePath }, context(root, {
+      deviceGrants: [deviceGrant(['read_file'])],
+      deviceSelection: deviceSelection(),
+    }));
+
+    assert.equal(result.ok, true);
+    assert.match(String(result.content), /selected content/);
+  });
+
+  test('blocks device tools when backend requires device selection first', async () => {
+    const root = makeWorkspace();
+    const filePath = path.join(root, 'notes.txt');
+    fs.writeFileSync(filePath, 'secret');
+
+    const result = await new ReadTool().execute({ file_path: filePath }, context(root, {
+      deviceGrants: [deviceGrant(['read_file'])],
+      deviceSelection: deviceSelection({
+        status: 'needs_selection',
+        selectedDeviceId: undefined,
+        selectedDeviceBodyId: undefined,
+        selectedDeviceInstallationId: undefined,
+      }),
+    }));
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.errorCode, 'PERMISSION_DENIED');
+      assert.match(result.message, /尚未选定/);
+      assert.doesNotMatch(result.message, new RegExp(escapeRegExp(filePath)));
+    }
+  });
+
+  test('blocks remote-selected device tools when Device RPC transport is unavailable', async () => {
+    const root = makeWorkspace();
+    const filePath = path.join(root, 'notes.txt');
+    fs.writeFileSync(filePath, 'secret');
+
+    const result = await new ReadTool().execute({ file_path: filePath }, context(root, {
+      deviceGrants: [deviceGrant(['read_file'], {
+        deviceId: 'other-device',
+        deviceDisplayName: 'Other Device',
+        deviceBodyId: 'body-other',
+        deviceInstallationId: 'install-other',
+      })],
+      deviceSelection: deviceSelection({
+        selectedDeviceId: 'other-device',
+        selectedDeviceDisplayName: 'Other Device',
+        selectedDeviceBodyId: 'body-other',
+        selectedDeviceInstallationId: 'install-other',
+      }),
+    }));
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.errorCode, 'PERMISSION_DENIED');
+      assert.match(result.message, /没有配置远程设备 RPC 通道/);
+      assert.doesNotMatch(result.message, new RegExp(escapeRegExp(filePath)));
+    }
+  });
+
+  test('routes read_file to the backend-selected remote device without local file access', async () => {
+    const root = makeWorkspace();
+    const requestedPath = path.join(root, 'missing-on-agent.txt');
+    let rpcRequest: any;
+    const result = await new ReadTool().execute({ file_path: requestedPath, limit: 20 }, context(root, {
+      deviceGrants: [deviceGrant(['read_file'], {
+        deviceId: 'other-device',
+        deviceDisplayName: 'Other Device',
+        deviceBodyId: 'body-other',
+        deviceInstallationId: 'install-other',
+      })],
+      deviceSelection: deviceSelection({
+        selectedDeviceId: 'other-device',
+        selectedDeviceDisplayName: 'Other Device',
+        selectedDeviceBodyId: 'body-other',
+        selectedDeviceInstallationId: 'install-other',
+        selectedDeviceOperations: ['read_file'],
+      }),
+      deviceRpc: {
+        executeTool: async request => {
+          rpcRequest = request;
+          return { ok: true, content: 'remote file content' };
+        },
+      },
+    }));
+
+    assert.equal(result.ok, true);
+    assert.equal(String(result.content), 'remote file content');
+    assert.equal(rpcRequest.toolName, 'read_file');
+    assert.equal(rpcRequest.operation, 'read_file');
+    assert.equal(rpcRequest.grant.deviceId, 'other-device');
+    assert.deepEqual(rpcRequest.args, { file_path: requestedPath, limit: 20 });
+  });
+
+  test('routes glob and grep to the backend-selected remote device', async () => {
+    const root = makeWorkspace();
+    const calls: Array<{ toolName: string; operation: string; args: Record<string, unknown> }> = [];
+    const deviceRpc: DeviceRpcTransport = {
+      executeTool: async request => {
+        calls.push({
+          toolName: request.toolName,
+          operation: request.operation,
+          args: request.args,
+        });
+        return { ok: true, content: `remote ${request.toolName}` };
+      },
+    };
+    const remoteContext = context(root, {
+      deviceGrants: [
+        deviceGrant(['glob'], {
+          grantId: 'grant-glob',
+          deviceId: 'other-device',
+          deviceDisplayName: 'Other Device',
+          deviceBodyId: 'body-other',
+          deviceInstallationId: 'install-other',
+        }),
+        deviceGrant(['grep'], {
+          grantId: 'grant-grep',
+          deviceId: 'other-device',
+          deviceDisplayName: 'Other Device',
+          deviceBodyId: 'body-other',
+          deviceInstallationId: 'install-other',
+        }),
+      ],
+      deviceSelection: deviceSelection({
+        selectedDeviceId: 'other-device',
+        selectedDeviceDisplayName: 'Other Device',
+        selectedDeviceBodyId: 'body-other',
+        selectedDeviceInstallationId: 'install-other',
+        selectedDeviceOperations: ['glob', 'grep'],
+      }),
+      deviceRpc,
+    });
+
+    const glob = await new GlobTool().execute({ pattern: '**/*.ts', path: '/remote/project' }, remoteContext);
+    const grep = await new GrepTool().execute({ pattern: 'needle', path: '/remote/project', output_mode: 'files' }, remoteContext);
+
+    assert.equal(glob.ok, true);
+    assert.equal(grep.ok, true);
+    assert.deepEqual(calls.map(call => [call.toolName, call.operation]), [
+      ['glob', 'glob'],
+      ['grep', 'grep'],
+    ]);
+    assert.deepEqual(calls[0].args, { pattern: '**/*.ts', path: '/remote/project' });
+    assert.deepEqual(calls[1].args, { pattern: 'needle', path: '/remote/project', output_mode: 'files' });
+  });
+
+  test('redacts local absolute paths from successful CatsCo device file results', async () => {
+    const root = makeWorkspace();
+    const filePath = path.join(root, 'notes.txt');
+    const outPath = path.join(root, 'out.txt');
+    fs.writeFileSync(filePath, 'allowed content\nneedle');
+    fs.writeFileSync(outPath, 'before');
+    const ctx = context(root, {
+      deviceGrants: [deviceGrant(['read_file', 'glob', 'grep', 'write_file', 'edit_file', 'send_file'])],
+    });
+    ctx.channel = {
+      chatId: scope().topicId,
+      reply: async () => {},
+      sendFile: async () => {},
+    };
+
+    const read = await new ReadTool().execute({ file_path: filePath }, ctx);
+    assert.equal(read.ok, true);
+    assert.doesNotMatch(String(read.content), new RegExp(escapeRegExp(filePath)));
+
+    const glob = await new GlobTool().execute({ pattern: '*.txt', path: root }, ctx);
+    assert.equal(glob.ok, true);
+    assert.match(String(glob.content), /notes\.txt/);
+    assert.doesNotMatch(String(glob.content), new RegExp(escapeRegExp(root)));
+
+    const grep = await new GrepTool().execute({ pattern: 'needle', path: filePath, output_mode: 'content' }, ctx);
+    assert.equal(grep.ok, true);
+    assert.match(String(grep.content), /needle/);
+    assert.doesNotMatch(String(grep.content), new RegExp(escapeRegExp(root)));
+
+    const write = await new WriteTool().execute({ file_path: outPath, content: 'after' }, ctx);
+    assert.equal(write.ok, true);
+    assert.doesNotMatch(String(write.content), new RegExp(escapeRegExp(outPath)));
+
+    const edit = await new EditTool().execute({ file_path: outPath, old_string: 'after', new_string: 'done' }, ctx);
+    assert.equal(edit.ok, true);
+    assert.doesNotMatch(String(edit.content), new RegExp(escapeRegExp(outPath)));
+
+    const send = await new SendFileTool().execute({ file_path: filePath, file_name: 'notes.txt' }, ctx);
+    assert.equal(send.ok, true);
+    assert.doesNotMatch(String(send.content), new RegExp(escapeRegExp(filePath)));
+  });
+
+  test('redacts local absolute paths from CatsCo device file failure results', async () => {
+    const root = makeWorkspace();
+    const missingPath = path.join(root, 'missing.txt');
+    const ctx = context(root, {
+      deviceGrants: [deviceGrant(['read_file', 'send_file'])],
+    });
+
+    const readDirectory = await new ReadTool().execute({ file_path: root }, ctx);
+    assert.equal(readDirectory.ok, false);
+    if (!readDirectory.ok) {
+      assert.equal(readDirectory.errorCode, 'TOOL_EXECUTION_ERROR');
+      assert.match(readDirectory.message, /Path is not a file/);
+      assert.doesNotMatch(readDirectory.message, new RegExp(escapeRegExp(root)));
+    }
+
+    const sendMissing = await new SendFileTool().execute({ file_path: missingPath, file_name: 'missing.txt' }, ctx);
+    assert.equal(sendMissing.ok, false);
+    if (!sendMissing.ok) {
+      assert.equal(sendMissing.errorCode, 'FILE_NOT_FOUND');
+      assert.match(sendMissing.message, /File not found/);
+      assert.doesNotMatch(sendMissing.message, new RegExp(escapeRegExp(missingPath)));
+      assert.doesNotMatch(sendMissing.message, new RegExp(escapeRegExp(root)));
+    }
+
+    const sendDirectory = await new SendFileTool().execute({ file_path: root, file_name: 'root' }, ctx);
+    assert.equal(sendDirectory.ok, false);
+    if (!sendDirectory.ok) {
+      assert.equal(sendDirectory.errorCode, 'TOOL_EXECUTION_ERROR');
+      assert.match(sendDirectory.message, /Path is not a file/);
+      assert.doesNotMatch(sendDirectory.message, new RegExp(escapeRegExp(root)));
+    }
+  });
+
+  test('allows glob only when the CatsCo device grant includes glob operation', async () => {
+    const root = makeWorkspace();
+    fs.writeFileSync(path.join(root, 'a.txt'), 'a');
+
+    const denied = await new GlobTool().execute({ pattern: '*.txt' }, context(root, {
+      deviceGrants: [deviceGrant(['read_file'])],
+    }));
+    assert.equal(denied.ok, false);
+    if (!denied.ok) assert.match(denied.message, /执行 glob/);
+
+    const allowed = await new GlobTool().execute({ pattern: '*.txt' }, context(root, {
+      deviceGrants: [deviceGrant(['glob'])],
+    }));
+    assert.equal(allowed.ok, true);
+    assert.match(String(allowed.content), /a\.txt/);
+  });
+
+  test('blocks write_file until the server grants write_file for the current device', async () => {
+    const root = makeWorkspace();
+    const result = await new WriteTool().execute({ file_path: 'out.txt', content: 'hello' }, context(root, {
+      deviceGrants: [deviceGrant(['read_file'])],
+    }));
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.errorCode, 'PERMISSION_DENIED');
+      assert.match(result.message, /执行 write_file/);
+      assert.equal(fs.existsSync(path.join(root, 'out.txt')), false);
+    }
+  });
+
+  test('blocks execute_shell in CatsCo sessions even when a grant contains execute_shell', async () => {
+    const root = makeWorkspace();
+    const result = await new ShellTool().execute({ command: 'echo hello' }, context(root, {
+      deviceGrants: [deviceGrant(['execute_shell'])],
+    }));
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.errorCode, 'PERMISSION_DENIED');
+      assert.match(result.message, /暂不允许通过 execute_shell/);
+    }
+  });
+});
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/tests/tool-result-read-file-local-grants.test.ts
+++ b/tests/tool-result-read-file-local-grants.test.ts
@@ -42,6 +42,7 @@ describe('ReadTool local file grants', () => {
     return {
       kind: 'catscompany_attachment',
       source: 'catscompany',
+      attachmentRef: 'catsco_attachment:current-read-grant',
       filePath,
       fileName: path.basename(filePath),
       fileType: 'file',
@@ -106,6 +107,35 @@ describe('ReadTool local file grants', () => {
     assert.match(String(result.content), /hello from current attachment/);
   });
 
+  test('allows reading a CatsCo attachment by opaque reference without exposing the local path', async () => {
+    const filePath = managedFile('referenced.md');
+    const result = await tool.execute(
+      { file_path: 'catsco_attachment:read-current' },
+      catsContext([grant(filePath, { attachmentRef: 'catsco_attachment:read-current' })]),
+    );
+
+    assert.equal(result.ok, true);
+    assert.match(String(result.content), /hello from current attachment/);
+    assert.match(String(result.content), /Path: catsco_attachment:read-current/);
+    assert.doesNotMatch(String(result.content), new RegExp(escapeRegExp(filePath)));
+    assert.doesNotMatch(String(result.content), new RegExp(escapeRegExp(testRoot)));
+  });
+
+  test('rejects unknown CatsCo attachment references without exposing granted local paths', async () => {
+    const filePath = managedFile('private.md');
+    const result = await tool.execute(
+      { file_path: 'catsco_attachment:missing-read' },
+      catsContext([grant(filePath, { attachmentRef: 'catsco_attachment:owned-read' })]),
+    );
+
+    assert.equal(result.ok, false);
+    assert.equal(result.errorCode, 'PERMISSION_DENIED');
+    assert.match(result.message, /附件引用不属于当前已授权/);
+    assert.match(result.message, /catsco_attachment:missing-read/);
+    assert.doesNotMatch(result.message, new RegExp(escapeRegExp(filePath)));
+    assert.doesNotMatch(result.message, new RegExp(escapeRegExp(testRoot)));
+  });
+
   test('allows reading a relative CatsCo attachment path with an absolute matching grant', async () => {
     const filePath = managedFile('relative.md');
     const result = await tool.execute({ file_path: path.join('tmp', 'downloads', 'relative.md') }, catsContext([grant(filePath)]));
@@ -144,6 +174,23 @@ describe('ReadTool local file grants', () => {
     assert.doesNotMatch(untrusted.message, /hello from current attachment/);
   });
 
+  test('rejects stale CatsCo attachment references without exposing the local path', async () => {
+    const filePath = managedFile('expired-reference.md');
+    const result = await tool.execute({
+      file_path: 'catsco_attachment:expired-read',
+    }, catsContext([grant(filePath, {
+      attachmentRef: 'catsco_attachment:expired-read',
+      expiresAt: Date.now() - 1,
+    })]));
+
+    assert.equal(result.ok, false);
+    assert.equal(result.errorCode, 'PERMISSION_DENIED');
+    assert.match(result.message, /已过期/);
+    assert.match(result.message, /catsco_attachment:expired-read/);
+    assert.doesNotMatch(result.message, /expired-reference\.md/);
+    assert.doesNotMatch(result.message, new RegExp(escapeRegExp(testRoot)));
+  });
+
   test('keeps missing-file errors ahead of local grant checks', async () => {
     const filePath = path.join(testRoot, 'tmp', 'downloads', 'missing.md');
     const result = await tool.execute({ file_path: filePath }, catsContext());
@@ -177,3 +224,7 @@ describe('ReadTool local file grants', () => {
     assert.match(String(result.content), /hello from current attachment/);
   });
 });
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/tests/tool-result-read-file-local-grants.test.ts
+++ b/tests/tool-result-read-file-local-grants.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ReadTool } from '../src/tools/read-tool';
+import type { ExecutionScope, ScopedLocalDeviceGrant, ScopedLocalFileGrant } from '../src/types/session-identity';
+import type { ToolExecutionContext } from '../src/types/tool';
+
+describe('ReadTool local file grants', () => {
+  let testRoot: string;
+  let tool: ReadTool;
+
+  beforeEach(() => {
+    testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'read-file-grants-'));
+    tool = new ReadTool();
+  });
+
+  afterEach(() => {
+    fs.rmSync(testRoot, { recursive: true, force: true });
+  });
+
+  function scope(overrides: Partial<ExecutionScope> = {}): ExecutionScope {
+    return {
+      source: 'catscompany',
+      sessionKey: 'cc_user:usr7',
+      topicId: 'p2p_7_43',
+      topicType: 'p2p',
+      actorUserId: 'usr7',
+      agentId: 'usr43',
+      agentBodyId: 'body-main',
+      permissionsSource: 'server_canonical_message',
+      identityTrust: 'server_canonical',
+      isTrusted: true,
+      ...overrides,
+    };
+  }
+
+  function grant(filePath: string, overrides: Partial<ScopedLocalFileGrant> = {}): ScopedLocalFileGrant {
+    const stat = fs.statSync(filePath);
+    const now = Date.now();
+    return {
+      kind: 'catscompany_attachment',
+      source: 'catscompany',
+      filePath,
+      fileName: path.basename(filePath),
+      fileType: 'file',
+      size: stat.size,
+      mtimeMs: stat.mtimeMs,
+      sessionKey: 'cc_user:usr7',
+      topicId: 'p2p_7_43',
+      topicType: 'p2p',
+      actorUserId: 'usr7',
+      agentId: 'usr43',
+      agentBodyId: 'body-main',
+      deviceBodyId: 'body-main',
+      deviceInstallationId: 'install-main',
+      identityTrust: 'server_canonical',
+      operations: ['read_file', 'send_file'],
+      createdAt: now,
+      expiresAt: now + 60_000,
+      ...overrides,
+    };
+  }
+
+  function deviceGrant(overrides: Partial<ScopedLocalDeviceGrant> = {}): ScopedLocalDeviceGrant {
+    return {
+      kind: 'catscompany_body',
+      source: 'catscompany',
+      bodyId: 'body-main',
+      installationId: 'install-main',
+      deviceId: 'install-main',
+      createdAt: Date.now(),
+      ...overrides,
+    };
+  }
+
+  function catsContext(
+    localFileGrants?: ScopedLocalFileGrant[],
+    executionScope: ExecutionScope = scope(),
+  ): ToolExecutionContext {
+    return {
+      workingDirectory: testRoot,
+      workspaceRoot: testRoot,
+      conversationHistory: [],
+      sessionId: executionScope.sessionKey,
+      surface: 'catscompany',
+      executionScope,
+      localDeviceGrant: deviceGrant(),
+      localFileGrants,
+    };
+  }
+
+  function managedFile(name = 'report.md'): string {
+    const filePath = path.join(testRoot, 'tmp', 'downloads', name);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, 'hello from current attachment\nsecond line');
+    return filePath;
+  }
+
+  test('allows reading a CatsCo attachment cache file with a matching local grant', async () => {
+    const filePath = managedFile();
+    const result = await tool.execute({ file_path: filePath }, catsContext([grant(filePath)]));
+
+    assert.equal(result.ok, true);
+    assert.match(String(result.content), /hello from current attachment/);
+  });
+
+  test('allows reading a relative CatsCo attachment path with an absolute matching grant', async () => {
+    const filePath = managedFile('relative.md');
+    const result = await tool.execute({ file_path: path.join('tmp', 'downloads', 'relative.md') }, catsContext([grant(filePath)]));
+
+    assert.equal(result.ok, true);
+    assert.match(String(result.content), /hello from current attachment/);
+  });
+
+  test('rejects reading a CatsCo attachment cache file without a current grant', async () => {
+    const filePath = managedFile('old-report.md');
+    const result = await tool.execute({ file_path: filePath }, catsContext());
+
+    assert.equal(result.ok, false);
+    assert.equal(result.errorCode, 'PERMISSION_DENIED');
+    assert.match(result.message, /不属于当前已授权的用户消息/);
+  });
+
+  test('rejects managed attachment reads for legacy or untrusted execution scopes', async () => {
+    const filePath = managedFile('legacy.md');
+    const canonicalGrant = grant(filePath);
+
+    const legacy = await tool.execute({ file_path: filePath }, catsContext([canonicalGrant], scope({
+      identityTrust: 'legacy_context',
+      isTrusted: false,
+    })));
+    assert.equal(legacy.ok, false);
+    assert.equal(legacy.errorCode, 'PERMISSION_DENIED');
+    assert.doesNotMatch(legacy.message, /hello from current attachment/);
+
+    const untrusted = await tool.execute({ file_path: filePath }, catsContext([canonicalGrant], scope({
+      identityTrust: 'untrusted',
+      isTrusted: false,
+    })));
+    assert.equal(untrusted.ok, false);
+    assert.equal(untrusted.errorCode, 'PERMISSION_DENIED');
+    assert.doesNotMatch(untrusted.message, /hello from current attachment/);
+  });
+
+  test('keeps missing-file errors ahead of local grant checks', async () => {
+    const filePath = path.join(testRoot, 'tmp', 'downloads', 'missing.md');
+    const result = await tool.execute({ file_path: filePath }, catsContext());
+
+    assert.equal(result.ok, false);
+    assert.equal(result.errorCode, 'FILE_NOT_FOUND');
+  });
+
+  test('returns a directory read error before local grant checks for managed directories', async () => {
+    const directoryPath = path.join(testRoot, 'tmp', 'downloads');
+    fs.mkdirSync(directoryPath, { recursive: true });
+    const result = await tool.execute({ file_path: directoryPath }, catsContext());
+
+    assert.equal(result.ok, false);
+    assert.equal(result.errorCode, 'TOOL_EXECUTION_ERROR');
+    assert.match(result.message, /Path is not a file/);
+  });
+
+  test('does not require local grants for CLI reads', async () => {
+    const filePath = managedFile('cli-report.md');
+    const result = await tool.execute({
+      file_path: filePath,
+    }, {
+      workingDirectory: testRoot,
+      workspaceRoot: testRoot,
+      conversationHistory: [],
+      surface: 'cli',
+    });
+
+    assert.equal(result.ok, true);
+    assert.match(String(result.content), /hello from current attachment/);
+  });
+});

--- a/tests/tool-result-read-file-local-grants.test.ts
+++ b/tests/tool-result-read-file-local-grants.test.ts
@@ -105,6 +105,9 @@ describe('ReadTool local file grants', () => {
 
     assert.equal(result.ok, true);
     assert.match(String(result.content), /hello from current attachment/);
+    assert.match(String(result.content), /Path: catsco_attachment:current-read-grant/);
+    assert.doesNotMatch(String(result.content), new RegExp(escapeRegExp(filePath)));
+    assert.doesNotMatch(String(result.content), new RegExp(escapeRegExp(testRoot)));
   });
 
   test('allows reading a CatsCo attachment by opaque reference without exposing the local path', async () => {
@@ -142,6 +145,9 @@ describe('ReadTool local file grants', () => {
 
     assert.equal(result.ok, true);
     assert.match(String(result.content), /hello from current attachment/);
+    assert.match(String(result.content), /Path: catsco_attachment:current-read-grant/);
+    assert.doesNotMatch(String(result.content), new RegExp(escapeRegExp(filePath)));
+    assert.doesNotMatch(String(result.content), new RegExp(escapeRegExp(testRoot)));
   });
 
   test('rejects reading a CatsCo attachment cache file without a current grant', async () => {
@@ -151,6 +157,9 @@ describe('ReadTool local file grants', () => {
     assert.equal(result.ok, false);
     assert.equal(result.errorCode, 'PERMISSION_DENIED');
     assert.match(result.message, /不属于当前已授权的用户消息/);
+    assert.match(result.message, /\[CatsCo managed attachment cache\]/);
+    assert.doesNotMatch(result.message, new RegExp(escapeRegExp(filePath)));
+    assert.doesNotMatch(result.message, new RegExp(escapeRegExp(testRoot)));
   });
 
   test('rejects managed attachment reads for legacy or untrusted execution scopes', async () => {
@@ -164,6 +173,8 @@ describe('ReadTool local file grants', () => {
     assert.equal(legacy.ok, false);
     assert.equal(legacy.errorCode, 'PERMISSION_DENIED');
     assert.doesNotMatch(legacy.message, /hello from current attachment/);
+    assert.doesNotMatch(legacy.message, new RegExp(escapeRegExp(filePath)));
+    assert.doesNotMatch(legacy.message, new RegExp(escapeRegExp(testRoot)));
 
     const untrusted = await tool.execute({ file_path: filePath }, catsContext([canonicalGrant], scope({
       identityTrust: 'untrusted',
@@ -172,6 +183,8 @@ describe('ReadTool local file grants', () => {
     assert.equal(untrusted.ok, false);
     assert.equal(untrusted.errorCode, 'PERMISSION_DENIED');
     assert.doesNotMatch(untrusted.message, /hello from current attachment/);
+    assert.doesNotMatch(untrusted.message, new RegExp(escapeRegExp(filePath)));
+    assert.doesNotMatch(untrusted.message, new RegExp(escapeRegExp(testRoot)));
   });
 
   test('rejects stale CatsCo attachment references without exposing the local path', async () => {
@@ -191,22 +204,27 @@ describe('ReadTool local file grants', () => {
     assert.doesNotMatch(result.message, new RegExp(escapeRegExp(testRoot)));
   });
 
-  test('keeps missing-file errors ahead of local grant checks', async () => {
+  test('checks local grants before missing managed cache files to avoid leaking raw paths', async () => {
     const filePath = path.join(testRoot, 'tmp', 'downloads', 'missing.md');
     const result = await tool.execute({ file_path: filePath }, catsContext());
 
     assert.equal(result.ok, false);
-    assert.equal(result.errorCode, 'FILE_NOT_FOUND');
+    assert.equal(result.errorCode, 'PERMISSION_DENIED');
+    assert.match(result.message, /\[CatsCo managed attachment cache\]/);
+    assert.doesNotMatch(result.message, /missing\.md/);
+    assert.doesNotMatch(result.message, new RegExp(escapeRegExp(testRoot)));
   });
 
-  test('returns a directory read error before local grant checks for managed directories', async () => {
+  test('checks local grants before managed directories to avoid leaking raw paths', async () => {
     const directoryPath = path.join(testRoot, 'tmp', 'downloads');
     fs.mkdirSync(directoryPath, { recursive: true });
     const result = await tool.execute({ file_path: directoryPath }, catsContext());
 
     assert.equal(result.ok, false);
-    assert.equal(result.errorCode, 'TOOL_EXECUTION_ERROR');
-    assert.match(result.message, /Path is not a file/);
+    assert.equal(result.errorCode, 'PERMISSION_DENIED');
+    assert.match(result.message, /\[CatsCo managed attachment cache\]/);
+    assert.doesNotMatch(result.message, new RegExp(escapeRegExp(directoryPath)));
+    assert.doesNotMatch(result.message, new RegExp(escapeRegExp(testRoot)));
   });
 
   test('does not require local grants for CLI reads', async () => {

--- a/tests/tool-result-send-file-tool.test.ts
+++ b/tests/tool-result-send-file-tool.test.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import * as os from 'os';
 import * as fs from 'fs';
 import { SendFileTool } from '../src/tools/send-file-tool';
+import type { ExecutionScope } from '../src/types/session-identity';
 import { ToolExecutionContext } from '../src/types/tool';
 
 describe('SendFileTool - ToolExecutionResult', () => {
@@ -22,6 +23,22 @@ describe('SendFileTool - ToolExecutionResult', () => {
       fs.rmSync(testRoot, { recursive: true, force: true });
     }
   });
+
+  function scope(overrides: Partial<ExecutionScope> = {}): ExecutionScope {
+    return {
+      source: 'catscompany',
+      sessionKey: 'cc_user:usr7',
+      topicId: 'chat-1',
+      topicType: 'p2p',
+      actorUserId: 'usr7',
+      agentId: 'usr43',
+      agentBodyId: 'body-main',
+      permissionsSource: 'server_canonical_message',
+      identityTrust: 'server_canonical',
+      isTrusted: true,
+      ...overrides,
+    };
+  }
 
   test('definition marks sent files as outbound transcript messages', () => {
     assert.strictEqual(tool.definition.transcriptMode, 'outbound_file');
@@ -83,6 +100,96 @@ describe('SendFileTool - ToolExecutionResult', () => {
     assert.strictEqual(sentPath, filePath);
     assert.ok((result.content as string).includes('File sent to current chat.'));
     assert.ok((result.content as string).includes(`Path: ${filePath}`));
+  });
+
+  test('uses executionScope topic for file sends when scope is present', async () => {
+    const filePath = path.join(testRoot, 'scoped.md');
+    fs.writeFileSync(filePath, 'hello');
+    let sentChatId = '';
+    context.executionScope = scope({ topicId: 'chat-1' });
+    context.channel = {
+      chatId: 'chat-1',
+      reply: async () => {},
+      sendFile: async (chatId) => {
+        sentChatId = chatId;
+      },
+    };
+
+    const result = await tool.execute({ file_path: filePath, file_name: 'scoped.md' }, context);
+
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(sentChatId, 'chat-1');
+  });
+
+  test('blocks file send when channel chatId conflicts with executionScope topic', async () => {
+    const filePath = path.join(testRoot, 'secret.md');
+    fs.writeFileSync(filePath, 'hello');
+    let sendCalled = false;
+    context.executionScope = scope({ topicId: 'chat-1' });
+    context.channel = {
+      chatId: 'chat-2',
+      reply: async () => {},
+      sendFile: async () => {
+        sendCalled = true;
+      },
+    };
+
+    const result = await tool.execute({ file_path: filePath, file_name: 'secret.md' }, context);
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.errorCode, 'PERMISSION_DENIED');
+    assert.match(result.message, /外发目标与当前执行身份不一致/);
+    assert.strictEqual(sendCalled, false);
+  });
+
+  test('blocks file send for untrusted CatsCo scope', async () => {
+    const filePath = path.join(testRoot, 'report.md');
+    fs.writeFileSync(filePath, 'hello');
+    let sendCalled = false;
+    context.executionScope = scope({
+      identityTrust: 'untrusted',
+      isTrusted: false,
+      agentBodyId: undefined,
+      permissionsSource: undefined,
+    });
+    context.channel = {
+      chatId: 'chat-1',
+      reply: async () => {},
+      sendFile: async () => {
+        sendCalled = true;
+      },
+    };
+
+    const result = await tool.execute({ file_path: filePath, file_name: 'report.md' }, context);
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.errorCode, 'PERMISSION_DENIED');
+    assert.match(result.message, /身份未通过服务端一致性校验/);
+    assert.strictEqual(sendCalled, false);
+  });
+
+  test('allows file send for legacy CatsCo scope when topic matches', async () => {
+    const filePath = path.join(testRoot, 'legacy.md');
+    fs.writeFileSync(filePath, 'hello');
+    let sentChatId = '';
+    context.executionScope = scope({
+      identityTrust: 'legacy_context',
+      isTrusted: false,
+      agentBodyId: undefined,
+      permissionsSource: undefined,
+    });
+    context.channel = {
+      chatId: 'chat-1',
+      reply: async () => {},
+      sendFile: async (chatId) => {
+        sentChatId = chatId;
+      },
+    };
+
+    const result = await tool.execute({ file_path: filePath, file_name: 'legacy.md' }, context);
+
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(sentChatId, 'chat-1');
   });
 
   test('directory path is rejected before send', async () => {

--- a/tests/tool-result-send-file-tool.test.ts
+++ b/tests/tool-result-send-file-tool.test.ts
@@ -259,6 +259,9 @@ describe('SendFileTool - ToolExecutionResult', () => {
 
     assert.strictEqual(result.ok, true);
     assert.strictEqual(sentPath, filePath);
+    assert.match(String(result.content), /Path: catsco_attachment:current-send-grant/);
+    assert.doesNotMatch(String(result.content), new RegExp(escapeRegExp(filePath)));
+    assert.doesNotMatch(String(result.content), new RegExp(escapeRegExp(testRoot)));
   });
 
   test('allows sending a CatsCo attachment by opaque reference without exposing the local path', async () => {
@@ -342,6 +345,9 @@ describe('SendFileTool - ToolExecutionResult', () => {
 
     assert.strictEqual(result.ok, true);
     assert.strictEqual(sentPath, filePath);
+    assert.match(String(result.content), /Path: catsco_attachment:current-send-grant/);
+    assert.doesNotMatch(String(result.content), new RegExp(escapeRegExp(filePath)));
+    assert.doesNotMatch(String(result.content), new RegExp(escapeRegExp(testRoot)));
   });
 
   test('blocks sending a CatsCo attachment cache file without a current local grant', async () => {
@@ -364,6 +370,9 @@ describe('SendFileTool - ToolExecutionResult', () => {
     assert.strictEqual(result.ok, false);
     assert.strictEqual(result.errorCode, 'PERMISSION_DENIED');
     assert.match(result.message, /不属于当前已授权的用户消息/);
+    assert.match(result.message, /\[CatsCo managed attachment cache\]/);
+    assert.doesNotMatch(result.message, new RegExp(escapeRegExp(filePath)));
+    assert.doesNotMatch(result.message, new RegExp(escapeRegExp(testRoot)));
     assert.strictEqual(sendCalled, false);
   });
 
@@ -392,6 +401,8 @@ describe('SendFileTool - ToolExecutionResult', () => {
     assert.strictEqual(result.ok, false);
     assert.strictEqual(result.errorCode, 'PERMISSION_DENIED');
     assert.match(result.message, /未通过服务端一致性校验/);
+    assert.doesNotMatch(result.message, new RegExp(escapeRegExp(filePath)));
+    assert.doesNotMatch(result.message, new RegExp(escapeRegExp(testRoot)));
     assert.strictEqual(sendCalled, false);
   });
 
@@ -449,6 +460,8 @@ describe('SendFileTool - ToolExecutionResult', () => {
     assert.strictEqual(result.ok, false);
     assert.strictEqual(result.errorCode, 'PERMISSION_DENIED');
     assert.match(result.message, /topicId/);
+    assert.doesNotMatch(result.message, new RegExp(escapeRegExp(filePath)));
+    assert.doesNotMatch(result.message, new RegExp(escapeRegExp(testRoot)));
     assert.strictEqual(sendCalled, false);
   });
 
@@ -468,7 +481,7 @@ describe('SendFileTool - ToolExecutionResult', () => {
     assert.ok(result.message.includes('Path is not a file.'));
   });
 
-  test('CatsCo managed directory path is rejected before local grant checks', async () => {
+  test('CatsCo managed directory path is rejected by local grant checks without exposing the path', async () => {
     const directoryPath = path.join(testRoot, 'tmp', 'downloads');
     fs.mkdirSync(directoryPath, { recursive: true });
     context.surface = 'catscompany';
@@ -486,8 +499,38 @@ describe('SendFileTool - ToolExecutionResult', () => {
     const result = await tool.execute({ file_path: directoryPath, file_name: 'downloads' }, context);
 
     assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.errorCode, 'PERMISSION_DENIED');
+    assert.match(result.message, /\[CatsCo managed attachment cache\]/);
+    assert.doesNotMatch(result.message, new RegExp(escapeRegExp(directoryPath)));
+    assert.doesNotMatch(result.message, new RegExp(escapeRegExp(testRoot)));
+  });
+
+  test('redacts CatsCo attachment paths from channel send errors', async () => {
+    const filePath = managedFile('send-error.md');
+    context.surface = 'catscompany';
+    context.sessionId = 'cc_user:usr7';
+    context.executionScope = scope({ topicId: 'chat-1' });
+    context.localDeviceGrant = deviceGrant();
+    context.localFileGrants = [grant(filePath, { attachmentRef: 'catsco_attachment:send-error' })];
+    context.channel = {
+      chatId: 'chat-1',
+      reply: async () => {},
+      sendFile: async () => {
+        throw new Error(`upload failed for ${filePath}`);
+      },
+    };
+
+    const result = await tool.execute({
+      file_path: 'catsco_attachment:send-error',
+      file_name: 'send-error.md',
+    }, context);
+
+    assert.strictEqual(result.ok, false);
     assert.strictEqual(result.errorCode, 'TOOL_EXECUTION_ERROR');
-    assert.ok(result.message.includes('Path is not a file.'));
+    assert.match(result.message, /File send failed: upload failed for catsco_attachment:send-error/);
+    assert.match(result.message, /Path: catsco_attachment:send-error/);
+    assert.doesNotMatch(result.message, new RegExp(escapeRegExp(filePath)));
+    assert.doesNotMatch(result.message, new RegExp(escapeRegExp(testRoot)));
   });
 
   test('channel errors are returned in tool_result content', async () => {

--- a/tests/tool-result-send-file-tool.test.ts
+++ b/tests/tool-result-send-file-tool.test.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import * as os from 'os';
 import * as fs from 'fs';
 import { SendFileTool } from '../src/tools/send-file-tool';
-import type { ExecutionScope, ScopedLocalDeviceGrant, ScopedLocalFileGrant } from '../src/types/session-identity';
+import type { ExecutionScope, ScopedDeviceGrant, ScopedLocalDeviceGrant, ScopedLocalFileGrant } from '../src/types/session-identity';
 import { ToolExecutionContext } from '../src/types/tool';
 
 describe('SendFileTool - ToolExecutionResult', () => {
@@ -76,6 +76,33 @@ describe('SendFileTool - ToolExecutionResult', () => {
       installationId: 'install-main',
       deviceId: 'install-main',
       createdAt: Date.now(),
+      ...overrides,
+    };
+  }
+
+  function userDeviceGrant(operations: ScopedDeviceGrant['operations'], overrides: Partial<ScopedDeviceGrant> = {}): ScopedDeviceGrant {
+    const currentScope = scope();
+    return {
+      kind: 'user_device_grant',
+      source: 'catscompany',
+      grantId: 'device-grant-send-file',
+      status: 'active',
+      identityTrust: 'server_canonical',
+      identitySource: 'metadata.catsco_identity',
+      deviceId: 'install-main',
+      deviceDisplayName: 'Main Device',
+      deviceBodyId: 'body-main',
+      deviceInstallationId: 'install-main',
+      ownerUserId: currentScope.actorUserId,
+      sessionKey: currentScope.sessionKey,
+      topicId: currentScope.topicId,
+      topicType: currentScope.topicType,
+      actorUserId: currentScope.actorUserId,
+      agentId: currentScope.agentId,
+      agentBodyId: currentScope.agentBodyId,
+      operations,
+      createdAt: Date.now(),
+      expiresAt: Date.now() + 60_000,
       ...overrides,
     };
   }
@@ -154,6 +181,8 @@ describe('SendFileTool - ToolExecutionResult', () => {
     fs.writeFileSync(filePath, 'hello');
     let sentChatId = '';
     context.executionScope = scope({ topicId: 'chat-1' });
+    context.localDeviceGrant = deviceGrant();
+    context.deviceGrants = [userDeviceGrant(['send_file'], { topicId: 'chat-1' })];
     context.channel = {
       chatId: 'chat-1',
       reply: async () => {},
@@ -215,7 +244,7 @@ describe('SendFileTool - ToolExecutionResult', () => {
     assert.strictEqual(sendCalled, false);
   });
 
-  test('allows file send for legacy CatsCo scope when topic matches', async () => {
+  test('blocks regular file send for legacy CatsCo scope even when topic matches', async () => {
     const filePath = path.join(testRoot, 'legacy.md');
     fs.writeFileSync(filePath, 'hello');
     let sentChatId = '';
@@ -235,8 +264,10 @@ describe('SendFileTool - ToolExecutionResult', () => {
 
     const result = await tool.execute({ file_path: filePath, file_name: 'legacy.md' }, context);
 
-    assert.strictEqual(result.ok, true);
-    assert.strictEqual(sentChatId, 'chat-1');
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.errorCode, 'PERMISSION_DENIED');
+    assert.match(result.message, /身份未通过服务端一致性校验/);
+    assert.strictEqual(sentChatId, '');
   });
 
   test('allows sending a CatsCo attachment cache file with a matching local grant', async () => {

--- a/tests/tool-result-send-file-tool.test.ts
+++ b/tests/tool-result-send-file-tool.test.ts
@@ -46,6 +46,7 @@ describe('SendFileTool - ToolExecutionResult', () => {
     return {
       kind: 'catscompany_attachment',
       source: 'catscompany',
+      attachmentRef: 'catsco_attachment:current-send-grant',
       filePath,
       fileName: path.basename(filePath),
       fileType: 'file',
@@ -260,6 +261,64 @@ describe('SendFileTool - ToolExecutionResult', () => {
     assert.strictEqual(sentPath, filePath);
   });
 
+  test('allows sending a CatsCo attachment by opaque reference without exposing the local path', async () => {
+    const filePath = managedFile('referenced-send.md');
+    let sentPath = '';
+    context.surface = 'catscompany';
+    context.sessionId = 'cc_user:usr7';
+    context.executionScope = scope({ topicId: 'chat-1' });
+    context.localDeviceGrant = deviceGrant();
+    context.localFileGrants = [grant(filePath, { attachmentRef: 'catsco_attachment:send-current' })];
+    context.channel = {
+      chatId: 'chat-1',
+      reply: async () => {},
+      sendFile: async (_chatId, resolvedPath) => {
+        sentPath = resolvedPath;
+      },
+    };
+
+    const result = await tool.execute({
+      file_path: 'catsco_attachment:send-current',
+      file_name: 'referenced-send.md',
+    }, context);
+
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(sentPath, filePath);
+    assert.match(String(result.content), /Path: catsco_attachment:send-current/);
+    assert.doesNotMatch(String(result.content), new RegExp(escapeRegExp(filePath)));
+    assert.doesNotMatch(String(result.content), new RegExp(escapeRegExp(testRoot)));
+  });
+
+  test('blocks unknown CatsCo attachment references before sending', async () => {
+    const filePath = managedFile('private-send.md');
+    let sendCalled = false;
+    context.surface = 'catscompany';
+    context.sessionId = 'cc_user:usr7';
+    context.executionScope = scope({ topicId: 'chat-1' });
+    context.localDeviceGrant = deviceGrant();
+    context.localFileGrants = [grant(filePath, { attachmentRef: 'catsco_attachment:owned-send' })];
+    context.channel = {
+      chatId: 'chat-1',
+      reply: async () => {},
+      sendFile: async () => {
+        sendCalled = true;
+      },
+    };
+
+    const result = await tool.execute({
+      file_path: 'catsco_attachment:missing-send',
+      file_name: 'missing.md',
+    }, context);
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.errorCode, 'PERMISSION_DENIED');
+    assert.match(result.message, /附件引用不属于当前已授权/);
+    assert.match(result.message, /catsco_attachment:missing-send/);
+    assert.doesNotMatch(result.message, new RegExp(escapeRegExp(filePath)));
+    assert.doesNotMatch(result.message, new RegExp(escapeRegExp(testRoot)));
+    assert.strictEqual(sendCalled, false);
+  });
+
   test('allows sending a relative CatsCo attachment cache path with a matching local grant', async () => {
     const filePath = managedFile('relative.md');
     let sentPath = '';
@@ -333,6 +392,39 @@ describe('SendFileTool - ToolExecutionResult', () => {
     assert.strictEqual(result.ok, false);
     assert.strictEqual(result.errorCode, 'PERMISSION_DENIED');
     assert.match(result.message, /未通过服务端一致性校验/);
+    assert.strictEqual(sendCalled, false);
+  });
+
+  test('blocks stale CatsCo attachment references without exposing the local path', async () => {
+    const filePath = managedFile('expired-send.md');
+    let sendCalled = false;
+    context.surface = 'catscompany';
+    context.sessionId = 'cc_user:usr7';
+    context.executionScope = scope({ topicId: 'chat-1' });
+    context.localDeviceGrant = deviceGrant();
+    context.localFileGrants = [grant(filePath, {
+      attachmentRef: 'catsco_attachment:expired-send',
+      expiresAt: Date.now() - 1,
+    })];
+    context.channel = {
+      chatId: 'chat-1',
+      reply: async () => {},
+      sendFile: async () => {
+        sendCalled = true;
+      },
+    };
+
+    const result = await tool.execute({
+      file_path: 'catsco_attachment:expired-send',
+      file_name: 'expired-send.md',
+    }, context);
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.errorCode, 'PERMISSION_DENIED');
+    assert.match(result.message, /已过期/);
+    assert.match(result.message, /catsco_attachment:expired-send/);
+    assert.doesNotMatch(result.message, /expired-send\.md/);
+    assert.doesNotMatch(result.message, new RegExp(escapeRegExp(testRoot)));
     assert.strictEqual(sendCalled, false);
   });
 
@@ -417,3 +509,7 @@ describe('SendFileTool - ToolExecutionResult', () => {
     assert.ok(result.message.includes(`Path: ${filePath}`));
   });
 });
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/tests/tool-result-send-file-tool.test.ts
+++ b/tests/tool-result-send-file-tool.test.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import * as os from 'os';
 import * as fs from 'fs';
 import { SendFileTool } from '../src/tools/send-file-tool';
-import type { ExecutionScope } from '../src/types/session-identity';
+import type { ExecutionScope, ScopedLocalDeviceGrant, ScopedLocalFileGrant } from '../src/types/session-identity';
 import { ToolExecutionContext } from '../src/types/tool';
 
 describe('SendFileTool - ToolExecutionResult', () => {
@@ -38,6 +38,52 @@ describe('SendFileTool - ToolExecutionResult', () => {
       isTrusted: true,
       ...overrides,
     };
+  }
+
+  function grant(filePath: string, overrides: Partial<ScopedLocalFileGrant> = {}): ScopedLocalFileGrant {
+    const stat = fs.statSync(filePath);
+    const now = Date.now();
+    return {
+      kind: 'catscompany_attachment',
+      source: 'catscompany',
+      filePath,
+      fileName: path.basename(filePath),
+      fileType: 'file',
+      size: stat.size,
+      mtimeMs: stat.mtimeMs,
+      sessionKey: 'cc_user:usr7',
+      topicId: 'chat-1',
+      topicType: 'p2p',
+      actorUserId: 'usr7',
+      agentId: 'usr43',
+      agentBodyId: 'body-main',
+      deviceBodyId: 'body-main',
+      deviceInstallationId: 'install-main',
+      identityTrust: 'server_canonical',
+      operations: ['read_file', 'send_file'],
+      createdAt: now,
+      expiresAt: now + 60_000,
+      ...overrides,
+    };
+  }
+
+  function deviceGrant(overrides: Partial<ScopedLocalDeviceGrant> = {}): ScopedLocalDeviceGrant {
+    return {
+      kind: 'catscompany_body',
+      source: 'catscompany',
+      bodyId: 'body-main',
+      installationId: 'install-main',
+      deviceId: 'install-main',
+      createdAt: Date.now(),
+      ...overrides,
+    };
+  }
+
+  function managedFile(name = 'attachment.md'): string {
+    const filePath = path.join(testRoot, 'tmp', 'downloads', name);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, 'hello');
+    return filePath;
   }
 
   test('definition marks sent files as outbound transcript messages', () => {
@@ -192,6 +238,128 @@ describe('SendFileTool - ToolExecutionResult', () => {
     assert.strictEqual(sentChatId, 'chat-1');
   });
 
+  test('allows sending a CatsCo attachment cache file with a matching local grant', async () => {
+    const filePath = managedFile('current.md');
+    let sentPath = '';
+    context.surface = 'catscompany';
+    context.sessionId = 'cc_user:usr7';
+    context.executionScope = scope({ topicId: 'chat-1' });
+    context.localDeviceGrant = deviceGrant();
+    context.localFileGrants = [grant(filePath)];
+    context.channel = {
+      chatId: 'chat-1',
+      reply: async () => {},
+      sendFile: async (_chatId, resolvedPath) => {
+        sentPath = resolvedPath;
+      },
+    };
+
+    const result = await tool.execute({ file_path: filePath, file_name: 'current.md' }, context);
+
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(sentPath, filePath);
+  });
+
+  test('allows sending a relative CatsCo attachment cache path with a matching local grant', async () => {
+    const filePath = managedFile('relative.md');
+    let sentPath = '';
+    context.surface = 'catscompany';
+    context.sessionId = 'cc_user:usr7';
+    context.executionScope = scope({ topicId: 'chat-1' });
+    context.localDeviceGrant = deviceGrant();
+    context.localFileGrants = [grant(filePath)];
+    context.channel = {
+      chatId: 'chat-1',
+      reply: async () => {},
+      sendFile: async (_chatId, resolvedPath) => {
+        sentPath = resolvedPath;
+      },
+    };
+
+    const result = await tool.execute({
+      file_path: path.join('tmp', 'downloads', 'relative.md'),
+      file_name: 'relative.md',
+    }, context);
+
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(sentPath, filePath);
+  });
+
+  test('blocks sending a CatsCo attachment cache file without a current local grant', async () => {
+    const filePath = managedFile('old.md');
+    let sendCalled = false;
+    context.surface = 'catscompany';
+    context.sessionId = 'cc_user:usr7';
+    context.executionScope = scope({ topicId: 'chat-1' });
+    context.localDeviceGrant = deviceGrant();
+    context.channel = {
+      chatId: 'chat-1',
+      reply: async () => {},
+      sendFile: async () => {
+        sendCalled = true;
+      },
+    };
+
+    const result = await tool.execute({ file_path: filePath, file_name: 'old.md' }, context);
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.errorCode, 'PERMISSION_DENIED');
+    assert.match(result.message, /不属于当前已授权的用户消息/);
+    assert.strictEqual(sendCalled, false);
+  });
+
+  test('blocks managed attachment send for legacy execution scope even with a matching grant', async () => {
+    const filePath = managedFile('legacy-cache.md');
+    let sendCalled = false;
+    context.surface = 'catscompany';
+    context.sessionId = 'cc_user:usr7';
+    context.executionScope = scope({
+      topicId: 'chat-1',
+      identityTrust: 'legacy_context',
+      isTrusted: false,
+    });
+    context.localDeviceGrant = deviceGrant();
+    context.localFileGrants = [grant(filePath)];
+    context.channel = {
+      chatId: 'chat-1',
+      reply: async () => {},
+      sendFile: async () => {
+        sendCalled = true;
+      },
+    };
+
+    const result = await tool.execute({ file_path: filePath, file_name: 'legacy-cache.md' }, context);
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.errorCode, 'PERMISSION_DENIED');
+    assert.match(result.message, /未通过服务端一致性校验/);
+    assert.strictEqual(sendCalled, false);
+  });
+
+  test('blocks managed attachment send when grant topic identity mismatches', async () => {
+    const filePath = managedFile('wrong-topic.md');
+    let sendCalled = false;
+    context.surface = 'catscompany';
+    context.sessionId = 'cc_user:usr7';
+    context.executionScope = scope({ topicId: 'chat-1' });
+    context.localDeviceGrant = deviceGrant();
+    context.localFileGrants = [grant(filePath, { topicId: 'chat-2' })];
+    context.channel = {
+      chatId: 'chat-1',
+      reply: async () => {},
+      sendFile: async () => {
+        sendCalled = true;
+      },
+    };
+
+    const result = await tool.execute({ file_path: filePath, file_name: 'wrong-topic.md' }, context);
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.errorCode, 'PERMISSION_DENIED');
+    assert.match(result.message, /topicId/);
+    assert.strictEqual(sendCalled, false);
+  });
+
   test('directory path is rejected before send', async () => {
     context.channel = {
       chatId: 'chat-1',
@@ -202,6 +370,28 @@ describe('SendFileTool - ToolExecutionResult', () => {
     };
 
     const result = await tool.execute({ file_path: '.', file_name: 'root' }, context);
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.errorCode, 'TOOL_EXECUTION_ERROR');
+    assert.ok(result.message.includes('Path is not a file.'));
+  });
+
+  test('CatsCo managed directory path is rejected before local grant checks', async () => {
+    const directoryPath = path.join(testRoot, 'tmp', 'downloads');
+    fs.mkdirSync(directoryPath, { recursive: true });
+    context.surface = 'catscompany';
+    context.sessionId = 'cc_user:usr7';
+    context.executionScope = scope({ topicId: 'chat-1' });
+    context.localDeviceGrant = deviceGrant();
+    context.channel = {
+      chatId: 'chat-1',
+      reply: async () => {},
+      sendFile: async () => {
+        throw new Error('should not send');
+      },
+    };
+
+    const result = await tool.execute({ file_path: directoryPath, file_name: 'downloads' }, context);
 
     assert.strictEqual(result.ok, false);
     assert.strictEqual(result.errorCode, 'TOOL_EXECUTION_ERROR');

--- a/tests/tool-result-send-text-tool.test.ts
+++ b/tests/tool-result-send-text-tool.test.ts
@@ -1,0 +1,90 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import { SendTextTool } from '../src/tools/send-text-tool';
+import type { ExecutionScope } from '../src/types/session-identity';
+import type { ToolExecutionContext } from '../src/types/tool';
+
+function scope(overrides: Partial<ExecutionScope> = {}): ExecutionScope {
+  return {
+    source: 'catscompany',
+    sessionKey: 'cc_user:usr7',
+    topicId: 'p2p_7_43',
+    topicType: 'p2p',
+    actorUserId: 'usr7',
+    agentId: 'usr43',
+    agentBodyId: 'body-main',
+    channelSeq: 12,
+    permissionsSource: 'server_canonical_message',
+    identityTrust: 'server_canonical',
+    isTrusted: true,
+    ...overrides,
+  };
+}
+
+function contextWithChannel(chatId: string, executionScope?: ExecutionScope) {
+  const sent: Array<{ chatId: string; text: string }> = [];
+  const context: ToolExecutionContext = {
+    workingDirectory: process.cwd(),
+    workspaceRoot: process.cwd(),
+    conversationHistory: [],
+    surface: 'catscompany',
+    executionScope,
+    channel: {
+      chatId,
+      reply: async (targetChatId, text) => {
+        sent.push({ chatId: targetChatId, text });
+      },
+      sendFile: async () => undefined,
+    },
+  };
+  return { context, sent };
+}
+
+describe('SendTextTool outbound scope checks', () => {
+  test('uses executionScope topic as the outbound target when scope is present', async () => {
+    const tool = new SendTextTool();
+    const { context, sent } = contextWithChannel('p2p_7_43', scope());
+
+    const result = await tool.execute({ text: '  合同已查到  ' }, context);
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(sent, [{ chatId: 'p2p_7_43', text: '合同已查到' }]);
+  });
+
+  test('keeps legacy channel-only behavior when executionScope is missing', async () => {
+    const tool = new SendTextTool();
+    const { context, sent } = contextWithChannel('legacy-chat');
+
+    const result = await tool.execute({ text: 'hello' }, context);
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(sent, [{ chatId: 'legacy-chat', text: 'hello' }]);
+  });
+
+  test('blocks text send when channel chatId conflicts with executionScope topic', async () => {
+    const tool = new SendTextTool();
+    const { context, sent } = contextWithChannel('p2p_8_43', scope());
+
+    const result = await tool.execute({ text: 'should not send' }, context);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.errorCode, 'PERMISSION_DENIED');
+    assert.match(result.message, /外发目标与当前执行身份不一致/);
+    assert.deepEqual(sent, []);
+  });
+
+  test('allows basic text replies for untrusted scope when topic still matches', async () => {
+    const tool = new SendTextTool();
+    const { context, sent } = contextWithChannel('p2p_7_43', scope({
+      identityTrust: 'untrusted',
+      isTrusted: false,
+      agentBodyId: undefined,
+      permissionsSource: undefined,
+    }));
+
+    const result = await tool.execute({ text: '请重新发送一下' }, context);
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(sent, [{ chatId: 'p2p_7_43', text: '请重新发送一下' }]);
+  });
+});

--- a/tests/tool-result-tool-manager.test.ts
+++ b/tests/tool-result-tool-manager.test.ts
@@ -7,6 +7,7 @@ import * as path from 'path';
 import * as os from 'os';
 import * as fs from 'fs';
 import { ToolManager } from '../src/tools/tool-manager';
+import type { ExecutionScope } from '../src/types/session-identity';
 
 describe('ToolManager - ToolExecutionResult 统一处理', () => {
   let manager: ToolManager;
@@ -283,6 +284,42 @@ describe('ToolManager - ToolExecutionResult 统一处理', () => {
 
     assert.strictEqual(result.ok, true);
     assert.strictEqual(capturedSignal, controller.signal);
+  });
+
+  test('context overrides do not clear an existing executionScope with undefined', async () => {
+    const executionScope: ExecutionScope = {
+      source: 'catscompany',
+      sessionKey: 'cc_user:usr7',
+      topicId: 'p2p_7_43',
+      topicType: 'p2p',
+      actorUserId: 'usr7',
+      identityTrust: 'server_canonical',
+      isTrusted: true,
+    };
+    const scopedManager = new ToolManager(testRoot, { executionScope }, {
+      enabledToolNames: [],
+    });
+    let capturedScope: ExecutionScope | undefined;
+    scopedManager.registerTool({
+      definition: {
+        name: 'capture_scope',
+        description: 'capture scope',
+        parameters: { type: 'object', properties: {} },
+      },
+      async execute(_args, context) {
+        capturedScope = context.executionScope;
+        return { ok: true, content: 'ok' };
+      },
+    });
+
+    const result = await scopedManager.executeTool(
+      { id: 't19_scope_merge', type: 'function', function: { name: 'capture_scope', arguments: '{}' } },
+      [],
+      { executionScope: undefined },
+    );
+
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(capturedScope, executionScope);
   });
 
   test('Write 别名映射到 write_file 成功', async () => {

--- a/tests/weixin-session-route.test.ts
+++ b/tests/weixin-session-route.test.ts
@@ -1,0 +1,130 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import { WeixinBot } from '../src/weixin';
+import { SubAgentManager } from '../src/core/sub-agent-manager';
+
+describe('Weixin SessionRoute V2', () => {
+  test('routes messages through a Weixin V2 key while preserving the outbound user id', async () => {
+    const sentTexts: Array<{ userId: string; text: string; contextToken?: string }> = [];
+    const bot = createHarness({
+      sentTexts,
+      parsed: {
+        message_id: 'wx-msg-1',
+        from: { id: 'shared' },
+        chat: { id: 'wx-bot' },
+        text: 'hello',
+        context_token: 'ctx-token',
+      },
+    });
+
+    try {
+      await (bot as any).handleMessage({
+        message_type: 0,
+        message_id: 'wx-msg-1',
+        from_user_id: 'shared',
+        to_user_id: 'wx-bot',
+        context_token: 'ctx-token',
+      });
+
+      const sessionKey = 'session:v2:weixin:p2p:shared';
+      assert.deepEqual(bot.createdSessions, [sessionKey]);
+      assert.equal(bot.contextTokens.get(sessionKey), 'ctx-token');
+      assert.equal(bot.contextTokens.get('user:shared'), 'ctx-token');
+      assert.equal(bot.handledTurns.length, 1);
+      assert.equal(bot.handledTurns[0].options.channel.chatId, 'shared');
+      assert.equal(bot.handledTurns[0].options.sessionRoute.sessionKey, sessionKey);
+      assert.equal(bot.handledTurns[0].options.executionScope.source, 'weixin');
+      assert.equal(bot.handledTurns[0].options.executionScope.topicType, 'p2p');
+      assert.equal(bot.handledTurns[0].options.executionScope.topicId, 'shared');
+      assert.equal(bot.handledTurns[0].options.executionScope.actorUserId, 'shared');
+
+      await bot.handledTurns[0].options.channel.reply('ignored-chat-id', 'reply text');
+
+      assert.deepEqual(sentTexts, [
+        { userId: 'shared', text: 'reply text', contextToken: 'ctx-token' },
+      ]);
+    } finally {
+      SubAgentManager.getInstance().unregisterPlatformCallbacks('session:v2:weixin:p2p:shared');
+    }
+  });
+
+  test('keeps busy queue entries bound to the same Weixin actor user id', async () => {
+    const bot = createHarness({
+      busy: true,
+      parsed: {
+        message_id: 'wx-msg-2',
+        from: { id: 'shared' },
+        chat: { id: 'wx-bot' },
+        text: 'queued',
+        context_token: 'ctx-token',
+      },
+    });
+
+    try {
+      await (bot as any).handleMessage({
+        message_type: 0,
+        message_id: 'wx-msg-2',
+        from_user_id: 'shared',
+        to_user_id: 'wx-bot',
+        context_token: 'ctx-token',
+      });
+
+      const sessionKey = 'session:v2:weixin:p2p:shared';
+      assert.equal(bot.messageQueue.has(sessionKey), true);
+      assert.equal(bot.messageQueue.get(sessionKey)?.[0]?.userId, 'shared');
+      assert.equal(bot.messageQueue.get(sessionKey)?.[0]?.sessionRoute.actorUserId, 'shared');
+      bot.sessionBusy = false;
+      await (bot as any).drainMessageQueue(sessionKey);
+
+      assert.deepEqual(bot.createdSessions, [sessionKey, sessionKey]);
+      assert.equal(bot.handledTurns.length, 1);
+      assert.equal(bot.handledTurns[0].options.channel.chatId, 'shared');
+      assert.equal(bot.handledTurns[0].options.executionScope.topicId, 'shared');
+    } finally {
+      SubAgentManager.getInstance().unregisterPlatformCallbacks('session:v2:weixin:p2p:shared');
+    }
+  });
+});
+
+function createHarness(options: {
+  busy?: boolean;
+  parsed: any;
+  sentTexts?: Array<{ userId: string; text: string; contextToken?: string }>;
+}): any {
+  const bot = Object.create(WeixinBot.prototype) as any;
+  bot.sessionBusy = options.busy ?? false;
+  bot.createdSessions = [] as string[];
+  bot.handledTurns = [] as any[];
+  bot.contextTokens = new Map();
+  bot.messageQueue = new Map();
+  bot.saveState = async () => undefined;
+  bot.handler = {
+    parseMessage: () => options.parsed,
+    shouldIgnoreMessage: () => false,
+    downloadMedia: async () => [],
+  };
+  const session = {
+    isBusy: () => bot.sessionBusy,
+    handleMessage: async (userText: string, handleOptions: any) => {
+      bot.handledTurns.push({ userText, options: handleOptions });
+      return { visibleToUser: false, text: '' };
+    },
+    handleRuntimeObservation: async (userText: string, handleOptions: any) => {
+      bot.handledTurns.push({ userText, options: handleOptions });
+      return { visibleToUser: false, text: '' };
+    },
+  };
+  bot.sessionManager = {
+    getOrCreate: (input: any) => {
+      bot.createdSessions.push(typeof input === 'string' ? input : input.sessionKey);
+      return session;
+    },
+  };
+  bot.sender = {
+    sendText: async (userId: string, text: string, contextToken?: string) => {
+      options.sentTexts?.push({ userId, text, contextToken });
+    },
+    sendFile: async () => undefined,
+  };
+  return bot;
+}


### PR DESCRIPTION
## 背景

这个 PR 将原本拆开的三层能力合并成一个完整的 CatsCo 虚拟员工执行边界闭环：

- MessageEnvelope / ExecutionScope：让后端明确“当前消息是谁、来自哪个会话/群聊、要服务哪个机器人 body”。
- Outbound Gateway：让 `send_text` / `send_file` 不能发到错误 topic。
- Local File Grants：让 CatsCo 附件必须通过当前用户、当前话题、当前本机 body 的授权，才能被 `read_file` 或 `send_file` 使用。

这样评审时不需要分别理解几个技术薄片，而是可以围绕一个产品问题看：多用户、群聊、虚拟员工 body、本地设备和附件文件同时存在时，机器人是否会串用户、串群、发错会话、读错本地附件，或者把本地真实路径暴露给模型。

## 主要改动

- 新增 CatsCo `MessageEnvelope`，统一解析 websocket message 的 canonical identity、topic、actor、recipient agent body 和 trust level。
- 新增 `ExecutionScope` 并贯穿 `CatsCompanyBot -> AgentSession -> AgentTurnController -> ConversationRunner -> ToolExecutionContext`。
- 兼容 canonical / legacy / untrusted CatsCo metadata：可信上下文用于边界判断，legacy 仍可文本对话，但不会获得本地附件授权。
- 新增 `outbound-gateway`，让 `send_text` / `send_file` 优先使用当前 `ExecutionScope.topicId`，并阻止 channel chatId 与当前 topic 冲突。
- 新增 `ScopedLocalDeviceGrant` / `ScopedLocalFileGrant`。
- CatsCo canonical 附件下载成功后，仅在 server_canonical + trusted + local body 匹配 + 位于 `tmp/downloads` 管理缓存时生成本轮本地文件 grant。
- 本地文件 grant 现在生成 opaque `catsco_attachment:<id>` 引用；模型上下文只看到引用，不再看到真实本地路径。
- `read_file` / `send_file` 支持接收 `catsco_attachment:<id>`，由后端根据当前 `localFileGrants` 解析到真实文件路径并校验 scope、body、mtime、size 和有效期。
- 新增 `local-file-gateway`，让 `read_file` / `send_file` 对 CatsCo managed attachment cache 做授权校验，并避免 reference 拒绝结果、raw cache 路径拒绝结果和发送失败结果泄露真实路径。
- CatsCo 图片附件的 image block 历史降级也保留 `catsco_attachment:<id>`，避免后续轮次把真实本地路径转成文本进入上下文。
- 忙碌期间 queued / pending 的用户输入继续携带并合并本轮附件 grants，避免排队消息丢失附件授权。
- 更新 CatsCo surface prompt 和工具说明：收到的附件使用当前 `catsco_attachment:<id>` 引用，`tmp/downloads` 是后端内部缓存，不应猜测或复用。
- 补充 MessageEnvelope、ExecutionScope flow、outbound gateway、local file grant、opaque attachment reference、read_file、send_file、pending input、图片历史降级等 runtime 测试。

## 当前产品形态

- 私聊中，机器人可以稳定知道当前服务的用户、topic 和机器人 body。
- 群聊中，session key 使用 group/topic，但 execution scope 仍保留具体 actor，避免把 A 用户附件当成 B 用户附件。
- 机器人回复文本或文件时，会绑定当前 ExecutionScope 的 topic，避免发到错误会话。
- 当前可信 CatsCo 附件可以被当前机器人读取/转发；不同用户、不同 topic、不同 agent body、本机 body 不匹配、grant 过期或文件变化时会被拒绝。
- 模型只看到 `catsco_attachment:<id>` 这类授权附件引用；真实本地路径留在后端 grant 中，不进入模型上下文，也不在工具结果、发送失败结果或图片历史降级文本中回显。
- legacy / untrusted CatsCo 上下文仍可正常文本回复，但不能访问 managed attachment cache。
- 非 CatsCo 场景、以及非 `tmp/downloads` 管理缓存里的普通生成文件，保持原有兼容性。

## 边界说明

这个 PR 解决的是 CatsCo 虚拟员工的消息身份、回复目标和附件缓存访问边界。它不宣称实现完整 OS 文件沙箱；`glob` / `grep` / `execute_shell` 等更广义的本地文件访问面可以作为后续 hardening PR 继续收敛。

## 验证

- `npm.cmd run build -- --noEmit`
- `npm.cmd run test:runtime`
  - tests: 561
  - pass: 559
  - skipped: 2
  - fail: 0

## 整合说明

这个 PR 整合并替代此前拆得过细的 stacked PR：

- #96 MessageEnvelope / ExecutionScope
- #97 Execution-scoped outbound gateway
- #98 Scoped local file grants

合并后，评审入口统一为本 PR。
