### PR TITLE
feat(m3-cache): transient injection 观测 + safe prompt hash

### DIFF
--- a/scripts/observe-transients-demo.ts
+++ b/scripts/observe-transients-demo.ts
@@ -1,0 +1,97 @@
+/**
+ * 模拟几轮对话，观测 transient injection 日志输出。
+ * 用法: XIAOBA_TRANSIENT_OBSERVE=1 npx tsx scripts/observe-transients-demo.ts
+ */
+import { TurnContextBuilder } from '../src/core/turn-context-builder';
+import { createTransientObserver, resetPreviousSystemHash } from '../src/utils/transient-observation';
+import { SessionSkillRuntime, TRANSIENT_SKILLS_LIST_PREFIX } from '../src/skills/session-skill-runtime';
+import { Message } from '../src/types';
+
+// Force enable observation for this script
+process.env.XIAOBA_TRANSIENT_OBSERVE = '1';
+
+const mockSkillRuntime: SessionSkillRuntime = {
+  reloadSkills: async () => {},
+  buildSkillsListMessage: () => ({
+    role: 'user' as const,
+    content: `${TRANSIENT_SKILLS_LIST_PREFIX}\n- deep-research: 深度研究\n- code-review: 代码审查`,
+    __injected: true,
+  }),
+  handleSkillsCommand: () => ({ handled: false }),
+} as any;
+
+const mockPlanRuntime = {
+  formatForPrompt: () => '1. [x] 建立观测\n2. [ ] 跑测试\n3. [ ] 分析结果',
+};
+
+async function simulateTurn(turn: number, systemPrompt: string, userMessage: string) {
+  console.log(`\n${'='.repeat(60)}`);
+  console.log(`Turn ${turn}`);
+  console.log('='.repeat(60));
+
+  const observer = createTransientObserver();
+  const builder = new TurnContextBuilder();
+
+  const durableMessages: Message[] = [
+    { role: 'system', content: systemPrompt },
+    { role: 'user', content: userMessage },
+  ];
+
+  await builder.build({
+    sessionKey: 'demo-session',
+    durableMessages,
+    runtimeFeedback: turn > 1 ? ['上一轮工具执行成功'] : [],
+    skillRuntime: mockSkillRuntime,
+    planRuntime: mockPlanRuntime as any,
+    observer,
+  });
+
+  // Simulate an unrelated transient filtered by policy.
+  observer.recordSuppressed('[transient_soft_check]', 'filtered_by_policy');
+  if (turn > 2) {
+    observer.recordInjected('[transient_runner_hint]', 'system', 'system', 120);
+  }
+
+  // Compute a fake system hash (in real code this comes from the assembled request)
+  const { createHash } = await import('crypto');
+  const systemHash = createHash('sha256').update(systemPrompt).digest('hex').slice(0, 16);
+
+  observer.log({
+    turn,
+    sessionId: 'demo-session',
+    provider: 'anthropic',
+    model: 'minimax-m3',
+    requestId: `ph_demo_${turn}`,
+    systemHash,
+    systemLen: systemPrompt.length,
+  });
+}
+
+async function main() {
+  resetPreviousSystemHash();
+
+  const stableSystem = '你是 XiaoBa，一个 AI 开发助手。\n\n## 工具\n可以使用 execute_shell、read_file 等工具。';
+
+  // Turn 1: 正常注入
+  await simulateTurn(1, stableSystem, '帮我看看 src/index.ts 的结构');
+
+  // Turn 2: system 不变，观测 systemHashChanged=false
+  await simulateTurn(2, stableSystem, '继续分析');
+
+  // Turn 3: system 不变，多了 soft_check 抑制
+  await simulateTurn(3, stableSystem, '加一个新功能');
+
+  // Turn 4: system 变了！（模拟 transient 意外进入 system）
+  const changedSystem = stableSystem + '\n\n[transient_runner_hint]\n这是一个不该进 system 的内容';
+  await simulateTurn(4, changedSystem, '继续');
+
+  // Turn 5: system 恢复正常
+  await simulateTurn(5, stableSystem, '好了');
+
+  console.log('\n' + '='.repeat(60));
+  console.log('Demo complete. Check [TRANSIENT_OBSERVE] logs above.');
+  console.log('Turn 4 should show systemHashChanged=true (simulated contamination).');
+  console.log('Turn 5 should also show systemHashChanged=true (recovered).');
+}
+
+main().catch(console.error);

--- a/src/core/agent-turn-controller.ts
+++ b/src/core/agent-turn-controller.ts
@@ -25,6 +25,7 @@ import { TurnContextBuilder } from './turn-context-builder';
 import { TurnLogRecorder } from './turn-log-recorder';
 import { PlanRuntime } from './plan-runtime';
 import { getPetService } from '../pet/pet-service';
