### PR TITLE
接入虚拟员工入口码绑定路由

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,126 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  runtime:
+    name: Build and runtime tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout XiaoBa-CLI
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --prefer-offline --no-audit --fund=false
+
+      - name: Release branding check
+        run: npm run release:check
+
+      - name: Build
+        run: npm run build
+
+      - name: Runtime tests
+        run: npm test
+
+  cross-repo-catsco:
+    name: CatsCo cross-repo smoke and e2e
+    runs-on: ubuntu-latest
+    needs: runtime
+    services:
+      postgres:
+        image: postgres:18-alpine
+        env:
+          POSTGRES_DB: cats_xiaoba_e2e
+          POSTGRES_USER: catsco
+          POSTGRES_PASSWORD: catsco_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U catsco -d cats_xiaoba_e2e"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+
+    steps:
+      - name: Checkout XiaoBa-CLI
+        uses: actions/checkout@v4
+        with:
+          path: XiaoBa-CLI
+
+      - name: Detect cross-repo scripts
+        id: scripts
+        working-directory: XiaoBa-CLI
+        run: |
+          if [ -f scripts/cross-repo-catsco-smoke.mjs ]; then
+            echo "smoke=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "smoke=false" >> "$GITHUB_OUTPUT"
+          fi
+          if [ -f scripts/cross-repo-catsco-e2e.ts ]; then
+            echo "e2e=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "e2e=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout cats-company
+        if: steps.scripts.outputs.smoke == 'true' || steps.scripts.outputs.e2e == 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: buildsense-ai/cats-company
+          ref: ${{ vars.CATSCOMPANY_SMOKE_REF || 'codex/feishu-cloud-oauth-events' }}
+          path: cats-company
+
+      - name: Set up Node.js
+        if: steps.scripts.outputs.smoke == 'true' || steps.scripts.outputs.e2e == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: XiaoBa-CLI/package-lock.json
+
+      - name: Set up Go
+        if: steps.scripts.outputs.smoke == 'true' || steps.scripts.outputs.e2e == 'true'
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: cats-company/go.mod
+          cache-dependency-path: cats-company/go.sum
+
+      - name: Install XiaoBa dependencies
+        if: steps.scripts.outputs.smoke == 'true' || steps.scripts.outputs.e2e == 'true'
+        working-directory: XiaoBa-CLI
+        run: npm ci --prefer-offline --no-audit --fund=false
+
+      - name: Cross-repo CatsCo smoke
+        if: steps.scripts.outputs.smoke == 'true'
+        working-directory: XiaoBa-CLI
+        env:
+          CATSCOMPANY_REPO: ../cats-company
+        run: npm run test:cross-repo:catsco
+
+      - name: Cross-repo CatsCo e2e
+        if: steps.scripts.outputs.e2e == 'true'
+        working-directory: XiaoBa-CLI
+        env:
+          CATSCOMPANY_REPO: ../cats-company
+          CATSCOMPANY_E2E_DB_DSN: postgres://catsco:catsco_test@127.0.0.1:5432/cats_xiaoba_e2e?sslmode=disable
+        run: npm run test:e2e:catsco-cross-repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,10 +42,75 @@ jobs:
       - name: Runtime tests
         run: npm test
 
+  detect-cross-repo:
+    name: Detect CatsCo cross-repo impact
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.detect.outputs.run }}
+      smoke: ${{ steps.detect.outputs.smoke }}
+      e2e: ${{ steps.detect.outputs.e2e }}
+
+    steps:
+      - name: Checkout XiaoBa-CLI
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect impacted files
+        id: detect
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+
+          smoke=false
+          e2e=false
+          if [ -f scripts/cross-repo-catsco-smoke.mjs ]; then
+            smoke=true
+          fi
+          if [ -f scripts/cross-repo-catsco-e2e.ts ]; then
+            e2e=true
+          fi
+
+          if [ "$smoke" != "true" ] && [ "$e2e" != "true" ]; then
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "smoke=$smoke" >> "$GITHUB_OUTPUT"
+            echo "e2e=$e2e" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            run=true
+          else
+            if [ "$EVENT_NAME" = "pull_request" ] && [ -n "$BASE_SHA" ]; then
+              git diff --name-only "$BASE_SHA"...HEAD > changed-files.txt
+            elif [ -n "$BEFORE_SHA" ] && ! echo "$BEFORE_SHA" | grep -Eq '^0+$'; then
+              git diff --name-only "$BEFORE_SHA"...HEAD > changed-files.txt
+            else
+              git diff --name-only HEAD~1...HEAD > changed-files.txt || git ls-files > changed-files.txt
+            fi
+
+            if grep -Eq '^(\.github/workflows/ci\.yml|package(-lock)?\.json|scripts/cross-repo-catsco-|src/(catscompany|commands/device-connector|tools/(device-rpc-tool|read-tool|glob-tool|grep-tool|write-tool|bash-tool)|types/session-identity)|tests/(catscompany|catsco-command-config|tool-gateway-catsco))' changed-files.txt; then
+              run=true
+            else
+              run=false
+            fi
+          fi
+
+          echo "run=$run" >> "$GITHUB_OUTPUT"
+          echo "smoke=$smoke" >> "$GITHUB_OUTPUT"
+          echo "e2e=$e2e" >> "$GITHUB_OUTPUT"
+
   cross-repo-catsco:
     name: CatsCo cross-repo smoke and e2e
     runs-on: ubuntu-latest
-    needs: runtime
+    needs:
+      - runtime
+      - detect-cross-repo
+    if: needs.detect-cross-repo.outputs.run == 'true'
+    timeout-minutes: 20
     services:
       postgres:
         image: postgres:18-alpine
@@ -67,23 +132,7 @@ jobs:
         with:
           path: XiaoBa-CLI
 
-      - name: Detect cross-repo scripts
-        id: scripts
-        working-directory: XiaoBa-CLI
-        run: |
-          if [ -f scripts/cross-repo-catsco-smoke.mjs ]; then
-            echo "smoke=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "smoke=false" >> "$GITHUB_OUTPUT"
-          fi
-          if [ -f scripts/cross-repo-catsco-e2e.ts ]; then
-            echo "e2e=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "e2e=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Checkout cats-company
-        if: steps.scripts.outputs.smoke == 'true' || steps.scripts.outputs.e2e == 'true'
         uses: actions/checkout@v4
         with:
           repository: buildsense-ai/cats-company
@@ -91,7 +140,6 @@ jobs:
           path: cats-company
 
       - name: Set up Node.js
-        if: steps.scripts.outputs.smoke == 'true' || steps.scripts.outputs.e2e == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -99,28 +147,28 @@ jobs:
           cache-dependency-path: XiaoBa-CLI/package-lock.json
 
       - name: Set up Go
-        if: steps.scripts.outputs.smoke == 'true' || steps.scripts.outputs.e2e == 'true'
         uses: actions/setup-go@v5
         with:
           go-version-file: cats-company/go.mod
           cache-dependency-path: cats-company/go.sum
 
       - name: Install XiaoBa dependencies
-        if: steps.scripts.outputs.smoke == 'true' || steps.scripts.outputs.e2e == 'true'
         working-directory: XiaoBa-CLI
         run: npm ci --prefer-offline --no-audit --fund=false
 
       - name: Cross-repo CatsCo smoke
-        if: steps.scripts.outputs.smoke == 'true'
+        if: needs.detect-cross-repo.outputs.smoke == 'true'
         working-directory: XiaoBa-CLI
         env:
           CATSCOMPANY_REPO: ../cats-company
         run: npm run test:cross-repo:catsco
 
       - name: Cross-repo CatsCo e2e
-        if: steps.scripts.outputs.e2e == 'true'
+        if: needs.detect-cross-repo.outputs.e2e == 'true'
+        timeout-minutes: 10
         working-directory: XiaoBa-CLI
         env:
           CATSCOMPANY_REPO: ../cats-company
           CATSCOMPANY_E2E_DB_DSN: postgres://catsco:catsco_test@127.0.0.1:5432/cats_xiaoba_e2e?sslmode=disable
+          CATSCOMPANY_E2E_TIMEOUT_MS: 180000
         run: npm run test:e2e:catsco-cross-repo

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,17 +1,36 @@
 const { app, BrowserWindow, Tray, Menu, nativeImage, ipcMain, dialog, shell } = require('electron');
 const path = require('path');
 const fs = require('fs');
+const http = require('http');
 
 const DASHBOARD_PORT = resolveDashboardPort(process.env.XIAOBA_DASHBOARD_PORT);
+const DEEP_LINK_PROTOCOL = 'catsco';
 let mainWindow = null;
 let tray = null;
 let autoUpdater = null;
 let hideNoticeShown = false;
+let dashboardReady = false;
+const pendingDeepLinks = [];
 const REFRESHABLE_BUNDLED_SKILLS = new Set([]);
 const RETIRED_BUNDLED_SKILLS = new Set(['advanced-reader', 'vision-analysis']);
 const SKILL_SYNC_MARKER = '.xiaoba-bundled-skill.json';
 
 applyConfiguredUserDataPath();
+
+const gotSingleInstanceLock = app.requestSingleInstanceLock();
+if (!gotSingleInstanceLock) {
+  app.quit();
+} else {
+  app.on('second-instance', (_event, argv) => {
+    showMainWindow();
+    queueCatsCoDeepLink(extractCatsCoDeepLink(argv));
+  });
+}
+
+app.on('open-url', (event, url) => {
+  event.preventDefault();
+  queueCatsCoDeepLink(url);
+});
 
 function resolveDashboardPort(value) {
   const text = String(value || '').trim();
@@ -108,6 +127,146 @@ function notifyWindowHidden() {
     content: '点击右下角 CatsCo 图标可恢复窗口。',
     icon: createTrayIcon(),
   });
+}
+
+function registerDeepLinkProtocol() {
+  try {
+    if (process.defaultApp && process.argv.length >= 2) {
+      app.setAsDefaultProtocolClient(DEEP_LINK_PROTOCOL, process.execPath, [path.resolve(process.argv[1])]);
+    } else {
+      app.setAsDefaultProtocolClient(DEEP_LINK_PROTOCOL);
+    }
+  } catch (error) {
+    console.log('CatsCo deep link registration skipped:', error?.message || error);
+  }
+}
+
+function extractCatsCoDeepLink(argv) {
+  if (!Array.isArray(argv)) return null;
+  return argv.find((arg) => /^catsco:\/\//i.test(String(arg || '').trim())) || null;
+}
+
+function queueCatsCoDeepLink(rawUrl) {
+  if (!rawUrl) return;
+  if (!dashboardReady) {
+    pendingDeepLinks.push(String(rawUrl));
+    return;
+  }
+  handleCatsCoDeepLink(String(rawUrl)).catch((error) => {
+    showDeviceConnectorError(error);
+  });
+}
+
+async function drainPendingDeepLinks() {
+  const links = pendingDeepLinks.splice(0, pendingDeepLinks.length);
+  for (const link of links) {
+    await handleCatsCoDeepLink(link);
+  }
+}
+
+async function handleCatsCoDeepLink(rawUrl) {
+  let url;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    throw new Error('无法识别 CatsCo 连接。');
+  }
+
+  if (url.protocol !== `${DEEP_LINK_PROTOCOL}:`) return;
+  if (url.hostname !== 'device-connector' || url.pathname !== '/pair') {
+    throw new Error('这个 CatsCo 连接类型暂不支持。');
+  }
+
+  const code = url.searchParams.get('code') || url.searchParams.get('pairing_code') || url.searchParams.get('pair');
+  if (!code) {
+    throw new Error('设备配对链接缺少配对码。');
+  }
+
+  const result = await postLocalDashboardJson('/api/cats/device-connector/pair', {
+    code,
+    http_base_url: url.searchParams.get('http_base_url') || url.searchParams.get('httpBaseUrl') || undefined,
+    server_url: url.searchParams.get('server_url') || url.searchParams.get('serverUrl') || undefined,
+    device_name: url.searchParams.get('device_name') || url.searchParams.get('deviceName') || undefined,
+  });
+
+  enableOpenAtLogin();
+  showMainWindow();
+  notifyDeviceConnectorStatus('CatsCo 本机设备已连接', result?.message || 'Device Connector 已在后台运行。');
+}
+
+function postLocalDashboardJson(apiPath, body) {
+  return new Promise((resolve, reject) => {
+    const payload = JSON.stringify(body || {});
+    const request = http.request({
+      hostname: '127.0.0.1',
+      port: DASHBOARD_PORT,
+      path: apiPath,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(payload),
+      },
+    }, (response) => {
+      const chunks = [];
+      response.on('data', (chunk) => chunks.push(chunk));
+      response.on('end', () => {
+        const text = Buffer.concat(chunks).toString('utf8');
+        let data = {};
+        if (text) {
+          try {
+            data = JSON.parse(text);
+          } catch {
+            data = { raw: text };
+          }
+        }
+        if (response.statusCode && response.statusCode >= 200 && response.statusCode < 300) {
+          resolve(data);
+          return;
+        }
+        reject(new Error(data?.error || `CatsCo local request failed: ${response.statusCode}`));
+      });
+    });
+    request.on('error', reject);
+    request.write(payload);
+    request.end();
+  });
+}
+
+function enableOpenAtLogin() {
+  if (!app.isPackaged || typeof app.setLoginItemSettings !== 'function') return;
+  try {
+    app.setLoginItemSettings({ openAtLogin: true, openAsHidden: true });
+  } catch (error) {
+    console.log('CatsCo login item registration skipped:', error?.message || error);
+  }
+}
+
+function notifyDeviceConnectorStatus(title, content) {
+  if (tray && process.platform === 'win32' && typeof tray.displayBalloon === 'function') {
+    tray.displayBalloon({ title, content, icon: createTrayIcon() });
+  }
+}
+
+function showDeviceConnectorError(error) {
+  const message = error?.message || '本机设备连接失败，请重新生成配对码后再试。';
+  showMainWindow();
+  dialog.showMessageBox({
+    type: 'warning',
+    title: '本机设备连接失败',
+    message,
+    buttons: ['知道了'],
+  }).catch(() => {});
+}
+
+async function startSavedDeviceConnector() {
+  try {
+    await postLocalDashboardJson('/api/cats/device-connector/ensure-running', {});
+  } catch (error) {
+    const message = String(error?.message || error || '');
+    if (!/not paired|auto-connect|already running|preflight/i.test(message)) {
+      console.log('CatsCo Device Connector auto-start skipped:', message);
+    }
+  }
 }
 
 // 闂佽绻愮换鎴犳崲閸℃稒鍎婃い鏍仜缁€澶愭煟濡厧鍔嬬紒?electron-updater闂備焦瀵х粙鎴︽偋閸℃哎浜归柡灞诲劜閻掕顭块懜鐢点€掔紒鈧?
@@ -769,12 +928,19 @@ if (autoUpdater) {
   });
 }
 
