### PR TITLE
清理 CatsCo 发言人前缀与路径显示

### DIFF
--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -146,7 +146,7 @@ function speakerNameFromMetadata(msg: Pick<ParsedCatsMessage, 'metadata' | 'send
 }
 
 function prefixCatsUserMessage(name: string, content: string | ContentBlock[]): string | ContentBlock[] {
-  const prefix = `${name}：\n`;
+  const prefix = `[发言人: ${name}]\n`;
   if (typeof content === 'string') return `${prefix}${content}`;
   const blocks = [...content];
   const firstTextIndex = blocks.findIndex(block => block.type === 'text');
@@ -160,6 +160,24 @@ function prefixCatsUserMessage(name: string, content: string | ContentBlock[]): 
     return blocks;
   }
   return [{ type: 'text', text: prefix.trimEnd() }, ...blocks];
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function isCatsCoAttachmentSummaryText(text: string, files: CatsFileInfo[]): boolean {
+  const trimmed = String(text || '').trim();
+  if (!trimmed || files.length === 0) return false;
+
+  let remainder = trimmed.replace(/\[(?:附件|图片|文件)\]/g, '');
+  for (const file of files) {
+    const fileName = String(file.fileName || '').trim();
+    if (!fileName) continue;
+    remainder = remainder.replace(new RegExp(escapeRegExp(fileName), 'g'), '');
+  }
+
+  return remainder.replace(/[\s,，、;；\r\n]+/g, '').length === 0;
 }
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
@@ -1288,11 +1306,9 @@ export class CatsCompanyBot {
     // 顶层 content 可能只是附件摘要，因此只作为没有 text block 时的 fallback。
     const blockText = blockTextParts.join('\n\n');
     const mergedText = blockText || text;
-    if (!mergedText && files.length === 0) return null;
-    const messageText = mergedText
-      || (files.length > 0
-        ? files.map(item => `[${item.type === 'image' ? '图片' : '文件'}] ${item.fileName}`).join('\n')
-        : '');
+    const userText = isCatsCoAttachmentSummaryText(mergedText, files) ? '' : mergedText;
+    if (!userText && files.length === 0) return null;
+    const messageText = userText;
     const envelope = createCatsCoMessageEnvelope({
       topic: ctx.topic,
       isGroup: ctx.isGroup,

--- a/src/tools/send-file-tool.ts
+++ b/src/tools/send-file-tool.ts
@@ -227,13 +227,12 @@ function validateCatsCoLocalSendFileContext(
 }
 
 function denyLocalSendFile(reason: string, targetLabel: string): { ok: false; errorCode: 'PERMISSION_DENIED'; message: string } {
+  const lines = [reason];
+  if (targetLabel) lines.push(`Target: ${targetLabel}`);
   return {
     ok: false,
     errorCode: 'PERMISSION_DENIED',
-    message: [
-      reason,
-      `Target: ${targetLabel || '[current CatsCo device]'}`,
-    ].join('\n'),
+    message: lines.join('\n'),
   };
 }
 

--- a/src/tools/tool-gateway.ts
+++ b/src/tools/tool-gateway.ts
@@ -82,16 +82,10 @@ export function formatCatsCoVisiblePath(
   value: string | undefined,
   options: CatsCoVisiblePathOptions = {},
 ): string {
-  const fallback = options.fallback ?? '[current CatsCo device]';
+  void context;
+  const fallback = options.fallback ?? '';
   const text = String(value || '').trim();
-  if (!isCatsCoToolGatewayContext(context)) {
-    return text || fallback;
-  }
-  if (!text) return fallback;
-  if (/^catsco_attachment:[A-Za-z0-9._:-]+$/.test(text)) return text;
-  if (/^\[CatsCo [^\]]+\]$/.test(text)) return text;
-  if (options.preserveRelative && !looksLikeAbsoluteLocalPath(text)) return text;
-  return text;
+  return text || fallback;
 }
 
 export function redactCatsCoVisiblePath(
@@ -411,18 +405,7 @@ function denied(lines: string[], targetLabel?: string): ToolGatewayDecision {
 }
 
 function sanitizeTargetLabel(value: string): string {
-  const text = String(value || '').trim();
-  if (!text) return '[current CatsCo device]';
-  if (/^catsco_attachment:[A-Za-z0-9._:-]+$/.test(text)) return text;
-  if (/^\[CatsCo [^\]]+\]$/.test(text)) return text;
-  return '[current CatsCo device]';
-}
-
-function looksLikeAbsoluteLocalPath(value: string): boolean {
-  return /^[A-Za-z]:[\\/]/.test(value)
-    || /^\\\\/.test(value)
-    || /^\//.test(value)
-    || /^~[\\/]/.test(value);
+  return String(value || '').trim();
 }
 
 function isCatsCoDeviceRpcForwardLocalContext(

--- a/tests/catscompany-content-blocks.test.ts
+++ b/tests/catscompany-content-blocks.test.ts
@@ -218,6 +218,28 @@ describe('CatsCo content blocks', () => {
     assert.strictEqual(parsed.files[0].fileName, 'crack.png');
   });
 
+  test('drops top-level attachment summary when message has only attachments', () => {
+    const bot = Object.create(CatsCompanyBot.prototype);
+
+    const parsed = (bot as any).parseMessage({
+      topic: 'p2p_1_2',
+      senderId: 'usr1',
+      text: '[附件] image.png, image.png',
+      content: '[附件] image.png, image.png',
+      content_blocks: [
+        { type: 'image', payload: { url: '/uploads/images/a.png', name: 'image.png', size: 12 } },
+        { type: 'image', payload: { url: '/uploads/images/b.png', name: 'image.png', size: 34 } },
+      ],
+      isGroup: false,
+      seq: 10,
+    });
+
+    assert.ok(parsed);
+    assert.strictEqual(parsed.text, '');
+    assert.strictEqual(parsed.files.length, 2);
+    assert.deepStrictEqual(parsed.files.map((file: any) => file.fileName), ['image.png', 'image.png']);
+  });
+
   test('builds CatsCo attachment context with stable local cache paths', async () => {
     const bot = Object.create(CatsCompanyBot.prototype);
     const localPath = 'C:\\tmp\\catsco-secret\\tmp\\downloads\\report.pdf';
@@ -279,7 +301,7 @@ describe('CatsCo content blocks', () => {
     );
     assert.strictEqual(handledTurns.length, 1);
     assert.deepStrictEqual(handledTurns[0].userMessage, [
-      { type: 'text', text: 'usr1：\n一起看这些附件' },
+      { type: 'text', text: '[发言人: usr1]\n一起看这些附件' },
       { type: 'text', text: '[image] a.png -> (no authorized attachment reference)' },
       { type: 'text', text: '[image] c.png -> (no authorized attachment reference)' },
       { type: 'text', text: '[file] b.pdf -> (no authorized attachment reference)' },
@@ -380,7 +402,7 @@ describe('CatsCo content blocks', () => {
     );
     assert.strictEqual(handledTurns.length, 1);
     assert.deepStrictEqual(handledTurns[0].userMessage, [
-      { type: 'text', text: 'usr1：\n非 Dashboard 入口一起看这些附件' },
+      { type: 'text', text: '[发言人: usr1]\n非 Dashboard 入口一起看这些附件' },
       { type: 'text', text: '[image] a.png -> (no authorized attachment reference)' },
       { type: 'text', text: '[file] b.pdf -> (no authorized attachment reference)' },
     ]);
@@ -572,7 +594,7 @@ describe('CatsCo content blocks', () => {
     });
 
     assert.strictEqual(handledTurns.length, 1);
-    assert.strictEqual(handledTurns[0].userMessage, 'usr1：\n这条纯文本不应该等待附件');
+    assert.strictEqual(handledTurns[0].userMessage, '[发言人: usr1]\n这条纯文本不应该等待附件');
     assert.strictEqual(typeof handledTurns[0].options.callbacks?.onThinking, 'function');
     assert.strictEqual(typeof handledTurns[0].options.callbacks?.onAssistantText, 'function');
     await handledTurns[0].options.callbacks.onAssistantText('工具调用前的可见回复');

--- a/tests/tool-gateway-catsco.test.ts
+++ b/tests/tool-gateway-catsco.test.ts
@@ -473,7 +473,7 @@ describe('CatsCo ToolGateway', () => {
     assert.deepEqual(calls[1].args, { pattern: 'needle', path: '/remote/project', output_mode: 'files' });
   });
 
-  test('redacts local absolute paths from successful CatsCo device file results', async () => {
+  test('keeps local absolute paths in successful CatsCo device file results', async () => {
     const root = makeWorkspace();
     const filePath = path.join(root, 'notes.txt');
     const outPath = path.join(root, 'out.txt');
@@ -490,32 +490,32 @@ describe('CatsCo ToolGateway', () => {
 
     const read = await new ReadTool().execute({ file_path: filePath }, ctx);
     assert.equal(read.ok, true);
-    assert.doesNotMatch(String(read.content), new RegExp(escapeRegExp(filePath)));
+    assert.match(String(read.content), new RegExp(escapeRegExp(filePath)));
 
     const glob = await new GlobTool().execute({ pattern: '*.txt', path: root }, ctx);
     assert.equal(glob.ok, true);
     assert.match(String(glob.content), /notes\.txt/);
-    assert.doesNotMatch(String(glob.content), new RegExp(escapeRegExp(root)));
+    assert.match(String(glob.content), new RegExp(escapeRegExp(root)));
 
     const grep = await new GrepTool().execute({ pattern: 'needle', path: filePath, output_mode: 'content' }, ctx);
     assert.equal(grep.ok, true);
     assert.match(String(grep.content), /needle/);
-    assert.doesNotMatch(String(grep.content), new RegExp(escapeRegExp(root)));
+    assert.match(String(grep.content), new RegExp(escapeRegExp(root)));
 
     const write = await new WriteTool().execute({ file_path: outPath, content: 'after' }, ctx);
     assert.equal(write.ok, true);
-    assert.doesNotMatch(String(write.content), new RegExp(escapeRegExp(outPath)));
+    assert.match(String(write.content), /Path: out\.txt/);
 
     const edit = await new EditTool().execute({ file_path: outPath, old_string: 'after', new_string: 'done' }, ctx);
     assert.equal(edit.ok, true);
-    assert.doesNotMatch(String(edit.content), new RegExp(escapeRegExp(outPath)));
+    assert.match(String(edit.content), new RegExp(escapeRegExp(outPath)));
 
     const send = await new SendFileTool().execute({ file_path: filePath, file_name: 'notes.txt' }, ctx);
     assert.equal(send.ok, true);
-    assert.doesNotMatch(String(send.content), new RegExp(escapeRegExp(filePath)));
+    assert.match(String(send.content), new RegExp(escapeRegExp(filePath)));
   });
 
-  test('redacts local absolute paths from CatsCo device file failure results', async () => {
+  test('keeps local absolute paths in CatsCo device file failure results', async () => {
     const root = makeWorkspace();
     const missingPath = path.join(root, 'missing.txt');
     const ctx = context(root, {
@@ -527,7 +527,7 @@ describe('CatsCo ToolGateway', () => {
     if (!readDirectory.ok) {
       assert.equal(readDirectory.errorCode, 'TOOL_EXECUTION_ERROR');
       assert.match(readDirectory.message, /Path is not a file/);
-      assert.doesNotMatch(readDirectory.message, new RegExp(escapeRegExp(root)));
+      assert.match(readDirectory.message, new RegExp(escapeRegExp(root)));
     }
 
     const sendMissing = await new SendFileTool().execute({ file_path: missingPath, file_name: 'missing.txt' }, ctx);
@@ -535,8 +535,8 @@ describe('CatsCo ToolGateway', () => {
     if (!sendMissing.ok) {
       assert.equal(sendMissing.errorCode, 'FILE_NOT_FOUND');
       assert.match(sendMissing.message, /File not found/);
-      assert.doesNotMatch(sendMissing.message, new RegExp(escapeRegExp(missingPath)));
-      assert.doesNotMatch(sendMissing.message, new RegExp(escapeRegExp(root)));
+      assert.match(sendMissing.message, new RegExp(escapeRegExp(missingPath)));
+      assert.match(sendMissing.message, new RegExp(escapeRegExp(root)));
     }
 
     const sendDirectory = await new SendFileTool().execute({ file_path: root, file_name: 'root' }, ctx);
@@ -544,7 +544,7 @@ describe('CatsCo ToolGateway', () => {
     if (!sendDirectory.ok) {
       assert.equal(sendDirectory.errorCode, 'TOOL_EXECUTION_ERROR');
       assert.match(sendDirectory.message, /Path is not a file/);
-      assert.doesNotMatch(sendDirectory.message, new RegExp(escapeRegExp(root)));
+      assert.match(sendDirectory.message, new RegExp(escapeRegExp(root)));
     }
   });
 


### PR DESCRIPTION
## 变更

- 将 CatsCo 用户消息前缀改为 \[发言人: 名字]\，降低多用户上下文歧义。
- 保留 CatsCo 工具结果中的真实本地路径，不再显示 \[current CatsCo device]\ 这类伪 target。
- 清理只有附件没有文字时的顶层附件摘要重复，保留逐个附件的本地缓存路径与读取方式。
- 调整 send_file 错误信息，只有存在真实 target label 时才显示 Target。

## 验证

- \
pm run build\
- \
ode_modules\\.bin\\tsx.cmd --test tests\\catscompany-content-blocks.test.ts\
- 手动 CatsCo 测试：单图、双图、文字+图片均能看到正确发言人前缀与本地缓存路径。