### PR TITLE
恢复 read_file PDF 文本解析

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "gray-matter": "^4.0.3",
         "inquirer": "^8.2.7",
         "ora": "^5.4.1",
+        "pdf-parse": "^1.1.1",
         "sharp": "^0.34.5"
       },
       "bin": {
@@ -477,6 +478,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -498,6 +500,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -514,6 +517,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -528,6 +532,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -2188,7 +2193,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3242,7 +3246,8 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3502,7 +3507,6 @@
       "integrity": "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.8.1",
         "builder-util": "26.8.1",
@@ -4172,6 +4176,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -4192,6 +4197,7 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -6177,6 +6183,7 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -6279,6 +6286,12 @@
       "engines": {
         "node": ">=10.5.0"
       }
+    },
+    "node_modules/node-ensure": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
+      "integrity": "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==",
+      "license": "MIT"
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
@@ -6696,6 +6709,28 @@
         "node": ">=4"
       }
     },
+    "node_modules/pdf-parse": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.1.tgz",
+      "integrity": "sha512-v6ZJ/efsBpGrGGknjtq9J/oC8tZWq0KWL5vQrk2GlzLEQPUDB1ex+13Rmidl1neNN358Jn9EHZw5y07FFtaC7A==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.1.0",
+        "node-ensure": "^0.0.0"
+      },
+      "engines": {
+        "node": ">=6.8.1"
+      }
+    },
+    "node_modules/pdf-parse/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
     "node_modules/pe-library": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/pe-library/-/pe-library-0.4.1.tgz",
@@ -6731,7 +6766,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6818,6 +6852,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -6835,6 +6870,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -7179,6 +7215,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -7192,6 +7229,7 @@
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -7204,6 +7242,7 @@
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -7225,6 +7264,7 @@
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -7949,6 +7989,7 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "gray-matter": "^4.0.3",
     "inquirer": "^8.2.7",
     "ora": "^5.4.1",
