### PR TITLE
Add CatsCo device RPC client transport

### DIFF
--- a/src/catscompany/client.ts
+++ b/src/catscompany/client.ts
@@ -12,6 +12,7 @@ export interface CatsClientConfig {
   apiKey: string;
   bodyId?: string;
   installationId?: string;
+  deviceRegistration?: CatsDeviceRegistration;
   httpBaseUrl?: string;
 }
 
@@ -22,6 +23,34 @@ export interface CatsDeviceRegistration {
   installation_id?: string;
   status?: 'online' | 'offline';
   capabilities?: string[];
+}
+
+export interface CatsDeviceRpcError {
+  code: string;
+  message: string;
+}
+
+export interface CatsDeviceRpcMessage {
+  id?: string;
+  type: 'request' | 'result';
+  request_id: string;
+  grant_id?: string;
+  session_key?: string;
+  topic_id?: string;
+  topic_type?: string;
+  actor_user_id?: string;
+  agent_id?: string;
+  agent_body_id?: string;
+  device_id?: string;
+  device_body_id?: string;
+  device_installation_id?: string;
+  operation?: string;
+  tool_name?: string;
+  payload?: Record<string, unknown>;
+  result?: unknown;
+  error?: CatsDeviceRpcError;
+  created_at?: number;
+  expires_at?: number;
 }
 
 export interface MessageContext {
@@ -116,6 +145,7 @@ export class CatsClient extends EventEmitter {
   private msgId = 0;
   private closed = false;
   private pendingAcks = new Map<string, PendingAck>();
+  private pendingDeviceRpc = new Map<string, PendingDeviceRpc>();
   private pingTimer: NodeJS.Timeout | null = null;
   private pongTimer: NodeJS.Timeout | null = null;
   private reconnectAttempts = 0;
@@ -161,7 +191,14 @@ export class CatsClient extends EventEmitter {
 
     this.ws.on('open', () => {
       this.reconnectAttempts = 0;
-      this.send({ hi: { id: '1', ver: CATSCOMPANY_PROTOCOL_VERSION, ua: CATSCOMPANY_CLIENT_UA } });
+      this.send({
+        hi: {
+          id: '1',
+          ver: CATSCOMPANY_PROTOCOL_VERSION,
+          ua: CATSCOMPANY_CLIENT_UA,
+          device: this.config.deviceRegistration,
+        },
+      });
       this.startHeartbeat();
     });
 
@@ -186,6 +223,10 @@ export class CatsClient extends EventEmitter {
         undefined,
         { retryableWithHttp: this.supportsClientMessageDedupe }
       ));
+      this.rejectPendingDeviceRpc(new CatsSendError(
+        'timeout',
+        'WebSocket 在收到 Device RPC 结果前关闭'
+      ));
       if (!this.closed) this.scheduleReconnect();
     });
   }
@@ -203,6 +244,9 @@ export class CatsClient extends EventEmitter {
           && msg.ctrl.params.features.includes('client_msg_id');
         if (this.supportsClientMessageDedupe) {
           Logger.info('[CatsCompany] 服务端支持 client_msg_id 幂等发送');
+        }
+        if (Array.isArray(msg.ctrl.params?.features) && msg.ctrl.params.features.includes('device_rpc')) {
+          Logger.info('[CatsCompany] 服务端支持 device_rpc 远程设备传输');
         }
         this.emit('ready', { uid: this.uid, name: this.name });
         this.autoAcceptFriendRequests().catch(console.error);
@@ -223,6 +267,8 @@ export class CatsClient extends EventEmitter {
           }
         }
       }
+    } else if (msg.device_rpc) {
+      this.handleDeviceRpcMessage(msg.device_rpc);
     } else if (msg.data) {
       Logger.info(
         `[CatsCompany] 收到消息: topic=${msg.data.topic || '-'}, ` +
@@ -254,6 +300,45 @@ export class CatsClient extends EventEmitter {
         Logger.info(`[CatsCompany] 收到 presence: what=${msg.pres.what}, src=${msg.pres.src || '-'}`);
       }
     }
+  }
+
+  private handleDeviceRpcMessage(raw: any): void {
+    const message = normalizeDeviceRpcMessage(raw);
+    if (!message) {
+      Logger.warning('[CatsCompany] 收到无效 device_rpc 消息，已忽略');
+      return;
+    }
+    if (message.type === 'result') {
+      const pending = this.pendingDeviceRpc.get(message.request_id);
+      if (pending) {
+        if (!deviceRpcResultMatchesPending(message, pending.request)) {
+          clearTimeout(pending.timer);
+          this.pendingDeviceRpc.delete(message.request_id);
+          pending.reject(new CatsSendError(
+            'ack',
+            `Device RPC ${message.request_id} result scope does not match pending request`,
+            409
+          ));
+        } else if (pending.acknowledged) {
+          this.resolvePendingDeviceRpc(message.request_id, pending, message);
+        } else {
+          pending.result = message;
+        }
+      }
+      this.emit('device_rpc_result', message);
+      return;
+    }
+    this.emit('device_rpc_request', message);
+  }
+
+  private resolvePendingDeviceRpc(
+    requestID: string,
+    pending: PendingDeviceRpc,
+    result: CatsDeviceRpcMessage
+  ): void {
+    clearTimeout(pending.timer);
+    this.pendingDeviceRpc.delete(requestID);
+    pending.resolve(result);
   }
 
   async sendMessage(topic: string, text: string): Promise<number> {
@@ -296,21 +381,112 @@ export class CatsClient extends EventEmitter {
       },
     });
 
+    return this.sendEnvelopeWithAck(msgId, { pub }, {
+      clientMsgID,
+      retryableWithHttp: this.supportsClientMessageDedupe,
+      timeoutMessage: 'WebSocket 已发送消息，但 10 秒内没有收到 CatsCompany 服务器确认',
+    });
+  }
+
+  async sendDeviceRpcRequest(
+    request: Omit<CatsDeviceRpcMessage, 'id' | 'type'> & { request_id?: string },
+    timeoutMs = 60000
+  ): Promise<CatsDeviceRpcMessage> {
+    const requestID = request.request_id || buildDeviceRpcRequestID();
+    if (this.pendingDeviceRpc.has(requestID)) {
+      throw new CatsSendError('ack', `Device RPC request_id already pending: ${requestID}`, 409);
+    }
+    const msgId = `${++this.msgId}`;
+    const deviceRpc: CatsDeviceRpcMessage = {
+      ...request,
+      id: msgId,
+      type: 'request',
+      request_id: requestID,
+    };
+
+    const resultPromise = new Promise<CatsDeviceRpcMessage>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pendingDeviceRpc.delete(requestID);
+        reject(new CatsSendError(
+          'timeout',
+          `Device RPC ${requestID} 在 ${timeoutMs}ms 内没有收到设备结果`
+        ));
+      }, timeoutMs);
+      this.pendingDeviceRpc.set(requestID, {
+        request: deviceRpc,
+        resolve,
+        reject,
+        timer,
+        acknowledged: false,
+      });
+    });
+
+    try {
+      await this.sendEnvelopeWithAck(msgId, { device_rpc: deviceRpc }, {
+        timeoutMessage: 'WebSocket 已发送 Device RPC 请求，但 10 秒内没有收到 CatsCompany 服务器确认',
+      });
+    } catch (err) {
+      const pending = this.pendingDeviceRpc.get(requestID);
+      if (pending) {
+        clearTimeout(pending.timer);
+        this.pendingDeviceRpc.delete(requestID);
+        throw err;
+      }
+      throw err;
+    }
+
+    const pending = this.pendingDeviceRpc.get(requestID);
+    if (pending) {
+      pending.acknowledged = true;
+      if (pending.result) {
+        this.resolvePendingDeviceRpc(requestID, pending, pending.result);
+      }
+    }
+    return resultPromise;
+  }
+
+  async sendDeviceRpcResult(result: Omit<CatsDeviceRpcMessage, 'id' | 'type'>): Promise<void> {
+    const requestID = String(result.request_id || '').trim();
+    if (!requestID) {
+      throw new Error('Device RPC result request_id is required');
+    }
+    const msgId = `${++this.msgId}`;
+    await this.sendEnvelopeWithAck(msgId, {
+      device_rpc: {
+        ...result,
+        id: msgId,
+        type: 'result',
+        request_id: requestID,
+      },
+    }, {
+      timeoutMessage: 'WebSocket 已发送 Device RPC 结果，但 10 秒内没有收到 CatsCompany 服务器确认',
+    });
+  }
+
+  private sendEnvelopeWithAck(
+    msgId: string,
+    envelope: Record<string, unknown>,
+    options: {
+      clientMsgID?: string;
+      retryableWithHttp?: boolean;
+      timeoutMessage?: string;
+    } = {}
+  ): Promise<number> {
     return new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
         this.pendingAcks.delete(msgId);
         this.forceReconnect('ack timeout');
         reject(new CatsSendError(
           'timeout',
-          'WebSocket 已发送消息，但 10 秒内没有收到 CatsCompany 服务器确认',
+          options.timeoutMessage || 'WebSocket 已发送消息，但 10 秒内没有收到 CatsCompany 服务器确认',
           undefined,
-          { clientMsgID, retryableWithHttp: this.supportsClientMessageDedupe }
+          { clientMsgID: options.clientMsgID, retryableWithHttp: options.retryableWithHttp ?? false }
         ));
       }, 10000);
 
-      this.pendingAcks.set(msgId, { resolve, reject, timer, clientMsgID });
+      this.pendingAcks.set(msgId, { resolve, reject, timer, clientMsgID: options.clientMsgID });
       try {
-        this.sendOrThrow({ pub });
+        this.sendOrThrow(envelope);
       } catch (err: any) {
         clearTimeout(timer);
         this.pendingAcks.delete(msgId);
@@ -437,6 +613,14 @@ export class CatsClient extends EventEmitter {
     }
   }
 
