### PR TITLE
增强 read_file PDF 读取和扫描件回退

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.27.0",
         "@larksuiteoapi/node-sdk": "^1.58.0",
+        "@napi-rs/canvas": "^1.0.2",
         "axios": "^1.6.2",
         "chalk": "^4.1.2",
         "commander": "^11.1.0",
@@ -23,6 +24,7 @@
         "inquirer": "^8.2.7",
         "ora": "^5.4.1",
         "pdf-parse": "^1.1.1",
+        "pdfjs-dist": "^4.6.82",
         "sharp": "^0.34.5"
       },
       "bin": {
@@ -1677,6 +1679,514 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@mapbox/node-pre-gyp": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
+      "integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.1.0",
+        "node-fetch": "^2.6.7",
+        "nopt": "^5.0.0",
+        "npmlog": "^5.0.1",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.11"
+      },
+      "bin": {
+        "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-1.0.2.tgz",
+      "integrity": "sha512-EYEqlMYaCbpZDz+IgDH5xp9MTd3ui4dmGqbQYryhMLnSRxrhHKq5KQWHHKxFUcEP4Hp8/BWgvqXocX4j7iSbOQ==",
+      "license": "MIT",
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "1.0.2",
+        "@napi-rs/canvas-darwin-arm64": "1.0.2",
+        "@napi-rs/canvas-darwin-x64": "1.0.2",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "1.0.2",
+        "@napi-rs/canvas-linux-arm64-gnu": "1.0.2",
+        "@napi-rs/canvas-linux-arm64-musl": "1.0.2",
+        "@napi-rs/canvas-linux-riscv64-gnu": "1.0.2",
+        "@napi-rs/canvas-linux-x64-gnu": "1.0.2",
+        "@napi-rs/canvas-linux-x64-musl": "1.0.2",
+        "@napi-rs/canvas-win32-arm64-msvc": "1.0.2",
+        "@napi-rs/canvas-win32-x64-msvc": "1.0.2"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-1.0.2.tgz",
+      "integrity": "sha512-IMXKVQod0ol4vt3gmClUfXz4JAgHYESGPCUqmH3lQxBoL0K/2greJaQE1HVBVxWWFKfLc4OLZVdxg7kXVyXv+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-1.0.2.tgz",
+      "integrity": "sha512-Sc8tPi6cF+5lqOzCCKFALJHhDiRwyMzTPYm3bbhdXsOunU0lQO5f05ucyOzN2r55I23Hg5bsjH63uSCvWp3EgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-1.0.2.tgz",
+      "integrity": "sha512-niDXZ9LhKB1zLrUdYB64RHQFDGz9rr0eGx061qtJJU3U20EMMIx28ADF5fVYbhtOgkWQrBjFicfaye1yM0U62A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-1.0.2.tgz",
+      "integrity": "sha512-sgatQL9JxGRH/Amzcvu0P3t8Am3duou74CisfuJ41Dwt8cWy723z/9KZ8LlgmxfypEwEZxSTNFJtU8d281lmhQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-1.0.2.tgz",
+      "integrity": "sha512-dgKuX0peF3xwY6ZF5QxGS4wbfDqpoFAJYXiLSp+guZKARQUKMkRqZSDrXKj7nfrec3UCMzC0PFCPte0ES98AiA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-1.0.2.tgz",
+      "integrity": "sha512-qwROoDIC9upfvDoRLuPn2aNg9CGW1x0Ygr4k2Or+8paA9d0qBLwk87U+g8KQpoOviKoPoiwl97kvBYuYD7qZoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-1.0.2.tgz",
+      "integrity": "sha512-fXRjnPihdnbO6qy1QQOgxAonb68A0TCEG7rj1x7v7rxNElsE8EVIKIEUTvyDtU+sthYSbX+8e7g3oZiLGnOmxw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-1.0.2.tgz",
+      "integrity": "sha512-nPR97DXhbWIAy7yazF3jc06kEPMqYMLmPzFOVNlwKPfIoSChnI+x7dc0hTLaihz3jxrjL6j4BbA7earxfx4X3g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-1.0.2.tgz",
+      "integrity": "sha512-l7zZY5+jL5qnBZtDz7CoBtY6p7EkHu422g/0zWwrOrzIwWyWxZFRfZZORY1UG7YApymPLx+UbOkN206xXn/c1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-1.0.2.tgz",
+      "integrity": "sha512-yE0koHCFF4PIbMc2o2SEALhnipz7WBISh5glLvQiomtIoCcW0np3H4Lw93ceJAfJttTTeIIWFbwH84F7EVzjMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-1.0.2.tgz",
+      "integrity": "sha512-okU8/t2foV6C31n0GtvEMbfD5rOFc70+/6xUNME9Guld29sgSOIGUEDScAWFlcP3k5TYQRl9TNkwJEEjh15w8A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
     "node_modules/@npmcli/agent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-3.0.0.tgz",
@@ -2524,6 +3034,28 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/aproba": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
+      "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/are-we-there-yet": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+      "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -2948,6 +3480,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/canvas": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.11.2.tgz",
+      "integrity": "sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@mapbox/node-pre-gyp": "^1.0.0",
+        "nan": "^2.17.0",
+        "simple-get": "^3.0.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3143,6 +3691,16 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -3178,8 +3736,15 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/content-disposition": {
       "version": "1.0.1",
@@ -3439,6 +4004,13 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -4910,7 +5482,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
@@ -4988,6 +5560,28 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/gauge": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
+      "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.2",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.1",
+        "object-assign": "^4.1.1",
+        "signal-exit": "^3.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/get-caller-file": {
@@ -5264,6 +5858,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+      "license": "ISC",
+      "optional": true
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -5456,7 +6057,7 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -5879,6 +6480,22 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
     },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/make-fetch-happen": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-14.0.3.tgz",
@@ -6203,6 +6820,13 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "license": "ISC"
     },
+    "node_modules/nan": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.28.0.tgz",
+      "integrity": "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -6436,6 +7060,30 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/npmlog": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
+      "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "are-we-there-yet": "^2.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^3.0.0",
+        "set-blocking": "^2.0.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -6648,7 +7296,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6709,6 +7357,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/path2d": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/path2d/-/path2d-0.2.2.tgz",
+      "integrity": "sha512-+vnG6S4dYcYxZd+CZxzXCNKdELYZSKfohrk98yajCo1PtRoDgCTrrwOvK1GT0UoAdVszagDVllQc0U1vaX4NUQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pdf-parse": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.1.tgz",
@@ -6729,6 +7387,19 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "4.6.82",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-4.6.82.tgz",
+      "integrity": "sha512-BUOryeRFwvbLe0lOU6NhkJNuVQUp06WxlJVVCsxdmJ4y5cU3O3s3/0DunVdK1PMm7v2MUw52qKYaidhDH1Z9+w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "canvas": "^2.11.2",
+        "path2d": "^0.2.1"
       }
     },
     "node_modules/pe-library": {
@@ -7395,7 +8066,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -7509,6 +8180,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -7670,6 +8348,65 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/simple-get": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
+      "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "decompress-response": "^4.2.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/simple-get/node_modules/decompress-response": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mimic-response": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/simple-get/node_modules/mimic-response": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
@@ -8393,6 +9130,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
     "node_modules/wrap-ansi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "gray-matter": "^4.0.3",
         "inquirer": "^8.2.7",
         "ora": "^5.4.1",
+        "pdf-parse": "^1.1.1",
         "sharp": "^0.34.5"
       },
       "bin": {
@@ -477,6 +478,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -498,6 +500,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -514,6 +517,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -528,6 +532,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -2188,7 +2193,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3242,7 +3246,8 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3502,7 +3507,6 @@
       "integrity": "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.8.1",
         "builder-util": "26.8.1",
@@ -4172,6 +4176,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -4192,6 +4197,7 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -6177,6 +6183,7 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -6279,6 +6286,12 @@
       "engines": {
         "node": ">=10.5.0"
       }
+    },
+    "node_modules/node-ensure": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
+      "integrity": "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==",
+      "license": "MIT"
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
@@ -6696,6 +6709,28 @@
         "node": ">=4"
       }
     },
