### PR TITLE
Show CatsCo device routing and authorization state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,174 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  runtime:
+    name: Build and runtime tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout XiaoBa-CLI
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --prefer-offline --no-audit --fund=false
+
+      - name: Release branding check
+        run: npm run release:check
+
+      - name: Build
+        run: npm run build
+
+      - name: Runtime tests
+        run: npm test
+
+  detect-cross-repo:
+    name: Detect CatsCo cross-repo impact
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.detect.outputs.run }}
+      smoke: ${{ steps.detect.outputs.smoke }}
+      e2e: ${{ steps.detect.outputs.e2e }}
+
+    steps:
+      - name: Checkout XiaoBa-CLI
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect impacted files
+        id: detect
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+
+          smoke=false
+          e2e=false
+          if [ -f scripts/cross-repo-catsco-smoke.mjs ]; then
+            smoke=true
+          fi
+          if [ -f scripts/cross-repo-catsco-e2e.ts ]; then
+            e2e=true
+          fi
+
+          if [ "$smoke" != "true" ] && [ "$e2e" != "true" ]; then
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "smoke=$smoke" >> "$GITHUB_OUTPUT"
+            echo "e2e=$e2e" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            run=true
+          else
+            if [ "$EVENT_NAME" = "pull_request" ] && [ -n "$BASE_SHA" ]; then
+              git diff --name-only "$BASE_SHA"...HEAD > changed-files.txt
+            elif [ -n "$BEFORE_SHA" ] && ! echo "$BEFORE_SHA" | grep -Eq '^0+$'; then
+              git diff --name-only "$BEFORE_SHA"...HEAD > changed-files.txt
+            else
+              git diff --name-only HEAD~1...HEAD > changed-files.txt || git ls-files > changed-files.txt
+            fi
+
+            if grep -Eq '^(\.github/workflows/ci\.yml|package(-lock)?\.json|scripts/cross-repo-catsco-|src/(catscompany|commands/device-connector|tools/(device-rpc-tool|read-tool|glob-tool|grep-tool|write-tool|bash-tool)|types/session-identity)|tests/(catscompany|catsco-command-config|tool-gateway-catsco))' changed-files.txt; then
+              run=true
+            else
+              run=false
+            fi
+          fi
+
+          echo "run=$run" >> "$GITHUB_OUTPUT"
+          echo "smoke=$smoke" >> "$GITHUB_OUTPUT"
+          echo "e2e=$e2e" >> "$GITHUB_OUTPUT"
+
+  cross-repo-catsco:
+    name: CatsCo cross-repo smoke and e2e
+    runs-on: ubuntu-latest
+    needs:
+      - runtime
+      - detect-cross-repo
+    if: needs.detect-cross-repo.outputs.run == 'true'
+    timeout-minutes: 20
+    services:
+      postgres:
+        image: postgres:18-alpine
+        env:
+          POSTGRES_DB: cats_xiaoba_e2e
+          POSTGRES_USER: catsco
+          POSTGRES_PASSWORD: catsco_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U catsco -d cats_xiaoba_e2e"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+
+    steps:
+      - name: Checkout XiaoBa-CLI
+        uses: actions/checkout@v4
+        with:
+          path: XiaoBa-CLI
+
+      - name: Checkout cats-company
+        uses: actions/checkout@v4
+        with:
+          repository: buildsense-ai/cats-company
+          ref: ${{ vars.CATSCOMPANY_SMOKE_REF || 'codex/feishu-cloud-oauth-events' }}
+          path: cats-company
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: XiaoBa-CLI/package-lock.json
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: cats-company/go.mod
+          cache-dependency-path: cats-company/go.sum
+
+      - name: Install XiaoBa dependencies
+        working-directory: XiaoBa-CLI
+        run: npm ci --prefer-offline --no-audit --fund=false
+
+      - name: Cross-repo CatsCo smoke
+        if: needs.detect-cross-repo.outputs.smoke == 'true'
+        working-directory: XiaoBa-CLI
+        env:
+          CATSCOMPANY_REPO: ../cats-company
+        run: npm run test:cross-repo:catsco
+
+      - name: Cross-repo CatsCo e2e
+        if: needs.detect-cross-repo.outputs.e2e == 'true'
+        timeout-minutes: 10
+        working-directory: XiaoBa-CLI
+        env:
+          CATSCOMPANY_REPO: ../cats-company
+          CATSCOMPANY_E2E_DB_DSN: postgres://catsco:catsco_test@127.0.0.1:5432/cats_xiaoba_e2e?sslmode=disable
+          CATSCOMPANY_E2E_TIMEOUT_MS: 180000
+        run: npm run test:e2e:catsco-cross-repo

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -8327,6 +8327,7 @@
     function catsDeviceRpcStatusLabel(rpcStatus){
       if(!rpcStatus || rpcStatus.state==='not_configured') return '未就绪';
       if(rpcStatus.state==='auth_error') return '权限错误';
+      if(rpcStatus.routeState==='unavailable') return '共享状态不可用';
       if(rpcStatus.state==='unknown') return '未知';
       if(rpcStatus.state==='degraded') return '部分不可达';
       const pending=Number(rpcStatus.pendingCount||rpcStatus.pending_count||0);
@@ -8343,6 +8344,34 @@
       return state+suffix;
     }
 
+    function catsDeviceAuthorizationLabel(auth){
+      if(!auth) return '无设备';
+      const state=auth.state||'unknown';
+      const selected=auth.selectedDevice||{};
+      const name=selected.displayName||selected.deviceId||'未选择';
+      const route=selected.routable===true?'可路由':(selected.routeConnected===false?'路由断开':'未就绪');
+      const pending=Number(auth.pendingCount||0);
+      const ttl=Number(auth.ttlMs||0);
+      const suffix=pending>0?(' / '+pending+' pending'):(ttl>0?(' / '+Math.ceil(ttl/1000)+'s'):'');
+      if(state==='no_devices') return '无设备';
+      if(state==='available') return '可用设备 '+Number(auth.routableCount||0)+' 台 / 本轮未选择';
+      if(state==='needs_route') return '等待设备连接';
+      return name+' / '+route+suffix;
+    }
+
+    function catsDeviceOperationsLabel(auth){
+      const ops=Array.isArray(auth?.operations)?auth.operations.filter(Boolean):[];
+      return ops.length?ops.join(', '):'无本轮授权';
+    }
+
+    function catsDeviceDenialLabel(auth){
+      if(!auth) return '';
+      if(auth.deniedReason) return auth.deniedReason;
+      const candidates=Array.isArray(auth.unavailableCandidates)?auth.unavailableCandidates:[];
+      const blocked=candidates.find(item=>item && item.unavailableReason);
+      return blocked?.unavailableReason||'';
+    }
+
     function renderCatsStatus(){
       const service=catsState.service||{};
       const user=catsState.user||{};
@@ -8353,6 +8382,8 @@
       const stage=buildCatsChatStage();
       const bodyStatus=catsState.bodyStatus||{};
       const rpcStatus=catsState.deviceRpcStatus||{};
+      const deviceAuth=catsState.deviceAuthorization||{};
+      const denial=catsDeviceDenialLabel(deviceAuth);
       const botLabel=catsState.bot?.name||catsState.botName||catsState.bot?.username||catsState.botUid||'未绑定';
       const accountMeta=connected
         ? (user.display_name?escapeHtml(user.display_name):'已登录')
@@ -8362,6 +8393,9 @@
         '<div class="chat-status-row"><span>CatsCo Agent</span><strong>'+escapeHtml(botLabel)+'</strong></div>'+
         '<div class="chat-status-row"><span>Body</span><strong>'+escapeHtml(catsBodyLeaseLabel(bodyStatus))+'</strong></div>'+
         '<div class="chat-status-row"><span>Device RPC</span><strong>'+escapeHtml(catsDeviceRpcStatusLabel(rpcStatus))+'</strong></div>'+
+        '<div class="chat-status-row"><span>设备授权</span><strong>'+escapeHtml(catsDeviceAuthorizationLabel(deviceAuth))+'</strong></div>'+
+        '<div class="chat-status-row"><span>授权操作</span><strong>'+escapeHtml(catsDeviceOperationsLabel(deviceAuth))+'</strong></div>'+
+        (denial?'<div class="chat-status-row"><span>最近拒绝</span><strong>'+escapeHtml(denial)+'</strong></div>':'')+
         '<div class="chat-status-row"><span>Topic</span><strong>'+(catsState.topicId?escapeHtml(catsState.topicId):'未就绪')+'</strong></div>'+
         '<div class="chat-status-row"><span>CatsCompany connector</span><strong style="color:'+(running?'var(--green)':'var(--orange)')+'">'+(running?'运行中':'未启动')+'</strong></div>';
 

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,17 +1,36 @@
 const { app, BrowserWindow, Tray, Menu, nativeImage, ipcMain, dialog, shell } = require('electron');
 const path = require('path');
 const fs = require('fs');
+const http = require('http');
 
 const DASHBOARD_PORT = resolveDashboardPort(process.env.XIAOBA_DASHBOARD_PORT);
+const DEEP_LINK_PROTOCOL = 'catsco';
 let mainWindow = null;
 let tray = null;
 let autoUpdater = null;
 let hideNoticeShown = false;
+let dashboardReady = false;
+const pendingDeepLinks = [];
 const REFRESHABLE_BUNDLED_SKILLS = new Set([]);
 const RETIRED_BUNDLED_SKILLS = new Set(['advanced-reader', 'vision-analysis']);
 const SKILL_SYNC_MARKER = '.xiaoba-bundled-skill.json';
 
 applyConfiguredUserDataPath();
+
+const gotSingleInstanceLock = app.requestSingleInstanceLock();
+if (!gotSingleInstanceLock) {
+  app.quit();
+} else {
+  app.on('second-instance', (_event, argv) => {
+    showMainWindow();
+    queueCatsCoDeepLink(extractCatsCoDeepLink(argv));
+  });
+}
+
+app.on('open-url', (event, url) => {
+  event.preventDefault();
+  queueCatsCoDeepLink(url);
+});
 
 function resolveDashboardPort(value) {
   const text = String(value || '').trim();
@@ -108,6 +127,146 @@ function notifyWindowHidden() {
     content: '点击右下角 CatsCo 图标可恢复窗口。',
     icon: createTrayIcon(),
   });
+}
+
+function registerDeepLinkProtocol() {
+  try {
+    if (process.defaultApp && process.argv.length >= 2) {
+      app.setAsDefaultProtocolClient(DEEP_LINK_PROTOCOL, process.execPath, [path.resolve(process.argv[1])]);
+    } else {
+      app.setAsDefaultProtocolClient(DEEP_LINK_PROTOCOL);
+    }
+  } catch (error) {
+    console.log('CatsCo deep link registration skipped:', error?.message || error);
+  }
+}
+
+function extractCatsCoDeepLink(argv) {
+  if (!Array.isArray(argv)) return null;
+  return argv.find((arg) => /^catsco:\/\//i.test(String(arg || '').trim())) || null;
+}
+
+function queueCatsCoDeepLink(rawUrl) {
+  if (!rawUrl) return;
+  if (!dashboardReady) {
+    pendingDeepLinks.push(String(rawUrl));
+    return;
+  }
+  handleCatsCoDeepLink(String(rawUrl)).catch((error) => {
+    showDeviceConnectorError(error);
+  });
+}
+
+async function drainPendingDeepLinks() {
+  const links = pendingDeepLinks.splice(0, pendingDeepLinks.length);
+  for (const link of links) {
+    await handleCatsCoDeepLink(link);
+  }
+}
+
+async function handleCatsCoDeepLink(rawUrl) {
+  let url;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    throw new Error('无法识别 CatsCo 连接。');
+  }
+
+  if (url.protocol !== `${DEEP_LINK_PROTOCOL}:`) return;
+  if (url.hostname !== 'device-connector' || url.pathname !== '/pair') {
+    throw new Error('这个 CatsCo 连接类型暂不支持。');
+  }
+
+  const code = url.searchParams.get('code') || url.searchParams.get('pairing_code') || url.searchParams.get('pair');
+  if (!code) {
+    throw new Error('设备配对链接缺少配对码。');
+  }
+
+  const result = await postLocalDashboardJson('/api/cats/device-connector/pair', {
+    code,
+    http_base_url: url.searchParams.get('http_base_url') || url.searchParams.get('httpBaseUrl') || undefined,
+    server_url: url.searchParams.get('server_url') || url.searchParams.get('serverUrl') || undefined,
+    device_name: url.searchParams.get('device_name') || url.searchParams.get('deviceName') || undefined,
+  });
+
+  enableOpenAtLogin();
+  showMainWindow();
+  notifyDeviceConnectorStatus('CatsCo 本机设备已连接', result?.message || 'Device Connector 已在后台运行。');
+}
+
+function postLocalDashboardJson(apiPath, body) {
+  return new Promise((resolve, reject) => {
+    const payload = JSON.stringify(body || {});
+    const request = http.request({
+      hostname: '127.0.0.1',
+      port: DASHBOARD_PORT,
+      path: apiPath,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(payload),
+      },
+    }, (response) => {
+      const chunks = [];
+      response.on('data', (chunk) => chunks.push(chunk));
+      response.on('end', () => {
+        const text = Buffer.concat(chunks).toString('utf8');
+        let data = {};
+        if (text) {
+          try {
+            data = JSON.parse(text);
+          } catch {
+            data = { raw: text };
+          }
+        }
+        if (response.statusCode && response.statusCode >= 200 && response.statusCode < 300) {
+          resolve(data);
+          return;
+        }
+        reject(new Error(data?.error || `CatsCo local request failed: ${response.statusCode}`));
+      });
+    });
+    request.on('error', reject);
+    request.write(payload);
+    request.end();
+  });
+}
+
+function enableOpenAtLogin() {
+  if (!app.isPackaged || typeof app.setLoginItemSettings !== 'function') return;
+  try {
+    app.setLoginItemSettings({ openAtLogin: true, openAsHidden: true });
+  } catch (error) {
+    console.log('CatsCo login item registration skipped:', error?.message || error);
+  }
+}
+
+function notifyDeviceConnectorStatus(title, content) {
+  if (tray && process.platform === 'win32' && typeof tray.displayBalloon === 'function') {
+    tray.displayBalloon({ title, content, icon: createTrayIcon() });
+  }
+}
+
+function showDeviceConnectorError(error) {
+  const message = error?.message || '本机设备连接失败，请重新生成配对码后再试。';
+  showMainWindow();
+  dialog.showMessageBox({
+    type: 'warning',
+    title: '本机设备连接失败',
+    message,
+    buttons: ['知道了'],
+  }).catch(() => {});
+}
+
+async function startSavedDeviceConnector() {
+  try {
+    await postLocalDashboardJson('/api/cats/device-connector/ensure-running', {});
+  } catch (error) {
+    const message = String(error?.message || error || '');
+    if (!/not paired|auto-connect|already running|preflight/i.test(message)) {
+      console.log('CatsCo Device Connector auto-start skipped:', message);
+    }
+  }
 }
 
 // 闂佽绻愮换鎴犳崲閸℃稒鍎婃い鏍仜缁€澶愭煟濡厧鍔嬬紒?electron-updater闂備焦瀵х粙鎴︽偋閸℃哎浜归柡灞诲劜閻掕顭块懜鐢点€掔紒鈧?
@@ -769,12 +928,19 @@ if (autoUpdater) {
   });
 }
 
+if (gotSingleInstanceLock) {
 app.whenReady().then(async () => {
   try {
+    registerDeepLinkProtocol();
     await startServer();
+    dashboardReady = true;
     createApplicationMenu();
     createWindow();
     createTray();
+    const startupDeepLink = extractCatsCoDeepLink(process.argv);
+    if (startupDeepLink) pendingDeepLinks.push(startupDeepLink);
+    await drainPendingDeepLinks().catch(showDeviceConnectorError);
+    startSavedDeviceConnector().catch(() => {});
     
     // 闂備礁鎲￠崙褰掑垂閻楀牊鍙忛柍鍝勬噹鐟欙箓骞栧ǎ顒€鐒烘慨濠囩畺閺岋紕浠︾拠鎻掑濠电偞褰冨鈥愁嚕?
     if (app.isPackaged && autoUpdater) {
@@ -800,3 +966,4 @@ app.on('window-all-closed', () => {
 app.on('before-quit', () => {
   app.isQuitting = true;
 });
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "watch": "tsc --watch",
     "test": "node scripts/run-tests.mjs runtime",
     "test:runtime": "node scripts/run-tests.mjs runtime",
+    "test:cross-repo:catsco": "node scripts/cross-repo-catsco-smoke.mjs",
+    "test:e2e:catsco-cross-repo": "tsx scripts/cross-repo-catsco-e2e.ts",
     "test:legacy": "node scripts/run-tests.mjs legacy",
     "test:all": "node scripts/run-tests.mjs all",
     "test:list": "node scripts/run-tests.mjs runtime --list",
@@ -96,6 +98,14 @@
       "output": "release"
     },
     "asar": false,
+    "protocols": [
+      {
+        "name": "CatsCo Link",
+        "schemes": [
+          "catsco"
+        ]
+      }
+    ],
     "publish": {
       "provider": "github",
       "owner": "buildsense-ai",

--- a/scripts/cross-repo-catsco-e2e.ts
+++ b/scripts/cross-repo-catsco-e2e.ts
@@ -1,0 +1,456 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { fileURLToPath } from 'node:url';
+import { CatsClient, type MessageContext } from '../src/catscompany/client';
+import { CatsCoDeviceConnector } from '../src/catscompany/device-connector';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(__dirname, '..');
+const catsRepo = path.resolve(process.env.CATSCOMPANY_REPO || path.join(rootDir, '..', 'cats-company'));
+const dbDsn = String(process.env.CATSCOMPANY_E2E_DB_DSN || '').trim();
+const e2eTimeoutMs = positiveNumber(process.env.CATSCOMPANY_E2E_TIMEOUT_MS, 180_000);
+const apiTimeoutMs = positiveNumber(process.env.CATSCOMPANY_E2E_API_TIMEOUT_MS, 15_000);
+
+if (!dbDsn) {
+  const message = '[cross-repo:e2e] CATSCOMPANY_E2E_DB_DSN is not set';
+  if (process.env.CI === 'true') {
+    console.error(message);
+    process.exit(1);
+  }
+  console.log(`${message}; skipped outside CI`);
+  process.exit(0);
+}
+
+if (!fs.existsSync(path.join(catsRepo, 'go.mod'))) {
+  throw new Error(`cats-company repo not found at ${catsRepo}`);
+}
+
+const runId = `${Date.now()}_${Math.random().toString(16).slice(2)}`;
+const tmpRoot = path.join(rootDir, 'tmp', `catsco-cross-repo-e2e-${runId}`);
+const deviceRoot = path.join(tmpRoot, 'device');
+fs.mkdirSync(deviceRoot, { recursive: true });
+
+const sentinel = `catsco-cross-repo-e2e-${runId}`;
+const sentinelFile = path.join(deviceRoot, 'sentinel.txt');
+fs.writeFileSync(sentinelFile, `${sentinel}\n`, 'utf8');
+
+let httpBaseUrl = '';
+let serverProcess: ChildProcessWithoutNullStreams | undefined;
+let connector: CatsCoDeviceConnector | undefined;
+let botClient: CatsClient | undefined;
+
+const watchdog = setTimeout(() => {
+  console.error(`[cross-repo:e2e] timed out after ${e2eTimeoutMs}ms`);
+  serverProcess?.kill('SIGKILL');
+  process.exit(1);
+}, e2eTimeoutMs);
+
+main().then(() => {
+  clearTimeout(watchdog);
+}).catch(error => {
+  clearTimeout(watchdog);
+  console.error(`[cross-repo:e2e] failed: ${error?.message || error}`);
+  process.exit(1);
+});
+
+async function main(): Promise<void> {
+  const httpPort = await findFreePort();
+  const grpcPort = await findFreePort();
+  httpBaseUrl = `http://127.0.0.1:${httpPort}`;
+  const wsUrl = `ws://127.0.0.1:${httpPort}/v0/channels`;
+  const configPath = path.join(tmpRoot, 'cats-company-e2e.conf');
+  fs.writeFileSync(configPath, JSON.stringify({
+    listen: `127.0.0.1:${httpPort}`,
+    grpc_port: `127.0.0.1:${grpcPort}`,
+    database: {
+      driver: 'postgres',
+      dsn: dbDsn,
+      max_open_conns: 4,
+      max_idle_conns: 2,
+    },
+    websocket: { path: '/v0/channels' },
+    static: { dir: '' },
+  }, null, 2), 'utf8');
+
+  try {
+    logStep('starting cats-company server');
+    serverProcess = startCatsCompanyServer(configPath);
+    await waitForReady(`${httpBaseUrl}/ready`, 45_000);
+
+  logStep('registering human user');
+  const user = await api('POST', '/api/auth/register', {
+    username: `e2e_user_${runId.slice(-10)}`,
+    password: 'password123',
+    display_name: 'E2E User',
+  }, undefined, 201);
+
+  const token = stringField(user, 'token');
+  const userId = numberField(user, 'uid');
+  assert(token, 'register response missing token');
+  assert(userId > 0, 'register response missing uid');
+
+  logStep('creating bot user');
+  const bot = await api('POST', '/api/bots', {
+    username: `e2e_agent_${runId.slice(-10)}`,
+    password: 'password123',
+    display_name: 'E2E Agent',
+    model: 'e2e',
+  }, token, 201);
+
+  const botUid = numberField(bot, 'uid');
+  const botApiKey = stringField(bot, 'api_key');
+  assert(botUid > 0, 'create bot response missing uid');
+  assert(botApiKey, 'create bot response missing api_key');
+
+  logStep('creating device pairing');
+  const pairing = await api('POST', '/api/device-connectors/pairings', {
+    device_name: 'E2E Device',
+    capabilities: ['read_file', 'glob', 'grep'],
+  }, token);
+
+  const pairingCode = stringField(pairing, 'pairing_code');
+  const pairingId = stringField(pairing, 'pairing_id');
+  assert(pairingCode, 'pairing response missing pairing_code');
+  assert(pairingId, 'pairing response missing pairing_id');
+
+  logStep('enrolling device connector');
+  const deviceId = `e2e-device-${runId.slice(-10)}`;
+  const enrollment = await api('POST', '/api/device-connectors/enroll', {
+    pairing_code: pairingCode,
+    device_id: deviceId,
+    installation_id: deviceId,
+    device_name: 'E2E Device',
+    capabilities: ['read_file', 'glob', 'grep'],
+  });
+
+  const connectorToken = stringField(enrollment, 'connector_token');
+  assert(connectorToken, 'enroll response missing connector_token');
+
+  const pairingStatus = await api('GET', `/api/device-connectors/pairings/${pairingId}`, undefined, token);
+  assert(stringField(pairingStatus, 'status') === 'consumed', 'pairing was not consumed');
+
+  logStep('starting XiaoBa device connector');
+  connector = new CatsCoDeviceConnector({
+    serverUrl: wsUrl,
+    httpBaseUrl,
+    authMode: 'device_connector',
+    connectorToken,
+    bodyId: deviceId,
+    installationId: deviceId,
+    deviceName: 'E2E Device',
+    capabilities: ['read_file', 'glob', 'grep'],
+  });
+  await connector.start();
+  await waitForRoutableDevice(token, deviceId, 20_000);
+
+  logStep('starting XiaoBa bot client');
+  botClient = new CatsClient({
+    serverUrl: wsUrl,
+    httpBaseUrl,
+    apiKey: botApiKey,
+    bodyId: `body-e2e-${runId.slice(-10)}`,
+    installationId: `body-e2e-${runId.slice(-10)}`,
+  });
+  const botReady = waitForClientReady(botClient, 20_000);
+  botClient.connect();
+  await botReady;
+
+  logStep('opening agent conversation');
+  const openAgent = await api('POST', '/api/agents/open', {
+    agent_uid: botUid,
+  }, token);
+  const topic = stringField(openAgent, 'topic');
+  assert(topic, 'open agent response missing topic');
+
+  logStep('sending message and waiting for device grant');
+  const messagePromise = waitForMessageWithGrant(botClient, topic, 20_000);
+  await api('POST', '/api/messages/send', {
+    topic_id: topic,
+    type: 'text',
+    content: 'Please read my local sentinel file.',
+  }, token);
+
+  const incoming = await messagePromise;
+  const identity = incoming.metadata?.catsco_identity as Record<string, unknown> | undefined;
+  const grants = Array.isArray(identity?.device_grants) ? identity?.device_grants as Record<string, unknown>[] : [];
+  const grant = grants[0];
+  assert(grant, 'message metadata missing device grant');
+
+  assert(stringField(grant, 'actorUserId') === `usr${userId}`, 'grant actor did not match user');
+  assert(stringField(grant, 'agentId') === `usr${botUid}`, 'grant agent did not match bot');
+  assert(stringField(grant, 'deviceId') === deviceId, 'grant device did not match connector');
+
+  logStep('sending device_rpc read_file request');
+  const result = await botClient.sendDeviceRpcRequest({
+    request_id: `rpc-${runId}`,
+    grant_id: stringField(grant, 'grantId'),
+    session_key: stringField(grant, 'sessionKey'),
+    topic_id: stringField(grant, 'topicId'),
+    topic_type: stringField(grant, 'topicType'),
+    actor_user_id: stringField(grant, 'actorUserId'),
+    agent_id: stringField(grant, 'agentId'),
+    agent_body_id: stringField(grant, 'agentBodyId'),
+    device_id: stringField(grant, 'deviceId'),
+    device_body_id: stringField(grant, 'deviceBodyId'),
+    device_installation_id: stringField(grant, 'deviceInstallationId'),
+    operation: 'read_file',
+    tool_name: 'read_file',
+    payload: { args: { file_path: sentinelFile, limit: 20 } },
+  }, 20_000);
+
+  const payload = result.result as Record<string, unknown> | undefined;
+  assert(payload?.ok === true, `device RPC did not return ok=true: ${JSON.stringify(result)}`);
+  assert(String(payload.content || '').includes(sentinel), 'device RPC result did not include sentinel content');
+
+  logStep('checking pending cleanup and status redaction');
+  const status = await api('GET', `/api/devices/rpc-status?agent_id=usr${botUid}`, undefined, token);
+  assert(numberField(status, 'pending_count') === 0, `pending RPC was not cleared: ${JSON.stringify(status)}`);
+  const statusText = JSON.stringify(status);
+  assert(!statusText.includes(sentinelFile), 'rpc-status leaked local absolute file path');
+  assert(!statusText.includes(sentinel), 'rpc-status leaked file content');
+
+  logStep('deleting device connector registration');
+  await api('DELETE', `/api/devices/${encodeURIComponent(deviceId)}`, undefined, token);
+  const devicesAfterDelete = await api('GET', '/api/devices', undefined, token);
+  const remaining = Array.isArray(devicesAfterDelete.devices) ? devicesAfterDelete.devices : [];
+  assert(!remaining.some((device: any) => device?.deviceId === deviceId && device?.routable), 'deleted device is still routable');
+
+    console.log('[cross-repo:e2e] CatsCo full device RPC e2e passed');
+  } finally {
+    await connector?.destroy().catch(() => undefined);
+    botClient?.disconnect();
+    if (serverProcess) await stopProcess(serverProcess);
+  }
+}
+
+function startCatsCompanyServer(configFile: string): ChildProcessWithoutNullStreams {
+  const goCache = process.env.CATSCOMPANY_GOCACHE || path.join(catsRepo, '.gocache');
+  fs.mkdirSync(goCache, { recursive: true });
+  const child = spawn('go', ['run', './server/cmd', configFile], {
+    cwd: catsRepo,
+    env: {
+      ...process.env,
+      GOCACHE: goCache,
+      OC_JWT_SECRET: process.env.OC_JWT_SECRET || `catsco-e2e-${runId}`,
+    },
+    detached: process.platform !== 'win32',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    shell: false,
+  });
+  child.stdout.on('data', data => process.stdout.write(prefixLines('[cats-company] ', data.toString())));
+  child.stderr.on('data', data => process.stderr.write(prefixLines('[cats-company] ', data.toString())));
+  child.on('exit', code => {
+    if (code !== null && code !== 0) {
+      process.stderr.write(`[cross-repo:e2e] cats-company server exited with code ${code}\n`);
+    }
+  });
+  return child;
+}
+
+async function waitForReady(url: string, timeoutMs: number): Promise<void> {
+  const started = Date.now();
+  let lastError = '';
+  while (Date.now() - started < timeoutMs) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return;
+      lastError = `${res.status} ${await res.text().catch(() => '')}`;
+    } catch (err: any) {
+      lastError = err?.message || String(err);
+    }
+    await sleep(500);
+  }
+  throw new Error(`server was not ready after ${timeoutMs}ms: ${lastError}`);
+}
+
+async function api(
+  method: string,
+  route: string,
+  body?: unknown,
+  token?: string,
+  expected = 200,
+): Promise<any> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), apiTimeoutMs);
+  let res: Response;
+  try {
+    res = await fetch(`${httpBaseUrl}${route}`, {
+      method,
+      headers: {
+        ...(body === undefined ? {} : { 'Content-Type': 'application/json' }),
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: body === undefined ? undefined : JSON.stringify(body),
+      signal: controller.signal,
+    });
+  } catch (err: any) {
+    if (err?.name === 'AbortError') {
+      throw new Error(`${method} ${route} timed out after ${apiTimeoutMs}ms`);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+  const text = await res.text();
+  let parsed: any = {};
+  if (text) {
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = { raw: text };
+    }
+  }
+  if (res.status !== expected) {
+    throw new Error(`${method} ${route} returned ${res.status}, expected ${expected}: ${text}`);
+  }
+  return parsed;
+}
+
+async function waitForRoutableDevice(token: string, deviceId: string, timeoutMs: number): Promise<void> {
+  const started = Date.now();
+  let lastDevices = '';
+  while (Date.now() - started < timeoutMs) {
+    const body = await api('GET', '/api/devices', undefined, token);
+    const devices = Array.isArray(body.devices) ? body.devices : [];
+    const device = devices.find((item: any) => item?.deviceId === deviceId);
+    if (device?.active && device?.routeConnected && device?.routable) return;
+    lastDevices = JSON.stringify(devices);
+    await sleep(500);
+  }
+  throw new Error(`device ${deviceId} did not become routable: ${lastDevices}`);
+}
+
+async function waitForClientReady(client: CatsClient, timeoutMs: number): Promise<void> {
+  await waitForEvent(client, 'ready', timeoutMs);
+}
+
+async function waitForMessageWithGrant(client: CatsClient, topic: string, timeoutMs: number): Promise<MessageContext> {
+  const started = Date.now();
+  return await new Promise<MessageContext>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`timed out waiting for device grant message after ${timeoutMs}ms`));
+    }, timeoutMs);
+    const onMessage = (message: MessageContext) => {
+      const identity = message.metadata?.catsco_identity as Record<string, unknown> | undefined;
+      const grants = identity?.device_grants;
+      if (message.topic === topic && Array.isArray(grants) && grants.length > 0) {
+        cleanup();
+        resolve(message);
+      }
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const cleanup = () => {
+      clearTimeout(timer);
+      client.off('message', onMessage);
+      client.off('error', onError);
+    };
+    client.on('message', onMessage);
+    client.on('error', onError);
+    void started;
+  });
+}
+
+async function waitForEvent(emitter: NodeJS.EventEmitter, event: string, timeoutMs: number): Promise<unknown[]> {
+  return await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`timed out waiting for ${event} after ${timeoutMs}ms`));
+    }, timeoutMs);
+    const onEvent = (...args: unknown[]) => {
+      cleanup();
+      resolve(args);
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const cleanup = () => {
+      clearTimeout(timer);
+      emitter.off(event, onEvent);
+      emitter.off('error', onError);
+    };
+    emitter.once(event, onEvent);
+    emitter.once('error', onError);
+  });
+}
+
+async function findFreePort(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        server.close(() => reject(new Error('failed to allocate port')));
+        return;
+      }
+      const port = address.port;
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+async function stopProcess(child: ChildProcessWithoutNullStreams): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  await new Promise<void>(resolve => {
+    const kill = (signal: NodeJS.Signals) => {
+      if (process.platform !== 'win32' && child.pid) {
+        try {
+          process.kill(-child.pid, signal);
+          return;
+        } catch {
+          // Fall back to killing the direct child below.
+        }
+      }
+      child.kill(signal);
+    };
+    const timer = setTimeout(() => {
+      kill('SIGKILL');
+      resolve();
+    }, 5000);
+    child.once('exit', () => {
+      clearTimeout(timer);
+      resolve();
+    });
+    kill('SIGTERM');
+  });
+}
+
+function stringField(record: any, key: string): string {
+  return String(record?.[key] || '').trim();
+}
+
+function numberField(record: any, key: string): number {
+  const value = Number(record?.[key]);
+  return Number.isFinite(value) ? value : 0;
+}
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function logStep(message: string): void {
+  console.log(`[cross-repo:e2e] ${message}`);
+}
+
+function positiveNumber(value: unknown, fallback: number): number {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? number : fallback;
+}
+
+function prefixLines(prefix: string, value: string): string {
+  return value
+    .split(/\r?\n/)
+    .map((line, index, lines) => (line || index < lines.length - 1 ? `${prefix}${line}` : line))
+    .join('\n');
+}

