### PR TITLE
支持 OpenAI Responses API 与提示词缓存

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@ GAUZ_LLM_PROVIDER=anthropic
 GAUZ_LLM_API_BASE=
 GAUZ_LLM_API_KEY=
 GAUZ_LLM_MODEL=
+# OpenAI only: chat_completions keeps broad compatible-provider support;
+# responses enables the Responses API and stable prompt cache routing.
+GAUZ_LLM_OPENAI_API_MODE=chat_completions
 # Reasoning control for supported models. For DeepSeek, high/max map to
 # reasoning_effort and disabled maps to thinking.type=disabled. Legacy default
 # is still accepted by the app, but the Dashboard treats it as high.

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -8341,6 +8341,10 @@
       {value:'512000',label:'512K',hint:'超长文档'},
       {value:'1000000',label:'1M',hint:'百万上下文'},
     ];
+    const OPENAI_API_MODE_OPTIONS=[
+      {value:'chat_completions',label:'Chat Completions（兼容优先）'},
+      {value:'responses',label:'Responses API（提示词缓存）'},
+    ];
     const REASONING_EFFORT_OPTIONS=[
       {value:'default',label:'default',hint:'兼容旧配置，不在 DeepSeek 卡片中展示'},
       {value:'high',label:'reasoning_effort: high',hint:'thinking.type=enabled'},
@@ -8517,6 +8521,29 @@
       )).join('');
     }
 