+    "node_modules/pdf-parse": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.1.tgz",
+      "integrity": "sha512-v6ZJ/efsBpGrGGknjtq9J/oC8tZWq0KWL5vQrk2GlzLEQPUDB1ex+13Rmidl1neNN358Jn9EHZw5y07FFtaC7A==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.1.0",
+        "node-ensure": "^0.0.0"
+      },
+      "engines": {
+        "node": ">=6.8.1"
+      }
+    },
+    "node_modules/pdf-parse/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
     "node_modules/pe-library": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/pe-library/-/pe-library-0.4.1.tgz",
@@ -6731,7 +6766,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6818,6 +6852,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -6835,6 +6870,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -7179,6 +7215,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -7192,6 +7229,7 @@
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -7204,6 +7242,7 @@
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -7225,6 +7264,7 @@
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -7949,6 +7989,7 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.27.0",
     "@larksuiteoapi/node-sdk": "^1.58.0",
+    "@napi-rs/canvas": "^1.0.2",
     "axios": "^1.6.2",
     "chalk": "^4.1.2",
     "commander": "^11.1.0",
@@ -69,6 +70,7 @@
     "inquirer": "^8.2.7",
     "ora": "^5.4.1",
     "pdf-parse": "^1.1.1",
+    "pdfjs-dist": "^4.6.82",
     "sharp": "^0.34.5"
   },
   "devDependencies": {
@@ -122,6 +124,8 @@
         "filter": [
           "**/*.node",
           "**/*.js",
+          "**/*.mjs",
+          "**/*.wasm",
           "**/*.json",
           "!**/.bin/**",
           "!**/test/**",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "gray-matter": "^4.0.3",
     "inquirer": "^8.2.7",
     "ora": "^5.4.1",
+    "pdf-parse": "^1.1.1",
     "sharp": "^0.34.5"
   },
   "devDependencies": {

--- a/src/tools/read-tool.ts
+++ b/src/tools/read-tool.ts
@@ -1,6 +1,8 @@
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import * as readline from 'readline';
+import { execFileSync } from 'child_process';
 import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import { isReadPathAllowed } from '../utils/safety';
 import { createImageBlock } from '../utils/image-utils';
@@ -20,6 +22,18 @@ export const DEFAULT_PDF_READ_PAGES = 10;
 export const MAX_PDF_READ_PAGES = 30;
 export const MAX_PDF_READ_BYTES = 20 * 1024 * 1024;
 export const MAX_PDF_OUTPUT_BYTES = 192 * 1024;
+export const DEFAULT_PDF_IMAGE_FALLBACK_PAGES = 3;
+export const MAX_PDF_IMAGE_FALLBACK_PAGES = 5;
+const MAX_PDF_RENDER_PIXELS = 4_000_000;
+const DEFAULT_PDF_RENDER_SCALE = 1.75;
+const PDF_VISUAL_INTENT_PATTERNS = [
+  /图片|图像|照片|截图|扫描|扫描件|影印|拍照/,
+  /签名|签字|手写|字迹|笔迹|批注/,
+  /印章|盖章|公章|章印|红章|骑缝章/,
+  /版式|布局|排版|页面结构|格式|样式|颜色|表格|图表|流程图/,
+  /试卷|答题卡|作业|批改|卷面/,
+  /\b(image|photo|picture|screenshot|scan|scanned|signature|handwriting|stamp|seal|layout|table|chart|diagram|visual)\b/i,
+];
 
 interface PdfParseOptions {
   max?: number;
@@ -74,6 +88,31 @@ interface PdfPageSelection {
   warnings: string[];
 }
 
+interface RenderedPdfPage {
+  pageNumber: number;
+  imagePath: string;
+  renderer: 'pdfjs' | 'pdftoppm';
+}
+
+interface PdfCanvasAndContext {
+  canvas: any;
+  context: any;
+}
+
+interface ReadImageOptions {
+  forceReaderProxy?: boolean;
+  metadataType?: string;
+  proxyIntro?: string;
+}
+
+interface PdfRenderedImageReadOptions {
+  reason: 'missing_text' | 'parse_failed' | 'visual_supplement';
+  totalPages?: number;
+}
+
+type DynamicImport = (specifier: string) => Promise<any>;
+const dynamicImport: DynamicImport = new Function('specifier', 'return import(specifier)') as DynamicImport;
+
 /**
  * Read tool - reads local files and returns content to the model.
  */
@@ -83,6 +122,7 @@ export class ReadTool implements Tool {
     description: [
       '读取一个本地文件或当前用户轮次授权的 CatsCo 附件。',
       '支持文本/代码、PDF、图片和 Jupyter notebook。文本默认只读前若干行，可用 offset/limit 分页。',
+      'PDF 会先提取文本层；如果文本层为空、解析失败，或用户明显关心图片/签章/手写/版式等视觉内容，会自动把少量页面转成图片并走读图链路。',
       '图片会按当前模型能力处理：视觉模型收到图片块，非视觉模型收到 reader proxy 的文字解析结果。',
     ].join('\n'),
     parameters: {
@@ -222,7 +262,7 @@ export class ReadTool implements Tool {
     const ext = path.extname(absolutePath).toLowerCase();
 
     if (ext === '.pdf') {
-      const content = await this.readPDF(absolutePath, displayPath, visiblePath, pages);
+      const content = await this.readPDF(absolutePath, displayPath, visiblePath, context, pages, prompt || analysis_prompt);
       return { ok: true, content };
     }
 
@@ -479,6 +519,33 @@ export class ReadTool implements Tool {
     };
   }
 
+  private getPdfCoverageNotice(selection: PdfPageSelection, totalPages?: number): string[] {
+    if (!Number.isFinite(totalPages) || !totalPages || totalPages <= 0) return [];
+    const pageCount = Math.floor(totalPages);
+    const selectedPages = selection.selectedPages
+      ? Array.from(selection.selectedPages).filter(page => page <= pageCount).sort((a, b) => a - b)
+      : undefined;
+
+    if (selectedPages) {
+      const coversAllPages = selectedPages.length === pageCount
+        && selectedPages.every((page, index) => page === index + 1);
+      if (coversAllPages) return [];
+
+      return [
+        `读取范围提示: 仅已读取页 ${selectedPages.length > 0 ? selectedPages.join(', ') : selection.label} / 共 ${pageCount} 页。`,
+        '重要: 下面内容只代表已读取页，不能当作整份 PDF 的完整总结；如果用户要全文/整份分析，请询问是否继续分段读取全文，或让用户指定页码。',
+      ];
+    }
+
+    const readCount = Math.min(selection.maxPageToRender, pageCount);
+    if (readCount >= pageCount) return [];
+
+    return [
+      `读取范围提示: 仅已读取前 ${readCount} / 共 ${pageCount} 页。`,
+      '重要: 下面内容只代表已读取页，不能当作整份 PDF 的完整总结；如果用户要全文/整份分析，请询问是否继续分段读取全文，或让用户指定页码。',
+    ];
+  }
+
   private async extractPdfText(absolutePath: string, selection: PdfPageSelection): Promise<PdfParseResult> {
     const data = fs.readFileSync(absolutePath);
     const selectedPages = selection.selectedPages;
@@ -513,7 +580,265 @@ export class ReadTool implements Tool {
     return pdfParse(data, options);
   }
 
-  private async readPDF(absolutePath: string, filePath: string, visiblePath: string, pages?: string): Promise<string> {
+  private getPdfRenderedImagePages(selection: PdfPageSelection, totalPages?: number): number[] {
+    if (selection.selectedPages && selection.selectedPages.size > 0) {
+      return Array.from(selection.selectedPages)
+        .sort((a, b) => a - b)
+        .slice(0, MAX_PDF_IMAGE_FALLBACK_PAGES);
+    }
+
+    const knownPages = Number.isFinite(totalPages) && totalPages && totalPages > 0
+      ? Math.floor(totalPages)
+      : undefined;
+    const count = knownPages && knownPages <= MAX_PDF_IMAGE_FALLBACK_PAGES
+      ? knownPages
+      : Math.min(DEFAULT_PDF_IMAGE_FALLBACK_PAGES, selection.maxPageToRender);
+    return Array.from({ length: count }, (_, index) => index + 1);
+  }
+
+  private shouldSupplementPdfVisualRead(context: ToolExecutionContext, prompt?: string): boolean {
+    const task = this.getImageReadPrompt(context, prompt);
+    if (!task) return false;
+    return PDF_VISUAL_INTENT_PATTERNS.some(pattern => pattern.test(task));
+  }
+
+  private loadPdfCanvasModule(): any {
+    const rawCanvasModule = require('@napi-rs/canvas');
+    const canvasModule = rawCanvasModule?.createCanvas
+      ? rawCanvasModule
+      : rawCanvasModule?.default;
+    if (!canvasModule?.createCanvas) {
+      throw new Error('@napi-rs/canvas createCanvas is unavailable');
+    }
+    return canvasModule;
+  }
+
+  private createPdfCanvasFactory(canvasModule: any): any {
+    return {
+      create(width: number, height: number): PdfCanvasAndContext {
+        if (width <= 0 || height <= 0) {
+          throw new Error('Invalid PDF canvas size');
+        }
+        const canvas = canvasModule.createCanvas(width, height);
+        return {
+          canvas,
+          context: canvas.getContext('2d', { willReadFrequently: true }),
+        };
+      },
+      reset(canvasAndContext: PdfCanvasAndContext, width: number, height: number): void {
+        if (!canvasAndContext?.canvas) {
+          throw new Error('PDF canvas is not specified');
+        }
+        if (width <= 0 || height <= 0) {
+          throw new Error('Invalid PDF canvas size');
+        }
+        canvasAndContext.canvas.width = width;
+        canvasAndContext.canvas.height = height;
+      },
+      destroy(canvasAndContext: PdfCanvasAndContext): void {
+        if (!canvasAndContext?.canvas) return;
+        canvasAndContext.canvas.width = 0;
+        canvasAndContext.canvas.height = 0;
+        canvasAndContext.canvas = null;
+        canvasAndContext.context = null;
+      },
+    };
+  }
+
+  private async renderPdfPagesWithPdfJs(
+    absolutePath: string,
+    pages: number[],
+    tempDir: string,
+  ): Promise<RenderedPdfPage[]> {
+    const canvasModule = this.loadPdfCanvasModule();
+    const globalScope = globalThis as any;
+    if (!globalScope.DOMMatrix && canvasModule.DOMMatrix) globalScope.DOMMatrix = canvasModule.DOMMatrix;
+    if (!globalScope.DOMPoint && canvasModule.DOMPoint) globalScope.DOMPoint = canvasModule.DOMPoint;
+    if (!globalScope.DOMRect && canvasModule.DOMRect) globalScope.DOMRect = canvasModule.DOMRect;
+    if (!globalScope.ImageData && canvasModule.ImageData) globalScope.ImageData = canvasModule.ImageData;
+    if (!globalScope.Path2D && canvasModule.Path2D) globalScope.Path2D = canvasModule.Path2D;
+
+    const pdfjs = await dynamicImport('pdfjs-dist/legacy/build/pdf.mjs');
+    const canvasFactory = this.createPdfCanvasFactory(canvasModule);
+    const data = new Uint8Array(fs.readFileSync(absolutePath));
+    const loadingTask = pdfjs.getDocument({
+      data,
+      disableWorker: true,
+      useSystemFonts: true,
+      canvasFactory,
+    });
+
+    const rendered: RenderedPdfPage[] = [];
+    const doc = await loadingTask.promise;
+    try {
+      for (const pageNumber of pages) {
+        if (pageNumber > doc.numPages) continue;
+
+        const page = await doc.getPage(pageNumber);
+        const baseViewport = page.getViewport({ scale: 1 });
+        const basePixels = Math.max(1, baseViewport.width * baseViewport.height);
+        const maxScale = Math.sqrt(MAX_PDF_RENDER_PIXELS / basePixels);
+        const scale = Math.min(DEFAULT_PDF_RENDER_SCALE, maxScale);
+        const viewport = page.getViewport({ scale });
+        const canvas = canvasModule.createCanvas(Math.ceil(viewport.width), Math.ceil(viewport.height));
+        const canvasContext = canvas.getContext('2d');
+        await page.render({ canvasContext, viewport, canvasFactory }).promise;
+
+        const imagePath = path.join(tempDir, `page-${pageNumber}.png`);
+        fs.writeFileSync(imagePath, canvas.toBuffer('image/png'));
+        rendered.push({ pageNumber, imagePath, renderer: 'pdfjs' });
+        page.cleanup?.();
+      }
+    } finally {
+      await doc.destroy();
+    }
+
+    if (rendered.length === 0) {
+      throw new Error('PDF 页码超出范围，未渲染出任何页面。');
+    }
+    return rendered;
+  }
+
+  private async renderPdfPagesWithPdftoppm(
+    absolutePath: string,
+    pages: number[],
+    tempDir: string,
+  ): Promise<RenderedPdfPage[]> {
+    const rendered: RenderedPdfPage[] = [];
+    for (const pageNumber of pages) {
+      const outputPrefix = path.join(tempDir, `pdftoppm-page-${pageNumber}`);
+      execFileSync('pdftoppm', [
+        '-f',
+        String(pageNumber),
+        '-l',
+        String(pageNumber),
+        '-singlefile',
+        '-png',
+        '-r',
+        '150',
+        absolutePath,
+        outputPrefix,
+      ], { timeout: 45_000, stdio: 'pipe' });
+
+      const imagePath = `${outputPrefix}.png`;
+      if (fs.existsSync(imagePath)) {
+        rendered.push({ pageNumber, imagePath, renderer: 'pdftoppm' });
+      }
+    }
+
+    if (rendered.length === 0) {
+      throw new Error('pdftoppm 未生成页面图片。');
+    }
+    return rendered;
+  }
+
+  private async renderPdfPagesToImages(
+    absolutePath: string,
+    pages: number[],
+    tempDir: string,
+  ): Promise<RenderedPdfPage[]> {
+    let pdfJsMessage = 'unknown pdfjs error';
+    try {
+      return await this.renderPdfPagesWithPdfJs(absolutePath, pages, tempDir);
+    } catch (pdfJsError: any) {
+      pdfJsMessage = String(pdfJsError?.message || pdfJsError || 'unknown pdfjs error');
+      Logger.warning(`[CatsCo] pdf_image_fallback pdfjs_failed file=${formatPathForLog(absolutePath)} reason=${pdfJsMessage.slice(0, 300)}`);
+    }
+
+    try {
+      return await this.renderPdfPagesWithPdftoppm(absolutePath, pages, tempDir);
+    } catch (pdftoppmError: any) {
+      const message = String(pdftoppmError?.message || pdftoppmError || 'unknown pdftoppm error');
+      throw new Error(`PDF 页面渲染失败：内置 PDF.js 渲染失败：${pdfJsMessage}；系统 pdftoppm 也不可用或执行失败：${message}`);
+    }
+  }
+
+  private async readPdfViaRenderedImages(
+    absolutePath: string,
+    filePath: string,
+    visiblePath: string,
+    context: ToolExecutionContext,
+    selection: PdfPageSelection,
+    prompt?: string,
+    options?: PdfRenderedImageReadOptions,
+  ): Promise<string> {
+    const pages = this.getPdfRenderedImagePages(selection, options?.totalPages);
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'catsco-pdf-pages-'));
+
+    try {
+      const renderedPages = await this.renderPdfPagesToImages(absolutePath, pages, tempDir);
+      const isSupplement = options?.reason === 'visual_supplement';
+      const parts = [
+        isSupplement
+          ? 'PDF 文本层已提取；由于用户任务可能涉及图片、签名、印章、手写、版式或表格，已额外转成页面图片补充读取。'
+          : 'PDF 文本层未提取到内容，已自动转成页面图片继续读取。',
+        `${isSupplement ? '视觉补充页码' : '转图片页码'}: ${renderedPages.map(page => page.pageNumber).join(', ')}`,
+        `读取方式: ${renderedPages[0]?.renderer === 'pdftoppm' ? '系统 pdftoppm 渲染 + Cats reader proxy 读图' : '内置 PDF.js 渲染 + Cats reader proxy 读图'}`,
+      ];
+
+      if (pages.length > renderedPages.length) {
+        const renderedSet = new Set(renderedPages.map(page => page.pageNumber));
+        const skipped = pages.filter(page => !renderedSet.has(page));
+        if (skipped.length > 0) {
+          parts.push(`跳过页码: ${skipped.join(', ')}（可能超出 PDF 总页数）`);
+        }
+      }
+
+      if (!selection.selectedPages && options?.totalPages && options.totalPages > renderedPages.length) {
+        parts.push(`PDF 共 ${options.totalPages} 页，为避免大 PDF 转图过慢和上下文膨胀，默认只补读前 ${renderedPages.length} 页；需要指定页请用 pages，例如 pages="12-15"。`);
+      } else if ((!selection.selectedPages || selection.selectedPages.size > MAX_PDF_IMAGE_FALLBACK_PAGES)
+        && selection.maxPageToRender > renderedPages.length) {
+        parts.push(`为避免读图成本和上下文膨胀，图片读取默认最多处理 ${renderedPages.length} 页；需要更多页请用 pages 指定更小范围。`);
+      }
+
+      const userTask = this.getImageReadPrompt(context, prompt);
+      for (const page of renderedPages) {
+        const pagePrompt = [
+          `用户正在读取 PDF 文件: ${visiblePath}`,
+          `当前是 PDF 第 ${page.pageNumber} 页的渲染图片。`,
+          userTask ? `用户任务: ${userTask}` : '请提取这一页中可见的文字、表格和关键结构。',
+        ].join('\n');
+        const analysis = await this.readImage(
+          page.imagePath,
+          `${filePath}#page=${page.pageNumber}`,
+          `${visiblePath}#page=${page.pageNumber}`,
+          context,
+          pagePrompt,
+          {
+            forceReaderProxy: true,
+            metadataType: 'PDF 页面图片',
+            proxyIntro: isSupplement
+              ? '视觉补充结果（PDF 文本层可能漏掉图片、签章、手写或版式信息）：'
+              : '读图结果（PDF 文本层不可用，已转为页面图片解析）：',
+          },
+        );
+        parts.push('', `--- 第 ${page.pageNumber} 页 ---`, String(analysis));
+      }
+
+      return parts.join('\n');
+    } catch (error: any) {
+      const rawMessage = String(error?.message || error || 'unknown error').trim();
+      const message = rawMessage.length > 500 ? `${rawMessage.slice(0, 500)}...` : rawMessage;
+      return [
+        options?.reason === 'visual_supplement'
+          ? 'PDF 文本层已提取，但 CatsCo 额外尝试转为页面图片补充读取时失败。'
+          : 'PDF 文本层未提取到内容，CatsCo 已尝试转为页面图片读取，但转图链路失败。',
+        `原因: ${message}`,
+        '可以改发截图/图片，或在当前环境安装 Poppler(pdftoppm) 后重试。',
+      ].join('\n');
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  }
+
+  private async readPDF(
+    absolutePath: string,
+    filePath: string,
+    visiblePath: string,
+    context: ToolExecutionContext,
+    pages?: string,
+    prompt?: string,
+  ): Promise<string> {
     const stats = fs.statSync(absolutePath);
     const sizeMB = (stats.size / 1024 / 1024).toFixed(2);
     const selection = this.parsePdfPages(pages);
@@ -545,6 +870,11 @@ export class ReadTool implements Tool {
         `已解析页: ${selection.label}`,
       );
 
+      const coverageNotice = this.getPdfCoverageNotice(selection, parsed.numpages);
+      if (coverageNotice.length > 0) {
+        lines.push('', ...coverageNotice);
+      }
+
       if (selection.warnings.length > 0) {
         lines.push('', ...selection.warnings);
       }
@@ -552,8 +882,10 @@ export class ReadTool implements Tool {
       if (!rawText) {
         lines.push(
           '',
-          '未提取到可用文本。这个 PDF 可能是扫描件/图片型 PDF、加密文档，或文本层为空。',
-          '如果用户需要读内容，建议改用图片 OCR、截图读图，或 shell 中更专业的文档解析工具。',
+          await this.readPdfViaRenderedImages(absolutePath, filePath, visiblePath, context, selection, prompt, {
+            reason: 'missing_text',
+            totalPages: parsed.numpages,
+          }),
         );
         return lines.join('\n');
       }
@@ -573,6 +905,16 @@ export class ReadTool implements Tool {
         );
       }
 
+      if (this.shouldSupplementPdfVisualRead(context, prompt)) {
+        lines.push(
+          '',
+          await this.readPdfViaRenderedImages(absolutePath, filePath, visiblePath, context, selection, prompt, {
+            reason: 'visual_supplement',
+            totalPages: parsed.numpages,
+          }),
+        );
+      }
+
       return lines.join('\n');
     } catch (error: any) {
       const rawMessage = String(error?.message || error || 'unknown error').trim();
@@ -581,7 +923,10 @@ export class ReadTool implements Tool {
         '',
         'PDF 解析失败，read_file 未能提取正文。',
         `原因: ${message}`,
-        '可以尝试重新上传 PDF、改发截图，或使用 shell 中可用的文档解析库/系统工具处理。',
+        '',
+        await this.readPdfViaRenderedImages(absolutePath, filePath, visiblePath, context, selection, prompt, {
+          reason: 'parse_failed',
+        }),
       );
       return lines.join('\n');
     }
@@ -620,10 +965,15 @@ export class ReadTool implements Tool {
     return explicit || this.getLatestUserText(context);
   }
 
-  private formatImageMetadata(absolutePath: string, filePath: string, visiblePath: string): string {
+  private formatImageMetadata(
+    absolutePath: string,
+    filePath: string,
+    visiblePath: string,
+    metadataType = '图片文件',
+  ): string {
     const stats = fs.statSync(absolutePath);
     const sizeKB = (stats.size / 1024).toFixed(2);
-    return [`文件: ${filePath}`, `Path: ${visiblePath}`, '类型: 图片文件', `大小: ${sizeKB} KB`].join('\n');
+    return [`文件: ${filePath}`, `Path: ${visiblePath}`, `类型: ${metadataType}`, `大小: ${sizeKB} KB`].join('\n');
   }
 
   private formatReaderProxyFailure(proxyResult: ReaderProxyResult, visionCapable: boolean): string {
@@ -683,13 +1033,15 @@ export class ReadTool implements Tool {
     visiblePath: string,
     context: ToolExecutionContext,
     prompt?: string,
+    options?: ReadImageOptions,
   ): Promise<any> {
     const config = ConfigManager.getConfigReadonly();
     const imagePrompt = this.getImageReadPrompt(context, prompt);
     const visionCapable = isPrimaryModelVisionCapable(config);
+    const forceReaderProxy = Boolean(options?.forceReaderProxy);
     const modelName = config.model || 'unknown';
 
-    if (visionCapable) {
+    if (visionCapable && !forceReaderProxy) {
       const imageBlock = await createImageBlock(absolutePath);
       const logFile = formatPathForLog(absolutePath || filePath);
       if (imageBlock) {
@@ -713,19 +1065,19 @@ export class ReadTool implements Tool {
 
     if (proxyResult.ok && proxyResult.analysis) {
       return [
-        this.formatImageMetadata(absolutePath, filePath, visiblePath),
+        this.formatImageMetadata(absolutePath, filePath, visiblePath, options?.metadataType),
         '',
-        visionCapable
+        options?.proxyIntro || (visionCapable && !forceReaderProxy
           ? '主模型图片块生成失败，已自动改用 Cats reader proxy 解析：'
-          : '读图结果（由 Cats reader proxy 解析，已作为 read_file 结果返回给当前非多模态主模型）：',
+          : '读图结果（由 Cats reader proxy 解析，已作为 read_file 结果返回给当前非多模态主模型）：'),
         proxyResult.analysis,
       ].join('\n');
     }
 
     return [
-      this.formatImageMetadata(absolutePath, filePath, visiblePath),
+      this.formatImageMetadata(absolutePath, filePath, visiblePath, options?.metadataType),
       '',
-      this.formatReaderProxyFailure(proxyResult, visionCapable),
+      this.formatReaderProxyFailure(proxyResult, visionCapable && !forceReaderProxy),
     ].join('\n');
   }
 

--- a/src/tools/read-tool.ts
+++ b/src/tools/read-tool.ts
@@ -16,6 +16,26 @@ import { executeRouteIfRemote, resolveExecutionRoute, targetParameterDescription
 export const DEFAULT_TEXT_READ_LIMIT = 200;
 export const MAX_TEXT_READ_LIMIT = 2000;
 export const MAX_TEXT_READ_BYTES = 256 * 1024;
+export const DEFAULT_PDF_READ_PAGES = 10;
+export const MAX_PDF_READ_PAGES = 30;
+export const MAX_PDF_READ_BYTES = 20 * 1024 * 1024;
+export const MAX_PDF_OUTPUT_BYTES = 192 * 1024;
+
+interface PdfParseOptions {
+  max?: number;
+  version?: string;
+  pagerender?: (pageData: any) => Promise<string>;
+}
+
+interface PdfParseResult {
+  numpages?: number;
+  numrender?: number;
+  text?: string;
+  info?: Record<string, unknown>;
+}
+
+type PdfParse = (dataBuffer: Buffer, options?: PdfParseOptions) => Promise<PdfParseResult>;
+const pdfParse: PdfParse = require('pdf-parse');
 
 interface TextReadOptions {
   offset?: unknown;
@@ -45,6 +65,13 @@ interface TextReadResult {
   isUnlimitedRequest: boolean;
   requestedLimit?: number;
   nextOffset?: number;
+}
+
+interface PdfPageSelection {
+  label: string;
+  maxPageToRender: number;
+  selectedPages?: Set<number>;
+  warnings: string[];
 }
 
 /**
@@ -195,7 +222,7 @@ export class ReadTool implements Tool {
     const ext = path.extname(absolutePath).toLowerCase();
 
     if (ext === '.pdf') {
-      const content = this.readPDF(absolutePath, displayPath, visiblePath, pages);
+      const content = await this.readPDF(absolutePath, displayPath, visiblePath, pages);
       return { ok: true, content };
     }
 
@@ -395,25 +422,169 @@ export class ReadTool implements Tool {
     return this.formatTextReadResult(filePath, visiblePath, result);
   }
 
-  private readPDF(absolutePath: string, filePath: string, visiblePath: string, pages?: string): string {
+  private parsePdfPages(pages?: string): PdfPageSelection {
+    const warnings: string[] = [];
+    const raw = typeof pages === 'string' ? pages.trim() : '';
+
+    if (!raw) {
+      return {
+        label: `前 ${DEFAULT_PDF_READ_PAGES} 页`,
+        maxPageToRender: DEFAULT_PDF_READ_PAGES,
+        warnings,
+      };
+    }
+
+    const selected = new Set<number>();
+    for (const part of raw.split(',').map(item => item.trim()).filter(Boolean)) {
+      const range = part.match(/^(\d+)\s*-\s*(\d+)$/);
+      if (range) {
+        const start = Number(range[1]);
+        const end = Number(range[2]);
+        if (!Number.isInteger(start) || !Number.isInteger(end) || start <= 0 || end <= 0 || end < start) {
+          warnings.push(`已忽略无效页码范围: ${part}`);
+          continue;
+        }
+        for (let page = start; page <= end; page += 1) selected.add(page);
+        continue;
+      }
+
+      const page = Number(part);
+      if (Number.isInteger(page) && page > 0) {
+        selected.add(page);
+      } else {
+        warnings.push(`已忽略无效页码: ${part}`);
+      }
+    }
+
+    if (selected.size === 0) {
+      warnings.push(`pages="${raw}" 未匹配到有效页码，已改为默认读取前 ${DEFAULT_PDF_READ_PAGES} 页。`);
+      return {
+        label: `前 ${DEFAULT_PDF_READ_PAGES} 页`,
+        maxPageToRender: DEFAULT_PDF_READ_PAGES,
+        warnings,
+      };
+    }
+
+    const sorted = Array.from(selected).sort((a, b) => a - b);
+    const capped = sorted.slice(0, MAX_PDF_READ_PAGES);
+    if (sorted.length > capped.length) {
+      warnings.push(`请求页数 ${sorted.length} 页，已限制为前 ${MAX_PDF_READ_PAGES} 个页码。`);
+    }
+
+    return {
+      label: capped.join(', '),
+      maxPageToRender: Math.max(...capped),
+      selectedPages: new Set(capped),
+      warnings,
+    };
+  }
+
+  private async extractPdfText(absolutePath: string, selection: PdfPageSelection): Promise<PdfParseResult> {
+    const data = fs.readFileSync(absolutePath);
+    const selectedPages = selection.selectedPages;
+    const options: PdfParseOptions = {
+      max: selection.maxPageToRender,
+      pagerender: async (pageData: any) => {
+        const pageNumber = typeof pageData?.pageIndex === 'number' ? pageData.pageIndex + 1 : undefined;
+        if (selectedPages && pageNumber && !selectedPages.has(pageNumber)) return '';
+
+        const textContent = await pageData.getTextContent({
+          normalizeWhitespace: false,
+          disableCombineTextItems: false,
+        });
+
+        let lastY: number | undefined;
+        let text = '';
+        for (const item of textContent.items || []) {
+          const value = typeof item?.str === 'string' ? item.str : '';
+          const y = Array.isArray(item?.transform) ? item.transform[5] : undefined;
+          if (!value) continue;
+          if (lastY === undefined || y === lastY) {
+            text += value;
+          } else {
+            text += `\n${value}`;
+          }
+          lastY = y;
+        }
+        return text;
+      },
+    };
+
+    return pdfParse(data, options);
+  }
+
+  private async readPDF(absolutePath: string, filePath: string, visiblePath: string, pages?: string): Promise<string> {
     const stats = fs.statSync(absolutePath);
     const sizeMB = (stats.size / 1024 / 1024).toFixed(2);
+    const selection = this.parsePdfPages(pages);
 
     const lines = [
       `文件: ${filePath}`,
       `Path: ${visiblePath}`,
       '类型: PDF',
       `大小: ${sizeMB} MB`,
-      '',
-      '当前 read_file 不再做 PDF 全文解析。',
-      '建议使用 shell 中可用的文档解析库、系统工具，或后续新增专门文档解析工具。',
     ];
 
-    if (pages) {
-      lines.push('', `已忽略 pages 参数: ${pages}`);
+    if (stats.size > MAX_PDF_READ_BYTES) {
+      lines.push(
+        '',
+        `PDF 文件超过 ${(MAX_PDF_READ_BYTES / 1024 / 1024).toFixed(0)} MB，read_file 不会自动解析，避免占满内存和上下文。`,
+        '请先指定更小文件，或使用 shell 中的文档解析工具做分段提取。',
+      );
+      return lines.join('\n');
     }
 
-    return lines.join('\n');
+    try {
+      const parsed = await this.extractPdfText(absolutePath, selection);
+      const rawText = String(parsed.text || '').trim();
+      const text = this.trimToUtf8ByteLimit(rawText, MAX_PDF_OUTPUT_BYTES);
+      const wasTruncated = Buffer.byteLength(rawText, 'utf-8') > Buffer.byteLength(text, 'utf-8');
+
+      lines.push(
+        `总页数: ${parsed.numpages ?? '未知'}`,
+        `已解析页: ${selection.label}`,
+      );
+
+      if (selection.warnings.length > 0) {
+        lines.push('', ...selection.warnings);
+      }
+
+      if (!rawText) {
+        lines.push(
+          '',
+          '未提取到可用文本。这个 PDF 可能是扫描件/图片型 PDF、加密文档，或文本层为空。',
+          '如果用户需要读内容，建议改用图片 OCR、截图读图，或 shell 中更专业的文档解析工具。',
+        );
+        return lines.join('\n');
+      }
+
+      lines.push('', '文本内容:', text);
+      if (wasTruncated) {
+        lines.push(
+          '',
+          `输出达到 ${(MAX_PDF_OUTPUT_BYTES / 1024).toFixed(0)} KB 上限，后续内容已省略。`,
+          '如需继续读取，请用 pages 参数指定更小页码范围，例如 pages="11-20"。',
+        );
+      } else if (!pages && parsed.numpages && parsed.numpages > DEFAULT_PDF_READ_PAGES) {
+        lines.push(
+          '',
+          `默认只解析前 ${DEFAULT_PDF_READ_PAGES} 页。`,
+          `如需继续读取，请调用 read_file 并指定 pages="${DEFAULT_PDF_READ_PAGES + 1}-${Math.min(parsed.numpages, DEFAULT_PDF_READ_PAGES * 2)}"。`,
+        );
+      }
+
+      return lines.join('\n');
+    } catch (error: any) {
+      const rawMessage = String(error?.message || error || 'unknown error').trim();
+      const message = rawMessage.length > 500 ? `${rawMessage.slice(0, 500)}...` : rawMessage;
+      lines.push(
+        '',
+        'PDF 解析失败，read_file 未能提取正文。',
+        `原因: ${message}`,
+        '可以尝试重新上传 PDF、改发截图，或使用 shell 中可用的文档解析库/系统工具处理。',
+      );
+      return lines.join('\n');
+    }
   }
 
   private isImageExt(ext: string): boolean {

--- a/tests/tool-result-read-tool.test.ts
+++ b/tests/tool-result-read-tool.test.ts
@@ -6,8 +6,108 @@ import * as assert from 'node:assert';
 import * as path from 'path';
 import * as os from 'os';
 import * as fs from 'fs';
-import { DEFAULT_PDF_READ_PAGES, DEFAULT_TEXT_READ_LIMIT, ReadTool } from '../src/tools/read-tool';
+import * as http from 'http';
+import { DEFAULT_PDF_IMAGE_FALLBACK_PAGES, DEFAULT_PDF_READ_PAGES, DEFAULT_TEXT_READ_LIMIT, ReadTool } from '../src/tools/read-tool';
 import { ToolExecutionContext } from '../src/types/tool';
+
+function writeVectorOnlyPdf(filePath: string): void {
+  const stream = [
+    '0.85 0.90 1 rg',
+    '20 20 160 160 re',
+    'f',
+    '0.1 0.4 0.7 RG',
+    '3 w',
+    '20 20 160 160 re',
+    'S',
+  ].join('\n');
+  const objects = [
+    '1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n',
+    '2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n',
+    '3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R >>\nendobj\n',
+    `4 0 obj\n<< /Length ${Buffer.byteLength(stream, 'ascii')} >>\nstream\n${stream}\nendstream\nendobj\n`,
+  ];
+
+  let body = '%PDF-1.4\n';
+  const offsets: number[] = [];
+  for (const object of objects) {
+    offsets.push(Buffer.byteLength(body, 'ascii'));
+    body += object;
+  }
+
+  const xrefOffset = Buffer.byteLength(body, 'ascii');
+  body += `xref\n0 ${objects.length + 1}\n`;
+  body += '0000000000 65535 f \n';
+  for (const offset of offsets) {
+    body += `${String(offset).padStart(10, '0')} 00000 n \n`;
+  }
+  body += [
+    'trailer',
+    `<< /Size ${objects.length + 1} /Root 1 0 R >>`,
+    'startxref',
+    String(xrefOffset),
+    '%%EOF',
+    '',
+  ].join('\n');
+
+  fs.writeFileSync(filePath, body, 'ascii');
+}
+
+function writeInlineImagePdf(filePath: string): void {
+  const inlineImageData = Buffer.from([
+    255, 255, 255,
+    210, 80, 80,
+    80, 150, 220,
+    45, 45, 45,
+  ]);
+  const stream = Buffer.concat([
+    Buffer.from([
+      'q',
+      '160 0 0 160 20 20 cm',
+      'BI',
+      '/W 2',
+      '/H 2',
+      '/CS /RGB',
+      '/BPC 8',
+      'ID ',
+    ].join('\n'), 'ascii'),
+    inlineImageData,
+    Buffer.from('\nEI\nQ\n', 'ascii'),
+  ]);
+  const objects = [
+    Buffer.from('1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n', 'ascii'),
+    Buffer.from('2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n', 'ascii'),
+    Buffer.from('3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R >>\nendobj\n', 'ascii'),
+    Buffer.concat([
+      Buffer.from(`4 0 obj\n<< /Length ${stream.length} >>\nstream\n`, 'ascii'),
+      stream,
+      Buffer.from('\nendstream\nendobj\n', 'ascii'),
+    ]),
+  ];
+
+  const chunks: Buffer[] = [Buffer.from('%PDF-1.4\n', 'ascii')];
+  const offsets: number[] = [];
+  for (const object of objects) {
+    offsets.push(Buffer.concat(chunks).length);
+    chunks.push(object);
+  }
+
+  const bodyBeforeXref = Buffer.concat(chunks);
+  let xref = `xref\n0 ${objects.length + 1}\n`;
+  xref += '0000000000 65535 f \n';
+  for (const offset of offsets) {
+    xref += `${String(offset).padStart(10, '0')} 00000 n \n`;
+  }
+  xref += [
+    'trailer',
+    `<< /Size ${objects.length + 1} /Root 1 0 R >>`,
+    'startxref',
+    String(bodyBeforeXref.length),
+    '%%EOF',
+    '',
+  ].join('\n');
+
+  fs.writeFileSync(filePath, Buffer.concat([bodyBeforeXref, Buffer.from(xref, 'ascii')]));
+}
 
 describe('ReadTool - ToolExecutionResult', () => {
   let tool: ReadTool;
@@ -155,6 +255,9 @@ describe('ReadTool - ToolExecutionResult', () => {
     assert.strictEqual(result.ok, true);
     const content = result.content as string;
     assert.ok(content.includes(`已解析页: 前 ${DEFAULT_PDF_READ_PAGES} 页`));
+    assert.ok(content.includes(`读取范围提示: 仅已读取前 ${DEFAULT_PDF_READ_PAGES} / 共 14 页。`));
+    assert.ok(content.includes('不能当作整份 PDF 的完整总结'));
+    assert.ok(content.includes('询问是否继续分段读取全文'));
     assert.ok(content.includes(`默认只解析前 ${DEFAULT_PDF_READ_PAGES} 页`));
     assert.ok(content.includes('pages="11-14"'));
   });
@@ -174,8 +277,183 @@ describe('ReadTool - ToolExecutionResult', () => {
     assert.strictEqual(result.ok, true);
     const content = result.content as string;
     assert.ok(content.includes('已解析页: 2'));
+    assert.ok(content.includes('读取范围提示: 仅已读取页 2 / 共 14 页。'));
+    assert.ok(content.includes('不能当作整份 PDF 的完整总结'));
     assert.ok(content.includes('Every compiled trace'));
     assert.ok(!content.includes('Trace-based Just-in-Time Type Specialization'));
+  });
+
+  test('PDF 有文本层但用户关心视觉内容时会补读少量页面图片', async () => {
+    const previousConfigPath = process.env.XIAOBA_CONFIG_PATH;
+    const previousReaderUrl = process.env.CATSCOMPANY_READER_API_URL;
+    const previousApiKey = process.env.CATSCOMPANY_API_KEY;
+    const observedRequests: Buffer[] = [];
+
+    const readerServer = http.createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', chunk => chunks.push(Buffer.from(chunk)));
+      req.on('end', () => {
+        observedRequests.push(Buffer.concat(chunks));
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ analysis: `visual supplement ${observedRequests.length}` }));
+      });
+    });
+
+    let serverListening = false;
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const onError = (error: Error) => reject(error);
+        readerServer.once('error', onError);
+        readerServer.listen(0, '127.0.0.1', () => {
+          readerServer.off('error', onError);
+          serverListening = true;
+          resolve();
+        });
+      });
+      const address = readerServer.address();
+      if (!address || typeof address === 'string') throw new Error('reader server did not bind');
+
+      process.env.XIAOBA_CONFIG_PATH = path.join(testRoot, 'missing-config.json');
+      process.env.CATSCOMPANY_READER_API_URL = `http://127.0.0.1:${address.port}`;
+      process.env.CATSCOMPANY_API_KEY = 'cats-reader-test-key';
+
+      const fixturePath = path.join(
+        path.dirname(require.resolve('pdf-parse')),
+        'test',
+        'data',
+        '01-valid.pdf',
+      );
+      const filePath = path.join(testRoot, 'fixture-visual-supplement.pdf');
+      fs.copyFileSync(fixturePath, filePath);
+      context = {
+        ...context,
+        conversationHistory: [{ role: 'user', content: '请读取这个 PDF，并检查有没有签名、印章和版式问题' }],
+      };
+
+      const result = await tool.execute({ file_path: filePath, pages: '1' }, context);
+
+      assert.strictEqual(result.ok, true);
+      assert.strictEqual(observedRequests.length, 1);
+      assert.ok(observedRequests[0].includes(Buffer.from('PDF 第 1 页')));
+      const content = result.content as string;
+      assert.ok(content.includes('文本内容:'));
+      assert.ok(content.includes('PDF 文本层已提取'));
+      assert.ok(content.includes('视觉补充页码: 1'));
+      assert.ok(content.includes('visual supplement 1'));
+    } finally {
+      if (serverListening) {
+        await new Promise<void>(resolve => readerServer.close(() => resolve()));
+      }
+      if (previousConfigPath === undefined) delete process.env.XIAOBA_CONFIG_PATH;
+      else process.env.XIAOBA_CONFIG_PATH = previousConfigPath;
+      if (previousReaderUrl === undefined) delete process.env.CATSCOMPANY_READER_API_URL;
+      else process.env.CATSCOMPANY_READER_API_URL = previousReaderUrl;
+      if (previousApiKey === undefined) delete process.env.CATSCOMPANY_API_KEY;
+      else process.env.CATSCOMPANY_API_KEY = previousApiKey;
+    }
+  });
+
+  test('PDF 默认视觉补读会按页数做保守抽样', () => {
+    const defaultSelection = {
+      label: `前 ${DEFAULT_PDF_READ_PAGES} 页`,
+      maxPageToRender: DEFAULT_PDF_READ_PAGES,
+      warnings: [],
+    };
+
+    assert.deepStrictEqual(
+      (tool as any).getPdfRenderedImagePages(defaultSelection, 2),
+      [1, 2],
+    );
+    assert.deepStrictEqual(
+      (tool as any).getPdfRenderedImagePages(defaultSelection, 200),
+      Array.from({ length: DEFAULT_PDF_IMAGE_FALLBACK_PAGES }, (_, index) => index + 1),
+    );
+    assert.deepStrictEqual(
+      (tool as any).getPdfRenderedImagePages({
+        label: '10-20',
+        maxPageToRender: 20,
+        selectedPages: new Set([10, 11, 12, 13, 14, 15]),
+        warnings: [],
+      }, 200),
+      [10, 11, 12, 13, 14],
+    );
+  });
+
+  test('无文本层 PDF 会转图片并通过 reader proxy 读取', async () => {
+    const previousConfigPath = process.env.XIAOBA_CONFIG_PATH;
+    const previousReaderUrl = process.env.CATSCOMPANY_READER_API_URL;
+    const previousApiKey = process.env.CATSCOMPANY_API_KEY;
+    let observedRequest:
+      | { method?: string; url?: string; authorization?: string; body: Buffer }
+      | undefined;
+
+    const readerServer = http.createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', chunk => chunks.push(Buffer.from(chunk)));
+      req.on('end', () => {
+        observedRequest = {
+          method: req.method,
+          url: req.url,
+          authorization: Array.isArray(req.headers.authorization)
+            ? req.headers.authorization.join(',')
+            : req.headers.authorization,
+          body: Buffer.concat(chunks),
+        };
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ analysis: 'reader proxy saw rendered pdf page' }));
+      });
+    });
+
+    let serverListening = false;
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const onError = (error: Error) => reject(error);
+        readerServer.once('error', onError);
+        readerServer.listen(0, '127.0.0.1', () => {
+          readerServer.off('error', onError);
+          serverListening = true;
+          resolve();
+        });
+      });
+      const address = readerServer.address();
+      if (!address || typeof address === 'string') throw new Error('reader server did not bind');
+
+      process.env.XIAOBA_CONFIG_PATH = path.join(testRoot, 'missing-config.json');
+      process.env.CATSCOMPANY_READER_API_URL = `http://127.0.0.1:${address.port}`;
+      process.env.CATSCOMPANY_API_KEY = 'cats-reader-test-key';
+
+      const filePath = path.join(testRoot, 'scan-like.pdf');
+      writeInlineImagePdf(filePath);
+      context = {
+        ...context,
+        conversationHistory: [{ role: 'user', content: '请读取这个扫描版 PDF 的内容' }],
+      };
+
+      const result = await tool.execute({ file_path: filePath }, context);
+
+      assert.strictEqual(result.ok, true);
+      assert.strictEqual(observedRequest?.method, 'POST');
+      assert.strictEqual(observedRequest?.url, '/analyze');
+      assert.strictEqual(observedRequest?.authorization, 'ApiKey cats-reader-test-key');
+      assert.ok(observedRequest?.body.includes(Buffer.from('Content-Type: image/png')));
+      assert.ok(observedRequest?.body.includes(Buffer.from('PDF 第 1 页')));
+      const content = result.content as string;
+      assert.ok(content.includes('PDF 文本层未提取到内容'));
+      assert.ok(content.includes('已自动转成页面图片继续读取'));
+      assert.ok(content.includes('reader proxy saw rendered pdf page'));
+    } finally {
+      if (serverListening) {
+        await new Promise<void>(resolve => readerServer.close(() => resolve()));
+      }
+      if (previousConfigPath === undefined) delete process.env.XIAOBA_CONFIG_PATH;
+      else process.env.XIAOBA_CONFIG_PATH = previousConfigPath;
+      if (previousReaderUrl === undefined) delete process.env.CATSCOMPANY_READER_API_URL;
+      else process.env.CATSCOMPANY_READER_API_URL = previousReaderUrl;
+      if (previousApiKey === undefined) delete process.env.CATSCOMPANY_API_KEY;
+      else process.env.CATSCOMPANY_API_KEY = previousApiKey;
+    }
   });
 
   test('损坏 PDF 返回解析失败提示', async () => {

--- a/tests/tool-result-read-tool.test.ts
+++ b/tests/tool-result-read-tool.test.ts
@@ -465,6 +465,9 @@ describe('ReadTool - ToolExecutionResult', () => {
     assert.ok(content.includes('PDF'));
     assert.ok(content.includes('PDF 解析失败'));
     assert.ok(content.includes('未能提取正文'));
+    assert.ok(content.includes('PDF 页面渲染失败：内置 PDF.js 渲染失败'));
+    assert.ok(content.includes('系统 pdftoppm 也不可用或执行失败'));
+    assert.ok(content.includes('安装 Poppler(pdftoppm) 后重试'));
     assert.ok(!content.includes('paper-analysis'));
   });
 });

--- a/tests/tool-result-read-tool.test.ts
+++ b/tests/tool-result-read-tool.test.ts
@@ -6,7 +6,7 @@ import * as assert from 'node:assert';
 import * as path from 'path';
 import * as os from 'os';
 import * as fs from 'fs';
-import { DEFAULT_TEXT_READ_LIMIT, ReadTool } from '../src/tools/read-tool';
+import { DEFAULT_PDF_READ_PAGES, DEFAULT_TEXT_READ_LIMIT, ReadTool } from '../src/tools/read-tool';
 import { ToolExecutionContext } from '../src/types/tool';
 
 describe('ReadTool - ToolExecutionResult', () => {
@@ -118,15 +118,75 @@ describe('ReadTool - ToolExecutionResult', () => {
     assert.ok(result.message.includes('文件不存在'));
   });
 
-  test('PDF 文件返回 ok=true 并给出提示', async () => {
+  test('PDF 文件会提取正文文本', async () => {
+    const fixturePath = path.join(
+      path.dirname(require.resolve('pdf-parse')),
+      'test',
+      'data',
+      '01-valid.pdf',
+    );
+    const filePath = path.join(testRoot, 'fixture.pdf');
+    fs.copyFileSync(fixturePath, filePath);
+
+    const result = await tool.execute({ file_path: filePath, pages: '1' }, context);
+
+    assert.strictEqual(result.ok, true);
+    const content = result.content as string;
+    assert.ok(content.includes('类型: PDF'));
+    assert.ok(content.includes('总页数:'));
+    assert.ok(content.includes('已解析页: 1'));
+    assert.ok(content.includes('文本内容:'));
+    assert.ok(content.includes('Trace-based'));
+    assert.ok(!content.includes('不再做 PDF 全文解析'));
+  });
+
+  test('PDF 默认只读取前若干页并提示继续读取', async () => {
+    const fixturePath = path.join(
+      path.dirname(require.resolve('pdf-parse')),
+      'test',
+      'data',
+      '01-valid.pdf',
+    );
+    const filePath = path.join(testRoot, 'fixture-default.pdf');
+    fs.copyFileSync(fixturePath, filePath);
+
+    const result = await tool.execute({ file_path: filePath }, context);
+
+    assert.strictEqual(result.ok, true);
+    const content = result.content as string;
+    assert.ok(content.includes(`已解析页: 前 ${DEFAULT_PDF_READ_PAGES} 页`));
+    assert.ok(content.includes(`默认只解析前 ${DEFAULT_PDF_READ_PAGES} 页`));
+    assert.ok(content.includes('pages="11-14"'));
+  });
+
+  test('PDF pages 参数只返回指定页内容', async () => {
+    const fixturePath = path.join(
+      path.dirname(require.resolve('pdf-parse')),
+      'test',
+      'data',
+      '01-valid.pdf',
+    );
+    const filePath = path.join(testRoot, 'fixture-page-filter.pdf');
+    fs.copyFileSync(fixturePath, filePath);
+
+    const result = await tool.execute({ file_path: filePath, pages: '2' }, context);
+
+    assert.strictEqual(result.ok, true);
+    const content = result.content as string;
+    assert.ok(content.includes('已解析页: 2'));
+    assert.ok(content.includes('Every compiled trace'));
+    assert.ok(!content.includes('Trace-based Just-in-Time Type Specialization'));
+  });
+
+  test('损坏 PDF 返回解析失败提示', async () => {
     const filePath = path.join(testRoot, 'dummy.pdf');
     fs.writeFileSync(filePath, '%PDF-1.4 fake content');
     const result = await tool.execute({ file_path: filePath }, context);
     assert.strictEqual(result.ok, true);
     const content = result.content as string;
     assert.ok(content.includes('PDF'));
-    assert.ok(content.includes('不再做 PDF 全文解析'));
-    assert.ok(content.includes('文档解析工具'));
+    assert.ok(content.includes('PDF 解析失败'));
+    assert.ok(content.includes('未能提取正文'));
     assert.ok(!content.includes('paper-analysis'));
   });
 });


### PR DESCRIPTION
## 变更内容

- 恢复并增强 `read_file` 的 PDF 文本层解析，默认读取前 10 页，最大 30 页，并在只读部分页时明确提示不要当作整份 PDF 总结。
- 为扫描件/无文本层 PDF 增加页面转图回退，优先使用内置 PDF.js + `@napi-rs/canvas`，系统 `pdftoppm` 仅作为可选 fallback。
- 扫描件/视觉 fallback 不是全文 OCR：默认只转前 3 页，最多 5 页；如需更多内容，用户需要继续分段读取或用 `pages` 指定页码。
- 当用户明显关心签名、印章、手写、版式、表格等视觉内容时，在文本层解析外补读少量页面图片。
- 补充 PDF 页码选择、部分读取提示、扫描件转图回退、PDF.js + `pdftoppm` 失败提示等测试覆盖。

## 为什么改

之前 PDF 附件只能很有限地读取，扫描件会直接提示读不了；大 PDF 默认只读前几页时，模型也容易误以为已经读完整份文件。这次把默认文本读取、扫描件回退和“只读了多少页”的提示一起补上，避免用户拿到误导性总结。

## 影响

- 普通文本 PDF：走文本层解析，成本低。
- 扫描件 PDF：默认只转少量页面图片并走 Cats reader proxy，避免一次性爆上下文或费用。
- 大 PDF：结果里会明确提示已读页数，并引导继续指定页码或分段读取。
- 打包依赖：新增 `pdf-parse`、`pdfjs-dist`、`@napi-rs/canvas`；Windows unpacked 包已确认包含 `pdf.worker.mjs` 和 `@napi-rs/canvas-win32-x64-msvc` 原生模块。

## 验证

- `npx tsx --test tests/tool-result-read-tool.test.ts`
- `npm run build`
- `git diff --check`
- `npx -y npm@10.9.3 install --package-lock-only --ignore-scripts`：未产生额外 diff，`package-lock.json` 变更来自新增依赖图，而不是 npm 版本漂移。
- Windows unpacked 打包 smoke：`npm run electron:build:win -- --dir` 已生成 `release/win-unpacked`；本机后续停在 electron-builder `winCodeSign` 辅助包解压的 symlink 权限问题，非应用依赖加载失败。
- 打包产物依赖 smoke：从 `release/win-unpacked/resources/app` 解析并加载 `pdfjs-dist/legacy/build/pdf.mjs`、`@napi-rs/canvas`，创建 canvas 并导出 PNG 成功。
- 打包产物 read_file smoke：直接调用 `release/win-unpacked/resources/app/dist/tools/read-tool.js`，普通文本 PDF 抽取成功；扫描件 PDF 用内置 PDF.js + canvas 渲染成 PNG，并 POST 到 fake Cats reader proxy 成功。