### PR TITLE
修复 Dashboard 退出后的 CatsCo connector 孤儿锁

### DIFF
--- a/src/catscompany/connector-lock.ts
+++ b/src/catscompany/connector-lock.ts
@@ -5,6 +5,7 @@ import * as path from 'node:path';
 export interface CatsCoConnectorLockRecord {
   bodyId: string;
   pid: number;
+  ownerPid?: number;
   startedAt: string;
   command?: string;
   token: string;
@@ -29,13 +30,15 @@ export function acquireCatsCoConnectorLock(options: {
   runtimeRoot: string;
   bodyId: string;
   command?: string;
+  ownerPid?: number;
 }): CatsCoConnectorLockResult {
   const lockDir = path.join(options.runtimeRoot, '.xiaoba');
   const lockPath = path.join(lockDir, 'catsco-connector.lock.json');
   fs.mkdirSync(lockDir, { recursive: true });
 
   const existing = readLock(lockPath);
-  if (existing && existing.bodyId === options.bodyId && isProcessAlive(existing.pid)) {
+  const existingOwnerExited = existing?.ownerPid !== undefined && !isProcessAlive(existing.ownerPid);
+  if (existing && existing.bodyId === options.bodyId && isProcessAlive(existing.pid) && !existingOwnerExited) {
     return {
       acquired: false,
       lockPath,
@@ -46,6 +49,7 @@ export function acquireCatsCoConnectorLock(options: {
   const record: CatsCoConnectorLockRecord = {
     bodyId: options.bodyId,
     pid: process.pid,
+    ...(isValidPid(options.ownerPid) ? { ownerPid: options.ownerPid } : {}),
     startedAt: new Date().toISOString(),
     command: options.command,
     token: crypto.randomUUID(),
@@ -74,6 +78,7 @@ function readLock(lockPath: string): CatsCoConnectorLockRecord | null {
       return {
         bodyId: parsed.bodyId,
         pid,
+        ownerPid: isValidPid(parsed.ownerPid) ? parsed.ownerPid : undefined,
         startedAt: parsed.startedAt,
         command: typeof parsed.command === 'string' ? parsed.command : undefined,
         token: parsed.token,
@@ -101,8 +106,12 @@ function releaseCatsCoConnectorLock(lockPath: string, record: CatsCoConnectorLoc
   }
 }
 
-function isProcessAlive(pid: number): boolean {
-  if (!Number.isInteger(pid) || pid <= 0) {
+function isValidPid(pid: unknown): pid is number {
+  return typeof pid === 'number' && Number.isInteger(pid) && pid > 0;
+}
+
+export function isProcessAlive(pid: number): boolean {
+  if (!isValidPid(pid)) {
     return false;
   }
   try {

--- a/src/commands/catscompany.ts
+++ b/src/commands/catscompany.ts
@@ -5,7 +5,9 @@ import { CatsCompanyConfig } from '../catscompany/types';
 import { startRuntimeCommandSupport, stopRuntimeCommandSupport } from '../utils/runtime-command-support';
 import { ChatConfig } from '../types';
 import { resolveCatsCoRuntimeConfig } from '../catscompany/runtime-config';
-import { CatsCoConnectorLock, acquireCatsCoConnectorLock } from '../catscompany/connector-lock';
+import { CatsCoConnectorLock, acquireCatsCoConnectorLock, isProcessAlive } from '../catscompany/connector-lock';
+
+const CONNECTOR_OWNER_POLL_MS = 2000;
 
 export interface CatsCoCommandConfigResolution {
   config?: CatsCompanyConfig;
@@ -44,29 +46,46 @@ export async function catscompanyCommand(): Promise<void> {
     process.exit(1);
   }
 
+  const configuredOwnerPid = Number(process.env.CATSCO_CONNECTOR_OWNER_PID);
+  const ownerPid = Number.isInteger(configuredOwnerPid) && configuredOwnerPid > 0 && configuredOwnerPid !== process.pid
+    ? configuredOwnerPid
+    : undefined;
   const connectorLock = acquireCatsCoConnectorLock({
     runtimeRoot: process.cwd(),
     bodyId,
     command: process.argv.join(' '),
+    ownerPid,
   });
   if (!connectorLock.acquired) {
-    Logger.warning(
-      `CatsCo connector already running for this device; skip duplicate startup. bodyId=${bodyId}, pid=${connectorLock.existing.pid}`,
+    Logger.error(
+      `CatsCo connector 已由另一个进程运行，无法重复启动。bodyId=${bodyId}, pid=${connectorLock.existing.pid}`,
     );
     Logger.warning('已跳过第二条 CatsCo WebSocket 连接，避免同一设备重复连接互相挤下线。');
+    process.exitCode = 2;
     return;
   }
 
   const bot = new CatsCompanyBot(connectorConfig);
   let lock: CatsCoConnectorLock | null = connectorLock;
+  let ownerWatchTimer: NodeJS.Timeout | null = null;
+  let shuttingDown = false;
 
   // 优雅退出
   const shutdown = async () => {
-    await stopRuntimeCommandSupport();
-    await bot.destroy();
-    lock?.release();
-    lock = null;
-    process.exit(0);
+    if (shuttingDown) return;
+    shuttingDown = true;
+    if (ownerWatchTimer) {
+      clearInterval(ownerWatchTimer);
+      ownerWatchTimer = null;
+    }
+    try {
+      await stopRuntimeCommandSupport();
+      await bot.destroy();
+    } finally {
+      lock?.release();
+      lock = null;
+      process.exit(0);
+    }
   };
   process.on('SIGINT', shutdown);
   process.on('SIGTERM', shutdown);
@@ -75,10 +94,22 @@ export async function catscompanyCommand(): Promise<void> {
     lock = null;
   });
 
+  if (ownerPid) {
+    ownerWatchTimer = setInterval(() => {
+      if (isProcessAlive(ownerPid)) return;
+      Logger.warning(`CatsCo Dashboard owner process 已退出，正在关闭孤儿 connector。ownerPid=${ownerPid}`);
+      void shutdown();
+    }, CONNECTOR_OWNER_POLL_MS);
+  }
+
   try {
     await bot.start();
     await startRuntimeCommandSupport();
   } catch (error) {
+    if (ownerWatchTimer) {
+      clearInterval(ownerWatchTimer);
+      ownerWatchTimer = null;
+    }
     lock?.release();
     lock = null;
     throw error;

--- a/src/dashboard/service-manager.ts
+++ b/src/dashboard/service-manager.ts
@@ -250,6 +250,7 @@ export class ServiceManager extends EventEmitter {
       envVars = {
         ...envVars,
         ...catsCoRuntime.envOverlay,
+        CATSCO_CONNECTOR_OWNER_PID: String(process.pid),
       };
     }
 

--- a/tests/catsco-connector-lock.test.ts
+++ b/tests/catsco-connector-lock.test.ts
@@ -41,6 +41,32 @@ describe('CatsCo connector startup lock', () => {
     otherDevice.release();
   });
 
+  test('replaces a live connector lock whose dashboard owner has exited', () => {
+    const lockDir = path.join(tempDir, '.xiaoba');
+    fs.mkdirSync(lockDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(lockDir, 'catsco-connector.lock.json'),
+      JSON.stringify({
+        bodyId: 'body-a',
+        pid: process.pid,
+        ownerPid: 2_147_483_647,
+        startedAt: new Date().toISOString(),
+        command: 'orphaned-dashboard-connector',
+        token: 'orphaned-token',
+      }),
+      'utf8',
+    );
+
+    const acquired = acquireCatsCoConnectorLock({
+      runtimeRoot: tempDir,
+      bodyId: 'body-a',
+      command: 'replacement',
+      ownerPid: process.pid,
+    });
+    assert.equal(acquired.acquired, true);
+    acquired.release();
+  });
+
   test('overwrites a stale lock for the same body id', () => {
     const lockDir = path.join(tempDir, '.xiaoba');
     fs.mkdirSync(lockDir, { recursive: true });

--- a/tests/dashboard-service-manager.test.ts
+++ b/tests/dashboard-service-manager.test.ts
@@ -143,6 +143,26 @@ describe('dashboard service manager', () => {
     assert.equal((service?.lastError || '').includes('sk-live-secret1234567890'), false);
   });
 
+  test('passes the dashboard owner pid to the CatsCo connector process', async () => {
+    const manager = new ServiceManager(process.cwd());
+    const serviceRecord = (manager as any).services.get('catscompany');
+    serviceRecord.info.command = process.execPath;
+    serviceRecord.info.args = [
+      '-e',
+      "console.log('owner=' + process.env.CATSCO_CONNECTOR_OWNER_PID);",
+    ];
+
+    const stopped = new Promise<void>(resolve => {
+      manager.once('service-stopped', () => resolve());
+    });
+
+    manager.start('catscompany');
+    await stopped;
+
+    assert.ok(manager.getLogs('catscompany').includes(`owner=${process.pid}`));
+    assert.equal(manager.getService('catscompany')?.status, 'stopped');
+  });
+
   test('treats dashboard-requested service stop as stopped even when the child exits non-zero', async () => {
     const manager = new ServiceManager(process.cwd());
     const serviceRecord = (manager as any).services.get('weixin');


### PR DESCRIPTION
## 改动内容

- Dashboard 启动 CatsCo connector 时传入 owner PID
- owner 进程退出后，connector 自动停止并释放启动锁
- 允许新进程接管 owner 已退出的孤儿锁
- 重复启动时返回明确错误，避免按钮静默恢复为“启动”
- 保持纯 CLI/systemd connector 原有的常驻重连行为

## 问题原因

Dashboard 异常退出后，CatsCo connector 可能继续存活并持有本地锁。后续从首页或机器人页面再次启动时，新进程会识别为重复实例后正常退出，界面因此只短暂显示启动中，再恢复为启动按钮。

## 用户影响

修复后，Dashboard 所属 connector 会跟随 Dashboard 生命周期退出。再次打开桌面应用时不会被此前遗留的 connector 锁阻塞；真正的重复实例也会显示可诊断的错误。

## 验证

- `npx tsx --test tests/catsco-connector-lock.test.ts tests/catscompany-client-body-id.test.ts tests/catsco-command-config.test.ts tests/dashboard-service-manager.test.ts`（28/28）
- `npm test`（956 通过，0 失败，4 跳过）
- `npm run build`
- `git diff --check`