### PR TITLE
[codex] 收口工具执行契约和输出控制

### DIFF
--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -428,7 +428,7 @@ export class CatsCompanyBot {
             retryable: this.isRetryableDeviceRpcError(response.error.code),
           };
         }
-        return normalizeDeviceRpcToolResultPayload(response.result);
+        return normalizeDeviceRpcToolResultPayload(response.result, { toolName });
       },
     };
   }
@@ -636,7 +636,7 @@ export class CatsCompanyBot {
         device_installation_id: this.localDeviceGrant?.installationId || request.device_installation_id,
         operation: request.operation,
         tool_name: request.tool_name,
-        result: error || !result ? undefined : normalizeDeviceRpcToolResultForTransport(result),
+        result: error || !result ? undefined : normalizeDeviceRpcToolResultForTransport(result, { toolName: request.tool_name }),
         error,
       });
     } catch (err: any) {

--- a/src/core/execute-shell-message-folder.ts
+++ b/src/core/execute-shell-message-folder.ts
@@ -330,6 +330,8 @@ function selectKeyLines(lines: string[], maxKeyLines: number): string[] {
 }
 
 function readCommand(rawText: string): string | undefined {
+  const command = readField(rawText, 'command');
+  if (command) return command;
   const lines = rawText.split(/\r?\n/);
   for (const line of lines) {
     if (line.startsWith('$ ')) return line.slice(2).trim() || undefined;
@@ -338,9 +340,18 @@ function readCommand(rawText: string): string | undefined {
 }
 
 function readStatus(rawText: string): ShellMetadata['status'] {
+  const status = readField(rawText, 'status');
+  if (status === 'succeeded' || status === 'failed') return status;
+  if (status === 'timed_out' || status === 'aborted') return 'failed';
   if (/^Command succeeded:/m.test(rawText)) return 'succeeded';
   if (/^Command failed:/m.test(rawText)) return 'failed';
   return 'unknown';
+}
+
+function readField(rawText: string, key: string): string | undefined {
+  const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = rawText.match(new RegExp(`^${escapedKey}:\\s*(.*)$`, 'm'));
+  return match?.[1]?.trim() || undefined;
 }
 
 function parseToolArguments(toolCall?: NonNullable<Message['tool_calls']>[number]): Record<string, unknown> {

--- a/src/core/transient-environment.ts
+++ b/src/core/transient-environment.ts
@@ -16,6 +16,8 @@ export interface BuildTransientEnvironmentHintOptions {
   provider?: string;
   model?: string;
   env?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+  now?: Date;
   gitInfo?: GitRepositoryInfo | null;
 }
 
@@ -26,6 +28,7 @@ export function buildTransientEnvironmentHint(
   if (!currentDirectory) return null;
 
   const env = options.env ?? process.env;
+  const platform = options.platform ?? process.platform;
   const gitInfo = options.gitInfo === undefined
     ? resolveGitRepositoryInfo(currentDirectory)
     : options.gitInfo;
@@ -35,8 +38,8 @@ export function buildTransientEnvironmentHint(
     'Runtime context only. Not a user request. Do not answer.',
     `cwd: ${currentDirectory}`,
     renderModelInfo(options.provider, options.model),
-    `os: ${process.platform}`,
-    `shell: ${resolveShellName(env)}`,
+    `os: ${platform}`,
+    `shell: ${resolveShellName(env, platform)}`,
     gitInfo ? renderGitInfo(gitInfo, currentDirectory) : '',
     'Use cwd for relative file and shell paths.',
   ].filter(Boolean);
@@ -48,8 +51,13 @@ export function buildTransientEnvironmentHint(
   };
 }
 
-export function resolveShellName(env: NodeJS.ProcessEnv = process.env): string {
-  if (process.platform === 'win32' && env.PSModulePath) return 'powershell';
+export function resolveShellName(
+  env: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  if (platform === 'win32') {
+    return 'powershell';
+  }
   const raw = env.SHELL || env.ComSpec || env.COMSPEC || (env.PSModulePath ? 'powershell' : '');
   if (!raw) return 'unknown';
   const basename = path.win32.basename(raw);

--- a/src/tools/bash-tool.ts
+++ b/src/tools/bash-tool.ts
@@ -26,6 +26,24 @@ interface ShellOutput {
   stderr: string;
 }
 
+type ShellRunStatus = 'succeeded' | 'failed' | 'timed_out' | 'aborted';
+
+interface ShellRunResult {
+  command: string;
+  description?: string;
+  status: ShellRunStatus;
+  exitCode?: number;
+  signal?: string;
+  timedOut: boolean;
+  durationMs: number;
+  cwdBefore: string;
+  cwdAfter: string;
+  stdout: string;
+  stderr: string;
+  errorMessage?: string;
+  truncated: boolean;
+}
+
 export class ShellTool implements Tool {
   definition: ToolDefinition = {
     name: 'execute_shell',
@@ -68,9 +86,26 @@ export class ShellTool implements Tool {
 
   async execute(args: any, context: ToolExecutionContext): Promise<ToolExecutionResult> {
     const { command, description, timeout = 30000, confirm_dangerous = false, cwd } = args;
+    let cwdBefore = context.workingDirectory;
 
     if (context.abortSignal?.aborted) {
-      return { ok: false, errorCode: 'EXECUTION_TIMEOUT', message: `命令已取消，未开始执行:\n$ ${command}` };
+      return {
+        ok: false,
+        errorCode: 'EXECUTION_TIMEOUT',
+        message: this.formatShellRunResult({
+          command,
+          description,
+          status: 'aborted',
+          timedOut: false,
+          durationMs: 0,
+          cwdBefore,
+          cwdAfter: cwdBefore,
+          stdout: '',
+          stderr: '',
+          errorMessage: 'Command aborted before execution',
+          truncated: false,
+        }),
+      };
     }
 
     const route = resolveExecutionRoute(context, {
@@ -104,6 +139,7 @@ export class ShellTool implements Tool {
     }
     const executionDirectory = this.resolveExecutionDirectory(cwd, context);
     if (!executionDirectory.ok) return executionDirectory;
+    cwdBefore = executionDirectory.directory;
 
     Logger.info(`$ ${command}`);
     Logger.info(`Current directory: ${executionDirectory.directory}`);
@@ -126,25 +162,26 @@ export class ShellTool implements Tool {
 
       const parsedStdout = this.extractDirectoryProbe(stdout || '', wrapped.marker);
       const parsedStderr = this.extractDirectoryProbe(stderr || '', wrapped.marker);
-      const finalDirectory = this.readDirectoryProbe(wrapped) || parsedStdout.directory || parsedStderr.directory;
-      this.updateCurrentDirectory(finalDirectory, context);
+      const cwdAfter = this.updateCurrentDirectory(
+        this.readDirectoryProbe(wrapped) || parsedStdout.directory || parsedStderr.directory,
+        context,
+      ) || cwdBefore;
 
       const stdoutOutput = parsedStdout.output || '';
       const stderrOutput = parsedStderr.output || '';
-      const output = this.formatSuccessfulOutput(stdoutOutput, stderrOutput);
       if (stderrOutput) {
         Logger.warning(`stderr: ${stderrOutput.substring(0, 200)}`);
       }
 
       const executionTime = Date.now() - startTime;
-      const outputLines = this.countOutputLines(output);
-      const outputSize = Buffer.byteLength(output, 'utf-8');
+      const outputLines = this.countOutputLines(stdoutOutput) + this.countOutputLines(stderrOutput);
+      const outputSize = Buffer.byteLength(stdoutOutput, 'utf-8') + Buffer.byteLength(stderrOutput, 'utf-8');
 
       Logger.success(`Command succeeded (elapsed: ${executionTime}ms)`);
       Logger.info(`  Output: ${outputLines} lines | ${(outputSize / 1024).toFixed(2)} KB`);
 
       if (outputLines > 20) {
-        const previewLines = output.split('\n').slice(0, 10);
+        const previewLines = [stdoutOutput, stderrOutput].filter(Boolean).join('\n').split('\n').slice(0, 10);
         Logger.info('  Output preview (first 10 lines):');
         previewLines.forEach(line => {
           const displayLine = line.length > 100 ? line.substring(0, 97) + '...' : line;
@@ -155,38 +192,54 @@ export class ShellTool implements Tool {
 
       return {
         ok: true,
-        content: [
-          'Command succeeded:',
-          `$ ${command}`,
-          '',
-          `Working directory: ${executionDirectory.directory}`,
-          finalDirectory ? `Final cwd: ${finalDirectory}` : '',
-          `Shell: ${this.resolveShellDisplayName()}`,
-          `Elapsed: ${executionTime}ms`,
-          `Output lines: ${outputLines}`,
-          '',
-          output,
-        ].filter(line => line !== '').join('\n'),
+        content: this.formatShellRunResult({
+          command,
+          description,
+          status: 'succeeded',
+          exitCode: 0,
+          timedOut: false,
+          durationMs: executionTime,
+          cwdBefore,
+          cwdAfter,
+          stdout: stdoutOutput,
+          stderr: stderrOutput,
+          truncated: false,
+        }),
       };
     } catch (error: any) {
       const executionTime = Date.now() - startTime;
       const parsedStdout = this.extractDirectoryProbe(error.stdout || '', wrapped.marker);
       const parsedStderr = this.extractDirectoryProbe(error.stderr || '', wrapped.marker);
-      const finalDirectory = this.readDirectoryProbe(wrapped) || parsedStdout.directory || parsedStderr.directory;
-      this.updateCurrentDirectory(finalDirectory, context);
-      if (context.abortSignal?.aborted || /aborted|abort/i.test(String(error.message || ''))) {
-        Logger.warning(`命令已取消 (耗时: ${executionTime}ms)`);
+      const cwdAfter = this.updateCurrentDirectory(
+        this.readDirectoryProbe(wrapped) || parsedStdout.directory || parsedStderr.directory,
+        context,
+      ) || cwdBefore;
+      const aborted = context.abortSignal?.aborted || /aborted|abort/i.test(String(error.message || ''));
+      const timedOut = !aborted && this.isTimeoutError(error);
+      if (aborted || timedOut) {
         return {
           ok: false,
           errorCode: 'EXECUTION_TIMEOUT',
-          message: `命令已取消:\n$ ${command}\n\n执行时间: ${executionTime}ms`,
+          message: this.formatShellRunResult({
+            command,
+            description,
+            status: aborted ? 'aborted' : 'timed_out',
+            signal: typeof error.signal === 'string' ? error.signal : undefined,
+            timedOut,
+            durationMs: executionTime,
+            cwdBefore,
+            cwdAfter,
+            stdout: parsedStdout.output || '',
+            stderr: parsedStderr.output || '',
+            errorMessage: this.formatExecutionError(error),
+            truncated: false,
+          }),
         };
       }
-      const errorOutput = [
-        parsedStderr.output,
-        parsedStdout.output,
-        this.formatExecutionError(error),
-      ].filter(Boolean).join('\n').trim();
+      const stdoutOutput = parsedStdout.output || '';
+      const stderrOutput = parsedStderr.output || '';
+      const exitCode = typeof error.code === 'number' ? error.code : undefined;
+      const signal = typeof error.signal === 'string' ? error.signal : undefined;
 
       Logger.error(`Command failed (elapsed: ${executionTime}ms)`);
       Logger.error(`  Error: ${error.message}`);
@@ -194,17 +247,21 @@ export class ShellTool implements Tool {
       return {
         ok: false,
         errorCode: 'TOOL_EXECUTION_ERROR',
-        message: [
-          'Command failed:',
-          `$ ${command}`,
-          '',
-          `Working directory: ${executionDirectory.directory}`,
-          finalDirectory ? `Final cwd: ${finalDirectory}` : '',
-          `Shell: ${this.resolveShellDisplayName()}`,
-          `Elapsed: ${executionTime}ms`,
-          'Error:',
-          errorOutput,
-        ].filter(line => line !== '').join('\n'),
+        message: this.formatShellRunResult({
+          command,
+          description,
+          status: 'failed',
+          exitCode,
+          signal,
+          timedOut: false,
+          durationMs: executionTime,
+          cwdBefore,
+          cwdAfter,
+          stdout: stdoutOutput,
+          stderr: stderrOutput,
+          errorMessage: this.formatExecutionError(error),
+          truncated: false,
+        }),
       };
     } finally {
       this.cleanupWrappedCommand(wrapped);
@@ -544,22 +601,43 @@ export class ShellTool implements Tool {
       .replace(/\n+$/, '');
   }
 
-  private formatSuccessfulOutput(stdout: string, stderr: string): string {
-    const cleanStdout = String(stdout || '');
-    const cleanStderr = String(stderr || '');
-    if (cleanStdout && cleanStderr) {
-      return [
-        'Stdout:',
-        cleanStdout,
-        '',
-        'Stderr:',
-        cleanStderr,
-      ].join('\n');
-    }
-    if (cleanStderr) {
-      return ['Stderr:', cleanStderr].join('\n');
-    }
-    return cleanStdout;
+  private formatShellRunResult(result: ShellRunResult): string {
+    const stdoutLines = this.countOutputLines(result.stdout);
+    const stderrLines = this.countOutputLines(result.stderr);
+    const stdoutBytes = Buffer.byteLength(result.stdout, 'utf-8');
+    const stderrBytes = Buffer.byteLength(result.stderr, 'utf-8');
+    const header = [
+      'Command completed',
+      `status: ${result.status}`,
+      `command: ${this.formatHeaderValue(result.command)}`,
+      result.description ? `description: ${this.formatHeaderValue(result.description)}` : '',
+      result.exitCode !== undefined ? `exit_code: ${result.exitCode}` : 'exit_code:',
+      result.signal ? `signal: ${result.signal}` : 'signal:',
+      `timed_out: ${result.timedOut}`,
+      `duration_ms: ${result.durationMs}`,
+      `cwd_before: ${result.cwdBefore}`,
+      `cwd_after: ${result.cwdAfter}`,
+      `stdout_lines: ${stdoutLines}`,
+      `stderr_lines: ${stderrLines}`,
+      `stdout_bytes: ${stdoutBytes}`,
+      `stderr_bytes: ${stderrBytes}`,
+      `truncated: ${result.truncated}`,
+      result.errorMessage ? `error_message: ${this.formatHeaderValue(result.errorMessage)}` : '',
+    ].filter(line => line !== '');
+
+    return [
+      ...header,
+      '',
+      'stdout:',
+      result.stdout || '(empty)',
+      '',
+      'stderr:',
+      result.stderr || '(empty)',
+    ].join('\n');
+  }
+
+  private formatHeaderValue(value: string): string {
+    return String(value || '').replace(/\r?\n/g, ' ; ');
   }
 
   private countOutputLines(output: string): number {
@@ -667,8 +745,9 @@ export class ShellTool implements Tool {
     return { ok: true, directory };
   }
 
-  private resolveShellDisplayName(): string {
-    return process.platform === 'win32' ? 'powershell' : 'sh';
+  private isTimeoutError(error: any): boolean {
+    const text = String(error?.message || error?.code || '').toLowerCase();
+    return text.includes('timed out') || text.includes('timeout') || text === 'etimedout';
   }
 
   private formatExecutionError(error: any): string {
@@ -684,14 +763,15 @@ export class ShellTool implements Tool {
     return this.stripAnyDirectoryProbe(String(error?.message || error || 'Command failed'));
   }
 
-  private updateCurrentDirectory(directory: string | undefined, context: ToolExecutionContext): void {
-    if (!directory) return;
+  private updateCurrentDirectory(directory: string | undefined, context: ToolExecutionContext): string | undefined {
+    if (!directory) return undefined;
     const resolved = path.resolve(directory);
     try {
-      if (!fs.existsSync(resolved) || !fs.statSync(resolved).isDirectory()) return;
+      if (!fs.existsSync(resolved) || !fs.statSync(resolved).isDirectory()) return undefined;
       context.updateCurrentDirectory?.(resolved);
+      return resolved;
     } catch {
-      return;
+      return undefined;
     }
   }
 }

--- a/src/tools/bash-tool.ts
+++ b/src/tools/bash-tool.ts
@@ -10,6 +10,9 @@ import { isToolAllowed, isBashCommandAllowed } from '../utils/safety';
 import { executeRouteIfRemote, resolveExecutionRoute, targetParameterDescription } from './execution-router';
 
 const CWD_MARKER_PREFIX = '__XIAOBA_CWD_MARKER__';
+const SHELL_CONTRACT_VERSION = 'shell/v1';
+const SHELL_INLINE_OUTPUT_MAX_CHARS = 30_000;
+const SHELL_ARTIFACT_DIR = 'tool-results';
 
 interface WrappedCommand {
   command: string;
@@ -33,13 +36,38 @@ interface ShellRunResult {
   exitCode?: number;
   signal?: string;
   timedOut: boolean;
+  timeoutMs: number;
   durationMs: number;
   cwdBefore: string;
   cwdAfter: string;
   stdout: string;
   stderr: string;
+  stdoutLines?: number;
+  stderrLines?: number;
+  stdoutBytes?: number;
+  stderrBytes?: number;
   errorMessage?: string;
   truncated: boolean;
+  truncatedReason?: string;
+  inlineOutputChars?: number;
+  originalOutputChars?: number;
+  outputArtifact?: string;
+  artifactError?: string;
+}
+
+interface ShellOutputPresentation {
+  stdout: string;
+  stderr: string;
+  stdoutLines: number;
+  stderrLines: number;
+  stdoutBytes: number;
+  stderrBytes: number;
+  truncated: boolean;
+  truncatedReason?: string;
+  inlineOutputChars: number;
+  originalOutputChars: number;
+  outputArtifact?: string;
+  artifactError?: string;
 }
 
 export class ShellTool implements Tool {
@@ -95,13 +123,20 @@ export class ShellTool implements Tool {
           description,
           status: 'aborted',
           timedOut: false,
+          timeoutMs: timeout,
           durationMs: 0,
           cwdBefore,
           cwdAfter: cwdBefore,
           stdout: '',
           stderr: '',
+          stdoutLines: 0,
+          stderrLines: 0,
+          stdoutBytes: 0,
+          stderrBytes: 0,
           errorMessage: 'Command aborted before execution',
           truncated: false,
+          inlineOutputChars: 0,
+          originalOutputChars: 0,
         }),
       };
     }
@@ -172,14 +207,22 @@ export class ShellTool implements Tool {
       }
 
       const executionTime = Date.now() - startTime;
-      const outputLines = this.countOutputLines(stdoutOutput) + this.countOutputLines(stderrOutput);
-      const outputSize = Buffer.byteLength(stdoutOutput, 'utf-8') + Buffer.byteLength(stderrOutput, 'utf-8');
+      const outputPresentation = this.prepareShellOutputPresentation(stdoutOutput, stderrOutput, context, {
+        command,
+        description,
+        status: 'succeeded',
+        cwdBefore,
+        cwdAfter,
+        durationMs: executionTime,
+      });
+      const outputLines = outputPresentation.stdoutLines + outputPresentation.stderrLines;
+      const outputSize = outputPresentation.stdoutBytes + outputPresentation.stderrBytes;
 
       Logger.success(`Command succeeded (elapsed: ${executionTime}ms)`);
       Logger.info(`  Output: ${outputLines} lines | ${(outputSize / 1024).toFixed(2)} KB`);
 
       if (outputLines > 20) {
-        const previewLines = [stdoutOutput, stderrOutput].filter(Boolean).join('\n').split('\n').slice(0, 10);
+        const previewLines = [outputPresentation.stdout, outputPresentation.stderr].filter(Boolean).join('\n').split('\n').slice(0, 10);
         Logger.info('  Output preview (first 10 lines):');
         previewLines.forEach(line => {
           const displayLine = line.length > 100 ? line.substring(0, 97) + '...' : line;
@@ -196,12 +239,22 @@ export class ShellTool implements Tool {
           status: 'succeeded',
           exitCode: 0,
           timedOut: false,
+          timeoutMs: timeout,
           durationMs: executionTime,
           cwdBefore,
           cwdAfter,
-          stdout: stdoutOutput,
-          stderr: stderrOutput,
-          truncated: false,
+          stdout: outputPresentation.stdout,
+          stderr: outputPresentation.stderr,
+          stdoutLines: outputPresentation.stdoutLines,
+          stderrLines: outputPresentation.stderrLines,
+          stdoutBytes: outputPresentation.stdoutBytes,
+          stderrBytes: outputPresentation.stderrBytes,
+          truncated: outputPresentation.truncated,
+          truncatedReason: outputPresentation.truncatedReason,
+          inlineOutputChars: outputPresentation.inlineOutputChars,
+          originalOutputChars: outputPresentation.originalOutputChars,
+          outputArtifact: outputPresentation.outputArtifact,
+          artifactError: outputPresentation.artifactError,
         }),
       };
     } catch (error: any) {
@@ -215,6 +268,16 @@ export class ShellTool implements Tool {
       const aborted = context.abortSignal?.aborted || /aborted|abort/i.test(String(error.message || ''));
       const timedOut = !aborted && this.isTimeoutError(error);
       if (aborted || timedOut) {
+        const stdoutOutput = parsedStdout.output || '';
+        const stderrOutput = parsedStderr.output || '';
+        const outputPresentation = this.prepareShellOutputPresentation(stdoutOutput, stderrOutput, context, {
+          command,
+          description,
+          status: aborted ? 'aborted' : 'timed_out',
+          cwdBefore,
+          cwdAfter,
+          durationMs: executionTime,
+        });
         return {
           ok: false,
           errorCode: 'EXECUTION_TIMEOUT',
@@ -224,18 +287,36 @@ export class ShellTool implements Tool {
             status: aborted ? 'aborted' : 'timed_out',
             signal: typeof error.signal === 'string' ? error.signal : undefined,
             timedOut,
+            timeoutMs: timeout,
             durationMs: executionTime,
             cwdBefore,
             cwdAfter,
-            stdout: parsedStdout.output || '',
-            stderr: parsedStderr.output || '',
+            stdout: outputPresentation.stdout,
+            stderr: outputPresentation.stderr,
+            stdoutLines: outputPresentation.stdoutLines,
+            stderrLines: outputPresentation.stderrLines,
+            stdoutBytes: outputPresentation.stdoutBytes,
+            stderrBytes: outputPresentation.stderrBytes,
             errorMessage: this.formatExecutionError(error),
-            truncated: false,
+            truncated: outputPresentation.truncated,
+            truncatedReason: outputPresentation.truncatedReason,
+            inlineOutputChars: outputPresentation.inlineOutputChars,
+            originalOutputChars: outputPresentation.originalOutputChars,
+            outputArtifact: outputPresentation.outputArtifact,
+            artifactError: outputPresentation.artifactError,
           }),
         };
       }
       const stdoutOutput = parsedStdout.output || '';
       const stderrOutput = parsedStderr.output || '';
+      const outputPresentation = this.prepareShellOutputPresentation(stdoutOutput, stderrOutput, context, {
+        command,
+        description,
+        status: 'failed',
+        cwdBefore,
+        cwdAfter,
+        durationMs: executionTime,
+      });
       const exitCode = typeof error.code === 'number' ? error.code : undefined;
       const signal = typeof error.signal === 'string' ? error.signal : undefined;
 
@@ -252,13 +333,23 @@ export class ShellTool implements Tool {
           exitCode,
           signal,
           timedOut: false,
+          timeoutMs: timeout,
           durationMs: executionTime,
           cwdBefore,
           cwdAfter,
-          stdout: stdoutOutput,
-          stderr: stderrOutput,
+          stdout: outputPresentation.stdout,
+          stderr: outputPresentation.stderr,
+          stdoutLines: outputPresentation.stdoutLines,
+          stderrLines: outputPresentation.stderrLines,
+          stdoutBytes: outputPresentation.stdoutBytes,
+          stderrBytes: outputPresentation.stderrBytes,
           errorMessage: this.formatExecutionError(error),
-          truncated: false,
+          truncated: outputPresentation.truncated,
+          truncatedReason: outputPresentation.truncatedReason,
+          inlineOutputChars: outputPresentation.inlineOutputChars,
+          originalOutputChars: outputPresentation.originalOutputChars,
+          outputArtifact: outputPresentation.outputArtifact,
+          artifactError: outputPresentation.artifactError,
         }),
       };
     } finally {
@@ -833,19 +924,173 @@ export class ShellTool implements Tool {
       .replace(/\n+$/, '');
   }
 
+  private prepareShellOutputPresentation(
+    stdout: string,
+    stderr: string,
+    context: ToolExecutionContext,
+    metadata: {
+      command: string;
+      description?: string;
+      status: ShellRunStatus;
+      cwdBefore: string;
+      cwdAfter: string;
+      durationMs: number;
+    },
+  ): ShellOutputPresentation {
+    const stdoutOutput = String(stdout || '');
+    const stderrOutput = String(stderr || '');
+    const stdoutBytes = Buffer.byteLength(stdoutOutput, 'utf-8');
+    const stderrBytes = Buffer.byteLength(stderrOutput, 'utf-8');
+    const originalOutputChars = stdoutOutput.length + stderrOutput.length;
+
+    if (originalOutputChars <= SHELL_INLINE_OUTPUT_MAX_CHARS) {
+      return {
+        stdout: stdoutOutput,
+        stderr: stderrOutput,
+        stdoutLines: this.countOutputLines(stdoutOutput),
+        stderrLines: this.countOutputLines(stderrOutput),
+        stdoutBytes,
+        stderrBytes,
+        truncated: false,
+        inlineOutputChars: originalOutputChars,
+        originalOutputChars,
+      };
+    }
+
+    let outputArtifact: string | undefined;
+    let artifactError: string | undefined;
+    try {
+      outputArtifact = this.writeShellOutputArtifact(stdoutOutput, stderrOutput, context, metadata);
+    } catch (error: any) {
+      artifactError = String(error?.message || error || 'failed to write shell output artifact');
+    }
+
+    const budgets = this.allocateInlineOutputBudgets(stdoutOutput.length, stderrOutput.length);
+    const previewStdout = this.buildOutputPreview(stdoutOutput, budgets.stdout);
+    const previewStderr = this.buildOutputPreview(stderrOutput, budgets.stderr);
+
+    return {
+      stdout: previewStdout,
+      stderr: previewStderr,
+      stdoutLines: this.countOutputLines(stdoutOutput),
+      stderrLines: this.countOutputLines(stderrOutput),
+      stdoutBytes,
+      stderrBytes,
+      truncated: true,
+      truncatedReason: 'output_exceeded_inline_limit',
+      inlineOutputChars: previewStdout.length + previewStderr.length,
+      originalOutputChars,
+      outputArtifact,
+      artifactError,
+    };
+  }
+
+  private writeShellOutputArtifact(
+    stdout: string,
+    stderr: string,
+    context: ToolExecutionContext,
+    metadata: {
+      command: string;
+      description?: string;
+      status: ShellRunStatus;
+      cwdBefore: string;
+      cwdAfter: string;
+      durationMs: number;
+    },
+  ): string {
+    const root = path.resolve(context.workspaceRoot || context.workingDirectory || process.cwd());
+    const dir = path.join(root, SHELL_ARTIFACT_DIR);
+    fs.mkdirSync(dir, { recursive: true });
+    const filePath = path.join(dir, `shell-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}.log`);
+    const content = [
+      'Shell output artifact',
+      `contract_version: ${SHELL_CONTRACT_VERSION}`,
+      `status: ${metadata.status}`,
+      `command: ${this.formatHeaderValue(metadata.command)}`,
+      metadata.description ? `description: ${this.formatHeaderValue(metadata.description)}` : '',
+      `duration_ms: ${metadata.durationMs}`,
+      `cwd_before: ${metadata.cwdBefore}`,
+      `cwd_after: ${metadata.cwdAfter}`,
+      `stdout_bytes: ${Buffer.byteLength(stdout, 'utf-8')}`,
+      `stderr_bytes: ${Buffer.byteLength(stderr, 'utf-8')}`,
+      '',
+      'stdout:',
+      stdout || '(empty)',
+      '',
+      'stderr:',
+      stderr || '(empty)',
+    ].filter(line => line !== '').join('\n');
+    fs.writeFileSync(filePath, content, 'utf8');
+    return filePath;
+  }
+
+  private allocateInlineOutputBudgets(stdoutChars: number, stderrChars: number): { stdout: number; stderr: number } {
+    const total = stdoutChars + stderrChars;
+    if (total <= SHELL_INLINE_OUTPUT_MAX_CHARS) {
+      return { stdout: stdoutChars, stderr: stderrChars };
+    }
+    if (stdoutChars <= 0) return { stdout: 0, stderr: SHELL_INLINE_OUTPUT_MAX_CHARS };
+    if (stderrChars <= 0) return { stdout: SHELL_INLINE_OUTPUT_MAX_CHARS, stderr: 0 };
+
+    const minimumStreamBudget = Math.min(4000, Math.floor(SHELL_INLINE_OUTPUT_MAX_CHARS / 4));
+    let stdoutBudget = Math.floor(SHELL_INLINE_OUTPUT_MAX_CHARS * (stdoutChars / total));
+    stdoutBudget = Math.max(minimumStreamBudget, Math.min(stdoutChars, stdoutBudget));
+    let stderrBudget = SHELL_INLINE_OUTPUT_MAX_CHARS - stdoutBudget;
+
+    if (stderrBudget < minimumStreamBudget) {
+      stderrBudget = Math.min(stderrChars, minimumStreamBudget);
+      stdoutBudget = SHELL_INLINE_OUTPUT_MAX_CHARS - stderrBudget;
+    }
+    if (stdoutBudget > stdoutChars) {
+      stderrBudget = Math.min(stderrChars, stderrBudget + (stdoutBudget - stdoutChars));
+      stdoutBudget = stdoutChars;
+    }
+    if (stderrBudget > stderrChars) {
+      stdoutBudget = Math.min(stdoutChars, stdoutBudget + (stderrBudget - stderrChars));
+      stderrBudget = stderrChars;
+    }
+
+    return { stdout: Math.max(0, stdoutBudget), stderr: Math.max(0, stderrBudget) };
+  }
+
+  private buildOutputPreview(output: string, maxChars: number): string {
+    if (!output || maxChars <= 0) return '';
+    if (output.length <= maxChars) return output;
+
+    const lines = output.split(/\r?\n/);
+    const omittedLines = Math.max(0, lines.length - 120);
+    const lineMarker = `\n\n... [${omittedLines} lines omitted, ${lines.length} lines total, ${output.length} chars total; full output saved as artifact] ...\n\n`;
+    const linePreview = [
+      ...lines.slice(0, 80),
+      lineMarker.trim(),
+      ...lines.slice(-40),
+    ].join('\n');
+    if (linePreview.length <= maxChars) return linePreview;
+
+    const charMarker = `\n\n... [truncated, ${lines.length} lines total, ${output.length} chars total; full output saved as artifact] ...\n\n`;
+    const available = maxChars - charMarker.length;
+    if (available <= 0) return charMarker.trim().slice(0, maxChars);
+
+    const headChars = Math.max(0, Math.floor(available * 0.7));
+    const tailChars = Math.max(0, available - headChars);
+    return `${output.slice(0, headChars)}${charMarker}${tailChars > 0 ? output.slice(-tailChars) : ''}`;
+  }
+
   private formatShellRunResult(result: ShellRunResult): string {
-    const stdoutLines = this.countOutputLines(result.stdout);
-    const stderrLines = this.countOutputLines(result.stderr);
-    const stdoutBytes = Buffer.byteLength(result.stdout, 'utf-8');
-    const stderrBytes = Buffer.byteLength(result.stderr, 'utf-8');
+    const stdoutLines = result.stdoutLines ?? this.countOutputLines(result.stdout);
+    const stderrLines = result.stderrLines ?? this.countOutputLines(result.stderr);
+    const stdoutBytes = result.stdoutBytes ?? Buffer.byteLength(result.stdout, 'utf-8');
+    const stderrBytes = result.stderrBytes ?? Buffer.byteLength(result.stderr, 'utf-8');
     const header = [
       'Command completed',
+      `contract_version: ${SHELL_CONTRACT_VERSION}`,
       `status: ${result.status}`,
       `command: ${this.formatHeaderValue(result.command)}`,
       result.description ? `description: ${this.formatHeaderValue(result.description)}` : '',
       result.exitCode !== undefined ? `exit_code: ${result.exitCode}` : 'exit_code:',
       result.signal ? `signal: ${result.signal}` : 'signal:',
       `timed_out: ${result.timedOut}`,
+      `timeout_ms: ${result.timeoutMs}`,
       `duration_ms: ${result.durationMs}`,
       `cwd_before: ${result.cwdBefore}`,
       `cwd_after: ${result.cwdAfter}`,
@@ -854,6 +1099,11 @@ export class ShellTool implements Tool {
       `stdout_bytes: ${stdoutBytes}`,
       `stderr_bytes: ${stderrBytes}`,
       `truncated: ${result.truncated}`,
+      result.truncatedReason ? `truncated_reason: ${result.truncatedReason}` : '',
+      result.inlineOutputChars !== undefined ? `inline_output_chars: ${result.inlineOutputChars}` : '',
+      result.originalOutputChars !== undefined ? `original_output_chars: ${result.originalOutputChars}` : '',
+      result.outputArtifact ? `output_artifact: ${result.outputArtifact}` : '',
+      result.artifactError ? `artifact_error: ${this.formatHeaderValue(result.artifactError)}` : '',
       result.errorMessage ? `error_message: ${this.formatHeaderValue(result.errorMessage)}` : '',
     ].filter(line => line !== '');
 

--- a/src/tools/bash-tool.ts
+++ b/src/tools/bash-tool.ts
@@ -1,5 +1,4 @@
-import { exec, spawn, type ChildProcess } from 'child_process';
-import { promisify } from 'util';
+import { spawn, type ChildProcess } from 'child_process';
 import { TextDecoder } from 'util';
 import * as fs from 'fs';
 import * as os from 'os';
@@ -10,7 +9,6 @@ import { resolveRuntimeEnvironment } from '../utils/runtime-environment';
 import { isToolAllowed, isBashCommandAllowed } from '../utils/safety';
 import { executeRouteIfRemote, resolveExecutionRoute, targetParameterDescription } from './execution-router';
 
-const execAsync = promisify(exec);
 const CWD_MARKER_PREFIX = '__XIAOBA_CWD_MARKER__';
 
 interface WrappedCommand {
@@ -335,16 +333,7 @@ export class ShellTool implements Tool {
     signal?: AbortSignal,
   ): Promise<ShellOutput> {
     if (process.platform !== 'win32') {
-      return execAsync(wrapped.command, {
-        cwd,
-        env,
-        encoding: 'utf-8',
-        shell: this.resolvePosixShell(env),
-        timeout,
-        signal,
-        killSignal: 'SIGTERM',
-        maxBuffer: 10 * 1024 * 1024,
-      });
+      return this.executePosixShellScript(wrapped, cwd, env, timeout, signal);
     }
 
     try {
@@ -353,6 +342,138 @@ export class ShellTool implements Tool {
       if (!this.isPowerShellLaunchFailure(error)) throw error;
       return this.executeWindowsCmdFallback(wrapped, cwd, env, timeout, signal);
     }
+  }
+
+  private executePosixShellScript(
+    wrapped: WrappedCommand,
+    cwd: string,
+    env: NodeJS.ProcessEnv,
+    timeout: number,
+    signal?: AbortSignal,
+  ): Promise<ShellOutput> {
+    if (signal?.aborted) {
+      return Promise.reject(this.createShellAbortError());
+    }
+
+    const shell = this.resolvePosixShell(env) || '/bin/sh';
+    return new Promise((resolve, reject) => {
+      const child = spawn(shell, ['-c', wrapped.command], {
+        cwd,
+        env,
+        detached: true,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+
+      const stdoutChunks: Buffer[] = [];
+      const stderrChunks: Buffer[] = [];
+      let settled = false;
+      let pendingFailure: any;
+      let stdoutBytes = 0;
+      let stderrBytes = 0;
+      const maxBuffer = 10 * 1024 * 1024;
+      let timer: NodeJS.Timeout | undefined;
+      let closeWaitTimer: NodeJS.Timeout | undefined;
+      let abortHandler: (() => void) | undefined;
+
+      const cleanup = () => {
+        if (timer) clearTimeout(timer);
+        if (closeWaitTimer) clearTimeout(closeWaitTimer);
+        if (signal && abortHandler) {
+          signal.removeEventListener('abort', abortHandler);
+        }
+      };
+
+      const settle = (fn: () => void) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        fn();
+      };
+
+      const rejectWithOutput = (error: any) => {
+        settle(() => {
+          error.stdout = Buffer.concat(stdoutChunks).toString('utf8');
+          error.stderr = Buffer.concat(stderrChunks).toString('utf8');
+          reject(error);
+        });
+      };
+
+      const failAfterClose = (error: any) => {
+        if (settled) return;
+        if (pendingFailure) return;
+        pendingFailure = error;
+        this.terminateProcessTree(child);
+        closeWaitTimer = setTimeout(() => {
+          rejectWithOutput(error);
+        }, 5000);
+        closeWaitTimer.unref?.();
+      };
+
+      timer = setTimeout(() => {
+        failAfterClose(this.createShellTimeoutError(timeout));
+      }, timeout);
+      timer.unref?.();
+
+      abortHandler = () => {
+        failAfterClose(this.createShellAbortError());
+      };
+      if (signal?.aborted) {
+        abortHandler();
+      } else {
+        signal?.addEventListener('abort', abortHandler, { once: true });
+      }
+
+      child.stdout?.on('data', (chunk: Buffer) => {
+        const buffer = Buffer.from(chunk);
+        stdoutBytes += buffer.length;
+        if (stdoutBytes > maxBuffer) {
+          failAfterClose(new Error(`stdout maxBuffer exceeded (${maxBuffer} bytes)`));
+          return;
+        }
+        stdoutChunks.push(buffer);
+      });
+
+      child.stderr?.on('data', (chunk: Buffer) => {
+        const buffer = Buffer.from(chunk);
+        stderrBytes += buffer.length;
+        if (stderrBytes > maxBuffer) {
+          failAfterClose(new Error(`stderr maxBuffer exceeded (${maxBuffer} bytes)`));
+          return;
+        }
+        stderrChunks.push(buffer);
+      });
+
+      child.on('error', (error: Error) => {
+        rejectWithOutput(error);
+      });
+
+      child.on('close', (code: number | null, closeSignal: NodeJS.Signals | null) => {
+        if (settled) return;
+        const stdout = Buffer.concat(stdoutChunks).toString('utf8');
+        const stderr = Buffer.concat(stderrChunks).toString('utf8');
+        settle(() => {
+          if (pendingFailure) {
+            if (closeSignal) pendingFailure.signal = closeSignal;
+            pendingFailure.stdout = stdout;
+            pendingFailure.stderr = stderr;
+            reject(pendingFailure);
+            return;
+          }
+          if (code === 0) {
+            resolve({ stdout, stderr });
+            return;
+          }
+          const error: any = new Error(code !== null
+            ? `Command failed with exit code ${code}`
+            : `Command terminated by signal ${closeSignal || 'unknown'}`);
+          if (code !== null) error.code = code;
+          if (closeSignal) error.signal = closeSignal;
+          error.stdout = stdout;
+          error.stderr = stderr;
+          reject(error);
+        });
+      });
+    });
   }
 
   private executeWindowsPowerShellScript(
@@ -367,7 +488,7 @@ export class ShellTool implements Tool {
       return Promise.reject(new Error('Internal error: missing Windows PowerShell script'));
     }
     if (signal?.aborted) {
-      return Promise.reject(new Error('Command aborted by user'));
+      return Promise.reject(this.createShellAbortError());
     }
 
     return new Promise((resolve, reject) => {
@@ -438,7 +559,11 @@ export class ShellTool implements Tool {
       abortHandler = () => {
         failAfterClose(this.createShellAbortError());
       };
-      signal?.addEventListener('abort', abortHandler, { once: true });
+      if (signal?.aborted) {
+        abortHandler();
+      } else {
+        signal?.addEventListener('abort', abortHandler, { once: true });
+      }
 
       child.stdout?.on('data', (chunk: Buffer) => {
         const buffer = Buffer.from(chunk);
@@ -470,6 +595,7 @@ export class ShellTool implements Tool {
         const stderr = this.decodeWindowsOutput(Buffer.concat(stderrChunks));
         settle(() => {
           if (pendingFailure) {
+            if (closeSignal) pendingFailure.signal = closeSignal;
             pendingFailure.stdout = stdout;
             pendingFailure.stderr = stderr;
             reject(pendingFailure);
@@ -565,7 +691,11 @@ export class ShellTool implements Tool {
       abortHandler = () => {
         failAfterClose(this.createShellAbortError());
       };
-      signal?.addEventListener('abort', abortHandler, { once: true });
+      if (signal?.aborted) {
+        abortHandler();
+      } else {
+        signal?.addEventListener('abort', abortHandler, { once: true });
+      }
 
       child.stdout?.on('data', (chunk: Buffer) => {
         const buffer = Buffer.from(chunk);
@@ -597,6 +727,7 @@ export class ShellTool implements Tool {
         const stderr = this.stripCmdSessionNoise(this.decodeWindowsOutput(Buffer.concat(stderrChunks)));
         settle(() => {
           if (pendingFailure) {
+            if (closeSignal) pendingFailure.signal = closeSignal;
             pendingFailure.stdout = stdout;
             pendingFailure.stderr = stderr;
             reject(pendingFailure);
@@ -654,7 +785,11 @@ export class ShellTool implements Tool {
       return;
     }
 
-    try { child.kill('SIGTERM'); } catch {}
+    try {
+      process.kill(-child.pid, 'SIGTERM');
+    } catch {
+      try { child.kill('SIGTERM'); } catch {}
+    }
   }
 
   private isPowerShellLaunchFailure(error: any): boolean {

--- a/src/tools/bash-tool.ts
+++ b/src/tools/bash-tool.ts
@@ -9,6 +9,7 @@ import { Logger } from '../utils/logger';
 import { resolveRuntimeEnvironment } from '../utils/runtime-environment';
 import { isToolAllowed, isBashCommandAllowed } from '../utils/safety';
 import { executeRouteIfRemote, resolveExecutionRoute, targetParameterDescription } from './execution-router';
+import { MAX_DEVICE_RPC_SHELL_CONTENT_CHARS } from './device-rpc-tool';
 
 const execAsync = promisify(exec);
 const CWD_MARKER_PREFIX = '__XIAOBA_CWD_MARKER__';
@@ -26,14 +27,21 @@ interface ShellOutput {
   stderr: string;
 }
 
+interface FormattedShellOutput {
+  content: string;
+  originalChars: number;
+  originalLines: number;
+}
+
 export class ShellTool implements Tool {
   definition: ToolDefinition = {
     name: 'execute_shell',
     description: [
-      '执行一条非交互式系统命令。',
-      '命令从当前目录或显式 cwd 启动；每次调用都是新的 shell 进程，只有最终当前目录会保留到后续工具调用。',
+      '执行一条非交互式系统命令，适合运行测试、构建、包管理器、系统诊断或项目脚本。',
+      '路径发现、目录概览和候选文件定位优先使用 glob；内容搜索使用 grep；读取已定位文件使用 read_file。',
+      'Windows 目标上 command 会作为 PowerShell 脚本执行，可直接写多行 PowerShell，无需再套一层 powershell -Command。',
+      '命令从当前目录启动；每次调用都是新的 shell 进程，只有最终当前目录会保留到后续工具调用。',
       '环境变量、alias、函数和已激活虚拟环境不会自动跨调用保留；需要时在同一条 command 中显式设置。',
-      '在 CatsCo/远程用户设备场景中，不要用它做普通文件查看或创建；查看文件列表用 glob，创建/覆盖文本文件用 write_file，编辑文件用 edit_file。',
     ].join('\n'),
     parameters: {
       type: 'object',
@@ -52,7 +60,7 @@ export class ShellTool implements Tool {
         },
         cwd: {
           type: 'string',
-          description: '可选。命令启动目录。支持绝对路径或相对当前目录的路径；需要在桌面/下载等目录运行命令时，先用 resolve_common_directory 解析，再把返回的 path 传给 cwd。',
+          description: 'Optional command start directory. Supports absolute paths or paths relative to the current working directory.',
         },
         confirm_dangerous: {
           type: 'boolean',
@@ -126,10 +134,7 @@ export class ShellTool implements Tool {
       const parsedStdout = this.extractDirectoryProbe(stdout || '', wrapped.marker);
       const parsedStderr = this.extractDirectoryProbe(stderr || '', wrapped.marker);
       const finalDirectory = this.readDirectoryProbe(wrapped) || parsedStdout.directory || parsedStderr.directory;
-      this.updateCurrentDirectory(
-        finalDirectory,
-        context,
-      );
+      this.updateCurrentDirectory(finalDirectory, context);
 
       const output = parsedStdout.output || '';
       if (parsedStderr.output) {
@@ -139,6 +144,7 @@ export class ShellTool implements Tool {
       const executionTime = Date.now() - startTime;
       const outputLines = output ? output.split('\n').length : 0;
       const outputSize = Buffer.byteLength(output, 'utf-8');
+      const formattedOutput = formatShellOutputForTool(output);
 
       Logger.success(`Command succeeded (elapsed: ${executionTime}ms)`);
       Logger.info(`  Output: ${outputLines} lines | ${(outputSize / 1024).toFixed(2)} KB`);
@@ -163,9 +169,10 @@ export class ShellTool implements Tool {
           finalDirectory ? `Final cwd: ${finalDirectory}` : '',
           `Shell: ${this.resolveShellDisplayName()}`,
           `Elapsed: ${executionTime}ms`,
-          `Output lines: ${outputLines}`,
+          `Output lines: ${formattedOutput.originalLines}`,
+          `Output chars: ${formattedOutput.originalChars}`,
           '',
-          output,
+          formattedOutput.content,
         ].filter(line => line !== '').join('\n'),
       };
     } catch (error: any) {
@@ -173,24 +180,13 @@ export class ShellTool implements Tool {
       const parsedStdout = this.extractDirectoryProbe(error.stdout || '', wrapped.marker);
       const parsedStderr = this.extractDirectoryProbe(error.stderr || '', wrapped.marker);
       const finalDirectory = this.readDirectoryProbe(wrapped) || parsedStdout.directory || parsedStderr.directory;
-      this.updateCurrentDirectory(
-        finalDirectory,
-        context,
-      );
+      this.updateCurrentDirectory(finalDirectory, context);
       if (context.abortSignal?.aborted || /aborted|abort/i.test(String(error.message || ''))) {
         Logger.warning(`命令已取消 (耗时: ${executionTime}ms)`);
         return {
           ok: false,
           errorCode: 'EXECUTION_TIMEOUT',
-          message: [
-            '命令已取消:',
-            `$ ${command}`,
-            '',
-            `Working directory: ${executionDirectory.directory}`,
-            finalDirectory ? `Final cwd: ${finalDirectory}` : '',
-            `Shell: ${this.resolveShellDisplayName()}`,
-            `执行时间: ${executionTime}ms`,
-          ].filter(line => line !== '').join('\n'),
+          message: `命令已取消:\n$ ${command}\n\n执行时间: ${executionTime}ms`,
         };
       }
       const errorOutput = [
@@ -198,6 +194,7 @@ export class ShellTool implements Tool {
         parsedStdout.output,
         this.formatExecutionError(error),
       ].filter(Boolean).join('\n').trim();
+      const formattedError = formatShellOutputForTool(errorOutput);
 
       Logger.error(`Command failed (elapsed: ${executionTime}ms)`);
       Logger.error(`  Error: ${error.message}`);
@@ -213,8 +210,10 @@ export class ShellTool implements Tool {
           finalDirectory ? `Final cwd: ${finalDirectory}` : '',
           `Shell: ${this.resolveShellDisplayName()}`,
           `Elapsed: ${executionTime}ms`,
+          `Error chars: ${formattedError.originalChars}`,
+          '',
           'Error:',
-          errorOutput,
+          formattedError.content,
         ].filter(line => line !== '').join('\n'),
       };
     } finally {
@@ -607,7 +606,7 @@ export class ShellTool implements Tool {
       return {
         ok: false,
         errorCode: 'INVALID_TOOL_ARGUMENTS',
-        message: 'execute_shell.cwd 必须是字符串路径。',
+        message: 'execute_shell.cwd must be a string path.',
       };
     }
     const directory = path.isAbsolute(cwd)
@@ -618,21 +617,21 @@ export class ShellTool implements Tool {
         return {
           ok: false,
           errorCode: 'INVALID_TOOL_ARGUMENTS',
-          message: `execute_shell.cwd 不存在: ${directory}`,
+          message: `execute_shell.cwd does not exist: ${directory}`,
         };
       }
       if (!fs.statSync(directory).isDirectory()) {
         return {
           ok: false,
           errorCode: 'INVALID_TOOL_ARGUMENTS',
-          message: `execute_shell.cwd 不是目录: ${directory}`,
+          message: `execute_shell.cwd is not a directory: ${directory}`,
         };
       }
     } catch (error: any) {
       return {
         ok: false,
         errorCode: 'INVALID_TOOL_ARGUMENTS',
-        message: `execute_shell.cwd 无法访问: ${error?.message || error}`,
+        message: `execute_shell.cwd is not accessible: ${error?.message || error}`,
       };
     }
     return { ok: true, directory };
@@ -665,4 +664,26 @@ export class ShellTool implements Tool {
       return;
     }
   }
+}
+
+function formatShellOutputForTool(output: string): FormattedShellOutput {
+  const originalChars = output.length;
+  const originalLines = output ? output.split(/\r\n|\n|\r/).length : 0;
+  if (originalChars <= MAX_DEVICE_RPC_SHELL_CONTENT_CHARS) {
+    return { content: output, originalChars, originalLines };
+  }
+
+  const headChars = Math.floor(MAX_DEVICE_RPC_SHELL_CONTENT_CHARS * 0.7);
+  const tailChars = MAX_DEVICE_RPC_SHELL_CONTENT_CHARS - headChars;
+  return {
+    content: [
+      output.slice(0, headChars).trimEnd(),
+      '',
+      `[execute_shell 输出已摘要：原始 ${originalChars} 字符 / ${originalLines} 行，仅保留开头 ${headChars} 字符和结尾 ${tailChars} 字符。请缩小命令范围，或改用 glob / grep / read_file 等专用工具继续。]`,
+      '',
+      output.slice(-tailChars).trimStart(),
+    ].join('\n'),
+    originalChars,
+    originalLines,
+  };
 }

--- a/src/tools/bash-tool.ts
+++ b/src/tools/bash-tool.ts
@@ -9,7 +9,6 @@ import { Logger } from '../utils/logger';
 import { resolveRuntimeEnvironment } from '../utils/runtime-environment';
 import { isToolAllowed, isBashCommandAllowed } from '../utils/safety';
 import { executeRouteIfRemote, resolveExecutionRoute, targetParameterDescription } from './execution-router';
-import { MAX_DEVICE_RPC_SHELL_CONTENT_CHARS } from './device-rpc-tool';
 
 const execAsync = promisify(exec);
 const CWD_MARKER_PREFIX = '__XIAOBA_CWD_MARKER__';
@@ -25,12 +24,6 @@ interface WrappedCommand {
 interface ShellOutput {
   stdout: string;
   stderr: string;
-}
-
-interface FormattedShellOutput {
-  content: string;
-  originalChars: number;
-  originalLines: number;
 }
 
 export class ShellTool implements Tool {
@@ -144,7 +137,6 @@ export class ShellTool implements Tool {
       const executionTime = Date.now() - startTime;
       const outputLines = output ? output.split('\n').length : 0;
       const outputSize = Buffer.byteLength(output, 'utf-8');
-      const formattedOutput = formatShellOutputForTool(output);
 
       Logger.success(`Command succeeded (elapsed: ${executionTime}ms)`);
       Logger.info(`  Output: ${outputLines} lines | ${(outputSize / 1024).toFixed(2)} KB`);
@@ -169,10 +161,9 @@ export class ShellTool implements Tool {
           finalDirectory ? `Final cwd: ${finalDirectory}` : '',
           `Shell: ${this.resolveShellDisplayName()}`,
           `Elapsed: ${executionTime}ms`,
-          `Output lines: ${formattedOutput.originalLines}`,
-          `Output chars: ${formattedOutput.originalChars}`,
+          `Output lines: ${outputLines}`,
           '',
-          formattedOutput.content,
+          output,
         ].filter(line => line !== '').join('\n'),
       };
     } catch (error: any) {
@@ -194,7 +185,6 @@ export class ShellTool implements Tool {
         parsedStdout.output,
         this.formatExecutionError(error),
       ].filter(Boolean).join('\n').trim();
-      const formattedError = formatShellOutputForTool(errorOutput);
 
       Logger.error(`Command failed (elapsed: ${executionTime}ms)`);
       Logger.error(`  Error: ${error.message}`);
@@ -210,10 +200,8 @@ export class ShellTool implements Tool {
           finalDirectory ? `Final cwd: ${finalDirectory}` : '',
           `Shell: ${this.resolveShellDisplayName()}`,
           `Elapsed: ${executionTime}ms`,
-          `Error chars: ${formattedError.originalChars}`,
-          '',
           'Error:',
-          formattedError.content,
+          errorOutput,
         ].filter(line => line !== '').join('\n'),
       };
     } finally {
@@ -664,26 +652,4 @@ export class ShellTool implements Tool {
       return;
     }
   }
-}
-
-function formatShellOutputForTool(output: string): FormattedShellOutput {
-  const originalChars = output.length;
-  const originalLines = output ? output.split(/\r\n|\n|\r/).length : 0;
-  if (originalChars <= MAX_DEVICE_RPC_SHELL_CONTENT_CHARS) {
-    return { content: output, originalChars, originalLines };
-  }
-
-  const headChars = Math.floor(MAX_DEVICE_RPC_SHELL_CONTENT_CHARS * 0.7);
-  const tailChars = MAX_DEVICE_RPC_SHELL_CONTENT_CHARS - headChars;
-  return {
-    content: [
-      output.slice(0, headChars).trimEnd(),
-      '',
-      `[execute_shell 输出已摘要：原始 ${originalChars} 字符 / ${originalLines} 行，仅保留开头 ${headChars} 字符和结尾 ${tailChars} 字符。请缩小命令范围，或改用 glob / grep / read_file 等专用工具继续。]`,
-      '',
-      output.slice(-tailChars).trimStart(),
-    ].join('\n'),
-    originalChars,
-    originalLines,
-  };
 }

--- a/src/tools/bash-tool.ts
+++ b/src/tools/bash-tool.ts
@@ -129,13 +129,15 @@ export class ShellTool implements Tool {
       const finalDirectory = this.readDirectoryProbe(wrapped) || parsedStdout.directory || parsedStderr.directory;
       this.updateCurrentDirectory(finalDirectory, context);
 
-      const output = parsedStdout.output || '';
-      if (parsedStderr.output) {
-        Logger.warning(`stderr: ${parsedStderr.output.substring(0, 200)}`);
+      const stdoutOutput = parsedStdout.output || '';
+      const stderrOutput = parsedStderr.output || '';
+      const output = this.formatSuccessfulOutput(stdoutOutput, stderrOutput);
+      if (stderrOutput) {
+        Logger.warning(`stderr: ${stderrOutput.substring(0, 200)}`);
       }
 
       const executionTime = Date.now() - startTime;
-      const outputLines = output ? output.split('\n').length : 0;
+      const outputLines = this.countOutputLines(output);
       const outputSize = Buffer.byteLength(output, 'utf-8');
 
       Logger.success(`Command succeeded (elapsed: ${executionTime}ms)`);
@@ -280,6 +282,7 @@ export class ShellTool implements Tool {
         cwd,
         env,
         encoding: 'utf-8',
+        shell: this.resolvePosixShell(env),
         timeout,
         signal,
         killSignal: 'SIGTERM',
@@ -539,6 +542,45 @@ export class ShellTool implements Tool {
       })
       .join('\n')
       .replace(/\n+$/, '');
+  }
+
+  private formatSuccessfulOutput(stdout: string, stderr: string): string {
+    const cleanStdout = String(stdout || '');
+    const cleanStderr = String(stderr || '');
+    if (cleanStdout && cleanStderr) {
+      return [
+        'Stdout:',
+        cleanStdout,
+        '',
+        'Stderr:',
+        cleanStderr,
+      ].join('\n');
+    }
+    if (cleanStderr) {
+      return ['Stderr:', cleanStderr].join('\n');
+    }
+    return cleanStdout;
+  }
+
+  private countOutputLines(output: string): number {
+    return output ? output.split('\n').length : 0;
+  }
+
+  private resolvePosixShell(env: NodeJS.ProcessEnv): string | undefined {
+    const candidates = [
+      env.SHELL && path.basename(env.SHELL) === 'bash' ? env.SHELL : undefined,
+      '/bin/bash',
+      '/usr/bin/bash',
+    ].filter((value): value is string => Boolean(value));
+
+    for (const candidate of candidates) {
+      try {
+        if (path.isAbsolute(candidate) && fs.existsSync(candidate)) return candidate;
+      } catch {
+        // Fall through to the next candidate.
+      }
+    }
+    return undefined;
   }
 
   private cleanupWrappedCommand(wrapped: WrappedCommand): void {

--- a/src/tools/bash-tool.ts
+++ b/src/tools/bash-tool.ts
@@ -1,4 +1,4 @@
-import { exec, spawn } from 'child_process';
+import { exec, spawn, type ChildProcess } from 'child_process';
 import { promisify } from 'util';
 import { TextDecoder } from 'util';
 import * as fs from 'fs';
@@ -351,7 +351,7 @@ export class ShellTool implements Tool {
       return await this.executeWindowsPowerShellScript(wrapped, cwd, env, timeout, signal);
     } catch (error) {
       if (!this.isPowerShellLaunchFailure(error)) throw error;
-      return this.executeWindowsCmdFallback(wrapped, cwd, env, timeout);
+      return this.executeWindowsCmdFallback(wrapped, cwd, env, timeout, signal);
     }
   }
 
@@ -388,37 +388,55 @@ export class ShellTool implements Tool {
       const stdoutChunks: Buffer[] = [];
       const stderrChunks: Buffer[] = [];
       let settled = false;
-      let timedOut = false;
+      let pendingFailure: any;
       let stdoutBytes = 0;
       let stderrBytes = 0;
       const maxBuffer = 10 * 1024 * 1024;
-      let timer: NodeJS.Timeout;
+      let timer: NodeJS.Timeout | undefined;
+      let closeWaitTimer: NodeJS.Timeout | undefined;
+      let abortHandler: (() => void) | undefined;
 
-      const finish = (fn: () => void) => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(timer);
+      const cleanup = () => {
+        if (timer) clearTimeout(timer);
+        if (closeWaitTimer) clearTimeout(closeWaitTimer);
         if (signal && abortHandler) {
           signal.removeEventListener('abort', abortHandler);
         }
+      };
+
+      const settle = (fn: () => void) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
         fn();
       };
 
-      const fail = (error: any) => {
-        finish(() => {
-          try { child.kill(); } catch {}
+      const rejectWithOutput = (error: any) => {
+        settle(() => {
           error.stdout = this.decodeWindowsOutput(Buffer.concat(stdoutChunks));
           error.stderr = this.decodeWindowsOutput(Buffer.concat(stderrChunks));
           reject(error);
         });
       };
 
+      const failAfterClose = (error: any) => {
+        if (settled) return;
+        if (pendingFailure) return;
+        pendingFailure = error;
+        this.terminateProcessTree(child);
+        closeWaitTimer = setTimeout(() => {
+          rejectWithOutput(error);
+        }, 5000);
+        closeWaitTimer.unref?.();
+      };
+
       timer = setTimeout(() => {
-        timedOut = true;
-        fail(new Error(`Command timed out after ${timeout}ms`));
+        failAfterClose(this.createShellTimeoutError(timeout));
       }, timeout);
-      const abortHandler = () => {
-        fail(new Error('Command aborted by user'));
+      timer.unref?.();
+
+      abortHandler = () => {
+        failAfterClose(this.createShellAbortError());
       };
       signal?.addEventListener('abort', abortHandler, { once: true });
 
@@ -426,7 +444,7 @@ export class ShellTool implements Tool {
         const buffer = Buffer.from(chunk);
         stdoutBytes += buffer.length;
         if (stdoutBytes > maxBuffer) {
-          fail(new Error(`stdout maxBuffer exceeded (${maxBuffer} bytes)`));
+          failAfterClose(new Error(`stdout maxBuffer exceeded (${maxBuffer} bytes)`));
           return;
         }
         stdoutChunks.push(buffer);
@@ -436,28 +454,34 @@ export class ShellTool implements Tool {
         const buffer = Buffer.from(chunk);
         stderrBytes += buffer.length;
         if (stderrBytes > maxBuffer) {
-          fail(new Error(`stderr maxBuffer exceeded (${maxBuffer} bytes)`));
+          failAfterClose(new Error(`stderr maxBuffer exceeded (${maxBuffer} bytes)`));
           return;
         }
         stderrChunks.push(buffer);
       });
 
       child.on('error', (error: Error) => {
-        fail(error);
+        rejectWithOutput(error);
       });
 
-      child.on('close', (code: number | null) => {
+      child.on('close', (code: number | null, closeSignal: NodeJS.Signals | null) => {
         if (settled) return;
         const stdout = this.decodeWindowsOutput(Buffer.concat(stdoutChunks));
         const stderr = this.decodeWindowsOutput(Buffer.concat(stderrChunks));
-        finish(() => {
-          if (timedOut) return;
+        settle(() => {
+          if (pendingFailure) {
+            pendingFailure.stdout = stdout;
+            pendingFailure.stderr = stderr;
+            reject(pendingFailure);
+            return;
+          }
           if (code === 0) {
             resolve({ stdout, stderr });
             return;
           }
           const error: any = new Error(`Command failed with exit code ${code}`);
-          error.code = code;
+          if (code !== null) error.code = code;
+          if (closeSignal) error.signal = closeSignal;
           error.stdout = stdout;
           error.stderr = stderr;
           reject(error);
@@ -471,10 +495,14 @@ export class ShellTool implements Tool {
     cwd: string,
     env: NodeJS.ProcessEnv,
     timeout: number,
+    signal?: AbortSignal,
   ): Promise<ShellOutput> {
     const cmdScript = wrapped.cmdScript;
     if (!cmdScript) {
       return Promise.reject(new Error('Internal error: missing Windows cmd script'));
+    }
+    if (signal?.aborted) {
+      return Promise.reject(this.createShellAbortError());
     }
 
     return new Promise((resolve, reject) => {
@@ -488,37 +516,62 @@ export class ShellTool implements Tool {
       const stdoutChunks: Buffer[] = [];
       const stderrChunks: Buffer[] = [];
       let settled = false;
-      let timedOut = false;
+      let pendingFailure: any;
       let stdoutBytes = 0;
       let stderrBytes = 0;
       const maxBuffer = 10 * 1024 * 1024;
+      let closeWaitTimer: NodeJS.Timeout | undefined;
+      let abortHandler: (() => void) | undefined;
 
-      const finish = (fn: () => void) => {
+      const cleanup = () => {
+        clearTimeout(timer);
+        if (closeWaitTimer) clearTimeout(closeWaitTimer);
+        if (signal && abortHandler) {
+          signal.removeEventListener('abort', abortHandler);
+        }
+      };
+
+      const settle = (fn: () => void) => {
         if (settled) return;
         settled = true;
-        clearTimeout(timer);
+        cleanup();
         fn();
       };
 
-      const fail = (error: any) => {
-        finish(() => {
-          try { child.kill(); } catch {}
+      const rejectWithOutput = (error: any) => {
+        settle(() => {
           error.stdout = this.stripCmdSessionNoise(this.decodeWindowsOutput(Buffer.concat(stdoutChunks)));
           error.stderr = this.stripCmdSessionNoise(this.decodeWindowsOutput(Buffer.concat(stderrChunks)));
           reject(error);
         });
       };
 
+      const failAfterClose = (error: any) => {
+        if (settled) return;
+        if (pendingFailure) return;
+        pendingFailure = error;
+        this.terminateProcessTree(child);
+        closeWaitTimer = setTimeout(() => {
+          rejectWithOutput(error);
+        }, 5000);
+        closeWaitTimer.unref?.();
+      };
+
       const timer = setTimeout(() => {
-        timedOut = true;
-        fail(new Error(`Command timed out after ${timeout}ms`));
+        failAfterClose(this.createShellTimeoutError(timeout));
       }, timeout);
+      timer.unref?.();
+
+      abortHandler = () => {
+        failAfterClose(this.createShellAbortError());
+      };
+      signal?.addEventListener('abort', abortHandler, { once: true });
 
       child.stdout?.on('data', (chunk: Buffer) => {
         const buffer = Buffer.from(chunk);
         stdoutBytes += buffer.length;
         if (stdoutBytes > maxBuffer) {
-          fail(new Error(`stdout maxBuffer exceeded (${maxBuffer} bytes)`));
+          failAfterClose(new Error(`stdout maxBuffer exceeded (${maxBuffer} bytes)`));
           return;
         }
         stdoutChunks.push(buffer);
@@ -528,28 +581,34 @@ export class ShellTool implements Tool {
         const buffer = Buffer.from(chunk);
         stderrBytes += buffer.length;
         if (stderrBytes > maxBuffer) {
-          fail(new Error(`stderr maxBuffer exceeded (${maxBuffer} bytes)`));
+          failAfterClose(new Error(`stderr maxBuffer exceeded (${maxBuffer} bytes)`));
           return;
         }
         stderrChunks.push(buffer);
       });
 
       child.on('error', (error: Error) => {
-        fail(error);
+        rejectWithOutput(error);
       });
 
-      child.on('close', (code: number | null) => {
+      child.on('close', (code: number | null, closeSignal: NodeJS.Signals | null) => {
         if (settled) return;
         const stdout = this.stripCmdSessionNoise(this.decodeWindowsOutput(Buffer.concat(stdoutChunks)));
         const stderr = this.stripCmdSessionNoise(this.decodeWindowsOutput(Buffer.concat(stderrChunks)));
-        finish(() => {
-          if (timedOut) return;
+        settle(() => {
+          if (pendingFailure) {
+            pendingFailure.stdout = stdout;
+            pendingFailure.stderr = stderr;
+            reject(pendingFailure);
+            return;
+          }
           if (code === 0) {
             resolve({ stdout, stderr });
             return;
           }
           const error: any = new Error(`Command failed with exit code ${code}`);
-          error.code = code;
+          if (code !== null) error.code = code;
+          if (closeSignal) error.signal = closeSignal;
           error.stdout = stdout;
           error.stderr = stderr;
           reject(error);
@@ -558,6 +617,44 @@ export class ShellTool implements Tool {
 
       child.stdin.end(cmdScript + '\r\n');
     });
+  }
+
+  private createShellTimeoutError(timeout: number): Error {
+    const error: any = new Error(`Command timed out after ${timeout}ms`);
+    error.code = 'ETIMEDOUT';
+    error.timedOut = true;
+    return error;
+  }
+
+  private createShellAbortError(): Error {
+    const error: any = new Error('Command aborted by user');
+    error.code = 'ABORT_ERR';
+    error.aborted = true;
+    return error;
+  }
+
+  private terminateProcessTree(child: ChildProcess): void {
+    if (!child.pid) {
+      try { child.kill(); } catch {}
+      return;
+    }
+
+    if (process.platform === 'win32') {
+      try {
+        const killer = spawn('taskkill', ['/pid', String(child.pid), '/t', '/f'], {
+          windowsHide: true,
+          stdio: 'ignore',
+        });
+        killer.on('error', () => {
+          try { child.kill(); } catch {}
+        });
+      } catch {
+        try { child.kill(); } catch {}
+      }
+      return;
+    }
+
+    try { child.kill('SIGTERM'); } catch {}
   }
 
   private isPowerShellLaunchFailure(error: any): boolean {
@@ -746,6 +843,7 @@ export class ShellTool implements Tool {
   }
 
   private isTimeoutError(error: any): boolean {
+    if (error?.timedOut === true) return true;
     const text = String(error?.message || error?.code || '').toLowerCase();
     return text.includes('timed out') || text.includes('timeout') || text === 'etimedout';
   }

--- a/src/tools/bash-tool.ts
+++ b/src/tools/bash-tool.ts
@@ -12,6 +12,7 @@ import { executeRouteIfRemote, resolveExecutionRoute, targetParameterDescription
 const CWD_MARKER_PREFIX = '__XIAOBA_CWD_MARKER__';
 const SHELL_CONTRACT_VERSION = 'shell/v1';
 const SHELL_INLINE_OUTPUT_MAX_CHARS = 30_000;
+const SHELL_INLINE_OUTPUT_DECODE_MAX_BYTES = SHELL_INLINE_OUTPUT_MAX_CHARS * 4;
 const SHELL_ARTIFACT_DIR = 'tool-results';
 
 interface WrappedCommand {
@@ -25,6 +26,33 @@ interface WrappedCommand {
 interface ShellOutput {
   stdout: string;
   stderr: string;
+  stdoutFilePath?: string;
+  stderrFilePath?: string;
+  decoder?: ShellOutputDecoder;
+  stripCmdNoise?: boolean;
+}
+
+type ShellOutputDecoder = 'utf8' | 'windows';
+
+interface ShellTempOutputFiles {
+  stdoutPath: string;
+  stderrPath: string;
+  stdoutFd: number;
+  stderrFd: number;
+}
+
+interface FileBackedProcessOptions {
+  command: string;
+  args: string[];
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  timeout: number;
+  signal?: AbortSignal;
+  stdin?: string;
+  detached?: boolean;
+  windowsHide?: boolean;
+  decoder?: ShellOutputDecoder;
+  stripCmdNoise?: boolean;
 }
 
 type ShellRunStatus = 'succeeded' | 'failed' | 'timed_out' | 'aborted';
@@ -68,6 +96,15 @@ interface ShellOutputPresentation {
   originalOutputChars: number;
   outputArtifact?: string;
   artifactError?: string;
+}
+
+interface ShellOutputMetadata {
+  command: string;
+  description?: string;
+  status: ShellRunStatus;
+  cwdBefore: string;
+  cwdAfter: string;
+  durationMs: number;
 }
 
 export class ShellTool implements Tool {
@@ -185,7 +222,7 @@ export class ShellTool implements Tool {
     const wrapped = this.wrapCommandWithDirectoryProbe(command);
 
     try {
-      const { stdout, stderr } = await this.executeWrappedCommand(
+      const shellOutput = await this.executeWrappedCommand(
         wrapped,
         executionDirectory.directory,
         runtimeEnvironment.env,
@@ -193,8 +230,8 @@ export class ShellTool implements Tool {
         context.abortSignal,
       );
 
-      const parsedStdout = this.extractDirectoryProbe(stdout || '', wrapped.marker);
-      const parsedStderr = this.extractDirectoryProbe(stderr || '', wrapped.marker);
+      const parsedStdout = this.extractDirectoryProbe(shellOutput.stdout || '', wrapped.marker);
+      const parsedStderr = this.extractDirectoryProbe(shellOutput.stderr || '', wrapped.marker);
       const cwdAfter = this.updateCurrentDirectory(
         this.readDirectoryProbe(wrapped) || parsedStdout.directory || parsedStderr.directory,
         context,
@@ -207,7 +244,7 @@ export class ShellTool implements Tool {
       }
 
       const executionTime = Date.now() - startTime;
-      const outputPresentation = this.prepareShellOutputPresentation(stdoutOutput, stderrOutput, context, {
+      const outputPresentation = this.prepareShellOutputPresentationForShellOutput(shellOutput, stdoutOutput, stderrOutput, context, {
         command,
         description,
         status: 'succeeded',
@@ -270,7 +307,7 @@ export class ShellTool implements Tool {
       if (aborted || timedOut) {
         const stdoutOutput = parsedStdout.output || '';
         const stderrOutput = parsedStderr.output || '';
-        const outputPresentation = this.prepareShellOutputPresentation(stdoutOutput, stderrOutput, context, {
+        const outputPresentation = this.prepareShellOutputPresentationForShellOutput(error, stdoutOutput, stderrOutput, context, {
           command,
           description,
           status: aborted ? 'aborted' : 'timed_out',
@@ -309,7 +346,7 @@ export class ShellTool implements Tool {
       }
       const stdoutOutput = parsedStdout.output || '';
       const stderrOutput = parsedStderr.output || '';
-      const outputPresentation = this.prepareShellOutputPresentation(stdoutOutput, stderrOutput, context, {
+      const outputPresentation = this.prepareShellOutputPresentationForShellOutput(error, stdoutOutput, stderrOutput, context, {
         command,
         description,
         status: 'failed',
@@ -370,16 +407,21 @@ export class ShellTool implements Tool {
       };
     }
 
+    const cwdFilePath = path.join(os.tmpdir(), `xiaoba-shell-cwd-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.txt`);
     return {
       command: [
         command,
         'status=$?',
-        // POSIX sh-compatible probe for Linux/macOS. Node exec() uses /bin/sh here.
-        `printf '\\n${marker}=%s\\n' "$PWD"`,
+        `printf '%s\\n' "$PWD" > ${this.quotePosixShellString(cwdFilePath)}`,
         'exit "$status"',
       ].join('\n'),
       marker,
+      cwdFilePath,
     };
+  }
+
+  private quotePosixShellString(value: string): string {
+    return `'${String(value).replace(/'/g, "'\\''")}'`;
   }
 
   private buildPowerShellScript(command: string, cwdFilePath: string): string {
@@ -442,128 +484,16 @@ export class ShellTool implements Tool {
     timeout: number,
     signal?: AbortSignal,
   ): Promise<ShellOutput> {
-    if (signal?.aborted) {
-      return Promise.reject(this.createShellAbortError());
-    }
-
     const shell = this.resolvePosixShell(env) || '/bin/sh';
-    return new Promise((resolve, reject) => {
-      const child = spawn(shell, ['-c', wrapped.command], {
-        cwd,
-        env,
-        detached: true,
-        stdio: ['ignore', 'pipe', 'pipe'],
-      });
-
-      const stdoutChunks: Buffer[] = [];
-      const stderrChunks: Buffer[] = [];
-      let settled = false;
-      let pendingFailure: any;
-      let stdoutBytes = 0;
-      let stderrBytes = 0;
-      const maxBuffer = 10 * 1024 * 1024;
-      let timer: NodeJS.Timeout | undefined;
-      let closeWaitTimer: NodeJS.Timeout | undefined;
-      let abortHandler: (() => void) | undefined;
-
-      const cleanup = () => {
-        if (timer) clearTimeout(timer);
-        if (closeWaitTimer) clearTimeout(closeWaitTimer);
-        if (signal && abortHandler) {
-          signal.removeEventListener('abort', abortHandler);
-        }
-      };
-
-      const settle = (fn: () => void) => {
-        if (settled) return;
-        settled = true;
-        cleanup();
-        fn();
-      };
-
-      const rejectWithOutput = (error: any) => {
-        settle(() => {
-          error.stdout = Buffer.concat(stdoutChunks).toString('utf8');
-          error.stderr = Buffer.concat(stderrChunks).toString('utf8');
-          reject(error);
-        });
-      };
-
-      const failAfterClose = (error: any) => {
-        if (settled) return;
-        if (pendingFailure) return;
-        pendingFailure = error;
-        this.terminateProcessTree(child);
-        closeWaitTimer = setTimeout(() => {
-          rejectWithOutput(error);
-        }, 5000);
-        closeWaitTimer.unref?.();
-      };
-
-      timer = setTimeout(() => {
-        failAfterClose(this.createShellTimeoutError(timeout));
-      }, timeout);
-      timer.unref?.();
-
-      abortHandler = () => {
-        failAfterClose(this.createShellAbortError());
-      };
-      if (signal?.aborted) {
-        abortHandler();
-      } else {
-        signal?.addEventListener('abort', abortHandler, { once: true });
-      }
-
-      child.stdout?.on('data', (chunk: Buffer) => {
-        const buffer = Buffer.from(chunk);
-        stdoutBytes += buffer.length;
-        if (stdoutBytes > maxBuffer) {
-          failAfterClose(new Error(`stdout maxBuffer exceeded (${maxBuffer} bytes)`));
-          return;
-        }
-        stdoutChunks.push(buffer);
-      });
-
-      child.stderr?.on('data', (chunk: Buffer) => {
-        const buffer = Buffer.from(chunk);
-        stderrBytes += buffer.length;
-        if (stderrBytes > maxBuffer) {
-          failAfterClose(new Error(`stderr maxBuffer exceeded (${maxBuffer} bytes)`));
-          return;
-        }
-        stderrChunks.push(buffer);
-      });
-
-      child.on('error', (error: Error) => {
-        rejectWithOutput(error);
-      });
-
-      child.on('close', (code: number | null, closeSignal: NodeJS.Signals | null) => {
-        if (settled) return;
-        const stdout = Buffer.concat(stdoutChunks).toString('utf8');
-        const stderr = Buffer.concat(stderrChunks).toString('utf8');
-        settle(() => {
-          if (pendingFailure) {
-            if (closeSignal) pendingFailure.signal = closeSignal;
-            pendingFailure.stdout = stdout;
-            pendingFailure.stderr = stderr;
-            reject(pendingFailure);
-            return;
-          }
-          if (code === 0) {
-            resolve({ stdout, stderr });
-            return;
-          }
-          const error: any = new Error(code !== null
-            ? `Command failed with exit code ${code}`
-            : `Command terminated by signal ${closeSignal || 'unknown'}`);
-          if (code !== null) error.code = code;
-          if (closeSignal) error.signal = closeSignal;
-          error.stdout = stdout;
-          error.stderr = stderr;
-          reject(error);
-        });
-      });
+    return this.executeFileBackedProcess({
+      command: shell,
+      args: ['-c', wrapped.command],
+      cwd,
+      env,
+      timeout,
+      signal,
+      detached: true,
+      decoder: 'utf8',
     });
   }
 
@@ -578,132 +508,22 @@ export class ShellTool implements Tool {
     if (!powershellScript) {
       return Promise.reject(new Error('Internal error: missing Windows PowerShell script'));
     }
-    if (signal?.aborted) {
-      return Promise.reject(this.createShellAbortError());
-    }
-
-    return new Promise((resolve, reject) => {
-      const child = spawn('powershell.exe', [
+    return this.executeFileBackedProcess({
+      command: 'powershell.exe',
+      args: [
         '-NoProfile',
         '-NonInteractive',
         '-ExecutionPolicy',
         'Bypass',
         '-EncodedCommand',
         Buffer.from(powershellScript, 'utf16le').toString('base64'),
-      ], {
-        cwd,
-        env,
-        windowsHide: true,
-        stdio: ['ignore', 'pipe', 'pipe'],
-      }) as ReturnType<typeof spawn>;
-
-      const stdoutChunks: Buffer[] = [];
-      const stderrChunks: Buffer[] = [];
-      let settled = false;
-      let pendingFailure: any;
-      let stdoutBytes = 0;
-      let stderrBytes = 0;
-      const maxBuffer = 10 * 1024 * 1024;
-      let timer: NodeJS.Timeout | undefined;
-      let closeWaitTimer: NodeJS.Timeout | undefined;
-      let abortHandler: (() => void) | undefined;
-
-      const cleanup = () => {
-        if (timer) clearTimeout(timer);
-        if (closeWaitTimer) clearTimeout(closeWaitTimer);
-        if (signal && abortHandler) {
-          signal.removeEventListener('abort', abortHandler);
-        }
-      };
-
-      const settle = (fn: () => void) => {
-        if (settled) return;
-        settled = true;
-        cleanup();
-        fn();
-      };
-
-      const rejectWithOutput = (error: any) => {
-        settle(() => {
-          error.stdout = this.decodeWindowsOutput(Buffer.concat(stdoutChunks));
-          error.stderr = this.decodeWindowsOutput(Buffer.concat(stderrChunks));
-          reject(error);
-        });
-      };
-
-      const failAfterClose = (error: any) => {
-        if (settled) return;
-        if (pendingFailure) return;
-        pendingFailure = error;
-        this.terminateProcessTree(child);
-        closeWaitTimer = setTimeout(() => {
-          rejectWithOutput(error);
-        }, 5000);
-        closeWaitTimer.unref?.();
-      };
-
-      timer = setTimeout(() => {
-        failAfterClose(this.createShellTimeoutError(timeout));
-      }, timeout);
-      timer.unref?.();
-
-      abortHandler = () => {
-        failAfterClose(this.createShellAbortError());
-      };
-      if (signal?.aborted) {
-        abortHandler();
-      } else {
-        signal?.addEventListener('abort', abortHandler, { once: true });
-      }
-
-      child.stdout?.on('data', (chunk: Buffer) => {
-        const buffer = Buffer.from(chunk);
-        stdoutBytes += buffer.length;
-        if (stdoutBytes > maxBuffer) {
-          failAfterClose(new Error(`stdout maxBuffer exceeded (${maxBuffer} bytes)`));
-          return;
-        }
-        stdoutChunks.push(buffer);
-      });
-
-      child.stderr?.on('data', (chunk: Buffer) => {
-        const buffer = Buffer.from(chunk);
-        stderrBytes += buffer.length;
-        if (stderrBytes > maxBuffer) {
-          failAfterClose(new Error(`stderr maxBuffer exceeded (${maxBuffer} bytes)`));
-          return;
-        }
-        stderrChunks.push(buffer);
-      });
-
-      child.on('error', (error: Error) => {
-        rejectWithOutput(error);
-      });
-
-      child.on('close', (code: number | null, closeSignal: NodeJS.Signals | null) => {
-        if (settled) return;
-        const stdout = this.decodeWindowsOutput(Buffer.concat(stdoutChunks));
-        const stderr = this.decodeWindowsOutput(Buffer.concat(stderrChunks));
-        settle(() => {
-          if (pendingFailure) {
-            if (closeSignal) pendingFailure.signal = closeSignal;
-            pendingFailure.stdout = stdout;
-            pendingFailure.stderr = stderr;
-            reject(pendingFailure);
-            return;
-          }
-          if (code === 0) {
-            resolve({ stdout, stderr });
-            return;
-          }
-          const error: any = new Error(`Command failed with exit code ${code}`);
-          if (code !== null) error.code = code;
-          if (closeSignal) error.signal = closeSignal;
-          error.stdout = stdout;
-          error.stderr = stderr;
-          reject(error);
-        });
-      });
+      ],
+      cwd,
+      env,
+      timeout,
+      signal,
+      windowsHide: true,
+      decoder: 'windows',
     });
   }
 
@@ -722,30 +542,60 @@ export class ShellTool implements Tool {
       return Promise.reject(this.createShellAbortError());
     }
 
-    return new Promise((resolve, reject) => {
-      const child = spawn('cmd.exe', ['/d', '/q'], {
-        cwd,
-        env,
-        windowsHide: true,
-        stdio: ['pipe', 'pipe', 'pipe'],
-      });
+    return this.executeFileBackedProcess({
+      command: 'cmd.exe',
+      args: ['/d', '/q'],
+      cwd,
+      env,
+      timeout,
+      signal,
+      stdin: cmdScript + '\r\n',
+      windowsHide: true,
+      decoder: 'windows',
+      stripCmdNoise: true,
+    });
+  }
 
-      const stdoutChunks: Buffer[] = [];
-      const stderrChunks: Buffer[] = [];
+  private executeFileBackedProcess(options: FileBackedProcessOptions): Promise<ShellOutput> {
+    if (options.signal?.aborted) {
+      return Promise.reject(this.createShellAbortError());
+    }
+
+    const outputFiles = this.createShellTempOutputFiles();
+    return new Promise((resolve, reject) => {
+      const stdinMode = options.stdin !== undefined ? 'pipe' : 'ignore';
+      let child: ReturnType<typeof spawn>;
+      try {
+        child = spawn(options.command, options.args, {
+          cwd: options.cwd,
+          env: options.env,
+          detached: options.detached,
+          windowsHide: options.windowsHide,
+          stdio: [stdinMode, outputFiles.stdoutFd, outputFiles.stderrFd] as any,
+        });
+      } catch (error) {
+        this.closeShellTempOutputFiles(outputFiles);
+        this.cleanupShellOutputFiles({
+          stdoutFilePath: outputFiles.stdoutPath,
+          stderrFilePath: outputFiles.stderrPath,
+        });
+        reject(error);
+        return;
+      }
+
       let settled = false;
       let pendingFailure: any;
-      let stdoutBytes = 0;
-      let stderrBytes = 0;
-      const maxBuffer = 10 * 1024 * 1024;
+      let timer: NodeJS.Timeout | undefined;
       let closeWaitTimer: NodeJS.Timeout | undefined;
       let abortHandler: (() => void) | undefined;
 
       const cleanup = () => {
-        clearTimeout(timer);
+        if (timer) clearTimeout(timer);
         if (closeWaitTimer) clearTimeout(closeWaitTimer);
-        if (signal && abortHandler) {
-          signal.removeEventListener('abort', abortHandler);
+        if (options.signal && abortHandler) {
+          options.signal.removeEventListener('abort', abortHandler);
         }
+        this.closeShellTempOutputFiles(outputFiles);
       };
 
       const settle = (fn: () => void) => {
@@ -755,10 +605,37 @@ export class ShellTool implements Tool {
         fn();
       };
 
+      const outputResult = (): ShellOutput => ({
+        stdout: '',
+        stderr: '',
+        stdoutFilePath: outputFiles.stdoutPath,
+        stderrFilePath: outputFiles.stderrPath,
+        decoder: options.decoder || 'utf8',
+        stripCmdNoise: options.stripCmdNoise,
+      });
+
+      const attachOutput = (target: any) => {
+        const output = outputResult();
+        target.stdout = output.stdout;
+        target.stderr = output.stderr;
+        target.stdoutFilePath = output.stdoutFilePath;
+        target.stderrFilePath = output.stderrFilePath;
+        target.decoder = output.decoder;
+        target.stripCmdNoise = output.stripCmdNoise;
+      };
+
+      const rejectWithoutOutput = (error: any) => {
+        settle(() => {
+          error.stdout = '';
+          error.stderr = '';
+          this.cleanupShellOutputFiles(outputResult());
+          reject(error);
+        });
+      };
+
       const rejectWithOutput = (error: any) => {
         settle(() => {
-          error.stdout = this.stripCmdSessionNoise(this.decodeWindowsOutput(Buffer.concat(stdoutChunks)));
-          error.stderr = this.stripCmdSessionNoise(this.decodeWindowsOutput(Buffer.concat(stderrChunks)));
+          attachOutput(error);
           reject(error);
         });
       };
@@ -774,70 +651,50 @@ export class ShellTool implements Tool {
         closeWaitTimer.unref?.();
       };
 
-      const timer = setTimeout(() => {
-        failAfterClose(this.createShellTimeoutError(timeout));
-      }, timeout);
+      timer = setTimeout(() => {
+        failAfterClose(this.createShellTimeoutError(options.timeout));
+      }, options.timeout);
       timer.unref?.();
 
       abortHandler = () => {
         failAfterClose(this.createShellAbortError());
       };
-      if (signal?.aborted) {
+      if (options.signal?.aborted) {
         abortHandler();
       } else {
-        signal?.addEventListener('abort', abortHandler, { once: true });
+        options.signal?.addEventListener('abort', abortHandler, { once: true });
       }
 
-      child.stdout?.on('data', (chunk: Buffer) => {
-        const buffer = Buffer.from(chunk);
-        stdoutBytes += buffer.length;
-        if (stdoutBytes > maxBuffer) {
-          failAfterClose(new Error(`stdout maxBuffer exceeded (${maxBuffer} bytes)`));
-          return;
-        }
-        stdoutChunks.push(buffer);
-      });
-
-      child.stderr?.on('data', (chunk: Buffer) => {
-        const buffer = Buffer.from(chunk);
-        stderrBytes += buffer.length;
-        if (stderrBytes > maxBuffer) {
-          failAfterClose(new Error(`stderr maxBuffer exceeded (${maxBuffer} bytes)`));
-          return;
-        }
-        stderrChunks.push(buffer);
-      });
-
       child.on('error', (error: Error) => {
-        rejectWithOutput(error);
+        rejectWithoutOutput(error);
       });
 
       child.on('close', (code: number | null, closeSignal: NodeJS.Signals | null) => {
         if (settled) return;
-        const stdout = this.stripCmdSessionNoise(this.decodeWindowsOutput(Buffer.concat(stdoutChunks)));
-        const stderr = this.stripCmdSessionNoise(this.decodeWindowsOutput(Buffer.concat(stderrChunks)));
         settle(() => {
           if (pendingFailure) {
             if (closeSignal) pendingFailure.signal = closeSignal;
-            pendingFailure.stdout = stdout;
-            pendingFailure.stderr = stderr;
+            attachOutput(pendingFailure);
             reject(pendingFailure);
             return;
           }
           if (code === 0) {
-            resolve({ stdout, stderr });
+            resolve(outputResult());
             return;
           }
-          const error: any = new Error(`Command failed with exit code ${code}`);
+          const error: any = new Error(code !== null
+            ? `Command failed with exit code ${code}`
+            : `Command terminated by signal ${closeSignal || 'unknown'}`);
           if (code !== null) error.code = code;
           if (closeSignal) error.signal = closeSignal;
-          error.stdout = stdout;
-          error.stderr = stderr;
+          attachOutput(error);
           reject(error);
         });
       });
 
-      child.stdin.end(cmdScript + '\r\n');
+      if (options.stdin !== undefined) {
+        child.stdin?.end(options.stdin);
+      }
     });
   }
 
@@ -924,18 +781,119 @@ export class ShellTool implements Tool {
       .replace(/\n+$/, '');
   }
 
+  private createShellTempOutputFiles(): ShellTempOutputFiles {
+    const suffix = `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const stdoutPath = path.join(os.tmpdir(), `xiaoba-shell-stdout-${suffix}.log`);
+    const stderrPath = path.join(os.tmpdir(), `xiaoba-shell-stderr-${suffix}.log`);
+    let stdoutFd: number | undefined;
+    let stderrFd: number | undefined;
+
+    try {
+      stdoutFd = fs.openSync(stdoutPath, 'w');
+      stderrFd = fs.openSync(stderrPath, 'w');
+      return { stdoutPath, stderrPath, stdoutFd, stderrFd };
+    } catch (error) {
+      if (stdoutFd !== undefined) {
+        try { fs.closeSync(stdoutFd); } catch {}
+      }
+      if (stderrFd !== undefined) {
+        try { fs.closeSync(stderrFd); } catch {}
+      }
+      for (const filePath of [stdoutPath, stderrPath]) {
+        try {
+          if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+        } catch {}
+      }
+      throw error;
+    }
+  }
+
+  private closeShellTempOutputFiles(files: ShellTempOutputFiles): void {
+    for (const fd of [files.stdoutFd, files.stderrFd]) {
+      try { fs.closeSync(fd); } catch {}
+    }
+  }
+
+  private cleanupShellOutputFiles(output: Partial<ShellOutput> | undefined): void {
+    if (!output) return;
+    for (const filePath of [output.stdoutFilePath, output.stderrFilePath]) {
+      if (!filePath) continue;
+      try {
+        if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+      } catch {
+        // Best-effort cleanup only; Windows can keep files busy briefly after process exit.
+      }
+    }
+  }
+
+  private prepareShellOutputPresentationForShellOutput(
+    output: Partial<ShellOutput> | undefined,
+    stdout: string,
+    stderr: string,
+    context: ToolExecutionContext,
+    metadata: ShellOutputMetadata,
+  ): ShellOutputPresentation {
+    if (output?.stdoutFilePath || output?.stderrFilePath) {
+      return this.prepareShellOutputPresentationFromFiles(output, context, metadata);
+    }
+    return this.prepareShellOutputPresentation(stdout, stderr, context, metadata);
+  }
+
+  private prepareShellOutputPresentationFromFiles(
+    output: Partial<ShellOutput>,
+    context: ToolExecutionContext,
+    metadata: ShellOutputMetadata,
+  ): ShellOutputPresentation {
+    const decoder = output.decoder || 'utf8';
+    const stripCmdNoise = output.stripCmdNoise === true;
+
+    try {
+      const stdoutBytes = this.getOutputFileSize(output.stdoutFilePath);
+      const stderrBytes = this.getOutputFileSize(output.stderrFilePath);
+      const totalBytes = stdoutBytes + stderrBytes;
+
+      if (totalBytes <= SHELL_INLINE_OUTPUT_DECODE_MAX_BYTES) {
+        const stdoutOutput = this.readDecodedOutputFile(output.stdoutFilePath, decoder, stripCmdNoise);
+        const stderrOutput = this.readDecodedOutputFile(output.stderrFilePath, decoder, stripCmdNoise);
+        return this.prepareShellOutputPresentation(stdoutOutput, stderrOutput, context, metadata);
+      }
+
+      let outputArtifact: string | undefined;
+      let artifactError: string | undefined;
+      try {
+        outputArtifact = this.writeShellOutputArtifactFromFiles(output, context, metadata, stdoutBytes, stderrBytes);
+      } catch (error: any) {
+        artifactError = String(error?.message || error || 'failed to write shell output artifact');
+      }
+
+      const budgets = this.allocateInlineOutputBudgets(stdoutBytes, stderrBytes);
+      const previewStdout = this.buildOutputPreviewFromFile(output.stdoutFilePath, budgets.stdout, decoder, stripCmdNoise);
+      const previewStderr = this.buildOutputPreviewFromFile(output.stderrFilePath, budgets.stderr, decoder, stripCmdNoise);
+
+      return {
+        stdout: previewStdout,
+        stderr: previewStderr,
+        stdoutLines: this.countFileLines(output.stdoutFilePath),
+        stderrLines: this.countFileLines(output.stderrFilePath),
+        stdoutBytes,
+        stderrBytes,
+        truncated: true,
+        truncatedReason: 'output_exceeded_inline_limit',
+        inlineOutputChars: previewStdout.length + previewStderr.length,
+        originalOutputChars: totalBytes,
+        outputArtifact,
+        artifactError,
+      };
+    } finally {
+      this.cleanupShellOutputFiles(output);
+    }
+  }
+
   private prepareShellOutputPresentation(
     stdout: string,
     stderr: string,
     context: ToolExecutionContext,
-    metadata: {
-      command: string;
-      description?: string;
-      status: ShellRunStatus;
-      cwdBefore: string;
-      cwdAfter: string;
-      durationMs: number;
-    },
+    metadata: ShellOutputMetadata,
   ): ShellOutputPresentation {
     const stdoutOutput = String(stdout || '');
     const stderrOutput = String(stderr || '');
@@ -989,14 +947,7 @@ export class ShellTool implements Tool {
     stdout: string,
     stderr: string,
     context: ToolExecutionContext,
-    metadata: {
-      command: string;
-      description?: string;
-      status: ShellRunStatus;
-      cwdBefore: string;
-      cwdAfter: string;
-      durationMs: number;
-    },
+    metadata: ShellOutputMetadata,
   ): string {
     const root = path.resolve(context.workspaceRoot || context.workingDirectory || process.cwd());
     const dir = path.join(root, SHELL_ARTIFACT_DIR);
@@ -1022,6 +973,162 @@ export class ShellTool implements Tool {
     ].filter(line => line !== '').join('\n');
     fs.writeFileSync(filePath, content, 'utf8');
     return filePath;
+  }
+
+  private writeShellOutputArtifactFromFiles(
+    output: Partial<ShellOutput>,
+    context: ToolExecutionContext,
+    metadata: ShellOutputMetadata,
+    stdoutBytes: number,
+    stderrBytes: number,
+  ): string {
+    const root = path.resolve(context.workspaceRoot || context.workingDirectory || process.cwd());
+    const dir = path.join(root, SHELL_ARTIFACT_DIR);
+    fs.mkdirSync(dir, { recursive: true });
+    const filePath = path.join(dir, `shell-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}.log`);
+    const fd = fs.openSync(filePath, 'w');
+
+    try {
+      this.writeArtifactText(fd, [
+        'Shell output artifact',
+        `contract_version: ${SHELL_CONTRACT_VERSION}`,
+        `status: ${metadata.status}`,
+        `command: ${this.formatHeaderValue(metadata.command)}`,
+        metadata.description ? `description: ${this.formatHeaderValue(metadata.description)}` : '',
+        `duration_ms: ${metadata.durationMs}`,
+        `cwd_before: ${metadata.cwdBefore}`,
+        `cwd_after: ${metadata.cwdAfter}`,
+        `stdout_bytes: ${stdoutBytes}`,
+        `stderr_bytes: ${stderrBytes}`,
+        '',
+        'stdout:',
+      ].filter(line => line !== '').join('\n') + '\n');
+
+      if (output.stdoutFilePath && stdoutBytes > 0) {
+        this.appendFileToArtifact(fd, output.stdoutFilePath);
+      } else {
+        this.writeArtifactText(fd, '(empty)');
+      }
+
+      this.writeArtifactText(fd, '\n\nstderr:\n');
+      if (output.stderrFilePath && stderrBytes > 0) {
+        this.appendFileToArtifact(fd, output.stderrFilePath);
+      } else {
+        this.writeArtifactText(fd, '(empty)');
+      }
+    } finally {
+      try { fs.closeSync(fd); } catch {}
+    }
+
+    return filePath;
+  }
+
+  private writeArtifactText(fd: number, text: string): void {
+    fs.writeSync(fd, Buffer.from(text, 'utf8'));
+  }
+
+  private appendFileToArtifact(fd: number, filePath: string): void {
+    const inputFd = fs.openSync(filePath, 'r');
+    const buffer = Buffer.allocUnsafe(64 * 1024);
+    try {
+      while (true) {
+        const bytesRead = fs.readSync(inputFd, buffer, 0, buffer.length, null);
+        if (bytesRead <= 0) break;
+        fs.writeSync(fd, buffer, 0, bytesRead);
+      }
+    } finally {
+      try { fs.closeSync(inputFd); } catch {}
+    }
+  }
+
+  private readDecodedOutputFile(filePath: string | undefined, decoder: ShellOutputDecoder, stripCmdNoise: boolean): string {
+    if (!filePath || !fs.existsSync(filePath)) return '';
+    let output = this.decodeShellOutputBuffer(fs.readFileSync(filePath), decoder);
+    if (stripCmdNoise) output = this.stripCmdSessionNoise(output);
+    return this.normalizeVisibleShellOutput(output);
+  }
+
+  private decodeShellOutputBuffer(buffer: Buffer, decoder: ShellOutputDecoder): string {
+    return decoder === 'windows' ? this.decodeWindowsOutput(buffer) : buffer.toString('utf8');
+  }
+
+  private normalizeVisibleShellOutput(output: string): string {
+    return this.stripAnyDirectoryProbe(output)
+      .replace(/^\n+/, '')
+      .replace(/\n+$/, '');
+  }
+
+  private getOutputFileSize(filePath: string | undefined): number {
+    if (!filePath) return 0;
+    try {
+      return fs.statSync(filePath).size;
+    } catch {
+      return 0;
+    }
+  }
+
+  private countFileLines(filePath: string | undefined): number {
+    const size = this.getOutputFileSize(filePath);
+    if (!filePath || size <= 0) return 0;
+
+    const fd = fs.openSync(filePath, 'r');
+    const buffer = Buffer.allocUnsafe(64 * 1024);
+    let position = 0;
+    let newlines = 0;
+    try {
+      while (position < size) {
+        const bytesRead = fs.readSync(fd, buffer, 0, Math.min(buffer.length, size - position), position);
+        if (bytesRead <= 0) break;
+        for (let index = 0; index < bytesRead; index += 1) {
+          if (buffer[index] === 10) newlines += 1;
+        }
+        position += bytesRead;
+      }
+    } finally {
+      try { fs.closeSync(fd); } catch {}
+    }
+
+    return newlines + 1;
+  }
+
+  private buildOutputPreviewFromFile(
+    filePath: string | undefined,
+    maxChars: number,
+    decoder: ShellOutputDecoder,
+    stripCmdNoise: boolean,
+  ): string {
+    if (!filePath || maxChars <= 0) return '';
+
+    const size = this.getOutputFileSize(filePath);
+    if (size <= 0) return '';
+    if (size <= maxChars * 4) {
+      return this.buildOutputPreview(this.readDecodedOutputFile(filePath, decoder, stripCmdNoise), maxChars);
+    }
+
+    const marker = `\n\n... [truncated, ${size} bytes total; full output saved as artifact] ...\n\n`;
+    const available = maxChars - marker.length;
+    if (available <= 0) return marker.trim().slice(0, maxChars);
+
+    const headBytes = Math.max(0, Math.floor(available * 0.7));
+    const tailBytes = Math.max(0, available - headBytes);
+    const head = this.decodeShellOutputBuffer(this.readFileRange(filePath, 0, headBytes), decoder);
+    const tailStart = Math.max(0, size - tailBytes);
+    const tail = tailBytes > 0 ? this.decodeShellOutputBuffer(this.readFileRange(filePath, tailStart, tailBytes), decoder) : '';
+    let preview = `${head}${marker}${tail}`;
+    if (stripCmdNoise) preview = this.stripCmdSessionNoise(preview);
+    return preview.length > maxChars ? preview.slice(0, maxChars) : preview;
+  }
+
+  private readFileRange(filePath: string, start: number, length: number): Buffer {
+    if (length <= 0) return Buffer.alloc(0);
+    const fd = fs.openSync(filePath, 'r');
+    const buffer = Buffer.allocUnsafe(length);
+    try {
+      const bytesRead = fs.readSync(fd, buffer, 0, length, start);
+      return bytesRead === length ? buffer : buffer.subarray(0, bytesRead);
+    } finally {
+      try { fs.closeSync(fd); } catch {}
+    }
   }
 
   private allocateInlineOutputBudgets(stdoutChars: number, stderrChars: number): { stdout: number; stderr: number } {

--- a/src/tools/device-rpc-tool.ts
+++ b/src/tools/device-rpc-tool.ts
@@ -2,8 +2,17 @@ import type { DeviceGrantOperation } from '../types/session-identity';
 import type { ToolErrorCode, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import type { ToolGatewayDecision } from './tool-gateway';
 
-const REMOTE_TOOL_TIMEOUT_MS = 60_000;
+const REMOTE_TOOL_DEFAULT_TIMEOUT_MS = 60_000;
+const REMOTE_TOOL_MIN_TIMEOUT_MS = 5_000;
+const REMOTE_TOOL_MAX_TIMEOUT_MS = 180_000;
 export const MAX_DEVICE_RPC_TOOL_CONTENT_CHARS = 48_000;
+export const MAX_DEVICE_RPC_SHELL_CONTENT_CHARS = 12_000;
+
+type RemoteDeviceRpcToolName = 'read_file' | 'resolve_common_directory' | 'glob' | 'grep' | 'write_file' | 'edit_file' | 'execute_shell';
+
+interface DeviceRpcNormalizeOptions {
+  toolName?: string;
+}
 
 export function isRemoteReadonlyTool(toolName: string, operation: DeviceGrantOperation): boolean {
   return (toolName === 'read_file' && operation === 'read_file')
@@ -22,7 +31,7 @@ export function isRemoteDeviceRpcTool(toolName: string, operation: DeviceGrantOp
 export async function executeRemoteDeviceRpcTool(
   context: ToolExecutionContext,
   gateway: ToolGatewayDecision,
-  toolName: 'read_file' | 'resolve_common_directory' | 'glob' | 'grep' | 'write_file' | 'edit_file' | 'execute_shell',
+  toolName: RemoteDeviceRpcToolName,
   operation: DeviceGrantOperation,
   args: Record<string, unknown>,
 ): Promise<ToolExecutionResult | undefined> {
@@ -54,13 +63,13 @@ export async function executeRemoteDeviceRpcTool(
       targetDeviceDisplayName: gateway.targetDeviceDisplayName,
       targetDeviceBodyId: gateway.targetDeviceBodyId,
       targetDeviceInstallationId: gateway.targetDeviceInstallationId,
-      timeoutMs: gateway.grant ? timeoutForGrant(gateway.grant.expiresAt) : REMOTE_TOOL_TIMEOUT_MS,
+      timeoutMs: resolveRemoteToolTimeoutMs(gateway.grant?.expiresAt, requestedToolTimeoutMs(toolName, args)),
     });
   } catch (error: any) {
     return {
       ok: false,
       errorCode: mapRpcErrorCode(error),
-      message: `远程设备工具执行失败: ${error?.message || error || 'unknown error'}`,
+      message: formatRpcErrorMessage(error, toolName),
       retryable: isRetryableRpcError(error),
     };
   }
@@ -81,7 +90,10 @@ export async function executeRemoteReadonlyTool(
   return executeRemoteDeviceRpcTool(context, gateway, toolName, operation, args);
 }
 
-export function normalizeDeviceRpcToolResultPayload(payload: unknown): ToolExecutionResult {
+export function normalizeDeviceRpcToolResultPayload(
+  payload: unknown,
+  options: DeviceRpcNormalizeOptions = {},
+): ToolExecutionResult {
   if (!payload || typeof payload !== 'object') {
     return {
       ok: false,
@@ -93,14 +105,14 @@ export function normalizeDeviceRpcToolResultPayload(payload: unknown): ToolExecu
   if (record.ok === true) {
     return {
       ok: true,
-      content: normalizeDeviceRpcContent(record.content),
+      content: normalizeDeviceRpcContent(record.content, options),
     };
   }
   if (record.ok === false) {
     return {
       ok: false,
       errorCode: normalizeErrorCode(record.errorCode),
-      message: truncateText(String(record.message || '远程设备工具执行失败。')),
+      message: truncateText(String(record.message || '远程设备工具执行失败。'), options),
       retryable: Boolean(record.retryable),
     };
   }
@@ -111,29 +123,49 @@ export function normalizeDeviceRpcToolResultPayload(payload: unknown): ToolExecu
   };
 }
 
-export function normalizeDeviceRpcToolResultForTransport(result: ToolExecutionResult): ToolExecutionResult {
+export function normalizeDeviceRpcToolResultForTransport(
+  result: ToolExecutionResult,
+  options: DeviceRpcNormalizeOptions = {},
+): ToolExecutionResult {
   if (!result.ok) {
     return {
       ok: false,
       errorCode: normalizeErrorCode(result.errorCode),
-      message: truncateText(result.message),
+      message: truncateText(result.message, options),
       retryable: Boolean(result.retryable),
     };
   }
   return {
     ok: true,
-    content: normalizeDeviceRpcContent(result.content),
+    content: normalizeDeviceRpcContent(result.content, options),
   };
 }
 
-function timeoutForGrant(expiresAt: number): number {
-  const remaining = expiresAt - Date.now();
-  if (!Number.isFinite(remaining) || remaining <= 0) return 10_000;
-  return Math.max(5_000, Math.min(REMOTE_TOOL_TIMEOUT_MS, remaining));
+export function resolveRemoteToolTimeoutMs(
+  expiresAt?: number,
+  requestedTimeoutMs?: number,
+  now = Date.now(),
+): number {
+  const grantRemaining = typeof expiresAt === 'number' ? expiresAt - now : REMOTE_TOOL_DEFAULT_TIMEOUT_MS;
+  if (!Number.isFinite(grantRemaining) || grantRemaining <= 0) return REMOTE_TOOL_MIN_TIMEOUT_MS;
+  const requested = Number.isFinite(requestedTimeoutMs)
+    ? Math.floor(requestedTimeoutMs as number)
+    : REMOTE_TOOL_DEFAULT_TIMEOUT_MS;
+  const desired = Math.min(
+    REMOTE_TOOL_MAX_TIMEOUT_MS,
+    Math.max(REMOTE_TOOL_MIN_TIMEOUT_MS, requested),
+  );
+  return Math.max(0, Math.min(desired, Math.floor(grantRemaining)));
 }
 
-function normalizeDeviceRpcContent(content: unknown): string {
-  if (typeof content === 'string') return truncateText(content);
+function requestedToolTimeoutMs(toolName: string, args: Record<string, unknown>): number | undefined {
+  if (toolName !== 'execute_shell') return undefined;
+  const timeout = Number(args?.timeout);
+  return Number.isFinite(timeout) && timeout > 0 ? timeout : undefined;
+}
+
+function normalizeDeviceRpcContent(content: unknown, options: DeviceRpcNormalizeOptions): string {
+  if (typeof content === 'string') return truncateText(content, options);
   if (Array.isArray(content)) {
     const lines: string[] = [];
     for (const block of content) {
@@ -145,7 +177,7 @@ function normalizeDeviceRpcContent(content: unknown): string {
         lines.push('[远程设备返回了图片内容块；当前 Device RPC 不转发图片二进制，请让用户以附件方式上传该图片。]');
       }
     }
-    return truncateText(lines.join('\n'));
+    return truncateText(lines.join('\n'), options);
   }
   if (content && typeof content === 'object') {
     const record = content as Record<string, unknown>;
@@ -153,15 +185,36 @@ function normalizeDeviceRpcContent(content: unknown): string {
       return '[远程设备读取到图片文件；当前 Device RPC 不转发图片二进制，请让用户以附件方式上传该图片。]';
     }
   }
-  return truncateText(String(content ?? ''));
+  return truncateText(String(content ?? ''), options);
 }
 
-function truncateText(value: string): string {
-  if (value.length <= MAX_DEVICE_RPC_TOOL_CONTENT_CHARS) return value;
+function truncateText(value: string, options: DeviceRpcNormalizeOptions = {}): string {
+  const maxChars = maxContentCharsForTool(options.toolName);
+  if (value.length <= maxChars) return value;
+  if (options.toolName === 'execute_shell') return summarizeLongShellOutput(value, maxChars);
   return [
-    value.slice(0, MAX_DEVICE_RPC_TOOL_CONTENT_CHARS),
+    value.slice(0, maxChars),
     '',
-    `[远程设备结果超过 ${MAX_DEVICE_RPC_TOOL_CONTENT_CHARS} 字符，已截断。请用更精确的 path/pattern/limit/offset 继续读取。]`,
+    `[远程设备结果超过 ${maxChars} 字符，已截断。请用更精确的 path/pattern/limit/offset 继续读取。]`,
+  ].join('\n');
+}
+
+function maxContentCharsForTool(toolName?: string): number {
+  return toolName === 'execute_shell'
+    ? MAX_DEVICE_RPC_SHELL_CONTENT_CHARS
+    : MAX_DEVICE_RPC_TOOL_CONTENT_CHARS;
+}
+
+function summarizeLongShellOutput(value: string, maxChars: number): string {
+  const lineCount = value.split(/\r\n|\n|\r/).length;
+  const headChars = Math.floor(maxChars * 0.7);
+  const tailChars = Math.max(0, maxChars - headChars);
+  return [
+    value.slice(0, headChars).trimEnd(),
+    '',
+    `[execute_shell 输出已摘要：原始 ${value.length} 字符 / ${lineCount} 行，仅保留开头 ${headChars} 字符和结尾 ${tailChars} 字符。请缩小命令范围，或改用 glob / grep / read_file 等专用工具继续。]`,
+    '',
+    value.slice(-tailChars).trimStart(),
   ].join('\n');
 }
 
@@ -191,4 +244,10 @@ function mapRpcErrorCode(error: any): ToolErrorCode {
 function isRetryableRpcError(error: any): boolean {
   const text = String(error?.code || error?.kind || error?.message || '').toLowerCase();
   return text.includes('timeout') || text.includes('offline') || text.includes('unavailable') || text.includes('transport');
+}
+
+function formatRpcErrorMessage(error: any, toolName: string): string {
+  const message = `远程设备工具执行失败: ${error?.message || error || 'unknown error'}`;
+  if (toolName !== 'execute_shell' || mapRpcErrorCode(error) !== 'EXECUTION_TIMEOUT') return message;
+  return `${message}\n请缩小命令范围，或改用 glob / grep / read_file 等专用工具继续；避免无变化地重复执行同一条长命令。`;
 }

--- a/src/tools/device-rpc-tool.ts
+++ b/src/tools/device-rpc-tool.ts
@@ -6,7 +6,6 @@ const REMOTE_TOOL_DEFAULT_TIMEOUT_MS = 60_000;
 const REMOTE_TOOL_MIN_TIMEOUT_MS = 5_000;
 const REMOTE_TOOL_MAX_TIMEOUT_MS = 180_000;
 export const MAX_DEVICE_RPC_TOOL_CONTENT_CHARS = 48_000;
-export const MAX_DEVICE_RPC_SHELL_CONTENT_CHARS = 12_000;
 
 type RemoteDeviceRpcToolName = 'read_file' | 'resolve_common_directory' | 'glob' | 'grep' | 'write_file' | 'edit_file' | 'execute_shell';
 
@@ -189,32 +188,12 @@ function normalizeDeviceRpcContent(content: unknown, options: DeviceRpcNormalize
 }
 
 function truncateText(value: string, options: DeviceRpcNormalizeOptions = {}): string {
-  const maxChars = maxContentCharsForTool(options.toolName);
+  const maxChars = MAX_DEVICE_RPC_TOOL_CONTENT_CHARS;
   if (value.length <= maxChars) return value;
-  if (options.toolName === 'execute_shell') return summarizeLongShellOutput(value, maxChars);
   return [
     value.slice(0, maxChars),
     '',
     `[远程设备结果超过 ${maxChars} 字符，已截断。请用更精确的 path/pattern/limit/offset 继续读取。]`,
-  ].join('\n');
-}
-
-function maxContentCharsForTool(toolName?: string): number {
-  return toolName === 'execute_shell'
-    ? MAX_DEVICE_RPC_SHELL_CONTENT_CHARS
-    : MAX_DEVICE_RPC_TOOL_CONTENT_CHARS;
-}
-
-function summarizeLongShellOutput(value: string, maxChars: number): string {
-  const lineCount = value.split(/\r\n|\n|\r/).length;
-  const headChars = Math.floor(maxChars * 0.7);
-  const tailChars = Math.max(0, maxChars - headChars);
-  return [
-    value.slice(0, headChars).trimEnd(),
-    '',
-    `[execute_shell 输出已摘要：原始 ${value.length} 字符 / ${lineCount} 行，仅保留开头 ${headChars} 字符和结尾 ${tailChars} 字符。请缩小命令范围，或改用 glob / grep / read_file 等专用工具继续。]`,
-    '',
-    value.slice(-tailChars).trimStart(),
   ].join('\n');
 }
 

--- a/src/tools/edit-tool.ts
+++ b/src/tools/edit-tool.ts
@@ -5,6 +5,38 @@ import { isToolAllowed, isPathAllowed } from '../utils/safety';
 import { formatCatsCoVisiblePath } from './tool-gateway';
 import { executeRouteIfRemote, resolveExecutionRoute, targetParameterDescription } from './execution-router';
 
+const MAX_EDIT_FILE_BYTES = 5 * 1024 * 1024;
+const BINARY_CHECK_BYTES = 8192;
+const BINARY_FILE_EXTENSIONS = new Set([
+  '.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.ico',
+  '.pdf', '.zip', '.gz', '.tgz', '.tar', '.rar', '.7z',
+  '.exe', '.dll', '.so', '.dylib', '.bin',
+  '.woff', '.woff2', '.ttf', '.otf',
+  '.mp3', '.mp4', '.mov', '.avi',
+  '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx',
+]);
+
+function invalidArguments(message: string): ToolExecutionResult {
+  return { ok: false, errorCode: 'INVALID_TOOL_ARGUMENTS', message };
+}
+
+function isLikelyBinaryFile(filePath: string): boolean {
+  const ext = path.extname(filePath).toLowerCase();
+  if (BINARY_FILE_EXTENSIONS.has(ext)) return true;
+
+  let fd: number | undefined;
+  try {
+    fd = fs.openSync(filePath, 'r');
+    const buffer = Buffer.alloc(BINARY_CHECK_BYTES);
+    const bytesRead = fs.readSync(fd, buffer, 0, buffer.length, 0);
+    return buffer.subarray(0, bytesRead).includes(0);
+  } finally {
+    if (fd !== undefined) {
+      try { fs.closeSync(fd); } catch {}
+    }
+  }
+}
+
 /**
  * Edit 工具 - 精确字符串替换
  */
@@ -43,7 +75,22 @@ export class EditTool implements Tool {
   };
 
   async execute(args: any, context: ToolExecutionContext): Promise<ToolExecutionResult> {
+    if (!args || typeof args !== 'object') {
+      return invalidArguments('edit_file requires an arguments object.');
+    }
     const { file_path, old_string, new_string, replace_all = false } = args;
+    if (typeof file_path !== 'string' || file_path.length === 0) {
+      return invalidArguments('edit_file requires a non-empty file_path string.');
+    }
+    if (typeof old_string !== 'string' || old_string.length === 0) {
+      return invalidArguments('edit_file requires a non-empty old_string string.');
+    }
+    if (typeof new_string !== 'string') {
+      return invalidArguments('edit_file requires new_string to be a string.');
+    }
+    if (replace_all !== undefined && typeof replace_all !== 'boolean') {
+      return invalidArguments('edit_file requires replace_all to be a boolean when provided.');
+    }
 
     const toolPermission = isToolAllowed(this.definition.name);
     if (!toolPermission.allowed) {
@@ -77,8 +124,59 @@ export class EditTool implements Tool {
       return { ok: false, errorCode: 'FILE_NOT_FOUND', message: `错误：文件不存在: ${displayPath}` };
     }
 
+    let stats: fs.Stats;
+    try {
+      stats = fs.statSync(absolutePath);
+    } catch {
+      return { ok: false, errorCode: 'FILE_NOT_FOUND', message: `错误：文件不存在: ${displayPath}` };
+    }
+
+    if (!stats.isFile()) {
+      return {
+        ok: false,
+        errorCode: 'TOOL_EXECUTION_ERROR',
+        message: `错误：edit_file 只能编辑普通文本文件，目标不是文件。\n文件: ${displayPath}`,
+      };
+    }
+
+    if (stats.size > MAX_EDIT_FILE_BYTES) {
+      return {
+        ok: false,
+        errorCode: 'TOOL_EXECUTION_ERROR',
+        message: `错误：文件过大，edit_file 只处理 ${MAX_EDIT_FILE_BYTES} bytes 以内的文本文件。\n文件: ${displayPath}\n大小: ${stats.size} bytes`,
+      };
+    }
+
+    let likelyBinary: boolean;
+    try {
+      likelyBinary = isLikelyBinaryFile(absolutePath);
+    } catch (error: any) {
+      return {
+        ok: false,
+        errorCode: 'TOOL_EXECUTION_ERROR',
+        message: `错误：读取文件失败。\n文件: ${displayPath}\n原因: ${error?.message || error}`,
+      };
+    }
+
+    if (likelyBinary) {
+      return {
+        ok: false,
+        errorCode: 'TOOL_EXECUTION_ERROR',
+        message: `错误：目标看起来不是普通文本文件，已阻止 edit_file 以避免损坏二进制文件。\n文件: ${displayPath}`,
+      };
+    }
+
     // 读取文件内容
-    const content = fs.readFileSync(absolutePath, 'utf-8');
+    let content: string;
+    try {
+      content = fs.readFileSync(absolutePath, 'utf-8');
+    } catch (error: any) {
+      return {
+        ok: false,
+        errorCode: 'TOOL_EXECUTION_ERROR',
+        message: `错误：读取文件失败。\n文件: ${displayPath}\n原因: ${error?.message || error}`,
+      };
+    }
 
     // 检查 old_string 是否存在
     if (!content.includes(old_string)) {

--- a/src/tools/edit-tool.ts
+++ b/src/tools/edit-tool.ts
@@ -7,6 +7,10 @@ import { executeRouteIfRemote, resolveExecutionRoute, targetParameterDescription
 
 const MAX_EDIT_FILE_BYTES = 5 * 1024 * 1024;
 const BINARY_CHECK_BYTES = 8192;
+const EDIT_CONTEXT_LINES = 2;
+const MAX_PREVIEW_CHARS = 180;
+const MAX_CANDIDATE_LINES = 3;
+const MAX_SNIPPET_LINE_CHARS = 180;
 const BINARY_FILE_EXTENSIONS = new Set([
   '.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.ico',
   '.pdf', '.zip', '.gz', '.tgz', '.tar', '.rar', '.7z',
@@ -18,6 +22,112 @@ const BINARY_FILE_EXTENSIONS = new Set([
 
 function invalidArguments(message: string): ToolExecutionResult {
   return { ok: false, errorCode: 'INVALID_TOOL_ARGUMENTS', message };
+}
+
+function truncateForMessage(value: string, maxChars: number = MAX_PREVIEW_CHARS): string {
+  if (value.length <= maxChars) return value;
+  return `${value.slice(0, maxChars)}...`;
+}
+
+function normalizeNewlines(value: string): string {
+  return value.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+}
+
+function normalizeWhitespace(value: string): string {
+  return normalizeNewlines(value).replace(/[ \t]+/g, ' ').trim();
+}
+
+function normalizeLooseLine(value: string): string {
+  return normalizeWhitespace(value)
+    .replace(/['"`]/g, '"')
+    .replace(/[;,]/g, '');
+}
+
+function lineNumberForIndex(content: string, index: number): number {
+  return normalizeNewlines(content.slice(0, Math.max(0, Math.min(index, content.length)))).split('\n').length;
+}
+
+function truncateLineForSnippet(line: string): string {
+  const clean = line.endsWith('\r') ? line.slice(0, -1) : line;
+  if (clean.length <= MAX_SNIPPET_LINE_CHARS) return clean;
+  return `${clean.slice(0, MAX_SNIPPET_LINE_CHARS)}...`;
+}
+
+function formatLineSnippet(content: string, centerLine: number, contextLines: number = EDIT_CONTEXT_LINES): string {
+  const lines = normalizeNewlines(content).split('\n');
+  const start = Math.max(1, centerLine - contextLines);
+  const end = Math.min(lines.length, centerLine + contextLines);
+  return lines
+    .slice(start - 1, end)
+    .map((line, index) => `${String(start + index).padStart(4, ' ')} | ${truncateLineForSnippet(line)}`)
+    .join('\n');
+}
+
+function meaningfulOldStringLines(oldString: string): string[] {
+  const lines = normalizeNewlines(oldString)
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line.length >= 4);
+  return Array.from(new Set(lines)).sort((a, b) => b.length - a.length).slice(0, 4);
+}
+
+function findCandidateLines(content: string, oldString: string): Array<{ lineNumber: number; line: string }> {
+  const anchors = meaningfulOldStringLines(oldString);
+  if (anchors.length === 0) return [];
+
+  const contentLines = normalizeNewlines(content).split('\n');
+  const candidates: Array<{ lineNumber: number; line: string }> = [];
+  for (let index = 0; index < contentLines.length; index++) {
+    const line = contentLines[index];
+    const normalizedLine = normalizeWhitespace(line);
+    const looseLine = normalizeLooseLine(line);
+    for (const anchor of anchors) {
+      const normalizedAnchor = normalizeWhitespace(anchor);
+      const looseAnchor = normalizeLooseLine(anchor);
+      if (
+        (normalizedAnchor.length >= 4 && normalizedLine.includes(normalizedAnchor))
+        || (looseAnchor.length >= 4 && looseLine.includes(looseAnchor))
+      ) {
+        candidates.push({ lineNumber: index + 1, line });
+        break;
+      }
+    }
+    if (candidates.length >= MAX_CANDIDATE_LINES) break;
+  }
+  return candidates;
+}
+
+function buildNoMatchMessage(content: string, oldString: string, displayPath: string): string {
+  const lines = [
+    '错误：在文件中未找到要替换的字符串。',
+    `文件: ${displayPath}`,
+    `查找: ${truncateForMessage(oldString)}`,
+  ];
+  const hints: string[] = [];
+
+  if (normalizeNewlines(content).includes(normalizeNewlines(oldString))) {
+    hints.push('提示：发现仅换行风格不同的相似内容，可能是 LF/CRLF 差异。');
+  }
+
+  const trimmedOldString = oldString.trim();
+  if (trimmedOldString !== oldString && trimmedOldString.length > 0 && content.includes(trimmedOldString)) {
+    hints.push('提示：去掉 old_string 首尾空白后能找到匹配，可能是开头/结尾多了空格或空行。');
+  }
+
+  const candidates = findCandidateLines(content, oldString);
+  if (candidates.length > 0) {
+    hints.push('可能相关位置:');
+    hints.push(...candidates.map(candidate => `${String(candidate.lineNumber).padStart(4, ' ')} | ${truncateLineForSnippet(candidate.line)}`));
+  }
+
+  hints.push('建议：先用 read_file 读取目标区域，复制当前文件里的原文作为 old_string 后重试。');
+  return [...lines, ...hints].join('\n');
+}
+
+function formatSuccessContext(content: string, editIndex: number, replacedCount: number): string {
+  const centerLine = lineNumberForIndex(content, editIndex);
+  const heading = replacedCount > 1 ? '修改后首个替换位置附近内容:' : '修改后附近内容:';
+  return `${heading}\n${formatLineSnippet(content, centerLine)}`;
 }
 
 function isLikelyBinaryFile(filePath: string): boolean {
@@ -179,13 +289,19 @@ export class EditTool implements Tool {
     }
 
     // 检查 old_string 是否存在
-    if (!content.includes(old_string)) {
-      return { ok: false, errorCode: 'TOOL_EXECUTION_ERROR', message: `错误：在文件中未找到要替换的字符串。\n文件: ${displayPath}\n查找: ${old_string.substring(0, 100)}${old_string.length > 100 ? '...' : ''}` };
+    const firstMatchIndex = content.indexOf(old_string);
+    if (firstMatchIndex === -1) {
+      return {
+        ok: false,
+        errorCode: 'TOOL_EXECUTION_ERROR',
+        message: buildNoMatchMessage(content, old_string, displayPath),
+      };
     }
+
+    const occurrences = content.split(old_string).length - 1;
 
     // 检查唯一性（如果不是 replace_all）
     if (!replace_all) {
-      const occurrences = content.split(old_string).length - 1;
       if (occurrences > 1) {
         return { ok: false, errorCode: 'TOOL_EXECUTION_ERROR', message: `错误：找到 ${occurrences} 个匹配项，但 replace_all=false。\n请提供更具体的字符串以确保唯一性，或设置 replace_all=true 替换所有匹配项。\n文件: ${displayPath}` };
       }
@@ -197,7 +313,6 @@ export class EditTool implements Tool {
 
     if (replace_all) {
       // 替换所有匹配项
-      const occurrences = content.split(old_string).length - 1;
       newContent = content.split(old_string).join(new_string);
       replacedCount = occurrences;
     } else {
@@ -213,7 +328,8 @@ export class EditTool implements Tool {
     const oldLines = content.split('\n').length;
     const newLines = newContent.split('\n').length;
     const lineDiff = newLines - oldLines;
+    const successContext = formatSuccessContext(newContent, firstMatchIndex, replacedCount);
 
-    return { ok: true, content: `成功编辑文件: ${displayPath}\nPath: ${displayPath}\n替换次数: ${replacedCount}\n原始行数: ${oldLines}\n新行数: ${newLines}${lineDiff !== 0 ? `\n行数变化: ${lineDiff > 0 ? '+' : ''}${lineDiff}` : ''}` };
+    return { ok: true, content: `成功编辑文件: ${displayPath}\nPath: ${displayPath}\n替换次数: ${replacedCount}\n原始行数: ${oldLines}\n新行数: ${newLines}${lineDiff !== 0 ? `\n行数变化: ${lineDiff > 0 ? '+' : ''}${lineDiff}` : ''}\n${successContext}` };
   }
 }

--- a/src/tools/grep-tool.ts
+++ b/src/tools/grep-tool.ts
@@ -1,4 +1,4 @@
-import { execFileSync, spawnSync } from 'child_process';
+import { spawn, spawnSync } from 'child_process';
 import * as path from 'path';
 import * as fs from 'fs';
 import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
@@ -8,6 +8,9 @@ import { executeRouteIfRemote, resolveExecutionRoute, targetParameterDescription
 
 const VCS_DIRECTORIES_TO_EXCLUDE = ['.git', '.svn', '.hg', '.bzr'] as const;
 const DEFAULT_LIMIT = 250;
+const MAX_GREP_LIMIT = 2000;
+const MAX_GREP_OUTPUT_BYTES = 512 * 1024;
+const GREP_COMMAND_TIMEOUT_MS = 30_000;
 
 interface GrepResult {
   mode: 'content' | 'files' | 'count';
@@ -18,27 +21,79 @@ interface GrepResult {
   numMatches?: number;
   appliedLimit?: number;
   appliedOffset?: number;
+  requestedLimit?: number;
+  limitWasCapped?: boolean;
+  reachedOutputLimit?: boolean;
+  nextOffset?: number;
+}
+
+interface NormalizedGrepPaging {
+  offset: number;
+  limit: number;
+  requestedLimit?: number;
+  limitWasCapped: boolean;
 }
 
 interface FallbackResult {
   content: string;
-  error?: string;
+}
+
+interface SearchCommandResult {
+  output: string;
+  stderr: string;
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  reachedOutputLimit: boolean;
 }
 
 function applyHeadLimit<T>(
   items: T[],
-  limit: number | undefined,
-  offset: number = 0,
-): { items: T[]; appliedLimit: number | undefined } {
-  if (limit === 0) {
-    return { items: items.slice(offset), appliedLimit: undefined };
-  }
-  const effectiveLimit = limit ?? DEFAULT_LIMIT;
-  const sliced = items.slice(offset, offset + effectiveLimit);
-  const wasTruncated = items.length - offset > effectiveLimit;
+  paging: NormalizedGrepPaging,
+  reachedOutputLimit: boolean,
+): { items: T[]; appliedLimit: number | undefined; nextOffset?: number } {
+  const sliced = items.slice(paging.offset, paging.offset + paging.limit);
+  const wasTruncated = reachedOutputLimit || items.length - paging.offset > paging.limit;
   return {
     items: sliced,
-    appliedLimit: wasTruncated ? effectiveLimit : undefined,
+    appliedLimit: wasTruncated ? paging.limit : undefined,
+    nextOffset: wasTruncated ? paging.offset + sliced.length : undefined,
+  };
+}
+
+function normalizeGrepPaging(limit: unknown, offset: unknown): NormalizedGrepPaging {
+  const parsedOffset = Number(offset);
+  const normalizedOffset = Number.isFinite(parsedOffset) && parsedOffset > 0
+    ? Math.floor(parsedOffset)
+    : 0;
+
+  if (limit === 0 || limit === '0') {
+    return {
+      offset: normalizedOffset,
+      limit: MAX_GREP_LIMIT,
+      requestedLimit: 0,
+      limitWasCapped: true,
+    };
+  }
+
+  const parsedLimit = Number(limit);
+  const hasExplicitLimit = limit !== undefined && limit !== null && limit !== '';
+  const requestedLimit = hasExplicitLimit && Number.isFinite(parsedLimit)
+    ? Math.floor(parsedLimit)
+    : undefined;
+
+  if (!hasExplicitLimit || requestedLimit === undefined || requestedLimit <= 0) {
+    return {
+      offset: normalizedOffset,
+      limit: DEFAULT_LIMIT,
+      limitWasCapped: false,
+    };
+  }
+
+  return {
+    offset: normalizedOffset,
+    limit: Math.min(requestedLimit, MAX_GREP_LIMIT),
+    requestedLimit,
+    limitWasCapped: requestedLimit > MAX_GREP_LIMIT,
   };
 }
 
@@ -106,6 +161,13 @@ export class GrepTool implements Tool {
 
   async execute(args: any, context: ToolExecutionContext): Promise<ToolExecutionResult> {
     const { pattern, path: searchPath } = args;
+    if (typeof pattern !== 'string' || pattern.trim() === '') {
+      return {
+        ok: false,
+        errorCode: 'INVALID_TOOL_ARGUMENTS',
+        message: 'grep requires a non-empty pattern.',
+      };
+    }
 
     const route = resolveExecutionRoute(context, {
       toolName: this.definition.name,
@@ -147,6 +209,13 @@ export class GrepTool implements Tool {
         lastError = null; // 重置错误，因为空结果是正常情况
         continue;
       } catch (error: any) {
+        if (this.isCancellationError(error)) {
+          return {
+            ok: false,
+            errorCode: 'EXECUTION_TIMEOUT',
+            message: String(error?.message || error || 'grep execution was interrupted'),
+          };
+        }
         lastError = error;
         // 如果有多个 fallback，继续尝试下一个
         continue;
@@ -159,8 +228,139 @@ export class GrepTool implements Tool {
     return { ok: false, errorCode: 'EXECUTION_ERROR', message: errorMsg };
   }
 
+  private runSearchCommand(
+    command: string,
+    commandArgs: string[],
+    cwd: string,
+    context: ToolExecutionContext,
+    lineBudget: number,
+  ): Promise<SearchCommandResult> {
+    return new Promise((resolve, reject) => {
+      const child = spawn(command, commandArgs, {
+        cwd,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        windowsHide: true,
+      });
+
+      const lines: string[] = [];
+      const stderrChunks: Buffer[] = [];
+      let stdoutCarry = '';
+      let stdoutBytes = 0;
+      let stderrBytes = 0;
+      let reachedOutputLimit = false;
+      let timedOut = false;
+      let aborted = false;
+      let settled = false;
+      let timer: NodeJS.Timeout | undefined;
+      let abortHandler: (() => void) | undefined;
+
+      const cleanup = () => {
+        if (timer) clearTimeout(timer);
+        if (abortHandler) context.abortSignal?.removeEventListener('abort', abortHandler);
+      };
+
+      const terminate = () => {
+        try { child.kill(); } catch {}
+      };
+
+      const settle = (fn: () => void) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        fn();
+      };
+
+      const appendStdout = (chunk: Buffer) => {
+        if (reachedOutputLimit) return;
+        stdoutBytes += chunk.length;
+        if (stdoutBytes > MAX_GREP_OUTPUT_BYTES) {
+          reachedOutputLimit = true;
+          terminate();
+          return;
+        }
+
+        const parts = (stdoutCarry + chunk.toString('utf8')).split(/\r?\n/);
+        stdoutCarry = parts.pop() || '';
+        for (const line of parts) {
+          lines.push(line);
+          if (lines.length >= lineBudget) {
+            reachedOutputLimit = true;
+            terminate();
+            break;
+          }
+        }
+      };
+
+      child.stdout?.on('data', (chunk: Buffer) => appendStdout(Buffer.from(chunk)));
+      child.stderr?.on('data', (chunk: Buffer) => {
+        const buffer = Buffer.from(chunk);
+        stderrBytes += buffer.length;
+        if (stderrBytes <= 64 * 1024) stderrChunks.push(buffer);
+      });
+
+      child.on('error', error => {
+        settle(() => reject(error));
+      });
+
+      timer = setTimeout(() => {
+        timedOut = true;
+        terminate();
+      }, GREP_COMMAND_TIMEOUT_MS);
+      timer.unref?.();
+
+      abortHandler = () => {
+        aborted = true;
+        terminate();
+      };
+      if (context.abortSignal?.aborted) {
+        abortHandler();
+      } else {
+        context.abortSignal?.addEventListener('abort', abortHandler, { once: true });
+      }
+
+      child.on('close', (exitCode: number | null, signal: NodeJS.Signals | null) => {
+        settle(() => {
+          if (aborted) {
+            reject(this.createGrepAbortError());
+            return;
+          }
+          if (timedOut) {
+            reject(this.createGrepTimeoutError());
+            return;
+          }
+          if (!reachedOutputLimit && stdoutCarry) lines.push(stdoutCarry);
+          resolve({
+            output: lines.join('\n'),
+            stderr: Buffer.concat(stderrChunks).toString('utf8'),
+            exitCode,
+            signal,
+            reachedOutputLimit,
+          });
+        });
+      });
+    });
+  }
+
+  private createGrepTimeoutError(): Error {
+    const error: any = new Error(`grep timed out after ${GREP_COMMAND_TIMEOUT_MS}ms`);
+    error.code = 'ETIMEDOUT';
+    return error;
+  }
+
+  private createGrepAbortError(): Error {
+    const error: any = new Error('grep aborted by user');
+    error.code = 'ABORT_ERR';
+    return error;
+  }
+
+  private isCancellationError(error: any): boolean {
+    const code = String(error?.code || '');
+    return code === 'ETIMEDOUT' || code === 'ABORT_ERR';
+  }
+
   private async executeWithRipgrep(args: any, searchPath: string, context: ToolExecutionContext, visibleSearchPath?: string): Promise<FallbackResult> {
-    const { pattern, path: originalPath, glob: globPattern, type: fileType, case_insensitive = false, context: contextLines, output_mode = 'files', limit = DEFAULT_LIMIT, offset = 0 } = args;
+    const { pattern, path: originalPath, glob: globPattern, type: fileType, case_insensitive = false, context: contextLines, output_mode = 'files' } = args;
+    const paging = normalizeGrepPaging(args?.limit, args?.offset);
     const rgArgs: string[] = ['--color=never', '--no-heading', '--hidden'];
 
     for (const dir of VCS_DIRECTORIES_TO_EXCLUDE) rgArgs.push('--glob', `!${dir}`);
@@ -178,9 +378,17 @@ export class GrepTool implements Tool {
     rgArgs.push(originalPath ? searchPath : '.');
 
     try {
-      const output = execFileSync('rg', rgArgs, { cwd: context.workingDirectory, encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024, stdio: ['pipe', 'pipe', 'pipe'] }) as string;
-      return { content: this.processOutput(output, args, context, visibleSearchPath) };
+      const searchResult = await this.runSearchCommand('rg', rgArgs, context.workingDirectory, context, paging.offset + paging.limit + 1);
+      if (searchResult.exitCode === 1 && !searchResult.output) {
+        return { content: this.formatNoMatch(pattern, visibleSearchPath ?? originalPath, globPattern, fileType) };
+      }
+      if (searchResult.exitCode === 0 || searchResult.reachedOutputLimit) {
+        return { content: this.processOutput(searchResult.output, args, context, visibleSearchPath, searchResult.reachedOutputLimit) };
+      }
+      throw new Error(searchResult.stderr || `rg execution failed (exit ${searchResult.exitCode ?? searchResult.signal ?? 'unknown'})`);
     } catch (error: any) {
+      if (this.isCancellationError(error)) throw error;
+      if (error.status === undefined && !error.stderr) throw error;
       if (error.status === 1) {
         // 无匹配，返回格式化的"未找到"
         return { content: this.formatNoMatch(pattern, visibleSearchPath ?? originalPath, globPattern, fileType) };
@@ -192,7 +400,8 @@ export class GrepTool implements Tool {
   }
 
   private async executeWithSystemGrep(args: any, searchPath: string, context: ToolExecutionContext, visibleSearchPath?: string): Promise<FallbackResult> {
-    const { pattern, path: originalPath, glob: globPattern, type: fileType, case_insensitive = false, context: contextLines, output_mode = 'files', limit = DEFAULT_LIMIT, offset = 0 } = args;
+    const { pattern, path: originalPath, glob: globPattern, type: fileType, case_insensitive = false, context: contextLines, output_mode = 'files' } = args;
+    const paging = normalizeGrepPaging(args?.limit, args?.offset);
     const grepArgs: string[] = [];
 
     if (case_insensitive) grepArgs.push('-i');
@@ -202,20 +411,28 @@ export class GrepTool implements Tool {
 
     grepArgs.push('-r');
     for (const dir of VCS_DIRECTORIES_TO_EXCLUDE) grepArgs.push('--exclude-dir=' + dir);
-    grepArgs.push(pattern, searchPath);
+    grepArgs.push('-e', pattern, searchPath);
 
     try {
-      const output = execFileSync('grep', grepArgs, { cwd: context.workingDirectory, encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024, stdio: ['pipe', 'pipe', 'pipe'] }) as string;
-      let processedOutput = output;
+      const searchResult = await this.runSearchCommand('grep', grepArgs, context.workingDirectory, context, paging.offset + paging.limit + 1);
+      if (searchResult.exitCode === 1 && !searchResult.output) {
+        return { content: this.formatNoMatch(pattern, visibleSearchPath ?? originalPath, globPattern, fileType) };
+      }
+      if (searchResult.exitCode !== 0 && !searchResult.reachedOutputLimit) {
+        throw new Error(searchResult.stderr || `grep execution failed (exit ${searchResult.exitCode ?? searchResult.signal ?? 'unknown'})`);
+      }
+      let processedOutput = searchResult.output;
 
       if (globPattern) {
-        const lines = output.trim().split('\n').filter(Boolean);
+        const lines = searchResult.output.trim().split('\n').filter(Boolean);
         const globRegex = new RegExp(globPattern.replace(/\*/g, '.*').replace(/\?/g, '.'));
         processedOutput = lines.filter(line => globRegex.test(path.basename(line.split(':')[0]))).join('\n');
       }
 
-      return { content: this.processOutput(processedOutput, args, context, visibleSearchPath) };
+      return { content: this.processOutput(processedOutput, args, context, visibleSearchPath, searchResult.reachedOutputLimit) };
     } catch (error: any) {
+      if (this.isCancellationError(error)) throw error;
+      if (error.status === undefined && !error.stderr) throw error;
       if (error.status === 1) {
         return { content: this.formatNoMatch(pattern, visibleSearchPath ?? originalPath, globPattern, fileType) };
       }
@@ -225,20 +442,35 @@ export class GrepTool implements Tool {
   }
 
   private async executeWithNodeJS(args: any, searchPath: string, context: ToolExecutionContext, visibleSearchPath?: string): Promise<FallbackResult> {
-    const { pattern, path: originalPath, glob: globPattern, type: fileType, case_insensitive = false, context: contextLines, output_mode = 'files', limit = DEFAULT_LIMIT, offset = 0 } = args;
+    const { pattern, glob: globPattern, case_insensitive = false, output_mode = 'files' } = args;
+    const paging = normalizeGrepPaging(args?.limit, args?.offset);
 
     if (!fs.existsSync(searchPath)) {
       throw new Error(`目录不存在: ${searchPath}`);
     }
 
-    const escapeRegex = (str: string) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    const regex = new RegExp(escapeRegex(pattern), case_insensitive ? 'i' : '');
+    const regex = new RegExp(pattern, case_insensitive ? 'i' : '');
     const results: string[] = [];
+    const lineBudget = paging.offset + paging.limit + 1;
+    let resultBytes = 0;
+    let reachedOutputLimit = false;
+
+    const addResult = (value: string) => {
+      if (reachedOutputLimit) return;
+      results.push(value);
+      resultBytes += Buffer.byteLength(value, 'utf8') + 1;
+      if (results.length >= lineBudget || resultBytes >= MAX_GREP_OUTPUT_BYTES) {
+        reachedOutputLimit = true;
+      }
+    };
 
     const walkDir = (dir: string) => {
+      if (reachedOutputLimit) return;
+      if (context.abortSignal?.aborted) throw this.createGrepAbortError();
       if (!fs.existsSync(dir)) return;
       try {
         for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+          if (reachedOutputLimit) return;
           const fullPath = path.join(dir, entry.name);
           if (VCS_DIRECTORIES_TO_EXCLUDE.includes(entry.name as any)) continue;
           if (entry.isDirectory()) { walkDir(fullPath); continue; }
@@ -249,13 +481,16 @@ export class GrepTool implements Tool {
             }
             try {
               const lines = fs.readFileSync(fullPath, 'utf-8').split('\n');
+              let fileMatchCount = 0;
               for (let i = 0; i < lines.length; i++) {
                 if (regex.test(lines[i])) {
-                  if (output_mode === 'files') { results.push(fullPath); break; }
-                  else if (output_mode === 'count') { results.push(`${fullPath}:1`); break; }
-                  else results.push(`${fullPath}:${i + 1}:${lines[i]}`);
+                  if (output_mode === 'files') { addResult(fullPath); break; }
+                  else if (output_mode === 'count') { fileMatchCount++; }
+                  else addResult(`${fullPath}:${i + 1}:${lines[i]}`);
+                  if (reachedOutputLimit) break;
                 }
               }
+              if (output_mode === 'count' && fileMatchCount > 0) addResult(`${fullPath}:${fileMatchCount}`);
             } catch {}
           }
         }
@@ -265,14 +500,25 @@ export class GrepTool implements Tool {
     };
 
     walkDir(searchPath);
-    return { content: this.processOutput(results.join('\n'), args, context, visibleSearchPath) };
+    return { content: this.processOutput(results.join('\n'), args, context, visibleSearchPath, reachedOutputLimit) };
   }
 
-  private processOutput(output: string, args: any, context: ToolExecutionContext, visibleSearchPath?: string): string {
-    const { pattern, path: originalPath, glob: globPattern, type: fileType, output_mode = 'files', limit = DEFAULT_LIMIT, offset = 0 } = args;
+  private processOutput(output: string, args: any, context: ToolExecutionContext, visibleSearchPath?: string, reachedOutputLimit: boolean = false): string {
+    const { pattern, path: originalPath, glob: globPattern, type: fileType, output_mode = 'files' } = args;
+    const paging = normalizeGrepPaging(args?.limit, args?.offset);
     const allLines = output.trim().split('\n').filter(Boolean);
-    const { items: limitedLines, appliedLimit } = applyHeadLimit(allLines, limit, offset);
-    const result: GrepResult = { mode: output_mode, numFiles: 0, filenames: [], appliedLimit, appliedOffset: offset > 0 ? offset : undefined };
+    const { items: limitedLines, appliedLimit, nextOffset } = applyHeadLimit(allLines, paging, reachedOutputLimit);
+    const result: GrepResult = {
+      mode: output_mode,
+      numFiles: 0,
+      filenames: [],
+      appliedLimit,
+      appliedOffset: paging.offset > 0 ? paging.offset : undefined,
+      requestedLimit: paging.requestedLimit,
+      limitWasCapped: paging.limitWasCapped,
+      reachedOutputLimit,
+      nextOffset,
+    };
 
     if (output_mode === 'content') {
       result.content = limitedLines.map(line => {
@@ -303,12 +549,31 @@ export class GrepTool implements Tool {
     return `未找到匹配项。\n模式: ${pattern}\n路径: ${searchPath || '.'}\n${globPattern ? `Glob: ${globPattern}\n` : ''}${fileType ? `类型: ${fileType}\n` : ''}`;
   }
 
+  private formatResultNotes(result: GrepResult): string {
+    const notes: string[] = [];
+    if (result.limitWasCapped) {
+      if (result.requestedLimit === 0) {
+        notes.push(`Note: limit=0 is capped to ${MAX_GREP_LIMIT} results for safety.`);
+      } else if (result.requestedLimit !== undefined) {
+        notes.push(`Note: requested limit=${result.requestedLimit} was capped to ${MAX_GREP_LIMIT} results.`);
+      }
+    }
+    if (result.reachedOutputLimit) {
+      notes.push('Note: grep stopped collecting output after reaching the safety limit. Narrow pattern/path/glob or continue with offset.');
+    }
+    if (result.nextOffset !== undefined && result.appliedLimit !== undefined) {
+      notes.push(`Next page: call grep with offset=${result.nextOffset}, limit=${result.appliedLimit}.`);
+    }
+    return notes.length ? `\n\n${notes.join('\n')}` : '';
+  }
+
   private formatResult(result: GrepResult, pattern: string, searchPath: string | undefined, globPattern: string | undefined, fileType: string | undefined): string {
     const { mode, numFiles, filenames, content, numLines, numMatches, appliedLimit, appliedOffset } = result;
-    if (numFiles === 0 && !content) return `未找到匹配项。\n模式: ${pattern}\n路径: ${searchPath || '.'}\n${globPattern ? `Glob: ${globPattern}\n` : ''}${fileType ? `类型: ${fileType}\n` : ''}`;
+    const notes = this.formatResultNotes(result);
+    if (numFiles === 0 && !content) return `未找到匹配项。\n模式: ${pattern}\n路径: ${searchPath || '.'}\n${globPattern ? `Glob: ${globPattern}\n` : ''}${fileType ? `类型: ${fileType}\n` : ''}${notes}`;
     const limitInfo = formatLimitInfo(appliedLimit, appliedOffset);
-    if (mode === 'content') return `找到 ${numLines} 行匹配${limitInfo ? ` (${limitInfo})` : ''}:\n模式: ${pattern}\n路径: ${searchPath || '.'}\n${globPattern ? `Glob: ${globPattern}\n` : ''}${fileType ? `类型: ${fileType}\n` : ''}\n` + content;
-    if (mode === 'count') return `找到 ${numMatches} 个匹配，分布在 ${numFiles} 个文件${limitInfo ? ` (${limitInfo})` : ''}:\n模式: ${pattern}\n路径: ${searchPath || '.'}\n${globPattern ? `Glob: ${globPattern}\n` : ''}${fileType ? `类型: ${fileType}\n` : ''}\n` + content;
-    return `找到 ${numFiles} 个文件${limitInfo ? ` (${limitInfo})` : ''}:\n模式: ${pattern}\n路径: ${searchPath || '.'}\n${globPattern ? `Glob: ${globPattern}\n` : ''}${fileType ? `类型: ${fileType}\n` : ''}\n` + filenames.map((file, i) => `${(i + 1).toString().padStart(4, ' ')}. ${file}`).join('\n');
+    if (mode === 'content') return `找到 ${numLines} 行匹配${limitInfo ? ` (${limitInfo})` : ''}:\n模式: ${pattern}\n路径: ${searchPath || '.'}\n${globPattern ? `Glob: ${globPattern}\n` : ''}${fileType ? `类型: ${fileType}\n` : ''}\n` + content + notes;
+    if (mode === 'count') return `找到 ${numMatches} 个匹配，分布在 ${numFiles} 个文件${limitInfo ? ` (${limitInfo})` : ''}:\n模式: ${pattern}\n路径: ${searchPath || '.'}\n${globPattern ? `Glob: ${globPattern}\n` : ''}${fileType ? `类型: ${fileType}\n` : ''}\n` + content + notes;
+    return `找到 ${numFiles} 个文件${limitInfo ? ` (${limitInfo})` : ''}:\n模式: ${pattern}\n路径: ${searchPath || '.'}\n${globPattern ? `Glob: ${globPattern}\n` : ''}${fileType ? `类型: ${fileType}\n` : ''}\n` + filenames.map((file, i) => `${(i + 1).toString().padStart(4, ' ')}. ${file}`).join('\n') + notes;
   }
 }

--- a/src/tools/grep-tool.ts
+++ b/src/tools/grep-tool.ts
@@ -78,7 +78,7 @@ export class GrepTool implements Tool {
     name: 'grep',
     description: [
       '在文件内容中搜索文本或正则表达式。',
-      '适合查找符号、函数名、配置项、错误文本；要按文件名/路径找文件请使用 glob。',
+      '适合查找符号、函数名、配置项、错误文本；路径候选通常先由 glob 缩小范围。',
       '默认返回匹配文件列表；需要具体匹配行时设置 output_mode="content"。',
     ].join('\n'),
     parameters: {

--- a/src/tools/read-tool.ts
+++ b/src/tools/read-tool.ts
@@ -54,7 +54,8 @@ export class ReadTool implements Tool {
   definition: ToolDefinition = {
     name: 'read_file',
     description: [
-      '读取一个本地文件或当前用户轮次授权的 CatsCo 附件。',
+      '读取一个已定位的本地文件或当前用户轮次授权的 CatsCo 附件。',
+      '通常先用 glob 定位候选路径，或用 grep 找到包含目标内容的文件，再读取具体文件。',
       '支持文本/代码、PDF、图片和 Jupyter notebook。文本默认只读前若干行，可用 offset/limit 分页。',
       '图片会按当前模型能力处理：视觉模型收到图片块，非视觉模型收到 reader proxy 的文字解析结果。',
     ].join('\n'),

--- a/src/tools/send-text-tool.ts
+++ b/src/tools/send-text-tool.ts
@@ -28,11 +28,24 @@ export class SendTextTool implements Tool {
     },
   };
 
-  async execute(args: { text: string }, context: ToolExecutionContext): Promise<ToolExecutionResult> {
-    const { text } = args;
+  async execute(args: unknown, context: ToolExecutionContext): Promise<ToolExecutionResult> {
+    if (!args || typeof args !== 'object') {
+      return {
+        ok: false,
+        errorCode: 'INVALID_TOOL_ARGUMENTS',
+        message: 'send_text requires a non-empty text string.',
+      };
+    }
 
-    if (!text || !text.trim()) {
-      throw new Error('text 不能为空');
+    const { text } = args as { text?: unknown };
+    const normalizedText = typeof text === 'string' ? text.trim() : '';
+
+    if (!normalizedText) {
+      return {
+        ok: false,
+        errorCode: 'INVALID_TOOL_ARGUMENTS',
+        message: 'send_text requires a non-empty text string.',
+      };
     }
 
     const target = resolveOutboundTarget(context, {
@@ -47,7 +60,15 @@ export class SendTextTool implements Tool {
       };
     }
 
-    await context.channel!.reply(target.chatId, text.trim());
+    try {
+      await context.channel!.reply(target.chatId, normalizedText);
+    } catch (error: any) {
+      return {
+        ok: false,
+        errorCode: 'TOOL_EXECUTION_ERROR',
+        message: `Message send failed: ${String(error?.message || error)}`,
+      };
+    }
 
     return { ok: true, content: '已发送' };
   }

--- a/src/tools/write-tool.ts
+++ b/src/tools/write-tool.ts
@@ -6,6 +6,10 @@ import { isToolAllowed, isPathAllowed } from '../utils/safety';
 import { formatCatsCoVisiblePath } from './tool-gateway';
 import { executeRouteIfRemote, resolveExecutionRoute, targetParameterDescription } from './execution-router';
 
+function invalidArguments(message: string): ToolExecutionResult {
+  return { ok: false, errorCode: 'INVALID_TOOL_ARGUMENTS', message };
+}
+
 /**
  * Write 工具 - 写入文件内容
  */
@@ -35,7 +39,16 @@ export class WriteTool implements Tool {
   };
 
   async execute(args: any, context: ToolExecutionContext): Promise<ToolExecutionResult> {
+    if (!args || typeof args !== 'object') {
+      return invalidArguments('write_file requires an arguments object.');
+    }
     const { file_path, content } = args;
+    if (typeof file_path !== 'string' || file_path.trim().length === 0) {
+      return invalidArguments('write_file requires a non-empty file_path string.');
+    }
+    if (typeof content !== 'string') {
+      return invalidArguments('write_file requires content to be a string.');
+    }
 
     const toolPermission = isToolAllowed(this.definition.name);
     if (!toolPermission.allowed) {
@@ -69,17 +82,61 @@ export class WriteTool implements Tool {
     const displayPath = formatCatsCoVisiblePath(context, rawDisplayPath, { preserveRelative: true });
 
     // 检查文件是否已存在
-    const fileExists = fs.existsSync(absolutePath);
+    let fileExists = false;
+    try {
+      const targetStats = fs.statSync(absolutePath);
+      fileExists = true;
+      if (!targetStats.isFile()) {
+        return {
+          ok: false,
+          errorCode: 'TOOL_EXECUTION_ERROR',
+          message: `错误：write_file 只能创建或覆盖普通文本文件，目标路径不是文件。\n文件: ${displayPath}`,
+        };
+      }
+    } catch (error: any) {
+      if (error?.code !== 'ENOENT' && error?.code !== 'ENOTDIR') {
+        return {
+          ok: false,
+          errorCode: 'TOOL_EXECUTION_ERROR',
+          message: `错误：检查目标文件失败。\n文件: ${displayPath}\n原因: ${error?.message || error}`,
+        };
+      }
+    }
     const operation = fileExists ? '覆盖' : '创建';
-
-    Logger.info(`${operation}文件: ${displayPath}`);
 
     // 确保目录存在
     const dir = path.dirname(absolutePath);
-    if (!fs.existsSync(dir)) {
-      Logger.info(`创建目录: ${path.relative(context.workingDirectory, dir)}`);
-      fs.mkdirSync(dir, { recursive: true });
+    if (fs.existsSync(dir)) {
+      try {
+        const dirStats = fs.statSync(dir);
+        if (!dirStats.isDirectory()) {
+          return {
+            ok: false,
+            errorCode: 'TOOL_EXECUTION_ERROR',
+            message: `错误：父路径不是目录，无法创建文件。\n父路径: ${formatCatsCoVisiblePath(context, path.relative(context.workingDirectory, dir) || dir, { preserveRelative: true })}\n文件: ${displayPath}`,
+          };
+        }
+      } catch (error: any) {
+        return {
+          ok: false,
+          errorCode: 'TOOL_EXECUTION_ERROR',
+          message: `错误：检查父目录失败。\n文件: ${displayPath}\n原因: ${error?.message || error}`,
+        };
+      }
+    } else {
+      try {
+        Logger.info(`创建目录: ${path.relative(context.workingDirectory, dir)}`);
+        fs.mkdirSync(dir, { recursive: true });
+      } catch (error: any) {
+        return {
+          ok: false,
+          errorCode: 'TOOL_EXECUTION_ERROR',
+          message: `错误：创建父目录失败。\n文件: ${displayPath}\n原因: ${error?.message || error}`,
+        };
+      }
     }
+
+    Logger.info(`${operation}文件: ${displayPath}`);
 
     // 计算文件信息
     const lines = content.split('\n').length;

--- a/src/tools/write-tool.ts
+++ b/src/tools/write-tool.ts
@@ -13,9 +13,9 @@ export class WriteTool implements Tool {
   definition: ToolDefinition = {
     name: 'write_file',
     description: [
-      '创建或完整覆盖一个 UTF-8 文本文件。',
+      '创建或完整覆盖一个用户明确需要保留的 UTF-8 文本文件。',
       '适合生成新文件或重写整个文件；对已有文件做小范围修改时优先使用 edit_file。',
-      '当用户要求在桌面、下载、文档等常见目录创建文件时，先用 resolve_common_directory 解析目录，再把目标文件路径传给本工具；不要用 execute_shell 创建普通文本文件。',
+      '当用户要求在桌面、下载、文档等常见目录创建文件时，先用 resolve_common_directory 解析目录，再把目标文件路径传给本工具。',
     ].join('\n'),
     parameters: {
       type: 'object',

--- a/tests/device-rpc-tool.test.ts
+++ b/tests/device-rpc-tool.test.ts
@@ -1,7 +1,7 @@
 import { describe, test } from 'node:test';
 import * as assert from 'node:assert';
 import {
-  MAX_DEVICE_RPC_SHELL_CONTENT_CHARS,
+  MAX_DEVICE_RPC_TOOL_CONTENT_CHARS,
   normalizeDeviceRpcToolResultPayload,
   normalizeDeviceRpcToolResultForTransport,
   resolveRemoteToolTimeoutMs,
@@ -19,26 +19,20 @@ describe('Device RPC tool helpers', () => {
     assert.equal(resolveRemoteToolTimeoutMs(now + 30_000, 120_000, now), 30_000);
   });
 
-  test('summarizes long execute_shell result content with head and tail context', () => {
-    const longOutput = Array.from({ length: 2000 }, (_, i) => `line-${i.toString().padStart(4, '0')} ${'x'.repeat(40)}`).join('\n');
+  test('keeps execute_shell result content below the general RPC limit intact', () => {
+    const content = 'x'.repeat(20_000);
 
     const result = normalizeDeviceRpcToolResultPayload({
       ok: true,
-      content: longOutput,
+      content,
     }, { toolName: 'execute_shell' });
 
     assert.equal(result.ok, true);
-    const content = result.ok ? String(result.content) : '';
-    assert.ok(content.length < longOutput.length);
-    assert.match(content, /execute_shell 输出已摘要/);
-    assert.match(content, /原始 \d+ 字符/);
-    assert.match(content, /line-0000/);
-    assert.match(content, /line-1999/);
-    assert.ok(content.length > MAX_DEVICE_RPC_SHELL_CONTENT_CHARS);
+    assert.equal(result.ok ? result.content : '', content);
   });
 
   test('does not apply shell-sized budget to non-shell tool results', () => {
-    const content = 'x'.repeat(MAX_DEVICE_RPC_SHELL_CONTENT_CHARS + 1000);
+    const content = 'x'.repeat(20_000);
 
     const result = normalizeDeviceRpcToolResultPayload({
       ok: true,
@@ -49,19 +43,28 @@ describe('Device RPC tool helpers', () => {
     assert.equal(result.ok ? result.content : '', content);
   });
 
-  test('summarizes long local-device shell result before transport returns it', () => {
-    const longOutput = Array.from({ length: 2000 }, (_, i) => `transport-${i.toString().padStart(4, '0')} ${'y'.repeat(40)}`).join('\n');
+  test('keeps local-device shell transport content below the general RPC limit intact', () => {
+    const content = 'y'.repeat(20_000);
 
     const result = normalizeDeviceRpcToolResultForTransport({
       ok: true,
-      content: longOutput,
+      content,
     }, { toolName: 'execute_shell' });
 
     assert.equal(result.ok, true);
-    const content = result.ok ? String(result.content) : '';
-    assert.ok(content.length < longOutput.length);
-    assert.match(content, /execute_shell 输出已摘要/);
-    assert.match(content, /transport-0000/);
-    assert.match(content, /transport-1999/);
+    assert.equal(result.ok ? result.content : '', content);
+  });
+
+  test('still truncates remote tool content above the general RPC limit', () => {
+    const content = 'z'.repeat(MAX_DEVICE_RPC_TOOL_CONTENT_CHARS + 1000);
+
+    const result = normalizeDeviceRpcToolResultPayload({
+      ok: true,
+      content,
+    }, { toolName: 'execute_shell' });
+
+    assert.equal(result.ok, true);
+    assert.ok((result.ok ? String(result.content) : '').length < content.length);
+    assert.match(result.ok ? String(result.content) : '', /远程设备结果超过/);
   });
 });

--- a/tests/device-rpc-tool.test.ts
+++ b/tests/device-rpc-tool.test.ts
@@ -1,0 +1,67 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import {
+  MAX_DEVICE_RPC_SHELL_CONTENT_CHARS,
+  normalizeDeviceRpcToolResultPayload,
+  normalizeDeviceRpcToolResultForTransport,
+  resolveRemoteToolTimeoutMs,
+} from '../src/tools/device-rpc-tool';
+
+describe('Device RPC tool helpers', () => {
+  test('resolves default, requested, capped, and grant-bounded timeouts', () => {
+    const now = 1_000_000;
+    const longGrant = now + 10 * 60_000;
+
+    assert.equal(resolveRemoteToolTimeoutMs(longGrant, undefined, now), 60_000);
+    assert.equal(resolveRemoteToolTimeoutMs(longGrant, 120_000, now), 120_000);
+    assert.equal(resolveRemoteToolTimeoutMs(longGrant, 999, now), 5_000);
+    assert.equal(resolveRemoteToolTimeoutMs(longGrant, 999_999, now), 180_000);
+    assert.equal(resolveRemoteToolTimeoutMs(now + 30_000, 120_000, now), 30_000);
+  });
+
+  test('summarizes long execute_shell result content with head and tail context', () => {
+    const longOutput = Array.from({ length: 2000 }, (_, i) => `line-${i.toString().padStart(4, '0')} ${'x'.repeat(40)}`).join('\n');
+
+    const result = normalizeDeviceRpcToolResultPayload({
+      ok: true,
+      content: longOutput,
+    }, { toolName: 'execute_shell' });
+
+    assert.equal(result.ok, true);
+    const content = result.ok ? String(result.content) : '';
+    assert.ok(content.length < longOutput.length);
+    assert.match(content, /execute_shell 输出已摘要/);
+    assert.match(content, /原始 \d+ 字符/);
+    assert.match(content, /line-0000/);
+    assert.match(content, /line-1999/);
+    assert.ok(content.length > MAX_DEVICE_RPC_SHELL_CONTENT_CHARS);
+  });
+
+  test('does not apply shell-sized budget to non-shell tool results', () => {
+    const content = 'x'.repeat(MAX_DEVICE_RPC_SHELL_CONTENT_CHARS + 1000);
+
+    const result = normalizeDeviceRpcToolResultPayload({
+      ok: true,
+      content,
+    }, { toolName: 'read_file' });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.ok ? result.content : '', content);
+  });
+
+  test('summarizes long local-device shell result before transport returns it', () => {
+    const longOutput = Array.from({ length: 2000 }, (_, i) => `transport-${i.toString().padStart(4, '0')} ${'y'.repeat(40)}`).join('\n');
+
+    const result = normalizeDeviceRpcToolResultForTransport({
+      ok: true,
+      content: longOutput,
+    }, { toolName: 'execute_shell' });
+
+    assert.equal(result.ok, true);
+    const content = result.ok ? String(result.content) : '';
+    assert.ok(content.length < longOutput.length);
+    assert.match(content, /execute_shell 输出已摘要/);
+    assert.match(content, /transport-0000/);
+    assert.match(content, /transport-1999/);
+  });
+});

--- a/tests/edit-tool.test.ts
+++ b/tests/edit-tool.test.ts
@@ -1,0 +1,122 @@
+import { describe, test, beforeEach, afterEach } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { EditTool } from '../src/tools/edit-tool';
+import type { ToolExecutionContext, ToolExecutionResult } from '../src/types/tool';
+
+function getFailure(result: ToolExecutionResult): Extract<ToolExecutionResult, { ok: false }> {
+  assert.equal(result.ok, false);
+  if (result.ok) throw new Error('expected edit_file to fail');
+  return result;
+}
+
+describe('EditTool', () => {
+  let tool: EditTool;
+  let testRoot: string;
+  let context: ToolExecutionContext;
+
+  beforeEach(() => {
+    testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'edit-tool-'));
+    tool = new EditTool();
+    context = {
+      workingDirectory: testRoot,
+      sessionId: 'edit-tool-test',
+      surface: 'cli',
+    };
+  });
+
+  afterEach(() => {
+    if (testRoot && fs.existsSync(testRoot)) {
+      fs.rmSync(testRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('edits a unique string in a text file', async () => {
+    const filePath = path.join(testRoot, 'sample.txt');
+    fs.writeFileSync(filePath, 'hello world', 'utf8');
+
+    const result = await tool.execute({
+      file_path: filePath,
+      old_string: 'world',
+      new_string: 'XiaoBa',
+    }, context);
+
+    assert.equal(result.ok, true);
+    assert.equal(fs.readFileSync(filePath, 'utf8'), 'hello XiaoBa');
+  });
+
+  test('rejects missing new_string without writing undefined', async () => {
+    const filePath = path.join(testRoot, 'missing-new.txt');
+    fs.writeFileSync(filePath, 'hello world', 'utf8');
+
+    const result = await tool.execute({
+      file_path: filePath,
+      old_string: 'world',
+    }, context);
+
+    const failure = getFailure(result);
+    assert.equal(failure.errorCode, 'INVALID_TOOL_ARGUMENTS');
+    assert.equal(fs.readFileSync(filePath, 'utf8'), 'hello world');
+  });
+
+  test('rejects empty old_string without inserting between characters', async () => {
+    const filePath = path.join(testRoot, 'empty-old.txt');
+    fs.writeFileSync(filePath, 'abc', 'utf8');
+
+    const result = await tool.execute({
+      file_path: filePath,
+      old_string: '',
+      new_string: 'X',
+      replace_all: true,
+    }, context);
+
+    const failure = getFailure(result);
+    assert.equal(failure.errorCode, 'INVALID_TOOL_ARGUMENTS');
+    assert.equal(fs.readFileSync(filePath, 'utf8'), 'abc');
+  });
+
+  test('rejects directory paths instead of throwing', async () => {
+    const result = await tool.execute({
+      file_path: testRoot,
+      old_string: 'a',
+      new_string: 'b',
+    }, context);
+
+    const failure = getFailure(result);
+    assert.equal(failure.errorCode, 'TOOL_EXECUTION_ERROR');
+    assert.match(failure.message, /不是文件|not a file/);
+  });
+
+  test('rejects likely binary files without modifying bytes', async () => {
+    const filePath = path.join(testRoot, 'image.png');
+    const original = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0x01, 0x02]);
+    fs.writeFileSync(filePath, original);
+
+    const result = await tool.execute({
+      file_path: filePath,
+      old_string: 'PNG',
+      new_string: 'TXT',
+    }, context);
+
+    const failure = getFailure(result);
+    assert.equal(failure.errorCode, 'TOOL_EXECUTION_ERROR');
+    assert.deepEqual(fs.readFileSync(filePath), original);
+  });
+
+  test('rejects oversized text files before reading them into the edit path', async () => {
+    const filePath = path.join(testRoot, 'large.txt');
+    fs.writeFileSync(filePath, Buffer.alloc(5 * 1024 * 1024 + 1, 0x61));
+
+    const result = await tool.execute({
+      file_path: filePath,
+      old_string: 'aaa',
+      new_string: 'bbb',
+    }, context);
+
+    const failure = getFailure(result);
+    assert.equal(failure.errorCode, 'TOOL_EXECUTION_ERROR');
+    assert.match(failure.message, /文件过大|too large/);
+  });
+});

--- a/tests/edit-tool.test.ts
+++ b/tests/edit-tool.test.ts
@@ -12,6 +12,12 @@ function getFailure(result: ToolExecutionResult): Extract<ToolExecutionResult, {
   return result;
 }
 
+function getSuccess(result: ToolExecutionResult): Extract<ToolExecutionResult, { ok: true }> {
+  assert.equal(result.ok, true);
+  if (!result.ok) throw new Error('expected edit_file to succeed');
+  return result;
+}
+
 describe('EditTool', () => {
   let tool: EditTool;
   let testRoot: string;
@@ -43,7 +49,9 @@ describe('EditTool', () => {
       new_string: 'XiaoBa',
     }, context);
 
-    assert.equal(result.ok, true);
+    const success = getSuccess(result);
+    assert.match(String(success.content), /修改后附近内容/);
+    assert.match(String(success.content), /hello XiaoBa/);
     assert.equal(fs.readFileSync(filePath, 'utf8'), 'hello XiaoBa');
   });
 
@@ -118,5 +126,55 @@ describe('EditTool', () => {
     const failure = getFailure(result);
     assert.equal(failure.errorCode, 'TOOL_EXECUTION_ERROR');
     assert.match(failure.message, /文件过大|too large/);
+  });
+
+  test('explains likely LF and CRLF mismatch when old_string is not found', async () => {
+    const filePath = path.join(testRoot, 'line-endings.txt');
+    fs.writeFileSync(filePath, 'alpha\r\nbeta\r\ngamma', 'utf8');
+
+    const result = await tool.execute({
+      file_path: filePath,
+      old_string: 'alpha\nbeta',
+      new_string: 'changed',
+    }, context);
+
+    const failure = getFailure(result);
+    assert.equal(failure.errorCode, 'TOOL_EXECUTION_ERROR');
+    assert.match(failure.message, /LF\/CRLF|换行/);
+  });
+
+  test('explains likely leading or trailing whitespace mismatch', async () => {
+    const filePath = path.join(testRoot, 'trimmed.txt');
+    fs.writeFileSync(filePath, 'target', 'utf8');
+
+    const result = await tool.execute({
+      file_path: filePath,
+      old_string: '  target  ',
+      new_string: 'changed',
+    }, context);
+
+    const failure = getFailure(result);
+    assert.equal(failure.errorCode, 'TOOL_EXECUTION_ERROR');
+    assert.match(failure.message, /首尾空白/);
+  });
+
+  test('returns candidate lines when a similar string is present', async () => {
+    const filePath = path.join(testRoot, 'candidate.txt');
+    fs.writeFileSync(filePath, [
+      'const before = 1;',
+      'const name = "Tom";',
+      'const after = 2;',
+    ].join('\n'), 'utf8');
+
+    const result = await tool.execute({
+      file_path: filePath,
+      old_string: "const name = 'Tom';",
+      new_string: 'const name = "Jerry";',
+    }, context);
+
+    const failure = getFailure(result);
+    assert.equal(failure.errorCode, 'TOOL_EXECUTION_ERROR');
+    assert.match(failure.message, /可能相关位置/);
+    assert.match(failure.message, /const name = "Tom";/);
   });
 });

--- a/tests/execute-shell-message-folder.test.ts
+++ b/tests/execute-shell-message-folder.test.ts
@@ -33,6 +33,39 @@ function makeShellOutput(command: string, lineCount = 100, failed = false): stri
   ].filter(line => line !== '').join('\n');
 }
 
+function makeStructuredShellOutput(command: string, lineCount = 100): string {
+  const lines = Array.from({ length: lineCount }, (_, index) => {
+    const lineNumber = index + 1;
+    if (lineNumber === 50) {
+      return 'ERROR failed at src/structured.ts:45 with assertion failure';
+    }
+    return `structured shell output line ${lineNumber}`;
+  });
+  return [
+    'Command completed',
+    'status: failed',
+    `command: ${command}`,
+    'exit_code: 1',
+    'signal:',
+    'timed_out: false',
+    'duration_ms: 321',
+    'cwd_before: C:\\work\\repo',
+    'cwd_after: C:\\work\\repo',
+    `stdout_lines: ${lineCount}`,
+    'stderr_lines: 1',
+    'stdout_bytes: 1000',
+    'stderr_bytes: 25',
+    'truncated: false',
+    'error_message: Command failed with exit code 1',
+    '',
+    'stdout:',
+    lines.join('\n'),
+    '',
+    'stderr:',
+    'warning before failure',
+  ].join('\n');
+}
+
 function makeToolCallMessage(id: string, command: string): Message {
   return {
     role: 'assistant',
@@ -115,6 +148,33 @@ test('writes truncated execute_shell full output to a linkable artifact', () => 
   } finally {
     fs.rmSync(artifactRoot, { recursive: true, force: true });
   }
+});
+
+test('folds structured execute_shell output and reads contract metadata', () => {
+  const raw = makeStructuredShellOutput('npm test -- structured', 100);
+  const messages: Message[] = [
+    { role: 'user', content: 'run tests' },
+    makeToolCallMessage('call_structured_shell', 'npm test -- structured'),
+    { role: 'tool', name: 'execute_shell', tool_call_id: 'call_structured_shell', content: raw },
+    { role: 'assistant', content: 'tests failed' },
+    { role: 'user', content: 'summarize failure' },
+  ];
+
+  const result = foldHistoricalExecuteShellMessages(messages, {
+    thresholdTokens: 20,
+    maxHeadLines: 2,
+    maxTailLines: 2,
+    maxKeyLines: 4,
+  });
+  const folded = result.messages[2];
+
+  assert.ok(String(folded.content).startsWith(TRUNCATED_EXECUTE_SHELL_PREFIX));
+  assert.match(String(folded.content), /command: npm test -- structured/);
+  assert.match(String(folded.content), /cwd: C:\\work\\repo/);
+  assert.match(String(folded.content), /status: failed/);
+  assert.match(String(folded.content), /elapsed: 321ms/);
+  assert.match(String(folded.content), /output_lines: 101/);
+  assert.match(String(folded.content), /ERROR failed at src\/structured\.ts:45/);
 });
 
 test('does not fold execute_shell result from the current tool loop', () => {

--- a/tests/execute-shell-message-folder.test.ts
+++ b/tests/execute-shell-message-folder.test.ts
@@ -55,7 +55,10 @@ function makeStructuredShellOutput(command: string, lineCount = 100): string {
     'stderr_lines: 1',
     'stdout_bytes: 1000',
     'stderr_bytes: 25',
-    'truncated: false',
+    'truncated: true',
+    'truncated_reason: output_exceeded_inline_limit',
+    'original_output_chars: 123456',
+    'output_artifact: C:\\work\\repo\\tool-results\\shell-structured.log',
     'error_message: Command failed with exit code 1',
     '',
     'stdout:',
@@ -170,10 +173,14 @@ test('folds structured execute_shell output and reads contract metadata', () => 
 
   assert.ok(String(folded.content).startsWith(TRUNCATED_EXECUTE_SHELL_PREFIX));
   assert.match(String(folded.content), /command: npm test -- structured/);
-  assert.match(String(folded.content), /cwd: C:\\work\\repo/);
   assert.match(String(folded.content), /status: failed/);
-  assert.match(String(folded.content), /elapsed: 321ms/);
-  assert.match(String(folded.content), /output_lines: 101/);
+  assert.match(String(folded.content), /omitted: \d+ lines, \d+ chars/);
+  assert.doesNotMatch(String(folded.content), /^cwd:/m);
+  assert.doesNotMatch(String(folded.content), /^elapsed:/m);
+  assert.doesNotMatch(String(folded.content), /^output_lines:/m);
+  assert.doesNotMatch(String(folded.content), /^truncated:/m);
+  assert.doesNotMatch(String(folded.content), /^original_output_chars:/m);
+  assert.doesNotMatch(String(folded.content), /^output_artifact:/m);
   assert.match(String(folded.content), /ERROR failed at src\/structured\.ts:45/);
 });
 

--- a/tests/grep-tool.test.ts
+++ b/tests/grep-tool.test.ts
@@ -12,6 +12,23 @@ function getContent(result: { ok: boolean; content: unknown }): string {
   return result.content as string;
 }
 
+async function withCommandPathDisabled<T>(fn: () => Promise<T>): Promise<T> {
+  const pathKeys = Object.keys(process.env).filter(key => key.toLowerCase() === 'path');
+  if (pathKeys.length === 0) pathKeys.push('PATH');
+  const originals = new Map(pathKeys.map(key => [key, process.env[key]]));
+
+  try {
+    for (const key of pathKeys) process.env[key] = '';
+    return await fn();
+  } finally {
+    for (const key of pathKeys) {
+      const original = originals.get(key);
+      if (original === undefined) delete process.env[key];
+      else process.env[key] = original;
+    }
+  }
+}
+
 describe('GrepTool', () => {
   let grepTool: GrepTool;
   let testDir: string;
@@ -64,6 +81,15 @@ describe('GrepTool', () => {
   });
 
   describe('基础搜索功能', () => {
+    test('应该拒绝空pattern', async () => {
+      const result = await grepTool.execute({
+        output_mode: 'files'
+      }, context);
+
+      assert.strictEqual(result.ok, false);
+      assert.strictEqual(result.errorCode, 'INVALID_TOOL_ARGUMENTS');
+    });
+
     test('应该能找到匹配的文件（files模式）', async () => {
       const result = await grepTool.execute({
         pattern: 'Hello',
@@ -163,6 +189,7 @@ describe('GrepTool', () => {
 
       const text = getContent(result);
       assert.ok(text.includes('limit: 2'), '应该显示limit信息');
+      assert.ok(text.includes('Next page:'), '应该提示下一页offset');
     });
 
     test('应该支持offset跳过结果', async () => {
@@ -174,6 +201,17 @@ describe('GrepTool', () => {
 
       const text = getContent(result);
       assert.ok(text.includes('offset: 1'), '应该显示offset信息');
+    });
+
+    test('limit=0应该被安全上限收住', async () => {
+      const result = await grepTool.execute({
+        pattern: 'Hello',
+        output_mode: 'files',
+        limit: 0
+      }, context);
+
+      const text = getContent(result);
+      assert.ok(text.includes('limit=0 is capped'), '应该提示limit=0已被安全上限收住');
     });
   });
 
@@ -246,6 +284,30 @@ describe('GrepTool', () => {
       } finally {
         process.env.PATH = originalPath;
       }
+    });
+
+    test('Node fallback应该按regex语义搜索', async () => {
+      const result = await withCommandPathDisabled(() => grepTool.execute({
+        pattern: 'hello|greet',
+        output_mode: 'files'
+      }, context));
+
+      const text = getContent(result);
+      assert.ok(text.includes('test1.js'), '应该匹配hello');
+      assert.ok(text.includes('nested.js'), '应该匹配greet');
+    });
+
+    test('Node fallback的count模式应该统计真实匹配次数', async () => {
+      const marker = `count_marker_${Date.now()}`;
+      fs.writeFileSync(path.join(testDir, 'count-exact.txt'), `${marker}\n${marker}\nnope\n`);
+
+      const result = await withCommandPathDisabled(() => grepTool.execute({
+        pattern: marker,
+        output_mode: 'count'
+      }, context));
+
+      const text = getContent(result);
+      assert.ok(text.includes('count-exact.txt:2'), `应该统计到2次匹配，实际: ${text}`);
     });
   });
 

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -51,12 +51,12 @@ describe('Logger', () => {
     Logger.closeLogFile();
     await waitForFlush();
 
-    const globalContent = fs.readFileSync(globalLogPath, 'utf-8');
+    const globalContent = await readFileEventually(globalLogPath, /\[INFO\] outside context/);
     assert.match(globalContent, /\[INFO\] outside context/);
     assert.doesNotMatch(globalContent, /inside context/);
     assert.doesNotMatch(globalContent, /still inside context/);
 
-    const sessionEntries = fs.readFileSync(sessionLogPath, 'utf-8')
+    const sessionEntries = (await readFileEventually(sessionLogPath, /still inside context/))
       .trim()
       .split('\n')
       .filter(Boolean)
@@ -88,4 +88,20 @@ describe('Logger', () => {
 
 function waitForFlush(): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, 20));
+}
+
+async function readFileEventually(filePath: string, expected: RegExp): Promise<string> {
+  let lastContent = '';
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    try {
+      lastContent = fs.readFileSync(filePath, 'utf-8');
+      if (expected.test(lastContent)) return lastContent;
+    } catch (error) {
+      lastError = error;
+    }
+    await waitForFlush();
+  }
+  if (lastError && !fs.existsSync(filePath)) throw lastError;
+  return lastContent;
 }

--- a/tests/shell-current-directory.test.ts
+++ b/tests/shell-current-directory.test.ts
@@ -88,8 +88,15 @@ describe('ShellTool current directory probe', () => {
     });
 
     assert.strictEqual(result.ok, true);
-    assert.ok((result.content as string).includes('stdout-visible'));
-    assert.ok((result.content as string).includes('stderr-visible'));
+    const content = result.content as string;
+    assert.match(content, /^Command completed/);
+    assert.match(content, /^status: succeeded$/m);
+    assert.match(content, /^exit_code: 0$/m);
+    assert.match(content, /^timed_out: false$/m);
+    assert.match(content, /^stdout_lines: 1$/m);
+    assert.match(content, /^stderr_lines: 1$/m);
+    assert.ok(content.includes('stdout-visible'));
+    assert.ok(content.includes('stderr-visible'));
   });
 
   test('POSIX execution uses bash when bash is available', {
@@ -114,10 +121,32 @@ describe('ShellTool current directory probe', () => {
 
     assert.strictEqual(result.ok, false);
     assert.strictEqual(currentDirectory, testRoot);
+    assert.match(result.message, /^Command completed/);
+    assert.match(result.message, /^status: failed$/m);
+    assert.match(result.message, /^timed_out: false$/m);
     assert.ok(!result.message.includes('__XIAOBA_CWD_MARKER__'));
     assert.ok(!result.message.includes('status=$?'));
     assert.ok(!result.message.includes('printf'));
     assert.ok(!result.message.includes('exit "$status"'));
+  });
+
+  test('timed out commands return structured timeout metadata', {
+    skip: process.platform === 'win32',
+  }, async () => {
+    const tool = new ShellTool();
+    const command = process.platform === 'win32' ? 'Start-Sleep -Seconds 5' : 'sleep 5';
+    const result = await tool.execute({ command, timeout: 50 }, {
+      ...context,
+      workingDirectory: currentDirectory,
+    });
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.errorCode, 'EXECUTION_TIMEOUT');
+    assert.match(result.message, /^Command completed/);
+    assert.match(result.message, /^status: timed_out$/m);
+    assert.match(result.message, /^timed_out: true$/m);
+    assert.match(result.message, /^stdout:/m);
+    assert.match(result.message, /^stderr:/m);
   });
 
   test('successful cd is persisted even when a later command fails', async () => {

--- a/tests/shell-current-directory.test.ts
+++ b/tests/shell-current-directory.test.ts
@@ -73,8 +73,8 @@ describe('ShellTool current directory probe', () => {
     assert.strictEqual(result.ok, true);
     assert.ok(fs.existsSync(path.join(testRoot, 'sub', 'marker.txt')));
     assertSameDirectory(currentDirectory, path.join(testRoot, 'sub'));
-    assert.ok((result.content as string).includes(`Working directory: ${path.resolve(testRoot, 'sub')}`));
-    assert.ok((result.content as string).includes(`Final cwd: ${path.resolve(testRoot, 'sub')}`));
+    assert.ok((result.content as string).includes(`cwd_before: ${path.resolve(testRoot, 'sub')}`));
+    assert.ok((result.content as string).includes(`cwd_after: ${path.resolve(testRoot, 'sub')}`));
   });
 
   test('successful commands return both stdout and stderr', async () => {

--- a/tests/shell-current-directory.test.ts
+++ b/tests/shell-current-directory.test.ts
@@ -172,6 +172,24 @@ describe('ShellTool current directory probe', () => {
     }
   });
 
+  test('POSIX timeout terminates child process group', {
+    skip: process.platform === 'win32',
+  }, async () => {
+    const tool = new ShellTool();
+    const markerPath = path.join(testRoot, 'late-output.txt');
+    const script = `sleep 1; printf late > ${quotePosixString(markerPath)}`;
+    const result = await tool.execute({ command: `sh -c ${quotePosixString(script)}`, timeout: 50 }, {
+      ...context,
+      workingDirectory: currentDirectory,
+    });
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.errorCode, 'EXECUTION_TIMEOUT');
+    assert.match(result.message, /^status: timed_out$/m);
+    await delay(1200);
+    assert.strictEqual(fs.existsSync(markerPath), false);
+  });
+
   test('successful cd is persisted even when a later command fails', async () => {
     const tool = new ShellTool();
     const failingCommand = process.platform === 'win32'
@@ -319,4 +337,8 @@ function quotePowerShellString(value: string): string {
 
 function quotePosixString(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
 }

--- a/tests/shell-current-directory.test.ts
+++ b/tests/shell-current-directory.test.ts
@@ -99,6 +99,56 @@ describe('ShellTool current directory probe', () => {
     assert.ok(content.includes('stderr-visible'));
   });
 
+  test('large successful output is truncated and persisted as an artifact', async () => {
+    const tool = new ShellTool();
+    const command = process.platform === 'win32'
+      ? `& ${quotePowerShellString(process.execPath)} -e "process.stdout.write('out-' + 'x'.repeat(35000) + '-end')"`
+      : `${quotePosixString(process.execPath)} -e "process.stdout.write('out-' + 'x'.repeat(35000) + '-end')"`;
+    const result = await tool.execute({ command }, {
+      ...context,
+      workingDirectory: currentDirectory,
+    });
+
+    assert.strictEqual(result.ok, true);
+    const content = result.content as string;
+    assert.match(content, /^status: succeeded$/m);
+    assert.match(content, /^truncated: true$/m);
+    assert.match(content, /^truncated_reason: output_exceeded_inline_limit$/m);
+    assert.match(content, /^original_output_chars: 35008$/m);
+    assert.ok(content.length < 34000);
+
+    const artifactPath = readContractField(content, 'output_artifact');
+    assert.ok(artifactPath, 'expected output_artifact field');
+    assert.ok(fs.existsSync(artifactPath));
+    const artifact = fs.readFileSync(artifactPath, 'utf8');
+    assert.ok(artifact.includes('out-' + 'x'.repeat(35000) + '-end'));
+  });
+
+  test('large failed stderr output is truncated and persisted as an artifact', async () => {
+    const tool = new ShellTool();
+    const command = process.platform === 'win32'
+      ? `& ${quotePowerShellString(process.execPath)} -e "process.stderr.write('err-' + 'y'.repeat(35000) + '-end'); process.exit(7)"`
+      : `${quotePosixString(process.execPath)} -e "process.stderr.write('err-' + 'y'.repeat(35000) + '-end'); process.exit(7)"`;
+    const result = await tool.execute({ command }, {
+      ...context,
+      workingDirectory: currentDirectory,
+    });
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.errorCode, 'TOOL_EXECUTION_ERROR');
+    assert.match(result.message, /^status: failed$/m);
+    assert.match(result.message, /^exit_code: 7$/m);
+    assert.match(result.message, /^truncated: true$/m);
+    assert.match(result.message, /^original_output_chars: 35008$/m);
+    assert.ok(result.message.length < 34000);
+
+    const artifactPath = readContractField(result.message, 'output_artifact');
+    assert.ok(artifactPath, 'expected output_artifact field');
+    assert.ok(fs.existsSync(artifactPath));
+    const artifact = fs.readFileSync(artifactPath, 'utf8');
+    assert.ok(artifact.includes('err-' + 'y'.repeat(35000) + '-end'));
+  });
+
   test('POSIX execution uses bash when bash is available', {
     skip: process.platform === 'win32' || !fs.existsSync('/bin/bash'),
   }, async () => {
@@ -341,4 +391,10 @@ function quotePosixString(value: string): string {
 
 function delay(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function readContractField(content: string, field: string): string | undefined {
+  const escaped = field.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = content.match(new RegExp(`^${escaped}:\\s*(.+)$`, 'm'));
+  return match?.[1]?.trim();
 }

--- a/tests/shell-current-directory.test.ts
+++ b/tests/shell-current-directory.test.ts
@@ -124,6 +124,29 @@ describe('ShellTool current directory probe', () => {
     assert.ok(artifact.includes('out-' + 'x'.repeat(35000) + '-end'));
   });
 
+  test('stdout larger than the old maxBuffer is persisted without failing', async () => {
+    const tool = new ShellTool();
+    const outputChars = 11 * 1024 * 1024;
+    const command = process.platform === 'win32'
+      ? `& ${quotePowerShellString(process.execPath)} -e "process.stdout.write('z'.repeat(${outputChars}))"`
+      : `${quotePosixString(process.execPath)} -e "process.stdout.write('z'.repeat(${outputChars}))"`;
+    const result = await tool.execute({ command, timeout: 60000 }, {
+      ...context,
+      workingDirectory: currentDirectory,
+    });
+
+    assert.strictEqual(result.ok, true);
+    const content = result.content as string;
+    assert.match(content, /^status: succeeded$/m);
+    assert.match(content, /^truncated: true$/m);
+    assert.match(content, new RegExp(`^original_output_chars: ${outputChars}$`, 'm'));
+    assert.doesNotMatch(content, /maxBuffer exceeded/);
+
+    const artifactPath = readContractField(content, 'output_artifact');
+    assert.ok(artifactPath, 'expected output_artifact field');
+    assert.ok(fs.statSync(artifactPath).size > outputChars);
+  });
+
   test('large failed stderr output is truncated and persisted as an artifact', async () => {
     const tool = new ShellTool();
     const command = process.platform === 'win32'

--- a/tests/shell-current-directory.test.ts
+++ b/tests/shell-current-directory.test.ts
@@ -130,9 +130,7 @@ describe('ShellTool current directory probe', () => {
     assert.ok(!result.message.includes('exit "$status"'));
   });
 
-  test('timed out commands return structured timeout metadata', {
-    skip: process.platform === 'win32',
-  }, async () => {
+  test('timed out commands return structured timeout metadata', async () => {
     const tool = new ShellTool();
     const command = process.platform === 'win32' ? 'Start-Sleep -Seconds 5' : 'sleep 5';
     const result = await tool.execute({ command, timeout: 50 }, {
@@ -147,6 +145,31 @@ describe('ShellTool current directory probe', () => {
     assert.match(result.message, /^timed_out: true$/m);
     assert.match(result.message, /^stdout:/m);
     assert.match(result.message, /^stderr:/m);
+  });
+
+  test('aborted commands return structured abort metadata', async () => {
+    const tool = new ShellTool();
+    const controller = new AbortController();
+    const command = process.platform === 'win32' ? 'Start-Sleep -Seconds 5' : 'sleep 5';
+    const run = tool.execute({ command, timeout: 5000 }, {
+      ...context,
+      workingDirectory: currentDirectory,
+      abortSignal: controller.signal,
+    });
+    const abortTimer = setTimeout(() => controller.abort(), 50);
+
+    try {
+      const result = await run;
+      assert.strictEqual(result.ok, false);
+      assert.strictEqual(result.errorCode, 'EXECUTION_TIMEOUT');
+      assert.match(result.message, /^Command completed/);
+      assert.match(result.message, /^status: aborted$/m);
+      assert.match(result.message, /^timed_out: false$/m);
+      assert.match(result.message, /^stdout:/m);
+      assert.match(result.message, /^stderr:/m);
+    } finally {
+      clearTimeout(abortTimer);
+    }
   });
 
   test('successful cd is persisted even when a later command fails', async () => {
@@ -253,6 +276,35 @@ describe('ShellTool current directory probe', () => {
     assert.ok(!result.message.includes('cd >'));
     assert.ok(!result.message.includes('exit /b'));
     assert.ok(!/[A-Z]:\\.*>/.test(result.message));
+  });
+
+  test('Windows cmd fallback honors abort signal', {
+    skip: process.platform !== 'win32',
+  }, async () => {
+    const tool = new ShellTool();
+    (tool as any).executeWindowsPowerShellScript = async () => {
+      const error: any = new Error('spawn powershell.exe ENOENT');
+      error.code = 'ENOENT';
+      throw error;
+    };
+
+    const controller = new AbortController();
+    const run = tool.execute({ command: 'ping -n 6 127.0.0.1 > nul', timeout: 5000 }, {
+      ...context,
+      workingDirectory: currentDirectory,
+      abortSignal: controller.signal,
+    });
+    const abortTimer = setTimeout(() => controller.abort(), 50);
+
+    try {
+      const result = await run;
+      assert.strictEqual(result.ok, false);
+      assert.strictEqual(result.errorCode, 'EXECUTION_TIMEOUT');
+      assert.match(result.message, /^status: aborted$/m);
+      assert.match(result.message, /^timed_out: false$/m);
+    } finally {
+      clearTimeout(abortTimer);
+    }
   });
 
 });

--- a/tests/shell-current-directory.test.ts
+++ b/tests/shell-current-directory.test.ts
@@ -77,6 +77,34 @@ describe('ShellTool current directory probe', () => {
     assert.ok((result.content as string).includes(`Final cwd: ${path.resolve(testRoot, 'sub')}`));
   });
 
+  test('successful commands return both stdout and stderr', async () => {
+    const tool = new ShellTool();
+    const command = process.platform === 'win32'
+      ? `& ${quotePowerShellString(process.execPath)} -e "process.stdout.write('stdout-visible\\n'); process.stderr.write('stderr-visible\\n')"`
+      : `${quotePosixString(process.execPath)} -e "process.stdout.write('stdout-visible\\n'); process.stderr.write('stderr-visible\\n')"`;
+    const result = await tool.execute({ command }, {
+      ...context,
+      workingDirectory: currentDirectory,
+    });
+
+    assert.strictEqual(result.ok, true);
+    assert.ok((result.content as string).includes('stdout-visible'));
+    assert.ok((result.content as string).includes('stderr-visible'));
+  });
+
+  test('POSIX execution uses bash when bash is available', {
+    skip: process.platform === 'win32' || !fs.existsSync('/bin/bash'),
+  }, async () => {
+    const tool = new ShellTool();
+    const result = await tool.execute({ command: 'echo "bash-version:${BASH_VERSION:-missing}"' }, {
+      ...context,
+      workingDirectory: currentDirectory,
+    });
+
+    assert.strictEqual(result.ok, true);
+    assert.match(result.content as string, /bash-version:[0-9]/);
+  });
+
   test('failed cd does not update session current directory', async () => {
     const tool = new ShellTool();
     const result = await tool.execute({ command: 'cd missing-directory' }, {
@@ -202,4 +230,12 @@ describe('ShellTool current directory probe', () => {
 
 function assertSameDirectory(actual: string, expected: string): void {
   assert.strictEqual(fs.realpathSync(actual), fs.realpathSync(expected));
+}
+
+function quotePowerShellString(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+function quotePosixString(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
 }

--- a/tests/tool-result-send-text-tool.test.ts
+++ b/tests/tool-result-send-text-tool.test.ts
@@ -61,6 +61,22 @@ describe('SendTextTool outbound scope checks', () => {
     assert.deepEqual(sent, [{ chatId: 'legacy-chat', text: 'hello' }]);
   });
 
+  test('rejects missing or empty text without sending', async () => {
+    const tool = new SendTextTool();
+    const { context, sent } = contextWithChannel('p2p_7_43', scope());
+
+    const missingResult = await tool.execute({}, context);
+    const emptyResult = await tool.execute({ text: '   ' }, context);
+
+    assert.equal(missingResult.ok, false);
+    assert.equal(missingResult.errorCode, 'INVALID_TOOL_ARGUMENTS');
+    assert.match(missingResult.message, /non-empty text/);
+    assert.equal(emptyResult.ok, false);
+    assert.equal(emptyResult.errorCode, 'INVALID_TOOL_ARGUMENTS');
+    assert.match(emptyResult.message, /non-empty text/);
+    assert.deepEqual(sent, []);
+  });
+
   test('blocks text send when channel chatId conflicts with executionScope topic', async () => {
     const tool = new SendTextTool();
     const { context, sent } = contextWithChannel('p2p_8_43', scope());
@@ -88,7 +104,7 @@ describe('SendTextTool outbound scope checks', () => {
     assert.deepEqual(sent, [{ chatId: 'p2p_7_43', text: '请重新发送一下' }]);
   });
 
-  test('propagates channel send failures to the tool caller', async () => {
+  test('returns channel send failures as structured tool errors', async () => {
     const tool = new SendTextTool();
     const context: ToolExecutionContext = {
       workingDirectory: process.cwd(),
@@ -105,9 +121,10 @@ describe('SendTextTool outbound scope checks', () => {
       },
     };
 
-    await assert.rejects(
-      () => tool.execute({ text: '会发送失败' }, context),
-      /ack timeout/,
-    );
+    const result = await tool.execute({ text: '会发送失败' }, context);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.errorCode, 'TOOL_EXECUTION_ERROR');
+    assert.match(result.message, /Message send failed: ack timeout/);
   });
 });

--- a/tests/tool-result-write-tool.test.ts
+++ b/tests/tool-result-write-tool.test.ts
@@ -1,13 +1,19 @@
 /**
  * write-tool 测试：验证 ToolExecutionResult 结构
  */
-import { describe, test, beforeEach } from 'node:test';
+import { describe, test, beforeEach, afterEach } from 'node:test';
 import * as assert from 'node:assert';
 import * as path from 'path';
 import * as os from 'os';
 import * as fs from 'fs';
 import { WriteTool } from '../src/tools/write-tool';
-import { ToolExecutionContext } from '../src/types/tool';
+import { ToolExecutionContext, ToolExecutionResult } from '../src/types/tool';
+
+function getFailure(result: ToolExecutionResult): Extract<ToolExecutionResult, { ok: false }> {
+  assert.strictEqual(result.ok, false);
+  if (result.ok) throw new Error('expected write_file to fail');
+  return result;
+}
 
 describe('WriteTool - ToolExecutionResult', () => {
   let tool: WriteTool;
@@ -18,6 +24,12 @@ describe('WriteTool - ToolExecutionResult', () => {
     tool = new WriteTool();
     testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'write-tool-test-'));
     context = { workingDirectory: testRoot, conversationHistory: [] };
+  });
+
+  afterEach(() => {
+    if (testRoot && fs.existsSync(testRoot)) {
+      fs.rmSync(testRoot, { recursive: true, force: true });
+    }
   });
 
   test('成功写入新文件返回 ok=true', async () => {
@@ -47,5 +59,45 @@ describe('WriteTool - ToolExecutionResult', () => {
     const result = await tool.execute({ file_path: 'a/b/c/deep.txt', content: 'deep' }, context);
     assert.strictEqual(result.ok, true);
     assert.ok(fs.existsSync(path.join(testRoot, 'a/b/c/deep.txt')));
+  });
+
+  test('缺少 content 时返回 INVALID_TOOL_ARGUMENTS 且不创建文件', async () => {
+    const result = await tool.execute({ file_path: 'missing-content.txt' }, context);
+
+    const failure = getFailure(result);
+    assert.strictEqual(failure.errorCode, 'INVALID_TOOL_ARGUMENTS');
+    assert.strictEqual(fs.existsSync(path.join(testRoot, 'missing-content.txt')), false);
+  });
+
+  test('缺少或空 file_path 时返回 INVALID_TOOL_ARGUMENTS', async () => {
+    const missingPath = await tool.execute({ content: 'hello' }, context);
+    const emptyPath = await tool.execute({ file_path: '', content: 'hello' }, context);
+
+    assert.strictEqual(getFailure(missingPath).errorCode, 'INVALID_TOOL_ARGUMENTS');
+    assert.strictEqual(getFailure(emptyPath).errorCode, 'INVALID_TOOL_ARGUMENTS');
+  });
+
+  test('目标路径是目录时返回结构化错误', async () => {
+    const dirPath = path.join(testRoot, 'dir-target');
+    fs.mkdirSync(dirPath);
+
+    const result = await tool.execute({ file_path: dirPath, content: 'hello' }, context);
+
+    const failure = getFailure(result);
+    assert.strictEqual(failure.errorCode, 'TOOL_EXECUTION_ERROR');
+    assert.match(failure.message, /不是文件|not a file/);
+    assert.strictEqual(fs.statSync(dirPath).isDirectory(), true);
+  });
+
+  test('父路径是文件时返回结构化错误', async () => {
+    const parentFile = path.join(testRoot, 'parent-file');
+    fs.writeFileSync(parentFile, 'not a directory');
+
+    const result = await tool.execute({ file_path: path.join(parentFile, 'child.txt'), content: 'hello' }, context);
+
+    const failure = getFailure(result);
+    assert.strictEqual(failure.errorCode, 'TOOL_EXECUTION_ERROR');
+    assert.match(failure.message, /父路径不是目录/);
+    assert.strictEqual(fs.readFileSync(parentFile, 'utf8'), 'not a directory');
   });
 });

--- a/tests/transient-environment.test.ts
+++ b/tests/transient-environment.test.ts
@@ -12,6 +12,8 @@ test('transient environment hint carries cwd and local execution details outside
     provider: 'openai',
     model: 'MiniMax-M3',
     env: { ComSpec: 'C:\\Windows\\System32\\cmd.exe' },
+    platform: 'win32',
+    now: new Date('2026-06-14T12:00:00.000Z'),
     gitInfo: {
       root: 'C:\\work\\project',
       branch: 'main',
@@ -28,7 +30,8 @@ test('transient environment hint carries cwd and local execution details outside
   assert.match(message.content, /cwd: C:\\work\\project/);
   assert.doesNotMatch(message.content, /^surface:/m);
   assert.match(message.content, /model: openai\/MiniMax-M3/);
-  assert.match(message.content, /shell: cmd/);
+  assert.match(message.content, /os: win32/);
+  assert.match(message.content, /shell: powershell/);
   assert.match(message.content, /git: root=\., branch=main, tracked_changes=2/);
   assert.match(message.content, /Use cwd for relative file and shell paths\./);
 });
@@ -38,13 +41,7 @@ test('transient environment hint is omitted without a current directory', () => 
 });
 
 test('shell name resolver accepts common Windows and POSIX env fields', () => {
-  assert.equal(resolveShellName({ ComSpec: 'C:\\Windows\\System32\\cmd.exe' }), 'cmd');
-  assert.equal(resolveShellName({ SHELL: '/bin/zsh' }), 'zsh');
-  assert.equal(resolveShellName({ PSModulePath: 'C:\\Users\\test\\Documents\\PowerShell\\Modules' }), 'powershell');
-  if (process.platform === 'win32') {
-    assert.equal(resolveShellName({
-      ComSpec: 'C:\\Windows\\System32\\cmd.exe',
-      PSModulePath: 'C:\\Users\\test\\Documents\\PowerShell\\Modules',
-    }), 'powershell');
-  }
+  assert.equal(resolveShellName({ ComSpec: 'C:\\Windows\\System32\\cmd.exe' }, 'win32'), 'powershell');
+  assert.equal(resolveShellName({ SHELL: '/bin/zsh' }, 'linux'), 'zsh');
+  assert.equal(resolveShellName({ PSModulePath: 'C:\\Users\\test\\Documents\\PowerShell\\Modules' }, 'win32'), 'powershell');
 });


### PR DESCRIPTION
## 这次改了什么

这轮主要收口一批工具的执行契约、输出控制和错误提示，重点不是重构工具系统，而是把最常用、最容易影响 agent 体验的工具先补稳。

### execute_shell

- 改成结构化输出 contract，明确区分 `stdout`、`stderr`、退出码、超时、截断等状态。
- 修复进程生命周期问题：工具返回前会等待进程真正结束，避免子进程还没收尾就把结果交给模型。
- 在 POSIX 场景优先用 `spawn` 执行，减少 shell 命令被包一层后带来的行为偏差。
- 对大输出做控制：返回给模型的是受限预览，超大内容会落到文件里，避免一次性把大量日志塞进上下文。
- 补了 shell 相关测试，覆盖当前目录、超时、stderr、退出码、大输出、文件化输出等行为。

### grep

- 给 grep 结果加输出上限，避免匹配内容太多时直接撑爆上下文。
- 补齐 `limit` / `output_mode` 等场景下的返回提示，让模型知道结果是不是被截断、下一步该缩小范围还是继续查。
- 改善系统 grep 不可用或行为不一致时的 JS fallback，尽量保持语义一致。
- 补了输出量、fallback、参数校验等测试。

### edit_file

- 增加参数校验，避免缺 `new_string`、空 `old_string` 之类输入造成异常写入或无意义替换。
- 拦截目录、疑似二进制文件、过大文件，减少误改风险。
- 找不到 `old_string` 时给更具体的线索：换行差异、首尾空白差异、相似候选行等。
- 成功编辑后返回修改位置附近的少量上下文，方便模型确认自己改到了正确位置。
- 补了无效参数、目录/二进制/大文件、失败诊断、成功上下文等测试。

### write_file

- 增加运行时参数校验：`file_path` 必须是非空字符串，`content` 必须是字符串。
- 写入前检查目标路径和父路径：目标不能是目录，父路径不能是文件。
- 创建父目录失败、路径类型不对等情况返回结构化错误，而不是抛异常或留下不清晰日志。
- 补了缺参数、空路径、目标为目录、父路径为文件等测试。

### send_text

- 把空文本、缺 `text` 改成结构化 `INVALID_TOOL_ARGUMENTS`。
- 把平台 `reply` 失败改成结构化 `TOOL_EXECUTION_ERROR`，不再让异常直接冒泡。
- 保持成功路径不变：仍然 trim 后发送，并进入原有 outbound transcript 归一化流程。
- 补了空文本、缺文本、发送失败等测试。

## 为什么要改

这些工具是 agent 真正做事的手脚。之前最大的问题不是“功能不够多”，而是一些边界行为不稳定：

- 输出太大时容易浪费上下文，甚至影响后续推理。
- 工具失败有时返回结构化结果，有时直接 throw。
- 文件编辑失败时给模型的线索太少，容易让它重复试错。
- shell 的 stdout/stderr、退出码、超时、大输出没有统一 contract。

这次先把高频工具的行为变得更可预测，让模型拿到的工具结果更像稳定 API，而不是一堆临时字符串。

## 对用户/开发者的影响

- 模型更容易判断工具是否真的成功、失败原因是什么、下一步该怎么修。
- 大输出不会无脑塞满上下文。
- 文件编辑失败时更容易自我修正。
- 写文件和发文本的异常路径更稳定，方便上层 runtime 统一处理。

## 验证

- `npm run build`
- `npx tsx --test tests\grep-tool.test.ts tests\tool-result-tool-manager.test.ts tests\tool-gateway-catsco.test.ts`
- `npx tsx --test tests\edit-tool.test.ts tests\tool-result-tool-manager.test.ts tests\tool-gateway-catsco.test.ts`
- `npx tsx --test tests\tool-result-write-tool.test.ts tests\tool-result-tool-manager.test.ts tests\tool-gateway-catsco.test.ts`
- `npx tsx --test tests\tool-result-send-text-tool.test.ts tests\outbound-gateway.test.ts tests\conversation-runner-transcript-normalization.test.ts`
- `npm test` 通过：862 tests，858 pass，4 skipped
