### PR TITLE
修复微信登录态过期后空转

### DIFF
--- a/src/commands/weixin.ts
+++ b/src/commands/weixin.ts
@@ -3,6 +3,8 @@ import { WeixinBot } from '../weixin';
 import { WeixinConfig } from '../weixin/types';
 import { startRuntimeCommandSupport, stopRuntimeCommandSupport } from '../utils/runtime-command-support';
 
+const WEIXIN_SESSION_EXPIRED_EXIT_CODE = 78;
+
 export async function weixinCommand(): Promise<void> {
   const token = process.env.WEIXIN_TOKEN;
   const baseUrl = process.env.WEIXIN_BASE_URL || 'https://ilinkai.weixin.qq.com';
@@ -15,19 +17,31 @@ export async function weixinCommand(): Promise<void> {
 
   process.env.CURRENT_PLATFORM = '微信';
 
-  const config: WeixinConfig = { token, baseUrl, cdnBaseUrl };
-  const bot = new WeixinBot(config);
+  let bot: WeixinBot | undefined;
+  let exiting = false;
 
-  const shutdown = () => {
+  const shutdown = (exitCode = 0) => {
+    if (exiting) return;
+    exiting = true;
     Promise.resolve(stopRuntimeCommandSupport())
       .catch(() => undefined)
       .finally(() => {
-        bot.destroy();
-        process.exit(0);
+        bot?.destroy();
+        Logger.closeLogFile();
+        process.exit(exitCode);
       });
   };
-  process.on('SIGINT', shutdown);
-  process.on('SIGTERM', shutdown);
+
+  const config: WeixinConfig = {
+    token,
+    baseUrl,
+    cdnBaseUrl,
+    onSessionExpired: () => shutdown(WEIXIN_SESSION_EXPIRED_EXIT_CODE),
+  };
+  bot = new WeixinBot(config);
+
+  process.on('SIGINT', () => shutdown(0));
+  process.on('SIGTERM', () => shutdown(0));
 
   await bot.start();
   await startRuntimeCommandSupport();

--- a/src/dashboard/service-manager.ts
+++ b/src/dashboard/service-manager.ts
@@ -24,18 +24,32 @@ interface ManagedService {
   info: ServiceInfo;
   process?: ChildProcess;
   logs: string[];  // 最近的日志
+  expectedExit?: 'stop' | 'restart';
 }
 
 const MAX_LOG_LINES = 500;
+const MAX_LAST_ERROR_LENGTH = 500;
 
 function stripAnsi(value: string): string {
   // eslint-disable-next-line no-control-regex
   return value.replace(/\x1B\[[0-9;]*m/g, '');
 }
 
+function sanitizeServiceLogLine(value: string): string {
+  const sanitized = stripAnsi(value)
+    .replace(/cats_svc_[A-Za-z0-9_-]+/g, '[redacted-token]')
+    .replace(/\bsk-[A-Za-z0-9_-]{8,}\b/g, '[redacted-key]')
+    .replace(/\bAuthorization\s*[:=]\s*(?:[A-Za-z][A-Za-z0-9+.-]*\s+)?[^\s,;'"`<>]+/gi, 'Authorization: [redacted-token]')
+    .replace(/\b(?:Bearer|ApiKey|Token)\s+[A-Za-z0-9._~+/=-]+/gi, match => `${match.split(/\s+/)[0]} [redacted-token]`)
+    .replace(/(["']?)([A-Za-z0-9_.-]*(?:token|api[_-]?key|secret|password)[A-Za-z0-9_.-]*)\1\s*[:=]\s*["']?[^&\s,'"`<>}]+["']?/gi, '$1$2$1=[redacted-token]')
+    .trim();
+  if (sanitized.length <= MAX_LAST_ERROR_LENGTH) return sanitized;
+  return `${sanitized.slice(0, MAX_LAST_ERROR_LENGTH - 1)}…`;
+}
+
 function pickLastErrorLine(logs: string[]): string | undefined {
   for (let i = logs.length - 1; i >= 0; i -= 1) {
-    const line = stripAnsi(logs[i] || '').trim();
+    const line = sanitizeServiceLogLine(logs[i] || '');
     if (/\[ERROR\]|\berror\b|错误|失败|过期/i.test(line)) {
       return line;
     }
@@ -265,6 +279,7 @@ export class ServiceManager extends EventEmitter {
     }
 
     svc.process = child;
+    svc.expectedExit = undefined;
     svc.info.status = 'running';
     svc.info.pid = child.pid;
     svc.info.startedAt = Date.now();
@@ -282,14 +297,21 @@ export class ServiceManager extends EventEmitter {
     child.stdout?.on('data', appendLog);
     child.stderr?.on('data', appendLog);
 
-    child.on('exit', (code) => {
-      svc.info.status = code === 0 ? 'stopped' : 'error';
+    child.on('exit', (code, signal) => {
+      const expectedExit = svc.expectedExit;
+      svc.expectedExit = undefined;
+      svc.info.status = expectedExit || code === 0
+        ? 'stopped'
+        : 'error';
       svc.info.pid = undefined;
-      if (code !== 0) {
+      if (expectedExit || code === 0) {
+        svc.info.lastError = undefined;
+      } else {
         const lastErrorLine = pickLastErrorLine(svc.logs);
+        const exitReason = code === null ? `signal ${signal || 'unknown'}` : `code ${code}`;
         svc.info.lastError = lastErrorLine
-          ? `${lastErrorLine} (code ${code})`
-          : `Process exited with code ${code}`;
+          ? `${lastErrorLine} (${exitReason})`
+          : `Process exited with ${exitReason}`;
       }
       svc.process = undefined;
       this.emit('service-stopped', name, code);
@@ -332,16 +354,19 @@ export class ServiceManager extends EventEmitter {
 
     if (isWindows) {
       // Windows: 直接用 taskkill 强制终止进程树
+      svc.expectedExit = 'stop';
       this.killProcess(svc.process, true);
     } else {
+      svc.expectedExit = 'stop';
       svc.process.kill('SIGTERM');
 
       // 5秒后强制kill
-      setTimeout(() => {
+      const forceKillTimer = setTimeout(() => {
         if (svc.process && !svc.process.killed) {
           svc.process.kill('SIGKILL');
         }
       }, 5000);
+      forceKillTimer.unref?.();
     }
 
     return this.getService(name)!;
@@ -354,8 +379,10 @@ export class ServiceManager extends EventEmitter {
     if (svc.info.status === 'running' && svc.process) {
       // 先停再启，等进程退出后启动
       svc.process.once('exit', () => {
-        setTimeout(() => this.start(name), 500);
+        const restartTimer = setTimeout(() => this.start(name), 500);
+        restartTimer.unref?.();
       });
+      svc.expectedExit = 'restart';
       this.killProcess(svc.process);
       return this.getService(name)!;
     }
@@ -366,6 +393,7 @@ export class ServiceManager extends EventEmitter {
   stopAll() {
     for (const [name, svc] of this.services) {
       if (svc.info.status === 'running' && svc.process) {
+        svc.expectedExit = 'stop';
         this.killProcess(svc.process, true);
       }
     }

--- a/src/dashboard/service-manager.ts
+++ b/src/dashboard/service-manager.ts
@@ -28,6 +28,21 @@ interface ManagedService {
 
 const MAX_LOG_LINES = 500;
 
+function stripAnsi(value: string): string {
+  // eslint-disable-next-line no-control-regex
+  return value.replace(/\x1B\[[0-9;]*m/g, '');
+}
+
+function pickLastErrorLine(logs: string[]): string | undefined {
+  for (let i = logs.length - 1; i >= 0; i -= 1) {
+    const line = stripAnsi(logs[i] || '').trim();
+    if (/\[ERROR\]|\berror\b|错误|失败|过期/i.test(line)) {
+      return line;
+    }
+  }
+  return undefined;
+}
+
 function readEnvFile(root: string): Record<string, string> {
   const envPath = path.join(root, '.env');
   if (!fs.existsSync(envPath)) return {};
@@ -271,7 +286,10 @@ export class ServiceManager extends EventEmitter {
       svc.info.status = code === 0 ? 'stopped' : 'error';
       svc.info.pid = undefined;
       if (code !== 0) {
-        svc.info.lastError = `Process exited with code ${code}`;
+        const lastErrorLine = pickLastErrorLine(svc.logs);
+        svc.info.lastError = lastErrorLine
+          ? `${lastErrorLine} (code ${code})`
+          : `Process exited with code ${code}`;
       }
       svc.process = undefined;
       this.emit('service-stopped', name, code);

--- a/src/weixin/index.ts
+++ b/src/weixin/index.ts
@@ -80,13 +80,42 @@ export class WeixinBot {
 
   private async saveState(): Promise<void> {
     try {
-      const bufPath = path.join(this.stateDir, 'get_updates.buf');
-      const tokensPath = path.join(this.stateDir, 'context_tokens.json');
+      const { bufPath, tokensPath } = this.getStatePaths();
 
       await fs.writeFile(bufPath, this.getUpdatesBuf);
       await fs.writeFile(tokensPath, JSON.stringify(Object.fromEntries(this.contextTokens)));
     } catch (err) {
       Logger.error(`[微信] 保存状态失败: ${err}`);
+    }
+  }
+
+  private getStatePaths(): { bufPath: string; tokensPath: string } {
+    return {
+      bufPath: path.join(this.stateDir, 'get_updates.buf'),
+      tokensPath: path.join(this.stateDir, 'context_tokens.json'),
+    };
+  }
+
+  private async clearState(): Promise<void> {
+    this.getUpdatesBuf = '';
+    this.contextTokens.clear();
+    try {
+      const { bufPath, tokensPath } = this.getStatePaths();
+      await fs.rm(bufPath, { force: true });
+      await fs.rm(tokensPath, { force: true });
+    } catch (err) {
+      Logger.error(`[微信] 清理过期状态失败: ${err}`);
+    }
+  }
+
+  private async handleSessionExpired(): Promise<void> {
+    Logger.error('[微信] 会话已过期，请重新登录：打开 Dashboard 的微信配置，点击“获取 Token”扫码授权，保存后重新启动微信机器人。');
+    await this.clearState();
+    this.isRunning = false;
+    try {
+      await this.config.onSessionExpired?.();
+    } catch (err) {
+      Logger.error(`[微信] 会话过期收束失败: ${err}`);
     }
   }
 
@@ -142,9 +171,8 @@ export class WeixinBot {
         const { ret, errcode, errmsg, msgs = [], get_updates_buf } = response.data;
 
         if (errcode === -14) {
-          Logger.error('[微信] 会话已过期，请重新登录');
-          await new Promise(resolve => setTimeout(resolve, 3600000));
-          continue;
+          await this.handleSessionExpired();
+          return;
         }
 
         if (get_updates_buf) {
@@ -316,6 +344,9 @@ export class WeixinBot {
   destroy(): void {
     this.isRunning = false;
     this.messageQueue.clear();
+    void this.sessionManager.destroy().catch(err => {
+      Logger.warning(`[微信] 清理会话管理器失败: ${err}`);
+    });
     Logger.info('[微信] 机器人已停止');
   }
 }

--- a/src/weixin/types.ts
+++ b/src/weixin/types.ts
@@ -3,6 +3,7 @@ export interface WeixinConfig {
   baseUrl: string;
   cdnBaseUrl: string;
   stateDir?: string;
+  onSessionExpired?: () => void | Promise<void>;
 }
 
 export interface WeixinMessage {

--- a/tests/dashboard-service-manager.test.ts
+++ b/tests/dashboard-service-manager.test.ts
@@ -122,7 +122,7 @@ describe('dashboard service manager', () => {
     serviceRecord.info.command = process.execPath;
     serviceRecord.info.args = [
       '-e',
-      "console.error('[ERROR] [微信] 会话已过期，请重新登录'); process.exit(78);",
+      "console.error('[ERROR] [微信] 会话已过期，请重新登录 Authorization: Bearer wx-secret-token WEIXIN_TOKEN=wx-secret-token sk-live-secret1234567890'); process.exit(78);",
     ];
 
     const stopped = new Promise<void>(resolve => {
@@ -136,6 +136,33 @@ describe('dashboard service manager', () => {
     assert.equal(service?.status, 'error');
     assert.match(service?.lastError || '', /会话已过期/);
     assert.match(service?.lastError || '', /code 78/);
+    assert.match(service?.lastError || '', /Authorization: \[redacted-token\]/);
+    assert.match(service?.lastError || '', /WEIXIN_TOKEN=\[redacted-token\]/);
+    assert.match(service?.lastError || '', /\[redacted-key\]/);
+    assert.equal((service?.lastError || '').includes('wx-secret-token'), false);
+    assert.equal((service?.lastError || '').includes('sk-live-secret1234567890'), false);
+  });
+
+  test('treats dashboard-requested service stop as stopped even when the child exits non-zero', async () => {
+    const manager = new ServiceManager(process.cwd());
+    const serviceRecord = (manager as any).services.get('weixin');
+    serviceRecord.info.command = process.execPath;
+    serviceRecord.info.args = [
+      '-e',
+      "console.error('[ERROR] transient startup line'); setInterval(() => {}, 1000);",
+    ];
+
+    const stopped = new Promise<void>(resolve => {
+      manager.once('service-stopped', () => resolve());
+    });
+
+    manager.start('weixin');
+    manager.stop('weixin');
+    await stopped;
+
+    const service = manager.getService('weixin');
+    assert.equal(service?.status, 'stopped');
+    assert.equal(service?.lastError, undefined);
   });
 });
 

--- a/tests/dashboard-service-manager.test.ts
+++ b/tests/dashboard-service-manager.test.ts
@@ -115,6 +115,28 @@ describe('dashboard service manager', () => {
       fs.rmSync(runtimeRoot, { recursive: true, force: true });
     }
   });
+
+  test('preserves the last child error line when a service exits non-zero', async () => {
+    const manager = new ServiceManager(process.cwd());
+    const serviceRecord = (manager as any).services.get('weixin');
+    serviceRecord.info.command = process.execPath;
+    serviceRecord.info.args = [
+      '-e',
+      "console.error('[ERROR] [微信] 会话已过期，请重新登录'); process.exit(78);",
+    ];
+
+    const stopped = new Promise<void>(resolve => {
+      manager.once('service-stopped', () => resolve());
+    });
+
+    manager.start('weixin');
+    await stopped;
+
+    const service = manager.getService('weixin');
+    assert.equal(service?.status, 'error');
+    assert.match(service?.lastError || '', /会话已过期/);
+    assert.match(service?.lastError || '', /code 78/);
+  });
 });
 
 function normalize(value: string): string {

--- a/tests/weixin-session-expiry.test.ts
+++ b/tests/weixin-session-expiry.test.ts
@@ -1,0 +1,42 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { WeixinBot } from '../src/weixin';
+
+describe('weixin session expiry', () => {
+  test('stops polling, clears local cursor state, and notifies the command when the token expires', async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-weixin-state-'));
+    const bufPath = path.join(stateDir, 'get_updates.buf');
+    const tokensPath = path.join(stateDir, 'context_tokens.json');
+    fs.writeFileSync(bufPath, 'stale-cursor', 'utf-8');
+    fs.writeFileSync(tokensPath, JSON.stringify({ 'user:old': 'stale-context' }), 'utf-8');
+
+    let expiredCalls = 0;
+    let bot: WeixinBot | undefined;
+
+    try {
+      bot = new WeixinBot({
+        token: 'expired-token',
+        baseUrl: 'https://weixin.example.test',
+        cdnBaseUrl: 'https://cdn.example.test',
+        stateDir,
+        onSessionExpired: () => {
+          expiredCalls += 1;
+        },
+      });
+
+      (bot as any).isRunning = true;
+      await (bot as any).handleSessionExpired();
+
+      assert.equal(expiredCalls, 1);
+      assert.equal((bot as any).isRunning, false);
+      assert.equal(fs.existsSync(bufPath), false);
+      assert.equal(fs.existsSync(tokensPath), false);
+    } finally {
+      bot?.destroy();
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## 背景

1.2.0 微信机器人启动后，如果微信 iLink 返回 `errcode=-14`，当前实现只打印“会话已过期”并睡眠 1 小时继续轮询。

用户侧表现是：Dashboard 日志显示微信机器人已启动，但实际已经无法收消息/回消息，也没有明确的恢复动作。

## 修改

- 微信 session 过期时立即停止轮询，不再静默睡眠空转。
- 清理本地微信轮询游标和 context token，避免重新授权后继续带旧状态。
- 命令入口用固定非零退出码结束微信服务，让 Dashboard 服务状态进入 error。
- ServiceManager 在子进程异常退出时保留最后一条错误日志，界面能看到“会话已过期，请重新登录”。
- 停止微信机器人时销毁 MessageSessionManager，释放清理 timer。

## 验证

- `node --import tsx tests/weixin-session-expiry.test.ts`
- `node --import tsx tests/dashboard-service-manager.test.ts`
- `npm.cmd run build`
- `npm.cmd run test:runtime`