### PR TITLE
fix: 防止 CatsCo connector 重连前退出

### DIFF
--- a/src/catscompany/client.ts
+++ b/src/catscompany/client.ts
@@ -896,7 +896,6 @@ export class CatsClient extends EventEmitter {
       this.reconnectTimer = null;
       if (!this.closed) this.connect();
     }, delay);
-    (this.reconnectTimer as any).unref?.();
   }
 
   private resubscribeTopics(): void {

--- a/tests/catscompany-client-body-id.test.ts
+++ b/tests/catscompany-client-body-id.test.ts
@@ -178,6 +178,25 @@ describe('CatsCompany client body identity', () => {
     client.disconnect();
   });
 
+  test('keeps the process alive while waiting to reconnect', () => {
+    const client = new CatsClient({
+      serverUrl: 'ws://127.0.0.1:1',
+      apiKey: 'cc-test-key',
+      bodyId: 'body-test',
+      reconnectBaseDelayMs: 1000,
+      reconnectMaxDelayMs: 1000,
+    });
+
+    const internal = client as any;
+    internal.scheduleReconnect();
+
+    try {
+      assert.equal(internal.reconnectTimer?.hasRef?.(), true);
+    } finally {
+      client.disconnect();
+    }
+  });
+
   test('includes local device registration in websocket hi', async () => {
     const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
     servers.push(server);


### PR DESCRIPTION
## 问题
CatsCompany WebSocket 关闭后会进入退避重连，但重连 timer 被 `unref()`，在心跳和 socket 已清理时 Node 可能直接以退出码 0 结束。Dashboard 因此只显示服务 `stopped`，不会继续重连。

## 修改
- 保留 reconnect timer 对 Node 事件循环的引用，直到下一次连接尝试开始。
- 新增回归测试，确认重连等待期间 connector 进程保持存活。

## 验证
- `npm run build`
- `npx tsx --test tests/catscompany-client-body-id.test.ts`（15/15）