### PR TITLE
支持自定义模型上下文档位选择

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -7104,6 +7104,13 @@
       {id:'deepseek-v4-flash',label:'DeepSeek V4 Flash',model:'deepseek-v4-flash',provider:'anthropic',base_url:'https://relay.catsco.cc/anthropic',quota_class:'flash-low',context_window_tokens:1000000,context_label:'1M'},
       {id:'glm-5.1',label:'GLM 5.1',model:'glm-5.1',provider:'anthropic',base_url:'https://relay.catsco.cc/anthropic',quota_class:'standard',context_window_tokens:200000,context_label:'200K'},
     ];
+    const CUSTOM_MODEL_CONTEXT_WINDOW_OPTIONS=[
+      {value:'128000',label:'128K',hint:'安全默认'},
+      {value:'200000',label:'200K',hint:'常见中长上下文'},
+      {value:'256000',label:'256K',hint:'长文档'},
+      {value:'512000',label:'512K',hint:'超长文档'},
+      {value:'1000000',label:'1M',hint:'百万上下文'},
+    ];
     const serviceConfigGroups={
       catscompany:{
         title:'CatsCo 连接配置',
@@ -7254,6 +7261,24 @@
       return String(n);
     }
 
+    function customModelContextWindowValue(){
+      const custom=customStartupProfile();
+      const raw=String(custom.contextWindowTokens || settingValue('model.contextWindowTokens') || '128000');
+      return CUSTOM_MODEL_CONTEXT_WINDOW_OPTIONS.some(option=>option.value===raw)?raw:'128000';
+    }
+
+    function customModelContextWindowLabel(){
+      return formatModelContextLabel(Number(customModelContextWindowValue()));
+    }
+
+    function customModelContextWindowOptionsHtml(selectedValue){
+      return CUSTOM_MODEL_CONTEXT_WINDOW_OPTIONS.map(option=>(
+        '<option value="'+escapeHtml(option.value)+'" '+(option.value===selectedValue?'selected':'')+'>'
+        +escapeHtml(option.label+' · '+option.hint)
+        +'</option>'
+      )).join('');
+    }
+
     function modelStartupSnapshot(){
       return dashboardSettingsSnapshot?.modelStartup || {};
     }
@@ -7312,8 +7337,9 @@
       const configured=isCustomStartupConfigured();
       const provider=custom.provider || settingValue('model.provider') || 'anthropic';
       const model=custom.model || settingValue('model.model') || '未配置';
+      const contextLabel=customModelContextWindowLabel();
       const meta=configured
-        ? '自定义配置 · 安全上下文 128K · '+(provider==='openai'?'OpenAI SDK':'Anthropic SDK')
+        ? '自定义配置 · 上下文 '+contextLabel+' · '+(provider==='openai'?'OpenAI SDK':'Anthropic SDK')
         : '去设置填写 endpoint / key';
       return '<button class="relay-model-choice '+(active?' active':'')+(configured?'':' needs-config')+'" type="button" data-custom-startup-action="true" data-custom-startup-context="'+escapeHtml(context)+'" '+(relayActionBusy()?'disabled':'')+' onclick="enableCustomStartupModelFromButton(this)">'
         +'<span class="relay-model-label">自定义模型</span>'
@@ -7367,6 +7393,7 @@
         provider: document.getElementById('model-provider-setting')?.value,
         apiBase: document.getElementById('model-api-base-setting')?.value,
         model: document.getElementById('model-name-setting')?.value,
+        contextWindowTokens: document.getElementById('model-context-window-setting')?.value,
         secret: document.getElementById('model-secret-setting')?.value,
         clearSecret: document.getElementById('model-secret-clear-setting')?.checked,
       };
@@ -7385,6 +7412,7 @@
           ['model-provider-setting',draft.provider],
           ['model-api-base-setting',draft.apiBase],
           ['model-name-setting',draft.model],
