### PR TITLE
[codex] Allow CatsCo agent body local tools

### DIFF
--- a/src/tools/local-tool-risk.ts
+++ b/src/tools/local-tool-risk.ts
@@ -1,6 +1,6 @@
 import type { DeviceGrantOperation } from '../types/session-identity';
 import type { ToolExecutionContext, ToolExecutionResult, ToolRiskLevel } from '../types/tool';
-import { isCatsCoLocalOwnerSelfContext, resolveToolGatewayAccess } from './tool-gateway';
+import { isCatsCoAgentLocalBodyContext, isCatsCoLocalOwnerSelfContext, resolveToolGatewayAccess } from './tool-gateway';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -99,8 +99,8 @@ export function classifyLocalToolRisk(
     return { requiresConfirmation: false, risk: 'low', reason: '只读或状态类工具。' };
   }
 
-  if (isCatsCoLocalOwnerSelfContext(context)) {
-    return { requiresConfirmation: false, risk: 'low', reason: 'CatsCo 本地 owner 自用场景允许直接执行本机工具。' };
+  if (isCatsCoLocalOwnerSelfContext(context) || isCatsCoAgentLocalBodyContext(context)) {
+    return { requiresConfirmation: false, risk: 'low', reason: 'CatsCo 虚拟员工本机运行体允许直接执行本机工具。' };
   }
 
   const remoteFileOperation = REMOTE_DEVICE_FILE_TOOL_OPERATIONS[toolName];

--- a/src/tools/tool-gateway.ts
+++ b/src/tools/tool-gateway.ts
@@ -64,6 +64,19 @@ export function isCatsCoLocalOwnerSelfContext(context: ToolExecutionContext): bo
   return false;
 }
 
