### PR TITLE
修复 CatsCompany WebSocket 半开重连

### DIFF
--- a/src/catscompany/client.ts
+++ b/src/catscompany/client.ts
@@ -14,6 +14,10 @@ export interface CatsClientConfig {
   installationId?: string;
   deviceRegistration?: CatsDeviceRegistration;
   httpBaseUrl?: string;
+  connectTimeoutMs?: number;
+  readyTimeoutMs?: number;
+  reconnectBaseDelayMs?: number;
+  reconnectMaxDelayMs?: number;
 }
 
 export interface CatsDeviceRegistration {
@@ -119,6 +123,10 @@ export type CatsSendErrorKind = 'transport' | 'ack' | 'timeout';
 // Cats 服务端握手协议版本，不是 CatsCo 客户端发布版本。
 const CATSCOMPANY_PROTOCOL_VERSION = '0.1.0';
 const CATSCOMPANY_CLIENT_UA = 'CatsCo/1.0';
+const DEFAULT_WS_CONNECT_TIMEOUT_MS = 20_000;
+const DEFAULT_WS_READY_TIMEOUT_MS = 20_000;
+const DEFAULT_RECONNECT_BASE_DELAY_MS = 1_000;
+const DEFAULT_RECONNECT_MAX_DELAY_MS = 30_000;
 
 function maskSecret(value: string): string {
   if (value.length <= 10) return '***';
@@ -174,10 +182,14 @@ export class CatsClient extends EventEmitter {
   private pendingThinToolRpc = new Map<string, PendingThinToolRpc>();
   private pingTimer: NodeJS.Timeout | null = null;
   private pongTimer: NodeJS.Timeout | null = null;
+  private connectTimer: NodeJS.Timeout | null = null;
+  private readyTimer: NodeJS.Timeout | null = null;
+  private reconnectTimer: NodeJS.Timeout | null = null;
   private reconnectAttempts = 0;
   private subscribedTopics = new Set<string>();
   private supportsClientMessageDedupe = false;
   public supportsThinToolRpc = false;
+  private awaitingReady = false;
 
   public uid = '';
   public name = '';
@@ -216,9 +228,12 @@ export class CatsClient extends EventEmitter {
         'X-CatsCo-Installation-ID': installationId,
       },
     });
+    this.startConnectTimeout(bodyId);
 
     this.ws.on('open', () => {
-      this.reconnectAttempts = 0;
+      this.clearConnectTimeout();
+      this.awaitingReady = true;
+      this.startReadyTimeout();
       this.send({
         hi: {
           id: '1',
@@ -243,6 +258,9 @@ export class CatsClient extends EventEmitter {
     this.ws.on('error', (err: Error) => this.emit('error', err));
     this.ws.on('close', (code: number, reason: Buffer) => {
       Logger.warning(`[CatsCompany] WebSocket 已关闭: code=${code}, reason=${reason.toString() || '-'}`);
+      this.clearConnectTimeout();
+      this.clearReadyTimeout();
+      this.awaitingReady = false;
       this.stopHeartbeat();
       this.ws = null;
       this.rejectPendingAcks(new CatsSendError(
@@ -266,6 +284,9 @@ export class CatsClient extends EventEmitter {
   private handleMessage(msg: any): void {
     if (msg.ctrl) {
       if (msg.ctrl.code === 200 && msg.ctrl.params?.build === 'catscompany') {
+        this.awaitingReady = false;
+        this.clearReadyTimeout();
+        this.reconnectAttempts = 0;
         this.uid = String(msg.ctrl.params?.uid || 'bot');
         this.name = String(msg.ctrl.params?.name || 'CatsCo');
         Logger.info(
@@ -797,6 +818,44 @@ export class CatsClient extends EventEmitter {
     }
   }
 
+  private startConnectTimeout(bodyId: string): void {
+    this.clearConnectTimeout();
+    const timeoutMs = this.positiveTimeout(this.config.connectTimeoutMs, DEFAULT_WS_CONNECT_TIMEOUT_MS);
+    this.connectTimer = setTimeout(() => {
+      if (this.ws?.readyState !== WebSocket.CONNECTING) return;
+      Logger.warning(`[CatsCompany] WebSocket 连接握手超时 ${timeoutMs}ms，主动重建连接: bodyId=${bodyId}`);
+      this.ws.terminate();
+    }, timeoutMs);
+    (this.connectTimer as any).unref?.();
+  }
+
+  private clearConnectTimeout(): void {
+    if (!this.connectTimer) return;
+    clearTimeout(this.connectTimer);
+    this.connectTimer = null;
+  }
+
+  private startReadyTimeout(): void {
+    this.clearReadyTimeout();
+    const timeoutMs = this.positiveTimeout(this.config.readyTimeoutMs, DEFAULT_WS_READY_TIMEOUT_MS);
+    this.readyTimer = setTimeout(() => {
+      if (!this.awaitingReady || this.ws?.readyState !== WebSocket.OPEN) return;
+      Logger.warning(`[CatsCompany] CatsCompany 握手确认超时 ${timeoutMs}ms，主动重建 WebSocket 连接`);
+      this.ws.terminate();
+    }, timeoutMs);
+    (this.readyTimer as any).unref?.();
+  }
+
+  private clearReadyTimeout(): void {
+    if (!this.readyTimer) return;
+    clearTimeout(this.readyTimer);
+    this.readyTimer = null;
+  }
+
+  private positiveTimeout(value: number | undefined, fallback: number): number {
+    return Number.isFinite(value) && Number(value) > 0 ? Number(value) : fallback;
+  }
+
   private startHeartbeat(): void {
     this.stopHeartbeat();
     this.pingTimer = setInterval(() => {
@@ -827,10 +886,17 @@ export class CatsClient extends EventEmitter {
   }
 
   private scheduleReconnect(): void {
-    const delay = Math.min(1000 * Math.pow(2, this.reconnectAttempts), 30000);
+    const baseDelay = this.positiveTimeout(this.config.reconnectBaseDelayMs, DEFAULT_RECONNECT_BASE_DELAY_MS);
+    const maxDelay = this.positiveTimeout(this.config.reconnectMaxDelayMs, DEFAULT_RECONNECT_MAX_DELAY_MS);
+    const delay = Math.min(baseDelay * Math.pow(2, this.reconnectAttempts), maxDelay);
     Logger.info(`[CatsCompany] ${delay}ms 后重连 (尝试 ${this.reconnectAttempts + 1})`);
     this.reconnectAttempts++;
-    setTimeout(() => this.connect(), delay);
+    if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      if (!this.closed) this.connect();
+    }, delay);
+    (this.reconnectTimer as any).unref?.();
   }
 
   private resubscribeTopics(): void {
@@ -848,6 +914,13 @@ export class CatsClient extends EventEmitter {
 
   disconnect(): void {
     this.closed = true;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    this.clearConnectTimeout();
+    this.clearReadyTimeout();
+    this.awaitingReady = false;
     this.stopHeartbeat();
     this.ws?.close();
   }

--- a/tests/catscompany-client-body-id.test.ts
+++ b/tests/catscompany-client-body-id.test.ts
@@ -145,9 +145,18 @@ describe('CatsCompany client body identity', () => {
     servers.push(server);
     await new Promise<void>(resolve => server.once('listening', resolve));
 
+    let connections = 0;
     const socketClosed = new Promise<void>(resolve => {
-      server.once('connection', socket => {
-        socket.once('close', () => resolve());
+      server.on('connection', socket => {
+        connections++;
+        if (connections === 1) {
+          socket.once('close', () => resolve());
+        }
+      });
+    });
+    const secondConnection = new Promise<void>(resolve => {
+      server.on('connection', () => {
+        if (connections >= 2) resolve();
       });
     });
 
@@ -157,12 +166,15 @@ describe('CatsCompany client body identity', () => {
       apiKey: 'cc-test-key',
       bodyId: 'body-test',
       readyTimeoutMs: 30,
-      reconnectBaseDelayMs: 1000,
+      reconnectBaseDelayMs: 10,
+      reconnectMaxDelayMs: 10,
     });
     client.on('error', () => undefined);
     client.connect();
 
     await withTimeout(socketClosed);
+    await withTimeout(secondConnection);
+    assert.ok(connections >= 2);
     client.disconnect();
   });
 

--- a/tests/catscompany-client-body-id.test.ts
+++ b/tests/catscompany-client-body-id.test.ts
@@ -1,13 +1,16 @@
 import { afterEach, beforeEach, describe, test } from 'node:test';
 import * as assert from 'node:assert';
-import { createServer, type Server } from 'node:http';
+import { createServer, type Server as HttpServer } from 'node:http';
+import { createServer as createNetServer, type Server as NetServer, type Socket } from 'node:net';
 import type { AddressInfo } from 'node:net';
 import { WebSocketServer } from 'ws';
 import { CatsClient, type CatsDeviceRpcMessage } from '../src/catscompany/client';
 
 describe('CatsCompany client body identity', () => {
   const servers: WebSocketServer[] = [];
-  const httpServers: Server[] = [];
+  const httpServers: HttpServer[] = [];
+  const netServers: NetServer[] = [];
+  const netSockets: Socket[] = [];
   const identityEnvKeys = [
     'CATSCO_BODY_ID',
     'CATSCOMPANY_BODY_ID',
@@ -31,6 +34,12 @@ describe('CatsCompany client body identity', () => {
     for (const server of httpServers.splice(0)) {
       server.close();
     }
+    for (const socket of netSockets.splice(0)) {
+      socket.destroy();
+    }
+    for (const server of netServers.splice(0)) {
+      server.close();
+    }
     for (const key of identityEnvKeys) {
       if (originalEnv[key] === undefined) delete process.env[key];
       else process.env[key] = originalEnv[key];
@@ -40,6 +49,18 @@ describe('CatsCompany client body identity', () => {
   function clearIdentityEnv(): void {
     for (const key of identityEnvKeys) {
       delete process.env[key];
+    }
+  }
+
+  async function withTimeout<T>(promise: Promise<T>, timeoutMs = 1000): Promise<T> {
+    let timer: NodeJS.Timeout | undefined;
+    const timeout = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => reject(new Error(`Timed out after ${timeoutMs}ms`)), timeoutMs);
+    });
+    try {
+      return await Promise.race([promise, timeout]);
+    } finally {
+      if (timer) clearTimeout(timer);
     }
   }
 
@@ -81,6 +102,68 @@ describe('CatsCompany client body identity', () => {
     });
 
     assert.throws(() => client.connect(), /bodyId missing/);
+  });
+
+  test('retries when websocket upgrade handshake stalls', async () => {
+    let connections = 0;
+    const server = createNetServer(socket => {
+      connections++;
+      netSockets.push(socket);
+      socket.on('error', () => undefined);
+    });
+    netServers.push(server);
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+
+    const secondConnection = new Promise<void>(resolve => {
+      server.on('connection', () => {
+        if (connections >= 2) resolve();
+      });
+    });
+
+    const address = server.address() as AddressInfo;
+    const client = new CatsClient({
+      serverUrl: `ws://127.0.0.1:${address.port}`,
+      apiKey: 'cc-test-key',
+      bodyId: 'body-test',
+      connectTimeoutMs: 30,
+      reconnectBaseDelayMs: 10,
+      reconnectMaxDelayMs: 10,
+    });
+    client.on('error', () => undefined);
+
+    try {
+      client.connect();
+      await withTimeout(secondConnection);
+      assert.ok(connections >= 2);
+    } finally {
+      client.disconnect();
+    }
+  });
+
+  test('reconnects when CatsCompany ready handshake is not received', async () => {
+    const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    servers.push(server);
+    await new Promise<void>(resolve => server.once('listening', resolve));
+
+    const socketClosed = new Promise<void>(resolve => {
+      server.once('connection', socket => {
+        socket.once('close', () => resolve());
+      });
+    });
+
+    const address = server.address() as AddressInfo;
+    const client = new CatsClient({
+      serverUrl: `ws://127.0.0.1:${address.port}`,
+      apiKey: 'cc-test-key',
+      bodyId: 'body-test',
+      readyTimeoutMs: 30,
+      reconnectBaseDelayMs: 1000,
+    });
+    client.on('error', () => undefined);
+    client.connect();
+
+    await withTimeout(socketClosed);
+    client.disconnect();
   });
 
   test('includes local device registration in websocket hi', async () => {


### PR DESCRIPTION
## 背景
- 线上机器人在 CatsCompany/网络短抖后出现进程仍运行、设备能力心跳仍刷新，但 bot-body websocket 没有重新上线的问题。
- 现场 worker1/worker2 日志显示 13:44 心跳超时后进入重连，但只打印“正在连接”，没有后续“握手成功/关闭/错误”，连接卡在握手阶段。

## 改动
- CatsCompany websocket 客户端增加连接握手超时，CONNECTING 超时会主动 terminate 并进入重连。
- websocket 打开后增加 CatsCompany ready 握手确认超时，避免 socket OPEN 但服务端协议握手不完成时卡住。
- 记录并清理 reconnect timer，disconnect 时避免残留重连。
- 重连退避保持原默认策略：1s 起步，最多 30s；测试可注入短超时。

## 验证
- npx tsx --test tests/catscompany-client-body-id.test.ts
- npx tsx --test tests/catscompany-client-body-id.test.ts tests/catscompany-message-sender.test.ts tests/dashboard-catsco-auth-status.test.ts
- npm run build
- git diff --check

## 线上处置
- 已重启 worker1/worker2 的 catsco-agent，服务端已看到 uid=405/407 重新 client connected。