--- a/scripts/cross-repo-catsco-smoke.mjs
+++ b/scripts/cross-repo-catsco-smoke.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(__dirname, '..');
+const require = createRequire(import.meta.url);
+
+const catsRepo = path.resolve(process.env.CATSCOMPANY_REPO || path.join(rootDir, '..', 'cats-company'));
+const catsGoMod = path.join(catsRepo, 'go.mod');
+
+if (!fs.existsSync(catsGoMod)) {
+  console.error(`[cross-repo] cats-company repo not found at ${catsRepo}`);
+  console.error('[cross-repo] Set CATSCOMPANY_REPO to the local cats-company checkout.');
+  process.exit(1);
+}
+
+const catsGoCache = process.env.CATSCOMPANY_GOCACHE || path.join(catsRepo, '.gocache');
+fs.mkdirSync(catsGoCache, { recursive: true });
+
+const catsServerSmoke = [
+  'TestDeviceConnectorPairingEnrollmentAndScopedRegistration',
+  'TestDeviceRPCRoutesRequestToSelectedDeviceAndReturnsResult',
+  'TestDeviceRPCDoesNotBroadcastToSiblingConnections',
+  'TestDeviceRPCRejectsResultFromWrongDeviceConnection',
+  'TestDeviceRPCRejectsOfflineDevice',
+  'TestDeviceRPCDoesNotRouteByBareBodyOrInstallationID',
+  'TestSharedRuntimeRoutesDeviceRPCAcrossHubs',
+  'TestRedisRuntimeRoutesDeviceRPCAcrossStates',
+  'TestChannelAgentBindingLinkUser',
+  'TestChannelAgentBindingConfirmRequiresTokenInProduction',
+  'TestBotRecipientIdentityUsesLinkedChannelDeviceOwner',
+  'TestFeishuMessageEventDeliversToBoundAgent',
+  'TestWeixinTextMessageDeliversToBoundAgent',
+].join('|');
+
+const tsxCli = require.resolve('tsx/cli');
+const xiaoBaSmokeTests = [
+  'tests/catscompany-client-body-id.test.ts',
+  'tests/catscompany-device-rpc-tools.test.ts',
+  'tests/catscompany-execution-scope-flow.test.ts',
+  'tests/tool-gateway-catsco.test.ts',
+];
+
+runStep('cats-company server device connector/RPC smoke', 'go', [
+  'test',
+  './server',
+  '-run',
+  catsServerSmoke,
+  '-count=1',
+], {
+  cwd: catsRepo,
+  env: {
+    ...process.env,
+    GOCACHE: catsGoCache,
+  },
+});
+
+runStep('XiaoBa CatsCo device RPC smoke', process.execPath, [
+  tsxCli,
+  '--test',
+  ...xiaoBaSmokeTests,
+], {
+  cwd: rootDir,
+});
+
+console.log('[cross-repo] CatsCo cross-repo smoke passed');
+
+function runStep(name, command, args, options = {}) {
+  console.log(`[cross-repo] ${name}`);
+  const result = spawnSync(command, args, {
+    cwd: options.cwd || rootDir,
+    env: options.env || process.env,
+    stdio: 'inherit',
+    shell: false,
+  });
+
+  if (result.error) {
+    console.error(`[cross-repo] Failed to start ${name}: ${result.error.message}`);
+    process.exit(1);
+  }
+
+  if (result.signal) {
+    console.error(`[cross-repo] ${name} terminated by ${result.signal}`);
+    process.exit(1);
+  }
+
+  if (result.status !== 0) {
+    console.error(`[cross-repo] ${name} failed with exit code ${result.status}`);
+    process.exit(result.status || 1);
+  }
+}

--- a/src/catscompany/client.ts
+++ b/src/catscompany/client.ts
@@ -5,11 +5,15 @@ import crypto from 'crypto';
 import { Logger } from '../utils/logger';
 import { uploadCatsLocalFile, type UploadResult } from './upload';
 
