### PR TITLE
增加 prompt 可观测性日志

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -796,6 +796,201 @@
       color: var(--red);
     }
 
+    .prompt-workbench {
+      display: grid;
+      gap: 18px;
+    }
+
+    .prompt-trace-grid {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 12px;
+    }
+
+    .prompt-trace-card {
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      background: var(--surface-muted);
+      padding: 14px;
+      min-width: 0;
+    }
+
+    .prompt-trace-label {
+      color: var(--text3);
+      font-size: 11px;
+      font-weight: 800;
+      margin-bottom: 8px;
+    }
+
+    .prompt-trace-value {
+      color: var(--text);
+      font-size: 13px;
+      font-weight: 800;
+      line-height: 1.4;
+      overflow-wrap: anywhere;
+    }
+
+    .prompt-editor-layout {
+      display: grid;
+      grid-template-columns: minmax(220px, 300px) minmax(0, 1fr);
+      gap: 16px;
+      align-items: stretch;
+    }
+
+    .prompt-file-list,
+    .prompt-editor-pane {
+      border: 1px solid var(--border);
+      border-radius: 18px;
+      background: var(--surface-strong);
+      box-shadow: var(--shadow-sm), var(--glow);
+      min-width: 0;
+    }
+
+    .prompt-file-list {
+      padding: 10px;
+      max-height: min(68vh, 720px);
+      overflow: auto;
+    }
+
+    .prompt-file-group {
+      display: grid;
+      gap: 4px;
+      margin-bottom: 8px;
+    }
+
+    .prompt-file-group-title {
+      width: 100%;
+      border: 0;
+      background: transparent;
+      color: var(--text2);
+      padding: 8px 8px 6px;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font: inherit;
+      font-size: 12px;
+      font-weight: 900;
+      text-align: left;
+      cursor: pointer;
+      letter-spacing: 0;
+    }
+
+    .prompt-file-group-title:hover {
+      color: var(--text);
+    }
+
+    .prompt-file-group-title .chevron {
+      width: 14px;
+      color: var(--text3);
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    }
+
+    .prompt-file-item {
+      width: 100%;
+      border: 1px solid transparent;
+      border-radius: 12px;
+      background: transparent;
+      padding: 10px 11px;
+      color: var(--text);
+      text-align: left;
+      cursor: pointer;
+      display: grid;
+      gap: 5px;
+      font: inherit;
+    }
+
+    .prompt-file-item.nested {
+      margin-left: 14px;
+      width: calc(100% - 14px);
+    }
+
+    .prompt-file-item:hover {
+      background: var(--surface-muted);
+      border-color: var(--border-light);
+    }
+
+    .prompt-file-item.active {
+      background: rgba(59, 130, 246, 0.09);
+      border-color: rgba(59, 130, 246, 0.24);
+    }
+
+    .prompt-file-name {
+      font-size: 12px;
+      font-weight: 800;
+      overflow-wrap: anywhere;
+    }
+
+    .prompt-file-meta {
+      color: var(--text3);
+      font-size: 11px;
+      font-weight: 700;
+      line-height: 1.4;
+    }
+
+    .prompt-editor-pane {
+      padding: 16px;
+      display: grid;
+      gap: 12px;
+    }
+
+    .prompt-editor-head {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 12px;
+    }
+
+    .prompt-editor-title {
+      color: var(--text);
+      font-size: 16px;
+      font-weight: 800;
+      overflow-wrap: anywhere;
+    }
+
+    .prompt-editor-meta {
+      color: var(--text2);
+      font-size: 12px;
+      line-height: 1.5;
+      margin-top: 5px;
+    }
+
+    .prompt-editor-textarea {
+      width: 100%;
+      min-height: 460px;
+      resize: vertical;
+      font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+      font-size: 13px;
+      line-height: 1.65;
+      white-space: pre;
+      overflow: auto;
+    }
+
+    .prompt-editor-actions {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .prompt-editor-status {
+      color: var(--text2);
+      font-size: 12px;
+      font-weight: 700;
+      line-height: 1.5;
+    }
+
+    @media (max-width: 980px) {
+      .prompt-trace-grid,
+      .prompt-editor-layout {
+        grid-template-columns: 1fr;
+      }
+
+      .prompt-file-list {
+        max-height: 280px;
+      }
+    }
+
     .model-source-layout {
       display: grid;
       gap: 14px;
@@ -4867,6 +5062,9 @@
       <a class="nav-item" onclick="switchPage('store')" data-page="store">
         <span class="nav-icon">+</span> <span>Skills</span>
       </a>
+      <a class="nav-item" onclick="switchPage('prompts')" data-page="prompts">
+        <span class="nav-icon">#</span> <span>提示词</span>
+      </a>
       <a class="nav-item" onclick="switchPage('companion')" data-page="companion">
         <span class="nav-icon">*</span> <span>伙伴中心</span>
       </a>
@@ -5057,6 +5255,24 @@
             <div class="settings-meta" style="margin-bottom:14px">管理你发布到 SkillHub 的 Skill 和版本。下架会隐藏公开安装；删除会移除服务器版本和包文件。</div>
             <div class="portal-list" id="skillhub-package-versions-list"><div class="loading">暂无发布版本</div></div>
           </div>
+      </div>
+
+      <!-- Page: Prompts -->
+      <div class="page" id="page-prompts">
+        <div class="settings-header">
+          <div class="settings-heading">
+            <div class="settings-kicker">Prompt Lab</div>
+            <div class="section-title" style="margin-bottom:0">提示词调试</div>
+            <div class="settings-meta">编辑本地覆盖版本，重启 connector 或新建 session 后生效；日志会记录 system 和 bundle hash。</div>
+          </div>
+          <div class="settings-actions">
+            <button class="btn" onclick="copyPromptOverridesPath()">复制覆盖目录</button>
+            <button class="btn btn-primary" onclick="refreshPromptWorkbench()">刷新</button>
+          </div>
+        </div>
+        <div class="prompt-workbench" id="prompt-workbench">
+          <div class="loading">加载提示词...</div>
+        </div>
       </div>
 
       <!-- Page: Chat -->
@@ -5292,7 +5508,7 @@
     let appReadinessSnapshot = {};
     let appReadinessLoaded = false;
     let appReadinessError = '';
-    const pageTitles = { services:'Agent Hub', store:'SkillHub', companion:'Companion Hub', chat:'CatsCo' };
+    const pageTitles = { services:'Agent Hub', store:'SkillHub', prompts:'Prompt Lab', companion:'Companion Hub', chat:'CatsCo' };
     let catsAuthMode = 'login';
     let catsState = {};
     let catsNextAction = 'none';
@@ -5345,6 +5561,7 @@
     const PET_PROFILE_KEY = 'xiaoba.petProfile';
     const PET_PROCESS_KEY = 'xiaoba.petProcess';
     const PET_POSITION_KEY = 'xiaoba.petPosition';
+    const PROMPT_GROUP_STATE_KEY = 'xiaoba.promptGroupOpenState';
     const DASHBOARD_FONT_SCALE_KEY = 'xiaoba.dashboardFontScale';
     const DASHBOARD_FONT_SCALE_MIN = 85;
     const DASHBOARD_FONT_SCALE_MAX = 150;
@@ -5384,6 +5601,11 @@
     let skillHubAutoConnectInFlight = null;
     let skillHubRegistryCache = [];
     let localSkillsCache = [];
+    let promptEditorState = null;
+    let promptEditorFile = null;
+    let promptEditorSelectedPath = 'system-prompt.md';
+    let promptEditorDirty = false;
+    let promptGroupOpenState = loadPromptGroupOpenState();
 
     function loadPetProfile() {
       try {
@@ -5931,9 +6153,250 @@
       } else if (name === 'store') {
         refreshSkillHubPage();
         fetchSkillHubDeveloper();
+      } else if (name === 'prompts') {
+        refreshPromptWorkbench();
       } else if (name === 'services') {
         fetchStatus();
         refreshSettingsPage();
+      }
+    }
+
+    async function refreshPromptWorkbench(selectPath){
+      const root=document.getElementById('prompt-workbench');
+      if(root && !promptEditorState)root.innerHTML='<div class="loading">加载提示词...</div>';
+      try{
+        promptEditorState=await parseSimpleResponse(await fetch(API+'/api/prompts'));
+        const paths=(promptEditorState.files||[]).map(file=>file.path);
+        if(selectPath)promptEditorSelectedPath=selectPath;
+        if(!paths.includes(promptEditorSelectedPath)){
+          promptEditorSelectedPath=paths.includes('system-prompt.md')?'system-prompt.md':(paths[0]||'');
+        }
+        if(promptEditorSelectedPath){
+          promptEditorFile=await parseSimpleResponse(await fetch(API+'/api/prompts/file?path='+encodeURIComponent(promptEditorSelectedPath)));
+        }
+        promptEditorDirty=false;
+        renderPromptWorkbench();
+      }catch(e){
+        if(root)root.innerHTML='<div class="runtime-note danger">提示词加载失败：'+escapeHtml(e.message||String(e))+'</div>';
+      }
+    }
+
+    async function selectPromptEditorFile(path){
+      if(promptEditorDirty && !confirm('当前 prompt 有未保存改动，确定切换文件吗？'))return;
+      promptEditorSelectedPath=path;
+      promptEditorDirty=false;
+      await refreshPromptWorkbench(path);
+    }
+
+    function renderPromptWorkbench(){
+      const root=document.getElementById('prompt-workbench');
+      if(!root)return;
+      if(!promptEditorState){
+        root.innerHTML='<div class="loading">加载提示词...</div>';
+        return;
+      }
+      const trace=promptEditorState.trace||{};
+      const system=trace.system||{};
+      const bundle=trace.bundle||{};
+      const files=promptEditorState.files||[];
+      const selected=promptEditorFile;
+      const listHtml=renderPromptFileTree(files);
+      const editorHtml=selected?renderPromptEditorPane(selected):'<div class="prompt-editor-pane"><div class="loading">请选择 prompt 文件</div></div>';
+      root.innerHTML=
+        '<div class="prompt-trace-grid">'+
+          promptTraceCard('System hash', system.short_hash||'-', (system.chars||0)+' 字符')+
+          promptTraceCard('Bundle hash', bundle.short_hash||'-', (bundle.file_count||0)+' 个文件')+
+          promptTraceCard('Version', trace.prompt_version||'local', trace.source||'-')+
+          promptTraceCard('Overrides', promptEditorState.writable?'可写':'未配置', promptEditorState.overrides_dir||'-')+
+        '</div>'+
+        '<div class="runtime-note">保存只写入本地覆盖目录，不改安装包内置 prompts。当前运行中的 connector 需要重启，已存在 session 也要新建后才会重新读取 system prompt。</div>'+
+        '<div class="prompt-editor-layout">'+
+          '<div class="prompt-file-list">'+(listHtml||'<div class="loading">没有可编辑的 prompt 文件</div>')+'</div>'+
+          editorHtml+
+        '</div>';
+    }
+
+    function loadPromptGroupOpenState(){
+      try{
+        return {
+          core:true,
+          docs:false,
+          sidecars:true,
+          subagents:true,
+          transient:true,
+          ...JSON.parse(localStorage.getItem(PROMPT_GROUP_STATE_KEY)||'{}')
+        };
+      }catch(_e){
+        return {core:true,docs:false,sidecars:true,subagents:true,transient:true};
+      }
+    }
+
+    function savePromptGroupOpenState(){
+      try{localStorage.setItem(PROMPT_GROUP_STATE_KEY,JSON.stringify(promptGroupOpenState));}catch(_e){}
+    }
+
+    function togglePromptFileGroup(group){
+      promptGroupOpenState[group]=!promptGroupOpenState[group];
+      savePromptGroupOpenState();
+      renderPromptWorkbench();
+    }
+
+    function renderPromptFileTree(files){
+      const groups=new Map();
+      (files||[]).forEach(file=>{
+        const group=promptFileGroup(file.path);
+        if(!groups.has(group))groups.set(group,[]);
+        groups.get(group).push(file);
+      });
+      const order=['core','docs','sidecars','subagents','transient'];
+      const extra=[...groups.keys()].filter(group=>!order.includes(group)).sort();
+      return [...order,...extra]
+        .filter(group=>groups.has(group))
+        .map(group=>renderPromptFileGroup(group,groups.get(group)))
+        .join('');
+    }
+
+    function promptFileGroup(filePath){
+      if(filePath==='system-prompt.md'||filePath==='runtime-context.md'||filePath==='compact-system.md')return 'core';
+      if(filePath==='README.md')return 'docs';
+      return String(filePath||'').split('/')[0]||'other';
+    }
+
+    function promptGroupLabel(group){
+      const labels={
+        core:'核心提示词',
+        docs:'文档',
+        sidecars:'sidecars',
+        subagents:'subagents',
+        transient:'transient'
+      };
+      return labels[group]||group;
+    }
+
+    function promptGroupHint(group,count){
+      const hints={
+        core:'主会话和压缩的关键入口',
+        docs:'规范说明',
+        sidecars:'独立小模型调用',
+        subagents:'子 agent 角色和边界',
+        transient:'每轮临时注入模板'
+      };
+      return (hints[group]||'目录')+' · '+count+' 个文件';
+    }
+
+    function renderPromptFileGroup(group,files){
+      const open=promptGroupOpenState[group]!==false;
+      const chevron=open?'v':'>';
+      const items=open?files.map(file=>renderPromptFileItem(file,group)).join(''):'';
+      return '<div class="prompt-file-group">'+
+        '<button class="prompt-file-group-title" type="button" onclick="togglePromptFileGroup(\''+escapeHtml(group)+'\')">'+
+          '<span class="chevron">'+chevron+'</span><span>'+escapeHtml(promptGroupLabel(group))+'</span>'+
+          '<span class="prompt-file-meta">'+escapeHtml(promptGroupHint(group,files.length))+'</span>'+
+        '</button>'+
+        items+
+      '</div>';
+    }
+
+    function renderPromptFileItem(file,group){
+      const active=file.path===promptEditorSelectedPath?' active':'';
+      const nested=group==='core'||group==='docs'?'':' nested';
+      const badge=file.overridden?'<span class="tag green">override</span>':'';
+      const label=promptFileLabel(file.path,group);
+      const subpath=promptFileSubpath(file.path,group);
+      const meta=[file.effective?.short_hash||'-', (file.effective?.lines||0)+' 行', subpath].filter(Boolean).join(' · ');
+      return '<button class="prompt-file-item'+nested+active+'" type="button" onclick="selectPromptEditorFile(decodeURIComponent(\''+encodeURIComponent(file.path)+'\'))">'+
+        '<span class="prompt-file-name">'+escapeHtml(label)+'</span>'+
+        '<span class="prompt-file-meta">'+escapeHtml(meta)+' '+badge+'</span>'+
+      '</button>';
+    }
+
+    function promptFileLabel(filePath,group){
+      if(group==='core'||group==='docs')return filePath;
+      const parts=String(filePath||'').split('/').filter(Boolean);
+      return parts.slice(1).join('/')||filePath;
+    }
+
+    function promptFileSubpath(filePath,group){
+      if(group==='core'||group==='docs')return '';
+      const parts=String(filePath||'').split('/').filter(Boolean);
+      return parts.length>2?parts.slice(0,-1).join('/'):'';
+    }
+
+    function promptTraceCard(label, value, meta){
+      return '<div class="prompt-trace-card">'+
+        '<div class="prompt-trace-label">'+escapeHtml(label)+'</div>'+
+        '<div class="prompt-trace-value">'+escapeHtml(value)+'</div>'+
+        '<div class="settings-meta" style="margin-top:6px">'+escapeHtml(meta||'')+'</div>'+
+      '</div>';
+    }
+
+    function renderPromptEditorPane(file){
+      const saveDisabled=promptEditorState?.writable?'':' disabled';
+      const resetDisabled=file.overridden?'':' disabled';
+      return '<div class="prompt-editor-pane">'+
+        '<div class="prompt-editor-head">'+
+          '<div><div class="prompt-editor-title">'+escapeHtml(file.path)+'</div>'+
+          '<div class="prompt-editor-meta">当前 '+escapeHtml(file.effective.short_hash)+' · 基线 '+escapeHtml(file.base.short_hash)+' · '+(file.overridden?'已有本地覆盖':'使用内置基线')+'</div></div>'+
+          (file.overridden?'<span class="tag green">override</span>':'<span class="tag">base</span>')+
+        '</div>'+
+        '<textarea class="config-input prompt-editor-textarea" id="prompt-editor-textarea" spellcheck="false" oninput="markPromptEditorDirty()">'+escapeHtml(file.content||'')+'</textarea>'+
+        '<div class="prompt-editor-actions">'+
+          '<div class="prompt-editor-status" id="prompt-editor-status">'+(promptEditorState?.writable?'编辑后保存覆盖版本；重启 connector 后生效。':'当前环境没有配置覆盖目录，不能保存。')+'</div>'+
+          '<div class="settings-actions">'+
+            '<button class="btn" onclick="resetPromptEditorFile()"'+resetDisabled+'>重置为内置</button>'+
+            '<button class="btn btn-primary" id="prompt-editor-save-btn" onclick="savePromptEditorFile()"'+saveDisabled+'>保存覆盖</button>'+
+          '</div>'+
+        '</div>'+
+      '</div>';
+    }
+
+    function markPromptEditorDirty(){
+      promptEditorDirty=true;
+      const status=document.getElementById('prompt-editor-status');
+      if(status)status.textContent='有未保存改动。保存后需要重启 connector 或新建 session。';
+    }
+
+    async function savePromptEditorFile(){
+      const textarea=document.getElementById('prompt-editor-textarea');
+      if(!textarea || !promptEditorSelectedPath)return;
+      const status=document.getElementById('prompt-editor-status');
+      try{
+        if(status)status.textContent='正在保存...';
+        promptEditorFile=await parseSimpleResponse(await fetch(API+'/api/prompts/file',{
+          method:'PUT',
+          headers:{'Content-Type':'application/json'},
+          body:JSON.stringify({path:promptEditorSelectedPath,content:textarea.value})
+        }));
+        await refreshPromptWorkbench(promptEditorSelectedPath);
+        const nextStatus=document.getElementById('prompt-editor-status');
+        if(nextStatus)nextStatus.textContent='已保存覆盖版本。重启 connector 或新建 session 后生效。';
+      }catch(e){
+        if(status)status.textContent='保存失败：'+(e.message||String(e));
+      }
+    }
+
+    async function resetPromptEditorFile(){
+      if(!promptEditorSelectedPath)return;
+      if(!confirm('确定删除这个 prompt 的本地覆盖，恢复使用内置版本吗？'))return;
+      const status=document.getElementById('prompt-editor-status');
+      try{
+        if(status)status.textContent='正在重置...';
+        promptEditorFile=await parseSimpleResponse(await fetch(API+'/api/prompts/file?path='+encodeURIComponent(promptEditorSelectedPath),{method:'DELETE'}));
+        await refreshPromptWorkbench(promptEditorSelectedPath);
+        const nextStatus=document.getElementById('prompt-editor-status');
+        if(nextStatus)nextStatus.textContent='已恢复内置版本。重启 connector 或新建 session 后生效。';
+      }catch(e){
+        if(status)status.textContent='重置失败：'+(e.message||String(e));
+      }
+    }
+
+    async function copyPromptOverridesPath(){
+      try{
+        if(!promptEditorState)promptEditorState=await parseSimpleResponse(await fetch(API+'/api/prompts'));
+        await copyTextToClipboard(promptEditorState.overrides_dir||'');
+        alert('已复制 prompt 覆盖目录');
+      }catch(e){
+        alert('复制失败：'+(e.message||String(e)));
       }
     }
 

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -6161,7 +6161,7 @@
       }
     }
 
