### PR TITLE
稳定 CatsCo thin RPC 路由与防重复 connector 启动

### DIFF
--- a/docs/execution-routing-debug-notes.md
+++ b/docs/execution-routing-debug-notes.md
@@ -1,12 +1,23 @@
 # Execution Routing Debug Notes
 
-## Current Inconsistency To Verify
+## Legacy Inconsistency Notes
 
-- Model-facing target IDs are generic: `agent_self` and `speaker_default`.
-- Tool schemas expose the same fixed enum: `agent_self | speaker_default`.
-- The router maps `speaker_default` to CatsCompany `deviceSelection` or device grants.
-- If CatsCompany selects the wrong device, the agent currently has no more precise target ID to choose.
-- Remote tool results can be labeled as `agent_self`, which can pollute durable history and confuse later turns.
+These notes were written while debugging the old `deviceSelection/deviceGrants`
+route. The current lightweight route is:
+
+`CatsCompany runtime devices -> XiaoBa targetRoutes -> user-name target -> thin_tool_rpc`
+
+In the current route, model-facing base tools accept a free-form user name or
+user id target. `speaker_default` is legacy fallback behavior kept for old
+messages/tests and should not be described as the primary architecture.
+
+Old inconsistency that motivated the rewrite:
+
+- Model-facing target IDs were generic: `agent_self` and `speaker_default`.
+- Tool schemas exposed the same fixed enum: `agent_self | speaker_default`.
+- The router mapped `speaker_default` to CatsCompany `deviceSelection` or device grants.
+- If CatsCompany selected the wrong device, the agent had no more precise target ID to choose.
+- Remote tool results could be labeled as `agent_self`, polluting durable history and confusing later turns.
 
 ## Debug Order
 
@@ -61,7 +72,7 @@ Target-aware tools:
 - `edit_file`
 - `execute_shell`
 
-Current intended route:
+Legacy intended route captured during this debug pass:
 
 1. Tool receives optional `target`.
 2. `resolveExecutionRoute()` chooses `agent_self` by default.

--- a/src/catscompany/client.ts
+++ b/src/catscompany/client.ts
@@ -955,14 +955,21 @@ function deviceRpcResultMatchesPending(result: CatsDeviceRpcMessage, request: Ca
 }
 
 function thinToolRpcResultMatchesPending(result: CatsThinToolRpcMessage, request: CatsThinToolRpcMessage): boolean {
-  return deviceRpcOptionalFieldMatches(result.target_owner_user_id, request.target_owner_user_id)
-    && deviceRpcOptionalFieldMatches(result.target_device_id, request.target_device_id)
-    && deviceRpcOptionalFieldMatches(result.device_id, request.target_device_id)
-    && deviceRpcOptionalFieldMatches(result.tool_name, request.tool_name);
+  return deviceRpcPresentFieldMatches(result.target_owner_user_id, request.target_owner_user_id)
+    && deviceRpcPresentFieldMatches(result.target_device_id, request.target_device_id)
+    && deviceRpcPresentFieldMatches(result.device_id, request.target_device_id)
+    && deviceRpcPresentFieldMatches(result.tool_name, request.tool_name);
 }
 
 function deviceRpcOptionalFieldMatches(actual: unknown, expected: unknown): boolean {
   const actualText = typeof actual === 'string' ? actual.trim() : '';
   const expectedText = typeof expected === 'string' ? expected.trim() : '';
   return !actualText || !expectedText || actualText === expectedText;
+}
+
+function deviceRpcPresentFieldMatches(actual: unknown, expected: unknown): boolean {
+  const expectedText = typeof expected === 'string' ? expected.trim() : '';
+  if (!expectedText) return true;
+  const actualText = typeof actual === 'string' ? actual.trim() : '';
+  return actualText === expectedText;
 }

