### PR TITLE
[codex] Close CatsCo tool target loop

### DIFF
--- a/prompts/transient/runtime-context-rules.md
+++ b/prompts/transient/runtime-context-rules.md
@@ -2,4 +2,8 @@
 不要要求用户提供这里的内部 ID；需要时使用工具和后端作用域。
 工具需要用户设备时，优先使用 execution.deviceSelection 里后端选定的目标。
 如果 execution.deviceSelection.status 是 needs_selection 或 unavailable，请先让用户按展示名选择可用设备，再使用设备工具。
+当用户说“我的电脑/我的桌面/我本地”时，目标通常是当前发言人的用户设备；当用户说“你的电脑/你自己的云电脑/虚拟员工自己的桌面”时，目标是智能体自己的 cloud runtime body。
+如果是在智能体自己的 cloud runtime body 上执行，不要先要求选择用户设备；直接让工具走当前 agent local body。
+resolve_common_directory 返回的路径只对产生它的目标设备有效；如果目标在用户设备和智能体云运行体之间切换，必须重新解析。
+execute_shell 需要在某个目录运行时，优先传 cwd，不要依赖上一条命令里的 cd。
 不要猜测或暴露本地文件系统路径；工具需要文件引用时使用 attachment ref。

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -401,8 +401,18 @@ export class CatsCompanyBot {
     return annotateToolExecutionResultWithTargetContext(result, context, {
       toolName,
       operation,
-      cwd: context.workingDirectory,
+      cwd: this.resolveDeviceRpcTargetContextCwd(operation, args, context.workingDirectory),
     });
+  }
+
+  private resolveDeviceRpcTargetContextCwd(
+    operation: DeviceGrantOperation,
+    args: Record<string, unknown>,
+    fallback: string,
+  ): string {
+    if (operation !== 'execute_shell') return fallback;
+    const cwd = args.cwd;
+    return typeof cwd === 'string' && cwd.trim() ? cwd.trim() : fallback;
   }
 
   private buildDeviceRpcToolContext(

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -33,6 +33,10 @@ import {
   normalizeDeviceRpcToolResultForTransport,
   normalizeDeviceRpcToolResultPayload,
 } from '../tools/device-rpc-tool';
+import {
+  annotateToolExecutionResultWithTargetContext,
+  stripToolTargetContextForDisplay,
+} from '../tools/tool-target-context';
 import { formatPathForLog } from '../utils/log-redaction';
 
 interface PendingAttachment {
@@ -363,28 +367,42 @@ export class CatsCompanyBot {
 
     const context = this.buildDeviceRpcToolContext(request, operation);
     const args = this.extractDeviceRpcToolArgs(request.payload);
+    let result: ToolExecutionResult;
     switch (operation) {
       case 'read_file':
-        return new ReadTool().execute(args, context);
+        result = await new ReadTool().execute(args, context);
+        break;
       case 'resolve_common_directory':
-        return resolveCommonDirectoryToolArgs(args);
+        result = resolveCommonDirectoryToolArgs(args);
+        break;
       case 'glob':
-        return new GlobTool().execute(args, context);
+        result = await new GlobTool().execute(args, context);
+        break;
       case 'grep':
-        return new GrepTool().execute(args, context);
+        result = await new GrepTool().execute(args, context);
+        break;
       case 'write_file':
-        return new WriteTool().execute(args, context);
+        result = await new WriteTool().execute(args, context);
+        break;
       case 'edit_file':
-        return new EditTool().execute(args, context);
+        result = await new EditTool().execute(args, context);
+        break;
       case 'execute_shell':
-        return new ShellTool().execute(args, context);
+        result = await new ShellTool().execute(args, context);
+        break;
       default:
-        return {
+        result = {
           ok: false,
           errorCode: 'PERMISSION_DENIED',
           message: `Device RPC 不允许执行 ${operation}。`,
         };
     }
+
+    return annotateToolExecutionResultWithTargetContext(result, context, {
+      toolName,
+      operation,
+      cwd: context.workingDirectory,
+    });
   }
 
   private buildDeviceRpcToolContext(
@@ -652,7 +670,7 @@ export class CatsCompanyBot {
           return;
         }
         try {
-          let content = result;
+          let content = stripToolTargetContextForDisplay(result);
 
           // 清理 execute_shell 的格式化前缀
           if (content.startsWith('命令执行成功:') || content.startsWith('命令执行失败:')) {

--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -52,6 +52,7 @@ import { MODEL_IMAGE_SAFETY_MESSAGE, isModelImageSafetyError } from '../utils/mo
 import { formatProviderErrorForLog } from '../utils/provider-error-log-sanitizer';
 import { renderRequiredDefaultPromptFile } from '../utils/prompt-template';
 import { PromptTraceLogger } from '../utils/prompt-trace-logger';
+import { prependToolTargetContext } from '../tools/tool-target-context';
 import {
   buildSyntheticObservationLifecycleEvent,
   buildSyntheticObservationMessages,
@@ -636,9 +637,9 @@ export class ConversationRunner {
           hasDeliveredMessageOutThisRun = true;
         }
 
-        const toolContent = result.content;
+        const toolContent = prependToolTargetContext(result.content, result.targetContext);
 
-        this.handleToolDisplay(toolCall, contentToString(toolContent), callbacks);
+        this.handleToolDisplay(toolCall, contentToString(result.content), callbacks);
         executionRecords.push({
           toolCall,
           toolName,

--- a/src/core/transient-environment.ts
+++ b/src/core/transient-environment.ts
@@ -55,6 +55,7 @@ export function buildTransientEnvironmentHint(
 }
 
 export function resolveShellName(env: NodeJS.ProcessEnv = process.env): string {
+  if (process.platform === 'win32' && env.PSModulePath) return 'powershell';
   const raw = env.SHELL || env.ComSpec || env.COMSPEC || (env.PSModulePath ? 'powershell' : '');
   if (!raw) return 'unknown';
   const basename = path.win32.basename(raw);

--- a/src/tools/bash-tool.ts
+++ b/src/tools/bash-tool.ts
@@ -32,7 +32,7 @@ export class ShellTool implements Tool {
     name: 'execute_shell',
     description: [
       '执行一条非交互式系统命令。',
-      '命令从当前目录启动；每次调用都是新的 shell 进程，只有最终当前目录会保留到后续工具调用。',
+      '命令从当前目录或显式 cwd 启动；每次调用都是新的 shell 进程，只有最终当前目录会保留到后续工具调用。',
       '环境变量、alias、函数和已激活虚拟环境不会自动跨调用保留；需要时在同一条 command 中显式设置。',
       '在 CatsCo/远程用户设备场景中，不要用它做普通文件查看或创建；查看文件列表用 glob，创建/覆盖文本文件用 write_file，编辑文件用 edit_file。',
     ].join('\n'),
@@ -51,6 +51,10 @@ export class ShellTool implements Tool {
           type: 'number',
           description: '超时时间，单位毫秒。默认 30000。',
         },
+        cwd: {
+          type: 'string',
+          description: '可选。命令启动目录。支持绝对路径或相对当前目录的路径；需要在桌面/下载等目录运行命令时，先用 resolve_common_directory 解析，再把返回的 path 传给 cwd。',
+        },
         confirm_dangerous: {
           type: 'boolean',
           description: 'Set true only after the user explicitly requested or confirmed a risky destructive command such as recursive deletion, git reset --hard, git clean, or force push.',
@@ -62,7 +66,7 @@ export class ShellTool implements Tool {
   };
 
   async execute(args: any, context: ToolExecutionContext): Promise<ToolExecutionResult> {
-    const { command, description, timeout = 30000, confirm_dangerous = false } = args;
+    const { command, description, timeout = 30000, confirm_dangerous = false, cwd } = args;
 
     if (context.abortSignal?.aborted) {
       return { ok: false, errorCode: 'EXECUTION_TIMEOUT', message: `命令已取消，未开始执行:\n$ ${command}` };
@@ -93,8 +97,11 @@ export class ShellTool implements Tool {
     if (description) {
       Logger.info(`Executing command: ${description}`);
     }
+    const executionDirectory = this.resolveExecutionDirectory(cwd, context);
+    if (!executionDirectory.ok) return executionDirectory;
+
     Logger.info(`$ ${command}`);
-    Logger.info(`Current directory: ${context.workingDirectory}`);
+    Logger.info(`Current directory: ${executionDirectory.directory}`);
 
     const startTime = Date.now();
     const runtimeEnvironment = resolveRuntimeEnvironment({
@@ -106,7 +113,7 @@ export class ShellTool implements Tool {
     try {
       const { stdout, stderr } = await this.executeWrappedCommand(
         wrapped,
-        context.workingDirectory,
+        executionDirectory.directory,
         runtimeEnvironment.env,
         timeout,
         context.abortSignal,
@@ -114,8 +121,9 @@ export class ShellTool implements Tool {
 
       const parsedStdout = this.extractDirectoryProbe(stdout || '', wrapped.marker);
       const parsedStderr = this.extractDirectoryProbe(stderr || '', wrapped.marker);
+      const finalDirectory = this.readDirectoryProbe(wrapped) || parsedStdout.directory || parsedStderr.directory;
       this.updateCurrentDirectory(
-        this.readDirectoryProbe(wrapped) || parsedStdout.directory || parsedStderr.directory,
+        finalDirectory,
         context,
       );
 
@@ -143,14 +151,26 @@ export class ShellTool implements Tool {
 
       return {
         ok: true,
-        content: `Command succeeded:\n$ ${command}\n\nElapsed: ${executionTime}ms\nOutput lines: ${outputLines}\n\n${output}`,
+        content: [
+          'Command succeeded:',
+          `$ ${command}`,
+          '',
+          `Working directory: ${executionDirectory.directory}`,
+          finalDirectory ? `Final cwd: ${finalDirectory}` : '',
+          `Shell: ${this.resolveShellDisplayName()}`,
+          `Elapsed: ${executionTime}ms`,
+          `Output lines: ${outputLines}`,
+          '',
+          output,
+        ].filter(line => line !== '').join('\n'),
       };
     } catch (error: any) {
       const executionTime = Date.now() - startTime;
       const parsedStdout = this.extractDirectoryProbe(error.stdout || '', wrapped.marker);
       const parsedStderr = this.extractDirectoryProbe(error.stderr || '', wrapped.marker);
+      const finalDirectory = this.readDirectoryProbe(wrapped) || parsedStdout.directory || parsedStderr.directory;
       this.updateCurrentDirectory(
-        this.readDirectoryProbe(wrapped) || parsedStdout.directory || parsedStderr.directory,
+        finalDirectory,
         context,
       );
       if (context.abortSignal?.aborted || /aborted|abort/i.test(String(error.message || ''))) {
@@ -158,7 +178,15 @@ export class ShellTool implements Tool {
         return {
           ok: false,
           errorCode: 'EXECUTION_TIMEOUT',
-          message: `命令已取消:\n$ ${command}\n\n执行时间: ${executionTime}ms`,
+          message: [
+            '命令已取消:',
+            `$ ${command}`,
+            '',
+            `Working directory: ${executionDirectory.directory}`,
+            finalDirectory ? `Final cwd: ${finalDirectory}` : '',
+            `Shell: ${this.resolveShellDisplayName()}`,
+            `执行时间: ${executionTime}ms`,
+          ].filter(line => line !== '').join('\n'),
         };
       }
       const errorOutput = [
@@ -173,7 +201,17 @@ export class ShellTool implements Tool {
       return {
         ok: false,
         errorCode: 'TOOL_EXECUTION_ERROR',
-        message: `Command failed:\n$ ${command}\n\nElapsed: ${executionTime}ms\nError:\n${errorOutput}`,
+        message: [
+          'Command failed:',
+          `$ ${command}`,
+          '',
+          `Working directory: ${executionDirectory.directory}`,
+          finalDirectory ? `Final cwd: ${finalDirectory}` : '',
+          `Shell: ${this.resolveShellDisplayName()}`,
+          `Elapsed: ${executionTime}ms`,
+          'Error:',
+          errorOutput,
+        ].filter(line => line !== '').join('\n'),
       };
     } finally {
       this.cleanupWrappedCommand(wrapped);
@@ -552,6 +590,52 @@ export class ShellTool implements Tool {
       .filter(line => !line.startsWith(CWD_MARKER_PREFIX))
       .join('\n')
       .replace(/\n+$/, '');
+  }
+
+  private resolveExecutionDirectory(
+    cwd: unknown,
+    context: ToolExecutionContext,
+  ): { ok: true; directory: string } | { ok: false; errorCode: 'INVALID_TOOL_ARGUMENTS'; message: string } {
+    if (cwd === undefined || cwd === null || cwd === '') {
+      return { ok: true, directory: context.workingDirectory };
+    }
+    if (typeof cwd !== 'string') {
+      return {
+        ok: false,
+        errorCode: 'INVALID_TOOL_ARGUMENTS',
+        message: 'execute_shell.cwd 必须是字符串路径。',
+      };
+    }
+    const directory = path.isAbsolute(cwd)
+      ? path.resolve(cwd)
+      : path.resolve(context.workingDirectory, cwd);
+    try {
+      if (!fs.existsSync(directory)) {
+        return {
+          ok: false,
+          errorCode: 'INVALID_TOOL_ARGUMENTS',
+          message: `execute_shell.cwd 不存在: ${directory}`,
+        };
+      }
+      if (!fs.statSync(directory).isDirectory()) {
+        return {
+          ok: false,
+          errorCode: 'INVALID_TOOL_ARGUMENTS',
+          message: `execute_shell.cwd 不是目录: ${directory}`,
+        };
+      }
+    } catch (error: any) {
+      return {
+        ok: false,
+        errorCode: 'INVALID_TOOL_ARGUMENTS',
+        message: `execute_shell.cwd 无法访问: ${error?.message || error}`,
+      };
+    }
+    return { ok: true, directory };
+  }
+
+  private resolveShellDisplayName(): string {
+    return process.platform === 'win32' ? 'powershell' : 'sh';
   }
 
   private formatExecutionError(error: any): string {

--- a/src/tools/common-directory-tool.ts
+++ b/src/tools/common-directory-tool.ts
@@ -143,9 +143,10 @@ export class CommonDirectoryTool implements Tool {
   definition: ToolDefinition = {
     name: 'resolve_common_directory',
     description: [
-      '把常见用户目录名称解析为当前系统上的真实本地路径。',
+      '把常见用户目录名称解析为当前工具目标设备上的真实本地路径。',
       '当用户说“桌面”“下载”“文档”等自然语言目录时先用它解析，不要手猜 C:\\Users\\...\\Desktop、~/Desktop 等路径。',
-      '解析后如果要查看目录文件，请用 glob；如果要创建文件，请用 write_file。不要为了普通文件操作改用 execute_shell。',
+      '解析出的 path 只属于本次工具实际执行的目标：可能是虚拟员工自己的云运行体，也可能是后端选中的用户设备。',
+      '解析后如果要查看目录文件，请用 glob；如果要创建文件，请用 write_file。必须用命令时，把 path 传给 execute_shell.cwd，不要单独 cd 后再猜当前目录。',
       '只解析标准 OS 用户目录；不搜索项目目录、应用目录、浏览器下载子目录或语义目录。',
     ].join('\n'),
     parameters: {
@@ -206,9 +207,11 @@ export function formatCommonDirectoryResolution(result: DirectoryResolution): st
     `exists: ${result.exists}`,
     `platform: ${result.platform}`,
     '',
-    'Use this exact path as the base directory for follow-up file operations.',
+    'Use this exact path only with the same tool target that produced this result.',
+    'If the next user request switches between "my/user computer" and "your/virtual employee cloud computer", call resolve_common_directory again on the new target.',
     'To list files here, call glob with this path and an appropriate pattern such as "*".',
     'To create or overwrite a text file here, call write_file with a file_path under this path.',
+    'If shell is truly required, pass this path as execute_shell.cwd instead of relying on a prior cd command.',
     'Do not use execute_shell for routine file listing or file creation.',
   ].join('\n');
 }

--- a/src/tools/tool-manager.ts
+++ b/src/tools/tool-manager.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import { Tool, ToolDefinition, ToolCall, ToolResult, ToolExecutionContext, ToolExecutor, ToolExecutionResult } from '../types/tool';
 import { Logger } from '../utils/logger';
 import { ReadTool } from './read-tool';
@@ -22,6 +23,7 @@ import { PromptModeTool } from './prompt-mode-tool';
 import { DEFAULT_TOOL_NAMES } from './default-tool-names';
 import { mergeToolExecutionContext } from '../utils/tool-context';
 import { confirmLocalToolExecution } from './local-tool-risk';
+import { buildToolTargetContext, operationForToolTargetContext } from './tool-target-context';
 
 const INTERNAL_TOOL_NAMES = ['ask_parent'] as const;
 
@@ -207,6 +209,11 @@ export class ToolManager implements ToolExecutor {
       }
 
       const output = await tool.execute(args, context);
+      const targetContext = buildToolTargetContext(context, {
+        toolName,
+        operation: operationForToolTargetContext(toolName),
+        cwd: resolveTargetContextCwd(toolName, args, context.workingDirectory),
+      });
 
       // 失败结果：统一走 ok=false 分支
       if (!output.ok) {
@@ -215,6 +222,7 @@ export class ToolManager implements ToolExecutor {
           role: 'tool',
           name: toolCall.function.name,
           content: output.message,
+          targetContext,
           ok: false,
           errorCode: output.errorCode,
           retryable: output.retryable ?? isRateLimitLikeMessage(output.message),
@@ -226,6 +234,7 @@ export class ToolManager implements ToolExecutor {
         role: 'tool',
         name: toolCall.function.name,
         content: output.content,
+        targetContext,
         ok: true,
         controlSignal: tool.definition.controlMode,
       };
@@ -254,5 +263,20 @@ export class ToolManager implements ToolExecutor {
 
   getAllTools(): Tool[] {
     return Array.from(this.tools.values());
+  }
+}
+
+function resolveTargetContextCwd(toolName: string, args: unknown, currentDirectory: string): string {
+  if (toolName !== 'execute_shell' || !args || typeof args !== 'object') {
+    return currentDirectory;
+  }
+  const cwd = (args as Record<string, unknown>).cwd;
+  if (typeof cwd !== 'string' || !cwd.trim()) return currentDirectory;
+  try {
+    return path.isAbsolute(cwd)
+      ? path.resolve(cwd)
+      : path.resolve(currentDirectory, cwd);
+  } catch {
+    return currentDirectory;
   }
 }

--- a/src/tools/tool-manager.ts
+++ b/src/tools/tool-manager.ts
@@ -1,4 +1,3 @@
-import * as path from 'path';
 import { Tool, ToolDefinition, ToolCall, ToolResult, ToolExecutionContext, ToolExecutor, ToolExecutionResult } from '../types/tool';
 import { Logger } from '../utils/logger';
 import { ReadTool } from './read-tool';
@@ -271,12 +270,5 @@ function resolveTargetContextCwd(toolName: string, args: unknown, currentDirecto
     return currentDirectory;
   }
   const cwd = (args as Record<string, unknown>).cwd;
-  if (typeof cwd !== 'string' || !cwd.trim()) return currentDirectory;
-  try {
-    return path.isAbsolute(cwd)
-      ? path.resolve(cwd)
-      : path.resolve(currentDirectory, cwd);
-  } catch {
-    return currentDirectory;
-  }
+  return typeof cwd === 'string' && cwd.trim() ? cwd.trim() : currentDirectory;
 }

--- a/src/tools/tool-target-context.ts
+++ b/src/tools/tool-target-context.ts
@@ -1,4 +1,3 @@
-import * as path from 'path';
 import type { DeviceGrantOperation } from '../types/session-identity';
 import type { ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import {
@@ -42,7 +41,7 @@ export function buildToolTargetContext(
   if (!operation) return undefined;
 
   const target = resolveToolTarget(context, options.gateway);
-  const cwd = normalizeCwdForTarget(options.cwd || context.workingDirectory);
+  const cwd = preserveCwdForTarget(options.cwd || context.workingDirectory);
   const lines = [
     TOOL_TARGET_CONTEXT_PREFIX,
     `tool: ${options.toolName}`,
@@ -138,12 +137,7 @@ function resolveToolTarget(
   return { kind: 'current_local_runtime' };
 }
 
-function normalizeCwdForTarget(cwd: string | undefined): string | undefined {
+function preserveCwdForTarget(cwd: string | undefined): string | undefined {
   const text = String(cwd || '').trim();
-  if (!text) return undefined;
-  try {
-    return path.resolve(text);
-  } catch {
-    return text;
-  }
+  return text || undefined;
 }

--- a/src/tools/tool-target-context.ts
+++ b/src/tools/tool-target-context.ts
@@ -1,0 +1,149 @@
+import * as path from 'path';
+import type { DeviceGrantOperation } from '../types/session-identity';
+import type { ToolExecutionContext, ToolExecutionResult } from '../types/tool';
+import {
+  isCatsCoAgentLocalBodyContext,
+  isCatsCoLocalOwnerSelfContext,
+  isCatsCoToolGatewayContext,
+  type ToolGatewayDecision,
+} from './tool-gateway';
+
+export const TOOL_TARGET_CONTEXT_PREFIX = '[tool_target]';
+export const TOOL_TARGET_CONTEXT_SUFFIX = '[/tool_target]';
+
+const DEVICE_TOOL_OPERATIONS: Partial<Record<string, DeviceGrantOperation>> = {
+  read_file: 'read_file',
+  resolve_common_directory: 'resolve_common_directory',
+  glob: 'glob',
+  grep: 'grep',
+  write_file: 'write_file',
+  edit_file: 'edit_file',
+  execute_shell: 'execute_shell',
+};
+
+export interface ToolTargetContextOptions {
+  toolName: string;
+  operation?: DeviceGrantOperation;
+  gateway?: ToolGatewayDecision;
+  cwd?: string;
+  shell?: string;
+}
+
+export function operationForToolTargetContext(toolName: string): DeviceGrantOperation | undefined {
+  return DEVICE_TOOL_OPERATIONS[toolName];
+}
+
+export function buildToolTargetContext(
+  context: ToolExecutionContext,
+  options: ToolTargetContextOptions,
+): string | undefined {
+  if (!isCatsCoToolGatewayContext(context)) return undefined;
+  const operation = options.operation || operationForToolTargetContext(options.toolName);
+  if (!operation) return undefined;
+
+  const target = resolveToolTarget(context, options.gateway);
+  const cwd = normalizeCwdForTarget(options.cwd || context.workingDirectory);
+  const lines = [
+    TOOL_TARGET_CONTEXT_PREFIX,
+    `tool: ${options.toolName}`,
+    `operation: ${operation}`,
+    `target: ${target.kind}`,
+    target.displayName ? `target_display_name: ${target.displayName}` : '',
+    cwd ? `cwd: ${cwd}` : '',
+    options.shell ? `shell: ${options.shell}` : '',
+    'path_scope: Paths in this result belong only to the target above. Re-resolve common directories after switching targets.',
+    TOOL_TARGET_CONTEXT_SUFFIX,
+  ].filter(Boolean);
+
+  return lines.join('\n');
+}
+
+export function annotateToolExecutionResultWithTargetContext(
+  result: ToolExecutionResult,
+  context: ToolExecutionContext,
+  options: ToolTargetContextOptions,
+): ToolExecutionResult {
+  const targetContext = buildToolTargetContext(context, options);
+  if (!targetContext) return result;
+
+  if (result.ok) {
+    if (typeof result.content !== 'string' || hasToolTargetContext(result.content)) return result;
+    return {
+      ...result,
+      content: `${targetContext}\n\n${result.content}`,
+    };
+  }
+
+  if (hasToolTargetContext(result.message)) return result;
+  return {
+    ...result,
+    message: `${targetContext}\n\n${result.message}`,
+  };
+}
+
+export function hasToolTargetContext(content: unknown): boolean {
+  return typeof content === 'string' && content.trimStart().startsWith(TOOL_TARGET_CONTEXT_PREFIX);
+}
+
+export function prependToolTargetContext(
+  content: string | import('../types').ContentBlock[],
+  targetContext: string | undefined,
+): string | import('../types').ContentBlock[] {
+  if (!targetContext || typeof content !== 'string' || hasToolTargetContext(content)) return content;
+  return `${targetContext}\n\n${content}`;
+}
+
+export function stripToolTargetContextForDisplay(content: string): string {
+  return String(content || '')
+    .replace(/^\s*\[tool_target\]\r?\n[\s\S]*?\r?\n\[\/tool_target\]\r?\n*/u, '')
+    .replace(/^\n+/, '');
+}
+
+function resolveToolTarget(
+  context: ToolExecutionContext,
+  gateway?: ToolGatewayDecision,
+): { kind: string; displayName?: string } {
+  if (gateway?.ok && gateway.mode === 'remote') {
+    return {
+      kind: 'selected_user_device',
+      displayName: gateway.targetDeviceDisplayName,
+    };
+  }
+
+  if (context.executionScope?.permissionsSource === 'device_rpc_forward') {
+    return {
+      kind: 'selected_user_device',
+      displayName: context.deviceSelection?.selectedDeviceDisplayName,
+    };
+  }
+
+  if (isCatsCoAgentLocalBodyContext(context)) {
+    return { kind: 'virtual_employee_cloud_runtime' };
+  }
+
+  if (isCatsCoLocalOwnerSelfContext(context)) {
+    return {
+      kind: 'local_owner_device',
+      displayName: context.deviceSelection?.selectedDeviceDisplayName,
+    };
+  }
+
+  if (context.deviceSelection?.status === 'selected') {
+    return {
+      kind: 'backend_selected_device',
+      displayName: context.deviceSelection.selectedDeviceDisplayName,
+    };
+  }
+
+  return { kind: 'current_local_runtime' };
+}
+
+function normalizeCwdForTarget(cwd: string | undefined): string | undefined {
+  const text = String(cwd || '').trim();
+  if (!text) return undefined;
+  try {
+    return path.resolve(text);
+  } catch {
+    return text;
+  }
+}

--- a/src/types/tool.ts
+++ b/src/types/tool.ts
@@ -75,6 +75,8 @@ export interface ToolResult {
   role: 'tool';
   name: string;
   content: string | import('./index').ContentBlock[];
+  /** Transient provider-only context that disambiguates which device/runtime produced this tool result. */
+  targetContext?: string;
   ok?: boolean;
   errorCode?: string;
   retryable?: boolean;

--- a/tests/catscompany-device-rpc-tools.test.ts
+++ b/tests/catscompany-device-rpc-tools.test.ts
@@ -190,6 +190,8 @@ describe('CatsCompany Device RPC file tools', () => {
     assert.ok(captured.result);
     assert.equal(captured.result.error, undefined);
     assert.equal(captured.result.result.ok, true);
+    assert.match(String(captured.result.result.content), /\[tool_target\]/);
+    assert.match(String(captured.result.result.content), /target: selected_user_device/);
     assert.match(String(captured.result.result.content), /Resolved common directory:/);
     assert.match(String(captured.result.result.content), /kind: home/);
     assert.equal(captured.result.device_id, 'install-device');

--- a/tests/common-directory-tool.test.ts
+++ b/tests/common-directory-tool.test.ts
@@ -47,9 +47,11 @@ describe('CommonDirectoryTool', () => {
     assert.equal(result.ok, true);
     assert.match(result.content as string, /Resolved common directory:/);
     assert.match(result.content as string, /kind: home/);
-    assert.match(result.content as string, /Use this exact path as the base directory/);
+    assert.match(result.content as string, /Use this exact path only with the same tool target/);
+    assert.match(result.content as string, /call resolve_common_directory again on the new target/);
     assert.match(result.content as string, /call glob with this path/);
     assert.match(result.content as string, /call write_file with a file_path under this path/);
+    assert.match(result.content as string, /pass this path as execute_shell\.cwd/);
     assert.match(result.content as string, /Do not use execute_shell/);
   });
 });

--- a/tests/conversation-runner-transcript-normalization.test.ts
+++ b/tests/conversation-runner-transcript-normalization.test.ts
@@ -86,6 +86,40 @@ class MockToolExecutor implements ToolExecutor {
   }
 }
 
+class TargetContextToolExecutor implements ToolExecutor {
+  getToolDefinitions(): ToolDefinition[] {
+    return [{
+      name: 'execute_shell',
+      description: 'mock shell',
+      parameters: {
+        type: 'object',
+        properties: {
+          command: { type: 'string' },
+        },
+        required: ['command'],
+      },
+    }];
+  }
+
+  async executeTool(toolCall: ToolCall): Promise<ToolResult> {
+    return {
+      tool_call_id: toolCall.id,
+      role: 'tool',
+      name: toolCall.function.name,
+      content: 'Command succeeded:\n$ echo ok\nok',
+      targetContext: [
+        '[tool_target]',
+        'tool: execute_shell',
+        'operation: execute_shell',
+        'target: virtual_employee_cloud_runtime',
+        'cwd: C:\\agent\\repo',
+        '[/tool_target]',
+      ].join('\n'),
+      ok: true,
+    };
+  }
+}
+
 function createMockAI(responses: ChatResponse[]) {
   const receivedMessages: Message[][] = [];
   let index = 0;
@@ -145,6 +179,30 @@ test('runner exposes assistant text before tool calls separately from working st
   assert.deepEqual(assistantText, ['我先查一下天气。']);
   assert.deepEqual(thinking, []);
   assert.equal(result.response, '天气结果已整理。');
+});
+
+test('runner injects tool target context into provider transcript only', async () => {
+  const responses = [
+    makeToolResponse(makeToolCall('call_1', 'execute_shell', { command: 'echo ok' })),
+    makeFinalResponse('done'),
+  ];
+  const { aiService, getReceivedMessages } = createMockAI(responses);
+  const runner = new ConversationRunner(aiService, new TargetContextToolExecutor(), {
+    stream: false,
+  });
+  const displayed: string[] = [];
+
+  await runner.run([{ role: 'user', content: 'run it' }], {
+    onToolEnd: (_name, _id, result) => displayed.push(result),
+  });
+
+  assert.equal(displayed[0], 'Command succeeded:\n$ echo ok\nok');
+  const secondRequest = getReceivedMessages()[1];
+  const toolMessage = secondRequest.find(message => message.role === 'tool');
+  assert.ok(toolMessage);
+  assert.match(String(toolMessage.content), /^\[tool_target\]/);
+  assert.match(String(toolMessage.content), /target: virtual_employee_cloud_runtime/);
+  assert.match(String(toolMessage.content), /Command succeeded/);
 });
 
 test('runner suppresses verbose diagnostic text before tool calls', async () => {

--- a/tests/shell-current-directory.test.ts
+++ b/tests/shell-current-directory.test.ts
@@ -60,6 +60,23 @@ describe('ShellTool current directory probe', () => {
     assert.ok(!(result.content as string).includes('__XIAOBA_CWD_MARKER__'));
   });
 
+  test('explicit cwd runs the command from that directory and persists final cwd', async () => {
+    const tool = new ShellTool();
+    const command = process.platform === 'win32'
+      ? 'Set-Content -LiteralPath marker.txt -Value ok'
+      : 'printf ok > marker.txt';
+    const result = await tool.execute({ command, cwd: 'sub' }, {
+      ...context,
+      workingDirectory: currentDirectory,
+    });
+
+    assert.strictEqual(result.ok, true);
+    assert.ok(fs.existsSync(path.join(testRoot, 'sub', 'marker.txt')));
+    assertSameDirectory(currentDirectory, path.join(testRoot, 'sub'));
+    assert.ok((result.content as string).includes(`Working directory: ${path.resolve(testRoot, 'sub')}`));
+    assert.ok((result.content as string).includes(`Final cwd: ${path.resolve(testRoot, 'sub')}`));
+  });
+
   test('failed cd does not update session current directory', async () => {
     const tool = new ShellTool();
     const result = await tool.execute({ command: 'cd missing-directory' }, {

--- a/tests/tool-manager.test.ts
+++ b/tests/tool-manager.test.ts
@@ -523,6 +523,39 @@ describe('ToolManager', () => {
     assert.equal(confirmed, false);
   });
 
+  test('CatsCo target context preserves explicit shell cwd strings from the target device', async () => {
+    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-catsco-agent-body-'));
+    const manager = new ToolManager(workspace, {}, { enabledToolNames: [] });
+    manager.registerTool(fakeTool('execute_shell', async () => {
+      return { ok: true, content: 'agent body shell ran' };
+    }));
+    const cwdCases = ['/Users/alice/Desktop', 'remote/session/Desktop'];
+
+    for (const [index, targetCwd] of cwdCases.entries()) {
+      const result = await manager.executeTool({
+        id: `call-catsco-agent-body-shell-cwd-${index}`,
+        type: 'function',
+        function: { name: 'execute_shell', arguments: JSON.stringify({ command: 'echo ok', cwd: targetCwd }) },
+      }, [], {
+        surface: 'catscompany',
+        permissionProfile: 'strict',
+        workingDirectory: workspace,
+        workspaceRoot: workspace,
+        executionScope: catsScope({
+          actorUserId: 'usr100',
+          sessionKey: 'session:v2:catscompany:p2p:p2p_100_43:agent:usr43',
+          topicId: 'p2p_100_43',
+        }),
+        localDeviceGrant: catsLocalDevice({ ownerUserId: 'usr7' }),
+      });
+
+      assert.equal(result.ok, true);
+      assert.match(result.targetContext || '', new RegExp(`cwd: ${escapeRegExp(targetCwd)}`));
+      assert.doesNotMatch(result.targetContext || '', /xiaoba-catsco-agent-body-[^\n]+[\\/]Users[\\/]alice[\\/]Desktop/);
+      assert.doesNotMatch(result.targetContext || '', new RegExp(`${escapeRegExp(workspace)}[\\\\/]remote[\\\\/]session[\\\\/]Desktop`));
+    }
+  });
+
   test('CatsCo non-agent-local-body shell contexts still require strict confirmation', async () => {
     const cases: Array<{
       name: string;
@@ -851,3 +884,7 @@ describe('ToolManager', () => {
     assert.equal(executed, false);
   });
 });
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/tests/tool-target-context.test.ts
+++ b/tests/tool-target-context.test.ts
@@ -1,0 +1,118 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert/strict';
+import * as path from 'node:path';
+import { buildToolTargetContext, stripToolTargetContextForDisplay } from '../src/tools/tool-target-context';
+import type { ToolExecutionContext } from '../src/types/tool';
+
+const runtimeCwd = path.resolve('runtime-repo');
+
+function catsContext(overrides: Partial<ToolExecutionContext> = {}): ToolExecutionContext {
+  return {
+    workingDirectory: runtimeCwd,
+    workspaceRoot: runtimeCwd,
+    conversationHistory: [],
+    surface: 'catscompany',
+    executionScope: {
+      source: 'catscompany',
+      sessionKey: 'session:v2:catscompany:p2p:p2p_7_43:agent:usr43',
+      topicId: 'p2p_7_43',
+      topicType: 'p2p',
+      actorUserId: 'usr7',
+      agentId: 'usr43',
+      agentBodyId: 'body-agent',
+      identityTrust: 'server_canonical',
+      isTrusted: true,
+    },
+    localDeviceGrant: {
+      kind: 'catscompany_body',
+      source: 'catscompany',
+      bodyId: 'body-agent',
+      deviceId: 'install-agent',
+      installationId: 'install-agent',
+      ownerUserId: 'usr9',
+      createdAt: Date.now(),
+    },
+    ...overrides,
+  };
+}
+
+describe('tool target context', () => {
+  test('labels virtual employee cloud runtime results', () => {
+    const context = buildToolTargetContext(catsContext(), {
+      toolName: 'execute_shell',
+      operation: 'execute_shell',
+      cwd: runtimeCwd,
+      shell: 'powershell',
+    });
+
+    assert.ok(context);
+    assert.match(context, /^\[tool_target\]/);
+    assert.match(context, /target: virtual_employee_cloud_runtime/);
+    assert.match(context, new RegExp(`cwd: ${escapeRegExp(runtimeCwd)}`));
+    assert.match(context, /shell: powershell/);
+  });
+
+  test('labels Device RPC forwarded user-device results', () => {
+    const context = buildToolTargetContext(catsContext({
+      executionScope: {
+        source: 'catscompany',
+        sessionKey: 'session:v2:catscompany:p2p:p2p_7_43:agent:usr43',
+        topicId: 'p2p_7_43',
+        topicType: 'p2p',
+        actorUserId: 'usr7',
+        agentId: 'usr43',
+        agentBodyId: 'body-agent',
+        permissionsSource: 'device_rpc_forward',
+        identityTrust: 'server_canonical',
+        isTrusted: true,
+      },
+      localDeviceGrant: {
+        kind: 'catscompany_body',
+        source: 'catscompany',
+        bodyId: 'body-user-device',
+        deviceId: 'install-user-device',
+        installationId: 'install-user-device',
+        ownerUserId: 'usr7',
+        createdAt: Date.now(),
+      },
+      deviceSelection: {
+        kind: 'user_device_selection',
+        source: 'catscompany',
+        status: 'selected',
+        sessionKey: 'session:v2:catscompany:p2p:p2p_7_43:agent:usr43',
+        topicId: 'p2p_7_43',
+        topicType: 'p2p',
+        actorUserId: 'usr7',
+        agentId: 'usr43',
+        identityTrust: 'server_canonical',
+        selectedDeviceId: 'install-user-device',
+        selectedDeviceDisplayName: 'Alice Laptop',
+      },
+    }), {
+      toolName: 'resolve_common_directory',
+      operation: 'resolve_common_directory',
+    });
+
+    assert.ok(context);
+    assert.match(context, /target: selected_user_device/);
+    assert.match(context, /target_display_name: Alice Laptop/);
+  });
+
+  test('strips target context before CatsCo display', () => {
+    const displayed = stripToolTargetContextForDisplay([
+      '[tool_target]',
+      'tool: execute_shell',
+      'target: virtual_employee_cloud_runtime',
+      '[/tool_target]',
+      '',
+      'Command succeeded:',
+      '$ echo ok',
+    ].join('\n'));
+
+    assert.equal(displayed, 'Command succeeded:\n$ echo ok');
+  });
+});
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/tests/tool-target-context.test.ts
+++ b/tests/tool-target-context.test.ts
@@ -52,6 +52,32 @@ describe('tool target context', () => {
     assert.match(context, /shell: powershell/);
   });
 
+  test('preserves target-device POSIX cwd without host OS normalization', () => {
+    const remoteCwd = '/Users/alice/Desktop';
+    const context = buildToolTargetContext(catsContext(), {
+      toolName: 'execute_shell',
+      operation: 'execute_shell',
+      cwd: remoteCwd,
+    });
+
+    assert.ok(context);
+    assert.match(context, new RegExp(`cwd: ${escapeRegExp(remoteCwd)}`));
+    assert.doesNotMatch(context, /runtime-repo[\\/]+Users[\\/]+alice[\\/]+Desktop/);
+  });
+
+  test('does not absolutize target-device cwd strings', () => {
+    const remoteCwd = 'remote/session/Desktop';
+    const context = buildToolTargetContext(catsContext(), {
+      toolName: 'execute_shell',
+      operation: 'execute_shell',
+      cwd: remoteCwd,
+    });
+
+    assert.ok(context);
+    assert.match(context, new RegExp(`cwd: ${escapeRegExp(remoteCwd)}`));
+    assert.doesNotMatch(context, new RegExp(`cwd: ${escapeRegExp(runtimeCwd)}[\\\\/]remote[\\\\/]session[\\\\/]Desktop`));
+  });
+
   test('labels Device RPC forwarded user-device results', () => {
     const context = buildToolTargetContext(catsContext({
       executionScope: {

--- a/tests/transient-environment.test.ts
+++ b/tests/transient-environment.test.ts
@@ -43,4 +43,10 @@ test('shell name resolver accepts common Windows and POSIX env fields', () => {
   assert.equal(resolveShellName({ ComSpec: 'C:\\Windows\\System32\\cmd.exe' }), 'cmd');
   assert.equal(resolveShellName({ SHELL: '/bin/zsh' }), 'zsh');
   assert.equal(resolveShellName({ PSModulePath: 'C:\\Users\\test\\Documents\\PowerShell\\Modules' }), 'powershell');
+  if (process.platform === 'win32') {
+    assert.equal(resolveShellName({
+      ComSpec: 'C:\\Windows\\System32\\cmd.exe',
+      PSModulePath: 'C:\\Users\\test\\Documents\\PowerShell\\Modules',
+    }), 'powershell');
+  }
 });


### PR DESCRIPTION
## Summary

This closes the CatsCo tool-target loop exposed by virtual employee cloud runtime testing.

## Root Cause

A single conversation could contain tool results from both the speaker's selected user device and the virtual employee's own cloud runtime, but those results entered the model transcript as plain text. After target switches, paths such as user Desktop, agent runtime cwd, and shell cwd could be mixed together. Shell also had no explicit cwd parameter, and Windows runtime hints could say cmd even though the executor runs PowerShell first.

## Changes

- Adds provider-only tool target context for CatsCo device tools so the model sees whether a result came from `selected_user_device` or `virtual_employee_cloud_runtime`.
- Annotates Device RPC results before transport while stripping the internal target block from CatsCo visible tool-result bubbles.
- Adds `execute_shell.cwd` and reports working directory, final cwd, and shell in shell output.
- Tightens `resolve_common_directory` semantics so resolved paths are scoped to the target device and must be re-resolved after target switches.
- Updates runtime context rules for “my/user computer” vs “your/virtual employee cloud computer”.
- Aligns Windows transient shell hints with the PowerShell-first executor.

## Validation

Passed:

- `npm.cmd run build`
- `tsx --test tests/tool-target-context.test.ts tests/shell-current-directory.test.ts tests/common-directory-tool.test.ts tests/transient-environment.test.ts`
- `tsx --test tests/catscompany-device-rpc-tools.test.ts tests/conversation-runner-transcript-normalization.test.ts`
- `tsx --test tests/tool-gateway-catsco.test.ts tests/tool-manager.test.ts tests/runtime-context-builder.test.ts`
- `git diff --check`

Attempted:

- `npm.cmd test` twice. The suite progressed through the relevant CatsCo/tool tests without failures, then timed out locally while later dashboard service-manager tests were still running; leftover test Node processes were stopped.