### PR TITLE
fix(dashboard): bind Weixin token to current agent

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -9757,13 +9757,17 @@
 
     // === 微信 Token 获取 ===
     let weixinPollInterval;
+    let weixinPollAgentUid='';
     async function getWeixinToken(){
       try{
         const r=await fetch(API+'/api/weixin/qrcode');
         const d=await r.json();
+        if(!r.ok||d.error)throw new Error(d.error||'获取二维码失败');
         if(d.qrcode){
+          weixinPollAgentUid=String(d.agent_uid||d.agent?.uid||'');
+          const agentName=d.agent?.name||d.agent?.username||weixinPollAgentUid||'当前 Agent';
           document.getElementById('logs-title').textContent='微信扫码授权';
-          document.getElementById('logs-body').innerHTML='<div style="text-align:center;padding:20px"><p style="margin-bottom:16px;color:var(--text)">请用微信扫描下方二维码授权</p><a href="'+d.qrcode_img_content+'" target="_blank" style="display:inline-block;padding:12px 20px;background:var(--accent-gradient);color:white;text-decoration:none;border-radius:12px;font-weight:700">点击打开二维码</a><p style="margin-top:16px;font-size:12px;color:var(--text3)">等待扫码中...</p></div>';
+          document.getElementById('logs-body').innerHTML='<div style="text-align:center;padding:20px"><p style="margin-bottom:8px;color:var(--text);font-weight:800">绑定到 '+escapeHtml(agentName)+'</p><p style="margin-bottom:16px;color:var(--text2)">请用微信扫描下方二维码授权。授权成功后，微信消息会进入这个 Agent。</p><a href="'+escapeHtml(d.qrcode_img_content||'')+'" target="_blank" style="display:inline-block;padding:12px 20px;background:var(--accent-gradient);color:white;text-decoration:none;border-radius:12px;font-weight:700">点击打开二维码</a><p style="margin-top:16px;font-size:12px;color:var(--text3)">等待扫码中...</p></div>';
           document.getElementById('logs-modal').classList.add('show');
           if(weixinPollInterval)clearInterval(weixinPollInterval);
           weixinPollInterval=setInterval(()=>checkWeixinStatus(d.qrcode),2000);
@@ -9772,18 +9776,24 @@
     }
     async function checkWeixinStatus(qrcode){
       try{
-        const r=await fetch(API+'/api/weixin/qrcode-status?qrcode='+qrcode);
+        const agentParam=weixinPollAgentUid?'&agent_uid='+encodeURIComponent(weixinPollAgentUid):'';
+        const r=await fetch(API+'/api/weixin/qrcode-status?qrcode='+encodeURIComponent(qrcode)+agentParam);
         const d=await r.json();
-        if(d.status==='confirmed'&&d.bot_token){
+        if(!r.ok||d.error)throw new Error(d.error||'微信授权状态检查失败');
+        if(d.status==='confirmed'&&d.token_saved){
           clearInterval(weixinPollInterval);
-          document.querySelector('[data-key="WEIXIN_TOKEN"]').value=d.bot_token;
-          document.getElementById('logs-body').innerHTML='<div style="text-align:center;padding:20px;color:var(--green)"><p style="font-size:18px;font-weight:700;margin-bottom:12px">✓ 授权成功</p><p>Token 已自动填入，请点击保存按钮</p></div>';
+          const bound=d.binding?.agentName||d.binding?.agentUsername||d.binding?.agentUid||'当前 Agent';
+          document.getElementById('logs-body').innerHTML='<div style="text-align:center;padding:20px;color:var(--green)"><p style="font-size:18px;font-weight:700;margin-bottom:12px">✓ 授权成功</p><p>微信通道已绑定到 '+escapeHtml(bound)+'，Token 已保存到本地环境。</p></div>';
+          await Promise.allSettled([fetchConfig(), fetchStatus(), fetchReadiness()]);
           setTimeout(()=>document.getElementById('logs-modal').classList.remove('show'),2000);
         }else if(d.status==='expired'){
           clearInterval(weixinPollInterval);
           document.getElementById('logs-body').innerHTML='<div style="text-align:center;padding:20px;color:var(--red)">二维码已过期，请重新获取</div>';
         }
-      }catch(e){}
+      }catch(e){
+        clearInterval(weixinPollInterval);
+        document.getElementById('logs-body').innerHTML='<div style="text-align:center;padding:20px;color:var(--red)">微信授权失败：'+escapeHtml(e.message||String(e))+'</div>';
+      }
     }
 
     // Init

--- a/src/dashboard/readiness.ts
+++ b/src/dashboard/readiness.ts
@@ -8,6 +8,7 @@ import { ChatConfig } from '../types';
 import { ServiceInfo, ServiceManager } from './service-manager';
 import { readDashboardEnvFile } from './settings';
 import { resolveCatsCoRuntimeConfig } from '../catscompany/runtime-config';
+import { getWeixinChannelStatus } from './weixin-channel-binding';
 
 export type DashboardReadinessStatus = 'ready' | 'warning' | 'blocked';
 export type DashboardReadinessCheckStatus = 'pass' | 'warning' | 'fail';
@@ -120,7 +121,7 @@ export function getServicePreflight(
   const checks = [
     ...buildModelChecks(env, config),
     ...buildRuntimeChecks(service, runtimeRoot, env, config, serviceNameToSurface(name)),
-    ...buildServiceSpecificChecks(name, env, config),
+    ...buildServiceSpecificChecks(name, env, config, runtimeRoot),
   ];
   const status = statusFromChecks(checks);
 
@@ -441,6 +442,7 @@ function buildServiceSpecificChecks(
   name: string,
   env: NodeJS.ProcessEnv,
   config: ChatConfig,
+  runtimeRoot: string,
 ): DashboardReadinessCheck[] {
   if (name === 'catscompany') {
     const serverUrl = firstNonEmpty(
@@ -487,10 +489,23 @@ function buildServiceSpecificChecks(
   }
 
   if (name === 'weixin') {
+    const status = getWeixinChannelStatus({ runtimeRoot, env });
     return [
+      status.currentAgent
+        ? passCheck('service.weixin.agent', '微信所属 Agent', `微信将接入当前 agent ${status.currentAgent.name || status.currentAgent.uid}`)
+        : failCheck('service.weixin.agent', '微信所属 Agent', status.reason || '请先选择并绑定 CatsCo agent', 'blocker', {
+          label: '打开 CatsCo',
+          target: 'catsco',
+        }),
+      status.configured
+        ? passCheck('service.weixin.binding', '微信通道绑定', `微信通道已绑定到 agent ${status.binding?.agentName || status.binding?.agentUid}`)
+        : failCheck('service.weixin.binding', '微信通道绑定', status.reason || '请先在当前 agent 下扫码绑定微信', 'blocker', {
+          label: '打开设置',
+          target: 'settings',
+        }),
       firstNonEmpty(env.WEIXIN_TOKEN)
         ? passCheck('service.weixin.token', '微信 Token', '微信 Token 已配置')
-        : failCheck('service.weixin.token', '微信 Token', '需要配置 WEIXIN_TOKEN', 'blocker', {
+        : failCheck('service.weixin.token', '微信 Token', '需要在当前 agent 下扫码获取微信 Token', 'blocker', {
           label: '打开设置',
           target: 'settings',
         }),

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -48,6 +48,12 @@ import {
   computeLocalSkillContentHash,
   readSkillHubLocalMetadata,
 } from '../../skillhub/local-skill-metadata';
+import {
+  BindWeixinChannelResult,
+  WeixinChannelStatus,
+  bindWeixinChannelToCurrentAgent,
+  getWeixinChannelStatus,
+} from '../weixin-channel-binding';
 // import { ReportGenerator } from '../../utils/report-generator';
 // import { LogUploader } from '../../utils/log-uploader';
 
@@ -202,6 +208,48 @@ function httpError(message: string, status: number): Error {
   const error = new Error(message);
   (error as any).status = status;
   return error;
+}
+
+function sanitizeWeixinChannelStatus(status: WeixinChannelStatus): Record<string, any> {
+  const binding = status.binding
+    ? {
+      channel: status.binding.channel,
+      agentUid: status.binding.agentUid,
+      agentName: status.binding.agentName,
+      agentUsername: status.binding.agentUsername,
+      bodyId: status.binding.bodyId,
+      boundByUserUid: status.binding.boundByUserUid,
+      tokenLast4: status.binding.tokenLast4,
+      legacyEnvKey: status.binding.legacyEnvKey,
+      createdAt: status.binding.createdAt,
+      updatedAt: status.binding.updatedAt,
+    }
+    : undefined;
+  return {
+    configured: status.configured,
+    currentAgent: status.currentAgent,
+    binding,
+    mismatch: status.mismatch,
+    reason: status.reason,
+  };
+}
+
+function sanitizeWeixinBindingResult(result: BindWeixinChannelResult): Record<string, any> {
+  return {
+    binding: sanitizeWeixinChannelStatus({
+      configured: true,
+      currentAgent: {
+        uid: result.binding.agentUid,
+        name: result.binding.agentName,
+        username: result.binding.agentUsername,
+        bodyId: result.binding.bodyId,
+        ownerUid: result.binding.boundByUserUid,
+        ownerUsername: result.binding.boundByUsername,
+      },
+      binding: result.binding,
+    }).binding,
+    updatedEnv: result.updatedEnv,
+  };
 }
 
 function assertCurrentCatsTopic(state: CatsAuthState, topicId: string): void {
@@ -1726,9 +1774,11 @@ export function createApiRouter(serviceManager: ServiceManager, updateController
       const masked = { ...parsed };
       for (const key of Object.keys(masked)) {
         if (isSensitiveEnvKey(key)) {
-          masked[key] = masked[key] && masked[key].length > 4
-            ? `****${masked[key].slice(-4)}`
-            : '****';
+          masked[key] = masked[key]
+            ? masked[key].length > 4
+              ? `****${masked[key].slice(-4)}`
+              : '****'
+            : '';
         }
       }
       res.json(masked);
@@ -1756,6 +1806,10 @@ export function createApiRouter(serviceManager: ServiceManager, updateController
         'FEISHU_BOT_OPEN_ID',
         'FEISHU_BOT_ALIASES',
         'WEIXIN_TOKEN',
+        'WEIXIN_BOUND_AGENT_UID',
+        'WEIXIN_BOUND_AGENT_NAME',
+        'WEIXIN_BOUND_BODY_ID',
+        'WEIXIN_BOUND_BY_USER_UID',
       ]);
       const safeUpdates: Record<string, string> = {};
 
@@ -1916,11 +1970,41 @@ export function createApiRouter(serviceManager: ServiceManager, updateController
 
   // ==================== 微信 Token 获取 ====================
 
+  router.get('/weixin/channel-binding', (_req, res) => {
+    try {
+      res.json(sanitizeWeixinChannelStatus(getWeixinChannelStatus({
+        runtimeRoot: process.cwd(),
+        env: process.env,
+      })));
+    } catch (e: any) {
+      res.status(500).json({ error: e.message });
+    }
+  });
+
   router.get('/weixin/qrcode', async (_req, res) => {
     try {
+      const status = getWeixinChannelStatus({
+        runtimeRoot: process.cwd(),
+        env: process.env,
+      });
+      if (!status.currentAgent) {
+        return res.status(409).json({
+          error: status.reason || '请先在 CatsCo Chat 中选择并绑定 agent，再绑定微信通道',
+          channelStatus: sanitizeWeixinChannelStatus(status),
+        });
+      }
       const response = await fetch('https://ilinkai.weixin.qq.com/ilink/bot/get_bot_qrcode?bot_type=3');
-      const data = await response.json();
-      res.json(data);
+      const data = await response.json() as Record<string, any>;
+      if (!response.ok) {
+        return res.status(response.status).json({
+          error: String(data?.error || data?.message || '获取微信二维码失败'),
+        });
+      }
+      res.json({
+        ...data,
+        agent_uid: status.currentAgent.uid,
+        agent: status.currentAgent,
+      });
     } catch (e: any) {
       res.status(500).json({ error: e.message });
     }
@@ -1929,10 +2013,48 @@ export function createApiRouter(serviceManager: ServiceManager, updateController
   router.get('/weixin/qrcode-status', async (req, res) => {
     try {
       const qrcode = req.query.qrcode as string;
+      const expectedAgentUid = String(req.query.agent_uid || '').trim();
       if (!qrcode) return res.status(400).json({ error: 'qrcode required' });
-      const response = await fetch(`https://ilinkai.weixin.qq.com/ilink/bot/get_qrcode_status?qrcode=${qrcode}`);
-      const data = await response.json();
-      res.json(data);
+      const status = getWeixinChannelStatus({
+        runtimeRoot: process.cwd(),
+        env: process.env,
+      });
+      if (!status.currentAgent) {
+        return res.status(409).json({
+          error: status.reason || '请先在 CatsCo Chat 中选择并绑定 agent，再绑定微信通道',
+          channelStatus: sanitizeWeixinChannelStatus(status),
+        });
+      }
+      if (expectedAgentUid && expectedAgentUid !== status.currentAgent.uid) {
+        return res.status(409).json({
+          error: `扫码开始时的 agent 是 ${expectedAgentUid}，当前 agent 是 ${status.currentAgent.uid}，请重新扫码`,
+          channelStatus: sanitizeWeixinChannelStatus(status),
+        });
+      }
+      const response = await fetch(`https://ilinkai.weixin.qq.com/ilink/bot/get_qrcode_status?qrcode=${encodeURIComponent(qrcode)}`);
+      const data = await response.json() as Record<string, any>;
+      if (!response.ok) {
+        return res.status(response.status).json({
+          error: String(data?.error || data?.message || '微信授权状态检查失败'),
+        });
+      }
+      const safeData = { ...data };
+      delete safeData.bot_token;
+      const botToken = String(data?.bot_token || '').trim();
+      if (data?.status === 'confirmed' && botToken) {
+        const result = bindWeixinChannelToCurrentAgent({
+          token: botToken,
+          runtimeRoot: process.cwd(),
+          env: process.env,
+          expectedAgentUid: expectedAgentUid || status.currentAgent.uid,
+        });
+        return res.json({
+          ...safeData,
+          token_saved: true,
+          ...sanitizeWeixinBindingResult(result),
+        });
+      }
+      res.json(safeData);
     } catch (e: any) {
       res.status(500).json({ error: e.message });
     }

--- a/src/dashboard/service-manager.ts
+++ b/src/dashboard/service-manager.ts
@@ -5,6 +5,7 @@ import * as dotenv from 'dotenv';
 import { EventEmitter } from 'events';
 import { resolveRuntimeEnvironment } from '../utils/runtime-environment';
 import { resolveCatsCoRuntimeConfig } from '../catscompany/runtime-config';
+import { weixinBindingEnvOverlay } from './weixin-channel-binding';
 
 const isWindows = process.platform === 'win32';
 
@@ -220,6 +221,19 @@ export class ServiceManager extends EventEmitter {
       envVars = {
         ...envVars,
         ...catsCoRuntime.envOverlay,
+      };
+    }
+
+    if (name === 'weixin') {
+      const catsCoRuntime = resolveCatsCoRuntimeConfig({
+        runtimeRoot: spawnCwd,
+        env: envVars,
+        migrateLegacyEnvBinding: true,
+      });
+      envVars = {
+        ...envVars,
+        ...catsCoRuntime.envOverlay,
+        ...weixinBindingEnvOverlay({ runtimeRoot: spawnCwd, env: envVars }),
       };
     }
 

--- a/src/dashboard/weixin-channel-binding.ts
+++ b/src/dashboard/weixin-channel-binding.ts
@@ -1,0 +1,269 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as dotenv from 'dotenv';
+import { CatsCoRuntimeConfigResolution, resolveCatsCoRuntimeConfig } from '../catscompany/runtime-config';
+import { writeDashboardEnvUpdates } from './settings';
+
+export interface WeixinAgentChannelBinding {
+  channel: 'weixin';
+  agentUid: string;
+  agentName?: string;
+  agentUsername?: string;
+  bodyId?: string;
+  boundByUserUid?: string;
+  boundByUsername?: string;
+  tokenHash: string;
+  tokenLast4?: string;
+  legacyEnvKey: 'WEIXIN_TOKEN';
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ChannelBindingsFile {
+  version: 1;
+  weixin?: WeixinAgentChannelBinding;
+  updatedAt?: string;
+}
+
+export interface WeixinChannelStatus {
+  configured: boolean;
+  currentAgent?: WeixinCurrentAgentSnapshot;
+  binding?: WeixinAgentChannelBinding;
+  mismatch?: boolean;
+  reason?: string;
+}
+
+export interface WeixinCurrentAgentSnapshot {
+  uid: string;
+  name?: string;
+  username?: string;
+  bodyId?: string;
+  ownerUid?: string;
+  ownerUsername?: string;
+}
+
+export interface BindWeixinChannelResult {
+  binding: WeixinAgentChannelBinding;
+  updatedEnv: string[];
+  bindingPath: string;
+}
+
+export function resolveChannelBindingsPath(runtimeRoot = process.cwd()): string {
+  return path.join(runtimeRoot, '.xiaoba', 'channel-bindings.json');
+}
+
+export function loadChannelBindings(runtimeRoot = process.cwd()): ChannelBindingsFile {
+  const bindingPath = resolveChannelBindingsPath(runtimeRoot);
+  if (!fs.existsSync(bindingPath)) return { version: 1 };
+  try {
+    const parsed = JSON.parse(fs.readFileSync(bindingPath, 'utf-8'));
+    if (parsed && parsed.version === 1) return parsed as ChannelBindingsFile;
+  } catch {
+    // Fall through to an empty file; callers can bind again.
+  }
+  return { version: 1 };
+}
+
+export function saveChannelBindings(runtimeRoot: string, data: ChannelBindingsFile): void {
+  const bindingPath = resolveChannelBindingsPath(runtimeRoot);
+  const dir = path.dirname(bindingPath);
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  chmodPrivateDirectory(dir);
+  const next: ChannelBindingsFile = {
+    ...data,
+    version: 1,
+    updatedAt: new Date().toISOString(),
+  };
+  const tempPath = `${bindingPath}.tmp`;
+  fs.writeFileSync(tempPath, JSON.stringify(next, null, 2), { encoding: 'utf-8', mode: 0o600 });
+  chmodOwnerOnly(tempPath);
+  fs.renameSync(tempPath, bindingPath);
+  chmodOwnerOnly(bindingPath);
+}
+
+export function currentWeixinAgent(runtime: CatsCoRuntimeConfigResolution): WeixinCurrentAgentSnapshot | undefined {
+  const bot = runtime.localConfig.currentBot;
+  if (!runtime.bodyConfigured || !bot?.uid) return undefined;
+  return {
+    uid: bot.uid,
+    name: bot.name,
+    username: bot.username,
+    bodyId: runtime.localConfig.device?.bodyId,
+    ownerUid: runtime.localConfig.account?.uid,
+    ownerUsername: runtime.localConfig.account?.username,
+  };
+}
+
+export function getWeixinChannelStatus(options: {
+  runtimeRoot?: string;
+  env?: NodeJS.ProcessEnv;
+} = {}): WeixinChannelStatus {
+  const runtimeRoot = options.runtimeRoot || process.cwd();
+  const fileEnv = readEnvFile(runtimeRoot);
+  const effectiveEnv = {
+    ...fileEnv,
+    ...(options.env || process.env),
+  };
+  const runtime = resolveCatsCoRuntimeConfig({ runtimeRoot, env: effectiveEnv });
+  const currentAgent = currentWeixinAgent(runtime);
+  const binding = loadChannelBindings(runtimeRoot).weixin;
+  if (!currentAgent) {
+    return {
+      configured: false,
+      binding,
+      reason: '请先登录 CatsCo，并选择/绑定当前 agent body。',
+    };
+  }
+  if (!binding) {
+    return {
+      configured: false,
+      currentAgent,
+      reason: '当前 agent 尚未绑定微信通道。',
+    };
+  }
+  const mismatch = binding.agentUid !== currentAgent.uid;
+  const tokenConfigured = Boolean(firstNonEmpty(effectiveEnv.WEIXIN_TOKEN));
+  const reason = mismatch
+    ? `微信通道绑定在 agent ${binding.agentUid}，当前 agent 是 ${currentAgent.uid}。`
+    : tokenConfigured
+      ? undefined
+      : '微信通道绑定元数据存在，但 WEIXIN_TOKEN 缺失，请重新扫码。';
+  return {
+    configured: !mismatch && tokenConfigured,
+    currentAgent,
+    binding,
+    mismatch,
+    reason,
+  };
+}
+
+export function bindWeixinChannelToCurrentAgent(options: {
+  token: string;
+  runtimeRoot?: string;
+  env?: NodeJS.ProcessEnv;
+  expectedAgentUid?: string;
+}): BindWeixinChannelResult {
+  const runtimeRoot = options.runtimeRoot || process.cwd();
+  const env = options.env || process.env;
+  const token = String(options.token || '').trim();
+  if (!token) throw new Error('微信授权未返回 token');
+
+  const runtime = resolveCatsCoRuntimeConfig({ runtimeRoot, env });
+  const agent = currentWeixinAgent(runtime);
+  if (!agent) {
+    throw new Error('请先在 CatsCo Chat 里选择并绑定当前 agent，再绑定微信通道');
+  }
+  if (options.expectedAgentUid && options.expectedAgentUid !== agent.uid) {
+    throw new Error(`扫码开始时的 agent 是 ${options.expectedAgentUid}，当前 agent 是 ${agent.uid}，请重新扫码`);
+  }
+
+  const existing = loadChannelBindings(runtimeRoot);
+  const previous = existing.weixin;
+  const now = new Date().toISOString();
+  const binding: WeixinAgentChannelBinding = {
+    channel: 'weixin',
+    agentUid: agent.uid,
+    agentName: agent.name,
+    agentUsername: agent.username,
+    bodyId: agent.bodyId,
+    boundByUserUid: agent.ownerUid,
+    boundByUsername: agent.ownerUsername,
+    tokenHash: hashToken(token),
+    tokenLast4: last4(token),
+    legacyEnvKey: 'WEIXIN_TOKEN',
+    createdAt: previous?.agentUid === agent.uid ? previous.createdAt : now,
+    updatedAt: now,
+  };
+
+  saveChannelBindings(runtimeRoot, {
+    ...existing,
+    weixin: binding,
+  });
+
+  const envResult = writeDashboardEnvUpdates(runtimeRoot, {
+    WEIXIN_TOKEN: token,
+    WEIXIN_BOUND_AGENT_UID: agent.uid,
+    WEIXIN_BOUND_AGENT_NAME: agent.name || agent.username || '',
+    WEIXIN_BOUND_BODY_ID: agent.bodyId || '',
+    WEIXIN_BOUND_BY_USER_UID: agent.ownerUid || '',
+  });
+
+  env.WEIXIN_TOKEN = token;
+  env.WEIXIN_BOUND_AGENT_UID = agent.uid;
+  env.WEIXIN_BOUND_AGENT_NAME = agent.name || agent.username || '';
+  process.env.WEIXIN_TOKEN = token;
+  process.env.WEIXIN_BOUND_AGENT_UID = agent.uid;
+  process.env.WEIXIN_BOUND_AGENT_NAME = agent.name || agent.username || '';
+  if (agent.bodyId) {
+    env.WEIXIN_BOUND_BODY_ID = agent.bodyId;
+    process.env.WEIXIN_BOUND_BODY_ID = agent.bodyId;
+  }
+  if (agent.ownerUid) {
+    env.WEIXIN_BOUND_BY_USER_UID = agent.ownerUid;
+    process.env.WEIXIN_BOUND_BY_USER_UID = agent.ownerUid;
+  }
+
+  return {
+    binding,
+    updatedEnv: envResult.updated,
+    bindingPath: resolveChannelBindingsPath(runtimeRoot),
+  };
+}
+
+export function weixinBindingEnvOverlay(options: {
+  runtimeRoot?: string;
+  env?: NodeJS.ProcessEnv;
+} = {}): Record<string, string> {
+  const status = getWeixinChannelStatus(options);
+  if (!status.configured || !status.binding) return {};
+  const agentName = status.binding.agentName || status.binding.agentUsername || '';
+  const overlay: Record<string, string> = {
+    WEIXIN_BOUND_AGENT_UID: status.binding.agentUid,
+    WEIXIN_BOUND_AGENT_NAME: agentName,
+  };
+  if (status.binding.bodyId) overlay.WEIXIN_BOUND_BODY_ID = status.binding.bodyId;
+  if (status.binding.boundByUserUid) overlay.WEIXIN_BOUND_BY_USER_UID = status.binding.boundByUserUid;
+  if (agentName) overlay.CURRENT_AGENT_DISPLAY_NAME = agentName;
+  return overlay;
+}
+
+function readEnvFile(runtimeRoot: string): Record<string, string> {
+  const envPath = path.join(runtimeRoot, '.env');
+  if (!fs.existsSync(envPath)) return {};
+  return dotenv.parse(fs.readFileSync(envPath, 'utf-8'));
+}
+
+function firstNonEmpty(...values: Array<string | undefined>): string | undefined {
+  for (const value of values) {
+    const text = String(value || '').trim();
+    if (text) return text;
+  }
+  return undefined;
+}
+
+function hashToken(token: string): string {
+  return crypto.createHash('sha256').update(token).digest('hex');
+}
+
+function last4(token: string): string | undefined {
+  return token.length >= 4 ? token.slice(-4) : undefined;
+}
+
+function chmodOwnerOnly(filePath: string, mode = 0o600): void {
+  if (process.platform === 'win32') return;
+  try {
+    fs.chmodSync(filePath, mode);
+  } catch {
+    // Best-effort permission hardening.
+  }
+}
+
+function chmodPrivateDirectory(dirPath: string): void {
+  if (process.platform === 'win32') return;
+  try {
+    fs.chmodSync(dirPath, 0o700);
+  } catch {
+    // Best-effort permission hardening.
+  }
+}

--- a/tests/dashboard-weixin-channel-binding.test.ts
+++ b/tests/dashboard-weixin-channel-binding.test.ts
@@ -1,0 +1,210 @@
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as dotenv from 'dotenv';
+import express from 'express';
+import type { Server } from 'node:http';
+import { createApiRouter } from '../src/dashboard/routes/api';
+
+describe('dashboard weixin agent channel binding', () => {
+  let testRoot: string;
+  let originalCwd: string;
+  let server: Server | undefined;
+  let baseUrl: string;
+  let envKeys: string[];
+  const originalFetch = globalThis.fetch;
+  const originalEnv: Record<string, string | undefined> = {};
+
+  beforeEach(async () => {
+    originalCwd = process.cwd();
+    testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-weixin-binding-'));
+    process.chdir(testRoot);
+    envKeys = isolatedEnvKeys();
+    for (const key of envKeys) {
+      originalEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+
+    globalThis.fetch = async (input: any, init?: any) => {
+      const url = String(input);
+      if (url.includes('/ilink/bot/get_bot_qrcode')) {
+        return jsonResponse({ qrcode: 'qr-1', qrcode_img_content: 'https://qr.example/1' });
+      }
+      if (url.includes('/ilink/bot/get_qrcode_status')) {
+        return jsonResponse({ status: 'confirmed', bot_token: 'wx-secret-token-1234' });
+      }
+      return originalFetch(input, init);
+    };
+
+    const app = express();
+    app.use(express.json());
+    app.use('/api', createApiRouter({
+      getAll: () => [],
+      getService: () => undefined,
+      getLogs: () => [],
+    } as any));
+    server = await listen(app);
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('server did not bind to a TCP port');
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>(resolve => server!.close(() => resolve()));
+      server = undefined;
+    }
+    globalThis.fetch = originalFetch;
+    process.chdir(originalCwd);
+    for (const key of envKeys) {
+      const value = originalEnv[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+      delete originalEnv[key];
+    }
+    if (testRoot && fs.existsSync(testRoot)) {
+      fs.rmSync(testRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('qrcode requires a selected CatsCo agent body', async () => {
+    const response = await fetch(`${baseUrl}/api/weixin/qrcode`);
+    const data = await response.json() as any;
+
+    assert.equal(response.status, 409);
+    assert.match(data.error, /agent/);
+    assert.equal(data.channelStatus.configured, false);
+  });
+
+  test('confirmed qrcode binds Weixin channel to the current agent without returning token', async () => {
+    writeCatsCoConfig({
+      botUid: '42',
+      botName: 'Dev Agent',
+      bodyId: 'body-dev',
+      userUid: '7',
+      username: 'alice',
+    });
+
+    const qrResponse = await fetch(`${baseUrl}/api/weixin/qrcode`);
+    const qr = await qrResponse.json() as any;
+    assert.equal(qrResponse.status, 200);
+    assert.equal(qr.agent_uid, '42');
+
+    const statusResponse = await fetch(`${baseUrl}/api/weixin/qrcode-status?qrcode=${encodeURIComponent(qr.qrcode)}&agent_uid=${qr.agent_uid}`);
+    const text = await statusResponse.text();
+    const data = JSON.parse(text) as any;
+
+    assert.equal(statusResponse.status, 200);
+    assert.equal(data.status, 'confirmed');
+    assert.equal(data.token_saved, true);
+    assert.equal(data.bot_token, undefined);
+    assert.equal(text.includes('wx-secret-token-1234'), false);
+    assert.equal(data.binding.agentUid, '42');
+    assert.equal(data.binding.agentName, 'Dev Agent');
+    assert.equal(data.binding.bodyId, 'body-dev');
+    assert.equal(data.binding.tokenLast4, '1234');
+    assert.equal(data.binding.tokenHash, undefined);
+
+    const env = dotenv.parse(fs.readFileSync(path.join(testRoot, '.env'), 'utf-8'));
+    assert.equal(env.WEIXIN_TOKEN, 'wx-secret-token-1234');
+    assert.equal(env.WEIXIN_BOUND_AGENT_UID, '42');
+    assert.equal(env.WEIXIN_BOUND_AGENT_NAME, 'Dev Agent');
+    assert.equal(env.WEIXIN_BOUND_BODY_ID, 'body-dev');
+
+    const file = JSON.parse(fs.readFileSync(path.join(testRoot, '.xiaoba', 'channel-bindings.json'), 'utf-8'));
+    assert.equal(file.weixin.agentUid, '42');
+    assert.equal(file.weixin.tokenLast4, '1234');
+    assert.equal(typeof file.weixin.tokenHash, 'string');
+
+    delete process.env.WEIXIN_TOKEN;
+    const bindingResponse = await fetch(`${baseUrl}/api/weixin/channel-binding`);
+    const bindingText = await bindingResponse.text();
+    const binding = JSON.parse(bindingText) as any;
+    assert.equal(binding.configured, true);
+    assert.equal(binding.binding.agentUid, '42');
+    assert.equal(binding.binding.tokenHash, undefined);
+    assert.equal(bindingText.includes('wx-secret-token-1234'), false);
+  });
+
+  test('qrcode confirmation rejects when the selected agent changed', async () => {
+    writeCatsCoConfig({
+      botUid: '42',
+      botName: 'Dev Agent',
+      bodyId: 'body-dev',
+      userUid: '7',
+      username: 'alice',
+    });
+
+    const response = await fetch(`${baseUrl}/api/weixin/qrcode-status?qrcode=qr-1&agent_uid=99`);
+    const data = await response.json() as any;
+
+    assert.equal(response.status, 409);
+    assert.match(data.error, /扫码开始时的 agent/);
+    assert.equal(fs.existsSync(path.join(testRoot, '.env')), false);
+  });
+
+  function writeCatsCoConfig(input: {
+    botUid: string;
+    botName: string;
+    bodyId: string;
+    userUid: string;
+    username: string;
+  }): void {
+    fs.mkdirSync(path.join(testRoot, '.xiaoba'), { recursive: true });
+    fs.writeFileSync(path.join(testRoot, '.xiaoba', 'catsco.json'), JSON.stringify({
+      version: 1,
+      account: {
+        token: 'user-token',
+        uid: input.userUid,
+        username: input.username,
+      },
+      currentBot: {
+        uid: input.botUid,
+        name: input.botName,
+        username: 'dev-agent',
+        apiKey: 'bot-api-key',
+        boundByUserUid: input.userUid,
+        bindingSource: 'test',
+      },
+      device: {
+        deviceId: 'device-dev',
+        bodyId: input.bodyId,
+        installationId: 'install-dev',
+      },
+      endpoints: {
+        httpBaseUrl: 'https://app.catsco.cc',
+        serverUrl: 'wss://app.catsco.cc/v0/channels',
+      },
+    }), 'utf-8');
+  }
+});
+
+function isolatedEnvKeys(): string[] {
+  const prefixes = ['CATSCO_', 'CATSCOMPANY_', 'WEIXIN_'];
+  const explicit = [
+    'CATSCO_LOCAL_CONFIG_PATH',
+    'CATSCO_CONFIG_PATH',
+  ];
+  return Array.from(new Set([
+    ...explicit,
+    ...Object.keys(process.env).filter(key => prefixes.some(prefix => key.startsWith(prefix))),
+  ]));
+}
+
+function jsonResponse(data: unknown): Response {
+  return new Response(JSON.stringify(data), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function listen(app: express.Express): Promise<Server> {
+  return new Promise(resolve => {
+    const server = app.listen(0, '127.0.0.1', () => resolve(server));
+  });
+}


### PR DESCRIPTION
## 背景

Dashboard 获取微信二维码后，微信授权成功返回的 bot_token 只会填入前端输入框，仍需要用户手动保存。

这会导致用户扫码后以为已经完成授权，但启动微信机器人时仍然可能提示缺少 WEIXIN_TOKEN，或者 token 没有和当前 CatsCo agent 建立明确绑定关系。

## 修改

- 新增 Weixin channel binding 模块，用于把微信 token 绑定到当前 CatsCo agent。
- 微信二维码确认成功后，由后端保存 WEIXIN_TOKEN 到本地 .env。
- 新增本地 `.xiaoba/channel-bindings.json`，只记录绑定元数据和 token hash/last4，不泄露完整 token。
- `/api/weixin/qrcode-status` 不再把 bot_token 返回给前端。
- 新增 `/api/weixin/channel-binding` 返回当前微信绑定状态，用于 Dashboard 检查。
- 微信启动前检查同时确认当前 agent、微信通道绑定和 token。
- 启动微信服务时注入当前 CatsCo agent 与微信绑定环境变量。
- 修复空 WEIXIN_TOKEN 在 `/api/config` 中被显示成 `****` 的误导问题。
- 前端扫码成功后自动刷新 config/status/readiness，不再提示用户手动保存。

## 不做什么

- 不修改微信运行中 session 过期逻辑，那个是 #105 的范围。
- 不改微信消息收发主流程。
- 不改 CatsCo agent 主绑定流程。
- 不在前端存储或展示完整微信 token。

## 验证

- `./node_modules/.bin/tsx.cmd --test tests/dashboard-weixin-channel-binding.test.ts`
- `./node_modules/.bin/tsx.cmd --test tests/dashboard-readiness.test.ts tests/dashboard-settings-api.test.ts tests/dashboard-productization-html.test.ts tests/dashboard-service-manager.test.ts tests/dashboard-weixin-channel-binding.test.ts`
- `npm run build`