### PR TITLE
把公共目录解析路由到说话人的设备

### DIFF
--- a/src/catscompany/device-grants.ts
+++ b/src/catscompany/device-grants.ts
@@ -99,6 +99,7 @@ function normalizeOperations(value: unknown): DeviceGrantOperation[] {
 
 function isDeviceGrantOperation(value: unknown): value is DeviceGrantOperation {
   return value === 'read_file'
+    || value === 'resolve_common_directory'
     || value === 'write_file'
     || value === 'edit_file'
     || value === 'send_file'

--- a/src/catscompany/device-selection.ts
+++ b/src/catscompany/device-selection.ts
@@ -117,6 +117,7 @@ function normalizeOperations(value: unknown): DeviceGrantOperation[] | undefined
 
 function isDeviceGrantOperation(value: unknown): value is DeviceGrantOperation {
   return value === 'read_file'
+    || value === 'resolve_common_directory'
     || value === 'write_file'
     || value === 'edit_file'
     || value === 'send_file'

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -27,6 +27,7 @@ import { GrepTool } from '../tools/grep-tool';
 import { WriteTool } from '../tools/write-tool';
 import { EditTool } from '../tools/edit-tool';
 import { ShellTool } from '../tools/bash-tool';
+import { resolveCommonDirectoryToolArgs } from '../tools/common-directory-tool';
 import {
   isRemoteDeviceRpcTool,
   normalizeDeviceRpcToolResultForTransport,
@@ -77,6 +78,7 @@ const HIDDEN_CATS_TOOL_PROGRESS = new Set([
 const SUBAGENT_TERMINAL_EVENTS = new Set(['agent_completed', 'agent_failed', 'agent_stopped']);
 export const CATSCOMPANY_FULL_RUNTIME_DEVICE_CAPABILITIES: DeviceGrantOperation[] = [
   'read_file',
+  'resolve_common_directory',
   'glob',
   'grep',
   'write_file',
@@ -351,6 +353,8 @@ export class CatsCompanyBot {
     switch (operation) {
       case 'read_file':
         return new ReadTool().execute(args, context);
+      case 'resolve_common_directory':
+        return resolveCommonDirectoryToolArgs(args);
       case 'glob':
         return new GlobTool().execute(args, context);
       case 'grep':
@@ -451,7 +455,7 @@ export class CatsCompanyBot {
     const operation = this.normalizeDeviceRpcOperation(request.operation);
     const toolName = String(request.tool_name || operation || '').trim();
     if (!operation || !isRemoteDeviceRpcTool(toolName, operation)) {
-      return { code: 'unsupported_operation', message: 'Device RPC only allows read_file, glob, grep, write_file, edit_file, and execute_shell.' };
+      return { code: 'unsupported_operation', message: 'Device RPC only allows read_file, resolve_common_directory, glob, grep, write_file, edit_file, and execute_shell.' };
     }
 
     const requiredFields: Array<[keyof CatsDeviceRpcMessage, string]> = [
@@ -483,6 +487,7 @@ export class CatsCompanyBot {
     const operation = String(value || '').trim();
     if (
       operation === 'read_file'
+      || operation === 'resolve_common_directory'
       || operation === 'glob'
       || operation === 'grep'
       || operation === 'write_file'

--- a/src/core/device-grants.ts
+++ b/src/core/device-grants.ts
@@ -230,6 +230,7 @@ function normalizeOperations(operations: DeviceGrantOperation[]): DeviceGrantOpe
 
 function isDeviceGrantOperation(value: string): value is DeviceGrantOperation {
   return value === 'read_file'
+    || value === 'resolve_common_directory'
     || value === 'write_file'
     || value === 'edit_file'
     || value === 'send_file'

--- a/src/tools/common-directory-tool.ts
+++ b/src/tools/common-directory-tool.ts
@@ -3,6 +3,8 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
+import { executeRemoteDeviceRpcTool } from './device-rpc-tool';
+import { resolveToolGatewayAccess } from './tool-gateway';
 
 export type CommonDirectoryKind =
   | 'desktop'
@@ -14,7 +16,7 @@ export type CommonDirectoryKind =
   | 'home'
   | 'temp';
 
-interface DirectoryResolution {
+export interface DirectoryResolution {
   kind: CommonDirectoryKind;
   path: string;
   source: string;
@@ -161,28 +163,58 @@ export class CommonDirectoryTool implements Tool {
     const input = typeof args?.directory === 'string' ? args.directory : '';
     const kind = normalizeCommonDirectory(input);
     if (!kind) {
-      return {
-        ok: false,
-        errorCode: 'INVALID_TOOL_ARGUMENTS',
-        message: `Unknown common directory: ${input || '(empty)'}\nSupported: desktop, downloads, documents, pictures, videos, music, home, temp`,
-      };
+      return invalidCommonDirectoryResult(input);
     }
 
-    const result = resolveCommonDirectory(kind);
-    return {
-      ok: true,
-      content: [
-        'Resolved common directory:',
-        `kind: ${result.kind}`,
-        `path: ${result.path}`,
-        `source: ${result.source}`,
-        `exists: ${result.exists}`,
-        `platform: ${result.platform}`,
-        '',
-        'Use this exact path as the base directory for follow-up file operations.',
-      ].join('\n'),
-    };
+    const gateway = resolveToolGatewayAccess(_context, {
+      toolName: 'resolve_common_directory',
+      operation: 'resolve_common_directory',
+      targetLabel: kind,
+    });
+    if (!gateway.ok) return gateway;
+
+    const remote = await executeRemoteDeviceRpcTool(
+      _context,
+      gateway,
+      'resolve_common_directory',
+      'resolve_common_directory',
+      { directory: kind },
+    );
+    if (remote) return remote;
+
+    return resolveCommonDirectoryToolArgs({ directory: kind });
   }
+}
+
+export function resolveCommonDirectoryToolArgs(args: any): ToolExecutionResult {
+  const input = typeof args?.directory === 'string' ? args.directory : '';
+  const kind = normalizeCommonDirectory(input);
+  if (!kind) return invalidCommonDirectoryResult(input);
+  return {
+    ok: true,
+    content: formatCommonDirectoryResolution(resolveCommonDirectory(kind)),
+  };
+}
+
+export function formatCommonDirectoryResolution(result: DirectoryResolution): string {
+  return [
+    'Resolved common directory:',
+    `kind: ${result.kind}`,
+    `path: ${result.path}`,
+    `source: ${result.source}`,
+    `exists: ${result.exists}`,
+    `platform: ${result.platform}`,
+    '',
+    'Use this exact path as the base directory for follow-up file operations.',
+  ].join('\n');
+}
+
+function invalidCommonDirectoryResult(input: string): ToolExecutionResult {
+  return {
+    ok: false,
+    errorCode: 'INVALID_TOOL_ARGUMENTS',
+    message: `Unknown common directory: ${input || '(empty)'}\nSupported: desktop, downloads, documents, pictures, videos, music, home, temp`,
+  };
 }
 
 function buildResolution(kind: CommonDirectoryKind, directoryPath: string, source: string): DirectoryResolution {

--- a/src/tools/device-rpc-tool.ts
+++ b/src/tools/device-rpc-tool.ts
@@ -7,6 +7,7 @@ export const MAX_DEVICE_RPC_TOOL_CONTENT_CHARS = 48_000;
 
 export function isRemoteReadonlyTool(toolName: string, operation: DeviceGrantOperation): boolean {
   return (toolName === 'read_file' && operation === 'read_file')
+    || (toolName === 'resolve_common_directory' && operation === 'resolve_common_directory')
     || (toolName === 'glob' && operation === 'glob')
     || (toolName === 'grep' && operation === 'grep');
 }
@@ -21,7 +22,7 @@ export function isRemoteDeviceRpcTool(toolName: string, operation: DeviceGrantOp
 export async function executeRemoteDeviceRpcTool(
   context: ToolExecutionContext,
   gateway: ToolGatewayDecision,
-  toolName: 'read_file' | 'glob' | 'grep' | 'write_file' | 'edit_file' | 'execute_shell',
+  toolName: 'read_file' | 'resolve_common_directory' | 'glob' | 'grep' | 'write_file' | 'edit_file' | 'execute_shell',
   operation: DeviceGrantOperation,
   args: Record<string, unknown>,
 ): Promise<ToolExecutionResult | undefined> {
@@ -31,7 +32,7 @@ export async function executeRemoteDeviceRpcTool(
     return {
       ok: false,
       errorCode: 'PERMISSION_DENIED',
-      message: `远程设备 RPC 当前只允许 read_file / glob / grep / write_file / edit_file / execute_shell，已阻止 ${toolName}。`,
+      message: `远程设备 RPC 当前只允许 read_file / resolve_common_directory / glob / grep / write_file / edit_file / execute_shell，已阻止 ${toolName}。`,
     };
   }
 

--- a/src/tools/tool-gateway.ts
+++ b/src/tools/tool-gateway.ts
@@ -33,7 +33,7 @@ export interface CatsCoVisiblePathOptions {
   preserveRelative?: boolean;
 }
 
-const REMOTE_DEVICE_RPC_OPERATIONS = new Set<DeviceGrantOperation>(['read_file', 'glob', 'grep', 'write_file', 'edit_file', 'execute_shell']);
+const REMOTE_DEVICE_RPC_OPERATIONS = new Set<DeviceGrantOperation>(['read_file', 'resolve_common_directory', 'glob', 'grep', 'write_file', 'edit_file', 'execute_shell']);
 
 export function isCatsCoToolGatewayContext(context: ToolExecutionContext): boolean {
   return context.surface === 'catscompany' || context.executionScope?.source === 'catscompany';
@@ -152,7 +152,7 @@ export function resolveToolGatewayAccess(
     if (!REMOTE_DEVICE_RPC_OPERATIONS.has(options.operation)) {
       return denied([
         `后端选定的用户设备不是当前运行体，但 ${options.operation} 还没有开放远程执行。`,
-        '当前只开放 read_file / glob / grep / write_file / edit_file / execute_shell 远程工具。',
+        '当前只开放 read_file / resolve_common_directory / glob / grep / write_file / edit_file / execute_shell 远程工具。',
       ], options.targetLabel);
     }
     if (!context.deviceRpc) {

--- a/src/types/session-identity.ts
+++ b/src/types/session-identity.ts
@@ -83,6 +83,7 @@ export type DeviceGrantStatus = 'active' | 'revoked';
 export type DeviceSelectionStatus = 'selected' | 'needs_selection' | 'unavailable';
 export type DeviceGrantOperation =
   | 'read_file'
+  | 'resolve_common_directory'
   | 'write_file'
   | 'edit_file'
   | 'send_file'

--- a/tests/catscompany-device-rpc-tools.test.ts
+++ b/tests/catscompany-device-rpc-tools.test.ts
@@ -69,7 +69,7 @@ function serverGrant(overrides: Partial<ScopedDeviceGrant> = {}): ScopedDeviceGr
     actorUserId: 'usr7',
     agentId: 'usr43',
     agentBodyId: 'body-agent',
-    operations: ['read_file', 'glob', 'grep'],
+    operations: ['read_file', 'resolve_common_directory', 'glob', 'grep'],
     createdAt: Date.now(),
     expiresAt: Date.now() + 60_000,
     ...overrides,
@@ -77,7 +77,7 @@ function serverGrant(overrides: Partial<ScopedDeviceGrant> = {}): ScopedDeviceGr
 }
 
 describe('CatsCompany Device RPC file tools', () => {
-  test('maps CatsCo server grant fields into outbound readonly device_rpc requests', async () => {
+  test('maps CatsCo server grant fields into outbound device_rpc requests', async () => {
     const captured: Array<{ request: any; timeoutMs?: number }> = [];
     const bot = Object.create(CatsCompanyBot.prototype) as any;
     bot.bot = {
@@ -120,6 +120,12 @@ describe('CatsCompany Device RPC file tools', () => {
       args: { pattern: '**/*.xlsx', path: 'catsco_attachment:project' },
       grant,
     });
+    const resolveDir = await transport.executeTool({
+      toolName: 'resolve_common_directory',
+      operation: 'resolve_common_directory',
+      args: { directory: 'desktop' },
+      grant,
+    });
     const grep = await transport.executeTool({
       toolName: 'grep',
       operation: 'grep',
@@ -129,13 +135,16 @@ describe('CatsCompany Device RPC file tools', () => {
 
     assert.equal(read.ok, true);
     assert.equal(glob.ok, true);
+    assert.equal(resolveDir.ok, true);
     assert.equal(grep.ok, true);
     assert.equal(read.ok ? read.content : '', 'remote read_file');
     assert.equal(glob.ok ? glob.content : '', 'remote glob');
+    assert.equal(resolveDir.ok ? resolveDir.content : '', 'remote resolve_common_directory');
     assert.equal(grep.ok ? grep.content : '', 'remote grep');
     assert.deepEqual(captured.map(item => [item.request.tool_name, item.request.operation]), [
       ['read_file', 'read_file'],
       ['glob', 'glob'],
+      ['resolve_common_directory', 'resolve_common_directory'],
       ['grep', 'grep'],
     ]);
 
@@ -156,6 +165,25 @@ describe('CatsCompany Device RPC file tools', () => {
     assert.equal(first.expires_at, grant.expiresAt);
     assert.deepEqual(first.payload, { args: { file_path: 'catsco_attachment:quote.xlsx', limit: 20 } });
     assert.equal(captured[0].timeoutMs, 12_345);
+  });
+
+  test('executes resolve_common_directory on the target local device and returns a normalized result', async () => {
+    const captured: { result?: any } = {};
+    const bot = botWithDevice(captured);
+
+    await bot.handleDeviceRpcRequest(request({
+      request_id: 'rpc-resolve-directory-1',
+      operation: 'resolve_common_directory',
+      tool_name: 'resolve_common_directory',
+      payload: { args: { directory: 'home' } },
+    }));
+
+    assert.ok(captured.result);
+    assert.equal(captured.result.error, undefined);
+    assert.equal(captured.result.result.ok, true);
+    assert.match(String(captured.result.result.content), /Resolved common directory:/);
+    assert.match(String(captured.result.result.content), /kind: home/);
+    assert.equal(captured.result.device_id, 'install-device');
   });
 
   test('executes read_file on the target local device and returns a normalized result', async () => {

--- a/tests/catscompany-runtime-device-capabilities.test.ts
+++ b/tests/catscompany-runtime-device-capabilities.test.ts
@@ -6,6 +6,7 @@ describe('CatsCompany runtime device capabilities', () => {
   test('full runtime advertises local owner self capabilities', () => {
     assert.deepEqual(CATSCOMPANY_FULL_RUNTIME_DEVICE_CAPABILITIES, [
       'read_file',
+      'resolve_common_directory',
       'glob',
       'grep',
       'write_file',

--- a/tests/tool-gateway-catsco.test.ts
+++ b/tests/tool-gateway-catsco.test.ts
@@ -10,6 +10,7 @@ import { GlobTool } from '../src/tools/glob-tool';
 import { GrepTool } from '../src/tools/grep-tool';
 import { SendFileTool } from '../src/tools/send-file-tool';
 import { ShellTool } from '../src/tools/bash-tool';
+import { CommonDirectoryTool } from '../src/tools/common-directory-tool';
 import type {
   ExecutionScope,
   ScopedDeviceGrant,
@@ -41,7 +42,7 @@ function localDevice(overrides: Partial<ScopedLocalDeviceGrant> = {}): ScopedLoc
     bodyId: 'body-device',
     installationId: 'install-device',
     deviceId: 'install-device',
-    capabilities: ['read_file', 'glob', 'grep', 'write_file', 'edit_file', 'send_file'],
+    capabilities: ['read_file', 'resolve_common_directory', 'glob', 'grep', 'write_file', 'edit_file', 'send_file'],
     createdAt: Date.now(),
     ...overrides,
   };
@@ -248,6 +249,52 @@ describe('CatsCo ToolGateway', () => {
     assert.equal(rpcRequest.operation, 'read_file');
     assert.equal(rpcRequest.grant.deviceId, 'other-device');
     assert.deepEqual(rpcRequest.args, { file_path: requestedPath, limit: 20 });
+  });
+
+  test('routes resolve_common_directory to the backend-selected remote device before path guessing', async () => {
+    const root = makeWorkspace();
+    let rpcRequest: any;
+    const result = await new CommonDirectoryTool().execute({ directory: 'desktop' }, context(root, {
+      deviceGrants: [deviceGrant(['resolve_common_directory'], {
+        deviceId: 'speaker-device',
+        deviceDisplayName: 'Speaker Laptop',
+        deviceBodyId: 'speaker-body',
+        deviceInstallationId: 'speaker-install',
+      })],
+      deviceSelection: deviceSelection({
+        selectedDeviceId: 'speaker-device',
+        selectedDeviceDisplayName: 'Speaker Laptop',
+        selectedDeviceBodyId: 'speaker-body',
+        selectedDeviceInstallationId: 'speaker-install',
+        selectedDeviceOperations: ['resolve_common_directory'],
+      }),
+      deviceRpc: {
+        executeTool: async request => {
+          rpcRequest = request;
+          return {
+            ok: true,
+            content: [
+              'Resolved common directory:',
+              'kind: desktop',
+              'path: C:\\Users\\Speaker\\Desktop',
+              'source: windows_user_shell_folders',
+              'exists: true',
+              'platform: win32',
+              '',
+              'Use this exact path as the base directory for follow-up file operations.',
+            ].join('\n'),
+          };
+        },
+      },
+    }));
+
+    assert.equal(result.ok, true);
+    assert.match(String(result.content), /C:\\Users\\Speaker\\Desktop/);
+    assert.doesNotMatch(String(result.content), /Administrator/);
+    assert.equal(rpcRequest.toolName, 'resolve_common_directory');
+    assert.equal(rpcRequest.operation, 'resolve_common_directory');
+    assert.equal(rpcRequest.grant.deviceId, 'speaker-device');
+    assert.deepEqual(rpcRequest.args, { directory: 'desktop' });
   });
 
   test('routes glob and grep to the backend-selected remote device', async () => {


### PR DESCRIPTION
## 背景

云端虚拟员工被多个用户添加为 AI 助手后，用户在网页端、微信或飞书里说“我的桌面”“我的电脑上的文件”时，系统必须操作当前说话人的设备，而不是云电脑运行体，也不能误操作其他用户设备。

之前 write_file / edit_file / execute_shell 已经可以走 Device RPC，但 resolve_common_directory 仍可能在云端运行体本地解析，导致后续操作拿到 C:\Users\Administrator\Desktop 这类云电脑路径。

## 本次改动

- 新增 `resolve_common_directory` 作为 Device RPC operation
- XiaoBa-CLI 侧将公共目录解析纳入 ToolGateway 和 Device RPC 路由
- cats-company 侧补充后端 grant / RPC allowlist / connector 默认能力 / TS SDK 类型
- 公共目录解析会先路由到后端选中的说话人设备，再返回真实桌面、下载、文档等目录
- 如果没有可信的说话人设备选择，不再静默 fallback 到云电脑本机路径

## 产品效果

用户添加共享虚拟员工后，可以像使用自己的助手一样说：

- “在我的桌面创建一个文件夹”
- “读取我电脑某个目录下的文件”
- “把结果写回我的电脑桌面”

系统会把“我的桌面”解析到当前说话人的设备，而不是虚拟员工所在云电脑。

## 验证

- XiaoBa-CLI 定向测试通过：42 passed
- XiaoBa-CLI `tsc --noEmit` 通过
- cats-company Go 定向测试通过
- cats-company TypeScript SDK device-rpc 测试通过
- cats-company TypeScript SDK `tsc --noEmit` 通过