### PR TITLE
[codex] Allow Weixin image file replies

### DIFF
--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -26,6 +26,7 @@ import { GlobTool } from '../tools/glob-tool';
 import { GrepTool } from '../tools/grep-tool';
 import { WriteTool } from '../tools/write-tool';
 import { EditTool } from '../tools/edit-tool';
+import { SendFileTool } from '../tools/send-file-tool';
 import { ShellTool } from '../tools/bash-tool';
 import { resolveCommonDirectoryToolArgs } from '../tools/common-directory-tool';
 import {
@@ -387,6 +388,9 @@ export class CatsCompanyBot {
       case 'edit_file':
         result = await new EditTool().execute(args, context);
         break;
+      case 'send_file':
+        result = await new SendFileTool().execute(args, context);
+        break;
       case 'execute_shell':
         result = await new ShellTool().execute(args, context);
         break;
@@ -486,6 +490,10 @@ export class CatsCompanyBot {
       localDeviceGrant: this.localDeviceGrant,
       deviceGrants: [grant],
       deviceSelection,
+      channel: this.buildChannel(executionScope.topicId, {
+        sessionKey: executionScope.sessionKey,
+        senderId: executionScope.actorUserId,
+      }),
     };
   }
 
@@ -496,7 +504,7 @@ export class CatsCompanyBot {
     const operation = this.normalizeDeviceRpcOperation(request.operation);
     const toolName = String(request.tool_name || operation || '').trim();
     if (!operation || !isRemoteDeviceRpcTool(toolName, operation)) {
-      return { code: 'unsupported_operation', message: 'Device RPC only allows read_file, resolve_common_directory, glob, grep, write_file, edit_file, and execute_shell.' };
+      return { code: 'unsupported_operation', message: 'Device RPC only allows read_file, resolve_common_directory, glob, grep, write_file, edit_file, send_file, and execute_shell.' };
     }
 
     const requiredFields: Array<[keyof CatsDeviceRpcMessage, string]> = [
@@ -533,6 +541,7 @@ export class CatsCompanyBot {
       || operation === 'grep'
       || operation === 'write_file'
       || operation === 'edit_file'
+      || operation === 'send_file'
       || operation === 'execute_shell'
     ) {
       return operation;

--- a/src/tools/device-rpc-tool.ts
+++ b/src/tools/device-rpc-tool.ts
@@ -16,13 +16,14 @@ export function isRemoteDeviceRpcTool(toolName: string, operation: DeviceGrantOp
   return isRemoteReadonlyTool(toolName, operation)
     || (toolName === 'write_file' && operation === 'write_file')
     || (toolName === 'edit_file' && operation === 'edit_file')
+    || (toolName === 'send_file' && operation === 'send_file')
     || (toolName === 'execute_shell' && operation === 'execute_shell');
 }
 
 export async function executeRemoteDeviceRpcTool(
   context: ToolExecutionContext,
   gateway: ToolGatewayDecision,
-  toolName: 'read_file' | 'resolve_common_directory' | 'glob' | 'grep' | 'write_file' | 'edit_file' | 'execute_shell',
+  toolName: 'read_file' | 'resolve_common_directory' | 'glob' | 'grep' | 'write_file' | 'edit_file' | 'send_file' | 'execute_shell',
   operation: DeviceGrantOperation,
   args: Record<string, unknown>,
 ): Promise<ToolExecutionResult | undefined> {
@@ -32,7 +33,7 @@ export async function executeRemoteDeviceRpcTool(
     return {
       ok: false,
       errorCode: 'PERMISSION_DENIED',
-      message: `远程设备 RPC 当前只允许 read_file / resolve_common_directory / glob / grep / write_file / edit_file / execute_shell，已阻止 ${toolName}。普通文件任务请优先用 resolve_common_directory / glob / write_file，只有服务端授权后才使用 execute_shell。`,
+      message: `远程设备 RPC 当前只允许 read_file / resolve_common_directory / glob / grep / write_file / edit_file / send_file / execute_shell，已阻止 ${toolName}。普通文件任务请优先用 resolve_common_directory / glob / write_file，只有服务端授权后才使用 execute_shell。`,
     };
   }
 

--- a/src/tools/local-tool-risk.ts
+++ b/src/tools/local-tool-risk.ts
@@ -1,6 +1,7 @@
 import type { DeviceGrantOperation } from '../types/session-identity';
 import type { ToolExecutionContext, ToolExecutionResult, ToolRiskLevel } from '../types/tool';
 import { isCatsCoAgentLocalBodyContext, isCatsCoLocalOwnerSelfContext, resolveToolGatewayAccess } from './tool-gateway';
+import { resolveOutboundTarget } from './outbound-gateway';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -151,6 +152,9 @@ export function classifyLocalToolRisk(
   }
 
   if (toolName === 'send_file') {
+    if (isCurrentMessageChannelWorkspaceFileSend(context, args)) {
+      return { requiresConfirmation: false, risk: 'low', reason: '当前微信/飞书会话内发送工作区文件。' };
+    }
     return { requiresConfirmation: true, risk: 'medium', reason: '工具会把本地文件发送到当前会话，需要用户确认。' };
   }
 
@@ -254,6 +258,33 @@ function classifyWritePathRisk(toolName: string, value: string, context: ToolExe
   if (!isWithin(resolved, workspaceRoot)) return 'high';
   if (toolName === 'write_file' && !fs.existsSync(resolved)) return 'low';
   return 'medium';
+}
+
+function classifySendFilePathRisk(args: unknown, context: ToolExecutionContext): ToolRiskLevel {
+  const target = (stringField(args, 'file_path') || stringField(args, 'path')).trim();
+  if (!target) return 'medium';
+  if (/^catsco_attachment:[A-Za-z0-9._:-]+$/.test(target)) return 'low';
+  if (looksSensitivePath(target)) return 'high';
+
+  const workingDirectory = context.workingDirectory || process.cwd();
+  const workspaceRoot = context.workspaceRoot || workingDirectory;
+  const resolved = path.resolve(workingDirectory, target);
+  if (looksSensitivePath(resolved)) return 'high';
+  return isWithin(resolved, workspaceRoot) ? 'low' : 'medium';
+}
+
+function isCurrentMessageChannelWorkspaceFileSend(context: ToolExecutionContext, args: unknown): boolean {
+  if (context.surface !== 'weixin' && context.surface !== 'feishu') return false;
+  const scope = context.executionScope;
+  if (!scope || scope.source !== context.surface) return false;
+  if (scope.identityTrust === 'untrusted') return false;
+  if (classifySendFilePathRisk(args, context) !== 'low') return false;
+
+  const target = resolveOutboundTarget(context, {
+    operation: 'send_file',
+    missingChannelMessage: '当前不在聊天会话中，无法发送文件',
+  });
+  return target.ok;
 }
 
 function isWithin(targetPath: string, parentPath: string): boolean {

--- a/src/tools/local-tool-risk.ts
+++ b/src/tools/local-tool-risk.ts
@@ -44,6 +44,7 @@ const REMOTE_DEVICE_FILE_TOOL_OPERATIONS: Record<string, DeviceGrantOperation> =
   grep: 'grep',
   write_file: 'write_file',
   edit_file: 'edit_file',
+  send_file: 'send_file',
 };
 
 export async function confirmLocalToolExecution(

--- a/src/tools/local-tool-risk.ts
+++ b/src/tools/local-tool-risk.ts
@@ -270,7 +270,23 @@ function classifySendFilePathRisk(args: unknown, context: ToolExecutionContext):
   const workspaceRoot = context.workspaceRoot || workingDirectory;
   const resolved = path.resolve(workingDirectory, target);
   if (looksSensitivePath(resolved)) return 'high';
-  return isWithin(resolved, workspaceRoot) ? 'low' : 'medium';
+  const resolvedWorkspaceRoot = path.resolve(workspaceRoot);
+  if (!isWithin(resolved, resolvedWorkspaceRoot)) return 'medium';
+  const realPathRisk = classifyExistingSendFileRealPathRisk(resolved, resolvedWorkspaceRoot);
+  return realPathRisk || 'low';
+}
+
+function classifyExistingSendFileRealPathRisk(resolved: string, resolvedWorkspaceRoot: string): ToolRiskLevel | undefined {
+  if (!fs.existsSync(resolved)) return undefined;
+
+  try {
+    const realTarget = fs.realpathSync(resolved);
+    const realWorkspaceRoot = fs.realpathSync(resolvedWorkspaceRoot);
+    if (looksSensitivePath(realTarget)) return 'high';
+    return isWithin(realTarget, realWorkspaceRoot) ? undefined : 'medium';
+  } catch {
+    return 'medium';
+  }
 }
 
 function isCurrentMessageChannelWorkspaceFileSend(context: ToolExecutionContext, args: unknown): boolean {

--- a/src/tools/send-file-tool.ts
+++ b/src/tools/send-file-tool.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import { Logger } from '../utils/logger';
 import { resolveToolPath } from '../utils/tool-path-resolver';
+import { executeRemoteDeviceRpcTool } from './device-rpc-tool';
 import { resolveLocalFileAccess, resolveLocalFileReference } from './local-file-gateway';
 import { resolveOutboundTarget } from './outbound-gateway';
 import { formatCatsCoVisiblePath, resolveToolGatewayAccess } from './tool-gateway';
@@ -115,6 +116,8 @@ export class SendFileTool implements Tool {
           message: gateway.message,
         };
       }
+      const remoteResult = await executeRemoteDeviceRpcTool(context, gateway, 'send_file', 'send_file', args);
+      if (remoteResult) return remoteResult;
       displayPath = formatCatsCoVisiblePath(context, displayPath, { preserveRelative: true });
       visibleInputPath = displayPath;
     }

--- a/src/tools/tool-gateway.ts
+++ b/src/tools/tool-gateway.ts
@@ -40,6 +40,7 @@ const REMOTE_DEVICE_RPC_OPERATIONS = new Set<DeviceGrantOperation>([
   'grep',
   'write_file',
   'edit_file',
+  'send_file',
   'execute_shell',
 ]);
 
@@ -175,7 +176,7 @@ export function resolveToolGatewayAccess(
     if (!REMOTE_DEVICE_RPC_OPERATIONS.has(options.operation)) {
       return denied([
         `后端选定的用户设备不是当前运行体，但 ${options.operation} 还没有开放远程执行。`,
-        '当前只开放 read_file / resolve_common_directory / glob / grep / write_file / edit_file 远程工具。',
+        '当前只开放 read_file / resolve_common_directory / glob / grep / write_file / edit_file / send_file 远程工具。',
         '如需查看目录文件请使用 glob；如需创建或覆盖文本文件请使用 write_file。',
       ], options.targetLabel);
     }

--- a/tests/catscompany-device-rpc-tools.test.ts
+++ b/tests/catscompany-device-rpc-tools.test.ts
@@ -69,7 +69,7 @@ function serverGrant(overrides: Partial<ScopedDeviceGrant> = {}): ScopedDeviceGr
     actorUserId: 'usr7',
     agentId: 'usr43',
     agentBodyId: 'body-agent',
-    operations: ['read_file', 'resolve_common_directory', 'glob', 'grep', 'execute_shell'],
+    operations: ['read_file', 'resolve_common_directory', 'glob', 'grep', 'send_file', 'execute_shell'],
     createdAt: Date.now(),
     expiresAt: Date.now() + 60_000,
     ...overrides,
@@ -138,6 +138,12 @@ describe('CatsCompany Device RPC file tools', () => {
       args: { command: 'echo remote-shell' },
       grant,
     });
+    const send = await transport.executeTool({
+      toolName: 'send_file',
+      operation: 'send_file',
+      args: { file_path: 'C:\\Users\\Alice\\Desktop\\graded.png', file_name: 'graded.png' },
+      grant,
+    });
 
     assert.equal(read.ok, true);
     assert.equal(glob.ok, true);
@@ -149,12 +155,14 @@ describe('CatsCompany Device RPC file tools', () => {
     assert.equal(resolveDir.ok ? resolveDir.content : '', 'remote resolve_common_directory');
     assert.equal(grep.ok ? grep.content : '', 'remote grep');
     assert.equal(shell.ok ? shell.content : '', 'remote execute_shell');
+    assert.equal(send.ok ? send.content : '', 'remote send_file');
     assert.deepEqual(captured.map(item => [item.request.tool_name, item.request.operation]), [
       ['read_file', 'read_file'],
       ['glob', 'glob'],
       ['resolve_common_directory', 'resolve_common_directory'],
       ['grep', 'grep'],
       ['execute_shell', 'execute_shell'],
+      ['send_file', 'send_file'],
     ]);
 
     const first = captured[0].request;
@@ -258,6 +266,35 @@ describe('CatsCompany Device RPC file tools', () => {
     assert.equal(captured.result.error, undefined);
     assert.equal(captured.result.result.ok, true);
     assert.equal(fs.readFileSync(filePath, 'utf8'), 'after');
+  });
+
+  test('executes send_file on the target local device and sends to the current topic', async () => {
+    const captured: { result?: any } = {};
+    const bot = botWithDevice(captured);
+    const sent: Array<{ topic: string; filePath: string; fileName: string }> = [];
+    bot.sender = {
+      sendFile: async (topic: string, filePath: string, fileName: string) => {
+        sent.push({ topic, filePath, fileName });
+      },
+    };
+    const tmpRoot = path.join(process.cwd(), 'tmp');
+    fs.mkdirSync(tmpRoot, { recursive: true });
+    const dir = fs.mkdtempSync(path.join(tmpRoot, 'device-rpc-send-file-'));
+    const filePath = path.join(dir, 'graded.png');
+    fs.writeFileSync(filePath, 'fake image');
+
+    await bot.handleDeviceRpcRequest(request({
+      request_id: 'rpc-send-file-1',
+      operation: 'send_file',
+      tool_name: 'send_file',
+      payload: { args: { file_path: filePath, file_name: 'graded.png' } },
+    }));
+
+    assert.ok(captured.result);
+    assert.equal(captured.result.error, undefined);
+    assert.equal(captured.result.result.ok, true);
+    assert.match(String(captured.result.result.content), /File sent to current chat/);
+    assert.deepEqual(sent, [{ topic: 'p2p_7_43', filePath, fileName: 'graded.png' }]);
   });
 
   test('rejects Device RPC requests missing owner identity', async () => {

--- a/tests/tool-gateway-catsco.test.ts
+++ b/tests/tool-gateway-catsco.test.ts
@@ -765,6 +765,83 @@ describe('CatsCo ToolGateway', () => {
     assert.equal(fs.existsSync(marker), false);
   });
 
+  test('routes mobile channel send_file to the speaker owner device instead of the cloud body', async () => {
+    const root = makeWorkspace();
+    const channelScope = scope({
+      actorUserId: 'usr100',
+      sessionKey: 'session:v2:catscompany:p2p:p2p_100_43:agent:usr43',
+      topicId: 'p2p_100_43',
+      deviceOwnerUserId: 'usr100',
+      deviceOwnerSource: 'channel_identity_link',
+      channelSource: 'weixin',
+    });
+    const calls: any[] = [];
+    let localSendCalled = false;
+    const sendContext = context(root, {
+      executionScope: channelScope,
+      localDeviceGrant: localDevice({
+        ownerUserId: 'usr9',
+        bodyId: 'cloud-body',
+        installationId: 'cloud-install',
+        deviceId: 'cloud-install',
+        capabilities: ['read_file', 'glob', 'grep', 'write_file', 'edit_file', 'send_file', 'execute_shell'],
+      }),
+      deviceGrants: [deviceGrant(['send_file'], {
+        grantId: 'speaker-send-file-grant',
+        identitySource: 'channel_identity_link',
+        deviceId: 'speaker-device',
+        deviceBodyId: 'speaker-body',
+        deviceInstallationId: 'speaker-install',
+        ownerUserId: 'usr100',
+        actorUserId: 'usr100',
+        sessionKey: channelScope.sessionKey,
+        topicId: channelScope.topicId,
+        topicType: channelScope.topicType,
+        agentId: channelScope.agentId,
+        agentBodyId: channelScope.agentBodyId,
+      })],
+      deviceSelection: deviceSelection({
+        sessionKey: channelScope.sessionKey,
+        topicId: channelScope.topicId,
+        topicType: channelScope.topicType,
+        actorUserId: channelScope.actorUserId,
+        agentId: channelScope.agentId,
+        selectedDeviceId: 'speaker-device',
+        selectedDeviceBodyId: 'speaker-body',
+        selectedDeviceInstallationId: 'speaker-install',
+        selectedDeviceDisplayName: 'Speaker Laptop',
+        selectedDeviceOperations: ['send_file'],
+      }),
+      deviceRpc: {
+        executeTool: async request => {
+          calls.push(request);
+          return { ok: true, content: 'remote send ok' };
+        },
+      },
+    });
+    sendContext.channel = {
+      chatId: channelScope.topicId,
+      reply: async () => {},
+      sendFile: async () => {
+        localSendCalled = true;
+      },
+    };
+
+    const result = await new SendFileTool().execute({
+      file_path: 'C:\\Users\\Alice\\Desktop\\graded.png',
+      file_name: 'graded.png',
+    }, sendContext);
+
+    assert.equal(result.ok, true);
+    assert.equal(result.ok ? result.content : '', 'remote send ok');
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].toolName, 'send_file');
+    assert.equal(calls[0].operation, 'send_file');
+    assert.equal(calls[0].grant.ownerUserId, 'usr100');
+    assert.equal(calls[0].grant.deviceId, 'speaker-device');
+    assert.equal(localSendCalled, false);
+  });
+
   test('routes remote edit_file through Device RPC without local fallback', async () => {
     const root = makeWorkspace();
     fs.writeFileSync(path.join(root, 'local.txt'), 'before');

--- a/tests/tool-manager.test.ts
+++ b/tests/tool-manager.test.ts
@@ -41,6 +41,19 @@ function catsScope(overrides: Partial<ExecutionScope> = {}): ExecutionScope {
   };
 }
 
+function weixinScope(overrides: Partial<ExecutionScope> = {}): ExecutionScope {
+  return {
+    source: 'weixin',
+    sessionKey: 'session:v2:weixin:p2p:user-1',
+    topicId: 'user-1',
+    topicType: 'p2p',
+    actorUserId: 'user-1',
+    identityTrust: 'legacy_context',
+    isTrusted: false,
+    ...overrides,
+  };
+}
+
 function catsLocalDevice(overrides: Partial<ScopedLocalDeviceGrant> = {}): ScopedLocalDeviceGrant {
   return {
     kind: 'catscompany_body',
@@ -391,6 +404,90 @@ describe('ToolManager', () => {
     assert.equal(result.ok, false);
     assert.equal(result.errorCode, 'NEEDS_CONFIRMATION');
     assert.equal(executed, false);
+  });
+
+  test('strict Weixin send_file to current chat can send workspace files without interactive confirmation', async () => {
+    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-weixin-send-file-'));
+    fs.writeFileSync(path.join(workspace, 'graded.png'), 'fake image');
+    const manager = new ToolManager(workspace, {}, { enabledToolNames: [] });
+    let executed = false;
+    let confirmations = 0;
+    manager.registerTool(fakeTool('send_file', async () => {
+      executed = true;
+      return { ok: true, content: 'weixin file sent' };
+    }));
+
+    const result = await manager.executeTool({
+      id: 'call-weixin-send-file',
+      type: 'function',
+      function: {
+        name: 'send_file',
+        arguments: JSON.stringify({ file_path: 'graded.png', file_name: 'graded.png' }),
+      },
+    }, [], {
+      surface: 'weixin',
+      permissionProfile: 'strict',
+      workingDirectory: workspace,
+      workspaceRoot: workspace,
+      executionScope: weixinScope(),
+      channel: {
+        chatId: 'user-1',
+        reply: async () => undefined,
+        sendFile: async () => undefined,
+      },
+      confirmToolExecution: async () => {
+        confirmations += 1;
+        return false;
+      },
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.content, 'weixin file sent');
+    assert.equal(executed, true);
+    assert.equal(confirmations, 0);
+  });
+
+  test('strict Weixin send_file still requires confirmation for files outside the workspace', async () => {
+    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-weixin-workspace-'));
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-weixin-outside-'));
+    const outsideFile = path.join(outside, 'secret.png');
+    fs.writeFileSync(outsideFile, 'secret image');
+    const manager = new ToolManager(workspace, {}, { enabledToolNames: [] });
+    let executed = false;
+    let confirmations = 0;
+    manager.registerTool(fakeTool('send_file', async () => {
+      executed = true;
+      return { ok: true, content: 'should not send' };
+    }));
+
+    const result = await manager.executeTool({
+      id: 'call-weixin-send-outside',
+      type: 'function',
+      function: {
+        name: 'send_file',
+        arguments: JSON.stringify({ file_path: outsideFile, file_name: 'secret.png' }),
+      },
+    }, [], {
+      surface: 'weixin',
+      permissionProfile: 'strict',
+      workingDirectory: workspace,
+      workspaceRoot: workspace,
+      executionScope: weixinScope(),
+      channel: {
+        chatId: 'user-1',
+        reply: async () => undefined,
+        sendFile: async () => undefined,
+      },
+      confirmToolExecution: async () => {
+        confirmations += 1;
+        return false;
+      },
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.errorCode, 'PERMISSION_DENIED');
+    assert.equal(executed, false);
+    assert.equal(confirmations, 1);
   });
 
   test('CatsCo context can create new ordinary home files without confirmation', async () => {

--- a/tests/tool-manager.test.ts
+++ b/tests/tool-manager.test.ts
@@ -829,7 +829,7 @@ describe('ToolManager', () => {
     const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-catsco-remote-file-'));
     const manager = new ToolManager(workspace, {}, { enabledToolNames: [] });
     const executed: string[] = [];
-    const operations: ScopedDeviceGrant['operations'] = ['read_file', 'glob', 'grep', 'write_file', 'edit_file'];
+    const operations: ScopedDeviceGrant['operations'] = ['read_file', 'glob', 'grep', 'write_file', 'edit_file', 'send_file'];
     for (const operation of operations) {
       manager.registerTool(fakeTool(operation, async () => {
         executed.push(operation);
@@ -923,6 +923,14 @@ describe('ToolManager', () => {
         arguments: JSON.stringify({ file_path: 'C:\\Users\\Alice\\Desktop\\note.txt', old_string: 'hello', new_string: 'hi' }),
       },
     }, [], remoteContext);
+    const send = await manager.executeTool({
+      id: 'call-remote-send-file',
+      type: 'function',
+      function: {
+        name: 'send_file',
+        arguments: JSON.stringify({ file_path: 'C:\\Users\\Alice\\Desktop\\graded.png', file_name: 'graded.png' }),
+      },
+    }, [], remoteContext);
 
     assert.equal(read.ok, true);
     assert.equal(read.content, 'remote read_file requested');
@@ -934,6 +942,8 @@ describe('ToolManager', () => {
     assert.equal(grep.content, 'remote grep requested');
     assert.equal(edit.ok, true);
     assert.equal(edit.content, 'remote edit_file requested');
+    assert.equal(send.ok, true);
+    assert.equal(send.content, 'remote send_file requested');
     assert.deepEqual(executed, operations);
     assert.equal(confirmations, 0);
   });

--- a/tests/tool-manager.test.ts
+++ b/tests/tool-manager.test.ts
@@ -490,6 +490,59 @@ describe('ToolManager', () => {
     assert.equal(confirmations, 1);
   });
 
+  test('strict Weixin send_file requires confirmation when a workspace link resolves outside the workspace', async (t) => {
+    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-weixin-workspace-link-'));
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-weixin-outside-link-'));
+    fs.writeFileSync(path.join(outside, 'secret.png'), 'secret image');
+    const linkDir = path.join(workspace, 'linked-outside');
+    try {
+      fs.symlinkSync(outside, linkDir, process.platform === 'win32' ? 'junction' : 'dir');
+    } catch (error) {
+      t.skip(`Cannot create symlink/junction in this environment: ${String(error)}`);
+      return;
+    }
+
+    const manager = new ToolManager(workspace, {}, { enabledToolNames: [] });
+    let executed = false;
+    let confirmations = 0;
+    manager.registerTool(fakeTool('send_file', async () => {
+      executed = true;
+      return { ok: true, content: 'should not send' };
+    }));
+
+    const result = await manager.executeTool({
+      id: 'call-weixin-send-linked-outside',
+      type: 'function',
+      function: {
+        name: 'send_file',
+        arguments: JSON.stringify({
+          file_path: path.join('linked-outside', 'secret.png'),
+          file_name: 'secret.png',
+        }),
+      },
+    }, [], {
+      surface: 'weixin',
+      permissionProfile: 'strict',
+      workingDirectory: workspace,
+      workspaceRoot: workspace,
+      executionScope: weixinScope(),
+      channel: {
+        chatId: 'user-1',
+        reply: async () => undefined,
+        sendFile: async () => undefined,
+      },
+      confirmToolExecution: async () => {
+        confirmations += 1;
+        return false;
+      },
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.errorCode, 'PERMISSION_DENIED');
+    assert.equal(executed, false);
+    assert.equal(confirmations, 1);
+  });
+
   test('CatsCo context can create new ordinary home files without confirmation', async () => {
     const manager = new ToolManager('/tmp/xiaoba-tool-manager', {}, { enabledToolNames: [] });
     let confirmed = false;

--- a/tests/weixin-message-sender.test.ts
+++ b/tests/weixin-message-sender.test.ts
@@ -1,6 +1,9 @@
 import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
 import axios from 'axios';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { MessageSender } from '../src/weixin/message-sender';
 
 describe('weixin message sender', () => {
@@ -65,6 +68,46 @@ describe('weixin message sender', () => {
       );
     } finally {
       (axios.post as any) = originalPost;
+    }
+  });
+
+  test('sends jpg files as Weixin image messages', async () => {
+    const originalPost = axios.post;
+    const originalFetch = globalThis.fetch;
+    const testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'weixin-image-send-'));
+    const imagePath = path.join(testRoot, 'graded.jpg');
+    fs.writeFileSync(imagePath, Buffer.from([0xff, 0xd8, 0xff, 0xd9]));
+    const calls: Array<{ url: string; body: any }> = [];
+
+    (axios.post as any) = async (url: string, body: any) => {
+      calls.push({ url, body });
+      if (url.endsWith('/ilink/bot/getuploadurl')) {
+        return { data: { errcode: 0, upload_param: 'upload-param' } };
+      }
+      return { data: { errcode: 0, msgid: 'wx-msg-1' } };
+    };
+    (globalThis.fetch as any) = async () => ({
+      status: 200,
+      headers: {
+        get: (name: string) => name.toLowerCase() === 'x-encrypted-param' ? 'download-param' : null,
+      },
+      text: async () => '',
+    });
+
+    try {
+      const sender = new MessageSender('token', 'https://weixin.example.test', 'https://cdn.example.test');
+      await sender.sendFile('user-1', imagePath, 'graded.jpg', 'ctx-1', 'bot-1');
+
+      assert.equal(calls.length, 2);
+      assert.equal(calls[0].body.media_type, 1);
+      const item = calls[1].body.msg.item_list[0];
+      assert.equal(item.type, 2);
+      assert.ok(item.image_item);
+      assert.equal(item.file_item, undefined);
+    } finally {
+      (axios.post as any) = originalPost;
+      globalThis.fetch = originalFetch;
+      fs.rmSync(testRoot, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
## Summary
- Allow Weixin/Feishu message-surface `send_file` calls to send files from the current workspace without requiring an unavailable interactive confirmation.
- Keep existing protections for untrusted identities, mismatched outbound targets, sensitive paths, and files outside the workspace.
- Add regression coverage that Weixin `.jpg` files are sent as image message items.

## Root Cause
The Weixin adapter already had an image-send path, but `send_file` could be stopped by strict local confirmation in message surfaces where no interactive confirmation channel exists. As a result, skill-generated images could fail to send back and the user would only see text.

## Validation
- `node node_modules\\tsx\\dist\\cli.mjs --test tests\\weixin-message-sender.test.ts tests\\tool-manager.test.ts tests\\runtime-characterization.test.ts tests\\outbound-gateway.test.ts`
- `node node_modules\\tsx\\dist\\cli.mjs --test tests\\runtime-characterization.test.ts` after one Windows temp-directory EBUSY cleanup retry
- `npm.cmd run build`