### PR TITLE
本地工具风险确认与设备授权执行边界

### DIFF
--- a/src/agents/agent-tool-executor.ts
+++ b/src/agents/agent-tool-executor.ts
@@ -1,5 +1,6 @@
 import { Tool, ToolDefinition, ToolCall, ToolResult, ToolExecutionContext, ToolExecutor, ToolExecutionResult } from '../types/tool';
 import { mergeToolExecutionContext } from '../utils/tool-context';
+import { confirmLocalToolExecution } from '../tools/local-tool-risk';
 
 const TOOL_NAME_ALIASES: Record<string, string> = {
   Bash: 'execute_shell',
@@ -75,6 +76,19 @@ export class AgentToolExecutor implements ToolExecutor {
           ok: false,
           errorCode: 'INVALID_TOOL_ARGUMENTS',
           retryable: false,
+        };
+      }
+
+      const confirmation = await confirmLocalToolExecution(name, args, context);
+      if (confirmation) {
+        return {
+          tool_call_id: toolCall.id,
+          role: 'tool',
+          name: requestedName,
+          content: confirmation.ok ? confirmation.content : confirmation.message,
+          ok: confirmation.ok,
+          errorCode: confirmation.ok ? undefined : confirmation.errorCode,
+          retryable: confirmation.ok ? undefined : confirmation.retryable,
         };
       }
 

--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -1,9 +1,11 @@
 import * as readline from 'readline';
+import inquirer from 'inquirer';
 import ora from 'ora';
 import { Logger } from '../utils/logger';
 import { CommandOptions } from '../types';
 import { styles } from '../theme/colors';
 import { AgentSession, SessionCallbacks } from '../core/agent-session';
+import type { ToolExecutionConfirmationRequest, ToolExecutionConfirmationResult } from '../types/tool';
 import { startRuntimeCommandSupport, stopRuntimeCommandSupport } from '../utils/runtime-command-support';
 import { RuntimeFactory } from '../runtime/runtime-factory';
 import { resolveRuntimeProfileFromConfig } from '../runtime/runtime-profile-config';
@@ -82,10 +84,47 @@ function createStreamingCallbacks(spinner: ora.Ora): { callbacks: SessionCallbac
       spinner.stop();
       console.log(content);
       spinner.start();
-    }
+    },
+    confirmToolExecution: async (request) => confirmCliToolExecution(request, spinner),
   };
 
   return { callbacks, didStream: () => streamed };
+}
+
+async function confirmCliToolExecution(
+  request: ToolExecutionConfirmationRequest,
+  spinner: ora.Ora,
+): Promise<ToolExecutionConfirmationResult> {
+  spinner.stop();
+  const riskLabel = request.risk === 'high' ? '高风险' : request.risk === 'medium' ? '需要确认' : '低风险';
+  console.log('');
+  Logger.warning(`${riskLabel}工具操作: ${request.toolName}`);
+  Logger.info(request.reason);
+  if (request.workingDirectory) {
+    Logger.info(`当前目录: ${request.workingDirectory}`);
+  }
+  const argsPreview = JSON.stringify(request.args ?? {}, null, 2);
+  if (argsPreview && argsPreview !== '{}') {
+    Logger.info(`参数: ${argsPreview.length > 800 ? `${argsPreview.slice(0, 800)}...` : argsPreview}`);
+  }
+
+  if (!process.stdin.isTTY) {
+    spinner.start();
+    return { approved: false, reason: '当前环境无法显示确认提示，已取消该工具调用。' };
+  }
+
+  const { approved } = await inquirer.prompt([
+    {
+      type: 'confirm',
+      name: 'approved',
+      message: `允许执行 ${request.toolName} 吗？`,
+      default: request.risk !== 'high',
+    },
+  ]);
+  spinner.start();
+  return approved
+    ? { approved: true }
+    : { approved: false, reason: `用户取消了 ${request.toolName}。` };
 }
 
 async function sendSingleMessage(

--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -12,7 +12,12 @@ import * as path from 'path';
 import { AIService } from '../utils/ai-service';
 import { ToolManager } from '../tools/tool-manager';
 import { SkillManager } from '../skills/skill-manager';
-import { ChannelCallbacks, DeviceRpcTransport } from '../types/tool';
+import {
+  ChannelCallbacks,
+  DeviceRpcTransport,
+  ToolExecutionConfirmationRequest,
+  ToolExecutionConfirmationResult,
+} from '../types/tool';
 import {
   SessionSkillRuntime,
   SkillReloadHandler,
@@ -66,6 +71,7 @@ export interface SessionCallbacks {
   onToolEnd?: (name: string, toolUseId: string, result: string) => void;
   onToolDisplay?: (name: string, content: string) => void;
   onRetry?: (attempt: number, maxRetries: number) => void;
+  confirmToolExecution?: (request: ToolExecutionConfirmationRequest) => Promise<ToolExecutionConfirmationResult>;
 }
 
 export interface InitSessionOptions {

--- a/src/core/agent-turn-controller.ts
+++ b/src/core/agent-turn-controller.ts
@@ -7,7 +7,12 @@ import type {
   ScopedLocalFileGrant,
   SessionRoute,
 } from '../types/session-identity';
-import { ChannelCallbacks, DeviceRpcTransport } from '../types/tool';
+import {
+  ChannelCallbacks,
+  DeviceRpcTransport,
+  ToolExecutionConfirmationRequest,
+  ToolExecutionConfirmationResult,
+} from '../types/tool';
 import { AIService } from '../utils/ai-service';
 import { ToolManager } from '../tools/tool-manager';
 import { SkillManager } from '../skills/skill-manager';
@@ -34,6 +39,7 @@ export interface AgentTurnCallbacks {
   onToolEnd?: (name: string, toolUseId: string, result: string) => void;
   onToolDisplay?: (name: string, content: string) => void;
   onRetry?: (attempt: number, maxRetries: number) => void;
+  confirmToolExecution?: (request: ToolExecutionConfirmationRequest) => Promise<ToolExecutionConfirmationResult>;
 }
 
 export interface RunAgentTurnParams {
@@ -120,6 +126,7 @@ export class AgentTurnController {
       deviceRpc: params.deviceRpc,
       localFileGrants: params.localFileGrants,
       pendingUserInputProvider: params.pendingUserInputProvider,
+      confirmToolExecution: params.callbacks?.confirmToolExecution,
       abortSignal: params.abortSignal,
       shouldContinue: params.shouldContinue,
     });
@@ -172,6 +179,7 @@ export class AgentTurnController {
     deviceRpc?: DeviceRpcTransport;
     localFileGrants?: ScopedLocalFileGrant[];
     pendingUserInputProvider?: PendingUserInputProvider;
+    confirmToolExecution?: AgentTurnCallbacks['confirmToolExecution'];
     abortSignal?: AbortSignal;
     shouldContinue: () => boolean;
   }): ConversationRunner {
@@ -206,6 +214,7 @@ export class AgentTurnController {
           deviceSelection: options.deviceSelection,
           deviceRpc: options.deviceRpc,
           localFileGrants: options.localFileGrants,
+          confirmToolExecution: options.confirmToolExecution,
         },
       },
     );

--- a/src/core/sub-agent-session.ts
+++ b/src/core/sub-agent-session.ts
@@ -8,6 +8,7 @@ import { ConversationRunner, RunnerCallbacks } from './conversation-runner';
 import { PromptManager } from '../utils/prompt-manager';
 import { Logger } from '../utils/logger';
 import { SubAgentEventType, SubAgentRuntimeEvent } from './sub-agent-events';
+import type { ToolExecutionConfirmationRequest, ToolExecutionConfirmationResult } from '../types/tool';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -282,6 +283,7 @@ export class SubAgentSession {
         permissionProfile: 'strict',
         abortSignal: this.abortController.signal,
         requestParentInput: (question: string) => this.waitForParentInput(question),
+        confirmToolExecution: (request) => this.confirmSubAgentToolExecution(request),
       },
     });
 