+if (gotSingleInstanceLock) {
 app.whenReady().then(async () => {
   try {
+    registerDeepLinkProtocol();
     await startServer();
+    dashboardReady = true;
     createApplicationMenu();
     createWindow();
     createTray();
+    const startupDeepLink = extractCatsCoDeepLink(process.argv);
+    if (startupDeepLink) pendingDeepLinks.push(startupDeepLink);
+    await drainPendingDeepLinks().catch(showDeviceConnectorError);
+    startSavedDeviceConnector().catch(() => {});
     
     // 闂備礁鎲￠崙褰掑垂閻楀牊鍙忛柍鍝勬噹鐟欙箓骞栧ǎ顒€鐒烘慨濠囩畺閺岋紕浠︾拠鎻掑濠电偞褰冨鈥愁嚕?
     if (app.isPackaged && autoUpdater) {
@@ -800,3 +966,4 @@ app.on('window-all-closed', () => {
 app.on('before-quit', () => {
   app.isQuitting = true;
 });
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "watch": "tsc --watch",
     "test": "node scripts/run-tests.mjs runtime",
     "test:runtime": "node scripts/run-tests.mjs runtime",
+    "test:cross-repo:catsco": "node scripts/cross-repo-catsco-smoke.mjs",
+    "test:e2e:catsco-cross-repo": "tsx scripts/cross-repo-catsco-e2e.ts",
     "test:legacy": "node scripts/run-tests.mjs legacy",
     "test:all": "node scripts/run-tests.mjs all",
     "test:list": "node scripts/run-tests.mjs runtime --list",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,14 @@
       "output": "release"
     },
     "asar": false,
+    "protocols": [
+      {
+        "name": "CatsCo Link",
+        "schemes": [
+          "catsco"
+        ]
+      }
+    ],
     "publish": {
       "provider": "github",
       "owner": "buildsense-ai",

--- a/scripts/cross-repo-catsco-e2e.ts
+++ b/scripts/cross-repo-catsco-e2e.ts
@@ -1,0 +1,394 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { fileURLToPath } from 'node:url';
+import { CatsClient, type MessageContext } from '../src/catscompany/client';
+import { CatsCoDeviceConnector } from '../src/catscompany/device-connector';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(__dirname, '..');
+const catsRepo = path.resolve(process.env.CATSCOMPANY_REPO || path.join(rootDir, '..', 'cats-company'));
+const dbDsn = String(process.env.CATSCOMPANY_E2E_DB_DSN || '').trim();
+
+if (!dbDsn) {
+  console.log('[cross-repo:e2e] skipped: CATSCOMPANY_E2E_DB_DSN is not set');
+  process.exit(0);
+}
+
+if (!fs.existsSync(path.join(catsRepo, 'go.mod'))) {
+  throw new Error(`cats-company repo not found at ${catsRepo}`);
+}
+
+const runId = `${Date.now()}_${Math.random().toString(16).slice(2)}`;
+const tmpRoot = path.join(rootDir, 'tmp', `catsco-cross-repo-e2e-${runId}`);
+const deviceRoot = path.join(tmpRoot, 'device');
+fs.mkdirSync(deviceRoot, { recursive: true });
+
+const sentinel = `catsco-cross-repo-e2e-${runId}`;
+const sentinelFile = path.join(deviceRoot, 'sentinel.txt');
+fs.writeFileSync(sentinelFile, `${sentinel}\n`, 'utf8');
+
+let httpBaseUrl = '';
+let serverProcess: ChildProcessWithoutNullStreams | undefined;
+let connector: CatsCoDeviceConnector | undefined;
+let botClient: CatsClient | undefined;
+
+main().catch(error => {
+  console.error(`[cross-repo:e2e] failed: ${error?.message || error}`);
+  process.exit(1);
+});
+
+async function main(): Promise<void> {
+  const httpPort = await findFreePort();
+  const grpcPort = await findFreePort();
+  httpBaseUrl = `http://127.0.0.1:${httpPort}`;
+  const wsUrl = `ws://127.0.0.1:${httpPort}/v0/channels`;
+  const configPath = path.join(tmpRoot, 'cats-company-e2e.conf');
+  fs.writeFileSync(configPath, JSON.stringify({
+    listen: `127.0.0.1:${httpPort}`,
+    grpc_port: `127.0.0.1:${grpcPort}`,
+    database: {
+      driver: 'postgres',
+      dsn: dbDsn,
+      max_open_conns: 4,
+      max_idle_conns: 2,
+    },
+    websocket: { path: '/v0/channels' },
+    static: { dir: '' },
+  }, null, 2), 'utf8');
+
+  try {
+    serverProcess = startCatsCompanyServer(configPath);
+    await waitForReady(`${httpBaseUrl}/ready`, 45_000);
+
+  const user = await api('POST', '/api/auth/register', {
+    username: `e2e_user_${runId.slice(-10)}`,
+    password: 'password123',
+    display_name: 'E2E User',
+  }, undefined, 201);
+
+  const token = stringField(user, 'token');
+  const userId = numberField(user, 'uid');
+  assert(token, 'register response missing token');
+  assert(userId > 0, 'register response missing uid');
+
+  const bot = await api('POST', '/api/bots', {
+    username: `e2e_agent_${runId.slice(-10)}`,
+    password: 'password123',
+    display_name: 'E2E Agent',
+    model: 'e2e',
+  }, token, 201);
+
+  const botUid = numberField(bot, 'uid');
+  const botApiKey = stringField(bot, 'api_key');
+  assert(botUid > 0, 'create bot response missing uid');
+  assert(botApiKey, 'create bot response missing api_key');
+
+  const pairing = await api('POST', '/api/device-connectors/pairings', {
+    device_name: 'E2E Device',
+    capabilities: ['read_file', 'glob', 'grep'],
+  }, token);
+
+  const pairingCode = stringField(pairing, 'pairing_code');
+  const pairingId = stringField(pairing, 'pairing_id');
+  assert(pairingCode, 'pairing response missing pairing_code');
+  assert(pairingId, 'pairing response missing pairing_id');
+
+  const deviceId = `e2e-device-${runId.slice(-10)}`;
+  const enrollment = await api('POST', '/api/device-connectors/enroll', {
+    pairing_code: pairingCode,
+    device_id: deviceId,
+    installation_id: deviceId,
+    device_name: 'E2E Device',
+    capabilities: ['read_file', 'glob', 'grep'],
+  });
+
+  const connectorToken = stringField(enrollment, 'connector_token');
+  assert(connectorToken, 'enroll response missing connector_token');
+
+  const pairingStatus = await api('GET', `/api/device-connectors/pairings/${pairingId}`, undefined, token);
+  assert(stringField(pairingStatus, 'status') === 'consumed', 'pairing was not consumed');
+
+  connector = new CatsCoDeviceConnector({
+    serverUrl: wsUrl,
+    httpBaseUrl,
+    authMode: 'device_connector',
+    connectorToken,
+    bodyId: deviceId,
+    installationId: deviceId,
+    deviceName: 'E2E Device',
+    capabilities: ['read_file', 'glob', 'grep'],
+  });
+  await connector.start();
+  await waitForRoutableDevice(token, deviceId, 20_000);
+
+  botClient = new CatsClient({
+    serverUrl: wsUrl,
+    httpBaseUrl,
+    apiKey: botApiKey,
+    bodyId: `body-e2e-${runId.slice(-10)}`,
+    installationId: `body-e2e-${runId.slice(-10)}`,
+  });
+  const botReady = waitForClientReady(botClient, 20_000);
+  botClient.connect();
+  await botReady;
+
+  const openAgent = await api('POST', '/api/agents/open', {
+    agent_uid: botUid,
+  }, token);
+  const topic = stringField(openAgent, 'topic');
+  assert(topic, 'open agent response missing topic');
+
+  const messagePromise = waitForMessageWithGrant(botClient, topic, 20_000);
+  await api('POST', '/api/messages/send', {
+    topic_id: topic,
+    type: 'text',
+    content: 'Please read my local sentinel file.',
+  }, token);
+
+  const incoming = await messagePromise;
+  const identity = incoming.metadata?.catsco_identity as Record<string, unknown> | undefined;
+  const grants = Array.isArray(identity?.device_grants) ? identity?.device_grants as Record<string, unknown>[] : [];
+  const grant = grants[0];
+  assert(grant, 'message metadata missing device grant');
+
+  assert(stringField(grant, 'actorUserId') === `usr${userId}`, 'grant actor did not match user');
+  assert(stringField(grant, 'agentId') === `usr${botUid}`, 'grant agent did not match bot');
+  assert(stringField(grant, 'deviceId') === deviceId, 'grant device did not match connector');
+
+  const result = await botClient.sendDeviceRpcRequest({
+    request_id: `rpc-${runId}`,
+    grant_id: stringField(grant, 'grantId'),
+    session_key: stringField(grant, 'sessionKey'),
+    topic_id: stringField(grant, 'topicId'),
+    topic_type: stringField(grant, 'topicType'),
+    actor_user_id: stringField(grant, 'actorUserId'),
+    agent_id: stringField(grant, 'agentId'),
+    agent_body_id: stringField(grant, 'agentBodyId'),
+    device_id: stringField(grant, 'deviceId'),
+    device_body_id: stringField(grant, 'deviceBodyId'),
+    device_installation_id: stringField(grant, 'deviceInstallationId'),
+    operation: 'read_file',
+    tool_name: 'read_file',
+    payload: { args: { file_path: sentinelFile, limit: 20 } },
+  }, 20_000);
+
+  const payload = result.result as Record<string, unknown> | undefined;
+  assert(payload?.ok === true, `device RPC did not return ok=true: ${JSON.stringify(result)}`);
+  assert(String(payload.content || '').includes(sentinel), 'device RPC result did not include sentinel content');
+
+  const status = await api('GET', `/api/devices/rpc-status?agent_id=usr${botUid}`, undefined, token);
+  assert(numberField(status, 'pending_count') === 0, `pending RPC was not cleared: ${JSON.stringify(status)}`);
+  const statusText = JSON.stringify(status);
+  assert(!statusText.includes(sentinelFile), 'rpc-status leaked local absolute file path');
+  assert(!statusText.includes(sentinel), 'rpc-status leaked file content');
+
+  await api('DELETE', `/api/devices/${encodeURIComponent(deviceId)}`, undefined, token);
+  const devicesAfterDelete = await api('GET', '/api/devices', undefined, token);
+  const remaining = Array.isArray(devicesAfterDelete.devices) ? devicesAfterDelete.devices : [];
+  assert(!remaining.some((device: any) => device?.deviceId === deviceId && device?.routable), 'deleted device is still routable');
+
+    console.log('[cross-repo:e2e] CatsCo full device RPC e2e passed');
+  } finally {
+    await connector?.destroy().catch(() => undefined);
+    botClient?.disconnect();
+    if (serverProcess) await stopProcess(serverProcess);
+  }
+}
+
+function startCatsCompanyServer(configFile: string): ChildProcessWithoutNullStreams {
+  const goCache = process.env.CATSCOMPANY_GOCACHE || path.join(catsRepo, '.gocache');
+  fs.mkdirSync(goCache, { recursive: true });
+  const child = spawn('go', ['run', './server/cmd', configFile], {
+    cwd: catsRepo,
+    env: {
+      ...process.env,
+      GOCACHE: goCache,
+      OC_JWT_SECRET: process.env.OC_JWT_SECRET || `catsco-e2e-${runId}`,
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+    shell: false,
+  });
+  child.stdout.on('data', data => process.stdout.write(prefixLines('[cats-company] ', data.toString())));
+  child.stderr.on('data', data => process.stderr.write(prefixLines('[cats-company] ', data.toString())));
+  child.on('exit', code => {
+    if (code !== null && code !== 0) {
+      process.stderr.write(`[cross-repo:e2e] cats-company server exited with code ${code}\n`);
+    }
+  });
+  return child;
+}
+
+async function waitForReady(url: string, timeoutMs: number): Promise<void> {
+  const started = Date.now();
+  let lastError = '';
+  while (Date.now() - started < timeoutMs) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return;
+      lastError = `${res.status} ${await res.text().catch(() => '')}`;
+    } catch (err: any) {
+      lastError = err?.message || String(err);
+    }
+    await sleep(500);
+  }
+  throw new Error(`server was not ready after ${timeoutMs}ms: ${lastError}`);
+}
+
+async function api(
+  method: string,
+  route: string,
+  body?: unknown,
+  token?: string,
+  expected = 200,
+): Promise<any> {
+  const res = await fetch(`${httpBaseUrl}${route}`, {
+    method,
+    headers: {
+      ...(body === undefined ? {} : { 'Content-Type': 'application/json' }),
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const text = await res.text();
+  let parsed: any = {};
+  if (text) {
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = { raw: text };
+    }
+  }
+  if (res.status !== expected) {
+    throw new Error(`${method} ${route} returned ${res.status}, expected ${expected}: ${text}`);
+  }
+  return parsed;
+}
+
+async function waitForRoutableDevice(token: string, deviceId: string, timeoutMs: number): Promise<void> {
+  const started = Date.now();
+  let lastDevices = '';
+  while (Date.now() - started < timeoutMs) {
+    const body = await api('GET', '/api/devices', undefined, token);
+    const devices = Array.isArray(body.devices) ? body.devices : [];
+    const device = devices.find((item: any) => item?.deviceId === deviceId);
+    if (device?.active && device?.routeConnected && device?.routable) return;
+    lastDevices = JSON.stringify(devices);
+    await sleep(500);
+  }
+  throw new Error(`device ${deviceId} did not become routable: ${lastDevices}`);
+}
+
+async function waitForClientReady(client: CatsClient, timeoutMs: number): Promise<void> {
+  await waitForEvent(client, 'ready', timeoutMs);
+}
+
+async function waitForMessageWithGrant(client: CatsClient, topic: string, timeoutMs: number): Promise<MessageContext> {
+  const started = Date.now();
+  return await new Promise<MessageContext>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`timed out waiting for device grant message after ${timeoutMs}ms`));
+    }, timeoutMs);
+    const onMessage = (message: MessageContext) => {
+      const identity = message.metadata?.catsco_identity as Record<string, unknown> | undefined;
+      const grants = identity?.device_grants;
+      if (message.topic === topic && Array.isArray(grants) && grants.length > 0) {
+        cleanup();
+        resolve(message);
+      }
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const cleanup = () => {
+      clearTimeout(timer);
+      client.off('message', onMessage);
+      client.off('error', onError);
+    };
+    client.on('message', onMessage);
+    client.on('error', onError);
+    void started;
+  });
+}
+
+async function waitForEvent(emitter: NodeJS.EventEmitter, event: string, timeoutMs: number): Promise<unknown[]> {
+  return await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`timed out waiting for ${event} after ${timeoutMs}ms`));
+    }, timeoutMs);
+    const onEvent = (...args: unknown[]) => {
+      cleanup();
+      resolve(args);
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const cleanup = () => {
+      clearTimeout(timer);
+      emitter.off(event, onEvent);
+      emitter.off('error', onError);
+    };
+    emitter.once(event, onEvent);
+    emitter.once('error', onError);
+  });
+}
+
+async function findFreePort(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        server.close(() => reject(new Error('failed to allocate port')));
+        return;
+      }
+      const port = address.port;
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+async function stopProcess(child: ChildProcessWithoutNullStreams): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  await new Promise<void>(resolve => {
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      resolve();
+    }, 5000);
+    child.once('exit', () => {
+      clearTimeout(timer);
+      resolve();
+    });
+    child.kill('SIGTERM');
+  });
+}
+
+function stringField(record: any, key: string): string {
+  return String(record?.[key] || '').trim();
+}
+
+function numberField(record: any, key: string): number {
+  const value = Number(record?.[key]);
+  return Number.isFinite(value) ? value : 0;
+}
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function prefixLines(prefix: string, value: string): string {
+  return value
+    .split(/\r?\n/)
+    .map((line, index, lines) => (line || index < lines.length - 1 ? `${prefix}${line}` : line))
+    .join('\n');
+}

--- a/scripts/cross-repo-catsco-e2e.ts
+++ b/scripts/cross-repo-catsco-e2e.ts
@@ -239,6 +239,7 @@ function startCatsCompanyServer(configFile: string): ChildProcessWithoutNullStre
       GOCACHE: goCache,
       OC_JWT_SECRET: process.env.OC_JWT_SECRET || `catsco-e2e-${runId}`,
     },
+    detached: process.platform !== 'win32',
     stdio: ['ignore', 'pipe', 'pipe'],
     shell: false,
   });
@@ -402,15 +403,26 @@ async function findFreePort(): Promise<number> {
 async function stopProcess(child: ChildProcessWithoutNullStreams): Promise<void> {
   if (child.exitCode !== null || child.signalCode !== null) return;
   await new Promise<void>(resolve => {
+    const kill = (signal: NodeJS.Signals) => {
+      if (process.platform !== 'win32' && child.pid) {
+        try {
+          process.kill(-child.pid, signal);
+          return;
+        } catch {
+          // Fall back to killing the direct child below.
+        }
+      }
+      child.kill(signal);
+    };
     const timer = setTimeout(() => {
-      child.kill('SIGKILL');
+      kill('SIGKILL');
       resolve();
     }, 5000);
     child.once('exit', () => {
       clearTimeout(timer);
       resolve();
     });
-    child.kill('SIGTERM');
+    kill('SIGTERM');
   });
 }
 

--- a/scripts/cross-repo-catsco-e2e.ts
+++ b/scripts/cross-repo-catsco-e2e.ts
@@ -14,9 +14,16 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, '..');
 const catsRepo = path.resolve(process.env.CATSCOMPANY_REPO || path.join(rootDir, '..', 'cats-company'));
 const dbDsn = String(process.env.CATSCOMPANY_E2E_DB_DSN || '').trim();
+const e2eTimeoutMs = positiveNumber(process.env.CATSCOMPANY_E2E_TIMEOUT_MS, 180_000);
+const apiTimeoutMs = positiveNumber(process.env.CATSCOMPANY_E2E_API_TIMEOUT_MS, 15_000);
 
 if (!dbDsn) {
-  console.log('[cross-repo:e2e] skipped: CATSCOMPANY_E2E_DB_DSN is not set');
+  const message = '[cross-repo:e2e] CATSCOMPANY_E2E_DB_DSN is not set';
+  if (process.env.CI === 'true') {
+    console.error(message);
+    process.exit(1);
+  }
+  console.log(`${message}; skipped outside CI`);
   process.exit(0);
 }
 
@@ -38,7 +45,16 @@ let serverProcess: ChildProcessWithoutNullStreams | undefined;
 let connector: CatsCoDeviceConnector | undefined;
 let botClient: CatsClient | undefined;
 
