### PR TITLE
fix: keep prompt mode routing out of main tools

### DIFF
--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -96,6 +96,7 @@ const EMPTY_MAX_TOKENS_MESSAGE = '模型这轮输出达到了 max_tokens 上限�
 const REPLAY_ARTIFACT_ONLY_MESSAGE = '模型工具调用回放异常，这轮没有生成可见回复。上下文已保留；你可以直接说“继续”，我会从这里接上。';
 export const PROMPT_BUDGET_TRIM_MESSAGE = '当前上下文超过模型窗口，已裁剪较早的历史内容以继续处理。';
 export const PROMPT_TOOLS_DISABLED_MESSAGE = '当前模型上下文不足以加载全部工具，本轮已先按纯文本继续处理。';
+const MAIN_AGENT_HIDDEN_TOOL_NAMES = new Set(['prompt_mode']);
 const MAX_VISIBLE_TOOL_PRELUDE_CHARS = 64;
 const MAX_VISIBLE_TOOL_PRELUDE_LINES = 2;
 
@@ -280,7 +281,8 @@ export class ConversationRunner {
   async run(messages: Message[], callbacks?: RunnerCallbacks): Promise<RunResult> {
     const allTools = this.toolExecutor.getToolDefinitions();
     const supportsToolCalling = (this.aiService as any).isToolCallingSupported?.() !== false;
-    const activeTools = supportsToolCalling ? allTools : [];
+    const providerTools = allTools.filter(tool => !MAIN_AGENT_HIDDEN_TOOL_NAMES.has(tool.name));
+    const activeTools = supportsToolCalling ? providerTools : [];
     if (activeTools.length === 0 && allTools.length > 0) {
       Logger.warning(`[${this.sessionLabel}] 当前模型/中转暂不启用工具调用，已按纯文本模型运行`);
     }
@@ -319,6 +321,7 @@ export class ConversationRunner {
       this.injectSyntheticObservations(messages, turns);
       const runtimeTransientHints = this.drainRuntimeTransientMessages(turns);
       const requestTools = this.fitToolsToPromptBudget(activeTools);
+      const requestToolNames = new Set(requestTools.map(tool => tool.name));
       if (requestTools.length < activeTools.length && !notifiedToolBudgetDisabled) {
         notifiedToolBudgetDisabled = true;
         if (callbacks?.onThinking) {
@@ -667,16 +670,31 @@ export class ConversationRunner {
         const toolUseId = toolCall.id;
         const toolInput = JSON.parse(toolCall.function.arguments);
         const transcriptMode = this.getToolTranscriptMode(toolName, toolDefinitions);
-        callbacks?.onToolStart?.(toolName, toolUseId, toolInput);
-        Logger.info(`[${this.sessionLabel}Turn ${turns}] 执行工具: ${toolName} | 参数: ${ConversationRunner.truncateForLog(toolCall.function.arguments, 500)}`);
-        const activeToolNames = allTools.map(tool => tool.name);
+        const normalizedToolName = normalizeToolName(toolName);
+        const toolWasExposed = requestToolNames.has(normalizedToolName);
         const toolStart = Date.now();
-        const result = await this.executeToolWithRetry(
-          toolCall,
-          messages,
-          this.toolExecutionContext || {},
-          turns,
-        );
+        let result: ToolResult;
+        if (!toolWasExposed) {
+          Logger.warning(`[${this.sessionLabel}Turn ${turns}] 模型调用了当前未暴露的工具: ${toolName}`);
+          result = {
+            tool_call_id: toolUseId,
+            role: 'tool',
+            name: normalizedToolName,
+            content: `错误：工具 "${toolName}" 当前不可用。`,
+            ok: false,
+            errorCode: 'TOOL_NOT_FOUND',
+            retryable: false,
+          };
+        } else {
+          callbacks?.onToolStart?.(toolName, toolUseId, toolInput);
+          Logger.info(`[${this.sessionLabel}Turn ${turns}] 执行工具: ${toolName} | 参数: ${ConversationRunner.truncateForLog(toolCall.function.arguments, 500)}`);
+          result = await this.executeToolWithRetry(
+            toolCall,
+            messages,
+            this.toolExecutionContext || {},
+            turns,
+          );
+        }
         executedToolCalls++;
         if (toolName === PLAN_TOOL_NAME) {
           hasUpdatedPlan = true;
@@ -689,7 +707,9 @@ export class ConversationRunner {
         Metrics.recordToolCall(toolName, toolDuration);
         this.promptTraceLogger.recordToolResult(turns, toolCall, result, toolDuration);
         Logger.info(`[${this.sessionLabel}Turn ${turns}] 工具完成: ${toolName} | 耗时: ${toolDuration}ms | 结果: ${ConversationRunner.truncateForLog(result.content, 300)}`);
-        callbacks?.onToolEnd?.(toolName, toolUseId, contentToString(result.content));
+        if (toolWasExposed) {
+          callbacks?.onToolEnd?.(toolName, toolUseId, contentToString(result.content));
+        }
 
         if (
           (transcriptMode === 'outbound_message' || transcriptMode === 'outbound_file')
@@ -701,7 +721,9 @@ export class ConversationRunner {
 
         const toolContent = prependToolTargetContext(result.content, result.targetContext);
 
-        this.handleToolDisplay(toolCall, contentToString(result.content), callbacks);
+        if (toolWasExposed) {
+          this.handleToolDisplay(toolCall, contentToString(result.content), callbacks);
+        }
         executionRecords.push({
           toolCall,
           toolName,

--- a/src/core/prompt-mode-runtime.ts
+++ b/src/core/prompt-mode-runtime.ts
@@ -198,7 +198,7 @@ export class PromptModeRuntime {
         this.formatModeTimingLine(this.active, turnNumber),
         `Full mode instructions refresh every ${this.fullPromptRefreshInterval} active turn(s).`,
         'Apply this mode where it fits the current user request. If the user has clearly changed topic, follow the user and do not force this mode.',
-        'If the user explicitly asks to leave or disable this mode, call prompt_mode with mode "clear" before answering.',
+        'If the user explicitly asks to leave or disable this mode, stop applying the active mode and answer the user normally.',
         ...(
           content
             ? ['', content]

--- a/src/core/turn-context-builder.ts
+++ b/src/core/turn-context-builder.ts
@@ -30,9 +30,7 @@ import {
   TRANSIENT_FIXED_PROMPT_MODE_PREFIX,
   TRANSIENT_PROMPT_MODES_LIST_PREFIX,
   buildFixedPromptModeMessage,
-  buildPromptModesListMessage,
   findFixedPromptModeState,
-  findPreviousPromptModeState,
 } from '../runtime/prompt-modes';
 import { resolveTurnContextTransientPolicy } from './transient-injection-policy';
 import { TRANSIENT_PENDING_USER_INPUT_PREFIX } from './pending-user-input-boundary';
@@ -192,21 +190,12 @@ export class TurnContextBuilder {
 
   private injectPromptModesList(
     messages: Message[],
-    options: { promptModeRoutingEnabled?: boolean } = {},
+    _options: { promptModeRoutingEnabled?: boolean } = {},
   ): void {
     const fixedMode = findFixedPromptModeState(messages);
     if (fixedMode) {
       this.insertBeforeLastUser(messages, buildFixedPromptModeMessage(fixedMode));
-      return;
     }
-
-    if (options.promptModeRoutingEnabled) return;
-
-    const modeList = buildPromptModesListMessage({
-      previousMode: findPreviousPromptModeState(messages),
-    });
-    if (!modeList) return;
-    this.insertBeforeLastUser(messages, modeList);
   }
 
   private extractRuntimeFeedback(messages: Message[]): string[] {

--- a/src/runtime/prompt-modes.ts
+++ b/src/runtime/prompt-modes.ts
@@ -105,7 +105,7 @@ export function buildFixedPromptModeMessage(
       TRANSIENT_FIXED_PROMPT_MODE_PREFIX,
       `Fixed prompt mode active: ${fixedMode.mode} (${fixedMode.title}).`,
       'This mode is already part of the system prompt.',
-      'Do not call prompt_mode or load another prompt mode unless the user explicitly asks to change the fixed profile.',
+      'Do not load another prompt mode unless the runtime profile changes.',
     ].join('\n'),
     __injected: true,
   };
@@ -156,7 +156,7 @@ export function buildPromptModesListMessage(
       '',
       `Previously active prompt mode: ${options.previousMode.mode} (${options.previousMode.title}), last loaded ${formatTurnsAgo(options.previousMode.turnsSinceLoaded)}.`,
       'Use the previous mode only if the current user message continues the same task. If the user changed task, ignore it.',
-      'If you need the full previous mode instructions again, call prompt_mode with that mode id.',
+      'Do not load prompt modes directly; current mode selection is handled by runtime routing.',
     ].join('\n')
     : '';
 
@@ -165,8 +165,8 @@ export function buildPromptModesListMessage(
     content: [
       TRANSIENT_PROMPT_MODES_LIST_PREFIX,
       'Available prompt modes. This is routing context, not a user request.',
-      'If one mode clearly helps with the current real user message, call the prompt_mode tool with that mode id before answering.',
-      'If no mode is clearly useful, ignore this list and answer normally.',
+      'Do not select or load prompt modes directly; current mode selection is handled by runtime routing.',
+      'If no active mode is supplied by runtime routing, answer normally.',
       previousMode,
       '',
       modeList,

--- a/src/tools/default-tool-names.ts
+++ b/src/tools/default-tool-names.ts
@@ -15,7 +15,6 @@ export const DEFAULT_TOOL_NAMES = [
   'update_plan',
   'record_decision',
   'share_skillhub_skill',
-  'prompt_mode',
   'skill',
 ] as const;
 

--- a/src/tools/tool-manager.ts
+++ b/src/tools/tool-manager.ts
@@ -18,7 +18,6 @@ import { UpdatePlanTool } from './update-plan-tool';
 import { RecordDecisionTool } from './record-decision-tool';
 import { ShareSkillHubSkillTool } from './share-skillhub-skill-tool';
 import { AskParentTool } from './ask-parent-tool';
-import { PromptModeTool } from './prompt-mode-tool';
 import { DEFAULT_TOOL_NAMES } from './default-tool-names';
 import { mergeToolExecutionContext } from '../utils/tool-context';
 import { confirmLocalToolExecution } from './local-tool-risk';
@@ -95,7 +94,6 @@ export class ToolManager implements ToolExecutor {
       new UpdatePlanTool(),
       new RecordDecisionTool(),
       new ShareSkillHubSkillTool(),
-      new PromptModeTool(),
       new SkillTool(),
     ];
 

--- a/tests/conversation-runner-runtime-transient.test.ts
+++ b/tests/conversation-runner-runtime-transient.test.ts
@@ -42,6 +42,42 @@ class NoopToolExecutor implements ToolExecutor {
   }
 }
 
+class PromptModeToolExecutor implements ToolExecutor {
+  executeCount = 0;
+
+  getToolDefinitions(): ToolDefinition[] {
+    return [
+      {
+        name: 'prompt_mode',
+        description: 'loads a prompt mode',
+        parameters: {
+          type: 'object',
+          properties: {
+            mode: { type: 'string' },
+          },
+          required: ['mode'],
+        },
+      },
+      {
+        name: 'noop',
+        description: 'noop',
+        parameters: { type: 'object', properties: {} },
+      },
+    ];
+  }
+
+  async executeTool(toolCall: ToolCall): Promise<ToolResult> {
+    this.executeCount += 1;
+    return {
+      tool_call_id: toolCall.id,
+      role: 'tool',
+      name: toolCall.function.name,
+      content: 'ok',
+      ok: true,
+    };
+  }
+}
+
 describe('ConversationRunner runtime transient messages', () => {
   test('injects runtime transient context into a later provider call in the same run', async () => {
     const received: Message[][] = [];
@@ -90,5 +126,78 @@ describe('ConversationRunner runtime transient messages', () => {
       received[1].some(message => typeof message.content === 'string' && message.content.startsWith(TRANSIENT_ACTIVE_PROMPT_MODE_PREFIX)),
       true,
     );
+  });
+
+  test('does not expose prompt_mode to the main agent provider tools', async () => {
+    const receivedTools: string[][] = [];
+    const aiService = {
+      chat: async (_messages: Message[], tools: ToolDefinition[] = []) => {
+        receivedTools.push(tools.map(tool => tool.name));
+        return {
+          content: 'done',
+          toolCalls: [],
+          usage,
+        };
+      },
+    } as any;
+
+    const runner = new ConversationRunner(aiService, new PromptModeToolExecutor(), {
+      stream: false,
+      enableCompression: false,
+    });
+
+    await runner.run([{ role: 'user', content: '准备一节公开课' }]);
+
+    assert.deepEqual(receivedTools, [['noop']]);
+  });
+
+  test('does not execute or surface prompt_mode even if the model calls it', async () => {
+    const executor = new PromptModeToolExecutor();
+    const responses: ChatResponse[] = [
+      {
+        content: null,
+        toolCalls: [{
+          id: 'call_prompt_mode',
+          type: 'function',
+          function: {
+            name: 'prompt_mode',
+            arguments: JSON.stringify({ mode: 'classroom' }),
+          },
+        }],
+        usage,
+      },
+      {
+        content: 'done',
+        toolCalls: [],
+        usage,
+      },
+    ];
+    const receivedTools: string[][] = [];
+    const aiService = {
+      chat: async (_messages: Message[], tools: ToolDefinition[] = []) => {
+        receivedTools.push(tools.map(tool => tool.name));
+        return responses[receivedTools.length - 1];
+      },
+    } as any;
+    const callbackEvents: string[] = [];
+
+    const runner = new ConversationRunner(aiService, executor, {
+      stream: false,
+      enableCompression: false,
+    });
+
+    const result = await runner.run(
+      [{ role: 'user', content: '准备一节公开课' }],
+      {
+        onToolStart: name => callbackEvents.push(`start:${name}`),
+        onToolEnd: name => callbackEvents.push(`end:${name}`),
+        onToolDisplay: name => callbackEvents.push(`display:${name}`),
+      },
+    );
+
+    assert.equal(result.response, 'done');
+    assert.deepEqual(receivedTools, [['noop'], ['noop']]);
+    assert.equal(executor.executeCount, 0);
+    assert.deepEqual(callbackEvents, []);
   });
 });

--- a/tests/prompt-mode-tool.test.ts
+++ b/tests/prompt-mode-tool.test.ts
@@ -31,10 +31,10 @@ test('prompt_mode tool loads plain-chat instructions on demand', async () => {
   assert.match(String(result.content), /角色扮演/);
 });
 
-test('prompt_mode is available as a default runtime tool', () => {
+test('prompt_mode is not exposed as a default runtime tool', () => {
   const manager = new ToolManager(process.cwd());
 
-  assert.ok(manager.getToolDefinitions().some(tool => tool.name === 'prompt_mode'));
+  assert.equal(manager.getToolDefinitions().some(tool => tool.name === 'prompt_mode'), false);
 });
 
 test('prompt_mode can clear an async active mode through runtime context', async () => {

--- a/tests/prompt-modes.test.ts
+++ b/tests/prompt-modes.test.ts
@@ -42,7 +42,7 @@ describe('prompt modes', () => {
     }
   });
 
-  test('injects prompt mode list as injected transient context, not a guessed mode', async () => {
+  test('does not inject selectable prompt modes into the main agent context', async () => {
     const builder = new TurnContextBuilder();
     const durableMessages: Message[] = [
       { role: 'system', content: 'base system' },
@@ -59,23 +59,7 @@ describe('prompt modes', () => {
       } as any,
     });
 
-    const modeList = result.messages.find(message => (
-      message.role === 'user'
-      && message.__injected
-      && typeof message.content === 'string'
-      && message.content.startsWith(TRANSIENT_PROMPT_MODES_LIST_PREFIX)
-    ));
-
-    assert.ok(modeList);
-    assert.match(String(modeList.content), /Available prompt modes/);
-    assert.match(String(modeList.content), /coding-agent: 工程协作模式/);
-    assert.match(String(modeList.content), /plain-chat: 普通对话模式/);
-    assert.match(String(modeList.content), /call the prompt_mode tool/);
-    assert.doesNotMatch(String(modeList.content), /Matched aliases:/);
-    assert.doesNotMatch(String(modeList.content), /Candidate mode:/);
-
-    const durable = builder.removeTransientMessages(result.messages);
-    assert.equal(durable.some(message => (
+    assert.equal(result.messages.some(message => (
       typeof message.content === 'string'
       && message.content.startsWith(TRANSIENT_PROMPT_MODES_LIST_PREFIX)
     )), false);
@@ -144,11 +128,7 @@ describe('prompt modes', () => {
       && message.content.startsWith(TRANSIENT_PROMPT_MODES_LIST_PREFIX)
     ));
 
-    assert.ok(modeList);
-    assert.match(String(modeList.content), /Previously active prompt mode: coding-agent/);
-    assert.match(String(modeList.content), /last loaded 1 user turn ago/);
-    assert.match(String(modeList.content), /Use the previous mode only if/);
-    assert.match(String(modeList.content), /If the user changed task, ignore it/);
+    assert.equal(modeList, undefined);
   });
 
   test('fixed prompt mode suppresses selectable mode list', async () => {

--- a/tests/runtime-characterization.test.ts
+++ b/tests/runtime-characterization.test.ts
@@ -81,7 +81,6 @@ describe('runtime characterization', () => {
         'execute_shell',
         'glob',
         'grep',
-        'prompt_mode',
         'read_file',
         'record_decision',
         'resolve_common_directory',


### PR DESCRIPTION
## Summary
- remove the legacy `prompt_mode` tool from the default main-agent tool set
- stop injecting selectable prompt-mode lists into the main-agent context
- add a runner-level fallback so hallucinated hidden tools are not executed or surfaced

## Test Plan
- `node node_modules\tsx\dist\cli.mjs --test tests\conversation-runner-runtime-transient.test.ts tests\prompt-modes.test.ts tests\prompt-mode-runtime.test.ts tests\agent-turn-mode-router.test.ts tests\prompt-mode-tool.test.ts tests\runtime-characterization.test.ts`
- `node node_modules\tsx\dist\cli.mjs --test tests\mode-router-branch.test.ts tests\sidecar-memory-branch.test.ts tests\agent-turn-mode-router.test.ts`
- `npm run build`