### PR TITLE
折叠历史 read_file 消息以降低上下文体积

### DIFF
--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -6,6 +6,7 @@ import { Logger } from '../utils/logger';
 import { Metrics } from '../utils/metrics';
 import { ContextCompressor } from './context-compressor';
 import { estimateMessagesTokens, estimateToolsTokens } from './token-estimator';
+import { foldHistoricalReadFileMessages, resolveReadFileMessageFoldingOptions } from './read-file-message-folder';
 import {
   buildExplicitPlanRequestHintIfUseful,
   buildInitialDecisionHintIfUseful,
@@ -264,11 +265,23 @@ export class ConversationRunner {
         nextSubagentNudgeAt = nextSubagentNudgeToolCount(executedToolCalls);
       }
 
-      const requestMessages = this.buildProviderInputMessages(messages, [
+      let requestMessages = this.buildProviderInputMessages(messages, [
         ...nextTurnTransientHints,
         ...orchestrationHints,
       ]);
       nextTurnTransientHints = [];
+      const readFileFolding = foldHistoricalReadFileMessages(
+        requestMessages,
+        resolveReadFileMessageFoldingOptions(),
+      );
+      requestMessages = readFileFolding.messages;
+      if (readFileFolding.stats.folded_count > 0) {
+        Logger.info(
+          `[${this.sessionLabel}Turn ${turns}] read_file 历史折叠: `
+          + `folded=${readFileFolding.stats.folded_count}, `
+          + `saved≈${readFileFolding.stats.saved_tokens_est} tokens`,
+        );
+      }
       const promptTrimmed = this.ensurePromptBudget(requestMessages, requestTools);
       if (promptTrimmed && callbacks?.onThinking) {
         await callbacks.onThinking(PROMPT_BUDGET_TRIM_MESSAGE);

--- a/src/core/read-file-message-folder.ts
+++ b/src/core/read-file-message-folder.ts
@@ -1,0 +1,328 @@
+import { createHash } from 'crypto';
+import { Message } from '../types';
+import { estimateTokens } from './token-estimator';
+
+export const FOLDED_READ_FILE_PREFIX = '[folded_read_file]';
+
+export interface ReadFileMessageFoldingOptions {
+  enabled: boolean;
+  thresholdTokens: number;
+  maxPreviewLines: number;
+  maxSymbolLines: number;
+  keepRecentHistoricalReads: number;
+}
+
+export interface ReadFileMessageFoldingStats {
+  enabled: boolean;
+  candidate_count: number;
+  folded_count: number;
+  skipped_recent_count: number;
+  skipped_current_turn_count: number;
+  raw_tokens_est: number;
+  folded_tokens_est: number;
+  saved_tokens_est: number;
+  threshold_tokens: number;
+  keep_recent_historical_reads: number;
+}
+
+export interface ReadFileMessageFoldingResult {
+  messages: Message[];
+  stats: ReadFileMessageFoldingStats;
+}
+
+interface FoldCandidate {
+  index: number;
+  message: Message;
+  rawText: string;
+  rawTokens: number;
+  toolCall?: NonNullable<Message['tool_calls']>[number];
+}
+
+const DEFAULT_OPTIONS: ReadFileMessageFoldingOptions = {
+  enabled: true,
+  thresholdTokens: 2000,
+  maxPreviewLines: 8,
+  maxSymbolLines: 18,
+  keepRecentHistoricalReads: 0,
+};
+
+export function resolveReadFileMessageFoldingOptions(
+  env: NodeJS.ProcessEnv = process.env,
+): ReadFileMessageFoldingOptions {
+  return {
+    enabled: readBooleanEnv(env.XIAOBA_READ_FILE_MESSAGE_FOLDING, DEFAULT_OPTIONS.enabled),
+    thresholdTokens: readPositiveIntegerEnv(
+      env.XIAOBA_READ_FILE_FOLD_THRESHOLD_TOKENS,
+      DEFAULT_OPTIONS.thresholdTokens,
+    ),
+    maxPreviewLines: readPositiveIntegerEnv(
+      env.XIAOBA_READ_FILE_FOLD_PREVIEW_LINES,
+      DEFAULT_OPTIONS.maxPreviewLines,
+    ),
+    maxSymbolLines: readPositiveIntegerEnv(
+      env.XIAOBA_READ_FILE_FOLD_SYMBOL_LINES,
+      DEFAULT_OPTIONS.maxSymbolLines,
+    ),
+    keepRecentHistoricalReads: readNonNegativeIntegerEnv(
+      env.XIAOBA_READ_FILE_FOLD_KEEP_RECENT,
+      DEFAULT_OPTIONS.keepRecentHistoricalReads,
+    ),
+  };
+}
+
+export function foldHistoricalReadFileMessages(
+  messages: Message[],
+  options: Partial<ReadFileMessageFoldingOptions> = {},
+): ReadFileMessageFoldingResult {
+  const resolved = { ...DEFAULT_OPTIONS, ...options };
+  const baseStats = emptyStats(resolved);
+  if (!resolved.enabled || messages.length === 0) {
+    return { messages, stats: baseStats };
+  }
+
+  const lastUserIndex = findLastRealUserIndex(messages);
+  if (lastUserIndex < 0) {
+    return { messages, stats: baseStats };
+  }
+
+  const toolCallsById = collectToolCallsById(messages);
+  const candidates: FoldCandidate[] = [];
+  let skippedCurrentTurnCount = 0;
+
+  messages.forEach((message, index) => {
+    if (!isReadFileToolResult(message)) return;
+    if (index > lastUserIndex) {
+      skippedCurrentTurnCount++;
+      return;
+    }
+
+    const rawText = typeof message.content === 'string' ? message.content : '';
+    if (!rawText || rawText.startsWith(FOLDED_READ_FILE_PREFIX)) return;
+
+    const rawTokens = estimateTokens(rawText);
+    if (rawTokens < resolved.thresholdTokens) return;
+
+    const toolCall = message.tool_call_id
+      ? toolCallsById.get(message.tool_call_id)
+      : undefined;
+    candidates.push({ index, message, rawText, rawTokens, toolCall });
+  });
+
+  const stats = emptyStats(resolved);
+  stats.candidate_count = candidates.length;
+  stats.skipped_current_turn_count = skippedCurrentTurnCount;
+
+  if (candidates.length === 0) {
+    return { messages, stats };
+  }
+
+  const keepRecent = Math.min(resolved.keepRecentHistoricalReads, candidates.length);
+  const candidatesToFold = candidates.slice(0, candidates.length - keepRecent);
+  stats.skipped_recent_count = keepRecent;
+
+  if (candidatesToFold.length === 0) {
+    return { messages, stats };
+  }
+
+  const foldedByIndex = new Map<number, string>();
+  for (const candidate of candidatesToFold) {
+    const folded = buildFoldedReadFileContent(candidate, resolved);
+    foldedByIndex.set(candidate.index, folded);
+    stats.folded_count++;
+    stats.raw_tokens_est += candidate.rawTokens;
+    stats.folded_tokens_est += estimateTokens(folded);
+  }
+  stats.saved_tokens_est = Math.max(0, stats.raw_tokens_est - stats.folded_tokens_est);
+
+  const foldedMessages = messages.map((message, index) => {
+    const folded = foldedByIndex.get(index);
+    if (!folded) return message;
+    return {
+      ...message,
+      content: folded,
+    };
+  });
+
+  return { messages: foldedMessages, stats };
+}
+
+function emptyStats(options: ReadFileMessageFoldingOptions): ReadFileMessageFoldingStats {
+  return {
+    enabled: options.enabled,
+    candidate_count: 0,
+    folded_count: 0,
+    skipped_recent_count: 0,
+    skipped_current_turn_count: 0,
+    raw_tokens_est: 0,
+    folded_tokens_est: 0,
+    saved_tokens_est: 0,
+    threshold_tokens: options.thresholdTokens,
+    keep_recent_historical_reads: options.keepRecentHistoricalReads,
+  };
+}
+
+function buildFoldedReadFileContent(
+  candidate: FoldCandidate,
+  options: ReadFileMessageFoldingOptions,
+): string {
+  const metadata = extractReadFileMetadata(candidate.rawText, candidate.toolCall);
+  const lines = extractNumberedLines(candidate.rawText);
+  const previewLines = selectPreviewLines(lines, options.maxPreviewLines);
+  const symbolLines = selectSymbolLines(lines, options.maxSymbolLines);
+  const hash = createHash('sha256')
+    .update(metadata.path || '')
+    .update('\0')
+    .update(candidate.rawText)
+    .digest('hex');
+  const foldedParts = [
+    FOLDED_READ_FILE_PREFIX,
+    `artifact_id: rf_${hash.slice(0, 16)}`,
+    metadata.file ? `file: ${metadata.file}` : '',
+    metadata.path ? `path: ${metadata.path}` : '',
+    metadata.display ? `range: ${metadata.display}` : '',
+    metadata.totalLines ? `total_lines: ${metadata.totalLines}` : '',
+    `original_chars: ${candidate.rawText.length}`,
+    `original_tokens_est: ${candidate.rawTokens}`,
+    `sha256: ${hash}`,
+    '',
+    'summary: Historical read_file output was folded out of the provider prompt. Re-read this file/range before exact edits or quoting.',
+    previewLines.length > 0 ? ['preview:', ...previewLines.map(line => `  ${line}`)].join('\n') : '',
+    symbolLines.length > 0 ? ['key_symbols:', ...symbolLines.map(line => `  ${line}`)].join('\n') : '',
+  ];
+
+  return foldedParts.filter(part => part !== '').join('\n');
+}
+
+function extractReadFileMetadata(
+  rawText: string,
+  toolCall?: NonNullable<Message['tool_calls']>[number],
+): {
+  file?: string;
+  path?: string;
+  display?: string;
+  totalLines?: string;
+} {
+  const args = parseToolArguments(toolCall);
+  return {
+    file: firstNonEmpty(readHeader(rawText, '文件'), readHeader(rawText, 'File'), stringArg(args, 'file_path'), stringArg(args, 'path')),
+    path: firstNonEmpty(readHeader(rawText, 'Path'), stringArg(args, 'file_path'), stringArg(args, 'path')),
+    display: firstNonEmpty(readHeader(rawText, '显示'), buildDisplayFromArgs(args)),
+    totalLines: readHeader(rawText, '总行数'),
+  };
+}
+
+function collectToolCallsById(messages: Message[]): Map<string, NonNullable<Message['tool_calls']>[number]> {
+  const result = new Map<string, NonNullable<Message['tool_calls']>[number]>();
+  for (const message of messages) {
+    for (const toolCall of message.tool_calls || []) {
+      result.set(toolCall.id, toolCall);
+    }
+  }
+  return result;
+}
+
+function isReadFileToolResult(message: Message): boolean {
+  if (message.role !== 'tool') return false;
+  if (Array.isArray(message.content)) return false;
+  return normalizeToolName(message.name || '') === 'read_file';
+}
+
+function normalizeToolName(name: string): string {
+  const normalized = String(name || '').trim();
+  if (normalized === 'Read') return 'read_file';
+  return normalized;
+}
+
+function findLastRealUserIndex(messages: Message[]): number {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (message.role !== 'user') continue;
+    if (message.__injected) continue;
+    if (typeof message.content === 'string' && message.content.startsWith('[transient_')) continue;
+    return i;
+  }
+  return -1;
+}
+
+function extractNumberedLines(rawText: string): string[] {
+  return rawText
+    .split(/\r?\n/)
+    .filter(line => /^\s*\d+\s*→\s?/.test(line))
+    .map(line => line.trim());
+}
+
+function selectPreviewLines(lines: string[], maxPreviewLines: number): string[] {
+  if (lines.length <= maxPreviewLines * 2) return lines;
+  return [
+    ...lines.slice(0, maxPreviewLines),
+    '...',
+    ...lines.slice(-maxPreviewLines),
+  ];
+}
+
+function selectSymbolLines(lines: string[], maxSymbolLines: number): string[] {
+  const symbolPattern = /\b(export\s+)?(class|interface|type|enum|function|const|let|var|def|async\s+function)\b|^\s*\d+\s*→\s*(public|private|protected)\s+/;
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const line of lines) {
+    if (!symbolPattern.test(line)) continue;
+    const compact = line.replace(/\s+/g, ' ').trim();
+    if (seen.has(compact)) continue;
+    seen.add(compact);
+    result.push(compact);
+    if (result.length >= maxSymbolLines) break;
+  }
+  return result;
+}
+
+function readHeader(rawText: string, label: string): string | undefined {
+  const escapedLabel = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = rawText.match(new RegExp(`^${escapedLabel}:\\s*(.+)$`, 'm'));
+  return match?.[1]?.trim() || undefined;
+}
+
+function parseToolArguments(toolCall?: NonNullable<Message['tool_calls']>[number]): Record<string, unknown> {
+  if (!toolCall?.function?.arguments) return {};
+  try {
+    const parsed = JSON.parse(toolCall.function.arguments);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function stringArg(args: Record<string, unknown>, key: string): string | undefined {
+  const value = args[key];
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function buildDisplayFromArgs(args: Record<string, unknown>): string | undefined {
+  const offset = Number(args.offset);
+  const limit = Number(args.limit);
+  if (!Number.isFinite(offset) || offset <= 0) return undefined;
+  if (!Number.isFinite(limit) || limit <= 0) return `${Math.floor(offset)}-?`;
+  return `${Math.floor(offset)}-${Math.floor(offset + limit - 1)}`;
+}
+
+function firstNonEmpty(...values: Array<string | undefined>): string | undefined {
+  return values.find(value => Boolean(value && value.trim()));
+}
+
+function readBooleanEnv(value: string | undefined, fallback: boolean): boolean {
+  if (value === undefined || value === '') return fallback;
+  if (/^(1|true|yes|on)$/i.test(value)) return true;
+  if (/^(0|false|no|off)$/i.test(value)) return false;
+  return fallback;
+}
+
+function readPositiveIntegerEnv(value: string | undefined, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function readNonNegativeIntegerEnv(value: string | undefined, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : fallback;
+}

--- a/tests/read-file-message-folder.test.ts
+++ b/tests/read-file-message-folder.test.ts
@@ -1,0 +1,171 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  FOLDED_READ_FILE_PREFIX,
+  foldHistoricalReadFileMessages,
+  resolveReadFileMessageFoldingOptions,
+} from '../src/core/read-file-message-folder';
+import { ConversationRunner } from '../src/core/conversation-runner';
+import { Message } from '../src/types';
+import { ToolExecutor } from '../src/types/tool';
+
+function makeReadFileOutput(path: string, lineCount = 80): string {
+  const lines = Array.from({ length: lineCount }, (_, index) => {
+    const lineNumber = index + 1;
+    return `${String(lineNumber).padStart(5, ' ')}→ plain historical content line ${lineNumber}`;
+  });
+  return [
+    `文件: ${path}`,
+    `Path: ${path}`,
+    `总行数: ${lineCount}`,
+    `显示: 1-${lineCount}`,
+    '',
+    lines.join('\n'),
+  ].join('\n');
+}
+
+function makeToolCallMessage(id: string, filePath: string): Message {
+  return {
+    role: 'assistant',
+    content: null,
+    tool_calls: [{
+      id,
+      type: 'function',
+      function: {
+        name: 'read_file',
+        arguments: JSON.stringify({ file_path: filePath }),
+      },
+    }],
+  };
+}
+
+test('folds large historical read_file tool results while preserving tool exchange ids', () => {
+  const raw = makeReadFileOutput('E:/repo/large.ts', 90);
+  const messages: Message[] = [
+    { role: 'user', content: '先看一下 large.ts' },
+    makeToolCallMessage('call_old_read', 'E:/repo/large.ts'),
+    { role: 'tool', name: 'read_file', tool_call_id: 'call_old_read', content: raw },
+    { role: 'assistant', content: '看完了。' },
+    { role: 'user', content: '继续说结论' },
+  ];
+
+  const result = foldHistoricalReadFileMessages(messages, {
+    thresholdTokens: 20,
+    maxPreviewLines: 2,
+    maxSymbolLines: 2,
+  });
+  const folded = result.messages[2];
+
+  assert.equal(result.stats.folded_count, 1);
+  assert.equal(result.stats.candidate_count, 1);
+  assert.equal(folded.tool_call_id, 'call_old_read');
+  assert.equal(folded.name, 'read_file');
+  assert.equal(typeof folded.content, 'string');
+  assert.ok(String(folded.content).startsWith(FOLDED_READ_FILE_PREFIX));
+  assert.match(String(folded.content), /artifact_id: rf_[a-f0-9]{16}/);
+  assert.match(String(folded.content), /path: E:\/repo\/large\.ts/);
+  assert.equal(String(folded.content).includes('plain historical content line 45'), false);
+  assert.ok(result.stats.saved_tokens_est > 0);
+});
+
+test('does not fold read_file result from the current tool loop', () => {
+  const raw = makeReadFileOutput('E:/repo/current.ts', 90);
+  const messages: Message[] = [
+    { role: 'user', content: '现在读取 current.ts 并修改' },
+    makeToolCallMessage('call_current_read', 'E:/repo/current.ts'),
+    { role: 'tool', name: 'read_file', tool_call_id: 'call_current_read', content: raw },
+  ];
+
+  const result = foldHistoricalReadFileMessages(messages, {
+    thresholdTokens: 20,
+  });
+
+  assert.equal(result.stats.folded_count, 0);
+  assert.equal(result.stats.skipped_current_turn_count, 1);
+  assert.equal(result.messages[2].content, raw);
+});
+
+test('can keep the most recent historical read_file result raw', () => {
+  const firstRaw = makeReadFileOutput('E:/repo/old.ts', 90);
+  const secondRaw = makeReadFileOutput('E:/repo/recent.ts', 90);
+  const messages: Message[] = [
+    { role: 'user', content: '读 old' },
+    makeToolCallMessage('call_old', 'E:/repo/old.ts'),
+    { role: 'tool', name: 'read_file', tool_call_id: 'call_old', content: firstRaw },
+    { role: 'assistant', content: 'old 看完了' },
+    { role: 'user', content: '读 recent' },
+    makeToolCallMessage('call_recent', 'E:/repo/recent.ts'),
+    { role: 'tool', name: 'read_file', tool_call_id: 'call_recent', content: secondRaw },
+    { role: 'assistant', content: 'recent 看完了' },
+    { role: 'user', content: '继续' },
+  ];
+
+  const result = foldHistoricalReadFileMessages(messages, {
+    thresholdTokens: 20,
+    keepRecentHistoricalReads: 1,
+  });
+
+  assert.equal(result.stats.candidate_count, 2);
+  assert.equal(result.stats.folded_count, 1);
+  assert.equal(result.stats.skipped_recent_count, 1);
+  assert.ok(String(result.messages[2].content).startsWith(FOLDED_READ_FILE_PREFIX));
+  assert.equal(result.messages[6].content, secondRaw);
+});
+
+test('environment options are deterministic and can disable folding', () => {
+  const env = {
+    XIAOBA_READ_FILE_MESSAGE_FOLDING: '0',
+    XIAOBA_READ_FILE_FOLD_THRESHOLD_TOKENS: '123',
+    XIAOBA_READ_FILE_FOLD_PREVIEW_LINES: '4',
+    XIAOBA_READ_FILE_FOLD_SYMBOL_LINES: '5',
+    XIAOBA_READ_FILE_FOLD_KEEP_RECENT: '2',
+  } as NodeJS.ProcessEnv;
+
+  const options = resolveReadFileMessageFoldingOptions(env);
+
+  assert.equal(options.enabled, false);
+  assert.equal(options.thresholdTokens, 123);
+  assert.equal(options.maxPreviewLines, 4);
+  assert.equal(options.maxSymbolLines, 5);
+  assert.equal(options.keepRecentHistoricalReads, 2);
+});
+
+test('runner folds only provider input and leaves durable session messages raw', async () => {
+  const previousThreshold = process.env.XIAOBA_READ_FILE_FOLD_THRESHOLD_TOKENS;
+  process.env.XIAOBA_READ_FILE_FOLD_THRESHOLD_TOKENS = '20';
+
+  const raw = makeReadFileOutput('E:/repo/provider-only.ts', 90);
+  const messages: Message[] = [
+    { role: 'user', content: '读 provider-only' },
+    makeToolCallMessage('call_provider_only', 'E:/repo/provider-only.ts'),
+    { role: 'tool', name: 'read_file', tool_call_id: 'call_provider_only', content: raw },
+    { role: 'assistant', content: '读完了' },
+    { role: 'user', content: '继续' },
+  ];
+  const captured: Message[][] = [];
+  const aiService = {
+    async chat(requestMessages: Message[]) {
+      captured.push(JSON.parse(JSON.stringify(requestMessages)));
+      return { content: 'done' };
+    },
+  };
+  const executor: ToolExecutor = {
+    getToolDefinitions: () => [],
+    executeTool: async () => ({ tool_call_id: 'unused', role: 'tool', name: 'unused', content: 'unused' }),
+  };
+
+  try {
+    const runner = new ConversationRunner(aiService as any, executor, {
+      stream: false,
+      enableCompression: false,
+    });
+    await runner.run(messages);
+  } finally {
+    if (previousThreshold === undefined) delete process.env.XIAOBA_READ_FILE_FOLD_THRESHOLD_TOKENS;
+    else process.env.XIAOBA_READ_FILE_FOLD_THRESHOLD_TOKENS = previousThreshold;
+  }
+
+  const providerToolResult = captured[0].find(message => message.role === 'tool');
+  assert.ok(String(providerToolResult?.content).startsWith(FOLDED_READ_FILE_PREFIX));
+  assert.equal(messages[2].content, raw);
+});


### PR DESCRIPTION
## 背景

长对话里历史 `read_file` 工具结果会反复进入 provider prompt。尤其是大文件读取结果，会显著抬高上下文体积，也可能影响缓存命中稳定性。

## 改动

- 新增 `read-file-message-folder`，在发送给 provider 前折叠历史的大型 `read_file` 结果。
- 只折叠历史消息，不折叠当前工具循环里刚读到的文件内容，避免影响当轮编辑和引用。
- 保留工具交换结构，包括 `role: tool`、`name`、`tool_call_id`，只替换 `content` 为带 metadata、hash、preview、key_symbols 的摘要。
- 支持环境变量调节或关闭：
  - `XIAOBA_READ_FILE_MESSAGE_FOLDING`
  - `XIAOBA_READ_FILE_FOLD_THRESHOLD_TOKENS`
  - `XIAOBA_READ_FILE_FOLD_PREVIEW_LINES`
  - `XIAOBA_READ_FILE_FOLD_SYMBOL_LINES`
  - `XIAOBA_READ_FILE_FOLD_KEEP_RECENT`
- 在 runner 中记录折叠数量和估算节省 token。

## 验证

- `npm run build`
- `node node_modules\\tsx\\dist\\cli.mjs --test tests\\read-file-message-folder.test.ts`
- `node node_modules\\tsx\\dist\\cli.mjs --test tests\\conversation-runner-context-budget.test.ts`
- `node node_modules\\tsx\\dist\\cli.mjs --test tests\\conversation-runner-transcript-normalization.test.ts`

## 注意

这版是 provider 输入侧折叠，不改持久会话历史。后续如果要继续压上下文，可以再扩展到长 shell 输出，或增加持久 artifact 存储。
