### PR TITLE
feat: 添加 runtime observation store 和 prompt 注入规范

### DIFF
--- a/docs/prompt-injection-guidelines.md
+++ b/docs/prompt-injection-guidelines.md
@@ -1,0 +1,204 @@
+# Prompt 注入规范草案
+
+这份文档定义 CatsCo / XiaoBa runtime 里“给模型额外塞上下文”的统一规则。它比 `runtime-observations.md` 更上层：Observation Store 只是其中一种注入来源，不应该承包所有注入。
+
+## 核心原则
+
+- `system` 只放稳定、低频变化、会话级的行为约束。动态信息默认不能进 `system`。
+- 动态注入默认使用 `role: "user"`，并带上 `__injected: true`。
+- 所有 runtime-only 注入都要可清理，不能写进 durable history。
+- 注入内容必须声明自己不是用户新请求，避免模型把它当成新任务。
+- 默认注入摘要和指针，不直接注入大段原始结果。
+- 任何会频繁变化的字段，都要先假设它会影响 prompt cache。
+
+## 注入分类
+
+### 1. Stable System Prompt
+
+用途：模型长期行为、工具使用规则、产品身份、稳定安全约束。
+
+规则：
+
+- 允许 `role: "system"`。
+- 内容应尽量稳定，不要包含时间、cwd、任务进度、后台结果、runner 状态。
+- 修改会影响缓存前缀，应当有明确收益。
+
+当前归属：
+
+- `PromptManager.buildSystemPrompt()`
+- `AgentSession.init()`
+
+### 2. Durable Conversation
+
+用途：真实用户消息、真实 assistant 回复、工具调用回放。
+
+规则：
+
+- 写入 session history。
+- 不能混入 `__injected` 的 runtime-only 内容。
+- 用于恢复、压缩、日志和下一轮上下文。
+
+当前归属：
+
+- `AgentSession`
+- `AgentTurnController`
+- `SessionStore`
+
+### 3. Turn-Scoped Runtime State
+
+用途：当前轮才有意义的运行时状态，例如 plan status、skills list、subagent active status、runtime feedback。
+
+规则：
+
+- 默认 `role: "user"` + `__injected: true`。
+- 只进入本轮 provider input，不进入 durable history。
+- 内容应有稳定 prefix，例如 `[transient_plan_status]`。
+- 由 `TurnContextBuilder.removeTransientMessages()` 清理。
+
+当前归属：
+
+- `TurnContextBuilder`
+- `RuntimeFeedbackInbox`
+- `SessionSkillRuntime`
+- `SubAgentManager` / `buildSubAgentStatusMessage`
+
+### 4. Runner-Tail Hints
+
+用途：ReAct 循环内部的局部提示，例如 runner hint、当前工作目录、空 max_tokens 恢复提示、重复外发提示。
+
+规则：
+
+- 默认 `role: "user"` + `__injected: true`。
+- 只在 provider input 尾部或工具交换附近出现。
+- 不能进入 `system`，不能沉淀进 durable history。
+- 放置位置由 `ConversationRunner` 控制，因为它最了解当前 ReAct 轮次。
+
+当前归属：
+
+- `ConversationRunner`
+- `runner-orchestration-policy`
+
+### 5. Runtime Observations
+
+用途：异步完成的外部观察结果，例如 memory graph、web search、review、长任务总结。
+
+规则：
+
+- 先写入 `RuntimeObservationStore`，不要直接拼 prompt。
+- 下一轮由 `TurnContextBuilder` 按预算挑选并渲染成 `[runtime_observations]`。
+- 默认放在当前真实用户消息之前。
+- 成功发送后标记为 `injected`；业务确认不再需要时标记为 `consumed`。
+- 默认注入 summary，不注入完整 detail。
+
+当前归属：
+
+- `RuntimeObservationStore`
+- `renderRuntimeObservations(...)`
+- `AgentSession.upsertRuntimeObservation(...)`
+- `TurnContextBuilder.injectRuntimeObservations(...)`
+
+### 6. Manual Injected Context
+
+用途：平台或人工侧显式塞入的一次性上下文。
+
+规则：
+
+- 必须 `role: "user"` + `__injected: true`。
+- 需要明确 prefix 和来源。
+- 如果是异步结果，优先改用 Runtime Observation。
+- 如果是机械状态，优先接入 TurnContextBuilder 或 ConversationRunner。
+
+当前归属：
+
+- `AgentSession.injectContext(...)`
+
+## 选择规则
+
+新增注入前先按这个顺序判断：
+
+1. 是长期稳定行为规则吗？
+   用 stable system prompt。
+2. 是真实用户或 assistant 对话吗？
+   写 durable conversation。
+3. 是当前轮机械状态吗？
+   放进 `TurnContextBuilder`。
+4. 是 ReAct 循环内部的即时提示吗？
+   放进 `ConversationRunner`。
+5. 是后台异步任务完成后的观察结果吗？
+   写入 `RuntimeObservationStore`。
+6. 只是临时手工塞上下文吗？
+   使用 `user + __injected`，并确保可清理。
+
+## 推荐 Prompt 形态
+
+机械状态：
+
+```text
+[transient_plan_status]
+Runtime context only. Not a user request.
+...
+```
+
+异步观察：
+
+```text
+[runtime_observations]
+以下是后台异步观察结果，不是用户的新请求。当前用户消息仍然优先；只在相关时参考。
+
+1. [web_search:obs_abc] 搜索结果
+   摘要: ...
+   来源: ...
+```
+
+当前目录：
+
+```text
+[transient_current_directory]
+Runtime context only. Not a user request. Do not answer.
+cwd: ...
+Use only for relative file paths.
+```
+
+## 禁止模式
+
+- 动态时间、cwd、runner hint、搜索结果、review 结果进入 `system`。
+- 没有 prefix 的注入消息。
+- 没有 `__injected` 标记的 runtime-only 消息。
+- 把 observation 原始长文本反复塞进 prompt。
+- 注入内容直接写成命令式用户需求，例如“请立刻处理以下搜索结果”。
+- 新增一套独立上下文拼装逻辑绕过 `TurnContextBuilder` / `ConversationRunner`。
+
+## 缓存安全
+
+MiniMax M3 实验显示，动态 `system` 内容会显著破坏缓存命中。当前规范因此采用保守策略：
+
+- stable system prompt 尽量稳定。
+- 动态注入放到 `user + __injected`。
+- 高频变化内容尽量放在当前用户消息附近或 runner tail，不插入稳定前缀中间。
+- 大段异步结果先摘要、去重、预算筛选。
+- provider 边界不能泄露 `__injected`、`__runtimeObservation` 等内部字段。
+
+## 接入检查清单
+
+新增一种注入来源时，PR 需要回答：
+
+- 这条信息属于哪一类注入？
+- 为什么不能用现有类别？
+- 它会不会每轮变化？
+- 它的 role 是什么？
+- 它是否带 `__injected`？
+- 它的 prefix 是什么？
+- 它插在当前用户消息前、runner tail，还是其他位置？
+- 它如何从 durable history 中清理？
+- 它是否可能破坏 prompt cache？
+- 有无测试证明它不会进入 `system`、不会污染 durable history？
+
+## 当前建议
+
+近期不要先做庞大的 lane/scheduler。先沿用现有分工：
+
+- `TurnContextBuilder` 管每轮 provider input 的 turn-scoped 注入。
+- `ConversationRunner` 管 ReAct 内部即时提示。
+- `RuntimeObservationStore` 管未来异步观察结果。
+
+等 memory graph、web search、review 真正接入后，再根据实际冲突决定是否需要更强的 scheduler。

