### PR TITLE
feat(skillhub): add user and runtime subscription management

### DIFF
--- a/src/skillhub/install-marker.ts
+++ b/src/skillhub/install-marker.ts
@@ -1,0 +1,55 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { PathResolver } from '../utils/path-resolver';
+import type { SkillHubPackageInstallMarker } from './types';
+
+export const SKILLHUB_INSTALL_MARKER_FILE = '.xiaoba-skillhub-install.json';
+
+export function readSkillHubInstallMarker(skillDir: string): SkillHubPackageInstallMarker | null {
+  const markerPath = path.join(skillDir, SKILLHUB_INSTALL_MARKER_FILE);
+  if (!fs.existsSync(markerPath)) return null;
+  try {
+    const value = JSON.parse(fs.readFileSync(markerPath, 'utf8')) as Partial<SkillHubPackageInstallMarker>;
+    if (
+      value?.source !== 'skillhub'
+      || !stringValue(value.skillId)
+      || !stringValue(value.name)
+      || !stringValue(value.installName)
+      || !stringValue(value.version)
+    ) {
+      return null;
+    }
+    return value as SkillHubPackageInstallMarker;
+  } catch {
+    return null;
+  }
+}
+
+export function writeSkillHubInstallMarker(skillDir: string, marker: SkillHubPackageInstallMarker): void {
+  fs.mkdirSync(skillDir, { recursive: true });
+  const markerPath = path.join(skillDir, SKILLHUB_INSTALL_MARKER_FILE);
+  const tempPath = `${markerPath}.tmp-${process.pid}-${Date.now()}`;
+  fs.writeFileSync(tempPath, `${JSON.stringify(marker, null, 2)}\n`, 'utf8');
+  fs.renameSync(tempPath, markerPath);
+}
+
+export function listInstalledSkillHubSkills(userId?: string): SkillHubPackageInstallMarker[] {
+  const root = path.resolve(PathResolver.getSkillsPath());
+  if (!fs.existsSync(root)) return [];
+  const expectedUserId = stringValue(userId);
+  const markers: SkillHubPackageInstallMarker[] = [];
+
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    if (!entry.isDirectory() || entry.isSymbolicLink()) continue;
+    const marker = readSkillHubInstallMarker(path.join(root, entry.name));
+    if (!marker) continue;
+    if (expectedUserId && marker.userId !== expectedUserId) continue;
+    markers.push(marker);
+  }
+
+  return markers.sort((left, right) => left.skillId.localeCompare(right.skillId));
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}

--- a/src/skillhub/package-installer.ts
+++ b/src/skillhub/package-installer.ts
@@ -1,19 +1,45 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import * as crypto from 'crypto';
 import { PathResolver } from '../utils/path-resolver';
 import type { SkillHubPackageVerificationResult } from './package-verifier';
-import type { SkillHubRegistryEntry } from './types';
+import type { SkillHubPackageInstallMarker, SkillHubRegistryEntry } from './types';
+import {
+  readSkillHubInstallMarker,
+  writeSkillHubInstallMarker,
+} from './install-marker';
 
 export interface InstallVerifiedSkillHubPackageOptions {
   verification: SkillHubPackageVerificationResult;
   registryEntry: SkillHubRegistryEntry;
-  overwrite?: boolean;
+  userId?: string;
+  allowUpdate?: boolean;
+  now?: () => Date;
 }
 
 export interface InstallVerifiedSkillHubPackageResult {
   skillId: string;
   name: string;
   version: string;
+  path: string;
+  installName: string;
+  action: 'installed' | 'updated' | 'unchanged';
+}
+
+export interface UninstallSkillHubPackageOptions {
+  userId?: string;
+  skillId: string;
+  installName: string;
+}
+
+export interface ClaimSkillHubPackageOwnershipOptions {
+  userId: string;
+  skillId: string;
+  installName: string;
+}
+
+export interface UninstallSkillHubPackageResult {
+  removed: boolean;
   path: string;
 }
 
