### PR TITLE
feat: add user device grant foundation

### DIFF
--- a/src/catscompany/client.ts
+++ b/src/catscompany/client.ts
@@ -12,7 +12,45 @@ export interface CatsClientConfig {
   apiKey: string;
   bodyId?: string;
   installationId?: string;
+  deviceRegistration?: CatsDeviceRegistration;
   httpBaseUrl?: string;
+}
+
+export interface CatsDeviceRegistration {
+  device_id: string;
+  display_name?: string;
+  body_id?: string;
+  installation_id?: string;
+  status?: 'online' | 'offline';
+  capabilities?: string[];
+}
+
+export interface CatsDeviceRpcError {
+  code: string;
+  message: string;
+}
+
+export interface CatsDeviceRpcMessage {
+  id?: string;
+  type: 'request' | 'result';
+  request_id: string;
+  grant_id?: string;
+  session_key?: string;
+  topic_id?: string;
+  topic_type?: string;
+  actor_user_id?: string;
+  agent_id?: string;
+  agent_body_id?: string;
+  device_id?: string;
+  device_body_id?: string;
+  device_installation_id?: string;
+  operation?: string;
+  tool_name?: string;
+  payload?: Record<string, unknown>;
+  result?: unknown;
+  error?: CatsDeviceRpcError;
+  created_at?: number;
+  expires_at?: number;
 }
 
 export interface MessageContext {
@@ -107,6 +145,7 @@ export class CatsClient extends EventEmitter {
   private msgId = 0;
   private closed = false;
   private pendingAcks = new Map<string, PendingAck>();
+  private pendingDeviceRpc = new Map<string, PendingDeviceRpc>();
   private pingTimer: NodeJS.Timeout | null = null;
   private pongTimer: NodeJS.Timeout | null = null;
   private reconnectAttempts = 0;
@@ -152,7 +191,14 @@ export class CatsClient extends EventEmitter {
 
     this.ws.on('open', () => {
       this.reconnectAttempts = 0;
-      this.send({ hi: { id: '1', ver: CATSCOMPANY_PROTOCOL_VERSION, ua: CATSCOMPANY_CLIENT_UA } });
+      this.send({
+        hi: {
+          id: '1',
+          ver: CATSCOMPANY_PROTOCOL_VERSION,
+          ua: CATSCOMPANY_CLIENT_UA,
+          device: this.config.deviceRegistration,
+        },
+      });
       this.startHeartbeat();
     });
 
@@ -177,6 +223,10 @@ export class CatsClient extends EventEmitter {
         undefined,
         { retryableWithHttp: this.supportsClientMessageDedupe }
       ));
+      this.rejectPendingDeviceRpc(new CatsSendError(
+        'timeout',
+        'WebSocket 在收到 Device RPC 结果前关闭'
+      ));
       if (!this.closed) this.scheduleReconnect();
     });
   }
@@ -194,6 +244,9 @@ export class CatsClient extends EventEmitter {
           && msg.ctrl.params.features.includes('client_msg_id');
         if (this.supportsClientMessageDedupe) {
           Logger.info('[CatsCompany] 服务端支持 client_msg_id 幂等发送');
+        }
+        if (Array.isArray(msg.ctrl.params?.features) && msg.ctrl.params.features.includes('device_rpc')) {
+          Logger.info('[CatsCompany] 服务端支持 device_rpc 远程设备传输');
         }
         this.emit('ready', { uid: this.uid, name: this.name });
         this.autoAcceptFriendRequests().catch(console.error);
@@ -214,6 +267,8 @@ export class CatsClient extends EventEmitter {
           }
         }
       }
+    } else if (msg.device_rpc) {
+      this.handleDeviceRpcMessage(msg.device_rpc);
     } else if (msg.data) {
       Logger.info(
         `[CatsCompany] 收到消息: topic=${msg.data.topic || '-'}, ` +
@@ -245,6 +300,45 @@ export class CatsClient extends EventEmitter {
         Logger.info(`[CatsCompany] 收到 presence: what=${msg.pres.what}, src=${msg.pres.src || '-'}`);
       }
     }
+  }
+
+  private handleDeviceRpcMessage(raw: any): void {
+    const message = normalizeDeviceRpcMessage(raw);
+    if (!message) {
+      Logger.warning('[CatsCompany] 收到无效 device_rpc 消息，已忽略');
+      return;
+    }
+    if (message.type === 'result') {
+      const pending = this.pendingDeviceRpc.get(message.request_id);
+      if (pending) {
+        if (!deviceRpcResultMatchesPending(message, pending.request)) {
+          clearTimeout(pending.timer);
+          this.pendingDeviceRpc.delete(message.request_id);
+          pending.reject(new CatsSendError(
+            'ack',
+            `Device RPC ${message.request_id} result scope does not match pending request`,
+            409
+          ));
+        } else if (pending.acknowledged) {
+          this.resolvePendingDeviceRpc(message.request_id, pending, message);
+        } else {
+          pending.result = message;
+        }
+      }
+      this.emit('device_rpc_result', message);
+      return;
+    }
+    this.emit('device_rpc_request', message);
+  }
+
+  private resolvePendingDeviceRpc(
+    requestID: string,
+    pending: PendingDeviceRpc,
+    result: CatsDeviceRpcMessage
+  ): void {
+    clearTimeout(pending.timer);
+    this.pendingDeviceRpc.delete(requestID);
+    pending.resolve(result);
   }
 
   async sendMessage(topic: string, text: string): Promise<number> {
@@ -287,21 +381,112 @@ export class CatsClient extends EventEmitter {
       },
     });
 
+    return this.sendEnvelopeWithAck(msgId, { pub }, {
+      clientMsgID,
+      retryableWithHttp: this.supportsClientMessageDedupe,
+      timeoutMessage: 'WebSocket 已发送消息，但 10 秒内没有收到 CatsCompany 服务器确认',
+    });
+  }
+
+  async sendDeviceRpcRequest(
+    request: Omit<CatsDeviceRpcMessage, 'id' | 'type'> & { request_id?: string },
+    timeoutMs = 60000
+  ): Promise<CatsDeviceRpcMessage> {
+    const requestID = request.request_id || buildDeviceRpcRequestID();
+    if (this.pendingDeviceRpc.has(requestID)) {
+      throw new CatsSendError('ack', `Device RPC request_id already pending: ${requestID}`, 409);
+    }
+    const msgId = `${++this.msgId}`;
+    const deviceRpc: CatsDeviceRpcMessage = {
+      ...request,
+      id: msgId,
+      type: 'request',
+      request_id: requestID,
+    };
+
+    const resultPromise = new Promise<CatsDeviceRpcMessage>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pendingDeviceRpc.delete(requestID);
+        reject(new CatsSendError(
+          'timeout',
+          `Device RPC ${requestID} 在 ${timeoutMs}ms 内没有收到设备结果`
+        ));
+      }, timeoutMs);
+      this.pendingDeviceRpc.set(requestID, {
+        request: deviceRpc,
+        resolve,
+        reject,
+        timer,
+        acknowledged: false,
+      });
+    });
+
+    try {
+      await this.sendEnvelopeWithAck(msgId, { device_rpc: deviceRpc }, {
+        timeoutMessage: 'WebSocket 已发送 Device RPC 请求，但 10 秒内没有收到 CatsCompany 服务器确认',
+      });
+    } catch (err) {
+      const pending = this.pendingDeviceRpc.get(requestID);
+      if (pending) {
+        clearTimeout(pending.timer);
+        this.pendingDeviceRpc.delete(requestID);
+        throw err;
+      }
+      throw err;
+    }
+
+    const pending = this.pendingDeviceRpc.get(requestID);
+    if (pending) {
+      pending.acknowledged = true;
+      if (pending.result) {
+        this.resolvePendingDeviceRpc(requestID, pending, pending.result);
+      }
+    }
+    return resultPromise;
+  }
+
+  async sendDeviceRpcResult(result: Omit<CatsDeviceRpcMessage, 'id' | 'type'>): Promise<void> {
+    const requestID = String(result.request_id || '').trim();
+    if (!requestID) {
+      throw new Error('Device RPC result request_id is required');
+    }
+    const msgId = `${++this.msgId}`;
+    await this.sendEnvelopeWithAck(msgId, {
+      device_rpc: {
+        ...result,
+        id: msgId,
+        type: 'result',
+        request_id: requestID,
+      },
+    }, {
+      timeoutMessage: 'WebSocket 已发送 Device RPC 结果，但 10 秒内没有收到 CatsCompany 服务器确认',
+    });
+  }
+
+  private sendEnvelopeWithAck(
+    msgId: string,
+    envelope: Record<string, unknown>,
+    options: {
+      clientMsgID?: string;
+      retryableWithHttp?: boolean;
+      timeoutMessage?: string;
+    } = {}
+  ): Promise<number> {
     return new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
         this.pendingAcks.delete(msgId);
         this.forceReconnect('ack timeout');
         reject(new CatsSendError(
           'timeout',
-          'WebSocket 已发送消息，但 10 秒内没有收到 CatsCompany 服务器确认',
+          options.timeoutMessage || 'WebSocket 已发送消息，但 10 秒内没有收到 CatsCompany 服务器确认',
           undefined,
-          { clientMsgID, retryableWithHttp: this.supportsClientMessageDedupe }
+          { clientMsgID: options.clientMsgID, retryableWithHttp: options.retryableWithHttp ?? false }
         ));
       }, 10000);
 
-      this.pendingAcks.set(msgId, { resolve, reject, timer, clientMsgID });
+      this.pendingAcks.set(msgId, { resolve, reject, timer, clientMsgID: options.clientMsgID });
       try {
-        this.sendOrThrow({ pub });
+        this.sendOrThrow(envelope);
       } catch (err: any) {
         clearTimeout(timer);
         this.pendingAcks.delete(msgId);
@@ -343,11 +528,26 @@ export class CatsClient extends EventEmitter {
 
   async uploadFile(filePath: string, type: 'image' | 'file' = 'file'): Promise<UploadResult> {
     return uploadCatsLocalFile({
-      httpBaseUrl: this.config.httpBaseUrl || 'https://app.catsco.cc',
+      httpBaseUrl: this.httpBaseUrl(),
       filePath,
       type,
       authHeader: `ApiKey ${this.config.apiKey}`,
     });
+  }
+
+  async registerDevice(registration: CatsDeviceRegistration): Promise<unknown> {
+    const res = await fetch(`${this.httpBaseUrl()}/api/devices/register`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `ApiKey ${this.config.apiKey}`,
+      },
+      body: JSON.stringify(registration),
+    });
+    if (!res.ok) {
+      throw new Error(`CatsCompany device registration failed: ${res.status}`);
+    }
+    return res.json().catch(() => ({}));
   }
 
   async sendImage(topic: string, upload: UploadResult): Promise<number> {
@@ -413,6 +613,14 @@ export class CatsClient extends EventEmitter {
     }
   }
 
+  private rejectPendingDeviceRpc(err: Error): void {
+    for (const [requestID, pending] of this.pendingDeviceRpc.entries()) {
+      clearTimeout(pending.timer);
+      this.pendingDeviceRpc.delete(requestID);
+      pending.reject(err);
+    }
+  }
+
   private forceReconnect(reason: string): void {
     Logger.warning(`[CatsCompany] ${reason}，主动重建 WebSocket 连接`);
     if (this.ws?.readyState === WebSocket.OPEN || this.ws?.readyState === WebSocket.CONNECTING) {
@@ -465,10 +673,38 @@ export class CatsClient extends EventEmitter {
     }
   }
 
+  private httpBaseUrl(): string {
+    return this.config.httpBaseUrl || inferHttpBaseUrl(this.config.serverUrl) || 'https://app.catsco.cc';
+  }
+
   disconnect(): void {
     this.closed = true;
     this.stopHeartbeat();
     this.ws?.close();
+  }
+}
+
+interface PendingDeviceRpc {
+  request: CatsDeviceRpcMessage;
+  resolve: (message: CatsDeviceRpcMessage) => void;
+  reject: (err: Error) => void;
+  timer: NodeJS.Timeout;
+  acknowledged: boolean;
+  result?: CatsDeviceRpcMessage;
+}
+
+function inferHttpBaseUrl(serverUrl: string): string | undefined {
+  try {
+    const url = new URL(serverUrl);
+    if (url.protocol === 'ws:') url.protocol = 'http:';
+    else if (url.protocol === 'wss:') url.protocol = 'https:';
+    else if (url.protocol !== 'http:' && url.protocol !== 'https:') return undefined;
+    url.pathname = '';
+    url.search = '';
+    url.hash = '';
+    return url.toString().replace(/\/$/, '');
+  } catch {
+    return undefined;
   }
 }
 
@@ -477,4 +713,48 @@ function buildClientMessageID(): string {
     return `catsco-${crypto.randomUUID()}`;
   }
   return `catsco-${Date.now()}-${crypto.randomBytes(8).toString('hex')}`;
+}
+
+function buildDeviceRpcRequestID(): string {
+  if (typeof crypto.randomUUID === 'function') {
+    return `device_rpc_${crypto.randomUUID()}`;
+  }
+  return `device_rpc_${Date.now()}_${crypto.randomBytes(8).toString('hex')}`;
+}
+
+function normalizeDeviceRpcMessage(raw: any): CatsDeviceRpcMessage | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const type = String(raw.type || '').trim();
+  const requestID = String(raw.request_id || '').trim();
+  if ((type !== 'request' && type !== 'result') || !requestID) return undefined;
+  const message: CatsDeviceRpcMessage = {
+    ...raw,
+    type,
+    request_id: requestID,
+  };
+  if (raw.payload && typeof raw.payload === 'object' && !Array.isArray(raw.payload)) {
+    message.payload = raw.payload;
+  }
+  return message;
+}
+
+function deviceRpcResultMatchesPending(result: CatsDeviceRpcMessage, request: CatsDeviceRpcMessage): boolean {
+  return deviceRpcOptionalFieldMatches(result.grant_id, request.grant_id)
+    && deviceRpcOptionalFieldMatches(result.session_key, request.session_key)
+    && deviceRpcOptionalFieldMatches(result.topic_id, request.topic_id)
+    && deviceRpcOptionalFieldMatches(result.topic_type, request.topic_type)
+    && deviceRpcOptionalFieldMatches(result.actor_user_id, request.actor_user_id)
+    && deviceRpcOptionalFieldMatches(result.agent_id, request.agent_id)
+    && deviceRpcOptionalFieldMatches(result.agent_body_id, request.agent_body_id)
+    && deviceRpcOptionalFieldMatches(result.device_id, request.device_id)
+    && deviceRpcOptionalFieldMatches(result.device_body_id, request.device_body_id)
+    && deviceRpcOptionalFieldMatches(result.device_installation_id, request.device_installation_id)
+    && deviceRpcOptionalFieldMatches(result.operation, request.operation)
+    && deviceRpcOptionalFieldMatches(result.tool_name, request.tool_name);
+}
+
+function deviceRpcOptionalFieldMatches(actual: unknown, expected: unknown): boolean {
+  const actualText = typeof actual === 'string' ? actual.trim() : '';
+  const expectedText = typeof expected === 'string' ? expected.trim() : '';
+  return !actualText || !expectedText || actualText === expectedText;
 }

--- a/src/catscompany/device-grants.ts
+++ b/src/catscompany/device-grants.ts
@@ -1,0 +1,162 @@
+import type {
+  DeviceGrantOperation,
+  DeviceGrantStatus,
+  ExecutionScope,
+  IdentityTrustLevel,
+  MessageSource,
+  MessageTopicType,
+  ScopedDeviceGrant,
+} from '../types/session-identity';
+
+type UnknownRecord = Record<string, unknown>;
+
+export function extractCatsCoDeviceGrants(
+  metadata: Record<string, unknown> | undefined,
+  scope: ExecutionScope,
+): ScopedDeviceGrant[] | undefined {
+  if (scope.identityTrust !== 'server_canonical') return undefined;
+  const identity = asRecord(metadata?.catsco_identity);
+  const permissions = asRecord(identity?.permissions);
+  if (stringField(permissions, 'source') !== 'server_canonical_message') return undefined;
+
+  const rawGrants = arrayField(identity, 'device_grants')
+    ?? arrayField(permissions, 'device_grants');
+  if (!rawGrants || rawGrants.length === 0) return undefined;
+
+  const grants = rawGrants
+    .map(normalizeDeviceGrant)
+    .filter((grant): grant is ScopedDeviceGrant => Boolean(grant))
+    .filter(grant => grantMatchesScope(grant, scope));
+
+  return grants.length > 0 ? grants : undefined;
+}
+
+function normalizeDeviceGrant(value: unknown): ScopedDeviceGrant | undefined {
+  const record = asRecord(value);
+  if (!record) return undefined;
+  if (stringField(record, 'kind') !== 'user_device_grant') return undefined;
+  const source = normalizeSource(stringField(record, 'source'));
+  if (source !== 'catscompany') return undefined;
+
+  const grantId = stringField(record, 'grantId') || stringField(record, 'grant_id');
+  const deviceId = stringField(record, 'deviceId') || stringField(record, 'device_id');
+  const ownerUserId = stringField(record, 'ownerUserId') || stringField(record, 'owner_user_id');
+  const sessionKey = stringField(record, 'sessionKey') || stringField(record, 'session_key');
+  const topicId = stringField(record, 'topicId') || stringField(record, 'topic_id');
+  const actorUserId = stringField(record, 'actorUserId') || stringField(record, 'actor_user_id');
+  const operations = normalizeOperations(record.operations);
+  const createdAt = numberField(record, 'createdAt') ?? numberField(record, 'created_at');
+  const expiresAt = numberField(record, 'expiresAt') ?? numberField(record, 'expires_at');
+  if (!grantId || !deviceId || !ownerUserId || !sessionKey || !topicId || !actorUserId) return undefined;
+  if (operations.length === 0 || createdAt === undefined || expiresAt === undefined) return undefined;
+
+  return pruneUndefined({
+    kind: 'user_device_grant',
+    source,
+    grantId,
+    status: normalizeStatus(stringField(record, 'status')),
+    identityTrust: normalizeTrust(stringField(record, 'identityTrust') || stringField(record, 'identity_trust')),
+    identitySource: stringField(record, 'identitySource') || stringField(record, 'identity_source'),
+    deviceId,
+    deviceDisplayName: stringField(record, 'deviceDisplayName') || stringField(record, 'device_display_name'),
+    deviceBodyId: stringField(record, 'deviceBodyId') || stringField(record, 'device_body_id'),
+    deviceInstallationId: stringField(record, 'deviceInstallationId') || stringField(record, 'device_installation_id'),
+    ownerUserId,
+    sessionKey,
+    topicId,
+    topicType: normalizeTopicType(stringField(record, 'topicType') || stringField(record, 'topic_type')),
+    actorUserId,
+    agentId: stringField(record, 'agentId') || stringField(record, 'agent_id'),
+    agentBodyId: stringField(record, 'agentBodyId') || stringField(record, 'agent_body_id'),
+    operations,
+    createdAt,
+    expiresAt,
+  }) as ScopedDeviceGrant;
+}
+
+function grantMatchesScope(grant: ScopedDeviceGrant, scope: ExecutionScope): boolean {
+  return grant.status === 'active'
+    && grant.identityTrust === 'server_canonical'
+    && grant.source === scope.source
+    && grant.sessionKey === scope.sessionKey
+    && grant.topicId === scope.topicId
+    && grant.topicType === scope.topicType
+    && grant.actorUserId === scope.actorUserId
+    && grant.ownerUserId === scope.actorUserId
+    && grant.agentId === scope.agentId
+    && grant.agentBodyId === scope.agentBodyId;
+}
+
+function normalizeOperations(value: unknown): DeviceGrantOperation[] {
+  if (!Array.isArray(value)) return [];
+  const unique = new Set<DeviceGrantOperation>();
+  for (const item of value) {
+    if (isDeviceGrantOperation(item)) unique.add(item);
+  }
+  return [...unique];
+}
+
+function isDeviceGrantOperation(value: unknown): value is DeviceGrantOperation {
+  return value === 'read_file'
+    || value === 'write_file'
+    || value === 'edit_file'
+    || value === 'send_file'
+    || value === 'execute_shell'
+    || value === 'glob'
+    || value === 'grep'
+    || value === 'browser_control'
+    || value === 'desktop_control';
+}
+
+function normalizeSource(value: string | undefined): MessageSource {
+  return value === 'catscompany' ? 'catscompany' : 'unknown';
+}
+
+function normalizeStatus(value: string | undefined): DeviceGrantStatus {
+  return value === 'revoked' ? 'revoked' : 'active';
+}
+
+function normalizeTrust(value: string | undefined): IdentityTrustLevel {
+  return value === 'server_canonical' ? 'server_canonical' : 'untrusted';
+}
+
+function normalizeTopicType(value: string | undefined): MessageTopicType {
+  if (value === 'p2p' || value === 'group') return value;
+  return 'unknown';
+}
+
+function asRecord(value: unknown): UnknownRecord | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  return value as UnknownRecord;
+}
+
+function arrayField(record: UnknownRecord | undefined, key: string): unknown[] | undefined {
+  const value = record?.[key];
+  return Array.isArray(value) ? value : undefined;
+}
+
+function stringField(record: UnknownRecord | undefined, key: string): string | undefined {
+  const value = record?.[key];
+  if (typeof value !== 'string') return undefined;
+  const text = value.trim();
+  return text || undefined;
+}
+
+function numberField(record: UnknownRecord, key: string): number | undefined {
+  const value = record[key];
+  if (typeof value === 'number' && Number.isFinite(value) && value >= 0) return value;
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed) && parsed >= 0) return parsed;
+  }
+  return undefined;
+}
+
+function pruneUndefined<T>(value: T): T {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return value;
+  const record = value as Record<string, unknown>;
+  for (const key of Object.keys(record)) {
+    if (record[key] === undefined) delete record[key];
+  }
+  return value;
+}

--- a/src/catscompany/device-selection.ts
+++ b/src/catscompany/device-selection.ts
@@ -1,0 +1,174 @@
+import type {
+  DeviceGrantOperation,
+  DeviceSelectionCandidate,
+  DeviceSelectionStatus,
+  ExecutionScope,
+  MessageSource,
+  MessageTopicType,
+  ScopedDeviceSelection,
+} from '../types/session-identity';
+
+type UnknownRecord = Record<string, unknown>;
+
+export function extractCatsCoDeviceSelection(
+  metadata: Record<string, unknown> | undefined,
+  scope: ExecutionScope,
+): ScopedDeviceSelection | undefined {
+  if (scope.identityTrust !== 'server_canonical') return undefined;
+  const identity = asRecord(metadata?.catsco_identity);
+  const permissions = asRecord(identity?.permissions);
+  if (stringField(permissions, 'source') !== 'server_canonical_message') return undefined;
+
+  const rawSelection = asRecord(identity?.device_selection) ?? asRecord(permissions?.device_selection);
+  if (!rawSelection) return undefined;
+
+  const selection = normalizeDeviceSelection(rawSelection, scope);
+  if (!selectionMatchesScope(selection, scope)) return undefined;
+  return selection;
+}
+
+function normalizeDeviceSelection(record: UnknownRecord, scope: ExecutionScope): ScopedDeviceSelection | undefined {
+  if (stringField(record, 'kind') !== 'user_device_selection') return undefined;
+  const source = normalizeSource(stringField(record, 'source'));
+  if (source !== 'catscompany') return undefined;
+
+  const selectedDevice = asRecord(record.selectedDevice) ?? asRecord(record.selected_device);
+  const selectedDeviceId = stringField(record, 'selectedDeviceId')
+    || stringField(record, 'selected_device_id')
+    || stringField(selectedDevice, 'deviceId')
+    || stringField(selectedDevice, 'device_id');
+  const status = normalizeStatus(stringField(record, 'status'), selectedDeviceId);
+  if (status === 'selected' && !selectedDeviceId) return undefined;
+
+  const sessionKey = stringField(record, 'sessionKey') || stringField(record, 'session_key');
+  const topicId = stringField(record, 'topicId') || stringField(record, 'topic_id');
+  const actorUserId = stringField(record, 'actorUserId') || stringField(record, 'actor_user_id');
+  if (!sessionKey || !topicId || !actorUserId) return undefined;
+
+  return pruneUndefined({
+    kind: 'user_device_selection',
+    source,
+    status,
+    selectionSource: stringField(record, 'selectionSource') || stringField(record, 'selection_source'),
+    sessionKey,
+    topicId,
+    topicType: normalizeTopicType(stringField(record, 'topicType') || stringField(record, 'topic_type')),
+    actorUserId,
+    agentId: stringField(record, 'agentId') || stringField(record, 'agent_id'),
+    identityTrust: scope.identityTrust,
+    identitySource: 'metadata.catsco_identity',
+    selectedDeviceId,
+    selectedDeviceDisplayName: stringField(record, 'selectedDeviceDisplayName')
+      || stringField(record, 'selected_device_display_name')
+      || stringField(selectedDevice, 'displayName')
+      || stringField(selectedDevice, 'display_name'),
+    selectedDeviceBodyId: stringField(record, 'selectedDeviceBodyId')
+      || stringField(record, 'selected_device_body_id')
+      || stringField(selectedDevice, 'bodyId')
+      || stringField(selectedDevice, 'body_id'),
+    selectedDeviceInstallationId: stringField(record, 'selectedDeviceInstallationId')
+      || stringField(record, 'selected_device_installation_id')
+      || stringField(selectedDevice, 'installationId')
+      || stringField(selectedDevice, 'installation_id'),
+    selectedDeviceOperations: normalizeOperations(selectedDevice?.operations ?? record.selectedDeviceOperations ?? record.selected_device_operations),
+    candidates: normalizeCandidates(record.candidates),
+    candidateCount: numberField(record, 'candidateCount') ?? numberField(record, 'candidate_count'),
+    createdAt: numberField(record, 'createdAt') ?? numberField(record, 'created_at'),
+  }) as ScopedDeviceSelection;
+}
+
+function selectionMatchesScope(selection: ScopedDeviceSelection | undefined, scope: ExecutionScope): selection is ScopedDeviceSelection {
+  return Boolean(selection)
+    && selection!.source === scope.source
+    && selection!.sessionKey === scope.sessionKey
+    && selection!.topicId === scope.topicId
+    && selection!.topicType === scope.topicType
+    && selection!.actorUserId === scope.actorUserId
+    && selection!.agentId === scope.agentId;
+}
+
+function normalizeCandidates(value: unknown): DeviceSelectionCandidate[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const candidates = value
+    .map(item => {
+      const record = asRecord(item);
+      if (!record) return undefined;
+      const deviceId = stringField(record, 'deviceId') || stringField(record, 'device_id');
+      if (!deviceId) return undefined;
+      return pruneUndefined({
+        deviceId,
+        displayName: stringField(record, 'displayName') || stringField(record, 'display_name'),
+        operations: normalizeOperations(record.operations),
+        lastSeenAt: numberField(record, 'lastSeenAt') ?? numberField(record, 'last_seen_at'),
+      }) as DeviceSelectionCandidate;
+    })
+    .filter((item): item is DeviceSelectionCandidate => Boolean(item));
+  return candidates.length > 0 ? candidates : undefined;
+}
+
+function normalizeOperations(value: unknown): DeviceGrantOperation[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const unique = new Set<DeviceGrantOperation>();
+  for (const item of value) {
+    if (isDeviceGrantOperation(item)) unique.add(item);
+  }
+  return unique.size > 0 ? [...unique] : undefined;
+}
+
+function isDeviceGrantOperation(value: unknown): value is DeviceGrantOperation {
+  return value === 'read_file'
+    || value === 'write_file'
+    || value === 'edit_file'
+    || value === 'send_file'
+    || value === 'execute_shell'
+    || value === 'glob'
+    || value === 'grep'
+    || value === 'browser_control'
+    || value === 'desktop_control';
+}
+
+function normalizeStatus(value: string | undefined, selectedDeviceId?: string): DeviceSelectionStatus {
+  if (value === 'needs_selection' || value === 'unavailable') return value;
+  if (value === 'selected' || selectedDeviceId) return 'selected';
+  return 'needs_selection';
+}
+
+function normalizeSource(value: string | undefined): MessageSource {
+  return value === 'catscompany' ? 'catscompany' : 'unknown';
+}
+
+function normalizeTopicType(value: string | undefined): MessageTopicType {
+  if (value === 'p2p' || value === 'group') return value;
+  return 'unknown';
+}
+
+function asRecord(value: unknown): UnknownRecord | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  return value as UnknownRecord;
+}
+
+function stringField(record: UnknownRecord | undefined, key: string): string | undefined {
+  const value = record?.[key];
+  if (typeof value !== 'string') return undefined;
+  const text = value.trim();
+  return text || undefined;
+}
+
+function numberField(record: UnknownRecord | undefined, key: string): number | undefined {
+  const value = record?.[key];
+  if (typeof value === 'number' && Number.isFinite(value) && value >= 0) return value;
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed) && parsed >= 0) return parsed;
+  }
+  return undefined;
+}
+
+function pruneUndefined<T>(value: T): T {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return value;
+  const record = value as Record<string, unknown>;
+  for (const key of Object.keys(record)) {
+    if (record[key] === undefined) delete record[key];
+  }
+  return value;
+}

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -1,23 +1,34 @@
-import { CatsClient, MessageContext } from './client';
+import { CatsClient, MessageContext, type CatsDeviceRpcMessage } from './client';
 import { CatsCompanyConfig, ParsedCatsMessage, CatsFileInfo } from './types';
 import { MessageSender } from './message-sender';
 import { extractContentBlocks } from './content-blocks';
 import { createCatsCoMessageEnvelope, createExecutionScope } from './message-envelope';
 import { createCatsCoAttachmentGrant, createCatsCoLocalDeviceGrant } from './local-file-grants';
