### PR TITLE
[codex] Refactor Device RPC tool registry

### DIFF
--- a/src/catscompany/device-rpc-tool-executor.ts
+++ b/src/catscompany/device-rpc-tool-executor.ts
@@ -1,0 +1,42 @@
+import type { ToolExecutionContext, ToolExecutionResult } from '../types/tool';
+import type { DeviceRpcToolRegistration, DeviceRpcToolName } from '../tools/device-rpc-registry';
+import { ReadTool } from '../tools/read-tool';
+import { GlobTool } from '../tools/glob-tool';
+import { GrepTool } from '../tools/grep-tool';
+import { WriteTool } from '../tools/write-tool';
+import { EditTool } from '../tools/edit-tool';
+import { SendFileTool } from '../tools/send-file-tool';
+import { ShellTool } from '../tools/bash-tool';
+import { resolveCommonDirectoryToolArgs } from '../tools/common-directory-tool';
+
+type DeviceRpcLocalExecutor = (
+  args: Record<string, unknown>,
+  context: ToolExecutionContext,
+) => Promise<ToolExecutionResult> | ToolExecutionResult;
+
+const LOCAL_DEVICE_RPC_EXECUTORS: Record<DeviceRpcToolName, DeviceRpcLocalExecutor> = {
+  read_file: (args, context) => new ReadTool().execute(args, context),
+  resolve_common_directory: args => resolveCommonDirectoryToolArgs(args),
+  glob: (args, context) => new GlobTool().execute(args, context),
+  grep: (args, context) => new GrepTool().execute(args, context),
+  write_file: (args, context) => new WriteTool().execute(args, context),
+  edit_file: (args, context) => new EditTool().execute(args, context),
+  send_file: (args, context) => new SendFileTool().execute(args, context),
+  execute_shell: (args, context) => new ShellTool().execute(args, context),
+};
+
+export async function executeRegisteredDeviceRpcTool(
+  registration: DeviceRpcToolRegistration,
+  args: Record<string, unknown>,
+  context: ToolExecutionContext,
+): Promise<ToolExecutionResult> {
+  const executor = LOCAL_DEVICE_RPC_EXECUTORS[registration.toolName];
+  if (!executor) {
+    return {
+      ok: false,
+      errorCode: 'PERMISSION_DENIED',
+      message: `Device RPC 不允许执行 ${registration.toolName}。`,
+    };
+  }
+  return executor(args, context);
+}

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -21,18 +21,17 @@ import { hostname } from 'os';
 import { ConfigManager } from '../utils/config';
 import { isPrimaryModelVisionCapable } from '../utils/model-capabilities';
 import { createCatsCoSessionRoute } from '../core/session-router';
-import { ReadTool } from '../tools/read-tool';
-import { GlobTool } from '../tools/glob-tool';
-import { GrepTool } from '../tools/grep-tool';
-import { WriteTool } from '../tools/write-tool';
-import { EditTool } from '../tools/edit-tool';
-import { ShellTool } from '../tools/bash-tool';
-import { resolveCommonDirectoryToolArgs } from '../tools/common-directory-tool';
 import {
-  isRemoteDeviceRpcTool,
   normalizeDeviceRpcToolResultForTransport,
   normalizeDeviceRpcToolResultPayload,
 } from '../tools/device-rpc-tool';
