### PR TITLE
[codex] add async prompt mode router

### DIFF
--- a/src/core/agent-turn-controller.ts
+++ b/src/core/agent-turn-controller.ts
@@ -35,7 +35,10 @@ import {
   withSyntheticObservationTiming,
 } from './synthetic-observation';
 import { MemorySidecarBranchHandle, startMemorySidecarBranch } from './sidecar-memory-branch';
+import { ModeRouterSidecarBranchHandle, startModeRouterSidecarBranch } from './sidecar-mode-router-branch';
 import { isBranchAgentsEnabled } from './branch-agent-settings';
+import { PromptModeRuntime } from './prompt-mode-runtime';
+import { findFixedPromptModeState, listPromptModeDefinitions, FixedPromptModeState } from '../runtime/prompt-modes';
 
 export interface AgentTurnServices {
   aiService: AIService;
@@ -104,21 +107,32 @@ interface MemoryBranchSlot {
   done: boolean;
 }
 
+interface ModeRouterBranchSlot {
+  queue: InMemorySyntheticObservationQueue;
+  handle: ModeRouterSidecarBranchHandle;
+  originTurn: number;
+  done: boolean;
+}
+
 /**
  * Runs one user turn: durable input -> transient context -> model/tool loop -> state/log sync.
  */
 export class AgentTurnController {
   private turnSequence = 0;
   private memoryBranchCarryover: MemoryBranchSlot | null = null;
+  private modeRouterCarryover: ModeRouterBranchSlot | null = null;
+  private promptModeRuntime = new PromptModeRuntime();
 
   constructor(private readonly options: AgentTurnControllerOptions) {}
 
   async run(params: RunAgentTurnParams): Promise<RunAgentTurnResult> {
     const turnNumber = ++this.turnSequence;
     const previousCarryoverMemoryBranch = this.memoryBranchCarryover;
+    const previousCarryoverModeRouter = this.modeRouterCarryover;
     const branchAgentsEnabled = isBranchAgentsEnabled();
     const carryoverMemoryBranch = branchAgentsEnabled ? previousCarryoverMemoryBranch : null;
     this.memoryBranchCarryover = null;
+    this.modeRouterCarryover = null;
     if (!branchAgentsEnabled) {
       this.expireMemoryBranch(previousCarryoverMemoryBranch, 'branch_agents_disabled');
     }
@@ -131,6 +145,18 @@ export class AgentTurnController {
         runtimeObservationSource: params.runtimeObservationSource,
       }),
     });
