### PR TITLE
修复 Skill 候选描述仅注入少数预设项的问题

### DIFF
--- a/prompts/transient/skills-list.md
+++ b/prompts/transient/skills-list.md
@@ -1,3 +1,3 @@
-你可以使用以下 skills（必须通过 skill 工具调用）：
+以下是本轮所有可用的 skills。请根据用户请求和 description 判断是否匹配；匹配时必须通过 skill 工具加载完整指令，没有合适的 skill 时不要勉强调用：
 
 {{skillList}}

--- a/src/core/transient-injection-policy.ts
+++ b/src/core/transient-injection-policy.ts
@@ -15,13 +15,11 @@ export interface TransientTurnIntent {
   skillRelevant: boolean;
   complexWork: boolean;
   plainChat: boolean;
-  skillNames?: string[];
 }
 
 export interface TurnContextTransientPolicy {
   intent: TransientTurnIntent;
   injectSkillsList: boolean;
-  skillNames?: string[];
 }
 
 export interface ProviderTransientPolicy {
@@ -92,12 +90,14 @@ const CONCEPTUAL_SIGNAL =
 
 export function resolveTurnContextTransientPolicy(messages: Message[]): TurnContextTransientPolicy {
   const intent = analyzeTransientIntent(messages);
-  const injectSkillsList = intent.skillRelevant;
+  // Every real user turn gets the complete list of user-invocable skills.
+  // Skill descriptions cannot participate in model routing unless the model
+  // can see them, so do not pre-filter the list with hard-coded intent rules.
+  const injectSkillsList = Boolean(intent.latestUserText);
 
   return {
     intent,
     injectSkillsList,
-    ...(intent.skillNames ? { skillNames: intent.skillNames } : {}),
   };
 }
 
@@ -177,15 +177,6 @@ export function analyzeTransientIntent(messages: Message[]): TransientTurnIntent
     || hasBrowserSignal
     || recentToolContext
   );
-  const skillNames = selectSkillNames({
-    hasWorkspaceSignal,
-    hasOfficeSignal,
-    hasBrowserSignal,
-    hasMemorySignal,
-    hasSelfEvolutionSignal,
-    hasSkillSignal,
-    actionable,
-  });
   const skillRelevant = hasSkillSignal
     || hasBrowserSignal
     || hasMemorySignal
@@ -215,7 +206,6 @@ export function analyzeTransientIntent(messages: Message[]): TransientTurnIntent
     skillRelevant,
     complexWork,
     plainChat: kind === 'plain-chat',
-    ...(skillNames.length > 0 ? { skillNames } : {}),
   };
 }
 
