### PR TITLE
修复 Shell 超时识别与 CI 断言

### DIFF
--- a/src/tools/bash-tool.ts
+++ b/src/tools/bash-tool.ts
@@ -44,6 +44,20 @@ interface ShellRunResult {
   truncated: boolean;
 }
 
+export function isShellCommandTimeoutError(error: any): boolean {
+  const text = [error?.message, error?.code, error?.name]
+    .filter(value => value !== undefined && value !== null)
+    .map(value => String(value).toLowerCase())
+    .join(' ');
+  if (text.includes('timed out') || text.includes('timeout') || text.includes('etimedout')) {
+    return true;
+  }
+
+  // child_process.exec reports POSIX timeouts as a killed child with a signal,
+  // while its message may only say "Command failed" and omit timeout wording.
+  return error?.killed === true && typeof error?.signal === 'string' && error.signal.length > 0;
+}
+
 export class ShellTool implements Tool {
   definition: ToolDefinition = {
     name: 'execute_shell',
@@ -215,7 +229,7 @@ export class ShellTool implements Tool {
         context,
       ) || cwdBefore;
       const aborted = context.abortSignal?.aborted || /aborted|abort/i.test(String(error.message || ''));
-      const timedOut = !aborted && this.isTimeoutError(error);
+      const timedOut = !aborted && isShellCommandTimeoutError(error);
       if (aborted || timedOut) {
         return {
           ok: false,
@@ -743,11 +757,6 @@ export class ShellTool implements Tool {
       };
     }
     return { ok: true, directory };
-  }
-
-  private isTimeoutError(error: any): boolean {
-    const text = String(error?.message || error?.code || '').toLowerCase();
-    return text.includes('timed out') || text.includes('timeout') || text === 'etimedout';
   }
 
   private formatExecutionError(error: any): string {

--- a/tests/shell-current-directory.test.ts
+++ b/tests/shell-current-directory.test.ts
@@ -3,7 +3,7 @@ import * as assert from 'node:assert';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { ShellTool } from '../src/tools/bash-tool';
+import { isShellCommandTimeoutError, ShellTool } from '../src/tools/bash-tool';
 import { ToolExecutionContext } from '../src/types/tool';
 
 describe('ShellTool current directory probe', () => {
@@ -73,8 +73,8 @@ describe('ShellTool current directory probe', () => {
     assert.strictEqual(result.ok, true);
     assert.ok(fs.existsSync(path.join(testRoot, 'sub', 'marker.txt')));
     assertSameDirectory(currentDirectory, path.join(testRoot, 'sub'));
-    assert.ok((result.content as string).includes(`Working directory: ${path.resolve(testRoot, 'sub')}`));
-    assert.ok((result.content as string).includes(`Final cwd: ${path.resolve(testRoot, 'sub')}`));
+    assert.ok((result.content as string).includes(`cwd_before: ${path.resolve(testRoot, 'sub')}`));
+    assert.ok((result.content as string).includes(`cwd_after: ${path.resolve(testRoot, 'sub')}`));
   });
 
   test('successful commands return both stdout and stderr', async () => {
@@ -147,6 +147,21 @@ describe('ShellTool current directory probe', () => {
     assert.match(result.message, /^timed_out: true$/m);
     assert.match(result.message, /^stdout:/m);
     assert.match(result.message, /^stderr:/m);
+  });
+
+  test('recognizes the POSIX child_process timeout error shape', () => {
+    assert.strictEqual(isShellCommandTimeoutError({
+      message: 'Command failed: sleep 5',
+      code: null,
+      killed: true,
+      signal: 'SIGTERM',
+    }), true);
+    assert.strictEqual(isShellCommandTimeoutError({
+      message: 'Command terminated by signal SIGTERM',
+      killed: false,
+      signal: 'SIGTERM',
+    }), false);
+    assert.strictEqual(isShellCommandTimeoutError({ code: 'ETIMEDOUT' }), true);
   });
 
   test('successful cd is persisted even when a later command fails', async () => {


### PR DESCRIPTION
## 问题

远程 `main` 的运行时测试在 ShellTool 链路出现两个失败：

- 结构化 shell 输出已改为 `cwd_before` / `cwd_after`，旧测试仍断言 `Working directory` / `Final cwd`。
- POSIX 下 `child_process.exec` 超时时，错误消息可能只有 `Command failed`，但会携带 `killed=true` 和终止信号；原判断只搜索 timeout 文案，导致超时被误报为 `TOOL_EXECUTION_ERROR`。

## 改动

- 更新显式 cwd 测试，断言当前结构化输出契约。
- 综合检查错误的 message、code 和 name，并识别 Node POSIX 超时的 killed + signal 形态。
- 增加跨平台单测，覆盖 POSIX 超时形态、普通信号终止和 `ETIMEDOUT`。
- 不改命令执行主体、超时值或中止请求的优先级。

## 影响

Linux/macOS 命令超时会稳定返回 `EXECUTION_TIMEOUT` 和 `status: timed_out`，让主 Agent 与远程设备链路按正确语义处理；普通命令失败和非超时信号终止保持原行为。

## 验证

- `npx tsx --test tests/shell-current-directory.test.ts`：12 通过，0 失败，2 平台跳过
- `npm test`：924 通过，0 失败，4 跳过
- `npm run build`
- `git diff --check`

关联失败流水线：https://github.com/buildsense-ai/XiaoBa-CLI/actions/runs/29193102545