### PR TITLE
[codex] add linked truncated tool result artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ Thumbs.db
 
 # 本地 agent / IDE 生成配置
 .claude/
+.xiaoba/
 .kiro/
 .playwright-mcp/
 

--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -22,6 +22,7 @@ import {
   foldToolResultsTowardPromptBudget,
   resolveAdaptiveToolResultFoldingOptions,
 } from './adaptive-tool-result-folder';
+import { resolveToolResultArtifactStoreOptions } from './tool-result-artifact-store';
 import {
   buildExplicitPlanRequestHintIfUseful,
   buildInitialDecisionHintIfUseful,
@@ -382,15 +383,18 @@ export class ConversationRunner {
         requestMessages,
         currentRunToolResultFoldingOptions,
       );
+      const toolResultArtifactStoreOptions = this.resolveToolResultArtifactStoreOptions(turns);
       const readFileFoldingOptions = {
         ...resolveReadFileMessageFoldingOptions(),
         foldCurrentRun: currentRunToolResultFoldingOptions.enabled,
         protectedCurrentRunToolResultIndexes,
+        artifactStore: toolResultArtifactStoreOptions,
       };
       const executeShellFoldingOptions = {
         ...resolveExecuteShellMessageFoldingOptions(),
         foldCurrentRun: currentRunToolResultFoldingOptions.enabled,
         protectedCurrentRunToolResultIndexes,
+        artifactStore: toolResultArtifactStoreOptions,
       };
       const readFileFolding = foldHistoricalReadFileMessages(
         requestMessages,
@@ -399,8 +403,8 @@ export class ConversationRunner {
       requestMessages = readFileFolding.messages;
       if (readFileFolding.stats.folded_count > 0) {
         Logger.info(
-          `[${this.sessionLabel}Turn ${turns}] read_file folding: `
-          + `folded=${readFileFolding.stats.folded_count}, `
+          `[${this.sessionLabel}Turn ${turns}] read_file truncation: `
+          + `truncated=${readFileFolding.stats.folded_count}, `
           + `current=${readFileFolding.stats.folded_current_turn_count}, `
           + `saved≈${readFileFolding.stats.saved_tokens_est} tokens`,
         );
@@ -412,8 +416,8 @@ export class ConversationRunner {
       requestMessages = executeShellFolding.messages;
       if (executeShellFolding.stats.folded_count > 0) {
         Logger.info(
-          `[${this.sessionLabel}Turn ${turns}] execute_shell folding: `
-          + `folded=${executeShellFolding.stats.folded_count}, `
+          `[${this.sessionLabel}Turn ${turns}] execute_shell truncation: `
+          + `truncated=${executeShellFolding.stats.folded_count}, `
           + `current=${executeShellFolding.stats.folded_current_turn_count}, `
           + `saved≈${executeShellFolding.stats.saved_tokens_est} tokens`,
         );
@@ -428,9 +432,9 @@ export class ConversationRunner {
       requestMessages = adaptiveFolding.messages;
       if (adaptiveFolding.stats.folded_count > 0) {
         Logger.info(
-          `[${this.sessionLabel}Turn ${turns}] adaptive tool_result folding: `
+          `[${this.sessionLabel}Turn ${turns}] adaptive tool_result truncation: `
           + `passes=${adaptiveFolding.stats.passes}, `
-          + `folded=${adaptiveFolding.stats.folded_count}, `
+          + `truncated=${adaptiveFolding.stats.folded_count}, `
           + `current=${adaptiveFolding.stats.folded_current_turn_count}, `
           + `saved≈${adaptiveFolding.stats.saved_tokens_est} tokens, `
           + `prompt≈${adaptiveFolding.stats.started_prompt_tokens_est}->${adaptiveFolding.stats.finished_prompt_tokens_est}, `
@@ -1387,6 +1391,21 @@ export class ConversationRunner {
       ...options,
       targetPromptTokens: Math.min(options.targetPromptTokens, promptBudget),
     };
+  }
+
+  private resolveToolResultArtifactStoreOptions(turn: number) {
+    const workspaceRoot = this.toolExecutionContext?.workspaceRoot
+      || this.toolExecutionContext?.workingDirectory;
+    const defaultRoot = workspaceRoot
+      ? path.join(workspaceRoot, '.xiaoba', 'tool-results')
+      : undefined;
+    return resolveToolResultArtifactStoreOptions(process.env, {
+      enabled: Boolean(defaultRoot),
+      rootDirectory: defaultRoot,
+      sessionId: this.toolExecutionContext?.sessionId
+        || this.toolExecutionContext?.executionScope?.sessionKey,
+      turn,
+    });
   }
 
   private fitToolsToPromptBudget(tools: ToolDefinition[]): ToolDefinition[] {

--- a/src/core/execute-shell-message-folder.ts
+++ b/src/core/execute-shell-message-folder.ts
@@ -1,8 +1,14 @@
 import { createHash } from 'crypto';
 import { Message } from '../types';
 import { estimateTokens } from './token-estimator';
+import {
+  persistToolResultArtifact,
+  ToolResultArtifactStoreOptions,
+} from './tool-result-artifact-store';
 
-export const FOLDED_EXECUTE_SHELL_PREFIX = '[folded_execute_shell]';
+export const TRUNCATED_EXECUTE_SHELL_PREFIX = '[truncated_execute_shell]';
+export const FOLDED_EXECUTE_SHELL_PREFIX = TRUNCATED_EXECUTE_SHELL_PREFIX;
+const LEGACY_FOLDED_EXECUTE_SHELL_PREFIX = '[folded_execute_shell]';
 
 export interface ExecuteShellMessageFoldingOptions {
   enabled: boolean;
@@ -13,6 +19,7 @@ export interface ExecuteShellMessageFoldingOptions {
   keepRecentHistoricalShells: number;
   foldCurrentRun: boolean;
   protectedCurrentRunToolResultIndexes?: ReadonlySet<number>;
+  artifactStore?: Partial<ToolResultArtifactStoreOptions>;
 }
 
 export interface ExecuteShellMessageFoldingStats {
@@ -128,7 +135,7 @@ export function foldHistoricalExecuteShellMessages(
     }
 
     const rawText = typeof message.content === 'string' ? message.content : '';
-    if (!rawText || rawText.startsWith(FOLDED_EXECUTE_SHELL_PREFIX)) return;
+    if (!rawText || isAlreadyTruncated(rawText)) return;
 
     const rawTokens = estimateTokens(rawText);
     if (rawTokens < resolved.thresholdTokens) return;
@@ -217,10 +224,22 @@ function buildFoldedExecuteShellContent(
     .update('\0')
     .update(candidate.rawText)
     .digest('hex');
+  const artifact = persistToolResultArtifact({
+    artifactId: `sh_${hash.slice(0, 16)}`,
+    toolName: 'execute_shell',
+    toolCallId: candidate.message.tool_call_id,
+    sha256: hash,
+    rawText: candidate.rawText,
+    store: options.artifactStore,
+  });
 
   const foldedParts = [
-    FOLDED_EXECUTE_SHELL_PREFIX,
-    `artifact_id: sh_${hash.slice(0, 16)}`,
+    TRUNCATED_EXECUTE_SHELL_PREFIX,
+    `artifact_id: ${artifact.artifactId}`,
+    artifact.ref ? `full_output_ref: ${artifact.ref}` : '',
+    artifact.filePath ? `full_output_path: ${artifact.filePath}` : '',
+    artifact.fileUri ? `full_output_link: ${artifact.fileUri}` : '',
+    artifact.writeError ? `full_output_store_error: ${oneLine(artifact.writeError, 300)}` : '',
     metadata.command ? `command: ${oneLine(metadata.command, 1600)}` : '',
     metadata.description ? `description: ${oneLine(metadata.description, 400)}` : '',
     metadata.cwd ? `cwd: ${metadata.cwd}` : '',
@@ -233,7 +252,7 @@ function buildFoldedExecuteShellContent(
     `original_tokens_est: ${candidate.rawTokens}`,
     `sha256: ${hash}`,
     '',
-    'summary: Historical execute_shell output was folded out of the provider prompt. Re-run the command or inspect logs before relying on omitted lines.',
+    'summary: Historical execute_shell output was truncated out of the provider prompt. Use full_output_path/full_output_ref, re-run the command, or inspect logs before relying on omitted lines.',
     headLines.length > 0 ? ['head:', ...headLines.map(line => `  ${line}`)].join('\n') : '',
     tailLines.length > 0 ? ['tail:', ...tailLines.map(line => `  ${line}`)].join('\n') : '',
     keyLines.length > 0 ? ['key_lines:', ...keyLines.map(line => `  ${line}`)].join('\n') : '',
@@ -280,6 +299,11 @@ function normalizeToolName(name: string): string {
     return 'execute_shell';
   }
   return normalized;
+}
+
+function isAlreadyTruncated(rawText: string): boolean {
+  return rawText.startsWith(TRUNCATED_EXECUTE_SHELL_PREFIX)
+    || rawText.startsWith(LEGACY_FOLDED_EXECUTE_SHELL_PREFIX);
 }
 
 function findLastRealUserIndex(messages: Message[]): number {

--- a/src/core/read-file-message-folder.ts
+++ b/src/core/read-file-message-folder.ts
@@ -1,8 +1,14 @@
 import { createHash } from 'crypto';
 import { Message } from '../types';
 import { estimateTokens } from './token-estimator';
+import {
+  persistToolResultArtifact,
+  ToolResultArtifactStoreOptions,
+} from './tool-result-artifact-store';
 
-export const FOLDED_READ_FILE_PREFIX = '[folded_read_file]';
+export const TRUNCATED_READ_FILE_PREFIX = '[truncated_read_file]';
+export const FOLDED_READ_FILE_PREFIX = TRUNCATED_READ_FILE_PREFIX;
+const LEGACY_FOLDED_READ_FILE_PREFIX = '[folded_read_file]';
 
 export interface ReadFileMessageFoldingOptions {
   enabled: boolean;
@@ -12,6 +18,7 @@ export interface ReadFileMessageFoldingOptions {
   keepRecentHistoricalReads: number;
   foldCurrentRun: boolean;
   protectedCurrentRunToolResultIndexes?: ReadonlySet<number>;
+  artifactStore?: Partial<ToolResultArtifactStoreOptions>;
 }
 
 export interface ReadFileMessageFoldingStats {
@@ -112,7 +119,7 @@ export function foldHistoricalReadFileMessages(
     }
 
     const rawText = typeof message.content === 'string' ? message.content : '';
-    if (!rawText || rawText.startsWith(FOLDED_READ_FILE_PREFIX)) return;
+    if (!rawText || isAlreadyTruncated(rawText)) return;
 
     const rawTokens = estimateTokens(rawText);
     if (rawTokens < resolved.thresholdTokens) return;
@@ -200,9 +207,21 @@ function buildFoldedReadFileContent(
     .update('\0')
     .update(candidate.rawText)
     .digest('hex');
+  const artifact = persistToolResultArtifact({
+    artifactId: `rf_${hash.slice(0, 16)}`,
+    toolName: 'read_file',
+    toolCallId: candidate.message.tool_call_id,
+    sha256: hash,
+    rawText: candidate.rawText,
+    store: options.artifactStore,
+  });
   const foldedParts = [
-    FOLDED_READ_FILE_PREFIX,
-    `artifact_id: rf_${hash.slice(0, 16)}`,
+    TRUNCATED_READ_FILE_PREFIX,
+    `artifact_id: ${artifact.artifactId}`,
+    artifact.ref ? `full_output_ref: ${artifact.ref}` : '',
+    artifact.filePath ? `full_output_path: ${artifact.filePath}` : '',
+    artifact.fileUri ? `full_output_link: ${artifact.fileUri}` : '',
+    artifact.writeError ? `full_output_store_error: ${oneLine(artifact.writeError, 300)}` : '',
     metadata.file ? `file: ${metadata.file}` : '',
     metadata.path ? `path: ${metadata.path}` : '',
     metadata.display ? `range: ${metadata.display}` : '',
@@ -211,7 +230,7 @@ function buildFoldedReadFileContent(
     `original_tokens_est: ${candidate.rawTokens}`,
     `sha256: ${hash}`,
     '',
-    'summary: Historical read_file output was folded out of the provider prompt. Re-read this file/range before exact edits or quoting.',
+    'summary: Historical read_file output was truncated out of the provider prompt. Use full_output_path/full_output_ref or re-read this file/range before exact edits or quoting.',
     previewLines.length > 0 ? ['preview:', ...previewLines.map(line => `  ${line}`)].join('\n') : '',
     symbolLines.length > 0 ? ['key_symbols:', ...symbolLines.map(line => `  ${line}`)].join('\n') : '',
   ];
@@ -257,6 +276,11 @@ function normalizeToolName(name: string): string {
   const normalized = String(name || '').trim();
   if (normalized === 'Read') return 'read_file';
   return normalized;
+}
+
+function isAlreadyTruncated(rawText: string): boolean {
+  return rawText.startsWith(TRUNCATED_READ_FILE_PREFIX)
+    || rawText.startsWith(LEGACY_FOLDED_READ_FILE_PREFIX);
 }
 
 function findLastRealUserIndex(messages: Message[]): number {
@@ -334,6 +358,12 @@ function buildDisplayFromArgs(args: Record<string, unknown>): string | undefined
 
 function firstNonEmpty(...values: Array<string | undefined>): string | undefined {
   return values.find(value => Boolean(value && value.trim()));
+}
+
+function oneLine(value: string, maxLength: number): string {
+  const trimmed = value.replace(/\r?\n/g, ' ; ').trim();
+  if (trimmed.length <= maxLength) return trimmed;
+  return `${trimmed.slice(0, maxLength - 20)}...(truncated ${trimmed.length} chars)`;
 }
 
 function readBooleanEnv(value: string | undefined, fallback: boolean): boolean {

--- a/src/core/tool-result-artifact-store.ts
+++ b/src/core/tool-result-artifact-store.ts
@@ -1,0 +1,119 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface ToolResultArtifactStoreOptions {
+  enabled: boolean;
+  rootDirectory?: string;
+  sessionId?: string;
+  turn?: number;
+}
+
+export interface ToolResultArtifactReference {
+  artifactId: string;
+  ref?: string;
+  filePath?: string;
+  fileUri?: string;
+  writeError?: string;
+}
+
+export interface PersistToolResultArtifactParams {
+  artifactId: string;
+  toolName: string;
+  toolCallId?: string;
+  sha256: string;
+  rawText: string;
+  store?: Partial<ToolResultArtifactStoreOptions>;
+}
+
+const DEFAULT_STORE_OPTIONS: ToolResultArtifactStoreOptions = {
+  enabled: false,
+};
+
+export function resolveToolResultArtifactStoreOptions(
+  env: NodeJS.ProcessEnv = process.env,
+  defaults: Partial<ToolResultArtifactStoreOptions> = {},
+): ToolResultArtifactStoreOptions {
+  const fallback = { ...DEFAULT_STORE_OPTIONS, ...defaults };
+  const envRootDirectory = stringEnv(env.XIAOBA_TOOL_RESULT_ARTIFACT_DIR);
+  const rootDirectory = envRootDirectory || fallback.rootDirectory;
+  const defaultEnabled = fallback.enabled || Boolean(envRootDirectory);
+  return {
+    enabled: readBooleanEnv(env.XIAOBA_TOOL_RESULT_ARTIFACTS, defaultEnabled),
+    rootDirectory,
+    sessionId: fallback.sessionId,
+    turn: fallback.turn,
+  };
+}
+
+export function persistToolResultArtifact(
+  params: PersistToolResultArtifactParams,
+): ToolResultArtifactReference {
+  const resolved = { ...DEFAULT_STORE_OPTIONS, ...params.store };
+  const artifactId = sanitizeFileSegment(params.artifactId);
+  if (!resolved.enabled || !resolved.rootDirectory) {
+    return { artifactId };
+  }
+
+  const sessionSegment = sanitizeFileSegment(resolved.sessionId || 'unknown-session');
+  const turnSegment = typeof resolved.turn === 'number' && Number.isFinite(resolved.turn)
+    ? `turn-${String(Math.max(0, Math.floor(resolved.turn))).padStart(4, '0')}`
+    : 'turn-unknown';
+  const directory = path.resolve(resolved.rootDirectory, sessionSegment, turnSegment);
+  const filePath = path.join(directory, `${artifactId}.txt`);
+  const ref = `tool-result://${sessionSegment}/${turnSegment}/${artifactId}`;
+
+  try {
+    fs.mkdirSync(directory, { recursive: true });
+    if (!fs.existsSync(filePath)) {
+      fs.writeFileSync(filePath, buildArtifactPayload(params), 'utf8');
+    }
+    return {
+      artifactId,
+      ref,
+      filePath,
+      fileUri: toFileUri(filePath),
+    };
+  } catch (error: any) {
+    return {
+      artifactId,
+      ref,
+      writeError: error?.message || String(error),
+    };
+  }
+}
+
+function buildArtifactPayload(params: PersistToolResultArtifactParams): string {
+  return [
+    `tool_name: ${params.toolName}`,
+    params.toolCallId ? `tool_call_id: ${params.toolCallId}` : '',
+    `sha256: ${params.sha256}`,
+    '',
+    params.rawText,
+  ].filter(Boolean).join('\n');
+}
+
+function toFileUri(filePath: string): string {
+  const normalized = path.resolve(filePath).replace(/\\/g, '/');
+  return normalized.startsWith('/')
+    ? `file://${normalized}`
+    : `file:///${normalized}`;
+}
+
+function sanitizeFileSegment(value: string): string {
+  const sanitized = String(value || '')
+    .replace(/[%/\\:*?"<>|\s]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+  return sanitized || 'unknown';
+}
+
+function stringEnv(value: string | undefined, fallback?: string): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed || fallback;
+}
+
+function readBooleanEnv(value: string | undefined, fallback: boolean): boolean {
+  if (value === undefined || value === '') return fallback;
+  if (/^(1|true|yes|on)$/i.test(value)) return true;
+  if (/^(0|false|no|off)$/i.test(value)) return false;
+  return fallback;
+}

--- a/tests/adaptive-tool-result-folder.test.ts
+++ b/tests/adaptive-tool-result-folder.test.ts
@@ -90,8 +90,8 @@ test('adaptively lowers thresholds to fold additional tool results toward a prom
   assert.equal(result.stats.execute_shell_folded_count, 1);
   assert.equal(result.stats.passes, 2);
   assert.deepEqual(result.stats.thresholds_tried, [1000, 500]);
-  assert.match(String(result.messages[2].content), /^\[folded_read_file\]/);
-  assert.match(String(result.messages[4].content), /^\[folded_execute_shell\]/);
+  assert.match(String(result.messages[2].content), /^\[truncated_read_file\]/);
+  assert.match(String(result.messages[4].content), /^\[truncated_execute_shell\]/);
 });
 
 test('does not adaptively fold when disabled or already under target', () => {

--- a/tests/conversation-runner-context-budget.test.ts
+++ b/tests/conversation-runner-context-budget.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { ConversationRunner, PROMPT_BUDGET_TRIM_MESSAGE, PROMPT_TOOLS_DISABLED_MESSAGE } from '../src/core/conversation-runner';
-import { FOLDED_READ_FILE_PREFIX } from '../src/core/read-file-message-folder';
+import { TRUNCATED_READ_FILE_PREFIX } from '../src/core/read-file-message-folder';
 import { estimateMessageTokens, estimateMessagesTokens, estimateToolsTokens } from '../src/core/token-estimator';
 import type { ContentBlock, Message } from '../src/types';
 import type { ToolDefinition, ToolExecutor } from '../src/types/tool';
@@ -166,7 +166,7 @@ test('adaptive tool result folding uses runner message budget before mechanical 
   }
 
   const providerToolResult = captured[0].find(message => message.tool_call_id === 'call_budget_read');
-  assert.ok(String(providerToolResult?.content).startsWith(FOLDED_READ_FILE_PREFIX));
+  assert.ok(String(providerToolResult?.content).startsWith(TRUNCATED_READ_FILE_PREFIX));
   assert.ok(estimateMessagesTokens(captured[0]) <= 5_000);
   assert.equal(messages[2].content, raw);
 });

--- a/tests/execute-shell-message-folder.test.ts
+++ b/tests/execute-shell-message-folder.test.ts
@@ -1,7 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import {
-  FOLDED_EXECUTE_SHELL_PREFIX,
+  TRUNCATED_EXECUTE_SHELL_PREFIX,
   foldHistoricalExecuteShellMessages,
   resolveExecuteShellMessageFoldingOptions,
 } from '../src/core/execute-shell-message-folder';
@@ -67,13 +70,47 @@ test('folds large historical execute_shell results while preserving tool exchang
   assert.equal(folded.tool_call_id, 'call_old_shell');
   assert.equal(folded.name, 'execute_shell');
   assert.equal(typeof folded.content, 'string');
-  assert.ok(String(folded.content).startsWith(FOLDED_EXECUTE_SHELL_PREFIX));
+  assert.ok(String(folded.content).startsWith(TRUNCATED_EXECUTE_SHELL_PREFIX));
   assert.match(String(folded.content), /artifact_id: sh_[a-f0-9]{16}/);
   assert.match(String(folded.content), /command: npm test/);
   assert.match(String(folded.content), /status: failed/);
   assert.match(String(folded.content), /ERROR failed at src\/broken\.ts:123/);
   assert.equal(String(folded.content).includes('plain shell output line 45'), false);
   assert.ok(result.stats.saved_tokens_est > 0);
+});
+
+test('writes truncated execute_shell full output to a linkable artifact', () => {
+  const artifactRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-shell-artifacts-'));
+  const raw = makeShellOutput('npm test -- linked', 100, true);
+  const messages: Message[] = [
+    { role: 'user', content: 'run linked tests' },
+    makeToolCallMessage('call_linked_shell', 'npm test -- linked'),
+    { role: 'tool', name: 'execute_shell', tool_call_id: 'call_linked_shell', content: raw },
+    { role: 'assistant', content: 'tests failed' },
+    { role: 'user', content: 'continue' },
+  ];
+
+  try {
+    const result = foldHistoricalExecuteShellMessages(messages, {
+      thresholdTokens: 20,
+      artifactStore: {
+        enabled: true,
+        rootDirectory: artifactRoot,
+        sessionId: 'test session',
+        turn: 9,
+      },
+    });
+    const content = String(result.messages[2].content);
+    const fullOutputPath = content.match(/^full_output_path: (.+)$/m)?.[1];
+
+    assert.ok(content.startsWith(TRUNCATED_EXECUTE_SHELL_PREFIX));
+    assert.match(content, /full_output_ref: tool-result:\/\/test_session\/turn-0009\/sh_[a-f0-9]{16}/);
+    assert.match(content, /full_output_link: file:\/\//);
+    assert.ok(fullOutputPath);
+    assert.equal(fs.readFileSync(fullOutputPath, 'utf8').includes(raw), true);
+  } finally {
+    fs.rmSync(artifactRoot, { recursive: true, force: true });
+  }
 });
 
 test('does not fold execute_shell result from the current tool loop', () => {
@@ -116,7 +153,7 @@ test('can delayed-fold older current-run execute_shell results while protecting 
   assert.equal(result.stats.folded_count, 1);
   assert.equal(result.stats.folded_current_turn_count, 1);
   assert.equal(result.stats.protected_current_turn_count, 1);
-  assert.ok(String(result.messages[2].content).startsWith(FOLDED_EXECUTE_SHELL_PREFIX));
+  assert.ok(String(result.messages[2].content).startsWith(TRUNCATED_EXECUTE_SHELL_PREFIX));
   assert.equal(result.messages[5].content, secondRaw);
 });
 
@@ -143,7 +180,7 @@ test('can keep the most recent historical execute_shell result raw', () => {
   assert.equal(result.stats.candidate_count, 2);
   assert.equal(result.stats.folded_count, 1);
   assert.equal(result.stats.skipped_recent_count, 1);
-  assert.ok(String(result.messages[2].content).startsWith(FOLDED_EXECUTE_SHELL_PREFIX));
+  assert.ok(String(result.messages[2].content).startsWith(TRUNCATED_EXECUTE_SHELL_PREFIX));
   assert.equal(result.messages[6].content, secondRaw);
 });
 
@@ -203,6 +240,6 @@ test('runner folds execute_shell only in provider input and leaves durable sessi
   }
 
   const providerToolResult = captured[0].find(message => message.role === 'tool');
-  assert.ok(String(providerToolResult?.content).startsWith(FOLDED_EXECUTE_SHELL_PREFIX));
+  assert.ok(String(providerToolResult?.content).startsWith(TRUNCATED_EXECUTE_SHELL_PREFIX));
   assert.equal(messages[2].content, raw);
 });

--- a/tests/read-file-message-folder.test.ts
+++ b/tests/read-file-message-folder.test.ts
@@ -1,7 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import {
-  FOLDED_READ_FILE_PREFIX,
+  TRUNCATED_READ_FILE_PREFIX,
   foldHistoricalReadFileMessages,
   resolveReadFileMessageFoldingOptions,
 } from '../src/core/read-file-message-folder';
@@ -61,11 +64,45 @@ test('folds large historical read_file tool results while preserving tool exchan
   assert.equal(folded.tool_call_id, 'call_old_read');
   assert.equal(folded.name, 'read_file');
   assert.equal(typeof folded.content, 'string');
-  assert.ok(String(folded.content).startsWith(FOLDED_READ_FILE_PREFIX));
+  assert.ok(String(folded.content).startsWith(TRUNCATED_READ_FILE_PREFIX));
   assert.match(String(folded.content), /artifact_id: rf_[a-f0-9]{16}/);
   assert.match(String(folded.content), /path: E:\/repo\/large\.ts/);
   assert.equal(String(folded.content).includes('plain historical content line 45'), false);
   assert.ok(result.stats.saved_tokens_est > 0);
+});
+
+test('writes truncated read_file full output to a linkable artifact', () => {
+  const artifactRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-read-artifacts-'));
+  const raw = makeReadFileOutput('E:/repo/linked-large.ts', 90);
+  const messages: Message[] = [
+    { role: 'user', content: 'read linked-large.ts' },
+    makeToolCallMessage('call_linked_read', 'E:/repo/linked-large.ts'),
+    { role: 'tool', name: 'read_file', tool_call_id: 'call_linked_read', content: raw },
+    { role: 'assistant', content: 'read complete' },
+    { role: 'user', content: 'continue' },
+  ];
+
+  try {
+    const result = foldHistoricalReadFileMessages(messages, {
+      thresholdTokens: 20,
+      artifactStore: {
+        enabled: true,
+        rootDirectory: artifactRoot,
+        sessionId: 'test session',
+        turn: 7,
+      },
+    });
+    const content = String(result.messages[2].content);
+    const fullOutputPath = content.match(/^full_output_path: (.+)$/m)?.[1];
+
+    assert.ok(content.startsWith(TRUNCATED_READ_FILE_PREFIX));
+    assert.match(content, /full_output_ref: tool-result:\/\/test_session\/turn-0007\/rf_[a-f0-9]{16}/);
+    assert.match(content, /full_output_link: file:\/\//);
+    assert.ok(fullOutputPath);
+    assert.equal(fs.readFileSync(fullOutputPath, 'utf8').includes(raw), true);
+  } finally {
+    fs.rmSync(artifactRoot, { recursive: true, force: true });
+  }
 });
 
 test('does not fold read_file result from the current tool loop', () => {
@@ -108,7 +145,7 @@ test('can delayed-fold older current-run read_file results while protecting rece
   assert.equal(result.stats.folded_count, 1);
   assert.equal(result.stats.folded_current_turn_count, 1);
   assert.equal(result.stats.protected_current_turn_count, 1);
-  assert.ok(String(result.messages[2].content).startsWith(FOLDED_READ_FILE_PREFIX));
+  assert.ok(String(result.messages[2].content).startsWith(TRUNCATED_READ_FILE_PREFIX));
   assert.equal(result.messages[5].content, secondRaw);
 });
 
@@ -135,7 +172,7 @@ test('can keep the most recent historical read_file result raw', () => {
   assert.equal(result.stats.candidate_count, 2);
   assert.equal(result.stats.folded_count, 1);
   assert.equal(result.stats.skipped_recent_count, 1);
-  assert.ok(String(result.messages[2].content).startsWith(FOLDED_READ_FILE_PREFIX));
+  assert.ok(String(result.messages[2].content).startsWith(TRUNCATED_READ_FILE_PREFIX));
   assert.equal(result.messages[6].content, secondRaw);
 });
 
@@ -193,7 +230,7 @@ test('runner folds only provider input and leaves durable session messages raw',
   }
 
   const providerToolResult = captured[0].find(message => message.role === 'tool');
-  assert.ok(String(providerToolResult?.content).startsWith(FOLDED_READ_FILE_PREFIX));
+  assert.ok(String(providerToolResult?.content).startsWith(TRUNCATED_READ_FILE_PREFIX));
   assert.equal(messages[2].content, raw);
 });
 
@@ -244,7 +281,7 @@ test('runner delayed-folds older current-run tool results and keeps recent ones 
 
   const providerOld = captured[0].find(message => message.tool_call_id === 'call_current_provider_old');
   const providerRecent = captured[0].find(message => message.tool_call_id === 'call_current_provider_recent');
-  assert.ok(String(providerOld?.content).startsWith(FOLDED_READ_FILE_PREFIX));
+  assert.ok(String(providerOld?.content).startsWith(TRUNCATED_READ_FILE_PREFIX));
   assert.equal(providerRecent?.content, secondRaw);
   assert.equal(messages[2].content, firstRaw);
   assert.equal(messages[5].content, secondRaw);

--- a/tests/tool-result-context-report.test.ts
+++ b/tests/tool-result-context-report.test.ts
@@ -46,7 +46,7 @@ test('formats before and after tool result context savings', () => {
     tool('read_file', 'y'.repeat(500), 'read_1'),
   ]);
   const after = summarizeToolResultContext([
-    tool('execute_shell', '[folded_execute_shell]\nsummary', 'shell_1'),
+    tool('execute_shell', '[truncated_execute_shell]\nsummary', 'shell_1'),
     tool('read_file', 'y'.repeat(500), 'read_1'),
   ]);
 


### PR DESCRIPTION
## What changed

- Stores full historical `read_file` and `execute_shell` tool results as local artifacts before truncating provider input.
- Replaces provider-visible `[folded_*]` summaries with `[truncated_*]` summaries that include `full_output_ref`, `full_output_path`, and `full_output_link`.
- Keeps existing context-budget, current-run protection, and adaptive truncation behavior while making the omitted full output recoverable.
- Ignores the local `.xiaoba/` artifact directory.

## Why

The previous folded summaries exposed an `artifact_id` that looked recoverable but was only a hash-like label. This makes truncation explicit and adds a real local artifact path/link for the full tool result.

## Validation

- `npm run build`
- `node node_modules\tsx\dist\cli.mjs --test tests\read-file-message-folder.test.ts tests\execute-shell-message-folder.test.ts tests\adaptive-tool-result-folder.test.ts tests\tool-result-context-report.test.ts tests\conversation-runner-context-budget.test.ts`