### PR TITLE
fix: route remote device file tasks away from shell

### DIFF
--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -26,7 +26,6 @@ import { GlobTool } from '../tools/glob-tool';
 import { GrepTool } from '../tools/grep-tool';
 import { WriteTool } from '../tools/write-tool';
 import { EditTool } from '../tools/edit-tool';
-import { ShellTool } from '../tools/bash-tool';
 import {
   isRemoteDeviceRpcTool,
   normalizeDeviceRpcToolResultForTransport,
@@ -359,8 +358,6 @@ export class CatsCompanyBot {
         return new WriteTool().execute(args, context);
       case 'edit_file':
         return new EditTool().execute(args, context);
-      case 'execute_shell':
-        return new ShellTool().execute(args, context);
       default:
         return {
           ok: false,
@@ -451,7 +448,7 @@ export class CatsCompanyBot {
     const operation = this.normalizeDeviceRpcOperation(request.operation);
     const toolName = String(request.tool_name || operation || '').trim();
     if (!operation || !isRemoteDeviceRpcTool(toolName, operation)) {
-      return { code: 'unsupported_operation', message: 'Device RPC only allows read_file, glob, grep, write_file, edit_file, and execute_shell.' };
+      return { code: 'unsupported_operation', message: 'Device RPC only allows read_file, glob, grep, write_file, and edit_file.' };
     }
 
     const requiredFields: Array<[keyof CatsDeviceRpcMessage, string]> = [
@@ -487,7 +484,6 @@ export class CatsCompanyBot {
       || operation === 'grep'
       || operation === 'write_file'
       || operation === 'edit_file'
-      || operation === 'execute_shell'
     ) {
       return operation;
     }

--- a/src/tools/bash-tool.ts
+++ b/src/tools/bash-tool.ts
@@ -34,6 +34,7 @@ export class ShellTool implements Tool {
       '执行一条非交互式系统命令。',
       '命令从当前目录启动；每次调用都是新的 shell 进程，只有最终当前目录会保留到后续工具调用。',
       '环境变量、alias、函数和已激活虚拟环境不会自动跨调用保留；需要时在同一条 command 中显式设置。',
+      '在 CatsCo/远程用户设备场景中，不要用它做普通文件查看或创建；查看文件列表用 glob，创建/覆盖文本文件用 write_file，编辑文件用 edit_file。',
     ].join('\n'),
     parameters: {
       type: 'object',

--- a/src/tools/common-directory-tool.ts
+++ b/src/tools/common-directory-tool.ts
@@ -143,6 +143,7 @@ export class CommonDirectoryTool implements Tool {
     description: [
       '把常见用户目录名称解析为当前系统上的真实本地路径。',
       '当用户说“桌面”“下载”“文档”等自然语言目录时先用它解析，不要手猜 C:\\Users\\...\\Desktop、~/Desktop 等路径。',
+      '解析后如果要查看目录文件，请用 glob；如果要创建文件，请用 write_file。不要为了普通文件操作改用 execute_shell。',
       '只解析标准 OS 用户目录；不搜索项目目录、应用目录、浏览器下载子目录或语义目录。',
     ].join('\n'),
     parameters: {
@@ -180,6 +181,9 @@ export class CommonDirectoryTool implements Tool {
         `platform: ${result.platform}`,
         '',
         'Use this exact path as the base directory for follow-up file operations.',
+        'To list files here, call glob with this path and an appropriate pattern such as "*".',
+        'To create or overwrite a text file here, call write_file with a file_path under this path.',
+        'Do not use execute_shell for routine file listing or file creation.',
       ].join('\n'),
     };
   }

--- a/src/tools/device-rpc-tool.ts
+++ b/src/tools/device-rpc-tool.ts
@@ -14,8 +14,7 @@ export function isRemoteReadonlyTool(toolName: string, operation: DeviceGrantOpe
 export function isRemoteDeviceRpcTool(toolName: string, operation: DeviceGrantOperation): boolean {
   return isRemoteReadonlyTool(toolName, operation)
     || (toolName === 'write_file' && operation === 'write_file')
-    || (toolName === 'edit_file' && operation === 'edit_file')
-    || (toolName === 'execute_shell' && operation === 'execute_shell');
+    || (toolName === 'edit_file' && operation === 'edit_file');
 }
 
 export async function executeRemoteDeviceRpcTool(
@@ -31,7 +30,7 @@ export async function executeRemoteDeviceRpcTool(
     return {
       ok: false,
       errorCode: 'PERMISSION_DENIED',
-      message: `远程设备 RPC 当前只允许 read_file / glob / grep / write_file / edit_file / execute_shell，已阻止 ${toolName}。`,
+      message: `远程设备 RPC 当前只允许 read_file / glob / grep / write_file / edit_file，已阻止 ${toolName}。请用 glob 查看文件列表，用 write_file 创建或覆盖文本文件。`,
     };
   }
 

--- a/src/tools/glob-tool.ts
+++ b/src/tools/glob-tool.ts
@@ -22,6 +22,7 @@ export class GlobTool implements Tool {
     description: [
       '按 glob 模式查找文件路径，返回匹配文件列表并按修改时间倒序排列。',
       '适合先定位候选文件；要搜索文件内容请使用 grep。',
+      '当用户问“桌面/下载/文档里有哪些文件”时，先用 resolve_common_directory 解析目录，再用本工具列出文件；不要用 execute_shell 跑 dir/ls。',
     ].join('\n'),
     parameters: {
       type: 'object',
@@ -32,7 +33,7 @@ export class GlobTool implements Tool {
         },
         path: {
           type: 'string',
-          description: '搜索起始目录。可选，默认当前目录。'
+          description: '搜索起始目录。可选，默认当前目录。可以使用 resolve_common_directory 返回的绝对路径。'
         },
         limit: {
           type: 'number',

--- a/src/tools/local-tool-risk.ts
+++ b/src/tools/local-tool-risk.ts
@@ -1,5 +1,6 @@
+import type { DeviceGrantOperation } from '../types/session-identity';
 import type { ToolExecutionContext, ToolExecutionResult, ToolRiskLevel } from '../types/tool';
-import { isCatsCoLocalOwnerSelfContext } from './tool-gateway';
+import { isCatsCoLocalOwnerSelfContext, resolveToolGatewayAccess } from './tool-gateway';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -31,6 +32,14 @@ const CONFIRM_TOOLS = new Set([
   'spawn_subagent',
   'share_skillhub_skill',
 ]);
+
+const REMOTE_DEVICE_FILE_TOOL_OPERATIONS: Record<string, DeviceGrantOperation> = {
+  read_file: 'read_file',
+  glob: 'glob',
+  grep: 'grep',
+  write_file: 'write_file',
+  edit_file: 'edit_file',
+};
 
 export async function confirmLocalToolExecution(
   toolName: string,
@@ -90,6 +99,15 @@ export function classifyLocalToolRisk(
     return { requiresConfirmation: false, risk: 'low', reason: 'CatsCo 本地 owner 自用场景允许直接执行本机工具。' };
   }
 
+  const remoteFileOperation = REMOTE_DEVICE_FILE_TOOL_OPERATIONS[toolName];
+  if (remoteFileOperation && isServerAuthorizedRemoteDeviceFileOperation(toolName, remoteFileOperation, context)) {
+    return {
+      requiresConfirmation: false,
+      risk: 'low',
+      reason: '服务端已选定远程设备并下发短期 device grant，普通文件工具不需要本机二次确认。',
+    };
+  }
+
   if (toolName === 'read_file' || toolName === 'glob' || toolName === 'grep') {
     const pathRisk = classifyReadTargetsRisk(readonlyToolTargets(toolName, args), context);
     if (pathRisk === 'low') {
@@ -130,6 +148,19 @@ export function classifyLocalToolRisk(
   }
 
   return { requiresConfirmation: true, risk: 'medium', reason: '未知工具未声明风险等级，需要用户确认。' };
+}
+
+function isServerAuthorizedRemoteDeviceFileOperation(
+  toolName: string,
+  operation: DeviceGrantOperation,
+  context: ToolExecutionContext,
+): boolean {
+  if (!context.deviceRpc) return false;
+  const decision = resolveToolGatewayAccess(context, {
+    toolName,
+    operation,
+  });
+  return decision.ok && decision.mode === 'remote';
 }
 
 function stringField(value: unknown, key: string): string {

--- a/src/tools/tool-gateway.ts
+++ b/src/tools/tool-gateway.ts
@@ -33,7 +33,7 @@ export interface CatsCoVisiblePathOptions {
   preserveRelative?: boolean;
 }
 
-const REMOTE_DEVICE_RPC_OPERATIONS = new Set<DeviceGrantOperation>(['read_file', 'glob', 'grep', 'write_file', 'edit_file', 'execute_shell']);
+const REMOTE_DEVICE_RPC_OPERATIONS = new Set<DeviceGrantOperation>(['read_file', 'glob', 'grep', 'write_file', 'edit_file']);
 
 export function isCatsCoToolGatewayContext(context: ToolExecutionContext): boolean {
   return context.surface === 'catscompany' || context.executionScope?.source === 'catscompany';
@@ -152,7 +152,8 @@ export function resolveToolGatewayAccess(
     if (!REMOTE_DEVICE_RPC_OPERATIONS.has(options.operation)) {
       return denied([
         `后端选定的用户设备不是当前运行体，但 ${options.operation} 还没有开放远程执行。`,
-        '当前只开放 read_file / glob / grep / write_file / edit_file / execute_shell 远程工具。',
+        '当前只开放 read_file / glob / grep / write_file / edit_file 远程工具。',
+        '如需查看目录文件请使用 glob；如需创建或覆盖文本文件请使用 write_file。',
       ], options.targetLabel);
     }
     if (!context.deviceRpc) {

--- a/src/tools/write-tool.ts
+++ b/src/tools/write-tool.ts
@@ -15,13 +15,14 @@ export class WriteTool implements Tool {
     description: [
       '创建或完整覆盖一个 UTF-8 文本文件。',
       '适合生成新文件或重写整个文件；对已有文件做小范围修改时优先使用 edit_file。',
+      '当用户要求在桌面、下载、文档等常见目录创建文件时，先用 resolve_common_directory 解析目录，再把目标文件路径传给本工具；不要用 execute_shell 创建普通文本文件。',
     ].join('\n'),
     parameters: {
       type: 'object',
       properties: {
         file_path: {
           type: 'string',
-          description: '要写入的文件路径。支持绝对路径或相对当前目录的路径。'
+          description: '要写入的文件路径。支持绝对路径或相对当前目录的路径；可以使用 resolve_common_directory 返回的路径拼出目标文件。'
         },
         content: {
           type: 'string',

--- a/tests/catscompany-device-rpc-tools.test.ts
+++ b/tests/catscompany-device-rpc-tools.test.ts
@@ -280,7 +280,7 @@ describe('CatsCompany Device RPC file tools', () => {
     assert.match(captured.result.error.message, /channel_identity_link/);
   });
 
-  test('executes shell Device RPC operations on the selected local device', async () => {
+  test('rejects shell Device RPC operations on the selected local device', async () => {
     const captured: { result?: any } = {};
     const bot = botWithDevice(captured);
 
@@ -292,9 +292,10 @@ describe('CatsCompany Device RPC file tools', () => {
     }));
 
     assert.ok(captured.result);
-    assert.equal(captured.result.error, undefined);
-    assert.equal(captured.result.result.ok, true);
-    assert.match(captured.result.result.content, /rpc-shell-ok/);
+    assert.equal(captured.result.result, undefined);
+    assert.equal(captured.result.error.code, 'unsupported_operation');
+    assert.match(captured.result.error.message, /read_file, glob, grep, write_file, and edit_file/);
+    assert.doesNotMatch(captured.result.error.message, /execute_shell/);
   });
 
   test('rejects Device RPC requests for another target device', async () => {

--- a/tests/common-directory-tool.test.ts
+++ b/tests/common-directory-tool.test.ts
@@ -48,5 +48,8 @@ describe('CommonDirectoryTool', () => {
     assert.match(result.content as string, /Resolved common directory:/);
     assert.match(result.content as string, /kind: home/);
     assert.match(result.content as string, /Use this exact path as the base directory/);
+    assert.match(result.content as string, /call glob with this path/);
+    assert.match(result.content as string, /call write_file with a file_path under this path/);
+    assert.match(result.content as string, /Do not use execute_shell/);
   });
 });

--- a/tests/tool-gateway-catsco.test.ts
+++ b/tests/tool-gateway-catsco.test.ts
@@ -642,7 +642,7 @@ describe('CatsCo ToolGateway', () => {
     if (result.ok) assert.match(result.content, /catsco-shell-ok/);
   });
 
-  test('routes execute_shell for a mobile channel speaker to the selected user device', async () => {
+  test('blocks remote execute_shell for a mobile channel speaker even when selected', async () => {
     const root = makeWorkspace();
     const marker = path.join(root, 'should-not-run-locally.txt');
     const channelScope = scope({
@@ -694,11 +694,14 @@ describe('CatsCo ToolGateway', () => {
       },
     }));
 
-    assert.equal(result.ok, true);
-    assert.equal(result.ok ? result.content : '', 'remote shell ok');
-    assert.equal(calls.length, 1);
-    assert.equal(calls[0].toolName, 'execute_shell');
-    assert.equal(calls[0].operation, 'execute_shell');
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.errorCode, 'PERMISSION_DENIED');
+      assert.match(result.message, /execute_shell 还没有开放远程执行/);
+      assert.match(result.message, /查看目录文件请使用 glob/);
+      assert.match(result.message, /创建或覆盖文本文件请使用 write_file/);
+    }
+    assert.equal(calls.length, 0);
     assert.equal(fs.existsSync(marker), false);
   });
 

--- a/tests/tool-manager.test.ts
+++ b/tests/tool-manager.test.ts
@@ -523,14 +523,13 @@ describe('ToolManager', () => {
     const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-catsco-remote-file-'));
     const manager = new ToolManager(workspace, {}, { enabledToolNames: [] });
     const executed: string[] = [];
-    manager.registerTool(fakeTool('write_file', async () => {
-      executed.push('write_file');
-      return { ok: true, content: 'remote write requested' };
-    }));
-    manager.registerTool(fakeTool('glob', async () => {
-      executed.push('glob');
-      return { ok: true, content: 'remote glob requested' };
-    }));
+    const operations: DeviceGrantOperation[] = ['read_file', 'glob', 'grep', 'write_file', 'edit_file'];
+    for (const operation of operations) {
+      manager.registerTool(fakeTool(operation, async () => {
+        executed.push(operation);
+        return { ok: true, content: `remote ${operation} requested` };
+      }));
+    }
 
     const channelScope = catsScope({
       actorUserId: 'usr100',
@@ -553,7 +552,7 @@ describe('ToolManager', () => {
         installationId: 'cloud-install',
         deviceId: 'cloud-install',
       }),
-      deviceGrants: [catsDeviceGrant(channelScope, ['write_file', 'glob'], {
+      deviceGrants: [catsDeviceGrant(channelScope, operations, {
         grantId: 'speaker-file-grant',
         identitySource: 'channel_identity_link',
         deviceId: 'speaker-device',
@@ -563,7 +562,7 @@ describe('ToolManager', () => {
         ownerUserId: 'usr100',
         actorUserId: 'usr100',
       })],
-      deviceSelection: catsDeviceSelection(channelScope, ['write_file', 'glob'], {
+      deviceSelection: catsDeviceSelection(channelScope, operations, {
         selectedDeviceId: 'speaker-device',
         selectedDeviceDisplayName: 'Speaker Laptop',
         selectedDeviceBodyId: 'speaker-body',
@@ -578,12 +577,12 @@ describe('ToolManager', () => {
       },
     };
 
-    const write = await manager.executeTool({
-      id: 'call-remote-write',
+    const read = await manager.executeTool({
+      id: 'call-remote-read',
       type: 'function',
       function: {
-        name: 'write_file',
-        arguments: JSON.stringify({ file_path: 'C:\\Users\\Alice\\Desktop\\note.txt', content: 'hello' }),
+        name: 'read_file',
+        arguments: JSON.stringify({ file_path: 'C:\\Users\\Alice\\Desktop\\note.txt' }),
       },
     }, [], remoteContext);
     const glob = await manager.executeTool({
@@ -594,10 +593,42 @@ describe('ToolManager', () => {
         arguments: JSON.stringify({ pattern: '*', path: 'C:\\Users\\Alice\\Desktop' }),
       },
     }, [], remoteContext);
+    const grep = await manager.executeTool({
+      id: 'call-remote-grep',
+      type: 'function',
+      function: {
+        name: 'grep',
+        arguments: JSON.stringify({ pattern: 'needle', path: 'C:\\Users\\Alice\\Desktop', output_mode: 'files' }),
+      },
+    }, [], remoteContext);
+    const write = await manager.executeTool({
+      id: 'call-remote-write',
+      type: 'function',
+      function: {
+        name: 'write_file',
+        arguments: JSON.stringify({ file_path: 'C:\\Users\\Alice\\Desktop\\note.txt', content: 'hello' }),
+      },
+    }, [], remoteContext);
+    const edit = await manager.executeTool({
+      id: 'call-remote-edit',
+      type: 'function',
+      function: {
+        name: 'edit_file',
+        arguments: JSON.stringify({ file_path: 'C:\\Users\\Alice\\Desktop\\note.txt', old_string: 'hello', new_string: 'hi' }),
+      },
+    }, [], remoteContext);
 
+    assert.equal(read.ok, true);
+    assert.equal(read.content, 'remote read_file requested');
     assert.equal(write.ok, true);
+    assert.equal(write.content, 'remote write_file requested');
     assert.equal(glob.ok, true);
-    assert.deepEqual(executed, ['write_file', 'glob']);
+    assert.equal(glob.content, 'remote glob requested');
+    assert.equal(grep.ok, true);
+    assert.equal(grep.content, 'remote grep requested');
+    assert.equal(edit.ok, true);
+    assert.equal(edit.content, 'remote edit_file requested');
+    assert.deepEqual(executed, operations);
     assert.equal(confirmations, 0);
   });
 

--- a/tests/tool-manager.test.ts
+++ b/tests/tool-manager.test.ts
@@ -6,8 +6,14 @@ import * as path from 'path';
 import { DEFAULT_TOOL_NAMES } from '../src/tools/default-tool-names';
 import { ToolManager } from '../src/tools/tool-manager';
 import { AgentToolExecutor } from '../src/agents/agent-tool-executor';
-import type { Tool } from '../src/types/tool';
-import type { ExecutionScope, ScopedLocalDeviceGrant } from '../src/types/session-identity';
+import type { Tool, ToolExecutionContext } from '../src/types/tool';
+import type {
+  DeviceGrantOperation,
+  ExecutionScope,
+  ScopedDeviceGrant,
+  ScopedDeviceSelection,
+  ScopedLocalDeviceGrant,
+} from '../src/types/session-identity';
 
 function fakeTool(name: string, execute: Tool['execute']): Tool {
   return {
@@ -45,6 +51,62 @@ function catsLocalDevice(overrides: Partial<ScopedLocalDeviceGrant> = {}): Scope
     installationId: 'install-local',
     deviceId: 'install-local',
     createdAt: Date.now(),
+    ...overrides,
+  };
+}
+
+function catsDeviceGrant(
+  scope: ExecutionScope,
+  operations: DeviceGrantOperation[],
+  overrides: Partial<ScopedDeviceGrant> = {},
+): ScopedDeviceGrant {
+  return {
+    kind: 'user_device_grant',
+    source: 'catscompany',
+    grantId: 'device-grant-main',
+    status: 'active',
+    identityTrust: 'server_canonical',
+    identitySource: 'metadata.catsco_identity',
+    deviceId: 'install-local',
+    deviceDisplayName: 'Local Device',
+    deviceBodyId: 'body-local',
+    deviceInstallationId: 'install-local',
+    ownerUserId: scope.actorUserId,
+    sessionKey: scope.sessionKey,
+    topicId: scope.topicId,
+    topicType: scope.topicType,
+    actorUserId: scope.actorUserId,
+    agentId: scope.agentId,
+    agentBodyId: scope.agentBodyId,
+    operations,
+    createdAt: Date.now(),
+    expiresAt: Date.now() + 60_000,
+    ...overrides,
+  };
+}
+
+function catsDeviceSelection(
+  scope: ExecutionScope,
+  operations: DeviceGrantOperation[],
+  overrides: Partial<ScopedDeviceSelection> = {},
+): ScopedDeviceSelection {
+  return {
+    kind: 'user_device_selection',
+    source: 'catscompany',
+    status: 'selected',
+    selectionSource: 'single_active_device',
+    sessionKey: scope.sessionKey,
+    topicId: scope.topicId,
+    topicType: scope.topicType,
+    actorUserId: scope.actorUserId,
+    agentId: scope.agentId,
+    identityTrust: 'server_canonical',
+    identitySource: 'metadata.catsco_identity',
+    selectedDeviceId: 'install-local',
+    selectedDeviceDisplayName: 'Local Device',
+    selectedDeviceBodyId: 'body-local',
+    selectedDeviceInstallationId: 'install-local',
+    selectedDeviceOperations: operations,
     ...overrides,
   };
 }
@@ -455,6 +517,88 @@ describe('ToolManager', () => {
     assert.equal(result.ok, true);
     assert.equal(executed, true);
     assert.equal(confirmed, false);
+  });
+
+  test('CatsCo server-authorized remote file tools skip local confirmation', async () => {
+    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-catsco-remote-file-'));
+    const manager = new ToolManager(workspace, {}, { enabledToolNames: [] });
+    const executed: string[] = [];
+    manager.registerTool(fakeTool('write_file', async () => {
+      executed.push('write_file');
+      return { ok: true, content: 'remote write requested' };
+    }));
+    manager.registerTool(fakeTool('glob', async () => {
+      executed.push('glob');
+      return { ok: true, content: 'remote glob requested' };
+    }));
+
+    const channelScope = catsScope({
+      actorUserId: 'usr100',
+      sessionKey: 'session:v2:catscompany:p2p:p2p_100_43:agent:usr43',
+      topicId: 'p2p_100_43',
+      deviceOwnerUserId: 'usr100',
+      deviceOwnerSource: 'channel_identity_link',
+      channelSource: 'weixin',
+    });
+    let confirmations = 0;
+    const remoteContext: Partial<ToolExecutionContext> = {
+      surface: 'catscompany',
+      permissionProfile: 'strict',
+      workingDirectory: workspace,
+      workspaceRoot: workspace,
+      executionScope: channelScope,
+      localDeviceGrant: catsLocalDevice({
+        ownerUserId: 'usr9',
+        bodyId: 'cloud-body',
+        installationId: 'cloud-install',
+        deviceId: 'cloud-install',
+      }),
+      deviceGrants: [catsDeviceGrant(channelScope, ['write_file', 'glob'], {
+        grantId: 'speaker-file-grant',
+        identitySource: 'channel_identity_link',
+        deviceId: 'speaker-device',
+        deviceDisplayName: 'Speaker Laptop',
+        deviceBodyId: 'speaker-body',
+        deviceInstallationId: 'speaker-install',
+        ownerUserId: 'usr100',
+        actorUserId: 'usr100',
+      })],
+      deviceSelection: catsDeviceSelection(channelScope, ['write_file', 'glob'], {
+        selectedDeviceId: 'speaker-device',
+        selectedDeviceDisplayName: 'Speaker Laptop',
+        selectedDeviceBodyId: 'speaker-body',
+        selectedDeviceInstallationId: 'speaker-install',
+      }),
+      deviceRpc: {
+        executeTool: async () => ({ ok: true, content: 'remote ok' }),
+      },
+      confirmToolExecution: async () => {
+        confirmations += 1;
+        return false;
+      },
+    };
+
+    const write = await manager.executeTool({
+      id: 'call-remote-write',
+      type: 'function',
+      function: {
+        name: 'write_file',
+        arguments: JSON.stringify({ file_path: 'C:\\Users\\Alice\\Desktop\\note.txt', content: 'hello' }),
+      },
+    }, [], remoteContext);
+    const glob = await manager.executeTool({
+      id: 'call-remote-glob',
+      type: 'function',
+      function: {
+        name: 'glob',
+        arguments: JSON.stringify({ pattern: '*', path: 'C:\\Users\\Alice\\Desktop' }),
+      },
+    }, [], remoteContext);
+
+    assert.equal(write.ok, true);
+    assert.equal(glob.ok, true);
+    assert.deepEqual(executed, ['write_file', 'glob']);
+    assert.equal(confirmations, 0);
   });
 
   test('AgentToolExecutor uses the same local confirmation gate', async () => {


### PR DESCRIPTION
## Summary

Follow-up to the cats-company `resolve_common_directory` Device RPC change: keep routine remote user-device file tasks on file tools instead of shell.

## Changes

- Make `resolve_common_directory` results tell the agent what to do next:
  - list files with `glob`
  - create/overwrite text files with `write_file`
  - avoid `execute_shell` for routine file listing/creation
- Strengthen `glob`, `write_file`, and `execute_shell` tool descriptions so desktop/downloads/documents file tasks do not drift into shell commands.
- Remove `execute_shell` from XiaoBa's remote Device RPC tool allowlist.
- Reject inbound shell Device RPC requests on the local device side so the XiaoBa client matches the server-side permission boundary.
- Skip XiaoBa's duplicate local confirmation gate for server-selected remote Device RPC file operations (`read_file`, `glob`, `grep`, `write_file`, `edit_file`) when a matching short-lived grant and RPC transport are present.
- Update tests for the new routing, duplicate-confirmation bypass, and shell rejection behavior.

## Why

After resolving a common directory such as Desktop, the agent could still choose `execute_shell` for follow-up tasks like listing or creating files. That conflicts with the intended permissions model: common file operations should use `glob`, `write_file`, or `edit_file`, while remote shell remains out of scope.

The remote file tools are already authorized by the server-selected device grant, so XiaoBa should not ask the mobile user to approve the same ordinary file action again before forwarding it through Device RPC.

## Validation

- `node_modules\\.bin\\tsx.cmd --test tests\\tool-manager.test.ts tests\\common-directory-tool.test.ts tests\\tool-gateway-catsco.test.ts tests\\catscompany-device-rpc-tools.test.ts tests\\catscompany-runtime-device-capabilities.test.ts`
- `npm.cmd run build`