+export function isCatsCoAgentLocalBodyContext(context: ToolExecutionContext): boolean {
+  if (!isCatsCoToolGatewayContext(context)) return false;
+  const scope = context.executionScope;
+  const localDevice = context.localDeviceGrant;
+  if (!scope || scope.source !== 'catscompany' || scope.identityTrust !== 'server_canonical' || !scope.isTrusted) {
+    return false;
+  }
+  if (!localDevice || localDevice.source !== 'catscompany' || !localDevice.bodyId) {
+    return false;
+  }
+  return Boolean(scope.agentBodyId && scope.agentBodyId === localDevice.bodyId);
+}
+
 export function formatCatsCoVisiblePath(
   context: ToolExecutionContext,
   value: string | undefined,
@@ -116,6 +129,7 @@ export function resolveToolGatewayAccess(
   }
 
   const localOwnerSelf = isCatsCoLocalOwnerSelfContext(context);
+  const agentLocalBody = isCatsCoAgentLocalBodyContext(context);
   const rpcForwardLocal = isCatsCoDeviceRpcForwardLocalContext(context, options.operation);
   const requireSelectedDevice = requiresExplicitBackendDeviceSelection(scope, localDevice, rpcForwardLocal);
 
@@ -128,14 +142,15 @@ export function resolveToolGatewayAccess(
     options.operation,
     options.targetLabel,
     {
-      allowLocalSelfOperation: localOwnerSelf || rpcForwardLocal,
-      requireSelection: requireSelectedDevice,
+      allowLocalSelfOperation: localOwnerSelf || agentLocalBody || rpcForwardLocal,
+      allowLocalAgentBodyFallback: agentLocalBody,
+      requireSelection: requireSelectedDevice && !agentLocalBody,
     },
   );
   if (!selectedTarget.ok) return selectedTarget;
 
   const targetDeviceId = selectedTarget.deviceId || localDevice.deviceId || localDevice.installationId || localDevice.bodyId;
-  if (selectedTarget.mode === 'local' && (localOwnerSelf || rpcForwardLocal)) {
+  if (selectedTarget.mode === 'local' && (localOwnerSelf || agentLocalBody || rpcForwardLocal)) {
     return {
       ok: true,
       mode: 'local',
@@ -182,14 +197,14 @@ export function resolveToolGatewayAccess(
     };
   }
 
-  if (!context.deviceSelection && requiresBackendSelectedDeviceForLocalExecution(scope, localDevice, grant, rpcForwardLocal)) {
+  if (!context.deviceSelection && !agentLocalBody && requiresBackendSelectedDeviceForLocalExecution(scope, localDevice, grant, rpcForwardLocal)) {
     return denied([
       '后端没有选定当前说话人的目标设备，已阻止本地设备操作。',
       '共享虚拟员工不能默认使用云端运行体本机，必须由服务端选择当前用户自己的在线设备。',
     ], options.targetLabel);
   }
 
-  if (options.operation === 'execute_shell' && !localOwnerSelf && !rpcForwardLocal && !options.allowCatsCoShell) {
+  if (options.operation === 'execute_shell' && !localOwnerSelf && !agentLocalBody && !rpcForwardLocal && !options.allowCatsCoShell) {
     return denied([
       'CatsCo 会话暂不允许外部用户或远程委托通过 execute_shell 操作命令行。',
       '命令执行只允许本机 owner 自用场景直接执行。',
@@ -253,7 +268,7 @@ function resolveBackendSelectedDevice(
   localDevice: ScopedLocalDeviceGrant,
   operation: DeviceGrantOperation,
   targetLabel?: string,
-  options: { allowLocalSelfOperation?: boolean; requireSelection?: boolean } = {},
+  options: { allowLocalSelfOperation?: boolean; allowLocalAgentBodyFallback?: boolean; requireSelection?: boolean } = {},
 ): SelectedDeviceDecision {
   if (!selection) {
     if (options.requireSelection) {
@@ -270,12 +285,18 @@ function resolveBackendSelectedDevice(
   }
 
   if (selection.status === 'needs_selection') {
+    if (options.allowLocalAgentBodyFallback) {
+      return localSelectedDevice(localDevice);
+    }
     return selectedDenied([
       '后端尚未选定要操作的用户设备，已阻止本地设备操作。',
       '请让用户从可用设备中选择一个设备名后再继续。',
     ], targetLabel);
   }
   if (selection.status === 'unavailable') {
+    if (options.allowLocalAgentBodyFallback) {
+      return localSelectedDevice(localDevice);
+    }
     return selectedDenied([
       '当前用户没有可用的在线设备授权，已阻止本地设备操作。',
       '请让用户打开并授权目标设备后再继续。',
@@ -321,6 +342,14 @@ function resolveBackendSelectedDevice(
     displayName: selection.selectedDeviceDisplayName,
     bodyId: selection.selectedDeviceBodyId,
     installationId: selection.selectedDeviceInstallationId,
+  };
+}
+
+function localSelectedDevice(localDevice: ScopedLocalDeviceGrant): Extract<SelectedDeviceDecision, { ok: true; mode: 'local' }> {
+  return {
+    ok: true,
+    mode: 'local',
+    deviceId: localDevice.deviceId || localDevice.installationId || localDevice.bodyId,
   };
 }
 

--- a/tests/tool-gateway-catsco.test.ts
+++ b/tests/tool-gateway-catsco.test.ts
@@ -139,6 +139,26 @@ describe('CatsCo ToolGateway', () => {
     }
   });
 
+  test('allows virtual employee local body tools when user device selection is unavailable', async () => {
+    const root = makeWorkspace();
+    const filePath = path.join(root, 'notes.txt');
+    fs.writeFileSync(filePath, 'agent body content');
+
+    const result = await new ReadTool().execute({ file_path: filePath }, context(root, {
+      executionScope: scope({ agentBodyId: 'body-device' }),
+      localDeviceGrant: localDevice({ ownerUserId: 'usr9' }),
+      deviceSelection: deviceSelection({
+        status: 'unavailable',
+        selectedDeviceId: undefined,
+        selectedDeviceBodyId: undefined,
+        selectedDeviceInstallationId: undefined,
+      }),
+    }));
+
+    assert.equal(result.ok, true);
+    assert.match(result.ok ? String(result.content) : '', /agent body content/);
+  });
+
   test('allows regular read_file with a matching CatsCo user device grant', async () => {
     const root = makeWorkspace();
     const filePath = path.join(root, 'notes.txt');
@@ -687,6 +707,20 @@ describe('CatsCo ToolGateway', () => {
 
     assert.equal(result.ok, true);
     if (result.ok) assert.match(result.content, /catsco-shell-ok/);
+  });
+
+  test('allows virtual employee local body execute_shell without user-device grant', async () => {
+    const root = makeWorkspace();
+    const result = await new ShellTool().execute({ command: 'echo catsco-agent-body-shell-ok' }, context(root, {
+      executionScope: scope({ agentBodyId: 'body-device' }),
+      localDeviceGrant: localDevice({
+        ownerUserId: 'usr9',
+        capabilities: ['read_file', 'glob', 'grep', 'write_file', 'edit_file', 'send_file', 'execute_shell'],
+      }),
+    }));
+
+    assert.equal(result.ok, true);
+    if (result.ok) assert.match(result.content, /catsco-agent-body-shell-ok/);
   });
 
   test('routes remote execute_shell for a mobile channel speaker when selected and granted', async () => {

--- a/tests/tool-gateway-catsco.test.ts
+++ b/tests/tool-gateway-catsco.test.ts
@@ -98,6 +98,16 @@ function deviceSelection(overrides: Partial<ScopedDeviceSelection> = {}): Scoped
   };
 }
 
+function unavailableDeviceSelection(overrides: Partial<ScopedDeviceSelection> = {}): ScopedDeviceSelection {
+  return deviceSelection({
+    status: 'unavailable',
+    selectedDeviceId: undefined,
+    selectedDeviceBodyId: undefined,
+    selectedDeviceInstallationId: undefined,
+    ...overrides,
+  });
+}
+
 function context(root: string, options: {
   executionScope?: ExecutionScope;
   localDeviceGrant?: ScopedLocalDeviceGrant;
@@ -147,16 +157,109 @@ describe('CatsCo ToolGateway', () => {
     const result = await new ReadTool().execute({ file_path: filePath }, context(root, {
       executionScope: scope({ agentBodyId: 'body-device' }),
       localDeviceGrant: localDevice({ ownerUserId: 'usr9' }),
-      deviceSelection: deviceSelection({
-        status: 'unavailable',
-        selectedDeviceId: undefined,
-        selectedDeviceBodyId: undefined,
-        selectedDeviceInstallationId: undefined,
-      }),
+      deviceSelection: unavailableDeviceSelection(),
     }));
 
     assert.equal(result.ok, true);
     assert.match(result.ok ? String(result.content) : '', /agent body content/);
+  });
+
+  test('blocks agent local body fallback when agent body does not match local device body', async () => {
+    const root = makeWorkspace();
+    const filePath = path.join(root, 'notes.txt');
+    fs.writeFileSync(filePath, 'must not read through fallback');
+
+    const result = await new ReadTool().execute({ file_path: filePath }, context(root, {
+      executionScope: scope({ agentBodyId: 'body-other' }),
+      localDeviceGrant: localDevice({ ownerUserId: 'usr9' }),
+      deviceSelection: unavailableDeviceSelection(),
+    }));
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.errorCode, 'PERMISSION_DENIED');
+      assert.match(result.message, /当前用户没有可用的在线设备授权/);
+    }
+  });
+
+  test('blocks agent local body fallback for untrusted CatsCo identities', async () => {
+    const root = makeWorkspace();
+    const filePath = path.join(root, 'notes.txt');
+    fs.writeFileSync(filePath, 'must not read through fallback');
+
+    const cases: Array<{ name: string; executionScope: ExecutionScope }> = [
+      {
+        name: 'untrusted identity',
+        executionScope: scope({
+          agentBodyId: 'body-device',
+          identityTrust: 'untrusted',
+          isTrusted: false,
+        }),
+      },
+      {
+        name: 'server canonical but not trusted',
+        executionScope: scope({
+          agentBodyId: 'body-device',
+          isTrusted: false,
+        }),
+      },
+    ];
+
+    for (const item of cases) {
+      const result = await new ReadTool().execute({ file_path: filePath }, context(root, {
+        executionScope: item.executionScope,
+        localDeviceGrant: localDevice({ ownerUserId: 'usr9' }),
+        deviceSelection: unavailableDeviceSelection(),
+      }));
+
+      assert.equal(result.ok, false, item.name);
+      if (!result.ok) {
+        assert.equal(result.errorCode, 'PERMISSION_DENIED', item.name);
+        assert.match(result.message, /身份未通过服务端一致性校验/, item.name);
+      }
+    }
+  });
+
+  test('blocks agent local body fallback when local device binding is not the CatsCo body', async () => {
+    const root = makeWorkspace();
+    const filePath = path.join(root, 'notes.txt');
+    fs.writeFileSync(filePath, 'must not read through fallback');
+
+    const result = await new ReadTool().execute({ file_path: filePath }, context(root, {
+      executionScope: scope({ agentBodyId: 'body-device' }),
+      localDeviceGrant: localDevice({
+        source: 'cli',
+        ownerUserId: 'usr9',
+      } as Partial<ScopedLocalDeviceGrant>),
+      deviceSelection: unavailableDeviceSelection(),
+    }));
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.errorCode, 'PERMISSION_DENIED');
+      assert.match(result.message, /缺少 CatsCo 本机设备绑定/);
+    }
+  });
+
+  test('blocks agent local body fallback when local device body id is missing', async () => {
+    const root = makeWorkspace();
+    const filePath = path.join(root, 'notes.txt');
+    fs.writeFileSync(filePath, 'must not read through fallback');
+
+    const result = await new ReadTool().execute({ file_path: filePath }, context(root, {
+      executionScope: scope({ agentBodyId: 'body-device' }),
+      localDeviceGrant: localDevice({
+        ownerUserId: 'usr9',
+        bodyId: undefined,
+      } as Partial<ScopedLocalDeviceGrant>),
+      deviceSelection: unavailableDeviceSelection(),
+    }));
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.errorCode, 'PERMISSION_DENIED');
+      assert.match(result.message, /当前用户没有可用的在线设备授权/);
+    }
   });
 
   test('allows regular read_file with a matching CatsCo user device grant', async () => {
@@ -721,6 +824,27 @@ describe('CatsCo ToolGateway', () => {
 
     assert.equal(result.ok, true);
     if (result.ok) assert.match(result.content, /catsco-agent-body-shell-ok/);
+  });
+
+  test('blocks virtual employee execute_shell fallback when agent body does not match local device body', async () => {
+    const root = makeWorkspace();
+    const marker = path.join(root, 'must-not-run-locally.txt');
+
+    const result = await new ShellTool().execute({ command: `node -e "require('fs').writeFileSync('${marker.replace(/\\/g, '\\\\')}', 'wrong')"` }, context(root, {
+      executionScope: scope({ agentBodyId: 'body-other' }),
+      localDeviceGrant: localDevice({
+        ownerUserId: 'usr9',
+        capabilities: ['read_file', 'glob', 'grep', 'write_file', 'edit_file', 'send_file', 'execute_shell'],
+      }),
+      deviceSelection: unavailableDeviceSelection(),
+    }));
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.errorCode, 'PERMISSION_DENIED');
+      assert.match(result.message, /当前用户没有可用的在线设备授权/);
+    }
+    assert.equal(fs.existsSync(marker), false);
   });
 
   test('routes remote execute_shell for a mobile channel speaker when selected and granted', async () => {

--- a/tests/tool-manager.test.ts
+++ b/tests/tool-manager.test.ts
@@ -486,6 +486,43 @@ describe('ToolManager', () => {
     assert.equal(confirmed, false);
   });
 
+  test('CatsCo virtual employee local body runs shell without confirmation for non-owner actors', async () => {
+    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-catsco-agent-body-'));
+    const manager = new ToolManager(workspace, {}, { enabledToolNames: [] });
+    let executed = false;
+    manager.registerTool(fakeTool('execute_shell', async () => {
+      executed = true;
+      return { ok: true, content: 'agent body shell ran' };
+    }));
+    let confirmed = false;
+
+    const result = await manager.executeTool({
+      id: 'call-catsco-agent-body-shell',
+      type: 'function',
+      function: { name: 'execute_shell', arguments: JSON.stringify({ command: 'Remove-Item -Recurse C:\\danger' }) },
+    }, [], {
+      surface: 'catscompany',
+      permissionProfile: 'strict',
+      workingDirectory: workspace,
+      workspaceRoot: workspace,
+      executionScope: catsScope({
+        actorUserId: 'usr100',
+        sessionKey: 'session:v2:catscompany:p2p:p2p_100_43:agent:usr43',
+        topicId: 'p2p_100_43',
+      }),
+      localDeviceGrant: catsLocalDevice({ ownerUserId: 'usr7' }),
+      confirmToolExecution: async () => {
+        confirmed = true;
+        return false;
+      },
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.content, 'agent body shell ran');
+    assert.equal(executed, true);
+    assert.equal(confirmed, false);
+  });
+
   test('CatsCo local owner self accepts numeric local owner ids from saved config', async () => {
     const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-catsco-owner-id-'));
     const manager = new ToolManager(workspace, {}, { enabledToolNames: [] });

--- a/tests/tool-manager.test.ts
+++ b/tests/tool-manager.test.ts
@@ -523,6 +523,93 @@ describe('ToolManager', () => {
     assert.equal(confirmed, false);
   });
 
+  test('CatsCo non-agent-local-body shell contexts still require strict confirmation', async () => {
+    const cases: Array<{
+      name: string;
+      executionScope: ExecutionScope;
+      localDeviceGrant: ScopedLocalDeviceGrant;
+    }> = [
+      {
+        name: 'agent body mismatch',
+        executionScope: catsScope({
+          actorUserId: 'usr100',
+          sessionKey: 'session:v2:catscompany:p2p:p2p_100_43:agent:usr43',
+          topicId: 'p2p_100_43',
+          agentBodyId: 'body-other',
+        }),
+        localDeviceGrant: catsLocalDevice({ ownerUserId: 'usr7' }),
+      },
+      {
+        name: 'untrusted identity',
+        executionScope: catsScope({
+          actorUserId: 'usr100',
+          sessionKey: 'session:v2:catscompany:p2p:p2p_100_43:agent:usr43',
+          topicId: 'p2p_100_43',
+          identityTrust: 'untrusted',
+          isTrusted: false,
+        }),
+        localDeviceGrant: catsLocalDevice({ ownerUserId: 'usr7' }),
+      },
+      {
+        name: 'non-CatsCo local device',
+        executionScope: catsScope({
+          actorUserId: 'usr100',
+          sessionKey: 'session:v2:catscompany:p2p:p2p_100_43:agent:usr43',
+          topicId: 'p2p_100_43',
+        }),
+        localDeviceGrant: catsLocalDevice({
+          ownerUserId: 'usr7',
+          source: 'cli',
+        } as Partial<ScopedLocalDeviceGrant>),
+      },
+      {
+        name: 'missing local body id',
+        executionScope: catsScope({
+          actorUserId: 'usr100',
+          sessionKey: 'session:v2:catscompany:p2p:p2p_100_43:agent:usr43',
+          topicId: 'p2p_100_43',
+        }),
+        localDeviceGrant: catsLocalDevice({
+          ownerUserId: 'usr7',
+          bodyId: undefined,
+        } as Partial<ScopedLocalDeviceGrant>),
+      },
+    ];
+
+    for (const item of cases) {
+      const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-catsco-non-agent-body-'));
+      const manager = new ToolManager(workspace, {}, { enabledToolNames: [] });
+      let executed = false;
+      let confirmations = 0;
+      manager.registerTool(fakeTool('execute_shell', async () => {
+        executed = true;
+        return { ok: true, content: 'should not run without confirmation' };
+      }));
+
+      const result = await manager.executeTool({
+        id: `call-catsco-shell-${item.name.replace(/\W+/g, '-')}`,
+        type: 'function',
+        function: { name: 'execute_shell', arguments: JSON.stringify({ command: 'echo should-confirm' }) },
+      }, [], {
+        surface: 'catscompany',
+        permissionProfile: 'strict',
+        workingDirectory: workspace,
+        workspaceRoot: workspace,
+        executionScope: item.executionScope,
+        localDeviceGrant: item.localDeviceGrant,
+        confirmToolExecution: async () => {
+          confirmations += 1;
+          return false;
+        },
+      });
+
+      assert.equal(result.ok, false, item.name);
+      assert.equal(result.errorCode, 'PERMISSION_DENIED', item.name);
+      assert.equal(executed, false, item.name);
+      assert.equal(confirmations, 1, item.name);
+    }
+  });
+
   test('CatsCo local owner self accepts numeric local owner ids from saved config', async () => {
     const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-catsco-owner-id-'));
     const manager = new ToolManager(workspace, {}, { enabledToolNames: [] });


### PR DESCRIPTION
﻿## Summary

Allow CatsCo virtual employees to use their own cloud runtime body as the local device target.

## Root Cause

The tool gateway treated CatsCo device tools as operations against the current speaker's user device. When the backend returned `device_selection: unavailable`, the gateway blocked local file/shell tools even when the current runtime body matched the virtual employee's own `agentBodyId`. `execute_shell` also had an extra non-owner block, so external users who added a virtual employee could not ask that employee to operate its own cloud computer.

## Changes

- Detect trusted CatsCo turns where `executionScope.agentBodyId` matches the local runtime `bodyId`.
- Allow that agent-local-body path to execute local tools even when user-device selection is unavailable or not selected.
- Exempt agent-local-body tool calls from local confirmation prompts, matching the requirement that virtual employees can operate their own cloud runtime directly.
- Add regression coverage for unavailable user-device selection, local shell execution without user-device grants, and strict-mode shell confirmation behavior.

## Validation

- `npm.cmd run build`
- `node_modules\.bin\tsx.cmd --test tests\tool-gateway-catsco.test.ts`
- `node_modules\.bin\tsx.cmd --test tests\tool-manager.test.ts`
