### PR TITLE
完善 CatsCo 中转模型视觉能力闭环

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -7099,10 +7099,10 @@
     let catsSetupInFlight=false;
     const CUSTOM_MODEL_AUTO_SAVE_DELAY=900;
     const RELAY_FALLBACK_MODELS=[
-      {id:'minimax-m2.7',label:'MiniMax M2.7',model:'MiniMax-M2.7',provider:'anthropic',base_url:'https://relay.catsco.cc/anthropic',quota_class:'standard',context_window_tokens:204800,context_label:'204.8K',default:true},
-      {id:'minimax-m3',label:'MiniMax M3',model:'MiniMax-M3',provider:'anthropic',base_url:'https://relay.catsco.cc/anthropic',quota_class:'multimodal',context_window_tokens:1000000,context_label:'1M'},
-      {id:'deepseek-v4-flash',label:'DeepSeek V4 Flash',model:'deepseek-v4-flash',provider:'anthropic',base_url:'https://relay.catsco.cc/anthropic',quota_class:'flash-low',context_window_tokens:1000000,context_label:'1M'},
-      {id:'glm-5.1',label:'GLM 5.1',model:'glm-5.1',provider:'anthropic',base_url:'https://relay.catsco.cc/anthropic',quota_class:'standard',context_window_tokens:200000,context_label:'200K'},
+      {id:'minimax-m2.7',label:'MiniMax M2.7',model:'MiniMax-M2.7',provider:'anthropic',protocol:'Anthropic-compatible',base_url:'https://relay.catsco.cc/anthropic',sdk_label:'Anthropic SDK',quota_class:'standard',context_window_tokens:204800,context_label:'204.8K',default:true},
+      {id:'minimax-m3',label:'MiniMax M3',model:'MiniMax-M3',provider:'anthropic',protocol:'Anthropic-compatible',base_url:'https://relay.catsco.cc/anthropic',sdk_label:'Anthropic SDK',quota_class:'multimodal',context_window_tokens:1000000,context_label:'1M'},
+      {id:'deepseek-v4-flash',label:'DeepSeek V4 Flash',model:'deepseek-v4-flash',provider:'openai',protocol:'OpenAI-compatible',base_url:'https://relay.catsco.cc/v1',sdk_label:'OpenAI SDK',quota_class:'flash-low',context_window_tokens:1000000,context_label:'1M'},
+      {id:'glm-5.1',label:'GLM 5.1',model:'glm-5.1',provider:'openai',protocol:'OpenAI-compatible',base_url:'https://relay.catsco.cc/v1',sdk_label:'OpenAI SDK',quota_class:'standard',context_window_tokens:200000,context_label:'200K'},
     ];
     const serviceConfigGroups={
       catscompany:{
@@ -7299,11 +7299,12 @@
       const active=id===activeId;
       const quota=model.quota_class==='flash-low'?'低额度 Flash':model.quota_class==='multimodal'?'多模态':'标准额度';
       const contextLabel=formatModelContextLabel(model.context_window_tokens, model.context_label);
+      const sdkLabel=model.sdk_label || (String(model.provider||model.protocol||'').toLowerCase().includes('openai')?'OpenAI SDK':'Anthropic SDK');
       const disabled=relayActionBusy() || (context!=='chat' && !catsConnected);
       return '<button class="relay-model-choice'+(active?' active':'')+'" type="button" data-relay-model-id="'+escapeHtml(id)+'" data-relay-model-context="'+escapeHtml(context)+'" '+(disabled?'disabled':'')+' onclick="enableCatsRelayModelFromButton(this)">'
         +'<span class="relay-model-label">'+escapeHtml(model.label||model.model||id)+'</span>'
         +'<span class="relay-model-name">'+escapeHtml(model.model||id)+'</span>'
-        +'<span class="relay-model-meta">'+escapeHtml(quota)+' · 上下文 '+escapeHtml(contextLabel)+' · Anthropic SDK</span>'
+        +'<span class="relay-model-meta">'+escapeHtml(quota)+' · 上下文 '+escapeHtml(contextLabel)+' · '+escapeHtml(sdkLabel)+'</span>'
         +'</button>';
     }
 

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -7101,8 +7101,8 @@
     const RELAY_FALLBACK_MODELS=[
       {id:'minimax-m2.7',label:'MiniMax M2.7',model:'MiniMax-M2.7',provider:'anthropic',protocol:'Anthropic-compatible',base_url:'https://relay.catsco.cc/anthropic',sdk_label:'Anthropic SDK',quota_class:'standard',context_window_tokens:204800,context_label:'204.8K',default:true},
       {id:'minimax-m3',label:'MiniMax M3',model:'MiniMax-M3',provider:'anthropic',protocol:'Anthropic-compatible',base_url:'https://relay.catsco.cc/anthropic',sdk_label:'Anthropic SDK',quota_class:'multimodal',context_window_tokens:1000000,context_label:'1M'},
-      {id:'deepseek-v4-flash',label:'DeepSeek V4 Flash',model:'deepseek-v4-flash',provider:'openai',protocol:'OpenAI-compatible',base_url:'https://relay.catsco.cc/v1',sdk_label:'OpenAI SDK',quota_class:'flash-low',context_window_tokens:1000000,context_label:'1M'},
-      {id:'glm-5.1',label:'GLM 5.1',model:'glm-5.1',provider:'openai',protocol:'OpenAI-compatible',base_url:'https://relay.catsco.cc/v1',sdk_label:'OpenAI SDK',quota_class:'standard',context_window_tokens:200000,context_label:'200K'},
+      {id:'deepseek-v4-flash',label:'DeepSeek V4 Flash',model:'deepseek-v4-flash',provider:'anthropic',protocol:'Anthropic-compatible',base_url:'https://relay.catsco.cc/anthropic',sdk_label:'Anthropic SDK',quota_class:'flash-low',context_window_tokens:1000000,context_label:'1M'},
+      {id:'glm-5.1',label:'GLM 5.1',model:'glm-5.1',provider:'anthropic',protocol:'Anthropic-compatible',base_url:'https://relay.catsco.cc/anthropic',sdk_label:'Anthropic SDK',quota_class:'standard',context_window_tokens:200000,context_label:'200K'},
     ];
     const serviceConfigGroups={
       catscompany:{

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -1359,6 +1359,7 @@ export class CatsCompanyBot {
     const blocks: import('../types').ContentBlock[] = [];
     const config = ConfigManager.getConfigReadonly();
     const primaryModelCanSeeImages = isPrimaryModelVisionCapable(config);
+    const modelName = config.model || 'unknown';
     const currentImageRefs: string[] = [];
 
     if (text) {
@@ -1380,9 +1381,10 @@ export class CatsCompanyBot {
             ...imgBlock,
             filePath: att.localFileGrant?.attachmentRef || `[CatsCo attachment: ${att.fileName}]`,
           } as any);
-          Logger.info(`[多模态] 已添加图片块: ${att.fileName}, base64长度: ${(imgBlock.source as any)?.data?.length || 0}`);
+          Logger.info(`[CatsCo] vision_direct model=${modelName} file=${att.fileName} bytes_base64=${((imgBlock as any).source as any)?.data?.length || 0}`);
         } else {
-          Logger.warning(`[多模态] 图片块创建失败: ${att.fileName} at ${att.localPath}`);
+          currentImageRefs.push(attachmentReference);
+          Logger.warning(`[CatsCo] vision_fallback_read_file model=${modelName} file=${att.fileName} reason=image_block_create_failed`);
         }
       } else {
         blocks.push({ type: 'text', text: attachmentReference });
@@ -1392,16 +1394,16 @@ export class CatsCompanyBot {
     Logger.info(`[多模态] 构建完成，共 ${blocks.length} 个块: ${blocks.map(b => b.type).join(', ')}`);
     if (currentImageRefs.length > 0) {
       blocks.push({
-        type: 'text',
-        text: [
-          '[Current user turn contains image attachments]',
-          'The primary model cannot directly inspect image pixels in this runtime.',
-          'If the user request depends on image content, call read_file with file_path set to the current authorized attachment reference below.',
-          'Use only the current authorized attachment reference(s) listed here. Do not use old tmp/downloads paths, old image URLs, old filenames, or prior image descriptions.',
-          currentImageRefs.join('\n\n'),
-        ].join('\n'),
-      });
-      Logger.info(`[CatsCo] Primary model is text-only; exposed ${currentImageRefs.length} current attachment reference(s) for read_file`);
+          type: 'text',
+          text: [
+            '[Current user turn contains image attachments]',
+            'The primary model cannot directly inspect image pixels in this runtime.',
+            'If the user request depends on image content, call read_file with file_path set to the current authorized attachment reference below.',
+            'Use only the current authorized attachment reference(s) listed here. Do not use old tmp/downloads paths, old image URLs, old filenames, or prior image descriptions.',
+            currentImageRefs.join('\n\n'),
+          ].join('\n'),
+        });
+      Logger.info(`[CatsCo] vision_fallback_read_file model=${modelName} images=${currentImageRefs.length} reason=${primaryModelCanSeeImages ? 'image_block_create_failed' : 'model_not_vision_capable'}`);
     }
 
     return blocks;

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -31,6 +31,7 @@ import {
   normalizeDeviceRpcToolResultForTransport,
   normalizeDeviceRpcToolResultPayload,
 } from '../tools/device-rpc-tool';
+import { formatPathForLog } from '../utils/log-redaction';
 
 interface PendingAttachment {
   fileName: string;
@@ -1376,15 +1377,16 @@ export class CatsCompanyBot {
 
         blocks.push({ type: 'text', text: attachmentReference });
         const imgBlock = await createImageBlock(att.localPath);
+        const logFile = formatPathForLog(att.localPath || att.fileName);
         if (imgBlock) {
           blocks.push({
             ...imgBlock,
             filePath: att.localFileGrant?.attachmentRef || `[CatsCo attachment: ${att.fileName}]`,
           } as any);
-          Logger.info(`[CatsCo] vision_direct model=${modelName} file=${att.fileName} bytes_base64=${((imgBlock as any).source as any)?.data?.length || 0}`);
+          Logger.info(`[CatsCo] vision_direct model=${modelName} file=${logFile} bytes_base64=${((imgBlock as any).source as any)?.data?.length || 0}`);
         } else {
           currentImageRefs.push(attachmentReference);
-          Logger.warning(`[CatsCo] vision_fallback_read_file model=${modelName} file=${att.fileName} reason=image_block_create_failed`);
+          Logger.warning(`[CatsCo] vision_fallback_read_file model=${modelName} file=${logFile} reason=image_block_create_failed`);
         }
       } else {
         blocks.push({ type: 'text', text: attachmentReference });

--- a/src/dashboard/readiness.ts
+++ b/src/dashboard/readiness.ts
@@ -214,7 +214,8 @@ function buildModelChecks(
   const apiKey = firstNonEmpty(env.GAUZ_LLM_API_KEY, config.apiKey);
   const catsCoToken = firstNonEmpty(env.CATSCO_USER_TOKEN, env.CATSCOMPANY_USER_TOKEN);
   const catsCoUserUid = firstNonEmpty(env.CATSCO_USER_UID, env.CATSCOMPANY_USER_UID);
-  const relayConfigured = isCatsRelayModelConfigured(provider, apiBase, model, apiKey);
+  const modelSource = String(env.CATSCO_MODEL_SOURCE || '').trim().toLowerCase();
+  const relayConfigured = modelSource !== 'custom' && isCatsRelayModelConfigured(provider, apiBase, model, apiKey);
   const relayCheck = relayConfigured
     ? passCheck(
       'model.managed.relay',

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -162,9 +162,9 @@ interface RelayModelConfig {
   quotaClass?: string;
   contextWindowTokens?: number;
   capabilities?: {
-    tool_calling: boolean;
-    vision: boolean;
-    streaming: boolean;
+    tool_calling?: boolean;
+    vision?: boolean;
+    streaming?: boolean;
   };
 }
 
@@ -874,11 +874,25 @@ function relayModelCapabilitiesPayload(item: any, profile?: RelayModelProfile): 
 
   const capabilities = item?.capabilities;
   if (!capabilities || typeof capabilities !== 'object') return undefined;
-  return {
-    tool_calling: Boolean(capabilities.tool_calling ?? capabilities.toolCalling),
-    vision: Boolean(capabilities.vision),
-    streaming: Boolean(capabilities.streaming),
-  };
+  const payload: RelayModelConfig['capabilities'] = {};
+  const toolCalling = optionalBoolean(capabilities.tool_calling ?? capabilities.toolCalling);
+  const vision = optionalBoolean(capabilities.vision);
+  const streaming = optionalBoolean(capabilities.streaming);
+  if (toolCalling !== undefined) payload.tool_calling = toolCalling;
+  if (vision !== undefined) payload.vision = vision;
+  if (streaming !== undefined) payload.streaming = streaming;
+  return Object.keys(payload).length > 0 ? payload : undefined;
+}
+
+function optionalBoolean(value: unknown): boolean | undefined {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'number' && Number.isFinite(value)) return value !== 0;
+  if (typeof value === 'string') {
+    const text = value.trim().toLowerCase();
+    if (['true', '1', 'yes', 'y', 'on'].includes(text)) return true;
+    if (['false', '0', 'no', 'n', 'off'].includes(text)) return false;
+  }
+  return undefined;
 }
 
 function normalizeRelayModelConfig(item: any, config: any, index: number): RelayModelConfig | null {

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -30,7 +30,7 @@ import {
   updateDashboardSettings,
   writeDashboardEnvUpdates,
 } from '../settings';
-import { RELAY_MODEL_PROFILES, findRelayModelProfile } from '../../utils/relay-model-profiles';
+import { RELAY_MODEL_PROFILES, findRelayModelProfile, type RelayModelProfile } from '../../utils/relay-model-profiles';
 import {
   RuntimeProfileEditInput,
   hasRuntimeProfileRollback,
@@ -863,10 +863,29 @@ function canonicalRelayModelName(value: unknown): string {
   return model;
 }
 
+function relayModelCapabilitiesPayload(item: any, profile?: RelayModelProfile): RelayModelConfig['capabilities'] {
+  if (profile) {
+    return {
+      tool_calling: profile.capabilities.toolCalling,
+      vision: profile.capabilities.vision,
+      streaming: profile.capabilities.streaming,
+    };
+  }
+
+  const capabilities = item?.capabilities;
+  if (!capabilities || typeof capabilities !== 'object') return undefined;
+  return {
+    tool_calling: Boolean(capabilities.tool_calling ?? capabilities.toolCalling),
+    vision: Boolean(capabilities.vision),
+    streaming: Boolean(capabilities.streaming),
+  };
+}
+
 function normalizeRelayModelConfig(item: any, config: any, index: number): RelayModelConfig | null {
-  const model = canonicalRelayModelName(item?.model);
-  if (!model) return null;
-  const profile = findRelayModelProfile(model);
+  const rawModel = canonicalRelayModelName(item?.model);
+  if (!rawModel) return null;
+  const profile = findRelayModelProfile(rawModel);
+  const model = profile?.model || rawModel;
   const provider: 'anthropic' = 'anthropic';
   const protocol = 'Anthropic-compatible';
   const baseUrl = relayEndpointForProtocol(config, 'anthropic');
@@ -875,7 +894,7 @@ function normalizeRelayModelConfig(item: any, config: any, index: number): Relay
     ?? profile?.contextWindowTokens
     ?? resolveKnownModelContextWindowTokens(model);
   return {
-    id: String(item?.id || model || `relay-model-${index}`).trim(),
+    id: String(item?.id || profile?.id || model || `relay-model-${index}`).trim(),
     label: String(item?.label || profile?.label || model).trim(),
     model,
     family: String(item?.family || profile?.family || '').trim() || undefined,
@@ -886,11 +905,7 @@ function normalizeRelayModelConfig(item: any, config: any, index: number): Relay
     default: item?.default === true,
     quotaClass: String(item?.quota_class || item?.quotaClass || profile?.quotaClass || '').trim() || undefined,
     contextWindowTokens,
-    capabilities: profile ? {
-      tool_calling: profile.capabilities.toolCalling,
-      vision: profile.capabilities.vision,
-      streaming: profile.capabilities.streaming,
-    } : undefined,
+    capabilities: relayModelCapabilitiesPayload(item, profile),
   };
 }
 

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -30,7 +30,15 @@ import {
   updateDashboardSettings,
   writeDashboardEnvUpdates,
 } from '../settings';
-import { RELAY_MODEL_PROFILES, findRelayModelProfile, type RelayModelProfile } from '../../utils/relay-model-profiles';
+import {
+  RELAY_MODEL_PROFILES,
+  findRelayModelProfile,
+  relayModelProviderBaseUrl,
+  relayModelProviderProtocolLabel,
+  relayModelProviderSdkLabel,
+  type RelayModelProfile,
+  type RelayModelProvider,
+} from '../../utils/relay-model-profiles';
 import {
   RuntimeProfileEditInput,
   hasRuntimeProfileRollback,
@@ -154,9 +162,10 @@ interface RelayModelConfig {
   label: string;
   model: string;
   family?: string;
-  provider: 'anthropic' | 'openai';
+  provider: RelayModelProvider;
   protocol: string;
   baseUrl: string;
+  sdkLabel: string;
   enabled: boolean;
   default: boolean;
   quotaClass?: string;
@@ -837,11 +846,11 @@ async function commitCatsBotBindingAndStartConnector(
 
 function normalizeRelayModelProtocol(value: unknown): RelayModelProtocol {
   const text = String(value || '').trim().toLowerCase();
-  return text === 'openai' ? 'openai' : 'anthropic';
+  return text.includes('openai') ? 'openai' : 'anthropic';
 }
 
-function normalizeRelayProvider(value: unknown): 'anthropic' | 'openai' {
-  return String(value || '').trim().toLowerCase() === 'openai' ? 'openai' : 'anthropic';
+function normalizeRelayProvider(value: unknown): RelayModelProvider {
+  return String(value || '').trim().toLowerCase().includes('openai') ? 'openai' : 'anthropic';
 }
 
 function relayEndpointForProtocol(config: any, protocol: RelayModelProtocol): string {
@@ -851,7 +860,9 @@ function relayEndpointForProtocol(config: any, protocol: RelayModelProtocol): st
     return protocol === 'openai' ? label.includes('openai') : label.includes('anthropic');
   });
   const baseUrl = normalizeBaseUrl(config?.base_url, 'https://relay.catsco.cc');
-  const fallback = protocol === 'openai' ? `${baseUrl}/v1` : `${baseUrl}/anthropic`;
+  const fallback = baseUrl === 'https://relay.catsco.cc'
+    ? relayModelProviderBaseUrl(protocol)
+    : protocol === 'openai' ? `${baseUrl}/v1` : `${baseUrl}/anthropic`;
   return normalizeBaseUrl(endpoint?.base_url, fallback);
 }
 
@@ -900,9 +911,10 @@ function normalizeRelayModelConfig(item: any, config: any, index: number): Relay
   if (!rawModel) return null;
   const profile = findRelayModelProfile(rawModel);
   const model = profile?.model || rawModel;
-  const provider: 'anthropic' = 'anthropic';
-  const protocol = 'Anthropic-compatible';
-  const baseUrl = relayEndpointForProtocol(config, 'anthropic');
+  const provider = profile?.preferredProvider
+    ?? normalizeRelayProvider(item?.provider ?? item?.protocol);
+  const protocol = relayModelProviderProtocolLabel(provider);
+  const baseUrl = relayEndpointForProtocol(config, provider);
   const contextWindowTokens = parsePositiveInteger(item?.context_window_tokens)
     ?? parsePositiveInteger(item?.contextWindowTokens)
     ?? profile?.contextWindowTokens
@@ -915,6 +927,7 @@ function normalizeRelayModelConfig(item: any, config: any, index: number): Relay
     provider,
     protocol,
     baseUrl,
+    sdkLabel: relayModelProviderSdkLabel(provider),
     enabled: item?.enabled !== false,
     default: item?.default === true,
     quotaClass: String(item?.quota_class || item?.quotaClass || profile?.quotaClass || '').trim() || undefined,
@@ -924,15 +937,15 @@ function normalizeRelayModelConfig(item: any, config: any, index: number): Relay
 }
 
 function fallbackRelayModelCatalog(config: any): RelayModelConfig[] {
-  const baseUrl = relayEndpointForProtocol(config, 'anthropic');
   return RELAY_MODEL_PROFILES.map((profile, index) => ({
     id: profile.id,
     label: profile.label,
     model: profile.model,
     family: profile.family,
-    provider: 'anthropic',
-    protocol: 'Anthropic-compatible',
-    baseUrl,
+    provider: profile.preferredProvider,
+    protocol: relayModelProviderProtocolLabel(profile.preferredProvider),
+    baseUrl: relayEndpointForProtocol(config, profile.preferredProvider),
+    sdkLabel: relayModelProviderSdkLabel(profile.preferredProvider),
     enabled: true,
     default: index === 0,
     quotaClass: profile.quotaClass,
@@ -1016,6 +1029,7 @@ function relayModelPayload(model: RelayModelConfig): Record<string, unknown> {
     provider: model.provider,
     protocol: model.protocol,
     base_url: model.baseUrl,
+    sdk_label: model.sdkLabel,
     enabled: model.enabled,
     default: model.default,
     quota_class: model.quotaClass,

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -30,6 +30,7 @@ import {
   updateDashboardSettings,
   writeDashboardEnvUpdates,
 } from '../settings';
+import { RELAY_MODEL_PROFILES, findRelayModelProfile } from '../../utils/relay-model-profiles';
 import {
   RuntimeProfileEditInput,
   hasRuntimeProfileRollback,
@@ -160,6 +161,11 @@ interface RelayModelConfig {
   default: boolean;
   quotaClass?: string;
   contextWindowTokens?: number;
+  capabilities?: {
+    tool_calling: boolean;
+    vision: boolean;
+    streaming: boolean;
+  };
 }
 
 const MODEL_SOURCE_ENV_KEY = 'CATSCO_MODEL_SOURCE';
@@ -860,83 +866,54 @@ function canonicalRelayModelName(value: unknown): string {
 function normalizeRelayModelConfig(item: any, config: any, index: number): RelayModelConfig | null {
   const model = canonicalRelayModelName(item?.model);
   if (!model) return null;
+  const profile = findRelayModelProfile(model);
   const provider: 'anthropic' = 'anthropic';
   const protocol = 'Anthropic-compatible';
   const baseUrl = relayEndpointForProtocol(config, 'anthropic');
   const contextWindowTokens = parsePositiveInteger(item?.context_window_tokens)
     ?? parsePositiveInteger(item?.contextWindowTokens)
+    ?? profile?.contextWindowTokens
     ?? resolveKnownModelContextWindowTokens(model);
   return {
     id: String(item?.id || model || `relay-model-${index}`).trim(),
-    label: String(item?.label || model).trim(),
+    label: String(item?.label || profile?.label || model).trim(),
     model,
-    family: String(item?.family || '').trim() || undefined,
+    family: String(item?.family || profile?.family || '').trim() || undefined,
     provider,
     protocol,
     baseUrl,
     enabled: item?.enabled !== false,
     default: item?.default === true,
-    quotaClass: String(item?.quota_class || item?.quotaClass || '').trim() || undefined,
+    quotaClass: String(item?.quota_class || item?.quotaClass || profile?.quotaClass || '').trim() || undefined,
     contextWindowTokens,
+    capabilities: profile ? {
+      tool_calling: profile.capabilities.toolCalling,
+      vision: profile.capabilities.vision,
+      streaming: profile.capabilities.streaming,
+    } : undefined,
   };
 }
 
 function fallbackRelayModelCatalog(config: any): RelayModelConfig[] {
   const baseUrl = relayEndpointForProtocol(config, 'anthropic');
-  return [
-    {
-      id: 'minimax-m2.7',
-      label: 'MiniMax M2.7',
-      model: 'MiniMax-M2.7',
-      family: 'minimax',
-      provider: 'anthropic',
-      protocol: 'Anthropic-compatible',
-      baseUrl,
-      enabled: true,
-      default: true,
-      quotaClass: 'standard',
-      contextWindowTokens: 204_800,
+  return RELAY_MODEL_PROFILES.map((profile, index) => ({
+    id: profile.id,
+    label: profile.label,
+    model: profile.model,
+    family: profile.family,
+    provider: 'anthropic',
+    protocol: 'Anthropic-compatible',
+    baseUrl,
+    enabled: true,
+    default: index === 0,
+    quotaClass: profile.quotaClass,
+    contextWindowTokens: profile.contextWindowTokens,
+    capabilities: {
+      tool_calling: profile.capabilities.toolCalling,
+      vision: profile.capabilities.vision,
+      streaming: profile.capabilities.streaming,
     },
-    {
-      id: 'minimax-m3',
-      label: 'MiniMax M3',
-      model: 'MiniMax-M3',
-      family: 'minimax',
-      provider: 'anthropic',
-      protocol: 'Anthropic-compatible',
-      baseUrl,
-      enabled: true,
-      default: false,
-      quotaClass: 'multimodal',
-      contextWindowTokens: 1_000_000,
-    },
-    {
-      id: 'deepseek-v4-flash',
-      label: 'DeepSeek V4 Flash',
-      model: 'deepseek-v4-flash',
-      family: 'deepseek',
-      provider: 'anthropic',
-      protocol: 'Anthropic-compatible',
-      baseUrl,
-      enabled: true,
-      default: false,
-      quotaClass: 'flash-low',
-      contextWindowTokens: 1_000_000,
-    },
-    {
-      id: 'glm-5.1',
-      label: 'GLM 5.1',
-      model: 'glm-5.1',
-      family: 'glm',
-      provider: 'anthropic',
-      protocol: 'Anthropic-compatible',
-      baseUrl,
-      enabled: true,
-      default: false,
-      quotaClass: 'standard',
-      contextWindowTokens: 200_000,
-    },
-  ];
+  }));
 }
 
 function relayModelCatalog(config: any): RelayModelConfig[] {
@@ -1016,6 +993,7 @@ function relayModelPayload(model: RelayModelConfig): Record<string, unknown> {
     context_window_tokens: model.contextWindowTokens,
     prompt_budget_tokens: promptBudget,
     context_label: model.contextWindowTokens ? formatContextWindowTokens(model.contextWindowTokens) : undefined,
+    capabilities: model.capabilities,
   };
 }
 

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -178,6 +178,8 @@ interface RelayModelConfig {
 }
 
 const MODEL_SOURCE_ENV_KEY = 'CATSCO_MODEL_SOURCE';
+const RELAY_MODEL_VISION_CAPABLE_ENV_KEY = 'CATSCO_RELAY_LLM_VISION_CAPABLE';
+const RELAY_MODEL_TOOL_CALLING_CAPABLE_ENV_KEY = 'CATSCO_RELAY_LLM_TOOL_CALLING_CAPABLE';
 const CUSTOM_MODEL_ENV_KEYS = {
   provider: 'CATSCO_CUSTOM_LLM_PROVIDER',
   apiBase: 'CATSCO_CUSTOM_LLM_API_BASE',
@@ -853,6 +855,12 @@ function normalizeRelayProvider(value: unknown): RelayModelProvider {
   return String(value || '').trim().toLowerCase().includes('openai') ? 'openai' : 'anthropic';
 }
 
+function explicitRelayProvider(item: any): RelayModelProvider | undefined {
+  if (!item || typeof item !== 'object') return undefined;
+  if (item.provider == null && item.protocol == null) return undefined;
+  return normalizeRelayProvider(item.provider ?? item.protocol);
+}
+
 function relayEndpointForProtocol(config: any, protocol: RelayModelProtocol): string {
   const endpoints = Array.isArray(config?.endpoints) ? config.endpoints : [];
   const endpoint = endpoints.find((item: any) => {
@@ -875,17 +883,18 @@ function canonicalRelayModelName(value: unknown): string {
 }
 
 function relayModelCapabilitiesPayload(item: any, profile?: RelayModelProfile): RelayModelConfig['capabilities'] {
-  if (profile) {
-    return {
+  const capabilities = item?.capabilities;
+  const payload: RelayModelConfig['capabilities'] = profile
+    ? {
       tool_calling: profile.capabilities.toolCalling,
       vision: profile.capabilities.vision,
       streaming: profile.capabilities.streaming,
-    };
+    }
+    : {};
+  if (!capabilities || typeof capabilities !== 'object') {
+    return Object.keys(payload).length > 0 ? payload : undefined;
   }
 
-  const capabilities = item?.capabilities;
-  if (!capabilities || typeof capabilities !== 'object') return undefined;
-  const payload: RelayModelConfig['capabilities'] = {};
   const toolCalling = optionalBoolean(capabilities.tool_calling ?? capabilities.toolCalling);
   const vision = optionalBoolean(capabilities.vision);
   const streaming = optionalBoolean(capabilities.streaming);
@@ -911,7 +920,8 @@ function normalizeRelayModelConfig(item: any, config: any, index: number): Relay
   if (!rawModel) return null;
   const profile = findRelayModelProfile(rawModel);
   const model = profile?.model || rawModel;
-  const provider = profile?.preferredProvider
+  const provider = explicitRelayProvider(item)
+    ?? profile?.preferredProvider
     ?? normalizeRelayProvider(item?.provider ?? item?.protocol);
   const protocol = relayModelProviderProtocolLabel(provider);
   const baseUrl = relayEndpointForProtocol(config, provider);
@@ -1192,6 +1202,8 @@ function writeCustomModelStartupConfig(): { profile: ModelLaunchProfile; updated
     ...modelProfileUpdates(CUSTOM_MODEL_ENV_KEYS, profile),
     ...modelProfileUpdates(EFFECTIVE_MODEL_ENV_KEYS, profile),
     [MODEL_SOURCE_ENV_KEY]: 'custom',
+    [RELAY_MODEL_VISION_CAPABLE_ENV_KEY]: undefined,
+    [RELAY_MODEL_TOOL_CALLING_CAPABLE_ENV_KEY]: undefined,
   });
   return { profile, ...result };
 }
@@ -1209,6 +1221,8 @@ function writeRelayModelStartupConfig(model: RelayModelConfig, apiKey: string): 
     ...modelProfileUpdates(RELAY_MODEL_ENV_KEYS, profile),
     ...modelProfileUpdates(EFFECTIVE_MODEL_ENV_KEYS, profile),
     [MODEL_SOURCE_ENV_KEY]: 'relay',
+    [RELAY_MODEL_VISION_CAPABLE_ENV_KEY]: model.capabilities?.vision === undefined ? undefined : String(model.capabilities.vision),
+    [RELAY_MODEL_TOOL_CALLING_CAPABLE_ENV_KEY]: model.capabilities?.tool_calling === undefined ? undefined : String(model.capabilities.tool_calling),
   });
   return {
     updated: [...preserved, ...result.updated],

--- a/src/dashboard/settings.ts
+++ b/src/dashboard/settings.ts
@@ -159,6 +159,8 @@ const RELAY_MODEL_ENV_KEYS = {
   apiKey: 'CATSCO_RELAY_LLM_API_KEY',
 } as const;
 
+const MODEL_SOURCE_ENV_KEY = 'CATSCO_MODEL_SOURCE';
+
 function isModelSetting(id: string): boolean {
   return id.startsWith('model.');
 }
@@ -231,7 +233,7 @@ function buildModelStartupSnapshot(
   const effective = readModelProfile(EFFECTIVE_MODEL_ENV_KEYS, fileEnv, env);
   const custom = readCustomModelProfile(fileEnv, env);
   const storedRelay = readModelProfile(RELAY_MODEL_ENV_KEYS, fileEnv, env);
-  const requestedSource = firstNonEmpty(fileEnv.CATSCO_MODEL_SOURCE, env.CATSCO_MODEL_SOURCE);
+  const requestedSource = firstNonEmpty(fileEnv[MODEL_SOURCE_ENV_KEY], env[MODEL_SOURCE_ENV_KEY]);
   const relay = storedRelay.configured
     ? storedRelay
     : {

--- a/src/providers/openai-provider.ts
+++ b/src/providers/openai-provider.ts
@@ -95,6 +95,18 @@ export class OpenAIProvider implements AIProvider {
     );
   }
 
+  private visibleMessageContent(message: any): string | null {
+    const content = typeof message?.content === 'string'
+      ? message.content
+      : Array.isArray(message?.content)
+        ? message.content
+            .map((item: any) => typeof item?.text === 'string' ? item.text : '')
+            .join('')
+        : '';
+    const visible = stripOpenAIThinkingText(content).trim();
+    return visible || null;
+  }
+
   /**
    * 构建请求头
    */
@@ -127,7 +139,7 @@ export class OpenAIProvider implements AIProvider {
     });
 
     return {
-      content: message.content || null,
+      content: this.visibleMessageContent(message),
       toolCalls: message.tool_calls,
       stopReason: choice.finish_reason || undefined,
       usage: usage ? {
@@ -162,6 +174,7 @@ export class OpenAIProvider implements AIProvider {
 
     return new Promise<ChatResponse>((resolve, reject) => {
       let fullContent = '';
+      let contentStripper = new OpenAIThinkingStripper();
       const toolCallsMap = new Map<number, { id: string; type: 'function'; function: { name: string; arguments: string } }>();
       let buffer = '';
       let streamUsage: ChatResponse['usage'] = undefined;
@@ -208,10 +221,21 @@ export class OpenAIProvider implements AIProvider {
             const delta = choice?.delta;
             if (!delta) continue;
 
+            // OpenAI-compatible providers may stream hidden reasoning fields
+            // (reasoning_content/thinking/etc.). CatsCo treats them as private
+            // provider-side work: never render them and never send them back as
+            // conversation content.
+            if (hasOpenAIReasoningDelta(delta)) {
+              // Deliberately ignored.
+            }
+
             // 文本内容
             if (delta.content) {
-              fullContent += delta.content;
-              callbacks?.onText?.(delta.content);
+              const visibleContent = contentStripper.push(delta.content);
+              if (visibleContent) {
+                fullContent += visibleContent;
+                callbacks?.onText?.(visibleContent);
+              }
             }
 
             // 工具调用（增量拼接）
@@ -239,6 +263,11 @@ export class OpenAIProvider implements AIProvider {
 
       stream.on('end', () => {
         options?.signal?.removeEventListener('abort', onAbort);
+        const tail = contentStripper.flush();
+        if (tail) {
+          fullContent += tail;
+          callbacks?.onText?.(tail);
+        }
         const toolCalls = toolCallsMap.size > 0
           ? Array.from(toolCallsMap.values())
           : undefined;
@@ -264,6 +293,84 @@ export class OpenAIProvider implements AIProvider {
         reject(err);
       });
     });
+  }
+}
+
+function hasOpenAIReasoningDelta(delta: any): boolean {
+  return typeof delta?.reasoning_content === 'string'
+    || typeof delta?.reasoning === 'string'
+    || typeof delta?.thinking === 'string';
+}
+
+function stripOpenAIThinkingText(text: string): string {
+  if (!text) return '';
+  return text
+    .replace(/<think\b[^>]*>[\s\S]*?<\/think>\s*/gi, '')
+    .replace(/^\s*<think\b[^>]*>[\s\S]*$/i, '');
+}
+
+function longestThinkTagPrefixSuffix(value: string, tag: string): number {
+  const lower = value.toLowerCase();
+  const max = Math.min(lower.length, tag.length - 1);
+  for (let length = max; length > 0; length--) {
+    if (lower.slice(-length) === tag.slice(0, length)) return length;
+  }
+  return 0;
+}
+
+class OpenAIThinkingStripper {
+  private buffer = '';
+  private inThinking = false;
+
+  push(chunk: string): string {
+    this.buffer += chunk;
+    let output = '';
+
+    while (this.buffer) {
+      const lower = this.buffer.toLowerCase();
+
+      if (this.inThinking) {
+        const closeIndex = lower.indexOf('</think>');
+        if (closeIndex < 0) {
+          const keep = longestThinkTagPrefixSuffix(this.buffer, '</think>');
+          this.buffer = keep > 0 ? this.buffer.slice(-keep) : '';
+          break;
+        }
+        this.buffer = this.buffer.slice(closeIndex + '</think>'.length);
+        this.inThinking = false;
+        continue;
+      }
+
+      const openIndex = lower.indexOf('<think');
+      if (openIndex < 0) {
+        const keep = longestThinkTagPrefixSuffix(this.buffer, '<think');
+        output += keep > 0 ? this.buffer.slice(0, -keep) : this.buffer;
+        this.buffer = keep > 0 ? this.buffer.slice(-keep) : '';
+        break;
+      }
+
+      output += this.buffer.slice(0, openIndex);
+      const openEndIndex = this.buffer.indexOf('>', openIndex);
+      if (openEndIndex < 0) {
+        this.buffer = this.buffer.slice(openIndex);
+        break;
+      }
+      this.buffer = this.buffer.slice(openEndIndex + 1);
+      this.inThinking = true;
+    }
+
+    return output;
+  }
+
+  flush(): string {
+    if (this.inThinking) {
+      this.buffer = '';
+      this.inThinking = false;
+      return '';
+    }
+    const output = this.buffer;
+    this.buffer = '';
+    return output;
   }
 }
 

--- a/src/tools/read-tool.ts
+++ b/src/tools/read-tool.ts
@@ -8,6 +8,7 @@ import { ConfigManager } from '../utils/config';
 import { isPrimaryModelVisionCapable } from '../utils/model-capabilities';
 import { analyzeImageWithReaderProxy, ReaderProxyResult } from '../utils/reader-proxy';
 import { Logger } from '../utils/logger';
+import { formatPathForLog } from '../utils/log-redaction';
 import { resolveLocalFileAccess, resolveLocalFileReference } from './local-file-gateway';
 import { formatCatsCoVisiblePath, resolveToolGatewayAccess } from './tool-gateway';
 import { executeRemoteReadonlyTool } from './device-rpc-tool';
@@ -518,17 +519,18 @@ export class ReadTool implements Tool {
 
     if (visionCapable) {
       const imageBlock = await createImageBlock(absolutePath);
+      const logFile = formatPathForLog(absolutePath || filePath);
       if (imageBlock) {
-        Logger.info(`[CatsCo] vision_direct model=${modelName} tool=read_file file=${filePath} bytes_base64=${((imageBlock as any).source as any)?.data?.length || 0}`);
+        Logger.info(`[CatsCo] vision_direct model=${modelName} tool=read_file file=${logFile} bytes_base64=${((imageBlock as any).source as any)?.data?.length || 0}`);
         return {
           _imageForNewMessage: true,
           imageBlock: { ...imageBlock, filePath },
           filePath,
         };
       }
-      Logger.warning(`[CatsCo] vision_fallback_read_file model=${modelName} tool=read_file file=${filePath} reason=image_block_create_failed path=${absolutePath}`);
+      Logger.warning(`[CatsCo] vision_fallback_read_file model=${modelName} tool=read_file file=${logFile} reason=image_block_create_failed path=${logFile}`);
     } else {
-      Logger.info(`[CatsCo] vision_fallback_read_file model=${modelName} tool=read_file file=${filePath} reason=model_not_vision_capable`);
+      Logger.info(`[CatsCo] vision_fallback_read_file model=${modelName} tool=read_file file=${formatPathForLog(absolutePath || filePath)} reason=model_not_vision_capable`);
     }
 
     const proxyResult = await analyzeImageWithReaderProxy({

--- a/src/tools/read-tool.ts
+++ b/src/tools/read-tool.ts
@@ -7,6 +7,7 @@ import { createImageBlock } from '../utils/image-utils';
 import { ConfigManager } from '../utils/config';
 import { isPrimaryModelVisionCapable } from '../utils/model-capabilities';
 import { analyzeImageWithReaderProxy, ReaderProxyResult } from '../utils/reader-proxy';
+import { Logger } from '../utils/logger';
 import { resolveLocalFileAccess, resolveLocalFileReference } from './local-file-gateway';
 import { formatCatsCoVisiblePath, resolveToolGatewayAccess } from './tool-gateway';
 import { executeRemoteReadonlyTool } from './device-rpc-tool';
@@ -513,16 +514,21 @@ export class ReadTool implements Tool {
     const config = ConfigManager.getConfigReadonly();
     const imagePrompt = this.getImageReadPrompt(context, prompt);
     const visionCapable = isPrimaryModelVisionCapable(config);
+    const modelName = config.model || 'unknown';
 
     if (visionCapable) {
       const imageBlock = await createImageBlock(absolutePath);
       if (imageBlock) {
+        Logger.info(`[CatsCo] vision_direct model=${modelName} tool=read_file file=${filePath} bytes_base64=${((imageBlock as any).source as any)?.data?.length || 0}`);
         return {
           _imageForNewMessage: true,
           imageBlock: { ...imageBlock, filePath },
           filePath,
         };
       }
+      Logger.warning(`[CatsCo] vision_fallback_read_file model=${modelName} tool=read_file file=${filePath} reason=image_block_create_failed path=${absolutePath}`);
+    } else {
+      Logger.info(`[CatsCo] vision_fallback_read_file model=${modelName} tool=read_file file=${filePath} reason=model_not_vision_capable`);
     }
 
     const proxyResult = await analyzeImageWithReaderProxy({

--- a/src/utils/log-redaction.ts
+++ b/src/utils/log-redaction.ts
@@ -1,0 +1,15 @@
+import { createHash } from 'crypto';
+
+export function formatPathForLog(value: unknown): string {
+  const text = typeof value === 'string' ? value.trim() : '';
+  if (!text) return '-';
+
+  const normalized = text.replace(/\\/g, '/');
+  const rawName = normalized.split('/').filter(Boolean).pop() || 'file';
+  const safeName = rawName
+    .replace(/[\r\n\t=]/g, '_')
+    .slice(0, 120)
+    || 'file';
+  const hash = createHash('sha256').update(text).digest('hex').slice(0, 8);
+  return `${safeName}#${hash}`;
+}

--- a/src/utils/model-capabilities.ts
+++ b/src/utils/model-capabilities.ts
@@ -32,13 +32,27 @@ function includesAny(value: string, patterns: RegExp[]): boolean {
   return patterns.some(pattern => pattern.test(value));
 }
 
+function optionalBooleanEnv(value: unknown): boolean | undefined {
+  if (typeof value === 'boolean') return value;
+  if (typeof value !== 'string') return undefined;
+  const text = value.trim().toLowerCase();
+  if (['true', '1', 'yes', 'y', 'on'].includes(text)) return true;
+  if (['false', '0', 'no', 'n', 'off'].includes(text)) return false;
+  return undefined;
+}
+
 export function isPrimaryModelVisionCapable(config: Pick<ChatConfig, 'apiUrl' | 'model' | 'provider'>): boolean {
   const apiUrl = (config.apiUrl || '').toLowerCase();
   const model = (config.model || '').trim();
   const modelKey = model.toLowerCase();
-  const relayProfile = apiUrl.includes('relay.catsco.cc') ? findRelayModelProfile(model) : undefined;
-  if (relayProfile) {
-    return relayProfile.capabilities.vision;
+  const isRelay = apiUrl.includes('relay.catsco.cc');
+  if (isRelay) {
+    const explicitRelayVision = optionalBooleanEnv(process.env.CATSCO_RELAY_LLM_VISION_CAPABLE);
+    if (explicitRelayVision !== undefined) return explicitRelayVision;
+    const relayProfile = findRelayModelProfile(model);
+    if (relayProfile) {
+      return relayProfile.capabilities.vision;
+    }
   }
 
   // Anthropic-compatible endpoints from text-only providers often reject image blocks.
@@ -55,9 +69,13 @@ export function isPrimaryModelVisionCapable(config: Pick<ChatConfig, 'apiUrl' | 
 
 export function isPrimaryModelToolCallingCapable(config: Pick<ChatConfig, 'apiUrl' | 'model' | 'provider'>): boolean {
   const apiUrl = (config.apiUrl || '').toLowerCase();
-  const relayProfile = apiUrl.includes('relay.catsco.cc') ? findRelayModelProfile(config.model) : undefined;
-  if (relayProfile) {
-    return relayProfile.capabilities.toolCalling;
+  if (apiUrl.includes('relay.catsco.cc')) {
+    const explicitToolCalling = optionalBooleanEnv(process.env.CATSCO_RELAY_LLM_TOOL_CALLING_CAPABLE);
+    if (explicitToolCalling !== undefined) return explicitToolCalling;
+    const relayProfile = findRelayModelProfile(config.model);
+    if (relayProfile) {
+      return relayProfile.capabilities.toolCalling;
+    }
   }
   return true;
 }

--- a/src/utils/model-capabilities.ts
+++ b/src/utils/model-capabilities.ts
@@ -1,4 +1,5 @@
 import { ChatConfig } from '../types';
+import { findRelayModelProfile } from './relay-model-profiles';
 
 const KNOWN_TEXT_ONLY_MODEL_PATTERNS = [
   /deepseek/i,
@@ -35,6 +36,10 @@ export function isPrimaryModelVisionCapable(config: Pick<ChatConfig, 'apiUrl' | 
   const apiUrl = (config.apiUrl || '').toLowerCase();
   const model = (config.model || '').trim();
   const modelKey = model.toLowerCase();
+  const relayProfile = apiUrl.includes('relay.catsco.cc') ? findRelayModelProfile(model) : undefined;
+  if (relayProfile) {
+    return relayProfile.capabilities.vision;
+  }
 
   // Anthropic-compatible endpoints from text-only providers often reject image blocks.
   if (apiUrl.includes('deepseek.com') || apiUrl.includes('minimaxi.com')) {
@@ -49,6 +54,10 @@ export function isPrimaryModelVisionCapable(config: Pick<ChatConfig, 'apiUrl' | 
 }
 
 export function isPrimaryModelToolCallingCapable(config: Pick<ChatConfig, 'apiUrl' | 'model' | 'provider'>): boolean {
-  void config;
+  const apiUrl = (config.apiUrl || '').toLowerCase();
+  const relayProfile = apiUrl.includes('relay.catsco.cc') ? findRelayModelProfile(config.model) : undefined;
+  if (relayProfile) {
+    return relayProfile.capabilities.toolCalling;
+  }
   return true;
 }

--- a/src/utils/model-context-window.ts
+++ b/src/utils/model-context-window.ts
@@ -1,5 +1,6 @@
 import { ChatConfig } from '../types';
 import { resolveMaxTokens } from '../providers/output-limits';
+import { RELAY_MODEL_PROFILES } from './relay-model-profiles';
 
 export interface ModelContextWindowSpec {
   id: string;
@@ -28,32 +29,19 @@ const MAX_SUMMARY_BUDGET_TOKENS = 300_000;
 const SUMMARY_BUDGET_RATIO = 0.35;
 const SUMMARY_WRAPPER_RESERVE_TOKENS = 8_192;
 
-export const RELAY_MODEL_CONTEXT_WINDOW_SPECS: ModelContextWindowSpec[] = [
-  {
-    id: 'minimax-m3',
-    label: 'MiniMax M3',
-    modelPatterns: [/^minimax-m3$/i],
-    contextWindowTokens: 1_000_000,
-  },
-  {
-    id: 'minimax-m2.7',
-    label: 'MiniMax M2.7',
-    modelPatterns: [/^minimax-m2\.7(?:-highspeed)?$/i],
-    contextWindowTokens: 204_800,
-  },
-  {
-    id: 'deepseek-v4-flash',
-    label: 'DeepSeek V4 Flash',
-    modelPatterns: [/^deepseek-v4-flash$/i],
-    contextWindowTokens: 1_000_000,
-  },
-  {
-    id: 'glm-5.1',
-    label: 'GLM 5.1',
-    modelPatterns: [/^glm-5\.1$/i],
-    contextWindowTokens: 200_000,
-  },
-];
+const RELAY_MODEL_ALIASES: Record<string, RegExp[]> = {
+  'minimax-m2.7': [/^minimax-m2\.7(?:-highspeed)?$/i],
+};
+
+export const RELAY_MODEL_CONTEXT_WINDOW_SPECS: ModelContextWindowSpec[] = RELAY_MODEL_PROFILES.map(profile => ({
+  id: profile.id,
+  label: profile.label,
+  modelPatterns: [
+    new RegExp(`^${profile.model.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`, 'i'),
+    ...(RELAY_MODEL_ALIASES[profile.id] || []),
+  ],
+  contextWindowTokens: profile.contextWindowTokens,
+}));
 
 export function parsePositiveInteger(value: unknown): number | undefined {
   const text = String(value ?? '').trim();

--- a/src/utils/relay-model-profiles.ts
+++ b/src/utils/relay-model-profiles.ts
@@ -1,4 +1,20 @@
 export type RelayModelFamily = 'minimax' | 'deepseek' | 'glm';
+export type RelayModelProvider = 'anthropic' | 'openai';
+
+export const RELAY_MODEL_BASE_URLS: Record<RelayModelProvider, string> = {
+  anthropic: 'https://relay.catsco.cc/anthropic',
+  openai: 'https://relay.catsco.cc/v1',
+};
+
+export const RELAY_MODEL_PROTOCOL_LABELS: Record<RelayModelProvider, string> = {
+  anthropic: 'Anthropic-compatible',
+  openai: 'OpenAI-compatible',
+};
+
+export const RELAY_MODEL_SDK_LABELS: Record<RelayModelProvider, string> = {
+  anthropic: 'Anthropic SDK',
+  openai: 'OpenAI SDK',
+};
 
 export interface RelayModelCapabilities {
   toolCalling: boolean;
@@ -12,6 +28,7 @@ export interface RelayModelProfile {
   model: string;
   family: RelayModelFamily;
   quotaClass: string;
+  preferredProvider: RelayModelProvider;
   contextWindowTokens: number;
   capabilities: RelayModelCapabilities;
 }
@@ -23,6 +40,7 @@ export const RELAY_MODEL_PROFILES: RelayModelProfile[] = [
     model: 'MiniMax-M2.7',
     family: 'minimax',
     quotaClass: 'standard',
+    preferredProvider: 'anthropic',
     contextWindowTokens: 204_800,
     capabilities: {
       toolCalling: true,
@@ -36,6 +54,7 @@ export const RELAY_MODEL_PROFILES: RelayModelProfile[] = [
     model: 'MiniMax-M3',
     family: 'minimax',
     quotaClass: 'multimodal',
+    preferredProvider: 'anthropic',
     contextWindowTokens: 1_000_000,
     capabilities: {
       toolCalling: true,
@@ -49,6 +68,7 @@ export const RELAY_MODEL_PROFILES: RelayModelProfile[] = [
     model: 'deepseek-v4-flash',
     family: 'deepseek',
     quotaClass: 'flash-low',
+    preferredProvider: 'openai',
     contextWindowTokens: 1_000_000,
     capabilities: {
       toolCalling: true,
@@ -62,6 +82,7 @@ export const RELAY_MODEL_PROFILES: RelayModelProfile[] = [
     model: 'glm-5.1',
     family: 'glm',
     quotaClass: 'standard',
+    preferredProvider: 'openai',
     contextWindowTokens: 200_000,
     capabilities: {
       toolCalling: true,
@@ -81,4 +102,16 @@ export function findRelayModelProfile(model: unknown): RelayModelProfile | undef
   return RELAY_MODEL_PROFILES.find(profile => (
     normalizeModelName(profile.model) === normalized || normalizeModelName(profile.id) === normalized
   ));
+}
+
+export function relayModelProviderBaseUrl(provider: RelayModelProvider): string {
+  return RELAY_MODEL_BASE_URLS[provider];
+}
+
+export function relayModelProviderProtocolLabel(provider: RelayModelProvider): string {
+  return RELAY_MODEL_PROTOCOL_LABELS[provider];
+}
+
+export function relayModelProviderSdkLabel(provider: RelayModelProvider): string {
+  return RELAY_MODEL_SDK_LABELS[provider];
 }

--- a/src/utils/relay-model-profiles.ts
+++ b/src/utils/relay-model-profiles.ts
@@ -1,0 +1,84 @@
+export type RelayModelFamily = 'minimax' | 'deepseek' | 'glm';
+
+export interface RelayModelCapabilities {
+  toolCalling: boolean;
+  vision: boolean;
+  streaming: boolean;
+}
+
+export interface RelayModelProfile {
+  id: string;
+  label: string;
+  model: string;
+  family: RelayModelFamily;
+  quotaClass: string;
+  contextWindowTokens: number;
+  capabilities: RelayModelCapabilities;
+}
+
+export const RELAY_MODEL_PROFILES: RelayModelProfile[] = [
+  {
+    id: 'minimax-m2.7',
+    label: 'MiniMax M2.7',
+    model: 'MiniMax-M2.7',
+    family: 'minimax',
+    quotaClass: 'standard',
+    contextWindowTokens: 204_800,
+    capabilities: {
+      toolCalling: true,
+      vision: false,
+      streaming: true,
+    },
+  },
+  {
+    id: 'minimax-m3',
+    label: 'MiniMax M3',
+    model: 'MiniMax-M3',
+    family: 'minimax',
+    quotaClass: 'multimodal',
+    contextWindowTokens: 1_000_000,
+    capabilities: {
+      toolCalling: true,
+      vision: true,
+      streaming: true,
+    },
+  },
+  {
+    id: 'deepseek-v4-flash',
+    label: 'DeepSeek V4 Flash',
+    model: 'deepseek-v4-flash',
+    family: 'deepseek',
+    quotaClass: 'flash-low',
+    contextWindowTokens: 1_000_000,
+    capabilities: {
+      toolCalling: true,
+      vision: false,
+      streaming: true,
+    },
+  },
+  {
+    id: 'glm-5.1',
+    label: 'GLM 5.1',
+    model: 'glm-5.1',
+    family: 'glm',
+    quotaClass: 'standard',
+    contextWindowTokens: 200_000,
+    capabilities: {
+      toolCalling: true,
+      vision: false,
+      streaming: true,
+    },
+  },
+];
+
+function normalizeModelName(value: unknown): string {
+  return String(value || '').trim().toLowerCase();
+}
+
+export function findRelayModelProfile(model: unknown): RelayModelProfile | undefined {
+  const normalized = normalizeModelName(model);
+  if (!normalized) return undefined;
+  return RELAY_MODEL_PROFILES.find(profile => (
+    normalizeModelName(profile.model) === normalized || normalizeModelName(profile.id) === normalized
+  ));
+}

--- a/src/utils/relay-model-profiles.ts
+++ b/src/utils/relay-model-profiles.ts
@@ -68,7 +68,7 @@ export const RELAY_MODEL_PROFILES: RelayModelProfile[] = [
     model: 'deepseek-v4-flash',
     family: 'deepseek',
     quotaClass: 'flash-low',
-    preferredProvider: 'openai',
+    preferredProvider: 'anthropic',
     contextWindowTokens: 1_000_000,
     capabilities: {
       toolCalling: true,
@@ -82,7 +82,7 @@ export const RELAY_MODEL_PROFILES: RelayModelProfile[] = [
     model: 'glm-5.1',
     family: 'glm',
     quotaClass: 'standard',
-    preferredProvider: 'openai',
+    preferredProvider: 'anthropic',
     contextWindowTokens: 200_000,
     capabilities: {
       toolCalling: true,

--- a/tests/catscompany-content-blocks.test.ts
+++ b/tests/catscompany-content-blocks.test.ts
@@ -1,9 +1,35 @@
 import { describe, test } from 'node:test';
 import * as assert from 'node:assert';
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { CatsCompanyBot } from '../src/catscompany';
+import { ConfigManager } from '../src/utils/config';
+
+const ONE_PIXEL_PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=';
+
+async function withPatchedModel<T>(
+  config: any,
+  run: () => Promise<T>,
+): Promise<T> {
+  const originalGetConfigReadonly = ConfigManager.getConfigReadonly;
+  (ConfigManager as any).getConfigReadonly = () => config;
+  try {
+    return await run();
+  } finally {
+    (ConfigManager as any).getConfigReadonly = originalGetConfigReadonly;
+  }
+}
+
+function createTempPng(name: string): { filePath: string; cleanup: () => void } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'catsco-image-'));
+  const filePath = path.join(dir, name);
+  fs.writeFileSync(filePath, Buffer.from(ONE_PIXEL_PNG_BASE64, 'base64'));
+  return {
+    filePath,
+    cleanup: () => fs.rmSync(dir, { recursive: true, force: true }),
+  };
+}
 
 function canonicalMetadata(actorUserId: string, topicId: string, agentId = 'usr43', bodyId = 'body-main') {
   return {
@@ -232,6 +258,63 @@ describe('CatsCo content blocks', () => {
       { type: 'text', text: '[file] b.pdf -> (no authorized attachment reference)' },
     ]);
     assert.deepStrictEqual(handledTurns[0].options.runtimeFeedback, []);
+  });
+
+  test('builds direct image blocks for MiniMax M3 relay model', async () => {
+    const bot = Object.create(CatsCompanyBot.prototype) as any;
+    const temp = createTempPng('red-blue.png');
+
+    try {
+      const blocks = await withPatchedModel(
+        {
+          provider: 'anthropic',
+          apiUrl: 'https://relay.catsco.cc/anthropic',
+          model: 'MiniMax-M3',
+        },
+        () => bot.buildMultimodalMessage('看图', [{
+          type: 'image',
+          fileName: 'red-blue.png',
+          localPath: temp.filePath,
+        }]),
+      );
+
+      assert.strictEqual(blocks.length, 3);
+      assert.deepStrictEqual(blocks[0], { type: 'text', text: '看图' });
+      assert.strictEqual(blocks[1].type, 'text');
+      assert.match((blocks[1] as any).text, /red-blue\.png/);
+      assert.strictEqual(blocks[2].type, 'image');
+      assert.strictEqual((blocks[2] as any).source.type, 'base64');
+      assert.strictEqual((blocks[2] as any).source.media_type, 'image/jpeg');
+      assert.ok((blocks[2] as any).source.data.length > 0);
+    } finally {
+      temp.cleanup();
+    }
+  });
+
+  test('exposes read_file fallback attachment reference for non-vision relay models', async () => {
+    const bot = Object.create(CatsCompanyBot.prototype) as any;
+
+    const blocks = await withPatchedModel(
+      {
+        provider: 'anthropic',
+        apiUrl: 'https://relay.catsco.cc/anthropic',
+        model: 'MiniMax-M2.7',
+      },
+      () => bot.buildMultimodalMessage('看图', [{
+        type: 'image',
+        fileName: 'red-blue.png',
+        localPath: 'C:\\tmp\\red-blue.png',
+        localFileGrant: { attachmentRef: 'catsco_attachment:image-ref' },
+      }]),
+    );
+
+    assert.strictEqual(blocks.length, 2);
+    assert.deepStrictEqual(blocks[0], { type: 'text', text: '看图' });
+    assert.strictEqual(blocks[1].type, 'text');
+    assert.match((blocks[1] as any).text, /Current user turn contains image attachments/);
+    assert.match((blocks[1] as any).text, /call read_file/);
+    assert.match((blocks[1] as any).text, /catsco_attachment:image-ref/);
+    assert.doesNotMatch((blocks[1] as any).text, /C:\\tmp\\red-blue\.png/);
   });
 
   test('processes CatsCompany websocket content_blocks as one user turn', async () => {

--- a/tests/dashboard-catsco-auth-status.test.ts
+++ b/tests/dashboard-catsco-auth-status.test.ts
@@ -460,13 +460,13 @@ describe('dashboard CatsCo account status', () => {
     assert.equal(data.relayModelSetup.model, 'glm-5.1');
     assert.equal(data.relayModelSetup.createdKey, true);
     assert.equal(text.includes('sk-bf-fresh-secret'), false);
-    assert.equal(env.GAUZ_LLM_PROVIDER, 'anthropic');
-    assert.equal(env.GAUZ_LLM_API_BASE, 'https://relay.catsco.cc/anthropic');
+    assert.equal(env.GAUZ_LLM_PROVIDER, 'openai');
+    assert.equal(env.GAUZ_LLM_API_BASE, 'https://relay.catsco.cc/v1');
     assert.equal(env.GAUZ_LLM_MODEL, 'glm-5.1');
     assert.equal(env.GAUZ_LLM_API_KEY, 'sk-bf-fresh-secret');
     assert.equal(env.CATSCO_MODEL_SOURCE, 'relay');
-    assert.equal(env.CATSCO_RELAY_LLM_PROVIDER, 'anthropic');
-    assert.equal(env.CATSCO_RELAY_LLM_API_BASE, 'https://relay.catsco.cc/anthropic');
+    assert.equal(env.CATSCO_RELAY_LLM_PROVIDER, 'openai');
+    assert.equal(env.CATSCO_RELAY_LLM_API_BASE, 'https://relay.catsco.cc/v1');
     assert.equal(env.CATSCO_RELAY_LLM_MODEL, 'glm-5.1');
     assert.equal(env.CATSCO_RELAY_LLM_API_KEY, 'sk-bf-fresh-secret');
     assert.equal(env.CATSCO_BOT_UID, '188');
@@ -773,8 +773,8 @@ describe('dashboard CatsCo account status', () => {
     assert.equal(data.relayModelSetup.createdKey, true);
     assert.equal(text.includes('sk-bf-existing-bot-secret'), false);
     assert.equal(relayKeyCreated, 1);
-    assert.equal(env.GAUZ_LLM_PROVIDER, 'anthropic');
-    assert.equal(env.GAUZ_LLM_API_BASE, 'https://relay.catsco.cc/anthropic');
+    assert.equal(env.GAUZ_LLM_PROVIDER, 'openai');
+    assert.equal(env.GAUZ_LLM_API_BASE, 'https://relay.catsco.cc/v1');
     assert.equal(env.GAUZ_LLM_MODEL, 'glm-5.1');
     assert.equal(env.GAUZ_LLM_API_KEY, 'sk-bf-existing-bot-secret');
     assert.equal(env.CATSCO_MODEL_SOURCE, 'relay');

--- a/tests/dashboard-catsco-auth-status.test.ts
+++ b/tests/dashboard-catsco-auth-status.test.ts
@@ -460,13 +460,13 @@ describe('dashboard CatsCo account status', () => {
     assert.equal(data.relayModelSetup.model, 'glm-5.1');
     assert.equal(data.relayModelSetup.createdKey, true);
     assert.equal(text.includes('sk-bf-fresh-secret'), false);
-    assert.equal(env.GAUZ_LLM_PROVIDER, 'openai');
-    assert.equal(env.GAUZ_LLM_API_BASE, 'https://relay.catsco.cc/v1');
+    assert.equal(env.GAUZ_LLM_PROVIDER, 'anthropic');
+    assert.equal(env.GAUZ_LLM_API_BASE, 'https://relay.catsco.cc/anthropic');
     assert.equal(env.GAUZ_LLM_MODEL, 'glm-5.1');
     assert.equal(env.GAUZ_LLM_API_KEY, 'sk-bf-fresh-secret');
     assert.equal(env.CATSCO_MODEL_SOURCE, 'relay');
-    assert.equal(env.CATSCO_RELAY_LLM_PROVIDER, 'openai');
-    assert.equal(env.CATSCO_RELAY_LLM_API_BASE, 'https://relay.catsco.cc/v1');
+    assert.equal(env.CATSCO_RELAY_LLM_PROVIDER, 'anthropic');
+    assert.equal(env.CATSCO_RELAY_LLM_API_BASE, 'https://relay.catsco.cc/anthropic');
     assert.equal(env.CATSCO_RELAY_LLM_MODEL, 'glm-5.1');
     assert.equal(env.CATSCO_RELAY_LLM_API_KEY, 'sk-bf-fresh-secret');
     assert.equal(env.CATSCO_BOT_UID, '188');
@@ -773,8 +773,8 @@ describe('dashboard CatsCo account status', () => {
     assert.equal(data.relayModelSetup.createdKey, true);
     assert.equal(text.includes('sk-bf-existing-bot-secret'), false);
     assert.equal(relayKeyCreated, 1);
-    assert.equal(env.GAUZ_LLM_PROVIDER, 'openai');
-    assert.equal(env.GAUZ_LLM_API_BASE, 'https://relay.catsco.cc/v1');
+    assert.equal(env.GAUZ_LLM_PROVIDER, 'anthropic');
+    assert.equal(env.GAUZ_LLM_API_BASE, 'https://relay.catsco.cc/anthropic');
     assert.equal(env.GAUZ_LLM_MODEL, 'glm-5.1');
     assert.equal(env.GAUZ_LLM_API_KEY, 'sk-bf-existing-bot-secret');
     assert.equal(env.CATSCO_MODEL_SOURCE, 'relay');

--- a/tests/dashboard-productization-html.test.ts
+++ b/tests/dashboard-productization-html.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import test from 'node:test';
+import vm from 'node:vm';
 
 const dashboardHtml = readFileSync(join(process.cwd(), 'dashboard/index.html'), 'utf-8');
 const servicesPageHtml = dashboardHtml.match(/<div class="page" id="page-services">[\s\S]*?<div class="page" id="page-companion">/)?.[0] || '';
@@ -142,6 +143,59 @@ test('CatsCo Chat page is driven by readiness state instead of loose controls', 
   assert.match(dashboardHtml, /needs-readiness/);
   assert.match(dashboardHtml, /appReadinessLoaded/);
   assert.doesNotMatch(dashboardHtml, /末尾 \+/);
+});
+
+test('relay model cards render SDK labels from model payloads', () => {
+  assert.match(dashboardHtml, /sdk_label:'Anthropic SDK'/);
+  assert.match(dashboardHtml, /const sdkLabel=model\.sdk_label \|\|/);
+  assert.match(dashboardHtml, /escapeHtml\(contextLabel\)\+' · '\+escapeHtml\(sdkLabel\)/);
+  assert.doesNotMatch(dashboardHtml, /escapeHtml\(contextLabel\)\+' · Anthropic SDK'/);
+
+  const functionSource = dashboardHtml.match(
+    /function relayModelChoiceHtml\(model, activeId, catsConnected, context='settings'\)\{[\s\S]*?\n    \}/,
+  )?.[0];
+  assert.ok(functionSource);
+
+  const relayModelChoiceHtml = vm.runInNewContext(`${functionSource}; relayModelChoiceHtml`, {
+    escapeHtml: (value: unknown) => String(value ?? '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;'),
+    formatModelContextLabel: (tokens: unknown, fallback: unknown) => fallback || `${tokens} tokens`,
+    relayActionBusy: () => false,
+    String,
+  }) as (
+    model: Record<string, unknown>,
+    activeId: string,
+    catsConnected: boolean,
+    context?: string,
+  ) => string;
+
+  const html = relayModelChoiceHtml(
+    {
+      id: 'custom-openai',
+      label: 'OpenAI <Relay>',
+      model: 'custom&model',
+      provider: 'anthropic',
+      sdk_label: 'OpenAI SDK',
+      quota_class: 'standard',
+      context_window_tokens: 128000,
+      context_label: '128K',
+    },
+    'custom-openai',
+    true,
+    'chat',
+  );
+
+  assert.match(html, /class="relay-model-choice active"/);
+  assert.match(html, /data-relay-model-id="custom-openai"/);
+  assert.match(html, /data-relay-model-context="chat"/);
+  assert.match(html, /OpenAI &lt;Relay&gt;/);
+  assert.match(html, /custom&amp;model/);
+  assert.match(html, /上下文 128K · OpenAI SDK/);
+  assert.doesNotMatch(html, /Anthropic SDK/);
 });
 
 test('custom model save refreshes simplified state before Chat remains locked', () => {

--- a/tests/dashboard-readiness.test.ts
+++ b/tests/dashboard-readiness.test.ts
@@ -225,6 +225,40 @@ describe('dashboard readiness and service preflight API', () => {
     assert.equal(readinessText.includes('sk-bf-relay-secret'), false);
   });
 
+  test('custom startup readiness can use a relay gateway endpoint without being treated as managed relay', async () => {
+    writeEnv([
+      'CATSCO_MODEL_SOURCE=custom',
+      'GAUZ_LLM_PROVIDER=openai',
+      'GAUZ_LLM_API_BASE=https://relay.catsco.cc/v1',
+      'GAUZ_LLM_API_KEY=sk-custom-relay-secret',
+      'GAUZ_LLM_MODEL=MiniMax-M3',
+      'CATSCO_CUSTOM_LLM_PROVIDER=openai',
+      'CATSCO_CUSTOM_LLM_API_BASE=https://relay.catsco.cc/v1',
+      'CATSCO_CUSTOM_LLM_API_KEY=sk-custom-relay-secret',
+      'CATSCO_CUSTOM_LLM_MODEL=MiniMax-M3',
+      'CATSCO_HTTP_BASE_URL=https://app.catsco.cc',
+      'CATSCO_SERVER_URL=wss://app.catsco.cc/v0/channels',
+      'CATSCO_API_KEY=catsco-agent-secret',
+      'CATSCO_USER_TOKEN=user-token',
+      'CATSCO_USER_UID=100',
+      'CATSCO_BOT_UID=200',
+    ]);
+    writeConfirmedCatsBinding();
+
+    const readinessResponse = await fetch(`${baseUrl}/api/readiness`);
+    const readinessText = await readinessResponse.text();
+    const readiness = JSON.parse(readinessText) as any;
+    const model = readiness.sections.find((section: any) => section.id === 'model');
+
+    assert.equal(readinessResponse.status, 200, readinessText);
+    assert.equal(model.status, 'warning');
+    assert.equal(model.summary.includes('自定义模型'), true);
+    assert.equal(model.checks.some((check: any) => check.id === 'model.managed.relay' && check.status === 'warning'), true);
+    assert.equal(model.checks.some((check: any) => check.id === 'model.custom.apiBase' && check.status === 'pass'), true);
+    assert.equal(model.checks.some((check: any) => check.id === 'model.custom.model' && check.status === 'pass'), true);
+    assert.equal(readinessText.includes('sk-custom-relay-secret'), false);
+  });
+
   test('Feishu and Weixin preflight block when connector credentials are missing', async () => {
     writeEnv([
       'GAUZ_LLM_PROVIDER=openai',

--- a/tests/dashboard-settings-api.test.ts
+++ b/tests/dashboard-settings-api.test.ts
@@ -1265,6 +1265,57 @@ describe('dashboard typed settings API', () => {
     }
   });
 
+  test('GET /cats/relay/model-config preserves partial unknown relay capabilities', async () => {
+    const catsApp = express();
+    catsApp.use(express.json());
+    catsApp.get('/api/relay/config', (_req, res) => {
+      res.json({
+        base_url: 'https://relay.catsco.cc',
+        default_model: 'custom-vision',
+        self_service_enabled: false,
+        endpoints: [
+          { protocol: 'Anthropic-compatible', base_url: 'https://relay.catsco.cc/anthropic' },
+        ],
+        models: [
+          {
+            id: 'custom-vision',
+            label: 'Custom Vision',
+            model: 'custom-vision',
+            enabled: true,
+            default: true,
+            capabilities: {
+              vision: 'true',
+              streaming: 0,
+            },
+          },
+        ],
+      });
+    });
+    const catsServer = await listen(catsApp);
+    const address = catsServer.address();
+    if (!address || typeof address === 'string') throw new Error('cats server did not bind');
+
+    try {
+      process.env.CATSCO_USER_TOKEN = 'user-token';
+      process.env.CATSCO_USER_UID = '38';
+      process.env.CATSCO_HTTP_BASE_URL = `http://127.0.0.1:${address.port}`;
+
+      const response = await fetch(`${baseUrl}/api/cats/relay/model-config?modelId=custom-vision`);
+      const text = await response.text();
+      const data = JSON.parse(text) as any;
+
+      assert.equal(response.status, 200, text);
+      assert.deepStrictEqual(data.selectedModel.capabilities, {
+        vision: true,
+        streaming: false,
+      });
+      assert.equal('tool_calling' in data.selectedModel.capabilities, false);
+      assert.deepStrictEqual(data.models[0].capabilities, data.selectedModel.capabilities);
+    } finally {
+      await new Promise<void>(resolve => catsServer.close(() => resolve()));
+    }
+  });
+
   test('POST /cats/relay/model-config/apply sanitizes upstream error payloads', async () => {
     const catsApp = express();
     catsApp.use(express.json());

--- a/tests/dashboard-settings-api.test.ts
+++ b/tests/dashboard-settings-api.test.ts
@@ -270,6 +270,38 @@ describe('dashboard typed settings API', () => {
     assert.equal(parsed.CATSCO_RELAY_LLM_MODEL, 'MiniMax-M2.7');
   });
 
+  test('custom startup source is preserved when it uses a relay gateway endpoint', async () => {
+    fs.writeFileSync(path.join(testRoot, '.env'), [
+      'CATSCO_MODEL_SOURCE=custom',
+      'GAUZ_LLM_PROVIDER=openai',
+      'GAUZ_LLM_API_BASE=https://relay.catsco.cc/v1',
+      'GAUZ_LLM_API_KEY=sk-custom-relay-secret',
+      'GAUZ_LLM_MODEL=MiniMax-M3',
+      'CATSCO_CUSTOM_LLM_PROVIDER=openai',
+      'CATSCO_CUSTOM_LLM_API_BASE=https://relay.catsco.cc/v1',
+      'CATSCO_CUSTOM_LLM_API_KEY=sk-custom-relay-secret',
+      'CATSCO_CUSTOM_LLM_MODEL=MiniMax-M3',
+      'CATSCO_RELAY_LLM_PROVIDER=anthropic',
+      'CATSCO_RELAY_LLM_API_BASE=https://relay.catsco.cc/anthropic',
+      'CATSCO_RELAY_LLM_API_KEY=sk-bf-relay-secret',
+      'CATSCO_RELAY_LLM_MODEL=MiniMax-M3',
+      '',
+    ].join('\n'));
+
+    const settingsResponse = await fetch(`${baseUrl}/api/settings`);
+    const settingsText = await settingsResponse.text();
+    const settings = JSON.parse(settingsText) as any;
+
+    assert.equal(settingsResponse.status, 200, settingsText);
+    assert.equal(settings.modelStartup.source, 'custom');
+    assert.equal(settings.modelStartup.custom.configured, true);
+    assert.equal(settings.modelStartup.custom.model, 'MiniMax-M3');
+    assert.equal(settings.modelStartup.custom.apiBase, 'https://relay.catsco.cc/v1');
+    assert.equal(settings.modelStartup.relay.configured, true);
+    assert.equal(settingsText.includes('sk-custom-relay-secret'), false);
+    assert.equal(settingsText.includes('sk-bf-relay-secret'), false);
+  });
+
   test('POST /model-source/custom/apply does not echo unsafe custom API base details', async () => {
     fs.writeFileSync(path.join(testRoot, '.env'), [
       'CATSCO_CUSTOM_LLM_PROVIDER=openai',

--- a/tests/dashboard-settings-api.test.ts
+++ b/tests/dashboard-settings-api.test.ts
@@ -711,6 +711,8 @@ describe('dashboard typed settings API', () => {
       assert.equal(parsed.CATSCO_RELAY_LLM_CONTEXT_WINDOW_TOKENS, '1000000');
       assert.equal(data.selectedModel.context_window_tokens, 1000000);
       assert.equal(data.selectedModel.context_label, '1M');
+      assert.equal(data.selectedModel.capabilities.vision, false);
+      assert.equal(data.selectedModel.capabilities.tool_calling, true);
       assert.equal(text.includes('sk-bf-openai-compatible'), false);
     } finally {
       await new Promise<void>(resolve => catsServer.close(() => resolve()));
@@ -774,6 +776,7 @@ describe('dashboard typed settings API', () => {
       assert.equal(parsed.GAUZ_LLM_API_KEY, 'sk-bf-glm-secret');
       assert.equal(parsed.CATSCO_RELAY_LLM_CONTEXT_WINDOW_TOKENS, '200000');
       assert.equal(data.selectedModel.context_window_tokens, 200000);
+      assert.equal(data.selectedModel.capabilities.vision, false);
     } finally {
       await new Promise<void>(resolve => catsServer.close(() => resolve()));
     }

--- a/tests/dashboard-settings-api.test.ts
+++ b/tests/dashboard-settings-api.test.ts
@@ -628,7 +628,7 @@ describe('dashboard typed settings API', () => {
     }
   });
 
-  test('POST /cats/relay/model-config/apply writes selected relay model with its preferred SDK settings', async () => {
+  test('POST /cats/relay/model-config/apply writes selected relay model with CatsCo Anthropic settings', async () => {
     const catsApp = express();
     catsApp.use(express.json());
     catsApp.get('/api/relay/config', (req, res) => {
@@ -698,14 +698,14 @@ describe('dashboard typed settings API', () => {
       assert.equal(response.status, 200, text);
       const parsed = dotenv.parse(fs.readFileSync(path.join(testRoot, '.env'), 'utf-8'));
 
-      assert.equal(data.provider, 'openai');
-      assert.equal(data.apiBase, 'https://relay.catsco.cc/v1');
+      assert.equal(data.provider, 'anthropic');
+      assert.equal(data.apiBase, 'https://relay.catsco.cc/anthropic');
       assert.equal(data.model, 'deepseek-v4-flash');
       assert.equal(data.selectedModel.id, 'deepseek-v4-flash');
-      assert.equal(data.selectedModel.base_url, 'https://relay.catsco.cc/v1');
-      assert.equal(data.selectedModel.sdk_label, 'OpenAI SDK');
-      assert.equal(parsed.GAUZ_LLM_PROVIDER, 'openai');
-      assert.equal(parsed.GAUZ_LLM_API_BASE, 'https://relay.catsco.cc/v1');
+      assert.equal(data.selectedModel.base_url, 'https://relay.catsco.cc/anthropic');
+      assert.equal(data.selectedModel.sdk_label, 'Anthropic SDK');
+      assert.equal(parsed.GAUZ_LLM_PROVIDER, 'anthropic');
+      assert.equal(parsed.GAUZ_LLM_API_BASE, 'https://relay.catsco.cc/anthropic');
       assert.equal(parsed.GAUZ_LLM_MODEL, 'deepseek-v4-flash');
       assert.equal(parsed.GAUZ_LLM_CONTEXT_WINDOW_TOKENS, '1000000');
       assert.equal(parsed.GAUZ_LLM_API_KEY, 'sk-bf-openai-compatible');
@@ -766,13 +766,13 @@ describe('dashboard typed settings API', () => {
       assert.equal(response.status, 200, text);
       const parsed = dotenv.parse(fs.readFileSync(path.join(testRoot, '.env'), 'utf-8'));
 
-      assert.equal(data.provider, 'openai');
-      assert.equal(data.apiBase, 'https://relay.catsco.cc/v1');
+      assert.equal(data.provider, 'anthropic');
+      assert.equal(data.apiBase, 'https://relay.catsco.cc/anthropic');
       assert.equal(data.model, 'glm-5.1');
       assert.equal(data.selectedModel.id, 'glm-5.1');
-      assert.equal(data.selectedModel.sdk_label, 'OpenAI SDK');
-      assert.equal(parsed.GAUZ_LLM_PROVIDER, 'openai');
-      assert.equal(parsed.GAUZ_LLM_API_BASE, 'https://relay.catsco.cc/v1');
+      assert.equal(data.selectedModel.sdk_label, 'Anthropic SDK');
+      assert.equal(parsed.GAUZ_LLM_PROVIDER, 'anthropic');
+      assert.equal(parsed.GAUZ_LLM_API_BASE, 'https://relay.catsco.cc/anthropic');
       assert.equal(parsed.GAUZ_LLM_MODEL, 'glm-5.1');
       assert.equal(parsed.GAUZ_LLM_CONTEXT_WINDOW_TOKENS, '200000');
       assert.equal(parsed.GAUZ_LLM_API_KEY, 'sk-bf-glm-secret');
@@ -908,10 +908,10 @@ describe('dashboard typed settings API', () => {
       const parsed = dotenv.parse(fs.readFileSync(path.join(testRoot, '.env'), 'utf-8'));
 
       assert.equal(response.status, 200, text);
-      assert.equal(data.apiBase, 'https://relay.catsco.cc/v1');
-      assert.equal(data.selectedModel.base_url, 'https://relay.catsco.cc/v1');
-      assert.equal(data.selectedModel.sdk_label, 'OpenAI SDK');
-      assert.equal(parsed.GAUZ_LLM_API_BASE, 'https://relay.catsco.cc/v1');
+      assert.equal(data.apiBase, 'https://relay.catsco.cc/anthropic');
+      assert.equal(data.selectedModel.base_url, 'https://relay.catsco.cc/anthropic');
+      assert.equal(data.selectedModel.sdk_label, 'Anthropic SDK');
+      assert.equal(parsed.GAUZ_LLM_API_BASE, 'https://relay.catsco.cc/anthropic');
       assert.equal(text.includes('wrong.example.test'), false);
     } finally {
       await new Promise<void>(resolve => catsServer.close(() => resolve()));
@@ -1255,12 +1255,12 @@ describe('dashboard typed settings API', () => {
       const data = JSON.parse(text) as any;
 
       assert.equal(response.status, 200, text);
-      assert.equal(data.provider, 'openai');
-      assert.equal(data.apiBase, 'https://relay.catsco.cc/v1');
+      assert.equal(data.provider, 'anthropic');
+      assert.equal(data.apiBase, 'https://relay.catsco.cc/anthropic');
       assert.equal(data.model, 'deepseek-v4-flash');
       assert.equal(data.selectedModel.id, 'deepseek-v4-flash');
-      assert.equal(data.selectedModel.sdk_label, 'OpenAI SDK');
-      assert.equal(data.configured, false);
+      assert.equal(data.selectedModel.sdk_label, 'Anthropic SDK');
+      assert.equal(data.configured, true);
       assert.equal(data.key.prefix, 'sk-bf-old...cret');
       assert.equal(text.includes('sk-bf-should-not-leak'), false);
       assert.equal(text.includes('sk-bf-old-local-secret'), false);
@@ -1506,16 +1506,16 @@ describe('dashboard typed settings API', () => {
       const parsed = dotenv.parse(fs.readFileSync(path.join(testRoot, '.env'), 'utf-8'));
 
       assert.equal(response.status, 200, text);
-      assert.equal(data.provider, 'openai');
-      assert.equal(data.apiBase, 'https://relay.catsco.cc/v1');
+      assert.equal(data.provider, 'anthropic');
+      assert.equal(data.apiBase, 'https://relay.catsco.cc/anthropic');
       assert.equal(data.model, 'deepseek-v4-flash');
       assert.equal(data.createdKey, false);
       assert.equal(data.rotatedKey, false);
       assert.equal(data.key.prefix, 'sk-bf-old...cret');
       assert.equal(createCalled, false);
       assert.equal(rotateCalled, false);
-      assert.equal(parsed.GAUZ_LLM_PROVIDER, 'openai');
-      assert.equal(parsed.GAUZ_LLM_API_BASE, 'https://relay.catsco.cc/v1');
+      assert.equal(parsed.GAUZ_LLM_PROVIDER, 'anthropic');
+      assert.equal(parsed.GAUZ_LLM_API_BASE, 'https://relay.catsco.cc/anthropic');
       assert.equal(parsed.GAUZ_LLM_MODEL, 'deepseek-v4-flash');
       assert.equal(parsed.GAUZ_LLM_API_KEY, 'sk-bf-old-local-secret');
       assert.equal(text.includes('sk-bf-old-local-secret'), false);
@@ -1693,8 +1693,8 @@ describe('dashboard typed settings API', () => {
       assert.equal(createCalled, false);
       assert.equal(rotateCalled, false);
       assert.equal(parsed.CATSCO_MODEL_SOURCE, 'relay');
-      assert.equal(parsed.GAUZ_LLM_PROVIDER, 'openai');
-      assert.equal(parsed.GAUZ_LLM_API_BASE, 'https://relay.catsco.cc/v1');
+      assert.equal(parsed.GAUZ_LLM_PROVIDER, 'anthropic');
+      assert.equal(parsed.GAUZ_LLM_API_BASE, 'https://relay.catsco.cc/anthropic');
       assert.equal(parsed.GAUZ_LLM_MODEL, 'glm-5.1');
       assert.equal(parsed.GAUZ_LLM_API_KEY, 'sk-bf-old-local-secret');
       assert.equal(parsed.CATSCO_RELAY_LLM_MODEL, 'glm-5.1');

--- a/tests/dashboard-settings-api.test.ts
+++ b/tests/dashboard-settings-api.test.ts
@@ -32,6 +32,8 @@ describe('dashboard typed settings API', () => {
     'CATSCO_RELAY_LLM_API_KEY',
     'CATSCO_RELAY_LLM_MODEL',
     'CATSCO_RELAY_LLM_CONTEXT_WINDOW_TOKENS',
+    'CATSCO_RELAY_LLM_VISION_CAPABLE',
+    'CATSCO_RELAY_LLM_TOOL_CALLING_CAPABLE',
     'CATSCO_HTTP_BASE_URL',
     'CATSCO_SERVER_URL',
     'CATSCO_USER_TOKEN',
@@ -730,18 +732,20 @@ describe('dashboard typed settings API', () => {
       assert.equal(response.status, 200, text);
       const parsed = dotenv.parse(fs.readFileSync(path.join(testRoot, '.env'), 'utf-8'));
 
-      assert.equal(data.provider, 'anthropic');
-      assert.equal(data.apiBase, 'https://relay.catsco.cc/anthropic');
+      assert.equal(data.provider, 'openai');
+      assert.equal(data.apiBase, 'https://relay.catsco.cc/v1');
       assert.equal(data.model, 'deepseek-v4-flash');
       assert.equal(data.selectedModel.id, 'deepseek-v4-flash');
-      assert.equal(data.selectedModel.base_url, 'https://relay.catsco.cc/anthropic');
-      assert.equal(data.selectedModel.sdk_label, 'Anthropic SDK');
-      assert.equal(parsed.GAUZ_LLM_PROVIDER, 'anthropic');
-      assert.equal(parsed.GAUZ_LLM_API_BASE, 'https://relay.catsco.cc/anthropic');
+      assert.equal(data.selectedModel.base_url, 'https://relay.catsco.cc/v1');
+      assert.equal(data.selectedModel.sdk_label, 'OpenAI SDK');
+      assert.equal(parsed.GAUZ_LLM_PROVIDER, 'openai');
+      assert.equal(parsed.GAUZ_LLM_API_BASE, 'https://relay.catsco.cc/v1');
       assert.equal(parsed.GAUZ_LLM_MODEL, 'deepseek-v4-flash');
       assert.equal(parsed.GAUZ_LLM_CONTEXT_WINDOW_TOKENS, '1000000');
       assert.equal(parsed.GAUZ_LLM_API_KEY, 'sk-bf-openai-compatible');
       assert.equal(parsed.CATSCO_RELAY_LLM_CONTEXT_WINDOW_TOKENS, '1000000');
+      assert.equal(parsed.CATSCO_RELAY_LLM_VISION_CAPABLE, 'false');
+      assert.equal(parsed.CATSCO_RELAY_LLM_TOOL_CALLING_CAPABLE, 'true');
       assert.equal(data.selectedModel.context_window_tokens, 1000000);
       assert.equal(data.selectedModel.context_label, '1M');
       assert.equal(data.selectedModel.capabilities.vision, false);
@@ -1347,6 +1351,61 @@ describe('dashboard typed settings API', () => {
       });
       assert.equal('tool_calling' in data.selectedModel.capabilities, false);
       assert.deepStrictEqual(data.models[0].capabilities, data.selectedModel.capabilities);
+    } finally {
+      await new Promise<void>(resolve => catsServer.close(() => resolve()));
+    }
+  });
+
+  test('GET /cats/relay/model-config lets upstream capabilities override local relay profiles', async () => {
+    const catsApp = express();
+    catsApp.use(express.json());
+    catsApp.get('/api/relay/config', (_req, res) => {
+      res.json({
+        base_url: 'https://relay.catsco.cc',
+        default_model: 'minimax-m3',
+        self_service_enabled: false,
+        endpoints: [
+          { protocol: 'OpenAI-compatible', base_url: 'https://relay.catsco.cc/v1' },
+          { protocol: 'Anthropic-compatible', base_url: 'https://relay.catsco.cc/anthropic' },
+        ],
+        models: [
+          {
+            id: 'minimax-m3',
+            label: 'MiniMax M3',
+            model: 'MiniMax-M3',
+            provider: 'openai',
+            protocol: 'OpenAI-compatible',
+            enabled: true,
+            capabilities: {
+              vision: false,
+              tool_calling: false,
+            },
+          },
+        ],
+      });
+    });
+    const catsServer = await listen(catsApp);
+    const address = catsServer.address();
+    if (!address || typeof address === 'string') throw new Error('cats server did not bind');
+
+    try {
+      process.env.CATSCO_USER_TOKEN = 'user-token';
+      process.env.CATSCO_USER_UID = '38';
+      process.env.CATSCO_HTTP_BASE_URL = `http://127.0.0.1:${address.port}`;
+
+      const response = await fetch(`${baseUrl}/api/cats/relay/model-config?modelId=minimax-m3`);
+      const text = await response.text();
+      const data = JSON.parse(text) as any;
+
+      assert.equal(response.status, 200, text);
+      assert.equal(data.selectedModel.provider, 'openai');
+      assert.equal(data.selectedModel.base_url, 'https://relay.catsco.cc/v1');
+      assert.equal(data.selectedModel.sdk_label, 'OpenAI SDK');
+      assert.deepStrictEqual(data.selectedModel.capabilities, {
+        tool_calling: false,
+        vision: false,
+        streaming: true,
+      });
     } finally {
       await new Promise<void>(resolve => catsServer.close(() => resolve()));
     }

--- a/tests/dashboard-settings-api.test.ts
+++ b/tests/dashboard-settings-api.test.ts
@@ -782,6 +782,73 @@ describe('dashboard typed settings API', () => {
     }
   });
 
+  test('POST /cats/relay/model-config/apply normalizes known relay model aliases before writing startup config', async () => {
+    const catsApp = express();
+    catsApp.use(express.json());
+    catsApp.get('/api/relay/config', (_req, res) => {
+      res.json({
+        base_url: 'https://relay.catsco.cc',
+        default_model: 'minimax-m3',
+        self_service_enabled: true,
+        endpoints: [
+          { protocol: 'Anthropic-compatible', base_url: 'https://relay.catsco.cc/anthropic' },
+        ],
+        models: [
+          {
+            id: 'minimax-m3',
+            label: 'MiniMax M3',
+            model: 'minimax-m3',
+            enabled: true,
+            default: true,
+          },
+        ],
+      });
+    });
+    catsApp.get('/api/relay/key', (_req, res) => {
+      res.json({ configured: false });
+    });
+    catsApp.post('/api/relay/key', (_req, res) => {
+      res.json({
+        key: {
+          id: 'vk-m3',
+          name: 'CatsCo user 38',
+          prefix: 'sk-bf-m3',
+          state: 'active',
+          key: 'sk-bf-m3-secret',
+        },
+      });
+    });
+    const catsServer = await listen(catsApp);
+    const address = catsServer.address();
+    if (!address || typeof address === 'string') throw new Error('cats server did not bind');
+
+    try {
+      process.env.CATSCO_USER_TOKEN = 'user-token';
+      process.env.CATSCO_USER_UID = '38';
+      process.env.CATSCO_HTTP_BASE_URL = `http://127.0.0.1:${address.port}`;
+
+      const response = await fetch(`${baseUrl}/api/cats/relay/model-config/apply`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ modelId: 'minimax-m3' }),
+      });
+      const text = await response.text();
+      const data = JSON.parse(text) as any;
+      assert.equal(response.status, 200, text);
+      const parsed = dotenv.parse(fs.readFileSync(path.join(testRoot, '.env'), 'utf-8'));
+
+      assert.equal(data.model, 'MiniMax-M3');
+      assert.equal(data.selectedModel.model, 'MiniMax-M3');
+      assert.equal(data.selectedModel.id, 'minimax-m3');
+      assert.equal(data.selectedModel.capabilities.vision, true);
+      assert.equal(parsed.GAUZ_LLM_MODEL, 'MiniMax-M3');
+      assert.equal(parsed.CATSCO_RELAY_LLM_MODEL, 'MiniMax-M3');
+      assert.equal(parsed.GAUZ_LLM_CONTEXT_WINDOW_TOKENS, '1000000');
+    } finally {
+      await new Promise<void>(resolve => catsServer.close(() => resolve()));
+    }
+  });
+
   test('POST /cats/relay/model-config/apply locks model catalog entries to the relay Anthropic endpoint', async () => {
     const catsApp = express();
     catsApp.use(express.json());

--- a/tests/dashboard-settings-api.test.ts
+++ b/tests/dashboard-settings-api.test.ts
@@ -628,7 +628,7 @@ describe('dashboard typed settings API', () => {
     }
   });
 
-  test('POST /cats/relay/model-config/apply writes selected relay model with Anthropic settings', async () => {
+  test('POST /cats/relay/model-config/apply writes selected relay model with its preferred SDK settings', async () => {
     const catsApp = express();
     catsApp.use(express.json());
     catsApp.get('/api/relay/config', (req, res) => {
@@ -698,13 +698,14 @@ describe('dashboard typed settings API', () => {
       assert.equal(response.status, 200, text);
       const parsed = dotenv.parse(fs.readFileSync(path.join(testRoot, '.env'), 'utf-8'));
 
-      assert.equal(data.provider, 'anthropic');
-      assert.equal(data.apiBase, 'https://relay.catsco.cc/anthropic');
+      assert.equal(data.provider, 'openai');
+      assert.equal(data.apiBase, 'https://relay.catsco.cc/v1');
       assert.equal(data.model, 'deepseek-v4-flash');
       assert.equal(data.selectedModel.id, 'deepseek-v4-flash');
-      assert.equal(data.selectedModel.base_url, 'https://relay.catsco.cc/anthropic');
-      assert.equal(parsed.GAUZ_LLM_PROVIDER, 'anthropic');
-      assert.equal(parsed.GAUZ_LLM_API_BASE, 'https://relay.catsco.cc/anthropic');
+      assert.equal(data.selectedModel.base_url, 'https://relay.catsco.cc/v1');
+      assert.equal(data.selectedModel.sdk_label, 'OpenAI SDK');
+      assert.equal(parsed.GAUZ_LLM_PROVIDER, 'openai');
+      assert.equal(parsed.GAUZ_LLM_API_BASE, 'https://relay.catsco.cc/v1');
       assert.equal(parsed.GAUZ_LLM_MODEL, 'deepseek-v4-flash');
       assert.equal(parsed.GAUZ_LLM_CONTEXT_WINDOW_TOKENS, '1000000');
       assert.equal(parsed.GAUZ_LLM_API_KEY, 'sk-bf-openai-compatible');
@@ -765,12 +766,13 @@ describe('dashboard typed settings API', () => {
       assert.equal(response.status, 200, text);
       const parsed = dotenv.parse(fs.readFileSync(path.join(testRoot, '.env'), 'utf-8'));
 
-      assert.equal(data.provider, 'anthropic');
-      assert.equal(data.apiBase, 'https://relay.catsco.cc/anthropic');
+      assert.equal(data.provider, 'openai');
+      assert.equal(data.apiBase, 'https://relay.catsco.cc/v1');
       assert.equal(data.model, 'glm-5.1');
       assert.equal(data.selectedModel.id, 'glm-5.1');
-      assert.equal(parsed.GAUZ_LLM_PROVIDER, 'anthropic');
-      assert.equal(parsed.GAUZ_LLM_API_BASE, 'https://relay.catsco.cc/anthropic');
+      assert.equal(data.selectedModel.sdk_label, 'OpenAI SDK');
+      assert.equal(parsed.GAUZ_LLM_PROVIDER, 'openai');
+      assert.equal(parsed.GAUZ_LLM_API_BASE, 'https://relay.catsco.cc/v1');
       assert.equal(parsed.GAUZ_LLM_MODEL, 'glm-5.1');
       assert.equal(parsed.GAUZ_LLM_CONTEXT_WINDOW_TOKENS, '200000');
       assert.equal(parsed.GAUZ_LLM_API_KEY, 'sk-bf-glm-secret');
@@ -849,7 +851,7 @@ describe('dashboard typed settings API', () => {
     }
   });
 
-  test('POST /cats/relay/model-config/apply locks model catalog entries to the relay Anthropic endpoint', async () => {
+  test('POST /cats/relay/model-config/apply locks known model catalog entries to their relay profile endpoint', async () => {
     const catsApp = express();
     catsApp.use(express.json());
     catsApp.get('/api/relay/config', (_req, res) => {
@@ -906,9 +908,10 @@ describe('dashboard typed settings API', () => {
       const parsed = dotenv.parse(fs.readFileSync(path.join(testRoot, '.env'), 'utf-8'));
 
       assert.equal(response.status, 200, text);
-      assert.equal(data.apiBase, 'https://relay.catsco.cc/anthropic');
-      assert.equal(data.selectedModel.base_url, 'https://relay.catsco.cc/anthropic');
-      assert.equal(parsed.GAUZ_LLM_API_BASE, 'https://relay.catsco.cc/anthropic');
+      assert.equal(data.apiBase, 'https://relay.catsco.cc/v1');
+      assert.equal(data.selectedModel.base_url, 'https://relay.catsco.cc/v1');
+      assert.equal(data.selectedModel.sdk_label, 'OpenAI SDK');
+      assert.equal(parsed.GAUZ_LLM_API_BASE, 'https://relay.catsco.cc/v1');
       assert.equal(text.includes('wrong.example.test'), false);
     } finally {
       await new Promise<void>(resolve => catsServer.close(() => resolve()));
@@ -1252,11 +1255,12 @@ describe('dashboard typed settings API', () => {
       const data = JSON.parse(text) as any;
 
       assert.equal(response.status, 200, text);
-      assert.equal(data.provider, 'anthropic');
-      assert.equal(data.apiBase, 'https://relay.catsco.cc/anthropic');
+      assert.equal(data.provider, 'openai');
+      assert.equal(data.apiBase, 'https://relay.catsco.cc/v1');
       assert.equal(data.model, 'deepseek-v4-flash');
       assert.equal(data.selectedModel.id, 'deepseek-v4-flash');
-      assert.equal(data.configured, true);
+      assert.equal(data.selectedModel.sdk_label, 'OpenAI SDK');
+      assert.equal(data.configured, false);
       assert.equal(data.key.prefix, 'sk-bf-old...cret');
       assert.equal(text.includes('sk-bf-should-not-leak'), false);
       assert.equal(text.includes('sk-bf-old-local-secret'), false);
@@ -1502,16 +1506,16 @@ describe('dashboard typed settings API', () => {
       const parsed = dotenv.parse(fs.readFileSync(path.join(testRoot, '.env'), 'utf-8'));
 
       assert.equal(response.status, 200, text);
-      assert.equal(data.provider, 'anthropic');
-      assert.equal(data.apiBase, 'https://relay.catsco.cc/anthropic');
+      assert.equal(data.provider, 'openai');
+      assert.equal(data.apiBase, 'https://relay.catsco.cc/v1');
       assert.equal(data.model, 'deepseek-v4-flash');
       assert.equal(data.createdKey, false);
       assert.equal(data.rotatedKey, false);
       assert.equal(data.key.prefix, 'sk-bf-old...cret');
       assert.equal(createCalled, false);
       assert.equal(rotateCalled, false);
-      assert.equal(parsed.GAUZ_LLM_PROVIDER, 'anthropic');
-      assert.equal(parsed.GAUZ_LLM_API_BASE, 'https://relay.catsco.cc/anthropic');
+      assert.equal(parsed.GAUZ_LLM_PROVIDER, 'openai');
+      assert.equal(parsed.GAUZ_LLM_API_BASE, 'https://relay.catsco.cc/v1');
       assert.equal(parsed.GAUZ_LLM_MODEL, 'deepseek-v4-flash');
       assert.equal(parsed.GAUZ_LLM_API_KEY, 'sk-bf-old-local-secret');
       assert.equal(text.includes('sk-bf-old-local-secret'), false);
@@ -1689,8 +1693,8 @@ describe('dashboard typed settings API', () => {
       assert.equal(createCalled, false);
       assert.equal(rotateCalled, false);
       assert.equal(parsed.CATSCO_MODEL_SOURCE, 'relay');
-      assert.equal(parsed.GAUZ_LLM_PROVIDER, 'anthropic');
-      assert.equal(parsed.GAUZ_LLM_API_BASE, 'https://relay.catsco.cc/anthropic');
+      assert.equal(parsed.GAUZ_LLM_PROVIDER, 'openai');
+      assert.equal(parsed.GAUZ_LLM_API_BASE, 'https://relay.catsco.cc/v1');
       assert.equal(parsed.GAUZ_LLM_MODEL, 'glm-5.1');
       assert.equal(parsed.GAUZ_LLM_API_KEY, 'sk-bf-old-local-secret');
       assert.equal(parsed.CATSCO_RELAY_LLM_MODEL, 'glm-5.1');

--- a/tests/log-redaction.test.ts
+++ b/tests/log-redaction.test.ts
@@ -1,0 +1,18 @@
+import { test } from 'node:test';
+import * as assert from 'node:assert';
+import { formatPathForLog } from '../src/utils/log-redaction';
+
+test('formatPathForLog keeps only a filename label and short hash', () => {
+  const label = formatPathForLog('C:\\Users\\alice\\secret-project\\page_0025.jpg');
+
+  assert.match(label, /^page_0025\.jpg#[a-f0-9]{8}$/);
+  assert.equal(label.includes('alice'), false);
+  assert.equal(label.includes('secret-project'), false);
+  assert.equal(label.includes('Users'), false);
+});
+
+test('formatPathForLog sanitizes control separators', () => {
+  const label = formatPathForLog('/tmp/catsco/bad=name\tfile.png');
+
+  assert.match(label, /^bad_name_file\.png#[a-f0-9]{8}$/);
+});

--- a/tests/model-capabilities.test.ts
+++ b/tests/model-capabilities.test.ts
@@ -103,4 +103,35 @@ describe('model capabilities', () => {
       true,
     );
   });
+
+  test('respects persisted relay capability overrides from CatsCo model catalog', () => {
+    const previousVision = process.env.CATSCO_RELAY_LLM_VISION_CAPABLE;
+    const previousToolCalling = process.env.CATSCO_RELAY_LLM_TOOL_CALLING_CAPABLE;
+    try {
+      process.env.CATSCO_RELAY_LLM_VISION_CAPABLE = 'false';
+      process.env.CATSCO_RELAY_LLM_TOOL_CALLING_CAPABLE = 'false';
+
+      assert.strictEqual(
+        isPrimaryModelVisionCapable({
+          provider: 'anthropic',
+          apiUrl: 'https://relay.catsco.cc/anthropic',
+          model: 'MiniMax-M3',
+        }),
+        false,
+      );
+      assert.strictEqual(
+        isPrimaryModelToolCallingCapable({
+          provider: 'anthropic',
+          apiUrl: 'https://relay.catsco.cc/anthropic',
+          model: 'MiniMax-M3',
+        }),
+        false,
+      );
+    } finally {
+      if (previousVision === undefined) delete process.env.CATSCO_RELAY_LLM_VISION_CAPABLE;
+      else process.env.CATSCO_RELAY_LLM_VISION_CAPABLE = previousVision;
+      if (previousToolCalling === undefined) delete process.env.CATSCO_RELAY_LLM_TOOL_CALLING_CAPABLE;
+      else process.env.CATSCO_RELAY_LLM_TOOL_CALLING_CAPABLE = previousToolCalling;
+    }
+  });
 });

--- a/tests/model-capabilities.test.ts
+++ b/tests/model-capabilities.test.ts
@@ -61,8 +61,8 @@ describe('model capabilities', () => {
       [
         { model: 'MiniMax-M2.7', provider: 'anthropic', vision: false, context: 204_800 },
         { model: 'MiniMax-M3', provider: 'anthropic', vision: true, context: 1_000_000 },
-        { model: 'deepseek-v4-flash', provider: 'openai', vision: false, context: 1_000_000 },
-        { model: 'glm-5.1', provider: 'openai', vision: false, context: 200_000 },
+        { model: 'deepseek-v4-flash', provider: 'anthropic', vision: false, context: 1_000_000 },
+        { model: 'glm-5.1', provider: 'anthropic', vision: false, context: 200_000 },
       ],
     );
     assert.strictEqual(findRelayModelProfile('minimax-m3')?.capabilities.vision, true);

--- a/tests/model-capabilities.test.ts
+++ b/tests/model-capabilities.test.ts
@@ -54,14 +54,15 @@ describe('model capabilities', () => {
     assert.deepStrictEqual(
       RELAY_MODEL_PROFILES.map(profile => ({
         model: profile.model,
+        provider: profile.preferredProvider,
         vision: profile.capabilities.vision,
         context: profile.contextWindowTokens,
       })),
       [
-        { model: 'MiniMax-M2.7', vision: false, context: 204_800 },
-        { model: 'MiniMax-M3', vision: true, context: 1_000_000 },
-        { model: 'deepseek-v4-flash', vision: false, context: 1_000_000 },
-        { model: 'glm-5.1', vision: false, context: 200_000 },
+        { model: 'MiniMax-M2.7', provider: 'anthropic', vision: false, context: 204_800 },
+        { model: 'MiniMax-M3', provider: 'anthropic', vision: true, context: 1_000_000 },
+        { model: 'deepseek-v4-flash', provider: 'openai', vision: false, context: 1_000_000 },
+        { model: 'glm-5.1', provider: 'openai', vision: false, context: 200_000 },
       ],
     );
     assert.strictEqual(findRelayModelProfile('minimax-m3')?.capabilities.vision, true);

--- a/tests/model-capabilities.test.ts
+++ b/tests/model-capabilities.test.ts
@@ -4,6 +4,7 @@ import {
   isPrimaryModelToolCallingCapable,
   isPrimaryModelVisionCapable,
 } from '../src/utils/model-capabilities';
+import { RELAY_MODEL_PROFILES, findRelayModelProfile } from '../src/utils/relay-model-profiles';
 
 describe('model capabilities', () => {
   test('treats Claude and GPT vision-capable models as multimodal', () => {
@@ -47,6 +48,24 @@ describe('model capabilities', () => {
       }),
       true,
     );
+  });
+
+  test('uses explicit relay model profiles for CatsCo relay vision capabilities', () => {
+    assert.deepStrictEqual(
+      RELAY_MODEL_PROFILES.map(profile => ({
+        model: profile.model,
+        vision: profile.capabilities.vision,
+        context: profile.contextWindowTokens,
+      })),
+      [
+        { model: 'MiniMax-M2.7', vision: false, context: 204_800 },
+        { model: 'MiniMax-M3', vision: true, context: 1_000_000 },
+        { model: 'deepseek-v4-flash', vision: false, context: 1_000_000 },
+        { model: 'glm-5.1', vision: false, context: 200_000 },
+      ],
+    );
+    assert.strictEqual(findRelayModelProfile('minimax-m3')?.capabilities.vision, true);
+    assert.strictEqual(findRelayModelProfile('MiniMax-M2.7')?.capabilities.vision, false);
   });
 
   test('keeps relay tool calling enabled for MiniMax, DeepSeek, and GLM', () => {

--- a/tests/openai-provider-runtime-feedback.test.ts
+++ b/tests/openai-provider-runtime-feedback.test.ts
@@ -87,6 +87,73 @@ describe('OpenAIProvider runtime feedback boundary', () => {
     }
   });
 
+  test('hides OpenAI-compatible reasoning fields and think tags in non-stream responses', async () => {
+    const originalPost = axios.post;
+    (axios as any).post = async () => ({
+      data: {
+        choices: [{
+          finish_reason: 'stop',
+          message: {
+            reasoning_content: 'private chain of thought',
+            content: '<think>hidden scratchpad</think>\n最终答案',
+          },
+        }],
+      },
+    });
+
+    try {
+      const provider = new OpenAIProvider({
+        apiKey: 'test-key',
+        apiUrl: 'https://example.test/v1/chat/completions',
+        model: 'test-model',
+      });
+
+      const result = await provider.chat([{ role: 'user', content: 'hello' }]);
+
+      assert.equal(result.content, '最终答案');
+      assert.equal(JSON.stringify(result).includes('private chain of thought'), false);
+      assert.equal(JSON.stringify(result).includes('hidden scratchpad'), false);
+    } finally {
+      (axios as any).post = originalPost;
+    }
+  });
+
+  test('keeps OpenAI tool calls while hiding reasoning text', async () => {
+    const originalPost = axios.post;
+    (axios as any).post = async () => ({
+      data: {
+        choices: [{
+          finish_reason: 'tool_calls',
+          message: {
+            content: '<think>choose tool</think>',
+            tool_calls: [{
+              id: 'call_1',
+              type: 'function',
+              function: { name: 'lookup', arguments: '{"query":"cats"}' },
+            }],
+          },
+        }],
+      },
+    });
+
+    try {
+      const provider = new OpenAIProvider({
+        apiKey: 'test-key',
+        apiUrl: 'https://example.test/v1/chat/completions',
+        model: 'test-model',
+      });
+
+      const result = await provider.chat([{ role: 'user', content: 'hello' }]);
+
+      assert.equal(result.content, null);
+      assert.equal(result.toolCalls?.[0].id, 'call_1');
+      assert.equal(result.toolCalls?.[0].function.name, 'lookup');
+      assert.equal(JSON.stringify(result).includes('choose tool'), false);
+    } finally {
+      (axios as any).post = originalPost;
+    }
+  });
+
   test('preserves finish reason for stream responses', async () => {
     const originalPost = axios.post;
     (axios as any).post = async () => ({
@@ -115,6 +182,42 @@ describe('OpenAIProvider runtime feedback boundary', () => {
       assert.equal(result.stopReason, 'stop');
       assert.equal(result.usage?.totalTokens, 3);
       assert.deepEqual(chunks, ['hel', 'lo']);
+    } finally {
+      (axios as any).post = originalPost;
+    }
+  });
+
+  test('hides OpenAI-compatible reasoning fields and split think tags in stream responses', async () => {
+    const originalPost = axios.post;
+    (axios as any).post = async () => ({
+      data: Readable.from([
+        'data: {"choices":[{"delta":{"reasoning_content":"private"}}]}\n\n',
+        'data: {"choices":[{"delta":{"content":"<thi"}}]}\n\n',
+        'data: {"choices":[{"delta":{"content":"nk>hidden"}}]}\n\n',
+        'data: {"choices":[{"delta":{"content":"</think>可见"}}]}\n\n',
+        'data: {"choices":[{"delta":{"content":"回复"},"finish_reason":"stop"}]}\n\n',
+        'data: [DONE]\n\n',
+      ]),
+    });
+
+    try {
+      const provider = new OpenAIProvider({
+        apiKey: 'test-key',
+        apiUrl: 'https://example.test/v1/chat/completions',
+        model: 'test-model',
+      });
+      const chunks: string[] = [];
+
+      const result = await provider.chatStream(
+        [{ role: 'user', content: 'hello' }],
+        undefined,
+        { onText: chunk => chunks.push(chunk) },
+      );
+
+      assert.equal(result.content, '可见回复');
+      assert.deepEqual(chunks, ['可见', '回复']);
+      assert.equal(JSON.stringify(result).includes('private'), false);
+      assert.equal(JSON.stringify(result).includes('hidden'), false);
     } finally {
       (axios as any).post = originalPost;
     }

--- a/tests/tool-result-tool-manager.test.ts
+++ b/tests/tool-result-tool-manager.test.ts
@@ -6,6 +6,7 @@ import * as assert from 'node:assert';
 import * as path from 'path';
 import * as os from 'os';
 import * as fs from 'fs';
+import * as http from 'http';
 import { ToolManager } from '../src/tools/tool-manager';
 import type { ExecutionScope } from '../src/types/session-identity';
 
@@ -155,6 +156,107 @@ describe('ToolManager - ToolExecutionResult 统一处理', () => {
       else process.env.GAUZ_LLM_API_BASE = previousApiBase;
       if (previousModel === undefined) delete process.env.GAUZ_LLM_MODEL;
       else process.env.GAUZ_LLM_MODEL = previousModel;
+    }
+  });
+
+  test('read_file falls back to reader proxy when MiniMax M3 image block creation fails', async () => {
+    const previousConfigPath = process.env.XIAOBA_CONFIG_PATH;
+    const previousProvider = process.env.GAUZ_LLM_PROVIDER;
+    const previousApiBase = process.env.GAUZ_LLM_API_BASE;
+    const previousModel = process.env.GAUZ_LLM_MODEL;
+    const previousReaderUrl = process.env.CATSCOMPANY_READER_API_URL;
+    const previousApiKey = process.env.CATSCOMPANY_API_KEY;
+    const consoleError = mock.method(console, 'error', () => {});
+    let requestCount = 0;
+    let observedRequest:
+      | { method?: string; url?: string; authorization?: string; body: string }
+      | undefined;
+
+    const readerServer = http.createServer((req, res) => {
+      requestCount += 1;
+      const chunks: Buffer[] = [];
+      req.on('data', chunk => chunks.push(Buffer.from(chunk)));
+      req.on('end', () => {
+        observedRequest = {
+          method: req.method,
+          url: req.url,
+          authorization: Array.isArray(req.headers.authorization)
+            ? req.headers.authorization.join(',')
+            : req.headers.authorization,
+          body: Buffer.concat(chunks).toString('utf8'),
+        };
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ analysis: 'fallback proxy analysis' }));
+      });
+    });
+
+    let serverListening = false;
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const onError = (error: Error) => reject(error);
+        readerServer.once('error', onError);
+        readerServer.listen(0, '127.0.0.1', () => {
+          readerServer.off('error', onError);
+          serverListening = true;
+          resolve();
+        });
+      });
+      const address = readerServer.address();
+      if (!address || typeof address === 'string') throw new Error('reader server did not bind');
+
+      process.env.XIAOBA_CONFIG_PATH = path.join(testRoot, 'missing-config.json');
+      process.env.GAUZ_LLM_PROVIDER = 'anthropic';
+      process.env.GAUZ_LLM_API_BASE = 'https://relay.catsco.cc/anthropic';
+      process.env.GAUZ_LLM_MODEL = 'MiniMax-M3';
+      process.env.CATSCOMPANY_READER_API_URL = `http://127.0.0.1:${address.port}`;
+      process.env.CATSCOMPANY_API_KEY = 'cats-reader-test-key';
+
+      const filePath = path.join(testRoot, 'broken-m3-image.png');
+      fs.writeFileSync(filePath, Buffer.from('not a valid image'));
+
+      const result = await manager.executeTool(
+        { id: 't2_m3_img_fallback', type: 'function', function: { name: 'read_file', arguments: JSON.stringify({ file_path: filePath }) } },
+        [{ role: 'user', content: '这张图里有什么' }],
+      );
+
+      assert.strictEqual(result.ok, true);
+      assert.strictEqual(requestCount, 1);
+      assert.deepStrictEqual(
+        {
+          method: observedRequest?.method,
+          url: observedRequest?.url,
+          authorization: observedRequest?.authorization,
+        },
+        {
+          method: 'POST',
+          url: '/analyze',
+          authorization: 'ApiKey cats-reader-test-key',
+        },
+      );
+      assert.ok(observedRequest?.body.includes('name="prompt"'));
+      assert.ok(observedRequest?.body.includes('这张图里有什么'));
+      assert.strictEqual(typeof result.content, 'string');
+      assert.ok(String(result.content).includes('主模型图片块生成失败，已自动改用 Cats reader proxy 解析'));
+      assert.ok(String(result.content).includes('fallback proxy analysis'));
+      assert.strictEqual(result.errorCode, undefined);
+    } finally {
+      if (serverListening) {
+        await new Promise<void>(resolve => readerServer.close(() => resolve()));
+      }
+      if (previousConfigPath === undefined) delete process.env.XIAOBA_CONFIG_PATH;
+      else process.env.XIAOBA_CONFIG_PATH = previousConfigPath;
+      if (previousProvider === undefined) delete process.env.GAUZ_LLM_PROVIDER;
+      else process.env.GAUZ_LLM_PROVIDER = previousProvider;
+      if (previousApiBase === undefined) delete process.env.GAUZ_LLM_API_BASE;
+      else process.env.GAUZ_LLM_API_BASE = previousApiBase;
+      if (previousModel === undefined) delete process.env.GAUZ_LLM_MODEL;
+      else process.env.GAUZ_LLM_MODEL = previousModel;
+      if (previousReaderUrl === undefined) delete process.env.CATSCOMPANY_READER_API_URL;
+      else process.env.CATSCOMPANY_READER_API_URL = previousReaderUrl;
+      if (previousApiKey === undefined) delete process.env.CATSCOMPANY_API_KEY;
+      else process.env.CATSCOMPANY_API_KEY = previousApiKey;
+      consoleError.mock.restore();
     }
   });
 

--- a/tests/tool-result-tool-manager.test.ts
+++ b/tests/tool-result-tool-manager.test.ts
@@ -9,6 +9,8 @@ import * as fs from 'fs';
 import { ToolManager } from '../src/tools/tool-manager';
 import type { ExecutionScope } from '../src/types/session-identity';
 
+const ONE_PIXEL_PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=';
+
 describe('ToolManager - ToolExecutionResult 统一处理', () => {
   let manager: ToolManager;
   let testRoot: string;
@@ -113,6 +115,46 @@ describe('ToolManager - ToolExecutionResult 统一处理', () => {
       else process.env.CATSCOMPANY_API_KEY = previousApiKey;
       if (previousReaderApiKey === undefined) delete process.env.READER_PROXY_API_KEY;
       else process.env.READER_PROXY_API_KEY = previousReaderApiKey;
+    }
+  });
+
+  test('read_file returns a direct image block for MiniMax M3 relay model', async () => {
+    const previousConfigPath = process.env.XIAOBA_CONFIG_PATH;
+    const previousProvider = process.env.GAUZ_LLM_PROVIDER;
+    const previousApiBase = process.env.GAUZ_LLM_API_BASE;
+    const previousModel = process.env.GAUZ_LLM_MODEL;
+    process.env.XIAOBA_CONFIG_PATH = path.join(testRoot, 'missing-config.json');
+    process.env.GAUZ_LLM_PROVIDER = 'anthropic';
+    process.env.GAUZ_LLM_API_BASE = 'https://relay.catsco.cc/anthropic';
+    process.env.GAUZ_LLM_MODEL = 'MiniMax-M3';
+
+    try {
+      const filePath = path.join(testRoot, 'm3-image.png');
+      fs.writeFileSync(filePath, Buffer.from(ONE_PIXEL_PNG_BASE64, 'base64'));
+
+      const result = await manager.executeTool(
+        { id: 't2_m3_img', type: 'function', function: { name: 'read_file', arguments: JSON.stringify({ file_path: filePath }) } },
+        [{ role: 'user', content: '帮我看看图里有什么' }],
+      );
+
+      assert.strictEqual(result.ok, true);
+      const content = result.content as any;
+      assert.strictEqual(content._imageForNewMessage, true);
+      assert.strictEqual(content.filePath, filePath);
+      assert.strictEqual(content.imageBlock.type, 'image');
+      assert.strictEqual(content.imageBlock.source.type, 'base64');
+      assert.strictEqual(content.imageBlock.source.media_type, 'image/jpeg');
+      assert.ok(content.imageBlock.source.data.length > 0);
+      assert.strictEqual(result.errorCode, undefined);
+    } finally {
+      if (previousConfigPath === undefined) delete process.env.XIAOBA_CONFIG_PATH;
+      else process.env.XIAOBA_CONFIG_PATH = previousConfigPath;
+      if (previousProvider === undefined) delete process.env.GAUZ_LLM_PROVIDER;
+      else process.env.GAUZ_LLM_PROVIDER = previousProvider;
+      if (previousApiBase === undefined) delete process.env.GAUZ_LLM_API_BASE;
+      else process.env.GAUZ_LLM_API_BASE = previousApiBase;
+      if (previousModel === undefined) delete process.env.GAUZ_LLM_MODEL;
+      else process.env.GAUZ_LLM_MODEL = previousModel;
     }
   });
 


### PR DESCRIPTION
## 变更内容

- 新增 CatsCo 中转模型 profile 表，统一维护 MiniMax-M2.7、MiniMax-M3、DeepSeek V4 Flash、GLM 5.1 的上下文、视觉、工具调用、流式能力和 CatsCo 桌面端推荐 SDK 兼容模式。
- Dashboard relay 配置接口改为从同一份 profile 派生 fallback 模型目录，并向前端返回 capabilities / sdk_label，避免 M3/非视觉模型能力判断漂移。
- CatsCo 桌面端自动接入统一默认 Anthropic-compatible：MiniMax-M2.7、MiniMax-M3、DeepSeek V4 Flash、GLM 5.1 都写入 `https://relay.catsco.cc/anthropic`。
- 保留 relay OpenAI-compatible `/v1` 能力给外部用户/第三方 agent 使用，但 CatsCo 桌面端不会默认切到 OpenAI SDK。
- CatsCompany 消息构建链路补齐视觉闭环：M3 图片直接进入 Anthropic image block；非视觉模型或图片 block 构建失败时回落到 read_file 提示。
- read_file 图片链路增加 vision_direct / vision_fallback_read_file 日志，方便线上确认图片到底是直传模型还是走文件读取。
- Review follow-up：补充 MiniMax-M3 relay 下 read_file 直接返回 image block 的测试；并将已知 relay 模型 alias 规范化成真实 provider model 后再写启动配置。
- Review follow-up：vision 诊断日志只记录文件名 + 短 hash，不再写完整本地路径；未知 relay 模型的 partial capabilities 只保留明确字段，不把缺失字段误判成 false。
- Review follow-up：补齐 M3 图片 block 构建失败后回落 reader proxy 的端到端测试，并执行 relay 模型卡片渲染函数验证 sdk_label 动态展示。

## 用户影响

- 选择 MiniMax-M3 后，图片消息会优先直接发给视觉模型，并继续使用 Anthropic SDK 以保持多模态链路稳定。
- 选择 DeepSeek V4 Flash / GLM 5.1 后，CatsCo 桌面端仍默认使用 CatsCo relay Anthropic-compatible endpoint，避免桌面工具/上下文链路被 OpenAI SDK 兼容层影响。
- 外部用户如果用自己的 agent 接入 CatsCo 中转，可以继续用同一把 relay key 走 `https://relay.catsco.cc/v1` 和 OpenAI SDK。
- MiniMax-M2.7、DeepSeek、GLM 继续按非视觉模型处理图片，提示 agent 使用 read_file。
- 如果 M3 图片 block 构建失败，不会静默丢图片，会回落到 read_file 链路。
- 即使 CatsCompany 之后下发 minimax-m3 这类 alias，桌面端也会写入 MiniMax-M3，避免启动后模型名不匹配。
- 本地日志不会再暴露完整附件路径、用户名或项目目录。

## 验证

- npm.cmd run build
- node .\\node_modules\\tsx\\dist\\cli.mjs --test tests\\tool-result-tool-manager.test.ts tests\\dashboard-productization-html.test.ts
- node .\\node_modules\\tsx\\dist\\cli.mjs --test tests\\dashboard-settings-api.test.ts tests\\dashboard-catsco-auth-status.test.ts tests\\model-capabilities.test.ts
- npm.cmd run test:runtime
- npm.cmd run release:check
- npx.cmd tsx --test tests/log-redaction.test.ts
- npx.cmd tsx --test tests/dashboard-settings-api.test.ts
- node --import tsx tests\\tool-result-tool-manager.test.ts
- node --import tsx tests\\dashboard-settings-api.test.ts
- node --import tsx tests\\model-capabilities.test.ts
- node --import tsx tests\\model-context-window.test.ts
- node --import tsx tests\\catscompany-content-blocks.test.ts
- npm.cmd run test:all
- git diff --check

备注：git diff --check 仅输出 Windows CRLF 提示，无 whitespace 错误。
