### PR TITLE
修复工具前说明误入 thinking

### DIFF
--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -97,8 +97,9 @@ const REPLAY_ARTIFACT_ONLY_MESSAGE = '模型工具调用回放异常，这轮没
 export const PROMPT_BUDGET_TRIM_MESSAGE = '当前上下文超过模型窗口，已裁剪较早的历史内容以继续处理。';
 export const PROMPT_TOOLS_DISABLED_MESSAGE = '当前模型上下文不足以加载全部工具，本轮已先按纯文本继续处理。';
 const MAIN_AGENT_HIDDEN_TOOL_NAMES = new Set(['prompt_mode']);
-const MAX_VISIBLE_TOOL_PRELUDE_CHARS = 64;
-const MAX_VISIBLE_TOOL_PRELUDE_LINES = 2;
+const MAX_VISIBLE_TOOL_PRELUDE_CHARS = 1600;
+const MAX_VISIBLE_TOOL_PRELUDE_LINES = 18;
+const MAX_VISIBLE_TOOL_PRELUDE_LINE_CHARS = 420;
 
 const TOOL_PRELUDE_INTERNAL_PATTERNS = [
   /\bmemory\b/i,
@@ -112,11 +113,13 @@ const TOOL_PRELUDE_INTERNAL_PATTERNS = [
   /\bactual=/i,
   /\bexpected=/i,
   /\b\d+\s*\/\s*\d+\b/,
-  /根因|原因|问题|诊断|bug|报错|错误|异常|失败|断言|调试|正则|期望|实际|可能是|应该|测试要求|代码块被切|硬切|贪心/,
+  /bug|报错|错误|异常|失败|断言|调试|正则|期望|实际|测试要求|代码块被切|硬切|贪心/,
 ];
 
 const TOOL_PRELUDE_PROGRESS_PATTERN =
   /^(?:先|我先|开始|准备|正在|继续|建|创建|写|生成|跑|执行|检查|验证|清理|上传|发送|重试|修复|已|完成|稍等|马上|接着)[^：:\n`]{0,48}(?:[。！？.!?]|$)/;
+const TOOL_PRELUDE_USER_FACING_PATTERN =
+  /^(?:[*_`~\s]*|[一二三四五六七八九十]+[、.]\s*|\d+[、.]\s*)?(?:找到|确认|看到了|我查到|我看了|问题|原因|根因|结论|修复|解决|说明|目前|现在|接下来|下一步|可以|不能|需要|这个|这里|先|我先|继续|正在|准备|开始|已|完成)/;
 
 /**
  * 对话运行回调
@@ -643,8 +646,6 @@ export class ConversationRunner {
         const shouldSurfacePrelude = this.shouldSurfaceToolPrelude(visiblePrelude);
         if (callbacks?.onAssistantText && shouldSurfacePrelude) {
           await callbacks.onAssistantText(visiblePrelude);
-        } else if (!callbacks?.onAssistantText && callbacks?.onThinking && shouldSurfacePrelude) {
-          await callbacks.onThinking(visiblePrelude);
         } else {
           Logger.info(`[${this.sessionLabel}Turn ${turns}] 工具前文本已作为内部进度保留，未发送给用户`);
         }
@@ -1359,12 +1360,11 @@ export class ConversationRunner {
 
     const lines = text.split(/\r?\n/).map(line => line.trim()).filter(Boolean);
     if (lines.length > MAX_VISIBLE_TOOL_PRELUDE_LINES) return false;
-    if (lines.some(line => line.length > MAX_VISIBLE_TOOL_PRELUDE_CHARS)) return false;
-    if (text.includes('```')) return false;
-    if (/^\s*#{1,6}\s/m.test(text) || /^\s*\|.+\|\s*$/m.test(text)) return false;
+    if (lines.some(line => line.length > MAX_VISIBLE_TOOL_PRELUDE_LINE_CHARS)) return false;
     if (TOOL_PRELUDE_INTERNAL_PATTERNS.some(pattern => pattern.test(text))) return false;
 
-    return TOOL_PRELUDE_PROGRESS_PATTERN.test(text);
+    return TOOL_PRELUDE_PROGRESS_PATTERN.test(text)
+      || TOOL_PRELUDE_USER_FACING_PATTERN.test(text);
   }
 
   private buildDuplicateOutboundHint(content: string): Message {

--- a/tests/conversation-runner-transcript-normalization.test.ts
+++ b/tests/conversation-runner-transcript-normalization.test.ts
@@ -567,6 +567,97 @@ test('runner still surfaces concise progress before tool calls', async () => {
   assert.equal(toolExecutor.getExecutionCount('execute_shell'), 1);
 });
 
+test('runner surfaces user-facing diagnostic prelude before tool calls', async () => {
+  const diagnostic = [
+    '**找到根本原因了，全是证据：**',
+    '',
+    '| 检查项 | 结果 | 说明 |',
+    '|---|---|---|',
+    '| 系统代理 | 未打开 | 需要继续检查 WinINET 设置 |',
+    '',
+    '我现在先验证代理配置，再按结果修复。',
+  ].join('\n');
+  const responses = [
+    {
+      content: diagnostic,
+      toolCalls: [makeToolCall('call_1', 'execute_shell', { command: 'netsh winhttp show proxy' })],
+      usage: {
+        promptTokens: 100,
+        completionTokens: 80,
+        totalTokens: 180,
+      },
+    },
+    makeFinalResponse('已确认代理配置。'),
+  ];
+  const mock = createMockAI(responses);
+  const toolExecutor = new MockToolExecutor(
+    [{
+      name: 'execute_shell',
+      description: 'run command',
+      parameters: {
+        type: 'object',
+        properties: {
+          command: { type: 'string' },
+        },
+        required: ['command'],
+      },
+    }],
+    { execute_shell: 'ok' },
+  );
+  const runner = new ConversationRunner(mock.aiService, toolExecutor, { stream: false, enableCompression: false });
+  const assistantText: string[] = [];
+  const thinking: string[] = [];
+
+  const result = await runner.run([{ role: 'user', content: '帮我看代理为什么不通' }], {
+    onAssistantText: text => assistantText.push(text),
+    onThinking: text => thinking.push(text),
+  });
+
+  assert.deepEqual(assistantText, [diagnostic]);
+  assert.deepEqual(thinking, []);
+  assert.equal(result.response, '已确认代理配置。');
+  assert.equal(toolExecutor.getExecutionCount('execute_shell'), 1);
+});
+
+test('runner does not route visible tool prelude through thinking callback', async () => {
+  const responses = [
+    {
+      content: '找到原因了，我先跑一个命令验证。',
+      toolCalls: [makeToolCall('call_1', 'execute_shell', { command: 'echo ok' })],
+      usage: {
+        promptTokens: 100,
+        completionTokens: 20,
+        totalTokens: 120,
+      },
+    },
+    makeFinalResponse('验证完成。'),
+  ];
+  const mock = createMockAI(responses);
+  const toolExecutor = new MockToolExecutor(
+    [{
+      name: 'execute_shell',
+      description: 'run command',
+      parameters: {
+        type: 'object',
+        properties: {
+          command: { type: 'string' },
+        },
+        required: ['command'],
+      },
+    }],
+    { execute_shell: 'ok' },
+  );
+  const runner = new ConversationRunner(mock.aiService, toolExecutor, { stream: false, enableCompression: false });
+  const thinking: string[] = [];
+
+  const result = await runner.run([{ role: 'user', content: '查一下' }], {
+    onThinking: text => thinking.push(text),
+  });
+
+  assert.deepEqual(thinking, []);
+  assert.equal(result.response, '验证完成。');
+});
+
 test('runner does not leak suppressed tool prelude through thinking callbacks', async () => {
   const responses = [
     {


### PR DESCRIPTION
## 概要

修复工具调用前的用户可读说明被归入 WORKING/thinking 的问题。

## 背景

反馈 #48 里，模型在执行工具前输出了代理诊断说明，这类内容不是隐藏思考，应作为普通 assistant 文本显示；此前 runner 只允许 64 字以内、最多 2 行的短进度句外显，较长诊断会被静默或在旧路径里落到 thinking。

## 改动

- 放宽用户可读工具前说明的显示规则，支持较长诊断和简单 Markdown 表格。
- 保留内部调试噪声过滤，例如断言、测试失败、raw debug、actual/expected 等。
- 移除可见工具前说明 fallback 到 `onThinking` 的路径，避免再次误入 WORKING。
- 补充回归测试覆盖：用户可读诊断外显、无 assistant_text 回调时不走 thinking。

## 验证

- `npx tsx --test tests/conversation-runner-transcript-normalization.test.ts`
- `npm run build`
- `git diff --check`
- `npm run test:runtime`