-main().catch(error => {
+const watchdog = setTimeout(() => {
+  console.error(`[cross-repo:e2e] timed out after ${e2eTimeoutMs}ms`);
+  serverProcess?.kill('SIGKILL');
+  process.exit(1);
+}, e2eTimeoutMs);
+
+main().then(() => {
+  clearTimeout(watchdog);
+}).catch(error => {
+  clearTimeout(watchdog);
   console.error(`[cross-repo:e2e] failed: ${error?.message || error}`);
   process.exit(1);
 });
@@ -63,9 +79,11 @@ async function main(): Promise<void> {
   }, null, 2), 'utf8');
 
   try {
+    logStep('starting cats-company server');
     serverProcess = startCatsCompanyServer(configPath);
     await waitForReady(`${httpBaseUrl}/ready`, 45_000);
 
+  logStep('registering human user');
   const user = await api('POST', '/api/auth/register', {
     username: `e2e_user_${runId.slice(-10)}`,
     password: 'password123',
@@ -77,6 +95,7 @@ async function main(): Promise<void> {
   assert(token, 'register response missing token');
   assert(userId > 0, 'register response missing uid');
 
+  logStep('creating bot user');
   const bot = await api('POST', '/api/bots', {
     username: `e2e_agent_${runId.slice(-10)}`,
     password: 'password123',
@@ -89,6 +108,7 @@ async function main(): Promise<void> {
   assert(botUid > 0, 'create bot response missing uid');
   assert(botApiKey, 'create bot response missing api_key');
 
+  logStep('creating device pairing');
   const pairing = await api('POST', '/api/device-connectors/pairings', {
     device_name: 'E2E Device',
     capabilities: ['read_file', 'glob', 'grep'],
@@ -99,6 +119,7 @@ async function main(): Promise<void> {
   assert(pairingCode, 'pairing response missing pairing_code');
   assert(pairingId, 'pairing response missing pairing_id');
 
+  logStep('enrolling device connector');
   const deviceId = `e2e-device-${runId.slice(-10)}`;
   const enrollment = await api('POST', '/api/device-connectors/enroll', {
     pairing_code: pairingCode,
@@ -114,6 +135,7 @@ async function main(): Promise<void> {
   const pairingStatus = await api('GET', `/api/device-connectors/pairings/${pairingId}`, undefined, token);
   assert(stringField(pairingStatus, 'status') === 'consumed', 'pairing was not consumed');
 
+  logStep('starting XiaoBa device connector');
   connector = new CatsCoDeviceConnector({
     serverUrl: wsUrl,
     httpBaseUrl,
@@ -127,6 +149,7 @@ async function main(): Promise<void> {
   await connector.start();
   await waitForRoutableDevice(token, deviceId, 20_000);
 
+  logStep('starting XiaoBa bot client');
   botClient = new CatsClient({
     serverUrl: wsUrl,
     httpBaseUrl,
@@ -138,12 +161,14 @@ async function main(): Promise<void> {
   botClient.connect();
   await botReady;
 
+  logStep('opening agent conversation');
   const openAgent = await api('POST', '/api/agents/open', {
     agent_uid: botUid,
   }, token);
   const topic = stringField(openAgent, 'topic');
   assert(topic, 'open agent response missing topic');
 
+  logStep('sending message and waiting for device grant');
   const messagePromise = waitForMessageWithGrant(botClient, topic, 20_000);
   await api('POST', '/api/messages/send', {
     topic_id: topic,
@@ -161,6 +186,7 @@ async function main(): Promise<void> {
   assert(stringField(grant, 'agentId') === `usr${botUid}`, 'grant agent did not match bot');
   assert(stringField(grant, 'deviceId') === deviceId, 'grant device did not match connector');
 
+  logStep('sending device_rpc read_file request');
   const result = await botClient.sendDeviceRpcRequest({
     request_id: `rpc-${runId}`,
     grant_id: stringField(grant, 'grantId'),
@@ -182,12 +208,14 @@ async function main(): Promise<void> {
   assert(payload?.ok === true, `device RPC did not return ok=true: ${JSON.stringify(result)}`);
   assert(String(payload.content || '').includes(sentinel), 'device RPC result did not include sentinel content');
 
+  logStep('checking pending cleanup and status redaction');
   const status = await api('GET', `/api/devices/rpc-status?agent_id=usr${botUid}`, undefined, token);
   assert(numberField(status, 'pending_count') === 0, `pending RPC was not cleared: ${JSON.stringify(status)}`);
   const statusText = JSON.stringify(status);
   assert(!statusText.includes(sentinelFile), 'rpc-status leaked local absolute file path');
   assert(!statusText.includes(sentinel), 'rpc-status leaked file content');
 
+  logStep('deleting device connector registration');
   await api('DELETE', `/api/devices/${encodeURIComponent(deviceId)}`, undefined, token);
   const devicesAfterDelete = await api('GET', '/api/devices', undefined, token);
   const remaining = Array.isArray(devicesAfterDelete.devices) ? devicesAfterDelete.devices : [];
@@ -247,14 +275,27 @@ async function api(
   token?: string,
   expected = 200,
 ): Promise<any> {
-  const res = await fetch(`${httpBaseUrl}${route}`, {
-    method,
-    headers: {
-      ...(body === undefined ? {} : { 'Content-Type': 'application/json' }),
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    },
-    body: body === undefined ? undefined : JSON.stringify(body),
-  });
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), apiTimeoutMs);
+  let res: Response;
+  try {
+    res = await fetch(`${httpBaseUrl}${route}`, {
+      method,
+      headers: {
+        ...(body === undefined ? {} : { 'Content-Type': 'application/json' }),
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: body === undefined ? undefined : JSON.stringify(body),
+      signal: controller.signal,
+    });
+  } catch (err: any) {
+    if (err?.name === 'AbortError') {
+      throw new Error(`${method} ${route} timed out after ${apiTimeoutMs}ms`);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
   const text = await res.text();
   let parsed: any = {};
   if (text) {
@@ -384,6 +425,15 @@ function numberField(record: any, key: string): number {
 
 function assert(condition: unknown, message: string): asserts condition {
   if (!condition) throw new Error(message);
+}
+
+function logStep(message: string): void {
+  console.log(`[cross-repo:e2e] ${message}`);
+}
+
+function positiveNumber(value: unknown, fallback: number): number {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? number : fallback;
 }
 
 function prefixLines(prefix: string, value: string): string {

--- a/scripts/cross-repo-catsco-smoke.mjs
+++ b/scripts/cross-repo-catsco-smoke.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(__dirname, '..');
+const require = createRequire(import.meta.url);
+
+const catsRepo = path.resolve(process.env.CATSCOMPANY_REPO || path.join(rootDir, '..', 'cats-company'));
+const catsGoMod = path.join(catsRepo, 'go.mod');
+
+if (!fs.existsSync(catsGoMod)) {
+  console.error(`[cross-repo] cats-company repo not found at ${catsRepo}`);
+  console.error('[cross-repo] Set CATSCOMPANY_REPO to the local cats-company checkout.');
+  process.exit(1);
+}
+
+const catsGoCache = process.env.CATSCOMPANY_GOCACHE || path.join(catsRepo, '.gocache');
+fs.mkdirSync(catsGoCache, { recursive: true });
+
+const catsServerSmoke = [
+  'TestDeviceConnectorPairingEnrollmentAndScopedRegistration',
+  'TestDeviceRPCRoutesRequestToSelectedDeviceAndReturnsResult',
+  'TestDeviceRPCDoesNotBroadcastToSiblingConnections',
+  'TestDeviceRPCRejectsResultFromWrongDeviceConnection',
+  'TestDeviceRPCRejectsOfflineDevice',
+  'TestDeviceRPCDoesNotRouteByBareBodyOrInstallationID',
+  'TestSharedRuntimeRoutesDeviceRPCAcrossHubs',
+  'TestRedisRuntimeRoutesDeviceRPCAcrossStates',
+].join('|');
+
+const tsxCli = require.resolve('tsx/cli');
+const xiaoBaSmokeTests = [
+  'tests/catscompany-client-body-id.test.ts',
+  'tests/catscompany-device-rpc-tools.test.ts',
+  'tests/tool-gateway-catsco.test.ts',
+];
+
+runStep('cats-company server device connector/RPC smoke', 'go', [
+  'test',
+  './server',
+  '-run',
+  catsServerSmoke,
+  '-count=1',
+], {
+  cwd: catsRepo,
+  env: {
+    ...process.env,
+    GOCACHE: catsGoCache,
+  },
+});
+
+runStep('XiaoBa CatsCo device RPC smoke', process.execPath, [
+  tsxCli,
+  '--test',
+  ...xiaoBaSmokeTests,
+], {
+  cwd: rootDir,
+});
+
+console.log('[cross-repo] CatsCo cross-repo smoke passed');
+
+function runStep(name, command, args, options = {}) {
+  console.log(`[cross-repo] ${name}`);
+  const result = spawnSync(command, args, {
+    cwd: options.cwd || rootDir,
+    env: options.env || process.env,
+    stdio: 'inherit',
+    shell: false,
+  });
+
+  if (result.error) {
+    console.error(`[cross-repo] Failed to start ${name}: ${result.error.message}`);
+    process.exit(1);
+  }
+
+  if (result.signal) {
+    console.error(`[cross-repo] ${name} terminated by ${result.signal}`);
+    process.exit(1);
+  }
+
+  if (result.status !== 0) {
+    console.error(`[cross-repo] ${name} failed with exit code ${result.status}`);
+    process.exit(result.status || 1);
+  }
+}

--- a/scripts/cross-repo-catsco-smoke.mjs
+++ b/scripts/cross-repo-catsco-smoke.mjs
@@ -31,12 +31,18 @@ const catsServerSmoke = [
   'TestDeviceRPCDoesNotRouteByBareBodyOrInstallationID',
   'TestSharedRuntimeRoutesDeviceRPCAcrossHubs',
   'TestRedisRuntimeRoutesDeviceRPCAcrossStates',
+  'TestChannelAgentBindingLinkUser',
+  'TestChannelAgentBindingConfirmRequiresTokenInProduction',
+  'TestBotRecipientIdentityUsesLinkedChannelDeviceOwner',
+  'TestFeishuMessageEventDeliversToBoundAgent',
+  'TestWeixinTextMessageDeliversToBoundAgent',
 ].join('|');
 
 const tsxCli = require.resolve('tsx/cli');
 const xiaoBaSmokeTests = [
   'tests/catscompany-client-body-id.test.ts',
   'tests/catscompany-device-rpc-tools.test.ts',
+  'tests/catscompany-execution-scope-flow.test.ts',
   'tests/tool-gateway-catsco.test.ts',
 ];
 

--- a/src/catscompany/client.ts
+++ b/src/catscompany/client.ts
@@ -5,6 +5,8 @@ import crypto from 'crypto';
 import { Logger } from '../utils/logger';
 import { uploadCatsLocalFile, type UploadResult } from './upload';
 
+const MAX_DEVICE_RPC_EVENT_ERROR_LENGTH = 240;
+
 export type { UploadResult } from './upload';
 
 export interface CatsClientConfig {
@@ -829,7 +831,7 @@ export class CatsClient extends EventEmitter {
       deviceId: message.device_id,
       createdAt: new Date().toISOString(),
       durationMs: startedAt ? Math.max(0, Date.now() - startedAt) : undefined,
-      error: options.error,
+      error: sanitizeDeviceRpcEventError(options.error),
     };
     this.deviceRpcRecent.push(event);
     if (this.deviceRpcRecent.length > 30) {
@@ -1048,5 +1050,19 @@ function deviceRpcResultMatchesPending(result: CatsDeviceRpcMessage, request: Ca
 function deviceRpcOptionalFieldMatches(actual: unknown, expected: unknown): boolean {
   const actualText = typeof actual === 'string' ? actual.trim() : '';
   const expectedText = typeof expected === 'string' ? expected.trim() : '';
-  return !actualText || !expectedText || actualText === expectedText;
+  if (!expectedText) return true;
+  return Boolean(actualText) && actualText === expectedText;
+}
+
+function sanitizeDeviceRpcEventError(error?: string): string | undefined {
+  const raw = String(error || '').trim();
+  if (!raw) return undefined;
+  const sanitized = raw
+    .replace(/\b(Bearer|ApiKey|Basic)\s+[A-Za-z0-9._~:/+=-]+/gi, '$1 [redacted]')
+    .replace(/\b((?:access|refresh)[_-]?token|token|api[_-]?key|secret|client[_-]?secret|password|CATSCO_[A-Z0-9_]*TOKEN)\s*=\s*[^\s'"&]+/gi, '$1=[redacted]')
+    .replace(/[A-Za-z]:[\\/][^\s'"<>]+/g, '[redacted-path]')
+    .replace(/\\\\[^\\/\s]+\\[^\\/\s]+(?:\\[^\s'"<>]+)*/g, '[redacted-path]')
+    .replace(/\/(?:Users|home|tmp|var|etc)\/[^\s'"<>]+/g, '[redacted-path]');
+  if (sanitized.length <= MAX_DEVICE_RPC_EVENT_ERROR_LENGTH) return sanitized;
+  return `${sanitized.slice(0, MAX_DEVICE_RPC_EVENT_ERROR_LENGTH - 3)}...`;
 }

--- a/src/catscompany/device-connector.ts
+++ b/src/catscompany/device-connector.ts
@@ -124,8 +124,19 @@ export class CatsCoDeviceConnector {
     if (!requestID) return;
 
     const validationError = this.validateDeviceRpcToolRequest(request);
-    const result = validationError ? undefined : await this.executeLocalDeviceRpcTool(request);
-    const error = validationError || (!result || result.ok
+    let result: ToolExecutionResult | undefined;
+    let executionError: { code: string; message: string } | undefined;
+    if (!validationError) {
+      try {
+        result = await this.executeLocalDeviceRpcTool(request);
+      } catch (err: any) {
+        executionError = {
+          code: 'tool_execution_error',
+          message: err?.message || String(err || 'Device RPC local tool execution failed.'),
+        };
+      }
+    }
+    const error = validationError || executionError || (!result || result.ok
       ? undefined
       : {
           code: result.errorCode || 'tool_execution_error',
@@ -362,8 +373,6 @@ function normalizeConnectorCapabilities(config: CatsCompanyConfig): string[] {
     if (text === 'write_file' && config.allowWriteFile) values.add(text);
     if (text === 'execute_shell' && config.allowShell) values.add(text);
   }
-  if (config.allowWriteFile) values.add('write_file');
-  if (config.allowShell) values.add('execute_shell');
   if (values.size === 0) values.add('read_file');
   return Array.from(values);
 }

--- a/src/catscompany/device-grants.ts
+++ b/src/catscompany/device-grants.ts
@@ -7,6 +7,7 @@ import type {
   MessageTopicType,
   ScopedDeviceGrant,
 } from '../types/session-identity';
+import { isDelegatedDeviceGrant } from '../core/device-grants';
 
 type UnknownRecord = Record<string, unknown>;
 
@@ -47,14 +48,16 @@ function normalizeDeviceGrant(value: unknown): ScopedDeviceGrant | undefined {
   const operations = normalizeOperations(record.operations);
   const createdAt = numberField(record, 'createdAt') ?? numberField(record, 'created_at');
   const expiresAt = numberField(record, 'expiresAt') ?? numberField(record, 'expires_at');
+  const status = normalizeStatus(stringField(record, 'status'));
   if (!grantId || !deviceId || !ownerUserId || !sessionKey || !topicId || !actorUserId) return undefined;
   if (operations.length === 0 || createdAt === undefined || expiresAt === undefined) return undefined;
+  if (status !== 'active') return undefined;
 
   return pruneUndefined({
     kind: 'user_device_grant',
     source,
     grantId,
-    status: normalizeStatus(stringField(record, 'status')),
+    status,
     identityTrust: normalizeTrust(stringField(record, 'identityTrust') || stringField(record, 'identity_trust')),
     identitySource: stringField(record, 'identitySource') || stringField(record, 'identity_source'),
     deviceId,
@@ -78,6 +81,9 @@ function normalizeDeviceGrant(value: unknown): ScopedDeviceGrant | undefined {
 }
 
 function grantMatchesScope(grant: ScopedDeviceGrant, scope: ExecutionScope): boolean {
+  if (grant.ownerUserId !== grant.actorUserId && !isDelegatedDeviceGrant(grant)) {
+    return false;
+  }
   return grant.status === 'active'
     && grant.identityTrust === 'server_canonical'
     && grant.source === scope.source
@@ -85,7 +91,6 @@ function grantMatchesScope(grant: ScopedDeviceGrant, scope: ExecutionScope): boo
     && grant.topicId === scope.topicId
     && grant.topicType === scope.topicType
     && grant.actorUserId === scope.actorUserId
-    && grant.ownerUserId === scope.actorUserId
     && grant.agentId === scope.agentId
     && grant.agentBodyId === scope.agentBodyId;
 }
@@ -115,8 +120,9 @@ function normalizeSource(value: string | undefined): MessageSource {
   return value === 'catscompany' ? 'catscompany' : 'unknown';
 }
 
-function normalizeStatus(value: string | undefined): DeviceGrantStatus {
-  return value === 'revoked' ? 'revoked' : 'active';
+function normalizeStatus(value: string | undefined): DeviceGrantStatus | undefined {
+  if (value === 'active' || value === 'revoked') return value;
+  return undefined;
 }
 
 function normalizeTrust(value: string | undefined): IdentityTrustLevel {

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -128,12 +128,17 @@ export class CatsCompanyBot {
     status: 'online';
     capabilities: string[];
   };
+  private readonly allowWriteFile: boolean;
+  private readonly allowShell: boolean;
 
   constructor(config: CatsCompanyConfig) {
     if (!config.apiKey) {
       throw new Error('CatsCompanyBot requires a bot API key. Use CatsCoDeviceConnector for device-only mode.');
     }
     const localDeviceId = config.installationId || config.bodyId;
+    const deviceCapabilities = normalizeRuntimeDeviceCapabilities(config);
+    this.allowWriteFile = deviceCapabilities.includes('write_file') && Boolean(config.allowWriteFile);
+    this.allowShell = deviceCapabilities.includes('execute_shell') && Boolean(config.allowShell);
     const deviceRegistration = localDeviceId
       ? {
           device_id: localDeviceId,
@@ -141,7 +146,7 @@ export class CatsCompanyBot {
           body_id: config.bodyId,
           installation_id: config.installationId || config.bodyId,
           status: 'online' as const,
-          capabilities: ['read_file', 'glob', 'grep'],
+          capabilities: deviceCapabilities,
         }
       : undefined;
 
@@ -281,8 +286,19 @@ export class CatsCompanyBot {
     if (!requestID) return;
 
     const validationError = this.validateDeviceRpcToolRequest(request);
-    const result = validationError ? undefined : await this.executeLocalDeviceRpcTool(request);
-    const error = validationError || (!result || result.ok
+    let result: ToolExecutionResult | undefined;
+    let executionError: { code: string; message: string } | undefined;
+    if (!validationError) {
+      try {
+        result = await this.executeLocalDeviceRpcTool(request);
+      } catch (err: any) {
+        executionError = {
+          code: 'tool_execution_error',
+          message: err?.message || String(err || 'Device RPC local tool execution failed.'),
+        };
+      }
+    }
+    const error = validationError || executionError || (!result || result.ok
       ? undefined
       : {
           code: result.errorCode || 'tool_execution_error',
@@ -320,6 +336,27 @@ export class CatsCompanyBot {
         ok: false,
         errorCode: 'PERMISSION_DENIED',
         message: `Device RPC 不允许执行 ${toolName || request.operation || 'unknown'}。`,
+      };
+    }
+    if (!(this.deviceRegistration?.capabilities || []).includes(operation)) {
+      return {
+        ok: false,
+        errorCode: 'PERMISSION_DENIED',
+        message: `当前 CatsCo runtime 未注册远程 ${operation} 能力。`,
+      };
+    }
+    if (operation === 'write_file' && !this.allowWriteFile) {
+      return {
+        ok: false,
+        errorCode: 'PERMISSION_DENIED',
+        message: '当前 CatsCo runtime 未显式开启远程写文件能力。',
+      };
+    }
+    if (operation === 'execute_shell' && !this.allowShell) {
+      return {
+        ok: false,
+        errorCode: 'PERMISSION_DENIED',
+        message: '当前 CatsCo runtime 未显式开启远程 shell 能力。',
       };
     }
 
@@ -1518,4 +1555,19 @@ export class CatsCompanyBot {
       this.pendingAnswerBySession.delete(pending.sessionKey);
     }
   }
+}
+
+function normalizeRuntimeDeviceCapabilities(config: CatsCompanyConfig): string[] {
+  const values = new Set<string>();
+  const configured = config.capabilities && config.capabilities.length > 0
+    ? config.capabilities
+    : ['read_file', 'glob', 'grep'];
+  for (const item of configured) {
+    const text = String(item || '').trim();
+    if (text === 'read_file' || text === 'glob' || text === 'grep') values.add(text);
+    if (text === 'write_file' && config.allowWriteFile) values.add(text);
+    if (text === 'execute_shell' && config.allowShell) values.add(text);
+  }
+  if (values.size === 0) values.add('read_file');
+  return Array.from(values);
 }

--- a/src/commands/device-connector.ts
+++ b/src/commands/device-connector.ts
@@ -154,7 +154,7 @@ export async function deviceConnectorCommand(options: DeviceConnectorCommandOpti
   await connector.start();
 }
 
-async function enrollDeviceConnector(
+export async function enrollDeviceConnector(
   service: ReturnType<typeof createCatsCoLocalConfigService>,
   config: ChatConfig,
   options: DeviceConnectorCommandOptions,
@@ -181,7 +181,14 @@ async function enrollDeviceConnector(
     }),
   });
   if (!res.ok) {
-    throw new Error(`CatsCo Device Connector 配对失败: ${res.status}`);
+    let reason = '';
+    try {
+      const body = await res.json() as any;
+      reason = String(body?.error || body?.message || '').trim();
+    } catch {
+      // Keep the status fallback below when the response is not JSON.
+    }
+    throw new Error(`CatsCo Device Connector 配对失败: ${reason || res.status}`);
   }
   const body = await res.json() as any;
   const token = String(body.connector_token || '').trim();

--- a/src/commands/feishu.ts
+++ b/src/commands/feishu.ts
@@ -2,6 +2,7 @@ import { Logger } from '../utils/logger';
 import { ConfigManager } from '../utils/config';
 import { FeishuBot } from '../feishu';
 import { FeishuConfig } from '../feishu/types';
+import { resolveChannelAgentBindingOptions } from '../core/channel-agent-binding-resolver';
 import { startRuntimeCommandSupport, stopRuntimeCommandSupport } from '../utils/runtime-command-support';
 
 /**
@@ -35,6 +36,7 @@ export async function feishuCommand(): Promise<void> {
     sessionTTL: config.feishu?.sessionTTL,
     botOpenId,
     botAliases,
+    channelAgentBinding: resolveChannelAgentBindingOptions(),
   };
 
   // Bot Bridge 配置

--- a/src/commands/weixin.ts
+++ b/src/commands/weixin.ts
@@ -1,12 +1,14 @@
 import { Logger } from '../utils/logger';
 import { WeixinBot } from '../weixin';
 import { WeixinConfig } from '../weixin/types';
+import { resolveChannelAgentBindingOptions } from '../core/channel-agent-binding-resolver';
 import { startRuntimeCommandSupport, stopRuntimeCommandSupport } from '../utils/runtime-command-support';
 
 export async function weixinCommand(): Promise<void> {
   const token = process.env.WEIXIN_TOKEN;
   const baseUrl = process.env.WEIXIN_BASE_URL || 'https://ilinkai.weixin.qq.com';
   const cdnBaseUrl = process.env.WEIXIN_CDN_BASE_URL || 'https://novac2c.cdn.weixin.qq.com/c2c';
+  const channelAppId = process.env.WEIXIN_APP_ID || process.env.WEIXIN_BOT_ID || process.env.CATSCO_WEIXIN_APP_ID;
 
   if (!token) {
     Logger.error('微信配置缺失。请设置环境变量 WEIXIN_TOKEN');
@@ -15,7 +17,13 @@ export async function weixinCommand(): Promise<void> {
 
   process.env.CURRENT_PLATFORM = '微信';
 
-  const config: WeixinConfig = { token, baseUrl, cdnBaseUrl };
+  const config: WeixinConfig = {
+    token,
+    baseUrl,
+    cdnBaseUrl,
+    channelAppId,
+    channelAgentBinding: resolveChannelAgentBindingOptions(),
+  };
   const bot = new WeixinBot(config);
 
   const shutdown = () => {

--- a/src/core/channel-agent-binding-resolver.ts
+++ b/src/core/channel-agent-binding-resolver.ts
@@ -28,6 +28,7 @@ export const CHANNEL_BINDING_REQUIRED_MESSAGE = '请先扫描虚拟员工入口�
 export class ChannelAgentBindingResolver {
   readonly enabled: boolean;
   readonly required: boolean;
+  readonly misconfiguredRequired: boolean;
   private readonly httpBaseUrl: string;
   private readonly token?: string;
   private readonly timeoutMs: number;
@@ -37,10 +38,14 @@ export class ChannelAgentBindingResolver {
     this.token = options.token?.trim() || undefined;
     this.timeoutMs = normalizeTimeout(options.timeoutMs);
     this.required = Boolean(options.required);
-    this.enabled = Boolean(options.enabled && this.httpBaseUrl);
+    this.enabled = Boolean((options.enabled || options.required) && this.httpBaseUrl);
+    this.misconfiguredRequired = Boolean(this.required && !this.httpBaseUrl);
   }
 
   async resolve(input: ChannelAgentBindingResolveInput): Promise<ChannelAgentBindingResolution | undefined> {
+    if (this.misconfiguredRequired) {
+      throw new Error('channel agent binding is required but CATSCO_CHANNEL_BINDING_HTTP_BASE_URL is missing');
+    }
     if (!this.enabled) return undefined;
     const params = new URLSearchParams({
       channel: input.channel,

--- a/src/core/channel-agent-binding-resolver.ts
+++ b/src/core/channel-agent-binding-resolver.ts
@@ -1,0 +1,170 @@
+import type { ChannelAgentRouteBinding } from './session-router';
+import type { IdentityTrustLevel } from '../types/session-identity';
+
+export interface ChannelAgentBindingResolverOptions {
+  httpBaseUrl?: string;
+  token?: string;
+  enabled?: boolean;
+  required?: boolean;
+  timeoutMs?: number;
+}
+
+export interface ChannelAgentBindingResolveInput {
+  channel: 'feishu' | 'weixin';
+  channelAppId?: string;
+  channelUserId: string;
+  channelConversationId?: string;
+  channelConversationType?: 'p2p' | 'group';
+}
+
+export interface ChannelAgentBindingResolution extends ChannelAgentRouteBinding {
+  bound: boolean;
+  agentUid?: number;
+  ownerUid?: number;
+}
+
+export const CHANNEL_BINDING_REQUIRED_MESSAGE = '请先扫描虚拟员工入口码完成绑定，然后再回来提问。';
+
+export class ChannelAgentBindingResolver {
+  readonly enabled: boolean;
+  readonly required: boolean;
+  private readonly httpBaseUrl: string;
+  private readonly token?: string;
+  private readonly timeoutMs: number;
+
+  constructor(options: ChannelAgentBindingResolverOptions = {}) {
+    this.httpBaseUrl = normalizeBaseUrl(options.httpBaseUrl);
+    this.token = options.token?.trim() || undefined;
+    this.timeoutMs = normalizeTimeout(options.timeoutMs);
+    this.required = Boolean(options.required);
+    this.enabled = Boolean(options.enabled && this.httpBaseUrl);
+  }
+
+  async resolve(input: ChannelAgentBindingResolveInput): Promise<ChannelAgentBindingResolution | undefined> {
+    if (!this.enabled) return undefined;
+    const params = new URLSearchParams({
+      channel: input.channel,
+      channel_user_id: input.channelUserId,
+      channel_conversation_type: input.channelConversationType || 'p2p',
+    });
+    if (input.channelAppId) params.set('channel_app_id', input.channelAppId);
+    if (input.channelConversationId) params.set('channel_conversation_id', input.channelConversationId);
+
+    const headers: Record<string, string> = { Accept: 'application/json' };
+    if (this.token) headers.Authorization = `Bearer ${this.token}`;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      const res = await fetch(`${this.httpBaseUrl}/api/channel-agent-bindings/resolve?${params.toString()}`, {
+        method: 'GET',
+        headers,
+        signal: controller.signal,
+      });
+      const data = await res.json().catch(() => ({})) as Record<string, unknown>;
+      if (!res.ok) {
+        throw new Error(stringField(data, 'error') || `binding resolve failed: ${res.status}`);
+      }
+      if (data.bound !== true) {
+        return { bound: false };
+      }
+      const agentId = stringField(data, 'agent_id') || agentIdFromUid(numberField(data, 'agent_uid'));
+      if (!agentId) {
+        throw new Error('binding response is missing agent_id');
+      }
+      return {
+        bound: true,
+        agentUid: numberField(data, 'agent_uid'),
+        ownerUid: numberField(data, 'owner_uid'),
+        agentId,
+        agentBodyId: stringField(data, 'agent_body_id'),
+        identityTrust: trustField(data, 'identity_trust') || 'server_canonical',
+        identitySource: stringField(data, 'identity_source') || 'channel_agent_binding',
+      };
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+export function resolveChannelAgentBindingOptions(
+  env: Record<string, string | undefined> = process.env,
+): ChannelAgentBindingResolverOptions {
+  return {
+    httpBaseUrl: firstNonEmpty(
+      env.CATSCO_CHANNEL_BINDING_HTTP_BASE_URL,
+      env.CATSCOMPANY_CHANNEL_BINDING_HTTP_BASE_URL,
+    ),
+    token: firstNonEmpty(env.CATSCO_CHANNEL_BINDING_TOKEN, env.CATSCOMPANY_CHANNEL_BINDING_TOKEN),
+    enabled: parseBoolean(firstNonEmpty(
+      env.CATSCO_CHANNEL_AGENT_BINDING_ENABLED,
+      env.CATSCOMPANY_CHANNEL_AGENT_BINDING_ENABLED,
+    )),
+    required: parseBoolean(firstNonEmpty(
+      env.CATSCO_CHANNEL_AGENT_BINDING_REQUIRED,
+      env.CATSCOMPANY_CHANNEL_AGENT_BINDING_REQUIRED,
+    )),
+    timeoutMs: parsePositiveInteger(firstNonEmpty(
+      env.CATSCO_CHANNEL_BINDING_TIMEOUT_MS,
+      env.CATSCOMPANY_CHANNEL_BINDING_TIMEOUT_MS,
+    )),
+  };
+}
+
+function normalizeBaseUrl(value?: string): string {
+  const text = value?.trim();
+  if (!text) return '';
+  return text.replace(/\/+$/, '');
+}
+
+function firstNonEmpty(...values: Array<string | undefined>): string | undefined {
+  for (const value of values) {
+    const text = value?.trim();
+    if (text) return text;
+  }
+  return undefined;
+}
+
+function parseBoolean(value?: string): boolean {
+  const text = value?.trim().toLowerCase();
+  return text === '1' || text === 'true' || text === 'yes' || text === 'required';
+}
+
+function parsePositiveInteger(value?: string): number | undefined {
+  const text = value?.trim();
+  if (!text) return undefined;
+  const parsed = Number(text);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : undefined;
+}
+
+function normalizeTimeout(value?: number): number {
+  if (!Number.isFinite(value) || !value || value <= 0) return 2500;
+  return Math.max(250, Math.min(Math.floor(value), 10000));
+}
+
+function stringField(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function numberField(record: Record<string, unknown>, key: string): number | undefined {
+  const value = record[key];
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+
+function trustField(record: Record<string, unknown>, key: string): IdentityTrustLevel | undefined {
+  const value = stringField(record, key);
+  if (value === 'server_canonical' || value === 'legacy_context' || value === 'untrusted') {
+    return value;
+  }
+  return undefined;
+}
+
+function agentIdFromUid(uid?: number): string | undefined {
+  return uid && uid > 0 ? `usr${uid}` : undefined;
+}

--- a/src/core/device-grants.ts
+++ b/src/core/device-grants.ts
@@ -45,6 +45,11 @@ export interface ResolveDeviceGrantOptions {
   now?: number;
 }
 
+const DELEGATED_DEVICE_GRANT_SOURCES = new Set([
+  'channel_agent_binding',
+  'channel_identity_link',
+]);
+
 export function createUserDevice(input: CreateUserDeviceInput): UserDevice | undefined {
   const source = normalizeSource(input.source);
   const ownerUserId = normalizeId(input.ownerUserId);
@@ -78,6 +83,8 @@ export function createDeviceGrant(
   if (operations.length === 0) return undefined;
   if (device.source !== scope.source) return undefined;
   if (device.ownerUserId !== scope.actorUserId) return undefined;
+  if (device.identityTrust !== 'server_canonical') return undefined;
+  if (device.status !== 'online') return undefined;
   const now = normalizeTime(options.now) ?? Date.now();
   const ttlMs = normalizeTtl(options.ttlMs);
 
@@ -165,8 +172,12 @@ export function validateDeviceGrant(
     return denied(`设备授权不是 active 状态，已阻止操作：${grant.status}`);
   }
 
-  if (grant.identityTrust === 'untrusted') {
-    return denied('设备授权来自未可信身份，已阻止操作。');
+  if (grant.identityTrust !== 'server_canonical') {
+    return denied('设备授权不是服务端可信身份签发，已阻止操作。');
+  }
+
+  if (grant.ownerUserId !== grant.actorUserId && !isDelegatedDeviceGrant(grant)) {
+    return denied('设备授权的设备 owner 与当前 actor 不一致，且缺少可信的渠道委托标记，已阻止操作。');
   }
 
   if (!grant.operations.includes(options.operation)) {
@@ -188,10 +199,6 @@ export function validateDeviceGrant(
     ['agentBodyId', grant.agentBodyId, scope.agentBodyId],
   ].filter(([, grantValue, scopeValue]) => grantValue !== scopeValue);
 
-  if (grant.ownerUserId !== scope.actorUserId) {
-    mismatches.push(['ownerUserId', grant.ownerUserId, scope.actorUserId]);
-  }
-
   if (mismatches.length > 0) {
     return {
       ok: false,
@@ -204,6 +211,13 @@ export function validateDeviceGrant(
   }
 
   return { ok: true, grant };
+}
+
+export function isDelegatedDeviceGrant(grant: Pick<ScopedDeviceGrant, 'ownerUserId' | 'actorUserId' | 'identityTrust' | 'identitySource'>): boolean {
+  if (grant.ownerUserId === grant.actorUserId) return false;
+  if (grant.identityTrust !== 'server_canonical') return false;
+  const identitySource = normalizeId(grant.identitySource);
+  return Boolean(identitySource && DELEGATED_DEVICE_GRANT_SOURCES.has(identitySource));
 }
 
 function denied(message: string): DeviceGrantDecision {

--- a/src/core/session-router.ts
+++ b/src/core/session-router.ts
@@ -25,6 +25,13 @@ export interface CreateSessionRouteInput {
   legacySessionKey?: string;
 }
 
+export interface ChannelAgentRouteBinding {
+  agentId?: string;
+  agentBodyId?: string;
+  identityTrust?: IdentityTrustLevel;
+  identitySource?: string;
+}
+
 export interface ParsedSessionKeyV2 {
   version: 2;
   source: MessageSource;
@@ -92,7 +99,10 @@ export function createCatsCoSessionRoute(envelope: MessageEnvelope): SessionRout
   });
 }
 
-export function createFeishuSessionRoute(message: ParsedFeishuMessage): SessionRoute {
+export function createFeishuSessionRoute(
+  message: ParsedFeishuMessage,
+  binding?: ChannelAgentRouteBinding,
+): SessionRoute {
   const topicType: MessageTopicType = message.chatType === 'group' ? 'group' : 'p2p';
   const topicId = normalizeId(message.chatId) || normalizeId(message.senderId) || 'unknown_chat';
   return createSessionRoute({
@@ -100,9 +110,11 @@ export function createFeishuSessionRoute(message: ParsedFeishuMessage): SessionR
     topicId,
     topicType,
     actorUserId: message.senderId,
+    agentId: binding?.agentId,
+    agentBodyId: binding?.agentBodyId,
     messageId: message.messageId,
-    identityTrust: 'legacy_context',
-    identitySource: 'feishu.event',
+    identityTrust: binding?.identityTrust || 'legacy_context',
+    identitySource: binding?.identitySource || 'feishu.event',
     legacySessionKey: buildLegacyFeishuSessionKey(topicType, topicId, message.senderId),
   });
 }
@@ -126,16 +138,21 @@ export function createFeishuBridgeSessionRoute(input: {
   });
 }
 
-export function createWeixinSessionRoute(message: WeixinMessage): SessionRoute {
+export function createWeixinSessionRoute(
+  message: WeixinMessage,
+  binding?: ChannelAgentRouteBinding,
+): SessionRoute {
   const actorUserId = normalizeId(message.from?.id) || 'unknown_user';
   return createSessionRoute({
     source: 'weixin',
     topicId: actorUserId,
     topicType: 'p2p',
     actorUserId,
+    agentId: binding?.agentId,
+    agentBodyId: binding?.agentBodyId,
     messageId: message.message_id,
-    identityTrust: 'legacy_context',
-    identitySource: 'weixin.ilink',
+    identityTrust: binding?.identityTrust || 'legacy_context',
+    identitySource: binding?.identitySource || 'weixin.ilink',
     legacySessionKey: `user:${actorUserId}`,
   });
 }

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -12,6 +12,7 @@ import { PathResolver } from '../../utils/path-resolver';
 import { APP_VERSION } from '../../version';
 import type { ChatConfig } from '../../types';
 import { createRuntimeConfigSnapshot } from '../../runtime/runtime-config-snapshot';
+import { enrollDeviceConnector } from '../../commands/device-connector';
 import {
   CUSTOM_MODEL_DEFAULT_CONTEXT_WINDOW_TOKENS,
   calculatePromptBudgetTokens,
@@ -221,6 +222,42 @@ function hostLabel(value: string): string {
   } catch {
     return value;
   }
+}
+
+function normalizeDevicePairingCode(value: unknown): string {
+  const text = String(value || '').trim();
+  if (!/^[A-Za-z0-9_-]{6,160}$/.test(text)) {
+    throw httpError('invalid device pairing code', 400);
+  }
+  return text;
+}
+
+function normalizeLaunchUrl(
+  value: unknown,
+  fallback: string,
+  allowedProtocols: Set<string>,
+): string {
+  const raw = String(value || '').trim();
+  const candidate = raw || fallback;
+  let parsed: URL;
+  try {
+    parsed = new URL(candidate);
+  } catch {
+    throw httpError('invalid connector launch URL', 400);
+  }
+  if (!allowedProtocols.has(parsed.protocol)) {
+    throw httpError('unsupported connector launch URL protocol', 400);
+  }
+  return parsed.toString().replace(/\/+$/, '');
+}
+
+function defaultWsUrlForHttpBase(httpBaseUrl: string): string {
+  const url = new URL(httpBaseUrl);
+  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+  url.pathname = '/v0/channels';
+  url.search = '';
+  url.hash = '';
+  return url.toString().replace(/\/+$/, '');
 }
 
 function createCatsNetworkError(error: any, httpBaseUrl: string): Error {
@@ -2813,6 +2850,92 @@ export function createApiRouter(serviceManager: ServiceManager, updateController
       res.json({ ok: true, preferences });
     } catch (e: any) {
       res.status(500).json({ error: e.message });
+    }
+  });
+
+  router.post('/cats/device-connector/pair', async (req, res) => {
+    try {
+      const pairingCode = normalizeDevicePairingCode(
+        req.body?.pairing_code || req.body?.pairingCode || req.body?.code,
+      );
+      const httpBaseUrl = normalizeLaunchUrl(
+        req.body?.http_base_url || req.body?.httpBaseUrl,
+        DEFAULT_CATSCO_HTTP_BASE_URL,
+        new Set(['http:', 'https:']),
+      );
+      const serverUrl = normalizeLaunchUrl(
+        req.body?.server_url || req.body?.serverUrl,
+        defaultWsUrlForHttpBase(httpBaseUrl),
+        new Set(['ws:', 'wss:']),
+      );
+      const deviceName = String(req.body?.device_name || req.body?.deviceName || req.body?.name || '').trim();
+      const localConfig = createCatsCoLocalConfigService({ runtimeRoot: process.cwd() });
+
+      await enrollDeviceConnector(localConfig, ConfigManager.getConfig(), {
+        pair: pairingCode,
+        httpBaseUrl,
+        serverUrl,
+        name: deviceName || undefined,
+      });
+
+      const current = serviceManager.getService('device-connector');
+      const wasRunning = current?.status === 'running';
+      const service = wasRunning
+        ? serviceManager.restart('device-connector')
+        : serviceManager.start('device-connector');
+
+      res.json({
+        ok: true,
+        service,
+        connectorStarted: !wasRunning,
+        connectorRestarted: wasRunning,
+        message: wasRunning
+          ? 'CatsCo Device Connector 已重新配对并在后台重启。'
+          : 'CatsCo Device Connector 已配对并在后台启动。',
+      });
+    } catch (e: any) {
+      res.status(e.status || 400).json({ error: e.message || 'device connector pairing failed' });
+    }
+  });
+
+  router.post('/cats/device-connector/ensure-running', async (_req, res) => {
+    try {
+      const localConfig = createCatsCoLocalConfigService({ runtimeRoot: process.cwd() }).load();
+      const connector = localConfig.deviceConnector;
+      if (localConfig.preferences?.autoConnect === false) {
+        return res.status(409).json({
+          ok: false,
+          error: 'Device Connector auto-connect is disabled',
+          reason: 'AUTO_CONNECT_DISABLED',
+        });
+      }
+      if (!connector?.token || !connector.deviceId) {
+        return res.status(409).json({
+          ok: false,
+          error: 'Device Connector is not paired',
+          reason: 'DEVICE_CONNECTOR_NOT_PAIRED',
+        });
+      }
+
+      const current = serviceManager.getService('device-connector');
+      if (current?.status === 'running') {
+        return res.json({
+          ok: true,
+          service: current,
+          connectorStarted: false,
+          connectorRestarted: false,
+        });
+      }
+
+      const service = serviceManager.start('device-connector');
+      return res.json({
+        ok: true,
+        service,
+        connectorStarted: true,
+        connectorRestarted: false,
+      });
+    } catch (e: any) {
+      return res.status(e.status || 400).json({ error: e.message || 'device connector start failed' });
     }
   });
 

--- a/src/feishu/index.ts
+++ b/src/feishu/index.ts
@@ -15,12 +15,17 @@ import { ChannelCallbacks } from '../types/tool';
 import { AdapterRuntimeBundle, createAdapterRuntime } from '../runtime/adapter-runtime';
 import { randomUUID } from 'crypto';
 import {
+  ChannelAgentBindingResolver,
+  CHANNEL_BINDING_REQUIRED_MESSAGE,
+} from '../core/channel-agent-binding-resolver';
+import {
   createExecutionScopeFromRoute,
   createFeishuBridgeSessionRoute,
   createFeishuSessionRoute,
   createSessionRoute,
   parseSessionKeyV2,
 } from '../core/session-router';
+import type { ChannelAgentRouteBinding } from '../core/session-router';
 import type { SessionRoute } from '../types/session-identity';
 
 interface PendingAttachment {
@@ -93,6 +98,8 @@ export class FeishuBot {
   private sessionManager: MessageSessionManager;
   private agentServices: AgentServices;
   private runtime: AdapterRuntimeBundle;
+  private bindingResolver: ChannelAgentBindingResolver;
+  private channelAppId: string;
   private bridgeServer: BridgeServer | null = null;
   private bridgeClient: BridgeClient | null = null;
   private bridgeConfig: FeishuConfig['bridge'] | undefined;
@@ -115,6 +122,8 @@ export class FeishuBot {
       appId: config.appId,
       appSecret: config.appSecret,
     };
+    this.channelAppId = config.appId;
+    this.bindingResolver = new ChannelAgentBindingResolver(config.channelAgentBinding);
 
     this.client = new Lark.Client(baseConfig);
     this.wsClient = new Lark.WSClient({
@@ -267,8 +276,10 @@ export class FeishuBot {
       this.processedMsgIds = new Set(ids.slice(-500));
     }
 
+    const routeBinding = await this.resolveChannelAgentBinding(msg);
+    if (routeBinding === null) return;
 
-    const route = createFeishuSessionRoute(msg);
+    const route = createFeishuSessionRoute(msg, routeBinding);
     const key = route.sessionKey;
     const isGroup = msg.chatType === 'group';
 
@@ -463,6 +474,36 @@ export class FeishuBot {
       source: 'subagent_feedback',
     });
     this.messageQueue.set(sessionKey, queue);
+  }
+
+  private async resolveChannelAgentBinding(msg: ReturnType<MessageHandler['parse']>): Promise<ChannelAgentRouteBinding | undefined | null> {
+    if (!msg || !this.bindingResolver.enabled) return undefined;
+    if (msg.chatType !== 'p2p') return undefined;
+    try {
+      const resolution = await this.bindingResolver.resolve({
+        channel: 'feishu',
+        channelAppId: this.channelAppId,
+        channelUserId: msg.senderId,
+        channelConversationType: 'p2p',
+      });
+      if (!resolution) return undefined;
+      if (!resolution.bound) {
+        if (this.bindingResolver.required) {
+          await this.sender.reply(msg.chatId, CHANNEL_BINDING_REQUIRED_MESSAGE);
+          Logger.warning(`[feishu_binding] 未找到绑定: sender=${msg.senderId}, chat=${msg.chatId}`);
+          return null;
+        }
+        return undefined;
+      }
+      return resolution;
+    } catch (error: any) {
+      Logger.warning(`[feishu_binding] 绑定查询失败: ${error?.message || error}`);
+      if (this.bindingResolver.required) {
+        await this.sender.reply(msg.chatId, '虚拟员工绑定查询失败，请稍后重试。');
+        return null;
+      }
+      return undefined;
+    }
   }
 
   /**

--- a/src/feishu/index.ts
+++ b/src/feishu/index.ts
@@ -477,7 +477,15 @@ export class FeishuBot {
   }
 
   private async resolveChannelAgentBinding(msg: ReturnType<MessageHandler['parse']>): Promise<ChannelAgentRouteBinding | undefined | null> {
-    if (!msg || !this.bindingResolver.enabled) return undefined;
+    if (!msg) return undefined;
+    if (!this.bindingResolver.enabled) {
+      if (this.bindingResolver.required) {
+        await this.sender.reply(msg.chatId, '虚拟员工绑定服务未配置，请联系管理员检查 CatsCo 绑定地址。');
+        Logger.warning(`[feishu_binding] required=true but resolver is disabled: sender=${msg.senderId}, chat=${msg.chatId}`);
+        return null;
+      }
+      return undefined;
+    }
     if (msg.chatType !== 'p2p') return undefined;
     try {
       const resolution = await this.bindingResolver.resolve({
@@ -486,7 +494,13 @@ export class FeishuBot {
         channelUserId: msg.senderId,
         channelConversationType: 'p2p',
       });
-      if (!resolution) return undefined;
+      if (!resolution) {
+        if (this.bindingResolver.required) {
+          await this.sender.reply(msg.chatId, '虚拟员工绑定查询失败，请稍后重试。');
+          return null;
+        }
+        return undefined;
+      }
       if (!resolution.bound) {
         if (this.bindingResolver.required) {
           await this.sender.reply(msg.chatId, CHANNEL_BINDING_REQUIRED_MESSAGE);

--- a/src/feishu/types.ts
+++ b/src/feishu/types.ts
@@ -10,6 +10,8 @@ export interface FeishuConfig {
   botOpenId?: string;
   /** 机器人别名（当未配置 botOpenId 时用于兜底匹配） */
   botAliases?: string[];
+  /** CatsCo channel binding resolver for QR-bound virtual employees */
+  channelAgentBinding?: import('../core/channel-agent-binding-resolver').ChannelAgentBindingResolverOptions;
   /** Bot Bridge 配置 */
   bridge?: {
     port: number;

--- a/src/tools/tool-gateway.ts
+++ b/src/tools/tool-gateway.ts
@@ -52,7 +52,7 @@ export function formatCatsCoVisiblePath(
   if (!text) return fallback;
   if (/^catsco_attachment:[A-Za-z0-9._:-]+$/.test(text)) return text;
   if (/^\[CatsCo [^\]]+\]$/.test(text)) return text;
-  if (options.preserveRelative && !looksLikeAbsoluteLocalPath(text)) return text;
+  if (options.preserveRelative && !looksLikeAbsoluteLocalPath(text) && isSafeRelativeDisplayPath(text)) return text;
   return fallback;
 }
 
@@ -285,18 +285,23 @@ function validateSelectionScope(
 }
 
 function matchesLocalDevice(selection: ScopedDeviceSelection, localDevice: ScopedLocalDeviceGrant): boolean {
-  const selectedIds = [
-    selection.selectedDeviceId,
-    selection.selectedDeviceInstallationId,
-    selection.selectedDeviceBodyId,
-  ].filter(Boolean);
-  const localIds = [
-    localDevice.deviceId,
-    localDevice.installationId,
-    localDevice.bodyId,
-  ].filter(Boolean);
-  if (selectedIds.length === 0 || localIds.length === 0) return false;
-  return selectedIds.some(selected => localIds.includes(selected));
+  let matchedStrongTarget = false;
+
+  if (selection.selectedDeviceId) {
+    if (!localDevice.deviceId || selection.selectedDeviceId !== localDevice.deviceId) return false;
+    matchedStrongTarget = true;
+  }
+
+  if (selection.selectedDeviceInstallationId) {
+    if (!localDevice.installationId || selection.selectedDeviceInstallationId !== localDevice.installationId) return false;
+    matchedStrongTarget = true;
+  }
+
+  if (selection.selectedDeviceBodyId) {
+    if (!localDevice.bodyId || selection.selectedDeviceBodyId !== localDevice.bodyId) return false;
+  }
+
+  return matchedStrongTarget;
 }
 
 function denied(lines: string[], targetLabel?: string): ToolGatewayDecision {
@@ -323,4 +328,9 @@ function looksLikeAbsoluteLocalPath(value: string): boolean {
     || /^\\\\/.test(value)
     || /^\//.test(value)
     || /^~[\\/]/.test(value);
+}
+
+function isSafeRelativeDisplayPath(value: string): boolean {
+  const normalized = value.replace(/\\/g, '/');
+  return normalized.split('/').every(segment => segment !== '..');
 }

--- a/src/weixin/index.ts
+++ b/src/weixin/index.ts
@@ -11,11 +11,16 @@ import { AdapterRuntimeBundle, createAdapterRuntime } from '../runtime/adapter-r
 import { promises as fs } from 'fs';
 import path from 'path';
 import {
+  ChannelAgentBindingResolver,
+  CHANNEL_BINDING_REQUIRED_MESSAGE,
+} from '../core/channel-agent-binding-resolver';
+import {
   createExecutionScopeFromRoute,
   createSessionRoute,
   createWeixinSessionRoute,
   parseSessionKeyV2,
 } from '../core/session-router';
+import type { ChannelAgentRouteBinding } from '../core/session-router';
 import type { SessionRoute } from '../types/session-identity';
 
 const CHANNEL_VERSION = 'xiaoba-weixin/1.0';
@@ -44,6 +49,8 @@ export class WeixinBot {
   private sessionManager: MessageSessionManager;
   private agentServices: AgentServices;
   private runtime: AdapterRuntimeBundle;
+  private bindingResolver: ChannelAgentBindingResolver;
+  private channelAppId: string;
   private contextTokens = new Map<string, string>();
   private messageQueue = new Map<string, QueuedMessage[]>();
   private isRunning = false;
@@ -58,6 +65,8 @@ export class WeixinBot {
     const runtime = createWeixinRuntime();
     this.runtime = runtime;
     this.agentServices = runtime.services;
+    this.bindingResolver = new ChannelAgentBindingResolver(config.channelAgentBinding);
+    this.channelAppId = config.channelAppId?.trim() || '';
 
     this.sessionManager = new MessageSessionManager(
       this.agentServices,
@@ -186,7 +195,10 @@ export class WeixinBot {
     const parsed = this.handler.parseMessage(msg);
     if (!parsed || this.handler.shouldIgnoreMessage(parsed)) return;
 
-    const route = createWeixinSessionRoute(parsed);
+    const routeBinding = await this.resolveChannelAgentBinding(parsed);
+    if (routeBinding === null) return;
+
+    const route = createWeixinSessionRoute(parsed, routeBinding);
     const sessionKey = route.sessionKey;
     const userId = route.actorUserId;
     if (msg.context_token) {
@@ -261,6 +273,37 @@ export class WeixinBot {
       await channel.reply(route.topicId, result.text);
     }
     await this.drainMessageQueue(sessionKey);
+  }
+
+  private async resolveChannelAgentBinding(message: WeixinMessage): Promise<ChannelAgentRouteBinding | undefined | null> {
+    if (!this.bindingResolver.enabled) return undefined;
+    const userId = message.from?.id?.trim();
+    if (!userId) return undefined;
+    try {
+      const resolution = await this.bindingResolver.resolve({
+        channel: 'weixin',
+        channelAppId: this.channelAppId || undefined,
+        channelUserId: userId,
+        channelConversationType: 'p2p',
+      });
+      if (!resolution) return undefined;
+      if (!resolution.bound) {
+        if (this.bindingResolver.required) {
+          await this.sender.sendText(userId, CHANNEL_BINDING_REQUIRED_MESSAGE, message.context_token);
+          Logger.warning(`[weixin_binding] 未找到绑定: user=${userId}`);
+          return null;
+        }
+        return undefined;
+      }
+      return resolution;
+    } catch (error: any) {
+      Logger.warning(`[weixin_binding] 绑定查询失败: ${error?.message || error}`);
+      if (this.bindingResolver.required) {
+        await this.sender.sendText(userId, '虚拟员工绑定查询失败，请稍后重试。', message.context_token);
+        return null;
+      }
+      return undefined;
+    }
   }
 
   private async handleSubAgentFeedback(

--- a/src/weixin/index.ts
+++ b/src/weixin/index.ts
@@ -276,9 +276,16 @@ export class WeixinBot {
   }
 
   private async resolveChannelAgentBinding(message: WeixinMessage): Promise<ChannelAgentRouteBinding | undefined | null> {
-    if (!this.bindingResolver.enabled) return undefined;
     const userId = message.from?.id?.trim();
     if (!userId) return undefined;
+    if (!this.bindingResolver.enabled) {
+      if (this.bindingResolver.required) {
+        await this.sender.sendText(userId, '虚拟员工绑定服务未配置，请联系管理员检查 CatsCo 绑定地址。', message.context_token);
+        Logger.warning(`[weixin_binding] required=true but resolver is disabled: user=${userId}`);
+        return null;
+      }
+      return undefined;
+    }
     try {
       const resolution = await this.bindingResolver.resolve({
         channel: 'weixin',
@@ -286,7 +293,13 @@ export class WeixinBot {
         channelUserId: userId,
         channelConversationType: 'p2p',
       });
-      if (!resolution) return undefined;
+      if (!resolution) {
+        if (this.bindingResolver.required) {
+          await this.sender.sendText(userId, '虚拟员工绑定查询失败，请稍后重试。', message.context_token);
+          return null;
+        }
+        return undefined;
+      }
       if (!resolution.bound) {
         if (this.bindingResolver.required) {
           await this.sender.sendText(userId, CHANNEL_BINDING_REQUIRED_MESSAGE, message.context_token);

--- a/src/weixin/types.ts
+++ b/src/weixin/types.ts
@@ -2,7 +2,9 @@ export interface WeixinConfig {
   token: string;
   baseUrl: string;
   cdnBaseUrl: string;
+  channelAppId?: string;
   stateDir?: string;
+  channelAgentBinding?: import('../core/channel-agent-binding-resolver').ChannelAgentBindingResolverOptions;
 }
 
 export interface WeixinMessage {

--- a/tests/catscompany-client-body-id.test.ts
+++ b/tests/catscompany-client-body-id.test.ts
@@ -394,6 +394,18 @@ describe('CatsCompany client body identity', () => {
               device_rpc: {
                 type: 'result',
                 request_id: msg.device_rpc.request_id,
+                grant_id: msg.device_rpc.grant_id,
+                session_key: msg.device_rpc.session_key,
+                topic_id: msg.device_rpc.topic_id,
+                topic_type: msg.device_rpc.topic_type,
+                actor_user_id: msg.device_rpc.actor_user_id,
+                agent_id: msg.device_rpc.agent_id,
+                agent_body_id: msg.device_rpc.agent_body_id,
+                device_id: msg.device_rpc.device_id,
+                device_body_id: msg.device_rpc.device_body_id,
+                device_installation_id: msg.device_rpc.device_installation_id,
+                operation: msg.device_rpc.operation,
+                tool_name: msg.device_rpc.tool_name,
                 result: { ok: true },
               },
             }));
@@ -469,6 +481,18 @@ describe('CatsCompany client body identity', () => {
             device_rpc: {
               type: 'result',
               request_id: msg.device_rpc.request_id,
+              grant_id: msg.device_rpc.grant_id,
+              session_key: msg.device_rpc.session_key,
+              topic_id: msg.device_rpc.topic_id,
+              topic_type: msg.device_rpc.topic_type,
+              actor_user_id: msg.device_rpc.actor_user_id,
+              agent_id: msg.device_rpc.agent_id,
+              agent_body_id: msg.device_rpc.agent_body_id,
+              device_id: msg.device_rpc.device_id,
+              device_body_id: msg.device_rpc.device_body_id,
+              device_installation_id: msg.device_rpc.device_installation_id,
+              operation: msg.device_rpc.operation,
+              tool_name: msg.device_rpc.tool_name,
               result: { ok: true },
             },
           }));
@@ -500,6 +524,78 @@ describe('CatsCompany client body identity', () => {
       /ack 500/
     );
     client.disconnect();
+  });
+
+  test('redacts and truncates device rpc recent errors in status snapshots', async () => {
+    const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    servers.push(server);
+    await new Promise<void>(resolve => server.once('listening', resolve));
+
+    server.once('connection', socket => {
+      socket.on('message', data => {
+        const msg = JSON.parse(data.toString());
+        if (msg.hi) {
+          socket.send(JSON.stringify({
+            ctrl: {
+              id: msg.hi.id,
+              code: 200,
+              params: {
+                build: 'catscompany',
+                ver: '0.1.0',
+                features: ['client_msg_id', 'device_rpc'],
+                uid: 'usr42',
+                name: 'Agent',
+              },
+            },
+          }));
+          return;
+        }
+        if (msg.device_rpc?.type === 'request') {
+          socket.send(JSON.stringify({
+            ctrl: {
+              id: msg.device_rpc.id,
+              code: 500,
+              text: `failed at C:/Users/alice/secret/project/file.txt with Bearer user-secret CATSCO_USER_TOKEN=very-secret ${'detail '.repeat(80)}`,
+            },
+          }));
+        }
+      });
+    });
+
+    const address = server.address() as AddressInfo;
+    const client = new CatsClient({
+      serverUrl: `ws://127.0.0.1:${address.port}`,
+      apiKey: 'cc-test-key',
+      bodyId: 'body-agent',
+      installationId: 'install-agent',
+    });
+    client.on('error', () => undefined);
+    await new Promise<void>(resolve => {
+      client.once('ready', () => resolve());
+      client.connect();
+    });
+
+    await assert.rejects(
+      () => client.sendDeviceRpcRequest({
+        request_id: 'rpc-redact-error',
+        grant_id: 'grant-1',
+        device_id: 'install-test',
+        operation: 'execute_shell',
+        tool_name: 'execute_shell',
+      }),
+      /ack 500/
+    );
+
+    const recentError = client.getStatusSnapshot().deviceRpc.recent.at(-1)?.error || '';
+    client.disconnect();
+
+    assert.ok(recentError.length <= 240);
+    assert.match(recentError, /\[redacted-path\]/);
+    assert.match(recentError, /Bearer \[redacted\]/);
+    assert.match(recentError, /CATSCO_USER_TOKEN=\[redacted\]/);
+    assert.equal(recentError.includes('secret/project/file.txt'), false);
+    assert.equal(recentError.includes('user-secret'), false);
+    assert.equal(recentError.includes('very-secret'), false);
   });
 
   test('rejects device rpc results whose scope does not match the pending request', async () => {
@@ -561,6 +657,77 @@ describe('CatsCompany client body identity', () => {
         request_id: 'rpc-scope-mismatch',
         grant_id: 'grant-1',
         device_id: 'install-test',
+        operation: 'read_file',
+        tool_name: 'read_file',
+      }),
+      /scope does not match/
+    );
+    client.disconnect();
+  });
+
+  test('rejects device rpc results that omit expected scope fields', async () => {
+    const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    servers.push(server);
+    await new Promise<void>(resolve => server.once('listening', resolve));
+
+    server.once('connection', socket => {
+      socket.on('message', data => {
+        const msg = JSON.parse(data.toString());
+        if (msg.hi) {
+          socket.send(JSON.stringify({
+            ctrl: {
+              id: msg.hi.id,
+              code: 200,
+              params: {
+                build: 'catscompany',
+                ver: '0.1.0',
+                features: ['client_msg_id', 'device_rpc'],
+                uid: 'usr42',
+                name: 'Agent',
+              },
+            },
+          }));
+          return;
+        }
+        if (msg.device_rpc?.type === 'request') {
+          socket.send(JSON.stringify({ ctrl: { id: msg.device_rpc.id, code: 200, text: 'ok' } }));
+          socket.send(JSON.stringify({
+            device_rpc: {
+              type: 'result',
+              request_id: msg.device_rpc.request_id,
+              result: { ok: true },
+            },
+          }));
+        }
+      });
+    });
+
+    const address = server.address() as AddressInfo;
+    const client = new CatsClient({
+      serverUrl: `ws://127.0.0.1:${address.port}`,
+      apiKey: 'cc-test-key',
+      bodyId: 'body-agent',
+      installationId: 'install-agent',
+    });
+    client.on('error', () => undefined);
+    await new Promise<void>(resolve => {
+      client.once('ready', () => resolve());
+      client.connect();
+    });
+
+    await assert.rejects(
+      () => client.sendDeviceRpcRequest({
+        request_id: 'rpc-missing-scope',
+        grant_id: 'grant-1',
+        session_key: 'session:v2:catscompany:p2p:p2p_7_42:agent:usr42',
+        topic_id: 'p2p_7_42',
+        topic_type: 'p2p',
+        actor_user_id: 'usr7',
+        agent_id: 'usr42',
+        agent_body_id: 'body-agent',
+        device_id: 'install-test',
+        device_body_id: 'body-device',
+        device_installation_id: 'install-test',
         operation: 'read_file',
         tool_name: 'read_file',
       }),

--- a/tests/catscompany-content-blocks.test.ts
+++ b/tests/catscompany-content-blocks.test.ts
@@ -407,11 +407,13 @@ describe('CatsCo content blocks', () => {
   test('sanitizes CatsCo image block metadata to use opaque references', async () => {
     const bot = Object.create(CatsCompanyBot.prototype) as any;
     const originalModel = process.env.GAUZ_LLM_MODEL;
+    const originalApiBase = process.env.GAUZ_LLM_API_BASE;
     const testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'catsco-image-ref-'));
     const localPath = path.join(testRoot, 'tmp', 'downloads', 'secret-image.png');
 
     try {
       process.env.GAUZ_LLM_MODEL = 'gpt-4o';
+      process.env.GAUZ_LLM_API_BASE = 'https://api.openai.com/v1';
       fs.mkdirSync(path.dirname(localPath), { recursive: true });
       fs.writeFileSync(
         localPath,
@@ -438,6 +440,11 @@ describe('CatsCo content blocks', () => {
         delete process.env.GAUZ_LLM_MODEL;
       } else {
         process.env.GAUZ_LLM_MODEL = originalModel;
+      }
+      if (originalApiBase === undefined) {
+        delete process.env.GAUZ_LLM_API_BASE;
+      } else {
+        process.env.GAUZ_LLM_API_BASE = originalApiBase;
       }
       fs.rmSync(testRoot, { recursive: true, force: true });
     }

--- a/tests/catscompany-device-rpc-tools.test.ts
+++ b/tests/catscompany-device-rpc-tools.test.ts
@@ -5,7 +5,11 @@ import * as path from 'path';
 import { CatsCompanyBot } from '../src/catscompany';
 import type { CatsDeviceRpcMessage } from '../src/catscompany/client';
 
-function botWithDevice(captured: { result?: any }): any {
+function botWithDevice(captured: { result?: any }, options: {
+  capabilities?: string[];
+  allowWriteFile?: boolean;
+  allowShell?: boolean;
+} = {}): any {
   const bot = Object.create(CatsCompanyBot.prototype) as any;
   bot.localDeviceGrant = {
     kind: 'catscompany_body',
@@ -15,6 +19,16 @@ function botWithDevice(captured: { result?: any }): any {
     deviceId: 'install-device',
     createdAt: Date.now(),
   };
+  bot.deviceRegistration = {
+    device_id: 'install-device',
+    display_name: 'Test Device',
+    body_id: 'body-device',
+    installation_id: 'install-device',
+    status: 'online',
+    capabilities: options.capabilities || ['read_file', 'glob', 'grep'],
+  };
+  bot.allowWriteFile = Boolean(options.allowWriteFile);
+  bot.allowShell = Boolean(options.allowShell);
   bot.bot = {
     sendDeviceRpcResult: async (result: any) => {
       captured.result = result;
@@ -69,7 +83,10 @@ describe('CatsCompany Device RPC tools', () => {
 
   test('executes write_file on the target local device when explicitly granted', async () => {
     const captured: { result?: any } = {};
-    const bot = botWithDevice(captured);
+    const bot = botWithDevice(captured, {
+      capabilities: ['read_file', 'glob', 'grep', 'write_file'],
+      allowWriteFile: true,
+    });
     const tmpRoot = path.join(process.cwd(), 'tmp');
     fs.mkdirSync(tmpRoot, { recursive: true });
     const dir = fs.mkdtempSync(path.join(tmpRoot, 'device-rpc-write-'));
@@ -86,6 +103,28 @@ describe('CatsCompany Device RPC tools', () => {
     assert.equal(captured.result.error, undefined);
     assert.equal(captured.result.result.ok, true);
     assert.equal(fs.readFileSync(filePath, 'utf-8'), 'hello from rpc write');
+  });
+
+  test('rejects write_file on the full runtime unless local capability is explicitly enabled', async () => {
+    const captured: { result?: any } = {};
+    const bot = botWithDevice(captured);
+    const tmpRoot = path.join(process.cwd(), 'tmp');
+    fs.mkdirSync(tmpRoot, { recursive: true });
+    const dir = fs.mkdtempSync(path.join(tmpRoot, 'device-rpc-write-denied-'));
+    const filePath = path.join(dir, 'created.txt');
+
+    await bot.handleDeviceRpcRequest(request({
+      request_id: 'rpc-write-denied-1',
+      operation: 'write_file',
+      tool_name: 'write_file',
+      payload: { args: { file_path: filePath, content: 'blocked' } },
+    }));
+
+    assert.ok(captured.result);
+    assert.equal(captured.result.result, undefined);
+    assert.equal(captured.result.error.code, 'PERMISSION_DENIED');
+    assert.match(captured.result.error.message, /未注册远程 write_file 能力|未显式开启远程写文件能力/);
+    assert.equal(fs.existsSync(filePath), false);
   });
 
   test('rejects unsupported Device RPC operations before local tool execution', async () => {
@@ -117,5 +156,22 @@ describe('CatsCompany Device RPC tools', () => {
     assert.ok(captured.result);
     assert.equal(captured.result.result, undefined);
     assert.equal(captured.result.error.code, 'target_device_mismatch');
+  });
+
+  test('returns a structured error when local Device RPC tool execution throws', async () => {
+    const captured: { result?: any } = {};
+    const bot = botWithDevice(captured);
+    bot.executeLocalDeviceRpcTool = async () => {
+      throw new Error('boom from local tool');
+    };
+
+    await bot.handleDeviceRpcRequest(request({ request_id: 'rpc-throw-1' }));
+
+    assert.ok(captured.result);
+    assert.equal(captured.result.result, undefined);
+    assert.equal(captured.result.error.code, 'tool_execution_error');
+    assert.match(captured.result.error.message, /boom from local tool/);
+    assert.equal(captured.result.grant_id, 'grant-read-1');
+    assert.equal(captured.result.device_id, 'install-device');
   });
 });

--- a/tests/catscompany-execution-scope-flow.test.ts
+++ b/tests/catscompany-execution-scope-flow.test.ts
@@ -208,6 +208,60 @@ describe('CatsCompany execution scope flow', () => {
     assert.deepEqual(handledTurns[0].options.deviceGrants[0].operations, ['read_file', 'send_file']);
   });
 
+  test('passes delegated channel device grants while preserving the channel actor', async () => {
+    const { bot, handledTurns } = createHarness();
+
+    await (bot as any).onMessage({
+      topic: 'p2p_100_43',
+      senderId: 'usr100',
+      text: '读一下我的电脑文件',
+      content: '读一下我的电脑文件',
+      metadata: metadataWithDeviceGrants('usr100', 'p2p_100_43', [
+        deviceGrant({
+          ownerUserId: 'usr7',
+          actorUserId: 'usr100',
+          identitySource: 'channel_identity_link',
+          sessionKey: 'session:v2:catscompany:p2p:p2p_100_43:agent:usr43',
+          topicId: 'p2p_100_43',
+        }),
+      ]),
+      isGroup: false,
+      seq: 12,
+    });
+
+    assert.equal(handledTurns.length, 1);
+    assert.equal(handledTurns[0].options.executionScope.actorUserId, 'usr100');
+    assert.equal(handledTurns[0].options.deviceGrants?.length, 1);
+    assert.equal(handledTurns[0].options.deviceGrants[0].ownerUserId, 'usr7');
+    assert.equal(handledTurns[0].options.deviceGrants[0].actorUserId, 'usr100');
+    assert.equal(handledTurns[0].options.deviceGrants[0].identitySource, 'channel_identity_link');
+  });
+
+  test('drops owner mismatch device grants without a delegated channel source', async () => {
+    const { bot, handledTurns } = createHarness();
+
+    await (bot as any).onMessage({
+      topic: 'p2p_100_43',
+      senderId: 'usr100',
+      text: '读一下我的电脑文件',
+      content: '读一下我的电脑文件',
+      metadata: metadataWithDeviceGrants('usr100', 'p2p_100_43', [
+        deviceGrant({
+          ownerUserId: 'usr7',
+          actorUserId: 'usr100',
+          identitySource: 'metadata.catsco_identity',
+          sessionKey: 'session:v2:catscompany:p2p:p2p_100_43:agent:usr43',
+          topicId: 'p2p_100_43',
+        }),
+      ]),
+      isGroup: false,
+      seq: 12,
+    });
+
+    assert.equal(handledTurns.length, 1);
+    assert.equal(handledTurns[0].options.deviceGrants, undefined);
+  });
+
   test('passes server canonical device selection into CatsCompany session turn', async () => {
     const { bot, handledTurns } = createHarness();
 
@@ -262,6 +316,8 @@ describe('CatsCompany execution scope flow', () => {
       metadata: metadataWithDeviceGrants('usr7', 'p2p_7_43', [
         deviceGrant({ actorUserId: 'usr8' }),
         deviceGrant({ agentBodyId: 'body-other' }),
+        deviceGrant({ status: 'revoked' }),
+        deviceGrant({ status: undefined }),
       ]),
       isGroup: false,
       seq: 12,

--- a/tests/channel-agent-binding-resolver.test.ts
+++ b/tests/channel-agent-binding-resolver.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import {
+  ChannelAgentBindingResolver,
+  resolveChannelAgentBindingOptions,
+} from '../src/core/channel-agent-binding-resolver';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('ChannelAgentBindingResolver', () => {
+  test('only enables when explicitly enabled and a binding base URL is configured', () => {
+    assert.equal(new ChannelAgentBindingResolver({ enabled: true }).enabled, false);
+    assert.equal(new ChannelAgentBindingResolver({
+      enabled: true,
+      httpBaseUrl: 'https://app.catsco.cc/',
+    }).enabled, true);
+  });
+
+  test('resolves env options with CatsCo and CatsCompany names', () => {
+    const catsco = resolveChannelAgentBindingOptions({
+      CATSCO_CHANNEL_BINDING_HTTP_BASE_URL: 'https://app.catsco.cc/',
+      CATSCO_CHANNEL_AGENT_BINDING_ENABLED: 'true',
+      CATSCO_CHANNEL_AGENT_BINDING_REQUIRED: 'yes',
+      CATSCO_CHANNEL_BINDING_TOKEN: 'secret',
+      CATSCO_CHANNEL_BINDING_TIMEOUT_MS: '1200',
+    });
+    assert.deepEqual(catsco, {
+      httpBaseUrl: 'https://app.catsco.cc/',
+      token: 'secret',
+      enabled: true,
+      required: true,
+      timeoutMs: 1200,
+    });
+
+    const legacy = resolveChannelAgentBindingOptions({
+      CATSCOMPANY_CHANNEL_BINDING_HTTP_BASE_URL: 'https://legacy.catsco.cc',
+      CATSCOMPANY_CHANNEL_AGENT_BINDING_ENABLED: '1',
+    });
+    assert.equal(legacy.httpBaseUrl, 'https://legacy.catsco.cc');
+    assert.equal(legacy.enabled, true);
+  });
+
+  test('sends channel identity query with bearer token and maps bound response', async () => {
+    const calls: Array<{ url: URL; auth?: string }> = [];
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      calls.push({
+        url: new URL(String(input)),
+        auth: String(init?.headers && (init.headers as Record<string, string>).Authorization || ''),
+      });
+      return new Response(JSON.stringify({
+        bound: true,
+        agent_uid: 43,
+        agent_id: 'usr43',
+        agent_body_id: 'body-contract',
+        owner_uid: 7,
+        identity_trust: 'server_canonical',
+        identity_source: 'channel_agent_binding',
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    }) as typeof fetch;
+
+    const resolver = new ChannelAgentBindingResolver({
+      enabled: true,
+      httpBaseUrl: 'https://app.catsco.cc/',
+      token: 'secret',
+    });
+    const resolved = await resolver.resolve({
+      channel: 'feishu',
+      channelAppId: 'cli_app',
+      channelUserId: 'ou_user',
+      channelConversationId: 'oc_chat',
+      channelConversationType: 'p2p',
+    });
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].url.pathname, '/api/channel-agent-bindings/resolve');
+    assert.equal(calls[0].url.searchParams.get('channel'), 'feishu');
+    assert.equal(calls[0].url.searchParams.get('channel_app_id'), 'cli_app');
+    assert.equal(calls[0].url.searchParams.get('channel_user_id'), 'ou_user');
+    assert.equal(calls[0].url.searchParams.get('channel_conversation_id'), 'oc_chat');
+    assert.equal(calls[0].url.searchParams.get('channel_conversation_type'), 'p2p');
+    assert.equal(calls[0].auth, 'Bearer secret');
+    assert.deepEqual(resolved, {
+      bound: true,
+      agentUid: 43,
+      ownerUid: 7,
+      agentId: 'usr43',
+      agentBodyId: 'body-contract',
+      identityTrust: 'server_canonical',
+      identitySource: 'channel_agent_binding',
+    });
+  });
+
+  test('returns unbound and rejects malformed bound responses', async () => {
+    globalThis.fetch = (async () => new Response(JSON.stringify({ bound: false }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })) as typeof fetch;
+    const resolver = new ChannelAgentBindingResolver({
+      enabled: true,
+      httpBaseUrl: 'https://app.catsco.cc',
+    });
+    assert.deepEqual(await resolver.resolve({
+      channel: 'weixin',
+      channelUserId: 'openid',
+    }), { bound: false });
+
+    globalThis.fetch = (async () => new Response(JSON.stringify({ bound: true }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })) as typeof fetch;
+    await assert.rejects(
+      resolver.resolve({ channel: 'weixin', channelUserId: 'openid' }),
+      /missing agent_id/,
+    );
+  });
+});

--- a/tests/channel-agent-binding-resolver.test.ts
+++ b/tests/channel-agent-binding-resolver.test.ts
@@ -14,10 +14,24 @@ afterEach(() => {
 describe('ChannelAgentBindingResolver', () => {
   test('only enables when explicitly enabled and a binding base URL is configured', () => {
     assert.equal(new ChannelAgentBindingResolver({ enabled: true }).enabled, false);
+    assert.equal(new ChannelAgentBindingResolver({ required: true }).enabled, false);
+    assert.equal(new ChannelAgentBindingResolver({ required: true }).misconfiguredRequired, true);
     assert.equal(new ChannelAgentBindingResolver({
       enabled: true,
       httpBaseUrl: 'https://app.catsco.cc/',
     }).enabled, true);
+    assert.equal(new ChannelAgentBindingResolver({
+      required: true,
+      httpBaseUrl: 'https://app.catsco.cc/',
+    }).enabled, true);
+  });
+
+  test('fails closed when binding is required but base URL is missing', async () => {
+    const resolver = new ChannelAgentBindingResolver({ required: true });
+    await assert.rejects(
+      resolver.resolve({ channel: 'feishu', channelUserId: 'ou_user' }),
+      /required.*HTTP_BASE_URL/i,
+    );
   });
 
   test('resolves env options with CatsCo and CatsCompany names', () => {

--- a/tests/dashboard-device-connector-link-api.test.ts
+++ b/tests/dashboard-device-connector-link-api.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import * as assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import express from 'express';
+import type { Server } from 'node:http';
+import { createApiRouter } from '../src/dashboard/routes/api';
+import type { ServiceInfo } from '../src/dashboard/service-manager';
+import { createCatsCoLocalConfigService } from '../src/catscompany/local-config';
+
+describe('dashboard device connector pairing link API', () => {
+  let originalCwd: string;
+  let testRoot: string;
+  let server: Server | undefined;
+  let baseUrl: string;
+  let originalFetch: typeof fetch;
+  let fetchCalls: Array<{ url: string; body: any }>;
+  let service: ServiceInfo;
+  let startCalls: string[];
+  const originalEnv: Record<string, string | undefined> = {};
+  const envKeys = ['XIAOBA_CONFIG_PATH', 'XIAOBA_RUNTIME_PROFILE_PATH'];
+
+  beforeEach(async () => {
+    originalCwd = process.cwd();
+    testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-device-link-api-'));
+    process.chdir(testRoot);
+    for (const key of envKeys) {
+      originalEnv[key] = process.env[key];
+    }
+    process.env.XIAOBA_CONFIG_PATH = path.join(testRoot, 'config.json');
+    process.env.XIAOBA_RUNTIME_PROFILE_PATH = path.join(testRoot, 'runtime-profile.json');
+
+    fetchCalls = [];
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: any, init?: any) => {
+      fetchCalls.push({
+        url: String(url),
+        body: init?.body ? JSON.parse(String(init.body)) : undefined,
+      });
+      return new Response(JSON.stringify({
+        connector_token: 'connector-token-1',
+        expires_in: 3600,
+        device: {
+          device_id: 'dev-1',
+          installation_id: 'install-1',
+          display_name: 'Office PC',
+          owner_user_id: 'user-1',
+          capabilities: ['read_file', 'glob', 'grep'],
+        },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as typeof fetch;
+
+    service = {
+      name: 'device-connector',
+      label: 'CatsCo Device Connector',
+      command: 'node',
+      args: ['dist/index.js', 'device-connector'],
+      status: 'stopped',
+    };
+    startCalls = [];
+    const app = express();
+    app.use(express.json());
+    app.use('/api', createApiRouter({
+      getAll: () => [service],
+      getService: () => service,
+      start: (name: string) => {
+        startCalls.push(name);
+        service = { ...service, status: 'running', pid: 1001, startedAt: Date.now() };
+        return service;
+      },
+      restart: (name: string) => {
+        startCalls.push(`restart:${name}`);
+        service = { ...service, status: 'running', pid: 1002, startedAt: Date.now() };
+        return service;
+      },
+      stop: () => service,
+      getLogs: () => [],
+    } as any));
+    server = await listen(app);
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('server did not bind');
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = originalFetch;
+    if (server) {
+      await new Promise<void>(resolve => server!.close(() => resolve()));
+      server = undefined;
+    }
+    process.chdir(originalCwd);
+    for (const key of envKeys) {
+      if (originalEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = originalEnv[key];
+    }
+    fs.rmSync(testRoot, { recursive: true, force: true });
+  });
+
+  test('pairs and starts the saved connector without echoing the pairing code', async () => {
+    const response = await originalFetch(`${baseUrl}/api/cats/device-connector/pair`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        code: 'PAIR123456',
+        http_base_url: 'https://app.catsco.cc',
+        server_url: 'wss://app.catsco.cc/v0/channels',
+      }),
+    });
+    const body = await response.json() as any;
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(startCalls, ['device-connector']);
+    assert.equal(fetchCalls[0].url, 'https://app.catsco.cc/api/device-connectors/enroll');
+    assert.equal(fetchCalls[0].body.pairing_code, 'PAIR123456');
+    assert.equal(fetchCalls[0].body.capabilities.includes('execute_shell'), false);
+    assert.equal(body.connectorStarted, true);
+    assert.equal(JSON.stringify(body).includes('PAIR123456'), false);
+
+    const local = createCatsCoLocalConfigService({ runtimeRoot: testRoot }).load();
+    assert.equal(local.deviceConnector?.token, 'connector-token-1');
+    assert.equal(local.deviceConnector?.deviceId, 'dev-1');
+    assert.deepEqual(local.deviceConnector?.capabilities, ['read_file', 'glob', 'grep']);
+  });
+
+  test('restarts the connector when pairing arrives while it is already running', async () => {
+    service = { ...service, status: 'running', pid: 999 };
+
+    const response = await originalFetch(`${baseUrl}/api/cats/device-connector/pair`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ code: 'PAIR654321' }),
+    });
+    const body = await response.json() as any;
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(startCalls, ['restart:device-connector']);
+    assert.equal(body.connectorRestarted, true);
+  });
+
+  test('rejects malformed pairing codes before calling the platform', async () => {
+    const response = await originalFetch(`${baseUrl}/api/cats/device-connector/pair`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ code: 'bad code with spaces' }),
+    });
+
+    assert.equal(response.status, 400);
+    assert.equal(fetchCalls.length, 0);
+    assert.deepEqual(startCalls, []);
+  });
+
+  test('auto-starts an already paired connector on desktop launch', async () => {
+    createCatsCoLocalConfigService({ runtimeRoot: testRoot }).writeDeviceConnectorEnrollment({
+      httpBaseUrl: 'https://app.catsco.cc',
+      serverUrl: 'wss://app.catsco.cc/v0/channels',
+    }, {
+      token: 'saved-token',
+      deviceId: 'saved-device',
+      installationId: 'saved-install',
+      capabilities: ['read_file', 'glob', 'grep'],
+    });
+
+    const response = await originalFetch(`${baseUrl}/api/cats/device-connector/ensure-running`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+    const body = await response.json() as any;
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(startCalls, ['device-connector']);
+    assert.equal(body.connectorStarted, true);
+  });
+
+  test('does not auto-start before a device is paired', async () => {
+    const response = await originalFetch(`${baseUrl}/api/cats/device-connector/ensure-running`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+    const body = await response.json() as any;
+
+    assert.equal(response.status, 409);
+    assert.equal(body.reason, 'DEVICE_CONNECTOR_NOT_PAIRED');
+    assert.deepEqual(startCalls, []);
+  });
+});
+
+function listen(app: express.Express): Promise<Server> {
+  return new Promise(resolve => {
+    const server = app.listen(0, '127.0.0.1', () => resolve(server));
+  });
+}

--- a/tests/device-grants.test.ts
+++ b/tests/device-grants.test.ts
@@ -101,6 +101,8 @@ describe('device grants', () => {
     assert.equal(createDeviceGrant(scope(), device(), { operations: [] }), undefined);
     assert.equal(createDeviceGrant(scope(), device({ source: 'feishu' }), { operations: ['read_file'] }), undefined);
     assert.equal(createDeviceGrant(scope(), device({ ownerUserId: 'usr8' }), { operations: ['read_file'] }), undefined);
+    assert.equal(createDeviceGrant(scope(), device({ identityTrust: 'untrusted' }), { operations: ['read_file'] }), undefined);
+    assert.equal(createDeviceGrant(scope(), device({ status: 'offline' }), { operations: ['read_file'] }), undefined);
   });
 
   test('resolves a matching grant by operation and optional target device', () => {
@@ -169,7 +171,8 @@ describe('device grants', () => {
       ['expired', grant({ expiresAt: 2_000 }), /已过期/],
       ['operation', grant({ operations: ['send_file'] }), /不允许执行 read_file/],
       ['target device', grant(), /目标设备不一致/],
-      ['untrusted', grant({ identityTrust: 'untrusted' }), /未可信身份/],
+      ['untrusted', grant({ identityTrust: 'untrusted' }), /不是服务端可信身份/],
+      ['legacy', grant({ identityTrust: 'legacy_context' }), /不是服务端可信身份/],
     ];
 
     for (const [name, candidate, messagePattern] of cases) {
@@ -192,7 +195,6 @@ describe('device grants', () => {
       ['topicId', { topicId: 'grp_81' }],
       ['topicType', { topicType: 'p2p' }],
       ['actorUserId', { actorUserId: 'usr8', ownerUserId: 'usr8' }],
-      ['ownerUserId', { ownerUserId: 'usr8' }],
       ['agentId', { agentId: 'usr99' }],
       ['agentBodyId', { agentBodyId: 'body-other' }],
     ];
@@ -207,6 +209,52 @@ describe('device grants', () => {
 
       assert.equal(decision.ok, false, field);
       if (!decision.ok) assert.match(decision.message, new RegExp(field), field);
+    }
+  });
+
+  test('accepts delegated channel grants where device owner differs from actor', () => {
+    const decision = validateDeviceGrant({
+      executionScope: scope({ actorUserId: 'usr100' }),
+    }, grant({
+      ownerUserId: 'usr7',
+      actorUserId: 'usr100',
+      identitySource: 'channel_identity_link',
+    }), {
+      operation: 'read_file',
+      now: 2_000,
+    });
+
+    assert.equal(decision.ok, true);
+    if (decision.ok) {
+      assert.equal(decision.grant.ownerUserId, 'usr7');
+      assert.equal(decision.grant.actorUserId, 'usr100');
+    }
+  });
+
+  test('rejects owner mismatch grants without an explicit trusted channel delegation source', () => {
+    const candidates: Array<[string, Partial<ScopedDeviceGrant>]> = [
+      ['missing identitySource', { identitySource: undefined }],
+      ['plain metadata source', { identitySource: 'metadata.catsco_identity' }],
+      ['device rpc forward source', { identitySource: 'device_rpc_forward' }],
+      ['legacy delegated source', { identitySource: 'channel_identity_link', identityTrust: 'legacy_context' }],
+    ];
+
+    for (const [name, overrides] of candidates) {
+      const decision = validateDeviceGrant({
+        executionScope: scope({ actorUserId: 'usr100' }),
+      }, grant({
+        ownerUserId: 'usr7',
+        actorUserId: 'usr100',
+        ...overrides,
+      }), {
+        operation: 'read_file',
+        now: 2_000,
+      });
+
+      assert.equal(decision.ok, false, name);
+      if (!decision.ok) {
+        assert.match(decision.message, /owner|可信身份|委托/, name);
+      }
     }
   });
 });

--- a/tests/electron-main-dashboard-url.test.ts
+++ b/tests/electron-main-dashboard-url.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import test from 'node:test';
 
 const electronMain = readFileSync(join(process.cwd(), 'electron/main.js'), 'utf-8');
+const packageJson = JSON.parse(readFileSync(join(process.cwd(), 'package.json'), 'utf-8'));
 
 test('electron opens the local dashboard through stable IPv4 loopback', () => {
   assert.match(electronMain, /mainWindow\.loadURL\(`http:\/\/127\.0\.0\.1:\$\{DASHBOARD_PORT\}`\)/);
@@ -46,4 +47,25 @@ test('electron tray uses app icons and notifies after background hide', () => {
   assert.match(electronMain, /tray\.displayBalloon/);
   assert.match(electronMain, /CatsCo 已在后台运行/);
   assert.match(electronMain, /notifyWindowHidden\(\)/);
+});
+
+test('electron registers and handles CatsCo device connector deep links', () => {
+  assert.match(electronMain, /const DEEP_LINK_PROTOCOL = 'catsco'/);
+  assert.match(electronMain, /app\.requestSingleInstanceLock\(\)/);
+  assert.match(electronMain, /app\.setAsDefaultProtocolClient\(DEEP_LINK_PROTOCOL/);
+  assert.match(electronMain, /app\.on\('second-instance'/);
+  assert.match(electronMain, /app\.on\('open-url'/);
+  assert.match(electronMain, /url\.hostname !== 'device-connector' \|\| url\.pathname !== '\/pair'/);
+  assert.match(electronMain, /postLocalDashboardJson\('\/api\/cats\/device-connector\/pair'/);
+  assert.match(electronMain, /postLocalDashboardJson\('\/api\/cats\/device-connector\/ensure-running'/);
+  assert.match(electronMain, /app\.setLoginItemSettings\(\{ openAtLogin: true, openAsHidden: true \}\)/);
+});
+
+test('packaged app declares the CatsCo URL protocol', () => {
+  assert.deepEqual(packageJson.build.protocols, [
+    {
+      name: 'CatsCo Link',
+      schemes: ['catsco'],
+    },
+  ]);
 });

--- a/tests/feishu-session-route.test.ts
+++ b/tests/feishu-session-route.test.ts
@@ -130,6 +130,35 @@ describe('Feishu SessionRoute V2', () => {
     assert.match(replies[0], /入口码|绑定/);
   });
 
+  test('does not create a model session when required channel binding resolver is disabled or returns empty', async () => {
+    for (const bindingResolver of [
+      { enabled: false, required: true },
+      { enabled: true, required: true, resolve: async () => undefined },
+    ]) {
+      const replies: string[] = [];
+      const bot = createHarness({
+        replies,
+        bindingResolver,
+        message: {
+          messageId: `msg-binding-disabled-${replies.length}`,
+          chatId: 'shared',
+          chatType: 'p2p',
+          senderId: 'shared',
+          text: 'hello',
+          mentionBot: false,
+          msgType: 'text',
+        },
+      });
+
+      await (bot as any).onMessage({});
+
+      assert.deepEqual(bot.createdSessions, []);
+      assert.equal(bot.handledTurns.length, 0);
+      assert.equal(replies.length, 1);
+      assert.match(replies[0], /绑定|配置|失败/);
+    }
+  });
+
   test('uses resolved channel binding as the Feishu agent session route', async () => {
     const bot = createHarness({
       bindingResolver: {

--- a/tests/feishu-session-route.test.ts
+++ b/tests/feishu-session-route.test.ts
@@ -68,9 +68,111 @@ describe('Feishu SessionRoute V2', () => {
       SubAgentManager.getInstance().unregisterPlatformCallbacks('session:v2:feishu:group:oc_group');
     }
   });
+
+  test('does not apply QR channel binding to Feishu group messages yet', async () => {
+    const bot = createHarness({
+      bindingResolver: {
+        enabled: true,
+        required: true,
+        resolve: async () => {
+          throw new Error('group binding should not be resolved in this PR');
+        },
+      },
+      message: {
+        messageId: 'msg-group-binding-skipped',
+        chatId: 'oc_group',
+        chatType: 'group',
+        senderId: 'ou_user',
+        text: '@bot 看一下',
+        mentionBot: true,
+        msgType: 'text',
+      },
+    });
+
+    try {
+      await (bot as any).onMessage({});
+
+      const sessionKey = 'session:v2:feishu:group:oc_group';
+      assert.deepEqual(bot.createdSessions, [sessionKey]);
+      assert.equal(bot.handledTurns.length, 1);
+      assert.equal(bot.handledTurns[0].options.sessionRoute.sessionKey, sessionKey);
+      assert.equal(bot.handledTurns[0].options.executionScope.topicType, 'group');
+    } finally {
+      SubAgentManager.getInstance().unregisterPlatformCallbacks('session:v2:feishu:group:oc_group');
+    }
+  });
+
+  test('does not create a model session when channel binding is required but missing', async () => {
+    const replies: string[] = [];
+    const bot = createHarness({
+      replies,
+      bindingResolver: {
+        enabled: true,
+        required: true,
+        resolve: async () => ({ bound: false }),
+      },
+      message: {
+        messageId: 'msg-binding-missing',
+        chatId: 'shared',
+        chatType: 'p2p',
+        senderId: 'shared',
+        text: 'hello',
+        mentionBot: false,
+        msgType: 'text',
+      },
+    });
+
+    await (bot as any).onMessage({});
+
+    assert.deepEqual(bot.createdSessions, []);
+    assert.equal(bot.handledTurns.length, 0);
+    assert.equal(replies.length, 1);
+    assert.match(replies[0], /入口码|绑定/);
+  });
+
+  test('uses resolved channel binding as the Feishu agent session route', async () => {
+    const bot = createHarness({
+      bindingResolver: {
+        enabled: true,
+        required: true,
+        resolve: async () => ({
+          bound: true,
+          agentId: 'usr43',
+          agentBodyId: 'body-contract',
+          identityTrust: 'server_canonical',
+          identitySource: 'channel_agent_binding',
+        }),
+      },
+      message: {
+        messageId: 'msg-binding-ok',
+        chatId: 'shared',
+        chatType: 'p2p',
+        senderId: 'ou_user',
+        text: '查合同',
+        mentionBot: false,
+        msgType: 'text',
+      },
+    });
+
+    try {
+      await (bot as any).onMessage({});
+
+      const sessionKey = 'session:v2:feishu:p2p:shared:agent:usr43';
+      assert.deepEqual(bot.createdSessions, [sessionKey]);
+      assert.equal(bot.handledTurns.length, 1);
+      assert.equal(bot.handledTurns[0].options.sessionRoute.agentId, 'usr43');
+      assert.equal(bot.handledTurns[0].options.sessionRoute.agentBodyId, 'body-contract');
+      assert.equal(bot.handledTurns[0].options.sessionRoute.identityTrust, 'server_canonical');
+      assert.equal(bot.handledTurns[0].options.executionScope.agentId, 'usr43');
+      assert.equal(bot.handledTurns[0].options.executionScope.agentBodyId, 'body-contract');
+      assert.equal(bot.handledTurns[0].options.executionScope.isTrusted, true);
+    } finally {
+      SubAgentManager.getInstance().unregisterPlatformCallbacks('session:v2:feishu:p2p:shared:agent:usr43');
+    }
+  });
 });
 
-function createHarness(options: { busy?: boolean; message: any }): any {
+function createHarness(options: { busy?: boolean; message: any; bindingResolver?: any; replies?: string[] }): any {
   const bot = Object.create(FeishuBot.prototype) as any;
   bot.sessionBusy = options.busy ?? false;
   bot.createdSessions = [] as string[];
@@ -82,6 +184,8 @@ function createHarness(options: { busy?: boolean; message: any }): any {
   bot.messageQueue = new Map();
   bot.bridgeClient = null;
   bot.bridgeConfig = undefined;
+  bot.channelAppId = 'cli_app';
+  bot.bindingResolver = options.bindingResolver || { enabled: false, required: false };
   bot.handler = {
     parse: () => options.message,
   };
@@ -104,7 +208,9 @@ function createHarness(options: { busy?: boolean; message: any }): any {
     },
   };
   bot.sender = {
-    reply: async () => undefined,
+    reply: async (_chatId: string, text: string) => {
+      options.replies?.push(text);
+    },
     downloadFile: async () => null,
     fetchMergeForwardTexts: async () => '',
     sendFile: async () => undefined,

--- a/tests/grep-tool.test.ts
+++ b/tests/grep-tool.test.ts
@@ -179,12 +179,17 @@ describe('GrepTool', () => {
 
   describe('安全性检查', () => {
     test('应该处理工作目录外的路径并返回错误', async () => {
+      const outsideMissingPath = path.join(
+        os.tmpdir(),
+        `grep-outside-missing-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+        'missing.txt'
+      );
       const result = await grepTool.execute({
         pattern: 'test',
-        path: '../../etc/passwd'
+        path: outsideMissingPath
       }, context);
 
-      // 由于路径不存在，应该返回错误
+      // 由于路径在工作目录外且不存在，应该返回错误
       assert.ok(!result.ok, '应该返回错误');
       assert.ok(result.message.includes('目录不存在') || result.message.includes('rg') || result.message.includes('grep'),
         `错误信息应该有用，实际: ${result.message}`);

--- a/tests/session-route-v2.test.ts
+++ b/tests/session-route-v2.test.ts
@@ -95,4 +95,53 @@ describe('SessionRoute V2', () => {
     assert.equal(route.actorUserId, 'ResearchBot');
     assert.equal(route.topicType, 'group');
   });
+
+  test('keeps channel users isolated by QR-bound agent id', () => {
+    const feishuContract = createFeishuSessionRoute({
+      messageId: 'msg-feishu-1',
+      chatId: 'oc_p2p',
+      chatType: 'p2p',
+      senderId: 'ou_user',
+      text: '查合同',
+      mentionBot: false,
+      msgType: 'text',
+    }, {
+      agentId: 'usr43',
+      agentBodyId: 'body-contract',
+      identityTrust: 'server_canonical',
+      identitySource: 'channel_agent_binding',
+    });
+    const feishuFinance = createFeishuSessionRoute({
+      messageId: 'msg-feishu-2',
+      chatId: 'oc_p2p',
+      chatType: 'p2p',
+      senderId: 'ou_user',
+      text: '查发票',
+      mentionBot: false,
+      msgType: 'text',
+    }, {
+      agentId: 'usr99',
+      identityTrust: 'server_canonical',
+      identitySource: 'channel_agent_binding',
+    });
+    const weixinContract = createWeixinSessionRoute({
+      message_id: 'msg-weixin-1',
+      from: { id: 'openid-user' },
+      chat: { id: 'bot' },
+      text: '查合同',
+      context_token: 'ctx',
+    }, {
+      agentId: 'usr43',
+      identityTrust: 'server_canonical',
+      identitySource: 'channel_agent_binding',
+    });
+
+    assert.equal(feishuContract.sessionKey, 'session:v2:feishu:p2p:oc_p2p:agent:usr43');
+    assert.equal(feishuFinance.sessionKey, 'session:v2:feishu:p2p:oc_p2p:agent:usr99');
+    assert.notEqual(feishuContract.sessionKey, feishuFinance.sessionKey);
+    assert.equal(feishuContract.agentBodyId, 'body-contract');
+    assert.equal(feishuContract.identityTrust, 'server_canonical');
+    assert.equal(feishuContract.identitySource, 'channel_agent_binding');
+    assert.equal(weixinContract.sessionKey, 'session:v2:weixin:p2p:openid-user:agent:usr43');
+  });
 });

--- a/tests/tool-gateway-catsco.test.ts
+++ b/tests/tool-gateway-catsco.test.ts
@@ -164,6 +164,28 @@ describe('CatsCo ToolGateway', () => {
     assert.match(String(result.content), /selected content/);
   });
 
+  test('does not execute locally when selected device identifiers conflict with the current device', async () => {
+    const root = makeWorkspace();
+    const filePath = path.join(root, 'notes.txt');
+    fs.writeFileSync(filePath, 'must not be read locally');
+
+    const result = await new ReadTool().execute({ file_path: filePath }, context(root, {
+      deviceGrants: [deviceGrant(['read_file'])],
+      deviceSelection: deviceSelection({
+        selectedDeviceId: 'install-device',
+        selectedDeviceBodyId: 'body-other',
+        selectedDeviceInstallationId: 'install-device',
+      }),
+    }));
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.errorCode, 'PERMISSION_DENIED');
+      assert.match(result.message, /远程设备 RPC 通道/);
+      assert.doesNotMatch(result.message, new RegExp(escapeRegExp(filePath)));
+    }
+  });
+
   test('blocks device tools when backend requires device selection first', async () => {
     const root = makeWorkspace();
     const filePath = path.join(root, 'notes.txt');
@@ -373,6 +395,14 @@ describe('CatsCo ToolGateway', () => {
     assert.match(String(outsideGrep.content), /outside needle/);
     assert.doesNotMatch(String(outsideGrep.content), /\.\.\//);
     assert.doesNotMatch(String(outsideGrep.content), new RegExp(escapeRegExp(outsideRoot)));
+
+    const relativeOutsidePath = path.relative(root, outsideFile);
+    const outsideRelativeGrep = await new GrepTool().execute({ pattern: 'needle', path: relativeOutsidePath, output_mode: 'content' }, ctx);
+    assert.equal(outsideRelativeGrep.ok, true);
+    assert.match(String(outsideRelativeGrep.content), /outside needle/);
+    assert.doesNotMatch(String(outsideRelativeGrep.content), /\.\.\//);
+    assert.doesNotMatch(String(outsideRelativeGrep.content), new RegExp(escapeRegExp(relativeOutsidePath)));
+    assert.doesNotMatch(String(outsideRelativeGrep.content), new RegExp(escapeRegExp(outsideRoot)));
 
     const write = await new WriteTool().execute({ file_path: outPath, content: 'after' }, ctx);
     assert.equal(write.ok, true);

--- a/tests/weixin-session-route.test.ts
+++ b/tests/weixin-session-route.test.ts
@@ -118,6 +118,39 @@ describe('Weixin SessionRoute V2', () => {
     assert.match(sentTexts[0].text, /入口码|绑定/);
   });
 
+  test('does not create a model session when required channel binding resolver is disabled or returns empty', async () => {
+    for (const bindingResolver of [
+      { enabled: false, required: true },
+      { enabled: true, required: true, resolve: async () => undefined },
+    ]) {
+      const sentTexts: Array<{ userId: string; text: string; contextToken?: string }> = [];
+      const bot = createHarness({
+        sentTexts,
+        bindingResolver,
+        parsed: {
+          message_id: 'wx-msg-binding-disabled',
+          from: { id: 'shared' },
+          chat: { id: 'wx-bot' },
+          text: 'hello',
+          context_token: 'ctx-token',
+        },
+      });
+
+      await (bot as any).handleMessage({
+        message_type: 0,
+        message_id: 'wx-msg-binding-disabled',
+        from_user_id: 'shared',
+        to_user_id: 'wx-bot',
+        context_token: 'ctx-token',
+      });
+
+      assert.deepEqual(bot.createdSessions, []);
+      assert.equal(bot.handledTurns.length, 0);
+      assert.equal(sentTexts.length, 1);
+      assert.match(sentTexts[0].text, /绑定|配置|失败/);
+    }
+  });
+
   test('uses resolved channel binding as the Weixin agent session route', async () => {
     const bindingInputs: any[] = [];
     const bot = createHarness({

--- a/tests/weixin-session-route.test.ts
+++ b/tests/weixin-session-route.test.ts
@@ -84,12 +84,103 @@ describe('Weixin SessionRoute V2', () => {
       SubAgentManager.getInstance().unregisterPlatformCallbacks('session:v2:weixin:p2p:shared');
     }
   });
+
+  test('does not create a model session when channel binding is required but missing', async () => {
+    const sentTexts: Array<{ userId: string; text: string; contextToken?: string }> = [];
+    const bot = createHarness({
+      sentTexts,
+      bindingResolver: {
+        enabled: true,
+        required: true,
+        resolve: async () => ({ bound: false }),
+      },
+      parsed: {
+        message_id: 'wx-msg-binding-missing',
+        from: { id: 'shared' },
+        chat: { id: 'wx-bot' },
+        text: 'hello',
+        context_token: 'ctx-token',
+      },
+    });
+
+    await (bot as any).handleMessage({
+      message_type: 0,
+      message_id: 'wx-msg-binding-missing',
+      from_user_id: 'shared',
+      to_user_id: 'wx-bot',
+      context_token: 'ctx-token',
+    });
+
+    assert.deepEqual(bot.createdSessions, []);
+    assert.equal(bot.handledTurns.length, 0);
+    assert.equal(sentTexts.length, 1);
+    assert.equal(sentTexts[0].userId, 'shared');
+    assert.match(sentTexts[0].text, /入口码|绑定/);
+  });
+
+  test('uses resolved channel binding as the Weixin agent session route', async () => {
+    const bindingInputs: any[] = [];
+    const bot = createHarness({
+      channelAppId: 'wx_app',
+      bindingResolver: {
+        enabled: true,
+        required: true,
+        resolve: async (input: any) => {
+          bindingInputs.push(input);
+          return {
+            bound: true,
+            agentId: 'usr43',
+            agentBodyId: 'body-contract',
+            identityTrust: 'server_canonical',
+            identitySource: 'channel_agent_binding',
+          };
+        },
+      },
+      parsed: {
+        message_id: 'wx-msg-binding-ok',
+        from: { id: 'openid-user' },
+        chat: { id: 'wx-bot' },
+        text: '查合同',
+        context_token: 'ctx-token',
+      },
+    });
+
+    try {
+      await (bot as any).handleMessage({
+        message_type: 0,
+        message_id: 'wx-msg-binding-ok',
+        from_user_id: 'openid-user',
+        to_user_id: 'wx-bot',
+        context_token: 'ctx-token',
+      });
+
+      const sessionKey = 'session:v2:weixin:p2p:openid-user:agent:usr43';
+      assert.deepEqual(bot.createdSessions, [sessionKey]);
+      assert.equal(bot.handledTurns.length, 1);
+      assert.equal(bot.handledTurns[0].options.sessionRoute.agentId, 'usr43');
+      assert.equal(bot.handledTurns[0].options.sessionRoute.agentBodyId, 'body-contract');
+      assert.equal(bot.handledTurns[0].options.sessionRoute.identityTrust, 'server_canonical');
+      assert.equal(bot.handledTurns[0].options.executionScope.agentId, 'usr43');
+      assert.equal(bot.handledTurns[0].options.executionScope.agentBodyId, 'body-contract');
+      assert.equal(bot.handledTurns[0].options.executionScope.isTrusted, true);
+      assert.deepEqual(bindingInputs, [{
+        channel: 'weixin',
+        channelAppId: 'wx_app',
+        channelUserId: 'openid-user',
+        channelConversationType: 'p2p',
+      }]);
+    } finally {
+      SubAgentManager.getInstance().unregisterPlatformCallbacks('session:v2:weixin:p2p:openid-user:agent:usr43');
+    }
+  });
 });
 
 function createHarness(options: {
   busy?: boolean;
   parsed: any;
   sentTexts?: Array<{ userId: string; text: string; contextToken?: string }>;
+  bindingResolver?: any;
+  channelAppId?: string;
 }): any {
   const bot = Object.create(WeixinBot.prototype) as any;
   bot.sessionBusy = options.busy ?? false;
@@ -97,6 +188,8 @@ function createHarness(options: {
   bot.handledTurns = [] as any[];
   bot.contextTokens = new Map();
   bot.messageQueue = new Map();
+  bot.bindingResolver = options.bindingResolver || { enabled: false, required: false };
+  bot.channelAppId = options.channelAppId || '';
   bot.saveState = async () => undefined;
   bot.handler = {
     parseMessage: () => options.parsed,


### PR DESCRIPTION
## 摘要

- 新增 ChannelAgentBindingResolver，用于飞书/微信适配器从 CatsCo 后端解析“渠道用户 -> 虚拟员工”的绑定关系。
- 绑定解析只有在显式开启并配置 binding base URL 后才生效；支持服务端 Bearer token、超时控制和 malformed response 防护。
- 飞书/微信私聊在 required 模式下未绑定会直接提示扫码，不会进入模型会话；绑定成功后将 agentId / agentBodyId 注入 SessionRoute 和 ExecutionScope。
- 微信新增 `channelAppId` 配置透传，飞书继续使用 appId 作为 channel_app_id，便于多应用接入时隔离身份。
- 明确本 PR 暂不处理飞书群聊 QR binding，群聊继续走原有群聊 session 逻辑。

## 边界

- 本 PR 完成渠道私聊与虚拟员工入口码绑定后的路由接入。
- 群聊绑定、微信/飞书 OAuth/ticket 身份确认、以及更完整的多虚拟员工选择体验，建议后续独立推进。

## 验证

- `npm.cmd run build`
- `npm.cmd run test:runtime`
- 定向测试：`tsx --test tests/channel-agent-binding-resolver.test.ts tests/feishu-session-route.test.ts tests/weixin-session-route.test.ts tests/session-route-v2.test.ts`
