### PR TITLE
[codex] Anchor CatsCo agent cloud runtime identity

### DIFF
--- a/prompts/transient/runtime-context-rules.md
+++ b/prompts/transient/runtime-context-rules.md
@@ -7,6 +7,7 @@ execution.deviceSelection.selectedDevice.displayName 只是当前发言人的用
 当用户说“我的电脑/我的桌面/我本地”时，目标通常是当前发言人的用户设备，工具参数 target 使用 selected_user_device。
 当用户说“你的电脑/你自己的云电脑/虚拟员工自己的桌面”时，目标是智能体自己的 cloud runtime body，工具参数 target 使用 agent_cloud_runtime。
 如果是在智能体自己的 cloud runtime body 上执行，不要先要求选择用户设备；直接让工具走当前 agent local body。
+当目标是 agent_cloud_runtime 时，resolve_common_directory 解析的是这台云电脑的真实 OS 用户目录；不要发明 .dev-user-data-real/Desktop 之类的替代桌面。
 resolve_common_directory 返回的路径只对产生它的目标设备有效；如果目标在用户设备和智能体云运行体之间切换，必须重新解析。
 execute_shell 需要在某个目录运行时，优先传 cwd，不要依赖上一条命令里的 cd；cwd 只是命令执行目录，不代表设备身份或归属。
 不要猜测或暴露本地文件系统路径；工具需要文件引用时使用 attachment ref。

--- a/prompts/transient/runtime-context-rules.md
+++ b/prompts/transient/runtime-context-rules.md
@@ -2,12 +2,12 @@
 不要要求用户提供这里的内部 ID；需要时使用工具和后端作用域。
 工具需要用户设备时，优先使用 execution.deviceSelection 里后端选定的目标。
 如果 execution.deviceSelection.status 是 needs_selection 或 unavailable，请先让用户按展示名选择可用设备，再使用设备工具。
-execution.agentRuntime.target 为 virtual_employee_cloud_runtime 时，它就是当前虚拟员工自己的云电脑；不要把它说成“不是我的电脑”或仅仅是临时沙盒。
+execution.agentRuntime.target 为 agent_runtime_device 时，它就是当前智能体自己的运行体设备；可能是云电脑，也可能是创建者本地电脑，不要根据部署形态或设备展示名判断“我是谁”。
 execution.deviceSelection.selectedDevice.displayName 只是当前发言人的用户设备展示名，不是智能体身份；不要根据展示名判断“我是谁”。
 当用户说“我的电脑/我的桌面/我本地”时，目标通常是当前发言人的用户设备，工具参数 target 使用 selected_user_device。
-当用户说“你的电脑/你自己的云电脑/虚拟员工自己的桌面”时，目标是智能体自己的 cloud runtime body，工具参数 target 使用 agent_cloud_runtime。
-如果是在智能体自己的 cloud runtime body 上执行，不要先要求选择用户设备；直接让工具走当前 agent local body。
-当目标是 agent_cloud_runtime 时，resolve_common_directory 解析的是这台云电脑的真实 OS 用户目录；不要发明 .dev-user-data-real/Desktop 之类的替代桌面。
-resolve_common_directory 返回的路径只对产生它的目标设备有效；如果目标在用户设备和智能体云运行体之间切换，必须重新解析。
+当用户说“你的电脑/你自己的电脑/机器人自己的桌面/智能体自己的运行体”时，目标是智能体自己的运行体设备，工具参数 target 使用 agent_runtime_device。
+如果是在智能体自己的运行体设备上执行，不要先要求选择用户设备；直接让工具走当前 agent local body。
+当目标是 agent_runtime_device 时，resolve_common_directory 解析的是这台运行体设备的真实 OS 用户目录；不要发明 .dev-user-data-real/Desktop 之类的替代桌面，也不要假设它一定是云电脑。
+resolve_common_directory 返回的路径只对产生它的目标设备有效；如果目标在用户设备和智能体运行体设备之间切换，必须重新解析。
 execute_shell 需要在某个目录运行时，优先传 cwd，不要依赖上一条命令里的 cd；cwd 只是命令执行目录，不代表设备身份或归属。
 不要猜测或暴露本地文件系统路径；工具需要文件引用时使用 attachment ref。

--- a/prompts/transient/runtime-context-rules.md
+++ b/prompts/transient/runtime-context-rules.md
@@ -2,8 +2,11 @@
 不要要求用户提供这里的内部 ID；需要时使用工具和后端作用域。
 工具需要用户设备时，优先使用 execution.deviceSelection 里后端选定的目标。
 如果 execution.deviceSelection.status 是 needs_selection 或 unavailable，请先让用户按展示名选择可用设备，再使用设备工具。
-当用户说“我的电脑/我的桌面/我本地”时，目标通常是当前发言人的用户设备；当用户说“你的电脑/你自己的云电脑/虚拟员工自己的桌面”时，目标是智能体自己的 cloud runtime body。
+execution.agentRuntime.target 为 virtual_employee_cloud_runtime 时，它就是当前虚拟员工自己的云电脑；不要把它说成“不是我的电脑”或仅仅是临时沙盒。
+execution.deviceSelection.selectedDevice.displayName 只是当前发言人的用户设备展示名，不是智能体身份；不要根据展示名判断“我是谁”。
+当用户说“我的电脑/我的桌面/我本地”时，目标通常是当前发言人的用户设备，工具参数 target 使用 selected_user_device。
+当用户说“你的电脑/你自己的云电脑/虚拟员工自己的桌面”时，目标是智能体自己的 cloud runtime body，工具参数 target 使用 agent_cloud_runtime。
 如果是在智能体自己的 cloud runtime body 上执行，不要先要求选择用户设备；直接让工具走当前 agent local body。
 resolve_common_directory 返回的路径只对产生它的目标设备有效；如果目标在用户设备和智能体云运行体之间切换，必须重新解析。
-execute_shell 需要在某个目录运行时，优先传 cwd，不要依赖上一条命令里的 cd。
+execute_shell 需要在某个目录运行时，优先传 cwd，不要依赖上一条命令里的 cd；cwd 只是命令执行目录，不代表设备身份或归属。
 不要猜测或暴露本地文件系统路径；工具需要文件引用时使用 attachment ref。

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -373,7 +373,7 @@ export class CatsCompanyBot {
         result = await new ReadTool().execute(args, context);
         break;
       case 'resolve_common_directory':
-        result = resolveCommonDirectoryToolArgs(args);
+        result = resolveCommonDirectoryToolArgs(args, context);
         break;
       case 'glob':
         result = await new GlobTool().execute(args, context);

--- a/src/core/runtime-context-builder.ts
+++ b/src/core/runtime-context-builder.ts
@@ -56,6 +56,15 @@ interface RuntimeContextSnapshot {
       source: MessageSource;
       deviceId?: string;
     };
+    agentRuntime?: {
+      target: 'virtual_employee_cloud_runtime';
+      owner: 'agent_self';
+      available: true;
+      localToolTarget: 'agent_cloud_runtime';
+      meaning: string;
+      userDeviceDisplayNamesAreIdentity: false;
+      commonDirectoryPolicy: 'agent_cloud_runtime_data_root';
+    };
     userDevices?: Array<{
       grantId: string;
       deviceId: string;
@@ -167,6 +176,7 @@ export function buildRuntimeContextSnapshot(params: BuildRuntimeContextParams): 
       scopeSource,
       toolsUseBackendScope: true,
       localDevice: sanitizeLocalDevice(params.localDeviceGrant),
+      agentRuntime: sanitizeAgentRuntime(scope, params.localDeviceGrant),
       userDevices: sanitizeDeviceGrants(params.deviceGrants),
       deviceSelection: sanitizeDeviceSelection(params.deviceSelection),
       localFiles: sanitizeLocalFiles(params.localFileGrants),
@@ -181,6 +191,32 @@ function sanitizeLocalDevice(grant?: ScopedLocalDeviceGrant): RuntimeContextSnap
     source: grant.source,
     deviceId: grant.deviceId,
   });
+}
+
+function sanitizeAgentRuntime(
+  scope?: ExecutionScope,
+  localDevice?: ScopedLocalDeviceGrant,
+): RuntimeContextSnapshot['execution']['agentRuntime'] | undefined {
+  if (!scope
+    || scope.source !== 'catscompany'
+    || scope.identityTrust !== 'server_canonical'
+    || !scope.isTrusted
+    || !scope.agentBodyId
+    || !localDevice
+    || localDevice.source !== 'catscompany'
+    || !localDevice.bodyId
+    || scope.agentBodyId !== localDevice.bodyId) {
+    return undefined;
+  }
+  return {
+    target: 'virtual_employee_cloud_runtime',
+    owner: 'agent_self',
+    available: true,
+    localToolTarget: 'agent_cloud_runtime',
+    meaning: "This cloud runtime body is the virtual employee's own cloud computer.",
+    userDeviceDisplayNamesAreIdentity: false,
+    commonDirectoryPolicy: 'agent_cloud_runtime_data_root',
+  };
 }
 
 function sanitizeDeviceGrants(grants?: ScopedDeviceGrant[]): RuntimeContextSnapshot['execution']['userDevices'] | undefined {

--- a/src/core/runtime-context-builder.ts
+++ b/src/core/runtime-context-builder.ts
@@ -63,7 +63,7 @@ interface RuntimeContextSnapshot {
       localToolTarget: 'agent_cloud_runtime';
       meaning: string;
       userDeviceDisplayNamesAreIdentity: false;
-      commonDirectoryPolicy: 'agent_cloud_runtime_data_root';
+      commonDirectoryPolicy: 'os_user_common_directories';
     };
     userDevices?: Array<{
       grantId: string;
@@ -215,7 +215,7 @@ function sanitizeAgentRuntime(
     localToolTarget: 'agent_cloud_runtime',
     meaning: "This cloud runtime body is the virtual employee's own cloud computer.",
     userDeviceDisplayNamesAreIdentity: false,
-    commonDirectoryPolicy: 'agent_cloud_runtime_data_root',
+    commonDirectoryPolicy: 'os_user_common_directories',
   };
 }
 

--- a/src/core/runtime-context-builder.ts
+++ b/src/core/runtime-context-builder.ts
@@ -57,10 +57,10 @@ interface RuntimeContextSnapshot {
       deviceId?: string;
     };
     agentRuntime?: {
-      target: 'virtual_employee_cloud_runtime';
+      target: 'agent_runtime_device';
       owner: 'agent_self';
       available: true;
-      localToolTarget: 'agent_cloud_runtime';
+      localToolTarget: 'agent_runtime_device';
       meaning: string;
       userDeviceDisplayNamesAreIdentity: false;
       commonDirectoryPolicy: 'os_user_common_directories';
@@ -209,11 +209,11 @@ function sanitizeAgentRuntime(
     return undefined;
   }
   return {
-    target: 'virtual_employee_cloud_runtime',
+    target: 'agent_runtime_device',
     owner: 'agent_self',
     available: true,
-    localToolTarget: 'agent_cloud_runtime',
-    meaning: "This cloud runtime body is the virtual employee's own cloud computer.",
+    localToolTarget: 'agent_runtime_device',
+    meaning: "This is the current agent body's own runtime device. It may be hosted in the cloud or on a creator-owned local computer.",
     userDeviceDisplayNamesAreIdentity: false,
     commonDirectoryPolicy: 'os_user_common_directories',
   };

--- a/src/tools/bash-tool.ts
+++ b/src/tools/bash-tool.ts
@@ -62,8 +62,8 @@ export class ShellTool implements Tool {
         },
         target: {
           type: 'string',
-          enum: ['auto', 'agent_cloud_runtime', 'selected_user_device'],
-          description: 'CatsCo 可选目标。用户说“你的/虚拟员工自己的云电脑或桌面”时用 agent_cloud_runtime；用户说“我的电脑/我的桌面/我本地”时用 selected_user_device；不确定用 auto。不要根据设备展示名判断身份。',
+          enum: ['auto', 'agent_runtime_device', 'selected_user_device'],
+          description: 'CatsCo 可选目标。用户说“你的/你自己的电脑/机器人自己的桌面/智能体自己的运行体”时用 agent_runtime_device；用户说“我的电脑/我的桌面/我本地”时用 selected_user_device；不确定用 auto。不要根据设备展示名判断身份，也不要假设 agent_runtime_device 一定是云电脑。',
         },
       },
       required: ['command'],

--- a/src/tools/bash-tool.ts
+++ b/src/tools/bash-tool.ts
@@ -8,7 +8,7 @@ import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from 
 import { Logger } from '../utils/logger';
 import { resolveRuntimeEnvironment } from '../utils/runtime-environment';
 import { isToolAllowed, isBashCommandAllowed } from '../utils/safety';
-import { resolveToolGatewayAccess } from './tool-gateway';
+import { normalizeToolTargetPreference, resolveToolGatewayAccess } from './tool-gateway';
 import { executeRemoteDeviceRpcTool } from './device-rpc-tool';
 
 const execAsync = promisify(exec);
@@ -60,6 +60,11 @@ export class ShellTool implements Tool {
           description: 'Set true only after the user explicitly requested or confirmed a risky destructive command such as recursive deletion, git reset --hard, git clean, or force push.',
           default: false,
         },
+        target: {
+          type: 'string',
+          enum: ['auto', 'agent_cloud_runtime', 'selected_user_device'],
+          description: 'CatsCo 可选目标。用户说“你的/虚拟员工自己的云电脑或桌面”时用 agent_cloud_runtime；用户说“我的电脑/我的桌面/我本地”时用 selected_user_device；不确定用 auto。不要根据设备展示名判断身份。',
+        },
       },
       required: ['command'],
     },