@@ -53,12 +79,40 @@ export function installVerifiedSkillHubPackage(
   const skillsRoot = path.resolve(PathResolver.getSkillsPath());
   PathResolver.ensureDir(skillsRoot);
   const targetDir = safeJoin(skillsRoot, installName);
-  const tempDir = safeJoin(skillsRoot, `.skillhub-install-${process.pid}-${Date.now()}`);
+  const operationId = `${process.pid}-${Date.now()}-${crypto.randomBytes(6).toString('hex')}`;
+  const tempDir = safeJoin(skillsRoot, `.skillhub-install-${operationId}`);
+  const backupDir = safeJoin(skillsRoot, `.skillhub-backup-${operationId}`);
+  const existingMarker = fs.existsSync(targetDir) ? readSkillHubInstallMarker(targetDir) : null;
 
-  try {
-    if (fs.existsSync(targetDir)) {
+  if (fs.existsSync(targetDir)) {
+    if (!options.allowUpdate) {
       throw new SkillHubInstallError('同名 Skill 目录已存在，请先删除本地目录后再安装。', 'TARGET_CONFLICT');
     }
+    if (!existingMarker || existingMarker.skillId !== skillId) {
+      throw new SkillHubInstallError('同名 Skill 已被其他本地或 SkillHub Skill 占用。', 'TARGET_CONFLICT');
+    }
+    if (options.userId && existingMarker.userId && existingMarker.userId !== options.userId) {
+      throw new SkillHubInstallError('同名 Skill 已属于另一个 SkillHub 用户。', 'USER_CONFLICT');
+    }
+    if (
+      existingMarker.version === version
+      && existingMarker.packageChecksumSha256 === registryEntry.checksumSha256
+    ) {
+      if (options.userId && !existingMarker.userId) {
+        writeSkillHubInstallMarker(targetDir, markerOwnedByUser(existingMarker, options.userId));
+      }
+      return {
+        skillId,
+        name: String(manifest.displayName || registryEntry.displayName || registryEntry.name || manifest.name || skillId),
+        version,
+        path: targetDir,
+        installName,
+        action: 'unchanged',
+      };
+    }
+  }
+
+  try {
     fs.mkdirSync(tempDir, { recursive: true });
     for (const file of packageObject.payload.files) {
       if (PACKAGE_METADATA_FILES.has(String(file.path || ''))) continue;
@@ -67,19 +121,108 @@ export function installVerifiedSkillHubPackage(
       fs.writeFileSync(destination, Buffer.from(file.contentBase64, 'base64'));
     }
 
+    const displayName = String(manifest.displayName || registryEntry.displayName || registryEntry.name || manifest.name || skillId);
+    writeSkillHubInstallMarker(tempDir, {
+      source: 'skillhub',
+      userId: String(options.userId || '').trim() || undefined,
+      skillId,
+      name: displayName,
+      installName,
+      version,
+      packageChecksumSha256: registryEntry.checksumSha256,
+      signature: registryEntry.signature,
+      packageUrl: registryEntry.packageUrl,
+      installedAt: (options.now?.() || new Date()).toISOString(),
+    });
+
     fs.mkdirSync(path.dirname(targetDir), { recursive: true });
-    fs.renameSync(tempDir, targetDir);
+    let action: InstallVerifiedSkillHubPackageResult['action'] = 'installed';
+    if (fs.existsSync(targetDir)) {
+      fs.renameSync(targetDir, backupDir);
+      disableBackupSkill(backupDir);
+      try {
+        fs.renameSync(tempDir, targetDir);
+        action = 'updated';
+      } catch (error) {
+        restoreBackupSkill(backupDir, targetDir);
+        throw error;
+      }
+      try {
+        fs.rmSync(backupDir, { recursive: true, force: true });
+      } catch {
+        // The active update has succeeded. A disabled backup is safe to leave for later cleanup.
+      }
+    } else {
+      fs.renameSync(tempDir, targetDir);
+    }
     return {
       skillId,
-      name: String(manifest.displayName || registryEntry.displayName || registryEntry.name || manifest.name || skillId),
+      name: displayName,
       version,
       path: targetDir,
+      installName,
+      action,
     };
   } catch (error: any) {
     if (fs.existsSync(tempDir)) fs.rmSync(tempDir, { recursive: true, force: true });
+    restoreBackupSkill(backupDir, targetDir);
     if (error instanceof SkillHubInstallError) throw error;
     throw new SkillHubInstallError(error?.message || String(error), 'INSTALL_FAILED');
   }
+}
+
+export function uninstallSkillHubPackage(
+  options: UninstallSkillHubPackageOptions,
+): UninstallSkillHubPackageResult {
+  const skillsRoot = path.resolve(PathResolver.getSkillsPath());
+  const targetDir = safeJoin(skillsRoot, options.installName);
+  if (!fs.existsSync(targetDir)) return { removed: false, path: targetDir };
+
+  const marker = readSkillHubInstallMarker(targetDir);
+  if (!marker || marker.skillId !== options.skillId) {
+    throw new SkillHubInstallError('目标目录不是当前订阅的 SkillHub Skill，已拒绝删除。', 'UNINSTALL_TARGET_MISMATCH');
+  }
+  if (options.userId && marker.userId && marker.userId !== options.userId) {
+    throw new SkillHubInstallError('目标 Skill 不属于当前 SkillHub 用户，已拒绝删除。', 'USER_CONFLICT');
+  }
+
+  fs.rmSync(targetDir, { recursive: true, force: true });
+  return { removed: true, path: targetDir };
+}
+
+export function claimSkillHubPackageOwnership(options: ClaimSkillHubPackageOwnershipOptions): boolean {
+  const skillsRoot = path.resolve(PathResolver.getSkillsPath());
+  const targetDir = safeJoin(skillsRoot, options.installName);
+  if (!fs.existsSync(targetDir)) return false;
+
+  const marker = readSkillHubInstallMarker(targetDir);
+  if (!marker || marker.skillId !== options.skillId) return false;
+  if (marker.userId && marker.userId !== options.userId) {
+    throw new SkillHubInstallError('目标 Skill 已属于另一个 SkillHub 用户。', 'USER_CONFLICT');
+  }
+  if (marker.userId === options.userId && !('agentId' in marker)) return true;
+  writeSkillHubInstallMarker(targetDir, markerOwnedByUser(marker, options.userId));
+  return true;
+}
+
+function markerOwnedByUser(
+  marker: SkillHubPackageInstallMarker,
+  userId: string,
+): SkillHubPackageInstallMarker {
+  const { agentId: _legacyOwner, ...current } = marker as typeof marker & { agentId?: string };
+  return { ...current, userId };
+}
+
+function disableBackupSkill(backupDir: string): void {
+  const activeSkillFile = path.join(backupDir, 'SKILL.md');
+  if (fs.existsSync(activeSkillFile)) fs.renameSync(activeSkillFile, `${activeSkillFile}.disabled`);
+}
+
+function restoreBackupSkill(backupDir: string, targetDir: string): void {
+  if (fs.existsSync(targetDir) || !fs.existsSync(backupDir)) return;
+  const disabledSkillFile = path.join(backupDir, 'SKILL.md.disabled');
+  if (fs.existsSync(disabledSkillFile)) fs.renameSync(disabledSkillFile, path.join(backupDir, 'SKILL.md'));
+  fs.renameSync(backupDir, targetDir);
 }
 
 function safeSkillDirName(value: string): string {

--- a/src/skillhub/service.ts
+++ b/src/skillhub/service.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import { createCatsCoLocalConfigService } from '../catscompany/local-config';
 import { SkillParser } from '../skills/skill-parser';
 import type { Skill } from '../types/skill';
 import { PathResolver } from '../utils/path-resolver';
@@ -7,7 +8,12 @@ import { SkillHubClient } from './client';
 import {
   writeSkillHubLocalMetadata,
 } from './local-skill-metadata';
-import { installVerifiedSkillHubPackage } from './package-installer';
+import {
+  claimSkillHubPackageOwnership,
+  installVerifiedSkillHubPackage,
+  uninstallSkillHubPackage,
+} from './package-installer';
+import { listInstalledSkillHubSkills } from './install-marker';
 import { verifySkillHubPackage } from './package-verifier';
 import { CATSCO_SKILLHUB_ROOT_PUBLIC_KEYS } from './trusted-keys';
 import type {
@@ -16,6 +22,8 @@ import type {
   SkillHubPackageInstallMarker,
   SkillHubRegistryEntry,
   SkillHubSearchResponse,
+  SkillHubSubscriptionScope,
+  SkillHubUser,
 } from './types';
 
 export class SkillHubService {
@@ -69,6 +77,42 @@ export class SkillHubService {
     });
   }
 
+  async requireAuthenticatedUser(): Promise<SkillHubUser> {
+    let auth = await this.client.status();
+    if (!auth.authenticated || !String(auth.user?.id || '').trim()) {
+      const cats = createCatsCoLocalConfigService({
+        runtimeRoot: PathResolver.getRuntimeDataRoot(),
+      }).getAuthState();
+      if (!cats.token) throw skillHubLoginRequired();
+      auth = await this.loginWithCatsCo({
+        token: cats.token,
+        baseUrl: cats.httpBaseUrl,
+        user: {
+          uid: cats.uid,
+          username: cats.username,
+          displayName: cats.displayName,
+        },
+      });
+    }
+    const user = auth.user;
+    const userId = String(user?.id || '').trim();
+    if (!auth.authenticated || !user || !userId) {
+      throw skillHubLoginRequired();
+    }
+    return { ...user, id: userId };
+  }
+
+  async resolveSubscriptionScope(): Promise<SkillHubSubscriptionScope> {
+    const cats = createCatsCoLocalConfigService({
+      runtimeRoot: PathResolver.getRuntimeDataRoot(),
+    }).getAuthState();
+    if (!String(cats.token || '').trim() && String(cats.apiKey || '').trim()) {
+      return { kind: 'runtime' };
+    }
+    const user = await this.requireAuthenticatedUser();
+    return { kind: 'user', userId: user.id };
+  }
+
   logout(): Promise<{ ok: true }> {
     return this.client.logout();
   }
@@ -87,7 +131,11 @@ export class SkillHubService {
     return this.client.getSkill(skillId);
   }
 
-  async install(skillId: string, version?: string): Promise<SkillHubInstallResult> {
+  async install(
+    skillId: string,
+    version?: string,
+    options: { userId?: string; allowUpdate?: boolean } = {},
+  ): Promise<SkillHubInstallResult> {
     const registryEntry = await this.resolveRegistryEntry(skillId, version);
     const [trust, packageBytes] = await Promise.all([
       this.client.getTrust(),
@@ -101,6 +149,8 @@ export class SkillHubService {
     const installed = installVerifiedSkillHubPackage({
       verification,
       registryEntry,
+      userId: options.userId,
+      allowUpdate: options.allowUpdate,
     });
     return {
       ok: true,
@@ -108,6 +158,14 @@ export class SkillHubService {
       signingKeyId: verification.signingKey.keyId,
       rootKeyId: verification.root.keyId,
     };
+  }
+
+  uninstall(input: { userId?: string; skillId: string; installName: string }): { removed: boolean; path: string } {
+    return uninstallSkillHubPackage(input);
+  }
+
+  claimInstalledSkillOwnership(input: { userId: string; skillId: string; installName: string }): boolean {
+    return claimSkillHubPackageOwnership(input);
   }
 
   developerDashboard(): Promise<any> {
@@ -467,6 +525,9 @@ function skillHubMetadataFromShareResponse(response: any): { author: string; ver
   return undefined;
 }
 
-function listInstalledSkillHubSkills(): SkillHubPackageInstallMarker[] {
-  return [];
+function skillHubLoginRequired(): Error {
+  const error: any = new Error('请先登录 CatsCo 并连接 SkillHub。');
+  error.status = 401;
+  error.code = 'skillhub.login_required';
+  return error;
 }

--- a/src/skillhub/subscription-service.ts
+++ b/src/skillhub/subscription-service.ts
@@ -1,0 +1,153 @@
+import { SkillHubService } from './service';
+import {
+  LocalUserSkillSubscriptionStore,
+  type UserSkillSubscriptionStore,
+} from './subscription-store';
+import { listInstalledSkillHubSkills } from './install-marker';
+import type {
+  SkillHubInstallResult,
+  SkillHubSubscriptionScope,
+  UserSkillSubscription,
+} from './types';
+
+export interface SkillHubSubscriptionGateway {
+  resolveSubscriptionScope(): Promise<SkillHubSubscriptionScope>;
+  install(
+    skillId: string,
+    version?: string,
+    options?: { userId?: string; allowUpdate?: boolean },
+  ): Promise<SkillHubInstallResult>;
+  uninstall(input: { userId?: string; skillId: string; installName: string }): { removed: boolean; path: string };
+  claimInstalledSkillOwnership?(input: { userId: string; skillId: string; installName: string }): boolean;
+}
+
+export interface SkillHubSubscriptionListResult {
+  scope: 'user' | 'runtime';
+  userId?: string;
+  subscriptions: UserSkillSubscription[];
+}
+
+export interface SkillHubSubscribeResult {
+  scope: 'user' | 'runtime';
+  userId?: string;
+  action: SkillHubInstallResult['skill']['action'];
+  subscription: UserSkillSubscription;
+}
+
+export interface SkillHubUnsubscribeResult {
+  scope: 'user' | 'runtime';
+  userId?: string;
+  skillId: string;
+  removed: boolean;
+  subscriptionFound: boolean;
+}
+
+export class SkillHubSubscriptionService {
+  constructor(
+    private readonly gateway: SkillHubSubscriptionGateway = new SkillHubService(),
+    private readonly store: UserSkillSubscriptionStore = new LocalUserSkillSubscriptionStore(),
+    private readonly now: () => Date = () => new Date(),
+  ) {}
+
+  async list(): Promise<SkillHubSubscriptionListResult> {
+    const scope = await this.gateway.resolveSubscriptionScope();
+    if (scope.kind === 'runtime') {
+      return {
+        ...scopeResult(scope),
+        subscriptions: runtimeSubscriptions(),
+      };
+    }
+
+    const userId = scope.userId;
+    const subscriptions = this.store.list(userId);
+    for (const subscription of subscriptions) {
+      this.gateway.claimInstalledSkillOwnership?.({
+        userId,
+        skillId: subscription.skillId,
+        installName: subscription.installName,
+      });
+    }
+    return { ...scopeResult(scope), subscriptions };
+  }
+
+  async subscribe(skillId: string): Promise<SkillHubSubscribeResult> {
+    const scope = await this.gateway.resolveSubscriptionScope();
+    const normalizedSkillId = required(skillId, 'skillId');
+    const existing = scope.kind === 'user'
+      ? this.store.get(scope.userId, normalizedSkillId)
+      : runtimeSubscriptions().find(item => item.skillId === normalizedSkillId);
+    const installed = await this.gateway.install(normalizedSkillId, undefined, {
+      allowUpdate: true,
+      ...(scope.kind === 'user' ? { userId: scope.userId } : {}),
+    });
+    const timestamp = this.now().toISOString();
+    const subscription: UserSkillSubscription = {
+      skillId: installed.skill.skillId,
+      name: installed.skill.name,
+      installName: installed.skill.installName,
+      versionPolicy: 'latest',
+      resolvedVersion: installed.skill.version,
+      subscribedAt: existing?.subscribedAt || timestamp,
+      updatedAt: timestamp,
+    };
+    if (scope.kind === 'user') {
+      this.store.set(scope.userId, subscription);
+    }
+    return { ...scopeResult(scope), action: installed.skill.action, subscription };
+  }
+
+  async unsubscribe(skillId: string): Promise<SkillHubUnsubscribeResult> {
+    const scope = await this.gateway.resolveSubscriptionScope();
+    const normalizedSkillId = required(skillId, 'skillId');
+    const subscription = scope.kind === 'user'
+      ? this.store.get(scope.userId, normalizedSkillId)
+      : runtimeSubscriptions().find(item => item.skillId === normalizedSkillId);
+    if (!subscription) {
+      return {
+        ...scopeResult(scope),
+        skillId: normalizedSkillId,
+        removed: false,
+        subscriptionFound: false,
+      };
+    }
+
+    const result = this.gateway.uninstall({
+      skillId: normalizedSkillId,
+      installName: subscription.installName,
+      ...(scope.kind === 'user' ? { userId: scope.userId } : {}),
+    });
+    if (scope.kind === 'user') {
+      this.store.remove(scope.userId, normalizedSkillId);
+    }
+    return {
+      ...scopeResult(scope),
+      skillId: normalizedSkillId,
+      removed: result.removed,
+      subscriptionFound: true,
+    };
+  }
+}
+
+function runtimeSubscriptions(): UserSkillSubscription[] {
+  return listInstalledSkillHubSkills().map(marker => ({
+    skillId: marker.skillId,
+    name: marker.name,
+    installName: marker.installName,
+    versionPolicy: 'latest',
+    resolvedVersion: marker.version,
+    subscribedAt: marker.installedAt,
+    updatedAt: marker.installedAt,
+  }));
+}
+
+function scopeResult(scope: SkillHubSubscriptionScope): { scope: 'runtime' } | { scope: 'user'; userId: string } {
+  return scope.kind === 'runtime'
+    ? { scope: 'runtime' }
+    : { scope: 'user', userId: scope.userId };
+}
+
+function required(value: string, field: string): string {
+  const normalized = String(value || '').trim();
+  if (!normalized) throw new Error(`${field} required`);
+  return normalized;
+}

--- a/src/skillhub/subscription-store.ts
+++ b/src/skillhub/subscription-store.ts
@@ -1,0 +1,129 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { loadSkillHubConfig } from './config';
+import type { UserSkillSubscription } from './types';
+
+const SUBSCRIPTION_SCHEMA = 'xiaoba.skillhub.subscriptions.v2';
+const LEGACY_SUBSCRIPTION_SCHEMA = 'xiaoba.skillhub.subscriptions.v1';
+
+interface SubscriptionStateFile {
+  schema: typeof SUBSCRIPTION_SCHEMA;
+  users: Record<string, Record<string, UserSkillSubscription>>;
+}
+
+interface LegacySubscriptionStateFile {
+  schema: typeof LEGACY_SUBSCRIPTION_SCHEMA;
+  agents: Record<string, Record<string, UserSkillSubscription>>;
+}
+
+export interface UserSkillSubscriptionStore {
+  list(userId: string): UserSkillSubscription[];
+  get(userId: string, skillId: string): UserSkillSubscription | undefined;
+  set(userId: string, subscription: UserSkillSubscription): void;
+  remove(userId: string, skillId: string): boolean;
+}
+
+export class LocalUserSkillSubscriptionStore implements UserSkillSubscriptionStore {
+  constructor(
+    private readonly filePath = path.join(loadSkillHubConfig().dataDir, 'subscriptions.json'),
+  ) {}
+
+  list(userId: string): UserSkillSubscription[] {
+    const key = requiredKey(userId, 'userId');
+    return Object.values(this.read(key).users[key] || {})
+      .sort((left, right) => left.skillId.localeCompare(right.skillId));
+  }
+
+  get(userId: string, skillId: string): UserSkillSubscription | undefined {
+    const userKey = requiredKey(userId, 'userId');
+    const skillKey = requiredKey(skillId, 'skillId');
+    return this.read(userKey).users[userKey]?.[skillKey];
+  }
+
+  set(userId: string, subscription: UserSkillSubscription): void {
+    const userKey = requiredKey(userId, 'userId');
+    const skillKey = requiredKey(subscription.skillId, 'skillId');
+    const state = this.read(userKey);
+    state.users[userKey] = state.users[userKey] || {};
+    state.users[userKey][skillKey] = { ...subscription, skillId: skillKey };
+    this.write(state);
+  }
+
+  remove(userId: string, skillId: string): boolean {
+    const userKey = requiredKey(userId, 'userId');
+    const skillKey = requiredKey(skillId, 'skillId');
+    const state = this.read(userKey);
+    if (!state.users[userKey]?.[skillKey]) return false;
+    delete state.users[userKey][skillKey];
+    if (Object.keys(state.users[userKey]).length === 0) delete state.users[userKey];
+    this.write(state);
+    return true;
+  }
+
+  private read(userId: string): SubscriptionStateFile {
+    if (!fs.existsSync(this.filePath)) return emptyState();
+    try {
+      const parsed = JSON.parse(fs.readFileSync(this.filePath, 'utf8')) as unknown;
+      if (isCurrentState(parsed)) return parsed;
+      if (isLegacyState(parsed)) {
+        const migrated = migrateLegacyState(parsed, userId);
+        this.write(migrated);
+        return migrated;
+      }
+      return emptyState();
+    } catch {
+      return emptyState();
+    }
+  }
+
+  private write(state: SubscriptionStateFile): void {
+    fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
+    const tempPath = `${this.filePath}.tmp-${process.pid}-${Date.now()}`;
+    fs.writeFileSync(tempPath, `${JSON.stringify(state, null, 2)}\n`, 'utf8');
+    fs.renameSync(tempPath, this.filePath);
+  }
+}
+
+function emptyState(): SubscriptionStateFile {
+  return { schema: SUBSCRIPTION_SCHEMA, users: {} };
+}
+
+function isCurrentState(value: unknown): value is SubscriptionStateFile {
+  const state = value as Partial<SubscriptionStateFile> | null;
+  return state?.schema === SUBSCRIPTION_SCHEMA && Boolean(state.users) && typeof state.users === 'object';
+}
+
+function isLegacyState(value: unknown): value is LegacySubscriptionStateFile {
+  const state = value as Partial<LegacySubscriptionStateFile> | null;
+  return state?.schema === LEGACY_SUBSCRIPTION_SCHEMA && Boolean(state.agents) && typeof state.agents === 'object';
+}
+
+function migrateLegacyState(legacy: LegacySubscriptionStateFile, userId: string): SubscriptionStateFile {
+  const subscriptions: Record<string, UserSkillSubscription> = {};
+  for (const bucket of Object.values(legacy.agents)) {
+    if (!bucket || typeof bucket !== 'object') continue;
+    for (const subscription of Object.values(bucket)) {
+      const skillId = String(subscription?.skillId || '').trim();
+      if (!skillId) continue;
+      const current = subscriptions[skillId];
+      if (!current || timestamp(subscription.updatedAt) >= timestamp(current.updatedAt)) {
+        subscriptions[skillId] = { ...subscription, skillId };
+      }
+    }
+  }
+  return {
+    schema: SUBSCRIPTION_SCHEMA,
+    users: Object.keys(subscriptions).length ? { [userId]: subscriptions } : {},
+  };
+}
+
+function timestamp(value: unknown): number {
+  const parsed = Date.parse(String(value || ''));
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function requiredKey(value: string, field: string): string {
+  const key = String(value || '').trim();
+  if (!key) throw new Error(`${field} required`);
+  return key;
+}

--- a/src/skillhub/types.ts
+++ b/src/skillhub/types.ts
@@ -48,15 +48,23 @@ export interface SkillHubInstallResult {
     name: string;
     version: string;
     path: string;
+    installName: string;
+    action: 'installed' | 'updated' | 'unchanged';
   };
   signingKeyId: string;
   rootKeyId: string;
 }
 
+export type SkillHubSubscriptionScope =
+  | { kind: 'user'; userId: string }
+  | { kind: 'runtime' };
+
 export interface SkillHubPackageInstallMarker {
   source: 'skillhub';
+  userId?: string;
   skillId: string;
   name: string;
+  installName: string;
   version: string;
   packageChecksumSha256: string;
   signature: VerifierRegistryEntry['signature'];
@@ -66,5 +74,21 @@ export interface SkillHubPackageInstallMarker {
 
 export type SkillHubRegistryEntry = VerifierRegistryEntry & {
   contentHash?: string;
+  description?: string;
+  categories?: string[];
+  tags?: string[];
+  permissions?: Record<string, unknown>;
+  runtime?: Record<string, unknown>;
+  riskLevel?: string;
 };
+
+export interface UserSkillSubscription {
+  skillId: string;
+  name: string;
+  installName: string;
+  versionPolicy: 'latest';
+  resolvedVersion: string;
+  subscribedAt: string;
+  updatedAt: string;
+}
 export type { SkillHubTrustResponse };

--- a/src/tools/default-tool-names.ts
+++ b/src/tools/default-tool-names.ts
@@ -16,6 +16,7 @@ export const DEFAULT_TOOL_NAMES = [
   'update_plan',
   'record_decision',
   'share_skillhub_skill',
+  'skillhub',
   'skill',
 ] as const;
 

--- a/src/tools/local-tool-risk.ts
+++ b/src/tools/local-tool-risk.ts
@@ -95,6 +95,14 @@ export function classifyLocalToolRisk(
   args: unknown,
   context: ToolExecutionContext,
 ): LocalToolRiskDecision {
+  if (toolName === 'skillhub') {
+    return {
+      requiresConfirmation: false,
+      risk: 'low',
+      reason: 'SkillHub 工具只允许受约束的目录浏览和当前 Agent 订阅操作，不使用二次确认。',
+    };
+  }
+
   if (context.surface === 'catscompany') {
     return { requiresConfirmation: false, risk: 'low', reason: 'CatsCo lightweight execution routes do not require local confirmation.' };
   }

--- a/src/tools/skillhub-tool.ts
+++ b/src/tools/skillhub-tool.ts
@@ -31,6 +31,7 @@ export class SkillHubTool implements Tool {
       '只有当用户在当前请求中明确要求订阅、安装、取消订阅或删除时，才能调用 subscribe/unsubscribe。',
       'subscribe 总是获取 latest：未安装时安装，已有同一 Skill 时更新或保持最新；同名异源会安全拒绝。',
       '在虚拟员工中，subscribe/unsubscribe 只表示为当前员工添加或删除 Skill，不需要 SkillHub 登录。',
+      '一次只调用一个 subscribe/unsubscribe；多个 Skill 必须串行处理，任一操作失败后停止，不要并行或重试。',
       'unsubscribe 只删除带有匹配 SkillHub 安装标记的本地 Skill。不要把发布者删除版本的请求交给本工具。',
     ].join('\n'),
     parameters: {

--- a/src/tools/skillhub-tool.ts
+++ b/src/tools/skillhub-tool.ts
@@ -1,0 +1,156 @@
+import type { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
+import { SkillHubService } from '../skillhub/service';
+import { SkillHubSubscriptionService } from '../skillhub/subscription-service';
+import type { SkillHubSearchResponse } from '../skillhub/types';
+import {
+  isCatsCoLocalOwnerSelfContext,
+  isCatsCoToolGatewayContext,
+} from './tool-gateway';
+
+export interface SkillHubCatalogGateway {
+  search(query?: string, options?: { category?: string }): Promise<SkillHubSearchResponse & { installed?: unknown[] }>;
+}
+
+export interface SkillHubSubscriptionGateway {
+  list(): ReturnType<SkillHubSubscriptionService['list']>;
+  subscribe(skillId: string): ReturnType<SkillHubSubscriptionService['subscribe']>;
+  unsubscribe(skillId: string): ReturnType<SkillHubSubscriptionService['unsubscribe']>;
+}
+
+export class SkillHubTool implements Tool {
+  constructor(
+    private readonly catalog: SkillHubCatalogGateway = new SkillHubService(),
+    private readonly subscriptions: SkillHubSubscriptionGateway = new SkillHubSubscriptionService(),
+  ) {}
+
+  definition: ToolDefinition = {
+    name: 'skillhub',
+    description: [
+      '浏览 SkillHub，并管理当前运行环境中已添加的 Skill。',
+      'browse/search 用于查看可用 Skill；list_subscriptions 查看当前运行环境已添加的 Skill。',
+      '只有当用户在当前请求中明确要求订阅、安装、取消订阅或删除时，才能调用 subscribe/unsubscribe。',
+      'subscribe 总是获取 latest：未安装时安装，已有同一 Skill 时更新或保持最新；同名异源会安全拒绝。',
+      '在虚拟员工中，subscribe/unsubscribe 只表示为当前员工添加或删除 Skill，不需要 SkillHub 登录。',
+      'unsubscribe 只删除带有匹配 SkillHub 安装标记的本地 Skill。不要把发布者删除版本的请求交给本工具。',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        action: {
+          type: 'string',
+          enum: ['browse', 'search', 'list_subscriptions', 'subscribe', 'unsubscribe'],
+          description: '要执行的 SkillHub 动作。',
+        },
+        query: {
+          type: 'string',
+          description: 'browse/search 的可选关键词；browse 可留空。',
+        },
+        category: {
+          type: 'string',
+          description: 'browse/search 的可选分类。',
+        },
+        skillId: {
+          type: 'string',
+          description: 'subscribe/unsubscribe 使用的完整 SkillHub skillId，例如 author/skill-name。',
+        },
+      },
+      required: ['action'],
+    },
+  };
+
+  async execute(args: any, context: ToolExecutionContext): Promise<ToolExecutionResult> {
+    const action = String(args?.action || '').trim();
+    try {
+      if (action === 'browse' || action === 'search') {
+        const query = action === 'browse' ? String(args?.query || '') : required(args?.query, 'query');
+        const response = await this.catalog.search(query, {
+          category: String(args?.category || '').trim() || undefined,
+        });
+        const skills = Array.isArray(response.skills) ? response.skills : [];
+        return {
+          ok: true,
+          content: JSON.stringify({
+            query,
+            total: skills.length,
+            skills: skills.slice(0, 20).map(skill => ({
+              skillId: skill.skillId,
+              name: skill.displayName || skill.name || skill.skillId,
+              description: clipped(skill.description, 500),
+              latestVersion: skill.latestVersion,
+              categories: skill.categories || [],
+              riskLevel: skill.riskLevel,
+              permissions: skill.permissions,
+            })),
+            truncated: skills.length > 20,
+          }, null, 2),
+        };
+      }
+
+      if (action === 'list_subscriptions') {
+        const result = await this.subscriptions.list();
+        return {
+          ok: true,
+          content: JSON.stringify(result, null, 2),
+        };
+      }
+
+      if (action === 'subscribe' || action === 'unsubscribe') {
+        const denied = mutationDenied(context);
+        if (denied) return denied;
+        const skillId = required(args?.skillId, 'skillId');
+        if (action === 'subscribe') {
+          const result = await this.subscriptions.subscribe(skillId);
+          await context.runtimeServices?.skillManager.loadSkills();
+          return {
+            ok: true,
+            content: JSON.stringify(result, null, 2),
+          };
+        }
+
+        const result = await this.subscriptions.unsubscribe(skillId);
+        await context.runtimeServices?.skillManager.loadSkills();
+        return {
+          ok: true,
+          content: JSON.stringify(result, null, 2),
+        };
+      }
+
+      return {
+        ok: false,
+        errorCode: 'INVALID_TOOL_ARGUMENTS',
+        message: 'action must be browse, search, list_subscriptions, subscribe, or unsubscribe',
+      };
+    } catch (error: any) {
+      return {
+        ok: false,
+        errorCode: String(error?.code || 'SKILLHUB_OPERATION_FAILED'),
+        message: error?.message || String(error),
+        retryable: Number(error?.status || 0) >= 500,
+      };
+    }
+  }
+}
+
+function mutationDenied(context: ToolExecutionContext): ToolExecutionResult | undefined {
+  if (!isCatsCoToolGatewayContext(context) || isCatsCoLocalOwnerSelfContext(context)) return undefined;
+  return {
+    ok: false,
+    errorCode: 'PERMISSION_DENIED',
+    message: '只有当前 Agent 的所有者可以添加或删除 Skill。',
+  };
+}
+
+function required(value: unknown, field: string): string {
+  const normalized = String(value || '').trim();
+  if (!normalized) {
+    const error: any = new Error(`${field} required`);
+    error.code = 'INVALID_TOOL_ARGUMENTS';
+    throw error;
+  }
+  return normalized;
+}
+
+function clipped(value: unknown, maxLength: number): string {
+  const text = String(value || '').trim();
+  return text.length <= maxLength ? text : `${text.slice(0, maxLength)}…`;
+}

--- a/src/tools/tool-manager.ts
+++ b/src/tools/tool-manager.ts
@@ -18,6 +18,7 @@ import { ResumeSubagentTool } from './resume-subagent-tool';
 import { UpdatePlanTool } from './update-plan-tool';
 import { RecordDecisionTool } from './record-decision-tool';
 import { ShareSkillHubSkillTool } from './share-skillhub-skill-tool';
+import { SkillHubTool } from './skillhub-tool';
 import { AskParentTool } from './ask-parent-tool';
 import { DEFAULT_TOOL_NAMES } from './default-tool-names';
 import { mergeToolExecutionContext } from '../utils/tool-context';
@@ -97,6 +98,7 @@ export class ToolManager implements ToolExecutor {
       new UpdatePlanTool(),
       new RecordDecisionTool(),
       new ShareSkillHubSkillTool(),
+      new SkillHubTool(),
       new SkillTool(),
     ];
 

--- a/tests/runtime-characterization.test.ts
+++ b/tests/runtime-characterization.test.ts
@@ -90,6 +90,7 @@ describe('runtime characterization', () => {
         'send_text',
         'share_skillhub_skill',
         'skill',
+        'skillhub',
         'spawn_subagent',
         'stop_subagent',
         'update_plan',

--- a/tests/skillhub-service-install.test.ts
+++ b/tests/skillhub-service-install.test.ts
@@ -61,7 +61,12 @@ describe('SkillHub connected install service', () => {
     assert.equal(fs.existsSync(path.join(install.skill.path, 'skill.json')), false);
     assert.equal(fs.existsSync(path.join(install.skill.path, 'REVIEW.json')), false);
     assert.equal(fs.existsSync(path.join(install.skill.path, 'SBOM.json')), false);
-    assert.equal(fs.existsSync(path.join(install.skill.path, '.xiaoba-skillhub-install.json')), false);
+    const markerPath = path.join(install.skill.path, '.xiaoba-skillhub-install.json');
+    assert.equal(fs.existsSync(markerPath), true);
+    const marker = JSON.parse(fs.readFileSync(markerPath, 'utf8'));
+    assert.equal(marker.source, 'skillhub');
+    assert.equal(marker.skillId, fixture.entry.skillId);
+    assert.equal(marker.version, fixture.entry.latestVersion);
   });
 
   test('does not write files when package checksum verification fails', async () => {

--- a/tests/skillhub-subscription.test.ts
+++ b/tests/skillhub-subscription.test.ts
@@ -346,6 +346,14 @@ describe('SkillHub user subscriptions', () => {
     assert.match(String(subscribed.ok && subscribed.content), /skillhub-user/);
   });
 
+  test('Tool tells the Agent to serialize multiple subscription mutations', () => {
+    const tool = new SkillHubTool();
+
+    assert.match(tool.definition.description, /一次只调用一个 subscribe\/unsubscribe/);
+    assert.match(tool.definition.description, /任一操作失败后停止/);
+    assert.match(tool.definition.description, /不要并行或重试/);
+  });
+
   test('Tool rejects subscription mutations from a non-owner CatsCo actor', async () => {
     let called = false;
     const tool = new SkillHubTool(

--- a/tests/skillhub-subscription.test.ts
+++ b/tests/skillhub-subscription.test.ts
@@ -1,0 +1,507 @@
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import * as assert from 'node:assert/strict';
+import * as fs from 'fs';
+import { createServer } from 'http';
+import * as os from 'os';
+import * as path from 'path';
+import { SkillHubService } from '../src/skillhub/service';
+import {
+  claimSkillHubPackageOwnership,
+  installVerifiedSkillHubPackage,
+  SkillHubInstallError,
+  uninstallSkillHubPackage,
+} from '../src/skillhub/package-installer';
+import { LocalUserSkillSubscriptionStore } from '../src/skillhub/subscription-store';
+import { SkillHubSubscriptionService } from '../src/skillhub/subscription-service';
+import type { SkillHubInstallResult, SkillHubUser, UserSkillSubscription } from '../src/skillhub/types';
+import { SkillHubTool } from '../src/tools/skillhub-tool';
+import { ToolManager } from '../src/tools/tool-manager';
+import type { ExecutionScope, ScopedLocalDeviceGrant } from '../src/types/session-identity';
+import type { ToolExecutionContext } from '../src/types/tool';
+
+describe('SkillHub user subscriptions', () => {
+  let testRoot: string;
+  let originalSkillsDir: string | undefined;
+  let originalUserDataDir: string | undefined;
+  let originalCatsCoToken: string | undefined;
+  let originalCatsCoApiKey: string | undefined;
+  let originalCatsCompanyToken: string | undefined;
+  let originalCatsCompanyApiKey: string | undefined;
+  let originalCatsCoBaseUrl: string | undefined;
+
+  beforeEach(() => {
+    testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-skillhub-subscriptions-'));
+    originalSkillsDir = process.env.XIAOBA_SKILLS_DIR;
+    originalUserDataDir = process.env.XIAOBA_USER_DATA_DIR;
+    originalCatsCoToken = process.env.CATSCO_USER_TOKEN;
+    originalCatsCoApiKey = process.env.CATSCO_API_KEY;
+    originalCatsCompanyToken = process.env.CATSCOMPANY_USER_TOKEN;
+    originalCatsCompanyApiKey = process.env.CATSCOMPANY_API_KEY;
+    originalCatsCoBaseUrl = process.env.CATSCO_HTTP_BASE_URL;
+    process.env.XIAOBA_SKILLS_DIR = path.join(testRoot, 'skills');
+    process.env.XIAOBA_USER_DATA_DIR = testRoot;
+    fs.mkdirSync(process.env.XIAOBA_SKILLS_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (originalSkillsDir === undefined) delete process.env.XIAOBA_SKILLS_DIR;
+    else process.env.XIAOBA_SKILLS_DIR = originalSkillsDir;
+    restoreEnv('XIAOBA_USER_DATA_DIR', originalUserDataDir);
+    restoreEnv('CATSCO_USER_TOKEN', originalCatsCoToken);
+    restoreEnv('CATSCO_API_KEY', originalCatsCoApiKey);
+    restoreEnv('CATSCOMPANY_USER_TOKEN', originalCatsCompanyToken);
+    restoreEnv('CATSCOMPANY_API_KEY', originalCatsCompanyApiKey);
+    restoreEnv('CATSCO_HTTP_BASE_URL', originalCatsCoBaseUrl);
+    fs.rmSync(testRoot, { recursive: true, force: true });
+  });
+
+  test('stores subscriptions independently for each SkillHub user', () => {
+    const store = new LocalUserSkillSubscriptionStore(path.join(testRoot, 'subscriptions.json'));
+    store.set('user-a', subscription('alice/ppt', 'ppt', '1.0.0'));
+    store.set('user-b', subscription('bob/search', 'search', '2.0.0'));
+
+    assert.deepEqual(store.list('user-a').map(item => item.skillId), ['alice/ppt']);
+    assert.deepEqual(store.list('user-b').map(item => item.skillId), ['bob/search']);
+    assert.equal(store.remove('user-a', 'alice/ppt'), true);
+    assert.deepEqual(store.list('user-a'), []);
+    assert.deepEqual(store.list('user-b').map(item => item.skillId), ['bob/search']);
+  });
+
+  test('migrates the prototype Agent buckets to the first authenticated SkillHub user', () => {
+    const filePath = path.join(testRoot, 'subscriptions.json');
+    fs.writeFileSync(filePath, JSON.stringify({
+      schema: 'xiaoba.skillhub.subscriptions.v1',
+      agents: {
+        'agent-a': { 'alice/ppt': subscription('alice/ppt', 'ppt', '1.0.0') },
+        'agent-b': { 'bob/search': subscription('bob/search', 'search', '2.0.0') },
+      },
+    }));
+    const store = new LocalUserSkillSubscriptionStore(filePath);
+
+    assert.deepEqual(store.list('skillhub-user').map(item => item.skillId), ['alice/ppt', 'bob/search']);
+    const migrated = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    assert.equal(migrated.schema, 'xiaoba.skillhub.subscriptions.v2');
+    assert.deepEqual(Object.keys(migrated.users), ['skillhub-user']);
+    assert.equal('agents' in migrated, false);
+  });
+
+  test('resolves identity from the SkillHub session and auto-connects with the local CatsCo login', async t => {
+    let exchangeBody: any;
+    const server = createServer((request, response) => {
+      if (request.method === 'GET' && request.url === '/api/auth/me') {
+        if (!String(request.headers.cookie || '').includes('skillhub_session=test-session')) {
+          response.writeHead(401, { 'Content-Type': 'application/json' });
+          response.end(JSON.stringify({ error: 'login required' }));
+          return;
+        }
+        response.writeHead(200, { 'Content-Type': 'application/json' });
+        response.end(JSON.stringify({
+          user: skillHubUser('skillhub-user'),
+          roles: ['user'],
+          permissions: [],
+        }));
+        return;
+      }
+      if (request.method === 'POST' && request.url === '/api/auth/catsco-exchange') {
+        const chunks: Buffer[] = [];
+        request.on('data', chunk => chunks.push(Buffer.from(chunk)));
+        request.on('end', () => {
+          exchangeBody = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+          response.writeHead(200, {
+            'Content-Type': 'application/json',
+            'Set-Cookie': 'skillhub_session=test-session; Path=/; HttpOnly',
+          });
+          response.end(JSON.stringify({ ok: true }));
+        });
+        return;
+      }
+      response.writeHead(404);
+      response.end();
+    });
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+    t.after(() => new Promise<void>(resolve => server.close(() => resolve())));
+    const address = server.address();
+    assert.ok(address && typeof address !== 'string');
+    process.env.CATSCO_USER_TOKEN = 'catsco-login-token';
+    process.env.CATSCO_API_KEY = 'catsco-bot-key-that-must-not-win';
+    process.env.CATSCO_HTTP_BASE_URL = 'https://catsco.example';
+
+    const service = new SkillHubService({ baseUrl: `http://127.0.0.1:${address.port}` });
+    const user = await service.requireAuthenticatedUser();
+
+    assert.equal(user.id, 'skillhub-user');
+    assert.equal(exchangeBody.token, 'catsco-login-token');
+    assert.equal(exchangeBody.baseUrl, 'https://catsco.example');
+  });
+
+  test('uses runtime-local Skill state for a cloud Agent without contacting SkillHub auth', async () => {
+    delete process.env.CATSCO_USER_TOKEN;
+    delete process.env.CATSCOMPANY_USER_TOKEN;
+    delete process.env.CATSCO_API_KEY;
+    process.env.CATSCOMPANY_API_KEY = 'cc_420_cloud-agent-key';
+
+    const service = new SkillHubService({ baseUrl: 'http://127.0.0.1:1' });
+    const scope = await service.resolveSubscriptionScope();
+
+    assert.deepEqual(scope, { kind: 'runtime' });
+  });
+
+  test('subscribe is idempotent and refreshes the same Skill to latest', async () => {
+    const store = new LocalUserSkillSubscriptionStore(path.join(testRoot, 'subscriptions.json'));
+    let version = '1.0.0';
+    let action: SkillHubInstallResult['skill']['action'] = 'installed';
+    const installCalls: Array<{ skillId: string; userId?: string; allowUpdate?: boolean }> = [];
+    const gateway = {
+      resolveSubscriptionScope: async () => ({ kind: 'user' as const, userId: 'user-a' }),
+      install: async (skillId: string, _requested?: string, options?: { userId?: string; allowUpdate?: boolean }) => {
+        installCalls.push({ skillId, ...options });
+        return installResult(skillId, version, action);
+      },
+      uninstall: () => ({ removed: true, path: path.join(testRoot, 'skills', 'ppt') }),
+    };
+    const timestamps = [new Date('2026-07-14T01:00:00.000Z'), new Date('2026-07-14T02:00:00.000Z')];
+    const service = new SkillHubSubscriptionService(gateway, store, () => timestamps.shift()!);
+
+    const first = await service.subscribe('alice/ppt');
+    version = '1.1.0';
+    action = 'updated';
+    const second = await service.subscribe('alice/ppt');
+
+    assert.equal(first.action, 'installed');
+    assert.equal(second.action, 'updated');
+    assert.equal(second.subscription.resolvedVersion, '1.1.0');
+    assert.equal(second.subscription.subscribedAt, '2026-07-14T01:00:00.000Z');
+    assert.equal(second.subscription.updatedAt, '2026-07-14T02:00:00.000Z');
+    assert.deepEqual(installCalls, [
+      { skillId: 'alice/ppt', userId: 'user-a', allowUpdate: true },
+      { skillId: 'alice/ppt', userId: 'user-a', allowUpdate: true },
+    ]);
+  });
+
+  test('unsubscribe deletes the managed copy before removing the user subscription', async () => {
+    const store = new LocalUserSkillSubscriptionStore(path.join(testRoot, 'subscriptions.json'));
+    store.set('user-a', subscription('alice/ppt', 'ppt', '1.0.0'));
+    const uninstallCalls: unknown[] = [];
+    const gateway = {
+      resolveSubscriptionScope: async () => ({ kind: 'user' as const, userId: 'user-a' }),
+      install: async () => installResult('alice/ppt', '1.0.0', 'unchanged'),
+      uninstall: (input: unknown) => {
+        uninstallCalls.push(input);
+        return { removed: true, path: path.join(testRoot, 'skills', 'ppt') };
+      },
+    };
+    const service = new SkillHubSubscriptionService(gateway, store);
+
+    const result = await service.unsubscribe('alice/ppt');
+
+    assert.deepEqual(result, {
+      scope: 'user',
+      userId: 'user-a',
+      skillId: 'alice/ppt',
+      removed: true,
+      subscriptionFound: true,
+    });
+    assert.deepEqual(uninstallCalls, [{ userId: 'user-a', skillId: 'alice/ppt', installName: 'ppt' }]);
+    assert.deepEqual(store.list('user-a'), []);
+  });
+
+  test('runtime scope installs, lists, and removes Skills using only install markers', async () => {
+    const storePath = path.join(testRoot, 'subscriptions.json');
+    const store = new LocalUserSkillSubscriptionStore(storePath);
+    const installCalls: unknown[] = [];
+    const gateway = {
+      resolveSubscriptionScope: async () => ({ kind: 'runtime' as const }),
+      install: async (skillId: string, _requested?: string, options?: { userId?: string; allowUpdate?: boolean }) => {
+        installCalls.push({ skillId, options });
+        const installed = installVerifiedSkillHubPackage(
+          packageOptions(skillId, 'ppt', '1.0.0', '# runtime', undefined),
+        );
+        return {
+          ok: true as const,
+          skill: installed,
+          signingKeyId: 'signing-test',
+          rootKeyId: 'root-test',
+        };
+      },
+      uninstall: (input: { userId?: string; skillId: string; installName: string }) => (
+        uninstallSkillHubPackage(input)
+      ),
+    };
+    const service = new SkillHubSubscriptionService(
+      gateway,
+      store,
+      () => new Date('2026-07-14T03:00:00.000Z'),
+    );
+
+    const added = await service.subscribe('alice/ppt');
+    const listed = await service.list();
+
+    assert.equal(added.scope, 'runtime');
+    assert.equal(added.userId, undefined);
+    assert.deepEqual(installCalls, [{
+      skillId: 'alice/ppt',
+      options: { allowUpdate: true },
+    }]);
+    assert.deepEqual(listed.subscriptions.map(item => item.skillId), ['alice/ppt']);
+    assert.equal(fs.existsSync(storePath), false);
+
+    const removed = await service.unsubscribe('alice/ppt');
+    assert.deepEqual(removed, {
+      scope: 'runtime',
+      skillId: 'alice/ppt',
+      removed: true,
+      subscriptionFound: true,
+    });
+    assert.equal(fs.existsSync(path.join(testRoot, 'skills', 'ppt')), false);
+    assert.equal(fs.existsSync(storePath), false);
+  });
+
+  test('verified installs write trusted markers, update same skill, and reject same-name strangers', () => {
+    const first = installVerifiedSkillHubPackage(packageOptions('alice/ppt', 'ppt', '1.0.0', '# v1', 'user-a'));
+    assert.equal(first.action, 'installed');
+    const marker = JSON.parse(fs.readFileSync(path.join(first.path, '.xiaoba-skillhub-install.json'), 'utf8'));
+    assert.equal(marker.userId, 'user-a');
+    assert.equal(marker.skillId, 'alice/ppt');
+
+    const unchanged = installVerifiedSkillHubPackage(packageOptions('alice/ppt', 'ppt', '1.0.0', '# v1', 'user-a'));
+    assert.equal(unchanged.action, 'unchanged');
+
+    const updated = installVerifiedSkillHubPackage(packageOptions('alice/ppt', 'ppt', '1.1.0', '# v2', 'user-a'));
+    assert.equal(updated.action, 'updated');
+    assert.match(fs.readFileSync(path.join(updated.path, 'SKILL.md'), 'utf8'), /# v2/);
+
+    assert.throws(
+      () => installVerifiedSkillHubPackage(packageOptions('mallory/ppt', 'ppt', '9.0.0', '# stranger', 'user-a')),
+      (error: any) => error instanceof SkillHubInstallError && error.code === 'TARGET_CONFLICT',
+    );
+  });
+
+  test('uninstall only removes the matching SkillHub user and Skill marker', () => {
+    installVerifiedSkillHubPackage(packageOptions('alice/ppt', 'ppt', '1.0.0', '# v1', 'user-a'));
+
+    assert.throws(
+      () => uninstallSkillHubPackage({ userId: 'user-b', skillId: 'alice/ppt', installName: 'ppt' }),
+      (error: any) => error instanceof SkillHubInstallError && error.code === 'USER_CONFLICT',
+    );
+    assert.equal(fs.existsSync(path.join(testRoot, 'skills', 'ppt')), true);
+
+    const result = uninstallSkillHubPackage({ userId: 'user-a', skillId: 'alice/ppt', installName: 'ppt' });
+    assert.equal(result.removed, true);
+    assert.equal(fs.existsSync(path.join(testRoot, 'skills', 'ppt')), false);
+  });
+
+  test('claims legacy install markers for the authenticated SkillHub user', () => {
+    const installed = installVerifiedSkillHubPackage(packageOptions('alice/ppt', 'ppt', '1.0.0', '# v1', 'old-user'));
+    const markerPath = path.join(installed.path, '.xiaoba-skillhub-install.json');
+    const legacyMarker = JSON.parse(fs.readFileSync(markerPath, 'utf8'));
+    delete legacyMarker.userId;
+    legacyMarker.agentId = 'usr420';
+    fs.writeFileSync(markerPath, JSON.stringify(legacyMarker, null, 2));
+
+    assert.equal(claimSkillHubPackageOwnership({
+      userId: 'skillhub-user',
+      skillId: 'alice/ppt',
+      installName: 'ppt',
+    }), true);
+    const claimed = JSON.parse(fs.readFileSync(markerPath, 'utf8'));
+    assert.equal(claimed.userId, 'skillhub-user');
+    assert.equal('agentId' in claimed, false);
+  });
+
+  test('Tool can browse and owner can subscribe without a confirmation step', async () => {
+    const calls: string[] = [];
+    const tool = new SkillHubTool(
+      {
+        search: async query => ({
+          skills: [{
+            skillId: 'alice/ppt',
+            name: 'ppt',
+            displayName: 'PPT Assistant',
+            description: `matches ${query}`,
+            latestVersion: '1.0.0',
+            packageUrl: '/download',
+            checksumSha256: 'abc',
+            signature: { algorithm: 'ed25519', keyId: 'key', signature: 'sig' },
+          }],
+        }),
+      },
+      {
+        list: async () => ({ scope: 'user', userId: 'skillhub-user', subscriptions: [] }),
+        subscribe: async skillId => {
+          calls.push(skillId);
+          return { scope: 'user', userId: 'skillhub-user', action: 'installed', subscription: subscription(skillId, 'ppt', '1.0.0') };
+        },
+        unsubscribe: async skillId => ({ scope: 'user', userId: 'skillhub-user', skillId, removed: true, subscriptionFound: true }),
+      },
+    );
+
+    const browse = await tool.execute({ action: 'search', query: 'slides' }, baseContext());
+    assert.equal(browse.ok, true);
+    assert.match(String(browse.ok && browse.content), /alice\/ppt/);
+
+    const subscribed = await tool.execute({ action: 'subscribe', skillId: 'alice/ppt' }, ownerContext());
+    assert.equal(subscribed.ok, true);
+    assert.deepEqual(calls, ['alice/ppt']);
+    assert.doesNotMatch(String(subscribed.ok && subscribed.content), /usr43/);
+    assert.match(String(subscribed.ok && subscribed.content), /skillhub-user/);
+  });
+
+  test('Tool rejects subscription mutations from a non-owner CatsCo actor', async () => {
+    let called = false;
+    const tool = new SkillHubTool(
+      { search: async () => ({ skills: [] }) },
+      {
+        list: async () => ({ scope: 'user', userId: 'skillhub-user', subscriptions: [] }),
+        subscribe: async () => {
+          called = true;
+          return { scope: 'user', userId: 'skillhub-user', action: 'installed', subscription: subscription('alice/ppt', 'ppt', '1.0.0') };
+        },
+        unsubscribe: async skillId => {
+          called = true;
+          return { scope: 'user', userId: 'skillhub-user', skillId, removed: true, subscriptionFound: true };
+        },
+      },
+    );
+    const context = ownerContext();
+    context.executionScope = { ...context.executionScope!, actorUserId: 'usr9' };
+
+    const result = await tool.execute({ action: 'unsubscribe', skillId: 'alice/ppt' }, context);
+
+    assert.equal(result.ok, false);
+    if (!result.ok) assert.equal(result.errorCode, 'PERMISSION_DENIED');
+    assert.equal(called, false);
+  });
+
+  test('ToolManager does not introduce a confirmation step for SkillHub operations', async () => {
+    const manager = new ToolManager(testRoot, {}, { enabledToolNames: [] });
+    let confirmations = 0;
+    manager.registerTool({
+      definition: {
+        name: 'skillhub',
+        description: 'test skillhub',
+        parameters: { type: 'object', properties: {} },
+      },
+      execute: async () => ({ ok: true, content: 'skillhub ran' }),
+    });
+
+    const result = await manager.executeTool({
+      id: 'skillhub-no-confirmation',
+      type: 'function',
+      function: { name: 'skillhub', arguments: '{}' },
+    }, [], {
+      permissionProfile: 'strict',
+      confirmToolExecution: async () => {
+        confirmations += 1;
+        return false;
+      },
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(confirmations, 0);
+  });
+});
+
+function subscription(skillId: string, installName: string, version: string): UserSkillSubscription {
+  return {
+    skillId,
+    name: installName,
+    installName,
+    versionPolicy: 'latest',
+    resolvedVersion: version,
+    subscribedAt: '2026-07-14T00:00:00.000Z',
+    updatedAt: '2026-07-14T00:00:00.000Z',
+  };
+}
+
+function skillHubUser(id: string): SkillHubUser {
+  return { id, email: `${id}@example.com`, displayName: id };
+}
+
+function installResult(
+  skillId: string,
+  version: string,
+  action: SkillHubInstallResult['skill']['action'],
+): SkillHubInstallResult {
+  return {
+    ok: true,
+    skill: {
+      skillId,
+      name: 'ppt',
+      installName: 'ppt',
+      version,
+      path: path.join(os.tmpdir(), 'skills', 'ppt'),
+      action,
+    },
+    signingKeyId: 'signing-test',
+    rootKeyId: 'root-test',
+  };
+}
+
+function packageOptions(skillId: string, name: string, version: string, content: string, userId?: string): any {
+  const encoded = Buffer.from(content).toString('base64');
+  const checksum = `${skillId}:${version}:${content}`;
+  return {
+    userId,
+    allowUpdate: true,
+    registryEntry: {
+      skillId,
+      name,
+      latestVersion: version,
+      packageUrl: `/skills/${skillId}/${version}`,
+      checksumSha256: checksum,
+      signature: { algorithm: 'ed25519', keyId: 'signing-test', signature: 'sig' },
+    },
+    verification: {
+      packageObject: {
+        payload: {
+          packageSchemaVersion: '1.0.0',
+          manifest: { id: skillId, name, displayName: name, version, entrypoints: { skillFile: 'SKILL.md' } },
+          files: [{ path: 'SKILL.md', size: content.length, sha256: checksum, contentBase64: encoded }],
+        },
+      },
+      signingKey: { keyId: 'signing-test' },
+      root: { keyId: 'root-test' },
+    },
+  };
+}
+
+function baseContext(): ToolExecutionContext {
+  return { workingDirectory: testCwd(), conversationHistory: [] };
+}
+
+function ownerContext(): ToolExecutionContext {
+  const scope: ExecutionScope = {
+    source: 'catscompany',
+    sessionKey: 'session:v2:catscompany:p2p:p2p_7_43:agent:usr43',
+    topicId: 'p2p_7_43',
+    topicType: 'p2p',
+    actorUserId: 'usr7',
+    agentId: 'usr43',
+    agentBodyId: 'body-main',
+    identityTrust: 'server_canonical',
+    isTrusted: true,
+  };
+  const localDeviceGrant: ScopedLocalDeviceGrant = {
+    kind: 'catscompany_body',
+    source: 'catscompany',
+    ownerUserId: 'usr7',
+    bodyId: 'body-main',
+    createdAt: Date.now(),
+  };
+  return {
+    workingDirectory: testCwd(),
+    conversationHistory: [],
+    surface: 'catscompany',
+    executionScope: scope,
+    localDeviceGrant,
+  };
+}
+
+function testCwd(): string {
+  return process.env.XIAOBA_SKILLS_DIR || process.cwd();
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}


### PR DESCRIPTION
## 背景

让 Agent 能直接查看 SkillHub 中有什么，并按用户请求添加或删除 Skill。桌面端和虚拟员工使用同一个 `skillhub` Tool，但订阅状态采用不同作用域。

## 改动

- 注册默认 `skillhub` Tool，提供 `browse`、`search`、`list_subscriptions`、`subscribe`、`unsubscribe`。
- 桌面端以 SkillHub 登录用户为作用域保存订阅；将早期按 Agent 保存的本地记录迁移为按用户保存。
- 只有 API Key、没有人类登录 Token 的虚拟员工使用 runtime 作用域：
  - 不要求虚拟员工登录 SkillHub；
  - 直接安装到该员工自己的 Skill 目录；
  - 通过受管安装标记列出和删除已添加的 Skill。
- 订阅始终获取 latest；同一 Skill 可安全更新或保持不变，同名异源目录会拒绝覆盖。
- 删除只允许匹配 `skillId` 和 SkillHub 安装标记的目录。
- CatsCompany 会话中的添加/删除继续使用服务端可信身份，并只允许当前 Agent 的 owner。
- 多个订阅操作要求串行执行，首个失败后停止，避免并发调用和消息限流。
- 未修改 CatsCompany 仓库或协议。

## 作用域

| 运行环境 | Tool | 订阅身份 | 状态来源 |
| --- | --- | --- | --- |
| 桌面端 | `skillhub` | SkillHub 登录用户 | 本地 user subscription store |
| 虚拟员工 | `skillhub` | 当前运行实例 | 该实例 Skill 目录中的安装标记 |

## 部署要求

独立虚拟员工的 `currentBot.boundByUserUid` 必须写入真实 owner UID，不能使用部署占位值；否则 owner-only 变更会被安全拒绝。

## 验证

- `npm run build`
- `npx tsx --test tests/skillhub-subscription.test.ts`：14/14 通过
- `npm test`：957 项，953 通过，4 跳过，0 失败
- 独立虚拟员工真实环境验证：
  - SkillHub browse/list 正常；
  - owner 可添加；
  - 非 owner 被拒绝；
  - 服务重启后 Skill 目录和既有 Skill 保持正常。