@@ -423,6 +425,35 @@ export class SubAgentSession {
       this.clearParentInputReminder();
       throw error;
     }
+  }
+
+  private async confirmSubAgentToolExecution(
+    request: ToolExecutionConfirmationRequest,
+  ): Promise<ToolExecutionConfirmationResult> {
+    if (!this.options.notifyParent) {
+      return { approved: false, reason: '当前子智能体没有主会话确认通道，已取消该工具调用。' };
+    }
+    const argsPreview = JSON.stringify(request.args ?? {});
+    const question = [
+      `子智能体「${this.displayName || this.id}」想执行 ${request.toolName}。`,
+      `风险等级: ${request.risk}`,
+      request.reason,
+      argsPreview && argsPreview !== '{}' ? `参数: ${argsPreview.slice(0, 500)}${argsPreview.length > 500 ? '...' : ''}` : '',
+      '请回复“确认/允许/yes”批准，或回复其他内容取消。',
+    ].filter(Boolean).join('\n');
+    const answer = await this.waitForParentInput(question);
+    const normalized = String(answer || '').trim().toLowerCase();
+    const approved = normalized === 'y'
+      || normalized === 'yes'
+      || normalized === 'ok'
+      || normalized === 'approve'
+      || normalized.includes('确认')
+      || normalized.includes('允许')
+      || normalized.includes('同意')
+      || normalized.includes('批准');
+    return approved
+      ? { approved: true }
+      : { approved: false, reason: `主会话未确认 ${request.toolName}，已取消。` };
   }
 
   async close(): Promise<void> {

--- a/src/tools/local-tool-risk.ts
+++ b/src/tools/local-tool-risk.ts
@@ -1,5 +1,6 @@
 import type { ToolExecutionContext, ToolExecutionResult, ToolRiskLevel } from '../types/tool';
 import { isCatsCoToolGatewayContext } from './tool-gateway';
+import * as fs from 'fs';
 import * as path from 'path';
 
 export interface LocalToolRiskDecision {
@@ -88,8 +89,7 @@ export function classifyLocalToolRisk(
   }
 
   if (toolName === 'read_file' || toolName === 'glob' || toolName === 'grep') {
-    const target = readonlyToolTarget(toolName, args);
-    const pathRisk = classifyReadPathRisk(target, context);
+    const pathRisk = classifyReadTargetsRisk(readonlyToolTargets(toolName, args), context);
     if (pathRisk === 'low') {
       return { requiresConfirmation: false, risk: 'low', reason: '读取当前工作区内的普通路径。' };
     }
@@ -109,7 +109,11 @@ export function classifyLocalToolRisk(
 
   if (toolName === 'write_file' || toolName === 'edit_file') {
     const target = stringField(args, 'file_path') || stringField(args, 'path') || stringField(args, 'target');
-    if (looksSensitivePath(target)) {
+    const pathRisk = classifyWritePathRisk(toolName, target, context);
+    if (pathRisk === 'low') {
+      return { requiresConfirmation: false, risk: 'low', reason: '在当前工作区内新建普通文件。' };
+    }
+    if (pathRisk === 'high') {
       return { requiresConfirmation: true, risk: 'high', reason: '目标看起来是环境变量、密钥、系统配置或工作区外路径。' };
     }
     return { requiresConfirmation: true, risk: 'medium', reason: '工具会修改本机文件，需要用户确认。' };
@@ -142,27 +146,61 @@ function looksSensitivePath(value: string): boolean {
     || text.includes('/etc/');
 }
 
-function readonlyToolTarget(toolName: string, args: unknown): string {
+function readonlyToolTargets(toolName: string, args: unknown): string[] {
   if (toolName === 'read_file') {
-    return stringField(args, 'file_path') || stringField(args, 'path');
+    return [stringField(args, 'file_path') || stringField(args, 'path')].filter(Boolean);
   }
-  if (toolName === 'glob' || toolName === 'grep') {
-    return stringField(args, 'path') || '.';
+  if (toolName === 'glob') {
+    return [
+      stringField(args, 'path') || '.',
+      stringField(args, 'pattern'),
+    ].filter(Boolean);
   }
-  return '';
+  if (toolName === 'grep') {
+    return [
+      stringField(args, 'path') || '.',
+      stringField(args, 'glob'),
+    ].filter(Boolean);
+  }
+  return [];
+}
+
+function classifyReadTargetsRisk(values: string[], context: ToolExecutionContext): ToolRiskLevel {
+  const risks = (values.length > 0 ? values : ['.']).map(value => classifyReadPathRisk(value, context));
+  if (risks.includes('high')) return 'high';
+  if (risks.includes('medium')) return 'medium';
+  return 'low';
 }
 
 function classifyReadPathRisk(value: string, context: ToolExecutionContext): ToolRiskLevel {
   const target = value.trim();
-  if (!target || target === '.' || target === './' || target === '.\\') return 'low';
   if (/^catsco_attachment:[A-Za-z0-9._:-]+$/.test(target)) return 'low';
+  if (looksSensitivePath(target)) return 'high';
+
+  const workingDirectory = context.workingDirectory || process.cwd();
+  const workspaceRoot = context.workspaceRoot || workingDirectory;
+  const resolvedWorkingDirectory = path.resolve(workingDirectory);
+  const resolvedWorkspaceRoot = path.resolve(workspaceRoot);
+  if (!target || target === '.' || target === './' || target === '.\\') {
+    return isWithin(resolvedWorkingDirectory, resolvedWorkspaceRoot) ? 'low' : 'medium';
+  }
+  const resolved = path.resolve(resolvedWorkingDirectory, target);
+  if (looksSensitivePath(resolved)) return 'high';
+  if (isWithin(resolved, resolvedWorkspaceRoot)) return 'low';
+  return 'medium';
+}
+
+function classifyWritePathRisk(toolName: string, value: string, context: ToolExecutionContext): ToolRiskLevel {
+  const target = value.trim();
+  if (!target) return 'medium';
   if (looksSensitivePath(target)) return 'high';
 
   const workingDirectory = context.workingDirectory || process.cwd();
   const workspaceRoot = context.workspaceRoot || workingDirectory;
   const resolved = path.resolve(workingDirectory, target);
   if (looksSensitivePath(resolved)) return 'high';
-  if (isWithin(resolved, workingDirectory) || isWithin(resolved, workspaceRoot)) return 'low';
+  if (!isWithin(resolved, workspaceRoot)) return 'high';
+  if (toolName === 'write_file' && !fs.existsSync(resolved)) return 'low';
   return 'medium';
 }
 

--- a/src/tools/local-tool-risk.ts
+++ b/src/tools/local-tool-risk.ts
@@ -1,0 +1,187 @@
+import type { ToolExecutionContext, ToolExecutionResult, ToolRiskLevel } from '../types/tool';
+import { isCatsCoToolGatewayContext } from './tool-gateway';
+import * as path from 'path';
+
+export interface LocalToolRiskDecision {
+  requiresConfirmation: boolean;
+  risk: ToolRiskLevel;
+  reason: string;
+}
+
+const LOW_RISK_TOOLS = new Set([
+  'resolve_common_directory',
+  'common_directory',
+  'update_plan',
+  'record_decision',
+  'check_subagent',
+  'stop_subagent',
+  'resume_subagent',
+  'ask_parent',
+  'send_text',
+  'skill',
+]);
+
+const CONFIRM_TOOLS = new Set([
+  'write_file',
+  'edit_file',
+  'execute_shell',
+  'send_file',
+  'spawn_subagent',
+  'share_skillhub_skill',
+]);
+
+export async function confirmLocalToolExecution(
+  toolName: string,
+  args: unknown,
+  context: ToolExecutionContext,
+): Promise<ToolExecutionResult | undefined> {
+  const decision = classifyLocalToolRisk(toolName, args, context);
+  if (!decision.requiresConfirmation) return undefined;
+
+  const confirm = context.confirmToolExecution;
+  if (!confirm && context.permissionProfile !== 'strict') {
+    return undefined;
+  }
+  if (!confirm) {
+    return {
+      ok: false,
+      errorCode: 'NEEDS_CONFIRMATION',
+      retryable: true,
+      message: [
+        `工具 ${toolName} 需要用户确认后才能继续。`,
+        `风险等级: ${decision.risk}`,
+        decision.reason,
+      ].filter(Boolean).join('\n'),
+    };
+  }
+
+  const result = await confirm({
+    toolName,
+    args,
+    risk: decision.risk,
+    reason: decision.reason,
+    surface: context.surface,
+    workingDirectory: context.workingDirectory,
+  });
+  const approved = typeof result === 'boolean' ? result : result?.approved === true;
+  if (approved) return undefined;
+
+  const reason = typeof result === 'object' ? result.reason : '';
+  return {
+    ok: false,
+    errorCode: 'PERMISSION_DENIED',
+    retryable: false,
+    message: reason || `用户未确认 ${toolName}，工具调用已取消。`,
+  };
+}
+
+export function classifyLocalToolRisk(
+  toolName: string,
+  args: unknown,
+  context: ToolExecutionContext,
+): LocalToolRiskDecision {
+  if (isCatsCoToolGatewayContext(context)) {
+    return { requiresConfirmation: false, risk: 'low', reason: 'CatsCo 会话由服务端 device grant 控制。' };
+  }
+  if (LOW_RISK_TOOLS.has(toolName)) {
+    return { requiresConfirmation: false, risk: 'low', reason: '只读或状态类工具。' };
+  }
+
+  if (toolName === 'read_file' || toolName === 'glob' || toolName === 'grep') {
+    const target = readonlyToolTarget(toolName, args);
+    const pathRisk = classifyReadPathRisk(target, context);
+    if (pathRisk === 'low') {
+      return { requiresConfirmation: false, risk: 'low', reason: '读取当前工作区内的普通路径。' };
+    }
+    if (pathRisk === 'high') {
+      return { requiresConfirmation: true, risk: 'high', reason: '目标看起来是敏感文件、系统目录或密钥路径，需要用户确认。' };
+    }
+    return { requiresConfirmation: true, risk: 'medium', reason: '工具会读取或搜索当前工作区外的本机路径，需要用户确认。' };
+  }
+
+  if (toolName === 'execute_shell') {
+    const command = stringField(args, 'command') || stringField(args, 'cmd') || stringField(args, 'script');
+    if (looksDangerousShell(command)) {
+      return { requiresConfirmation: true, risk: 'high', reason: '命令可能删除、覆盖、关闭系统或下载并执行脚本。' };
+    }
+    return { requiresConfirmation: true, risk: 'medium', reason: '命令会在本机执行，需要用户确认。' };
+  }
+
+  if (toolName === 'write_file' || toolName === 'edit_file') {
+    const target = stringField(args, 'file_path') || stringField(args, 'path') || stringField(args, 'target');
+    if (looksSensitivePath(target)) {
+      return { requiresConfirmation: true, risk: 'high', reason: '目标看起来是环境变量、密钥、系统配置或工作区外路径。' };
+    }
+    return { requiresConfirmation: true, risk: 'medium', reason: '工具会修改本机文件，需要用户确认。' };
+  }
+
+  if (toolName === 'send_file') {
+    return { requiresConfirmation: true, risk: 'medium', reason: '工具会把本地文件发送到当前会话，需要用户确认。' };
+  }
+
+  if (CONFIRM_TOOLS.has(toolName)) {
+    return { requiresConfirmation: true, risk: 'medium', reason: '工具会启动额外执行流程或产生外部影响，需要用户确认。' };
+  }
+
+  return { requiresConfirmation: true, risk: 'medium', reason: '未知工具未声明风险等级，需要用户确认。' };
+}
+
+function stringField(value: unknown, key: string): string {
+  if (!value || typeof value !== 'object') return '';
+  const raw = (value as Record<string, unknown>)[key];
+  return typeof raw === 'string' ? raw.trim() : '';
+}
+
+function looksSensitivePath(value: string): boolean {
+  const text = value.replace(/\\/g, '/').toLowerCase();
+  if (!text) return false;
+  if (text.includes('/../') || text.startsWith('../') || text === '..') return true;
+  return /(^|\/)(\.env|\.npmrc|\.pypirc|id_rsa|id_ed25519|known_hosts|authorized_keys)(\.|$|\/)/.test(text)
+    || text.includes('/.ssh/')
+    || text.includes('/windows/system32/')
+    || text.includes('/etc/');
+}
+
+function readonlyToolTarget(toolName: string, args: unknown): string {
+  if (toolName === 'read_file') {
+    return stringField(args, 'file_path') || stringField(args, 'path');
+  }
+  if (toolName === 'glob' || toolName === 'grep') {
+    return stringField(args, 'path') || '.';
+  }
+  return '';
+}
+
+function classifyReadPathRisk(value: string, context: ToolExecutionContext): ToolRiskLevel {
+  const target = value.trim();
+  if (!target || target === '.' || target === './' || target === '.\\') return 'low';
+  if (/^catsco_attachment:[A-Za-z0-9._:-]+$/.test(target)) return 'low';
+  if (looksSensitivePath(target)) return 'high';
+
+  const workingDirectory = context.workingDirectory || process.cwd();
+  const workspaceRoot = context.workspaceRoot || workingDirectory;
+  const resolved = path.resolve(workingDirectory, target);
+  if (looksSensitivePath(resolved)) return 'high';
+  if (isWithin(resolved, workingDirectory) || isWithin(resolved, workspaceRoot)) return 'low';
+  return 'medium';
+}
+
+function isWithin(targetPath: string, parentPath: string): boolean {
+  const target = path.resolve(targetPath);
+  const parent = path.resolve(parentPath);
+  if (target === parent) return true;
+  const relative = path.relative(parent, target);
+  return Boolean(relative) && !relative.startsWith('..') && !path.isAbsolute(relative);
+}
+
+function looksDangerousShell(value: string): boolean {
+  const text = value.toLowerCase();
+  if (!text) return false;
+  return /\brm\s+-rf\b/.test(text)
+    || /\bremove-item\b[\s\S]*\b-recurse\b/.test(text)
+    || /\bdel\s+\/[sq]\b/.test(text)
+    || /\bformat\s+[a-z]:/.test(text)
+    || /\bshutdown\b/.test(text)
+    || /\breboot\b/.test(text)
+    || /(curl|wget|irm|iwr)[\s\S]*(\||;\s*)(sh|bash|powershell|pwsh|cmd)\b/.test(text);
+}

--- a/src/tools/tool-manager.ts
+++ b/src/tools/tool-manager.ts
@@ -20,6 +20,7 @@ import { ShareSkillHubSkillTool } from './share-skillhub-skill-tool';
 import { AskParentTool } from './ask-parent-tool';
 import { DEFAULT_TOOL_NAMES } from './default-tool-names';
 import { mergeToolExecutionContext } from '../utils/tool-context';
+import { confirmLocalToolExecution } from './local-tool-risk';
 
 const INTERNAL_TOOL_NAMES = ['ask_parent'] as const;
 
@@ -187,6 +188,19 @@ export class ToolManager implements ToolExecutor {
           ok: false,
           errorCode: 'INVALID_TOOL_ARGUMENTS',
           retryable: false,
+        };
+      }
+
+      const confirmation = await confirmLocalToolExecution(toolName, args, context);
+      if (confirmation) {
+        return {
+          tool_call_id: toolCall.id,
+          role: 'tool',
+          name: toolCall.function.name,
+          content: confirmation.ok ? confirmation.content : confirmation.message,
+          ok: confirmation.ok,
+          errorCode: confirmation.ok ? undefined : confirmation.errorCode,
+          retryable: confirmation.ok ? undefined : confirmation.retryable,
         };
       }
 

--- a/src/types/tool.ts
+++ b/src/types/tool.ts
@@ -107,6 +107,7 @@ export type ToolErrorCode =
   | 'INVALID_TOOL_ARGUMENTS'
   | 'TOOL_EXECUTION_ERROR'
   | 'RATE_LIMIT'
+  | 'NEEDS_CONFIRMATION'
   | 'PERMISSION_DENIED'
   | 'FILE_NOT_FOUND'
   | 'EXECUTION_TIMEOUT';
@@ -137,6 +138,22 @@ export interface RuntimeToolServices {
   skillManager: SkillManager;
 }
 
+export type ToolRiskLevel = 'low' | 'medium' | 'high';
+
+export interface ToolExecutionConfirmationRequest {
+  toolName: string;
+  risk: ToolRiskLevel;
+  reason: string;
+  args: unknown;
+  surface?: ToolSurface;
+  workingDirectory?: string;
+}
+
+export type ToolExecutionConfirmationResult = boolean | {
+  approved: boolean;
+  reason?: string;
+};
+
 /**
  * 工具执行上下文
  */
@@ -156,6 +173,8 @@ export interface ToolExecutionContext {
   updateCurrentDirectory?: (directory: string) => void;
   /** 子智能体需要主 agent 补充信息时使用；仅 subagent runtime 注入 */
   requestParentInput?: (question: string) => Promise<string>;
+  /** 本地自用的中高风险工具确认；CatsCo/远程委托仍由服务端 grant 控制。 */
+  confirmToolExecution?: (request: ToolExecutionConfirmationRequest) => Promise<ToolExecutionConfirmationResult>;
   /** 当前 runtime 已创建的共享服务，供调度类工具复用，避免重复初始化 */
   runtimeServices?: RuntimeToolServices;
   /** 平台通道回调（飞书/CatsCompany 等聊天会话时由平台层注入） */

--- a/tests/catscompany-content-blocks.test.ts
+++ b/tests/catscompany-content-blocks.test.ts
@@ -407,11 +407,13 @@ describe('CatsCo content blocks', () => {
   test('sanitizes CatsCo image block metadata to use opaque references', async () => {
     const bot = Object.create(CatsCompanyBot.prototype) as any;
     const originalModel = process.env.GAUZ_LLM_MODEL;
+    const originalApiBase = process.env.GAUZ_LLM_API_BASE;
     const testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'catsco-image-ref-'));
     const localPath = path.join(testRoot, 'tmp', 'downloads', 'secret-image.png');
 
     try {
       process.env.GAUZ_LLM_MODEL = 'gpt-4o';
+      process.env.GAUZ_LLM_API_BASE = 'https://api.openai.com/v1';
       fs.mkdirSync(path.dirname(localPath), { recursive: true });
       fs.writeFileSync(
         localPath,
@@ -438,6 +440,11 @@ describe('CatsCo content blocks', () => {
         delete process.env.GAUZ_LLM_MODEL;
       } else {
         process.env.GAUZ_LLM_MODEL = originalModel;
+      }
+      if (originalApiBase === undefined) {
+        delete process.env.GAUZ_LLM_API_BASE;
+      } else {
+        process.env.GAUZ_LLM_API_BASE = originalApiBase;
       }
       fs.rmSync(testRoot, { recursive: true, force: true });
     }

--- a/tests/tool-manager.test.ts
+++ b/tests/tool-manager.test.ts
@@ -1,5 +1,7 @@
 import { describe, test } from 'node:test';
 import * as assert from 'node:assert';
+import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { DEFAULT_TOOL_NAMES } from '../src/tools/default-tool-names';
 import { ToolManager } from '../src/tools/tool-manager';
@@ -156,8 +158,67 @@ describe('ToolManager', () => {
     assert.equal(result.errorCode, 'PERMISSION_DENIED');
   });
 
+  test('strict local glob absolute pattern outside workspace requires confirmation', async () => {
+    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-workspace-'));
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-outside-'));
+    const outsidePattern = path.join(outside, '**', '*.json');
+    const manager = new ToolManager(workspace, {}, { enabledToolNames: [] });
+    let executed = false;
+    manager.registerTool(fakeTool('glob', async () => {
+      executed = true;
+      return { ok: true, content: 'glob ok' };
+    }));
+
+    const result = await manager.executeTool({
+      id: 'call-glob-absolute',
+      type: 'function',
+      function: { name: 'glob', arguments: JSON.stringify({ pattern: outsidePattern }) },
+    }, [], {
+      permissionProfile: 'strict',
+      workingDirectory: workspace,
+      workspaceRoot: workspace,
+      confirmToolExecution: async request => {
+        assert.equal(request.toolName, 'glob');
+        assert.equal(request.risk, 'medium');
+        return { approved: false, reason: '搜索范围不在当前工作区' };
+      },
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.errorCode, 'PERMISSION_DENIED');
+    assert.equal(result.content, '搜索范围不在当前工作区');
+    assert.equal(executed, false);
+  });
+
+  test('strict local write can create new ordinary workspace files without confirmation', async () => {
+    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-workspace-'));
+    const manager = new ToolManager(workspace, {}, { enabledToolNames: [] });
+    let confirmed = false;
+    manager.registerTool(fakeTool('write_file', async () => ({ ok: true, content: 'write ok' })));
+
+    const result = await manager.executeTool({
+      id: 'call-write-new',
+      type: 'function',
+      function: { name: 'write_file', arguments: JSON.stringify({ file_path: 'new-note.txt', content: 'hello' }) },
+    }, [], {
+      permissionProfile: 'strict',
+      workingDirectory: workspace,
+      workspaceRoot: workspace,
+      confirmToolExecution: async () => {
+        confirmed = true;
+        return false;
+      },
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.content, 'write ok');
+    assert.equal(confirmed, false);
+  });
+
   test('strict local write waits for confirmation and respects denial', async () => {
-    const manager = new ToolManager('/tmp/xiaoba-tool-manager', {}, { enabledToolNames: [] });
+    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-workspace-'));
+    fs.writeFileSync(path.join(workspace, 'a.txt'), 'old');
+    const manager = new ToolManager(workspace, {}, { enabledToolNames: [] });
     let executed = false;
     manager.registerTool(fakeTool('write_file', async () => {
       executed = true;
@@ -170,6 +231,8 @@ describe('ToolManager', () => {
       function: { name: 'write_file', arguments: JSON.stringify({ file_path: 'a.txt', content: 'hello' }) },
     }, [], {
       permissionProfile: 'strict',
+      workingDirectory: workspace,
+      workspaceRoot: workspace,
       confirmToolExecution: async () => ({ approved: false, reason: '用户取消' }),
     });
 
@@ -184,6 +247,8 @@ describe('ToolManager', () => {
       function: { name: 'write_file', arguments: JSON.stringify({ file_path: 'a.txt', content: 'hello' }) },
     }, [], {
       permissionProfile: 'strict',
+      workingDirectory: workspace,
+      workspaceRoot: workspace,
       confirmToolExecution: async request => {
         assert.equal(request.toolName, 'write_file');
         assert.equal(request.risk, 'medium');
@@ -197,14 +262,20 @@ describe('ToolManager', () => {
   });
 
   test('strict local write returns retryable confirmation request without provider', async () => {
-    const manager = new ToolManager('/tmp/xiaoba-tool-manager', {}, { enabledToolNames: [] });
+    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-workspace-'));
+    fs.writeFileSync(path.join(workspace, 'a.txt'), 'old');
+    const manager = new ToolManager(workspace, {}, { enabledToolNames: [] });
     manager.registerTool(fakeTool('write_file', async () => ({ ok: true, content: 'write ok' })));
 
     const result = await manager.executeTool({
       id: 'call-write',
       type: 'function',
       function: { name: 'write_file', arguments: JSON.stringify({ file_path: 'a.txt', content: 'hello' }) },
-    }, [], { permissionProfile: 'strict' });
+    }, [], {
+      permissionProfile: 'strict',
+      workingDirectory: workspace,
+      workspaceRoot: workspace,
+    });
 
     assert.equal(result.ok, false);
     assert.equal(result.errorCode, 'NEEDS_CONFIRMATION');
@@ -255,13 +326,15 @@ describe('ToolManager', () => {
   });
 
   test('AgentToolExecutor uses the same local confirmation gate', async () => {
+    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-agent-workspace-'));
+    fs.writeFileSync(path.join(workspace, 'a.txt'), 'old');
     let executed = false;
     const executor = new AgentToolExecutor([
       fakeTool('write_file', async () => {
         executed = true;
         return { ok: true, content: 'agent write ok' };
       }),
-    ], '/tmp/xiaoba-agent-tool-manager');
+    ], workspace);
 
     const result = await executor.executeTool({
       id: 'agent-write',
@@ -269,6 +342,8 @@ describe('ToolManager', () => {
       function: { name: 'write_file', arguments: JSON.stringify({ file_path: 'a.txt', content: 'hello' }) },
     }, [], {
       permissionProfile: 'strict',
+      workingDirectory: workspace,
+      workspaceRoot: workspace,
       confirmToolExecution: async () => false,
     });
 

--- a/tests/tool-manager.test.ts
+++ b/tests/tool-manager.test.ts
@@ -1,7 +1,21 @@
 import { describe, test } from 'node:test';
 import * as assert from 'node:assert';
+import * as path from 'path';
 import { DEFAULT_TOOL_NAMES } from '../src/tools/default-tool-names';
 import { ToolManager } from '../src/tools/tool-manager';
+import { AgentToolExecutor } from '../src/agents/agent-tool-executor';
+import type { Tool } from '../src/types/tool';
+
+function fakeTool(name: string, execute: Tool['execute']): Tool {
+  return {
+    definition: {
+      name,
+      description: name,
+      parameters: { type: 'object', properties: {} },
+    },
+    execute,
+  };
+}
 
 describe('ToolManager', () => {
   test('registers all default tools when no enabled list is provided', () => {
@@ -68,5 +82,198 @@ describe('ToolManager', () => {
 
     assert.equal(result.ok, true);
     assert.match(result.content, /收到问题：继续吗/);
+  });
+
+  test('strict local low-risk tools do not require confirmation', async () => {
+    const manager = new ToolManager('/tmp/xiaoba-tool-manager', {}, { enabledToolNames: [] });
+    let confirmed = false;
+    manager.registerTool(fakeTool('read_file', async () => ({ ok: true, content: 'read ok' })));
+
+    const result = await manager.executeTool({
+      id: 'call-read',
+      type: 'function',
+      function: { name: 'read_file', arguments: JSON.stringify({ file_path: 'a.txt' }) },
+    }, [], {
+      permissionProfile: 'strict',
+      confirmToolExecution: async () => {
+        confirmed = true;
+        return false;
+      },
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.content, 'read ok');
+    assert.equal(confirmed, false);
+  });
+
+  test('strict local read outside the workspace requires confirmation', async () => {
+    const workspace = path.resolve('/tmp/xiaoba-tool-manager');
+    const manager = new ToolManager(workspace, {}, { enabledToolNames: [] });
+    let executed = false;
+    manager.registerTool(fakeTool('read_file', async () => {
+      executed = true;
+      return { ok: true, content: 'read ok' };
+    }));
+
+    const denied = await manager.executeTool({
+      id: 'call-read-outside',
+      type: 'function',
+      function: { name: 'read_file', arguments: JSON.stringify({ file_path: path.resolve('/tmp/outside-secret.txt') }) },
+    }, [], {
+      permissionProfile: 'strict',
+      workingDirectory: workspace,
+      workspaceRoot: workspace,
+      confirmToolExecution: async request => {
+        assert.equal(request.toolName, 'read_file');
+        assert.equal(request.risk, 'medium');
+        return { approved: false, reason: '需要用户选择文件' };
+      },
+    });
+
+    assert.equal(denied.ok, false);
+    assert.equal(denied.errorCode, 'PERMISSION_DENIED');
+    assert.equal(denied.content, '需要用户选择文件');
+    assert.equal(executed, false);
+  });
+
+  test('strict local sensitive reads require high-risk confirmation', async () => {
+    const manager = new ToolManager('/tmp/xiaoba-tool-manager', {}, { enabledToolNames: [] });
+    manager.registerTool(fakeTool('read_file', async () => ({ ok: true, content: 'read ok' })));
+
+    const result = await manager.executeTool({
+      id: 'call-read-env',
+      type: 'function',
+      function: { name: 'read_file', arguments: JSON.stringify({ file_path: '.env' }) },
+    }, [], {
+      permissionProfile: 'strict',
+      confirmToolExecution: async request => {
+        assert.equal(request.risk, 'high');
+        return false;
+      },
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.errorCode, 'PERMISSION_DENIED');
+  });
+
+  test('strict local write waits for confirmation and respects denial', async () => {
+    const manager = new ToolManager('/tmp/xiaoba-tool-manager', {}, { enabledToolNames: [] });
+    let executed = false;
+    manager.registerTool(fakeTool('write_file', async () => {
+      executed = true;
+      return { ok: true, content: 'write ok' };
+    }));
+
+    const denied = await manager.executeTool({
+      id: 'call-write',
+      type: 'function',
+      function: { name: 'write_file', arguments: JSON.stringify({ file_path: 'a.txt', content: 'hello' }) },
+    }, [], {
+      permissionProfile: 'strict',
+      confirmToolExecution: async () => ({ approved: false, reason: '用户取消' }),
+    });
+
+    assert.equal(denied.ok, false);
+    assert.equal(denied.errorCode, 'PERMISSION_DENIED');
+    assert.equal(denied.content, '用户取消');
+    assert.equal(executed, false);
+
+    const approved = await manager.executeTool({
+      id: 'call-write-2',
+      type: 'function',
+      function: { name: 'write_file', arguments: JSON.stringify({ file_path: 'a.txt', content: 'hello' }) },
+    }, [], {
+      permissionProfile: 'strict',
+      confirmToolExecution: async request => {
+        assert.equal(request.toolName, 'write_file');
+        assert.equal(request.risk, 'medium');
+        return true;
+      },
+    });
+
+    assert.equal(approved.ok, true);
+    assert.equal(approved.content, 'write ok');
+    assert.equal(executed, true);
+  });
+
+  test('strict local write returns retryable confirmation request without provider', async () => {
+    const manager = new ToolManager('/tmp/xiaoba-tool-manager', {}, { enabledToolNames: [] });
+    manager.registerTool(fakeTool('write_file', async () => ({ ok: true, content: 'write ok' })));
+
+    const result = await manager.executeTool({
+      id: 'call-write',
+      type: 'function',
+      function: { name: 'write_file', arguments: JSON.stringify({ file_path: 'a.txt', content: 'hello' }) },
+    }, [], { permissionProfile: 'strict' });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.errorCode, 'NEEDS_CONFIRMATION');
+    assert.equal(result.retryable, true);
+    assert.match(String(result.content), /需要用户确认/);
+  });
+
+  test('strict local unknown tools require confirmation instead of defaulting to low risk', async () => {
+    const manager = new ToolManager('/tmp/xiaoba-tool-manager', {}, { enabledToolNames: [] });
+    let executed = false;
+    manager.registerTool(fakeTool('custom_mutating_tool', async () => {
+      executed = true;
+      return { ok: true, content: 'custom ok' };
+    }));
+
+    const result = await manager.executeTool({
+      id: 'call-custom',
+      type: 'function',
+      function: { name: 'custom_mutating_tool', arguments: JSON.stringify({}) },
+    }, [], { permissionProfile: 'strict' });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.errorCode, 'NEEDS_CONFIRMATION');
+    assert.equal(executed, false);
+  });
+
+  test('CatsCo context is not intercepted by local confirmation layer', async () => {
+    const manager = new ToolManager('/tmp/xiaoba-tool-manager', {}, { enabledToolNames: [] });
+    let confirmed = false;
+    manager.registerTool(fakeTool('write_file', async () => ({ ok: true, content: 'catsco tool ran' })));
+
+    const result = await manager.executeTool({
+      id: 'call-catsco-write',
+      type: 'function',
+      function: { name: 'write_file', arguments: JSON.stringify({ file_path: 'a.txt', content: 'hello' }) },
+    }, [], {
+      surface: 'catscompany',
+      permissionProfile: 'strict',
+      confirmToolExecution: async () => {
+        confirmed = true;
+        return false;
+      },
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.content, 'catsco tool ran');
+    assert.equal(confirmed, false);
+  });
+
+  test('AgentToolExecutor uses the same local confirmation gate', async () => {
+    let executed = false;
+    const executor = new AgentToolExecutor([
+      fakeTool('write_file', async () => {
+        executed = true;
+        return { ok: true, content: 'agent write ok' };
+      }),
+    ], '/tmp/xiaoba-agent-tool-manager');
+
+    const result = await executor.executeTool({
+      id: 'agent-write',
+      type: 'function',
+      function: { name: 'write_file', arguments: JSON.stringify({ file_path: 'a.txt', content: 'hello' }) },
+    }, [], {
+      permissionProfile: 'strict',
+      confirmToolExecution: async () => false,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.errorCode, 'PERMISSION_DENIED');
+    assert.equal(executed, false);
   });
 });


### PR DESCRIPTION
## 背景

本地自用场景需要更顺滑：低风险操作不应频繁打断用户；但写文件、执行命令、发送文件等高风险操作不能直接失败，也不能无感执行。本 PR 补齐本地工具确认边界，并保持 CatsCo 远程设备操作继续由服务端 grant 控制。

## 本次改动

- 新增本地工具风险判断层。
- 工作区内新建普通文件默认无感执行。
- 覆盖文件、编辑文件、执行命令、发送文件、未知工具等中高风险操作需要确认。
- CLI 接入真实确认提示，用户确认后继续执行，拒绝后取消执行。
- 子 Agent 遇到高风险操作时，通过主会话确认，不再静默执行。
- `read_file/glob/grep` 不再无条件读取工作区外路径。
- 修复 `glob` 绝对 pattern 可绕过工作区判断的问题。
- CatsCo/Device RPC 上下文不走本地确认层，仍由服务端 device grant、ToolGateway 和设备能力声明控制。
- 补充本地低风险、敏感路径、绝对 glob、确认通过/拒绝、CatsCo bypass 等测试。

## 产品形态

用户本地和虚拟员工对话时，简单的新建文件等低风险任务可以顺畅完成；涉及覆盖、命令、发送文件等操作时，系统会先让用户确认，确认后继续执行。

通过微信/飞书触发的远程设备操作不依赖模型自行判断权限，而是继续走后端授权和设备网关，避免串用户、串设备。

## 验证

- `node scripts/run-tests.mjs runtime --filter tool-manager`
- `npm run build`
- `npm run test:cross-repo:catsco`