### PR TITLE
优化模型临时异常重试与提示

### DIFF
--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -49,6 +49,7 @@ export type { RuntimeFeedbackInput, RuntimeFeedbackOptions } from './runtime-fee
 export const BUSY_MESSAGE = '正在处理上一条消息，请稍候...';
 export const ERROR_MESSAGE = '不好意思，刚才处理出了点问题，你再试一次？';
 export const MODEL_TIMEOUT_MESSAGE = '模型中转请求超时了，我已经保留本轮已完成的工具结果和上下文。你可以直接说“继续”，我会从这里接上。';
+export const MODEL_TRANSIENT_ERROR_MESSAGE = '当前模型服务临时异常，刚才这次请求没有完成。我已经保留上下文；你可以稍后重试，或临时切换到其他模型继续。';
 export const CONTEXT_COMPACTION_START_MESSAGE = '正在压缩上下文，整理较早的对话内容。';
 export const CONTEXT_COMPACTION_COMPLETE_MESSAGE = '上下文压缩完成，继续处理当前请求。';
 export const CONTEXT_COMPACTION_ERROR_MESSAGE = '上下文压缩失败，已保留原上下文继续处理。';
@@ -514,6 +515,7 @@ export class AgentSession {
         const isImageSafetyError = isModelImageSafetyError(err);
         const isVisionError = !isImageSafetyError && errorMsg.match(/image|vision|multimodal|media_type|base64.*not supported/i);
         const isModelTimeoutError = this.isModelTimeoutError(err);
+        const isTransientProviderError = this.isTransientProviderError(err);
         const relayBudgetErrorReply = this.formatRelayBudgetErrorReply(err);
 
         let errorReply = ERROR_MESSAGE;
@@ -525,12 +527,18 @@ export class AgentSession {
           errorReply = '当前模型不支持图片识别。请使用支持多模态的模型（如 Claude 3.5 Sonnet 或 GPT-4V），或者用文字描述图片内容。';
         } else if (isModelTimeoutError) {
           errorReply = MODEL_TIMEOUT_MESSAGE;
+        } else if (isTransientProviderError) {
+          errorReply = this.formatTransientProviderErrorReply();
         }
 
         // 添加错误回复到上下文，保持对话连贯性
         this.messages.push({
           role: 'assistant',
-          content: this.formatErrorContextMessage(err, isModelTimeoutError, isImageSafetyError),
+          content: this.formatErrorContextMessage(err, {
+            isModelTimeoutError,
+            isImageSafetyError,
+            isTransientProviderError,
+          }),
           __internalErrorArtifact: true,
         });
         this.messages = stripAssistantArtifactsFromMessages(this.turnContextBuilder.removeTransientMessages(this.messages));
@@ -741,6 +749,16 @@ export class AgentSession {
     return /API错误\s*\(504\)|request_timed_out|request timed out|default_request_timeout_in_seconds|upstream request timeout|gateway timeout/i.test(text);
   }
 
+  private isTransientProviderError(error: any): boolean {
+    const status = this.extractErrorStatus(error);
+    if (status && [500, 502, 503, 504, 520, 524, 529].includes(status)) {
+      return true;
+    }
+
+    const text = String(error?.message || error || '');
+    return /unknown error,\s*520|overloaded_error|service unavailable|bad gateway|gateway timeout|upstream (?:error|timeout)|MaxRetriesExceededError|Connection error|ECONNRESET|ETIMEDOUT|EAI_AGAIN|fetch failed|socket hang up|network error|premature close/i.test(text);
+  }
+
   private formatRelayBudgetErrorReply(error: any): string | null {
     const text = String(error?.message || error || '');
     const status = this.extractErrorStatus(error);
@@ -769,7 +787,13 @@ export class AgentSession {
 
   private extractErrorStatus(error: any): number | null {
     const status = error?.status || error?.response?.status || error?.error?.status;
-    return typeof status === 'number' ? status : null;
+    if (typeof status === 'number') return status;
+
+    const text = String(error?.message || error || '');
+    const match = text.match(/(?:API错误|HTTP|status(?:\s*code)?)\s*[\(:= ]\s*(\d{3})\b/i);
+    if (!match) return null;
+    const parsed = Number(match[1]);
+    return Number.isFinite(parsed) ? parsed : null;
   }
 
   private currentModelName(): string | null {
@@ -780,13 +804,30 @@ export class AgentSession {
     return model || null;
   }
 
-  private formatErrorContextMessage(error: any, isModelTimeoutError: boolean, isImageSafetyError = false): string {
+  private formatTransientProviderErrorReply(): string {
+    const model = this.currentModelName();
+    return model
+      ? `当前模型 ${model} 的服务临时异常，刚才这次请求没有完成。我已经保留上下文；你可以稍后重试，或临时切换到其他模型继续。`
+      : MODEL_TRANSIENT_ERROR_MESSAGE;
+  }
+
+  private formatErrorContextMessage(
+    error: any,
+    flags: {
+      isModelTimeoutError?: boolean;
+      isImageSafetyError?: boolean;
+      isTransientProviderError?: boolean;
+    },
+  ): string {
     const detail = this.sanitizeErrorMessage(error?.message || String(error));
-    if (isModelTimeoutError) {
+    if (flags.isModelTimeoutError) {
       return `[处理中断: 模型中转请求超时。已保留本轮已完成的工具结果和上下文；如果用户要求继续，请基于当前上下文继续，避免重复已经完成的工具步骤。错误摘要: ${detail}]`;
     }
-    if (isImageSafetyError) {
+    if (flags.isImageSafetyError) {
       return `[处理中断: 上游模型拒绝了当前对话中的图片。已保留本轮已完成的上下文；如果用户要求继续，请提示用户删除或更换相关图片，或新开对话后继续。错误摘要: ${detail}]`;
+    }
+    if (flags.isTransientProviderError) {
+      return `[处理中断: 模型服务临时异常或上游网关错误。已保留本轮上下文；如果用户要求继续，请从当前状态继续，不要重复已经完成的工具步骤。错误摘要: ${detail}]`;
     }
     return `[处理失败: ${detail}]`;
   }

--- a/src/utils/ai-service.ts
+++ b/src/utils/ai-service.ts
@@ -13,7 +13,7 @@ import { resolveModelContextWindow } from './model-context-window';
  * 内部委托给对应的 Provider 实现
  */
 /** 可重试的 HTTP 状态码 */
-const RETRYABLE_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504, 529]);
+const RETRYABLE_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504, 520, 524, 529]);
 const MAX_RETRIES = 3;
 const BASE_DELAY_MS = 1000;
 
@@ -100,9 +100,9 @@ export class AIService {
   }
 
   /**
-   * 流式调用
-   * 默认不重试，避免部分 token 已输出后出现重复文本。
-   * 如需强制开启重试，可设置 GAUZ_STREAM_RETRY=true（需自行保证幂等）。
+   * 流式调用。
+   * 默认只在没有任何文本输出前重试，避免用户看到重复片段。
+   * 如需强制开启完整流式重试，可设置 GAUZ_STREAM_RETRY=true（需自行保证幂等）。
    */
   async chatStream(
     messages: Message[],
@@ -115,18 +115,18 @@ export class AIService {
     }
 
     const allowStreamRetry = process.env.GAUZ_STREAM_RETRY === 'true';
-    const providerCallbacks = this.createProviderStreamCallbacks(callbacks);
+    let hasStreamedText = false;
+    const providerCallbacks = this.createProviderStreamCallbacks(callbacks, () => {
+      hasStreamedText = true;
+    });
 
     try {
-      if (allowStreamRetry) {
-        return await this.withRetry(
-          () => this.provider.chatStream(messages, tools, providerCallbacks, options),
-          callbacks,
-          options.signal,
-        );
-      }
-      this.throwIfAborted(options.signal);
-      return await this.provider.chatStream(messages, tools, providerCallbacks, options);
+      return await this.withRetry(
+        () => this.provider.chatStream(messages, tools, providerCallbacks, options),
+        callbacks,
+        options.signal,
+        () => allowStreamRetry || !hasStreamedText,
+      );
     } catch (error: any) {
       const wrapped = this.wrapError(error);
       callbacks?.onError?.(wrapped);
@@ -134,13 +134,16 @@ export class AIService {
     }
   }
 
-  private createProviderStreamCallbacks(callbacks?: StreamCallbacks): StreamCallbacks | undefined {
+  private createProviderStreamCallbacks(callbacks?: StreamCallbacks, onTextObserved?: () => void): StreamCallbacks | undefined {
     if (!callbacks) {
       return undefined;
     }
 
     return {
-      onText: callbacks.onText,
+      onText: (text: string) => {
+        if (text) onTextObserved?.();
+        callbacks.onText?.(text);
+      },
       onComplete: callbacks.onComplete,
     };
   }
@@ -195,7 +198,13 @@ export class AIService {
     }
 
     const message = String(error?.message || '');
-    if (/timeout|timed out|socket hang up|network error|fetch failed|premature close|ECONNREFUSED/i.test(message)) {
+    const hasRetryableStatusText =
+      /(?:API错误|HTTP|status(?:\s*code)?|response status)\s*[\(:= ]\s*(?:500|502|503|504|520|524|529)\b/i.test(message)
+      || /^\s*(?:500|502|503|504|520|524|529)\b/.test(message);
+    if (
+      hasRetryableStatusText
+      || /timeout|timed out|socket hang up|network error|fetch failed|premature close|ECONNREFUSED|bad gateway|gateway timeout|service unavailable|unknown error,\s*520/i.test(message)
+    ) {
       return true;
     }
 
@@ -215,6 +224,12 @@ export class AIService {
     if (typeof status === 'number') {
       return status;
     }
+    const text = String(error?.message || error || '');
+    const match = text.match(/(?:API错误|HTTP|status(?:\s*code)?)\s*[\(:= ]\s*(\d{3})\b/i);
+    if (match) {
+      const parsed = Number(match[1]);
+      return Number.isFinite(parsed) ? parsed : null;
+    }
     return null;
   }
 
@@ -233,7 +248,12 @@ export class AIService {
   /**
    * 带指数退避的重试包装器
    */
-  private async withRetry<T>(fn: () => Promise<T>, callbacks?: StreamCallbacks, signal?: AbortSignal): Promise<T> {
+  private async withRetry<T>(
+    fn: () => Promise<T>,
+    callbacks?: StreamCallbacks,
+    signal?: AbortSignal,
+    shouldRetry?: (error: any, attempt: number) => boolean,
+  ): Promise<T> {
     let lastError: any;
 
     for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
@@ -247,7 +267,7 @@ export class AIService {
           throw this.createAbortError();
         }
 
-        if (attempt >= MAX_RETRIES || !this.isRetryable(error)) {
+        if (attempt >= MAX_RETRIES || !this.isRetryable(error) || shouldRetry?.(error, attempt) === false) {
           throw error;
         }
 

--- a/tests/ai-service.test.ts
+++ b/tests/ai-service.test.ts
@@ -14,7 +14,7 @@ afterEach(() => {
   }
 });
 
-test('AIService reports stream provider errors once', async () => {
+test('AIService reports non-retryable stream provider errors once', async () => {
   const service = createTestService();
   const rawError = new Error('provider stream failed');
   (service as any).provider = {
@@ -35,8 +35,7 @@ test('AIService reports stream provider errors once', async () => {
   assert.match(errors[0].message, /请求失败: provider stream failed/);
 });
 
-test('AIService does not surface transient stream errors when retry succeeds', async () => {
-  process.env.GAUZ_STREAM_RETRY = 'true';
+test('AIService retries transient stream errors before any text is emitted', async () => {
   const service = createTestService();
   let attempts = 0;
   const finalResponse: ChatResponse = { content: 'ok' };
@@ -46,7 +45,11 @@ test('AIService does not surface transient stream errors when retry succeeds', a
       attempts += 1;
       if (attempts === 1) {
         const retryableError = Object.assign(new Error('temporary stream failure'), {
-          response: { status: 503, data: { message: 'temporary stream failure' } },
+          response: {
+            status: 503,
+            headers: { 'retry-after': '0' },
+            data: { message: 'temporary stream failure' },
+          },
         });
         callbacks?.onError?.(retryableError);
         throw retryableError;
@@ -72,6 +75,96 @@ test('AIService does not surface transient stream errors when retry succeeds', a
   assert.deepStrictEqual(errors, []);
   assert.deepStrictEqual(retries, [[1, 3]]);
   assert.deepStrictEqual(chunks, ['ok']);
+});
+
+test('AIService does not retry stream errors after visible text is emitted', async () => {
+  const service = createTestService();
+  let attempts = 0;
+  const retryableError = Object.assign(new Error('temporary stream failure after text'), {
+    response: {
+      status: 503,
+      headers: { 'retry-after': '0' },
+      data: { message: 'temporary stream failure after text' },
+    },
+  });
+  (service as any).provider = {
+    chat: async () => ({ content: null }),
+    chatStream: async (_messages: unknown, _tools: unknown, callbacks?: StreamCallbacks) => {
+      attempts += 1;
+      callbacks?.onText?.('partial');
+      throw retryableError;
+    },
+  };
+
+  const errors: Error[] = [];
+  const retries: Array<[number, number]> = [];
+  const chunks: string[] = [];
+  await assert.rejects(
+    () => service.chatStream([], undefined, {
+      onError: error => errors.push(error),
+      onRetry: (attempt, maxRetries) => retries.push([attempt, maxRetries]),
+      onText: text => chunks.push(text),
+    }),
+    /API错误 \(503\): temporary stream failure after text/,
+  );
+
+  assert.equal(attempts, 1);
+  assert.equal(errors.length, 1);
+  assert.deepStrictEqual(retries, []);
+  assert.deepStrictEqual(chunks, ['partial']);
+});
+
+test('AIService still honors explicit full stream retry opt-in', async () => {
+  process.env.GAUZ_STREAM_RETRY = 'true';
+  const service = createTestService();
+  let attempts = 0;
+  const finalResponse: ChatResponse = { content: 'ok' };
+  (service as any).provider = {
+    chat: async () => ({ content: null }),
+    chatStream: async (_messages: unknown, _tools: unknown, callbacks?: StreamCallbacks) => {
+      attempts += 1;
+      callbacks?.onText?.(attempts === 1 ? 'partial' : 'ok');
+      if (attempts === 1) {
+        throw Object.assign(new Error('temporary stream failure'), {
+          response: {
+            status: 503,
+            headers: { 'retry-after': '0' },
+            data: { message: 'temporary stream failure' },
+          },
+        });
+      }
+      callbacks?.onComplete?.(finalResponse);
+      return finalResponse;
+    },
+  };
+
+  const chunks: string[] = [];
+  const result = await service.chatStream([], undefined, {
+    onText: text => chunks.push(text),
+  });
+
+  assert.equal(result, finalResponse);
+  assert.equal(attempts, 2);
+  assert.deepStrictEqual(chunks, ['partial', 'ok']);
+});
+
+test('AIService does not treat bare token counts as retryable status codes', async () => {
+  const service = createTestService();
+  let attempts = 0;
+  const rawError = new Error('requested 500 tokens but schema is invalid');
+  (service as any).provider = {
+    chat: async () => {
+      attempts += 1;
+      throw rawError;
+    },
+    chatStream: async () => ({ content: null }),
+  };
+
+  await assert.rejects(
+    () => service.chat([]),
+    /请求失败: requested 500 tokens but schema is invalid/,
+  );
+  assert.equal(attempts, 1);
 });
 
 test('AIService passes AbortSignal to chatStream provider calls', async () => {

--- a/tests/session-lifecycle-manager.test.ts
+++ b/tests/session-lifecycle-manager.test.ts
@@ -595,6 +595,26 @@ describe('AgentSession lifecycle', () => {
     assert.doesNotMatch(result.text, /unknown error|request_id|API错误|520/);
   });
 
+  test('handleMessage treats wrapped 503 request errors as transient provider failures', async () => {
+    const { AgentSession } = loadSessionModules();
+    const session = new AgentSession('catscompany:lifecycle-transient-503', buildMockServices({
+      aiService: {
+        getConfig() {
+          return { model: 'gpt-5.5' };
+        },
+        async chatStream() {
+          throw new Error('API错误 (503): 503 请求错误(状态码: 503)');
+        },
+      },
+    }), 'catscompany');
+    session.setSystemPromptProvider(() => 'system prompt');
+
+    const result = await session.handleMessage('继续');
+
+    assert.match(result.text, /当前模型 gpt-5\.5 的服务临时异常/);
+    assert.doesNotMatch(result.text, /API错误|状态码|503/);
+  });
+
   test('cleanup persists without invoking hidden AI wakeup checks', async () => {
     const { AgentSession, SessionStore } = loadSessionModules();
     let aiCalls = 0;

--- a/tests/session-lifecycle-manager.test.ts
+++ b/tests/session-lifecycle-manager.test.ts
@@ -575,6 +575,26 @@ describe('AgentSession lifecycle', () => {
     assert.equal(result.text, ERROR_MESSAGE);
   });
 
+  test('handleMessage surfaces transient provider failures without leaking raw upstream payload', async () => {
+    const { AgentSession } = loadSessionModules();
+    const session = new AgentSession('catscompany:lifecycle-transient-provider', buildMockServices({
+      aiService: {
+        getConfig() {
+          return { model: 'MiniMax-M3' };
+        },
+        async chatStream() {
+          throw new Error('API错误 (500): 500 {"type":"error","error":{"type":"api_error","message":"unknown error, 520 (1000)"},"request_id":"req_123"}');
+        },
+      },
+    }), 'catscompany');
+    session.setSystemPromptProvider(() => 'system prompt');
+
+    const result = await session.handleMessage('continue');
+
+    assert.match(result.text, /当前模型 MiniMax-M3 的服务临时异常/);
+    assert.doesNotMatch(result.text, /unknown error|request_id|API错误|520/);
+  });
+
   test('cleanup persists without invoking hidden AI wakeup checks', async () => {
     const { AgentSession, SessionStore } = loadSessionModules();
     let aiCalls = 0;
@@ -643,6 +663,7 @@ function loadSessionModules(): any {
     AgentSession: require('../src/core/agent-session').AgentSession,
     ERROR_MESSAGE: require('../src/core/agent-session').ERROR_MESSAGE,
     MODEL_TIMEOUT_MESSAGE: require('../src/core/agent-session').MODEL_TIMEOUT_MESSAGE,
+    MODEL_TRANSIENT_ERROR_MESSAGE: require('../src/core/agent-session').MODEL_TRANSIENT_ERROR_MESSAGE,
     CONTEXT_COMPACTION_START_MESSAGE: require('../src/core/agent-session').CONTEXT_COMPACTION_START_MESSAGE,
     CONTEXT_COMPACTION_COMPLETE_MESSAGE: require('../src/core/agent-session').CONTEXT_COMPACTION_COMPLETE_MESSAGE,
     SessionStore: require('../src/utils/session-store').SessionStore,


### PR DESCRIPTION
## 变更
- 将 500/502/503/504/520/524/529 等上游临时异常纳入可重试范围。
- 流式请求默认只在尚未输出可见文本前重试，避免用户看到重复回复；保留 `GAUZ_STREAM_RETRY=true` 作为显式完整流式重试开关。
- 对模型临时异常给出更清楚的用户提示，避免把上游原始 JSON、request_id 或 520 文案直接发到聊天里。

## 背景
反馈 #43 中 MiniMax-M3 偶发返回 500/520，用户看到的是裸 provider 错误。服务器日志显示这是上游/relay 短时异常窗口，客户端应自动做有限重试，并在最终失败时给可理解的恢复提示。

## 验证
- `npx.cmd tsx --test tests/ai-service.test.ts`
- `npx.cmd tsx --test tests/session-lifecycle-manager.test.ts`
- `npm.cmd run build`
- `npm.cmd run release:check`
- `git diff --check`
- `npm.cmd run test:runtime`（692 tests, 0 fail）