+const MAX_DEVICE_RPC_EVENT_ERROR_LENGTH = 240;
+
 export type { UploadResult } from './upload';
 
 export interface CatsClientConfig {
   serverUrl: string;
-  apiKey: string;
+  apiKey?: string;
+  connectorToken?: string;
+  authMode?: 'bot' | 'device_connector';
   bodyId?: string;
   installationId?: string;
   deviceRegistration?: CatsDeviceRegistration;
@@ -235,19 +239,31 @@ export class CatsClient extends EventEmitter {
 
   connect(): void {
     if (this.ws) return;
+    const connectorMode = this.isDeviceConnectorAuth();
 
     const bodyId = firstNonEmpty(
       this.config.bodyId,
+      this.config.deviceRegistration?.body_id,
+      this.config.deviceRegistration?.device_id,
       process.env.CATSCO_BODY_ID,
       process.env.CATSCOMPANY_BODY_ID,
       process.env.CATSCO_DEVICE_ID,
       process.env.CATSCOMPANY_DEVICE_ID,
     );
     if (!bodyId) {
-      throw new Error('CatsCo bodyId missing; bind this runtime to a CatsCo agent body before starting the connector.');
+      throw new Error(connectorMode
+        ? 'CatsCo deviceId missing; pair this device connector before starting it.'
+        : 'CatsCo bodyId missing; bind this runtime to a CatsCo agent body before starting the connector.');
+    }
+    if (!connectorMode && !firstNonEmpty(this.config.apiKey)) {
+      throw new Error('CatsCo apiKey missing; bind this runtime to a CatsCo agent body before starting the connector.');
+    }
+    if (connectorMode && !firstNonEmpty(this.config.connectorToken)) {
+      throw new Error('CatsCo connectorToken missing; pair this device connector before starting it.');
     }
     const installationId = firstNonEmpty(
       this.config.installationId,
+      this.config.deviceRegistration?.installation_id,
       process.env.CATSCO_INSTALLATION_ID,
       process.env.CATSCOMPANY_INSTALLATION_ID,
       bodyId,
@@ -255,17 +271,22 @@ export class CatsClient extends EventEmitter {
     this.activeBodyId = bodyId;
     this.activeInstallationId = installationId;
 
-    Logger.info(`[CatsCompany] 正在连接: ${this.config.serverUrl}, apiKey=${maskSecret(this.config.apiKey)}, bodyId=${bodyId}`);
+    Logger.info(`[CatsCompany] 正在连接: ${this.config.serverUrl}, auth=${connectorMode ? 'device_connector' : 'bot_api_key'}, bodyId=${bodyId}`);
     this.supportsClientMessageDedupe = false;
     this.supportsDeviceRpc = false;
     this.ready = false;
     this.bodyLease = undefined;
+    const headers: Record<string, string> = {
+      'X-CatsCo-Body-ID': bodyId,
+      'X-CatsCo-Installation-ID': installationId,
+    };
+    if (connectorMode) {
+      headers['X-CatsCo-Connector-Token'] = firstNonEmpty(this.config.connectorToken) || '';
+    } else {
+      headers['X-API-Key'] = firstNonEmpty(this.config.apiKey) || '';
+    }
     this.ws = new WebSocket(this.config.serverUrl, {
-      headers: {
-        'X-API-Key': this.config.apiKey,
-        'X-CatsCo-Body-ID': bodyId,
-        'X-CatsCo-Installation-ID': installationId,
-      },
+      headers,
     });
 
     this.ws.on('open', () => {
@@ -342,8 +363,10 @@ export class CatsClient extends EventEmitter {
         this.bodyLease = normalizeBodyLeaseStatus(msg.ctrl.params?.body_lease || msg.ctrl.params?.bodyLease);
         this.ready = true;
         this.emit('ready', { uid: this.uid, name: this.name, bodyLease: this.bodyLease });
-        this.autoAcceptFriendRequests().catch(console.error);
-        this.resubscribeTopics();
+        if (!this.isDeviceConnectorAuth()) {
+          this.autoAcceptFriendRequests().catch(console.error);
+          this.resubscribeTopics();
+        }
       } else if (msg.ctrl.id) {
         const pending = this.pendingAcks.get(msg.ctrl.id);
         if (pending) {
@@ -636,12 +659,13 @@ export class CatsClient extends EventEmitter {
   }
 
   private async acceptFriendRequest(userId: number): Promise<void> {
+    if (this.isDeviceConnectorAuth()) return;
     const httpBaseUrl = this.config.httpBaseUrl || 'https://app.catsco.cc';
     const res = await fetch(`${httpBaseUrl}/api/friends/accept`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `ApiKey ${this.config.apiKey}`
+        'Authorization': this.authHeader()
       },
       body: JSON.stringify({ user_id: userId })
     });
@@ -661,16 +685,19 @@ export class CatsClient extends EventEmitter {
       httpBaseUrl: this.httpBaseUrl(),
       filePath,
       type,
-      authHeader: `ApiKey ${this.config.apiKey}`,
+      authHeader: this.authHeader(),
     });
   }
 
   async registerDevice(registration: CatsDeviceRegistration): Promise<unknown> {
-    const res = await fetch(`${this.httpBaseUrl()}/api/devices/register`, {
+    const path = this.isDeviceConnectorAuth()
+      ? '/api/device-connectors/register'
+      : '/api/devices/register';
+    const res = await fetch(`${this.httpBaseUrl()}${path}`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `ApiKey ${this.config.apiKey}`,
+        'Authorization': this.authHeader(),
       },
       body: JSON.stringify(registration),
     });
@@ -804,7 +831,7 @@ export class CatsClient extends EventEmitter {
       deviceId: message.device_id,
       createdAt: new Date().toISOString(),
       durationMs: startedAt ? Math.max(0, Date.now() - startedAt) : undefined,
-      error: options.error,
+      error: sanitizeDeviceRpcEventError(options.error),
     };
     this.deviceRpcRecent.push(event);
     if (this.deviceRpcRecent.length > 30) {
@@ -895,6 +922,21 @@ export class CatsClient extends EventEmitter {
 
   private httpBaseUrl(): string {
     return this.config.httpBaseUrl || inferHttpBaseUrl(this.config.serverUrl) || 'https://app.catsco.cc';
+  }
+
+  private isDeviceConnectorAuth(): boolean {
+    return this.config.authMode === 'device_connector' || Boolean(firstNonEmpty(this.config.connectorToken));
+  }
+
+  private authHeader(): string {
+    if (this.isDeviceConnectorAuth()) {
+      const token = firstNonEmpty(this.config.connectorToken);
+      if (!token) throw new Error('CatsCo connector token is required');
+      return `DeviceConnector ${token}`;
+    }
+    const apiKey = firstNonEmpty(this.config.apiKey);
+    if (!apiKey) throw new Error('CatsCo API key is required');
+    return `ApiKey ${apiKey}`;
   }
 
   disconnect(): void {
@@ -1008,5 +1050,19 @@ function deviceRpcResultMatchesPending(result: CatsDeviceRpcMessage, request: Ca
 function deviceRpcOptionalFieldMatches(actual: unknown, expected: unknown): boolean {
   const actualText = typeof actual === 'string' ? actual.trim() : '';
   const expectedText = typeof expected === 'string' ? expected.trim() : '';
-  return !actualText || !expectedText || actualText === expectedText;
+  if (!expectedText) return true;
+  return Boolean(actualText) && actualText === expectedText;
+}
+
+function sanitizeDeviceRpcEventError(error?: string): string | undefined {
+  const raw = String(error || '').trim();
+  if (!raw) return undefined;
+  const sanitized = raw
+    .replace(/\b(Bearer|ApiKey|Basic)\s+[A-Za-z0-9._~:/+=-]+/gi, '$1 [redacted]')
+    .replace(/\b((?:access|refresh)[_-]?token|token|api[_-]?key|secret|client[_-]?secret|password|CATSCO_[A-Z0-9_]*TOKEN)\s*=\s*[^\s'"&]+/gi, '$1=[redacted]')
+    .replace(/[A-Za-z]:[\\/][^\s'"<>]+/g, '[redacted-path]')
+    .replace(/\\\\[^\\/\s]+\\[^\\/\s]+(?:\\[^\s'"<>]+)*/g, '[redacted-path]')
+    .replace(/\/(?:Users|home|tmp|var|etc)\/[^\s'"<>]+/g, '[redacted-path]');
+  if (sanitized.length <= MAX_DEVICE_RPC_EVENT_ERROR_LENGTH) return sanitized;
+  return `${sanitized.slice(0, MAX_DEVICE_RPC_EVENT_ERROR_LENGTH - 3)}...`;
 }

--- a/src/catscompany/device-connector.ts
+++ b/src/catscompany/device-connector.ts
@@ -1,0 +1,378 @@
+import { hostname } from 'os';
+import { CatsClient, type CatsDeviceRegistration, type CatsDeviceRpcMessage } from './client';
+import { CatsCompanyConfig } from './types';
+import { createCatsCoLocalDeviceGrant } from './local-file-grants';
+import type { DeviceGrantOperation, ExecutionScope, ScopedDeviceGrant, ScopedDeviceSelection, ScopedLocalDeviceGrant } from '../types/session-identity';
+import type { ToolExecutionContext, ToolExecutionResult } from '../types/tool';
+import { Logger } from '../utils/logger';
+import { ReadTool } from '../tools/read-tool';
+import { GlobTool } from '../tools/glob-tool';
+import { GrepTool } from '../tools/grep-tool';
+import { WriteTool } from '../tools/write-tool';
+import { ShellTool } from '../tools/bash-tool';
+import {
+  isRemoteDeviceTool,
+  normalizeDeviceRpcToolResultForTransport,
+} from '../tools/device-rpc-tool';
+
+const DEVICE_REGISTRATION_REFRESH_MS = 120_000;
+const DEVICE_RPC_DEFAULT_TTL_MS = 60_000;
+
+export class CatsCoDeviceConnector {
+  private readonly client: CatsClient;
+  private readonly localDeviceGrant: ScopedLocalDeviceGrant;
+  private readonly deviceRegistration: CatsDeviceRegistration;
+  private deviceRegistrationTimer?: ReturnType<typeof setInterval>;
+  private readonly allowWriteFile: boolean;
+  private readonly allowShell: boolean;
+
+  constructor(private readonly config: CatsCompanyConfig) {
+    if (!config.connectorToken) {
+      throw new Error('CatsCo device connector token is missing. Pair this device before starting connector-only mode.');
+    }
+    const deviceId = config.installationId || config.bodyId;
+    if (!deviceId) {
+      throw new Error('CatsCo device id is missing. Pair this device before starting connector-only mode.');
+    }
+    const capabilities = normalizeConnectorCapabilities(config);
+    this.allowWriteFile = capabilities.includes('write_file') && Boolean(config.allowWriteFile);
+    this.allowShell = capabilities.includes('execute_shell') && Boolean(config.allowShell);
+    this.deviceRegistration = {
+      device_id: deviceId,
+      display_name: config.deviceName || process.env.COMPUTERNAME || process.env.HOSTNAME || hostname() || deviceId,
+      body_id: config.bodyId || deviceId,
+      installation_id: config.installationId || deviceId,
+      status: 'online',
+      capabilities,
+    };
+    const localDeviceGrant = createCatsCoLocalDeviceGrant({
+      bodyId: this.deviceRegistration.body_id,
+      installationId: this.deviceRegistration.installation_id,
+      deviceId: this.deviceRegistration.device_id,
+    });
+    if (!localDeviceGrant) {
+      throw new Error('CatsCo device connector could not create a local device grant.');
+    }
+    this.localDeviceGrant = localDeviceGrant;
+    this.client = new CatsClient({
+      serverUrl: config.serverUrl,
+      connectorToken: config.connectorToken,
+      authMode: 'device_connector',
+      bodyId: this.deviceRegistration.body_id,
+      installationId: this.deviceRegistration.installation_id,
+      deviceRegistration: this.deviceRegistration,
+      httpBaseUrl: config.httpBaseUrl,
+    });
+  }
+
+  async start(): Promise<void> {
+    Logger.openLogFile('catsco-device-connector');
+    Logger.info('正在启动 CatsCo Device Connector...');
+
+    this.client.on('ready', () => {
+      Logger.success(`CatsCo Device Connector 已连接，device=${this.deviceRegistration.device_id}`);
+      this.registerCurrentDevice().catch((err: any) => {
+        Logger.warning(`CatsCo 设备注册失败，继续保持连接: ${err?.message || err}`);
+      });
+      this.startDeviceRegistrationRefresh();
+    });
+
+    this.client.on('device_rpc_request', async (request: CatsDeviceRpcMessage) => {
+      await this.handleDeviceRpcRequest(request);
+    });
+
+    this.client.on('message', () => {
+      Logger.warning('Device Connector 收到普通聊天消息，已忽略。');
+    });
+
+    this.client.on('error', (err: Error) => {
+      Logger.error(`CatsCo Device Connector 连接错误: ${err.message}`);
+    });
+
+    this.client.connect();
+    Logger.success('CatsCo Device Connector 已启动，只监听本机设备任务。');
+  }
+
+  async destroy(): Promise<void> {
+    this.stopDeviceRegistrationRefresh();
+    this.client.disconnect();
+  }
+
+  private async registerCurrentDevice(): Promise<void> {
+    await this.client.registerDevice(this.deviceRegistration);
+    Logger.info(`[CatsCo Device Connector] 已注册本机设备能力: device=${this.deviceRegistration.device_id}, capabilities=${(this.deviceRegistration.capabilities || []).join(',')}`);
+  }
+
+  private startDeviceRegistrationRefresh(): void {
+    this.stopDeviceRegistrationRefresh();
+    this.deviceRegistrationTimer = setInterval(() => {
+      this.registerCurrentDevice().catch((err: any) => {
+        Logger.warning(`CatsCo 设备状态刷新失败: ${err?.message || err}`);
+      });
+    }, DEVICE_REGISTRATION_REFRESH_MS);
+    (this.deviceRegistrationTimer as any).unref?.();
+  }
+
+  private stopDeviceRegistrationRefresh(): void {
+    if (!this.deviceRegistrationTimer) return;
+    clearInterval(this.deviceRegistrationTimer);
+    this.deviceRegistrationTimer = undefined;
+  }
+
+  private async handleDeviceRpcRequest(request: CatsDeviceRpcMessage): Promise<void> {
+    const requestID = request.request_id;
+    if (!requestID) return;
+
+    const validationError = this.validateDeviceRpcToolRequest(request);
+    let result: ToolExecutionResult | undefined;
+    let executionError: { code: string; message: string } | undefined;
+    if (!validationError) {
+      try {
+        result = await this.executeLocalDeviceRpcTool(request);
+      } catch (err: any) {
+        executionError = {
+          code: 'tool_execution_error',
+          message: err?.message || String(err || 'Device RPC local tool execution failed.'),
+        };
+      }
+    }
+    const error = validationError || executionError || (!result || result.ok
+      ? undefined
+      : {
+          code: result.errorCode || 'tool_execution_error',
+          message: result.message,
+        });
+
+    try {
+      await this.client.sendDeviceRpcResult({
+        request_id: requestID,
+        grant_id: request.grant_id,
+        session_key: request.session_key,
+        topic_id: request.topic_id,
+        topic_type: request.topic_type,
+        actor_user_id: request.actor_user_id,
+        agent_id: request.agent_id,
+        agent_body_id: request.agent_body_id,
+        device_id: this.localDeviceGrant.deviceId || request.device_id,
+        device_body_id: this.localDeviceGrant.bodyId || request.device_body_id,
+        device_installation_id: this.localDeviceGrant.installationId || request.device_installation_id,
+        operation: request.operation,
+        tool_name: request.tool_name,
+        result: error || !result ? undefined : normalizeDeviceRpcToolResultForTransport(result),
+        error,
+      });
+    } catch (err: any) {
+      Logger.warning(`[CatsCo Device Connector] Device RPC result 发送失败: request=${requestID}, error=${err?.message || err}`);
+    }
+  }
+
+  private async executeLocalDeviceRpcTool(request: CatsDeviceRpcMessage): Promise<ToolExecutionResult> {
+    const operation = this.normalizeDeviceRpcOperation(request.operation);
+    const toolName = String(request.tool_name || operation || '').trim();
+    if (!operation || !isRemoteDeviceTool(toolName, operation)) {
+      return {
+        ok: false,
+        errorCode: 'PERMISSION_DENIED',
+        message: `Device RPC 不允许执行 ${toolName || request.operation || 'unknown'}。`,
+      };
+    }
+    if (operation === 'write_file' && !this.allowWriteFile) {
+      return {
+        ok: false,
+        errorCode: 'PERMISSION_DENIED',
+        message: '本机 Device Connector 未开启远程写文件能力。',
+      };
+    }
+    if (operation === 'execute_shell' && !this.allowShell) {
+      return {
+        ok: false,
+        errorCode: 'PERMISSION_DENIED',
+        message: '本机 Device Connector 未开启远程 shell 能力。',
+      };
+    }
+
+    const context = this.buildDeviceRpcToolContext(request, operation);
+    const args = this.extractDeviceRpcToolArgs(request.payload);
+    switch (operation) {
+      case 'read_file':
+        return new ReadTool().execute(args, context);
+      case 'glob':
+        return new GlobTool().execute(args, context);
+      case 'grep':
+        return new GrepTool().execute(args, context);
+      case 'write_file':
+        return new WriteTool().execute(args, context);
+      case 'execute_shell':
+        return new ShellTool().execute(args, context);
+      default:
+        return {
+          ok: false,
+          errorCode: 'PERMISSION_DENIED',
+          message: `Device RPC 不允许执行 ${operation}。`,
+        };
+    }
+  }
+
+  private buildDeviceRpcToolContext(
+    request: CatsDeviceRpcMessage,
+    operation: DeviceGrantOperation,
+  ): ToolExecutionContext {
+    const topicType = request.topic_type === 'group' || request.topic_type === 'p2p'
+      ? request.topic_type
+      : 'unknown';
+    const executionScope: ExecutionScope = {
+      source: 'catscompany',
+      sessionKey: String(request.session_key || ''),
+      topicId: String(request.topic_id || ''),
+      topicType,
+      actorUserId: String(request.actor_user_id || ''),
+      agentId: request.agent_id,
+      agentBodyId: request.agent_body_id,
+      permissionsSource: 'device_rpc_forward',
+      identityTrust: 'server_canonical',
+      isTrusted: true,
+    };
+    const now = Date.now();
+    const grant: ScopedDeviceGrant = {
+      kind: 'user_device_grant',
+      source: 'catscompany',
+      grantId: String(request.grant_id || ''),
+      status: 'active',
+      identityTrust: 'server_canonical',
+      identitySource: 'device_rpc_forward',
+      deviceId: String(request.device_id || this.localDeviceGrant.deviceId || ''),
+      deviceBodyId: request.device_body_id || this.localDeviceGrant.bodyId,
+      deviceInstallationId: request.device_installation_id || this.localDeviceGrant.installationId,
+      ownerUserId: executionScope.actorUserId,
+      sessionKey: executionScope.sessionKey,
+      topicId: executionScope.topicId,
+      topicType,
+      actorUserId: executionScope.actorUserId,
+      agentId: executionScope.agentId,
+      agentBodyId: executionScope.agentBodyId,
+      operations: [operation],
+      createdAt: typeof request.created_at === 'number' ? request.created_at : now,
+      expiresAt: typeof request.expires_at === 'number' ? request.expires_at : now + DEVICE_RPC_DEFAULT_TTL_MS,
+    };
+    const deviceSelection: ScopedDeviceSelection = {
+      kind: 'user_device_selection',
+      source: 'catscompany',
+      status: 'selected',
+      selectionSource: 'device_rpc_forward',
+      sessionKey: executionScope.sessionKey,
+      topicId: executionScope.topicId,
+      topicType,
+      actorUserId: executionScope.actorUserId,
+      agentId: executionScope.agentId,
+      identityTrust: 'server_canonical',
+      identitySource: 'device_rpc_forward',
+      selectedDeviceId: grant.deviceId,
+      selectedDeviceBodyId: grant.deviceBodyId,
+      selectedDeviceInstallationId: grant.deviceInstallationId,
+      selectedDeviceOperations: [operation],
+      createdAt: now,
+    };
+    const workingDirectory = process.cwd();
+    return {
+      workingDirectory,
+      workspaceRoot: workingDirectory,
+      conversationHistory: [],
+      sessionId: executionScope.sessionKey,
+      surface: 'catscompany',
+      permissionProfile: 'strict',
+      executionScope,
+      localDeviceGrant: this.localDeviceGrant,
+      deviceGrants: [grant],
+      deviceSelection,
+    };
+  }
+
+  private validateDeviceRpcToolRequest(request: CatsDeviceRpcMessage): { code: string; message: string } | undefined {
+    const targetError = this.validateDeviceRpcTarget(request);
+    if (targetError) return targetError;
+
+    const operation = this.normalizeDeviceRpcOperation(request.operation);
+    const toolName = String(request.tool_name || operation || '').trim();
+    if (!operation || !isRemoteDeviceTool(toolName, operation)) {
+      return { code: 'unsupported_operation', message: 'Device RPC only allows read_file, glob, grep, write_file, and execute_shell.' };
+    }
+    if (!(this.deviceRegistration.capabilities || []).includes(operation)) {
+      return { code: 'capability_not_enabled', message: `This connector has not enabled ${operation}.` };
+    }
+
+    const requiredFields: Array<[keyof CatsDeviceRpcMessage, string]> = [
+      ['grant_id', 'grant_id'],
+      ['session_key', 'session_key'],
+      ['topic_id', 'topic_id'],
+      ['topic_type', 'topic_type'],
+      ['actor_user_id', 'actor_user_id'],
+      ['device_id', 'device_id'],
+    ];
+    for (const [field, label] of requiredFields) {
+      if (!String(request[field] || '').trim()) {
+        return { code: 'invalid_request', message: `Device RPC request missing ${label}.` };
+      }
+    }
+    if (typeof request.expires_at === 'number' && Date.now() > request.expires_at) {
+      return { code: 'request_expired', message: 'Device RPC request has expired.' };
+    }
+    return undefined;
+  }
+
+  private normalizeDeviceRpcOperation(value: unknown): DeviceGrantOperation | undefined {
+    const operation = String(value || '').trim();
+    if (operation === 'read_file'
+      || operation === 'glob'
+      || operation === 'grep'
+      || operation === 'write_file'
+      || operation === 'execute_shell') {
+      return operation;
+    }
+    return undefined;
+  }
+
+  private extractDeviceRpcToolArgs(payload: unknown): Record<string, unknown> {
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return {};
+    const record = payload as Record<string, unknown>;
+    if (record.args && typeof record.args === 'object' && !Array.isArray(record.args)) {
+      return { ...(record.args as Record<string, unknown>) };
+    }
+    return { ...record };
+  }
+
+  private validateDeviceRpcTarget(request: CatsDeviceRpcMessage): { code: string; message: string } | undefined {
+    const checks: Array<[unknown, unknown, string]> = [
+      [request.device_id, this.localDeviceGrant.deviceId, 'device_id'],
+      [request.device_installation_id, this.localDeviceGrant.installationId, 'installation_id'],
+      [request.device_body_id, this.localDeviceGrant.bodyId, 'body_id'],
+    ];
+    let matchedAny = false;
+    for (const [requested, local, label] of checks) {
+      const requestedText = String(requested || '').trim();
+      if (!requestedText) continue;
+      const localText = String(local || '').trim();
+      if (!localText || requestedText !== localText) {
+        return { code: 'target_device_mismatch', message: `Device RPC target ${label} does not match this local connector.` };
+      }
+      matchedAny = true;
+    }
+    return matchedAny
+      ? undefined
+      : { code: 'target_device_mismatch', message: 'Device RPC target does not match this local connector.' };
+  }
+}
+
+function normalizeConnectorCapabilities(config: CatsCompanyConfig): string[] {
+  const values = new Set<string>();
+  const configured = config.capabilities && config.capabilities.length > 0
+    ? config.capabilities
+    : ['read_file', 'glob', 'grep'];
+  for (const item of configured) {
+    const text = String(item || '').trim();
+    if (text === 'read_file' || text === 'glob' || text === 'grep') values.add(text);
+    if (text === 'write_file' && config.allowWriteFile) values.add(text);
+    if (text === 'execute_shell' && config.allowShell) values.add(text);
+  }
+  if (values.size === 0) values.add('read_file');
+  return Array.from(values);
+}

--- a/src/catscompany/device-grants.ts
+++ b/src/catscompany/device-grants.ts
@@ -7,6 +7,7 @@ import type {
   MessageTopicType,
   ScopedDeviceGrant,
 } from '../types/session-identity';
+import { isDelegatedDeviceGrant } from '../core/device-grants';
 
 type UnknownRecord = Record<string, unknown>;
 
@@ -47,14 +48,16 @@ function normalizeDeviceGrant(value: unknown): ScopedDeviceGrant | undefined {
   const operations = normalizeOperations(record.operations);
   const createdAt = numberField(record, 'createdAt') ?? numberField(record, 'created_at');
   const expiresAt = numberField(record, 'expiresAt') ?? numberField(record, 'expires_at');
+  const status = normalizeStatus(stringField(record, 'status'));
   if (!grantId || !deviceId || !ownerUserId || !sessionKey || !topicId || !actorUserId) return undefined;
   if (operations.length === 0 || createdAt === undefined || expiresAt === undefined) return undefined;
+  if (status !== 'active') return undefined;
 
   return pruneUndefined({
     kind: 'user_device_grant',
     source,
     grantId,
-    status: normalizeStatus(stringField(record, 'status')),
+    status,
     identityTrust: normalizeTrust(stringField(record, 'identityTrust') || stringField(record, 'identity_trust')),
     identitySource: stringField(record, 'identitySource') || stringField(record, 'identity_source'),
     deviceId,
@@ -78,6 +81,9 @@ function normalizeDeviceGrant(value: unknown): ScopedDeviceGrant | undefined {
 }
 
 function grantMatchesScope(grant: ScopedDeviceGrant, scope: ExecutionScope): boolean {
+  if (grant.ownerUserId !== grant.actorUserId && !isDelegatedDeviceGrant(grant)) {
+    return false;
+  }
   return grant.status === 'active'
     && grant.identityTrust === 'server_canonical'
     && grant.source === scope.source
@@ -85,7 +91,6 @@ function grantMatchesScope(grant: ScopedDeviceGrant, scope: ExecutionScope): boo
     && grant.topicId === scope.topicId
     && grant.topicType === scope.topicType
     && grant.actorUserId === scope.actorUserId
-    && grant.ownerUserId === scope.actorUserId
     && grant.agentId === scope.agentId
     && grant.agentBodyId === scope.agentBodyId;
 }
@@ -115,8 +120,9 @@ function normalizeSource(value: string | undefined): MessageSource {
   return value === 'catscompany' ? 'catscompany' : 'unknown';
 }
 
-function normalizeStatus(value: string | undefined): DeviceGrantStatus {
-  return value === 'revoked' ? 'revoked' : 'active';
+function normalizeStatus(value: string | undefined): DeviceGrantStatus | undefined {
+  if (value === 'active' || value === 'revoked') return value;
+  return undefined;
 }
 
 function normalizeTrust(value: string | undefined): IdentityTrustLevel {

--- a/src/catscompany/device-grants.ts
+++ b/src/catscompany/device-grants.ts
@@ -61,6 +61,9 @@ function normalizeDeviceGrant(value: unknown): ScopedDeviceGrant | undefined {
     deviceDisplayName: stringField(record, 'deviceDisplayName') || stringField(record, 'device_display_name'),
     deviceBodyId: stringField(record, 'deviceBodyId') || stringField(record, 'device_body_id'),
     deviceInstallationId: stringField(record, 'deviceInstallationId') || stringField(record, 'device_installation_id'),
+    deviceActive: booleanField(record, 'deviceActive') ?? booleanField(record, 'device_active'),
+    deviceRouteConnected: booleanField(record, 'deviceRouteConnected') ?? booleanField(record, 'device_route_connected'),
+    deviceRoutable: booleanField(record, 'deviceRoutable') ?? booleanField(record, 'device_routable'),
     ownerUserId,
     sessionKey,
     topicId,
@@ -149,6 +152,12 @@ function numberField(record: UnknownRecord, key: string): number | undefined {
     const parsed = Number(value);
     if (Number.isFinite(parsed) && parsed >= 0) return parsed;
   }
+  return undefined;
+}
+
+function booleanField(record: UnknownRecord | undefined, key: string): boolean | undefined {
+  const value = record?.[key];
+  if (typeof value === 'boolean') return value;
   return undefined;
 }
 

--- a/src/catscompany/device-selection.ts
+++ b/src/catscompany/device-selection.ts
@@ -70,6 +70,15 @@ function normalizeDeviceSelection(record: UnknownRecord, scope: ExecutionScope):
       || stringField(record, 'selected_device_installation_id')
       || stringField(selectedDevice, 'installationId')
       || stringField(selectedDevice, 'installation_id'),
+    selectedDeviceStatus: normalizeDeviceStatus(stringField(selectedDevice, 'status') || stringField(record, 'selectedDeviceStatus')),
+    selectedDeviceActive: booleanField(selectedDevice, 'active') ?? booleanField(record, 'selectedDeviceActive'),
+    selectedDeviceRouteConnected: booleanField(selectedDevice, 'routeConnected')
+      ?? booleanField(selectedDevice, 'route_connected')
+      ?? booleanField(record, 'selectedDeviceRouteConnected'),
+    selectedDeviceRoutable: booleanField(selectedDevice, 'routable') ?? booleanField(record, 'selectedDeviceRoutable'),
+    selectedDeviceUnavailableReason: stringField(selectedDevice, 'unavailableReason')
+      || stringField(selectedDevice, 'unavailable_reason')
+      || stringField(record, 'selectedDeviceUnavailableReason'),
     selectedDeviceOperations: normalizeOperations(selectedDevice?.operations ?? record.selectedDeviceOperations ?? record.selected_device_operations),
     candidates: normalizeCandidates(record.candidates),
     candidateCount: numberField(record, 'candidateCount') ?? numberField(record, 'candidate_count'),
@@ -98,6 +107,11 @@ function normalizeCandidates(value: unknown): DeviceSelectionCandidate[] | undef
       return pruneUndefined({
         deviceId,
         displayName: stringField(record, 'displayName') || stringField(record, 'display_name'),
+        status: normalizeDeviceStatus(stringField(record, 'status')),
+        active: booleanField(record, 'active'),
+        routeConnected: booleanField(record, 'routeConnected') ?? booleanField(record, 'route_connected'),
+        routable: booleanField(record, 'routable'),
+        unavailableReason: stringField(record, 'unavailableReason') || stringField(record, 'unavailable_reason'),
         operations: normalizeOperations(record.operations),
         lastSeenAt: numberField(record, 'lastSeenAt') ?? numberField(record, 'last_seen_at'),
       }) as DeviceSelectionCandidate;
@@ -142,6 +156,12 @@ function normalizeTopicType(value: string | undefined): MessageTopicType {
   return 'unknown';
 }
 
+function normalizeDeviceStatus(value: string | undefined): 'online' | 'offline' | 'unknown' | undefined {
+  if (value === 'online' || value === 'offline') return value;
+  if (value === 'unknown') return 'unknown';
+  return undefined;
+}
+
 function asRecord(value: unknown): UnknownRecord | undefined {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
   return value as UnknownRecord;
@@ -161,6 +181,12 @@ function numberField(record: UnknownRecord | undefined, key: string): number | u
     const parsed = Number(value);
     if (Number.isFinite(parsed) && parsed >= 0) return parsed;
   }
+  return undefined;
+}
+
+function booleanField(record: UnknownRecord | undefined, key: string): boolean | undefined {
+  const value = record?.[key];
+  if (typeof value === 'boolean') return value;
   return undefined;
 }
 

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -17,6 +17,8 @@ import type { PendingUserInput } from '../core/conversation-runner';
 import type { DeviceGrantOperation, ExecutionScope, ScopedDeviceGrant, ScopedDeviceSelection, ScopedLocalDeviceGrant, ScopedLocalFileGrant } from '../types/session-identity';
 import { AdapterRuntimeBundle, createAdapterRuntime } from '../runtime/adapter-runtime';
 import { randomUUID } from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
 import { hostname } from 'os';
 import { ConfigManager } from '../utils/config';
 import { isPrimaryModelVisionCapable } from '../utils/model-capabilities';
@@ -24,8 +26,10 @@ import { createCatsCoSessionRoute } from '../core/session-router';
 import { ReadTool } from '../tools/read-tool';
 import { GlobTool } from '../tools/glob-tool';
 import { GrepTool } from '../tools/grep-tool';
+import { WriteTool } from '../tools/write-tool';
+import { ShellTool } from '../tools/bash-tool';
 import {
-  isRemoteReadonlyTool,
+  isRemoteDeviceTool,
   normalizeDeviceRpcToolResultForTransport,
   normalizeDeviceRpcToolResultPayload,
 } from '../tools/device-rpc-tool';
@@ -65,6 +69,7 @@ const PENDING_ANSWER_TIMEOUT_MS = 120_000;
 const TYPING_HEARTBEAT_INTERVAL_MS = 5_000;
 const DEVICE_REGISTRATION_REFRESH_MS = 120_000;
 const DEVICE_RPC_DEFAULT_TTL_MS = 60_000;
+const DEVICE_AUTH_SNAPSHOT_PATH = path.join(process.cwd(), 'tmp', 'catsco-device-authorization.json');
 const HIDDEN_CATS_TOOL_PROGRESS = new Set([
   'send_text',
   'send_file',
@@ -304,9 +309,9 @@ export class CatsCompanyBot {
   }
 
   private async executeLocalDeviceRpcTool(request: CatsDeviceRpcMessage): Promise<ToolExecutionResult> {
-    const operation = this.normalizeDeviceRpcReadonlyOperation(request.operation);
+    const operation = this.normalizeDeviceRpcOperation(request.operation);
     const toolName = String(request.tool_name || operation || '').trim();
-    if (!operation || !isRemoteReadonlyTool(toolName, operation)) {
+    if (!operation || !isRemoteDeviceTool(toolName, operation)) {
       return {
         ok: false,
         errorCode: 'PERMISSION_DENIED',
@@ -323,6 +328,10 @@ export class CatsCompanyBot {
         return new GlobTool().execute(args, context);
       case 'grep':
         return new GrepTool().execute(args, context);
+      case 'write_file':
+        return new WriteTool().execute(args, context);
+      case 'execute_shell':
+        return new ShellTool().execute(args, context);
       default:
         return {
           ok: false,
@@ -410,10 +419,10 @@ export class CatsCompanyBot {
     const targetError = this.validateDeviceRpcTarget(request);
     if (targetError) return targetError;
 
-    const operation = this.normalizeDeviceRpcReadonlyOperation(request.operation);
+    const operation = this.normalizeDeviceRpcOperation(request.operation);
     const toolName = String(request.tool_name || operation || '').trim();
-    if (!operation || !isRemoteReadonlyTool(toolName, operation)) {
-      return { code: 'unsupported_operation', message: 'Device RPC only allows read_file, glob, and grep.' };
+    if (!operation || !isRemoteDeviceTool(toolName, operation)) {
+      return { code: 'unsupported_operation', message: 'Device RPC only allows read_file, glob, grep, write_file, and execute_shell.' };
     }
 
     const requiredFields: Array<[keyof CatsDeviceRpcMessage, string]> = [
@@ -435,9 +444,13 @@ export class CatsCompanyBot {
     return undefined;
   }
 
-  private normalizeDeviceRpcReadonlyOperation(value: unknown): DeviceGrantOperation | undefined {
+  private normalizeDeviceRpcOperation(value: unknown): DeviceGrantOperation | undefined {
     const operation = String(value || '').trim();
-    if (operation === 'read_file' || operation === 'glob' || operation === 'grep') {
+    if (operation === 'read_file'
+      || operation === 'glob'
+      || operation === 'grep'
+      || operation === 'write_file'
+      || operation === 'execute_shell') {
       return operation;
     }
     return undefined;
@@ -883,7 +896,7 @@ export class CatsCompanyBot {
     });
     const executionScope = createExecutionScope(envelope);
 
-    return {
+    const parsed: ParsedCatsMessage = {
       topic: ctx.topic,
       chatType,
       senderId: ctx.senderId,
@@ -898,6 +911,65 @@ export class CatsCompanyBot {
       file: files[0],
       files,
     };
+    this.persistDeviceAuthorizationSnapshot(parsed);
+    return parsed;
+  }
+
+  private persistDeviceAuthorizationSnapshot(message: ParsedCatsMessage): void {
+    const selection = message.deviceSelection;
+    const grants = message.deviceGrants || [];
+    if (!selection && grants.length === 0) return;
+    const now = Date.now();
+    const ttlMsValues = grants
+      .map(grant => grant.expiresAt - now)
+      .filter(value => Number.isFinite(value) && value >= 0);
+    const operations = [...new Set(grants.flatMap(grant => grant.operations || []))];
+    const snapshot = {
+      schema: 'catsco.device_authorization.v1',
+      updatedAt: new Date(now).toISOString(),
+      source: 'last_catsco_turn',
+      topicId: message.topic,
+      topicType: message.chatType,
+      actorUserId: message.executionScope.actorUserId,
+      agentId: message.executionScope.agentId,
+      messageSeq: message.seq,
+      state: selection?.status || (grants.length > 0 ? 'selected' : 'unknown'),
+      selectionSource: selection?.selectionSource,
+      selectedDevice: selection?.selectedDeviceId ? {
+        deviceId: selection.selectedDeviceId,
+        displayName: selection.selectedDeviceDisplayName,
+        status: selection.selectedDeviceStatus,
+        active: selection.selectedDeviceActive,
+        routeConnected: selection.selectedDeviceRouteConnected,
+        routable: selection.selectedDeviceRoutable,
+        unavailableReason: selection.selectedDeviceUnavailableReason,
+      } : undefined,
+      operations,
+      ttlMs: ttlMsValues.length > 0 ? Math.min(...ttlMsValues) : undefined,
+      expiresAt: grants.length > 0 ? Math.min(...grants.map(grant => grant.expiresAt)) : undefined,
+      deniedReason: selection?.status === 'unavailable'
+        ? selection.selectionSource || selection.selectedDeviceUnavailableReason
+        : undefined,
+      candidates: selection?.candidates?.map(candidate => ({
+        deviceId: candidate.deviceId,
+        displayName: candidate.displayName,
+        status: candidate.status,
+        active: candidate.active,
+        routeConnected: candidate.routeConnected,
+        routable: candidate.routable,
+        unavailableReason: candidate.unavailableReason,
+        operations: candidate.operations,
+      })),
+      grantCount: grants.length,
+    };
+    try {
+      fs.mkdirSync(path.dirname(DEVICE_AUTH_SNAPSHOT_PATH), { recursive: true });
+      const tmpPath = `${DEVICE_AUTH_SNAPSHOT_PATH}.tmp`;
+      fs.writeFileSync(tmpPath, JSON.stringify(snapshot, null, 2), 'utf-8');
+      fs.renameSync(tmpPath, DEVICE_AUTH_SNAPSHOT_PATH);
+    } catch (error: any) {
+      Logger.warning(`[CatsCompany] device authorization snapshot write skipped: ${error?.message || error}`);
+    }
   }
 
   /**

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -128,9 +128,17 @@ export class CatsCompanyBot {
     status: 'online';
     capabilities: string[];
   };
+  private readonly allowWriteFile: boolean;
+  private readonly allowShell: boolean;
 
   constructor(config: CatsCompanyConfig) {
+    if (!config.apiKey) {
+      throw new Error('CatsCompanyBot requires a bot API key. Use CatsCoDeviceConnector for device-only mode.');
+    }
     const localDeviceId = config.installationId || config.bodyId;
+    const deviceCapabilities = normalizeRuntimeDeviceCapabilities(config);
+    this.allowWriteFile = deviceCapabilities.includes('write_file') && Boolean(config.allowWriteFile);
+    this.allowShell = deviceCapabilities.includes('execute_shell') && Boolean(config.allowShell);
     const deviceRegistration = localDeviceId
       ? {
           device_id: localDeviceId,
@@ -138,13 +146,14 @@ export class CatsCompanyBot {
           body_id: config.bodyId,
           installation_id: config.installationId || config.bodyId,
           status: 'online' as const,
-          capabilities: ['read_file', 'glob', 'grep'],
+          capabilities: deviceCapabilities,
         }
       : undefined;
 
     this.bot = new CatsClient({
       serverUrl: config.serverUrl,
       apiKey: config.apiKey,
+      authMode: 'bot',
       bodyId: config.bodyId,
       installationId: config.installationId,
       deviceRegistration,
@@ -277,8 +286,19 @@ export class CatsCompanyBot {
     if (!requestID) return;
 
     const validationError = this.validateDeviceRpcToolRequest(request);
-    const result = validationError ? undefined : await this.executeLocalDeviceRpcTool(request);
-    const error = validationError || (!result || result.ok
+    let result: ToolExecutionResult | undefined;
+    let executionError: { code: string; message: string } | undefined;
+    if (!validationError) {
+      try {
+        result = await this.executeLocalDeviceRpcTool(request);
+      } catch (err: any) {
+        executionError = {
+          code: 'tool_execution_error',
+          message: err?.message || String(err || 'Device RPC local tool execution failed.'),
+        };
+      }
+    }
+    const error = validationError || executionError || (!result || result.ok
       ? undefined
       : {
           code: result.errorCode || 'tool_execution_error',
@@ -316,6 +336,27 @@ export class CatsCompanyBot {
         ok: false,
         errorCode: 'PERMISSION_DENIED',
         message: `Device RPC 不允许执行 ${toolName || request.operation || 'unknown'}。`,
+      };
+    }
+    if (!(this.deviceRegistration?.capabilities || []).includes(operation)) {
+      return {
+        ok: false,
+        errorCode: 'PERMISSION_DENIED',
+        message: `当前 CatsCo runtime 未注册远程 ${operation} 能力。`,
+      };
+    }
+    if (operation === 'write_file' && !this.allowWriteFile) {
+      return {
+        ok: false,
+        errorCode: 'PERMISSION_DENIED',
+        message: '当前 CatsCo runtime 未显式开启远程写文件能力。',
+      };
+    }
+    if (operation === 'execute_shell' && !this.allowShell) {
+      return {
+        ok: false,
+        errorCode: 'PERMISSION_DENIED',
+        message: '当前 CatsCo runtime 未显式开启远程 shell 能力。',
       };
     }
 
@@ -1514,4 +1555,19 @@ export class CatsCompanyBot {
       this.pendingAnswerBySession.delete(pending.sessionKey);
     }
   }
+}
+
+function normalizeRuntimeDeviceCapabilities(config: CatsCompanyConfig): string[] {
+  const values = new Set<string>();
+  const configured = config.capabilities && config.capabilities.length > 0
+    ? config.capabilities
+    : ['read_file', 'glob', 'grep'];
+  for (const item of configured) {
+    const text = String(item || '').trim();
+    if (text === 'read_file' || text === 'glob' || text === 'grep') values.add(text);
+    if (text === 'write_file' && config.allowWriteFile) values.add(text);
+    if (text === 'execute_shell' && config.allowShell) values.add(text);
+  }
+  if (values.size === 0) values.add('read_file');
+  return Array.from(values);
 }

--- a/src/catscompany/local-config.ts
+++ b/src/catscompany/local-config.ts
@@ -27,6 +27,19 @@ export interface CatsCoLocalDevice {
   name?: string;
 }
 
+export interface CatsCoLocalDeviceConnector {
+  token: string;
+  ownerUid?: string;
+  deviceId: string;
+  installationId: string;
+  name?: string;
+  capabilities?: string[];
+  allowWriteFile?: boolean;
+  allowShell?: boolean;
+  pairedAt?: string;
+  tokenExpiresAt?: string;
+}
+
 export interface CatsCoLocalConfig {
   version: 1;
   endpoints?: {
@@ -36,6 +49,7 @@ export interface CatsCoLocalConfig {
   account?: CatsCoLocalAccount;
   currentBot?: CatsCoLocalBot;
   device?: CatsCoLocalDevice;
+  deviceConnector?: CatsCoLocalDeviceConnector;
   preferences?: {
     autoConnect?: boolean;
     switchConfirmEnabled?: boolean;
@@ -438,6 +452,67 @@ export class CatsCoLocalConfigService {
     });
   }
 
+  writeDeviceConnectorEnrollment(state: CatsCoAuthSnapshot, input: {
+    token: string;
+    ownerUid?: string;
+    deviceId: string;
+    installationId?: string;
+    name?: string;
+    capabilities?: string[];
+    allowWriteFile?: boolean;
+    allowShell?: boolean;
+    tokenExpiresAt?: string;
+  }): string[] {
+    const deviceId = String(input.deviceId || '').trim();
+    if (!deviceId) {
+      throw new Error('deviceId is required');
+    }
+    const installationId = String(input.installationId || deviceId).trim();
+    const config = this.load();
+    this.save({
+      ...config,
+      endpoints: {
+        ...(config.endpoints || {}),
+        httpBaseUrl: state.httpBaseUrl,
+        serverUrl: state.serverUrl,
+      },
+      device: {
+        ...(config.device || {}),
+        deviceId,
+        bodyId: deviceId,
+        installationId,
+        name: input.name || config.device?.name,
+      },
+      deviceConnector: {
+        token: input.token,
+        ownerUid: input.ownerUid || state.uid,
+        deviceId,
+        installationId,
+        name: input.name,
+        capabilities: input.capabilities,
+        allowWriteFile: Boolean(input.allowWriteFile),
+        allowShell: Boolean(input.allowShell),
+        pairedAt: new Date().toISOString(),
+        tokenExpiresAt: input.tokenExpiresAt,
+      },
+    });
+
+    return writeEnvUpdates(this.runtimeRoot, this.env, {
+      CATSCO_HTTP_BASE_URL: state.httpBaseUrl,
+      CATSCO_SERVER_URL: state.serverUrl,
+      CATSCO_CONNECTOR_TOKEN: input.token,
+      CATSCO_DEVICE_ID: deviceId,
+      CATSCO_BODY_ID: deviceId,
+      CATSCO_INSTALLATION_ID: installationId,
+      CATSCOMPANY_HTTP_BASE_URL: state.httpBaseUrl,
+      CATSCOMPANY_SERVER_URL: state.serverUrl,
+      CATSCOMPANY_CONNECTOR_TOKEN: input.token,
+      CATSCOMPANY_DEVICE_ID: deviceId,
+      CATSCOMPANY_BODY_ID: deviceId,
+      CATSCOMPANY_INSTALLATION_ID: installationId,
+    });
+  }
+
   clearAccount(): string[] {
     const config = this.load();
     this.save({
@@ -541,6 +616,19 @@ export class CatsCoLocalConfigService {
           bodyId: config.device.bodyId,
           installationId: config.device.installationId,
           name: config.device.name || '',
+        }
+        : null,
+      deviceConnector: config.deviceConnector
+        ? {
+          ownerUid: config.deviceConnector.ownerUid || '',
+          deviceId: config.deviceConnector.deviceId,
+          installationId: config.deviceConnector.installationId,
+          name: config.deviceConnector.name || '',
+          capabilities: config.deviceConnector.capabilities || [],
+          allowWriteFile: Boolean(config.deviceConnector.allowWriteFile),
+          allowShell: Boolean(config.deviceConnector.allowShell),
+          pairedAt: config.deviceConnector.pairedAt || '',
+          hasToken: Boolean(config.deviceConnector.token),
         }
         : null,
       preferences: {

--- a/src/catscompany/types.ts
+++ b/src/catscompany/types.ts
@@ -7,7 +7,11 @@ export interface CatsCompanyConfig {
   /** WebSocket 服务器地址，如 "ws://localhost:6061/v0/channels" */
   serverUrl: string;
   /** Bot API Key，如 "cc_8_abc123..." */
-  apiKey: string;
+  apiKey?: string;
+  /** Device Connector 专用 token；只允许本机设备注册和 Device RPC 回传 */
+  connectorToken?: string;
+  /** 连接身份模式。默认是完整 agent bot；device_connector 是轻量本机执行载体。 */
+  authMode?: 'bot' | 'device_connector';
   /** 当前本地运行体 ID，用于防止同一个 bot 被多个本地 body 混用 */
   bodyId?: string;
   /** 当前安装/设备 ID，默认与 bodyId 相同 */
@@ -18,6 +22,12 @@ export interface CatsCompanyConfig {
   httpBaseUrl?: string;
   /** 会话过期时间（毫秒），默认 30 分钟 */
   sessionTTL?: number;
+  /** 轻量 connector 暴露给云端的本机工具能力 */
+  capabilities?: string[];
+  /** 是否允许远程写文件；默认不允许 */
+  allowWriteFile?: boolean;
+  /** 是否允许远程执行 shell；默认不允许 */
+  allowShell?: boolean;
 }
 
 /**

--- a/src/commands/device-connector.ts
+++ b/src/commands/device-connector.ts
@@ -1,0 +1,274 @@
+import { Logger } from '../utils/logger';
+import { ConfigManager } from '../utils/config';
+import { ChatConfig } from '../types';
+import { CatsCompanyConfig } from '../catscompany/types';
+import {
+  DEFAULT_CATSCO_HTTP_BASE_URL,
+  createCatsCoLocalConfigService,
+} from '../catscompany/local-config';
+import { resolveCatsCoRuntimeConfig } from '../catscompany/runtime-config';
+import { CatsCoDeviceConnector } from '../catscompany/device-connector';
+
+export interface DeviceConnectorCommandOptions {
+  pair?: string;
+  name?: string;
+  allowWrite?: boolean;
+  allowShell?: boolean;
+  capability?: string[];
+  httpBaseUrl?: string;
+  serverUrl?: string;
+  runtimeRoot?: string;
+}
+
+export interface DeviceConnectorConfigResolution {
+  config?: CatsCompanyConfig;
+  missing: Array<'serverUrl' | 'connectorToken' | 'deviceId'>;
+}
+
+function firstNonEmpty(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    const text = String(value || '').trim();
+    if (text) return text;
+  }
+  return undefined;
+}
+
+function normalizeCapabilities(options: DeviceConnectorCommandOptions, saved?: string[]): string[] {
+  const values = new Set<string>();
+  for (const item of saved && saved.length > 0 ? saved : ['read_file', 'glob', 'grep']) {
+    const text = String(item || '').trim();
+    if (text) values.add(text);
+  }
+  for (const item of options.capability || []) {
+    const text = String(item || '').trim();
+    if (text) values.add(text);
+  }
+  if (options.allowWrite) values.add('write_file');
+  if (options.allowShell) values.add('execute_shell');
+  return Array.from(values);
+}
+
+function normalizeSavedCapabilities(saved?: string[]): string[] | undefined {
+  if (!saved || saved.length === 0) return undefined;
+  const values = new Set<string>();
+  for (const item of saved) {
+    const text = String(item || '').trim();
+    if (text) values.add(text);
+  }
+  return values.size > 0 ? Array.from(values) : undefined;
+}
+
+function limitToApprovedCapabilities(capabilities: string[], approved?: string[]): string[] {
+  if (!approved || approved.length === 0) return capabilities;
+  const allowed = new Set(approved);
+  return capabilities.filter(capability => allowed.has(capability));
+}
+
+export function resolveDeviceConnectorCommandConfig(
+  config: ChatConfig,
+  env: NodeJS.ProcessEnv = process.env,
+  options: DeviceConnectorCommandOptions = {},
+): DeviceConnectorConfigResolution {
+  const resolved = resolveCatsCoRuntimeConfig({
+    runtimeRoot: options.runtimeRoot || process.env.XIAOBA_RUNTIME_ROOT || process.cwd(),
+    env,
+    config,
+    overrides: {
+      httpBaseUrl: options.httpBaseUrl,
+      serverUrl: options.serverUrl,
+    },
+  });
+  const local = resolved.localConfig;
+  const saved = local.deviceConnector;
+  const token = firstNonEmpty(
+    env.CATSCO_CONNECTOR_TOKEN,
+    env.CATSCOMPANY_CONNECTOR_TOKEN,
+    saved?.token,
+  );
+  const deviceId = firstNonEmpty(
+    env.CATSCO_DEVICE_ID,
+    env.CATSCOMPANY_DEVICE_ID,
+    saved?.deviceId,
+    local.device?.deviceId,
+  );
+  const installationId = firstNonEmpty(
+    env.CATSCO_INSTALLATION_ID,
+    env.CATSCOMPANY_INSTALLATION_ID,
+    saved?.installationId,
+    local.device?.installationId,
+    deviceId,
+  );
+  const serverUrl = firstNonEmpty(options.serverUrl, resolved.auth.serverUrl);
+  const httpBaseUrl = firstNonEmpty(options.httpBaseUrl, resolved.auth.httpBaseUrl, DEFAULT_CATSCO_HTTP_BASE_URL);
+  const approvedCapabilities = normalizeSavedCapabilities(saved?.capabilities);
+  const capabilities = limitToApprovedCapabilities(normalizeCapabilities(options, saved?.capabilities), approvedCapabilities);
+
+  const missing: DeviceConnectorConfigResolution['missing'] = [];
+  if (!serverUrl) missing.push('serverUrl');
+  if (!token) missing.push('connectorToken');
+  if (!deviceId) missing.push('deviceId');
+
+  return {
+    missing,
+    config: missing.length === 0 ? {
+      serverUrl: serverUrl!,
+      httpBaseUrl,
+      authMode: 'device_connector',
+      connectorToken: token,
+      bodyId: deviceId,
+      installationId,
+      deviceName: options.name || saved?.name || local.device?.name,
+      capabilities,
+      allowWriteFile: capabilities.includes('write_file') && Boolean(options.allowWrite || saved?.allowWriteFile),
+      allowShell: capabilities.includes('execute_shell') && Boolean(options.allowShell || saved?.allowShell),
+    } : undefined,
+  };
+}
+
+export async function deviceConnectorCommand(options: DeviceConnectorCommandOptions = {}): Promise<void> {
+  const config = ConfigManager.getConfig();
+  const runtimeRoot = options.runtimeRoot || process.env.XIAOBA_RUNTIME_ROOT || process.cwd();
+  const service = createCatsCoLocalConfigService({ runtimeRoot });
+  if (options.pair) {
+    await enrollDeviceConnector(service, config, options);
+  } else {
+    await refreshSavedDeviceConnector(service, config, options).catch((err: any) => {
+      Logger.warning(`CatsCo Device Connector token 刷新失败，将继续使用本地 token: ${err?.message || err}`);
+    });
+  }
+
+  const resolved = resolveDeviceConnectorCommandConfig(config, process.env, options);
+  if (!resolved.config) {
+    Logger.error(`CatsCo Device Connector 配置缺失：${resolved.missing.join(', ') || 'unknown'}。`);
+    Logger.error('请先在 CatsCo 网页端生成配对码，然后运行 catsco device-connector --pair <code>。');
+    process.exit(1);
+  }
+
+  const connector = new CatsCoDeviceConnector(resolved.config);
+  const shutdown = async () => {
+    await connector.destroy();
+    process.exit(0);
+  };
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+  await connector.start();
+}
+
+export async function enrollDeviceConnector(
+  service: ReturnType<typeof createCatsCoLocalConfigService>,
+  config: ChatConfig,
+  options: DeviceConnectorCommandOptions,
+): Promise<void> {
+  const resolved = resolveCatsCoRuntimeConfig({
+    runtimeRoot: options.runtimeRoot || process.env.XIAOBA_RUNTIME_ROOT || process.cwd(),
+    config,
+    overrides: {
+      httpBaseUrl: options.httpBaseUrl,
+      serverUrl: options.serverUrl,
+    },
+  });
+  const deviceId = service.ensureDeviceId();
+  const capabilities = normalizeCapabilities(options);
+  const res = await fetch(`${resolved.auth.httpBaseUrl}/api/device-connectors/enroll`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      pairing_code: options.pair,
+      device_id: deviceId,
+      installation_id: deviceId,
+      device_name: options.name,
+      capabilities,
+    }),
+  });
+  if (!res.ok) {
+    let reason = '';
+    try {
+      const body = await res.json() as any;
+      reason = String(body?.error || body?.message || '').trim();
+    } catch {
+      // Keep the status fallback below when the response is not JSON.
+    }
+    throw new Error(`CatsCo Device Connector 配对失败: ${reason || res.status}`);
+  }
+  const body = await res.json() as any;
+  const token = String(body.connector_token || '').trim();
+  const enrolledDevice = body.device || {};
+  const enrolledDeviceId = String(enrolledDevice.deviceId || enrolledDevice.device_id || deviceId).trim();
+  const installationId = String(enrolledDevice.installationId || enrolledDevice.installation_id || enrolledDeviceId).trim();
+  const enrolledCapabilities = normalizeCapabilityList(enrolledDevice.capabilities || body.capabilities || capabilities);
+  if (!token || !enrolledDeviceId) {
+    throw new Error('CatsCo Device Connector 配对响应缺少 token 或 deviceId。');
+  }
+  service.writeDeviceConnectorEnrollment(resolved.auth, {
+    token,
+    ownerUid: String(enrolledDevice.ownerUserId || enrolledDevice.owner_user_id || resolved.auth.uid || ''),
+    deviceId: enrolledDeviceId,
+    installationId,
+    name: String(enrolledDevice.displayName || enrolledDevice.display_name || options.name || ''),
+    capabilities: enrolledCapabilities,
+    allowWriteFile: Boolean(options.allowWrite && enrolledCapabilities.includes('write_file')),
+    allowShell: Boolean(options.allowShell && enrolledCapabilities.includes('execute_shell')),
+    tokenExpiresAt: tokenExpiresAtFromExpiresIn(body.expires_in),
+  });
+  Logger.success(`CatsCo Device Connector 已绑定设备：${enrolledDeviceId}`);
+}
+
+async function refreshSavedDeviceConnector(
+  service: ReturnType<typeof createCatsCoLocalConfigService>,
+  config: ChatConfig,
+  options: DeviceConnectorCommandOptions,
+): Promise<void> {
+  const local = service.load();
+  const connector = local.deviceConnector;
+  if (!connector?.token) return;
+  const resolved = resolveCatsCoRuntimeConfig({
+    runtimeRoot: options.runtimeRoot || process.env.XIAOBA_RUNTIME_ROOT || process.cwd(),
+    config,
+    overrides: {
+      httpBaseUrl: options.httpBaseUrl,
+      serverUrl: options.serverUrl,
+    },
+  });
+  const res = await fetch(`${resolved.auth.httpBaseUrl}/api/device-connectors/token/refresh`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `DeviceConnector ${connector.token}`,
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`refresh failed: ${res.status}`);
+  }
+  const body = await res.json() as any;
+  const token = String(body.connector_token || '').trim();
+  if (!token) {
+    throw new Error('refresh response missing connector token');
+  }
+  service.writeDeviceConnectorEnrollment(resolved.auth, {
+    token,
+    ownerUid: connector.ownerUid,
+    deviceId: connector.deviceId,
+    installationId: connector.installationId,
+    name: connector.name,
+    capabilities: connector.capabilities,
+    allowWriteFile: connector.allowWriteFile,
+    allowShell: connector.allowShell,
+    tokenExpiresAt: tokenExpiresAtFromExpiresIn(body.expires_in),
+  });
+}
+
+function tokenExpiresAtFromExpiresIn(expiresIn: unknown): string | undefined {
+  const seconds = Number(expiresIn);
+  if (!Number.isFinite(seconds) || seconds <= 0) return undefined;
+  return new Date(Date.now() + seconds * 1000).toISOString();
+}
+
+function normalizeCapabilityList(value: unknown): string[] {
+  if (!Array.isArray(value)) return ['read_file', 'glob', 'grep'];
+  const values = new Set<string>();
+  for (const item of value) {
+    const text = String(item || '').trim();
+    if (text) values.add(text);
+  }
+  return values.size > 0 ? Array.from(values) : ['read_file'];
+}

--- a/src/commands/feishu.ts
+++ b/src/commands/feishu.ts
@@ -2,6 +2,7 @@ import { Logger } from '../utils/logger';
 import { ConfigManager } from '../utils/config';
 import { FeishuBot } from '../feishu';
 import { FeishuConfig } from '../feishu/types';
+import { resolveChannelAgentBindingOptions } from '../core/channel-agent-binding-resolver';
 import { startRuntimeCommandSupport, stopRuntimeCommandSupport } from '../utils/runtime-command-support';
 
 /**
@@ -35,6 +36,7 @@ export async function feishuCommand(): Promise<void> {
     sessionTTL: config.feishu?.sessionTTL,
     botOpenId,
     botAliases,
+    channelAgentBinding: resolveChannelAgentBindingOptions(),
   };
 
   // Bot Bridge 配置

--- a/src/commands/weixin.ts
+++ b/src/commands/weixin.ts
@@ -1,12 +1,14 @@
 import { Logger } from '../utils/logger';
 import { WeixinBot } from '../weixin';
 import { WeixinConfig } from '../weixin/types';
+import { resolveChannelAgentBindingOptions } from '../core/channel-agent-binding-resolver';
 import { startRuntimeCommandSupport, stopRuntimeCommandSupport } from '../utils/runtime-command-support';
 
 export async function weixinCommand(): Promise<void> {
   const token = process.env.WEIXIN_TOKEN;
   const baseUrl = process.env.WEIXIN_BASE_URL || 'https://ilinkai.weixin.qq.com';
   const cdnBaseUrl = process.env.WEIXIN_CDN_BASE_URL || 'https://novac2c.cdn.weixin.qq.com/c2c';
+  const channelAppId = process.env.WEIXIN_APP_ID || process.env.WEIXIN_BOT_ID || process.env.CATSCO_WEIXIN_APP_ID;
 
   if (!token) {
     Logger.error('微信配置缺失。请设置环境变量 WEIXIN_TOKEN');
@@ -15,7 +17,13 @@ export async function weixinCommand(): Promise<void> {
 
   process.env.CURRENT_PLATFORM = '微信';
 
-  const config: WeixinConfig = { token, baseUrl, cdnBaseUrl };
+  const config: WeixinConfig = {
+    token,
+    baseUrl,
+    cdnBaseUrl,
+    channelAppId,
+    channelAgentBinding: resolveChannelAgentBindingOptions(),
+  };
   const bot = new WeixinBot(config);
 
   const shutdown = () => {

--- a/src/core/channel-agent-binding-resolver.ts
+++ b/src/core/channel-agent-binding-resolver.ts
@@ -1,0 +1,175 @@
+import type { ChannelAgentRouteBinding } from './session-router';
+import type { IdentityTrustLevel } from '../types/session-identity';
+
+export interface ChannelAgentBindingResolverOptions {
+  httpBaseUrl?: string;
+  token?: string;
+  enabled?: boolean;
+  required?: boolean;
+  timeoutMs?: number;
+}
+
+export interface ChannelAgentBindingResolveInput {
+  channel: 'feishu' | 'weixin';
+  channelAppId?: string;
+  channelUserId: string;
+  channelConversationId?: string;
+  channelConversationType?: 'p2p' | 'group';
+}
+
+export interface ChannelAgentBindingResolution extends ChannelAgentRouteBinding {
+  bound: boolean;
+  agentUid?: number;
+  ownerUid?: number;
+}
+
+export const CHANNEL_BINDING_REQUIRED_MESSAGE = '请先扫描虚拟员工入口码完成绑定，然后再回来提问。';
+
+export class ChannelAgentBindingResolver {
+  readonly enabled: boolean;
+  readonly required: boolean;
+  readonly misconfiguredRequired: boolean;
+  private readonly httpBaseUrl: string;
+  private readonly token?: string;
+  private readonly timeoutMs: number;
+
+  constructor(options: ChannelAgentBindingResolverOptions = {}) {
+    this.httpBaseUrl = normalizeBaseUrl(options.httpBaseUrl);
+    this.token = options.token?.trim() || undefined;
+    this.timeoutMs = normalizeTimeout(options.timeoutMs);
+    this.required = Boolean(options.required);
+    this.enabled = Boolean((options.enabled || options.required) && this.httpBaseUrl);
+    this.misconfiguredRequired = Boolean(this.required && !this.httpBaseUrl);
+  }
+
+  async resolve(input: ChannelAgentBindingResolveInput): Promise<ChannelAgentBindingResolution | undefined> {
+    if (this.misconfiguredRequired) {
+      throw new Error('channel agent binding is required but CATSCO_CHANNEL_BINDING_HTTP_BASE_URL is missing');
+    }
+    if (!this.enabled) return undefined;
+    const params = new URLSearchParams({
+      channel: input.channel,
+      channel_user_id: input.channelUserId,
+      channel_conversation_type: input.channelConversationType || 'p2p',
+    });
+    if (input.channelAppId) params.set('channel_app_id', input.channelAppId);
+    if (input.channelConversationId) params.set('channel_conversation_id', input.channelConversationId);
+
+    const headers: Record<string, string> = { Accept: 'application/json' };
+    if (this.token) headers.Authorization = `Bearer ${this.token}`;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      const res = await fetch(`${this.httpBaseUrl}/api/channel-agent-bindings/resolve?${params.toString()}`, {
+        method: 'GET',
+        headers,
+        signal: controller.signal,
+      });
+      const data = await res.json().catch(() => ({})) as Record<string, unknown>;
+      if (!res.ok) {
+        throw new Error(stringField(data, 'error') || `binding resolve failed: ${res.status}`);
+      }
+      if (data.bound !== true) {
+        return { bound: false };
+      }
+      const agentId = stringField(data, 'agent_id') || agentIdFromUid(numberField(data, 'agent_uid'));
+      if (!agentId) {
+        throw new Error('binding response is missing agent_id');
+      }
+      return {
+        bound: true,
+        agentUid: numberField(data, 'agent_uid'),
+        ownerUid: numberField(data, 'owner_uid'),
+        agentId,
+        agentBodyId: stringField(data, 'agent_body_id'),
+        identityTrust: trustField(data, 'identity_trust') || 'server_canonical',
+        identitySource: stringField(data, 'identity_source') || 'channel_agent_binding',
+      };
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+export function resolveChannelAgentBindingOptions(
+  env: Record<string, string | undefined> = process.env,
+): ChannelAgentBindingResolverOptions {
+  return {
+    httpBaseUrl: firstNonEmpty(
+      env.CATSCO_CHANNEL_BINDING_HTTP_BASE_URL,
+      env.CATSCOMPANY_CHANNEL_BINDING_HTTP_BASE_URL,
+    ),
+    token: firstNonEmpty(env.CATSCO_CHANNEL_BINDING_TOKEN, env.CATSCOMPANY_CHANNEL_BINDING_TOKEN),
+    enabled: parseBoolean(firstNonEmpty(
+      env.CATSCO_CHANNEL_AGENT_BINDING_ENABLED,
+      env.CATSCOMPANY_CHANNEL_AGENT_BINDING_ENABLED,
+    )),
+    required: parseBoolean(firstNonEmpty(
+      env.CATSCO_CHANNEL_AGENT_BINDING_REQUIRED,
+      env.CATSCOMPANY_CHANNEL_AGENT_BINDING_REQUIRED,
+    )),
+    timeoutMs: parsePositiveInteger(firstNonEmpty(
+      env.CATSCO_CHANNEL_BINDING_TIMEOUT_MS,
+      env.CATSCOMPANY_CHANNEL_BINDING_TIMEOUT_MS,
+    )),
+  };
+}
+
+function normalizeBaseUrl(value?: string): string {
+  const text = value?.trim();
+  if (!text) return '';
+  return text.replace(/\/+$/, '');
+}
+
+function firstNonEmpty(...values: Array<string | undefined>): string | undefined {
+  for (const value of values) {
+    const text = value?.trim();
+    if (text) return text;
+  }
+  return undefined;
+}
+
+function parseBoolean(value?: string): boolean {
+  const text = value?.trim().toLowerCase();
+  return text === '1' || text === 'true' || text === 'yes' || text === 'required';
+}
+
+function parsePositiveInteger(value?: string): number | undefined {
+  const text = value?.trim();
+  if (!text) return undefined;
+  const parsed = Number(text);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : undefined;
+}
+
+function normalizeTimeout(value?: number): number {
+  if (!Number.isFinite(value) || !value || value <= 0) return 2500;
+  return Math.max(250, Math.min(Math.floor(value), 10000));
+}
+
+function stringField(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function numberField(record: Record<string, unknown>, key: string): number | undefined {
+  const value = record[key];
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+
+function trustField(record: Record<string, unknown>, key: string): IdentityTrustLevel | undefined {
+  const value = stringField(record, key);
+  if (value === 'server_canonical' || value === 'legacy_context' || value === 'untrusted') {
+    return value;
+  }
+  return undefined;
+}
+
+function agentIdFromUid(uid?: number): string | undefined {
+  return uid && uid > 0 ? `usr${uid}` : undefined;
+}

--- a/src/core/device-grants.ts
+++ b/src/core/device-grants.ts
@@ -45,6 +45,11 @@ export interface ResolveDeviceGrantOptions {
   now?: number;
 }
 
+const DELEGATED_DEVICE_GRANT_SOURCES = new Set([
+  'channel_agent_binding',
+  'channel_identity_link',
+]);
+
 export function createUserDevice(input: CreateUserDeviceInput): UserDevice | undefined {
   const source = normalizeSource(input.source);
   const ownerUserId = normalizeId(input.ownerUserId);
@@ -78,6 +83,8 @@ export function createDeviceGrant(
   if (operations.length === 0) return undefined;
   if (device.source !== scope.source) return undefined;
   if (device.ownerUserId !== scope.actorUserId) return undefined;
+  if (device.identityTrust !== 'server_canonical') return undefined;
+  if (device.status !== 'online') return undefined;
   const now = normalizeTime(options.now) ?? Date.now();
   const ttlMs = normalizeTtl(options.ttlMs);
 
@@ -165,8 +172,12 @@ export function validateDeviceGrant(
     return denied(`设备授权不是 active 状态，已阻止操作：${grant.status}`);
   }
 
-  if (grant.identityTrust === 'untrusted') {
-    return denied('设备授权来自未可信身份，已阻止操作。');
+  if (grant.identityTrust !== 'server_canonical') {
+    return denied('设备授权不是服务端可信身份签发，已阻止操作。');
+  }
+
+  if (grant.ownerUserId !== grant.actorUserId && !isDelegatedDeviceGrant(grant)) {
+    return denied('设备授权的设备 owner 与当前 actor 不一致，且缺少可信的渠道委托标记，已阻止操作。');
   }
 
   if (!grant.operations.includes(options.operation)) {
@@ -188,10 +199,6 @@ export function validateDeviceGrant(
     ['agentBodyId', grant.agentBodyId, scope.agentBodyId],
   ].filter(([, grantValue, scopeValue]) => grantValue !== scopeValue);
 
-  if (grant.ownerUserId !== scope.actorUserId) {
-    mismatches.push(['ownerUserId', grant.ownerUserId, scope.actorUserId]);
-  }
-
   if (mismatches.length > 0) {
     return {
       ok: false,
@@ -204,6 +211,13 @@ export function validateDeviceGrant(
   }
 
   return { ok: true, grant };
+}
+
+export function isDelegatedDeviceGrant(grant: Pick<ScopedDeviceGrant, 'ownerUserId' | 'actorUserId' | 'identityTrust' | 'identitySource'>): boolean {
+  if (grant.ownerUserId === grant.actorUserId) return false;
+  if (grant.identityTrust !== 'server_canonical') return false;
+  const identitySource = normalizeId(grant.identitySource);
+  return Boolean(identitySource && DELEGATED_DEVICE_GRANT_SOURCES.has(identitySource));
 }
 
 function denied(message: string): DeviceGrantDecision {

--- a/src/core/runtime-context-builder.ts
+++ b/src/core/runtime-context-builder.ts
@@ -55,25 +55,36 @@ interface RuntimeContextSnapshot {
       source: MessageSource;
       deviceId?: string;
     };
-    userDevices?: Array<{
-      grantId: string;
-      deviceId: string;
-      displayName?: string;
-      operations: string[];
-      status: string;
-      expiresAt: number;
-    }>;
+      userDevices?: Array<{
+        grantId: string;
+        deviceId: string;
+        displayName?: string;
+        operations: string[];
+        status: string;
+        routable?: boolean;
+        routeConnected?: boolean;
+        ttlMs?: number;
+        expiresAt: number;
+      }>;
     deviceSelection?: {
       status: string;
       selectionSource?: string;
       selectedDevice?: {
         deviceId: string;
         displayName?: string;
+        status?: string;
+        routable?: boolean;
+        routeConnected?: boolean;
+        unavailableReason?: string;
         operations?: string[];
       };
       candidates?: Array<{
         deviceId: string;
         displayName?: string;
+        status?: string;
+        routable?: boolean;
+        routeConnected?: boolean;
+        unavailableReason?: string;
         operations?: string[];
       }>;
       candidateCount?: number;
@@ -190,11 +201,14 @@ function sanitizeDeviceGrants(grants?: ScopedDeviceGrant[]): RuntimeContextSnaps
   return grants.map(grant => pruneUndefined({
     grantId: grant.grantId,
     deviceId: grant.deviceId,
-    displayName: grant.deviceDisplayName,
-    operations: [...grant.operations],
-    status: grant.status,
-    expiresAt: grant.expiresAt,
-  }));
+      displayName: grant.deviceDisplayName,
+      operations: [...grant.operations],
+      status: grant.status,
+      routable: grant.deviceRoutable,
+      routeConnected: grant.deviceRouteConnected,
+      ttlMs: Math.max(0, grant.expiresAt - Date.now()),
+      expiresAt: grant.expiresAt,
+    }));
 }
 
 function sanitizeDeviceSelection(selection?: ScopedDeviceSelection): RuntimeContextSnapshot['execution']['deviceSelection'] | undefined {
@@ -206,12 +220,20 @@ function sanitizeDeviceSelection(selection?: ScopedDeviceSelection): RuntimeCont
       ? pruneUndefined({
         deviceId: selection.selectedDeviceId,
         displayName: selection.selectedDeviceDisplayName,
+        status: selection.selectedDeviceStatus,
+        routable: selection.selectedDeviceRoutable,
+        routeConnected: selection.selectedDeviceRouteConnected,
+        unavailableReason: selection.selectedDeviceUnavailableReason,
         operations: selection.selectedDeviceOperations ? [...selection.selectedDeviceOperations] : undefined,
       })
       : undefined,
     candidates: selection.candidates?.map(candidate => pruneUndefined({
       deviceId: candidate.deviceId,
       displayName: candidate.displayName,
+      status: candidate.status,
+      routable: candidate.routable,
+      routeConnected: candidate.routeConnected,
+      unavailableReason: candidate.unavailableReason,
       operations: candidate.operations ? [...candidate.operations] : undefined,
     })),
     candidateCount: selection.candidateCount,

--- a/src/core/session-router.ts
+++ b/src/core/session-router.ts
@@ -25,6 +25,13 @@ export interface CreateSessionRouteInput {
   legacySessionKey?: string;
 }
 
+export interface ChannelAgentRouteBinding {
+  agentId?: string;
+  agentBodyId?: string;
+  identityTrust?: IdentityTrustLevel;
+  identitySource?: string;
+}
+
 export interface ParsedSessionKeyV2 {
   version: 2;
   source: MessageSource;
@@ -92,7 +99,10 @@ export function createCatsCoSessionRoute(envelope: MessageEnvelope): SessionRout
   });
 }
 
-export function createFeishuSessionRoute(message: ParsedFeishuMessage): SessionRoute {
+export function createFeishuSessionRoute(
+  message: ParsedFeishuMessage,
+  binding?: ChannelAgentRouteBinding,
+): SessionRoute {
   const topicType: MessageTopicType = message.chatType === 'group' ? 'group' : 'p2p';
   const topicId = normalizeId(message.chatId) || normalizeId(message.senderId) || 'unknown_chat';
   return createSessionRoute({
@@ -100,9 +110,11 @@ export function createFeishuSessionRoute(message: ParsedFeishuMessage): SessionR
     topicId,
     topicType,
     actorUserId: message.senderId,
+    agentId: binding?.agentId,
+    agentBodyId: binding?.agentBodyId,
     messageId: message.messageId,
-    identityTrust: 'legacy_context',
-    identitySource: 'feishu.event',
+    identityTrust: binding?.identityTrust || 'legacy_context',
+    identitySource: binding?.identitySource || 'feishu.event',
     legacySessionKey: buildLegacyFeishuSessionKey(topicType, topicId, message.senderId),
   });
 }
@@ -126,16 +138,21 @@ export function createFeishuBridgeSessionRoute(input: {
   });
 }
 
-export function createWeixinSessionRoute(message: WeixinMessage): SessionRoute {
+export function createWeixinSessionRoute(
+  message: WeixinMessage,
+  binding?: ChannelAgentRouteBinding,
+): SessionRoute {
   const actorUserId = normalizeId(message.from?.id) || 'unknown_user';
   return createSessionRoute({
     source: 'weixin',
     topicId: actorUserId,
     topicType: 'p2p',
     actorUserId,
+    agentId: binding?.agentId,
+    agentBodyId: binding?.agentBodyId,
     messageId: message.message_id,
-    identityTrust: 'legacy_context',
-    identitySource: 'weixin.ilink',
+    identityTrust: binding?.identityTrust || 'legacy_context',
+    identitySource: binding?.identitySource || 'weixin.ilink',
     legacySessionKey: `user:${actorUserId}`,
   });
 }

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -53,6 +53,7 @@ import {
 
 const DEFAULT_CATSCO_HTTP_BASE_URL = 'https://app.catsco.cc';
 const DEFAULT_CATSCO_WS_URL = 'wss://app.catsco.cc/v0/channels';
+const CATS_DEVICE_AUTH_SNAPSHOT_FILE = 'catsco-device-authorization.json';
 const BUNDLED_SKILL_MARKER = '.xiaoba-bundled-skill.json';
 const SYSTEM_SKILL_DIRS = new Set<string>();
 
@@ -653,11 +654,12 @@ async function getCatsDeviceRpcStatus(state: CatsAuthState, botUid?: string): Pr
     const disconnectedPending = scopedPending.filter((item: any) => item.requesterConnected === false || item.targetConnected === false);
     const serverState = safeCatsStatusString(data?.state);
     const routeState = safeCatsStatusString(data?.route_state || data?.routeState);
+    const routerReady = isCatsRouteStateReady(routeState);
     return {
-      state: disconnectedPending.length > 0 ? 'degraded' : serverState || 'ok',
+      state: !routerReady ? 'degraded' : disconnectedPending.length > 0 ? 'degraded' : serverState || 'ok',
       runtimeMode: safeCatsStatusString(data?.runtime_mode || data?.runtimeMode),
       routeState,
-      routerReady: routeState ? routeState === 'ready' || routeState === 'process_local' : true,
+      routerReady,
       pendingCount: scopedPending.length,
       disconnectedPendingCount: disconnectedPending.length,
       pending: scopedPending,
@@ -684,6 +686,242 @@ async function getCatsDeviceRpcStatus(state: CatsAuthState, botUid?: string): Pr
       error: redactCatsStatusError(String(error?.message || 'unable to query CatsCo device RPC status')),
     };
   }
+}
+
+async function getCatsDevicesStatus(state: CatsAuthState): Promise<Record<string, unknown>> {
+  if (!state.token) {
+    return {
+      state: 'not_configured',
+      devices: [],
+      deviceCount: 0,
+      routableCount: 0,
+    };
+  }
+
+  try {
+    const data = await catsRequest(
+      'GET',
+      state.httpBaseUrl,
+      '/api/devices',
+      undefined,
+      state.token,
+      { timeoutMs: 2500 },
+    );
+    const devices = Array.isArray(data?.devices)
+      ? data.devices.map(sanitizeCatsDeviceStatus).filter(Boolean)
+      : [];
+    const routableCount = devices.filter((device: any) => device.routable === true).length;
+    const activeCount = devices.filter((device: any) => device.active === true).length;
+    return {
+      state: 'ok',
+      devices,
+      deviceCount: devices.length,
+      activeCount,
+      routableCount,
+      checkedAt: new Date().toISOString(),
+    };
+  } catch (error: any) {
+    const status = Number(error?.status || 0);
+    if (status === 401 || status === 403) {
+      return {
+        state: 'auth_error',
+        devices: [],
+        deviceCount: 0,
+        routableCount: 0,
+        checkedAt: new Date().toISOString(),
+        error: status === 403
+          ? '当前 CatsCo 账号不能查询设备状态'
+          : 'CatsCo 登录态无法查询设备状态，请重新登录',
+      };
+    }
+    return {
+      state: 'unknown',
+      devices: [],
+      deviceCount: 0,
+      routableCount: 0,
+      checkedAt: new Date().toISOString(),
+      error: redactCatsStatusError(String(error?.message || 'unable to query CatsCo devices')),
+    };
+  }
+}
+
+function sanitizeCatsDeviceStatus(item: any): Record<string, unknown> | undefined {
+  if (!item || typeof item !== 'object') return undefined;
+  const deviceId = safeCatsStatusString(item.deviceId || item.device_id);
+  if (!deviceId) return undefined;
+  const capabilities = Array.isArray(item.capabilities)
+    ? item.capabilities.map((value: unknown) => safeCatsStatusString(value)).filter(Boolean)
+    : [];
+  return {
+    deviceId,
+    displayName: safeCatsStatusString(item.displayName || item.display_name),
+    status: safeCatsStatusString(item.status),
+    active: Boolean(item.active),
+    routeConnected: Boolean(item.routeConnected || item.route_connected),
+    routable: Boolean(item.routable),
+    unavailableReason: safeCatsStatusString(item.unavailableReason || item.unavailable_reason),
+    capabilities,
+    registeredAt: Number.isFinite(Number(item.registeredAt || item.registered_at)) ? Number(item.registeredAt || item.registered_at) : undefined,
+    lastSeenAt: Number.isFinite(Number(item.lastSeenAt || item.last_seen_at)) ? Number(item.lastSeenAt || item.last_seen_at) : undefined,
+  };
+}
+
+function isCatsRouteStateReady(routeState?: string): boolean {
+  const normalized = safeCatsStatusString(routeState);
+  if (!normalized) return true;
+  if (normalized === 'unavailable' || normalized === 'degraded' || normalized === 'error' || normalized === 'unknown') {
+    return false;
+  }
+  return normalized === 'ready'
+    || normalized === 'process_local'
+    || normalized === 'shared_memory'
+    || normalized === 'redis'
+    || normalized.endsWith('_ready');
+}
+
+function buildCatsDeviceAuthorizationSummary(
+  devicesStatus: Record<string, unknown>,
+  deviceRpcStatus: Record<string, unknown>,
+): Record<string, unknown> {
+  const localSnapshot = readCatsDeviceAuthorizationSnapshot();
+  const hasPendingRpc = Array.isArray(deviceRpcStatus.pending) && deviceRpcStatus.pending.length > 0;
+  if (localSnapshot && localSnapshot.state !== 'stale' && !hasPendingRpc) {
+    return mergeCatsDeviceAuthorizationSnapshot(localSnapshot, devicesStatus, deviceRpcStatus);
+  }
+  const devices = Array.isArray(devicesStatus.devices) ? devicesStatus.devices as Array<Record<string, unknown>> : [];
+  const pending = Array.isArray(deviceRpcStatus.pending) ? deviceRpcStatus.pending as Array<Record<string, unknown>> : [];
+  const firstPending = pending[0];
+  const selectedDeviceId = safeCatsStatusString(firstPending?.deviceId);
+  const selected = selectedDeviceId
+    ? devices.find(device => device.deviceId === selectedDeviceId)
+    : undefined;
+  const unavailable = devices.filter(device => device.routable !== true);
+  const pendingOperation = safeCatsStatusString(firstPending?.operation);
+  const ttlMs = Number.isFinite(Number(firstPending?.ttlMs)) ? Number(firstPending?.ttlMs) : undefined;
+  const deniedReason = selected
+    ? safeCatsStatusString(selected.unavailableReason)
+    : devices.length > 0 && Number(devicesStatus.routableCount || 0) === 0 && unavailable.length > 0
+      ? safeCatsStatusString(unavailable[0].unavailableReason)
+      : undefined;
+  const state = firstPending
+    ? 'pending'
+    : selected
+      ? selected.routable === true ? 'ready' : 'unavailable'
+      : devices.length > 0
+        ? Number(devicesStatus.routableCount || 0) > 0 ? 'available' : 'needs_route'
+        : 'no_devices';
+  return {
+    state,
+    selectedDevice: selected ? {
+      deviceId: selected.deviceId,
+      displayName: selected.displayName,
+      status: selected.status,
+      active: selected.active,
+      routeConnected: selected.routeConnected,
+      routable: selected.routable,
+      unavailableReason: selected.unavailableReason,
+    } : undefined,
+    operations: pendingOperation ? [pendingOperation] : [],
+    ttlMs,
+    pendingCount: pending.length,
+    deniedReason,
+    candidateCount: devices.length,
+    routableCount: Number(devicesStatus.routableCount || 0),
+    unavailableCandidates: unavailable.slice(0, 5).map(device => ({
+      deviceId: device.deviceId,
+      displayName: device.displayName,
+      status: device.status,
+      active: device.active,
+      routeConnected: device.routeConnected,
+      routable: device.routable,
+      unavailableReason: device.unavailableReason,
+    })),
+  };
+}
+
+function readCatsDeviceAuthorizationSnapshot(): Record<string, unknown> | undefined {
+  try {
+    const snapshotPath = path.join(process.cwd(), 'tmp', CATS_DEVICE_AUTH_SNAPSHOT_FILE);
+    if (!fs.existsSync(snapshotPath)) return undefined;
+    const raw = fs.readFileSync(snapshotPath, 'utf-8');
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || parsed.schema !== 'catsco.device_authorization.v1') return undefined;
+    const updatedAt = Date.parse(String(parsed.updatedAt || ''));
+    const ageMs = Number.isFinite(updatedAt) ? Date.now() - updatedAt : Number.POSITIVE_INFINITY;
+    const sanitized = sanitizeCatsDeviceAuthorizationSnapshot(parsed);
+    if (ageMs > 10 * 60_000) {
+      return { ...sanitized, state: 'stale', stale: true };
+    }
+    return sanitized;
+  } catch {
+    return undefined;
+  }
+}
+
+function sanitizeCatsDeviceAuthorizationSnapshot(snapshot: any): Record<string, unknown> {
+  const selected = snapshot.selectedDevice && typeof snapshot.selectedDevice === 'object'
+    ? sanitizeCatsDeviceStatus({
+      deviceId: snapshot.selectedDevice.deviceId,
+      displayName: snapshot.selectedDevice.displayName,
+      status: snapshot.selectedDevice.status,
+      active: snapshot.selectedDevice.active,
+      routeConnected: snapshot.selectedDevice.routeConnected,
+      routable: snapshot.selectedDevice.routable,
+      unavailableReason: snapshot.selectedDevice.unavailableReason,
+      capabilities: snapshot.operations,
+    })
+    : undefined;
+  const candidates = Array.isArray(snapshot.candidates)
+    ? snapshot.candidates.map(sanitizeCatsDeviceStatus).filter(Boolean)
+    : [];
+  return {
+    state: safeCatsStatusString(snapshot.state) || 'unknown',
+    source: 'last_catsco_turn',
+    updatedAt: safeCatsStatusString(snapshot.updatedAt),
+    topicId: safeCatsStatusString(snapshot.topicId),
+    topicType: safeCatsStatusString(snapshot.topicType),
+    actorUserId: safeCatsStatusString(snapshot.actorUserId),
+    agentId: safeCatsStatusString(snapshot.agentId),
+    messageSeq: Number.isFinite(Number(snapshot.messageSeq)) ? Number(snapshot.messageSeq) : undefined,
+    selectionSource: safeCatsStatusString(snapshot.selectionSource),
+    selectedDevice: selected,
+    operations: Array.isArray(snapshot.operations) ? snapshot.operations.map((value: unknown) => safeCatsStatusString(value)).filter(Boolean) : [],
+    ttlMs: Number.isFinite(Number(snapshot.ttlMs)) ? Math.max(0, Number(snapshot.ttlMs)) : undefined,
+    expiresAt: Number.isFinite(Number(snapshot.expiresAt)) ? Number(snapshot.expiresAt) : undefined,
+    deniedReason: safeCatsStatusString(snapshot.deniedReason),
+    candidates,
+    grantCount: Number.isFinite(Number(snapshot.grantCount)) ? Number(snapshot.grantCount) : 0,
+  };
+}
+
+function mergeCatsDeviceAuthorizationSnapshot(
+  snapshot: Record<string, unknown>,
+  devicesStatus: Record<string, unknown>,
+  deviceRpcStatus: Record<string, unknown>,
+): Record<string, unknown> {
+  const pending = Array.isArray(deviceRpcStatus.pending) ? deviceRpcStatus.pending as Array<Record<string, unknown>> : [];
+  const devices = Array.isArray(devicesStatus.devices) ? devicesStatus.devices as Array<Record<string, unknown>> : [];
+  const selected = snapshot.selectedDevice && typeof snapshot.selectedDevice === 'object'
+    ? { ...(snapshot.selectedDevice as Record<string, unknown>) }
+    : undefined;
+  const selectedDeviceId = safeCatsStatusString(selected?.deviceId);
+  const liveDevice = selectedDeviceId ? devices.find(device => device.deviceId === selectedDeviceId) : undefined;
+  const mergedSelected = selected || liveDevice
+    ? {
+      ...(selected || {}),
+      ...(liveDevice || {}),
+    }
+    : undefined;
+  const pendingForSelected = selectedDeviceId
+    ? pending.filter(item => item.deviceId === selectedDeviceId)
+    : pending;
+  return {
+    ...snapshot,
+    selectedDevice: mergedSelected,
+    pendingCount: pendingForSelected.length,
+    routableCount: Number(devicesStatus.routableCount || 0),
+    deniedReason: snapshot.deniedReason || safeCatsStatusString(mergedSelected?.unavailableReason),
+  };
 }
 
 function sanitizeCatsDeviceRpcPending(item: any): Record<string, unknown> | undefined {
@@ -2105,6 +2343,8 @@ export function createApiRouter(serviceManager: ServiceManager, updateController
     const localBodyId = runtime.localConfig.device?.bodyId;
     const bodyStatus = await getCatsBotBodyStatus(state, state.botUid, localBodyId);
     const deviceRpcStatus = await getCatsDeviceRpcStatus(state, state.botUid);
+    const devicesStatus = await getCatsDevicesStatus(state);
+    const deviceAuthorization = buildCatsDeviceAuthorizationSummary(devicesStatus, deviceRpcStatus);
     const bodyBlocking = bodyStatus.state === 'conflict' || bodyStatus.state === 'auth_error';
     const bindingConfigured = connected && runtime.bodyConfigured && !bodyBlocking;
     const bodyLeaseReady = bodyStatus.state === 'online' && Boolean(bodyStatus.active);
@@ -2133,6 +2373,8 @@ export function createApiRouter(serviceManager: ServiceManager, updateController
       } : null,
       device: runtime.localConfig.device || null,
       bodyStatus,
+      devicesStatus,
+      deviceAuthorization,
       deviceRpcStatus,
       conflicts: runtime.conflicts,
       topicId: chatReady && user?.uid && state.botUid ? p2pTopicId(user.uid, state.botUid) : '',

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -12,6 +12,7 @@ import { PathResolver } from '../../utils/path-resolver';
 import { APP_VERSION } from '../../version';
 import type { ChatConfig } from '../../types';
 import { createRuntimeConfigSnapshot } from '../../runtime/runtime-config-snapshot';
+import { enrollDeviceConnector } from '../../commands/device-connector';
 import {
   CUSTOM_MODEL_DEFAULT_CONTEXT_WINDOW_TOKENS,
   calculatePromptBudgetTokens,
@@ -221,6 +222,42 @@ function hostLabel(value: string): string {
   } catch {
     return value;
   }
+}
+
+function normalizeDevicePairingCode(value: unknown): string {
+  const text = String(value || '').trim();
+  if (!/^[A-Za-z0-9_-]{6,160}$/.test(text)) {
+    throw httpError('invalid device pairing code', 400);
+  }
+  return text;
+}
+
+function normalizeLaunchUrl(
+  value: unknown,
+  fallback: string,
+  allowedProtocols: Set<string>,
+): string {
+  const raw = String(value || '').trim();
+  const candidate = raw || fallback;
+  let parsed: URL;
+  try {
+    parsed = new URL(candidate);
+  } catch {
+    throw httpError('invalid connector launch URL', 400);
+  }
+  if (!allowedProtocols.has(parsed.protocol)) {
+    throw httpError('unsupported connector launch URL protocol', 400);
+  }
+  return parsed.toString().replace(/\/+$/, '');
+}
+
+function defaultWsUrlForHttpBase(httpBaseUrl: string): string {
+  const url = new URL(httpBaseUrl);
+  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+  url.pathname = '/v0/channels';
+  url.search = '';
+  url.hash = '';
+  return url.toString().replace(/\/+$/, '');
 }
 
 function createCatsNetworkError(error: any, httpBaseUrl: string): Error {
@@ -2813,6 +2850,92 @@ export function createApiRouter(serviceManager: ServiceManager, updateController
       res.json({ ok: true, preferences });
     } catch (e: any) {
       res.status(500).json({ error: e.message });
+    }
+  });
+
+  router.post('/cats/device-connector/pair', async (req, res) => {
+    try {
+      const pairingCode = normalizeDevicePairingCode(
+        req.body?.pairing_code || req.body?.pairingCode || req.body?.code,
+      );
+      const httpBaseUrl = normalizeLaunchUrl(
+        req.body?.http_base_url || req.body?.httpBaseUrl,
+        DEFAULT_CATSCO_HTTP_BASE_URL,
+        new Set(['http:', 'https:']),
+      );
+      const serverUrl = normalizeLaunchUrl(
+        req.body?.server_url || req.body?.serverUrl,
+        defaultWsUrlForHttpBase(httpBaseUrl),
+        new Set(['ws:', 'wss:']),
+      );
+      const deviceName = String(req.body?.device_name || req.body?.deviceName || req.body?.name || '').trim();
+      const localConfig = createCatsCoLocalConfigService({ runtimeRoot: process.cwd() });
+
+      await enrollDeviceConnector(localConfig, ConfigManager.getConfig(), {
+        pair: pairingCode,
+        httpBaseUrl,
+        serverUrl,
+        name: deviceName || undefined,
+      });
+
+      const current = serviceManager.getService('device-connector');
+      const wasRunning = current?.status === 'running';
+      const service = wasRunning
+        ? serviceManager.restart('device-connector')
+        : serviceManager.start('device-connector');
+
+      res.json({
+        ok: true,
+        service,
+        connectorStarted: !wasRunning,
+        connectorRestarted: wasRunning,
+        message: wasRunning
+          ? 'CatsCo Device Connector 已重新配对并在后台重启。'
+          : 'CatsCo Device Connector 已配对并在后台启动。',
+      });
+    } catch (e: any) {
+      res.status(e.status || 400).json({ error: e.message || 'device connector pairing failed' });
+    }
+  });
+
+  router.post('/cats/device-connector/ensure-running', async (_req, res) => {
+    try {
+      const localConfig = createCatsCoLocalConfigService({ runtimeRoot: process.cwd() }).load();
+      const connector = localConfig.deviceConnector;
+      if (localConfig.preferences?.autoConnect === false) {
+        return res.status(409).json({
+          ok: false,
+          error: 'Device Connector auto-connect is disabled',
+          reason: 'AUTO_CONNECT_DISABLED',
+        });
+      }
+      if (!connector?.token || !connector.deviceId) {
+        return res.status(409).json({
+          ok: false,
+          error: 'Device Connector is not paired',
+          reason: 'DEVICE_CONNECTOR_NOT_PAIRED',
+        });
+      }
+
+      const current = serviceManager.getService('device-connector');
+      if (current?.status === 'running') {
+        return res.json({
+          ok: true,
+          service: current,
+          connectorStarted: false,
+          connectorRestarted: false,
+        });
+      }
+
+      const service = serviceManager.start('device-connector');
+      return res.json({
+        ok: true,
+        service,
+        connectorStarted: true,
+        connectorRestarted: false,
+      });
+    } catch (e: any) {
+      return res.status(e.status || 400).json({ error: e.message || 'device connector start failed' });
     }
   });
 

--- a/src/dashboard/service-manager.ts
+++ b/src/dashboard/service-manager.ts
@@ -141,6 +141,17 @@ export class ServiceManager extends EventEmitter {
       logs: [],
     });
 
+    this.services.set('device-connector', {
+      info: {
+        name: 'device-connector',
+        label: 'CatsCo Device Connector',
+        command,
+        args: args('device-connector'),
+        status: 'stopped',
+      },
+      logs: [],
+    });
+
     this.services.set('feishu', {
       info: {
         name: 'feishu',

--- a/src/feishu/index.ts
+++ b/src/feishu/index.ts
@@ -15,12 +15,17 @@ import { ChannelCallbacks } from '../types/tool';
 import { AdapterRuntimeBundle, createAdapterRuntime } from '../runtime/adapter-runtime';
 import { randomUUID } from 'crypto';
 import {
+  ChannelAgentBindingResolver,
+  CHANNEL_BINDING_REQUIRED_MESSAGE,
+} from '../core/channel-agent-binding-resolver';
+import {
   createExecutionScopeFromRoute,
   createFeishuBridgeSessionRoute,
   createFeishuSessionRoute,
   createSessionRoute,
   parseSessionKeyV2,
 } from '../core/session-router';
+import type { ChannelAgentRouteBinding } from '../core/session-router';
 import type { SessionRoute } from '../types/session-identity';
 
 interface PendingAttachment {
@@ -93,6 +98,8 @@ export class FeishuBot {
   private sessionManager: MessageSessionManager;
   private agentServices: AgentServices;
   private runtime: AdapterRuntimeBundle;
+  private bindingResolver: ChannelAgentBindingResolver;
+  private channelAppId: string;
   private bridgeServer: BridgeServer | null = null;
   private bridgeClient: BridgeClient | null = null;
   private bridgeConfig: FeishuConfig['bridge'] | undefined;
@@ -115,6 +122,8 @@ export class FeishuBot {
       appId: config.appId,
       appSecret: config.appSecret,
     };
+    this.channelAppId = config.appId;
+    this.bindingResolver = new ChannelAgentBindingResolver(config.channelAgentBinding);
 
     this.client = new Lark.Client(baseConfig);
     this.wsClient = new Lark.WSClient({
@@ -267,8 +276,10 @@ export class FeishuBot {
       this.processedMsgIds = new Set(ids.slice(-500));
     }
 
+    const routeBinding = await this.resolveChannelAgentBinding(msg);
+    if (routeBinding === null) return;
 
-    const route = createFeishuSessionRoute(msg);
+    const route = createFeishuSessionRoute(msg, routeBinding);
     const key = route.sessionKey;
     const isGroup = msg.chatType === 'group';
 
@@ -463,6 +474,50 @@ export class FeishuBot {
       source: 'subagent_feedback',
     });
     this.messageQueue.set(sessionKey, queue);
+  }
+
+  private async resolveChannelAgentBinding(msg: ReturnType<MessageHandler['parse']>): Promise<ChannelAgentRouteBinding | undefined | null> {
+    if (!msg) return undefined;
+    if (!this.bindingResolver.enabled) {
+      if (this.bindingResolver.required) {
+        await this.sender.reply(msg.chatId, '虚拟员工绑定服务未配置，请联系管理员检查 CatsCo 绑定地址。');
+        Logger.warning(`[feishu_binding] required=true but resolver is disabled: sender=${msg.senderId}, chat=${msg.chatId}`);
+        return null;
+      }
+      return undefined;
+    }
+    if (msg.chatType !== 'p2p') return undefined;
+    try {
+      const resolution = await this.bindingResolver.resolve({
+        channel: 'feishu',
+        channelAppId: this.channelAppId,
+        channelUserId: msg.senderId,
+        channelConversationType: 'p2p',
+      });
+      if (!resolution) {
+        if (this.bindingResolver.required) {
+          await this.sender.reply(msg.chatId, '虚拟员工绑定查询失败，请稍后重试。');
+          return null;
+        }
+        return undefined;
+      }
+      if (!resolution.bound) {
+        if (this.bindingResolver.required) {
+          await this.sender.reply(msg.chatId, CHANNEL_BINDING_REQUIRED_MESSAGE);
+          Logger.warning(`[feishu_binding] 未找到绑定: sender=${msg.senderId}, chat=${msg.chatId}`);
+          return null;
+        }
+        return undefined;
+      }
+      return resolution;
+    } catch (error: any) {
+      Logger.warning(`[feishu_binding] 绑定查询失败: ${error?.message || error}`);
+      if (this.bindingResolver.required) {
+        await this.sender.reply(msg.chatId, '虚拟员工绑定查询失败，请稍后重试。');
+        return null;
+      }
+      return undefined;
+    }
   }
 
   /**

--- a/src/feishu/types.ts
+++ b/src/feishu/types.ts
@@ -10,6 +10,8 @@ export interface FeishuConfig {
   botOpenId?: string;
   /** 机器人别名（当未配置 botOpenId 时用于兜底匹配） */
   botAliases?: string[];
+  /** CatsCo channel binding resolver for QR-bound virtual employees */
+  channelAgentBinding?: import('../core/channel-agent-binding-resolver').ChannelAgentBindingResolverOptions;
   /** Bot Bridge 配置 */
   bridge?: {
     port: number;

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,38 @@ function main() {
     });
 
   program
+    .command('device-connector')
+    .description('Start the lightweight CatsCo local device connector')
+    .option('--pair <code>', 'Pair this device with a CatsCo account using a pairing code')
+    .option('--name <name>', 'Set the local device display name')
+    .option('--allow-write', 'Allow approved remote write_file requests on this device')
+    .option('--allow-shell', 'Allow approved remote execute_shell requests on this device')
+    .option('--capability <capability...>', 'Expose additional device capabilities')
+    .option('--http-base-url <url>', 'CatsCo HTTP API base URL')
+    .option('--server-url <url>', 'CatsCo WebSocket URL')
+    .option('--runtime-root <path>', 'Runtime directory for CatsCo local connector config')
+    .action(async (options) => {
+      const { deviceConnectorCommand } = await import('./commands/device-connector');
+      await deviceConnectorCommand(options);
+    });
+
+  program
+    .command('connector')
+    .description('Start the lightweight CatsCo local device connector')
+    .option('--pair <code>', 'Pair this device with a CatsCo account using a pairing code')
+    .option('--name <name>', 'Set the local device display name')
+    .option('--allow-write', 'Allow approved remote write_file requests on this device')
+    .option('--allow-shell', 'Allow approved remote execute_shell requests on this device')
+    .option('--capability <capability...>', 'Expose additional device capabilities')
+    .option('--http-base-url <url>', 'CatsCo HTTP API base URL')
+    .option('--server-url <url>', 'CatsCo WebSocket URL')
+    .option('--runtime-root <path>', 'Runtime directory for CatsCo local connector config')
+    .action(async (options) => {
+      const { deviceConnectorCommand } = await import('./commands/device-connector');
+      await deviceConnectorCommand(options);
+    });
+
+  program
     .command('catsco')
     .description('Start the CatsCo webapp connector (compatibility alias)')
     .action(async () => {

--- a/src/tools/bash-tool.ts
+++ b/src/tools/bash-tool.ts
@@ -9,6 +9,7 @@ import { Logger } from '../utils/logger';
 import { resolveRuntimeEnvironment } from '../utils/runtime-environment';
 import { isToolAllowed, isBashCommandAllowed } from '../utils/safety';
 import { resolveToolGatewayAccess } from './tool-gateway';
+import { executeRemoteTool } from './device-rpc-tool';
 
 const execAsync = promisify(exec);
 const CWD_MARKER_PREFIX = '__XIAOBA_CWD_MARKER__';
@@ -73,10 +74,13 @@ export class ShellTool implements Tool {
     const gateway = resolveToolGatewayAccess(context, {
       toolName: this.definition.name,
       operation: 'execute_shell',
+      allowCatsCoShell: true,
     });
     if (!gateway.ok) {
       return { ok: false, errorCode: gateway.errorCode, message: gateway.message };
     }
+    const remoteResult = await executeRemoteTool(context, gateway, 'execute_shell', 'execute_shell', args);
+    if (remoteResult) return remoteResult;
 
     if (description) {
       Logger.info(`Executing command: ${description}`);

--- a/src/tools/device-rpc-tool.ts
+++ b/src/tools/device-rpc-tool.ts
@@ -1,3 +1,4 @@
+import type { ContentBlock } from '../types';
 import type { DeviceGrantOperation } from '../types/session-identity';
 import type { ToolErrorCode, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import type { ToolGatewayDecision } from './tool-gateway';
@@ -11,6 +12,12 @@ export function isRemoteReadonlyTool(toolName: string, operation: DeviceGrantOpe
     || (toolName === 'grep' && operation === 'grep');
 }
 
+export function isRemoteDeviceTool(toolName: string, operation: DeviceGrantOperation): boolean {
+  return isRemoteReadonlyTool(toolName, operation)
+    || (toolName === 'write_file' && operation === 'write_file')
+    || (toolName === 'execute_shell' && operation === 'execute_shell');
+}
+
 export async function executeRemoteReadonlyTool(
   context: ToolExecutionContext,
   gateway: ToolGatewayDecision,
@@ -18,13 +25,23 @@ export async function executeRemoteReadonlyTool(
   operation: DeviceGrantOperation,
   args: Record<string, unknown>,
 ): Promise<ToolExecutionResult | undefined> {
+  return executeRemoteTool(context, gateway, toolName, operation, args);
+}
+
+export async function executeRemoteTool(
+  context: ToolExecutionContext,
+  gateway: ToolGatewayDecision,
+  toolName: 'read_file' | 'glob' | 'grep' | 'write_file' | 'execute_shell',
+  operation: DeviceGrantOperation,
+  args: Record<string, unknown>,
+): Promise<ToolExecutionResult | undefined> {
   if (!gateway.ok || gateway.mode !== 'remote') return undefined;
 
-  if (!isRemoteReadonlyTool(toolName, operation)) {
+  if (!isRemoteDeviceTool(toolName, operation)) {
     return {
       ok: false,
       errorCode: 'PERMISSION_DENIED',
-      message: `远程设备 RPC 当前只允许 read_file / glob / grep，已阻止 ${toolName}。`,
+      message: `远程设备 RPC 当前不支持 ${toolName}。`,
     };
   }
 
@@ -105,28 +122,55 @@ function timeoutForGrant(expiresAt: number): number {
   return Math.max(5_000, Math.min(REMOTE_TOOL_TIMEOUT_MS, remaining));
 }
 
-function normalizeDeviceRpcContent(content: unknown): string {
+function normalizeDeviceRpcContent(content: unknown): string | ContentBlock[] {
   if (typeof content === 'string') return truncateText(content);
   if (Array.isArray(content)) {
+    const blocks: ContentBlock[] = [];
     const lines: string[] = [];
     for (const block of content) {
       if (!block || typeof block !== 'object') continue;
       const record = block as Record<string, unknown>;
       if (record.type === 'text' && typeof record.text === 'string') {
-        lines.push(record.text);
+        const text = truncateText(record.text);
+        lines.push(text);
+        blocks.push({ type: 'text', text });
       } else if (record.type === 'image') {
-        lines.push('[远程设备返回了图片内容块；当前 Device RPC 不转发图片二进制，请让用户以附件方式上传该图片。]');
+        const imageBlock = sanitizeImageBlock(record);
+        if (imageBlock) {
+          blocks.push(imageBlock);
+        } else {
+          lines.push('[远程设备返回了图片内容块，但内容格式无效。]');
+        }
       }
     }
-    return truncateText(lines.join('\n'));
+    return blocks.length > 0 ? blocks : truncateText(lines.join('\n'));
   }
   if (content && typeof content === 'object') {
     const record = content as Record<string, unknown>;
-    if (record._imageForNewMessage) {
-      return '[远程设备读取到图片文件；当前 Device RPC 不转发图片二进制，请让用户以附件方式上传该图片。]';
+    if (record._imageForNewMessage && record.imageBlock && typeof record.imageBlock === 'object') {
+      const imageBlock = sanitizeImageBlock(record.imageBlock as Record<string, unknown>);
+      if (imageBlock) return [imageBlock];
     }
   }
   return truncateText(String(content ?? ''));
+}
+
+function sanitizeImageBlock(record: Record<string, unknown>): ContentBlock | undefined {
+  if (record.type !== 'image') return undefined;
+  const source = record.source;
+  if (!source || typeof source !== 'object' || Array.isArray(source)) return undefined;
+  const sourceRecord = source as Record<string, unknown>;
+  const mediaType = typeof sourceRecord.media_type === 'string' ? sourceRecord.media_type : undefined;
+  const data = typeof sourceRecord.data === 'string' ? sourceRecord.data : undefined;
+  if (!mediaType || !data) return undefined;
+  return {
+    type: 'image',
+    source: {
+      type: 'base64',
+      media_type: mediaType,
+      data,
+    },
+  } as unknown as ContentBlock;
 }
 
 function truncateText(value: string): string {

--- a/src/tools/grep-tool.ts
+++ b/src/tools/grep-tool.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import { isReadPathAllowed } from '../utils/safety';
-import { formatCatsCoVisiblePath, redactCatsCoVisiblePath, resolveToolGatewayAccess } from './tool-gateway';
+import { formatCatsCoVisiblePath, isCatsCoToolGatewayContext, redactCatsCoVisiblePath, resolveToolGatewayAccess } from './tool-gateway';
 import { executeRemoteReadonlyTool } from './device-rpc-tool';
 
 const VCS_DIRECTORIES_TO_EXCLUDE = ['.git', '.svn', '.hg', '.bzr'] as const;
@@ -52,7 +52,7 @@ function formatLimitInfo(
   return parts.join(', ');
 }
 
-function toRelativePath(absolutePath: string, cwd: string): string {
+function toRelativePath(absolutePath: string, cwd: string, context?: ToolExecutionContext, visibleSearchPath?: string): string {
   let relative = absolutePath;
 
   if (path.isAbsolute(absolutePath)) {
@@ -61,7 +61,16 @@ function toRelativePath(absolutePath: string, cwd: string): string {
     relative = absolutePath.slice(2);
   }
 
-  return relative.replace(/\\/g, '/');
+  const normalized = relative.replace(/\\/g, '/');
+  if (!context || !isCatsCoToolGatewayContext(context)) {
+    return normalized;
+  }
+  if (!normalized.startsWith('../') && normalized !== '..' && !path.isAbsolute(normalized)) {
+    return normalized;
+  }
+  const basename = path.basename(absolutePath);
+  const base = visibleSearchPath || '[current CatsCo device]';
+  return basename ? `${base.replace(/\/$/, '')}/${basename}` : base;
 }
 
 function isCommandAvailable(command: string): boolean {
@@ -272,13 +281,13 @@ export class GrepTool implements Tool {
     if (output_mode === 'content') {
       result.content = limitedLines.map(line => {
         const colonIndex = line.indexOf(':');
-        return colonIndex > 0 ? toRelativePath(line.substring(0, colonIndex), context.workingDirectory) + line.substring(colonIndex) : line;
+        return colonIndex > 0 ? toRelativePath(line.substring(0, colonIndex), context.workingDirectory, context, visibleSearchPath) + line.substring(colonIndex) : line;
       }).join('\n');
       result.numLines = limitedLines.length;
     } else if (output_mode === 'count') {
       const finalCountLines = limitedLines.map(line => {
         const colonIndex = line.lastIndexOf(':');
-        return colonIndex > 0 ? toRelativePath(line.substring(0, colonIndex), context.workingDirectory) + line.substring(colonIndex) : line;
+        return colonIndex > 0 ? toRelativePath(line.substring(0, colonIndex), context.workingDirectory, context, visibleSearchPath) + line.substring(colonIndex) : line;
       });
       result.numMatches = finalCountLines.reduce((sum, line) => {
         const count = parseInt(line.substring(line.lastIndexOf(':') + 1), 10);
@@ -287,7 +296,7 @@ export class GrepTool implements Tool {
       result.content = finalCountLines.join('\n');
       result.numFiles = finalCountLines.length;
     } else {
-      result.filenames = limitedLines.map(line => toRelativePath(line, context.workingDirectory));
+      result.filenames = limitedLines.map(line => toRelativePath(line, context.workingDirectory, context, visibleSearchPath));
       result.numFiles = result.filenames.length;
     }
 

--- a/src/tools/tool-gateway.ts
+++ b/src/tools/tool-gateway.ts
@@ -33,7 +33,7 @@ export interface CatsCoVisiblePathOptions {
   preserveRelative?: boolean;
 }
 
-const REMOTE_READONLY_OPERATIONS = new Set<DeviceGrantOperation>(['read_file', 'glob', 'grep']);
+const REMOTE_RPC_OPERATIONS = new Set<DeviceGrantOperation>(['read_file', 'glob', 'grep', 'write_file', 'execute_shell']);
 
 export function isCatsCoToolGatewayContext(context: ToolExecutionContext): boolean {
   return context.surface === 'catscompany' || context.executionScope?.source === 'catscompany';
@@ -122,10 +122,10 @@ export function resolveToolGatewayAccess(
 
   const grant = decision.grant;
   if (selectedTarget.mode === 'remote') {
-    if (!REMOTE_READONLY_OPERATIONS.has(options.operation)) {
+    if (!REMOTE_RPC_OPERATIONS.has(options.operation)) {
       return denied([
         `后端选定的用户设备不是当前运行体，但 ${options.operation} 还没有开放远程执行。`,
-        '当前 PR 只开放 read_file / glob / grep 三个只读远程工具。',
+        '当前远程设备 RPC 仅支持 read_file / glob / grep / write_file / execute_shell，且必须由服务端显式授权。',
       ], options.targetLabel);
     }
     if (!context.deviceRpc) {
@@ -208,7 +208,9 @@ function resolveBackendSelectedDevice(
   }
   if (selection.status === 'unavailable') {
     return selectedDenied([
-      '当前用户没有可用的在线设备授权，已阻止本地设备操作。',
+      selection.selectionSource === 'no_routable_devices'
+        ? '当前用户有设备记录，但没有可路由的在线设备连接，已阻止设备操作。'
+        : '当前用户没有可用的在线设备授权，已阻止本地设备操作。',
       '请让用户打开并授权目标设备后再继续。',
     ], targetLabel);
   }
@@ -223,6 +225,14 @@ function resolveBackendSelectedDevice(
     && !selection.selectedDeviceOperations.includes(operation)) {
     return selectedDenied([
       `后端选定设备没有声明支持 ${operation}，已阻止设备工具调用。`,
+      selection.selectedDeviceDisplayName ? `Selected device: ${selection.selectedDeviceDisplayName}` : '',
+    ], targetLabel);
+  }
+
+  if (selection.selectedDeviceRoutable === false) {
+    return selectedDenied([
+      '后端选定设备当前不可路由，已阻止设备工具调用。',
+      selection.selectedDeviceUnavailableReason ? `原因: ${selection.selectedDeviceUnavailableReason}` : '',
       selection.selectedDeviceDisplayName ? `Selected device: ${selection.selectedDeviceDisplayName}` : '',
     ], targetLabel);
   }

--- a/src/tools/tool-gateway.ts
+++ b/src/tools/tool-gateway.ts
@@ -52,7 +52,7 @@ export function formatCatsCoVisiblePath(
   if (!text) return fallback;
   if (/^catsco_attachment:[A-Za-z0-9._:-]+$/.test(text)) return text;
   if (/^\[CatsCo [^\]]+\]$/.test(text)) return text;
-  if (options.preserveRelative && !looksLikeAbsoluteLocalPath(text)) return text;
+  if (options.preserveRelative && !looksLikeAbsoluteLocalPath(text) && isSafeRelativeDisplayPath(text)) return text;
   return fallback;
 }
 
@@ -285,18 +285,23 @@ function validateSelectionScope(
 }
 
 function matchesLocalDevice(selection: ScopedDeviceSelection, localDevice: ScopedLocalDeviceGrant): boolean {
-  const selectedIds = [
-    selection.selectedDeviceId,
-    selection.selectedDeviceInstallationId,
-    selection.selectedDeviceBodyId,
-  ].filter(Boolean);
-  const localIds = [
-    localDevice.deviceId,
-    localDevice.installationId,
-    localDevice.bodyId,
-  ].filter(Boolean);
-  if (selectedIds.length === 0 || localIds.length === 0) return false;
-  return selectedIds.some(selected => localIds.includes(selected));
+  let matchedStrongTarget = false;
+
+  if (selection.selectedDeviceId) {
+    if (!localDevice.deviceId || selection.selectedDeviceId !== localDevice.deviceId) return false;
+    matchedStrongTarget = true;
+  }
+
+  if (selection.selectedDeviceInstallationId) {
+    if (!localDevice.installationId || selection.selectedDeviceInstallationId !== localDevice.installationId) return false;
+    matchedStrongTarget = true;
+  }
+
+  if (selection.selectedDeviceBodyId) {
+    if (!localDevice.bodyId || selection.selectedDeviceBodyId !== localDevice.bodyId) return false;
+  }
+
+  return matchedStrongTarget;
 }
 
 function denied(lines: string[], targetLabel?: string): ToolGatewayDecision {
@@ -323,4 +328,9 @@ function looksLikeAbsoluteLocalPath(value: string): boolean {
     || /^\\\\/.test(value)
     || /^\//.test(value)
     || /^~[\\/]/.test(value);
+}
+
+function isSafeRelativeDisplayPath(value: string): boolean {
+  const normalized = value.replace(/\\/g, '/');
+  return normalized.split('/').every(segment => segment !== '..');
 }

--- a/src/tools/write-tool.ts
+++ b/src/tools/write-tool.ts
@@ -4,6 +4,7 @@ import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from 
 import { Logger } from '../utils/logger';
 import { isToolAllowed, isPathAllowed } from '../utils/safety';
 import { formatCatsCoVisiblePath, resolveToolGatewayAccess } from './tool-gateway';
+import { executeRemoteTool } from './device-rpc-tool';
 
 /**
  * Write 工具 - 写入文件内容
@@ -36,6 +37,17 @@ export class WriteTool implements Tool {
       return { ok: false, errorCode: 'PERMISSION_DENIED', message: `执行被阻止: ${toolPermission.reason}` };
     }
 
+    const gateway = resolveToolGatewayAccess(context, {
+      toolName: this.definition.name,
+      operation: 'write_file',
+      targetLabel: file_path,
+    });
+    if (!gateway.ok) {
+      return { ok: false, errorCode: gateway.errorCode, message: gateway.message };
+    }
+    const remoteResult = await executeRemoteTool(context, gateway, 'write_file', 'write_file', args);
+    if (remoteResult) return remoteResult;
+
     // 解析文件路径
     const absolutePath = path.isAbsolute(file_path)
       ? file_path
@@ -44,15 +56,6 @@ export class WriteTool implements Tool {
     const pathPermission = isPathAllowed(absolutePath, context.workingDirectory);
     if (!pathPermission.allowed) {
       return { ok: false, errorCode: 'PERMISSION_DENIED', message: `执行被阻止: ${pathPermission.reason}` };
-    }
-
-    const gateway = resolveToolGatewayAccess(context, {
-      toolName: this.definition.name,
-      operation: 'write_file',
-      targetLabel: file_path,
-    });
-    if (!gateway.ok) {
-      return { ok: false, errorCode: gateway.errorCode, message: gateway.message };
     }
 
     // 获取相对路径用于显示

--- a/src/types/session-identity.ts
+++ b/src/types/session-identity.ts
@@ -106,6 +106,10 @@ export interface UserDevice {
   identityTrust: IdentityTrustLevel;
   identitySource?: string;
   status: UserDeviceStatus;
+  active?: boolean;
+  routeConnected?: boolean;
+  routable?: boolean;
+  unavailableReason?: string;
   registeredAt: number;
   lastSeenAt?: number;
 }
@@ -121,6 +125,9 @@ export interface ScopedDeviceGrant {
   deviceDisplayName?: string;
   deviceBodyId?: string;
   deviceInstallationId?: string;
+  deviceActive?: boolean;
+  deviceRouteConnected?: boolean;
+  deviceRoutable?: boolean;
   ownerUserId: string;
   sessionKey: string;
   topicId: string;
@@ -136,6 +143,11 @@ export interface ScopedDeviceGrant {
 export interface DeviceSelectionCandidate {
   deviceId: string;
   displayName?: string;
+  status?: UserDeviceStatus;
+  active?: boolean;
+  routeConnected?: boolean;
+  routable?: boolean;
+  unavailableReason?: string;
   operations?: DeviceGrantOperation[];
   lastSeenAt?: number;
 }
@@ -156,6 +168,11 @@ export interface ScopedDeviceSelection {
   selectedDeviceDisplayName?: string;
   selectedDeviceBodyId?: string;
   selectedDeviceInstallationId?: string;
+  selectedDeviceStatus?: UserDeviceStatus;
+  selectedDeviceActive?: boolean;
+  selectedDeviceRouteConnected?: boolean;
+  selectedDeviceRoutable?: boolean;
+  selectedDeviceUnavailableReason?: string;
   selectedDeviceOperations?: DeviceGrantOperation[];
   candidates?: DeviceSelectionCandidate[];
   candidateCount?: number;

--- a/src/weixin/index.ts
+++ b/src/weixin/index.ts
@@ -11,11 +11,16 @@ import { AdapterRuntimeBundle, createAdapterRuntime } from '../runtime/adapter-r
 import { promises as fs } from 'fs';
 import path from 'path';
 import {
+  ChannelAgentBindingResolver,
+  CHANNEL_BINDING_REQUIRED_MESSAGE,
+} from '../core/channel-agent-binding-resolver';
+import {
   createExecutionScopeFromRoute,
   createSessionRoute,
   createWeixinSessionRoute,
   parseSessionKeyV2,
 } from '../core/session-router';
+import type { ChannelAgentRouteBinding } from '../core/session-router';
 import type { SessionRoute } from '../types/session-identity';
 
 const CHANNEL_VERSION = 'xiaoba-weixin/1.0';
@@ -44,6 +49,8 @@ export class WeixinBot {
   private sessionManager: MessageSessionManager;
   private agentServices: AgentServices;
   private runtime: AdapterRuntimeBundle;
+  private bindingResolver: ChannelAgentBindingResolver;
+  private channelAppId: string;
   private contextTokens = new Map<string, string>();
   private messageQueue = new Map<string, QueuedMessage[]>();
   private isRunning = false;
@@ -58,6 +65,8 @@ export class WeixinBot {
     const runtime = createWeixinRuntime();
     this.runtime = runtime;
     this.agentServices = runtime.services;
+    this.bindingResolver = new ChannelAgentBindingResolver(config.channelAgentBinding);
+    this.channelAppId = config.channelAppId?.trim() || '';
 
     this.sessionManager = new MessageSessionManager(
       this.agentServices,
@@ -186,7 +195,10 @@ export class WeixinBot {
     const parsed = this.handler.parseMessage(msg);
     if (!parsed || this.handler.shouldIgnoreMessage(parsed)) return;
 
-    const route = createWeixinSessionRoute(parsed);
+    const routeBinding = await this.resolveChannelAgentBinding(parsed);
+    if (routeBinding === null) return;
+
+    const route = createWeixinSessionRoute(parsed, routeBinding);
     const sessionKey = route.sessionKey;
     const userId = route.actorUserId;
     if (msg.context_token) {
@@ -261,6 +273,50 @@ export class WeixinBot {
       await channel.reply(route.topicId, result.text);
     }
     await this.drainMessageQueue(sessionKey);
+  }
+
+  private async resolveChannelAgentBinding(message: WeixinMessage): Promise<ChannelAgentRouteBinding | undefined | null> {
+    const userId = message.from?.id?.trim();
+    if (!userId) return undefined;
+    if (!this.bindingResolver.enabled) {
+      if (this.bindingResolver.required) {
+        await this.sender.sendText(userId, '虚拟员工绑定服务未配置，请联系管理员检查 CatsCo 绑定地址。', message.context_token);
+        Logger.warning(`[weixin_binding] required=true but resolver is disabled: user=${userId}`);
+        return null;
+      }
+      return undefined;
+    }
+    try {
+      const resolution = await this.bindingResolver.resolve({
+        channel: 'weixin',
+        channelAppId: this.channelAppId || undefined,
+        channelUserId: userId,
+        channelConversationType: 'p2p',
+      });
+      if (!resolution) {
+        if (this.bindingResolver.required) {
+          await this.sender.sendText(userId, '虚拟员工绑定查询失败，请稍后重试。', message.context_token);
+          return null;
+        }
+        return undefined;
+      }
+      if (!resolution.bound) {
+        if (this.bindingResolver.required) {
+          await this.sender.sendText(userId, CHANNEL_BINDING_REQUIRED_MESSAGE, message.context_token);
+          Logger.warning(`[weixin_binding] 未找到绑定: user=${userId}`);
+          return null;
+        }
+        return undefined;
+      }
+      return resolution;
+    } catch (error: any) {
+      Logger.warning(`[weixin_binding] 绑定查询失败: ${error?.message || error}`);
+      if (this.bindingResolver.required) {
+        await this.sender.sendText(userId, '虚拟员工绑定查询失败，请稍后重试。', message.context_token);
+        return null;
+      }
+      return undefined;
+    }
   }
 
   private async handleSubAgentFeedback(

--- a/src/weixin/types.ts
+++ b/src/weixin/types.ts
@@ -2,7 +2,9 @@ export interface WeixinConfig {
   token: string;
   baseUrl: string;
   cdnBaseUrl: string;
+  channelAppId?: string;
   stateDir?: string;
+  channelAgentBinding?: import('../core/channel-agent-binding-resolver').ChannelAgentBindingResolverOptions;
 }
 
 export interface WeixinMessage {

--- a/tests/catsco-command-config.test.ts
+++ b/tests/catsco-command-config.test.ts
@@ -4,6 +4,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { resolveCatsCoCommandConfig } from '../src/commands/catscompany';
+import { resolveDeviceConnectorCommandConfig } from '../src/commands/device-connector';
 import { ChatConfig } from '../src/types';
 import { createCatsCoLocalConfigService } from '../src/catscompany/local-config';
 
@@ -81,6 +82,70 @@ describe('CatsCo command config resolution', () => {
 
     assert.deepEqual(resolved.missing, ['apiKey', 'bodyId']);
     assert.equal(resolved.config, undefined);
+  });
+
+  test('resolves lightweight device connector config from local enrollment', () => {
+    createCatsCoLocalConfigService({ runtimeRoot: tempDir }).save({
+      version: 1,
+      endpoints: {
+        httpBaseUrl: 'https://app.example',
+        serverUrl: 'wss://app.example/v0/channels',
+      },
+      device: {
+        deviceId: 'device-local',
+        bodyId: 'device-local',
+        installationId: 'install-local',
+      },
+      deviceConnector: {
+        token: 'device-token',
+        ownerUid: 'usr7',
+        deviceId: 'device-local',
+        installationId: 'install-local',
+        capabilities: ['read_file', 'glob'],
+      },
+    });
+
+    const resolved = resolveDeviceConnectorCommandConfig({}, {}, {});
+
+    assert.deepEqual(resolved.missing, []);
+    assert.equal(resolved.config?.authMode, 'device_connector');
+    assert.equal(resolved.config?.connectorToken, 'device-token');
+    assert.equal(resolved.config?.bodyId, 'device-local');
+    assert.equal(resolved.config?.installationId, 'install-local');
+    assert.deepEqual(resolved.config?.capabilities, ['read_file', 'glob']);
+  });
+
+  test('keeps saved device connector capabilities as the startup ceiling', () => {
+    createCatsCoLocalConfigService({ runtimeRoot: tempDir }).save({
+      version: 1,
+      endpoints: {
+        httpBaseUrl: 'https://app.example',
+        serverUrl: 'wss://app.example/v0/channels',
+      },
+      device: {
+        deviceId: 'device-local',
+        bodyId: 'device-local',
+        installationId: 'install-local',
+      },
+      deviceConnector: {
+        token: 'device-token',
+        ownerUid: 'usr7',
+        deviceId: 'device-local',
+        installationId: 'install-local',
+        capabilities: ['read_file', 'glob', 'grep'],
+      },
+    });
+
+    const resolved = resolveDeviceConnectorCommandConfig({}, {}, {
+      allowWrite: true,
+      allowShell: true,
+      capability: ['read_file', 'write_file', 'execute_shell'],
+    });
+
+    assert.deepEqual(resolved.missing, []);
+    assert.deepEqual(resolved.config?.capabilities, ['read_file', 'glob', 'grep']);
+    assert.equal(resolved.config?.allowWriteFile, false);
+    assert.equal(resolved.config?.allowShell, false);
   });
 
   function saveConfirmedBinding(): void {

--- a/tests/catscompany-client-body-id.test.ts
+++ b/tests/catscompany-client-body-id.test.ts
@@ -73,6 +73,38 @@ describe('CatsCompany client body identity', () => {
     assert.equal(headers['x-catsco-installation-id'], 'install-test');
   });
 
+  test('sends connector token headers without api key in device connector mode', async () => {
+    const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    servers.push(server);
+    await new Promise<void>(resolve => server.once('listening', resolve));
+
+    const headersPromise = new Promise<Record<string, string | string[] | undefined>>(resolve => {
+      server.once('connection', (socket, request) => {
+        resolve(request.headers);
+        socket.close();
+      });
+    });
+
+    const address = server.address() as AddressInfo;
+    const client = new CatsClient({
+      serverUrl: `ws://127.0.0.1:${address.port}`,
+      authMode: 'device_connector',
+      connectorToken: 'device-token',
+      bodyId: 'device-local',
+      installationId: 'install-local',
+    });
+    client.on('error', () => undefined);
+
+    client.connect();
+    const headers = await headersPromise;
+    client.disconnect();
+
+    assert.equal(headers['x-api-key'], undefined);
+    assert.equal(headers['x-catsco-connector-token'], 'device-token');
+    assert.equal(headers['x-catsco-body-id'], 'device-local');
+    assert.equal(headers['x-catsco-installation-id'], 'install-local');
+  });
+
   test('fails before connecting when body id is missing', () => {
     clearIdentityEnv();
     const client = new CatsClient({
@@ -175,6 +207,49 @@ describe('CatsCompany client body identity', () => {
       installation_id: 'install-test',
       status: 'online',
       capabilities: ['read_file', 'send_file'],
+    });
+  });
+
+  test('registers connector devices through scoped Device Connector HTTP API', async () => {
+    const requestPromise = new Promise<{ url?: string; method?: string; headers: Record<string, string | string[] | undefined>; body: any }>((resolve, reject) => {
+      const server = createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on('data', chunk => chunks.push(Buffer.from(chunk)));
+        req.on('end', () => {
+          const body = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+          resolve({ url: req.url, method: req.method, headers: req.headers, body });
+          res.setHeader('Content-Type', 'application/json');
+          res.end(JSON.stringify({ device: { deviceId: body.device_id } }));
+        });
+      });
+      httpServers.push(server);
+      server.listen(0, '127.0.0.1', () => {
+        void (async () => {
+          const address = server.address() as AddressInfo;
+          const client = new CatsClient({
+            serverUrl: 'ws://127.0.0.1:1/v0/channels',
+            httpBaseUrl: `http://127.0.0.1:${address.port}`,
+            authMode: 'device_connector',
+            connectorToken: 'device-token',
+            bodyId: 'device-local',
+          });
+          await client.registerDevice({
+            device_id: 'device-local',
+            status: 'online',
+            capabilities: ['read_file', 'glob'],
+          });
+        })().catch(reject);
+      });
+    });
+
+    const request = await requestPromise;
+    assert.equal(request.method, 'POST');
+    assert.equal(request.url, '/api/device-connectors/register');
+    assert.equal(request.headers.authorization, 'DeviceConnector device-token');
+    assert.deepEqual(request.body, {
+      device_id: 'device-local',
+      status: 'online',
+      capabilities: ['read_file', 'glob'],
     });
   });
 
@@ -319,6 +394,18 @@ describe('CatsCompany client body identity', () => {
               device_rpc: {
                 type: 'result',
                 request_id: msg.device_rpc.request_id,
+                grant_id: msg.device_rpc.grant_id,
+                session_key: msg.device_rpc.session_key,
+                topic_id: msg.device_rpc.topic_id,
+                topic_type: msg.device_rpc.topic_type,
+                actor_user_id: msg.device_rpc.actor_user_id,
+                agent_id: msg.device_rpc.agent_id,
+                agent_body_id: msg.device_rpc.agent_body_id,
+                device_id: msg.device_rpc.device_id,
+                device_body_id: msg.device_rpc.device_body_id,
+                device_installation_id: msg.device_rpc.device_installation_id,
+                operation: msg.device_rpc.operation,
+                tool_name: msg.device_rpc.tool_name,
                 result: { ok: true },
               },
             }));
@@ -394,6 +481,18 @@ describe('CatsCompany client body identity', () => {
             device_rpc: {
               type: 'result',
               request_id: msg.device_rpc.request_id,
+              grant_id: msg.device_rpc.grant_id,
+              session_key: msg.device_rpc.session_key,
+              topic_id: msg.device_rpc.topic_id,
+              topic_type: msg.device_rpc.topic_type,
+              actor_user_id: msg.device_rpc.actor_user_id,
+              agent_id: msg.device_rpc.agent_id,
+              agent_body_id: msg.device_rpc.agent_body_id,
+              device_id: msg.device_rpc.device_id,
+              device_body_id: msg.device_rpc.device_body_id,
+              device_installation_id: msg.device_rpc.device_installation_id,
+              operation: msg.device_rpc.operation,
+              tool_name: msg.device_rpc.tool_name,
               result: { ok: true },
             },
           }));
@@ -425,6 +524,78 @@ describe('CatsCompany client body identity', () => {
       /ack 500/
     );
     client.disconnect();
+  });
+
+  test('redacts and truncates device rpc recent errors in status snapshots', async () => {
+    const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    servers.push(server);
+    await new Promise<void>(resolve => server.once('listening', resolve));
+
+    server.once('connection', socket => {
+      socket.on('message', data => {
+        const msg = JSON.parse(data.toString());
+        if (msg.hi) {
+          socket.send(JSON.stringify({
+            ctrl: {
+              id: msg.hi.id,
+              code: 200,
+              params: {
+                build: 'catscompany',
+                ver: '0.1.0',
+                features: ['client_msg_id', 'device_rpc'],
+                uid: 'usr42',
+                name: 'Agent',
+              },
+            },
+          }));
+          return;
+        }
+        if (msg.device_rpc?.type === 'request') {
+          socket.send(JSON.stringify({
+            ctrl: {
+              id: msg.device_rpc.id,
+              code: 500,
+              text: `failed at C:/Users/alice/secret/project/file.txt with Bearer user-secret CATSCO_USER_TOKEN=very-secret ${'detail '.repeat(80)}`,
+            },
+          }));
+        }
+      });
+    });
+
+    const address = server.address() as AddressInfo;
+    const client = new CatsClient({
+      serverUrl: `ws://127.0.0.1:${address.port}`,
+      apiKey: 'cc-test-key',
+      bodyId: 'body-agent',
+      installationId: 'install-agent',
+    });
+    client.on('error', () => undefined);
+    await new Promise<void>(resolve => {
+      client.once('ready', () => resolve());
+      client.connect();
+    });
+
+    await assert.rejects(
+      () => client.sendDeviceRpcRequest({
+        request_id: 'rpc-redact-error',
+        grant_id: 'grant-1',
+        device_id: 'install-test',
+        operation: 'execute_shell',
+        tool_name: 'execute_shell',
+      }),
+      /ack 500/
+    );
+
+    const recentError = client.getStatusSnapshot().deviceRpc.recent.at(-1)?.error || '';
+    client.disconnect();
+
+    assert.ok(recentError.length <= 240);
+    assert.match(recentError, /\[redacted-path\]/);
+    assert.match(recentError, /Bearer \[redacted\]/);
+    assert.match(recentError, /CATSCO_USER_TOKEN=\[redacted\]/);
+    assert.equal(recentError.includes('secret/project/file.txt'), false);
+    assert.equal(recentError.includes('user-secret'), false);
+    assert.equal(recentError.includes('very-secret'), false);
   });
 
   test('rejects device rpc results whose scope does not match the pending request', async () => {
@@ -486,6 +657,77 @@ describe('CatsCompany client body identity', () => {
         request_id: 'rpc-scope-mismatch',
         grant_id: 'grant-1',
         device_id: 'install-test',
+        operation: 'read_file',
+        tool_name: 'read_file',
+      }),
+      /scope does not match/
+    );
+    client.disconnect();
+  });
+
+  test('rejects device rpc results that omit expected scope fields', async () => {
+    const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    servers.push(server);
+    await new Promise<void>(resolve => server.once('listening', resolve));
+
+    server.once('connection', socket => {
+      socket.on('message', data => {
+        const msg = JSON.parse(data.toString());
+        if (msg.hi) {
+          socket.send(JSON.stringify({
+            ctrl: {
+              id: msg.hi.id,
+              code: 200,
+              params: {
+                build: 'catscompany',
+                ver: '0.1.0',
+                features: ['client_msg_id', 'device_rpc'],
+                uid: 'usr42',
+                name: 'Agent',
+              },
+            },
+          }));
+          return;
+        }
+        if (msg.device_rpc?.type === 'request') {
+          socket.send(JSON.stringify({ ctrl: { id: msg.device_rpc.id, code: 200, text: 'ok' } }));
+          socket.send(JSON.stringify({
+            device_rpc: {
+              type: 'result',
+              request_id: msg.device_rpc.request_id,
+              result: { ok: true },
+            },
+          }));
+        }
+      });
+    });
+
+    const address = server.address() as AddressInfo;
+    const client = new CatsClient({
+      serverUrl: `ws://127.0.0.1:${address.port}`,
+      apiKey: 'cc-test-key',
+      bodyId: 'body-agent',
+      installationId: 'install-agent',
+    });
+    client.on('error', () => undefined);
+    await new Promise<void>(resolve => {
+      client.once('ready', () => resolve());
+      client.connect();
+    });
+
+    await assert.rejects(
+      () => client.sendDeviceRpcRequest({
+        request_id: 'rpc-missing-scope',
+        grant_id: 'grant-1',
+        session_key: 'session:v2:catscompany:p2p:p2p_7_42:agent:usr42',
+        topic_id: 'p2p_7_42',
+        topic_type: 'p2p',
+        actor_user_id: 'usr7',
+        agent_id: 'usr42',
+        agent_body_id: 'body-agent',
+        device_id: 'install-test',
+        device_body_id: 'body-device',
+        device_installation_id: 'install-test',
         operation: 'read_file',
         tool_name: 'read_file',
       }),

--- a/tests/catscompany-content-blocks.test.ts
+++ b/tests/catscompany-content-blocks.test.ts
@@ -407,11 +407,13 @@ describe('CatsCo content blocks', () => {
   test('sanitizes CatsCo image block metadata to use opaque references', async () => {
     const bot = Object.create(CatsCompanyBot.prototype) as any;
     const originalModel = process.env.GAUZ_LLM_MODEL;
+    const originalApiBase = process.env.GAUZ_LLM_API_BASE;
     const testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'catsco-image-ref-'));
     const localPath = path.join(testRoot, 'tmp', 'downloads', 'secret-image.png');
 
     try {
       process.env.GAUZ_LLM_MODEL = 'gpt-4o';
+      process.env.GAUZ_LLM_API_BASE = 'https://api.openai.com/v1';
       fs.mkdirSync(path.dirname(localPath), { recursive: true });
       fs.writeFileSync(
         localPath,
@@ -438,6 +440,11 @@ describe('CatsCo content blocks', () => {
         delete process.env.GAUZ_LLM_MODEL;
       } else {
         process.env.GAUZ_LLM_MODEL = originalModel;
+      }
+      if (originalApiBase === undefined) {
+        delete process.env.GAUZ_LLM_API_BASE;
+      } else {
+        process.env.GAUZ_LLM_API_BASE = originalApiBase;
       }
       fs.rmSync(testRoot, { recursive: true, force: true });
     }

--- a/tests/catscompany-device-rpc-tools.test.ts
+++ b/tests/catscompany-device-rpc-tools.test.ts
@@ -46,7 +46,7 @@ function request(overrides: Partial<CatsDeviceRpcMessage> = {}): CatsDeviceRpcMe
   };
 }
 
-describe('CatsCompany Device RPC readonly tools', () => {
+describe('CatsCompany Device RPC tools', () => {
   test('executes read_file on the target local device and returns a normalized result', async () => {
     const captured: { result?: any } = {};
     const bot = botWithDevice(captured);
@@ -67,21 +67,42 @@ describe('CatsCompany Device RPC readonly tools', () => {
     assert.equal(captured.result.device_id, 'install-device');
   });
 
-  test('rejects non-readonly Device RPC operations before local tool execution', async () => {
+  test('executes write_file on the target local device when explicitly granted', async () => {
+    const captured: { result?: any } = {};
+    const bot = botWithDevice(captured);
+    const tmpRoot = path.join(process.cwd(), 'tmp');
+    fs.mkdirSync(tmpRoot, { recursive: true });
+    const dir = fs.mkdtempSync(path.join(tmpRoot, 'device-rpc-write-'));
+    const filePath = path.join(dir, 'created.txt');
+
+    await bot.handleDeviceRpcRequest(request({
+      request_id: 'rpc-write-1',
+      operation: 'write_file',
+      tool_name: 'write_file',
+      payload: { args: { file_path: filePath, content: 'hello from rpc write' } },
+    }));
+
+    assert.ok(captured.result);
+    assert.equal(captured.result.error, undefined);
+    assert.equal(captured.result.result.ok, true);
+    assert.equal(fs.readFileSync(filePath, 'utf-8'), 'hello from rpc write');
+  });
+
+  test('rejects unsupported Device RPC operations before local tool execution', async () => {
     const captured: { result?: any } = {};
     const bot = botWithDevice(captured);
 
     await bot.handleDeviceRpcRequest(request({
-      request_id: 'rpc-shell-1',
-      operation: 'execute_shell',
-      tool_name: 'execute_shell',
-      payload: { args: { command: 'echo unsafe' } },
+      request_id: 'rpc-send-file-1',
+      operation: 'send_file',
+      tool_name: 'send_file',
+      payload: { args: { file_path: 'secret.txt' } },
     }));
 
     assert.ok(captured.result);
     assert.equal(captured.result.result, undefined);
     assert.equal(captured.result.error.code, 'unsupported_operation');
-    assert.match(captured.result.error.message, /read_file, glob, and grep/);
+    assert.match(captured.result.error.message, /read_file, glob, grep, write_file, and execute_shell/);
   });
 
   test('rejects Device RPC requests for another target device', async () => {

--- a/tests/catscompany-device-rpc-tools.test.ts
+++ b/tests/catscompany-device-rpc-tools.test.ts
@@ -5,7 +5,11 @@ import * as path from 'path';
 import { CatsCompanyBot } from '../src/catscompany';
 import type { CatsDeviceRpcMessage } from '../src/catscompany/client';
 
-function botWithDevice(captured: { result?: any }): any {
+function botWithDevice(captured: { result?: any }, options: {
+  capabilities?: string[];
+  allowWriteFile?: boolean;
+  allowShell?: boolean;
+} = {}): any {
   const bot = Object.create(CatsCompanyBot.prototype) as any;
   bot.localDeviceGrant = {
     kind: 'catscompany_body',
@@ -15,6 +19,16 @@ function botWithDevice(captured: { result?: any }): any {
     deviceId: 'install-device',
     createdAt: Date.now(),
   };
+  bot.deviceRegistration = {
+    device_id: 'install-device',
+    display_name: 'Test Device',
+    body_id: 'body-device',
+    installation_id: 'install-device',
+    status: 'online',
+    capabilities: options.capabilities || ['read_file', 'glob', 'grep'],
+  };
+  bot.allowWriteFile = Boolean(options.allowWriteFile);
+  bot.allowShell = Boolean(options.allowShell);
   bot.bot = {
     sendDeviceRpcResult: async (result: any) => {
       captured.result = result;
@@ -69,7 +83,10 @@ describe('CatsCompany Device RPC tools', () => {
 
   test('executes write_file on the target local device when explicitly granted', async () => {
     const captured: { result?: any } = {};
-    const bot = botWithDevice(captured);
+    const bot = botWithDevice(captured, {
+      capabilities: ['read_file', 'glob', 'grep', 'write_file'],
+      allowWriteFile: true,
+    });
     const tmpRoot = path.join(process.cwd(), 'tmp');
     fs.mkdirSync(tmpRoot, { recursive: true });
     const dir = fs.mkdtempSync(path.join(tmpRoot, 'device-rpc-write-'));
@@ -86,6 +103,28 @@ describe('CatsCompany Device RPC tools', () => {
     assert.equal(captured.result.error, undefined);
     assert.equal(captured.result.result.ok, true);
     assert.equal(fs.readFileSync(filePath, 'utf-8'), 'hello from rpc write');
+  });
+
+  test('rejects write_file on the full runtime unless local capability is explicitly enabled', async () => {
+    const captured: { result?: any } = {};
+    const bot = botWithDevice(captured);
+    const tmpRoot = path.join(process.cwd(), 'tmp');
+    fs.mkdirSync(tmpRoot, { recursive: true });
+    const dir = fs.mkdtempSync(path.join(tmpRoot, 'device-rpc-write-denied-'));
+    const filePath = path.join(dir, 'created.txt');
+
+    await bot.handleDeviceRpcRequest(request({
+      request_id: 'rpc-write-denied-1',
+      operation: 'write_file',
+      tool_name: 'write_file',
+      payload: { args: { file_path: filePath, content: 'blocked' } },
+    }));
+
+    assert.ok(captured.result);
+    assert.equal(captured.result.result, undefined);
+    assert.equal(captured.result.error.code, 'PERMISSION_DENIED');
+    assert.match(captured.result.error.message, /未注册远程 write_file 能力|未显式开启远程写文件能力/);
+    assert.equal(fs.existsSync(filePath), false);
   });
 
   test('rejects unsupported Device RPC operations before local tool execution', async () => {
@@ -117,5 +156,22 @@ describe('CatsCompany Device RPC tools', () => {
     assert.ok(captured.result);
     assert.equal(captured.result.result, undefined);
     assert.equal(captured.result.error.code, 'target_device_mismatch');
+  });
+
+  test('returns a structured error when local Device RPC tool execution throws', async () => {
+    const captured: { result?: any } = {};
+    const bot = botWithDevice(captured);
+    bot.executeLocalDeviceRpcTool = async () => {
+      throw new Error('boom from local tool');
+    };
+
+    await bot.handleDeviceRpcRequest(request({ request_id: 'rpc-throw-1' }));
+
+    assert.ok(captured.result);
+    assert.equal(captured.result.result, undefined);
+    assert.equal(captured.result.error.code, 'tool_execution_error');
+    assert.match(captured.result.error.message, /boom from local tool/);
+    assert.equal(captured.result.grant_id, 'grant-read-1');
+    assert.equal(captured.result.device_id, 'install-device');
   });
 });

--- a/tests/catscompany-execution-scope-flow.test.ts
+++ b/tests/catscompany-execution-scope-flow.test.ts
@@ -208,6 +208,60 @@ describe('CatsCompany execution scope flow', () => {
     assert.deepEqual(handledTurns[0].options.deviceGrants[0].operations, ['read_file', 'send_file']);
   });
 
+  test('passes delegated channel device grants while preserving the channel actor', async () => {
+    const { bot, handledTurns } = createHarness();
+
+    await (bot as any).onMessage({
+      topic: 'p2p_100_43',
+      senderId: 'usr100',
+      text: '读一下我的电脑文件',
+      content: '读一下我的电脑文件',
+      metadata: metadataWithDeviceGrants('usr100', 'p2p_100_43', [
+        deviceGrant({
+          ownerUserId: 'usr7',
+          actorUserId: 'usr100',
+          identitySource: 'channel_identity_link',
+          sessionKey: 'session:v2:catscompany:p2p:p2p_100_43:agent:usr43',
+          topicId: 'p2p_100_43',
+        }),
+      ]),
+      isGroup: false,
+      seq: 12,
+    });
+
+    assert.equal(handledTurns.length, 1);
+    assert.equal(handledTurns[0].options.executionScope.actorUserId, 'usr100');
+    assert.equal(handledTurns[0].options.deviceGrants?.length, 1);
+    assert.equal(handledTurns[0].options.deviceGrants[0].ownerUserId, 'usr7');
+    assert.equal(handledTurns[0].options.deviceGrants[0].actorUserId, 'usr100');
+    assert.equal(handledTurns[0].options.deviceGrants[0].identitySource, 'channel_identity_link');
+  });
+
+  test('drops owner mismatch device grants without a delegated channel source', async () => {
+    const { bot, handledTurns } = createHarness();
+
+    await (bot as any).onMessage({
+      topic: 'p2p_100_43',
+      senderId: 'usr100',
+      text: '读一下我的电脑文件',
+      content: '读一下我的电脑文件',
+      metadata: metadataWithDeviceGrants('usr100', 'p2p_100_43', [
+        deviceGrant({
+          ownerUserId: 'usr7',
+          actorUserId: 'usr100',
+          identitySource: 'metadata.catsco_identity',
+          sessionKey: 'session:v2:catscompany:p2p:p2p_100_43:agent:usr43',
+          topicId: 'p2p_100_43',
+        }),
+      ]),
+      isGroup: false,
+      seq: 12,
+    });
+
+    assert.equal(handledTurns.length, 1);
+    assert.equal(handledTurns[0].options.deviceGrants, undefined);
+  });
+
   test('passes server canonical device selection into CatsCompany session turn', async () => {
     const { bot, handledTurns } = createHarness();
 
@@ -262,6 +316,8 @@ describe('CatsCompany execution scope flow', () => {
       metadata: metadataWithDeviceGrants('usr7', 'p2p_7_43', [
         deviceGrant({ actorUserId: 'usr8' }),
         deviceGrant({ agentBodyId: 'body-other' }),
+        deviceGrant({ status: 'revoked' }),
+        deviceGrant({ status: undefined }),
       ]),
       isGroup: false,
       seq: 12,

--- a/tests/channel-agent-binding-resolver.test.ts
+++ b/tests/channel-agent-binding-resolver.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import {
+  ChannelAgentBindingResolver,
+  resolveChannelAgentBindingOptions,
+} from '../src/core/channel-agent-binding-resolver';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('ChannelAgentBindingResolver', () => {
+  test('only enables when explicitly enabled and a binding base URL is configured', () => {
+    assert.equal(new ChannelAgentBindingResolver({ enabled: true }).enabled, false);
+    assert.equal(new ChannelAgentBindingResolver({ required: true }).enabled, false);
+    assert.equal(new ChannelAgentBindingResolver({ required: true }).misconfiguredRequired, true);
+    assert.equal(new ChannelAgentBindingResolver({
+      enabled: true,
+      httpBaseUrl: 'https://app.catsco.cc/',
+    }).enabled, true);
+    assert.equal(new ChannelAgentBindingResolver({
+      required: true,
+      httpBaseUrl: 'https://app.catsco.cc/',
+    }).enabled, true);
+  });
+
+  test('fails closed when binding is required but base URL is missing', async () => {
+    const resolver = new ChannelAgentBindingResolver({ required: true });
+    await assert.rejects(
+      resolver.resolve({ channel: 'feishu', channelUserId: 'ou_user' }),
+      /required.*HTTP_BASE_URL/i,
+    );
+  });
+
+  test('resolves env options with CatsCo and CatsCompany names', () => {
+    const catsco = resolveChannelAgentBindingOptions({
+      CATSCO_CHANNEL_BINDING_HTTP_BASE_URL: 'https://app.catsco.cc/',
+      CATSCO_CHANNEL_AGENT_BINDING_ENABLED: 'true',
+      CATSCO_CHANNEL_AGENT_BINDING_REQUIRED: 'yes',
+      CATSCO_CHANNEL_BINDING_TOKEN: 'secret',
+      CATSCO_CHANNEL_BINDING_TIMEOUT_MS: '1200',
+    });
+    assert.deepEqual(catsco, {
+      httpBaseUrl: 'https://app.catsco.cc/',
+      token: 'secret',
+      enabled: true,
+      required: true,
+      timeoutMs: 1200,
+    });
+
+    const legacy = resolveChannelAgentBindingOptions({
+      CATSCOMPANY_CHANNEL_BINDING_HTTP_BASE_URL: 'https://legacy.catsco.cc',
+      CATSCOMPANY_CHANNEL_AGENT_BINDING_ENABLED: '1',
+    });
+    assert.equal(legacy.httpBaseUrl, 'https://legacy.catsco.cc');
+    assert.equal(legacy.enabled, true);
+  });
+
+  test('sends channel identity query with bearer token and maps bound response', async () => {
+    const calls: Array<{ url: URL; auth?: string }> = [];
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      calls.push({
+        url: new URL(String(input)),
+        auth: String(init?.headers && (init.headers as Record<string, string>).Authorization || ''),
+      });
+      return new Response(JSON.stringify({
+        bound: true,
+        agent_uid: 43,
+        agent_id: 'usr43',
+        agent_body_id: 'body-contract',
+        owner_uid: 7,
+        identity_trust: 'server_canonical',
+        identity_source: 'channel_agent_binding',
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    }) as typeof fetch;
+
+    const resolver = new ChannelAgentBindingResolver({
+      enabled: true,
+      httpBaseUrl: 'https://app.catsco.cc/',
+      token: 'secret',
+    });
+    const resolved = await resolver.resolve({
+      channel: 'feishu',
+      channelAppId: 'cli_app',
+      channelUserId: 'ou_user',
+      channelConversationId: 'oc_chat',
+      channelConversationType: 'p2p',
+    });
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].url.pathname, '/api/channel-agent-bindings/resolve');
+    assert.equal(calls[0].url.searchParams.get('channel'), 'feishu');
+    assert.equal(calls[0].url.searchParams.get('channel_app_id'), 'cli_app');
+    assert.equal(calls[0].url.searchParams.get('channel_user_id'), 'ou_user');
+    assert.equal(calls[0].url.searchParams.get('channel_conversation_id'), 'oc_chat');
+    assert.equal(calls[0].url.searchParams.get('channel_conversation_type'), 'p2p');
+    assert.equal(calls[0].auth, 'Bearer secret');
+    assert.deepEqual(resolved, {
+      bound: true,
+      agentUid: 43,
+      ownerUid: 7,
+      agentId: 'usr43',
+      agentBodyId: 'body-contract',
+      identityTrust: 'server_canonical',
+      identitySource: 'channel_agent_binding',
+    });
+  });
+
+  test('returns unbound and rejects malformed bound responses', async () => {
+    globalThis.fetch = (async () => new Response(JSON.stringify({ bound: false }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })) as typeof fetch;
+    const resolver = new ChannelAgentBindingResolver({
+      enabled: true,
+      httpBaseUrl: 'https://app.catsco.cc',
+    });
+    assert.deepEqual(await resolver.resolve({
+      channel: 'weixin',
+      channelUserId: 'openid',
+    }), { bound: false });
+
+    globalThis.fetch = (async () => new Response(JSON.stringify({ bound: true }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })) as typeof fetch;
+    await assert.rejects(
+      resolver.resolve({ channel: 'weixin', channelUserId: 'openid' }),
+      /missing agent_id/,
+    );
+  });
+});

--- a/tests/dashboard-catsco-auth-status.test.ts
+++ b/tests/dashboard-catsco-auth-status.test.ts
@@ -198,6 +198,29 @@ describe('dashboard CatsCo account status', () => {
           }],
         });
       }
+      if (req.path === '/api/devices') {
+        return res.json({
+          devices: [{
+            deviceId: 'alice-laptop',
+            displayName: 'Alice Laptop',
+            status: 'online',
+            active: true,
+            routeConnected: true,
+            routable: true,
+            capabilities: ['read_file', 'glob', 'grep'],
+            lastSeenAt: 1780560000000,
+          }, {
+            deviceId: 'alice-desktop',
+            displayName: 'Alice Desktop',
+            status: 'online',
+            active: true,
+            routeConnected: false,
+            routable: false,
+            unavailableReason: 'route_unavailable',
+            capabilities: ['read_file'],
+          }],
+        });
+      }
       return res.status(404).json({ error: 'not found' });
     });
     createCatsCoLocalConfigService({ runtimeRoot: testRoot }).save({
@@ -245,9 +268,94 @@ describe('dashboard CatsCo account status', () => {
     assert.equal(data.deviceRpcStatus.state, 'ok');
     assert.equal(data.deviceRpcStatus.pendingCount, 1);
     assert.equal(data.deviceRpcStatus.pending[0].requestId, 'rpc-status-1');
+    assert.equal(data.devicesStatus.deviceCount, 2);
+    assert.equal(data.devicesStatus.routableCount, 1);
+    assert.equal(data.deviceAuthorization.state, 'pending');
+    assert.equal(data.deviceAuthorization.selectedDevice.displayName, 'Alice Laptop');
+    assert.deepEqual(data.deviceAuthorization.operations, ['read_file']);
     assert.equal(JSON.stringify(data.deviceRpcStatus).includes('rpc-other-agent'), false);
     assert.equal(JSON.stringify(data.deviceRpcStatus).includes('secret.txt'), false);
+    assert.equal(JSON.stringify(data.deviceAuthorization).includes('secret.txt'), false);
     assert.equal(data.topicId, 'p2p_42_110');
+  });
+
+  test('GET /cats/status does not invent a selected device when no turn has chosen one', async () => {
+    await startCatsServer((req, res) => {
+      assert.equal(req.header('authorization'), 'Bearer valid-user-token');
+      if (req.path === '/api/me') {
+        return res.json({ uid: 42, username: 'webuser', display_name: 'Web User' });
+      }
+      if (req.path === '/api/bots/body-status') {
+        return res.json({
+          body_id: 'body-local',
+          active: true,
+          runtime_mode: 'redis',
+          route_state: 'ready',
+          lease_ttl_ms: 120000,
+        });
+      }
+      if (req.path === '/api/devices/rpc-status') {
+        return res.json({
+          state: 'ok',
+          runtime_mode: 'redis',
+          route_state: 'redis_ready',
+          pending_count: 0,
+          pending: [],
+        });
+      }
+      if (req.path === '/api/devices') {
+        return res.json({
+          devices: [{
+            deviceId: 'alice-laptop',
+            displayName: 'Alice Laptop',
+            status: 'online',
+            active: true,
+            routeConnected: true,
+            routable: true,
+            capabilities: ['read_file', 'glob'],
+          }],
+        });
+      }
+      return res.status(404).json({ error: 'not found' });
+    });
+    createCatsCoLocalConfigService({ runtimeRoot: testRoot }).save({
+      version: 1,
+      endpoints: {
+        httpBaseUrl: catsBaseUrl,
+        serverUrl: 'wss://app.catsco.cc/v0/channels',
+      },
+      account: {
+        token: 'valid-user-token',
+        uid: '42',
+        username: 'webuser',
+        displayName: 'Web User',
+      },
+      currentBot: {
+        uid: '110',
+        name: 'CatsCo',
+        username: 'catsco_42',
+        apiKey: 'agent-api-key',
+        boundByUserUid: '42',
+        bindingSource: 'test',
+      },
+      device: {
+        deviceId: 'body-local',
+        bodyId: 'body-local',
+        installationId: 'body-local',
+      },
+    });
+
+    const response = await fetch(`${dashboardBaseUrl}/api/cats/status`);
+    const data = await response.json() as any;
+
+    assert.equal(response.status, 200);
+    assert.equal(data.deviceRpcStatus.runtimeMode, 'redis');
+    assert.equal(data.deviceRpcStatus.routeState, 'redis_ready');
+    assert.equal(data.deviceRpcStatus.routerReady, true);
+    assert.equal(data.deviceAuthorization.state, 'available');
+    assert.equal(data.deviceAuthorization.routableCount, 1);
+    assert.equal(data.deviceAuthorization.selectedDevice, undefined);
+    assert.deepEqual(data.deviceAuthorization.operations, []);
   });
 
   test('GET /cats/status keeps binding configured but blocks chat when body lease is offline', async () => {

--- a/tests/dashboard-device-connector-link-api.test.ts
+++ b/tests/dashboard-device-connector-link-api.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import * as assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import express from 'express';
+import type { Server } from 'node:http';
+import { createApiRouter } from '../src/dashboard/routes/api';
+import type { ServiceInfo } from '../src/dashboard/service-manager';
+import { createCatsCoLocalConfigService } from '../src/catscompany/local-config';
+
+describe('dashboard device connector pairing link API', () => {
+  let originalCwd: string;
+  let testRoot: string;
+  let server: Server | undefined;
+  let baseUrl: string;
+  let originalFetch: typeof fetch;
+  let fetchCalls: Array<{ url: string; body: any }>;
+  let service: ServiceInfo;
+  let startCalls: string[];
+  const originalEnv: Record<string, string | undefined> = {};
+  const envKeys = ['XIAOBA_CONFIG_PATH', 'XIAOBA_RUNTIME_PROFILE_PATH'];
+
+  beforeEach(async () => {
+    originalCwd = process.cwd();
+    testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-device-link-api-'));
+    process.chdir(testRoot);
+    for (const key of envKeys) {
+      originalEnv[key] = process.env[key];
+    }
+    process.env.XIAOBA_CONFIG_PATH = path.join(testRoot, 'config.json');
+    process.env.XIAOBA_RUNTIME_PROFILE_PATH = path.join(testRoot, 'runtime-profile.json');
+
+    fetchCalls = [];
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: any, init?: any) => {
+      fetchCalls.push({
+        url: String(url),
+        body: init?.body ? JSON.parse(String(init.body)) : undefined,
+      });
+      return new Response(JSON.stringify({
+        connector_token: 'connector-token-1',
+        expires_in: 3600,
+        device: {
+          device_id: 'dev-1',
+          installation_id: 'install-1',
+          display_name: 'Office PC',
+          owner_user_id: 'user-1',
+          capabilities: ['read_file', 'glob', 'grep'],
+        },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as typeof fetch;
+
+    service = {
+      name: 'device-connector',
+      label: 'CatsCo Device Connector',
+      command: 'node',
+      args: ['dist/index.js', 'device-connector'],
+      status: 'stopped',
+    };
+    startCalls = [];
+    const app = express();
+    app.use(express.json());
+    app.use('/api', createApiRouter({
+      getAll: () => [service],
+      getService: () => service,
+      start: (name: string) => {
+        startCalls.push(name);
+        service = { ...service, status: 'running', pid: 1001, startedAt: Date.now() };
+        return service;
+      },
+      restart: (name: string) => {
+        startCalls.push(`restart:${name}`);
+        service = { ...service, status: 'running', pid: 1002, startedAt: Date.now() };
+        return service;
+      },
+      stop: () => service,
+      getLogs: () => [],
+    } as any));
+    server = await listen(app);
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('server did not bind');
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = originalFetch;
+    if (server) {
+      await new Promise<void>(resolve => server!.close(() => resolve()));
+      server = undefined;
+    }
+    process.chdir(originalCwd);
+    for (const key of envKeys) {
+      if (originalEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = originalEnv[key];
+    }
+    fs.rmSync(testRoot, { recursive: true, force: true });
+  });
+
+  test('pairs and starts the saved connector without echoing the pairing code', async () => {
+    const response = await originalFetch(`${baseUrl}/api/cats/device-connector/pair`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        code: 'PAIR123456',
+        http_base_url: 'https://app.catsco.cc',
+        server_url: 'wss://app.catsco.cc/v0/channels',
+      }),
+    });
+    const body = await response.json() as any;
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(startCalls, ['device-connector']);
+    assert.equal(fetchCalls[0].url, 'https://app.catsco.cc/api/device-connectors/enroll');
+    assert.equal(fetchCalls[0].body.pairing_code, 'PAIR123456');
+    assert.equal(fetchCalls[0].body.capabilities.includes('execute_shell'), false);
+    assert.equal(body.connectorStarted, true);
+    assert.equal(JSON.stringify(body).includes('PAIR123456'), false);
+
+    const local = createCatsCoLocalConfigService({ runtimeRoot: testRoot }).load();
+    assert.equal(local.deviceConnector?.token, 'connector-token-1');
+    assert.equal(local.deviceConnector?.deviceId, 'dev-1');
+    assert.deepEqual(local.deviceConnector?.capabilities, ['read_file', 'glob', 'grep']);
+  });
+
+  test('restarts the connector when pairing arrives while it is already running', async () => {
+    service = { ...service, status: 'running', pid: 999 };
+
+    const response = await originalFetch(`${baseUrl}/api/cats/device-connector/pair`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ code: 'PAIR654321' }),
+    });
+    const body = await response.json() as any;
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(startCalls, ['restart:device-connector']);
+    assert.equal(body.connectorRestarted, true);
+  });
+
+  test('rejects malformed pairing codes before calling the platform', async () => {
+    const response = await originalFetch(`${baseUrl}/api/cats/device-connector/pair`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ code: 'bad code with spaces' }),
+    });
+
+    assert.equal(response.status, 400);
+    assert.equal(fetchCalls.length, 0);
+    assert.deepEqual(startCalls, []);
+  });
+
+  test('auto-starts an already paired connector on desktop launch', async () => {
+    createCatsCoLocalConfigService({ runtimeRoot: testRoot }).writeDeviceConnectorEnrollment({
+      httpBaseUrl: 'https://app.catsco.cc',
+      serverUrl: 'wss://app.catsco.cc/v0/channels',
+    }, {
+      token: 'saved-token',
+      deviceId: 'saved-device',
+      installationId: 'saved-install',
+      capabilities: ['read_file', 'glob', 'grep'],
+    });
+
+    const response = await originalFetch(`${baseUrl}/api/cats/device-connector/ensure-running`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+    const body = await response.json() as any;
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(startCalls, ['device-connector']);
+    assert.equal(body.connectorStarted, true);
+  });
+
+  test('does not auto-start before a device is paired', async () => {
+    const response = await originalFetch(`${baseUrl}/api/cats/device-connector/ensure-running`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+    const body = await response.json() as any;
+
+    assert.equal(response.status, 409);
+    assert.equal(body.reason, 'DEVICE_CONNECTOR_NOT_PAIRED');
+    assert.deepEqual(startCalls, []);
+  });
+});
+
+function listen(app: express.Express): Promise<Server> {
+  return new Promise(resolve => {
+    const server = app.listen(0, '127.0.0.1', () => resolve(server));
+  });
+}

--- a/tests/device-grants.test.ts
+++ b/tests/device-grants.test.ts
@@ -101,6 +101,8 @@ describe('device grants', () => {
     assert.equal(createDeviceGrant(scope(), device(), { operations: [] }), undefined);
     assert.equal(createDeviceGrant(scope(), device({ source: 'feishu' }), { operations: ['read_file'] }), undefined);
     assert.equal(createDeviceGrant(scope(), device({ ownerUserId: 'usr8' }), { operations: ['read_file'] }), undefined);
+    assert.equal(createDeviceGrant(scope(), device({ identityTrust: 'untrusted' }), { operations: ['read_file'] }), undefined);
+    assert.equal(createDeviceGrant(scope(), device({ status: 'offline' }), { operations: ['read_file'] }), undefined);
   });
 
   test('resolves a matching grant by operation and optional target device', () => {
@@ -169,7 +171,8 @@ describe('device grants', () => {
       ['expired', grant({ expiresAt: 2_000 }), /已过期/],
       ['operation', grant({ operations: ['send_file'] }), /不允许执行 read_file/],
       ['target device', grant(), /目标设备不一致/],
-      ['untrusted', grant({ identityTrust: 'untrusted' }), /未可信身份/],
+      ['untrusted', grant({ identityTrust: 'untrusted' }), /不是服务端可信身份/],
+      ['legacy', grant({ identityTrust: 'legacy_context' }), /不是服务端可信身份/],
     ];
 
     for (const [name, candidate, messagePattern] of cases) {
@@ -192,7 +195,6 @@ describe('device grants', () => {
       ['topicId', { topicId: 'grp_81' }],
       ['topicType', { topicType: 'p2p' }],
       ['actorUserId', { actorUserId: 'usr8', ownerUserId: 'usr8' }],
-      ['ownerUserId', { ownerUserId: 'usr8' }],
       ['agentId', { agentId: 'usr99' }],
       ['agentBodyId', { agentBodyId: 'body-other' }],
     ];
@@ -207,6 +209,52 @@ describe('device grants', () => {
 
       assert.equal(decision.ok, false, field);
       if (!decision.ok) assert.match(decision.message, new RegExp(field), field);
+    }
+  });
+
+  test('accepts delegated channel grants where device owner differs from actor', () => {
+    const decision = validateDeviceGrant({
+      executionScope: scope({ actorUserId: 'usr100' }),
+    }, grant({
+      ownerUserId: 'usr7',
+      actorUserId: 'usr100',
+      identitySource: 'channel_identity_link',
+    }), {
+      operation: 'read_file',
+      now: 2_000,
+    });
+
+    assert.equal(decision.ok, true);
+    if (decision.ok) {
+      assert.equal(decision.grant.ownerUserId, 'usr7');
+      assert.equal(decision.grant.actorUserId, 'usr100');
+    }
+  });
+
+  test('rejects owner mismatch grants without an explicit trusted channel delegation source', () => {
+    const candidates: Array<[string, Partial<ScopedDeviceGrant>]> = [
+      ['missing identitySource', { identitySource: undefined }],
+      ['plain metadata source', { identitySource: 'metadata.catsco_identity' }],
+      ['device rpc forward source', { identitySource: 'device_rpc_forward' }],
+      ['legacy delegated source', { identitySource: 'channel_identity_link', identityTrust: 'legacy_context' }],
+    ];
+
+    for (const [name, overrides] of candidates) {
+      const decision = validateDeviceGrant({
+        executionScope: scope({ actorUserId: 'usr100' }),
+      }, grant({
+        ownerUserId: 'usr7',
+        actorUserId: 'usr100',
+        ...overrides,
+      }), {
+        operation: 'read_file',
+        now: 2_000,
+      });
+
+      assert.equal(decision.ok, false, name);
+      if (!decision.ok) {
+        assert.match(decision.message, /owner|可信身份|委托/, name);
+      }
     }
   });
 });

--- a/tests/electron-main-dashboard-url.test.ts
+++ b/tests/electron-main-dashboard-url.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import test from 'node:test';
 
 const electronMain = readFileSync(join(process.cwd(), 'electron/main.js'), 'utf-8');
+const packageJson = JSON.parse(readFileSync(join(process.cwd(), 'package.json'), 'utf-8'));
 
 test('electron opens the local dashboard through stable IPv4 loopback', () => {
   assert.match(electronMain, /mainWindow\.loadURL\(`http:\/\/127\.0\.0\.1:\$\{DASHBOARD_PORT\}`\)/);
@@ -46,4 +47,25 @@ test('electron tray uses app icons and notifies after background hide', () => {
   assert.match(electronMain, /tray\.displayBalloon/);
   assert.match(electronMain, /CatsCo 已在后台运行/);
   assert.match(electronMain, /notifyWindowHidden\(\)/);
+});
+
+test('electron registers and handles CatsCo device connector deep links', () => {
+  assert.match(electronMain, /const DEEP_LINK_PROTOCOL = 'catsco'/);
+  assert.match(electronMain, /app\.requestSingleInstanceLock\(\)/);
+  assert.match(electronMain, /app\.setAsDefaultProtocolClient\(DEEP_LINK_PROTOCOL/);
+  assert.match(electronMain, /app\.on\('second-instance'/);
+  assert.match(electronMain, /app\.on\('open-url'/);
+  assert.match(electronMain, /url\.hostname !== 'device-connector' \|\| url\.pathname !== '\/pair'/);
+  assert.match(electronMain, /postLocalDashboardJson\('\/api\/cats\/device-connector\/pair'/);
+  assert.match(electronMain, /postLocalDashboardJson\('\/api\/cats\/device-connector\/ensure-running'/);
+  assert.match(electronMain, /app\.setLoginItemSettings\(\{ openAtLogin: true, openAsHidden: true \}\)/);
+});
+
+test('packaged app declares the CatsCo URL protocol', () => {
+  assert.deepEqual(packageJson.build.protocols, [
+    {
+      name: 'CatsCo Link',
+      schemes: ['catsco'],
+    },
+  ]);
 });

--- a/tests/feishu-session-route.test.ts
+++ b/tests/feishu-session-route.test.ts
@@ -68,9 +68,140 @@ describe('Feishu SessionRoute V2', () => {
       SubAgentManager.getInstance().unregisterPlatformCallbacks('session:v2:feishu:group:oc_group');
     }
   });
+
+  test('does not apply QR channel binding to Feishu group messages yet', async () => {
+    const bot = createHarness({
+      bindingResolver: {
+        enabled: true,
+        required: true,
+        resolve: async () => {
+          throw new Error('group binding should not be resolved in this PR');
+        },
+      },
+      message: {
+        messageId: 'msg-group-binding-skipped',
+        chatId: 'oc_group',
+        chatType: 'group',
+        senderId: 'ou_user',
+        text: '@bot 看一下',
+        mentionBot: true,
+        msgType: 'text',
+      },
+    });
+
+    try {
+      await (bot as any).onMessage({});
+
+      const sessionKey = 'session:v2:feishu:group:oc_group';
+      assert.deepEqual(bot.createdSessions, [sessionKey]);
+      assert.equal(bot.handledTurns.length, 1);
+      assert.equal(bot.handledTurns[0].options.sessionRoute.sessionKey, sessionKey);
+      assert.equal(bot.handledTurns[0].options.executionScope.topicType, 'group');
+    } finally {
+      SubAgentManager.getInstance().unregisterPlatformCallbacks('session:v2:feishu:group:oc_group');
+    }
+  });
+
+  test('does not create a model session when channel binding is required but missing', async () => {
+    const replies: string[] = [];
+    const bot = createHarness({
+      replies,
+      bindingResolver: {
+        enabled: true,
+        required: true,
+        resolve: async () => ({ bound: false }),
+      },
+      message: {
+        messageId: 'msg-binding-missing',
+        chatId: 'shared',
+        chatType: 'p2p',
+        senderId: 'shared',
+        text: 'hello',
+        mentionBot: false,
+        msgType: 'text',
+      },
+    });
+
+    await (bot as any).onMessage({});
+
+    assert.deepEqual(bot.createdSessions, []);
+    assert.equal(bot.handledTurns.length, 0);
+    assert.equal(replies.length, 1);
+    assert.match(replies[0], /入口码|绑定/);
+  });
+
+  test('does not create a model session when required channel binding resolver is disabled or returns empty', async () => {
+    for (const bindingResolver of [
+      { enabled: false, required: true },
+      { enabled: true, required: true, resolve: async () => undefined },
+    ]) {
+      const replies: string[] = [];
+      const bot = createHarness({
+        replies,
+        bindingResolver,
+        message: {
+          messageId: `msg-binding-disabled-${replies.length}`,
+          chatId: 'shared',
+          chatType: 'p2p',
+          senderId: 'shared',
+          text: 'hello',
+          mentionBot: false,
+          msgType: 'text',
+        },
+      });
+
+      await (bot as any).onMessage({});
+
+      assert.deepEqual(bot.createdSessions, []);
+      assert.equal(bot.handledTurns.length, 0);
+      assert.equal(replies.length, 1);
+      assert.match(replies[0], /绑定|配置|失败/);
+    }
+  });
+
+  test('uses resolved channel binding as the Feishu agent session route', async () => {
+    const bot = createHarness({
+      bindingResolver: {
+        enabled: true,
+        required: true,
+        resolve: async () => ({
+          bound: true,
+          agentId: 'usr43',
+          agentBodyId: 'body-contract',
+          identityTrust: 'server_canonical',
+          identitySource: 'channel_agent_binding',
+        }),
+      },
+      message: {
+        messageId: 'msg-binding-ok',
+        chatId: 'shared',
+        chatType: 'p2p',
+        senderId: 'ou_user',
+        text: '查合同',
+        mentionBot: false,
+        msgType: 'text',
+      },
+    });
+
+    try {
+      await (bot as any).onMessage({});
+
+      const sessionKey = 'session:v2:feishu:p2p:shared:agent:usr43';
+      assert.deepEqual(bot.createdSessions, [sessionKey]);
+      assert.equal(bot.handledTurns.length, 1);
+      assert.equal(bot.handledTurns[0].options.sessionRoute.agentId, 'usr43');
+      assert.equal(bot.handledTurns[0].options.sessionRoute.agentBodyId, 'body-contract');
+      assert.equal(bot.handledTurns[0].options.sessionRoute.identityTrust, 'server_canonical');
+      assert.equal(bot.handledTurns[0].options.executionScope.agentId, 'usr43');
+      assert.equal(bot.handledTurns[0].options.executionScope.agentBodyId, 'body-contract');
+      assert.equal(bot.handledTurns[0].options.executionScope.isTrusted, true);
+    } finally {
+      SubAgentManager.getInstance().unregisterPlatformCallbacks('session:v2:feishu:p2p:shared:agent:usr43');
+    }
+  });
 });
 
-function createHarness(options: { busy?: boolean; message: any }): any {
+function createHarness(options: { busy?: boolean; message: any; bindingResolver?: any; replies?: string[] }): any {
   const bot = Object.create(FeishuBot.prototype) as any;
   bot.sessionBusy = options.busy ?? false;
   bot.createdSessions = [] as string[];
@@ -82,6 +213,8 @@ function createHarness(options: { busy?: boolean; message: any }): any {
   bot.messageQueue = new Map();
   bot.bridgeClient = null;
   bot.bridgeConfig = undefined;
+  bot.channelAppId = 'cli_app';
+  bot.bindingResolver = options.bindingResolver || { enabled: false, required: false };
   bot.handler = {
     parse: () => options.message,
   };
@@ -104,7 +237,9 @@ function createHarness(options: { busy?: boolean; message: any }): any {
     },
   };
   bot.sender = {
-    reply: async () => undefined,
+    reply: async (_chatId: string, text: string) => {
+      options.replies?.push(text);
+    },
     downloadFile: async () => null,
     fetchMergeForwardTexts: async () => '',
     sendFile: async () => undefined,

--- a/tests/grep-tool.test.ts
+++ b/tests/grep-tool.test.ts
@@ -179,12 +179,17 @@ describe('GrepTool', () => {
 
   describe('安全性检查', () => {
     test('应该处理工作目录外的路径并返回错误', async () => {
+      const outsideMissingPath = path.join(
+        os.tmpdir(),
+        `grep-outside-missing-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+        'missing.txt'
+      );
       const result = await grepTool.execute({
         pattern: 'test',
-        path: '../../etc/passwd'
+        path: outsideMissingPath
       }, context);
 
-      // 由于路径不存在，应该返回错误
+      // 由于路径在工作目录外且不存在，应该返回错误
       assert.ok(!result.ok, '应该返回错误');
       assert.ok(result.message.includes('目录不存在') || result.message.includes('rg') || result.message.includes('grep'),
         `错误信息应该有用，实际: ${result.message}`);

--- a/tests/session-route-v2.test.ts
+++ b/tests/session-route-v2.test.ts
@@ -95,4 +95,53 @@ describe('SessionRoute V2', () => {
     assert.equal(route.actorUserId, 'ResearchBot');
     assert.equal(route.topicType, 'group');
   });
+
+  test('keeps channel users isolated by QR-bound agent id', () => {
+    const feishuContract = createFeishuSessionRoute({
+      messageId: 'msg-feishu-1',
+      chatId: 'oc_p2p',
+      chatType: 'p2p',
+      senderId: 'ou_user',
+      text: '查合同',
+      mentionBot: false,
+      msgType: 'text',
+    }, {
+      agentId: 'usr43',
+      agentBodyId: 'body-contract',
+      identityTrust: 'server_canonical',
+      identitySource: 'channel_agent_binding',
+    });
+    const feishuFinance = createFeishuSessionRoute({
+      messageId: 'msg-feishu-2',
+      chatId: 'oc_p2p',
+      chatType: 'p2p',
+      senderId: 'ou_user',
+      text: '查发票',
+      mentionBot: false,
+      msgType: 'text',
+    }, {
+      agentId: 'usr99',
+      identityTrust: 'server_canonical',
+      identitySource: 'channel_agent_binding',
+    });
+    const weixinContract = createWeixinSessionRoute({
+      message_id: 'msg-weixin-1',
+      from: { id: 'openid-user' },
+      chat: { id: 'bot' },
+      text: '查合同',
+      context_token: 'ctx',
+    }, {
+      agentId: 'usr43',
+      identityTrust: 'server_canonical',
+      identitySource: 'channel_agent_binding',
+    });
+
+    assert.equal(feishuContract.sessionKey, 'session:v2:feishu:p2p:oc_p2p:agent:usr43');
+    assert.equal(feishuFinance.sessionKey, 'session:v2:feishu:p2p:oc_p2p:agent:usr99');
+    assert.notEqual(feishuContract.sessionKey, feishuFinance.sessionKey);
+    assert.equal(feishuContract.agentBodyId, 'body-contract');
+    assert.equal(feishuContract.identityTrust, 'server_canonical');
+    assert.equal(feishuContract.identitySource, 'channel_agent_binding');
+    assert.equal(weixinContract.sessionKey, 'session:v2:weixin:p2p:openid-user:agent:usr43');
+  });
 });

--- a/tests/tool-gateway-catsco.test.ts
+++ b/tests/tool-gateway-catsco.test.ts
@@ -302,6 +302,40 @@ describe('CatsCo ToolGateway', () => {
     assert.deepEqual(calls[1].args, { pattern: 'needle', path: '/remote/project', output_mode: 'files' });
   });
 
+  test('routes write_file to the backend-selected remote device without local writes', async () => {
+    const root = makeWorkspace();
+    const requestedPath = path.join(root, 'should-not-exist.txt');
+    let rpcRequest: any;
+    const result = await new WriteTool().execute({ file_path: requestedPath, content: 'remote write' }, context(root, {
+      deviceGrants: [deviceGrant(['write_file'], {
+        deviceId: 'other-device',
+        deviceDisplayName: 'Other Device',
+        deviceBodyId: 'body-other',
+        deviceInstallationId: 'install-other',
+      })],
+      deviceSelection: deviceSelection({
+        selectedDeviceId: 'other-device',
+        selectedDeviceDisplayName: 'Other Device',
+        selectedDeviceBodyId: 'body-other',
+        selectedDeviceInstallationId: 'install-other',
+        selectedDeviceOperations: ['write_file'],
+      }),
+      deviceRpc: {
+        executeTool: async request => {
+          rpcRequest = request;
+          return { ok: true, content: 'remote write ok' };
+        },
+      },
+    }));
+
+    assert.equal(result.ok, true);
+    assert.equal(String(result.content), 'remote write ok');
+    assert.equal(rpcRequest.toolName, 'write_file');
+    assert.equal(rpcRequest.operation, 'write_file');
+    assert.deepEqual(rpcRequest.args, { file_path: requestedPath, content: 'remote write' });
+    assert.equal(fs.existsSync(requestedPath), false);
+  });
+
   test('redacts local absolute paths from successful CatsCo device file results', async () => {
     const root = makeWorkspace();
     const filePath = path.join(root, 'notes.txt');
@@ -408,16 +442,16 @@ describe('CatsCo ToolGateway', () => {
     }
   });
 
-  test('blocks execute_shell in CatsCo sessions even when a grant contains execute_shell', async () => {
+  test('blocks execute_shell until the server grants execute_shell for the current device', async () => {
     const root = makeWorkspace();
     const result = await new ShellTool().execute({ command: 'echo hello' }, context(root, {
-      deviceGrants: [deviceGrant(['execute_shell'])],
+      deviceGrants: [deviceGrant(['read_file'])],
     }));
 
     assert.equal(result.ok, false);
     if (!result.ok) {
       assert.equal(result.errorCode, 'PERMISSION_DENIED');
-      assert.match(result.message, /暂不允许通过 execute_shell/);
+      assert.match(result.message, /执行 execute_shell/);
     }
   });
 });

--- a/tests/tool-gateway-catsco.test.ts
+++ b/tests/tool-gateway-catsco.test.ts
@@ -164,6 +164,28 @@ describe('CatsCo ToolGateway', () => {
     assert.match(String(result.content), /selected content/);
   });
 
+  test('does not execute locally when selected device identifiers conflict with the current device', async () => {
+    const root = makeWorkspace();
+    const filePath = path.join(root, 'notes.txt');
+    fs.writeFileSync(filePath, 'must not be read locally');
+
+    const result = await new ReadTool().execute({ file_path: filePath }, context(root, {
+      deviceGrants: [deviceGrant(['read_file'])],
+      deviceSelection: deviceSelection({
+        selectedDeviceId: 'install-device',
+        selectedDeviceBodyId: 'body-other',
+        selectedDeviceInstallationId: 'install-device',
+      }),
+    }));
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.errorCode, 'PERMISSION_DENIED');
+      assert.match(result.message, /远程设备 RPC 通道/);
+      assert.doesNotMatch(result.message, new RegExp(escapeRegExp(filePath)));
+    }
+  });
+
   test('blocks device tools when backend requires device selection first', async () => {
     const root = makeWorkspace();
     const filePath = path.join(root, 'notes.txt');
@@ -364,6 +386,23 @@ describe('CatsCo ToolGateway', () => {
     assert.equal(grep.ok, true);
     assert.match(String(grep.content), /needle/);
     assert.doesNotMatch(String(grep.content), new RegExp(escapeRegExp(root)));
+
+    const outsideRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-tool-gateway-outside-'));
+    const outsideFile = path.join(outsideRoot, 'outside-notes.txt');
+    fs.writeFileSync(outsideFile, 'outside needle');
+    const outsideGrep = await new GrepTool().execute({ pattern: 'needle', path: outsideFile, output_mode: 'content' }, ctx);
+    assert.equal(outsideGrep.ok, true);
+    assert.match(String(outsideGrep.content), /outside needle/);
+    assert.doesNotMatch(String(outsideGrep.content), /\.\.\//);
+    assert.doesNotMatch(String(outsideGrep.content), new RegExp(escapeRegExp(outsideRoot)));
+
+    const relativeOutsidePath = path.relative(root, outsideFile);
+    const outsideRelativeGrep = await new GrepTool().execute({ pattern: 'needle', path: relativeOutsidePath, output_mode: 'content' }, ctx);
+    assert.equal(outsideRelativeGrep.ok, true);
+    assert.match(String(outsideRelativeGrep.content), /outside needle/);
+    assert.doesNotMatch(String(outsideRelativeGrep.content), /\.\.\//);
+    assert.doesNotMatch(String(outsideRelativeGrep.content), new RegExp(escapeRegExp(relativeOutsidePath)));
+    assert.doesNotMatch(String(outsideRelativeGrep.content), new RegExp(escapeRegExp(outsideRoot)));
 
     const write = await new WriteTool().execute({ file_path: outPath, content: 'after' }, ctx);
     assert.equal(write.ok, true);

--- a/tests/weixin-session-route.test.ts
+++ b/tests/weixin-session-route.test.ts
@@ -84,12 +84,136 @@ describe('Weixin SessionRoute V2', () => {
       SubAgentManager.getInstance().unregisterPlatformCallbacks('session:v2:weixin:p2p:shared');
     }
   });
+
+  test('does not create a model session when channel binding is required but missing', async () => {
+    const sentTexts: Array<{ userId: string; text: string; contextToken?: string }> = [];
+    const bot = createHarness({
+      sentTexts,
+      bindingResolver: {
+        enabled: true,
+        required: true,
+        resolve: async () => ({ bound: false }),
+      },
+      parsed: {
+        message_id: 'wx-msg-binding-missing',
+        from: { id: 'shared' },
+        chat: { id: 'wx-bot' },
+        text: 'hello',
+        context_token: 'ctx-token',
+      },
+    });
+
+    await (bot as any).handleMessage({
+      message_type: 0,
+      message_id: 'wx-msg-binding-missing',
+      from_user_id: 'shared',
+      to_user_id: 'wx-bot',
+      context_token: 'ctx-token',
+    });
+
+    assert.deepEqual(bot.createdSessions, []);
+    assert.equal(bot.handledTurns.length, 0);
+    assert.equal(sentTexts.length, 1);
+    assert.equal(sentTexts[0].userId, 'shared');
+    assert.match(sentTexts[0].text, /入口码|绑定/);
+  });
+
+  test('does not create a model session when required channel binding resolver is disabled or returns empty', async () => {
+    for (const bindingResolver of [
+      { enabled: false, required: true },
+      { enabled: true, required: true, resolve: async () => undefined },
+    ]) {
+      const sentTexts: Array<{ userId: string; text: string; contextToken?: string }> = [];
+      const bot = createHarness({
+        sentTexts,
+        bindingResolver,
+        parsed: {
+          message_id: 'wx-msg-binding-disabled',
+          from: { id: 'shared' },
+          chat: { id: 'wx-bot' },
+          text: 'hello',
+          context_token: 'ctx-token',
+        },
+      });
+
+      await (bot as any).handleMessage({
+        message_type: 0,
+        message_id: 'wx-msg-binding-disabled',
+        from_user_id: 'shared',
+        to_user_id: 'wx-bot',
+        context_token: 'ctx-token',
+      });
+
+      assert.deepEqual(bot.createdSessions, []);
+      assert.equal(bot.handledTurns.length, 0);
+      assert.equal(sentTexts.length, 1);
+      assert.match(sentTexts[0].text, /绑定|配置|失败/);
+    }
+  });
+
+  test('uses resolved channel binding as the Weixin agent session route', async () => {
+    const bindingInputs: any[] = [];
+    const bot = createHarness({
+      channelAppId: 'wx_app',
+      bindingResolver: {
+        enabled: true,
+        required: true,
+        resolve: async (input: any) => {
+          bindingInputs.push(input);
+          return {
+            bound: true,
+            agentId: 'usr43',
+            agentBodyId: 'body-contract',
+            identityTrust: 'server_canonical',
+            identitySource: 'channel_agent_binding',
+          };
+        },
+      },
+      parsed: {
+        message_id: 'wx-msg-binding-ok',
+        from: { id: 'openid-user' },
+        chat: { id: 'wx-bot' },
+        text: '查合同',
+        context_token: 'ctx-token',
+      },
+    });
+
+    try {
+      await (bot as any).handleMessage({
+        message_type: 0,
+        message_id: 'wx-msg-binding-ok',
+        from_user_id: 'openid-user',
+        to_user_id: 'wx-bot',
+        context_token: 'ctx-token',
+      });
+
+      const sessionKey = 'session:v2:weixin:p2p:openid-user:agent:usr43';
+      assert.deepEqual(bot.createdSessions, [sessionKey]);
+      assert.equal(bot.handledTurns.length, 1);
+      assert.equal(bot.handledTurns[0].options.sessionRoute.agentId, 'usr43');
+      assert.equal(bot.handledTurns[0].options.sessionRoute.agentBodyId, 'body-contract');
+      assert.equal(bot.handledTurns[0].options.sessionRoute.identityTrust, 'server_canonical');
+      assert.equal(bot.handledTurns[0].options.executionScope.agentId, 'usr43');
+      assert.equal(bot.handledTurns[0].options.executionScope.agentBodyId, 'body-contract');
+      assert.equal(bot.handledTurns[0].options.executionScope.isTrusted, true);
+      assert.deepEqual(bindingInputs, [{
+        channel: 'weixin',
+        channelAppId: 'wx_app',
+        channelUserId: 'openid-user',
+        channelConversationType: 'p2p',
+      }]);
+    } finally {
+      SubAgentManager.getInstance().unregisterPlatformCallbacks('session:v2:weixin:p2p:openid-user:agent:usr43');
+    }
+  });
 });
 
 function createHarness(options: {
   busy?: boolean;
   parsed: any;
   sentTexts?: Array<{ userId: string; text: string; contextToken?: string }>;
+  bindingResolver?: any;
+  channelAppId?: string;
 }): any {
   const bot = Object.create(WeixinBot.prototype) as any;
   bot.sessionBusy = options.busy ?? false;
@@ -97,6 +221,8 @@ function createHarness(options: {
   bot.handledTurns = [] as any[];
   bot.contextTokens = new Map();
   bot.messageQueue = new Map();
+  bot.bindingResolver = options.bindingResolver || { enabled: false, required: false };
+  bot.channelAppId = options.channelAppId || '';
   bot.saveState = async () => undefined;
   bot.handler = {
     parseMessage: () => options.parsed,


### PR DESCRIPTION
## 概要

- Dashboard CatsCo 状态卡增加设备授权、授权操作、最近拒绝、Device RPC pending/route 状态展示。
- 解析并展示设备 active / routeConnected / routable / unavailableReason，避免把“设备已注册”误认为“设备可执行”。
- 设备授权摘要不再在没有 pending RPC 或本轮 snapshot 时默认选择第一台设备，而是显示“可用设备 N 台 / 本轮未选择”。
- Device RPC 工具链支持远程 write_file / execute_shell 的协议路径，但仍需要服务端 grant 和 ToolGateway 校验；默认注册能力仍保持低风险。
- Dashboard snapshot 路径改为运行时 cwd 解析，避免测试或不同启动目录读到错误快照。

## 验证

- `npm.cmd run build`
- `npm.cmd run test:runtime -- --test-name-pattern catsco`