### PR TITLE
默认安装基础 SkillHub 技能

### DIFF
--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -4,6 +4,7 @@ import type { Server } from 'http';
 import { Logger } from '../utils/logger';
 import { createApiRouter } from './routes/api';
 import { ServiceManager } from './service-manager';
+import { bootstrapDefaultSkillHubSkillsOnce } from '../skillhub/default-skill-bootstrap';
 
 const DEFAULT_PORT = 3800;
 const activeServers: Server[] = [];
@@ -33,6 +34,10 @@ export async function startDashboard(
   const serviceManager = new ServiceManager(projectRoot);
 
   app.use(express.json({ limit: '25mb' }));
+
+  bootstrapDefaultSkillHubSkillsOnce().catch(error => {
+    Logger.warning(`Default SkillHub bootstrap failed: ${error?.message || String(error)}`);
+  });
 
   // API routes
   app.use('/api', createApiRouter(serviceManager, controllers.updateController));

--- a/src/skillhub/default-skill-bootstrap.ts
+++ b/src/skillhub/default-skill-bootstrap.ts
@@ -1,0 +1,200 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { PathResolver } from '../utils/path-resolver';
+import { Logger } from '../utils/logger';
+import { loadSkillHubConfig } from './config';
+import { DEFAULT_SKILLHUB_SKILLS, DefaultSkillHubSkill } from './default-skills';
+import { SkillHubService } from './service';
+
+const STATE_SCHEMA = 'xiaoba.default_skills.v1';
+
+type DefaultSkillBootstrapStateName =
+  | 'installed'
+  | 'user_removed'
+  | 'user_disabled'
+  | 'name_conflict'
+  | 'failed';
+
+interface DefaultSkillBootstrapItemState {
+  state: DefaultSkillBootstrapStateName;
+  skillId: string;
+  version: string;
+  installName: string;
+  relativePath?: string;
+  updatedAt: string;
+  installedAt?: string;
+  lastAttemptAt?: string;
+  lastError?: string;
+}
+
+interface DefaultSkillBootstrapStateFile {
+  schema: typeof STATE_SCHEMA;
+  items: Record<string, DefaultSkillBootstrapItemState>;
+}
+
+export interface DefaultSkillBootstrapResult {
+  key: string;
+  state: DefaultSkillBootstrapStateName | 'skipped';
+  action: 'installed' | 'skipped' | 'recorded';
+  reason?: string;
+}
+
+export interface DefaultSkillBootstrapOptions {
+  skills?: DefaultSkillHubSkill[];
+  service?: Pick<SkillHubService, 'install'>;
+  now?: () => Date;
+}
+
+let bootstrapInFlight: Promise<DefaultSkillBootstrapResult[]> | null = null;
+
+export function bootstrapDefaultSkillHubSkillsOnce(
+  options: DefaultSkillBootstrapOptions = {},
+): Promise<DefaultSkillBootstrapResult[]> {
+  if (!bootstrapInFlight) {
+    bootstrapInFlight = bootstrapDefaultSkillHubSkills(options)
+      .finally(() => {
+        bootstrapInFlight = null;
+      });
+  }
+  return bootstrapInFlight;
+}
+
+export async function bootstrapDefaultSkillHubSkills(
+  options: DefaultSkillBootstrapOptions = {},
+): Promise<DefaultSkillBootstrapResult[]> {
+  const defaults = (options.skills ?? DEFAULT_SKILLHUB_SKILLS).filter(isValidDefaultSkill);
+  if (!defaults.length) return [];
+
+  const service = options.service ?? new SkillHubService();
+  const now = options.now ?? (() => new Date());
+  const statePath = getDefaultSkillBootstrapStatePath();
+  const state = readStateFile(statePath);
+  const results: DefaultSkillBootstrapResult[] = [];
+  let changed = false;
+
+  for (const item of defaults) {
+    const itemState = state.items[item.key];
+    const targetDir = resolveSkillDirectory(item.installName);
+    const activeSkillFile = path.join(targetDir, 'SKILL.md');
+    const disabledSkillFile = `${activeSkillFile}.disabled`;
+
+    if (itemState?.state === 'user_removed' || itemState?.state === 'user_disabled' || itemState?.state === 'name_conflict') {
+      results.push({ key: item.key, state: itemState.state, action: 'skipped', reason: itemState.state });
+      continue;
+    }
+
+    if (itemState?.state === 'installed') {
+      if (fs.existsSync(activeSkillFile)) {
+        results.push({ key: item.key, state: 'installed', action: 'skipped', reason: 'already_installed' });
+        continue;
+      }
+      if (fs.existsSync(disabledSkillFile)) {
+        state.items[item.key] = nextState(item, 'user_disabled', now);
+        changed = true;
+        results.push({ key: item.key, state: 'user_disabled', action: 'recorded', reason: 'disabled_after_install' });
+        continue;
+      }
+      state.items[item.key] = nextState(item, 'user_removed', now);
+      changed = true;
+      results.push({ key: item.key, state: 'user_removed', action: 'recorded', reason: 'removed_after_install' });
+      continue;
+    }
+
+    if (fs.existsSync(targetDir)) {
+      state.items[item.key] = {
+        ...nextState(item, 'name_conflict', now),
+        relativePath: path.relative(PathResolver.getSkillsPath(), targetDir),
+      };
+      changed = true;
+      results.push({ key: item.key, state: 'name_conflict', action: 'recorded', reason: 'local_same_name_exists' });
+      continue;
+    }
+
+    const attemptedAt = now().toISOString();
+    try {
+      const installed = await service.install(item.skillId, item.version);
+      state.items[item.key] = {
+        ...nextState(item, 'installed', now),
+        relativePath: path.relative(PathResolver.getSkillsPath(), installed.skill.path),
+        installedAt: attemptedAt,
+        lastAttemptAt: attemptedAt,
+      };
+      changed = true;
+      results.push({ key: item.key, state: 'installed', action: 'installed' });
+    } catch (error: any) {
+      const code = String(error?.code || '');
+      state.items[item.key] = {
+        ...nextState(item, code === 'TARGET_CONFLICT' ? 'name_conflict' : 'failed', now),
+        lastAttemptAt: attemptedAt,
+        lastError: error?.message || String(error),
+      };
+      changed = true;
+      results.push({
+        key: item.key,
+        state: state.items[item.key].state,
+        action: 'recorded',
+        reason: state.items[item.key].lastError,
+      });
+    }
+  }
+
+  if (changed) writeStateFile(statePath, state);
+  return results;
+}
+
+export function getDefaultSkillBootstrapStatePath(): string {
+  return path.join(loadSkillHubConfig().dataDir, 'default-skills-state.json');
+}
+
+function isValidDefaultSkill(item: DefaultSkillHubSkill): boolean {
+  return Boolean(
+    String(item?.key || '').trim()
+    && String(item?.skillId || '').trim()
+    && String(item?.version || '').trim()
+    && String(item?.installName || '').trim(),
+  );
+}
+
+function nextState(
+  item: DefaultSkillHubSkill,
+  state: DefaultSkillBootstrapStateName,
+  now: () => Date,
+): DefaultSkillBootstrapItemState {
+  return {
+    state,
+    skillId: item.skillId,
+    version: item.version,
+    installName: item.installName,
+    updatedAt: now().toISOString(),
+  };
+}
+
+function readStateFile(filePath: string): DefaultSkillBootstrapStateFile {
+  try {
+    if (!fs.existsSync(filePath)) return { schema: STATE_SCHEMA, items: {} };
+    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as DefaultSkillBootstrapStateFile;
+    if (parsed?.schema === STATE_SCHEMA && parsed.items && typeof parsed.items === 'object') {
+      return { schema: STATE_SCHEMA, items: parsed.items };
+    }
+  } catch (error: any) {
+    Logger.warning(`Failed to read default SkillHub state: ${error?.message || String(error)}`);
+  }
+  return { schema: STATE_SCHEMA, items: {} };
+}
+
+function writeStateFile(filePath: string, state: DefaultSkillBootstrapStateFile): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const tmpPath = `${filePath}.tmp-${process.pid}-${Date.now()}`;
+  fs.writeFileSync(tmpPath, `${JSON.stringify(state, null, 2)}\n`);
+  fs.renameSync(tmpPath, filePath);
+}
+
+function resolveSkillDirectory(installName: string): string {
+  const root = path.resolve(PathResolver.getSkillsPath());
+  const target = path.resolve(root, installName);
+  const relative = path.relative(root, target);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(`Unsafe default Skill install name: ${installName}`);
+  }
+  return target;
+}