-    async function refreshPromptWorkbench(selectPath){
+    async function refreshPromptWorkbench(selectPath, options={}){
       const root=document.getElementById('prompt-workbench');
       if(root && !promptEditorState)root.innerHTML='<div class="loading">加载提示词...</div>';
       try{
@@ -6175,7 +6175,7 @@
           promptEditorFile=await parseSimpleResponse(await fetch(API+'/api/prompts/file?path='+encodeURIComponent(promptEditorSelectedPath)));
         }
         promptEditorDirty=false;
-        renderPromptWorkbench();
+        renderPromptWorkbench(options);
       }catch(e){
         if(root)root.innerHTML='<div class="runtime-note danger">提示词加载失败：'+escapeHtml(e.message||String(e))+'</div>';
       }
@@ -6185,16 +6185,40 @@
       if(promptEditorDirty && !confirm('当前 prompt 有未保存改动，确定切换文件吗？'))return;
       promptEditorSelectedPath=path;
       promptEditorDirty=false;
-      await refreshPromptWorkbench(path);
+      await refreshPromptWorkbench(path, {preserveFileListScroll:true});
     }
 
-    function renderPromptWorkbench(){
+    function capturePromptWorkbenchScroll(){
+      const list=document.querySelector('#prompt-workbench .prompt-file-list');
+      const textarea=document.getElementById('prompt-editor-textarea');
+      return {
+        fileList:list?list.scrollTop:0,
+        textarea:textarea?textarea.scrollTop:0
+      };
+    }
+
+    function restorePromptWorkbenchScroll(scrollState, options={}){
+      if(!scrollState)return;
+      requestAnimationFrame(()=>{
+        const list=document.querySelector('#prompt-workbench .prompt-file-list');
+        if(list && options.preserveFileListScroll!==false){
+          list.scrollTop=scrollState.fileList||0;
+        }
+        const textarea=document.getElementById('prompt-editor-textarea');
+        if(textarea && options.preserveEditorScroll){
+          textarea.scrollTop=scrollState.textarea||0;
+        }
+      });
+    }
+
+    function renderPromptWorkbench(options={}){
       const root=document.getElementById('prompt-workbench');
       if(!root)return;
       if(!promptEditorState){
         root.innerHTML='<div class="loading">加载提示词...</div>';
         return;
       }
+      const scrollState=capturePromptWorkbenchScroll();
       const trace=promptEditorState.trace||{};
       const system=trace.system||{};
       const bundle=trace.bundle||{};
@@ -6214,6 +6238,7 @@
           '<div class="prompt-file-list">'+(listHtml||'<div class="loading">没有可编辑的 prompt 文件</div>')+'</div>'+
           editorHtml+
         '</div>';
+      restorePromptWorkbenchScroll(scrollState, options);
     }
 
     function loadPromptGroupOpenState(){
@@ -6238,7 +6263,7 @@
     function togglePromptFileGroup(group){
       promptGroupOpenState[group]=!promptGroupOpenState[group];
       savePromptGroupOpenState();
-      renderPromptWorkbench();
+      renderPromptWorkbench({preserveFileListScroll:true});
     }
 
     function renderPromptFileTree(files){
@@ -6367,7 +6392,10 @@
           headers:{'Content-Type':'application/json'},
           body:JSON.stringify({path:promptEditorSelectedPath,content:textarea.value})
         }));
