### PR TITLE
Add CatsCo desktop deep link onboarding

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -7643,6 +7643,9 @@
       const label=selectedModel.label||selectedModel.model||selectedModelId;
       let retrying=false;
       try{
+        pendingStartupSource='relay';
+        pendingRelayModelId=selectedModelId;
+        renderCatsStatus();
         setRelayModelApplyBusy(true);
         setRelayModelApplyStatus('正在启用 CatsCo 中转模型（'+label+'）...','muted',source);
         const r=await fetch(API+'/api/cats/relay/model-config/apply',{
@@ -7707,6 +7710,9 @@
         return;
       }
       try{
+        pendingStartupSource='custom';
+        pendingRelayModelId='';
+        renderCatsStatus();
         setRelayModelApplyBusy(true);
         setRelayModelApplyStatus('正在切换为自定义模型...','muted',source);
         const r=await fetch(API+'/api/model-source/custom/apply',{
@@ -8612,8 +8618,9 @@
         document.getElementById('cats-register-password').value='';
         invalidateRelayModelConfigRequests();
         invalidateCatsStatusRequests();
-        setCatsAction('登录态已保存。请选择要绑定的 CatsCo agent。');
+        setCatsAction('登录态已保存。正在自动绑定 CatsCo agent 并启动 connector...');
         await fetchCatsStatus();
+        await setupCatsBot({forceLegacySetup:true});
         pulsePetState('success', '已登录', 1800);
       }catch(e){
         setCatsAction('连接失败：'+e.message,true);

--- a/electron/main.js
+++ b/electron/main.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 
 const DASHBOARD_PORT = resolveDashboardPort(process.env.XIAOBA_DASHBOARD_PORT);
 const DEEP_LINK_PROTOCOL = 'catsco';
+const TRUSTED_DEEP_LINK_BASE_ORIGINS = new Set(['https://app.catsco.cc']);
 let mainWindow = null;
 let tray = null;
 let autoUpdater = null;
@@ -149,6 +150,32 @@ async function drainPendingDeepLinks() {
   }
 }
 
+function isLoopbackDeepLinkHost(hostname) {
+  const host = String(hostname || '').toLowerCase();
+  return host === 'localhost' || host === '127.0.0.1' || host === '::1' || host === '[::1]';
+}
+
+function trustedDeepLinkBase(value) {
+  const text = String(value || '').trim();
+  if (!text) return '';
+  let url;
+  try {
+    url = new URL(text);
+  } catch (_error) {
+    return '';
+  }
+  if (!['http:', 'https:'].includes(url.protocol) || url.username || url.password || url.search || url.hash) {
+    return '';
+  }
+  if (TRUSTED_DEEP_LINK_BASE_ORIGINS.has(url.origin)) {
+    return url.origin;
+  }
+  if (!app.isPackaged && url.protocol === 'http:' && isLoopbackDeepLinkHost(url.hostname)) {
+    return url.origin;
+  }
+  return '';
+}
+
 async function processDeepLink(value) {
   let parsed;
   try {
@@ -160,7 +187,11 @@ async function processDeepLink(value) {
   if (action !== 'connect') return;
   const code = parsed.searchParams.get('code');
   if (!code) return;
-  const base = parsed.searchParams.get('base') || '';
+  const rawBase = parsed.searchParams.get('base') || '';
+  const base = trustedDeepLinkBase(rawBase);
+  if (rawBase && !base) {
+    console.warn('[desktop-connect] ignored untrusted CatsCo base:', rawBase);
+  }
   const desktopConnectBody = {
     code,
     ...(base ? { httpBaseUrl: base } : {}),

--- a/electron/main.js
+++ b/electron/main.js
@@ -3,15 +3,35 @@ const path = require('path');
 const fs = require('fs');
 
 const DASHBOARD_PORT = resolveDashboardPort(process.env.XIAOBA_DASHBOARD_PORT);
+const DEEP_LINK_PROTOCOL = 'catsco';
 let mainWindow = null;
 let tray = null;
 let autoUpdater = null;
 let hideNoticeShown = false;
+let dashboardServerReady = false;
+const pendingDeepLinks = [];
+let deepLinkDrainPromise = null;
 const REFRESHABLE_BUNDLED_SKILLS = new Set([]);
 const RETIRED_BUNDLED_SKILLS = new Set(['advanced-reader', 'vision-analysis']);
 const SKILL_SYNC_MARKER = '.xiaoba-bundled-skill.json';
 
 applyConfiguredUserDataPath();
+
+const gotSingleInstanceLock = app.requestSingleInstanceLock();
+if (!gotSingleInstanceLock) {
+  app.quit();
+} else {
+  app.on('second-instance', (_event, argv) => {
+    enqueueDeepLinkFromArgv(argv);
+    showMainWindow();
+  });
+}
+
+app.on('open-url', (event, url) => {
+  event.preventDefault();
+  enqueueDeepLink(url);
+  showMainWindow();
+});
 
 function resolveDashboardPort(value) {
   const text = String(value || '').trim();
@@ -78,6 +98,90 @@ function showMainWindow() {
   } else {
     createWindow();
   }
+}
+
+function isCatsCoDeepLink(value) {
+  return typeof value === 'string' && value.toLowerCase().startsWith(`${DEEP_LINK_PROTOCOL}://`);
+}
+
+function enqueueDeepLinkFromArgv(argv) {
+  const link = (argv || []).find(isCatsCoDeepLink);
+  if (link) enqueueDeepLink(link);
+}
+
+function enqueueDeepLink(value) {
+  if (!isCatsCoDeepLink(value)) return;
+  pendingDeepLinks.push(value);
+  if (dashboardServerReady) {
+    scheduleDeepLinkDrain();
+  }
+}
+
+function scheduleDeepLinkDrain() {
+  if (deepLinkDrainPromise) return deepLinkDrainPromise;
+  deepLinkDrainPromise = drainPendingDeepLinks()
+    .catch((error) => {
+      console.error('[desktop-connect] failed to process pending deep links:', error);
+    })
+    .finally(() => {
+      deepLinkDrainPromise = null;
+      if (pendingDeepLinks.length > 0) scheduleDeepLinkDrain();
+    });
+  return deepLinkDrainPromise;
+}
+
+function registerDeepLinkProtocol() {
+  try {
+    if (process.defaultApp && process.argv.length >= 2) {
+      app.setAsDefaultProtocolClient(DEEP_LINK_PROTOCOL, process.execPath, [path.resolve(process.argv[1])]);
+    } else {
+      app.setAsDefaultProtocolClient(DEEP_LINK_PROTOCOL);
+    }
+  } catch (error) {
+    console.warn('[desktop-connect] failed to register catsco:// protocol:', error?.message || error);
+  }
+}
+
+async function drainPendingDeepLinks() {
+  while (pendingDeepLinks.length > 0) {
+    const link = pendingDeepLinks.shift();
+    await processDeepLink(link);
+  }
+}
+
+async function processDeepLink(value) {
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch (_error) {
+    return;
+  }
+  const action = parsed.hostname || parsed.pathname.replace(/^\/+/, '');
+  if (action !== 'connect') return;
+  const code = parsed.searchParams.get('code');
+  if (!code) return;
+  const base = parsed.searchParams.get('base') || '';
+  const desktopConnectBody = {
+    code,
+    ...(base ? { httpBaseUrl: base } : {}),
+  };
+  const localApiBase = `http://127.0.0.1:${DASHBOARD_PORT}/api`;
+  await postLocalJson(`${localApiBase}/cats/desktop-connect`, desktopConnectBody);
+  await postLocalJson(`${localApiBase}/cats/setup`, {});
+  showMainWindow();
+}
+
+async function postLocalJson(url, body) {
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body || {}),
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(`POST ${url} failed: ${response.status} ${text}`);
+  }
+  return response.json().catch(() => ({}));
 }
 
 function createTrayIcon() {
@@ -771,10 +875,14 @@ if (autoUpdater) {
 
 app.whenReady().then(async () => {
   try {
+    registerDeepLinkProtocol();
     await startServer();
+    dashboardServerReady = true;
     createApplicationMenu();
     createWindow();
     createTray();
+    enqueueDeepLinkFromArgv(process.argv);
+    scheduleDeepLinkDrain();
     
     // 闂備礁鎲￠崙褰掑垂閻楀牊鍙忛柍鍝勬噹鐟欙箓骞栧ǎ顒€鐒烘慨濠囩畺閺岋紕浠︾拠鎻掑濠电偞褰冨鈥愁嚕?
     if (app.isPackaged && autoUpdater) {

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -916,6 +916,19 @@ function selectRelayModel(
   return models.find(model => model.default) || models[0];
 }
 
+function preferredRelayModelRequest(requested: unknown): unknown {
+  const explicit = String(requested || '').trim();
+  if (explicit) return explicit;
+  const fileEnv = readEnvFile();
+  return firstNonEmpty(
+    process.env.CATSCO_RELAY_LLM_MODEL,
+    fileEnv.CATSCO_RELAY_LLM_MODEL,
+    isCatsRelayApiBase(firstNonEmpty(process.env.GAUZ_LLM_API_BASE, fileEnv.GAUZ_LLM_API_BASE))
+      ? firstNonEmpty(process.env.GAUZ_LLM_MODEL, fileEnv.GAUZ_LLM_MODEL)
+      : undefined,
+  );
+}
+
 function relayModelPayload(model: RelayModelConfig): Record<string, unknown> {
   const promptBudget = model.contextWindowTokens
     ? calculatePromptBudgetTokens(model.contextWindowTokens, 32_768).promptBudgetTokens
@@ -1285,7 +1298,8 @@ async function setupCatsRelayModelForDesktop(
     };
   }
 
-  const selectedModel = selectRelayModel(config, requestedModel, { strict: Boolean(requestedModel) });
+  const preferredModel = preferredRelayModelRequest(requestedModel);
+  const selectedModel = selectRelayModel(config, preferredModel, { strict: Boolean(String(requestedModel || '').trim()) });
   const ensured = await ensureCatsRelayPlainKey(state, {
     rotateExisting: options.rotateExisting,
   });
@@ -2216,6 +2230,39 @@ export function createApiRouter(serviceManager: ServiceManager, updateController
     res.json({ ok: true, removed });
   });
 
+  router.post('/cats/desktop-connect', async (req, res) => {
+    try {
+      const code = String(req.body?.code || '').trim();
+      if (!code) return res.status(400).json({ error: 'code is required' });
+
+      const state = getCatsAuthState(req.body || {});
+      const login = await catsRequest('POST', state.httpBaseUrl, '/api/desktop-connect/exchange', { code }, undefined, { timeoutMs: 8000 });
+      const nextState: CatsAuthState = {
+        ...state,
+        token: String(login.token || '').trim(),
+        uid: String(login.uid || '').trim(),
+        username: String(login.username || '').trim(),
+        displayName: String(login.display_name || login.displayName || login.username || '').trim(),
+        httpBaseUrl: String(login.http_base_url || login.httpBaseUrl || state.httpBaseUrl || DEFAULT_CATSCO_HTTP_BASE_URL).trim(),
+        serverUrl: String(login.server_url || login.serverUrl || state.serverUrl || DEFAULT_CATSCO_WS_URL).trim(),
+      };
+      persistCatsUserSession(nextState, login);
+      res.json({
+        ok: true,
+        user: {
+          uid: nextState.uid,
+          username: nextState.username,
+          display_name: nextState.displayName,
+        },
+        httpBaseUrl: nextState.httpBaseUrl,
+        serverUrl: nextState.serverUrl,
+      });
+    } catch (e: any) {
+      const payload = catsErrorResponse(e);
+      res.status(payload.status).json(payload.body);
+    }
+  });
+
   router.post('/cats/setup', async (req, res) => {
     try {
       const state = getCatsAuthState(req.body || {});
@@ -2243,7 +2290,8 @@ export function createApiRouter(serviceManager: ServiceManager, updateController
         || bots.find((item: any) => String(item.display_name || '') === preferredName)
         || bots.find((item: any) => String(item.username || '') === legacyUsername)
         || bots.find((item: any) => String(item.username || '') === legacyCatsCoUsername)
-        || bots.find((item: any) => String(item.display_name || '') === legacyName);
+        || bots.find((item: any) => String(item.display_name || '') === legacyName)
+        || bots[0];
 
       if (!bot) {
         const created = await catsRequest('POST', state.httpBaseUrl, '/api/bots', {

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -59,6 +59,8 @@ import {
 
 const DEFAULT_CATSCO_HTTP_BASE_URL = 'https://app.catsco.cc';
 const DEFAULT_CATSCO_WS_URL = 'wss://app.catsco.cc/v0/channels';
+const TRUSTED_CATSCO_HTTP_ORIGINS = new Set([new URL(DEFAULT_CATSCO_HTTP_BASE_URL).origin]);
+const TRUSTED_CATSCO_WS_URL = new URL(DEFAULT_CATSCO_WS_URL);
 const BUNDLED_SKILL_MARKER = '.xiaoba-bundled-skill.json';
 const SYSTEM_SKILL_DIRS = new Set<string>();
 
@@ -194,6 +196,73 @@ interface ModelLaunchProfile {
 function normalizeBaseUrl(value: unknown, fallback: string): string {
   const text = String(value || '').trim().replace(/\/+$/, '');
   return text || fallback;
+}
+
+function truthyEnv(value: unknown): boolean {
+  return /^(1|true|yes|on)$/i.test(String(value || '').trim());
+}
+
+function canUseLocalCatsCoEndpoint(): boolean {
+  return process.env.NODE_ENV === 'test'
+    || truthyEnv(process.env.CATSCO_ALLOW_LOCAL_ENDPOINTS)
+    || truthyEnv(process.env.CATSCOMPANY_ALLOW_LOCAL_ENDPOINTS);
+}
+
+function isLoopbackHost(hostname: string): boolean {
+  const host = hostname.toLowerCase();
+  return host === 'localhost' || host === '127.0.0.1' || host === '::1' || host === '[::1]';
+}
+
+function normalizeTrustedCatsHttpBaseUrl(value: unknown): string {
+  const text = String(value || DEFAULT_CATSCO_HTTP_BASE_URL).trim();
+  let url: URL;
+  try {
+    url = new URL(text);
+  } catch {
+    throw httpError('Untrusted CatsCo HTTP endpoint', 400);
+  }
+
+  if (!['http:', 'https:'].includes(url.protocol) || url.username || url.password || url.search || url.hash) {
+    throw httpError('Untrusted CatsCo HTTP endpoint', 400);
+  }
+  if (TRUSTED_CATSCO_HTTP_ORIGINS.has(url.origin)) {
+    return url.origin;
+  }
+  if (canUseLocalCatsCoEndpoint() && isLoopbackHost(url.hostname)) {
+    return url.origin;
+  }
+  throw httpError('Untrusted CatsCo HTTP endpoint', 400);
+}
+
+function normalizeTrustedCatsServerUrl(value: unknown): string {
+  const text = String(value || DEFAULT_CATSCO_WS_URL).trim();
+  let url: URL;
+  try {
+    url = new URL(text);
+  } catch {
+    throw httpError('Untrusted CatsCo websocket endpoint', 400);
+  }
+
+  if (!['ws:', 'wss:'].includes(url.protocol) || url.username || url.password || url.search || url.hash) {
+    throw httpError('Untrusted CatsCo websocket endpoint', 400);
+  }
+
+  const pathname = url.pathname.replace(/\/+$/, '') || '/';
+  if (url.origin === TRUSTED_CATSCO_WS_URL.origin && pathname === TRUSTED_CATSCO_WS_URL.pathname) {
+    return `${url.protocol}//${url.host}${pathname}`;
+  }
+  if (canUseLocalCatsCoEndpoint() && isLoopbackHost(url.hostname)) {
+    return `${url.protocol}//${url.host}${pathname}`;
+  }
+  throw httpError('Untrusted CatsCo websocket endpoint', 400);
+}
+
+function trustCatsAuthStateEndpoints(state: CatsAuthState): CatsAuthState {
+  return {
+    ...state,
+    httpBaseUrl: normalizeTrustedCatsHttpBaseUrl(state.httpBaseUrl),
+    serverUrl: normalizeTrustedCatsServerUrl(state.serverUrl),
+  };
 }
 
 function p2pTopicId(uid1: string | number, uid2: string | number): string {
@@ -2235,16 +2304,18 @@ export function createApiRouter(serviceManager: ServiceManager, updateController
       const code = String(req.body?.code || '').trim();
       if (!code) return res.status(400).json({ error: 'code is required' });
 
-      const state = getCatsAuthState(req.body || {});
+      const state = trustCatsAuthStateEndpoints(getCatsAuthState(req.body || {}));
       const login = await catsRequest('POST', state.httpBaseUrl, '/api/desktop-connect/exchange', { code }, undefined, { timeoutMs: 8000 });
+      const httpBaseUrl = normalizeTrustedCatsHttpBaseUrl(login.http_base_url || login.httpBaseUrl || state.httpBaseUrl || DEFAULT_CATSCO_HTTP_BASE_URL);
+      const serverUrl = normalizeTrustedCatsServerUrl(login.server_url || login.serverUrl || state.serverUrl || DEFAULT_CATSCO_WS_URL);
       const nextState: CatsAuthState = {
         ...state,
         token: String(login.token || '').trim(),
         uid: String(login.uid || '').trim(),
         username: String(login.username || '').trim(),
         displayName: String(login.display_name || login.displayName || login.username || '').trim(),
-        httpBaseUrl: String(login.http_base_url || login.httpBaseUrl || state.httpBaseUrl || DEFAULT_CATSCO_HTTP_BASE_URL).trim(),
-        serverUrl: String(login.server_url || login.serverUrl || state.serverUrl || DEFAULT_CATSCO_WS_URL).trim(),
+        httpBaseUrl,
+        serverUrl,
       };
       persistCatsUserSession(nextState, login);
       res.json({
@@ -2265,7 +2336,7 @@ export function createApiRouter(serviceManager: ServiceManager, updateController
 
   router.post('/cats/setup', async (req, res) => {
     try {
-      const state = getCatsAuthState(req.body || {});
+      const state = trustCatsAuthStateEndpoints(getCatsAuthState(req.body || {}));
       if (!state.token) return res.status(401).json({ error: 'CatsCo user token is missing' });
       if (req.body?.botUid) {
         return res.status(409).json({ error: 'Legacy setup no longer accepts botUid; use /api/cats/bind-bot' });
@@ -2282,16 +2353,16 @@ export function createApiRouter(serviceManager: ServiceManager, updateController
       const preferredUsername = sanitizeCatsUsernamePart(String(req.body?.botUsername || `catsco_${userUid}_${deviceId}`))
         || `catsco_${userUid}_${deviceId.replace(/[^a-zA-Z0-9_]/g, '_')}`;
       const preferredName = String(req.body?.botDisplayName || `CatsCo (${deviceName})`).trim() || `CatsCo (${deviceName})`;
-      const legacyUsername = `xiaoba_${userUid}`;
-      const legacyCatsCoUsername = `catsco_${userUid}`;
-      const legacyName = 'XiaoBa';
-      let bot = bots.find((item: any) => String(item.id || item.uid) === String(state.botUid || ''))
-        || bots.find((item: any) => String(item.username || '') === preferredUsername)
-        || bots.find((item: any) => String(item.display_name || '') === preferredName)
-        || bots.find((item: any) => String(item.username || '') === legacyUsername)
-        || bots.find((item: any) => String(item.username || '') === legacyCatsCoUsername)
-        || bots.find((item: any) => String(item.display_name || '') === legacyName)
-        || bots[0];
+      let botSelectionSource: 'last-used' | 'first-owned-bot' | 'created-default' = 'first-owned-bot';
+      let bot = state.botUid
+        ? bots.find((item: any) => String(item.id || item.uid || '') === String(state.botUid))
+        : undefined;
+      if (bot) {
+        botSelectionSource = 'last-used';
+      } else if (bots.length > 0) {
+        bot = bots[0];
+        botSelectionSource = 'first-owned-bot';
+      }
 
       if (!bot) {
         const created = await catsRequest('POST', state.httpBaseUrl, '/api/bots', {
@@ -2305,6 +2376,7 @@ export function createApiRouter(serviceManager: ServiceManager, updateController
           display_name: preferredName,
           api_key: created.api_key,
         };
+        botSelectionSource = 'created-default';
       }
 
       const botUid = String(bot.id || bot.uid || '');
@@ -2387,6 +2459,7 @@ export function createApiRouter(serviceManager: ServiceManager, updateController
         connectorStarted: result.connectorStarted,
         connectorRestarted: result.connectorRestarted,
         relayModelSetup,
+        botSelectionSource,
         warnings: result.warnings.length > 0 ? result.warnings : undefined,
       });
     } catch (e: any) {

--- a/src/dashboard/service-manager.ts
+++ b/src/dashboard/service-manager.ts
@@ -223,7 +223,7 @@ export class ServiceManager extends EventEmitter {
   start(name: string): ServiceInfo {
     const svc = this.services.get(name);
     if (!svc) throw new Error(`Service "${name}" not found`);
-    if (svc.info.status === 'running') throw new Error(`Service "${name}" is already running`);
+    if (svc.info.status === 'running') return this.getService(name)!;
 
     // cwd 统一用 process.cwd()，Electron 主进程已 chdir 到 userData 目录
     // 这样子进程创建的 skill 文件和 Dashboard 读取的在同一个目录
@@ -393,7 +393,18 @@ export class ServiceManager extends EventEmitter {
     if (svc.info.status === 'running' && svc.process) {
       // 先停再启，等进程退出后启动
       svc.process.once('exit', () => {
-        const restartTimer = setTimeout(() => this.start(name), 500);
+        const restartTimer = setTimeout(() => {
+          try {
+            this.start(name);
+          } catch (error) {
+            const current = this.services.get(name);
+            if (current) {
+              current.info.status = 'error';
+              current.info.lastError = error instanceof Error ? error.message : String(error);
+            }
+            this.emit('service-error', name, error);
+          }
+        }, 500);
         restartTimer.unref?.();
       });
       svc.expectedExit = 'restart';

--- a/src/dashboard/settings.ts
+++ b/src/dashboard/settings.ts
@@ -231,6 +231,7 @@ function buildModelStartupSnapshot(
   const effective = readModelProfile(EFFECTIVE_MODEL_ENV_KEYS, fileEnv, env);
   const custom = readCustomModelProfile(fileEnv, env);
   const storedRelay = readModelProfile(RELAY_MODEL_ENV_KEYS, fileEnv, env);
+  const requestedSource = firstNonEmpty(fileEnv.CATSCO_MODEL_SOURCE, env.CATSCO_MODEL_SOURCE);
   const relay = storedRelay.configured
     ? storedRelay
     : {
@@ -241,7 +242,12 @@ function buildModelStartupSnapshot(
       apiKeyPresent: storedRelay.apiKeyPresent || (isCatsRelayApiBase(effective.apiBase) && effective.apiKeyPresent),
       configured: isCatsRelayApiBase(effective.apiBase) && effective.configured,
     };
-  const source = isCatsRelayApiBase(effective.apiBase) ? 'relay' : 'custom';
+  const effectiveIsRelay = isCatsRelayApiBase(effective.apiBase);
+  const source = requestedSource === 'custom' && custom.configured
+    ? 'custom'
+    : requestedSource === 'relay' && relay.configured && effectiveIsRelay
+    ? 'relay'
+    : effectiveIsRelay ? 'relay' : 'custom';
 
   return { source, effective, custom, relay };
 }

--- a/tests/dashboard-catsco-auth-status.test.ts
+++ b/tests/dashboard-catsco-auth-status.test.ts
@@ -250,6 +250,42 @@ describe('dashboard CatsCo account status', () => {
     assert.equal(env.CATSCOMPANY_USER_DISPLAY_NAME, 'Demo User');
   });
 
+  test('POST /cats/desktop-connect exchanges a web login code and persists CatsCo account aliases', async () => {
+    await startCatsServer((req, res) => {
+      if (req.path === '/api/desktop-connect/exchange') {
+        assert.deepStrictEqual(req.body, { code: 'one-time-code' });
+        return res.json({
+          token: 'desktop-user-token',
+          uid: 91,
+          username: 'desktop',
+          display_name: 'Desktop User',
+          http_base_url: catsBaseUrl,
+          server_url: 'wss://app.catsco.cc/v0/channels',
+        });
+      }
+      return res.status(404).json({ error: 'not found' });
+    });
+
+    const response = await fetch(`${dashboardBaseUrl}/api/cats/desktop-connect`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        code: 'one-time-code',
+        httpBaseUrl: catsBaseUrl,
+      }),
+    });
+    const data = await response.json() as any;
+    const env = dotenv.parse(fs.readFileSync(path.join(testRoot, '.env'), 'utf-8'));
+
+    assert.equal(response.status, 200);
+    assert.equal(data.ok, true);
+    assert.equal(data.user.uid, '91');
+    assert.equal(env.CATSCO_USER_TOKEN, 'desktop-user-token');
+    assert.equal(env.CATSCOMPANY_USER_TOKEN, 'desktop-user-token');
+    assert.equal(env.CATSCO_USER_UID, '91');
+    assert.equal(env.CATSCOMPANY_USER_DISPLAY_NAME, 'Desktop User');
+  });
+
   test('POST /cats/setup creates a relay key, writes model config, and starts connector for a new account', async () => {
     if (dashboardServer) {
       await close(dashboardServer);
@@ -387,6 +423,96 @@ describe('dashboard CatsCo account status', () => {
     assert.equal(env.CATSCO_API_KEY, 'cats-agent-key');
     assert.equal(startCalled, 1);
     assert.equal(data.service.status, 'running');
+  });
+
+  test('POST /cats/setup reuses an existing owned bot instead of creating a default bot', async () => {
+    if (dashboardServer) {
+      await close(dashboardServer);
+      dashboardServer = undefined;
+    }
+
+    const service = {
+      name: 'catscompany',
+      label: 'CatsCo agent',
+      command: process.execPath,
+      args: [],
+      status: 'stopped',
+    };
+    const dashboardApp = express();
+    dashboardApp.use(express.json());
+    dashboardApp.use('/api', createApiRouter({
+      getAll: () => [service],
+      getService: (name: string) => (name === 'catscompany' ? service : undefined),
+      start: () => {
+        service.status = 'running';
+        return service;
+      },
+    } as any));
+    dashboardServer = await listen(dashboardApp);
+    dashboardBaseUrl = serverBaseUrl(dashboardServer);
+
+    let createBotCalls = 0;
+    await startCatsServer((req, res) => {
+      if (req.path === '/api/me') {
+        return res.json({ uid: 88, username: 'fresh', display_name: 'Fresh User' });
+      }
+      if (req.path === '/api/bots' && req.method === 'GET') {
+        return res.json({
+          bots: [{
+            id: 188,
+            uid: 188,
+            username: 'existing-agent',
+            display_name: 'Existing Agent',
+            api_key: 'existing-agent-key',
+          }],
+        });
+      }
+      if (req.path === '/api/bots' && req.method === 'POST') {
+        createBotCalls += 1;
+        return res.status(500).json({ error: 'should not create bot' });
+      }
+      if (req.path === '/api/friends/request') {
+        return res.json({ ok: true });
+      }
+      if (req.path === '/api/friends/accept') {
+        assert.equal(req.header('authorization'), 'ApiKey existing-agent-key');
+        return res.json({ ok: true });
+      }
+      return res.status(404).json({ error: 'not found' });
+    });
+    writeEnv([
+      `CATSCO_HTTP_BASE_URL=${catsBaseUrl}`,
+      'CATSCO_SERVER_URL=wss://app.catsco.cc/v0/channels',
+      'CATSCO_USER_TOKEN=user-token',
+      'CATSCO_USER_UID=88',
+      'CATSCO_USER_NAME=fresh',
+      'CATSCO_USER_DISPLAY_NAME=Fresh User',
+      'GAUZ_LLM_PROVIDER=anthropic',
+      'GAUZ_LLM_API_BASE=https://model.example.test/v1/messages',
+      'GAUZ_LLM_API_KEY=sk-test',
+      'GAUZ_LLM_MODEL=test-model',
+    ]);
+
+    const response = await fetch(`${dashboardBaseUrl}/api/cats/setup`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        httpBaseUrl: catsBaseUrl,
+        serverUrl: 'wss://app.catsco.cc/v0/channels',
+        setupRelayModel: false,
+      }),
+    });
+    const text = await response.text();
+    const data = JSON.parse(text) as any;
+    const env = dotenv.parse(fs.readFileSync(path.join(testRoot, '.env'), 'utf-8'));
+
+    assert.equal(response.status, 200, text);
+    assert.equal(data.ok, true);
+    assert.equal(data.bot.uid, '188');
+    assert.equal(data.bot.display_name, 'Existing Agent');
+    assert.equal(env.CATSCO_BOT_UID, '188');
+    assert.equal(env.CATSCO_API_KEY, 'existing-agent-key');
+    assert.equal(createBotCalls, 0);
   });
 
   test('POST /cats/bind-bot writes relay model config before starting an existing bot binding', async () => {

--- a/tests/dashboard-catsco-auth-status.test.ts
+++ b/tests/dashboard-catsco-auth-status.test.ts
@@ -52,6 +52,8 @@ describe('dashboard CatsCo account status', () => {
     'CATSCOMPANY_DEVICE_ID',
     'CATSCOMPANY_BODY_ID',
     'CATSCOMPANY_INSTALLATION_ID',
+    'CATSCO_ALLOW_LOCAL_ENDPOINTS',
+    'CATSCOMPANY_ALLOW_LOCAL_ENDPOINTS',
   ];
   const originalEnv: Record<string, string | undefined> = {};
 
@@ -64,6 +66,7 @@ describe('dashboard CatsCo account status', () => {
       originalEnv[key] = process.env[key];
       delete process.env[key];
     }
+    process.env.CATSCO_ALLOW_LOCAL_ENDPOINTS = '1';
 
     const app = express();
     app.use(express.json());
@@ -286,6 +289,52 @@ describe('dashboard CatsCo account status', () => {
     assert.equal(env.CATSCOMPANY_USER_DISPLAY_NAME, 'Desktop User');
   });
 
+  test('POST /cats/desktop-connect rejects an untrusted requested base before exchange', async () => {
+    const response = await fetch(`${dashboardBaseUrl}/api/cats/desktop-connect`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        code: 'one-time-code',
+        httpBaseUrl: 'https://evil.example',
+      }),
+    });
+    const data = await response.json() as any;
+
+    assert.equal(response.status, 400);
+    assert.match(data.error, /Untrusted CatsCo HTTP endpoint/);
+    assert.equal(fs.existsSync(path.join(testRoot, '.env')), false);
+  });
+
+  test('POST /cats/desktop-connect rejects untrusted exchange endpoints before persisting', async () => {
+    await startCatsServer((req, res) => {
+      if (req.path === '/api/desktop-connect/exchange') {
+        return res.json({
+          token: 'desktop-user-token',
+          uid: 91,
+          username: 'desktop',
+          display_name: 'Desktop User',
+          http_base_url: 'https://evil.example',
+          server_url: 'wss://app.catsco.cc/v0/channels',
+        });
+      }
+      return res.status(404).json({ error: 'not found' });
+    });
+
+    const response = await fetch(`${dashboardBaseUrl}/api/cats/desktop-connect`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        code: 'one-time-code',
+        httpBaseUrl: catsBaseUrl,
+      }),
+    });
+    const data = await response.json() as any;
+
+    assert.equal(response.status, 400);
+    assert.match(data.error, /Untrusted CatsCo HTTP endpoint/);
+    assert.equal(fs.existsSync(path.join(testRoot, '.env')), false);
+  });
+
   test('POST /cats/setup creates a relay key, writes model config, and starts connector for a new account', async () => {
     if (dashboardServer) {
       await close(dashboardServer);
@@ -406,6 +455,7 @@ describe('dashboard CatsCo account status', () => {
 
     assert.equal(response.status, 200, text);
     assert.equal(data.ok, true);
+    assert.equal(data.botSelectionSource, 'created-default');
     assert.equal(data.relayModelSetup.ok, true);
     assert.equal(data.relayModelSetup.model, 'glm-5.1');
     assert.equal(data.relayModelSetup.createdKey, true);
@@ -508,10 +558,100 @@ describe('dashboard CatsCo account status', () => {
 
     assert.equal(response.status, 200, text);
     assert.equal(data.ok, true);
+    assert.equal(data.botSelectionSource, 'first-owned-bot');
     assert.equal(data.bot.uid, '188');
     assert.equal(data.bot.display_name, 'Existing Agent');
     assert.equal(env.CATSCO_BOT_UID, '188');
     assert.equal(env.CATSCO_API_KEY, 'existing-agent-key');
+    assert.equal(createBotCalls, 0);
+  });
+
+  test('POST /cats/setup reuses the last selected bot before the first owned bot', async () => {
+    if (dashboardServer) {
+      await close(dashboardServer);
+      dashboardServer = undefined;
+    }
+
+    const service = {
+      name: 'catscompany',
+      label: 'CatsCo agent',
+      command: process.execPath,
+      args: [],
+      status: 'stopped',
+    };
+    const dashboardApp = express();
+    dashboardApp.use(express.json());
+    dashboardApp.use('/api', createApiRouter({
+      getAll: () => [service],
+      getService: (name: string) => (name === 'catscompany' ? service : undefined),
+      start: () => {
+        service.status = 'running';
+        return service;
+      },
+    } as any));
+    dashboardServer = await listen(dashboardApp);
+    dashboardBaseUrl = serverBaseUrl(dashboardServer);
+
+    let createBotCalls = 0;
+    await startCatsServer((req, res) => {
+      if (req.path === '/api/me') {
+        return res.json({ uid: 88, username: 'fresh', display_name: 'Fresh User' });
+      }
+      if (req.path === '/api/bots' && req.method === 'GET') {
+        return res.json({
+          bots: [
+            { uid: 188, username: 'first-agent', display_name: 'First Agent', api_key: 'first-agent-key' },
+            { uid: 199, username: 'last-agent', display_name: 'Last Agent', api_key: 'last-agent-key' },
+          ],
+        });
+      }
+      if (req.path === '/api/bots' && req.method === 'POST') {
+        createBotCalls += 1;
+        return res.status(500).json({ error: 'should not create bot' });
+      }
+      if (req.path === '/api/friends/request') {
+        return res.json({ ok: true });
+      }
+      if (req.path === '/api/friends/accept') {
+        assert.equal(req.header('authorization'), 'ApiKey last-agent-key');
+        return res.json({ ok: true });
+      }
+      return res.status(404).json({ error: 'not found' });
+    });
+    writeEnv([
+      `CATSCO_HTTP_BASE_URL=${catsBaseUrl}`,
+      'CATSCO_SERVER_URL=wss://app.catsco.cc/v0/channels',
+      'CATSCO_USER_TOKEN=user-token',
+      'CATSCO_USER_UID=88',
+      'CATSCO_USER_NAME=fresh',
+      'CATSCO_USER_DISPLAY_NAME=Fresh User',
+      'CATSCO_BOT_UID=199',
+      'GAUZ_LLM_PROVIDER=anthropic',
+      'GAUZ_LLM_API_BASE=https://model.example.test/v1/messages',
+      'GAUZ_LLM_API_KEY=sk-test',
+      'GAUZ_LLM_MODEL=test-model',
+    ]);
+
+    const response = await fetch(`${dashboardBaseUrl}/api/cats/setup`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        httpBaseUrl: catsBaseUrl,
+        serverUrl: 'wss://app.catsco.cc/v0/channels',
+        setupRelayModel: false,
+      }),
+    });
+    const text = await response.text();
+    const data = JSON.parse(text) as any;
+    const env = dotenv.parse(fs.readFileSync(path.join(testRoot, '.env'), 'utf-8'));
+
+    assert.equal(response.status, 200, text);
+    assert.equal(data.ok, true);
+    assert.equal(data.botSelectionSource, 'last-used');
+    assert.equal(data.bot.uid, '199');
+    assert.equal(data.bot.display_name, 'Last Agent');
+    assert.equal(env.CATSCO_BOT_UID, '199');
+    assert.equal(env.CATSCO_API_KEY, 'last-agent-key');
     assert.equal(createBotCalls, 0);
   });
 

--- a/tests/electron-main-dashboard-url.test.ts
+++ b/tests/electron-main-dashboard-url.test.ts
@@ -56,6 +56,10 @@ test('electron registers catsco deep links and forwards connect codes to the loc
   assert.match(electronMain, /app\.on\('open-url'/);
   assert.match(electronMain, /deepLinkDrainPromise/);
   assert.match(electronMain, /function scheduleDeepLinkDrain\(\)/);
+  assert.match(electronMain, /TRUSTED_DEEP_LINK_BASE_ORIGINS/);
+  assert.match(electronMain, /function trustedDeepLinkBase\(value\)/);
+  assert.match(electronMain, /https:\/\/app\.catsco\.cc/);
   assert.match(electronMain, /\/cats\/desktop-connect/);
   assert.match(electronMain, /\/cats\/setup/);
+  assert.doesNotMatch(electronMain, /httpBaseUrl: rawBase/);
 });

--- a/tests/electron-main-dashboard-url.test.ts
+++ b/tests/electron-main-dashboard-url.test.ts
@@ -47,3 +47,15 @@ test('electron tray uses app icons and notifies after background hide', () => {
   assert.match(electronMain, /CatsCo 已在后台运行/);
   assert.match(electronMain, /notifyWindowHidden\(\)/);
 });
+
+test('electron registers catsco deep links and forwards connect codes to the local dashboard', () => {
+  assert.match(electronMain, /const DEEP_LINK_PROTOCOL = 'catsco'/);
+  assert.match(electronMain, /app\.requestSingleInstanceLock\(\)/);
+  assert.match(electronMain, /app\.setAsDefaultProtocolClient\(DEEP_LINK_PROTOCOL/);
+  assert.match(electronMain, /app\.on\('second-instance'/);
+  assert.match(electronMain, /app\.on\('open-url'/);
+  assert.match(electronMain, /deepLinkDrainPromise/);
+  assert.match(electronMain, /function scheduleDeepLinkDrain\(\)/);
+  assert.match(electronMain, /\/cats\/desktop-connect/);
+  assert.match(electronMain, /\/cats\/setup/);
+});


### PR DESCRIPTION
## Summary
- Add `catsco://connect` desktop deep link handling in Electron.
- Exchange the web one-time connect code through the local dashboard API.
- Automatically run CatsCo setup after login so the local agent can bind/reuse a bot and start the connector.
- Make service start idempotent to avoid duplicate “already running” errors.
- Preserve existing model preference behavior while improving relay model selection fallback.

## Notes
- Existing bots are reused first; a default CatsCo bot is only created when no suitable bot exists.
- Deep link processing is serialized to avoid duplicate setup/start when users click repeatedly.
- This keeps the web-to-desktop flow as a single deep link; no browser access to local dashboard ports is required.

## Test
- `node_modules\.bin\tsx.cmd tests\dashboard-catsco-auth-status.test.ts`
- `node_modules\.bin\tsx.cmd tests\electron-main-dashboard-url.test.ts`
- `npm run build`