--- a/src/skillhub/default-skills.ts
+++ b/src/skillhub/default-skills.ts
@@ -1,0 +1,10 @@
+export interface DefaultSkillHubSkill {
+  key: string;
+  skillId: string;
+  version: string;
+  installName: string;
+}
+
+export const DEFAULT_SKILLHUB_SKILLS: DefaultSkillHubSkill[] = [
+  { key: 'lin/agent-browser', skillId: 'lin/agent-browser', version: '1.0.3', installName: 'agent-browser' },
+];

--- a/src/skillhub/service.ts
+++ b/src/skillhub/service.ts
@@ -249,16 +249,34 @@ export class SkillHubService {
     if (version) {
       const detail = await this.client.getVersion(skillId, version);
       const entry = normalizeRegistryEntryVersion(detail.version || detail.skill, version);
-      if (entry) return entry;
+      if (entry) return assertRegistryEntryMatchesRequest(entry, skillId, version);
     } else {
       const detail = await this.client.getSkill(skillId);
-      if (detail.skill) return detail.skill;
-      if (detail.version) return detail.version;
+      if (detail.skill) return assertRegistryEntryMatchesRequest(detail.skill, skillId);
+      if (detail.version) return assertRegistryEntryMatchesRequest(detail.version, skillId);
     }
     const error: any = new Error('SkillHub 未找到这个 Skill 版本。');
     error.status = 404;
     throw error;
   }
