### PR TITLE
[codex] add prompt-first short visible reply guidance

### DIFF
--- a/docs/short-visible-reply-implementation.md
+++ b/docs/short-visible-reply-implementation.md
@@ -1,0 +1,258 @@
+# Short Visible Reply Implementation
+
+本文只记录“短可见回复 / 长内容产物化”的当前实现方向。
+
+## 目标
+
+目标不是在模型输出后用硬规则截断或强行改写，而是让 agent 在生成前形成产品习惯：
+
+- 聊天可见回复默认短。
+- 长内容优先做成文件、artifact、网页详情或当前通道支持的交付物。
+- 聊天里只给结论、摘要、位置和下一步。
+- 用户明确要求“直接贴全文 / 不要文件”时尊重用户。
+
+## 当前方案：Prompt-First
+
+这版不再把“最终回复出口硬拦截”作为主方案。
+
+当前实现是：
+
+```text
+按场景注入可见输出偏好 -> 模型在生成前决定短答还是产物化 -> 原有工具链负责写文件/发文件
+```
+
+也就是说，主要依赖：
+
+- 稳定 system prompt 的输出原则。
+- 每轮 transient 软提示。
+- 少量 in-context examples。
+- 现有 `write_file` / `send_file` 等工具能力。
+
+运行时不再默认做：
+
+- 按字符数/行数硬拦截最终回复。
+- 自动把最终长文本保存成文件。
+- 自动替换模型原始回复。
+- 为了判断长短而缓冲所有流式输出。
+
+## 涉及文件
+
+核心实现：
+
+- `prompts/system-prompt.md`
+- `prompts/transient/visible-output-guidance.md`
+- `src/core/visible-output-guidance.ts`
+- `src/core/transient-injection-policy.ts`
+- `src/core/conversation-runner.ts`
+- `src/core/turn-context-builder.ts`
+
+测试：
+
+- `tests/visible-output-guidance.test.ts`
+
+## 稳定 System Prompt
+
+`prompts/system-prompt.md` 中已经包含长期输出原则：
+
+- 聊天可见回复默认简短。
+- 需要长篇内容、完整材料、报告、讲义、表格、详细过程或其他交付物时，优先写入文件、artifact、网页详情或当前通道支持的交付形式。
+- 聊天中只说明交付物位置、内容摘要和验证结果。
+- 除非用户明确要求直接在聊天里展开全文，否则不要把长内容完整贴进对话气泡。
+
+这部分是长期产品行为，不依赖具体 surface。
+
+## Transient 软提示
+
+新增 transient 模板：
+
+```text
+prompts/transient/visible-output-guidance.md
+```
+
+它通过 `buildVisibleOutputGuidance()` 构造成一条临时注入消息：
+
+```ts
+{
+  role: 'user',
+  content: '[transient_visible_output_guidance]\n...',
+  __injected: true
+}
+```
+
+为什么用 `role: "user"`：
+
+- 这类提示更接近“本轮运行时上下文/产品偏好”，不是永久系统规则。
+- 它插在当前真实用户消息附近，让模型生成当前回复前看到。
+- `__injected: true` 标记保证它不会被当成真实用户消息长期保存。
+
+模板内容包括：
+
+- 当前 surface。
+- 当前可用交付路径。
+- 短可见回复偏好。
+- “长内容产物化”的行为说明。
+- 少量 examples。
+
+示例片段：
+
+```text
+User asks for a complete plan/report/material -> create a Markdown/document file, then reply:
+"已整理到 <file>。核心结论是 ...，我还验证了/待确认 ..."
+
+User asks a quick question -> answer directly in a few sentences, no file.
+
+User says "直接贴全文" or "不要文件" -> provide the requested inline content.
+```
+
+## 注入策略
+
+注入策略在：
+
+```ts
+src/core/transient-injection-policy.ts
+```
+
+字段：
+
+```ts
+injectVisibleOutputGuidance: boolean
+```
+
+判断函数：
+
+```ts
+shouldInjectVisibleOutputGuidance(...)
+```
+
+当前触发原则：
+
+- 普通闲聊不注入。
+- 微信、飞书、CatsCo 等消息端的非闲聊任务注入。
+- 复杂任务注入。
+- `office` / `classroom` / `team-assistant` 这类容易产生交付物的任务注入。
+
+这不是业务硬规则，只是决定“这一轮是否需要提醒模型注意可见输出形态”。
+
+## 注入位置
+
+`ConversationRunner.run()` 中计算 provider transient policy：
+
+```ts
+const transientPolicy = resolveProviderTransientPolicy(...)
+```
+
+如果 `injectVisibleOutputGuidance` 为 true，则构建：
+
+```ts
+const visibleOutputGuidance = buildVisibleOutputGuidance({
+  surface,
+  tools: requestTools,
+  intent: transientPolicy.intent,
+});
+```
+
+然后加入 `buildProviderInputMessages()` 的 transient hints：
+
+```ts
+[
+  perTurnRunnerHint,
+  toolGuidance,
+  visibleOutputGuidance,
+  ...
+]
+```
+
+最终它只进入本次 provider 请求的 `messages`，不会写入 durable session。
+
+## 清理策略
+
+`ConversationRunner.buildProviderInputMessages()` 会移除上一轮残留的：
+
+```text
+[transient_visible_output_guidance]
+```
+
+`TurnContextBuilder.removeTransientMessages()` 也会移除同类消息。
+
+这保证 visible output guidance 是 turn-scoped/provider-scoped，不污染长期历史。
+
+## 和工具的关系
+
+真正的文件能力仍然来自工具 schema：
+
+- `write_file`
+- `edit_file`
+- `send_file`
+
+`visible-output-guidance` 不替代工具 schema，也不复制完整工具参数。
+
+它只告诉模型当前可用交付路径，例如：
+
+```text
+write_file for local Markdown/text artifacts;
+send_file for chat file delivery after a file exists
+```
+
+模型仍需要自己决定：
+
+- 是否需要创建文件。
+- 用哪个工具创建文件。
+- 是否需要发送文件。
+- 聊天里给什么短说明。
+
+## 和硬规则方案的区别
+
+当前方案不是：
+
+```text
+模型已经输出长文 -> runner 用字符数判断 -> 强制写文件 -> 替换回复
+```
+
+当前方案是：
+
+```text
+模型生成前看到产品偏好和示例 -> 主动短答或主动产物化
+```
+
+因此它更符合产品预期：
+
+- 让 agent 看起来“会工作”，不是“被拦截”。
+- 不在运行时强行改变模型最终回答。
+- 保留用户明确要求 inline 的自由。
+- 后续可以通过 prompt、ICL、eval 持续优化。
+
+## 当前边界
+
+已经完成：
+
+- 稳定 system prompt 中有短回复/产物化原则。
+- 新增 visible output transient 模板。
+- 新增 provider-scoped 注入策略。
+- 根据 surface、任务复杂度和 intent 选择性注入。
+- 注入消息不进入长期历史。
+- 单测覆盖注入和清理行为。
+
+尚未完成：
+
+- 真实模型效果验证。
+- 更丰富的 in-context examples。
+- surface 级别的输出偏好配置。
+- 网页端 artifact/card 展示策略。
+- 微信/飞书真实文件发送体验验证。
+- shadow 日志和 eval，用真实数据判断提示是否有效。
+
+## 测试
+
+运行：
+
+```bash
+npx tsx --test tests/visible-output-guidance.test.ts
+```
+
+测试覆盖：
+
+- 非闲聊/交付物场景会注入 visible output guidance。
+- 普通闲聊不会注入。
+- guidance 是 `role: "user"` 且 `__injected: true`。
+- provider input 中可见，durable messages 中不可见。
+- cleanup 能移除意外残留的 guidance。