+    function customOpenAIApiModeValue(){
+      const custom=customStartupProfile();
+      const value=String(custom.openaiApiMode || settingValue('model.openaiApiMode') || 'chat_completions');
+      return OPENAI_API_MODE_OPTIONS.some(option=>option.value===value)?value:'chat_completions';
+    }
+
+    function openAIApiModeOptionsHtml(selectedValue){
+      return OPENAI_API_MODE_OPTIONS.map(option=>(
+        '<option value="'+escapeHtml(option.value)+'" '+(option.value===selectedValue?'selected':'')+'>'
+        +escapeHtml(option.label)
+        +'</option>'
+      )).join('');
+    }
+
+    function syncCustomOpenAIApiModeVisibility(){
+      const provider=document.getElementById('model-provider-setting')?.value;
+      const row=document.getElementById('model-openai-api-mode-row');
+      const select=document.getElementById('model-openai-api-mode-setting');
+      const visible=provider==='openai';
+      if(row)row.style.display=visible?'':'none';
+      if(select)select.disabled=!visible;
+    }
+
     function normalizeReasoningEffortValue(value){
       const text=String(value||'').trim().toLowerCase();
       return REASONING_EFFORT_OPTIONS.some(option=>option.value===text)?text:'default';
@@ -8676,8 +8703,11 @@
       const model=custom.model || settingValue('model.model') || '未配置';
       const contextLabel=customModelContextWindowLabel();
       const reasoningMeta=modelSupportsReasoningSwitch(model)?' · 推理 '+deepseekReasoningEffortLabel(customReasoningEffortValue()):'';
+      const apiModeMeta=provider==='openai'
+        ? ' · '+(customOpenAIApiModeValue()==='responses'?'Responses API':'Chat Completions')
+        : '';
       const meta=configured
-        ? '自定义配置 · 上下文 '+contextLabel+' · '+(provider==='openai'?'OpenAI SDK':'Anthropic SDK')+reasoningMeta
+        ? '自定义配置 · 上下文 '+contextLabel+' · '+(provider==='openai'?'OpenAI SDK':'Anthropic SDK')+apiModeMeta+reasoningMeta
         : '去设置填写 endpoint / key';
       return '<div class="relay-model-choice '+(active?' active':'')+(configured?'':' needs-config')+'">'
         +'<button class="relay-model-main" type="button" data-custom-startup-action="true" data-custom-startup-context="'+escapeHtml(context)+'" '+(relayActionBusy()?'disabled':'')+' onclick="enableCustomStartupModelFromButton(this)">'
@@ -8744,6 +8774,7 @@
         selectionStart: activeInForm && typeof active.selectionStart==='number' ? active.selectionStart : null,
         selectionEnd: activeInForm && typeof active.selectionEnd==='number' ? active.selectionEnd : null,
         provider: document.getElementById('model-provider-setting')?.value,
+        openaiApiMode: document.getElementById('model-openai-api-mode-setting')?.value,
         apiBase: document.getElementById('model-api-base-setting')?.value,
         model: document.getElementById('model-name-setting')?.value,
         contextWindowTokens: document.getElementById('model-context-window-setting')?.value,
@@ -8764,6 +8795,7 @@
       if(draft && draft.open){
         const pairs=[
           ['model-provider-setting',draft.provider],
+          ['model-openai-api-mode-setting',draft.openaiApiMode],
           ['model-api-base-setting',draft.apiBase],
           ['model-name-setting',draft.model],
           ['model-context-window-setting',draft.contextWindowTokens],
@@ -8777,6 +8809,7 @@
         const clear=document.getElementById('model-secret-clear-setting');
         if(clear && draft.clearSecret!==undefined)clear.checked=Boolean(draft.clearSecret);
       }
+      syncCustomOpenAIApiModeVisibility();
 
       if(draft?.activeId){
         const active=document.getElementById(draft.activeId);
@@ -8806,6 +8839,7 @@
       const apiBaseDisplayValue=hideInternalGateway?'':apiBaseValue;
       const apiBasePlaceholder=hideInternalGateway?'已配置 CatsCo 内部兼容网关（隐藏）':'https://example.com/v1/messages';
       const selectedContextWindow=customModelContextWindowValue();
+      const selectedOpenAIApiMode=customOpenAIApiModeValue();
       const draft=captureCustomModelDraft();
 
       p.innerHTML=`<div class="model-source-layout">
@@ -8821,7 +8855,8 @@
             </div>
           </summary>
           <div class="model-source-form">
-            <div class="config-row"><label class="config-label">兼容类型</label><select class="config-select" id="model-provider-setting"><option value="anthropic"${settingValue('model.provider')==='anthropic'?' selected':''}>Anthropic-compatible</option><option value="openai"${settingValue('model.provider')==='openai'?' selected':''}>OpenAI-compatible</option></select></div>
+            <div class="config-row"><label class="config-label">接口协议</label><select class="config-select" id="model-provider-setting"><option value="anthropic"${settingValue('model.provider')==='anthropic'?' selected':''}>Anthropic Messages</option><option value="openai"${settingValue('model.provider')==='openai'?' selected':''}>OpenAI compatible</option></select></div>
+            <div class="config-row" id="model-openai-api-mode-row"><label class="config-label">OpenAI API</label><select class="config-select" id="model-openai-api-mode-setting">${openAIApiModeOptionsHtml(selectedOpenAIApiMode)}</select></div>
             <div class="config-row"><label class="config-label">模型地址</label><input class="config-input" id="model-api-base-setting" value="${escapeHtml(apiBaseDisplayValue)}" placeholder="${escapeHtml(apiBasePlaceholder)}" data-hidden-internal="${hideInternalGateway?'true':'false'}" /></div>
             <div class="config-row"><label class="config-label">模型名称</label><input class="config-input" id="model-name-setting" value="${escapeHtml(settingValue('model.model'))}" placeholder="model-name" /></div>
             <div class="config-row"><label class="config-label">上下文窗口</label><select class="config-select" id="model-context-window-setting">${customModelContextWindowOptionsHtml(selectedContextWindow)}</select></div>
@@ -9007,6 +9042,7 @@
         payload:{
           settings:{
             'model.provider':document.getElementById('model-provider-setting').value,
+            'model.openaiApiMode':document.getElementById('model-openai-api-mode-setting')?.value || 'chat_completions',
             'model.apiBase':apiBaseValue,
             'model.model':document.getElementById('model-name-setting').value.trim(),
             'model.contextWindowTokens':document.getElementById('model-context-window-setting').value,
@@ -9022,6 +9058,7 @@
       const secret=settings['model.apiKey']||{action:'keep'};
       return JSON.stringify({
         provider:settings['model.provider'],
+        openaiApiMode:settings['model.openaiApiMode'],
         apiBase:settings['model.apiBase'],
         model:settings['model.model'],
         contextWindowTokens:settings['model.contextWindowTokens'],
@@ -9245,6 +9282,7 @@
 
     function bindCustomModelAutoSave(){
       const provider=document.getElementById('model-provider-setting');
+      const openaiApiMode=document.getElementById('model-openai-api-mode-setting');
       const apiBase=document.getElementById('model-api-base-setting');
       const model=document.getElementById('model-name-setting');
       const contextWindow=document.getElementById('model-context-window-setting');
@@ -9256,7 +9294,8 @@
         setModelSourceStatus('改动待自动保存...', 'muted');
         customModelAutoSaveTimer=setTimeout(()=>saveCustomModelSettings({auto:true}),CUSTOM_MODEL_AUTO_SAVE_DELAY);
       };
-      if(provider)provider.addEventListener('change',schedule);
+      if(provider)provider.addEventListener('change',()=>{syncCustomOpenAIApiModeVisibility();schedule();});
+      if(openaiApiMode)openaiApiMode.addEventListener('change',schedule);
       if(apiBase)apiBase.addEventListener('input',schedule);
       if(model)model.addEventListener('input',schedule);
       if(contextWindow)contextWindow.addEventListener('change',schedule);

--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -1034,19 +1034,24 @@ export class ConversationRunner {
 
     const transcriptToolCallIds = new Set(transcriptToolCalls.map(toolCall => toolCall.id));
     const blocks: NonNullable<Message['providerContent']> = [];
-    let hasToolUse = false;
+    let hasMatchingToolCall = false;
 
     for (const block of assistantMsg.providerContent) {
       if (!block || typeof block !== 'object') continue;
       if (block.type === 'tool_use') {
         const id = typeof block.id === 'string' ? block.id : '';
         if (!transcriptToolCallIds.has(id)) continue;
-        hasToolUse = true;
+        hasMatchingToolCall = true;
+      }
+      if (block.type === 'function_call') {
+        const callId = typeof block.call_id === 'string' ? block.call_id : '';
+        if (!transcriptToolCallIds.has(callId)) continue;
+        hasMatchingToolCall = true;
       }
       blocks.push(block);
     }
 
-    return hasToolUse ? blocks : undefined;
+    return hasMatchingToolCall ? blocks : undefined;
   }
 
   private shouldKeepAssistantDraft(

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -10,7 +10,7 @@ import * as path from 'path';
 import * as dotenv from 'dotenv';
 import { PathResolver } from '../../utils/path-resolver';
 import { APP_VERSION } from '../../version';
-import type { ChatConfig, ReasoningEffort } from '../../types';
+import type { ChatConfig, OpenAIApiMode, ReasoningEffort } from '../../types';
 import { createRuntimeConfigSnapshot } from '../../runtime/runtime-config-snapshot';
 import {
   CUSTOM_MODEL_DEFAULT_CONTEXT_WINDOW_TOKENS,
@@ -70,6 +70,7 @@ import {
   serializeBranchAgentsEnabled,
 } from '../../core/branch-agent-settings';
 import { normalizeReasoningEffort, reasoningEffortOrDefault } from '../../utils/reasoning-effort';
+import { normalizeOpenAIApiMode, openAIApiModeOrDefault } from '../../utils/openai-api-mode';
 import {
   BindWeixinChannelResult,
   WeixinChannelStatus,
@@ -201,6 +202,7 @@ const CUSTOM_MODEL_ENV_KEYS = {
   apiKey: 'CATSCO_CUSTOM_LLM_API_KEY',
   contextWindowTokens: 'CATSCO_CUSTOM_LLM_CONTEXT_WINDOW_TOKENS',
   reasoningEffort: 'CATSCO_CUSTOM_LLM_REASONING_EFFORT',
+  openaiApiMode: 'CATSCO_CUSTOM_LLM_OPENAI_API_MODE',
 } as const;
 const RELAY_MODEL_ENV_KEYS = {
   provider: 'CATSCO_RELAY_LLM_PROVIDER',
@@ -209,6 +211,7 @@ const RELAY_MODEL_ENV_KEYS = {
   apiKey: 'CATSCO_RELAY_LLM_API_KEY',
   contextWindowTokens: 'CATSCO_RELAY_LLM_CONTEXT_WINDOW_TOKENS',
   reasoningEffort: 'CATSCO_RELAY_LLM_REASONING_EFFORT',
+  openaiApiMode: 'CATSCO_RELAY_LLM_OPENAI_API_MODE',
 } as const;
 const EFFECTIVE_MODEL_ENV_KEYS = {
   provider: 'GAUZ_LLM_PROVIDER',
@@ -217,6 +220,7 @@ const EFFECTIVE_MODEL_ENV_KEYS = {
   apiKey: 'GAUZ_LLM_API_KEY',
   contextWindowTokens: 'GAUZ_LLM_CONTEXT_WINDOW_TOKENS',
   reasoningEffort: 'GAUZ_LLM_REASONING_EFFORT',
+  openaiApiMode: 'GAUZ_LLM_OPENAI_API_MODE',
 } as const;
 
 interface ModelLaunchProfile {
@@ -226,6 +230,7 @@ interface ModelLaunchProfile {
   apiKey?: string;
   contextWindowTokens?: number;
   reasoningEffort?: ReasoningEffort;
+  openaiApiMode?: OpenAIApiMode;
 }
 
 function normalizeBaseUrl(value: unknown, fallback: string): string {
@@ -465,7 +470,7 @@ export function getCatsAuthState(overrides: Record<string, unknown> = {}): CatsA
   return createCatsCoLocalConfigService({ runtimeRoot: process.cwd() }).getAuthState(overrides);
 }
 
-function getModelConfigReadonly(): Pick<ChatConfig, 'apiKey' | 'apiUrl' | 'model' | 'provider' | 'reasoningEffort'> {
+function getModelConfigReadonly(): Pick<ChatConfig, 'apiKey' | 'apiUrl' | 'model' | 'provider' | 'reasoningEffort' | 'openaiApiMode'> {
   const config = ConfigManager.getConfigReadonly();
   const env = readEnvFile();
   const provider = firstNonEmpty(process.env.GAUZ_LLM_PROVIDER, env.GAUZ_LLM_PROVIDER, config.provider);
@@ -477,12 +482,18 @@ function getModelConfigReadonly(): Pick<ChatConfig, 'apiKey' | 'apiUrl' | 'model
     env.GAUZ_LLM_REASONING_EFFORT,
     config.reasoningEffort,
   ));
+  const openaiApiMode = openAIApiModeOrDefault(firstNonEmpty(
+    process.env.GAUZ_LLM_OPENAI_API_MODE,
+    env.GAUZ_LLM_OPENAI_API_MODE,
+    config.openaiApiMode,
+  ));
 
   return {
     apiKey,
     apiUrl,
     model,
     reasoningEffort,
+    openaiApiMode,
     provider: provider === 'anthropic' || provider === 'openai' ? provider : config.provider,
   };
 }
@@ -1110,6 +1121,7 @@ function modelProfileFromCurrentConfig(): ModelLaunchProfile {
     apiKey: config.apiKey,
     contextWindowTokens: parsePositiveInteger(firstNonEmpty(process.env.GAUZ_LLM_CONTEXT_WINDOW_TOKENS, fileEnv.GAUZ_LLM_CONTEXT_WINDOW_TOKENS)),
     reasoningEffort: normalizeReasoningEffort(firstNonEmpty(process.env.GAUZ_LLM_REASONING_EFFORT, fileEnv.GAUZ_LLM_REASONING_EFFORT, config.reasoningEffort)),
+    openaiApiMode: openAIApiModeOrDefault(firstNonEmpty(process.env.GAUZ_LLM_OPENAI_API_MODE, fileEnv.GAUZ_LLM_OPENAI_API_MODE, config.openaiApiMode)),
   };
 }
 
@@ -1125,6 +1137,7 @@ function modelProfileFromStoredEnv(
     apiKey: firstNonEmpty(process.env[keys.apiKey], fileEnv[keys.apiKey]),
     contextWindowTokens: parsePositiveInteger(firstNonEmpty(process.env[keys.contextWindowTokens], fileEnv[keys.contextWindowTokens])),
     reasoningEffort: normalizeReasoningEffort(firstNonEmpty(process.env[keys.reasoningEffort], fileEnv[keys.reasoningEffort])),
+    openaiApiMode: openAIApiModeOrDefault(firstNonEmpty(process.env[keys.openaiApiMode], fileEnv[keys.openaiApiMode])),
   };
 }
 
@@ -1154,6 +1167,7 @@ function modelProfileUpdates(
     [keys.apiKey]: profile.apiKey,
     [keys.contextWindowTokens]: profile.contextWindowTokens ? String(profile.contextWindowTokens) : undefined,
     [keys.reasoningEffort]: profile.reasoningEffort ? profile.reasoningEffort : undefined,
+    [keys.openaiApiMode]: profile.openaiApiMode ?? 'chat_completions',
   };
 }
 
@@ -1187,6 +1201,12 @@ function requestedCustomReasoningEffort(input: any): ReasoningEffort | undefined
   if (!input?.settings || typeof input.settings !== 'object') return undefined;
   if (!Object.prototype.hasOwnProperty.call(input.settings, 'model.reasoningEffort')) return undefined;
   return reasoningEffortOrDefault(input.settings['model.reasoningEffort']);
+}
+
+function requestedCustomOpenAIApiMode(input: any): OpenAIApiMode | undefined {
+  if (!input?.settings || typeof input.settings !== 'object') return undefined;
+  if (!Object.prototype.hasOwnProperty.call(input.settings, 'model.openaiApiMode')) return undefined;
+  return normalizeOpenAIApiMode(input.settings['model.openaiApiMode']) ?? 'chat_completions';
 }
 
 function requestedReasoningEffort(value: unknown): ReasoningEffort | undefined {
@@ -1235,6 +1255,9 @@ function mirrorCurrentModelAsCustomStartup(input: any, previous: ModelLaunchProf
     reasoningEffort: requestedCustomReasoningEffort(input)
       ?? storedCustom.reasoningEffort
       ?? 'default',
+    openaiApiMode: requestedCustomOpenAIApiMode(input)
+      ?? storedCustom.openaiApiMode
+      ?? 'chat_completions',
   };
 
   if (!isCompleteModelProfile(custom) && (previousSource === 'relay' || isCatsRelayApiBase(previous.apiBase))) {
@@ -1265,6 +1288,7 @@ function writeCustomModelStartupConfig(): { profile: ModelLaunchProfile; updated
   }
   profile.contextWindowTokens = profile.contextWindowTokens ?? CUSTOM_MODEL_DEFAULT_CONTEXT_WINDOW_TOKENS;
   profile.reasoningEffort = profile.reasoningEffort ?? 'default';
+  profile.openaiApiMode = profile.openaiApiMode ?? 'chat_completions';
   const result = writeDashboardEnvAndProcess({
     ...modelProfileUpdates(CUSTOM_MODEL_ENV_KEYS, profile),
     ...modelProfileUpdates(EFFECTIVE_MODEL_ENV_KEYS, profile),
@@ -1322,6 +1346,7 @@ function writeRelayModelStartupConfig(
     apiKey,
     contextWindowTokens: model.contextWindowTokens ?? resolveKnownModelContextWindowTokens(model.model),
     reasoningEffort: relayReasoningEffortOrHigh(options.reasoningEffort ?? currentRelayReasoningEffort()),
+    openaiApiMode: 'chat_completions',
   };
   const result = writeDashboardEnvAndProcess({
     ...modelProfileUpdates(RELAY_MODEL_ENV_KEYS, profile),
@@ -2113,6 +2138,7 @@ export function createApiRouter(
         contextWindowTokens: result.profile.contextWindowTokens,
         contextLabel: result.profile.contextWindowTokens ? formatContextWindowTokens(result.profile.contextWindowTokens) : undefined,
         reasoningEffort: result.profile.reasoningEffort ?? 'default',
+        openaiApiMode: result.profile.openaiApiMode ?? 'chat_completions',
         updated: result.updated,
         cleared: result.cleared,
         restartRequired: activation.wasRunning && !activation.restartRequested,

--- a/src/dashboard/settings.ts
+++ b/src/dashboard/settings.ts
@@ -1,8 +1,9 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as dotenv from 'dotenv';
-import type { ReasoningEffort } from '../types';
+import type { OpenAIApiMode, ReasoningEffort } from '../types';
 import { REASONING_EFFORT_OPTIONS, normalizeReasoningEffort, reasoningEffortOrDefault } from '../utils/reasoning-effort';
+import { OPENAI_API_MODE_OPTIONS, openAIApiModeOrDefault } from '../utils/openai-api-mode';
 
 export type DashboardSettingType = 'enum' | 'string' | 'url' | 'secret';
 export type SecretSettingAction = 'keep' | 'replace' | 'clear';
@@ -46,6 +47,7 @@ export interface DashboardModelProfileSnapshot {
   model?: string;
   contextWindowTokens?: number;
   reasoningEffort?: ReasoningEffort;
+  openaiApiMode?: OpenAIApiMode;
   apiKeyPresent: boolean;
   configured: boolean;
 }
@@ -104,6 +106,16 @@ export const DASHBOARD_SETTING_DEFINITIONS: DashboardSettingDefinition[] = [
     type: 'url',
     required: true,
     protocols: ['http:', 'https:'],
+  },
+  {
+    id: 'model.openaiApiMode',
+    group: 'model',
+    label: 'OpenAI 接口模式',
+    description: 'Chat Completions 兼容旧中转；Responses API 支持新版工具事件和稳定提示词缓存。',
+    envKey: 'GAUZ_LLM_OPENAI_API_MODE',
+    type: 'enum',
+    required: false,
+    options: OPENAI_API_MODE_OPTIONS,
   },
   {
     id: 'model.model',
@@ -176,6 +188,7 @@ const CUSTOM_MODEL_ENV_KEYS: Record<string, string> = {
   'model.model': 'CATSCO_CUSTOM_LLM_MODEL',
   'model.contextWindowTokens': 'CATSCO_CUSTOM_LLM_CONTEXT_WINDOW_TOKENS',
   'model.reasoningEffort': 'CATSCO_CUSTOM_LLM_REASONING_EFFORT',
+  'model.openaiApiMode': 'CATSCO_CUSTOM_LLM_OPENAI_API_MODE',
   'model.apiKey': 'CATSCO_CUSTOM_LLM_API_KEY',
 };
 
@@ -186,6 +199,7 @@ const EFFECTIVE_MODEL_ENV_KEYS = {
   apiKey: 'GAUZ_LLM_API_KEY',
   contextWindowTokens: 'GAUZ_LLM_CONTEXT_WINDOW_TOKENS',
   reasoningEffort: 'GAUZ_LLM_REASONING_EFFORT',
+  openaiApiMode: 'GAUZ_LLM_OPENAI_API_MODE',
 } as const;
 
 const RELAY_MODEL_ENV_KEYS = {
@@ -195,6 +209,7 @@ const RELAY_MODEL_ENV_KEYS = {
   apiKey: 'CATSCO_RELAY_LLM_API_KEY',
   contextWindowTokens: 'CATSCO_RELAY_LLM_CONTEXT_WINDOW_TOKENS',
   reasoningEffort: 'CATSCO_RELAY_LLM_REASONING_EFFORT',
+  openaiApiMode: 'CATSCO_RELAY_LLM_OPENAI_API_MODE',
 } as const;
 
 const MODEL_SOURCE_ENV_KEY = 'CATSCO_MODEL_SOURCE';
@@ -240,12 +255,14 @@ function readModelProfile(
   const apiKey = firstNonEmpty(fileEnv[keys.apiKey], env[keys.apiKey]);
   const contextWindowTokens = parsePositiveInteger(firstNonEmpty(fileEnv[keys.contextWindowTokens], env[keys.contextWindowTokens]));
   const reasoningEffort = normalizeReasoningEffort(firstNonEmpty(fileEnv[keys.reasoningEffort], env[keys.reasoningEffort]));
+  const openaiApiMode = openAIApiModeOrDefault(firstNonEmpty(fileEnv[keys.openaiApiMode], env[keys.openaiApiMode]));
   return {
     provider,
     apiBase: sanitizeUrlSettingValue(apiBase ?? ''),
     model,
     contextWindowTokens,
     reasoningEffort: reasoningEffort ?? 'default',
+    openaiApiMode,
     apiKeyPresent: Boolean(apiKey),
     configured: Boolean(provider && apiBase && model && apiKey),
   };
@@ -267,12 +284,17 @@ function readCustomModelProfile(
     fileEnv.CATSCO_CUSTOM_LLM_REASONING_EFFORT,
     env.CATSCO_CUSTOM_LLM_REASONING_EFFORT,
   ));
+  const openaiApiMode = openAIApiModeOrDefault(firstNonEmpty(
+    fileEnv.CATSCO_CUSTOM_LLM_OPENAI_API_MODE,
+    env.CATSCO_CUSTOM_LLM_OPENAI_API_MODE,
+  ));
   return {
     provider,
     apiBase: sanitizeUrlSettingValue(apiBase ?? ''),
     model,
     contextWindowTokens,
     reasoningEffort: reasoningEffort ?? 'default',
+    openaiApiMode,
     apiKeyPresent: Boolean(apiKey),
     configured: Boolean(provider && apiBase && model && apiKey),
   };
@@ -351,7 +373,11 @@ export function getDashboardSettings(
 
       return {
         ...common,
-        value: definition.type === 'url' ? sanitizeUrlSettingValue(value ?? '') : value ?? '',
+        value: definition.type === 'url'
+          ? sanitizeUrlSettingValue(value ?? '')
+          : definition.id === 'model.openaiApiMode'
+            ? openAIApiModeOrDefault(value)
+            : value ?? '',
       };
     }),
   };

--- a/src/providers/openai-provider.ts
+++ b/src/providers/openai-provider.ts
@@ -1,11 +1,17 @@
 import axios from 'axios';
+import { createHash } from 'crypto';
 import { Message, ChatConfig, ChatResponse, ContentBlock } from '../types';
 import { ToolDefinition } from '../types/tool';
 import { AIProvider, AIRequestOptions, StreamCallbacks } from './provider';
 import { ContextDebugLogger } from '../utils/context-debug-logger';
-import { normalizeOpenAIChatCompletionsUrl } from './openai-url';
+import { normalizeOpenAIChatCompletionsUrl, normalizeOpenAIResponsesUrl } from './openai-url';
 import { resolveMaxTokens } from './output-limits';
-import { applyOpenAIReasoningOptions, supportsOpenAIReasoningReplay } from '../utils/reasoning-effort';
+import {
+  applyOpenAIReasoningOptions,
+  supportsOpenAIReasoningReplay,
+  supportsReasoningSwitch,
+} from '../utils/reasoning-effort';
+import { openAIApiModeOrDefault } from '../utils/openai-api-mode';
 
 /**
  * OpenAI Provider
@@ -15,20 +21,24 @@ import { applyOpenAIReasoningOptions, supportsOpenAIReasoningReplay } from '../u
 export class OpenAIProvider implements AIProvider {
   private apiUrl: string;
   private chatCompletionsUrl: string;
+  private responsesUrl: string;
   private apiKey: string;
   private model: string;
   private temperature: number;
   private maxTokens: number;
   private reasoningEffort: ChatConfig['reasoningEffort'];
+  private openaiApiMode: ChatConfig['openaiApiMode'];
 
   constructor(config: ChatConfig) {
     this.apiUrl = config.apiUrl!;
     this.chatCompletionsUrl = normalizeOpenAIChatCompletionsUrl(this.apiUrl);
+    this.responsesUrl = normalizeOpenAIResponsesUrl(this.apiUrl);
     this.apiKey = config.apiKey!;
     this.model = config.model || 'gpt-4o';
     this.temperature = config.temperature ?? 0.7;
     this.maxTokens = resolveMaxTokens(config);
     this.reasoningEffort = config.reasoningEffort;
+    this.openaiApiMode = openAIApiModeOrDefault(config.openaiApiMode);
   }
 
   /**
@@ -156,6 +166,9 @@ export class OpenAIProvider implements AIProvider {
    * 普通调用
    */
   async chat(messages: Message[], tools?: ToolDefinition[], options?: AIRequestOptions): Promise<ChatResponse> {
+    if (this.openaiApiMode === 'responses') {
+      return this.chatResponses(messages, tools, options);
+    }
     const body = this.buildRequestBody(messages, tools, false);
     ContextDebugLogger.dumpSdkBoundary('before', undefined, {
       apiUrl: this.chatCompletionsUrl,
@@ -181,6 +194,11 @@ export class OpenAIProvider implements AIProvider {
         promptTokens: usage.prompt_tokens ?? 0,
         completionTokens: usage.completion_tokens ?? 0,
         totalTokens: usage.total_tokens ?? 0,
+        cachedReadTokens: usage.prompt_tokens_details?.cached_tokens ?? 0,
+        cachedWriteTokens: usage.prompt_tokens_details?.cache_write_tokens
+          ?? usage.prompt_tokens_details?.cached_creation_tokens
+          ?? usage.prompt_tokens_details?.cache_creation_tokens
+          ?? 0,
       } : undefined,
       ...this.buildOpenAIProviderContent(message),
     };
@@ -195,6 +213,9 @@ export class OpenAIProvider implements AIProvider {
     callbacks?: StreamCallbacks,
     options?: AIRequestOptions,
   ): Promise<ChatResponse> {
+    if (this.openaiApiMode === 'responses') {
+      return this.chatStreamResponses(messages, tools, callbacks, options);
+    }
     const body = this.buildRequestBody(messages, tools, true);
 
     ContextDebugLogger.dumpSdkBoundary('before', undefined, {
@@ -252,6 +273,11 @@ export class OpenAIProvider implements AIProvider {
                 promptTokens: parsed.usage.prompt_tokens ?? 0,
                 completionTokens: parsed.usage.completion_tokens ?? 0,
                 totalTokens: parsed.usage.total_tokens ?? 0,
+                cachedReadTokens: parsed.usage.prompt_tokens_details?.cached_tokens ?? 0,
+                cachedWriteTokens: parsed.usage.prompt_tokens_details?.cache_write_tokens
+                  ?? parsed.usage.prompt_tokens_details?.cached_creation_tokens
+                  ?? parsed.usage.prompt_tokens_details?.cache_creation_tokens
+                  ?? 0,
               };
             }
 
@@ -330,6 +356,361 @@ export class OpenAIProvider implements AIProvider {
         options?.signal?.removeEventListener('abort', onAbort);
         callbacks?.onError?.(err);
         reject(err);
+      });
+    });
+  }
+
+  private buildResponsesRequestBody(messages: Message[], tools?: ToolDefinition[], stream = false): any {
+    const instructions = messages
+      .filter(message => message.role === 'system')
+      .map(message => this.contentAsText(message.content))
+      .filter(Boolean)
+      .join('\n\n');
+    const responseTools = tools?.map(tool => ({
+      type: 'function',
+      name: tool.name,
+      description: tool.description,
+      parameters: tool.parameters,
+    })) ?? [];
+    const body: any = {
+      model: this.model,
+      input: this.buildResponsesInput(messages),
+      max_output_tokens: this.maxTokens,
+      stream,
+      store: false,
+      prompt_cache_key: this.buildPromptCacheKey(instructions, responseTools),
+    };
+
+    if (instructions) body.instructions = instructions;
+    if (Number.isFinite(this.temperature)) body.temperature = this.temperature;
+    if (responseTools.length > 0) body.tools = responseTools;
+    body.include = ['reasoning.encrypted_content'];
+    this.applyResponsesReasoningOptions(body);
+    return body;
+  }
+
+  private isOfficialOpenAIResponsesEndpoint(): boolean {
+    try {
+      return new URL(this.responsesUrl).hostname.toLowerCase() === 'api.openai.com';
+    } catch {
+      return false;
+    }
+  }
+
+  private buildResponsesInput(messages: Message[]): any[] {
+    const input: any[] = [];
+
+    for (const message of messages) {
+      if (message.role === 'system') continue;
+
+      if (message.role === 'tool') {
+        if (!message.tool_call_id) continue;
+        input.push({
+          type: 'function_call_output',
+          call_id: message.tool_call_id,
+          output: this.responsesFunctionOutput(message.content),
+        });
+        continue;
+      }
+
+      if (message.role === 'assistant' && message.tool_calls?.length) {
+        const replayItems = (message.providerContent || [])
+          .filter(item => this.isResponsesReplayItem(item))
+          .map(item => JSON.parse(JSON.stringify(item)));
+        if (replayItems.length > 0) {
+          input.push(...replayItems);
+          continue;
+        }
+
+        const text = this.contentAsText(message.content);
+        if (text) input.push({ role: 'assistant', content: text });
+        for (const toolCall of message.tool_calls) {
+          input.push({
+            type: 'function_call',
+            call_id: toolCall.id,
+            name: toolCall.function.name,
+            arguments: toolCall.function.arguments || '{}',
+          });
+        }
+        continue;
+      }
+
+      input.push({
+        role: message.role,
+        content: this.responsesMessageContent(message.content),
+      });
+    }
+
+    return input;
+  }
+
+  private responsesMessageContent(content: Message['content']): any {
+    if (!Array.isArray(content)) return content ?? '';
+    return content.map(block => block.type === 'text'
+      ? { type: 'input_text', text: block.text }
+      : { type: 'input_image', image_url: `data:${block.source.media_type};base64,${block.source.data}` });
+  }
+
+  private responsesFunctionOutput(content: Message['content']): any {
+    if (!Array.isArray(content)) return content ?? '';
+    return content.map(block => block.type === 'text'
+      ? { type: 'input_text', text: block.text }
+      : { type: 'input_image', image_url: `data:${block.source.media_type};base64,${block.source.data}` });
+  }
+
+  private contentAsText(content: Message['content']): string {
+    if (typeof content === 'string') return content;
+    if (!Array.isArray(content)) return '';
+    return content
+      .filter((block): block is Extract<ContentBlock, { type: 'text' }> => block.type === 'text')
+      .map(block => block.text)
+      .join('\n');
+  }
+
+  private isResponsesReplayItem(item: any): boolean {
+    return Boolean(item && typeof item === 'object' && [
+      'message',
+      'function_call',
+      'reasoning',
+    ].includes(String(item.type || '')));
+  }
+
+  private buildPromptCacheKey(instructions: string, tools: any[]): string {
+    const digest = createHash('sha256')
+      .update(JSON.stringify({ model: this.model, instructions, tools }))
+      .digest('hex')
+      .slice(0, 48);
+    return `catsco-${digest}`;
+  }
+
+  private applyResponsesReasoningOptions(body: any): void {
+    const effort = this.reasoningEffort;
+    if (!effort || effort === 'default') return;
+    if (!this.isOfficialOpenAIResponsesEndpoint() && !supportsReasoningSwitch({
+      apiUrl: this.apiUrl,
+      model: this.model,
+    })) return;
+    body.reasoning = {
+      effort: effort === 'max' ? 'xhigh' : effort === 'disabled' ? 'none' : effort,
+    };
+  }
+
+  private responsesFailureError(response: any): Error | undefined {
+    if (response?.status !== 'failed' && !response?.error) return undefined;
+    const details = response?.error && typeof response.error === 'object'
+      ? response.error
+      : { message: response?.error };
+    const code = String(details?.code || details?.type || '').trim();
+    const statusByCode: Record<string, number> = {
+      server_error: 500,
+      rate_limit_exceeded: 429,
+      overloaded_error: 529,
+    };
+    const explicitStatus = Number(details?.status ?? details?.status_code ?? response?.status_code);
+    const status = Number.isFinite(explicitStatus) && explicitStatus > 0
+      ? explicitStatus
+      : statusByCode[code];
+    return Object.assign(
+      new Error(String(details?.message || 'Responses API request failed')),
+      {
+        ...(code ? { code } : {}),
+        ...(status ? { status } : {}),
+        error: details,
+      },
+    );
+  }
+
+  private parseResponsesUsage(usage: any): ChatResponse['usage'] {
+    if (!usage || typeof usage !== 'object') return undefined;
+    const details = usage.input_tokens_details || {};
+    const promptTokens = Number(usage.input_tokens ?? usage.prompt_tokens ?? 0);
+    const completionTokens = Number(usage.output_tokens ?? usage.completion_tokens ?? 0);
+    const cachedReadTokens = Number(details.cached_tokens ?? 0);
+    const cachedWriteTokens = Number(
+      details.cache_write_tokens
+      ?? details.cached_creation_tokens
+      ?? details.cache_creation_tokens
+      ?? 0,
+    );
+    return {
+      promptTokens,
+      completionTokens,
+      totalTokens: Number(usage.total_tokens ?? promptTokens + completionTokens),
+      cachedReadTokens,
+      cachedWriteTokens,
+    };
+  }
+
+  private parseResponsesResponse(response: any): ChatResponse {
+    const output = Array.isArray(response?.output) ? response.output : [];
+    const textParts: string[] = [];
+    const toolCalls: NonNullable<ChatResponse['toolCalls']> = [];
+
+    for (const item of output) {
+      if (item?.type === 'message' && Array.isArray(item.content)) {
+        for (const block of item.content) {
+          if (block?.type === 'output_text' && typeof block.text === 'string') {
+            textParts.push(block.text);
+          }
+          if (block?.type === 'refusal' && typeof block.refusal === 'string') {
+            textParts.push(block.refusal);
+          }
+        }
+      }
+      if (item?.type === 'function_call' && typeof item.name === 'string') {
+        toolCalls.push({
+          id: String(item.call_id || item.id || ''),
+          type: 'function',
+          function: {
+            name: item.name,
+            arguments: typeof item.arguments === 'string' ? item.arguments : JSON.stringify(item.arguments ?? {}),
+          },
+        });
+      }
+    }
+
+    const incompleteReason = String(response?.incomplete_details?.reason || '');
+    const stopReason = response?.status === 'incomplete'
+      ? incompleteReason === 'max_output_tokens' ? 'length' : incompleteReason || 'incomplete'
+      : toolCalls.length > 0 ? 'tool_calls' : response?.status || undefined;
+    const providerContent = toolCalls.length > 0
+      ? output.filter((item: any) => this.isResponsesReplayItem(item)).map((item: any) => JSON.parse(JSON.stringify(item)))
+      : undefined;
+
+    return {
+      content: this.visibleMessageContent({ content: textParts.join('') }),
+      toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
+      usage: this.parseResponsesUsage(response?.usage),
+      stopReason,
+      ...(providerContent?.length ? { providerContent } : {}),
+    };
+  }
+
+  private async chatResponses(
+    messages: Message[],
+    tools?: ToolDefinition[],
+    options?: AIRequestOptions,
+  ): Promise<ChatResponse> {
+    const body = this.buildResponsesRequestBody(messages, tools, false);
+    ContextDebugLogger.dumpSdkBoundary('before', undefined, {
+      apiUrl: this.responsesUrl,
+      body,
+    });
+    const response = await axios.post(this.responsesUrl, body, {
+      headers: this.headers,
+      signal: options?.signal,
+    });
+    ContextDebugLogger.dumpSdkBoundary('after', undefined, { response: response.data });
+    const failure = this.responsesFailureError(response.data);
+    if (failure) throw failure;
+    return this.parseResponsesResponse(response.data);
+  }
+
+  private async chatStreamResponses(
+    messages: Message[],
+    tools?: ToolDefinition[],
+    callbacks?: StreamCallbacks,
+    options?: AIRequestOptions,
+  ): Promise<ChatResponse> {
+    const body = this.buildResponsesRequestBody(messages, tools, true);
+    ContextDebugLogger.dumpSdkBoundary('before', undefined, {
+      apiUrl: this.responsesUrl,
+      body,
+    });
+    const response = await axios.post(this.responsesUrl, body, {
+      headers: this.headers,
+      responseType: 'stream',
+      signal: options?.signal,
+    });
+
+    return new Promise<ChatResponse>((resolve, reject) => {
+      const stream = response.data;
+      const contentStripper = new OpenAIThinkingStripper();
+      const outputItems: any[] = [];
+      let buffer = '';
+      let finalResponse: any;
+      let settled = false;
+
+      const finishError = (error: Error) => {
+        if (settled) return;
+        settled = true;
+        callbacks?.onError?.(error);
+        reject(error);
+      };
+      const onAbort = () => stream.destroy(createAbortError());
+      if (options?.signal?.aborted) onAbort();
+      else options?.signal?.addEventListener('abort', onAbort, { once: true });
+
+      const handleEvent = (event: any) => {
+        if (
+          (event?.type === 'response.output_text.delta' || event?.type === 'response.refusal.delta')
+          && typeof event.delta === 'string'
+        ) {
+          const visible = contentStripper.push(event.delta);
+          if (visible) callbacks?.onText?.(visible);
+          return;
+        }
+        if (event?.type === 'response.output_item.done' && event.item) {
+          outputItems[Number(event.output_index ?? outputItems.length)] = event.item;
+          return;
+        }
+        if (event?.type === 'response.completed' || event?.type === 'response.incomplete') {
+          finalResponse = event.response;
+          return;
+        }
+        if (event?.type === 'response.failed' || event?.type === 'error') {
+          const failure = this.responsesFailureError(event?.response || {
+            status: 'failed',
+            error: event?.error || { message: event?.message },
+          });
+          finishError(failure || new Error('Responses API request failed'));
+        }
+      };
+
+      stream.on('data', (chunk: Buffer) => {
+        buffer += chunk.toString();
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || '';
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed.startsWith('data:')) continue;
+          const data = trimmed.slice(5).trim();
+          if (!data || data === '[DONE]') continue;
+          try {
+            handleEvent(JSON.parse(data));
+          } catch {
+            // Ignore malformed individual SSE events and continue the stream.
+          }
+        }
+      });
+
+      stream.on('end', () => {
+        options?.signal?.removeEventListener('abort', onAbort);
+        if (settled) return;
+        const tail = contentStripper.flush();
+        if (tail) callbacks?.onText?.(tail);
+        if (!finalResponse) {
+          finishError(new Error('Responses API stream ended without a terminal response'));
+          return;
+        }
+        const failure = this.responsesFailureError(finalResponse);
+        if (failure) {
+          finishError(failure);
+          return;
+        }
+        if (!Array.isArray(finalResponse.output) || finalResponse.output.length === 0) {
+          finalResponse.output = outputItems.filter(Boolean);
+        }
+        const result = this.parseResponsesResponse(finalResponse);
+        ContextDebugLogger.dumpSdkBoundary('after', undefined, { response: finalResponse });
+        settled = true;
+        callbacks?.onComplete?.(result);
+        resolve(result);
+      });
+
+      stream.on('error', (error: Error) => {
+        options?.signal?.removeEventListener('abort', onAbort);
+        finishError(error);
       });
     });
   }

--- a/src/providers/openai-url.ts
+++ b/src/providers/openai-url.ts
@@ -28,3 +28,21 @@ export function normalizeOpenAIChatCompletionsUrl(rawUrl: string): string {
   parsed.pathname = `${path || ''}/chat/completions`;
   return parsed.toString();
 }
+
+export function normalizeOpenAIResponsesUrl(rawUrl: string): string {
+  const trimmed = rawUrl.trim();
+  if (!trimmed) return trimmed;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return trimmed;
+  }
+
+  const path = parsed.pathname
+    .replace(/\/(?:chat\/completions|responses)\/?$/i, '')
+    .replace(/\/+$/, '');
+  parsed.pathname = `${path || ''}/responses`;
+  return parsed.toString();
+}

--- a/src/runtime/runtime-profile-config.ts
+++ b/src/runtime/runtime-profile-config.ts
@@ -10,6 +10,7 @@ import {
   resolveDefaultRuntimeProfile,
 } from './runtime-profile';
 import { normalizeReasoningEffort } from '../utils/reasoning-effort';
+import { normalizeOpenAIApiMode } from '../utils/openai-api-mode';
 
 export const RUNTIME_PROFILE_SCHEMA_VERSION = 1;
 export const DEFAULT_RUNTIME_PROFILE_FILENAME = 'runtime-profile.json';
@@ -17,7 +18,7 @@ export const DEFAULT_RUNTIME_PROFILE_FILENAME = 'runtime-profile.json';
 const PROFILE_PATH_ENV_KEYS = ['XIAOBA_RUNTIME_PROFILE_PATH', 'XIAOBA_PROFILE_PATH'];
 
 export interface RuntimeProfileFileModelConfig extends Pick<RuntimeModelProfile,
-  'provider' | 'apiUrl' | 'model' | 'temperature' | 'maxTokens' | 'reasoningEffort'
+  'provider' | 'apiUrl' | 'model' | 'temperature' | 'maxTokens' | 'reasoningEffort' | 'openaiApiMode'
 > {}
 
 export interface RuntimeProfileFilePromptConfig {
@@ -334,6 +335,7 @@ function copyModel(
   copyNumber(source.model, model as Record<string, unknown>, 'temperature', 'profile.model.temperature', issues);
   copyNumber(source.model, model as Record<string, unknown>, 'maxTokens', 'profile.model.maxTokens', issues);
   copyReasoningEffort(source.model, model, issues);
+  copyOpenAIApiMode(source.model, model, issues);
 
   if (source.model.apiKey !== undefined) {
     issues.push({
@@ -444,6 +446,24 @@ function copyReasoningEffort(
   target.reasoningEffort = normalized;
 }
 
+function copyOpenAIApiMode(
+  source: Record<string, unknown>,
+  target: RuntimeProfileFileModelConfig,
+  issues: RuntimeProfileConfigIssue[],
+): void {
+  if (source.openaiApiMode === undefined) return;
+  if (typeof source.openaiApiMode !== 'string') {
+    issues.push({ path: 'profile.model.openaiApiMode', message: 'Expected string' });
+    return;
+  }
+  const normalized = normalizeOpenAIApiMode(source.openaiApiMode);
+  if (!normalized) {
+    issues.push({ path: 'profile.model.openaiApiMode', message: 'Expected one of: chat_completions, responses' });
+    return;
+  }
+  target.openaiApiMode = normalized;
+}
+
 function copyNumber(
   source: Record<string, unknown>,
   target: Record<string, unknown>,
@@ -482,6 +502,7 @@ function filterModelConfig(model: RuntimeProfileFileModelConfig): RuntimeProfile
     ...(model.temperature !== undefined ? { temperature: model.temperature } : {}),
     ...(model.maxTokens !== undefined ? { maxTokens: model.maxTokens } : {}),
     ...(model.reasoningEffort !== undefined ? { reasoningEffort: model.reasoningEffort } : {}),
+    ...(model.openaiApiMode !== undefined ? { openaiApiMode: model.openaiApiMode } : {}),
   };
 }
 

--- a/src/runtime/runtime-profile.ts
+++ b/src/runtime/runtime-profile.ts
@@ -24,7 +24,7 @@ export interface RuntimeLoggingProfile {
 }
 
 export interface RuntimeModelProfile extends Partial<Pick<ChatConfig,
-  'provider' | 'apiUrl' | 'model' | 'temperature' | 'maxTokens' | 'reasoningEffort'
+  'provider' | 'apiUrl' | 'model' | 'temperature' | 'maxTokens' | 'reasoningEffort' | 'openaiApiMode'
 >> {}
 
 export interface RuntimeProfile {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,6 +4,7 @@ export type ContentBlock =
 
 export type ProviderContentBlock = Record<string, unknown> & { type: string };
 export type ReasoningEffort = 'default' | 'high' | 'max' | 'disabled';
+export type OpenAIApiMode = 'chat_completions' | 'responses';
 
 export interface Message {
   role: 'user' | 'assistant' | 'system' | 'tool';
@@ -46,6 +47,7 @@ export interface ChatConfig {
   maxTokens?: number;
   contextWindowTokens?: number;
   reasoningEffort?: ReasoningEffort;
+  openaiApiMode?: OpenAIApiMode;
   provider?: 'openai' | 'anthropic';
   feishu?: {
     appId?: string;
@@ -79,6 +81,8 @@ export interface TokenUsage {
   promptTokens: number;
   completionTokens: number;
   totalTokens: number;
+  cachedReadTokens?: number;
+  cachedWriteTokens?: number;
 }
 
 export interface ChatResponse {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -4,6 +4,7 @@ import * as os from 'os';
 import * as dotenv from 'dotenv';
 import { ChatConfig } from '../types';
 import { normalizeReasoningEffort } from './reasoning-effort';
+import { normalizeOpenAIApiMode } from './openai-api-mode';
 
 // 加载环境变量（静默模式）
 dotenv.config({ path: process.env.DOTENV_CONFIG_PATH || '.env', quiet: true });
@@ -100,6 +101,7 @@ export class ConfigManager {
       model,
       temperature: 0.7,
       provider,
+      openaiApiMode: normalizeOpenAIApiMode(process.env.GAUZ_LLM_OPENAI_API_MODE) ?? 'chat_completions',
       feishu: {
         appId: process.env.FEISHU_APP_ID,
         appSecret: process.env.FEISHU_APP_SECRET,
@@ -132,6 +134,7 @@ export class ConfigManager {
       process.env.GAUZ_LLM_CONTEXT_TOKENS,
     );
     const reasoningEffort = normalizeReasoningEffort(process.env.GAUZ_LLM_REASONING_EFFORT);
+    const openaiApiMode = normalizeOpenAIApiMode(process.env.GAUZ_LLM_OPENAI_API_MODE);
 
     if (provider === 'openai' || provider === 'anthropic') {
       override.provider = provider;
@@ -153,6 +156,9 @@ export class ConfigManager {
     }
     if (reasoningEffort !== undefined) {
       override.reasoningEffort = reasoningEffort;
+    }
+    if (openaiApiMode !== undefined) {
+      override.openaiApiMode = openaiApiMode;
     }
 
     return override;

--- a/src/utils/openai-api-mode.ts
+++ b/src/utils/openai-api-mode.ts
@@ -1,0 +1,14 @@
+import type { OpenAIApiMode } from '../types';
+
+export const OPENAI_API_MODE_OPTIONS: OpenAIApiMode[] = ['chat_completions', 'responses'];
+
+export function normalizeOpenAIApiMode(value: unknown): OpenAIApiMode | undefined {
+  const normalized = String(value ?? '').trim().toLowerCase();
+  return OPENAI_API_MODE_OPTIONS.includes(normalized as OpenAIApiMode)
+    ? normalized as OpenAIApiMode
+    : undefined;
+}
+
+export function openAIApiModeOrDefault(value: unknown): OpenAIApiMode {
+  return normalizeOpenAIApiMode(value) ?? 'chat_completions';
+}

--- a/tests/conversation-runner-transcript-normalization.test.ts
+++ b/tests/conversation-runner-transcript-normalization.test.ts
@@ -409,6 +409,56 @@ test('runner keeps normal providerContent tool replay for M3 style tool calls', 
   ]);
 });
 
+test('runner keeps Responses reasoning and matching function calls in the tool transcript', async () => {
+  const toolCall = makeToolCall('call_responses_1', 'execute_shell', { command: 'echo ok' });
+  const providerContent = [
+    { type: 'reasoning', id: 'rs_1', encrypted_content: 'opaque-reasoning', summary: [] },
+    {
+      type: 'function_call',
+      id: 'fc_1',
+      call_id: 'call_responses_1',
+      name: 'execute_shell',
+      arguments: '{"command":"echo ok"}',
+    },
+  ];
+  const mock = createMockAI([
+    {
+      content: null,
+      toolCalls: [toolCall],
+      providerContent,
+      usage: {
+        promptTokens: 100,
+        completionTokens: 20,
+        totalTokens: 120,
+      },
+    },
+    makeFinalResponse('done'),
+  ]);
+  const runner = new ConversationRunner(mock.aiService, new MockToolExecutor([{
+    name: 'execute_shell',
+    description: 'mock shell',
+    parameters: {
+      type: 'object',
+      properties: {
+        command: { type: 'string' },
+      },
+      required: ['command'],
+    },
+  }], { execute_shell: 'ok' }), {
+    stream: false,
+    enableCompression: false,
+  });
+
+  const result = await runner.run([{ role: 'user', content: 'run shell' }]);
+  const assistantWithTool = result.messages.find(message => message.role === 'assistant' && message.tool_calls?.length);
+  const secondRequestAssistant = mock.getReceivedMessages()[1]
+    .find(message => message.role === 'assistant' && message.tool_calls?.length);
+
+  assert.equal(result.response, 'done');
+  assert.deepEqual(assistantWithTool?.providerContent, providerContent);
+  assert.deepEqual(secondRequestAssistant?.providerContent, providerContent);
+});
+
 test('runner injects tool target context into provider transcript only', async () => {
   const responses = [
     makeToolResponse(makeToolCall('call_1', 'execute_shell', { command: 'echo ok' })),

--- a/tests/dashboard-productization-html.test.ts
+++ b/tests/dashboard-productization-html.test.ts
@@ -35,6 +35,10 @@ test('Agent Hub keeps connector controls and third-party model config without du
   assert.match(dashboardHtml, /CatsCo 中转模型在 CatsCo 页面选择/);
   assert.match(dashboardHtml, /CUSTOM_MODEL_CONTEXT_WINDOW_OPTIONS/);
   assert.match(dashboardHtml, /id="model-context-window-setting"/);
+  assert.match(dashboardHtml, /id="model-openai-api-mode-setting"/);
+  assert.match(dashboardHtml, /Responses API（提示词缓存）/);
+  assert.match(dashboardHtml, /function syncCustomOpenAIApiModeVisibility\(\)/);
+  assert.match(dashboardHtml, /'model\.openaiApiMode':document\.getElementById\('model-openai-api-mode-setting'\)/);
   assert.match(dashboardHtml, /'model\.contextWindowTokens':document\.getElementById\('model-context-window-setting'\)\.value/);
   assert.match(dashboardHtml, /自定义模型可在 128K 到 1M 间选择上下文/);
   assert.match(dashboardHtml, /上下文 '\+escapeHtml\(contextLabel\)\+'/);

--- a/tests/dashboard-settings-api.test.ts
+++ b/tests/dashboard-settings-api.test.ts
@@ -22,6 +22,7 @@ describe('dashboard typed settings API', () => {
     'GAUZ_LLM_CONTEXT_WINDOW_TOKENS',
     'GAUZ_LLM_CONTEXT_TOKENS',
     'GAUZ_LLM_REASONING_EFFORT',
+    'GAUZ_LLM_OPENAI_API_MODE',
     'CATSCO_MODEL_SOURCE',
     'CATSCO_CUSTOM_LLM_PROVIDER',
     'CATSCO_CUSTOM_LLM_API_BASE',
@@ -29,12 +30,14 @@ describe('dashboard typed settings API', () => {
     'CATSCO_CUSTOM_LLM_MODEL',
     'CATSCO_CUSTOM_LLM_CONTEXT_WINDOW_TOKENS',
     'CATSCO_CUSTOM_LLM_REASONING_EFFORT',
+    'CATSCO_CUSTOM_LLM_OPENAI_API_MODE',
     'CATSCO_RELAY_LLM_PROVIDER',
     'CATSCO_RELAY_LLM_API_BASE',
     'CATSCO_RELAY_LLM_API_KEY',
     'CATSCO_RELAY_LLM_MODEL',
     'CATSCO_RELAY_LLM_CONTEXT_WINDOW_TOKENS',
     'CATSCO_RELAY_LLM_REASONING_EFFORT',
+    'CATSCO_RELAY_LLM_OPENAI_API_MODE',
     'CATSCO_RELAY_LLM_VISION_CAPABLE',
     'CATSCO_RELAY_LLM_TOOL_CALLING_CAPABLE',
     'CATSCO_HTTP_BASE_URL',
@@ -181,8 +184,10 @@ describe('dashboard typed settings API', () => {
     fs.writeFileSync(path.join(testRoot, '.env'), [
       'GAUZ_LLM_CONTEXT_WINDOW_TOKENS=256000',
       'GAUZ_LLM_REASONING_EFFORT=max',
+      'GAUZ_LLM_OPENAI_API_MODE=responses',
       'CATSCO_CUSTOM_LLM_CONTEXT_WINDOW_TOKENS=256000',
       'CATSCO_CUSTOM_LLM_REASONING_EFFORT=high',
+      'CATSCO_CUSTOM_LLM_OPENAI_API_MODE=responses',
       '',
     ].join('\n'));
 
@@ -199,6 +204,11 @@ describe('dashboard typed settings API', () => {
     assert.equal(data.modelStartup.custom.contextWindowTokens, 256000);
     assert.equal(data.modelStartup.effective.reasoningEffort, 'max');
     assert.equal(data.modelStartup.custom.reasoningEffort, 'high');
+    const openaiApiMode = data.fields.find((field: any) => field.id === 'model.openaiApiMode');
+    assert.equal(openaiApiMode.value, 'responses');
+    assert.deepStrictEqual(openaiApiMode.options, ['chat_completions', 'responses']);
+    assert.equal(data.modelStartup.effective.openaiApiMode, 'responses');
+    assert.equal(data.modelStartup.custom.openaiApiMode, 'responses');
   });
 
   test('GET /settings carries legacy relay reasoning effort into startup snapshot', async () => {
@@ -488,6 +498,7 @@ describe('dashboard typed settings API', () => {
       body: JSON.stringify({
         settings: {
           'model.provider': 'openai',
+          'model.openaiApiMode': 'responses',
           'model.apiBase': 'https://api.deepseek.com/v1',
           'model.model': 'deepseek-chat-v2',
           'model.contextWindowTokens': '512000',
@@ -504,6 +515,8 @@ describe('dashboard typed settings API', () => {
     assert.equal(parsed.CATSCO_CUSTOM_LLM_API_KEY, 'sk-custom-secret');
     assert.equal(parsed.CATSCO_RELAY_LLM_API_KEY, 'sk-bf-relay-secret');
     assert.equal(parsed.CATSCO_CUSTOM_LLM_MODEL, 'deepseek-chat-v2');
+    assert.equal(parsed.CATSCO_CUSTOM_LLM_OPENAI_API_MODE, 'responses');
+    assert.equal(parsed.GAUZ_LLM_OPENAI_API_MODE, 'responses');
     assert.equal(parsed.GAUZ_LLM_CONTEXT_WINDOW_TOKENS, '512000');
     assert.equal(parsed.CATSCO_CUSTOM_LLM_CONTEXT_WINDOW_TOKENS, '512000');
   });

--- a/tests/openai-provider-responses.test.ts
+++ b/tests/openai-provider-responses.test.ts
@@ -1,0 +1,343 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Readable } from 'node:stream';
+import axios from 'axios';
+import { OpenAIProvider } from '../src/providers/openai-provider';
+import { AIService } from '../src/utils/ai-service';
+import type { Message } from '../src/types';
+import type { ToolDefinition } from '../src/types/tool';
+
+const lookupTool: ToolDefinition = {
+  name: 'lookup',
+  description: 'Look up a value',
+  parameters: {
+    type: 'object',
+    properties: { query: { type: 'string' } },
+    required: ['query'],
+  },
+};
+
+function createProvider(): OpenAIProvider {
+  return new OpenAIProvider({
+    apiKey: 'test-key',
+    apiUrl: 'https://example.test/v1/chat/completions',
+    model: 'gpt-test',
+    openaiApiMode: 'responses',
+  });
+}
+
+describe('OpenAIProvider Responses API mode', () => {
+  test('builds Responses input and a stable prompt cache key', () => {
+    const provider = createProvider();
+    const first = (provider as any).buildResponsesRequestBody([
+      { role: 'system', content: 'You are concise.' },
+      { role: 'user', content: 'first question' },
+    ], [lookupTool]);
+    const second = (provider as any).buildResponsesRequestBody([
+      { role: 'system', content: 'You are concise.' },
+      { role: 'user', content: 'another question' },
+    ], [lookupTool]);
+
+    assert.equal(first.instructions, 'You are concise.');
+    assert.deepEqual(first.input, [{ role: 'user', content: 'first question' }]);
+    assert.deepEqual(first.tools, [{
+      type: 'function',
+      name: 'lookup',
+      description: 'Look up a value',
+      parameters: lookupTool.parameters,
+    }]);
+    assert.match(first.prompt_cache_key, /^catsco-[a-f0-9]{48}$/);
+    assert.equal(first.prompt_cache_key, second.prompt_cache_key);
+    assert.equal(first.store, false);
+    assert.deepEqual(first.include, ['reasoning.encrypted_content']);
+  });
+
+  test('applies configured reasoning only to endpoints known to support it', () => {
+    const provider = new OpenAIProvider({
+      apiKey: 'test-key',
+      apiUrl: 'https://api.openai.com/v1',
+      model: 'gpt-test',
+      openaiApiMode: 'responses',
+      reasoningEffort: 'high',
+    });
+    const compatibleProvider = new OpenAIProvider({
+      apiKey: 'test-key',
+      apiUrl: 'https://example.test/v1',
+      model: 'gpt-test',
+      openaiApiMode: 'responses',
+      reasoningEffort: 'high',
+    });
+
+    const body = (provider as any).buildResponsesRequestBody([
+      { role: 'user', content: 'use a tool' },
+    ], [lookupTool]);
+    const compatibleBody = (compatibleProvider as any).buildResponsesRequestBody([
+      { role: 'user', content: 'use a tool' },
+    ], [lookupTool]);
+
+    assert.deepEqual(body.reasoning, { effort: 'high' });
+    assert.equal(compatibleBody.reasoning, undefined);
+  });
+
+  test('parses cached token usage from a non-stream response', async () => {
+    const originalPost = axios.post;
+    let seenUrl = '';
+    let seenBody: any;
+    (axios as any).post = async (url: string, body: any) => {
+      seenUrl = url;
+      seenBody = body;
+      return {
+        data: {
+          status: 'completed',
+          output: [{
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'cached answer' }],
+          }],
+          usage: {
+            input_tokens: 10000,
+            output_tokens: 20,
+            total_tokens: 10020,
+            input_tokens_details: { cached_tokens: 9472 },
+          },
+        },
+      };
+    };
+
+    try {
+      const result = await createProvider().chat([{ role: 'user', content: 'hello' }]);
+
+      assert.equal(seenUrl, 'https://example.test/v1/responses');
+      assert.equal(seenBody.stream, false);
+      assert.equal(result.content, 'cached answer');
+      assert.equal(result.usage?.cachedReadTokens, 9472);
+      assert.equal(result.usage?.totalTokens, 10020);
+    } finally {
+      (axios as any).post = originalPost;
+    }
+  });
+
+  test('returns a Responses refusal as visible content', async () => {
+    const originalPost = axios.post;
+    (axios as any).post = async () => ({
+      data: {
+        status: 'completed',
+        output: [{
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'refusal', refusal: 'I cannot help with that.' }],
+        }],
+      },
+    });
+
+    try {
+      const result = await createProvider().chat([{ role: 'user', content: 'hello' }]);
+      assert.equal(result.content, 'I cannot help with that.');
+    } finally {
+      (axios as any).post = originalPost;
+    }
+  });
+
+  test('throws a failed Responses result so callers can retry it', async () => {
+    const originalPost = axios.post;
+    (axios as any).post = async () => ({
+      data: {
+        status: 'failed',
+        error: { code: 'server_error', message: 'upstream unavailable' },
+      },
+    });
+
+    try {
+      await assert.rejects(
+        createProvider().chat([{ role: 'user', content: 'hello' }]),
+        (error: any) => (
+          error?.message === 'upstream unavailable'
+          && error?.code === 'server_error'
+          && error?.status === 500
+        ),
+      );
+    } finally {
+      (axios as any).post = originalPost;
+    }
+  });
+
+  test('lets AIService retry a transient failed Responses result', async () => {
+    const originalPost = axios.post;
+    const originalMaxRetries = process.env.CATSCO_MODEL_RETRY_MAX_RETRIES;
+    let attempts = 0;
+    (axios as any).post = async () => {
+      attempts += 1;
+      return {
+        data: attempts === 1
+          ? {
+              status: 'failed',
+              error: { code: 'server_error', message: 'temporary upstream failure' },
+            }
+          : {
+              status: 'completed',
+              output: [{
+                type: 'message',
+                role: 'assistant',
+                content: [{ type: 'output_text', text: 'recovered' }],
+              }],
+            },
+      };
+    };
+    process.env.CATSCO_MODEL_RETRY_MAX_RETRIES = '1';
+
+    try {
+      const service = new AIService({
+        apiKey: 'test-key',
+        apiUrl: 'https://example.test/v1',
+        model: 'gpt-test',
+        provider: 'openai',
+        openaiApiMode: 'responses',
+      });
+      (service as any).sleepWithAbort = async () => {};
+
+      const result = await service.chat([{ role: 'user', content: 'hello' }]);
+      assert.equal(attempts, 2);
+      assert.equal(result.content, 'recovered');
+    } finally {
+      (axios as any).post = originalPost;
+      if (originalMaxRetries === undefined) delete process.env.CATSCO_MODEL_RETRY_MAX_RETRIES;
+      else process.env.CATSCO_MODEL_RETRY_MAX_RETRIES = originalMaxRetries;
+    }
+  });
+
+  test('replays provider function calls and CatsCo tool results', async () => {
+    const originalPost = axios.post;
+    const bodies: any[] = [];
+    (axios as any).post = async (_url: string, body: any) => {
+      bodies.push(body);
+      return {
+        data: bodies.length === 1
+          ? {
+              status: 'completed',
+              output: [{
+                type: 'function_call',
+                id: 'fc_1',
+                call_id: 'call_1',
+                name: 'lookup',
+                arguments: '{"query":"cats"}',
+              }],
+            }
+          : {
+              status: 'completed',
+              output: [{
+                type: 'message',
+                role: 'assistant',
+                content: [{ type: 'output_text', text: 'tool result integrated' }],
+              }],
+            },
+      };
+    };
+
+    try {
+      const provider = createProvider();
+      const first = await provider.chat([{ role: 'user', content: 'look it up' }], [lookupTool]);
+      const messages: Message[] = [
+        { role: 'user', content: 'look it up' },
+        {
+          role: 'assistant',
+          content: first.content,
+          tool_calls: first.toolCalls,
+          providerContent: first.providerContent,
+        },
+        { role: 'tool', tool_call_id: 'call_1', content: 'found cats' },
+      ];
+      const second = await provider.chat(messages, [lookupTool]);
+
+      assert.equal(first.toolCalls?.[0].id, 'call_1');
+      assert.equal(first.stopReason, 'tool_calls');
+      assert.deepEqual(bodies[1].input.slice(-2), [
+        {
+          type: 'function_call',
+          id: 'fc_1',
+          call_id: 'call_1',
+          name: 'lookup',
+          arguments: '{"query":"cats"}',
+        },
+        { type: 'function_call_output', call_id: 'call_1', output: 'found cats' },
+      ]);
+      assert.equal(second.content, 'tool result integrated');
+    } finally {
+      (axios as any).post = originalPost;
+    }
+  });
+
+  test('streams visible text and resolves from the terminal Responses event', async () => {
+    const originalPost = axios.post;
+    const terminalResponse = {
+      status: 'completed',
+      output: [{
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'output_text', text: 'hello<' }],
+      }],
+      usage: {
+        input_tokens: 12,
+        output_tokens: 2,
+        total_tokens: 14,
+        input_tokens_details: { cached_tokens: 8 },
+      },
+    };
+    (axios as any).post = async () => ({
+      data: Readable.from([
+        sse({ type: 'response.output_text.delta', delta: 'hello<' }),
+        sse({ type: 'response.completed', response: terminalResponse }),
+      ]),
+    });
+
+    try {
+      const chunks: string[] = [];
+      const result = await createProvider().chatStream(
+        [{ role: 'user', content: 'hello' }],
+        undefined,
+        { onText: value => chunks.push(value) },
+      );
+
+      assert.deepEqual(chunks, ['hello', '<']);
+      assert.equal(result.content, 'hello<');
+      assert.equal(result.usage?.cachedReadTokens, 8);
+    } finally {
+      (axios as any).post = originalPost;
+    }
+  });
+
+  test('streams a Responses refusal and preserves it in the final result', async () => {
+    const originalPost = axios.post;
+    const terminalResponse = {
+      status: 'completed',
+      output: [{
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'refusal', refusal: 'I cannot help with that.' }],
+      }],
+    };
+    (axios as any).post = async () => ({
+      data: Readable.from([
+        sse({ type: 'response.refusal.delta', delta: 'I cannot help with that.' }),
+        sse({ type: 'response.completed', response: terminalResponse }),
+      ]),
+    });
+
+    try {
+      const chunks: string[] = [];
+      const result = await createProvider().chatStream(
+        [{ role: 'user', content: 'hello' }],
+        undefined,
+        { onText: value => chunks.push(value) },
+      );
+
+      assert.deepEqual(chunks, ['I cannot help with that.']);
+      assert.equal(result.content, 'I cannot help with that.');
+    } finally {
+      (axios as any).post = originalPost;
+    }
+  });
+});
+
+function sse(payload: unknown): string {
+  return `data: ${JSON.stringify(payload)}\n\n`;
+}

--- a/tests/openai-provider-url.test.ts
+++ b/tests/openai-provider-url.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import axios from 'axios';
-import { normalizeOpenAIChatCompletionsUrl } from '../src/providers/openai-url';
+import { normalizeOpenAIChatCompletionsUrl, normalizeOpenAIResponsesUrl } from '../src/providers/openai-url';
 import { OpenAIProvider } from '../src/providers/openai-provider';
 
 test('normalizeOpenAIChatCompletionsUrl accepts SDK-style base URLs', () => {
@@ -27,6 +27,21 @@ test('normalizeOpenAIChatCompletionsUrl keeps complete chat completions endpoint
   assert.equal(
     normalizeOpenAIChatCompletionsUrl('https://example.test/openai/deployments/test/chat/completions?api-version=2024-06-01'),
     'https://example.test/openai/deployments/test/chat/completions?api-version=2024-06-01',
+  );
+});
+
+test('normalizeOpenAIResponsesUrl accepts bases and replaces concrete OpenAI endpoints', () => {
+  assert.equal(
+    normalizeOpenAIResponsesUrl('https://api.openai.com/v1'),
+    'https://api.openai.com/v1/responses',
+  );
+  assert.equal(
+    normalizeOpenAIResponsesUrl('https://example.test/v1/chat/completions'),
+    'https://example.test/v1/responses',
+  );
+  assert.equal(
+    normalizeOpenAIResponsesUrl('https://example.test/v1/responses'),
+    'https://example.test/v1/responses',
   );
 });
 

--- a/tests/runtime-profile.test.ts
+++ b/tests/runtime-profile.test.ts
@@ -88,6 +88,7 @@ describe('RuntimeProfile', () => {
         provider: 'openai',
         model: 'custom-model',
         apiUrl: 'https://example.com/v1',
+        openaiApiMode: 'responses',
         temperature: 0.2,
         maxTokens: 2048,
       },
@@ -108,6 +109,7 @@ describe('RuntimeProfile', () => {
       provider: 'openai',
       model: 'custom-model',
       apiUrl: 'https://example.com/v1',
+      openaiApiMode: 'responses',
       temperature: 0.2,
       maxTokens: 2048,
     });
@@ -180,6 +182,7 @@ describe('RuntimeProfile', () => {
         model: {
           provider: 'openai',
           model: 'profile-model',
+          openaiApiMode: 'responses',
           temperature: 0.2,
           reasoningEffort: 'high',
         },
@@ -221,6 +224,7 @@ describe('RuntimeProfile', () => {
     assert.deepStrictEqual(resolved.profile.model, {
       provider: 'openai',
       model: 'profile-model',
+      openaiApiMode: 'responses',
       temperature: 0.2,
       reasoningEffort: 'high',
     });
@@ -278,6 +282,22 @@ describe('RuntimeProfile', () => {
     assert.equal(resolved.profile.model.model, 'safe-model');
     assert.equal((resolved.profile.model as any).apiKey, undefined);
     assert.equal(JSON.stringify(resolved.config).includes('secret-key'), false);
+  });
+
+  test('rejects unknown OpenAI API modes in runtime profile files', () => {
+    const profilePath = path.join(testRoot, 'runtime-profile.json');
+    fs.writeFileSync(profilePath, JSON.stringify({
+      schemaVersion: 1,
+      profile: { model: { openaiApiMode: 'legacy-responses' } },
+    }), 'utf-8');
+
+    const resolved = resolveRuntimeProfileFromConfig({ configPath: profilePath, env: {} });
+
+    assert.deepStrictEqual(resolved.config.issues, [{
+      path: 'profile.model.openaiApiMode',
+      message: 'Expected one of: chat_completions, responses',
+    }]);
+    assert.equal(resolved.profile.model.openaiApiMode, undefined);
   });
 
   test('ignores legacy prompt modes in validation', () => {


### PR DESCRIPTION
## 改动

- 为自定义 OpenAI-compatible 模型增加 `Chat Completions` / `Responses API` 选择，旧配置默认保持 Chat Completions。
- 接入 Responses API 的流式文本、拒答、工具调用、工具结果回放、usage 与缓存 Token 统计。
- 使用稳定 `prompt_cache_key`，并在无状态工具循环中保留 `reasoning.encrypted_content`。
- Responses 失败结果保留错误码和状态码，继续走 CatsCo 现有的 5 分钟模型重试链路。
- ConversationRunner 保留 Responses 的 reasoning/function_call，避免真实工具循环丢失回放状态。
- CatsCo relay 激活路径固定写入 Chat Completions，不改变现有 MiniMax、DeepSeek 等中转模型链路。

## 兼容性

- 未配置 `GAUZ_LLM_OPENAI_API_MODE` 时仍使用 `chat_completions`。
- Anthropic provider 不读取该配置。
- 自定义模型只有主动选择 Responses API 才会切换端点。
- 历史推理强度不会注入任意 Responses 兼容模型；仅对官方 OpenAI 或明确支持的推理模型生效。

## 实测

在现有自定义端点 `gpt-5.6-terra` 上完成真实请求测试：

- 连续会话与工具循环预热后缓存 Token 命中约 98.5%。
- 完全相同请求预热后命中约 97.2%。
- 同端点 Chat Completions 对照约 16.6%。
- 带 `reasoning.encrypted_content` 的流式工具调用和第二轮工具结果回放成功。

## 验证

- 定向 provider / runner / Dashboard / runtime 测试：127 项通过。
- `npm test`：940 项，935 通过、4 跳过；唯一一次失败为 Windows 临时目录 after-hook 清理 `EPERM`，对应测试独立重跑通过。
- `npm run build` 通过。
- `git diff --check` 通过。