+          ['model-context-window-setting',draft.contextWindowTokens],
           ['model-secret-setting',draft.secret],
         ];
         pairs.forEach(([id,value])=>{
@@ -7422,16 +7450,17 @@
       const hideInternalGateway=isInternalModelGateway(apiBaseValue);
       const apiBaseDisplayValue=hideInternalGateway?'':apiBaseValue;
       const apiBasePlaceholder=hideInternalGateway?'已配置 CatsCo 内部兼容网关（隐藏）':'https://example.com/v1/messages';
+      const selectedContextWindow=customModelContextWindowValue();
       const draft=captureCustomModelDraft();
 
       p.innerHTML=`<div class="model-source-layout">
-        <div class="runtime-note">中转模型和自定义模型会分别保存。CatsCo 中转会按所选模型自动调整上下文；自定义模型默认按 128K 安全上下文运行，若模型实际窗口更小，请减少历史或在高级环境变量里降低 GAUZ_LLM_CONTEXT_WINDOW_TOKENS。</div>
+        <div class="runtime-note">中转模型和自定义模型会分别保存。CatsCo 中转会按所选模型自动调整上下文；自定义模型按下方选择的上下文窗口运行。若模型真实窗口更小，请选择更小档位避免超限。</div>
         <details class="model-source-card warning" id="custom-model-settings"${customModelSettingsOpen?' open':''}>
           <summary>
             <div class="model-source-head">
               <div>
                 <div class="model-source-title">自定义模型（第三方）</div>
-                <div class="model-source-copy">只有手动接入第三方模型时需要填写。CatsCo 中转模型请在 CatsCo 页面选择；自定义模型默认使用 128K 安全上下文。</div>
+                <div class="model-source-copy">只有手动接入第三方模型时需要填写。CatsCo 中转模型请在 CatsCo 页面选择；自定义模型可在 128K 到 1M 间选择上下文。</div>
               </div>
               ${runtimeTag(credentialMeta, keyField.present?'green':'gray')}
             </div>
@@ -7440,6 +7469,7 @@
             <div class="config-row"><label class="config-label">兼容类型</label><select class="config-select" id="model-provider-setting"><option value="anthropic"${settingValue('model.provider')==='anthropic'?' selected':''}>Anthropic-compatible</option><option value="openai"${settingValue('model.provider')==='openai'?' selected':''}>OpenAI-compatible</option></select></div>
             <div class="config-row"><label class="config-label">模型地址</label><input class="config-input" id="model-api-base-setting" value="${escapeHtml(apiBaseDisplayValue)}" placeholder="${escapeHtml(apiBasePlaceholder)}" data-hidden-internal="${hideInternalGateway?'true':'false'}" /></div>
             <div class="config-row"><label class="config-label">模型名称</label><input class="config-input" id="model-name-setting" value="${escapeHtml(settingValue('model.model'))}" placeholder="model-name" /></div>
+            <div class="config-row"><label class="config-label">上下文窗口</label><select class="config-select" id="model-context-window-setting">${customModelContextWindowOptionsHtml(selectedContextWindow)}</select></div>
             <div class="config-row"><label class="config-label">访问凭证</label><input class="config-input" id="model-secret-setting" type="password" value="" placeholder="${keyField.present?'留空表示保持现有凭证':'输入访问凭证'}" /></div>
             <div class="model-secret-row">
               <label><input type="checkbox" id="model-secret-clear-setting" /> 清除已保存的访问凭证</label>
@@ -7449,7 +7479,7 @@
               <button class="btn btn-primary" onclick="saveCustomModelSettings()">保存自定义模型</button>
               <span class="config-saved" id="model-source-saved">已保存</span>
             </div>
-            <div id="model-source-status" style="color:var(--text2);font-size:13px">凭证仅保存到本地 .env；自定义模型默认 128K 安全上下文，新 session 或下一次启动 connector 后生效。</div>
+            <div id="model-source-status" style="color:var(--text2);font-size:13px">凭证仅保存到本地 .env；自定义模型上下文会写入本地配置，新 session 或下一次启动 connector 后生效。</div>
           </div>
         </details>
       </div>`;
@@ -7541,6 +7571,7 @@
             'model.provider':document.getElementById('model-provider-setting').value,
             'model.apiBase':apiBaseValue,
             'model.model':document.getElementById('model-name-setting').value.trim(),
+            'model.contextWindowTokens':document.getElementById('model-context-window-setting').value,
             'model.apiKey':secretUpdate,
           }
         }
