### PR TITLE
恢复 CatsCo 群聊旧会话 key

### DIFF
--- a/src/catscompany/message-envelope.ts
+++ b/src/catscompany/message-envelope.ts
@@ -88,7 +88,7 @@ export function createCatsCoMessageEnvelope(input: CatsCoEnvelopeInput): Message
       ? 'untrusted'
       : 'legacy_context';
   const legacyCleanupKey = buildCatsCoSessionKey(resolvedTopicType, topicId, actorUserId);
-  const legacyRestoreKey = resolvedTopicType === 'group' ? undefined : legacyCleanupKey;
+  const legacyRestoreKey = legacyCleanupKey;
   const route = createSessionRoute({
     source: 'catscompany',
     topicId,
@@ -104,10 +104,13 @@ export function createCatsCoMessageEnvelope(input: CatsCoEnvelopeInput): Message
     legacyRestoreKey,
     legacyCleanupKey,
   });
+  const sessionKey = resolvedTopicType === 'group'
+    ? legacyCleanupKey
+    : route.sessionKey;
 
   return {
     source: 'catscompany',
-    sessionKey: route.sessionKey,
+    sessionKey,
     legacySessionKey: legacyRestoreKey,
     legacyRestoreKey,
     legacyCleanupKey,

--- a/src/core/session-router.ts
+++ b/src/core/session-router.ts
@@ -88,10 +88,8 @@ export function buildCatsCoSessionTopicId(
   actorUserId: string,
 ): string {
   const normalizedTopicId = normalizeId(topicId) || 'unknown_topic';
-  const normalizedActorUserId = normalizeId(actorUserId);
-  if (normalizeTopicType(topicType) === 'group' && normalizedActorUserId) {
-    return `${normalizedTopicId}:actor:${normalizedActorUserId}`;
-  }
+  void topicType;
+  void actorUserId;
   return normalizedTopicId;
 }
 
@@ -103,11 +101,11 @@ export function createCatsCoSessionRoute(envelope: MessageEnvelope): SessionRout
   );
   const legacyRestoreKey = envelope.legacyRestoreKey
     || envelope.legacySessionKey
-    || (normalizeTopicType(envelope.topicType) === 'group' ? undefined : fallbackLegacyKey);
+    || fallbackLegacyKey;
   const legacyCleanupKey = envelope.legacyCleanupKey
     || envelope.legacySessionKey
     || fallbackLegacyKey;
