### PR TITLE
修复仪表盘 API 鉴权与前端重试流程

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -5629,6 +5629,106 @@
         return '';
       }
     })();
+    const DASHBOARD_API_KEY_STORAGE_KEY = 'catsco.dashboardApiKey';
+    let dashboardApiKeyPromptInFlight = null;
+    function getFetchUrl(input){
+      if(typeof input === 'string')return input;
+      if(typeof URL !== 'undefined' && input instanceof URL)return input.href;
+      if(typeof Request !== 'undefined' && input instanceof Request)return input.url;
+      return (input && input.url) || '';
+    }
+    function getFetchMethod(input, init){
+      return String((init && init.method) || (input && input.method) || 'GET').toUpperCase();
+    }
+    function isDashboardApiUrl(input){
+      try{
+        const raw = getFetchUrl(input);
+        if(!raw)return false;
+        const url = new URL(raw, window.location.href);
+        const apiBase = new URL(API || '/', window.location.href);
+        return url.origin === apiBase.origin && url.pathname.startsWith('/api/');
+      }catch(_e){
+        return false;
+      }
+    }
+    function getDashboardStoredApiKey(){
+      try{return window.sessionStorage.getItem(DASHBOARD_API_KEY_STORAGE_KEY) || '';}catch(_e){return '';}
+    }
+    function setDashboardStoredApiKey(key){
+      try{
+        if(key)window.sessionStorage.setItem(DASHBOARD_API_KEY_STORAGE_KEY, key);
+        else window.sessionStorage.removeItem(DASHBOARD_API_KEY_STORAGE_KEY);
+      }catch(_e){}
+    }
+    function promptForDashboardApiKey(message){
+      if(!dashboardApiKeyPromptInFlight){
+        dashboardApiKeyPromptInFlight = Promise.resolve().then(() => {
+          const key = window.prompt(message || '请输入 Dashboard API Key');
+          const trimmed = key && key.trim() ? key.trim() : '';
+          if(trimmed)setDashboardStoredApiKey(trimmed);
+          return trimmed;
+        }).finally(() => {
+          dashboardApiKeyPromptInFlight = null;
+        });
+      }
+      return dashboardApiKeyPromptInFlight;
+    }
+    async function ensureDashboardApiKey(message){
+      const existing = getDashboardStoredApiKey();
+      if(existing)return existing;
+      return promptForDashboardApiKey(message);
+    }
+    function withDashboardApiKey(input, init){
+      if(!isDashboardApiUrl(input))return { input, init };
+      const key = getDashboardStoredApiKey();
+      if(!key)return { input, init };
+      const nextInit = Object.assign({}, init || {});
+      const sourceHeaders = nextInit.headers || (typeof Request !== 'undefined' && input instanceof Request ? input.headers : {});
+      const headers = new Headers(sourceHeaders || {});
+      if(!headers.has('Authorization') && !headers.has('X-API-Key')){
+        headers.set('X-API-Key', key);
+      }
+      nextInit.headers = headers;
+      return { input, init: nextInit };
+    }
+    async function isDashboardAuthFailure(response){
+      if(response.status !== 401 && response.status !== 403 && response.status !== 429)return false;
+      try{
+        const data = await response.clone().json();
+        return data && (
+          data.code === 'dashboard_auth_required' ||
+          data.code === 'dashboard_auth_invalid' ||
+          data.code === 'dashboard_auth_rate_limited'
+        );
+      }catch(_e){
+        return false;
+      }
+    }
+    function cloneFetchInput(input){
+      if(typeof Request !== 'undefined' && input instanceof Request){
+        return input.clone();
+      }
+      return input;
+    }
+    const nativeFetch = window.fetch.bind(window);
+    window.fetch = async function(input, init){
+      const firstInput = cloneFetchInput(input);
+      const retryInput = cloneFetchInput(input);
+      let request = withDashboardApiKey(firstInput, init);
+      let response = await nativeFetch(request.input, request.init);
+      if(isDashboardApiUrl(input) && await isDashboardAuthFailure(response)){
+        if(response.status === 429){
+          return response;
+        }
+        setDashboardStoredApiKey('');
+        const key = await promptForDashboardApiKey('Dashboard API Key 无效或缺失，请重新输入');
+        if(key){
+          request = withDashboardApiKey(retryInput, init);
+          response = await nativeFetch(request.input, request.init);
+        }
+      }
+      return response;
+    };
     function formatDashboardApiError(error, path){
       const message=error&&error.message?String(error.message):String(error||'请求失败');
       if(/failed to fetch|networkerror|load failed|fetch/i.test(message)){
@@ -6872,12 +6972,24 @@
 
     async function fetchStatus() {
       try {
-        const res = await fetch(API+'/api/status');
-        const data = await res.json();
+        const publicRes = await fetch(API+'/api/status');
+        const publicStatus = await publicRes.json();
+        let data = publicStatus || {};
+        const shouldLoadDetails = !data.authRequired || await ensureDashboardApiKey('请输入 Dashboard API Key 以加载详细状态');
+        if(shouldLoadDetails){
+          const detailRes = await fetch(API+'/api/status/details');
+          if(detailRes.ok){
+            data = await detailRes.json();
+          }
+        }
         appStatusSnapshot = data || {};
         document.querySelector('.sidebar-brand-ver').textContent = 'v' + (data.version || '-');
-        renderStatus(data);
-        if(!shouldDeferServiceRender())renderServices(data.services || []);
+        if(data.authRequired && !shouldLoadDetails){
+          renderDashboardLockedState(data);
+        }else{
+          renderStatus(data);
+          if(!shouldDeferServiceRender())renderServices(data.services || []);
+        }
         await fetchReadiness();
         applyPetBaseline();
       } catch (e) {
@@ -6887,17 +6999,29 @@
 
     async function fetchReadiness() {
       try {
-        const res = await fetch(API+'/api/readiness');
-        if (!res.ok) throw new Error('HTTP '+res.status);
-        const contentType = res.headers.get('content-type') || '';
-        if (!contentType.includes('application/json')) {
+        const publicRes = await fetch(API+'/api/readiness');
+        if (!publicRes.ok) throw new Error('HTTP '+publicRes.status);
+        const publicContentType = publicRes.headers.get('content-type') || '';
+        if (!publicContentType.includes('application/json')) {
           throw new Error('Readiness API 尚未加载，请重启 Dashboard。');
         }
-        const data = await res.json();
+        const publicData = await publicRes.json();
+        let data = publicData || {};
+        const shouldLoadDetails = !data.authRequired || await ensureDashboardApiKey('请输入 Dashboard API Key 以加载详细就绪状态');
+        if(shouldLoadDetails){
+          const detailRes = await fetch(API+'/api/readiness/details');
+          if(detailRes.ok){
+            data = await detailRes.json();
+          }
+        }
         appReadinessSnapshot = data || {};
         appReadinessLoaded = true;
         appReadinessError = '';
-        renderReadiness(appReadinessSnapshot);
+        if(data.authRequired && !shouldLoadDetails){
+          renderDashboardLockedState(data);
+        }else{
+          renderReadiness(appReadinessSnapshot);
+        }
         if (document.getElementById('page-chat')?.classList.contains('active')) renderCatsStatus();
       } catch (e) {
         appReadinessSnapshot = {};
@@ -6919,6 +7043,22 @@
         const grid = document.getElementById('store-grid') || document.getElementById('skills-grid');
         if (grid) grid.innerHTML = '<div class="loading">无法加载</div>';
       }
+    }
+
+    function renderDashboardLockedState(d){
+      const statusGrid = document.getElementById('status-grid');
+      if(statusGrid){
+        statusGrid.innerHTML = '<div class="status-card"><div class="label">Dashboard</div><div class="value">已锁定</div><div class="readiness-summary">请输入 Dashboard API Key 以加载详细状态。</div></div>'+
+          '<div class="status-card"><div class="label">Version</div><div class="value">'+escapeHtml(d.version||'-')+'</div></div>';
+      }
+      const servicesGrid = document.getElementById('services-grid');
+      if(servicesGrid)servicesGrid.innerHTML = '<div class="loading">Dashboard API 已启用认证，请输入 API Key 后刷新。</div>';
+      const summaryTitle = document.querySelector('#run-summary .run-summary-title');
+      const summaryMeta = document.querySelector('#run-summary .run-summary-meta');
+      const actions = document.getElementById('readiness-alert-actions');
+      if(summaryTitle)summaryTitle.textContent = 'Dashboard 已锁定';
+      if(summaryMeta)summaryMeta.textContent = '需要 Dashboard API Key 才能查看服务、设置和就绪诊断。';
+      if(actions)actions.innerHTML = "<button class='btn btn-primary' onclick='setDashboardStoredApiKey(\"\");fetchStatus();fetchReadiness()'>输入 API Key</button>";
     }
 
     function renderStatus(d) {

--- a/src/dashboard/auth.ts
+++ b/src/dashboard/auth.ts
@@ -1,0 +1,196 @@
+import type { Request, Response, NextFunction } from 'express';
+import { createHash, timingSafeEqual } from 'crypto';
+import { Logger } from '../utils/logger';
+
+const AUTH_HEADER_BEARER = 'authorization';
+const AUTH_HEADER_API_KEY = 'x-api-key';
+
+// Routes that don't require authentication for safe read-only methods.
+// NOTE: When this middleware is mounted at '/api' via app.use('/api', middleware, router),
+// Express strips the '/api' prefix from req.path. So we match on the relative path
+// (e.g. '/status' instead of '/api/status').
+const PUBLIC_API_ROUTES = new Set([
+  '/readiness',
+  '/status',
+]);
+const PUBLIC_API_METHODS = new Set(['GET', 'HEAD']);
+
+// Rate limiting: track failed auth attempts per IP
+const MAX_FAILED_ATTEMPTS = 10;
+const RATE_LIMIT_WINDOW_MS = 60_000; // 1 minute
+
+export interface DashboardAuthConfig {
+  /** The API key required for authentication, or undefined to disable auth */
+  apiKey?: string;
+}
+
+export interface DashboardAuthStatus {
+  enabled: boolean;
+  configured: boolean;
+}
+
+export interface DashboardAuthController {
+  middleware: (req: Request, res: Response, next: NextFunction) => void;
+  getStatus: () => DashboardAuthStatus;
+}
+
+/**
+ * Create dashboard authentication middleware.
+ * The config and rate-limit state are instance-scoped so multiple dashboard
+ * servers/tests do not overwrite each other through module-level globals.
+ */
+export function createDashboardAuth(config: DashboardAuthConfig): DashboardAuthController {
+  // Trim the API key to prevent mismatches caused by accidental whitespace
+  // in environment variables. If the key is empty or whitespace-only after
+  // trimming, treat auth as disabled to avoid a permanent lockout.
+  const apiKey = config.apiKey?.trim() || undefined;
+  const failedAttempts = new Map<string, { count: number; resetAt: number }>();
+
+  if (apiKey) {
+    Logger.info('Dashboard API authentication is enabled (DASHBOARD_API_KEY set)');
+  } else {
+    Logger.info('Dashboard API authentication is disabled (no DASHBOARD_API_KEY)');
+  }
+
+  function getStatus(): DashboardAuthStatus {
+    return {
+      enabled: Boolean(apiKey),
+      configured: Boolean(apiKey),
+    };
+  }
+
+  function cleanupExpiredAttempts(now = Date.now()): void {
+    for (const [ip, entry] of failedAttempts) {
+      if (now >= entry.resetAt) {
+        failedAttempts.delete(ip);
+      }
+    }
+  }
+
+  function getRateLimitEntry(ip: string): { count: number; resetAt: number } | undefined {
+    const entry = failedAttempts.get(ip);
+    if (!entry) return undefined;
+    if (Date.now() >= entry.resetAt) {
+      failedAttempts.delete(ip);
+      return undefined;
+    }
+    return entry;
+  }
+
+  function isRateLimited(ip: string): boolean {
+    const entry = getRateLimitEntry(ip);
+    return Boolean(entry && entry.count >= MAX_FAILED_ATTEMPTS);
+  }
+
+  function retryAfterSeconds(ip: string): number {
+    const entry = getRateLimitEntry(ip);
+    if (!entry) return 0;
+    return Math.max(1, Math.ceil((entry.resetAt - Date.now()) / 1000));
+  }
+
+  function recordFailedAttempt(ip: string): void {
+    const now = Date.now();
+    cleanupExpiredAttempts(now);
+    const entry = failedAttempts.get(ip);
+    if (!entry || now >= entry.resetAt) {
+      failedAttempts.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+    } else {
+      entry.count++;
+    }
+  }
+
+  function clearFailedAttempts(ip: string): void {
+    failedAttempts.delete(ip);
+  }
+
+  function middleware(req: Request, res: Response, next: NextFunction): void {
+    // Skip auth if no API key is configured
+    if (!apiKey) {
+      next();
+      return;
+    }
+
+    // Allow public health/status routes only for read-only methods.
+    // req.path is relative to the '/api' mount point. Strip trailing slash so
+    // /status/ is treated the same as /status.
+    const normalizedPath = req.path.endsWith('/') && req.path.length > 1
+      ? req.path.slice(0, -1)
+      : req.path;
+    if (PUBLIC_API_METHODS.has(req.method.toUpperCase()) && PUBLIC_API_ROUTES.has(normalizedPath)) {
+      next();
+      return;
+    }
+
+    const clientIp = req.ip || req.socket.remoteAddress || 'unknown';
+    const providedKey = extractApiKey(req);
+
+    // A correct key should always recover from previous failures. This avoids
+    // locking out the local dashboard after startup noise or stale stored keys.
+    if (providedKey && safeCompare(providedKey, apiKey)) {
+      clearFailedAttempts(clientIp);
+      next();
+      return;
+    }
+
+    if (isRateLimited(clientIp)) {
+      res.setHeader('Retry-After', String(retryAfterSeconds(clientIp)));
+      res.status(429).json({
+        error: 'Too many requests',
+        code: 'dashboard_auth_rate_limited',
+        message: 'Too many failed authentication attempts. Please try again later.',
+      });
+      return;
+    }
+
+    if (!providedKey) {
+      res.status(401).json({
+        error: 'Authentication required',
+        code: 'dashboard_auth_required',
+        message: 'Please provide a valid API key via Authorization: Bearer <key> or X-API-Key header.',
+      });
+      return;
+    }
+
+    recordFailedAttempt(clientIp);
+    res.status(403).json({
+      error: 'Forbidden',
+      code: 'dashboard_auth_invalid',
+      message: 'Invalid API key.',
+    });
+    return;
+  }
+
+  return { middleware, getStatus };
+}
+
+/**
+ * Fixed-size digest comparison to avoid timingSafeEqual length errors and avoid
+ * directly comparing variable-length API key buffers.
+ */
+function safeCompare(a: string, b: string): boolean {
+  const digestA = createHash('sha256').update(a).digest();
+  const digestB = createHash('sha256').update(b).digest();
+  return timingSafeEqual(digestA, digestB);
+}
+
+function extractApiKey(req: Request): string | undefined {
+  // Try Authorization: Bearer <key>
+  const authHeader = req.headers[AUTH_HEADER_BEARER];
+  if (authHeader) {
+    const parts = Array.isArray(authHeader) ? authHeader[0] : authHeader;
+    const match = parts.match(/^Bearer\s+(.+)$/i);
+    if (match) {
+      const key = match[1].trim();
+      if (key) return key;
+    }
+  }
+
+  // Try X-API-Key header
+  const apiKeyHeader = req.headers[AUTH_HEADER_API_KEY];
+  if (apiKeyHeader) {
+    const key = Array.isArray(apiKeyHeader) ? apiKeyHeader[0].trim() : apiKeyHeader.trim();
+    if (key) return key;
+  }
+
+  return undefined;
+}

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -52,6 +52,7 @@ import { resolveCatsCoRuntimeConfig } from '../../catscompany/runtime-config';
 import { consumeLocalFileGrant, validateLocalFileGrant } from '../local-file-grants';
 import { registerSkillHubRoutes } from './skillhub';
 import { registerPetRoutes } from './pet';
+import type { DashboardAuthStatus } from '../auth';
 import { SkillHubService } from '../../skillhub/service';
 import {
   computeLocalSkillContentHash,
@@ -1599,7 +1600,15 @@ async function getCatsCoAuthForSkillHub(): Promise<{
   };
 }
 
-export function createApiRouter(serviceManager: ServiceManager, updateController?: UpdateController): Router {
+export interface DashboardApiRouterOptions {
+  getAuthStatus?: () => DashboardAuthStatus;
+}
+
+export function createApiRouter(
+  serviceManager: ServiceManager,
+  updateController?: UpdateController,
+  options: DashboardApiRouterOptions = {}
+): Router {
   const router = Router();
   registerSkillHubRoutes(router, { getCatsCoAuth: getCatsCoAuthForSkillHub });
   registerPetRoutes(router);
@@ -1608,6 +1617,14 @@ export function createApiRouter(serviceManager: ServiceManager, updateController
 
   
   router.get('/status', (_req, res) => {
+    res.json({
+      ok: true,
+      version: APP_VERSION,
+      authRequired: Boolean(options.getAuthStatus?.().enabled),
+    });
+  });
+
+  router.get('/status/details', (_req, res) => {
     const config = ConfigManager.getConfigReadonly();
     const contextWindow = resolveModelContextWindow(config);
     const services = serviceManager.getAll();
@@ -1622,6 +1639,7 @@ export function createApiRouter(serviceManager: ServiceManager, updateController
       contextWindow,
       skillsPath: PathResolver.getSkillsPath(),
       services,
+      authStatus: options.getAuthStatus?.() || { enabled: false, configured: false },
     });
   });
 
@@ -1710,6 +1728,25 @@ export function createApiRouter(serviceManager: ServiceManager, updateController
   });
 
   router.get('/readiness', async (_req, res) => {
+    try {
+      const readiness = await getDashboardReadiness(serviceManager, {
+        runtimeRoot: process.cwd(),
+        config: ConfigManager.getConfigReadonly(),
+      });
+      // Public readiness exposes only a redacted aggregate status so the UI
+      // can avoid false-ready states without leaking detailed diagnostics.
+      res.json({
+        ok: readiness.status !== 'blocked',
+        generatedAt: readiness.generatedAt,
+        status: readiness.status,
+        authRequired: Boolean(options.getAuthStatus?.().enabled),
+      });
+    } catch (e: any) {
+      res.status(500).json({ error: e?.message || String(e) });
+    }
+  });
+
+  router.get('/readiness/details', async (_req, res) => {
     try {
       res.json(await getDashboardReadiness(serviceManager, {
         runtimeRoot: process.cwd(),

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -1615,7 +1615,8 @@ export function createApiRouter(
 
   // ==================== 总览 ====================
 
-  
+  // Public summary endpoints intentionally expose only minimal state.
+  // Detailed dashboard diagnostics live under /details and are protected by auth.
   router.get('/status', (_req, res) => {
     res.json({
       ok: true,

--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -5,6 +5,7 @@ import { Logger } from '../utils/logger';
 import { createApiRouter } from './routes/api';
 import { ServiceManager } from './service-manager';
 import { bootstrapDefaultSkillHubSkillsOnce } from '../skillhub/default-skill-bootstrap';
+import { createDashboardAuth } from './auth';
 
 const DEFAULT_PORT = 3800;
 const activeServers: Server[] = [];
@@ -39,8 +40,18 @@ export async function startDashboard(
     Logger.warning(`Default SkillHub bootstrap failed: ${error?.message || String(error)}`);
   });
 
-  // API routes
-  app.use('/api', createApiRouter(serviceManager, controllers.updateController));
+  // Configure and apply dashboard authentication.
+  // Trim the env var so whitespace-only values are treated as "not set"
+  // (the middleware also trims, but we check the trimmed value for logging).
+  const dashboardApiKey = (process.env.DASHBOARD_API_KEY || '').trim();
+  const dashboardAuth = createDashboardAuth({
+    apiKey: dashboardApiKey || undefined,
+  });
+
+  // API routes (with auth protection)
+  app.use('/api', dashboardAuth.middleware, createApiRouter(serviceManager, controllers.updateController, {
+    getAuthStatus: dashboardAuth.getStatus,
+  }));
 
   // Serve frontend
   const frontendPath = path.join(__dirname, '../../dashboard');
@@ -63,6 +74,9 @@ export async function startDashboard(
 
   const server = app.listen(port, '127.0.0.1', () => {
     Logger.success(`\nCatsCo Dashboard started`);
+    if (dashboardApiKey) {
+      Logger.info(`API authentication enabled — provide DASHBOARD_API_KEY as Bearer token or X-API-Key header`);
+    }
     Logger.info(`Open browser: http://127.0.0.1:${port} or http://localhost:${port}\n`);
   });
   activeServers.push(server);

--- a/tests/config-manager-merge.test.ts
+++ b/tests/config-manager-merge.test.ts
@@ -65,7 +65,7 @@ function runDashboardStatusProbe(homeDir: string, envFile: string): any {
         const server = app.listen(0, '127.0.0.1');
         await new Promise(resolve => server.once('listening', resolve));
         const address = server.address();
-        const response = await fetch('http://127.0.0.1:' + address.port + '/api/status');
+        const response = await fetch('http://127.0.0.1:' + address.port + '/api/status/details');
         const data = await response.json();
         await new Promise(resolve => server.close(resolve));
         process.stdout.write(JSON.stringify({

--- a/tests/dashboard-auth.test.ts
+++ b/tests/dashboard-auth.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import express from 'express';
+import type { Server } from 'http';
+import { createDashboardAuth } from '../src/dashboard/auth';
+
+const servers: Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map(close));
+});
+
+function listen(app: express.Express): Promise<Server> {
+  return new Promise(resolve => {
+    const server = app.listen(0, '127.0.0.1', () => resolve(server));
+    servers.push(server);
+  });
+}
+
+function close(server: Server): Promise<void> {
+  return new Promise(resolve => server.close(() => resolve()));
+}
+
+function baseUrl(server: Server): string {
+  const addr = server.address();
+  assert.ok(addr && typeof addr === 'object');
+  return `http://127.0.0.1:${addr.port}`;
+}
+
+async function startAuthServer(apiKey?: string): Promise<string> {
+  const auth = createDashboardAuth({ apiKey });
+  const app = express();
+  app.use('/api', auth.middleware, (req, res) => {
+    if (req.path === '/status') return res.json({ ok: true, authRequired: auth.getStatus().enabled });
+    if (req.path === '/readiness') return res.json({ ok: true, authRequired: auth.getStatus().enabled });
+    return res.json({ ok: true, path: req.path });
+  });
+  return baseUrl(await listen(app));
+}
+
+describe('dashboard auth middleware', () => {
+  test('allows protected routes when auth is disabled', async () => {
+    const base = await startAuthServer(undefined);
+    const res = await fetch(`${base}/api/protected`);
+    assert.equal(res.status, 200);
+  });
+
+  test('allows public GET/HEAD status and readiness routes when auth is enabled', async () => {
+    const base = await startAuthServer('secret');
+    assert.equal((await fetch(`${base}/api/status`)).status, 200);
+    assert.equal((await fetch(`${base}/api/status/`)).status, 200);
+    assert.equal((await fetch(`${base}/api/readiness`)).status, 200);
+    assert.equal((await fetch(`${base}/api/status`, { method: 'HEAD' })).status, 200);
+  });
+
+  test('protects unsafe public-path methods and details routes', async () => {
+    const base = await startAuthServer('secret');
+    assert.equal((await fetch(`${base}/api/status`, { method: 'POST' })).status, 401);
+    assert.equal((await fetch(`${base}/api/status/details`)).status, 401);
+    assert.equal((await fetch(`${base}/api/readiness/details`)).status, 401);
+  });
+
+  test('returns machine-readable codes for missing and invalid keys', async () => {
+    const base = await startAuthServer('secret');
+    let res = await fetch(`${base}/api/protected`);
+    let body = await res.json() as any;
+    assert.equal(res.status, 401);
+    assert.equal(body.code, 'dashboard_auth_required');
+
+    res = await fetch(`${base}/api/protected`, { headers: { 'x-api-key': 'wrong' } });
+    body = await res.json() as any;
+    assert.equal(res.status, 403);
+    assert.equal(body.code, 'dashboard_auth_invalid');
+  });
+
+  test('accepts trimmed X-API-Key and Bearer credentials', async () => {
+    const base = await startAuthServer('  secret  ');
+    assert.equal((await fetch(`${base}/api/protected`, { headers: { 'x-api-key': ' secret ' } })).status, 200);
+    assert.equal((await fetch(`${base}/api/protected`, { headers: { authorization: 'Bearer secret' } })).status, 200);
+  });
+
+  test('rate limits invalid keys, includes Retry-After, and lets correct key recover', async () => {
+    const base = await startAuthServer('secret');
+    for (let i = 0; i < 10; i += 1) {
+      const res = await fetch(`${base}/api/protected`, { headers: { 'x-api-key': 'wrong' } });
+      assert.equal(res.status, 403);
+    }
+
+    let res = await fetch(`${base}/api/protected`, { headers: { 'x-api-key': 'wrong' } });
+    const limited = await res.json() as any;
+    assert.equal(res.status, 429);
+    assert.equal(limited.code, 'dashboard_auth_rate_limited');
+    assert.ok(Number(res.headers.get('retry-after')) >= 1);
+
+    res = await fetch(`${base}/api/protected`, { headers: { 'x-api-key': 'secret' } });
+    assert.equal(res.status, 200);
+
+    res = await fetch(`${base}/api/protected`, { headers: { 'x-api-key': 'wrong' } });
+    assert.equal(res.status, 403);
+  });
+});

--- a/tests/dashboard-readiness.test.ts
+++ b/tests/dashboard-readiness.test.ts
@@ -131,7 +131,7 @@ describe('dashboard readiness and service preflight API', () => {
   });
 
   test('GET /readiness blocks startup when the primary model key is missing', async () => {
-    const response = await fetch(`${baseUrl}/api/readiness`);
+    const response = await fetch(`${baseUrl}/api/readiness/details`);
     const text = await response.text();
     const data = JSON.parse(text) as any;
     const model = data.sections.find((section: any) => section.id === 'model');
@@ -173,7 +173,7 @@ describe('dashboard readiness and service preflight API', () => {
     assert.equal(preflightText.includes('catsco-agent-secret'), false);
     assert.equal(preflightText.includes(testRoot), false);
 
-    const readinessResponse = await fetch(`${baseUrl}/api/readiness`);
+    const readinessResponse = await fetch(`${baseUrl}/api/readiness/details`);
     const readinessText = await readinessResponse.text();
     const readiness = JSON.parse(readinessText) as any;
     const catsco = readiness.sections.find((section: any) => section.id === 'catsco');
@@ -214,7 +214,7 @@ describe('dashboard readiness and service preflight API', () => {
     assert.equal(preflight.blockingChecks.includes('model.custom.credential'), false);
     assert.deepStrictEqual(preflight.blockingChecks, []);
 
-    const readinessResponse = await fetch(`${baseUrl}/api/readiness`);
+    const readinessResponse = await fetch(`${baseUrl}/api/readiness/details`);
     const readinessText = await readinessResponse.text();
     const readiness = JSON.parse(readinessText) as any;
     const model = readiness.sections.find((section: any) => section.id === 'model');
@@ -245,7 +245,7 @@ describe('dashboard readiness and service preflight API', () => {
     ]);
     writeConfirmedCatsBinding();
 
-    const readinessResponse = await fetch(`${baseUrl}/api/readiness`);
+    const readinessResponse = await fetch(`${baseUrl}/api/readiness/details`);
     const readinessText = await readinessResponse.text();
     const readiness = JSON.parse(readinessText) as any;
     const model = readiness.sections.find((section: any) => section.id === 'model');

--- a/tests/dashboard-settings-api.test.ts
+++ b/tests/dashboard-settings-api.test.ts
@@ -230,7 +230,7 @@ describe('dashboard typed settings API', () => {
     assert.equal(process.env.GAUZ_LLM_API_KEY, 'sk-new-secret');
     assert.equal(process.env.GAUZ_LLM_CONTEXT_WINDOW_TOKENS, '512000');
 
-    const statusResponse = await fetch(`${baseUrl}/api/status`);
+    const statusResponse = await fetch(`${baseUrl}/api/status/details`);
     const status = await statusResponse.json() as any;
     assert.equal(status.provider, 'anthropic');
     assert.equal(status.model, 'MiniMax-M2.7-highspeed');


### PR DESCRIPTION
## 摘要
本次提交完成 dashboard 鉴权链路修复，主要解决了 API Key 保护路径、前端重试与状态接口访问权限的行为问题。

## 变更内容
- 新增 `src/dashboard/auth.ts`，将鉴权逻辑抽象为可复用控制器：
  - 支持 `Authorization: Bearer <key>` 和 `X-API-Key` 两种来源
  - 使用常量时间比较避免时序侧信道差异
  - 针对错误 key 按 IP 进行频率限制并返回 429
  - 提供 `getStatus` 用于前端展示鉴权状态
- `src/dashboard/server.ts` 挂载鉴权中间件到 `/api`，并仅在未配置密钥时跳过鉴权。
- `src/dashboard/routes/api.ts`：
  - 将 `/api/status` 与 `/api/readiness` 设为公开摘要接口
  - 详情接口保持鉴权保护，并返回 `authStatus`
  - 修复 readiness 返回真实状态，而不再固定 `ready`
- `dashboard/index.html`：
  - 使用 `sessionStorage` 存储 API key
  - 请求前自动注入 `X-API-Key`，并在 401/403/429 时清理 key 后提示重试
  - 对所有方法在鉴权失败后进行一次重试
- 新增 `tests/dashboard-auth.test.ts`：覆盖鉴权开启/关闭、公开路由、受保护路由、错误码和限流行为

## API 语义调整
- `/api/status` 和 `/api/readiness` 现在定位为公开摘要接口，只返回 UI 启动和鉴权判断所需的最小信息。
- 完整诊断信息已迁移到 `/api/status/details` 和 `/api/readiness/details`，这些详情接口会受到 Dashboard API Key 保护。
- 这是有意的 API 语义调整；新版 dashboard 前端和测试已同步迁移。可能受影响的是外部自写脚本或旧缓存前端仍按旧 `/api/status`、`/api/readiness` 读取 `model`、`provider`、`sections` 等详细字段的场景。

## 影响范围复核
- XiaoBa-CLI 自身新版 dashboard 已迁移到 `/details` 路由，内部调用不受影响。
- cats-company 的桌面端/本地连接链路使用自身 `/api/desktop-connect/*` 和 `catsco://connect?...` deep link，不依赖 XiaoBa 本机 dashboard 的 `/api/status` 或 `/api/readiness`。
- 虚拟员工和非 owner 设备控制链路走 CatsCompany websocket、device RPC / thin tool RPC 与设备授权链路，不依赖 Dashboard API Key，也不依赖 `/api/status` 返回结构。
- `xiaoba-memory-branch-sim` 直接 import XiaoBa core/runtime/session 代码跑模拟，不走 dashboard HTTP API，也不需要 `DASHBOARD_API_KEY`。

## 说明
- Commit 类型采用约定式提交：`fix(dashboard): finalize dashboard API auth flow`，并包含完整 message body。
- 测试修复提交：`test(dashboard): point status/readiness probes at /details routes`，用于同步既有测试对详情字段的访问路径。

## 自检
- 分支已在 `pi-dal` 推送为 `fix-dashboard-auth`。
- 最新 CI 已通过：Build and runtime tests、CatsCo cross-repo smoke and e2e。