+  private rejectPendingDeviceRpc(err: Error): void {
+    for (const [requestID, pending] of this.pendingDeviceRpc.entries()) {
+      clearTimeout(pending.timer);
+      this.pendingDeviceRpc.delete(requestID);
+      pending.reject(err);
+    }
+  }
+
   private forceReconnect(reason: string): void {
     Logger.warning(`[CatsCompany] ${reason}，主动重建 WebSocket 连接`);
     if (this.ws?.readyState === WebSocket.OPEN || this.ws?.readyState === WebSocket.CONNECTING) {
@@ -500,6 +684,15 @@ export class CatsClient extends EventEmitter {
   }
 }
 
+interface PendingDeviceRpc {
+  request: CatsDeviceRpcMessage;
+  resolve: (message: CatsDeviceRpcMessage) => void;
+  reject: (err: Error) => void;
+  timer: NodeJS.Timeout;
+  acknowledged: boolean;
+  result?: CatsDeviceRpcMessage;
+}
+
 function inferHttpBaseUrl(serverUrl: string): string | undefined {
   try {
     const url = new URL(serverUrl);
@@ -520,4 +713,48 @@ function buildClientMessageID(): string {
     return `catsco-${crypto.randomUUID()}`;
   }
   return `catsco-${Date.now()}-${crypto.randomBytes(8).toString('hex')}`;
+}
+
+function buildDeviceRpcRequestID(): string {
+  if (typeof crypto.randomUUID === 'function') {
+    return `device_rpc_${crypto.randomUUID()}`;
+  }
+  return `device_rpc_${Date.now()}_${crypto.randomBytes(8).toString('hex')}`;
+}
+
+function normalizeDeviceRpcMessage(raw: any): CatsDeviceRpcMessage | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const type = String(raw.type || '').trim();
+  const requestID = String(raw.request_id || '').trim();
+  if ((type !== 'request' && type !== 'result') || !requestID) return undefined;
+  const message: CatsDeviceRpcMessage = {
+    ...raw,
+    type,
+    request_id: requestID,
+  };
+  if (raw.payload && typeof raw.payload === 'object' && !Array.isArray(raw.payload)) {
+    message.payload = raw.payload;
+  }
+  return message;
+}
+
+function deviceRpcResultMatchesPending(result: CatsDeviceRpcMessage, request: CatsDeviceRpcMessage): boolean {
+  return deviceRpcOptionalFieldMatches(result.grant_id, request.grant_id)
+    && deviceRpcOptionalFieldMatches(result.session_key, request.session_key)
+    && deviceRpcOptionalFieldMatches(result.topic_id, request.topic_id)
+    && deviceRpcOptionalFieldMatches(result.topic_type, request.topic_type)
+    && deviceRpcOptionalFieldMatches(result.actor_user_id, request.actor_user_id)
+    && deviceRpcOptionalFieldMatches(result.agent_id, request.agent_id)
+    && deviceRpcOptionalFieldMatches(result.agent_body_id, request.agent_body_id)
+    && deviceRpcOptionalFieldMatches(result.device_id, request.device_id)
+    && deviceRpcOptionalFieldMatches(result.device_body_id, request.device_body_id)
+    && deviceRpcOptionalFieldMatches(result.device_installation_id, request.device_installation_id)
+    && deviceRpcOptionalFieldMatches(result.operation, request.operation)
+    && deviceRpcOptionalFieldMatches(result.tool_name, request.tool_name);
+}
+
+function deviceRpcOptionalFieldMatches(actual: unknown, expected: unknown): boolean {
+  const actualText = typeof actual === 'string' ? actual.trim() : '';
+  const expectedText = typeof expected === 'string' ? expected.trim() : '';
+  return !actualText || !expectedText || actualText === expectedText;
 }

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -11,16 +11,24 @@ import { AgentServices, BUSY_MESSAGE, RuntimeFeedbackInput, SessionCallbacks } f
 import { Logger } from '../utils/logger';
 import { SubAgentManager } from '../core/sub-agent-manager';
 import type { SubAgentInfo } from '../core/sub-agent-session';
-import { ChannelCallbacks } from '../types/tool';
+import { ChannelCallbacks, DeviceRpcTransport, ToolErrorCode, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import { ContentBlock } from '../types';
 import type { PendingUserInput } from '../core/conversation-runner';
-import type { ScopedDeviceGrant, ScopedDeviceSelection, ScopedLocalDeviceGrant, ScopedLocalFileGrant } from '../types/session-identity';
+import type { DeviceGrantOperation, ExecutionScope, ScopedDeviceGrant, ScopedDeviceSelection, ScopedLocalDeviceGrant, ScopedLocalFileGrant } from '../types/session-identity';
 import { AdapterRuntimeBundle, createAdapterRuntime } from '../runtime/adapter-runtime';
 import { randomUUID } from 'crypto';
 import { hostname } from 'os';
 import { ConfigManager } from '../utils/config';
 import { isPrimaryModelVisionCapable } from '../utils/model-capabilities';
 import { createCatsCoSessionRoute } from '../core/session-router';
+import { ReadTool } from '../tools/read-tool';
+import { GlobTool } from '../tools/glob-tool';
+import { GrepTool } from '../tools/grep-tool';
+import {
+  isRemoteReadonlyTool,
+  normalizeDeviceRpcToolResultForTransport,
+  normalizeDeviceRpcToolResultPayload,
+} from '../tools/device-rpc-tool';
 
 interface PendingAttachment {
   fileName: string;
@@ -56,6 +64,7 @@ interface QueuedMessage {
 const PENDING_ANSWER_TIMEOUT_MS = 120_000;
 const TYPING_HEARTBEAT_INTERVAL_MS = 5_000;
 const DEVICE_REGISTRATION_REFRESH_MS = 120_000;
+const DEVICE_RPC_DEFAULT_TTL_MS = 60_000;
 const HIDDEN_CATS_TOOL_PROGRESS = new Set([
   'send_text',
   'send_file',
@@ -124,7 +133,7 @@ export class CatsCompanyBot {
           body_id: config.bodyId,
           installation_id: config.installationId || config.bodyId,
           status: 'online' as const,
-          capabilities: ['read_file', 'send_file', 'glob', 'grep'],
+          capabilities: ['read_file', 'glob', 'grep'],
         }
       : undefined;
 
@@ -224,17 +233,51 @@ export class CatsCompanyBot {
     this.deviceRegistrationTimer = undefined;
   }
 
+  private buildDeviceRpcTransport(): DeviceRpcTransport {
+    return {
+      executeTool: async ({ toolName, operation, args, grant, timeoutMs }) => {
+        const response = await this.bot.sendDeviceRpcRequest({
+          request_id: `device_rpc_${randomUUID()}`,
+          grant_id: grant.grantId,
+          session_key: grant.sessionKey,
+          topic_id: grant.topicId,
+          topic_type: grant.topicType,
+          actor_user_id: grant.actorUserId,
+          agent_id: grant.agentId,
+          agent_body_id: grant.agentBodyId,
+          device_id: grant.deviceId,
+          device_body_id: grant.deviceBodyId,
+          device_installation_id: grant.deviceInstallationId,
+          operation,
+          tool_name: toolName,
+          payload: { args },
+          expires_at: grant.expiresAt,
+        }, timeoutMs);
+
+        if (response.error) {
+          return {
+            ok: false,
+            errorCode: this.mapDeviceRpcToolErrorCode(response.error.code),
+            message: response.error.message || response.error.code || '远程设备工具执行失败。',
+            retryable: this.isRetryableDeviceRpcError(response.error.code),
+          };
+        }
+        return normalizeDeviceRpcToolResultPayload(response.result);
+      },
+    };
+  }
+
   private async handleDeviceRpcRequest(request: CatsDeviceRpcMessage): Promise<void> {
     const requestID = request.request_id;
     if (!requestID) return;
 
-    const targetError = this.validateDeviceRpcTarget(request);
-    const isPing = request.operation === 'ping' || request.tool_name === 'ping';
-    const error = targetError || (isPing
+    const validationError = this.validateDeviceRpcToolRequest(request);
+    const result = validationError ? undefined : await this.executeLocalDeviceRpcTool(request);
+    const error = validationError || (!result || result.ok
       ? undefined
       : {
-          code: 'unsupported_operation',
-          message: 'CatsCo Device RPC transport is connected, but local tool execution is not enabled for this operation yet.',
+          code: result.errorCode || 'tool_execution_error',
+          message: result.message,
         });
 
     try {
@@ -252,7 +295,7 @@ export class CatsCompanyBot {
         device_installation_id: this.localDeviceGrant?.installationId || request.device_installation_id,
         operation: request.operation,
         tool_name: request.tool_name,
-        result: error ? undefined : { ok: true, pong: true },
+        result: error || !result ? undefined : normalizeDeviceRpcToolResultForTransport(result),
         error,
       });
     } catch (err: any) {
@@ -260,29 +303,196 @@ export class CatsCompanyBot {
     }
   }
 
-  private validateDeviceRpcTarget(request: CatsDeviceRpcMessage): { code: string; message: string } | undefined {
-    if (!this.localDeviceGrant) {
-      return { code: 'device_not_bound', message: 'Current runtime is not bound to a CatsCo local device.' };
+  private async executeLocalDeviceRpcTool(request: CatsDeviceRpcMessage): Promise<ToolExecutionResult> {
+    const operation = this.normalizeDeviceRpcReadonlyOperation(request.operation);
+    const toolName = String(request.tool_name || operation || '').trim();
+    if (!operation || !isRemoteReadonlyTool(toolName, operation)) {
+      return {
+        ok: false,
+        errorCode: 'PERMISSION_DENIED',
+        message: `Device RPC 不允许执行 ${toolName || request.operation || 'unknown'}。`,
+      };
+    }
+
+    const context = this.buildDeviceRpcToolContext(request, operation);
+    const args = this.extractDeviceRpcToolArgs(request.payload);
+    switch (operation) {
+      case 'read_file':
+        return new ReadTool().execute(args, context);
+      case 'glob':
+        return new GlobTool().execute(args, context);
+      case 'grep':
+        return new GrepTool().execute(args, context);
+      default:
+        return {
+          ok: false,
+          errorCode: 'PERMISSION_DENIED',
+          message: `Device RPC 不允许执行 ${operation}。`,
+        };
+    }
+  }
+
+  private buildDeviceRpcToolContext(
+    request: CatsDeviceRpcMessage,
+    operation: DeviceGrantOperation,
+  ): ToolExecutionContext {
+    const topicType = request.topic_type === 'group' || request.topic_type === 'p2p'
+      ? request.topic_type
+      : 'unknown';
+    const executionScope: ExecutionScope = {
+      source: 'catscompany',
+      sessionKey: String(request.session_key || ''),
+      topicId: String(request.topic_id || ''),
+      topicType,
+      actorUserId: String(request.actor_user_id || ''),
+      agentId: request.agent_id,
+      agentBodyId: request.agent_body_id,
+      permissionsSource: 'device_rpc_forward',
+      identityTrust: 'server_canonical',
+      isTrusted: true,
+    };
+    const now = Date.now();
+    const grant: ScopedDeviceGrant = {
+      kind: 'user_device_grant',
+      source: 'catscompany',
+      grantId: String(request.grant_id || ''),
+      status: 'active',
+      identityTrust: 'server_canonical',
+      identitySource: 'device_rpc_forward',
+      deviceId: String(request.device_id || this.localDeviceGrant?.deviceId || ''),
+      deviceBodyId: request.device_body_id || this.localDeviceGrant?.bodyId,
+      deviceInstallationId: request.device_installation_id || this.localDeviceGrant?.installationId,
+      ownerUserId: executionScope.actorUserId,
+      sessionKey: executionScope.sessionKey,
+      topicId: executionScope.topicId,
+      topicType,
+      actorUserId: executionScope.actorUserId,
+      agentId: executionScope.agentId,
+      agentBodyId: executionScope.agentBodyId,
+      operations: [operation],
+      createdAt: typeof request.created_at === 'number' ? request.created_at : now,
+      expiresAt: typeof request.expires_at === 'number' ? request.expires_at : now + DEVICE_RPC_DEFAULT_TTL_MS,
+    };
+    const deviceSelection: ScopedDeviceSelection = {
+      kind: 'user_device_selection',
+      source: 'catscompany',
+      status: 'selected',
+      selectionSource: 'device_rpc_forward',
+      sessionKey: executionScope.sessionKey,
+      topicId: executionScope.topicId,
+      topicType,
+      actorUserId: executionScope.actorUserId,
+      agentId: executionScope.agentId,
+      identityTrust: 'server_canonical',
+      identitySource: 'device_rpc_forward',
+      selectedDeviceId: grant.deviceId,
+      selectedDeviceBodyId: grant.deviceBodyId,
+      selectedDeviceInstallationId: grant.deviceInstallationId,
+      selectedDeviceOperations: [operation],
+      createdAt: now,
+    };
+    const workingDirectory = process.cwd();
+    return {
+      workingDirectory,
+      workspaceRoot: workingDirectory,
+      conversationHistory: [],
+      sessionId: executionScope.sessionKey,
+      surface: 'catscompany',
+      permissionProfile: 'strict',
+      executionScope,
+      localDeviceGrant: this.localDeviceGrant,
+      deviceGrants: [grant],
+      deviceSelection,
+    };
+  }
+
+  private validateDeviceRpcToolRequest(request: CatsDeviceRpcMessage): { code: string; message: string } | undefined {
+    const targetError = this.validateDeviceRpcTarget(request);
+    if (targetError) return targetError;
+
+    const operation = this.normalizeDeviceRpcReadonlyOperation(request.operation);
+    const toolName = String(request.tool_name || operation || '').trim();
+    if (!operation || !isRemoteReadonlyTool(toolName, operation)) {
+      return { code: 'unsupported_operation', message: 'Device RPC only allows read_file, glob, and grep.' };
+    }
+
+    const requiredFields: Array<[keyof CatsDeviceRpcMessage, string]> = [
+      ['grant_id', 'grant_id'],
+      ['session_key', 'session_key'],
+      ['topic_id', 'topic_id'],
+      ['topic_type', 'topic_type'],
+      ['actor_user_id', 'actor_user_id'],
+      ['device_id', 'device_id'],
+    ];
+    for (const [field, label] of requiredFields) {
+      if (!String(request[field] || '').trim()) {
+        return { code: 'invalid_request', message: `Device RPC request missing ${label}.` };
+      }
     }
     if (typeof request.expires_at === 'number' && Date.now() > request.expires_at) {
       return { code: 'request_expired', message: 'Device RPC request has expired.' };
     }
-    if (request.device_id && this.localDeviceGrant.deviceId) {
-      return request.device_id === this.localDeviceGrant.deviceId
-        ? undefined
-        : { code: 'target_device_mismatch', message: 'Device RPC target device_id does not match this local runtime.' };
+    return undefined;
+  }
+
+  private normalizeDeviceRpcReadonlyOperation(value: unknown): DeviceGrantOperation | undefined {
+    const operation = String(value || '').trim();
+    if (operation === 'read_file' || operation === 'glob' || operation === 'grep') {
+      return operation;
     }
-    if (request.device_installation_id && this.localDeviceGrant.installationId) {
-      return request.device_installation_id === this.localDeviceGrant.installationId
-        ? undefined
-        : { code: 'target_device_mismatch', message: 'Device RPC target installation_id does not match this local runtime.' };
+    return undefined;
+  }
+
+  private extractDeviceRpcToolArgs(payload: unknown): Record<string, unknown> {
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return {};
+    const record = payload as Record<string, unknown>;
+    if (record.args && typeof record.args === 'object' && !Array.isArray(record.args)) {
+      return { ...(record.args as Record<string, unknown>) };
     }
-    if (request.device_body_id) {
-      return request.device_body_id === this.localDeviceGrant.bodyId
-        ? undefined
-        : { code: 'target_device_mismatch', message: 'Device RPC target body_id does not match this local runtime.' };
+    return { ...record };
+  }
+
+  private mapDeviceRpcToolErrorCode(code: unknown): ToolErrorCode {
+    const text = String(code || '').toLowerCase();
+    if (text.includes('permission') || text.includes('forbidden') || text.includes('mismatch') || text.includes('unsupported')) {
+      return 'PERMISSION_DENIED';
     }
-    return { code: 'target_device_mismatch', message: 'Device RPC target does not match this local runtime.' };
+    if (text.includes('timeout') || text.includes('expired')) {
+      return 'EXECUTION_TIMEOUT';
+    }
+    if (text.includes('not_found') || text.includes('offline') || text.includes('unavailable')) {
+      return 'TOOL_EXECUTION_ERROR';
+    }
+    return 'TOOL_EXECUTION_ERROR';
+  }
+
+  private isRetryableDeviceRpcError(code: unknown): boolean {
+    const text = String(code || '').toLowerCase();
+    return text.includes('timeout') || text.includes('offline') || text.includes('unavailable');
+  }
+
+  private validateDeviceRpcTarget(request: CatsDeviceRpcMessage): { code: string; message: string } | undefined {
+    if (!this.localDeviceGrant) {
+      return { code: 'device_not_bound', message: 'Current runtime is not bound to a CatsCo local device.' };
+    }
+    const checks: Array<[unknown, unknown, string]> = [
+      [request.device_id, this.localDeviceGrant.deviceId, 'device_id'],
+      [request.device_installation_id, this.localDeviceGrant.installationId, 'installation_id'],
+      [request.device_body_id, this.localDeviceGrant.bodyId, 'body_id'],
+    ];
+    let matchedAny = false;
+    for (const [requested, local, label] of checks) {
+      const requestedText = String(requested || '').trim();
+      if (!requestedText) continue;
+      const localText = String(local || '').trim();
+      if (!localText || requestedText !== localText) {
+        return { code: 'target_device_mismatch', message: `Device RPC target ${label} does not match this local runtime.` };
+      }
+      matchedAny = true;
+    }
+    return matchedAny
+      ? undefined
+      : { code: 'target_device_mismatch', message: 'Device RPC target does not match this local runtime.' };
   }
 
   // ─── 构建 ChannelCallbacks ──────────────────────
@@ -559,6 +769,7 @@ export class CatsCompanyBot {
         localDeviceGrant: this.localDeviceGrant,
         deviceGrants: msg.deviceGrants,
         deviceSelection: msg.deviceSelection,
+        deviceRpc: this.buildDeviceRpcTransport(),
         localFileGrants,
         runtimeFeedback,
         pendingUserInputProvider: () => this.consumeQueuedUserInput(key, msg.executionScope),
@@ -726,6 +937,8 @@ export class CatsCompanyBot {
         callbacks: this.buildSessionCallbacks(topic),
         source: 'subagent_result',
         executionScope,
+        localDeviceGrant: this.localDeviceGrant,
+        deviceRpc: this.buildDeviceRpcTransport(),
       });
       if (result.text === BUSY_MESSAGE) {
         this.enqueueSubAgentFeedback(sessionKey, topic, senderId, text, executionScope);
@@ -931,6 +1144,7 @@ export class CatsCompanyBot {
           executionScope: msg.executionScope,
           localDeviceGrant: this.localDeviceGrant,
           deviceSelection: msg.deviceSelection,
+          deviceRpc: this.buildDeviceRpcTransport(),
         })
         : await session.handleMessage(msg.userMessage, {
           channel,
@@ -938,6 +1152,7 @@ export class CatsCompanyBot {
           localDeviceGrant: this.localDeviceGrant,
           deviceGrants: msg.deviceGrants,
           deviceSelection: msg.deviceSelection,
+          deviceRpc: this.buildDeviceRpcTransport(),
           runtimeFeedback: msg.runtimeFeedback,
           localFileGrants: msg.localFileGrants,
           pendingUserInputProvider: () => this.consumeQueuedUserInput(sessionKey, msg.executionScope),

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -1,4 +1,4 @@
-import { CatsClient, MessageContext } from './client';
+import { CatsClient, MessageContext, type CatsDeviceRpcMessage } from './client';
 import { CatsCompanyConfig, ParsedCatsMessage, CatsFileInfo } from './types';
 import { MessageSender } from './message-sender';
 import { extractContentBlocks } from './content-blocks';
@@ -116,11 +116,24 @@ export class CatsCompanyBot {
   };
 
   constructor(config: CatsCompanyConfig) {
+    const localDeviceId = config.installationId || config.bodyId;
+    const deviceRegistration = localDeviceId
+      ? {
+          device_id: localDeviceId,
+          display_name: config.deviceName || process.env.COMPUTERNAME || process.env.HOSTNAME || hostname() || localDeviceId,
+          body_id: config.bodyId,
+          installation_id: config.installationId || config.bodyId,
+          status: 'online' as const,
+          capabilities: ['read_file', 'send_file', 'glob', 'grep'],
+        }
+      : undefined;
+
     this.bot = new CatsClient({
       serverUrl: config.serverUrl,
       apiKey: config.apiKey,
       bodyId: config.bodyId,
       installationId: config.installationId,
+      deviceRegistration,
       httpBaseUrl: config.httpBaseUrl,
     });
 
@@ -130,17 +143,7 @@ export class CatsCompanyBot {
       installationId: config.installationId,
       deviceId: config.installationId || config.bodyId,
     });
-    if (config.bodyId || config.installationId) {
-      const deviceId = config.installationId || config.bodyId!;
-      this.deviceRegistration = {
-        device_id: deviceId,
-        display_name: config.deviceName || process.env.COMPUTERNAME || process.env.HOSTNAME || hostname() || deviceId,
-        body_id: config.bodyId,
-        installation_id: config.installationId || config.bodyId,
-        status: 'online',
-        capabilities: ['read_file', 'send_file', 'glob', 'grep'],
-      };
-    }
+    this.deviceRegistration = deviceRegistration;
 
     const runtime = createCatsCompanyRuntime(config.sessionTTL);
     this.runtime = runtime;
@@ -186,6 +189,10 @@ export class CatsCompanyBot {
       await this.onMessage(ctx);
     });
 
+    this.bot.on('device_rpc_request', async (request: CatsDeviceRpcMessage) => {
+      await this.handleDeviceRpcRequest(request);
+    });
+
     this.bot.on('error', (err: Error) => {
       Logger.error(`CatsCo 连接错误: ${err.message}`);
     });
@@ -215,6 +222,67 @@ export class CatsCompanyBot {
     if (!this.deviceRegistrationTimer) return;
     clearInterval(this.deviceRegistrationTimer);
     this.deviceRegistrationTimer = undefined;
+  }
+
+  private async handleDeviceRpcRequest(request: CatsDeviceRpcMessage): Promise<void> {
+    const requestID = request.request_id;
+    if (!requestID) return;
+
+    const targetError = this.validateDeviceRpcTarget(request);
+    const isPing = request.operation === 'ping' || request.tool_name === 'ping';
+    const error = targetError || (isPing
+      ? undefined
+      : {
+          code: 'unsupported_operation',
+          message: 'CatsCo Device RPC transport is connected, but local tool execution is not enabled for this operation yet.',
+        });
+
+    try {
+      await this.bot.sendDeviceRpcResult({
+        request_id: requestID,
+        grant_id: request.grant_id,
+        session_key: request.session_key,
+        topic_id: request.topic_id,
+        topic_type: request.topic_type,
+        actor_user_id: request.actor_user_id,
+        agent_id: request.agent_id,
+        agent_body_id: request.agent_body_id,
+        device_id: this.localDeviceGrant?.deviceId || request.device_id,
+        device_body_id: this.localDeviceGrant?.bodyId || request.device_body_id,
+        device_installation_id: this.localDeviceGrant?.installationId || request.device_installation_id,
+        operation: request.operation,
+        tool_name: request.tool_name,
+        result: error ? undefined : { ok: true, pong: true },
+        error,
+      });
+    } catch (err: any) {
+      Logger.warning(`[CatsCompany] Device RPC result 发送失败: request=${requestID}, error=${err?.message || err}`);
+    }
+  }
+
+  private validateDeviceRpcTarget(request: CatsDeviceRpcMessage): { code: string; message: string } | undefined {
+    if (!this.localDeviceGrant) {
+      return { code: 'device_not_bound', message: 'Current runtime is not bound to a CatsCo local device.' };
+    }
+    if (typeof request.expires_at === 'number' && Date.now() > request.expires_at) {
+      return { code: 'request_expired', message: 'Device RPC request has expired.' };
+    }
+    if (request.device_id && this.localDeviceGrant.deviceId) {
+      return request.device_id === this.localDeviceGrant.deviceId
+        ? undefined
+        : { code: 'target_device_mismatch', message: 'Device RPC target device_id does not match this local runtime.' };
+    }
+    if (request.device_installation_id && this.localDeviceGrant.installationId) {
+      return request.device_installation_id === this.localDeviceGrant.installationId
+        ? undefined
+        : { code: 'target_device_mismatch', message: 'Device RPC target installation_id does not match this local runtime.' };
+    }
+    if (request.device_body_id) {
+      return request.device_body_id === this.localDeviceGrant.bodyId
+        ? undefined
+        : { code: 'target_device_mismatch', message: 'Device RPC target body_id does not match this local runtime.' };
+    }
+    return { code: 'target_device_mismatch', message: 'Device RPC target does not match this local runtime.' };
   }
 
   // ─── 构建 ChannelCallbacks ──────────────────────

--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -12,7 +12,7 @@ import * as path from 'path';
 import { AIService } from '../utils/ai-service';
 import { ToolManager } from '../tools/tool-manager';
 import { SkillManager } from '../skills/skill-manager';
-import { ChannelCallbacks } from '../types/tool';
+import { ChannelCallbacks, DeviceRpcTransport } from '../types/tool';
 import {
   SessionSkillRuntime,
   SkillReloadHandler,
@@ -88,6 +88,8 @@ export interface HandleMessageOptions {
   deviceGrants?: ScopedDeviceGrant[];
   /** 服务端为当前 turn 选定的用户设备。 */
   deviceSelection?: ScopedDeviceSelection;
+  /** 当前 turn 可用的远程设备 RPC 通道。 */
+  deviceRpc?: DeviceRpcTransport;
   /** 当前 turn 已授权的本地文件资源。 */
   localFileGrants?: ScopedLocalFileGrant[];
   /** 当前 turn 专属、给 agent 可见的运行时反馈 */
@@ -395,6 +397,7 @@ export class AgentSession {
       let localDeviceGrant: ScopedLocalDeviceGrant | undefined;
       let deviceGrants: ScopedDeviceGrant[] | undefined;
       let deviceSelection: ScopedDeviceSelection | undefined;
+      let deviceRpc: DeviceRpcTransport | undefined;
       let localFileGrants: ScopedLocalFileGrant[] | undefined;
       let runtimeFeedbackInputs: RuntimeFeedbackInput[] = [];
       let pendingUserInputProvider: PendingUserInputProvider | undefined;
@@ -407,6 +410,7 @@ export class AgentSession {
           || 'localDeviceGrant' in callbacksOrOptions
           || 'deviceGrants' in callbacksOrOptions
           || 'deviceSelection' in callbacksOrOptions
+          || 'deviceRpc' in callbacksOrOptions
           || 'localFileGrants' in callbacksOrOptions
           || 'callbacks' in callbacksOrOptions
           || 'runtimeFeedback' in callbacksOrOptions
@@ -421,6 +425,7 @@ export class AgentSession {
           localDeviceGrant = opts.localDeviceGrant;
           deviceGrants = opts.deviceGrants;
           deviceSelection = opts.deviceSelection;
+          deviceRpc = opts.deviceRpc;
           localFileGrants = opts.localFileGrants;
           runtimeFeedbackInputs = opts.runtimeFeedback || [];
           pendingUserInputProvider = opts.pendingUserInputProvider;
@@ -468,6 +473,7 @@ export class AgentSession {
           localDeviceGrant,
           deviceGrants,
           deviceSelection,
+          deviceRpc,
           localFileGrants,
           pendingUserInputProvider,
           abortSignal: this.activeAbortController.signal,

--- a/src/core/agent-turn-controller.ts
+++ b/src/core/agent-turn-controller.ts
@@ -7,7 +7,7 @@ import type {
   ScopedLocalFileGrant,
   SessionRoute,
 } from '../types/session-identity';
-import { ChannelCallbacks } from '../types/tool';
+import { ChannelCallbacks, DeviceRpcTransport } from '../types/tool';
 import { AIService } from '../utils/ai-service';
 import { ToolManager } from '../tools/tool-manager';
 import { SkillManager } from '../skills/skill-manager';
@@ -48,6 +48,7 @@ export interface RunAgentTurnParams {
   localDeviceGrant?: ScopedLocalDeviceGrant;
   deviceGrants?: ScopedDeviceGrant[];
   deviceSelection?: ScopedDeviceSelection;
+  deviceRpc?: DeviceRpcTransport;
   localFileGrants?: ScopedLocalFileGrant[];
   pendingUserInputProvider?: PendingUserInputProvider;
   abortSignal?: AbortSignal;
@@ -116,6 +117,7 @@ export class AgentTurnController {
       localDeviceGrant: params.localDeviceGrant,
       deviceGrants: params.deviceGrants,
       deviceSelection: params.deviceSelection,
+      deviceRpc: params.deviceRpc,
       localFileGrants: params.localFileGrants,
       pendingUserInputProvider: params.pendingUserInputProvider,
       abortSignal: params.abortSignal,
@@ -167,6 +169,7 @@ export class AgentTurnController {
     localDeviceGrant?: ScopedLocalDeviceGrant;
     deviceGrants?: ScopedDeviceGrant[];
     deviceSelection?: ScopedDeviceSelection;
+    deviceRpc?: DeviceRpcTransport;
     localFileGrants?: ScopedLocalFileGrant[];
     pendingUserInputProvider?: PendingUserInputProvider;
     abortSignal?: AbortSignal;
@@ -201,6 +204,7 @@ export class AgentTurnController {
           localDeviceGrant: options.localDeviceGrant,
           deviceGrants: options.deviceGrants,
           deviceSelection: options.deviceSelection,
+          deviceRpc: options.deviceRpc,
           localFileGrants: options.localFileGrants,
         },
       },

--- a/src/tools/device-rpc-tool.ts
+++ b/src/tools/device-rpc-tool.ts
@@ -1,0 +1,167 @@
+import type { DeviceGrantOperation } from '../types/session-identity';
+import type { ToolErrorCode, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
+import type { ToolGatewayDecision } from './tool-gateway';
+
+const REMOTE_TOOL_TIMEOUT_MS = 60_000;
+export const MAX_DEVICE_RPC_TOOL_CONTENT_CHARS = 48_000;
+
+export function isRemoteReadonlyTool(toolName: string, operation: DeviceGrantOperation): boolean {
+  return (toolName === 'read_file' && operation === 'read_file')
+    || (toolName === 'glob' && operation === 'glob')
+    || (toolName === 'grep' && operation === 'grep');
+}
+
+export async function executeRemoteReadonlyTool(
+  context: ToolExecutionContext,
+  gateway: ToolGatewayDecision,
+  toolName: 'read_file' | 'glob' | 'grep',
+  operation: DeviceGrantOperation,
+  args: Record<string, unknown>,
+): Promise<ToolExecutionResult | undefined> {
+  if (!gateway.ok || gateway.mode !== 'remote') return undefined;
+
+  if (!isRemoteReadonlyTool(toolName, operation)) {
+    return {
+      ok: false,
+      errorCode: 'PERMISSION_DENIED',
+      message: `远程设备 RPC 当前只允许 read_file / glob / grep，已阻止 ${toolName}。`,
+    };
+  }
+
+  if (!context.deviceRpc) {
+    return {
+      ok: false,
+      errorCode: 'PERMISSION_DENIED',
+      message: '后端选定的设备不是当前运行体，但当前上下文没有远程设备 RPC 通道。',
+    };
+  }
+
+  try {
+    return await context.deviceRpc.executeTool({
+      toolName,
+      operation,
+      args,
+      grant: gateway.grant,
+      timeoutMs: timeoutForGrant(gateway.grant.expiresAt),
+    });
+  } catch (error: any) {
+    return {
+      ok: false,
+      errorCode: mapRpcErrorCode(error),
+      message: `远程设备工具执行失败: ${error?.message || error || 'unknown error'}`,
+      retryable: isRetryableRpcError(error),
+    };
+  }
+}
+
+export function normalizeDeviceRpcToolResultPayload(payload: unknown): ToolExecutionResult {
+  if (!payload || typeof payload !== 'object') {
+    return {
+      ok: false,
+      errorCode: 'TOOL_EXECUTION_ERROR',
+      message: '远程设备返回了无效工具结果。',
+    };
+  }
+  const record = payload as Record<string, unknown>;
+  if (record.ok === true) {
+    return {
+      ok: true,
+      content: normalizeDeviceRpcContent(record.content),
+    };
+  }
+  if (record.ok === false) {
+    return {
+      ok: false,
+      errorCode: normalizeErrorCode(record.errorCode),
+      message: truncateText(String(record.message || '远程设备工具执行失败。')),
+      retryable: Boolean(record.retryable),
+    };
+  }
+  return {
+    ok: false,
+    errorCode: 'TOOL_EXECUTION_ERROR',
+    message: '远程设备返回的工具结果缺少 ok 字段。',
+  };
+}
+
+export function normalizeDeviceRpcToolResultForTransport(result: ToolExecutionResult): ToolExecutionResult {
+  if (!result.ok) {
+    return {
+      ok: false,
+      errorCode: normalizeErrorCode(result.errorCode),
+      message: truncateText(result.message),
+      retryable: Boolean(result.retryable),
+    };
+  }
+  return {
+    ok: true,
+    content: normalizeDeviceRpcContent(result.content),
+  };
+}
+
+function timeoutForGrant(expiresAt: number): number {
+  const remaining = expiresAt - Date.now();
+  if (!Number.isFinite(remaining) || remaining <= 0) return 10_000;
+  return Math.max(5_000, Math.min(REMOTE_TOOL_TIMEOUT_MS, remaining));
+}
+
+function normalizeDeviceRpcContent(content: unknown): string {
+  if (typeof content === 'string') return truncateText(content);
+  if (Array.isArray(content)) {
+    const lines: string[] = [];
+    for (const block of content) {
+      if (!block || typeof block !== 'object') continue;
+      const record = block as Record<string, unknown>;
+      if (record.type === 'text' && typeof record.text === 'string') {
+        lines.push(record.text);
+      } else if (record.type === 'image') {
+        lines.push('[远程设备返回了图片内容块；当前 Device RPC 不转发图片二进制，请让用户以附件方式上传该图片。]');
+      }
+    }
+    return truncateText(lines.join('\n'));
+  }
+  if (content && typeof content === 'object') {
+    const record = content as Record<string, unknown>;
+    if (record._imageForNewMessage) {
+      return '[远程设备读取到图片文件；当前 Device RPC 不转发图片二进制，请让用户以附件方式上传该图片。]';
+    }
+  }
+  return truncateText(String(content ?? ''));
+}
+
+function truncateText(value: string): string {
+  if (value.length <= MAX_DEVICE_RPC_TOOL_CONTENT_CHARS) return value;
+  return [
+    value.slice(0, MAX_DEVICE_RPC_TOOL_CONTENT_CHARS),
+    '',
+    `[远程设备结果超过 ${MAX_DEVICE_RPC_TOOL_CONTENT_CHARS} 字符，已截断。请用更精确的 path/pattern/limit/offset 继续读取。]`,
+  ].join('\n');
+}
+
+function normalizeErrorCode(value: unknown): ToolErrorCode {
+  const text = String(value || '').trim();
+  if (
+    text === 'TOOL_NOT_FOUND'
+    || text === 'INVALID_TOOL_ARGUMENTS'
+    || text === 'TOOL_EXECUTION_ERROR'
+    || text === 'RATE_LIMIT'
+    || text === 'PERMISSION_DENIED'
+    || text === 'FILE_NOT_FOUND'
+    || text === 'EXECUTION_TIMEOUT'
+  ) {
+    return text;
+  }
+  return 'TOOL_EXECUTION_ERROR';
+}
+
+function mapRpcErrorCode(error: any): ToolErrorCode {
+  const text = String(error?.code || error?.kind || error?.message || '').toLowerCase();
+  if (text.includes('timeout')) return 'EXECUTION_TIMEOUT';
+  if (text.includes('permission') || text.includes('forbidden') || text.includes('denied')) return 'PERMISSION_DENIED';
+  return 'TOOL_EXECUTION_ERROR';
+}
+
+function isRetryableRpcError(error: any): boolean {
+  const text = String(error?.code || error?.kind || error?.message || '').toLowerCase();
+  return text.includes('timeout') || text.includes('offline') || text.includes('unavailable') || text.includes('transport');
+}

--- a/src/tools/glob-tool.ts
+++ b/src/tools/glob-tool.ts
@@ -4,6 +4,7 @@ import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from 
 import { glob } from 'glob';
 import { isReadPathAllowed } from '../utils/safety';
 import { formatCatsCoVisiblePath, isCatsCoToolGatewayContext, resolveToolGatewayAccess } from './tool-gateway';
+import { executeRemoteReadonlyTool } from './device-rpc-tool';
 
 interface GlobResult {
   numFiles: number;
@@ -44,6 +45,17 @@ export class GlobTool implements Tool {
     const { pattern, path: searchPath, limit = 100 } = args;
     const startTime = Date.now();
 
+    const gateway = resolveToolGatewayAccess(context, {
+      toolName: this.definition.name,
+      operation: 'glob',
+      targetLabel: searchPath || '.',
+    });
+    if (!gateway.ok) {
+      return { ok: false, errorCode: gateway.errorCode, message: gateway.message };
+    }
+    const remoteResult = await executeRemoteReadonlyTool(context, gateway, 'glob', 'glob', args);
+    if (remoteResult) return remoteResult;
+
     // 确定搜索目录
     const cwd = searchPath
       ? (path.isAbsolute(searchPath) ? searchPath : path.join(context.workingDirectory, searchPath))
@@ -54,14 +66,6 @@ export class GlobTool implements Tool {
       return { ok: false, errorCode: 'PERMISSION_DENIED', message: `执行被阻止: ${pathPermission.reason}` };
     }
 
-    const gateway = resolveToolGatewayAccess(context, {
-      toolName: this.definition.name,
-      operation: 'glob',
-      targetLabel: searchPath || '.',
-    });
-    if (!gateway.ok) {
-      return { ok: false, errorCode: gateway.errorCode, message: gateway.message };
-    }
     const visibleSearchPath = formatCatsCoVisiblePath(context, searchPath || '.', { preserveRelative: true });
     const visibleCwd = formatCatsCoVisiblePath(context, cwd);
 

--- a/src/tools/grep-tool.ts
+++ b/src/tools/grep-tool.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs';
 import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import { isReadPathAllowed } from '../utils/safety';
 import { formatCatsCoVisiblePath, redactCatsCoVisiblePath, resolveToolGatewayAccess } from './tool-gateway';
+import { executeRemoteReadonlyTool } from './device-rpc-tool';
 
 const VCS_DIRECTORIES_TO_EXCLUDE = ['.git', '.svn', '.hg', '.bzr'] as const;
 const DEFAULT_LIMIT = 250;
@@ -101,15 +102,6 @@ export class GrepTool implements Tool {
   async execute(args: any, context: ToolExecutionContext): Promise<ToolExecutionResult> {
     const { pattern, path: searchPath } = args;
 
-    const resolvedSearchPath = searchPath
-      ? (path.isAbsolute(searchPath) ? searchPath : path.join(context.workingDirectory, searchPath))
-      : context.workingDirectory;
-
-    const pathPermission = isReadPathAllowed(resolvedSearchPath, context.workingDirectory);
-    if (!pathPermission.allowed) {
-      return { ok: false, errorCode: 'PERMISSION_DENIED', message: `执行被阻止: ${pathPermission.reason}` };
-    }
-
     const gateway = resolveToolGatewayAccess(context, {
       toolName: this.definition.name,
       operation: 'grep',
@@ -117,6 +109,17 @@ export class GrepTool implements Tool {
     });
     if (!gateway.ok) {
       return { ok: false, errorCode: gateway.errorCode, message: gateway.message };
+    }
+    const remoteResult = await executeRemoteReadonlyTool(context, gateway, 'grep', 'grep', args);
+    if (remoteResult) return remoteResult;
+
+    const resolvedSearchPath = searchPath
+      ? (path.isAbsolute(searchPath) ? searchPath : path.join(context.workingDirectory, searchPath))
+      : context.workingDirectory;
+
+    const pathPermission = isReadPathAllowed(resolvedSearchPath, context.workingDirectory);
+    if (!pathPermission.allowed) {
+      return { ok: false, errorCode: 'PERMISSION_DENIED', message: `执行被阻止: ${pathPermission.reason}` };
     }
     const visibleSearchPath = formatCatsCoVisiblePath(context, searchPath || '.', { preserveRelative: true });
 

--- a/src/tools/read-tool.ts
+++ b/src/tools/read-tool.ts
@@ -9,6 +9,7 @@ import { isPrimaryModelVisionCapable } from '../utils/model-capabilities';
 import { analyzeImageWithReaderProxy, ReaderProxyResult } from '../utils/reader-proxy';
 import { resolveLocalFileAccess, resolveLocalFileReference } from './local-file-gateway';
 import { formatCatsCoVisiblePath, resolveToolGatewayAccess } from './tool-gateway';
+import { executeRemoteReadonlyTool } from './device-rpc-tool';
 
 export const DEFAULT_TEXT_READ_LIMIT = 200;
 export const MAX_TEXT_READ_LIMIT = 2000;
@@ -120,11 +121,6 @@ export class ReadTool implements Tool {
         ? file_path
         : path.join(context.workingDirectory, file_path);
       visiblePath = absolutePath;
-
-      const pathPermission = isReadPathAllowed(absolutePath, context.workingDirectory);
-      if (!pathPermission.allowed) {
-        return { ok: false, errorCode: 'PERMISSION_DENIED', message: `执行被阻止: ${pathPermission.reason}` };
-      }
     }
 
     if (!resolvedFromAttachmentRef) {
@@ -159,6 +155,13 @@ export class ReadTool implements Tool {
           errorCode: gateway.errorCode,
           message: gateway.message,
         };
+      }
+      const remoteResult = await executeRemoteReadonlyTool(context, gateway, 'read_file', 'read_file', args);
+      if (remoteResult) return remoteResult;
+
+      const pathPermission = isReadPathAllowed(absolutePath, context.workingDirectory);
+      if (!pathPermission.allowed) {
+        return { ok: false, errorCode: 'PERMISSION_DENIED', message: `执行被阻止: ${pathPermission.reason}` };
       }
       displayPath = formatCatsCoVisiblePath(context, displayPath, { preserveRelative: true });
       visiblePath = formatCatsCoVisiblePath(context, visiblePath);

--- a/src/tools/tool-gateway.ts
+++ b/src/tools/tool-gateway.ts
@@ -3,7 +3,22 @@ import type { ToolErrorCode, ToolExecutionContext } from '../types/tool';
 import { resolveDeviceGrant } from '../core/device-grants';
 
 export type ToolGatewayDecision =
-  | { ok: true; grant?: ScopedDeviceGrant }
+  | {
+      ok: true;
+      mode: 'local';
+      grant?: ScopedDeviceGrant;
+      targetDeviceId?: string;
+      targetDeviceDisplayName?: string;
+    }
+  | {
+      ok: true;
+      mode: 'remote';
+      grant: ScopedDeviceGrant;
+      targetDeviceId: string;
+      targetDeviceDisplayName?: string;
+      targetDeviceBodyId?: string;
+      targetDeviceInstallationId?: string;
+    }
   | { ok: false; errorCode: ToolErrorCode; message: string };
 
 export interface ResolveToolGatewayAccessOptions {
@@ -17,6 +32,8 @@ export interface CatsCoVisiblePathOptions {
   fallback?: string;
   preserveRelative?: boolean;
 }
+
+const REMOTE_READONLY_OPERATIONS = new Set<DeviceGrantOperation>(['read_file', 'glob', 'grep']);
 
 export function isCatsCoToolGatewayContext(context: ToolExecutionContext): boolean {
   return context.surface === 'catscompany' || context.executionScope?.source === 'catscompany';
@@ -56,7 +73,7 @@ export function resolveToolGatewayAccess(
   options: ResolveToolGatewayAccessOptions,
 ): ToolGatewayDecision {
   if (!isCatsCoToolGatewayContext(context)) {
-    return { ok: true };
+    return { ok: true, mode: 'local' };
   }
 
   if (options.operation === 'execute_shell' && !options.allowCatsCoShell) {
@@ -80,7 +97,15 @@ export function resolveToolGatewayAccess(
     return denied(['当前运行体缺少 CatsCo 本机设备绑定，已阻止本地设备操作。'], options.targetLabel);
   }
 
-  const selectedTarget = resolveBackendSelectedDevice(context.deviceSelection, localDevice, options.targetLabel);
+  const selectionScope = validateSelectionScope(context.deviceSelection, scope, options.targetLabel);
+  if (!selectionScope.ok) return selectionScope;
+
+  const selectedTarget = resolveBackendSelectedDevice(
+    context.deviceSelection,
+    localDevice,
+    options.operation,
+    options.targetLabel,
+  );
   if (!selectedTarget.ok) return selectedTarget;
 
   const targetDeviceId = selectedTarget.deviceId || localDevice.deviceId || localDevice.installationId || localDevice.bodyId;
@@ -96,6 +121,31 @@ export function resolveToolGatewayAccess(
   }
 
   const grant = decision.grant;
+  if (selectedTarget.mode === 'remote') {
+    if (!REMOTE_READONLY_OPERATIONS.has(options.operation)) {
+      return denied([
+        `后端选定的用户设备不是当前运行体，但 ${options.operation} 还没有开放远程执行。`,
+        '当前 PR 只开放 read_file / glob / grep 三个只读远程工具。',
+      ], options.targetLabel);
+    }
+    if (!context.deviceRpc) {
+      return denied([
+        '后端选定的用户设备不是当前运行体，且当前运行体没有配置远程设备 RPC 通道。',
+        '已阻止本地 fallback，避免误操作当前设备或串设备。',
+        selectedTarget.displayName ? `Selected device: ${selectedTarget.displayName}` : '',
+      ], options.targetLabel);
+    }
+    return {
+      ok: true,
+      mode: 'remote',
+      grant,
+      targetDeviceId: selectedTarget.deviceId,
+      targetDeviceDisplayName: selectedTarget.displayName,
+      targetDeviceBodyId: selectedTarget.bodyId,
+      targetDeviceInstallationId: selectedTarget.installationId,
+    };
+  }
+
   const mismatches: string[] = [];
   if (grant.deviceBodyId && localDevice.bodyId && grant.deviceBodyId !== localDevice.bodyId) {
     mismatches.push('device body');
@@ -110,28 +160,54 @@ export function resolveToolGatewayAccess(
     ], options.targetLabel);
   }
 
-  return { ok: true, grant };
+  return {
+    ok: true,
+    mode: 'local',
+    grant,
+    targetDeviceId,
+    targetDeviceDisplayName: selectedTarget.displayName,
+  };
 }
 
 type SelectedDeviceDecision =
-  | { ok: true; deviceId?: string }
+  | {
+      ok: true;
+      mode: 'local';
+      deviceId?: string;
+      displayName?: string;
+    }
+  | {
+      ok: true;
+      mode: 'remote';
+      deviceId: string;
+      displayName?: string;
+      bodyId?: string;
+      installationId?: string;
+    }
   | { ok: false; errorCode: ToolErrorCode; message: string };
 
 function resolveBackendSelectedDevice(
   selection: ScopedDeviceSelection | undefined,
   localDevice: ScopedLocalDeviceGrant,
+  operation: DeviceGrantOperation,
   targetLabel?: string,
 ): SelectedDeviceDecision {
-  if (!selection) return { ok: true };
+  if (!selection) {
+    return {
+      ok: true,
+      mode: 'local',
+      deviceId: localDevice.deviceId || localDevice.installationId || localDevice.bodyId,
+    };
+  }
 
   if (selection.status === 'needs_selection') {
-    return denied([
+    return selectedDenied([
       '后端尚未选定要操作的用户设备，已阻止本地设备操作。',
       '请让用户从可用设备中选择一个设备名后再继续。',
     ], targetLabel);
   }
   if (selection.status === 'unavailable') {
-    return denied([
+    return selectedDenied([
       '当前用户没有可用的在线设备授权，已阻止本地设备操作。',
       '请让用户打开并授权目标设备后再继续。',
     ], targetLabel);
@@ -139,17 +215,63 @@ function resolveBackendSelectedDevice(
 
   const selectedDeviceId = selection.selectedDeviceId;
   if (!selectedDeviceId) {
-    return denied(['后端设备选择缺少 selectedDeviceId，已阻止本地设备操作。'], targetLabel);
+    return selectedDenied(['后端设备选择缺少 selectedDeviceId，已阻止本地设备操作。'], targetLabel);
   }
 
-  if (!matchesLocalDevice(selection, localDevice)) {
-    return denied([
-      '后端选定的用户设备不是当前运行体，已阻止本地设备操作以避免串设备。',
+  if (Array.isArray(selection.selectedDeviceOperations)
+    && selection.selectedDeviceOperations.length > 0
+    && !selection.selectedDeviceOperations.includes(operation)) {
+    return selectedDenied([
+      `后端选定设备没有声明支持 ${operation}，已阻止设备工具调用。`,
       selection.selectedDeviceDisplayName ? `Selected device: ${selection.selectedDeviceDisplayName}` : '',
     ], targetLabel);
   }
 
-  return { ok: true, deviceId: selectedDeviceId };
+  if (matchesLocalDevice(selection, localDevice)) {
+    return {
+      ok: true,
+      mode: 'local',
+      deviceId: selectedDeviceId,
+      displayName: selection.selectedDeviceDisplayName,
+    };
+  }
+
+  return {
+    ok: true,
+    mode: 'remote',
+    deviceId: selectedDeviceId,
+    displayName: selection.selectedDeviceDisplayName,
+    bodyId: selection.selectedDeviceBodyId,
+    installationId: selection.selectedDeviceInstallationId,
+  };
+}
+
+function selectedDenied(lines: string[], targetLabel?: string): SelectedDeviceDecision {
+  return denied(lines, targetLabel) as Extract<SelectedDeviceDecision, { ok: false }>;
+}
+
+function validateSelectionScope(
+  selection: ScopedDeviceSelection | undefined,
+  scope: NonNullable<ToolExecutionContext['executionScope']>,
+  targetLabel?: string,
+): ToolGatewayDecision {
+  if (!selection) return { ok: true, mode: 'local' };
+  if (selection.identityTrust !== 'server_canonical') {
+    return denied(['后端设备选择不是服务端可信身份生成的，已阻止设备工具调用。'], targetLabel);
+  }
+  const mismatches = [
+    ['source', selection.source, scope.source],
+    ['sessionKey', selection.sessionKey, scope.sessionKey],
+    ['topicId', selection.topicId, scope.topicId],
+    ['topicType', selection.topicType, scope.topicType],
+    ['actorUserId', selection.actorUserId, scope.actorUserId],
+    ['agentId', selection.agentId, scope.agentId],
+  ].filter(([, selectionValue, scopeValue]) => selectionValue !== scopeValue);
+  if (mismatches.length === 0) return { ok: true, mode: 'local' };
+  return denied([
+    '后端设备选择与当前执行身份不一致，已阻止设备工具调用以避免串用户或串会话。',
+    ...mismatches.map(([field, selectionValue, scopeValue]) => `${field}: selection=${selectionValue || '(empty)'} scope=${scopeValue || '(empty)'}`),
+  ], targetLabel);
 }
 
 function matchesLocalDevice(selection: ScopedDeviceSelection, localDevice: ScopedLocalDeviceGrant): boolean {

--- a/src/types/tool.ts
+++ b/src/types/tool.ts
@@ -90,6 +90,18 @@ export type ToolExecutionResult =
   | { ok: true; content: string | import('./index').ContentBlock[] }
   | { ok: false; errorCode: string; message: string; retryable?: boolean };
 
+export interface DeviceRpcToolRequest {
+  toolName: string;
+  operation: ScopedDeviceGrant['operations'][number];
+  args: Record<string, unknown>;
+  grant: ScopedDeviceGrant;
+  timeoutMs?: number;
+}
+
+export interface DeviceRpcTransport {
+  executeTool(request: DeviceRpcToolRequest): Promise<ToolExecutionResult>;
+}
+
 export type ToolErrorCode =
   | 'TOOL_NOT_FOUND'
   | 'INVALID_TOOL_ARGUMENTS'
@@ -156,6 +168,8 @@ export interface ToolExecutionContext {
   deviceGrants?: ScopedDeviceGrant[];
   /** 服务端为当前 turn 选定的用户设备，或明确要求先选择设备。 */
   deviceSelection?: ScopedDeviceSelection;
+  /** CatsCo 远程设备 RPC 通道。工具只能通过窄接口请求后端选定设备执行。 */
+  deviceRpc?: DeviceRpcTransport;
   /** 当前 turn 已授权的本地文件资源，例如用户本轮上传的 CatsCo 附件缓存。 */
   localFileGrants?: ScopedLocalFileGrant[];
 }

--- a/tests/catscompany-client-body-id.test.ts
+++ b/tests/catscompany-client-body-id.test.ts
@@ -354,6 +354,73 @@ describe('CatsCompany client body identity', () => {
     client.disconnect();
   });
 
+  test('rejects device rpc results whose scope does not match the pending request', async () => {
+    const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    servers.push(server);
+    await new Promise<void>(resolve => server.once('listening', resolve));
+
+    server.once('connection', socket => {
+      socket.on('message', data => {
+        const msg = JSON.parse(data.toString());
+        if (msg.hi) {
+          socket.send(JSON.stringify({
+            ctrl: {
+              id: msg.hi.id,
+              code: 200,
+              params: {
+                build: 'catscompany',
+                ver: '0.1.0',
+                features: ['client_msg_id', 'device_rpc'],
+                uid: 'usr42',
+                name: 'Agent',
+              },
+            },
+          }));
+          return;
+        }
+        if (msg.device_rpc?.type === 'request') {
+          socket.send(JSON.stringify({ ctrl: { id: msg.device_rpc.id, code: 200, text: 'ok' } }));
+          socket.send(JSON.stringify({
+            device_rpc: {
+              type: 'result',
+              request_id: msg.device_rpc.request_id,
+              grant_id: 'wrong-grant',
+              device_id: msg.device_rpc.device_id,
+              operation: msg.device_rpc.operation,
+              tool_name: msg.device_rpc.tool_name,
+              result: { ok: true },
+            },
+          }));
+        }
+      });
+    });
+
+    const address = server.address() as AddressInfo;
+    const client = new CatsClient({
+      serverUrl: `ws://127.0.0.1:${address.port}`,
+      apiKey: 'cc-test-key',
+      bodyId: 'body-agent',
+      installationId: 'install-agent',
+    });
+    client.on('error', () => undefined);
+    await new Promise<void>(resolve => {
+      client.once('ready', () => resolve());
+      client.connect();
+    });
+
+    await assert.rejects(
+      () => client.sendDeviceRpcRequest({
+        request_id: 'rpc-scope-mismatch',
+        grant_id: 'grant-1',
+        device_id: 'install-test',
+        operation: 'read_file',
+        tool_name: 'read_file',
+      }),
+      /scope does not match/
+    );
+    client.disconnect();
+  });
+
   test('sends device rpc results with websocket ack', async () => {
     const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
     servers.push(server);

--- a/tests/catscompany-client-body-id.test.ts
+++ b/tests/catscompany-client-body-id.test.ts
@@ -3,7 +3,7 @@ import * as assert from 'node:assert';
 import { createServer, type Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { WebSocketServer } from 'ws';
-import { CatsClient } from '../src/catscompany/client';
+import { CatsClient, type CatsDeviceRpcMessage } from '../src/catscompany/client';
 
 describe('CatsCompany client body identity', () => {
   const servers: WebSocketServer[] = [];
@@ -83,6 +83,51 @@ describe('CatsCompany client body identity', () => {
     assert.throws(() => client.connect(), /bodyId missing/);
   });
 
+  test('includes local device registration in websocket hi', async () => {
+    const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    servers.push(server);
+    await new Promise<void>(resolve => server.once('listening', resolve));
+
+    const hiPromise = new Promise<any>(resolve => {
+      server.once('connection', socket => {
+        socket.once('message', data => {
+          resolve(JSON.parse(data.toString()));
+          socket.close();
+        });
+      });
+    });
+
+    const address = server.address() as AddressInfo;
+    const client = new CatsClient({
+      serverUrl: `ws://127.0.0.1:${address.port}`,
+      apiKey: 'cc-test-key',
+      bodyId: 'body-test',
+      installationId: 'install-test',
+      deviceRegistration: {
+        device_id: 'install-test',
+        display_name: 'Test Device',
+        body_id: 'body-test',
+        installation_id: 'install-test',
+        status: 'online',
+        capabilities: ['read_file'],
+      },
+    });
+    client.on('error', () => undefined);
+    client.connect();
+
+    const hi = await hiPromise;
+    client.disconnect();
+
+    assert.deepEqual(hi.hi.device, {
+      device_id: 'install-test',
+      display_name: 'Test Device',
+      body_id: 'body-test',
+      installation_id: 'install-test',
+      status: 'online',
+      capabilities: ['read_file'],
+    });
+  });
+
   test('registers device capabilities through CatsCompany HTTP API', async () => {
     const requestPromise = new Promise<{ url?: string; method?: string; headers: Record<string, string | string[] | undefined>; body: any }>((resolve, reject) => {
       const server = createServer((req, res) => {
@@ -131,5 +176,232 @@ describe('CatsCompany client body identity', () => {
       status: 'online',
       capabilities: ['read_file', 'send_file'],
     });
+  });
+
+  test('emits device rpc requests outside the regular message stream', async () => {
+    const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    servers.push(server);
+    await new Promise<void>(resolve => server.once('listening', resolve));
+
+    server.once('connection', socket => {
+      socket.once('message', () => {
+        socket.send(JSON.stringify({
+          device_rpc: {
+            type: 'request',
+            request_id: 'rpc-inbound-1',
+            grant_id: 'grant-1',
+            device_id: 'install-test',
+            operation: 'ping',
+          },
+        }));
+      });
+    });
+
+    const address = server.address() as AddressInfo;
+    const client = new CatsClient({
+      serverUrl: `ws://127.0.0.1:${address.port}`,
+      apiKey: 'cc-test-key',
+      bodyId: 'body-test',
+      installationId: 'install-test',
+    });
+    client.on('error', () => undefined);
+
+    let regularMessageSeen = false;
+    client.on('message', () => {
+      regularMessageSeen = true;
+    });
+    const requestPromise = new Promise<CatsDeviceRpcMessage>(resolve => {
+      client.once('device_rpc_request', resolve);
+    });
+
+    client.connect();
+    const request = await requestPromise;
+    client.disconnect();
+
+    assert.equal(request.request_id, 'rpc-inbound-1');
+    assert.equal(request.operation, 'ping');
+    assert.equal(regularMessageSeen, false);
+  });
+
+  test('sends device rpc requests and resolves matching results', async () => {
+    const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    servers.push(server);
+    await new Promise<void>(resolve => server.once('listening', resolve));
+
+    const requestPromise = new Promise<any>(resolve => {
+      server.once('connection', socket => {
+        socket.on('message', data => {
+          const msg = JSON.parse(data.toString());
+          if (msg.hi) {
+            socket.send(JSON.stringify({
+              ctrl: {
+                id: msg.hi.id,
+                code: 200,
+                params: {
+                  build: 'catscompany',
+                  ver: '0.1.0',
+                  features: ['client_msg_id', 'device_rpc'],
+                  uid: 'usr42',
+                  name: 'Agent',
+                },
+              },
+            }));
+            return;
+          }
+          if (msg.device_rpc?.type === 'request') {
+            resolve(msg.device_rpc);
+            socket.send(JSON.stringify({ ctrl: { id: msg.device_rpc.id, code: 200, text: 'ok' } }));
+            socket.send(JSON.stringify({
+              device_rpc: {
+                type: 'result',
+                request_id: msg.device_rpc.request_id,
+                result: { ok: true },
+              },
+            }));
+          }
+        });
+      });
+    });
+
+    const address = server.address() as AddressInfo;
+    const client = new CatsClient({
+      serverUrl: `ws://127.0.0.1:${address.port}`,
+      apiKey: 'cc-test-key',
+      bodyId: 'body-agent',
+      installationId: 'install-agent',
+    });
+    client.on('error', () => undefined);
+    await new Promise<void>(resolve => {
+      client.once('ready', () => resolve());
+      client.connect();
+    });
+
+    const result = await client.sendDeviceRpcRequest({
+      request_id: 'rpc-outbound-1',
+      grant_id: 'grant-1',
+      device_id: 'install-test',
+      operation: 'ping',
+      payload: { value: 1 },
+    });
+    const request = await requestPromise;
+    client.disconnect();
+
+    assert.equal(request.request_id, 'rpc-outbound-1');
+    assert.equal(request.grant_id, 'grant-1');
+    assert.equal(request.operation, 'ping');
+    assert.deepEqual(result.result, { ok: true });
+  });
+
+  test('rejects device rpc request when ack fails after an early result', async () => {
+    const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    servers.push(server);
+    await new Promise<void>(resolve => server.once('listening', resolve));
+
+    server.once('connection', socket => {
+      socket.on('message', data => {
+        const msg = JSON.parse(data.toString());
+        if (msg.hi) {
+          socket.send(JSON.stringify({
+            ctrl: {
+              id: msg.hi.id,
+              code: 200,
+              params: {
+                build: 'catscompany',
+                ver: '0.1.0',
+                features: ['client_msg_id', 'device_rpc'],
+                uid: 'usr42',
+                name: 'Agent',
+              },
+            },
+          }));
+          return;
+        }
+        if (msg.device_rpc?.type === 'request') {
+          socket.send(JSON.stringify({
+            device_rpc: {
+              type: 'result',
+              request_id: msg.device_rpc.request_id,
+              result: { ok: true },
+            },
+          }));
+          socket.send(JSON.stringify({ ctrl: { id: msg.device_rpc.id, code: 500, text: 'nack after result' } }));
+        }
+      });
+    });
+
+    const address = server.address() as AddressInfo;
+    const client = new CatsClient({
+      serverUrl: `ws://127.0.0.1:${address.port}`,
+      apiKey: 'cc-test-key',
+      bodyId: 'body-agent',
+      installationId: 'install-agent',
+    });
+    client.on('error', () => undefined);
+    await new Promise<void>(resolve => {
+      client.once('ready', () => resolve());
+      client.connect();
+    });
+
+    await assert.rejects(
+      () => client.sendDeviceRpcRequest({
+        request_id: 'rpc-early-result-nack',
+        grant_id: 'grant-1',
+        device_id: 'install-test',
+        operation: 'ping',
+      }),
+      /ack 500/
+    );
+    client.disconnect();
+  });
+
+  test('sends device rpc results with websocket ack', async () => {
+    const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    servers.push(server);
+    await new Promise<void>(resolve => server.once('listening', resolve));
+
+    const resultPromise = new Promise<any>(resolve => {
+      server.once('connection', socket => {
+        socket.on('message', data => {
+          const msg = JSON.parse(data.toString());
+          if (msg.hi) {
+            socket.send(JSON.stringify({
+              ctrl: {
+                id: msg.hi.id,
+                code: 200,
+                params: { build: 'catscompany', features: ['client_msg_id', 'device_rpc'], uid: 'usr7', name: 'Device' },
+              },
+            }));
+            return;
+          }
+          if (msg.device_rpc?.type === 'result') {
+            resolve(msg.device_rpc);
+            socket.send(JSON.stringify({ ctrl: { id: msg.device_rpc.id, code: 200, text: 'ok' } }));
+          }
+        });
+      });
+    });
+
+    const address = server.address() as AddressInfo;
+    const client = new CatsClient({
+      serverUrl: `ws://127.0.0.1:${address.port}`,
+      apiKey: 'cc-test-key',
+      bodyId: 'body-device',
+      installationId: 'install-device',
+    });
+    client.on('error', () => undefined);
+    await new Promise<void>(resolve => {
+      client.once('ready', () => resolve());
+      client.connect();
+    });
+
+    await client.sendDeviceRpcResult({
+      request_id: 'rpc-result-1',
+      result: { ok: true },
+    });
+    const result = await resultPromise;
+    client.disconnect();
+
+    assert.equal(result.request_id, 'rpc-result-1');
+    assert.deepEqual(result.result, { ok: true });
   });
 });

--- a/tests/catscompany-device-rpc-tools.test.ts
+++ b/tests/catscompany-device-rpc-tools.test.ts
@@ -1,0 +1,204 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import { CatsCompanyBot } from '../src/catscompany';
+import type { CatsDeviceRpcMessage } from '../src/catscompany/client';
+import type { ScopedDeviceGrant } from '../src/types/session-identity';
+
+function botWithDevice(captured: { result?: any }): any {
+  const bot = Object.create(CatsCompanyBot.prototype) as any;
+  bot.localDeviceGrant = {
+    kind: 'catscompany_body',
+    source: 'catscompany',
+    bodyId: 'body-device',
+    installationId: 'install-device',
+    deviceId: 'install-device',
+    createdAt: Date.now(),
+  };
+  bot.bot = {
+    sendDeviceRpcResult: async (result: any) => {
+      captured.result = result;
+    },
+  };
+  return bot;
+}
+
+function request(overrides: Partial<CatsDeviceRpcMessage> = {}): CatsDeviceRpcMessage {
+  return {
+    type: 'request',
+    request_id: 'rpc-read-1',
+    grant_id: 'grant-read-1',
+    session_key: 'session:v2:catscompany:p2p:p2p_7_43:agent:usr43',
+    topic_id: 'p2p_7_43',
+    topic_type: 'p2p',
+    actor_user_id: 'usr7',
+    agent_id: 'usr43',
+    agent_body_id: 'body-agent',
+    device_id: 'install-device',
+    device_body_id: 'body-device',
+    device_installation_id: 'install-device',
+    operation: 'read_file',
+    tool_name: 'read_file',
+    created_at: Date.now(),
+    expires_at: Date.now() + 60_000,
+    payload: {},
+    ...overrides,
+  };
+}
+
+function serverGrant(overrides: Partial<ScopedDeviceGrant> = {}): ScopedDeviceGrant {
+  return {
+    kind: 'user_device_grant',
+    source: 'catscompany',
+    grantId: 'grant-server-readonly',
+    status: 'active',
+    identityTrust: 'server_canonical',
+    identitySource: 'metadata.catsco_identity',
+    deviceId: 'install-remote',
+    deviceDisplayName: 'Remote Laptop',
+    deviceBodyId: 'body-remote',
+    deviceInstallationId: 'install-remote',
+    ownerUserId: 'usr7',
+    sessionKey: 'session:v2:catscompany:p2p:p2p_7_43:agent:usr43',
+    topicId: 'p2p_7_43',
+    topicType: 'p2p',
+    actorUserId: 'usr7',
+    agentId: 'usr43',
+    agentBodyId: 'body-agent',
+    operations: ['read_file', 'glob', 'grep'],
+    createdAt: Date.now(),
+    expiresAt: Date.now() + 60_000,
+    ...overrides,
+  };
+}
+
+describe('CatsCompany Device RPC readonly tools', () => {
+  test('maps CatsCo server grant fields into outbound readonly device_rpc requests', async () => {
+    const captured: Array<{ request: any; timeoutMs?: number }> = [];
+    const bot = Object.create(CatsCompanyBot.prototype) as any;
+    bot.bot = {
+      sendDeviceRpcRequest: async (requestPayload: any, timeoutMs?: number) => {
+        captured.push({ request: requestPayload, timeoutMs });
+        return {
+          type: 'result',
+          request_id: requestPayload.request_id,
+          grant_id: requestPayload.grant_id,
+          session_key: requestPayload.session_key,
+          topic_id: requestPayload.topic_id,
+          topic_type: requestPayload.topic_type,
+          actor_user_id: requestPayload.actor_user_id,
+          agent_id: requestPayload.agent_id,
+          agent_body_id: requestPayload.agent_body_id,
+          device_id: requestPayload.device_id,
+          device_body_id: requestPayload.device_body_id,
+          device_installation_id: requestPayload.device_installation_id,
+          operation: requestPayload.operation,
+          tool_name: requestPayload.tool_name,
+          result: { ok: true, content: `remote ${requestPayload.tool_name}` },
+        };
+      },
+    };
+
+    const transport = bot.buildDeviceRpcTransport();
+    const grant = serverGrant();
+    const read = await transport.executeTool({
+      toolName: 'read_file',
+      operation: 'read_file',
+      args: { file_path: 'catsco_attachment:quote.xlsx', limit: 20 },
+      grant,
+      timeoutMs: 12_345,
+    });
+    const glob = await transport.executeTool({
+      toolName: 'glob',
+      operation: 'glob',
+      args: { pattern: '**/*.xlsx', path: 'catsco_attachment:project' },
+      grant,
+    });
+    const grep = await transport.executeTool({
+      toolName: 'grep',
+      operation: 'grep',
+      args: { pattern: '合同', path: 'catsco_attachment:project', output_mode: 'files' },
+      grant,
+    });
+
+    assert.equal(read.ok, true);
+    assert.equal(glob.ok, true);
+    assert.equal(grep.ok, true);
+    assert.equal(read.ok ? read.content : '', 'remote read_file');
+    assert.equal(glob.ok ? glob.content : '', 'remote glob');
+    assert.equal(grep.ok ? grep.content : '', 'remote grep');
+    assert.deepEqual(captured.map(item => [item.request.tool_name, item.request.operation]), [
+      ['read_file', 'read_file'],
+      ['glob', 'glob'],
+      ['grep', 'grep'],
+    ]);
+
+    const first = captured[0].request;
+    assert.match(first.request_id, /^device_rpc_/);
+    assert.equal(first.grant_id, grant.grantId);
+    assert.equal(first.session_key, grant.sessionKey);
+    assert.equal(first.topic_id, grant.topicId);
+    assert.equal(first.topic_type, grant.topicType);
+    assert.equal(first.actor_user_id, grant.actorUserId);
+    assert.equal(first.agent_id, grant.agentId);
+    assert.equal(first.agent_body_id, grant.agentBodyId);
+    assert.equal(first.device_id, grant.deviceId);
+    assert.equal(first.device_body_id, grant.deviceBodyId);
+    assert.equal(first.device_installation_id, grant.deviceInstallationId);
+    assert.equal(first.expires_at, grant.expiresAt);
+    assert.deepEqual(first.payload, { args: { file_path: 'catsco_attachment:quote.xlsx', limit: 20 } });
+    assert.equal(captured[0].timeoutMs, 12_345);
+  });
+
+  test('executes read_file on the target local device and returns a normalized result', async () => {
+    const captured: { result?: any } = {};
+    const bot = botWithDevice(captured);
+    const tmpRoot = path.join(process.cwd(), 'tmp');
+    fs.mkdirSync(tmpRoot, { recursive: true });
+    const dir = fs.mkdtempSync(path.join(tmpRoot, 'device-rpc-read-'));
+    const filePath = path.join(dir, 'notes.txt');
+    fs.writeFileSync(filePath, 'hello from target device\n');
+
+    await bot.handleDeviceRpcRequest(request({
+      payload: { args: { file_path: filePath, limit: 5 } },
+    }));
+
+    assert.ok(captured.result);
+    assert.equal(captured.result.error, undefined);
+    assert.equal(captured.result.result.ok, true);
+    assert.match(String(captured.result.result.content), /hello from target device/);
+    assert.equal(captured.result.device_id, 'install-device');
+  });
+
+  test('rejects non-readonly Device RPC operations before local tool execution', async () => {
+    const captured: { result?: any } = {};
+    const bot = botWithDevice(captured);
+
+    await bot.handleDeviceRpcRequest(request({
+      request_id: 'rpc-shell-1',
+      operation: 'execute_shell',
+      tool_name: 'execute_shell',
+      payload: { args: { command: 'echo unsafe' } },
+    }));
+
+    assert.ok(captured.result);
+    assert.equal(captured.result.result, undefined);
+    assert.equal(captured.result.error.code, 'unsupported_operation');
+    assert.match(captured.result.error.message, /read_file, glob, and grep/);
+  });
+
+  test('rejects Device RPC requests for another target device', async () => {
+    const captured: { result?: any } = {};
+    const bot = botWithDevice(captured);
+
+    await bot.handleDeviceRpcRequest(request({
+      request_id: 'rpc-wrong-device-1',
+      device_id: 'other-device',
+    }));
+
+    assert.ok(captured.result);
+    assert.equal(captured.result.result, undefined);
+    assert.equal(captured.result.error.code, 'target_device_mismatch');
+  });
+});

--- a/tests/tool-gateway-catsco.test.ts
+++ b/tests/tool-gateway-catsco.test.ts
@@ -16,7 +16,7 @@ import type {
   ScopedDeviceSelection,
   ScopedLocalDeviceGrant,
 } from '../src/types/session-identity';
-import type { ToolExecutionContext } from '../src/types/tool';
+import type { DeviceRpcTransport, ToolExecutionContext } from '../src/types/tool';
 
 function scope(overrides: Partial<ExecutionScope> = {}): ExecutionScope {
   return {
@@ -101,6 +101,7 @@ function context(root: string, options: {
   localDeviceGrant?: ScopedLocalDeviceGrant;
   deviceGrants?: ScopedDeviceGrant[];
   deviceSelection?: ScopedDeviceSelection;
+  deviceRpc?: DeviceRpcTransport;
 } = {}): ToolExecutionContext {
   return {
     workingDirectory: root,
@@ -112,6 +113,7 @@ function context(root: string, options: {
     localDeviceGrant: options.localDeviceGrant ?? localDevice(),
     deviceGrants: options.deviceGrants,
     deviceSelection: options.deviceSelection,
+    deviceRpc: options.deviceRpc,
   };
 }
 
@@ -185,7 +187,7 @@ describe('CatsCo ToolGateway', () => {
     }
   });
 
-  test('blocks device tools when backend-selected device is not the current CatsCo device', async () => {
+  test('blocks remote-selected device tools when Device RPC transport is unavailable', async () => {
     const root = makeWorkspace();
     const filePath = path.join(root, 'notes.txt');
     fs.writeFileSync(filePath, 'secret');
@@ -208,9 +210,96 @@ describe('CatsCo ToolGateway', () => {
     assert.equal(result.ok, false);
     if (!result.ok) {
       assert.equal(result.errorCode, 'PERMISSION_DENIED');
-      assert.match(result.message, /不是当前运行体/);
+      assert.match(result.message, /没有配置远程设备 RPC 通道/);
       assert.doesNotMatch(result.message, new RegExp(escapeRegExp(filePath)));
     }
+  });
+
+  test('routes read_file to the backend-selected remote device without local file access', async () => {
+    const root = makeWorkspace();
+    const requestedPath = path.join(root, 'missing-on-agent.txt');
+    let rpcRequest: any;
+    const result = await new ReadTool().execute({ file_path: requestedPath, limit: 20 }, context(root, {
+      deviceGrants: [deviceGrant(['read_file'], {
+        deviceId: 'other-device',
+        deviceDisplayName: 'Other Device',
+        deviceBodyId: 'body-other',
+        deviceInstallationId: 'install-other',
+      })],
+      deviceSelection: deviceSelection({
+        selectedDeviceId: 'other-device',
+        selectedDeviceDisplayName: 'Other Device',
+        selectedDeviceBodyId: 'body-other',
+        selectedDeviceInstallationId: 'install-other',
+        selectedDeviceOperations: ['read_file'],
+      }),
+      deviceRpc: {
+        executeTool: async request => {
+          rpcRequest = request;
+          return { ok: true, content: 'remote file content' };
+        },
+      },
+    }));
+
+    assert.equal(result.ok, true);
+    assert.equal(String(result.content), 'remote file content');
+    assert.equal(rpcRequest.toolName, 'read_file');
+    assert.equal(rpcRequest.operation, 'read_file');
+    assert.equal(rpcRequest.grant.deviceId, 'other-device');
+    assert.deepEqual(rpcRequest.args, { file_path: requestedPath, limit: 20 });
+  });
+
+  test('routes glob and grep to the backend-selected remote device', async () => {
+    const root = makeWorkspace();
+    const calls: Array<{ toolName: string; operation: string; args: Record<string, unknown> }> = [];
+    const deviceRpc: DeviceRpcTransport = {
+      executeTool: async request => {
+        calls.push({
+          toolName: request.toolName,
+          operation: request.operation,
+          args: request.args,
+        });
+        return { ok: true, content: `remote ${request.toolName}` };
+      },
+    };
+    const remoteContext = context(root, {
+      deviceGrants: [
+        deviceGrant(['glob'], {
+          grantId: 'grant-glob',
+          deviceId: 'other-device',
+          deviceDisplayName: 'Other Device',
+          deviceBodyId: 'body-other',
+          deviceInstallationId: 'install-other',
+        }),
+        deviceGrant(['grep'], {
+          grantId: 'grant-grep',
+          deviceId: 'other-device',
+          deviceDisplayName: 'Other Device',
+          deviceBodyId: 'body-other',
+          deviceInstallationId: 'install-other',
+        }),
+      ],
+      deviceSelection: deviceSelection({
+        selectedDeviceId: 'other-device',
+        selectedDeviceDisplayName: 'Other Device',
+        selectedDeviceBodyId: 'body-other',
+        selectedDeviceInstallationId: 'install-other',
+        selectedDeviceOperations: ['glob', 'grep'],
+      }),
+      deviceRpc,
+    });
+
+    const glob = await new GlobTool().execute({ pattern: '**/*.ts', path: '/remote/project' }, remoteContext);
+    const grep = await new GrepTool().execute({ pattern: 'needle', path: '/remote/project', output_mode: 'files' }, remoteContext);
+
+    assert.equal(glob.ok, true);
+    assert.equal(grep.ok, true);
+    assert.deepEqual(calls.map(call => [call.toolName, call.operation]), [
+      ['glob', 'glob'],
+      ['grep', 'grep'],
+    ]);
+    assert.deepEqual(calls[0].args, { pattern: '**/*.ts', path: '/remote/project' });
+    assert.deepEqual(calls[1].args, { pattern: 'needle', path: '/remote/project', output_mode: 'files' });
   });
 
   test('redacts local absolute paths from successful CatsCo device file results', async () => {


### PR DESCRIPTION
## 摘要
- CatsClient 连接时把本机 deviceRegistration 放入 hi.device，供服务端绑定 live device socket。
- 新增 device_rpc request/result 类型、sendDeviceRpcRequest / sendDeviceRpcResult，以及 ack + result 双条件完成的 pending 状态机。
- 入站 device_rpc 不进入普通 message 流；CatsCompanyBot 先提供 ping/unsupported responder，真实远程文件工具执行留给后续 PR。

## 边界
- 本 PR 不把 read_file/glob/grep/send_file 远程化。
- 本 PR 不放开 execute_shell / browser / desktop 等高风险远程操作。

## 验证
- npm run build
- npm run test:runtime