+
+    this.promptModeRuntime.beginTurn(turnNumber);
+    const fixedMode = findFixedPromptModeState(params.messages);
+    const promptModeRouterEnabled = this.isPromptModeRouterEnabled(branchAgentsEnabled, fixedMode);
+    const carryoverModeRouter = promptModeRouterEnabled ? previousCarryoverModeRouter : null;
+    if (!promptModeRouterEnabled) {
+      this.promptModeRuntime.clear(fixedMode ? 'fixed_mode_active' : 'prompt_mode_router_disabled');
+      this.expireModeRouterBranch(
+        previousCarryoverModeRouter,
+        fixedMode ? 'fixed_mode_active' : 'prompt_mode_router_disabled',
+      );
+    }
 
     const turnContext = await this.options.turnContextBuilder.build({
       sessionKey: this.options.sessionKey,
@@ -145,9 +171,17 @@ export class AgentTurnController {
       runtimeFeedback: params.runtimeFeedback,
       skillRuntime: this.options.skillRuntime,
       planRuntime: this.options.planRuntime,
+      promptModeRoutingEnabled: promptModeRouterEnabled,
     });
 
     const currentMemoryBranch = this.startMemorySidecarIfEnabled({
+      turnNumber,
+      input: params.input,
+      messages: params.messages,
+      abortSignal: params.abortSignal,
+    });
+    const currentModeRouter = this.startModeRouterIfEnabled({
+      enabled: promptModeRouterEnabled,
       turnNumber,
       input: params.input,
       messages: params.messages,
@@ -168,6 +202,12 @@ export class AgentTurnController {
         carryoverMemoryBranch,
         currentMemoryBranch,
       ),
+      runtimeTransientProvider: () => this.buildPromptModeTransientMessages(
+        carryoverModeRouter,
+        currentModeRouter,
+        turnNumber,
+        fixedMode,
+      ),
       abortSignal: params.abortSignal,
       shouldContinue: params.shouldContinue,
     });
@@ -184,10 +224,16 @@ export class AgentTurnController {
       throw error;
     } finally {
       this.expireMemoryBranch(carryoverMemoryBranch, 'carryover_ttl_expired');
+      this.expireModeRouterBranch(carryoverModeRouter, 'carryover_ttl_expired');
       if (result && currentMemoryBranch && this.shouldCarryMemoryBranch(currentMemoryBranch)) {
         this.memoryBranchCarryover = currentMemoryBranch;
       } else {
         this.expireMemoryBranch(currentMemoryBranch, result ? 'current_branch_consumed' : 'turn_failed');
+      }
+      if (result && currentModeRouter && this.shouldCarryModeRouterBranch(currentModeRouter)) {
+        this.modeRouterCarryover = currentModeRouter;
+      } else {
+        this.expireModeRouterBranch(currentModeRouter, result ? 'current_branch_consumed' : 'turn_failed');
       }
     }
     const nextMessages = this.options.turnContextBuilder.removeTransientMessages(result.messages);
@@ -229,6 +275,7 @@ export class AgentTurnController {
     pendingUserInputProvider?: PendingUserInputProvider;
     confirmToolExecution?: AgentTurnCallbacks['confirmToolExecution'];
     syntheticObservationProvider?: () => SyntheticObservation[];
+    runtimeTransientProvider?: () => Message[];
     abortSignal?: AbortSignal;
     shouldContinue: () => boolean;
   }): ConversationRunner {
@@ -240,6 +287,7 @@ export class AgentTurnController {
         shouldContinue: options.shouldContinue,
         pendingUserInputProvider: options.pendingUserInputProvider,
         syntheticObservationProvider: options.syntheticObservationProvider,
+        runtimeTransientProvider: options.runtimeTransientProvider,
         // AgentSession/ContextWindowManager compacts durable history before the turn.
         // Runner-level compaction can fold transient runtime feedback into summary.
         enableCompression: false,
@@ -303,6 +351,40 @@ export class AgentTurnController {
     return slot;
   }
 
+  private startModeRouterIfEnabled(options: {
+    enabled: boolean;
+    turnNumber: number;
+    input: string | ContentBlock[];
+    messages: Message[];
+    abortSignal?: AbortSignal;
+  }): ModeRouterBranchSlot | null {
+    if (!options.enabled) {
+      return null;
+    }
+    if (!(this.options.services.aiService instanceof AIService)) {
+      return null;
+    }
+    if (listPromptModeDefinitions().length === 0) {
+      return null;
+    }
+    const queue = new InMemorySyntheticObservationQueue();
+    const slot: ModeRouterBranchSlot = {
+      queue,
+      originTurn: options.turnNumber,
+      done: false,
+      handle: this.createModeRouterHandle({
+        input: options.input,
+        messages: options.messages,
+        queue,
+        abortSignal: options.abortSignal,
+      }),
+    };
+    slot.handle.done.finally(() => {
+      slot.done = true;
+    });
+    return slot;
+  }
+
   private drainMemoryObservations(
     carryover: MemoryBranchSlot | null,
     current: MemoryBranchSlot | null,
@@ -324,6 +406,10 @@ export class AgentTurnController {
   }
 
   private shouldCarryMemoryBranch(slot: MemoryBranchSlot): boolean {
+    return !slot.done || slot.queue.size() > 0;
+  }
+
+  private shouldCarryModeRouterBranch(slot: ModeRouterBranchSlot): boolean {
     return !slot.done || slot.queue.size() > 0;
   }
 
@@ -361,6 +447,35 @@ export class AgentTurnController {
     }
   }
 
+  private expireModeRouterBranch(slot: ModeRouterBranchSlot | null, reason: string): void {
+    if (!slot) return;
+    slot.handle.cancel();
+    const droppedObservations = slot.queue.cancel();
+    if (droppedObservations.length > 0) {
+      Logger.info(
+        `[${this.options.sessionKey}] dropped ${droppedObservations.length} unconsumed prompt mode router observation(s): `
+        + `reason=${reason} origin_turn=${slot.originTurn} `
+        + droppedObservations.map(describeSyntheticObservationForLog).join(' | ')
+      );
+      for (const observation of droppedObservations) {
+        Logger.runtimeEvent(
+          'INFO',
+          `[${this.options.sessionKey}] prompt_mode_router_lifecycle dropped id=${observation.id || '(unassigned)'}`,
+          buildSyntheticObservationLifecycleEvent(observation, {
+            outcome: 'dropped',
+            reason,
+            originTurn: slot.originTurn,
+          }),
+        );
+      }
+    } else if (!slot.done && reason === 'carryover_ttl_expired') {
+      Logger.info(
+        `[${this.options.sessionKey}] cancelled unfinished prompt mode router carryover: `
+        + `reason=${reason} origin_turn=${slot.originTurn}`
+      );
+    }
+  }
+
   private createMemorySidecarHandle(options: {
     input: string | ContentBlock[];
     messages: Message[];
@@ -376,6 +491,60 @@ export class AgentTurnController {
       queue: options.queue,
       signal: options.abortSignal,
     });
+  }
+
+  private createModeRouterHandle(options: {
+    input: string | ContentBlock[];
+    messages: Message[];
+    queue: SyntheticObservationQueue;
+    abortSignal?: AbortSignal;
+  }): ModeRouterSidecarBranchHandle {
+    return startModeRouterSidecarBranch({
+      sessionKey: this.options.sessionKey,
+      input: options.input,
+      recentMessages: options.messages,
+      workingDirectory: this.options.getCurrentDirectory(),
+      aiService: this.options.services.aiService,
+      queue: options.queue,
+      activeMode: this.promptModeRuntime.getActiveMode(),
+      signal: options.abortSignal,
+    });
+  }
+
+  private buildPromptModeTransientMessages(
+    carryover: ModeRouterBranchSlot | null,
+    current: ModeRouterBranchSlot | null,
+    turnNumber: number,
+    fixedMode?: FixedPromptModeState,
+  ): Message[] {
+    if (fixedMode) return [];
+    const observations = [
+      ...this.drainModeRouterBranch(carryover),
+      ...this.drainModeRouterBranch(current),
+    ];
+    this.promptModeRuntime.applyRouterObservations(observations, turnNumber);
+    const message = this.promptModeRuntime.buildTransientMessage({
+      turnNumber,
+      fixedMode,
+    });
+    return message ? [message] : [];
+  }
+
+  private drainModeRouterBranch(slot: ModeRouterBranchSlot | null): SyntheticObservation[] {
+    if (!slot) return [];
+    return slot.queue.drain();
+  }
+
+  private isPromptModeRouterEnabled(
+    branchAgentsEnabled: boolean,
+    fixedMode?: FixedPromptModeState,
+  ): boolean {
+    if (fixedMode) return false;
+    if (!branchAgentsEnabled) return false;
+    if (process.env.XIAOBA_PROMPT_MODE_ROUTER_ENABLED === 'false') return false;
+    if (!(this.options.services.aiService instanceof AIService)) return false;
+    if (listPromptModeDefinitions().length === 0) return false;
+    return true;
   }
 
   private withMemoryBranchObservationMetadata(

--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -42,6 +42,7 @@ import {
   describeSyntheticObservationForLog,
   SyntheticObservation,
 } from './synthetic-observation';
+import { TRANSIENT_ACTIVE_PROMPT_MODE_PREFIX } from './prompt-mode-runtime';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -126,6 +127,7 @@ function isPendingUserInput(value: string | ContentBlock[] | PendingUserInput): 
 }
 
 export type SyntheticObservationProvider = () => SyntheticObservation[];
+export type RuntimeTransientProvider = () => Message[];
 
 interface ToolExecutionRecord {
   toolCall: ToolCall;
@@ -152,6 +154,8 @@ export interface RunnerOptions {
   pendingUserInputProvider?: PendingUserInputProvider;
   /** Non-blocking runtime observations produced by sidecar branches. */
   syntheticObservationProvider?: SyntheticObservationProvider;
+  /** Non-durable runtime system context produced by sidecar branches. */
+  runtimeTransientProvider?: RuntimeTransientProvider;
 }
 
 /**
@@ -172,6 +176,7 @@ export class ConversationRunner {
   private pendingUserInputProvider?: PendingUserInputProvider;
   private promptTraceLogger: PromptTraceLogger;
   private syntheticObservationProvider?: SyntheticObservationProvider;
+  private runtimeTransientProvider?: RuntimeTransientProvider;
 
   /** 截断字符串用于日志输出，避免日志过大 */
   private static truncateForLog(text: any, maxLen = 200): string {
@@ -195,6 +200,7 @@ export class ConversationRunner {
     this.toolExecutionContext = options?.toolExecutionContext;
     this.pendingUserInputProvider = options?.pendingUserInputProvider;
     this.syntheticObservationProvider = options?.syntheticObservationProvider;
+    this.runtimeTransientProvider = options?.runtimeTransientProvider;
     this.maxTurns = options?.maxTurns;
 
     this.maxPromptTokens = this.resolvePromptBudget(options?.maxContextTokens);
@@ -259,6 +265,7 @@ export class ConversationRunner {
         };
       }
       this.injectSyntheticObservations(messages, turns);
+      const runtimeTransientHints = this.drainRuntimeTransientMessages(turns);
       const requestTools = this.fitToolsToPromptBudget(activeTools);
       if (requestTools.length < activeTools.length && !notifiedToolBudgetDisabled) {
         notifiedToolBudgetDisabled = true;
@@ -322,6 +329,7 @@ export class ConversationRunner {
         ? buildPerTurnRunnerHint(requestTools)
         : null;
       const requestMessages = this.buildProviderInputMessages(messages, [
+        ...runtimeTransientHints,
         ...(perTurnRunnerHint ? [perTurnRunnerHint] : []),
         ...nextTurnTransientHints,
         ...orchestrationHints,
@@ -872,6 +880,7 @@ export class ConversationRunner {
         return true;
       }
       return !message.content.startsWith(TRANSIENT_RUNNER_HINT_PREFIX)
+        && !message.content.startsWith(TRANSIENT_ACTIVE_PROMPT_MODE_PREFIX)
         && !message.content.startsWith(TRANSIENT_CURRENT_DIRECTORY_PREFIX);
     });
 
@@ -952,6 +961,16 @@ export class ConversationRunner {
     return message.role === 'system'
       && typeof message.content === 'string'
       && message.content.startsWith(TRANSIENT_RUNNER_HINT_PREFIX);
+  }
+
+  private drainRuntimeTransientMessages(turn: number): Message[] {
+    if (!this.runtimeTransientProvider) return [];
+    try {
+      return this.runtimeTransientProvider();
+    } catch (error: any) {
+      Logger.warning(`[${this.sessionLabel}Turn ${turn}] runtime transient drain failed: ${error.message}`);
+      return [];
+    }
   }
 
   private isCurrentDirectoryHint(message: Message): boolean {

--- a/src/core/mode-router-branch-session.ts
+++ b/src/core/mode-router-branch-session.ts
@@ -1,0 +1,177 @@
+import { randomUUID } from 'crypto';
+import { ContentBlock, Message } from '../types';
+import { AIService } from '../utils/ai-service';
+import { Tool } from '../types/tool';
+import { SyntheticObservation, SyntheticObservationQueue } from './synthetic-observation';
+import { ObservationBranchDisposition, ObservationBranchSession } from './observation-branch-session';
+import {
+  FinishPromptModeRoutingTool,
+  PromptModeRouterFinishPayload,
+} from '../tools/prompt-mode-router-tools';
+import {
+  PromptModeRuntimeState,
+  buildPromptModeRouterObservation,
+} from './prompt-mode-runtime';
+import {
+  PromptModeDefinition,
+  getPromptModeDefinition,
+  listPromptModeDefinitions,
+} from '../runtime/prompt-modes';
+import { getPromptBaseDir } from '../utils/prompt-template';
+
+export interface ModeRouterBranchSessionOptions {
+  sessionKey: string;
+  input: string | ContentBlock[];
+  recentMessages: Message[];
+  workingDirectory: string;
+  aiService: AIService;
+  queue: SyntheticObservationQueue;
+  activeMode?: PromptModeRuntimeState | null;
+  signal?: AbortSignal;
+  logEnabled?: boolean;
+  promptsDir?: string;
+}
+
+export class ModeRouterBranchSession extends ObservationBranchSession<PromptModeRouterFinishPayload> {
+  private readonly promptsDir: string;
+
+  constructor(private readonly modeOptions: ModeRouterBranchSessionOptions) {
+    super({
+      id: `prompt-mode-router-${Date.now().toString(36)}-${randomUUID().slice(0, 8)}`,
+      type: 'prompt-mode-router',
+      aiService: modeOptions.aiService,
+      workingDirectory: modeOptions.workingDirectory,
+      queue: modeOptions.queue,
+      signal: modeOptions.signal,
+      logEnabled: modeOptions.logEnabled,
+    });
+    this.promptsDir = modeOptions.promptsDir ?? getPromptBaseDir();
+  }
+
+  protected async buildInitialMessages(): Promise<Message[]> {
+    return [
+      {
+        role: 'system',
+        content: buildModeRouterSystemPrompt(),
+      },
+      {
+        role: 'user',
+        content: buildModeRouterUserInput({
+          input: this.modeOptions.input,
+          recentMessages: this.modeOptions.recentMessages,
+          activeMode: this.modeOptions.activeMode,
+          modes: listPromptModeDefinitions(this.promptsDir),
+        }),
+      },
+    ];
+  }
+
+  protected buildTools(): Tool[] {
+    return [
+      new FinishPromptModeRoutingTool(payload => {
+        this.complete(payload);
+      }),
+    ];
+  }
+
+  protected buildFinishReminderMessage(): Message {
+    return {
+      role: 'user',
+      content: [
+        'Your previous response will not be sent to the parent agent.',
+        'This branch can only finish by calling finish_prompt_mode_routing.',
+        'Use action:ignore if there is no clear mode decision.',
+      ].join(' '),
+    };
+  }
+
+  protected getObservationDisposition(payload: PromptModeRouterFinishPayload): ObservationBranchDisposition {
+    return {
+      inject: true,
+      logPayload: {
+        action: payload.action,
+        mode: payload.mode,
+        confidence: payload.confidence,
+        reason: payload.reason,
+      },
+    };
+  }
+
+  protected buildObservation(payload: PromptModeRouterFinishPayload): SyntheticObservation {
+    const definition = payload.action === 'activate'
+      ? getPromptModeDefinition(payload.mode, this.promptsDir)
+      : undefined;
+    return buildPromptModeRouterObservation(payload, definition);
+  }
+}
+
+function buildModeRouterSystemPrompt(): string {
+  return [
+    'You are PromptModeRouterBranchSession, a background routing branch for a parent agent.',
+    'You do not answer the user and your text output is discarded.',
+    'Your only job is to decide whether the runtime should activate, clear, or ignore a prompt mode for the parent agent.',
+    '',
+    'Decision rules:',
+    '- action=activate when the current user request clearly benefits from one available mode.',
+    '- action=clear when an active mode exists and the current user request clearly changes away from that mode.',
+    '- action=ignore when there is no clear decision, confidence is low, or the active mode can safely remain unchanged.',
+    '- Prefer ignore over weak guesses.',
+    '- Do not infer hidden file contents or facts; route only from the user request and recent context summary.',
+    '- Call finish_prompt_mode_routing exactly once.',
+  ].join('\n');
+}
+
+function buildModeRouterUserInput(options: {
+  input: string | ContentBlock[];
+  recentMessages: Message[];
+  activeMode?: PromptModeRuntimeState | null;
+  modes: PromptModeDefinition[];
+}): string {
+  const payload = {
+    current_user_input: contentToText(options.input),
+    current_active_mode: options.activeMode
+      ? {
+        id: options.activeMode.mode,
+        title: options.activeMode.title,
+        confidence: options.activeMode.confidence,
+        reason: options.activeMode.reason,
+      }
+      : null,
+    available_modes: options.modes.map(mode => ({
+      id: mode.id,
+      title: mode.title,
+      description: mode.description,
+    })),
+    recent_context: extractRecentContext(options.recentMessages),
+  };
+  return JSON.stringify(payload, null, 2);
+}
+
+function extractRecentContext(messages: Message[]): Array<{ role: string; content: string }> {
+  return messages
+    .filter(message => (
+      (message.role === 'user' || message.role === 'assistant')
+      && !message.__injected
+      && !message.__runtimeFeedback
+      && !message.__syntheticObservation
+    ))
+    .slice(-6)
+    .map(message => ({
+      role: message.role,
+      content: truncate(contentToText(message.content), 800),
+    }))
+    .filter(item => item.content.length > 0);
+}
+
+function contentToText(content: string | ContentBlock[] | null): string {
+  if (!content) return '';
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  return content.map(block => block.type === 'text' ? block.text : '[image]').join('\n');
+}
+
+function truncate(value: string, maxLength: number): string {
+  const normalized = value.replace(/\s+/g, ' ').trim();
+  if (normalized.length <= maxLength) return normalized;
+  return `${normalized.slice(0, maxLength)}...`;
+}

--- a/src/core/prompt-mode-runtime.ts
+++ b/src/core/prompt-mode-runtime.ts
@@ -1,0 +1,218 @@
+import { Message } from '../types';
+import {
+  FixedPromptModeState,
+  PromptModeDefinition,
+  PromptModeId,
+  getPromptModeDefinition,
+  loadPromptModePrompt,
+} from '../runtime/prompt-modes';
+import { getPromptBaseDir } from '../utils/prompt-template';
+import { Logger } from '../utils/logger';
+import { SyntheticObservation } from './synthetic-observation';
+import {
+  PromptModeRouterAction,
+  PromptModeRouterFinishPayload,
+} from '../tools/prompt-mode-router-tools';
+
+export const TRANSIENT_ACTIVE_PROMPT_MODE_PREFIX = '[transient_active_prompt_mode]';
+
+const DEFAULT_MAX_ACTIVE_TURNS = 5;
+const DEFAULT_ACTIVATE_CONFIDENCE = 0.7;
+const DEFAULT_CLEAR_CONFIDENCE = 0.7;
+
+export interface PromptModeRuntimeState {
+  mode: PromptModeId;
+  title: string;
+  confidence: number;
+  reason: string;
+  activatedTurn: number;
+  updatedTurn: number;
+}
+
+export interface PromptModeRuntimeOptions {
+  promptsDir?: string;
+  maxActiveTurns?: number;
+  activateConfidence?: number;
+  clearConfidence?: number;
+}
+
+export class PromptModeRuntime {
+  private active: PromptModeRuntimeState | null = null;
+  private currentTurn = 0;
+  private readonly promptsDir: string;
+  private readonly maxActiveTurns: number;
+  private readonly activateConfidence: number;
+  private readonly clearConfidence: number;
+
+  constructor(options: PromptModeRuntimeOptions = {}) {
+    this.promptsDir = options.promptsDir ?? getPromptBaseDir();
+    this.maxActiveTurns = options.maxActiveTurns ?? DEFAULT_MAX_ACTIVE_TURNS;
+    this.activateConfidence = options.activateConfidence ?? DEFAULT_ACTIVATE_CONFIDENCE;
+    this.clearConfidence = options.clearConfidence ?? DEFAULT_CLEAR_CONFIDENCE;
+  }
+
+  beginTurn(turnNumber: number): void {
+    this.currentTurn = turnNumber;
+    this.expireIfNeeded(turnNumber);
+  }
+
+  getActiveMode(): PromptModeRuntimeState | null {
+    return this.active ? { ...this.active } : null;
+  }
+
+  clear(reason = 'cleared'): void {
+    if (this.active) {
+      Logger.info(`[prompt-mode-runtime] cleared active mode ${this.active.mode}: ${reason}`);
+    }
+    this.active = null;
+  }
+
+  applyRouterObservations(observations: SyntheticObservation[], turnNumber = this.currentTurn): void {
+    for (const observation of observations) {
+      const payload = parsePromptModeRouterObservation(observation);
+      if (!payload) {
+        Logger.warning(`[prompt-mode-runtime] ignored malformed router observation id=${observation.id || '(none)'}`);
+        continue;
+      }
+      this.applyRouterPayload(payload, turnNumber);
+    }
+  }
+
+  applyRouterPayload(payload: PromptModeRouterFinishPayload, turnNumber = this.currentTurn): void {
+    const action = payload.action;
+    if (action === 'ignore') {
+      Logger.info(`[prompt-mode-runtime] router ignored mode change confidence=${payload.confidence.toFixed(2)} reason=${payload.reason}`);
+      return;
+    }
+
+    if (action === 'clear') {
+      if (payload.confidence < this.clearConfidence) {
+        Logger.info(`[prompt-mode-runtime] ignored low-confidence clear confidence=${payload.confidence.toFixed(2)} reason=${payload.reason}`);
+        return;
+      }
+      this.clear(`router_clear confidence=${payload.confidence.toFixed(2)} reason=${payload.reason}`);
+      return;
+    }
+
+    if (payload.confidence < this.activateConfidence) {
+      Logger.info(`[prompt-mode-runtime] ignored low-confidence activate mode=${payload.mode || '(none)'} confidence=${payload.confidence.toFixed(2)} reason=${payload.reason}`);
+      return;
+    }
+
+    const definition = getPromptModeDefinition(payload.mode, this.promptsDir);
+    if (!definition) {
+      Logger.warning(`[prompt-mode-runtime] ignored unknown prompt mode "${payload.mode || ''}" from router`);
+      return;
+    }
+
+    this.active = {
+      mode: definition.id,
+      title: definition.title,
+      confidence: payload.confidence,
+      reason: payload.reason,
+      activatedTurn: this.active?.mode === definition.id
+        ? this.active.activatedTurn
+        : turnNumber,
+      updatedTurn: turnNumber,
+    };
+    Logger.info(`[prompt-mode-runtime] active mode=${definition.id} confidence=${payload.confidence.toFixed(2)} reason=${payload.reason}`);
+  }
+
+  buildTransientMessage(options: {
+    turnNumber?: number;
+    fixedMode?: FixedPromptModeState;
+  } = {}): Message | null {
+    const turnNumber = options.turnNumber ?? this.currentTurn;
+    if (options.fixedMode) return null;
+    this.expireIfNeeded(turnNumber);
+    if (!this.active) return null;
+
+    const content = loadPromptModePrompt(this.promptsDir, this.active.mode);
+    if (!content) {
+      Logger.warning(`[prompt-mode-runtime] active mode "${this.active.mode}" is unreadable; clearing`);
+      this.active = null;
+      return null;
+    }
+
+    return {
+      role: 'system',
+      content: [
+        TRANSIENT_ACTIVE_PROMPT_MODE_PREFIX,
+        `Active prompt mode: ${this.active.mode} (${this.active.title}).`,
+        `Selected asynchronously by runtime mode router with confidence ${this.active.confidence.toFixed(2)}.`,
+        `Reason: ${this.active.reason}`,
+        'Apply this mode where it fits the current user request. If the user has clearly changed topic, follow the user and do not force this mode.',
+        '',
+        content,
+      ].join('\n'),
+    };
+  }
+
+  private expireIfNeeded(turnNumber: number): void {
+    if (!this.active) return;
+    if (turnNumber - this.active.updatedTurn <= this.maxActiveTurns) return;
+    Logger.info(`[prompt-mode-runtime] expired active mode ${this.active.mode} after ${this.maxActiveTurns} turns`);
+    this.active = null;
+  }
+}
+
+export function buildPromptModeRouterObservation(
+  payload: PromptModeRouterFinishPayload,
+  definition?: PromptModeDefinition,
+): SyntheticObservation {
+  const idParts = [
+    'prompt-mode-router',
+    payload.action,
+    payload.mode || 'none',
+    Date.now().toString(36),
+  ];
+
+  return {
+    id: idParts.join('-').replace(/[^a-zA-Z0-9_-]/g, '_'),
+    source: 'runtime',
+    status: 'completed',
+    relevance: payload.action === 'ignore' ? 'low' : 'high',
+    confidence: payload.confidence,
+    summary: payload.reason,
+    metadata: {
+      branchType: 'prompt_mode_router',
+      ...(payload.mode ? { refs: [`mode:${payload.mode}`] } : {}),
+    },
+    formattedContent: JSON.stringify({
+      source: 'prompt_mode_router',
+      action: payload.action,
+      mode: definition?.id || payload.mode,
+      confidence: payload.confidence,
+      reason: payload.reason,
+    }),
+  };
+}
+
+export function parsePromptModeRouterObservation(
+  observation: SyntheticObservation,
+): PromptModeRouterFinishPayload | null {
+  const raw = observation.formattedContent || observation.summary;
+  let parsed: any;
+  try {
+    parsed = JSON.parse(String(raw || '{}'));
+  } catch {
+    return null;
+  }
+
+  if (parsed?.source !== 'prompt_mode_router') return null;
+  const action = parsed.action as PromptModeRouterAction;
+  if (action !== 'activate' && action !== 'clear' && action !== 'ignore') return null;
+  const confidence = Number(parsed.confidence);
+  if (!Number.isFinite(confidence)) return null;
+  const reason = String(parsed.reason || '').trim() || 'mode router result';
+  const mode = typeof parsed.mode === 'string' && parsed.mode.trim()
+    ? parsed.mode.trim()
+    : undefined;
+
+  return {
+    action,
+    ...(mode ? { mode } : {}),
+    confidence: Math.max(0, Math.min(1, confidence)),
+    reason,
+  };
+}

--- a/src/core/sidecar-mode-router-branch.ts
+++ b/src/core/sidecar-mode-router-branch.ts
@@ -1,0 +1,64 @@
+import { ContentBlock, Message } from '../types';
+import { AIService } from '../utils/ai-service';
+import { Logger } from '../utils/logger';
+import { SyntheticObservationQueue } from './synthetic-observation';
+import { ModeRouterBranchSession } from './mode-router-branch-session';
+import { PromptModeRuntimeState } from './prompt-mode-runtime';
+
+export interface ModeRouterSidecarBranchOptions {
+  sessionKey: string;
+  input: string | ContentBlock[];
+  recentMessages: Message[];
+  workingDirectory: string;
+  aiService: AIService;
+  queue: SyntheticObservationQueue;
+  activeMode?: PromptModeRuntimeState | null;
+  signal?: AbortSignal;
+  logEnabled?: boolean;
+}
+
+export interface ModeRouterSidecarBranchHandle {
+  cancel(): void;
+  done: Promise<void>;
+}
+
+export function startModeRouterSidecarBranch(
+  options: ModeRouterSidecarBranchOptions,
+): ModeRouterSidecarBranchHandle {
+  const controller = new AbortController();
+  const signal = linkAbortSignals(controller.signal, options.signal);
+  const session = new ModeRouterBranchSession({
+    ...options,
+    signal,
+  });
+  const done = session.run().catch(error => {
+    if (isAbortError(error) || signal.aborted) return;
+    Logger.warning(`[${options.sessionKey}] prompt mode router branch failed: ${error.message}`);
+  });
+
+  return {
+    cancel: () => {
+      controller.abort();
+      session.stop();
+    },
+    done,
+  };
+}
+
+function linkAbortSignals(...signals: Array<AbortSignal | undefined>): AbortSignal {
+  const controller = new AbortController();
+  const abort = () => controller.abort();
+  for (const signal of signals) {
+    if (!signal) continue;
+    if (signal.aborted) {
+      abort();
+      break;
+    }
+    signal.addEventListener('abort', abort, { once: true });
+  }
+  return controller.signal;
+}
+
+function isAbortError(error: any): boolean {
+  return error?.name === 'AbortError' || /aborted|aborterror|canceled|cancelled/i.test(String(error?.message || ''));
+}

--- a/src/core/turn-context-builder.ts
+++ b/src/core/turn-context-builder.ts
@@ -22,6 +22,7 @@ import {
   buildRuntimeContextMessage,
 } from './runtime-context-builder';
 import { stripAssistantArtifactsFromMessages } from '../utils/transcript-artifacts';
+import { TRANSIENT_ACTIVE_PROMPT_MODE_PREFIX } from './prompt-mode-runtime';
 import {
   TRANSIENT_FIXED_PROMPT_MODE_PREFIX,
   TRANSIENT_PROMPT_MODES_LIST_PREFIX,
@@ -50,6 +51,7 @@ export interface BuildTurnContextParams {
   runtimeFeedback: string[];
   skillRuntime: SessionSkillRuntime;
   planRuntime?: PlanRuntime;
+  promptModeRoutingEnabled?: boolean;
 }
 
 export interface BuildTurnContextResult {
@@ -70,7 +72,7 @@ export class TurnContextBuilder {
     this.injectRuntimeFeedback(contextMessages, params.runtimeFeedback);
     this.injectPlanStatus(contextMessages, params.planRuntime);
     this.injectSubAgentStatus(contextMessages, params.sessionKey);
-    this.injectPromptModesList(contextMessages);
+    this.injectPromptModesList(contextMessages, params.promptModeRoutingEnabled === true);
     const transientPolicy = resolveTurnContextTransientPolicy(contextMessages);
     if (transientPolicy.injectSkillsList) {
       await params.skillRuntime.reloadSkills();
@@ -101,6 +103,11 @@ export class TurnContextBuilder {
         msg.role === 'system'
         && typeof msg.content === 'string'
         && msg.content.startsWith(TRANSIENT_FIXED_PROMPT_MODE_PREFIX)
+      ) return false;
+      if (
+        msg.role === 'system'
+        && typeof msg.content === 'string'
+        && msg.content.startsWith(TRANSIENT_ACTIVE_PROMPT_MODE_PREFIX)
       ) return false;
       if (msg.role !== 'system' || typeof msg.content !== 'string') return true;
       if (msg.content.startsWith(TRANSIENT_SUBAGENT_STATUS_PREFIX)) return false;
@@ -172,12 +179,13 @@ export class TurnContextBuilder {
     this.insertBeforeLastUser(messages, statusMessage);
   }
 
-  private injectPromptModesList(messages: Message[]): void {
+  private injectPromptModesList(messages: Message[], routingEnabled = false): void {
     const fixedMode = findFixedPromptModeState(messages);
     if (fixedMode) {
       this.insertBeforeLastUser(messages, buildFixedPromptModeMessage(fixedMode));
       return;
     }
+    if (routingEnabled) return;
 
     const modeList = buildPromptModesListMessage({
       previousMode: findPreviousPromptModeState(messages),

--- a/src/tools/local-tool-risk.ts
+++ b/src/tools/local-tool-risk.ts
@@ -26,6 +26,7 @@ const LOW_RISK_TOOLS = new Set([
   'memory_read_turn',
   'memory_neighbors',
   'finish_memory_search',
+  'finish_prompt_mode_routing',
 ]);
 
 const CONFIRM_TOOLS = new Set([

--- a/src/tools/prompt-mode-router-tools.ts
+++ b/src/tools/prompt-mode-router-tools.ts
@@ -1,0 +1,104 @@
+import { Tool, ToolDefinition, ToolExecutionResult } from '../types/tool';
+
+export type PromptModeRouterAction = 'activate' | 'clear' | 'ignore';
+
+export interface PromptModeRouterFinishPayload {
+  action: PromptModeRouterAction;
+  mode?: string;
+  confidence: number;
+  reason: string;
+}
+
+export type PromptModeRouterFinishHandler = (payload: PromptModeRouterFinishPayload) => void;
+
+const ROUTER_ACTIONS = new Set<PromptModeRouterAction>(['activate', 'clear', 'ignore']);
+
+export class FinishPromptModeRoutingTool implements Tool {
+  definition: ToolDefinition = {
+    name: 'finish_prompt_mode_routing',
+    description: [
+      'Finish prompt mode routing for the parent agent.',
+      'This branch does not answer the user. It only decides whether the parent runtime should activate, clear, or ignore a prompt mode.',
+      'Call this exactly once with the best available decision.',
+    ].join(' '),
+    controlMode: 'pause_turn',
+    parameters: {
+      type: 'object',
+      properties: {
+        action: {
+          type: 'string',
+          enum: ['activate', 'clear', 'ignore'],
+          description: 'activate a mode, clear the current mode, or ignore without changing mode state.',
+        },
+        mode: {
+          type: 'string',
+          description: 'Prompt mode id when action is activate. Leave empty for clear or ignore.',
+        },
+        confidence: {
+          type: 'number',
+          description: 'Confidence from 0 to 1.',
+        },
+        reason: {
+          type: 'string',
+          description: 'Short reason for logs and diagnostics.',
+        },
+      },
+      required: ['action', 'confidence', 'reason'],
+    },
+  };
+
+  constructor(private readonly onFinish: PromptModeRouterFinishHandler) {}
+
+  async execute(args: any): Promise<ToolExecutionResult> {
+    const validation = validatePromptModeRouterFinishArgs(args);
+    if (!validation.ok) {
+      return {
+        ok: false,
+        errorCode: 'INVALID_TOOL_ARGUMENTS',
+        message: validation.error,
+        retryable: false,
+      };
+    }
+
+    this.onFinish(validation.payload);
+    return {
+      ok: true,
+      content: JSON.stringify({ ok: true }),
+    };
+  }
+}
+
+export function validatePromptModeRouterFinishArgs(args: any):
+  | { ok: true; payload: PromptModeRouterFinishPayload }
+  | { ok: false; error: string } {
+  const rawAction = String(args?.action || '').trim();
+  if (!ROUTER_ACTIONS.has(rawAction as PromptModeRouterAction)) {
+    return { ok: false, error: 'action must be activate, clear, or ignore' };
+  }
+  const action = rawAction as PromptModeRouterAction;
+
+  const confidence = Number(args?.confidence);
+  if (!Number.isFinite(confidence) || confidence < 0 || confidence > 1) {
+    return { ok: false, error: 'confidence must be a number from 0 to 1' };
+  }
+
+  const reason = String(args?.reason || '').replace(/\s+/g, ' ').trim();
+  if (!reason) {
+    return { ok: false, error: 'reason must be a non-empty string' };
+  }
+
+  const mode = String(args?.mode || '').trim();
+  if (action === 'activate' && !mode) {
+    return { ok: false, error: 'mode is required when action is activate' };
+  }
+
+  return {
+    ok: true,
+    payload: {
+      action,
+      ...(mode ? { mode } : {}),
+      confidence,
+      reason,
+    },
+  };
+}

--- a/tests/agent-turn-mode-router.test.ts
+++ b/tests/agent-turn-mode-router.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import * as assert from 'node:assert/strict';
+import { AgentTurnController } from '../src/core/agent-turn-controller';
+import { BRANCH_AGENTS_ENABLED_ENV } from '../src/core/branch-agent-settings';
+import { InMemorySyntheticObservationQueue } from '../src/core/synthetic-observation';
+import {
+  TRANSIENT_ACTIVE_PROMPT_MODE_PREFIX,
+  buildPromptModeRouterObservation,
+} from '../src/core/prompt-mode-runtime';
+import { TRANSIENT_FIXED_PROMPT_MODE_PREFIX, TRANSIENT_PROMPT_MODES_LIST_PREFIX } from '../src/runtime/prompt-modes';
+import { TurnContextBuilder } from '../src/core/turn-context-builder';
+import { PlanRuntime } from '../src/core/plan-runtime';
+import { Message } from '../src/types';
+
+const usage = { promptTokens: 1, completionTokens: 1, totalTokens: 2 };
+
+class CapturingAIService {
+  requests: Message[][] = [];
+
+  isToolCallingSupported(): boolean {
+    return true;
+  }
+
+  async chatStream(messages: Message[]): Promise<any> {
+    this.requests.push(JSON.parse(JSON.stringify(messages)));
+    return {
+      content: `done ${this.requests.length}`,
+      toolCalls: [],
+      usage,
+    };
+  }
+}
+
+describe('AgentTurnController prompt mode router integration', () => {
+  let previousBranchEnv: string | undefined;
+
+  beforeEach(() => {
+    previousBranchEnv = process.env[BRANCH_AGENTS_ENABLED_ENV];
+    process.env[BRANCH_AGENTS_ENABLED_ENV] = 'true';
+  });
+
+  afterEach(() => {
+    if (previousBranchEnv === undefined) {
+      delete process.env[BRANCH_AGENTS_ENABLED_ENV];
+    } else {
+      process.env[BRANCH_AGENTS_ENABLED_ENV] = previousBranchEnv;
+    }
+  });
+
+  test('carries a late mode router result into the next user turn', async () => {
+    const aiService = new CapturingAIService();
+    const queues: InMemorySyntheticObservationQueue[] = [];
+    const controller = buildController(aiService);
+
+    (controller as any).isPromptModeRouterEnabled = () => true;
+    (controller as any).startModeRouterIfEnabled = (options: { turnNumber: number; enabled: boolean }) => {
+      if (!options.enabled) return null;
+      const queue = new InMemorySyntheticObservationQueue();
+      queues.push(queue);
+      return {
+        queue,
+        originTurn: options.turnNumber,
+        done: false,
+        handle: {
+          cancel: () => undefined,
+          done: new Promise<void>(() => undefined),
+        },
+      };
+    };
+
+    let messages: Message[] = [];
+    let result = await controller.run({
+      input: 'debug this build',
+      messages,
+      runtimeFeedback: [],
+      shouldContinue: () => true,
+    });
+    messages = result.messages;
+    assert.equal(aiService.requests.length, 1);
+    assert.equal(hasPrefix(aiService.requests[0], TRANSIENT_ACTIVE_PROMPT_MODE_PREFIX), false);
+
+    assert.equal(queues[0].push(buildPromptModeRouterObservation({
+      action: 'activate',
+      mode: 'coding-agent',
+      confidence: 0.93,
+      reason: 'local build debugging',
+    })), true);
+
+    result = await controller.run({
+      input: 'continue',
+      messages,
+      runtimeFeedback: [],
+      shouldContinue: () => true,
+    });
+
+    assert.equal(aiService.requests.length, 2);
+    assert.equal(hasPrefix(aiService.requests[1], TRANSIENT_ACTIVE_PROMPT_MODE_PREFIX), true);
+    assert.equal(hasPrefix(result.messages, TRANSIENT_ACTIVE_PROMPT_MODE_PREFIX), false);
+  });
+
+  test('fixed mode suppresses router list and async active mode', async () => {
+    const aiService = new CapturingAIService();
+    const controller = buildController(aiService);
+    let enabledStarts = 0;
+
+    (controller as any).promptModeRuntime.applyRouterPayload({
+      action: 'activate',
+      mode: 'office',
+      confidence: 0.95,
+      reason: 'preloaded async mode',
+    }, 1);
+    (controller as any).isPromptModeRouterEnabled = (branchAgentsEnabled: boolean, fixedMode: unknown) => {
+      return branchAgentsEnabled && !fixedMode;
+    };
+    (controller as any).startModeRouterIfEnabled = (options: { enabled: boolean }) => {
+      if (options.enabled) enabledStarts += 1;
+      return null;
+    };
+
+    await controller.run({
+      input: 'debug this build',
+      messages: [
+        { role: 'system', content: 'base\n[mode:coding-agent]\nfixed coding instructions' },
+      ],
+      runtimeFeedback: [],
+      shouldContinue: () => true,
+    });
+
+    assert.equal(enabledStarts, 0);
+    assert.equal(hasPrefix(aiService.requests[0], TRANSIENT_FIXED_PROMPT_MODE_PREFIX), true);
+    assert.equal(hasPrefix(aiService.requests[0], TRANSIENT_PROMPT_MODES_LIST_PREFIX), false);
+    assert.equal(hasPrefix(aiService.requests[0], TRANSIENT_ACTIVE_PROMPT_MODE_PREFIX), false);
+  });
+});
+
+function buildController(aiService: CapturingAIService): AgentTurnController {
+  return new AgentTurnController({
+    sessionKey: 'session:v2:catscompany:group:grp_test:agent:usr1',
+    sessionType: 'catscompany',
+    services: {
+      aiService: aiService as any,
+      toolManager: {
+        getToolDefinitions: () => [],
+        executeTool: async () => {
+          throw new Error('not expected');
+        },
+      } as any,
+      skillManager: {} as any,
+    },
+    skillRuntime: {
+      reloadSkills: async () => undefined,
+      buildSkillsListMessage: () => null,
+    } as any,
+    planRuntime: new PlanRuntime(),
+    turnContextBuilder: new TurnContextBuilder(),
+    turnLogRecorder: {
+      recordTurn: () => undefined,
+    } as any,
+    workspaceRoot: process.cwd(),
+    getCurrentDirectory: () => process.cwd(),
+    updateCurrentDirectory: () => undefined,
+  });
+}
+
+function hasPrefix(messages: Message[], prefix: string): boolean {
+  return messages.some(message => (
+    typeof message.content === 'string'
+    && message.content.startsWith(prefix)
+  ));
+}

--- a/tests/conversation-runner-runtime-transient.test.ts
+++ b/tests/conversation-runner-runtime-transient.test.ts
@@ -1,0 +1,94 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert/strict';
+import { ConversationRunner } from '../src/core/conversation-runner';
+import { TRANSIENT_ACTIVE_PROMPT_MODE_PREFIX } from '../src/core/prompt-mode-runtime';
+import { ChatResponse, Message } from '../src/types';
+import { ToolCall, ToolDefinition, ToolExecutor, ToolResult } from '../src/types/tool';
+
+const usage = { promptTokens: 1, completionTokens: 1, totalTokens: 2 };
+
+function cloneMessages(messages: Message[]): Message[] {
+  return JSON.parse(JSON.stringify(messages));
+}
+
+function makeToolCall(id: string): ToolCall {
+  return {
+    id,
+    type: 'function',
+    function: {
+      name: 'noop',
+      arguments: '{}',
+    },
+  };
+}
+
+class NoopToolExecutor implements ToolExecutor {
+  getToolDefinitions(): ToolDefinition[] {
+    return [{
+      name: 'noop',
+      description: 'noop',
+      parameters: { type: 'object', properties: {} },
+    }];
+  }
+
+  async executeTool(toolCall: ToolCall): Promise<ToolResult> {
+    return {
+      tool_call_id: toolCall.id,
+      role: 'tool',
+      name: toolCall.function.name,
+      content: 'ok',
+      ok: true,
+    };
+  }
+}
+
+describe('ConversationRunner runtime transient messages', () => {
+  test('injects runtime transient context into a later provider call in the same run', async () => {
+    const received: Message[][] = [];
+    const responses: ChatResponse[] = [
+      {
+        content: null,
+        toolCalls: [makeToolCall('call_1')],
+        usage,
+      },
+      {
+        content: 'done',
+        toolCalls: [],
+        usage,
+      },
+    ];
+
+    const aiService = {
+      chat: async (messages: Message[]) => {
+        received.push(cloneMessages(messages));
+        return responses[received.length - 1];
+      },
+    } as any;
+
+    let drainCount = 0;
+    const runner = new ConversationRunner(aiService, new NoopToolExecutor(), {
+      stream: false,
+      enableCompression: false,
+      runtimeTransientProvider: () => {
+        drainCount += 1;
+        if (drainCount !== 2) return [];
+        return [{
+          role: 'system',
+          content: `${TRANSIENT_ACTIVE_PROMPT_MODE_PREFIX}\n[mode:coding-agent]\nUse engineering workflow.`,
+        }];
+      },
+    });
+
+    await runner.run([{ role: 'user', content: 'debug it' }]);
+
+    assert.equal(received.length, 2);
+    assert.equal(
+      received[0].some(message => typeof message.content === 'string' && message.content.startsWith(TRANSIENT_ACTIVE_PROMPT_MODE_PREFIX)),
+      false,
+    );
+    assert.equal(
+      received[1].some(message => typeof message.content === 'string' && message.content.startsWith(TRANSIENT_ACTIVE_PROMPT_MODE_PREFIX)),
+      true,
+    );
+  });
+});

--- a/tests/mode-router-branch.test.ts
+++ b/tests/mode-router-branch.test.ts
@@ -1,0 +1,127 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert/strict';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ModeRouterBranchSession } from '../src/core/mode-router-branch-session';
+import { InMemorySyntheticObservationQueue } from '../src/core/synthetic-observation';
+import { PromptModeRuntime } from '../src/core/prompt-mode-runtime';
+import { ChatResponse, Message } from '../src/types';
+import { ToolCall, ToolDefinition } from '../src/types/tool';
+
+const usage = { promptTokens: 1, completionTokens: 1, totalTokens: 2 };
+
+function makeToolCall(id: string, args: unknown): ToolCall {
+  return {
+    id,
+    type: 'function',
+    function: {
+      name: 'finish_prompt_mode_routing',
+      arguments: JSON.stringify(args),
+    },
+  };
+}
+
+class ModeRouterAI {
+  calls: Message[][] = [];
+
+  constructor(private readonly args: unknown) {}
+
+  isToolCallingSupported(): boolean {
+    return true;
+  }
+
+  async chat(messages: Message[], tools?: ToolDefinition[]): Promise<ChatResponse> {
+    this.calls.push(JSON.parse(JSON.stringify(messages)));
+    assert.equal(tools?.map(tool => tool.name).join(','), 'finish_prompt_mode_routing');
+    return {
+      content: null,
+      toolCalls: [makeToolCall('finish_1', this.args)],
+      usage,
+    };
+  }
+}
+
+describe('mode router branch', () => {
+  test('publishes activate, clear, and ignore router observations', async () => {
+    for (const args of [
+      {
+        action: 'activate',
+        mode: 'coding-agent',
+        confidence: 0.92,
+        reason: 'local build debugging',
+      },
+      {
+        action: 'clear',
+        confidence: 0.88,
+        reason: 'topic changed to casual chat',
+      },
+      {
+        action: 'ignore',
+        confidence: 0.3,
+        reason: 'no clear mode',
+      },
+    ]) {
+      const queue = new InMemorySyntheticObservationQueue();
+      const aiService = new ModeRouterAI(args);
+      const session = new ModeRouterBranchSession({
+        sessionKey: 'mode-router-test',
+        input: 'debug this build',
+        recentMessages: [],
+        workingDirectory: process.cwd(),
+        aiService: aiService as any,
+        queue,
+        logEnabled: false,
+      });
+
+      await session.run();
+      const observations = queue.drain();
+      assert.equal(observations.length, 1);
+      const payload = JSON.parse(String(observations[0].formattedContent));
+      assert.equal(payload.source, 'prompt_mode_router');
+      assert.equal(payload.action, (args as any).action);
+      assert.equal(aiService.calls.length, 1);
+    }
+  });
+
+  test('runtime ignores invalid router mode from branch output', async () => {
+    const promptsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-mode-router-invalid-'));
+    try {
+      fs.mkdirSync(path.join(promptsDir, 'modes'), { recursive: true });
+      fs.writeFileSync(path.join(promptsDir, 'modes', 'coding-agent.md'), [
+        '---',
+        'id: coding-agent',
+        'name: Coding Agent',
+        'description: Work on code',
+        '---',
+        '',
+        'Use engineering workflow.',
+      ].join('\n'), 'utf-8');
+
+      const queue = new InMemorySyntheticObservationQueue();
+      const session = new ModeRouterBranchSession({
+        sessionKey: 'mode-router-invalid',
+        input: 'debug this build',
+        recentMessages: [],
+        workingDirectory: process.cwd(),
+        aiService: new ModeRouterAI({
+          action: 'activate',
+          mode: 'does-not-exist',
+          confidence: 0.99,
+          reason: 'bad model output',
+        }) as any,
+        queue,
+        logEnabled: false,
+        promptsDir,
+      });
+
+      await session.run();
+      const runtime = new PromptModeRuntime({ promptsDir });
+      runtime.beginTurn(1);
+      runtime.applyRouterObservations(queue.drain(), 1);
+      assert.equal(runtime.buildTransientMessage({ turnNumber: 1 }), null);
+    } finally {
+      fs.rmSync(promptsDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/prompt-mode-runtime.test.ts
+++ b/tests/prompt-mode-runtime.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import * as assert from 'node:assert/strict';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  PromptModeRuntime,
+  TRANSIENT_ACTIVE_PROMPT_MODE_PREFIX,
+} from '../src/core/prompt-mode-runtime';
+
+describe('PromptModeRuntime', () => {
+  let promptsDir: string;
+
+  beforeEach(() => {
+    promptsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-mode-runtime-'));
+    fs.mkdirSync(path.join(promptsDir, 'modes'), { recursive: true });
+    fs.writeFileSync(path.join(promptsDir, 'modes', 'coding-agent.md'), [
+      '---',
+      'id: coding-agent',
+      'name: Coding Agent',
+      'description: Work on code and local projects',
+      '---',
+      '',
+      'Use engineering workflow.',
+    ].join('\n'), 'utf-8');
+  });
+
+  afterEach(() => {
+    fs.rmSync(promptsDir, { recursive: true, force: true });
+  });
+
+  test('activates a prompt mode and builds a transient system message', () => {
+    const runtime = new PromptModeRuntime({ promptsDir });
+    runtime.beginTurn(1);
+    runtime.applyRouterPayload({
+      action: 'activate',
+      mode: 'coding-agent',
+      confidence: 0.91,
+      reason: 'User is debugging a local build.',
+    }, 1);
+
+    const message = runtime.buildTransientMessage({ turnNumber: 1 });
+    assert.equal(message?.role, 'system');
+    assert.match(String(message?.content), new RegExp(`^\\${TRANSIENT_ACTIVE_PROMPT_MODE_PREFIX}`));
+    assert.match(String(message?.content), /\[mode:coding-agent\]/);
+    assert.match(String(message?.content), /Use engineering workflow/);
+  });
+
+  test('ignores low-confidence activation and unknown modes', () => {
+    const runtime = new PromptModeRuntime({ promptsDir });
+    runtime.beginTurn(1);
+
+    runtime.applyRouterPayload({
+      action: 'activate',
+      mode: 'coding-agent',
+      confidence: 0.4,
+      reason: 'weak signal',
+    }, 1);
+    assert.equal(runtime.buildTransientMessage({ turnNumber: 1 }), null);
+
+    runtime.applyRouterPayload({
+      action: 'activate',
+      mode: 'unknown-mode',
+      confidence: 0.95,
+      reason: 'bad mode',
+    }, 1);
+    assert.equal(runtime.buildTransientMessage({ turnNumber: 1 }), null);
+  });
+
+  test('clears active mode and expires after the TTL', () => {
+    const runtime = new PromptModeRuntime({ promptsDir, maxActiveTurns: 2 });
+    runtime.beginTurn(1);
+    runtime.applyRouterPayload({
+      action: 'activate',
+      mode: 'coding-agent',
+      confidence: 0.95,
+      reason: 'coding task',
+    }, 1);
+    assert.ok(runtime.buildTransientMessage({ turnNumber: 3 }));
+    assert.equal(runtime.buildTransientMessage({ turnNumber: 4 }), null);
+
+    runtime.applyRouterPayload({
+      action: 'activate',
+      mode: 'coding-agent',
+      confidence: 0.95,
+      reason: 'coding task again',
+    }, 4);
+    assert.ok(runtime.buildTransientMessage({ turnNumber: 4 }));
+    runtime.applyRouterPayload({
+      action: 'clear',
+      confidence: 0.95,
+      reason: 'topic changed',
+    }, 4);
+    assert.equal(runtime.buildTransientMessage({ turnNumber: 4 }), null);
+  });
+});

--- a/tests/prompt-modes.test.ts
+++ b/tests/prompt-modes.test.ts
@@ -167,4 +167,47 @@ describe('prompt modes', () => {
       && message.content.startsWith(TRANSIENT_PROMPT_MODES_LIST_PREFIX)
     )), false);
   });
+
+  test('prompt mode routing suppresses selectable mode list but not fixed mode notice', async () => {
+    const builder = new TurnContextBuilder();
+    const routed = await builder.build({
+      sessionKey: 'cli',
+      durableMessages: [
+        { role: 'system', content: 'base system' },
+        { role: 'user', content: 'debug this build' },
+      ],
+      runtimeFeedback: [],
+      skillRuntime: {
+        reloadSkills: async () => {},
+        buildSkillsListMessage: () => undefined,
+      } as any,
+      promptModeRoutingEnabled: true,
+    });
+
+    assert.equal(routed.messages.some(message => (
+      message.role === 'system'
+      && typeof message.content === 'string'
+      && message.content.startsWith(TRANSIENT_PROMPT_MODES_LIST_PREFIX)
+    )), false);
+
+    const fixed = await builder.build({
+      sessionKey: 'cli',
+      durableMessages: [
+        { role: 'system', content: 'base system\n[mode:coding-agent]\nfixed coding instructions' },
+        { role: 'user', content: 'debug this build' },
+      ],
+      runtimeFeedback: [],
+      skillRuntime: {
+        reloadSkills: async () => {},
+        buildSkillsListMessage: () => undefined,
+      } as any,
+      promptModeRoutingEnabled: true,
+    });
+
+    assert.equal(fixed.messages.some(message => (
+      message.role === 'system'
+      && typeof message.content === 'string'
+      && message.content.startsWith(TRANSIENT_FIXED_PROMPT_MODE_PREFIX)
+    )), true);
+  });
 });


### PR DESCRIPTION
﻿## Summary

- adds an async prompt mode router sidecar that classifies `activate` / `clear` / `ignore` outside the main agent
- tracks active prompt mode in session runtime and injects the full mode prompt as transient system context
- suppresses the selectable mode list while async routing is enabled, while keeping fixed mode highest priority
- keeps `prompt_mode` as a compatibility/manual entrypoint

This PR is stacked on #138 (`codex/prompt-stack-transient-guidance`) and intentionally does not include #143 short visible reply guidance.

## Validation

- `npm run build`
- `node --import tsx --test tests\prompt-mode-runtime.test.ts tests\mode-router-branch.test.ts tests\conversation-runner-runtime-transient.test.ts tests\agent-turn-mode-router.test.ts tests\prompt-modes.test.ts tests\conversation-runner-synthetic-observation.test.ts tests\agent-turn-memory-carryover.test.ts`
- `npm run test:runtime` was run; mode-router tests passed, but the suite still reports the existing Windows temp cleanup `EPERM` in `tests\weixin-session-expiry.test.ts`
- manual desktop smoke: a TypeScript build request started `prompt-mode-router`, called `finish_prompt_mode_routing` with `activate coding-agent`, and injected active mode before the next provider call in the same turn