+}
+
+function assertRegistryEntryMatchesRequest(
+  entry: SkillHubRegistryEntry,
+  requestedSkillId: string,
+  requestedVersion?: string,
+): SkillHubRegistryEntry {
+  const actualSkillId = String(entry.skillId || '').trim();
+  const expectedSkillId = String(requestedSkillId || '').trim();
+  const actualVersion = String(entry.latestVersion || (entry as any).version || '').trim();
+  const expectedVersion = String(requestedVersion || '').trim();
+  if (actualSkillId !== expectedSkillId || (expectedVersion && actualVersion !== expectedVersion)) {
+    const error: any = new Error('SkillHub 返回的 Skill 版本与请求不一致，已停止安装。');
+    error.status = 409;
+    error.code = 'skillhub.registry_entry_mismatch';
+    throw error;
+  }
+  return entry;
 }
 
 function normalizeRegistryEntryVersion(entry: SkillHubRegistryEntry | undefined, requestedVersion?: string): SkillHubRegistryEntry | undefined {

--- a/tests/skillhub-default-skills.test.ts
+++ b/tests/skillhub-default-skills.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import * as assert from 'node:assert/strict';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  bootstrapDefaultSkillHubSkills,
+  getDefaultSkillBootstrapStatePath,
+} from '../src/skillhub/default-skill-bootstrap';
+import type { DefaultSkillHubSkill } from '../src/skillhub/default-skills';
+
+describe('default SkillHub bootstrap', () => {
+  let testRoot: string;
+  let originalCwd: string;
+  let originalSkillsEnv: string | undefined;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    originalSkillsEnv = process.env.XIAOBA_SKILLS_DIR;
+    testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-default-skills-'));
+    process.chdir(testRoot);
+    process.env.XIAOBA_SKILLS_DIR = path.join(testRoot, 'skills');
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    if (originalSkillsEnv === undefined) delete process.env.XIAOBA_SKILLS_DIR;
+    else process.env.XIAOBA_SKILLS_DIR = originalSkillsEnv;
+    if (fs.existsSync(testRoot)) fs.rmSync(testRoot, { recursive: true, force: true });
+  });
+
+  test('installs a missing default skill once and records central state', async () => {
+    const calls: string[] = [];
+    const skill = defaultSkill('agent-browser');
+    const service = fakeInstallService(calls);
+
+    const first = await bootstrapDefaultSkillHubSkills({ skills: [skill], service });
+    const second = await bootstrapDefaultSkillHubSkills({ skills: [skill], service });
+
+    assert.deepEqual(first.map(item => item.action), ['installed']);
+    assert.deepEqual(second.map(item => item.reason), ['already_installed']);
+    assert.deepEqual(calls, ['catsco/agent-browser@1.0.0']);
+    const state = readState();
+    assert.equal(state.items[skill.key].state, 'installed');
+    assert.equal(state.items[skill.key].relativePath, 'agent-browser');
+    assert.equal(fs.existsSync(path.join(testRoot, 'skills', 'agent-browser', 'SKILL.md')), true);
+  });
+
+  test('does not reinstall a default skill after the user removes it', async () => {
+    const calls: string[] = [];
+    const skill = defaultSkill('officecli');
+    const service = fakeInstallService(calls);
+
+    await bootstrapDefaultSkillHubSkills({ skills: [skill], service });
+    fs.rmSync(path.join(testRoot, 'skills', 'officecli'), { recursive: true, force: true });
+    const removed = await bootstrapDefaultSkillHubSkills({ skills: [skill], service });
+    const later = await bootstrapDefaultSkillHubSkills({ skills: [skill], service });
+
+    assert.equal(removed[0].state, 'user_removed');
+    assert.equal(later[0].state, 'user_removed');
+    assert.deepEqual(calls, ['catsco/officecli@1.0.0']);
+  });
+
+  test('does not overwrite an existing user skill with the same install name', async () => {
+    const calls: string[] = [];
+    const skill = defaultSkill('self-evolution');
+    const existingDir = path.join(testRoot, 'skills', 'self-evolution');
+    fs.mkdirSync(existingDir, { recursive: true });
+    fs.writeFileSync(path.join(existingDir, 'SKILL.md'), '---\nname: self-evolution\ndescription: user copy\n---\n');
+
+    const result = await bootstrapDefaultSkillHubSkills({
+      skills: [skill],
+      service: fakeInstallService(calls),
+    });
+
+    assert.equal(result[0].state, 'name_conflict');
+    assert.deepEqual(calls, []);
+    assert.equal(readState().items[skill.key].state, 'name_conflict');
+  });
+
+  test('installs newly added defaults without reviving removed defaults', async () => {
+    const calls: string[] = [];
+    const firstSkill = defaultSkill('agent-browser');
+    const secondSkill = defaultSkill('officecli');
+    const service = fakeInstallService(calls);
+
+    await bootstrapDefaultSkillHubSkills({ skills: [firstSkill], service });
+    fs.rmSync(path.join(testRoot, 'skills', 'agent-browser'), { recursive: true, force: true });
+    await bootstrapDefaultSkillHubSkills({ skills: [firstSkill], service });
+
+    const result = await bootstrapDefaultSkillHubSkills({
+      skills: [firstSkill, secondSkill],
+      service,
+    });
+
+    assert.equal(result.find(item => item.key === firstSkill.key)?.state, 'user_removed');
+    assert.equal(result.find(item => item.key === secondSkill.key)?.action, 'installed');
+    assert.deepEqual(calls, ['catsco/agent-browser@1.0.0', 'catsco/officecli@1.0.0']);
+  });
+});
+
+function defaultSkill(name: string): DefaultSkillHubSkill {
+  return {
+    key: `catsco/${name}`,
+    skillId: `catsco/${name}`,
+    version: '1.0.0',
+    installName: name,
+  };
+}
+
+function fakeInstallService(calls: string[]) {
+  return {
+    async install(skillId: string, version?: string) {
+      calls.push(`${skillId}@${version}`);
+      const name = skillId.split('/').pop() || skillId;
+      const skillDir = path.join(process.env.XIAOBA_SKILLS_DIR || '', name);
+      fs.mkdirSync(skillDir, { recursive: true });
+      fs.writeFileSync(path.join(skillDir, 'SKILL.md'), `---\nname: ${name}\ndescription: default skill\n---\n`);
+      return {
+        ok: true as const,
+        skill: {
+          skillId,
+          name,
+          version: String(version || ''),
+          path: skillDir,
+        },
+        signingKeyId: 'test-signing',
+        rootKeyId: 'test-root',
+      };
+    },
+  };
+}
+
+function readState(): any {
+  return JSON.parse(fs.readFileSync(getDefaultSkillBootstrapStatePath(), 'utf-8'));
+}

