### PR TITLE
#1 add log-cursor based distillation unit extraction

### DIFF
--- a/src/utils/distillation-unit.ts
+++ b/src/utils/distillation-unit.ts
@@ -1,0 +1,258 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  isSessionTurnEntry,
+  ParsedSessionLogEntry,
+  SessionTurnLogEntry,
+  LegacySessionTurnLogEntry,
+} from './session-log-schema';
+import {
+  advanceCursor,
+  getCursor,
+  loadLogCursorState,
+  LogCursorEntry,
+  LogCursorState,
+  markCursorFailed,
+  saveLogCursorState,
+} from './log-cursor-state';
+
+/**
+ * Distillation Unit extraction for append-only session logs.
+ *
+ * A Distillation Unit is a chunk of one session log file made from newly
+ * appended completed turns plus continuity context (up to ten prior completed
+ * turns from the same file), processed independently by the distiller.
+ *
+ * See CONTEXT.md → "Distillation Unit", "Continuity Context", "Log Cursor".
+ */
+
+export const MAX_CONTINUITY_TURNS = 10;
+
+export type CompletedTurn = SessionTurnLogEntry | LegacySessionTurnLogEntry;
+
+export interface DistillationUnit {
+  /** Session log file this unit was extracted from. */
+  filePath: string;
+  /** Newly appended completed turns not yet processed. */
+  newTurns: CompletedTurn[];
+  /** Up to MAX_CONTINUITY_TURNS prior completed turns from the same file. */
+  continuityTurns: CompletedTurn[];
+  /** Byte range of the newly processed content in the source file. */
+  byteRange: { start: number; end: number };
+  /** ISO timestamp of unit creation. */
+  generatedAt: string;
+}
+
+export interface ExtractionResult {
+  /** The produced Distillation Unit, or null when no new completed turns. */
+  distillationUnit: DistillationUnit | null;
+  /** The cursor after this extraction (caller persists on success). */
+  newCursor: LogCursorEntry;
+  /** Whether the cursor advanced past previously unprocessed content. */
+  advanced: boolean;
+}
+
+export interface ProcessSessionLogResult {
+  distillationUnit: DistillationUnit | null;
+  advanced: boolean;
+  processed: boolean;
+}
+
+/**
+ * Extract a Distillation Unit from a single session log file given the
+ * current cursor position.
+ *
+ * This is a pure function — it does not persist state. The caller is
+ * responsible for saving the returned cursor only after successful processing.
+ */
+export function extractDistillationUnit(
+  filePath: string,
+  cursor: LogCursorEntry,
+): ExtractionResult {
+  const buffer = fs.readFileSync(filePath);
+  const fileSize = buffer.length;
+
+  // No new bytes beyond the cursor → idempotent, no duplicate DU.
+  if (fileSize <= cursor.byteOffset) {
+    return {
+      distillationUnit: null,
+      newCursor: { ...cursor, status: 'completed' },
+      advanced: false,
+    };
+  }
+
+  const newBuffer = buffer.subarray(cursor.byteOffset);
+
+  // Only process up to the last complete line (ending with \n).
+  // Partial content at the tail will be retried on the next run.
+  const lastNewline = newBuffer.lastIndexOf(0x0a); // '\n'
+  const completeBytes = lastNewline === -1 ? 0 : lastNewline + 1;
+
+  if (completeBytes === 0) {
+    // No complete lines yet — don't advance, don't produce a DU.
+    return {
+      distillationUnit: null,
+      newCursor: cursor,
+      advanced: false,
+    };
+  }
+
+  const newContent = newBuffer.subarray(0, completeBytes).toString('utf-8');
+  const newEntries = parseLines(newContent);
+  const newTurns = newEntries.filter(isSessionTurnEntry);
+
+  const advancedOffset = cursor.byteOffset + completeBytes;
+
+  // New non-turn content (runtime, prompt_trace, etc.) advances the cursor
+  // but does not produce a Distillation Unit.
+  if (newTurns.length === 0) {
+    return {
+      distillationUnit: null,
+      newCursor: {
+        filePath,
+        byteOffset: advancedOffset,
+        processedTurnCount: cursor.processedTurnCount,
+        updatedAt: new Date().toISOString(),
+        status: 'completed',
+      },
+      advanced: true,
+    };
+  }
+
+  // Continuity context: up to MAX_CONTINUITY_TURNS prior completed turns.
+  const priorBuffer = buffer.subarray(0, cursor.byteOffset);
+  const priorContent = priorBuffer.toString('utf-8');
+  const priorEntries = parseLines(priorContent);
+  const priorTurns = priorEntries.filter(isSessionTurnEntry);
+  const continuityTurns = priorTurns.slice(-MAX_CONTINUITY_TURNS);
+
+  const distillationUnit: DistillationUnit = {
+    filePath,
+    newTurns,
+    continuityTurns,
+    byteRange: { start: cursor.byteOffset, end: advancedOffset },
+    generatedAt: new Date().toISOString(),
+  };
+
+  return {
+    distillationUnit,
+    newCursor: {
+      filePath,
+      byteOffset: advancedOffset,
+      processedTurnCount: cursor.processedTurnCount + newTurns.length,
+      updatedAt: new Date().toISOString(),
+      status: 'completed',
+    },
+    advanced: true,
+  };
+}
+
+/**
+ * Full processing flow for one session log file.
+ *
+ * Loads cursor state, extracts the Distillation Unit, invokes the processor,
+ * and durably persists the cursor only after the processor succeeds.
+ *
+ * If the processor throws, the cursor stays at its original byte offset
+ * (retryable) while the original log file is untouched (evidence preserved).
+ *
+ * @param filePath    Path to the append-only session log file.
+ * @param stateFilePath  Path to the cursor state JSON file.
+ * @param processor   Callback invoked with the Distillation Unit when one is
+ *                    produced. If it throws, the cursor is not advanced.
+ * @returns The Distillation Unit (if produced) and whether the cursor advanced.
+ */
+export function processSessionLog(
+  filePath: string,
+  stateFilePath: string,
+  processor: (unit: DistillationUnit) => void,
+): ProcessSessionLogResult {
+  const state = loadLogCursorState(stateFilePath);
+  const cursor = getCursor(state, filePath);
+
+  let result: ExtractionResult;
+  try {
+    result = extractDistillationUnit(filePath, cursor);
+  } catch (error) {
+    markCursorFailed(state, filePath, cursor.byteOffset, error);
+    saveLogCursorState(stateFilePath, state);
+    return { distillationUnit: null, advanced: false, processed: false };
+  }
+
+  if (result.distillationUnit) {
+    try {
+      processor(result.distillationUnit);
+      advanceCursor(state, result.newCursor);
+      saveLogCursorState(stateFilePath, state);
+      return {
+        distillationUnit: result.distillationUnit,
+        advanced: true,
+        processed: true,
+      };
+    } catch (error) {
+      // Processing failed — mark failed but preserve original byte offset
+      // for retry. The log file (evidence) is never modified.
+      markCursorFailed(state, filePath, cursor.byteOffset, error);
+      saveLogCursorState(stateFilePath, state);
+      return {
+        distillationUnit: result.distillationUnit,
+        advanced: false,
+        processed: false,
+      };
+    }
+  }
+
+  // No Distillation Unit produced. Advance the cursor if new non-turn
+  // content was seen, but don't invoke the processor.
+  if (result.advanced) {
+    advanceCursor(state, result.newCursor);
+    saveLogCursorState(stateFilePath, state);
+  }
+
+  return { distillationUnit: null, advanced: result.advanced, processed: false };
+}
+
+/**
+ * Process all session log files found under a directory tree.
+ *
+ * Each file is processed independently via {@link processSessionLog}.
+ */
+export function processSessionLogDirectory(
+  logDir: string,
+  stateFilePath: string,
+  processor: (unit: DistillationUnit) => void,
+): { units: DistillationUnit[]; advancedFiles: number } {
+  const files = collectJsonlFiles(logDir);
+  const units: DistillationUnit[] = [];
+  let advancedFiles = 0;
+
+  for (const filePath of files) {
+    const result = processSessionLog(filePath, stateFilePath, processor);
+    if (result.processed && result.distillationUnit) units.push(result.distillationUnit);
+    if (result.advanced) advancedFiles++;
+  }
+
+  return { units, advancedFiles };
+}
+
+function collectJsonlFiles(dir: string): string[] {
+  if (!fs.existsSync(dir)) return [];
+  const results: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...collectJsonlFiles(fullPath));
+    } else if (entry.isFile() && entry.name.endsWith('.jsonl')) {
+      results.push(fullPath);
+    }
+  }
+  return results.sort();
+}
+
+function parseLines(content: string): ParsedSessionLogEntry[] {
+  return content
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(Boolean)
+    .map(line => JSON.parse(line) as ParsedSessionLogEntry);
+}

