### PR TITLE
修复 Responses 流式回复偶发为空

### DIFF
--- a/src/providers/openai-provider.ts
+++ b/src/providers/openai-provider.ts
@@ -627,9 +627,16 @@ export class OpenAIProvider implements AIProvider {
       const stream = response.data;
       const contentStripper = new OpenAIThinkingStripper();
       const outputItems: any[] = [];
+      let streamedVisibleText = '';
       let buffer = '';
       let finalResponse: any;
       let settled = false;
+
+      const emitVisibleText = (text: string) => {
+        if (!text) return;
+        streamedVisibleText += text;
+        callbacks?.onText?.(text);
+      };
 
       const finishError = (error: Error) => {
         if (settled) return;
@@ -647,7 +654,7 @@ export class OpenAIProvider implements AIProvider {
           && typeof event.delta === 'string'
         ) {
           const visible = contentStripper.push(event.delta);
-          if (visible) callbacks?.onText?.(visible);
+          emitVisibleText(visible);
           return;
         }
         if (event?.type === 'response.output_item.done' && event.item) {
@@ -688,7 +695,7 @@ export class OpenAIProvider implements AIProvider {
         options?.signal?.removeEventListener('abort', onAbort);
         if (settled) return;
         const tail = contentStripper.flush();
-        if (tail) callbacks?.onText?.(tail);
+        emitVisibleText(tail);
         if (!finalResponse) {
           finishError(new Error('Responses API stream ended without a terminal response'));
           return;
@@ -702,6 +709,9 @@ export class OpenAIProvider implements AIProvider {
           finalResponse.output = outputItems.filter(Boolean);
         }
         const result = this.parseResponsesResponse(finalResponse);
+        if (!result.content && streamedVisibleText) {
+          result.content = this.visibleMessageContent({ content: streamedVisibleText });
+        }
         ContextDebugLogger.dumpSdkBoundary('after', undefined, { response: finalResponse });
         settled = true;
         callbacks?.onComplete?.(result);

--- a/tests/openai-provider-responses.test.ts
+++ b/tests/openai-provider-responses.test.ts
@@ -305,6 +305,74 @@ describe('OpenAIProvider Responses API mode', () => {
     }
   });
 
+  test('preserves streamed text when the terminal response omits its message', async () => {
+    const originalPost = axios.post;
+    (axios as any).post = async () => ({
+      data: Readable.from([
+        sse({ type: 'response.output_text.delta', delta: 'answer from ' }),
+        sse({ type: 'response.output_text.delta', delta: 'stream' }),
+        sse({
+          type: 'response.completed',
+          response: {
+            status: 'completed',
+            output: [{ type: 'reasoning', id: 'reasoning_1', summary: [] }],
+            usage: {
+              input_tokens: 50,
+              output_tokens: 10,
+              total_tokens: 60,
+            },
+          },
+        }),
+      ]),
+    });
+
+    try {
+      const chunks: string[] = [];
+      const result = await createProvider().chatStream(
+        [{ role: 'user', content: 'hello' }],
+        undefined,
+        { onText: value => chunks.push(value) },
+      );
+
+      assert.deepEqual(chunks, ['answer from ', 'stream']);
+      assert.equal(result.content, 'answer from stream');
+      assert.equal(result.stopReason, 'completed');
+      assert.equal(result.usage?.totalTokens, 60);
+    } finally {
+      (axios as any).post = originalPost;
+    }
+  });
+
+  test('prefers terminal response text over the streamed fallback', async () => {
+    const originalPost = axios.post;
+    (axios as any).post = async () => ({
+      data: Readable.from([
+        sse({ type: 'response.output_text.delta', delta: 'streamed draft' }),
+        sse({
+          type: 'response.completed',
+          response: {
+            status: 'completed',
+            output: [{
+              type: 'message',
+              role: 'assistant',
+              content: [{ type: 'output_text', text: 'terminal answer' }],
+            }],
+          },
+        }),
+      ]),
+    });
+
+    try {
+      const result = await createProvider().chatStream(
+        [{ role: 'user', content: 'hello' }],
+      );
+
+      assert.equal(result.content, 'terminal answer');
+    } finally {
+      (axios as any).post = originalPost;
+    }
+  });
+
   test('streams a Responses refusal and preserves it in the final result', async () => {
     const originalPost = axios.post;
     const terminalResponse = {


### PR DESCRIPTION
## 问题

部分 OpenAI Responses 兼容中转会通过 SSE delta 正常返回正文，但在 `response.completed` 终包中只保留 reasoning，不包含 message。CatsCo 过去只从终包生成最终结果，导致已经流式收到并展示过的正文最终被记为空消息，CatsCompany 显示 `[无回复]`。

## 修改

- 在 Responses 流式处理期间累计经过 thinking 过滤后的可见正文
- 终包存在正文时继续以终包为准
- 仅在终包解析不到可见正文时，使用已收到的流式正文作为最终内容
- 补充终包缺 message 和终包正文优先两类回归测试

## 影响

修复自定义 OpenAI Responses 模型偶发无回复的问题。改动仅作用于 Responses 流式结果收束，不修改 Anthropic、工具调用、reasoning replay、消息注入或 branchagent 链路。

## 验证

- `npx tsx --test tests/openai-provider-responses.test.ts`：11/11
- `npx tsx --test tests/conversation-runner-transcript-normalization.test.ts`：33/33
- `npm run build`
- `git diff --check`
- 使用当前 `gpt-5.6-terra` Responses 中转连续真实请求 5 次，最终正文均非空