+import {
+  CATSCOMPANY_FULL_RUNTIME_DEVICE_CAPABILITIES as DEVICE_RPC_RUNTIME_CAPABILITIES,
+  formatDeviceRpcAllowedToolList,
+  getDeviceRpcToolRegistration,
+  normalizeDeviceRpcOperation,
+} from '../tools/device-rpc-registry';
+import { executeRegisteredDeviceRpcTool } from './device-rpc-tool-executor';
 import {
   annotateToolExecutionResultWithTargetContext,
   stripToolTargetContextForDisplay,
@@ -80,16 +79,7 @@ const HIDDEN_CATS_TOOL_PROGRESS = new Set([
   'spawn_subagent',
 ]);
 const SUBAGENT_TERMINAL_EVENTS = new Set(['agent_completed', 'agent_failed', 'agent_stopped']);
-export const CATSCOMPANY_FULL_RUNTIME_DEVICE_CAPABILITIES: DeviceGrantOperation[] = [
-  'read_file',
-  'resolve_common_directory',
-  'glob',
-  'grep',
-  'write_file',
-  'edit_file',
-  'send_file',
-  'execute_shell',
-];
+export { CATSCOMPANY_FULL_RUNTIME_DEVICE_CAPABILITIES } from '../tools/device-rpc-registry';
 
 function shouldHideCatsToolProgress(toolName: string): boolean {
   return HIDDEN_CATS_TOOL_PROGRESS.has(toolName);
@@ -166,7 +156,7 @@ export class CatsCompanyBot {
           installation_id: config.installationId || config.bodyId,
           owner_user_id: config.ownerUserId,
           status: 'online' as const,
-          capabilities: [...CATSCOMPANY_FULL_RUNTIME_DEVICE_CAPABILITIES],
+          capabilities: [...DEVICE_RPC_RUNTIME_CAPABILITIES],
         }
       : undefined;
 
@@ -185,7 +175,7 @@ export class CatsCompanyBot {
       installationId: config.installationId,
       deviceId: config.installationId || config.bodyId,
       ownerUserId: config.ownerUserId,
-      capabilities: [...CATSCOMPANY_FULL_RUNTIME_DEVICE_CAPABILITIES],
+      capabilities: [...DEVICE_RPC_RUNTIME_CAPABILITIES],
     });
     this.deviceRegistration = deviceRegistration;
 
@@ -355,9 +345,10 @@ export class CatsCompanyBot {
   }
 
   private async executeLocalDeviceRpcTool(request: CatsDeviceRpcMessage): Promise<ToolExecutionResult> {
-    const operation = this.normalizeDeviceRpcOperation(request.operation);
+    const operation = normalizeDeviceRpcOperation(request.operation);
     const toolName = String(request.tool_name || operation || '').trim();
-    if (!operation || !isRemoteDeviceRpcTool(toolName, operation)) {
+    const registration = operation ? getDeviceRpcToolRegistration(toolName, operation) : undefined;
+    if (!registration) {
       return {
         ok: false,
         errorCode: 'PERMISSION_DENIED',
@@ -365,43 +356,16 @@ export class CatsCompanyBot {
       };
     }
 
-    const context = this.buildDeviceRpcToolContext(request, operation);
+    const context = this.buildDeviceRpcToolContext(request, registration.operation, {
+      requiresChannel: registration.requiresChannel === true,
+    });
     const args = this.extractDeviceRpcToolArgs(request.payload);
-    let result: ToolExecutionResult;
-    switch (operation) {
-      case 'read_file':
-        result = await new ReadTool().execute(args, context);
-        break;
-      case 'resolve_common_directory':
-        result = resolveCommonDirectoryToolArgs(args);
-        break;
-      case 'glob':
-        result = await new GlobTool().execute(args, context);
-        break;
-      case 'grep':
-        result = await new GrepTool().execute(args, context);
-        break;
-      case 'write_file':
-        result = await new WriteTool().execute(args, context);
-        break;
-      case 'edit_file':
-        result = await new EditTool().execute(args, context);
-        break;
-      case 'execute_shell':
-        result = await new ShellTool().execute(args, context);
-        break;
-      default:
-        result = {
-          ok: false,
-          errorCode: 'PERMISSION_DENIED',
-          message: `Device RPC 不允许执行 ${operation}。`,
-        };
-    }
+    const result = await executeRegisteredDeviceRpcTool(registration, args, context);
 
     return annotateToolExecutionResultWithTargetContext(result, context, {
       toolName,
-      operation,
-      cwd: this.resolveDeviceRpcTargetContextCwd(operation, args, context.workingDirectory),
+      operation: registration.operation,
+      cwd: this.resolveDeviceRpcTargetContextCwd(registration.operation, args, context.workingDirectory),
     });
   }
 
@@ -418,6 +382,7 @@ export class CatsCompanyBot {
   private buildDeviceRpcToolContext(
     request: CatsDeviceRpcMessage,
     operation: DeviceGrantOperation,
+    options: { requiresChannel?: boolean } = {},
   ): ToolExecutionContext {
     const topicType = request.topic_type === 'group' || request.topic_type === 'p2p'
       ? request.topic_type
@@ -475,7 +440,7 @@ export class CatsCompanyBot {
       createdAt: now,
     };
     const workingDirectory = this.runtimeProfile?.workingDirectory || this.runtime?.profile?.workingDirectory || process.cwd();
-    return {
+    const context: ToolExecutionContext = {
       workingDirectory,
       workspaceRoot: workingDirectory,
       conversationHistory: [],
@@ -487,16 +452,23 @@ export class CatsCompanyBot {
       deviceGrants: [grant],
       deviceSelection,
     };
+    if (options.requiresChannel) {
+      context.channel = this.buildChannel(executionScope.topicId, {
+        sessionKey: executionScope.sessionKey,
+        senderId: executionScope.actorUserId,
+      });
+    }
+    return context;
   }
 
   private validateDeviceRpcToolRequest(request: CatsDeviceRpcMessage): { code: string; message: string } | undefined {
     const targetError = this.validateDeviceRpcTarget(request);
     if (targetError) return targetError;
 
-    const operation = this.normalizeDeviceRpcOperation(request.operation);
+    const operation = normalizeDeviceRpcOperation(request.operation);
     const toolName = String(request.tool_name || operation || '').trim();
-    if (!operation || !isRemoteDeviceRpcTool(toolName, operation)) {
-      return { code: 'unsupported_operation', message: 'Device RPC only allows read_file, resolve_common_directory, glob, grep, write_file, edit_file, and execute_shell.' };
+    if (!operation || !getDeviceRpcToolRegistration(toolName, operation)) {
+      return { code: 'unsupported_operation', message: `Device RPC only allows ${formatDeviceRpcAllowedToolList()}.` };
     }
 
     const requiredFields: Array<[keyof CatsDeviceRpcMessage, string]> = [
@@ -520,22 +492,6 @@ export class CatsCompanyBot {
     }
     if (typeof request.expires_at === 'number' && Date.now() > request.expires_at) {
       return { code: 'request_expired', message: 'Device RPC request has expired.' };
-    }
-    return undefined;
-  }
-
-  private normalizeDeviceRpcOperation(value: unknown): DeviceGrantOperation | undefined {
-    const operation = String(value || '').trim();
-    if (
-      operation === 'read_file'
-      || operation === 'resolve_common_directory'
-      || operation === 'glob'
-      || operation === 'grep'
-      || operation === 'write_file'
-      || operation === 'edit_file'
-      || operation === 'execute_shell'
-    ) {
-      return operation;
     }
     return undefined;
   }

--- a/src/tools/device-rpc-registry.ts
+++ b/src/tools/device-rpc-registry.ts
@@ -1,0 +1,157 @@
+import type { DeviceGrantOperation } from '../types/session-identity';
+import type { ToolRiskLevel } from '../types/tool';
+
+export type DeviceRpcToolName =
+  | 'read_file'
+  | 'resolve_common_directory'
+  | 'glob'
+  | 'grep'
+  | 'write_file'
+  | 'edit_file'
+  | 'send_file'
+  | 'execute_shell';
+
+export type DeviceRpcToolCategory =
+  | 'readonly'
+  | 'file_mutation'
+  | 'outbound'
+  | 'shell';
+
+export interface DeviceRpcToolRegistration {
+  toolName: DeviceRpcToolName;
+  operation: DeviceGrantOperation;
+  category: DeviceRpcToolCategory;
+  skipLocalConfirmationWhenRemoteAuthorized: boolean;
+  remoteConfirmationRisk: ToolRiskLevel;
+  requiresChannel?: boolean;
+}
+
+export const DEVICE_RPC_TOOL_REGISTRY: readonly DeviceRpcToolRegistration[] = [
+  {
+    toolName: 'read_file',
+    operation: 'read_file',
+    category: 'readonly',
+    skipLocalConfirmationWhenRemoteAuthorized: true,
+    remoteConfirmationRisk: 'low',
+  },
+  {
+    toolName: 'resolve_common_directory',
+    operation: 'resolve_common_directory',
+    category: 'readonly',
+    skipLocalConfirmationWhenRemoteAuthorized: true,
+    remoteConfirmationRisk: 'low',
+  },
+  {
+    toolName: 'glob',
+    operation: 'glob',
+    category: 'readonly',
+    skipLocalConfirmationWhenRemoteAuthorized: true,
+    remoteConfirmationRisk: 'low',
+  },
+  {
+    toolName: 'grep',
+    operation: 'grep',
+    category: 'readonly',
+    skipLocalConfirmationWhenRemoteAuthorized: true,
+    remoteConfirmationRisk: 'low',
+  },
+  {
+    toolName: 'write_file',
+    operation: 'write_file',
+    category: 'file_mutation',
+    skipLocalConfirmationWhenRemoteAuthorized: true,
+    remoteConfirmationRisk: 'low',
+  },
+  {
+    toolName: 'edit_file',
+    operation: 'edit_file',
+    category: 'file_mutation',
+    skipLocalConfirmationWhenRemoteAuthorized: true,
+    remoteConfirmationRisk: 'low',
+  },
+  {
+    toolName: 'send_file',
+    operation: 'send_file',
+    category: 'outbound',
+    skipLocalConfirmationWhenRemoteAuthorized: true,
+    remoteConfirmationRisk: 'low',
+    requiresChannel: true,
+  },
+  {
+    toolName: 'execute_shell',
+    operation: 'execute_shell',
+    category: 'shell',
+    skipLocalConfirmationWhenRemoteAuthorized: true,
+    remoteConfirmationRisk: 'high',
+  },
+] as const;
+
+const REGISTRY_BY_PAIR = new Map<string, DeviceRpcToolRegistration>(
+  DEVICE_RPC_TOOL_REGISTRY.map(registration => [
+    registryKey(registration.toolName, registration.operation),
+    registration,
+  ]),
+);
+
+const REGISTRY_BY_TOOL = new Map<string, DeviceRpcToolRegistration>(
+  DEVICE_RPC_TOOL_REGISTRY.map(registration => [registration.toolName, registration]),
+);
+
+const OPERATIONS = new Set<DeviceGrantOperation>(
+  DEVICE_RPC_TOOL_REGISTRY.map(registration => registration.operation),
+);
+
+export const CATSCOMPANY_FULL_RUNTIME_DEVICE_CAPABILITIES: readonly DeviceGrantOperation[] =
+  DEVICE_RPC_TOOL_REGISTRY.map(registration => registration.operation);
+
+export function getDeviceRpcToolRegistration(
+  toolName: string,
+  operation: DeviceGrantOperation,
+): DeviceRpcToolRegistration | undefined {
+  return REGISTRY_BY_PAIR.get(registryKey(toolName, operation));
+}
+
+export function getDeviceRpcToolRegistrationByToolName(
+  toolName: string,
+): DeviceRpcToolRegistration | undefined {
+  return REGISTRY_BY_TOOL.get(toolName);
+}
+
+export function isDeviceRpcTool(toolName: string, operation: DeviceGrantOperation): boolean {
+  return Boolean(getDeviceRpcToolRegistration(toolName, operation));
+}
+
+export function isDeviceRpcReadonlyTool(toolName: string, operation: DeviceGrantOperation): boolean {
+  return getDeviceRpcToolRegistration(toolName, operation)?.category === 'readonly';
+}
+
+export function isDeviceRpcOperation(operation: DeviceGrantOperation): boolean {
+  return OPERATIONS.has(operation);
+}
+
+export function normalizeDeviceRpcOperation(value: unknown): DeviceGrantOperation | undefined {
+  const operation = String(value || '').trim() as DeviceGrantOperation;
+  return OPERATIONS.has(operation) ? operation : undefined;
+}
+
+export function formatDeviceRpcAllowedToolList(): string {
+  return DEVICE_RPC_TOOL_REGISTRY.map(registration => registration.toolName).join(' / ');
+}
+
+export function formatDeviceRpcAllowedOperationList(): string {
+  return DEVICE_RPC_TOOL_REGISTRY.map(registration => registration.operation).join(' / ');
+}
+
+export function getDeviceRpcRemoteConfirmationReason(registration: DeviceRpcToolRegistration): string {
+  if (registration.category === 'shell') {
+    return '服务端已选定远程设备并下发 execute_shell device grant，命令由 Device RPC 直接转发。';
+  }
+  if (registration.category === 'outbound') {
+    return '服务端已选定远程设备并下发短期 device grant，文件外发由 Device RPC 在目标设备上执行。';
+  }
+  return '服务端已选定远程设备并下发短期 device grant，普通文件工具不需要本机二次确认。';
+}
+
+function registryKey(toolName: string, operation: DeviceGrantOperation): string {
+  return `${toolName}:${operation}`;
+}

--- a/src/tools/device-rpc-tool.ts
+++ b/src/tools/device-rpc-tool.ts
@@ -1,38 +1,40 @@
 import type { DeviceGrantOperation } from '../types/session-identity';
 import type { ToolErrorCode, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import type { ToolGatewayDecision } from './tool-gateway';
+import {
+  type DeviceRpcToolName,
+  formatDeviceRpcAllowedToolList,
+  getDeviceRpcToolRegistration,
+  isDeviceRpcReadonlyTool,
+  isDeviceRpcTool,
+} from './device-rpc-registry';
 
 const REMOTE_TOOL_TIMEOUT_MS = 60_000;
 export const MAX_DEVICE_RPC_TOOL_CONTENT_CHARS = 48_000;
 
 export function isRemoteReadonlyTool(toolName: string, operation: DeviceGrantOperation): boolean {
-  return (toolName === 'read_file' && operation === 'read_file')
-    || (toolName === 'resolve_common_directory' && operation === 'resolve_common_directory')
-    || (toolName === 'glob' && operation === 'glob')
-    || (toolName === 'grep' && operation === 'grep');
+  return isDeviceRpcReadonlyTool(toolName, operation);
 }
 
 export function isRemoteDeviceRpcTool(toolName: string, operation: DeviceGrantOperation): boolean {
-  return isRemoteReadonlyTool(toolName, operation)
-    || (toolName === 'write_file' && operation === 'write_file')
-    || (toolName === 'edit_file' && operation === 'edit_file')
-    || (toolName === 'execute_shell' && operation === 'execute_shell');
+  return isDeviceRpcTool(toolName, operation);
 }
 
 export async function executeRemoteDeviceRpcTool(
   context: ToolExecutionContext,
   gateway: ToolGatewayDecision,
-  toolName: 'read_file' | 'resolve_common_directory' | 'glob' | 'grep' | 'write_file' | 'edit_file' | 'execute_shell',
+  toolName: DeviceRpcToolName,
   operation: DeviceGrantOperation,
   args: Record<string, unknown>,
 ): Promise<ToolExecutionResult | undefined> {
   if (!gateway.ok || gateway.mode !== 'remote') return undefined;
 
-  if (!isRemoteDeviceRpcTool(toolName, operation)) {
+  const registration = getDeviceRpcToolRegistration(toolName, operation);
+  if (!registration) {
     return {
       ok: false,
       errorCode: 'PERMISSION_DENIED',
-      message: `远程设备 RPC 当前只允许 read_file / resolve_common_directory / glob / grep / write_file / edit_file / execute_shell，已阻止 ${toolName}。普通文件任务请优先用 resolve_common_directory / glob / write_file，只有服务端授权后才使用 execute_shell。`,
+      message: `远程设备 RPC 当前只允许 ${formatDeviceRpcAllowedToolList()}，已阻止 ${toolName}。普通文件任务请优先用 resolve_common_directory / glob / write_file，只有服务端授权后才使用 execute_shell。`,
     };
   }
 

--- a/src/tools/local-tool-risk.ts
+++ b/src/tools/local-tool-risk.ts
@@ -1,6 +1,10 @@
 import type { DeviceGrantOperation } from '../types/session-identity';
 import type { ToolExecutionContext, ToolExecutionResult, ToolRiskLevel } from '../types/tool';
 import { isCatsCoAgentLocalBodyContext, isCatsCoLocalOwnerSelfContext, resolveToolGatewayAccess } from './tool-gateway';
+import {
+  getDeviceRpcRemoteConfirmationReason,
+  getDeviceRpcToolRegistrationByToolName,
+} from './device-rpc-registry';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -36,14 +40,6 @@ const CONFIRM_TOOLS = new Set([
   'spawn_subagent',
   'share_skillhub_skill',
 ]);
-
-const REMOTE_DEVICE_FILE_TOOL_OPERATIONS: Record<string, DeviceGrantOperation> = {
-  read_file: 'read_file',
-  glob: 'glob',
-  grep: 'grep',
-  write_file: 'write_file',
-  edit_file: 'edit_file',
-};
 
 export async function confirmLocalToolExecution(
   toolName: string,
@@ -103,12 +99,17 @@ export function classifyLocalToolRisk(
     return { requiresConfirmation: false, risk: 'low', reason: 'CatsCo 虚拟员工本机运行体允许直接执行本机工具。' };
   }
 
-  const remoteFileOperation = REMOTE_DEVICE_FILE_TOOL_OPERATIONS[toolName];
-  if (remoteFileOperation && isServerAuthorizedRemoteDeviceOperation(toolName, remoteFileOperation, context)) {
+  const remoteDeviceTool = getDeviceRpcToolRegistrationByToolName(toolName);
+  if (
+    remoteDeviceTool
+    && remoteDeviceTool.category !== 'shell'
+    && remoteDeviceTool.skipLocalConfirmationWhenRemoteAuthorized
+    && isServerAuthorizedRemoteDeviceOperation(toolName, remoteDeviceTool.operation, context)
+  ) {
     return {
       requiresConfirmation: false,
-      risk: 'low',
-      reason: '服务端已选定远程设备并下发短期 device grant，普通文件工具不需要本机二次确认。',
+      risk: remoteDeviceTool.remoteConfirmationRisk,
+      reason: getDeviceRpcRemoteConfirmationReason(remoteDeviceTool),
     };
   }
 
@@ -125,11 +126,16 @@ export function classifyLocalToolRisk(
 
   if (toolName === 'execute_shell') {
     const command = stringField(args, 'command') || stringField(args, 'cmd') || stringField(args, 'script');
-    if (isServerAuthorizedRemoteDeviceOperation(toolName, 'execute_shell', context)) {
+    const shellTool = getDeviceRpcToolRegistrationByToolName(toolName);
+    if (
+      shellTool
+      && shellTool.skipLocalConfirmationWhenRemoteAuthorized
+      && isServerAuthorizedRemoteDeviceOperation(toolName, shellTool.operation, context)
+    ) {
       return {
         requiresConfirmation: false,
-        risk: 'high',
-        reason: '服务端已选定远程设备并下发 execute_shell device grant，命令由 Device RPC 直接转发。',
+        risk: shellTool.remoteConfirmationRisk,
+        reason: getDeviceRpcRemoteConfirmationReason(shellTool),
       };
     }
     if (looksDangerousShell(command)) {

--- a/src/tools/send-file-tool.ts
+++ b/src/tools/send-file-tool.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import { Logger } from '../utils/logger';
 import { resolveToolPath } from '../utils/tool-path-resolver';
+import { executeRemoteDeviceRpcTool } from './device-rpc-tool';
 import { resolveLocalFileAccess, resolveLocalFileReference } from './local-file-gateway';
 import { resolveOutboundTarget } from './outbound-gateway';
 import { formatCatsCoVisiblePath, resolveToolGatewayAccess } from './tool-gateway';
@@ -115,6 +116,8 @@ export class SendFileTool implements Tool {
           message: gateway.message,
         };
       }
+      const remoteResult = await executeRemoteDeviceRpcTool(context, gateway, 'send_file', 'send_file', args);
+      if (remoteResult) return remoteResult;
       displayPath = formatCatsCoVisiblePath(context, displayPath, { preserveRelative: true });
       visibleInputPath = displayPath;
     }

--- a/src/tools/tool-gateway.ts
+++ b/src/tools/tool-gateway.ts
@@ -1,6 +1,7 @@
 import type { DeviceGrantOperation, ScopedDeviceGrant, ScopedDeviceSelection, ScopedLocalDeviceGrant } from '../types/session-identity';
 import type { ToolErrorCode, ToolExecutionContext } from '../types/tool';
 import { isDelegatedDeviceGrant, resolveDeviceGrant } from '../core/device-grants';
+import { formatDeviceRpcAllowedOperationList, isDeviceRpcOperation } from './device-rpc-registry';
 
 export type ToolGatewayDecision =
   | {
@@ -32,16 +33,6 @@ export interface CatsCoVisiblePathOptions {
   fallback?: string;
   preserveRelative?: boolean;
 }
-
-const REMOTE_DEVICE_RPC_OPERATIONS = new Set<DeviceGrantOperation>([
-  'read_file',
-  'resolve_common_directory',
-  'glob',
-  'grep',
-  'write_file',
-  'edit_file',
-  'execute_shell',
-]);
 
 export function isCatsCoToolGatewayContext(context: ToolExecutionContext): boolean {
   return context.surface === 'catscompany' || context.executionScope?.source === 'catscompany';
@@ -172,10 +163,10 @@ export function resolveToolGatewayAccess(
 
   const grant = decision.grant;
   if (selectedTarget.mode === 'remote') {
-    if (!REMOTE_DEVICE_RPC_OPERATIONS.has(options.operation)) {
+    if (!isDeviceRpcOperation(options.operation)) {
       return denied([
         `后端选定的用户设备不是当前运行体，但 ${options.operation} 还没有开放远程执行。`,
-        '当前只开放 read_file / resolve_common_directory / glob / grep / write_file / edit_file 远程工具。',
+        `当前只开放 ${formatDeviceRpcAllowedOperationList()} 远程工具。`,
         '如需查看目录文件请使用 glob；如需创建或覆盖文本文件请使用 write_file。',
       ], options.targetLabel);
     }

--- a/tests/catscompany-device-rpc-tools.test.ts
+++ b/tests/catscompany-device-rpc-tools.test.ts
@@ -69,7 +69,7 @@ function serverGrant(overrides: Partial<ScopedDeviceGrant> = {}): ScopedDeviceGr
     actorUserId: 'usr7',
     agentId: 'usr43',
     agentBodyId: 'body-agent',
-    operations: ['read_file', 'resolve_common_directory', 'glob', 'grep', 'execute_shell'],
+    operations: ['read_file', 'resolve_common_directory', 'glob', 'grep', 'write_file', 'edit_file', 'send_file', 'execute_shell'],
     createdAt: Date.now(),
     expiresAt: Date.now() + 60_000,
     ...overrides,
@@ -138,23 +138,32 @@ describe('CatsCompany Device RPC file tools', () => {
       args: { command: 'echo remote-shell' },
       grant,
     });
+    const send = await transport.executeTool({
+      toolName: 'send_file',
+      operation: 'send_file',
+      args: { file_path: 'C:\\Users\\Speaker\\Desktop\\report.jpg', file_name: 'report.jpg' },
+      grant,
+    });
 
     assert.equal(read.ok, true);
     assert.equal(glob.ok, true);
     assert.equal(resolveDir.ok, true);
     assert.equal(grep.ok, true);
     assert.equal(shell.ok, true);
+    assert.equal(send.ok, true);
     assert.equal(read.ok ? read.content : '', 'remote read_file');
     assert.equal(glob.ok ? glob.content : '', 'remote glob');
     assert.equal(resolveDir.ok ? resolveDir.content : '', 'remote resolve_common_directory');
     assert.equal(grep.ok ? grep.content : '', 'remote grep');
     assert.equal(shell.ok ? shell.content : '', 'remote execute_shell');
+    assert.equal(send.ok ? send.content : '', 'remote send_file');
     assert.deepEqual(captured.map(item => [item.request.tool_name, item.request.operation]), [
       ['read_file', 'read_file'],
       ['glob', 'glob'],
       ['resolve_common_directory', 'resolve_common_directory'],
       ['grep', 'grep'],
       ['execute_shell', 'execute_shell'],
+      ['send_file', 'send_file'],
     ]);
 
     const first = captured[0].request;
@@ -260,6 +269,37 @@ describe('CatsCompany Device RPC file tools', () => {
     assert.equal(fs.readFileSync(filePath, 'utf8'), 'after');
   });
 
+  test('executes send_file on the target local device and sends to the current topic', async () => {
+    const captured: { result?: any; sent?: any } = {};
+    const bot = botWithDevice(captured);
+    bot.sender = {
+      sendFile: async (topic: string, filePath: string, fileName: string) => {
+        captured.sent = { topic, filePath, fileName };
+      },
+    };
+    const tmpRoot = path.join(process.cwd(), 'tmp');
+    fs.mkdirSync(tmpRoot, { recursive: true });
+    const dir = fs.mkdtempSync(path.join(tmpRoot, 'device-rpc-send-'));
+    const filePath = path.join(dir, 'preview.jpg');
+    fs.writeFileSync(filePath, 'image-bytes');
+
+    await bot.handleDeviceRpcRequest(request({
+      request_id: 'rpc-send-file-1',
+      operation: 'send_file',
+      tool_name: 'send_file',
+      payload: { args: { file_path: filePath, file_name: 'preview.jpg' } },
+    }));
+
+    assert.ok(captured.result);
+    assert.equal(captured.result.error, undefined);
+    assert.equal(captured.result.result.ok, true);
+    assert.deepEqual(captured.sent, {
+      topic: 'p2p_7_43',
+      filePath,
+      fileName: 'preview.jpg',
+    });
+  });
+
   test('rejects Device RPC requests missing owner identity', async () => {
     const captured: { result?: any } = {};
     const bot = botWithDevice(captured);
@@ -317,6 +357,23 @@ describe('CatsCompany Device RPC file tools', () => {
     assert.equal(captured.result.result, undefined);
     assert.equal(captured.result.error.code, 'invalid_request');
     assert.match(captured.result.error.message, /channel_identity_link/);
+  });
+
+  test('rejects Device RPC requests when tool name and operation do not match the registry', async () => {
+    const captured: { result?: any } = {};
+    const bot = botWithDevice(captured);
+
+    await bot.handleDeviceRpcRequest(request({
+      request_id: 'rpc-tool-operation-mismatch-1',
+      operation: 'read_file',
+      tool_name: 'write_file',
+      payload: { args: { file_path: path.join(process.cwd(), 'tmp', 'mismatch.txt') } },
+    }));
+
+    assert.ok(captured.result);
+    assert.equal(captured.result.result, undefined);
+    assert.equal(captured.result.error.code, 'unsupported_operation');
+    assert.match(captured.result.error.message, /Device RPC only allows/);
   });
 
   test('executes shell Device RPC operations on the selected local device', async () => {

--- a/tests/catscompany-runtime-device-capabilities.test.ts
+++ b/tests/catscompany-runtime-device-capabilities.test.ts
@@ -1,6 +1,12 @@
 import { describe, test } from 'node:test';
 import * as assert from 'node:assert';
 import { CATSCOMPANY_FULL_RUNTIME_DEVICE_CAPABILITIES } from '../src/catscompany';
+import {
+  DEVICE_RPC_TOOL_REGISTRY,
+  getDeviceRpcToolRegistration,
+  normalizeDeviceRpcOperation,
+} from '../src/tools/device-rpc-registry';
+import { isRemoteDeviceRpcTool } from '../src/tools/device-rpc-tool';
 
 describe('CatsCompany runtime device capabilities', () => {
   test('full runtime advertises local owner self capabilities', () => {
@@ -14,5 +20,27 @@ describe('CatsCompany runtime device capabilities', () => {
       'send_file',
       'execute_shell',
     ]);
+  });
+
+  test('Device RPC registry drives advertised capabilities and remote allowlist', () => {
+    assert.deepEqual(
+      CATSCOMPANY_FULL_RUNTIME_DEVICE_CAPABILITIES,
+      DEVICE_RPC_TOOL_REGISTRY.map(registration => registration.operation),
+    );
+
+    for (const registration of DEVICE_RPC_TOOL_REGISTRY) {
+      assert.equal(
+        getDeviceRpcToolRegistration(registration.toolName, registration.operation),
+        registration,
+      );
+      assert.equal(
+        normalizeDeviceRpcOperation(registration.operation),
+        registration.operation,
+      );
+      assert.equal(
+        isRemoteDeviceRpcTool(registration.toolName, registration.operation),
+        true,
+      );
+    }
   });
 });

--- a/tests/tool-gateway-catsco.test.ts
+++ b/tests/tool-gateway-catsco.test.ts
@@ -796,6 +796,72 @@ describe('CatsCo ToolGateway', () => {
     assert.equal(fs.readFileSync(path.join(root, 'local.txt'), 'utf8'), 'before');
   });
 
+  test('routes mobile channel send_file to the backend-selected remote device', async () => {
+    const root = makeWorkspace();
+    const missingLocalPath = path.join(root, 'missing-on-cloud.jpg');
+    const channelScope = scope({
+      actorUserId: 'usr100',
+      sessionKey: 'session:v2:catscompany:p2p:p2p_100_43:agent:usr43',
+      topicId: 'p2p_100_43',
+      deviceOwnerUserId: 'usr100',
+      deviceOwnerSource: 'channel_identity_link',
+      channelSource: 'weixin',
+    });
+    const calls: any[] = [];
+    const result = await new SendFileTool().execute({ file_path: missingLocalPath, file_name: 'preview.jpg' }, context(root, {
+      executionScope: channelScope,
+      localDeviceGrant: localDevice({
+        ownerUserId: 'usr9',
+        bodyId: 'cloud-body',
+        installationId: 'cloud-install',
+        deviceId: 'cloud-install',
+        capabilities: ['read_file', 'glob', 'grep', 'write_file', 'edit_file', 'send_file', 'execute_shell'],
+      }),
+      deviceGrants: [deviceGrant(['send_file'], {
+        grantId: 'speaker-send-grant',
+        identitySource: 'channel_identity_link',
+        deviceId: 'speaker-device',
+        deviceBodyId: 'speaker-body',
+        deviceInstallationId: 'speaker-install',
+        ownerUserId: 'usr100',
+        actorUserId: 'usr100',
+        sessionKey: channelScope.sessionKey,
+        topicId: channelScope.topicId,
+        topicType: channelScope.topicType,
+        agentId: channelScope.agentId,
+        agentBodyId: channelScope.agentBodyId,
+      })],
+      deviceSelection: deviceSelection({
+        sessionKey: channelScope.sessionKey,
+        topicId: channelScope.topicId,
+        topicType: channelScope.topicType,
+        actorUserId: channelScope.actorUserId,
+        agentId: channelScope.agentId,
+        selectedDeviceId: 'speaker-device',
+        selectedDeviceBodyId: 'speaker-body',
+        selectedDeviceInstallationId: 'speaker-install',
+        selectedDeviceDisplayName: 'Speaker Laptop',
+        selectedDeviceOperations: ['send_file'],
+      }),
+      deviceRpc: {
+        executeTool: async request => {
+          calls.push(request);
+          return { ok: true, content: 'remote send ok' };
+        },
+      },
+    }));
+
+    assert.equal(result.ok, true);
+    assert.equal(result.ok ? result.content : '', 'remote send ok');
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].toolName, 'send_file');
+    assert.equal(calls[0].operation, 'send_file');
+    assert.deepEqual(calls[0].args, { file_path: missingLocalPath, file_name: 'preview.jpg' });
+    assert.equal(calls[0].grant.ownerUserId, 'usr100');
+    assert.equal(calls[0].grant.deviceId, 'speaker-device');
+    assert.equal(fs.existsSync(missingLocalPath), false);
+  });
+
   test('allows execute_shell for local owner self on the current device', async () => {
     const root = makeWorkspace();
     const result = await new ShellTool().execute({ command: 'echo catsco-shell-ok' }, context(root, {

--- a/tests/tool-manager.test.ts
+++ b/tests/tool-manager.test.ts
@@ -679,7 +679,7 @@ describe('ToolManager', () => {
     const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-catsco-remote-file-'));
     const manager = new ToolManager(workspace, {}, { enabledToolNames: [] });
     const executed: string[] = [];
-    const operations: ScopedDeviceGrant['operations'] = ['read_file', 'glob', 'grep', 'write_file', 'edit_file'];
+    const operations: ScopedDeviceGrant['operations'] = ['read_file', 'glob', 'grep', 'write_file', 'edit_file', 'send_file'];
     for (const operation of operations) {
       manager.registerTool(fakeTool(operation, async () => {
         executed.push(operation);
@@ -773,6 +773,14 @@ describe('ToolManager', () => {
         arguments: JSON.stringify({ file_path: 'C:\\Users\\Alice\\Desktop\\note.txt', old_string: 'hello', new_string: 'hi' }),
       },
     }, [], remoteContext);
+    const send = await manager.executeTool({
+      id: 'call-remote-send',
+      type: 'function',
+      function: {
+        name: 'send_file',
+        arguments: JSON.stringify({ file_path: 'C:\\Users\\Alice\\Desktop\\preview.jpg', file_name: 'preview.jpg' }),
+      },
+    }, [], remoteContext);
 
     assert.equal(read.ok, true);
     assert.equal(read.content, 'remote read_file requested');
@@ -784,6 +792,8 @@ describe('ToolManager', () => {
     assert.equal(grep.content, 'remote grep requested');
     assert.equal(edit.ok, true);
     assert.equal(edit.content, 'remote edit_file requested');
+    assert.equal(send.ok, true);
+    assert.equal(send.content, 'remote send_file requested');
     assert.deepEqual(executed, operations);
     assert.equal(confirmations, 0);
   });


### PR DESCRIPTION
## Summary

- Add a centralized Device RPC tool registry that defines tool/operation pairs, categories, remote confirmation behavior, and channel requirements.
- Derive CatsCo runtime device capabilities, gateway remote allowlist, Device RPC helper validation, and local confirmation bypass rules from the registry.
- Move target-device local RPC execution into a dedicated executor map and wire `send_file` through Device RPC with an explicit channel requirement.

## Why

The previous Device RPC mechanism repeated the same tool list across capabilities, gateway routing, RPC validation, target-device dispatch, and local confirmation risk handling. That drift already showed up with `send_file`: CatsCo advertised it as a device capability, but the RPC path did not consistently allow or execute it.

## Safety Notes

- The registry does not bypass existing trust checks: server-canonical identity, device selection, grants, owner/delegation, expiry, and target-device matching remain in place.
- `tool_name` and `operation` must match the same registry entry before a target device executes a request.
- `send_file` is modeled as an outbound side-effect tool with `requiresChannel`, so the target device constructs the current topic channel before sending.

## Validation

- `npm.cmd run build`
- `node node_modules\\tsx\\dist\\cli.mjs --test tests\\catscompany-runtime-device-capabilities.test.ts tests\\catscompany-device-rpc-tools.test.ts tests\\tool-gateway-catsco.test.ts tests\\tool-manager.test.ts`
- `node node_modules\\tsx\\dist\\cli.mjs --test tests\\device-grants.test.ts tests\\local-file-gateway.test.ts tests\\outbound-gateway.test.ts tests\\catscompany-execution-scope-flow.test.ts tests\\tool-result-read-file-local-grants.test.ts tests\\tool-result-send-file-tool.test.ts`

## Review

A sub-agent reviewed the mechanism and recommended using a capability matrix rather than a plain whitelist, keeping all existing security boundaries, and treating `send_file` as a channel-bound outbound tool. This PR follows that shape.