### PR TITLE
[codex] 稳定缓存 CatsCo 附件路径

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -638,6 +638,27 @@ ipcMain.handle('catsco:select-files', async (event) => {
     .filter(Boolean);
 });
 
+function getRuntimeDataRootForMenu() {
+  return process.env.XIAOBA_USER_DATA_DIR
+    || process.env.CATSCO_USER_DATA_DIR
+    || process.env.XIAOBA_ELECTRON_USER_DATA_DIR
+    || app.getPath('userData');
+}
+
+function openAttachmentCacheDirectory() {
+  const dir = path.join(getRuntimeDataRootForMenu(), 'data', 'attachments');
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+  } catch (error) {
+    console.error('Failed to create attachment cache directory:', error);
+  }
+  shell.openPath(dir).then((error) => {
+    if (error) {
+      console.error('Failed to open attachment cache directory:', error);
+    }
+  });
+}
+
 function createApplicationMenu() {
   const closeToTray = readCloseToTrayPreference();
   const quit = () => {
@@ -679,6 +700,12 @@ function createApplicationMenu() {
     {
       label: '编辑',
       submenu: editMenu,
+    },
+    {
+      label: '设置',
+      submenu: [
+        { label: '打开本地缓存文件位置', click: openAttachmentCacheDirectory },
+      ],
     },
     {
       label: '视图',

--- a/src/catscompany/attachment-cache.ts
+++ b/src/catscompany/attachment-cache.ts
@@ -1,0 +1,241 @@
+import * as fs from 'fs';
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+import { randomUUID } from 'crypto';
+import { PathResolver } from '../utils/path-resolver';
+import { Logger } from '../utils/logger';
+
+export const CATSCOMPANY_ATTACHMENT_CACHE_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+export const CATSCOMPANY_ATTACHMENT_CACHE_HIGH_WATER_BYTES = 5 * 1024 * 1024 * 1024;
+export const CATSCOMPANY_ATTACHMENT_CACHE_LOW_WATER_BYTES = 4 * 1024 * 1024 * 1024;
+
+export interface AttachmentCacheCleanupSummary {
+  scanned: number;
+  removed: number;
+  bytesBefore: number;
+  bytesAfter: number;
+}
+
+interface CacheFileInfo {
+  filePath: string;
+  size: number;
+  recencyMs: number;
+  mtimeMs: number;
+}
+
+let cleanupRunning = false;
+
+export function getCatsCoAttachmentCacheRoot(): string {
+  return PathResolver.getAttachmentsPath('catscompany');
+}
+
+export function buildCatsCoAttachmentCachePath(
+  sessionKey: string | undefined,
+  fileName: string,
+  now = new Date(),
+): string {
+  const sessionSegment = sanitizePathSegment(sessionKey || 'unknown-session');
+  const dir = path.join(getCatsCoAttachmentCacheRoot(), sessionSegment);
+
+  const safeName = sanitizeFileName(fileName || 'attachment');
+  const stamp = formatTimestamp(now);
+  const nonce = randomUUID().slice(0, 8);
+  return path.join(dir, `${stamp}_${nonce}_${safeName}`);
+}
+
+export function isInsideCatsCoAttachmentCacheRoot(filePath: string): boolean {
+  return isPathInsideRoot(filePath, getCatsCoAttachmentCacheRoot());
+}
+
+export function scheduleCatsCoAttachmentCacheCleanup(): void {
+  if (cleanupRunning) return;
+  cleanupRunning = true;
+  setTimeout(() => {
+    cleanupCatsCoAttachmentCache()
+      .catch((err: any) => {
+        Logger.warning(`[CatsCo] attachment cache cleanup failed: ${err?.message || err}`);
+      })
+      .finally(() => {
+        cleanupRunning = false;
+      });
+  }, 0);
+}
+
+export async function cleanupCatsCoAttachmentCache(
+  root = getCatsCoAttachmentCacheRoot(),
+  options: {
+    now?: number;
+    maxAgeMs?: number;
+    highWaterBytes?: number;
+    lowWaterBytes?: number;
+  } = {},
+): Promise<AttachmentCacheCleanupSummary> {
+  const now = options.now ?? Date.now();
+  const maxAgeMs = options.maxAgeMs ?? CATSCOMPANY_ATTACHMENT_CACHE_MAX_AGE_MS;
+  const highWaterBytes = options.highWaterBytes ?? CATSCOMPANY_ATTACHMENT_CACHE_HIGH_WATER_BYTES;
+  const lowWaterBytes = options.lowWaterBytes ?? CATSCOMPANY_ATTACHMENT_CACHE_LOW_WATER_BYTES;
+
+  if (!fs.existsSync(root)) {
+    return { scanned: 0, removed: 0, bytesBefore: 0, bytesAfter: 0 };
+  }
+
+  let files = await listCacheFiles(root);
+  const bytesBefore = files.reduce((sum, file) => sum + file.size, 0);
+  let removed = 0;
+
+  for (const file of files) {
+    if (now - file.recencyMs <= maxAgeMs) continue;
+    if (await removeFileIfExists(file.filePath)) {
+      removed += 1;
+    }
+  }
+
+  files = await listCacheFiles(root);
+  let total = files.reduce((sum, file) => sum + file.size, 0);
+  if (total > highWaterBytes) {
+    const byOldestFirst = [...files].sort((a, b) => {
+      if (a.recencyMs !== b.recencyMs) return a.recencyMs - b.recencyMs;
+      return a.mtimeMs - b.mtimeMs;
+    });
+
+    for (const file of byOldestFirst) {
+      if (total <= lowWaterBytes) break;
+      if (await removeFileIfExists(file.filePath)) {
+        removed += 1;
+        total -= file.size;
+      }
+    }
+  }
+
+  await removeEmptyDirectories(root);
+  const remaining = await listCacheFiles(root);
+  const bytesAfter = remaining.reduce((sum, file) => sum + file.size, 0);
+
+  if (removed > 0) {
+    Logger.info(`[CatsCo] attachment cache cleanup removed=${removed} before=${bytesBefore} after=${bytesAfter}`);
+  }
+
+  return {
+    scanned: files.length,
+    removed,
+    bytesBefore,
+    bytesAfter,
+  };
+}
+
+async function listCacheFiles(root: string): Promise<CacheFileInfo[]> {
+  const results: CacheFileInfo[] = [];
+  await visit(root, results);
+  return results;
+}
+
+async function visit(dir: string, results: CacheFileInfo[]): Promise<void> {
+  let entries: fs.Dirent[];
+  try {
+    entries = await fsp.readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await visit(fullPath, results);
+      continue;
+    }
+    if (!entry.isFile()) continue;
+    if (entry.name.endsWith('.part')) continue;
+
+    try {
+      const stats = await fsp.stat(fullPath);
+      results.push({
+        filePath: fullPath,
+        size: stats.size,
+        recencyMs: Math.max(stats.atimeMs || 0, stats.mtimeMs || 0),
+        mtimeMs: stats.mtimeMs,
+      });
+    } catch {
+      // File disappeared during cleanup; ignore it.
+    }
+  }
+}
+
+async function removeFileIfExists(filePath: string): Promise<boolean> {
+  try {
+    await fsp.unlink(filePath);
+    return true;
+  } catch (err: any) {
+    if (err?.code === 'ENOENT') return false;
+    Logger.warning(`[CatsCo] attachment cache file delete failed: ${filePath}: ${err?.message || err}`);
+    return false;
+  }
+}
+
+async function removeEmptyDirectories(root: string): Promise<boolean> {
+  let entries: fs.Dirent[];
+  try {
+    entries = await fsp.readdir(root, { withFileTypes: true });
+  } catch {
+    return true;
+  }
+
+  let empty = true;
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      empty = false;
+      continue;
+    }
+    const child = path.join(root, entry.name);
+    const childEmpty = await removeEmptyDirectories(child);
+    if (childEmpty) {
+      try {
+        await fsp.rmdir(child);
+      } catch {
+        empty = false;
+      }
+    } else {
+      empty = false;
+    }
+  }
+
+  return empty;
+}
+
+function sanitizePathSegment(value: string): string {
+  const text = value.replace(/[^a-zA-Z0-9._-]+/g, '_').replace(/^_+|_+$/g, '');
+  return text.slice(0, 120) || 'unknown';
+}
+
+function sanitizeFileName(fileName: string): string {
+  const base = path.basename(fileName).replace(/[<>:"/\\|?*\x00-\x1F]+/g, '_').trim();
+  const normalized = base.replace(/\s+/g, ' ');
+  return normalized.slice(0, 160) || 'attachment';
+}
+
+function formatTimestamp(date: Date): string {
+  const pad = (value: number, width = 2) => String(value).padStart(width, '0');
+  return [
+    date.getFullYear(),
+    pad(date.getMonth() + 1),
+    pad(date.getDate()),
+    '_',
+    pad(date.getHours()),
+    pad(date.getMinutes()),
+    pad(date.getSeconds()),
+    '_',
+    pad(date.getMilliseconds(), 3),
+  ].join('');
+}
+
+function isPathInsideRoot(filePath: string, root: string): boolean {
+  const target = normalizeForCompare(filePath);
+  const base = normalizeForCompare(root);
+  if (target === base) return true;
+  const baseWithSep = base.endsWith(path.sep) ? base : `${base}${path.sep}`;
+  return target.startsWith(baseWithSep);
+}
+
+function normalizeForCompare(filePath: string): string {
+  const resolved = path.resolve(filePath);
+  return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
+}

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -41,6 +41,10 @@ import {
 } from '../tools/tool-target-context';
 import { formatPathForLog } from '../utils/log-redaction';
 import { resolveCatsDeviceModelStatus } from './model-status';
+import {
+  buildCatsCoAttachmentCachePath,
+  scheduleCatsCoAttachmentCacheCleanup,
+} from './attachment-cache';
 
 interface PendingAttachment {
   fileName: string;
@@ -296,6 +300,7 @@ export class CatsCompanyBot {
    */
   async start(): Promise<void> {
     Logger.openLogFile('catscompany');
+    scheduleCatsCoAttachmentCacheCleanup();
     Logger.info('正在启动 CatsCompany connector...');
 
     // 加载 skills
@@ -1096,7 +1101,8 @@ export class CatsCompanyBot {
     if (messageFiles.length > 0) {
       const attachments: PendingAttachment[] = [];
       for (const file of messageFiles) {
-        const localPath = await this.sender.downloadFile(file.url, file.fileName);
+        const targetPath = buildCatsCoAttachmentCachePath(key, file.fileName);
+        const localPath = await this.sender.downloadFile(file.url, file.fileName, { targetPath });
         if (!localPath) {
           runtimeFeedback.push({
             source: 'catscompany.file_download',
@@ -1117,6 +1123,7 @@ export class CatsCompanyBot {
             workspaceRoot: process.cwd(),
           }),
         });
+        scheduleCatsCoAttachmentCacheCleanup();
       }
 
       if (attachments.length > 0) {
@@ -1789,7 +1796,7 @@ export class CatsCompanyBot {
         if (imgBlock) {
           blocks.push({
             ...imgBlock,
-            filePath: att.localFileGrant?.attachmentRef || `[CatsCo attachment: ${att.fileName}]`,
+            filePath: att.localPath || `[CatsCo attachment: ${att.fileName}]`,
           } as any);
           Logger.info(`[CatsCo] vision_direct model=${modelName} file=${logFile} bytes_base64=${((imgBlock as any).source as any)?.data?.length || 0}`);
         } else {
@@ -1808,8 +1815,8 @@ export class CatsCompanyBot {
           text: [
             '[Current user turn contains image attachments]',
             'The primary model cannot directly inspect image pixels in this runtime.',
-            'If the user request depends on image content, call read_file with file_path set to the current authorized attachment reference below.',
-            'Use only the current authorized attachment reference(s) listed here. Do not use old tmp/downloads paths, old image URLs, old filenames, or prior image descriptions.',
+            'If the user request depends on image content, call read_file with file_path set to the local cache path below.',
+            'Use the local cache path shown here. Do not use old tmp/downloads paths, old image URLs, old filenames, or prior image descriptions.',
             currentImageRefs.join('\n\n'),
           ].join('\n'),
         });
@@ -1821,18 +1828,10 @@ export class CatsCompanyBot {
 
   private formatAttachmentReferenceForModel(attachment: PendingAttachment): string {
     const label = attachment.type === 'image' ? '图片' : '文件';
-    const attachmentRef = attachment.localFileGrant?.attachmentRef;
-    if (!attachmentRef) {
-      return [
-        `[${label}] ${attachment.fileName}`,
-        '[附件授权状态] 当前消息没有生成可读取的本地附件引用。',
-      ].join('\n');
-    }
-
     return [
       `[${label}] ${attachment.fileName}`,
-      `[授权附件引用] ${attachmentRef}`,
-      '[使用方式] 如需读取或转发该附件，将 read_file/send_file 的 file_path 设置为这个引用。',
+      `本地缓存路径: ${attachment.localPath}`,
+      '读取方式: 如需查看该附件，调用 read_file，file_path 使用上面的本地缓存路径。',
     ].join('\n');
   }
 

--- a/src/catscompany/local-file-grants.ts
+++ b/src/catscompany/local-file-grants.ts
@@ -7,6 +7,7 @@ import type {
   ScopedLocalDeviceGrant,
   ScopedLocalFileGrant,
 } from '../types/session-identity';
+import { isInsideCatsCoAttachmentCacheRoot } from './attachment-cache';
 
 export const CATSCOMPANY_ATTACHMENT_GRANT_TTL_MS = 30 * 60 * 1000;
 export const CATSCOMPANY_ATTACHMENT_REF_PREFIX = 'catsco_attachment:';
@@ -54,7 +55,7 @@ export function createCatsCoAttachmentGrant(
   if (scope.agentBodyId !== localDeviceGrant.bodyId) return undefined;
 
   const filePath = normalizeLocalPath(input.localPath);
-  if (!isInsideDownloadsRoot(filePath, input.workspaceRoot)) return undefined;
+  if (!isInsideManagedAttachmentRoot(filePath, input.workspaceRoot)) return undefined;
 
   let stats: fs.Stats;
   try {
@@ -98,7 +99,9 @@ export function normalizeLocalPath(filePath: string): string {
   }
 }
 
-function isInsideDownloadsRoot(filePath: string, workspaceRoot = process.cwd()): boolean {
+function isInsideManagedAttachmentRoot(filePath: string, workspaceRoot = process.cwd()): boolean {
+  if (isInsideCatsCoAttachmentCacheRoot(filePath)) return true;
+
   const downloadsRoot = normalizeLocalPath(path.join(workspaceRoot, 'tmp', 'downloads'));
   const target = normalizeForCompare(filePath);
   const root = normalizeForCompare(downloadsRoot);

--- a/src/catscompany/message-sender.ts
+++ b/src/catscompany/message-sender.ts
@@ -487,13 +487,16 @@ export class MessageSender {
     }
   }
 
-  async downloadFile(url: string, fileName: string): Promise<string | null> {
+  async downloadFile(url: string, fileName: string, options: { targetPath?: string } = {}): Promise<string | null> {
+    let partPath: string | undefined;
     try {
-      const tmpDir = path.join(process.cwd(), 'tmp', 'downloads');
-      fs.mkdirSync(tmpDir, { recursive: true });
 
       const fullUrl = url.startsWith('http') ? url : `${this.baseUrl}${url}`;
-      const localPath = path.join(tmpDir, `${Date.now()}_${fileName}`);
+      const localPath = options.targetPath
+        ? path.resolve(options.targetPath)
+        : path.join(process.cwd(), 'tmp', 'downloads', `${Date.now()}_${path.basename(fileName)}`);
+      fs.mkdirSync(path.dirname(localPath), { recursive: true });
+      partPath = `${localPath}.part-${process.pid}-${Date.now()}`;
       const res = await fetch(fullUrl);
       if (!res.ok) {
         Logger.error(`文件下载失败: HTTP ${res.status} - ${url}`);
@@ -501,10 +504,19 @@ export class MessageSender {
       }
 
       const buffer = Buffer.from(await res.arrayBuffer());
-      fs.writeFileSync(localPath, buffer);
+      fs.writeFileSync(partPath, buffer);
+      fs.renameSync(partPath, localPath);
+      partPath = undefined;
       Logger.info(`文件已下载: ${fileName} -> ${localPath} (${buffer.length} bytes)`);
       return localPath;
     } catch (err: any) {
+      if (partPath) {
+        try {
+          fs.unlinkSync(partPath);
+        } catch {
+          // ignore partial cleanup failure
+        }
+      }
       Logger.error(`文件下载失败: ${err.message}`);
       return null;
     }

--- a/src/core/branch-session.ts
+++ b/src/core/branch-session.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { Message } from '../types';
 import { AIService } from '../utils/ai-service';
 import { Logger } from '../utils/logger';
+import { PathResolver } from '../utils/path-resolver';
 import { Tool } from '../types/tool';
 import { AgentToolExecutor } from '../agents/agent-tool-executor';
 import { ConversationRunner, RunResult, RunnerCallbacks } from './conversation-runner';
@@ -147,7 +148,7 @@ export class BranchSessionLogger {
     }
     const date = new Date();
     const dateStr = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
-    const dir = path.resolve(options.workingDirectory, 'logs', 'branches', options.branchType, dateStr);
+    const dir = PathResolver.getLogsPath('branches', options.branchType, dateStr);
     fs.mkdirSync(dir, { recursive: true });
     this.filePath = path.join(dir, `${sanitizeFilePart(options.branchId)}.jsonl`);
   }

--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -54,6 +54,7 @@ import { MODEL_IMAGE_SAFETY_MESSAGE, isModelImageSafetyError } from '../utils/mo
 import { formatProviderErrorForLog } from '../utils/provider-error-log-sanitizer';
 import { renderRequiredDefaultPromptFile } from '../utils/prompt-template';
 import { PromptTraceLogger } from '../utils/prompt-trace-logger';
+import { PathResolver } from '../utils/path-resolver';
 import {
   restoreProviderReplayToolCalls,
   stripAssistantArtifactsFromMessages,
@@ -1435,7 +1436,7 @@ export class ConversationRunner {
     try {
       const date = new Date();
       const dateStr = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
-      const dir = path.resolve('logs', 'provider-messages', dateStr);
+      const dir = PathResolver.getLogsPath('provider-messages', dateStr);
       fs.mkdirSync(dir, { recursive: true });
       const safeSession = (this.toolExecutionContext?.sessionId || 'unknown').replace(/[:<>"|?*]/g, '_');
       const filePath = path.join(dir, `${safeSession}.jsonl`);

--- a/src/core/memory-log-store.ts
+++ b/src/core/memory-log-store.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import type { SessionToolCallLog, SessionTurnLogEntry } from '../utils/session-log-schema';
 import { stripAssistantTranscriptArtifacts } from '../utils/transcript-artifacts';
+import { PathResolver } from '../utils/path-resolver';
 
 export interface MemorySearchMatch {
   ref: string;
@@ -272,8 +273,8 @@ function normalizeKeywords(value: unknown): string[] {
 
 function resolveLogRoots(workingDirectory: string): string[] {
   const roots = [
+    PathResolver.getLogsPath('sessions'),
     path.resolve(workingDirectory, 'logs', 'sessions'),
-    path.resolve(process.cwd(), 'logs', 'sessions'),
   ];
   return Array.from(new Set(roots)).filter(root => {
     try {

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -3072,7 +3072,7 @@ export function createApiRouter(serviceManager: ServiceManager, updateController
       }
 
       const uploader = new LogUploader(serverUrl, apiKey);
-      await uploader.uploadLogs(path.resolve('logs/sessions'), date);
+      await uploader.uploadLogs(PathResolver.getLogsPath('sessions'), date);
       res.json({ ok: true });
     } catch (e: any) {
       res.status(500).json({ error: e.message });

--- a/src/pet/prompt-companion.ts
+++ b/src/pet/prompt-companion.ts
@@ -15,6 +15,7 @@ import {
   ParsedSessionLogEntry,
   SessionPromptTraceLogEntry,
 } from '../utils/session-log-schema';
+import { PathResolver } from '../utils/path-resolver';
 import { getPetService } from './pet-service';
 import { resolvePetDataDir } from './pet-store';
 import { PetEvent } from './pet-types';
@@ -837,7 +838,7 @@ function looksLikeShellPortabilityError(text: string): boolean {
 function resolveSessionLogsDir(env: NodeJS.ProcessEnv = process.env): string {
   const userData = String(env.XIAOBA_ELECTRON_USER_DATA_DIR || env.XIAOBA_USER_DATA_DIR || env.CATSCO_USER_DATA_DIR || '').trim();
   if (userData) return path.join(path.resolve(userData), 'logs', 'sessions');
-  return path.resolve(process.cwd(), 'logs', 'sessions');
+  return PathResolver.getLogsPath('sessions');
 }
 
 function listRecentSessionLogFiles(root: string, limit: number): string[] {

--- a/src/runtime/runtime-config-snapshot.ts
+++ b/src/runtime/runtime-config-snapshot.ts
@@ -99,7 +99,7 @@ export async function createRuntimeConfigSnapshot(
   options: CreateRuntimeConfigSnapshotOptions = {},
 ): Promise<RuntimeConfigSnapshot> {
   const env = options.env ?? process.env;
-  const runtimeRoot = path.resolve(options.runtimeRoot ?? process.cwd());
+  const runtimeRoot = path.resolve(options.runtimeRoot ?? PathResolver.getRuntimeDataRoot());
   const resolved = options.profile
     ? {
       profile: options.profile,

--- a/src/skillhub/config.ts
+++ b/src/skillhub/config.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as dotenv from 'dotenv';
+import { PathResolver } from '../utils/path-resolver';
 
 export const DEFAULT_SKILLHUB_BASE_URL = 'https://logs.catsco.fun:9000';
 
@@ -22,7 +23,7 @@ export function loadSkillHubConfig(overrides: { baseUrl?: unknown } = {}): Skill
     ),
     DEFAULT_SKILLHUB_BASE_URL,
   );
-  const dataDir = path.join(process.cwd(), 'data', 'skillhub');
+  const dataDir = PathResolver.getDataPath('skillhub');
   return {
     baseUrl,
     dataDir,
@@ -45,7 +46,7 @@ export function normalizeBaseUrl(value: unknown, fallback = DEFAULT_SKILLHUB_BAS
 }
 
 function readEnvFile(): Record<string, string> {
-  const envPath = path.join(process.cwd(), '.env');
+  const envPath = path.join(PathResolver.getRuntimeDataRoot(), '.env');
   if (!fs.existsSync(envPath)) return {};
   return dotenv.parse(fs.readFileSync(envPath, 'utf-8'));
 }

--- a/src/tools/read-tool.ts
+++ b/src/tools/read-tool.ts
@@ -120,17 +120,18 @@ export class ReadTool implements Tool {
   definition: ToolDefinition = {
     name: 'read_file',
     description: [
-      '读取一个本地文件或当前用户轮次授权的 CatsCo 附件。',
+      '读取一个本地文件。CatsCo 附件请优先使用消息中显示的本地缓存路径。',
       '支持文本/代码、PDF、图片和 Jupyter notebook。文本默认只读前若干行，可用 offset/limit 分页。',
-      'PDF 会先提取文本层；如果文本层为空、解析失败，或用户明显关心图片/签章/手写/版式等视觉内容，会自动把少量页面转成图片并走读图链路。',
-      '图片会按当前模型能力处理：视觉模型收到图片块，非视觉模型收到 reader proxy 的文字解析结果。',
+        'PDF 会先提取文本层；如果文本层为空、解析失败，或用户明显关心图片/签章/手写/版式等视觉内容，会自动把少量页面转成图片并走读图链路。',
+        'catsco_attachment:<id> 仅用于兼容当前轮旧附件引用；后续追问应使用历史消息里的本地缓存路径。',
+        '图片会按当前模型能力处理：视觉模型收到图片块，非视觉模型收到 reader proxy 的文字解析结果。',
     ].join('\n'),
     parameters: {
       type: 'object',
       properties: {
         file_path: {
           type: 'string',
-          description: '要读取的文件路径或授权附件引用。支持绝对路径、相对当前目录路径、catsco_attachment:<id>。',
+          description: '要读取的文件路径。支持绝对路径、相对当前目录路径；CatsCo 附件优先使用消息中的本地缓存路径，catsco_attachment:<id> 仅作旧引用兼容。',
         },
         offset: {
           type: 'number',

--- a/src/tools/send-file-tool.ts
+++ b/src/tools/send-file-tool.ts
@@ -11,7 +11,8 @@ export class SendFileTool implements Tool {
     name: 'send_file',
     description: [
       '向当前聊天会话发送一个已存在的本地文件。',
-      'file_path 接受绝对路径、相对当前目录的路径，或当前 CatsCo 用户轮次授权的 catsco_attachment:<id> 引用。',
+      'file_path 接受绝对路径或相对当前目录的路径。CatsCo 附件请优先使用消息中显示的本地缓存路径。',
+      'catsco_attachment:<id> 仅用于兼容当前轮旧附件引用；后续转发应使用历史消息里的本地缓存路径。',
       '只发送文件本身；如果只是回复文字，请用普通 assistant 回复或 send_text。',
     ].join('\n'),
     transcriptMode: 'outbound_file',
@@ -20,7 +21,7 @@ export class SendFileTool implements Tool {
       properties: {
         file_path: {
           type: 'string',
-          description: '要发送的本地文件路径或授权附件引用。支持绝对路径、相对当前目录路径、catsco_attachment:<id>。',
+          description: '要发送的本地文件路径。支持绝对路径、相对当前目录路径；CatsCo 附件优先使用消息中的本地缓存路径，catsco_attachment:<id> 仅作旧引用兼容。',
         },
         file_name: {
           type: 'string',

--- a/src/tools/tool-gateway.ts
+++ b/src/tools/tool-gateway.ts
@@ -91,7 +91,7 @@ export function formatCatsCoVisiblePath(
   if (/^catsco_attachment:[A-Za-z0-9._:-]+$/.test(text)) return text;
   if (/^\[CatsCo [^\]]+\]$/.test(text)) return text;
   if (options.preserveRelative && !looksLikeAbsoluteLocalPath(text)) return text;
-  return fallback;
+  return text;
 }
 
 export function redactCatsCoVisiblePath(

--- a/src/utils/context-debug-logger.ts
+++ b/src/utils/context-debug-logger.ts
@@ -4,8 +4,9 @@ import { Message } from '../types';
 import { ToolDefinition } from '../types/tool';
 import { estimateMessageTokens, estimateToolsTokens } from '../core/token-estimator';
 import { TRANSIENT_RUNTIME_CONTEXT_PREFIX } from '../core/runtime-context-builder';
+import { PathResolver } from './path-resolver';
 
-const DEBUG_DIR = path.resolve('logs/context-debug');
+const DEBUG_DIR = PathResolver.getLogsPath('context-debug');
 
 export interface ContextDebugEntry {
   request_id: string;

--- a/src/utils/daily-report-generator.ts
+++ b/src/utils/daily-report-generator.ts
@@ -10,9 +10,10 @@ import type {
   LegacySessionTurnLogEntry,
   SessionTurnLogEntry,
 } from './session-log-schema';
+import { PathResolver } from './path-resolver';
 
-const SESSION_LOG_DIR = path.resolve('logs/sessions');
-const REPORT_DIR = path.resolve('logs/reports');
+const SESSION_LOG_DIR = PathResolver.getLogsPath('sessions');
+const REPORT_DIR = PathResolver.getLogsPath('reports');
 
 type TurnLog = SessionTurnLogEntry | LegacySessionTurnLogEntry;
 

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -5,6 +5,7 @@ import { styles } from '../theme/colors';
 import ora, { Ora } from 'ora';
 import type { SessionTurnLogger } from './session-turn-logger';
 import type { SessionRuntimeLogEvent } from './session-log-schema';
+import { PathResolver } from './path-resolver';
 
 interface LoggerContextStore {
   sessionId?: string;
@@ -73,7 +74,7 @@ export class Logger {
     const ss = String(now.getSeconds()).padStart(2, '0');
     const suffix = sessionKey ? `${sessionType}_${sessionKey}` : sessionType;
     const fileName = `${hh}-${mm}-${ss}_${suffix}.log`;
-    const dir = path.resolve('logs', dateDir);
+    const dir = PathResolver.getLogsPath(dateDir);
 
     fs.mkdirSync(dir, { recursive: true });
     this.logFilePath = path.join(dir, fileName);

--- a/src/utils/path-resolver.ts
+++ b/src/utils/path-resolver.ts
@@ -1,8 +1,36 @@
 import * as path from 'path';
 import * as fs from 'fs';
-import * as os from 'os';
 
 export class PathResolver {
+  static getRuntimeDataRoot(): string {
+    const explicit = [
+      process.env.XIAOBA_USER_DATA_DIR,
+      process.env.CATSCO_USER_DATA_DIR,
+      process.env.XIAOBA_ELECTRON_USER_DATA_DIR,
+      process.env.XIAOBA_RUNTIME_ROOT,
+    ]
+      .map(value => String(value || '').trim())
+      .find(Boolean);
+
+    return path.resolve(explicit || process.cwd());
+  }
+
+  static getDataPath(...segments: string[]): string {
+    return path.join(this.getRuntimeDataRoot(), 'data', ...segments);
+  }
+
+  static getLogsPath(...segments: string[]): string {
+    return path.join(this.getRuntimeDataRoot(), 'logs', ...segments);
+  }
+
+  static getAttachmentsPath(...segments: string[]): string {
+    return this.getDataPath('attachments', ...segments);
+  }
+
+  static getPromptOverridesPath(): string {
+    return path.join(this.getRuntimeDataRoot(), 'prompt-overrides');
+  }
+
   static getSkillsPath(): string {
     const override = process.env.XIAOBA_SKILLS_DIR?.trim();
     if (override) return path.resolve(override);
@@ -10,13 +38,7 @@ export class PathResolver {
   }
 
   static getUserDataSkillsPath(): string {
-    if (process.platform === 'win32') {
-      return path.join(process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming'), 'xiaoba-cli', 'skills');
-    }
-    if (process.platform === 'darwin') {
-      return path.join(os.homedir(), 'Library', 'Application Support', 'xiaoba-cli', 'skills');
-    }
-    return path.join(process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config'), 'xiaoba-cli', 'skills');
+    return path.join(this.getRuntimeDataRoot(), 'skills');
   }
 
   static ensureDir(dirPath: string): void {

--- a/src/utils/prompt-template.ts
+++ b/src/utils/prompt-template.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import { PathResolver } from './path-resolver';
 
 export const DEFAULT_PROMPTS_DIR = path.join(__dirname, '../../prompts');
 
@@ -17,7 +18,7 @@ export function getPromptOverridesDir(env: NodeJS.ProcessEnv = process.env): str
   const userDataDir = (env.XIAOBA_USER_DATA_DIR || env.CATSCO_USER_DATA_DIR || '').trim();
   if (userDataDir) return path.resolve(userDataDir, 'prompt-overrides');
   const runtimeRoot = (env.XIAOBA_RUNTIME_ROOT || '').trim();
-  return runtimeRoot ? path.resolve(runtimeRoot, 'prompt-overrides') : undefined;
+  return runtimeRoot ? path.resolve(runtimeRoot, 'prompt-overrides') : PathResolver.getPromptOverridesPath();
 }
 
 export function isSafePromptOverridesDir(promptsDir: string, overridesDir: string): boolean {

--- a/src/utils/prompt-trace-logger.ts
+++ b/src/utils/prompt-trace-logger.ts
@@ -3,8 +3,9 @@ import * as path from 'path';
 import { ChatConfig, ChatResponse, ContentBlock, Message } from '../types';
 import { ToolCall, ToolDefinition, ToolResult, ToolSurface } from '../types/tool';
 import { Logger } from './logger';
+import { PathResolver } from './path-resolver';
 
-const DEFAULT_TRACE_DIR = path.resolve('logs', 'prompt-trace');
+const DEFAULT_TRACE_DIR = PathResolver.getLogsPath('prompt-trace');
 const SECRET_PATTERNS: RegExp[] = [
   /sk-[A-Za-z0-9_-]{8,}/g,
   /cats_svc_[A-Za-z0-9_-]+/g,

--- a/src/utils/session-store.ts
+++ b/src/utils/session-store.ts
@@ -6,9 +6,10 @@ import {
   contentToText,
   stripAssistantTranscriptArtifacts,
 } from './transcript-artifacts';
+import { PathResolver } from './path-resolver';
 
-const SESSIONS_DIR = path.resolve(process.cwd(), 'data', 'sessions');
-const SESSION_STATE_DIR = path.resolve(process.cwd(), 'data', 'session-state');
+const SESSIONS_DIR = PathResolver.getDataPath('sessions');
+const SESSION_STATE_DIR = PathResolver.getDataPath('session-state');
 
 function ensureDir(): void {
   if (!fs.existsSync(SESSIONS_DIR)) fs.mkdirSync(SESSIONS_DIR, { recursive: true });

--- a/src/utils/session-turn-logger.ts
+++ b/src/utils/session-turn-logger.ts
@@ -14,6 +14,7 @@ import type {
 import type { SubAgentRuntimeEvent } from '../core/sub-agent-events';
 import type { SubAgentInfo } from '../core/sub-agent-session';
 import type { PromptTraceSnapshot } from './prompt-observability';
+import { PathResolver } from './path-resolver';
 
 export type {
   LegacySessionTurnLogEntry,
@@ -27,7 +28,7 @@ export type {
   SessionTurnLogEntry,
 } from './session-log-schema';
 
-const SESSION_LOG_DIR = path.resolve('logs/sessions');
+const SESSION_LOG_DIR = PathResolver.getLogsPath('sessions');
 const MAX_TOOL_RESULT_LENGTH = parseOptionalLimit(process.env.XIAOBA_SESSION_TOOL_RESULT_LIMIT);
 const MAX_RUNTIME_FEEDBACK_LENGTH = Number(process.env.XIAOBA_SESSION_RUNTIME_FEEDBACK_LIMIT || 4000);
 

--- a/tests/catscompany-attachment-cache.test.ts
+++ b/tests/catscompany-attachment-cache.test.ts
@@ -1,0 +1,72 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  buildCatsCoAttachmentCachePath,
+  cleanupCatsCoAttachmentCache,
+  getCatsCoAttachmentCacheRoot,
+} from '../src/catscompany/attachment-cache';
+
+async function withRuntimeRoot<T>(run: (root: string) => T | Promise<T>): Promise<T> {
+  const previous = process.env.XIAOBA_USER_DATA_DIR;
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'catsco-attachment-cache-'));
+  process.env.XIAOBA_USER_DATA_DIR = root;
+  try {
+    return await run(root);
+  } finally {
+    if (previous === undefined) delete process.env.XIAOBA_USER_DATA_DIR;
+    else process.env.XIAOBA_USER_DATA_DIR = previous;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function writeFile(filePath: string, content: string, timeMs: number): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+  const time = new Date(timeMs);
+  fs.utimesSync(filePath, time, time);
+}
+
+describe('CatsCo attachment cache', () => {
+  test('builds stable cache paths under the runtime data root', () => {
+    return withRuntimeRoot((root) => {
+      const filePath = buildCatsCoAttachmentCachePath('cc_group:grp/123', '../image.png', new Date(2026, 6, 3, 1, 2, 3, 4));
+
+      assert.equal(path.dirname(path.dirname(filePath)), getCatsCoAttachmentCacheRoot());
+      assert.ok(filePath.startsWith(path.join(root, 'data', 'attachments', 'catscompany')));
+      assert.match(path.basename(filePath), /^20260703_010203_004_[a-f0-9-]{8}_image\.png$/);
+      assert.equal(fs.existsSync(path.dirname(filePath)), false);
+    });
+  });
+
+  test('removes old files and trims cache below the low-water mark', async () => {
+    await withRuntimeRoot(async () => {
+      const root = getCatsCoAttachmentCacheRoot();
+      const oldFile = path.join(root, 'session', 'old.txt');
+      const a = path.join(root, 'session', 'a.txt');
+      const b = path.join(root, 'session', 'b.txt');
+      const c = path.join(root, 'session', 'c.txt');
+
+      writeFile(oldFile, 'old', 1_000);
+      writeFile(a, 'aaa', 10_000);
+      writeFile(b, 'bbb', 20_000);
+      writeFile(c, 'ccc', 30_000);
+
+      const summary = await cleanupCatsCoAttachmentCache(root, {
+        now: 50_000,
+        maxAgeMs: 40_000,
+        highWaterBytes: 8,
+        lowWaterBytes: 4,
+      });
+
+      assert.equal(fs.existsSync(oldFile), false);
+      assert.equal(fs.existsSync(a), false);
+      assert.equal(fs.existsSync(b), false);
+      assert.equal(fs.existsSync(c), true);
+      assert.equal(summary.removed, 3);
+      assert.equal(summary.bytesAfter, 3);
+    });
+  });
+});

--- a/tests/catscompany-content-blocks.test.ts
+++ b/tests/catscompany-content-blocks.test.ts
@@ -218,7 +218,7 @@ describe('CatsCo content blocks', () => {
     assert.strictEqual(parsed.files[0].fileName, 'crack.png');
   });
 
-  test('builds CatsCo attachment context with opaque references instead of local paths', async () => {
+  test('builds CatsCo attachment context with stable local cache paths', async () => {
     const bot = Object.create(CatsCompanyBot.prototype);
     const localPath = 'C:\\tmp\\catsco-secret\\tmp\\downloads\\report.pdf';
     const attachment = {
@@ -235,10 +235,9 @@ describe('CatsCo content blocks', () => {
     const prompt = (bot as any).buildAttachmentOnlyPrompt([attachment]);
     const modelVisible = JSON.stringify(blocks) + '\n' + prompt;
 
-    assert.match(modelVisible, /catsco_attachment:visible-ref/);
-    assert.match(modelVisible, /授权附件引用/);
-    assert.doesNotMatch(modelVisible, /catsco-secret/);
-    assert.doesNotMatch(modelVisible, new RegExp(escapeRegExp(localPath)));
+    assert.doesNotMatch(modelVisible, /catsco_attachment:visible-ref/);
+    assert.match(modelVisible, /本地缓存路径:/);
+    assert.match(modelVisible, new RegExp(escapeRegExp(localPath)));
   });
 
   test('processes multiple attachments as one user turn', async () => {
@@ -341,8 +340,8 @@ describe('CatsCo content blocks', () => {
     assert.strictEqual(blocks[1].type, 'text');
     assert.match((blocks[1] as any).text, /Current user turn contains image attachments/);
     assert.match((blocks[1] as any).text, /call read_file/);
-    assert.match((blocks[1] as any).text, /catsco_attachment:image-ref/);
-    assert.doesNotMatch((blocks[1] as any).text, /C:\\tmp\\red-blue\.png/);
+    assert.match((blocks[1] as any).text, /C:\\tmp\\red-blue\.png/);
+    assert.doesNotMatch((blocks[1] as any).text, /catsco_attachment:image-ref/);
   });
 
   test('processes CatsCompany websocket content_blocks as one user turn', async () => {
@@ -489,7 +488,7 @@ describe('CatsCo content blocks', () => {
     }
   });
 
-  test('builds attachment messages with opaque references instead of local paths', async () => {
+  test('builds attachment messages with stable local cache paths', async () => {
     const bot = Object.create(CatsCompanyBot.prototype) as any;
     const localPath = 'C:\\tmp\\catsco-test\\secret-report.pdf';
 
@@ -509,13 +508,12 @@ describe('CatsCo content blocks', () => {
       .join('\n');
 
     assert.match(text, /请读取这个文件/);
-    assert.match(text, /catsco_attachment:opaque-ref/);
-    assert.doesNotMatch(text, /secret-report\.pdf -> C:/);
-    assert.doesNotMatch(text, /C:\\tmp\\catsco-test/);
-    assert.doesNotMatch(text, /授权附件路径/);
+    assert.match(text, /本地缓存路径:/);
+    assert.match(text, new RegExp(escapeRegExp(localPath)));
+    assert.doesNotMatch(text, /catsco_attachment:opaque-ref/);
   });
 
-  test('sanitizes CatsCo image block metadata to use opaque references', async () => {
+  test('keeps CatsCo image block metadata on the stable local cache path', async () => {
     const bot = Object.create(CatsCompanyBot.prototype) as any;
     const originalModel = process.env.GAUZ_LLM_MODEL;
     const originalApiBase = process.env.GAUZ_LLM_API_BASE;
@@ -543,9 +541,9 @@ describe('CatsCo content blocks', () => {
 
       const imageBlock = blocks.find((block: any) => block.type === 'image') as any;
       assert.ok(imageBlock);
-      assert.strictEqual(imageBlock.filePath, 'catsco_attachment:image-ref');
-      assert.doesNotMatch(JSON.stringify(blocks), new RegExp(escapeRegExp(localPath)));
-      assert.doesNotMatch(JSON.stringify(blocks), new RegExp(escapeRegExp(testRoot)));
+      assert.strictEqual(imageBlock.filePath, localPath);
+      assert.ok(blocks.some((block: any) => block.type === 'text' && String(block.text).includes(localPath)));
+      assert.doesNotMatch(JSON.stringify(blocks), /catsco_attachment:image-ref/);
     } finally {
       if (originalModel === undefined) {
         delete process.env.GAUZ_LLM_MODEL;

--- a/tests/catscompany-local-file-grants.test.ts
+++ b/tests/catscompany-local-file-grants.test.ts
@@ -66,6 +66,37 @@ describe('CatsCo local file grant creation', () => {
     assert.ok(result.expiresAt > result.createdAt);
   });
 
+  test('creates a scoped file grant for stable CatsCo attachment cache files', () => {
+    const previous = process.env.XIAOBA_USER_DATA_DIR;
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'catsco-local-cache-grant-'));
+    process.env.XIAOBA_USER_DATA_DIR = root;
+    try {
+      const filePath = path.join(root, 'data', 'attachments', 'catscompany', 'cc_user_usr7', 'report.md');
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+      fs.writeFileSync(filePath, 'hello');
+      const device = createCatsCoLocalDeviceGrant({
+        bodyId: 'body-main',
+        installationId: 'install-main',
+      });
+
+      const result = createCatsCoAttachmentGrant(scope(), device, {
+        localPath: filePath,
+        fileName: 'report.md',
+        type: 'file',
+        workspaceRoot: path.join(root, 'workspace-that-does-not-contain-cache'),
+      });
+
+      assert.ok(result);
+      assert.equal(result.filePath, fs.realpathSync(filePath));
+      assert.equal(result.fileName, 'report.md');
+      assert.deepEqual(result.operations, ['read_file', 'send_file']);
+    } finally {
+      if (previous === undefined) delete process.env.XIAOBA_USER_DATA_DIR;
+      else process.env.XIAOBA_USER_DATA_DIR = previous;
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   test('does not create grants for missing, legacy, untrusted, non-CatsCo, or bodyless scopes', () => {
     const { root, filePath } = workspaceWithAttachment('blocked.md');
     const device = createCatsCoLocalDeviceGrant({ bodyId: 'body-main' });

--- a/tests/sidecar-memory-branch.test.ts
+++ b/tests/sidecar-memory-branch.test.ts
@@ -130,12 +130,17 @@ class PromptInjectionMemoryBranchAI {
 
 describe('memory sidecar branch', () => {
   let testRoot: string;
+  let previousUserDataDir: string | undefined;
 
   beforeEach(() => {
+    previousUserDataDir = process.env.XIAOBA_USER_DATA_DIR;
     testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-memory-sidecar-'));
+    process.env.XIAOBA_USER_DATA_DIR = testRoot;
   });
 
   afterEach(() => {
+    if (previousUserDataDir === undefined) delete process.env.XIAOBA_USER_DATA_DIR;
+    else process.env.XIAOBA_USER_DATA_DIR = previousUserDataDir;
     if (testRoot && fs.existsSync(testRoot)) {
       fs.rmSync(testRoot, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

- 将 CatsCo 附件保存到运行实例的数据目录下的稳定缓存路径，并把本地缓存路径写入用户消息，方便后续轮次继续读取图片/文件。
- 统一运行实例内 sessions、logs、skills、attachments 等路径从 runtime data root 派生。
- 在 Electron 菜单增加 设置 -> 打开本地缓存文件位置，并保留普通 CatsCo 工具结果中的真实路径。

## Validation

- npm run build
- 相关附件缓存、CatsCo content blocks、本地文件授权、sidecar memory 分支测试已在本地跑过。