### PR TITLE
支持glob返回目录项

### DIFF
--- a/src/tools/common-directory-tool.ts
+++ b/src/tools/common-directory-tool.ts
@@ -145,7 +145,7 @@ export class CommonDirectoryTool implements Tool {
       '把常见用户目录名称解析为当前工具目标设备上的真实本地路径。',
       '当用户说“桌面”“下载”“文档”等自然语言目录时先用它解析，不要手猜 C:\\Users\\...\\Desktop、~/Desktop 等路径。',
       '解析出的 path 只属于本次工具实际执行的目标：可能是虚拟员工自己的云运行体，也可能是后端选中的用户设备。',
-      '解析后如果要查看目录文件，请用 glob；如果要创建文件，请用 write_file。必须用命令时，把 path 传给 execute_shell.cwd，不要单独 cd 后再猜当前目录。',
+      '解析后如果要查看目录文件，请用 glob；如果要列出目录项或查看有哪些文件夹，请用 glob 的 pattern="*" 且 include_directories=true；如果要创建文件，请用 write_file。必须用命令时，把 path 传给 execute_shell.cwd，不要单独 cd 后再猜当前目录。',
       '只解析标准 OS 用户目录；不搜索项目目录、应用目录、浏览器下载子目录或语义目录。',
     ].join('\n'),
     parameters: {

--- a/src/tools/glob-tool.ts
+++ b/src/tools/glob-tool.ts
@@ -95,8 +95,10 @@ export class GlobTool implements Tool {
       ignore: ['**/node_modules/**', '**/.git/**', '**/dist/**', '**/build/**']
     });
 
+    const resultLabel = include_directories ? '目录项' : '文件';
+
     if (files.length === 0) {
-      return { ok: true, content: `未找到匹配的文件。\n模式: ${pattern}\n目录: ${visibleSearchPath}\nPath: ${visibleCwd}` };
+      return { ok: true, content: `未找到匹配的${resultLabel}。\n模式: ${pattern}\n目录: ${visibleSearchPath}\nPath: ${visibleCwd}` };
     }
 
     // 使用Promise.allSettled容错处理stat（文件可能在glob后被删除）
@@ -123,7 +125,7 @@ export class GlobTool implements Tool {
       durationMs: Date.now() - startTime
     };
 
-    return { ok: true, content: this.formatResult(result, pattern, visibleSearchPath, visibleCwd) };
+    return { ok: true, content: this.formatResult(result, pattern, visibleSearchPath, visibleCwd, resultLabel) };
   }
 
   private formatResult(
@@ -131,12 +133,13 @@ export class GlobTool implements Tool {
     pattern: string,
     visibleSearchPath: string,
     visibleCwd: string,
+    resultLabel: string,
   ): string {
     const { numFiles, filenames, truncated, durationMs } = result;
 
-    const header = `找到 ${numFiles} 个文件 (${durationMs}ms)${truncated ? ' - 结果已截断，考虑使用更精确的模式' : ''}:\n模式: ${pattern}\n目录: ${visibleSearchPath}\nPath: ${visibleCwd}\n\n`;
+    const header = `找到 ${numFiles} 个${resultLabel} (${durationMs}ms)${truncated ? ' - 结果已截断，考虑使用更精确的模式' : ''}:\n模式: ${pattern}\n目录: ${visibleSearchPath}\nPath: ${visibleCwd}\n\n`;
     const fileList = filenames.map((file, i) => `${(i + 1).toString().padStart(4, ' ')}. ${file}`).join('\n');
     
-    return header + fileList + (truncated ? '\n\n提示: 结果被限制在前 100 个文件。使用更具体的路径或模式来缩小范围。' : '');
+    return header + fileList + (truncated ? `\n\n提示: 结果被限制在前 100 个${resultLabel}。使用更具体的路径或模式来缩小范围。` : '');
   }
 }