@@ -7554,6 +7585,7 @@
         provider:settings['model.provider'],
         apiBase:settings['model.apiBase'],
         model:settings['model.model'],
+        contextWindowTokens:settings['model.contextWindowTokens'],
         secretAction:secret.action,
       });
     }
@@ -7741,6 +7773,7 @@
       const provider=document.getElementById('model-provider-setting');
       const apiBase=document.getElementById('model-api-base-setting');
       const model=document.getElementById('model-name-setting');
+      const contextWindow=document.getElementById('model-context-window-setting');
       const secret=document.getElementById('model-secret-setting');
       const clear=document.getElementById('model-secret-clear-setting');
       const schedule=()=>{
@@ -7751,6 +7784,7 @@
       if(provider)provider.addEventListener('change',schedule);
       if(apiBase)apiBase.addEventListener('input',schedule);
       if(model)model.addEventListener('input',schedule);
+      if(contextWindow)contextWindow.addEventListener('change',schedule);
       if(secret)secret.addEventListener('change',schedule);
       if(clear)clear.addEventListener('change',schedule);
     }

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -1110,6 +1110,12 @@ function requestedSecretAction(input: any): 'keep' | 'replace' | 'clear' {
   return 'keep';
 }
 
+function requestedCustomContextWindowTokens(input: any): number | undefined {
+  if (!input?.settings || typeof input.settings !== 'object') return undefined;
+  if (!Object.prototype.hasOwnProperty.call(input.settings, 'model.contextWindowTokens')) return undefined;
+  return parsePositiveInteger(input.settings['model.contextWindowTokens']);
+}
+
 function sanitizePublicUrl(value: unknown): string | undefined {
   const text = String(value || '').trim();
   if (!text) return undefined;
@@ -1137,7 +1143,9 @@ function mirrorCurrentModelAsCustomStartup(input: any, previous: ModelLaunchProf
   const custom: ModelLaunchProfile = {
     ...current,
     apiKey,
-    contextWindowTokens: storedCustom.contextWindowTokens ?? CUSTOM_MODEL_DEFAULT_CONTEXT_WINDOW_TOKENS,
+    contextWindowTokens: requestedCustomContextWindowTokens(input)
+      ?? storedCustom.contextWindowTokens
+      ?? CUSTOM_MODEL_DEFAULT_CONTEXT_WINDOW_TOKENS,
   };
 
   if (!isCompleteModelProfile(custom) && (previousSource === 'relay' || isCatsRelayApiBase(previous.apiBase))) {
@@ -1819,6 +1827,8 @@ export function createApiRouter(serviceManager: ServiceManager, updateController
         provider: result.profile.provider,
         apiBase: sanitizePublicUrl(result.profile.apiBase),
         model: result.profile.model,
+        contextWindowTokens: result.profile.contextWindowTokens,
+        contextLabel: result.profile.contextWindowTokens ? formatContextWindowTokens(result.profile.contextWindowTokens) : undefined,
         updated: result.updated,
         cleared: result.cleared,
         restartRequired: activation.wasRunning && !activation.restartRequested,

--- a/src/dashboard/settings.ts
+++ b/src/dashboard/settings.ts
@@ -42,6 +42,7 @@ export interface DashboardModelProfileSnapshot {
   provider?: string;
   apiBase?: string;
   model?: string;
+  contextWindowTokens?: number;
   apiKeyPresent: boolean;
   configured: boolean;
 }
@@ -72,6 +73,14 @@ interface NormalizedSettingUpdate {
   secretAction?: SecretSettingAction;
 }
 
+export const CUSTOM_MODEL_CONTEXT_WINDOW_OPTIONS = [
+  '128000',
+  '200000',
+  '256000',
+  '512000',
+  '1000000',
+];
+
 export const DASHBOARD_SETTING_DEFINITIONS: DashboardSettingDefinition[] = [
   {
     id: 'model.provider',
@@ -101,6 +110,16 @@ export const DASHBOARD_SETTING_DEFINITIONS: DashboardSettingDefinition[] = [
     envKey: 'GAUZ_LLM_MODEL',
     type: 'string',
     required: true,
+  },
+  {
+    id: 'model.contextWindowTokens',
+    group: 'model',
+    label: '上下文窗口',
+    description: '自定义模型可用上下文窗口。若模型真实窗口更小，请选择更小档位避免超限。',
+    envKey: 'GAUZ_LLM_CONTEXT_WINDOW_TOKENS',
+    type: 'enum',
+    required: true,
+    options: CUSTOM_MODEL_CONTEXT_WINDOW_OPTIONS,
   },
   {
     id: 'model.apiKey',
@@ -142,6 +161,7 @@ const CUSTOM_MODEL_ENV_KEYS: Record<string, string> = {
   'model.provider': 'CATSCO_CUSTOM_LLM_PROVIDER',
   'model.apiBase': 'CATSCO_CUSTOM_LLM_API_BASE',
   'model.model': 'CATSCO_CUSTOM_LLM_MODEL',
+  'model.contextWindowTokens': 'CATSCO_CUSTOM_LLM_CONTEXT_WINDOW_TOKENS',
   'model.apiKey': 'CATSCO_CUSTOM_LLM_API_KEY',
 };
 
@@ -150,6 +170,7 @@ const EFFECTIVE_MODEL_ENV_KEYS = {
   apiBase: 'GAUZ_LLM_API_BASE',
   model: 'GAUZ_LLM_MODEL',
   apiKey: 'GAUZ_LLM_API_KEY',
+  contextWindowTokens: 'GAUZ_LLM_CONTEXT_WINDOW_TOKENS',
 } as const;
 
 const RELAY_MODEL_ENV_KEYS = {
@@ -157,6 +178,7 @@ const RELAY_MODEL_ENV_KEYS = {
   apiBase: 'CATSCO_RELAY_LLM_API_BASE',
   model: 'CATSCO_RELAY_LLM_MODEL',
   apiKey: 'CATSCO_RELAY_LLM_API_KEY',
+  contextWindowTokens: 'CATSCO_RELAY_LLM_CONTEXT_WINDOW_TOKENS',
 } as const;
 
 function isModelSetting(id: string): boolean {
@@ -198,10 +220,12 @@ function readModelProfile(
   const apiBase = firstNonEmpty(fileEnv[keys.apiBase], env[keys.apiBase]);
   const model = firstNonEmpty(fileEnv[keys.model], env[keys.model]);
   const apiKey = firstNonEmpty(fileEnv[keys.apiKey], env[keys.apiKey]);
+  const contextWindowTokens = parsePositiveInteger(firstNonEmpty(fileEnv[keys.contextWindowTokens], env[keys.contextWindowTokens]));
   return {
     provider,
     apiBase: sanitizeUrlSettingValue(apiBase ?? ''),
     model,
+    contextWindowTokens,
     apiKeyPresent: Boolean(apiKey),
     configured: Boolean(provider && apiBase && model && apiKey),
   };
@@ -215,10 +239,15 @@ function readCustomModelProfile(
   const apiBase = firstNonEmpty(fileEnv.CATSCO_CUSTOM_LLM_API_BASE, env.CATSCO_CUSTOM_LLM_API_BASE);
   const model = firstNonEmpty(fileEnv.CATSCO_CUSTOM_LLM_MODEL, env.CATSCO_CUSTOM_LLM_MODEL);
   const apiKey = firstNonEmpty(fileEnv.CATSCO_CUSTOM_LLM_API_KEY, env.CATSCO_CUSTOM_LLM_API_KEY);
+  const contextWindowTokens = parsePositiveInteger(firstNonEmpty(
+    fileEnv.CATSCO_CUSTOM_LLM_CONTEXT_WINDOW_TOKENS,
+    env.CATSCO_CUSTOM_LLM_CONTEXT_WINDOW_TOKENS,
+  ));
   return {
     provider,
     apiBase: sanitizeUrlSettingValue(apiBase ?? ''),
     model,
+    contextWindowTokens,
     apiKeyPresent: Boolean(apiKey),
     configured: Boolean(provider && apiBase && model && apiKey),
   };
@@ -522,6 +551,14 @@ function firstNonEmpty(...values: Array<string | undefined>): string | undefined
     if (text) return text;
   }
   return undefined;
+}
+
+function parsePositiveInteger(value: unknown): number | undefined {
+  const text = String(value ?? '').trim();
+  if (!text) return undefined;
+  const parsed = Number(text);
+  if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+  return Math.floor(parsed);
 }
 
 function serializeEnvValue(value: string): string {

--- a/tests/dashboard-productization-html.test.ts
+++ b/tests/dashboard-productization-html.test.ts
@@ -32,7 +32,10 @@ test('Agent Hub keeps connector controls and third-party model config without du
   assert.match(dashboardHtml, /\/api\/cats\/relay\/model-config\/apply/);
   assert.match(dashboardHtml, /service-config/);
   assert.match(dashboardHtml, /CatsCo 中转模型在 CatsCo 页面选择/);
-  assert.match(dashboardHtml, /自定义模型默认使用 128K 安全上下文/);
+  assert.match(dashboardHtml, /CUSTOM_MODEL_CONTEXT_WINDOW_OPTIONS/);
+  assert.match(dashboardHtml, /id="model-context-window-setting"/);
+  assert.match(dashboardHtml, /'model\.contextWindowTokens':document\.getElementById\('model-context-window-setting'\)\.value/);
+  assert.match(dashboardHtml, /自定义模型可在 128K 到 1M 间选择上下文/);
   assert.match(dashboardHtml, /上下文 '\+escapeHtml\(contextLabel\)\+'/);
   assert.doesNotMatch(servicesPageHtml, /模型来源与 Runtime Profile/);
   assert.doesNotMatch(servicesPageHtml, /id="settings-setup-panel"/);

--- a/tests/dashboard-settings-api.test.ts
+++ b/tests/dashboard-settings-api.test.ts
@@ -172,6 +172,23 @@ describe('dashboard typed settings API', () => {
     assert.equal(text.includes('token=secret'), false);
   });
 
+  test('GET /settings exposes fixed custom model context window tiers', async () => {
+    fs.writeFileSync(path.join(testRoot, '.env'), [
+      'GAUZ_LLM_CONTEXT_WINDOW_TOKENS=256000',
+      'CATSCO_CUSTOM_LLM_CONTEXT_WINDOW_TOKENS=256000',
+      '',
+    ].join('\n'));
+
+    const response = await fetch(`${baseUrl}/api/settings`);
+    const data = await response.json() as any;
+    const contextWindow = data.fields.find((field: any) => field.id === 'model.contextWindowTokens');
+
+    assert.equal(response.status, 200);
+    assert.equal(contextWindow.value, '256000');
+    assert.deepStrictEqual(contextWindow.options, ['128000', '200000', '256000', '512000', '1000000']);
+    assert.equal(data.modelStartup.custom.contextWindowTokens, 256000);
+  });
+
   test('PUT /settings writes allowlisted model settings and refreshes process env', async () => {
     const response = await fetch(`${baseUrl}/api/settings`, {
       method: 'PUT',
@@ -181,6 +198,7 @@ describe('dashboard typed settings API', () => {
           'model.provider': 'anthropic',
           'model.apiBase': 'https://model.example.test/v1/messages',
           'model.model': 'MiniMax-M2.7-highspeed',
+          'model.contextWindowTokens': '512000',
           'model.apiKey': { action: 'replace', value: 'sk-new-secret' },
         },
       }),
@@ -194,17 +212,21 @@ describe('dashboard typed settings API', () => {
     assert.deepStrictEqual(data.updated.sort(), [
       'GAUZ_LLM_API_BASE',
       'GAUZ_LLM_API_KEY',
+      'GAUZ_LLM_CONTEXT_WINDOW_TOKENS',
       'GAUZ_LLM_MODEL',
       'GAUZ_LLM_PROVIDER',
     ].sort());
     assert.equal(text.includes('sk-new-secret'), false);
     assert.equal(parsed.GAUZ_LLM_API_KEY, 'sk-new-secret');
+    assert.equal(parsed.GAUZ_LLM_CONTEXT_WINDOW_TOKENS, '512000');
     assert.equal(parsed.CATSCO_MODEL_SOURCE, 'custom');
     assert.equal(parsed.CATSCO_CUSTOM_LLM_PROVIDER, 'anthropic');
     assert.equal(parsed.CATSCO_CUSTOM_LLM_API_BASE, 'https://model.example.test/v1/messages');
     assert.equal(parsed.CATSCO_CUSTOM_LLM_MODEL, 'MiniMax-M2.7-highspeed');
     assert.equal(parsed.CATSCO_CUSTOM_LLM_API_KEY, 'sk-new-secret');
+    assert.equal(parsed.CATSCO_CUSTOM_LLM_CONTEXT_WINDOW_TOKENS, '512000');
     assert.equal(process.env.GAUZ_LLM_API_KEY, 'sk-new-secret');
+    assert.equal(process.env.GAUZ_LLM_CONTEXT_WINDOW_TOKENS, '512000');
 
     const statusResponse = await fetch(`${baseUrl}/api/status`);
     const status = await statusResponse.json() as any;
@@ -320,6 +342,7 @@ describe('dashboard typed settings API', () => {
           'model.provider': 'openai',
           'model.apiBase': 'https://api.deepseek.com/v1',
           'model.model': 'deepseek-chat-v2',
+          'model.contextWindowTokens': '512000',
           'model.apiKey': { action: 'keep' },
         },
       }),
@@ -333,6 +356,8 @@ describe('dashboard typed settings API', () => {
     assert.equal(parsed.CATSCO_CUSTOM_LLM_API_KEY, 'sk-custom-secret');
     assert.equal(parsed.CATSCO_RELAY_LLM_API_KEY, 'sk-bf-relay-secret');
     assert.equal(parsed.CATSCO_CUSTOM_LLM_MODEL, 'deepseek-chat-v2');
+    assert.equal(parsed.GAUZ_LLM_CONTEXT_WINDOW_TOKENS, '512000');
+    assert.equal(parsed.CATSCO_CUSTOM_LLM_CONTEXT_WINDOW_TOKENS, '512000');
   });
 
   test('saving incomplete custom settings keeps active relay startup intact', async () => {
@@ -454,6 +479,20 @@ describe('dashboard typed settings API', () => {
     const unsafeUrl = await unsafeUrlResponse.json() as any;
     assert.equal(unsafeUrlResponse.status, 400);
     assert.match(unsafeUrl.error, /must not include credentials, query, or fragment/);
+    assert.equal(fs.existsSync(path.join(testRoot, '.env')), false);
+
+    const invalidContextResponse = await fetch(`${baseUrl}/api/settings`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        settings: {
+          'model.contextWindowTokens': '999999',
+        },
+      }),
+    });
+    const invalidContext = await invalidContextResponse.json() as any;
+    assert.equal(invalidContextResponse.status, 400);
+    assert.match(invalidContext.error, /model\.contextWindowTokens must be one of/);
     assert.equal(fs.existsSync(path.join(testRoot, '.env')), false);
   });
 


### PR DESCRIPTION
## 变更内容

- 自定义模型配置增加上下文窗口档位，可选 128K / 200K / 256K / 512K / 1M。
- 保存自定义模型时写入 `GAUZ_LLM_CONTEXT_WINDOW_TOKENS` 和 `CATSCO_CUSTOM_LLM_CONTEXT_WINDOW_TOKENS`，启动本地 agent 时会沿用用户选择的上下文上限。
- 自定义模型和 CatsCo 中转模型的上下文配置保持隔离，避免切换中转模型时把中转模型上下文误写回自定义配置。
- Dashboard 自定义模型卡片会展示当前选择的上下文档位，不再固定显示 128K。

## 验证

- 通过：`node --import tsx --test tests/dashboard-productization-html.test.ts tests/model-context-window.test.ts`
- 通过：`git diff --check`（仅有既有 CRLF warning）
- 受阻：`tests/dashboard-settings-api.test.ts` / `tsc --noEmit` 当前本地 `node_modules` 缺少 `@anthropic-ai/sdk`，尝试 `npm install` 时被正在运行的 Electron 文件锁阻塞（`EBUSY ... node_modules\electron\dist\icudtl.dat`）。