--- a/src/catscompany/connector-lock.ts
+++ b/src/catscompany/connector-lock.ts
@@ -1,0 +1,115 @@
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+export interface CatsCoConnectorLockRecord {
+  bodyId: string;
+  pid: number;
+  startedAt: string;
+  command?: string;
+  token: string;
+}
+
+export interface CatsCoConnectorLock {
+  acquired: true;
+  lockPath: string;
+  record: CatsCoConnectorLockRecord;
+  release: () => void;
+}
+
+export interface CatsCoConnectorLockBlocked {
+  acquired: false;
+  lockPath: string;
+  existing: CatsCoConnectorLockRecord;
+}
+
+export type CatsCoConnectorLockResult = CatsCoConnectorLock | CatsCoConnectorLockBlocked;
+
+export function acquireCatsCoConnectorLock(options: {
+  runtimeRoot: string;
+  bodyId: string;
+  command?: string;
+}): CatsCoConnectorLockResult {
+  const lockDir = path.join(options.runtimeRoot, '.xiaoba');
+  const lockPath = path.join(lockDir, 'catsco-connector.lock.json');
+  fs.mkdirSync(lockDir, { recursive: true });
+
+  const existing = readLock(lockPath);
+  if (existing && existing.bodyId === options.bodyId && isProcessAlive(existing.pid)) {
+    return {
+      acquired: false,
+      lockPath,
+      existing,
+    };
+  }
+
+  const record: CatsCoConnectorLockRecord = {
+    bodyId: options.bodyId,
+    pid: process.pid,
+    startedAt: new Date().toISOString(),
+    command: options.command,
+    token: crypto.randomUUID(),
+  };
+  writeLock(lockPath, record);
+
+  return {
+    acquired: true,
+    lockPath,
+    record,
+    release: () => releaseCatsCoConnectorLock(lockPath, record),
+  };
+}
+
+function readLock(lockPath: string): CatsCoConnectorLockRecord | null {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(lockPath, 'utf8')) as Partial<CatsCoConnectorLockRecord>;
+    const pid = parsed.pid;
+    if (
+      typeof parsed.bodyId === 'string' &&
+      typeof pid === 'number' &&
+      Number.isInteger(pid) &&
+      typeof parsed.startedAt === 'string' &&
+      typeof parsed.token === 'string'
+    ) {
+      return {
+        bodyId: parsed.bodyId,
+        pid,
+        startedAt: parsed.startedAt,
+        command: typeof parsed.command === 'string' ? parsed.command : undefined,
+        token: parsed.token,
+      };
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function writeLock(lockPath: string, record: CatsCoConnectorLockRecord): void {
+  fs.writeFileSync(lockPath, `${JSON.stringify(record, null, 2)}\n`, 'utf8');
+}
+
+function releaseCatsCoConnectorLock(lockPath: string, record: CatsCoConnectorLockRecord): void {
+  const current = readLock(lockPath);
+  if (!current || current.bodyId !== record.bodyId || current.pid !== record.pid || current.token !== record.token) {
+    return;
+  }
+  try {
+    fs.unlinkSync(lockPath);
+  } catch {
+    // Best-effort cleanup only.
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return false;
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    return code === 'EPERM';
+  }
+}

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -142,7 +142,7 @@ function speakerNameFromMetadata(msg: Pick<ParsedCatsMessage, 'metadata' | 'send
 }
 
 function prefixCatsUserMessage(name: string, content: string | ContentBlock[]): string | ContentBlock[] {
-  const prefix = `${name}：\n`;
+  const prefix = `[发言人: ${name}]\n`;
   if (typeof content === 'string') return `${prefix}${content}`;
   const blocks = [...content];
   const firstTextIndex = blocks.findIndex(block => block.type === 'text');

--- a/src/commands/catscompany.ts
+++ b/src/commands/catscompany.ts
@@ -5,6 +5,7 @@ import { CatsCompanyConfig } from '../catscompany/types';
 import { startRuntimeCommandSupport, stopRuntimeCommandSupport } from '../utils/runtime-command-support';
 import { ChatConfig } from '../types';
 import { resolveCatsCoRuntimeConfig } from '../catscompany/runtime-config';
+import { CatsCoConnectorLock, acquireCatsCoConnectorLock } from '../catscompany/connector-lock';
 
 export interface CatsCoCommandConfigResolution {
   config?: CatsCompanyConfig;
@@ -37,17 +38,49 @@ export async function catscompanyCommand(): Promise<void> {
     process.exit(1);
   }
 
+  const bodyId = connectorConfig.bodyId;
+  if (!bodyId) {
+    Logger.error('CatsCo connector missing bodyId; cannot start.');
+    process.exit(1);
+  }
+
+  const connectorLock = acquireCatsCoConnectorLock({
+    runtimeRoot: process.cwd(),
+    bodyId,
+    command: process.argv.join(' '),
+  });
+  if (!connectorLock.acquired) {
+    Logger.warning(
+      `CatsCo connector already running for this device; skip duplicate startup. bodyId=${bodyId}, pid=${connectorLock.existing.pid}`,
+    );
+    Logger.warning('已跳过第二条 CatsCo WebSocket 连接，避免同一设备重复连接互相挤下线。');
+    return;
+  }
+
   const bot = new CatsCompanyBot(connectorConfig);
+  let lock: CatsCoConnectorLock | null = connectorLock;
 
   // 优雅退出
   const shutdown = async () => {
     await stopRuntimeCommandSupport();
     await bot.destroy();
+    lock?.release();
+    lock = null;
     process.exit(0);
   };
   process.on('SIGINT', shutdown);
   process.on('SIGTERM', shutdown);
+  process.on('exit', () => {
+    lock?.release();
+    lock = null;
+  });
 
-  await bot.start();
-  await startRuntimeCommandSupport();
+  try {
+    await bot.start();
+    await startRuntimeCommandSupport();
+  } catch (error) {
+    lock?.release();
+    lock = null;
+    throw error;
+  }
 }

--- a/src/tools/send-file-tool.ts
+++ b/src/tools/send-file-tool.ts
@@ -226,13 +226,14 @@ function validateCatsCoLocalSendFileContext(
 }
 
 function denyLocalSendFile(reason: string, targetLabel: string): { ok: false; errorCode: 'PERMISSION_DENIED'; message: string } {
+  const lines = [reason];
+  if (targetLabel) {
+    lines.push(`Target: ${targetLabel}`);
+  }
   return {
     ok: false,
     errorCode: 'PERMISSION_DENIED',
-    message: [
-      reason,
-      `Target: ${targetLabel || '[current CatsCo device]'}`,
-    ].join('\n'),
+    message: lines.join('\n'),
   };
 }
 

--- a/src/tools/tool-gateway.ts
+++ b/src/tools/tool-gateway.ts
@@ -82,16 +82,11 @@ export function formatCatsCoVisiblePath(
   value: string | undefined,
   options: CatsCoVisiblePathOptions = {},
 ): string {
-  const fallback = options.fallback ?? '[current CatsCo device]';
+  void context;
+  const fallback = options.fallback ?? '';
   const text = String(value || '').trim();
-  if (!isCatsCoToolGatewayContext(context)) {
-    return text || fallback;
-  }
   if (!text) return fallback;
-  if (/^catsco_attachment:[A-Za-z0-9._:-]+$/.test(text)) return text;
-  if (/^\[CatsCo [^\]]+\]$/.test(text)) return text;
-  if (options.preserveRelative && !looksLikeAbsoluteLocalPath(text)) return text;
-  return fallback;
+  return text;
 }
 
 export function redactCatsCoVisiblePath(
@@ -412,17 +407,7 @@ function denied(lines: string[], targetLabel?: string): ToolGatewayDecision {
 
 function sanitizeTargetLabel(value: string): string {
   const text = String(value || '').trim();
-  if (!text) return '[current CatsCo device]';
-  if (/^catsco_attachment:[A-Za-z0-9._:-]+$/.test(text)) return text;
-  if (/^\[CatsCo [^\]]+\]$/.test(text)) return text;
-  return '[current CatsCo device]';
-}
-
-function looksLikeAbsoluteLocalPath(value: string): boolean {
-  return /^[A-Za-z]:[\\/]/.test(value)
-    || /^\\\\/.test(value)
-    || /^\//.test(value)
-    || /^~[\\/]/.test(value);
+  return text;
 }
 
 function isCatsCoDeviceRpcForwardLocalContext(

--- a/tests/catsco-connector-lock.test.ts
+++ b/tests/catsco-connector-lock.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { acquireCatsCoConnectorLock } from '../src/catscompany/connector-lock';
+
+describe('CatsCo connector startup lock', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'catsco-connector-lock-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test('blocks a second live connector for the same body id', () => {
+    const first = acquireCatsCoConnectorLock({
+      runtimeRoot: tempDir,
+      bodyId: 'body-a',
+      command: 'first',
+    });
+    assert.equal(first.acquired, true);
+
+    const second = acquireCatsCoConnectorLock({
+      runtimeRoot: tempDir,
+      bodyId: 'body-a',
+      command: 'second',
+    });
+    assert.equal(second.acquired, false);
+
+    const otherDevice = acquireCatsCoConnectorLock({
+      runtimeRoot: tempDir,
+      bodyId: 'body-b',
+      command: 'other-device',
+    });
+    assert.equal(otherDevice.acquired, true);
+    first.release();
+    otherDevice.release();
+  });
+
+  test('overwrites a stale lock for the same body id', () => {
+    const lockDir = path.join(tempDir, '.xiaoba');
+    fs.mkdirSync(lockDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(lockDir, 'catsco-connector.lock.json'),
+      JSON.stringify({
+        bodyId: 'body-a',
+        pid: -1,
+        startedAt: new Date().toISOString(),
+        command: 'stale-process',
+        token: 'stale-token',
+      }),
+      'utf8',
+    );
+
+    const acquired = acquireCatsCoConnectorLock({
+      runtimeRoot: tempDir,
+      bodyId: 'body-a',
+      command: 'replacement',
+    });
+    assert.equal(acquired.acquired, true);
+    acquired.release();
+  });
+});

