### PR TITLE
允许 CatsCo 本地 owner 自用设备工具无确认执行

### DIFF
--- a/src/catscompany/client.ts
+++ b/src/catscompany/client.ts
@@ -21,6 +21,7 @@ export interface CatsDeviceRegistration {
   display_name?: string;
   body_id?: string;
   installation_id?: string;
+  owner_user_id?: string;
   status?: 'online' | 'offline';
   capabilities?: string[];
 }
@@ -39,6 +40,8 @@ export interface CatsDeviceRpcMessage {
   topic_id?: string;
   topic_type?: string;
   actor_user_id?: string;
+  owner_user_id?: string;
+  identity_source?: string;
   agent_id?: string;
   agent_body_id?: string;
   device_id?: string;

--- a/src/catscompany/device-grants.ts
+++ b/src/catscompany/device-grants.ts
@@ -7,6 +7,7 @@ import type {
   MessageTopicType,
   ScopedDeviceGrant,
 } from '../types/session-identity';
+import { isDelegatedDeviceGrant } from '../core/device-grants';
 
 type UnknownRecord = Record<string, unknown>;
 
@@ -82,7 +83,7 @@ function grantMatchesScope(grant: ScopedDeviceGrant, scope: ExecutionScope): boo
     && grant.topicId === scope.topicId
     && grant.topicType === scope.topicType
     && grant.actorUserId === scope.actorUserId
-    && grant.ownerUserId === scope.actorUserId
+    && (grant.ownerUserId === scope.actorUserId || isDelegatedDeviceGrant(grant))
     && grant.agentId === scope.agentId
     && grant.agentBodyId === scope.agentBodyId;
 }