--- a/tests/skillhub-service-install.test.ts
+++ b/tests/skillhub-service-install.test.ts
@@ -91,6 +91,20 @@ describe('SkillHub connected install service', () => {
     assert.equal(fs.existsSync(path.join(install.skill.path, 'SKILL.md')), true);
   });
 
+  test('rejects registry entries that do not match the requested skill id', async () => {
+    const fixture = createFixture();
+    (fixture as any).allowMismatchedRequest = true;
+    CATSCO_SKILLHUB_ROOT_PUBLIC_KEYS.push(fixture.rootTrust);
+    await startFixtureServer(fixture);
+    process.env.CATSCO_SKILLHUB_BASE_URL = baseUrl;
+
+    await assert.rejects(
+      () => new SkillHubService().install('lin/other-skill', '1.0.0'),
+      (error: any) => error?.code === 'skillhub.registry_entry_mismatch',
+    );
+    assert.equal(fs.existsSync(path.join(testRoot, 'skills', 'contract-review')), false);
+  });
+
   async function startFixtureServer(fixture: ReturnType<typeof createFixture>): Promise<void> {
     const app = express();
     app.use(express.json());
@@ -110,7 +124,7 @@ describe('SkillHub connected install service', () => {
       res.type('application/octet-stream').send(fixture.packageBytes);
     });
     app.get(/^\/api\/skills\/(.+)\/versions\/([^/]+)$/, (req, res) => {
-      assert.equal(req.params[0], fixture.entry.skillId);
+      if (!(fixture as any).allowMismatchedRequest) assert.equal(req.params[0], fixture.entry.skillId);
       res.json({
         version: {
           ...fixture.entry,
@@ -120,7 +134,7 @@ describe('SkillHub connected install service', () => {
       });
     });
     app.get(/^\/api\/skills\/(.+)$/, (req, res) => {
-      assert.equal(req.params[0], fixture.entry.skillId);
+      if (!(fixture as any).allowMismatchedRequest) assert.equal(req.params[0], fixture.entry.skillId);
       res.json({ skill: fixture.entry, versions: [fixture.entry] });
     });
     server = await listen(app);


### PR DESCRIPTION
## Summary

- 新增默认 SkillHub 技能 bootstrap：Dashboard 启动后后台安装默认技能
- 默认预设先包含 lin/agent-browser@1.0.3，安装名为 agent-browser
- 使用 data/skillhub/default-skills-state.json 记录自动安装状态，避免用户删除后被反复装回
- 同名本地 skill 已存在时记录 name_conflict，不覆盖用户内容
- SkillHub 安装增加请求 skillId/version 与返回条目一致性校验

## Test Plan

- node_modules\\.bin\\tsx.cmd --test tests\\skillhub-default-skills.test.ts tests\\skillhub-service-install.test.ts
- npm run build