--- a/prompts/transient/visible-output-guidance.md
+++ b/prompts/transient/visible-output-guidance.md
@@ -1,0 +1,34 @@
+Runtime output preference only. Not a user request. Do not answer this message directly.
+
+Current surface: {{surface}}
+Available delivery path: {{deliveryPath}}
+
+Visible reply preference:
+- Keep the chat-visible reply short and useful: conclusion, current status, and next step.
+- If the user asks for a complete document, long report, detailed material, full table, lesson handout, implementation notes, or other long deliverable, create or update a file/artifact when an appropriate tool is available, then reply with a short summary and location.
+- Do not paste a long deliverable into the chat unless the user explicitly asks for inline/full text.
+- If no file/artifact delivery path is available, keep the answer concise and ask before expanding into a long inline response.
+
+Behavior examples:
+
+Example 1: long work product
+User: "帮我整理一份完整的项目复盘报告。"
+Assistant action: create or update a Markdown/document file with the full report.
+Visible reply: "已整理到 <file>。核心结论是：...；还需要确认的是：..."
+Do not paste the full report into chat.
+
+Example 2: classroom/material deliverable
+User: "给老师准备一份课堂讲义和练习题。"
+Assistant action: create a file/artifact containing the full handout and exercises.
+Visible reply: "讲义和练习题已放到 <file>。包含：...；可直接检查/发送。"
+Do not paste all handout content into chat.
+
+Example 3: normal short answer
+User: "这个概念是什么意思？"
+Assistant action: no file unless the user asks for a complete handout or document.
+Visible reply: answer directly in a few concise sentences.
+
+Example 4: explicit inline request
+User: "不要文件，直接贴全文。"
+Assistant action: provide the requested inline content.
+Visible reply: include the full content because the user explicitly asked for it.