--- a/src/utils/log-cursor-state.ts
+++ b/src/utils/log-cursor-state.ts
@@ -1,0 +1,138 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Per-session-log Log Cursor state.
+ *
+ * The Log Cursor records how far the heartbeat log distillation agent has
+ * processed an append-only log file. Advancement is durable and keyed by byte
+ * offset — it does not depend on last-processed date alone.
+ *
+ * See CONTEXT.md → "Log Cursor".
+ */
+
+export interface LogCursorEntry {
+  /** Absolute or relative path of the session log file this cursor tracks. */
+  filePath: string;
+  /** Byte offset up to which the file has been fully processed. */
+  byteOffset: number;
+  /** Number of completed turns already processed from this file. */
+  processedTurnCount: number;
+  /** ISO timestamp of the last cursor advancement (metadata only). */
+  updatedAt: string;
+  /** Processing status for retryable-state tracking. */
+  status: 'pending' | 'completed' | 'failed';
+  /** Last error message when status === 'failed'. */
+  lastError?: string;
+}
+
+export interface LogCursorState {
+  schemaVersion: 1;
+  /** Map of file path → cursor entry. */
+  cursors: Record<string, LogCursorEntry>;
+  /** Set when the state file was corrupt and quarantined on load. */
+  stateCorrupt?: boolean;
+}
+
+export function emptyLogCursorState(): LogCursorState {
+  return { schemaVersion: 1, cursors: {} };
+}
+
+export function loadLogCursorState(stateFilePath: string): LogCursorState {
+  try {
+    if (!fs.existsSync(stateFilePath)) {
+      return emptyLogCursorState();
+    }
+    const parsed = JSON.parse(
+      fs.readFileSync(stateFilePath, 'utf-8'),
+    ) as Partial<LogCursorState>;
+    return {
+      schemaVersion: 1,
+      cursors: parsed.cursors || {},
+    };
+  } catch {
+    quarantineCorruptState(stateFilePath);
+    return { ...emptyLogCursorState(), stateCorrupt: true };
+  }
+}
+
+/**
+ * Atomically persist cursor state. Uses temp-file + rename for durability.
+ */
+export function saveLogCursorState(
+  stateFilePath: string,
+  state: LogCursorState,
+): void {
+  fs.mkdirSync(path.dirname(stateFilePath), { recursive: true });
+  const payload: LogCursorState = {
+    schemaVersion: 1,
+    cursors: state.cursors || {},
+  };
+  const tmpPath = `${stateFilePath}.${process.pid}.${Date.now()}.tmp`;
+  fs.writeFileSync(tmpPath, JSON.stringify(payload, null, 2), {
+    encoding: 'utf-8',
+    mode: 0o600,
+  });
+  fs.renameSync(tmpPath, stateFilePath);
+}
+
+/**
+ * Returns the cursor for a given file, creating a fresh one at byteOffset 0
+ * when none exists yet.
+ */
+export function getCursor(
+  state: LogCursorState,
+  filePath: string,
+): LogCursorEntry {
+  return (
+    state.cursors[filePath] ?? {
+      filePath,
+      byteOffset: 0,
+      processedTurnCount: 0,
+      updatedAt: '',
+      status: 'pending',
+    }
+  );
+}
+
+/**
+ * Updates a cursor entry in the state, marking it completed.
+ */
+export function advanceCursor(
+  state: LogCursorState,
+  entry: LogCursorEntry,
+): void {
+  state.cursors[entry.filePath] = entry;
+}
+
+/**
+ * Marks a cursor as failed while preserving the original byte offset so the
+ * next run can retry without losing evidence.
+ */
+export function markCursorFailed(
+  state: LogCursorState,
+  filePath: string,
+  byteOffset: number,
+  error: unknown,
+): LogCursorEntry {
+  const entry: LogCursorEntry = {
+    filePath,
+    byteOffset,
+    processedTurnCount: state.cursors[filePath]?.processedTurnCount ?? 0,
+    updatedAt: new Date().toISOString(),
+    status: 'failed',
+    lastError: String(error),
+  };
+  state.cursors[filePath] = entry;
+  return entry;
+}
+
+function quarantineCorruptState(stateFilePath: string): void {
+  try {
+    if (!fs.existsSync(stateFilePath)) return;
+    const corruptPath = `${stateFilePath}.corrupt.${Date.now()}`;
+    fs.renameSync(stateFilePath, corruptPath);
+  } catch {
+    // Best-effort quarantine only.
+  }
+}