--- a/tests/catscompany-client-body-id.test.ts
+++ b/tests/catscompany-client-body-id.test.ts
@@ -500,6 +500,69 @@ describe('CatsCompany client body identity', () => {
     client.disconnect();
   });
 
+  test('rejects thin tool rpc results that omit pending request scope fields', async () => {
+    const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    servers.push(server);
+    await new Promise<void>(resolve => server.once('listening', resolve));
+
+    server.once('connection', socket => {
+      socket.on('message', data => {
+        const msg = JSON.parse(data.toString());
+        if (msg.hi) {
+          socket.send(JSON.stringify({
+            ctrl: {
+              id: msg.hi.id,
+              code: 200,
+              params: {
+                build: 'catscompany',
+                ver: '0.1.0',
+                features: ['client_msg_id', 'thin_tool_rpc'],
+                uid: 'usr42',
+                name: 'Agent',
+              },
+            },
+          }));
+          return;
+        }
+        if (msg.thin_tool_rpc?.type === 'request') {
+          socket.send(JSON.stringify({ ctrl: { id: msg.thin_tool_rpc.id, code: 200, text: 'ok' } }));
+          socket.send(JSON.stringify({
+            thin_tool_rpc: {
+              type: 'result',
+              request_id: msg.thin_tool_rpc.request_id,
+              result: { ok: true },
+            },
+          }));
+        }
+      });
+    });
+
+    const address = server.address() as AddressInfo;
+    const client = new CatsClient({
+      serverUrl: `ws://127.0.0.1:${address.port}`,
+      apiKey: 'cc-test-key',
+      bodyId: 'body-agent',
+      installationId: 'install-agent',
+    });
+    client.on('error', () => undefined);
+    await new Promise<void>(resolve => {
+      client.once('ready', () => resolve());
+      client.connect();
+    });
+
+    await assert.rejects(
+      () => client.sendThinToolRpcRequest({
+        request_id: 'thin-missing-scope',
+        target_owner_user_id: 'usr7',
+        target_device_id: 'install-test',
+        tool_name: 'read_file',
+        payload: { args: { file_path: '/tmp/a.txt' } },
+      }),
+      /scope does not match/
+    );
+    client.disconnect();
+  });
+
   test('rejects pending thin tool rpc when websocket closes before result', async () => {
     const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
     servers.push(server);

--- a/tests/catscompany-content-blocks.test.ts
+++ b/tests/catscompany-content-blocks.test.ts
@@ -280,7 +280,7 @@ describe('CatsCo content blocks', () => {
     );
     assert.strictEqual(handledTurns.length, 1);
     assert.deepStrictEqual(handledTurns[0].userMessage, [
-      { type: 'text', text: 'usr1：\n一起看这些附件' },
+      { type: 'text', text: '[发言人: usr1]\n一起看这些附件' },
       { type: 'text', text: '[image] a.png -> (no authorized attachment reference)' },
       { type: 'text', text: '[image] c.png -> (no authorized attachment reference)' },
       { type: 'text', text: '[file] b.pdf -> (no authorized attachment reference)' },
@@ -381,7 +381,7 @@ describe('CatsCo content blocks', () => {
     );
     assert.strictEqual(handledTurns.length, 1);
     assert.deepStrictEqual(handledTurns[0].userMessage, [
-      { type: 'text', text: 'usr1：\n非 Dashboard 入口一起看这些附件' },
+      { type: 'text', text: '[发言人: usr1]\n非 Dashboard 入口一起看这些附件' },
       { type: 'text', text: '[image] a.png -> (no authorized attachment reference)' },
       { type: 'text', text: '[file] b.pdf -> (no authorized attachment reference)' },
     ]);
@@ -574,7 +574,7 @@ describe('CatsCo content blocks', () => {
     });
 
     assert.strictEqual(handledTurns.length, 1);
-    assert.strictEqual(handledTurns[0].userMessage, 'usr1：\n这条纯文本不应该等待附件');
+    assert.strictEqual(handledTurns[0].userMessage, '[发言人: usr1]\n这条纯文本不应该等待附件');
     assert.strictEqual(typeof handledTurns[0].options.callbacks?.onThinking, 'function');
     assert.strictEqual(typeof handledTurns[0].options.callbacks?.onAssistantText, 'function');
     await handledTurns[0].options.callbacks.onAssistantText('工具调用前的可见回复');

--- a/tests/tool-gateway-catsco.test.ts
+++ b/tests/tool-gateway-catsco.test.ts
@@ -473,7 +473,7 @@ describe('CatsCo ToolGateway', () => {
     assert.deepEqual(calls[1].args, { pattern: 'needle', path: '/remote/project', output_mode: 'files' });
   });
 
-  test('redacts local absolute paths from successful CatsCo device file results', async () => {
+  test('preserves local absolute paths in successful CatsCo device file results', async () => {
     const root = makeWorkspace();
     const filePath = path.join(root, 'notes.txt');
     const outPath = path.join(root, 'out.txt');
@@ -490,32 +490,34 @@ describe('CatsCo ToolGateway', () => {
 
     const read = await new ReadTool().execute({ file_path: filePath }, ctx);
     assert.equal(read.ok, true);
-    assert.doesNotMatch(String(read.content), new RegExp(escapeRegExp(filePath)));
+    assert.match(String(read.content), new RegExp(escapeRegExp(filePath)));
 
     const glob = await new GlobTool().execute({ pattern: '*.txt', path: root }, ctx);
     assert.equal(glob.ok, true);
     assert.match(String(glob.content), /notes\.txt/);
-    assert.doesNotMatch(String(glob.content), new RegExp(escapeRegExp(root)));
+    assert.match(String(glob.content), new RegExp(escapeRegExp(root)));
 
     const grep = await new GrepTool().execute({ pattern: 'needle', path: filePath, output_mode: 'content' }, ctx);
     assert.equal(grep.ok, true);
     assert.match(String(grep.content), /needle/);
-    assert.doesNotMatch(String(grep.content), new RegExp(escapeRegExp(root)));
+    assert.match(String(grep.content), new RegExp(escapeRegExp(root)));
 
     const write = await new WriteTool().execute({ file_path: outPath, content: 'after' }, ctx);
     assert.equal(write.ok, true);
-    assert.doesNotMatch(String(write.content), new RegExp(escapeRegExp(outPath)));
+    assert.match(String(write.content), /Path: out\.txt/);
+    assert.doesNotMatch(String(write.content), /\[current CatsCo device\]/);
 
     const edit = await new EditTool().execute({ file_path: outPath, old_string: 'after', new_string: 'done' }, ctx);
     assert.equal(edit.ok, true);
-    assert.doesNotMatch(String(edit.content), new RegExp(escapeRegExp(outPath)));
+    assert.match(String(edit.content), new RegExp(escapeRegExp(outPath)));
+    assert.doesNotMatch(String(edit.content), /\[current CatsCo device\]/);
 
     const send = await new SendFileTool().execute({ file_path: filePath, file_name: 'notes.txt' }, ctx);
     assert.equal(send.ok, true);
-    assert.doesNotMatch(String(send.content), new RegExp(escapeRegExp(filePath)));
+    assert.match(String(send.content), new RegExp(escapeRegExp(filePath)));
   });
 
-  test('redacts local absolute paths from CatsCo device file failure results', async () => {
+  test('preserves local absolute paths in CatsCo device file failure results', async () => {
     const root = makeWorkspace();
     const missingPath = path.join(root, 'missing.txt');
     const ctx = context(root, {
@@ -527,7 +529,7 @@ describe('CatsCo ToolGateway', () => {
     if (!readDirectory.ok) {
       assert.equal(readDirectory.errorCode, 'TOOL_EXECUTION_ERROR');
       assert.match(readDirectory.message, /Path is not a file/);
-      assert.doesNotMatch(readDirectory.message, new RegExp(escapeRegExp(root)));
+      assert.match(readDirectory.message, new RegExp(escapeRegExp(root)));
     }
 
     const sendMissing = await new SendFileTool().execute({ file_path: missingPath, file_name: 'missing.txt' }, ctx);
@@ -535,8 +537,7 @@ describe('CatsCo ToolGateway', () => {
     if (!sendMissing.ok) {
       assert.equal(sendMissing.errorCode, 'FILE_NOT_FOUND');
       assert.match(sendMissing.message, /File not found/);
-      assert.doesNotMatch(sendMissing.message, new RegExp(escapeRegExp(missingPath)));
-      assert.doesNotMatch(sendMissing.message, new RegExp(escapeRegExp(root)));
+      assert.match(sendMissing.message, new RegExp(escapeRegExp(missingPath)));
     }
 
     const sendDirectory = await new SendFileTool().execute({ file_path: root, file_name: 'root' }, ctx);
@@ -544,7 +545,7 @@ describe('CatsCo ToolGateway', () => {
     if (!sendDirectory.ok) {
       assert.equal(sendDirectory.errorCode, 'TOOL_EXECUTION_ERROR');
       assert.match(sendDirectory.message, /Path is not a file/);
-      assert.doesNotMatch(sendDirectory.message, new RegExp(escapeRegExp(root)));
+      assert.match(sendDirectory.message, new RegExp(escapeRegExp(root)));
     }
   });
 


### PR DESCRIPTION
## Summary

本 PR 基于最新 main 补充 CatsCo 远程执行链路的稳定性修复，重点解决实际测试中遇到的两个问题：

1. thin_tool_rpc result 匹配更严格，避免缺失关键字段的 result 错误命中 pending request。
2. 保留真实执行路径，不再把 CatsCo 工具结果中的路径替换成 [current CatsCo device]，避免 agent 后续路径判断偏移。
3. CatsCompany 输入改为 [发言人: 用户名] 前缀，帮助 agent 在多人或远程会话中更稳定地区分发言人。
4. 增加 CatsCo connector 启动锁，防止同一 bodyId 同时启动多条 WebSocket connector，避免互相挤下线导致偶发 NO_SOCKET。

## Key Changes

- thin_tool_rpc result matcher 改为 strict-present：request 中存在的 target_owner_user_id、target_device_id、tool_name 等字段，result 必须显式一致。
- WebSocket close 时清理 pending thin RPC，避免一直等到超时。
- 工具结果保留真实路径，移除 [current CatsCo device] 这类占位替换。
- send_file 错误提示同样不再使用路径占位。
- CatsCo 用户消息前缀改为 [发言人: Alice]。
- 新增本地 connector lock：
  - 锁文件位于 .xiaoba/catsco-connector.lock.json
  - 同一个 bodyId 已有活跃 pid 时，第二个 connector 启动会直接跳过
  - stale lock 会自动被覆盖
  - 进程正常退出时释放锁

## Why

真实测试中发现，如果服务器上同时运行 node dist/index.js connect 和 dashboard/service-manager 拉起的第二条 CatsCompany connector，同一个 bodyId 会出现 WebSocket 互踢，导致远程工具偶发 NO_SOCKET。

本 PR 不改变 thin RPC 的轻量设计，不重新引入旧授权拦截，只在启动层避免重复连接，并增强 result 匹配与路径上下文稳定性。

## Tests

- npm run build
- node_modules\.bin\tsx.cmd tests\catsco-connector-lock.test.ts
- node_modules\.bin\tsx.cmd tests\catscompany-client-body-id.test.ts
- node_modules\.bin\tsx.cmd tests\catscompany-content-blocks.test.ts

说明：tests/tool-gateway-catsco.test.ts 全量仍包含旧强权限阻断预期，和当前轻量远程执行路线不一致；本 PR 中路径保真相关用例通过。