### PR TITLE
Stabilize CatsCo routing, add dimensional glob search, and secure Dashboard API

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -5686,6 +5686,106 @@
         return '';
       }
     })();
+    const DASHBOARD_API_KEY_STORAGE_KEY = 'catsco.dashboardApiKey';
+    let dashboardApiKeyPromptInFlight = null;
+    function getFetchUrl(input){
+      if(typeof input === 'string')return input;
+      if(typeof URL !== 'undefined' && input instanceof URL)return input.href;
+      if(typeof Request !== 'undefined' && input instanceof Request)return input.url;
+      return (input && input.url) || '';
+    }
+    function getFetchMethod(input, init){
+      return String((init && init.method) || (input && input.method) || 'GET').toUpperCase();
+    }
+    function isDashboardApiUrl(input){
+      try{
+        const raw = getFetchUrl(input);
+        if(!raw)return false;
+        const url = new URL(raw, window.location.href);
+        const apiBase = new URL(API || '/', window.location.href);
+        return url.origin === apiBase.origin && url.pathname.startsWith('/api/');
+      }catch(_e){
+        return false;
+      }
+    }
+    function getDashboardStoredApiKey(){
+      try{return window.sessionStorage.getItem(DASHBOARD_API_KEY_STORAGE_KEY) || '';}catch(_e){return '';}
+    }
+    function setDashboardStoredApiKey(key){
+      try{
+        if(key)window.sessionStorage.setItem(DASHBOARD_API_KEY_STORAGE_KEY, key);
+        else window.sessionStorage.removeItem(DASHBOARD_API_KEY_STORAGE_KEY);
+      }catch(_e){}
+    }
+    function promptForDashboardApiKey(message){
+      if(!dashboardApiKeyPromptInFlight){
+        dashboardApiKeyPromptInFlight = Promise.resolve().then(() => {
+          const key = window.prompt(message || '请输入 Dashboard API Key');
+          const trimmed = key && key.trim() ? key.trim() : '';
+          if(trimmed)setDashboardStoredApiKey(trimmed);
+          return trimmed;
+        }).finally(() => {
+          dashboardApiKeyPromptInFlight = null;
+        });
+      }
+      return dashboardApiKeyPromptInFlight;
+    }
+    async function ensureDashboardApiKey(message){
+      const existing = getDashboardStoredApiKey();
+      if(existing)return existing;
+      return promptForDashboardApiKey(message);
+    }
+    function withDashboardApiKey(input, init){
+      if(!isDashboardApiUrl(input))return { input, init };
+      const key = getDashboardStoredApiKey();
+      if(!key)return { input, init };
+      const nextInit = Object.assign({}, init || {});
+      const sourceHeaders = nextInit.headers || (typeof Request !== 'undefined' && input instanceof Request ? input.headers : {});
+      const headers = new Headers(sourceHeaders || {});
+      if(!headers.has('Authorization') && !headers.has('X-API-Key')){
+        headers.set('X-API-Key', key);
+      }
+      nextInit.headers = headers;
+      return { input, init: nextInit };
+    }
+    async function isDashboardAuthFailure(response){
+      if(response.status !== 401 && response.status !== 403 && response.status !== 429)return false;
+      try{
+        const data = await response.clone().json();
+        return data && (
+          data.code === 'dashboard_auth_required' ||
+          data.code === 'dashboard_auth_invalid' ||
+          data.code === 'dashboard_auth_rate_limited'
+        );
+      }catch(_e){
+        return false;
+      }
+    }
+    function cloneFetchInput(input){
+      if(typeof Request !== 'undefined' && input instanceof Request){
+        return input.clone();
+      }
+      return input;
+    }
+    const nativeFetch = window.fetch.bind(window);
+    window.fetch = async function(input, init){
+      const firstInput = cloneFetchInput(input);
+      const retryInput = cloneFetchInput(input);
+      let request = withDashboardApiKey(firstInput, init);
+      let response = await nativeFetch(request.input, request.init);
+      if(isDashboardApiUrl(input) && await isDashboardAuthFailure(response)){
+        if(response.status === 429){
+          return response;
+        }
+        setDashboardStoredApiKey('');
+        const key = await promptForDashboardApiKey('Dashboard API Key 无效或缺失，请重新输入');
+        if(key){
+          request = withDashboardApiKey(retryInput, init);
+          response = await nativeFetch(request.input, request.init);
+        }
+      }
+      return response;
+    };
     function formatDashboardApiError(error, path){
       const message=error&&error.message?String(error.message):String(error||'请求失败');
       if(/failed to fetch|networkerror|load failed|fetch/i.test(message)){
@@ -6931,12 +7031,24 @@
 
     async function fetchStatus() {
       try {
-        const res = await fetch(API+'/api/status');
-        const data = await res.json();
+        const publicRes = await fetch(API+'/api/status');
+        const publicStatus = await publicRes.json();
+        let data = publicStatus || {};
+        const shouldLoadDetails = !data.authRequired || await ensureDashboardApiKey('请输入 Dashboard API Key 以加载详细状态');
+        if(shouldLoadDetails){
+          const detailRes = await fetch(API+'/api/status/details');
+          if(detailRes.ok){
+            data = await detailRes.json();
+          }
+        }
         appStatusSnapshot = data || {};
         document.querySelector('.sidebar-brand-ver').textContent = 'v' + (data.version || '-');
-        renderStatus(data);
-        if(!shouldDeferServiceRender())renderServices(data.services || []);
+        if(data.authRequired && !shouldLoadDetails){
+          renderDashboardLockedState(data);
+        }else{
+          renderStatus(data);
+          if(!shouldDeferServiceRender())renderServices(data.services || []);
+        }
         await fetchReadiness();
         applyPetBaseline();
       } catch (e) {
@@ -6946,17 +7058,29 @@
 
     async function fetchReadiness() {
       try {
-        const res = await fetch(API+'/api/readiness');
-        if (!res.ok) throw new Error('HTTP '+res.status);
-        const contentType = res.headers.get('content-type') || '';
-        if (!contentType.includes('application/json')) {
+        const publicRes = await fetch(API+'/api/readiness');
+        if (!publicRes.ok) throw new Error('HTTP '+publicRes.status);
+        const publicContentType = publicRes.headers.get('content-type') || '';
+        if (!publicContentType.includes('application/json')) {
           throw new Error('Readiness API 尚未加载，请重启 Dashboard。');
         }
-        const data = await res.json();
+        const publicData = await publicRes.json();
+        let data = publicData || {};
+        const shouldLoadDetails = !data.authRequired || await ensureDashboardApiKey('请输入 Dashboard API Key 以加载详细就绪状态');
+        if(shouldLoadDetails){
+          const detailRes = await fetch(API+'/api/readiness/details');
+          if(detailRes.ok){
+            data = await detailRes.json();
+          }
+        }
         appReadinessSnapshot = data || {};
         appReadinessLoaded = true;
         appReadinessError = '';
-        renderReadiness(appReadinessSnapshot);
+        if(data.authRequired && !shouldLoadDetails){
+          renderDashboardLockedState(data);
+        }else{
+          renderReadiness(appReadinessSnapshot);
+        }
         if (document.getElementById('page-chat')?.classList.contains('active')) renderCatsStatus();
       } catch (e) {
         appReadinessSnapshot = {};
@@ -6978,6 +7102,22 @@
         const grid = document.getElementById('store-grid') || document.getElementById('skills-grid');
         if (grid) grid.innerHTML = '<div class="loading">无法加载</div>';
       }
+    }
+
+    function renderDashboardLockedState(d){
+      const statusGrid = document.getElementById('status-grid');
+      if(statusGrid){
+        statusGrid.innerHTML = '<div class="status-card"><div class="label">Dashboard</div><div class="value">已锁定</div><div class="readiness-summary">请输入 Dashboard API Key 以加载详细状态。</div></div>'+
+          '<div class="status-card"><div class="label">Version</div><div class="value">'+escapeHtml(d.version||'-')+'</div></div>';
+      }
+      const servicesGrid = document.getElementById('services-grid');
+      if(servicesGrid)servicesGrid.innerHTML = '<div class="loading">Dashboard API 已启用认证，请输入 API Key 后刷新。</div>';
+      const summaryTitle = document.querySelector('#run-summary .run-summary-title');
+      const summaryMeta = document.querySelector('#run-summary .run-summary-meta');
+      const actions = document.getElementById('readiness-alert-actions');
+      if(summaryTitle)summaryTitle.textContent = 'Dashboard 已锁定';
+      if(summaryMeta)summaryMeta.textContent = '需要 Dashboard API Key 才能查看服务、设置和就绪诊断。';
+      if(actions)actions.innerHTML = "<button class='btn btn-primary' onclick='setDashboardStoredApiKey(\"\");fetchStatus();fetchReadiness()'>输入 API Key</button>";
     }
 
     function renderStatus(d) {

--- a/docs/execution-routing-debug-notes.md
+++ b/docs/execution-routing-debug-notes.md
@@ -1,12 +1,23 @@
 # Execution Routing Debug Notes
 
-## Current Inconsistency To Verify
+## Legacy Inconsistency Notes
 
-- Model-facing target IDs are generic: `agent_self` and `speaker_default`.
-- Tool schemas expose the same fixed enum: `agent_self | speaker_default`.
-- The router maps `speaker_default` to CatsCompany `deviceSelection` or device grants.
-- If CatsCompany selects the wrong device, the agent currently has no more precise target ID to choose.
-- Remote tool results can be labeled as `agent_self`, which can pollute durable history and confuse later turns.
+These notes were written while debugging the old `deviceSelection/deviceGrants`
+route. The current lightweight route is:
+
+`CatsCompany runtime devices -> XiaoBa targetRoutes -> user-name target -> thin_tool_rpc`
+
+In the current route, model-facing base tools accept a free-form user name or
+user id target. `speaker_default` is legacy fallback behavior kept for old
+messages/tests and should not be described as the primary architecture.
+
+Old inconsistency that motivated the rewrite:
+
+- Model-facing target IDs were generic: `agent_self` and `speaker_default`.
+- Tool schemas exposed the same fixed enum: `agent_self | speaker_default`.
+- The router mapped `speaker_default` to CatsCompany `deviceSelection` or device grants.
+- If CatsCompany selected the wrong device, the agent had no more precise target ID to choose.
+- Remote tool results could be labeled as `agent_self`, polluting durable history and confusing later turns.
 
 ## Debug Order
 
@@ -61,7 +72,7 @@ Target-aware tools:
 - `edit_file`
 - `execute_shell`
 
-Current intended route:
+Legacy intended route captured during this debug pass:
 
 1. Tool receives optional `target`.
 2. `resolveExecutionRoute()` chooses `agent_self` by default.

--- a/src/catscompany/client.ts
+++ b/src/catscompany/client.ts
@@ -1028,14 +1028,21 @@ function deviceRpcResultMatchesPending(result: CatsDeviceRpcMessage, request: Ca
 }
 
 function thinToolRpcResultMatchesPending(result: CatsThinToolRpcMessage, request: CatsThinToolRpcMessage): boolean {
-  return deviceRpcOptionalFieldMatches(result.target_owner_user_id, request.target_owner_user_id)
-    && deviceRpcOptionalFieldMatches(result.target_device_id, request.target_device_id)
-    && deviceRpcOptionalFieldMatches(result.device_id, request.target_device_id)
-    && deviceRpcOptionalFieldMatches(result.tool_name, request.tool_name);
+  return deviceRpcPresentFieldMatches(result.target_owner_user_id, request.target_owner_user_id)
+    && deviceRpcPresentFieldMatches(result.target_device_id, request.target_device_id)
+    && deviceRpcPresentFieldMatches(result.device_id, request.target_device_id)
+    && deviceRpcPresentFieldMatches(result.tool_name, request.tool_name);
 }
 
 function deviceRpcOptionalFieldMatches(actual: unknown, expected: unknown): boolean {
   const actualText = typeof actual === 'string' ? actual.trim() : '';
   const expectedText = typeof expected === 'string' ? expected.trim() : '';
   return !actualText || !expectedText || actualText === expectedText;
+}
+
+function deviceRpcPresentFieldMatches(actual: unknown, expected: unknown): boolean {
+  const expectedText = typeof expected === 'string' ? expected.trim() : '';
+  if (!expectedText) return true;
+  const actualText = typeof actual === 'string' ? actual.trim() : '';
+  return actualText === expectedText;
 }

--- a/src/catscompany/connector-lock.ts
+++ b/src/catscompany/connector-lock.ts
@@ -1,0 +1,115 @@
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+export interface CatsCoConnectorLockRecord {
+  bodyId: string;
+  pid: number;
+  startedAt: string;
+  command?: string;
+  token: string;
+}
+
+export interface CatsCoConnectorLock {
+  acquired: true;
+  lockPath: string;
+  record: CatsCoConnectorLockRecord;
+  release: () => void;
+}
+
+export interface CatsCoConnectorLockBlocked {
+  acquired: false;
+  lockPath: string;
+  existing: CatsCoConnectorLockRecord;
+}
+
+export type CatsCoConnectorLockResult = CatsCoConnectorLock | CatsCoConnectorLockBlocked;
+
+export function acquireCatsCoConnectorLock(options: {
+  runtimeRoot: string;
+  bodyId: string;
+  command?: string;
+}): CatsCoConnectorLockResult {
+  const lockDir = path.join(options.runtimeRoot, '.xiaoba');
+  const lockPath = path.join(lockDir, 'catsco-connector.lock.json');
+  fs.mkdirSync(lockDir, { recursive: true });
+
+  const existing = readLock(lockPath);
+  if (existing && existing.bodyId === options.bodyId && isProcessAlive(existing.pid)) {
+    return {
+      acquired: false,
+      lockPath,
+      existing,
+    };
+  }
+
+  const record: CatsCoConnectorLockRecord = {
+    bodyId: options.bodyId,
+    pid: process.pid,
+    startedAt: new Date().toISOString(),
+    command: options.command,
+    token: crypto.randomUUID(),
+  };
+  writeLock(lockPath, record);
+
+  return {
+    acquired: true,
+    lockPath,
+    record,
+    release: () => releaseCatsCoConnectorLock(lockPath, record),
+  };
+}
+
+function readLock(lockPath: string): CatsCoConnectorLockRecord | null {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(lockPath, 'utf8')) as Partial<CatsCoConnectorLockRecord>;
+    const pid = parsed.pid;
+    if (
+      typeof parsed.bodyId === 'string' &&
+      typeof pid === 'number' &&
+      Number.isInteger(pid) &&
+      typeof parsed.startedAt === 'string' &&
+      typeof parsed.token === 'string'
+    ) {
+      return {
+        bodyId: parsed.bodyId,
+        pid,
+        startedAt: parsed.startedAt,
+        command: typeof parsed.command === 'string' ? parsed.command : undefined,
+        token: parsed.token,
+      };
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function writeLock(lockPath: string, record: CatsCoConnectorLockRecord): void {
+  fs.writeFileSync(lockPath, `${JSON.stringify(record, null, 2)}\n`, 'utf8');
+}
+
+function releaseCatsCoConnectorLock(lockPath: string, record: CatsCoConnectorLockRecord): void {
+  const current = readLock(lockPath);
+  if (!current || current.bodyId !== record.bodyId || current.pid !== record.pid || current.token !== record.token) {
+    return;
+  }
+  try {
+    fs.unlinkSync(lockPath);
+  } catch {
+    // Best-effort cleanup only.
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return false;
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    return code === 'EPERM';
+  }
+}

--- a/src/commands/catscompany.ts
+++ b/src/commands/catscompany.ts
@@ -5,6 +5,7 @@ import { CatsCompanyConfig } from '../catscompany/types';
 import { startRuntimeCommandSupport, stopRuntimeCommandSupport } from '../utils/runtime-command-support';
 import { ChatConfig } from '../types';
 import { resolveCatsCoRuntimeConfig } from '../catscompany/runtime-config';
+import { CatsCoConnectorLock, acquireCatsCoConnectorLock } from '../catscompany/connector-lock';
 
 export interface CatsCoCommandConfigResolution {
   config?: CatsCompanyConfig;
@@ -37,17 +38,49 @@ export async function catscompanyCommand(): Promise<void> {
     process.exit(1);
   }
 
+  const bodyId = connectorConfig.bodyId;
+  if (!bodyId) {
+    Logger.error('CatsCo connector missing bodyId; cannot start.');
+    process.exit(1);
+  }
+
+  const connectorLock = acquireCatsCoConnectorLock({
+    runtimeRoot: process.cwd(),
+    bodyId,
+    command: process.argv.join(' '),
+  });
+  if (!connectorLock.acquired) {
+    Logger.warning(
+      `CatsCo connector already running for this device; skip duplicate startup. bodyId=${bodyId}, pid=${connectorLock.existing.pid}`,
+    );
+    Logger.warning('已跳过第二条 CatsCo WebSocket 连接，避免同一设备重复连接互相挤下线。');
+    return;
+  }
+
   const bot = new CatsCompanyBot(connectorConfig);
+  let lock: CatsCoConnectorLock | null = connectorLock;
 
   // 优雅退出
   const shutdown = async () => {
     await stopRuntimeCommandSupport();
     await bot.destroy();
+    lock?.release();
+    lock = null;
     process.exit(0);
   };
   process.on('SIGINT', shutdown);
   process.on('SIGTERM', shutdown);
+  process.on('exit', () => {
+    lock?.release();
+    lock = null;
+  });
 
-  await bot.start();
-  await startRuntimeCommandSupport();
+  try {
+    await bot.start();
+    await startRuntimeCommandSupport();
+  } catch (error) {
+    lock?.release();
+    lock = null;
+    throw error;
+  }
 }

--- a/src/dashboard/auth.ts
+++ b/src/dashboard/auth.ts
@@ -1,0 +1,196 @@
+import type { Request, Response, NextFunction } from 'express';
+import { createHash, timingSafeEqual } from 'crypto';
+import { Logger } from '../utils/logger';
+
+const AUTH_HEADER_BEARER = 'authorization';
+const AUTH_HEADER_API_KEY = 'x-api-key';
+
+// Routes that don't require authentication for safe read-only methods.
+// NOTE: When this middleware is mounted at '/api' via app.use('/api', middleware, router),
+// Express strips the '/api' prefix from req.path. So we match on the relative path
+// (e.g. '/status' instead of '/api/status').
+const PUBLIC_API_ROUTES = new Set([
+  '/readiness',
+  '/status',
+]);
+const PUBLIC_API_METHODS = new Set(['GET', 'HEAD']);
+
+// Rate limiting: track failed auth attempts per IP
+const MAX_FAILED_ATTEMPTS = 10;
+const RATE_LIMIT_WINDOW_MS = 60_000; // 1 minute
+
+export interface DashboardAuthConfig {
+  /** The API key required for authentication, or undefined to disable auth */
+  apiKey?: string;
+}
+
+export interface DashboardAuthStatus {
+  enabled: boolean;
+  configured: boolean;
+}
+
+export interface DashboardAuthController {
+  middleware: (req: Request, res: Response, next: NextFunction) => void;
+  getStatus: () => DashboardAuthStatus;
+}
+
+/**
+ * Create dashboard authentication middleware.
+ * The config and rate-limit state are instance-scoped so multiple dashboard
+ * servers/tests do not overwrite each other through module-level globals.
+ */
+export function createDashboardAuth(config: DashboardAuthConfig): DashboardAuthController {
+  // Trim the API key to prevent mismatches caused by accidental whitespace
+  // in environment variables. If the key is empty or whitespace-only after
+  // trimming, treat auth as disabled to avoid a permanent lockout.
+  const apiKey = config.apiKey?.trim() || undefined;
+  const failedAttempts = new Map<string, { count: number; resetAt: number }>();
+
+  if (apiKey) {
+    Logger.info('Dashboard API authentication is enabled (DASHBOARD_API_KEY set)');
+  } else {
+    Logger.info('Dashboard API authentication is disabled (no DASHBOARD_API_KEY)');
+  }
+
+  function getStatus(): DashboardAuthStatus {
+    return {
+      enabled: Boolean(apiKey),
+      configured: Boolean(apiKey),
+    };
+  }
+
+  function cleanupExpiredAttempts(now = Date.now()): void {
+    for (const [ip, entry] of failedAttempts) {
+      if (now >= entry.resetAt) {
+        failedAttempts.delete(ip);
+      }
+    }
+  }
+
+  function getRateLimitEntry(ip: string): { count: number; resetAt: number } | undefined {
+    const entry = failedAttempts.get(ip);
+    if (!entry) return undefined;
+    if (Date.now() >= entry.resetAt) {
+      failedAttempts.delete(ip);
+      return undefined;
+    }
+    return entry;
+  }
+
+  function isRateLimited(ip: string): boolean {
+    const entry = getRateLimitEntry(ip);
+    return Boolean(entry && entry.count >= MAX_FAILED_ATTEMPTS);
+  }
+
+  function retryAfterSeconds(ip: string): number {
+    const entry = getRateLimitEntry(ip);
+    if (!entry) return 0;
+    return Math.max(1, Math.ceil((entry.resetAt - Date.now()) / 1000));
+  }
+
+  function recordFailedAttempt(ip: string): void {
+    const now = Date.now();
+    cleanupExpiredAttempts(now);
+    const entry = failedAttempts.get(ip);
+    if (!entry || now >= entry.resetAt) {
+      failedAttempts.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+    } else {
+      entry.count++;
+    }
+  }
+
+  function clearFailedAttempts(ip: string): void {
+    failedAttempts.delete(ip);
+  }
+
+  function middleware(req: Request, res: Response, next: NextFunction): void {
+    // Skip auth if no API key is configured
+    if (!apiKey) {
+      next();
+      return;
+    }
+
+    // Allow public health/status routes only for read-only methods.
+    // req.path is relative to the '/api' mount point. Strip trailing slash so
+    // /status/ is treated the same as /status.
+    const normalizedPath = req.path.endsWith('/') && req.path.length > 1
+      ? req.path.slice(0, -1)
+      : req.path;
+    if (PUBLIC_API_METHODS.has(req.method.toUpperCase()) && PUBLIC_API_ROUTES.has(normalizedPath)) {
+      next();
+      return;
+    }
+
+    const clientIp = req.ip || req.socket.remoteAddress || 'unknown';
+    const providedKey = extractApiKey(req);
+
+    // A correct key should always recover from previous failures. This avoids
+    // locking out the local dashboard after startup noise or stale stored keys.
+    if (providedKey && safeCompare(providedKey, apiKey)) {
+      clearFailedAttempts(clientIp);
+      next();
+      return;
+    }
+
+    if (isRateLimited(clientIp)) {
+      res.setHeader('Retry-After', String(retryAfterSeconds(clientIp)));
+      res.status(429).json({
+        error: 'Too many requests',
+        code: 'dashboard_auth_rate_limited',
+        message: 'Too many failed authentication attempts. Please try again later.',
+      });
+      return;
+    }
+
+    if (!providedKey) {
+      res.status(401).json({
+        error: 'Authentication required',
+        code: 'dashboard_auth_required',
+        message: 'Please provide a valid API key via Authorization: Bearer <key> or X-API-Key header.',
+      });
+      return;
+    }
+
+    recordFailedAttempt(clientIp);
+    res.status(403).json({
+      error: 'Forbidden',
+      code: 'dashboard_auth_invalid',
+      message: 'Invalid API key.',
+    });
+    return;
+  }
+
+  return { middleware, getStatus };
+}
+
+/**
+ * Fixed-size digest comparison to avoid timingSafeEqual length errors and avoid
+ * directly comparing variable-length API key buffers.
+ */
+function safeCompare(a: string, b: string): boolean {
+  const digestA = createHash('sha256').update(a).digest();
+  const digestB = createHash('sha256').update(b).digest();
+  return timingSafeEqual(digestA, digestB);
+}
+
+function extractApiKey(req: Request): string | undefined {
+  // Try Authorization: Bearer <key>
+  const authHeader = req.headers[AUTH_HEADER_BEARER];
+  if (authHeader) {
+    const parts = Array.isArray(authHeader) ? authHeader[0] : authHeader;
+    const match = parts.match(/^Bearer\s+(.+)$/i);
+    if (match) {
+      const key = match[1].trim();
+      if (key) return key;
+    }
+  }
+
+  // Try X-API-Key header
+  const apiKeyHeader = req.headers[AUTH_HEADER_API_KEY];
+  if (apiKeyHeader) {
+    const key = Array.isArray(apiKeyHeader) ? apiKeyHeader[0].trim() : apiKeyHeader.trim();
+    if (key) return key;
+  }
+
+  return undefined;
+}

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -1695,7 +1695,8 @@ export function createApiRouter(serviceManager: ServiceManager, updateController
 
   // ==================== 总览 ====================
 
-  
+  // Public summary endpoints intentionally expose only minimal state.
+  // Detailed dashboard diagnostics live under /details and are protected by auth.
   router.get('/status', (_req, res) => {
     const config = ConfigManager.getConfigReadonly();
     const contextWindow = resolveModelContextWindow(config);

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -52,6 +52,7 @@ import { resolveCatsCoRuntimeConfig } from '../../catscompany/runtime-config';
 import { consumeLocalFileGrant, validateLocalFileGrant } from '../local-file-grants';
 import { registerSkillHubRoutes } from './skillhub';
 import { registerPetRoutes } from './pet';
+import type { DashboardAuthStatus } from '../auth';
 import { SkillHubService } from '../../skillhub/service';
 import {
   computeLocalSkillContentHash,
@@ -1688,7 +1689,15 @@ async function getCatsCoAuthForSkillHub(): Promise<{
   };
 }
 
-export function createApiRouter(serviceManager: ServiceManager, updateController?: UpdateController): Router {
+export interface DashboardApiRouterOptions {
+  getAuthStatus?: () => DashboardAuthStatus;
+}
+
+export function createApiRouter(
+  serviceManager: ServiceManager,
+  updateController?: UpdateController,
+  options: DashboardApiRouterOptions = {}
+): Router {
   const router = Router();
   registerSkillHubRoutes(router, { getCatsCoAuth: getCatsCoAuthForSkillHub });
   registerPetRoutes(router);
@@ -1698,6 +1707,14 @@ export function createApiRouter(serviceManager: ServiceManager, updateController
   // Public summary endpoints intentionally expose only minimal state.
   // Detailed dashboard diagnostics live under /details and are protected by auth.
   router.get('/status', (_req, res) => {
+    res.json({
+      ok: true,
+      version: APP_VERSION,
+      authRequired: Boolean(options.getAuthStatus?.().enabled),
+    });
+  });
+
+  router.get('/status/details', (_req, res) => {
     const config = ConfigManager.getConfigReadonly();
     const contextWindow = resolveModelContextWindow(config);
     const services = serviceManager.getAll();
@@ -1712,6 +1729,7 @@ export function createApiRouter(serviceManager: ServiceManager, updateController
       contextWindow,
       skillsPath: PathResolver.getSkillsPath(),
       services,
+      authStatus: options.getAuthStatus?.() || { enabled: false, configured: false },
     });
   });
 
@@ -1800,6 +1818,25 @@ export function createApiRouter(serviceManager: ServiceManager, updateController
   });
 
   router.get('/readiness', async (_req, res) => {
+    try {
+      const readiness = await getDashboardReadiness(serviceManager, {
+        runtimeRoot: process.cwd(),
+        config: ConfigManager.getConfigReadonly(),
+      });
+      // Public readiness exposes only a redacted aggregate status so the UI
+      // can avoid false-ready states without leaking detailed diagnostics.
+      res.json({
+        ok: readiness.status !== 'blocked',
+        generatedAt: readiness.generatedAt,
+        status: readiness.status,
+        authRequired: Boolean(options.getAuthStatus?.().enabled),
+      });
+    } catch (e: any) {
+      res.status(500).json({ error: e?.message || String(e) });
+    }
+  });
+
+  router.get('/readiness/details', async (_req, res) => {
     try {
       res.json(await getDashboardReadiness(serviceManager, {
         runtimeRoot: process.cwd(),

--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -5,6 +5,7 @@ import { Logger } from '../utils/logger';
 import { createApiRouter } from './routes/api';
 import { ServiceManager } from './service-manager';
 import { bootstrapDefaultSkillHubSkillsOnce } from '../skillhub/default-skill-bootstrap';
+import { createDashboardAuth } from './auth';
 
 const DEFAULT_PORT = 3800;
 const activeServers: Server[] = [];
@@ -39,8 +40,18 @@ export async function startDashboard(
     Logger.warning(`Default SkillHub bootstrap failed: ${error?.message || String(error)}`);
   });
 
-  // API routes
-  app.use('/api', createApiRouter(serviceManager, controllers.updateController));
+  // Configure and apply dashboard authentication.
+  // Trim the env var so whitespace-only values are treated as "not set"
+  // (the middleware also trims, but we check the trimmed value for logging).
+  const dashboardApiKey = (process.env.DASHBOARD_API_KEY || '').trim();
+  const dashboardAuth = createDashboardAuth({
+    apiKey: dashboardApiKey || undefined,
+  });
+
+  // API routes (with auth protection)
+  app.use('/api', dashboardAuth.middleware, createApiRouter(serviceManager, controllers.updateController, {
+    getAuthStatus: dashboardAuth.getStatus,
+  }));
 
   // Serve frontend
   const frontendPath = path.join(__dirname, '../../dashboard');
@@ -63,6 +74,9 @@ export async function startDashboard(
 
   const server = app.listen(port, '127.0.0.1', () => {
     Logger.success(`\nCatsCo Dashboard started`);
+    if (dashboardApiKey) {
+      Logger.info(`API authentication enabled — provide DASHBOARD_API_KEY as Bearer token or X-API-Key header`);
+    }
     Logger.info(`Open browser: http://127.0.0.1:${port} or http://localhost:${port}\n`);
   });
   activeServers.push(server);

--- a/src/tools/glob-tool.ts
+++ b/src/tools/glob-tool.ts
@@ -43,16 +43,10 @@ export class GlobTool implements Tool {
   definition: ToolDefinition = {
     name: 'glob',
     description: [
-<<<<<<< HEAD
-      '按 glob 模式查找文件路径，返回匹配文件列表并按修改时间倒序排列。',
-      '适合先定位候选文件；要搜索文件内容请使用 grep。',
-      '当用户问“桌面/下载/文档里有什么/有哪些文件或文件夹”时，先用 resolve_common_directory 解析目录，再用 pattern="*" 且 include_directories=true 列出目录项；不要用 execute_shell 跑 dir/ls。',
-=======
       'Find files or directories by path pattern and metadata.',
       'Use this to discover candidate paths before grep/read_file. Use grep for content search.',
       'Supports multiple filename patterns, file/directory kind, modified time filters, max depth, and result summaries.',
       'For broad recent-file questions, prefer patterns + modified_after + max_depth + summary over repeated one-off glob calls.',
->>>>>>> origin/pr-156
     ].join('\n'),
     parameters: {
       type: 'object',
@@ -75,14 +69,6 @@ export class GlobTool implements Tool {
           description: 'Maximum number of results to return. Defaults to 100.',
           default: 100,
         },
-<<<<<<< HEAD
-        include_directories: {
-          type: 'boolean',
-          description: '是否包含匹配到的目录。默认 false，保持只返回文件；用户要查看目录里有什么、有哪些文件夹或列目录内容时设为 true。',
-          default: false
-        },
-        target: targetParameterDescription()
-=======
         kind: {
           type: 'string',
           description: 'Return files, directories, or all entries. Defaults to files.',
@@ -112,16 +98,12 @@ export class GlobTool implements Tool {
           default: false,
         },
         target: targetParameterDescription(),
->>>>>>> origin/pr-156
       },
       required: [],
     },
   };
 
   async execute(args: any, context: ToolExecutionContext): Promise<ToolExecutionResult> {
-<<<<<<< HEAD
-    const { pattern, path: searchPath, limit = 100, include_directories = false } = args;
-=======
     const searchPath = args?.path;
     const patterns = normalizePatterns(args);
     const limit = normalizeLimit(args?.limit);
@@ -131,7 +113,6 @@ export class GlobTool implements Tool {
     const modifiedBefore = parseDateFilter(args?.modified_before);
     const includeHidden = args?.include_hidden === true;
     const includeSummary = args?.summary === true;
->>>>>>> origin/pr-156
     const startTime = Date.now();
 
     if (patterns.length === 0) {
@@ -175,20 +156,6 @@ export class GlobTool implements Tool {
     const shouldReturnAbsolutePaths = !isCatsCoToolGatewayContext(context) && Boolean(searchPath && path.isAbsolute(searchPath));
     const matchedPaths = new Map<string, Set<string>>();
 
-<<<<<<< HEAD
-    const files = await glob(pattern, {
-      cwd,
-      absolute: false,
-      nodir: !include_directories,
-      dot: false,
-      ignore: ['**/node_modules/**', '**/.git/**', '**/dist/**', '**/build/**']
-    });
-
-    const resultLabel = include_directories ? '目录项' : '文件';
-
-    if (files.length === 0) {
-      return { ok: true, content: `未找到匹配的${resultLabel}。\n模式: ${pattern}\n目录: ${visibleSearchPath}\nPath: ${visibleCwd}` };
-=======
     for (const candidatePattern of patterns) {
       const matches = await glob(candidatePattern, {
         cwd,
@@ -204,7 +171,6 @@ export class GlobTool implements Tool {
         if (!matchedPaths.has(normalized)) matchedPaths.set(normalized, new Set());
         matchedPaths.get(normalized)!.add(candidatePattern);
       }
->>>>>>> origin/pr-156
     }
 
     const entries = await collectEntries(cwd, matchedPaths, {
@@ -236,22 +202,14 @@ export class GlobTool implements Tool {
       summary: includeSummary ? buildSummary(entries) : undefined,
     };
 
-<<<<<<< HEAD
-    return { ok: true, content: this.formatResult(result, pattern, visibleSearchPath, visibleCwd, resultLabel) };
-=======
     return { ok: true, content: this.formatResult(result, visibleSearchPath, visibleCwd, limit) };
->>>>>>> origin/pr-156
   }
 
   private formatResult(
     result: GlobResult,
     visibleSearchPath: string,
     visibleCwd: string,
-<<<<<<< HEAD
-    resultLabel: string,
-=======
     limit: number,
->>>>>>> origin/pr-156
   ): string {
     const { numEntries, totalMatches, entries, truncated, durationMs, patterns, kind, filters, summary } = result;
     const noun = kind === 'files' ? 'files' : kind === 'directories' ? 'directories' : 'entries';
@@ -267,12 +225,6 @@ export class GlobTool implements Tool {
       '',
     ].filter(line => line !== '').join('\n');
 
-<<<<<<< HEAD
-    const header = `找到 ${numFiles} 个${resultLabel} (${durationMs}ms)${truncated ? ' - 结果已截断，考虑使用更精确的模式' : ''}:\n模式: ${pattern}\n目录: ${visibleSearchPath}\nPath: ${visibleCwd}\n\n`;
-    const fileList = filenames.map((file, i) => `${(i + 1).toString().padStart(4, ' ')}. ${file}`).join('\n');
-    
-    return header + fileList + (truncated ? `\n\n提示: 结果被限制在前 100 个${resultLabel}。使用更具体的路径或模式来缩小范围。` : '');
-=======
     const summaryText = summary ? [
       'Summary:',
       formatFacet('top directories', summary.byTopDirectory),
@@ -305,7 +257,6 @@ export class GlobTool implements Tool {
       entryList,
       truncated ? `\nHint: results were limited to ${limit}. Use narrower patterns, modified_after/modified_before, max_depth, or a more specific path to continue.` : '',
     ].filter(Boolean).join('\n');
->>>>>>> origin/pr-156
   }
 }
 

--- a/src/tools/glob-tool.ts
+++ b/src/tools/glob-tool.ts
@@ -1,92 +1,181 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import { glob } from 'glob';
+import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import { isReadPathAllowed } from '../utils/safety';
 import { formatCatsCoVisiblePath, isCatsCoToolGatewayContext } from './tool-gateway';
 import { executeRouteIfRemote, resolveExecutionRoute, targetParameterDescription } from './execution-router';
 
-interface GlobResult {
-  numFiles: number;
-  filenames: string[];
-  truncated: boolean;
-  durationMs: number;
+type GlobEntryKind = 'file' | 'directory' | 'symlink' | 'other';
+type GlobKindFilter = 'files' | 'directories' | 'all';
+
+interface GlobEntry {
+  path: string;
+  kind: GlobEntryKind;
+  mtime: number;
+  size?: number;
+  matchedPatterns: string[];
 }
 
-/**
- * Glob 工具 - 文件模式匹配搜索
- */
+interface GlobResult {
+  numEntries: number;
+  totalMatches: number;
+  entries: GlobEntry[];
+  truncated: boolean;
+  durationMs: number;
+  patterns: string[];
+  kind: GlobKindFilter;
+  filters: {
+    modifiedAfter?: string;
+    modifiedBefore?: string;
+    maxDepth?: number;
+  };
+  summary?: GlobSummary;
+}
+
+interface GlobSummary {
+  byTopDirectory: Array<{ key: string; count: number }>;
+  byExtension: Array<{ key: string; count: number }>;
+  byModifiedDay: Array<{ key: string; count: number }>;
+}
+
 export class GlobTool implements Tool {
   definition: ToolDefinition = {
     name: 'glob',
     description: [
+<<<<<<< HEAD
       '按 glob 模式查找文件路径，返回匹配文件列表并按修改时间倒序排列。',
       '适合先定位候选文件；要搜索文件内容请使用 grep。',
       '当用户问“桌面/下载/文档里有什么/有哪些文件或文件夹”时，先用 resolve_common_directory 解析目录，再用 pattern="*" 且 include_directories=true 列出目录项；不要用 execute_shell 跑 dir/ls。',
+=======
+      'Find files or directories by path pattern and metadata.',
+      'Use this to discover candidate paths before grep/read_file. Use grep for content search.',
+      'Supports multiple filename patterns, file/directory kind, modified time filters, max depth, and result summaries.',
+      'For broad recent-file questions, prefer patterns + modified_after + max_depth + summary over repeated one-off glob calls.',
+>>>>>>> origin/pr-156
     ].join('\n'),
     parameters: {
       type: 'object',
       properties: {
         pattern: {
           type: 'string',
-          description: 'Glob 模式，例如 "**/*.ts"、"src/**/*.js"。'
+          description: 'Single glob pattern, e.g. "**/*.ts" or "src/**/*.js". Use either pattern or patterns.',
+        },
+        patterns: {
+          type: 'array',
+          description: 'Multiple glob patterns to search in one call. Results are deduplicated and can show matched patterns.',
+          items: { type: 'string' },
         },
         path: {
           type: 'string',
-          description: '搜索起始目录。可选，默认当前目录。可以使用 resolve_common_directory 返回的绝对路径。'
+          description: 'Search root directory. Defaults to the current working directory. Can use resolve_common_directory output.',
         },
         limit: {
           type: 'number',
-          description: '返回结果最大数量，默认 100。',
-          default: 100
+          description: 'Maximum number of results to return. Defaults to 100.',
+          default: 100,
         },
+<<<<<<< HEAD
         include_directories: {
           type: 'boolean',
           description: '是否包含匹配到的目录。默认 false，保持只返回文件；用户要查看目录里有什么、有哪些文件夹或列目录内容时设为 true。',
           default: false
         },
         target: targetParameterDescription()
+=======
+        kind: {
+          type: 'string',
+          description: 'Return files, directories, or all entries. Defaults to files.',
+          enum: ['files', 'directories', 'all'],
+          default: 'files',
+        },
+        max_depth: {
+          type: 'number',
+          description: 'Maximum search depth relative to path. Use 1-3 for shallow structure checks.',
+        },
+        modified_after: {
+          type: 'string',
+          description: 'Only return entries modified after this time. Accepts ISO time or YYYY-MM-DD.',
+        },
+        modified_before: {
+          type: 'string',
+          description: 'Only return entries modified before this time. Accepts ISO time or YYYY-MM-DD.',
+        },
+        include_hidden: {
+          type: 'boolean',
+          description: 'Include dotfiles and dot-directories. Defaults to false.',
+          default: false,
+        },
+        summary: {
+          type: 'boolean',
+          description: 'Include summary facets by top directory, extension, and modified day.',
+          default: false,
+        },
+        target: targetParameterDescription(),
+>>>>>>> origin/pr-156
       },
-      required: ['pattern']
-    }
+      required: [],
+    },
   };
 
   async execute(args: any, context: ToolExecutionContext): Promise<ToolExecutionResult> {
+<<<<<<< HEAD
     const { pattern, path: searchPath, limit = 100, include_directories = false } = args;
+=======
+    const searchPath = args?.path;
+    const patterns = normalizePatterns(args);
+    const limit = normalizeLimit(args?.limit);
+    const kind = normalizeKind(args?.kind);
+    const maxDepth = normalizePositiveInteger(args?.max_depth);
+    const modifiedAfter = parseDateFilter(args?.modified_after);
+    const modifiedBefore = parseDateFilter(args?.modified_before);
+    const includeHidden = args?.include_hidden === true;
+    const includeSummary = args?.summary === true;
+>>>>>>> origin/pr-156
     const startTime = Date.now();
+
+    if (patterns.length === 0) {
+      return {
+        ok: false,
+        errorCode: 'INVALID_TOOL_ARGUMENTS',
+        message: 'glob requires either pattern or patterns.',
+      };
+    }
 
     const route = resolveExecutionRoute(context, {
       toolName: this.definition.name,
       operation: 'glob',
-      target: args.target,
+      target: args?.target,
     });
     if (!route.ok) {
       return { ok: false, errorCode: route.errorCode, message: route.message };
     }
-    const remoteResult = await executeRouteIfRemote(context, route, 'glob', 'glob', args);
+    const remoteArgs = typeof args?.pattern === 'string' && args.pattern.trim()
+      ? args
+      : (patterns.length > 0 ? { ...args, pattern: patterns[0] } : args);
+    const remoteResult = await executeRouteIfRemote(context, route, 'glob', 'glob', remoteArgs);
     if (remoteResult) return remoteResult;
 
-    // 确定搜索目录
     const cwd = searchPath
       ? (path.isAbsolute(searchPath) ? searchPath : path.join(context.workingDirectory, searchPath))
       : context.workingDirectory;
 
     const pathPermission = isReadPathAllowed(cwd, context.workingDirectory);
     if (!pathPermission.allowed) {
-      return { ok: false, errorCode: 'PERMISSION_DENIED', message: `执行被阻止: ${pathPermission.reason}` };
+      return { ok: false, errorCode: 'PERMISSION_DENIED', message: `Execution blocked: ${pathPermission.reason}` };
     }
 
     const visibleSearchPath = formatCatsCoVisiblePath(context, searchPath || '.', { preserveRelative: true });
     const visibleCwd = formatCatsCoVisiblePath(context, cwd);
 
-    // 检查目录是否存在
     if (!fs.existsSync(cwd)) {
-      return { ok: false, errorCode: 'FILE_NOT_FOUND', message: `目录不存在: ${visibleCwd}` };
+      return { ok: false, errorCode: 'FILE_NOT_FOUND', message: `Directory not found: ${visibleCwd}` };
     }
 
-    // 执行 glob 搜索
     const shouldReturnAbsolutePaths = !isCatsCoToolGatewayContext(context) && Boolean(searchPath && path.isAbsolute(searchPath));
+    const matchedPaths = new Map<string, Set<string>>();
 
+<<<<<<< HEAD
     const files = await glob(pattern, {
       cwd,
       absolute: false,
@@ -99,47 +188,253 @@ export class GlobTool implements Tool {
 
     if (files.length === 0) {
       return { ok: true, content: `未找到匹配的${resultLabel}。\n模式: ${pattern}\n目录: ${visibleSearchPath}\nPath: ${visibleCwd}` };
+=======
+    for (const candidatePattern of patterns) {
+      const matches = await glob(candidatePattern, {
+        cwd,
+        absolute: false,
+        nodir: kind === 'files',
+        dot: includeHidden,
+        maxDepth,
+        ignore: ['**/node_modules/**', '**/.git/**', '**/dist/**', '**/build/**'],
+        windowsPathsNoEscape: process.platform === 'win32',
+      });
+      for (const match of matches) {
+        const normalized = normalizeRelativePath(String(match));
+        if (!matchedPaths.has(normalized)) matchedPaths.set(normalized, new Set());
+        matchedPaths.get(normalized)!.add(candidatePattern);
+      }
+>>>>>>> origin/pr-156
     }
 
-    // 使用Promise.allSettled容错处理stat（文件可能在glob后被删除）
-    const statsPromises = files.map(file => {
-      const fullPath = path.join(cwd, file);
-      return fs.promises.stat(fullPath)
-        .then(stats => ({ file, mtime: stats.mtime.getTime() }))
-        .catch(() => ({ file, mtime: 0 })); // 失败的文件排在最后
+    const entries = await collectEntries(cwd, matchedPaths, {
+      kind,
+      modifiedAfter,
+      modifiedBefore,
     });
+    entries.sort((a, b) => b.mtime - a.mtime || a.path.localeCompare(b.path));
 
-    const filesWithStats = await Promise.all(statsPromises);
-
-    // 按修改时间降序排序（最新的在前）
-    filesWithStats.sort((a, b) => b.mtime - a.mtime);
-
-    // 应用限制
-    const truncated = files.length > limit;
-    const limitedFiles = filesWithStats.slice(0, limit);
+    const truncated = entries.length > limit;
+    const limitedEntries = entries.slice(0, limit).map(entry => ({
+      ...entry,
+      path: shouldReturnAbsolutePaths ? path.join(cwd, entry.path) : entry.path,
+    }));
 
     const result: GlobResult = {
-      numFiles: limitedFiles.length,
-      filenames: limitedFiles.map(f => shouldReturnAbsolutePaths ? path.join(cwd, f.file) : f.file),
+      numEntries: limitedEntries.length,
+      totalMatches: entries.length,
+      entries: limitedEntries,
       truncated,
-      durationMs: Date.now() - startTime
+      durationMs: Date.now() - startTime,
+      patterns,
+      kind,
+      filters: {
+        modifiedAfter: modifiedAfter?.label,
+        modifiedBefore: modifiedBefore?.label,
+        maxDepth,
+      },
+      summary: includeSummary ? buildSummary(entries) : undefined,
     };
 
+<<<<<<< HEAD
     return { ok: true, content: this.formatResult(result, pattern, visibleSearchPath, visibleCwd, resultLabel) };
+=======
+    return { ok: true, content: this.formatResult(result, visibleSearchPath, visibleCwd, limit) };
+>>>>>>> origin/pr-156
   }
 
   private formatResult(
     result: GlobResult,
-    pattern: string,
     visibleSearchPath: string,
     visibleCwd: string,
+<<<<<<< HEAD
     resultLabel: string,
+=======
+    limit: number,
+>>>>>>> origin/pr-156
   ): string {
-    const { numFiles, filenames, truncated, durationMs } = result;
+    const { numEntries, totalMatches, entries, truncated, durationMs, patterns, kind, filters, summary } = result;
+    const noun = kind === 'files' ? 'files' : kind === 'directories' ? 'directories' : 'entries';
+    const header = [
+      `Found ${numEntries}/${totalMatches} ${noun} (${durationMs}ms)${truncated ? ' - truncated' : ''}:`,
+      `Patterns: ${patterns.join(', ')}`,
+      `Directory: ${visibleSearchPath}`,
+      `Path: ${visibleCwd}`,
+      `Kind: ${kind}`,
+      filters.maxDepth !== undefined ? `Max depth: ${filters.maxDepth}` : '',
+      filters.modifiedAfter ? `Modified after: ${filters.modifiedAfter}` : '',
+      filters.modifiedBefore ? `Modified before: ${filters.modifiedBefore}` : '',
+      '',
+    ].filter(line => line !== '').join('\n');
 
+<<<<<<< HEAD
     const header = `找到 ${numFiles} 个${resultLabel} (${durationMs}ms)${truncated ? ' - 结果已截断，考虑使用更精确的模式' : ''}:\n模式: ${pattern}\n目录: ${visibleSearchPath}\nPath: ${visibleCwd}\n\n`;
     const fileList = filenames.map((file, i) => `${(i + 1).toString().padStart(4, ' ')}. ${file}`).join('\n');
     
     return header + fileList + (truncated ? `\n\n提示: 结果被限制在前 100 个${resultLabel}。使用更具体的路径或模式来缩小范围。` : '');
+=======
+    const summaryText = summary ? [
+      'Summary:',
+      formatFacet('top directories', summary.byTopDirectory),
+      formatFacet('extensions', summary.byExtension),
+      formatFacet('modified days', summary.byModifiedDay),
+      '',
+    ].join('\n') : '';
+
+    if (entries.length === 0) {
+      return [
+        header,
+        summaryText,
+        'No matching entries.',
+        'Try broader patterns, a wider modified_after/modified_before range, or a higher max_depth.',
+      ].filter(Boolean).join('\n');
+    }
+
+    const entryList = entries.map((entry, i) => {
+      const kindLabel = entry.kind.padEnd(9, ' ');
+      const modified = entry.mtime > 0 ? new Date(entry.mtime).toISOString() : 'unknown';
+      const size = entry.kind === 'file' ? formatBytes(entry.size ?? 0).padStart(9, ' ') : ''.padStart(9, ' ');
+      const suffix = entry.kind === 'directory' ? '/' : '';
+      const matched = entry.matchedPatterns.length > 1 ? ` [${entry.matchedPatterns.join(', ')}]` : '';
+      return `${(i + 1).toString().padStart(4, ' ')}. [${kindLabel}] ${size} ${modified} ${entry.path}${suffix}${matched}`;
+    }).join('\n');
+
+    return [
+      header,
+      summaryText,
+      entryList,
+      truncated ? `\nHint: results were limited to ${limit}. Use narrower patterns, modified_after/modified_before, max_depth, or a more specific path to continue.` : '',
+    ].filter(Boolean).join('\n');
+>>>>>>> origin/pr-156
   }
+}
+
+function normalizePatterns(args: any): string[] {
+  const values: string[] = [];
+  if (typeof args?.pattern === 'string' && args.pattern.trim()) values.push(args.pattern.trim());
+  if (Array.isArray(args?.patterns)) {
+    for (const item of args.patterns) {
+      if (typeof item === 'string' && item.trim()) values.push(item.trim());
+    }
+  }
+  return [...new Set(values)].slice(0, 20);
+}
+
+function normalizeLimit(value: unknown): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return 100;
+  return Math.floor(parsed);
+}
+
+function normalizeKind(value: unknown): GlobKindFilter {
+  if (value === 'directories' || value === 'all') return value;
+  return 'files';
+}
+
+function normalizePositiveInteger(value: unknown): number | undefined {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+  return Math.floor(parsed);
+}
+
+function parseDateFilter(value: unknown): { timestamp: number; label: string } | undefined {
+  if (value === undefined || value === null || value === '') return undefined;
+  const label = String(value).trim();
+  if (!label) return undefined;
+  const timestamp = typeof value === 'number' ? value : Date.parse(label);
+  if (!Number.isFinite(timestamp)) return undefined;
+  return { timestamp, label };
+}
+
+function normalizeRelativePath(value: string): string {
+  return value.replace(/\\/g, '/').replace(/^\.\//, '');
+}
+
+async function collectEntries(
+  cwd: string,
+  matchedPaths: Map<string, Set<string>>,
+  options: {
+    kind: GlobKindFilter;
+    modifiedAfter?: { timestamp: number };
+    modifiedBefore?: { timestamp: number };
+  },
+): Promise<GlobEntry[]> {
+  const entries: GlobEntry[] = [];
+  for (const [relativePath, matchedPatterns] of matchedPaths) {
+    const fullPath = path.join(cwd, relativePath);
+    let stats: fs.Stats;
+    try {
+      stats = await fs.promises.lstat(fullPath);
+    } catch {
+      continue;
+    }
+    const kind = entryKind(stats);
+    if (options.kind === 'files' && kind !== 'file') continue;
+    if (options.kind === 'directories' && kind !== 'directory') continue;
+    const mtime = stats.mtime.getTime();
+    if (options.modifiedAfter && mtime < options.modifiedAfter.timestamp) continue;
+    if (options.modifiedBefore && mtime > options.modifiedBefore.timestamp) continue;
+    entries.push({
+      path: relativePath,
+      kind,
+      mtime,
+      size: kind === 'file' ? stats.size : undefined,
+      matchedPatterns: [...matchedPatterns],
+    });
+  }
+  return entries;
+}
+
+function entryKind(stats: fs.Stats): GlobEntryKind {
+  if (stats.isFile()) return 'file';
+  if (stats.isDirectory()) return 'directory';
+  if (stats.isSymbolicLink()) return 'symlink';
+  return 'other';
+}
+
+function buildSummary(entries: GlobEntry[]): GlobSummary {
+  return {
+    byTopDirectory: topFacet(entries.map(entry => topDirectory(entry.path))),
+    byExtension: topFacet(entries.map(entry => entry.kind === 'directory' ? '[directory]' : extensionOf(entry.path))),
+    byModifiedDay: topFacet(entries.map(entry => entry.mtime > 0 ? new Date(entry.mtime).toISOString().slice(0, 10) : 'unknown')),
+  };
+}
+
+function topFacet(values: string[], limit = 8): Array<{ key: string; count: number }> {
+  const counts = new Map<string, number>();
+  for (const value of values) counts.set(value, (counts.get(value) || 0) + 1);
+  return [...counts.entries()]
+    .map(([key, count]) => ({ key, count }))
+    .sort((a, b) => b.count - a.count || a.key.localeCompare(b.key))
+    .slice(0, limit);
+}
+
+function topDirectory(filePath: string): string {
+  const normalized = normalizeRelativePath(filePath);
+  const parts = normalized.split('/').filter(Boolean);
+  if (parts.length <= 1) return '.';
+  return parts[0];
+}
+
+function extensionOf(filePath: string): string {
+  const ext = path.extname(filePath).toLowerCase();
+  return ext || '[no extension]';
+}
+
+function formatFacet(label: string, values: Array<{ key: string; count: number }>): string {
+  if (values.length === 0) return `  ${label}: none`;
+  return `  ${label}: ${values.map(item => `${item.key}=${item.count}`).join(', ')}`;
+}
+
+function formatBytes(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let size = value;
+  let unitIndex = 0;
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024;
+    unitIndex += 1;
+  }
+  const precision = unitIndex === 0 || size >= 10 ? 0 : 1;
+  return `${size.toFixed(precision)} ${units[unitIndex]}`;
 }

--- a/src/tools/glob-tool.ts
+++ b/src/tools/glob-tool.ts
@@ -75,6 +75,11 @@ export class GlobTool implements Tool {
           enum: ['files', 'directories', 'all'],
           default: 'files',
         },
+        include_directories: {
+          type: 'boolean',
+          description: 'Legacy compatibility alias for kind=all. Include matching directories as well as files.',
+          default: false,
+        },
         max_depth: {
           type: 'number',
           description: 'Maximum search depth relative to path. Use 1-3 for shallow structure checks.',
@@ -107,7 +112,9 @@ export class GlobTool implements Tool {
     const searchPath = args?.path;
     const patterns = normalizePatterns(args);
     const limit = normalizeLimit(args?.limit);
-    const kind = normalizeKind(args?.kind);
+    const kind = args?.kind === undefined && args?.include_directories === true
+      ? 'all'
+      : normalizeKind(args?.kind);
     const maxDepth = normalizePositiveInteger(args?.max_depth);
     const modifiedAfter = parseDateFilter(args?.modified_after);
     const modifiedBefore = parseDateFilter(args?.modified_before);

--- a/tests/catsco-connector-lock.test.ts
+++ b/tests/catsco-connector-lock.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { acquireCatsCoConnectorLock } from '../src/catscompany/connector-lock';
+
+describe('CatsCo connector startup lock', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'catsco-connector-lock-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test('blocks a second live connector for the same body id', () => {
+    const first = acquireCatsCoConnectorLock({
+      runtimeRoot: tempDir,
+      bodyId: 'body-a',
+      command: 'first',
+    });
+    assert.equal(first.acquired, true);
+
+    const second = acquireCatsCoConnectorLock({
+      runtimeRoot: tempDir,
+      bodyId: 'body-a',
+      command: 'second',
+    });
+    assert.equal(second.acquired, false);
+
+    const otherDevice = acquireCatsCoConnectorLock({
+      runtimeRoot: tempDir,
+      bodyId: 'body-b',
+      command: 'other-device',
+    });
+    assert.equal(otherDevice.acquired, true);
+    first.release();
+    otherDevice.release();
+  });
+
+  test('overwrites a stale lock for the same body id', () => {
+    const lockDir = path.join(tempDir, '.xiaoba');
+    fs.mkdirSync(lockDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(lockDir, 'catsco-connector.lock.json'),
+      JSON.stringify({
+        bodyId: 'body-a',
+        pid: -1,
+        startedAt: new Date().toISOString(),
+        command: 'stale-process',
+        token: 'stale-token',
+      }),
+      'utf8',
+    );
+
+    const acquired = acquireCatsCoConnectorLock({
+      runtimeRoot: tempDir,
+      bodyId: 'body-a',
+      command: 'replacement',
+    });
+    assert.equal(acquired.acquired, true);
+    acquired.release();
+  });
+});

--- a/tests/catscompany-client-body-id.test.ts
+++ b/tests/catscompany-client-body-id.test.ts
@@ -595,6 +595,69 @@ describe('CatsCompany client body identity', () => {
     client.disconnect();
   });
 
+  test('rejects thin tool rpc results that omit pending request scope fields', async () => {
+    const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    servers.push(server);
+    await new Promise<void>(resolve => server.once('listening', resolve));
+
+    server.once('connection', socket => {
+      socket.on('message', data => {
+        const msg = JSON.parse(data.toString());
+        if (msg.hi) {
+          socket.send(JSON.stringify({
+            ctrl: {
+              id: msg.hi.id,
+              code: 200,
+              params: {
+                build: 'catscompany',
+                ver: '0.1.0',
+                features: ['client_msg_id', 'thin_tool_rpc'],
+                uid: 'usr42',
+                name: 'Agent',
+              },
+            },
+          }));
+          return;
+        }
+        if (msg.thin_tool_rpc?.type === 'request') {
+          socket.send(JSON.stringify({ ctrl: { id: msg.thin_tool_rpc.id, code: 200, text: 'ok' } }));
+          socket.send(JSON.stringify({
+            thin_tool_rpc: {
+              type: 'result',
+              request_id: msg.thin_tool_rpc.request_id,
+              result: { ok: true },
+            },
+          }));
+        }
+      });
+    });
+
+    const address = server.address() as AddressInfo;
+    const client = new CatsClient({
+      serverUrl: `ws://127.0.0.1:${address.port}`,
+      apiKey: 'cc-test-key',
+      bodyId: 'body-agent',
+      installationId: 'install-agent',
+    });
+    client.on('error', () => undefined);
+    await new Promise<void>(resolve => {
+      client.once('ready', () => resolve());
+      client.connect();
+    });
+
+    await assert.rejects(
+      () => client.sendThinToolRpcRequest({
+        request_id: 'thin-missing-scope',
+        target_owner_user_id: 'usr7',
+        target_device_id: 'install-test',
+        tool_name: 'read_file',
+        payload: { args: { file_path: '/tmp/a.txt' } },
+      }),
+      /scope does not match/
+    );
+    client.disconnect();
+  });
+
   test('rejects pending thin tool rpc when websocket closes before result', async () => {
     const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
     servers.push(server);

--- a/tests/config-manager-merge.test.ts
+++ b/tests/config-manager-merge.test.ts
@@ -65,7 +65,7 @@ function runDashboardStatusProbe(homeDir: string, envFile: string): any {
         const server = app.listen(0, '127.0.0.1');
         await new Promise(resolve => server.once('listening', resolve));
         const address = server.address();
-        const response = await fetch('http://127.0.0.1:' + address.port + '/api/status');
+        const response = await fetch('http://127.0.0.1:' + address.port + '/api/status/details');
         const data = await response.json();
         await new Promise(resolve => server.close(resolve));
         process.stdout.write(JSON.stringify({

--- a/tests/dashboard-auth.test.ts
+++ b/tests/dashboard-auth.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import express from 'express';
+import type { Server } from 'http';
+import { createDashboardAuth } from '../src/dashboard/auth';
+
+const servers: Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map(close));
+});
+
+function listen(app: express.Express): Promise<Server> {
+  return new Promise(resolve => {
+    const server = app.listen(0, '127.0.0.1', () => resolve(server));
+    servers.push(server);
+  });
+}
+
+function close(server: Server): Promise<void> {
+  return new Promise(resolve => server.close(() => resolve()));
+}
+
+function baseUrl(server: Server): string {
+  const addr = server.address();
+  assert.ok(addr && typeof addr === 'object');
+  return `http://127.0.0.1:${addr.port}`;
+}
+
+async function startAuthServer(apiKey?: string): Promise<string> {
+  const auth = createDashboardAuth({ apiKey });
+  const app = express();
+  app.use('/api', auth.middleware, (req, res) => {
+    if (req.path === '/status') return res.json({ ok: true, authRequired: auth.getStatus().enabled });
+    if (req.path === '/readiness') return res.json({ ok: true, authRequired: auth.getStatus().enabled });
+    return res.json({ ok: true, path: req.path });
+  });
+  return baseUrl(await listen(app));
+}
+
+describe('dashboard auth middleware', () => {
+  test('allows protected routes when auth is disabled', async () => {
+    const base = await startAuthServer(undefined);
+    const res = await fetch(`${base}/api/protected`);
+    assert.equal(res.status, 200);
+  });
+
+  test('allows public GET/HEAD status and readiness routes when auth is enabled', async () => {
+    const base = await startAuthServer('secret');
+    assert.equal((await fetch(`${base}/api/status`)).status, 200);
+    assert.equal((await fetch(`${base}/api/status/`)).status, 200);
+    assert.equal((await fetch(`${base}/api/readiness`)).status, 200);
+    assert.equal((await fetch(`${base}/api/status`, { method: 'HEAD' })).status, 200);
+  });
+
+  test('protects unsafe public-path methods and details routes', async () => {
+    const base = await startAuthServer('secret');
+    assert.equal((await fetch(`${base}/api/status`, { method: 'POST' })).status, 401);
+    assert.equal((await fetch(`${base}/api/status/details`)).status, 401);
+    assert.equal((await fetch(`${base}/api/readiness/details`)).status, 401);
+  });
+
+  test('returns machine-readable codes for missing and invalid keys', async () => {
+    const base = await startAuthServer('secret');
+    let res = await fetch(`${base}/api/protected`);
+    let body = await res.json() as any;
+    assert.equal(res.status, 401);
+    assert.equal(body.code, 'dashboard_auth_required');
+
+    res = await fetch(`${base}/api/protected`, { headers: { 'x-api-key': 'wrong' } });
+    body = await res.json() as any;
+    assert.equal(res.status, 403);
+    assert.equal(body.code, 'dashboard_auth_invalid');
+  });
+
+  test('accepts trimmed X-API-Key and Bearer credentials', async () => {
+    const base = await startAuthServer('  secret  ');
+    assert.equal((await fetch(`${base}/api/protected`, { headers: { 'x-api-key': ' secret ' } })).status, 200);
+    assert.equal((await fetch(`${base}/api/protected`, { headers: { authorization: 'Bearer secret' } })).status, 200);
+  });
+
+  test('rate limits invalid keys, includes Retry-After, and lets correct key recover', async () => {
+    const base = await startAuthServer('secret');
+    for (let i = 0; i < 10; i += 1) {
+      const res = await fetch(`${base}/api/protected`, { headers: { 'x-api-key': 'wrong' } });
+      assert.equal(res.status, 403);
+    }
+
+    let res = await fetch(`${base}/api/protected`, { headers: { 'x-api-key': 'wrong' } });
+    const limited = await res.json() as any;
+    assert.equal(res.status, 429);
+    assert.equal(limited.code, 'dashboard_auth_rate_limited');
+    assert.ok(Number(res.headers.get('retry-after')) >= 1);
+
+    res = await fetch(`${base}/api/protected`, { headers: { 'x-api-key': 'secret' } });
+    assert.equal(res.status, 200);
+
+    res = await fetch(`${base}/api/protected`, { headers: { 'x-api-key': 'wrong' } });
+    assert.equal(res.status, 403);
+  });
+});

--- a/tests/dashboard-readiness.test.ts
+++ b/tests/dashboard-readiness.test.ts
@@ -134,7 +134,7 @@ describe('dashboard readiness and service preflight API', () => {
   });
 
   test('GET /readiness blocks startup when the primary model key is missing', async () => {
-    const response = await fetch(`${baseUrl}/api/readiness`);
+    const response = await fetch(`${baseUrl}/api/readiness/details`);
     const text = await response.text();
     const data = JSON.parse(text) as any;
     const model = data.sections.find((section: any) => section.id === 'model');
@@ -176,7 +176,7 @@ describe('dashboard readiness and service preflight API', () => {
     assert.equal(preflightText.includes('catsco-agent-secret'), false);
     assert.equal(preflightText.includes(testRoot), false);
 
-    const readinessResponse = await fetch(`${baseUrl}/api/readiness`);
+    const readinessResponse = await fetch(`${baseUrl}/api/readiness/details`);
     const readinessText = await readinessResponse.text();
     const readiness = JSON.parse(readinessText) as any;
     const catsco = readiness.sections.find((section: any) => section.id === 'catsco');
@@ -217,7 +217,7 @@ describe('dashboard readiness and service preflight API', () => {
     assert.equal(preflight.blockingChecks.includes('model.custom.credential'), false);
     assert.deepStrictEqual(preflight.blockingChecks, []);
 
-    const readinessResponse = await fetch(`${baseUrl}/api/readiness`);
+    const readinessResponse = await fetch(`${baseUrl}/api/readiness/details`);
     const readinessText = await readinessResponse.text();
     const readiness = JSON.parse(readinessText) as any;
     const model = readiness.sections.find((section: any) => section.id === 'model');
@@ -248,7 +248,7 @@ describe('dashboard readiness and service preflight API', () => {
     ]);
     writeConfirmedCatsBinding();
 
-    const readinessResponse = await fetch(`${baseUrl}/api/readiness`);
+    const readinessResponse = await fetch(`${baseUrl}/api/readiness/details`);
     const readinessText = await readinessResponse.text();
     const readiness = JSON.parse(readinessText) as any;
     const model = readiness.sections.find((section: any) => section.id === 'model');

--- a/tests/dashboard-settings-api.test.ts
+++ b/tests/dashboard-settings-api.test.ts
@@ -264,7 +264,7 @@ describe('dashboard typed settings API', () => {
     assert.equal(process.env.GAUZ_LLM_CONTEXT_WINDOW_TOKENS, '512000');
     assert.equal(process.env.GAUZ_LLM_REASONING_EFFORT, 'max');
 
-    const statusResponse = await fetch(`${baseUrl}/api/status`);
+    const statusResponse = await fetch(`${baseUrl}/api/status/details`);
     const status = await statusResponse.json() as any;
     assert.equal(status.provider, 'anthropic');
     assert.equal(status.model, 'MiniMax-M2.7-highspeed');

--- a/tests/glob-tool.test.ts
+++ b/tests/glob-tool.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { GlobTool } from '../src/tools/glob-tool';
+import type { DeviceRpcToolRequest, ToolExecutionContext } from '../src/types/tool';
+import type { DeviceGrantOperation, ScopedDeviceGrant, ScopedDeviceSelection } from '../src/types/session-identity';
+
+describe('GlobTool', () => {
+  let root: string;
+  let tool: GlobTool;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'glob-tool-'));
+    tool = new GlobTool();
+
+    writeFixture('scripts/chat_eval.py', 'print("chat")\n', '2026-06-24T12:00:00.000Z');
+    writeFixture('scripts/dialog_test.ts', 'export const dialog = true;\n', '2026-06-24T12:05:00.000Z');
+    writeFixture('logs/recent.log', 'recent\n', '2026-06-24T13:00:00.000Z');
+    writeFixture('logs/old.log', 'old\n', '2026-06-20T13:00:00.000Z');
+    writeFixture('nested/deep/deep_test.py', 'print("deep")\n', '2026-06-24T14:00:00.000Z');
+    writeFixture('README.md', '# fixture\n', '2026-06-24T15:00:00.000Z');
+    fs.mkdirSync(path.join(root, 'empty-dir'), { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('keeps legacy single-pattern file search behavior', async () => {
+    const result = await tool.execute({ pattern: '**/*.py' }, context());
+
+    assert.equal(result.ok, true);
+    const output = String(result.content);
+    assert.match(output, /Found 2\/2 files/);
+    assert.match(output, /scripts\/chat_eval\.py/);
+    assert.match(output, /nested\/deep\/deep_test\.py/);
+  });
+
+  test('accepts multiple patterns and includes summary facets', async () => {
+    const result = await tool.execute({
+      patterns: ['**/*chat*.py', '**/*dialog*.ts'],
+      summary: true,
+    }, context());
+
+    assert.equal(result.ok, true);
+    const output = String(result.content);
+    assert.match(output, /Patterns: \*\*\/\*chat\*\.py, \*\*\/\*dialog\*\.ts/);
+    assert.match(output, /scripts\/chat_eval\.py/);
+    assert.match(output, /scripts\/dialog_test\.ts/);
+    assert.match(output, /Summary:/);
+    assert.match(output, /top directories: scripts=2/);
+    assert.match(output, /extensions: \.py=1, \.ts=1|extensions: \.ts=1, \.py=1/);
+  });
+
+  test('filters by entry kind', async () => {
+    const result = await tool.execute({ pattern: '*', kind: 'directories' }, context());
+
+    assert.equal(result.ok, true);
+    const output = String(result.content);
+    assert.match(output, /Kind: directories/);
+    assert.match(output, /scripts\//);
+    assert.match(output, /logs\//);
+    assert.match(output, /empty-dir\//);
+    assert.doesNotMatch(output, /README\.md/);
+  });
+
+  test('filters by modified time', async () => {
+    const result = await tool.execute({
+      pattern: 'logs/*.log',
+      modified_after: '2026-06-23T00:00:00.000Z',
+    }, context());
+
+    assert.equal(result.ok, true);
+    const output = String(result.content);
+    assert.match(output, /logs\/recent\.log/);
+    assert.doesNotMatch(output, /logs\/old\.log/);
+    assert.match(output, /Modified after: 2026-06-23T00:00:00.000Z/);
+  });
+
+  test('limits recursive traversal with max_depth', async () => {
+    const result = await tool.execute({
+      pattern: '**/*.py',
+      max_depth: 2,
+    }, context());
+
+    assert.equal(result.ok, true);
+    const output = String(result.content);
+    assert.match(output, /scripts\/chat_eval\.py/);
+    assert.doesNotMatch(output, /nested\/deep\/deep_test\.py/);
+    assert.match(output, /Max depth: 2/);
+  });
+
+  test('rejects calls without a pattern dimension', async () => {
+    const result = await tool.execute({}, context());
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.errorCode, 'INVALID_TOOL_ARGUMENTS');
+      assert.match(result.message, /requires either pattern or patterns/);
+    }
+  });
+
+  test('adds legacy pattern when forwarding patterns-only calls to a remote target', async () => {
+    let forwardedRequest: DeviceRpcToolRequest | undefined;
+    const ctx = context();
+    ctx.surface = 'catscompany';
+    ctx.deviceSelection = selectedDevice(['glob']);
+    ctx.deviceGrants = [deviceGrant(['glob'])];
+    ctx.deviceRpc = {
+      executeTool: async (request) => {
+        forwardedRequest = request;
+        return { ok: true, content: 'remote glob ok' };
+      },
+    };
+
+    const result = await tool.execute({
+      target: 'speaker_default',
+      patterns: ['**/*chat*.py', '**/*dialog*.ts'],
+      path: '/remote/project',
+      summary: true,
+    }, ctx);
+
+    assert.equal(result.ok, true);
+    assert.equal(forwardedRequest?.toolName, 'glob');
+    assert.equal(forwardedRequest?.operation, 'glob');
+    assert.equal(forwardedRequest?.targetDeviceId, 'speaker-device');
+    assert.deepEqual(forwardedRequest?.args, {
+      patterns: ['**/*chat*.py', '**/*dialog*.ts'],
+      path: '/remote/project',
+      summary: true,
+      pattern: '**/*chat*.py',
+    });
+  });
+
+  function context(): ToolExecutionContext {
+    return {
+      workingDirectory: root,
+      conversationHistory: [],
+      surface: 'cli',
+    };
+  }
+
+  function selectedDevice(operations: DeviceGrantOperation[]): ScopedDeviceSelection {
+    return {
+      kind: 'user_device_selection',
+      source: 'catscompany',
+      status: 'selected',
+      sessionKey: 'session:v2:catscompany:p2p:topic:agent:agent-1',
+      topicId: 'topic',
+      topicType: 'p2p',
+      actorUserId: 'speaker-user',
+      agentId: 'agent-1',
+      identityTrust: 'server_canonical',
+      selectedDeviceId: 'speaker-device',
+      selectedDeviceDisplayName: 'Speaker Laptop',
+      selectedDeviceBodyId: 'speaker-body',
+      selectedDeviceInstallationId: 'speaker-install',
+      selectedDeviceOperations: operations,
+      createdAt: Date.now() - 1000,
+    };
+  }
+
+  function deviceGrant(operations: DeviceGrantOperation[]): ScopedDeviceGrant {
+    return {
+      kind: 'user_device_grant',
+      source: 'catscompany',
+      grantId: 'grant-glob',
+      status: 'active',
+      identityTrust: 'server_canonical',
+      deviceId: 'speaker-device',
+      deviceDisplayName: 'Speaker Laptop',
+      deviceBodyId: 'speaker-body',
+      deviceInstallationId: 'speaker-install',
+      ownerUserId: 'speaker-user',
+      sessionKey: 'session:v2:catscompany:p2p:topic:agent:agent-1',
+      topicId: 'topic',
+      topicType: 'p2p',
+      actorUserId: 'speaker-user',
+      agentId: 'agent-1',
+      operations,
+      createdAt: Date.now() - 1000,
+      expiresAt: Date.now() + 60_000,
+    };
+  }
+
+  function writeFixture(relativePath: string, content: string, isoMtime: string): void {
+    const fullPath = path.join(root, relativePath);
+    fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+    fs.writeFileSync(fullPath, content);
+    const time = new Date(isoMtime);
+    fs.utimesSync(fullPath, time, time);
+  }
+});

--- a/tests/tool-result-tool-manager.test.ts
+++ b/tests/tool-result-tool-manager.test.ts
@@ -65,7 +65,8 @@ describe('ToolManager - ToolExecutionResult 统一处理', () => {
       [],
     );
     assert.strictEqual(result.ok, true);
-    assert.ok(result.content?.includes('找到'));
+    assert.ok(String(result.content).includes('a.txt'));
+    assert.ok(String(result.content).includes('b.txt'));
     assert.strictEqual(result.errorCode, undefined);
   });
 


### PR DESCRIPTION
Integrates the requested work from #176, #156, and #192 onto current main.

- #176: retain connector-lock/body-binding fixes while preserving current path-redaction behavior.
- #156: add multi-pattern and metadata glob search, preserving legacy include_directories compatibility.
- #192: add optional Dashboard API key auth, public summaries, protected details, and rate limiting.

Validation:
- npm run build
- 49 targeted CatsCo/glob/tool tests passed
- 55 targeted Dashboard tests passed
- Full runtime suite matches main baseline: 29 pre-existing failures in both runs.