### PR TITLE
[codex] add visible progress sidecar

### DIFF
--- a/src/core/agent-turn-controller.ts
+++ b/src/core/agent-turn-controller.ts
@@ -22,7 +22,7 @@ import { SkillManager } from '../skills/skill-manager';
 import { SessionSkillRuntime } from '../skills/session-skill-runtime';
 import { Logger } from '../utils/logger';
 import { Metrics } from '../utils/metrics';
-import { ConversationRunner, RunnerCallbacks, PendingUserInputProvider } from './conversation-runner';
+import { ConversationRunner, RunnerCallbacks, PendingUserInputProvider, VisibleProgressEventSink } from './conversation-runner';
 import { resolveSessionSurface } from './session-surface';
 import { TurnContextBuilder } from './turn-context-builder';
 import { TurnLogRecorder } from './turn-log-recorder';
@@ -42,6 +42,7 @@ import { ModeRouterSidecarBranchHandle, startModeRouterSidecarBranch } from './s
 import { isBranchAgentsEnabled } from './branch-agent-settings';
 import { PromptModeRuntime } from './prompt-mode-runtime';
 import { findFixedPromptModeState, listPromptModeDefinitions, FixedPromptModeState } from '../runtime/prompt-modes';
+import { VisibleProgressRuntime } from './visible-progress-runtime';
 
 export interface AgentTurnServices {
   aiService: AIService;
@@ -197,6 +198,14 @@ export class AgentTurnController {
       messages: params.messages,
       abortSignal: params.abortSignal,
     });
+    const visibleProgressRuntime = this.startVisibleProgressRuntimeIfEnabled({
+      branchAgentsEnabled,
+      input: params.input,
+      messages: params.messages,
+      callbacks: params.callbacks,
+      abortSignal: params.abortSignal,
+    });
+    visibleProgressRuntime?.recordEvent({ type: 'turn_started' });
 
     const runner = this.createRunner({
       channel: params.channel,
@@ -222,6 +231,9 @@ export class AgentTurnController {
         turnNumber,
         fixedMode,
       ),
+      visibleProgressEventSink: visibleProgressRuntime
+        ? event => visibleProgressRuntime.recordEvent(event)
+        : undefined,
       abortSignal: params.abortSignal,
       shouldContinue: params.shouldContinue,
     });