--- a/docs/runtime-observations.md
+++ b/docs/runtime-observations.md
@@ -1,0 +1,105 @@
+# Runtime Observations 草案
+
+这份文档是 `prompt-injection-guidelines.md` 里的 Runtime Observations 细化说明。先看整体注入规范，再看这里的 store 数据结构和闭环细节。
+
+这份文档定义一层轻量的 runtime observation store，用来承接未来的异步上下文来源，例如 memory graph、web search、review、长任务或子任务结果。它不是现有注入机制的重构，也不要求现在把 runner hint、plan status、skills list、current directory 等直接注入全部迁进来。
+
+## 目标
+
+- 给未来异步结果一个统一入口：后台任务完成后先写入 store，再由对话循环按预算挑选摘要注入模型。
+- 明确缓存安全边界：runtime observation 只能以 `role: "user"` 和 `__injected: true` 进入模型上下文，不能进入 `system`。
+- 把“事实存储”和“prompt 渲染”分开：store 保存结构化观察结果，renderer 负责生成一次性的 `[runtime_observations]` 消息。
+- 先提供接口和规范，方便后续 memory graph、web search、review 等功能接入。
+
+## 非目标
+
+- 不迁移现有 runner hint、plan status、skills list、subagent status、current directory 注入。
+- 不做持久化，不跨进程共享，不做复杂队列。
+- 不引入完整 lane/scheduler。第一版只做选择、去重、预算和状态流转。
+- 不把动态 observation 写进 `system`，也不依赖 provider 特殊能力。
+
+## 数据模型
+
+每条 observation 代表一条后台观察结果：
+
+- `id`: observation 的稳定 id。
+- `sessionId`: 所属会话。
+- `turnId`: 可选，产生这条 observation 的轮次。
+- `source`: 来源，例如 `memory_graph`、`web_search`、`review`、`subagent`、`runtime`。
+- `status`: `pending`、`ready`、`injected`、`consumed`、`stale`、`failed`。
+- `title`: 给模型看的短标题。
+- `summary`: 默认注入模型的摘要。
+- `detail`: 可选的完整详情，默认不直接塞进 prompt。
+- `citations`: 可选来源引用。
+- `priority` / `relevance`: 用于预算内排序。
+- `tokenEstimate`: 粗略 token 估算，用于 prompt budget。
+- `expiresAt`: 可选过期时间。
+- `hash`: 内容指纹，用于去重。
+- `policy`: 注入策略，例如只注入一次、持续注入直到消费、仅指针、不自动注入。
+
+## 生命周期
+
+1. 用户消息进入 ReAct 循环。
+2. memory graph、web search、review 等后台任务异步执行。
+3. 后台任务完成后调用 `store.upsert(...)` 写入 observation。
+4. 每次构造下一轮 provider input 前，调用 `store.pickForPrompt(...)` 按状态、过期时间、优先级、相关性和预算选择 observation。
+5. `TurnContextBuilder` 调用 `renderRuntimeObservations(...)` 生成一条模型可见消息：
+
+```ts
+{
+  role: 'user',
+  content: '[runtime_observations]\n...',
+  __injected: true,
+  __runtimeObservation: true,
+  runtimeObservationSource: 'runtime_observations',
+}
+```
+
+6. `AgentTurnController` 在本轮发送成功后调用 `store.markInjected(...)`。模型已经处理或业务确认不再需要时调用 `store.markConsumed(...)`。
+
+当前实验版已经把这条链路接到 `AgentSession.upsertRuntimeObservation(...)`：
+
+```ts
+session.upsertRuntimeObservation({
+  source: 'web_search',
+  title: '搜索结果',
+  summary: '...',
+});
+
+await session.handleMessage('继续处理刚才的问题');
+```
+
+这会在下一轮真实用户消息前注入一条 `[runtime_observations]`，并在发送成功后把对应 observation 标为 `injected`。
+
+## Prompt 形态
+
+第一版统一渲染为一条 `user` 注入消息：
+
+```text
+[runtime_observations]
+以下是后台异步观察结果，不是用户的新请求。当前用户消息仍然优先；只在相关时参考。
+
+1. [web_search:obs_abc] 搜索结果
+   摘要: ...
+   来源: ...
+```
+
+放置位置由后续接入点决定。当前实验版默认放在当前用户消息之前。如果某类 observation 必须在 ReAct 循环内部补充，可放在 runner tail，但仍保持 `user + __injected`。
+
+## 缓存安全规则
+
+- 所有动态 observation 都不能进入 `system`。
+- 尽量注入摘要，不直接注入完整详情。
+- 同一 hash 的 observation 只保留最高优先级的一条进入 prompt。
+- 超过预算的 observation 跳过，等待下一次或由业务改成更短摘要。
+- 过期、失败、已消费的 observation 不自动注入。
+
+## 现有注入的处理
+
+现有直接注入先保持原状：
+
+- runner hint 仍由 `ConversationRunner` 管。
+- plan status、skills list、subagent status、runtime feedback 仍由 `TurnContextBuilder` 管。
+- current directory 仍由 runner 按现有逻辑注入。
+
+这些信息是“当前轮 prompt 机械状态”，不是异步产生的外部观察结果；提前迁入 observation store 反而会增加不必要复杂度。等 memory graph、web search、review 等真实异步来源出现后，再把它们接入这层 store。