--- a/tests/log-cursor-distillation.test.ts
+++ b/tests/log-cursor-distillation.test.ts
@@ -1,0 +1,522 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  DistillationUnit,
+  MAX_CONTINUITY_TURNS,
+  extractDistillationUnit,
+  processSessionLog,
+  processSessionLogDirectory,
+} from '../src/utils/distillation-unit';
+import {
+  loadLogCursorState,
+  saveLogCursorState,
+  getCursor,
+} from '../src/utils/log-cursor-state';
+import { SessionTurnLogEntry } from '../src/utils/session-log-schema';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTurn(turn: number, session_id: string, session_type: string): SessionTurnLogEntry {
+  return {
+    entry_type: 'turn',
+    turn,
+    timestamp: new Date(2026, 0, 1, 0, 0, 0, turn * 1000).toISOString(),
+    session_id,
+    session_type,
+    user: { text: `user input ${turn}` },
+    assistant: { text: `assistant reply ${turn}`, tool_calls: [] },
+    tokens: { prompt: 10, completion: 20 },
+  };
+}
+
+function makeRuntimeEntry(session_id: string, session_type: string) {
+  return {
+    entry_type: 'runtime',
+    timestamp: new Date().toISOString(),
+    session_id,
+    session_type,
+    level: 'info',
+    message: 'runtime event',
+  };
+}
+
+function writeLog(filePath: string, entries: object[]): void {
+  const content = entries.map(e => JSON.stringify(e)).join('\n') + '\n';
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, 'utf-8');
+}
+
+function appendLog(filePath: string, entries: object[]): void {
+  const content = entries.map(e => JSON.stringify(e)).join('\n') + '\n';
+  fs.appendFileSync(filePath, content, 'utf-8');
+}
+
+function setup(): { root: string; logFile: string; stateFile: string; teardown: () => void } {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-log-cursor-'));
+  const logFile = path.join(root, 'logs', 'sessions', 'chat', '2026-07-08', 'chat_cli.jsonl');
+  const stateFile = path.join(root, 'data', 'log-cursor-state.json');
+  fs.mkdirSync(path.dirname(stateFile), { recursive: true });
+
+  return {
+    root,
+    logFile,
+    stateFile,
+    teardown: () => fs.rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Log Cursor based Distillation Unit extraction', () => {
+  describe('initial extraction', () => {
+    test('produces a Distillation Unit with all turns when cursor starts at zero', () => {
+      const env = setup();
+      try {
+        const turns = [
+          makeTurn(1, 'cli', 'chat'),
+          makeTurn(2, 'cli', 'chat'),
+          makeTurn(3, 'cli', 'chat'),
+        ];
+        writeLog(env.logFile, turns);
+
+        const state = loadLogCursorState(env.stateFile);
+        const cursor = getCursor(state, env.logFile);
+        assert.equal(cursor.byteOffset, 0);
+        assert.equal(cursor.status, 'pending');
+
+        const result = extractDistillationUnit(env.logFile, cursor);
+
+        assert.ok(result.distillationUnit);
+        assert.equal(result.distillationUnit!.newTurns.length, 3);
+        // No prior turns → empty continuity context
+        assert.equal(result.distillationUnit!.continuityTurns.length, 0);
+        assert.equal(result.advanced, true);
+        assert.equal(result.newCursor.byteOffset, fs.statSync(env.logFile).size);
+        assert.equal(result.newCursor.processedTurnCount, 3);
+        assert.equal(result.newCursor.status, 'completed');
+      } finally {
+        env.teardown();
+      }
+    });
+
+    test('includes non-turn entries in file but only advances past them without a DU when no turns exist', () => {
+      const env = setup();
+      try {
+        writeLog(env.logFile, [
+          makeRuntimeEntry('cli', 'chat'),
+          makeRuntimeEntry('cli', 'chat'),
+        ]);
+
+        const state = loadLogCursorState(env.stateFile);
+        const cursor = getCursor(state, env.logFile);
+        const result = extractDistillationUnit(env.logFile, cursor);
+
+        assert.equal(result.distillationUnit, null);
+        assert.equal(result.advanced, true);
+        assert.equal(result.newCursor.processedTurnCount, 0);
+      } finally {
+        env.teardown();
+      }
+    });
+  });
+
+  describe('append processing', () => {
+    test('produces a DU with only newly appended turns and continuity context from prior turns', () => {
+      const env = setup();
+      try {
+        const initialTurns = [
+          makeTurn(1, 'cli', 'chat'),
+          makeTurn(2, 'cli', 'chat'),
+        ];
+        writeLog(env.logFile, initialTurns);
+
+        // First extraction
+        const state1 = loadLogCursorState(env.stateFile);
+        const cursor1 = getCursor(state1, env.logFile);
+        const result1 = extractDistillationUnit(env.logFile, cursor1);
+        assert.ok(result1.distillationUnit);
+        assert.equal(result1.distillationUnit!.newTurns.length, 2);
+
+        // Save cursor (simulates successful processing)
+        state1.cursors[env.logFile] = result1.newCursor;
+        saveLogCursorState(env.stateFile, state1);
+
+        // Append new turns
+        const appendedTurns = [
+          makeTurn(3, 'cli', 'chat'),
+          makeTurn(4, 'cli', 'chat'),
+        ];
+        appendLog(env.logFile, appendedTurns);
+
+        // Second extraction
+        const state2 = loadLogCursorState(env.stateFile);
+        const cursor2 = getCursor(state2, env.logFile);
+        const result2 = extractDistillationUnit(env.logFile, cursor2);
+
+        assert.ok(result2.distillationUnit);
+        // Only the newly appended turns
+        assert.equal(result2.distillationUnit!.newTurns.length, 2);
+        assert.equal(result2.distillationUnit!.newTurns[0].turn, 3);
+        assert.equal(result2.distillationUnit!.newTurns[1].turn, 4);
+        // Continuity context from prior turns (up to 10)
+        assert.equal(result2.distillationUnit!.continuityTurns.length, 2);
+        assert.equal(result2.distillationUnit!.continuityTurns[0].turn, 1);
+        assert.equal(result2.distillationUnit!.continuityTurns[1].turn, 2);
+        assert.equal(result2.newCursor.processedTurnCount, 4);
+      } finally {
+        env.teardown();
+      }
+    });
+  });
+
+  describe('idempotent re-run', () => {
+    test('produces no duplicate Distillation Unit when no new turns are appended', () => {
+      const env = setup();
+      try {
+        writeLog(env.logFile, [makeTurn(1, 'cli', 'chat'), makeTurn(2, 'cli', 'chat')]);
+
+        // First extraction
+        const state1 = loadLogCursorState(env.stateFile);
+        const cursor1 = getCursor(state1, env.logFile);
+        const result1 = extractDistillationUnit(env.logFile, cursor1);
+        assert.ok(result1.distillationUnit);
+        state1.cursors[env.logFile] = result1.newCursor;
+        saveLogCursorState(env.stateFile, state1);
+
+        // Re-run without changes
+        const state2 = loadLogCursorState(env.stateFile);
+        const cursor2 = getCursor(state2, env.logFile);
+        const result2 = extractDistillationUnit(env.logFile, cursor2);
+
+        assert.equal(result2.distillationUnit, null);
+        assert.equal(result2.advanced, false);
+        assert.equal(result2.newCursor.byteOffset, cursor2.byteOffset);
+      } finally {
+        env.teardown();
+      }
+    });
+
+    test('processSessionLog does not invoke processor on re-run without new content', () => {
+      const env = setup();
+      try {
+        writeLog(env.logFile, [makeTurn(1, 'cli', 'chat')]);
+
+        let processorCalls = 0;
+        processSessionLog(env.logFile, env.stateFile, () => {
+          processorCalls++;
+        });
+        assert.equal(processorCalls, 1);
+
+        // Re-run — no new content
+        processSessionLog(env.logFile, env.stateFile, () => {
+          processorCalls++;
+        });
+        assert.equal(processorCalls, 1); // still 1
+      } finally {
+        env.teardown();
+      }
+    });
+  });
+
+  describe('continuity context selection', () => {
+    test('includes at most ten prior completed turns as continuity context', () => {
+      const env = setup();
+      try {
+        // Write 15 turns initially
+        const initialTurns = Array.from({ length: 15 }, (_, i) => makeTurn(i + 1, 'cli', 'chat'));
+        writeLog(env.logFile, initialTurns);
+
+        // First extraction processes all 15 turns
+        const state1 = loadLogCursorState(env.stateFile);
+        const cursor1 = getCursor(state1, env.logFile);
+        const result1 = extractDistillationUnit(env.logFile, cursor1);
+        assert.ok(result1.distillationUnit);
+        assert.equal(result1.distillationUnit!.newTurns.length, 15);
+        assert.equal(result1.distillationUnit!.continuityTurns.length, 0);
+        state1.cursors[env.logFile] = result1.newCursor;
+        saveLogCursorState(env.stateFile, state1);
+
+        // Append 1 new turn
+        appendLog(env.logFile, [makeTurn(16, 'cli', 'chat')]);
+
+        // Second extraction — continuity should be last 10 of the 15 prior turns
+        const state2 = loadLogCursorState(env.stateFile);
+        const cursor2 = getCursor(state2, env.logFile);
+        const result2 = extractDistillationUnit(env.logFile, cursor2);
+
+        assert.ok(result2.distillationUnit);
+        assert.equal(result2.distillationUnit!.newTurns.length, 1);
+        assert.equal(result2.distillationUnit!.newTurns[0].turn, 16);
+        assert.equal(result2.distillationUnit!.continuityTurns.length, MAX_CONTINUITY_TURNS);
+        // The continuity turns should be turns 6–15 (last 10 of the first 15)
+        assert.equal(result2.distillationUnit!.continuityTurns[0].turn, 6);
+        assert.equal(result2.distillationUnit!.continuityTurns[9].turn, 15);
+      } finally {
+        env.teardown();
+      }
+    });
+
+    test('continuity context includes fewer than ten when fewer prior turns exist', () => {
+      const env = setup();
+      try {
+        writeLog(env.logFile, [makeTurn(1, 'cli', 'chat'), makeTurn(2, 'cli', 'chat')]);
+
+        const state1 = loadLogCursorState(env.stateFile);
+        const cursor1 = getCursor(state1, env.logFile);
+        const result1 = extractDistillationUnit(env.logFile, cursor1);
+        state1.cursors[env.logFile] = result1.newCursor;
+        saveLogCursorState(env.stateFile, state1);
+
+        appendLog(env.logFile, [makeTurn(3, 'cli', 'chat')]);
+
+        const state2 = loadLogCursorState(env.stateFile);
+        const cursor2 = getCursor(state2, env.logFile);
+        const result2 = extractDistillationUnit(env.logFile, cursor2);
+
+        assert.ok(result2.distillationUnit);
+        assert.equal(result2.distillationUnit!.continuityTurns.length, 2);
+        assert.equal(result2.distillationUnit!.continuityTurns[0].turn, 1);
+        assert.equal(result2.distillationUnit!.continuityTurns[1].turn, 2);
+      } finally {
+        env.teardown();
+      }
+    });
+  });
+
+  describe('durable cursor advancement', () => {
+    test('cursor byte offset persists across runs and does not depend on date alone', () => {
+      const env = setup();
+      try {
+        writeLog(env.logFile, [makeTurn(1, 'cli', 'chat'), makeTurn(2, 'cli', 'chat')]);
+
+        // First extraction
+        processSessionLog(env.logFile, env.stateFile, () => {});
+
+        // Verify persisted cursor
+        const state = loadLogCursorState(env.stateFile);
+        const cursor = getCursor(state, env.logFile);
+        assert.equal(cursor.byteOffset, fs.statSync(env.logFile).size);
+        assert.equal(cursor.processedTurnCount, 2);
+        assert.equal(cursor.status, 'completed');
+        assert.ok(cursor.updatedAt);
+
+        // Re-run — no new content, cursor unchanged
+        processSessionLog(env.logFile, env.stateFile, () => {});
+        const state2 = loadLogCursorState(env.stateFile);
+        const cursor2 = getCursor(state2, env.logFile);
+        assert.equal(cursor2.byteOffset, cursor.byteOffset);
+        assert.equal(cursor2.processedTurnCount, 2);
+      } finally {
+        env.teardown();
+      }
+    });
+  });
+
+  describe('failed processing retry', () => {
+    test('leaves retryable state without losing original evidence', () => {
+      const env = setup();
+      try {
+        writeLog(env.logFile, [makeTurn(1, 'cli', 'chat'), makeTurn(2, 'cli', 'chat')]);
+
+        let callCount = 0;
+        // First attempt — processor fails
+        processSessionLog(env.logFile, env.stateFile, () => {
+          callCount++;
+          throw new Error('simulated processing failure');
+        });
+
+        assert.equal(callCount, 1);
+
+        // Cursor should be marked failed but retain original byte offset (0)
+        const state = loadLogCursorState(env.stateFile);
+        const cursor = getCursor(state, env.logFile);
+        assert.equal(cursor.status, 'failed');
+        assert.equal(cursor.byteOffset, 0); // not advanced — retryable
+        assert.ok(cursor.lastError?.includes('simulated processing failure'));
+
+        // Original log file is untouched (evidence preserved)
+        const fileContent = fs.readFileSync(env.logFile, 'utf-8');
+        assert.ok(fileContent.includes('user input 1'));
+        assert.ok(fileContent.includes('user input 2'));
+
+        // Retry — processor succeeds this time
+        processSessionLog(env.logFile, env.stateFile, () => {
+          callCount++;
+        });
+
+        assert.equal(callCount, 2);
+
+        // Cursor now advanced
+        const state2 = loadLogCursorState(env.stateFile);
+        const cursor2 = getCursor(state2, env.logFile);
+        assert.equal(cursor2.status, 'completed');
+        assert.equal(cursor2.byteOffset, fs.statSync(env.logFile).size);
+        assert.equal(cursor2.processedTurnCount, 2);
+
+        // Third run — no new content, no DU
+        let callCount3 = 0;
+        processSessionLog(env.logFile, env.stateFile, () => {
+          callCount3++;
+        });
+        assert.equal(callCount3, 0);
+      } finally {
+        env.teardown();
+      }
+    });
+
+    test('directory processing reports only successfully processed units', () => {
+      const env = setup();
+      try {
+        const secondLogFile = path.join(path.dirname(env.logFile), 'chat_other.jsonl');
+        writeLog(env.logFile, [makeTurn(1, 'cli', 'chat')]);
+        writeLog(secondLogFile, [makeTurn(1, 'other', 'chat')]);
+
+        const result = processSessionLogDirectory(
+          path.join(env.root, 'logs'),
+          env.stateFile,
+          unit => {
+            if (unit.filePath === env.logFile) {
+              throw new Error('simulated directory failure');
+            }
+          },
+        );
+
+        assert.equal(result.units.length, 1);
+        assert.equal(result.units[0].filePath, secondLogFile);
+        assert.equal(result.advancedFiles, 1);
+
+        const state = loadLogCursorState(env.stateFile);
+        const failedCursor = getCursor(state, env.logFile);
+        const completedCursor = getCursor(state, secondLogFile);
+        assert.equal(failedCursor.status, 'failed');
+        assert.equal(failedCursor.byteOffset, 0);
+        assert.equal(completedCursor.status, 'completed');
+        assert.equal(completedCursor.byteOffset, fs.statSync(secondLogFile).size);
+      } finally {
+        env.teardown();
+      }
+    });
+
+    test('malformed complete lines leave retryable state without advancing the cursor', () => {
+      const env = setup();
+      try {
+        fs.mkdirSync(path.dirname(env.logFile), { recursive: true });
+        fs.writeFileSync(env.logFile, '{"entry_type":"turn"\n', 'utf-8');
+
+        const result = processSessionLog(env.logFile, env.stateFile, () => {
+          throw new Error('processor should not run');
+        });
+
+        assert.equal(result.distillationUnit, null);
+        assert.equal(result.advanced, false);
+        assert.equal(result.processed, false);
+
+        const state = loadLogCursorState(env.stateFile);
+        const cursor = getCursor(state, env.logFile);
+        assert.equal(cursor.status, 'failed');
+        assert.equal(cursor.byteOffset, 0);
+        assert.ok(cursor.lastError?.includes('Expected'));
+      } finally {
+        env.teardown();
+      }
+    });
+  });
+
+  describe('partial line handling', () => {
+    test('does not advance past an incomplete trailing line', () => {
+      const env = setup();
+      try {
+        // Write file with a complete turn, then an incomplete line (no trailing \n)
+        const completeLine = JSON.stringify(makeTurn(1, 'cli', 'chat')) + '\n';
+        const incompleteLine = JSON.stringify(makeTurn(2, 'cli', 'chat')); // no \n
+        fs.mkdirSync(path.dirname(env.logFile), { recursive: true });
+        fs.writeFileSync(env.logFile, completeLine + incompleteLine, 'utf-8');
+
+        const state = loadLogCursorState(env.stateFile);
+        const cursor = getCursor(state, env.logFile);
+        const result = extractDistillationUnit(env.logFile, cursor);
+
+        // Should produce a DU with only the first turn (complete line)
+        assert.ok(result.distillationUnit);
+        assert.equal(result.distillationUnit!.newTurns.length, 1);
+        assert.equal(result.distillationUnit!.newTurns[0].turn, 1);
+
+        // Cursor should advance only past the complete line, not the incomplete one
+        assert.equal(result.newCursor.byteOffset, completeLine.length);
+
+        // Re-run — the incomplete line is still there, but now we treat it as
+        // new content. Since it has no trailing \n, it's still incomplete.
+        // No new complete line → no DU, cursor doesn't advance further.
+        const state2 = loadLogCursorState(env.stateFile);
+        state2.cursors[env.logFile] = result.newCursor;
+        saveLogCursorState(env.stateFile, state2);
+
+        const state3 = loadLogCursorState(env.stateFile);
+        const cursor3 = getCursor(state3, env.logFile);
+        const result3 = extractDistillationUnit(env.logFile, cursor3);
+        assert.equal(result3.distillationUnit, null);
+        assert.equal(result3.advanced, false);
+      } finally {
+        env.teardown();
+      }
+    });
+  });
+
+  describe('corrupt state recovery', () => {
+    test('quarantines corrupt state file and starts fresh', () => {
+      const env = setup();
+      try {
+        fs.writeFileSync(env.stateFile, '{not json', 'utf-8');
+
+        const state = loadLogCursorState(env.stateFile);
+        assert.equal(state.stateCorrupt, true);
+        assert.equal(Object.keys(state.cursors).length, 0);
+        // Original corrupt file moved aside
+        assert.equal(fs.existsSync(env.stateFile), false);
+        assert.ok(
+          fs.readdirSync(path.dirname(env.stateFile)).some(name =>
+            name.includes('.corrupt.'),
+          ),
+        );
+      } finally {
+        env.teardown();
+      }
+    });
+  });
+
+  describe('legacy turn entries', () => {
+    test('handles legacy entries without entry_type field', () => {
+      const env = setup();
+      try {
+        const legacyTurn = {
+          // No entry_type field — legacy format
+          turn: 1,
+          timestamp: new Date().toISOString(),
+          session_id: 'cli',
+          session_type: 'chat',
+          user: { text: 'legacy user' },
+          assistant: { text: 'legacy assistant', tool_calls: [] },
+          tokens: { prompt: 5, completion: 10 },
+        };
+        writeLog(env.logFile, [legacyTurn]);
+
+        const state = loadLogCursorState(env.stateFile);
+        const cursor = getCursor(state, env.logFile);
+        const result = extractDistillationUnit(env.logFile, cursor);
+
+        assert.ok(result.distillationUnit);
+        assert.equal(result.distillationUnit!.newTurns.length, 1);
+        assert.equal(result.newCursor.processedTurnCount, 1);
+      } finally {
+        env.teardown();
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Added durable per-file log cursor state in `src/utils/log-cursor-state.ts`.
- Added distillation unit extraction and processing from append-only session JSONL logs in `src/utils/distillation-unit.ts`.
- Added focused test coverage in `tests/log-cursor-distillation.test.ts` for cursor advancement, continuity, idempotence, failure/retry behavior, partial lines, and corrupted state.

## Scope
This implements issue #1 extraction path only (no model-based distillation orchestration yet).

## Testing
- `npx tsc --noEmit`
- `npx tsx --test tests/log-cursor-distillation.test.ts`
