### PR TITLE
feat: 收敛 bot 维度的 LLM Definition 本地模拟

### DIFF
--- a/docs/bot-definition-local-simulation.md
+++ b/docs/bot-definition-local-simulation.md
@@ -7,9 +7,9 @@
 `botId` 是唯一锚点。一份 Definition 只保存一个模型选择：
 
 - 目录模型：只保存 `modelId`。
-- 自定义模型：保存协议、API 地址、模型名、API key、上下文窗口和可选的 reasoning effort。
+- 自定义模型：保存协议、API 地址、模型名、API key、上下文窗口、最大输出、温度和可选的 reasoning effort。
 
-目录模型的 endpoint 与 relay key 不属于可迁移的 BotDefinition。它们是当前设备取得的运行时材料，单独保存；新设备激活同一 bot 时会重新从 CatsCo relay 获取。
+目录模型的 endpoint 与 relay key 不属于可迁移的 BotDefinition。它们是当前设备取得的运行时材料，单独保存；未来接入 CatsCompany Definition API 后，新设备会按 `modelId` 重新获取这份设备运行时材料。
 
 第一版不纳入显示名、设备身份、session、额度、工作目录、prompt 或 skill 数据。
 
@@ -38,15 +38,16 @@ current botId
 
 因此 `.env` 不再是已绑定 bot 的实际模型决定来源。它只保留两项兼容职责：
 
-1. 老安装第一次创建 Definition 或缺少目录模型运行时材料时，作为一次性迁移来源。
+1. 老安装第一次创建 Definition，或目录模型缺少设备运行时材料且模型 id 精确匹配时，作为一次性迁移来源。
 2. 未绑定 bot 的旧启动方式继续可用。
 
-迁移成功后，即使 `.env` 里的旧模型值改变，已绑定 bot 仍使用本地 Definition 缓存和目录模型运行时材料。
+迁移或本机模型保存成功后，会删除 `.env` 与旧 `config.json` 中的模型字段，但不会动 CatsCo 登录、绑定和设备字段。之后已绑定 bot 只使用本地 Definition 缓存和目录模型运行时材料。
 
 ## 同步方向
 
 - 本机在 Dashboard 修改模型：本机发布 Definition 到 canonical，并更新当前设备缓存。
-- 绑定或切换 bot：先从 canonical 拉取 Definition 到当前设备缓存；若是目录模型，再为当前设备获取 relay 运行时材料。
+- 每次 connector 启动、绑定或切换 bot：先从 canonical 拉取 Definition 到当前设备缓存。目录模型缺少当前设备运行时材料时，会向 CatsCo Relay 获取并写入本机材料，不修改 Definition 的模型选择。
 - 未存在 Definition 的老 bot：从当前旧模型配置创建一次 Definition，确保历史安装可继续使用。
+- 未存在 Definition 且没有旧模型配置的已绑定 bot：自动选用 `minimax-m3`（`MiniMax-M3`），先获取本机 Relay endpoint/key，再创建 Definition，避免留下无法执行的空配置。
 
 当前运行实例的数据根沿用既有规则：Electron 使用 userData；CLI 或云端使用显式数据根或启动目录。因此 Definition、`.env`、`.xiaoba/catsco.json`、日志和 session 不会因本次改动额外产生新的数据根。

--- a/docs/bot-definition-local-simulation.md
+++ b/docs/bot-definition-local-simulation.md
@@ -1,0 +1,52 @@
+# BotDefinition 本地模拟与模型配置解耦
+
+这是 BotDefinition 的第一块落地实现，刻意保持很小：它当前只定义一个 CatsCo bot 选择了什么模型。Prompt 与 skill 快照仍待后续确定各自的版本契约后再加入。
+
+## 定义范围
+
+`botId` 是唯一锚点。一份 Definition 只保存一个模型选择：
+
+- 目录模型：只保存 `modelId`。
+- 自定义模型：保存协议、API 地址、模型名、API key、上下文窗口和可选的 reasoning effort。
+
+目录模型的 endpoint 与 relay key 不属于可迁移的 BotDefinition。它们是当前设备取得的运行时材料，单独保存；新设备激活同一 bot 时会重新从 CatsCo relay 获取。
+
+第一版不纳入显示名、设备身份、session、额度、工作目录、prompt 或 skill 数据。
+
+## 本地文件接口
+
+当前仓库用文件模拟未来 CatsCompany 的 BotDefinition API：
+
+- canonical Definition：`<runtimeDataRoot>/data/bot-definition-simulated-cloud/bots/<botId>.json`
+- 当前设备 Definition 缓存：`<runtimeDataRoot>/data/bot-definition-cache/bots/<botId>.json`
+- 当前设备目录模型运行时材料：`<runtimeDataRoot>/data/bot-catalog-model-runtime/bots/<botId>.json`
+
+可以设置 `XIAOBA_BOT_DEFINITION_SIMULATED_CLOUD_DIR`，让多个本地测试实例共用一个模拟 canonical 存储。
+
+## 最终模型读取链路
+
+已绑定 bot 的实际模型配置只走这一条链：
+
+```text
+current botId
+  -> BotDefinition 本地缓存
+  -> 自定义模型定义 / 目录模型设备运行时材料
+  -> LLMConfigResolver
+  -> ConfigManager
+  -> AIService
+```
+
+因此 `.env` 不再是已绑定 bot 的实际模型决定来源。它只保留两项兼容职责：
+
+1. 老安装第一次创建 Definition 或缺少目录模型运行时材料时，作为一次性迁移来源。
+2. 未绑定 bot 的旧启动方式继续可用。
+
+迁移成功后，即使 `.env` 里的旧模型值改变，已绑定 bot 仍使用本地 Definition 缓存和目录模型运行时材料。
+
+## 同步方向
+
+- 本机在 Dashboard 修改模型：本机发布 Definition 到 canonical，并更新当前设备缓存。
+- 绑定或切换 bot：先从 canonical 拉取 Definition 到当前设备缓存；若是目录模型，再为当前设备获取 relay 运行时材料。
+- 未存在 Definition 的老 bot：从当前旧模型配置创建一次 Definition，确保历史安装可继续使用。
+
+当前运行实例的数据根沿用既有规则：Electron 使用 userData；CLI 或云端使用显式数据根或启动目录。因此 Definition、`.env`、`.xiaoba/catsco.json`、日志和 session 不会因本次改动额外产生新的数据根。

--- a/src/bot-definition/activation.ts
+++ b/src/bot-definition/activation.ts
@@ -1,0 +1,77 @@
+import { createCatsCoLocalConfigService, type CatsCoAuthSnapshot } from '../catscompany/local-config';
+import { provisionCatsRelayCatalogRuntime } from '../catscompany/relay-model-bootstrap';
+import { DEFAULT_CATSCO_RELAY_MODEL_ID } from '../utils/relay-model-profiles';
+import {
+  catalogRuntimeMatchesModelId,
+  createBotDefinitionSyncService,
+  type BotDefinitionSyncServiceOptions,
+} from './service';
+import type { BotDefinition, BotDefinitionSyncResult } from './types';
+
+export interface PrepareBoundBotDefinitionOptions extends BotDefinitionSyncServiceOptions {
+  runtimeRoot: string;
+  botId?: string;
+  auth?: CatsCoAuthSnapshot;
+  fetchImpl?: typeof fetch;
+}
+
+export interface PreparedBoundBotDefinition {
+  botId: string;
+  definition: BotDefinition;
+  sync?: BotDefinitionSyncResult;
+  initializedDefault: boolean;
+  materializedCatalogRuntime: boolean;
+}
+
+/**
+ * Makes the selected bot runnable on this machine before connector preflight.
+ * Definition sync is portable; catalog runtime material is deliberately local.
+ */
+export async function prepareBoundBotDefinition(
+  options: PrepareBoundBotDefinitionOptions,
+): Promise<PreparedBoundBotDefinition | undefined> {
+  const localConfig = createCatsCoLocalConfigService({ runtimeRoot: options.runtimeRoot }).load();
+  const botId = String(options.botId || localConfig.currentBot?.uid || '').trim();
+  if (!botId) return undefined;
+
+  const definitionService = createBotDefinitionSyncService(options);
+  let sync = definitionService.pullOrBootstrap(botId);
+  let definition = sync?.definition;
+  const auth = options.auth ?? createCatsCoLocalConfigService({ runtimeRoot: options.runtimeRoot }).getAuthState();
+  let initializedDefault = false;
+  let materializedCatalogRuntime = false;
+
+  if (!definition) {
+    const runtime = await provisionCatsRelayCatalogRuntime({
+      botId,
+      modelId: DEFAULT_CATSCO_RELAY_MODEL_ID,
+      auth,
+      fetchImpl: options.fetchImpl,
+    });
+    definitionService.storeCatalogRuntime(runtime);
+    sync = definitionService.publish(botId, {
+      kind: 'catalog',
+      modelId: DEFAULT_CATSCO_RELAY_MODEL_ID,
+    });
+    definition = sync.definition;
+    initializedDefault = true;
+    materializedCatalogRuntime = true;
+  }
+
+  if (definition.model.kind === 'catalog') {
+    const runtime = definitionService.readCatalogRuntime(botId);
+    if (!runtime || !catalogRuntimeMatchesModelId(runtime, definition.model.modelId)) {
+      const materialized = await provisionCatsRelayCatalogRuntime({
+        botId,
+        modelId: definition.model.modelId,
+        auth,
+        fetchImpl: options.fetchImpl,
+      });
+      definitionService.storeCatalogRuntime(materialized);
+      materializedCatalogRuntime = true;
+    }
+  }
+
+  definitionService.clearLegacyModelConfigurationWhenReady(definition);
+  return { botId, definition, sync, initializedDefault, materializedCatalogRuntime };
+}