+import { extractCatsCoDeviceGrants } from './device-grants';
+import { extractCatsCoDeviceSelection } from './device-selection';
 import { MessageSessionManager } from '../core/message-session-manager';
 import { AgentServices, BUSY_MESSAGE, RuntimeFeedbackInput, SessionCallbacks } from '../core/agent-session';
 import { Logger } from '../utils/logger';
 import { SubAgentManager } from '../core/sub-agent-manager';
 import type { SubAgentInfo } from '../core/sub-agent-session';
-import { ChannelCallbacks } from '../types/tool';
+import { ChannelCallbacks, DeviceRpcTransport, ToolErrorCode, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import { ContentBlock } from '../types';
 import type { PendingUserInput } from '../core/conversation-runner';
-import type { ScopedLocalDeviceGrant, ScopedLocalFileGrant } from '../types/session-identity';
+import type { DeviceGrantOperation, ExecutionScope, ScopedDeviceGrant, ScopedDeviceSelection, ScopedLocalDeviceGrant, ScopedLocalFileGrant } from '../types/session-identity';
 import { AdapterRuntimeBundle, createAdapterRuntime } from '../runtime/adapter-runtime';
 import { randomUUID } from 'crypto';
+import { hostname } from 'os';
 import { ConfigManager } from '../utils/config';
 import { isPrimaryModelVisionCapable } from '../utils/model-capabilities';
 import { createCatsCoSessionRoute } from '../core/session-router';
+import { ReadTool } from '../tools/read-tool';
+import { GlobTool } from '../tools/glob-tool';
+import { GrepTool } from '../tools/grep-tool';
+import {
+  isRemoteReadonlyTool,
+  normalizeDeviceRpcToolResultForTransport,
+  normalizeDeviceRpcToolResultPayload,
+} from '../tools/device-rpc-tool';
 
 interface PendingAttachment {
   fileName: string;
@@ -42,6 +53,8 @@ interface QueuedMessage {
   senderId: string;
   seq: number;
   executionScope: ParsedCatsMessage['executionScope'];
+  deviceGrants?: ScopedDeviceGrant[];
+  deviceSelection?: ScopedDeviceSelection;
   localFileGrants?: ScopedLocalFileGrant[];
   receivedAt: number;
   source?: 'user' | 'subagent_feedback';
@@ -50,6 +63,8 @@ interface QueuedMessage {
 
 const PENDING_ANSWER_TIMEOUT_MS = 120_000;
 const TYPING_HEARTBEAT_INTERVAL_MS = 5_000;
+const DEVICE_REGISTRATION_REFRESH_MS = 120_000;
+const DEVICE_RPC_DEFAULT_TTL_MS = 60_000;
 const HIDDEN_CATS_TOOL_PROGRESS = new Set([
   'send_text',
   'send_file',
@@ -99,13 +114,35 @@ export class CatsCompanyBot {
   private runtime: AdapterRuntimeBundle;
   private runtimeProfile: AdapterRuntimeBundle['profile'];
   private localDeviceGrant?: ScopedLocalDeviceGrant;
+  private deviceRegistrationTimer?: ReturnType<typeof setInterval>;
+  private readonly deviceRegistration?: {
+    device_id: string;
+    display_name?: string;
+    body_id?: string;
+    installation_id?: string;
+    status: 'online';
+    capabilities: string[];
+  };
 
   constructor(config: CatsCompanyConfig) {
+    const localDeviceId = config.installationId || config.bodyId;
+    const deviceRegistration = localDeviceId
+      ? {
+          device_id: localDeviceId,
+          display_name: config.deviceName || process.env.COMPUTERNAME || process.env.HOSTNAME || hostname() || localDeviceId,
+          body_id: config.bodyId,
+          installation_id: config.installationId || config.bodyId,
+          status: 'online' as const,
+          capabilities: ['read_file', 'glob', 'grep'],
+        }
+      : undefined;
+
     this.bot = new CatsClient({
       serverUrl: config.serverUrl,
       apiKey: config.apiKey,
       bodyId: config.bodyId,
       installationId: config.installationId,
+      deviceRegistration,
       httpBaseUrl: config.httpBaseUrl,
     });
 
@@ -115,6 +152,7 @@ export class CatsCompanyBot {
       installationId: config.installationId,
       deviceId: config.installationId || config.bodyId,
     });
+    this.deviceRegistration = deviceRegistration;
 
     const runtime = createCatsCompanyRuntime(config.sessionTTL);
     this.runtime = runtime;
@@ -150,10 +188,18 @@ export class CatsCompanyBot {
       this.runtimeProfile.prompt.displayName = botName;
       process.env.CURRENT_AGENT_DISPLAY_NAME = botName;
       Logger.success(`CatsCo agent 已连接，uid=${info.uid}, name=${botName}`);
+      this.registerCurrentDevice().catch((err: any) => {
+        Logger.warning(`CatsCo 设备注册失败，继续保持聊天连接: ${err?.message || err}`);
+      });
+      this.startDeviceRegistrationRefresh();
     });
 
     this.bot.on('message', async (ctx: MessageContext) => {
       await this.onMessage(ctx);
+    });
+
+    this.bot.on('device_rpc_request', async (request: CatsDeviceRpcMessage) => {
+      await this.handleDeviceRpcRequest(request);
     });
 
     this.bot.on('error', (err: Error) => {
@@ -162,6 +208,291 @@ export class CatsCompanyBot {
 
     this.bot.connect();
     Logger.success('CatsCo agent 已启动，等待消息...');
+  }
+
+  private async registerCurrentDevice(): Promise<void> {
+    if (!this.deviceRegistration?.device_id) return;
+    await this.bot.registerDevice(this.deviceRegistration);
+    Logger.info(`[CatsCompany] 已注册本机设备能力: device=${this.deviceRegistration.device_id}, capabilities=${this.deviceRegistration.capabilities.join(',')}`);
+  }
+
+  private startDeviceRegistrationRefresh(): void {
+    if (!this.deviceRegistration?.device_id) return;
+    this.stopDeviceRegistrationRefresh();
+    this.deviceRegistrationTimer = setInterval(() => {
+      this.registerCurrentDevice().catch((err: any) => {
+        Logger.warning(`CatsCo 设备状态刷新失败: ${err?.message || err}`);
+      });
+    }, DEVICE_REGISTRATION_REFRESH_MS);
+    (this.deviceRegistrationTimer as any).unref?.();
+  }
+
+  private stopDeviceRegistrationRefresh(): void {
+    if (!this.deviceRegistrationTimer) return;
+    clearInterval(this.deviceRegistrationTimer);
+    this.deviceRegistrationTimer = undefined;
+  }
+
+  private buildDeviceRpcTransport(): DeviceRpcTransport {
+    return {
+      executeTool: async ({ toolName, operation, args, grant, timeoutMs }) => {
+        const response = await this.bot.sendDeviceRpcRequest({
+          request_id: `device_rpc_${randomUUID()}`,
+          grant_id: grant.grantId,
+          session_key: grant.sessionKey,
+          topic_id: grant.topicId,
+          topic_type: grant.topicType,
+          actor_user_id: grant.actorUserId,
+          agent_id: grant.agentId,
+          agent_body_id: grant.agentBodyId,
+          device_id: grant.deviceId,
+          device_body_id: grant.deviceBodyId,
+          device_installation_id: grant.deviceInstallationId,
+          operation,
+          tool_name: toolName,
+          payload: { args },
+          expires_at: grant.expiresAt,
+        }, timeoutMs);
+
+        if (response.error) {
+          return {
+            ok: false,
+            errorCode: this.mapDeviceRpcToolErrorCode(response.error.code),
+            message: response.error.message || response.error.code || '远程设备工具执行失败。',
+            retryable: this.isRetryableDeviceRpcError(response.error.code),
+          };
+        }
+        return normalizeDeviceRpcToolResultPayload(response.result);
+      },
+    };
+  }
+
+  private async handleDeviceRpcRequest(request: CatsDeviceRpcMessage): Promise<void> {
+    const requestID = request.request_id;
+    if (!requestID) return;
+
+    const validationError = this.validateDeviceRpcToolRequest(request);
+    const result = validationError ? undefined : await this.executeLocalDeviceRpcTool(request);
+    const error = validationError || (!result || result.ok
+      ? undefined
+      : {
+          code: result.errorCode || 'tool_execution_error',
+          message: result.message,
+        });
+
+    try {
+      await this.bot.sendDeviceRpcResult({
+        request_id: requestID,
+        grant_id: request.grant_id,
+        session_key: request.session_key,
+        topic_id: request.topic_id,
+        topic_type: request.topic_type,
+        actor_user_id: request.actor_user_id,
+        agent_id: request.agent_id,
+        agent_body_id: request.agent_body_id,
+        device_id: this.localDeviceGrant?.deviceId || request.device_id,
+        device_body_id: this.localDeviceGrant?.bodyId || request.device_body_id,
+        device_installation_id: this.localDeviceGrant?.installationId || request.device_installation_id,
+        operation: request.operation,
+        tool_name: request.tool_name,
+        result: error || !result ? undefined : normalizeDeviceRpcToolResultForTransport(result),
+        error,
+      });
+    } catch (err: any) {
+      Logger.warning(`[CatsCompany] Device RPC result 发送失败: request=${requestID}, error=${err?.message || err}`);
+    }
+  }
+
+  private async executeLocalDeviceRpcTool(request: CatsDeviceRpcMessage): Promise<ToolExecutionResult> {
+    const operation = this.normalizeDeviceRpcReadonlyOperation(request.operation);
+    const toolName = String(request.tool_name || operation || '').trim();
+    if (!operation || !isRemoteReadonlyTool(toolName, operation)) {
+      return {
+        ok: false,
+        errorCode: 'PERMISSION_DENIED',
+        message: `Device RPC 不允许执行 ${toolName || request.operation || 'unknown'}。`,
+      };
+    }
+
+    const context = this.buildDeviceRpcToolContext(request, operation);
+    const args = this.extractDeviceRpcToolArgs(request.payload);
+    switch (operation) {
+      case 'read_file':
+        return new ReadTool().execute(args, context);
+      case 'glob':
+        return new GlobTool().execute(args, context);
+      case 'grep':
+        return new GrepTool().execute(args, context);
+      default:
+        return {
+          ok: false,
+          errorCode: 'PERMISSION_DENIED',
+          message: `Device RPC 不允许执行 ${operation}。`,
+        };
+    }
+  }
+
+  private buildDeviceRpcToolContext(
+    request: CatsDeviceRpcMessage,
+    operation: DeviceGrantOperation,
+  ): ToolExecutionContext {
+    const topicType = request.topic_type === 'group' || request.topic_type === 'p2p'
+      ? request.topic_type
+      : 'unknown';
+    const executionScope: ExecutionScope = {
+      source: 'catscompany',
+      sessionKey: String(request.session_key || ''),
+      topicId: String(request.topic_id || ''),
+      topicType,
+      actorUserId: String(request.actor_user_id || ''),
+      agentId: request.agent_id,
+      agentBodyId: request.agent_body_id,
+      permissionsSource: 'device_rpc_forward',
+      identityTrust: 'server_canonical',
+      isTrusted: true,
+    };
+    const now = Date.now();
+    const grant: ScopedDeviceGrant = {
+      kind: 'user_device_grant',
+      source: 'catscompany',
+      grantId: String(request.grant_id || ''),
+      status: 'active',
+      identityTrust: 'server_canonical',
+      identitySource: 'device_rpc_forward',
+      deviceId: String(request.device_id || this.localDeviceGrant?.deviceId || ''),
+      deviceBodyId: request.device_body_id || this.localDeviceGrant?.bodyId,
+      deviceInstallationId: request.device_installation_id || this.localDeviceGrant?.installationId,
+      ownerUserId: executionScope.actorUserId,
+      sessionKey: executionScope.sessionKey,
+      topicId: executionScope.topicId,
+      topicType,
+      actorUserId: executionScope.actorUserId,
+      agentId: executionScope.agentId,
+      agentBodyId: executionScope.agentBodyId,
+      operations: [operation],
+      createdAt: typeof request.created_at === 'number' ? request.created_at : now,
+      expiresAt: typeof request.expires_at === 'number' ? request.expires_at : now + DEVICE_RPC_DEFAULT_TTL_MS,
+    };
+    const deviceSelection: ScopedDeviceSelection = {
+      kind: 'user_device_selection',
+      source: 'catscompany',
+      status: 'selected',
+      selectionSource: 'device_rpc_forward',
+      sessionKey: executionScope.sessionKey,
+      topicId: executionScope.topicId,
+      topicType,
+      actorUserId: executionScope.actorUserId,
+      agentId: executionScope.agentId,
+      identityTrust: 'server_canonical',
+      identitySource: 'device_rpc_forward',
+      selectedDeviceId: grant.deviceId,
+      selectedDeviceBodyId: grant.deviceBodyId,
+      selectedDeviceInstallationId: grant.deviceInstallationId,
+      selectedDeviceOperations: [operation],
+      createdAt: now,
+    };
+    const workingDirectory = process.cwd();
+    return {
+      workingDirectory,
+      workspaceRoot: workingDirectory,
+      conversationHistory: [],
+      sessionId: executionScope.sessionKey,
+      surface: 'catscompany',
+      permissionProfile: 'strict',
+      executionScope,
+      localDeviceGrant: this.localDeviceGrant,
+      deviceGrants: [grant],
+      deviceSelection,
+    };
+  }
+
+  private validateDeviceRpcToolRequest(request: CatsDeviceRpcMessage): { code: string; message: string } | undefined {
+    const targetError = this.validateDeviceRpcTarget(request);
+    if (targetError) return targetError;
+
+    const operation = this.normalizeDeviceRpcReadonlyOperation(request.operation);
+    const toolName = String(request.tool_name || operation || '').trim();
+    if (!operation || !isRemoteReadonlyTool(toolName, operation)) {
+      return { code: 'unsupported_operation', message: 'Device RPC only allows read_file, glob, and grep.' };
+    }
+
+    const requiredFields: Array<[keyof CatsDeviceRpcMessage, string]> = [
+      ['grant_id', 'grant_id'],
+      ['session_key', 'session_key'],
+      ['topic_id', 'topic_id'],
+      ['topic_type', 'topic_type'],
+      ['actor_user_id', 'actor_user_id'],
+      ['device_id', 'device_id'],
+    ];
+    for (const [field, label] of requiredFields) {
+      if (!String(request[field] || '').trim()) {
+        return { code: 'invalid_request', message: `Device RPC request missing ${label}.` };
+      }
+    }
+    if (typeof request.expires_at === 'number' && Date.now() > request.expires_at) {
+      return { code: 'request_expired', message: 'Device RPC request has expired.' };
+    }
+    return undefined;
+  }
+
+  private normalizeDeviceRpcReadonlyOperation(value: unknown): DeviceGrantOperation | undefined {
+    const operation = String(value || '').trim();
+    if (operation === 'read_file' || operation === 'glob' || operation === 'grep') {
+      return operation;
+    }
+    return undefined;
+  }
+
+  private extractDeviceRpcToolArgs(payload: unknown): Record<string, unknown> {
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return {};
+    const record = payload as Record<string, unknown>;
+    if (record.args && typeof record.args === 'object' && !Array.isArray(record.args)) {
+      return { ...(record.args as Record<string, unknown>) };
+    }
+    return { ...record };
+  }
+
+  private mapDeviceRpcToolErrorCode(code: unknown): ToolErrorCode {
+    const text = String(code || '').toLowerCase();
+    if (text.includes('permission') || text.includes('forbidden') || text.includes('mismatch') || text.includes('unsupported')) {
+      return 'PERMISSION_DENIED';
+    }
+    if (text.includes('timeout') || text.includes('expired')) {
+      return 'EXECUTION_TIMEOUT';
+    }
+    if (text.includes('not_found') || text.includes('offline') || text.includes('unavailable')) {
+      return 'TOOL_EXECUTION_ERROR';
+    }
+    return 'TOOL_EXECUTION_ERROR';
+  }
+
+  private isRetryableDeviceRpcError(code: unknown): boolean {
+    const text = String(code || '').toLowerCase();
+    return text.includes('timeout') || text.includes('offline') || text.includes('unavailable');
+  }
+
+  private validateDeviceRpcTarget(request: CatsDeviceRpcMessage): { code: string; message: string } | undefined {
+    if (!this.localDeviceGrant) {
+      return { code: 'device_not_bound', message: 'Current runtime is not bound to a CatsCo local device.' };
+    }
+    const checks: Array<[unknown, unknown, string]> = [
+      [request.device_id, this.localDeviceGrant.deviceId, 'device_id'],
+      [request.device_installation_id, this.localDeviceGrant.installationId, 'installation_id'],
+      [request.device_body_id, this.localDeviceGrant.bodyId, 'body_id'],
+    ];
+    let matchedAny = false;
+    for (const [requested, local, label] of checks) {
+      const requestedText = String(requested || '').trim();
+      if (!requestedText) continue;
+      const localText = String(local || '').trim();
+      if (!localText || requestedText !== localText) {
+        return { code: 'target_device_mismatch', message: `Device RPC target ${label} does not match this local runtime.` };
+      }
+      matchedAny = true;
+    }
+    return matchedAny
+      ? undefined
+      : { code: 'target_device_mismatch', message: 'Device RPC target does not match this local runtime.' };
   }
 
   // ─── 构建 ChannelCallbacks ──────────────────────
@@ -410,6 +741,8 @@ export class CatsCompanyBot {
         senderId: msg.senderId,
         seq: msg.seq,
         executionScope: msg.executionScope,
+        deviceGrants: msg.deviceGrants,
+        deviceSelection: msg.deviceSelection,
         localFileGrants,
         receivedAt: Date.now(),
         source: 'user',
@@ -433,12 +766,15 @@ export class CatsCompanyBot {
         channel,
         sessionRoute,
         executionScope: msg.executionScope,
-          localDeviceGrant: this.localDeviceGrant,
-          localFileGrants,
-          runtimeFeedback,
-          pendingUserInputProvider: () => this.consumeQueuedUserInput(key, msg.executionScope),
-          callbacks: this.buildSessionCallbacks(msg.topic),
-        });
+        localDeviceGrant: this.localDeviceGrant,
+        deviceGrants: msg.deviceGrants,
+        deviceSelection: msg.deviceSelection,
+        deviceRpc: this.buildDeviceRpcTransport(),
+        localFileGrants,
+        runtimeFeedback,
+        pendingUserInputProvider: () => this.consumeQueuedUserInput(key, msg.executionScope),
+        callbacks: this.buildSessionCallbacks(msg.topic),
+      });
 
       // 最终文本回复
       if (result.visibleToUser && result.text) {
@@ -545,6 +881,7 @@ export class CatsCompanyBot {
       metadata: ctx.metadata,
       botUid: this.botUid,
     });
+    const executionScope = createExecutionScope(envelope);
 
     return {
       topic: ctx.topic,
@@ -555,7 +892,9 @@ export class CatsCompanyBot {
       rawContent: ctx.content,
       metadata: ctx.metadata,
       envelope,
-      executionScope: createExecutionScope(envelope),
+      executionScope,
+      deviceGrants: extractCatsCoDeviceGrants(ctx.metadata, executionScope),
+      deviceSelection: extractCatsCoDeviceSelection(ctx.metadata, executionScope),
       file: files[0],
       files,
     };
@@ -598,6 +937,8 @@ export class CatsCompanyBot {
         callbacks: this.buildSessionCallbacks(topic),
         source: 'subagent_result',
         executionScope,
+        localDeviceGrant: this.localDeviceGrant,
+        deviceRpc: this.buildDeviceRpcTransport(),
       });
       if (result.text === BUSY_MESSAGE) {
         this.enqueueSubAgentFeedback(sessionKey, topic, senderId, text, executionScope);
@@ -802,11 +1143,16 @@ export class CatsCompanyBot {
           source: 'subagent_result',
           executionScope: msg.executionScope,
           localDeviceGrant: this.localDeviceGrant,
+          deviceSelection: msg.deviceSelection,
+          deviceRpc: this.buildDeviceRpcTransport(),
         })
         : await session.handleMessage(msg.userMessage, {
           channel,
           executionScope: msg.executionScope,
           localDeviceGrant: this.localDeviceGrant,
+          deviceGrants: msg.deviceGrants,
+          deviceSelection: msg.deviceSelection,
+          deviceRpc: this.buildDeviceRpcTransport(),
           runtimeFeedback: msg.runtimeFeedback,
           localFileGrants: msg.localFileGrants,
           pendingUserInputProvider: () => this.consumeQueuedUserInput(sessionKey, msg.executionScope),
@@ -864,8 +1210,15 @@ export class CatsCompanyBot {
     Logger.info(`[${sessionKey}] 合并 ${messages.length} 条处理期间新到的用户消息`);
     const content = this.mergeQueuedMessages(messages);
     const localFileGrants = messages.flatMap(item => item.localFileGrants || []);
-    if (localFileGrants.length === 0) return content;
-    return { content, localFileGrants };
+    const deviceGrants = messages.flatMap(item => item.deviceGrants || []);
+    const deviceSelection = [...messages].reverse().find(item => item.deviceSelection)?.deviceSelection;
+    if (localFileGrants.length === 0 && deviceGrants.length === 0 && !deviceSelection) return content;
+    return {
+      content,
+      localFileGrants: localFileGrants.length > 0 ? localFileGrants : undefined,
+      deviceGrants: deviceGrants.length > 0 ? deviceGrants : undefined,
+      deviceSelection,
+    };
   }
 
   private canMergeQueuedMessage(
@@ -920,6 +1273,7 @@ export class CatsCompanyBot {
    * 停止机器人
    */
   async destroy(): Promise<void> {
+    this.stopDeviceRegistrationRefresh();
     this.bot.disconnect();
     await this.sessionManager.destroy();
     for (const pendingId of Array.from(this.pendingAnswers.keys())) {

--- a/src/catscompany/runtime-config.ts
+++ b/src/catscompany/runtime-config.ts
@@ -137,6 +137,7 @@ export function resolveCatsCoRuntimeConfig(
       apiKey,
       bodyId,
       installationId,
+      deviceName: localConfig.device?.name,
       httpBaseUrl,
       sessionTTL: config.catscompany?.sessionTTL,
     }

--- a/src/catscompany/types.ts
+++ b/src/catscompany/types.ts
@@ -1,4 +1,4 @@
-import type { ExecutionScope, MessageEnvelope } from '../types/session-identity';
+import type { ExecutionScope, MessageEnvelope, ScopedDeviceGrant, ScopedDeviceSelection } from '../types/session-identity';
 
 /**
  * CatsCo agent 连接配置
@@ -12,6 +12,8 @@ export interface CatsCompanyConfig {
   bodyId?: string;
   /** 当前安装/设备 ID，默认与 bodyId 相同 */
   installationId?: string;
+  /** 用户可见设备名，用于 Dashboard 展示和服务端设备选择 */
+  deviceName?: string;
   /** HTTP 基础地址（用于文件上传），默认从 serverUrl 推导 */
   httpBaseUrl?: string;
   /** 会话过期时间（毫秒），默认 30 分钟 */
@@ -40,6 +42,10 @@ export interface ParsedCatsMessage {
   envelope: MessageEnvelope;
   /** 当前 turn 的执行身份 */
   executionScope: ExecutionScope;
+  /** 服务端签发的当前 turn 用户设备授权 */
+  deviceGrants?: ScopedDeviceGrant[];
+  /** 服务端为当前 turn 选择的用户设备，或要求先选择设备 */
+  deviceSelection?: ScopedDeviceSelection;
   /** 文件附件信息（rich content file/image 时存在） */
   file?: CatsFileInfo;
   /** 同一条消息里的全部附件（content_blocks 或 rich content） */

--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -2,6 +2,7 @@ import { Message } from '../types';
 import type {
   ExecutionScope,
   ScopedDeviceGrant,
+  ScopedDeviceSelection,
   ScopedLocalDeviceGrant,
   ScopedLocalFileGrant,
   SessionRoute,
@@ -11,7 +12,7 @@ import * as path from 'path';
 import { AIService } from '../utils/ai-service';
 import { ToolManager } from '../tools/tool-manager';
 import { SkillManager } from '../skills/skill-manager';
-import { ChannelCallbacks } from '../types/tool';
+import { ChannelCallbacks, DeviceRpcTransport } from '../types/tool';
 import {
   SessionSkillRuntime,
   SkillReloadHandler,
@@ -85,6 +86,10 @@ export interface HandleMessageOptions {
   localDeviceGrant?: ScopedLocalDeviceGrant;
   /** 当前 turn 已授权的用户设备资源。 */
   deviceGrants?: ScopedDeviceGrant[];
+  /** 服务端为当前 turn 选定的用户设备。 */
+  deviceSelection?: ScopedDeviceSelection;
+  /** 当前 turn 可用的远程设备 RPC 通道。 */
+  deviceRpc?: DeviceRpcTransport;
   /** 当前 turn 已授权的本地文件资源。 */
   localFileGrants?: ScopedLocalFileGrant[];
   /** 当前 turn 专属、给 agent 可见的运行时反馈 */
@@ -391,6 +396,8 @@ export class AgentSession {
       let executionScope: ExecutionScope | undefined;
       let localDeviceGrant: ScopedLocalDeviceGrant | undefined;
       let deviceGrants: ScopedDeviceGrant[] | undefined;
+      let deviceSelection: ScopedDeviceSelection | undefined;
+      let deviceRpc: DeviceRpcTransport | undefined;
       let localFileGrants: ScopedLocalFileGrant[] | undefined;
       let runtimeFeedbackInputs: RuntimeFeedbackInput[] = [];
       let pendingUserInputProvider: PendingUserInputProvider | undefined;
@@ -402,6 +409,8 @@ export class AgentSession {
           || 'executionScope' in callbacksOrOptions
           || 'localDeviceGrant' in callbacksOrOptions
           || 'deviceGrants' in callbacksOrOptions
+          || 'deviceSelection' in callbacksOrOptions
+          || 'deviceRpc' in callbacksOrOptions
           || 'localFileGrants' in callbacksOrOptions
           || 'callbacks' in callbacksOrOptions
           || 'runtimeFeedback' in callbacksOrOptions
@@ -415,6 +424,8 @@ export class AgentSession {
           executionScope = opts.executionScope;
           localDeviceGrant = opts.localDeviceGrant;
           deviceGrants = opts.deviceGrants;
+          deviceSelection = opts.deviceSelection;
+          deviceRpc = opts.deviceRpc;
           localFileGrants = opts.localFileGrants;
           runtimeFeedbackInputs = opts.runtimeFeedback || [];
           pendingUserInputProvider = opts.pendingUserInputProvider;
@@ -461,6 +472,8 @@ export class AgentSession {
           executionScope,
           localDeviceGrant,
           deviceGrants,
+          deviceSelection,
+          deviceRpc,
           localFileGrants,
           pendingUserInputProvider,
           abortSignal: this.activeAbortController.signal,

--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -1,5 +1,11 @@
 import { Message } from '../types';
-import type { ExecutionScope, ScopedLocalDeviceGrant, ScopedLocalFileGrant, SessionRoute } from '../types/session-identity';
+import type {
+  ExecutionScope,
+  ScopedDeviceGrant,
+  ScopedLocalDeviceGrant,
+  ScopedLocalFileGrant,
+  SessionRoute,
+} from '../types/session-identity';
 import * as fs from 'fs';
 import * as path from 'path';
 import { AIService } from '../utils/ai-service';
@@ -77,6 +83,8 @@ export interface HandleMessageOptions {
   executionScope?: ExecutionScope;
   /** 当前本机运行体授权，例如 CatsCo body/device 绑定。 */
   localDeviceGrant?: ScopedLocalDeviceGrant;
+  /** 当前 turn 已授权的用户设备资源。 */
+  deviceGrants?: ScopedDeviceGrant[];
   /** 当前 turn 已授权的本地文件资源。 */
   localFileGrants?: ScopedLocalFileGrant[];
   /** 当前 turn 专属、给 agent 可见的运行时反馈 */
@@ -382,6 +390,7 @@ export class AgentSession {
       let sessionRoute: SessionRoute | undefined;
       let executionScope: ExecutionScope | undefined;
       let localDeviceGrant: ScopedLocalDeviceGrant | undefined;
+      let deviceGrants: ScopedDeviceGrant[] | undefined;
       let localFileGrants: ScopedLocalFileGrant[] | undefined;
       let runtimeFeedbackInputs: RuntimeFeedbackInput[] = [];
       let pendingUserInputProvider: PendingUserInputProvider | undefined;
@@ -392,6 +401,7 @@ export class AgentSession {
           || 'sessionRoute' in callbacksOrOptions
           || 'executionScope' in callbacksOrOptions
           || 'localDeviceGrant' in callbacksOrOptions
+          || 'deviceGrants' in callbacksOrOptions
           || 'localFileGrants' in callbacksOrOptions
           || 'callbacks' in callbacksOrOptions
           || 'runtimeFeedback' in callbacksOrOptions
@@ -404,6 +414,7 @@ export class AgentSession {
           sessionRoute = opts.sessionRoute;
           executionScope = opts.executionScope;
           localDeviceGrant = opts.localDeviceGrant;
+          deviceGrants = opts.deviceGrants;
           localFileGrants = opts.localFileGrants;
           runtimeFeedbackInputs = opts.runtimeFeedback || [];
           pendingUserInputProvider = opts.pendingUserInputProvider;
@@ -449,6 +460,7 @@ export class AgentSession {
           sessionRoute,
           executionScope,
           localDeviceGrant,
+          deviceGrants,
           localFileGrants,
           pendingUserInputProvider,
           abortSignal: this.activeAbortController.signal,

--- a/src/core/agent-turn-controller.ts
+++ b/src/core/agent-turn-controller.ts
@@ -1,5 +1,11 @@
 import { ContentBlock, Message } from '../types';
-import type { ExecutionScope, ScopedLocalDeviceGrant, ScopedLocalFileGrant, SessionRoute } from '../types/session-identity';
+import type {
+  ExecutionScope,
+  ScopedDeviceGrant,
+  ScopedLocalDeviceGrant,
+  ScopedLocalFileGrant,
+  SessionRoute,
+} from '../types/session-identity';
 import { ChannelCallbacks } from '../types/tool';
 import { AIService } from '../utils/ai-service';
 import { ToolManager } from '../tools/tool-manager';
@@ -39,6 +45,7 @@ export interface RunAgentTurnParams {
   sessionRoute?: SessionRoute;
   executionScope?: ExecutionScope;
   localDeviceGrant?: ScopedLocalDeviceGrant;
+  deviceGrants?: ScopedDeviceGrant[];
   localFileGrants?: ScopedLocalFileGrant[];
   pendingUserInputProvider?: PendingUserInputProvider;
   abortSignal?: AbortSignal;
@@ -92,6 +99,7 @@ export class AgentTurnController {
       sessionRoute: params.sessionRoute ?? this.options.sessionRoute,
       executionScope: params.executionScope,
       localDeviceGrant: params.localDeviceGrant,
+      deviceGrants: params.deviceGrants,
       localFileGrants: params.localFileGrants,
       durableMessages: params.messages,
       runtimeFeedback: params.runtimeFeedback,
@@ -103,6 +111,7 @@ export class AgentTurnController {
       channel: params.channel,
       executionScope: params.executionScope,
       localDeviceGrant: params.localDeviceGrant,
+      deviceGrants: params.deviceGrants,
       localFileGrants: params.localFileGrants,
       pendingUserInputProvider: params.pendingUserInputProvider,
       abortSignal: params.abortSignal,
@@ -152,6 +161,7 @@ export class AgentTurnController {
     channel?: ChannelCallbacks;
     executionScope?: ExecutionScope;
     localDeviceGrant?: ScopedLocalDeviceGrant;
+    deviceGrants?: ScopedDeviceGrant[];
     localFileGrants?: ScopedLocalFileGrant[];
     pendingUserInputProvider?: PendingUserInputProvider;
     abortSignal?: AbortSignal;
@@ -184,6 +194,7 @@ export class AgentTurnController {
           channel: options.channel,
           executionScope: options.executionScope,
           localDeviceGrant: options.localDeviceGrant,
+          deviceGrants: options.deviceGrants,
           localFileGrants: options.localFileGrants,
         },
       },

--- a/src/core/agent-turn-controller.ts
+++ b/src/core/agent-turn-controller.ts
@@ -2,11 +2,12 @@ import { ContentBlock, Message } from '../types';
 import type {
   ExecutionScope,
   ScopedDeviceGrant,
+  ScopedDeviceSelection,
   ScopedLocalDeviceGrant,
   ScopedLocalFileGrant,
   SessionRoute,
 } from '../types/session-identity';
-import { ChannelCallbacks } from '../types/tool';
+import { ChannelCallbacks, DeviceRpcTransport } from '../types/tool';
 import { AIService } from '../utils/ai-service';
 import { ToolManager } from '../tools/tool-manager';
 import { SkillManager } from '../skills/skill-manager';
@@ -46,6 +47,8 @@ export interface RunAgentTurnParams {
   executionScope?: ExecutionScope;
   localDeviceGrant?: ScopedLocalDeviceGrant;
   deviceGrants?: ScopedDeviceGrant[];
+  deviceSelection?: ScopedDeviceSelection;
+  deviceRpc?: DeviceRpcTransport;
   localFileGrants?: ScopedLocalFileGrant[];
   pendingUserInputProvider?: PendingUserInputProvider;
   abortSignal?: AbortSignal;
@@ -100,6 +103,7 @@ export class AgentTurnController {
       executionScope: params.executionScope,
       localDeviceGrant: params.localDeviceGrant,
       deviceGrants: params.deviceGrants,
+      deviceSelection: params.deviceSelection,
       localFileGrants: params.localFileGrants,
       durableMessages: params.messages,
       runtimeFeedback: params.runtimeFeedback,
@@ -112,6 +116,8 @@ export class AgentTurnController {
       executionScope: params.executionScope,
       localDeviceGrant: params.localDeviceGrant,
       deviceGrants: params.deviceGrants,
+      deviceSelection: params.deviceSelection,
+      deviceRpc: params.deviceRpc,
       localFileGrants: params.localFileGrants,
       pendingUserInputProvider: params.pendingUserInputProvider,
       abortSignal: params.abortSignal,
@@ -162,6 +168,8 @@ export class AgentTurnController {
     executionScope?: ExecutionScope;
     localDeviceGrant?: ScopedLocalDeviceGrant;
     deviceGrants?: ScopedDeviceGrant[];
+    deviceSelection?: ScopedDeviceSelection;
+    deviceRpc?: DeviceRpcTransport;
     localFileGrants?: ScopedLocalFileGrant[];
     pendingUserInputProvider?: PendingUserInputProvider;
     abortSignal?: AbortSignal;
@@ -195,6 +203,8 @@ export class AgentTurnController {
           executionScope: options.executionScope,
           localDeviceGrant: options.localDeviceGrant,
           deviceGrants: options.deviceGrants,
+          deviceSelection: options.deviceSelection,
+          deviceRpc: options.deviceRpc,
           localFileGrants: options.localFileGrants,
         },
       },

--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -1,5 +1,5 @@
 import { Message, ContentBlock, ChatConfig, ChatResponse } from '../types';
-import type { ScopedLocalFileGrant } from '../types/session-identity';
+import type { ScopedDeviceGrant, ScopedLocalFileGrant } from '../types/session-identity';
 import { AIService } from '../utils/ai-service';
 import { ToolCall, ToolDefinition, ToolExecutionContext, ToolExecutor, ToolResult, ToolTranscriptMode } from '../types/tool';
 import { StreamCallbacks } from '../providers/provider';
@@ -21,6 +21,10 @@ import {
   SUBAGENT_TOOL_NAME,
   TRANSIENT_RUNNER_HINT_PREFIX,
 } from './runner-orchestration-policy';
+import {
+  TRANSIENT_RUNTIME_CONTEXT_PREFIX,
+  buildRuntimeContextMessage,
+} from './runtime-context-builder';
 import { calculateSummaryBudgetTokens, resolveModelPromptBudgetTokens } from '../utils/model-context-window';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -86,6 +90,7 @@ export interface RunResult {
 
 export interface PendingUserInput {
   content: string | ContentBlock[];
+  deviceGrants?: ScopedDeviceGrant[];
   localFileGrants?: ScopedLocalFileGrant[];
 }
 
@@ -514,6 +519,17 @@ export class ConversationRunner {
     if (!pending) return false;
 
     const content = isPendingUserInput(pending) ? pending.content : pending;
+    let shouldRefreshRuntimeContext = false;
+    if (isPendingUserInput(pending) && pending.deviceGrants?.length) {
+      this.toolExecutionContext = {
+        ...(this.toolExecutionContext || {}),
+        deviceGrants: [
+          ...(this.toolExecutionContext?.deviceGrants || []),
+          ...pending.deviceGrants,
+        ],
+      };
+      shouldRefreshRuntimeContext = true;
+    }
     if (isPendingUserInput(pending) && pending.localFileGrants?.length) {
       this.toolExecutionContext = {
         ...(this.toolExecutionContext || {}),
@@ -522,6 +538,10 @@ export class ConversationRunner {
           ...pending.localFileGrants,
         ],
       };
+      shouldRefreshRuntimeContext = true;
+    }
+    if (shouldRefreshRuntimeContext) {
+      this.refreshRuntimeContextForPendingInput(messages);
     }
 
     const userMessage: Message = { role: 'user', content };
@@ -537,6 +557,34 @@ export class ConversationRunner {
     );
 
     return true;
+  }
+
+  private refreshRuntimeContextForPendingInput(messages: Message[]): void {
+    const sessionKey = this.toolExecutionContext?.sessionId
+      || this.toolExecutionContext?.executionScope?.sessionKey;
+    if (!sessionKey) return;
+
+    const runtimeContext = buildRuntimeContextMessage({
+      sessionKey,
+      sessionType: this.toolExecutionContext?.surface,
+      executionScope: this.toolExecutionContext?.executionScope,
+      localDeviceGrant: this.toolExecutionContext?.localDeviceGrant,
+      deviceGrants: this.toolExecutionContext?.deviceGrants,
+      localFileGrants: this.toolExecutionContext?.localFileGrants,
+    });
+    if (!runtimeContext) return;
+
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const message = messages[i];
+      if (
+        message.role === 'system'
+        && typeof message.content === 'string'
+        && message.content.startsWith(TRANSIENT_RUNTIME_CONTEXT_PREFIX)
+      ) {
+        messages.splice(i, 1);
+      }
+    }
+    messages.push(runtimeContext);
   }
 
   /**

--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -1,5 +1,5 @@
 import { Message, ContentBlock, ChatConfig, ChatResponse } from '../types';
-import type { ScopedDeviceGrant, ScopedLocalFileGrant } from '../types/session-identity';
+import type { ScopedDeviceGrant, ScopedDeviceSelection, ScopedLocalFileGrant } from '../types/session-identity';
 import { AIService } from '../utils/ai-service';
 import { ToolCall, ToolDefinition, ToolExecutionContext, ToolExecutor, ToolResult, ToolTranscriptMode } from '../types/tool';
 import { StreamCallbacks } from '../providers/provider';
@@ -91,6 +91,7 @@ export interface RunResult {
 export interface PendingUserInput {
   content: string | ContentBlock[];
   deviceGrants?: ScopedDeviceGrant[];
+  deviceSelection?: ScopedDeviceSelection;
   localFileGrants?: ScopedLocalFileGrant[];
 }
 
@@ -530,6 +531,13 @@ export class ConversationRunner {
       };
       shouldRefreshRuntimeContext = true;
     }
+    if (isPendingUserInput(pending) && pending.deviceSelection) {
+      this.toolExecutionContext = {
+        ...(this.toolExecutionContext || {}),
+        deviceSelection: pending.deviceSelection,
+      };
+      shouldRefreshRuntimeContext = true;
+    }
     if (isPendingUserInput(pending) && pending.localFileGrants?.length) {
       this.toolExecutionContext = {
         ...(this.toolExecutionContext || {}),
@@ -570,6 +578,7 @@ export class ConversationRunner {
       executionScope: this.toolExecutionContext?.executionScope,
       localDeviceGrant: this.toolExecutionContext?.localDeviceGrant,
       deviceGrants: this.toolExecutionContext?.deviceGrants,
+      deviceSelection: this.toolExecutionContext?.deviceSelection,
       localFileGrants: this.toolExecutionContext?.localFileGrants,
     });
     if (!runtimeContext) return;

--- a/src/core/device-grants.ts
+++ b/src/core/device-grants.ts
@@ -1,0 +1,275 @@
+import { randomUUID } from 'crypto';
+import type {
+  DeviceGrantOperation,
+  DeviceGrantStatus,
+  ExecutionScope,
+  MessageSource,
+  ScopedDeviceGrant,
+  UserDevice,
+  UserDeviceStatus,
+} from '../types/session-identity';
+import type { ToolExecutionContext } from '../types/tool';
+
+export const DEFAULT_DEVICE_GRANT_TTL_MS = 10 * 60 * 1000;
+
+export interface CreateUserDeviceInput {
+  source: MessageSource;
+  ownerUserId: string;
+  deviceId: string;
+  displayName?: string;
+  bodyId?: string;
+  installationId?: string;
+  identityTrust?: UserDevice['identityTrust'];
+  identitySource?: string;
+  status?: UserDeviceStatus;
+  registeredAt?: number;
+  lastSeenAt?: number;
+}
+
+export interface CreateDeviceGrantOptions {
+  operations: DeviceGrantOperation[];
+  ttlMs?: number;
+  now?: number;
+  grantId?: string;
+  status?: DeviceGrantStatus;
+  identitySource?: string;
+}
+
+export type DeviceGrantDecision =
+  | { ok: true; grant: ScopedDeviceGrant }
+  | { ok: false; errorCode: 'PERMISSION_DENIED' | 'TOOL_EXECUTION_ERROR'; message: string };
+
+export interface ResolveDeviceGrantOptions {
+  operation: DeviceGrantOperation;
+  deviceId?: string;
+  now?: number;
+}
+
+export function createUserDevice(input: CreateUserDeviceInput): UserDevice | undefined {
+  const source = normalizeSource(input.source);
+  const ownerUserId = normalizeId(input.ownerUserId);
+  const deviceId = normalizeId(input.deviceId);
+  if (!ownerUserId || !deviceId) return undefined;
+  const registeredAt = normalizeTime(input.registeredAt) ?? Date.now();
+
+  return pruneUndefined({
+    kind: 'user_device',
+    source,
+    ownerUserId,
+    deviceId,
+    displayName: normalizeId(input.displayName),
+    bodyId: normalizeId(input.bodyId),
+    installationId: normalizeId(input.installationId),
+    identityTrust: normalizeIdentityTrust(input.identityTrust),
+    identitySource: normalizeId(input.identitySource),
+    status: normalizeStatus(input.status),
+    registeredAt,
+    lastSeenAt: normalizeTime(input.lastSeenAt),
+  }) as UserDevice;
+}
+
+export function createDeviceGrant(
+  scope: ExecutionScope | undefined,
+  device: UserDevice | undefined,
+  options: CreateDeviceGrantOptions,
+): ScopedDeviceGrant | undefined {
+  if (!scope || !device) return undefined;
+  const operations = normalizeOperations(options.operations);
+  if (operations.length === 0) return undefined;
+  if (device.source !== scope.source) return undefined;
+  if (device.ownerUserId !== scope.actorUserId) return undefined;
+  const now = normalizeTime(options.now) ?? Date.now();
+  const ttlMs = normalizeTtl(options.ttlMs);
+
+  return pruneUndefined({
+    kind: 'user_device_grant',
+    source: device.source,
+    grantId: normalizeId(options.grantId) || `device_grant_${randomUUID()}`,
+    status: options.status || 'active',
+    identityTrust: scope.identityTrust,
+    identitySource: normalizeId(options.identitySource) || scope.permissionsSource,
+    deviceId: device.deviceId,
+    deviceDisplayName: device.displayName,
+    deviceBodyId: device.bodyId,
+    deviceInstallationId: device.installationId,
+    ownerUserId: device.ownerUserId,
+    sessionKey: scope.sessionKey,
+    topicId: scope.topicId,
+    topicType: scope.topicType,
+    actorUserId: scope.actorUserId,
+    agentId: scope.agentId,
+    agentBodyId: scope.agentBodyId,
+    operations,
+    createdAt: now,
+    expiresAt: now + ttlMs,
+  }) as ScopedDeviceGrant;
+}
+
+export function resolveDeviceGrant(
+  context: Pick<ToolExecutionContext, 'executionScope' | 'deviceGrants'>,
+  options: ResolveDeviceGrantOptions,
+): DeviceGrantDecision {
+  const grants = context.deviceGrants || [];
+  if (grants.length === 0) {
+    return denied('当前会话没有可用的用户设备授权，无法操作本地设备。');
+  }
+
+  const normalizedDeviceId = normalizeId(options.deviceId);
+  const matchingGrants = grants.filter(candidate => {
+    if (normalizedDeviceId && candidate.deviceId !== normalizedDeviceId) return false;
+    return candidate.operations.includes(options.operation);
+  });
+
+  if (matchingGrants.length === 0) {
+    return denied(
+      normalizedDeviceId
+        ? `当前会话没有允许 ${options.operation} 的设备授权：${normalizedDeviceId}。`
+        : `当前会话没有允许 ${options.operation} 的设备授权。`,
+    );
+  }
+
+  const validDecisions = matchingGrants
+    .map(candidate => validateDeviceGrant(context, candidate, options))
+    .filter((decision): decision is Extract<DeviceGrantDecision, { ok: true }> => decision.ok);
+
+  if (validDecisions.length === 0) {
+    return validateDeviceGrant(context, matchingGrants[0], options);
+  }
+
+  if (!normalizedDeviceId) {
+    const targetDeviceIds = new Set(validDecisions.map(decision => decision.grant.deviceId));
+    if (targetDeviceIds.size > 1) {
+      return denied(`当前会话有多个允许 ${options.operation} 的用户设备授权，请由后端指定目标 deviceId 后再执行。`);
+    }
+  }
+
+  return validDecisions[0];
+}
+
+export function validateDeviceGrant(
+  context: Pick<ToolExecutionContext, 'executionScope'>,
+  grant: ScopedDeviceGrant,
+  options: ResolveDeviceGrantOptions,
+): DeviceGrantDecision {
+  const scope = context.executionScope;
+  if (!scope) {
+    return denied('当前工具调用缺少执行身份，无法校验用户设备授权。');
+  }
+
+  const normalizedDeviceId = normalizeId(options.deviceId);
+  if (normalizedDeviceId && grant.deviceId !== normalizedDeviceId) {
+    return denied(`设备授权与目标设备不一致，已阻止操作：grant=${grant.deviceId} target=${normalizedDeviceId}`);
+  }
+
+  if (grant.status !== 'active') {
+    return denied(`设备授权不是 active 状态，已阻止操作：${grant.status}`);
+  }
+
+  if (grant.identityTrust === 'untrusted') {
+    return denied('设备授权来自未可信身份，已阻止操作。');
+  }
+
+  if (!grant.operations.includes(options.operation)) {
+    return denied(`设备授权不允许执行 ${options.operation}。`);
+  }
+
+  const now = normalizeTime(options.now) ?? Date.now();
+  if (grant.expiresAt <= now) {
+    return denied('设备授权已过期，请让用户重新授权当前设备。');
+  }
+
+  const mismatches = [
+    ['source', grant.source, scope.source],
+    ['sessionKey', grant.sessionKey, scope.sessionKey],
+    ['topicId', grant.topicId, scope.topicId],
+    ['topicType', grant.topicType, scope.topicType],
+    ['actorUserId', grant.actorUserId, scope.actorUserId],
+    ['agentId', grant.agentId, scope.agentId],
+    ['agentBodyId', grant.agentBodyId, scope.agentBodyId],
+  ].filter(([, grantValue, scopeValue]) => grantValue !== scopeValue);
+
+  if (grant.ownerUserId !== scope.actorUserId) {
+    mismatches.push(['ownerUserId', grant.ownerUserId, scope.actorUserId]);
+  }
+
+  if (mismatches.length > 0) {
+    return {
+      ok: false,
+      errorCode: 'PERMISSION_DENIED',
+      message: [
+        '设备授权与当前执行身份不一致，已阻止操作以避免串用户或串设备。',
+        ...mismatches.map(([field, grantValue, scopeValue]) => `${field}: grant=${grantValue || '(empty)'} scope=${scopeValue || '(empty)'}`),
+      ].join('\n'),
+    };
+  }
+
+  return { ok: true, grant };
+}
+
+function denied(message: string): DeviceGrantDecision {
+  return { ok: false, errorCode: 'PERMISSION_DENIED', message };
+}
+
+function normalizeOperations(operations: DeviceGrantOperation[]): DeviceGrantOperation[] {
+  const unique = new Set<DeviceGrantOperation>();
+  for (const operation of operations) {
+    if (isDeviceGrantOperation(operation)) unique.add(operation);
+  }
+  return [...unique];
+}
+
+function isDeviceGrantOperation(value: string): value is DeviceGrantOperation {
+  return value === 'read_file'
+    || value === 'write_file'
+    || value === 'edit_file'
+    || value === 'send_file'
+    || value === 'execute_shell'
+    || value === 'glob'
+    || value === 'grep'
+    || value === 'browser_control'
+    || value === 'desktop_control';
+}
+
+function normalizeSource(value: MessageSource | string | undefined): MessageSource {
+  if (value === 'catscompany' || value === 'feishu' || value === 'weixin' || value === 'cli') {
+    return value;
+  }
+  return 'unknown';
+}
+
+function normalizeStatus(value?: UserDeviceStatus): UserDeviceStatus {
+  if (value === 'online' || value === 'offline') return value;
+  return 'unknown';
+}
+
+function normalizeIdentityTrust(value?: UserDevice['identityTrust']): UserDevice['identityTrust'] {
+  if (value === 'server_canonical' || value === 'legacy_context' || value === 'untrusted') return value;
+  return 'untrusted';
+}
+
+function normalizeId(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const text = value.trim();
+  return text || undefined;
+}
+
+function normalizeTime(value: unknown): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) return undefined;
+  return value;
+}
+
+function normalizeTtl(value: unknown): number {
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) return value;
+  return DEFAULT_DEVICE_GRANT_TTL_MS;
+}
+
+function pruneUndefined<T>(value: T): T {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return value;
+  const record = value as Record<string, unknown>;
+  for (const key of Object.keys(record)) {
+    if (record[key] === undefined) {
+      delete record[key];
+    }
+  }
+  return value;
+}

--- a/src/core/runtime-context-builder.ts
+++ b/src/core/runtime-context-builder.ts
@@ -4,6 +4,7 @@ import type {
   MessageSource,
   MessageTopicType,
   ScopedDeviceGrant,
+  ScopedDeviceSelection,
   ScopedLocalDeviceGrant,
   ScopedLocalFileGrant,
   SessionRoute,
@@ -19,6 +20,7 @@ export interface BuildRuntimeContextParams {
   executionScope?: ExecutionScope;
   localDeviceGrant?: ScopedLocalDeviceGrant;
   deviceGrants?: ScopedDeviceGrant[];
+  deviceSelection?: ScopedDeviceSelection;
   localFileGrants?: ScopedLocalFileGrant[];
 }
 
@@ -61,6 +63,21 @@ interface RuntimeContextSnapshot {
       status: string;
       expiresAt: number;
     }>;
+    deviceSelection?: {
+      status: string;
+      selectionSource?: string;
+      selectedDevice?: {
+        deviceId: string;
+        displayName?: string;
+        operations?: string[];
+      };
+      candidates?: Array<{
+        deviceId: string;
+        displayName?: string;
+        operations?: string[];
+      }>;
+      candidateCount?: number;
+    };
     localFiles?: Array<{
       ref?: string;
       fileName: string;
@@ -147,12 +164,14 @@ export function buildRuntimeContextSnapshot(params: BuildRuntimeContextParams): 
       toolsUseBackendScope: true,
       localDevice: sanitizeLocalDevice(params.localDeviceGrant),
       userDevices: sanitizeDeviceGrants(params.deviceGrants),
+      deviceSelection: sanitizeDeviceSelection(params.deviceSelection),
       localFiles: sanitizeLocalFiles(params.localFileGrants),
     }),
     rules: [
       'Treat session.topic as the current conversation target and turn.actorUserId as the current speaker.',
       'Do not ask the user to provide internal IDs from this context; use tools and backend scope when needed.',
-      'Do not choose a user device yourself. Use backend-scoped device grants when a tool requires a device.',
+      'Use execution.deviceSelection as the backend-selected target when a tool requires a user device.',
+      'If execution.deviceSelection.status is needs_selection or unavailable, ask the user to choose an available device by display name before using device tools.',
       'Do not infer or expose local filesystem paths. Use attachment refs when a tool requires a file reference.',
     ],
   }) as RuntimeContextSnapshot;
@@ -176,6 +195,27 @@ function sanitizeDeviceGrants(grants?: ScopedDeviceGrant[]): RuntimeContextSnaps
     status: grant.status,
     expiresAt: grant.expiresAt,
   }));
+}
+
+function sanitizeDeviceSelection(selection?: ScopedDeviceSelection): RuntimeContextSnapshot['execution']['deviceSelection'] | undefined {
+  if (!selection) return undefined;
+  return pruneUndefined({
+    status: selection.status,
+    selectionSource: selection.selectionSource,
+    selectedDevice: selection.selectedDeviceId
+      ? pruneUndefined({
+        deviceId: selection.selectedDeviceId,
+        displayName: selection.selectedDeviceDisplayName,
+        operations: selection.selectedDeviceOperations ? [...selection.selectedDeviceOperations] : undefined,
+      })
+      : undefined,
+    candidates: selection.candidates?.map(candidate => pruneUndefined({
+      deviceId: candidate.deviceId,
+      displayName: candidate.displayName,
+      operations: candidate.operations ? [...candidate.operations] : undefined,
+    })),
+    candidateCount: selection.candidateCount,
+  });
 }
 
 function sanitizeLocalFiles(grants?: ScopedLocalFileGrant[]): RuntimeContextSnapshot['execution']['localFiles'] | undefined {

--- a/src/core/runtime-context-builder.ts
+++ b/src/core/runtime-context-builder.ts
@@ -3,6 +3,7 @@ import type {
   ExecutionScope,
   MessageSource,
   MessageTopicType,
+  ScopedDeviceGrant,
   ScopedLocalDeviceGrant,
   ScopedLocalFileGrant,
   SessionRoute,
@@ -17,6 +18,7 @@ export interface BuildRuntimeContextParams {
   sessionRoute?: SessionRoute;
   executionScope?: ExecutionScope;
   localDeviceGrant?: ScopedLocalDeviceGrant;
+  deviceGrants?: ScopedDeviceGrant[];
   localFileGrants?: ScopedLocalFileGrant[];
 }
 
@@ -32,7 +34,6 @@ interface RuntimeContextSnapshot {
     };
     agent?: {
       id?: string;
-      bodyId?: string;
     };
   };
   turn: {
@@ -50,9 +51,16 @@ interface RuntimeContextSnapshot {
     toolsUseBackendScope: true;
     localDevice?: {
       source: MessageSource;
-      bodyId: string;
       deviceId?: string;
     };
+    userDevices?: Array<{
+      grantId: string;
+      deviceId: string;
+      displayName?: string;
+      operations: string[];
+      status: string;
+      expiresAt: number;
+    }>;
     localFiles?: Array<{
       ref?: string;
       fileName: string;
@@ -99,8 +107,6 @@ export function buildRuntimeContextSnapshot(params: BuildRuntimeContextParams): 
   const agentId = scope?.agentId
     ?? route?.agentId
     ?? parsedKey?.agentId;
-  const agentBodyId = scope?.agentBodyId
-    ?? route?.agentBodyId;
   const identityTrust = scope?.identityTrust
     ?? route?.identityTrust
     ?? 'legacy_context';
@@ -120,10 +126,9 @@ export function buildRuntimeContextSnapshot(params: BuildRuntimeContextParams): 
         id: topicId,
         type: topicType,
       },
-      agent: agentId || agentBodyId
+      agent: agentId
         ? pruneUndefined({
           id: agentId,
-          bodyId: agentBodyId,
         })
         : undefined,
     }),
@@ -141,11 +146,13 @@ export function buildRuntimeContextSnapshot(params: BuildRuntimeContextParams): 
       scopeSource,
       toolsUseBackendScope: true,
       localDevice: sanitizeLocalDevice(params.localDeviceGrant),
+      userDevices: sanitizeDeviceGrants(params.deviceGrants),
       localFiles: sanitizeLocalFiles(params.localFileGrants),
     }),
     rules: [
       'Treat session.topic as the current conversation target and turn.actorUserId as the current speaker.',
       'Do not ask the user to provide internal IDs from this context; use tools and backend scope when needed.',
+      'Do not choose a user device yourself. Use backend-scoped device grants when a tool requires a device.',
       'Do not infer or expose local filesystem paths. Use attachment refs when a tool requires a file reference.',
     ],
   }) as RuntimeContextSnapshot;
@@ -155,9 +162,20 @@ function sanitizeLocalDevice(grant?: ScopedLocalDeviceGrant): RuntimeContextSnap
   if (!grant) return undefined;
   return pruneUndefined({
     source: grant.source,
-    bodyId: grant.bodyId,
     deviceId: grant.deviceId,
   });
+}
+
+function sanitizeDeviceGrants(grants?: ScopedDeviceGrant[]): RuntimeContextSnapshot['execution']['userDevices'] | undefined {
+  if (!grants || grants.length === 0) return undefined;
+  return grants.map(grant => pruneUndefined({
+    grantId: grant.grantId,
+    deviceId: grant.deviceId,
+    displayName: grant.deviceDisplayName,
+    operations: [...grant.operations],
+    status: grant.status,
+    expiresAt: grant.expiresAt,
+  }));
 }
 
 function sanitizeLocalFiles(grants?: ScopedLocalFileGrant[]): RuntimeContextSnapshot['execution']['localFiles'] | undefined {

--- a/src/core/turn-context-builder.ts
+++ b/src/core/turn-context-builder.ts
@@ -1,6 +1,7 @@
 import { Message } from '../types';
 import type {
   ExecutionScope,
+  ScopedDeviceGrant,
   ScopedLocalDeviceGrant,
   ScopedLocalFileGrant,
   SessionRoute,
@@ -30,6 +31,7 @@ export interface BuildTurnContextParams {
   sessionRoute?: SessionRoute;
   executionScope?: ExecutionScope;
   localDeviceGrant?: ScopedLocalDeviceGrant;
+  deviceGrants?: ScopedDeviceGrant[];
   localFileGrants?: ScopedLocalFileGrant[];
   durableMessages: Message[];
   runtimeFeedback: string[];
@@ -88,6 +90,7 @@ export class TurnContextBuilder {
       sessionRoute: params.sessionRoute,
       executionScope: params.executionScope,
       localDeviceGrant: params.localDeviceGrant,
+      deviceGrants: params.deviceGrants,
       localFileGrants: params.localFileGrants,
     });
     if (!message) return;

--- a/src/core/turn-context-builder.ts
+++ b/src/core/turn-context-builder.ts
@@ -2,6 +2,7 @@ import { Message } from '../types';
 import type {
   ExecutionScope,
   ScopedDeviceGrant,
+  ScopedDeviceSelection,
   ScopedLocalDeviceGrant,
   ScopedLocalFileGrant,
   SessionRoute,
@@ -32,6 +33,7 @@ export interface BuildTurnContextParams {
   executionScope?: ExecutionScope;
   localDeviceGrant?: ScopedLocalDeviceGrant;
   deviceGrants?: ScopedDeviceGrant[];
+  deviceSelection?: ScopedDeviceSelection;
   localFileGrants?: ScopedLocalFileGrant[];
   durableMessages: Message[];
   runtimeFeedback: string[];
@@ -91,6 +93,7 @@ export class TurnContextBuilder {
       executionScope: params.executionScope,
       localDeviceGrant: params.localDeviceGrant,
       deviceGrants: params.deviceGrants,
+      deviceSelection: params.deviceSelection,
       localFileGrants: params.localFileGrants,
     });
     if (!message) return;

--- a/src/tools/bash-tool.ts
+++ b/src/tools/bash-tool.ts
@@ -8,6 +8,7 @@ import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from 
 import { Logger } from '../utils/logger';
 import { resolveRuntimeEnvironment } from '../utils/runtime-environment';
 import { isToolAllowed, isBashCommandAllowed } from '../utils/safety';
+import { resolveToolGatewayAccess } from './tool-gateway';
 
 const execAsync = promisify(exec);
 const CWD_MARKER_PREFIX = '__XIAOBA_CWD_MARKER__';
@@ -67,6 +68,14 @@ export class ShellTool implements Tool {
     const commandPermission = isBashCommandAllowed(command);
     if (!commandPermission.allowed) {
       return { ok: false, errorCode: 'PERMISSION_DENIED', message: `Execution blocked: ${commandPermission.reason}` };
+    }
+
+    const gateway = resolveToolGatewayAccess(context, {
+      toolName: this.definition.name,
+      operation: 'execute_shell',
+    });
+    if (!gateway.ok) {
+      return { ok: false, errorCode: gateway.errorCode, message: gateway.message };
     }
 
     if (description) {

--- a/src/tools/device-rpc-tool.ts
+++ b/src/tools/device-rpc-tool.ts
@@ -1,0 +1,167 @@
+import type { DeviceGrantOperation } from '../types/session-identity';
+import type { ToolErrorCode, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
+import type { ToolGatewayDecision } from './tool-gateway';
+
+const REMOTE_TOOL_TIMEOUT_MS = 60_000;
+export const MAX_DEVICE_RPC_TOOL_CONTENT_CHARS = 48_000;
+
+export function isRemoteReadonlyTool(toolName: string, operation: DeviceGrantOperation): boolean {
+  return (toolName === 'read_file' && operation === 'read_file')
+    || (toolName === 'glob' && operation === 'glob')
+    || (toolName === 'grep' && operation === 'grep');
+}
+
+export async function executeRemoteReadonlyTool(
+  context: ToolExecutionContext,
+  gateway: ToolGatewayDecision,
+  toolName: 'read_file' | 'glob' | 'grep',
+  operation: DeviceGrantOperation,
+  args: Record<string, unknown>,
+): Promise<ToolExecutionResult | undefined> {
+  if (!gateway.ok || gateway.mode !== 'remote') return undefined;
+
+  if (!isRemoteReadonlyTool(toolName, operation)) {
+    return {
+      ok: false,
+      errorCode: 'PERMISSION_DENIED',
+      message: `远程设备 RPC 当前只允许 read_file / glob / grep，已阻止 ${toolName}。`,
+    };
+  }
+
+  if (!context.deviceRpc) {
+    return {
+      ok: false,
+      errorCode: 'PERMISSION_DENIED',
+      message: '后端选定的设备不是当前运行体，但当前上下文没有远程设备 RPC 通道。',
+    };
+  }
+
+  try {
+    return await context.deviceRpc.executeTool({
+      toolName,
+      operation,
+      args,
+      grant: gateway.grant,
+      timeoutMs: timeoutForGrant(gateway.grant.expiresAt),
+    });
+  } catch (error: any) {
+    return {
+      ok: false,
+      errorCode: mapRpcErrorCode(error),
+      message: `远程设备工具执行失败: ${error?.message || error || 'unknown error'}`,
+      retryable: isRetryableRpcError(error),
+    };
+  }
+}
+
+export function normalizeDeviceRpcToolResultPayload(payload: unknown): ToolExecutionResult {
+  if (!payload || typeof payload !== 'object') {
+    return {
+      ok: false,
+      errorCode: 'TOOL_EXECUTION_ERROR',
+      message: '远程设备返回了无效工具结果。',
+    };
+  }
+  const record = payload as Record<string, unknown>;
+  if (record.ok === true) {
+    return {
+      ok: true,
+      content: normalizeDeviceRpcContent(record.content),
+    };
+  }
+  if (record.ok === false) {
+    return {
+      ok: false,
+      errorCode: normalizeErrorCode(record.errorCode),
+      message: truncateText(String(record.message || '远程设备工具执行失败。')),
+      retryable: Boolean(record.retryable),
+    };
+  }
+  return {
+    ok: false,
+    errorCode: 'TOOL_EXECUTION_ERROR',
+    message: '远程设备返回的工具结果缺少 ok 字段。',
+  };
+}
+
+export function normalizeDeviceRpcToolResultForTransport(result: ToolExecutionResult): ToolExecutionResult {
+  if (!result.ok) {
+    return {
+      ok: false,
+      errorCode: normalizeErrorCode(result.errorCode),
+      message: truncateText(result.message),
+      retryable: Boolean(result.retryable),
+    };
+  }
+  return {
+    ok: true,
+    content: normalizeDeviceRpcContent(result.content),
+  };
+}
+
+function timeoutForGrant(expiresAt: number): number {
+  const remaining = expiresAt - Date.now();
+  if (!Number.isFinite(remaining) || remaining <= 0) return 10_000;
+  return Math.max(5_000, Math.min(REMOTE_TOOL_TIMEOUT_MS, remaining));
+}
+
+function normalizeDeviceRpcContent(content: unknown): string {
+  if (typeof content === 'string') return truncateText(content);
+  if (Array.isArray(content)) {
+    const lines: string[] = [];
+    for (const block of content) {
+      if (!block || typeof block !== 'object') continue;
+      const record = block as Record<string, unknown>;
+      if (record.type === 'text' && typeof record.text === 'string') {
+        lines.push(record.text);
+      } else if (record.type === 'image') {
+        lines.push('[远程设备返回了图片内容块；当前 Device RPC 不转发图片二进制，请让用户以附件方式上传该图片。]');
+      }
+    }
+    return truncateText(lines.join('\n'));
+  }
+  if (content && typeof content === 'object') {
+    const record = content as Record<string, unknown>;
+    if (record._imageForNewMessage) {
+      return '[远程设备读取到图片文件；当前 Device RPC 不转发图片二进制，请让用户以附件方式上传该图片。]';
+    }
+  }
+  return truncateText(String(content ?? ''));
+}
+
+function truncateText(value: string): string {
+  if (value.length <= MAX_DEVICE_RPC_TOOL_CONTENT_CHARS) return value;
+  return [
+    value.slice(0, MAX_DEVICE_RPC_TOOL_CONTENT_CHARS),
+    '',
+    `[远程设备结果超过 ${MAX_DEVICE_RPC_TOOL_CONTENT_CHARS} 字符，已截断。请用更精确的 path/pattern/limit/offset 继续读取。]`,
+  ].join('\n');
+}
+
+function normalizeErrorCode(value: unknown): ToolErrorCode {
+  const text = String(value || '').trim();
+  if (
+    text === 'TOOL_NOT_FOUND'
+    || text === 'INVALID_TOOL_ARGUMENTS'
+    || text === 'TOOL_EXECUTION_ERROR'
+    || text === 'RATE_LIMIT'
+    || text === 'PERMISSION_DENIED'
+    || text === 'FILE_NOT_FOUND'
+    || text === 'EXECUTION_TIMEOUT'
+  ) {
+    return text;
+  }
+  return 'TOOL_EXECUTION_ERROR';
+}
+
+function mapRpcErrorCode(error: any): ToolErrorCode {
+  const text = String(error?.code || error?.kind || error?.message || '').toLowerCase();
+  if (text.includes('timeout')) return 'EXECUTION_TIMEOUT';
+  if (text.includes('permission') || text.includes('forbidden') || text.includes('denied')) return 'PERMISSION_DENIED';
+  return 'TOOL_EXECUTION_ERROR';
+}
+
+function isRetryableRpcError(error: any): boolean {
+  const text = String(error?.code || error?.kind || error?.message || '').toLowerCase();
+  return text.includes('timeout') || text.includes('offline') || text.includes('unavailable') || text.includes('transport');
+}

--- a/src/tools/edit-tool.ts
+++ b/src/tools/edit-tool.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import { isToolAllowed, isPathAllowed } from '../utils/safety';
+import { formatCatsCoVisiblePath, resolveToolGatewayAccess } from './tool-gateway';
 
 /**
  * Edit 工具 - 精确字符串替换
@@ -53,9 +54,19 @@ export class EditTool implements Tool {
       return { ok: false, errorCode: 'PERMISSION_DENIED', message: `执行被阻止: ${pathPermission.reason}` };
     }
 
+    const gateway = resolveToolGatewayAccess(context, {
+      toolName: this.definition.name,
+      operation: 'edit_file',
+      targetLabel: file_path,
+    });
+    if (!gateway.ok) {
+      return { ok: false, errorCode: gateway.errorCode, message: gateway.message };
+    }
+    const displayPath = formatCatsCoVisiblePath(context, file_path, { preserveRelative: true });
+
     // 检查文件是否存在
     if (!fs.existsSync(absolutePath)) {
-      return { ok: false, errorCode: 'FILE_NOT_FOUND', message: `错误：文件不存在: ${absolutePath}` };
+      return { ok: false, errorCode: 'FILE_NOT_FOUND', message: `错误：文件不存在: ${displayPath}` };
     }
 
     // 读取文件内容
@@ -63,14 +74,14 @@ export class EditTool implements Tool {
 
     // 检查 old_string 是否存在
     if (!content.includes(old_string)) {
-      return { ok: false, errorCode: 'TOOL_EXECUTION_ERROR', message: `错误：在文件中未找到要替换的字符串。\n文件: ${file_path}\n查找: ${old_string.substring(0, 100)}${old_string.length > 100 ? '...' : ''}` };
+      return { ok: false, errorCode: 'TOOL_EXECUTION_ERROR', message: `错误：在文件中未找到要替换的字符串。\n文件: ${displayPath}\n查找: ${old_string.substring(0, 100)}${old_string.length > 100 ? '...' : ''}` };
     }
 
     // 检查唯一性（如果不是 replace_all）
     if (!replace_all) {
       const occurrences = content.split(old_string).length - 1;
       if (occurrences > 1) {
-        return { ok: false, errorCode: 'TOOL_EXECUTION_ERROR', message: `错误：找到 ${occurrences} 个匹配项，但 replace_all=false。\n请提供更具体的字符串以确保唯一性，或设置 replace_all=true 替换所有匹配项。\n文件: ${file_path}` };
+        return { ok: false, errorCode: 'TOOL_EXECUTION_ERROR', message: `错误：找到 ${occurrences} 个匹配项，但 replace_all=false。\n请提供更具体的字符串以确保唯一性，或设置 replace_all=true 替换所有匹配项。\n文件: ${displayPath}` };
       }
     }
 
@@ -97,6 +108,6 @@ export class EditTool implements Tool {
     const newLines = newContent.split('\n').length;
     const lineDiff = newLines - oldLines;
 
-    return { ok: true, content: `成功编辑文件: ${file_path}\nPath: ${absolutePath}\n替换次数: ${replacedCount}\n原始行数: ${oldLines}\n新行数: ${newLines}${lineDiff !== 0 ? `\n行数变化: ${lineDiff > 0 ? '+' : ''}${lineDiff}` : ''}` };
+    return { ok: true, content: `成功编辑文件: ${displayPath}\nPath: ${displayPath}\n替换次数: ${replacedCount}\n原始行数: ${oldLines}\n新行数: ${newLines}${lineDiff !== 0 ? `\n行数变化: ${lineDiff > 0 ? '+' : ''}${lineDiff}` : ''}` };
   }
 }

--- a/src/tools/glob-tool.ts
+++ b/src/tools/glob-tool.ts
@@ -3,6 +3,8 @@ import * as path from 'path';
 import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import { glob } from 'glob';
 import { isReadPathAllowed } from '../utils/safety';
+import { formatCatsCoVisiblePath, isCatsCoToolGatewayContext, resolveToolGatewayAccess } from './tool-gateway';
+import { executeRemoteReadonlyTool } from './device-rpc-tool';
 
 interface GlobResult {
   numFiles: number;
@@ -43,6 +45,17 @@ export class GlobTool implements Tool {
     const { pattern, path: searchPath, limit = 100 } = args;
     const startTime = Date.now();
 
+    const gateway = resolveToolGatewayAccess(context, {
+      toolName: this.definition.name,
+      operation: 'glob',
+      targetLabel: searchPath || '.',
+    });
+    if (!gateway.ok) {
+      return { ok: false, errorCode: gateway.errorCode, message: gateway.message };
+    }
+    const remoteResult = await executeRemoteReadonlyTool(context, gateway, 'glob', 'glob', args);
+    if (remoteResult) return remoteResult;
+
     // 确定搜索目录
     const cwd = searchPath
       ? (path.isAbsolute(searchPath) ? searchPath : path.join(context.workingDirectory, searchPath))
@@ -53,13 +66,16 @@ export class GlobTool implements Tool {
       return { ok: false, errorCode: 'PERMISSION_DENIED', message: `执行被阻止: ${pathPermission.reason}` };
     }
 
+    const visibleSearchPath = formatCatsCoVisiblePath(context, searchPath || '.', { preserveRelative: true });
+    const visibleCwd = formatCatsCoVisiblePath(context, cwd);
+
     // 检查目录是否存在
     if (!fs.existsSync(cwd)) {
-      return { ok: false, errorCode: 'FILE_NOT_FOUND', message: `目录不存在: ${cwd}` };
+      return { ok: false, errorCode: 'FILE_NOT_FOUND', message: `目录不存在: ${visibleCwd}` };
     }
 
     // 执行 glob 搜索
-    const shouldReturnAbsolutePaths = Boolean(searchPath && path.isAbsolute(searchPath));
+    const shouldReturnAbsolutePaths = !isCatsCoToolGatewayContext(context) && Boolean(searchPath && path.isAbsolute(searchPath));
 
     const files = await glob(pattern, {
       cwd,
@@ -70,7 +86,7 @@ export class GlobTool implements Tool {
     });
 
     if (files.length === 0) {
-      return { ok: true, content: `未找到匹配的文件。\n模式: ${pattern}\n目录: ${searchPath || '.'}\nPath: ${cwd}` };
+      return { ok: true, content: `未找到匹配的文件。\n模式: ${pattern}\n目录: ${visibleSearchPath}\nPath: ${visibleCwd}` };
     }
 
     // 使用Promise.allSettled容错处理stat（文件可能在glob后被删除）
@@ -97,18 +113,18 @@ export class GlobTool implements Tool {
       durationMs: Date.now() - startTime
     };
 
-    return { ok: true, content: this.formatResult(result, pattern, searchPath, cwd) };
+    return { ok: true, content: this.formatResult(result, pattern, visibleSearchPath, visibleCwd) };
   }
 
   private formatResult(
     result: GlobResult,
     pattern: string,
-    searchPath: string | undefined,
-    cwd: string,
+    visibleSearchPath: string,
+    visibleCwd: string,
   ): string {
     const { numFiles, filenames, truncated, durationMs } = result;
 
-    const header = `找到 ${numFiles} 个文件 (${durationMs}ms)${truncated ? ' - 结果已截断，考虑使用更精确的模式' : ''}:\n模式: ${pattern}\n目录: ${searchPath || '.'}\nPath: ${cwd}\n\n`;
+    const header = `找到 ${numFiles} 个文件 (${durationMs}ms)${truncated ? ' - 结果已截断，考虑使用更精确的模式' : ''}:\n模式: ${pattern}\n目录: ${visibleSearchPath}\nPath: ${visibleCwd}\n\n`;
     const fileList = filenames.map((file, i) => `${(i + 1).toString().padStart(4, ' ')}. ${file}`).join('\n');
     
     return header + fileList + (truncated ? '\n\n提示: 结果被限制在前 100 个文件。使用更具体的路径或模式来缩小范围。' : '');

--- a/src/tools/grep-tool.ts
+++ b/src/tools/grep-tool.ts
@@ -3,6 +3,8 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import { isReadPathAllowed } from '../utils/safety';
+import { formatCatsCoVisiblePath, redactCatsCoVisiblePath, resolveToolGatewayAccess } from './tool-gateway';
+import { executeRemoteReadonlyTool } from './device-rpc-tool';
 
 const VCS_DIRECTORIES_TO_EXCLUDE = ['.git', '.svn', '.hg', '.bzr'] as const;
 const DEFAULT_LIMIT = 250;
@@ -100,6 +102,17 @@ export class GrepTool implements Tool {
   async execute(args: any, context: ToolExecutionContext): Promise<ToolExecutionResult> {
     const { pattern, path: searchPath } = args;
 
+    const gateway = resolveToolGatewayAccess(context, {
+      toolName: this.definition.name,
+      operation: 'grep',
+      targetLabel: searchPath || '.',
+    });
+    if (!gateway.ok) {
+      return { ok: false, errorCode: gateway.errorCode, message: gateway.message };
+    }
+    const remoteResult = await executeRemoteReadonlyTool(context, gateway, 'grep', 'grep', args);
+    if (remoteResult) return remoteResult;
+
     const resolvedSearchPath = searchPath
       ? (path.isAbsolute(searchPath) ? searchPath : path.join(context.workingDirectory, searchPath))
       : context.workingDirectory;
@@ -108,12 +121,13 @@ export class GrepTool implements Tool {
     if (!pathPermission.allowed) {
       return { ok: false, errorCode: 'PERMISSION_DENIED', message: `执行被阻止: ${pathPermission.reason}` };
     }
+    const visibleSearchPath = formatCatsCoVisiblePath(context, searchPath || '.', { preserveRelative: true });
 
     // 按优先级尝试各个 fallback
     const fallbacks = [
-      { name: 'ripgrep (rg)', fn: () => this.executeWithRipgrep(args, resolvedSearchPath, context) },
-      { name: 'system grep', fn: () => this.executeWithSystemGrep(args, resolvedSearchPath, context) },
-      { name: 'Node.js glob', fn: () => this.executeWithNodeJS(args, resolvedSearchPath, context) },
+      { name: 'ripgrep (rg)', fn: () => this.executeWithRipgrep(args, resolvedSearchPath, context, visibleSearchPath) },
+      { name: 'system grep', fn: () => this.executeWithSystemGrep(args, resolvedSearchPath, context, visibleSearchPath) },
+      { name: 'Node.js glob', fn: () => this.executeWithNodeJS(args, resolvedSearchPath, context, visibleSearchPath) },
     ];
 
     let lastError: Error | null = null;
@@ -135,11 +149,12 @@ export class GrepTool implements Tool {
     }
 
     // 所有 fallback 都失败
-    const errorMsg = lastError?.message || '所有搜索方法都失败了';
+    const rawErrorMsg = lastError?.message || '所有搜索方法都失败了';
+    const errorMsg = redactCatsCoVisiblePath(context, rawErrorMsg, resolvedSearchPath, visibleSearchPath);
     return { ok: false, errorCode: 'EXECUTION_ERROR', message: errorMsg };
   }
 
-  private async executeWithRipgrep(args: any, searchPath: string, context: ToolExecutionContext): Promise<FallbackResult> {
+  private async executeWithRipgrep(args: any, searchPath: string, context: ToolExecutionContext, visibleSearchPath?: string): Promise<FallbackResult> {
     const { pattern, path: originalPath, glob: globPattern, type: fileType, case_insensitive = false, context: contextLines, output_mode = 'files', limit = DEFAULT_LIMIT, offset = 0 } = args;
     const rgArgs: string[] = ['--color=never', '--no-heading', '--hidden'];
 
@@ -159,11 +174,11 @@ export class GrepTool implements Tool {
 
     try {
       const output = execFileSync('rg', rgArgs, { cwd: context.workingDirectory, encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024, stdio: ['pipe', 'pipe', 'pipe'] }) as string;
-      return { content: this.processOutput(output, args, context) };
+      return { content: this.processOutput(output, args, context, visibleSearchPath) };
     } catch (error: any) {
       if (error.status === 1) {
         // 无匹配，返回格式化的"未找到"
-        return { content: this.formatNoMatch(pattern, originalPath, globPattern, fileType) };
+        return { content: this.formatNoMatch(pattern, visibleSearchPath ?? originalPath, globPattern, fileType) };
       }
       // exit code 2 或其他错误，抛出让 execute 统一处理
       const errorMsg = error.stderr || `rg 执行失败 (exit ${error.status})`;
@@ -171,7 +186,7 @@ export class GrepTool implements Tool {
     }
   }
 
-  private async executeWithSystemGrep(args: any, searchPath: string, context: ToolExecutionContext): Promise<FallbackResult> {
+  private async executeWithSystemGrep(args: any, searchPath: string, context: ToolExecutionContext, visibleSearchPath?: string): Promise<FallbackResult> {
     const { pattern, path: originalPath, glob: globPattern, type: fileType, case_insensitive = false, context: contextLines, output_mode = 'files', limit = DEFAULT_LIMIT, offset = 0 } = args;
     const grepArgs: string[] = [];
 
@@ -194,17 +209,17 @@ export class GrepTool implements Tool {
         processedOutput = lines.filter(line => globRegex.test(path.basename(line.split(':')[0]))).join('\n');
       }
 
-      return { content: this.processOutput(processedOutput, args, context) };
+      return { content: this.processOutput(processedOutput, args, context, visibleSearchPath) };
     } catch (error: any) {
       if (error.status === 1) {
-        return { content: this.formatNoMatch(pattern, originalPath, globPattern, fileType) };
+        return { content: this.formatNoMatch(pattern, visibleSearchPath ?? originalPath, globPattern, fileType) };
       }
       const errorMsg = error.stderr || `grep 执行失败 (exit ${error.status})`;
       throw new Error(errorMsg);
     }
   }
 
-  private async executeWithNodeJS(args: any, searchPath: string, context: ToolExecutionContext): Promise<FallbackResult> {
+  private async executeWithNodeJS(args: any, searchPath: string, context: ToolExecutionContext, visibleSearchPath?: string): Promise<FallbackResult> {
     const { pattern, path: originalPath, glob: globPattern, type: fileType, case_insensitive = false, context: contextLines, output_mode = 'files', limit = DEFAULT_LIMIT, offset = 0 } = args;
 
     if (!fs.existsSync(searchPath)) {
@@ -245,10 +260,10 @@ export class GrepTool implements Tool {
     };
 
     walkDir(searchPath);
-    return { content: this.processOutput(results.join('\n'), args, context) };
+    return { content: this.processOutput(results.join('\n'), args, context, visibleSearchPath) };
   }
 
-  private processOutput(output: string, args: any, context: ToolExecutionContext): string {
+  private processOutput(output: string, args: any, context: ToolExecutionContext, visibleSearchPath?: string): string {
     const { pattern, path: originalPath, glob: globPattern, type: fileType, output_mode = 'files', limit = DEFAULT_LIMIT, offset = 0 } = args;
     const allLines = output.trim().split('\n').filter(Boolean);
     const { items: limitedLines, appliedLimit } = applyHeadLimit(allLines, limit, offset);
@@ -276,7 +291,7 @@ export class GrepTool implements Tool {
       result.numFiles = result.filenames.length;
     }
 
-    return this.formatResult(result, pattern, originalPath, globPattern, fileType);
+    return this.formatResult(result, pattern, visibleSearchPath ?? originalPath, globPattern, fileType);
   }
 
   private formatNoMatch(pattern: string, searchPath: string | undefined, globPattern: string | undefined, fileType: string | undefined): string {

--- a/src/tools/local-file-gateway.ts
+++ b/src/tools/local-file-gateway.ts
@@ -143,9 +143,12 @@ function validateGrant(
   }
 
   const mismatches = [
+    ['source', grant.source, scope.source],
     ['sessionKey', grant.sessionKey, scope.sessionKey],
     ['topicId', grant.topicId, scope.topicId],
+    ['topicType', grant.topicType, scope.topicType],
     ['actorUserId', grant.actorUserId, scope.actorUserId],
+    ['agentId', grant.agentId, scope.agentId],
     ['agentBodyId', grant.agentBodyId, scope.agentBodyId],
     ['deviceBodyId', grant.deviceBodyId, localDeviceGrant.bodyId],
   ].filter(([, grantValue, scopeValue]) => grantValue !== scopeValue);

--- a/src/tools/read-tool.ts
+++ b/src/tools/read-tool.ts
@@ -8,6 +8,8 @@ import { ConfigManager } from '../utils/config';
 import { isPrimaryModelVisionCapable } from '../utils/model-capabilities';
 import { analyzeImageWithReaderProxy, ReaderProxyResult } from '../utils/reader-proxy';
 import { resolveLocalFileAccess, resolveLocalFileReference } from './local-file-gateway';
+import { formatCatsCoVisiblePath, resolveToolGatewayAccess } from './tool-gateway';
+import { executeRemoteReadonlyTool } from './device-rpc-tool';
 
 export const DEFAULT_TEXT_READ_LIMIT = 200;
 export const MAX_TEXT_READ_LIMIT = 2000;
@@ -92,7 +94,9 @@ export class ReadTool implements Tool {
     let absolutePath: string;
     let displayPath = file_path;
     let visiblePath: string;
+    let visibleInputPath = file_path;
     let resolvedFromAttachmentRef = false;
+    let authorizedByLocalFileGrant = false;
 
     const reference = resolveLocalFileReference(context, {
       operation: 'read_file',
@@ -109,17 +113,14 @@ export class ReadTool implements Tool {
       absolutePath = reference.absolutePath;
       displayPath = reference.displayPath;
       visiblePath = reference.displayPath;
+      visibleInputPath = reference.displayPath;
       resolvedFromAttachmentRef = true;
+      authorizedByLocalFileGrant = true;
     } else {
       absolutePath = path.isAbsolute(file_path)
         ? file_path
         : path.join(context.workingDirectory, file_path);
       visiblePath = absolutePath;
-
-      const pathPermission = isReadPathAllowed(absolutePath, context.workingDirectory);
-      if (!pathPermission.allowed) {
-        return { ok: false, errorCode: 'PERMISSION_DENIED', message: `执行被阻止: ${pathPermission.reason}` };
-      }
     }
 
     if (!resolvedFromAttachmentRef) {
@@ -137,7 +138,34 @@ export class ReadTool implements Tool {
       if (localAccess.displayPath) {
         displayPath = localAccess.displayPath;
         visiblePath = localAccess.displayPath;
+        visibleInputPath = localAccess.displayPath;
       }
+      authorizedByLocalFileGrant = Boolean(localAccess.grant);
+    }
+
+    if (!authorizedByLocalFileGrant) {
+      const gateway = resolveToolGatewayAccess(context, {
+        toolName: this.definition.name,
+        operation: 'read_file',
+        targetLabel: displayPath,
+      });
+      if (!gateway.ok) {
+        return {
+          ok: false,
+          errorCode: gateway.errorCode,
+          message: gateway.message,
+        };
+      }
+      const remoteResult = await executeRemoteReadonlyTool(context, gateway, 'read_file', 'read_file', args);
+      if (remoteResult) return remoteResult;
+
+      const pathPermission = isReadPathAllowed(absolutePath, context.workingDirectory);
+      if (!pathPermission.allowed) {
+        return { ok: false, errorCode: 'PERMISSION_DENIED', message: `执行被阻止: ${pathPermission.reason}` };
+      }
+      displayPath = formatCatsCoVisiblePath(context, displayPath, { preserveRelative: true });
+      visiblePath = formatCatsCoVisiblePath(context, visiblePath);
+      visibleInputPath = formatCatsCoVisiblePath(context, file_path);
     }
 
     if (!fs.existsSync(absolutePath)) {
@@ -152,7 +180,7 @@ export class ReadTool implements Tool {
           errorCode: 'TOOL_EXECUTION_ERROR',
           message: [
             'Path is not a file.',
-            `Input path: ${file_path}`,
+            `Input path: ${visibleInputPath}`,
             `Resolved path: ${visiblePath}`,
           ].join('\n'),
         };

--- a/src/tools/send-file-tool.ts
+++ b/src/tools/send-file-tool.ts
@@ -4,6 +4,7 @@ import { Logger } from '../utils/logger';
 import { resolveToolPath } from '../utils/tool-path-resolver';
 import { resolveLocalFileAccess, resolveLocalFileReference } from './local-file-gateway';
 import { resolveOutboundTarget } from './outbound-gateway';
+import { formatCatsCoVisiblePath, resolveToolGatewayAccess } from './tool-gateway';
 
 export class SendFileTool implements Tool {
   definition: ToolDefinition = {
@@ -47,7 +48,9 @@ CatsCo file selection rules:
 
     let absolutePath: string;
     let displayPath: string;
+    let visibleInputPath = file_path;
     let resolvedFromAttachmentRef = false;
+    let authorizedByLocalFileGrant = false;
 
     const reference = resolveLocalFileReference(context, {
       operation: 'send_file',
@@ -63,7 +66,9 @@ CatsCo file selection rules:
       }
       absolutePath = reference.absolutePath;
       displayPath = reference.displayPath;
+      visibleInputPath = reference.displayPath;
       resolvedFromAttachmentRef = true;
+      authorizedByLocalFileGrant = true;
     } else {
       const resolved = resolveToolPath(file_path, context);
       absolutePath = resolved.absolutePath;
@@ -84,7 +89,38 @@ CatsCo file selection rules:
       }
       if (localAccess.displayPath) {
         displayPath = localAccess.displayPath;
+        visibleInputPath = localAccess.displayPath;
       }
+      authorizedByLocalFileGrant = Boolean(localAccess.grant);
+    }
+
+    const earlyTarget = resolveOutboundTarget(context, {
+      operation: 'send_file',
+      missingChannelMessage: '当前不在聊天会话中，无法发送文件',
+    });
+    if (!earlyTarget.ok && /外发目标与当前执行身份不一致/.test(earlyTarget.message)) {
+      return {
+        ok: false,
+        errorCode: earlyTarget.errorCode,
+        message: earlyTarget.message,
+      };
+    }
+
+    if (!authorizedByLocalFileGrant) {
+      const gateway = resolveToolGatewayAccess(context, {
+        toolName: this.definition.name,
+        operation: 'send_file',
+        targetLabel: displayPath,
+      });
+      if (!gateway.ok) {
+        return {
+          ok: false,
+          errorCode: gateway.errorCode,
+          message: gateway.message,
+        };
+      }
+      displayPath = formatCatsCoVisiblePath(context, displayPath, { preserveRelative: true });
+      visibleInputPath = displayPath;
     }
 
     if (!fs.existsSync(absolutePath)) {
@@ -93,7 +129,7 @@ CatsCo file selection rules:
         errorCode: 'FILE_NOT_FOUND',
         message: [
           'File not found.',
-          `Input path: ${file_path}`,
+          `Input path: ${visibleInputPath}`,
           `Resolved path: ${displayPath}`,
         ].join('\n'),
       };
@@ -107,7 +143,7 @@ CatsCo file selection rules:
           errorCode: 'TOOL_EXECUTION_ERROR',
           message: [
             'Path is not a file.',
-            `Input path: ${file_path}`,
+            `Input path: ${visibleInputPath}`,
             `Resolved path: ${displayPath}`,
           ].join('\n'),
         };
@@ -118,7 +154,7 @@ CatsCo file selection rules:
         errorCode: 'FILE_NOT_FOUND',
         message: [
           'File not found.',
-          `Input path: ${file_path}`,
+          `Input path: ${visibleInputPath}`,
           `Resolved path: ${displayPath}`,
         ].join('\n'),
       };
@@ -132,14 +168,14 @@ CatsCo file selection rules:
         errorCode: 'PERMISSION_DENIED',
         message: [
           'File is not readable.',
-          `Input path: ${file_path}`,
+          `Input path: ${visibleInputPath}`,
           `Resolved path: ${displayPath}`,
         ].join('\n'),
       };
     }
 
     const channel = context.channel;
-    const target = resolveOutboundTarget(context, {
+    const target = earlyTarget.ok ? earlyTarget : resolveOutboundTarget(context, {
       operation: 'send_file',
       missingChannelMessage: '当前不在聊天会话中，无法发送文件',
     });

--- a/src/tools/spawn-subagent-tool.ts
+++ b/src/tools/spawn-subagent-tool.ts
@@ -5,6 +5,9 @@ import { AIService } from '../utils/ai-service';
 import { SkillManager } from '../skills/skill-manager';
 import { Logger } from '../utils/logger';
 import { styles } from '../theme/colors';
+import { isCatsCoToolGatewayContext } from './tool-gateway';
+
+const CATSCO_SUBAGENT_ALLOWED_TOOLS = ['ask_parent'] as const;
 
 /**
  * spawn_subagent - 派遣子智能体后台执行隔离任务
@@ -98,6 +101,10 @@ export class SpawnSubagentTool implements Tool {
     if (!maxTurnsResult.ok) {
       return { ok: false, errorCode: 'INVALID_TOOL_ARGUMENTS', message: maxTurnsResult.message };
     }
+    const catsCoSubAgentTools = resolveCatsCoSubAgentAllowedTools(context, allowedToolsResult.value);
+    if (!catsCoSubAgentTools.ok) {
+      return { ok: false, errorCode: 'PERMISSION_DENIED', message: catsCoSubAgentTools.message };
+    }
 
     const manager = SubAgentManager.getInstance();
     const sessionKey = context.sessionId || 'unknown';
@@ -111,7 +118,7 @@ export class SpawnSubagentTool implements Tool {
         agentType,
         toolScope,
         subAgentPrompt,
-        allowedTools: allowedToolsResult.value,
+        allowedTools: catsCoSubAgentTools.value,
         maxTurns: maxTurnsResult.value,
         taskDescription,
         userMessage,
@@ -132,7 +139,7 @@ export class SpawnSubagentTool implements Tool {
     console.log(styles.text(`   ID: ${result.id}`));
     const displayAgentType = result.agentType || agentType || (skillName ? 'skill' : 'worker');
     const displayToolScope = result.toolScope || toolScope || defaultToolScopeFor(displayAgentType);
-    const effectiveAllowedTools = result.allowedTools ?? allowedToolsResult.value;
+    const effectiveAllowedTools = result.allowedTools ?? catsCoSubAgentTools.value;
 
     console.log(styles.text(`   Type: ${displayAgentType}`));
     console.log(styles.text(`   Scope: ${displayToolScope}\n`));
@@ -149,6 +156,35 @@ export class SpawnSubagentTool implements Tool {
       `完成后会以后台结果通知回到主会话；你仍负责主线推进和最终回复。`,
     ].filter(Boolean).join('\n') };
   }
+}
+
+function resolveCatsCoSubAgentAllowedTools(
+  context: ToolExecutionContext,
+  requestedTools?: string[],
+): { ok: true; value?: string[] } | { ok: false; message: string } {
+  const hasCatsCoDeviceContext = isCatsCoToolGatewayContext(context)
+    && Boolean(context.executionScope || context.deviceGrants?.length || context.localFileGrants?.length || context.localDeviceGrant);
+  if (!hasCatsCoDeviceContext) {
+    return { ok: true, value: requestedTools };
+  }
+
+  if (!requestedTools) {
+    return { ok: true, value: [...CATSCO_SUBAGENT_ALLOWED_TOOLS] };
+  }
+
+  const deniedTools = requestedTools.filter(tool => !CATSCO_SUBAGENT_ALLOWED_TOOLS.includes(tool as any));
+  if (deniedTools.length > 0) {
+    return {
+      ok: false,
+      message: [
+        'CatsCo 用户设备授权不会传递给子智能体，已阻止子智能体使用本地文件或命令工具。',
+        `被拒绝的工具: ${deniedTools.join(', ')}`,
+        '请在主会话当前 turn 中直接使用已授权工具，或让子智能体通过 ask_parent 请求主会话继续处理。',
+      ].join('\n'),
+    };
+  }
+
+  return { ok: true, value: requestedTools };
 }
 
 function normalizeMaxTurns(value: unknown): { ok: true; value?: number } | { ok: false; message: string } {

--- a/src/tools/tool-gateway.ts
+++ b/src/tools/tool-gateway.ts
@@ -1,0 +1,316 @@
+import type { DeviceGrantOperation, ScopedDeviceGrant, ScopedDeviceSelection, ScopedLocalDeviceGrant } from '../types/session-identity';
+import type { ToolErrorCode, ToolExecutionContext } from '../types/tool';
+import { resolveDeviceGrant } from '../core/device-grants';
+
+export type ToolGatewayDecision =
+  | {
+      ok: true;
+      mode: 'local';
+      grant?: ScopedDeviceGrant;
+      targetDeviceId?: string;
+      targetDeviceDisplayName?: string;
+    }
+  | {
+      ok: true;
+      mode: 'remote';
+      grant: ScopedDeviceGrant;
+      targetDeviceId: string;
+      targetDeviceDisplayName?: string;
+      targetDeviceBodyId?: string;
+      targetDeviceInstallationId?: string;
+    }
+  | { ok: false; errorCode: ToolErrorCode; message: string };
+
+export interface ResolveToolGatewayAccessOptions {
+  toolName: string;
+  operation: DeviceGrantOperation;
+  targetLabel?: string;
+  allowCatsCoShell?: boolean;
+}
+
+export interface CatsCoVisiblePathOptions {
+  fallback?: string;
+  preserveRelative?: boolean;
+}
+
+const REMOTE_READONLY_OPERATIONS = new Set<DeviceGrantOperation>(['read_file', 'glob', 'grep']);
+
+export function isCatsCoToolGatewayContext(context: ToolExecutionContext): boolean {
+  return context.surface === 'catscompany' || context.executionScope?.source === 'catscompany';
+}
+
+export function formatCatsCoVisiblePath(
+  context: ToolExecutionContext,
+  value: string | undefined,
+  options: CatsCoVisiblePathOptions = {},
+): string {
+  const fallback = options.fallback ?? '[current CatsCo device]';
+  const text = String(value || '').trim();
+  if (!isCatsCoToolGatewayContext(context)) {
+    return text || fallback;
+  }
+  if (!text) return fallback;
+  if (/^catsco_attachment:[A-Za-z0-9._:-]+$/.test(text)) return text;
+  if (/^\[CatsCo [^\]]+\]$/.test(text)) return text;
+  if (options.preserveRelative && !looksLikeAbsoluteLocalPath(text)) return text;
+  return fallback;
+}
+
+export function redactCatsCoVisiblePath(
+  context: ToolExecutionContext,
+  message: unknown,
+  rawPath: string,
+  visiblePath?: string,
+): string {
+  const text = String(message || '');
+  if (!isCatsCoToolGatewayContext(context) || !rawPath) return text;
+  const replacement = visiblePath ?? formatCatsCoVisiblePath(context, rawPath);
+  return text.split(rawPath).join(replacement);
+}
+
+export function resolveToolGatewayAccess(
+  context: ToolExecutionContext,
+  options: ResolveToolGatewayAccessOptions,
+): ToolGatewayDecision {
+  if (!isCatsCoToolGatewayContext(context)) {
+    return { ok: true, mode: 'local' };
+  }
+
+  if (options.operation === 'execute_shell' && !options.allowCatsCoShell) {
+    return denied([
+      'CatsCo 会话暂不允许通过 execute_shell 直接操作本机命令行。',
+      '当前 PR 只开放文件级设备授权；命令执行需要后续独立审批和更细的命令策略。',
+    ], options.targetLabel);
+  }
+
+  const scope = context.executionScope;
+  if (!scope || scope.source !== 'catscompany') {
+    return denied(['当前工具调用缺少 CatsCo 执行身份，已阻止本地设备操作。'], options.targetLabel);
+  }
+
+  if (scope.identityTrust !== 'server_canonical' || !scope.isTrusted) {
+    return denied(['当前消息身份未通过服务端一致性校验，已阻止本地设备操作。'], options.targetLabel);
+  }
+
+  const localDevice = context.localDeviceGrant;
+  if (!localDevice || localDevice.source !== 'catscompany') {
+    return denied(['当前运行体缺少 CatsCo 本机设备绑定，已阻止本地设备操作。'], options.targetLabel);
+  }
+
+  const selectionScope = validateSelectionScope(context.deviceSelection, scope, options.targetLabel);
+  if (!selectionScope.ok) return selectionScope;
+
+  const selectedTarget = resolveBackendSelectedDevice(
+    context.deviceSelection,
+    localDevice,
+    options.operation,
+    options.targetLabel,
+  );
+  if (!selectedTarget.ok) return selectedTarget;
+
+  const targetDeviceId = selectedTarget.deviceId || localDevice.deviceId || localDevice.installationId || localDevice.bodyId;
+  const decision = resolveDeviceGrant(context, {
+    operation: options.operation,
+    deviceId: targetDeviceId,
+  });
+  if (!decision.ok) {
+    return denied([
+      `当前会话没有允许当前设备执行 ${options.operation} 的短期授权，已阻止 ${options.toolName}。`,
+      '请确认用户已在对应设备授权，或等待服务端为本轮消息下发匹配的 device_grant。',
+    ], options.targetLabel);
+  }
+
+  const grant = decision.grant;
+  if (selectedTarget.mode === 'remote') {
+    if (!REMOTE_READONLY_OPERATIONS.has(options.operation)) {
+      return denied([
+        `后端选定的用户设备不是当前运行体，但 ${options.operation} 还没有开放远程执行。`,
+        '当前 PR 只开放 read_file / glob / grep 三个只读远程工具。',
+      ], options.targetLabel);
+    }
+    if (!context.deviceRpc) {
+      return denied([
+        '后端选定的用户设备不是当前运行体，且当前运行体没有配置远程设备 RPC 通道。',
+        '已阻止本地 fallback，避免误操作当前设备或串设备。',
+        selectedTarget.displayName ? `Selected device: ${selectedTarget.displayName}` : '',
+      ], options.targetLabel);
+    }
+    return {
+      ok: true,
+      mode: 'remote',
+      grant,
+      targetDeviceId: selectedTarget.deviceId,
+      targetDeviceDisplayName: selectedTarget.displayName,
+      targetDeviceBodyId: selectedTarget.bodyId,
+      targetDeviceInstallationId: selectedTarget.installationId,
+    };
+  }
+
+  const mismatches: string[] = [];
+  if (grant.deviceBodyId && localDevice.bodyId && grant.deviceBodyId !== localDevice.bodyId) {
+    mismatches.push('device body');
+  }
+  if (grant.deviceInstallationId && localDevice.installationId && grant.deviceInstallationId !== localDevice.installationId) {
+    mismatches.push('device installation');
+  }
+  if (mismatches.length > 0) {
+    return denied([
+      '设备授权与当前运行体不一致，已阻止本地设备操作以避免串设备。',
+      `不一致字段: ${mismatches.join(', ')}`,
+    ], options.targetLabel);
+  }
+
+  return {
+    ok: true,
+    mode: 'local',
+    grant,
+    targetDeviceId,
+    targetDeviceDisplayName: selectedTarget.displayName,
+  };
+}
+
+type SelectedDeviceDecision =
+  | {
+      ok: true;
+      mode: 'local';
+      deviceId?: string;
+      displayName?: string;
+    }
+  | {
+      ok: true;
+      mode: 'remote';
+      deviceId: string;
+      displayName?: string;
+      bodyId?: string;
+      installationId?: string;
+    }
+  | { ok: false; errorCode: ToolErrorCode; message: string };
+
+function resolveBackendSelectedDevice(
+  selection: ScopedDeviceSelection | undefined,
+  localDevice: ScopedLocalDeviceGrant,
+  operation: DeviceGrantOperation,
+  targetLabel?: string,
+): SelectedDeviceDecision {
+  if (!selection) {
+    return {
+      ok: true,
+      mode: 'local',
+      deviceId: localDevice.deviceId || localDevice.installationId || localDevice.bodyId,
+    };
+  }
+
+  if (selection.status === 'needs_selection') {
+    return selectedDenied([
+      '后端尚未选定要操作的用户设备，已阻止本地设备操作。',
+      '请让用户从可用设备中选择一个设备名后再继续。',
+    ], targetLabel);
+  }
+  if (selection.status === 'unavailable') {
+    return selectedDenied([
+      '当前用户没有可用的在线设备授权，已阻止本地设备操作。',
+      '请让用户打开并授权目标设备后再继续。',
+    ], targetLabel);
+  }
+
+  const selectedDeviceId = selection.selectedDeviceId;
+  if (!selectedDeviceId) {
+    return selectedDenied(['后端设备选择缺少 selectedDeviceId，已阻止本地设备操作。'], targetLabel);
+  }
+
+  if (Array.isArray(selection.selectedDeviceOperations)
+    && selection.selectedDeviceOperations.length > 0
+    && !selection.selectedDeviceOperations.includes(operation)) {
+    return selectedDenied([
+      `后端选定设备没有声明支持 ${operation}，已阻止设备工具调用。`,
+      selection.selectedDeviceDisplayName ? `Selected device: ${selection.selectedDeviceDisplayName}` : '',
+    ], targetLabel);
+  }
+
+  if (matchesLocalDevice(selection, localDevice)) {
+    return {
+      ok: true,
+      mode: 'local',
+      deviceId: selectedDeviceId,
+      displayName: selection.selectedDeviceDisplayName,
+    };
+  }
+
+  return {
+    ok: true,
+    mode: 'remote',
+    deviceId: selectedDeviceId,
+    displayName: selection.selectedDeviceDisplayName,
+    bodyId: selection.selectedDeviceBodyId,
+    installationId: selection.selectedDeviceInstallationId,
+  };
+}
+
+function selectedDenied(lines: string[], targetLabel?: string): SelectedDeviceDecision {
+  return denied(lines, targetLabel) as Extract<SelectedDeviceDecision, { ok: false }>;
+}
+
+function validateSelectionScope(
+  selection: ScopedDeviceSelection | undefined,
+  scope: NonNullable<ToolExecutionContext['executionScope']>,
+  targetLabel?: string,
+): ToolGatewayDecision {
+  if (!selection) return { ok: true, mode: 'local' };
+  if (selection.identityTrust !== 'server_canonical') {
+    return denied(['后端设备选择不是服务端可信身份生成的，已阻止设备工具调用。'], targetLabel);
+  }
+  const mismatches = [
+    ['source', selection.source, scope.source],
+    ['sessionKey', selection.sessionKey, scope.sessionKey],
+    ['topicId', selection.topicId, scope.topicId],
+    ['topicType', selection.topicType, scope.topicType],
+    ['actorUserId', selection.actorUserId, scope.actorUserId],
+    ['agentId', selection.agentId, scope.agentId],
+  ].filter(([, selectionValue, scopeValue]) => selectionValue !== scopeValue);
+  if (mismatches.length === 0) return { ok: true, mode: 'local' };
+  return denied([
+    '后端设备选择与当前执行身份不一致，已阻止设备工具调用以避免串用户或串会话。',
+    ...mismatches.map(([field, selectionValue, scopeValue]) => `${field}: selection=${selectionValue || '(empty)'} scope=${scopeValue || '(empty)'}`),
+  ], targetLabel);
+}
+
+function matchesLocalDevice(selection: ScopedDeviceSelection, localDevice: ScopedLocalDeviceGrant): boolean {
+  const selectedIds = [
+    selection.selectedDeviceId,
+    selection.selectedDeviceInstallationId,
+    selection.selectedDeviceBodyId,
+  ].filter(Boolean);
+  const localIds = [
+    localDevice.deviceId,
+    localDevice.installationId,
+    localDevice.bodyId,
+  ].filter(Boolean);
+  if (selectedIds.length === 0 || localIds.length === 0) return false;
+  return selectedIds.some(selected => localIds.includes(selected));
+}
+
+function denied(lines: string[], targetLabel?: string): ToolGatewayDecision {
+  return {
+    ok: false,
+    errorCode: 'PERMISSION_DENIED',
+    message: [
+      ...lines,
+      targetLabel ? `Target: ${sanitizeTargetLabel(targetLabel)}` : '',
+    ].filter(Boolean).join('\n'),
+  };
+}
+
+function sanitizeTargetLabel(value: string): string {
+  const text = String(value || '').trim();
+  if (!text) return '[current CatsCo device]';
+  if (/^catsco_attachment:[A-Za-z0-9._:-]+$/.test(text)) return text;
+  if (/^\[CatsCo [^\]]+\]$/.test(text)) return text;
+  return '[current CatsCo device]';
+}
+
+function looksLikeAbsoluteLocalPath(value: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(value)
+    || /^\\\\/.test(value)
+    || /^\//.test(value)
+    || /^~[\\/]/.test(value);
+}

--- a/src/tools/write-tool.ts
+++ b/src/tools/write-tool.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import { Logger } from '../utils/logger';
 import { isToolAllowed, isPathAllowed } from '../utils/safety';
+import { formatCatsCoVisiblePath, resolveToolGatewayAccess } from './tool-gateway';
 
 /**
  * Write 工具 - 写入文件内容
@@ -45,9 +46,19 @@ export class WriteTool implements Tool {
       return { ok: false, errorCode: 'PERMISSION_DENIED', message: `执行被阻止: ${pathPermission.reason}` };
     }
 
+    const gateway = resolveToolGatewayAccess(context, {
+      toolName: this.definition.name,
+      operation: 'write_file',
+      targetLabel: file_path,
+    });
+    if (!gateway.ok) {
+      return { ok: false, errorCode: gateway.errorCode, message: gateway.message };
+    }
+
     // 获取相对路径用于显示
     const relativePath = path.relative(context.workingDirectory, absolutePath);
-    const displayPath = relativePath.startsWith('..') ? absolutePath : relativePath;
+    const rawDisplayPath = relativePath.startsWith('..') ? absolutePath : relativePath;
+    const displayPath = formatCatsCoVisiblePath(context, rawDisplayPath, { preserveRelative: true });
 
     // 检查文件是否已存在
     const fileExists = fs.existsSync(absolutePath);
@@ -89,6 +100,6 @@ export class WriteTool implements Tool {
       }
     }
 
-    return { ok: true, content: `成功${operation}文件: ${file_path}\nPath: ${absolutePath}\n行数: ${lines}\n大小: ${sizeKB} KB (${bytes} bytes)` };
+    return { ok: true, content: `成功${operation}文件: ${displayPath}\nPath: ${displayPath}\n行数: ${lines}\n大小: ${sizeKB} KB (${bytes} bytes)` };
   }
 }

--- a/src/types/session-identity.ts
+++ b/src/types/session-identity.ts
@@ -72,6 +72,18 @@ export interface SessionRoute {
 export type LocalFileGrantKind = 'catscompany_attachment';
 export type LocalFileGrantFileType = 'file' | 'image' | 'unknown';
 export type LocalFileGrantOperation = 'read_file' | 'send_file';
+export type UserDeviceStatus = 'unknown' | 'online' | 'offline';
+export type DeviceGrantStatus = 'active' | 'revoked';
+export type DeviceGrantOperation =
+  | 'read_file'
+  | 'write_file'
+  | 'edit_file'
+  | 'send_file'
+  | 'execute_shell'
+  | 'glob'
+  | 'grep'
+  | 'browser_control'
+  | 'desktop_control';
 
 export interface ScopedLocalDeviceGrant {
   kind: 'catscompany_body';
@@ -80,6 +92,44 @@ export interface ScopedLocalDeviceGrant {
   installationId?: string;
   deviceId?: string;
   createdAt: number;
+}
+
+export interface UserDevice {
+  kind: 'user_device';
+  source: MessageSource;
+  ownerUserId: string;
+  deviceId: string;
+  displayName?: string;
+  bodyId?: string;
+  installationId?: string;
+  identityTrust: IdentityTrustLevel;
+  identitySource?: string;
+  status: UserDeviceStatus;
+  registeredAt: number;
+  lastSeenAt?: number;
+}
+
+export interface ScopedDeviceGrant {
+  kind: 'user_device_grant';
+  source: MessageSource;
+  grantId: string;
+  status: DeviceGrantStatus;
+  identityTrust: IdentityTrustLevel;
+  identitySource?: string;
+  deviceId: string;
+  deviceDisplayName?: string;
+  deviceBodyId?: string;
+  deviceInstallationId?: string;
+  ownerUserId: string;
+  sessionKey: string;
+  topicId: string;
+  topicType: MessageTopicType;
+  actorUserId: string;
+  agentId?: string;
+  agentBodyId?: string;
+  operations: DeviceGrantOperation[];
+  createdAt: number;
+  expiresAt: number;
 }
 
 export interface ScopedLocalFileGrant {

--- a/src/types/session-identity.ts
+++ b/src/types/session-identity.ts
@@ -74,6 +74,7 @@ export type LocalFileGrantFileType = 'file' | 'image' | 'unknown';
 export type LocalFileGrantOperation = 'read_file' | 'send_file';
 export type UserDeviceStatus = 'unknown' | 'online' | 'offline';
 export type DeviceGrantStatus = 'active' | 'revoked';
+export type DeviceSelectionStatus = 'selected' | 'needs_selection' | 'unavailable';
 export type DeviceGrantOperation =
   | 'read_file'
   | 'write_file'
@@ -130,6 +131,35 @@ export interface ScopedDeviceGrant {
   operations: DeviceGrantOperation[];
   createdAt: number;
   expiresAt: number;
+}
+
+export interface DeviceSelectionCandidate {
+  deviceId: string;
+  displayName?: string;
+  operations?: DeviceGrantOperation[];
+  lastSeenAt?: number;
+}
+
+export interface ScopedDeviceSelection {
+  kind: 'user_device_selection';
+  source: MessageSource;
+  status: DeviceSelectionStatus;
+  selectionSource?: string;
+  sessionKey: string;
+  topicId: string;
+  topicType: MessageTopicType;
+  actorUserId: string;
+  agentId?: string;
+  identityTrust: IdentityTrustLevel;
+  identitySource?: string;
+  selectedDeviceId?: string;
+  selectedDeviceDisplayName?: string;
+  selectedDeviceBodyId?: string;
+  selectedDeviceInstallationId?: string;
+  selectedDeviceOperations?: DeviceGrantOperation[];
+  candidates?: DeviceSelectionCandidate[];
+  candidateCount?: number;
+  createdAt?: number;
 }
 
 export interface ScopedLocalFileGrant {

--- a/src/types/tool.ts
+++ b/src/types/tool.ts
@@ -1,5 +1,10 @@
 import { ContentBlock } from './index';
-import type { ExecutionScope, ScopedLocalDeviceGrant, ScopedLocalFileGrant } from './session-identity';
+import type {
+  ExecutionScope,
+  ScopedDeviceGrant,
+  ScopedLocalDeviceGrant,
+  ScopedLocalFileGrant,
+} from './session-identity';
 import type { PlanRuntime, RuntimePlanSnapshot } from '../core/plan-runtime';
 import type { AIService } from '../utils/ai-service';
 import type { SkillManager } from '../skills/skill-manager';
@@ -146,6 +151,8 @@ export interface ToolExecutionContext {
   executionScope?: ExecutionScope;
   /** 当前本机运行体授权，例如 CatsCo body/device 绑定。 */
   localDeviceGrant?: ScopedLocalDeviceGrant;
+  /** 当前 turn 已授权的用户设备资源，供未来远程设备工具校验。 */
+  deviceGrants?: ScopedDeviceGrant[];
   /** 当前 turn 已授权的本地文件资源，例如用户本轮上传的 CatsCo 附件缓存。 */
   localFileGrants?: ScopedLocalFileGrant[];
 }

--- a/src/types/tool.ts
+++ b/src/types/tool.ts
@@ -2,6 +2,7 @@ import { ContentBlock } from './index';
 import type {
   ExecutionScope,
   ScopedDeviceGrant,
+  ScopedDeviceSelection,
   ScopedLocalDeviceGrant,
   ScopedLocalFileGrant,
 } from './session-identity';
@@ -89,6 +90,18 @@ export type ToolExecutionResult =
   | { ok: true; content: string | import('./index').ContentBlock[] }
   | { ok: false; errorCode: string; message: string; retryable?: boolean };
 
+export interface DeviceRpcToolRequest {
+  toolName: string;
+  operation: ScopedDeviceGrant['operations'][number];
+  args: Record<string, unknown>;
+  grant: ScopedDeviceGrant;
+  timeoutMs?: number;
+}
+
+export interface DeviceRpcTransport {
+  executeTool(request: DeviceRpcToolRequest): Promise<ToolExecutionResult>;
+}
+
 export type ToolErrorCode =
   | 'TOOL_NOT_FOUND'
   | 'INVALID_TOOL_ARGUMENTS'
@@ -153,6 +166,10 @@ export interface ToolExecutionContext {
   localDeviceGrant?: ScopedLocalDeviceGrant;
   /** 当前 turn 已授权的用户设备资源，供未来远程设备工具校验。 */
   deviceGrants?: ScopedDeviceGrant[];
+  /** 服务端为当前 turn 选定的用户设备，或明确要求先选择设备。 */
+  deviceSelection?: ScopedDeviceSelection;
+  /** CatsCo 远程设备 RPC 通道。工具只能通过窄接口请求后端选定设备执行。 */
+  deviceRpc?: DeviceRpcTransport;
   /** 当前 turn 已授权的本地文件资源，例如用户本轮上传的 CatsCo 附件缓存。 */
   localFileGrants?: ScopedLocalFileGrant[];
 }

--- a/tests/agent-turn-execution-scope.test.ts
+++ b/tests/agent-turn-execution-scope.test.ts
@@ -14,6 +14,8 @@ test('AgentSession accepts executionScope in HandleMessageOptions', () => {
   assert.match(agentSessionSource, /executionScope\s*=\s*opts\.executionScope/);
   assert.match(agentSessionSource, /localDeviceGrant\?:\s*ScopedLocalDeviceGrant/);
   assert.match(agentSessionSource, /localDeviceGrant\s*=\s*opts\.localDeviceGrant/);
+  assert.match(agentSessionSource, /deviceGrants\?:\s*ScopedDeviceGrant\[\]/);
+  assert.match(agentSessionSource, /deviceGrants\s*=\s*opts\.deviceGrants/);
   assert.match(agentSessionSource, /localFileGrants\?:\s*ScopedLocalFileGrant\[\]/);
   assert.match(agentSessionSource, /localFileGrants\s*=\s*opts\.localFileGrants/);
 });
@@ -21,11 +23,14 @@ test('AgentSession accepts executionScope in HandleMessageOptions', () => {
 test('AgentTurnController forwards executionScope into ToolExecutionContext', () => {
   assert.match(agentTurnSource, /executionScope\?:\s*ExecutionScope/);
   assert.match(agentTurnSource, /localDeviceGrant\?:\s*ScopedLocalDeviceGrant/);
+  assert.match(agentTurnSource, /deviceGrants\?:\s*ScopedDeviceGrant\[\]/);
   assert.match(agentTurnSource, /localFileGrants\?:\s*ScopedLocalFileGrant\[\]/);
   assert.match(agentTurnSource, /executionScope:\s*params\.executionScope/);
   assert.match(agentTurnSource, /executionScope:\s*options\.executionScope/);
   assert.match(agentTurnSource, /localDeviceGrant:\s*params\.localDeviceGrant/);
   assert.match(agentTurnSource, /localDeviceGrant:\s*options\.localDeviceGrant/);
+  assert.match(agentTurnSource, /deviceGrants:\s*params\.deviceGrants/);
+  assert.match(agentTurnSource, /deviceGrants:\s*options\.deviceGrants/);
   assert.match(agentTurnSource, /localFileGrants:\s*params\.localFileGrants/);
   assert.match(agentTurnSource, /localFileGrants:\s*options\.localFileGrants/);
 });
@@ -33,6 +38,7 @@ test('AgentTurnController forwards executionScope into ToolExecutionContext', ()
 test('ToolExecutionContext exposes executionScope for future ToolGateway checks', () => {
   assert.match(toolTypesSource, /executionScope\?:\s*ExecutionScope/);
   assert.match(toolTypesSource, /localDeviceGrant\?:\s*ScopedLocalDeviceGrant/);
+  assert.match(toolTypesSource, /deviceGrants\?:\s*ScopedDeviceGrant\[\]/);
   assert.match(toolTypesSource, /localFileGrants\?:\s*ScopedLocalFileGrant\[\]/);
 });
 

--- a/tests/catscompany-client-body-id.test.ts
+++ b/tests/catscompany-client-body-id.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, beforeEach, describe, test } from 'node:test';
 import * as assert from 'node:assert';
+import { createServer, type Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { WebSocketServer } from 'ws';
-import { CatsClient } from '../src/catscompany/client';
+import { CatsClient, type CatsDeviceRpcMessage } from '../src/catscompany/client';
 
 describe('CatsCompany client body identity', () => {
   const servers: WebSocketServer[] = [];
+  const httpServers: Server[] = [];
   const identityEnvKeys = [
     'CATSCO_BODY_ID',
     'CATSCOMPANY_BODY_ID',
@@ -24,6 +26,9 @@ describe('CatsCompany client body identity', () => {
 
   afterEach(() => {
     for (const server of servers.splice(0)) {
+      server.close();
+    }
+    for (const server of httpServers.splice(0)) {
       server.close();
     }
     for (const key of identityEnvKeys) {
@@ -76,5 +81,394 @@ describe('CatsCompany client body identity', () => {
     });
 
     assert.throws(() => client.connect(), /bodyId missing/);
+  });
+
+  test('includes local device registration in websocket hi', async () => {
+    const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    servers.push(server);
+    await new Promise<void>(resolve => server.once('listening', resolve));
+
+    const hiPromise = new Promise<any>(resolve => {
+      server.once('connection', socket => {
+        socket.once('message', data => {
+          resolve(JSON.parse(data.toString()));
+          socket.close();
+        });
+      });
+    });
+
+    const address = server.address() as AddressInfo;
+    const client = new CatsClient({
+      serverUrl: `ws://127.0.0.1:${address.port}`,
+      apiKey: 'cc-test-key',
+      bodyId: 'body-test',
+      installationId: 'install-test',
+      deviceRegistration: {
+        device_id: 'install-test',
+        display_name: 'Test Device',
+        body_id: 'body-test',
+        installation_id: 'install-test',
+        status: 'online',
+        capabilities: ['read_file'],
+      },
+    });
+    client.on('error', () => undefined);
+    client.connect();
+
+    const hi = await hiPromise;
+    client.disconnect();
+
+    assert.deepEqual(hi.hi.device, {
+      device_id: 'install-test',
+      display_name: 'Test Device',
+      body_id: 'body-test',
+      installation_id: 'install-test',
+      status: 'online',
+      capabilities: ['read_file'],
+    });
+  });
+
+  test('registers device capabilities through CatsCompany HTTP API', async () => {
+    const requestPromise = new Promise<{ url?: string; method?: string; headers: Record<string, string | string[] | undefined>; body: any }>((resolve, reject) => {
+      const server = createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on('data', chunk => chunks.push(Buffer.from(chunk)));
+        req.on('end', () => {
+          const body = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+          resolve({ url: req.url, method: req.method, headers: req.headers, body });
+          res.setHeader('Content-Type', 'application/json');
+          res.end(JSON.stringify({ device: { deviceId: body.device_id } }));
+        });
+      });
+      httpServers.push(server);
+      server.listen(0, '127.0.0.1', () => {
+        void (async () => {
+          const address = server.address() as AddressInfo;
+          const client = new CatsClient({
+            serverUrl: 'ws://127.0.0.1:1/v0/channels',
+            httpBaseUrl: `http://127.0.0.1:${address.port}`,
+            apiKey: 'cc-test-key',
+            bodyId: 'body-test',
+            installationId: 'install-test',
+          });
+          await client.registerDevice({
+            device_id: 'install-test',
+            display_name: 'Test Device',
+            body_id: 'body-test',
+            installation_id: 'install-test',
+            status: 'online',
+            capabilities: ['read_file', 'send_file'],
+          });
+        })().catch(reject);
+      });
+    });
+
+    const request = await requestPromise;
+    assert.equal(request.method, 'POST');
+    assert.equal(request.url, '/api/devices/register');
+    assert.equal(request.headers.authorization, 'ApiKey cc-test-key');
+    assert.equal(request.headers['content-type'], 'application/json');
+    assert.deepEqual(request.body, {
+      device_id: 'install-test',
+      display_name: 'Test Device',
+      body_id: 'body-test',
+      installation_id: 'install-test',
+      status: 'online',
+      capabilities: ['read_file', 'send_file'],
+    });
+  });
+
+  test('emits device rpc requests outside the regular message stream', async () => {
+    const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    servers.push(server);
+    await new Promise<void>(resolve => server.once('listening', resolve));
+
+    server.once('connection', socket => {
+      socket.once('message', () => {
+        socket.send(JSON.stringify({
+          device_rpc: {
+            type: 'request',
+            request_id: 'rpc-inbound-1',
+            grant_id: 'grant-1',
+            device_id: 'install-test',
+            operation: 'ping',
+          },
+        }));
+      });
+    });
+
+    const address = server.address() as AddressInfo;
+    const client = new CatsClient({
+      serverUrl: `ws://127.0.0.1:${address.port}`,
+      apiKey: 'cc-test-key',
+      bodyId: 'body-test',
+      installationId: 'install-test',
+    });
+    client.on('error', () => undefined);
+
+    let regularMessageSeen = false;
+    client.on('message', () => {
+      regularMessageSeen = true;
+    });
+    const requestPromise = new Promise<CatsDeviceRpcMessage>(resolve => {
+      client.once('device_rpc_request', resolve);
+    });
+
+    client.connect();
+    const request = await requestPromise;
+    client.disconnect();
+
+    assert.equal(request.request_id, 'rpc-inbound-1');
+    assert.equal(request.operation, 'ping');
+    assert.equal(regularMessageSeen, false);
+  });
+
+  test('sends device rpc requests and resolves matching results', async () => {
+    const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    servers.push(server);
+    await new Promise<void>(resolve => server.once('listening', resolve));
+
+    const requestPromise = new Promise<any>(resolve => {
+      server.once('connection', socket => {
+        socket.on('message', data => {
+          const msg = JSON.parse(data.toString());
+          if (msg.hi) {
+            socket.send(JSON.stringify({
+              ctrl: {
+                id: msg.hi.id,
+                code: 200,
+                params: {
+                  build: 'catscompany',
+                  ver: '0.1.0',
+                  features: ['client_msg_id', 'device_rpc'],
+                  uid: 'usr42',
+                  name: 'Agent',
+                },
+              },
+            }));
+            return;
+          }
+          if (msg.device_rpc?.type === 'request') {
+            resolve(msg.device_rpc);
+            socket.send(JSON.stringify({ ctrl: { id: msg.device_rpc.id, code: 200, text: 'ok' } }));
+            socket.send(JSON.stringify({
+              device_rpc: {
+                type: 'result',
+                request_id: msg.device_rpc.request_id,
+                result: { ok: true },
+              },
+            }));
+          }
+        });
+      });
+    });
+
+    const address = server.address() as AddressInfo;
+    const client = new CatsClient({
+      serverUrl: `ws://127.0.0.1:${address.port}`,
+      apiKey: 'cc-test-key',
+      bodyId: 'body-agent',
+      installationId: 'install-agent',
+    });
+    client.on('error', () => undefined);
+    await new Promise<void>(resolve => {
+      client.once('ready', () => resolve());
+      client.connect();
+    });
+
+    const result = await client.sendDeviceRpcRequest({
+      request_id: 'rpc-outbound-1',
+      grant_id: 'grant-1',
+      device_id: 'install-test',
+      operation: 'ping',
+      payload: { value: 1 },
+    });
+    const request = await requestPromise;
+    client.disconnect();
+
+    assert.equal(request.request_id, 'rpc-outbound-1');
+    assert.equal(request.grant_id, 'grant-1');
+    assert.equal(request.operation, 'ping');
+    assert.deepEqual(result.result, { ok: true });
+  });
+
+  test('rejects device rpc request when ack fails after an early result', async () => {
+    const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    servers.push(server);
+    await new Promise<void>(resolve => server.once('listening', resolve));
+
+    server.once('connection', socket => {
+      socket.on('message', data => {
+        const msg = JSON.parse(data.toString());
+        if (msg.hi) {
+          socket.send(JSON.stringify({
+            ctrl: {
+              id: msg.hi.id,
+              code: 200,
+              params: {
+                build: 'catscompany',
+                ver: '0.1.0',
+                features: ['client_msg_id', 'device_rpc'],
+                uid: 'usr42',
+                name: 'Agent',
+              },
+            },
+          }));
+          return;
+        }
+        if (msg.device_rpc?.type === 'request') {
+          socket.send(JSON.stringify({
+            device_rpc: {
+              type: 'result',
+              request_id: msg.device_rpc.request_id,
+              result: { ok: true },
+            },
+          }));
+          socket.send(JSON.stringify({ ctrl: { id: msg.device_rpc.id, code: 500, text: 'nack after result' } }));
+        }
+      });
+    });
+
+    const address = server.address() as AddressInfo;
+    const client = new CatsClient({
+      serverUrl: `ws://127.0.0.1:${address.port}`,
+      apiKey: 'cc-test-key',
+      bodyId: 'body-agent',
+      installationId: 'install-agent',
+    });
+    client.on('error', () => undefined);
+    await new Promise<void>(resolve => {
+      client.once('ready', () => resolve());
+      client.connect();
+    });
+
+    await assert.rejects(
+      () => client.sendDeviceRpcRequest({
+        request_id: 'rpc-early-result-nack',
+        grant_id: 'grant-1',
+        device_id: 'install-test',
+        operation: 'ping',
+      }),
+      /ack 500/
+    );
+    client.disconnect();
+  });
+
+  test('rejects device rpc results whose scope does not match the pending request', async () => {
+    const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    servers.push(server);
+    await new Promise<void>(resolve => server.once('listening', resolve));
+
+    server.once('connection', socket => {
+      socket.on('message', data => {
+        const msg = JSON.parse(data.toString());
+        if (msg.hi) {
+          socket.send(JSON.stringify({
+            ctrl: {
+              id: msg.hi.id,
+              code: 200,
+              params: {
+                build: 'catscompany',
+                ver: '0.1.0',
+                features: ['client_msg_id', 'device_rpc'],
+                uid: 'usr42',
+                name: 'Agent',
+              },
+            },
+          }));
+          return;
+        }
+        if (msg.device_rpc?.type === 'request') {
+          socket.send(JSON.stringify({ ctrl: { id: msg.device_rpc.id, code: 200, text: 'ok' } }));
+          socket.send(JSON.stringify({
+            device_rpc: {
+              type: 'result',
+              request_id: msg.device_rpc.request_id,
+              grant_id: 'wrong-grant',
+              device_id: msg.device_rpc.device_id,
+              operation: msg.device_rpc.operation,
+              tool_name: msg.device_rpc.tool_name,
+              result: { ok: true },
+            },
+          }));
+        }
+      });
+    });
+
+    const address = server.address() as AddressInfo;
+    const client = new CatsClient({
+      serverUrl: `ws://127.0.0.1:${address.port}`,
+      apiKey: 'cc-test-key',
+      bodyId: 'body-agent',
+      installationId: 'install-agent',
+    });
+    client.on('error', () => undefined);
+    await new Promise<void>(resolve => {
+      client.once('ready', () => resolve());
+      client.connect();
+    });
+
+    await assert.rejects(
+      () => client.sendDeviceRpcRequest({
+        request_id: 'rpc-scope-mismatch',
+        grant_id: 'grant-1',
+        device_id: 'install-test',
+        operation: 'read_file',
+        tool_name: 'read_file',
+      }),
+      /scope does not match/
+    );
+    client.disconnect();
+  });
+
+  test('sends device rpc results with websocket ack', async () => {
+    const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    servers.push(server);
+    await new Promise<void>(resolve => server.once('listening', resolve));
+
+    const resultPromise = new Promise<any>(resolve => {
+      server.once('connection', socket => {
+        socket.on('message', data => {
+          const msg = JSON.parse(data.toString());
+          if (msg.hi) {
+            socket.send(JSON.stringify({
+              ctrl: {
+                id: msg.hi.id,
+                code: 200,
+                params: { build: 'catscompany', features: ['client_msg_id', 'device_rpc'], uid: 'usr7', name: 'Device' },
+              },
+            }));
+            return;
+          }
+          if (msg.device_rpc?.type === 'result') {
+            resolve(msg.device_rpc);
+            socket.send(JSON.stringify({ ctrl: { id: msg.device_rpc.id, code: 200, text: 'ok' } }));
+          }
+        });
+      });
+    });
+
+    const address = server.address() as AddressInfo;
+    const client = new CatsClient({
+      serverUrl: `ws://127.0.0.1:${address.port}`,
+      apiKey: 'cc-test-key',
+      bodyId: 'body-device',
+      installationId: 'install-device',
+    });
+    client.on('error', () => undefined);
+    await new Promise<void>(resolve => {
+      client.once('ready', () => resolve());
+      client.connect();
+    });
+
+    await client.sendDeviceRpcResult({
+      request_id: 'rpc-result-1',
+      result: { ok: true },
+    });
+    const result = await resultPromise;
+    client.disconnect();
+
+    assert.equal(result.request_id, 'rpc-result-1');
+    assert.deepEqual(result.result, { ok: true });
   });
 });

--- a/tests/catscompany-device-rpc-tools.test.ts
+++ b/tests/catscompany-device-rpc-tools.test.ts
@@ -1,0 +1,204 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import { CatsCompanyBot } from '../src/catscompany';
+import type { CatsDeviceRpcMessage } from '../src/catscompany/client';
+import type { ScopedDeviceGrant } from '../src/types/session-identity';
+
+function botWithDevice(captured: { result?: any }): any {
+  const bot = Object.create(CatsCompanyBot.prototype) as any;
+  bot.localDeviceGrant = {
+    kind: 'catscompany_body',
+    source: 'catscompany',
+    bodyId: 'body-device',
+    installationId: 'install-device',
+    deviceId: 'install-device',
+    createdAt: Date.now(),
+  };
+  bot.bot = {
+    sendDeviceRpcResult: async (result: any) => {
+      captured.result = result;
+    },
+  };
+  return bot;
+}
+
+function request(overrides: Partial<CatsDeviceRpcMessage> = {}): CatsDeviceRpcMessage {
+  return {
+    type: 'request',
+    request_id: 'rpc-read-1',
+    grant_id: 'grant-read-1',
+    session_key: 'session:v2:catscompany:p2p:p2p_7_43:agent:usr43',
+    topic_id: 'p2p_7_43',
+    topic_type: 'p2p',
+    actor_user_id: 'usr7',
+    agent_id: 'usr43',
+    agent_body_id: 'body-agent',
+    device_id: 'install-device',
+    device_body_id: 'body-device',
+    device_installation_id: 'install-device',
+    operation: 'read_file',
+    tool_name: 'read_file',
+    created_at: Date.now(),
+    expires_at: Date.now() + 60_000,
+    payload: {},
+    ...overrides,
+  };
+}
+
+function serverGrant(overrides: Partial<ScopedDeviceGrant> = {}): ScopedDeviceGrant {
+  return {
+    kind: 'user_device_grant',
+    source: 'catscompany',
+    grantId: 'grant-server-readonly',
+    status: 'active',
+    identityTrust: 'server_canonical',
+    identitySource: 'metadata.catsco_identity',
+    deviceId: 'install-remote',
+    deviceDisplayName: 'Remote Laptop',
+    deviceBodyId: 'body-remote',
+    deviceInstallationId: 'install-remote',
+    ownerUserId: 'usr7',
+    sessionKey: 'session:v2:catscompany:p2p:p2p_7_43:agent:usr43',
+    topicId: 'p2p_7_43',
+    topicType: 'p2p',
+    actorUserId: 'usr7',
+    agentId: 'usr43',
+    agentBodyId: 'body-agent',
+    operations: ['read_file', 'glob', 'grep'],
+    createdAt: Date.now(),
+    expiresAt: Date.now() + 60_000,
+    ...overrides,
+  };
+}
+
+describe('CatsCompany Device RPC readonly tools', () => {
+  test('maps CatsCo server grant fields into outbound readonly device_rpc requests', async () => {
+    const captured: Array<{ request: any; timeoutMs?: number }> = [];
+    const bot = Object.create(CatsCompanyBot.prototype) as any;
+    bot.bot = {
+      sendDeviceRpcRequest: async (requestPayload: any, timeoutMs?: number) => {
+        captured.push({ request: requestPayload, timeoutMs });
+        return {
+          type: 'result',
+          request_id: requestPayload.request_id,
+          grant_id: requestPayload.grant_id,
+          session_key: requestPayload.session_key,
+          topic_id: requestPayload.topic_id,
+          topic_type: requestPayload.topic_type,
+          actor_user_id: requestPayload.actor_user_id,
+          agent_id: requestPayload.agent_id,
+          agent_body_id: requestPayload.agent_body_id,
+          device_id: requestPayload.device_id,
+          device_body_id: requestPayload.device_body_id,
+          device_installation_id: requestPayload.device_installation_id,
+          operation: requestPayload.operation,
+          tool_name: requestPayload.tool_name,
+          result: { ok: true, content: `remote ${requestPayload.tool_name}` },
+        };
+      },
+    };
+
+    const transport = bot.buildDeviceRpcTransport();
+    const grant = serverGrant();
+    const read = await transport.executeTool({
+      toolName: 'read_file',
+      operation: 'read_file',
+      args: { file_path: 'catsco_attachment:quote.xlsx', limit: 20 },
+      grant,
+      timeoutMs: 12_345,
+    });
+    const glob = await transport.executeTool({
+      toolName: 'glob',
+      operation: 'glob',
+      args: { pattern: '**/*.xlsx', path: 'catsco_attachment:project' },
+      grant,
+    });
+    const grep = await transport.executeTool({
+      toolName: 'grep',
+      operation: 'grep',
+      args: { pattern: '合同', path: 'catsco_attachment:project', output_mode: 'files' },
+      grant,
+    });
+
+    assert.equal(read.ok, true);
+    assert.equal(glob.ok, true);
+    assert.equal(grep.ok, true);
+    assert.equal(read.ok ? read.content : '', 'remote read_file');
+    assert.equal(glob.ok ? glob.content : '', 'remote glob');
+    assert.equal(grep.ok ? grep.content : '', 'remote grep');
+    assert.deepEqual(captured.map(item => [item.request.tool_name, item.request.operation]), [
+      ['read_file', 'read_file'],
+      ['glob', 'glob'],
+      ['grep', 'grep'],
+    ]);
+
+    const first = captured[0].request;
+    assert.match(first.request_id, /^device_rpc_/);
+    assert.equal(first.grant_id, grant.grantId);
+    assert.equal(first.session_key, grant.sessionKey);
+    assert.equal(first.topic_id, grant.topicId);
+    assert.equal(first.topic_type, grant.topicType);
+    assert.equal(first.actor_user_id, grant.actorUserId);
+    assert.equal(first.agent_id, grant.agentId);
+    assert.equal(first.agent_body_id, grant.agentBodyId);
+    assert.equal(first.device_id, grant.deviceId);
+    assert.equal(first.device_body_id, grant.deviceBodyId);
+    assert.equal(first.device_installation_id, grant.deviceInstallationId);
+    assert.equal(first.expires_at, grant.expiresAt);
+    assert.deepEqual(first.payload, { args: { file_path: 'catsco_attachment:quote.xlsx', limit: 20 } });
+    assert.equal(captured[0].timeoutMs, 12_345);
+  });
+
+  test('executes read_file on the target local device and returns a normalized result', async () => {
+    const captured: { result?: any } = {};
+    const bot = botWithDevice(captured);
+    const tmpRoot = path.join(process.cwd(), 'tmp');
+    fs.mkdirSync(tmpRoot, { recursive: true });
+    const dir = fs.mkdtempSync(path.join(tmpRoot, 'device-rpc-read-'));
+    const filePath = path.join(dir, 'notes.txt');
+    fs.writeFileSync(filePath, 'hello from target device\n');
+
+    await bot.handleDeviceRpcRequest(request({
+      payload: { args: { file_path: filePath, limit: 5 } },
+    }));
+
+    assert.ok(captured.result);
+    assert.equal(captured.result.error, undefined);
+    assert.equal(captured.result.result.ok, true);
+    assert.match(String(captured.result.result.content), /hello from target device/);
+    assert.equal(captured.result.device_id, 'install-device');
+  });
+
+  test('rejects non-readonly Device RPC operations before local tool execution', async () => {
+    const captured: { result?: any } = {};
+    const bot = botWithDevice(captured);
+
+    await bot.handleDeviceRpcRequest(request({
+      request_id: 'rpc-shell-1',
+      operation: 'execute_shell',
+      tool_name: 'execute_shell',
+      payload: { args: { command: 'echo unsafe' } },
+    }));
+
+    assert.ok(captured.result);
+    assert.equal(captured.result.result, undefined);
+    assert.equal(captured.result.error.code, 'unsupported_operation');
+    assert.match(captured.result.error.message, /read_file, glob, and grep/);
+  });
+
+  test('rejects Device RPC requests for another target device', async () => {
+    const captured: { result?: any } = {};
+    const bot = botWithDevice(captured);
+
+    await bot.handleDeviceRpcRequest(request({
+      request_id: 'rpc-wrong-device-1',
+      device_id: 'other-device',
+    }));
+
+    assert.ok(captured.result);
+    assert.equal(captured.result.result, undefined);
+    assert.equal(captured.result.error.code, 'target_device_mismatch');
+  });
+});

--- a/tests/catscompany-execution-scope-flow.test.ts
+++ b/tests/catscompany-execution-scope-flow.test.ts
@@ -14,6 +14,61 @@ function canonicalMetadata(actorUserId: string, topicId: string, agentId = 'usr4
   };
 }
 
+function deviceGrant(overrides: Record<string, unknown> = {}) {
+  return {
+    kind: 'user_device_grant',
+    source: 'catscompany',
+    grantId: 'device-grant-1',
+    status: 'active',
+    identityTrust: 'server_canonical',
+    identitySource: 'metadata.catsco_identity',
+    deviceId: 'alice-laptop',
+    deviceDisplayName: 'Alice Laptop',
+    deviceBodyId: 'body-device',
+    deviceInstallationId: 'install-device',
+    ownerUserId: 'usr7',
+    sessionKey: 'session:v2:catscompany:p2p:p2p_7_43:agent:usr43',
+    topicId: 'p2p_7_43',
+    topicType: 'p2p',
+    actorUserId: 'usr7',
+    agentId: 'usr43',
+    agentBodyId: 'body-main',
+    operations: ['read_file', 'send_file'],
+    createdAt: 1_000,
+    expiresAt: 601_000,
+    ...overrides,
+  };
+}
+
+function metadataWithDeviceGrants(actorUserId: string, topicId: string, grants: unknown[], agentId = 'usr43', bodyId = 'body-main') {
+  const metadata = canonicalMetadata(actorUserId, topicId, agentId, bodyId);
+  (metadata.catsco_identity as any).device_grants = grants;
+  return metadata;
+}
+
+function metadataWithDeviceSelection(actorUserId: string, topicId: string, selection: Record<string, unknown>, agentId = 'usr43', bodyId = 'body-main') {
+  const metadata = metadataWithDeviceGrants(actorUserId, topicId, [deviceGrant()], agentId, bodyId);
+  (metadata.catsco_identity as any).device_selection = {
+    kind: 'user_device_selection',
+    source: 'catscompany',
+    status: 'selected',
+    sessionKey: `session:v2:catscompany:${topicId.startsWith('grp_') ? 'group' : 'p2p'}:${topicId}:agent:${agentId}`,
+    topicId,
+    topicType: topicId.startsWith('grp_') ? 'group' : 'p2p',
+    actorUserId,
+    agentId,
+    selectedDevice: {
+      deviceId: 'alice-laptop',
+      displayName: 'Alice Laptop',
+      bodyId: 'body-device',
+      installationId: 'install-device',
+      operations: ['read_file', 'send_file'],
+    },
+    ...selection,
+  };
+  return metadata;
+}
+
 function createHarness(options: { busy?: boolean } = {}) {
   const bot = Object.create(CatsCompanyBot.prototype) as any;
   const handledTurns: Array<{ userMessage: unknown; options: any }> = [];
@@ -134,6 +189,88 @@ describe('CatsCompany execution scope flow', () => {
     assert.equal(handledTurns[0].options.executionScope.actorUserId, 'usr7');
   });
 
+  test('passes server canonical device grants into CatsCompany session turn', async () => {
+    const { bot, handledTurns } = createHarness();
+
+    await (bot as any).onMessage({
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      text: '读一下本机文件',
+      content: '读一下本机文件',
+      metadata: metadataWithDeviceGrants('usr7', 'p2p_7_43', [deviceGrant()]),
+      isGroup: false,
+      seq: 12,
+    });
+
+    assert.equal(handledTurns.length, 1);
+    assert.equal(handledTurns[0].options.deviceGrants?.length, 1);
+    assert.equal(handledTurns[0].options.deviceGrants[0].deviceId, 'alice-laptop');
+    assert.deepEqual(handledTurns[0].options.deviceGrants[0].operations, ['read_file', 'send_file']);
+  });
+
+  test('passes server canonical device selection into CatsCompany session turn', async () => {
+    const { bot, handledTurns } = createHarness();
+
+    await (bot as any).onMessage({
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      text: '读一下本机文件',
+      content: '读一下本机文件',
+      metadata: metadataWithDeviceSelection('usr7', 'p2p_7_43', {
+        selectionSource: 'explicit_mention',
+      }),
+      isGroup: false,
+      seq: 12,
+    });
+
+    assert.equal(handledTurns.length, 1);
+    assert.equal(handledTurns[0].options.deviceSelection?.status, 'selected');
+    assert.equal(handledTurns[0].options.deviceSelection?.selectionSource, 'explicit_mention');
+    assert.equal(handledTurns[0].options.deviceSelection?.selectedDeviceId, 'alice-laptop');
+    assert.equal(handledTurns[0].options.deviceSelection?.selectedDeviceDisplayName, 'Alice Laptop');
+    assert.equal(handledTurns[0].options.deviceSelection?.selectedDeviceBodyId, 'body-device');
+    assert.deepEqual(handledTurns[0].options.deviceSelection?.selectedDeviceOperations, ['read_file', 'send_file']);
+  });
+
+  test('drops device selection that does not match the canonical execution scope', async () => {
+    const { bot, handledTurns } = createHarness();
+
+    await (bot as any).onMessage({
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      text: '读一下本机文件',
+      content: '读一下本机文件',
+      metadata: metadataWithDeviceSelection('usr7', 'p2p_7_43', {
+        actorUserId: 'usr8',
+      }),
+      isGroup: false,
+      seq: 12,
+    });
+
+    assert.equal(handledTurns.length, 1);
+    assert.equal(handledTurns[0].options.deviceSelection, undefined);
+  });
+
+  test('drops device grants that do not match the canonical execution scope', async () => {
+    const { bot, handledTurns } = createHarness();
+
+    await (bot as any).onMessage({
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      text: '读一下本机文件',
+      content: '读一下本机文件',
+      metadata: metadataWithDeviceGrants('usr7', 'p2p_7_43', [
+        deviceGrant({ actorUserId: 'usr8' }),
+        deviceGrant({ agentBodyId: 'body-other' }),
+      ]),
+      isGroup: false,
+      seq: 12,
+    });
+
+    assert.equal(handledTurns.length, 1);
+    assert.equal(handledTurns[0].options.deviceGrants, undefined);
+  });
+
   test('does not merge queued CatsCo group input from another actor into the current actor scope', () => {
     const { bot } = createHarness();
     const sessionKey = 'session:v2:catscompany:group:grp_80:agent:usr43';
@@ -170,5 +307,74 @@ describe('CatsCompany execution scope flow', () => {
     const pendingForBob = (bot as any).consumeQueuedUserInput(sessionKey, bobScope);
     assert.equal(pendingForBob, 'bob follow-up');
     assert.equal(bot.messageQueue.has(sessionKey), false);
+  });
+
+  test('preserves device grants when queued CatsCompany user input is merged', () => {
+    const { bot } = createHarness();
+    const scope = createExecutionScope(createCatsCoMessageEnvelope({
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      text: 'first',
+      metadata: canonicalMetadata('usr7', 'p2p_7_43'),
+      botUid: 'usr43',
+    }));
+
+    bot.messageQueue.set(scope.sessionKey, [{
+      userMessage: '补充读取文件',
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      seq: 13,
+      executionScope: scope,
+      deviceGrants: [deviceGrant()],
+      receivedAt: Date.now(),
+      source: 'user',
+    }]);
+
+    const pending = (bot as any).consumeQueuedUserInput(scope.sessionKey, scope);
+    assert.equal(typeof pending, 'object');
+    assert.equal(pending.content, '补充读取文件');
+    assert.equal(pending.deviceGrants.length, 1);
+    assert.equal(pending.deviceGrants[0].deviceId, 'alice-laptop');
+  });
+
+  test('preserves latest device selection when queued CatsCompany user input is merged', () => {
+    const { bot } = createHarness();
+    const scope = createExecutionScope(createCatsCoMessageEnvelope({
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      text: 'first',
+      metadata: canonicalMetadata('usr7', 'p2p_7_43'),
+      botUid: 'usr43',
+    }));
+
+    const selection = {
+      kind: 'user_device_selection',
+      source: 'catscompany',
+      status: 'selected',
+      sessionKey: scope.sessionKey,
+      topicId: scope.topicId,
+      topicType: scope.topicType,
+      actorUserId: scope.actorUserId,
+      agentId: scope.agentId,
+      identityTrust: 'server_canonical',
+      selectedDeviceId: 'alice-laptop',
+      selectedDeviceDisplayName: 'Alice Laptop',
+    };
+
+    bot.messageQueue.set(scope.sessionKey, [{
+      userMessage: '补充读取文件',
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      seq: 13,
+      executionScope: scope,
+      deviceSelection: selection,
+      receivedAt: Date.now(),
+      source: 'user',
+    }]);
+
+    const pending = (bot as any).consumeQueuedUserInput(scope.sessionKey, scope);
+    assert.equal(typeof pending, 'object');
+    assert.equal(pending.content, '补充读取文件');
+    assert.equal(pending.deviceSelection.selectedDeviceId, 'alice-laptop');
   });
 });

--- a/tests/conversation-runner-pending-input.test.ts
+++ b/tests/conversation-runner-pending-input.test.ts
@@ -2,11 +2,27 @@ import { describe, test } from 'node:test';
 import * as assert from 'node:assert';
 import * as path from 'path';
 import { ConversationRunner } from '../src/core/conversation-runner';
+import { TRANSIENT_RUNTIME_CONTEXT_PREFIX } from '../src/core/runtime-context-builder';
 import { Message } from '../src/types';
-import type { ScopedLocalFileGrant } from '../src/types/session-identity';
+import type { ExecutionScope, ScopedDeviceGrant, ScopedLocalFileGrant } from '../src/types/session-identity';
 import { ToolCall, ToolDefinition, ToolExecutionContext, ToolExecutor, ToolResult } from '../src/types/tool';
 
 const usage = { promptTokens: 1, completionTokens: 1, totalTokens: 2 };
+
+function scope(): ExecutionScope {
+  return {
+    source: 'catscompany',
+    sessionKey: 'cc_user:usr7',
+    topicId: 'p2p_7_43',
+    topicType: 'p2p',
+    actorUserId: 'usr7',
+    agentId: 'usr43',
+    agentBodyId: 'body-main',
+    permissionsSource: 'metadata.catsco_identity',
+    identityTrust: 'server_canonical',
+    isTrusted: true,
+  };
+}
 
 function createNoopToolExecutor(): ToolExecutor {
   const noopTool: ToolDefinition = {
@@ -47,6 +63,32 @@ function grant(filePath: string): ScopedLocalFileGrant {
     deviceBodyId: 'body-main',
     identityTrust: 'server_canonical',
     operations: ['read_file', 'send_file'],
+    createdAt: now,
+    expiresAt: now + 60_000,
+  };
+}
+
+function deviceGrant(deviceId: string): ScopedDeviceGrant {
+  const now = Date.now();
+  return {
+    kind: 'user_device_grant',
+    source: 'catscompany',
+    grantId: `device_grant:${deviceId}`,
+    status: 'active',
+    identityTrust: 'server_canonical',
+    identitySource: 'metadata.catsco_identity',
+    deviceId,
+    deviceDisplayName: deviceId,
+    deviceBodyId: 'body-main',
+    deviceInstallationId: `install:${deviceId}`,
+    ownerUserId: 'usr7',
+    sessionKey: 'cc_user:usr7',
+    topicId: 'p2p_7_43',
+    topicType: 'p2p',
+    actorUserId: 'usr7',
+    agentId: 'usr43',
+    agentBodyId: 'body-main',
+    operations: ['read_file'],
     createdAt: now,
     expiresAt: now + 60_000,
   };
@@ -193,4 +235,103 @@ describe('ConversationRunner pending input', () => {
     assert.deepEqual(contexts[0]?.localFileGrants, [initialGrant]);
     assert.deepEqual(contexts[1]?.localFileGrants, [initialGrant, pendingGrant]);
   });
+
+  test('merges pending device grants into later tool execution context without clearing existing grants', async () => {
+    const requests: Message[][] = [];
+    const aiService = {
+      chat: async (messages: Message[]) => {
+        requests.push(messages.map(msg => ({ ...msg })));
+        if (requests.length === 1) {
+          return {
+            content: null,
+            toolCalls: [{
+              id: 'call_1',
+              type: 'function',
+              function: { name: 'noop', arguments: '{}' },
+            }],
+            usage,
+          };
+        }
+        if (requests.length === 2) {
+          return {
+            content: null,
+            toolCalls: [{
+              id: 'call_2',
+              type: 'function',
+              function: { name: 'noop', arguments: '{}' },
+            }],
+            usage,
+          };
+        }
+        return { content: 'done', toolCalls: [], usage };
+      },
+    } as any;
+    const contexts: Array<Partial<ToolExecutionContext> | undefined> = [];
+    const executor: ToolExecutor = {
+      getToolDefinitions: () => [{
+        name: 'noop',
+        description: 'noop',
+        parameters: { type: 'object', properties: {} },
+      }],
+      executeTool: async (toolCall, _history, contextOverrides) => {
+        contexts.push(contextOverrides);
+        return {
+          tool_call_id: toolCall.id,
+          role: 'tool',
+          name: toolCall.function.name,
+          content: 'ok',
+          ok: true,
+        };
+      },
+    };
+
+    let pendingUsed = false;
+    const initialGrant = deviceGrant('device-initial');
+    const pendingGrant = deviceGrant('device-pending');
+    const runner = new ConversationRunner(aiService, executor, {
+      stream: false,
+      toolExecutionContext: {
+        sessionId: 'cc_user:usr7',
+        surface: 'catscompany',
+        executionScope: scope(),
+        deviceGrants: [initialGrant],
+      },
+      pendingUserInputProvider: () => {
+        if (pendingUsed) return null;
+        pendingUsed = true;
+        return {
+          content: 'new device grant while busy',
+          deviceGrants: [pendingGrant],
+        };
+      },
+    });
+
+    const result = await runner.run([{ role: 'user', content: 'run a tool' }]);
+
+    assert.equal(result.response, 'done');
+    assert.equal(contexts.length, 2);
+    assert.deepEqual(contexts[0]?.deviceGrants, [initialGrant]);
+    assert.deepEqual(contexts[1]?.deviceGrants, [initialGrant, pendingGrant]);
+
+    const refreshedContext = requests[1].find(isRuntimeContextMessage);
+    assert.ok(refreshedContext);
+    const snapshot = parseRuntimeContext(refreshedContext);
+    assert.deepEqual(
+      snapshot.execution.userDevices.map((device: any) => device.deviceId),
+      ['device-initial', 'device-pending'],
+    );
+    assert.doesNotMatch(refreshedContext.content as string, /install:device-/);
+    assert.doesNotMatch(refreshedContext.content as string, /body-main/);
+  });
 });
+
+function isRuntimeContextMessage(message: Message): boolean {
+  return message.role === 'system'
+    && typeof message.content === 'string'
+    && message.content.startsWith(TRANSIENT_RUNTIME_CONTEXT_PREFIX);
+}
+
+function parseRuntimeContext(message: Message): any {
+  const content = String(message.content || '');
+  return JSON.parse(content.slice(TRANSIENT_RUNTIME_CONTEXT_PREFIX.length).trim());
+}

--- a/tests/device-grants.test.ts
+++ b/tests/device-grants.test.ts
@@ -1,0 +1,212 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  type CreateUserDeviceInput,
+  createDeviceGrant,
+  createUserDevice,
+  resolveDeviceGrant,
+  validateDeviceGrant,
+} from '../src/core/device-grants';
+import type {
+  ExecutionScope,
+  ScopedDeviceGrant,
+} from '../src/types/session-identity';
+
+function scope(overrides: Partial<ExecutionScope> = {}): ExecutionScope {
+  return {
+    source: 'catscompany',
+    sessionKey: 'session:v2:catscompany:group:grp_80:agent:usr43',
+    topicId: 'grp_80',
+    topicType: 'group',
+    actorUserId: 'usr7',
+    agentId: 'usr43',
+    agentBodyId: 'body-main',
+    permissionsSource: 'metadata.catsco_identity',
+    identityTrust: 'server_canonical',
+    isTrusted: true,
+    ...overrides,
+  };
+}
+
+function device(overrides: Partial<CreateUserDeviceInput> = {}) {
+  const result = createUserDevice({
+    source: 'catscompany',
+    ownerUserId: ' usr7 ',
+    deviceId: ' device-main ',
+    displayName: ' Alice laptop ',
+    bodyId: ' body-main ',
+    installationId: ' install-main ',
+    identityTrust: 'server_canonical',
+    identitySource: 'device.registry',
+    status: 'online',
+    registeredAt: 100,
+    lastSeenAt: 200,
+    ...overrides,
+  });
+  assert.ok(result);
+  return result;
+}
+
+function grant(overrides: Partial<ScopedDeviceGrant> = {}): ScopedDeviceGrant {
+  const created = createDeviceGrant(scope(), device(), {
+    grantId: 'grant-main',
+    operations: ['read_file', 'send_file'],
+    now: 1_000,
+    ttlMs: 5_000,
+  });
+  assert.ok(created);
+  return { ...created, ...overrides };
+}
+
+describe('device grants', () => {
+  test('creates a normalized user device without exposing local filesystem concepts', () => {
+    const result = device();
+
+    assert.equal(result.ownerUserId, 'usr7');
+    assert.equal(result.deviceId, 'device-main');
+    assert.equal(result.displayName, 'Alice laptop');
+    assert.equal(result.bodyId, 'body-main');
+    assert.equal(result.installationId, 'install-main');
+    assert.equal(result.identityTrust, 'server_canonical');
+    assert.equal(result.status, 'online');
+  });
+
+  test('creates a scoped active grant tied to the current actor, agent, topic, and device', () => {
+    const created = createDeviceGrant(scope(), device(), {
+      grantId: 'grant-main',
+      operations: ['read_file', 'read_file', 'execute_shell', 'invalid' as any],
+      identitySource: 'catsco.device_grant',
+      now: 1_000,
+      ttlMs: 10_000,
+    });
+
+    assert.ok(created);
+    assert.equal(created.kind, 'user_device_grant');
+    assert.equal(created.status, 'active');
+    assert.equal(created.identityTrust, 'server_canonical');
+    assert.equal(created.identitySource, 'catsco.device_grant');
+    assert.equal(created.ownerUserId, 'usr7');
+    assert.equal(created.actorUserId, 'usr7');
+    assert.equal(created.agentId, 'usr43');
+    assert.equal(created.agentBodyId, 'body-main');
+    assert.equal(created.deviceId, 'device-main');
+    assert.equal(created.deviceBodyId, 'body-main');
+    assert.equal(created.deviceInstallationId, 'install-main');
+    assert.deepEqual(created.operations, ['read_file', 'execute_shell']);
+    assert.equal(created.createdAt, 1_000);
+    assert.equal(created.expiresAt, 11_000);
+  });
+
+  test('refuses to create grants for empty operations, source mismatch, or a different owner', () => {
+    assert.equal(createDeviceGrant(scope(), device(), { operations: [] }), undefined);
+    assert.equal(createDeviceGrant(scope(), device({ source: 'feishu' }), { operations: ['read_file'] }), undefined);
+    assert.equal(createDeviceGrant(scope(), device({ ownerUserId: 'usr8' }), { operations: ['read_file'] }), undefined);
+  });
+
+  test('resolves a matching grant by operation and optional target device', () => {
+    const other = grant({
+      grantId: 'grant-other',
+      deviceId: 'device-other',
+      operations: ['execute_shell'],
+    });
+    const result = resolveDeviceGrant({
+      executionScope: scope(),
+      deviceGrants: [other, grant()],
+    }, {
+      operation: 'send_file',
+      deviceId: 'device-main',
+      now: 2_000,
+    });
+
+    assert.equal(result.ok, true);
+    if (result.ok) assert.equal(result.grant.grantId, 'grant-main');
+  });
+
+  test('rejects ambiguous device resolution when multiple target devices can perform the same operation', () => {
+    const result = resolveDeviceGrant({
+      executionScope: scope(),
+      deviceGrants: [
+        grant({ grantId: 'grant-main', deviceId: 'device-main' }),
+        grant({ grantId: 'grant-second', deviceId: 'device-second' }),
+      ],
+    }, {
+      operation: 'read_file',
+      now: 2_000,
+    });
+
+    assert.equal(result.ok, false);
+    if (!result.ok) assert.match(result.message, /多个允许 read_file 的用户设备授权/);
+  });
+
+  test('skips invalid candidates when a later grant for the same target device is valid', () => {
+    const result = resolveDeviceGrant({
+      executionScope: scope(),
+      deviceGrants: [
+        grant({ grantId: 'grant-expired', expiresAt: 2_000 }),
+        grant({ grantId: 'grant-valid', expiresAt: 6_000 }),
+      ],
+    }, {
+      operation: 'read_file',
+      deviceId: 'device-main',
+      now: 2_000,
+    });
+
+    assert.equal(result.ok, true);
+    if (result.ok) assert.equal(result.grant.grantId, 'grant-valid');
+  });
+
+  test('rejects missing, revoked, expired, operation, and target-device mismatches', () => {
+    assert.equal(resolveDeviceGrant({
+      executionScope: scope(),
+      deviceGrants: [],
+    }, {
+      operation: 'read_file',
+      now: 2_000,
+    }).ok, false);
+
+    const cases: Array<[string, ScopedDeviceGrant, RegExp]> = [
+      ['revoked', grant({ status: 'revoked' }), /不是 active/],
+      ['expired', grant({ expiresAt: 2_000 }), /已过期/],
+      ['operation', grant({ operations: ['send_file'] }), /不允许执行 read_file/],
+      ['target device', grant(), /目标设备不一致/],
+      ['untrusted', grant({ identityTrust: 'untrusted' }), /未可信身份/],
+    ];
+
+    for (const [name, candidate, messagePattern] of cases) {
+      const decision = validateDeviceGrant({
+        executionScope: scope(),
+      }, candidate, {
+        operation: 'read_file',
+        deviceId: name === 'target device' ? 'device-other' : undefined,
+        now: 2_000,
+      });
+      assert.equal(decision.ok, false, name);
+      if (!decision.ok) assert.match(decision.message, messagePattern, name);
+    }
+  });
+
+  test('rejects grants from another session, source, actor, topic type, agent, or body', () => {
+    const mismatchCases: Array<[string, Partial<ScopedDeviceGrant>]> = [
+      ['source', { source: 'feishu' }],
+      ['sessionKey', { sessionKey: 'session:v2:catscompany:group:grp_81:agent:usr43' }],
+      ['topicId', { topicId: 'grp_81' }],
+      ['topicType', { topicType: 'p2p' }],
+      ['actorUserId', { actorUserId: 'usr8', ownerUserId: 'usr8' }],
+      ['ownerUserId', { ownerUserId: 'usr8' }],
+      ['agentId', { agentId: 'usr99' }],
+      ['agentBodyId', { agentBodyId: 'body-other' }],
+    ];
+
+    for (const [field, overrides] of mismatchCases) {
+      const decision = validateDeviceGrant({
+        executionScope: scope(),
+      }, grant(overrides), {
+        operation: 'read_file',
+        now: 2_000,
+      });
+
+      assert.equal(decision.ok, false, field);
+      if (!decision.ok) assert.match(decision.message, new RegExp(field), field);
+    }
+  });
+});

--- a/tests/local-file-gateway.test.ts
+++ b/tests/local-file-gateway.test.ts
@@ -303,12 +303,17 @@ describe('resolveLocalFileAccess', () => {
     }
   });
 
-  test('rejects a grant when topic or body identity does not match', () => {
+  test('rejects a grant when topic, agent, or body identity does not match', () => {
     const workspaceRoot = makeWorkspace();
     const filePath = makeManagedFile(workspaceRoot);
     const result = resolveLocalFileAccess(context({
       workspaceRoot,
-      executionScope: scope({ topicId: 'p2p_8_43', agentBodyId: 'body-other' }),
+      executionScope: scope({
+        topicId: 'p2p_8_43',
+        topicType: 'group',
+        agentId: 'usr99',
+        agentBodyId: 'body-other',
+      }),
       localDeviceGrant: deviceGrant({ bodyId: 'body-other' }),
       localFileGrants: [grant(filePath)],
     }), {
@@ -319,8 +324,30 @@ describe('resolveLocalFileAccess', () => {
     assert.equal(result.ok, false);
     if (!result.ok) {
       assert.match(result.message, /topicId/);
+      assert.match(result.message, /topicType/);
+      assert.match(result.message, /agentId/);
       assert.match(result.message, /agentBodyId/);
       assert.match(result.message, /deviceBodyId/);
+    }
+  });
+
+  test('rejects a grant when device installation identity does not match', () => {
+    const workspaceRoot = makeWorkspace();
+    const filePath = makeManagedFile(workspaceRoot);
+    const result = resolveLocalFileAccess(context({
+      workspaceRoot,
+      executionScope: scope(),
+      localDeviceGrant: deviceGrant({ installationId: 'install-other' }),
+      localFileGrants: [grant(filePath, { deviceInstallationId: 'install-main' })],
+    }), {
+      operation: 'read_file',
+      absolutePath: filePath,
+    });
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.match(result.message, /deviceInstallationId/);
+      assert.doesNotMatch(result.message, new RegExp(escapeRegExp(workspaceRoot)));
     }
   });
 

--- a/tests/runtime-context-builder.test.ts
+++ b/tests/runtime-context-builder.test.ts
@@ -6,9 +6,14 @@ import * as path from 'path';
 import { AgentSession } from '../src/core/agent-session';
 import { TurnContextBuilder } from '../src/core/turn-context-builder';
 import { TRANSIENT_RUNTIME_CONTEXT_PREFIX } from '../src/core/runtime-context-builder';
+import { createDeviceGrant, createUserDevice } from '../src/core/device-grants';
 import { createExecutionScopeFromRoute, createSessionRoute } from '../src/core/session-router';
 import type { Message } from '../src/types';
-import type { ScopedLocalFileGrant } from '../src/types/session-identity';
+import type {
+  ExecutionScope,
+  ScopedDeviceGrant,
+  ScopedLocalFileGrant,
+} from '../src/types/session-identity';
 
 describe('runtime context builder', () => {
   test('injects structured runtime context before the latest user message and removes it from durable history', async () => {
@@ -26,7 +31,9 @@ describe('runtime context builder', () => {
       identitySource: 'metadata.catsco_identity',
       legacySessionKey: 'cc_group:grp_80',
     });
+    const executionScope = createExecutionScopeFromRoute(route);
     const grant = localGrant('C:\\secret\\tmp\\downloads\\contract.pdf');
+    const userDeviceGrant = deviceGrant(executionScope);
 
     const durableMessages: Message[] = [
       { role: 'system', content: 'base system' },
@@ -37,7 +44,7 @@ describe('runtime context builder', () => {
       sessionKey: route.sessionKey,
       sessionType: 'catscompany',
       sessionRoute: route,
-      executionScope: createExecutionScopeFromRoute(route),
+      executionScope,
       localDeviceGrant: {
         kind: 'catscompany_body',
         source: 'catscompany',
@@ -45,6 +52,7 @@ describe('runtime context builder', () => {
         deviceId: 'device-1',
         createdAt: Date.now(),
       },
+      deviceGrants: [userDeviceGrant],
       localFileGrants: [grant],
       durableMessages,
       runtimeFeedback: [],
@@ -62,13 +70,30 @@ describe('runtime context builder', () => {
     assert.equal(snapshot.session.key, route.sessionKey);
     assert.equal(snapshot.session.topic.id, 'grp_80');
     assert.equal(snapshot.session.agent.id, 'usr43');
+    assert.equal('bodyId' in snapshot.session.agent, false);
     assert.equal(snapshot.turn.actorUserId, 'usr7');
     assert.equal(snapshot.turn.identityTrust, 'server_canonical');
     assert.equal(snapshot.execution.scopeSource, 'execution_scope');
+    assert.equal(snapshot.execution.localDevice.source, 'catscompany');
+    assert.equal(snapshot.execution.localDevice.deviceId, 'device-1');
+    assert.equal('bodyId' in snapshot.execution.localDevice, false);
+    assert.equal(snapshot.execution.userDevices[0].grantId, 'device_grant_current');
+    assert.equal(snapshot.execution.userDevices[0].deviceId, 'device-user-1');
+    assert.equal(snapshot.execution.userDevices[0].displayName, 'Alice laptop');
+    assert.deepEqual(snapshot.execution.userDevices[0].operations, ['read_file', 'execute_shell']);
+    assert.equal(snapshot.execution.userDevices[0].status, 'active');
     assert.equal(snapshot.execution.localFiles[0].ref, 'catsco_attachment:contract');
     assert.equal(snapshot.execution.localFiles[0].fileName, 'contract.pdf');
     assert.doesNotMatch(result.messages[runtimeIndex].content as string, /C:\\secret/);
     assert.doesNotMatch(result.messages[runtimeIndex].content as string, /tmp[\\/]downloads/);
+    assert.doesNotMatch(result.messages[runtimeIndex].content as string, /body-main/);
+    assert.doesNotMatch(result.messages[runtimeIndex].content as string, /body-secret/);
+    assert.doesNotMatch(result.messages[runtimeIndex].content as string, /"bodyId"/);
+    assert.doesNotMatch(result.messages[runtimeIndex].content as string, /installation-main/);
+    assert.doesNotMatch(result.messages[runtimeIndex].content as string, /deviceBodyId/);
+    assert.doesNotMatch(result.messages[runtimeIndex].content as string, /deviceInstallationId/);
+    assert.doesNotMatch(result.messages[runtimeIndex].content as string, /createdAt/);
+    assert.doesNotMatch(result.messages[runtimeIndex].content as string, /mtimeMs/);
 
     const durable = builder.removeTransientMessages(result.messages);
     assert.equal(durable.some(isRuntimeContextMessage), false);
@@ -106,6 +131,7 @@ describe('runtime context builder', () => {
       await session.handleMessage('第一条', {
         sessionRoute: route,
         executionScope: createExecutionScopeFromRoute(route),
+        deviceGrants: [deviceGrant(createExecutionScopeFromRoute(route), 'alice-device')],
       });
 
       const bobRoute = createSessionRoute({
@@ -128,6 +154,7 @@ describe('runtime context builder', () => {
       assert.equal(firstContexts.length, 1);
       assert.equal(secondContexts.length, 1);
       assert.equal(parseRuntimeContext(firstContexts[0]).turn.actorUserId, 'alice');
+      assert.equal(parseRuntimeContext(firstContexts[0]).execution.userDevices[0].deviceId, 'alice-device');
       assert.equal(parseRuntimeContext(secondContexts[0]).turn.actorUserId, 'bob');
       assert.equal(parseRuntimeContext(secondContexts[0]).session.topic.id, 'oc_group');
 
@@ -181,6 +208,28 @@ function localGrant(filePath: string): ScopedLocalFileGrant {
     createdAt: now,
     expiresAt: now + 60_000,
   };
+}
+
+function deviceGrant(scope: ExecutionScope, deviceId = 'device-user-1'): ScopedDeviceGrant {
+  const device = createUserDevice({
+    source: scope.source,
+    ownerUserId: scope.actorUserId,
+    deviceId,
+    displayName: 'Alice laptop',
+    bodyId: 'body-secret',
+    installationId: 'installation-main',
+    identityTrust: 'server_canonical',
+    status: 'online',
+    registeredAt: 1_000,
+  });
+  const grant = createDeviceGrant(scope, device, {
+    grantId: 'device_grant_current',
+    operations: ['read_file', 'execute_shell'],
+    now: 2_000,
+    ttlMs: 60_000,
+  });
+  assert.ok(grant);
+  return grant;
 }
 
 function buildMockServices(overrides: any = {}): any {

--- a/tests/runtime-context-builder.test.ts
+++ b/tests/runtime-context-builder.test.ts
@@ -12,6 +12,7 @@ import type { Message } from '../src/types';
 import type {
   ExecutionScope,
   ScopedDeviceGrant,
+  ScopedDeviceSelection,
   ScopedLocalFileGrant,
 } from '../src/types/session-identity';
 
@@ -53,6 +54,7 @@ describe('runtime context builder', () => {
         createdAt: Date.now(),
       },
       deviceGrants: [userDeviceGrant],
+      deviceSelection: deviceSelection(executionScope),
       localFileGrants: [grant],
       durableMessages,
       runtimeFeedback: [],
@@ -82,6 +84,11 @@ describe('runtime context builder', () => {
     assert.equal(snapshot.execution.userDevices[0].displayName, 'Alice laptop');
     assert.deepEqual(snapshot.execution.userDevices[0].operations, ['read_file', 'execute_shell']);
     assert.equal(snapshot.execution.userDevices[0].status, 'active');
+    assert.equal(snapshot.execution.deviceSelection.status, 'selected');
+    assert.equal(snapshot.execution.deviceSelection.selectionSource, 'single_active_device');
+    assert.equal(snapshot.execution.deviceSelection.selectedDevice.deviceId, 'device-user-1');
+    assert.equal(snapshot.execution.deviceSelection.selectedDevice.displayName, 'Alice laptop');
+    assert.deepEqual(snapshot.execution.deviceSelection.selectedDevice.operations, ['read_file']);
     assert.equal(snapshot.execution.localFiles[0].ref, 'catsco_attachment:contract');
     assert.equal(snapshot.execution.localFiles[0].fileName, 'contract.pdf');
     assert.doesNotMatch(result.messages[runtimeIndex].content as string, /C:\\secret/);
@@ -230,6 +237,28 @@ function deviceGrant(scope: ExecutionScope, deviceId = 'device-user-1'): ScopedD
   });
   assert.ok(grant);
   return grant;
+}
+
+function deviceSelection(scope: ExecutionScope): ScopedDeviceSelection {
+  return {
+    kind: 'user_device_selection',
+    source: scope.source,
+    status: 'selected',
+    selectionSource: 'single_active_device',
+    sessionKey: scope.sessionKey,
+    topicId: scope.topicId,
+    topicType: scope.topicType,
+    actorUserId: scope.actorUserId,
+    agentId: scope.agentId,
+    identityTrust: scope.identityTrust,
+    identitySource: 'metadata.catsco_identity',
+    selectedDeviceId: 'device-user-1',
+    selectedDeviceDisplayName: 'Alice laptop',
+    selectedDeviceBodyId: 'body-secret',
+    selectedDeviceInstallationId: 'installation-main',
+    selectedDeviceOperations: ['read_file'],
+    createdAt: 2_000,
+  };
 }
 
 function buildMockServices(overrides: any = {}): any {

--- a/tests/subagent-runtime-events.test.ts
+++ b/tests/subagent-runtime-events.test.ts
@@ -446,6 +446,113 @@ describe('subagent runtime events', () => {
     }
   });
 
+  test('CatsCo device-scoped spawn_subagent defaults to ask_parent only', async () => {
+    const originalGetInstance = SubAgentManager.getInstance;
+    let capturedAllowedTools: unknown;
+
+    (SubAgentManager as any).getInstance = () => ({
+      spawn(
+        _parentSessionKey: string,
+        request: any,
+      ) {
+        capturedAllowedTools = request.allowedTools;
+        return {
+          id: 'sub-catsco-isolated',
+          agentType: request.agentType,
+          skillName: request.agentType,
+          toolScope: 'read_only',
+          allowedTools: request.allowedTools,
+          taskDescription: request.taskDescription,
+          status: 'running',
+          createdAt: Date.now(),
+          progressLog: [],
+          outputFiles: [],
+        };
+      },
+    });
+
+    try {
+      const result = await new SpawnSubagentTool().execute({
+        agent_type: 'explorer',
+        task: '审查当前问题',
+        context: '只看主会话提供的信息，不操作本机文件',
+      }, {
+        workingDirectory: process.cwd(),
+        conversationHistory: [],
+        sessionId: 'session:v2:catscompany:p2p:p2p_7_43:agent:usr43',
+        surface: 'catscompany',
+        executionScope: {
+          source: 'catscompany',
+          sessionKey: 'session:v2:catscompany:p2p:p2p_7_43:agent:usr43',
+          topicId: 'p2p_7_43',
+          topicType: 'p2p',
+          actorUserId: 'usr7',
+          agentId: 'usr43',
+          agentBodyId: 'body-main',
+          identityTrust: 'server_canonical',
+          isTrusted: true,
+        },
+        localDeviceGrant: {
+          kind: 'catscompany_body',
+          source: 'catscompany',
+          bodyId: 'body-main',
+          createdAt: Date.now(),
+        },
+        runtimeServices: {
+          aiService: {} as any,
+          skillManager: {} as any,
+        },
+      });
+
+      assert.equal(result.ok, true);
+      assert.deepEqual(capturedAllowedTools, ['ask_parent']);
+    } finally {
+      (SubAgentManager as any).getInstance = originalGetInstance;
+    }
+  });
+
+  test('CatsCo device-scoped spawn_subagent rejects local file tool delegation', async () => {
+    const result = await new SpawnSubagentTool().execute({
+      agent_type: 'explorer',
+      allowed_tools: ['read_file', 'ask_parent'],
+      task: '读取本机文件',
+      context: '请读取用户设备文件',
+    }, {
+      workingDirectory: process.cwd(),
+      conversationHistory: [],
+      sessionId: 'session:v2:catscompany:p2p:p2p_7_43:agent:usr43',
+      surface: 'catscompany',
+      executionScope: {
+        source: 'catscompany',
+        sessionKey: 'session:v2:catscompany:p2p:p2p_7_43:agent:usr43',
+        topicId: 'p2p_7_43',
+        topicType: 'p2p',
+        actorUserId: 'usr7',
+        agentId: 'usr43',
+        agentBodyId: 'body-main',
+        identityTrust: 'server_canonical',
+        isTrusted: true,
+      },
+      localDeviceGrant: {
+        kind: 'catscompany_body',
+        source: 'catscompany',
+        bodyId: 'body-main',
+        createdAt: Date.now(),
+      },
+      runtimeServices: {
+        aiService: {} as any,
+        skillManager: {} as any,
+      },
+    });
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.errorCode, 'PERMISSION_DENIED');
+      assert.match(result.message, /不会传递给子智能体/);
+      assert.match(result.message, /read_file/);
+    }
+  });
+
   test('spawn_subagent rejects unsafe tools before creating a subagent', async () => {
     const result = await new SpawnSubagentTool().execute({
       agent_type: 'worker',

--- a/tests/tool-gateway-catsco.test.ts
+++ b/tests/tool-gateway-catsco.test.ts
@@ -1,0 +1,427 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ReadTool } from '../src/tools/read-tool';
+import { WriteTool } from '../src/tools/write-tool';
+import { EditTool } from '../src/tools/edit-tool';
+import { GlobTool } from '../src/tools/glob-tool';
+import { GrepTool } from '../src/tools/grep-tool';
+import { SendFileTool } from '../src/tools/send-file-tool';
+import { ShellTool } from '../src/tools/bash-tool';
+import type {
+  ExecutionScope,
+  ScopedDeviceGrant,
+  ScopedDeviceSelection,
+  ScopedLocalDeviceGrant,
+} from '../src/types/session-identity';
+import type { DeviceRpcTransport, ToolExecutionContext } from '../src/types/tool';
+
+function scope(overrides: Partial<ExecutionScope> = {}): ExecutionScope {
+  return {
+    source: 'catscompany',
+    sessionKey: 'session:v2:catscompany:p2p:p2p_7_43:agent:usr43',
+    topicId: 'p2p_7_43',
+    topicType: 'p2p',
+    actorUserId: 'usr7',
+    agentId: 'usr43',
+    agentBodyId: 'body-main',
+    permissionsSource: 'server_canonical_message',
+    identityTrust: 'server_canonical',
+    isTrusted: true,
+    ...overrides,
+  };
+}
+
+function localDevice(overrides: Partial<ScopedLocalDeviceGrant> = {}): ScopedLocalDeviceGrant {
+  return {
+    kind: 'catscompany_body',
+    source: 'catscompany',
+    bodyId: 'body-device',
+    installationId: 'install-device',
+    deviceId: 'install-device',
+    createdAt: Date.now(),
+    ...overrides,
+  };
+}
+
+function deviceGrant(operations: ScopedDeviceGrant['operations'], overrides: Partial<ScopedDeviceGrant> = {}): ScopedDeviceGrant {
+  const currentScope = scope();
+  return {
+    kind: 'user_device_grant',
+    source: 'catscompany',
+    grantId: 'device-grant-main',
+    status: 'active',
+    identityTrust: 'server_canonical',
+    identitySource: 'metadata.catsco_identity',
+    deviceId: 'install-device',
+    deviceDisplayName: 'Test Device',
+    deviceBodyId: 'body-device',
+    deviceInstallationId: 'install-device',
+    ownerUserId: currentScope.actorUserId,
+    sessionKey: currentScope.sessionKey,
+    topicId: currentScope.topicId,
+    topicType: currentScope.topicType,
+    actorUserId: currentScope.actorUserId,
+    agentId: currentScope.agentId,
+    agentBodyId: currentScope.agentBodyId,
+    operations,
+    createdAt: Date.now(),
+    expiresAt: Date.now() + 60_000,
+    ...overrides,
+  };
+}
+
+function deviceSelection(overrides: Partial<ScopedDeviceSelection> = {}): ScopedDeviceSelection {
+  const currentScope = scope();
+  return {
+    kind: 'user_device_selection',
+    source: 'catscompany',
+    status: 'selected',
+    selectionSource: 'single_active_device',
+    sessionKey: currentScope.sessionKey,
+    topicId: currentScope.topicId,
+    topicType: currentScope.topicType,
+    actorUserId: currentScope.actorUserId,
+    agentId: currentScope.agentId,
+    identityTrust: 'server_canonical',
+    identitySource: 'metadata.catsco_identity',
+    selectedDeviceId: 'install-device',
+    selectedDeviceDisplayName: 'Test Device',
+    selectedDeviceBodyId: 'body-device',
+    selectedDeviceInstallationId: 'install-device',
+    selectedDeviceOperations: ['read_file'],
+    ...overrides,
+  };
+}
+
+function context(root: string, options: {
+  executionScope?: ExecutionScope;
+  localDeviceGrant?: ScopedLocalDeviceGrant;
+  deviceGrants?: ScopedDeviceGrant[];
+  deviceSelection?: ScopedDeviceSelection;
+  deviceRpc?: DeviceRpcTransport;
+} = {}): ToolExecutionContext {
+  return {
+    workingDirectory: root,
+    workspaceRoot: root,
+    conversationHistory: [],
+    sessionId: options.executionScope?.sessionKey,
+    surface: 'catscompany',
+    executionScope: options.executionScope ?? scope(),
+    localDeviceGrant: options.localDeviceGrant ?? localDevice(),
+    deviceGrants: options.deviceGrants,
+    deviceSelection: options.deviceSelection,
+    deviceRpc: options.deviceRpc,
+  };
+}
+
+function makeWorkspace(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-tool-gateway-'));
+}
+
+describe('CatsCo ToolGateway', () => {
+  test('blocks regular read_file without a current user device grant', async () => {
+    const root = makeWorkspace();
+    const filePath = path.join(root, 'notes.txt');
+    fs.writeFileSync(filePath, 'secret');
+
+    const result = await new ReadTool().execute({ file_path: filePath }, context(root));
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.errorCode, 'PERMISSION_DENIED');
+      assert.match(result.message, /没有允许当前设备执行 read_file/);
+      assert.doesNotMatch(result.message, new RegExp(escapeRegExp(filePath)));
+    }
+  });
+
+  test('allows regular read_file with a matching CatsCo user device grant', async () => {
+    const root = makeWorkspace();
+    const filePath = path.join(root, 'notes.txt');
+    fs.writeFileSync(filePath, 'allowed content');
+
+    const result = await new ReadTool().execute({ file_path: filePath }, context(root, {
+      deviceGrants: [deviceGrant(['read_file'])],
+    }));
+
+    assert.equal(result.ok, true);
+    assert.match(String(result.content), /allowed content/);
+  });
+
+  test('allows read_file when backend-selected device matches the current CatsCo device', async () => {
+    const root = makeWorkspace();
+    const filePath = path.join(root, 'notes.txt');
+    fs.writeFileSync(filePath, 'selected content');
+
+    const result = await new ReadTool().execute({ file_path: filePath }, context(root, {
+      deviceGrants: [deviceGrant(['read_file'])],
+      deviceSelection: deviceSelection(),
+    }));
+
+    assert.equal(result.ok, true);
+    assert.match(String(result.content), /selected content/);
+  });
+
+  test('blocks device tools when backend requires device selection first', async () => {
+    const root = makeWorkspace();
+    const filePath = path.join(root, 'notes.txt');
+    fs.writeFileSync(filePath, 'secret');
+
+    const result = await new ReadTool().execute({ file_path: filePath }, context(root, {
+      deviceGrants: [deviceGrant(['read_file'])],
+      deviceSelection: deviceSelection({
+        status: 'needs_selection',
+        selectedDeviceId: undefined,
+        selectedDeviceBodyId: undefined,
+        selectedDeviceInstallationId: undefined,
+      }),
+    }));
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.errorCode, 'PERMISSION_DENIED');
+      assert.match(result.message, /尚未选定/);
+      assert.doesNotMatch(result.message, new RegExp(escapeRegExp(filePath)));
+    }
+  });
+
+  test('blocks remote-selected device tools when Device RPC transport is unavailable', async () => {
+    const root = makeWorkspace();
+    const filePath = path.join(root, 'notes.txt');
+    fs.writeFileSync(filePath, 'secret');
+
+    const result = await new ReadTool().execute({ file_path: filePath }, context(root, {
+      deviceGrants: [deviceGrant(['read_file'], {
+        deviceId: 'other-device',
+        deviceDisplayName: 'Other Device',
+        deviceBodyId: 'body-other',
+        deviceInstallationId: 'install-other',
+      })],
+      deviceSelection: deviceSelection({
+        selectedDeviceId: 'other-device',
+        selectedDeviceDisplayName: 'Other Device',
+        selectedDeviceBodyId: 'body-other',
+        selectedDeviceInstallationId: 'install-other',
+      }),
+    }));
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.errorCode, 'PERMISSION_DENIED');
+      assert.match(result.message, /没有配置远程设备 RPC 通道/);
+      assert.doesNotMatch(result.message, new RegExp(escapeRegExp(filePath)));
+    }
+  });
+
+  test('routes read_file to the backend-selected remote device without local file access', async () => {
+    const root = makeWorkspace();
+    const requestedPath = path.join(root, 'missing-on-agent.txt');
+    let rpcRequest: any;
+    const result = await new ReadTool().execute({ file_path: requestedPath, limit: 20 }, context(root, {
+      deviceGrants: [deviceGrant(['read_file'], {
+        deviceId: 'other-device',
+        deviceDisplayName: 'Other Device',
+        deviceBodyId: 'body-other',
+        deviceInstallationId: 'install-other',
+      })],
+      deviceSelection: deviceSelection({
+        selectedDeviceId: 'other-device',
+        selectedDeviceDisplayName: 'Other Device',
+        selectedDeviceBodyId: 'body-other',
+        selectedDeviceInstallationId: 'install-other',
+        selectedDeviceOperations: ['read_file'],
+      }),
+      deviceRpc: {
+        executeTool: async request => {
+          rpcRequest = request;
+          return { ok: true, content: 'remote file content' };
+        },
+      },
+    }));
+
+    assert.equal(result.ok, true);
+    assert.equal(String(result.content), 'remote file content');
+    assert.equal(rpcRequest.toolName, 'read_file');
+    assert.equal(rpcRequest.operation, 'read_file');
+    assert.equal(rpcRequest.grant.deviceId, 'other-device');
+    assert.deepEqual(rpcRequest.args, { file_path: requestedPath, limit: 20 });
+  });
+
+  test('routes glob and grep to the backend-selected remote device', async () => {
+    const root = makeWorkspace();
+    const calls: Array<{ toolName: string; operation: string; args: Record<string, unknown> }> = [];
+    const deviceRpc: DeviceRpcTransport = {
+      executeTool: async request => {
+        calls.push({
+          toolName: request.toolName,
+          operation: request.operation,
+          args: request.args,
+        });
+        return { ok: true, content: `remote ${request.toolName}` };
+      },
+    };
+    const remoteContext = context(root, {
+      deviceGrants: [
+        deviceGrant(['glob'], {
+          grantId: 'grant-glob',
+          deviceId: 'other-device',
+          deviceDisplayName: 'Other Device',
+          deviceBodyId: 'body-other',
+          deviceInstallationId: 'install-other',
+        }),
+        deviceGrant(['grep'], {
+          grantId: 'grant-grep',
+          deviceId: 'other-device',
+          deviceDisplayName: 'Other Device',
+          deviceBodyId: 'body-other',
+          deviceInstallationId: 'install-other',
+        }),
+      ],
+      deviceSelection: deviceSelection({
+        selectedDeviceId: 'other-device',
+        selectedDeviceDisplayName: 'Other Device',
+        selectedDeviceBodyId: 'body-other',
+        selectedDeviceInstallationId: 'install-other',
+        selectedDeviceOperations: ['glob', 'grep'],
+      }),
+      deviceRpc,
+    });
+
+    const glob = await new GlobTool().execute({ pattern: '**/*.ts', path: '/remote/project' }, remoteContext);
+    const grep = await new GrepTool().execute({ pattern: 'needle', path: '/remote/project', output_mode: 'files' }, remoteContext);
+
+    assert.equal(glob.ok, true);
+    assert.equal(grep.ok, true);
+    assert.deepEqual(calls.map(call => [call.toolName, call.operation]), [
+      ['glob', 'glob'],
+      ['grep', 'grep'],
+    ]);
+    assert.deepEqual(calls[0].args, { pattern: '**/*.ts', path: '/remote/project' });
+    assert.deepEqual(calls[1].args, { pattern: 'needle', path: '/remote/project', output_mode: 'files' });
+  });
+
+  test('redacts local absolute paths from successful CatsCo device file results', async () => {
+    const root = makeWorkspace();
+    const filePath = path.join(root, 'notes.txt');
+    const outPath = path.join(root, 'out.txt');
+    fs.writeFileSync(filePath, 'allowed content\nneedle');
+    fs.writeFileSync(outPath, 'before');
+    const ctx = context(root, {
+      deviceGrants: [deviceGrant(['read_file', 'glob', 'grep', 'write_file', 'edit_file', 'send_file'])],
+    });
+    ctx.channel = {
+      chatId: scope().topicId,
+      reply: async () => {},
+      sendFile: async () => {},
+    };
+
+    const read = await new ReadTool().execute({ file_path: filePath }, ctx);
+    assert.equal(read.ok, true);
+    assert.doesNotMatch(String(read.content), new RegExp(escapeRegExp(filePath)));
+
+    const glob = await new GlobTool().execute({ pattern: '*.txt', path: root }, ctx);
+    assert.equal(glob.ok, true);
+    assert.match(String(glob.content), /notes\.txt/);
+    assert.doesNotMatch(String(glob.content), new RegExp(escapeRegExp(root)));
+
+    const grep = await new GrepTool().execute({ pattern: 'needle', path: filePath, output_mode: 'content' }, ctx);
+    assert.equal(grep.ok, true);
+    assert.match(String(grep.content), /needle/);
+    assert.doesNotMatch(String(grep.content), new RegExp(escapeRegExp(root)));
+
+    const write = await new WriteTool().execute({ file_path: outPath, content: 'after' }, ctx);
+    assert.equal(write.ok, true);
+    assert.doesNotMatch(String(write.content), new RegExp(escapeRegExp(outPath)));
+
+    const edit = await new EditTool().execute({ file_path: outPath, old_string: 'after', new_string: 'done' }, ctx);
+    assert.equal(edit.ok, true);
+    assert.doesNotMatch(String(edit.content), new RegExp(escapeRegExp(outPath)));
+
+    const send = await new SendFileTool().execute({ file_path: filePath, file_name: 'notes.txt' }, ctx);
+    assert.equal(send.ok, true);
+    assert.doesNotMatch(String(send.content), new RegExp(escapeRegExp(filePath)));
+  });
+
+  test('redacts local absolute paths from CatsCo device file failure results', async () => {
+    const root = makeWorkspace();
+    const missingPath = path.join(root, 'missing.txt');
+    const ctx = context(root, {
+      deviceGrants: [deviceGrant(['read_file', 'send_file'])],
+    });
+
+    const readDirectory = await new ReadTool().execute({ file_path: root }, ctx);
+    assert.equal(readDirectory.ok, false);
+    if (!readDirectory.ok) {
+      assert.equal(readDirectory.errorCode, 'TOOL_EXECUTION_ERROR');
+      assert.match(readDirectory.message, /Path is not a file/);
+      assert.doesNotMatch(readDirectory.message, new RegExp(escapeRegExp(root)));
+    }
+
+    const sendMissing = await new SendFileTool().execute({ file_path: missingPath, file_name: 'missing.txt' }, ctx);
+    assert.equal(sendMissing.ok, false);
+    if (!sendMissing.ok) {
+      assert.equal(sendMissing.errorCode, 'FILE_NOT_FOUND');
+      assert.match(sendMissing.message, /File not found/);
+      assert.doesNotMatch(sendMissing.message, new RegExp(escapeRegExp(missingPath)));
+      assert.doesNotMatch(sendMissing.message, new RegExp(escapeRegExp(root)));
+    }
+
+    const sendDirectory = await new SendFileTool().execute({ file_path: root, file_name: 'root' }, ctx);
+    assert.equal(sendDirectory.ok, false);
+    if (!sendDirectory.ok) {
+      assert.equal(sendDirectory.errorCode, 'TOOL_EXECUTION_ERROR');
+      assert.match(sendDirectory.message, /Path is not a file/);
+      assert.doesNotMatch(sendDirectory.message, new RegExp(escapeRegExp(root)));
+    }
+  });
+
+  test('allows glob only when the CatsCo device grant includes glob operation', async () => {
+    const root = makeWorkspace();
+    fs.writeFileSync(path.join(root, 'a.txt'), 'a');
+
+    const denied = await new GlobTool().execute({ pattern: '*.txt' }, context(root, {
+      deviceGrants: [deviceGrant(['read_file'])],
+    }));
+    assert.equal(denied.ok, false);
+    if (!denied.ok) assert.match(denied.message, /执行 glob/);
+
+    const allowed = await new GlobTool().execute({ pattern: '*.txt' }, context(root, {
+      deviceGrants: [deviceGrant(['glob'])],
+    }));
+    assert.equal(allowed.ok, true);
+    assert.match(String(allowed.content), /a\.txt/);
+  });
+
+  test('blocks write_file until the server grants write_file for the current device', async () => {
+    const root = makeWorkspace();
+    const result = await new WriteTool().execute({ file_path: 'out.txt', content: 'hello' }, context(root, {
+      deviceGrants: [deviceGrant(['read_file'])],
+    }));
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.errorCode, 'PERMISSION_DENIED');
+      assert.match(result.message, /执行 write_file/);
+      assert.equal(fs.existsSync(path.join(root, 'out.txt')), false);
+    }
+  });
+
+  test('blocks execute_shell in CatsCo sessions even when a grant contains execute_shell', async () => {
+    const root = makeWorkspace();
+    const result = await new ShellTool().execute({ command: 'echo hello' }, context(root, {
+      deviceGrants: [deviceGrant(['execute_shell'])],
+    }));
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.errorCode, 'PERMISSION_DENIED');
+      assert.match(result.message, /暂不允许通过 execute_shell/);
+    }
+  });
+});
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/tests/tool-result-send-file-tool.test.ts
+++ b/tests/tool-result-send-file-tool.test.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import * as os from 'os';
 import * as fs from 'fs';
 import { SendFileTool } from '../src/tools/send-file-tool';
-import type { ExecutionScope, ScopedLocalDeviceGrant, ScopedLocalFileGrant } from '../src/types/session-identity';
+import type { ExecutionScope, ScopedDeviceGrant, ScopedLocalDeviceGrant, ScopedLocalFileGrant } from '../src/types/session-identity';
 import { ToolExecutionContext } from '../src/types/tool';
 
 describe('SendFileTool - ToolExecutionResult', () => {
@@ -76,6 +76,33 @@ describe('SendFileTool - ToolExecutionResult', () => {
       installationId: 'install-main',
       deviceId: 'install-main',
       createdAt: Date.now(),
+      ...overrides,
+    };
+  }
+
+  function userDeviceGrant(operations: ScopedDeviceGrant['operations'], overrides: Partial<ScopedDeviceGrant> = {}): ScopedDeviceGrant {
+    const currentScope = scope();
+    return {
+      kind: 'user_device_grant',
+      source: 'catscompany',
+      grantId: 'device-grant-send-file',
+      status: 'active',
+      identityTrust: 'server_canonical',
+      identitySource: 'metadata.catsco_identity',
+      deviceId: 'install-main',
+      deviceDisplayName: 'Main Device',
+      deviceBodyId: 'body-main',
+      deviceInstallationId: 'install-main',
+      ownerUserId: currentScope.actorUserId,
+      sessionKey: currentScope.sessionKey,
+      topicId: currentScope.topicId,
+      topicType: currentScope.topicType,
+      actorUserId: currentScope.actorUserId,
+      agentId: currentScope.agentId,
+      agentBodyId: currentScope.agentBodyId,
+      operations,
+      createdAt: Date.now(),
+      expiresAt: Date.now() + 60_000,
       ...overrides,
     };
   }
@@ -154,6 +181,8 @@ describe('SendFileTool - ToolExecutionResult', () => {
     fs.writeFileSync(filePath, 'hello');
     let sentChatId = '';
     context.executionScope = scope({ topicId: 'chat-1' });
+    context.localDeviceGrant = deviceGrant();
+    context.deviceGrants = [userDeviceGrant(['send_file'], { topicId: 'chat-1' })];
     context.channel = {
       chatId: 'chat-1',
       reply: async () => {},
@@ -215,7 +244,7 @@ describe('SendFileTool - ToolExecutionResult', () => {
     assert.strictEqual(sendCalled, false);
   });
 
-  test('allows file send for legacy CatsCo scope when topic matches', async () => {
+  test('blocks regular file send for legacy CatsCo scope even when topic matches', async () => {
     const filePath = path.join(testRoot, 'legacy.md');
     fs.writeFileSync(filePath, 'hello');
     let sentChatId = '';
@@ -235,8 +264,10 @@ describe('SendFileTool - ToolExecutionResult', () => {
 
     const result = await tool.execute({ file_path: filePath, file_name: 'legacy.md' }, context);
 
-    assert.strictEqual(result.ok, true);
-    assert.strictEqual(sentChatId, 'chat-1');
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.errorCode, 'PERMISSION_DENIED');
+    assert.match(result.message, /身份未通过服务端一致性校验/);
+    assert.strictEqual(sentChatId, '');
   });
 
   test('allows sending a CatsCo attachment cache file with a matching local grant', async () => {


### PR DESCRIPTION
## 背景

这是 PR4：Device Identity & DeviceGrant Foundation。它堆叠在 PR3 `codex/context-builder-structured-runtime-context` 之上，目标是在 XiaoBa-CLI 侧建立“当前用户授权了哪些设备、工具执行时如何校验”的本地运行时契约。

## 这个 PR 做了什么

- 新增 `UserDevice` / `ScopedDeviceGrant` 契约，表达用户设备、设备授权、授权操作、状态、过期时间和会话身份边界。
- 新增 `createUserDevice`、`createDeviceGrant`、`resolveDeviceGrant`、`validateDeviceGrant`，用于创建和校验设备授权。
- 将 `deviceGrants` 从 `AgentSession` 透传到 `TurnContextBuilder`、`ConversationRunner` 和 `ToolExecutionContext`。
- 在 runtime context 中给模型暴露安全摘要 `execution.userDevices`，只包含 `grantId/deviceId/displayName/operations/status/expiresAt`，不暴露 `bodyId`、`installationId` 或本地路径。
- pending 用户输入携带新设备/文件授权时，会刷新下一次模型请求看到的 transient runtime context，避免工具上下文和模型上下文不一致。
- 设备授权解析时，如果同一操作存在多个有效设备且后端没有指定 `deviceId`，会拒绝执行，避免默认选错设备。
- 顺手补强 CatsCo 本地文件授权网关的 `source/topicType/agentId/deviceInstallationId` mismatch 覆盖，降低串会话/串设备风险。

## 明确边界

- 这个 PR 不实现云端设备注册、在线状态、远程连接、任务派发或真正的本地电脑控制。
- `DeviceGrantOperation` 里预留了 `glob/grep/execute_shell` 等操作词表，但本 PR 不 harden 这些广义工具；后续 PR 再接具体工具网关策略。
- cats-company 侧的设备注册、授权下发、body lease/status 仍然放在后续 PR。

## 验证

- `npm.cmd run build -- --noEmit`
- `node .\\node_modules\\tsx\\dist\\cli.mjs --test tests\\device-grants.test.ts tests\\runtime-context-builder.test.ts tests\\agent-turn-execution-scope.test.ts tests\\conversation-runner-pending-input.test.ts tests\\local-file-gateway.test.ts tests\\tool-result-read-file-local-grants.test.ts tests\\tool-result-send-file-tool.test.ts`
- `npm.cmd run test:runtime`，结果：583 passed / 0 failed / 2 skipped

## 子 Agent 审查

本 PR 过程中调用了 3 个独立子 Agent 做安全边界、测试覆盖和产品范围审查；审查指出的 runtime context bodyId 泄露、多设备歧义、pending context 刷新、坏授权挡住好授权、installation mismatch 测试都已补齐。