### PR TITLE
[codex] Hide mobile bridge tool progress

### DIFF
--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -783,7 +783,7 @@ export class CatsCompanyBot {
         await this.handleSubAgentFeedback(key, msg.topic, msg.senderId, text, msg.executionScope);
       },
       onSubAgentEvent: async (event: any, info?: SubAgentInfo) => {
-        await this.handleSubAgentRuntimeEvent(msg.topic, event, info);
+        await this.handleSubAgentRuntimeEvent(msg.topic, event, info, msg.executionScope?.channelSource);
       },
     } as any);
 
@@ -1132,9 +1132,14 @@ export class CatsCompanyBot {
     topic: string,
     event: any,
     info?: SubAgentInfo,
+    channelSource?: string,
   ): Promise<void> {
     const subAgentId = String(event?.subAgentId || info?.id || '');
     if (!subAgentId) return;
+
+    if (shouldSuppressStructuredToolProgress(channelSource)) {
+      return;
+    }
 
     const displayName = String(event?.subAgentName || (info as any)?.displayName || subAgentId.slice(0, 12));
     const toolUseId = `subagent:${subAgentId}`;

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -85,8 +85,11 @@ const HIDDEN_CATS_TOOL_PROGRESS = new Set([
   'spawn_subagent',
 ]);
 const STRUCTURED_TOOL_PROGRESS_UNSUPPORTED_CHANNELS = new Set([
+  'clawbot',
   'mobile',
+  'wechat_clawbot',
   'wechat',
+  'weixin_clawbot',
   'weixin',
   'wx',
 ]);

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -79,6 +79,12 @@ const HIDDEN_CATS_TOOL_PROGRESS = new Set([
   'send_file',
   'spawn_subagent',
 ]);
+const STRUCTURED_TOOL_PROGRESS_UNSUPPORTED_CHANNELS = new Set([
+  'mobile',
+  'wechat',
+  'weixin',
+  'wx',
+]);
 const SUBAGENT_TERMINAL_EVENTS = new Set(['agent_completed', 'agent_failed', 'agent_stopped']);
 export const CATSCOMPANY_FULL_RUNTIME_DEVICE_CAPABILITIES: DeviceGrantOperation[] = [
   'read_file',
@@ -93,6 +99,12 @@ export const CATSCOMPANY_FULL_RUNTIME_DEVICE_CAPABILITIES: DeviceGrantOperation[
 
 function shouldHideCatsToolProgress(toolName: string): boolean {
   return HIDDEN_CATS_TOOL_PROGRESS.has(toolName);
+}
+
+function shouldSuppressStructuredToolProgress(channelSource?: string): boolean {
+  const normalized = String(channelSource || '').trim().toLowerCase();
+  if (!normalized) return false;
+  return STRUCTURED_TOOL_PROGRESS_UNSUPPORTED_CHANNELS.has(normalized);
 }
 
 export function isCatsCompanyPassiveAcknowledgement(text: string): boolean {
@@ -640,7 +652,11 @@ export class CatsCompanyBot {
     return channel;
   }
 
-  private buildSessionCallbacks(topic: string, opts?: { sessionKey?: string; senderId?: string }): SessionCallbacks {
+  private buildSessionCallbacks(
+    topic: string,
+    opts?: { sessionKey?: string; senderId?: string; channelSource?: string },
+  ): SessionCallbacks {
+    const suppressToolProgress = shouldSuppressStructuredToolProgress(opts?.channelSource);
     return {
       onRetry: async (attempt, maxRetries) => {
         try {
@@ -665,7 +681,7 @@ export class CatsCompanyBot {
       },
       onToolStart: async (toolName: string, toolUseId: string, input: any) => {
         // 跳过输出型工具的 WORKING 消息
-        if (shouldHideCatsToolProgress(toolName)) {
+        if (suppressToolProgress || shouldHideCatsToolProgress(toolName)) {
           return;
         }
         try {
@@ -676,7 +692,7 @@ export class CatsCompanyBot {
       },
       onToolEnd: async (toolName: string, toolUseId: string, result: string) => {
         // 跳过输出型工具的 WORKING 消息
-        if (shouldHideCatsToolProgress(toolName)) {
+        if (suppressToolProgress || shouldHideCatsToolProgress(toolName)) {
           return;
         }
         try {
@@ -887,7 +903,11 @@ export class CatsCompanyBot {
         localFileGrants,
         runtimeFeedback,
         pendingUserInputProvider: () => this.consumeQueuedUserInput(key, msg.executionScope),
-        callbacks: this.buildSessionCallbacks(msg.topic, { sessionKey: key, senderId: msg.senderId }),
+        callbacks: this.buildSessionCallbacks(msg.topic, {
+          sessionKey: key,
+          senderId: msg.senderId,
+          channelSource: msg.executionScope?.channelSource,
+        }),
       });
 
       // 最终文本回复
@@ -1048,7 +1068,11 @@ export class CatsCompanyBot {
     try {
       const result = await session.handleRuntimeObservation(text, {
         channel,
-        callbacks: this.buildSessionCallbacks(topic),
+        callbacks: this.buildSessionCallbacks(topic, {
+          sessionKey,
+          senderId,
+          channelSource: executionScope?.channelSource,
+        }),
         source: 'subagent_result',
         executionScope,
         localDeviceGrant: this.localDeviceGrant,
@@ -1253,7 +1277,11 @@ export class CatsCompanyBot {
       const result = msg.source === 'subagent_feedback'
         ? await session.handleRuntimeObservation(msg.userMessage as string, {
           channel,
-          callbacks: this.buildSessionCallbacks(msg.topic, { sessionKey, senderId: msg.senderId }),
+          callbacks: this.buildSessionCallbacks(msg.topic, {
+            sessionKey,
+            senderId: msg.senderId,
+            channelSource: msg.executionScope?.channelSource,
+          }),
           source: 'subagent_result',
           executionScope: msg.executionScope,
           localDeviceGrant: this.localDeviceGrant,
@@ -1270,7 +1298,11 @@ export class CatsCompanyBot {
           runtimeFeedback: msg.runtimeFeedback,
           localFileGrants: msg.localFileGrants,
           pendingUserInputProvider: () => this.consumeQueuedUserInput(sessionKey, msg.executionScope),
-          callbacks: this.buildSessionCallbacks(msg.topic, { sessionKey, senderId: msg.senderId }),
+          callbacks: this.buildSessionCallbacks(msg.topic, {
+            sessionKey,
+            senderId: msg.senderId,
+            channelSource: msg.executionScope?.channelSource,
+          }),
         });
       if (result.text.startsWith('处理消息时出错:')) {
         try {

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -70,6 +70,11 @@ interface QueuedMessage {
   runtimeFeedback?: RuntimeFeedbackInput[];
 }
 
+interface SubAgentEventRoute {
+  topic: string;
+  channelSource?: string;
+}
+
 const PENDING_ANSWER_TIMEOUT_MS = 120_000;
 const TYPING_HEARTBEAT_INTERVAL_MS = 5_000;
 const DEVICE_REGISTRATION_REFRESH_MS = 120_000;
@@ -152,6 +157,8 @@ export class CatsCompanyBot {
   private pendingAttachments = new Map<string, PendingAttachment[]>();
   /** 主会话忙时的消息队列，key = sessionKey */
   private messageQueue = new Map<string, QueuedMessage[]>();
+  /** 子 Agent 事件应沿用 spawn 时的通道能力，不能被同 session 后续消息覆盖 */
+  private subAgentEventRoutes = new Map<string, SubAgentEventRoute>();
   /** Bot 自身的 uid，用于过滤自己发出的消息 */
   private botUid: string | null = null;
   private runtime: AdapterRuntimeBundle;
@@ -1156,7 +1163,19 @@ export class CatsCompanyBot {
     const subAgentId = String(event?.subAgentId || info?.id || '');
     if (!subAgentId) return;
 
-    if (shouldSuppressStructuredToolProgress(channelSource)) {
+    const eventType = String(event?.type || '');
+    if (eventType === 'agent_spawned') {
+      this.subAgentEventRoutes.set(subAgentId, { topic, channelSource });
+    }
+    const route = this.subAgentEventRoutes.get(subAgentId);
+    const eventTopic = route?.topic || topic;
+    const eventChannelSource = route ? route.channelSource : channelSource;
+    const isTerminalEvent = SUBAGENT_TERMINAL_EVENTS.has(eventType);
+
+    if (shouldSuppressStructuredToolProgress(eventChannelSource)) {
+      if (isTerminalEvent) {
+        this.subAgentEventRoutes.delete(subAgentId);
+      }
       return;
     }
 
@@ -1166,7 +1185,7 @@ export class CatsCompanyBot {
 
     try {
       if (event?.type === 'agent_spawned') {
-        await this.sender.sendToolUse(topic, toolUseId, displayName, {
+        await this.sender.sendToolUse(eventTopic, toolUseId, displayName, {
           kind: 'subagent',
           subagent_id: subAgentId,
           display_name: displayName,
@@ -1190,12 +1209,13 @@ export class CatsCompanyBot {
           info?.outputFiles?.length ? `产出文件:\n${info.outputFiles.map(file => `- ${file}`).join('\n')}` : '',
         ].filter(Boolean).join('\n');
         await this.sender.sendToolResult(
-          topic,
+          eventTopic,
           toolUseId,
           summary,
           event.type === 'agent_failed',
           this.subAgentEventMetadata(event, info, status),
         );
+        this.subAgentEventRoutes.delete(subAgentId);
         return;
       }
 
@@ -1205,7 +1225,7 @@ export class CatsCompanyBot {
 
       if (event?.summary) {
         await this.sender.sendThinking(
-          topic,
+          eventTopic,
           `[${displayName}] ${event.summary}`,
           this.subAgentEventMetadata(event, info, status),
         );
@@ -1454,6 +1474,7 @@ export class CatsCompanyBot {
     this.pendingAnswerBySession.clear();
     this.pendingAttachments.clear();
     this.messageQueue.clear();
+    this.subAgentEventRoutes.clear();
     Logger.info('CatsCo agent 已停止');
   }
 

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -615,9 +615,11 @@ export class CatsCompanyBot {
     opts?: {
       sessionKey?: string;
       senderId?: string;
+      channelSource?: string;
     },
   ): ChannelCallbacks & { hasOutbound: boolean } {
     let _hasOutbound = false;
+    const suppressStructuredProgress = shouldSuppressStructuredToolProgress(opts?.channelSource);
     const channel: ChannelCallbacks & { hasOutbound: boolean } = {
       chatId: topic,
       get hasOutbound() { return _hasOutbound; },
@@ -640,6 +642,9 @@ export class CatsCompanyBot {
         }
       },
       sendRuntimePlan: async (_targetTopic, snapshot) => {
+        if (suppressStructuredProgress) {
+          return;
+        }
         try {
           await this.sender.sendRuntimePlan(topic, snapshot);
         } catch (err: any) {
@@ -673,6 +678,9 @@ export class CatsCompanyBot {
         }
       },
       onThinking: async (thinking: string) => {
+        if (suppressToolProgress) {
+          return;
+        }
         try {
           await this.sender.sendThinking(topic, thinking);
         } catch (err: any) {
@@ -772,20 +780,25 @@ export class CatsCompanyBot {
     await this.processParsedMessage(msg, key);
   }
 
+  private registerSubAgentPlatformCallbacks(
+    sessionKey: string,
+    topic: string,
+    senderId: string,
+    executionScope?: ParsedCatsMessage['executionScope'],
+  ): void {
+    SubAgentManager.getInstance().registerPlatformCallbacks(sessionKey, {
+      injectMessage: async (text: string) => {
+        await this.handleSubAgentFeedback(sessionKey, topic, senderId, text, executionScope);
+      },
+      onSubAgentEvent: async (event: any, info?: SubAgentInfo) => {
+        await this.handleSubAgentRuntimeEvent(topic, event, info, executionScope?.channelSource);
+      },
+    } as any);
+  }
+
   private async processParsedMessage(msg: ParsedCatsMessage, key: string): Promise<void> {
     const sessionRoute = msg.envelope ? createCatsCoSessionRoute(msg.envelope) : undefined;
     const session = this.sessionManager.getOrCreate(sessionRoute && sessionRoute.sessionKey === key ? sessionRoute : key);
-
-    // 注册持久化回调到 SubAgentManager
-    const subAgentManager = SubAgentManager.getInstance();
-    subAgentManager.registerPlatformCallbacks(key, {
-      injectMessage: async (text: string) => {
-        await this.handleSubAgentFeedback(key, msg.topic, msg.senderId, text, msg.executionScope);
-      },
-      onSubAgentEvent: async (event: any, info?: SubAgentInfo) => {
-        await this.handleSubAgentRuntimeEvent(msg.topic, event, info, msg.executionScope?.channelSource);
-      },
-    } as any);
 
     // 处理斜杠命令
     if (typeof msg.text === 'string' && msg.text.startsWith('/')) {
@@ -883,10 +896,13 @@ export class CatsCompanyBot {
       return;
     }
 
+    this.registerSubAgentPlatformCallbacks(key, msg.topic, msg.senderId, msg.executionScope);
+
     // 构建通道回调，通过 context 传递给工具（替代 bind/unbind）
     const channel = this.buildChannel(msg.topic, {
       sessionKey: key,
       senderId: msg.senderId,
+      channelSource: msg.executionScope?.channelSource,
     });
 
     const stopTypingHeartbeat = this.startTypingHeartbeat(msg.topic);
@@ -1052,9 +1068,12 @@ export class CatsCompanyBot {
       return;
     }
 
+    this.registerSubAgentPlatformCallbacks(sessionKey, topic, senderId, executionScope);
+
     const channel = this.buildChannel(topic, {
       sessionKey,
       senderId,
+      channelSource: executionScope?.channelSource,
     });
 
     const stopTypingHeartbeat = this.startTypingHeartbeat(topic);
@@ -1271,9 +1290,11 @@ export class CatsCompanyBot {
     }
 
     const session = this.sessionManager.getOrCreate(sessionKey);
+    this.registerSubAgentPlatformCallbacks(sessionKey, msg.topic, msg.senderId, msg.executionScope);
     const channel = this.buildChannel(msg.topic, {
       sessionKey,
       senderId: msg.senderId,
+      channelSource: msg.executionScope?.channelSource,
     });
 
     const stopTypingHeartbeat = this.startTypingHeartbeat(msg.topic);

--- a/tests/catscompany-content-blocks.test.ts
+++ b/tests/catscompany-content-blocks.test.ts
@@ -799,6 +799,52 @@ describe('CatsCo content blocks', () => {
     assert.match(toolResults[0].content, /logs\/report\.md/);
   });
 
+  test('subagent runtime events are suppressed for Weixin mobile bridge channels', async () => {
+    const { bot, sentThinking, toolUses, toolResults } = createProcessHarness();
+    const now = Date.now();
+    const info = {
+      id: 'sub-1',
+      skillName: 'explorer',
+      taskDescription: '扫描桌面文件',
+      status: 'running',
+      createdAt: now,
+      progressLog: [],
+      outputFiles: [],
+    };
+
+    await bot.handleSubAgentRuntimeEvent('p2p_1_2', {
+      subAgentId: 'sub-1',
+      subAgentName: '子agent1',
+      type: 'agent_spawned',
+      timestamp: now,
+      summary: '派遣子agent1 扫描桌面文件',
+    }, info, 'weixin');
+
+    await bot.handleSubAgentRuntimeEvent('p2p_1_2', {
+      subAgentId: 'sub-1',
+      subAgentName: '子agent1',
+      type: 'agent_progress',
+      timestamp: now + 1,
+      summary: '开始执行：扫描桌面文件',
+    }, info, 'weixin');
+
+    await bot.handleSubAgentRuntimeEvent('p2p_1_2', {
+      subAgentId: 'sub-1',
+      subAgentName: '子agent1',
+      type: 'agent_completed',
+      timestamp: now + 2,
+      summary: '完成',
+    }, {
+      ...info,
+      status: 'completed',
+      resultSummary: '桌面文件扫描完成',
+    }, 'weixin');
+
+    assert.deepStrictEqual(toolUses, []);
+    assert.deepStrictEqual(toolResults, []);
+    assert.deepStrictEqual(sentThinking, []);
+  });
+
   test('subagent feedback visible reply is sent back to CatsCompany', async () => {
     const { bot, runtimeObservations, replies, sentThinking, session } = createProcessHarness();
     session.handleRuntimeObservation = async (text: string, options: any) => {

--- a/tests/catscompany-content-blocks.test.ts
+++ b/tests/catscompany-content-blocks.test.ts
@@ -663,6 +663,71 @@ describe('CatsCo content blocks', () => {
     assert.deepStrictEqual(replies, [{ topic: 'p2p_1_2', text: '我先看一下桌面。' }]);
   });
 
+  test('suppresses structured progress for Weixin ClawBot bridge channels', async () => {
+    const { bot, handledTurns, replies, sentThinking, toolUses, toolResults, runtimePlans } = createProcessHarness();
+
+    await (bot as any).onMessage({
+      topic: 'p2p_1_2',
+      senderId: 'usr1',
+      text: '你帮我看一下我的桌面有什么文件吧',
+      content: '你帮我看一下我的桌面有什么文件吧',
+      metadata: canonicalMetadata('usr1', 'p2p_1_2', 'usr43', 'body-main', 'weixin_clawbot'),
+      isGroup: false,
+      seq: 16,
+    });
+
+    assert.strictEqual(handledTurns[0].options.executionScope.channelSource, 'weixin_clawbot');
+    const callbacks = handledTurns[0].options.callbacks;
+    await callbacks.onToolStart('glob', 'call_glob', { pattern: '*', path: 'C:\\Users\\me\\Desktop' });
+    await callbacks.onToolEnd('glob', 'call_glob', '找到 12 个文件 (14ms):\n\n  1. desktop.ini');
+    await callbacks.onThinking('正在压缩上下文。');
+    await handledTurns[0].options.channel.sendRuntimePlan('p2p_1_2', {
+      revision: 1,
+      updatedAt: Date.now(),
+      steps: [{ text: '查看桌面文件', status: 'in_progress' }],
+    });
+    await callbacks.onAssistantText('我先看一下桌面。');
+
+    const now = Date.now();
+    await bot.handleSubAgentRuntimeEvent('p2p_1_2', {
+      subAgentId: 'sub-clawbot',
+      subAgentName: '子agent1',
+      type: 'agent_spawned',
+      timestamp: now,
+      summary: '派遣子agent1 扫描桌面文件',
+    }, {
+      id: 'sub-clawbot',
+      skillName: 'explorer',
+      taskDescription: '扫描桌面文件',
+      status: 'running',
+      createdAt: now,
+      progressLog: [],
+      outputFiles: [],
+    }, 'weixin_clawbot');
+    await bot.handleSubAgentRuntimeEvent('p2p_1_2', {
+      subAgentId: 'sub-clawbot',
+      subAgentName: '子agent1',
+      type: 'agent_completed',
+      timestamp: now + 1,
+      summary: '完成',
+    }, {
+      id: 'sub-clawbot',
+      skillName: 'explorer',
+      taskDescription: '扫描桌面文件',
+      status: 'completed',
+      createdAt: now,
+      progressLog: [],
+      outputFiles: [],
+      resultSummary: '桌面文件扫描完成',
+    });
+
+    assert.deepStrictEqual(toolUses, []);
+    assert.deepStrictEqual(toolResults, []);
+    assert.deepStrictEqual(sentThinking, []);
+    assert.deepStrictEqual(runtimePlans, []);
+    assert.deepStrictEqual(replies, [{ topic: 'p2p_1_2', text: '我先看一下桌面。' }]);
+  });
+
   test('busy queued native message does not overwrite active mobile subagent event suppression', async () => {
     const { bot, handledTurns, sentThinking, session } = createProcessHarness();
 

--- a/tests/catscompany-content-blocks.test.ts
+++ b/tests/catscompany-content-blocks.test.ts
@@ -107,6 +107,7 @@ function createProcessHarness() {
   bot.pendingAnswerBySession = new Map();
   bot.pendingAttachments = new Map();
   bot.messageQueue = new Map();
+  bot.subAgentEventRoutes = new Map();
   bot.botUid = 'usr43';
   bot.buildMultimodalMessage = async (text: string, attachments: any[]) => {
     multimodalCalls.push({ text, attachments });
@@ -884,7 +885,7 @@ describe('CatsCo content blocks', () => {
       type: 'agent_progress',
       timestamp: now + 1,
       summary: '开始执行：扫描桌面文件',
-    }, info, 'weixin');
+    }, info);
 
     await bot.handleSubAgentRuntimeEvent('p2p_1_2', {
       subAgentId: 'sub-1',
@@ -896,7 +897,7 @@ describe('CatsCo content blocks', () => {
       ...info,
       status: 'completed',
       resultSummary: '桌面文件扫描完成',
-    }, 'weixin');
+    });
 
     assert.deepStrictEqual(toolUses, []);
     assert.deepStrictEqual(toolResults, []);

--- a/tests/catscompany-content-blocks.test.ts
+++ b/tests/catscompany-content-blocks.test.ts
@@ -6,6 +6,7 @@ import * as path from 'node:path';
 import { CatsCompanyBot } from '../src/catscompany';
 import { extractContentBlocks } from '../src/catscompany/content-blocks';
 import { ConfigManager } from '../src/utils/config';
+import { SubAgentManager } from '../src/core/sub-agent-manager';
 
 const ONE_PIXEL_PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=';
 
@@ -56,6 +57,7 @@ function createProcessHarness() {
   const sentThinking: Array<{ topic: string; text: string; metadata?: any }> = [];
   const toolUses: Array<{ topic: string; toolUseId: string; name: string; input: any; metadata?: any }> = [];
   const toolResults: Array<{ topic: string; toolUseId: string; content: string; isError?: boolean; metadata?: any }> = [];
+  const runtimePlans: Array<{ topic: string; snapshot: any }> = [];
 
   const session = {
     isBusy: () => false,
@@ -97,6 +99,9 @@ function createProcessHarness() {
     sendToolResult: async (topic: string, toolUseId: string, content: string, isError?: boolean, metadata?: any) => {
       toolResults.push({ topic, toolUseId, content, isError, metadata });
     },
+    sendRuntimePlan: async (topic: string, snapshot: any) => {
+      runtimePlans.push({ topic, snapshot });
+    },
   };
   bot.pendingAnswers = new Map();
   bot.pendingAnswerBySession = new Map();
@@ -114,7 +119,7 @@ function createProcessHarness() {
     ];
   };
 
-  return { bot, downloads, multimodalCalls, handledTurns, runtimeObservations, sentTexts, replies, sentTyping, sentThinking, toolUses, toolResults, session };
+  return { bot, downloads, multimodalCalls, handledTurns, runtimeObservations, sentTexts, replies, sentTyping, sentThinking, toolUses, toolResults, runtimePlans, session };
 }
 
 describe('CatsCo content blocks', () => {
@@ -586,7 +591,7 @@ describe('CatsCo content blocks', () => {
   });
 
   test('sends structured tool progress on CatsCompany-native channels', async () => {
-    const { bot, handledTurns, toolUses, toolResults } = createProcessHarness();
+    const { bot, handledTurns, toolUses, toolResults, runtimePlans } = createProcessHarness();
 
     await (bot as any).onMessage({
       topic: 'p2p_1_2',
@@ -601,6 +606,11 @@ describe('CatsCo content blocks', () => {
     const callbacks = handledTurns[0].options.callbacks;
     await callbacks.onToolStart('glob', 'call_glob', { pattern: '*', path: 'C:\\Users\\me\\Desktop' });
     await callbacks.onToolEnd('glob', 'call_glob', '找到 1 个匹配文件:\n\n  1. desktop.ini');
+    await handledTurns[0].options.channel.sendRuntimePlan('p2p_1_2', {
+      revision: 1,
+      updatedAt: Date.now(),
+      steps: [{ text: '查看桌面文件', status: 'in_progress' }],
+    });
 
     assert.deepStrictEqual(
       toolUses.map(({ topic, toolUseId, name }) => ({ topic, toolUseId, name })),
@@ -610,10 +620,12 @@ describe('CatsCo content blocks', () => {
       toolResults.map(({ topic, toolUseId, content }) => ({ topic, toolUseId, content })),
       [{ topic: 'p2p_1_2', toolUseId: 'call_glob', content: '1. desktop.ini' }],
     );
+    assert.strictEqual(runtimePlans.length, 1);
+    assert.strictEqual(runtimePlans[0].topic, 'p2p_1_2');
   });
 
   test('suppresses structured tool progress for Weixin mobile bridge channels', async () => {
-    const { bot, handledTurns, replies, toolUses, toolResults } = createProcessHarness();
+    const { bot, handledTurns, replies, sentThinking, toolUses, toolResults, runtimePlans } = createProcessHarness();
 
     await (bot as any).onMessage({
       topic: 'p2p_1_2',
@@ -635,11 +647,57 @@ describe('CatsCo content blocks', () => {
     );
     await callbacks.onToolStart('glob', 'call_glob', { pattern: '*', path: 'C:\\Users\\me\\Desktop' });
     await callbacks.onToolEnd('glob', 'call_glob', '找到 12 个文件 (14ms):\n\n  1. desktop.ini');
+    await callbacks.onThinking('正在压缩上下文。');
+    await handledTurns[0].options.channel.sendRuntimePlan('p2p_1_2', {
+      revision: 1,
+      updatedAt: Date.now(),
+      steps: [{ text: '查看桌面文件', status: 'in_progress' }],
+    });
     await callbacks.onAssistantText('我先看一下桌面。');
 
     assert.deepStrictEqual(toolUses, []);
     assert.deepStrictEqual(toolResults, []);
+    assert.deepStrictEqual(sentThinking, []);
+    assert.deepStrictEqual(runtimePlans, []);
     assert.deepStrictEqual(replies, [{ topic: 'p2p_1_2', text: '我先看一下桌面。' }]);
+  });
+
+  test('busy queued native message does not overwrite active mobile subagent event suppression', async () => {
+    const { bot, handledTurns, sentThinking, session } = createProcessHarness();
+
+    await (bot as any).onMessage({
+      topic: 'p2p_1_2',
+      senderId: 'usr1',
+      text: '移动端发起一个需要子任务的请求',
+      content: '移动端发起一个需要子任务的请求',
+      metadata: canonicalMetadata('usr1', 'p2p_1_2', 'usr43', 'body-main', 'weixin'),
+      isGroup: false,
+      seq: 14,
+    });
+
+    const sessionKey = handledTurns[0].options.sessionRoute.sessionKey;
+    session.isBusy = () => true;
+
+    await (bot as any).onMessage({
+      topic: 'p2p_1_2',
+      senderId: 'usr1',
+      text: '网页端后来的同会话消息应该排队',
+      content: '网页端后来的同会话消息应该排队',
+      metadata: canonicalMetadata('usr1', 'p2p_1_2'),
+      isGroup: false,
+      seq: 15,
+    });
+
+    SubAgentManager.getInstance().recordEvent(
+      sessionKey,
+      'sub-mobile-active',
+      'agent_progress',
+      '开始执行：扫描桌面文件',
+    );
+    await new Promise(resolve => setTimeout(resolve, 0));
+    SubAgentManager.getInstance().unregisterPlatformCallbacks(sessionKey);
+
+    assert.deepStrictEqual(sentThinking, []);
   });
 
   test('queued CatsCompany turns keep working callbacks for compaction status', async () => {

--- a/tests/catscompany-content-blocks.test.ts
+++ b/tests/catscompany-content-blocks.test.ts
@@ -32,8 +32,9 @@ function createTempPng(name: string): { filePath: string; cleanup: () => void } 
   };
 }
 
-function canonicalMetadata(actorUserId: string, topicId: string, agentId = 'usr43', bodyId = 'body-main') {
+function canonicalMetadata(actorUserId: string, topicId: string, agentId = 'usr43', bodyId = 'body-main', channelSource?: string) {
   return {
+    ...(channelSource ? { source_channel: channelSource } : {}),
     catsco_identity: {
       actor: { user_id: actorUserId },
       agent: { agent_id: agentId, body_id: bodyId },
@@ -582,6 +583,63 @@ describe('CatsCo content blocks', () => {
       sentThinking.map(({ topic, text }) => ({ topic, text })),
       [{ topic: 'p2p_1_2', text: '纯文本压缩状态' }],
     );
+  });
+
+  test('sends structured tool progress on CatsCompany-native channels', async () => {
+    const { bot, handledTurns, toolUses, toolResults } = createProcessHarness();
+
+    await (bot as any).onMessage({
+      topic: 'p2p_1_2',
+      senderId: 'usr1',
+      text: '看一下桌面文件',
+      content: '看一下桌面文件',
+      metadata: canonicalMetadata('usr1', 'p2p_1_2'),
+      isGroup: false,
+      seq: 12,
+    });
+
+    const callbacks = handledTurns[0].options.callbacks;
+    await callbacks.onToolStart('glob', 'call_glob', { pattern: '*', path: 'C:\\Users\\me\\Desktop' });
+    await callbacks.onToolEnd('glob', 'call_glob', '找到 1 个匹配文件:\n\n  1. desktop.ini');
+
+    assert.deepStrictEqual(
+      toolUses.map(({ topic, toolUseId, name }) => ({ topic, toolUseId, name })),
+      [{ topic: 'p2p_1_2', toolUseId: 'call_glob', name: 'glob' }],
+    );
+    assert.deepStrictEqual(
+      toolResults.map(({ topic, toolUseId, content }) => ({ topic, toolUseId, content })),
+      [{ topic: 'p2p_1_2', toolUseId: 'call_glob', content: '1. desktop.ini' }],
+    );
+  });
+
+  test('suppresses structured tool progress for Weixin mobile bridge channels', async () => {
+    const { bot, handledTurns, replies, toolUses, toolResults } = createProcessHarness();
+
+    await (bot as any).onMessage({
+      topic: 'p2p_1_2',
+      senderId: 'usr1',
+      text: '你帮我看一下我的桌面有什么文件吧',
+      content: '你帮我看一下我的桌面有什么文件吧',
+      metadata: canonicalMetadata('usr1', 'p2p_1_2', 'usr43', 'body-main', 'weixin'),
+      isGroup: false,
+      seq: 13,
+    });
+
+    assert.strictEqual(handledTurns[0].options.executionScope.channelSource, 'weixin');
+    const callbacks = handledTurns[0].options.callbacks;
+    await callbacks.onToolStart('resolve_common_directory', 'call_resolve', { kind: 'desktop' });
+    await callbacks.onToolEnd(
+      'resolve_common_directory',
+      'call_resolve',
+      'Resolved common directory:\nkind: desktop\npath: C:\\Users\\me\\Desktop',
+    );
+    await callbacks.onToolStart('glob', 'call_glob', { pattern: '*', path: 'C:\\Users\\me\\Desktop' });
+    await callbacks.onToolEnd('glob', 'call_glob', '找到 12 个文件 (14ms):\n\n  1. desktop.ini');
+    await callbacks.onAssistantText('我先看一下桌面。');
+
+    assert.deepStrictEqual(toolUses, []);
+    assert.deepStrictEqual(toolResults, []);
+    assert.deepStrictEqual(replies, [{ topic: 'p2p_1_2', text: '我先看一下桌面。' }]);
   });
 
   test('queued CatsCompany turns keep working callbacks for compaction status', async () => {


### PR DESCRIPTION
## Summary
- Suppress CatsCompany structured working metadata on mobile/Weixin bridge channels that cannot render it safely, including `tool_use`, `tool_result`, `thinking`, and `runtime_plan` messages.
- Include ClawBot bridge source aliases (`weixin_clawbot`, `wechat_clawbot`, `clawbot`) alongside `mobile`, `wechat`, `weixin`, and `wx`, so backend `source_channel` values cannot leak raw structured progress.
- Preserve CatsCompany-native web behavior, where structured tool progress and runtime plan cards still render as working UI instead of chat text.
- Pin sub-agent runtime event routing to the channel that spawned the sub-agent, so later same-session messages cannot cause mobile or ClawBot sub-agent progress to leak through a web/native callback.
- Add regression coverage for native CatsCompany behavior, Weixin/mobile suppression, ClawBot suppression, runtime plan/thinking suppression, queued turns, and sub-agent event routing.

## Root cause
CatsCompany sends tool progress, thinking updates, runtime plan cards, and sub-agent lifecycle events as structured working metadata. The web app renders those blocks correctly, but Weixin/mobile bridge clients can degrade unsupported structured messages into normal chat bubbles, exposing internal tool names, raw tool results, or progress details to end users.

The ClawBot path is another bridge source: the backend records the real binding channel as `source_channel`, and ClawBot inbound messages use `weixin_clawbot`. Without treating that source as unsupported, the mobile ClawBot client could still receive raw `tool_use`, `tool_result`, `thinking`, or `runtime_plan` blocks.

A separate routing issue was that sub-agent runtime events were routed through a session-level callback. If a later message in the same session refreshed that callback, an older background sub-agent could inherit the wrong channel capabilities. The fix records each sub-agent event route at spawn time and uses that route for later progress and terminal events.

## User impact
Mobile/Weixin/ClawBot users should now only see user-facing assistant replies and explicit outbound content, not internal tool execution process messages. Web users keep the richer structured working UI.

## Validation
- `.\node_modules\.bin\tsx.cmd --test tests\catscompany-content-blocks.test.ts`
- `npm.cmd run build`

## Review follow-up
A sub-agent review found additional leak paths through `thinking`, `runtime_plan`, and sub-agent runtime event routing. Those are addressed in this PR.

A later reviewer found that ClawBot uses `source_channel: weixin_clawbot`, which was not in the unsupported bridge-channel set. The latest commit adds ClawBot aliases and a regression test covering tool progress, thinking, runtime plan, and sub-agent runtime event suppression for `weixin_clawbot`.