### PR TITLE
上报 CatsCo 当前模型状态

### DIFF
--- a/src/catscompany/client.ts
+++ b/src/catscompany/client.ts
@@ -24,6 +24,11 @@ export interface CatsDeviceRegistration {
   owner_user_id?: string;
   status?: 'online' | 'offline';
   capabilities?: string[];
+  model_status?: {
+    source?: 'relay' | 'custom';
+    model?: string;
+    updated_at?: number;
+  };
 }
 
 export interface CatsDeviceRpcError {

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -177,7 +177,6 @@ export class CatsCompanyBot {
           owner_user_id: config.ownerUserId,
           status: 'online' as const,
           capabilities: [...CATSCOMPANY_FULL_RUNTIME_DEVICE_CAPABILITIES],
-          model_status: resolveCatsDeviceModelStatus(),
         }
       : undefined;
 
@@ -260,13 +259,21 @@ export class CatsCompanyBot {
     if (!this.deviceRegistration?.device_id) return;
     const registration = {
       ...this.deviceRegistration,
-      model_status: resolveCatsDeviceModelStatus(),
+      model_status: this.resolveCurrentDeviceModelStatus(),
     };
     await this.bot.registerDevice(registration);
     const modelStatus = registration.model_status
       ? `, model=${registration.model_status.source}/${registration.model_status.model}`
       : '';
     Logger.info(`[CatsCompany] 已注册本机设备能力: device=${registration.device_id}, capabilities=${registration.capabilities.join(',')}${modelStatus}`);
+  }
+
+  private resolveCurrentDeviceModelStatus(): ReturnType<typeof resolveCatsDeviceModelStatus> {
+    const getConfig = (this.agentServices.aiService as any).getConfig;
+    const config = typeof getConfig === 'function'
+      ? getConfig.call(this.agentServices.aiService)
+      : undefined;
+    return resolveCatsDeviceModelStatus({ config });
   }
 
   private startDeviceRegistrationRefresh(): void {

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -38,6 +38,7 @@ import {
   stripToolTargetContextForDisplay,
 } from '../tools/tool-target-context';
 import { formatPathForLog } from '../utils/log-redaction';
+import { resolveCatsDeviceModelStatus } from './model-status';
 
 interface PendingAttachment {
   fileName: string;
@@ -161,6 +162,7 @@ export class CatsCompanyBot {
     installation_id?: string;
     status: 'online';
     capabilities: string[];
+    model_status?: ReturnType<typeof resolveCatsDeviceModelStatus>;
   };
 
   constructor(config: CatsCompanyConfig) {
@@ -175,6 +177,7 @@ export class CatsCompanyBot {
           owner_user_id: config.ownerUserId,
           status: 'online' as const,
           capabilities: [...CATSCOMPANY_FULL_RUNTIME_DEVICE_CAPABILITIES],
+          model_status: resolveCatsDeviceModelStatus(),
         }
       : undefined;
 
@@ -255,8 +258,15 @@ export class CatsCompanyBot {
 
   private async registerCurrentDevice(): Promise<void> {
     if (!this.deviceRegistration?.device_id) return;
-    await this.bot.registerDevice(this.deviceRegistration);
-    Logger.info(`[CatsCompany] 已注册本机设备能力: device=${this.deviceRegistration.device_id}, capabilities=${this.deviceRegistration.capabilities.join(',')}`);
+    const registration = {
+      ...this.deviceRegistration,
+      model_status: resolveCatsDeviceModelStatus(),
+    };
+    await this.bot.registerDevice(registration);
+    const modelStatus = registration.model_status
+      ? `, model=${registration.model_status.source}/${registration.model_status.model}`
+      : '';
+    Logger.info(`[CatsCompany] 已注册本机设备能力: device=${registration.device_id}, capabilities=${registration.capabilities.join(',')}${modelStatus}`);
   }
 
   private startDeviceRegistrationRefresh(): void {

--- a/src/catscompany/model-status.ts
+++ b/src/catscompany/model-status.ts
@@ -9,6 +9,7 @@ export interface CatsDeviceModelStatus {
 interface ModelStatusOptions {
   env?: NodeJS.ProcessEnv;
   config?: {
+    provider?: string;
     apiUrl?: string;
     apiKey?: string;
     model?: string;
@@ -36,12 +37,12 @@ export function resolveCatsDeviceModelStatus(options: ModelStatusOptions = {}): 
   const env = options.env || process.env;
   const config = options.config || ConfigManager.getConfigReadonly();
   const source = String(env.CATSCO_MODEL_SOURCE || '').trim().toLowerCase();
-  const apiBase = firstNonEmpty(env.GAUZ_LLM_API_BASE, config.apiUrl);
-  const apiKey = firstNonEmpty(env.GAUZ_LLM_API_KEY, config.apiKey);
-  const model = firstNonEmpty(env.GAUZ_LLM_MODEL, config.model);
+  const apiBase = firstNonEmpty(config.apiUrl, env.GAUZ_LLM_API_BASE);
+  const apiKey = firstNonEmpty(config.apiKey, env.GAUZ_LLM_API_KEY);
+  const model = firstNonEmpty(config.model, env.GAUZ_LLM_MODEL);
   const now = options.now || Date.now;
 
-  if (source === 'relay' || isCatsRelayApiBase(apiBase)) {
+  if (isCatsRelayApiBase(apiBase)) {
     if (!model) return undefined;
     return {
       source: 'relay',

--- a/src/catscompany/model-status.ts
+++ b/src/catscompany/model-status.ts
@@ -51,7 +51,8 @@ export function resolveCatsDeviceModelStatus(options: ModelStatusOptions = {}): 
     };
   }
 
-  if (source === 'custom' || (apiKey && (model || apiBase))) {
+  const hasCustomSignal = Boolean(model || apiBase || apiKey);
+  if ((source === 'custom' && hasCustomSignal) || (apiKey && (model || apiBase))) {
     return {
       source: 'custom',
       model: model || '自定义模型',

--- a/src/catscompany/model-status.ts
+++ b/src/catscompany/model-status.ts
@@ -1,0 +1,62 @@
+import { ConfigManager } from '../utils/config';
+
+export interface CatsDeviceModelStatus {
+  source: 'relay' | 'custom';
+  model: string;
+  updated_at: number;
+}
+
+interface ModelStatusOptions {
+  env?: NodeJS.ProcessEnv;
+  config?: {
+    apiUrl?: string;
+    apiKey?: string;
+    model?: string;
+  };
+  now?: () => number;
+}
+
+function firstNonEmpty(...values: Array<string | undefined>): string {
+  for (const value of values) {
+    const text = String(value || '').trim();
+    if (text) return text;
+  }
+  return '';
+}
+
+function isCatsRelayApiBase(value: string): boolean {
+  try {
+    return new URL(value).hostname.toLowerCase() === 'relay.catsco.cc';
+  } catch {
+    return value.toLowerCase().includes('relay.catsco.cc');
+  }
+}
+
+export function resolveCatsDeviceModelStatus(options: ModelStatusOptions = {}): CatsDeviceModelStatus | undefined {
+  const env = options.env || process.env;
+  const config = options.config || ConfigManager.getConfigReadonly();
+  const source = String(env.CATSCO_MODEL_SOURCE || '').trim().toLowerCase();
+  const apiBase = firstNonEmpty(env.GAUZ_LLM_API_BASE, config.apiUrl);
+  const apiKey = firstNonEmpty(env.GAUZ_LLM_API_KEY, config.apiKey);
+  const model = firstNonEmpty(env.GAUZ_LLM_MODEL, config.model);
+  const now = options.now || Date.now;
+
+  if (source === 'relay' || isCatsRelayApiBase(apiBase)) {
+    if (!model) return undefined;
+    return {
+      source: 'relay',
+      model,
+      updated_at: now(),
+    };
+  }
+
+  if (source === 'custom' || (apiKey && (model || apiBase))) {
+    return {
+      source: 'custom',
+      model: model || '自定义模型',
+      updated_at: now(),
+    };
+  }
+
+  return undefined;
+}

--- a/tests/catscompany-client-body-id.test.ts
+++ b/tests/catscompany-client-body-id.test.ts
@@ -158,6 +158,11 @@ describe('CatsCompany client body identity', () => {
             installation_id: 'install-test',
             status: 'online',
             capabilities: ['read_file', 'send_file'],
+            model_status: {
+              source: 'relay',
+              model: 'MiniMax-M3',
+              updated_at: 1782790000000,
+            },
           });
         })().catch(reject);
       });
@@ -175,7 +180,14 @@ describe('CatsCompany client body identity', () => {
       installation_id: 'install-test',
       status: 'online',
       capabilities: ['read_file', 'send_file'],
+      model_status: {
+        source: 'relay',
+        model: 'MiniMax-M3',
+        updated_at: 1782790000000,
+      },
     });
+    assert.equal(request.body.apiUrl, undefined);
+    assert.equal(request.body.apiKey, undefined);
   });
 
   test('emits device rpc requests outside the regular message stream', async () => {

--- a/tests/catscompany-model-status.test.ts
+++ b/tests/catscompany-model-status.test.ts
@@ -34,6 +34,46 @@ test('treats relay base URL as relay even when source is absent', () => {
   assert.equal(status?.model, 'deepseek-v4-flash');
 });
 
+test('uses effective runtime config before stale env values', () => {
+  const status = resolveCatsDeviceModelStatus({
+    env: {
+      GAUZ_LLM_MODEL: 'MiniMax-M2.7',
+      GAUZ_LLM_API_BASE: 'https://relay.catsco.cc/anthropic',
+    } as NodeJS.ProcessEnv,
+    config: {
+      apiUrl: 'https://relay.catsco.cc/anthropic',
+      model: 'MiniMax-M3',
+    },
+    now: () => 1782790000005,
+  });
+
+  assert.deepEqual(status, {
+    source: 'relay',
+    model: 'MiniMax-M3',
+    updated_at: 1782790000005,
+  });
+});
+
+test('does not let stale relay source override a custom endpoint', () => {
+  const status = resolveCatsDeviceModelStatus({
+    env: {
+      CATSCO_MODEL_SOURCE: 'relay',
+    } as NodeJS.ProcessEnv,
+    config: {
+      apiUrl: 'https://example.test/v1',
+      apiKey: 'sk-secret',
+      model: 'claude-fable-5',
+    },
+    now: () => 1782790000006,
+  });
+
+  assert.deepEqual(status, {
+    source: 'custom',
+    model: 'claude-fable-5',
+    updated_at: 1782790000006,
+  });
+});
+
 test('reports custom model status without exposing endpoint or key', () => {
   const status = resolveCatsDeviceModelStatus({
     env: {

--- a/tests/catscompany-model-status.test.ts
+++ b/tests/catscompany-model-status.test.ts
@@ -93,10 +93,11 @@ test('reports custom model status without exposing endpoint or key', () => {
   });
 });
 
-test('falls back to custom label when a custom source has no model name', () => {
+test('falls back to custom label when custom source has a partial config but no model name', () => {
   const status = resolveCatsDeviceModelStatus({
     env: {
       CATSCO_MODEL_SOURCE: 'custom',
+      GAUZ_LLM_API_BASE: 'https://example.test/v1',
     } as NodeJS.ProcessEnv,
     config: {},
     now: () => 1782790000003,
@@ -104,6 +105,18 @@ test('falls back to custom label when a custom source has no model name', () => 
 
   assert.equal(status?.source, 'custom');
   assert.equal(status?.model, '自定义模型');
+});
+
+test('does not report stale empty custom source as configured model status', () => {
+  const status = resolveCatsDeviceModelStatus({
+    env: {
+      CATSCO_MODEL_SOURCE: 'custom',
+    } as NodeJS.ProcessEnv,
+    config: {},
+    now: () => 1782790000007,
+  });
+
+  assert.equal(status, undefined);
 });
 
 test('does not report default config when no model source is configured', () => {

--- a/tests/catscompany-model-status.test.ts
+++ b/tests/catscompany-model-status.test.ts
@@ -1,0 +1,80 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveCatsDeviceModelStatus } from '../src/catscompany/model-status';
+
+test('reports selected CatsCo relay model status', () => {
+  const status = resolveCatsDeviceModelStatus({
+    env: {
+      CATSCO_MODEL_SOURCE: 'relay',
+      GAUZ_LLM_MODEL: 'MiniMax-M3',
+      GAUZ_LLM_API_BASE: 'https://relay.catsco.cc/anthropic',
+    } as NodeJS.ProcessEnv,
+    config: {},
+    now: () => 1782790000000,
+  });
+
+  assert.deepEqual(status, {
+    source: 'relay',
+    model: 'MiniMax-M3',
+    updated_at: 1782790000000,
+  });
+});
+
+test('treats relay base URL as relay even when source is absent', () => {
+  const status = resolveCatsDeviceModelStatus({
+    env: {
+      GAUZ_LLM_MODEL: 'deepseek-v4-flash',
+      GAUZ_LLM_API_BASE: 'https://relay.catsco.cc/anthropic',
+    } as NodeJS.ProcessEnv,
+    config: {},
+    now: () => 1782790000001,
+  });
+
+  assert.equal(status?.source, 'relay');
+  assert.equal(status?.model, 'deepseek-v4-flash');
+});
+
+test('reports custom model status without exposing endpoint or key', () => {
+  const status = resolveCatsDeviceModelStatus({
+    env: {
+      CATSCO_MODEL_SOURCE: 'custom',
+      GAUZ_LLM_MODEL: 'gpt-5.5',
+      GAUZ_LLM_API_BASE: 'https://example.test/v1',
+      GAUZ_LLM_API_KEY: 'sk-secret',
+    } as NodeJS.ProcessEnv,
+    config: {},
+    now: () => 1782790000002,
+  });
+
+  assert.deepEqual(status, {
+    source: 'custom',
+    model: 'gpt-5.5',
+    updated_at: 1782790000002,
+  });
+});
+
+test('falls back to custom label when a custom source has no model name', () => {
+  const status = resolveCatsDeviceModelStatus({
+    env: {
+      CATSCO_MODEL_SOURCE: 'custom',
+    } as NodeJS.ProcessEnv,
+    config: {},
+    now: () => 1782790000003,
+  });
+
+  assert.equal(status?.source, 'custom');
+  assert.equal(status?.model, '自定义模型');
+});
+
+test('does not report default config when no model source is configured', () => {
+  const status = resolveCatsDeviceModelStatus({
+    env: {} as NodeJS.ProcessEnv,
+    config: {
+      apiUrl: 'https://api.openai.com/v1',
+      model: 'gpt-3.5-turbo',
+    },
+    now: () => 1782790000004,
+  });
+
+  assert.equal(status, undefined);
+});


### PR DESCRIPTION
## 变更
- CatsCompany 设备注册 payload 增加当前模型状态 `model_status`。
- Connector 启动握手和定时设备刷新时上报当前模型来源与模型名。
- 新增模型状态解析测试，覆盖 CatsCo relay、自定义模型和未配置默认模型不误报。

## 影响
- CatsCompany 服务端可以拿到当前在线桌面端正在使用的模型，用于用户中转页面按当前模型展示额度/剩余百分比。
- 不上传 endpoint、key 或其他敏感配置，只包含 `source`、`model` 和更新时间。

## 验证
- `npx tsx --test tests/catscompany-model-status.test.ts tests/catscompany-client-body-id.test.ts`
- `npm.cmd run build`
- `git diff --check`