@@ -239,31 +229,6 @@ function resolveIntentKind(options: {
   }
   if (options.workspaceRelevant || options.actionable) return 'workspace';
   return 'plain-chat';
-}
-
-function selectSkillNames(options: {
-  hasWorkspaceSignal: boolean;
-  hasOfficeSignal: boolean;
-  hasBrowserSignal: boolean;
-  hasMemorySignal: boolean;
-  hasSelfEvolutionSignal: boolean;
-  hasSkillSignal: boolean;
-  actionable: boolean;
-}): string[] {
-  if (options.hasSkillSignal && !options.hasBrowserSignal && !options.hasMemorySignal && !options.hasSelfEvolutionSignal) {
-    return [];
-  }
-
-  const names = new Set<string>();
-  if (options.hasWorkspaceSignal && options.actionable) names.add('coding-context');
-  if (
-    options.actionable
-    && options.hasOfficeSignal
-  ) names.add('officecli');
-  if (options.hasBrowserSignal) names.add('agent-browser');
-  if (options.hasMemorySignal) names.add('memory-search');
-  if (options.hasSelfEvolutionSignal) names.add('self-evolution');
-  return [...names];
 }
 
 function findLatestRealUserText(messages: Message[]): string {

--- a/src/core/turn-context-builder.ts
+++ b/src/core/turn-context-builder.ts
@@ -71,9 +71,7 @@ export class TurnContextBuilder {
     const transientPolicy = resolveTurnContextTransientPolicy(contextMessages);
     if (transientPolicy.injectSkillsList) {
       await params.skillRuntime.reloadSkills();
-      const skillsListMsg = params.skillRuntime.buildSkillsListMessage({
-        skillNames: transientPolicy.skillNames,
-      });
+      const skillsListMsg = params.skillRuntime.buildSkillsListMessage();
       if (skillsListMsg) {
         this.insertBeforeLastUser(contextMessages, skillsListMsg);
       }

--- a/src/skills/session-skill-runtime.ts
+++ b/src/skills/session-skill-runtime.ts
@@ -10,10 +10,6 @@ export interface SkillCommandResult {
   reply?: string;
 }
 
-export interface BuildSkillsListMessageOptions {
-  skillNames?: string[];
-}
-
 export class SessionSkillRuntime {
   constructor(
     private skillManager: SkillManager,
@@ -29,13 +25,8 @@ export class SessionSkillRuntime {
     await this.reloadHandler();
   }
 
-  buildSkillsListMessage(options: BuildSkillsListMessageOptions = {}): Message | undefined {
-    const allowedNames = options.skillNames && options.skillNames.length > 0
-      ? new Set(options.skillNames)
-      : undefined;
-    const skills = this.skillManager
-      .getUserInvocableSkills()
-      .filter(skill => !allowedNames || allowedNames.has(skill.metadata.name));
+  buildSkillsListMessage(): Message | undefined {
+    const skills = this.skillManager.getUserInvocableSkills();
     if (skills.length === 0) return undefined;
 
     const skillList = skills

--- a/tests/session-skill-runtime.test.ts
+++ b/tests/session-skill-runtime.test.ts
@@ -21,7 +21,7 @@ describe('SessionSkillRuntime', () => {
     assert.match(String(message.content), /skill 工具/);
   });
 
-  test('builds a filtered transient skills list when names are provided', () => {
+  test('includes every user-invocable skill description in the transient list', () => {
     const runtime = new SessionSkillRuntime(buildSkillManager({
       userInvocableSkills: [
         buildSkill('coding-context', 'Coding skill'),
@@ -29,13 +29,12 @@ describe('SessionSkillRuntime', () => {
       ],
     }) as any, 'session-demo');
 
-    const message = runtime.buildSkillsListMessage({
-      skillNames: ['coding-context'],
-    });
+    const message = runtime.buildSkillsListMessage();
 
     assert.ok(message);
     assert.match(String(message.content), /coding-context: Coding skill/);
-    assert.doesNotMatch(String(message.content), /officecli: Office skill/);
+    assert.match(String(message.content), /officecli: Office skill/);
+    assert.match(String(message.content), /本轮所有可用的 skills/);
   });
 
   test('lists skills as names only for slash skills command', () => {

--- a/tests/transient-injection-policy.test.ts
+++ b/tests/transient-injection-policy.test.ts
@@ -28,7 +28,7 @@ const defaultTools = [
   tool('spawn_subagent'),
 ];
 
-test('plain chat does not request transient mode, skills, cwd, or runner hint', () => {
+test('plain chat still receives the complete skills list without cwd or runner hints', () => {
   const messages: Message[] = [{ role: 'user', content: '早，今天状态怎么样？' }];
 
   const turnPolicy = resolveTurnContextTransientPolicy(messages);
@@ -42,12 +42,12 @@ test('plain chat does not request transient mode, skills, cwd, or runner hint', 
   });
 
   assert.equal(turnPolicy.intent.kind, 'plain-chat');
-  assert.equal(turnPolicy.injectSkillsList, false);
+  assert.equal(turnPolicy.injectSkillsList, true);
   assert.equal(providerPolicy.injectEnvironment, false);
   assert.equal(providerPolicy.injectRunnerHint, false);
 });
 
-test('coding work requests get workspace context plus a narrow coding skill list', () => {
+test('coding work requests get workspace context plus the complete skills list', () => {
   const messages: Message[] = [
     { role: 'user', content: '这个项目 npm run build 报错，帮我定位原因' },
   ];
@@ -64,8 +64,16 @@ test('coding work requests get workspace context plus a narrow coding skill list
 
   assert.equal(turnPolicy.intent.kind, 'workspace');
   assert.equal(turnPolicy.injectSkillsList, true);
-  assert.deepEqual(turnPolicy.skillNames, ['coding-context']);
+  assert.equal('skillNames' in turnPolicy, false);
   assert.equal(providerPolicy.injectEnvironment, true);
+});
+
+test('does not request a skills list when no real user message exists', () => {
+  const messages: Message[] = [{ role: 'system', content: 'base prompt' }];
+
+  const turnPolicy = resolveTurnContextTransientPolicy(messages);
+
+  assert.equal(turnPolicy.injectSkillsList, false);
 });
 
 test('legacy system mode tags are ignored while keeping coding workspace context', () => {


### PR DESCRIPTION
## 问题

旧的 transient injection policy 会先通过硬编码意图规则筛选 Skill，并只允许 `coding-context`、`officecli`、`agent-browser`、`memory-search`、`self-evolution` 这几个预设名称进入候选列表。

`SessionSkillRuntime` 随后又按这些名称过滤已安装 Skill。结果是：其他 Skill 的 description 根本不会进入模型上下文。即使 description 本身写得准确，模型也没有机会看到并选择它们，导致 Skill 召回率被候选阶段直接限制。

## 修改

- 每个包含真实用户消息的回合都注入全部 user-invocable Skill 的名称和 description。
- 移除 transient policy 和 `SessionSkillRuntime` 之间的 `skillNames` 硬编码过滤链路。
- 保持完整 `SKILL.md` 按需加载：上下文中只放名称和 description，模型确认匹配后仍需调用 `skill` 工具。
- 更新 transient 提示，明确按 description 判断匹配，没有合适 Skill 时不要勉强调用。
- 补充普通聊天、编码任务和无真实用户消息等场景的回归测试。

## 影响

所有已安装且允许用户调用的 Skill 都能参与模型选择，不再被固定的五项候选集提前排除。这优先修复召回缺失，同时避免把完整 Skill 内容常驻注入上下文。

代价是每个真实用户回合都会增加全部 Skill description 的 token；当前 Skill 规模下先以正确召回为优先，后续如规模增长，再基于评测结果考虑高召回的动态候选策略。

## 验证

- 定向测试：9 项通过
- `npm run build`：通过
- 完整测试：908 项，906 通过，2 跳过，0 失败