### PR TITLE
修复微信消息发送确认

### DIFF
--- a/src/weixin/index.ts
+++ b/src/weixin/index.ts
@@ -128,16 +128,16 @@ export class WeixinBot {
     }
   }
 
-  private buildChannel(chatId: string, sessionKey: string, userId: string): ChannelCallbacks {
+  private buildChannel(chatId: string, sessionKey: string, userId: string, botUserId?: string): ChannelCallbacks {
     return {
       chatId,
       reply: async (cid: string, text: string) => {
         const contextToken = this.contextTokens.get(sessionKey) || this.contextTokens.get(`user:${userId}`);
-        await this.sender.sendText(userId, text, contextToken);
+        await this.sender.sendText(userId, text, contextToken, botUserId);
       },
       sendFile: async (cid: string, filePath: string, fileName: string) => {
         const contextToken = this.contextTokens.get(sessionKey) || this.contextTokens.get(`user:${userId}`);
-        await this.sender.sendFile(userId, filePath, fileName, contextToken);
+        await this.sender.sendFile(userId, filePath, fileName, contextToken, botUserId);
       },
     };
   }
@@ -224,7 +224,7 @@ export class WeixinBot {
     }
 
     const session = this.sessionManager.getOrCreate(route);
-    const channel = this.buildChannel(route.topicId, sessionKey, userId);
+    const channel = this.buildChannel(route.topicId, sessionKey, userId, parsed.chat?.id);
     SubAgentManager.getInstance().registerPlatformCallbacks(sessionKey, {
       injectMessage: async (text: string) => {
         await this.handleSubAgentFeedback(sessionKey, route.topicId, userId, text, route);

--- a/src/weixin/message-sender.ts
+++ b/src/weixin/message-sender.ts
@@ -3,6 +3,7 @@ import crypto from 'crypto';
 import { promises as fs } from 'fs';
 import path from 'path';
 import { uploadBufferToCDN, aesECBPaddedSize } from './cdn';
+import { Logger } from '../utils/logger';
 
 const CHANNEL_VERSION = 'xiaoba-weixin/1.0';
 
@@ -15,6 +16,105 @@ function md5Hex(buffer: Buffer): string {
   return crypto.createHash('md5').update(buffer).digest('hex');
 }
 
+function shortHash(value: string): string {
+  return crypto.createHash('sha256').update(value).digest('hex').slice(0, 12);
+}
+
+function maskUserId(value: string): string {
+  if (value.length <= 10) return value;
+  return `${value.slice(0, 6)}...${value.slice(-8)}`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function getResponseField(data: unknown, field: string): unknown {
+  if (!isRecord(data)) return undefined;
+  if (Object.prototype.hasOwnProperty.call(data, field)) return data[field];
+
+  for (const nestedKey of ['data', 'result', 'response']) {
+    const nested = data[nestedKey];
+    if (isRecord(nested) && Object.prototype.hasOwnProperty.call(nested, field)) {
+      return nested[field];
+    }
+  }
+
+  return undefined;
+}
+
+function isSuccessCode(value: unknown): boolean {
+  if (typeof value === 'number') return value === 0 || value === 200;
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    return normalized === '0' || normalized === '200' || normalized === 'ok' || normalized === 'success';
+  }
+  return true;
+}
+
+function summarizeResponse(data: unknown): string {
+  if (!isRecord(data)) return JSON.stringify(data) ?? String(data);
+
+  const summary: Record<string, unknown> = {};
+  for (const field of ['ret', 'errcode', 'errmsg', 'error_code', 'error_msg', 'code', 'message', 'msgid', 'request_id']) {
+    const value = getResponseField(data, field);
+    if (value !== undefined) summary[field] = value;
+  }
+
+  const safeBody = Object.keys(summary).length > 0
+    ? summary
+    : { keys: Object.keys(data).sort() };
+  const text = JSON.stringify(safeBody);
+  return text.length > 800 ? `${text.slice(0, 800)}...` : text;
+}
+
+function hasBusinessAcknowledgement(data: unknown): boolean {
+  if (!isRecord(data)) return false;
+  const fields = ['ret', 'errcode', 'error_code', 'code', 'status_code', 'success', 'status', 'msgid', 'message_id', 'request_id'];
+  return fields.some(field => getResponseField(data, field) !== undefined);
+}
+
+function assertWeixinBusinessOk(operation: string, data: unknown, options: { requireAck?: boolean } = {}): void {
+  if (data == null) {
+    if (options.requireAck) {
+      throw new Error(`微信 ${operation} 响应为空，缺少业务确认字段`);
+    }
+    Logger.warning(`[微信] ${operation} 响应为空，按 HTTP 成功处理`);
+    return;
+  }
+
+  if (options.requireAck && !hasBusinessAcknowledgement(data)) {
+    throw new Error(`微信 ${operation} 响应缺少业务确认字段: response=${summarizeResponse(data)}`);
+  }
+
+  if (!options.requireAck && !hasBusinessAcknowledgement(data)) {
+    Logger.warning(`[微信] ${operation} 响应缺少业务确认字段，已按 HTTP 成功处理: ${summarizeResponse(data)}`);
+    return;
+  }
+
+  const success = getResponseField(data, 'success');
+  if (success === false || success === 'false') {
+    throw new Error(`微信 ${operation} 业务失败: success=false, response=${summarizeResponse(data)}`);
+  }
+
+  for (const field of ['ret', 'errcode', 'error_code', 'code', 'status_code']) {
+    const value = getResponseField(data, field);
+    if (value !== undefined && !isSuccessCode(value)) {
+      throw new Error(`微信 ${operation} 业务失败: ${field}=${String(value)}, response=${summarizeResponse(data)}`);
+    }
+  }
+
+  const status = getResponseField(data, 'status');
+  if (typeof status === 'string') {
+    const normalized = status.trim().toLowerCase();
+    if (['fail', 'failed', 'failure', 'error', 'err'].includes(normalized)) {
+      throw new Error(`微信 ${operation} 业务失败: status=${status}, response=${summarizeResponse(data)}`);
+    }
+  }
+
+  Logger.info(`[微信] ${operation} 响应: ${summarizeResponse(data)}`);
+}
+
 export class MessageSender {
   constructor(
     private token: string,
@@ -22,18 +122,20 @@ export class MessageSender {
     private cdnBaseUrl: string
   ) {}
 
-  async sendText(to: string, text: string, contextToken?: string): Promise<void> {
+  async sendText(to: string, text: string, contextToken?: string, fromUserId?: string): Promise<void> {
     if (!contextToken) {
       throw new Error('context_token is required for sending messages');
     }
 
-    await axios.post(
+    const clientId = 'xiaoba-' + crypto.randomBytes(3).toString('hex');
+    Logger.info(`[微信] sendmessage:text 请求: from=${fromUserId ? maskUserId(fromUserId) : '-'}, to=${maskUserId(to)}, context=${shortHash(contextToken)}, client=${clientId}, chars=${text.length}`);
+    const response = await axios.post(
       `${this.baseUrl}/ilink/bot/sendmessage`,
       {
         msg: {
-          from_user_id: '',
+          from_user_id: fromUserId || '',
           to_user_id: to,
-          client_id: 'xiaoba-' + crypto.randomBytes(3).toString('hex'),
+          client_id: clientId,
           message_type: 2,
           message_state: 2,
           item_list: [{ type: 1, text_item: { text } }],
@@ -50,9 +152,10 @@ export class MessageSender {
         },
       }
     );
+    assertWeixinBusinessOk('sendmessage:text', response.data);
   }
 
-  async sendFile(to: string, filePath: string, fileName: string, contextToken?: string): Promise<void> {
+  async sendFile(to: string, filePath: string, fileName: string, contextToken?: string, fromUserId?: string): Promise<void> {
     if (!contextToken) {
       throw new Error('context_token is required for sending messages');
     }
@@ -90,7 +193,7 @@ export class MessageSender {
       }
     );
 
-    console.log('[DEBUG] 微信上传URL响应:', JSON.stringify(uploadResp.data));
+    assertWeixinBusinessOk('getuploadurl', uploadResp.data);
 
     let uploadParam: string;
     if (uploadResp.data.upload_param) {
@@ -138,13 +241,15 @@ export class MessageSender {
           },
         };
 
-    await axios.post(
+    const clientId = 'xiaoba-' + crypto.randomBytes(3).toString('hex');
+    Logger.info(`[微信] sendmessage:${isImage ? 'image' : 'file'} 请求: from=${fromUserId ? maskUserId(fromUserId) : '-'}, to=${maskUserId(to)}, context=${shortHash(contextToken)}, client=${clientId}, file=${fileName}, bytes=${rawsize}`);
+    const sendResp = await axios.post(
       `${this.baseUrl}/ilink/bot/sendmessage`,
       {
         msg: {
-          from_user_id: '',
+          from_user_id: fromUserId || '',
           to_user_id: to,
-          client_id: 'xiaoba-' + crypto.randomBytes(3).toString('hex'),
+          client_id: clientId,
           message_type: 2,
           message_state: 2,
           item_list: [messageItem],
@@ -161,5 +266,6 @@ export class MessageSender {
         },
       }
     );
+    assertWeixinBusinessOk(`sendmessage:${isImage ? 'image' : 'file'}`, sendResp.data);
   }
 }

--- a/tests/weixin-message-sender.test.ts
+++ b/tests/weixin-message-sender.test.ts
@@ -1,0 +1,70 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import axios from 'axios';
+import { MessageSender } from '../src/weixin/message-sender';
+
+describe('weixin message sender', () => {
+  test('treats HTTP 200 with successful business response as sent', async () => {
+    const originalPost = axios.post;
+    const calls: unknown[] = [];
+    (axios.post as any) = async (...args: unknown[]) => {
+      calls.push(args);
+      return { data: { errcode: 0, errmsg: 'ok' } };
+    };
+
+    try {
+      const sender = new MessageSender('token', 'https://weixin.example.test', 'https://cdn.example.test');
+      await sender.sendText('user-1', 'hello', 'ctx-1', 'bot-1');
+      assert.equal(calls.length, 1);
+      assert.equal((calls[0] as any[])[1].msg.from_user_id, 'bot-1');
+    } finally {
+      (axios.post as any) = originalPost;
+    }
+  });
+
+  test('rejects HTTP 200 when sendmessage business response fails', async () => {
+    const originalPost = axios.post;
+    (axios.post as any) = async () => ({
+      data: { errcode: 40003, errmsg: 'invalid context token' },
+    });
+
+    try {
+      const sender = new MessageSender('token', 'https://weixin.example.test', 'https://cdn.example.test');
+      await assert.rejects(
+        () => sender.sendText('user-1', 'hello', 'ctx-1'),
+        /微信 sendmessage:text 业务失败: errcode=40003/
+      );
+    } finally {
+      (axios.post as any) = originalPost;
+    }
+  });
+
+  test('allows HTTP 200 when sendmessage response has no acknowledgement fields', async () => {
+    const originalPost = axios.post;
+    (axios.post as any) = async () => ({ data: {} });
+
+    try {
+      const sender = new MessageSender('token', 'https://weixin.example.test', 'https://cdn.example.test');
+      await sender.sendText('user-1', 'hello', 'ctx-1', 'bot-1');
+    } finally {
+      (axios.post as any) = originalPost;
+    }
+  });
+
+  test('rejects HTTP 200 when success flag is false', async () => {
+    const originalPost = axios.post;
+    (axios.post as any) = async () => ({
+      data: { success: false, message: 'send denied' },
+    });
+
+    try {
+      const sender = new MessageSender('token', 'https://weixin.example.test', 'https://cdn.example.test');
+      await assert.rejects(
+        () => sender.sendText('user-1', 'hello', 'ctx-1'),
+        /微信 sendmessage:text 业务失败: success=false/
+      );
+    } finally {
+      (axios.post as any) = originalPost;
+    }
+  });
+});

--- a/tests/weixin-session-route.test.ts
+++ b/tests/weixin-session-route.test.ts
@@ -5,7 +5,7 @@ import { SubAgentManager } from '../src/core/sub-agent-manager';
 
 describe('Weixin SessionRoute V2', () => {
   test('routes messages through a Weixin V2 key while preserving the outbound user id', async () => {
-    const sentTexts: Array<{ userId: string; text: string; contextToken?: string }> = [];
+    const sentTexts: Array<{ userId: string; text: string; contextToken?: string; fromUserId?: string }> = [];
     const bot = createHarness({
       sentTexts,
       parsed: {
@@ -41,7 +41,7 @@ describe('Weixin SessionRoute V2', () => {
       await bot.handledTurns[0].options.channel.reply('ignored-chat-id', 'reply text');
 
       assert.deepEqual(sentTexts, [
-        { userId: 'shared', text: 'reply text', contextToken: 'ctx-token' },
+        { userId: 'shared', text: 'reply text', contextToken: 'ctx-token', fromUserId: 'wx-bot' },
       ]);
     } finally {
       SubAgentManager.getInstance().unregisterPlatformCallbacks('session:v2:weixin:p2p:shared');
@@ -89,7 +89,7 @@ describe('Weixin SessionRoute V2', () => {
 function createHarness(options: {
   busy?: boolean;
   parsed: any;
-  sentTexts?: Array<{ userId: string; text: string; contextToken?: string }>;
+  sentTexts?: Array<{ userId: string; text: string; contextToken?: string; fromUserId?: string }>;
 }): any {
   const bot = Object.create(WeixinBot.prototype) as any;
   bot.sessionBusy = options.busy ?? false;
@@ -121,8 +121,8 @@ function createHarness(options: {
     },
   };
   bot.sender = {
-    sendText: async (userId: string, text: string, contextToken?: string) => {
-      options.sentTexts?.push({ userId, text, contextToken });
+    sendText: async (userId: string, text: string, contextToken?: string, fromUserId?: string) => {
+      options.sentTexts?.push({ userId, text, contextToken, fromUserId });
     },
     sendFile: async () => undefined,
   };


### PR DESCRIPTION
## 背景

微信消息链路里，日志会记录 `Message模式：已自动转发`，但用户侧偶发收不到消息。排查后发现发送端只判断 `sendmessage` HTTP 是否成功，没有记录或校验微信接口返回体；同时发消息 payload 里 `from_user_id` 为空，部分会话下会导致接口返回 HTTP 成功但实际不投递。

## 改动

- 微信 `sendmessage` 请求带上收到消息里的 bot/self `chat.id` 作为 `from_user_id`。
- 为文本和文件发送增加脱敏请求日志，记录 from/to/context/client 等关键定位信息。
- 校验微信接口返回体里的业务失败字段，显式失败时抛错；对当前 observed 的 `{ keys: [] }` 空确认响应保留兼容并输出 warning。
- `getuploadurl` 和 `sendmessage` 都统一走响应摘要与业务状态检查。
- 补充微信 sender 与 session route 测试，覆盖 `from_user_id` 传递、业务失败、空确认响应兼容等场景。

## 说明

用户看到主 session 回复后又出现 `branch:memory` 的 Turn 2/3，是旁路记忆检索分支在异步运行；微信回复本身已经在主 `weixin` session Turn 1 生成并发送，不会重复投递。

## 验证

- `npx tsx --test tests/weixin-message-sender.test.ts tests/weixin-session-route.test.ts`
- `npm.cmd run build`
- `npm.cmd run release:check`
- `git diff --check`