@@ -238,6 +250,7 @@ export class AgentTurnController {
       }
       throw error;
     } finally {
+      visibleProgressRuntime?.close(result ? 'turn_completed' : 'turn_failed');
       this.expireMemoryBranch(carryoverMemoryBranch, 'carryover_ttl_expired');
       this.expireModeRouterBranch(carryoverModeRouter, 'carryover_ttl_expired');
       if (result && currentMemoryBranch && this.shouldCarryMemoryBranch(currentMemoryBranch)) {
@@ -306,6 +319,7 @@ export class AgentTurnController {
     episodeId?: string;
     syntheticObservationProvider?: () => SyntheticObservation[];
     runtimeTransientProvider?: () => Message[];
+    visibleProgressEventSink?: VisibleProgressEventSink;
     abortSignal?: AbortSignal;
     shouldContinue: () => boolean;
   }): ConversationRunner {
@@ -319,6 +333,7 @@ export class AgentTurnController {
         syntheticObservationProvider: options.syntheticObservationProvider,
         runtimeTransientProvider: options.runtimeTransientProvider,
         episodeId: options.episodeId,
+        visibleProgressEventSink: options.visibleProgressEventSink,
         // AgentSession/ContextWindowManager compacts durable history before the turn.
         // Runner-level compaction can fold transient runtime feedback into summary.
         enableCompression: false,
@@ -418,6 +433,37 @@ export class AgentTurnController {
       slot.done = true;
     });
     return slot;
+  }
+
+  private startVisibleProgressRuntimeIfEnabled(options: {
+    branchAgentsEnabled: boolean;
+    input: string | ContentBlock[];
+    messages: Message[];
+    callbacks?: AgentTurnCallbacks;
+    abortSignal?: AbortSignal;
+  }): VisibleProgressRuntime | null {
+    if (!options.callbacks?.onThinking) {
+      return null;
+    }
+    if (!options.branchAgentsEnabled) {
+      return null;
+    }
+    if (process.env.XIAOBA_VISIBLE_PROGRESS_AGENT_ENABLED === 'false') {
+      return null;
+    }
+    if (!(this.options.services.aiService instanceof AIService)) {
+      return null;
+    }
+    return new VisibleProgressRuntime({
+      sessionKey: this.options.sessionKey,
+      input: options.input,
+      recentMessages: options.messages,
+      workingDirectory: this.options.getCurrentDirectory(),
+      aiService: this.options.services.aiService,
+      surface: resolveSessionSurface(this.options.sessionKey, this.options.sessionType),
+      signal: options.abortSignal,
+      onProgress: options.callbacks.onThinking,
+    });
   }
 
   private drainMemoryObservations(

--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -67,6 +67,7 @@ import {
   SyntheticObservation,
 } from './synthetic-observation';
 import { TRANSIENT_ACTIVE_PROMPT_MODE_PREFIX } from './prompt-mode-runtime';
+import { VisibleProgressEvent } from './visible-progress-types';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -177,6 +178,7 @@ function isPendingUserInput(value: string | ContentBlock[] | PendingUserInput): 
 
 export type SyntheticObservationProvider = () => SyntheticObservation[];
 export type RuntimeTransientProvider = () => Message[];
+export type VisibleProgressEventSink = (event: VisibleProgressEvent) => void;
 
 interface ToolExecutionRecord {
   toolCall: ToolCall;
@@ -207,6 +209,8 @@ export interface RunnerOptions {
   runtimeTransientProvider?: RuntimeTransientProvider;
   /** Internal id that ties all messages created by one externally visible user turn together. */
   episodeId?: string;
+  /** User-visible progress events consumed by a sidecar rewriter. */
+  visibleProgressEventSink?: VisibleProgressEventSink;
 }
 
 /**
@@ -229,6 +233,7 @@ export class ConversationRunner {
   private syntheticObservationProvider?: SyntheticObservationProvider;
   private runtimeTransientProvider?: RuntimeTransientProvider;
   private episodeId?: string;
+  private visibleProgressEventSink?: VisibleProgressEventSink;
 
   /** 截断字符串用于日志输出，避免日志过大 */
   private static truncateForLog(text: any, maxLen = 200): string {
@@ -254,6 +259,7 @@ export class ConversationRunner {
     this.syntheticObservationProvider = options?.syntheticObservationProvider;
     this.runtimeTransientProvider = options?.runtimeTransientProvider;
     this.episodeId = options?.episodeId;
+    this.visibleProgressEventSink = options?.visibleProgressEventSink;
     this.maxTurns = options?.maxTurns;
 
     this.maxPromptTokens = this.resolvePromptBudget(options?.maxContextTokens);
@@ -640,13 +646,20 @@ export class ConversationRunner {
           Logger.warning(`[${this.sessionLabel}Turn ${turns}] 已过滤工具前文本里的内部历史回放占位文本`);
         }
         Logger.info(`[${this.sessionLabel}Turn ${turns}] AI文本: ${ConversationRunner.truncateForLog(visiblePrelude, 300)}`);
-        const shouldSurfacePrelude = this.shouldSurfaceToolPrelude(visiblePrelude);
-        if (callbacks?.onAssistantText && shouldSurfacePrelude) {
-          await callbacks.onAssistantText(visiblePrelude);
-        } else if (!callbacks?.onAssistantText && callbacks?.onThinking && shouldSurfacePrelude) {
-          await callbacks.onThinking(visiblePrelude);
+        if (this.visibleProgressEventSink) {
+          this.emitVisibleProgressEvent({
+            type: 'model_prelude',
+            text: visiblePrelude,
+          });
         } else {
-          Logger.info(`[${this.sessionLabel}Turn ${turns}] 工具前文本已作为内部进度保留，未发送给用户`);
+          const shouldSurfacePrelude = this.shouldSurfaceToolPrelude(visiblePrelude);
+          if (callbacks?.onAssistantText && shouldSurfacePrelude) {
+            await callbacks.onAssistantText(visiblePrelude);
+          } else if (!callbacks?.onAssistantText && callbacks?.onThinking && shouldSurfacePrelude) {
+            await callbacks.onThinking(visiblePrelude);
+          } else {
+            Logger.info(`[${this.sessionLabel}Turn ${turns}] 工具前文本已作为内部进度保留，未发送给用户`);
+          }
         }
       }
       const toolNames = response.toolCalls.map(tc => tc.function.name).join(', ');
@@ -686,6 +699,11 @@ export class ConversationRunner {
             retryable: false,
           };
         } else {
+          this.emitVisibleProgressEvent({
+            type: 'tool_started',
+            toolName,
+            toolDescription: this.extractToolDescription(toolInput),
+          });
           callbacks?.onToolStart?.(toolName, toolUseId, toolInput);
           Logger.info(`[${this.sessionLabel}Turn ${turns}] 执行工具: ${toolName} | 参数: ${ConversationRunner.truncateForLog(toolCall.function.arguments, 500)}`);
           result = await this.executeToolWithRetry(
@@ -708,6 +726,16 @@ export class ConversationRunner {
         this.promptTraceLogger.recordToolResult(turns, toolCall, result, toolDuration);
         Logger.info(`[${this.sessionLabel}Turn ${turns}] 工具完成: ${toolName} | 耗时: ${toolDuration}ms | 结果: ${ConversationRunner.truncateForLog(result.content, 300)}`);
         if (toolWasExposed) {
+          this.emitVisibleProgressEvent({
+            type: 'tool_finished',
+            toolName,
+            ok: result.ok !== false && !result.errorCode,
+            errorCode: result.errorCode,
+            durationMs: toolDuration,
+            resultSummary: result.ok === false || result.errorCode
+              ? ConversationRunner.truncateForLog(contentToString(result.content), 180)
+              : undefined,
+          });
           callbacks?.onToolEnd?.(toolName, toolUseId, contentToString(result.content));
         }
 
@@ -1253,6 +1281,21 @@ export class ConversationRunner {
       Logger.warning(`[${this.sessionLabel}Turn ${turn}] runtime transient drain failed: ${error.message}`);
       return [];
     }
+  }
+
+  private emitVisibleProgressEvent(event: VisibleProgressEvent): void {
+    if (!this.visibleProgressEventSink) return;
+    try {
+      this.visibleProgressEventSink(event);
+    } catch (error: any) {
+      Logger.warning(`[${this.sessionLabel}] visible progress event failed: ${error.message}`);
+    }
+  }
+
+  private extractToolDescription(input: unknown): string | undefined {
+    if (!input || typeof input !== 'object') return undefined;
+    const value = (input as Record<string, unknown>).description;
+    return typeof value === 'string' ? value.replace(/\s+/g, ' ').trim() : undefined;
   }
 
   private isCurrentDirectoryHint(message: Message): boolean {

--- a/src/core/sidecar-visible-progress-branch.ts
+++ b/src/core/sidecar-visible-progress-branch.ts
@@ -1,0 +1,61 @@
+import { AIService } from '../utils/ai-service';
+import { Logger } from '../utils/logger';
+import { VisibleProgressSnapshot } from './visible-progress-types';
+import { VisibleProgressBranchSession } from './visible-progress-branch-session';
+import { VisibleProgressFinishPayload } from '../tools/visible-progress-tools';
+
+export interface VisibleProgressSidecarBranchOptions {
+  sessionKey: string;
+  snapshot: VisibleProgressSnapshot;
+  workingDirectory: string;
+  aiService: AIService;
+  signal?: AbortSignal;
+  logEnabled?: boolean;
+}
+
+export interface VisibleProgressSidecarBranchHandle {
+  cancel(): void;
+  done: Promise<VisibleProgressFinishPayload | null>;
+}
+
+export function startVisibleProgressSidecarBranch(
+  options: VisibleProgressSidecarBranchOptions,
+): VisibleProgressSidecarBranchHandle {
+  const controller = new AbortController();
+  const signal = linkAbortSignals(controller.signal, options.signal);
+  const session = new VisibleProgressBranchSession({
+    ...options,
+    signal,
+  });
+  const done = session.run().catch(error => {
+    if (isAbortError(error) || signal.aborted) return null;
+    Logger.warning(`[${options.sessionKey}] visible progress branch failed: ${error.message}`);
+    return null;
+  });
+
+  return {
+    cancel: () => {
+      controller.abort();
+      session.stop();
+    },
+    done,
+  };
+}
+
+function linkAbortSignals(...signals: Array<AbortSignal | undefined>): AbortSignal {
+  const controller = new AbortController();
+  const abort = () => controller.abort();
+  for (const signal of signals) {
+    if (!signal) continue;
+    if (signal.aborted) {
+      abort();
+      break;
+    }
+    signal.addEventListener('abort', abort, { once: true });
+  }
+  return controller.signal;
+}
+
+function isAbortError(error: any): boolean {
+  return error?.name === 'AbortError' || /aborted|aborterror|canceled|cancelled/i.test(String(error?.message || ''));
+}

--- a/src/core/visible-progress-branch-session.ts
+++ b/src/core/visible-progress-branch-session.ts
@@ -1,0 +1,155 @@
+import { randomUUID } from 'crypto';
+import { Message } from '../types';
+import { AIService } from '../utils/ai-service';
+import { Tool } from '../types/tool';
+import { BranchRunOutcome, BranchSession } from './branch-session';
+import {
+  FinishVisibleProgressTool,
+  VisibleProgressFinishPayload,
+} from '../tools/visible-progress-tools';
+import { VisibleProgressSnapshot } from './visible-progress-types';
+
+export interface VisibleProgressBranchSessionOptions {
+  sessionKey: string;
+  snapshot: VisibleProgressSnapshot;
+  workingDirectory: string;
+  aiService: AIService;
+  signal?: AbortSignal;
+  logEnabled?: boolean;
+}
+
+export class VisibleProgressBranchSession extends BranchSession {
+  private finishPayload: VisibleProgressFinishPayload | null = null;
+
+  constructor(private readonly progressOptions: VisibleProgressBranchSessionOptions) {
+    super({
+      id: `visible-progress-${Date.now().toString(36)}-${randomUUID().slice(0, 8)}`,
+      type: 'visible-progress',
+      aiService: progressOptions.aiService,
+      workingDirectory: progressOptions.workingDirectory,
+      signal: progressOptions.signal,
+      logEnabled: progressOptions.logEnabled,
+    });
+  }
+
+  async run(): Promise<VisibleProgressFinishPayload | null> {
+    try {
+      while (this.shouldContinue() && !this.finishPayload) {
+        const outcome = await this.runConversation();
+        if (this.finishPayload || !this.shouldContinue()) break;
+
+        this.handleStrayOutput(outcome);
+        this.messages.push(this.buildFinishReminderMessage());
+      }
+
+      if (!this.finishPayload || !this.shouldContinue()) {
+        this.logger.write('cancelled_or_no_finish', {
+          has_finish_payload: Boolean(this.finishPayload),
+        });
+        return null;
+      }
+
+      this.logger.write('finished', { ...this.finishPayload });
+      return this.finishPayload;
+    } catch (error: any) {
+      if (!this.isAbortError(error) && this.shouldContinue()) {
+        this.logFailure(error);
+      }
+      return null;
+    }
+  }
+
+  protected async buildInitialMessages(): Promise<Message[]> {
+    return [
+      {
+        role: 'system',
+        content: buildVisibleProgressSystemPrompt(),
+      },
+      {
+        role: 'user',
+        content: JSON.stringify(buildVisibleProgressUserPayload(this.progressOptions.snapshot), null, 2),
+      },
+    ];
+  }
+
+  protected buildTools(): Tool[] {
+    return [
+      new FinishVisibleProgressTool(payload => {
+        this.finishPayload = payload;
+      }),
+    ];
+  }
+
+  private buildFinishReminderMessage(): Message {
+    return {
+      role: 'user',
+      content: [
+        'Your previous response will not be sent to the user.',
+        'This branch can only finish by calling finish_visible_progress.',
+        'Use action:skip if no useful progress update should be shown.',
+      ].join(' '),
+    };
+  }
+
+  private handleStrayOutput(outcome: BranchRunOutcome): void {
+    const strayOutput = String(outcome.result?.response || '').trim();
+    if (strayOutput) {
+      this.logger.write('stray_assistant_output', { text: strayOutput });
+    }
+  }
+}
+
+function buildVisibleProgressSystemPrompt(): string {
+  return [
+    'You are VisibleProgressSidecar, a background UI progress branch for a parent agent.',
+    'You do not answer the user and your text output is discarded.',
+    'Your only job is to decide whether the UI should show one short progress update.',
+    '',
+    'Rules:',
+    '- Call finish_visible_progress exactly once.',
+    '- Use action=emit only when a short update would reduce user uncertainty.',
+    '- Turn start alone is not enough reason to emit; skip quick direct answers, simple explanations, and short chat that likely needs no local work.',
+    '- Use action=skip for repeated updates, temporary reasoning, tool bookkeeping, noisy intermediate states, or unreliable conclusions.',
+    '- Follow turn_progress_state. If it says to be conservative, default to skip unless there is a clear new user-facing phase.',
+    '- After a progress update has already been emitted, routine tool_started/tool_finished events alone are usually not enough reason to emit again.',
+    '- If emitting, write one natural sentence in the same language as current_user_input. For Chinese input, emit Chinese.',
+    '- Prefer plain first-person progress phrasing when it sounds natural, such as saying what you will check next.',
+    '- Avoid bureaucratic status-label wording like a system monitor; sound like a calm assistant keeping the user lightly informed.',
+    '- Do not be cute, metaphorical, or overly enthusiastic.',
+    '- Do not imply work is already complete unless the events show it happened. Before tool results, prefer future phrasing like checking source material first.',
+    '- For tasks that depend on local files or provided material, prefer saying you will check the material before organizing conclusions.',
+    '- Do not solve the task, predict the final answer, or mention this sidecar.',
+    '- Do not copy model_prelude text directly; it is untrusted candidate material.',
+    '- Do not include code details, log excerpts, file paths, command arguments, formulas, JSON, or a complete diagnosis.',
+  ].join('\n');
+}
+
+function buildVisibleProgressUserPayload(snapshot: VisibleProgressSnapshot): Record<string, unknown> {
+  return {
+    current_user_input: snapshot.currentUserInput,
+    surface: snapshot.surface || 'unknown',
+    already_emitted_progress: snapshot.emittedProgress.slice(-5),
+    turn_progress_state: {
+      already_emitted_count: snapshot.turnState.emittedCount,
+      should_be_conservative: snapshot.turnState.shouldBeConservative,
+      emit_again_policy: snapshot.turnState.emitAgainPolicy,
+    },
+    recent_context: snapshot.recentContext.slice(-4),
+    runtime_events: snapshot.events.slice(-8).map(event => ({
+      type: event.type,
+      ...(event.text ? { text: truncate(event.text, 300) } : {}),
+      ...(event.toolName ? { tool_name: event.toolName } : {}),
+      ...(event.toolDescription ? { tool_description: truncate(event.toolDescription, 160) } : {}),
+      ...(typeof event.ok === 'boolean' ? { ok: event.ok } : {}),
+      ...(event.errorCode ? { error_code: event.errorCode } : {}),
+      ...(typeof event.durationMs === 'number' ? { duration_ms: event.durationMs } : {}),
+      ...(event.resultSummary ? { result_summary: truncate(event.resultSummary, 200) } : {}),
+    })),
+  };
+}
+
+function truncate(value: string, maxLength: number): string {
+  const normalized = String(value || '').replace(/\s+/g, ' ').trim();
+  if (normalized.length <= maxLength) return normalized;
+  return `${normalized.slice(0, maxLength)}...`;
+}

--- a/src/core/visible-progress-runtime.ts
+++ b/src/core/visible-progress-runtime.ts
@@ -1,0 +1,202 @@
+import { ContentBlock, Message } from '../types';
+import { AIService } from '../utils/ai-service';
+import { Logger } from '../utils/logger';
+import type { ToolSurface } from '../types/tool';
+import {
+  VisibleProgressEvent,
+  VisibleProgressRecentContextItem,
+  VisibleProgressSnapshot,
+  VisibleProgressTurnState,
+} from './visible-progress-types';
+import {
+  startVisibleProgressSidecarBranch,
+  VisibleProgressSidecarBranchHandle,
+} from './sidecar-visible-progress-branch';
+import { VisibleProgressFinishPayload } from '../tools/visible-progress-tools';
+
+export interface VisibleProgressRuntimeOptions {
+  sessionKey: string;
+  input: string | ContentBlock[];
+  recentMessages: Message[];
+  workingDirectory: string;
+  aiService: AIService;
+  surface?: ToolSurface;
+  signal?: AbortSignal;
+  logEnabled?: boolean;
+  maxSidecarRuns?: number;
+  onProgress: (text: string) => void | Promise<void>;
+}
+
+export class VisibleProgressRuntime {
+  private readonly events: VisibleProgressEvent[] = [];
+  private readonly emittedProgress: string[] = [];
+  private readonly maxSidecarRuns: number;
+  private active: VisibleProgressSidecarBranchHandle | null = null;
+  private dirty = false;
+  private closed = false;
+  private runCount = 0;
+
+  constructor(private readonly options: VisibleProgressRuntimeOptions) {
+    this.maxSidecarRuns = Math.max(1, options.maxSidecarRuns ?? 3);
+  }
+
+  recordEvent(event: VisibleProgressEvent): void {
+    if (this.closed) return;
+    this.events.push({
+      ...event,
+      timestamp: event.timestamp || new Date().toISOString(),
+    });
+    while (this.events.length > 20) this.events.shift();
+
+    if (this.active) {
+      this.dirty = true;
+      return;
+    }
+    this.startSidecar();
+  }
+
+  close(reason = 'turn_closed'): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.active?.cancel();
+    this.active = null;
+    Logger.info(`[${this.options.sessionKey}] visible progress runtime closed: ${reason}`);
+  }
+
+  async waitForIdle(timeoutMs = 2000): Promise<void> {
+    const started = Date.now();
+    while (this.active || this.dirty) {
+      if (Date.now() - started > timeoutMs) {
+        throw new Error('visible progress runtime did not become idle before timeout');
+      }
+      const active = this.active;
+      if (active) {
+        await active.done.catch(() => null);
+      } else {
+        await new Promise(resolve => setTimeout(resolve, 0));
+      }
+    }
+  }
+
+  private startSidecar(): void {
+    if (this.closed || this.active || this.runCount >= this.maxSidecarRuns) return;
+    this.runCount++;
+    this.dirty = false;
+
+    const handle = startVisibleProgressSidecarBranch({
+      sessionKey: this.options.sessionKey,
+      snapshot: this.buildSnapshot(),
+      workingDirectory: this.options.workingDirectory,
+      aiService: this.options.aiService,
+      signal: this.options.signal,
+      logEnabled: this.options.logEnabled,
+    });
+    this.active = handle;
+
+    handle.done
+      .then(payload => this.handlePayload(payload))
+      .catch(error => {
+        if (!this.closed) {
+          Logger.warning(`[${this.options.sessionKey}] visible progress branch failed: ${error.message}`);
+        }
+      })
+      .finally(() => {
+        if (this.active === handle) {
+          this.active = null;
+        }
+        if (!this.closed && this.dirty && this.runCount < this.maxSidecarRuns) {
+          this.startSidecar();
+        } else if (this.runCount >= this.maxSidecarRuns) {
+          this.dirty = false;
+        }
+      });
+  }
+
+  private async handlePayload(payload: VisibleProgressFinishPayload | null): Promise<void> {
+    if (this.closed || !payload || payload.action !== 'emit') return;
+    const text = sanitizeProgressText(payload.text);
+    if (!text || this.emittedProgress.includes(text)) return;
+
+    this.emittedProgress.push(text);
+    while (this.emittedProgress.length > 5) this.emittedProgress.shift();
+
+    try {
+      await this.options.onProgress(text);
+      Logger.info(`[${this.options.sessionKey}] visible progress emitted: ${text}`);
+    } catch (error: any) {
+      Logger.warning(`[${this.options.sessionKey}] visible progress send failed: ${error.message}`);
+    }
+  }
+
+  private buildSnapshot(): VisibleProgressSnapshot {
+    return {
+      currentUserInput: contentToText(this.options.input),
+      surface: this.options.surface,
+      recentContext: extractRecentContext(this.options.recentMessages),
+      emittedProgress: [...this.emittedProgress],
+      turnState: buildTurnState(this.emittedProgress.length),
+      events: this.events.slice(-8),
+    };
+  }
+}
+
+function buildTurnState(emittedCount: number): VisibleProgressTurnState {
+  if (emittedCount === 0) {
+    return {
+      emittedCount,
+      shouldBeConservative: false,
+      emitAgainPolicy: [
+        'No progress update has been shown yet this turn.',
+        'Turn start alone is not enough reason to emit.',
+        'Skip for quick direct answers or short chat that likely needs no local work and no long wait.',
+        'Emit only when a short update helps the user understand that visible work is starting.',
+      ].join(' '),
+    };
+  }
+
+  return {
+    emittedCount,
+    shouldBeConservative: true,
+    emitAgainPolicy: [
+      'A progress update has already been shown this turn.',
+      'Default to skip routine tool start/end events, repeated planning, or restating the same intent.',
+      'Emit again only for a clear new phase such as moving to verification, retrying after failure, or a meaningfully long wait.',
+    ].join(' '),
+  };
+}
+
+function sanitizeProgressText(value: unknown): string {
+  const text = String(value || '').replace(/\s+/g, ' ').trim();
+  if (!text) return '';
+  return text.length <= 160 ? text : `${text.slice(0, 160)}...`;
+}
+
+function extractRecentContext(messages: Message[]): VisibleProgressRecentContextItem[] {
+  return messages
+    .filter(message => (
+      (message.role === 'user' || message.role === 'assistant')
+      && !message.__injected
+      && !message.__runtimeFeedback
+      && !message.__syntheticObservation
+      && !message.__runtimeObservation
+    ))
+    .slice(-4)
+    .map(message => ({
+      role: message.role,
+      content: truncate(contentToText(message.content), 300),
+    }))
+    .filter(item => item.content.length > 0);
+}
+
+function contentToText(content: string | ContentBlock[] | null): string {
+  if (!content) return '';
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  return content.map(block => block.type === 'text' ? block.text : '[image]').join('\n');
+}
+
+function truncate(value: string, maxLength: number): string {
+  const normalized = String(value || '').replace(/\s+/g, ' ').trim();
+  if (normalized.length <= maxLength) return normalized;
+  return `${normalized.slice(0, maxLength)}...`;
+}

--- a/src/core/visible-progress-types.ts
+++ b/src/core/visible-progress-types.ts
@@ -1,0 +1,41 @@
+import type { ToolSurface } from '../types/tool';
+
+export type VisibleProgressEventType =
+  | 'turn_started'
+  | 'model_prelude'
+  | 'tool_started'
+  | 'tool_finished'
+  | 'runtime_status'
+  | 'retry';
+
+export interface VisibleProgressEvent {
+  type: VisibleProgressEventType;
+  text?: string;
+  toolName?: string;
+  toolDescription?: string;
+  ok?: boolean;
+  errorCode?: string;
+  durationMs?: number;
+  resultSummary?: string;
+  timestamp?: string;
+}
+
+export interface VisibleProgressRecentContextItem {
+  role: string;
+  content: string;
+}
+
+export interface VisibleProgressTurnState {
+  emittedCount: number;
+  shouldBeConservative: boolean;
+  emitAgainPolicy: string;
+}
+
+export interface VisibleProgressSnapshot {
+  currentUserInput: string;
+  surface?: ToolSurface;
+  recentContext: VisibleProgressRecentContextItem[];
+  emittedProgress: string[];
+  turnState: VisibleProgressTurnState;
+  events: VisibleProgressEvent[];
+}

--- a/src/tools/local-tool-risk.ts
+++ b/src/tools/local-tool-risk.ts
@@ -27,6 +27,7 @@ const LOW_RISK_TOOLS = new Set([
   'memory_neighbors',
   'finish_memory_search',
   'finish_prompt_mode_routing',
+  'finish_visible_progress',
 ]);
 
 const CONFIRM_TOOLS = new Set([

--- a/src/tools/visible-progress-tools.ts
+++ b/src/tools/visible-progress-tools.ts
@@ -1,0 +1,97 @@
+import { Tool, ToolDefinition, ToolExecutionResult } from '../types/tool';
+
+export type VisibleProgressAction = 'emit' | 'skip';
+
+export interface VisibleProgressFinishPayload {
+  action: VisibleProgressAction;
+  text?: string;
+  reason: string;
+}
+
+export type VisibleProgressFinishHandler = (payload: VisibleProgressFinishPayload) => void;
+
+const VISIBLE_PROGRESS_ACTIONS = new Set<VisibleProgressAction>(['emit', 'skip']);
+
+export class FinishVisibleProgressTool implements Tool {
+  definition: ToolDefinition = {
+    name: 'finish_visible_progress',
+    description: [
+      'Finish visible progress routing for the parent agent.',
+      'This branch does not answer the user. It only decides whether a short user-visible progress update should be emitted.',
+      'Call this exactly once with action emit or skip.',
+    ].join(' '),
+    controlMode: 'pause_turn',
+    parameters: {
+      type: 'object',
+      properties: {
+        action: {
+          type: 'string',
+          enum: ['emit', 'skip'],
+          description: 'emit a short progress update, or skip without showing anything.',
+        },
+        text: {
+          type: 'string',
+          description: 'Short user-visible progress text when action is emit. Leave empty for skip.',
+        },
+        reason: {
+          type: 'string',
+          description: 'Short reason for logs and diagnostics.',
+        },
+      },
+      required: ['action', 'reason'],
+    },
+  };
+
+  constructor(private readonly onFinish: VisibleProgressFinishHandler) {}
+
+  async execute(args: any): Promise<ToolExecutionResult> {
+    const validation = validateVisibleProgressFinishArgs(args);
+    if (!validation.ok) {
+      return {
+        ok: false,
+        errorCode: 'INVALID_TOOL_ARGUMENTS',
+        message: validation.error,
+        retryable: false,
+      };
+    }
+
+    this.onFinish(validation.payload);
+    return {
+      ok: true,
+      content: JSON.stringify({ ok: true }),
+    };
+  }
+}
+
+export function validateVisibleProgressFinishArgs(args: any):
+  | { ok: true; payload: VisibleProgressFinishPayload }
+  | { ok: false; error: string } {
+  const rawAction = String(args?.action || '').trim();
+  if (!VISIBLE_PROGRESS_ACTIONS.has(rawAction as VisibleProgressAction)) {
+    return { ok: false, error: 'action must be emit or skip' };
+  }
+  const action = rawAction as VisibleProgressAction;
+
+  const reason = normalizeText(args?.reason);
+  if (!reason) {
+    return { ok: false, error: 'reason must be a non-empty string' };
+  }
+
+  const text = normalizeText(args?.text);
+  if (action === 'emit' && !text) {
+    return { ok: false, error: 'text is required when action is emit' };
+  }
+
+  return {
+    ok: true,
+    payload: {
+      action,
+      ...(text ? { text } : {}),
+      reason,
+    },
+  };
+}
+
+function normalizeText(value: unknown): string {
+  return String(value || '').replace(/\s+/g, ' ').trim();
+}

--- a/tests/conversation-runner-visible-progress.test.ts
+++ b/tests/conversation-runner-visible-progress.test.ts
@@ -1,0 +1,118 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert/strict';
+import { ConversationRunner } from '../src/core/conversation-runner';
+import { ChatResponse, Message } from '../src/types';
+import { ToolCall, ToolDefinition, ToolExecutor, ToolResult } from '../src/types/tool';
+import { VisibleProgressEvent } from '../src/core/visible-progress-types';
+
+const usage = { promptTokens: 1, completionTokens: 1, totalTokens: 2 };
+
+function makeToolCall(id: string): ToolCall {
+  return {
+    id,
+    type: 'function',
+    function: {
+      name: 'noop',
+      arguments: JSON.stringify({ description: '??????' }),
+    },
+  };
+}
+
+class NoopToolExecutor implements ToolExecutor {
+  getToolDefinitions(): ToolDefinition[] {
+    return [{
+      name: 'noop',
+      description: 'noop',
+      parameters: {
+        type: 'object',
+        properties: {
+          description: { type: 'string' },
+        },
+      },
+    }];
+  }
+
+  async executeTool(toolCall: ToolCall): Promise<ToolResult> {
+    return {
+      tool_call_id: toolCall.id,
+      role: 'tool',
+      name: toolCall.function.name,
+      content: 'ok',
+      ok: true,
+    };
+  }
+}
+
+describe('ConversationRunner visible progress events', () => {
+  test('sends pre-tool assistant content to progress sink instead of onThinking', async () => {
+    const rawPrelude = '?? bug ??`coupon.value` ??????subtotal 250 ? 0.8 = 200?';
+    const responses: ChatResponse[] = [
+      {
+        content: rawPrelude,
+        toolCalls: [makeToolCall('call_1')],
+        usage,
+      },
+      {
+        content: 'done',
+        toolCalls: [],
+        usage,
+      },
+    ];
+    const aiService = {
+      chat: async (): Promise<ChatResponse> => responses.shift()!,
+    } as any;
+    const thinking: string[] = [];
+    const events: VisibleProgressEvent[] = [];
+    const toolStarts: string[] = [];
+    const toolEnds: string[] = [];
+    const runner = new ConversationRunner(aiService, new NoopToolExecutor(), {
+      stream: false,
+      enableCompression: false,
+      visibleProgressEventSink: event => events.push(event),
+    });
+
+    await runner.run([{ role: 'user', content: 'fix it' } as Message], {
+      onThinking: text => thinking.push(text),
+      onToolStart: name => toolStarts.push(name),
+      onToolEnd: name => toolEnds.push(name),
+    });
+
+    assert.deepEqual(thinking, []);
+    assert.equal(events[0].type, 'model_prelude');
+    assert.equal(events[0].text, rawPrelude);
+    assert.equal(events.some(event => event.type === 'tool_started' && event.toolName === 'noop'), true);
+    assert.equal(events.some(event => event.type === 'tool_finished' && event.toolName === 'noop'), true);
+    assert.deepEqual(toolStarts, ['noop']);
+    assert.deepEqual(toolEnds, ['noop']);
+  });
+
+  test('falls back to existing prelude policy when no progress sink exists', async () => {
+    const rawPrelude = '??????????';
+    const responses: ChatResponse[] = [
+      {
+        content: rawPrelude,
+        toolCalls: [makeToolCall('call_1')],
+        usage,
+      },
+      {
+        content: 'done',
+        toolCalls: [],
+        usage,
+      },
+    ];
+    const aiService = {
+      chat: async (): Promise<ChatResponse> => responses.shift()!,
+    } as any;
+    const thinking: string[] = [];
+    const runner = new ConversationRunner(aiService, new NoopToolExecutor(), {
+      stream: false,
+      enableCompression: false,
+    });
+
+    await runner.run([{ role: 'user', content: 'fix it' } as Message], {
+      onThinking: text => thinking.push(text),
+    });
+
+    assert.deepEqual(thinking, []);
+  });
+});

--- a/tests/visible-progress-sidecar.test.ts
+++ b/tests/visible-progress-sidecar.test.ts
@@ -1,0 +1,198 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert/strict';
+import { ChatResponse, Message } from '../src/types';
+import { ToolCall, ToolDefinition } from '../src/types/tool';
+import { VisibleProgressBranchSession } from '../src/core/visible-progress-branch-session';
+import { VisibleProgressRuntime } from '../src/core/visible-progress-runtime';
+import { VisibleProgressFinishPayload } from '../src/tools/visible-progress-tools';
+
+const usage = { promptTokens: 1, completionTokens: 1, totalTokens: 2 };
+const initialTurnState = {
+  emittedCount: 0,
+  shouldBeConservative: false,
+  emitAgainPolicy: 'No progress has been emitted yet.',
+};
+
+function makeToolCall(id: string, args: unknown): ToolCall {
+  return {
+    id,
+    type: 'function',
+    function: {
+      name: 'finish_visible_progress',
+      arguments: JSON.stringify(args),
+    },
+  };
+}
+
+class VisibleProgressAI {
+  calls: Message[][] = [];
+
+  constructor(private readonly nextPayload: () => Promise<VisibleProgressFinishPayload> | VisibleProgressFinishPayload) {}
+
+  async chat(messages: Message[], tools?: ToolDefinition[]): Promise<ChatResponse> {
+    this.calls.push(JSON.parse(JSON.stringify(messages)));
+    assert.equal(tools?.map(tool => tool.name).join(','), 'finish_visible_progress');
+    const payload = await this.nextPayload();
+    return {
+      content: null,
+      toolCalls: [makeToolCall('finish_1', payload)],
+      usage,
+    };
+  }
+
+  async chatStream(messages: Message[], tools?: ToolDefinition[]): Promise<ChatResponse> {
+    return this.chat(messages, tools);
+  }
+}
+
+describe('visible progress sidecar', () => {
+  test('branch returns an emit payload from finish_visible_progress', async () => {
+    const aiService = new VisibleProgressAI(() => ({
+      action: 'emit',
+      text: '?????????????',
+      reason: 'useful_progress',
+    }));
+    const session = new VisibleProgressBranchSession({
+      sessionKey: 'visible-progress-branch-test',
+      snapshot: {
+        currentUserInput: '??????????',
+        surface: 'cli',
+        recentContext: [],
+        emittedProgress: [],
+        turnState: initialTurnState,
+        events: [
+          {
+            type: 'model_prelude',
+            text: '?? bug ??`coupon.value` ??????subtotal 250 ? 0.8 = 200?',
+          },
+        ],
+      },
+      workingDirectory: process.cwd(),
+      aiService: aiService as any,
+      logEnabled: false,
+    });
+
+    const payload = await session.run();
+
+    assert.deepEqual(payload, {
+      action: 'emit',
+      text: '?????????????',
+      reason: 'useful_progress',
+    });
+    assert.match(String(aiService.calls[0][1].content), /model_prelude/);
+  });
+
+  test('runtime emits sidecar progress and skips skip payloads', async () => {
+    const emitted: string[] = [];
+    const runtime = new VisibleProgressRuntime({
+      sessionKey: 'visible-progress-runtime-test',
+      input: '???? build ??',
+      recentMessages: [],
+      workingDirectory: process.cwd(),
+      surface: 'cli',
+      aiService: new VisibleProgressAI(() => ({
+        action: 'emit',
+        text: '??????????????',
+        reason: 'turn_start',
+      })) as any,
+      logEnabled: false,
+      onProgress: text => emitted.push(text),
+    });
+
+    runtime.recordEvent({ type: 'turn_started' });
+    await runtime.waitForIdle();
+
+    assert.deepEqual(emitted, ['??????????????']);
+
+    const skipped: string[] = [];
+    const skipRuntime = new VisibleProgressRuntime({
+      sessionKey: 'visible-progress-runtime-skip-test',
+      input: '???? build ??',
+      recentMessages: [],
+      workingDirectory: process.cwd(),
+      surface: 'cli',
+      aiService: new VisibleProgressAI(() => ({
+        action: 'skip',
+        reason: 'tool_bookkeeping',
+      })) as any,
+      logEnabled: false,
+      onProgress: text => skipped.push(text),
+    });
+
+    skipRuntime.recordEvent({ type: 'model_prelude', text: '??????' });
+    await skipRuntime.waitForIdle();
+
+    assert.deepEqual(skipped, []);
+  });
+
+  test('runtime marks later snapshots conservative after emitting progress', async () => {
+    const emitted: string[] = [];
+    const payloads: VisibleProgressFinishPayload[] = [
+      {
+        action: 'emit',
+        text: 'I will check the failing output first.',
+        reason: 'turn_start',
+      },
+      {
+        action: 'skip',
+        reason: 'already_updated',
+      },
+    ];
+    const aiService = new VisibleProgressAI(() => payloads.shift()!);
+    const runtime = new VisibleProgressRuntime({
+      sessionKey: 'visible-progress-runtime-budget-test',
+      input: 'debug build failure',
+      recentMessages: [],
+      workingDirectory: process.cwd(),
+      surface: 'cli',
+      aiService: aiService as any,
+      logEnabled: false,
+      onProgress: text => emitted.push(text),
+    });
+
+    runtime.recordEvent({ type: 'turn_started' });
+    await runtime.waitForIdle();
+    runtime.recordEvent({ type: 'tool_started', toolName: 'read_file' });
+    await runtime.waitForIdle();
+
+    assert.deepEqual(emitted, ['I will check the failing output first.']);
+    assert.equal(aiService.calls.length, 2);
+
+    const firstPayload = JSON.parse(String(aiService.calls[0][1].content));
+    const secondPayload = JSON.parse(String(aiService.calls[1][1].content));
+    assert.equal(firstPayload.turn_progress_state.should_be_conservative, false);
+    assert.match(firstPayload.turn_progress_state.emit_again_policy, /Skip for quick direct answers/);
+    assert.equal(secondPayload.turn_progress_state.should_be_conservative, true);
+    assert.equal(secondPayload.turn_progress_state.already_emitted_count, 1);
+    assert.match(secondPayload.turn_progress_state.emit_again_policy, /Default to skip/);
+  });
+
+  test('runtime drops late sidecar results after close', async () => {
+    const emitted: string[] = [];
+    let resolvePayload!: (payload: VisibleProgressFinishPayload) => void;
+    const payloadPromise = new Promise<VisibleProgressFinishPayload>(resolve => {
+      resolvePayload = resolve;
+    });
+    const runtime = new VisibleProgressRuntime({
+      sessionKey: 'visible-progress-runtime-late-test',
+      input: '?????',
+      recentMessages: [],
+      workingDirectory: process.cwd(),
+      surface: 'cli',
+      aiService: new VisibleProgressAI(() => payloadPromise) as any,
+      logEnabled: false,
+      onProgress: text => emitted.push(text),
+    });
+
+    runtime.recordEvent({ type: 'model_prelude', text: '?????????????' });
+    runtime.close('test_finished');
+    resolvePayload({
+      action: 'emit',
+      text: '????????????',
+      reason: 'late',
+    });
+    await new Promise(resolve => setTimeout(resolve, 20));
+
+    assert.deepEqual(emitted, []);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a visible-progress sidecar that rewrites or suppresses user-visible pre-tool progress text asynchronously.

## Why

The previous flow showed the main model's raw pre-tool content directly through `onThinking`. That content can expose intermediate diagnoses, command details, paths, or noisy half-formed reasoning. This PR moves visible progress wording into a small background branch that only decides whether to emit one short UI progress sentence.

## Changes

- Add `VisibleProgressRuntime`, `VisibleProgressBranchSession`, and `finish_visible_progress`.
- Start the runtime per turn when `onThinking`, branch agents, and `AIService` are available.
- Send `model_prelude`, `tool_started`, and `tool_finished` event snapshots to the sidecar instead of showing raw pre-tool content directly.
- Keep runtime status hints and tool cards unchanged.
- Drop late/failed sidecar results without falling back to raw model prelude text.
- Add turn-level progress budgeting so simple direct answers stay quiet and repeated tool bookkeeping usually skips.

## Validation

- `node --import tsx --test tests\visible-progress-sidecar.test.ts tests\conversation-runner-visible-progress.test.ts tests\agent-turn-controller-callbacks.test.ts`
- `npm run build`
- `git diff --check`

Note: `npm ci` in the clean worktree reported existing dependency audit/engine warnings, but install, tests, and build completed.