--- a/src/bot-definition/llm-config-resolver.ts
+++ b/src/bot-definition/llm-config-resolver.ts
@@ -1,0 +1,92 @@
+import * as path from 'path';
+import { createCatsCoLocalConfigService } from '../catscompany/local-config';
+import type { ChatConfig } from '../types';
+import { PathResolver } from '../utils/path-resolver';
+import { FileBotCatalogModelRuntimeRepository, FileBotDefinitionRepository } from './repository';
+import { catalogRuntimeFromLocalProfile, readLocalModelProfile } from './service';
+
+export type BotLLMConfigSource = 'custom_definition' | 'catalog_runtime';
+
+export interface ResolvedBotLLMConfig {
+  botId: string;
+  source: BotLLMConfigSource;
+  config: Pick<ChatConfig, 'provider' | 'apiUrl' | 'apiKey' | 'model' | 'contextWindowTokens' | 'reasoningEffort' | 'openaiApiMode'>;
+}
+
+export interface ResolveBotLLMConfigOptions {
+  runtimeRoot?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+function runtimeToConfig(runtime: {
+  provider: 'anthropic' | 'openai';
+  apiBase: string;
+  apiKey: string;
+  model: string;
+  contextWindowTokens: number;
+  reasoningEffort?: ChatConfig['reasoningEffort'];
+  openaiApiMode?: ChatConfig['openaiApiMode'];
+}): ResolvedBotLLMConfig['config'] {
+  return {
+    provider: runtime.provider,
+    apiUrl: runtime.apiBase,
+    apiKey: runtime.apiKey,
+    model: runtime.model,
+    contextWindowTokens: runtime.contextWindowTokens,
+    ...(runtime.reasoningEffort ? { reasoningEffort: runtime.reasoningEffort } : {}),
+    ...(runtime.openaiApiMode ? { openaiApiMode: runtime.openaiApiMode } : {}),
+  };
+}
+
+/**
+ * Resolves the effective model for a bound bot without consulting legacy .env
+ * as the decision source. Legacy values are used once only to migrate missing
+ * catalog runtime material from an older installation.
+ */
+export function resolveActiveBotLLMConfig(
+  options: ResolveBotLLMConfigOptions = {},
+): ResolvedBotLLMConfig | undefined {
+  const runtimeRoot = path.resolve(options.runtimeRoot ?? PathResolver.getRuntimeDataRoot());
+  const env = options.env ?? process.env;
+  const localConfig = createCatsCoLocalConfigService({ runtimeRoot, env }).load();
+  const botId = String(localConfig.currentBot?.uid || '').trim();
+  if (!botId) return undefined;
+
+  const definitions = new FileBotDefinitionRepository({ runtimeRoot });
+  const definition = definitions.readCache(botId);
+  if (!definition) return undefined;
+
+  if (definition.model.kind === 'custom') {
+    const model = definition.model;
+    return {
+      botId,
+      source: 'custom_definition',
+      config: {
+        provider: model.protocol === 'anthropic' ? 'anthropic' : 'openai',
+        apiUrl: model.apiBase,
+        apiKey: model.apiKey,
+        model: model.model,
+        contextWindowTokens: model.contextWindowTokens,
+        ...(model.reasoningEffort ? { reasoningEffort: model.reasoningEffort } : {}),
+        openaiApiMode: model.protocol === 'openai-responses' ? 'responses' : 'chat_completions',
+      },
+    };
+  }
+
+  const catalogRuntime = new FileBotCatalogModelRuntimeRepository({ runtimeRoot });
+  let runtime = catalogRuntime.read(botId);
+  if (!runtime || runtime.modelId !== definition.model.modelId) {
+    const profile = readLocalModelProfile(runtimeRoot, env);
+    const migrated = profile && catalogRuntimeFromLocalProfile(botId, definition.model.modelId, profile);
+    if (migrated) {
+      catalogRuntime.write(migrated);
+      runtime = migrated;
+    }
+  }
+  if (!runtime || runtime.modelId !== definition.model.modelId) return undefined;
+  return {
+    botId,
+    source: 'catalog_runtime',
+    config: runtimeToConfig(runtime),
+  };
+}

--- a/src/bot-definition/llm-config-resolver.ts
+++ b/src/bot-definition/llm-config-resolver.ts
@@ -3,6 +3,7 @@ import { createCatsCoLocalConfigService } from '../catscompany/local-config';
 import type { ChatConfig } from '../types';
 import { PathResolver } from '../utils/path-resolver';
 import { FileBotCatalogModelRuntimeRepository, FileBotDefinitionRepository } from './repository';
+import { catalogRuntimeMatchesModelId } from './service';
 
 export type BotLLMConfigSource = 'custom_definition' | 'catalog_runtime';
 
@@ -82,7 +83,7 @@ export function resolveActiveBotLLMConfig(
 
   const catalogRuntime = new FileBotCatalogModelRuntimeRepository({ runtimeRoot });
   const runtime = catalogRuntime.read(botId);
-  if (!runtime || runtime.modelId !== definition.model.modelId) return undefined;
+  if (!runtime || !catalogRuntimeMatchesModelId(runtime, definition.model.modelId)) return undefined;
   return {
     botId,
     source: 'catalog_runtime',

--- a/src/bot-definition/llm-config-resolver.ts
+++ b/src/bot-definition/llm-config-resolver.ts
@@ -3,14 +3,13 @@ import { createCatsCoLocalConfigService } from '../catscompany/local-config';
 import type { ChatConfig } from '../types';
 import { PathResolver } from '../utils/path-resolver';
 import { FileBotCatalogModelRuntimeRepository, FileBotDefinitionRepository } from './repository';
-import { catalogRuntimeFromLocalProfile, readLocalModelProfile } from './service';
 
 export type BotLLMConfigSource = 'custom_definition' | 'catalog_runtime';
 
 export interface ResolvedBotLLMConfig {
   botId: string;
   source: BotLLMConfigSource;
-  config: Pick<ChatConfig, 'provider' | 'apiUrl' | 'apiKey' | 'model' | 'contextWindowTokens' | 'reasoningEffort' | 'openaiApiMode'>;
+  config: Pick<ChatConfig, 'provider' | 'apiUrl' | 'apiKey' | 'model' | 'contextWindowTokens' | 'maxTokens' | 'temperature' | 'reasoningEffort' | 'openaiApiMode' | 'modelCapabilities'>;
 }
 
 export interface ResolveBotLLMConfigOptions {
@@ -24,8 +23,11 @@ function runtimeToConfig(runtime: {
   apiKey: string;
   model: string;
   contextWindowTokens: number;
+  maxTokens?: number;
+  temperature?: number;
   reasoningEffort?: ChatConfig['reasoningEffort'];
   openaiApiMode?: ChatConfig['openaiApiMode'];
+  capabilities?: ChatConfig['modelCapabilities'];
 }): ResolvedBotLLMConfig['config'] {
   return {
     provider: runtime.provider,
@@ -33,8 +35,11 @@ function runtimeToConfig(runtime: {
     apiKey: runtime.apiKey,
     model: runtime.model,
     contextWindowTokens: runtime.contextWindowTokens,
+    ...(runtime.maxTokens ? { maxTokens: runtime.maxTokens } : {}),
+    temperature: runtime.temperature ?? 0.7,
     ...(runtime.reasoningEffort ? { reasoningEffort: runtime.reasoningEffort } : {}),
     ...(runtime.openaiApiMode ? { openaiApiMode: runtime.openaiApiMode } : {}),
+    ...(runtime.capabilities ? { modelCapabilities: runtime.capabilities } : {}),
   };
 }
 
@@ -67,6 +72,8 @@ export function resolveActiveBotLLMConfig(
         apiKey: model.apiKey,
         model: model.model,
         contextWindowTokens: model.contextWindowTokens,
+        ...(model.maxTokens ? { maxTokens: model.maxTokens } : {}),
+        temperature: model.temperature ?? 0.7,
         ...(model.reasoningEffort ? { reasoningEffort: model.reasoningEffort } : {}),
         openaiApiMode: model.protocol === 'openai-responses' ? 'responses' : 'chat_completions',
       },
@@ -74,15 +81,7 @@ export function resolveActiveBotLLMConfig(
   }
 
   const catalogRuntime = new FileBotCatalogModelRuntimeRepository({ runtimeRoot });
-  let runtime = catalogRuntime.read(botId);
-  if (!runtime || runtime.modelId !== definition.model.modelId) {
-    const profile = readLocalModelProfile(runtimeRoot, env);
-    const migrated = profile && catalogRuntimeFromLocalProfile(botId, definition.model.modelId, profile);
-    if (migrated) {
-      catalogRuntime.write(migrated);
-      runtime = migrated;
-    }
-  }
+  const runtime = catalogRuntime.read(botId);
   if (!runtime || runtime.modelId !== definition.model.modelId) return undefined;
   return {
     botId,

--- a/src/bot-definition/repository.ts
+++ b/src/bot-definition/repository.ts
@@ -1,0 +1,206 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { PathResolver } from '../utils/path-resolver';
+import { BOT_CATALOG_MODEL_RUNTIME_SCHEMA, type BotCatalogModelRuntime, type BotDefinition } from './types';
+
+export interface BotDefinitionRepository {
+  readCanonical(botId: string): BotDefinition | undefined;
+  writeCanonical(definition: BotDefinition): void;
+  readCache(botId: string): BotDefinition | undefined;
+  writeCache(definition: BotDefinition): void;
+}
+
+/**
+ * Per-device catalog runtime material. This is intentionally a separate
+ * repository because relay credentials are not part of the portable bot
+ * definition.
+ */
+export interface BotCatalogModelRuntimeRepository {
+  read(botId: string): BotCatalogModelRuntime | undefined;
+  write(runtime: BotCatalogModelRuntime): void;
+}
+
+export interface FileBotDefinitionRepositoryOptions {
+  runtimeRoot?: string;
+  simulatedCloudRoot?: string;
+  cacheRoot?: string;
+}
+
+function normalizeBotId(botId: string): string {
+  const value = String(botId || '').trim();
+  if (!value) throw new Error('botId is required');
+  if (!/^[a-zA-Z0-9_.-]+$/.test(value)) {
+    throw new Error('botId contains unsupported characters');
+  }
+  return value;
+}
+
+function isValidDefinition(definition: unknown, expectedBotId: string): definition is BotDefinition {
+  const value = definition as BotDefinition | undefined;
+  if (!value || value.schema !== 'xiaoba.bot-definition.v1' || value.botId !== expectedBotId || !value.model) {
+    return false;
+  }
+  if (value.model.kind === 'catalog') {
+    return Boolean(String(value.model.modelId || '').trim());
+  }
+  if (value.model.kind !== 'custom') return false;
+  return (
+    ['anthropic', 'openai-chat-completions', 'openai-responses'].includes(value.model.protocol)
+    && Boolean(String(value.model.apiBase || '').trim())
+    && Boolean(String(value.model.model || '').trim())
+    && Boolean(String(value.model.apiKey || '').trim())
+    && Number.isFinite(value.model.contextWindowTokens)
+    && value.model.contextWindowTokens > 0
+  );
+}
+
+function isValidCatalogRuntime(runtime: unknown, expectedBotId: string): runtime is BotCatalogModelRuntime {
+  const value = runtime as BotCatalogModelRuntime | undefined;
+  return Boolean(
+    value
+      && value.schema === BOT_CATALOG_MODEL_RUNTIME_SCHEMA
+      && value.botId === expectedBotId
+      && String(value.modelId || '').trim()
+      && (value.provider === 'anthropic' || value.provider === 'openai')
+      && String(value.apiBase || '').trim()
+      && String(value.apiKey || '').trim()
+      && String(value.model || '').trim()
+      && Number.isFinite(value.contextWindowTokens)
+      && value.contextWindowTokens > 0,
+  );
+}
+
+function readDefinition(filePath: string, expectedBotId: string): BotDefinition | undefined {
+  if (!fs.existsSync(filePath)) return undefined;
+  try {
+    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as BotDefinition;
+    return isValidDefinition(parsed, expectedBotId) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function writeDefinition(filePath: string, definition: BotDefinition): void {
+  if (!isValidDefinition(definition, definition.botId)) {
+    throw new Error('BotDefinition is invalid');
+  }
+  const directory = path.dirname(filePath);
+  fs.mkdirSync(directory, { recursive: true });
+  const temporary = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  fs.writeFileSync(temporary, `${JSON.stringify(definition, null, 2)}\n`, { encoding: 'utf-8', mode: 0o600 });
+  fs.renameSync(temporary, filePath);
+  if (process.platform !== 'win32') {
+    try {
+      fs.chmodSync(filePath, 0o600);
+    } catch {
+      // Existing installs must remain usable on filesystems without POSIX modes.
+    }
+  }
+}
+
+function writeCatalogRuntime(filePath: string, runtime: BotCatalogModelRuntime): void {
+  if (!isValidCatalogRuntime(runtime, runtime.botId)) {
+    throw new Error('Bot catalog model runtime is invalid');
+  }
+  const directory = path.dirname(filePath);
+  fs.mkdirSync(directory, { recursive: true });
+  const temporary = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  fs.writeFileSync(temporary, `${JSON.stringify(runtime, null, 2)}\n`, { encoding: 'utf-8', mode: 0o600 });
+  fs.renameSync(temporary, filePath);
+  if (process.platform !== 'win32') {
+    try {
+      fs.chmodSync(filePath, 0o600);
+    } catch {
+      // Existing installs must remain usable on filesystems without POSIX modes.
+    }
+  }
+}
+
+/**
+ * File-backed stand-in for the future cloud BotDefinition API. The interface
+ * keeps the application code independent from whether the canonical record is
+ * a file today or a CatsCompany endpoint later.
+ */
+export class FileBotDefinitionRepository implements BotDefinitionRepository {
+  private readonly canonicalRoot: string;
+  private readonly cacheRoot: string;
+
+  constructor(options: FileBotDefinitionRepositoryOptions = {}) {
+    const runtimeRoot = path.resolve(options.runtimeRoot ?? PathResolver.getRuntimeDataRoot());
+    this.canonicalRoot = path.resolve(
+      options.simulatedCloudRoot
+        ?? process.env.XIAOBA_BOT_DEFINITION_SIMULATED_CLOUD_DIR
+        ?? path.join(runtimeRoot, 'data', 'bot-definition-simulated-cloud'),
+    );
+    this.cacheRoot = path.resolve(
+      options.cacheRoot
+        ?? path.join(runtimeRoot, 'data', 'bot-definition-cache'),
+    );
+  }
+
+  readCanonical(botId: string): BotDefinition | undefined {
+    const normalized = normalizeBotId(botId);
+    return readDefinition(this.definitionPath(this.canonicalRoot, normalized), normalized);
+  }
+
+  writeCanonical(definition: BotDefinition): void {
+    const botId = normalizeBotId(definition.botId);
+    writeDefinition(this.definitionPath(this.canonicalRoot, botId), definition);
+  }
+
+  readCache(botId: string): BotDefinition | undefined {
+    const normalized = normalizeBotId(botId);
+    return readDefinition(this.definitionPath(this.cacheRoot, normalized), normalized);
+  }
+
+  writeCache(definition: BotDefinition): void {
+    const botId = normalizeBotId(definition.botId);
+    writeDefinition(this.definitionPath(this.cacheRoot, botId), definition);
+  }
+
+  getCanonicalPath(botId: string): string {
+    return this.definitionPath(this.canonicalRoot, normalizeBotId(botId));
+  }
+
+  getCachePath(botId: string): string {
+    return this.definitionPath(this.cacheRoot, normalizeBotId(botId));
+  }
+
+  private definitionPath(root: string, botId: string): string {
+    return path.join(root, 'bots', `${botId}.json`);
+  }
+}
+
+export class FileBotCatalogModelRuntimeRepository implements BotCatalogModelRuntimeRepository {
+  private readonly root: string;
+
+  constructor(options: FileBotDefinitionRepositoryOptions = {}) {
+    const runtimeRoot = path.resolve(options.runtimeRoot ?? PathResolver.getRuntimeDataRoot());
+    this.root = path.resolve(path.join(runtimeRoot, 'data', 'bot-catalog-model-runtime'));
+  }
+
+  read(botId: string): BotCatalogModelRuntime | undefined {
+    const normalized = normalizeBotId(botId);
+    const filePath = this.runtimePath(normalized);
+    if (!fs.existsSync(filePath)) return undefined;
+    try {
+      const parsed = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as BotCatalogModelRuntime;
+      return isValidCatalogRuntime(parsed, normalized) ? parsed : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  write(runtime: BotCatalogModelRuntime): void {
+    const botId = normalizeBotId(runtime.botId);
+    writeCatalogRuntime(this.runtimePath(botId), runtime);
+  }
+
+  getPath(botId: string): string {
+    return this.runtimePath(normalizeBotId(botId));
+  }
+
+  private runtimePath(botId: string): string {
+    return path.join(this.root, 'bots', `${botId}.json`);
+  }
+}

--- a/src/bot-definition/service.ts
+++ b/src/bot-definition/service.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import * as dotenv from 'dotenv';
 import { createCatsCoLocalConfigService } from '../catscompany/local-config';
@@ -23,6 +24,61 @@ import {
 
 const CUSTOM_DEFAULT_CONTEXT_WINDOW_TOKENS = 200_000;
 
+/**
+ * These keys belonged to the pre-BotDefinition model configuration. They are
+ * deliberately separate from CatsCo account/device keys: migration removes
+ * only model settings and leaves connector identity untouched.
+ */
+export const LEGACY_MODEL_ENV_KEYS = [
+  'GAUZ_LLM_PROVIDER',
+  'GAUZ_LLM_API_BASE',
+  'GAUZ_LLM_API_KEY',
+  'GAUZ_LLM_MODEL',
+  'GAUZ_LLM_MAX_OUTPUT_TOKENS',
+  'GAUZ_LLM_MAX_TOKENS',
+  'GAUZ_LLM_CONTEXT_WINDOW_TOKENS',
+  'GAUZ_LLM_CONTEXT_TOKENS',
+  'GAUZ_LLM_MAX_PROMPT_TOKENS',
+  'GAUZ_LLM_TEMPERATURE',
+  'GAUZ_LLM_REASONING_EFFORT',
+  'GAUZ_LLM_OPENAI_API_MODE',
+  'CATSCO_MODEL_SOURCE',
+  'CATSCO_RELAY_LLM_PROVIDER',
+  'CATSCO_RELAY_LLM_API_BASE',
+  'CATSCO_RELAY_LLM_API_KEY',
+  'CATSCO_RELAY_LLM_MODEL',
+  'CATSCO_RELAY_LLM_MAX_OUTPUT_TOKENS',
+  'CATSCO_RELAY_LLM_MAX_TOKENS',
+  'CATSCO_RELAY_LLM_CONTEXT_WINDOW_TOKENS',
+  'CATSCO_RELAY_LLM_TEMPERATURE',
+  'CATSCO_RELAY_LLM_REASONING_EFFORT',
+  'CATSCO_RELAY_LLM_OPENAI_API_MODE',
+  'CATSCO_RELAY_LLM_VISION_CAPABLE',
+  'CATSCO_RELAY_LLM_TOOL_CALLING_CAPABLE',
+  'CATSCO_CUSTOM_LLM_PROVIDER',
+  'CATSCO_CUSTOM_LLM_API_BASE',
+  'CATSCO_CUSTOM_LLM_API_KEY',
+  'CATSCO_CUSTOM_LLM_MODEL',
+  'CATSCO_CUSTOM_LLM_MAX_OUTPUT_TOKENS',
+  'CATSCO_CUSTOM_LLM_MAX_TOKENS',
+  'CATSCO_CUSTOM_LLM_CONTEXT_WINDOW_TOKENS',
+  'CATSCO_CUSTOM_LLM_TEMPERATURE',
+  'CATSCO_CUSTOM_LLM_REASONING_EFFORT',
+  'CATSCO_CUSTOM_LLM_OPENAI_API_MODE',
+] as const;
+
+const LEGACY_CONFIG_MODEL_KEYS = [
+  'apiKey',
+  'apiUrl',
+  'model',
+  'provider',
+  'temperature',
+  'maxTokens',
+  'contextWindowTokens',
+  'reasoningEffort',
+  'openaiApiMode',
+] as const;
+
 function firstNonEmpty(...values: Array<string | undefined>): string | undefined {
   for (const value of values) {
     const text = String(value || '').trim();
@@ -34,6 +90,18 @@ function firstNonEmpty(...values: Array<string | undefined>): string | undefined
 function parsePositiveInteger(value: string | undefined): number | undefined {
   const parsed = Number(value);
   return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : undefined;
+}
+
+function parseTemperature(value: string | undefined): number | undefined {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 && parsed <= 2 ? parsed : undefined;
+}
+
+function parseOptionalBoolean(value: string | undefined): boolean | undefined {
+  const normalized = String(value || '').trim().toLowerCase();
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
+  if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
+  return undefined;
 }
 
 function readRuntimeEnv(runtimeRoot: string, env: NodeJS.ProcessEnv): Record<string, string | undefined> {
@@ -49,7 +117,11 @@ function isRelayProfile(profile: Record<string, string | undefined>): boolean {
   return apiBase.toLowerCase().includes('relay.catsco.cc');
 }
 
-export function readLocalModelProfile(
+/**
+ * Reads only pre-Definition configuration. This is a migration input, never a
+ * normal runtime source for a bound bot.
+ */
+export function readLegacyLocalModelProfile(
   runtimeRoot: string,
   env: NodeJS.ProcessEnv = process.env,
 ): LocalModelProfile | undefined {
@@ -65,6 +137,16 @@ export function readLocalModelProfile(
     values.GAUZ_LLM_CONTEXT_WINDOW_TOKENS,
     values.GAUZ_LLM_CONTEXT_TOKENS,
   ));
+  const maxTokens = parsePositiveInteger(firstNonEmpty(
+    values[`${prefix}MAX_OUTPUT_TOKENS`],
+    values[`${prefix}MAX_TOKENS`],
+    values.GAUZ_LLM_MAX_OUTPUT_TOKENS,
+    values.GAUZ_LLM_MAX_TOKENS,
+  ));
+  const temperature = parseTemperature(firstNonEmpty(
+    values[`${prefix}TEMPERATURE`],
+    values.GAUZ_LLM_TEMPERATURE,
+  ));
   const reasoningEffort = normalizeReasoningEffort(firstNonEmpty(
     values[`${prefix}REASONING_EFFORT`],
     values.GAUZ_LLM_REASONING_EFFORT,
@@ -73,6 +155,8 @@ export function readLocalModelProfile(
     values[`${prefix}OPENAI_API_MODE`],
     values.GAUZ_LLM_OPENAI_API_MODE,
   ));
+  const vision = relay ? parseOptionalBoolean(values.CATSCO_RELAY_LLM_VISION_CAPABLE) : undefined;
+  const toolCalling = relay ? parseOptionalBoolean(values.CATSCO_RELAY_LLM_TOOL_CALLING_CAPABLE) : undefined;
 
   if (relay) {
     return model ? {
@@ -83,8 +167,16 @@ export function readLocalModelProfile(
       model,
       apiKey,
       contextWindowTokens,
+      maxTokens,
+      temperature,
       reasoningEffort,
       openaiApiMode,
+      ...((vision !== undefined || toolCalling !== undefined) ? {
+        capabilities: {
+          ...(vision !== undefined ? { vision } : {}),
+          ...(toolCalling !== undefined ? { toolCalling } : {}),
+        },
+      } : {}),
     } : undefined;
   }
   if (!provider || !apiBase || !model || !apiKey) return undefined;
@@ -96,10 +188,15 @@ export function readLocalModelProfile(
     model,
     apiKey,
     contextWindowTokens: contextWindowTokens ?? CUSTOM_DEFAULT_CONTEXT_WINDOW_TOKENS,
+    maxTokens,
+    temperature,
     reasoningEffort,
     openaiApiMode: openaiApiMode ?? 'chat_completions',
   };
 }
+
+/** @deprecated Use readLegacyLocalModelProfile. */
+export const readLocalModelProfile = readLegacyLocalModelProfile;
 
 /**
  * The catalog definition identifies a model; this separately captures the
@@ -122,8 +219,11 @@ export function catalogRuntimeFromLocalProfile(
     apiKey: profile.apiKey,
     model: profile.model,
     contextWindowTokens: profile.contextWindowTokens ?? CUSTOM_DEFAULT_CONTEXT_WINDOW_TOKENS,
+    ...(profile.maxTokens ? { maxTokens: profile.maxTokens } : {}),
+    ...(profile.temperature !== undefined ? { temperature: profile.temperature } : {}),
     ...(profile.reasoningEffort ? { reasoningEffort: profile.reasoningEffort } : {}),
     ...(profile.openaiApiMode ? { openaiApiMode: profile.openaiApiMode } : {}),
+    ...(profile.capabilities ? { capabilities: profile.capabilities } : {}),
   };
 }
 
@@ -146,6 +246,8 @@ export function botModelDefinitionFromLocalProfile(profile: LocalModelProfile): 
     model: profile.model,
     apiKey: profile.apiKey,
     contextWindowTokens: profile.contextWindowTokens,
+    ...(profile.maxTokens ? { maxTokens: profile.maxTokens } : {}),
+    ...(profile.temperature !== undefined ? { temperature: profile.temperature } : {}),
     ...(profile.reasoningEffort ? { reasoningEffort: profile.reasoningEffort } : {}),
   };
 }
@@ -178,7 +280,6 @@ export class BotDefinitionSyncService {
     const definition = this.repository.readCanonical(botId);
     if (definition) {
       this.repository.writeCache(definition);
-      this.bootstrapCatalogRuntimeFromLocalProfile(definition);
     }
     return definition;
   }
@@ -191,6 +292,7 @@ export class BotDefinitionSyncService {
     };
     this.repository.writeCanonical(definition);
     this.repository.writeCache(definition);
+    this.clearLegacyModelConfiguration();
     return {
       botId,
       direction: 'local_to_simulated_cloud',
@@ -209,16 +311,21 @@ export class BotDefinitionSyncService {
   pullOrBootstrap(botId: string): BotDefinitionSyncResult | undefined {
     const existing = this.pull(botId);
     if (existing) {
+      this.migrateLegacyCatalogRuntime(existing);
+      // The canonical Definition is already authoritative. Any legacy model
+      // fields left on disk can only be stale pre-Definition input.
+      this.clearLegacyModelConfiguration();
       return {
         botId,
         direction: 'simulated_cloud_to_local',
         definition: existing,
       };
     }
-    const profile = readLocalModelProfile(this.runtimeRoot, this.env);
+    const profile = readLegacyLocalModelProfile(this.runtimeRoot, this.env);
     if (!profile) return undefined;
     const definition = this.publish(botId, botModelDefinitionFromLocalProfile(profile)).definition;
     this.bootstrapCatalogRuntimeFromLocalProfile(definition, profile);
+    this.clearLegacyModelConfiguration();
     return {
       botId,
       direction: 'bootstrap_to_simulated_cloud',
@@ -226,15 +333,16 @@ export class BotDefinitionSyncService {
     };
   }
 
+  /**
+   * Compatibility helper for callers which have not yet been converted to
+   * explicit Definition writes. It only bootstraps an empty Definition from
+   * legacy material; it never overwrites an existing bot from .env.
+   */
   publishCurrentBoundBot(): BotDefinitionSyncResult | undefined {
     const localConfig = createCatsCoLocalConfigService({ runtimeRoot: this.runtimeRoot, env: this.env }).load();
     const botId = String(localConfig.currentBot?.uid || '').trim();
     if (!botId) return undefined;
-    const profile = readLocalModelProfile(this.runtimeRoot, this.env);
-    if (!profile) return undefined;
-    const result = this.publish(botId, botModelDefinitionFromLocalProfile(profile));
-    this.bootstrapCatalogRuntimeFromLocalProfile(result.definition, profile);
-    return result;
+    return this.pullOrBootstrap(botId);
   }
 
   pullOrBootstrapCurrentBoundBot(): BotDefinitionSyncResult | undefined {
@@ -250,13 +358,69 @@ export class BotDefinitionSyncService {
     if (definition.model.kind !== 'catalog') return;
     const existing = this.catalogRuntimeRepository.read(definition.botId);
     if (existing?.modelId === definition.model.modelId) return;
-    const profile = knownProfile ?? readLocalModelProfile(this.runtimeRoot, this.env);
+    const profile = knownProfile;
     const runtime = profile && catalogRuntimeFromLocalProfile(
       definition.botId,
       definition.model.modelId,
       profile,
     );
     if (runtime) this.catalogRuntimeRepository.write(runtime);
+  }
+
+  private migrateLegacyCatalogRuntime(definition: BotDefinition): void {
+    if (definition.model.kind !== 'catalog') return;
+    if (this.catalogRuntimeRepository.read(definition.botId)?.modelId === definition.model.modelId) return;
+    const profile = readLegacyLocalModelProfile(this.runtimeRoot, this.env);
+    // A legacy relay key belongs to this catalog model only when both ids
+    // agree. Never attach whatever happens to be in .env to a different bot.
+    if (profile?.source !== 'catalog' || profile.modelId !== definition.model.modelId) return;
+    const runtime = catalogRuntimeFromLocalProfile(definition.botId, definition.model.modelId, profile);
+    if (!runtime) return;
+    this.catalogRuntimeRepository.write(runtime);
+    this.clearLegacyModelConfiguration();
+  }
+
+  /**
+   * Removes model-only legacy state after it has been captured by the
+   * Definition. CatsCo login, binding, and device fields are intentionally not
+   * touched here.
+   */
+  private clearLegacyModelConfiguration(): void {
+    const envPath = path.join(this.runtimeRoot, '.env');
+    if (fs.existsSync(envPath)) {
+      const lines = fs.readFileSync(envPath, 'utf-8').replace(/\r\n/g, '\n').split('\n');
+      const legacy = new Set<string>(LEGACY_MODEL_ENV_KEYS);
+      const next = lines.filter(line => {
+        const match = line.match(/^([A-Za-z_][A-Za-z0-9_]*)=/);
+        return !match || !legacy.has(match[1]);
+      });
+      fs.writeFileSync(envPath, `${next.filter((line, index, all) => line || index < all.length - 1).join('\n').replace(/\n+$/, '')}\n`, 'utf-8');
+    }
+    for (const key of LEGACY_MODEL_ENV_KEYS) {
+      delete this.env[key];
+    }
+
+    const explicit = String(this.env.XIAOBA_CONFIG_PATH || '').trim();
+    const configPath = explicit
+      ? path.resolve(explicit)
+      : path.join(os.homedir(), '.xiaoba', 'config.json');
+    if (!fs.existsSync(configPath)) return;
+    try {
+      const parsed = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return;
+      let changed = false;
+      for (const key of LEGACY_CONFIG_MODEL_KEYS) {
+        if (Object.prototype.hasOwnProperty.call(parsed, key)) {
+          delete parsed[key];
+          changed = true;
+        }
+      }
+      if (changed) {
+        fs.writeFileSync(configPath, `${JSON.stringify(parsed, null, 2)}\n`, { encoding: 'utf-8', mode: 0o600 });
+      }
+    } catch {
+      // A malformed legacy config must not block a successfully created Definition.
+    }
   }
 }
 

--- a/src/bot-definition/service.ts
+++ b/src/bot-definition/service.ts
@@ -6,6 +6,11 @@ import { createCatsCoLocalConfigService } from '../catscompany/local-config';
 import { normalizeOpenAIApiMode } from '../utils/openai-api-mode';
 import { normalizeReasoningEffort } from '../utils/reasoning-effort';
 import {
+  canonicalRelayModelId,
+  findRelayModelProfile,
+  relayModelIdsMatch,
+} from '../utils/relay-model-profiles';
+import {
   BOT_CATALOG_MODEL_RUNTIME_SCHEMA,
   BOT_DEFINITION_SCHEMA,
   type BotCatalogModelRuntime,
@@ -210,27 +215,65 @@ export function catalogRuntimeFromLocalProfile(
 ): BotCatalogModelRuntime | undefined {
   if (profile.source !== 'catalog') return undefined;
   if (!profile.provider || !profile.apiBase || !profile.apiKey || !profile.model) return undefined;
+  if (!profile.modelId || !relayModelIdsMatch(profile.modelId, modelId)) return undefined;
+  const catalogProfile = findRelayModelProfile(modelId);
   return {
     schema: BOT_CATALOG_MODEL_RUNTIME_SCHEMA,
     botId,
-    modelId,
+    modelId: catalogProfile?.id ?? modelId,
     provider: profile.provider,
     apiBase: profile.apiBase,
     apiKey: profile.apiKey,
-    model: profile.model,
-    contextWindowTokens: profile.contextWindowTokens ?? CUSTOM_DEFAULT_CONTEXT_WINDOW_TOKENS,
+    model: catalogProfile?.model ?? profile.model,
+    contextWindowTokens: catalogProfile?.contextWindowTokens
+      ?? profile.contextWindowTokens
+      ?? CUSTOM_DEFAULT_CONTEXT_WINDOW_TOKENS,
     ...(profile.maxTokens ? { maxTokens: profile.maxTokens } : {}),
     ...(profile.temperature !== undefined ? { temperature: profile.temperature } : {}),
     ...(profile.reasoningEffort ? { reasoningEffort: profile.reasoningEffort } : {}),
     ...(profile.openaiApiMode ? { openaiApiMode: profile.openaiApiMode } : {}),
-    ...(profile.capabilities ? { capabilities: profile.capabilities } : {}),
+    ...(catalogProfile
+      ? { capabilities: catalogProfile.capabilities }
+      : profile.capabilities ? { capabilities: profile.capabilities } : {}),
+  };
+}
+
+export function catalogRuntimeMatchesModelId(
+  runtime: Pick<BotCatalogModelRuntime, 'modelId' | 'model'>,
+  modelId: string,
+): boolean {
+  if (!relayModelIdsMatch(runtime.modelId, modelId)) return false;
+  const profile = findRelayModelProfile(modelId);
+  return !profile || relayModelIdsMatch(runtime.model, profile.id);
+}
+
+function normalizeBotModelDefinition(model: BotModelDefinition): BotModelDefinition {
+  if (model.kind !== 'catalog') return model;
+  const modelId = canonicalRelayModelId(model.modelId);
+  return modelId && modelId !== model.modelId ? { ...model, modelId } : model;
+}
+
+function normalizeBotDefinition(definition: BotDefinition): BotDefinition {
+  const model = normalizeBotModelDefinition(definition.model);
+  return model === definition.model ? definition : { ...definition, model };
+}
+
+function normalizeCatalogRuntime(runtime: BotCatalogModelRuntime): BotCatalogModelRuntime {
+  const profile = findRelayModelProfile(runtime.modelId) ?? findRelayModelProfile(runtime.model);
+  if (!profile) return runtime;
+  return {
+    ...runtime,
+    modelId: profile.id,
+    model: profile.model,
+    contextWindowTokens: profile.contextWindowTokens,
+    capabilities: profile.capabilities,
   };
 }
 
 export function botModelDefinitionFromLocalProfile(profile: LocalModelProfile): BotModelDefinition {
   if (profile.source === 'catalog') {
     if (!profile.modelId) throw new Error('catalog modelId is required');
-    return { kind: 'catalog', modelId: profile.modelId };
+    return { kind: 'catalog', modelId: canonicalRelayModelId(profile.modelId) ?? profile.modelId };
   }
   if (!profile.provider || !profile.apiBase || !profile.model || !profile.apiKey || !profile.contextWindowTokens) {
     throw new Error('custom model profile is incomplete');
@@ -277,8 +320,10 @@ export class BotDefinitionSyncService {
   }
 
   pull(botId: string): BotDefinition | undefined {
-    const definition = this.repository.readCanonical(botId);
+    const rawDefinition = this.repository.readCanonical(botId);
+    const definition = rawDefinition && normalizeBotDefinition(rawDefinition);
     if (definition) {
+      if (definition !== rawDefinition) this.repository.writeCanonical(definition);
       this.repository.writeCache(definition);
     }
     return definition;
@@ -288,11 +333,11 @@ export class BotDefinitionSyncService {
     const definition: BotDefinition = {
       schema: BOT_DEFINITION_SCHEMA,
       botId,
-      model,
+      model: normalizeBotModelDefinition(model),
     };
     this.repository.writeCanonical(definition);
     this.repository.writeCache(definition);
-    this.clearLegacyModelConfiguration();
+    this.clearLegacyModelConfigurationWhenReady(definition);
     return {
       botId,
       direction: 'local_to_simulated_cloud',
@@ -301,7 +346,7 @@ export class BotDefinitionSyncService {
   }
 
   storeCatalogRuntime(runtime: BotCatalogModelRuntime): void {
-    this.catalogRuntimeRepository.write(runtime);
+    this.catalogRuntimeRepository.write(normalizeCatalogRuntime(runtime));
   }
 
   readCatalogRuntime(botId: string): BotCatalogModelRuntime | undefined {
@@ -312,9 +357,7 @@ export class BotDefinitionSyncService {
     const existing = this.pull(botId);
     if (existing) {
       this.migrateLegacyCatalogRuntime(existing);
-      // The canonical Definition is already authoritative. Any legacy model
-      // fields left on disk can only be stale pre-Definition input.
-      this.clearLegacyModelConfiguration();
+      this.clearLegacyModelConfigurationWhenReady(existing);
       return {
         botId,
         direction: 'simulated_cloud_to_local',
@@ -325,7 +368,7 @@ export class BotDefinitionSyncService {
     if (!profile) return undefined;
     const definition = this.publish(botId, botModelDefinitionFromLocalProfile(profile)).definition;
     this.bootstrapCatalogRuntimeFromLocalProfile(definition, profile);
-    this.clearLegacyModelConfiguration();
+    this.clearLegacyModelConfigurationWhenReady(definition);
     return {
       botId,
       direction: 'bootstrap_to_simulated_cloud',
@@ -357,7 +400,7 @@ export class BotDefinitionSyncService {
   ): void {
     if (definition.model.kind !== 'catalog') return;
     const existing = this.catalogRuntimeRepository.read(definition.botId);
-    if (existing?.modelId === definition.model.modelId) return;
+    if (existing && catalogRuntimeMatchesModelId(existing, definition.model.modelId)) return;
     const profile = knownProfile;
     const runtime = profile && catalogRuntimeFromLocalProfile(
       definition.botId,
@@ -369,15 +412,28 @@ export class BotDefinitionSyncService {
 
   private migrateLegacyCatalogRuntime(definition: BotDefinition): void {
     if (definition.model.kind !== 'catalog') return;
-    if (this.catalogRuntimeRepository.read(definition.botId)?.modelId === definition.model.modelId) return;
+    const existing = this.catalogRuntimeRepository.read(definition.botId);
+    if (existing && catalogRuntimeMatchesModelId(existing, definition.model.modelId)) return;
     const profile = readLegacyLocalModelProfile(this.runtimeRoot, this.env);
     // A legacy relay key belongs to this catalog model only when both ids
     // agree. Never attach whatever happens to be in .env to a different bot.
-    if (profile?.source !== 'catalog' || profile.modelId !== definition.model.modelId) return;
+    if (profile?.source !== 'catalog' || !relayModelIdsMatch(profile.modelId, definition.model.modelId)) return;
     const runtime = catalogRuntimeFromLocalProfile(definition.botId, definition.model.modelId, profile);
     if (!runtime) return;
-    this.catalogRuntimeRepository.write(runtime);
+    this.storeCatalogRuntime(runtime);
     this.clearLegacyModelConfiguration();
+  }
+
+  /** Clears old model fields only after the selected Definition is runnable. */
+  clearLegacyModelConfigurationWhenReady(definition: BotDefinition): void {
+    if (definition.model.kind === 'custom') {
+      this.clearLegacyModelConfiguration();
+      return;
+    }
+    const runtime = this.catalogRuntimeRepository.read(definition.botId);
+    if (runtime && catalogRuntimeMatchesModelId(runtime, definition.model.modelId)) {
+      this.clearLegacyModelConfiguration();
+    }
   }
 
   /**

--- a/src/bot-definition/service.ts
+++ b/src/bot-definition/service.ts
@@ -1,0 +1,278 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as dotenv from 'dotenv';
+import { createCatsCoLocalConfigService } from '../catscompany/local-config';
+import { normalizeOpenAIApiMode } from '../utils/openai-api-mode';
+import { normalizeReasoningEffort } from '../utils/reasoning-effort';
+import {
+  BOT_CATALOG_MODEL_RUNTIME_SCHEMA,
+  BOT_DEFINITION_SCHEMA,
+  type BotCatalogModelRuntime,
+  type BotDefinition,
+  type BotDefinitionSyncResult,
+  type BotModelDefinition,
+  type LocalModelProfile,
+} from './types';
+import {
+  FileBotCatalogModelRuntimeRepository,
+  FileBotDefinitionRepository,
+  type BotCatalogModelRuntimeRepository,
+  type BotDefinitionRepository,
+  type FileBotDefinitionRepositoryOptions,
+} from './repository';
+
+const CUSTOM_DEFAULT_CONTEXT_WINDOW_TOKENS = 200_000;
+
+function firstNonEmpty(...values: Array<string | undefined>): string | undefined {
+  for (const value of values) {
+    const text = String(value || '').trim();
+    if (text) return text;
+  }
+  return undefined;
+}
+
+function parsePositiveInteger(value: string | undefined): number | undefined {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : undefined;
+}
+
+function readRuntimeEnv(runtimeRoot: string, env: NodeJS.ProcessEnv): Record<string, string | undefined> {
+  const envPath = path.join(runtimeRoot, '.env');
+  const fileEnv = fs.existsSync(envPath) ? dotenv.parse(fs.readFileSync(envPath, 'utf-8')) : {};
+  return { ...fileEnv, ...env };
+}
+
+function isRelayProfile(profile: Record<string, string | undefined>): boolean {
+  if (profile.CATSCO_MODEL_SOURCE === 'relay') return true;
+  if (profile.CATSCO_MODEL_SOURCE === 'custom') return false;
+  const apiBase = firstNonEmpty(profile.CATSCO_RELAY_LLM_API_BASE, profile.GAUZ_LLM_API_BASE) || '';
+  return apiBase.toLowerCase().includes('relay.catsco.cc');
+}
+
+export function readLocalModelProfile(
+  runtimeRoot: string,
+  env: NodeJS.ProcessEnv = process.env,
+): LocalModelProfile | undefined {
+  const values = readRuntimeEnv(runtimeRoot, env);
+  const relay = isRelayProfile(values);
+  const prefix = relay ? 'CATSCO_RELAY_LLM_' : 'CATSCO_CUSTOM_LLM_';
+  const provider = firstNonEmpty(values[`${prefix}PROVIDER`], values.GAUZ_LLM_PROVIDER);
+  const apiBase = firstNonEmpty(values[`${prefix}API_BASE`], values.GAUZ_LLM_API_BASE);
+  const model = firstNonEmpty(values[`${prefix}MODEL`], values.GAUZ_LLM_MODEL);
+  const apiKey = firstNonEmpty(values[`${prefix}API_KEY`], values.GAUZ_LLM_API_KEY);
+  const contextWindowTokens = parsePositiveInteger(firstNonEmpty(
+    values[`${prefix}CONTEXT_WINDOW_TOKENS`],
+    values.GAUZ_LLM_CONTEXT_WINDOW_TOKENS,
+    values.GAUZ_LLM_CONTEXT_TOKENS,
+  ));
+  const reasoningEffort = normalizeReasoningEffort(firstNonEmpty(
+    values[`${prefix}REASONING_EFFORT`],
+    values.GAUZ_LLM_REASONING_EFFORT,
+  ));
+  const openaiApiMode = normalizeOpenAIApiMode(firstNonEmpty(
+    values[`${prefix}OPENAI_API_MODE`],
+    values.GAUZ_LLM_OPENAI_API_MODE,
+  ));
+
+  if (relay) {
+    return model ? {
+      source: 'catalog',
+      modelId: model,
+      provider: provider === 'anthropic' || provider === 'openai' ? provider : undefined,
+      apiBase,
+      model,
+      apiKey,
+      contextWindowTokens,
+      reasoningEffort,
+      openaiApiMode,
+    } : undefined;
+  }
+  if (!provider || !apiBase || !model || !apiKey) return undefined;
+  if (provider !== 'anthropic' && provider !== 'openai') return undefined;
+  return {
+    source: 'custom',
+    provider,
+    apiBase,
+    model,
+    apiKey,
+    contextWindowTokens: contextWindowTokens ?? CUSTOM_DEFAULT_CONTEXT_WINDOW_TOKENS,
+    reasoningEffort,
+    openaiApiMode: openaiApiMode ?? 'chat_completions',
+  };
+}
+
+/**
+ * The catalog definition identifies a model; this separately captures the
+ * device-local relay material needed to call it. It is intentionally never
+ * written into BotDefinition.
+ */
+export function catalogRuntimeFromLocalProfile(
+  botId: string,
+  modelId: string,
+  profile: LocalModelProfile,
+): BotCatalogModelRuntime | undefined {
+  if (profile.source !== 'catalog') return undefined;
+  if (!profile.provider || !profile.apiBase || !profile.apiKey || !profile.model) return undefined;
+  return {
+    schema: BOT_CATALOG_MODEL_RUNTIME_SCHEMA,
+    botId,
+    modelId,
+    provider: profile.provider,
+    apiBase: profile.apiBase,
+    apiKey: profile.apiKey,
+    model: profile.model,
+    contextWindowTokens: profile.contextWindowTokens ?? CUSTOM_DEFAULT_CONTEXT_WINDOW_TOKENS,
+    ...(profile.reasoningEffort ? { reasoningEffort: profile.reasoningEffort } : {}),
+    ...(profile.openaiApiMode ? { openaiApiMode: profile.openaiApiMode } : {}),
+  };
+}
+
+export function botModelDefinitionFromLocalProfile(profile: LocalModelProfile): BotModelDefinition {
+  if (profile.source === 'catalog') {
+    if (!profile.modelId) throw new Error('catalog modelId is required');
+    return { kind: 'catalog', modelId: profile.modelId };
+  }
+  if (!profile.provider || !profile.apiBase || !profile.model || !profile.apiKey || !profile.contextWindowTokens) {
+    throw new Error('custom model profile is incomplete');
+  }
+  return {
+    kind: 'custom',
+    protocol: profile.provider === 'anthropic'
+      ? 'anthropic'
+      : profile.openaiApiMode === 'responses'
+        ? 'openai-responses'
+        : 'openai-chat-completions',
+    apiBase: profile.apiBase,
+    model: profile.model,
+    apiKey: profile.apiKey,
+    contextWindowTokens: profile.contextWindowTokens,
+    ...(profile.reasoningEffort ? { reasoningEffort: profile.reasoningEffort } : {}),
+  };
+}
+
+export interface BotDefinitionSyncServiceOptions extends FileBotDefinitionRepositoryOptions {
+  repository?: BotDefinitionRepository;
+  catalogRuntimeRepository?: BotCatalogModelRuntimeRepository;
+  env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * This service owns direction only. The file repository is a local stand-in
+ * for the future CatsCompany BotDefinition API and can be swapped unchanged.
+ */
+export class BotDefinitionSyncService {
+  private readonly runtimeRoot: string;
+  private readonly env: NodeJS.ProcessEnv;
+  private readonly repository: BotDefinitionRepository;
+  private readonly catalogRuntimeRepository: BotCatalogModelRuntimeRepository;
+
+  constructor(options: BotDefinitionSyncServiceOptions = {}) {
+    this.runtimeRoot = path.resolve(options.runtimeRoot ?? process.cwd());
+    this.env = options.env ?? process.env;
+    this.repository = options.repository ?? new FileBotDefinitionRepository(options);
+    this.catalogRuntimeRepository = options.catalogRuntimeRepository
+      ?? new FileBotCatalogModelRuntimeRepository({ runtimeRoot: this.runtimeRoot });
+  }
+
+  pull(botId: string): BotDefinition | undefined {
+    const definition = this.repository.readCanonical(botId);
+    if (definition) {
+      this.repository.writeCache(definition);
+      this.bootstrapCatalogRuntimeFromLocalProfile(definition);
+    }
+    return definition;
+  }
+
+  publish(botId: string, model: BotModelDefinition): BotDefinitionSyncResult {
+    const definition: BotDefinition = {
+      schema: BOT_DEFINITION_SCHEMA,
+      botId,
+      model,
+    };
+    this.repository.writeCanonical(definition);
+    this.repository.writeCache(definition);
+    return {
+      botId,
+      direction: 'local_to_simulated_cloud',
+      definition,
+    };
+  }
+
+  storeCatalogRuntime(runtime: BotCatalogModelRuntime): void {
+    this.catalogRuntimeRepository.write(runtime);
+  }
+
+  readCatalogRuntime(botId: string): BotCatalogModelRuntime | undefined {
+    return this.catalogRuntimeRepository.read(botId);
+  }
+
+  pullOrBootstrap(botId: string): BotDefinitionSyncResult | undefined {
+    const existing = this.pull(botId);
+    if (existing) {
+      return {
+        botId,
+        direction: 'simulated_cloud_to_local',
+        definition: existing,
+      };
+    }
+    const profile = readLocalModelProfile(this.runtimeRoot, this.env);
+    if (!profile) return undefined;
+    const definition = this.publish(botId, botModelDefinitionFromLocalProfile(profile)).definition;
+    this.bootstrapCatalogRuntimeFromLocalProfile(definition, profile);
+    return {
+      botId,
+      direction: 'bootstrap_to_simulated_cloud',
+      definition,
+    };
+  }
+
+  publishCurrentBoundBot(): BotDefinitionSyncResult | undefined {
+    const localConfig = createCatsCoLocalConfigService({ runtimeRoot: this.runtimeRoot, env: this.env }).load();
+    const botId = String(localConfig.currentBot?.uid || '').trim();
+    if (!botId) return undefined;
+    const profile = readLocalModelProfile(this.runtimeRoot, this.env);
+    if (!profile) return undefined;
+    const result = this.publish(botId, botModelDefinitionFromLocalProfile(profile));
+    this.bootstrapCatalogRuntimeFromLocalProfile(result.definition, profile);
+    return result;
+  }
+
+  pullOrBootstrapCurrentBoundBot(): BotDefinitionSyncResult | undefined {
+    const localConfig = createCatsCoLocalConfigService({ runtimeRoot: this.runtimeRoot, env: this.env }).load();
+    const botId = String(localConfig.currentBot?.uid || '').trim();
+    return botId ? this.pullOrBootstrap(botId) : undefined;
+  }
+
+  private bootstrapCatalogRuntimeFromLocalProfile(
+    definition: BotDefinition,
+    knownProfile?: LocalModelProfile,
+  ): void {
+    if (definition.model.kind !== 'catalog') return;
+    const existing = this.catalogRuntimeRepository.read(definition.botId);
+    if (existing?.modelId === definition.model.modelId) return;
+    const profile = knownProfile ?? readLocalModelProfile(this.runtimeRoot, this.env);
+    const runtime = profile && catalogRuntimeFromLocalProfile(
+      definition.botId,
+      definition.model.modelId,
+      profile,
+    );
+    if (runtime) this.catalogRuntimeRepository.write(runtime);
+  }
+}
+
+export function createBotDefinitionSyncService(
+  options: BotDefinitionSyncServiceOptions = {},
+): BotDefinitionSyncService {
+  return new BotDefinitionSyncService(options);
+}
+
+/** Returns the active bot's cache without reading or overwriting the canonical side. */
+export function readCachedDefinitionForCurrentBot(
+  runtimeRoot: string,
+  env: NodeJS.ProcessEnv = process.env,
+): BotDefinition | undefined {
+  const localConfig = createCatsCoLocalConfigService({ runtimeRoot, env }).load();
+  const botId = String(localConfig.currentBot?.uid || '').trim();
+  if (!botId) return undefined;
+  return new FileBotDefinitionRepository({ runtimeRoot }).readCache(botId);
+}

--- a/src/bot-definition/service.ts
+++ b/src/bot-definition/service.ts
@@ -350,7 +350,13 @@ export class BotDefinitionSyncService {
   }
 
   readCatalogRuntime(botId: string): BotCatalogModelRuntime | undefined {
-    return this.catalogRuntimeRepository.read(botId);
+    const runtime = this.catalogRuntimeRepository.read(botId);
+    if (!runtime) return undefined;
+    const normalized = normalizeCatalogRuntime(runtime);
+    if (JSON.stringify(normalized) !== JSON.stringify(runtime)) {
+      this.catalogRuntimeRepository.write(normalized);
+    }
+    return normalized;
   }
 
   pullOrBootstrap(botId: string): BotDefinitionSyncResult | undefined {
@@ -399,7 +405,7 @@ export class BotDefinitionSyncService {
     knownProfile?: LocalModelProfile,
   ): void {
     if (definition.model.kind !== 'catalog') return;
-    const existing = this.catalogRuntimeRepository.read(definition.botId);
+    const existing = this.readCatalogRuntime(definition.botId);
     if (existing && catalogRuntimeMatchesModelId(existing, definition.model.modelId)) return;
     const profile = knownProfile;
     const runtime = profile && catalogRuntimeFromLocalProfile(
@@ -412,7 +418,7 @@ export class BotDefinitionSyncService {
 
   private migrateLegacyCatalogRuntime(definition: BotDefinition): void {
     if (definition.model.kind !== 'catalog') return;
-    const existing = this.catalogRuntimeRepository.read(definition.botId);
+    const existing = this.readCatalogRuntime(definition.botId);
     if (existing && catalogRuntimeMatchesModelId(existing, definition.model.modelId)) return;
     const profile = readLegacyLocalModelProfile(this.runtimeRoot, this.env);
     // A legacy relay key belongs to this catalog model only when both ids
@@ -430,7 +436,7 @@ export class BotDefinitionSyncService {
       this.clearLegacyModelConfiguration();
       return;
     }
-    const runtime = this.catalogRuntimeRepository.read(definition.botId);
+    const runtime = this.readCatalogRuntime(definition.botId);
     if (runtime && catalogRuntimeMatchesModelId(runtime, definition.model.modelId)) {
       this.clearLegacyModelConfiguration();
     }

--- a/src/bot-definition/types.ts
+++ b/src/bot-definition/types.ts
@@ -23,6 +23,8 @@ export interface CustomBotModelDefinition {
   model: string;
   apiKey: string;
   contextWindowTokens: number;
+  maxTokens?: number;
+  temperature?: number;
   reasoningEffort?: ReasoningEffort;
 }
 
@@ -46,8 +48,15 @@ export interface LocalModelProfile {
   model?: string;
   apiKey?: string;
   contextWindowTokens?: number;
+  maxTokens?: number;
+  temperature?: number;
   reasoningEffort?: ReasoningEffort;
   openaiApiMode?: OpenAIApiMode;
+  capabilities?: {
+    vision?: boolean;
+    toolCalling?: boolean;
+    streaming?: boolean;
+  };
 }
 
 /**
@@ -65,8 +74,15 @@ export interface BotCatalogModelRuntime {
   apiKey: string;
   model: string;
   contextWindowTokens: number;
+  maxTokens?: number;
+  temperature?: number;
   reasoningEffort?: ReasoningEffort;
   openaiApiMode?: OpenAIApiMode;
+  capabilities?: {
+    vision?: boolean;
+    toolCalling?: boolean;
+    streaming?: boolean;
+  };
 }
 
 export interface BotDefinitionSyncResult {

--- a/src/bot-definition/types.ts
+++ b/src/bot-definition/types.ts
@@ -1,0 +1,76 @@
+import type { OpenAIApiMode, ReasoningEffort } from '../types';
+
+export const BOT_DEFINITION_SCHEMA = 'xiaoba.bot-definition.v1';
+export const BOT_CATALOG_MODEL_RUNTIME_SCHEMA = 'xiaoba.bot-catalog-model-runtime.v1';
+
+/**
+ * A catalog model is identified by the CatsCo model catalog. Its endpoint and
+ * relay credential are materialized when the bot is activated on a device.
+ */
+export interface CatalogBotModelDefinition {
+  kind: 'catalog';
+  modelId: string;
+}
+
+/**
+ * A custom model has no shared catalog entry, so its complete runtime profile
+ * is part of the bot definition.
+ */
+export interface CustomBotModelDefinition {
+  kind: 'custom';
+  protocol: 'anthropic' | 'openai-chat-completions' | 'openai-responses';
+  apiBase: string;
+  model: string;
+  apiKey: string;
+  contextWindowTokens: number;
+  reasoningEffort?: ReasoningEffort;
+}
+
+export type BotModelDefinition = CatalogBotModelDefinition | CustomBotModelDefinition;
+
+/**
+ * The deliberately small, portable part of a bot. Prompt and skill fields are
+ * intentionally deferred until their source/version contracts are settled.
+ */
+export interface BotDefinition {
+  schema: typeof BOT_DEFINITION_SCHEMA;
+  botId: string;
+  model: BotModelDefinition;
+}
+
+export interface LocalModelProfile {
+  source: 'catalog' | 'custom';
+  modelId?: string;
+  provider?: 'anthropic' | 'openai';
+  apiBase?: string;
+  model?: string;
+  apiKey?: string;
+  contextWindowTokens?: number;
+  reasoningEffort?: ReasoningEffort;
+  openaiApiMode?: OpenAIApiMode;
+}
+
+/**
+ * Device-local runtime material for a catalog model. It is deliberately kept
+ * separate from BotDefinition: the portable definition contains only the
+ * catalog model id, while this record contains the current device's relay
+ * endpoint and credential.
+ */
+export interface BotCatalogModelRuntime {
+  schema: typeof BOT_CATALOG_MODEL_RUNTIME_SCHEMA;
+  botId: string;
+  modelId: string;
+  provider: 'anthropic' | 'openai';
+  apiBase: string;
+  apiKey: string;
+  model: string;
+  contextWindowTokens: number;
+  reasoningEffort?: ReasoningEffort;
+  openaiApiMode?: OpenAIApiMode;
+}
+
+export interface BotDefinitionSyncResult {
+  botId: string;
+  direction: 'local_to_simulated_cloud' | 'simulated_cloud_to_local' | 'bootstrap_to_simulated_cloud';
+  definition: BotDefinition;
+}

--- a/src/catscompany/relay-model-bootstrap.ts
+++ b/src/catscompany/relay-model-bootstrap.ts
@@ -1,0 +1,156 @@
+import type { CatsCoAuthSnapshot } from './local-config';
+import {
+  findRelayModelProfile,
+  relayModelProviderBaseUrl,
+  type RelayModelProvider,
+} from '../utils/relay-model-profiles';
+import type { BotCatalogModelRuntime } from '../bot-definition/types';
+
+const REQUEST_TIMEOUT_MS = 10_000;
+
+export interface CatsRelayBootstrapOptions {
+  botId: string;
+  modelId: string;
+  auth: CatsCoAuthSnapshot;
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Obtains the device-local material needed to run a catalog model. The caller
+ * owns the Definition write, so a failed request never creates a half-ready
+ * bot Definition.
+ */
+export async function provisionCatsRelayCatalogRuntime(
+  options: CatsRelayBootstrapOptions,
+): Promise<BotCatalogModelRuntime> {
+  const botId = String(options.botId || '').trim();
+  const modelId = String(options.modelId || '').trim();
+  const token = String(options.auth.token || '').trim();
+  const httpBaseUrl = String(options.auth.httpBaseUrl || '').trim().replace(/\/+$/, '');
+  const profile = findRelayModelProfile(modelId);
+  if (!botId) throw new Error('Cannot initialize a catalog model without botId.');
+  if (!profile) throw new Error(`Unknown CatsCo relay model: ${modelId}`);
+  if (!token || !httpBaseUrl) {
+    throw new Error('CatsCo account login is required before the default model can be initialized.');
+  }
+
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const relayConfig = await catsRequest(fetchImpl, httpBaseUrl, token, 'GET', '/api/relay/config');
+  if (relayConfig?.self_service_enabled === false) {
+    throw new Error('CatsCo relay self-service is unavailable, so the default model cannot be initialized.');
+  }
+  ensureRequestedModelIsAvailable(relayConfig, profile.id, profile.model);
+
+  const apiKey = await ensurePlainRelayKey(fetchImpl, httpBaseUrl, token, options.auth);
+  return {
+    schema: 'xiaoba.bot-catalog-model-runtime.v1',
+    botId,
+    modelId: profile.id,
+    provider: profile.preferredProvider,
+    apiBase: relayEndpointForProvider(relayConfig, profile.preferredProvider),
+    apiKey,
+    model: profile.model,
+    contextWindowTokens: profile.contextWindowTokens,
+    reasoningEffort: 'high',
+    openaiApiMode: 'chat_completions',
+    capabilities: {
+      vision: profile.capabilities.vision,
+      toolCalling: profile.capabilities.toolCalling,
+      streaming: profile.capabilities.streaming,
+    },
+  };
+}
+
+async function ensurePlainRelayKey(
+  fetchImpl: typeof fetch,
+  httpBaseUrl: string,
+  token: string,
+  auth: CatsCoAuthSnapshot,
+): Promise<string> {
+  const current = await catsRequest(fetchImpl, httpBaseUrl, token, 'GET', '/api/relay/key');
+  const key = current?.key;
+  const active = key && String(key.state || 'active') === 'active';
+  const plain = String(key?.key || '').trim();
+  if (active && plain) return plain;
+
+  if (active) {
+    const revealed = await catsRequest(fetchImpl, httpBaseUrl, token, 'POST', '/api/relay/key/reveal', {});
+    const revealedPlain = String(revealed?.key?.key || '').trim();
+    if (revealedPlain) return revealedPlain;
+    throw new Error('CatsCo relay key exists but its plaintext could not be retrieved on this device.');
+  }
+
+  const created = await catsRequest(fetchImpl, httpBaseUrl, token, 'POST', '/api/relay/key', {
+    name: auth.displayName || auth.username || (auth.uid ? `CatsCo user ${auth.uid}` : 'CatsCo desktop'),
+  });
+  const createdPlain = String(created?.key?.key || '').trim();
+  if (!createdPlain) {
+    throw new Error('CatsCo relay key was created without a plaintext value.');
+  }
+  return createdPlain;
+}
+
+function ensureRequestedModelIsAvailable(config: any, modelId: string, model: string): void {
+  if (!Array.isArray(config?.models)) return;
+  const requested = modelId.toLowerCase();
+  const requestedModel = model.toLowerCase();
+  const available = config.models.some((item: any) => (
+    item?.enabled !== false
+    && [String(item?.id || '').toLowerCase(), String(item?.model || '').toLowerCase()]
+      .some(value => value === requested || value === requestedModel)
+  ));
+  if (!available) {
+    throw new Error(`CatsCo relay does not currently provide the default model ${modelId}.`);
+  }
+}
+
+function relayEndpointForProvider(config: any, provider: RelayModelProvider): string {
+  const endpoints = Array.isArray(config?.endpoints) ? config.endpoints : [];
+  const endpoint = endpoints.find((item: any) => {
+    const protocol = String(item?.protocol || '').toLowerCase();
+    return provider === 'openai' ? protocol.includes('openai') : protocol.includes('anthropic');
+  });
+  const baseUrl = String(config?.base_url || 'https://relay.catsco.cc').trim().replace(/\/+$/, '');
+  const fallback = baseUrl === 'https://relay.catsco.cc'
+    ? relayModelProviderBaseUrl(provider)
+    : provider === 'openai' ? `${baseUrl}/v1` : `${baseUrl}/anthropic`;
+  return String(endpoint?.base_url || fallback).trim().replace(/\/+$/, '');
+}
+
+async function catsRequest(
+  fetchImpl: typeof fetch,
+  httpBaseUrl: string,
+  token: string,
+  method: string,
+  apiPath: string,
+  body?: unknown,
+): Promise<any> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetchImpl(`${httpBaseUrl}${apiPath}`, {
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: body === undefined ? undefined : JSON.stringify(body),
+      signal: controller.signal,
+    });
+    const text = await response.text();
+    let data: any = {};
+    if (text) {
+      try {
+        data = JSON.parse(text);
+      } catch {
+        data = { raw: text };
+      }
+    }
+    if (!response.ok) {
+      throw new Error(String(data?.error || data?.message || `CatsCo relay request failed: ${response.status}`));
+    }
+    return data;
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/src/commands/catscompany.ts
+++ b/src/commands/catscompany.ts
@@ -6,11 +6,8 @@ import { startRuntimeCommandSupport, stopRuntimeCommandSupport } from '../utils/
 import { ChatConfig } from '../types';
 import { resolveCatsCoRuntimeConfig } from '../catscompany/runtime-config';
 import { CatsCoConnectorLock, acquireCatsCoConnectorLock, isProcessAlive } from '../catscompany/connector-lock';
-import { createBotDefinitionSyncService } from '../bot-definition/service';
 import { PathResolver } from '../utils/path-resolver';
-import { createCatsCoLocalConfigService } from '../catscompany/local-config';
-import { provisionCatsRelayCatalogRuntime } from '../catscompany/relay-model-bootstrap';
-import { DEFAULT_CATSCO_RELAY_MODEL_ID } from '../utils/relay-model-profiles';
+import { prepareBoundBotDefinition } from '../bot-definition/activation';
 
 const CONNECTOR_OWNER_POLL_MS = 2000;
 
@@ -18,7 +15,6 @@ export interface CatsCoCommandConfigResolution {
   config?: CatsCompanyConfig;
   missing: Array<'serverUrl' | 'apiKey' | 'bodyId'>;
 }
-
 export function resolveCatsCoCommandConfig(
   config: ChatConfig,
   env: NodeJS.ProcessEnv = process.env,
@@ -36,7 +32,12 @@ export function resolveCatsCoCommandConfig(
  */
 export async function catscompanyCommand(): Promise<void> {
   const runtimeRoot = PathResolver.getRuntimeDataRoot();
-  await ensureBoundBotModelDefinition(runtimeRoot);
+  const preparedBot = await prepareBoundBotDefinition({ runtimeRoot });
+  if (preparedBot?.initializedDefault) {
+    Logger.info(`CatsCo bot ${preparedBot.botId} 已自动初始化默认模型 MiniMax M3。`);
+  } else if (preparedBot?.materializedCatalogRuntime) {
+    Logger.info(`CatsCo bot ${preparedBot.botId} 已在当前设备准备 ${preparedBot.definition.model.kind === 'catalog' ? preparedBot.definition.model.modelId : '模型'} 的运行材料。`);
+  }
   const config = ConfigManager.getConfig();
   const resolved = resolveCatsCoCommandConfig(config);
 
@@ -121,48 +122,4 @@ export async function catscompanyCommand(): Promise<void> {
     lock = null;
     throw error;
   }
-}
-
-/**
- * Connector startup is also the device-switch boundary. It first pulls the
- * selected Definition and materializes its catalog runtime locally. A bot
- * with no Definition or legacy model is initialized to the product default,
- * MiniMax M3, only after its relay material is ready.
- */
-async function ensureBoundBotModelDefinition(runtimeRoot: string): Promise<void> {
-  const localConfig = createCatsCoLocalConfigService({ runtimeRoot }).load();
-  const botId = String(localConfig.currentBot?.uid || '').trim();
-  if (!botId) return;
-
-  const definitionService = createBotDefinitionSyncService({ runtimeRoot });
-  let result = definitionService.pullOrBootstrap(botId);
-  let definition = result?.definition;
-  const auth = createCatsCoLocalConfigService({ runtimeRoot }).getAuthState();
-
-  if (!definition) {
-    const runtime = await provisionCatsRelayCatalogRuntime({
-      botId,
-      modelId: DEFAULT_CATSCO_RELAY_MODEL_ID,
-      auth,
-    });
-    definitionService.storeCatalogRuntime(runtime);
-    result = definitionService.publish(botId, {
-      kind: 'catalog',
-      modelId: DEFAULT_CATSCO_RELAY_MODEL_ID,
-    });
-    definition = result.definition;
-    Logger.info(`CatsCo bot ${botId} 已自动初始化默认模型 MiniMax M3。`);
-  }
-
-  if (definition.model.kind !== 'catalog') return;
-  const runtime = definitionService.readCatalogRuntime(botId);
-  if (runtime?.modelId === definition.model.modelId) return;
-
-  const materialized = await provisionCatsRelayCatalogRuntime({
-    botId,
-    modelId: definition.model.modelId,
-    auth,
-  });
-  definitionService.storeCatalogRuntime(materialized);
-  Logger.info(`CatsCo bot ${botId} 已在当前设备准备 ${definition.model.modelId} 的运行材料。`);
 }

--- a/src/commands/catscompany.ts
+++ b/src/commands/catscompany.ts
@@ -6,6 +6,8 @@ import { startRuntimeCommandSupport, stopRuntimeCommandSupport } from '../utils/
 import { ChatConfig } from '../types';
 import { resolveCatsCoRuntimeConfig } from '../catscompany/runtime-config';
 import { CatsCoConnectorLock, acquireCatsCoConnectorLock, isProcessAlive } from '../catscompany/connector-lock';
+import { createBotDefinitionSyncService } from '../bot-definition/service';
+import { PathResolver } from '../utils/path-resolver';
 
 const CONNECTOR_OWNER_POLL_MS = 2000;
 
@@ -18,7 +20,7 @@ export function resolveCatsCoCommandConfig(
   config: ChatConfig,
   env: NodeJS.ProcessEnv = process.env,
 ): CatsCoCommandConfigResolution {
-  const resolved = resolveCatsCoRuntimeConfig({ runtimeRoot: process.cwd(), env, config });
+  const resolved = resolveCatsCoRuntimeConfig({ runtimeRoot: PathResolver.getRuntimeDataRoot(), env, config });
   return {
     missing: resolved.missing,
     config: resolved.connector,
@@ -30,6 +32,12 @@ export function resolveCatsCoCommandConfig(
  * 启动 CatsCompany WebSocket connector
  */
 export async function catscompanyCommand(): Promise<void> {
+  const runtimeRoot = PathResolver.getRuntimeDataRoot();
+  // Normal connector startup also performs the cloud-to-local definition pull.
+  // The current file repository will be replaced by a CatsCompany API adapter
+  // later without changing this startup boundary.
+  createBotDefinitionSyncService({ runtimeRoot })
+    .pullOrBootstrapCurrentBoundBot();
   const config = ConfigManager.getConfig();
   const resolved = resolveCatsCoCommandConfig(config);
 
@@ -51,7 +59,7 @@ export async function catscompanyCommand(): Promise<void> {
     ? configuredOwnerPid
     : undefined;
   const connectorLock = acquireCatsCoConnectorLock({
-    runtimeRoot: process.cwd(),
+    runtimeRoot,
     bodyId,
     command: process.argv.join(' '),
     ownerPid,

--- a/src/commands/catscompany.ts
+++ b/src/commands/catscompany.ts
@@ -8,6 +8,9 @@ import { resolveCatsCoRuntimeConfig } from '../catscompany/runtime-config';
 import { CatsCoConnectorLock, acquireCatsCoConnectorLock, isProcessAlive } from '../catscompany/connector-lock';
 import { createBotDefinitionSyncService } from '../bot-definition/service';
 import { PathResolver } from '../utils/path-resolver';
+import { createCatsCoLocalConfigService } from '../catscompany/local-config';
+import { provisionCatsRelayCatalogRuntime } from '../catscompany/relay-model-bootstrap';
+import { DEFAULT_CATSCO_RELAY_MODEL_ID } from '../utils/relay-model-profiles';
 
 const CONNECTOR_OWNER_POLL_MS = 2000;
 
@@ -33,11 +36,7 @@ export function resolveCatsCoCommandConfig(
  */
 export async function catscompanyCommand(): Promise<void> {
   const runtimeRoot = PathResolver.getRuntimeDataRoot();
-  // Normal connector startup also performs the cloud-to-local definition pull.
-  // The current file repository will be replaced by a CatsCompany API adapter
-  // later without changing this startup boundary.
-  createBotDefinitionSyncService({ runtimeRoot })
-    .pullOrBootstrapCurrentBoundBot();
+  await ensureBoundBotModelDefinition(runtimeRoot);
   const config = ConfigManager.getConfig();
   const resolved = resolveCatsCoCommandConfig(config);
 
@@ -122,4 +121,48 @@ export async function catscompanyCommand(): Promise<void> {
     lock = null;
     throw error;
   }
+}
+
+/**
+ * Connector startup is also the device-switch boundary. It first pulls the
+ * selected Definition and materializes its catalog runtime locally. A bot
+ * with no Definition or legacy model is initialized to the product default,
+ * MiniMax M3, only after its relay material is ready.
+ */
+async function ensureBoundBotModelDefinition(runtimeRoot: string): Promise<void> {
+  const localConfig = createCatsCoLocalConfigService({ runtimeRoot }).load();
+  const botId = String(localConfig.currentBot?.uid || '').trim();
+  if (!botId) return;
+
+  const definitionService = createBotDefinitionSyncService({ runtimeRoot });
+  let result = definitionService.pullOrBootstrap(botId);
+  let definition = result?.definition;
+  const auth = createCatsCoLocalConfigService({ runtimeRoot }).getAuthState();
+
+  if (!definition) {
+    const runtime = await provisionCatsRelayCatalogRuntime({
+      botId,
+      modelId: DEFAULT_CATSCO_RELAY_MODEL_ID,
+      auth,
+    });
+    definitionService.storeCatalogRuntime(runtime);
+    result = definitionService.publish(botId, {
+      kind: 'catalog',
+      modelId: DEFAULT_CATSCO_RELAY_MODEL_ID,
+    });
+    definition = result.definition;
+    Logger.info(`CatsCo bot ${botId} 已自动初始化默认模型 MiniMax M3。`);
+  }
+
+  if (definition.model.kind !== 'catalog') return;
+  const runtime = definitionService.readCatalogRuntime(botId);
+  if (runtime?.modelId === definition.model.modelId) return;
+
+  const materialized = await provisionCatsRelayCatalogRuntime({
+    botId,
+    modelId: definition.model.modelId,
+    auth,
+  });
+  definitionService.storeCatalogRuntime(materialized);
+  Logger.info(`CatsCo bot ${botId} 已在当前设备准备 ${definition.model.modelId} 的运行材料。`);
 }

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,6 +1,9 @@
 import inquirer from 'inquirer';
 import { Logger } from '../utils/logger';
 import { ConfigManager } from '../utils/config';
+import { createCatsCoLocalConfigService } from '../catscompany/local-config';
+import { createBotDefinitionSyncService } from '../bot-definition/service';
+import { PathResolver } from '../utils/path-resolver';
 import { styles } from '../theme/colors';
 
 export async function configCommand(): Promise<void> {
@@ -46,6 +49,25 @@ export async function configCommand(): Promise<void> {
     temperature: answers.temperature,
   };
 
-  ConfigManager.saveConfig(finalConfig);
+  const runtimeRoot = PathResolver.getRuntimeDataRoot();
+  const botId = String(createCatsCoLocalConfigService({ runtimeRoot }).load().currentBot?.uid || '').trim();
+  if (botId) {
+    const provider = currentConfig.provider === 'anthropic' ? 'anthropic' : 'openai';
+    createBotDefinitionSyncService({ runtimeRoot }).publish(botId, {
+      kind: 'custom',
+      protocol: provider === 'anthropic'
+        ? 'anthropic'
+        : currentConfig.openaiApiMode === 'responses' ? 'openai-responses' : 'openai-chat-completions',
+      apiBase: finalConfig.apiUrl,
+      model: finalConfig.model,
+      apiKey: finalConfig.apiKey,
+      contextWindowTokens: currentConfig.contextWindowTokens ?? 200_000,
+      ...(currentConfig.maxTokens ? { maxTokens: currentConfig.maxTokens } : {}),
+      ...(typeof finalConfig.temperature === 'number' ? { temperature: finalConfig.temperature } : {}),
+      ...(currentConfig.reasoningEffort ? { reasoningEffort: currentConfig.reasoningEffort } : {}),
+    });
+  } else {
+    ConfigManager.saveConfig(finalConfig);
+  }
   Logger.success('配置已保存！');
 }

--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -1751,16 +1751,11 @@ export class ConversationRunner {
   }
 
   private resolvePromptBudget(maxContextTokens?: number): number {
-    const envBudget = Number(process.env.GAUZ_LLM_MAX_PROMPT_TOKENS);
-    if (Number.isFinite(envBudget) && envBudget > 0) {
-      return envBudget;
-    }
-
     if (maxContextTokens && maxContextTokens > 0) {
       return maxContextTokens;
     }
 
-    return resolveModelPromptBudgetTokens(this.resolveModelConfig(), process.env);
+    return resolveModelPromptBudgetTokens(this.resolveModelConfig());
   }
 
   private resolveModelConfig(): Pick<ChatConfig, 'apiUrl' | 'model' | 'provider' | 'maxTokens' | 'contextWindowTokens'> {
@@ -1771,15 +1766,7 @@ export class ConversationRunner {
       return serviceConfig;
     }
 
-    return {
-      provider: process.env.GAUZ_LLM_PROVIDER === 'anthropic' || process.env.GAUZ_LLM_PROVIDER === 'openai'
-        ? process.env.GAUZ_LLM_PROVIDER
-        : undefined,
-      apiUrl: process.env.GAUZ_LLM_API_BASE,
-      model: process.env.GAUZ_LLM_MODEL,
-      maxTokens: Number(process.env.GAUZ_LLM_MAX_OUTPUT_TOKENS || process.env.GAUZ_LLM_MAX_TOKENS) || undefined,
-      contextWindowTokens: Number(process.env.GAUZ_LLM_CONTEXT_WINDOW_TOKENS || process.env.GAUZ_LLM_CONTEXT_TOKENS) || undefined,
-    };
+    return {};
   }
 
   private isPromptTooLongError(error: any): boolean {

--- a/src/dashboard/readiness.ts
+++ b/src/dashboard/readiness.ts
@@ -9,6 +9,7 @@ import { ServiceInfo, ServiceManager } from './service-manager';
 import { readDashboardEnvFile } from './settings';
 import { resolveCatsCoRuntimeConfig } from '../catscompany/runtime-config';
 import { getWeixinChannelStatus } from './weixin-channel-binding';
+import { resolveActiveBotLLMConfig } from '../bot-definition/llm-config-resolver';
 
 export type DashboardReadinessStatus = 'ready' | 'warning' | 'blocked';
 export type DashboardReadinessCheckStatus = 'pass' | 'warning' | 'fail';
@@ -79,15 +80,16 @@ export async function getDashboardReadiness(
   const runtimeRoot = path.resolve(options.runtimeRoot ?? process.cwd());
   const config = options.config ?? {};
   const env = getEffectiveCatsCoRuntimeEnv(runtimeRoot, getEffectiveDashboardEnv(runtimeRoot, options.env), config, options.catsCoOverrides);
+  const modelInputs = resolveReadinessModelInputs(runtimeRoot, env, config);
   const services = serviceManager.getAll().map(service => getServicePreflight(
     serviceManager,
     service.name,
     { runtimeRoot, env, config, catsCoOverrides: options.catsCoOverrides, now: options.now },
   ));
   const sections = [
-    buildModelSection(env, config),
+    buildModelSection(modelInputs.env, modelInputs.config),
     buildCatsCoSection(serviceManager, env, config),
-    buildRuntimeProfileSection(runtimeRoot, env, config),
+    buildRuntimeProfileSection(runtimeRoot, modelInputs.env, modelInputs.config),
     await buildSkillsSection(runtimeRoot),
   ];
 
@@ -113,14 +115,15 @@ export function getServicePreflight(
   const runtimeRoot = path.resolve(options.runtimeRoot ?? process.cwd());
   const config = options.config ?? {};
   const env = getEffectiveCatsCoRuntimeEnv(runtimeRoot, getEffectiveDashboardEnv(runtimeRoot, options.env), config, options.catsCoOverrides);
+  const modelInputs = resolveReadinessModelInputs(runtimeRoot, env, config);
   const service = serviceManager.getService(name);
   if (!service) {
     throw new Error(`Service "${name}" not found`);
   }
 
   const checks = [
-    ...buildModelChecks(env, config),
-    ...buildRuntimeChecks(service, runtimeRoot, env, config, serviceNameToSurface(name)),
+    ...buildModelChecks(modelInputs.env, modelInputs.config),
+    ...buildRuntimeChecks(service, runtimeRoot, modelInputs.env, modelInputs.config, serviceNameToSurface(name)),
     ...buildServiceSpecificChecks(name, env, config, runtimeRoot),
   ];
   const status = statusFromChecks(checks);
@@ -141,6 +144,22 @@ export function getServicePreflight(
     warningChecks: checks
       .filter(check => check.status !== 'pass' && check.severity === 'warning')
       .map(check => check.id),
+  };
+}
+
+function resolveReadinessModelInputs(
+  runtimeRoot: string,
+  env: NodeJS.ProcessEnv,
+  config: ChatConfig,
+): { env: NodeJS.ProcessEnv; config: ChatConfig } {
+  const active = resolveActiveBotLLMConfig({ runtimeRoot, env });
+  if (!active) return { env, config };
+
+  // A bound bot is Definition-owned. Hide stale legacy model fields from model
+  // readiness while keeping CatsCo account and connector settings available.
+  return {
+    env: {},
+    config: { ...config, ...active.config },
   };
 }
 

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -50,6 +50,7 @@ import {
 import { inferCatsUploadType, uploadCatsLocalFile } from '../../catscompany/upload';
 import { createCatsCoLocalConfigService } from '../../catscompany/local-config';
 import { createBotDefinitionSyncService } from '../../bot-definition/service';
+import { prepareBoundBotDefinition } from '../../bot-definition/activation';
 import { resolveActiveBotLLMConfig } from '../../bot-definition/llm-config-resolver';
 import type { BotDefinitionSyncResult } from '../../bot-definition/types';
 import { resolveCatsCoRuntimeConfig } from '../../catscompany/runtime-config';
@@ -799,36 +800,6 @@ async function getCatsBotBodyStatus(
   }
 }
 
-function getCatsCompanyBindingPreflight(
-  serviceManager: ServiceManager,
-  state: CatsAuthState,
-  input: CatsBotBindingInput,
-): any {
-  const service = serviceManager.getService('catscompany');
-  if (!service) return undefined;
-  return getServicePreflight(serviceManager, 'catscompany', {
-    runtimeRoot: runtimeDataRoot(),
-    config: ConfigManager.getConfigReadonly(),
-    catsCoOverrides: {
-      token: state.token,
-      uid: input.userUid,
-      username: input.username || state.username,
-      displayName: input.displayName || state.displayName,
-      httpBaseUrl: state.httpBaseUrl,
-      serverUrl: state.serverUrl,
-      botUid: input.botUid,
-      apiKey: input.apiKey,
-    },
-  });
-}
-
-function assertCatsCompanyPreflightCanStart(preflight: any): void {
-  if (!preflight || preflight.status !== 'blocked') return;
-  const error = httpError('CatsCo connector preflight blocked', 400) as any;
-  error.data = { preflight };
-  throw error;
-}
-
 async function startCatsCompanyConnectorIfReady(
   serviceManager: ServiceManager,
   options: { restartIfRunning?: boolean; preflight?: any } = {},
@@ -863,7 +834,6 @@ async function commitCatsBotBindingAndStartConnector(
   serviceManager: ServiceManager,
   state: CatsAuthState,
   input: CatsBotBindingInput,
-  options: { catalogModelId?: string } = {},
 ): Promise<{
   updated: string[];
   warnings: string[];
@@ -874,29 +844,15 @@ async function commitCatsBotBindingAndStartConnector(
   botDefinitionSync?: Record<string, unknown>;
 }> {
   ensureCatsDeviceId();
-  const preflight = getCatsCompanyBindingPreflight(serviceManager, state, input);
-  assertCatsCompanyPreflightCanStart(preflight);
   const rollback = createCatsCoLocalConfigRollback();
   try {
     const warnings = await ensureCatsFriendBinding(state, input.userUid, input.botUid, input.apiKey);
     const updated = writeCatsBotBinding(state, input);
-    const definitionService = createBotDefinitionSyncService({ runtimeRoot: runtimeDataRoot() });
-    let definitionResult = definitionService.pullOrBootstrap(input.botUid);
-    if (
-      options.catalogModelId
-      && definitionResult?.direction === 'bootstrap_to_simulated_cloud'
-      && definitionResult.definition.model.kind === 'catalog'
-    ) {
-      const runtime = definitionService.readCatalogRuntime(input.botUid);
-      if (runtime) {
-        definitionService.storeCatalogRuntime({ ...runtime, modelId: options.catalogModelId });
-      }
-      definitionResult = definitionService.publish(input.botUid, {
-        kind: 'catalog',
-        modelId: options.catalogModelId,
-      });
-    }
-    const botDefinitionSync = toBotDefinitionSyncPayload(definitionResult);
+    const preparedBot = await prepareBoundBotDefinition({
+      runtimeRoot: runtimeDataRoot(),
+      botId: input.botUid,
+    });
+    const botDefinitionSync = toBotDefinitionSyncPayload(preparedBot?.sync);
     const {
       service,
       preflight: startPreflight,
@@ -3049,8 +3005,6 @@ export function createApiRouter(
         botUsername: bot.username || preferredUsername,
         apiKey,
         bindingSource: 'legacy-setup',
-      }, {
-        catalogModelId: String(relayModelSetup?.modelId || '').trim() || undefined,
       });
 
       res.json({
@@ -3213,8 +3167,6 @@ export function createApiRouter(
         botUsername: targetBot.username || '',
         apiKey,
         bindingSource: 'explicit-bind',
-      }, {
-        catalogModelId: String(relayModelSetup?.modelId || '').trim() || undefined,
       });
       const botName = String(targetBot.display_name || targetBot.username || 'Bot');
 

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -49,7 +49,7 @@ import {
 } from '../../runtime/runtime-profile-editor';
 import { inferCatsUploadType, uploadCatsLocalFile } from '../../catscompany/upload';
 import { createCatsCoLocalConfigService } from '../../catscompany/local-config';
-import { createBotDefinitionSyncService } from '../../bot-definition/service';
+import { catalogRuntimeMatchesModelId, createBotDefinitionSyncService } from '../../bot-definition/service';
 import { prepareBoundBotDefinition } from '../../bot-definition/activation';
 import { resolveActiveBotLLMConfig } from '../../bot-definition/llm-config-resolver';
 import type { BotDefinitionSyncResult } from '../../bot-definition/types';
@@ -861,6 +861,17 @@ async function commitCatsBotBindingAndStartConnector(
     } = await startCatsCompanyConnectorIfReady(serviceManager, {
       restartIfRunning: true,
     });
+    if (startPreflight?.status === 'blocked') {
+      const error = httpError('CatsCo connector preflight blocked', 400) as Error & { data?: unknown };
+      error.data = {
+        preflight: {
+          status: startPreflight.status,
+          blockingChecks: startPreflight.blockingChecks,
+          warningChecks: startPreflight.warningChecks,
+        },
+      };
+      throw error;
+    }
     return {
       updated,
       warnings,
@@ -1240,7 +1251,7 @@ function updateCurrentCatalogRuntimeReasoningEffort(
   const definition = service.pullOrBootstrapCurrentBoundBot()?.definition;
   if (!definition || definition.model.kind !== 'catalog') return undefined;
   const runtime = service.readCatalogRuntime(definition.botId);
-  if (!runtime || runtime.modelId !== definition.model.modelId) {
+  if (!runtime || !catalogRuntimeMatchesModelId(runtime, definition.model.modelId)) {
     throw httpError('The selected catalog model is not materialized on this device.', 409);
   }
   service.storeCatalogRuntime({ ...runtime, reasoningEffort });
@@ -1689,6 +1700,19 @@ function sanitizeCatsErrorData(data: unknown): unknown {
   if (!data || typeof data !== 'object') return undefined;
   const safe: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(data as Record<string, unknown>)) {
+    if (key === 'preflight' && value && typeof value === 'object') {
+      const preflight = value as Record<string, unknown>;
+      safe.preflight = {
+        ...(typeof preflight.status === 'string' ? { status: preflight.status } : {}),
+        ...(Array.isArray(preflight.blockingChecks)
+          ? { blockingChecks: preflight.blockingChecks.filter(item => typeof item === 'string') }
+          : {}),
+        ...(Array.isArray(preflight.warningChecks)
+          ? { warningChecks: preflight.warningChecks.filter(item => typeof item === 'string') }
+          : {}),
+      };
+      continue;
+    }
     const lower = key.toLowerCase();
     if (
       lower.includes('key')

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -48,6 +48,9 @@ import {
 } from '../../runtime/runtime-profile-editor';
 import { inferCatsUploadType, uploadCatsLocalFile } from '../../catscompany/upload';
 import { createCatsCoLocalConfigService } from '../../catscompany/local-config';
+import { createBotDefinitionSyncService } from '../../bot-definition/service';
+import { resolveActiveBotLLMConfig } from '../../bot-definition/llm-config-resolver';
+import type { BotDefinitionSyncResult } from '../../bot-definition/types';
 import { resolveCatsCoRuntimeConfig } from '../../catscompany/runtime-config';
 import { consumeLocalFileGrant, validateLocalFileGrant } from '../local-file-grants';
 import { registerSkillHubRoutes } from './skillhub';
@@ -87,6 +90,10 @@ const TRUSTED_CATSCO_WS_URL = new URL(DEFAULT_CATSCO_WS_URL);
 const BUNDLED_SKILL_MARKER = '.xiaoba-bundled-skill.json';
 const SYSTEM_SKILL_DIRS = new Set<string>();
 const PROMPT_EDITOR_SKILL_NAME = 'catsco-prompt-editor';
+
+function runtimeDataRoot(): string {
+  return PathResolver.getRuntimeDataRoot();
+}
 
 type SkillSource = 'system' | 'bundled' | 'user';
 
@@ -405,7 +412,7 @@ function createCatsNetworkError(error: any, httpBaseUrl: string): Error {
 }
 
 function readEnvFile(): Record<string, string> {
-  const envPath = path.join(process.cwd(), '.env');
+  const envPath = path.join(runtimeDataRoot(), '.env');
   if (!fs.existsSync(envPath)) return {};
   return dotenv.parse(fs.readFileSync(envPath, 'utf-8'));
 }
@@ -419,7 +426,7 @@ function firstNonEmpty(...values: unknown[]): string | undefined {
 }
 
 function writeEnvUpdates(updates: Record<string, string | undefined>): string[] {
-  const envPath = path.join(process.cwd(), '.env');
+  const envPath = path.join(runtimeDataRoot(), '.env');
   let content = fs.existsSync(envPath) ? fs.readFileSync(envPath, 'utf-8') : '';
   const updatedKeys: string[] = [];
 
@@ -443,7 +450,7 @@ function writeEnvUpdates(updates: Record<string, string | undefined>): string[] 
 }
 
 function removeEnvKeys(keys: string[]): string[] {
-  const envPath = path.join(process.cwd(), '.env');
+  const envPath = path.join(runtimeDataRoot(), '.env');
   let content = fs.existsSync(envPath) ? fs.readFileSync(envPath, 'utf-8') : '';
   const removed: string[] = [];
 
@@ -467,10 +474,12 @@ function removeEnvKeys(keys: string[]): string[] {
 }
 
 export function getCatsAuthState(overrides: Record<string, unknown> = {}): CatsAuthState {
-  return createCatsCoLocalConfigService({ runtimeRoot: process.cwd() }).getAuthState(overrides);
+  return createCatsCoLocalConfigService({ runtimeRoot: runtimeDataRoot() }).getAuthState(overrides);
 }
 
 function getModelConfigReadonly(): Pick<ChatConfig, 'apiKey' | 'apiUrl' | 'model' | 'provider' | 'reasoningEffort' | 'openaiApiMode'> {
+  const botConfig = resolveActiveBotLLMConfig({ runtimeRoot: runtimeDataRoot() });
+  if (botConfig) return botConfig.config;
   const config = ConfigManager.getConfigReadonly();
   const env = readEnvFile();
   const provider = firstNonEmpty(process.env.GAUZ_LLM_PROVIDER, env.GAUZ_LLM_PROVIDER, config.provider);
@@ -635,7 +644,7 @@ function sanitizeCatsUsernamePart(value: string): string {
 }
 
 function ensureCatsDeviceId(): string {
-  return createCatsCoLocalConfigService({ runtimeRoot: process.cwd() }).ensureDeviceId();
+  return createCatsCoLocalConfigService({ runtimeRoot: runtimeDataRoot() }).ensureDeviceId();
 }
 
 function chmodOwnerOnly(filePath: string): void {
@@ -664,7 +673,7 @@ function restoreFile(filePath: string, snapshot: { exists: boolean; content?: st
 }
 
 function createCatsCoLocalConfigRollback(): () => void {
-  const runtimeRoot = process.cwd();
+  const runtimeRoot = runtimeDataRoot();
   const service = createCatsCoLocalConfigService({ runtimeRoot });
   const configPath = service.getConfigPath();
   const envPath = path.join(runtimeRoot, '.env');
@@ -794,7 +803,7 @@ function getCatsCompanyBindingPreflight(
   const service = serviceManager.getService('catscompany');
   if (!service) return undefined;
   return getServicePreflight(serviceManager, 'catscompany', {
-    runtimeRoot: process.cwd(),
+    runtimeRoot: runtimeDataRoot(),
     config: ConfigManager.getConfigReadonly(),
     catsCoOverrides: {
       token: state.token,
@@ -824,7 +833,7 @@ async function startCatsCompanyConnectorIfReady(
   let preflight = options.preflight;
   if (service) {
     preflight = preflight || getServicePreflight(serviceManager, 'catscompany', {
-      runtimeRoot: process.cwd(),
+      runtimeRoot: runtimeDataRoot(),
       config: ConfigManager.getConfigReadonly(),
     });
     if (preflight.status === 'blocked') {
@@ -843,14 +852,23 @@ async function startCatsCompanyConnectorIfReady(
 }
 
 function writeCatsBotBinding(state: CatsAuthState, input: CatsBotBindingInput): string[] {
-  return createCatsCoLocalConfigService({ runtimeRoot: process.cwd() }).writeBotBinding(state, input);
+  return createCatsCoLocalConfigService({ runtimeRoot: runtimeDataRoot() }).writeBotBinding(state, input);
 }
 
 async function commitCatsBotBindingAndStartConnector(
   serviceManager: ServiceManager,
   state: CatsAuthState,
   input: CatsBotBindingInput,
-): Promise<{ updated: string[]; warnings: string[]; service: any; preflight: any; connectorStarted: boolean; connectorRestarted: boolean }> {
+  options: { catalogModelId?: string } = {},
+): Promise<{
+  updated: string[];
+  warnings: string[];
+  service: any;
+  preflight: any;
+  connectorStarted: boolean;
+  connectorRestarted: boolean;
+  botDefinitionSync?: Record<string, unknown>;
+}> {
   ensureCatsDeviceId();
   const preflight = getCatsCompanyBindingPreflight(serviceManager, state, input);
   assertCatsCompanyPreflightCanStart(preflight);
@@ -858,6 +876,23 @@ async function commitCatsBotBindingAndStartConnector(
   try {
     const warnings = await ensureCatsFriendBinding(state, input.userUid, input.botUid, input.apiKey);
     const updated = writeCatsBotBinding(state, input);
+    const definitionService = createBotDefinitionSyncService({ runtimeRoot: runtimeDataRoot() });
+    let definitionResult = definitionService.pullOrBootstrap(input.botUid);
+    if (
+      options.catalogModelId
+      && definitionResult?.direction === 'bootstrap_to_simulated_cloud'
+      && definitionResult.definition.model.kind === 'catalog'
+    ) {
+      const runtime = definitionService.readCatalogRuntime(input.botUid);
+      if (runtime) {
+        definitionService.storeCatalogRuntime({ ...runtime, modelId: options.catalogModelId });
+      }
+      definitionResult = definitionService.publish(input.botUid, {
+        kind: 'catalog',
+        modelId: options.catalogModelId,
+      });
+    }
+    const botDefinitionSync = toBotDefinitionSyncPayload(definitionResult);
     const {
       service,
       preflight: startPreflight,
@@ -865,7 +900,6 @@ async function commitCatsBotBindingAndStartConnector(
       connectorRestarted,
     } = await startCatsCompanyConnectorIfReady(serviceManager, {
       restartIfRunning: true,
-      preflight,
     });
     return {
       updated,
@@ -874,6 +908,7 @@ async function commitCatsBotBindingAndStartConnector(
       preflight: startPreflight,
       connectorStarted,
       connectorRestarted,
+      botDefinitionSync,
     };
   } catch (error) {
     rollback();
@@ -1100,7 +1135,7 @@ function isCatsRelayApiBase(value: unknown): boolean {
 }
 
 function writeDashboardEnvAndProcess(updates: Record<string, string | undefined>): { updated: string[]; cleared: string[] } {
-  const result = writeDashboardEnvUpdates(process.cwd(), updates);
+  const result = writeDashboardEnvUpdates(runtimeDataRoot(), updates);
   for (const [key, value] of Object.entries(updates)) {
     if (value === undefined) {
       delete process.env[key];
@@ -1123,6 +1158,42 @@ function modelProfileFromCurrentConfig(): ModelLaunchProfile {
     reasoningEffort: normalizeReasoningEffort(firstNonEmpty(process.env.GAUZ_LLM_REASONING_EFFORT, fileEnv.GAUZ_LLM_REASONING_EFFORT, config.reasoningEffort)),
     openaiApiMode: openAIApiModeOrDefault(firstNonEmpty(process.env.GAUZ_LLM_OPENAI_API_MODE, fileEnv.GAUZ_LLM_OPENAI_API_MODE, config.openaiApiMode)),
   };
+}
+
+function publishCurrentBotDefinition(): BotDefinitionSyncResult | undefined {
+  return createBotDefinitionSyncService({ runtimeRoot: runtimeDataRoot() }).publishCurrentBoundBot();
+}
+
+function toBotDefinitionSyncPayload(result: BotDefinitionSyncResult | undefined): Record<string, unknown> | undefined {
+  if (!result) return undefined;
+  const model = result.definition.model.kind === 'custom'
+    ? (() => {
+      const { apiKey: _apiKey, ...safeModel } = result.definition.model;
+      return safeModel;
+    })()
+    : result.definition.model;
+  return {
+    botId: result.botId,
+    direction: result.direction,
+    model,
+  };
+}
+
+function publishCurrentBotDefinitionPayload(): Record<string, unknown> | undefined {
+  return toBotDefinitionSyncPayload(publishCurrentBotDefinition());
+}
+
+function updateCurrentCustomDefinitionReasoningEffort(
+  reasoningEffort: ReasoningEffort,
+): Record<string, unknown> | undefined {
+  const service = createBotDefinitionSyncService({ runtimeRoot: runtimeDataRoot() });
+  const definition = service.pullOrBootstrapCurrentBoundBot()?.definition;
+  if (!definition || definition.model.kind !== 'custom') return undefined;
+  const result = service.publish(definition.botId, {
+    ...definition.model,
+    reasoningEffort,
+  });
+  return toBotDefinitionSyncPayload(result);
 }
 
 function modelProfileFromStoredEnv(
@@ -1238,7 +1309,7 @@ function sanitizePublicUrl(value: unknown): string | undefined {
 }
 
 function mirrorCurrentModelAsCustomStartup(input: any, previous: ModelLaunchProfile, previousSource: 'relay' | 'custom'): void {
-  const current = modelProfileFromCurrentConfig();
+  const current = modelProfileFromStoredEnv(EFFECTIVE_MODEL_ENV_KEYS);
   const secretAction = requestedSecretAction(input);
   const storedCustom = modelProfileFromStoredEnv(CUSTOM_MODEL_ENV_KEYS);
   const apiKey = secretAction === 'clear'
@@ -1549,6 +1620,7 @@ async function setupCatsRelayModelForDesktop(
     provider: selectedModel.provider,
     apiBase: selectedModel.baseUrl,
     model: selectedModel.model,
+    modelId: selectedModel.id,
     reasoningEffort,
     selectedModel: relayModelPayload(selectedModel),
     updated: settingsResult.updated,
@@ -1664,7 +1736,7 @@ function activateCatsCompanyConnector(
 
   try {
     const preflight = getServicePreflight(serviceManager, 'catscompany', {
-      runtimeRoot: process.cwd(),
+      runtimeRoot: runtimeDataRoot(),
       config: ConfigManager.getConfigReadonly(),
     });
     if (preflight.status === 'blocked') {
@@ -1684,7 +1756,7 @@ function activateCatsCompanyConnector(
 }
 
 function persistCatsUserSession(state: CatsAuthState, login: any): void {
-  createCatsCoLocalConfigService({ runtimeRoot: process.cwd() }).persistAccountSession(state, login);
+  createCatsCoLocalConfigService({ runtimeRoot: runtimeDataRoot() }).persistAccountSession(state, login);
 }
 
 async function getCatsCoAuthForSkillHub(): Promise<{
@@ -1790,7 +1862,7 @@ export function createApiRouter(
         return res.status(400).json({ error: 'enabled must be a boolean' });
       }
       const value = serializeBranchAgentsEnabled(req.body.enabled);
-      const result = writeDashboardEnvUpdates(process.cwd(), {
+      const result = writeDashboardEnvUpdates(runtimeDataRoot(), {
         [BRANCH_AGENTS_ENABLED_ENV]: value,
       });
       process.env[BRANCH_AGENTS_ENABLED_ENV] = value;
@@ -1845,7 +1917,7 @@ export function createApiRouter(
   router.get('/readiness', async (_req, res) => {
     try {
       const readiness = await getDashboardReadiness(serviceManager, {
-        runtimeRoot: process.cwd(),
+        runtimeRoot: runtimeDataRoot(),
         config: ConfigManager.getConfigReadonly(),
       });
       // Public readiness exposes only a redacted aggregate status so the UI
@@ -1864,7 +1936,7 @@ export function createApiRouter(
   router.get('/readiness/details', async (_req, res) => {
     try {
       res.json(await getDashboardReadiness(serviceManager, {
-        runtimeRoot: process.cwd(),
+        runtimeRoot: runtimeDataRoot(),
         config: ConfigManager.getConfigReadonly(),
       }));
     } catch (e: any) {
@@ -1874,10 +1946,10 @@ export function createApiRouter(
 
   router.get('/runtime/profile/edit', (_req, res) => {
     try {
-      const preview = previewRuntimeProfileEdit({}, { runtimeRoot: process.cwd() });
+      const preview = previewRuntimeProfileEdit({}, { runtimeRoot: runtimeDataRoot() });
       res.json(sanitizeRuntimeProfileEditResponse({
         ...preview,
-        rollbackAvailable: hasRuntimeProfileRollback({ runtimeRoot: process.cwd() }),
+        rollbackAvailable: hasRuntimeProfileRollback({ runtimeRoot: runtimeDataRoot() }),
       }));
     } catch (e: any) {
       res.status(500).json({ error: e?.message || String(e) });
@@ -1887,11 +1959,11 @@ export function createApiRouter(
   router.post('/runtime/profile/preview', (req, res) => {
     try {
       const preview = previewRuntimeProfileEdit(req.body as RuntimeProfileEditInput, {
-        runtimeRoot: process.cwd(),
+        runtimeRoot: runtimeDataRoot(),
       });
       res.json(sanitizeRuntimeProfileEditResponse({
         ...preview,
-        rollbackAvailable: hasRuntimeProfileRollback({ runtimeRoot: process.cwd() }),
+        rollbackAvailable: hasRuntimeProfileRollback({ runtimeRoot: runtimeDataRoot() }),
       }));
     } catch (e: any) {
       res.status(400).json({ error: e?.message || String(e) });
@@ -1901,7 +1973,7 @@ export function createApiRouter(
   router.put('/runtime/profile', (req, res) => {
     try {
       const result = saveRuntimeProfileEdit(req.body as RuntimeProfileEditInput, {
-        runtimeRoot: process.cwd(),
+        runtimeRoot: runtimeDataRoot(),
       });
       res.json(sanitizeRuntimeProfileEditResponse(result));
     } catch (e: any) {
@@ -1911,7 +1983,7 @@ export function createApiRouter(
 
   router.post('/runtime/profile/rollback', (_req, res) => {
     try {
-      res.json(rollbackRuntimeProfileEdit({ runtimeRoot: process.cwd() }));
+      res.json(rollbackRuntimeProfileEdit({ runtimeRoot: runtimeDataRoot() }));
     } catch (e: any) {
       res.status(400).json({ error: e?.message || String(e) });
     }
@@ -1998,7 +2070,7 @@ export function createApiRouter(
   router.post('/services/:name/preflight', (req, res) => {
     try {
       res.json(getServicePreflight(serviceManager, req.params.name, {
-        runtimeRoot: process.cwd(),
+        runtimeRoot: runtimeDataRoot(),
         config: ConfigManager.getConfigReadonly(),
       }));
     } catch (e: any) {
@@ -2009,7 +2081,7 @@ export function createApiRouter(
   router.post('/services/:name/start', (req, res) => {
     try {
       const preflight = getServicePreflight(serviceManager, req.params.name, {
-        runtimeRoot: process.cwd(),
+        runtimeRoot: runtimeDataRoot(),
         config: ConfigManager.getConfigReadonly(),
       });
       if (preflight.status === 'blocked' && req.body?.force !== true) {
@@ -2035,7 +2107,7 @@ export function createApiRouter(
   router.post('/services/:name/restart', (req, res) => {
     try {
       const preflight = getServicePreflight(serviceManager, req.params.name, {
-        runtimeRoot: process.cwd(),
+        runtimeRoot: runtimeDataRoot(),
         config: ConfigManager.getConfigReadonly(),
       });
       if (preflight.status === 'blocked' && req.body?.force !== true) {
@@ -2059,7 +2131,7 @@ export function createApiRouter(
 
   router.get('/settings', (_req, res) => {
     try {
-      res.json(getDashboardSettings({ runtimeRoot: process.cwd() }));
+      res.json(getDashboardSettings({ runtimeRoot: runtimeDataRoot() }));
     } catch (e: any) {
       res.status(500).json({ error: e.message });
     }
@@ -2069,17 +2141,21 @@ export function createApiRouter(
     try {
       const previousModel = modelProfileFromCurrentConfig();
       const previousSource = storedModelSource();
-      const result = updateDashboardSettings(req.body, { runtimeRoot: process.cwd() });
+      const result = updateDashboardSettings(req.body, { runtimeRoot: runtimeDataRoot() });
       const changedModelSettings = result.updated.some(key => key.startsWith('GAUZ_LLM_'))
         || result.cleared.some(key => key.startsWith('GAUZ_LLM_'));
       if (changedModelSettings) {
         mirrorCurrentModelAsCustomStartup(req.body, previousModel, previousSource);
       }
+      const botDefinitionSync = changedModelSettings
+        ? publishCurrentBotDefinitionPayload()
+        : undefined;
       const restartInfo = req.body?.restartConnector === true && changedModelSettings
         ? activateCatsCompanyConnector(serviceManager)
         : { wasRunning: false, restartRequested: false, startRequested: false, startBlocked: false };
       res.json({
         ...result,
+        botDefinitionSync,
         connectorRestarted: restartInfo.restartRequested,
         restartError: restartInfo.restartError ? sanitizeCatsErrorMessage(restartInfo.restartError) : undefined,
       });
@@ -2091,6 +2167,32 @@ export function createApiRouter(
   router.put('/model/reasoning-effort', (req, res) => {
     try {
       const requested = requestedReasoningEffort(req.body?.reasoningEffort);
+      const activeBotConfig = resolveActiveBotLLMConfig({ runtimeRoot: runtimeDataRoot() });
+      if (activeBotConfig?.source === 'custom_definition') {
+        const previousReasoningEffort = activeBotConfig.config.reasoningEffort ?? 'default';
+        const reasoningEffort = requested ?? previousReasoningEffort;
+        const botDefinitionSync = updateCurrentCustomDefinitionReasoningEffort(reasoningEffort);
+        const restartInfo = req.body?.restartConnector === true || req.body?.activateConnector === true
+          ? activateCatsCompanyConnector(serviceManager, {
+            startIfStopped: req.body?.activateConnector === true || req.body?.startConnector === true,
+          })
+          : { wasRunning: false, restartRequested: false, startRequested: false, startBlocked: false };
+        return res.json({
+          ok: true,
+          source: 'custom',
+          reasoningEffort,
+          previousReasoningEffort,
+          updated: [],
+          cleared: [],
+          botDefinitionSync,
+          restartRequired: restartInfo.wasRunning && !restartInfo.restartRequested,
+          connectorRestarted: restartInfo.restartRequested,
+          connectorStarted: restartInfo.startRequested,
+          connectorStartBlocked: restartInfo.startBlocked,
+          restartError: restartInfo.restartError ? sanitizeCatsErrorMessage(restartInfo.restartError) : undefined,
+          startError: restartInfo.startError ? sanitizeCatsErrorMessage(restartInfo.startError) : undefined,
+        });
+      }
       const previousReasoningEffort = currentStartupReasoningEffort();
       const explicitSource = storedModelSourceRaw();
       const current = modelProfileFromCurrentConfig();
@@ -2099,6 +2201,9 @@ export function createApiRouter(
         ? relayReasoningEffortOrHigh(requested ?? previousReasoningEffort)
         : requested ?? previousReasoningEffort;
       const result = writeStartupReasoningEffort(reasoningEffort);
+      const botDefinitionSync = result.source === 'custom'
+        ? updateCurrentCustomDefinitionReasoningEffort(reasoningEffort)
+        : undefined;
       const restartInfo = req.body?.restartConnector === true || req.body?.activateConnector === true
         ? activateCatsCompanyConnector(serviceManager, {
           startIfStopped: req.body?.activateConnector === true || req.body?.startConnector === true,
@@ -2111,6 +2216,7 @@ export function createApiRouter(
         previousReasoningEffort,
         updated: result.updated,
         cleared: result.cleared,
+        botDefinitionSync,
         restartRequired: restartInfo.wasRunning && !restartInfo.restartRequested,
         connectorRestarted: restartInfo.restartRequested,
         connectorStarted: restartInfo.startRequested,
@@ -2126,6 +2232,7 @@ export function createApiRouter(
   router.post('/model-source/custom/apply', (req, res) => {
     try {
       const result = writeCustomModelStartupConfig();
+      const botDefinitionSync = publishCurrentBotDefinitionPayload();
       const activation = activateCatsCompanyConnector(serviceManager, {
         startIfStopped: req.body?.activateConnector === true || req.body?.startConnector === true,
       });
@@ -2141,6 +2248,7 @@ export function createApiRouter(
         openaiApiMode: result.profile.openaiApiMode ?? 'chat_completions',
         updated: result.updated,
         cleared: result.cleared,
+        botDefinitionSync,
         restartRequired: activation.wasRunning && !activation.restartRequested,
         connectorRestarted: activation.restartRequested,
         connectorStarted: activation.startRequested,
@@ -2169,7 +2277,7 @@ export function createApiRouter(
 
   router.get('/config', (_req, res) => {
     try {
-      const envPath = path.join(process.cwd(), '.env');
+      const envPath = path.join(runtimeDataRoot(), '.env');
       if (!fs.existsSync(envPath)) return res.json({});
       const content = fs.readFileSync(envPath, 'utf-8');
       const parsed = dotenv.parse(content);
@@ -2228,7 +2336,7 @@ export function createApiRouter(
         safeUpdates[key] = value;
       }
 
-      const result = writeDashboardEnvUpdates(process.cwd(), safeUpdates);
+      const result = writeDashboardEnvUpdates(runtimeDataRoot(), safeUpdates);
       for (const [key, value] of Object.entries(safeUpdates)) {
         process.env[key] = value;
       }
@@ -2386,7 +2494,7 @@ export function createApiRouter(
   router.get('/weixin/channel-binding', (_req, res) => {
     try {
       res.json(sanitizeWeixinChannelStatus(getWeixinChannelStatus({
-        runtimeRoot: process.cwd(),
+        runtimeRoot: runtimeDataRoot(),
         env: process.env,
       })));
     } catch (e: any) {
@@ -2397,7 +2505,7 @@ export function createApiRouter(
   router.get('/weixin/qrcode', async (_req, res) => {
     try {
       const status = getWeixinChannelStatus({
-        runtimeRoot: process.cwd(),
+        runtimeRoot: runtimeDataRoot(),
         env: process.env,
       });
       if (!status.currentAgent) {
@@ -2429,7 +2537,7 @@ export function createApiRouter(
       const expectedAgentUid = String(req.query.agent_uid || '').trim();
       if (!qrcode) return res.status(400).json({ error: 'qrcode required' });
       const status = getWeixinChannelStatus({
-        runtimeRoot: process.cwd(),
+        runtimeRoot: runtimeDataRoot(),
         env: process.env,
       });
       if (!status.currentAgent) {
@@ -2457,7 +2565,7 @@ export function createApiRouter(
       if (data?.status === 'confirmed' && botToken) {
         const result = bindWeixinChannelToCurrentAgent({
           token: botToken,
-          runtimeRoot: process.cwd(),
+          runtimeRoot: runtimeDataRoot(),
           env: process.env,
           expectedAgentUid: expectedAgentUid || status.currentAgent.uid,
         });
@@ -2477,7 +2585,7 @@ export function createApiRouter(
 
   router.get('/cats/status', async (_req, res) => {
     const runtime = resolveCatsCoRuntimeConfig({
-      runtimeRoot: process.cwd(),
+      runtimeRoot: runtimeDataRoot(),
       config: ConfigManager.getConfigReadonly(),
     });
     const state = runtime.auth;
@@ -2625,7 +2733,7 @@ export function createApiRouter(
   });
 
   router.post('/cats/auth/logout', (_req, res) => {
-    const removed = createCatsCoLocalConfigService({ runtimeRoot: process.cwd() }).clearAccount();
+    const removed = createCatsCoLocalConfigService({ runtimeRoot: runtimeDataRoot() }).clearAccount();
     res.json({ ok: true, removed });
   });
 
@@ -2769,6 +2877,8 @@ export function createApiRouter(
         botUsername: bot.username || preferredUsername,
         apiKey,
         bindingSource: 'legacy-setup',
+      }, {
+        catalogModelId: String(relayModelSetup?.modelId || '').trim() || undefined,
       });
 
       res.json({
@@ -2789,6 +2899,7 @@ export function createApiRouter(
         preflight: result.preflight,
         connectorStarted: result.connectorStarted,
         connectorRestarted: result.connectorRestarted,
+        botDefinitionSync: result.botDefinitionSync,
         relayModelSetup,
         botSelectionSource,
         warnings: result.warnings.length > 0 ? result.warnings : undefined,
@@ -2930,6 +3041,8 @@ export function createApiRouter(
         botUsername: targetBot.username || '',
         apiKey,
         bindingSource: 'explicit-bind',
+      }, {
+        catalogModelId: String(relayModelSetup?.modelId || '').trim() || undefined,
       });
       const botName = String(targetBot.display_name || targetBot.username || 'Bot');
 
@@ -2947,6 +3060,7 @@ export function createApiRouter(
         preflight: result.preflight,
         connectorStarted: result.connectorStarted,
         connectorRestarted: result.connectorRestarted,
+        botDefinitionSync: result.botDefinitionSync,
         relayModelSetup,
         warnings: result.warnings.length > 0 ? result.warnings : undefined,
         message: `已绑定机器人 "${botName}"`,
@@ -3012,7 +3126,7 @@ export function createApiRouter(
 
   router.get('/cats/config', async (_req, res) => {
     try {
-      res.json(createCatsCoLocalConfigService({ runtimeRoot: process.cwd() }).toDashboardConfigPayload());
+      res.json(createCatsCoLocalConfigService({ runtimeRoot: runtimeDataRoot() }).toDashboardConfigPayload());
     } catch (e: any) {
       res.status(500).json({ error: e.message });
     }
@@ -3020,7 +3134,7 @@ export function createApiRouter(
 
   router.put('/cats/config/preferences', async (req, res) => {
     try {
-      const preferences = createCatsCoLocalConfigService({ runtimeRoot: process.cwd() }).updatePreferences(req.body || {});
+      const preferences = createCatsCoLocalConfigService({ runtimeRoot: runtimeDataRoot() }).updatePreferences(req.body || {});
       res.json({ ok: true, preferences });
     } catch (e: any) {
       res.status(500).json({ error: e.message });
@@ -3114,6 +3228,26 @@ export function createApiRouter(
       const provider = selectedModel.provider;
       const model = selectedModel.model;
       const settingsResult = writeRelayModelStartupConfig(selectedModel, ensured.plainKey, { reasoningEffort });
+      const definitionService = createBotDefinitionSyncService({ runtimeRoot: runtimeDataRoot() });
+      const botId = String(createCatsCoLocalConfigService({ runtimeRoot: runtimeDataRoot() }).load().currentBot?.uid || '').trim();
+      let botDefinitionSync: Record<string, unknown> | undefined;
+      if (botId) {
+        definitionService.storeCatalogRuntime({
+          schema: 'xiaoba.bot-catalog-model-runtime.v1',
+          botId,
+          modelId: selectedModel.id,
+          provider: selectedModel.provider,
+          apiBase: selectedModel.baseUrl,
+          apiKey: ensured.plainKey,
+          model: selectedModel.model,
+          contextWindowTokens: selectedModel.contextWindowTokens ?? 200_000,
+          reasoningEffort,
+          openaiApiMode: 'chat_completions',
+        });
+        botDefinitionSync = toBotDefinitionSyncPayload(
+          definitionService.publish(botId, { kind: 'catalog', modelId: selectedModel.id }),
+        );
+      }
       const restartInfo = activateCatsCompanyConnector(serviceManager, {
         startIfStopped: req.body?.activateConnector === true || req.body?.startConnector === true,
       });
@@ -3128,6 +3262,7 @@ export function createApiRouter(
         selectedModel: relayModelPayload(selectedModel),
         models: relayModelCatalog(config).map(relayModelPayload),
         updated: settingsResult.updated,
+        botDefinitionSync,
         key: sanitizeRelayKeyInfo(ensured.response?.key),
         createdKey: ensured.created,
         rotatedKey: ensured.rotated,

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -31,6 +31,7 @@ import {
   writeDashboardEnvUpdates,
 } from '../settings';
 import {
+  DEFAULT_CATSCO_RELAY_MODEL_ID,
   RELAY_MODEL_PROFILES,
   findRelayModelProfile,
   relayModelProviderBaseUrl,
@@ -477,7 +478,7 @@ export function getCatsAuthState(overrides: Record<string, unknown> = {}): CatsA
   return createCatsCoLocalConfigService({ runtimeRoot: runtimeDataRoot() }).getAuthState(overrides);
 }
 
-function getModelConfigReadonly(): Pick<ChatConfig, 'apiKey' | 'apiUrl' | 'model' | 'provider' | 'reasoningEffort' | 'openaiApiMode'> {
+function getModelConfigReadonly(): Pick<ChatConfig, 'apiKey' | 'apiUrl' | 'model' | 'provider' | 'contextWindowTokens' | 'maxTokens' | 'temperature' | 'reasoningEffort' | 'openaiApiMode'> {
   const botConfig = resolveActiveBotLLMConfig({ runtimeRoot: runtimeDataRoot() });
   if (botConfig) return botConfig.config;
   const config = ConfigManager.getConfigReadonly();
@@ -496,11 +497,14 @@ function getModelConfigReadonly(): Pick<ChatConfig, 'apiKey' | 'apiUrl' | 'model
     env.GAUZ_LLM_OPENAI_API_MODE,
     config.openaiApiMode,
   ));
-
   return {
     apiKey,
     apiUrl,
     model,
+    contextWindowTokens: parsePositiveInteger(firstNonEmpty(
+      process.env.GAUZ_LLM_CONTEXT_WINDOW_TOKENS,
+      env.GAUZ_LLM_CONTEXT_WINDOW_TOKENS,
+    )),
     reasoningEffort,
     openaiApiMode,
     provider: provider === 'anthropic' || provider === 'openai' ? provider : config.provider,
@@ -1091,6 +1095,10 @@ function selectRelayModel(
 function preferredRelayModelRequest(requested: unknown): unknown {
   const explicit = String(requested || '').trim();
   if (explicit) return explicit;
+  const active = getModelConfigReadonly();
+  if (isCatsRelayApiBase(active.apiUrl) && String(active.model || '').trim()) {
+    return active.model;
+  }
   const fileEnv = readEnvFile();
   return firstNonEmpty(
     process.env.CATSCO_RELAY_LLM_MODEL,
@@ -1098,7 +1106,7 @@ function preferredRelayModelRequest(requested: unknown): unknown {
     isCatsRelayApiBase(firstNonEmpty(process.env.GAUZ_LLM_API_BASE, fileEnv.GAUZ_LLM_API_BASE))
       ? firstNonEmpty(process.env.GAUZ_LLM_MODEL, fileEnv.GAUZ_LLM_MODEL)
       : undefined,
-  );
+  ) || DEFAULT_CATSCO_RELAY_MODEL_ID;
 }
 
 function relayModelPayload(model: RelayModelConfig): Record<string, unknown> {
@@ -1148,16 +1156,89 @@ function writeDashboardEnvAndProcess(updates: Record<string, string | undefined>
 
 function modelProfileFromCurrentConfig(): ModelLaunchProfile {
   const config = getModelConfigReadonly();
-  const fileEnv = readEnvFile();
   return {
     provider: config.provider,
     apiBase: config.apiUrl,
     model: config.model,
     apiKey: config.apiKey,
-    contextWindowTokens: parsePositiveInteger(firstNonEmpty(process.env.GAUZ_LLM_CONTEXT_WINDOW_TOKENS, fileEnv.GAUZ_LLM_CONTEXT_WINDOW_TOKENS)),
-    reasoningEffort: normalizeReasoningEffort(firstNonEmpty(process.env.GAUZ_LLM_REASONING_EFFORT, fileEnv.GAUZ_LLM_REASONING_EFFORT, config.reasoningEffort)),
-    openaiApiMode: openAIApiModeOrDefault(firstNonEmpty(process.env.GAUZ_LLM_OPENAI_API_MODE, fileEnv.GAUZ_LLM_OPENAI_API_MODE, config.openaiApiMode)),
+    contextWindowTokens: config.contextWindowTokens,
+    reasoningEffort: config.reasoningEffort,
+    openaiApiMode: config.openaiApiMode,
   };
+}
+
+function currentBoundBotId(): string | undefined {
+  const config = createCatsCoLocalConfigService({ runtimeRoot: runtimeDataRoot() }).load();
+  const botId = String(config.currentBot?.uid || '').trim();
+  return botId || undefined;
+}
+
+function hasDashboardModelUpdates(body: any): boolean {
+  const settings = body?.settings;
+  return Boolean(settings && typeof settings === 'object' && !Array.isArray(settings)
+    && Object.keys(settings).some(key => key.startsWith('model.')));
+}
+
+function withoutDashboardModelUpdates(body: any): any {
+  const settings = body?.settings;
+  if (!settings || typeof settings !== 'object' || Array.isArray(settings)) return body;
+  return {
+    ...body,
+    settings: Object.fromEntries(Object.entries(settings).filter(([key]) => !key.startsWith('model.'))),
+  };
+}
+
+function dashboardSecretValue(raw: unknown, current: string | undefined, id: string): string {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw httpError(`${id} must be a secret update object`, 400);
+  }
+  const action = (raw as { action?: unknown }).action;
+  if (action === 'keep') return String(current || '').trim();
+  if (action === 'replace') {
+    const value = String((raw as { value?: unknown }).value || '').trim();
+    if (value) return value;
+  }
+  throw httpError(`${id} must keep or replace a non-empty value`, 400);
+}
+
+/** Writes an explicit user model edit straight to the current bot Definition. */
+function updateBoundBotModelFromDashboardSettings(body: any): Record<string, unknown> | undefined {
+  const botId = currentBoundBotId();
+  if (!botId || !hasDashboardModelUpdates(body)) return undefined;
+  const settings = body.settings as Record<string, unknown>;
+  const current = getModelConfigReadonly();
+  const text = (id: string, fallback: unknown): string => (
+    Object.prototype.hasOwnProperty.call(settings, id) ? String(settings[id] || '').trim() : String(fallback || '').trim()
+  );
+  const providerValue = text('model.provider', current.provider);
+  const provider = providerValue === 'anthropic' || providerValue === 'openai' ? providerValue : undefined;
+  const apiBase = text('model.apiBase', current.apiUrl);
+  const model = text('model.model', current.model);
+  const apiKey = Object.prototype.hasOwnProperty.call(settings, 'model.apiKey')
+    ? dashboardSecretValue(settings['model.apiKey'], current.apiKey, 'model.apiKey')
+    : String(current.apiKey || '').trim();
+  const contextText = text('model.contextWindowTokens', current.contextWindowTokens);
+  const contextWindowTokens = parsePositiveInteger(contextText);
+  const reasoningValue = text('model.reasoningEffort', current.reasoningEffort || 'default');
+  const reasoningEffort = normalizeReasoningEffort(reasoningValue);
+  const openaiApiMode = openAIApiModeOrDefault(text('model.openaiApiMode', current.openaiApiMode || 'chat_completions'));
+  if (!provider || !apiBase || !model || !apiKey || !contextWindowTokens) {
+    throw httpError('A bound bot requires provider, API base, model, API key, and context window.', 400);
+  }
+  const service = createBotDefinitionSyncService({ runtimeRoot: runtimeDataRoot() });
+  return toBotDefinitionSyncPayload(service.publish(botId, {
+    kind: 'custom',
+    protocol: provider === 'anthropic'
+      ? 'anthropic'
+      : openaiApiMode === 'responses' ? 'openai-responses' : 'openai-chat-completions',
+    apiBase,
+    model,
+    apiKey,
+    contextWindowTokens,
+    ...(current.maxTokens ? { maxTokens: current.maxTokens } : {}),
+    ...(current.temperature !== undefined ? { temperature: current.temperature } : {}),
+    ...(reasoningEffort ? { reasoningEffort } : {}),
+  }));
 }
 
 function publishCurrentBotDefinition(): BotDefinitionSyncResult | undefined {
@@ -1194,6 +1275,20 @@ function updateCurrentCustomDefinitionReasoningEffort(
     reasoningEffort,
   });
   return toBotDefinitionSyncPayload(result);
+}
+
+function updateCurrentCatalogRuntimeReasoningEffort(
+  reasoningEffort: ReasoningEffort,
+): Record<string, unknown> | undefined {
+  const service = createBotDefinitionSyncService({ runtimeRoot: runtimeDataRoot() });
+  const definition = service.pullOrBootstrapCurrentBoundBot()?.definition;
+  if (!definition || definition.model.kind !== 'catalog') return undefined;
+  const runtime = service.readCatalogRuntime(definition.botId);
+  if (!runtime || runtime.modelId !== definition.model.modelId) {
+    throw httpError('The selected catalog model is not materialized on this device.', 409);
+  }
+  service.storeCatalogRuntime({ ...runtime, reasoningEffort });
+  return toBotDefinitionSyncPayload(service.publish(definition.botId, definition.model));
 }
 
 function modelProfileFromStoredEnv(
@@ -1371,12 +1466,12 @@ function writeCustomModelStartupConfig(): { profile: ModelLaunchProfile; updated
 }
 
 function currentRelayReasoningEffort(): ReasoningEffort {
-  const storedRelay = modelProfileFromStoredEnv(RELAY_MODEL_ENV_KEYS);
-  if (storedRelay.reasoningEffort) return relayReasoningEffortOrHigh(storedRelay.reasoningEffort);
   const current = modelProfileFromCurrentConfig();
   if (isCatsRelayApiBase(current.apiBase) && current.reasoningEffort) {
     return relayReasoningEffortOrHigh(current.reasoningEffort);
   }
+  const storedRelay = modelProfileFromStoredEnv(RELAY_MODEL_ENV_KEYS);
+  if (storedRelay.reasoningEffort) return relayReasoningEffortOrHigh(storedRelay.reasoningEffort);
   return 'high';
 }
 
@@ -1538,7 +1633,9 @@ async function ensureCatsRelayPlainKey(
 function findReusableLocalRelayKey(currentKey: any): string | undefined {
   const fileEnv = readEnvFile();
   const currentConfig = ConfigManager.getConfigReadonly();
+  const activeRelayConfig = isCatsRelayApiBase(currentConfig.apiUrl) ? currentConfig : undefined;
   const apiKey = firstNonEmpty(
+    activeRelayConfig?.apiKey,
     process.env.CATSCO_RELAY_LLM_API_KEY,
     fileEnv.CATSCO_RELAY_LLM_API_KEY,
     process.env.GAUZ_LLM_API_KEY,
@@ -1546,6 +1643,7 @@ function findReusableLocalRelayKey(currentKey: any): string | undefined {
     currentConfig.apiKey,
   );
   const apiBase = firstNonEmpty(
+    activeRelayConfig?.apiUrl,
     process.env.CATSCO_RELAY_LLM_API_BASE,
     fileEnv.CATSCO_RELAY_LLM_API_BASE,
     process.env.GAUZ_LLM_API_BASE,
@@ -2131,7 +2229,11 @@ export function createApiRouter(
 
   router.get('/settings', (_req, res) => {
     try {
-      res.json(getDashboardSettings({ runtimeRoot: runtimeDataRoot() }));
+      const activeBotConfig = resolveActiveBotLLMConfig({ runtimeRoot: runtimeDataRoot() });
+      res.json(getDashboardSettings({
+        runtimeRoot: runtimeDataRoot(),
+        ...(activeBotConfig ? { modelConfig: activeBotConfig.config } : {}),
+      }));
     } catch (e: any) {
       res.status(500).json({ error: e.message });
     }
@@ -2141,13 +2243,21 @@ export function createApiRouter(
     try {
       const previousModel = modelProfileFromCurrentConfig();
       const previousSource = storedModelSource();
-      const result = updateDashboardSettings(req.body, { runtimeRoot: runtimeDataRoot() });
-      const changedModelSettings = result.updated.some(key => key.startsWith('GAUZ_LLM_'))
-        || result.cleared.some(key => key.startsWith('GAUZ_LLM_'));
-      if (changedModelSettings) {
+      const boundBot = currentBoundBotId();
+      const changedModelSettings = hasDashboardModelUpdates(req.body);
+      // Bound bots never write a second model source to .env. Non-model
+      // dashboard settings keep their existing machine-local behavior.
+      const botDefinitionSync = boundBot
+        ? updateBoundBotModelFromDashboardSettings(req.body)
+        : undefined;
+      const result = updateDashboardSettings(
+        boundBot ? withoutDashboardModelUpdates(req.body) : req.body,
+        { runtimeRoot: runtimeDataRoot() },
+      );
+      if (changedModelSettings && !boundBot) {
         mirrorCurrentModelAsCustomStartup(req.body, previousModel, previousSource);
       }
-      const botDefinitionSync = changedModelSettings
+      const legacyDefinitionSync = changedModelSettings && !boundBot
         ? publishCurrentBotDefinitionPayload()
         : undefined;
       const restartInfo = req.body?.restartConnector === true && changedModelSettings
@@ -2155,7 +2265,7 @@ export function createApiRouter(
         : { wasRunning: false, restartRequested: false, startRequested: false, startBlocked: false };
       res.json({
         ...result,
-        botDefinitionSync,
+        botDefinitionSync: botDefinitionSync ?? legacyDefinitionSync,
         connectorRestarted: restartInfo.restartRequested,
         restartError: restartInfo.restartError ? sanitizeCatsErrorMessage(restartInfo.restartError) : undefined,
       });
@@ -2180,6 +2290,31 @@ export function createApiRouter(
         return res.json({
           ok: true,
           source: 'custom',
+          reasoningEffort,
+          previousReasoningEffort,
+          updated: [],
+          cleared: [],
+          botDefinitionSync,
+          restartRequired: restartInfo.wasRunning && !restartInfo.restartRequested,
+          connectorRestarted: restartInfo.restartRequested,
+          connectorStarted: restartInfo.startRequested,
+          connectorStartBlocked: restartInfo.startBlocked,
+          restartError: restartInfo.restartError ? sanitizeCatsErrorMessage(restartInfo.restartError) : undefined,
+          startError: restartInfo.startError ? sanitizeCatsErrorMessage(restartInfo.startError) : undefined,
+        });
+      }
+      if (activeBotConfig?.source === 'catalog_runtime') {
+        const previousReasoningEffort = activeBotConfig.config.reasoningEffort ?? 'high';
+        const reasoningEffort = relayReasoningEffortOrHigh(requested ?? previousReasoningEffort);
+        const botDefinitionSync = updateCurrentCatalogRuntimeReasoningEffort(reasoningEffort);
+        const restartInfo = req.body?.restartConnector === true || req.body?.activateConnector === true
+          ? activateCatsCompanyConnector(serviceManager, {
+            startIfStopped: req.body?.activateConnector === true || req.body?.startConnector === true,
+          })
+          : { wasRunning: false, restartRequested: false, startRequested: false, startBlocked: false };
+        return res.json({
+          ok: true,
+          source: 'relay',
           reasoningEffort,
           previousReasoningEffort,
           updated: [],
@@ -2231,6 +2366,36 @@ export function createApiRouter(
 
   router.post('/model-source/custom/apply', (req, res) => {
     try {
+      const activeBotConfig = resolveActiveBotLLMConfig({ runtimeRoot: runtimeDataRoot() });
+      if (activeBotConfig) {
+        if (activeBotConfig.source !== 'custom_definition') {
+          throw httpError('Set custom model fields in Settings before selecting the custom source.', 409);
+        }
+        const activation = activateCatsCompanyConnector(serviceManager, {
+          startIfStopped: req.body?.activateConnector === true || req.body?.startConnector === true,
+        });
+        return res.json({
+          ok: true,
+          source: 'custom',
+          provider: activeBotConfig.config.provider,
+          apiBase: sanitizePublicUrl(activeBotConfig.config.apiUrl),
+          model: activeBotConfig.config.model,
+          contextWindowTokens: activeBotConfig.config.contextWindowTokens,
+          contextLabel: activeBotConfig.config.contextWindowTokens
+            ? formatContextWindowTokens(activeBotConfig.config.contextWindowTokens)
+            : undefined,
+          reasoningEffort: activeBotConfig.config.reasoningEffort ?? 'default',
+          openaiApiMode: activeBotConfig.config.openaiApiMode ?? 'chat_completions',
+          updated: [],
+          cleared: [],
+          restartRequired: activation.wasRunning && !activation.restartRequested,
+          connectorRestarted: activation.restartRequested,
+          connectorStarted: activation.startRequested,
+          connectorStartBlocked: activation.startBlocked,
+          restartError: activation.restartError ? sanitizeCatsErrorMessage(activation.restartError) : undefined,
+          startError: activation.startError ? sanitizeCatsErrorMessage(activation.startError) : undefined,
+        });
+      }
       const result = writeCustomModelStartupConfig();
       const botDefinitionSync = publishCurrentBotDefinitionPayload();
       const activation = activateCatsCompanyConnector(serviceManager, {
@@ -2301,6 +2466,13 @@ export function createApiRouter(
   router.put('/config', (req, res) => {
     try {
       const updates: Record<string, string> = req.body;
+      const boundBot = currentBoundBotId();
+      const requestedModelEnv = Object.keys(updates || {}).filter(key => key.startsWith('GAUZ_LLM_'));
+      if (boundBot && requestedModelEnv.length > 0) {
+        return res.status(409).json({
+          error: 'Bound bot model settings are stored in BotDefinition. Use the Settings model fields instead of /api/config.',
+        });
+      }
       const allowedKeys = new Set([
         'GAUZ_LLM_PROVIDER',
         'GAUZ_LLM_API_BASE',
@@ -3151,7 +3323,7 @@ export function createApiRouter(
       const requestedModel = req.query.modelId || req.query.model;
       const selectedModel = selectRelayModel(
         config,
-        requestedModel || currentConfig.model,
+        preferredRelayModelRequest(requestedModel),
         { strict: Boolean(requestedModel) },
       );
       const keyResponse = config?.self_service_enabled ? await fetchCatsRelayKey(state) : { key: null };
@@ -3196,7 +3368,11 @@ export function createApiRouter(
 
       const config = await fetchCatsRelayConfig(state);
       const requestedModel = req.body?.modelId || req.body?.model;
-      const selectedModel = selectRelayModel(config, requestedModel, { strict: Boolean(requestedModel) });
+      const selectedModel = selectRelayModel(
+        config,
+        preferredRelayModelRequest(requestedModel),
+        { strict: Boolean(requestedModel) },
+      );
       const reasoningEffort = relayReasoningEffortOrHigh(
         requestedReasoningEffort(req.body?.reasoningEffort) ?? currentRelayReasoningEffort(),
       );
@@ -3227,9 +3403,14 @@ export function createApiRouter(
       const apiBase = selectedModel.baseUrl;
       const provider = selectedModel.provider;
       const model = selectedModel.model;
-      const settingsResult = writeRelayModelStartupConfig(selectedModel, ensured.plainKey, { reasoningEffort });
       const definitionService = createBotDefinitionSyncService({ runtimeRoot: runtimeDataRoot() });
       const botId = String(createCatsCoLocalConfigService({ runtimeRoot: runtimeDataRoot() }).load().currentBot?.uid || '').trim();
+      // Before a bot is bound, .env remains the temporary onboarding staging
+      // area. Once it is bound, select the catalog model directly in its
+      // Definition instead of creating a transient second source of truth.
+      const settingsResult = botId
+        ? { updated: [], cleared: [] }
+        : writeRelayModelStartupConfig(selectedModel, ensured.plainKey, { reasoningEffort });
       let botDefinitionSync: Record<string, unknown> | undefined;
       if (botId) {
         definitionService.storeCatalogRuntime({
@@ -3243,6 +3424,11 @@ export function createApiRouter(
           contextWindowTokens: selectedModel.contextWindowTokens ?? 200_000,
           reasoningEffort,
           openaiApiMode: 'chat_completions',
+          capabilities: selectedModel.capabilities ? {
+            ...(selectedModel.capabilities.vision !== undefined ? { vision: selectedModel.capabilities.vision } : {}),
+            ...(selectedModel.capabilities.tool_calling !== undefined ? { toolCalling: selectedModel.capabilities.tool_calling } : {}),
+            ...(selectedModel.capabilities.streaming !== undefined ? { streaming: selectedModel.capabilities.streaming } : {}),
+          } : undefined,
         });
         botDefinitionSync = toBotDefinitionSyncPayload(
           definitionService.publish(botId, { kind: 'catalog', modelId: selectedModel.id }),

--- a/src/dashboard/settings.ts
+++ b/src/dashboard/settings.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as dotenv from 'dotenv';
-import type { OpenAIApiMode, ReasoningEffort } from '../types';
+import type { ChatConfig, OpenAIApiMode, ReasoningEffort } from '../types';
 import { REASONING_EFFORT_OPTIONS, normalizeReasoningEffort, reasoningEffortOrDefault } from '../utils/reasoning-effort';
 import { OPENAI_API_MODE_OPTIONS, openAIApiModeOrDefault } from '../utils/openai-api-mode';
 
@@ -70,6 +70,8 @@ export interface DashboardSettingsOptions {
   runtimeRoot?: string;
   env?: NodeJS.ProcessEnv;
   now?: Date;
+  /** The bound bot's resolved Definition config, when one is active. */
+  modelConfig?: Pick<ChatConfig, 'provider' | 'apiUrl' | 'apiKey' | 'model' | 'contextWindowTokens' | 'reasoningEffort' | 'openaiApiMode'>;
 }
 
 interface NormalizedSettingUpdate {
@@ -337,6 +339,44 @@ function buildModelStartupSnapshot(
   return { source, effective, custom, relay };
 }
 
+function modelConfigValue(
+  definition: DashboardSettingDefinition,
+  config: NonNullable<DashboardSettingsOptions['modelConfig']>,
+): string | undefined {
+  switch (definition.id) {
+    case 'model.provider': return config.provider;
+    case 'model.apiBase': return config.apiUrl;
+    case 'model.model': return config.model;
+    case 'model.contextWindowTokens': return config.contextWindowTokens ? String(config.contextWindowTokens) : undefined;
+    case 'model.reasoningEffort': return config.reasoningEffort;
+    case 'model.openaiApiMode': return config.openaiApiMode;
+    case 'model.apiKey': return config.apiKey;
+    default: return undefined;
+  }
+}
+
+function modelConfigSnapshot(
+  config: NonNullable<DashboardSettingsOptions['modelConfig']>,
+): DashboardModelStartupSnapshot {
+  const effective: DashboardModelProfileSnapshot = {
+    provider: config.provider,
+    apiBase: sanitizeUrlSettingValue(config.apiUrl ?? ''),
+    model: config.model,
+    contextWindowTokens: config.contextWindowTokens,
+    reasoningEffort: config.reasoningEffort ?? 'default',
+    openaiApiMode: config.openaiApiMode ?? 'chat_completions',
+    apiKeyPresent: Boolean(config.apiKey),
+    configured: Boolean(config.provider && config.apiUrl && config.model && config.apiKey),
+  };
+  const relay = isCatsRelayApiBase(config.apiUrl)
+    ? { ...effective, reasoningEffort: effective.reasoningEffort === 'default' ? 'high' as const : effective.reasoningEffort }
+    : { apiKeyPresent: false, configured: false };
+  const custom = isCatsRelayApiBase(config.apiUrl)
+    ? { apiKeyPresent: false, configured: false }
+    : effective;
+  return { source: isCatsRelayApiBase(config.apiUrl) ? 'relay' : 'custom', effective, custom, relay };
+}
+
 export function getDashboardSettings(
   options: DashboardSettingsOptions = {},
 ): DashboardSettingsSnapshot {
@@ -347,10 +387,14 @@ export function getDashboardSettings(
   return {
     runtimeRoot,
     generatedAt: (options.now ?? new Date()).toISOString(),
-    modelStartup: buildModelStartupSnapshot(fileEnv, env),
+    modelStartup: options.modelConfig
+      ? modelConfigSnapshot(options.modelConfig)
+      : buildModelStartupSnapshot(fileEnv, env),
     fields: DASHBOARD_SETTING_DEFINITIONS.map(definition => {
       const value = isModelSetting(definition.id)
-        ? modelSettingDisplayValue(definition, fileEnv, env)
+        ? options.modelConfig
+          ? modelConfigValue(definition, options.modelConfig)
+          : modelSettingDisplayValue(definition, fileEnv, env)
         : firstNonEmpty(fileEnv[definition.envKey], env[definition.envKey]);
       const common = {
         id: definition.id,

--- a/src/runtime/runtime-factory.ts
+++ b/src/runtime/runtime-factory.ts
@@ -2,6 +2,7 @@ import { AgentServices, AgentSession, SystemPromptProvider } from '../core/agent
 import { SkillManager } from '../skills/skill-manager';
 import { ToolManager } from '../tools/tool-manager';
 import { AIService } from '../utils/ai-service';
+import { resolveActiveBotLLMConfig } from '../bot-definition/llm-config-resolver';
 import { Logger } from '../utils/logger';
 import { PromptManager } from '../utils/prompt-manager';
 import { PromptComposer } from './prompt-composer';
@@ -63,8 +64,13 @@ export class RuntimeFactory {
   static createServicesSync(profile: RuntimeProfile): AgentServices {
     assertValidRuntimeProfile(profile);
 
+    // A per-surface runtime profile may still carry old model fields. Once a
+    // CatsCo bot is bound, let ConfigManager resolve its Definition instead of
+    // allowing that profile to override the bot identity.
+    const modelOverride = resolveActiveBotLLMConfig() ? {} : profile.model;
+
     return {
-      aiService: new AIService(profile.model),
+      aiService: new AIService(modelOverride),
       toolManager: new ToolManager(profile.workingDirectory, {}, {
         enabledToolNames: profile.tools.enabled,
       }),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -48,6 +48,12 @@ export interface ChatConfig {
   contextWindowTokens?: number;
   reasoningEffort?: ReasoningEffort;
   openaiApiMode?: OpenAIApiMode;
+  /** Capability facts supplied by the selected model catalog, when available. */
+  modelCapabilities?: {
+    vision?: boolean;
+    toolCalling?: boolean;
+    streaming?: boolean;
+  };
   provider?: 'openai' | 'anthropic';
   feishu?: {
     appId?: string;

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -175,9 +175,28 @@ export class ConfigManager {
     const resolved = resolveActiveBotLLMConfig({ runtimeRoot: PathResolver.getRuntimeDataRoot() });
     if (!resolved) return config;
     return {
-      ...config,
+      ...this.withoutModelConfig(config),
       ...resolved.config,
     };
+  }
+
+  /**
+   * Once a bot is bound, its Definition owns every model-affecting field.
+   * Keeping a legacy value here as a partial fallback would let one device's
+   * stale .env silently alter a different bot.
+   */
+  private static withoutModelConfig(config: ChatConfig): ChatConfig {
+    const next = { ...config };
+    delete next.apiKey;
+    delete next.apiUrl;
+    delete next.model;
+    delete next.provider;
+    delete next.temperature;
+    delete next.maxTokens;
+    delete next.contextWindowTokens;
+    delete next.reasoningEffort;
+    delete next.openaiApiMode;
+    return next;
   }
 
   private static parsePositiveIntegerEnv(...values: Array<string | undefined>): number | undefined {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -5,6 +5,8 @@ import * as dotenv from 'dotenv';
 import { ChatConfig } from '../types';
 import { normalizeReasoningEffort } from './reasoning-effort';
 import { normalizeOpenAIApiMode } from './openai-api-mode';
+import { resolveActiveBotLLMConfig } from '../bot-definition/llm-config-resolver';
+import { PathResolver } from './path-resolver';
 
 // 加载环境变量（静默模式）
 dotenv.config({ path: process.env.DOTENV_CONFIG_PATH || '.env', quiet: true });
@@ -64,17 +66,17 @@ export class ConfigManager {
 
   static getConfig(): ChatConfig {
     this.ensureConfigDir();
-    return this.mergeConfig(
+    return this.applyActiveBotDefinition(this.mergeConfig(
       this.mergeConfig(this.getDefaultConfig(), this.loadUserConfigFile()),
       this.getExplicitModelEnvConfig(),
-    );
+    ));
   }
 
   static getConfigReadonly(): ChatConfig {
-    return this.mergeConfig(
+    return this.applyActiveBotDefinition(this.mergeConfig(
       this.mergeConfig(this.getDefaultConfig(), this.loadUserConfigFile()),
       this.getExplicitModelEnvConfig(),
-    );
+    ));
   }
 
   static saveConfig(config: ChatConfig): void {
@@ -162,6 +164,20 @@ export class ConfigManager {
     }
 
     return override;
+  }
+
+  /**
+   * A bound bot resolves its model entirely from the local BotDefinition
+   * cache and (for catalog models) device-local relay material. Legacy .env
+   * remains only as a one-time migration source when that material is absent.
+   */
+  private static applyActiveBotDefinition(config: ChatConfig): ChatConfig {
+    const resolved = resolveActiveBotLLMConfig({ runtimeRoot: PathResolver.getRuntimeDataRoot() });
+    if (!resolved) return config;
+    return {
+      ...config,
+      ...resolved.config,
+    };
   }
 
   private static parsePositiveIntegerEnv(...values: Array<string | undefined>): number | undefined {

--- a/src/utils/model-capabilities.ts
+++ b/src/utils/model-capabilities.ts
@@ -32,23 +32,13 @@ function includesAny(value: string, patterns: RegExp[]): boolean {
   return patterns.some(pattern => pattern.test(value));
 }
 
-function optionalBooleanEnv(value: unknown): boolean | undefined {
-  if (typeof value === 'boolean') return value;
-  if (typeof value !== 'string') return undefined;
-  const text = value.trim().toLowerCase();
-  if (['true', '1', 'yes', 'y', 'on'].includes(text)) return true;
-  if (['false', '0', 'no', 'n', 'off'].includes(text)) return false;
-  return undefined;
-}
-
-export function isPrimaryModelVisionCapable(config: Pick<ChatConfig, 'apiUrl' | 'model' | 'provider'>): boolean {
+export function isPrimaryModelVisionCapable(config: Pick<ChatConfig, 'apiUrl' | 'model' | 'provider' | 'modelCapabilities'>): boolean {
+  if (config.modelCapabilities?.vision !== undefined) return config.modelCapabilities.vision;
   const apiUrl = (config.apiUrl || '').toLowerCase();
   const model = (config.model || '').trim();
   const modelKey = model.toLowerCase();
   const isRelay = apiUrl.includes('relay.catsco.cc');
   if (isRelay) {
-    const explicitRelayVision = optionalBooleanEnv(process.env.CATSCO_RELAY_LLM_VISION_CAPABLE);
-    if (explicitRelayVision !== undefined) return explicitRelayVision;
     const relayProfile = findRelayModelProfile(model);
     if (relayProfile) {
       return relayProfile.capabilities.vision;
@@ -67,11 +57,10 @@ export function isPrimaryModelVisionCapable(config: Pick<ChatConfig, 'apiUrl' | 
   return includesAny(model, KNOWN_VISION_MODEL_PATTERNS);
 }
 
-export function isPrimaryModelToolCallingCapable(config: Pick<ChatConfig, 'apiUrl' | 'model' | 'provider'>): boolean {
+export function isPrimaryModelToolCallingCapable(config: Pick<ChatConfig, 'apiUrl' | 'model' | 'provider' | 'modelCapabilities'>): boolean {
+  if (config.modelCapabilities?.toolCalling !== undefined) return config.modelCapabilities.toolCalling;
   const apiUrl = (config.apiUrl || '').toLowerCase();
   if (apiUrl.includes('relay.catsco.cc')) {
-    const explicitToolCalling = optionalBooleanEnv(process.env.CATSCO_RELAY_LLM_TOOL_CALLING_CAPABLE);
-    if (explicitToolCalling !== undefined) return explicitToolCalling;
     const relayProfile = findRelayModelProfile(config.model);
     if (relayProfile) {
       return relayProfile.capabilities.toolCalling;

--- a/src/utils/relay-model-profiles.ts
+++ b/src/utils/relay-model-profiles.ts
@@ -93,6 +93,28 @@ export function findRelayModelProfile(model: unknown): RelayModelProfile | undef
   ));
 }
 
+/**
+ * Catalog records persist this stable ID only. The relay-facing model spelling
+ * and the UI label are always derived from the profile at their use sites.
+ */
+export function canonicalRelayModelId(value: unknown): string | undefined {
+  const profile = findRelayModelProfile(value);
+  return profile?.id;
+}
+
+/**
+ * Old installations stored either the catalog ID or the relay-facing model
+ * name. Treat known aliases as one catalog model during migration.
+ */
+export function relayModelIdsMatch(left: unknown, right: unknown): boolean {
+  const leftProfile = findRelayModelProfile(left);
+  const rightProfile = findRelayModelProfile(right);
+  if (leftProfile || rightProfile) return leftProfile?.id === rightProfile?.id;
+  const normalizedLeft = normalizeModelName(left);
+  const normalizedRight = normalizeModelName(right);
+  return Boolean(normalizedLeft && normalizedRight && normalizedLeft === normalizedRight);
+}
+
 export function relayModelProviderBaseUrl(provider: RelayModelProvider): string {
   return RELAY_MODEL_BASE_URLS[provider];
 }

--- a/src/utils/relay-model-profiles.ts
+++ b/src/utils/relay-model-profiles.ts
@@ -78,6 +78,9 @@ export const RELAY_MODEL_PROFILES: RelayModelProfile[] = [
   },
 ];
 
+/** The first-run CatsCo model when the user has not chosen one yet. */
+export const DEFAULT_CATSCO_RELAY_MODEL_ID = 'minimax-m3';
+
 function normalizeModelName(value: unknown): string {
   return String(value || '').trim().toLowerCase();
 }

--- a/tests/bot-definition-activation.test.ts
+++ b/tests/bot-definition-activation.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { prepareBoundBotDefinition } from '../src/bot-definition/activation';
+import { createCatsCoLocalConfigService } from '../src/catscompany/local-config';
+import { FileBotCatalogModelRuntimeRepository, FileBotDefinitionRepository } from '../src/bot-definition/repository';
+import { resolveActiveBotLLMConfig } from '../src/bot-definition/llm-config-resolver';
+import { BOT_DEFINITION_SCHEMA } from '../src/bot-definition/types';
+
+describe('BotDefinition activation', () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('materializes the selected catalog model before connector preflight instead of mixing stale legacy material', async () => {
+    const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-definition-activation-runtime-'));
+    const simulatedCloudRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-definition-activation-cloud-'));
+    roots.push(runtimeRoot, simulatedCloudRoot);
+    const env = {
+      CATSCO_MODEL_SOURCE: 'relay',
+      CATSCO_RELAY_LLM_PROVIDER: 'anthropic',
+      CATSCO_RELAY_LLM_API_BASE: 'https://relay.example.test/anthropic',
+      CATSCO_RELAY_LLM_MODEL: 'deepseek-v4-flash',
+      CATSCO_RELAY_LLM_API_KEY: 'sk-stale-deepseek-material',
+    } as NodeJS.ProcessEnv;
+
+    createCatsCoLocalConfigService({ runtimeRoot, env }).save({
+      version: 1,
+      endpoints: {
+        httpBaseUrl: 'https://cats.example.test',
+        serverUrl: 'wss://cats.example.test/v0/channels',
+      },
+      account: { token: 'user-token', uid: 'user-1', displayName: 'Alice' },
+      currentBot: {
+        uid: 'bot-bravo',
+        apiKey: 'bot-bravo-key',
+        boundByUserUid: 'user-1',
+        bindingSource: 'test',
+      },
+      device: { deviceId: 'device-1', bodyId: 'body-1', installationId: 'install-1' },
+    });
+    new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot }).writeCanonical({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-bravo',
+      model: { kind: 'catalog', modelId: 'minimax-m3' },
+    });
+
+    const requests: string[] = [];
+    const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(String(input));
+      requests.push(`${init?.method || 'GET'} ${url.pathname}`);
+      if (url.pathname === '/api/relay/config') {
+        return Response.json({
+          self_service_enabled: true,
+          base_url: 'https://relay.example.test',
+          endpoints: [{ protocol: 'Anthropic-compatible', base_url: 'https://relay.example.test/anthropic' }],
+        });
+      }
+      if (url.pathname === '/api/relay/key') {
+        return Response.json({ key: { state: 'active', key: 'sk-bravo-relay-material' } });
+      }
+      return Response.json({ error: 'unexpected request' }, { status: 500 });
+    }) as typeof fetch;
+
+    const prepared = await prepareBoundBotDefinition({
+      runtimeRoot,
+      simulatedCloudRoot,
+      env,
+      fetchImpl,
+    });
+
+    assert.equal(prepared?.botId, 'bot-bravo');
+    assert.equal(prepared?.materializedCatalogRuntime, true);
+    const runtime = new FileBotCatalogModelRuntimeRepository({ runtimeRoot }).read('bot-bravo');
+    assert.equal(runtime?.modelId, 'minimax-m3');
+    assert.equal(runtime?.model, 'MiniMax-M3');
+    assert.equal(runtime?.apiKey, 'sk-bravo-relay-material');
+    assert.equal(resolveActiveBotLLMConfig({ runtimeRoot, env })?.config.model, 'MiniMax-M3');
+    assert.equal(resolveActiveBotLLMConfig({ runtimeRoot, env })?.config.apiKey, 'sk-bravo-relay-material');
+    assert.equal(env.CATSCO_RELAY_LLM_API_KEY, undefined);
+    assert.deepStrictEqual(requests, [
+      'GET /api/relay/config',
+      'GET /api/relay/key',
+    ]);
+  });
+});

--- a/tests/bot-definition-local-repository.test.ts
+++ b/tests/bot-definition-local-repository.test.ts
@@ -289,6 +289,29 @@ describe('BotDefinition local simulation', () => {
     assert.equal(second?.config.apiKey, 'sk-legacy-relay-material');
   });
 
+  test('normalizes a relay-facing legacy model name to the catalog id during migration', () => {
+    bindCurrentBot();
+    new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot }).writeCanonical({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-alpha',
+      model: { kind: 'catalog', modelId: 'minimax-m3' },
+    });
+    const env = {
+      CATSCO_MODEL_SOURCE: 'relay',
+      CATSCO_RELAY_LLM_PROVIDER: 'anthropic',
+      CATSCO_RELAY_LLM_API_BASE: 'https://relay.example.test/anthropic',
+      CATSCO_RELAY_LLM_MODEL: 'MiniMax-M3',
+      CATSCO_RELAY_LLM_API_KEY: 'sk-minimax-legacy-material',
+    } as NodeJS.ProcessEnv;
+
+    createBotDefinitionSyncService({ runtimeRoot, simulatedCloudRoot, env }).pullOrBootstrap('bot-alpha');
+
+    const runtime = new FileBotCatalogModelRuntimeRepository({ runtimeRoot }).read('bot-alpha');
+    assert.equal(runtime?.modelId, 'minimax-m3');
+    assert.equal(runtime?.model, 'MiniMax-M3');
+    assert.equal(resolveActiveBotLLMConfig({ runtimeRoot, env })?.config.apiKey, 'sk-minimax-legacy-material');
+  });
+
   test('does not attach a stale legacy relay profile to a different catalog model', () => {
     bindCurrentBot();
     new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot }).writeCanonical({

--- a/tests/bot-definition-local-repository.test.ts
+++ b/tests/bot-definition-local-repository.test.ts
@@ -31,14 +31,19 @@ const managedEnvKeys = [
   'CATSCO_CUSTOM_LLM_OPENAI_API_MODE',
   'CATSCO_RELAY_LLM_MODEL',
   'CATSCO_RELAY_LLM_API_BASE',
+  'CATSCO_RELAY_LLM_API_KEY',
+  'CATSCO_RELAY_LLM_VISION_CAPABLE',
+  'CATSCO_RELAY_LLM_TOOL_CALLING_CAPABLE',
   'GAUZ_LLM_PROVIDER',
   'GAUZ_LLM_API_BASE',
   'GAUZ_LLM_API_KEY',
   'GAUZ_LLM_MODEL',
   'GAUZ_LLM_CONTEXT_WINDOW_TOKENS',
   'GAUZ_LLM_CONTEXT_TOKENS',
+  'GAUZ_LLM_TEMPERATURE',
   'GAUZ_LLM_REASONING_EFFORT',
   'GAUZ_LLM_OPENAI_API_MODE',
+  'XIAOBA_CONFIG_PATH',
 ];
 
 describe('BotDefinition local simulation', () => {
@@ -95,7 +100,7 @@ describe('BotDefinition local simulation', () => {
     const service = createBotDefinitionSyncService({ runtimeRoot, simulatedCloudRoot, env });
 
     const result = service.publishCurrentBoundBot();
-    assert.equal(result?.direction, 'local_to_simulated_cloud');
+    assert.equal(result?.direction, 'bootstrap_to_simulated_cloud');
     assert.deepStrictEqual(result?.definition.model, {
       kind: 'custom',
       protocol: 'anthropic',
@@ -245,7 +250,7 @@ describe('BotDefinition local simulation', () => {
     assert.equal(config.reasoningEffort, 'high');
   });
 
-  test('catalog runtime performs a one-time migration from legacy relay values', () => {
+  test('catalog runtime performs a one-time migration only when the legacy model matches the Definition', () => {
     bindCurrentBot();
     new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot }).writeCache({
       schema: BOT_DEFINITION_SCHEMA,
@@ -256,18 +261,23 @@ describe('BotDefinition local simulation', () => {
       CATSCO_MODEL_SOURCE: 'relay',
       CATSCO_RELAY_LLM_PROVIDER: 'anthropic',
       CATSCO_RELAY_LLM_API_BASE: 'https://relay.example.test/anthropic',
-      CATSCO_RELAY_LLM_MODEL: 'gpt-5-catalog-runtime',
+      CATSCO_RELAY_LLM_MODEL: 'catalog-gpt-5',
       CATSCO_RELAY_LLM_API_KEY: 'sk-legacy-relay-material',
       CATSCO_RELAY_LLM_CONTEXT_WINDOW_TOKENS: '272000',
       CATSCO_RELAY_LLM_REASONING_EFFORT: 'high',
+      CATSCO_RELAY_LLM_VISION_CAPABLE: 'false',
+      CATSCO_RELAY_LLM_TOOL_CALLING_CAPABLE: 'true',
     } as NodeJS.ProcessEnv;
 
+    createBotDefinitionSyncService({ runtimeRoot, simulatedCloudRoot, env }).pullOrBootstrap('bot-alpha');
     const first = resolveActiveBotLLMConfig({ runtimeRoot, env });
     assert.equal(first?.source, 'catalog_runtime');
     assert.equal(first?.config.apiKey, 'sk-legacy-relay-material');
+    assert.deepStrictEqual(first?.config.modelCapabilities, { vision: false, toolCalling: true });
     const stored = new FileBotCatalogModelRuntimeRepository({ runtimeRoot }).read('bot-alpha');
     assert.equal(stored?.modelId, 'catalog-gpt-5');
     assert.equal(stored?.apiKey, 'sk-legacy-relay-material');
+    assert.deepStrictEqual(stored?.capabilities, { vision: false, toolCalling: true });
 
     const second = resolveActiveBotLLMConfig({
       runtimeRoot,
@@ -277,5 +287,73 @@ describe('BotDefinition local simulation', () => {
       } as NodeJS.ProcessEnv,
     });
     assert.equal(second?.config.apiKey, 'sk-legacy-relay-material');
+  });
+
+  test('does not attach a stale legacy relay profile to a different catalog model', () => {
+    bindCurrentBot();
+    new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot }).writeCanonical({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-alpha',
+      model: { kind: 'catalog', modelId: 'current-catalog-model' },
+    });
+    const env = {
+      CATSCO_MODEL_SOURCE: 'relay',
+      CATSCO_RELAY_LLM_PROVIDER: 'anthropic',
+      CATSCO_RELAY_LLM_API_BASE: 'https://relay.example.test/anthropic',
+      CATSCO_RELAY_LLM_MODEL: 'stale-catalog-model',
+      CATSCO_RELAY_LLM_API_KEY: 'sk-stale-relay-material',
+    } as NodeJS.ProcessEnv;
+
+    createBotDefinitionSyncService({ runtimeRoot, simulatedCloudRoot, env }).pullOrBootstrap('bot-alpha');
+
+    assert.equal(new FileBotCatalogModelRuntimeRepository({ runtimeRoot }).read('bot-alpha'), undefined);
+    assert.equal(resolveActiveBotLLMConfig({ runtimeRoot, env }), undefined);
+  });
+
+  test('captures legacy model settings once, then removes only model keys', () => {
+    bindCurrentBot();
+    const configPath = path.join(runtimeRoot, 'legacy-config.json');
+    fs.writeFileSync(path.join(runtimeRoot, '.env'), [
+      'CATSCO_USER_TOKEN=user-token-must-remain',
+      'CATSCO_MODEL_SOURCE=custom',
+      'CATSCO_CUSTOM_LLM_PROVIDER=openai',
+      'CATSCO_CUSTOM_LLM_API_BASE=https://models.example.test/v1',
+      'CATSCO_CUSTOM_LLM_MODEL=portable-model',
+      'CATSCO_CUSTOM_LLM_API_KEY=sk-portable',
+      'CATSCO_CUSTOM_LLM_CONTEXT_WINDOW_TOKENS=272000',
+      'GAUZ_LLM_TEMPERATURE=0.2',
+      '',
+    ].join('\n'));
+    fs.writeFileSync(configPath, JSON.stringify({
+      apiKey: 'stale-config-key',
+      model: 'stale-config-model',
+      catscompany: { enabled: true },
+    }));
+    const env = {
+      XIAOBA_CONFIG_PATH: configPath,
+      CATSCO_MODEL_SOURCE: 'custom',
+      CATSCO_CUSTOM_LLM_PROVIDER: 'openai',
+      CATSCO_CUSTOM_LLM_API_BASE: 'https://models.example.test/v1',
+      CATSCO_CUSTOM_LLM_MODEL: 'portable-model',
+      CATSCO_CUSTOM_LLM_API_KEY: 'sk-portable',
+      CATSCO_CUSTOM_LLM_CONTEXT_WINDOW_TOKENS: '272000',
+      GAUZ_LLM_TEMPERATURE: '0.2',
+    } as NodeJS.ProcessEnv;
+
+    const result = createBotDefinitionSyncService({ runtimeRoot, simulatedCloudRoot, env })
+      .pullOrBootstrapCurrentBoundBot();
+
+    assert.equal(result?.definition.model.kind, 'custom');
+    if (result?.definition.model.kind === 'custom') {
+      assert.equal(result.definition.model.temperature, 0.2);
+    }
+    const envContents = fs.readFileSync(path.join(runtimeRoot, '.env'), 'utf-8');
+    assert.match(envContents, /CATSCO_USER_TOKEN=user-token-must-remain/);
+    assert.doesNotMatch(envContents, /CATSCO_(MODEL_SOURCE|CUSTOM_LLM_)|GAUZ_LLM_/);
+    assert.equal(env.CATSCO_CUSTOM_LLM_API_KEY, undefined);
+    const cleanedConfig = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    assert.equal(cleanedConfig.apiKey, undefined);
+    assert.equal(cleanedConfig.model, undefined);
+    assert.deepStrictEqual(cleanedConfig.catscompany, { enabled: true });
   });
 });

--- a/tests/bot-definition-local-repository.test.ts
+++ b/tests/bot-definition-local-repository.test.ts
@@ -312,6 +312,30 @@ describe('BotDefinition local simulation', () => {
     assert.equal(resolveActiveBotLLMConfig({ runtimeRoot, env })?.config.apiKey, 'sk-minimax-legacy-material');
   });
 
+  test('normalizes an existing catalog runtime alias when it is read', () => {
+    const runtimeRepository = new FileBotCatalogModelRuntimeRepository({ runtimeRoot });
+    runtimeRepository.write({
+      schema: BOT_CATALOG_MODEL_RUNTIME_SCHEMA,
+      botId: 'bot-alpha',
+      modelId: 'MiniMax-M3',
+      provider: 'anthropic',
+      apiBase: 'https://relay.example.test/anthropic',
+      apiKey: 'sk-minimax-legacy-runtime',
+      model: 'MiniMax-M3',
+      contextWindowTokens: 200000,
+      reasoningEffort: 'high',
+    });
+
+    const runtime = createBotDefinitionSyncService({ runtimeRoot, simulatedCloudRoot })
+      .readCatalogRuntime('bot-alpha');
+    const persisted = runtimeRepository.read('bot-alpha');
+
+    assert.equal(runtime?.modelId, 'minimax-m3');
+    assert.equal(runtime?.model, 'MiniMax-M3');
+    assert.equal(persisted?.modelId, 'minimax-m3');
+    assert.equal(persisted?.model, 'MiniMax-M3');
+  });
+
   test('does not attach a stale legacy relay profile to a different catalog model', () => {
     bindCurrentBot();
     new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot }).writeCanonical({

--- a/tests/bot-definition-local-repository.test.ts
+++ b/tests/bot-definition-local-repository.test.ts
@@ -1,0 +1,281 @@
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { createCatsCoLocalConfigService } from '../src/catscompany/local-config';
+import { ConfigManager } from '../src/utils/config';
+import { FileBotCatalogModelRuntimeRepository, FileBotDefinitionRepository } from '../src/bot-definition/repository';
+import { resolveActiveBotLLMConfig } from '../src/bot-definition/llm-config-resolver';
+import {
+  botModelDefinitionFromLocalProfile,
+  createBotDefinitionSyncService,
+  readLocalModelProfile,
+} from '../src/bot-definition/service';
+import {
+  BOT_CATALOG_MODEL_RUNTIME_SCHEMA,
+  BOT_DEFINITION_SCHEMA,
+  type BotDefinition,
+} from '../src/bot-definition/types';
+
+const managedEnvKeys = [
+  'XIAOBA_USER_DATA_DIR',
+  'XIAOBA_BOT_DEFINITION_SIMULATED_CLOUD_DIR',
+  'CATSCO_MODEL_SOURCE',
+  'CATSCO_CUSTOM_LLM_PROVIDER',
+  'CATSCO_CUSTOM_LLM_API_BASE',
+  'CATSCO_CUSTOM_LLM_MODEL',
+  'CATSCO_CUSTOM_LLM_API_KEY',
+  'CATSCO_CUSTOM_LLM_CONTEXT_WINDOW_TOKENS',
+  'CATSCO_CUSTOM_LLM_REASONING_EFFORT',
+  'CATSCO_CUSTOM_LLM_OPENAI_API_MODE',
+  'CATSCO_RELAY_LLM_MODEL',
+  'CATSCO_RELAY_LLM_API_BASE',
+  'GAUZ_LLM_PROVIDER',
+  'GAUZ_LLM_API_BASE',
+  'GAUZ_LLM_API_KEY',
+  'GAUZ_LLM_MODEL',
+  'GAUZ_LLM_CONTEXT_WINDOW_TOKENS',
+  'GAUZ_LLM_CONTEXT_TOKENS',
+  'GAUZ_LLM_REASONING_EFFORT',
+  'GAUZ_LLM_OPENAI_API_MODE',
+];
+
+describe('BotDefinition local simulation', () => {
+  let runtimeRoot: string;
+  let simulatedCloudRoot: string;
+  let originalEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-bot-definition-runtime-'));
+    simulatedCloudRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-bot-definition-cloud-'));
+    originalEnv = {};
+    for (const key of managedEnvKeys) {
+      originalEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of managedEnvKeys) {
+      if (originalEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = originalEnv[key];
+    }
+    fs.rmSync(runtimeRoot, { recursive: true, force: true });
+    fs.rmSync(simulatedCloudRoot, { recursive: true, force: true });
+  });
+
+  function bindCurrentBot(botId = 'bot-alpha'): void {
+    createCatsCoLocalConfigService({ runtimeRoot, env: {} as NodeJS.ProcessEnv }).save({
+      version: 1,
+      currentBot: {
+        uid: botId,
+        apiKey: 'bot-api-key',
+        boundByUserUid: 'user-alpha',
+        bindingSource: 'test',
+      },
+      device: {
+        deviceId: 'device-alpha',
+        bodyId: 'body-alpha',
+        installationId: 'install-alpha',
+      },
+    });
+  }
+
+  test('publishes a custom model on local change and refreshes the local cache', () => {
+    bindCurrentBot();
+    const env = {
+      CATSCO_MODEL_SOURCE: 'custom',
+      CATSCO_CUSTOM_LLM_PROVIDER: 'anthropic',
+      CATSCO_CUSTOM_LLM_API_BASE: 'https://models.example.test/v1/messages',
+      CATSCO_CUSTOM_LLM_MODEL: 'claude-custom',
+      CATSCO_CUSTOM_LLM_API_KEY: 'sk-custom-secret',
+      CATSCO_CUSTOM_LLM_CONTEXT_WINDOW_TOKENS: '272000',
+    } as NodeJS.ProcessEnv;
+    const service = createBotDefinitionSyncService({ runtimeRoot, simulatedCloudRoot, env });
+
+    const result = service.publishCurrentBoundBot();
+    assert.equal(result?.direction, 'local_to_simulated_cloud');
+    assert.deepStrictEqual(result?.definition.model, {
+      kind: 'custom',
+      protocol: 'anthropic',
+      apiBase: 'https://models.example.test/v1/messages',
+      model: 'claude-custom',
+      apiKey: 'sk-custom-secret',
+      contextWindowTokens: 272000,
+    });
+
+    const repository = new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot });
+    assert.deepStrictEqual(repository.readCanonical('bot-alpha'), result?.definition);
+    assert.deepStrictEqual(repository.readCache('bot-alpha'), result?.definition);
+  });
+
+  test('pull uses canonical data over stale cache and does not overwrite canonical data', () => {
+    const repository = new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot });
+    const canonical: BotDefinition = {
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-alpha',
+      model: { kind: 'catalog', modelId: 'gpt-5.6-terra' },
+    };
+    repository.writeCanonical(canonical);
+    repository.writeCache({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-alpha',
+      model: { kind: 'catalog', modelId: 'old-model' },
+    });
+    const service = createBotDefinitionSyncService({ runtimeRoot, simulatedCloudRoot });
+
+    const result = service.pullOrBootstrap('bot-alpha');
+    assert.equal(result?.direction, 'simulated_cloud_to_local');
+    assert.deepStrictEqual(result?.definition, canonical);
+    assert.deepStrictEqual(repository.readCanonical('bot-alpha'), canonical);
+    assert.deepStrictEqual(repository.readCache('bot-alpha'), canonical);
+  });
+
+  test('ignores a malformed canonical record instead of applying a partial model', () => {
+    const repository = new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot });
+    const canonicalPath = repository.getCanonicalPath('bot-alpha');
+    fs.mkdirSync(path.dirname(canonicalPath), { recursive: true });
+    fs.writeFileSync(canonicalPath, JSON.stringify({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-alpha',
+      model: { kind: 'custom', model: 'missing-required-fields' },
+    }));
+
+    assert.equal(repository.readCanonical('bot-alpha'), undefined);
+  });
+
+  test('catalog definition stores only the model identifier', () => {
+    const profile = readLocalModelProfile(runtimeRoot, {
+      CATSCO_MODEL_SOURCE: 'relay',
+      CATSCO_RELAY_LLM_MODEL: 'gpt-5.6-terra',
+      CATSCO_RELAY_LLM_API_KEY: 'sk-relay-key-not-in-definition',
+    } as NodeJS.ProcessEnv);
+    assert.deepStrictEqual(botModelDefinitionFromLocalProfile(profile!), {
+      kind: 'catalog',
+      modelId: 'gpt-5.6-terra',
+    });
+  });
+
+  test('explicit custom source remains custom even when it uses a relay gateway URL', () => {
+    const profile = readLocalModelProfile(runtimeRoot, {
+      CATSCO_MODEL_SOURCE: 'custom',
+      CATSCO_CUSTOM_LLM_PROVIDER: 'openai',
+      CATSCO_CUSTOM_LLM_API_BASE: 'https://relay.catsco.cc/v1',
+      CATSCO_CUSTOM_LLM_MODEL: 'third-party-model',
+      CATSCO_CUSTOM_LLM_API_KEY: 'sk-third-party-key',
+      CATSCO_CUSTOM_LLM_CONTEXT_WINDOW_TOKENS: '200000',
+    } as NodeJS.ProcessEnv);
+    assert.deepStrictEqual(botModelDefinitionFromLocalProfile(profile!), {
+      kind: 'custom',
+      protocol: 'openai-chat-completions',
+      apiBase: 'https://relay.catsco.cc/v1',
+      model: 'third-party-model',
+      apiKey: 'sk-third-party-key',
+      contextWindowTokens: 200000,
+    });
+  });
+
+  test('cached custom definition overrides stale legacy model variables at runtime', () => {
+    bindCurrentBot();
+    const repository = new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot });
+    const definition: BotDefinition = {
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-alpha',
+      model: {
+        kind: 'custom',
+        protocol: 'openai-responses',
+        apiBase: 'https://new-model.example.test/v1',
+        model: 'gpt-new',
+        apiKey: 'sk-new-secret',
+        contextWindowTokens: 272000,
+        reasoningEffort: 'high',
+      },
+    };
+    repository.writeCache(definition);
+    process.env.XIAOBA_USER_DATA_DIR = runtimeRoot;
+    process.env.GAUZ_LLM_PROVIDER = 'anthropic';
+    process.env.GAUZ_LLM_API_BASE = 'https://stale.example.test/v1';
+    process.env.GAUZ_LLM_MODEL = 'stale-model';
+    process.env.GAUZ_LLM_API_KEY = 'stale-key';
+
+    const config = ConfigManager.getConfigReadonly();
+    assert.equal(config.provider, 'openai');
+    assert.equal(config.apiUrl, 'https://new-model.example.test/v1');
+    assert.equal(config.model, 'gpt-new');
+    assert.equal(config.apiKey, 'sk-new-secret');
+    assert.equal(config.contextWindowTokens, 272000);
+    assert.equal(config.openaiApiMode, 'responses');
+    assert.equal(config.reasoningEffort, 'high');
+
+  });
+
+  test('cached catalog runtime overrides stale legacy environment variables at runtime', () => {
+    bindCurrentBot();
+    const definitions = new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot });
+    definitions.writeCache({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-alpha',
+      model: { kind: 'catalog', modelId: 'catalog-gpt-5' },
+    });
+    new FileBotCatalogModelRuntimeRepository({ runtimeRoot }).write({
+      schema: BOT_CATALOG_MODEL_RUNTIME_SCHEMA,
+      botId: 'bot-alpha',
+      modelId: 'catalog-gpt-5',
+      provider: 'anthropic',
+      apiBase: 'https://relay.example.test/anthropic',
+      apiKey: 'sk-device-relay-material',
+      model: 'gpt-5-catalog-runtime',
+      contextWindowTokens: 272000,
+      reasoningEffort: 'high',
+      openaiApiMode: 'chat_completions',
+    });
+    process.env.XIAOBA_USER_DATA_DIR = runtimeRoot;
+    process.env.GAUZ_LLM_PROVIDER = 'openai';
+    process.env.GAUZ_LLM_API_BASE = 'https://stale.example.test/v1';
+    process.env.GAUZ_LLM_MODEL = 'stale-model';
+    process.env.GAUZ_LLM_API_KEY = 'stale-key';
+
+    const config = ConfigManager.getConfigReadonly();
+    assert.equal(config.provider, 'anthropic');
+    assert.equal(config.apiUrl, 'https://relay.example.test/anthropic');
+    assert.equal(config.model, 'gpt-5-catalog-runtime');
+    assert.equal(config.apiKey, 'sk-device-relay-material');
+    assert.equal(config.contextWindowTokens, 272000);
+    assert.equal(config.reasoningEffort, 'high');
+  });
+
+  test('catalog runtime performs a one-time migration from legacy relay values', () => {
+    bindCurrentBot();
+    new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot }).writeCache({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-alpha',
+      model: { kind: 'catalog', modelId: 'catalog-gpt-5' },
+    });
+    const env = {
+      CATSCO_MODEL_SOURCE: 'relay',
+      CATSCO_RELAY_LLM_PROVIDER: 'anthropic',
+      CATSCO_RELAY_LLM_API_BASE: 'https://relay.example.test/anthropic',
+      CATSCO_RELAY_LLM_MODEL: 'gpt-5-catalog-runtime',
+      CATSCO_RELAY_LLM_API_KEY: 'sk-legacy-relay-material',
+      CATSCO_RELAY_LLM_CONTEXT_WINDOW_TOKENS: '272000',
+      CATSCO_RELAY_LLM_REASONING_EFFORT: 'high',
+    } as NodeJS.ProcessEnv;
+
+    const first = resolveActiveBotLLMConfig({ runtimeRoot, env });
+    assert.equal(first?.source, 'catalog_runtime');
+    assert.equal(first?.config.apiKey, 'sk-legacy-relay-material');
+    const stored = new FileBotCatalogModelRuntimeRepository({ runtimeRoot }).read('bot-alpha');
+    assert.equal(stored?.modelId, 'catalog-gpt-5');
+    assert.equal(stored?.apiKey, 'sk-legacy-relay-material');
+
+    const second = resolveActiveBotLLMConfig({
+      runtimeRoot,
+      env: {
+        ...env,
+        CATSCO_RELAY_LLM_API_KEY: 'sk-stale-after-migration',
+      } as NodeJS.ProcessEnv,
+    });
+    assert.equal(second?.config.apiKey, 'sk-legacy-relay-material');
+  });
+});

--- a/tests/catsco-command-config.test.ts
+++ b/tests/catsco-command-config.test.ts
@@ -10,6 +10,7 @@ import { createCatsCoLocalConfigService } from '../src/catscompany/local-config'
 describe('CatsCo command config resolution', () => {
   let tempDir: string;
   let originalCwd: string;
+  let originalRuntimeRoot: string | undefined;
 
   const baseConfig: ChatConfig = {
     catscompany: {
@@ -22,12 +23,18 @@ describe('CatsCo command config resolution', () => {
 
   beforeEach(() => {
     originalCwd = process.cwd();
+    originalRuntimeRoot = process.env.XIAOBA_RUNTIME_ROOT;
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'catsco-command-config-'));
     process.chdir(tempDir);
   });
 
   afterEach(() => {
     process.chdir(originalCwd);
+    if (originalRuntimeRoot === undefined) {
+      delete process.env.XIAOBA_RUNTIME_ROOT;
+    } else {
+      process.env.XIAOBA_RUNTIME_ROOT = originalRuntimeRoot;
+    }
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
@@ -83,8 +90,25 @@ describe('CatsCo command config resolution', () => {
     assert.equal(resolved.config, undefined);
   });
 
-  function saveConfirmedBinding(): void {
-    createCatsCoLocalConfigService({ runtimeRoot: tempDir }).save({
+  test('uses the explicit runtime data root for CatsCo binding and model resolution', () => {
+    const runtimeRoot = path.join(tempDir, 'runtime-data');
+    process.env.XIAOBA_RUNTIME_ROOT = runtimeRoot;
+    saveConfirmedBinding(runtimeRoot);
+
+    const resolved = resolveCatsCoCommandConfig({}, {
+      CATSCO_USER_TOKEN: 'env-token',
+      CATSCO_USER_UID: 'user-1',
+      CATSCO_SERVER_URL: 'wss://catsco.example/v0/channels',
+      CATSCO_API_KEY: 'catsco-key',
+    });
+
+    assert.deepEqual(resolved.missing, []);
+    assert.equal(resolved.config?.apiKey, 'local-bot-key');
+    assert.equal(resolved.config?.bodyId, 'body-local');
+  });
+
+  function saveConfirmedBinding(runtimeRoot = tempDir): void {
+    createCatsCoLocalConfigService({ runtimeRoot }).save({
       version: 1,
       endpoints: {
         httpBaseUrl: 'https://local.example',

--- a/tests/catscompany-device-rpc-tools.test.ts
+++ b/tests/catscompany-device-rpc-tools.test.ts
@@ -326,7 +326,7 @@ describe('CatsCompany Device RPC file tools', () => {
       request_id: 'rpc-shell-1',
       operation: 'execute_shell',
       tool_name: 'execute_shell',
-      payload: { args: { command: 'node -e "console.log(\'rpc-shell-ok\')"' } },
+      payload: { args: { command: `& "${process.execPath}" -e "console.log('rpc-shell-ok')"` } },
     }));
 
     assert.ok(captured.result);

--- a/tests/catscompany-device-rpc-tools.test.ts
+++ b/tests/catscompany-device-rpc-tools.test.ts
@@ -321,12 +321,15 @@ describe('CatsCompany Device RPC file tools', () => {
   test('executes shell Device RPC operations on the selected local device', async () => {
     const captured: { result?: any } = {};
     const bot = botWithDevice(captured);
+    const command = process.platform === 'win32'
+      ? `& "${process.execPath}" -e "console.log('rpc-shell-ok')"`
+      : `"${process.execPath}" -e "console.log('rpc-shell-ok')"`;
 
     await bot.handleDeviceRpcRequest(request({
       request_id: 'rpc-shell-1',
       operation: 'execute_shell',
       tool_name: 'execute_shell',
-      payload: { args: { command: `& "${process.execPath}" -e "console.log('rpc-shell-ok')"` } },
+      payload: { args: { command } },
     }));
 
     assert.ok(captured.result);

--- a/tests/catscompany-relay-model-bootstrap.test.ts
+++ b/tests/catscompany-relay-model-bootstrap.test.ts
@@ -1,0 +1,52 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import { provisionCatsRelayCatalogRuntime } from '../src/catscompany/relay-model-bootstrap';
+
+describe('CatsCo default relay model bootstrap', () => {
+  test('materializes MiniMax M3 and creates a relay key for a fresh device', async () => {
+    const requests: Array<{ path: string; method?: string }> = [];
+    const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(String(input));
+      requests.push({ path: url.pathname, method: init?.method });
+      if (url.pathname === '/api/relay/config') {
+        return Response.json({
+          base_url: 'https://relay.example.test',
+          self_service_enabled: true,
+          endpoints: [{ protocol: 'Anthropic-compatible', base_url: 'https://relay.example.test/anthropic' }],
+        });
+      }
+      if (url.pathname === '/api/relay/key' && init?.method === 'GET') {
+        return Response.json({ configured: false });
+      }
+      if (url.pathname === '/api/relay/key' && init?.method === 'POST') {
+        return Response.json({ key: { key: 'sk-fresh-device-relay-key' } });
+      }
+      return new Response(JSON.stringify({ error: 'unexpected request' }), { status: 500 });
+    }) as typeof fetch;
+
+    const runtime = await provisionCatsRelayCatalogRuntime({
+      botId: 'bot-1',
+      modelId: 'minimax-m3',
+      auth: {
+        token: 'user-token',
+        uid: 'user-1',
+        displayName: 'Alice',
+        httpBaseUrl: 'https://cats.example.test',
+        serverUrl: 'wss://cats.example.test/v0/channels',
+      },
+      fetchImpl,
+    });
+
+    assert.equal(runtime.modelId, 'minimax-m3');
+    assert.equal(runtime.model, 'MiniMax-M3');
+    assert.equal(runtime.provider, 'anthropic');
+    assert.equal(runtime.apiBase, 'https://relay.example.test/anthropic');
+    assert.equal(runtime.contextWindowTokens, 1_000_000);
+    assert.equal(runtime.apiKey, 'sk-fresh-device-relay-key');
+    assert.deepStrictEqual(requests, [
+      { path: '/api/relay/config', method: 'GET' },
+      { path: '/api/relay/key', method: 'GET' },
+      { path: '/api/relay/key', method: 'POST' },
+    ]);
+  });
+});

--- a/tests/dashboard-catsco-auth-status.test.ts
+++ b/tests/dashboard-catsco-auth-status.test.ts
@@ -8,7 +8,8 @@ import express from 'express';
 import type { Server } from 'http';
 import { createApiRouter } from '../src/dashboard/routes/api';
 import { createCatsCoLocalConfigService } from '../src/catscompany/local-config';
-import { FileBotCatalogModelRuntimeRepository } from '../src/bot-definition/repository';
+import { FileBotCatalogModelRuntimeRepository, FileBotDefinitionRepository } from '../src/bot-definition/repository';
+import { BOT_CATALOG_MODEL_RUNTIME_SCHEMA, BOT_DEFINITION_SCHEMA } from '../src/bot-definition/types';
 
 describe('dashboard CatsCo account status', () => {
   let testRoot: string;
@@ -656,6 +657,135 @@ describe('dashboard CatsCo account status', () => {
     assert.equal(env.CATSCO_BOT_UID, '199');
     assert.equal(env.CATSCO_API_KEY, 'last-agent-key');
     assert.equal(createBotCalls, 0);
+  });
+
+  test('POST /cats/bind-bot restores the active binding when target preflight is blocked', async () => {
+    if (dashboardServer) {
+      await close(dashboardServer);
+      dashboardServer = undefined;
+    }
+
+    const service = {
+      name: 'catscompany',
+      label: 'CatsCo agent',
+      command: 'xiaoba-command-that-does-not-exist',
+      args: [],
+      status: 'running',
+    };
+    let restartCalled = 0;
+    const dashboardApp = express();
+    dashboardApp.use(express.json());
+    dashboardApp.use('/api', createApiRouter({
+      getAll: () => [service],
+      getService: (name: string) => (name === 'catscompany' ? service : undefined),
+      restart: () => {
+        restartCalled += 1;
+        return service;
+      },
+    } as any));
+    dashboardServer = await listen(dashboardApp);
+    dashboardBaseUrl = serverBaseUrl(dashboardServer);
+
+    await startCatsServer((req, res) => {
+      if (req.path === '/api/me') {
+        return res.json({ uid: 88, username: 'fresh', display_name: 'Fresh User' });
+      }
+      if (req.path === '/api/bots' && req.method === 'GET') {
+        return res.json({
+          bots: [{ uid: 199, username: 'target-agent', display_name: 'Target Agent', api_key: 'target-agent-key' }],
+        });
+      }
+      if (req.path === '/api/friends/request' || req.path === '/api/friends/accept') {
+        return res.json({ ok: true });
+      }
+      return res.status(404).json({ error: 'not found' });
+    });
+
+    const localConfig = createCatsCoLocalConfigService({ runtimeRoot: testRoot });
+    localConfig.save({
+      version: 1,
+      endpoints: { httpBaseUrl: catsBaseUrl, serverUrl: 'wss://app.catsco.cc/v0/channels' },
+      account: { token: 'user-token', uid: '88', username: 'fresh', displayName: 'Fresh User' },
+      currentBot: { uid: '188', name: 'Active Agent', apiKey: 'active-agent-key' },
+      device: { deviceId: 'device-1', bodyId: 'body-1', installationId: 'install-1' },
+    });
+
+    const definitions = new FileBotDefinitionRepository({ runtimeRoot: testRoot });
+    const targetDefinition = {
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: '199',
+      model: { kind: 'catalog' as const, modelId: 'minimax-m3' },
+    };
+    definitions.writeCanonical(targetDefinition);
+    definitions.writeCache(targetDefinition);
+    new FileBotCatalogModelRuntimeRepository({ runtimeRoot: testRoot }).write({
+      schema: BOT_CATALOG_MODEL_RUNTIME_SCHEMA,
+      botId: '199',
+      modelId: 'minimax-m3',
+      provider: 'anthropic',
+      apiBase: 'https://relay.example.test/anthropic',
+      apiKey: 'sk-target-runtime',
+      model: 'MiniMax-M3',
+      contextWindowTokens: 200000,
+      reasoningEffort: 'high',
+    });
+
+    const response = await fetch(`${dashboardBaseUrl}/api/cats/bind-bot`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ botUid: '199', setupRelayModel: false }),
+    });
+    const data = await response.json() as any;
+
+    assert.equal(response.status, 400);
+    assert.equal(data.error, 'CatsCo connector preflight blocked');
+    assert.equal(data.data?.preflight?.status, 'blocked');
+    assert.equal(data.data?.preflight?.blockingChecks.includes('runtime.command'), true);
+    assert.equal(localConfig.load().currentBot?.uid, '188');
+    assert.equal(restartCalled, 0);
+  });
+
+  test('PUT /model/reasoning-effort accepts and normalizes a legacy catalog runtime alias', async () => {
+    createCatsCoLocalConfigService({ runtimeRoot: testRoot }).save({
+      version: 1,
+      currentBot: { uid: '188', name: 'Catalog Agent', apiKey: 'catalog-agent-key' },
+      device: { deviceId: 'device-1', bodyId: 'body-1', installationId: 'install-1' },
+    });
+    const definitions = new FileBotDefinitionRepository({ runtimeRoot: testRoot });
+    const definition = {
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: '188',
+      model: { kind: 'catalog' as const, modelId: 'minimax-m3' },
+    };
+    definitions.writeCanonical(definition);
+    definitions.writeCache(definition);
+    const runtimeRepository = new FileBotCatalogModelRuntimeRepository({ runtimeRoot: testRoot });
+    runtimeRepository.write({
+      schema: BOT_CATALOG_MODEL_RUNTIME_SCHEMA,
+      botId: '188',
+      modelId: 'MiniMax-M3',
+      provider: 'anthropic',
+      apiBase: 'https://relay.example.test/anthropic',
+      apiKey: 'sk-legacy-runtime',
+      model: 'MiniMax-M3',
+      contextWindowTokens: 200000,
+      reasoningEffort: 'high',
+    });
+
+    const response = await fetch(`${dashboardBaseUrl}/api/model/reasoning-effort`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ reasoningEffort: 'max' }),
+    });
+    const data = await response.json() as any;
+    const runtime = runtimeRepository.read('188');
+
+    assert.equal(response.status, 200, JSON.stringify(data));
+    assert.equal(data.source, 'relay');
+    assert.equal(data.reasoningEffort, 'max');
+    assert.equal(runtime?.modelId, 'minimax-m3');
+    assert.equal(runtime?.model, 'MiniMax-M3');
+    assert.equal(runtime?.reasoningEffort, 'max');
   });
 
   test('POST /cats/bind-bot writes relay model config before starting an existing bot binding', async () => {

--- a/tests/dashboard-catsco-auth-status.test.ts
+++ b/tests/dashboard-catsco-auth-status.test.ts
@@ -8,6 +8,7 @@ import express from 'express';
 import type { Server } from 'http';
 import { createApiRouter } from '../src/dashboard/routes/api';
 import { createCatsCoLocalConfigService } from '../src/catscompany/local-config';
+import { FileBotCatalogModelRuntimeRepository } from '../src/bot-definition/repository';
 
 describe('dashboard CatsCo account status', () => {
   let testRoot: string;
@@ -455,6 +456,7 @@ describe('dashboard CatsCo account status', () => {
     const text = await response.text();
     const data = JSON.parse(text) as any;
     const env = dotenv.parse(fs.readFileSync(path.join(testRoot, '.env'), 'utf-8'));
+    const runtime = new FileBotCatalogModelRuntimeRepository({ runtimeRoot: testRoot }).read('188');
 
     assert.equal(response.status, 200, text);
     assert.equal(data.ok, true);
@@ -464,17 +466,12 @@ describe('dashboard CatsCo account status', () => {
     assert.equal(data.relayModelSetup.reasoningEffort, 'high');
     assert.equal(data.relayModelSetup.createdKey, true);
     assert.equal(text.includes('sk-bf-fresh-secret'), false);
-    assert.equal(env.GAUZ_LLM_PROVIDER, 'anthropic');
-    assert.equal(env.GAUZ_LLM_API_BASE, 'https://relay.catsco.cc/anthropic');
-    assert.equal(env.GAUZ_LLM_MODEL, 'MiniMax-M3');
-    assert.equal(env.GAUZ_LLM_API_KEY, 'sk-bf-fresh-secret');
-    assert.equal(env.GAUZ_LLM_REASONING_EFFORT, 'high');
-    assert.equal(env.CATSCO_MODEL_SOURCE, 'relay');
-    assert.equal(env.CATSCO_RELAY_LLM_PROVIDER, 'anthropic');
-    assert.equal(env.CATSCO_RELAY_LLM_API_BASE, 'https://relay.catsco.cc/anthropic');
-    assert.equal(env.CATSCO_RELAY_LLM_MODEL, 'MiniMax-M3');
-    assert.equal(env.CATSCO_RELAY_LLM_API_KEY, 'sk-bf-fresh-secret');
-    assert.equal(env.CATSCO_RELAY_LLM_REASONING_EFFORT, 'high');
+    assert.equal(runtime?.modelId, 'minimax-m3');
+    assert.equal(runtime?.provider, 'anthropic');
+    assert.equal(runtime?.apiBase, 'https://relay.catsco.cc/anthropic');
+    assert.equal(runtime?.model, 'MiniMax-M3');
+    assert.equal(runtime?.apiKey, 'sk-bf-fresh-secret');
+    assert.equal(runtime?.reasoningEffort, 'high');
     assert.equal(env.CATSCO_BOT_UID, '188');
     assert.equal(env.CATSCO_API_KEY, 'cats-agent-key');
     assert.equal(startCalled, 1);
@@ -771,6 +768,7 @@ describe('dashboard CatsCo account status', () => {
     const text = await response.text();
     const data = JSON.parse(text) as any;
     const env = dotenv.parse(fs.readFileSync(path.join(testRoot, '.env'), 'utf-8'));
+    const runtime = new FileBotCatalogModelRuntimeRepository({ runtimeRoot: testRoot }).read('188');
 
     assert.equal(response.status, 200, text);
     assert.equal(data.ok, true);
@@ -780,13 +778,12 @@ describe('dashboard CatsCo account status', () => {
     assert.equal(data.relayModelSetup.createdKey, true);
     assert.equal(text.includes('sk-bf-existing-bot-secret'), false);
     assert.equal(relayKeyCreated, 1);
-    assert.equal(env.GAUZ_LLM_PROVIDER, 'anthropic');
-    assert.equal(env.GAUZ_LLM_API_BASE, 'https://relay.catsco.cc/anthropic');
-    assert.equal(env.GAUZ_LLM_MODEL, 'MiniMax-M3');
-    assert.equal(env.GAUZ_LLM_API_KEY, 'sk-bf-existing-bot-secret');
-    assert.equal(env.GAUZ_LLM_REASONING_EFFORT, 'high');
-    assert.equal(env.CATSCO_MODEL_SOURCE, 'relay');
-    assert.equal(env.CATSCO_RELAY_LLM_REASONING_EFFORT, 'high');
+    assert.equal(runtime?.modelId, 'minimax-m3');
+    assert.equal(runtime?.provider, 'anthropic');
+    assert.equal(runtime?.apiBase, 'https://relay.catsco.cc/anthropic');
+    assert.equal(runtime?.model, 'MiniMax-M3');
+    assert.equal(runtime?.apiKey, 'sk-bf-existing-bot-secret');
+    assert.equal(runtime?.reasoningEffort, 'high');
     assert.equal(env.CATSCO_BOT_UID, '188');
     assert.equal(env.CATSCO_API_KEY, 'cats-agent-key');
     assert.equal(startCalled, 1);

--- a/tests/dashboard-settings-api.test.ts
+++ b/tests/dashboard-settings-api.test.ts
@@ -8,6 +8,8 @@ import express from 'express';
 import type { Server } from 'http';
 import { createApiRouter } from '../src/dashboard/routes/api';
 import { createCatsCoLocalConfigService } from '../src/catscompany/local-config';
+import { FileBotCatalogModelRuntimeRepository } from '../src/bot-definition/repository';
+import { createBotDefinitionSyncService } from '../src/bot-definition/service';
 
 describe('dashboard typed settings API', () => {
   let testRoot: string;
@@ -62,6 +64,7 @@ describe('dashboard typed settings API', () => {
     'CATSCOMPANY_DEVICE_ID',
     'CATSCOMPANY_BODY_ID',
     'CATSCOMPANY_INSTALLATION_ID',
+    'XIAOBA_USER_DATA_DIR',
   ];
   const originalEnv: Record<string, string | undefined> = {};
 
@@ -278,6 +281,158 @@ describe('dashboard typed settings API', () => {
     const status = await statusResponse.json() as any;
     assert.equal(status.provider, 'anthropic');
     assert.equal(status.model, 'MiniMax-M2.7-highspeed');
+  });
+
+  test('PUT /settings publishes the bound bot model definition without exposing its API key', async () => {
+    createCatsCoLocalConfigService({ runtimeRoot: testRoot }).save({
+      version: 1,
+      currentBot: {
+        uid: 'bot-definition-test',
+        apiKey: 'catsco-bot-api-key',
+        boundByUserUid: 'user-definition-test',
+        bindingSource: 'test',
+      },
+      device: {
+        deviceId: 'device-definition-test',
+        bodyId: 'body-definition-test',
+        installationId: 'install-definition-test',
+      },
+    });
+
+    const response = await fetch(`${baseUrl}/api/settings`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        settings: {
+          'model.provider': 'openai',
+          'model.apiBase': 'https://model.example.test/v1',
+          'model.model': 'gpt-portable',
+          'model.contextWindowTokens': '256000',
+          'model.apiKey': { action: 'replace', value: 'sk-portable-secret' },
+        },
+      }),
+    });
+    const text = await response.text();
+    const data = JSON.parse(text) as any;
+    const definitionPath = path.join(
+      testRoot,
+      'data',
+      'bot-definition-simulated-cloud',
+      'bots',
+      'bot-definition-test.json',
+    );
+
+    assert.equal(response.status, 200, text);
+    assert.ok(data.botDefinitionSync, text);
+    const definition = JSON.parse(fs.readFileSync(definitionPath, 'utf-8')) as any;
+    assert.equal(data.botDefinitionSync.botId, 'bot-definition-test');
+    assert.equal(data.botDefinitionSync.direction, 'local_to_simulated_cloud');
+    assert.equal(data.botDefinitionSync.model.kind, 'custom');
+    assert.equal(data.botDefinitionSync.model.model, 'gpt-portable');
+    assert.equal(text.includes('sk-portable-secret'), false);
+    assert.equal(definition.model.apiKey, 'sk-portable-secret');
+  });
+
+  test('PUT /settings uses the explicit runtime data root for bound bot state and Definition storage', async () => {
+    const runtimeRoot = path.join(testRoot, 'electron-user-data');
+    process.env.XIAOBA_USER_DATA_DIR = runtimeRoot;
+    createCatsCoLocalConfigService({ runtimeRoot }).save({
+      version: 1,
+      currentBot: {
+        uid: 'runtime-root-bot',
+        apiKey: 'catsco-bot-api-key',
+        boundByUserUid: 'user-definition-test',
+        bindingSource: 'test',
+      },
+      device: {
+        deviceId: 'device-definition-test',
+        bodyId: 'body-definition-test',
+        installationId: 'install-definition-test',
+      },
+    });
+
+    const response = await fetch(`${baseUrl}/api/settings`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        settings: {
+          'model.provider': 'openai',
+          'model.apiBase': 'https://model.example.test/v1',
+          'model.model': 'gpt-runtime-root',
+          'model.contextWindowTokens': '256000',
+          'model.apiKey': { action: 'replace', value: 'sk-runtime-root-secret' },
+        },
+      }),
+    });
+    const text = await response.text();
+    const data = JSON.parse(text) as any;
+    const definitionPath = path.join(
+      runtimeRoot,
+      'data',
+      'bot-definition-cache',
+      'bots',
+      'runtime-root-bot.json',
+    );
+    const runtimeEnv = dotenv.parse(fs.readFileSync(path.join(runtimeRoot, '.env'), 'utf-8'));
+
+    assert.equal(response.status, 200, text);
+    assert.equal(data.botDefinitionSync?.botId, 'runtime-root-bot');
+    assert.equal(JSON.parse(fs.readFileSync(definitionPath, 'utf-8')).model.model, 'gpt-runtime-root');
+    assert.equal(runtimeEnv.CATSCO_CUSTOM_LLM_MODEL, 'gpt-runtime-root');
+    assert.equal(fs.existsSync(path.join(testRoot, '.env')), false);
+    assert.equal(text.includes('sk-runtime-root-secret'), false);
+  });
+
+  test('PUT /model/reasoning-effort updates a bound custom Definition without changing legacy env', async () => {
+    createCatsCoLocalConfigService({ runtimeRoot: testRoot }).save({
+      version: 1,
+      currentBot: {
+        uid: 'bound-reasoning-test',
+        apiKey: 'catsco-bot-api-key',
+        boundByUserUid: 'user-definition-test',
+        bindingSource: 'test',
+      },
+      device: {
+        deviceId: 'device-definition-test',
+        bodyId: 'body-definition-test',
+        installationId: 'install-definition-test',
+      },
+    });
+    createBotDefinitionSyncService({ runtimeRoot: testRoot }).publish('bound-reasoning-test', {
+      kind: 'custom',
+      protocol: 'openai-chat-completions',
+      apiBase: 'https://model.example.test/v1',
+      model: 'gpt-portable',
+      apiKey: 'sk-portable-secret',
+      contextWindowTokens: 256_000,
+      reasoningEffort: 'default',
+    });
+    fs.writeFileSync(path.join(testRoot, '.env'), 'GAUZ_LLM_REASONING_EFFORT=max\n');
+
+    const response = await fetch(`${baseUrl}/api/model/reasoning-effort`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ reasoningEffort: 'high' }),
+    });
+    const text = await response.text();
+    const data = JSON.parse(text) as any;
+    const definitionPath = path.join(
+      testRoot,
+      'data',
+      'bot-definition-cache',
+      'bots',
+      'bound-reasoning-test.json',
+    );
+    const definition = JSON.parse(fs.readFileSync(definitionPath, 'utf-8')) as any;
+    const env = dotenv.parse(fs.readFileSync(path.join(testRoot, '.env'), 'utf-8'));
+
+    assert.equal(response.status, 200, text);
+    assert.equal(data.source, 'custom');
+    assert.equal(data.previousReasoningEffort, 'default');
+    assert.equal(data.reasoningEffort, 'high');
+    assert.equal(definition.model.reasoningEffort, 'high');
+    assert.equal(env.GAUZ_LLM_REASONING_EFFORT, 'max');
+    assert.equal(data.botDefinitionSync.direction, 'local_to_simulated_cloud');
   });
 
   test('PUT /model/reasoning-effort updates the active relay source without touching custom startup', async () => {
@@ -1314,7 +1469,7 @@ describe('dashboard typed settings API', () => {
       });
       const text = await response.text();
       const data = JSON.parse(text) as any;
-      const parsed = dotenv.parse(fs.readFileSync(path.join(testRoot, '.env'), 'utf-8'));
+      const runtime = new FileBotCatalogModelRuntimeRepository({ runtimeRoot: testRoot }).read('110');
 
       assert.equal(response.status, 200, text);
       assert.equal(data.model, 'MiniMax-M3');
@@ -1324,7 +1479,8 @@ describe('dashboard typed settings API', () => {
       assert.match(data.message, /已启动 CatsCompany connector/);
       assert.equal(startCalled, 1);
       assert.equal(restartCalled, 0);
-      assert.equal(parsed.GAUZ_LLM_MODEL, 'MiniMax-M3');
+      assert.equal(runtime?.modelId, 'minimax-m3');
+      assert.equal(runtime?.model, 'MiniMax-M3');
       assert.equal(text.includes('sk-bf-minimax-secret'), false);
     } finally {
       await new Promise<void>(resolve => dashboardServer.close(() => resolve()));

--- a/tests/dashboard-settings-api.test.ts
+++ b/tests/dashboard-settings-api.test.ts
@@ -378,7 +378,8 @@ describe('dashboard typed settings API', () => {
     assert.equal(response.status, 200, text);
     assert.equal(data.botDefinitionSync?.botId, 'runtime-root-bot');
     assert.equal(JSON.parse(fs.readFileSync(definitionPath, 'utf-8')).model.model, 'gpt-runtime-root');
-    assert.equal(runtimeEnv.CATSCO_CUSTOM_LLM_MODEL, 'gpt-runtime-root');
+    assert.equal(runtimeEnv.CATSCO_CUSTOM_LLM_MODEL, undefined);
+    assert.equal(runtimeEnv.GAUZ_LLM_MODEL, undefined);
     assert.equal(fs.existsSync(path.join(testRoot, '.env')), false);
     assert.equal(text.includes('sk-runtime-root-secret'), false);
   });
@@ -431,7 +432,7 @@ describe('dashboard typed settings API', () => {
     assert.equal(data.previousReasoningEffort, 'default');
     assert.equal(data.reasoningEffort, 'high');
     assert.equal(definition.model.reasoningEffort, 'high');
-    assert.equal(env.GAUZ_LLM_REASONING_EFFORT, 'max');
+    assert.equal(env.GAUZ_LLM_REASONING_EFFORT, undefined);
     assert.equal(data.botDefinitionSync.direction, 'local_to_simulated_cloud');
   });
 
@@ -938,7 +939,7 @@ describe('dashboard typed settings API', () => {
       assert.equal(data.ok, true);
       assert.equal(data.provider, 'anthropic');
       assert.equal(data.apiBase, 'https://relay.catsco.cc/anthropic');
-      assert.equal(data.model, 'MiniMax-M2.7');
+      assert.equal(data.model, 'MiniMax-M3');
       assert.equal(data.createdKey, true);
       assert.equal(data.key.key, undefined);
       assert.equal(data.key.api_key, undefined);
@@ -949,16 +950,16 @@ describe('dashboard typed settings API', () => {
       assert.equal(createCount, 1);
       assert.equal(parsed.GAUZ_LLM_PROVIDER, 'anthropic');
       assert.equal(parsed.GAUZ_LLM_API_BASE, 'https://relay.catsco.cc/anthropic');
-      assert.equal(parsed.GAUZ_LLM_MODEL, 'MiniMax-M2.7');
+      assert.equal(parsed.GAUZ_LLM_MODEL, 'MiniMax-M3');
       assert.equal(parsed.GAUZ_LLM_API_KEY, 'sk-bf-secret-created-once');
-      assert.equal(parsed.GAUZ_LLM_CONTEXT_WINDOW_TOKENS, '204800');
+      assert.equal(parsed.GAUZ_LLM_CONTEXT_WINDOW_TOKENS, '1000000');
       assert.equal(parsed.GAUZ_LLM_REASONING_EFFORT, 'high');
       assert.equal(parsed.CATSCO_MODEL_SOURCE, 'relay');
       assert.equal(parsed.CATSCO_RELAY_LLM_PROVIDER, 'anthropic');
       assert.equal(parsed.CATSCO_RELAY_LLM_API_BASE, 'https://relay.catsco.cc/anthropic');
-      assert.equal(parsed.CATSCO_RELAY_LLM_MODEL, 'MiniMax-M2.7');
+      assert.equal(parsed.CATSCO_RELAY_LLM_MODEL, 'MiniMax-M3');
       assert.equal(parsed.CATSCO_RELAY_LLM_API_KEY, 'sk-bf-secret-created-once');
-      assert.equal(parsed.CATSCO_RELAY_LLM_CONTEXT_WINDOW_TOKENS, '204800');
+      assert.equal(parsed.CATSCO_RELAY_LLM_CONTEXT_WINDOW_TOKENS, '1000000');
       assert.equal(parsed.CATSCO_RELAY_LLM_REASONING_EFFORT, 'high');
       assert.equal(process.env.GAUZ_LLM_PROVIDER, 'anthropic');
 
@@ -1304,7 +1305,7 @@ describe('dashboard typed settings API', () => {
     }
   });
 
-  test('POST /cats/relay/model-config/apply keeps fallback MiniMax independent from legacy default_model', async () => {
+  test('POST /cats/relay/model-config/apply defaults a fresh setup to MiniMax M3', async () => {
     const catsApp = express();
     catsApp.use(express.json());
     catsApp.get('/api/relay/config', (_req, res) => {
@@ -1350,9 +1351,9 @@ describe('dashboard typed settings API', () => {
       const parsed = dotenv.parse(fs.readFileSync(path.join(testRoot, '.env'), 'utf-8'));
 
       assert.equal(response.status, 200, text);
-      assert.equal(data.model, 'MiniMax-M2.7');
-      assert.equal(data.selectedModel.id, 'minimax-m2.7');
-      assert.equal(parsed.GAUZ_LLM_MODEL, 'MiniMax-M2.7');
+      assert.equal(data.model, 'MiniMax-M3');
+      assert.equal(data.selectedModel.id, 'minimax-m3');
+      assert.equal(parsed.GAUZ_LLM_MODEL, 'MiniMax-M3');
     } finally {
       await new Promise<void>(resolve => catsServer.close(() => resolve()));
     }

--- a/tests/model-capabilities.test.ts
+++ b/tests/model-capabilities.test.ts
@@ -95,34 +95,15 @@ describe('model capabilities', () => {
     );
   });
 
-  test('respects persisted relay capability overrides from CatsCo model catalog', () => {
-    const previousVision = process.env.CATSCO_RELAY_LLM_VISION_CAPABLE;
-    const previousToolCalling = process.env.CATSCO_RELAY_LLM_TOOL_CALLING_CAPABLE;
-    try {
-      process.env.CATSCO_RELAY_LLM_VISION_CAPABLE = 'false';
-      process.env.CATSCO_RELAY_LLM_TOOL_CALLING_CAPABLE = 'false';
+  test('respects capabilities carried by the active catalog runtime', () => {
+    const config = {
+      provider: 'anthropic' as const,
+      apiUrl: 'https://relay.catsco.cc/anthropic',
+      model: 'MiniMax-M3',
+      modelCapabilities: { vision: false, toolCalling: false },
+    };
 
-      assert.strictEqual(
-        isPrimaryModelVisionCapable({
-          provider: 'anthropic',
-          apiUrl: 'https://relay.catsco.cc/anthropic',
-          model: 'MiniMax-M3',
-        }),
-        false,
-      );
-      assert.strictEqual(
-        isPrimaryModelToolCallingCapable({
-          provider: 'anthropic',
-          apiUrl: 'https://relay.catsco.cc/anthropic',
-          model: 'MiniMax-M3',
-        }),
-        false,
-      );
-    } finally {
-      if (previousVision === undefined) delete process.env.CATSCO_RELAY_LLM_VISION_CAPABLE;
-      else process.env.CATSCO_RELAY_LLM_VISION_CAPABLE = previousVision;
-      if (previousToolCalling === undefined) delete process.env.CATSCO_RELAY_LLM_TOOL_CALLING_CAPABLE;
-      else process.env.CATSCO_RELAY_LLM_TOOL_CALLING_CAPABLE = previousToolCalling;
-    }
+    assert.strictEqual(isPrimaryModelVisionCapable(config), false);
+    assert.strictEqual(isPrimaryModelToolCallingCapable(config), false);
   });
 });


### PR DESCRIPTION
## 概述

将当前分散在 Dashboard、`.env` 与 CatsCo connector 中的有效 LLM 配置，收敛为按 botId 保存的本地 BotDefinition 模拟仓库。它是后续云端 BotDefinition 与多设备同步的本地接口版本。

## 改动

- 新增 BotDefinition 本地仓库、缓存与 LLM 配置解析器。
- Dashboard 保存模型设置、切换自定义模型或绑定 CatsCo bot 时，发布当前 bot 的 Definition。
- CatsCo connector 启动时拉取或初始化当前绑定 bot 的 Definition。
- 运行时优先读取当前 bot 的 Definition；保留 `.env` 作为旧配置兼容和启动材料。
- 统一 Dashboard 与 connector 使用当前 runtime data root，避免 Electron dev 将数据误写到仓库根目录。
- 补充本地 Definition、Dashboard 设置和 CatsCo 启动链路测试。

## 验证

- `npm run build`
- `npx tsx --test tests/bot-definition-local-repository.test.ts tests/catsco-command-config.test.ts tests/dashboard-catsco-auth-status.test.ts tests/dashboard-settings-api.test.ts`
- 共 68 项定向测试通过。
- 手动验证：切换 Friday bot、保存自定义模型并发送消息后，Definition 正本、缓存与兼容环境配置均解析为同一模型。