### PR TITLE
过滤 DeepSeek replay 内部占位

### DIFF
--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -53,6 +53,11 @@ import { MODEL_IMAGE_SAFETY_MESSAGE, isModelImageSafetyError } from '../utils/mo
 import { formatProviderErrorForLog } from '../utils/provider-error-log-sanitizer';
 import { renderRequiredDefaultPromptFile } from '../utils/prompt-template';
 import { PromptTraceLogger } from '../utils/prompt-trace-logger';
+import {
+  restoreProviderReplayToolCalls,
+  stripAssistantArtifactsFromMessages,
+  stripAssistantTranscriptArtifacts,
+} from '../utils/transcript-artifacts';
 import { prependToolTargetContext } from '../tools/tool-target-context';
 import {
   buildSyntheticObservationLifecycleEvent,
@@ -87,6 +92,7 @@ const MIN_MESSAGE_BUDGET = 2000;
 const OVERFLOW_REDUCTION_RATIO = 0.6;
 const MAX_EMPTY_MAX_TOKEN_RECOVERIES = 1;
 const EMPTY_MAX_TOKENS_MESSAGE = '模型这轮输出达到了 max_tokens 上限，但没有生成可见回复或工具调用。已保留当前上下文；请回复“继续”，我会从刚才的位置继续推进。';
+const REPLAY_ARTIFACT_ONLY_MESSAGE = '模型工具调用回放异常，这轮没有生成可见回复。上下文已保留；你可以直接说“继续”，我会从这里接上。';
 export const PROMPT_BUDGET_TRIM_MESSAGE = '当前上下文超过模型窗口，已裁剪较早的历史内容以继续处理。';
 export const PROMPT_TOOLS_DISABLED_MESSAGE = '当前模型上下文不足以加载全部工具，本轮已先按纯文本继续处理。';
 const MAX_VISIBLE_TOOL_PRELUDE_CHARS = 64;
@@ -521,6 +527,36 @@ export class ConversationRunner {
         Logger.info(`[${this.sessionLabel}Turn ${turns}] AI返回 tokens: ${response.usage.promptTokens}+${response.usage.completionTokens}=${response.usage.totalTokens}`);
       }
 
+      if ((!response.toolCalls || response.toolCalls.length === 0) && response.content) {
+        const restored = restoreProviderReplayToolCalls(
+          response.content,
+          this.buildRestorableReplayToolNameSet(requestTools),
+        );
+        if (restored.toolCalls.length > 0) {
+          const restoredToolCalls = restored.toolCalls
+            .map(toolCall => ({
+              ...toolCall,
+              function: {
+                ...toolCall.function,
+                name: normalizeToolName(toolCall.function.name),
+              },
+            }))
+            .filter(toolCall => this.isRestoredReplayToolCallSafe(toolCall, currentDirectory));
+          if (restoredToolCalls.length > 0) {
+            Logger.warning(
+              `[${this.sessionLabel}Turn ${turns}] 已将模型内部 replay 摘要恢复为工具调用: `
+              + restoredToolCalls.map(toolCall => toolCall.function.name).join(', ')
+            );
+            response = {
+              ...response,
+              content: restored.visibleText || null,
+              toolCalls: restoredToolCalls,
+              providerContent: undefined,
+            };
+          }
+        }
+      }
+
       if (!response.toolCalls || response.toolCalls.length === 0) {
         if (this.isEmptyMaxTokensResponse(response)) {
           Logger.warning(`[${this.sessionLabel}Turn ${turns}] 模型输出达到 max_tokens 且没有可见内容或工具调用`);
@@ -533,10 +569,18 @@ export class ConversationRunner {
           response = { ...response, content: EMPTY_MAX_TOKENS_MESSAGE, toolCalls: [] };
         }
 
-        Logger.info(`[${this.sessionLabel}Turn ${turns}] AI最终回复: ${ConversationRunner.truncateForLog(response.content || '', 300)}`);
+        let visibleContent = stripAssistantTranscriptArtifacts(response.content || '');
+        if ((response.content || '') && visibleContent !== (response.content || '')) {
+          Logger.warning(`[${this.sessionLabel}Turn ${turns}] 已过滤模型返回的内部历史回放占位文本`);
+        }
+        if ((response.content || '') && !visibleContent) {
+          visibleContent = REPLAY_ARTIFACT_ONLY_MESSAGE;
+        }
 
-        if (response.content) {
-          const finalAssistantMessage: Message = { role: 'assistant', content: response.content };
+        Logger.info(`[${this.sessionLabel}Turn ${turns}] AI最终回复: ${ConversationRunner.truncateForLog(visibleContent, 300)}`);
+
+        if (visibleContent) {
+          const finalAssistantMessage: Message = { role: 'assistant', content: visibleContent };
           messages.push(finalAssistantMessage);
           newMessages.push(finalAssistantMessage);
         }
@@ -546,7 +590,7 @@ export class ConversationRunner {
         }
 
         if (this.isMessageSurface()) {
-          let finalText = response.content || '';
+          let finalText = visibleContent;
           finalText = finalText.replace(/^\[已发送信息\]\s*/, '');
           finalText = finalText.replace(/^\[已发送文件\]\s*/, '');
 
@@ -573,7 +617,7 @@ export class ConversationRunner {
           };
         }
 
-        let cleanedResponse = response.content || '';
+        let cleanedResponse = visibleContent;
         cleanedResponse = cleanedResponse.replace(/^\[已发送信息\]\s*/, '');
         cleanedResponse = cleanedResponse.replace(/^\[已发送文件\]\s*/, '');
 
@@ -586,12 +630,16 @@ export class ConversationRunner {
       }
 
       if (response.content) {
-        Logger.info(`[${this.sessionLabel}Turn ${turns}] AI文本: ${ConversationRunner.truncateForLog(response.content, 300)}`);
-        const shouldSurfacePrelude = this.shouldSurfaceToolPrelude(response.content);
+        const visiblePrelude = stripAssistantTranscriptArtifacts(response.content);
+        if (visiblePrelude !== response.content) {
+          Logger.warning(`[${this.sessionLabel}Turn ${turns}] 已过滤工具前文本里的内部历史回放占位文本`);
+        }
+        Logger.info(`[${this.sessionLabel}Turn ${turns}] AI文本: ${ConversationRunner.truncateForLog(visiblePrelude, 300)}`);
+        const shouldSurfacePrelude = this.shouldSurfaceToolPrelude(visiblePrelude);
         if (callbacks?.onAssistantText && shouldSurfacePrelude) {
-          await callbacks.onAssistantText(response.content);
+          await callbacks.onAssistantText(visiblePrelude);
         } else if (!callbacks?.onAssistantText && callbacks?.onThinking && shouldSurfacePrelude) {
-          await callbacks.onThinking(response.content);
+          await callbacks.onThinking(visiblePrelude);
         } else {
           Logger.info(`[${this.sessionLabel}Turn ${turns}] 工具前文本已作为内部进度保留，未发送给用户`);
         }
@@ -601,7 +649,7 @@ export class ConversationRunner {
 
       const assistantMsg: Message = {
         role: 'assistant',
-        content: response.content,
+        content: stripAssistantTranscriptArtifacts(response.content || ''),
         tool_calls: response.toolCalls,
         providerContent: response.providerContent,
       };
@@ -1020,8 +1068,9 @@ export class ConversationRunner {
         && !message.content.startsWith(TRANSIENT_CURRENT_DIRECTORY_PREFIX);
     });
 
+    const repairedBase = this.repairToolExchangeMessages(stripAssistantArtifactsFromMessages(sanitizedBase));
     const collapsed: Message[] = [];
-    for (const message of sanitizedBase) {
+    for (const message of repairedBase) {
       const previous = collapsed[collapsed.length - 1];
       if (
         previous
@@ -1049,6 +1098,71 @@ export class ConversationRunner {
         ...transientHints,
       ],
     );
+  }
+
+  private buildRestorableReplayToolNameSet(tools: ToolDefinition[]): Set<string> {
+    const allowed = new Set<string>();
+    for (const tool of tools) {
+      if (tool.transcriptMode !== 'outbound_file' || normalizeToolName(tool.name) !== 'send_file') {
+        continue;
+      }
+      allowed.add(tool.name);
+      allowed.add(normalizeToolName(tool.name));
+    }
+    for (const [alias, normalized] of Object.entries(TOOL_NAME_ALIASES)) {
+      if (allowed.has(normalized)) {
+        allowed.add(alias);
+      }
+    }
+    return allowed;
+  }
+
+  private isRestoredReplayToolCallSafe(toolCall: ToolCall, currentDirectory?: string): boolean {
+    const toolName = normalizeToolName(toolCall.function.name);
+    if (toolName !== 'send_file') {
+      return false;
+    }
+    return this.isRestoredSendFilePathInsideCurrentDirectory(
+      toolCall.function.arguments,
+      currentDirectory || this.toolExecutionContext?.workingDirectory,
+    );
+  }
+
+  private isRestoredSendFilePathInsideCurrentDirectory(argumentsJson: string, currentDirectory?: string): boolean {
+    if (!currentDirectory) return false;
+    let args: unknown;
+    try {
+      args = JSON.parse(argumentsJson);
+    } catch {
+      return false;
+    }
+    if (!args || typeof args !== 'object' || Array.isArray(args)) return false;
+    const filePath = (args as Record<string, unknown>).file_path;
+    if (typeof filePath !== 'string' || !filePath.trim()) return false;
+
+    if (this.isWindowsPathLike(currentDirectory) || this.isWindowsPathLike(filePath)) {
+      if (!this.isWindowsPathLike(currentDirectory)) {
+        return false;
+      }
+      const base = path.win32.resolve(currentDirectory);
+      const resolved = path.win32.resolve(base, filePath);
+      return this.isPathInside(base, resolved, path.win32.sep, true);
+    }
+
+    const base = path.resolve(currentDirectory);
+    const resolved = path.resolve(base, filePath);
+    return this.isPathInside(base, resolved, path.sep, process.platform === 'win32');
+  }
+
+  private isWindowsPathLike(value: string): boolean {
+    return /^[a-zA-Z]:[\\/]/.test(value) || /^[\\/]{2}[^\\/]/.test(value);
+  }
+
+  private isPathInside(base: string, resolved: string, separator: string, caseInsensitive: boolean): boolean {
+    const normalizedBase = caseInsensitive ? base.toLowerCase() : base;
+    const normalizedResolved = caseInsensitive ? resolved.toLowerCase() : resolved;
+    return normalizedResolved === normalizedBase
+      || normalizedResolved.startsWith(normalizedBase + separator);
   }
 
   private insertProviderTransientHints(messages: Message[], hints: Message[]): Message[] {

--- a/src/core/memory-log-store.ts
+++ b/src/core/memory-log-store.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import type { SessionToolCallLog, SessionTurnLogEntry } from '../utils/session-log-schema';
+import { stripAssistantTranscriptArtifacts } from '../utils/transcript-artifacts';
 
 export interface MemorySearchMatch {
   ref: string;
@@ -340,7 +341,7 @@ function formatRef(ref: ParsedRef): string {
 function searchableText(entry: SessionTurnLogEntry): string {
   return [
     entry.user?.text || '',
-    entry.assistant?.text || '',
+    stripAssistantTranscriptArtifacts(entry.assistant?.text || ''),
     ...(entry.assistant?.tool_calls || []).flatMap(toolCall => [
       toolCall.name || '',
       normalizeToolArgument(toolCall.arguments),
@@ -362,7 +363,10 @@ function formatTurnRecord(record: MemoryTurnRecord, budgetChars: number): Memory
   const builder = new BudgetTextBuilder(budgetChars);
   builder.appendLine(`REF: ${record.ref}`);
   builder.appendSection('USER', record.entry.user?.text || '');
-  builder.appendSection('ASSISTANT_FINAL', record.entry.assistant?.text || '');
+  builder.appendSection(
+    'ASSISTANT_FINAL',
+    stripAssistantTranscriptArtifacts(record.entry.assistant?.text || ''),
+  );
   builder.appendSection('TOOL_CALLS_AND_RESULTS', formatToolCalls(record.entry.assistant?.tool_calls || []));
   return {
     ref: record.ref,

--- a/src/utils/transcript-artifacts.ts
+++ b/src/utils/transcript-artifacts.ts
@@ -1,7 +1,15 @@
 import type { Message } from '../types';
 
+type ToolCall = NonNullable<Message['tool_calls']>[number];
+
 const PROVIDER_REPLAY_PLACEHOLDER_LINE =
   /^\[历史工具调用已完成；provider replay 隐藏内容未写入本地会话。.*\]$/;
+const PROVIDER_REPLAY_SUMMARY_PREFIX = '[历史工具调用已转为摘要：';
+const PROVIDER_REPLAY_SUMMARY_MARKER =
+  /(?:provider replay|thinking replay|缓存缺失)/;
+const PROVIDER_REPLAY_TOOL_MARKER = '工具=';
+const PROVIDER_REPLAY_ID_MARKER = '，id=';
+const PROVIDER_REPLAY_ARGS_MARKER = '，参数=';
 const PROVIDER_REPLAY_RESULT_SUMMARY_HEADER = '[历史工具结果摘要]';
 const GENERIC_INTERNAL_FAILURE_LINE = /^\[处理失败: .+\]$/;
 const MODEL_TIMEOUT_INTERNAL_LINE = /^\[处理中断: 模型中转请求超时。.+\]$/;
@@ -23,10 +31,27 @@ export function stripAssistantTranscriptArtifacts(text: string): string {
 
   const keptLines: string[] = [];
   let sawProviderReplayArtifact = false;
+  let skippingProviderReplaySummary = false;
   for (const line of lines) {
     const trimmed = line.trim();
+    if (skippingProviderReplaySummary) {
+      if (isProviderReplaySummaryEnd(trimmed)) {
+        skippingProviderReplaySummary = false;
+      }
+      continue;
+    }
     if (PROVIDER_REPLAY_PLACEHOLDER_LINE.test(trimmed)) {
       sawProviderReplayArtifact = true;
+      continue;
+    }
+    if (
+      trimmed.startsWith(PROVIDER_REPLAY_SUMMARY_PREFIX)
+      && PROVIDER_REPLAY_SUMMARY_MARKER.test(trimmed)
+    ) {
+      sawProviderReplayArtifact = true;
+      if (!isProviderReplaySummaryEnd(trimmed)) {
+        skippingProviderReplaySummary = true;
+      }
       continue;
     }
     if (
@@ -42,6 +67,109 @@ export function stripAssistantTranscriptArtifacts(text: string): string {
     .join('\n')
     .replace(/\n{3,}/g, '\n\n')
     .trim();
+}
+
+export interface RestoredReplayToolCalls {
+  visibleText: string;
+  toolCalls: ToolCall[];
+}
+
+export function restoreProviderReplayToolCalls(
+  text: string,
+  allowedToolNames: Set<string>,
+): RestoredReplayToolCalls {
+  const toolCalls: ToolCall[] = [];
+  for (const summary of collectProviderReplaySummaries(text)) {
+    const toolCall = parseProviderReplaySummaryToolCall(summary);
+    if (!toolCall) continue;
+    if (!allowedToolNames.has(toolCall.function.name)) continue;
+    toolCalls.push(toolCall);
+  }
+
+  return {
+    visibleText: stripAssistantTranscriptArtifacts(text),
+    toolCalls,
+  };
+}
+
+function collectProviderReplaySummaries(text: string): string[] {
+  const summaries: string[] = [];
+  const lines = text.split(/\r?\n/);
+  let current: string[] = [];
+  let collecting = false;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!collecting) {
+      if (
+        trimmed.startsWith(PROVIDER_REPLAY_SUMMARY_PREFIX)
+        && PROVIDER_REPLAY_SUMMARY_MARKER.test(trimmed)
+      ) {
+        current = [trimmed];
+        if (isProviderReplaySummaryEnd(trimmed)) {
+          summaries.push(current.join('\n'));
+          current = [];
+        } else {
+          collecting = true;
+        }
+      }
+      continue;
+    }
+
+    current.push(line);
+    if (isProviderReplaySummaryEnd(trimmed)) {
+      summaries.push(current.join('\n'));
+      current = [];
+      collecting = false;
+    }
+  }
+
+  // 未闭合的 replay 摘要不恢复，fail-safe 地当普通文本剥离。
+  return summaries;
+}
+
+function parseProviderReplaySummaryToolCall(summary: string): ToolCall | null {
+  if (!summary.startsWith(PROVIDER_REPLAY_SUMMARY_PREFIX)) return null;
+  // Expected: [历史工具调用已转为摘要：... 工具=<name>，id=<id>，参数=<json>]
+  const toolMarkerIndex = summary.indexOf(PROVIDER_REPLAY_TOOL_MARKER);
+  const idMarkerIndex = summary.indexOf(PROVIDER_REPLAY_ID_MARKER, toolMarkerIndex);
+  const argsMarkerIndex = summary.indexOf(PROVIDER_REPLAY_ARGS_MARKER, idMarkerIndex);
+  if (toolMarkerIndex < 0 || idMarkerIndex < 0 || argsMarkerIndex < 0) return null;
+
+  const name = summary
+    .slice(toolMarkerIndex + PROVIDER_REPLAY_TOOL_MARKER.length, idMarkerIndex)
+    .trim();
+  const id = summary
+    .slice(idMarkerIndex + PROVIDER_REPLAY_ID_MARKER.length, argsMarkerIndex)
+    .trim();
+  if (!name || !id) return null;
+
+  const argsRaw = summary.slice(argsMarkerIndex + PROVIDER_REPLAY_ARGS_MARKER.length);
+  const jsonStart = argsRaw.indexOf('{');
+  const jsonEnd = argsRaw.lastIndexOf('}');
+  if (jsonStart < 0 || jsonEnd <= jsonStart) return null;
+
+  let args: unknown;
+  try {
+    args = JSON.parse(argsRaw.slice(jsonStart, jsonEnd + 1));
+  } catch {
+    return null;
+  }
+  if (!args || typeof args !== 'object' || Array.isArray(args)) return null;
+
+  return {
+    id,
+    type: 'function',
+    function: {
+      name,
+      arguments: JSON.stringify(args),
+    },
+  };
+}
+
+function isProviderReplaySummaryEnd(line: string): boolean {
+  if (!line.includes('{')) return line.endsWith(']');
+  return /\}\]$/.test(line);
 }
 
 function isInternalRuntimeErrorLine(line: string, allowGenericFailure: boolean): boolean {

--- a/tests/conversation-runner-transcript-normalization.test.ts
+++ b/tests/conversation-runner-transcript-normalization.test.ts
@@ -181,6 +181,234 @@ test('runner exposes assistant text before tool calls separately from working st
   assert.equal(result.response, '天气结果已整理。');
 });
 
+test('runner strips DeepSeek replay summary artifacts from final visible replies', async () => {
+  const leakedReplay = [
+    '明白，这次给你做个之前没做过的小游戏。',
+    '',
+    '[历史工具调用已转为摘要：DeepSeek thinking replay 缓存缺失，工具=write_file，id=call_function_1，参数={"content":"<!DOCTYPE html>',
+    '<html>',
+    '<script>',
+    'const levels = [1, 2, 3];',
+    '</script>',
+    '</html>","file_path":"E:\\\\tmp\\\\flappy.html"}]',
+  ].join('\n');
+  const mock = createMockAI([makeFinalResponse(leakedReplay)]);
+  const runner = new ConversationRunner(mock.aiService, new MockToolExecutor([], {}), {
+    stream: false,
+    enableCompression: false,
+  });
+
+  const result = await runner.run([{ role: 'user', content: '写个 html 游戏' }]);
+
+  assert.equal(result.response, '明白，这次给你做个之前没做过的小游戏。');
+  assert.deepEqual(
+    result.messages.filter(message => message.role === 'assistant').map(message => message.content),
+    ['明白，这次给你做个之前没做过的小游戏。'],
+  );
+  assert.doesNotMatch(JSON.stringify(result), /DeepSeek thinking replay|DOCTYPE html|flappy\.html/);
+});
+
+test('runner surfaces a clear fallback when final reply only contains replay artifacts', async () => {
+  const artifactOnly = [
+    '[历史工具调用已转为摘要：DeepSeek thinking replay 缓存缺失，工具=unknown_tool，id=call_function_2，参数={"content":"<!DOCTYPE html>',
+    '<html>hidden</html>","file_path":"E:\\\\tmp\\\\hidden.html"}]',
+  ].join('\n');
+  const mock = createMockAI([makeFinalResponse(artifactOnly)]);
+  const runner = new ConversationRunner(mock.aiService, new MockToolExecutor([], {}), {
+    stream: false,
+    enableCompression: false,
+  });
+
+  const result = await runner.run([{ role: 'user', content: '继续' }]);
+
+  assert.match(result.response, /模型工具调用回放异常/);
+  assert.doesNotMatch(JSON.stringify(result), /DOCTYPE html|hidden\.html/);
+});
+
+test('runner restores DeepSeek replay summaries into executable tool calls', async () => {
+  const replaySummary = [
+    '没看到吗？我再发一次。',
+    '',
+    '[历史工具调用已转为摘要：DeepSeek thinking replay 缓存缺失，工具=send_file，id=call_function_send_1，参数={"file_name":"flappy-bird.html","file_path":"E:/tmp/flappy-bird.html"}]',
+  ].join('\n');
+  const mock = createMockAI([
+    makeFinalResponse(replaySummary),
+    makeFinalResponse('已经重新发了一次。'),
+  ]);
+  const executor = new MockToolExecutor(
+    [{
+      name: 'send_file',
+      description: 'mock send file',
+      transcriptMode: 'outbound_file',
+      parameters: {
+        type: 'object',
+        properties: {
+          file_path: { type: 'string' },
+          file_name: { type: 'string' },
+        },
+        required: ['file_path'],
+      },
+    }],
+    { send_file: 'file sent' },
+  );
+  const runner = new ConversationRunner(mock.aiService, executor, {
+    stream: false,
+    enableCompression: false,
+    toolExecutionContext: {
+      workingDirectory: 'E:/tmp',
+    },
+  });
+
+  const result = await runner.run([{ role: 'user', content: '我没看到文件' }]);
+
+  assert.equal(executor.getExecutionCount('send_file'), 1);
+  assert.equal(result.response, '已经重新发了一次。');
+  assert.doesNotMatch(JSON.stringify(result), /DeepSeek thinking replay/);
+});
+
+test('runner does not restore DeepSeek replay summaries for state-changing tools', async () => {
+  const replaySummary = [
+    '[历史工具调用已转为摘要：DeepSeek thinking replay 缓存缺失，工具=execute_shell，id=call_function_shell_1，参数={"command":"echo should-not-run"}]',
+  ].join('\n');
+  const mock = createMockAI([makeFinalResponse(replaySummary)]);
+  const executor = new MockToolExecutor(
+    [{
+      name: 'execute_shell',
+      description: 'mock shell',
+      parameters: {
+        type: 'object',
+        properties: {
+          command: { type: 'string' },
+        },
+        required: ['command'],
+      },
+    }],
+    { execute_shell: 'should not run' },
+  );
+  const runner = new ConversationRunner(mock.aiService, executor, {
+    stream: false,
+    enableCompression: false,
+  });
+
+  const result = await runner.run([{ role: 'user', content: '继续' }]);
+
+  assert.equal(executor.getExecutionCount('execute_shell'), 0);
+  assert.match(result.response, /模型工具调用回放异常/);
+  assert.doesNotMatch(JSON.stringify(result), /should-not-run|DeepSeek thinking replay/);
+});
+
+test('runner does not restore outbound file replay summaries outside the current directory', async () => {
+  const replaySummary = [
+    '[历史工具调用已转为摘要：DeepSeek thinking replay 缓存缺失，工具=send_file，id=call_function_send_unsafe，参数={"file_name":"secret.txt","file_path":"E:/secrets/secret.txt"}]',
+  ].join('\n');
+  const mock = createMockAI([makeFinalResponse(replaySummary)]);
+  const executor = new MockToolExecutor(
+    [{
+      name: 'send_file',
+      description: 'mock send file',
+      transcriptMode: 'outbound_file',
+      parameters: {
+        type: 'object',
+        properties: {
+          file_path: { type: 'string' },
+          file_name: { type: 'string' },
+        },
+        required: ['file_path'],
+      },
+    }],
+    { send_file: 'file sent' },
+  );
+  const runner = new ConversationRunner(mock.aiService, executor, {
+    stream: false,
+    enableCompression: false,
+    toolExecutionContext: {
+      workingDirectory: 'E:/work/safe',
+    },
+  });
+
+  const result = await runner.run([{ role: 'user', content: '继续' }]);
+
+  assert.equal(executor.getExecutionCount('send_file'), 0);
+  assert.match(result.response, /模型工具调用回放异常/);
+  assert.doesNotMatch(JSON.stringify(result), /secret\.txt|DeepSeek thinking replay/);
+});
+
+test('runner does not restore outbound message replay summaries', async () => {
+  const replaySummary = [
+    '[历史工具调用已转为摘要：DeepSeek thinking replay 缓存缺失，工具=send_text，id=call_function_text_1，参数={"text":"should-not-send"}]',
+  ].join('\n');
+  const mock = createMockAI([makeFinalResponse(replaySummary)]);
+  const executor = new MockToolExecutor(
+    [{
+      name: 'send_text',
+      description: 'mock send text',
+      transcriptMode: 'outbound_message',
+      parameters: {
+        type: 'object',
+        properties: {
+          text: { type: 'string' },
+        },
+        required: ['text'],
+      },
+    }],
+    { send_text: 'sent' },
+  );
+  const runner = new ConversationRunner(mock.aiService, executor, {
+    stream: false,
+    enableCompression: false,
+  });
+
+  const result = await runner.run([{ role: 'user', content: '继续' }]);
+
+  assert.equal(executor.getExecutionCount('send_text'), 0);
+  assert.match(result.response, /模型工具调用回放异常/);
+  assert.doesNotMatch(JSON.stringify(result), /should-not-send|DeepSeek thinking replay/);
+});
+
+test('runner keeps normal providerContent tool replay for M3 style tool calls', async () => {
+  const toolCall = makeToolCall('call_m3_1', 'execute_shell', { command: 'echo ok' });
+  const mock = createMockAI([
+    {
+      content: null,
+      toolCalls: [toolCall],
+      providerContent: [
+        { type: 'thinking', thinking: 'hidden reasoning', signature: 'sig_m3' },
+        { type: 'tool_use', id: 'call_m3_1', name: 'execute_shell', input: { command: 'echo ok' } },
+      ],
+      usage: {
+        promptTokens: 100,
+        completionTokens: 20,
+        totalTokens: 120,
+      },
+    },
+    makeFinalResponse('done'),
+  ]);
+  const runner = new ConversationRunner(mock.aiService, new MockToolExecutor([{
+    name: 'execute_shell',
+    description: 'mock shell',
+    parameters: {
+      type: 'object',
+      properties: {
+        command: { type: 'string' },
+      },
+      required: ['command'],
+    },
+  }], { execute_shell: 'ok' }), {
+    stream: false,
+    enableCompression: false,
+  });
+
+  const result = await runner.run([{ role: 'user', content: 'run shell' }]);
+  const assistantWithTool = result.messages.find(message => message.role === 'assistant' && message.tool_calls?.length);
+
+  assert.equal(result.response, 'done');
+  assert.deepEqual(assistantWithTool?.tool_calls?.map(call => call.id), ['call_m3_1']);
+  assert.deepEqual(assistantWithTool?.providerContent?.map(block => block.type === 'tool_use' ? block.id : block.type), [
+    'thinking',
+    'call_m3_1',
+  ]);
+});
+
 test('runner injects tool target context into provider transcript only', async () => {
   const responses = [
     makeToolResponse(makeToolCall('call_1', 'execute_shell', { command: 'echo ok' })),

--- a/tests/memory-branch-tools.test.ts
+++ b/tests/memory-branch-tools.test.ts
@@ -176,6 +176,43 @@ describe('memory branch tools', () => {
     assert.equal(parsed.truncated, true);
     assert.match(parsed.text, /truncated field/);
   });
+
+  test('read strips DeepSeek replay summary artifacts from historical assistant text', async () => {
+    const leakedReplay = [
+      '先给你做个小游戏。',
+      '',
+      '[历史工具调用已转为摘要：DeepSeek thinking replay 缓存缺失，工具=write_file，id=call_function_1，参数={"content":"<!DOCTYPE html>',
+      '<html>',
+      '<script>',
+      'const levels = [1, 2, 3];',
+      '</script>',
+      '</html>","file_path":"E:\\\\tmp\\\\flappy.html"}]',
+    ].join('\n');
+    writeSessionLog(testRoot, [
+      turn(1, '2026-06-16T10:00:00.000Z', '写个游戏', leakedReplay),
+    ]);
+
+    const store = new MemoryLogStore(testRoot);
+    const readTool = new MemoryReadTurnTool(store);
+    const result = await readTool.execute({
+      ref: 'chat/2026-06-16/demo.jsonl#1',
+      budget_chars: 4000,
+    }, { workingDirectory: testRoot, conversationHistory: [] });
+
+    assert.equal(result.ok, true);
+    const parsed = JSON.parse(String(result.content));
+    assert.match(parsed.text, /ASSISTANT_FINAL:\n先给你做个小游戏。/);
+    assert.doesNotMatch(parsed.text, /DeepSeek thinking replay|DOCTYPE html|flappy\.html/);
+
+    const searchTool = new MemorySearchTool(store);
+    const search = await searchTool.execute({
+      keywords: ['flappy.html'],
+      start_time: '2026-06-16T00:00:00.000Z',
+      end_time: '2026-06-16T23:59:59.999Z',
+    }, { workingDirectory: testRoot, conversationHistory: [] });
+    assert.equal(search.ok, true);
+    assert.deepEqual(JSON.parse(String(search.content)).matches, []);
+  });
 });
 
 function writeSessionLog(root: string, entries: unknown[]): void {


### PR DESCRIPTION
## 背景
DeepSeek V4 的 thinking/tool replay 在历史回放缓存缺失时，可能把内部占位文本直接作为 assistant 可见回复返回，例如 `[历史工具调用已转为摘要：DeepSeek thinking replay 缓存缺失 ...]`，甚至携带 `write_file` 参数中的 HTML 内容。

## 改动
- 扩展 transcript artifact 过滤，识别并移除多行 DeepSeek/provider replay 摘要占位。
- ConversationRunner 在最终回复和工具前文本出口过滤内部 replay 占位；artifact-only 回复给出可见收束提示，不再泄漏内部参数。
- MemoryLogStore 在搜索和 read_turn 时过滤历史 assistant replay 污染，避免旧日志再次喂给 memory sidecar。
- 补充 ConversationRunner 和 memory 分支回归测试。

## 设计说明
不把 provider 原始 thinking 接入 CatsCo durable history。CatsCo 只保存用户可见文本和合法 tool_use/tool_result；M3、DeepSeek 等 provider-specific thinking 仍由 provider/relay adapter 处理，避免协议互相污染。

## 验证
- `npx tsx --test tests/conversation-runner-transcript-normalization.test.ts tests/memory-branch-tools.test.ts`
- `npm.cmd run build`
- `git diff --check`（仅 Windows 行尾提示）