@@ -87,6 +92,7 @@ export class ShellTool implements Tool {
     const gateway = resolveToolGatewayAccess(context, {
       toolName: this.definition.name,
       operation: 'execute_shell',
+      targetPreference: normalizeToolTargetPreference(args),
     });
     if (!gateway.ok) {
       return { ok: false, errorCode: gateway.errorCode, message: gateway.message };

--- a/src/tools/common-directory-tool.ts
+++ b/src/tools/common-directory-tool.ts
@@ -4,7 +4,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import { executeRemoteDeviceRpcTool } from './device-rpc-tool';
-import { resolveToolGatewayAccess } from './tool-gateway';
+import { isCatsCoAgentLocalBodyContext, normalizeToolTargetPreference, resolveToolGatewayAccess } from './tool-gateway';
 
 export type CommonDirectoryKind =
   | 'desktop'
@@ -100,6 +100,17 @@ const STANDARD_SUBDIRECTORIES: Record<Exclude<CommonDirectoryKind, 'home' | 'tem
   music: 'Music',
 };
 
+const AGENT_RUNTIME_SUBDIRECTORIES: Record<CommonDirectoryKind, string> = {
+  desktop: 'Desktop',
+  downloads: 'Downloads',
+  documents: 'Documents',
+  pictures: 'Pictures',
+  videos: 'Videos',
+  music: 'Music',
+  home: '.',
+  temp: 'Temp',
+};
+
 const XDG_KEYS: Partial<Record<CommonDirectoryKind, string>> = {
   desktop: 'XDG_DESKTOP_DIR',
   downloads: 'XDG_DOWNLOAD_DIR',
@@ -139,6 +150,16 @@ export function resolveCommonDirectory(kind: CommonDirectoryKind): DirectoryReso
   return buildResolution(kind, path.join(os.homedir(), STANDARD_SUBDIRECTORIES[kind]), 'home_fallback');
 }
 
+export function resolveAgentRuntimeCommonDirectory(
+  kind: CommonDirectoryKind,
+  context: Pick<ToolExecutionContext, 'workingDirectory' | 'workspaceRoot'>,
+): DirectoryResolution {
+  const root = resolveAgentRuntimeDataRoot(context);
+  const directoryPath = path.join(root, AGENT_RUNTIME_SUBDIRECTORIES[kind]);
+  fs.mkdirSync(directoryPath, { recursive: true });
+  return buildResolution(kind, directoryPath, 'agent_cloud_runtime_data');
+}
+
 export class CommonDirectoryTool implements Tool {
   definition: ToolDefinition = {
     name: 'resolve_common_directory',
@@ -156,6 +177,11 @@ export class CommonDirectoryTool implements Tool {
           type: 'string',
           description: '要解析的目录名。支持 desktop, downloads, documents, pictures, videos, music, home, temp 及常见中文别名。',
         },
+        target: {
+          type: 'string',
+          enum: ['auto', 'agent_cloud_runtime', 'selected_user_device'],
+          description: 'CatsCo 可选目标。用户说“你的/虚拟员工自己的云电脑或桌面”时用 agent_cloud_runtime；用户说“我的电脑/我的桌面/我本地”时用 selected_user_device；不确定用 auto。不要根据设备展示名判断身份。',
+        },
       },
       required: ['directory'],
     },
@@ -172,6 +198,7 @@ export class CommonDirectoryTool implements Tool {
       toolName: 'resolve_common_directory',
       operation: 'resolve_common_directory',
       targetLabel: kind,
+      targetPreference: normalizeToolTargetPreference(args),
     });
     if (!gateway.ok) return gateway;
 
@@ -184,18 +211,25 @@ export class CommonDirectoryTool implements Tool {
     );
     if (remote) return remote;
 
-    return resolveCommonDirectoryToolArgs({ directory: kind });
+    return resolveCommonDirectoryToolArgs({ directory: kind }, _context);
   }
 }
 
-export function resolveCommonDirectoryToolArgs(args: any): ToolExecutionResult {
+export function resolveCommonDirectoryToolArgs(args: any, context?: ToolExecutionContext): ToolExecutionResult {
   const input = typeof args?.directory === 'string' ? args.directory : '';
   const kind = normalizeCommonDirectory(input);
   if (!kind) return invalidCommonDirectoryResult(input);
   return {
     ok: true,
-    content: formatCommonDirectoryResolution(resolveCommonDirectory(kind)),
+    content: formatCommonDirectoryResolution(resolveCommonDirectoryForContext(kind, context)),
   };
+}
+
+function resolveCommonDirectoryForContext(kind: CommonDirectoryKind, context?: ToolExecutionContext): DirectoryResolution {
+  if (context && isCatsCoAgentLocalBodyContext(context)) {
+    return resolveAgentRuntimeCommonDirectory(kind, context);
+  }
+  return resolveCommonDirectory(kind);
 }
 
 export function formatCommonDirectoryResolution(result: DirectoryResolution): string {
@@ -233,6 +267,12 @@ function buildResolution(kind: CommonDirectoryKind, directoryPath: string, sourc
     exists: fs.existsSync(resolvedPath),
     platform: process.platform,
   };
+}
+
+function resolveAgentRuntimeDataRoot(context: Pick<ToolExecutionContext, 'workingDirectory' | 'workspaceRoot'>): string {
+  const base = path.resolve(context.workspaceRoot || context.workingDirectory);
+  if (path.basename(base) === '.dev-user-data-real') return base;
+  return path.join(base, '.dev-user-data-real');
 }
 
 function readWindowsKnownFolder(kind: CommonDirectoryKind): string | null {

--- a/src/tools/common-directory-tool.ts
+++ b/src/tools/common-directory-tool.ts
@@ -145,7 +145,7 @@ export class CommonDirectoryTool implements Tool {
     description: [
       '把常见用户目录名称解析为当前工具目标设备上的真实本地路径。',
       '当用户说“桌面”“下载”“文档”等自然语言目录时先用它解析，不要手猜 C:\\Users\\...\\Desktop、~/Desktop 等路径。',
-      '解析出的 path 只属于本次工具实际执行的目标：可能是虚拟员工自己的云运行体，也可能是后端选中的用户设备。',
+      '解析出的 path 只属于本次工具实际执行的目标：可能是智能体自己的运行体设备，也可能是后端选中的用户设备。',
       '解析后如果要查看目录文件，请用 glob；如果要创建文件，请用 write_file。必须用命令时，把 path 传给 execute_shell.cwd，不要单独 cd 后再猜当前目录。',
       '只解析标准 OS 用户目录；不搜索项目目录、应用目录、浏览器下载子目录或语义目录。',
     ].join('\n'),
@@ -158,8 +158,8 @@ export class CommonDirectoryTool implements Tool {
         },
         target: {
           type: 'string',
-          enum: ['auto', 'agent_cloud_runtime', 'selected_user_device'],
-          description: 'CatsCo 可选目标。用户说“你的/虚拟员工自己的云电脑或桌面”时用 agent_cloud_runtime；用户说“我的电脑/我的桌面/我本地”时用 selected_user_device；不确定用 auto。不要根据设备展示名判断身份。',
+          enum: ['auto', 'agent_runtime_device', 'selected_user_device'],
+          description: 'CatsCo 可选目标。用户说“你的/你自己的电脑/机器人自己的桌面/智能体自己的运行体”时用 agent_runtime_device；用户说“我的电脑/我的桌面/我本地”时用 selected_user_device；不确定用 auto。不要根据设备展示名判断身份，也不要假设 agent_runtime_device 一定是云电脑。',
         },
       },
       required: ['directory'],
@@ -214,7 +214,7 @@ export function formatCommonDirectoryResolution(result: DirectoryResolution): st
     `platform: ${result.platform}`,
     '',
     'Use this exact path only with the same tool target that produced this result.',
-    'If the next user request switches between "my/user computer" and "your/virtual employee cloud computer", call resolve_common_directory again on the new target.',
+    'If the next user request switches between "my/user computer" and "your/agent runtime device", call resolve_common_directory again on the new target.',
     'To list files here, call glob with this path and an appropriate pattern such as "*".',
     'To create or overwrite a text file here, call write_file with a file_path under this path.',
     'If shell is truly required, pass this path as execute_shell.cwd instead of relying on a prior cd command.',

--- a/src/tools/common-directory-tool.ts
+++ b/src/tools/common-directory-tool.ts
@@ -4,7 +4,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import { executeRemoteDeviceRpcTool } from './device-rpc-tool';
-import { isCatsCoAgentLocalBodyContext, normalizeToolTargetPreference, resolveToolGatewayAccess } from './tool-gateway';
+import { normalizeToolTargetPreference, resolveToolGatewayAccess } from './tool-gateway';
 
 export type CommonDirectoryKind =
   | 'desktop'
@@ -100,17 +100,6 @@ const STANDARD_SUBDIRECTORIES: Record<Exclude<CommonDirectoryKind, 'home' | 'tem
   music: 'Music',
 };
 
-const AGENT_RUNTIME_SUBDIRECTORIES: Record<CommonDirectoryKind, string> = {
-  desktop: 'Desktop',
-  downloads: 'Downloads',
-  documents: 'Documents',
-  pictures: 'Pictures',
-  videos: 'Videos',
-  music: 'Music',
-  home: '.',
-  temp: 'Temp',
-};
-
 const XDG_KEYS: Partial<Record<CommonDirectoryKind, string>> = {
   desktop: 'XDG_DESKTOP_DIR',
   downloads: 'XDG_DOWNLOAD_DIR',
@@ -148,16 +137,6 @@ export function resolveCommonDirectory(kind: CommonDirectoryKind): DirectoryReso
   }
 
   return buildResolution(kind, path.join(os.homedir(), STANDARD_SUBDIRECTORIES[kind]), 'home_fallback');
-}
-
-export function resolveAgentRuntimeCommonDirectory(
-  kind: CommonDirectoryKind,
-  context: Pick<ToolExecutionContext, 'workingDirectory' | 'workspaceRoot'>,
-): DirectoryResolution {
-  const root = resolveAgentRuntimeDataRoot(context);
-  const directoryPath = path.join(root, AGENT_RUNTIME_SUBDIRECTORIES[kind]);
-  fs.mkdirSync(directoryPath, { recursive: true });
-  return buildResolution(kind, directoryPath, 'agent_cloud_runtime_data');
 }
 
 export class CommonDirectoryTool implements Tool {
@@ -215,21 +194,14 @@ export class CommonDirectoryTool implements Tool {
   }
 }
 
