### PR TITLE
Allow server-granted remote execute_shell Device RPC

### DIFF
--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -26,6 +26,7 @@ import { GlobTool } from '../tools/glob-tool';
 import { GrepTool } from '../tools/grep-tool';
 import { WriteTool } from '../tools/write-tool';
 import { EditTool } from '../tools/edit-tool';
+import { ShellTool } from '../tools/bash-tool';
 import { resolveCommonDirectoryToolArgs } from '../tools/common-directory-tool';
 import {
   isRemoteDeviceRpcTool,
@@ -362,6 +363,8 @@ export class CatsCompanyBot {
         return new WriteTool().execute(args, context);
       case 'edit_file':
         return new EditTool().execute(args, context);
+      case 'execute_shell':
+        return new ShellTool().execute(args, context);
       default:
         return {
           ok: false,
@@ -452,7 +455,7 @@ export class CatsCompanyBot {
     const operation = this.normalizeDeviceRpcOperation(request.operation);
     const toolName = String(request.tool_name || operation || '').trim();
     if (!operation || !isRemoteDeviceRpcTool(toolName, operation)) {
-      return { code: 'unsupported_operation', message: 'Device RPC only allows read_file, resolve_common_directory, glob, grep, write_file, and edit_file.' };
+      return { code: 'unsupported_operation', message: 'Device RPC only allows read_file, resolve_common_directory, glob, grep, write_file, edit_file, and execute_shell.' };
     }
 
     const requiredFields: Array<[keyof CatsDeviceRpcMessage, string]> = [
@@ -489,6 +492,7 @@ export class CatsCompanyBot {
       || operation === 'grep'
       || operation === 'write_file'
       || operation === 'edit_file'
+      || operation === 'execute_shell'
     ) {
       return operation;
     }

--- a/src/tools/device-rpc-tool.ts
+++ b/src/tools/device-rpc-tool.ts
@@ -15,7 +15,8 @@ export function isRemoteReadonlyTool(toolName: string, operation: DeviceGrantOpe
 export function isRemoteDeviceRpcTool(toolName: string, operation: DeviceGrantOperation): boolean {
   return isRemoteReadonlyTool(toolName, operation)
     || (toolName === 'write_file' && operation === 'write_file')
-    || (toolName === 'edit_file' && operation === 'edit_file');
+    || (toolName === 'edit_file' && operation === 'edit_file')
+    || (toolName === 'execute_shell' && operation === 'execute_shell');
 }
 
 export async function executeRemoteDeviceRpcTool(
@@ -31,7 +32,7 @@ export async function executeRemoteDeviceRpcTool(
     return {
       ok: false,
       errorCode: 'PERMISSION_DENIED',
-      message: `远程设备 RPC 当前只允许 read_file / resolve_common_directory / glob / grep / write_file / edit_file，已阻止 ${toolName}。请用 resolve_common_directory 解析常见目录，用 glob 查看文件列表，用 write_file 创建或覆盖文本文件。`,
+      message: `远程设备 RPC 当前只允许 read_file / resolve_common_directory / glob / grep / write_file / edit_file / execute_shell，已阻止 ${toolName}。普通文件任务请优先用 resolve_common_directory / glob / write_file，只有服务端授权后才使用 execute_shell。`,
     };
   }
 

--- a/src/tools/local-tool-risk.ts
+++ b/src/tools/local-tool-risk.ts
@@ -100,7 +100,7 @@ export function classifyLocalToolRisk(
   }
 
   const remoteFileOperation = REMOTE_DEVICE_FILE_TOOL_OPERATIONS[toolName];
-  if (remoteFileOperation && isServerAuthorizedRemoteDeviceFileOperation(toolName, remoteFileOperation, context)) {
+  if (remoteFileOperation && isServerAuthorizedRemoteDeviceOperation(toolName, remoteFileOperation, context)) {
     return {
       requiresConfirmation: false,
       risk: 'low',
@@ -121,6 +121,13 @@ export function classifyLocalToolRisk(
 
   if (toolName === 'execute_shell') {
     const command = stringField(args, 'command') || stringField(args, 'cmd') || stringField(args, 'script');
+    if (isServerAuthorizedRemoteDeviceOperation(toolName, 'execute_shell', context)) {
+      return {
+        requiresConfirmation: false,
+        risk: 'high',
+        reason: '服务端已选定远程设备并下发 execute_shell device grant，命令由 Device RPC 直接转发。',
+      };
+    }
     if (looksDangerousShell(command)) {
       return { requiresConfirmation: true, risk: 'high', reason: '命令可能删除、覆盖、关闭系统或下载并执行脚本。' };
     }
@@ -150,7 +157,7 @@ export function classifyLocalToolRisk(
   return { requiresConfirmation: true, risk: 'medium', reason: '未知工具未声明风险等级，需要用户确认。' };
 }
 
-function isServerAuthorizedRemoteDeviceFileOperation(
+function isServerAuthorizedRemoteDeviceOperation(
   toolName: string,
   operation: DeviceGrantOperation,
   context: ToolExecutionContext,

--- a/src/tools/tool-gateway.ts
+++ b/src/tools/tool-gateway.ts
@@ -40,6 +40,7 @@ const REMOTE_DEVICE_RPC_OPERATIONS = new Set<DeviceGrantOperation>([
   'grep',
   'write_file',
   'edit_file',
+  'execute_shell',
 ]);
 
 export function isCatsCoToolGatewayContext(context: ToolExecutionContext): boolean {

--- a/tests/catscompany-device-rpc-tools.test.ts
+++ b/tests/catscompany-device-rpc-tools.test.ts
@@ -69,7 +69,7 @@ function serverGrant(overrides: Partial<ScopedDeviceGrant> = {}): ScopedDeviceGr
     actorUserId: 'usr7',
     agentId: 'usr43',
     agentBodyId: 'body-agent',
-    operations: ['read_file', 'resolve_common_directory', 'glob', 'grep'],
+    operations: ['read_file', 'resolve_common_directory', 'glob', 'grep', 'execute_shell'],
     createdAt: Date.now(),
     expiresAt: Date.now() + 60_000,
     ...overrides,
@@ -132,20 +132,29 @@ describe('CatsCompany Device RPC file tools', () => {
       args: { pattern: '合同', path: 'catsco_attachment:project', output_mode: 'files' },
       grant,
     });
+    const shell = await transport.executeTool({
+      toolName: 'execute_shell',
+      operation: 'execute_shell',
+      args: { command: 'echo remote-shell' },
+      grant,
+    });
 
     assert.equal(read.ok, true);
     assert.equal(glob.ok, true);
     assert.equal(resolveDir.ok, true);
     assert.equal(grep.ok, true);
+    assert.equal(shell.ok, true);
     assert.equal(read.ok ? read.content : '', 'remote read_file');
     assert.equal(glob.ok ? glob.content : '', 'remote glob');
     assert.equal(resolveDir.ok ? resolveDir.content : '', 'remote resolve_common_directory');
     assert.equal(grep.ok ? grep.content : '', 'remote grep');
+    assert.equal(shell.ok ? shell.content : '', 'remote execute_shell');
     assert.deepEqual(captured.map(item => [item.request.tool_name, item.request.operation]), [
       ['read_file', 'read_file'],
       ['glob', 'glob'],
       ['resolve_common_directory', 'resolve_common_directory'],
       ['grep', 'grep'],
+      ['execute_shell', 'execute_shell'],
     ]);
 
     const first = captured[0].request;
@@ -308,7 +317,7 @@ describe('CatsCompany Device RPC file tools', () => {
     assert.match(captured.result.error.message, /channel_identity_link/);
   });
 
-  test('rejects shell Device RPC operations on the selected local device', async () => {
+  test('executes shell Device RPC operations on the selected local device', async () => {
     const captured: { result?: any } = {};
     const bot = botWithDevice(captured);
 
@@ -320,10 +329,9 @@ describe('CatsCompany Device RPC file tools', () => {
     }));
 
     assert.ok(captured.result);
-    assert.equal(captured.result.result, undefined);
-    assert.equal(captured.result.error.code, 'unsupported_operation');
-    assert.match(captured.result.error.message, /read_file, resolve_common_directory, glob, grep, write_file, and edit_file/);
-    assert.doesNotMatch(captured.result.error.message, /execute_shell/);
+    assert.equal(captured.result.error, undefined);
+    assert.equal(captured.result.result.ok, true);
+    assert.match(String(captured.result.result.content), /rpc-shell-ok/);
   });
 
   test('rejects Device RPC requests for another target device', async () => {

--- a/tests/tool-gateway-catsco.test.ts
+++ b/tests/tool-gateway-catsco.test.ts
@@ -689,7 +689,7 @@ describe('CatsCo ToolGateway', () => {
     if (result.ok) assert.match(result.content, /catsco-shell-ok/);
   });
 
-  test('blocks remote execute_shell for a mobile channel speaker even when selected', async () => {
+  test('routes remote execute_shell for a mobile channel speaker when selected and granted', async () => {
     const root = makeWorkspace();
     const marker = path.join(root, 'should-not-run-locally.txt');
     const channelScope = scope({
@@ -741,14 +741,13 @@ describe('CatsCo ToolGateway', () => {
       },
     }));
 
-    assert.equal(result.ok, false);
-    if (!result.ok) {
-      assert.equal(result.errorCode, 'PERMISSION_DENIED');
-      assert.match(result.message, /execute_shell 还没有开放远程执行/);
-      assert.match(result.message, /查看目录文件请使用 glob/);
-      assert.match(result.message, /创建或覆盖文本文件请使用 write_file/);
-    }
-    assert.equal(calls.length, 0);
+    assert.equal(result.ok, true);
+    assert.equal(result.ok ? result.content : '', 'remote shell ok');
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].toolName, 'execute_shell');
+    assert.equal(calls[0].operation, 'execute_shell');
+    assert.equal(calls[0].grant.ownerUserId, 'usr100');
+    assert.equal(calls[0].grant.deviceId, 'speaker-device');
     assert.equal(fs.existsSync(marker), false);
   });
 

--- a/tests/tool-manager.test.ts
+++ b/tests/tool-manager.test.ts
@@ -8,7 +8,6 @@ import { ToolManager } from '../src/tools/tool-manager';
 import { AgentToolExecutor } from '../src/agents/agent-tool-executor';
 import type { Tool, ToolExecutionContext } from '../src/types/tool';
 import type {
-  DeviceGrantOperation,
   ExecutionScope,
   ScopedDeviceGrant,
   ScopedDeviceSelection,
@@ -57,7 +56,7 @@ function catsLocalDevice(overrides: Partial<ScopedLocalDeviceGrant> = {}): Scope
 
 function catsDeviceGrant(
   scope: ExecutionScope,
-  operations: DeviceGrantOperation[],
+  operations: ScopedDeviceGrant['operations'],
   overrides: Partial<ScopedDeviceGrant> = {},
 ): ScopedDeviceGrant {
   return {
@@ -87,7 +86,7 @@ function catsDeviceGrant(
 
 function catsDeviceSelection(
   scope: ExecutionScope,
-  operations: DeviceGrantOperation[],
+  operations: ScopedDeviceGrant['operations'],
   overrides: Partial<ScopedDeviceSelection> = {},
 ): ScopedDeviceSelection {
   return {
@@ -523,7 +522,7 @@ describe('ToolManager', () => {
     const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-catsco-remote-file-'));
     const manager = new ToolManager(workspace, {}, { enabledToolNames: [] });
     const executed: string[] = [];
-    const operations: DeviceGrantOperation[] = ['read_file', 'glob', 'grep', 'write_file', 'edit_file'];
+    const operations: ScopedDeviceGrant['operations'] = ['read_file', 'glob', 'grep', 'write_file', 'edit_file'];
     for (const operation of operations) {
       manager.registerTool(fakeTool(operation, async () => {
         executed.push(operation);
@@ -629,6 +628,75 @@ describe('ToolManager', () => {
     assert.equal(edit.ok, true);
     assert.equal(edit.content, 'remote edit_file requested');
     assert.deepEqual(executed, operations);
+    assert.equal(confirmations, 0);
+  });
+
+  test('CatsCo server-authorized remote execute_shell skips local confirmation', async () => {
+    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-catsco-remote-shell-'));
+    const manager = new ToolManager(workspace, {}, { enabledToolNames: [] });
+    let executed = false;
+    manager.registerTool(fakeTool('execute_shell', async () => {
+      executed = true;
+      return { ok: true, content: 'remote shell requested' };
+    }));
+
+    const channelScope = catsScope({
+      actorUserId: 'usr100',
+      sessionKey: 'session:v2:catscompany:p2p:p2p_100_43:agent:usr43',
+      topicId: 'p2p_100_43',
+      deviceOwnerUserId: 'usr100',
+      deviceOwnerSource: 'channel_identity_link',
+      channelSource: 'weixin',
+    });
+    const remoteContext: Partial<ToolExecutionContext> = {
+      surface: 'catscompany',
+      permissionProfile: 'strict',
+      workingDirectory: workspace,
+      workspaceRoot: workspace,
+      executionScope: channelScope,
+      localDeviceGrant: catsLocalDevice({
+        ownerUserId: 'usr9',
+        bodyId: 'cloud-body',
+        installationId: 'cloud-install',
+        deviceId: 'cloud-install',
+      }),
+      deviceGrants: [catsDeviceGrant(channelScope, ['execute_shell'], {
+        grantId: 'speaker-shell-grant',
+        identitySource: 'channel_identity_link',
+        deviceId: 'speaker-device',
+        deviceDisplayName: 'Speaker Laptop',
+        deviceBodyId: 'speaker-body',
+        deviceInstallationId: 'speaker-install',
+        ownerUserId: 'usr100',
+        actorUserId: 'usr100',
+      })],
+      deviceSelection: catsDeviceSelection(channelScope, ['execute_shell'], {
+        selectedDeviceId: 'speaker-device',
+        selectedDeviceDisplayName: 'Speaker Laptop',
+        selectedDeviceBodyId: 'speaker-body',
+        selectedDeviceInstallationId: 'speaker-install',
+      }),
+      deviceRpc: {
+        executeTool: async () => ({ ok: true, content: 'remote shell ok' }),
+      },
+    };
+    let confirmations = 0;
+
+    const result = await manager.executeTool({
+      id: 'call-remote-shell',
+      type: 'function',
+      function: { name: 'execute_shell', arguments: JSON.stringify({ command: 'echo remote-shell' }) },
+    }, [], {
+      ...remoteContext,
+      confirmToolExecution: async () => {
+        confirmations += 1;
+        return false;
+      },
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.content, 'remote shell requested');
+    assert.equal(executed, true);
     assert.equal(confirmations, 0);
   });
 


### PR DESCRIPTION
## Status

Ready for review as the XiaoBa-CLI half of paired remote `execute_shell` support.

This PR is intentionally scoped to XiaoBa-CLI. It should be reviewed together with buildsense-ai/cats-company#43 and should not be merged before the cats-company backend PR lands.

## Paired Backend PR

- buildsense-ai/cats-company#43 opens server Device RPC `execute_shell` only when the active server-issued device grant contains `execute_shell`.
- The backend PR also syncs runtime grant operations, TypeScript SDK operation types, protocol docs, shell command audit fields, and server tests.
- The remaining policy decision is explicit: neither side adds a server-side command denylist or extra high-risk second confirmation in this pass. Authorization is the server-issued, user/session/device-scoped grant plus XiaoBa local command safety for the target device.

## XiaoBa-CLI Changes

- Allows remote Device RPC routing for `execute_shell` when the selected remote device and active CatsCo grant both include `execute_shell`.
- Allows CatsCo inbound Device RPC requests to execute `execute_shell` on the selected local device.
- Treats a matching server `execute_shell` device grant as the authorization source and skips XiaoBa's duplicate local confirmation prompt for that remote request.
- Keeps ordinary remote file tasks on file operations (`read_file`, `resolve_common_directory`, `glob`, `grep`, `write_file`, `edit_file`).
- Keeps external / untrusted CatsCo shell paths blocked unless the gateway is explicitly authorized for this server-granted operation.

## Permission Boundary

Remote `execute_shell` is allowed only when all of these are true:

- CatsCo selected a target device for the current user/session/topic.
- The active device grant includes `execute_shell`.
- The request matches the grant scope: actor, owner, agent/body, session/topic, and device.
- Device RPC transport is available and the request is routed to the selected device.

If any of those fail, XiaoBa-CLI still rejects or falls back to the existing permission-denied behavior.

## Validation

- `node_modules\\.bin\\tsx.cmd --test tests\\tool-manager.test.ts tests\\tool-gateway-catsco.test.ts tests\\catscompany-device-rpc-tools.test.ts tests\\catscompany-runtime-device-capabilities.test.ts`
- `npm.cmd run build`