### PR TITLE
修复共享虚拟员工移动端/网页对话时的用户设备路由

### DIFF
--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -26,6 +26,7 @@ import { GlobTool } from '../tools/glob-tool';
 import { GrepTool } from '../tools/grep-tool';
 import { WriteTool } from '../tools/write-tool';
 import { EditTool } from '../tools/edit-tool';
+import { ShellTool } from '../tools/bash-tool';
 import {
   isRemoteDeviceRpcTool,
   normalizeDeviceRpcToolResultForTransport,
@@ -358,6 +359,8 @@ export class CatsCompanyBot {
         return new WriteTool().execute(args, context);
       case 'edit_file':
         return new EditTool().execute(args, context);
+      case 'execute_shell':
+        return new ShellTool().execute(args, context);
       default:
         return {
           ok: false,
@@ -448,7 +451,7 @@ export class CatsCompanyBot {
     const operation = this.normalizeDeviceRpcOperation(request.operation);
     const toolName = String(request.tool_name || operation || '').trim();
     if (!operation || !isRemoteDeviceRpcTool(toolName, operation)) {
-      return { code: 'unsupported_operation', message: 'Device RPC only allows read_file, glob, grep, write_file, and edit_file.' };
+      return { code: 'unsupported_operation', message: 'Device RPC only allows read_file, glob, grep, write_file, edit_file, and execute_shell.' };
     }
 
     const requiredFields: Array<[keyof CatsDeviceRpcMessage, string]> = [
@@ -484,6 +487,7 @@ export class CatsCompanyBot {
       || operation === 'grep'
       || operation === 'write_file'
       || operation === 'edit_file'
+      || operation === 'execute_shell'
     ) {
       return operation;
     }

--- a/src/catscompany/message-envelope.ts
+++ b/src/catscompany/message-envelope.ts
@@ -42,7 +42,10 @@ export function createCatsCoMessageEnvelope(input: CatsCoEnvelopeInput): Message
   if (metadataLooksCanonical && canonicalTopicId && canonicalTopicId !== topicId) {
     warnings.push('catsco_identity topic_id does not match message topic');
   }
-  if (metadataLooksCanonical && canonicalActorId && senderId !== 'unknown' && canonicalActorId !== senderId) {
+  const senderMatchesCanonicalActor = senderId === 'unknown'
+    || sameCatsCoUserId(canonicalActorId, senderId);
+
+  if (metadataLooksCanonical && canonicalActorId && !senderMatchesCanonicalActor) {
     warnings.push('catsco_identity actor.user_id does not match message sender');
   }
 
@@ -51,7 +54,7 @@ export function createCatsCoMessageEnvelope(input: CatsCoEnvelopeInput): Message
     && metadataLooksCanonical
     && canonicalActorId
     && canonicalTopicId === topicId
-    && (senderId === 'unknown' || canonicalActorId === senderId),
+    && senderMatchesCanonicalActor,
   );
 
   const actorUserId = isCanonicalTrusted ? canonicalActorId! : senderId;
@@ -62,6 +65,19 @@ export function createCatsCoMessageEnvelope(input: CatsCoEnvelopeInput): Message
     ? firstNonEmpty(stringField(agent, 'agent_id'), safeString(input.botUid))
     : safeString(input.botUid);
   const agentBodyId = isCanonicalTrusted ? stringField(agent, 'body_id') : undefined;
+  const deviceOwnerUserId = isCanonicalTrusted
+    ? stringField(permissions, 'device_owner_user_id')
+    : undefined;
+  const deviceOwnerSource = isCanonicalTrusted
+    ? stringField(permissions, 'device_owner_source')
+    : undefined;
+  const channelSource = isCanonicalTrusted
+    ? firstNonEmpty(
+      stringField(metadata, 'source_channel'),
+      stringField(metadata, 'channel_source'),
+      stringField(metadata, 'channel'),
+    )
+    : undefined;
   const channelSeq = isCanonicalTrusted
     ? canonicalChannelSeq ?? normalizeSeq(input.seq)
     : normalizeSeq(input.seq);
@@ -99,6 +115,9 @@ export function createCatsCoMessageEnvelope(input: CatsCoEnvelopeInput): Message
     rawText: input.text,
     rawMetadata: metadata,
     permissionsSource: isCanonicalTrusted ? permissionsSource : undefined,
+    deviceOwnerUserId,
+    deviceOwnerSource,
+    channelSource,
     identityTrust,
     identitySource: isCanonicalTrusted ? 'metadata.catsco_identity' : undefined,
     warnings: warnings.length > 0 ? warnings : undefined,
@@ -117,6 +136,9 @@ export function createExecutionScope(envelope: MessageEnvelope): ExecutionScope 
     agentBodyId: envelope.agentBodyId,
     channelSeq: envelope.channelSeq,
     permissionsSource: envelope.permissionsSource,
+    deviceOwnerUserId: envelope.deviceOwnerUserId,
+    deviceOwnerSource: envelope.deviceOwnerSource,
+    channelSource: envelope.channelSource,
     identityTrust: envelope.identityTrust,
     isTrusted: envelope.identityTrust === 'server_canonical',
   };
@@ -194,4 +216,16 @@ function firstNonEmpty(...values: Array<string | undefined>): string | undefined
     if (value) return value;
   }
   return undefined;
+}
+
+function sameCatsCoUserId(left: string | undefined, right: string | undefined): boolean {
+  const normalizedLeft = normalizeCatsCoUserId(left);
+  const normalizedRight = normalizeCatsCoUserId(right);
+  return Boolean(normalizedLeft && normalizedRight && normalizedLeft === normalizedRight);
+}
+
+function normalizeCatsCoUserId(value: string | undefined): string {
+  const text = String(value || '').trim();
+  if (!text) return '';
+  return /^\d+$/.test(text) ? `usr${text}` : text;
 }

--- a/src/tools/bash-tool.ts
+++ b/src/tools/bash-tool.ts
@@ -9,6 +9,7 @@ import { Logger } from '../utils/logger';
 import { resolveRuntimeEnvironment } from '../utils/runtime-environment';
 import { isToolAllowed, isBashCommandAllowed } from '../utils/safety';
 import { resolveToolGatewayAccess } from './tool-gateway';
+import { executeRemoteDeviceRpcTool } from './device-rpc-tool';
 
 const execAsync = promisify(exec);
 const CWD_MARKER_PREFIX = '__XIAOBA_CWD_MARKER__';
@@ -77,6 +78,8 @@ export class ShellTool implements Tool {
     if (!gateway.ok) {
       return { ok: false, errorCode: gateway.errorCode, message: gateway.message };
     }
+    const remoteResult = await executeRemoteDeviceRpcTool(context, gateway, 'execute_shell', 'execute_shell', args);
+    if (remoteResult) return remoteResult;
 
     if (description) {
       Logger.info(`Executing command: ${description}`);

--- a/src/tools/device-rpc-tool.ts
+++ b/src/tools/device-rpc-tool.ts
@@ -14,13 +14,14 @@ export function isRemoteReadonlyTool(toolName: string, operation: DeviceGrantOpe
 export function isRemoteDeviceRpcTool(toolName: string, operation: DeviceGrantOperation): boolean {
   return isRemoteReadonlyTool(toolName, operation)
     || (toolName === 'write_file' && operation === 'write_file')
-    || (toolName === 'edit_file' && operation === 'edit_file');
+    || (toolName === 'edit_file' && operation === 'edit_file')
+    || (toolName === 'execute_shell' && operation === 'execute_shell');
 }
 
 export async function executeRemoteDeviceRpcTool(
   context: ToolExecutionContext,
   gateway: ToolGatewayDecision,
-  toolName: 'read_file' | 'glob' | 'grep' | 'write_file' | 'edit_file',
+  toolName: 'read_file' | 'glob' | 'grep' | 'write_file' | 'edit_file' | 'execute_shell',
   operation: DeviceGrantOperation,
   args: Record<string, unknown>,
 ): Promise<ToolExecutionResult | undefined> {
@@ -30,7 +31,7 @@ export async function executeRemoteDeviceRpcTool(
     return {
       ok: false,
       errorCode: 'PERMISSION_DENIED',
-      message: `远程设备 RPC 当前只允许 read_file / glob / grep / write_file / edit_file，已阻止 ${toolName}。`,
+      message: `远程设备 RPC 当前只允许 read_file / glob / grep / write_file / edit_file / execute_shell，已阻止 ${toolName}。`,
     };
   }
 

--- a/src/tools/edit-tool.ts
+++ b/src/tools/edit-tool.ts
@@ -45,16 +45,6 @@ export class EditTool implements Tool {
       return { ok: false, errorCode: 'PERMISSION_DENIED', message: `执行被阻止: ${toolPermission.reason}` };
     }
 
-    // 解析文件路径
-    const absolutePath = path.isAbsolute(file_path)
-      ? file_path
-      : path.join(context.workingDirectory, file_path);
-
-    const pathPermission = isPathAllowed(absolutePath, context.workingDirectory);
-    if (!pathPermission.allowed) {
-      return { ok: false, errorCode: 'PERMISSION_DENIED', message: `执行被阻止: ${pathPermission.reason}` };
-    }
-
     const gateway = resolveToolGatewayAccess(context, {
       toolName: this.definition.name,
       operation: 'edit_file',
@@ -65,6 +55,16 @@ export class EditTool implements Tool {
     }
     const remoteResult = await executeRemoteDeviceRpcTool(context, gateway, 'edit_file', 'edit_file', args);
     if (remoteResult) return remoteResult;
+
+    // 解析文件路径
+    const absolutePath = path.isAbsolute(file_path)
+      ? file_path
+      : path.join(context.workingDirectory, file_path);
+
+    const pathPermission = isPathAllowed(absolutePath, context.workingDirectory);
+    if (!pathPermission.allowed) {
+      return { ok: false, errorCode: 'PERMISSION_DENIED', message: `执行被阻止: ${pathPermission.reason}` };
+    }
     const displayPath = formatCatsCoVisiblePath(context, file_path, { preserveRelative: true });
 
     // 检查文件是否存在

--- a/src/tools/tool-gateway.ts
+++ b/src/tools/tool-gateway.ts
@@ -33,7 +33,7 @@ export interface CatsCoVisiblePathOptions {
   preserveRelative?: boolean;
 }
 
-const REMOTE_DEVICE_RPC_OPERATIONS = new Set<DeviceGrantOperation>(['read_file', 'glob', 'grep', 'write_file', 'edit_file']);
+const REMOTE_DEVICE_RPC_OPERATIONS = new Set<DeviceGrantOperation>(['read_file', 'glob', 'grep', 'write_file', 'edit_file', 'execute_shell']);
 
 export function isCatsCoToolGatewayContext(context: ToolExecutionContext): boolean {
   return context.surface === 'catscompany' || context.executionScope?.source === 'catscompany';
@@ -47,7 +47,13 @@ export function isCatsCoLocalOwnerSelfContext(context: ToolExecutionContext): bo
     return false;
   }
   const ownerUserId = localDevice?.ownerUserId;
-  return sameCatsCoUserId(ownerUserId, scope.actorUserId);
+  if (scope.deviceOwnerUserId && !sameCatsCoUserId(scope.deviceOwnerUserId, ownerUserId)) {
+    return false;
+  }
+  if (sameCatsCoUserId(ownerUserId, scope.actorUserId)) {
+    return true;
+  }
+  return false;
 }
 
 export function formatCatsCoVisiblePath(
@@ -102,12 +108,8 @@ export function resolveToolGatewayAccess(
   }
 
   const localOwnerSelf = isCatsCoLocalOwnerSelfContext(context);
-  if (options.operation === 'execute_shell' && !localOwnerSelf && !options.allowCatsCoShell) {
-    return denied([
-      'CatsCo 会话暂不允许外部用户或远程委托通过 execute_shell 操作命令行。',
-      '命令执行只允许本机 owner 自用场景直接执行。',
-    ], options.targetLabel);
-  }
+  const rpcForwardLocal = isCatsCoDeviceRpcForwardLocalContext(context, options.operation);
+  const requireSelectedDevice = requiresExplicitBackendDeviceSelection(scope, localDevice, rpcForwardLocal);
 
   const selectionScope = validateSelectionScope(context.deviceSelection, scope, options.targetLabel);
   if (!selectionScope.ok) return selectionScope;
@@ -117,12 +119,15 @@ export function resolveToolGatewayAccess(
     localDevice,
     options.operation,
     options.targetLabel,
-    { allowLocalSelfOperation: localOwnerSelf },
+    {
+      allowLocalSelfOperation: localOwnerSelf || rpcForwardLocal,
+      requireSelection: requireSelectedDevice,
+    },
   );
   if (!selectedTarget.ok) return selectedTarget;
 
   const targetDeviceId = selectedTarget.deviceId || localDevice.deviceId || localDevice.installationId || localDevice.bodyId;
-  if (selectedTarget.mode === 'local' && localOwnerSelf) {
+  if (selectedTarget.mode === 'local' && (localOwnerSelf || rpcForwardLocal)) {
     return {
       ok: true,
       mode: 'local',
@@ -147,7 +152,7 @@ export function resolveToolGatewayAccess(
     if (!REMOTE_DEVICE_RPC_OPERATIONS.has(options.operation)) {
       return denied([
         `后端选定的用户设备不是当前运行体，但 ${options.operation} 还没有开放远程执行。`,
-        '当前只开放 read_file / glob / grep / write_file / edit_file 文件级远程工具；命令执行不走远程 RPC。',
+        '当前只开放 read_file / glob / grep / write_file / edit_file / execute_shell 远程工具。',
       ], options.targetLabel);
     }
     if (!context.deviceRpc) {
@@ -166,6 +171,20 @@ export function resolveToolGatewayAccess(
       targetDeviceBodyId: selectedTarget.bodyId,
       targetDeviceInstallationId: selectedTarget.installationId,
     };
+  }
+
+  if (!context.deviceSelection && requiresBackendSelectedDeviceForLocalExecution(scope, localDevice, grant, rpcForwardLocal)) {
+    return denied([
+      '后端没有选定当前说话人的目标设备，已阻止本地设备操作。',
+      '共享虚拟员工不能默认使用云端运行体本机，必须由服务端选择当前用户自己的在线设备。',
+    ], options.targetLabel);
+  }
+
+  if (options.operation === 'execute_shell' && !localOwnerSelf && !rpcForwardLocal && !options.allowCatsCoShell) {
+    return denied([
+      'CatsCo 会话暂不允许外部用户或远程委托通过 execute_shell 操作命令行。',
+      '命令执行只允许本机 owner 自用场景直接执行。',
+    ], options.targetLabel);
   }
 
   if (localDevice.ownerUserId && !sameCatsCoUserId(grant.ownerUserId, localDevice.ownerUserId)) {
@@ -225,9 +244,15 @@ function resolveBackendSelectedDevice(
   localDevice: ScopedLocalDeviceGrant,
   operation: DeviceGrantOperation,
   targetLabel?: string,
-  options: { allowLocalSelfOperation?: boolean } = {},
+  options: { allowLocalSelfOperation?: boolean; requireSelection?: boolean } = {},
 ): SelectedDeviceDecision {
   if (!selection) {
+    if (options.requireSelection) {
+      return selectedDenied([
+        '后端没有选定当前说话人的目标设备，已阻止本地设备操作。',
+        '共享虚拟员工或移动端渠道不能默认使用云端运行体本机，必须由服务端选择当前用户自己的在线设备。',
+      ], targetLabel);
+    }
     return {
       ok: true,
       mode: 'local',
@@ -319,18 +344,21 @@ function validateSelectionScope(
 }
 
 function matchesLocalDevice(selection: ScopedDeviceSelection, localDevice: ScopedLocalDeviceGrant): boolean {
-  const selectedIds = [
-    selection.selectedDeviceId,
-    selection.selectedDeviceInstallationId,
-    selection.selectedDeviceBodyId,
-  ].filter(Boolean);
-  const localIds = [
-    localDevice.deviceId,
-    localDevice.installationId,
-    localDevice.bodyId,
-  ].filter(Boolean);
-  if (selectedIds.length === 0 || localIds.length === 0) return false;
-  return selectedIds.some(selected => localIds.includes(selected));
+  let matched = false;
+  if (selection.selectedDeviceId) {
+    const localDeviceIds = [localDevice.deviceId, localDevice.installationId].filter(Boolean);
+    if (!localDeviceIds.includes(selection.selectedDeviceId)) return false;
+    matched = true;
+  }
+  if (selection.selectedDeviceInstallationId) {
+    if (!localDevice.installationId || selection.selectedDeviceInstallationId !== localDevice.installationId) return false;
+    matched = true;
+  }
+  if (selection.selectedDeviceBodyId) {
+    if (!localDevice.bodyId || selection.selectedDeviceBodyId !== localDevice.bodyId) return false;
+    matched = true;
+  }
+  return matched;
 }
 
 function denied(lines: string[], targetLabel?: string): ToolGatewayDecision {
@@ -357,6 +385,118 @@ function looksLikeAbsoluteLocalPath(value: string): boolean {
     || /^\\\\/.test(value)
     || /^\//.test(value)
     || /^~[\\/]/.test(value);
+}
+
+function isCatsCoDeviceRpcForwardLocalContext(
+  context: ToolExecutionContext,
+  operation: DeviceGrantOperation,
+): boolean {
+  if (!isCatsCoToolGatewayContext(context)) return false;
+  const scope = context.executionScope;
+  const localDevice = context.localDeviceGrant;
+  if (!scope || scope.permissionsSource !== 'device_rpc_forward') return false;
+  if (scope.identityTrust !== 'server_canonical' || !scope.isTrusted || !localDevice?.ownerUserId) return false;
+  return (context.deviceGrants || []).some(grant =>
+    isCanonicalGrantForLocalOwnerDevice(grant, localDevice, localDevice.ownerUserId!, operation),
+  );
+}
+
+function isExternalActorOnLocalBody(
+  scope: NonNullable<ToolExecutionContext['executionScope']>,
+  localDevice: ScopedLocalDeviceGrant,
+): boolean {
+  return Boolean(
+    localDevice.ownerUserId
+    && scope.actorUserId
+    && !sameCatsCoUserId(localDevice.ownerUserId, scope.actorUserId),
+  );
+}
+
+function requiresBackendSelectedDeviceForLocalExecution(
+  scope: NonNullable<ToolExecutionContext['executionScope']>,
+  localDevice: ScopedLocalDeviceGrant,
+  grant: ScopedDeviceGrant,
+  rpcForwardLocal: boolean,
+): boolean {
+  if (rpcForwardLocal) return false;
+  if (scope.deviceOwnerUserId) return true;
+  if (isMobileChannelSource(scope.channelSource)) return true;
+  if (isChannelOwnerSource(scope.deviceOwnerSource)) return true;
+  if (isExternalActorOnLocalBody(scope, localDevice)) return true;
+  if (isDelegatedDeviceGrant(grant) || isChannelLinkedDeviceGrant(grant)) return true;
+  if (!localDevice.ownerUserId && !isPlainServerMetadataDeviceGrant(grant)) return true;
+  return false;
+}
+
+function requiresExplicitBackendDeviceSelection(
+  scope: NonNullable<ToolExecutionContext['executionScope']>,
+  localDevice: ScopedLocalDeviceGrant,
+  rpcForwardLocal: boolean,
+): boolean {
+  if (rpcForwardLocal) return false;
+  if (scope.deviceOwnerUserId) return true;
+  if (isMobileChannelSource(scope.channelSource)) return true;
+  if (isChannelOwnerSource(scope.deviceOwnerSource)) return true;
+  if (isExternalActorOnLocalBody(scope, localDevice)) return true;
+  return false;
+}
+
+function isChannelLinkedDeviceGrant(grant: Pick<ScopedDeviceGrant, 'identitySource'>): boolean {
+  const source = String(grant.identitySource || '').toLowerCase();
+  return source.includes('channel') || source.includes('feishu') || source.includes('weixin');
+}
+
+function isChannelOwnerSource(value: string | undefined): boolean {
+  const source = String(value || '').toLowerCase();
+  return source.includes('channel') || source.includes('feishu') || source.includes('weixin');
+}
+
+function isMobileChannelSource(value: string | undefined): boolean {
+  const source = String(value || '').toLowerCase();
+  return source === 'weixin' || source === 'wechat' || source === 'feishu' || source === 'lark';
+}
+
+function isPlainServerMetadataDeviceGrant(grant: Pick<ScopedDeviceGrant, 'identitySource' | 'ownerUserId' | 'actorUserId'>): boolean {
+  const source = String(grant.identitySource || '').toLowerCase();
+  return grant.ownerUserId === grant.actorUserId
+    && (source === 'metadata.catsco_identity' || source === 'server_canonical_message');
+}
+
+function isCanonicalGrantForLocalOwnerDevice(
+  grant: ScopedDeviceGrant,
+  localDevice: ScopedLocalDeviceGrant,
+  ownerUserId: string,
+  operation: DeviceGrantOperation,
+): boolean {
+  if (grant.status !== 'active') return false;
+  if (grant.identityTrust !== 'server_canonical') return false;
+  if (!grant.operations.includes(operation)) return false;
+  if (!sameCatsCoUserId(grant.ownerUserId, ownerUserId)) return false;
+  if (!sameCatsCoUserId(grant.ownerUserId, grant.actorUserId) && !isDelegatedDeviceGrant(grant)) {
+    return false;
+  }
+  return deviceGrantTargetsLocalDevice(grant, localDevice);
+}
+
+function deviceGrantTargetsLocalDevice(
+  grant: Pick<ScopedDeviceGrant, 'deviceId' | 'deviceBodyId' | 'deviceInstallationId'>,
+  localDevice: ScopedLocalDeviceGrant,
+): boolean {
+  let matched = false;
+  const localDeviceIds = [localDevice.deviceId, localDevice.installationId].filter(Boolean);
+  if (grant.deviceId) {
+    if (!localDeviceIds.includes(grant.deviceId)) return false;
+    matched = true;
+  }
+  if (grant.deviceInstallationId) {
+    if (!localDevice.installationId || grant.deviceInstallationId !== localDevice.installationId) return false;
+    matched = true;
+  }
+  if (grant.deviceBodyId) {
+    if (!localDevice.bodyId || grant.deviceBodyId !== localDevice.bodyId) return false;
+    matched = true;
+  }
+  return matched;
 }
 
 function sameCatsCoUserId(left: string | undefined, right: string | undefined): boolean {

--- a/src/tools/write-tool.ts
+++ b/src/tools/write-tool.ts
@@ -37,16 +37,6 @@ export class WriteTool implements Tool {
       return { ok: false, errorCode: 'PERMISSION_DENIED', message: `执行被阻止: ${toolPermission.reason}` };
     }
 
-    // 解析文件路径
-    const absolutePath = path.isAbsolute(file_path)
-      ? file_path
-      : path.join(context.workingDirectory, file_path);
-
-    const pathPermission = isPathAllowed(absolutePath, context.workingDirectory);
-    if (!pathPermission.allowed) {
-      return { ok: false, errorCode: 'PERMISSION_DENIED', message: `执行被阻止: ${pathPermission.reason}` };
-    }
-
     const gateway = resolveToolGatewayAccess(context, {
       toolName: this.definition.name,
       operation: 'write_file',
@@ -57,6 +47,16 @@ export class WriteTool implements Tool {
     }
     const remoteResult = await executeRemoteDeviceRpcTool(context, gateway, 'write_file', 'write_file', args);
     if (remoteResult) return remoteResult;
+
+    // 解析文件路径
+    const absolutePath = path.isAbsolute(file_path)
+      ? file_path
+      : path.join(context.workingDirectory, file_path);
+
+    const pathPermission = isPathAllowed(absolutePath, context.workingDirectory);
+    if (!pathPermission.allowed) {
+      return { ok: false, errorCode: 'PERMISSION_DENIED', message: `执行被阻止: ${pathPermission.reason}` };
+    }
 
     // 获取相对路径用于显示
     const relativePath = path.relative(context.workingDirectory, absolutePath);

--- a/src/types/session-identity.ts
+++ b/src/types/session-identity.ts
@@ -21,6 +21,9 @@ export interface MessageEnvelope {
   rawText: string;
   rawMetadata?: Record<string, unknown>;
   permissionsSource?: string;
+  deviceOwnerUserId?: string;
+  deviceOwnerSource?: string;
+  channelSource?: string;
   identityTrust: IdentityTrustLevel;
   identitySource?: string;
   warnings?: string[];
@@ -37,6 +40,9 @@ export interface ExecutionScope {
   agentBodyId?: string;
   channelSeq?: number;
   permissionsSource?: string;
+  deviceOwnerUserId?: string;
+  deviceOwnerSource?: string;
+  channelSource?: string;
   identityTrust: IdentityTrustLevel;
   isTrusted: boolean;
 }

--- a/tests/catscompany-device-rpc-tools.test.ts
+++ b/tests/catscompany-device-rpc-tools.test.ts
@@ -280,7 +280,7 @@ describe('CatsCompany Device RPC file tools', () => {
     assert.match(captured.result.error.message, /channel_identity_link/);
   });
 
-  test('rejects shell Device RPC operations before local tool execution', async () => {
+  test('executes shell Device RPC operations on the selected local device', async () => {
     const captured: { result?: any } = {};
     const bot = botWithDevice(captured);
 
@@ -288,13 +288,13 @@ describe('CatsCompany Device RPC file tools', () => {
       request_id: 'rpc-shell-1',
       operation: 'execute_shell',
       tool_name: 'execute_shell',
-      payload: { args: { command: 'echo unsafe' } },
+      payload: { args: { command: 'node -e "console.log(\'rpc-shell-ok\')"' } },
     }));
 
     assert.ok(captured.result);
-    assert.equal(captured.result.result, undefined);
-    assert.equal(captured.result.error.code, 'unsupported_operation');
-    assert.match(captured.result.error.message, /read_file, glob, grep, write_file, and edit_file/);
+    assert.equal(captured.result.error, undefined);
+    assert.equal(captured.result.result.ok, true);
+    assert.match(captured.result.result.content, /rpc-shell-ok/);
   });
 
   test('rejects Device RPC requests for another target device', async () => {

--- a/tests/catscompany-message-envelope.test.ts
+++ b/tests/catscompany-message-envelope.test.ts
@@ -76,6 +76,39 @@ describe('CatsCompany MessageEnvelope and ExecutionScope', () => {
     assert.equal(scope.isTrusted, true);
   });
 
+  test('trusts canonical identity when sender id omits usr prefix', () => {
+    const envelope = createCatsCoMessageEnvelope({
+      topic: 'p2p_7_43',
+      senderId: '7',
+      seq: 32,
+      text: 'mobile hello',
+      botUid: 'usr43',
+      metadata: {
+        source_channel: 'weixin',
+        catsco_identity: {
+          actor: { user_id: 'usr7', display_name: 'Alice' },
+          agent: { agent_id: 'usr43', body_id: 'body-cloud' },
+          topic: { topic_id: 'p2p_7_43', type: 'p2p', channel_seq: 32 },
+          permissions: {
+            source: 'server_canonical_message',
+            device_owner_user_id: 'usr7',
+            device_owner_source: 'channel_identity_link',
+          },
+        },
+      },
+    });
+    const scope = createExecutionScope(envelope);
+
+    assert.equal(envelope.identityTrust, 'server_canonical');
+    assert.equal(envelope.actorUserId, 'usr7');
+    assert.equal(scope.actorUserId, 'usr7');
+    assert.equal(scope.deviceOwnerUserId, 'usr7');
+    assert.equal(scope.deviceOwnerSource, 'channel_identity_link');
+    assert.equal(scope.channelSource, 'weixin');
+    assert.equal(scope.isTrusted, true);
+    assert.ok(!envelope.warnings?.some(warning => warning.includes('actor.user_id')));
+  });
+
   test('does not trust spoofed catsco_identity when it conflicts with sender', () => {
     const envelope = createCatsCoMessageEnvelope({
       topic: 'p2p_7_43',

--- a/tests/tool-gateway-catsco.test.ts
+++ b/tests/tool-gateway-catsco.test.ts
@@ -530,6 +530,71 @@ describe('CatsCo ToolGateway', () => {
     assert.equal(fs.existsSync(path.join(root, 'remote.txt')), false);
   });
 
+  test('routes mobile channel write_file to the speaker owner device instead of the cloud body', async () => {
+    const root = makeWorkspace();
+    const marker = path.join(root, 'must-not-create-on-cloud.txt');
+    const channelScope = scope({
+      actorUserId: 'usr100',
+      sessionKey: 'session:v2:catscompany:p2p:p2p_100_43:agent:usr43',
+      topicId: 'p2p_100_43',
+      deviceOwnerUserId: 'usr100',
+      deviceOwnerSource: 'channel_identity_link',
+      channelSource: 'weixin',
+    });
+    const calls: any[] = [];
+
+    const result = await new WriteTool().execute({ file_path: marker, content: 'from mobile' }, context(root, {
+      executionScope: channelScope,
+      localDeviceGrant: localDevice({
+        ownerUserId: 'usr9',
+        bodyId: 'cloud-body',
+        installationId: 'cloud-install',
+        deviceId: 'cloud-install',
+        capabilities: ['read_file', 'glob', 'grep', 'write_file', 'edit_file', 'send_file', 'execute_shell'],
+      }),
+      deviceGrants: [deviceGrant(['write_file'], {
+        grantId: 'speaker-write-grant',
+        identitySource: 'channel_identity_link',
+        deviceId: 'speaker-device',
+        deviceBodyId: 'speaker-body',
+        deviceInstallationId: 'speaker-install',
+        ownerUserId: 'usr100',
+        actorUserId: 'usr100',
+        sessionKey: channelScope.sessionKey,
+        topicId: channelScope.topicId,
+        topicType: channelScope.topicType,
+        agentId: channelScope.agentId,
+        agentBodyId: channelScope.agentBodyId,
+      })],
+      deviceSelection: deviceSelection({
+        sessionKey: channelScope.sessionKey,
+        topicId: channelScope.topicId,
+        topicType: channelScope.topicType,
+        actorUserId: channelScope.actorUserId,
+        agentId: channelScope.agentId,
+        selectedDeviceId: 'speaker-device',
+        selectedDeviceBodyId: 'speaker-body',
+        selectedDeviceInstallationId: 'speaker-install',
+        selectedDeviceDisplayName: 'Speaker Laptop',
+        selectedDeviceOperations: ['write_file'],
+      }),
+      deviceRpc: {
+        executeTool: async request => {
+          calls.push(request);
+          return { ok: true, content: 'remote write ok' };
+        },
+      },
+    }));
+
+    assert.equal(result.ok, true);
+    assert.equal(result.ok ? result.content : '', 'remote write ok');
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].toolName, 'write_file');
+    assert.equal(calls[0].grant.ownerUserId, 'usr100');
+    assert.equal(calls[0].grant.deviceId, 'speaker-device');
+    assert.equal(fs.existsSync(marker), false);
+  });
+
   test('routes remote edit_file through Device RPC without local fallback', async () => {
     const root = makeWorkspace();
     fs.writeFileSync(path.join(root, 'local.txt'), 'before');
@@ -575,6 +640,232 @@ describe('CatsCo ToolGateway', () => {
 
     assert.equal(result.ok, true);
     if (result.ok) assert.match(result.content, /catsco-shell-ok/);
+  });
+
+  test('routes execute_shell for a mobile channel speaker to the selected user device', async () => {
+    const root = makeWorkspace();
+    const marker = path.join(root, 'should-not-run-locally.txt');
+    const channelScope = scope({
+      actorUserId: 'usr100',
+      sessionKey: 'session:v2:catscompany:p2p:p2p_100_43:agent:usr43',
+      topicId: 'p2p_100_43',
+      deviceOwnerUserId: 'usr100',
+      deviceOwnerSource: 'channel_identity_link',
+      channelSource: 'weixin',
+    });
+    const calls: any[] = [];
+    const result = await new ShellTool().execute({ command: `node -e "require('fs').writeFileSync('${marker.replace(/\\/g, '\\\\')}', 'wrong')"` }, context(root, {
+      executionScope: channelScope,
+      localDeviceGrant: localDevice({
+        ownerUserId: 'usr9',
+        capabilities: ['read_file', 'glob', 'grep', 'write_file', 'edit_file', 'send_file', 'execute_shell'],
+      }),
+      deviceGrants: [deviceGrant(['execute_shell'], {
+        grantId: 'channel-owner-grant',
+        identitySource: 'channel_identity_link',
+        deviceId: 'speaker-device',
+        deviceBodyId: 'speaker-body',
+        deviceInstallationId: 'speaker-install',
+        ownerUserId: 'usr100',
+        actorUserId: 'usr100',
+        sessionKey: channelScope.sessionKey,
+        topicId: channelScope.topicId,
+        topicType: channelScope.topicType,
+        agentId: channelScope.agentId,
+        agentBodyId: channelScope.agentBodyId,
+      })],
+      deviceSelection: deviceSelection({
+        sessionKey: channelScope.sessionKey,
+        topicId: channelScope.topicId,
+        topicType: channelScope.topicType,
+        actorUserId: channelScope.actorUserId,
+        agentId: channelScope.agentId,
+        selectedDeviceId: 'speaker-device',
+        selectedDeviceBodyId: 'speaker-body',
+        selectedDeviceInstallationId: 'speaker-install',
+        selectedDeviceDisplayName: 'Speaker Laptop',
+        selectedDeviceOperations: ['execute_shell'],
+      }),
+      deviceRpc: {
+        executeTool: async request => {
+          calls.push(request);
+          return { ok: true, content: 'remote shell ok' };
+        },
+      },
+    }));
+
+    assert.equal(result.ok, true);
+    assert.equal(result.ok ? result.content : '', 'remote shell ok');
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].toolName, 'execute_shell');
+    assert.equal(calls[0].operation, 'execute_shell');
+    assert.equal(fs.existsSync(marker), false);
+  });
+
+  test('blocks shared mobile shell access when backend did not select the speaker device', async () => {
+    const root = makeWorkspace();
+    const marker = path.join(root, 'must-not-create-on-cloud.txt');
+    const channelScope = scope({
+      actorUserId: 'usr100',
+      sessionKey: 'session:v2:catscompany:p2p:p2p_100_43:agent:usr43',
+      topicId: 'p2p_100_43',
+      deviceOwnerUserId: 'usr100',
+      deviceOwnerSource: 'channel_identity_link',
+      channelSource: 'weixin',
+    });
+    const result = await new ShellTool().execute({ command: `node -e "require('fs').writeFileSync('${marker.replace(/\\/g, '\\\\')}', 'wrong')"` }, context(root, {
+      executionScope: channelScope,
+      localDeviceGrant: localDevice({
+        ownerUserId: 'usr9',
+        capabilities: ['read_file', 'glob', 'grep', 'write_file', 'edit_file', 'send_file', 'execute_shell'],
+      }),
+      deviceGrants: [deviceGrant(['execute_shell'], {
+        grantId: 'channel-owner-grant',
+        identitySource: 'channel_identity_link',
+        ownerUserId: 'usr100',
+        actorUserId: 'usr100',
+        sessionKey: channelScope.sessionKey,
+        topicId: channelScope.topicId,
+        topicType: channelScope.topicType,
+        agentId: channelScope.agentId,
+        agentBodyId: channelScope.agentBodyId,
+      })],
+    }));
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.errorCode, 'PERMISSION_DENIED');
+      assert.match(result.message, /后端没有选定当前说话人的目标设备/);
+    }
+    assert.equal(fs.existsSync(marker), false);
+  });
+
+  test('blocks channel write_file on cloud body when local device owner is missing and no speaker device is selected', async () => {
+    const root = makeWorkspace();
+    const marker = path.join(root, 'must-not-create-on-cloud.txt');
+    const channelScope = scope({
+      actorUserId: 'usr100',
+      sessionKey: 'session:v2:catscompany:p2p:p2p_100_43:agent:usr43',
+      topicId: 'p2p_100_43',
+      deviceOwnerUserId: 'usr100',
+      deviceOwnerSource: 'channel_identity_link',
+      channelSource: 'weixin',
+    });
+    const result = await new WriteTool().execute({ file_path: marker, content: 'wrong-device' }, context(root, {
+      executionScope: channelScope,
+      localDeviceGrant: localDevice({
+        ownerUserId: undefined,
+        capabilities: ['read_file', 'glob', 'grep', 'write_file', 'edit_file', 'send_file', 'execute_shell'],
+      }),
+      deviceGrants: [deviceGrant(['write_file'], {
+        grantId: 'channel-owner-grant',
+        identitySource: 'channel_identity_link',
+        ownerUserId: 'usr100',
+        actorUserId: 'usr100',
+        sessionKey: channelScope.sessionKey,
+        topicId: channelScope.topicId,
+        topicType: channelScope.topicType,
+        agentId: channelScope.agentId,
+        agentBodyId: channelScope.agentBodyId,
+      })],
+    }));
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.errorCode, 'PERMISSION_DENIED');
+      assert.match(result.message, /后端没有选定当前说话人的目标设备/);
+    }
+    assert.equal(fs.existsSync(marker), false);
+  });
+
+  test('blocks delegated local execution when selected device does not declare the requested operation', async () => {
+    const root = makeWorkspace();
+    const marker = path.join(root, 'must-not-write.txt');
+    const channelScope = scope({
+      actorUserId: 'usr101',
+      sessionKey: 'session:v2:catscompany:p2p:p2p_101_43:agent:usr43',
+      topicId: 'p2p_101_43',
+      deviceOwnerUserId: 'usr100',
+      deviceOwnerSource: 'channel_identity_link',
+      channelSource: 'weixin',
+    });
+    const result = await new WriteTool().execute({ file_path: marker, content: 'wrong-device' }, context(root, {
+      executionScope: channelScope,
+      localDeviceGrant: localDevice({
+        ownerUserId: 'usr100',
+        capabilities: ['read_file', 'glob', 'grep', 'write_file', 'edit_file', 'send_file', 'execute_shell'],
+      }),
+      deviceGrants: [deviceGrant(['write_file'], {
+        grantId: 'channel-owner-grant',
+        identitySource: 'channel_identity_link',
+        ownerUserId: 'usr100',
+        actorUserId: 'usr101',
+        sessionKey: channelScope.sessionKey,
+        topicId: channelScope.topicId,
+        topicType: channelScope.topicType,
+        agentId: channelScope.agentId,
+        agentBodyId: channelScope.agentBodyId,
+      })],
+      deviceSelection: deviceSelection({
+        sessionKey: channelScope.sessionKey,
+        topicId: channelScope.topicId,
+        topicType: channelScope.topicType,
+        actorUserId: channelScope.actorUserId,
+        agentId: channelScope.agentId,
+        selectedDeviceOperations: ['read_file'],
+      }),
+    }));
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.errorCode, 'PERMISSION_DENIED');
+      assert.match(result.message, /没有声明支持 write_file/);
+    }
+    assert.equal(fs.existsSync(marker), false);
+  });
+
+  test('blocks mobile channel linked grant when it targets another local device', async () => {
+    const root = makeWorkspace();
+    const channelScope = scope({
+      actorUserId: 'usr100',
+      sessionKey: 'session:v2:catscompany:p2p:p2p_100_43:agent:usr43',
+      topicId: 'p2p_100_43',
+    });
+    const result = await new ShellTool().execute({ command: 'echo should-not-run' }, context(root, {
+      executionScope: channelScope,
+      localDeviceGrant: localDevice({
+        ownerUserId: 'usr9',
+        capabilities: ['read_file', 'glob', 'grep', 'write_file', 'edit_file', 'send_file', 'execute_shell'],
+      }),
+      deviceGrants: [deviceGrant(['execute_shell'], {
+        grantId: 'other-device-grant',
+        identitySource: 'channel_identity_link',
+        ownerUserId: 'usr9',
+        actorUserId: 'usr100',
+        deviceId: 'other-device',
+        deviceBodyId: 'other-body',
+        deviceInstallationId: 'other-install',
+        sessionKey: channelScope.sessionKey,
+        topicId: channelScope.topicId,
+        topicType: channelScope.topicType,
+        agentId: channelScope.agentId,
+        agentBodyId: channelScope.agentBodyId,
+      })],
+      deviceSelection: deviceSelection({
+        sessionKey: channelScope.sessionKey,
+        topicId: channelScope.topicId,
+        topicType: channelScope.topicType,
+        actorUserId: channelScope.actorUserId,
+        agentId: channelScope.agentId,
+        selectedDeviceOperations: ['execute_shell'],
+      }),
+    }));
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.errorCode, 'PERMISSION_DENIED');
+      assert.match(result.message, /没有允许当前设备执行 execute_shell/);
+    }
   });
 
   test('blocks execute_shell in external CatsCo sessions even when a grant contains execute_shell', async () => {


### PR DESCRIPTION
## 背景

共享虚拟员工部署在云电脑上后，用户把它添加为自己的 AI 助手，再通过网页、微信或飞书与它对话时，设备操作应该落到“当前说话人的设备”，而不是虚拟员工运行体所在的云电脑。

此前在部分场景下，XiaoBa-CLI 会丢失后端下发的 canonical identity / device owner 信息，导致工具执行可能 fallback 到云端运行体本机，例如在 `C:\Users\Administrator\...` 下创建文件。

## 改动

- 兼容 `usr7` / `7` 这类 CatsCo 用户 ID 形式，避免误判 canonical actor 与 sender 不一致。
- 将后端下发的 `device_owner_user_id`、`device_owner_source`、`channelSource` 传入每轮 ExecutionScope。
- 共享虚拟员工、微信/飞书移动端等渠道场景下，必须依赖后端选中的当前说话人设备。
- `write_file`、`edit_file`、`execute_shell` 支持通过 Device RPC 路由到后端选中的用户设备。
- 如果后端没有明确选中当前用户设备，阻止本地执行，避免误操作云端运行体或其他用户设备。
- 补充移动端/共享虚拟员工回归测试，覆盖写文件和命令执行不能落到云电脑的场景。

## 验证

- `node node_modules\tsx\dist\cli.mjs --test tests\catscompany-message-envelope.test.ts tests\tool-gateway-catsco.test.ts tests\catscompany-device-rpc-tools.test.ts`
- `node node_modules\typescript\bin\tsc --noEmit`

## 产品效果

用户把云端虚拟员工添加为自己的 AI 助手后，无论在网页端、微信还是飞书里继续对话，虚拟员工都应该以当前说话人的身份选择设备。需要读写文件或执行命令时，工具调用会路由到该用户自己的在线设备；如果没有可用设备，则提示连接/绑定设备，而不是在虚拟员工所在云电脑上执行。