-  return createSessionRoute({
+  const route = createSessionRoute({
     source: 'catscompany',
     topicId: envelope.topicId,
     sessionTopicId: buildCatsCoSessionTopicId(
@@ -126,6 +124,16 @@ export function createCatsCoSessionRoute(envelope: MessageEnvelope): SessionRout
     legacyRestoreKey,
     legacyCleanupKey,
   });
+  if (route.topicType === 'group') {
+    return {
+      ...route,
+      sessionKey: fallbackLegacyKey,
+      legacySessionKey: fallbackLegacyKey,
+      legacyRestoreKey: fallbackLegacyKey,
+      legacyCleanupKey: fallbackLegacyKey,
+    };
+  }
+  return route;
 }
 
 export function createFeishuSessionRoute(message: ParsedFeishuMessage): SessionRoute {

--- a/src/utils/session-store.ts
+++ b/src/utils/session-store.ts
@@ -26,6 +26,21 @@ function stateFilePath(key: string): string {
   return path.join(SESSION_STATE_DIR, keyToFilename(key).replace(/\.jsonl$/, '.json'));
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function catsCoGroupIdFromLegacyKey(key: string): string | undefined {
+  const match = key.match(/^cc_group:(.+)$/);
+  return match?.[1]?.trim() || undefined;
+}
+
+function newestExistingFile(files: string[]): string | undefined {
+  return files
+    .filter(file => fs.existsSync(file))
+    .sort((a, b) => fs.statSync(b).mtimeMs - fs.statSync(a).mtimeMs)[0];
+}
+
 function hasHiddenProviderReplay(message: Message): boolean {
   return Array.isArray(message.providerContent)
     && message.providerContent.some(block => (
@@ -159,6 +174,7 @@ export class SessionStore {
 
   /** 检查是否有会话文件 */
   hasSession(sessionKey: string): boolean {
+    this.migrateCatsCoGroupSessionIfNeeded(sessionKey);
     return fs.existsSync(filePath(sessionKey));
   }
 
@@ -175,6 +191,7 @@ export class SessionStore {
 
   loadRuntimeState(sessionKey: string): SessionRuntimeState {
     try {
+      this.migrateCatsCoGroupStateIfNeeded(sessionKey);
       const fp = stateFilePath(sessionKey);
       if (!fs.existsSync(fp)) return {};
       const parsed = JSON.parse(fs.readFileSync(fp, 'utf-8')) as SessionRuntimeState;
@@ -204,5 +221,52 @@ export class SessionStore {
     } catch (err) {
       Logger.error(`Failed to delete session state [${sessionKey}]: ${err}`);
     }
+  }
+
+  private migrateCatsCoGroupSessionIfNeeded(sessionKey: string): void {
+    this.migrateCatsCoGroupFileIfNeeded(sessionKey, SESSIONS_DIR, '.jsonl');
+  }
+
+  private migrateCatsCoGroupStateIfNeeded(sessionKey: string): void {
+    this.migrateCatsCoGroupFileIfNeeded(sessionKey, SESSION_STATE_DIR, '.json');
+  }
+
+  private migrateCatsCoGroupFileIfNeeded(sessionKey: string, dir: string, extension: '.jsonl' | '.json'): void {
+    const groupId = catsCoGroupIdFromLegacyKey(sessionKey);
+    if (!groupId) return;
+
+    const target = extension === '.jsonl' ? filePath(sessionKey) : stateFilePath(sessionKey);
+    if (fs.existsSync(target) || !fs.existsSync(dir)) return;
+
+    const source = this.findCatsCoGroupCompatibilityFile(dir, groupId, extension);
+    if (!source) return;
+
+    try {
+      if (!fs.existsSync(path.dirname(target))) fs.mkdirSync(path.dirname(target), { recursive: true });
+      fs.copyFileSync(source, target);
+      Logger.info(`CatsCo group session migrated to legacy key: ${path.basename(source)} -> ${path.basename(target)}`);
+    } catch (err) {
+      Logger.error(`Failed to migrate CatsCo group session [${sessionKey}]: ${err}`);
+    }
+  }
+
+  private findCatsCoGroupCompatibilityFile(dir: string, groupId: string, extension: '.jsonl' | '.json'): string | undefined {
+    const escapedGroup = escapeRegExp(groupId);
+    const escapedExtension = escapeRegExp(extension);
+    const entries = fs.readdirSync(dir, { withFileTypes: true })
+      .filter(entry => entry.isFile())
+      .map(entry => entry.name);
+
+    const actorV2 = new RegExp(`^session_v2_catscompany_group_${escapedGroup}_3Aactor_3A[^_]+_agent_[^_]+${escapedExtension}$`);
+    const topicV2 = new RegExp(`^session_v2_catscompany_group_${escapedGroup}_agent_[^_]+${escapedExtension}$`);
+
+    const actorSource = newestExistingFile(entries
+      .filter(name => actorV2.test(name))
+      .map(name => path.join(dir, name)));
+    if (actorSource) return actorSource;
+
+    return newestExistingFile(entries
+      .filter(name => topicV2.test(name))
+      .map(name => path.join(dir, name)));
   }
 }

--- a/tests/catscompany-execution-scope-flow.test.ts
+++ b/tests/catscompany-execution-scope-flow.test.ts
@@ -16,8 +16,9 @@ function canonicalMetadata(actorUserId: string, topicId: string, agentId = 'usr4
 
 function expectedCatsCoSessionKey(actorUserId: string, topicId: string, agentId = 'usr43') {
   const topicType = topicId.startsWith('grp_') ? 'group' : 'p2p';
-  const sessionTopicId = topicType === 'group' ? `${topicId}:actor:${actorUserId}` : topicId;
-  return `session:v2:catscompany:${topicType}:${encodeURIComponent(sessionTopicId)}:agent:${encodeURIComponent(agentId)}`;
+  if (topicType === 'group') return `cc_group:${topicId}`;
+  void actorUserId;
+  return `session:v2:catscompany:${topicType}:${encodeURIComponent(topicId)}:agent:${encodeURIComponent(agentId)}`;
 }
 
 function deviceGrant(overrides: Record<string, unknown> = {}) {
@@ -177,7 +178,7 @@ describe('CatsCompany execution scope flow', () => {
     assert.equal(handledTurns[0].options.executionScope.isTrusted, true);
   });
 
-  test('group turn uses actor-scoped group session key while preserving raw topic in scope', async () => {
+  test('group turn uses legacy group session key while preserving actor in scope', async () => {
     const { bot, handledTurns, sessionKeys } = createHarness();
 
     await (bot as any).onMessage({
@@ -190,15 +191,15 @@ describe('CatsCompany execution scope flow', () => {
       seq: 12,
     });
 
-    assert.deepEqual(sessionKeys, ['session:v2:catscompany:group:grp_80%3Aactor%3Ausr7:agent:usr43']);
+    assert.deepEqual(sessionKeys, ['cc_group:grp_80']);
     assert.equal(handledTurns.length, 1);
-    assert.equal(handledTurns[0].options.sessionRoute.sessionKey, 'session:v2:catscompany:group:grp_80%3Aactor%3Ausr7:agent:usr43');
-    assert.equal(handledTurns[0].options.sessionRoute.legacySessionKey, undefined);
-    assert.equal(handledTurns[0].options.sessionRoute.legacyRestoreKey, undefined);
+    assert.equal(handledTurns[0].options.sessionRoute.sessionKey, 'cc_group:grp_80');
+    assert.equal(handledTurns[0].options.sessionRoute.legacySessionKey, 'cc_group:grp_80');
+    assert.equal(handledTurns[0].options.sessionRoute.legacyRestoreKey, 'cc_group:grp_80');
     assert.equal(handledTurns[0].options.sessionRoute.legacyCleanupKey, 'cc_group:grp_80');
-    assert.equal(handledTurns[0].options.executionScope.sessionKey, 'session:v2:catscompany:group:grp_80%3Aactor%3Ausr7:agent:usr43');
-    assert.equal(handledTurns[0].options.executionScope.legacySessionKey, undefined);
-    assert.equal(handledTurns[0].options.executionScope.legacyRestoreKey, undefined);
+    assert.equal(handledTurns[0].options.executionScope.sessionKey, 'cc_group:grp_80');
+    assert.equal(handledTurns[0].options.executionScope.legacySessionKey, 'cc_group:grp_80');
+    assert.equal(handledTurns[0].options.executionScope.legacyRestoreKey, 'cc_group:grp_80');
     assert.equal(handledTurns[0].options.executionScope.legacyCleanupKey, 'cc_group:grp_80');
     assert.equal(handledTurns[0].options.executionScope.topicType, 'group');
     assert.equal(handledTurns[0].options.executionScope.topicId, 'grp_80');
@@ -224,7 +225,7 @@ describe('CatsCompany execution scope flow', () => {
     assert.deepEqual(handledTurns[0].options.deviceGrants[0].operations, ['read_file', 'send_file']);
   });
 
-  test('passes actor-scoped group device grants into CatsCompany session turn', async () => {
+  test('passes group device grants into CatsCompany session turn', async () => {
     const { bot, handledTurns } = createHarness();
 
     await (bot as any).onMessage({
@@ -334,7 +335,7 @@ describe('CatsCompany execution scope flow', () => {
       botUid: 'usr43',
     }));
 
-    assert.notEqual(aliceScope.sessionKey, bobScope.sessionKey);
+    assert.equal(aliceScope.sessionKey, bobScope.sessionKey);
 
     bot.messageQueue.set(bobScope.sessionKey, [{
       userMessage: 'bob follow-up',

--- a/tests/catscompany-message-envelope.test.ts
+++ b/tests/catscompany-message-envelope.test.ts
@@ -71,12 +71,12 @@ describe('CatsCompany MessageEnvelope and ExecutionScope', () => {
     });
     const scope = createExecutionScope(envelope);
 
-    assert.equal(envelope.sessionKey, 'session:v2:catscompany:group:grp_80%3Aactor%3Ausr7:agent:usr43');
-    assert.equal(envelope.legacySessionKey, undefined);
-    assert.equal(envelope.legacyRestoreKey, undefined);
+    assert.equal(envelope.sessionKey, 'cc_group:grp_80');
+    assert.equal(envelope.legacySessionKey, 'cc_group:grp_80');
+    assert.equal(envelope.legacyRestoreKey, 'cc_group:grp_80');
     assert.equal(envelope.legacyCleanupKey, 'cc_group:grp_80');
-    assert.equal(scope.legacySessionKey, undefined);
-    assert.equal(scope.legacyRestoreKey, undefined);
+    assert.equal(scope.legacySessionKey, 'cc_group:grp_80');
+    assert.equal(scope.legacyRestoreKey, 'cc_group:grp_80');
     assert.equal(scope.legacyCleanupKey, 'cc_group:grp_80');
     assert.equal(scope.topicType, 'group');
     assert.equal(scope.actorUserId, 'usr7');

--- a/tests/session-lifecycle-manager.test.ts
+++ b/tests/session-lifecycle-manager.test.ts
@@ -139,8 +139,8 @@ describe('AgentSession lifecycle', () => {
     }
   });
 
-  test('CatsCo group cleanup-only legacy key is not used for restore fallback', async () => {
-    const { AgentSession, SessionStore, createSessionRoute } = loadSessionModules();
+  test('CatsCo group uses the legacy key as its primary session', async () => {
+    const { AgentSession, SessionStore, createCatsCoSessionRoute } = loadSessionModules();
     const defaultDir = fs.mkdtempSync(path.join(testRoot, 'default-'));
     const legacyDir = fs.mkdtempSync(path.join(testRoot, 'legacy-'));
     const store = SessionStore.getInstance();
@@ -149,18 +149,22 @@ describe('AgentSession lifecycle', () => {
     ]);
     store.saveRuntimeState('cc_group:grp_80', { currentDirectory: legacyDir });
 
-    const route = createSessionRoute({
+    const route = createCatsCoSessionRoute({
       source: 'catscompany',
+      sessionKey: 'cc_group:grp_80',
       topicType: 'group',
       topicId: 'grp_80',
-      sessionTopicId: 'grp_80:actor:alice',
+      rawText: 'hello',
       actorUserId: 'alice',
       agentId: 'usr43',
       identityTrust: 'server_canonical',
+      identitySource: 'test',
+      legacyRestoreKey: 'cc_group:grp_80',
       legacyCleanupKey: 'cc_group:grp_80',
     });
-    assert.equal(route.legacySessionKey, undefined);
-    assert.equal(route.legacyRestoreKey, undefined);
+    assert.equal(route.sessionKey, 'cc_group:grp_80');
+    assert.equal(route.legacySessionKey, 'cc_group:grp_80');
+    assert.equal(route.legacyRestoreKey, 'cc_group:grp_80');
     assert.equal(route.legacyCleanupKey, 'cc_group:grp_80');
 
     const session = new AgentSession(route.sessionKey, buildMockServices({
@@ -172,17 +176,73 @@ describe('AgentSession lifecycle', () => {
     }), 'catscompany', route);
     session.setSystemPromptProvider(() => 'system prompt');
 
-    assert.equal(session.restoreFromStore(), false);
-    assert.equal((session as any).currentDirectory, defaultDir);
+    assert.equal(session.restoreFromStore(), true);
+    assert.equal((session as any).currentDirectory, legacyDir);
     await session.init();
     assert.equal(
       (session as any).messages.some((message: any) => message.content === 'legacy group history'),
-      false,
+      true,
     );
 
     session.clear();
     assert.equal(store.hasSession('cc_group:grp_80'), false);
-    assert.deepEqual(store.loadRuntimeState('cc_group:grp_80'), {});
+  });
+
+  test('CatsCo group migrates actor-v2 and topic-v2 session files to the legacy key', async () => {
+    const { SessionStore } = loadSessionModules();
+    const sessionsDir = path.join(testRoot, 'data', 'sessions');
+    const stateDir = path.join(testRoot, 'data', 'session-state');
+    fs.mkdirSync(sessionsDir, { recursive: true });
+    fs.mkdirSync(stateDir, { recursive: true });
+
+    const actorV2File = path.join(sessionsDir, 'session_v2_catscompany_group_grp_80_3Aactor_3Ausr7_agent_usr43.jsonl');
+    const topicV2File = path.join(sessionsDir, 'session_v2_catscompany_group_grp_80_agent_usr43.jsonl');
+    fs.writeFileSync(topicV2File, `${JSON.stringify({ role: 'user', content: 'topic v2 history' })}\n`, 'utf-8');
+    fs.writeFileSync(actorV2File, `${JSON.stringify({ role: 'user', content: 'actor v2 history' })}\n`, 'utf-8');
+    fs.writeFileSync(
+      path.join(stateDir, 'session_v2_catscompany_group_grp_80_3Aactor_3Ausr7_agent_usr43.json'),
+      JSON.stringify({ currentDirectory: 'D:\\actor-v2' }),
+      'utf-8',
+    );
+
+    const store = SessionStore.getInstance();
+    assert.equal(store.hasSession('cc_group:grp_80'), true);
+    assert.deepEqual(
+      store.loadContext('cc_group:grp_80').map((message: any) => message.content),
+      ['actor v2 history'],
+    );
+    assert.equal(
+      fs.existsSync(path.join(sessionsDir, 'cc_group_grp_80.jsonl')),
+      true,
+    );
+    assert.deepEqual(store.loadRuntimeState('cc_group:grp_80').currentDirectory, 'D:\\actor-v2');
+  });
+
+  test('CatsCo group migrates topic-v2 files when no actor-v2 file exists', async () => {
+    const { SessionStore } = loadSessionModules();
+    const sessionsDir = path.join(testRoot, 'data', 'sessions');
+    const stateDir = path.join(testRoot, 'data', 'session-state');
+    fs.mkdirSync(sessionsDir, { recursive: true });
+    fs.mkdirSync(stateDir, { recursive: true });
+
+    fs.writeFileSync(
+      path.join(sessionsDir, 'session_v2_catscompany_group_grp_80_agent_usr43.jsonl'),
+      `${JSON.stringify({ role: 'user', content: 'topic v2 history' })}\n`,
+      'utf-8',
+    );
+    fs.writeFileSync(
+      path.join(stateDir, 'session_v2_catscompany_group_grp_80_agent_usr43.json'),
+      JSON.stringify({ currentDirectory: 'D:\\topic-v2' }),
+      'utf-8',
+    );
+
+    const store = SessionStore.getInstance();
+    assert.equal(store.hasSession('cc_group:grp_80'), true);
+    assert.deepEqual(
+      store.loadContext('cc_group:grp_80').map((message: any) => message.content),
+      ['topic v2 history'],
+    );
+    assert.deepEqual(store.loadRuntimeState('cc_group:grp_80').currentDirectory, 'D:\\topic-v2');
   });
 
   test('reset and clear discard pending runtime feedback', async () => {
@@ -767,6 +827,7 @@ function loadSessionModules(): any {
     CONTEXT_COMPACTION_COMPLETE_MESSAGE: require('../src/core/agent-session').CONTEXT_COMPACTION_COMPLETE_MESSAGE,
     SessionStore: require('../src/utils/session-store').SessionStore,
     createSessionRoute: require('../src/core/session-router').createSessionRoute,
+    createCatsCoSessionRoute: require('../src/core/session-router').createCatsCoSessionRoute,
   };
 }
 

--- a/tests/session-route-v2.test.ts
+++ b/tests/session-route-v2.test.ts
@@ -83,7 +83,7 @@ describe('SessionRoute V2', () => {
     assert.equal(route.identity.identityTrust, 'legacy_context');
   });
 
-  test('keeps CatsCo group legacy cleanup separate from restore', () => {
+  test('uses the legacy CatsCo group session key', () => {
     const envelope = createCatsCoMessageEnvelope({
       topic: 'grp_80',
       isGroup: true,
@@ -101,9 +101,9 @@ describe('SessionRoute V2', () => {
     });
     const route = createCatsCoSessionRoute(envelope);
 
-    assert.equal(route.sessionKey, 'session:v2:catscompany:group:grp_80%3Aactor%3Ausr7:agent:usr43');
-    assert.equal(route.legacySessionKey, undefined);
-    assert.equal(route.legacyRestoreKey, undefined);
+    assert.equal(route.sessionKey, 'cc_group:grp_80');
+    assert.equal(route.legacySessionKey, 'cc_group:grp_80');
+    assert.equal(route.legacyRestoreKey, 'cc_group:grp_80');
     assert.equal(route.legacyCleanupKey, 'cc_group:grp_80');
   });
 


### PR DESCRIPTION
恢复 CatsCo group 会话的旧 v2 session key，避免 #146 引入 actor-scoped group key 后导致历史 session 文件命中断层。\n\n改动要点：\n- group session key 恢复为 topic 级别，不再拼接 actor user id\n- actor 信息仍保留在 execution scope 中用于当前发言人识别和队列合并\n- 更新 CatsCompany metadata / execution scope 相关测试预期\n\n验证：\n- npm run build\n- node_modules\\.bin\\tsx.cmd --test tests\\session-route-v2.test.ts tests\\catscompany-message-envelope.test.ts tests\\catscompany-execution-scope-flow.test.ts tests\\session-lifecycle-manager.test.ts