### PR TITLE
增强模型请求失败长重试

### DIFF
--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -16,6 +16,7 @@ import type { SubAgentInfo } from '../core/sub-agent-session';
 import { ChannelCallbacks, DeviceRpcTransport, TargetRoutes, ThinToolRpcTransport, ToolErrorCode, ToolExecutionConfirmationRequest, ToolExecutionConfirmationResult, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import { ContentBlock } from '../types';
 import type { PendingUserInput } from '../core/conversation-runner';
+import type { StreamRetryInfo } from '../providers/provider';
 import type { DeviceGrantOperation, ExecutionScope, ScopedDeviceGrant, ScopedDeviceSelection, ScopedLocalDeviceGrant, ScopedLocalFileGrant } from '../types/session-identity';
 import { AdapterRuntimeBundle, createAdapterRuntime } from '../runtime/adapter-runtime';
 import { randomUUID } from 'crypto';
@@ -200,6 +201,16 @@ function shouldSuppressStructuredToolProgress(channelSource?: string): boolean {
   const normalized = String(channelSource || '').trim().toLowerCase();
   if (!normalized) return false;
   return STRUCTURED_TOOL_PROGRESS_UNSUPPORTED_CHANNELS.has(normalized);
+}
+
+function formatModelRetryThinking(attempt: number, maxRetries: number, info?: StreamRetryInfo): string {
+  const retryIn = info && info.delayMs >= 1000
+    ? `，约 ${Math.ceil(info.delayMs / 1000)} 秒后继续`
+    : '';
+  const status = info?.status && info.status !== 'unknown'
+    ? `（${info.status}）`
+    : '';
+  return `模型连接异常${status}，正在重试 ${attempt}/${maxRetries}${retryIn}...`;
 }
 
 export function isCatsCompanyPassiveAcknowledgement(text: string): boolean {
@@ -957,9 +968,18 @@ export class CatsCompanyBot {
   ): SessionCallbacks {
     const suppressToolProgress = shouldSuppressStructuredToolProgress(opts?.channelSource);
     return {
-      onRetry: async (attempt, maxRetries) => {
+      onRetry: async (attempt, maxRetries, info) => {
+        if (suppressToolProgress) {
+          return;
+        }
         try {
-          await this.sender.reply(topic, `⚠️ 大模型请求失败，正在重试 (${attempt}/${maxRetries})...`);
+          await this.sender.sendThinking(topic, formatModelRetryThinking(attempt, maxRetries, info), {
+            model_retry: true,
+            attempt,
+            max_retries: maxRetries,
+            delay_ms: info?.delayMs,
+            status: info?.status,
+          });
         } catch (err: any) {
           Logger.warning(`重试提示发送失败: ${err.message}`);
         }

--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -47,6 +47,7 @@ import { MODEL_IMAGE_SAFETY_MESSAGE, isModelImageSafetyError } from '../utils/mo
 import { stripAssistantArtifactsFromMessages } from '../utils/transcript-artifacts';
 import type { PromptTraceSnapshot } from '../utils/prompt-observability';
 import { toPromptTurnMetadata } from '../utils/prompt-observability';
+import type { StreamRetryInfo } from '../providers/provider';
 
 export type { RuntimeFeedbackInput, RuntimeFeedbackOptions } from './runtime-feedback-inbox';
 
@@ -78,7 +79,7 @@ export interface SessionCallbacks {
   onToolStart?: (name: string, toolUseId: string, input: any) => void;
   onToolEnd?: (name: string, toolUseId: string, result: string) => void;
   onToolDisplay?: (name: string, content: string) => void;
-  onRetry?: (attempt: number, maxRetries: number) => void;
+  onRetry?: (attempt: number, maxRetries: number, info?: StreamRetryInfo) => void | Promise<void>;
   confirmToolExecution?: (request: ToolExecutionConfirmationRequest) => Promise<ToolExecutionConfirmationResult>;
 }
 

--- a/src/core/agent-turn-controller.ts
+++ b/src/core/agent-turn-controller.ts
@@ -16,6 +16,7 @@ import {
   ToolExecutionConfirmationRequest,
   ToolExecutionConfirmationResult,
 } from '../types/tool';
+import type { StreamRetryInfo } from '../providers/provider';
 import { AIService } from '../utils/ai-service';
 import { ToolManager } from '../tools/tool-manager';
 import { SkillManager } from '../skills/skill-manager';
@@ -53,7 +54,7 @@ export interface AgentTurnCallbacks {
   onToolStart?: (name: string, toolUseId: string, input: any) => void;
   onToolEnd?: (name: string, toolUseId: string, result: string) => void;
   onToolDisplay?: (name: string, content: string) => void;
-  onRetry?: (attempt: number, maxRetries: number) => void;
+  onRetry?: (attempt: number, maxRetries: number, info?: StreamRetryInfo) => void | Promise<void>;
   confirmToolExecution?: (request: ToolExecutionConfirmationRequest) => Promise<ToolExecutionConfirmationResult>;
 }
 

--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -3,7 +3,7 @@ import type { ScopedDeviceGrant, ScopedDeviceSelection, ScopedLocalFileGrant } f
 import type { TargetRoutes } from '../types/tool';
 import { AIService } from '../utils/ai-service';
 import { ToolCall, ToolDefinition, ToolExecutionContext, ToolExecutor, ToolResult, ToolTranscriptMode } from '../types/tool';
-import { StreamCallbacks } from '../providers/provider';
+import { StreamCallbacks, StreamRetryInfo } from '../providers/provider';
 import { Logger } from '../utils/logger';
 import { Metrics } from '../utils/metrics';
 import { ContextCompressor } from './context-compressor';
@@ -134,7 +134,7 @@ export interface RunnerCallbacks {
   /** 需要显示工具输出（如 task_planner） */
   onToolDisplay?: (name: string, content: string) => void;
   /** 重试通知 */
-  onRetry?: (attempt: number, maxRetries: number) => void;
+  onRetry?: (attempt: number, maxRetries: number, info?: StreamRetryInfo) => void | Promise<void>;
 }
 
 /**
@@ -1464,7 +1464,7 @@ export class ConversationRunner {
       if (this.stream) {
         const streamCallbacks: StreamCallbacks = {
           onText: (text) => callbacks?.onText?.(text),
-          onRetry: (attempt, maxRetries) => callbacks?.onRetry?.(attempt, maxRetries),
+          onRetry: (attempt, maxRetries, info) => callbacks?.onRetry?.(attempt, maxRetries, info),
         };
         return await this.aiService.chatStream(messages, activeTools, streamCallbacks, requestOptions);
       }
@@ -1484,6 +1484,7 @@ export class ConversationRunner {
       if (this.stream) {
         const streamCallbacks: StreamCallbacks = {
           onText: (text) => callbacks?.onText?.(text),
+          onRetry: (attempt, maxRetries, info) => callbacks?.onRetry?.(attempt, maxRetries, info),
         };
         return await this.aiService.chatStream(messages, activeTools, streamCallbacks, requestOptions);
       }

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -12,7 +12,17 @@ export interface StreamCallbacks {
   /** 发生错误 */
   onError?: (error: Error) => void;
   /** 重试通知 */
-  onRetry?: (attempt: number, maxRetries: number) => void;
+  onRetry?: (attempt: number, maxRetries: number, info?: StreamRetryInfo) => void | Promise<void>;
+}
+
+export interface StreamRetryInfo {
+  attempt: number;
+  maxRetries: number;
+  delayMs: number;
+  elapsedMs: number;
+  maxElapsedMs: number;
+  status?: string | number;
+  message?: string;
 }
 
 export interface AIRequestOptions {

--- a/src/utils/ai-service.ts
+++ b/src/utils/ai-service.ts
@@ -1,7 +1,7 @@
 import { Message, ChatConfig, ChatResponse } from '../types';
 import { ConfigManager } from './config';
 import { ToolDefinition } from '../types/tool';
-import { AIProvider, AIRequestOptions, StreamCallbacks } from '../providers/provider';
+import { AIProvider, AIRequestOptions, StreamCallbacks, StreamRetryInfo } from '../providers/provider';
 import { AnthropicProvider } from '../providers/anthropic-provider';
 import { OpenAIProvider } from '../providers/openai-provider';
 import { Logger } from './logger';
@@ -14,10 +14,25 @@ import { resolveModelContextWindow } from './model-context-window';
  */
 /** 可重试的 HTTP 状态码 */
 const RETRYABLE_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504, 520, 524, 529]);
-const MAX_RETRIES = 3;
 const BASE_DELAY_MS = 1000;
+const MAX_DELAY_MS = 30000;
+const DEFAULT_MAX_RETRY_DURATION_MS = 5 * 60 * 1000;
+const DEFAULT_MAX_RETRIES = 14;
+const MAX_CONFIGURABLE_RETRY_DURATION_MS = 10 * 60 * 1000;
+const MAX_CONFIGURABLE_RETRIES = 30;
+const SHORT_NETWORK_RETRY_CODES = new Set(['ENOTFOUND', 'ECONNREFUSED']);
+const SHORT_NETWORK_MAX_RETRIES = 3;
+const SHORT_NETWORK_MAX_ELAPSED_MS = 30 * 1000;
+const SHORT_NETWORK_MAX_DELAY_MS = 5000;
 
 type ProviderKind = 'openai' | 'anthropic';
+
+interface RetryPolicy {
+  maxRetries: number;
+  maxElapsedMs: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+}
 
 export class AIService {
   private config: ChatConfig;
@@ -164,11 +179,7 @@ export class AIService {
     );
 
     const status = this.extractStatus(error);
-    const errorMessage = error?.response?.data?.error?.message
-      || error?.response?.data?.message
-      || error?.error?.message
-      || error?.message
-      || String(error);
+    const errorMessage = this.extractErrorMessage(error);
 
     if (status) {
       return new Error(`API错误 (${status}): ${errorMessage}`);
@@ -185,6 +196,10 @@ export class AIService {
       return false;
     }
 
+    if (this.isKnownNonRetryableProviderError(error)) {
+      return false;
+    }
+
     // HTTP 状态码可重试
     const status = this.extractStatus(error);
     if (status && RETRYABLE_STATUS_CODES.has(status)) {
@@ -192,15 +207,25 @@ export class AIService {
     }
 
     // 网络错误可重试
-    const code = String(error?.code || '').toUpperCase();
-    if (['ECONNRESET', 'ETIMEDOUT', 'ECONNABORTED', 'ENOTFOUND', 'EAI_AGAIN'].includes(code)) {
+    const code = this.extractErrorCode(error);
+    if ([
+      'ECONNRESET',
+      'ETIMEDOUT',
+      'ECONNABORTED',
+      'ECONNREFUSED',
+      'ENOTFOUND',
+      'EAI_AGAIN',
+      'UND_ERR_CONNECT_TIMEOUT',
+      'UND_ERR_HEADERS_TIMEOUT',
+      'UND_ERR_SOCKET',
+    ].includes(code)) {
       return true;
     }
 
     const message = String(error?.message || '');
     const hasRetryableStatusText =
-      /(?:API错误|HTTP|status(?:\s*code)?|response status)\s*[\(:= ]\s*(?:500|502|503|504|520|524|529)\b/i.test(message)
-      || /^\s*(?:500|502|503|504|520|524|529)\b/.test(message);
+      /(?:API错误|HTTP|status(?:\s*code)?|response status)\s*[\(:= ]\s*(?:408|429|500|502|503|504|520|524|529)\b/i.test(message)
+      || /^\s*(?:408|429|500|502|503|504|520|524|529)\b/.test(message);
     if (
       hasRetryableStatusText
       || /timeout|timed out|socket hang up|network error|fetch failed|premature close|ECONNREFUSED|bad gateway|gateway timeout|service unavailable|unknown error,\s*520/i.test(message)
@@ -214,6 +239,27 @@ export class AIService {
     }
 
     return false;
+  }
+
+  private isKnownNonRetryableProviderError(error: any): boolean {
+    const status = this.extractStatus(error);
+    if (status && [400, 401, 403, 404, 413, 422].includes(status)) {
+      return true;
+    }
+
+    const message = [
+      error?.response?.data?.error?.code,
+      error?.response?.data?.error?.type,
+      error?.response?.data?.error?.message,
+      error?.response?.data?.message,
+      error?.error?.code,
+      error?.error?.type,
+      error?.error?.message,
+      error?.message,
+    ].filter(Boolean).join(' ');
+
+    return /insufficient[_\s-]?quota|quota[_\s-]?exceeded|billing|(?:insufficient|low|exhausted)[_\s-]?(?:credit|balance)|(?:credit|balance)[_\s-]?(?:exhausted|insufficient|too low)|账户余额|余额不足|额度不足|额度已用尽|context length|maximum context|max(?:imum)? tokens?|prompt too long|invalid[_\s-]?request|invalid[_\s-]?api[_\s-]?key|unauthorized|forbidden|permission denied|model .*not found|model_not_found|tool schema|schema is invalid|content policy|safety/i
+      .test(message);
   }
 
   /**
@@ -241,6 +287,11 @@ export class AIService {
     if (retryAfter) {
       const seconds = parseInt(retryAfter, 10);
       if (!isNaN(seconds)) return seconds;
+
+      const dateMs = Date.parse(String(retryAfter));
+      if (Number.isFinite(dateMs)) {
+        return Math.max(0, Math.ceil((dateMs - Date.now()) / 1000));
+      }
     }
     return null;
   }
@@ -255,8 +306,10 @@ export class AIService {
     shouldRetry?: (error: any, attempt: number) => boolean,
   ): Promise<T> {
     let lastError: any;
+    const policy = this.resolveRetryPolicy();
+    const startedAt = Date.now();
 
-    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    for (let attempt = 0; ; attempt++) {
       try {
         this.throwIfAborted(signal);
         return await fn();
@@ -267,24 +320,38 @@ export class AIService {
           throw this.createAbortError();
         }
 
-        if (attempt >= MAX_RETRIES || !this.isRetryable(error) || shouldRetry?.(error, attempt) === false) {
+        const policy = this.resolveRetryPolicy(error);
+        const retryAttempt = attempt + 1;
+        if (
+          retryAttempt > policy.maxRetries
+          || !this.isRetryable(error)
+          || shouldRetry?.(error, retryAttempt) === false
+        ) {
           throw error;
         }
 
-        // 通知用户正在重试
-        if (attempt === 0 && callbacks?.onRetry) {
-          callbacks.onRetry(attempt + 1, MAX_RETRIES);
+        const elapsedMs = Date.now() - startedAt;
+        if (elapsedMs >= policy.maxElapsedMs) {
+          throw error;
         }
 
         // 计算等待时间：优先用 Retry-After，否则指数退避
-        const retryAfter = this.getRetryAfter(error);
-        const delay = retryAfter
-          ? retryAfter * 1000
-          : BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 500;
+        const delay = this.resolveRetryDelayMs(error, retryAttempt, policy, elapsedMs);
 
-        const status = this.extractStatus(error) || error?.code || 'unknown';
+        const status = this.extractStatus(error) || this.extractErrorCode(error) || 'unknown';
+        const retryInfo: StreamRetryInfo = {
+          attempt: retryAttempt,
+          maxRetries: policy.maxRetries,
+          delayMs: delay,
+          elapsedMs,
+          maxElapsedMs: policy.maxElapsedMs,
+          status,
+          message: this.extractErrorMessage(error),
+        };
+        await this.notifyRetry(callbacks, retryAttempt, policy.maxRetries, retryInfo);
+
         Logger.warning(
-          `API 调用失败 (${status})，${delay.toFixed(0)}ms 后重试 (${attempt + 1}/${MAX_RETRIES})... `
+          `API 调用失败 (${status})，${delay.toFixed(0)}ms 后重试 (${retryAttempt}/${policy.maxRetries})... `
           + `[${this.config.provider}/${this.config.model || 'default'}]`
         );
 
@@ -293,6 +360,91 @@ export class AIService {
     }
 
     throw lastError;
+  }
+
+  private resolveRetryPolicy(error?: any): RetryPolicy {
+    const policy: RetryPolicy = {
+      maxElapsedMs: this.readNumberEnv(
+        ['CATSCO_MODEL_RETRY_MAX_MS', 'GAUZ_MODEL_RETRY_MAX_MS'],
+        DEFAULT_MAX_RETRY_DURATION_MS,
+        0,
+        MAX_CONFIGURABLE_RETRY_DURATION_MS,
+      ),
+      maxRetries: this.readNumberEnv(
+        ['CATSCO_MODEL_RETRY_MAX_RETRIES', 'GAUZ_MODEL_RETRY_MAX_RETRIES'],
+        DEFAULT_MAX_RETRIES,
+        0,
+        MAX_CONFIGURABLE_RETRIES,
+      ),
+      maxDelayMs: this.readNumberEnv(
+        ['CATSCO_MODEL_RETRY_MAX_DELAY_MS', 'GAUZ_MODEL_RETRY_MAX_DELAY_MS'],
+        MAX_DELAY_MS,
+        BASE_DELAY_MS,
+        MAX_CONFIGURABLE_RETRY_DURATION_MS,
+      ),
+      baseDelayMs: BASE_DELAY_MS,
+    };
+
+    if (!this.isShortNetworkRetryError(error)) {
+      return policy;
+    }
+
+    return {
+      ...policy,
+      maxRetries: Math.min(policy.maxRetries, SHORT_NETWORK_MAX_RETRIES),
+      maxElapsedMs: Math.min(policy.maxElapsedMs, SHORT_NETWORK_MAX_ELAPSED_MS),
+      maxDelayMs: Math.min(policy.maxDelayMs, SHORT_NETWORK_MAX_DELAY_MS),
+    };
+  }
+
+  private resolveRetryDelayMs(error: any, retryAttempt: number, policy: RetryPolicy, elapsedMs: number): number {
+    const retryAfter = this.getRetryAfter(error);
+    const rawDelay = retryAfter !== null
+      ? retryAfter * 1000
+      : Math.min(policy.maxDelayMs, policy.baseDelayMs * Math.pow(2, retryAttempt - 1)) + Math.random() * 500;
+    const remainingMs = Math.max(0, policy.maxElapsedMs - elapsedMs);
+    return Math.max(0, Math.min(rawDelay, remainingMs));
+  }
+
+  private readNumberEnv(names: string[], fallback: number, min: number, max: number): number {
+    for (const name of names) {
+      const raw = process.env[name];
+      if (raw === undefined || raw.trim() === '') continue;
+      const parsed = Number(raw);
+      if (Number.isFinite(parsed)) {
+        return Math.min(max, Math.max(min, Math.floor(parsed)));
+      }
+    }
+    return fallback;
+  }
+
+  private extractErrorMessage(error: any): string {
+    return error?.response?.data?.error?.message
+      || error?.response?.data?.message
+      || error?.error?.message
+      || error?.message
+      || String(error);
+  }
+
+  private extractErrorCode(error: any): string {
+    return String(error?.code || error?.cause?.code || '').toUpperCase();
+  }
+
+  private isShortNetworkRetryError(error: any): boolean {
+    return SHORT_NETWORK_RETRY_CODES.has(this.extractErrorCode(error));
+  }
+
+  private async notifyRetry(
+    callbacks: StreamCallbacks | undefined,
+    attempt: number,
+    maxRetries: number,
+    info: StreamRetryInfo,
+  ): Promise<void> {
+    try {
+      await callbacks?.onRetry?.(attempt, maxRetries, info);
+    } catch (error: any) {
+      Logger.warning(`重试提示回调失败: ${error?.message || error}`);
+    }
   }
 
   private throwIfAborted(signal?: AbortSignal): void {

--- a/tests/ai-service.test.ts
+++ b/tests/ai-service.test.ts
@@ -5,6 +5,9 @@ import type { ChatResponse } from '../src/types';
 import type { StreamCallbacks } from '../src/providers/provider';
 
 const originalStreamRetry = process.env.GAUZ_STREAM_RETRY;
+const originalRetryMaxRetries = process.env.CATSCO_MODEL_RETRY_MAX_RETRIES;
+const originalRetryMaxMs = process.env.CATSCO_MODEL_RETRY_MAX_MS;
+const originalRetryMaxDelayMs = process.env.CATSCO_MODEL_RETRY_MAX_DELAY_MS;
 
 afterEach(() => {
   if (originalStreamRetry === undefined) {
@@ -12,6 +15,9 @@ afterEach(() => {
   } else {
     process.env.GAUZ_STREAM_RETRY = originalStreamRetry;
   }
+  restoreEnv('CATSCO_MODEL_RETRY_MAX_RETRIES', originalRetryMaxRetries);
+  restoreEnv('CATSCO_MODEL_RETRY_MAX_MS', originalRetryMaxMs);
+  restoreEnv('CATSCO_MODEL_RETRY_MAX_DELAY_MS', originalRetryMaxDelayMs);
 });
 
 test('AIService reports non-retryable stream provider errors once', async () => {
@@ -63,18 +69,59 @@ test('AIService retries transient stream errors before any text is emitted', asy
 
   const errors: Error[] = [];
   const retries: Array<[number, number]> = [];
+  const retryInfos: any[] = [];
   const chunks: string[] = [];
   const result = await service.chatStream([], undefined, {
     onError: error => errors.push(error),
-    onRetry: (attempt, maxRetries) => retries.push([attempt, maxRetries]),
+    onRetry: (attempt, maxRetries, info) => {
+      retries.push([attempt, maxRetries]);
+      retryInfos.push(info);
+    },
     onText: text => chunks.push(text),
   });
 
   assert.equal(result, finalResponse);
   assert.equal(attempts, 2);
   assert.deepStrictEqual(errors, []);
-  assert.deepStrictEqual(retries, [[1, 3]]);
+  assert.deepStrictEqual(retries, [[1, 14]]);
+  assert.equal(retryInfos[0].status, 503);
+  assert.equal(retryInfos[0].maxElapsedMs, 5 * 60 * 1000);
   assert.deepStrictEqual(chunks, ['ok']);
+});
+
+test('AIService can keep retrying transient stream failures beyond the old short cap', async () => {
+  process.env.CATSCO_MODEL_RETRY_MAX_RETRIES = '5';
+  const service = createTestService();
+  let attempts = 0;
+  const finalResponse: ChatResponse = { content: 'eventually ok' };
+  (service as any).provider = {
+    chat: async () => ({ content: null }),
+    chatStream: async (_messages: unknown, _tools: unknown, callbacks?: StreamCallbacks) => {
+      attempts += 1;
+      if (attempts <= 4) {
+        throw Object.assign(new Error(`temporary stream failure ${attempts}`), {
+          response: {
+            status: 503,
+            headers: { 'retry-after': '0' },
+            data: { message: 'temporary stream failure' },
+          },
+        });
+      }
+
+      callbacks?.onText?.('eventually ok');
+      callbacks?.onComplete?.(finalResponse);
+      return finalResponse;
+    },
+  };
+
+  const retries: Array<[number, number]> = [];
+  const result = await service.chatStream([], undefined, {
+    onRetry: (attempt, maxRetries) => retries.push([attempt, maxRetries]),
+  });
+
+  assert.equal(result, finalResponse);
+  assert.equal(attempts, 5);
+  assert.deepStrictEqual(retries, [[1, 5], [2, 5], [3, 5], [4, 5]]);
 });
 
 test('AIService does not retry stream errors after visible text is emitted', async () => {
@@ -167,6 +214,106 @@ test('AIService does not treat bare token counts as retryable status codes', asy
   assert.equal(attempts, 1);
 });
 
+test('AIService does not retry quota exhaustion even when provider uses HTTP 429', async () => {
+  const service = createTestService();
+  let attempts = 0;
+  const quotaError = Object.assign(new Error('quota exceeded'), {
+    response: {
+      status: 429,
+      headers: { 'retry-after': '0' },
+      data: { error: { message: 'quota exceeded' } },
+    },
+  });
+  (service as any).provider = {
+    chat: async () => {
+      attempts += 1;
+      throw quotaError;
+    },
+    chatStream: async () => ({ content: null }),
+  };
+
+  await assert.rejects(
+    () => service.chat([]),
+    /API错误 \(429\): quota exceeded/,
+  );
+  assert.equal(attempts, 1);
+});
+
+test('AIService still retries transient load balancer failures', async () => {
+  process.env.CATSCO_MODEL_RETRY_MAX_RETRIES = '1';
+  const service = createTestService();
+  let attempts = 0;
+  const transientError = Object.assign(new Error('load balancer returned 503'), {
+    response: {
+      status: 503,
+      headers: { 'retry-after': '0' },
+      data: { message: 'load balancer returned 503' },
+    },
+  });
+  (service as any).provider = {
+    chat: async () => {
+      attempts += 1;
+      if (attempts === 1) throw transientError;
+      return { content: 'ok' };
+    },
+    chatStream: async () => ({ content: null }),
+  };
+
+  const result = await service.chat([]);
+
+  assert.deepStrictEqual(result, { content: 'ok' });
+  assert.equal(attempts, 2);
+});
+
+test('AIService uses a short retry policy for likely custom endpoint configuration errors', () => {
+  process.env.CATSCO_MODEL_RETRY_MAX_RETRIES = '10';
+  process.env.CATSCO_MODEL_RETRY_MAX_MS = String(5 * 60 * 1000);
+  process.env.CATSCO_MODEL_RETRY_MAX_DELAY_MS = '30000';
+  const service = createTestService();
+
+  const policy = (service as any).resolveRetryPolicy(Object.assign(new Error('connect refused'), {
+    code: 'ECONNREFUSED',
+  }));
+
+  assert.equal(policy.maxRetries, 3);
+  assert.equal(policy.maxElapsedMs, 30 * 1000);
+  assert.equal(policy.maxDelayMs, 5000);
+});
+
+test('AIService waits for async retry callbacks before the next provider attempt', async () => {
+  process.env.CATSCO_MODEL_RETRY_MAX_RETRIES = '1';
+  const service = createTestService();
+  let attempts = 0;
+  let retryCallbackFinished = false;
+  (service as any).provider = {
+    chat: async () => ({ content: null }),
+    chatStream: async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        throw Object.assign(new Error('temporary stream failure'), {
+          response: {
+            status: 503,
+            headers: { 'retry-after': '0' },
+            data: { message: 'temporary stream failure' },
+          },
+        });
+      }
+      assert.equal(retryCallbackFinished, true);
+      return { content: 'ok' };
+    },
+  };
+
+  const result = await service.chatStream([], undefined, {
+    onRetry: async () => {
+      await new Promise(resolve => setTimeout(resolve, 5));
+      retryCallbackFinished = true;
+    },
+  });
+
+  assert.deepStrictEqual(result, { content: 'ok' });
+  assert.equal(attempts, 2);
+});
+
 test('AIService passes AbortSignal to chatStream provider calls', async () => {
   const service = createTestService();
   const controller = new AbortController();
@@ -215,4 +362,12 @@ function createTestService(): AIService {
     apiKey: 'primary-key',
     model: 'primary-model',
   });
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
 }

--- a/tests/catscompany-content-blocks.test.ts
+++ b/tests/catscompany-content-blocks.test.ts
@@ -144,6 +144,28 @@ describe('CatsCo content blocks', () => {
     }]);
   });
 
+  test('model retry progress is sent as working thinking instead of a normal reply', async () => {
+    const { bot, sentThinking, replies } = createProcessHarness();
+    const callbacks = (bot as any).buildSessionCallbacks('p2p_retry');
+
+    await callbacks.onRetry(3, 14, {
+      attempt: 3,
+      maxRetries: 14,
+      delayMs: 8000,
+      elapsedMs: 12000,
+      maxElapsedMs: 5 * 60 * 1000,
+      status: 503,
+      message: 'temporary upstream error',
+    });
+
+    assert.equal(replies.length, 0);
+    assert.equal(sentThinking.length, 1);
+    assert.equal(sentThinking[0].topic, 'p2p_retry');
+    assert.equal(sentThinking[0].text, '模型连接异常（503），正在重试 3/14，约 8 秒后继续...');
+    assert.equal(sentThinking[0].metadata.model_retry, true);
+    assert.equal(sentThinking[0].metadata.delay_ms, 8000);
+  });
+
   test('parses text and multiple attachments from one CatsCompany message', () => {
     const bot = Object.create(CatsCompanyBot.prototype);
 

--- a/tests/conversation-runner-abort-signal.test.ts
+++ b/tests/conversation-runner-abort-signal.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test';
 import { ConversationRunner } from '../src/core/conversation-runner';
 import { Message } from '../src/types';
 import { ToolDefinition, ToolExecutor, ToolCall, ToolResult } from '../src/types/tool';
+import { AIService } from '../src/utils/ai-service';
 
 class EmptyToolExecutor implements ToolExecutor {
   getToolDefinitions(): ToolDefinition[] {
@@ -114,6 +115,86 @@ test('ConversationRunner omits tool definitions when the model config disables t
 
   assert.equal(result.response, 'done');
   assert.deepEqual(observedTools, []);
+});
+
+test('ConversationRunner executes a tool only once after a transient model retry returns tool calls', async () => {
+  const service = new AIService({
+    provider: 'openai',
+    apiUrl: 'https://primary.example.test/v1',
+    apiKey: 'primary-key',
+    model: 'primary-model',
+  });
+  let modelCalls = 0;
+  (service as any).provider = {
+    chat: async () => {
+      modelCalls += 1;
+      if (modelCalls === 1) {
+        throw Object.assign(new Error('temporary upstream failure'), {
+          response: {
+            status: 503,
+            headers: { 'retry-after': '0' },
+            data: { message: 'temporary upstream failure' },
+          },
+        });
+      }
+      if (modelCalls === 2) {
+        return {
+          content: '',
+          toolCalls: [{
+            id: 'call_once',
+            type: 'function',
+            function: {
+              name: 'read_file',
+              arguments: JSON.stringify({ file_path: 'a.txt' }),
+            },
+          }],
+        };
+      }
+      return {
+        content: 'done',
+        toolCalls: [],
+        usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+      };
+    },
+  };
+
+  let toolExecutions = 0;
+  const toolExecutor: ToolExecutor = {
+    getToolDefinitions() {
+      return [{
+        name: 'read_file',
+        description: 'Read a file',
+        parameters: {
+          type: 'object',
+          properties: {
+            file_path: { type: 'string' },
+          },
+          required: ['file_path'],
+        },
+      }];
+    },
+    async executeTool(toolCall: ToolCall): Promise<ToolResult> {
+      toolExecutions += 1;
+      return {
+        role: 'tool',
+        tool_call_id: toolCall.id,
+        name: toolCall.function.name,
+        content: 'file content',
+        ok: true,
+      };
+    },
+  };
+
+  const runner = new ConversationRunner(service, toolExecutor, {
+    stream: false,
+    enableCompression: false,
+  });
+
+  const result = await runner.run([{ role: 'user', content: 'read it' }]);
+
+  assert.equal(result.response, 'done');
+  assert.equal(modelCalls, 3);
+  assert.equal(toolExecutions, 1);
 });
 
 async function waitFor(predicate: () => boolean, maxAttempts = 50): Promise<void> {


### PR DESCRIPTION
## 变更

- 将模型请求失败重试改为默认最长约 5 分钟的长重试，覆盖 CatsCo 中转和自定义 OpenAI/Anthropic 模型。
- 仅对网络抖动、超时、408/429/5xx 等临时错误重试；key、权限、模型不存在、额度不足、上下文超长、schema 错误等确定失败不重试。
- 流式输出已有可见文本后默认不重试，避免重复回复；自定义 host/port 这类 ENOTFOUND/ECONNREFUSED 走短重试，避免配置错误卡太久。
- CatsCompany retry 提示改为 WORKING/thinking 消息，并等待提示回调完成后再进入下一次请求，减少提示乱序。
- 补充 AIService、CatsCompany working、ConversationRunner 工具执行次数相关回归测试。

## 验证

- `npx tsx --test tests/ai-service.test.ts tests/conversation-runner-abort-signal.test.ts tests/catscompany-content-blocks.test.ts tests/agent-session-abort-signal.test.ts tests/subagent-model-abort-signal.test.ts`
- `npm run build`
- `git diff --check`

## Review

- 已自行复审。
- 已开子 agent 复审；反馈的短重试、onRetry await、工具只执行一次测试已处理。