### PR TITLE
改善中转额度耗尽提示

### DIFF
--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -511,10 +511,13 @@ export class AgentSession {
         const isImageSafetyError = isModelImageSafetyError(err);
         const isVisionError = !isImageSafetyError && errorMsg.match(/image|vision|multimodal|media_type|base64.*not supported/i);
         const isModelTimeoutError = this.isModelTimeoutError(err);
+        const relayBudgetErrorReply = this.formatRelayBudgetErrorReply(err);
 
         let errorReply = ERROR_MESSAGE;
         if (isImageSafetyError) {
           errorReply = MODEL_IMAGE_SAFETY_MESSAGE;
+        } else if (relayBudgetErrorReply) {
+          errorReply = relayBudgetErrorReply;
         } else if (isVisionError) {
           errorReply = '当前模型不支持图片识别。请使用支持多模态的模型（如 Claude 3.5 Sonnet 或 GPT-4V），或者用文字描述图片内容。';
         } else if (isModelTimeoutError) {
@@ -732,6 +735,45 @@ export class AgentSession {
   private isModelTimeoutError(error: any): boolean {
     const text = String(error?.message || error || '');
     return /API错误\s*\(504\)|request_timed_out|request timed out|default_request_timeout_in_seconds|upstream request timeout|gateway timeout/i.test(text);
+  }
+
+  private formatRelayBudgetErrorReply(error: any): string | null {
+    const text = String(error?.message || error || '');
+    const status = this.extractErrorStatus(error);
+    const isBudgetError =
+      status === 402
+      || /api错误\s*\(402\)|status(?:\s*code)?\s*[:=]?\s*402\b|http(?:\s*status)?\s*[:=]?\s*402\b|payment[_\s-]?required/i.test(text)
+      || /budget exceeded|quota exceeded|insufficient quota|insufficient balance|credits? exhausted|monthly budget|model budget|relay budget/i.test(text)
+      || /额度.{0,12}(不足|用完|耗尽|超限|达到上限|已用尽)|余额不足|已达.*额度上限/.test(text);
+
+    if (!isBudgetError) {
+      return null;
+    }
+
+    const model = this.currentModelName();
+    const modelLabel = model ? `当前模型 ${model} 的` : '当前模型的';
+    if (/model budget exceeded|model quota|模型.{0,8}额度/i.test(text)) {
+      return `${modelLabel}中转额度已用完，暂时不能继续调用。\n\n你可以切换到还有额度的模型，或到 CatsCompany 中转页面查看额度；如果这是学校/团队账号，请联系管理员调整额度。`;
+    }
+
+    if (/monthly budget exceeded|account budget|user budget|账号.{0,8}额度|本月.{0,8}额度/i.test(text)) {
+      return '当前账号的中转额度已用完，暂时不能继续调用模型。\n\n请到 CatsCompany 中转页面查看额度，或联系管理员调整额度。';
+    }
+
+    return `模型中转额度不足，当前请求没有继续调用${model ? ` ${model}` : ''}。\n\n你可以切换模型、稍后重试，或到 CatsCompany 中转页面查看额度并联系管理员调整。`;
+  }
+
+  private extractErrorStatus(error: any): number | null {
+    const status = error?.status || error?.response?.status || error?.error?.status;
+    return typeof status === 'number' ? status : null;
+  }
+
+  private currentModelName(): string | null {
+    const config = typeof (this.services.aiService as any).getConfig === 'function'
+      ? (this.services.aiService as any).getConfig()
+      : {};
+    const model = String(config?.model || '').trim();
+    return model || null;
   }
 
   private formatErrorContextMessage(error: any, isModelTimeoutError: boolean, isImageSafetyError = false): string {

--- a/tests/session-lifecycle-manager.test.ts
+++ b/tests/session-lifecycle-manager.test.ts
@@ -365,6 +365,59 @@ describe('AgentSession lifecycle', () => {
     ), true);
   });
 
+  test('handleMessage surfaces relay budget exhaustion without leaking raw provider errors', async () => {
+    const { AgentSession } = loadSessionModules();
+    const session = new AgentSession('catscompany:lifecycle-model-budget', buildMockServices({
+      aiService: {
+        getConfig() {
+          return { model: 'MiniMax-M3' };
+        },
+        async chatStream() {
+          throw new Error('API错误 (402): {"type":"error","error":{"message":"model budget exceeded"}}');
+        },
+      },
+    }), 'catscompany');
+    session.setSystemPromptProvider(() => 'system prompt');
+
+    const result = await session.handleMessage('continue');
+
+    assert.match(result.text, /当前模型 MiniMax-M3 的中转额度已用完/);
+    assert.doesNotMatch(result.text, /model budget exceeded|API错误/i);
+  });
+
+  test('handleMessage surfaces account budget exhaustion when model config is unavailable', async () => {
+    const { AgentSession } = loadSessionModules();
+    const session = new AgentSession('catscompany:lifecycle-account-budget', buildMockServices({
+      aiService: {
+        async chatStream() {
+          throw new Error('Request failed: Payment Required: monthly budget exceeded');
+        },
+      },
+    }), 'catscompany');
+    session.setSystemPromptProvider(() => 'system prompt');
+
+    const result = await session.handleMessage('continue');
+
+    assert.match(result.text, /当前账号的中转额度已用完/);
+    assert.doesNotMatch(result.text, /当前模型 当前模型/);
+  });
+
+  test('handleMessage does not treat unrelated 402 text as relay budget exhaustion', async () => {
+    const { AgentSession, ERROR_MESSAGE } = loadSessionModules();
+    const session = new AgentSession('catscompany:lifecycle-nonbudget-402', buildMockServices({
+      aiService: {
+        async chatStream() {
+          throw new Error('API错误 (400): request body mentions 402 tokens but schema is invalid');
+        },
+      },
+    }), 'catscompany');
+    session.setSystemPromptProvider(() => 'system prompt');
+
+    const result = await session.handleMessage('continue');
+
+    assert.equal(result.text, ERROR_MESSAGE);
+  });
+
   test('cleanup persists without invoking hidden AI wakeup checks', async () => {
     const { AgentSession, SessionStore } = loadSessionModules();
     let aiCalls = 0;
@@ -431,6 +484,7 @@ function loadSessionModules(): any {
   }
   return {
     AgentSession: require('../src/core/agent-session').AgentSession,
+    ERROR_MESSAGE: require('../src/core/agent-session').ERROR_MESSAGE,
     MODEL_TIMEOUT_MESSAGE: require('../src/core/agent-session').MODEL_TIMEOUT_MESSAGE,
     CONTEXT_COMPACTION_START_MESSAGE: require('../src/core/agent-session').CONTEXT_COMPACTION_START_MESSAGE,
     CONTEXT_COMPACTION_COMPLETE_MESSAGE: require('../src/core/agent-session').CONTEXT_COMPACTION_COMPLETE_MESSAGE,


### PR DESCRIPTION
## 变更
- 识别 relay / Bifrost 返回的额度类错误，例如 `model budget exceeded`、`monthly budget exceeded`、`402`、`quota exceeded`。
- 将用户可见文案从通用“处理出了点问题”改成明确的模型额度/账号额度提示。
- 保留原始错误摘要进入本地上下文，方便用户说“继续”时仍能接上当前状态。

## 根因
relay 侧已经会拦截额度耗尽并返回 402/预算错误，但 CatsCo 会话层把这类异常当成普通 API 失败处理，最终落到通用错误文案，用户不知道是额度问题。

## 验证
- `npm.cmd run build`
- `git diff --check`