--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -31,6 +31,10 @@ import {
   buildTransientToolGuidance,
 } from './transient-tool-guidance';
 import {
+  TRANSIENT_VISIBLE_OUTPUT_GUIDANCE_PREFIX,
+  buildVisibleOutputGuidance,
+} from './visible-output-guidance';
+import {
   TRANSIENT_CURRENT_DIRECTORY_PREFIX,
   buildTransientEnvironmentHint,
 } from './transient-environment';
@@ -319,9 +323,17 @@ export class ConversationRunner {
       const toolGuidance = transientPolicy.injectToolGuidance
         ? buildTransientToolGuidance(requestTools)
         : null;
+      const visibleOutputGuidance = transientPolicy.injectVisibleOutputGuidance
+        ? buildVisibleOutputGuidance({
+          surface: this.toolExecutionContext?.surface,
+          tools: requestTools,
+          intent: transientPolicy.intent,
+        })
+        : null;
       const requestMessages = this.buildProviderInputMessages(messages, [
         ...(perTurnRunnerHint ? [perTurnRunnerHint] : []),
         ...(toolGuidance ? [toolGuidance] : []),
+        ...(visibleOutputGuidance ? [visibleOutputGuidance] : []),
         ...nextTurnTransientHints,
         ...orchestrationHints,
       ], {
@@ -841,6 +853,9 @@ export class ConversationRunner {
       if (message.__injected && message.content.startsWith(TRANSIENT_TOOL_GUIDANCE_PREFIX)) {
         return false;
       }
+      if (message.__injected && message.content.startsWith(TRANSIENT_VISIBLE_OUTPUT_GUIDANCE_PREFIX)) {
+        return false;
+      }
       if (message.role !== 'system') {
         return true;
       }
@@ -1151,7 +1166,6 @@ export class ConversationRunner {
       if (this.stream) {
         const streamCallbacks: StreamCallbacks = {
           onText: (text) => callbacks?.onText?.(text),
-          onRetry: (attempt, maxRetries) => callbacks?.onRetry?.(attempt, maxRetries),
         };
         return await this.aiService.chatStream(messages, activeTools, streamCallbacks, requestOptions);
       }
@@ -1171,6 +1185,7 @@ export class ConversationRunner {
       if (this.stream) {
         const streamCallbacks: StreamCallbacks = {
           onText: (text) => callbacks?.onText?.(text),
+          onRetry: (attempt, maxRetries) => callbacks?.onRetry?.(attempt, maxRetries),
         };
         return await this.aiService.chatStream(messages, activeTools, streamCallbacks, requestOptions);
       }

--- a/src/core/transient-environment.ts
+++ b/src/core/transient-environment.ts
@@ -57,7 +57,8 @@ export function buildTransientEnvironmentHint(
 export function resolveShellName(env: NodeJS.ProcessEnv = process.env): string {
   const raw = env.SHELL || env.ComSpec || env.COMSPEC || env.PSModulePath && 'powershell' || '';
   if (!raw) return 'unknown';
-  return path.basename(raw).replace(/\.(exe|cmd|bat)$/i, '') || raw;
+  const basename = path.posix.basename(raw.replace(/\\/g, '/'));
+  return basename.replace(/\.(exe|cmd|bat)$/i, '') || raw;
 }
 
 export function resolveGitRepositoryInfo(currentDirectory: string): GitRepositoryInfo | null {

--- a/src/core/transient-injection-policy.ts
+++ b/src/core/transient-injection-policy.ts
@@ -5,6 +5,7 @@ import {
   detectPromptMode,
   normalizePromptModeId,
 } from '../runtime/prompt-modes';
+import { shouldInjectVisibleOutputGuidance } from './visible-output-guidance';
 
 export type TransientIntentKind =
   | 'coding'
@@ -40,6 +41,7 @@ export interface ProviderTransientPolicy {
   injectEnvironment: boolean;
   injectToolGuidance: boolean;
   injectRunnerHint: boolean;
+  injectVisibleOutputGuidance: boolean;
   reasons: string[];
 }
 
@@ -167,11 +169,20 @@ export function resolveProviderTransientPolicy(
   );
   if (injectRunnerHint) reasons.push('complex-work-orchestration');
 
+  const injectVisibleOutputGuidance = shouldInjectVisibleOutputGuidance({
+    surface: options.surface,
+    intent,
+    turn: options.turn,
+    executedToolCalls: options.executedToolCalls,
+  });
+  if (injectVisibleOutputGuidance) reasons.push('visible-output-preference');
+
   return {
     intent,
     injectEnvironment,
     injectToolGuidance,
     injectRunnerHint,
+    injectVisibleOutputGuidance,
     reasons,
   };
 }

--- a/src/core/turn-context-builder.ts
+++ b/src/core/turn-context-builder.ts
@@ -27,6 +27,7 @@ import {
   buildTransientModeHintFromMessages,
 } from '../runtime/prompt-modes';
 import { TRANSIENT_TOOL_GUIDANCE_PREFIX } from './transient-tool-guidance';
+import { TRANSIENT_VISIBLE_OUTPUT_GUIDANCE_PREFIX } from './visible-output-guidance';
 import { resolveTurnContextTransientPolicy } from './transient-injection-policy';
 
 const TRANSIENT_PLAN_STATUS_PREFIX = '[transient_plan_status]';
@@ -98,6 +99,11 @@ export class TurnContextBuilder {
         msg.__injected
         && typeof msg.content === 'string'
         && msg.content.startsWith(TRANSIENT_TOOL_GUIDANCE_PREFIX)
+      ) return false;
+      if (
+        msg.__injected
+        && typeof msg.content === 'string'
+        && msg.content.startsWith(TRANSIENT_VISIBLE_OUTPUT_GUIDANCE_PREFIX)
       ) return false;
       if (msg.role !== 'system' || typeof msg.content !== 'string') return true;
       if (msg.content.startsWith(TRANSIENT_SUBAGENT_STATUS_PREFIX)) return false;

--- a/src/core/visible-output-guidance.ts
+++ b/src/core/visible-output-guidance.ts
@@ -1,0 +1,79 @@
+import type { Message } from '../types';
+import type { ToolDefinition, ToolSurface } from '../types/tool';
+import { renderRequiredDefaultPromptFile } from '../utils/prompt-template';
+import type { TransientTurnIntent } from './transient-injection-policy';
+
+export const TRANSIENT_VISIBLE_OUTPUT_GUIDANCE_PREFIX = '[transient_visible_output_guidance]';
+
+export interface BuildVisibleOutputGuidanceOptions {
+  surface?: ToolSurface;
+  tools: ToolDefinition[];
+  intent: TransientTurnIntent;
+}
+
+const MESSAGE_SURFACES = new Set<ToolSurface>(['weixin', 'feishu', 'catscompany']);
+
+export function buildVisibleOutputGuidance(
+  options: BuildVisibleOutputGuidanceOptions,
+): Message | null {
+  const deliveryPath = describeDeliveryPath(options.tools);
+  const content = renderRequiredDefaultPromptFile('transient/visible-output-guidance.md', {
+    surface: describeSurface(options.surface),
+    deliveryPath,
+  });
+
+  return {
+    role: 'user',
+    content: `${TRANSIENT_VISIBLE_OUTPUT_GUIDANCE_PREFIX}\n${content}`,
+    __injected: true,
+  };
+}
+
+export function shouldInjectVisibleOutputGuidance(params: {
+  surface?: ToolSurface;
+  intent: TransientTurnIntent;
+  turn: number;
+  executedToolCalls: number;
+}): boolean {
+  if (params.intent.plainChat) return false;
+  if (MESSAGE_SURFACES.has(params.surface || 'unknown')) return true;
+  if (params.intent.complexWork) return true;
+  if (params.intent.kind === 'office' || params.intent.kind === 'classroom' || params.intent.kind === 'team') return true;
+  return false;
+}
+
+function describeDeliveryPath(tools: ToolDefinition[]): string {
+  const names = new Set(tools.map(tool => tool.name));
+  const paths: string[] = [];
+  if (names.has('write_file')) {
+    paths.push('write_file for local Markdown/text artifacts');
+  }
+  if (names.has('send_file')) {
+    paths.push('send_file for chat file delivery after a file exists');
+  }
+  if (names.has('edit_file')) {
+    paths.push('edit_file for existing files');
+  }
+  return paths.length > 0
+    ? paths.join('; ')
+    : 'no file/artifact tool is currently enabled';
+}
+
+function describeSurface(surface?: ToolSurface): string {
+  switch (surface) {
+    case 'weixin':
+      return 'weixin chat, where visible replies should be especially compact';
+    case 'feishu':
+      return 'feishu chat, where concise replies plus files are preferred for long deliverables';
+    case 'catscompany':
+      return 'CatsCo web/chat surface, where concise visible replies and artifact links/cards are preferred';
+    case 'cli':
+      return 'CLI, where concise terminal output is still preferred for long deliverables';
+    case 'agent':
+      return 'agent-to-agent context';
+    case 'research':
+      return 'research context';
+    default:
+      return 'unknown/default chat surface';
+  }
+}

--- a/tests/visible-output-guidance.test.ts
+++ b/tests/visible-output-guidance.test.ts
@@ -1,0 +1,131 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  TRANSIENT_VISIBLE_OUTPUT_GUIDANCE_PREFIX,
+  buildVisibleOutputGuidance,
+} from '../src/core/visible-output-guidance';
+import {
+  resolveProviderTransientPolicy,
+} from '../src/core/transient-injection-policy';
+import { ConversationRunner } from '../src/core/conversation-runner';
+import { TurnContextBuilder } from '../src/core/turn-context-builder';
+import type { Message } from '../src/types';
+import type { ToolDefinition, ToolExecutor } from '../src/types/tool';
+
+function tool(name: string): ToolDefinition {
+  return {
+    name,
+    description: `${name} description`,
+    parameters: {
+      type: 'object',
+      properties: {},
+    },
+  };
+}
+
+const artifactTools = [
+  tool('write_file'),
+  tool('send_file'),
+  tool('read_file'),
+];
+
+test('visible output guidance describes product preference without hard output enforcement', () => {
+  const messages: Message[] = [
+    { role: 'user', content: '帮我整理一份完整报告' },
+  ];
+  const policy = resolveProviderTransientPolicy({
+    messages,
+    tools: artifactTools,
+    turn: 1,
+    executedToolCalls: 0,
+    surface: 'feishu',
+  });
+
+  assert.equal(policy.injectVisibleOutputGuidance, true);
+  assert.ok(policy.reasons.includes('visible-output-preference'));
+
+  const guidance = buildVisibleOutputGuidance({
+    surface: 'feishu',
+    tools: artifactTools,
+    intent: policy.intent,
+  });
+
+  assert.ok(guidance);
+  assert.equal(guidance.role, 'user');
+  assert.equal(guidance.__injected, true);
+  assert.equal(typeof guidance.content, 'string');
+  assert.equal(guidance.content.startsWith(TRANSIENT_VISIBLE_OUTPUT_GUIDANCE_PREFIX), true);
+  assert.match(guidance.content, /Keep the chat-visible reply short/);
+  assert.match(guidance.content, /write_file/);
+  assert.match(guidance.content, /send_file/);
+  assert.match(guidance.content, /Example 1: long work product/);
+  assert.match(guidance.content, /Assistant action: create or update a Markdown\/document file/);
+  assert.match(guidance.content, /Example 2: classroom\/material deliverable/);
+  assert.match(guidance.content, /Example 4: explicit inline request/);
+  assert.doesNotMatch(guidance.content, /字符数超过|非空行数超过|threshold/i);
+});
+
+test('plain chat does not inject visible output guidance', () => {
+  const policy = resolveProviderTransientPolicy({
+    messages: [{ role: 'user', content: '早，今天状态怎么样？' }],
+    tools: artifactTools,
+    turn: 1,
+    executedToolCalls: 0,
+    surface: 'weixin',
+  });
+
+  assert.equal(policy.intent.plainChat, true);
+  assert.equal(policy.injectVisibleOutputGuidance, false);
+});
+
+test('conversation runner injects visible output guidance only into provider input', async () => {
+  const executor: ToolExecutor = {
+    getToolDefinitions: () => artifactTools,
+    executeTool: async () => ({ content: 'unused', role: 'tool', name: 'unused', tool_call_id: 'unused' }),
+  };
+  let capturedMessages: Message[] = [];
+  const aiService = {
+    async chat(messages: Message[]) {
+      capturedMessages = messages;
+      return { content: '我先给你短版结论。' };
+    },
+  };
+  const runner = new ConversationRunner(aiService as any, executor, {
+    stream: false,
+    enableCompression: false,
+    toolExecutionContext: {
+      surface: 'feishu',
+      workingDirectory: 'C:\\work\\project',
+    },
+  });
+
+  const result = await runner.run([{ role: 'user', content: '帮我整理一份完整报告' }]);
+
+  const guidance = capturedMessages.find(message =>
+    typeof message.content === 'string'
+    && message.content.startsWith(TRANSIENT_VISIBLE_OUTPUT_GUIDANCE_PREFIX)
+  );
+  assert.ok(guidance);
+  assert.equal(guidance.role, 'user');
+  assert.equal(guidance.__injected, true);
+  assert.equal(result.response, '我先给你短版结论。');
+  assert.equal(result.messages.some(message =>
+    typeof message.content === 'string'
+    && message.content.startsWith(TRANSIENT_VISIBLE_OUTPUT_GUIDANCE_PREFIX)
+  ), false);
+});
+
+test('turn context cleanup removes visible output guidance if it appears in durable messages', () => {
+  const builder = new TurnContextBuilder();
+  const durable = builder.removeTransientMessages([
+    { role: 'system', content: 'base' },
+    {
+      role: 'user',
+      content: `${TRANSIENT_VISIBLE_OUTPUT_GUIDANCE_PREFIX}\nRuntime output preference only.`,
+      __injected: true,
+    },
+    { role: 'user', content: 'real question' },
+  ]);
+
+  assert.deepEqual(durable.map(message => message.content), ['base', 'real question']);
+});


### PR DESCRIPTION
## Summary

This is a prompt-first implementation for short visible replies and long-deliverable productization.

Changes:
- Adds transient visible-output guidance with lightweight ICL examples.
- Injects the guidance only for non-chatty message surfaces, complex tasks, and office/classroom/team deliverable-style work.
- Keeps the guidance provider-scoped/transient so it does not persist in durable conversation history.
- Documents the current prompt-first approach and explicitly avoids final-output hard interception.

## Merge guidance

Do not merge yet. This PR is for review and later evaluation only. We should validate real model behavior before deciding whether to merge or adjust the prompt.

## Stack

Base: `codex/prompt-stack-transient-guidance` / PR #138.

## Validation

- `npx tsx --test tests/visible-output-guidance.test.ts tests/transient-injection-policy.test.ts tests/transient-tool-guidance.test.ts`
- `npx tsx --test tests/conversation-runner-transcript-normalization.test.ts`
- `npm run build`
- `git diff --check`