### PR TITLE
[codex] trim truncated tool result metadata

### DIFF
--- a/src/core/execute-shell-message-folder.ts
+++ b/src/core/execute-shell-message-folder.ts
@@ -54,12 +54,7 @@ interface FoldCandidate {
 
 interface ShellMetadata {
   command?: string;
-  description?: string;
-  timeout?: number;
-  cwd?: string;
   status?: 'succeeded' | 'failed' | 'unknown';
-  elapsed?: string;
-  outputLines?: string;
 }
 
 const DEFAULT_OPTIONS: ExecuteShellMessageFoldingOptions = {
@@ -232,27 +227,16 @@ function buildFoldedExecuteShellContent(
     rawText: candidate.rawText,
     store: options.artifactStore,
   });
+  const fullOutput = selectFullOutputReference(artifact);
 
   const foldedParts = [
     TRUNCATED_EXECUTE_SHELL_PREFIX,
-    `artifact_id: ${artifact.artifactId}`,
-    artifact.ref ? `full_output_ref: ${artifact.ref}` : '',
-    artifact.filePath ? `full_output_path: ${artifact.filePath}` : '',
-    artifact.fileUri ? `full_output_link: ${artifact.fileUri}` : '',
-    artifact.writeError ? `full_output_store_error: ${oneLine(artifact.writeError, 300)}` : '',
+    fullOutput ? `full_output: ${fullOutput}` : '',
     metadata.command ? `command: ${oneLine(metadata.command, 1600)}` : '',
-    metadata.description ? `description: ${oneLine(metadata.description, 400)}` : '',
-    metadata.cwd ? `cwd: ${metadata.cwd}` : '',
-    metadata.timeout ? `timeout_ms: ${metadata.timeout}` : '',
     metadata.status ? `status: ${metadata.status}` : '',
-    metadata.elapsed ? `elapsed: ${metadata.elapsed}` : '',
-    metadata.outputLines ? `output_lines: ${metadata.outputLines}` : '',
-    `original_chars: ${candidate.rawText.length}`,
-    `original_lines: ${lines.length}`,
-    `original_tokens_est: ${candidate.rawTokens}`,
-    `sha256: ${hash}`,
+    `omitted: ${formatOmitted(lines.length, candidate.rawText.length)}`,
     '',
-    'summary: Historical execute_shell output was truncated out of the provider prompt. Use full_output_path/full_output_ref, re-run the command, or inspect logs before relying on omitted lines.',
+    'summary: Historical execute_shell output was truncated out of the provider prompt. Open full_output, re-run the command, or inspect logs before relying on omitted lines.',
     headLines.length > 0 ? ['head:', ...headLines.map(line => `  ${line}`)].join('\n') : '',
     tailLines.length > 0 ? ['tail:', ...tailLines.map(line => `  ${line}`)].join('\n') : '',
     keyLines.length > 0 ? ['key_lines:', ...keyLines.map(line => `  ${line}`)].join('\n') : '',
@@ -268,12 +252,7 @@ function extractShellMetadata(
   const args = parseToolArguments(toolCall);
   return {
     command: firstNonEmpty(stringArg(args, 'command'), readCommand(rawText)),
-    description: stringArg(args, 'description'),
-    timeout: numberArg(args, 'timeout'),
-    cwd: firstNonEmpty(stringArg(args, 'cwd'), stringArg(args, 'workingDirectory')),
     status: readStatus(rawText),
-    elapsed: readHeader(rawText, 'Elapsed'),
-    outputLines: readHeader(rawText, 'Output lines'),
   };
 }
 
@@ -304,6 +283,15 @@ function normalizeToolName(name: string): string {
 function isAlreadyTruncated(rawText: string): boolean {
   return rawText.startsWith(TRUNCATED_EXECUTE_SHELL_PREFIX)
     || rawText.startsWith(LEGACY_FOLDED_EXECUTE_SHELL_PREFIX);
+}
+
+function selectFullOutputReference(artifact: ReturnType<typeof persistToolResultArtifact>): string | undefined {
+  return artifact.fileUri || artifact.filePath || artifact.ref;
+}
+
+function formatOmitted(lines: number, chars: number): string {
+  const lineLabel = lines === 1 ? 'line' : 'lines';
+  return `${lines} ${lineLabel}, ${chars} chars`;
 }
 
 function findLastRealUserIndex(messages: Message[]): number {
@@ -355,12 +343,6 @@ function readStatus(rawText: string): ShellMetadata['status'] {
   return 'unknown';
 }
 
-function readHeader(rawText: string, label: string): string | undefined {
-  const escapedLabel = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const match = rawText.match(new RegExp(`^${escapedLabel}:\\s*(.+)$`, 'm'));
-  return match?.[1]?.trim() || undefined;
-}
-
 function parseToolArguments(toolCall?: NonNullable<Message['tool_calls']>[number]): Record<string, unknown> {
   if (!toolCall?.function?.arguments) return {};
   try {
@@ -376,11 +358,6 @@ function parseToolArguments(toolCall?: NonNullable<Message['tool_calls']>[number
 function stringArg(args: Record<string, unknown>, key: string): string | undefined {
   const value = args[key];
   return typeof value === 'string' && value.trim() ? value.trim() : undefined;
-}
-
-function numberArg(args: Record<string, unknown>, key: string): number | undefined {
-  const value = Number(args[key]);
-  return Number.isFinite(value) && value > 0 ? value : undefined;
 }
 
 function firstNonEmpty(...values: Array<string | undefined>): string | undefined {

--- a/src/core/read-file-message-folder.ts
+++ b/src/core/read-file-message-folder.ts
@@ -215,22 +215,15 @@ function buildFoldedReadFileContent(
     rawText: candidate.rawText,
     store: options.artifactStore,
   });
+  const fullOutput = selectFullOutputReference(artifact);
   const foldedParts = [
     TRUNCATED_READ_FILE_PREFIX,
-    `artifact_id: ${artifact.artifactId}`,
-    artifact.ref ? `full_output_ref: ${artifact.ref}` : '',
-    artifact.filePath ? `full_output_path: ${artifact.filePath}` : '',
-    artifact.fileUri ? `full_output_link: ${artifact.fileUri}` : '',
-    artifact.writeError ? `full_output_store_error: ${oneLine(artifact.writeError, 300)}` : '',
-    metadata.file ? `file: ${metadata.file}` : '',
+    fullOutput ? `full_output: ${fullOutput}` : '',
     metadata.path ? `path: ${metadata.path}` : '',
     metadata.display ? `range: ${metadata.display}` : '',
-    metadata.totalLines ? `total_lines: ${metadata.totalLines}` : '',
-    `original_chars: ${candidate.rawText.length}`,
-    `original_tokens_est: ${candidate.rawTokens}`,
-    `sha256: ${hash}`,
+    `omitted: ${formatOmitted(lines.length, candidate.rawText.length)}`,
     '',
-    'summary: Historical read_file output was truncated out of the provider prompt. Use full_output_path/full_output_ref or re-read this file/range before exact edits or quoting.',
+    'summary: Historical read_file output was truncated out of the provider prompt. Open full_output or re-read this file/range before exact edits or quoting.',
     previewLines.length > 0 ? ['preview:', ...previewLines.map(line => `  ${line}`)].join('\n') : '',
     symbolLines.length > 0 ? ['key_symbols:', ...symbolLines.map(line => `  ${line}`)].join('\n') : '',
   ];
@@ -281,6 +274,15 @@ function normalizeToolName(name: string): string {
 function isAlreadyTruncated(rawText: string): boolean {
   return rawText.startsWith(TRUNCATED_READ_FILE_PREFIX)
     || rawText.startsWith(LEGACY_FOLDED_READ_FILE_PREFIX);
+}
+
+function selectFullOutputReference(artifact: ReturnType<typeof persistToolResultArtifact>): string | undefined {
+  return artifact.fileUri || artifact.filePath || artifact.ref;
+}
+
+function formatOmitted(lines: number, chars: number): string {
+  const lineLabel = lines === 1 ? 'line' : 'lines';
+  return `${lines} ${lineLabel}, ${chars} chars`;
 }
 
 function findLastRealUserIndex(messages: Message[]): number {
@@ -358,12 +360,6 @@ function buildDisplayFromArgs(args: Record<string, unknown>): string | undefined
 
 function firstNonEmpty(...values: Array<string | undefined>): string | undefined {
   return values.find(value => Boolean(value && value.trim()));
-}
-
-function oneLine(value: string, maxLength: number): string {
-  const trimmed = value.replace(/\r?\n/g, ' ; ').trim();
-  if (trimmed.length <= maxLength) return trimmed;
-  return `${trimmed.slice(0, maxLength - 20)}...(truncated ${trimmed.length} chars)`;
 }
 
 function readBooleanEnv(value: string | undefined, fallback: boolean): boolean {

--- a/tests/execute-shell-message-folder.test.ts
+++ b/tests/execute-shell-message-folder.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { fileURLToPath } from 'url';
 import {
   TRUNCATED_EXECUTE_SHELL_PREFIX,
   foldHistoricalExecuteShellMessages,
@@ -71,9 +72,9 @@ test('folds large historical execute_shell results while preserving tool exchang
   assert.equal(folded.name, 'execute_shell');
   assert.equal(typeof folded.content, 'string');
   assert.ok(String(folded.content).startsWith(TRUNCATED_EXECUTE_SHELL_PREFIX));
-  assert.match(String(folded.content), /artifact_id: sh_[a-f0-9]{16}/);
   assert.match(String(folded.content), /command: npm test/);
   assert.match(String(folded.content), /status: failed/);
+  assert.match(String(folded.content), /omitted: \d+ lines, \d+ chars/);
   assert.match(String(folded.content), /ERROR failed at src\/broken\.ts:123/);
   assert.equal(String(folded.content).includes('plain shell output line 45'), false);
   assert.ok(result.stats.saved_tokens_est > 0);
@@ -101,13 +102,16 @@ test('writes truncated execute_shell full output to a linkable artifact', () => 
       },
     });
     const content = String(result.messages[2].content);
-    const fullOutputPath = content.match(/^full_output_path: (.+)$/m)?.[1];
+    const fullOutput = content.match(/^full_output: (.+)$/m)?.[1];
 
     assert.ok(content.startsWith(TRUNCATED_EXECUTE_SHELL_PREFIX));
-    assert.match(content, /full_output_ref: tool-result:\/\/test_session\/turn-0009\/sh_[a-f0-9]{16}/);
-    assert.match(content, /full_output_link: file:\/\//);
-    assert.ok(fullOutputPath);
-    assert.equal(fs.readFileSync(fullOutputPath, 'utf8').includes(raw), true);
+    assert.match(content, /^full_output: file:\/\//m);
+    assert.doesNotMatch(content, /^artifact_id:/m);
+    assert.doesNotMatch(content, /^full_output_ref:/m);
+    assert.doesNotMatch(content, /^full_output_path:/m);
+    assert.doesNotMatch(content, /^full_output_link:/m);
+    assert.ok(fullOutput);
+    assert.equal(fs.readFileSync(fileURLToPath(fullOutput), 'utf8').includes(raw), true);
   } finally {
     fs.rmSync(artifactRoot, { recursive: true, force: true });
   }

--- a/tests/read-file-message-folder.test.ts
+++ b/tests/read-file-message-folder.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { fileURLToPath } from 'url';
 import {
   TRUNCATED_READ_FILE_PREFIX,
   foldHistoricalReadFileMessages,
@@ -65,8 +66,8 @@ test('folds large historical read_file tool results while preserving tool exchan
   assert.equal(folded.name, 'read_file');
   assert.equal(typeof folded.content, 'string');
   assert.ok(String(folded.content).startsWith(TRUNCATED_READ_FILE_PREFIX));
-  assert.match(String(folded.content), /artifact_id: rf_[a-f0-9]{16}/);
   assert.match(String(folded.content), /path: E:\/repo\/large\.ts/);
+  assert.match(String(folded.content), /omitted: \d+ lines, \d+ chars/);
   assert.equal(String(folded.content).includes('plain historical content line 45'), false);
   assert.ok(result.stats.saved_tokens_est > 0);
 });
@@ -93,13 +94,16 @@ test('writes truncated read_file full output to a linkable artifact', () => {
       },
     });
     const content = String(result.messages[2].content);
-    const fullOutputPath = content.match(/^full_output_path: (.+)$/m)?.[1];
+    const fullOutput = content.match(/^full_output: (.+)$/m)?.[1];
 
     assert.ok(content.startsWith(TRUNCATED_READ_FILE_PREFIX));
-    assert.match(content, /full_output_ref: tool-result:\/\/test_session\/turn-0007\/rf_[a-f0-9]{16}/);
-    assert.match(content, /full_output_link: file:\/\//);
-    assert.ok(fullOutputPath);
-    assert.equal(fs.readFileSync(fullOutputPath, 'utf8').includes(raw), true);
+    assert.match(content, /^full_output: file:\/\//m);
+    assert.doesNotMatch(content, /^artifact_id:/m);
+    assert.doesNotMatch(content, /^full_output_ref:/m);
+    assert.doesNotMatch(content, /^full_output_path:/m);
+    assert.doesNotMatch(content, /^full_output_link:/m);
+    assert.ok(fullOutput);
+    assert.equal(fs.readFileSync(fileURLToPath(fullOutput), 'utf8').includes(raw), true);
   } finally {
     fs.rmSync(artifactRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
## What changed

- Keeps truncated tool result summaries in the existing text format, but removes provider-visible debug metadata.
- Replaces the previous `artifact_id` + `full_output_ref/path/link` set with a single `full_output` line.
- Removes `sha256`, `original_*`, and other nonessential metadata from provider-visible `read_file` and `execute_shell` summaries.
- Leaves hash and tool call details in the persisted artifact file for debugging/recovery.

## Resulting shape

```text
[truncated_execute_shell]
full_output: file:///...
command: npm test
status: failed
omitted: 100 lines, 2801 chars
```

```text
[truncated_read_file]
full_output: file:///...
path: src/core/foo.ts
range: 1-500
omitted: 500 lines, 42000 chars
```

## Validation

- `npm run build`
- `node node_modules\tsx\dist\cli.mjs --test tests\read-file-message-folder.test.ts tests\execute-shell-message-folder.test.ts tests\adaptive-tool-result-folder.test.ts tests\tool-result-context-report.test.ts tests\conversation-runner-context-budget.test.ts`