+    "pdf-parse": "^1.1.1",
     "sharp": "^0.34.5"
   },
   "devDependencies": {

--- a/src/tools/read-tool.ts
+++ b/src/tools/read-tool.ts
@@ -16,6 +16,26 @@ import { executeRouteIfRemote, resolveExecutionRoute, targetParameterDescription
 export const DEFAULT_TEXT_READ_LIMIT = 200;
 export const MAX_TEXT_READ_LIMIT = 2000;
 export const MAX_TEXT_READ_BYTES = 256 * 1024;
+export const DEFAULT_PDF_READ_PAGES = 10;
+export const MAX_PDF_READ_PAGES = 30;
+export const MAX_PDF_READ_BYTES = 20 * 1024 * 1024;
+export const MAX_PDF_OUTPUT_BYTES = 192 * 1024;
+
+interface PdfParseOptions {
+  max?: number;
+  version?: string;
+  pagerender?: (pageData: any) => Promise<string>;
+}
+
+interface PdfParseResult {
+  numpages?: number;
+  numrender?: number;
+  text?: string;
+  info?: Record<string, unknown>;
+}
+
+type PdfParse = (dataBuffer: Buffer, options?: PdfParseOptions) => Promise<PdfParseResult>;
+const pdfParse: PdfParse = require('pdf-parse');
 
 interface TextReadOptions {
   offset?: unknown;
@@ -45,6 +65,13 @@ interface TextReadResult {
   isUnlimitedRequest: boolean;
   requestedLimit?: number;
   nextOffset?: number;
+}
+
+interface PdfPageSelection {
+  label: string;
+  maxPageToRender: number;
+  selectedPages?: Set<number>;
+  warnings: string[];
 }
 
 /**
@@ -195,7 +222,7 @@ export class ReadTool implements Tool {
     const ext = path.extname(absolutePath).toLowerCase();
 
     if (ext === '.pdf') {
-      const content = this.readPDF(absolutePath, displayPath, visiblePath, pages);
+      const content = await this.readPDF(absolutePath, displayPath, visiblePath, pages);
       return { ok: true, content };
     }
 
@@ -395,25 +422,169 @@ export class ReadTool implements Tool {
     return this.formatTextReadResult(filePath, visiblePath, result);
   }
 
-  private readPDF(absolutePath: string, filePath: string, visiblePath: string, pages?: string): string {
+  private parsePdfPages(pages?: string): PdfPageSelection {
+    const warnings: string[] = [];
+    const raw = typeof pages === 'string' ? pages.trim() : '';
+
+    if (!raw) {
+      return {
+        label: `前 ${DEFAULT_PDF_READ_PAGES} 页`,
+        maxPageToRender: DEFAULT_PDF_READ_PAGES,
+        warnings,
+      };
+    }
+
+    const selected = new Set<number>();
+    for (const part of raw.split(',').map(item => item.trim()).filter(Boolean)) {
+      const range = part.match(/^(\d+)\s*-\s*(\d+)$/);
+      if (range) {
+        const start = Number(range[1]);
+        const end = Number(range[2]);
+        if (!Number.isInteger(start) || !Number.isInteger(end) || start <= 0 || end <= 0 || end < start) {
+          warnings.push(`已忽略无效页码范围: ${part}`);
+          continue;
+        }
+        for (let page = start; page <= end; page += 1) selected.add(page);
+        continue;
+      }
+
+      const page = Number(part);
+      if (Number.isInteger(page) && page > 0) {
+        selected.add(page);
+      } else {
+        warnings.push(`已忽略无效页码: ${part}`);
+      }
+    }
+
+    if (selected.size === 0) {
+      warnings.push(`pages="${raw}" 未匹配到有效页码，已改为默认读取前 ${DEFAULT_PDF_READ_PAGES} 页。`);
+      return {
+        label: `前 ${DEFAULT_PDF_READ_PAGES} 页`,
+        maxPageToRender: DEFAULT_PDF_READ_PAGES,
+        warnings,
+      };
+    }
+
+    const sorted = Array.from(selected).sort((a, b) => a - b);
+    const capped = sorted.slice(0, MAX_PDF_READ_PAGES);
+    if (sorted.length > capped.length) {
+      warnings.push(`请求页数 ${sorted.length} 页，已限制为前 ${MAX_PDF_READ_PAGES} 个页码。`);
+    }
+
+    return {
+      label: capped.join(', '),
+      maxPageToRender: Math.max(...capped),
+      selectedPages: new Set(capped),
+      warnings,
+    };
+  }
+
+  private async extractPdfText(absolutePath: string, selection: PdfPageSelection): Promise<PdfParseResult> {
+    const data = fs.readFileSync(absolutePath);
+    const selectedPages = selection.selectedPages;
+    const options: PdfParseOptions = {
+      max: selection.maxPageToRender,
+      pagerender: async (pageData: any) => {
+        const pageNumber = typeof pageData?.pageIndex === 'number' ? pageData.pageIndex + 1 : undefined;
+        if (selectedPages && pageNumber && !selectedPages.has(pageNumber)) return '';
+
+        const textContent = await pageData.getTextContent({
+          normalizeWhitespace: false,
+          disableCombineTextItems: false,
+        });
+
+        let lastY: number | undefined;
+        let text = '';
+        for (const item of textContent.items || []) {
+          const value = typeof item?.str === 'string' ? item.str : '';
+          const y = Array.isArray(item?.transform) ? item.transform[5] : undefined;
+          if (!value) continue;
+          if (lastY === undefined || y === lastY) {
+            text += value;
+          } else {
+            text += `\n${value}`;
+          }
+          lastY = y;
+        }
+        return text;
+      },
+    };
+
+    return pdfParse(data, options);
+  }
+
+  private async readPDF(absolutePath: string, filePath: string, visiblePath: string, pages?: string): Promise<string> {
     const stats = fs.statSync(absolutePath);
     const sizeMB = (stats.size / 1024 / 1024).toFixed(2);
+    const selection = this.parsePdfPages(pages);
 
     const lines = [
       `文件: ${filePath}`,
       `Path: ${visiblePath}`,
       '类型: PDF',
       `大小: ${sizeMB} MB`,
-      '',
-      '当前 read_file 不再做 PDF 全文解析。',
-      '建议使用 shell 中可用的文档解析库、系统工具，或后续新增专门文档解析工具。',
     ];
 
-    if (pages) {
-      lines.push('', `已忽略 pages 参数: ${pages}`);
+    if (stats.size > MAX_PDF_READ_BYTES) {
+      lines.push(
+        '',
+        `PDF 文件超过 ${(MAX_PDF_READ_BYTES / 1024 / 1024).toFixed(0)} MB，read_file 不会自动解析，避免占满内存和上下文。`,
+        '请先指定更小文件，或使用 shell 中的文档解析工具做分段提取。',
+      );
+      return lines.join('\n');
     }
 
-    return lines.join('\n');
+    try {
+      const parsed = await this.extractPdfText(absolutePath, selection);
+      const rawText = String(parsed.text || '').trim();
+      const text = this.trimToUtf8ByteLimit(rawText, MAX_PDF_OUTPUT_BYTES);
+      const wasTruncated = Buffer.byteLength(rawText, 'utf-8') > Buffer.byteLength(text, 'utf-8');
+
+      lines.push(
+        `总页数: ${parsed.numpages ?? '未知'}`,
+        `已解析页: ${selection.label}`,
+      );
+
+      if (selection.warnings.length > 0) {
+        lines.push('', ...selection.warnings);
+      }
+
+      if (!rawText) {
+        lines.push(
+          '',
+          '未提取到可用文本。这个 PDF 可能是扫描件/图片型 PDF、加密文档，或文本层为空。',
+          '如果用户需要读内容，建议改用图片 OCR、截图读图，或 shell 中更专业的文档解析工具。',
+        );
+        return lines.join('\n');
+      }
+
+      lines.push('', '文本内容:', text);
+      if (wasTruncated) {
+        lines.push(
+          '',
+          `输出达到 ${(MAX_PDF_OUTPUT_BYTES / 1024).toFixed(0)} KB 上限，后续内容已省略。`,
+          '如需继续读取，请用 pages 参数指定更小页码范围，例如 pages="11-20"。',
+        );
+      } else if (!pages && parsed.numpages && parsed.numpages > DEFAULT_PDF_READ_PAGES) {
+        lines.push(
+          '',
+          `默认只解析前 ${DEFAULT_PDF_READ_PAGES} 页。`,
+          `如需继续读取，请调用 read_file 并指定 pages="${DEFAULT_PDF_READ_PAGES + 1}-${Math.min(parsed.numpages, DEFAULT_PDF_READ_PAGES * 2)}"。`,
+        );
+      }
+
+      return lines.join('\n');
+    } catch (error: any) {
+      const rawMessage = String(error?.message || error || 'unknown error').trim();
+      const message = rawMessage.length > 500 ? `${rawMessage.slice(0, 500)}...` : rawMessage;
+      lines.push(
+        '',
+        'PDF 解析失败，read_file 未能提取正文。',
+        `原因: ${message}`,
+        '可以尝试重新上传 PDF、改发截图，或使用 shell 中可用的文档解析库/系统工具处理。',
+      );
+      return lines.join('\n');
+    }
   }
 
   private isImageExt(ext: string): boolean {

--- a/tests/tool-result-read-tool.test.ts
+++ b/tests/tool-result-read-tool.test.ts
@@ -6,7 +6,7 @@ import * as assert from 'node:assert';
 import * as path from 'path';
 import * as os from 'os';
 import * as fs from 'fs';
-import { DEFAULT_TEXT_READ_LIMIT, ReadTool } from '../src/tools/read-tool';
+import { DEFAULT_PDF_READ_PAGES, DEFAULT_TEXT_READ_LIMIT, ReadTool } from '../src/tools/read-tool';
 import { ToolExecutionContext } from '../src/types/tool';
 
 describe('ReadTool - ToolExecutionResult', () => {
@@ -118,15 +118,75 @@ describe('ReadTool - ToolExecutionResult', () => {
     assert.ok(result.message.includes('文件不存在'));
   });
 
-  test('PDF 文件返回 ok=true 并给出提示', async () => {
+  test('PDF 文件会提取正文文本', async () => {
+    const fixturePath = path.join(
+      path.dirname(require.resolve('pdf-parse')),
+      'test',
+      'data',
+      '01-valid.pdf',
+    );
+    const filePath = path.join(testRoot, 'fixture.pdf');
+    fs.copyFileSync(fixturePath, filePath);
+
+    const result = await tool.execute({ file_path: filePath, pages: '1' }, context);
+
+    assert.strictEqual(result.ok, true);
+    const content = result.content as string;
+    assert.ok(content.includes('类型: PDF'));
+    assert.ok(content.includes('总页数:'));
+    assert.ok(content.includes('已解析页: 1'));
+    assert.ok(content.includes('文本内容:'));
+    assert.ok(content.includes('Trace-based'));
+    assert.ok(!content.includes('不再做 PDF 全文解析'));
+  });
+
+  test('PDF 默认只读取前若干页并提示继续读取', async () => {
+    const fixturePath = path.join(
+      path.dirname(require.resolve('pdf-parse')),
+      'test',
+      'data',
+      '01-valid.pdf',
+    );
+    const filePath = path.join(testRoot, 'fixture-default.pdf');
+    fs.copyFileSync(fixturePath, filePath);
+
+    const result = await tool.execute({ file_path: filePath }, context);
+
+    assert.strictEqual(result.ok, true);
+    const content = result.content as string;
+    assert.ok(content.includes(`已解析页: 前 ${DEFAULT_PDF_READ_PAGES} 页`));
+    assert.ok(content.includes(`默认只解析前 ${DEFAULT_PDF_READ_PAGES} 页`));
+    assert.ok(content.includes('pages="11-14"'));
+  });
+
+  test('PDF pages 参数只返回指定页内容', async () => {
+    const fixturePath = path.join(
+      path.dirname(require.resolve('pdf-parse')),
+      'test',
+      'data',
+      '01-valid.pdf',
+    );
+    const filePath = path.join(testRoot, 'fixture-page-filter.pdf');
+    fs.copyFileSync(fixturePath, filePath);
+
+    const result = await tool.execute({ file_path: filePath, pages: '2' }, context);
+
+    assert.strictEqual(result.ok, true);
+    const content = result.content as string;
+    assert.ok(content.includes('已解析页: 2'));
+    assert.ok(content.includes('Every compiled trace'));
+    assert.ok(!content.includes('Trace-based Just-in-Time Type Specialization'));
+  });
+
+  test('损坏 PDF 返回解析失败提示', async () => {
     const filePath = path.join(testRoot, 'dummy.pdf');
     fs.writeFileSync(filePath, '%PDF-1.4 fake content');
     const result = await tool.execute({ file_path: filePath }, context);
     assert.strictEqual(result.ok, true);
     const content = result.content as string;
     assert.ok(content.includes('PDF'));
-    assert.ok(content.includes('不再做 PDF 全文解析'));
-    assert.ok(content.includes('文档解析工具'));
+    assert.ok(content.includes('PDF 解析失败'));
+    assert.ok(content.includes('未能提取正文'));
     assert.ok(!content.includes('paper-analysis'));
   });
 });


### PR DESCRIPTION
## 变更
- 恢复 `read_file` 对 PDF 的文本提取能力，解决 CatsCo 附件 PDF 只能返回“不再做全文解析”的问题。
- 默认只解析前 10 页，最多允许 30 页，并限制 PDF 文件大小与输出字节数，避免大文档占满上下文。
- 支持 `pages` 参数按页读取；扫描件、加密或损坏 PDF 会返回明确失败/空文本提示。
- 补充 PDF 正文提取、默认分页提示、指定页过滤和损坏 PDF 的回归测试。

## 验证
- `npx tsx --test tests/tool-result-read-tool.test.ts`
- `npm run build`
- `npm run test:runtime`
- `npm ci`
- `npm run release:check`
- `git diff --check`