### PR TITLE
修复图片安全拦截的静默收束

### DIFF
--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -41,6 +41,7 @@ import { SubAgentManager } from './sub-agent-manager';
 import type { PendingUserInputProvider } from './conversation-runner';
 import { resolveModelContextWindow } from '../utils/model-context-window';
 import { parseSessionKeyV2 } from './session-router';
+import { MODEL_IMAGE_SAFETY_MESSAGE, isModelImageSafetyError } from '../utils/model-error-classifier';
 
 export type { RuntimeFeedbackInput, RuntimeFeedbackOptions } from './runtime-feedback-inbox';
 
@@ -507,11 +508,14 @@ export class AgentSession {
 
         // 识别多模态相关错误
         const errorMsg = err.message || String(err);
-        const isVisionError = errorMsg.match(/image|vision|multimodal|media_type|base64.*not supported/i);
+        const isImageSafetyError = isModelImageSafetyError(err);
+        const isVisionError = !isImageSafetyError && errorMsg.match(/image|vision|multimodal|media_type|base64.*not supported/i);
         const isModelTimeoutError = this.isModelTimeoutError(err);
 
         let errorReply = ERROR_MESSAGE;
-        if (isVisionError) {
+        if (isImageSafetyError) {
+          errorReply = MODEL_IMAGE_SAFETY_MESSAGE;
+        } else if (isVisionError) {
           errorReply = '当前模型不支持图片识别。请使用支持多模态的模型（如 Claude 3.5 Sonnet 或 GPT-4V），或者用文字描述图片内容。';
         } else if (isModelTimeoutError) {
           errorReply = MODEL_TIMEOUT_MESSAGE;
@@ -520,7 +524,7 @@ export class AgentSession {
         // 添加错误回复到上下文，保持对话连贯性
         this.messages.push({
           role: 'assistant',
-          content: this.formatErrorContextMessage(err, isModelTimeoutError),
+          content: this.formatErrorContextMessage(err, isModelTimeoutError, isImageSafetyError),
         });
         this.messages = this.turnContextBuilder.removeTransientMessages(this.messages);
         this.lifecycleManager.saveContext(this.messages);
@@ -730,10 +734,13 @@ export class AgentSession {
     return /API错误\s*\(504\)|request_timed_out|request timed out|default_request_timeout_in_seconds|upstream request timeout|gateway timeout/i.test(text);
   }
 
-  private formatErrorContextMessage(error: any, isModelTimeoutError: boolean): string {
+  private formatErrorContextMessage(error: any, isModelTimeoutError: boolean, isImageSafetyError = false): string {
     const detail = this.sanitizeErrorMessage(error?.message || String(error));
     if (isModelTimeoutError) {
       return `[处理中断: 模型中转请求超时。已保留本轮已完成的工具结果和上下文；如果用户要求继续，请基于当前上下文继续，避免重复已经完成的工具步骤。错误摘要: ${detail}]`;
+    }
+    if (isImageSafetyError) {
+      return `[处理中断: 上游模型拒绝了当前对话中的图片。已保留本轮已完成的上下文；如果用户要求继续，请提示用户删除或更换相关图片，或新开对话后继续。错误摘要: ${detail}]`;
     }
     return `[处理失败: ${detail}]`;
   }

--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -27,6 +27,7 @@ import {
 } from './runtime-context-builder';
 import { calculateSummaryBudgetTokens, resolveModelPromptBudgetTokens } from '../utils/model-context-window';
 import { MODEL_IMAGE_SAFETY_MESSAGE, isModelImageSafetyError } from '../utils/model-error-classifier';
+import { formatProviderErrorForLog } from '../utils/provider-error-log-sanitizer';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -321,7 +322,7 @@ export class ConversationRunner {
           };
           messages.push(assistantMessage);
           newMessages.push(assistantMessage);
-          Logger.warning(`[${this.sessionLabel}Turn ${turns}] 图片被模型安全策略拒绝，已发送可见收束提示: ${error.message}`);
+          Logger.warning(`[${this.sessionLabel}Turn ${turns}] 图片被模型安全策略拒绝，已发送可见收束提示: ${formatProviderErrorForLog(error)}`);
           return {
             response: MODEL_IMAGE_SAFETY_MESSAGE,
             finalResponseVisible: true,
@@ -330,7 +331,7 @@ export class ConversationRunner {
           };
         }
         if (hasDeliveredMessageOutThisRun && this.isMessageSurface()) {
-          Logger.warning(`[${this.sessionLabel}Turn ${turns}] 已有外发消息送达，后续推理失败后直接收束: ${error.message}`);
+          Logger.warning(`[${this.sessionLabel}Turn ${turns}] 已有外发消息送达，后续推理失败后直接收束: ${formatProviderErrorForLog(error)}`);
           return {
             response: '',
             finalResponseVisible: false,

--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -26,6 +26,7 @@ import {
   buildRuntimeContextMessage,
 } from './runtime-context-builder';
 import { calculateSummaryBudgetTokens, resolveModelPromptBudgetTokens } from '../utils/model-context-window';
+import { MODEL_IMAGE_SAFETY_MESSAGE, isModelImageSafetyError } from '../utils/model-error-classifier';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -303,6 +304,31 @@ export class ConversationRunner {
         const aiDuration = Date.now() - aiStartTime;
         Logger.info(`[${this.sessionLabel}Turn ${turns}] AI推理完成，耗时: ${aiDuration}ms`);
       } catch (error: any) {
+        if (this.isMessageSurface() && isModelImageSafetyError(error)) {
+          if (this.toolExecutionContext?.channel && this.toolExecutionContext?.surface !== 'catscompany') {
+            try {
+              await this.toolExecutionContext.channel.reply(
+                this.toolExecutionContext.channel.chatId,
+                MODEL_IMAGE_SAFETY_MESSAGE,
+              );
+            } catch (err: any) {
+              Logger.error(`[${this.sessionLabel}Turn ${turns}] 图片安全提示发送失败: ${err.message}`);
+            }
+          }
+          const assistantMessage: Message = {
+            role: 'assistant',
+            content: MODEL_IMAGE_SAFETY_MESSAGE,
+          };
+          messages.push(assistantMessage);
+          newMessages.push(assistantMessage);
+          Logger.warning(`[${this.sessionLabel}Turn ${turns}] 图片被模型安全策略拒绝，已发送可见收束提示: ${error.message}`);
+          return {
+            response: MODEL_IMAGE_SAFETY_MESSAGE,
+            finalResponseVisible: true,
+            messages,
+            newMessages,
+          };
+        }
         if (hasDeliveredMessageOutThisRun && this.isMessageSurface()) {
           Logger.warning(`[${this.sessionLabel}Turn ${turns}] 已有外发消息送达，后续推理失败后直接收束: ${error.message}`);
           return {

--- a/src/utils/model-error-classifier.ts
+++ b/src/utils/model-error-classifier.ts
@@ -1,0 +1,16 @@
+export const MODEL_IMAGE_SAFETY_MESSAGE =
+  '模型拒绝了当前对话里的某张图片，可能触发了上游图片安全策略。本轮已停止；请删除或更换这张图片，或新开对话后继续。';
+
+export function isModelImageSafetyError(error: unknown): boolean {
+  const text = String(
+    error instanceof Error ? error.message : error ?? '',
+  );
+
+  const hasSafetyCode = /input[\s_-]*new[\s_-]*sensitive/i.test(text)
+    || /sensitive/i.test(text);
+  const hasImageEvidence = /image\s+is\s+sensitive/i.test(text)
+    || /content\[\d+\][^{}]{0,120}image[^{}]{0,120}sensitive/i.test(text)
+    || /messages\[\d+\][^{}]{0,180}content\[\d+\][^{}]{0,180}image/i.test(text);
+
+  return hasSafetyCode && hasImageEvidence;
+}

--- a/src/utils/provider-error-log-sanitizer.ts
+++ b/src/utils/provider-error-log-sanitizer.ts
@@ -1,0 +1,76 @@
+const MAX_PROVIDER_ERROR_LOG_MESSAGE_LENGTH = 240;
+
+function valueToString(value: unknown): string {
+  if (value instanceof Error) return value.message;
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function pickErrorField(error: any, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = error?.[key] ?? error?.error?.[key] ?? error?.response?.[key];
+    if (typeof value === 'string' || typeof value === 'number') {
+      return String(value);
+    }
+  }
+  return undefined;
+}
+
+export function sanitizeProviderErrorMessageForLog(error: unknown): string {
+  const normalized = valueToString(error)
+    .replace(/\r?\n/g, ' ')
+    .replace(/\s+/g, ' ')
+    .replace(/https?:\/\/[^\s'"`<>)}]+/gi, '[redacted-url]')
+    .replace(/\bhost=(?:"[^"]*"|'[^']*'|[^\s,;)]+)/gi, 'host=[redacted-host]')
+    .replace(/\b\d{1,3}(?:\.\d{1,3}){3}\b/g, '[redacted-ip]')
+    .replace(/\bsk-[A-Za-z0-9_-]{8,}\b/g, 'sk-[redacted]')
+    .replace(/\bcc_[A-Za-z0-9_-]{8,}\b/g, 'cc_[redacted]')
+    .replace(/\bcats_svc_[A-Za-z0-9_-]+\b/g, 'cats_svc_[redacted]')
+    .replace(/\bAuthorization\s*[:=]\s*(?:[A-Za-z][A-Za-z0-9+.-]*\s+)?[^\s,;'"`<>}]+/gi, 'Authorization: [redacted-token]')
+    .replace(/\b(?:Bearer|ApiKey|Token)\s+[A-Za-z0-9._~+/=-]+/gi, match => `${match.split(/\s+/)[0]} [redacted-token]`)
+    .replace(/(["']?)([A-Za-z0-9_.-]*(?:token|api[_-]?key|apikey|secret|password|credential)[A-Za-z0-9_.-]*)\1\s*[:=]\s*["']?[^&\s,'"`<>}]+["']?/gi, '$1$2$1=[redacted-token]')
+    .trim();
+
+  if (normalized.length <= MAX_PROVIDER_ERROR_LOG_MESSAGE_LENGTH) {
+    return normalized || 'unknown error';
+  }
+  return `${normalized.slice(0, MAX_PROVIDER_ERROR_LOG_MESSAGE_LENGTH)}...(truncated)`;
+}
+
+export function classifyProviderErrorForLog(error: unknown): string {
+  const text = sanitizeProviderErrorMessageForLog(error);
+  if (/input_new_sensitive|image is sensitive|content\[\d+\]\s+image/i.test(text)) {
+    return 'model_image_safety';
+  }
+  if (/request_timed_out|request timed out|timeout|ETIMEDOUT|gateway timeout|504/i.test(text)) {
+    return 'provider_timeout';
+  }
+  if (/ECONNRESET|ECONNREFUSED|ENOTFOUND|ConnectTimeout|Connection error|connection/i.test(text)) {
+    return 'provider_connection';
+  }
+  if (/rate limit|too many requests|\b429\b/i.test(text)) {
+    return 'provider_rate_limited';
+  }
+  if (/\b5\d\d\b|api_error|server error/i.test(text)) {
+    return 'provider_server_error';
+  }
+  return 'provider_error';
+}
+
+export function formatProviderErrorForLog(error: unknown): string {
+  const status = pickErrorField(error as any, ['status', 'statusCode']);
+  const code = pickErrorField(error as any, ['code']);
+  const type = pickErrorField(error as any, ['type']);
+  const parts = [
+    `category=${classifyProviderErrorForLog(error)}`,
+    status ? `status=${status}` : '',
+    code ? `code=${code}` : '',
+    type ? `type=${type}` : '',
+    `message=${sanitizeProviderErrorMessageForLog(error)}`,
+  ].filter(Boolean);
+  return parts.join(' ');
+}

--- a/tests/conversation-runner-transcript-normalization.test.ts
+++ b/tests/conversation-runner-transcript-normalization.test.ts
@@ -6,6 +6,7 @@ import { ToolExecutor, ToolResult, ToolDefinition, ToolCall, ToolExecutionContex
 import { ChatResponse, Message } from '../src/types';
 import { ToolManager } from '../src/tools/tool-manager';
 import { SkillManager } from '../src/skills/skill-manager';
+import { MODEL_IMAGE_SAFETY_MESSAGE, isModelImageSafetyError } from '../src/utils/model-error-classifier';
 
 function cloneMessages(messages: Message[]): Message[] {
   return JSON.parse(JSON.stringify(messages));
@@ -210,6 +211,112 @@ test('runner injects current directory before the active request context without
     secondCallMessages[secondCallMessages.length - 1].role,
     'tool',
     'after a tool exchange, the tool_result should remain the final message instead of the cwd hint',
+  );
+});
+
+test('runner surfaces image safety errors after outbound messages on message surfaces', async () => {
+  const toolCall = makeToolCall('call_send', 'send_text', { text: '我先把前半段发给你。' });
+  const receivedMessages: Message[][] = [];
+  const sentReplies: string[] = [];
+  let calls = 0;
+  const aiService = {
+    async chat(messages: Message[]) {
+      return this.chatStream(messages);
+    },
+    async chatStream(messages: Message[]) {
+      receivedMessages.push(cloneMessages(messages));
+      calls++;
+      if (calls === 1) {
+        return makeToolResponse(toolCall);
+      }
+      throw new Error('API错误 (500): 500 {"type":"error","error":{"type":"api_error","message":"input_new_sensitive, messages[86] content[3] image is sensitive, please check your input (1026)"}}');
+    },
+  };
+  const toolExecutor = new MockToolExecutor(
+    [{
+      name: 'send_text',
+      description: 'send visible message',
+      transcriptMode: 'outbound_message',
+      parameters: {
+        type: 'object',
+        properties: {
+          text: { type: 'string' },
+        },
+        required: ['text'],
+      },
+    }],
+    { send_text: '消息已发送' },
+  );
+  const runner = new ConversationRunner(aiService as any, toolExecutor, {
+    stream: true,
+    enableCompression: false,
+    toolExecutionContext: {
+      surface: 'catscompany',
+      channel: {
+        chatId: 'p2p_1_2',
+        reply: async (_chatId: string, text: string) => {
+          sentReplies.push(text);
+        },
+      },
+    } as any,
+  });
+
+  const result = await runner.run([{ role: 'user', content: '读图后分段发结果' }]);
+
+  assert.equal(calls, 2);
+  assert.equal(result.finalResponseVisible, true);
+  assert.equal(result.response, MODEL_IMAGE_SAFETY_MESSAGE);
+  assert.equal(
+    result.messages.some(message => message.role === 'assistant' && message.content === MODEL_IMAGE_SAFETY_MESSAGE),
+    true,
+  );
+  assert.equal(
+    result.messages.some(message => message.role === 'assistant' && message.content === '我先把前半段发给你。'),
+    true,
+  );
+  assert.equal(receivedMessages.length, 2);
+  assert.deepEqual(sentReplies, [], 'CatsCompany outer adapter sends visible result, runner must not double-send');
+});
+
+test('runner replies image safety errors directly on non-CatsCompany message surfaces', async () => {
+  const sentReplies: string[] = [];
+  const aiService = {
+    async chat() {
+      throw new Error('API错误 (500): {"error":{"message":"input_new_sensitive, messages[3] content[1] image is sensitive"}}');
+    },
+    async chatStream() {
+      throw new Error('API错误 (500): {"error":{"message":"input_new_sensitive, messages[3] content[1] image is sensitive"}}');
+    },
+  };
+  const runner = new ConversationRunner(aiService as any, new MockToolExecutor([], {}), {
+    stream: true,
+    enableCompression: false,
+    toolExecutionContext: {
+      surface: 'feishu',
+      channel: {
+        chatId: 'chat_1',
+        reply: async (_chatId: string, text: string) => {
+          sentReplies.push(text);
+        },
+      },
+    } as any,
+  });
+
+  const result = await runner.run([{ role: 'user', content: '看图' }]);
+
+  assert.equal(result.finalResponseVisible, true);
+  assert.equal(result.response, MODEL_IMAGE_SAFETY_MESSAGE);
+  assert.deepEqual(sentReplies, [MODEL_IMAGE_SAFETY_MESSAGE]);
+});
+
+test('image safety classifier requires image evidence', () => {
+  assert.equal(
+    isModelImageSafetyError(new Error('API错误 (500): {"message":"input_new_sensitive, text is sensitive"}')),
+    false,
+  );
+  assert.equal(
+    isModelImageSafetyError(new Error('API错误 (500): {"message":"input_new_sensitive, messages[86] content[3] image is sensitive"}')),
+    true,
   );
 });
 

--- a/tests/provider-error-log-sanitizer.test.ts
+++ b/tests/provider-error-log-sanitizer.test.ts
@@ -1,0 +1,44 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  classifyProviderErrorForLog,
+  formatProviderErrorForLog,
+  sanitizeProviderErrorMessageForLog,
+} from '../src/utils/provider-error-log-sanitizer';
+
+test('provider error log sanitizer redacts secrets and network details', () => {
+  const error = new Error(
+    'anthropic: MaxRetriesExceededError: HTTPSConnectionPool(host=api.anthropic.com, host=\'173.252.107.94\', port=443). '
+    + 'Max retries exceeded with url: https://api.anthropic.com/v1/messages?api_key=super-secret '
+    + 'Authorization: Bearer sk-provider-secret-token and x_api_key=another-secret '
+    + 'request body contains sk-bf-1234567890abcdef',
+  );
+
+  const sanitized = sanitizeProviderErrorMessageForLog(error);
+
+  assert.match(sanitized, /host=\[redacted-host\]/);
+  assert.match(sanitized, /\[redacted-url\]/);
+  assert.match(sanitized, /Authorization: \[redacted-token\]/);
+  assert.doesNotMatch(sanitized, /api\.anthropic\.com/);
+  assert.doesNotMatch(sanitized, /173\.252\.107\.94/);
+  assert.doesNotMatch(sanitized, /super-secret/);
+  assert.doesNotMatch(sanitized, /sk-provider-secret-token/);
+  assert.doesNotMatch(sanitized, /sk-bf-1234567890abcdef/);
+});
+
+test('provider error formatter returns a compact classified summary', () => {
+  const formatted = formatProviderErrorForLog({
+    status: 500,
+    error: {
+      type: 'api_error',
+      code: 'invalid_request_error',
+      message: 'input_new_sensitive, messages[86] content[3] image is sensitive, please check your input',
+    },
+  });
+
+  assert.match(formatted, /category=model_image_safety/);
+  assert.match(formatted, /status=500/);
+  assert.match(formatted, /type=api_error/);
+  assert.match(formatted, /code=invalid_request_error/);
+  assert.equal(classifyProviderErrorForLog(new Error('Connection error. ECONNRESET')), 'provider_connection');
+});


### PR DESCRIPTION
## 概述
- 识别 MiniMax M3 / 上游模型返回的图片安全拦截错误，并给出用户可见的收束提示
- 修复 message surface 已经发过工具/外发消息后，图片安全 500 被静默收束的问题
- 非 CatsCompany 入口由 runner 直接发送提示；CatsCompany 入口继续交给外层 adapter 统一发送，避免双发
- 收紧错误分类，避免裸 `input_new_sensitive` 文本敏感误判为图片问题

## 根因
在 message surface 中，runner 如果已经有外发消息送达，后续模型请求失败会直接返回不可见结果；MiniMax M3 对历史图片返回 `input_new_sensitive` 时，用户会看到前面工具/消息停住，却没有明确结束提示。

## 验证
- `npm.cmd run build`
- `node --import tsx tests/conversation-runner-transcript-normalization.test.ts`
- `npm.cmd run test:runtime`（489 passed / 2 skipped）
- `git diff --check HEAD^ HEAD`

## Review
- 已让子 agent 做只读 review；初审发现 Feishu/Weixin 发送路径和分类过宽风险，已修复
- 复审无阻塞问题，并补了 CatsCompany 不由 runner 双发的回归断言
