### PR TITLE
折叠 execute_shell 并按预算压缩工具结果上下文

### DIFF
--- a/src/core/adaptive-tool-result-folder.ts
+++ b/src/core/adaptive-tool-result-folder.ts
@@ -1,0 +1,203 @@
+import { Message } from '../types';
+import { ToolDefinition } from '../types/tool';
+import { estimateMessagesTokens, estimateToolsTokens } from './token-estimator';
+import {
+  foldHistoricalReadFileMessages,
+  ReadFileMessageFoldingOptions,
+  ReadFileMessageFoldingStats,
+} from './read-file-message-folder';
+import {
+  ExecuteShellMessageFoldingOptions,
+  ExecuteShellMessageFoldingStats,
+  foldHistoricalExecuteShellMessages,
+} from './execute-shell-message-folder';
+
+export interface AdaptiveToolResultFoldingOptions {
+  enabled: boolean;
+  targetPromptTokens: number;
+  minThresholdTokens: number;
+  thresholdScale: number;
+  maxPasses: number;
+}
+
+export interface AdaptiveToolResultFoldingStats {
+  enabled: boolean;
+  target_prompt_tokens: number;
+  min_threshold_tokens: number;
+  threshold_scale: number;
+  max_passes: number;
+  passes: number;
+  started_prompt_tokens_est: number;
+  finished_prompt_tokens_est: number;
+  saved_prompt_tokens_est: number;
+  folded_count: number;
+  folded_current_turn_count: number;
+  saved_tokens_est: number;
+  read_file_folded_count: number;
+  read_file_saved_tokens_est: number;
+  execute_shell_folded_count: number;
+  execute_shell_saved_tokens_est: number;
+  thresholds_tried: number[];
+}
+
+export interface AdaptiveToolResultFoldingResult {
+  messages: Message[];
+  stats: AdaptiveToolResultFoldingStats;
+}
+
+const DEFAULT_OPTIONS: AdaptiveToolResultFoldingOptions = {
+  enabled: true,
+  targetPromptTokens: 100000,
+  minThresholdTokens: 300,
+  thresholdScale: 0.5,
+  maxPasses: 4,
+};
+
+export function resolveAdaptiveToolResultFoldingOptions(
+  env: NodeJS.ProcessEnv = process.env,
+): AdaptiveToolResultFoldingOptions {
+  return {
+    enabled: readBooleanEnv(env.XIAOBA_ADAPTIVE_TOOL_RESULT_FOLDING, DEFAULT_OPTIONS.enabled),
+    targetPromptTokens: readPositiveIntegerEnv(
+      env.XIAOBA_ADAPTIVE_TOOL_RESULT_FOLD_TARGET_PROMPT_TOKENS,
+      DEFAULT_OPTIONS.targetPromptTokens,
+    ),
+    minThresholdTokens: readPositiveIntegerEnv(
+      env.XIAOBA_ADAPTIVE_TOOL_RESULT_FOLD_MIN_THRESHOLD_TOKENS,
+      DEFAULT_OPTIONS.minThresholdTokens,
+    ),
+    thresholdScale: readThresholdScaleEnv(
+      env.XIAOBA_ADAPTIVE_TOOL_RESULT_FOLD_THRESHOLD_SCALE,
+      DEFAULT_OPTIONS.thresholdScale,
+    ),
+    maxPasses: readPositiveIntegerEnv(
+      env.XIAOBA_ADAPTIVE_TOOL_RESULT_FOLD_MAX_PASSES,
+      DEFAULT_OPTIONS.maxPasses,
+    ),
+  };
+}
+
+export function foldToolResultsTowardPromptBudget(
+  messages: Message[],
+  tools: ToolDefinition[],
+  readFileOptions: ReadFileMessageFoldingOptions,
+  executeShellOptions: ExecuteShellMessageFoldingOptions,
+  options: Partial<AdaptiveToolResultFoldingOptions> = {},
+): AdaptiveToolResultFoldingResult {
+  const resolved = { ...DEFAULT_OPTIONS, ...options };
+  const startedPromptTokens = estimatePromptTokens(messages, tools);
+  const stats = emptyStats(resolved, startedPromptTokens);
+  if (!resolved.enabled || startedPromptTokens <= resolved.targetPromptTokens) {
+    return { messages, stats };
+  }
+
+  let currentMessages = messages;
+  const thresholdsTried = new Set<number>();
+
+  for (let pass = 1; pass <= resolved.maxPasses; pass++) {
+    const promptTokensBeforePass = estimatePromptTokens(currentMessages, tools);
+    if (promptTokensBeforePass <= resolved.targetPromptTokens) break;
+
+    const threshold = thresholdForPass(
+      Math.min(readFileOptions.thresholdTokens, executeShellOptions.thresholdTokens),
+      pass,
+      resolved,
+    );
+    if (thresholdsTried.has(threshold)) break;
+    thresholdsTried.add(threshold);
+    stats.thresholds_tried.push(threshold);
+
+    const readFileResult = foldHistoricalReadFileMessages(currentMessages, {
+      ...readFileOptions,
+      thresholdTokens: Math.min(readFileOptions.thresholdTokens, threshold),
+    });
+    currentMessages = readFileResult.messages;
+
+    const shellResult = foldHistoricalExecuteShellMessages(currentMessages, {
+      ...executeShellOptions,
+      thresholdTokens: Math.min(executeShellOptions.thresholdTokens, threshold),
+    });
+    currentMessages = shellResult.messages;
+
+    const foldedThisPass = readFileResult.stats.folded_count + shellResult.stats.folded_count;
+    addStats(stats, readFileResult.stats, shellResult.stats);
+    stats.passes = pass;
+
+    const promptTokensAfterPass = estimatePromptTokens(currentMessages, tools);
+    if (promptTokensAfterPass <= resolved.targetPromptTokens) break;
+    if (foldedThisPass === 0 && threshold <= resolved.minThresholdTokens) break;
+  }
+
+  stats.finished_prompt_tokens_est = estimatePromptTokens(currentMessages, tools);
+  stats.saved_prompt_tokens_est = Math.max(0, stats.started_prompt_tokens_est - stats.finished_prompt_tokens_est);
+  return { messages: currentMessages, stats };
+}
+
+function emptyStats(
+  options: AdaptiveToolResultFoldingOptions,
+  startedPromptTokens: number,
+): AdaptiveToolResultFoldingStats {
+  return {
+    enabled: options.enabled,
+    target_prompt_tokens: options.targetPromptTokens,
+    min_threshold_tokens: options.minThresholdTokens,
+    threshold_scale: options.thresholdScale,
+    max_passes: options.maxPasses,
+    passes: 0,
+    started_prompt_tokens_est: startedPromptTokens,
+    finished_prompt_tokens_est: startedPromptTokens,
+    saved_prompt_tokens_est: 0,
+    folded_count: 0,
+    folded_current_turn_count: 0,
+    saved_tokens_est: 0,
+    read_file_folded_count: 0,
+    read_file_saved_tokens_est: 0,
+    execute_shell_folded_count: 0,
+    execute_shell_saved_tokens_est: 0,
+    thresholds_tried: [],
+  };
+}
+
+function addStats(
+  target: AdaptiveToolResultFoldingStats,
+  readFileStats: ReadFileMessageFoldingStats,
+  executeShellStats: ExecuteShellMessageFoldingStats,
+): void {
+  target.folded_count += readFileStats.folded_count + executeShellStats.folded_count;
+  target.folded_current_turn_count += readFileStats.folded_current_turn_count + executeShellStats.folded_current_turn_count;
+  target.saved_tokens_est += readFileStats.saved_tokens_est + executeShellStats.saved_tokens_est;
+  target.read_file_folded_count += readFileStats.folded_count;
+  target.read_file_saved_tokens_est += readFileStats.saved_tokens_est;
+  target.execute_shell_folded_count += executeShellStats.folded_count;
+  target.execute_shell_saved_tokens_est += executeShellStats.saved_tokens_est;
+}
+
+function estimatePromptTokens(messages: Message[], tools: ToolDefinition[]): number {
+  return estimateMessagesTokens(messages) + estimateToolsTokens(tools);
+}
+
+function thresholdForPass(
+  baseThreshold: number,
+  pass: number,
+  options: AdaptiveToolResultFoldingOptions,
+): number {
+  const scaled = Math.floor(baseThreshold * Math.pow(options.thresholdScale, pass));
+  return Math.max(options.minThresholdTokens, scaled);
+}
+
+function readBooleanEnv(value: string | undefined, fallback: boolean): boolean {
+  if (value === undefined || value === '') return fallback;
+  if (/^(1|true|yes|on)$/i.test(value)) return true;
+  if (/^(0|false|no|off)$/i.test(value)) return false;
+  return fallback;
+}
+
+function readPositiveIntegerEnv(value: string | undefined, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function readThresholdScaleEnv(value: string | undefined, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 && parsed < 1 ? parsed : fallback;
+}

--- a/src/core/adaptive-tool-result-folder.ts
+++ b/src/core/adaptive-tool-result-folder.ts
@@ -55,24 +55,26 @@ const DEFAULT_OPTIONS: AdaptiveToolResultFoldingOptions = {
 
 export function resolveAdaptiveToolResultFoldingOptions(
   env: NodeJS.ProcessEnv = process.env,
+  defaults: Partial<AdaptiveToolResultFoldingOptions> = {},
 ): AdaptiveToolResultFoldingOptions {
+  const fallback = { ...DEFAULT_OPTIONS, ...defaults };
   return {
-    enabled: readBooleanEnv(env.XIAOBA_ADAPTIVE_TOOL_RESULT_FOLDING, DEFAULT_OPTIONS.enabled),
+    enabled: readBooleanEnv(env.XIAOBA_ADAPTIVE_TOOL_RESULT_FOLDING, fallback.enabled),
     targetPromptTokens: readPositiveIntegerEnv(
       env.XIAOBA_ADAPTIVE_TOOL_RESULT_FOLD_TARGET_PROMPT_TOKENS,
-      DEFAULT_OPTIONS.targetPromptTokens,
+      fallback.targetPromptTokens,
     ),
     minThresholdTokens: readPositiveIntegerEnv(
       env.XIAOBA_ADAPTIVE_TOOL_RESULT_FOLD_MIN_THRESHOLD_TOKENS,
-      DEFAULT_OPTIONS.minThresholdTokens,
+      fallback.minThresholdTokens,
     ),
     thresholdScale: readThresholdScaleEnv(
       env.XIAOBA_ADAPTIVE_TOOL_RESULT_FOLD_THRESHOLD_SCALE,
-      DEFAULT_OPTIONS.thresholdScale,
+      fallback.thresholdScale,
     ),
     maxPasses: readPositiveIntegerEnv(
       env.XIAOBA_ADAPTIVE_TOOL_RESULT_FOLD_MAX_PASSES,
-      DEFAULT_OPTIONS.maxPasses,
+      fallback.maxPasses,
     ),
   };
 }

--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -368,7 +368,7 @@ export class ConversationRunner {
         requestTools,
         readFileFoldingOptions,
         executeShellFoldingOptions,
-        resolveAdaptiveToolResultFoldingOptions(),
+        this.resolveAdaptiveToolResultFoldingOptions(requestTools),
       );
       requestMessages = adaptiveFolding.messages;
       if (adaptiveFolding.stats.folded_count > 0) {
@@ -1278,6 +1278,17 @@ export class ConversationRunner {
       `[上下文守门] 裁剪后: messages=${messageTokens}, tools=${toolTokens}, budget=${this.maxPromptTokens}`
     );
     return true;
+  }
+
+  private resolveAdaptiveToolResultFoldingOptions(tools: ToolDefinition[]) {
+    const messageBudget = Math.max(1, this.maxPromptTokens - estimateToolsTokens(tools));
+    const options = resolveAdaptiveToolResultFoldingOptions(process.env, {
+      targetPromptTokens: messageBudget,
+    });
+    return {
+      ...options,
+      targetPromptTokens: Math.min(options.targetPromptTokens, messageBudget),
+    };
   }
 
   private fitToolsToPromptBudget(tools: ToolDefinition[]): ToolDefinition[] {

--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -15,6 +15,10 @@ import {
   summarizeToolResultContext,
 } from './tool-result-context-report';
 import {
+  resolveCurrentRunToolResultFoldingOptions,
+  selectProtectedCurrentRunToolResultIndexes,
+} from './current-run-tool-result-folding';
+import {
   buildExplicitPlanRequestHintIfUseful,
   buildInitialDecisionHintIfUseful,
   buildPlanSoftNudge,
@@ -314,27 +318,42 @@ export class ConversationRunner {
       const toolResultContextBeforeFolding = toolResultContextReportOptions.enabled
         ? summarizeToolResultContext(requestMessages, toolResultContextReportOptions)
         : null;
+      const currentRunToolResultFoldingOptions = resolveCurrentRunToolResultFoldingOptions();
+      const protectedCurrentRunToolResultIndexes = selectProtectedCurrentRunToolResultIndexes(
+        requestMessages,
+        currentRunToolResultFoldingOptions,
+      );
       const readFileFolding = foldHistoricalReadFileMessages(
         requestMessages,
-        resolveReadFileMessageFoldingOptions(),
+        {
+          ...resolveReadFileMessageFoldingOptions(),
+          foldCurrentRun: currentRunToolResultFoldingOptions.enabled,
+          protectedCurrentRunToolResultIndexes,
+        },
       );
       requestMessages = readFileFolding.messages;
       if (readFileFolding.stats.folded_count > 0) {
         Logger.info(
-          `[${this.sessionLabel}Turn ${turns}] read_file 历史折叠: `
+          `[${this.sessionLabel}Turn ${turns}] read_file folding: `
           + `folded=${readFileFolding.stats.folded_count}, `
+          + `current=${readFileFolding.stats.folded_current_turn_count}, `
           + `saved≈${readFileFolding.stats.saved_tokens_est} tokens`,
         );
       }
       const executeShellFolding = foldHistoricalExecuteShellMessages(
         requestMessages,
-        resolveExecuteShellMessageFoldingOptions(),
+        {
+          ...resolveExecuteShellMessageFoldingOptions(),
+          foldCurrentRun: currentRunToolResultFoldingOptions.enabled,
+          protectedCurrentRunToolResultIndexes,
+        },
       );
       requestMessages = executeShellFolding.messages;
       if (executeShellFolding.stats.folded_count > 0) {
         Logger.info(
-          `[${this.sessionLabel}Turn ${turns}] execute_shell historical folding: `
+          `[${this.sessionLabel}Turn ${turns}] execute_shell folding: `
           + `folded=${executeShellFolding.stats.folded_count}, `
+          + `current=${executeShellFolding.stats.folded_current_turn_count}, `
           + `saved≈${executeShellFolding.stats.saved_tokens_est} tokens`,
         );
       }

--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -8,6 +8,12 @@ import { Metrics } from '../utils/metrics';
 import { ContextCompressor } from './context-compressor';
 import { estimateMessagesTokens, estimateToolsTokens } from './token-estimator';
 import { foldHistoricalReadFileMessages, resolveReadFileMessageFoldingOptions } from './read-file-message-folder';
+import { foldHistoricalExecuteShellMessages, resolveExecuteShellMessageFoldingOptions } from './execute-shell-message-folder';
+import {
+  formatToolResultContextReport,
+  resolveToolResultContextReportOptions,
+  summarizeToolResultContext,
+} from './tool-result-context-report';
 import {
   buildExplicitPlanRequestHintIfUseful,
   buildInitialDecisionHintIfUseful,
@@ -304,6 +310,10 @@ export class ConversationRunner {
         ...orchestrationHints,
       ]);
       nextTurnTransientHints = [];
+      const toolResultContextReportOptions = resolveToolResultContextReportOptions();
+      const toolResultContextBeforeFolding = toolResultContextReportOptions.enabled
+        ? summarizeToolResultContext(requestMessages, toolResultContextReportOptions)
+        : null;
       const readFileFolding = foldHistoricalReadFileMessages(
         requestMessages,
         resolveReadFileMessageFoldingOptions(),
@@ -315,6 +325,30 @@ export class ConversationRunner {
           + `folded=${readFileFolding.stats.folded_count}, `
           + `saved≈${readFileFolding.stats.saved_tokens_est} tokens`,
         );
+      }
+      const executeShellFolding = foldHistoricalExecuteShellMessages(
+        requestMessages,
+        resolveExecuteShellMessageFoldingOptions(),
+      );
+      requestMessages = executeShellFolding.messages;
+      if (executeShellFolding.stats.folded_count > 0) {
+        Logger.info(
+          `[${this.sessionLabel}Turn ${turns}] execute_shell historical folding: `
+          + `folded=${executeShellFolding.stats.folded_count}, `
+          + `saved≈${executeShellFolding.stats.saved_tokens_est} tokens`,
+        );
+      }
+      if (toolResultContextBeforeFolding && toolResultContextBeforeFolding.tool_result_count > 0) {
+        const toolResultContextAfterFolding = summarizeToolResultContext(
+          requestMessages,
+          toolResultContextReportOptions,
+        );
+        for (const line of formatToolResultContextReport(
+          toolResultContextBeforeFolding,
+          toolResultContextAfterFolding,
+        )) {
+          Logger.info(`[${this.sessionLabel}Turn ${turns}] ${line}`);
+        }
       }
       const promptTrimmed = this.ensurePromptBudget(requestMessages, requestTools);
       if (promptTrimmed && callbacks?.onThinking) {

--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -19,6 +19,10 @@ import {
   selectProtectedCurrentRunToolResultIndexes,
 } from './current-run-tool-result-folding';
 import {
+  foldToolResultsTowardPromptBudget,
+  resolveAdaptiveToolResultFoldingOptions,
+} from './adaptive-tool-result-folder';
+import {
   buildExplicitPlanRequestHintIfUseful,
   buildInitialDecisionHintIfUseful,
   buildPlanSoftNudge,
@@ -323,13 +327,19 @@ export class ConversationRunner {
         requestMessages,
         currentRunToolResultFoldingOptions,
       );
+      const readFileFoldingOptions = {
+        ...resolveReadFileMessageFoldingOptions(),
+        foldCurrentRun: currentRunToolResultFoldingOptions.enabled,
+        protectedCurrentRunToolResultIndexes,
+      };
+      const executeShellFoldingOptions = {
+        ...resolveExecuteShellMessageFoldingOptions(),
+        foldCurrentRun: currentRunToolResultFoldingOptions.enabled,
+        protectedCurrentRunToolResultIndexes,
+      };
       const readFileFolding = foldHistoricalReadFileMessages(
         requestMessages,
-        {
-          ...resolveReadFileMessageFoldingOptions(),
-          foldCurrentRun: currentRunToolResultFoldingOptions.enabled,
-          protectedCurrentRunToolResultIndexes,
-        },
+        readFileFoldingOptions,
       );
       requestMessages = readFileFolding.messages;
       if (readFileFolding.stats.folded_count > 0) {
@@ -342,11 +352,7 @@ export class ConversationRunner {
       }
       const executeShellFolding = foldHistoricalExecuteShellMessages(
         requestMessages,
-        {
-          ...resolveExecuteShellMessageFoldingOptions(),
-          foldCurrentRun: currentRunToolResultFoldingOptions.enabled,
-          protectedCurrentRunToolResultIndexes,
-        },
+        executeShellFoldingOptions,
       );
       requestMessages = executeShellFolding.messages;
       if (executeShellFolding.stats.folded_count > 0) {
@@ -355,6 +361,26 @@ export class ConversationRunner {
           + `folded=${executeShellFolding.stats.folded_count}, `
           + `current=${executeShellFolding.stats.folded_current_turn_count}, `
           + `saved≈${executeShellFolding.stats.saved_tokens_est} tokens`,
+        );
+      }
+      const adaptiveFolding = foldToolResultsTowardPromptBudget(
+        requestMessages,
+        requestTools,
+        readFileFoldingOptions,
+        executeShellFoldingOptions,
+        resolveAdaptiveToolResultFoldingOptions(),
+      );
+      requestMessages = adaptiveFolding.messages;
+      if (adaptiveFolding.stats.folded_count > 0) {
+        Logger.info(
+          `[${this.sessionLabel}Turn ${turns}] adaptive tool_result folding: `
+          + `passes=${adaptiveFolding.stats.passes}, `
+          + `folded=${adaptiveFolding.stats.folded_count}, `
+          + `current=${adaptiveFolding.stats.folded_current_turn_count}, `
+          + `saved≈${adaptiveFolding.stats.saved_tokens_est} tokens, `
+          + `prompt≈${adaptiveFolding.stats.started_prompt_tokens_est}->${adaptiveFolding.stats.finished_prompt_tokens_est}, `
+          + `target=${adaptiveFolding.stats.target_prompt_tokens}, `
+          + `thresholds=${adaptiveFolding.stats.thresholds_tried.join('/')}`,
         );
       }
       if (toolResultContextBeforeFolding && toolResultContextBeforeFolding.tool_result_count > 0) {

--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -368,7 +368,7 @@ export class ConversationRunner {
         requestTools,
         readFileFoldingOptions,
         executeShellFoldingOptions,
-        this.resolveAdaptiveToolResultFoldingOptions(requestTools),
+        this.resolveAdaptiveToolResultFoldingOptions(),
       );
       requestMessages = adaptiveFolding.messages;
       if (adaptiveFolding.stats.folded_count > 0) {
@@ -1280,14 +1280,14 @@ export class ConversationRunner {
     return true;
   }
 
-  private resolveAdaptiveToolResultFoldingOptions(tools: ToolDefinition[]) {
-    const messageBudget = Math.max(1, this.maxPromptTokens - estimateToolsTokens(tools));
+  private resolveAdaptiveToolResultFoldingOptions() {
+    const promptBudget = Math.max(1, this.maxPromptTokens);
     const options = resolveAdaptiveToolResultFoldingOptions(process.env, {
-      targetPromptTokens: messageBudget,
+      targetPromptTokens: promptBudget,
     });
     return {
       ...options,
-      targetPromptTokens: Math.min(options.targetPromptTokens, messageBudget),
+      targetPromptTokens: Math.min(options.targetPromptTokens, promptBudget),
     };
   }
 

--- a/src/core/current-run-tool-result-folding.ts
+++ b/src/core/current-run-tool-result-folding.ts
@@ -1,0 +1,81 @@
+import { Message } from '../types';
+
+export interface CurrentRunToolResultFoldingOptions {
+  enabled: boolean;
+  keepRecentToolResults: number;
+}
+
+const DEFAULT_OPTIONS: CurrentRunToolResultFoldingOptions = {
+  enabled: true,
+  keepRecentToolResults: 3,
+};
+
+const FOLDABLE_TOOL_NAMES = new Set(['read_file', 'execute_shell']);
+
+export function resolveCurrentRunToolResultFoldingOptions(
+  env: NodeJS.ProcessEnv = process.env,
+): CurrentRunToolResultFoldingOptions {
+  return {
+    enabled: readBooleanEnv(env.XIAOBA_CURRENT_RUN_TOOL_RESULT_FOLDING, DEFAULT_OPTIONS.enabled),
+    keepRecentToolResults: readNonNegativeIntegerEnv(
+      env.XIAOBA_CURRENT_RUN_TOOL_RESULT_FOLD_KEEP_RECENT,
+      DEFAULT_OPTIONS.keepRecentToolResults,
+    ),
+  };
+}
+
+export function selectProtectedCurrentRunToolResultIndexes(
+  messages: Message[],
+  options: Partial<CurrentRunToolResultFoldingOptions> = {},
+): Set<number> {
+  const resolved = { ...DEFAULT_OPTIONS, ...options };
+  if (!resolved.enabled || resolved.keepRecentToolResults <= 0) {
+    return new Set();
+  }
+
+  const lastUserIndex = findLastRealUserIndex(messages);
+  if (lastUserIndex < 0) return new Set();
+
+  const currentRunToolIndexes: number[] = [];
+  messages.forEach((message, index) => {
+    if (index <= lastUserIndex) return;
+    if (message.role !== 'tool') return;
+    if (Array.isArray(message.content)) return;
+    if (!FOLDABLE_TOOL_NAMES.has(normalizeToolName(message.name || ''))) return;
+    currentRunToolIndexes.push(index);
+  });
+
+  return new Set(currentRunToolIndexes.slice(-resolved.keepRecentToolResults));
+}
+
+function findLastRealUserIndex(messages: Message[]): number {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (message.role !== 'user') continue;
+    if (message.__injected) continue;
+    if (typeof message.content === 'string' && message.content.startsWith('[transient_')) continue;
+    return i;
+  }
+  return -1;
+}
+
+function normalizeToolName(name: string): string {
+  const normalized = String(name || '').trim();
+  if (['Bash', 'bash', 'Shell', 'shell', 'execute_bash'].includes(normalized)) {
+    return 'execute_shell';
+  }
+  if (normalized === 'Read') return 'read_file';
+  return normalized;
+}
+
+function readBooleanEnv(value: string | undefined, fallback: boolean): boolean {
+  if (value === undefined || value === '') return fallback;
+  if (/^(1|true|yes|on)$/i.test(value)) return true;
+  if (/^(0|false|no|off)$/i.test(value)) return false;
+  return fallback;
+}
+
+function readNonNegativeIntegerEnv(value: string | undefined, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : fallback;
+}

--- a/src/core/execute-shell-message-folder.ts
+++ b/src/core/execute-shell-message-folder.ts
@@ -1,0 +1,365 @@
+import { createHash } from 'crypto';
+import { Message } from '../types';
+import { estimateTokens } from './token-estimator';
+
+export const FOLDED_EXECUTE_SHELL_PREFIX = '[folded_execute_shell]';
+
+export interface ExecuteShellMessageFoldingOptions {
+  enabled: boolean;
+  thresholdTokens: number;
+  maxHeadLines: number;
+  maxTailLines: number;
+  maxKeyLines: number;
+  keepRecentHistoricalShells: number;
+}
+
+export interface ExecuteShellMessageFoldingStats {
+  enabled: boolean;
+  candidate_count: number;
+  folded_count: number;
+  skipped_recent_count: number;
+  skipped_current_turn_count: number;
+  raw_tokens_est: number;
+  folded_tokens_est: number;
+  saved_tokens_est: number;
+  threshold_tokens: number;
+  keep_recent_historical_shells: number;
+}
+
+export interface ExecuteShellMessageFoldingResult {
+  messages: Message[];
+  stats: ExecuteShellMessageFoldingStats;
+}
+
+interface FoldCandidate {
+  index: number;
+  message: Message;
+  rawText: string;
+  rawTokens: number;
+  toolCall?: NonNullable<Message['tool_calls']>[number];
+}
+
+interface ShellMetadata {
+  command?: string;
+  description?: string;
+  timeout?: number;
+  cwd?: string;
+  status?: 'succeeded' | 'failed' | 'unknown';
+  elapsed?: string;
+  outputLines?: string;
+}
+
+const DEFAULT_OPTIONS: ExecuteShellMessageFoldingOptions = {
+  enabled: true,
+  thresholdTokens: 2000,
+  maxHeadLines: 12,
+  maxTailLines: 24,
+  maxKeyLines: 32,
+  keepRecentHistoricalShells: 0,
+};
+
+export function resolveExecuteShellMessageFoldingOptions(
+  env: NodeJS.ProcessEnv = process.env,
+): ExecuteShellMessageFoldingOptions {
+  return {
+    enabled: readBooleanEnv(env.XIAOBA_EXECUTE_SHELL_MESSAGE_FOLDING, DEFAULT_OPTIONS.enabled),
+    thresholdTokens: readPositiveIntegerEnv(
+      env.XIAOBA_EXECUTE_SHELL_FOLD_THRESHOLD_TOKENS,
+      DEFAULT_OPTIONS.thresholdTokens,
+    ),
+    maxHeadLines: readPositiveIntegerEnv(
+      env.XIAOBA_EXECUTE_SHELL_FOLD_HEAD_LINES,
+      DEFAULT_OPTIONS.maxHeadLines,
+    ),
+    maxTailLines: readPositiveIntegerEnv(
+      env.XIAOBA_EXECUTE_SHELL_FOLD_TAIL_LINES,
+      DEFAULT_OPTIONS.maxTailLines,
+    ),
+    maxKeyLines: readPositiveIntegerEnv(
+      env.XIAOBA_EXECUTE_SHELL_FOLD_KEY_LINES,
+      DEFAULT_OPTIONS.maxKeyLines,
+    ),
+    keepRecentHistoricalShells: readNonNegativeIntegerEnv(
+      env.XIAOBA_EXECUTE_SHELL_FOLD_KEEP_RECENT,
+      DEFAULT_OPTIONS.keepRecentHistoricalShells,
+    ),
+  };
+}
+
+export function foldHistoricalExecuteShellMessages(
+  messages: Message[],
+  options: Partial<ExecuteShellMessageFoldingOptions> = {},
+): ExecuteShellMessageFoldingResult {
+  const resolved = { ...DEFAULT_OPTIONS, ...options };
+  const baseStats = emptyStats(resolved);
+  if (!resolved.enabled || messages.length === 0) {
+    return { messages, stats: baseStats };
+  }
+
+  const lastUserIndex = findLastRealUserIndex(messages);
+  if (lastUserIndex < 0) {
+    return { messages, stats: baseStats };
+  }
+
+  const toolCallsById = collectToolCallsById(messages);
+  const candidates: FoldCandidate[] = [];
+  let skippedCurrentTurnCount = 0;
+
+  messages.forEach((message, index) => {
+    if (!isExecuteShellToolResult(message)) return;
+    if (index > lastUserIndex) {
+      skippedCurrentTurnCount++;
+      return;
+    }
+
+    const rawText = typeof message.content === 'string' ? message.content : '';
+    if (!rawText || rawText.startsWith(FOLDED_EXECUTE_SHELL_PREFIX)) return;
+
+    const rawTokens = estimateTokens(rawText);
+    if (rawTokens < resolved.thresholdTokens) return;
+
+    const toolCall = message.tool_call_id
+      ? toolCallsById.get(message.tool_call_id)
+      : undefined;
+    candidates.push({ index, message, rawText, rawTokens, toolCall });
+  });
+
+  const stats = emptyStats(resolved);
+  stats.candidate_count = candidates.length;
+  stats.skipped_current_turn_count = skippedCurrentTurnCount;
+
+  if (candidates.length === 0) {
+    return { messages, stats };
+  }
+
+  const keepRecent = Math.min(resolved.keepRecentHistoricalShells, candidates.length);
+  const candidatesToFold = candidates.slice(0, candidates.length - keepRecent);
+  stats.skipped_recent_count = keepRecent;
+
+  if (candidatesToFold.length === 0) {
+    return { messages, stats };
+  }
+
+  const foldedByIndex = new Map<number, string>();
+  for (const candidate of candidatesToFold) {
+    const folded = buildFoldedExecuteShellContent(candidate, resolved);
+    foldedByIndex.set(candidate.index, folded);
+    stats.folded_count++;
+    stats.raw_tokens_est += candidate.rawTokens;
+    stats.folded_tokens_est += estimateTokens(folded);
+  }
+  stats.saved_tokens_est = Math.max(0, stats.raw_tokens_est - stats.folded_tokens_est);
+
+  const foldedMessages = messages.map((message, index) => {
+    const folded = foldedByIndex.get(index);
+    if (!folded) return message;
+    return {
+      ...message,
+      content: folded,
+    };
+  });
+
+  return { messages: foldedMessages, stats };
+}
+
+function emptyStats(options: ExecuteShellMessageFoldingOptions): ExecuteShellMessageFoldingStats {
+  return {
+    enabled: options.enabled,
+    candidate_count: 0,
+    folded_count: 0,
+    skipped_recent_count: 0,
+    skipped_current_turn_count: 0,
+    raw_tokens_est: 0,
+    folded_tokens_est: 0,
+    saved_tokens_est: 0,
+    threshold_tokens: options.thresholdTokens,
+    keep_recent_historical_shells: options.keepRecentHistoricalShells,
+  };
+}
+
+function buildFoldedExecuteShellContent(
+  candidate: FoldCandidate,
+  options: ExecuteShellMessageFoldingOptions,
+): string {
+  const metadata = extractShellMetadata(candidate.rawText, candidate.toolCall);
+  const lines = candidate.rawText.split(/\r?\n/);
+  const headLines = selectHeadLines(lines, options.maxHeadLines);
+  const tailLines = selectTailLines(lines, options.maxTailLines, options.maxHeadLines);
+  const keyLines = selectKeyLines(lines, options.maxKeyLines);
+  const hash = createHash('sha256')
+    .update(metadata.command || '')
+    .update('\0')
+    .update(candidate.rawText)
+    .digest('hex');
+
+  const foldedParts = [
+    FOLDED_EXECUTE_SHELL_PREFIX,
+    `artifact_id: sh_${hash.slice(0, 16)}`,
+    metadata.command ? `command: ${oneLine(metadata.command, 1600)}` : '',
+    metadata.description ? `description: ${oneLine(metadata.description, 400)}` : '',
+    metadata.cwd ? `cwd: ${metadata.cwd}` : '',
+    metadata.timeout ? `timeout_ms: ${metadata.timeout}` : '',
+    metadata.status ? `status: ${metadata.status}` : '',
+    metadata.elapsed ? `elapsed: ${metadata.elapsed}` : '',
+    metadata.outputLines ? `output_lines: ${metadata.outputLines}` : '',
+    `original_chars: ${candidate.rawText.length}`,
+    `original_lines: ${lines.length}`,
+    `original_tokens_est: ${candidate.rawTokens}`,
+    `sha256: ${hash}`,
+    '',
+    'summary: Historical execute_shell output was folded out of the provider prompt. Re-run the command or inspect logs before relying on omitted lines.',
+    headLines.length > 0 ? ['head:', ...headLines.map(line => `  ${line}`)].join('\n') : '',
+    tailLines.length > 0 ? ['tail:', ...tailLines.map(line => `  ${line}`)].join('\n') : '',
+    keyLines.length > 0 ? ['key_lines:', ...keyLines.map(line => `  ${line}`)].join('\n') : '',
+  ];
+
+  return foldedParts.filter(part => part !== '').join('\n');
+}
+
+function extractShellMetadata(
+  rawText: string,
+  toolCall?: NonNullable<Message['tool_calls']>[number],
+): ShellMetadata {
+  const args = parseToolArguments(toolCall);
+  return {
+    command: firstNonEmpty(stringArg(args, 'command'), readCommand(rawText)),
+    description: stringArg(args, 'description'),
+    timeout: numberArg(args, 'timeout'),
+    cwd: firstNonEmpty(stringArg(args, 'cwd'), stringArg(args, 'workingDirectory')),
+    status: readStatus(rawText),
+    elapsed: readHeader(rawText, 'Elapsed'),
+    outputLines: readHeader(rawText, 'Output lines'),
+  };
+}
+
+function collectToolCallsById(messages: Message[]): Map<string, NonNullable<Message['tool_calls']>[number]> {
+  const result = new Map<string, NonNullable<Message['tool_calls']>[number]>();
+  for (const message of messages) {
+    for (const toolCall of message.tool_calls || []) {
+      result.set(toolCall.id, toolCall);
+    }
+  }
+  return result;
+}
+
+function isExecuteShellToolResult(message: Message): boolean {
+  if (message.role !== 'tool') return false;
+  if (Array.isArray(message.content)) return false;
+  return normalizeToolName(message.name || '') === 'execute_shell';
+}
+
+function normalizeToolName(name: string): string {
+  const normalized = String(name || '').trim();
+  if (['Bash', 'bash', 'Shell', 'shell', 'execute_bash'].includes(normalized)) {
+    return 'execute_shell';
+  }
+  return normalized;
+}
+
+function findLastRealUserIndex(messages: Message[]): number {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (message.role !== 'user') continue;
+    if (message.__injected) continue;
+    if (typeof message.content === 'string' && message.content.startsWith('[transient_')) continue;
+    return i;
+  }
+  return -1;
+}
+
+function selectHeadLines(lines: string[], maxHeadLines: number): string[] {
+  return lines.slice(0, maxHeadLines).map(trimForFoldedOutput);
+}
+
+function selectTailLines(lines: string[], maxTailLines: number, headLineCount: number): string[] {
+  if (lines.length <= headLineCount + maxTailLines) return [];
+  return lines.slice(-maxTailLines).map(trimForFoldedOutput);
+}
+
+function selectKeyLines(lines: string[], maxKeyLines: number): string[] {
+  const keyPattern = /\b(error|warn|warning|fail|failed|failure|exception|traceback|fatal|panic|timeout|timed out|denied|not found|cannot|can't|undefined|typeerror|assertionerror|npm err|exit code)\b|(^|\s)(ERR!|FAIL|ERROR|WARN)(\s|$)|([A-Za-z]:\\|\/)[^\s:]+:\d+/i;
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const line of lines) {
+    if (!keyPattern.test(line)) continue;
+    const compact = trimForFoldedOutput(line);
+    if (!compact || seen.has(compact)) continue;
+    seen.add(compact);
+    result.push(compact);
+    if (result.length >= maxKeyLines) break;
+  }
+  return result;
+}
+
+function readCommand(rawText: string): string | undefined {
+  const lines = rawText.split(/\r?\n/);
+  for (const line of lines) {
+    if (line.startsWith('$ ')) return line.slice(2).trim() || undefined;
+  }
+  return undefined;
+}
+
+function readStatus(rawText: string): ShellMetadata['status'] {
+  if (/^Command succeeded:/m.test(rawText)) return 'succeeded';
+  if (/^Command failed:/m.test(rawText)) return 'failed';
+  return 'unknown';
+}
+
+function readHeader(rawText: string, label: string): string | undefined {
+  const escapedLabel = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = rawText.match(new RegExp(`^${escapedLabel}:\\s*(.+)$`, 'm'));
+  return match?.[1]?.trim() || undefined;
+}
+
+function parseToolArguments(toolCall?: NonNullable<Message['tool_calls']>[number]): Record<string, unknown> {
+  if (!toolCall?.function?.arguments) return {};
+  try {
+    const parsed = JSON.parse(toolCall.function.arguments);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function stringArg(args: Record<string, unknown>, key: string): string | undefined {
+  const value = args[key];
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function numberArg(args: Record<string, unknown>, key: string): number | undefined {
+  const value = Number(args[key]);
+  return Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+function firstNonEmpty(...values: Array<string | undefined>): string | undefined {
+  return values.find(value => Boolean(value && value.trim()));
+}
+
+function oneLine(value: string, maxLength: number): string {
+  return trimForFoldedOutput(value.replace(/\r?\n/g, ' ; '), maxLength);
+}
+
+function trimForFoldedOutput(line: string, maxLength = 500): string {
+  const trimmed = line.replace(/\s+$/g, '');
+  if (trimmed.length <= maxLength) return trimmed;
+  return `${trimmed.slice(0, maxLength - 20)}...(truncated ${trimmed.length} chars)`;
+}
+
+function readBooleanEnv(value: string | undefined, fallback: boolean): boolean {
+  if (value === undefined || value === '') return fallback;
+  if (/^(1|true|yes|on)$/i.test(value)) return true;
+  if (/^(0|false|no|off)$/i.test(value)) return false;
+  return fallback;
+}
+
+function readPositiveIntegerEnv(value: string | undefined, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function readNonNegativeIntegerEnv(value: string | undefined, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : fallback;
+}

--- a/src/core/execute-shell-message-folder.ts
+++ b/src/core/execute-shell-message-folder.ts
@@ -11,14 +11,19 @@ export interface ExecuteShellMessageFoldingOptions {
   maxTailLines: number;
   maxKeyLines: number;
   keepRecentHistoricalShells: number;
+  foldCurrentRun: boolean;
+  protectedCurrentRunToolResultIndexes?: ReadonlySet<number>;
 }
 
 export interface ExecuteShellMessageFoldingStats {
   enabled: boolean;
   candidate_count: number;
+  current_turn_candidate_count: number;
   folded_count: number;
+  folded_current_turn_count: number;
   skipped_recent_count: number;
   skipped_current_turn_count: number;
+  protected_current_turn_count: number;
   raw_tokens_est: number;
   folded_tokens_est: number;
   saved_tokens_est: number;
@@ -36,6 +41,7 @@ interface FoldCandidate {
   message: Message;
   rawText: string;
   rawTokens: number;
+  currentRun: boolean;
   toolCall?: NonNullable<Message['tool_calls']>[number];
 }
 
@@ -56,6 +62,7 @@ const DEFAULT_OPTIONS: ExecuteShellMessageFoldingOptions = {
   maxTailLines: 24,
   maxKeyLines: 32,
   keepRecentHistoricalShells: 0,
+  foldCurrentRun: false,
 };
 
 export function resolveExecuteShellMessageFoldingOptions(
@@ -83,6 +90,7 @@ export function resolveExecuteShellMessageFoldingOptions(
       env.XIAOBA_EXECUTE_SHELL_FOLD_KEEP_RECENT,
       DEFAULT_OPTIONS.keepRecentHistoricalShells,
     ),
+    foldCurrentRun: DEFAULT_OPTIONS.foldCurrentRun,
   };
 }
 
@@ -104,11 +112,18 @@ export function foldHistoricalExecuteShellMessages(
   const toolCallsById = collectToolCallsById(messages);
   const candidates: FoldCandidate[] = [];
   let skippedCurrentTurnCount = 0;
+  let protectedCurrentTurnCount = 0;
 
   messages.forEach((message, index) => {
     if (!isExecuteShellToolResult(message)) return;
-    if (index > lastUserIndex) {
+    const currentRun = index > lastUserIndex;
+    if (currentRun && !resolved.foldCurrentRun) {
       skippedCurrentTurnCount++;
+      return;
+    }
+    if (currentRun && resolved.protectedCurrentRunToolResultIndexes?.has(index)) {
+      skippedCurrentTurnCount++;
+      protectedCurrentTurnCount++;
       return;
     }
 
@@ -121,19 +136,26 @@ export function foldHistoricalExecuteShellMessages(
     const toolCall = message.tool_call_id
       ? toolCallsById.get(message.tool_call_id)
       : undefined;
-    candidates.push({ index, message, rawText, rawTokens, toolCall });
+    candidates.push({ index, message, rawText, rawTokens, currentRun, toolCall });
   });
 
   const stats = emptyStats(resolved);
   stats.candidate_count = candidates.length;
+  stats.current_turn_candidate_count = candidates.filter(candidate => candidate.currentRun).length;
   stats.skipped_current_turn_count = skippedCurrentTurnCount;
+  stats.protected_current_turn_count = protectedCurrentTurnCount;
 
   if (candidates.length === 0) {
     return { messages, stats };
   }
 
-  const keepRecent = Math.min(resolved.keepRecentHistoricalShells, candidates.length);
-  const candidatesToFold = candidates.slice(0, candidates.length - keepRecent);
+  const historicalCandidates = candidates.filter(candidate => !candidate.currentRun);
+  const currentRunCandidates = candidates.filter(candidate => candidate.currentRun);
+  const keepRecent = Math.min(resolved.keepRecentHistoricalShells, historicalCandidates.length);
+  const candidatesToFold = [
+    ...historicalCandidates.slice(0, historicalCandidates.length - keepRecent),
+    ...currentRunCandidates,
+  ];
   stats.skipped_recent_count = keepRecent;
 
   if (candidatesToFold.length === 0) {
@@ -145,6 +167,7 @@ export function foldHistoricalExecuteShellMessages(
     const folded = buildFoldedExecuteShellContent(candidate, resolved);
     foldedByIndex.set(candidate.index, folded);
     stats.folded_count++;
+    if (candidate.currentRun) stats.folded_current_turn_count++;
     stats.raw_tokens_est += candidate.rawTokens;
     stats.folded_tokens_est += estimateTokens(folded);
   }
@@ -166,9 +189,12 @@ function emptyStats(options: ExecuteShellMessageFoldingOptions): ExecuteShellMes
   return {
     enabled: options.enabled,
     candidate_count: 0,
+    current_turn_candidate_count: 0,
     folded_count: 0,
+    folded_current_turn_count: 0,
     skipped_recent_count: 0,
     skipped_current_turn_count: 0,
+    protected_current_turn_count: 0,
     raw_tokens_est: 0,
     folded_tokens_est: 0,
     saved_tokens_est: 0,

--- a/src/core/read-file-message-folder.ts
+++ b/src/core/read-file-message-folder.ts
@@ -10,14 +10,19 @@ export interface ReadFileMessageFoldingOptions {
   maxPreviewLines: number;
   maxSymbolLines: number;
   keepRecentHistoricalReads: number;
+  foldCurrentRun: boolean;
+  protectedCurrentRunToolResultIndexes?: ReadonlySet<number>;
 }
 
 export interface ReadFileMessageFoldingStats {
   enabled: boolean;
   candidate_count: number;
+  current_turn_candidate_count: number;
   folded_count: number;
+  folded_current_turn_count: number;
   skipped_recent_count: number;
   skipped_current_turn_count: number;
+  protected_current_turn_count: number;
   raw_tokens_est: number;
   folded_tokens_est: number;
   saved_tokens_est: number;
@@ -35,6 +40,7 @@ interface FoldCandidate {
   message: Message;
   rawText: string;
   rawTokens: number;
+  currentRun: boolean;
   toolCall?: NonNullable<Message['tool_calls']>[number];
 }
 
@@ -44,6 +50,7 @@ const DEFAULT_OPTIONS: ReadFileMessageFoldingOptions = {
   maxPreviewLines: 8,
   maxSymbolLines: 18,
   keepRecentHistoricalReads: 0,
+  foldCurrentRun: false,
 };
 
 export function resolveReadFileMessageFoldingOptions(
@@ -67,6 +74,7 @@ export function resolveReadFileMessageFoldingOptions(
       env.XIAOBA_READ_FILE_FOLD_KEEP_RECENT,
       DEFAULT_OPTIONS.keepRecentHistoricalReads,
     ),
+    foldCurrentRun: DEFAULT_OPTIONS.foldCurrentRun,
   };
 }
 
@@ -88,11 +96,18 @@ export function foldHistoricalReadFileMessages(
   const toolCallsById = collectToolCallsById(messages);
   const candidates: FoldCandidate[] = [];
   let skippedCurrentTurnCount = 0;
+  let protectedCurrentTurnCount = 0;
 
   messages.forEach((message, index) => {
     if (!isReadFileToolResult(message)) return;
-    if (index > lastUserIndex) {
+    const currentRun = index > lastUserIndex;
+    if (currentRun && !resolved.foldCurrentRun) {
       skippedCurrentTurnCount++;
+      return;
+    }
+    if (currentRun && resolved.protectedCurrentRunToolResultIndexes?.has(index)) {
+      skippedCurrentTurnCount++;
+      protectedCurrentTurnCount++;
       return;
     }
 
@@ -105,19 +120,26 @@ export function foldHistoricalReadFileMessages(
     const toolCall = message.tool_call_id
       ? toolCallsById.get(message.tool_call_id)
       : undefined;
-    candidates.push({ index, message, rawText, rawTokens, toolCall });
+    candidates.push({ index, message, rawText, rawTokens, currentRun, toolCall });
   });
 
   const stats = emptyStats(resolved);
   stats.candidate_count = candidates.length;
+  stats.current_turn_candidate_count = candidates.filter(candidate => candidate.currentRun).length;
   stats.skipped_current_turn_count = skippedCurrentTurnCount;
+  stats.protected_current_turn_count = protectedCurrentTurnCount;
 
   if (candidates.length === 0) {
     return { messages, stats };
   }
 
-  const keepRecent = Math.min(resolved.keepRecentHistoricalReads, candidates.length);
-  const candidatesToFold = candidates.slice(0, candidates.length - keepRecent);
+  const historicalCandidates = candidates.filter(candidate => !candidate.currentRun);
+  const currentRunCandidates = candidates.filter(candidate => candidate.currentRun);
+  const keepRecent = Math.min(resolved.keepRecentHistoricalReads, historicalCandidates.length);
+  const candidatesToFold = [
+    ...historicalCandidates.slice(0, historicalCandidates.length - keepRecent),
+    ...currentRunCandidates,
+  ];
   stats.skipped_recent_count = keepRecent;
 
   if (candidatesToFold.length === 0) {
@@ -129,6 +151,7 @@ export function foldHistoricalReadFileMessages(
     const folded = buildFoldedReadFileContent(candidate, resolved);
     foldedByIndex.set(candidate.index, folded);
     stats.folded_count++;
+    if (candidate.currentRun) stats.folded_current_turn_count++;
     stats.raw_tokens_est += candidate.rawTokens;
     stats.folded_tokens_est += estimateTokens(folded);
   }
@@ -150,9 +173,12 @@ function emptyStats(options: ReadFileMessageFoldingOptions): ReadFileMessageFold
   return {
     enabled: options.enabled,
     candidate_count: 0,
+    current_turn_candidate_count: 0,
     folded_count: 0,
+    folded_current_turn_count: 0,
     skipped_recent_count: 0,
     skipped_current_turn_count: 0,
+    protected_current_turn_count: 0,
     raw_tokens_est: 0,
     folded_tokens_est: 0,
     saved_tokens_est: 0,

--- a/src/core/tool-result-context-report.ts
+++ b/src/core/tool-result-context-report.ts
@@ -1,0 +1,168 @@
+import { Message } from '../types';
+import { estimateTokens } from './token-estimator';
+
+export interface ToolResultContextReportOptions {
+  enabled: boolean;
+  topTools: number;
+  topMessages: number;
+}
+
+export interface ToolResultToolSummary {
+  name: string;
+  count: number;
+  chars: number;
+  tokens_est: number;
+  max_chars: number;
+}
+
+export interface ToolResultMessageSummary {
+  index: number;
+  name: string;
+  chars: number;
+  tokens_est: number;
+}
+
+export interface ToolResultContextSummary {
+  tool_result_count: number;
+  total_chars: number;
+  total_tokens_est: number;
+  by_tool: ToolResultToolSummary[];
+  largest_messages: ToolResultMessageSummary[];
+}
+
+const DEFAULT_OPTIONS: ToolResultContextReportOptions = {
+  enabled: true,
+  topTools: 5,
+  topMessages: 5,
+};
+
+export function resolveToolResultContextReportOptions(
+  env: NodeJS.ProcessEnv = process.env,
+): ToolResultContextReportOptions {
+  return {
+    enabled: readBooleanEnv(env.XIAOBA_TOOL_RESULT_CONTEXT_REPORT, DEFAULT_OPTIONS.enabled),
+    topTools: readPositiveIntegerEnv(
+      env.XIAOBA_TOOL_RESULT_CONTEXT_REPORT_TOP_TOOLS,
+      DEFAULT_OPTIONS.topTools,
+    ),
+    topMessages: readPositiveIntegerEnv(
+      env.XIAOBA_TOOL_RESULT_CONTEXT_REPORT_TOP_MESSAGES,
+      DEFAULT_OPTIONS.topMessages,
+    ),
+  };
+}
+
+export function summarizeToolResultContext(
+  messages: Message[],
+  options: Partial<Pick<ToolResultContextReportOptions, 'topTools' | 'topMessages'>> = {},
+): ToolResultContextSummary {
+  const resolved = { ...DEFAULT_OPTIONS, ...options };
+  const tools = new Map<string, ToolResultToolSummary>();
+  const largestCandidates: ToolResultMessageSummary[] = [];
+  let toolResultCount = 0;
+  let totalChars = 0;
+  let totalTokens = 0;
+
+  messages.forEach((message, index) => {
+    if (message.role !== 'tool') return;
+    const text = contentForMeasurement(message.content);
+    const chars = text.length;
+    const tokens = estimateTokens(text);
+    const name = normalizeToolName(message.name || 'unknown');
+    toolResultCount++;
+    totalChars += chars;
+    totalTokens += tokens;
+
+    const existing = tools.get(name) || {
+      name,
+      count: 0,
+      chars: 0,
+      tokens_est: 0,
+      max_chars: 0,
+    };
+    existing.count++;
+    existing.chars += chars;
+    existing.tokens_est += tokens;
+    existing.max_chars = Math.max(existing.max_chars, chars);
+    tools.set(name, existing);
+
+    largestCandidates.push({
+      index,
+      name,
+      chars,
+      tokens_est: tokens,
+    });
+  });
+
+  return {
+    tool_result_count: toolResultCount,
+    total_chars: totalChars,
+    total_tokens_est: totalTokens,
+    by_tool: Array.from(tools.values())
+      .sort((a, b) => b.chars - a.chars)
+      .slice(0, resolved.topTools),
+    largest_messages: largestCandidates
+      .sort((a, b) => b.chars - a.chars)
+      .slice(0, resolved.topMessages),
+  };
+}
+
+export function formatToolResultContextReport(
+  before: ToolResultContextSummary,
+  after: ToolResultContextSummary,
+): string[] {
+  const savedChars = Math.max(0, before.total_chars - after.total_chars);
+  const savedTokens = Math.max(0, before.total_tokens_est - after.total_tokens_est);
+  return [
+    `tool_result context: before=${before.tool_result_count} results/${before.total_chars} chars/${before.total_tokens_est} tokens_est; `
+      + `after=${after.tool_result_count} results/${after.total_chars} chars/${after.total_tokens_est} tokens_est; `
+      + `saved=${savedChars} chars/${savedTokens} tokens_est`,
+    `tool_result top_tools_before: ${formatToolSummaries(before.by_tool)}`,
+    `tool_result largest_before: ${formatMessageSummaries(before.largest_messages)}`,
+  ];
+}
+
+function formatToolSummaries(items: ToolResultToolSummary[]): string {
+  if (items.length === 0) return '(none)';
+  return items
+    .map(item => `${item.name} count=${item.count} chars=${item.chars} max=${item.max_chars}`)
+    .join('; ');
+}
+
+function formatMessageSummaries(items: ToolResultMessageSummary[]): string {
+  if (items.length === 0) return '(none)';
+  return items
+    .map(item => `#${item.index} ${item.name} chars=${item.chars} tokens_est=${item.tokens_est}`)
+    .join('; ');
+}
+
+function contentForMeasurement(content: Message['content']): string {
+  if (!content) return '';
+  if (typeof content === 'string') return content;
+  try {
+    return JSON.stringify(content);
+  } catch {
+    return String(content);
+  }
+}
+
+function normalizeToolName(name: string): string {
+  const normalized = String(name || '').trim();
+  if (['Bash', 'bash', 'Shell', 'shell', 'execute_bash'].includes(normalized)) {
+    return 'execute_shell';
+  }
+  if (normalized === 'Read') return 'read_file';
+  return normalized || 'unknown';
+}
+
+function readBooleanEnv(value: string | undefined, fallback: boolean): boolean {
+  if (value === undefined || value === '') return fallback;
+  if (/^(1|true|yes|on)$/i.test(value)) return true;
+  if (/^(0|false|no|off)$/i.test(value)) return false;
+  return fallback;
+}
+
+function readPositiveIntegerEnv(value: string | undefined, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}

--- a/tests/adaptive-tool-result-folder.test.ts
+++ b/tests/adaptive-tool-result-folder.test.ts
@@ -1,0 +1,187 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  foldToolResultsTowardPromptBudget,
+  resolveAdaptiveToolResultFoldingOptions,
+} from '../src/core/adaptive-tool-result-folder';
+import { Message } from '../src/types';
+
+function makeToolCall(id: string, name: string, args: Record<string, unknown>): Message {
+  return {
+    role: 'assistant',
+    content: null,
+    tool_calls: [{
+      id,
+      type: 'function',
+      function: {
+        name,
+        arguments: JSON.stringify(args),
+      },
+    }],
+  };
+}
+
+function makeReadFileOutput(path: string, chars: number): string {
+  return [
+    `File: ${path}`,
+    `Path: ${path}`,
+    '',
+    'read output '.repeat(Math.ceil(chars / 12)).slice(0, chars),
+  ].join('\n');
+}
+
+function makeShellOutput(command: string, chars: number): string {
+  return [
+    'Command succeeded:',
+    `$ ${command}`,
+    '',
+    'Elapsed: 100ms',
+    'Output lines: 1',
+    '',
+    'shell output '.repeat(Math.ceil(chars / 13)).slice(0, chars),
+  ].join('\n');
+}
+
+test('adaptively lowers thresholds to fold additional tool results toward a prompt budget', () => {
+  const readRaw = makeReadFileOutput('E:/repo/a.ts', 6000);
+  const shellRaw = makeShellOutput('npm test', 6000);
+  const messages: Message[] = [
+    { role: 'user', content: 'old request' },
+    makeToolCall('call_read', 'read_file', { file_path: 'E:/repo/a.ts' }),
+    { role: 'tool', name: 'read_file', tool_call_id: 'call_read', content: readRaw },
+    makeToolCall('call_shell', 'execute_shell', { command: 'npm test' }),
+    { role: 'tool', name: 'execute_shell', tool_call_id: 'call_shell', content: shellRaw },
+    { role: 'assistant', content: 'done' },
+    { role: 'user', content: 'continue' },
+  ];
+
+  const result = foldToolResultsTowardPromptBudget(
+    messages,
+    [],
+    {
+      enabled: true,
+      thresholdTokens: 2000,
+      maxPreviewLines: 2,
+      maxSymbolLines: 2,
+      keepRecentHistoricalReads: 0,
+      foldCurrentRun: false,
+    },
+    {
+      enabled: true,
+      thresholdTokens: 2000,
+      maxHeadLines: 2,
+      maxTailLines: 2,
+      maxKeyLines: 2,
+      keepRecentHistoricalShells: 0,
+      foldCurrentRun: false,
+    },
+    {
+      enabled: true,
+      targetPromptTokens: 1000,
+      minThresholdTokens: 500,
+      thresholdScale: 0.5,
+      maxPasses: 2,
+    },
+  );
+
+  assert.ok(result.stats.started_prompt_tokens_est > result.stats.finished_prompt_tokens_est);
+  assert.equal(result.stats.folded_count, 2);
+  assert.equal(result.stats.read_file_folded_count, 1);
+  assert.equal(result.stats.execute_shell_folded_count, 1);
+  assert.equal(result.stats.passes, 2);
+  assert.deepEqual(result.stats.thresholds_tried, [1000, 500]);
+  assert.match(String(result.messages[2].content), /^\[folded_read_file\]/);
+  assert.match(String(result.messages[4].content), /^\[folded_execute_shell\]/);
+});
+
+test('does not adaptively fold when disabled or already under target', () => {
+  const messages: Message[] = [
+    { role: 'user', content: 'old request' },
+    makeToolCall('call_read', 'read_file', { file_path: 'E:/repo/a.ts' }),
+    { role: 'tool', name: 'read_file', tool_call_id: 'call_read', content: makeReadFileOutput('E:/repo/a.ts', 6000) },
+    { role: 'assistant', content: 'done' },
+    { role: 'user', content: 'continue' },
+  ];
+
+  const disabled = foldToolResultsTowardPromptBudget(
+    messages,
+    [],
+    {
+      enabled: true,
+      thresholdTokens: 2000,
+      maxPreviewLines: 2,
+      maxSymbolLines: 2,
+      keepRecentHistoricalReads: 0,
+      foldCurrentRun: false,
+    },
+    {
+      enabled: true,
+      thresholdTokens: 2000,
+      maxHeadLines: 2,
+      maxTailLines: 2,
+      maxKeyLines: 2,
+      keepRecentHistoricalShells: 0,
+      foldCurrentRun: false,
+    },
+    {
+      enabled: false,
+      targetPromptTokens: 1,
+      minThresholdTokens: 500,
+      thresholdScale: 0.5,
+      maxPasses: 2,
+    },
+  );
+
+  assert.equal(disabled.stats.folded_count, 0);
+  assert.equal(disabled.messages[2].content, messages[2].content);
+
+  const underTarget = foldToolResultsTowardPromptBudget(
+    messages,
+    [],
+    {
+      enabled: true,
+      thresholdTokens: 2000,
+      maxPreviewLines: 2,
+      maxSymbolLines: 2,
+      keepRecentHistoricalReads: 0,
+      foldCurrentRun: false,
+    },
+    {
+      enabled: true,
+      thresholdTokens: 2000,
+      maxHeadLines: 2,
+      maxTailLines: 2,
+      maxKeyLines: 2,
+      keepRecentHistoricalShells: 0,
+      foldCurrentRun: false,
+    },
+    {
+      enabled: true,
+      targetPromptTokens: 100000,
+      minThresholdTokens: 500,
+      thresholdScale: 0.5,
+      maxPasses: 2,
+    },
+  );
+
+  assert.equal(underTarget.stats.folded_count, 0);
+  assert.equal(underTarget.messages[2].content, messages[2].content);
+});
+
+test('environment options control adaptive folding', () => {
+  const env = {
+    XIAOBA_ADAPTIVE_TOOL_RESULT_FOLDING: '0',
+    XIAOBA_ADAPTIVE_TOOL_RESULT_FOLD_TARGET_PROMPT_TOKENS: '90000',
+    XIAOBA_ADAPTIVE_TOOL_RESULT_FOLD_MIN_THRESHOLD_TOKENS: '250',
+    XIAOBA_ADAPTIVE_TOOL_RESULT_FOLD_THRESHOLD_SCALE: '0.25',
+    XIAOBA_ADAPTIVE_TOOL_RESULT_FOLD_MAX_PASSES: '6',
+  } as NodeJS.ProcessEnv;
+
+  const options = resolveAdaptiveToolResultFoldingOptions(env);
+
+  assert.equal(options.enabled, false);
+  assert.equal(options.targetPromptTokens, 90000);
+  assert.equal(options.minThresholdTokens, 250);
+  assert.equal(options.thresholdScale, 0.25);
+  assert.equal(options.maxPasses, 6);
+});

--- a/tests/conversation-runner-context-budget.test.ts
+++ b/tests/conversation-runner-context-budget.test.ts
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { ConversationRunner, PROMPT_BUDGET_TRIM_MESSAGE, PROMPT_TOOLS_DISABLED_MESSAGE } from '../src/core/conversation-runner';
+import { FOLDED_READ_FILE_PREFIX } from '../src/core/read-file-message-folder';
 import { estimateMessageTokens, estimateMessagesTokens, estimateToolsTokens } from '../src/core/token-estimator';
 import type { ContentBlock, Message } from '../src/types';
 import type { ToolDefinition, ToolExecutor } from '../src/types/tool';
@@ -14,6 +15,30 @@ function makeRunner(maxContextTokens: number): ConversationRunner {
     maxContextTokens,
     stream: false,
   });
+}
+
+function makeToolCallMessage(id: string, name: string, args: Record<string, unknown>): Message {
+  return {
+    role: 'assistant',
+    content: null,
+    tool_calls: [{
+      id,
+      type: 'function',
+      function: {
+        name,
+        arguments: JSON.stringify(args),
+      },
+    }],
+  };
+}
+
+function makeReadFileOutput(path: string, chars: number): string {
+  return [
+    `File: ${path}`,
+    `Path: ${path}`,
+    '',
+    'read output '.repeat(Math.ceil(chars / 12)).slice(0, chars),
+  ].join('\n');
 }
 
 test('prompt budget guard counts system messages and tool schemas before provider requests', () => {
@@ -91,6 +116,59 @@ test('prompt budget guard emits a visible thinking status before mechanical trim
   assert.equal(result.response, 'done');
   assert.deepEqual(thinking, [PROMPT_BUDGET_TRIM_MESSAGE]);
   assert.ok(estimateMessagesTokens(capturedMessages) <= 1_000);
+});
+
+test('adaptive tool result folding uses runner message budget before mechanical trimming', async () => {
+  const previousReadThreshold = process.env.XIAOBA_READ_FILE_FOLD_THRESHOLD_TOKENS;
+  const previousAdaptiveEnabled = process.env.XIAOBA_ADAPTIVE_TOOL_RESULT_FOLDING;
+  const previousAdaptiveTarget = process.env.XIAOBA_ADAPTIVE_TOOL_RESULT_FOLD_TARGET_PROMPT_TOKENS;
+  process.env.XIAOBA_READ_FILE_FOLD_THRESHOLD_TOKENS = '2000';
+  process.env.XIAOBA_ADAPTIVE_TOOL_RESULT_FOLDING = '1';
+  delete process.env.XIAOBA_ADAPTIVE_TOOL_RESULT_FOLD_TARGET_PROMPT_TOKENS;
+
+  const raw = makeReadFileOutput('E:/repo/budget-bound.ts', 7000);
+  const messages: Message[] = [
+    { role: 'user', content: 'old request' },
+    makeToolCallMessage('call_budget_read', 'read_file', { file_path: 'E:/repo/budget-bound.ts' }),
+    { role: 'tool', name: 'read_file', tool_call_id: 'call_budget_read', content: raw },
+    { role: 'assistant', content: 'old read complete' },
+    { role: 'user', content: 'current question '.repeat(1000) },
+  ];
+  assert.ok(estimateMessagesTokens(messages) > 5_000);
+  assert.ok(estimateMessagesTokens(messages) < 100_000);
+
+  const captured: Message[][] = [];
+  const aiService = {
+    async chat(requestMessages: Message[]) {
+      captured.push(JSON.parse(JSON.stringify(requestMessages)));
+      return { content: 'done' };
+    },
+  };
+  const executor: ToolExecutor = {
+    getToolDefinitions: () => [],
+    executeTool: async () => ({ content: 'unused' }),
+  };
+
+  try {
+    const runner = new ConversationRunner(aiService as any, executor, {
+      maxContextTokens: 5_000,
+      stream: false,
+      enableCompression: false,
+    });
+    await runner.run(messages);
+  } finally {
+    if (previousReadThreshold === undefined) delete process.env.XIAOBA_READ_FILE_FOLD_THRESHOLD_TOKENS;
+    else process.env.XIAOBA_READ_FILE_FOLD_THRESHOLD_TOKENS = previousReadThreshold;
+    if (previousAdaptiveEnabled === undefined) delete process.env.XIAOBA_ADAPTIVE_TOOL_RESULT_FOLDING;
+    else process.env.XIAOBA_ADAPTIVE_TOOL_RESULT_FOLDING = previousAdaptiveEnabled;
+    if (previousAdaptiveTarget === undefined) delete process.env.XIAOBA_ADAPTIVE_TOOL_RESULT_FOLD_TARGET_PROMPT_TOKENS;
+    else process.env.XIAOBA_ADAPTIVE_TOOL_RESULT_FOLD_TARGET_PROMPT_TOKENS = previousAdaptiveTarget;
+  }
+
+  const providerToolResult = captured[0].find(message => message.tool_call_id === 'call_budget_read');
+  assert.ok(String(providerToolResult?.content).startsWith(FOLDED_READ_FILE_PREFIX));
+  assert.ok(estimateMessagesTokens(captured[0]) <= 5_000);
+  assert.equal(messages[2].content, raw);
 });
 
 test('mechanical prompt trimming removes dangling tool result messages', () => {

--- a/tests/conversation-runner-context-budget.test.ts
+++ b/tests/conversation-runner-context-budget.test.ts
@@ -171,6 +171,77 @@ test('adaptive tool result folding uses runner message budget before mechanical 
   assert.equal(messages[2].content, raw);
 });
 
+test('adaptive tool result folding does not double-count tool schema budget', async () => {
+  const previousReadThreshold = process.env.XIAOBA_READ_FILE_FOLD_THRESHOLD_TOKENS;
+  const previousAdaptiveEnabled = process.env.XIAOBA_ADAPTIVE_TOOL_RESULT_FOLDING;
+  const previousAdaptiveTarget = process.env.XIAOBA_ADAPTIVE_TOOL_RESULT_FOLD_TARGET_PROMPT_TOKENS;
+  process.env.XIAOBA_READ_FILE_FOLD_THRESHOLD_TOKENS = '2000';
+  process.env.XIAOBA_ADAPTIVE_TOOL_RESULT_FOLDING = '1';
+  delete process.env.XIAOBA_ADAPTIVE_TOOL_RESULT_FOLD_TARGET_PROMPT_TOKENS;
+
+  const raw = makeReadFileOutput('E:/repo/under-budget.ts', 4000);
+  const messages: Message[] = [
+    { role: 'user', content: 'old request' },
+    makeToolCallMessage('call_under_budget_read', 'read_file', { file_path: 'E:/repo/under-budget.ts' }),
+    { role: 'tool', name: 'read_file', tool_call_id: 'call_under_budget_read', content: raw },
+    { role: 'assistant', content: 'old read complete' },
+    { role: 'user', content: 'current question '.repeat(500) },
+  ];
+  const tools: ToolDefinition[] = [{
+    name: 'large_tool',
+    description: 'tool schema '.repeat(250).slice(0, 3000),
+    parameters: {
+      type: 'object',
+      properties: {
+        payload: {
+          type: 'string',
+          description: 'payload '.repeat(100).slice(0, 700),
+        },
+      },
+    },
+  }];
+  const toolTokens = estimateToolsTokens(tools);
+  const totalPromptTokens = estimateMessagesTokens(messages) + toolTokens;
+  assert.ok(totalPromptTokens <= 5_000, `prompt should start under budget, got ${totalPromptTokens}`);
+  assert.ok(totalPromptTokens > 5_000 - toolTokens, 'fixture should catch accidental double-counting of tools');
+
+  const capturedMessages: Message[][] = [];
+  const capturedTools: ToolDefinition[][] = [];
+  const aiService = {
+    async chat(requestMessages: Message[], requestTools: ToolDefinition[]) {
+      capturedMessages.push(JSON.parse(JSON.stringify(requestMessages)));
+      capturedTools.push(JSON.parse(JSON.stringify(requestTools)));
+      return { content: 'done' };
+    },
+  };
+  const executor: ToolExecutor = {
+    getToolDefinitions: () => tools,
+    executeTool: async () => ({ content: 'unused' }),
+  };
+
+  try {
+    const runner = new ConversationRunner(aiService as any, executor, {
+      maxContextTokens: 5_000,
+      stream: false,
+      enableCompression: false,
+    });
+    await runner.run(messages);
+  } finally {
+    if (previousReadThreshold === undefined) delete process.env.XIAOBA_READ_FILE_FOLD_THRESHOLD_TOKENS;
+    else process.env.XIAOBA_READ_FILE_FOLD_THRESHOLD_TOKENS = previousReadThreshold;
+    if (previousAdaptiveEnabled === undefined) delete process.env.XIAOBA_ADAPTIVE_TOOL_RESULT_FOLDING;
+    else process.env.XIAOBA_ADAPTIVE_TOOL_RESULT_FOLDING = previousAdaptiveEnabled;
+    if (previousAdaptiveTarget === undefined) delete process.env.XIAOBA_ADAPTIVE_TOOL_RESULT_FOLD_TARGET_PROMPT_TOKENS;
+    else process.env.XIAOBA_ADAPTIVE_TOOL_RESULT_FOLD_TARGET_PROMPT_TOKENS = previousAdaptiveTarget;
+  }
+
+  const providerToolResult = capturedMessages[0].find(message => message.tool_call_id === 'call_under_budget_read');
+  assert.equal(providerToolResult?.content, raw);
+  assert.ok(
+    estimateMessagesTokens(capturedMessages[0]) + estimateToolsTokens(capturedTools[0]) <= 5_000,
+  );
+});
+
 test('mechanical prompt trimming removes dangling tool result messages', () => {
   const runner = makeRunner(1_200);
   const messages: Message[] = [

--- a/tests/current-run-tool-result-folding.test.ts
+++ b/tests/current-run-tool-result-folding.test.ts
@@ -1,0 +1,63 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  resolveCurrentRunToolResultFoldingOptions,
+  selectProtectedCurrentRunToolResultIndexes,
+} from '../src/core/current-run-tool-result-folding';
+import { Message } from '../src/types';
+
+function tool(name: string, content: string, id: string): Message {
+  return {
+    role: 'tool',
+    name,
+    tool_call_id: id,
+    content,
+  };
+}
+
+test('selects the most recent current-run foldable tool results for protection', () => {
+  const messages: Message[] = [
+    { role: 'user', content: 'inspect project' },
+    tool('read_file', 'old read', 'read_1'),
+    tool('grep', 'small grep', 'grep_1'),
+    tool('execute_shell', 'old shell', 'shell_1'),
+    tool('Bash', 'recent shell', 'shell_2'),
+    tool('read_file', 'recent read', 'read_2'),
+  ];
+
+  const protectedIndexes = selectProtectedCurrentRunToolResultIndexes(messages, {
+    enabled: true,
+    keepRecentToolResults: 2,
+  });
+
+  assert.deepEqual(Array.from(protectedIndexes), [4, 5]);
+});
+
+test('ignores historical tool results before the latest real user', () => {
+  const messages: Message[] = [
+    { role: 'user', content: 'old request' },
+    tool('read_file', 'historical read', 'read_old'),
+    { role: 'assistant', content: 'done' },
+    { role: 'user', content: 'new request' },
+    tool('execute_shell', 'current shell', 'shell_current'),
+  ];
+
+  const protectedIndexes = selectProtectedCurrentRunToolResultIndexes(messages, {
+    enabled: true,
+    keepRecentToolResults: 3,
+  });
+
+  assert.deepEqual(Array.from(protectedIndexes), [4]);
+});
+
+test('environment options can disable current-run folding and set keep window', () => {
+  const env = {
+    XIAOBA_CURRENT_RUN_TOOL_RESULT_FOLDING: '0',
+    XIAOBA_CURRENT_RUN_TOOL_RESULT_FOLD_KEEP_RECENT: '5',
+  } as NodeJS.ProcessEnv;
+
+  const options = resolveCurrentRunToolResultFoldingOptions(env);
+
+  assert.equal(options.enabled, false);
+  assert.equal(options.keepRecentToolResults, 5);
+});

--- a/tests/execute-shell-message-folder.test.ts
+++ b/tests/execute-shell-message-folder.test.ts
@@ -1,0 +1,181 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  FOLDED_EXECUTE_SHELL_PREFIX,
+  foldHistoricalExecuteShellMessages,
+  resolveExecuteShellMessageFoldingOptions,
+} from '../src/core/execute-shell-message-folder';
+import { ConversationRunner } from '../src/core/conversation-runner';
+import { Message } from '../src/types';
+import { ToolExecutor } from '../src/types/tool';
+
+function makeShellOutput(command: string, lineCount = 100, failed = false): string {
+  const lines = Array.from({ length: lineCount }, (_, index) => {
+    const lineNumber = index + 1;
+    if (lineNumber === 50) {
+      return 'ERROR failed at src/broken.ts:123 with assertion failure';
+    }
+    return `plain shell output line ${lineNumber}`;
+  });
+  return [
+    failed ? 'Command failed:' : 'Command succeeded:',
+    `$ ${command}`,
+    '',
+    'Elapsed: 123ms',
+    `Output lines: ${lineCount}`,
+    '',
+    failed ? 'Error:' : '',
+    lines.join('\n'),
+  ].filter(line => line !== '').join('\n');
+}
+
+function makeToolCallMessage(id: string, command: string): Message {
+  return {
+    role: 'assistant',
+    content: null,
+    tool_calls: [{
+      id,
+      type: 'function',
+      function: {
+        name: 'execute_shell',
+        arguments: JSON.stringify({ command, timeout: 10000 }),
+      },
+    }],
+  };
+}
+
+test('folds large historical execute_shell results while preserving tool exchange ids and key lines', () => {
+  const raw = makeShellOutput('npm test', 100, true);
+  const messages: Message[] = [
+    { role: 'user', content: 'run tests' },
+    makeToolCallMessage('call_old_shell', 'npm test'),
+    { role: 'tool', name: 'execute_shell', tool_call_id: 'call_old_shell', content: raw },
+    { role: 'assistant', content: 'tests failed' },
+    { role: 'user', content: 'summarize failure' },
+  ];
+
+  const result = foldHistoricalExecuteShellMessages(messages, {
+    thresholdTokens: 20,
+    maxHeadLines: 2,
+    maxTailLines: 2,
+    maxKeyLines: 4,
+  });
+  const folded = result.messages[2];
+
+  assert.equal(result.stats.folded_count, 1);
+  assert.equal(result.stats.candidate_count, 1);
+  assert.equal(folded.tool_call_id, 'call_old_shell');
+  assert.equal(folded.name, 'execute_shell');
+  assert.equal(typeof folded.content, 'string');
+  assert.ok(String(folded.content).startsWith(FOLDED_EXECUTE_SHELL_PREFIX));
+  assert.match(String(folded.content), /artifact_id: sh_[a-f0-9]{16}/);
+  assert.match(String(folded.content), /command: npm test/);
+  assert.match(String(folded.content), /status: failed/);
+  assert.match(String(folded.content), /ERROR failed at src\/broken\.ts:123/);
+  assert.equal(String(folded.content).includes('plain shell output line 45'), false);
+  assert.ok(result.stats.saved_tokens_est > 0);
+});
+
+test('does not fold execute_shell result from the current tool loop', () => {
+  const raw = makeShellOutput('npm run build', 100);
+  const messages: Message[] = [
+    { role: 'user', content: 'build now' },
+    makeToolCallMessage('call_current_shell', 'npm run build'),
+    { role: 'tool', name: 'execute_shell', tool_call_id: 'call_current_shell', content: raw },
+  ];
+
+  const result = foldHistoricalExecuteShellMessages(messages, {
+    thresholdTokens: 20,
+  });
+
+  assert.equal(result.stats.folded_count, 0);
+  assert.equal(result.stats.skipped_current_turn_count, 1);
+  assert.equal(result.messages[2].content, raw);
+});
+
+test('can keep the most recent historical execute_shell result raw', () => {
+  const firstRaw = makeShellOutput('npm test -- old', 100);
+  const secondRaw = makeShellOutput('npm test -- recent', 100);
+  const messages: Message[] = [
+    { role: 'user', content: 'run old shell' },
+    makeToolCallMessage('call_old', 'npm test -- old'),
+    { role: 'tool', name: 'execute_shell', tool_call_id: 'call_old', content: firstRaw },
+    { role: 'assistant', content: 'old done' },
+    { role: 'user', content: 'run recent shell' },
+    makeToolCallMessage('call_recent', 'npm test -- recent'),
+    { role: 'tool', name: 'Bash', tool_call_id: 'call_recent', content: secondRaw },
+    { role: 'assistant', content: 'recent done' },
+    { role: 'user', content: 'continue' },
+  ];
+
+  const result = foldHistoricalExecuteShellMessages(messages, {
+    thresholdTokens: 20,
+    keepRecentHistoricalShells: 1,
+  });
+
+  assert.equal(result.stats.candidate_count, 2);
+  assert.equal(result.stats.folded_count, 1);
+  assert.equal(result.stats.skipped_recent_count, 1);
+  assert.ok(String(result.messages[2].content).startsWith(FOLDED_EXECUTE_SHELL_PREFIX));
+  assert.equal(result.messages[6].content, secondRaw);
+});
+
+test('environment options are deterministic and can disable folding', () => {
+  const env = {
+    XIAOBA_EXECUTE_SHELL_MESSAGE_FOLDING: '0',
+    XIAOBA_EXECUTE_SHELL_FOLD_THRESHOLD_TOKENS: '321',
+    XIAOBA_EXECUTE_SHELL_FOLD_HEAD_LINES: '3',
+    XIAOBA_EXECUTE_SHELL_FOLD_TAIL_LINES: '7',
+    XIAOBA_EXECUTE_SHELL_FOLD_KEY_LINES: '9',
+    XIAOBA_EXECUTE_SHELL_FOLD_KEEP_RECENT: '2',
+  } as NodeJS.ProcessEnv;
+
+  const options = resolveExecuteShellMessageFoldingOptions(env);
+
+  assert.equal(options.enabled, false);
+  assert.equal(options.thresholdTokens, 321);
+  assert.equal(options.maxHeadLines, 3);
+  assert.equal(options.maxTailLines, 7);
+  assert.equal(options.maxKeyLines, 9);
+  assert.equal(options.keepRecentHistoricalShells, 2);
+});
+
+test('runner folds execute_shell only in provider input and leaves durable session messages raw', async () => {
+  const previousThreshold = process.env.XIAOBA_EXECUTE_SHELL_FOLD_THRESHOLD_TOKENS;
+  process.env.XIAOBA_EXECUTE_SHELL_FOLD_THRESHOLD_TOKENS = '20';
+
+  const raw = makeShellOutput('npm test -- provider-only', 100);
+  const messages: Message[] = [
+    { role: 'user', content: 'run provider shell' },
+    makeToolCallMessage('call_provider_shell', 'npm test -- provider-only'),
+    { role: 'tool', name: 'execute_shell', tool_call_id: 'call_provider_shell', content: raw },
+    { role: 'assistant', content: 'shell done' },
+    { role: 'user', content: 'continue' },
+  ];
+  const captured: Message[][] = [];
+  const aiService = {
+    async chat(requestMessages: Message[]) {
+      captured.push(JSON.parse(JSON.stringify(requestMessages)));
+      return { content: 'done' };
+    },
+  };
+  const executor: ToolExecutor = {
+    getToolDefinitions: () => [],
+    executeTool: async () => ({ tool_call_id: 'unused', role: 'tool', name: 'unused', content: 'unused' }),
+  };
+
+  try {
+    const runner = new ConversationRunner(aiService as any, executor, {
+      stream: false,
+      enableCompression: false,
+    });
+    await runner.run(messages);
+  } finally {
+    if (previousThreshold === undefined) delete process.env.XIAOBA_EXECUTE_SHELL_FOLD_THRESHOLD_TOKENS;
+    else process.env.XIAOBA_EXECUTE_SHELL_FOLD_THRESHOLD_TOKENS = previousThreshold;
+  }
+
+  const providerToolResult = captured[0].find(message => message.role === 'tool');
+  assert.ok(String(providerToolResult?.content).startsWith(FOLDED_EXECUTE_SHELL_PREFIX));
+  assert.equal(messages[2].content, raw);
+});

--- a/tests/execute-shell-message-folder.test.ts
+++ b/tests/execute-shell-message-folder.test.ts
@@ -93,6 +93,33 @@ test('does not fold execute_shell result from the current tool loop', () => {
   assert.equal(result.messages[2].content, raw);
 });
 
+test('can delayed-fold older current-run execute_shell results while protecting recent results', () => {
+  const firstRaw = makeShellOutput('npm test -- current-old', 100);
+  const secondRaw = makeShellOutput('npm test -- current-recent', 100);
+  const messages: Message[] = [
+    { role: 'user', content: 'run several commands in one request' },
+    makeToolCallMessage('call_current_old', 'npm test -- current-old'),
+    { role: 'tool', name: 'execute_shell', tool_call_id: 'call_current_old', content: firstRaw },
+    { role: 'assistant', content: 'old shell complete' },
+    makeToolCallMessage('call_current_recent', 'npm test -- current-recent'),
+    { role: 'tool', name: 'execute_shell', tool_call_id: 'call_current_recent', content: secondRaw },
+  ];
+
+  const result = foldHistoricalExecuteShellMessages(messages, {
+    thresholdTokens: 20,
+    foldCurrentRun: true,
+    protectedCurrentRunToolResultIndexes: new Set([5]),
+  });
+
+  assert.equal(result.stats.candidate_count, 1);
+  assert.equal(result.stats.current_turn_candidate_count, 1);
+  assert.equal(result.stats.folded_count, 1);
+  assert.equal(result.stats.folded_current_turn_count, 1);
+  assert.equal(result.stats.protected_current_turn_count, 1);
+  assert.ok(String(result.messages[2].content).startsWith(FOLDED_EXECUTE_SHELL_PREFIX));
+  assert.equal(result.messages[5].content, secondRaw);
+});
+
 test('can keep the most recent historical execute_shell result raw', () => {
   const firstRaw = makeShellOutput('npm test -- old', 100);
   const secondRaw = makeShellOutput('npm test -- recent', 100);

--- a/tests/read-file-message-folder.test.ts
+++ b/tests/read-file-message-folder.test.ts
@@ -85,6 +85,33 @@ test('does not fold read_file result from the current tool loop', () => {
   assert.equal(result.messages[2].content, raw);
 });
 
+test('can delayed-fold older current-run read_file results while protecting recent results', () => {
+  const firstRaw = makeReadFileOutput('E:/repo/current-old.ts', 90);
+  const secondRaw = makeReadFileOutput('E:/repo/current-recent.ts', 90);
+  const messages: Message[] = [
+    { role: 'user', content: 'read several files in one request' },
+    makeToolCallMessage('call_current_old', 'E:/repo/current-old.ts'),
+    { role: 'tool', name: 'read_file', tool_call_id: 'call_current_old', content: firstRaw },
+    { role: 'assistant', content: 'old read complete' },
+    makeToolCallMessage('call_current_recent', 'E:/repo/current-recent.ts'),
+    { role: 'tool', name: 'read_file', tool_call_id: 'call_current_recent', content: secondRaw },
+  ];
+
+  const result = foldHistoricalReadFileMessages(messages, {
+    thresholdTokens: 20,
+    foldCurrentRun: true,
+    protectedCurrentRunToolResultIndexes: new Set([5]),
+  });
+
+  assert.equal(result.stats.candidate_count, 1);
+  assert.equal(result.stats.current_turn_candidate_count, 1);
+  assert.equal(result.stats.folded_count, 1);
+  assert.equal(result.stats.folded_current_turn_count, 1);
+  assert.equal(result.stats.protected_current_turn_count, 1);
+  assert.ok(String(result.messages[2].content).startsWith(FOLDED_READ_FILE_PREFIX));
+  assert.equal(result.messages[5].content, secondRaw);
+});
+
 test('can keep the most recent historical read_file result raw', () => {
   const firstRaw = makeReadFileOutput('E:/repo/old.ts', 90);
   const secondRaw = makeReadFileOutput('E:/repo/recent.ts', 90);
@@ -168,4 +195,57 @@ test('runner folds only provider input and leaves durable session messages raw',
   const providerToolResult = captured[0].find(message => message.role === 'tool');
   assert.ok(String(providerToolResult?.content).startsWith(FOLDED_READ_FILE_PREFIX));
   assert.equal(messages[2].content, raw);
+});
+
+test('runner delayed-folds older current-run tool results and keeps recent ones raw', async () => {
+  const previousThreshold = process.env.XIAOBA_READ_FILE_FOLD_THRESHOLD_TOKENS;
+  const previousCurrentRunFolding = process.env.XIAOBA_CURRENT_RUN_TOOL_RESULT_FOLDING;
+  const previousKeepRecent = process.env.XIAOBA_CURRENT_RUN_TOOL_RESULT_FOLD_KEEP_RECENT;
+  process.env.XIAOBA_READ_FILE_FOLD_THRESHOLD_TOKENS = '20';
+  process.env.XIAOBA_CURRENT_RUN_TOOL_RESULT_FOLDING = '1';
+  process.env.XIAOBA_CURRENT_RUN_TOOL_RESULT_FOLD_KEEP_RECENT = '1';
+
+  const firstRaw = makeReadFileOutput('E:/repo/current-provider-old.ts', 90);
+  const secondRaw = makeReadFileOutput('E:/repo/current-provider-recent.ts', 90);
+  const messages: Message[] = [
+    { role: 'user', content: 'read multiple files before answering' },
+    makeToolCallMessage('call_current_provider_old', 'E:/repo/current-provider-old.ts'),
+    { role: 'tool', name: 'read_file', tool_call_id: 'call_current_provider_old', content: firstRaw },
+    { role: 'assistant', content: 'old read complete' },
+    makeToolCallMessage('call_current_provider_recent', 'E:/repo/current-provider-recent.ts'),
+    { role: 'tool', name: 'read_file', tool_call_id: 'call_current_provider_recent', content: secondRaw },
+  ];
+  const captured: Message[][] = [];
+  const aiService = {
+    async chat(requestMessages: Message[]) {
+      captured.push(JSON.parse(JSON.stringify(requestMessages)));
+      return { content: 'done' };
+    },
+  };
+  const executor: ToolExecutor = {
+    getToolDefinitions: () => [],
+    executeTool: async () => ({ tool_call_id: 'unused', role: 'tool', name: 'unused', content: 'unused' }),
+  };
+
+  try {
+    const runner = new ConversationRunner(aiService as any, executor, {
+      stream: false,
+      enableCompression: false,
+    });
+    await runner.run(messages);
+  } finally {
+    if (previousThreshold === undefined) delete process.env.XIAOBA_READ_FILE_FOLD_THRESHOLD_TOKENS;
+    else process.env.XIAOBA_READ_FILE_FOLD_THRESHOLD_TOKENS = previousThreshold;
+    if (previousCurrentRunFolding === undefined) delete process.env.XIAOBA_CURRENT_RUN_TOOL_RESULT_FOLDING;
+    else process.env.XIAOBA_CURRENT_RUN_TOOL_RESULT_FOLDING = previousCurrentRunFolding;
+    if (previousKeepRecent === undefined) delete process.env.XIAOBA_CURRENT_RUN_TOOL_RESULT_FOLD_KEEP_RECENT;
+    else process.env.XIAOBA_CURRENT_RUN_TOOL_RESULT_FOLD_KEEP_RECENT = previousKeepRecent;
+  }
+
+  const providerOld = captured[0].find(message => message.tool_call_id === 'call_current_provider_old');
+  const providerRecent = captured[0].find(message => message.tool_call_id === 'call_current_provider_recent');
+  assert.ok(String(providerOld?.content).startsWith(FOLDED_READ_FILE_PREFIX));
+  assert.equal(providerRecent?.content, secondRaw);
+  assert.equal(messages[2].content, firstRaw);
+  assert.equal(messages[5].content, secondRaw);
 });

--- a/tests/tool-result-context-report.test.ts
+++ b/tests/tool-result-context-report.test.ts
@@ -1,0 +1,74 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  formatToolResultContextReport,
+  resolveToolResultContextReportOptions,
+  summarizeToolResultContext,
+} from '../src/core/tool-result-context-report';
+import { Message } from '../src/types';
+
+function tool(name: string, content: string, id: string): Message {
+  return {
+    role: 'tool',
+    name,
+    tool_call_id: id,
+    content,
+  };
+}
+
+test('summarizes tool result context by tool name and largest messages', () => {
+  const messages: Message[] = [
+    { role: 'system', content: 'system prompt' },
+    tool('read_file', 'r'.repeat(100), 'read_1'),
+    tool('execute_shell', 's'.repeat(300), 'shell_1'),
+    tool('Bash', 'b'.repeat(250), 'shell_2'),
+    tool('grep', 'g'.repeat(20), 'grep_1'),
+    { role: 'user', content: 'continue' },
+  ];
+
+  const summary = summarizeToolResultContext(messages, {
+    topTools: 3,
+    topMessages: 2,
+  });
+
+  assert.equal(summary.tool_result_count, 4);
+  assert.equal(summary.total_chars, 670);
+  assert.equal(summary.by_tool[0].name, 'execute_shell');
+  assert.equal(summary.by_tool[0].count, 2);
+  assert.equal(summary.by_tool[0].chars, 550);
+  assert.equal(summary.by_tool[1].name, 'read_file');
+  assert.deepEqual(summary.largest_messages.map(item => item.index), [2, 3]);
+});
+
+test('formats before and after tool result context savings', () => {
+  const before = summarizeToolResultContext([
+    tool('execute_shell', 'x'.repeat(1000), 'shell_1'),
+    tool('read_file', 'y'.repeat(500), 'read_1'),
+  ]);
+  const after = summarizeToolResultContext([
+    tool('execute_shell', '[folded_execute_shell]\nsummary', 'shell_1'),
+    tool('read_file', 'y'.repeat(500), 'read_1'),
+  ]);
+
+  const lines = formatToolResultContextReport(before, after);
+
+  assert.equal(lines.length, 3);
+  assert.match(lines[0], /tool_result context: before=2 results\/1500 chars/);
+  assert.match(lines[0], /saved=\d+ chars\/\d+ tokens_est/);
+  assert.match(lines[1], /execute_shell count=1 chars=1000/);
+  assert.match(lines[2], /#0 execute_shell chars=1000/);
+});
+
+test('environment options can disable context report and set top counts', () => {
+  const env = {
+    XIAOBA_TOOL_RESULT_CONTEXT_REPORT: '0',
+    XIAOBA_TOOL_RESULT_CONTEXT_REPORT_TOP_TOOLS: '7',
+    XIAOBA_TOOL_RESULT_CONTEXT_REPORT_TOP_MESSAGES: '9',
+  } as NodeJS.ProcessEnv;
+
+  const options = resolveToolResultContextReportOptions(env);
+
+  assert.equal(options.enabled, false);
+  assert.equal(options.topTools, 7);
+  assert.equal(options.topMessages, 9);
+});


### PR DESCRIPTION
## 背景

上一版已经折叠历史 `read_file` 输出，但真实会话日志显示 `execute_shell` 历史输出也接近同量级：

- `read_file`: 54 条，约 202650 chars
- `execute_shell`: 130 条，约 166006 chars

继续实测后还发现：只折叠“上一条用户消息之前”的历史，无法压住同一次用户请求内连续读文件、跑 shell 带来的增长。最近一次桌面实测里，普通折叠已经生效，但 provider 请求仍约 14 万 prompt tokens，并出现 relay/provider 层 `Connection error`。因此本 PR 继续增加当前运行内延迟折叠和按预算自适应折叠。

## 改动

- 新增 `execute-shell-message-folder`，在发送给 provider 前折叠大型 `execute_shell` 结果。
- `read_file` 和 `execute_shell` 都支持当前运行内延迟折叠：
  - 当前用户请求里最近几个可折叠工具结果保持原文；
  - 更早的大型 `read_file` / `execute_shell` 结果会被折叠；
  - 默认保护最近 3 个当前运行工具结果。
- 新增 `adaptive-tool-result-folder`：普通折叠后如果 prompt 估算仍超过目标，会逐步降低 tool result 折叠阈值，继续折叠中等体积的 `read_file` / `execute_shell`。
- 直接调用 folder 时仍保持旧行为：不折叠当前工具循环结果；runner 才会打开延迟折叠。
- 保留工具交换结构，包括 `role: tool`、`name`、`tool_call_id`，只替换 `content`。
- shell 折叠内容保留 command/status/elapsed、artifact、hash、head/tail 输出和 error/warn/traceback/file:line 等关键行。
- 新增 tool result 体积报告，在 provider 请求前记录折叠前后体积、top tool 类型和最大 tool result。

## 环境变量

- `XIAOBA_EXECUTE_SHELL_MESSAGE_FOLDING`
- `XIAOBA_EXECUTE_SHELL_FOLD_THRESHOLD_TOKENS`
- `XIAOBA_EXECUTE_SHELL_FOLD_HEAD_LINES`
- `XIAOBA_EXECUTE_SHELL_FOLD_TAIL_LINES`
- `XIAOBA_EXECUTE_SHELL_FOLD_KEY_LINES`
- `XIAOBA_EXECUTE_SHELL_FOLD_KEEP_RECENT`
- `XIAOBA_CURRENT_RUN_TOOL_RESULT_FOLDING`
- `XIAOBA_CURRENT_RUN_TOOL_RESULT_FOLD_KEEP_RECENT`
- `XIAOBA_ADAPTIVE_TOOL_RESULT_FOLDING`
- `XIAOBA_ADAPTIVE_TOOL_RESULT_FOLD_TARGET_PROMPT_TOKENS`
- `XIAOBA_ADAPTIVE_TOOL_RESULT_FOLD_MIN_THRESHOLD_TOKENS`
- `XIAOBA_ADAPTIVE_TOOL_RESULT_FOLD_THRESHOLD_SCALE`
- `XIAOBA_ADAPTIVE_TOOL_RESULT_FOLD_MAX_PASSES`
- `XIAOBA_TOOL_RESULT_CONTEXT_REPORT`
- `XIAOBA_TOOL_RESULT_CONTEXT_REPORT_TOP_TOOLS`
- `XIAOBA_TOOL_RESULT_CONTEXT_REPORT_TOP_MESSAGES`

## 验证

- `npm run build`
- `node node_modules\tsx\dist\cli.mjs --test tests\adaptive-tool-result-folder.test.ts tests\current-run-tool-result-folding.test.ts tests\read-file-message-folder.test.ts tests\execute-shell-message-folder.test.ts`
- `node node_modules\tsx\dist\cli.mjs --test tests\tool-result-context-report.test.ts tests\conversation-runner-context-budget.test.ts tests\conversation-runner-transcript-normalization.test.ts`

## 注意

这个 PR 叠在 #117 上，因为它复用了 #117 中“provider 输入侧折叠历史 tool result”的接入点。#117 合并后，这个 PR 可以直接改 base 到 `main` 或 rebase。