@@ -113,7 +114,7 @@ function normalizeSource(value: string | undefined): MessageSource {
 }
 
 function normalizeStatus(value: string | undefined): DeviceGrantStatus {
-  return value === 'revoked' ? 'revoked' : 'active';
+  return value === 'active' ? 'active' : 'revoked';
 }
 
 function normalizeTrust(value: string | undefined): IdentityTrustLevel {

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -80,6 +80,7 @@ export const CATSCOMPANY_FULL_RUNTIME_DEVICE_CAPABILITIES: DeviceGrantOperation[
   'write_file',
   'edit_file',
   'send_file',
+  'execute_shell',
 ];
 
 function shouldHideCatsToolProgress(toolName: string): boolean {

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -11,7 +11,7 @@ import { AgentServices, BUSY_MESSAGE, RuntimeFeedbackInput, SessionCallbacks } f
 import { Logger } from '../utils/logger';
 import { SubAgentManager } from '../core/sub-agent-manager';
 import type { SubAgentInfo } from '../core/sub-agent-session';
-import { ChannelCallbacks, DeviceRpcTransport, ToolErrorCode, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
+import { ChannelCallbacks, DeviceRpcTransport, ToolErrorCode, ToolExecutionConfirmationRequest, ToolExecutionConfirmationResult, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import { ContentBlock } from '../types';
 import type { PendingUserInput } from '../core/conversation-runner';
 import type { DeviceGrantOperation, ExecutionScope, ScopedDeviceGrant, ScopedDeviceSelection, ScopedLocalDeviceGrant, ScopedLocalFileGrant } from '../types/session-identity';
@@ -24,8 +24,10 @@ import { createCatsCoSessionRoute } from '../core/session-router';
 import { ReadTool } from '../tools/read-tool';
 import { GlobTool } from '../tools/glob-tool';
 import { GrepTool } from '../tools/grep-tool';
+import { WriteTool } from '../tools/write-tool';
+import { EditTool } from '../tools/edit-tool';
 import {
-  isRemoteReadonlyTool,
+  isRemoteDeviceRpcTool,
   normalizeDeviceRpcToolResultForTransport,
   normalizeDeviceRpcToolResultPayload,
 } from '../tools/device-rpc-tool';
@@ -71,6 +73,14 @@ const HIDDEN_CATS_TOOL_PROGRESS = new Set([
   'spawn_subagent',
 ]);
 const SUBAGENT_TERMINAL_EVENTS = new Set(['agent_completed', 'agent_failed', 'agent_stopped']);
+export const CATSCOMPANY_FULL_RUNTIME_DEVICE_CAPABILITIES: DeviceGrantOperation[] = [
+  'read_file',
+  'glob',
+  'grep',
+  'write_file',
+  'edit_file',
+  'send_file',
+];
 
 function shouldHideCatsToolProgress(toolName: string): boolean {
   return HIDDEN_CATS_TOOL_PROGRESS.has(toolName);
@@ -132,8 +142,9 @@ export class CatsCompanyBot {
           display_name: config.deviceName || process.env.COMPUTERNAME || process.env.HOSTNAME || hostname() || localDeviceId,
           body_id: config.bodyId,
           installation_id: config.installationId || config.bodyId,
+          owner_user_id: config.ownerUserId,
           status: 'online' as const,
-          capabilities: ['read_file', 'glob', 'grep'],
+          capabilities: [...CATSCOMPANY_FULL_RUNTIME_DEVICE_CAPABILITIES],
         }
       : undefined;
 
@@ -151,6 +162,8 @@ export class CatsCompanyBot {
       bodyId: config.bodyId,
       installationId: config.installationId,
       deviceId: config.installationId || config.bodyId,
+      ownerUserId: config.ownerUserId,
+      capabilities: [...CATSCOMPANY_FULL_RUNTIME_DEVICE_CAPABILITIES],
     });
     this.deviceRegistration = deviceRegistration;
 
@@ -243,6 +256,8 @@ export class CatsCompanyBot {
           topic_id: grant.topicId,
           topic_type: grant.topicType,
           actor_user_id: grant.actorUserId,
+          owner_user_id: grant.ownerUserId,
+          identity_source: grant.identitySource,
           agent_id: grant.agentId,
           agent_body_id: grant.agentBodyId,
           device_id: grant.deviceId,
@@ -272,7 +287,19 @@ export class CatsCompanyBot {
     if (!requestID) return;
 
     const validationError = this.validateDeviceRpcToolRequest(request);
-    const result = validationError ? undefined : await this.executeLocalDeviceRpcTool(request);
+    let result: ToolExecutionResult | undefined;
+    if (!validationError) {
+      try {
+        result = await this.executeLocalDeviceRpcTool(request);
+      } catch (error: any) {
+        result = {
+          ok: false,
+          errorCode: 'TOOL_EXECUTION_ERROR',
+          message: `Device RPC tool execution error: ${error?.message || error || 'unknown error'}`,
+          retryable: false,
+        };
+      }
+    }
     const error = validationError || (!result || result.ok
       ? undefined
       : {
@@ -288,6 +315,8 @@ export class CatsCompanyBot {
         topic_id: request.topic_id,
         topic_type: request.topic_type,
         actor_user_id: request.actor_user_id,
+        owner_user_id: request.owner_user_id,
+        identity_source: request.identity_source,
         agent_id: request.agent_id,
         agent_body_id: request.agent_body_id,
         device_id: this.localDeviceGrant?.deviceId || request.device_id,
@@ -304,9 +333,9 @@ export class CatsCompanyBot {
   }
 
   private async executeLocalDeviceRpcTool(request: CatsDeviceRpcMessage): Promise<ToolExecutionResult> {
-    const operation = this.normalizeDeviceRpcReadonlyOperation(request.operation);
+    const operation = this.normalizeDeviceRpcOperation(request.operation);
     const toolName = String(request.tool_name || operation || '').trim();
-    if (!operation || !isRemoteReadonlyTool(toolName, operation)) {
+    if (!operation || !isRemoteDeviceRpcTool(toolName, operation)) {
       return {
         ok: false,
         errorCode: 'PERMISSION_DENIED',
@@ -323,6 +352,10 @@ export class CatsCompanyBot {
         return new GlobTool().execute(args, context);
       case 'grep':
         return new GrepTool().execute(args, context);
+      case 'write_file':
+        return new WriteTool().execute(args, context);
+      case 'edit_file':
+        return new EditTool().execute(args, context);
       default:
         return {
           ok: false,
@@ -358,11 +391,11 @@ export class CatsCompanyBot {
       grantId: String(request.grant_id || ''),
       status: 'active',
       identityTrust: 'server_canonical',
-      identitySource: 'device_rpc_forward',
+      identitySource: String(request.identity_source || 'device_rpc_forward'),
       deviceId: String(request.device_id || this.localDeviceGrant?.deviceId || ''),
       deviceBodyId: request.device_body_id || this.localDeviceGrant?.bodyId,
       deviceInstallationId: request.device_installation_id || this.localDeviceGrant?.installationId,
-      ownerUserId: executionScope.actorUserId,
+      ownerUserId: String(request.owner_user_id || executionScope.actorUserId || ''),
       sessionKey: executionScope.sessionKey,
       topicId: executionScope.topicId,
       topicType,
@@ -410,10 +443,10 @@ export class CatsCompanyBot {
     const targetError = this.validateDeviceRpcTarget(request);
     if (targetError) return targetError;
 
-    const operation = this.normalizeDeviceRpcReadonlyOperation(request.operation);
+    const operation = this.normalizeDeviceRpcOperation(request.operation);
     const toolName = String(request.tool_name || operation || '').trim();
-    if (!operation || !isRemoteReadonlyTool(toolName, operation)) {
-      return { code: 'unsupported_operation', message: 'Device RPC only allows read_file, glob, and grep.' };
+    if (!operation || !isRemoteDeviceRpcTool(toolName, operation)) {
+      return { code: 'unsupported_operation', message: 'Device RPC only allows read_file, glob, grep, write_file, and edit_file.' };
     }
 
     const requiredFields: Array<[keyof CatsDeviceRpcMessage, string]> = [
@@ -422,6 +455,7 @@ export class CatsCompanyBot {
       ['topic_id', 'topic_id'],
       ['topic_type', 'topic_type'],
       ['actor_user_id', 'actor_user_id'],
+      ['owner_user_id', 'owner_user_id'],
       ['device_id', 'device_id'],
     ];
     for (const [field, label] of requiredFields) {
@@ -429,15 +463,26 @@ export class CatsCompanyBot {
         return { code: 'invalid_request', message: `Device RPC request missing ${label}.` };
       }
     }
+    const actorUserID = String(request.actor_user_id || '').trim();
+    const ownerUserID = String(request.owner_user_id || '').trim();
+    if (ownerUserID !== actorUserID && String(request.identity_source || '').trim() !== 'channel_identity_link') {
+      return { code: 'invalid_request', message: 'Delegated Device RPC request missing channel_identity_link identity source.' };
+    }
     if (typeof request.expires_at === 'number' && Date.now() > request.expires_at) {
       return { code: 'request_expired', message: 'Device RPC request has expired.' };
     }
     return undefined;
   }
 
-  private normalizeDeviceRpcReadonlyOperation(value: unknown): DeviceGrantOperation | undefined {
+  private normalizeDeviceRpcOperation(value: unknown): DeviceGrantOperation | undefined {
     const operation = String(value || '').trim();
-    if (operation === 'read_file' || operation === 'glob' || operation === 'grep') {
+    if (
+      operation === 'read_file'
+      || operation === 'glob'
+      || operation === 'grep'
+      || operation === 'write_file'
+      || operation === 'edit_file'
+    ) {
       return operation;
     }
     return undefined;
@@ -542,7 +587,7 @@ export class CatsCompanyBot {
     return channel;
   }
 
-  private buildSessionCallbacks(topic: string): SessionCallbacks {
+  private buildSessionCallbacks(topic: string, opts?: { sessionKey?: string; senderId?: string }): SessionCallbacks {
     return {
       onRetry: async (attempt, maxRetries) => {
         try {
@@ -606,6 +651,9 @@ export class CatsCompanyBot {
           Logger.warning(`前端通知发送失败 (tool_result): ${err.message}`);
         }
       },
+      confirmToolExecution: opts?.sessionKey && opts?.senderId
+        ? (request) => this.confirmCatsCoToolExecution(topic, opts.sessionKey!, opts.senderId!, request)
+        : undefined,
     };
   }
 
@@ -773,7 +821,7 @@ export class CatsCompanyBot {
         localFileGrants,
         runtimeFeedback,
         pendingUserInputProvider: () => this.consumeQueuedUserInput(key, msg.executionScope),
-        callbacks: this.buildSessionCallbacks(msg.topic),
+        callbacks: this.buildSessionCallbacks(msg.topic, { sessionKey: key, senderId: msg.senderId }),
       });
 
       // 最终文本回复
@@ -1139,7 +1187,7 @@ export class CatsCompanyBot {
       const result = msg.source === 'subagent_feedback'
         ? await session.handleRuntimeObservation(msg.userMessage as string, {
           channel,
-          callbacks: this.buildSessionCallbacks(msg.topic),
+          callbacks: this.buildSessionCallbacks(msg.topic, { sessionKey, senderId: msg.senderId }),
           source: 'subagent_result',
           executionScope: msg.executionScope,
           localDeviceGrant: this.localDeviceGrant,
@@ -1156,7 +1204,7 @@ export class CatsCompanyBot {
           runtimeFeedback: msg.runtimeFeedback,
           localFileGrants: msg.localFileGrants,
           pendingUserInputProvider: () => this.consumeQueuedUserInput(sessionKey, msg.executionScope),
-          callbacks: this.buildSessionCallbacks(msg.topic),
+          callbacks: this.buildSessionCallbacks(msg.topic, { sessionKey, senderId: msg.senderId }),
         });
       if (result.text.startsWith('处理消息时出错:')) {
         try {
@@ -1390,6 +1438,83 @@ export class CatsCompanyBot {
       '如果任务不明确，先提出一个最小澄清问题；如果任务足够明确，再自行执行。',
       this.formatAttachmentContext(attachments),
     ].join('\n');
+  }
+
+  private async confirmCatsCoToolExecution(
+    topic: string,
+    sessionKey: string,
+    senderId: string,
+    request: ToolExecutionConfirmationRequest,
+  ): Promise<ToolExecutionConfirmationResult> {
+    const prompt = this.formatToolConfirmationPrompt(request);
+    try {
+      await this.sender.reply(topic, prompt);
+    } catch (err: any) {
+      Logger.warning(`工具确认请求发送失败: ${err?.message || err}`);
+      return { approved: false, reason: '无法发送工具确认请求，已取消本次操作。' };
+    }
+
+    const answer = await new Promise<string>((resolve) => {
+      this.registerPendingAnswer(sessionKey, topic, senderId, resolve);
+    });
+    const decision = this.parseToolConfirmationAnswer(answer);
+    if (decision === 'approve') return true;
+    if (decision === 'deny') {
+      return { approved: false, reason: '用户未确认该工具操作，已取消。' };
+    }
+    return { approved: false, reason: '未收到明确确认，已取消该工具操作。' };
+  }
+
+  private formatToolConfirmationPrompt(request: ToolExecutionConfirmationRequest): string {
+    const riskLabel = request.risk === 'high' ? '高' : request.risk === 'medium' ? '中' : '低';
+    const target = this.formatToolConfirmationTarget(request.args);
+    return [
+      `需要你确认后才能继续执行 ${request.toolName}。`,
+      `风险等级：${riskLabel}`,
+      target ? `操作对象：${target}` : '',
+      request.reason,
+      '请只回复“同意”或“确认执行”继续；回复“取消”或“不确认”则不会执行。',
+    ].filter(Boolean).join('\n');
+  }
+
+  private formatToolConfirmationTarget(args: unknown): string {
+    if (!args || typeof args !== 'object' || Array.isArray(args)) return '';
+    const record = args as Record<string, unknown>;
+    const preferredKeys = ['file_path', 'path', 'target', 'command', 'pattern', 'description'];
+    for (const key of preferredKeys) {
+      const value = record[key];
+      if (typeof value === 'string' && value.trim()) {
+        return `${key}=${this.truncateConfirmationValue(value.trim())}`;
+      }
+    }
+    try {
+      return this.truncateConfirmationValue(JSON.stringify(record));
+    } catch {
+      return '';
+    }
+  }
+
+  private truncateConfirmationValue(value: string): string {
+    return value.length <= 160 ? value : `${value.slice(0, 157)}...`;
+  }
+
+  private parseToolConfirmationAnswer(answer: string): 'approve' | 'deny' | 'unknown' {
+    const text = String(answer || '').trim().toLowerCase().replace(/[。.!！\s]+$/g, '');
+    if (!text || text.includes('未在120秒内回复')) return 'unknown';
+    if (/^(取消|不同意|拒绝|不要|不行|否|no|n|cancel|deny|denied)$/i.test(text)
+      || /不\s*确认/.test(text)
+      || /不是\s*确认/.test(text)
+      || /别\s*执行/.test(text)
+      || /不要\s*执行/.test(text)
+      || text.includes('取消')
+      || text.includes('不同意')
+      || text.includes('拒绝')) {
+      return 'deny';
+    }
+    if (/^(同意|确认|确认执行|可以|可以继续|继续|继续执行|执行|yes|y|ok|approve|approved)$/i.test(text)) {
+      return 'approve';
+    }
+    return 'unknown';
   }
 
   private registerPendingAnswer(

--- a/src/catscompany/local-file-grants.ts
+++ b/src/catscompany/local-file-grants.ts
@@ -33,7 +33,7 @@ export function createCatsCoLocalDeviceGrant(input: CatsCoDeviceGrantInput): Sco
   return {
     kind: 'catscompany_body',
     source: 'catscompany',
-    ownerUserId: safeString(input.ownerUserId),
+    ownerUserId: normalizeCatsCoUserId(input.ownerUserId),
     bodyId,
     installationId: safeString(input.installationId),
     deviceId: safeString(input.deviceId),
@@ -115,4 +115,10 @@ function safeString(value: unknown): string | undefined {
   if (typeof value !== 'string') return undefined;
   const text = value.trim();
   return text || undefined;
+}
+
+function normalizeCatsCoUserId(value: unknown): string | undefined {
+  const text = safeString(value);
+  if (!text) return undefined;
+  return /^\d+$/.test(text) ? `usr${text}` : text;
 }

--- a/src/catscompany/local-file-grants.ts
+++ b/src/catscompany/local-file-grants.ts
@@ -15,6 +15,8 @@ export interface CatsCoDeviceGrantInput {
   bodyId?: string;
   installationId?: string;
   deviceId?: string;
+  ownerUserId?: string;
+  capabilities?: ScopedLocalDeviceGrant['capabilities'];
 }
 
 export interface CatsCoAttachmentGrantInput {
@@ -31,9 +33,11 @@ export function createCatsCoLocalDeviceGrant(input: CatsCoDeviceGrantInput): Sco
   return {
     kind: 'catscompany_body',
     source: 'catscompany',
+    ownerUserId: safeString(input.ownerUserId),
     bodyId,
     installationId: safeString(input.installationId),
     deviceId: safeString(input.deviceId),
+    capabilities: input.capabilities,
     createdAt: Date.now(),
   };
 }

--- a/src/catscompany/runtime-config.ts
+++ b/src/catscompany/runtime-config.ts
@@ -123,6 +123,7 @@ export function resolveCatsCoRuntimeConfig(
   const apiKey = proposedBotBinding || confirmedLocalBotBinding ? rawApiKey : undefined;
   const bodyId = localConfig.device?.bodyId;
   const installationId = localConfig.device?.installationId || bodyId;
+  const ownerUserId = firstNonEmpty(localConfig.currentBot?.boundByUserUid, auth.uid);
 
   const missing: CatsCoRuntimeMissingField[] = [];
   if (!serverUrl) missing.push('serverUrl');
@@ -137,6 +138,7 @@ export function resolveCatsCoRuntimeConfig(
       apiKey,
       bodyId,
       installationId,
+      ownerUserId,
       deviceName: localConfig.device?.name,
       httpBaseUrl,
       sessionTTL: config.catscompany?.sessionTTL,

--- a/src/catscompany/types.ts
+++ b/src/catscompany/types.ts
@@ -12,6 +12,8 @@ export interface CatsCompanyConfig {
   bodyId?: string;
   /** 当前安装/设备 ID，默认与 bodyId 相同 */
   installationId?: string;
+  /** 当前本机设备归属的 CatsCo 用户 uid，用于区分本地自用与外部委托 */
+  ownerUserId?: string;
   /** 用户可见设备名，用于 Dashboard 展示和服务端设备选择 */
   deviceName?: string;
   /** HTTP 基础地址（用于文件上传），默认从 serverUrl 推导 */

--- a/src/core/device-grants.ts
+++ b/src/core/device-grants.ts
@@ -45,6 +45,16 @@ export interface ResolveDeviceGrantOptions {
   now?: number;
 }
 
+const DELEGATED_DEVICE_GRANT_IDENTITY_SOURCES = new Set([
+  'channel_identity_link',
+]);
+
+export function isDelegatedDeviceGrant(grant: Pick<ScopedDeviceGrant, 'identityTrust' | 'identitySource' | 'ownerUserId' | 'actorUserId'>): boolean {
+  return grant.identityTrust === 'server_canonical'
+    && grant.ownerUserId !== grant.actorUserId
+    && DELEGATED_DEVICE_GRANT_IDENTITY_SOURCES.has(String(grant.identitySource || ''));
+}
+
 export function createUserDevice(input: CreateUserDeviceInput): UserDevice | undefined {
   const source = normalizeSource(input.source);
   const ownerUserId = normalizeId(input.ownerUserId);
@@ -188,7 +198,7 @@ export function validateDeviceGrant(
     ['agentBodyId', grant.agentBodyId, scope.agentBodyId],
   ].filter(([, grantValue, scopeValue]) => grantValue !== scopeValue);
 
-  if (grant.ownerUserId !== scope.actorUserId) {
+  if (grant.ownerUserId !== scope.actorUserId && !isDelegatedDeviceGrant(grant)) {
     mismatches.push(['ownerUserId', grant.ownerUserId, scope.actorUserId]);
   }
 

--- a/src/core/sub-agent-session.ts
+++ b/src/core/sub-agent-session.ts
@@ -442,15 +442,16 @@ export class SubAgentSession {
       '请回复“确认/允许/yes”批准，或回复其他内容取消。',
     ].filter(Boolean).join('\n');
     const answer = await this.waitForParentInput(question);
-    const normalized = String(answer || '').trim().toLowerCase();
-    const approved = normalized === 'y'
-      || normalized === 'yes'
-      || normalized === 'ok'
-      || normalized === 'approve'
-      || normalized.includes('确认')
-      || normalized.includes('允许')
-      || normalized.includes('同意')
-      || normalized.includes('批准');
+    const normalized = String(answer || '').trim().toLowerCase().replace(/[。.!！\s]+$/g, '');
+    const denied = /^(取消|不同意|拒绝|不要|不行|否|no|n|cancel|deny|denied)$/i.test(normalized)
+      || /不\s*确认/.test(normalized)
+      || /不是\s*确认/.test(normalized)
+      || /别\s*执行/.test(normalized)
+      || /不要\s*执行/.test(normalized)
+      || normalized.includes('取消')
+      || normalized.includes('不同意')
+      || normalized.includes('拒绝');
+    const approved = !denied && /^(y|yes|ok|approve|approved|确认|确认执行|允许|允许执行|同意|批准|继续|继续执行)$/i.test(normalized);
     return approved
       ? { approved: true }
       : { approved: false, reason: `主会话未确认 ${request.toolName}，已取消。` };

--- a/src/tools/device-rpc-tool.ts
+++ b/src/tools/device-rpc-tool.ts
@@ -11,20 +11,26 @@ export function isRemoteReadonlyTool(toolName: string, operation: DeviceGrantOpe
     || (toolName === 'grep' && operation === 'grep');
 }
 
-export async function executeRemoteReadonlyTool(
+export function isRemoteDeviceRpcTool(toolName: string, operation: DeviceGrantOperation): boolean {
+  return isRemoteReadonlyTool(toolName, operation)
+    || (toolName === 'write_file' && operation === 'write_file')
+    || (toolName === 'edit_file' && operation === 'edit_file');
+}
+
+export async function executeRemoteDeviceRpcTool(
   context: ToolExecutionContext,
   gateway: ToolGatewayDecision,
-  toolName: 'read_file' | 'glob' | 'grep',
+  toolName: 'read_file' | 'glob' | 'grep' | 'write_file' | 'edit_file',
   operation: DeviceGrantOperation,
   args: Record<string, unknown>,
 ): Promise<ToolExecutionResult | undefined> {
   if (!gateway.ok || gateway.mode !== 'remote') return undefined;
 
-  if (!isRemoteReadonlyTool(toolName, operation)) {
+  if (!isRemoteDeviceRpcTool(toolName, operation)) {
     return {
       ok: false,
       errorCode: 'PERMISSION_DENIED',
-      message: `远程设备 RPC 当前只允许 read_file / glob / grep，已阻止 ${toolName}。`,
+      message: `远程设备 RPC 当前只允许 read_file / glob / grep / write_file / edit_file，已阻止 ${toolName}。`,
     };
   }
 
@@ -52,6 +58,16 @@ export async function executeRemoteReadonlyTool(
       retryable: isRetryableRpcError(error),
     };
   }
+}
+
+export async function executeRemoteReadonlyTool(
+  context: ToolExecutionContext,
+  gateway: ToolGatewayDecision,
+  toolName: 'read_file' | 'glob' | 'grep',
+  operation: DeviceGrantOperation,
+  args: Record<string, unknown>,
+): Promise<ToolExecutionResult | undefined> {
+  return executeRemoteDeviceRpcTool(context, gateway, toolName, operation, args);
 }
 
 export function normalizeDeviceRpcToolResultPayload(payload: unknown): ToolExecutionResult {

--- a/src/tools/edit-tool.ts
+++ b/src/tools/edit-tool.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import { isToolAllowed, isPathAllowed } from '../utils/safety';
 import { formatCatsCoVisiblePath, resolveToolGatewayAccess } from './tool-gateway';
+import { executeRemoteDeviceRpcTool } from './device-rpc-tool';
 
 /**
  * Edit 工具 - 精确字符串替换
@@ -62,6 +63,8 @@ export class EditTool implements Tool {
     if (!gateway.ok) {
       return { ok: false, errorCode: gateway.errorCode, message: gateway.message };
     }
+    const remoteResult = await executeRemoteDeviceRpcTool(context, gateway, 'edit_file', 'edit_file', args);
+    if (remoteResult) return remoteResult;
     const displayPath = formatCatsCoVisiblePath(context, file_path, { preserveRelative: true });
 
     // 检查文件是否存在

--- a/src/tools/local-tool-risk.ts
+++ b/src/tools/local-tool-risk.ts
@@ -1,6 +1,7 @@
 import type { ToolExecutionContext, ToolExecutionResult, ToolRiskLevel } from '../types/tool';
-import { isCatsCoToolGatewayContext } from './tool-gateway';
+import { isCatsCoLocalOwnerSelfContext } from './tool-gateway';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 
 export interface LocalToolRiskDecision {
@@ -81,9 +82,6 @@ export function classifyLocalToolRisk(
   args: unknown,
   context: ToolExecutionContext,
 ): LocalToolRiskDecision {
-  if (isCatsCoToolGatewayContext(context)) {
-    return { requiresConfirmation: false, risk: 'low', reason: 'CatsCo 会话由服务端 device grant 控制。' };
-  }
   if (LOW_RISK_TOOLS.has(toolName)) {
     return { requiresConfirmation: false, risk: 'low', reason: '只读或状态类工具。' };
   }
@@ -199,6 +197,14 @@ function classifyWritePathRisk(toolName: string, value: string, context: ToolExe
   const workspaceRoot = context.workspaceRoot || workingDirectory;
   const resolved = path.resolve(workingDirectory, target);
   if (looksSensitivePath(resolved)) return 'high';
+  if (
+    isCatsCoLocalOwnerSelfContext(context)
+    && toolName === 'write_file'
+    && !fs.existsSync(resolved)
+    && isWithin(resolved, os.homedir())
+  ) {
+    return 'low';
+  }
   if (!isWithin(resolved, workspaceRoot)) return 'high';
   if (toolName === 'write_file' && !fs.existsSync(resolved)) return 'low';
   return 'medium';

--- a/src/tools/local-tool-risk.ts
+++ b/src/tools/local-tool-risk.ts
@@ -86,6 +86,10 @@ export function classifyLocalToolRisk(
     return { requiresConfirmation: false, risk: 'low', reason: '只读或状态类工具。' };
   }
 
+  if (isCatsCoLocalOwnerSelfContext(context)) {
+    return { requiresConfirmation: false, risk: 'low', reason: 'CatsCo 本地 owner 自用场景允许直接执行本机工具。' };
+  }
+
   if (toolName === 'read_file' || toolName === 'glob' || toolName === 'grep') {
     const pathRisk = classifyReadTargetsRisk(readonlyToolTargets(toolName, args), context);
     if (pathRisk === 'low') {

--- a/src/tools/tool-gateway.ts
+++ b/src/tools/tool-gateway.ts
@@ -1,6 +1,6 @@
 import type { DeviceGrantOperation, ScopedDeviceGrant, ScopedDeviceSelection, ScopedLocalDeviceGrant } from '../types/session-identity';
 import type { ToolErrorCode, ToolExecutionContext } from '../types/tool';
-import { resolveDeviceGrant } from '../core/device-grants';
+import { isDelegatedDeviceGrant, resolveDeviceGrant } from '../core/device-grants';
 
 export type ToolGatewayDecision =
   | {
@@ -33,10 +33,21 @@ export interface CatsCoVisiblePathOptions {
   preserveRelative?: boolean;
 }
 
-const REMOTE_READONLY_OPERATIONS = new Set<DeviceGrantOperation>(['read_file', 'glob', 'grep']);
+const REMOTE_DEVICE_RPC_OPERATIONS = new Set<DeviceGrantOperation>(['read_file', 'glob', 'grep', 'write_file', 'edit_file']);
 
 export function isCatsCoToolGatewayContext(context: ToolExecutionContext): boolean {
   return context.surface === 'catscompany' || context.executionScope?.source === 'catscompany';
+}
+
+export function isCatsCoLocalOwnerSelfContext(context: ToolExecutionContext): boolean {
+  if (!isCatsCoToolGatewayContext(context)) return false;
+  const scope = context.executionScope;
+  const localDevice = context.localDeviceGrant;
+  if (!scope || scope.source !== 'catscompany' || scope.identityTrust !== 'server_canonical' || !scope.isTrusted) {
+    return false;
+  }
+  const ownerUserId = localDevice?.ownerUserId;
+  return Boolean(ownerUserId && ownerUserId === scope.actorUserId);
 }
 
 export function formatCatsCoVisiblePath(
@@ -76,13 +87,6 @@ export function resolveToolGatewayAccess(
     return { ok: true, mode: 'local' };
   }
 
-  if (options.operation === 'execute_shell' && !options.allowCatsCoShell) {
-    return denied([
-      'CatsCo 会话暂不允许通过 execute_shell 直接操作本机命令行。',
-      '当前 PR 只开放文件级设备授权；命令执行需要后续独立审批和更细的命令策略。',
-    ], options.targetLabel);
-  }
-
   const scope = context.executionScope;
   if (!scope || scope.source !== 'catscompany') {
     return denied(['当前工具调用缺少 CatsCo 执行身份，已阻止本地设备操作。'], options.targetLabel);
@@ -97,6 +101,14 @@ export function resolveToolGatewayAccess(
     return denied(['当前运行体缺少 CatsCo 本机设备绑定，已阻止本地设备操作。'], options.targetLabel);
   }
 
+  const localOwnerSelf = isCatsCoLocalOwnerSelfContext(context);
+  if (options.operation === 'execute_shell' && !localOwnerSelf && !options.allowCatsCoShell) {
+    return denied([
+      'CatsCo 会话暂不允许外部用户或远程委托通过 execute_shell 操作命令行。',
+      '命令执行只允许本机 owner 自用场景在用户确认后执行。',
+    ], options.targetLabel);
+  }
+
   const selectionScope = validateSelectionScope(context.deviceSelection, scope, options.targetLabel);
   if (!selectionScope.ok) return selectionScope;
 
@@ -105,10 +117,20 @@ export function resolveToolGatewayAccess(
     localDevice,
     options.operation,
     options.targetLabel,
+    { allowLocalSelfOperation: localOwnerSelf },
   );
   if (!selectedTarget.ok) return selectedTarget;
 
   const targetDeviceId = selectedTarget.deviceId || localDevice.deviceId || localDevice.installationId || localDevice.bodyId;
+  if (selectedTarget.mode === 'local' && localOwnerSelf) {
+    return {
+      ok: true,
+      mode: 'local',
+      targetDeviceId,
+      targetDeviceDisplayName: selectedTarget.displayName,
+    };
+  }
+
   const decision = resolveDeviceGrant(context, {
     operation: options.operation,
     deviceId: targetDeviceId,
@@ -122,10 +144,10 @@ export function resolveToolGatewayAccess(
 
   const grant = decision.grant;
   if (selectedTarget.mode === 'remote') {
-    if (!REMOTE_READONLY_OPERATIONS.has(options.operation)) {
+    if (!REMOTE_DEVICE_RPC_OPERATIONS.has(options.operation)) {
       return denied([
         `后端选定的用户设备不是当前运行体，但 ${options.operation} 还没有开放远程执行。`,
-        '当前 PR 只开放 read_file / glob / grep 三个只读远程工具。',
+        '当前只开放 read_file / glob / grep / write_file / edit_file 文件级远程工具；命令执行不走远程 RPC。',
       ], options.targetLabel);
     }
     if (!context.deviceRpc) {
@@ -144,6 +166,18 @@ export function resolveToolGatewayAccess(
       targetDeviceBodyId: selectedTarget.bodyId,
       targetDeviceInstallationId: selectedTarget.installationId,
     };
+  }
+
+  if (localDevice.ownerUserId && grant.ownerUserId !== localDevice.ownerUserId) {
+    return denied([
+      '设备授权归属与当前本机 owner 不一致，已阻止本地设备操作以避免他人会话误操作本机。',
+      `owner: grant=${grant.ownerUserId || '(empty)'} local=${localDevice.ownerUserId}`,
+    ], options.targetLabel);
+  }
+  if (grant.ownerUserId !== grant.actorUserId && !isDelegatedDeviceGrant(grant)) {
+    return denied([
+      '跨用户设备授权缺少服务端委托标记，已阻止本地设备操作。',
+    ], options.targetLabel);
   }
 
   const mismatches: string[] = [];
@@ -191,6 +225,7 @@ function resolveBackendSelectedDevice(
   localDevice: ScopedLocalDeviceGrant,
   operation: DeviceGrantOperation,
   targetLabel?: string,
+  options: { allowLocalSelfOperation?: boolean } = {},
 ): SelectedDeviceDecision {
   if (!selection) {
     return {
@@ -218,6 +253,24 @@ function resolveBackendSelectedDevice(
     return selectedDenied(['后端设备选择缺少 selectedDeviceId，已阻止本地设备操作。'], targetLabel);
   }
 
+  if (matchesLocalDevice(selection, localDevice)) {
+    if (!options.allowLocalSelfOperation
+      && Array.isArray(selection.selectedDeviceOperations)
+      && selection.selectedDeviceOperations.length > 0
+      && !selection.selectedDeviceOperations.includes(operation)) {
+      return selectedDenied([
+        `后端选定设备没有声明支持 ${operation}，已阻止设备工具调用。`,
+        selection.selectedDeviceDisplayName ? `Selected device: ${selection.selectedDeviceDisplayName}` : '',
+      ], targetLabel);
+    }
+    return {
+      ok: true,
+      mode: 'local',
+      deviceId: selectedDeviceId,
+      displayName: selection.selectedDeviceDisplayName,
+    };
+  }
+
   if (Array.isArray(selection.selectedDeviceOperations)
     && selection.selectedDeviceOperations.length > 0
     && !selection.selectedDeviceOperations.includes(operation)) {
@@ -225,15 +278,6 @@ function resolveBackendSelectedDevice(
       `后端选定设备没有声明支持 ${operation}，已阻止设备工具调用。`,
       selection.selectedDeviceDisplayName ? `Selected device: ${selection.selectedDeviceDisplayName}` : '',
     ], targetLabel);
-  }
-
-  if (matchesLocalDevice(selection, localDevice)) {
-    return {
-      ok: true,
-      mode: 'local',
-      deviceId: selectedDeviceId,
-      displayName: selection.selectedDeviceDisplayName,
-    };
   }
 
   return {

--- a/src/tools/tool-gateway.ts
+++ b/src/tools/tool-gateway.ts
@@ -105,7 +105,7 @@ export function resolveToolGatewayAccess(
   if (options.operation === 'execute_shell' && !localOwnerSelf && !options.allowCatsCoShell) {
     return denied([
       'CatsCo 会话暂不允许外部用户或远程委托通过 execute_shell 操作命令行。',
-      '命令执行只允许本机 owner 自用场景在用户确认后执行。',
+      '命令执行只允许本机 owner 自用场景直接执行。',
     ], options.targetLabel);
   }
 

--- a/src/tools/tool-gateway.ts
+++ b/src/tools/tool-gateway.ts
@@ -47,7 +47,7 @@ export function isCatsCoLocalOwnerSelfContext(context: ToolExecutionContext): bo
     return false;
   }
   const ownerUserId = localDevice?.ownerUserId;
-  return Boolean(ownerUserId && ownerUserId === scope.actorUserId);
+  return sameCatsCoUserId(ownerUserId, scope.actorUserId);
 }
 
 export function formatCatsCoVisiblePath(
@@ -168,7 +168,7 @@ export function resolveToolGatewayAccess(
     };
   }
 
-  if (localDevice.ownerUserId && grant.ownerUserId !== localDevice.ownerUserId) {
+  if (localDevice.ownerUserId && !sameCatsCoUserId(grant.ownerUserId, localDevice.ownerUserId)) {
     return denied([
       '设备授权归属与当前本机 owner 不一致，已阻止本地设备操作以避免他人会话误操作本机。',
       `owner: grant=${grant.ownerUserId || '(empty)'} local=${localDevice.ownerUserId}`,
@@ -357,4 +357,16 @@ function looksLikeAbsoluteLocalPath(value: string): boolean {
     || /^\\\\/.test(value)
     || /^\//.test(value)
     || /^~[\\/]/.test(value);
+}
+
+function sameCatsCoUserId(left: string | undefined, right: string | undefined): boolean {
+  const normalizedLeft = normalizeCatsCoUserId(left);
+  const normalizedRight = normalizeCatsCoUserId(right);
+  return Boolean(normalizedLeft && normalizedRight && normalizedLeft === normalizedRight);
+}
+
+function normalizeCatsCoUserId(value: string | undefined): string {
+  const text = String(value || '').trim();
+  if (!text) return '';
+  return /^\d+$/.test(text) ? `usr${text}` : text;
 }

--- a/src/tools/write-tool.ts
+++ b/src/tools/write-tool.ts
@@ -4,6 +4,7 @@ import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from 
 import { Logger } from '../utils/logger';
 import { isToolAllowed, isPathAllowed } from '../utils/safety';
 import { formatCatsCoVisiblePath, resolveToolGatewayAccess } from './tool-gateway';
+import { executeRemoteDeviceRpcTool } from './device-rpc-tool';
 
 /**
  * Write 工具 - 写入文件内容
@@ -54,6 +55,8 @@ export class WriteTool implements Tool {
     if (!gateway.ok) {
       return { ok: false, errorCode: gateway.errorCode, message: gateway.message };
     }
+    const remoteResult = await executeRemoteDeviceRpcTool(context, gateway, 'write_file', 'write_file', args);
+    if (remoteResult) return remoteResult;
 
     // 获取相对路径用于显示
     const relativePath = path.relative(context.workingDirectory, absolutePath);

--- a/src/types/session-identity.ts
+++ b/src/types/session-identity.ts
@@ -89,9 +89,11 @@ export type DeviceGrantOperation =
 export interface ScopedLocalDeviceGrant {
   kind: 'catscompany_body';
   source: MessageSource;
+  ownerUserId?: string;
   bodyId: string;
   installationId?: string;
   deviceId?: string;
+  capabilities?: DeviceGrantOperation[];
   createdAt: number;
 }
 

--- a/tests/catscompany-device-rpc-tools.test.ts
+++ b/tests/catscompany-device-rpc-tools.test.ts
@@ -11,6 +11,7 @@ function botWithDevice(captured: { result?: any }): any {
   bot.localDeviceGrant = {
     kind: 'catscompany_body',
     source: 'catscompany',
+    ownerUserId: 'usr7',
     bodyId: 'body-device',
     installationId: 'install-device',
     deviceId: 'install-device',
@@ -33,6 +34,8 @@ function request(overrides: Partial<CatsDeviceRpcMessage> = {}): CatsDeviceRpcMe
     topic_id: 'p2p_7_43',
     topic_type: 'p2p',
     actor_user_id: 'usr7',
+    owner_user_id: 'usr7',
+    identity_source: 'metadata.catsco_identity',
     agent_id: 'usr43',
     agent_body_id: 'body-agent',
     device_id: 'install-device',
@@ -73,7 +76,7 @@ function serverGrant(overrides: Partial<ScopedDeviceGrant> = {}): ScopedDeviceGr
   };
 }
 
-describe('CatsCompany Device RPC readonly tools', () => {
+describe('CatsCompany Device RPC file tools', () => {
   test('maps CatsCo server grant fields into outbound readonly device_rpc requests', async () => {
     const captured: Array<{ request: any; timeoutMs?: number }> = [];
     const bot = Object.create(CatsCompanyBot.prototype) as any;
@@ -88,6 +91,8 @@ describe('CatsCompany Device RPC readonly tools', () => {
           topic_id: requestPayload.topic_id,
           topic_type: requestPayload.topic_type,
           actor_user_id: requestPayload.actor_user_id,
+          owner_user_id: requestPayload.owner_user_id,
+          identity_source: requestPayload.identity_source,
           agent_id: requestPayload.agent_id,
           agent_body_id: requestPayload.agent_body_id,
           device_id: requestPayload.device_id,
@@ -141,6 +146,8 @@ describe('CatsCompany Device RPC readonly tools', () => {
     assert.equal(first.topic_id, grant.topicId);
     assert.equal(first.topic_type, grant.topicType);
     assert.equal(first.actor_user_id, grant.actorUserId);
+    assert.equal(first.owner_user_id, grant.ownerUserId);
+    assert.equal(first.identity_source, grant.identitySource);
     assert.equal(first.agent_id, grant.agentId);
     assert.equal(first.agent_body_id, grant.agentBodyId);
     assert.equal(first.device_id, grant.deviceId);
@@ -171,7 +178,109 @@ describe('CatsCompany Device RPC readonly tools', () => {
     assert.equal(captured.result.device_id, 'install-device');
   });
 
-  test('rejects non-readonly Device RPC operations before local tool execution', async () => {
+  test('executes write_file on the target local device when RPC scope is valid', async () => {
+    const captured: { result?: any } = {};
+    const bot = botWithDevice(captured);
+    const tmpRoot = path.join(process.cwd(), 'tmp');
+    fs.mkdirSync(tmpRoot, { recursive: true });
+    const dir = fs.mkdtempSync(path.join(tmpRoot, 'device-rpc-write-'));
+    const filePath = path.join(dir, 'created.txt');
+
+    await bot.handleDeviceRpcRequest(request({
+      request_id: 'rpc-write-1',
+      operation: 'write_file',
+      tool_name: 'write_file',
+      payload: { args: { file_path: filePath, content: 'hello from rpc' } },
+    }));
+
+    assert.ok(captured.result);
+    assert.equal(captured.result.error, undefined);
+    assert.equal(captured.result.result.ok, true);
+    assert.equal(fs.readFileSync(filePath, 'utf8'), 'hello from rpc');
+  });
+
+  test('executes edit_file on the target local device when RPC scope is valid', async () => {
+    const captured: { result?: any } = {};
+    const bot = botWithDevice(captured);
+    const tmpRoot = path.join(process.cwd(), 'tmp');
+    fs.mkdirSync(tmpRoot, { recursive: true });
+    const dir = fs.mkdtempSync(path.join(tmpRoot, 'device-rpc-edit-'));
+    const filePath = path.join(dir, 'edit.txt');
+    fs.writeFileSync(filePath, 'before');
+
+    await bot.handleDeviceRpcRequest(request({
+      request_id: 'rpc-edit-1',
+      operation: 'edit_file',
+      tool_name: 'edit_file',
+      payload: { args: { file_path: filePath, old_string: 'before', new_string: 'after' } },
+    }));
+
+    assert.ok(captured.result);
+    assert.equal(captured.result.error, undefined);
+    assert.equal(captured.result.result.ok, true);
+    assert.equal(fs.readFileSync(filePath, 'utf8'), 'after');
+  });
+
+  test('rejects Device RPC requests missing owner identity', async () => {
+    const captured: { result?: any } = {};
+    const bot = botWithDevice(captured);
+
+    await bot.handleDeviceRpcRequest(request({
+      request_id: 'rpc-missing-owner-1',
+      owner_user_id: '',
+      operation: 'write_file',
+      tool_name: 'write_file',
+      payload: { args: { file_path: path.join(process.cwd(), 'tmp', 'missing-owner.txt'), content: 'nope' } },
+    }));
+
+    assert.ok(captured.result);
+    assert.equal(captured.result.result, undefined);
+    assert.equal(captured.result.error.code, 'invalid_request');
+    assert.match(captured.result.error.message, /owner_user_id/);
+  });
+
+  test('rejects Device RPC requests for a different device owner', async () => {
+    const captured: { result?: any } = {};
+    const bot = botWithDevice(captured);
+    const filePath = path.join(process.cwd(), 'tmp', 'wrong-owner.txt');
+
+    await bot.handleDeviceRpcRequest(request({
+      request_id: 'rpc-wrong-owner-1',
+      actor_user_id: 'usr8',
+      owner_user_id: 'usr8',
+      operation: 'write_file',
+      tool_name: 'write_file',
+      payload: { args: { file_path: filePath, content: 'nope' } },
+    }));
+
+    assert.ok(captured.result);
+    assert.equal(captured.result.result, undefined);
+    assert.equal(captured.result.error.code, 'PERMISSION_DENIED');
+    assert.match(captured.result.error.message, /owner 不一致|设备 owner/);
+    assert.equal(fs.existsSync(filePath), false);
+  });
+
+  test('rejects delegated Device RPC when owner and actor differ without channel identity source', async () => {
+    const captured: { result?: any } = {};
+    const bot = botWithDevice(captured);
+
+    await bot.handleDeviceRpcRequest(request({
+      request_id: 'rpc-bad-delegation-1',
+      actor_user_id: 'usr100',
+      owner_user_id: 'usr7',
+      identity_source: 'metadata.catsco_identity',
+      operation: 'write_file',
+      tool_name: 'write_file',
+      payload: { args: { file_path: path.join(process.cwd(), 'tmp', 'bad-delegated.txt'), content: 'nope' } },
+    }));
+
+    assert.ok(captured.result);
+    assert.equal(captured.result.result, undefined);
+    assert.equal(captured.result.error.code, 'invalid_request');
+    assert.match(captured.result.error.message, /channel_identity_link/);
+  });
+
+  test('rejects shell Device RPC operations before local tool execution', async () => {
     const captured: { result?: any } = {};
     const bot = botWithDevice(captured);
 
@@ -185,7 +294,7 @@ describe('CatsCompany Device RPC readonly tools', () => {
     assert.ok(captured.result);
     assert.equal(captured.result.result, undefined);
     assert.equal(captured.result.error.code, 'unsupported_operation');
-    assert.match(captured.result.error.message, /read_file, glob, and grep/);
+    assert.match(captured.result.error.message, /read_file, glob, grep, write_file, and edit_file/);
   });
 
   test('rejects Device RPC requests for another target device', async () => {

--- a/tests/catscompany-runtime-device-capabilities.test.ts
+++ b/tests/catscompany-runtime-device-capabilities.test.ts
@@ -1,0 +1,17 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import { CATSCOMPANY_FULL_RUNTIME_DEVICE_CAPABILITIES } from '../src/catscompany';
+
+describe('CatsCompany runtime device capabilities', () => {
+  test('full runtime advertises local file write capabilities', () => {
+    assert.deepEqual(CATSCOMPANY_FULL_RUNTIME_DEVICE_CAPABILITIES, [
+      'read_file',
+      'glob',
+      'grep',
+      'write_file',
+      'edit_file',
+      'send_file',
+    ]);
+    assert.equal(CATSCOMPANY_FULL_RUNTIME_DEVICE_CAPABILITIES.includes('execute_shell'), false);
+  });
+});

--- a/tests/catscompany-runtime-device-capabilities.test.ts
+++ b/tests/catscompany-runtime-device-capabilities.test.ts
@@ -3,7 +3,7 @@ import * as assert from 'node:assert';
 import { CATSCOMPANY_FULL_RUNTIME_DEVICE_CAPABILITIES } from '../src/catscompany';
 
 describe('CatsCompany runtime device capabilities', () => {
-  test('full runtime advertises local file write capabilities', () => {
+  test('full runtime advertises local owner self capabilities', () => {
     assert.deepEqual(CATSCOMPANY_FULL_RUNTIME_DEVICE_CAPABILITIES, [
       'read_file',
       'glob',
@@ -11,7 +11,7 @@ describe('CatsCompany runtime device capabilities', () => {
       'write_file',
       'edit_file',
       'send_file',
+      'execute_shell',
     ]);
-    assert.equal(CATSCOMPANY_FULL_RUNTIME_DEVICE_CAPABILITIES.includes('execute_shell'), false);
   });
 });

--- a/tests/catscompany-tool-confirmation.test.ts
+++ b/tests/catscompany-tool-confirmation.test.ts
@@ -1,0 +1,33 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import { CatsCompanyBot } from '../src/catscompany';
+
+describe('CatsCompany tool confirmation prompts', () => {
+  test('parses only explicit approval phrases as approval', () => {
+    const bot = Object.create(CatsCompanyBot.prototype) as any;
+
+    assert.equal(bot.parseToolConfirmationAnswer('确认执行'), 'approve');
+    assert.equal(bot.parseToolConfirmationAnswer('同意'), 'approve');
+    assert.equal(bot.parseToolConfirmationAnswer('我不确认'), 'deny');
+    assert.equal(bot.parseToolConfirmationAnswer('不是确认'), 'deny');
+    assert.equal(bot.parseToolConfirmationAnswer('别执行'), 'deny');
+    assert.equal(bot.parseToolConfirmationAnswer('确认一下是什么操作'), 'unknown');
+  });
+
+  test('includes operation target in confirmation prompt', () => {
+    const bot = Object.create(CatsCompanyBot.prototype) as any;
+    const prompt = bot.formatToolConfirmationPrompt({
+      toolName: 'write_file',
+      risk: 'medium',
+      reason: '工具会修改本机文件，需要用户确认。',
+      args: { file_path: 'C:/Users/Annika/Desktop/hello.txt', content: '你好' },
+      surface: 'catscompany',
+      workingDirectory: 'C:/Users/Annika',
+    });
+
+    assert.match(prompt, /write_file/);
+    assert.match(prompt, /风险等级：中/);
+    assert.match(prompt, /file_path=C:\/Users\/Annika\/Desktop\/hello\.txt/);
+    assert.match(prompt, /确认执行/);
+  });
+});

--- a/tests/tool-gateway-catsco.test.ts
+++ b/tests/tool-gateway-catsco.test.ts
@@ -548,7 +548,23 @@ describe('CatsCo ToolGateway', () => {
     assert.equal(fs.readFileSync(path.join(root, 'local.txt'), 'utf8'), 'before');
   });
 
-  test('blocks execute_shell in CatsCo sessions even when a grant contains execute_shell', async () => {
+  test('allows execute_shell for local owner self on the current device', async () => {
+    const root = makeWorkspace();
+    const result = await new ShellTool().execute({ command: 'echo catsco-shell-ok' }, context(root, {
+      localDeviceGrant: localDevice({
+        ownerUserId: 'usr7',
+        capabilities: ['read_file', 'glob', 'grep', 'write_file', 'edit_file', 'send_file', 'execute_shell'],
+      }),
+      deviceSelection: deviceSelection({
+        selectedDeviceOperations: ['read_file'],
+      }),
+    }));
+
+    assert.equal(result.ok, true);
+    if (result.ok) assert.match(result.content, /catsco-shell-ok/);
+  });
+
+  test('blocks execute_shell in external CatsCo sessions even when a grant contains execute_shell', async () => {
     const root = makeWorkspace();
     const result = await new ShellTool().execute({ command: 'echo hello' }, context(root, {
       deviceGrants: [deviceGrant(['execute_shell'])],

--- a/tests/tool-gateway-catsco.test.ts
+++ b/tests/tool-gateway-catsco.test.ts
@@ -41,6 +41,7 @@ function localDevice(overrides: Partial<ScopedLocalDeviceGrant> = {}): ScopedLoc
     bodyId: 'body-device',
     installationId: 'install-device',
     deviceId: 'install-device',
+    capabilities: ['read_file', 'glob', 'grep', 'write_file', 'edit_file', 'send_file'],
     createdAt: Date.now(),
     ...overrides,
   };
@@ -408,6 +409,145 @@ describe('CatsCo ToolGateway', () => {
     }
   });
 
+  test('allows local owner self to write on the current device without a short-lived grant', async () => {
+    const root = makeWorkspace();
+    const result = await new WriteTool().execute({ file_path: 'owner.txt', content: 'hello owner' }, context(root, {
+      localDeviceGrant: localDevice({ ownerUserId: 'usr7' }),
+      deviceSelection: deviceSelection({
+        selectedDeviceOperations: ['read_file', 'glob', 'grep'],
+      }),
+    }));
+
+    assert.equal(result.ok, true);
+    assert.equal(fs.readFileSync(path.join(root, 'owner.txt'), 'utf8'), 'hello owner');
+  });
+
+  test('rejects external actor grant that points at the local owner device without delegation', async () => {
+    const root = makeWorkspace();
+    const externalScope = scope({ actorUserId: 'usr100' });
+    const result = await new WriteTool().execute({ file_path: 'external.txt', content: 'nope' }, context(root, {
+      executionScope: externalScope,
+      localDeviceGrant: localDevice({ ownerUserId: 'usr7' }),
+      deviceGrants: [deviceGrant(['write_file'], {
+        sessionKey: externalScope.sessionKey,
+        topicId: externalScope.topicId,
+        topicType: externalScope.topicType,
+        actorUserId: externalScope.actorUserId,
+        ownerUserId: externalScope.actorUserId,
+        agentId: externalScope.agentId,
+        agentBodyId: externalScope.agentBodyId,
+      })],
+      deviceSelection: deviceSelection({
+        actorUserId: externalScope.actorUserId,
+        selectedDeviceOperations: ['write_file'],
+      }),
+    }));
+
+    assert.equal(result.ok, false);
+    if (!result.ok) assert.match(result.message, /owner 不一致/);
+    assert.equal(fs.existsSync(path.join(root, 'external.txt')), false);
+  });
+
+  test('allows server canonical delegated grant to operate the matching local owner device', async () => {
+    const root = makeWorkspace();
+    const delegatedScope = scope({ actorUserId: 'usr100' });
+    const result = await new WriteTool().execute({ file_path: 'delegated.txt', content: 'ok' }, context(root, {
+      executionScope: delegatedScope,
+      localDeviceGrant: localDevice({ ownerUserId: 'usr7' }),
+      deviceGrants: [deviceGrant(['write_file'], {
+        sessionKey: delegatedScope.sessionKey,
+        topicId: delegatedScope.topicId,
+        topicType: delegatedScope.topicType,
+        actorUserId: delegatedScope.actorUserId,
+        ownerUserId: 'usr7',
+        identitySource: 'channel_identity_link',
+        agentId: delegatedScope.agentId,
+        agentBodyId: delegatedScope.agentBodyId,
+      })],
+      deviceSelection: deviceSelection({
+        actorUserId: delegatedScope.actorUserId,
+        selectedDeviceOperations: ['write_file'],
+      }),
+    }));
+
+    assert.equal(result.ok, true);
+    assert.equal(fs.readFileSync(path.join(root, 'delegated.txt'), 'utf8'), 'ok');
+  });
+
+  test('allows write_file when the selected local device advertises write capability', async () => {
+    const root = makeWorkspace();
+    const result = await new WriteTool().execute({ file_path: 'out.txt', content: 'hello' }, context(root, {
+      deviceGrants: [deviceGrant(['write_file'])],
+      deviceSelection: deviceSelection({
+        selectedDeviceOperations: ['read_file', 'glob', 'grep', 'write_file', 'edit_file'],
+      }),
+    }));
+
+    assert.equal(result.ok, true);
+    assert.equal(fs.readFileSync(path.join(root, 'out.txt'), 'utf8'), 'hello');
+  });
+
+  test('routes remote write_file through Device RPC without local fallback', async () => {
+    const root = makeWorkspace();
+    const calls: any[] = [];
+    const result = await new WriteTool().execute({ file_path: 'remote.txt', content: 'from chat' }, context(root, {
+      deviceGrants: [deviceGrant(['write_file'], {
+        deviceId: 'remote-device',
+        deviceBodyId: 'remote-body',
+        deviceInstallationId: 'remote-install',
+      })],
+      deviceSelection: deviceSelection({
+        selectedDeviceId: 'remote-device',
+        selectedDeviceBodyId: 'remote-body',
+        selectedDeviceInstallationId: 'remote-install',
+        selectedDeviceOperations: ['write_file'],
+      }),
+      deviceRpc: {
+        executeTool: async request => {
+          calls.push(request);
+          return { ok: true, content: 'remote wrote file' };
+        },
+      },
+    }));
+
+    assert.equal(result.ok, true);
+    assert.equal(result.ok ? result.content : '', 'remote wrote file');
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].toolName, 'write_file');
+    assert.equal(fs.existsSync(path.join(root, 'remote.txt')), false);
+  });
+
+  test('routes remote edit_file through Device RPC without local fallback', async () => {
+    const root = makeWorkspace();
+    fs.writeFileSync(path.join(root, 'local.txt'), 'before');
+    const calls: any[] = [];
+    const result = await new EditTool().execute({ file_path: 'local.txt', old_string: 'before', new_string: 'after' }, context(root, {
+      deviceGrants: [deviceGrant(['edit_file'], {
+        deviceId: 'remote-device',
+        deviceBodyId: 'remote-body',
+        deviceInstallationId: 'remote-install',
+      })],
+      deviceSelection: deviceSelection({
+        selectedDeviceId: 'remote-device',
+        selectedDeviceBodyId: 'remote-body',
+        selectedDeviceInstallationId: 'remote-install',
+        selectedDeviceOperations: ['edit_file'],
+      }),
+      deviceRpc: {
+        executeTool: async request => {
+          calls.push(request);
+          return { ok: true, content: 'remote edited file' };
+        },
+      },
+    }));
+
+    assert.equal(result.ok, true);
+    assert.equal(result.ok ? result.content : '', 'remote edited file');
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].toolName, 'edit_file');
+    assert.equal(fs.readFileSync(path.join(root, 'local.txt'), 'utf8'), 'before');
+  });
+
   test('blocks execute_shell in CatsCo sessions even when a grant contains execute_shell', async () => {
     const root = makeWorkspace();
     const result = await new ShellTool().execute({ command: 'echo hello' }, context(root, {
@@ -417,7 +557,7 @@ describe('CatsCo ToolGateway', () => {
     assert.equal(result.ok, false);
     if (!result.ok) {
       assert.equal(result.errorCode, 'PERMISSION_DENIED');
-      assert.match(result.message, /暂不允许通过 execute_shell/);
+      assert.match(result.message, /暂不允许外部用户或远程委托通过 execute_shell/);
     }
   });
 });

--- a/tests/tool-gateway-catsco.test.ts
+++ b/tests/tool-gateway-catsco.test.ts
@@ -422,6 +422,19 @@ describe('CatsCo ToolGateway', () => {
     assert.equal(fs.readFileSync(path.join(root, 'owner.txt'), 'utf8'), 'hello owner');
   });
 
+  test('allows local owner self when saved local config has numeric owner id', async () => {
+    const root = makeWorkspace();
+    const result = await new WriteTool().execute({ file_path: 'owner-numeric.txt', content: 'hello owner' }, context(root, {
+      localDeviceGrant: localDevice({ ownerUserId: '7' }),
+      deviceSelection: deviceSelection({
+        selectedDeviceOperations: ['read_file', 'glob', 'grep'],
+      }),
+    }));
+
+    assert.equal(result.ok, true);
+    assert.equal(fs.readFileSync(path.join(root, 'owner-numeric.txt'), 'utf8'), 'hello owner');
+  });
+
   test('rejects external actor grant that points at the local owner device without delegation', async () => {
     const root = makeWorkspace();
     const externalScope = scope({ actorUserId: 'usr100' });

--- a/tests/tool-manager.test.ts
+++ b/tests/tool-manager.test.ts
@@ -425,6 +425,38 @@ describe('ToolManager', () => {
     assert.equal(confirmed, false);
   });
 
+  test('CatsCo local owner self accepts numeric local owner ids from saved config', async () => {
+    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-catsco-owner-id-'));
+    const manager = new ToolManager(workspace, {}, { enabledToolNames: [] });
+    let executed = false;
+    manager.registerTool(fakeTool('write_file', async () => {
+      executed = true;
+      return { ok: true, content: 'catsco write ran' };
+    }));
+    let confirmed = false;
+
+    const result = await manager.executeTool({
+      id: 'call-catsco-numeric-owner',
+      type: 'function',
+      function: { name: 'write_file', arguments: JSON.stringify({ file_path: 'a.txt', content: 'hello' }) },
+    }, [], {
+      surface: 'catscompany',
+      permissionProfile: 'strict',
+      workingDirectory: workspace,
+      workspaceRoot: workspace,
+      executionScope: catsScope({ actorUserId: 'usr7' }),
+      localDeviceGrant: catsLocalDevice({ ownerUserId: '7' }),
+      confirmToolExecution: async () => {
+        confirmed = true;
+        return false;
+      },
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(executed, true);
+    assert.equal(confirmed, false);
+  });
+
   test('AgentToolExecutor uses the same local confirmation gate', async () => {
     const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-agent-workspace-'));
     fs.writeFileSync(path.join(workspace, 'a.txt'), 'old');

--- a/tests/tool-manager.test.ts
+++ b/tests/tool-manager.test.ts
@@ -7,6 +7,7 @@ import { DEFAULT_TOOL_NAMES } from '../src/tools/default-tool-names';
 import { ToolManager } from '../src/tools/tool-manager';
 import { AgentToolExecutor } from '../src/agents/agent-tool-executor';
 import type { Tool } from '../src/types/tool';
+import type { ExecutionScope, ScopedLocalDeviceGrant } from '../src/types/session-identity';
 
 function fakeTool(name: string, execute: Tool['execute']): Tool {
   return {
@@ -16,6 +17,35 @@ function fakeTool(name: string, execute: Tool['execute']): Tool {
       parameters: { type: 'object', properties: {} },
     },
     execute,
+  };
+}
+
+function catsScope(overrides: Partial<ExecutionScope> = {}): ExecutionScope {
+  return {
+    source: 'catscompany',
+    sessionKey: 'session:v2:catscompany:p2p:p2p_7_43:agent:usr43',
+    topicId: 'p2p_7_43',
+    topicType: 'p2p',
+    actorUserId: 'usr7',
+    agentId: 'usr43',
+    agentBodyId: 'body-local',
+    permissionsSource: 'server_canonical_message',
+    identityTrust: 'server_canonical',
+    isTrusted: true,
+    ...overrides,
+  };
+}
+
+function catsLocalDevice(overrides: Partial<ScopedLocalDeviceGrant> = {}): ScopedLocalDeviceGrant {
+  return {
+    kind: 'catscompany_body',
+    source: 'catscompany',
+    ownerUserId: 'usr7',
+    bodyId: 'body-local',
+    installationId: 'install-local',
+    deviceId: 'install-local',
+    createdAt: Date.now(),
+    ...overrides,
   };
 }
 
@@ -302,18 +332,23 @@ describe('ToolManager', () => {
     assert.equal(executed, false);
   });
 
-  test('CatsCo context is not intercepted by local confirmation layer', async () => {
+  test('CatsCo context can create new ordinary home files without confirmation', async () => {
     const manager = new ToolManager('/tmp/xiaoba-tool-manager', {}, { enabledToolNames: [] });
     let confirmed = false;
     manager.registerTool(fakeTool('write_file', async () => ({ ok: true, content: 'catsco tool ran' })));
+    const target = path.join(os.homedir(), `xiaoba-catsco-new-${Date.now()}.txt`);
 
     const result = await manager.executeTool({
       id: 'call-catsco-write',
       type: 'function',
-      function: { name: 'write_file', arguments: JSON.stringify({ file_path: 'a.txt', content: 'hello' }) },
+      function: { name: 'write_file', arguments: JSON.stringify({ file_path: target, content: 'hello' }) },
     }, [], {
       surface: 'catscompany',
       permissionProfile: 'strict',
+      workingDirectory: '/tmp/xiaoba-tool-manager',
+      workspaceRoot: '/tmp/xiaoba-tool-manager',
+      executionScope: catsScope(),
+      localDeviceGrant: catsLocalDevice(),
       confirmToolExecution: async () => {
         confirmed = true;
         return false;
@@ -323,6 +358,41 @@ describe('ToolManager', () => {
     assert.equal(result.ok, true);
     assert.equal(result.content, 'catsco tool ran');
     assert.equal(confirmed, false);
+  });
+
+  test('CatsCo context asks before overwriting local files', async () => {
+    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-catsco-workspace-'));
+    const existing = path.join(workspace, 'a.txt');
+    fs.writeFileSync(existing, 'old');
+    const manager = new ToolManager(workspace, {}, { enabledToolNames: [] });
+    let executed = false;
+    manager.registerTool(fakeTool('write_file', async () => {
+      executed = true;
+      return { ok: true, content: 'catsco overwrite ran' };
+    }));
+
+    const denied = await manager.executeTool({
+      id: 'call-catsco-overwrite',
+      type: 'function',
+      function: { name: 'write_file', arguments: JSON.stringify({ file_path: existing, content: 'hello' }) },
+    }, [], {
+      surface: 'catscompany',
+      permissionProfile: 'strict',
+      workingDirectory: workspace,
+      workspaceRoot: workspace,
+      executionScope: catsScope(),
+      localDeviceGrant: catsLocalDevice(),
+      confirmToolExecution: async request => {
+        assert.equal(request.toolName, 'write_file');
+        assert.equal(request.risk, 'medium');
+        return { approved: false, reason: '用户取消覆盖' };
+      },
+    });
+
+    assert.equal(denied.ok, false);
+    assert.equal(denied.errorCode, 'PERMISSION_DENIED');
+    assert.equal(denied.content, '用户取消覆盖');
+    assert.equal(executed, false);
   });
 
   test('AgentToolExecutor uses the same local confirmation gate', async () => {

--- a/tests/tool-manager.test.ts
+++ b/tests/tool-manager.test.ts
@@ -360,39 +360,69 @@ describe('ToolManager', () => {
     assert.equal(confirmed, false);
   });
 
-  test('CatsCo context asks before overwriting local files', async () => {
+  test('CatsCo local owner self runs write edit send and shell without confirmation', async () => {
     const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-catsco-workspace-'));
     const existing = path.join(workspace, 'a.txt');
     fs.writeFileSync(existing, 'old');
     const manager = new ToolManager(workspace, {}, { enabledToolNames: [] });
-    let executed = false;
+    const executed: string[] = [];
     manager.registerTool(fakeTool('write_file', async () => {
-      executed = true;
+      executed.push('write_file');
       return { ok: true, content: 'catsco overwrite ran' };
     }));
-
-    const denied = await manager.executeTool({
-      id: 'call-catsco-overwrite',
-      type: 'function',
-      function: { name: 'write_file', arguments: JSON.stringify({ file_path: existing, content: 'hello' }) },
-    }, [], {
-      surface: 'catscompany',
-      permissionProfile: 'strict',
+    manager.registerTool(fakeTool('edit_file', async () => {
+      executed.push('edit_file');
+      return { ok: true, content: 'catsco edit ran' };
+    }));
+    manager.registerTool(fakeTool('send_file', async () => {
+      executed.push('send_file');
+      return { ok: true, content: 'catsco send ran' };
+    }));
+    manager.registerTool(fakeTool('execute_shell', async () => {
+      executed.push('execute_shell');
+      return { ok: true, content: 'catsco shell ran' };
+    }));
+    let confirmed = false;
+    const catsContext = {
+      surface: 'catscompany' as const,
+      permissionProfile: 'strict' as const,
       workingDirectory: workspace,
       workspaceRoot: workspace,
       executionScope: catsScope(),
       localDeviceGrant: catsLocalDevice(),
-      confirmToolExecution: async request => {
-        assert.equal(request.toolName, 'write_file');
-        assert.equal(request.risk, 'medium');
-        return { approved: false, reason: '用户取消覆盖' };
+      confirmToolExecution: async () => {
+        confirmed = true;
+        return false;
       },
-    });
+    };
 
-    assert.equal(denied.ok, false);
-    assert.equal(denied.errorCode, 'PERMISSION_DENIED');
-    assert.equal(denied.content, '用户取消覆盖');
-    assert.equal(executed, false);
+    const write = await manager.executeTool({
+      id: 'call-catsco-overwrite',
+      type: 'function',
+      function: { name: 'write_file', arguments: JSON.stringify({ file_path: existing, content: 'hello' }) },
+    }, [], catsContext);
+    const edit = await manager.executeTool({
+      id: 'call-catsco-edit',
+      type: 'function',
+      function: { name: 'edit_file', arguments: JSON.stringify({ file_path: existing, old_string: 'old', new_string: 'new' }) },
+    }, [], catsContext);
+    const send = await manager.executeTool({
+      id: 'call-catsco-send',
+      type: 'function',
+      function: { name: 'send_file', arguments: JSON.stringify({ file_path: existing }) },
+    }, [], catsContext);
+    const shell = await manager.executeTool({
+      id: 'call-catsco-shell',
+      type: 'function',
+      function: { name: 'execute_shell', arguments: JSON.stringify({ command: 'Remove-Item -Recurse C:\\danger' }) },
+    }, [], catsContext);
+
+    assert.equal(write.ok, true);
+    assert.equal(edit.ok, true);
+    assert.equal(send.ok, true);
+    assert.equal(shell.ok, true);
+    assert.deepEqual(executed, ['write_file', 'edit_file', 'send_file', 'execute_shell']);
+    assert.equal(confirmed, false);
   });
 
   test('AgentToolExecutor uses the same local confirmation gate', async () => {


### PR DESCRIPTION
## 背景

本 PR 优化本地自用场景：当用户在自己的 CatsCo 本机运行体中和虚拟员工对话时，不应该再被普通设备授权/确认流程阻塞。

## 主要改动

- CatsCo 本地 owner self 场景下，写文件、编辑文件、发送文件、命令执行不再触发确认，直接执行。
- 完整本地 runtime 显式声明 `execute_shell` 能力。
- 保留外部用户/远程委托场景的命令执行限制：
  - 外部渠道用户不能通过 `execute_shell` 操作本机命令行。
  - 远程设备文件操作仍通过 Device RPC 和后端 grant 控制。
- 更新测试覆盖：
  - 本地 owner self 可无确认执行 write/edit/send/shell。
  - read-only selection 不再错误阻止本地 owner 自用写入。
  - 外部 actor / delegated 场景仍不能执行 shell。
  - runtime capability 包含 `execute_shell`。

## 验证

```powershell
npm.cmd run build

node node_modules\tsx\dist\cli.mjs --test tests\tool-manager.test.ts tests\tool-gateway-catsco.test.ts tests\catscompany-runtime-device-capabilities.test.ts tests\catscompany-device-rpc-tools.test.ts tests\catscompany-tool-confirmation.test.ts