--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -44,8 +44,14 @@ import { parseSessionKeyV2 } from './session-router';
 import { MODEL_IMAGE_SAFETY_MESSAGE, isModelImageSafetyError } from '../utils/model-error-classifier';
 import { stripAssistantArtifactsFromMessages } from '../utils/transcript-artifacts';
 import { toPromptTurnMetadata } from '../utils/prompt-observability';
+import {
+  RuntimeObservationStore,
+  type RuntimeObservation,
+  type RuntimeObservationInput,
+} from './runtime-observation-store';
 
 export type { RuntimeFeedbackInput, RuntimeFeedbackOptions } from './runtime-feedback-inbox';
+export type { RuntimeObservation, RuntimeObservationInput } from './runtime-observation-store';
 
 export const BUSY_MESSAGE = '正在处理上一条消息，请稍候...';
 export const ERROR_MESSAGE = '不好意思，刚才处理出了点问题，你再试一次？';
@@ -66,6 +72,9 @@ export interface AgentServices {
 }
 
 export type SystemPromptProvider = () => Promise<string> | string;
+
+export type SessionRuntimeObservationInput =
+  Omit<RuntimeObservationInput, 'sessionId'> & { sessionId?: string };
 
 /** 会话回调（由适配层提供） */
 export interface SessionCallbacks {
@@ -160,6 +169,7 @@ export class AgentSession {
   private contextWindowManager: ContextWindowManager;
   private skillRuntime: SessionSkillRuntime;
   private runtimeFeedbackInbox = new RuntimeFeedbackInbox();
+  private runtimeObservationStore = new RuntimeObservationStore();
   private planRuntime = new PlanRuntime();
   private lifecycleManager: SessionLifecycleManager;
   private readonly defaultDirectory: string;
@@ -205,6 +215,7 @@ export class AgentSession {
       workspaceRoot: this.defaultDirectory,
       getCurrentDirectory: () => this.currentDirectory,
       updateCurrentDirectory: directory => this.updateCurrentDirectory(directory),
+      runtimeObservationStore: this.runtimeObservationStore,
     });
 
     const runtimeFeedbackInbox = this.runtimeFeedbackInbox;
@@ -373,6 +384,16 @@ export class AgentSession {
       this.lastActiveAt = Date.now();
     }
     return enqueued;
+  }
+
+  upsertRuntimeObservation(input: SessionRuntimeObservationInput): RuntimeObservation {
+    const { sessionId, ...observationInput } = input;
+    const observation = this.runtimeObservationStore.upsert({
+      ...observationInput,
+      sessionId: sessionId ?? this.key,
+    });
+    this.lastActiveAt = Date.now();
+    return observation;
   }
 
   /**

--- a/src/core/agent-turn-controller.ts
+++ b/src/core/agent-turn-controller.ts
@@ -25,6 +25,7 @@ import { TurnContextBuilder } from './turn-context-builder';
 import { TurnLogRecorder } from './turn-log-recorder';
 import { PlanRuntime } from './plan-runtime';
 import { getPetService } from '../pet/pet-service';
+import type { RuntimeObservationStore } from './runtime-observation-store';
 
 export interface AgentTurnServices {
   aiService: AIService;
@@ -84,6 +85,9 @@ export interface AgentTurnControllerOptions {
   workspaceRoot: string;
   getCurrentDirectory: () => string;
   updateCurrentDirectory: (directory: string) => void;
+  runtimeObservationStore?: RuntimeObservationStore;
+  runtimeObservationPromptBudget?: number;
+  runtimeObservationMaxItems?: number;
 }
 
 /**
@@ -115,6 +119,9 @@ export class AgentTurnController {
       runtimeFeedback: params.runtimeFeedback,
       skillRuntime: this.options.skillRuntime,
       planRuntime: this.options.planRuntime,
+      runtimeObservationStore: this.options.runtimeObservationStore,
+      runtimeObservationPromptBudget: this.options.runtimeObservationPromptBudget,
+      runtimeObservationMaxItems: this.options.runtimeObservationMaxItems,
     });
 
     const runner = this.createRunner({
@@ -141,6 +148,9 @@ export class AgentTurnController {
         (error as AgentTurnRunError).partialMessages = partialMessages;
       }
       throw error;
+    }
+    if (turnContext.runtimeObservationIdsForPrompt.length > 0) {
+      this.options.runtimeObservationStore?.markInjected(turnContext.runtimeObservationIdsForPrompt);
     }
     const nextMessages = this.options.turnContextBuilder.removeTransientMessages(result.messages);
 

--- a/src/core/runtime-observation-store.ts
+++ b/src/core/runtime-observation-store.ts
@@ -1,0 +1,428 @@
+import { createHash } from 'crypto';
+import type { Message } from '../types';
+
+export const RUNTIME_OBSERVATIONS_PREFIX = '[runtime_observations]';
+
+export type RuntimeObservationSource =
+  | 'memory_graph'
+  | 'web_search'
+  | 'review'
+  | 'subagent'
+  | 'runtime'
+  | 'other';
+
+export type RuntimeObservationStatus =
+  | 'pending'
+  | 'ready'
+  | 'injected'
+  | 'consumed'
+  | 'stale'
+  | 'failed';
+
+export type RuntimeObservationInjectionMode =
+  | 'summary_once'
+  | 'summary_until_consumed'
+  | 'pointer_only'
+  | 'never_auto';
+
+export type RuntimeObservationPlacement =
+  | 'before_current_user'
+  | 'react_tail';
+
+export type RuntimeObservationTurnId = string | number;
+
+export interface RuntimeObservationCitation {
+  title?: string;
+  url?: string;
+  ref?: string;
+}
+
+export interface RuntimeObservationPolicy {
+  injectMode: RuntimeObservationInjectionMode;
+  placement: RuntimeObservationPlacement;
+  maxSummaryChars: number;
+}
+
+export interface RuntimeObservation {
+  id: string;
+  sessionId: string;
+  turnId?: RuntimeObservationTurnId;
+  source: RuntimeObservationSource;
+  status: RuntimeObservationStatus;
+  title: string;
+  summary: string;
+  detail?: string;
+  citations?: RuntimeObservationCitation[];
+  priority: number;
+  relevance: number;
+  tokenEstimate: number;
+  createdAt: number;
+  updatedAt: number;
+  expiresAt?: number;
+  injectedAtTurn?: RuntimeObservationTurnId;
+  consumedAtTurn?: RuntimeObservationTurnId;
+  hash: string;
+  policy: RuntimeObservationPolicy;
+}
+
+export interface RuntimeObservationInput {
+  id?: string;
+  sessionId: string;
+  turnId?: RuntimeObservationTurnId;
+  source: RuntimeObservationSource;
+  status?: RuntimeObservationStatus;
+  title: string;
+  summary: string;
+  detail?: string;
+  citations?: RuntimeObservationCitation[];
+  priority?: number;
+  relevance?: number;
+  tokenEstimate?: number;
+  createdAt?: number;
+  updatedAt?: number;
+  expiresAt?: number;
+  injectedAtTurn?: RuntimeObservationTurnId;
+  consumedAtTurn?: RuntimeObservationTurnId;
+  hash?: string;
+  policy?: Partial<RuntimeObservationPolicy>;
+}
+
+export interface RuntimeObservationStoreOptions {
+  now?: () => number;
+}
+
+export interface RuntimeObservationQuery {
+  sessionId: string;
+  sources?: RuntimeObservationSource[];
+  now?: number;
+}
+
+export interface PickRuntimeObservationsParams extends RuntimeObservationQuery {
+  tokenBudget?: number;
+  maxItems?: number;
+}
+
+export interface RenderRuntimeObservationsOptions {
+  sourceLabel?: string;
+  maxContentChars?: number;
+}
+
+const DEFAULT_POLICY: RuntimeObservationPolicy = {
+  injectMode: 'summary_once',
+  placement: 'before_current_user',
+  maxSummaryChars: 1200,
+};
+
+const DEFAULT_TOKEN_BUDGET = 1200;
+const DEFAULT_MAX_ITEMS = 6;
+const DEFAULT_MAX_RENDERED_CHARS = 6000;
+
+export class RuntimeObservationStore {
+  private observations = new Map<string, RuntimeObservation>();
+  private readonly now: () => number;
+
+  constructor(options: RuntimeObservationStoreOptions = {}) {
+    this.now = options.now ?? Date.now;
+  }
+
+  upsert(input: RuntimeObservationInput): RuntimeObservation {
+    const now = input.updatedAt ?? this.now();
+    const sessionId = input.sessionId.trim();
+    const title = normalizeBlock(input.title) || input.source;
+    const summary = normalizeBlock(input.summary);
+    if (!sessionId) {
+      throw new Error('RuntimeObservation sessionId is required');
+    }
+    if (!summary) {
+      throw new Error('RuntimeObservation summary is required');
+    }
+
+    const idForExistingLookup = input.id;
+    const existing = idForExistingLookup ? this.observations.get(idForExistingLookup) : undefined;
+    const detail = input.detail ?? existing?.detail;
+    const citations = input.citations ?? existing?.citations;
+    const hash = input.hash ?? fingerprintObservation({
+      source: input.source,
+      title,
+      summary,
+      detail,
+      citations,
+    });
+    const id = input.id ?? buildObservationId(input.source, hash);
+    const existingByGeneratedId = existing ?? this.observations.get(id);
+    const policy = normalizePolicy(input.policy, existingByGeneratedId?.policy);
+    const observation: RuntimeObservation = {
+      id,
+      sessionId,
+      turnId: input.turnId ?? existingByGeneratedId?.turnId,
+      source: input.source,
+      status: input.status ?? existingByGeneratedId?.status ?? 'ready',
+      title,
+      summary,
+      detail,
+      citations: cloneCitations(citations),
+      priority: clampNumber(input.priority ?? existingByGeneratedId?.priority ?? 50, 0, 100),
+      relevance: clampNumber(input.relevance ?? existingByGeneratedId?.relevance ?? 1, 0, 1),
+      tokenEstimate: Math.max(
+        1,
+        Math.ceil(input.tokenEstimate ?? estimateObservationTokens(summary, detail)),
+      ),
+      createdAt: input.createdAt ?? existingByGeneratedId?.createdAt ?? now,
+      updatedAt: now,
+      expiresAt: input.expiresAt ?? existingByGeneratedId?.expiresAt,
+      injectedAtTurn: input.injectedAtTurn ?? existingByGeneratedId?.injectedAtTurn,
+      consumedAtTurn: input.consumedAtTurn ?? existingByGeneratedId?.consumedAtTurn,
+      hash,
+      policy,
+    };
+
+    this.observations.set(id, observation);
+    return cloneObservation(observation);
+  }
+
+  get(id: string): RuntimeObservation | undefined {
+    const observation = this.observations.get(id);
+    return observation ? cloneObservation(observation) : undefined;
+  }
+
+  list(sessionId?: string): RuntimeObservation[] {
+    return Array.from(this.observations.values())
+      .filter(observation => !sessionId || observation.sessionId === sessionId)
+      .map(cloneObservation);
+  }
+
+  listReady(query: RuntimeObservationQuery): RuntimeObservation[] {
+    const now = query.now ?? this.now();
+    return Array.from(this.observations.values())
+      .filter(observation => observation.sessionId === query.sessionId)
+      .filter(observation => observation.status === 'ready')
+      .filter(observation => !isExpired(observation, now))
+      .filter(observation => matchesSources(observation, query.sources))
+      .map(cloneObservation);
+  }
+
+  pickForPrompt(params: PickRuntimeObservationsParams): RuntimeObservation[] {
+    const now = params.now ?? this.now();
+    const maxItems = params.maxItems ?? DEFAULT_MAX_ITEMS;
+    const tokenBudget = params.tokenBudget ?? DEFAULT_TOKEN_BUDGET;
+    const candidates = Array.from(this.observations.values())
+      .filter(observation => observation.sessionId === params.sessionId)
+      .filter(observation => matchesSources(observation, params.sources))
+      .filter(observation => isPromptEligible(observation, now))
+      .sort(compareForPrompt);
+
+    const picked: RuntimeObservation[] = [];
+    const seenHashes = new Set<string>();
+    let usedTokens = 0;
+
+    for (const observation of candidates) {
+      if (picked.length >= maxItems) break;
+      if (seenHashes.has(observation.hash)) continue;
+
+      const nextTokens = usedTokens + observation.tokenEstimate;
+      if (nextTokens > tokenBudget) continue;
+
+      picked.push(cloneObservation(observation));
+      seenHashes.add(observation.hash);
+      usedTokens = nextTokens;
+    }
+
+    return picked;
+  }
+
+  markInjected(ids: string[], turnId?: RuntimeObservationTurnId): void {
+    this.updateMany(ids, observation => ({
+      ...observation,
+      status: 'injected',
+      injectedAtTurn: turnId ?? observation.injectedAtTurn,
+      updatedAt: this.now(),
+    }));
+  }
+
+  markConsumed(ids: string[], turnId?: RuntimeObservationTurnId): void {
+    this.updateMany(ids, observation => ({
+      ...observation,
+      status: 'consumed',
+      consumedAtTurn: turnId ?? observation.consumedAtTurn,
+      updatedAt: this.now(),
+    }));
+  }
+
+  markStale(ids: string[]): void {
+    this.updateMany(ids, observation => ({
+      ...observation,
+      status: 'stale',
+      updatedAt: this.now(),
+    }));
+  }
+
+  clearSession(sessionId: string): void {
+    for (const [id, observation] of this.observations) {
+      if (observation.sessionId === sessionId) {
+        this.observations.delete(id);
+      }
+    }
+  }
+
+  reset(): void {
+    this.observations.clear();
+  }
+
+  private updateMany(
+    ids: string[],
+    update: (observation: RuntimeObservation) => RuntimeObservation,
+  ): void {
+    for (const id of ids) {
+      const observation = this.observations.get(id);
+      if (!observation) continue;
+      this.observations.set(id, update(observation));
+    }
+  }
+}
+
+export function renderRuntimeObservations(
+  observations: RuntimeObservation[],
+  options: RenderRuntimeObservationsOptions = {},
+): Message | null {
+  if (observations.length === 0) return null;
+
+  const sourceLabel = options.sourceLabel ?? 'runtime_observations';
+  const lines = [
+    RUNTIME_OBSERVATIONS_PREFIX,
+    '以下是后台异步观察结果，不是用户的新请求。当前用户消息仍然优先；只在相关时参考。',
+  ];
+
+  observations.forEach((observation, index) => {
+    const summary = renderSummary(observation);
+    const citations = renderCitations(observation.citations);
+    const section = [
+      `${index + 1}. [${observation.source}:${observation.id}] ${observation.title}`,
+      `   摘要: ${summary}`,
+      citations ? `   来源: ${citations}` : '',
+    ].filter(Boolean);
+    lines.push('', ...section);
+  });
+
+  return {
+    role: 'user',
+    content: truncateBlock(lines.join('\n'), options.maxContentChars ?? DEFAULT_MAX_RENDERED_CHARS),
+    __injected: true,
+    __runtimeObservation: true,
+    runtimeObservationSource: sourceLabel,
+  };
+}
+
+export function fingerprintObservation(input: {
+  source: RuntimeObservationSource;
+  title: string;
+  summary: string;
+  detail?: string;
+  citations?: RuntimeObservationCitation[];
+}): string {
+  return createHash('sha256')
+    .update(JSON.stringify({
+      source: input.source,
+      title: normalizeBlock(input.title),
+      summary: normalizeBlock(input.summary),
+      detail: normalizeBlock(input.detail ?? ''),
+      citations: cloneCitations(input.citations),
+    }))
+    .digest('hex');
+}
+
+function buildObservationId(source: RuntimeObservationSource, hash: string): string {
+  const normalizedSource = source.replace(/[^a-z0-9_]+/gi, '_').toLowerCase();
+  return `obs_${normalizedSource}_${hash.slice(0, 12)}`;
+}
+
+function normalizePolicy(
+  input?: Partial<RuntimeObservationPolicy>,
+  existing?: RuntimeObservationPolicy,
+): RuntimeObservationPolicy {
+  return {
+    ...DEFAULT_POLICY,
+    ...existing,
+    ...input,
+    maxSummaryChars: Math.max(
+      80,
+      Math.floor(input?.maxSummaryChars ?? existing?.maxSummaryChars ?? DEFAULT_POLICY.maxSummaryChars),
+    ),
+  };
+}
+
+function normalizeBlock(text: string): string {
+  return String(text || '').replace(/\s+/g, ' ').trim();
+}
+
+function truncateBlock(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  return `${text.slice(0, Math.max(0, maxChars - 16)).trimEnd()}... [truncated]`;
+}
+
+function estimateObservationTokens(summary: string, detail?: string): number {
+  const text = detail ? `${summary}\n${detail}` : summary;
+  return Math.max(1, Math.ceil(text.length / 4));
+}
+
+function cloneObservation(observation: RuntimeObservation): RuntimeObservation {
+  return {
+    ...observation,
+    citations: cloneCitations(observation.citations),
+    policy: { ...observation.policy },
+  };
+}
+
+function cloneCitations(
+  citations?: RuntimeObservationCitation[],
+): RuntimeObservationCitation[] | undefined {
+  return citations?.map(citation => ({ ...citation }));
+}
+
+function clampNumber(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.min(max, Math.max(min, value));
+}
+
+function isExpired(observation: RuntimeObservation, now: number): boolean {
+  return observation.expiresAt !== undefined && observation.expiresAt <= now;
+}
+
+function isPromptEligible(observation: RuntimeObservation, now: number): boolean {
+  if (isExpired(observation, now)) return false;
+  if (observation.policy.injectMode === 'never_auto') return false;
+  if (observation.status === 'ready') return true;
+  return observation.status === 'injected'
+    && observation.policy.injectMode === 'summary_until_consumed';
+}
+
+function matchesSources(
+  observation: RuntimeObservation,
+  sources?: RuntimeObservationSource[],
+): boolean {
+  return !sources || sources.length === 0 || sources.includes(observation.source);
+}
+
+function compareForPrompt(a: RuntimeObservation, b: RuntimeObservation): number {
+  return b.priority - a.priority
+    || b.relevance - a.relevance
+    || b.updatedAt - a.updatedAt
+    || a.id.localeCompare(b.id);
+}
+
+function renderSummary(observation: RuntimeObservation): string {
+  const summary = truncateBlock(observation.summary, observation.policy.maxSummaryChars);
+  if (observation.policy.injectMode !== 'pointer_only') return summary;
+  return `${summary}（详细内容保留在 observation store 中，默认不直接注入。）`;
+}
+
+function renderCitations(citations?: RuntimeObservationCitation[]): string {
+  if (!citations || citations.length === 0) return '';
+  return citations
+    .slice(0, 4)
+    .map(citation => {
+      const label = citation.title || citation.ref || citation.url || 'source';
+      if (!citation.url) return label;
+      return `${label} <${citation.url}>`;
+    })
+    .join('; ');
+}

--- a/src/core/turn-context-builder.ts
+++ b/src/core/turn-context-builder.ts
@@ -22,6 +22,11 @@ import {
   buildRuntimeContextMessage,
 } from './runtime-context-builder';
 import { stripAssistantArtifactsFromMessages } from '../utils/transcript-artifacts';
+import {
+  RUNTIME_OBSERVATIONS_PREFIX,
+  renderRuntimeObservations,
+} from './runtime-observation-store';
+import type { RuntimeObservationStore } from './runtime-observation-store';
 
 const TRANSIENT_PLAN_STATUS_PREFIX = '[transient_plan_status]';
 const TRANSIENT_RUNNER_HINT_PREFIX = '[transient_runner_hint]';
@@ -40,11 +45,15 @@ export interface BuildTurnContextParams {
   runtimeFeedback: string[];
   skillRuntime: SessionSkillRuntime;
   planRuntime?: PlanRuntime;
+  runtimeObservationStore?: RuntimeObservationStore;
+  runtimeObservationPromptBudget?: number;
+  runtimeObservationMaxItems?: number;
 }
 
 export interface BuildTurnContextResult {
   messages: Message[];
   runtimeFeedbackForLog: string[];
+  runtimeObservationIdsForPrompt: string[];
 }
 
 /**
@@ -65,16 +74,24 @@ export class TurnContextBuilder {
     if (skillsListMsg) {
       this.insertBeforeLastUser(contextMessages, skillsListMsg);
     }
+    const runtimeObservationIdsForPrompt = this.injectRuntimeObservations(contextMessages, params);
 
     return {
       messages: contextMessages,
       runtimeFeedbackForLog: this.extractRuntimeFeedback(contextMessages),
+      runtimeObservationIdsForPrompt,
     };
   }
 
   removeTransientMessages(messages: Message[]): Message[] {
     return messages.filter(msg => {
       if (msg.__runtimeFeedback) return false;
+      if (msg.__injected && msg.__runtimeObservation) return false;
+      if (
+        msg.__injected
+        && typeof msg.content === 'string'
+        && msg.content.startsWith(RUNTIME_OBSERVATIONS_PREFIX)
+      ) return false;
       if (msg.role !== 'system' || typeof msg.content !== 'string') return true;
       if (msg.content.startsWith(TRANSIENT_SUBAGENT_STATUS_PREFIX)) return false;
       if (msg.content.startsWith(TRANSIENT_PLAN_STATUS_PREFIX)) return false;
@@ -126,6 +143,24 @@ export class TurnContextBuilder {
     const statusMessage = buildSubAgentStatusMessage(sessionKey);
     if (!statusMessage) return;
     this.insertBeforeLastUser(messages, statusMessage);
+  }
+
+  private injectRuntimeObservations(
+    messages: Message[],
+    params: BuildTurnContextParams,
+  ): string[] {
+    if (!params.runtimeObservationStore) return [];
+
+    const observations = params.runtimeObservationStore.pickForPrompt({
+      sessionId: params.sessionKey,
+      tokenBudget: params.runtimeObservationPromptBudget,
+      maxItems: params.runtimeObservationMaxItems,
+    });
+    const observationMessage = renderRuntimeObservations(observations);
+    if (!observationMessage) return [];
+
+    this.insertBeforeLastUser(messages, observationMessage);
+    return observations.map(observation => observation.id);
   }
 
   private extractRuntimeFeedback(messages: Message[]): string[] {

--- a/tests/runtime-observation-store.test.ts
+++ b/tests/runtime-observation-store.test.ts
@@ -1,0 +1,336 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { createRequire } from 'node:module';
+import {
+  RUNTIME_OBSERVATIONS_PREFIX,
+  RuntimeObservationStore,
+  renderRuntimeObservations,
+} from '../src/core/runtime-observation-store';
+import { TurnContextBuilder } from '../src/core/turn-context-builder';
+
+const require = createRequire(import.meta.url);
+
+test('runtime observation store filters ready observations by status and expiry', () => {
+  const store = new RuntimeObservationStore({ now: () => 1_000 });
+
+  store.upsert({
+    id: 'ready',
+    sessionId: 'session-a',
+    source: 'web_search',
+    title: 'Fresh result',
+    summary: 'Ready to inject',
+    expiresAt: 2_000,
+  });
+  store.upsert({
+    id: 'expired',
+    sessionId: 'session-a',
+    source: 'review',
+    title: 'Old result',
+    summary: 'Expired already',
+    expiresAt: 999,
+  });
+  store.upsert({
+    id: 'pending',
+    sessionId: 'session-a',
+    source: 'memory_graph',
+    status: 'pending',
+    title: 'Pending result',
+    summary: 'Not ready yet',
+  });
+  store.upsert({
+    id: 'other-session',
+    sessionId: 'session-b',
+    source: 'web_search',
+    title: 'Other session',
+    summary: 'Should not leak',
+  });
+
+  assert.deepEqual(store.listReady({ sessionId: 'session-a' }).map(item => item.id), ['ready']);
+});
+
+test('runtime observation picker sorts, dedupes, and respects prompt budget', () => {
+  const store = new RuntimeObservationStore({ now: () => 1_000 });
+
+  store.upsert({
+    id: 'too-large',
+    sessionId: 'session-a',
+    source: 'review',
+    title: 'Large review',
+    summary: 'Large review summary',
+    priority: 100,
+    tokenEstimate: 10,
+  });
+  store.upsert({
+    id: 'best',
+    sessionId: 'session-a',
+    source: 'web_search',
+    title: 'Best result',
+    summary: 'Best result summary',
+    priority: 90,
+    relevance: 0.9,
+    tokenEstimate: 2,
+  });
+  store.upsert({
+    id: 'duplicate-lower',
+    sessionId: 'session-a',
+    source: 'web_search',
+    title: 'Duplicate lower',
+    summary: 'Same fact',
+    priority: 80,
+    tokenEstimate: 1,
+    hash: 'same-hash',
+  });
+  store.upsert({
+    id: 'duplicate-higher',
+    sessionId: 'session-a',
+    source: 'web_search',
+    title: 'Duplicate higher',
+    summary: 'Same fact with better rank',
+    priority: 85,
+    tokenEstimate: 1,
+    hash: 'same-hash',
+  });
+  store.upsert({
+    id: 'never-auto',
+    sessionId: 'session-a',
+    source: 'memory_graph',
+    title: 'Hidden memory',
+    summary: 'Policy says do not inject',
+    priority: 95,
+    tokenEstimate: 1,
+    policy: { injectMode: 'never_auto' },
+  });
+
+  const picked = store.pickForPrompt({
+    sessionId: 'session-a',
+    tokenBudget: 4,
+    maxItems: 3,
+  });
+
+  assert.deepEqual(picked.map(item => item.id), ['best', 'duplicate-higher']);
+});
+
+test('runtime observation renderer returns one injected user message', () => {
+  const store = new RuntimeObservationStore({ now: () => 1_000 });
+  const observation = store.upsert({
+    id: 'search-1',
+    sessionId: 'session-a',
+    source: 'web_search',
+    title: 'Search result',
+    summary: 'MiniMax cache is sensitive to dynamic system content.',
+    citations: [{ title: 'Experiment log', url: 'https://example.test/log' }],
+  });
+
+  const message = renderRuntimeObservations([observation]);
+
+  assert.ok(message);
+  assert.equal(message.role, 'user');
+  assert.equal(message.__injected, true);
+  assert.equal(message.__runtimeObservation, true);
+  assert.equal(message.runtimeObservationSource, 'runtime_observations');
+  assert.equal(typeof message.content, 'string');
+  assert.equal(message.content.startsWith(RUNTIME_OBSERVATIONS_PREFIX), true);
+  assert.match(message.content, /不是用户的新请求/);
+  assert.match(message.content, /\[web_search:search-1\]/);
+  assert.match(message.content, /Experiment log <https:\/\/example\.test\/log>/);
+});
+
+test('runtime observation lifecycle supports one-shot and until-consumed injections', () => {
+  const store = new RuntimeObservationStore({ now: () => 1_000 });
+
+  store.upsert({
+    id: 'once',
+    sessionId: 'session-a',
+    source: 'review',
+    title: 'One shot',
+    summary: 'Inject once',
+    tokenEstimate: 1,
+  });
+  store.upsert({
+    id: 'sticky',
+    sessionId: 'session-a',
+    source: 'memory_graph',
+    title: 'Sticky',
+    summary: 'Keep injecting until consumed',
+    tokenEstimate: 1,
+    policy: { injectMode: 'summary_until_consumed' },
+  });
+
+  assert.deepEqual(
+    store.pickForPrompt({ sessionId: 'session-a' }).map(item => item.id),
+    ['once', 'sticky'],
+  );
+
+  store.markInjected(['once', 'sticky'], 'turn-2');
+  assert.equal(store.get('once')?.status, 'injected');
+  assert.equal(store.get('sticky')?.injectedAtTurn, 'turn-2');
+  assert.deepEqual(
+    store.pickForPrompt({ sessionId: 'session-a' }).map(item => item.id),
+    ['sticky'],
+  );
+
+  store.markConsumed(['sticky'], 'turn-3');
+  assert.equal(store.get('sticky')?.status, 'consumed');
+  assert.equal(store.get('sticky')?.consumedAtTurn, 'turn-3');
+  assert.deepEqual(store.pickForPrompt({ sessionId: 'session-a' }), []);
+});
+
+test('turn context injects queued runtime observations before the latest user message', async () => {
+  const store = new RuntimeObservationStore({ now: () => 1_000 });
+  store.upsert({
+    id: 'queued-web',
+    sessionId: 'session-a',
+    source: 'web_search',
+    title: 'Fresh web result',
+    summary: 'The background search found a relevant release note.',
+    tokenEstimate: 3,
+  });
+
+  const builder = new TurnContextBuilder();
+  const result = await builder.build({
+    sessionKey: 'session-a',
+    durableMessages: [
+      { role: 'system', content: 'base system' },
+      { role: 'user', content: 'real question' },
+    ],
+    runtimeFeedback: [],
+    skillRuntime: createNoopSkillRuntime(),
+    runtimeObservationStore: store,
+  });
+
+  const observationIndex = result.messages.findIndex(message =>
+    typeof message.content === 'string'
+    && message.content.startsWith(RUNTIME_OBSERVATIONS_PREFIX)
+  );
+  const userIndex = result.messages.findIndex(message =>
+    message.role === 'user' && message.content === 'real question'
+  );
+
+  assert.deepEqual(result.runtimeObservationIdsForPrompt, ['queued-web']);
+  assert.ok(observationIndex >= 0, 'runtime observation should be injected');
+  assert.ok(observationIndex < userIndex, 'runtime observation should appear before latest user');
+  assert.equal(result.messages[observationIndex].role, 'user');
+  assert.equal(result.messages[observationIndex].__injected, true);
+  assert.equal(result.messages[observationIndex].__runtimeObservation, true);
+  assert.equal(store.get('queued-web')?.status, 'ready', 'builder should not mark sent observations');
+
+  const durable = builder.removeTransientMessages(result.messages);
+  assert.equal(durable.some(message =>
+    typeof message.content === 'string'
+    && message.content.startsWith(RUNTIME_OBSERVATIONS_PREFIX)
+  ), false);
+  assert.equal(durable.some(message => message.role === 'user' && message.content === 'real question'), true);
+});
+
+test('AgentSession sends queued runtime observations once and keeps durable history clean', async () => {
+  const originalCwd = process.cwd();
+  const testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-runtime-observation-store-'));
+  process.chdir(testRoot);
+
+  try {
+    const { AgentSession } = loadAgentSessionModules();
+    const capturedRequests: any[][] = [];
+    const session = new AgentSession('user:runtime-observation-store-demo', buildMockServices({
+      aiService: {
+        async chatStream(messages: any[]) {
+          capturedRequests.push(messages.map(message => ({ ...message })));
+          return {
+            content: 'done',
+            toolCalls: [],
+            usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+          };
+        },
+      },
+    }), 'chat');
+    session.setSystemPromptProvider(() => 'system prompt');
+
+    const queued = session.upsertRuntimeObservation({
+      id: 'queued-review',
+      source: 'review',
+      title: 'Background review',
+      summary: 'The async reviewer found one cache-sensitive prompt insertion.',
+      tokenEstimate: 4,
+    });
+    assert.equal(queued.status, 'ready');
+
+    await session.handleMessage('real question');
+
+    assert.equal(capturedRequests.length, 1);
+    const requestMessages = capturedRequests[0];
+    const observationIndex = requestMessages.findIndex(message =>
+      typeof message.content === 'string'
+      && message.content.startsWith(RUNTIME_OBSERVATIONS_PREFIX)
+    );
+    const userIndex = requestMessages.findIndex(message =>
+      message.role === 'user' && message.content === 'real question'
+    );
+
+    assert.ok(observationIndex >= 0, 'provider input should include the queued observation');
+    assert.ok(observationIndex < userIndex, 'queued observation should be before the real user request');
+    assert.equal(requestMessages[observationIndex].role, 'user');
+    assert.equal(requestMessages[observationIndex].__injected, true);
+    assert.equal(requestMessages[observationIndex].__runtimeObservation, true);
+    assert.equal((session as any).runtimeObservationStore.get('queued-review')?.status, 'injected');
+    assert.equal((session as any).messages.some((message: any) =>
+      typeof message.content === 'string'
+      && message.content.startsWith(RUNTIME_OBSERVATIONS_PREFIX)
+    ), false);
+  } finally {
+    process.chdir(originalCwd);
+    await removeTempDir(testRoot);
+  }
+});
+
+function createNoopSkillRuntime(): any {
+  return {
+    reloadSkills: async () => undefined,
+    buildSkillsListMessage: () => null,
+  };
+}
+
+function loadAgentSessionModules(): any {
+  for (const modulePath of [
+    '../src/core/agent-session',
+    '../src/core/session-lifecycle-manager',
+    '../src/utils/session-store',
+    '../src/utils/session-turn-logger',
+  ]) {
+    delete require.cache[require.resolve(modulePath)];
+  }
+  return require('../src/core/agent-session');
+}
+
+function buildMockServices(overrides: any = {}): any {
+  return {
+    aiService: overrides.aiService ?? {},
+    toolManager: overrides.toolManager ?? {
+      getToolDefinitions() { return []; },
+      executeTool() { throw new Error('not expected'); },
+      getWorkspaceRoot() { return process.cwd(); },
+    },
+    skillManager: {
+      getSkill() { return undefined; },
+      getUserInvocableSkills() { return []; },
+      getAutoInvocableSkills() { return []; },
+      findAutoInvocableSkillByText() { return undefined; },
+      loadSkills: async () => {},
+    },
+  };
+}
+
+async function removeTempDir(dir: string): Promise<void> {
+  for (let attempt = 0; attempt < 5; attempt++) {
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+      return;
+    } catch (error: any) {
+      if (error?.code !== 'EBUSY' && error?.code !== 'EPERM') {
+        throw error;
+      }
+      await new Promise(resolve => setTimeout(resolve, 25));
+    }
+  }
+}


### PR DESCRIPTION
## 背景

这版是 prompt 注入治理的第一步：先建立统一规范和一个最小可运行的 Runtime Observation Store，给后续 memory graph、web search、review 等异步上下文来源接入。

## 改动

- 新增 `docs/prompt-injection-guidelines.md`，定义 prompt 注入分类、role 规则、缓存安全边界和 PR 检查清单
- 新增 `docs/runtime-observations.md`，说明 runtime observation store 的数据模型、生命周期和 prompt 形态
- 新增 `RuntimeObservationStore`，支持 upsert、pickForPrompt、markInjected、markConsumed、过期、预算、优先级和 hash 去重
- 新增 `renderRuntimeObservations(...)`，统一渲染为 `[runtime_observations]` 的 `user + __injected` 消息
- 接入 `AgentSession.upsertRuntimeObservation(...)`，异步结果可先写入 store，下一轮真实用户消息前注入
- `TurnContextBuilder` 负责挑选和注入 observation，`AgentTurnController` 在发送成功后标记为 injected
- 确保 runtime observation 不进 `system`，不进入 durable history

## 非目标

- 不迁移现有 runner hint、plan status、skills list、subagent status、current directory 注入
- 不接入真实 memory graph / web search / review 逻辑
- 不引入完整 lane/scheduler 或持久化队列

## 验证

- `node node_modules\tsx\dist\cli.mjs --test tests\runtime-observation-store.test.ts`
- `npm run build`
- `git diff --check`

补充跑过相邻测试：

- `node node_modules\tsx\dist\cli.mjs --test tests\subagent-runtime-events.test.ts`
- `node node_modules\tsx\dist\cli.mjs --test tests\runtime-feedback.test.ts`