--- a/src/tools/glob-tool.ts
+++ b/src/tools/glob-tool.ts
@@ -22,7 +22,7 @@ export class GlobTool implements Tool {
     description: [
       '按 glob 模式查找文件路径，返回匹配文件列表并按修改时间倒序排列。',
       '适合先定位候选文件；要搜索文件内容请使用 grep。',
-      '当用户问“桌面/下载/文档里有哪些文件”时，先用 resolve_common_directory 解析目录，再用本工具列出文件；不要用 execute_shell 跑 dir/ls。',
+      '当用户问“桌面/下载/文档里有什么/有哪些文件或文件夹”时，先用 resolve_common_directory 解析目录，再用 pattern="*" 且 include_directories=true 列出目录项；不要用 execute_shell 跑 dir/ls。',
     ].join('\n'),
     parameters: {
       type: 'object',
@@ -40,6 +40,11 @@ export class GlobTool implements Tool {
           description: '返回结果最大数量，默认 100。',
           default: 100
         },
+        include_directories: {
+          type: 'boolean',
+          description: '是否包含匹配到的目录。默认 false，保持只返回文件；用户要查看目录里有什么、有哪些文件夹或列目录内容时设为 true。',
+          default: false
+        },
         target: targetParameterDescription()
       },
       required: ['pattern']
@@ -47,7 +52,7 @@ export class GlobTool implements Tool {
   };
 
   async execute(args: any, context: ToolExecutionContext): Promise<ToolExecutionResult> {
-    const { pattern, path: searchPath, limit = 100 } = args;
+    const { pattern, path: searchPath, limit = 100, include_directories = false } = args;
     const startTime = Date.now();
 
     const route = resolveExecutionRoute(context, {
@@ -85,7 +90,7 @@ export class GlobTool implements Tool {
     const files = await glob(pattern, {
       cwd,
       absolute: false,
-      nodir: true,
+      nodir: !include_directories,
       dot: false,
       ignore: ['**/node_modules/**', '**/.git/**', '**/dist/**', '**/build/**']
     });

--- a/tests/tool-result-tool-manager.test.ts
+++ b/tests/tool-result-tool-manager.test.ts
@@ -83,6 +83,28 @@ describe('ToolManager - ToolExecutionResult 统一处理', () => {
     assert.strictEqual(result.errorCode, undefined);
   });
 
+  test('glob can include directories when requested', async () => {
+    fs.mkdirSync(path.join(testRoot, 'matched-dir'));
+    fs.writeFileSync(path.join(testRoot, 'matched-file.txt'), '');
+
+    const defaultResult = await manager.executeTool(
+      { id: 't4_dir_default', type: 'function', function: { name: 'glob', arguments: JSON.stringify({ pattern: '*' }) } },
+      [],
+    );
+    assert.strictEqual(defaultResult.ok, true);
+    assert.ok(!String(defaultResult.content).includes('matched-dir'));
+    assert.ok(String(defaultResult.content).includes('matched-file.txt'));
+
+    const withDirectories = await manager.executeTool(
+      { id: 't4_dir_include', type: 'function', function: { name: 'glob', arguments: JSON.stringify({ pattern: '*', include_directories: true }) } },
+      [],
+    );
+    assert.strictEqual(withDirectories.ok, true);
+    assert.ok(String(withDirectories.content).includes('matched-dir'));
+    assert.ok(String(withDirectories.content).includes('matched-file.txt'));
+    assert.strictEqual(withDirectories.errorCode, undefined);
+  });
+
   test('read_file uses reader proxy path for images when primary model is text-only', async () => {
     const previousConfigPath = process.env.XIAOBA_CONFIG_PATH;
     const previousModel = process.env.GAUZ_LLM_MODEL;


### PR DESCRIPTION
## 变更说明

### 改动摘要
- 在 `glob` 工具新增 `include_directories` 可选参数，默认值为 `false`，默认行为保持不变，仅返回文件。
- 在 `glob` 调用中按 `nodir: !include_directories` 控制返回类型：开启时返回目录项，关闭时不返回目录。
- 增加回归测试覆盖：
  - 默认模式下 `pattern="*"` 不返回目录。
  - 开启 `include_directories` 后返回目录与文件。

### 兼容性与影响
- 默认返回值保持不变，向后兼容现有调用。
- 需要查看目录结构时，由调用方显式传 `include_directories: true`。
- 与 `resolve_common_directory` 的配合流程保持一致，`execute_shell` 的使用场景不受影响。