-        await refreshPromptWorkbench(promptEditorSelectedPath);
+        await refreshPromptWorkbench(promptEditorSelectedPath, {
+          preserveFileListScroll:true,
+          preserveEditorScroll:true
+        });
         const nextStatus=document.getElementById('prompt-editor-status');
         if(nextStatus)nextStatus.textContent='已保存覆盖版本。重启 connector 或新建 session 后生效。';
       }catch(e){
@@ -6382,7 +6410,10 @@
       try{
         if(status)status.textContent='正在重置...';
         promptEditorFile=await parseSimpleResponse(await fetch(API+'/api/prompts/file?path='+encodeURIComponent(promptEditorSelectedPath),{method:'DELETE'}));
-        await refreshPromptWorkbench(promptEditorSelectedPath);
+        await refreshPromptWorkbench(promptEditorSelectedPath, {
+          preserveFileListScroll:true,
+          preserveEditorScroll:true
+        });
         const nextStatus=document.getElementById('prompt-editor-status');
         if(nextStatus)nextStatus.textContent='已恢复内置版本。重启 connector 或新建 session 后生效。';
       }catch(e){

--- a/electron/main.js
+++ b/electron/main.js
@@ -486,6 +486,7 @@ async function startServer() {
 
   // 闂佽崵濮崇粈浣规櫠娴犲鍋柛鈩冾殢閸熷懘鏌曟径鍫濃偓妤冪矙婵犲洦鐓熼柍鍝勶工閺嬫稓绱撳鍛ч柡浣哥Ч瀹曞ジ鎮㈢亸浣稿緧闂備礁鎲￠悧鏇㈠箠鎼淬劌绠栨俊銈呮噺閸嬨劑鏌嶉搹瑙勭erData闂佽瀛╃粙鎺曟懌闂佸搫鍊风欢姘跺箖娴犲惟闁挎洍鍋撻柣鎾存礋閺屸剝鎷呴崫鍕垫毉閻庤鎸风欢姘跺极?
   const userDataPath = app.getPath('userData');
+  process.env.XIAOBA_USER_DATA_DIR = userDataPath;
   const skillsPath = path.join(userDataPath, 'skills');
   if (!String(process.env.XIAOBA_SKILLS_DIR || '').trim()) {
     process.env.XIAOBA_SKILLS_DIR = skillsPath;
@@ -518,6 +519,9 @@ async function startServer() {
   process.env.XIAOBA_APP_ROOT = appRoot;
   process.env.XIAOBA_IS_PACKAGED = app.isPackaged ? '1' : '0';
   process.env.XIAOBA_RUNTIME_ROOT = getRuntimeRoot();
+  if (!String(process.env.XIAOBA_PROMPT_OVERRIDES_DIR || '').trim()) {
+    process.env.XIAOBA_PROMPT_OVERRIDES_DIR = path.join(userDataPath, 'prompt-overrides');
+  }
 
   // 闂備胶鎳撻悘姘跺箰閸濄儮鍋撻崹顐€块柟顔ㄥ洤閱囨い鎺戝€婚悰銉╂煟閻樿京顦﹀褌绮欓幃?NODE_PATH 闂佽崵濮崇拋鏌ュ疾濞戙垺鍋ゆ繛鍡樺姈娴溿倖绻涢幋鐐茬劰闁哄被鍊濋弻銈団偓鍦Т琚氭繝銏ｎ潐閿曘垹鐣?node_modules
   const nodeModulesPath = getNodeModulesPath();

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -66,7 +66,35 @@ prompts/runtime-context.md 渲染后的内容
 - 主会话的 `system-prompt.md` 和 `runtime-context.md` 在会话初始化时读取并注入第一条 system 消息。改完这两个文件后，需要重启进程并开启新会话，或清空/重置当前会话，才会让已经初始化的会话用上新版本。
 - 恢复历史时不会长期保存旧 system prompt；持久化历史会过滤 system 消息，重启后恢复的会话会重新读取当前 prompt 文件。
 - `transient/`、`compact-system.md`、`subagents/`、`sidecars/` 多数是在每次对应调用时读取。改完文件后，下一次触发对应注入、压缩、子 agent 或 sidecar 调用就会使用新文本。
-- 开发目录和当前打包形态会从应用目录下的 `prompts/` 读取。安装版虽然也能读随包带上的文件，但不建议把安装目录当作用户自定义配置目录；后续如果要支持用户自定义 prompt，应单独提供受控的外部 promptsDir。
+- 运行时以应用目录下的 `prompts/` 作为内置基线；如果本地覆盖目录里存在同名 `.md` 文件，则优先读取覆盖版本。
+- Dashboard 的“提示词 / Prompt Lab”页面会写入覆盖目录，不会修改安装包或仓库里的基线文件。
+
+## 本地覆盖目录
+
+Prompt 覆盖目录用于快速试 prompt、回滚和做版本对比：
+
+- 开发版 Electron 默认目录：`.dev-user-data/prompt-overrides`。
+- 打包版默认目录：用户数据目录下的 `prompt-overrides`。
+- 也可以用环境变量显式指定：
+
+```powershell
+$env:XIAOBA_PROMPT_OVERRIDES_DIR="D:\CatsCoPromptOverrides"
+```
+
+或：
+
+```powershell
+$env:XIAOBA_RUNTIME_ROOT="D:\CatsCoRuntime"
+```
+
+此时默认覆盖目录为 `D:\CatsCoRuntime\prompt-overrides`。
+
+覆盖规则：
+
+- 只允许覆盖内置基线中已经存在的 `.md` prompt 文件。
+- 覆盖文件必须保持相同相对路径，例如 `transient/current-directory.md`。
+- 删除覆盖文件后会自动恢复读取内置基线。
+- `Prompt Lab` 页面中的“重置为内置”只删除覆盖文件，不会删除内置 prompt。
 
 ## 动态注入怎么处理
 
@@ -191,6 +219,7 @@ Electron 打包必须包含 `prompts/**/*`。当前 `package.json` 的 electron-
   - `bundle_hash`
   - `bundle_file_count`
   - `prompt_version`
+- 如果某个文件来自本地覆盖，`prompt.bundle.files[]` 中会带 `overridden: true`，并且该文件 hash 按实际生效内容计算。
 
 `prompt_version` 默认是 `local`。如果要做人工版本或 A/B 实验，可以启动时设置：
 
@@ -199,3 +228,13 @@ CATSCO_PROMPT_VERSION=brief-v2
 ```
 
 这样同一份用户请求在不同 prompt 下的日志可以按 `prompt_version` 和 hash 对齐比较。正文仍只从 `prompts/` 读取，不会每轮写入日志，避免日志变大或泄露长提示词内容。
+
+Dashboard 的 `Prompt Lab` 页面会显示当前：
+
+- system hash
+- bundle hash
+- prompt version
+- 覆盖目录
+- 每个 prompt 文件是否有 override
+
+保存后需要重启 connector 或开启新 session，日志里的 `prompt_trace` 才会记录新的 hash。

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -175,13 +175,27 @@ Electron 打包必须包含 `prompts/**/*`。当前 `package.json` 的 electron-
 - 不把用户隐私文件内容、图片 base64、聊天原文样本放进 prompt 文件。
 - 尽量避免过度长篇规则；长规则会挤占模型上下文，也会降低后续调试可控性。
 
-## 后续可观测性建议
+## Prompt 可观测性
 
-为了方便评估 prompt 效果，后续可以在每次模型请求日志里记录：
+为了方便评估 prompt 效果，运行时会在 session JSONL 里记录轻量 prompt 指纹，不记录完整 prompt 正文：
 
-- `prompt_files`：本轮加载了哪些 prompt 文件。
-- `prompt_hash`：最终 system prompt 的 hash。
-- `prompt_version`：可选的人工版本号。
-- `model` / `provider` / `context_window`：用于对比同一 prompt 在不同模型上的表现。
+- 会话初始化时写入一条 `entry_type: "prompt_trace"`：
+  - `prompt.system.short_hash`：最终 system prompt 文本的短 hash。
+  - `prompt.system.chars` / `lines`：最终 system prompt 的规模。
+  - `prompt.bundle.short_hash`：当前 `prompts/**/*.md` 文件集合的短 hash。
+  - `prompt.bundle.files[]`：prompt 文件路径、hash、字节数、字符数和行数。
+  - `prompt.loaded_files[]`：当前主会话 system prompt 直接加载的模板文件。
+- 每条 `entry_type: "turn"` 会带一个轻量 `prompt` 字段：
+  - `system_hash`
+  - `system_chars`
+  - `bundle_hash`
+  - `bundle_file_count`
+  - `prompt_version`
 
-这样后面做 A/B 测试或回溯用户反馈时，可以知道“这次回复到底用的是哪版提示词”。
+`prompt_version` 默认是 `local`。如果要做人工版本或 A/B 实验，可以启动时设置：
+
+```bash
+CATSCO_PROMPT_VERSION=brief-v2
+```
+
+这样同一份用户请求在不同 prompt 下的日志可以按 `prompt_version` 和 hash 对齐比较。正文仍只从 `prompts/` 读取，不会每轮写入日志，避免日志变大或泄露长提示词内容。

--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -43,6 +43,7 @@ import { resolveModelContextWindow } from '../utils/model-context-window';
 import { parseSessionKeyV2 } from './session-router';
 import { MODEL_IMAGE_SAFETY_MESSAGE, isModelImageSafetyError } from '../utils/model-error-classifier';
 import { stripAssistantArtifactsFromMessages } from '../utils/transcript-artifacts';
+import { toPromptTurnMetadata } from '../utils/prompt-observability';
 
 export type { RuntimeFeedbackInput, RuntimeFeedbackOptions } from './runtime-feedback-inbox';
 
@@ -299,6 +300,14 @@ export class AgentSession {
     const systemPrompt = this.systemPromptOverride
       ? await this.systemPromptOverride()
       : await PromptManager.buildSystemPrompt();
+    const promptTrace = PromptManager.buildPromptTraceSnapshot(systemPrompt, {
+      source: this.systemPromptOverride ? 'session-provider' : 'prompt-manager',
+    });
+    this.sessionTurnLogger.logPromptTrace(promptTrace);
+    this.turnLogRecorder.setPromptMetadata(toPromptTurnMetadata(promptTrace));
+    Logger.info(
+      `[会话 ${this.key}] Prompt trace: system=${promptTrace.system.short_hash}, bundle=${promptTrace.bundle.short_hash}, files=${promptTrace.bundle.file_count}, version=${promptTrace.prompt_version}`,
+    );
     this.initialized = true;
     const initialSystemMessages: Message[] = [];
     if (systemPrompt.trim()) {

--- a/src/core/context-compressor.ts
+++ b/src/core/context-compressor.ts
@@ -3,7 +3,7 @@ import { AIService } from '../utils/ai-service';
 import { estimateMessagesTokens, estimateTokens } from './token-estimator';
 import { Logger } from '../utils/logger';
 import { Metrics } from '../utils/metrics';
-import { DEFAULT_PROMPTS_DIR, readRequiredPromptFile, renderPromptTemplate } from '../utils/prompt-template';
+import { readRequiredDefaultPromptFile, renderPromptTemplate } from '../utils/prompt-template';
 
 const COMPACT_BOUNDARY_PREFIX = '[compact_boundary]';
 
@@ -226,7 +226,7 @@ export function truncateForSummary(messages: Message[], budget: number = SUMMARY
  * 生成压缩用的 system prompt
  */
 export function buildCompactSystemPrompt(customInstructions?: string): string {
-  const template = readRequiredPromptFile(DEFAULT_PROMPTS_DIR, 'compact-system.md');
+  const template = readRequiredDefaultPromptFile('compact-system.md');
   return renderPromptTemplate(template, {
     customInstructions: customInstructions?.trim(),
   });

--- a/src/core/turn-log-recorder.ts
+++ b/src/core/turn-log-recorder.ts
@@ -1,5 +1,6 @@
 import type { ContentBlock, Message } from '../types';
 import {
+  SessionPromptTurnLog,
   SessionToolCallLog,
   SessionTurnLogger,
 } from '../utils/session-turn-logger';
@@ -20,7 +21,13 @@ export interface RecordTurnParams {
  * Converts a completed turn into the stable session JSONL schema.
  */
 export class TurnLogRecorder {
+  private prompt?: SessionPromptTurnLog;
+
   constructor(private readonly logger: SessionTurnLogger) {}
+
+  setPromptMetadata(prompt: SessionPromptTurnLog | undefined): void {
+    this.prompt = prompt;
+  }
 
   recordTurn(params: RecordTurnParams): void {
     this.logger.logTurn(
@@ -31,6 +38,7 @@ export class TurnLogRecorder {
       {
         runtimeFeedback: params.runtimeFeedback,
         runtimeObservationSource: params.runtimeObservationSource,
+        prompt: this.prompt,
       },
     );
   }

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -58,6 +58,12 @@ import {
   readSkillHubLocalMetadata,
 } from '../../skillhub/local-skill-metadata';
 import {
+  deletePromptOverride,
+  getPromptEditorFile,
+  getPromptEditorState,
+  writePromptOverride,
+} from '../../utils/prompt-editor';
+import {
   BindWeixinChannelResult,
   WeixinChannelStatus,
   bindWeixinChannelToCurrentAgent,
@@ -1620,6 +1626,38 @@ export function createApiRouter(serviceManager: ServiceManager, updateController
       }));
     } catch (e: any) {
       res.status(500).json({ error: e?.message || String(e) });
+    }
+  });
+
+  router.get('/prompts', async (_req, res) => {
+    try {
+      res.json(await getPromptEditorState());
+    } catch (e: any) {
+      res.status(500).json({ error: e?.message || String(e) });
+    }
+  });
+
+  router.get('/prompts/file', (req, res) => {
+    try {
+      res.json(getPromptEditorFile(String(req.query.path || '')));
+    } catch (e: any) {
+      res.status(400).json({ error: e?.message || String(e) });
+    }
+  });
+
+  router.put('/prompts/file', (req, res) => {
+    try {
+      res.json(writePromptOverride(String(req.body?.path || ''), String(req.body?.content ?? '')));
+    } catch (e: any) {
+      res.status(400).json({ error: e?.message || String(e) });
+    }
+  });
+
+  router.delete('/prompts/file', (req, res) => {
+    try {
+      res.json(deletePromptOverride(String(req.query.path || '')));
+    } catch (e: any) {
+      res.status(400).json({ error: e?.message || String(e) });
     }
   });
 

--- a/src/utils/prompt-editor.ts
+++ b/src/utils/prompt-editor.ts
@@ -1,0 +1,195 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { PromptManager } from './prompt-manager';
+import {
+  getPromptOverridesDir,
+  normalizePromptRelativePath,
+  normalizePromptText,
+  readPromptFile,
+  resolvePromptPathWithin,
+} from './prompt-template';
+import { buildPromptTraceSnapshot, hashText } from './prompt-observability';
+
+const MAX_PROMPT_EDIT_BYTES = 256 * 1024;
+
+export interface PromptEditorFile {
+  path: string;
+  overridden: boolean;
+  base: {
+    sha256: string;
+    short_hash: string;
+    chars: number;
+    lines: number;
+  };
+  effective: {
+    sha256: string;
+    short_hash: string;
+    chars: number;
+    lines: number;
+  };
+}
+
+export interface PromptEditorState {
+  base_dir: string;
+  overrides_dir?: string;
+  writable: boolean;
+  trace: ReturnType<typeof buildPromptTraceSnapshot>;
+  files: PromptEditorFile[];
+}
+
+export interface PromptEditorFileDetail extends PromptEditorFile {
+  content: string;
+  base_content: string;
+}
+
+export async function getPromptEditorState(): Promise<PromptEditorState> {
+  const baseDir = PromptManager.getPromptsDir();
+  const systemPrompt = await PromptManager.buildSystemPrompt();
+  const files = listPromptEditorFiles();
+  const overridesDir = getPromptOverridesDir();
+
+  return {
+    base_dir: labelLocalPath(baseDir),
+    overrides_dir: overridesDir ? labelLocalPath(overridesDir) : undefined,
+    writable: Boolean(overridesDir),
+    trace: buildPromptTraceSnapshot({
+      promptsDir: baseDir,
+      systemPrompt,
+      source: 'prompt-editor',
+      loadedFiles: ['runtime-context.md', 'system-prompt.md'],
+    }),
+    files,
+  };
+}
+
+export function getPromptEditorFile(relativePath: string): PromptEditorFileDetail {
+  const normalized = normalizeEditablePromptPath(relativePath);
+  const baseDir = PromptManager.getPromptsDir();
+  const basePath = resolvePromptPathWithin(baseDir, normalized);
+  const baseContent = normalizePromptText(fs.readFileSync(basePath, 'utf-8'));
+  const content = readPromptFile(baseDir, normalized);
+  const file = buildPromptEditorFile(normalized, baseContent, content);
+  return {
+    ...file,
+    content,
+    base_content: baseContent,
+  };
+}
+
+export function writePromptOverride(relativePath: string, content: string): PromptEditorFileDetail {
+  const normalized = normalizeEditablePromptPath(relativePath);
+  const text = normalizePromptText(String(content ?? ''));
+  const bytes = Buffer.byteLength(text, 'utf-8');
+  if (bytes > MAX_PROMPT_EDIT_BYTES) {
+    throw new Error(`Prompt file is too large: ${bytes} bytes`);
+  }
+  if (!text) {
+    throw new Error('Prompt content cannot be empty');
+  }
+
+  const overridesDir = getPromptOverridesDir();
+  if (!overridesDir) {
+    throw new Error('Prompt override directory is not configured');
+  }
+
+  const outputPath = resolvePromptPathWithin(overridesDir, normalized);
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, `${text}\n`, 'utf-8');
+  return getPromptEditorFile(normalized);
+}
+
+export function deletePromptOverride(relativePath: string): PromptEditorFileDetail {
+  const normalized = normalizeEditablePromptPath(relativePath);
+  const overridesDir = getPromptOverridesDir();
+  if (overridesDir) {
+    const filePath = resolvePromptPathWithin(overridesDir, normalized);
+    fs.rmSync(filePath, { force: true });
+    pruneEmptyPromptDirs(path.dirname(filePath), overridesDir);
+  }
+  return getPromptEditorFile(normalized);
+}
+
+function listPromptEditorFiles(): PromptEditorFile[] {
+  const baseDir = PromptManager.getPromptsDir();
+  return listBasePromptPaths(baseDir).map(relativePath => {
+    const basePath = resolvePromptPathWithin(baseDir, relativePath);
+    const baseContent = normalizePromptText(fs.readFileSync(basePath, 'utf-8'));
+    const effectiveContent = readPromptFile(baseDir, relativePath);
+    return buildPromptEditorFile(relativePath, baseContent, effectiveContent);
+  });
+}
+
+function buildPromptEditorFile(relativePath: string, baseContent: string, effectiveContent: string): PromptEditorFile {
+  const baseHash = hashText(baseContent);
+  const effectiveHash = hashText(effectiveContent);
+  return {
+    path: relativePath,
+    overridden: baseHash !== effectiveHash || promptOverrideExists(relativePath),
+    base: textDigest(baseContent),
+    effective: textDigest(effectiveContent),
+  };
+}
+
+function textDigest(text: string): PromptEditorFile['effective'] {
+  const sha256 = hashText(text);
+  return {
+    sha256,
+    short_hash: sha256.slice(0, 12),
+    chars: text.length,
+    lines: text ? text.split(/\r?\n/).length : 0,
+  };
+}
+
+function normalizeEditablePromptPath(relativePath: string): string {
+  const normalized = normalizePromptRelativePath(relativePath);
+  const available = new Set(listBasePromptPaths(PromptManager.getPromptsDir()));
+  if (!available.has(normalized)) {
+    throw new Error(`Prompt file is not editable: ${relativePath}`);
+  }
+  return normalized;
+}
+
+function listBasePromptPaths(baseDir: string): string[] {
+  const root = path.resolve(baseDir);
+  if (!fs.existsSync(root)) return [];
+  const results: string[] = [];
+  walk(root, filePath => {
+    if (path.extname(filePath).toLowerCase() !== '.md') return;
+    results.push(path.relative(root, filePath).split(path.sep).join('/'));
+  });
+  return results.sort((a, b) => a.localeCompare(b));
+}
+
+function promptOverrideExists(relativePath: string): boolean {
+  const overridesDir = getPromptOverridesDir();
+  if (!overridesDir) return false;
+  return fs.existsSync(resolvePromptPathWithin(overridesDir, relativePath));
+}
+
+function pruneEmptyPromptDirs(startDir: string, rootDir: string): void {
+  const root = path.resolve(rootDir);
+  let current = path.resolve(startDir);
+  while (current.startsWith(root) && current !== root) {
+    try {
+      fs.rmdirSync(current);
+    } catch {
+      return;
+    }
+    current = path.dirname(current);
+  }
+}
+
+function walk(directory: string, visit: (filePath: string) => void): void {
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const filePath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      walk(filePath, visit);
+    } else if (entry.isFile()) {
+      visit(filePath);
+    }
+  }
+}
+
+function labelLocalPath(value: string): string {
+  return path.resolve(value);
+}

--- a/src/utils/prompt-manager.ts
+++ b/src/utils/prompt-manager.ts
@@ -1,5 +1,5 @@
 import { PromptComposer } from '../runtime/prompt-composer';
-import { DEFAULT_PROMPTS_DIR } from './prompt-template';
+import { getPromptBaseDir } from './prompt-template';
 import {
   PromptTraceSnapshot,
   buildPromptTraceSnapshot,
@@ -9,13 +9,14 @@ import {
  * System Prompt 管理器
  */
 export class PromptManager {
-  private static promptsDir = DEFAULT_PROMPTS_DIR;
+  private static promptsDir = getPromptBaseDir();
+  private static envPromptsDir = PromptManager.promptsDir;
 
   /**
    * 获取基础 system prompt
    */
   static getBaseSystemPrompt(): string {
-    return PromptComposer.getBaseSystemPrompt(this.promptsDir);
+    return PromptComposer.getBaseSystemPrompt(this.getPromptsDir());
   }
 
   /**
@@ -23,11 +24,16 @@ export class PromptManager {
    */
   static async buildSystemPrompt(): Promise<string> {
     return PromptComposer.composeSystemPrompt({
-      promptsDir: this.promptsDir,
+      promptsDir: this.getPromptsDir(),
     });
   }
 
   static getPromptsDir(): string {
+    const currentEnvPromptsDir = getPromptBaseDir();
+    if (this.promptsDir === this.envPromptsDir) {
+      this.promptsDir = currentEnvPromptsDir;
+    }
+    this.envPromptsDir = currentEnvPromptsDir;
     return this.promptsDir;
   }
 
@@ -41,7 +47,7 @@ export class PromptManager {
     } = {},
   ): PromptTraceSnapshot {
     return buildPromptTraceSnapshot({
-      promptsDir: this.promptsDir,
+      promptsDir: this.getPromptsDir(),
       systemPrompt,
       source: options.source || 'prompt-manager',
       loadedFiles: options.loadedFiles || ['runtime-context.md', 'system-prompt.md'],

--- a/src/utils/prompt-manager.ts
+++ b/src/utils/prompt-manager.ts
@@ -1,5 +1,9 @@
 import { PromptComposer } from '../runtime/prompt-composer';
 import { DEFAULT_PROMPTS_DIR } from './prompt-template';
+import {
+  PromptTraceSnapshot,
+  buildPromptTraceSnapshot,
+} from './prompt-observability';
 
 /**
  * System Prompt 管理器
@@ -25,5 +29,24 @@ export class PromptManager {
 
   static getPromptsDir(): string {
     return this.promptsDir;
+  }
+
+  static buildPromptTraceSnapshot(
+    systemPrompt: string,
+    options: {
+      source?: string;
+      loadedFiles?: string[];
+      env?: NodeJS.ProcessEnv;
+      now?: Date;
+    } = {},
+  ): PromptTraceSnapshot {
+    return buildPromptTraceSnapshot({
+      promptsDir: this.promptsDir,
+      systemPrompt,
+      source: options.source || 'prompt-manager',
+      loadedFiles: options.loadedFiles || ['runtime-context.md', 'system-prompt.md'],
+      env: options.env,
+      now: options.now,
+    });
   }
 }

--- a/src/utils/prompt-observability.ts
+++ b/src/utils/prompt-observability.ts
@@ -1,6 +1,11 @@
 import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
+import {
+  getPromptOverridesDir,
+  readPromptFile,
+  resolvePromptPathWithin,
+} from './prompt-template';
 
 export interface PromptFileDigest {
   path: string;
@@ -9,6 +14,7 @@ export interface PromptFileDigest {
   bytes: number;
   chars: number;
   lines: number;
+  overridden?: boolean;
 }
 
 export interface PromptTraceSnapshot {
@@ -90,24 +96,25 @@ export function listPromptFiles(promptsDir: string): PromptFileDigest[] {
   const root = path.resolve(promptsDir);
   if (!fs.existsSync(root)) return [];
 
-  const files: PromptFileDigest[] = [];
+  const relativePaths: string[] = [];
   walk(root, filePath => {
     if (path.extname(filePath).toLowerCase() !== '.md') return;
-    const relativePath = normalizeRelativePath(path.relative(root, filePath));
-    const content = fs.readFileSync(filePath, 'utf-8');
-    const bytes = fs.statSync(filePath).size;
+    relativePaths.push(normalizeRelativePath(path.relative(root, filePath)));
+  });
+
+  return relativePaths.sort((a, b) => a.localeCompare(b)).map(relativePath => {
+    const content = readPromptFile(root, relativePath);
     const sha256 = hashText(content);
-    files.push({
+    return {
       path: relativePath,
       sha256,
       short_hash: shortHash(sha256),
-      bytes,
+      bytes: Buffer.byteLength(content, 'utf-8'),
       chars: content.length,
       lines: countLines(content),
-    });
+      ...(isPromptOverridden(root, relativePath) ? { overridden: true } : {}),
+    } as PromptFileDigest;
   });
-
-  return files.sort((a, b) => a.path.localeCompare(b.path));
 }
 
 export function hashText(text: string): string {
@@ -136,6 +143,16 @@ function walk(directory: string, visit: (filePath: string) => void): void {
 
 function normalizeRelativePath(value: string): string {
   return value.split(path.sep).join('/');
+}
+
+function isPromptOverridden(promptsDir: string, relativePath: string): boolean {
+  const overridesDir = getPromptOverridesDir();
+  if (!overridesDir) return false;
+  try {
+    return fs.existsSync(resolvePromptPathWithin(overridesDir, relativePath));
+  } catch {
+    return false;
+  }
 }
 
 function labelPromptDir(promptsDir: string): string {

--- a/src/utils/prompt-observability.ts
+++ b/src/utils/prompt-observability.ts
@@ -1,0 +1,147 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface PromptFileDigest {
+  path: string;
+  sha256: string;
+  short_hash: string;
+  bytes: number;
+  chars: number;
+  lines: number;
+}
+
+export interface PromptTraceSnapshot {
+  source: string;
+  prompt_version: string;
+  prompts_dir: string;
+  generated_at: string;
+  system: {
+    sha256: string;
+    short_hash: string;
+    chars: number;
+    lines: number;
+  };
+  bundle: {
+    sha256: string;
+    short_hash: string;
+    file_count: number;
+    files: PromptFileDigest[];
+  };
+  loaded_files: string[];
+}
+
+export interface PromptTurnMetadata {
+  source: string;
+  prompt_version: string;
+  system_hash: string;
+  system_chars: number;
+  bundle_hash: string;
+  bundle_file_count: number;
+}
+
+export function buildPromptTraceSnapshot(options: {
+  promptsDir: string;
+  systemPrompt: string;
+  source: string;
+  loadedFiles?: string[];
+  env?: NodeJS.ProcessEnv;
+  now?: Date;
+}): PromptTraceSnapshot {
+  const env = options.env ?? process.env;
+  const now = options.now ?? new Date();
+  const files = listPromptFiles(options.promptsDir);
+  const bundleHash = hashText(files.map(file => `${file.path}\0${file.sha256}`).join('\n'));
+  const systemHash = hashText(options.systemPrompt);
+
+  return {
+    source: options.source,
+    prompt_version: (env.CATSCO_PROMPT_VERSION || env.XIAOBA_PROMPT_VERSION || 'local').trim() || 'local',
+    prompts_dir: labelPromptDir(options.promptsDir),
+    generated_at: now.toISOString(),
+    system: {
+      sha256: systemHash,
+      short_hash: shortHash(systemHash),
+      chars: options.systemPrompt.length,
+      lines: countLines(options.systemPrompt),
+    },
+    bundle: {
+      sha256: bundleHash,
+      short_hash: shortHash(bundleHash),
+      file_count: files.length,
+      files,
+    },
+    loaded_files: [...new Set(options.loadedFiles || [])].sort(),
+  };
+}
+
+export function toPromptTurnMetadata(snapshot: PromptTraceSnapshot): PromptTurnMetadata {
+  return {
+    source: snapshot.source,
+    prompt_version: snapshot.prompt_version,
+    system_hash: snapshot.system.short_hash,
+    system_chars: snapshot.system.chars,
+    bundle_hash: snapshot.bundle.short_hash,
+    bundle_file_count: snapshot.bundle.file_count,
+  };
+}
+
+export function listPromptFiles(promptsDir: string): PromptFileDigest[] {
+  const root = path.resolve(promptsDir);
+  if (!fs.existsSync(root)) return [];
+
+  const files: PromptFileDigest[] = [];
+  walk(root, filePath => {
+    if (path.extname(filePath).toLowerCase() !== '.md') return;
+    const relativePath = normalizeRelativePath(path.relative(root, filePath));
+    const content = fs.readFileSync(filePath, 'utf-8');
+    const bytes = fs.statSync(filePath).size;
+    const sha256 = hashText(content);
+    files.push({
+      path: relativePath,
+      sha256,
+      short_hash: shortHash(sha256),
+      bytes,
+      chars: content.length,
+      lines: countLines(content),
+    });
+  });
+
+  return files.sort((a, b) => a.path.localeCompare(b.path));
+}
+
+export function hashText(text: string): string {
+  return crypto.createHash('sha256').update(text, 'utf-8').digest('hex');
+}
+
+function shortHash(hash: string): string {
+  return hash.slice(0, 12);
+}
+
+function countLines(text: string): number {
+  if (!text) return 0;
+  return text.split(/\r?\n/).length;
+}
+
+function walk(directory: string, visit: (filePath: string) => void): void {
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const filePath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      walk(filePath, visit);
+    } else if (entry.isFile()) {
+      visit(filePath);
+    }
+  }
+}
+
+function normalizeRelativePath(value: string): string {
+  return value.split(path.sep).join('/');
+}
+
+function labelPromptDir(promptsDir: string): string {
+  const resolved = path.resolve(promptsDir);
+  if (path.basename(resolved).toLowerCase() === 'prompts') {
+    return 'app/prompts';
+  }
+  return `custom:${shortHash(hashText(resolved))}`;
+}

--- a/src/utils/prompt-template.ts
+++ b/src/utils/prompt-template.ts
@@ -3,16 +3,75 @@ import * as path from 'path';
 
 export const DEFAULT_PROMPTS_DIR = path.join(__dirname, '../../prompts');
 
+export function getPromptBaseDir(env: NodeJS.ProcessEnv = process.env): string {
+  const explicit = (env.XIAOBA_PROMPTS_DIR || env.CATSCO_PROMPTS_DIR || '').trim();
+  return explicit ? path.resolve(explicit) : DEFAULT_PROMPTS_DIR;
+}
+
+export function getPromptOverridesDir(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  if (/^(1|true|yes|on)$/i.test(String(env.XIAOBA_DISABLE_PROMPT_OVERRIDES || '').trim())) {
+    return undefined;
+  }
+  const explicit = (env.XIAOBA_PROMPT_OVERRIDES_DIR || env.CATSCO_PROMPT_OVERRIDES_DIR || '').trim();
+  if (explicit) return path.resolve(explicit);
+  const userDataDir = (env.XIAOBA_USER_DATA_DIR || env.CATSCO_USER_DATA_DIR || '').trim();
+  if (userDataDir) return path.resolve(userDataDir, 'prompt-overrides');
+  const runtimeRoot = (env.XIAOBA_RUNTIME_ROOT || '').trim();
+  return runtimeRoot ? path.resolve(runtimeRoot, 'prompt-overrides') : undefined;
+}
+
+export function normalizePromptRelativePath(relativePath: string): string {
+  const input = String(relativePath || '').replace(/\\/g, '/').trim();
+  const normalized = path.posix.normalize(input);
+  if (
+    !input
+    || normalized === '.'
+    || normalized.startsWith('../')
+    || normalized.includes('/../')
+    || path.posix.isAbsolute(normalized)
+    || path.posix.extname(normalized).toLowerCase() !== '.md'
+  ) {
+    throw new Error(`Invalid prompt file path: ${relativePath}`);
+  }
+  return normalized;
+}
+
+export function resolvePromptFilePath(promptsDir: string, relativePath: string): string {
+  const normalized = normalizePromptRelativePath(relativePath);
+  const overridePath = resolvePromptOverrideFilePath(promptsDir, normalized);
+  if (overridePath && fs.existsSync(overridePath)) {
+    return overridePath;
+  }
+  return resolvePromptPathWithin(promptsDir, normalized);
+}
+
+export function resolvePromptPathWithin(rootDir: string, relativePath: string): string {
+  const normalized = normalizePromptRelativePath(relativePath);
+  const root = path.resolve(rootDir);
+  const filePath = path.resolve(root, ...normalized.split('/'));
+  const relative = path.relative(root, filePath);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(`Invalid prompt file path: ${relativePath}`);
+  }
+  return filePath;
+}
+
+export function resolvePromptOverrideFilePath(promptsDir: string, relativePath: string): string | undefined {
+  if (!shouldUsePromptOverrides(promptsDir)) return undefined;
+  const overridesDir = getPromptOverridesDir();
+  return overridesDir ? resolvePromptPathWithin(overridesDir, relativePath) : undefined;
+}
+
 export function readPromptFile(promptsDir: string, relativePath: string): string {
   try {
-    return normalizePromptText(fs.readFileSync(path.join(promptsDir, relativePath), 'utf-8'));
+    return normalizePromptText(fs.readFileSync(resolvePromptFilePath(promptsDir, relativePath), 'utf-8'));
   } catch {
     return '';
   }
 }
 
 export function readRequiredPromptFile(promptsDir: string, relativePath: string): string {
-  const filePath = path.join(promptsDir, relativePath);
+  const filePath = resolvePromptFilePath(promptsDir, relativePath);
   try {
     const text = normalizePromptText(fs.readFileSync(filePath, 'utf-8'));
     if (!text) {
@@ -28,11 +87,11 @@ export function readRequiredPromptFile(promptsDir: string, relativePath: string)
 }
 
 export function readDefaultPromptFile(relativePath: string): string {
-  return readPromptFile(DEFAULT_PROMPTS_DIR, relativePath);
+  return readPromptFile(getPromptBaseDir(), relativePath);
 }
 
 export function readRequiredDefaultPromptFile(relativePath: string): string {
-  return readRequiredPromptFile(DEFAULT_PROMPTS_DIR, relativePath);
+  return readRequiredPromptFile(getPromptBaseDir(), relativePath);
 }
 
 export function readDefaultPromptLines(relativePath: string): string[] {
@@ -88,4 +147,11 @@ export function normalizePromptText(text: string): string {
     .join('\n')
     .replace(/\n{3,}/g, '\n\n')
     .trim();
+}
+
+function shouldUsePromptOverrides(promptsDir: string): boolean {
+  const overridesDir = getPromptOverridesDir();
+  if (!overridesDir) return false;
+  const resolved = path.resolve(promptsDir);
+  return resolved === path.resolve(getPromptBaseDir()) || resolved === path.resolve(DEFAULT_PROMPTS_DIR);
 }

--- a/src/utils/session-log-schema.ts
+++ b/src/utils/session-log-schema.ts
@@ -8,6 +8,24 @@ export interface SessionToolCallLog {
   duration_ms?: number;
 }
 
+export interface SessionPromptFileLog {
+  path: string;
+  sha256: string;
+  short_hash: string;
+  bytes: number;
+  chars: number;
+  lines: number;
+}
+
+export interface SessionPromptTurnLog {
+  source: string;
+  prompt_version: string;
+  system_hash: string;
+  system_chars: number;
+  bundle_hash: string;
+  bundle_file_count: number;
+}
+
 export interface SessionTurnLogEntry {
   entry_type: 'turn';
   turn: number;
@@ -28,6 +46,7 @@ export interface SessionTurnLogEntry {
     prompt: number;
     completion: number;
   };
+  prompt?: SessionPromptTurnLog;
 }
 
 export interface SessionRuntimeLogEntry {
@@ -58,11 +77,41 @@ export interface SessionSubAgentEventLogEntry {
   };
 }
 
+export interface SessionPromptTraceLogEntry {
+  entry_type: 'prompt_trace';
+  timestamp: string;
+  session_id: string;
+  session_type: string;
+  prompt: {
+    source: string;
+    prompt_version: string;
+    prompts_dir: string;
+    generated_at: string;
+    system: {
+      sha256: string;
+      short_hash: string;
+      chars: number;
+      lines: number;
+    };
+    bundle: {
+      sha256: string;
+      short_hash: string;
+      file_count: number;
+      files: SessionPromptFileLog[];
+    };
+    loaded_files: string[];
+  };
+}
+
 export interface LegacySessionTurnLogEntry extends Omit<SessionTurnLogEntry, 'entry_type'> {
   entry_type?: undefined;
 }
 
-export type SessionLogEntry = SessionTurnLogEntry | SessionRuntimeLogEntry | SessionSubAgentEventLogEntry;
+export type SessionLogEntry =
+  | SessionTurnLogEntry
+  | SessionRuntimeLogEntry
+  | SessionSubAgentEventLogEntry
+  | SessionPromptTraceLogEntry;
 export type ParsedSessionLogEntry = SessionLogEntry | LegacySessionTurnLogEntry;
 
 export function parseSessionLogContent(content: string): ParsedSessionLogEntry[] {

--- a/src/utils/session-turn-logger.ts
+++ b/src/utils/session-turn-logger.ts
@@ -3,6 +3,8 @@ import * as path from 'path';
 import { Message, ContentBlock } from '../types';
 import type {
   SessionLogEntry,
+  SessionPromptTraceLogEntry,
+  SessionPromptTurnLog,
   SessionRuntimeLogEntry,
   SessionSubAgentEventLogEntry,
   SessionToolCallLog,
@@ -10,11 +12,13 @@ import type {
 } from './session-log-schema';
 import type { SubAgentRuntimeEvent } from '../core/sub-agent-events';
 import type { SubAgentInfo } from '../core/sub-agent-session';
+import type { PromptTraceSnapshot } from './prompt-observability';
 
 export type {
   LegacySessionTurnLogEntry,
   ParsedSessionLogEntry,
   SessionLogEntry,
+  SessionPromptTurnLog,
   SessionRuntimeLogEntry,
   SessionSubAgentEventLogEntry,
   SessionToolCallLog,
@@ -28,6 +32,7 @@ const MAX_RUNTIME_FEEDBACK_LENGTH = Number(process.env.XIAOBA_SESSION_RUNTIME_FE
 export interface LogTurnOptions {
   runtimeFeedback?: string[];
   runtimeObservationSource?: string;
+  prompt?: SessionPromptTurnLog;
 }
 
 /**
@@ -96,9 +101,21 @@ export class SessionTurnLogger {
         })),
       },
       tokens,
+      ...(options.prompt && { prompt: options.prompt }),
     };
 
     this.appendLog(turnLog);
+  }
+
+  logPromptTrace(snapshot: PromptTraceSnapshot): void {
+    const entry: SessionPromptTraceLogEntry = {
+      entry_type: 'prompt_trace',
+      timestamp: new Date().toISOString(),
+      session_id: this.sessionId,
+      session_type: this.sessionType,
+      prompt: snapshot,
+    };
+    this.appendLog(entry);
   }
 
   logRuntime(level: string, message: string): void {

--- a/tests/prompt-editor.test.ts
+++ b/tests/prompt-editor.test.ts
@@ -1,0 +1,94 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  deletePromptOverride,
+  getPromptEditorFile,
+  getPromptEditorState,
+  writePromptOverride,
+} from '../src/utils/prompt-editor';
+
+describe('prompt-editor', () => {
+  test('writes and resets prompt overrides without editing bundled prompts', async () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-prompt-editor-base-'));
+    const overrides = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-prompt-editor-overrides-'));
+    const previous = capturePromptEnv();
+    try {
+      process.env.XIAOBA_PROMPTS_DIR = base;
+      process.env.XIAOBA_PROMPT_OVERRIDES_DIR = overrides;
+      delete process.env.XIAOBA_RUNTIME_ROOT;
+      delete process.env.XIAOBA_DISABLE_PROMPT_OVERRIDES;
+      fs.writeFileSync(path.join(base, 'system-prompt.md'), 'base prompt\n', 'utf-8');
+      fs.writeFileSync(path.join(base, 'runtime-context.md'), 'runtime prompt\n', 'utf-8');
+
+      const initial = await getPromptEditorState();
+      assert.equal(initial.writable, true);
+      assert.deepStrictEqual(
+        initial.files.map(file => file.path),
+        ['runtime-context.md', 'system-prompt.md'],
+      );
+      assert.equal(getPromptEditorFile('system-prompt.md').content, 'base prompt');
+
+      const updated = writePromptOverride('system-prompt.md', 'custom prompt\n\n');
+      assert.equal(updated.content, 'custom prompt');
+      assert.equal(updated.overridden, true);
+      assert.equal(fs.readFileSync(path.join(base, 'system-prompt.md'), 'utf-8'), 'base prompt\n');
+      assert.equal(fs.readFileSync(path.join(overrides, 'system-prompt.md'), 'utf-8'), 'custom prompt\n');
+
+      const reset = deletePromptOverride('system-prompt.md');
+      assert.equal(reset.content, 'base prompt');
+      assert.equal(reset.overridden, false);
+      assert.equal(fs.existsSync(path.join(overrides, 'system-prompt.md')), false);
+    } finally {
+      restorePromptEnv(previous);
+      fs.rmSync(base, { recursive: true, force: true });
+      fs.rmSync(overrides, { recursive: true, force: true });
+    }
+  });
+
+  test('rejects traversal and non-existing prompt paths', () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-prompt-editor-base-'));
+    const overrides = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-prompt-editor-overrides-'));
+    const previous = capturePromptEnv();
+    try {
+      process.env.XIAOBA_PROMPTS_DIR = base;
+      process.env.XIAOBA_PROMPT_OVERRIDES_DIR = overrides;
+      fs.writeFileSync(path.join(base, 'system-prompt.md'), 'base prompt\n', 'utf-8');
+      fs.writeFileSync(path.join(base, 'runtime-context.md'), 'runtime prompt\n', 'utf-8');
+
+      assert.throws(
+        () => writePromptOverride('../secret.md', 'nope'),
+        /Invalid prompt file path/,
+      );
+      assert.throws(
+        () => writePromptOverride('unknown.md', 'nope'),
+        /Prompt file is not editable/,
+      );
+    } finally {
+      restorePromptEnv(previous);
+      fs.rmSync(base, { recursive: true, force: true });
+      fs.rmSync(overrides, { recursive: true, force: true });
+    }
+  });
+});
+
+function capturePromptEnv(): Record<string, string | undefined> {
+  return {
+    XIAOBA_PROMPTS_DIR: process.env.XIAOBA_PROMPTS_DIR,
+    XIAOBA_PROMPT_OVERRIDES_DIR: process.env.XIAOBA_PROMPT_OVERRIDES_DIR,
+    XIAOBA_RUNTIME_ROOT: process.env.XIAOBA_RUNTIME_ROOT,
+    XIAOBA_DISABLE_PROMPT_OVERRIDES: process.env.XIAOBA_DISABLE_PROMPT_OVERRIDES,
+  };
+}
+
+function restorePromptEnv(previous: Record<string, string | undefined>): void {
+  for (const [key, value] of Object.entries(previous)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}

--- a/tests/prompt-observability.test.ts
+++ b/tests/prompt-observability.test.ts
@@ -1,0 +1,55 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  buildPromptTraceSnapshot,
+  toPromptTurnMetadata,
+} from '../src/utils/prompt-observability';
+
+describe('prompt-observability', () => {
+  test('builds deterministic prompt file and turn metadata hashes', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-prompt-observability-'));
+    try {
+      fs.mkdirSync(path.join(root, 'transient'), { recursive: true });
+      fs.writeFileSync(path.join(root, 'system-prompt.md'), 'Base prompt\n', 'utf-8');
+      fs.writeFileSync(path.join(root, 'runtime-context.md'), 'Runtime prompt\n', 'utf-8');
+      fs.writeFileSync(path.join(root, 'transient', 'plan.md'), 'Plan prompt\n', 'utf-8');
+
+      const snapshot = buildPromptTraceSnapshot({
+        promptsDir: root,
+        systemPrompt: 'Base prompt\n\nRuntime prompt',
+        source: 'test',
+        loadedFiles: ['system-prompt.md', 'runtime-context.md'],
+        env: { CATSCO_PROMPT_VERSION: 'v-test' } as any,
+        now: new Date('2026-06-17T00:00:00.000Z'),
+      });
+
+      assert.equal(snapshot.source, 'test');
+      assert.equal(snapshot.prompt_version, 'v-test');
+      assert.match(snapshot.prompts_dir, /^custom:[a-f0-9]{12}$/);
+      assert.equal(snapshot.generated_at, '2026-06-17T00:00:00.000Z');
+      assert.deepStrictEqual(
+        snapshot.bundle.files.map(file => file.path),
+        ['runtime-context.md', 'system-prompt.md', 'transient/plan.md'],
+      );
+      assert.equal(snapshot.loaded_files.join(','), 'runtime-context.md,system-prompt.md');
+      assert.match(snapshot.system.sha256, /^[a-f0-9]{64}$/);
+      assert.equal(snapshot.system.short_hash.length, 12);
+      assert.match(snapshot.bundle.sha256, /^[a-f0-9]{64}$/);
+
+      const turn = toPromptTurnMetadata(snapshot);
+      assert.deepStrictEqual(turn, {
+        source: 'test',
+        prompt_version: 'v-test',
+        system_hash: snapshot.system.short_hash,
+        system_chars: snapshot.system.chars,
+        bundle_hash: snapshot.bundle.short_hash,
+        bundle_file_count: 3,
+      });
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/prompt-template.test.ts
+++ b/tests/prompt-template.test.ts
@@ -5,6 +5,7 @@ import * as os from 'os';
 import * as path from 'path';
 import {
   normalizePromptText,
+  readRequiredDefaultPromptFile,
   readRequiredPromptFile,
   renderPromptTemplate,
 } from '../src/utils/prompt-template';
@@ -56,4 +57,41 @@ describe('prompt-template', () => {
     ].join('\n'));
     assert.doesNotMatch(rendered, /Missing section/);
   });
+
+  test('default prompt reads local override when configured', () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-prompt-base-'));
+    const overrides = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-prompt-overrides-'));
+    const previous = {
+      XIAOBA_PROMPTS_DIR: process.env.XIAOBA_PROMPTS_DIR,
+      XIAOBA_PROMPT_OVERRIDES_DIR: process.env.XIAOBA_PROMPT_OVERRIDES_DIR,
+      XIAOBA_RUNTIME_ROOT: process.env.XIAOBA_RUNTIME_ROOT,
+      XIAOBA_DISABLE_PROMPT_OVERRIDES: process.env.XIAOBA_DISABLE_PROMPT_OVERRIDES,
+    };
+    try {
+      process.env.XIAOBA_PROMPTS_DIR = base;
+      process.env.XIAOBA_PROMPT_OVERRIDES_DIR = overrides;
+      delete process.env.XIAOBA_RUNTIME_ROOT;
+      delete process.env.XIAOBA_DISABLE_PROMPT_OVERRIDES;
+
+      fs.writeFileSync(path.join(base, 'system-prompt.md'), 'base prompt\n', 'utf-8');
+      assert.equal(readRequiredDefaultPromptFile('system-prompt.md'), 'base prompt');
+
+      fs.writeFileSync(path.join(overrides, 'system-prompt.md'), 'override prompt\n', 'utf-8');
+      assert.equal(readRequiredDefaultPromptFile('system-prompt.md'), 'override prompt');
+    } finally {
+      restoreEnv(previous);
+      fs.rmSync(base, { recursive: true, force: true });
+      fs.rmSync(overrides, { recursive: true, force: true });
+    }
+  });
 });
+
+function restoreEnv(previous: Record<string, string | undefined>): void {
+  for (const [key, value] of Object.entries(previous)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}

--- a/tests/session-log-schema.test.ts
+++ b/tests/session-log-schema.test.ts
@@ -46,6 +46,38 @@ describe('session-log-schema', () => {
       level: 'INFO',
       message: 'runtime',
     };
+    const promptTrace = {
+      entry_type: 'prompt_trace',
+      timestamp: '2026-05-01T08:00:01.500Z',
+      session_id: 'user:current',
+      session_type: 'chat',
+      prompt: {
+        source: 'prompt-manager',
+        prompt_version: 'local',
+        prompts_dir: '/tmp/prompts',
+        generated_at: '2026-05-01T08:00:01.000Z',
+        system: {
+          sha256: 'a'.repeat(64),
+          short_hash: 'a'.repeat(12),
+          chars: 20,
+          lines: 2,
+        },
+        bundle: {
+          sha256: 'b'.repeat(64),
+          short_hash: 'b'.repeat(12),
+          file_count: 1,
+          files: [{
+            path: 'system-prompt.md',
+            sha256: 'a'.repeat(64),
+            short_hash: 'a'.repeat(12),
+            bytes: 20,
+            chars: 20,
+            lines: 2,
+          }],
+        },
+        loaded_files: ['system-prompt.md'],
+      },
+    };
     const legacyTurn = {
       turn: 2,
       timestamp: '2026-05-01T08:00:02.000Z',
@@ -64,14 +96,17 @@ describe('session-log-schema', () => {
     const entries = parseSessionLogContent([
       JSON.stringify(currentTurn),
       JSON.stringify(runtime),
+      JSON.stringify(promptTrace),
       JSON.stringify(legacyTurn),
       JSON.stringify(malformedTurn),
     ].join('\r\n'));
 
-    assert.equal(entries.length, 4);
-    assert.deepStrictEqual(entries.map(entry => isSessionTurnEntry(entry)), [true, false, true, false]);
+    assert.equal(entries.length, 5);
+    assert.deepStrictEqual(entries.map(entry => isSessionTurnEntry(entry)), [true, false, false, true, false]);
     assert.deepStrictEqual((entries[0] as any).user.runtime_feedback, ['[运行时反馈] runtime\n错误: failed']);
     assert.equal((entries[0] as any).user.runtime_observation_source, 'subagent_result');
+    assert.equal((entries[2] as any).entry_type, 'prompt_trace');
+    assert.equal((entries[2] as any).prompt.system.short_hash, 'a'.repeat(12));
   });
 
   test('resolves session id from content and falls back when content has no session id', () => {


### PR DESCRIPTION
增加 prompt 可观测性和本地 Prompt Lab。

## 变更
- 新增 prompt 指纹快照：记录最终 system prompt hash、prompt 文件 bundle hash、文件数量与文件级摘要
- session JSONL 初始化时新增 `prompt_trace` 事件，每轮 turn 追加轻量 `prompt` 元数据
- `prompts_dir` 只记录 `app/prompts` 或自定义目录 hash 标签，避免上传本机绝对路径
- prompt 文件读取支持本地覆盖目录，默认落到用户数据目录 `prompt-overrides`，不改内置基线文件
- Dashboard 新增 Prompt Lab：按核心提示词、文档、sidecars、subagents、transient 分组展示，可编辑覆盖、保存、重置、复制覆盖目录
- 压缩 prompt、sidecar prompt、transient prompt 和主 system prompt 统一走 prompt 模板读取链路
- 更新 prompts README，说明 prompt 目录规范、覆盖目录、prompt_version / hash 如何用于后续 A/B 和回溯
- 增加 prompt editor / observability / template / session log schema 测试

## 验证
- `node --import tsx --test tests/prompt-template.test.ts tests/prompt-observability.test.ts tests/prompt-editor.test.ts tests/session-log-schema.test.ts`
- `node --import tsx --test tests/dashboard-productization-html.test.ts tests/prompt-template.test.ts tests/prompt-editor.test.ts tests/prompt-observability.test.ts`
- `npm.cmd run build`
- `npm.cmd run test:runtime`
- `git diff --check`（仅 Windows 换行提示）
- 本地 Electron dev `http://127.0.0.1:3810` 验证 Prompt Lab：分组树展示、保存覆盖、hash 变化、重置回内置基线、控制台无 warning/error