-export function resolveCommonDirectoryToolArgs(args: any, context?: ToolExecutionContext): ToolExecutionResult {
+export function resolveCommonDirectoryToolArgs(args: any, _context?: ToolExecutionContext): ToolExecutionResult {
   const input = typeof args?.directory === 'string' ? args.directory : '';
   const kind = normalizeCommonDirectory(input);
   if (!kind) return invalidCommonDirectoryResult(input);
   return {
     ok: true,
-    content: formatCommonDirectoryResolution(resolveCommonDirectoryForContext(kind, context)),
+    content: formatCommonDirectoryResolution(resolveCommonDirectory(kind)),
   };
-}
-
-function resolveCommonDirectoryForContext(kind: CommonDirectoryKind, context?: ToolExecutionContext): DirectoryResolution {
-  if (context && isCatsCoAgentLocalBodyContext(context)) {
-    return resolveAgentRuntimeCommonDirectory(kind, context);
-  }
-  return resolveCommonDirectory(kind);
 }
 
 export function formatCommonDirectoryResolution(result: DirectoryResolution): string {
@@ -267,12 +239,6 @@ function buildResolution(kind: CommonDirectoryKind, directoryPath: string, sourc
     exists: fs.existsSync(resolvedPath),
     platform: process.platform,
   };
-}
-
-function resolveAgentRuntimeDataRoot(context: Pick<ToolExecutionContext, 'workingDirectory' | 'workspaceRoot'>): string {
-  const base = path.resolve(context.workspaceRoot || context.workingDirectory);
-  if (path.basename(base) === '.dev-user-data-real') return base;
-  return path.join(base, '.dev-user-data-real');
 }
 
 function readWindowsKnownFolder(kind: CommonDirectoryKind): string | null {

--- a/src/tools/edit-tool.ts
+++ b/src/tools/edit-tool.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import { isToolAllowed, isPathAllowed } from '../utils/safety';
-import { formatCatsCoVisiblePath, resolveToolGatewayAccess } from './tool-gateway';
+import { formatCatsCoVisiblePath, normalizeToolTargetPreference, resolveToolGatewayAccess } from './tool-gateway';
 import { executeRemoteDeviceRpcTool } from './device-rpc-tool';
 
 /**
@@ -35,6 +35,11 @@ export class EditTool implements Tool {
           type: 'boolean',
           description: '是否替换所有匹配项。默认 false，此时 old_string 必须唯一。',
           default: false
+        },
+        target: {
+          type: 'string',
+          enum: ['auto', 'agent_cloud_runtime', 'selected_user_device'],
+          description: 'CatsCo 可选目标。用户说“你的/虚拟员工自己的云电脑或桌面”时用 agent_cloud_runtime；用户说“我的电脑/我的桌面/我本地”时用 selected_user_device；不确定用 auto。不要根据设备展示名判断身份。'
         }
       },
       required: ['file_path', 'old_string', 'new_string']
@@ -53,6 +58,7 @@ export class EditTool implements Tool {
       toolName: this.definition.name,
       operation: 'edit_file',
       targetLabel: file_path,
+      targetPreference: normalizeToolTargetPreference(args),
     });
     if (!gateway.ok) {
       return { ok: false, errorCode: gateway.errorCode, message: gateway.message };

--- a/src/tools/edit-tool.ts
+++ b/src/tools/edit-tool.ts
@@ -38,8 +38,8 @@ export class EditTool implements Tool {
         },
         target: {
           type: 'string',
-          enum: ['auto', 'agent_cloud_runtime', 'selected_user_device'],
-          description: 'CatsCo 可选目标。用户说“你的/虚拟员工自己的云电脑或桌面”时用 agent_cloud_runtime；用户说“我的电脑/我的桌面/我本地”时用 selected_user_device；不确定用 auto。不要根据设备展示名判断身份。'
+          enum: ['auto', 'agent_runtime_device', 'selected_user_device'],
+          description: 'CatsCo 可选目标。用户说“你的/你自己的电脑/机器人自己的桌面/智能体自己的运行体”时用 agent_runtime_device；用户说“我的电脑/我的桌面/我本地”时用 selected_user_device；不确定用 auto。不要根据设备展示名判断身份，也不要假设 agent_runtime_device 一定是云电脑。'
         }
       },
       required: ['file_path', 'old_string', 'new_string']

--- a/src/tools/glob-tool.ts
+++ b/src/tools/glob-tool.ts
@@ -42,8 +42,8 @@ export class GlobTool implements Tool {
         },
         target: {
           type: 'string',
-          enum: ['auto', 'agent_cloud_runtime', 'selected_user_device'],
-          description: 'CatsCo 可选目标。用户说“你的/虚拟员工自己的云电脑或桌面”时用 agent_cloud_runtime；用户说“我的电脑/我的桌面/我本地”时用 selected_user_device；不确定用 auto。不要根据设备展示名判断身份。'
+          enum: ['auto', 'agent_runtime_device', 'selected_user_device'],
+          description: 'CatsCo 可选目标。用户说“你的/你自己的电脑/机器人自己的桌面/智能体自己的运行体”时用 agent_runtime_device；用户说“我的电脑/我的桌面/我本地”时用 selected_user_device；不确定用 auto。不要根据设备展示名判断身份，也不要假设 agent_runtime_device 一定是云电脑。'
         }
       },
       required: ['pattern']

--- a/src/tools/glob-tool.ts
+++ b/src/tools/glob-tool.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import { glob } from 'glob';
 import { isReadPathAllowed } from '../utils/safety';
-import { formatCatsCoVisiblePath, isCatsCoToolGatewayContext, resolveToolGatewayAccess } from './tool-gateway';
+import { formatCatsCoVisiblePath, isCatsCoToolGatewayContext, normalizeToolTargetPreference, resolveToolGatewayAccess } from './tool-gateway';
 import { executeRemoteReadonlyTool } from './device-rpc-tool';
 
 interface GlobResult {
@@ -39,6 +39,11 @@ export class GlobTool implements Tool {
           type: 'number',
           description: '返回结果最大数量，默认 100。',
           default: 100
+        },
+        target: {
+          type: 'string',
+          enum: ['auto', 'agent_cloud_runtime', 'selected_user_device'],
+          description: 'CatsCo 可选目标。用户说“你的/虚拟员工自己的云电脑或桌面”时用 agent_cloud_runtime；用户说“我的电脑/我的桌面/我本地”时用 selected_user_device；不确定用 auto。不要根据设备展示名判断身份。'
         }
       },
       required: ['pattern']
@@ -53,6 +58,7 @@ export class GlobTool implements Tool {
       toolName: this.definition.name,
       operation: 'glob',
       targetLabel: searchPath || '.',
+      targetPreference: normalizeToolTargetPreference(args),
     });
     if (!gateway.ok) {
       return { ok: false, errorCode: gateway.errorCode, message: gateway.message };

--- a/src/tools/grep-tool.ts
+++ b/src/tools/grep-tool.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import { isReadPathAllowed } from '../utils/safety';
-import { formatCatsCoVisiblePath, redactCatsCoVisiblePath, resolveToolGatewayAccess } from './tool-gateway';
+import { formatCatsCoVisiblePath, normalizeToolTargetPreference, redactCatsCoVisiblePath, resolveToolGatewayAccess } from './tool-gateway';
 import { executeRemoteReadonlyTool } from './device-rpc-tool';
 
 const VCS_DIRECTORIES_TO_EXCLUDE = ['.git', '.svn', '.hg', '.bzr'] as const;
@@ -97,7 +97,12 @@ export class GrepTool implements Tool {
           default: 'files'
         },
         limit: { type: 'number', description: '限制输出行数或文件数，默认 250。设为 0 表示不限制输出。', default: 250 },
-        offset: { type: 'number', description: '跳过前 N 行/文件，用于分页。默认 0。', default: 0 }
+        offset: { type: 'number', description: '跳过前 N 行/文件，用于分页。默认 0。', default: 0 },
+        target: {
+          type: 'string',
+          enum: ['auto', 'agent_cloud_runtime', 'selected_user_device'],
+          description: 'CatsCo 可选目标。用户说“你的/虚拟员工自己的云电脑或桌面”时用 agent_cloud_runtime；用户说“我的电脑/我的桌面/我本地”时用 selected_user_device；不确定用 auto。不要根据设备展示名判断身份。'
+        }
       },
       required: ['pattern']
     }
@@ -110,6 +115,7 @@ export class GrepTool implements Tool {
       toolName: this.definition.name,
       operation: 'grep',
       targetLabel: searchPath || '.',
+      targetPreference: normalizeToolTargetPreference(args),
     });
     if (!gateway.ok) {
       return { ok: false, errorCode: gateway.errorCode, message: gateway.message };

--- a/src/tools/grep-tool.ts
+++ b/src/tools/grep-tool.ts
@@ -100,8 +100,8 @@ export class GrepTool implements Tool {
         offset: { type: 'number', description: '跳过前 N 行/文件，用于分页。默认 0。', default: 0 },
         target: {
           type: 'string',
-          enum: ['auto', 'agent_cloud_runtime', 'selected_user_device'],
-          description: 'CatsCo 可选目标。用户说“你的/虚拟员工自己的云电脑或桌面”时用 agent_cloud_runtime；用户说“我的电脑/我的桌面/我本地”时用 selected_user_device；不确定用 auto。不要根据设备展示名判断身份。'
+          enum: ['auto', 'agent_runtime_device', 'selected_user_device'],
+          description: 'CatsCo 可选目标。用户说“你的/你自己的电脑/机器人自己的桌面/智能体自己的运行体”时用 agent_runtime_device；用户说“我的电脑/我的桌面/我本地”时用 selected_user_device；不确定用 auto。不要根据设备展示名判断身份，也不要假设 agent_runtime_device 一定是云电脑。'
         }
       },
       required: ['pattern']

--- a/src/tools/local-tool-risk.ts
+++ b/src/tools/local-tool-risk.ts
@@ -1,6 +1,6 @@
 import type { DeviceGrantOperation } from '../types/session-identity';
 import type { ToolExecutionContext, ToolExecutionResult, ToolRiskLevel } from '../types/tool';
-import { isCatsCoAgentLocalBodyContext, isCatsCoLocalOwnerSelfContext, resolveToolGatewayAccess } from './tool-gateway';
+import { isCatsCoAgentLocalBodyContext, isCatsCoLocalOwnerSelfContext, normalizeToolTargetPreference, resolveToolGatewayAccess } from './tool-gateway';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -104,7 +104,7 @@ export function classifyLocalToolRisk(
   }
 
   const remoteFileOperation = REMOTE_DEVICE_FILE_TOOL_OPERATIONS[toolName];
-  if (remoteFileOperation && isServerAuthorizedRemoteDeviceOperation(toolName, remoteFileOperation, context)) {
+  if (remoteFileOperation && isServerAuthorizedRemoteDeviceOperation(toolName, remoteFileOperation, context, args)) {
     return {
       requiresConfirmation: false,
       risk: 'low',
@@ -125,7 +125,7 @@ export function classifyLocalToolRisk(
 
   if (toolName === 'execute_shell') {
     const command = stringField(args, 'command') || stringField(args, 'cmd') || stringField(args, 'script');
-    if (isServerAuthorizedRemoteDeviceOperation(toolName, 'execute_shell', context)) {
+    if (isServerAuthorizedRemoteDeviceOperation(toolName, 'execute_shell', context, args)) {
       return {
         requiresConfirmation: false,
         risk: 'high',
@@ -165,11 +165,13 @@ function isServerAuthorizedRemoteDeviceOperation(
   toolName: string,
   operation: DeviceGrantOperation,
   context: ToolExecutionContext,
+  args?: unknown,
 ): boolean {
   if (!context.deviceRpc) return false;
   const decision = resolveToolGatewayAccess(context, {
     toolName,
     operation,
+    targetPreference: normalizeToolTargetPreference(args),
   });
   return decision.ok && decision.mode === 'remote';
 }

--- a/src/tools/read-tool.ts
+++ b/src/tools/read-tool.ts
@@ -10,7 +10,7 @@ import { analyzeImageWithReaderProxy, ReaderProxyResult } from '../utils/reader-
 import { Logger } from '../utils/logger';
 import { formatPathForLog } from '../utils/log-redaction';
 import { resolveLocalFileAccess, resolveLocalFileReference } from './local-file-gateway';
-import { formatCatsCoVisiblePath, resolveToolGatewayAccess } from './tool-gateway';
+import { formatCatsCoVisiblePath, normalizeToolTargetPreference, resolveToolGatewayAccess } from './tool-gateway';
 import { executeRemoteReadonlyTool } from './device-rpc-tool';
 
 export const DEFAULT_TEXT_READ_LIMIT = 200;
@@ -81,6 +81,11 @@ export class ReadTool implements Tool {
           type: 'string',
           description: '可选。读取图片时的分析目标；不传则使用当前用户请求作为分析目标。',
         },
+        target: {
+          type: 'string',
+          enum: ['auto', 'agent_cloud_runtime', 'selected_user_device'],
+          description: 'CatsCo 可选目标。用户说“你的/虚拟员工自己的云电脑或桌面”时用 agent_cloud_runtime；用户说“我的电脑/我的桌面/我本地”时用 selected_user_device；不确定用 auto。不要根据设备展示名判断身份。',
+        },
       },
       required: ['file_path'],
     },
@@ -150,6 +155,7 @@ export class ReadTool implements Tool {
         toolName: this.definition.name,
         operation: 'read_file',
         targetLabel: displayPath,
+        targetPreference: normalizeToolTargetPreference(args),
       });
       if (!gateway.ok) {
         return {

--- a/src/tools/read-tool.ts
+++ b/src/tools/read-tool.ts
@@ -83,8 +83,8 @@ export class ReadTool implements Tool {
         },
         target: {
           type: 'string',
-          enum: ['auto', 'agent_cloud_runtime', 'selected_user_device'],
-          description: 'CatsCo 可选目标。用户说“你的/虚拟员工自己的云电脑或桌面”时用 agent_cloud_runtime；用户说“我的电脑/我的桌面/我本地”时用 selected_user_device；不确定用 auto。不要根据设备展示名判断身份。',
+          enum: ['auto', 'agent_runtime_device', 'selected_user_device'],
+          description: 'CatsCo 可选目标。用户说“你的/你自己的电脑/机器人自己的桌面/智能体自己的运行体”时用 agent_runtime_device；用户说“我的电脑/我的桌面/我本地”时用 selected_user_device；不确定用 auto。不要根据设备展示名判断身份，也不要假设 agent_runtime_device 一定是云电脑。',
         },
       },
       required: ['file_path'],

--- a/src/tools/tool-gateway.ts
+++ b/src/tools/tool-gateway.ts
@@ -21,7 +21,7 @@ export type ToolGatewayDecision =
     }
   | { ok: false; errorCode: ToolErrorCode; message: string };
 
-export type ToolTargetPreference = 'auto' | 'agent_cloud_runtime' | 'selected_user_device';
+export type ToolTargetPreference = 'auto' | 'agent_runtime_device' | 'selected_user_device';
 
 export interface ResolveToolGatewayAccessOptions {
   toolName: string;
@@ -83,8 +83,10 @@ export function isCatsCoAgentLocalBodyContext(context: ToolExecutionContext): bo
 export function normalizeToolTargetPreference(args: unknown): ToolTargetPreference {
   if (!args || typeof args !== 'object') return 'auto';
   const target = String((args as Record<string, unknown>).target || '').trim().toLowerCase();
-  if (target === 'agent_cloud_runtime' || target === 'virtual_employee_cloud_runtime') {
-    return 'agent_cloud_runtime';
+  if (target === 'agent_runtime_device'
+    || target === 'agent_cloud_runtime'
+    || target === 'virtual_employee_cloud_runtime') {
+    return 'agent_runtime_device';
   }
   if (target === 'selected_user_device' || target === 'user_device') {
     return 'selected_user_device';
@@ -147,13 +149,13 @@ export function resolveToolGatewayAccess(
   const agentLocalBody = isCatsCoAgentLocalBodyContext(context);
   const rpcForwardLocal = isCatsCoDeviceRpcForwardLocalContext(context, options.operation);
   const targetPreference = options.targetPreference ?? 'auto';
-  const prefersAgentRuntime = targetPreference === 'agent_cloud_runtime';
+  const prefersAgentRuntime = targetPreference === 'agent_runtime_device';
   const prefersSelectedUserDevice = targetPreference === 'selected_user_device';
   const requireSelectedDevice = requiresExplicitBackendDeviceSelection(scope, localDevice, rpcForwardLocal);
 
   if (prefersAgentRuntime && !agentLocalBody) {
     return denied([
-      '工具目标要求使用虚拟员工自己的 cloud runtime，但当前运行体不是当前 agent 的本地 body，已阻止本地 fallback。',
+      '工具目标要求使用智能体自己的运行体设备，但当前运行体不是当前 agent 的本地 body，已阻止本地 fallback。',
     ], options.targetLabel);
   }
 
@@ -227,7 +229,7 @@ export function resolveToolGatewayAccess(
   if (!context.deviceSelection && !agentLocalBody && requiresBackendSelectedDeviceForLocalExecution(scope, localDevice, grant, rpcForwardLocal)) {
     return denied([
       '后端没有选定当前说话人的目标设备，已阻止本地设备操作。',
-      '共享虚拟员工不能默认使用云端运行体本机，必须由服务端选择当前用户自己的在线设备。',
+      '共享智能体不能默认使用智能体自己的运行体设备，必须由服务端选择当前用户自己的在线设备。',
     ], options.targetLabel);
   }
 
@@ -310,7 +312,7 @@ function resolveBackendSelectedDevice(
     if (options.requireSelection) {
       return selectedDenied([
         '后端没有选定当前说话人的目标设备，已阻止本地设备操作。',
-        '共享虚拟员工或移动端渠道不能默认使用云端运行体本机，必须由服务端选择当前用户自己的在线设备。',
+        '共享智能体或移动端渠道不能默认使用智能体自己的运行体设备，必须由服务端选择当前用户自己的在线设备。',
       ], targetLabel);
     }
     return {
@@ -321,6 +323,12 @@ function resolveBackendSelectedDevice(
   }
 
   if (selection.status === 'needs_selection') {
+    if (options.requireSelection) {
+      return selectedDenied([
+        '后端尚未选定要操作的用户设备，已阻止本地设备操作。',
+        '请让用户从可用设备中选择一个设备名后再继续。',
+      ], targetLabel);
+    }
     if (options.allowLocalAgentBodyFallback) {
       return localSelectedDevice(localDevice);
     }
@@ -330,6 +338,12 @@ function resolveBackendSelectedDevice(
     ], targetLabel);
   }
   if (selection.status === 'unavailable') {
+    if (options.requireSelection) {
+      return selectedDenied([
+        '当前用户没有可用的在线设备授权，已阻止本地设备操作。',
+        '请让用户打开并授权目标设备后再继续。',
+      ], targetLabel);
+    }
     if (options.allowLocalAgentBodyFallback) {
       return localSelectedDevice(localDevice);
     }

--- a/src/tools/tool-gateway.ts
+++ b/src/tools/tool-gateway.ts
@@ -21,11 +21,14 @@ export type ToolGatewayDecision =
     }
   | { ok: false; errorCode: ToolErrorCode; message: string };
 
+export type ToolTargetPreference = 'auto' | 'agent_cloud_runtime' | 'selected_user_device';
+
 export interface ResolveToolGatewayAccessOptions {
   toolName: string;
   operation: DeviceGrantOperation;
   targetLabel?: string;
   allowCatsCoShell?: boolean;
+  targetPreference?: ToolTargetPreference;
 }
 
 export interface CatsCoVisiblePathOptions {
@@ -75,6 +78,18 @@ export function isCatsCoAgentLocalBodyContext(context: ToolExecutionContext): bo
     return false;
   }
   return Boolean(scope.agentBodyId && scope.agentBodyId === localDevice.bodyId);
+}
+
+export function normalizeToolTargetPreference(args: unknown): ToolTargetPreference {
+  if (!args || typeof args !== 'object') return 'auto';
+  const target = String((args as Record<string, unknown>).target || '').trim().toLowerCase();
+  if (target === 'agent_cloud_runtime' || target === 'virtual_employee_cloud_runtime') {
+    return 'agent_cloud_runtime';
+  }
+  if (target === 'selected_user_device' || target === 'user_device') {
+    return 'selected_user_device';
+  }
+  return 'auto';
 }
 
 export function formatCatsCoVisiblePath(
@@ -131,9 +146,20 @@ export function resolveToolGatewayAccess(
   const localOwnerSelf = isCatsCoLocalOwnerSelfContext(context);
   const agentLocalBody = isCatsCoAgentLocalBodyContext(context);
   const rpcForwardLocal = isCatsCoDeviceRpcForwardLocalContext(context, options.operation);
+  const targetPreference = options.targetPreference ?? 'auto';
+  const prefersAgentRuntime = targetPreference === 'agent_cloud_runtime';
+  const prefersSelectedUserDevice = targetPreference === 'selected_user_device';
   const requireSelectedDevice = requiresExplicitBackendDeviceSelection(scope, localDevice, rpcForwardLocal);
 
-  const selectionScope = validateSelectionScope(context.deviceSelection, scope, options.targetLabel);
+  if (prefersAgentRuntime && !agentLocalBody) {
+    return denied([
+      '工具目标要求使用虚拟员工自己的 cloud runtime，但当前运行体不是当前 agent 的本地 body，已阻止本地 fallback。',
+    ], options.targetLabel);
+  }
+
+  const selectionScope = prefersAgentRuntime
+    ? { ok: true as const, mode: 'local' as const }
+    : validateSelectionScope(context.deviceSelection, scope, options.targetLabel);
   if (!selectionScope.ok) return selectionScope;
 
   const selectedTarget = resolveBackendSelectedDevice(
@@ -144,7 +170,8 @@ export function resolveToolGatewayAccess(
     {
       allowLocalSelfOperation: localOwnerSelf || agentLocalBody || rpcForwardLocal,
       allowLocalAgentBodyFallback: agentLocalBody,
-      requireSelection: requireSelectedDevice && !agentLocalBody,
+      preferLocalAgentBody: prefersAgentRuntime,
+      requireSelection: prefersSelectedUserDevice || (requireSelectedDevice && !agentLocalBody),
     },
   );
   if (!selectedTarget.ok) return selectedTarget;
@@ -268,8 +295,17 @@ function resolveBackendSelectedDevice(
   localDevice: ScopedLocalDeviceGrant,
   operation: DeviceGrantOperation,
   targetLabel?: string,
-  options: { allowLocalSelfOperation?: boolean; allowLocalAgentBodyFallback?: boolean; requireSelection?: boolean } = {},
+  options: {
+    allowLocalSelfOperation?: boolean;
+    allowLocalAgentBodyFallback?: boolean;
+    preferLocalAgentBody?: boolean;
+    requireSelection?: boolean;
+  } = {},
 ): SelectedDeviceDecision {
+  if (options.preferLocalAgentBody) {
+    return localSelectedDevice(localDevice);
+  }
+
   if (!selection) {
     if (options.requireSelection) {
       return selectedDenied([

--- a/src/tools/tool-manager.ts
+++ b/src/tools/tool-manager.ts
@@ -22,7 +22,8 @@ import { PromptModeTool } from './prompt-mode-tool';
 import { DEFAULT_TOOL_NAMES } from './default-tool-names';
 import { mergeToolExecutionContext } from '../utils/tool-context';
 import { confirmLocalToolExecution } from './local-tool-risk';
-import { buildToolTargetContext, operationForToolTargetContext } from './tool-target-context';
+import { buildToolTargetContext, operationForToolTargetContext, resolveToolTargetContextGateway } from './tool-target-context';
+import { normalizeToolTargetPreference } from './tool-gateway';
 
 const INTERNAL_TOOL_NAMES = ['ask_parent'] as const;
 
@@ -208,9 +209,12 @@ export class ToolManager implements ToolExecutor {
       }
 
       const output = await tool.execute(args, context);
+      const operation = operationForToolTargetContext(toolName);
       const targetContext = buildToolTargetContext(context, {
         toolName,
-        operation: operationForToolTargetContext(toolName),
+        operation,
+        gateway: resolveToolTargetContextGateway(context, toolName, args),
+        targetPreference: normalizeToolTargetPreference(args),
         cwd: resolveTargetContextCwd(toolName, args, context.workingDirectory),
       });
 

--- a/src/tools/tool-target-context.ts
+++ b/src/tools/tool-target-context.ts
@@ -125,8 +125,8 @@ function resolveToolTarget(
   gateway?: ToolGatewayDecision,
   targetPreference: ToolTargetPreference = 'auto',
 ): { kind: string; owner?: string; meaning?: string; displayName?: string } {
-  if (targetPreference === 'agent_cloud_runtime' && isCatsCoAgentLocalBodyContext(context)) {
-    return virtualEmployeeCloudRuntimeTarget();
+  if (targetPreference === 'agent_runtime_device' && isCatsCoAgentLocalBodyContext(context)) {
+    return agentRuntimeDeviceTarget();
   }
 
   if (targetPreference === 'selected_user_device' && gateway?.ok) {
@@ -142,7 +142,7 @@ function resolveToolTarget(
   }
 
   if (isCatsCoAgentLocalBodyContext(context)) {
-    return virtualEmployeeCloudRuntimeTarget();
+    return agentRuntimeDeviceTarget();
   }
 
   if (isCatsCoLocalOwnerSelfContext(context)) {
@@ -170,11 +170,11 @@ function preserveCwdForTarget(cwd: string | undefined): string | undefined {
   return text || undefined;
 }
 
-function virtualEmployeeCloudRuntimeTarget(): { kind: string; owner: string; meaning: string } {
+function agentRuntimeDeviceTarget(): { kind: string; owner: string; meaning: string } {
   return {
-    kind: 'virtual_employee_cloud_runtime',
+    kind: 'agent_runtime_device',
     owner: 'agent_self',
-    meaning: "This is the virtual employee's own cloud computer.",
+    meaning: "This is the current agent body's own runtime device. It may be hosted in the cloud or on a creator-owned local computer.",
   };
 }
 
@@ -185,7 +185,7 @@ function selectedUserDeviceTarget(
   return {
     kind,
     owner: 'current_speaker_user',
-    meaning: "This is the current user's selected device, not the virtual employee's own cloud computer.",
+    meaning: "This is the current speaker user's selected device, not the agent body's own runtime device.",
     displayName,
   };
 }

--- a/src/tools/tool-target-context.ts
+++ b/src/tools/tool-target-context.ts
@@ -4,6 +4,9 @@ import {
   isCatsCoAgentLocalBodyContext,
   isCatsCoLocalOwnerSelfContext,
   isCatsCoToolGatewayContext,
+  normalizeToolTargetPreference,
+  resolveToolGatewayAccess,
+  type ToolTargetPreference,
   type ToolGatewayDecision,
 } from './tool-gateway';
 
@@ -24,6 +27,7 @@ export interface ToolTargetContextOptions {
   toolName: string;
   operation?: DeviceGrantOperation;
   gateway?: ToolGatewayDecision;
+  targetPreference?: ToolTargetPreference;
   cwd?: string;
   shell?: string;
 }
@@ -40,16 +44,20 @@ export function buildToolTargetContext(
   const operation = options.operation || operationForToolTargetContext(options.toolName);
   if (!operation) return undefined;
 
-  const target = resolveToolTarget(context, options.gateway);
+  const target = resolveToolTarget(context, options.gateway, options.targetPreference);
   const cwd = preserveCwdForTarget(options.cwd || context.workingDirectory);
   const lines = [
     TOOL_TARGET_CONTEXT_PREFIX,
     `tool: ${options.toolName}`,
     `operation: ${operation}`,
     `target: ${target.kind}`,
+    target.owner ? `target_owner: ${target.owner}` : '',
+    target.meaning ? `target_meaning: ${target.meaning}` : '',
     target.displayName ? `target_display_name: ${target.displayName}` : '',
+    target.displayName ? `target_display_name_role: user_device_display_name_only` : '',
     cwd ? `cwd: ${cwd}` : '',
     options.shell ? `shell: ${options.shell}` : '',
+    'cwd_scope: cwd is an execution directory on the target; it does not identify device ownership.',
     'path_scope: Paths in this result belong only to the target above. Re-resolve common directories after switching targets.',
     TOOL_TARGET_CONTEXT_SUFFIX,
   ].filter(Boolean);
@@ -98,46 +106,86 @@ export function stripToolTargetContextForDisplay(content: string): string {
     .replace(/^\n+/, '');
 }
 
+export function resolveToolTargetContextGateway(
+  context: ToolExecutionContext,
+  toolName: string,
+  args: unknown,
+): ToolGatewayDecision | undefined {
+  const operation = operationForToolTargetContext(toolName);
+  if (!operation || !isCatsCoToolGatewayContext(context)) return undefined;
+  return resolveToolGatewayAccess(context, {
+    toolName,
+    operation,
+    targetPreference: normalizeToolTargetPreference(args),
+  });
+}
+
 function resolveToolTarget(
   context: ToolExecutionContext,
   gateway?: ToolGatewayDecision,
-): { kind: string; displayName?: string } {
+  targetPreference: ToolTargetPreference = 'auto',
+): { kind: string; owner?: string; meaning?: string; displayName?: string } {
+  if (targetPreference === 'agent_cloud_runtime' && isCatsCoAgentLocalBodyContext(context)) {
+    return virtualEmployeeCloudRuntimeTarget();
+  }
+
+  if (targetPreference === 'selected_user_device' && gateway?.ok) {
+    return selectedUserDeviceTarget(gateway.targetDeviceDisplayName || context.deviceSelection?.selectedDeviceDisplayName);
+  }
+
   if (gateway?.ok && gateway.mode === 'remote') {
-    return {
-      kind: 'selected_user_device',
-      displayName: gateway.targetDeviceDisplayName,
-    };
+    return selectedUserDeviceTarget(gateway.targetDeviceDisplayName);
   }
 
   if (context.executionScope?.permissionsSource === 'device_rpc_forward') {
-    return {
-      kind: 'selected_user_device',
-      displayName: context.deviceSelection?.selectedDeviceDisplayName,
-    };
+    return selectedUserDeviceTarget(context.deviceSelection?.selectedDeviceDisplayName);
   }
 
   if (isCatsCoAgentLocalBodyContext(context)) {
-    return { kind: 'virtual_employee_cloud_runtime' };
+    return virtualEmployeeCloudRuntimeTarget();
   }
 
   if (isCatsCoLocalOwnerSelfContext(context)) {
     return {
       kind: 'local_owner_device',
+      owner: 'local_authenticated_user',
+      meaning: 'This is the local device of the authenticated user running the current runtime.',
       displayName: context.deviceSelection?.selectedDeviceDisplayName,
     };
   }
 
   if (context.deviceSelection?.status === 'selected') {
-    return {
-      kind: 'backend_selected_device',
-      displayName: context.deviceSelection.selectedDeviceDisplayName,
-    };
+    return selectedUserDeviceTarget(context.deviceSelection.selectedDeviceDisplayName, 'backend_selected_device');
   }
 
-  return { kind: 'current_local_runtime' };
+  return {
+    kind: 'current_local_runtime',
+    owner: 'current_runtime',
+    meaning: 'This is the local runtime process that executed the tool.',
+  };
 }
 
 function preserveCwdForTarget(cwd: string | undefined): string | undefined {
   const text = String(cwd || '').trim();
   return text || undefined;
+}
+
+function virtualEmployeeCloudRuntimeTarget(): { kind: string; owner: string; meaning: string } {
+  return {
+    kind: 'virtual_employee_cloud_runtime',
+    owner: 'agent_self',
+    meaning: "This is the virtual employee's own cloud computer.",
+  };
+}
+
+function selectedUserDeviceTarget(
+  displayName?: string,
+  kind = 'selected_user_device',
+): { kind: string; owner: string; meaning: string; displayName?: string } {
+  return {
+    kind,
+    owner: 'current_speaker_user',
+    meaning: "This is the current user's selected device, not the virtual employee's own cloud computer.",
+    displayName,
+  };
 }

--- a/src/tools/write-tool.ts
+++ b/src/tools/write-tool.ts
@@ -30,8 +30,8 @@ export class WriteTool implements Tool {
         },
         target: {
           type: 'string',
-          enum: ['auto', 'agent_cloud_runtime', 'selected_user_device'],
-          description: 'CatsCo 可选目标。用户说“你的/虚拟员工自己的云电脑或桌面”时用 agent_cloud_runtime；用户说“我的电脑/我的桌面/我本地”时用 selected_user_device；不确定用 auto。不要根据设备展示名判断身份。'
+          enum: ['auto', 'agent_runtime_device', 'selected_user_device'],
+          description: 'CatsCo 可选目标。用户说“你的/你自己的电脑/机器人自己的桌面/智能体自己的运行体”时用 agent_runtime_device；用户说“我的电脑/我的桌面/我本地”时用 selected_user_device；不确定用 auto。不要根据设备展示名判断身份，也不要假设 agent_runtime_device 一定是云电脑。'
         }
       },
       required: ['file_path', 'content']

--- a/src/tools/write-tool.ts
+++ b/src/tools/write-tool.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import { Logger } from '../utils/logger';
 import { isToolAllowed, isPathAllowed } from '../utils/safety';
-import { formatCatsCoVisiblePath, resolveToolGatewayAccess } from './tool-gateway';
+import { formatCatsCoVisiblePath, normalizeToolTargetPreference, resolveToolGatewayAccess } from './tool-gateway';
 import { executeRemoteDeviceRpcTool } from './device-rpc-tool';
 
 /**
@@ -27,6 +27,11 @@ export class WriteTool implements Tool {
         content: {
           type: 'string',
           description: '要写入文件的完整 UTF-8 文本内容。'
+        },
+        target: {
+          type: 'string',
+          enum: ['auto', 'agent_cloud_runtime', 'selected_user_device'],
+          description: 'CatsCo 可选目标。用户说“你的/虚拟员工自己的云电脑或桌面”时用 agent_cloud_runtime；用户说“我的电脑/我的桌面/我本地”时用 selected_user_device；不确定用 auto。不要根据设备展示名判断身份。'
         }
       },
       required: ['file_path', 'content']
@@ -45,6 +50,7 @@ export class WriteTool implements Tool {
       toolName: this.definition.name,
       operation: 'write_file',
       targetLabel: file_path,
+      targetPreference: normalizeToolTargetPreference(args),
     });
     if (!gateway.ok) {
       return { ok: false, errorCode: gateway.errorCode, message: gateway.message };

--- a/tests/catscompany-tool-confirmation.test.ts
+++ b/tests/catscompany-tool-confirmation.test.ts
@@ -20,14 +20,14 @@ describe('CatsCompany tool confirmation prompts', () => {
       toolName: 'write_file',
       risk: 'medium',
       reason: '工具会修改本机文件，需要用户确认。',
-      args: { file_path: 'C:/Users/Annika/Desktop/hello.txt', content: '你好' },
+      args: { file_path: 'C:/Users/ExampleUser/Desktop/hello.txt', content: '你好' },
       surface: 'catscompany',
-      workingDirectory: 'C:/Users/Annika',
+      workingDirectory: 'C:/Users/ExampleUser',
     });
 
     assert.match(prompt, /write_file/);
     assert.match(prompt, /风险等级：中/);
-    assert.match(prompt, /file_path=C:\/Users\/Annika\/Desktop\/hello\.txt/);
+    assert.match(prompt, /file_path=C:\/Users\/ExampleUser\/Desktop\/hello\.txt/);
     assert.match(prompt, /确认执行/);
   });
 });

--- a/tests/common-directory-tool.test.ts
+++ b/tests/common-directory-tool.test.ts
@@ -1,7 +1,10 @@
 import { describe, test } from 'node:test';
 import * as assert from 'node:assert/strict';
+import * as fs from 'fs';
 import * as os from 'os';
+import * as path from 'path';
 import { CommonDirectoryTool, normalizeCommonDirectory, resolveCommonDirectory } from '../src/tools/common-directory-tool';
+import type { ToolExecutionContext } from '../src/types/tool';
 
 describe('CommonDirectoryTool', () => {
   test('normalizes English and Chinese common directory aliases', () => {
@@ -54,4 +57,56 @@ describe('CommonDirectoryTool', () => {
     assert.match(result.content as string, /pass this path as execute_shell\.cwd/);
     assert.match(result.content as string, /Do not use execute_shell/);
   });
+
+  test('resolves virtual employee cloud runtime desktop to a stable data directory', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-agent-runtime-desktop-'));
+    const tool = new CommonDirectoryTool();
+
+    const result = await tool.execute({
+      directory: 'desktop',
+      target: 'agent_cloud_runtime',
+    }, catsAgentRuntimeContext(root));
+
+    assert.equal(result.ok, true);
+    const content = String(result.content);
+    const expectedDesktop = path.join(root, '.dev-user-data-real', 'Desktop');
+    assert.match(content, /kind: desktop/);
+    assert.match(content, /source: agent_cloud_runtime_data/);
+    assert.match(content, new RegExp(`path: ${escapeRegExp(expectedDesktop)}`));
+    assert.equal(fs.existsSync(expectedDesktop), true);
+  });
 });
+
+function catsAgentRuntimeContext(root: string): ToolExecutionContext {
+  return {
+    workingDirectory: root,
+    workspaceRoot: root,
+    conversationHistory: [],
+    surface: 'catscompany',
+    executionScope: {
+      source: 'catscompany',
+      sessionKey: 'session:v2:catscompany:p2p:p2p_100_43:agent:usr43',
+      topicId: 'p2p_100_43',
+      topicType: 'p2p',
+      actorUserId: 'usr100',
+      agentId: 'usr43',
+      agentBodyId: 'body-agent',
+      permissionsSource: 'server_canonical_message',
+      identityTrust: 'server_canonical',
+      isTrusted: true,
+    },
+    localDeviceGrant: {
+      kind: 'catscompany_body',
+      source: 'catscompany',
+      ownerUserId: 'usr7',
+      bodyId: 'body-agent',
+      installationId: 'install-agent',
+      deviceId: 'install-agent',
+      createdAt: Date.now(),
+    },
+  };
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/tests/common-directory-tool.test.ts
+++ b/tests/common-directory-tool.test.ts
@@ -58,14 +58,14 @@ describe('CommonDirectoryTool', () => {
     assert.match(result.content as string, /Do not use execute_shell/);
   });
 
-  test('resolves virtual employee cloud runtime desktop through the runtime OS', async () => {
+  test('resolves agent runtime device desktop through the runtime OS', async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-agent-runtime-desktop-'));
     const tool = new CommonDirectoryTool();
     const expectedDesktop = resolveCommonDirectory('desktop');
 
     const result = await tool.execute({
       directory: 'desktop',
-      target: 'agent_cloud_runtime',
+      target: 'agent_runtime_device',
     }, catsAgentRuntimeContext(root));
 
     assert.equal(result.ok, true);

--- a/tests/common-directory-tool.test.ts
+++ b/tests/common-directory-tool.test.ts
@@ -58,9 +58,10 @@ describe('CommonDirectoryTool', () => {
     assert.match(result.content as string, /Do not use execute_shell/);
   });
 
-  test('resolves virtual employee cloud runtime desktop to a stable data directory', async () => {
+  test('resolves virtual employee cloud runtime desktop through the runtime OS', async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-agent-runtime-desktop-'));
     const tool = new CommonDirectoryTool();
+    const expectedDesktop = resolveCommonDirectory('desktop');
 
     const result = await tool.execute({
       directory: 'desktop',
@@ -69,11 +70,10 @@ describe('CommonDirectoryTool', () => {
 
     assert.equal(result.ok, true);
     const content = String(result.content);
-    const expectedDesktop = path.join(root, '.dev-user-data-real', 'Desktop');
     assert.match(content, /kind: desktop/);
-    assert.match(content, /source: agent_cloud_runtime_data/);
-    assert.match(content, new RegExp(`path: ${escapeRegExp(expectedDesktop)}`));
-    assert.equal(fs.existsSync(expectedDesktop), true);
+    assert.match(content, new RegExp(`source: ${escapeRegExp(expectedDesktop.source)}`));
+    assert.match(content, new RegExp(`path: ${escapeRegExp(expectedDesktop.path)}`));
+    assert.doesNotMatch(content, /\.dev-user-data-real/);
   });
 });
 

--- a/tests/conversation-runner-transcript-normalization.test.ts
+++ b/tests/conversation-runner-transcript-normalization.test.ts
@@ -111,7 +111,7 @@ class TargetContextToolExecutor implements ToolExecutor {
         '[tool_target]',
         'tool: execute_shell',
         'operation: execute_shell',
-        'target: virtual_employee_cloud_runtime',
+        'target: agent_runtime_device',
         'cwd: C:\\agent\\repo',
         '[/tool_target]',
       ].join('\n'),
@@ -201,7 +201,7 @@ test('runner injects tool target context into provider transcript only', async (
   const toolMessage = secondRequest.find(message => message.role === 'tool');
   assert.ok(toolMessage);
   assert.match(String(toolMessage.content), /^\[tool_target\]/);
-  assert.match(String(toolMessage.content), /target: virtual_employee_cloud_runtime/);
+  assert.match(String(toolMessage.content), /target: agent_runtime_device/);
   assert.match(String(toolMessage.content), /Command succeeded/);
 });
 

--- a/tests/runtime-context-builder.test.ts
+++ b/tests/runtime-context-builder.test.ts
@@ -82,7 +82,7 @@ describe('runtime context builder', () => {
     assert.equal(snapshot.execution.agentRuntime.owner, 'agent_self');
     assert.equal(snapshot.execution.agentRuntime.localToolTarget, 'agent_cloud_runtime');
     assert.equal(snapshot.execution.agentRuntime.userDeviceDisplayNamesAreIdentity, false);
-    assert.equal(snapshot.execution.agentRuntime.commonDirectoryPolicy, 'agent_cloud_runtime_data_root');
+    assert.equal(snapshot.execution.agentRuntime.commonDirectoryPolicy, 'os_user_common_directories');
     assert.equal('bodyId' in snapshot.execution.localDevice, false);
     assert.equal(snapshot.execution.userDevices[0].grantId, 'device_grant_current');
     assert.equal(snapshot.execution.userDevices[0].deviceId, 'device-user-1');

--- a/tests/runtime-context-builder.test.ts
+++ b/tests/runtime-context-builder.test.ts
@@ -78,9 +78,9 @@ describe('runtime context builder', () => {
     assert.equal(snapshot.execution.scopeSource, 'execution_scope');
     assert.equal(snapshot.execution.localDevice.source, 'catscompany');
     assert.equal(snapshot.execution.localDevice.deviceId, 'device-1');
-    assert.equal(snapshot.execution.agentRuntime.target, 'virtual_employee_cloud_runtime');
+    assert.equal(snapshot.execution.agentRuntime.target, 'agent_runtime_device');
     assert.equal(snapshot.execution.agentRuntime.owner, 'agent_self');
-    assert.equal(snapshot.execution.agentRuntime.localToolTarget, 'agent_cloud_runtime');
+    assert.equal(snapshot.execution.agentRuntime.localToolTarget, 'agent_runtime_device');
     assert.equal(snapshot.execution.agentRuntime.userDeviceDisplayNamesAreIdentity, false);
     assert.equal(snapshot.execution.agentRuntime.commonDirectoryPolicy, 'os_user_common_directories');
     assert.equal('bodyId' in snapshot.execution.localDevice, false);

--- a/tests/runtime-context-builder.test.ts
+++ b/tests/runtime-context-builder.test.ts
@@ -78,16 +78,21 @@ describe('runtime context builder', () => {
     assert.equal(snapshot.execution.scopeSource, 'execution_scope');
     assert.equal(snapshot.execution.localDevice.source, 'catscompany');
     assert.equal(snapshot.execution.localDevice.deviceId, 'device-1');
+    assert.equal(snapshot.execution.agentRuntime.target, 'virtual_employee_cloud_runtime');
+    assert.equal(snapshot.execution.agentRuntime.owner, 'agent_self');
+    assert.equal(snapshot.execution.agentRuntime.localToolTarget, 'agent_cloud_runtime');
+    assert.equal(snapshot.execution.agentRuntime.userDeviceDisplayNamesAreIdentity, false);
+    assert.equal(snapshot.execution.agentRuntime.commonDirectoryPolicy, 'agent_cloud_runtime_data_root');
     assert.equal('bodyId' in snapshot.execution.localDevice, false);
     assert.equal(snapshot.execution.userDevices[0].grantId, 'device_grant_current');
     assert.equal(snapshot.execution.userDevices[0].deviceId, 'device-user-1');
-    assert.equal(snapshot.execution.userDevices[0].displayName, 'Alice laptop');
+    assert.equal(snapshot.execution.userDevices[0].displayName, 'User Laptop');
     assert.deepEqual(snapshot.execution.userDevices[0].operations, ['read_file', 'execute_shell']);
     assert.equal(snapshot.execution.userDevices[0].status, 'active');
     assert.equal(snapshot.execution.deviceSelection.status, 'selected');
     assert.equal(snapshot.execution.deviceSelection.selectionSource, 'single_active_device');
     assert.equal(snapshot.execution.deviceSelection.selectedDevice.deviceId, 'device-user-1');
-    assert.equal(snapshot.execution.deviceSelection.selectedDevice.displayName, 'Alice laptop');
+    assert.equal(snapshot.execution.deviceSelection.selectedDevice.displayName, 'User Laptop');
     assert.deepEqual(snapshot.execution.deviceSelection.selectedDevice.operations, ['read_file']);
     assert.equal(snapshot.execution.localFiles[0].ref, 'catsco_attachment:contract');
     assert.equal(snapshot.execution.localFiles[0].fileName, 'contract.pdf');
@@ -222,7 +227,7 @@ function deviceGrant(scope: ExecutionScope, deviceId = 'device-user-1'): ScopedD
     source: scope.source,
     ownerUserId: scope.actorUserId,
     deviceId,
-    displayName: 'Alice laptop',
+    displayName: 'User Laptop',
     bodyId: 'body-secret',
     installationId: 'installation-main',
     identityTrust: 'server_canonical',
@@ -253,7 +258,7 @@ function deviceSelection(scope: ExecutionScope): ScopedDeviceSelection {
     identityTrust: scope.identityTrust,
     identitySource: 'metadata.catsco_identity',
     selectedDeviceId: 'device-user-1',
-    selectedDeviceDisplayName: 'Alice laptop',
+    selectedDeviceDisplayName: 'User Laptop',
     selectedDeviceBodyId: 'body-secret',
     selectedDeviceInstallationId: 'installation-main',
     selectedDeviceOperations: ['read_file'],

--- a/tests/tool-gateway-catsco.test.ts
+++ b/tests/tool-gateway-catsco.test.ts
@@ -164,6 +164,107 @@ describe('CatsCo ToolGateway', () => {
     assert.match(result.ok ? String(result.content) : '', /agent body content/);
   });
 
+  test('explicit agent cloud runtime target ignores a selected user device', async () => {
+    const root = makeWorkspace();
+    const filePath = path.join(root, 'notes.txt');
+    fs.writeFileSync(filePath, 'agent cloud runtime content');
+    const agentScope = scope({
+      actorUserId: 'usr100',
+      sessionKey: 'session:v2:catscompany:p2p:p2p_100_43:agent:usr43',
+      topicId: 'p2p_100_43',
+      agentBodyId: 'body-device',
+      deviceOwnerUserId: 'usr100',
+      deviceOwnerSource: 'channel_identity_link',
+    });
+    let rpcCalls = 0;
+
+    const result = await new ReadTool().execute({
+      file_path: filePath,
+      target: 'agent_cloud_runtime',
+    }, context(root, {
+      executionScope: agentScope,
+      localDeviceGrant: localDevice({ ownerUserId: 'usr7' }),
+      deviceSelection: deviceSelection({
+        sessionKey: agentScope.sessionKey,
+        topicId: agentScope.topicId,
+        actorUserId: agentScope.actorUserId,
+        agentId: agentScope.agentId,
+        selectedDeviceId: 'user-device',
+        selectedDeviceDisplayName: 'User Laptop',
+        selectedDeviceBodyId: 'user-body',
+        selectedDeviceInstallationId: 'user-install',
+        selectedDeviceOperations: ['read_file'],
+      }),
+      deviceRpc: {
+        executeTool: async () => {
+          rpcCalls += 1;
+          return { ok: true, content: 'user device content' };
+        },
+      },
+    }));
+
+    assert.equal(result.ok, true);
+    assert.match(result.ok ? String(result.content) : '', /agent cloud runtime content/);
+    assert.equal(rpcCalls, 0);
+  });
+
+  test('explicit selected user device target uses the backend-selected device', async () => {
+    const root = makeWorkspace();
+    const filePath = path.join(root, 'notes.txt');
+    fs.writeFileSync(filePath, 'agent cloud runtime content');
+    const agentScope = scope({
+      actorUserId: 'usr100',
+      sessionKey: 'session:v2:catscompany:p2p:p2p_100_43:agent:usr43',
+      topicId: 'p2p_100_43',
+      agentBodyId: 'body-device',
+      deviceOwnerUserId: 'usr100',
+      deviceOwnerSource: 'channel_identity_link',
+    });
+    const calls: Array<{ args: Record<string, unknown> }> = [];
+
+    const result = await new ReadTool().execute({
+      file_path: filePath,
+      target: 'selected_user_device',
+    }, context(root, {
+      executionScope: agentScope,
+      localDeviceGrant: localDevice({ ownerUserId: 'usr7' }),
+      deviceGrants: [deviceGrant(['read_file'], {
+        deviceId: 'user-device',
+        deviceDisplayName: 'User Laptop',
+        deviceBodyId: 'user-body',
+        deviceInstallationId: 'user-install',
+        ownerUserId: 'usr100',
+        sessionKey: agentScope.sessionKey,
+        topicId: agentScope.topicId,
+        actorUserId: agentScope.actorUserId,
+        agentId: agentScope.agentId,
+        agentBodyId: agentScope.agentBodyId,
+      })],
+      deviceSelection: deviceSelection({
+        sessionKey: agentScope.sessionKey,
+        topicId: agentScope.topicId,
+        actorUserId: agentScope.actorUserId,
+        agentId: agentScope.agentId,
+        selectedDeviceId: 'user-device',
+        selectedDeviceDisplayName: 'User Laptop',
+        selectedDeviceBodyId: 'user-body',
+        selectedDeviceInstallationId: 'user-install',
+        selectedDeviceOperations: ['read_file'],
+      }),
+      deviceRpc: {
+        executeTool: async request => {
+          calls.push({ args: request.args });
+          return { ok: true, content: 'user device content' };
+        },
+      },
+    }));
+
+    assert.equal(result.ok, true);
+    assert.equal(result.ok ? String(result.content) : '', 'user device content');
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].args.target, 'selected_user_device');
+  });
+
   test('blocks agent local body fallback when agent body does not match local device body', async () => {
     const root = makeWorkspace();
     const filePath = path.join(root, 'notes.txt');

--- a/tests/tool-gateway-catsco.test.ts
+++ b/tests/tool-gateway-catsco.test.ts
@@ -149,7 +149,7 @@ describe('CatsCo ToolGateway', () => {
     }
   });
 
-  test('allows virtual employee local body tools when user device selection is unavailable', async () => {
+  test('allows agent local body tools when user device selection is unavailable', async () => {
     const root = makeWorkspace();
     const filePath = path.join(root, 'notes.txt');
     fs.writeFileSync(filePath, 'agent body content');
@@ -164,10 +164,10 @@ describe('CatsCo ToolGateway', () => {
     assert.match(result.ok ? String(result.content) : '', /agent body content/);
   });
 
-  test('explicit agent cloud runtime target ignores a selected user device', async () => {
+  test('explicit agent runtime device target ignores a selected user device', async () => {
     const root = makeWorkspace();
     const filePath = path.join(root, 'notes.txt');
-    fs.writeFileSync(filePath, 'agent cloud runtime content');
+    fs.writeFileSync(filePath, 'agent runtime device content');
     const agentScope = scope({
       actorUserId: 'usr100',
       sessionKey: 'session:v2:catscompany:p2p:p2p_100_43:agent:usr43',
@@ -180,7 +180,7 @@ describe('CatsCo ToolGateway', () => {
 
     const result = await new ReadTool().execute({
       file_path: filePath,
-      target: 'agent_cloud_runtime',
+      target: 'agent_runtime_device',
     }, context(root, {
       executionScope: agentScope,
       localDeviceGrant: localDevice({ ownerUserId: 'usr7' }),
@@ -204,14 +204,54 @@ describe('CatsCo ToolGateway', () => {
     }));
 
     assert.equal(result.ok, true);
-    assert.match(result.ok ? String(result.content) : '', /agent cloud runtime content/);
+    assert.match(result.ok ? String(result.content) : '', /agent runtime device content/);
     assert.equal(rpcCalls, 0);
+  });
+
+  test('explicit legacy agent cloud runtime target remains a compatibility alias', async () => {
+    const root = makeWorkspace();
+    const filePath = path.join(root, 'notes.txt');
+    fs.writeFileSync(filePath, 'agent runtime device content');
+
+    const result = await new ReadTool().execute({
+      file_path: filePath,
+      target: 'agent_cloud_runtime',
+    }, context(root, {
+      executionScope: scope({ agentBodyId: 'body-device' }),
+      localDeviceGrant: localDevice({ ownerUserId: 'usr9' }),
+      deviceSelection: unavailableDeviceSelection(),
+    }));
+
+    assert.equal(result.ok, true);
+    assert.match(result.ok ? String(result.content) : '', /agent runtime device content/);
+  });
+
+  test('explicit selected user device target never falls back to the agent runtime device', async () => {
+    const root = makeWorkspace();
+    const filePath = path.join(root, 'notes.txt');
+    fs.writeFileSync(filePath, 'agent runtime device content');
+
+    const result = await new ReadTool().execute({
+      file_path: filePath,
+      target: 'selected_user_device',
+    }, context(root, {
+      executionScope: scope({ agentBodyId: 'body-device' }),
+      localDeviceGrant: localDevice({ ownerUserId: 'usr9' }),
+      deviceSelection: unavailableDeviceSelection(),
+    }));
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.errorCode, 'PERMISSION_DENIED');
+      assert.match(result.message, /当前用户没有可用的在线设备授权/);
+      assert.doesNotMatch(result.message, /agent runtime device content/);
+    }
   });
 
   test('explicit selected user device target uses the backend-selected device', async () => {
     const root = makeWorkspace();
     const filePath = path.join(root, 'notes.txt');
-    fs.writeFileSync(filePath, 'agent cloud runtime content');
+    fs.writeFileSync(filePath, 'agent runtime device content');
     const agentScope = scope({
       actorUserId: 'usr100',
       sessionKey: 'session:v2:catscompany:p2p:p2p_100_43:agent:usr43',
@@ -801,7 +841,7 @@ describe('CatsCo ToolGateway', () => {
     assert.equal(fs.existsSync(path.join(root, 'remote.txt')), false);
   });
 
-  test('routes mobile channel write_file to the speaker owner device instead of the cloud body', async () => {
+  test('routes mobile channel write_file to the speaker owner device instead of the agent body', async () => {
     const root = makeWorkspace();
     const marker = path.join(root, 'must-not-create-on-cloud.txt');
     const channelScope = scope({
@@ -913,7 +953,7 @@ describe('CatsCo ToolGateway', () => {
     if (result.ok) assert.match(result.content, /catsco-shell-ok/);
   });
 
-  test('allows virtual employee local body execute_shell without user-device grant', async () => {
+  test('allows agent local body execute_shell without user-device grant', async () => {
     const root = makeWorkspace();
     const result = await new ShellTool().execute({ command: 'echo catsco-agent-body-shell-ok' }, context(root, {
       executionScope: scope({ agentBodyId: 'body-device' }),
@@ -927,7 +967,7 @@ describe('CatsCo ToolGateway', () => {
     if (result.ok) assert.match(result.content, /catsco-agent-body-shell-ok/);
   });
 
-  test('blocks virtual employee execute_shell fallback when agent body does not match local device body', async () => {
+  test('blocks agent runtime execute_shell fallback when agent body does not match local device body', async () => {
     const root = makeWorkspace();
     const marker = path.join(root, 'must-not-run-locally.txt');
 
@@ -1048,7 +1088,7 @@ describe('CatsCo ToolGateway', () => {
     assert.equal(fs.existsSync(marker), false);
   });
 
-  test('blocks channel write_file on cloud body when local device owner is missing and no speaker device is selected', async () => {
+  test('blocks channel write_file on agent body when local device owner is missing and no speaker device is selected', async () => {
     const root = makeWorkspace();
     const marker = path.join(root, 'must-not-create-on-cloud.txt');
     const channelScope = scope({

--- a/tests/tool-manager.test.ts
+++ b/tests/tool-manager.test.ts
@@ -556,6 +556,60 @@ describe('ToolManager', () => {
     }
   });
 
+  test('CatsCo target context follows explicit selected user device target', async () => {
+    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-catsco-target-user-device-'));
+    const manager = new ToolManager(workspace, {}, { enabledToolNames: [] });
+    manager.registerTool(fakeTool('read_file', async () => {
+      return { ok: true, content: 'read result' };
+    }));
+    const channelScope = catsScope({
+      actorUserId: 'usr100',
+      sessionKey: 'session:v2:catscompany:p2p:p2p_100_43:agent:usr43',
+      topicId: 'p2p_100_43',
+      deviceOwnerUserId: 'usr100',
+      deviceOwnerSource: 'channel_identity_link',
+    });
+
+    const result = await manager.executeTool({
+      id: 'call-catsco-user-device-target-context',
+      type: 'function',
+      function: {
+        name: 'read_file',
+        arguments: JSON.stringify({ file_path: 'note.txt', target: 'selected_user_device' }),
+      },
+    }, [], {
+      surface: 'catscompany',
+      permissionProfile: 'strict',
+      workingDirectory: workspace,
+      workspaceRoot: workspace,
+      executionScope: channelScope,
+      localDeviceGrant: catsLocalDevice({ ownerUserId: 'usr7' }),
+      deviceGrants: [catsDeviceGrant(channelScope, ['read_file'], {
+        deviceId: 'user-device',
+        deviceDisplayName: 'User Laptop',
+        deviceBodyId: 'user-body',
+        deviceInstallationId: 'user-install',
+        ownerUserId: 'usr100',
+        actorUserId: 'usr100',
+      })],
+      deviceSelection: catsDeviceSelection(channelScope, ['read_file'], {
+        selectedDeviceId: 'user-device',
+        selectedDeviceDisplayName: 'User Laptop',
+        selectedDeviceBodyId: 'user-body',
+        selectedDeviceInstallationId: 'user-install',
+      }),
+      deviceRpc: {
+        executeTool: async () => ({ ok: true, content: 'remote read' }),
+      },
+    });
+
+    assert.equal(result.ok, true);
+    assert.match(result.targetContext || '', /target: selected_user_device/);
+    assert.match(result.targetContext || '', /target_owner: current_speaker_user/);
+    assert.match(result.targetContext || '', /target_display_name: User Laptop/);
+    assert.doesNotMatch(result.targetContext || '', /target: virtual_employee_cloud_runtime/);
+  });
+
   test('CatsCo non-agent-local-body shell contexts still require strict confirmation', async () => {
     const cases: Array<{
       name: string;

--- a/tests/tool-manager.test.ts
+++ b/tests/tool-manager.test.ts
@@ -486,7 +486,7 @@ describe('ToolManager', () => {
     assert.equal(confirmed, false);
   });
 
-  test('CatsCo virtual employee local body runs shell without confirmation for non-owner actors', async () => {
+  test('CatsCo agent local body runs shell without confirmation for non-owner actors', async () => {
     const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-catsco-agent-body-'));
     const manager = new ToolManager(workspace, {}, { enabledToolNames: [] });
     let executed = false;
@@ -607,7 +607,7 @@ describe('ToolManager', () => {
     assert.match(result.targetContext || '', /target: selected_user_device/);
     assert.match(result.targetContext || '', /target_owner: current_speaker_user/);
     assert.match(result.targetContext || '', /target_display_name: User Laptop/);
-    assert.doesNotMatch(result.targetContext || '', /target: virtual_employee_cloud_runtime/);
+    assert.doesNotMatch(result.targetContext || '', /target: agent_runtime_device/);
   });
 
   test('CatsCo non-agent-local-body shell contexts still require strict confirmation', async () => {

--- a/tests/tool-target-context.test.ts
+++ b/tests/tool-target-context.test.ts
@@ -37,7 +37,7 @@ function catsContext(overrides: Partial<ToolExecutionContext> = {}): ToolExecuti
 }
 
 describe('tool target context', () => {
-  test('labels virtual employee cloud runtime results', () => {
+  test('labels agent runtime device results without assuming cloud hosting', () => {
     const context = buildToolTargetContext(catsContext(), {
       toolName: 'execute_shell',
       operation: 'execute_shell',
@@ -47,9 +47,10 @@ describe('tool target context', () => {
 
     assert.ok(context);
     assert.match(context, /^\[tool_target\]/);
-    assert.match(context, /target: virtual_employee_cloud_runtime/);
+    assert.match(context, /target: agent_runtime_device/);
     assert.match(context, /target_owner: agent_self/);
-    assert.match(context, /target_meaning: This is the virtual employee's own cloud computer\./);
+    assert.match(context, /target_meaning: This is the current agent body's own runtime device\./);
+    assert.match(context, /It may be hosted in the cloud or on a creator-owned local computer\./);
     assert.match(context, new RegExp(`cwd: ${escapeRegExp(runtimeCwd)}`));
     assert.match(context, /cwd_scope: cwd is an execution directory on the target/);
     assert.match(context, /shell: powershell/);
@@ -125,7 +126,7 @@ describe('tool target context', () => {
     assert.ok(context);
     assert.match(context, /target: selected_user_device/);
     assert.match(context, /target_owner: current_speaker_user/);
-    assert.match(context, /not the virtual employee's own cloud computer/);
+    assert.match(context, /not the agent body's own runtime device/);
     assert.match(context, /target_display_name: User Laptop/);
     assert.match(context, /target_display_name_role: user_device_display_name_only/);
   });
@@ -134,7 +135,7 @@ describe('tool target context', () => {
     const displayed = stripToolTargetContextForDisplay([
       '[tool_target]',
       'tool: execute_shell',
-      'target: virtual_employee_cloud_runtime',
+      'target: agent_runtime_device',
       '[/tool_target]',
       '',
       'Command succeeded:',

--- a/tests/tool-target-context.test.ts
+++ b/tests/tool-target-context.test.ts
@@ -48,7 +48,10 @@ describe('tool target context', () => {
     assert.ok(context);
     assert.match(context, /^\[tool_target\]/);
     assert.match(context, /target: virtual_employee_cloud_runtime/);
+    assert.match(context, /target_owner: agent_self/);
+    assert.match(context, /target_meaning: This is the virtual employee's own cloud computer\./);
     assert.match(context, new RegExp(`cwd: ${escapeRegExp(runtimeCwd)}`));
+    assert.match(context, /cwd_scope: cwd is an execution directory on the target/);
     assert.match(context, /shell: powershell/);
   });
 
@@ -112,7 +115,7 @@ describe('tool target context', () => {
         agentId: 'usr43',
         identityTrust: 'server_canonical',
         selectedDeviceId: 'install-user-device',
-        selectedDeviceDisplayName: 'Alice Laptop',
+        selectedDeviceDisplayName: 'User Laptop',
       },
     }), {
       toolName: 'resolve_common_directory',
@@ -121,7 +124,10 @@ describe('tool target context', () => {
 
     assert.ok(context);
     assert.match(context, /target: selected_user_device/);
-    assert.match(context, /target_display_name: Alice Laptop/);
+    assert.match(context, /target_owner: current_speaker_user/);
+    assert.match(context, /not the virtual employee's own cloud computer/);
+    assert.match(context, /target_display_name: User Laptop/);
+    assert.match(context, /target_display_name_role: user_device_display_name_only/);
   });
 
   test('strips target context before CatsCo display', () => {


### PR DESCRIPTION
## Summary
- Adds an explicit CatsCo tool `target` preference so models can choose `agent_cloud_runtime` for the virtual employee's own cloud computer or `selected_user_device` for the current user's device.
- Anchors provider-only runtime and tool-result context with `agent_self` vs `current_speaker_user`, making device display names informational only.
- Resolves virtual employee cloud runtime common directories to a stable `.dev-user-data-real` data root, including a stable Desktop path.
- Tightens transient runtime rules and tests target switching without relying on any real device display name.

## Root Cause
Virtual employee conversations could include both a backend-selected user device and the agent's own cloud runtime. Without an explicit target parameter and stronger runtime identity context, the model could mix user desktop paths, agent runtime cwd, and shell cwd, then treat a user device display name as the agent's own identity.

## Validation
- `tsx --test tests\tool-gateway-catsco.test.ts tests\tool-manager.test.ts tests\tool-target-context.test.ts tests\common-directory-tool.test.ts tests\runtime-context-builder.test.ts`
- `tsx --test tests\catscompany-device-rpc-tools.test.ts tests\conversation-runner-transcript-normalization.test.ts tests\shell-current-directory.test.ts tests\transient-environment.test.ts`
- `tsx --test tests\catscompany-tool-confirmation.test.ts`
- `npm run build`
- `git diff --check`