+import { createTransientObserver, isTransientObserveEnabled } from '../utils/transient-observation';
 import {
   buildSyntheticObservationLifecycleEvent,
   describeSyntheticObservationForLog,
@@ -123,6 +124,7 @@ export class AgentTurnController {
     if (!branchAgentsEnabled) {
       this.expireMemoryBranch(previousCarryoverMemoryBranch, 'branch_agents_disabled');
     }
+    const transientObserver = isTransientObserveEnabled() ? createTransientObserver() : undefined;
 
     params.messages.push({
       role: 'user',
@@ -146,6 +148,7 @@ export class AgentTurnController {
       runtimeFeedback: params.runtimeFeedback,
       skillRuntime: this.options.skillRuntime,
       planRuntime: this.options.planRuntime,
+      observer: transientObserver,
     });
 
     const currentMemoryBranch = this.startMemorySidecarIfEnabled({
@@ -171,6 +174,7 @@ export class AgentTurnController {
       ),
       abortSignal: params.abortSignal,
       shouldContinue: params.shouldContinue,
+      observer: transientObserver,
     });
 
     let result;
@@ -232,6 +236,7 @@ export class AgentTurnController {
     syntheticObservationProvider?: () => SyntheticObservation[];
     abortSignal?: AbortSignal;
     shouldContinue: () => boolean;
+    observer?: ReturnType<typeof createTransientObserver>;
   }): ConversationRunner {
     const surface = resolveSessionSurface(this.options.sessionKey, this.options.sessionType);
     return new ConversationRunner(
@@ -244,6 +249,7 @@ export class AgentTurnController {
         // AgentSession/ContextWindowManager compacts durable history before the turn.
         // Runner-level compaction can fold transient runtime feedback into summary.
         enableCompression: false,
+        transientObserver: options.observer,
         toolExecutionContext: {
           sessionId: this.options.sessionKey,
           surface,

--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -2,7 +2,7 @@ import { Message, ContentBlock, ChatConfig, ChatResponse } from '../types';
 import type { ScopedDeviceGrant, ScopedDeviceSelection, ScopedLocalFileGrant } from '../types/session-identity';
 import { AIService } from '../utils/ai-service';
 import { ToolCall, ToolDefinition, ToolExecutionContext, ToolExecutor, ToolResult, ToolTranscriptMode } from '../types/tool';
-import { StreamCallbacks } from '../providers/provider';
+import { AIRequestOptions, StreamCallbacks } from '../providers/provider';
 import { Logger } from '../utils/logger';
 import { Metrics } from '../utils/metrics';
 import { ContextCompressor } from './context-compressor';
@@ -22,6 +22,8 @@ import {
   foldToolResultsTowardPromptBudget,
   resolveAdaptiveToolResultFoldingOptions,
 } from './adaptive-tool-result-folder';
+import { createSafePromptHashRequestId, isSafePromptHashEnabled, logSafePromptHash } from '../utils/safe-prompt-hash';
+import { TransientObserver, isTransientObserveEnabled } from '../utils/transient-observation';
 import {
   buildExplicitPlanRequestHintIfUseful,
   buildInitialDecisionHintIfUseful,
@@ -57,6 +59,7 @@ import {
   describeSyntheticObservationForLog,
   SyntheticObservation,
 } from './synthetic-observation';
+import { createHash } from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -169,6 +172,8 @@ export interface RunnerOptions {
   pendingUserInputProvider?: PendingUserInputProvider;
   /** Non-blocking runtime observations produced by sidecar branches. */
   syntheticObservationProvider?: SyntheticObservationProvider;
+  /** Transient injection observer for cache diagnostics. */
+  transientObserver?: TransientObserver;
 }
 
 /**
@@ -189,6 +194,7 @@ export class ConversationRunner {
   private pendingUserInputProvider?: PendingUserInputProvider;
   private promptTraceLogger: PromptTraceLogger;
   private syntheticObservationProvider?: SyntheticObservationProvider;
+  private transientObserver?: TransientObserver;
 
   /** 截断字符串用于日志输出，避免日志过大 */
   private static truncateForLog(text: any, maxLen = 200): string {
@@ -213,6 +219,7 @@ export class ConversationRunner {
     this.pendingUserInputProvider = options?.pendingUserInputProvider;
     this.syntheticObservationProvider = options?.syntheticObservationProvider;
     this.maxTurns = options?.maxTurns;
+    this.transientObserver = options?.transientObserver;
 
     this.maxPromptTokens = this.resolvePromptBudget(options?.maxContextTokens);
     this.sessionLabel = this.toolExecutionContext?.sessionId
@@ -338,10 +345,22 @@ export class ConversationRunner {
       const perTurnRunnerHint = transientPolicy.injectRunnerHint
         ? buildPerTurnRunnerHint(requestTools)
         : null;
-      let requestMessages = this.buildProviderInputMessages(messages, [
+      const transientRunnerHints = [
         ...(perTurnRunnerHint ? [perTurnRunnerHint] : []),
         ...nextTurnTransientHints,
         ...orchestrationHints,
+      ];
+      if (this.transientObserver) {
+        for (const hint of transientRunnerHints) {
+          const content = typeof hint.content === 'string' ? hint.content : '';
+          const prefix = content.startsWith(TRANSIENT_RUNNER_HINT_PREFIX)
+            ? TRANSIENT_RUNNER_HINT_PREFIX
+            : content.slice(0, content.indexOf(']') + 1) || '[unknown]';
+          this.transientObserver.recordInjected(prefix, hint.role, 'tail', content.length);
+        }
+      }
+      let requestMessages = this.buildProviderInputMessages(messages, [
+        ...transientRunnerHints,
       ], {
         includeCurrentDirectoryHint: transientPolicy.injectEnvironment,
         currentDirectory,
@@ -428,6 +447,62 @@ export class ConversationRunner {
       if (promptTrimmed && callbacks?.onThinking) {
         await callbacks.onThinking(PROMPT_BUDGET_TRIM_MESSAGE);
       }
+      const safePromptHashEnabled = isSafePromptHashEnabled();
+      const debugOptions: AIRequestOptions = safePromptHashEnabled
+        ? {
+          debugRequestId: createSafePromptHashRequestId(),
+          debugSessionId: this.toolExecutionContext?.sessionId,
+          debugSurface: this.toolExecutionContext?.surface,
+          debugTurn: turns,
+        }
+        : {};
+      if (safePromptHashEnabled) {
+        const aiConfig: ChatConfig = typeof (this.aiService as any).getConfig === 'function'
+          ? this.aiService.getConfig()
+          : {};
+        const requestMessageTokens = estimateMessagesTokens(requestMessages);
+        const requestToolTokens = estimateToolsTokens(requestTools);
+        logSafePromptHash({
+          boundary: 'xiaoba.runner.request',
+          requestId: debugOptions.debugRequestId,
+          sessionId: debugOptions.debugSessionId,
+          surface: debugOptions.debugSurface,
+          turn: turns,
+          provider: aiConfig.provider ?? '',
+          model: aiConfig.model ?? '',
+          stream: this.stream,
+        }, {
+          messages: requestMessages,
+          tools: requestTools,
+          extra: {
+            prompt_trimmed: promptTrimmed,
+            message_count: requestMessages.length,
+            tool_count: requestTools.length,
+            message_tokens_est: requestMessageTokens,
+            tool_tokens_est: requestToolTokens,
+            total_tokens_est: requestMessageTokens + requestToolTokens,
+            max_prompt_tokens: this.maxPromptTokens,
+            context_window_tokens: aiConfig.contextWindowTokens ?? null,
+          },
+        });
+      }
+      if (this.transientObserver && isTransientObserveEnabled()) {
+        const aiConfig: ChatConfig = typeof (this.aiService as any).getConfig === 'function'
+          ? this.aiService.getConfig()
+          : {};
+        const systemMessages = requestMessages.filter(m => m.role === 'system');
+        const systemText = systemMessages.map(m => typeof m.content === 'string' ? m.content : '').join('\n\n');
+        const systemHash = createHash('sha256').update(systemText).digest('hex').slice(0, 16);
+        this.transientObserver.log({
+          turn: turns,
+          sessionId: this.toolExecutionContext?.sessionId,
+          provider: aiConfig.provider,
+          model: aiConfig.model ?? '',
+          requestId: debugOptions.debugRequestId,
+          systemHash,
+          systemLen: systemText.length,
+        });
+      }
       this.logProviderMessagesForDebug(requestMessages, requestTools, turns);
       this.promptTraceLogger.recordRequest(turns, requestMessages, requestTools);
       const aiStartTime = Date.now();
@@ -435,7 +510,7 @@ export class ConversationRunner {
 
       let response;
       try {
-        response = await this.requestModelResponse(requestMessages, requestTools, callbacks);
+        response = await this.requestModelResponse(requestMessages, requestTools, callbacks, debugOptions);
         const aiDuration = Date.now() - aiStartTime;
         this.promptTraceLogger.recordResponse(turns, response, aiDuration);
         Logger.info(`[${this.sessionLabel}Turn ${turns}] AI推理完成，耗时: ${aiDuration}ms`);
@@ -960,14 +1035,16 @@ export class ConversationRunner {
       if (typeof message.content !== 'string') {
         return true;
       }
+      if (this.isTransientRunnerHint(message)) {
+        return false;
+      }
       if (message.content.startsWith(TRANSIENT_CURRENT_DIRECTORY_PREFIX)) {
         return false;
       }
       if (message.role !== 'system') {
         return true;
       }
-      return !message.content.startsWith(TRANSIENT_RUNNER_HINT_PREFIX)
-        && !message.content.startsWith(TRANSIENT_CURRENT_DIRECTORY_PREFIX);
+      return !message.content.startsWith(TRANSIENT_CURRENT_DIRECTORY_PREFIX);
     });
 
     const collapsed: Message[] = [];
@@ -1044,9 +1121,9 @@ export class ConversationRunner {
   }
 
   private isTransientRunnerHint(message: Message): boolean {
-    return message.role === 'system'
-      && typeof message.content === 'string'
-      && message.content.startsWith(TRANSIENT_RUNNER_HINT_PREFIX);
+    return typeof message.content === 'string'
+      && message.content.startsWith(TRANSIENT_RUNNER_HINT_PREFIX)
+      && (message.role === 'system' || message.__injected === true);
   }
 
   private isCurrentDirectoryHint(message: Message): boolean {
@@ -1259,9 +1336,11 @@ export class ConversationRunner {
     messages: Message[],
     activeTools: ToolDefinition[],
     callbacks?: RunnerCallbacks,
+    debugOptions: AIRequestOptions = {},
   ) {
-    const requestOptions = {
+    const requestOptions: AIRequestOptions = {
       signal: this.toolExecutionContext?.abortSignal,
+      ...debugOptions,
     };
     try {
       if (this.stream) {

--- a/src/core/turn-context-builder.ts
+++ b/src/core/turn-context-builder.ts
@@ -31,11 +31,24 @@ import {
   findPreviousPromptModeState,
 } from '../runtime/prompt-modes';
 import { resolveTurnContextTransientPolicy } from './transient-injection-policy';
+import { TransientObserver } from '../utils/transient-observation';
 
 const TRANSIENT_PLAN_STATUS_PREFIX = '[transient_plan_status]';
 const TRANSIENT_RUNNER_HINT_PREFIX = '[transient_runner_hint]';
 const TRANSIENT_SOFT_CHECK_PREFIX = '[transient_soft_check]';
 const TRANSIENT_RUNTIME_OBSERVATION_RULES_PREFIX = '[transient_runtime_observation_rules]';
+
+const TRANSIENT_PREFIXES = [
+  TRANSIENT_SUBAGENT_STATUS_PREFIX,
+  TRANSIENT_RUNTIME_CONTEXT_PREFIX,
+  TRANSIENT_PLAN_STATUS_PREFIX,
+  TRANSIENT_RUNNER_HINT_PREFIX,
+  TRANSIENT_SOFT_CHECK_PREFIX,
+  TRANSIENT_RUNTIME_OBSERVATION_RULES_PREFIX,
+  TRANSIENT_SKILLS_LIST_PREFIX,
+  TRANSIENT_PROMPT_MODES_LIST_PREFIX,
+  TRANSIENT_FIXED_PROMPT_MODE_PREFIX,
+];
 
 export interface BuildTurnContextParams {
   sessionKey: string;
@@ -50,6 +63,7 @@ export interface BuildTurnContextParams {
   runtimeFeedback: string[];
   skillRuntime: SessionSkillRuntime;
   planRuntime?: PlanRuntime;
+  observer?: TransientObserver;
 }
 
 export interface BuildTurnContextResult {
@@ -64,13 +78,15 @@ export interface BuildTurnContextResult {
  */
 export class TurnContextBuilder {
   async build(params: BuildTurnContextParams): Promise<BuildTurnContextResult> {
-    const contextMessages = stripAssistantArtifactsFromMessages(params.durableMessages);
-    this.injectRuntimeContext(contextMessages, params);
-    this.injectRuntimeObservationRules(contextMessages);
-    this.injectRuntimeFeedback(contextMessages, params.runtimeFeedback);
-    this.injectPlanStatus(contextMessages, params.planRuntime);
-    this.injectSubAgentStatus(contextMessages, params.sessionKey);
-    this.injectPromptModesList(contextMessages);
+    const contextMessages = this.removeTransientMessages(stripAssistantArtifactsFromMessages(params.durableMessages));
+    const obs = params.observer;
+
+    this.injectRuntimeContext(contextMessages, params, obs);
+    this.injectRuntimeObservationRules(contextMessages, obs);
+    this.injectRuntimeFeedback(contextMessages, params.runtimeFeedback, obs);
+    this.injectPlanStatus(contextMessages, params.planRuntime, obs);
+    this.injectSubAgentStatus(contextMessages, params.sessionKey, obs);
+    this.injectPromptModesList(contextMessages, obs);
     const transientPolicy = resolveTurnContextTransientPolicy(contextMessages);
     if (transientPolicy.injectSkillsList) {
       await params.skillRuntime.reloadSkills();
@@ -78,7 +94,9 @@ export class TurnContextBuilder {
         skillNames: transientPolicy.skillNames,
       });
       if (skillsListMsg) {
-        this.insertBeforeLastUser(contextMessages, skillsListMsg);
+        const safeSkillsListMsg = ensureTransientUserMessage(skillsListMsg);
+        this.insertBeforeLastUser(contextMessages, safeSkillsListMsg);
+        obs?.recordInjected(TRANSIENT_SKILLS_LIST_PREFIX, safeSkillsListMsg.role, 'before_last_user', contentLen(safeSkillsListMsg));
       }
     }
 
@@ -92,29 +110,12 @@ export class TurnContextBuilder {
     return messages.filter(msg => {
       if (msg.__syntheticObservation) return false;
       if (msg.__runtimeFeedback) return false;
-      if (
-        (msg.__injected || msg.role === 'system')
-        && typeof msg.content === 'string'
-        && msg.content.startsWith(TRANSIENT_PROMPT_MODES_LIST_PREFIX)
-      ) return false;
-      if (
-        (msg.__injected || msg.role === 'system')
-        && typeof msg.content === 'string'
-        && msg.content.startsWith(TRANSIENT_FIXED_PROMPT_MODE_PREFIX)
-      ) return false;
-      if (msg.role !== 'system' || typeof msg.content !== 'string') return true;
-      if (msg.content.startsWith(TRANSIENT_SUBAGENT_STATUS_PREFIX)) return false;
-      if (msg.content.startsWith(TRANSIENT_PLAN_STATUS_PREFIX)) return false;
-      if (msg.content.startsWith(TRANSIENT_RUNNER_HINT_PREFIX)) return false;
-      if (msg.content.startsWith(TRANSIENT_SOFT_CHECK_PREFIX)) return false;
-      if (msg.content.startsWith(TRANSIENT_RUNTIME_OBSERVATION_RULES_PREFIX)) return false;
-      if (msg.content.startsWith(TRANSIENT_SKILLS_LIST_PREFIX)) return false;
-      if (msg.content.startsWith(TRANSIENT_RUNTIME_CONTEXT_PREFIX)) return false;
+      if (isTransientPromptMessage(msg) && (msg.__injected || msg.role === 'system')) return false;
       return true;
     });
   }
 
-  private injectRuntimeContext(messages: Message[], params: BuildTurnContextParams): void {
+  private injectRuntimeContext(messages: Message[], params: BuildTurnContextParams, obs?: TransientObserver): void {
     const message = buildRuntimeContextMessage({
       sessionKey: params.sessionKey,
       sessionType: params.sessionType,
@@ -127,10 +128,11 @@ export class TurnContextBuilder {
     });
     if (!message) return;
     this.insertBeforeLastUser(messages, message);
+    obs?.recordInjected(TRANSIENT_RUNTIME_CONTEXT_PREFIX, message.role, 'before_last_user', contentLen(message));
   }
 
-  private injectRuntimeObservationRules(messages: Message[]): void {
-    this.insertBeforeLastUser(messages, {
+  private injectRuntimeObservationRules(messages: Message[], obs?: TransientObserver): void {
+    const message: Message = {
       role: 'system',
       content: [
         TRANSIENT_RUNTIME_OBSERVATION_RULES_PREFIX,
@@ -142,10 +144,12 @@ export class TurnContextBuilder {
         '如果 late_previous_turn 与当前用户输入冲突，以当前用户输入为准。',
         '如果它说明上一轮回答有遗漏且当前仍在同一话题，可以简短补充或修正；否则保持安静。',
       ].join('\n'),
-    });
+    };
+    this.insertBeforeLastUser(messages, message);
+    obs?.recordInjected(TRANSIENT_RUNTIME_OBSERVATION_RULES_PREFIX, message.role, 'before_last_user', contentLen(message));
   }
 
-  private injectRuntimeFeedback(messages: Message[], runtimeFeedback: string[]): void {
+  private injectRuntimeFeedback(messages: Message[], runtimeFeedback: string[], obs?: TransientObserver): void {
     if (runtimeFeedback.length === 0) return;
 
     const runtimeFeedbackMessages: Message[] = runtimeFeedback.map(content => ({
@@ -155,27 +159,37 @@ export class TurnContextBuilder {
       __runtimeFeedback: true,
     }));
     this.insertBeforeLastUser(messages, ...runtimeFeedbackMessages);
+    for (const msg of runtimeFeedbackMessages) {
+      obs?.recordInjected('[runtime_feedback]', 'user', 'before_last_user', contentLen(msg));
+    }
   }
 
-  private injectPlanStatus(messages: Message[], planRuntime?: PlanRuntime): void {
+  private injectPlanStatus(messages: Message[], planRuntime?: PlanRuntime, obs?: TransientObserver): void {
     const planText = planRuntime?.formatForPrompt();
     if (!planText) return;
-    this.insertBeforeLastUser(messages, {
-      role: 'system',
+    const msg: Message = {
+      role: 'user',
       content: `${TRANSIENT_PLAN_STATUS_PREFIX}\n${planText}`,
-    });
+      __injected: true,
+    };
+    this.insertBeforeLastUser(messages, msg);
+    obs?.recordInjected(TRANSIENT_PLAN_STATUS_PREFIX, 'user', 'before_last_user', contentLen(msg));
   }
 
-  private injectSubAgentStatus(messages: Message[], sessionKey: string): void {
+  private injectSubAgentStatus(messages: Message[], sessionKey: string, obs?: TransientObserver): void {
     const statusMessage = buildSubAgentStatusMessage(sessionKey);
     if (!statusMessage) return;
-    this.insertBeforeLastUser(messages, statusMessage);
+    const safeStatusMessage = ensureTransientUserMessage(statusMessage);
+    this.insertBeforeLastUser(messages, safeStatusMessage);
+    obs?.recordInjected(TRANSIENT_SUBAGENT_STATUS_PREFIX, safeStatusMessage.role, 'before_last_user', contentLen(safeStatusMessage));
   }
 
-  private injectPromptModesList(messages: Message[]): void {
+  private injectPromptModesList(messages: Message[], obs?: TransientObserver): void {
     const fixedMode = findFixedPromptModeState(messages);
     if (fixedMode) {
-      this.insertBeforeLastUser(messages, buildFixedPromptModeMessage(fixedMode));
+      const message = buildFixedPromptModeMessage(fixedMode);
+      this.insertBeforeLastUser(messages, message);
+      obs?.recordInjected(TRANSIENT_FIXED_PROMPT_MODE_PREFIX, message.role, 'before_last_user', contentLen(message));
       return;
     }
 
@@ -184,6 +198,7 @@ export class TurnContextBuilder {
     });
     if (!modeList) return;
     this.insertBeforeLastUser(messages, modeList);
+    obs?.recordInjected(TRANSIENT_PROMPT_MODES_LIST_PREFIX, modeList.role, 'before_last_user', contentLen(modeList));
   }
 
   private extractRuntimeFeedback(messages: Message[]): string[] {
@@ -207,4 +222,25 @@ function findLastIndex<T>(items: T[], predicate: (item: T) => boolean): number {
     if (predicate(items[idx])) return idx;
   }
   return -1;
+}
+
+function isTransientPromptMessage(message: Message): boolean {
+  const { content } = message;
+  return typeof content === 'string'
+    && TRANSIENT_PREFIXES.some(prefix => content.startsWith(prefix));
+}
+
+function contentLen(message: Message): number {
+  if (typeof message.content === 'string') return message.content.length;
+  if (Array.isArray(message.content)) return JSON.stringify(message.content).length;
+  return 0;
+}
+
+function ensureTransientUserMessage(message: Message): Message {
+  if (!isTransientPromptMessage(message)) return message;
+  return {
+    ...message,
+    role: 'user',
+    __injected: true,
+  };
 }

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -17,6 +17,10 @@ export interface StreamCallbacks {
 
 export interface AIRequestOptions {
   signal?: AbortSignal;
+  debugRequestId?: string;
+  debugSessionId?: string;
+  debugSurface?: string;
+  debugTurn?: number;
 }
 
 /**

--- a/src/utils/safe-prompt-hash.ts
+++ b/src/utils/safe-prompt-hash.ts
@@ -1,0 +1,411 @@
+import { createHash, createHmac, randomBytes } from 'crypto';
+import { Logger } from './logger';
+
+type Jsonish = string | number | boolean | null | Jsonish[] | { [key: string]: Jsonish };
+
+export interface SafePromptHashMeta {
+  boundary: string;
+  requestId?: string;
+  sessionId?: string;
+  surface?: string;
+  turn?: number;
+  provider?: string;
+  model?: string;
+  stream?: boolean;
+}
+
+export interface SafePromptHashInput {
+  messages?: unknown;
+  tools?: unknown;
+  system?: unknown;
+  body?: unknown;
+  extra?: Record<string, unknown>;
+}
+
+const HASH_LENGTH = 16;
+
+export function createSafePromptHashRequestId(): string {
+  return `ph_${Date.now().toString(36)}_${randomBytes(4).toString('hex')}`;
+}
+
+export function logSafePromptHash(meta: SafePromptHashMeta, input: SafePromptHashInput): void {
+  if (!isSafePromptHashEnabled()) return;
+
+  Logger.info(`[SAFE_PROMPT_HASH] ${JSON.stringify(buildSafePromptHashPayload(meta, input))}`);
+}
+
+export function buildSafePromptHashPayload(meta: SafePromptHashMeta, input: SafePromptHashInput): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    boundary: meta.boundary,
+    request_id: meta.requestId,
+    session_id: meta.sessionId,
+    session_hash: meta.sessionId ? digest(meta.sessionId) : undefined,
+    surface: meta.surface,
+    turn: meta.turn,
+    provider: meta.provider,
+    model: meta.model,
+    stream: meta.stream,
+  };
+
+  if (input.system !== undefined) {
+    const text = stableStringify(input.system);
+    payload.system = {
+      len: text.length,
+      hash: digest(text),
+    };
+  }
+
+  if (input.messages !== undefined) {
+    payload.messages = summarizeMessages(input.messages);
+  }
+
+  if (input.tools !== undefined) {
+    payload.tools = summarizeTools(input.tools);
+  }
+
+  if (input.body !== undefined) {
+    const text = stableStringify(input.body);
+    payload.body = {
+      len: text.length,
+      hash: digest(text),
+    };
+  }
+
+  if (input.extra) {
+    payload.extra = sanitizeExtra(input.extra);
+  }
+
+  return stripUndefined(payload) as Record<string, unknown>;
+}
+
+export function isSafePromptHashEnabled(): boolean {
+  return /^(1|true|yes)$/i.test(process.env.XIAOBA_SAFE_PROMPT_HASH || '');
+}
+
+function summarizeMessages(messages: unknown): Record<string, unknown> {
+  if (!Array.isArray(messages)) {
+    const text = stableStringify(messages);
+    return {
+      kind: typeOf(messages),
+      len: text.length,
+      hash: digest(text),
+    };
+  }
+
+  const normalized = messages.map(normalizeMessage);
+  const currentUserIndex = findCurrentUserIndex(messages);
+  const segmented = normalized.map((message, index) => ({
+    ...message,
+    index,
+    segment: classifyMessageSegment(messages[index], index, currentUserIndex),
+  }));
+  const items = normalized.map((message, index) => ({
+    index,
+    role: message.role,
+    name: message.name,
+    segment: segmented[index].segment,
+    content_kind: message.contentKind,
+    content_len: message.contentLen,
+    content_hash: message.contentHash,
+    tool_call_count: message.toolCallCount,
+    tool_calls_hash: message.toolCallsHash,
+    tool_call_id_hash: message.toolCallIdHash,
+  }));
+
+  return {
+    count: messages.length,
+    roles: normalized.map(message => message.role).join(','),
+    total_content_len: normalized.reduce((sum, message) => sum + message.contentLen, 0),
+    hash: digest(normalized),
+    segments: summarizeMessageSegments(segmented),
+    prefixes: summarizeMessagePrefixes(normalized),
+    tail: summarizeMessageTail(normalized),
+    items,
+  };
+}
+
+function normalizeMessage(message: unknown): Record<string, any> {
+  if (!isRecord(message)) {
+    const text = stableStringify(message);
+    return {
+      role: typeOf(message),
+      contentKind: typeOf(message),
+      contentLen: text.length,
+      contentHash: digest(text),
+      toolCallCount: 0,
+      toolCallsHash: undefined,
+      toolCallIdHash: undefined,
+      normalized: text,
+    };
+  }
+
+  const role = typeof message.role === 'string' ? message.role : '';
+  const name = typeof message.name === 'string' ? message.name : undefined;
+  const content = message.content;
+  const contentText = stableStringify(content);
+  const toolCalls = Array.isArray(message.tool_calls) ? message.tool_calls : undefined;
+  const toolCallId = typeof message.tool_call_id === 'string' ? message.tool_call_id : undefined;
+
+  return {
+    role,
+    name,
+    contentKind: Array.isArray(content) ? 'array' : typeOf(content),
+    contentLen: contentText.length,
+    contentHash: digest(contentText),
+    toolCallCount: toolCalls?.length ?? 0,
+    toolCallsHash: toolCalls ? digest(toolCalls) : undefined,
+    toolCallIdHash: toolCallId ? digest(toolCallId) : undefined,
+    normalized: {
+      role,
+      name,
+      tool_call_id: toolCallId,
+      content,
+      tool_calls: toolCalls,
+    },
+  };
+}
+
+function summarizeTools(tools: unknown): Record<string, unknown> {
+  if (!Array.isArray(tools)) {
+    const text = stableStringify(tools);
+    return {
+      kind: typeOf(tools),
+      len: text.length,
+      hash: digest(text),
+    };
+  }
+
+  const normalized = tools.map(normalizeTool);
+  const names = normalized.map(tool => tool.name);
+
+  return {
+    count: tools.length,
+    names,
+    total_len: normalized.reduce((sum, tool) => sum + tool.len, 0),
+    hash: digest(normalized.map(tool => tool.normalized)),
+    items: normalized.map(tool => ({
+      name: tool.name,
+      len: tool.len,
+      description_len: tool.descriptionLen,
+      schema_len: tool.schemaLen,
+      hash: tool.hash,
+    })),
+  };
+}
+
+function summarizeMessageSegments(messages: Array<Record<string, any>>): Record<string, unknown> {
+  const segments: Record<string, Array<Record<string, any>>> = {};
+  for (const message of messages) {
+    const segment = message.segment || 'unknown';
+    if (!segments[segment]) segments[segment] = [];
+    segments[segment].push(message);
+  }
+
+  const result: Record<string, unknown> = {};
+  for (const [segment, group] of Object.entries(segments)) {
+    result[segment] = {
+      count: group.length,
+      roles: countValues(group.map(item => item.role)),
+      total_content_len: group.reduce((sum, item) => sum + Number(item.contentLen || 0), 0),
+      tool_call_count: group.reduce((sum, item) => sum + Number(item.toolCallCount || 0), 0),
+      first_index: group[0]?.index,
+      last_index: group[group.length - 1]?.index,
+      hash: digest(group.map(item => item.normalized)),
+    };
+  }
+  return result;
+}
+
+function summarizeMessagePrefixes(messages: Array<Record<string, any>>): Array<Record<string, unknown>> {
+  if (messages.length === 0) return [];
+  const checkpoints = uniqueNumbers([
+    1,
+    2,
+    4,
+    8,
+    16,
+    32,
+    64,
+    128,
+    messages.length,
+  ]).filter(count => count > 0 && count <= messages.length);
+
+  return checkpoints.map(count => {
+    const slice = messages.slice(0, count);
+    return {
+      count,
+      roles: slice.map(message => message.role).join(','),
+      total_content_len: slice.reduce((sum, message) => sum + Number(message.contentLen || 0), 0),
+      hash: digest(slice.map(message => message.normalized)),
+    };
+  });
+}
+
+function summarizeMessageTail(messages: Array<Record<string, any>>): Record<string, unknown> {
+  const count = Math.min(8, messages.length);
+  const slice = messages.slice(messages.length - count);
+  return {
+    count,
+    start_index: messages.length - count,
+    roles: slice.map(message => message.role).join(','),
+    total_content_len: slice.reduce((sum, message) => sum + Number(message.contentLen || 0), 0),
+    hash: digest(slice.map(message => message.normalized)),
+  };
+}
+
+function classifyMessageSegment(raw: unknown, index: number, currentUserIndex: number): string {
+  if (!isRecord(raw)) return 'unknown';
+  const role = typeof raw.role === 'string' ? raw.role : '';
+  const content = typeof raw.content === 'string' ? raw.content : '';
+
+  if (role === 'system' && content.startsWith('[transient_skills_list]')) {
+    return 'skills';
+  }
+  if (isTransientMessage(raw)) {
+    return 'transient';
+  }
+  if (raw.__runtimeObservation) {
+    return 'runtime_observation';
+  }
+  if (index === currentUserIndex) {
+    return 'current_user';
+  }
+  if (role === 'system') {
+    return 'system';
+  }
+  if (role === 'tool') {
+    return 'tool_result';
+  }
+  if (role === 'assistant' && Array.isArray(raw.tool_calls) && raw.tool_calls.length > 0) {
+    return 'assistant_tool_call';
+  }
+  return 'history';
+}
+
+function isTransientMessage(message: Record<string, any>): boolean {
+  if (message.__injected || message.__runtimeFeedback) return true;
+  if (message.role !== 'system' || typeof message.content !== 'string') return false;
+  return message.content.startsWith('[transient_');
+}
+
+function findCurrentUserIndex(messages: unknown[]): number {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index];
+    if (!isRecord(message)) continue;
+    if (message.role !== 'user') continue;
+    if (message.__injected || message.__runtimeFeedback) continue;
+    if (typeof message.content === 'string' && message.content.startsWith('[transient_')) continue;
+    return index;
+  }
+  return -1;
+}
+
+function normalizeTool(tool: unknown): Record<string, any> {
+  const record = isRecord(tool) ? tool : {};
+  const functionRecord = isRecord(record.function) ? record.function : {};
+  const name = typeof record.name === 'string'
+    ? record.name
+    : typeof functionRecord.name === 'string'
+      ? functionRecord.name
+      : '';
+  const description = typeof record.description === 'string'
+    ? record.description
+    : typeof functionRecord.description === 'string'
+      ? functionRecord.description
+      : '';
+  const schema = record.parameters ?? functionRecord.parameters ?? {};
+  const normalized = {
+    name,
+    description,
+    parameters: schema,
+  };
+  const schemaText = stableStringify(schema);
+  return {
+    name,
+    descriptionLen: description.length,
+    schemaLen: schemaText.length,
+    len: stableStringify(normalized).length,
+    hash: digest(normalized),
+    normalized,
+  };
+}
+
+function sanitizeExtra(extra: Record<string, unknown>): Record<string, unknown> {
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(extra)) {
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean' || value === null) {
+      sanitized[key] = value;
+      continue;
+    }
+    const text = stableStringify(value);
+    sanitized[key] = {
+      kind: typeOf(value),
+      len: text.length,
+      hash: digest(text),
+    };
+  }
+  return sanitized;
+}
+
+function digest(value: unknown): string {
+  const text = typeof value === 'string' ? value : stableStringify(value);
+  const salt = process.env.XIAOBA_SAFE_PROMPT_HASH_SALT || '';
+  const hash = salt
+    ? createHmac('sha256', salt).update(text).digest('hex')
+    : createHash('sha256').update(text).digest('hex');
+  return hash.slice(0, HASH_LENGTH);
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(toStableJson(value));
+}
+
+function toStableJson(value: unknown): Jsonish {
+  if (value === null) return null;
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return value;
+  if (Array.isArray(value)) return value.map(toStableJson);
+  if (!isRecord(value)) return String(value);
+
+  const result: { [key: string]: Jsonish } = {};
+  for (const key of Object.keys(value).sort()) {
+    const current = value[key];
+    if (typeof current === 'undefined' || typeof current === 'function') continue;
+    result[key] = toStableJson(current);
+  }
+  return result;
+}
+
+function stripUndefined(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stripUndefined);
+  if (!isRecord(value)) return value;
+
+  const result: Record<string, unknown> = {};
+  for (const [key, current] of Object.entries(value)) {
+    if (typeof current === 'undefined') continue;
+    result[key] = stripUndefined(current);
+  }
+  return result;
+}
+
+function countValues(values: string[]): Record<string, number> {
+  const result: Record<string, number> = {};
+  for (const value of values) {
+    const key = value || 'unknown';
+    result[key] = (result[key] || 0) + 1;
+  }
+  return result;
+}
+
+function uniqueNumbers(values: number[]): number[] {
+  return [...new Set(values)];
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function typeOf(value: unknown): string {
+  if (Array.isArray(value)) return 'array';
+  if (value === null) return 'null';
+  return typeof value;
+}

--- a/src/utils/transient-observation.ts
+++ b/src/utils/transient-observation.ts
@@ -1,0 +1,109 @@
+import { Logger } from './logger';
+
+export interface TransientInjected {
+  prefix: string;
+  role: string;
+  placement: 'before_last_user' | 'tail' | 'system';
+  contentLen: number;
+}
+
+export interface TransientSuppressed {
+  prefix: string;
+  reason: string;
+}
+
+export interface TransientObservation {
+  turn?: number;
+  sessionId?: string;
+  provider?: string;
+  model?: string;
+  requestId?: string;
+  injected: TransientInjected[];
+  suppressed: TransientSuppressed[];
+  systemHash?: string;
+  systemHashChanged?: boolean;
+  systemLen?: number;
+}
+
+const LOG_PREFIX = '[TRANSIENT_OBSERVE]';
+
+export interface TransientObservationMeta {
+  turn?: number;
+  sessionId?: string;
+  provider?: string;
+  model?: string;
+  requestId?: string;
+  systemHash?: string;
+  systemLen?: number;
+}
+
+const previousSystemHashes = new Map<string, string>();
+
+export function isTransientObserveEnabled(): boolean {
+  return /^(1|true|yes)$/i.test(process.env.XIAOBA_TRANSIENT_OBSERVE || '');
+}
+
+export class TransientObserver {
+  private injected: TransientInjected[] = [];
+  private suppressed: TransientSuppressed[] = [];
+
+  recordInjected(prefix: string, role: string, placement: TransientInjected['placement'], contentLen: number): void {
+    this.injected.push({ prefix, role, placement, contentLen });
+  }
+
+  recordSuppressed(prefix: string, reason: string): void {
+    this.suppressed.push({ prefix, reason });
+  }
+
+  buildObservation(meta?: TransientObservationMeta): TransientObservation {
+    const obs: TransientObservation = {
+      turn: meta?.turn,
+      sessionId: meta?.sessionId,
+      provider: meta?.provider,
+      model: meta?.model,
+      requestId: meta?.requestId,
+      injected: this.injected,
+      suppressed: this.suppressed,
+    };
+
+    if (meta?.systemHash) {
+      const bucketKey = buildSystemHashBucketKey(meta);
+      const previousSystemHash = previousSystemHashes.get(bucketKey);
+      obs.systemHash = meta.systemHash;
+      obs.systemLen = meta.systemLen;
+      obs.systemHashChanged = previousSystemHash !== undefined && previousSystemHash !== meta.systemHash;
+      previousSystemHashes.set(bucketKey, meta.systemHash);
+    }
+
+    return obs;
+  }
+
+  log(meta?: TransientObservationMeta): void {
+    if (!isTransientObserveEnabled()) return;
+    const obs = this.buildObservation(meta);
+    Logger.info(`${LOG_PREFIX} ${JSON.stringify(obs)}`);
+  }
+
+  get injectedCount(): number {
+    return this.injected.length;
+  }
+
+  get suppressedCount(): number {
+    return this.suppressed.length;
+  }
+}
+
+export function createTransientObserver(): TransientObserver {
+  return new TransientObserver();
+}
+
+export function resetPreviousSystemHash(): void {
+  previousSystemHashes.clear();
+}
+
+function buildSystemHashBucketKey(meta: TransientObservationMeta): string {
+  const sessionId = meta.sessionId || 'unknown-session';
+  const provider = meta.provider || 'unknown-provider';
+  const model = meta.model || 'unknown-model';
+  return `${sessionId}|${provider}|${model}`;
+}

--- a/tests/subagent-runtime-events.test.ts
+++ b/tests/subagent-runtime-events.test.ts
@@ -118,13 +118,13 @@ describe('subagent runtime events', () => {
       });
 
       const eventIndex = result.messages.findIndex(message => (
-        message.role === 'system'
-        && typeof message.content === 'string'
+        typeof message.content === 'string'
         && message.content.startsWith('[transient_subagent_status]')
       ));
       const userIndex = result.messages.findIndex(message => message.role === 'user' && message.content === '用户新问题');
 
       assert.ok(eventIndex >= 0, 'subagent status observation should be injected');
+      assert.equal(result.messages[eventIndex].__injected, true);
       assert.ok(eventIndex < userIndex, 'subagent observation should appear before latest user message');
       assert.match(String(result.messages[eventIndex].content), /完成 dashboard 账号链路审查/);
       assert.doesNotMatch(

--- a/tests/transient-observation.test.ts
+++ b/tests/transient-observation.test.ts
@@ -1,0 +1,128 @@
+import { describe, test, beforeEach } from 'node:test';
+import * as assert from 'node:assert';
+import { TransientObserver, createTransientObserver, resetPreviousSystemHash } from '../src/utils/transient-observation';
+
+describe('TransientObserver', () => {
+  let observer: TransientObserver;
+
+  beforeEach(() => {
+    observer = createTransientObserver();
+    resetPreviousSystemHash();
+  });
+
+  test('records injected transients', () => {
+    observer.recordInjected('[transient_plan_status]', 'user', 'before_last_user', 342);
+    observer.recordInjected('[transient_skills_list]', 'user', 'before_last_user', 890);
+
+    assert.strictEqual(observer.injectedCount, 2);
+    const obs = observer.buildObservation();
+    assert.strictEqual(obs.injected.length, 2);
+    assert.strictEqual(obs.injected[0].prefix, '[transient_plan_status]');
+    assert.strictEqual(obs.injected[0].role, 'user');
+    assert.strictEqual(obs.injected[0].placement, 'before_last_user');
+    assert.strictEqual(obs.injected[0].contentLen, 342);
+    assert.strictEqual(obs.injected[1].prefix, '[transient_skills_list]');
+    assert.strictEqual(obs.injected[1].contentLen, 890);
+  });
+
+  test('records suppressed transients', () => {
+    observer.recordSuppressed('[transient_soft_check]', 'filtered_by_policy');
+    observer.recordSuppressed('[transient_tool_guidance]', 'filtered_by_policy');
+
+    assert.strictEqual(observer.suppressedCount, 2);
+    const obs = observer.buildObservation();
+    assert.strictEqual(obs.suppressed.length, 2);
+    assert.strictEqual(obs.suppressed[0].prefix, '[transient_soft_check]');
+    assert.strictEqual(obs.suppressed[0].reason, 'filtered_by_policy');
+  });
+
+  test('tracks system hash stability — first turn is not changed', () => {
+    const obs = observer.buildObservation({
+      turn: 1,
+      model: 'minimax-m3',
+      systemHash: 'abc123',
+      systemLen: 5000,
+    });
+
+    assert.strictEqual(obs.systemHash, 'abc123');
+    assert.strictEqual(obs.systemHashChanged, false);
+    assert.strictEqual(obs.systemLen, 5000);
+  });
+
+  test('tracks system hash stability — detects change on second turn', () => {
+    const obs1 = createTransientObserver();
+    obs1.buildObservation({ systemHash: 'abc123', systemLen: 5000 });
+
+    const obs2 = createTransientObserver();
+    const result = obs2.buildObservation({ systemHash: 'def456', systemLen: 5100 });
+
+    assert.strictEqual(result.systemHashChanged, true);
+  });
+
+  test('tracks system hash stability — no change when same hash', () => {
+    const obs1 = createTransientObserver();
+    obs1.buildObservation({ systemHash: 'abc123', systemLen: 5000 });
+
+    const obs2 = createTransientObserver();
+    const result = obs2.buildObservation({ systemHash: 'abc123', systemLen: 5000 });
+
+    assert.strictEqual(result.systemHashChanged, false);
+  });
+
+  test('tracks system hash stability per session and model bucket', () => {
+    const sessionA1 = createTransientObserver().buildObservation({
+      sessionId: 'session-a',
+      provider: 'anthropic',
+      model: 'MiniMax-M3',
+      systemHash: 'hash-a',
+      systemLen: 5000,
+    });
+    const sessionB1 = createTransientObserver().buildObservation({
+      sessionId: 'session-b',
+      provider: 'anthropic',
+      model: 'MiniMax-M3',
+      systemHash: 'hash-b',
+      systemLen: 5100,
+    });
+    const sessionA2 = createTransientObserver().buildObservation({
+      sessionId: 'session-a',
+      provider: 'anthropic',
+      model: 'MiniMax-M3',
+      systemHash: 'hash-a',
+      systemLen: 5000,
+    });
+    const sessionB2 = createTransientObserver().buildObservation({
+      sessionId: 'session-b',
+      provider: 'anthropic',
+      model: 'MiniMax-M3',
+      systemHash: 'hash-c',
+      systemLen: 5200,
+    });
+
+    assert.strictEqual(sessionA1.systemHashChanged, false);
+    assert.strictEqual(sessionB1.systemHashChanged, false);
+    assert.strictEqual(sessionA2.systemHashChanged, false);
+    assert.strictEqual(sessionB2.systemHashChanged, true);
+  });
+
+  test('buildObservation includes meta fields', () => {
+    observer.recordInjected('[transient_plan_status]', 'user', 'before_last_user', 100);
+    observer.recordSuppressed('[transient_tool_guidance]', 'filtered_by_policy');
+
+    const obs = observer.buildObservation({
+      turn: 3,
+      model: 'minimax-m3',
+      requestId: 'ph_abc_1234',
+      systemHash: 'xyz789',
+      systemLen: 4000,
+    });
+
+    assert.strictEqual(obs.turn, 3);
+    assert.strictEqual(obs.sessionId, undefined);
+    assert.strictEqual(obs.provider, undefined);
+    assert.strictEqual(obs.model, 'minimax-m3');
+    assert.strictEqual(obs.requestId, 'ph_abc_1234');
+    assert.strictEqual(obs.injected.length, 1);
+    assert.strictEqual(obs.suppressed.length, 1);
+  });
+});

--- a/tests/turn-context-builder-transients.test.ts
+++ b/tests/turn-context-builder-transients.test.ts
@@ -1,0 +1,96 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import { TurnContextBuilder } from '../src/core/turn-context-builder';
+import { TRANSIENT_RUNNER_HINT_PREFIX } from '../src/core/runner-orchestration-policy';
+import { TRANSIENT_SUBAGENT_STATUS_PREFIX } from '../src/core/sub-agent-observation';
+import { TRANSIENT_SKILLS_LIST_PREFIX } from '../src/skills/session-skill-runtime';
+import { Message } from '../src/types';
+
+describe('TurnContextBuilder transient cache safety', () => {
+  test('removes old system transients and new injected user transients', () => {
+    const builder = new TurnContextBuilder();
+    const messages: Message[] = [
+      { role: 'system', content: 'base system prompt' },
+      { role: 'system', content: '[transient_plan_status]\nold plan' },
+      { role: 'system', content: `${TRANSIENT_SUBAGENT_STATUS_PREFIX}\nold subagent` },
+      { role: 'system', content: `${TRANSIENT_SKILLS_LIST_PREFIX}\nold skills` },
+      { role: 'system', content: `${TRANSIENT_RUNNER_HINT_PREFIX}\nsystem runner hint` },
+      { role: 'user', content: '[transient_plan_status]\nnew plan', __injected: true },
+      { role: 'user', content: `${TRANSIENT_RUNNER_HINT_PREFIX}\nnew hint`, __injected: true },
+      { role: 'user', content: '[transient_soft_check]\nnew soft check', __injected: true },
+      { role: 'user', content: `${TRANSIENT_SUBAGENT_STATUS_PREFIX}\nnew subagent`, __injected: true },
+      { role: 'user', content: `${TRANSIENT_SKILLS_LIST_PREFIX}\nnew skills`, __injected: true },
+      { role: 'user', content: '[transient_plan_status]\nuser typed this literally' },
+      { role: 'user', content: 'latest real request' },
+    ];
+
+    const cleaned = builder.removeTransientMessages(messages);
+
+    assert.deepEqual(cleaned.map(message => message.content), [
+      'base system prompt',
+      '[transient_plan_status]\nuser typed this literally',
+      'latest real request',
+    ]);
+  });
+
+  test('does not put dynamic non-runner transient prompt messages into system context', async () => {
+    const builder = new TurnContextBuilder();
+    const result = await builder.build({
+      sessionKey: 'test-session',
+      durableMessages: [
+        { role: 'system', content: 'stable base system' },
+        { role: 'system', content: '[transient_skills_list]\nlegacy transient should be dropped' },
+        { role: 'user', content: 'hello' },
+      ],
+      runtimeFeedback: [],
+      planRuntime: {
+        formatForPrompt: () => 'current plan status',
+      } as any,
+      skillRuntime: {
+        reloadSkills: async () => undefined,
+        buildSkillsListMessage: () => ({
+          role: 'system',
+          content: '[transient_skills_list]\nuse skill tool by name',
+          __injected: true,
+        } as Message),
+      } as any,
+    });
+
+    const transientMessages = result.messages
+      .filter(isTransientPromptMessage)
+      .filter(message => !String(message.content).startsWith('[transient_runtime_observation_rules]'));
+    assert.ok(transientMessages.length >= 2, 'expected plan and skills transient messages');
+    assert.equal(
+      transientMessages.some(message => message.role === 'system'),
+      false,
+      'non-runner transient prompt messages must not enter system context',
+    );
+    assert.ok(transientMessages.every(message => message.role === 'user'));
+    assert.ok(transientMessages.every(message => message.__injected === true));
+
+    const systemText = result.messages
+      .filter(message => message.role === 'system')
+      .map(message => String(message.content))
+      .join('\n');
+    assert.doesNotMatch(systemText, /\[transient_(plan_status|skills_list|subagent_status|runner_hint|soft_check)/);
+  });
+
+  test('removes injected transient user messages from durable history', () => {
+    const builder = new TurnContextBuilder();
+    const durable = builder.removeTransientMessages([
+      { role: 'system', content: 'stable base system' },
+      { role: 'user', content: '[transient_plan_status]\nplan', __injected: true },
+      { role: 'user', content: '[transient_skills_list]\nskills', __injected: true },
+      { role: 'user', content: 'real user message' },
+    ]);
+
+    assert.deepEqual(durable, [
+      { role: 'system', content: 'stable base system' },
+      { role: 'user', content: 'real user message' },
+    ]);
+  });
+});
+
+function isTransientPromptMessage(message: Message): boolean {
+  return typeof message.content === 'string' && message.content.startsWith('[transient_');
+}


### PR DESCRIPTION
## Summary

- Reworked this PR into a clean branch directly based on latest `main`; it no longer stacks on #119.
- Adds `[TRANSIENT_OBSERVE]` structured logging for transient prompt injection, including per-session/provider/model system hash stability tracking.
- Adds optional `[SAFE_PROMPT_HASH]` diagnostics via `XIAOBA_SAFE_PROMPT_HASH=1`, with safe hashed summaries for messages/tools and a request id for correlation.
- Keeps M3 runner hints enabled by default; this PR does not suppress `nextTurnTransientHints`, so max_tokens recovery and duplicate-outbound correction hints are preserved.
- Moves dynamic plan/subagent/skills transient context to injected user messages and strips old system/injected transient messages from durable history.

## Scope notes

#119 is superseded by this approach. The only useful compatibility piece retained here is cleanup support for both old system runner hints and injected user runner hints.

## Test plan

- [x] `npx tsx --test tests/transient-observation.test.ts tests/turn-context-builder-transients.test.ts tests/subagent-runtime-events.test.ts`
- [x] `npm run build`
- [ ] Deploy with `XIAOBA_TRANSIENT_OBSERVE=1` and compare relay-side prompt cache logs.