### PR TITLE
修复 provider replay 占位泄漏到历史正文

### DIFF
--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -42,6 +42,7 @@ import type { PendingUserInputProvider } from './conversation-runner';
 import { resolveModelContextWindow } from '../utils/model-context-window';
 import { parseSessionKeyV2 } from './session-router';
 import { MODEL_IMAGE_SAFETY_MESSAGE, isModelImageSafetyError } from '../utils/model-error-classifier';
+import { stripAssistantArtifactsFromMessages } from '../utils/transcript-artifacts';
 
 export type { RuntimeFeedbackInput, RuntimeFeedbackOptions } from './runtime-feedback-inbox';
 
@@ -323,6 +324,7 @@ export class AgentSession {
       const usage = this.contextWindowManager.getUsageInfo(this.messages);
       Logger.info(`[${this.key}] 恢复后上下文: ${usage.usedTokens}/${usage.maxTokens} tokens (${usage.usagePercent}%)`);
 
+      this.messages = stripAssistantArtifactsFromMessages(this.messages);
       this.messages = await this.contextWindowManager.compactIfNeeded(this.messages, {
         sessionKey: this.key,
         reason: '恢复后',
@@ -456,6 +458,7 @@ export class AgentSession {
       this.activeAbortController = new AbortController();
       this.lastActiveAt = Date.now();
 
+      this.messages = stripAssistantArtifactsFromMessages(this.messages);
       this.messages = await this.contextWindowManager.compactIfNeeded(this.messages, {
         sessionKey: this.key,
         reason: '处理前',
@@ -525,8 +528,9 @@ export class AgentSession {
         this.messages.push({
           role: 'assistant',
           content: this.formatErrorContextMessage(err, isModelTimeoutError, isImageSafetyError),
+          __internalErrorArtifact: true,
         });
-        this.messages = this.turnContextBuilder.removeTransientMessages(this.messages);
+        this.messages = stripAssistantArtifactsFromMessages(this.turnContextBuilder.removeTransientMessages(this.messages));
         this.lifecycleManager.saveContext(this.messages);
 
         return { text: errorReply, visibleToUser: true };

--- a/src/core/turn-context-builder.ts
+++ b/src/core/turn-context-builder.ts
@@ -21,6 +21,7 @@ import {
   TRANSIENT_RUNTIME_CONTEXT_PREFIX,
   buildRuntimeContextMessage,
 } from './runtime-context-builder';
+import { stripAssistantArtifactsFromMessages } from '../utils/transcript-artifacts';
 
 const TRANSIENT_PLAN_STATUS_PREFIX = '[transient_plan_status]';
 const TRANSIENT_RUNNER_HINT_PREFIX = '[transient_runner_hint]';
@@ -53,7 +54,7 @@ export interface BuildTurnContextResult {
  */
 export class TurnContextBuilder {
   async build(params: BuildTurnContextParams): Promise<BuildTurnContextResult> {
-    const contextMessages = [...params.durableMessages];
+    const contextMessages = stripAssistantArtifactsFromMessages(params.durableMessages);
     this.injectRuntimeContext(contextMessages, params);
     this.injectRuntimeFeedback(contextMessages, params.runtimeFeedback);
     this.injectPlanStatus(contextMessages, params.planRuntime);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,6 +24,8 @@ export interface Message {
   /** 标记内部 runtime observation，例如子 agent 完成结果；对模型仍以 user role 承载 */
   __runtimeObservation?: boolean;
   runtimeObservationSource?: string;
+  /** 标记内部错误占位，仅用于本地恢复/继续，不应进入模型上下文或持久历史。 */
+  __internalErrorArtifact?: boolean;
   /** Provider 原始 assistant content blocks，仅用于下次请求回放，不展示给用户。 */
   providerContent?: ProviderContentBlock[];
 }

--- a/src/utils/session-store.ts
+++ b/src/utils/session-store.ts
@@ -2,12 +2,13 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { Message } from '../types';
 import { Logger } from './logger';
+import {
+  contentToText,
+  stripAssistantTranscriptArtifacts,
+} from './transcript-artifacts';
 
 const SESSIONS_DIR = path.resolve(process.cwd(), 'data', 'sessions');
 const SESSION_STATE_DIR = path.resolve(process.cwd(), 'data', 'session-state');
-const PROVIDER_REPLAY_PLACEHOLDER_LINE =
-  /^\[历史工具调用已完成；provider replay 隐藏内容未写入本地会话。.*\]$/;
-const PROVIDER_REPLAY_RESULT_SUMMARY_HEADER = '[历史工具结果摘要]';
 
 function ensureDir(): void {
   if (!fs.existsSync(SESSIONS_DIR)) fs.mkdirSync(SESSIONS_DIR, { recursive: true });
@@ -33,23 +34,6 @@ function hasHiddenProviderReplay(message: Message): boolean {
     ));
 }
 
-function contentToText(content: Message['content']): string {
-  if (typeof content === 'string') return content;
-  if (!Array.isArray(content)) return '';
-  return content.map(block => block.type === 'text' ? block.text : '[图片]').join('');
-}
-
-function stripProviderReplayArtifacts(text: string): string {
-  const summaryIndex = text.indexOf(PROVIDER_REPLAY_RESULT_SUMMARY_HEADER);
-  const withoutSummaries = summaryIndex >= 0 ? text.slice(0, summaryIndex) : text;
-  return withoutSummaries
-    .split(/\r?\n/)
-    .filter(line => !PROVIDER_REPLAY_PLACEHOLDER_LINE.test(line.trim()))
-    .join('\n')
-    .replace(/\n{3,}/g, '\n\n')
-    .trim();
-}
-
 function sanitizeForPersistence(messages: Message[]): Message[] {
   const hiddenReplayToolCallIds = new Set<string>();
   const durable: Message[] = [];
@@ -72,7 +56,7 @@ function sanitizeForPersistence(messages: Message[]): Message[] {
       for (const toolCall of message.tool_calls) {
         hiddenReplayToolCallIds.add(toolCall.id);
       }
-      const publicText = stripProviderReplayArtifacts(contentToText(message.content));
+      const publicText = stripAssistantTranscriptArtifacts(contentToText(message.content));
       if (publicText) {
         durable.push({
           ...message,
@@ -85,7 +69,7 @@ function sanitizeForPersistence(messages: Message[]): Message[] {
     }
 
     if (typeof message.content === 'string') {
-      const cleanedText = stripProviderReplayArtifacts(message.content);
+      const cleanedText = stripAssistantTranscriptArtifacts(message.content);
       if (cleanedText) {
         durable.push({
           ...message,

--- a/src/utils/session-store.ts
+++ b/src/utils/session-store.ts
@@ -34,6 +34,11 @@ function hasHiddenProviderReplay(message: Message): boolean {
     ));
 }
 
+function summarizeHiddenReplayToolResult(message: Message): string {
+  const toolName = String(message.name || 'tool').trim() || 'tool';
+  return `[历史工具结果已省略；${toolName} 已完成。]`;
+}
+
 function sanitizeForPersistence(messages: Message[]): Message[] {
   const hiddenReplayToolCallIds = new Set<string>();
   const durable: Message[] = [];
@@ -44,6 +49,11 @@ function sanitizeForPersistence(messages: Message[]): Message[] {
     }
 
     if (message.role === 'tool' && message.tool_call_id && hiddenReplayToolCallIds.has(message.tool_call_id)) {
+      durable.push({
+        ...message,
+        content: summarizeHiddenReplayToolResult(message),
+        providerContent: undefined,
+      });
       continue;
     }
 
@@ -57,14 +67,11 @@ function sanitizeForPersistence(messages: Message[]): Message[] {
         hiddenReplayToolCallIds.add(toolCall.id);
       }
       const publicText = stripAssistantTranscriptArtifacts(contentToText(message.content));
-      if (publicText) {
-        durable.push({
-          ...message,
-          content: publicText,
-          tool_calls: undefined,
-          providerContent: undefined,
-        });
-      }
+      durable.push({
+        ...message,
+        content: publicText || null,
+        providerContent: undefined,
+      });
       continue;
     }
 

--- a/src/utils/session-store.ts
+++ b/src/utils/session-store.ts
@@ -5,7 +5,9 @@ import { Logger } from './logger';
 
 const SESSIONS_DIR = path.resolve(process.cwd(), 'data', 'sessions');
 const SESSION_STATE_DIR = path.resolve(process.cwd(), 'data', 'session-state');
-const TOOL_RESULT_SUMMARY_MAX_CHARS = 800;
+const PROVIDER_REPLAY_PLACEHOLDER_LINE =
+  /^\[历史工具调用已完成；provider replay 隐藏内容未写入本地会话。.*\]$/;
+const PROVIDER_REPLAY_RESULT_SUMMARY_HEADER = '[历史工具结果摘要]';
 
 function ensureDir(): void {
   if (!fs.existsSync(SESSIONS_DIR)) fs.mkdirSync(SESSIONS_DIR, { recursive: true });
@@ -31,48 +33,24 @@ function hasHiddenProviderReplay(message: Message): boolean {
     ));
 }
 
-function contentToPersistenceText(content: Message['content']): string {
+function contentToText(content: Message['content']): string {
   if (typeof content === 'string') return content;
   if (!Array.isArray(content)) return '';
   return content.map(block => block.type === 'text' ? block.text : '[图片]').join('');
 }
 
-function truncatePersistenceText(text: string, maxChars = TOOL_RESULT_SUMMARY_MAX_CHARS): string {
-  if (text.length <= maxChars) return text;
-  return `${text.slice(0, Math.max(0, maxChars - 28))}\n...[共 ${text.length} 字符]`;
-}
-
-function collectToolResultSummaries(messages: Message[]): Map<string, string> {
-  const summaries = new Map<string, string>();
-  for (const message of messages) {
-    if (message.role !== 'tool' || !message.tool_call_id) continue;
-    const text = truncatePersistenceText(contentToPersistenceText(message.content).trim());
-    const name = message.name || 'unknown';
-    summaries.set(message.tool_call_id, `[工具 ${name}] ${text || '(无文本输出)'}`);
-  }
-  return summaries;
-}
-
-function providerReplaySummary(message: Message, toolResultSummaries: Map<string, string>): string {
-  const publicText = typeof message.content === 'string' ? message.content.trim() : '';
-  const toolNames = (message.tool_calls || [])
-    .map(toolCall => toolCall.function?.name)
-    .filter(Boolean);
-  const toolSummaries = (message.tool_calls || [])
-    .map(toolCall => toolResultSummaries.get(toolCall.id))
-    .filter((summary): summary is string => Boolean(summary));
-  const suffix = toolNames.length > 0
-    ? ` 工具调用: ${toolNames.join(', ')}。`
-    : '';
-  return [
-    publicText,
-    `[历史工具调用已完成；provider replay 隐藏内容未写入本地会话。${suffix}]`,
-    toolSummaries.length > 0 ? `[历史工具结果摘要]\n${toolSummaries.join('\n')}` : '',
-  ].filter(Boolean).join('\n');
+function stripProviderReplayArtifacts(text: string): string {
+  const summaryIndex = text.indexOf(PROVIDER_REPLAY_RESULT_SUMMARY_HEADER);
+  const withoutSummaries = summaryIndex >= 0 ? text.slice(0, summaryIndex) : text;
+  return withoutSummaries
+    .split(/\r?\n/)
+    .filter(line => !PROVIDER_REPLAY_PLACEHOLDER_LINE.test(line.trim()))
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
 }
 
 function sanitizeForPersistence(messages: Message[]): Message[] {
-  const toolResultSummaries = collectToolResultSummaries(messages);
   const hiddenReplayToolCallIds = new Set<string>();
   const durable: Message[] = [];
 
@@ -94,16 +72,40 @@ function sanitizeForPersistence(messages: Message[]): Message[] {
       for (const toolCall of message.tool_calls) {
         hiddenReplayToolCallIds.add(toolCall.id);
       }
-      durable.push({
-        ...message,
-        content: providerReplaySummary(message, toolResultSummaries),
-        tool_calls: undefined,
-        providerContent: undefined,
-      });
+      const publicText = stripProviderReplayArtifacts(contentToText(message.content));
+      if (publicText) {
+        durable.push({
+          ...message,
+          content: publicText,
+          tool_calls: undefined,
+          providerContent: undefined,
+        });
+      }
       continue;
     }
 
-    durable.push({ ...message, providerContent: undefined });
+    if (typeof message.content === 'string') {
+      const cleanedText = stripProviderReplayArtifacts(message.content);
+      if (cleanedText) {
+        durable.push({
+          ...message,
+          content: cleanedText,
+          providerContent: undefined,
+        });
+        continue;
+      }
+    } else if (message.content !== null) {
+      durable.push({ ...message, providerContent: undefined });
+      continue;
+    }
+
+    if (message.tool_calls?.length) {
+      durable.push({
+        ...message,
+        content: null,
+        providerContent: undefined,
+      });
+    }
   }
 
   return durable;

--- a/src/utils/transcript-artifacts.ts
+++ b/src/utils/transcript-artifacts.ts
@@ -1,0 +1,76 @@
+import type { Message } from '../types';
+
+const PROVIDER_REPLAY_PLACEHOLDER_LINE =
+  /^\[历史工具调用已完成；provider replay 隐藏内容未写入本地会话。.*\]$/;
+const PROVIDER_REPLAY_RESULT_SUMMARY_HEADER = '[历史工具结果摘要]';
+const GENERIC_INTERNAL_FAILURE_LINE = /^\[处理失败: .+\]$/;
+const MODEL_TIMEOUT_INTERNAL_LINE = /^\[处理中断: 模型中转请求超时。.+\]$/;
+const KNOWN_RUNTIME_ERROR_MARKERS =
+  /API错误\s*\(\d+\).*[{"]|MaxRetriesExceededError|HTTPSConnectionPool|ConnectTimeoutError|request[_ ]timed[_ ]out|default_request_timeout_in_seconds|upstream request timeout|gateway timeout|ECONNRESET|ETIMEDOUT|ENOTFOUND|ECONNREFUSED|fetch failed|bifrost request failed|API密钥未配置|当前模型不支持图片识别/i;
+
+export function contentToText(content: Message['content']): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  return content.map(block => block.type === 'text' ? block.text : '[图片]').join('');
+}
+
+export function stripAssistantTranscriptArtifacts(text: string): string {
+  const lines = text.split(/\r?\n/);
+  const nonBlankLines = lines.map(line => line.trim()).filter(Boolean);
+  if (nonBlankLines.length === 1 && isInternalRuntimeErrorLine(nonBlankLines[0], true)) {
+    return '';
+  }
+
+  const keptLines: string[] = [];
+  let sawProviderReplayArtifact = false;
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (PROVIDER_REPLAY_PLACEHOLDER_LINE.test(trimmed)) {
+      sawProviderReplayArtifact = true;
+      continue;
+    }
+    if (
+      trimmed === PROVIDER_REPLAY_RESULT_SUMMARY_HEADER
+      && sawProviderReplayArtifact
+    ) {
+      break;
+    }
+    keptLines.push(line);
+  }
+
+  return keptLines
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+function isInternalRuntimeErrorLine(line: string, allowGenericFailure: boolean): boolean {
+  if (MODEL_TIMEOUT_INTERNAL_LINE.test(line)) return true;
+  if (!GENERIC_INTERNAL_FAILURE_LINE.test(line)) return false;
+  return allowGenericFailure || KNOWN_RUNTIME_ERROR_MARKERS.test(line);
+}
+
+export function stripAssistantArtifactsFromMessages(messages: Message[]): Message[] {
+  const cleaned: Message[] = [];
+  for (const message of messages) {
+    if (message.role === 'assistant' && message.__internalErrorArtifact) {
+      continue;
+    }
+
+    if (message.role !== 'assistant' || typeof message.content !== 'string') {
+      cleaned.push(message);
+      continue;
+    }
+
+    const content = stripAssistantTranscriptArtifacts(message.content);
+    if (content) {
+      cleaned.push({ ...message, content });
+      continue;
+    }
+
+    if (message.tool_calls?.length) {
+      cleaned.push({ ...message, content: null });
+    }
+  }
+  return cleaned;
+}

--- a/tests/runtime-feedback.test.ts
+++ b/tests/runtime-feedback.test.ts
@@ -230,6 +230,45 @@ describe('runtime feedback', () => {
 
     assert.equal(aiCalls, 1);
   });
+
+  test('internal runtime error placeholders are not replayed into the next model turn', async () => {
+    const { AgentSession } = loadAgentSessionModules();
+    let aiCalls = 0;
+    let capturedMessages: any[] = [];
+    const session = new AgentSession('user:runtime-error-artifact-demo', buildMockServices({
+      aiService: {
+        async chatStream(messages: any[]) {
+          aiCalls++;
+          if (aiCalls === 1) {
+            throw new Error('API错误 (500): 500 {"type":"error","error":{"message":"anthropic: MaxRetriesExceededError: HTTPSConnectionPool(host=\'api.anthropic.com\')"}}');
+          }
+          capturedMessages = messages.map(message => ({ ...message }));
+          return {
+            content: '已继续处理',
+            toolCalls: [],
+            usage: { promptTokens: 3, completionTokens: 2, totalTokens: 5 },
+          };
+        },
+      },
+    }), 'catscompany');
+    session.setSystemPromptProvider(() => 'system prompt');
+
+    await session.handleMessage('先触发一次失败');
+    assert.equal((session as any).messages.some((message: any) =>
+      typeof message.content === 'string' && message.content.includes('api.anthropic.com')
+    ), false);
+
+    const result = await session.handleMessage('继续发文件');
+
+    assert.equal(result.text, '已继续处理');
+    assert.equal(capturedMessages.some(message =>
+      typeof message.content === 'string' && /\[(?:处理失败|处理中断):/.test(message.content)
+    ), false);
+    assert.equal(capturedMessages.some(message =>
+      typeof message.content === 'string' && message.content.includes('api.anthropic.com')
+    ), false);
+    assert.equal(aiCalls, 2);
+  });
 });
 
 function loadAgentSessionModules(): any {

--- a/tests/session-lifecycle-manager.test.ts
+++ b/tests/session-lifecycle-manager.test.ts
@@ -260,6 +260,80 @@ describe('AgentSession lifecycle', () => {
     assert.doesNotMatch(migratedRaw, /写入了 report\.md/);
   });
 
+  test('loading legacy sessions strips internal runtime error placeholders from assistant text', async () => {
+    const { SessionStore } = loadSessionModules();
+    const sessionFile = path.join(testRoot, 'data', 'sessions', 'user_lifecycle-runtime-error-leak.jsonl');
+    fs.mkdirSync(path.dirname(sessionFile), { recursive: true });
+    fs.writeFileSync(sessionFile, [
+      JSON.stringify({ role: 'user', content: '继续处理' }),
+      JSON.stringify({
+        role: 'assistant',
+        content: '[处理失败: API错误 (500): 500 {"type":"error","error":{"message":"anthropic: MaxRetriesExceededError: HTTPSConnectionPool(host=\'api.anthropic.com\')"}}]',
+      }),
+      JSON.stringify({ role: 'assistant', content: '[处理失败: unknown provider failure]' }),
+      JSON.stringify({
+        role: 'assistant',
+        content: '[处理中断: 模型中转请求超时。错误摘要: request timed out]',
+      }),
+      JSON.stringify({
+        role: 'assistant',
+        content: '保留公开说明\n继续保留说明',
+      }),
+    ].join('\n') + '\n', 'utf-8');
+
+    const restored = SessionStore.getInstance().loadContext('user:lifecycle-runtime-error-leak');
+    const migratedRaw = fs.readFileSync(sessionFile, 'utf-8');
+
+    assert.deepStrictEqual(
+      restored.map((message: any) => message.content),
+      ['继续处理', '保留公开说明\n继续保留说明'],
+    );
+    assert.doesNotMatch(migratedRaw, /处理失败/);
+    assert.doesNotMatch(migratedRaw, /处理中断/);
+    assert.doesNotMatch(migratedRaw, /api\.anthropic\.com/);
+    assert.doesNotMatch(migratedRaw, /MaxRetriesExceededError/);
+  });
+
+  test('loading sessions preserves ordinary assistant text that only resembles an error note', async () => {
+    const { SessionStore } = loadSessionModules();
+    const sessionFile = path.join(testRoot, 'data', 'sessions', 'user_lifecycle-error-looking-text.jsonl');
+    fs.mkdirSync(path.dirname(sessionFile), { recursive: true });
+    fs.writeFileSync(sessionFile, [
+      JSON.stringify({ role: 'user', content: '解释这段日志格式' }),
+      JSON.stringify({
+        role: 'assistant',
+        content: '这是一段普通说明：\n[处理失败: 这是用户文档里的示例文本]\n它不应该被删除。',
+      }),
+      JSON.stringify({
+        role: 'assistant',
+        content: '这也是普通说明：\n[处理失败: API错误 (500): 用户文档里的示例文本]\n[历史工具结果摘要]\n这里是文档摘录。',
+      }),
+      JSON.stringify({
+        role: 'assistant',
+        content: '[历史工具结果摘要]\n这是用户文档标题，不是 provider replay。',
+      }),
+      JSON.stringify({
+        role: 'assistant',
+        content: '错误排查说明：\n[处理失败: API错误 (500): anthropic: MaxRetriesExceededError 是用户粘贴的日志示例]\n保留分析。',
+      }),
+      JSON.stringify({ role: 'user', content: '[处理失败: API错误 (500): 用户自己发来的文本也要保留]' }),
+    ].join('\n') + '\n', 'utf-8');
+
+    const restored = SessionStore.getInstance().loadContext('user:lifecycle-error-looking-text');
+
+    assert.deepStrictEqual(
+      restored.map((message: any) => message.content),
+      [
+        '解释这段日志格式',
+        '这是一段普通说明：\n[处理失败: 这是用户文档里的示例文本]\n它不应该被删除。',
+        '这也是普通说明：\n[处理失败: API错误 (500): 用户文档里的示例文本]\n[历史工具结果摘要]\n这里是文档摘录。',
+        '[历史工具结果摘要]\n这是用户文档标题，不是 provider replay。',
+        '错误排查说明：\n[处理失败: API错误 (500): anthropic: MaxRetriesExceededError 是用户粘贴的日志示例]\n保留分析。',
+        '[处理失败: API错误 (500): 用户自己发来的文本也要保留]',
+      ],
+    );
+  });
+
   test('handleMessage persists each completed turn before cleanup', async () => {
     const { AgentSession, SessionStore } = loadSessionModules();
     const session = new AgentSession('catscompany:lifecycle-autosave', buildMockServices(), 'catscompany');
@@ -332,6 +406,32 @@ describe('AgentSession lifecycle', () => {
     ]);
   });
 
+  test('handleMessage strips internal error artifacts before context compaction sees them', async () => {
+    const { AgentSession } = loadSessionModules();
+    const session = new AgentSession('catscompany:lifecycle-precompact-sanitize', buildMockServices(), 'catscompany');
+    session.setSystemPromptProvider(() => 'system prompt');
+    (session as any).messages.push(
+      { role: 'user', content: '旧问题' },
+      { role: 'assistant', content: '[处理失败: API错误 (500): 500 {"type":"error"}]' },
+      { role: 'assistant', content: '普通回复保留' },
+    );
+
+    let preCompactMessages: any[] = [];
+    (session as any).contextWindowManager.compactIfNeeded = async (messages: any[], options: any) => {
+      if (options.reason === '处理前') {
+        preCompactMessages = messages.map(message => ({ ...message }));
+      }
+      return messages;
+    };
+
+    await session.handleMessage('继续');
+
+    assert.equal(preCompactMessages.some(message =>
+      typeof message.content === 'string' && message.content.includes('处理失败')
+    ), false);
+    assert.equal(preCompactMessages.some(message => message.content === '普通回复保留'), true);
+  });
+
   test('handleMessage preserves completed tool context when model relay times out', async () => {
     const { AgentSession, SessionStore, MODEL_TIMEOUT_MESSAGE } = loadSessionModules();
     let aiCalls = 0;
@@ -392,16 +492,25 @@ describe('AgentSession lifecycle', () => {
     const retainedMessages = (session as any).messages as any[];
     assert.equal(retainedMessages.some(message => message.content === 'notes content'), true);
     assert.equal(retainedMessages.some(message =>
+      message.role === 'assistant'
+      && message.tool_calls?.[0]?.id === 'call_read'
+    ), true);
+    assert.equal(retainedMessages.some(message =>
+      message.role === 'tool'
+      && message.tool_call_id === 'call_read'
+      && message.content === 'notes content'
+    ), true);
+    assert.equal(retainedMessages.some(message =>
       typeof message.content === 'string'
       && message.content.includes('模型中转请求超时')
-    ), true);
+    ), false);
 
     const restored = SessionStore.getInstance().loadContext('catscompany:lifecycle-timeout-recovery');
     assert.equal(restored.some(message => message.content === 'notes content'), true);
     assert.equal(restored.some(message =>
       typeof message.content === 'string'
       && message.content.includes('避免重复已经完成的工具步骤')
-    ), true);
+    ), false);
   });
 
   test('cleanup persists without invoking hidden AI wakeup checks', async () => {

--- a/tests/session-lifecycle-manager.test.ts
+++ b/tests/session-lifecycle-manager.test.ts
@@ -180,13 +180,19 @@ describe('AgentSession lifecycle', () => {
       'utf-8',
     );
 
+    assert.deepStrictEqual(
+      restored.map((message: any) => message.content),
+      ['需要读文件', '读完了'],
+    );
     assert.equal(restored.some((message: any) => Array.isArray(message.providerContent)), false);
     assert.equal(restored.some((message: any) => message.role === 'tool'), false);
     assert.equal(restored.some((message: any) => message.tool_calls?.length), false);
-    assert.match(String(restored[1]?.content || ''), /provider replay 隐藏内容未写入本地会话/);
-    assert.match(String(restored[1]?.content || ''), /private tool result/);
+    assert.equal(restored.some((message: any) => String(message.content || '').includes('provider replay 隐藏内容')), false);
+    assert.equal(restored.some((message: any) => String(message.content || '').includes('private tool result')), false);
     assert.doesNotMatch(raw, /hidden chain text/);
     assert.doesNotMatch(raw, /sig_secret/);
+    assert.doesNotMatch(raw, /provider replay 隐藏内容/);
+    assert.doesNotMatch(raw, /private tool result/);
   });
 
   test('loading legacy sessions migrates provider replay hidden thinking off disk', async () => {
@@ -214,11 +220,44 @@ describe('AgentSession lifecycle', () => {
     const restored = SessionStore.getInstance().loadContext('user:lifecycle-legacy-provider-replay');
     const migratedRaw = fs.readFileSync(sessionFile, 'utf-8');
 
+    assert.deepStrictEqual(
+      restored.map((message: any) => message.content),
+      ['旧历史'],
+    );
     assert.equal(restored.some((message: any) => Array.isArray(message.providerContent)), false);
     assert.equal(restored.some((message: any) => message.role === 'tool'), false);
-    assert.match(migratedRaw, /legacy tool result/);
+    assert.doesNotMatch(migratedRaw, /legacy tool result/);
     assert.doesNotMatch(migratedRaw, /legacy hidden chain/);
     assert.doesNotMatch(migratedRaw, /legacy_sig/);
+    assert.doesNotMatch(migratedRaw, /provider replay 隐藏内容/);
+  });
+
+  test('loading already-migrated provider replay placeholders strips them from assistant text', async () => {
+    const { SessionStore } = loadSessionModules();
+    const sessionFile = path.join(testRoot, 'data', 'sessions', 'user_lifecycle-placeholder-leak.jsonl');
+    fs.mkdirSync(path.dirname(sessionFile), { recursive: true });
+    fs.writeFileSync(sessionFile, [
+      JSON.stringify({ role: 'user', content: '旧会话继续' }),
+      JSON.stringify({
+        role: 'assistant',
+        content: '[历史工具调用已完成；provider replay 隐藏内容未写入本地会话。 工具调用: write_file。]\n[历史工具结果摘要]\n[工具 write_file] 写入了 report.md',
+      }),
+      JSON.stringify({
+        role: 'assistant',
+        content: '保留这句公开回复\n[历史工具调用已完成；provider replay 隐藏内容未写入本地会话。 工具调用: read_file。]\n继续保留这句',
+      }),
+    ].join('\n') + '\n', 'utf-8');
+
+    const restored = SessionStore.getInstance().loadContext('user:lifecycle-placeholder-leak');
+    const migratedRaw = fs.readFileSync(sessionFile, 'utf-8');
+
+    assert.deepStrictEqual(
+      restored.map((message: any) => message.content),
+      ['旧会话继续', '保留这句公开回复\n继续保留这句'],
+    );
+    assert.doesNotMatch(migratedRaw, /历史工具调用已完成/);
+    assert.doesNotMatch(migratedRaw, /历史工具结果摘要/);
+    assert.doesNotMatch(migratedRaw, /写入了 report\.md/);
   });
 
   test('handleMessage persists each completed turn before cleanup', async () => {

--- a/tests/session-lifecycle-manager.test.ts
+++ b/tests/session-lifecycle-manager.test.ts
@@ -182,11 +182,15 @@ describe('AgentSession lifecycle', () => {
 
     assert.deepStrictEqual(
       restored.map((message: any) => message.content),
-      ['需要读文件', '读完了'],
+      ['需要读文件', null, '[历史工具结果已省略；read_file 已完成。]', '读完了'],
     );
     assert.equal(restored.some((message: any) => Array.isArray(message.providerContent)), false);
-    assert.equal(restored.some((message: any) => message.role === 'tool'), false);
-    assert.equal(restored.some((message: any) => message.tool_calls?.length), false);
+    assert.equal(restored.some((message: any) => message.role === 'tool'), true);
+    assert.equal(restored.some((message: any) => message.tool_calls?.length), true);
+    assert.equal(
+      restored.some((message: any) => message.role === 'tool' && message.tool_call_id === 'toolu_1'),
+      true,
+    );
     assert.equal(restored.some((message: any) => String(message.content || '').includes('provider replay 隐藏内容')), false);
     assert.equal(restored.some((message: any) => String(message.content || '').includes('private tool result')), false);
     assert.doesNotMatch(raw, /hidden chain text/);
@@ -222,10 +226,15 @@ describe('AgentSession lifecycle', () => {
 
     assert.deepStrictEqual(
       restored.map((message: any) => message.content),
-      ['旧历史'],
+      ['旧历史', null, '[历史工具结果已省略；read_file 已完成。]'],
     );
     assert.equal(restored.some((message: any) => Array.isArray(message.providerContent)), false);
-    assert.equal(restored.some((message: any) => message.role === 'tool'), false);
+    assert.equal(restored.some((message: any) => message.role === 'tool'), true);
+    assert.equal(restored.some((message: any) => message.tool_calls?.length), true);
+    assert.equal(
+      restored.some((message: any) => message.role === 'tool' && message.tool_call_id === 'toolu_legacy'),
+      true,
+    );
     assert.doesNotMatch(migratedRaw, /legacy tool result/);
     assert.doesNotMatch(migratedRaw, /legacy hidden chain/);
     assert.doesNotMatch(migratedRaw, /legacy_sig/);


### PR DESCRIPTION
## 背景
反馈 #35 中，多位用户在长工具调用会话后看到大量 `[历史工具调用已完成；provider replay 隐藏内容未写入本地会话。 工具调用: ...]` 占位行。根因是隐藏 provider replay 的工具调用历史在持久化/恢复时被合成到了 assistant 正文，后续请求又把它当作上一轮 assistant 文本传给模型。

后续本地日志还出现过模型把旧的 `[处理失败: API错误 ... api.anthropic.com ...]` 当作历史正文继续复述的问题，本质也是内部运行时占位进入了下一轮模型上下文。

## 修改
- provider replay 隐藏工具调用不再合成为 assistant 正文占位行。
- 仅保留 assistant 公开文本；纯隐藏工具调用轮次会从持久化历史中省略。
- 加载旧会话时迁移清理已经写入磁盘的 provider replay 占位行和历史工具结果摘要。
- 新增 transcript artifact 清理工具，在会话恢复、处理前压缩、构建模型上下文、失败后保存前统一过滤内部占位。
- 内部错误占位只作为 runtime artifact 保留一瞬间，不写入持久历史，也不会进入下一轮模型请求。
- 保留普通 assistant 文档引用场景：用户/AI 正常文本里的 `[历史工具结果摘要]`、`[处理失败: API错误 ...]` 不会被误删。
- 保留已完成工具调用链路，timeout 后仍保留 assistant `tool_calls` 和对应 `tool_result`，方便用户继续。

## 验证
- `node node_modules\\tsx\\dist\\cli.mjs --test tests\\session-lifecycle-manager.test.ts tests\\runtime-feedback.test.ts`
- `node node_modules\\tsx\\dist\\cli.mjs --test tests\\session-lifecycle-manager.test.ts`
- `node node_modules\\tsx\\dist\\cli.mjs --test tests\\runtime-feedback.test.ts`
- `npm.cmd run test:runtime`
- `npm.cmd run build`
- `git diff --check`
- 子 agent 复审：P0/P1/P2 无阻塞，建议合并