### PR TITLE
feat: 缺失会话时从 CatsCompany 恢复上下文

### DIFF
--- a/src/catscompany/client.ts
+++ b/src/catscompany/client.ts
@@ -97,6 +97,33 @@ export interface MessageContext {
   seq?: number;   // Cats 服务端消息序号，用于排序和补充消息合并
 }
 
+export interface CatsAgentContextMessage {
+  id: number;
+  seq_id: number;
+  topic_id: string;
+  from_uid: number;
+  content?: unknown;
+  content_blocks?: unknown[];
+  type?: string;
+  msg_type?: string;
+  metadata?: Record<string, unknown>;
+  created_at?: string;
+  agent_uid: number;
+  agent_id: string;
+  context_role: 'user' | 'assistant' | 'other_agent';
+  context_eligible: boolean;
+  context_reason?: string;
+  mentions?: string[];
+}
+
+export interface CatsAgentContextPage {
+  messages: CatsAgentContextMessage[];
+  topic_id: string;
+  agent_uid: number;
+  has_more: boolean;
+  next_before_id: number;
+}
+
 export interface CatsOutgoingMessage {
   topic_id?: string;
   topic?: string;
@@ -445,6 +472,50 @@ export class CatsClient extends EventEmitter {
 
   async sendMessage(topic: string, text: string): Promise<number> {
     return this.sendStructuredMessage({ topic_id: topic, type: 'text', content: text });
+  }
+
+  async getAgentContextHistory(
+    topic: string,
+    options: { beforeId?: number; limit?: number; signal?: AbortSignal } = {},
+  ): Promise<CatsAgentContextPage> {
+    const url = new URL(`${this.httpBaseUrl()}/api/messages`);
+    url.searchParams.set('topic_id', topic);
+    url.searchParams.set('agent_context', '1');
+    url.searchParams.set('latest', '1');
+    url.searchParams.set('limit', String(options.limit || 100));
+    if (options.beforeId && options.beforeId > 0) {
+      url.searchParams.set('before_id', String(options.beforeId));
+    }
+
+    const res = await fetch(url, {
+      headers: {
+        Authorization: `ApiKey ${this.config.apiKey}`,
+        'User-Agent': CATSCOMPANY_CLIENT_UA,
+      },
+      signal: options.signal ?? AbortSignal.timeout(15_000),
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => '');
+      throw new Error(`CatsCompany agent context history failed: ${res.status}${body ? ` ${body.slice(0, 200)}` : ''}`);
+    }
+
+    const payload = await res.json() as Partial<CatsAgentContextPage>;
+    if (
+      !Array.isArray(payload.messages)
+      || typeof payload.topic_id !== 'string'
+      || typeof payload.agent_uid !== 'number'
+      || typeof payload.has_more !== 'boolean'
+      || typeof payload.next_before_id !== 'number'
+    ) {
+      throw new Error('CatsCompany server does not support safe agent context history');
+    }
+    return {
+      messages: payload.messages,
+      topic_id: payload.topic_id,
+      agent_uid: payload.agent_uid,
+      has_more: payload.has_more,
+      next_before_id: payload.next_before_id,
+    };
   }
 
   private buildPubMessage(msgId: string, payload: CatsOutgoingMessage): Record<string, unknown> {

--- a/src/catscompany/cloud-session-restore.ts
+++ b/src/catscompany/cloud-session-restore.ts
@@ -1,0 +1,334 @@
+import type { Message } from '../types';
+import type { AIService } from '../utils/ai-service';
+import { Logger } from '../utils/logger';
+import { SessionStore } from '../utils/session-store';
+import { ContextCompressor } from '../core/context-compressor';
+import { estimateMessagesTokens } from '../core/token-estimator';
+import type {
+  CatsAgentContextMessage,
+  CatsAgentContextPage,
+} from './client';
+
+const CLOUD_RESTORE_PAGE_SIZE = 200;
+const CLOUD_RESTORE_MAX_PAGES = 10;
+const CLOUD_RESTORE_DIRECT_TOKEN_BUDGET = 60_000;
+const CLOUD_RESTORE_FETCH_TOKEN_BUDGET = 160_000;
+const CLOUD_RESTORE_FINAL_TOKEN_CEILING = 90_000;
+const CLOUD_RESTORE_SUMMARY_INPUT_BUDGET = 70_000;
+const CLOUD_RESTORE_RECENT_EPISODES = 12;
+const CLOUD_RESTORE_RECENT_TOKEN_BUDGET = 30_000;
+
+interface AgentContextHistoryClient {
+  getAgentContextHistory(
+    topic: string,
+    options?: { beforeId?: number; limit?: number; signal?: AbortSignal },
+  ): Promise<CatsAgentContextPage>;
+}
+
+interface SessionContextStore {
+  hasSession(sessionKey: string): boolean;
+  loadContext(sessionKey: string): Message[];
+  saveContext(sessionKey: string, messages: Message[]): void;
+}
+
+export interface CloudSessionRestoreRequest {
+  sessionKey: string;
+  topicId: string;
+  topicType: 'p2p' | 'group';
+  agentId: string;
+  currentSeq: number;
+  signal?: AbortSignal;
+}
+
+export interface CloudSessionRestoreResult {
+  status: 'local_present' | 'restored' | 'empty' | 'skipped' | 'failed';
+  restoredMessages: number;
+  fetchedMessages: number;
+  compressed: boolean;
+  error?: unknown;
+}
+
+export class CatsCompanyCloudSessionRestorer {
+  constructor(
+    private readonly client: AgentContextHistoryClient,
+    private readonly aiService: AIService,
+    private readonly sessionStore: SessionContextStore = SessionStore.getInstance(),
+  ) {}
+
+  async restoreIfMissing(request: CloudSessionRestoreRequest): Promise<CloudSessionRestoreResult> {
+    if (this.hasLocalContext(request.sessionKey)) {
+      return this.result('local_present');
+    }
+    if (!Number.isFinite(request.currentSeq) || request.currentSeq <= 0) {
+      return this.result('skipped');
+    }
+
+    try {
+      const fetched = await this.fetchHistory(request);
+      if (fetched.messages.length === 0) {
+        return this.result('empty', { fetchedMessages: fetched.fetchedMessages });
+      }
+
+      const prepared = await this.prepareForPersistence(fetched.messages, request.signal);
+      if (this.hasLocalContext(request.sessionKey)) {
+        return this.result('local_present', { fetchedMessages: fetched.fetchedMessages });
+      }
+
+      this.sessionStore.saveContext(request.sessionKey, prepared.messages);
+      Logger.info(
+        `[${request.sessionKey}] 云端主会话恢复完成: fetched=${fetched.fetchedMessages}, `
+        + `restored=${prepared.messages.length}, compressed=${prepared.compressed}`,
+      );
+      return this.result('restored', {
+        restoredMessages: prepared.messages.length,
+        fetchedMessages: fetched.fetchedMessages,
+        compressed: prepared.compressed,
+      });
+    } catch (error) {
+      Logger.warning(`[${request.sessionKey}] 云端主会话恢复失败，继续使用本地空白会话: ${describeError(error)}`);
+      return this.result('failed', { error });
+    }
+  }
+
+  private hasLocalContext(sessionKey: string): boolean {
+    if (!this.sessionStore.hasSession(sessionKey)) return false;
+    return this.sessionStore.loadContext(sessionKey).length > 0;
+  }
+
+  private async fetchHistory(request: CloudSessionRestoreRequest): Promise<{
+    messages: Message[];
+    fetchedMessages: number;
+  }> {
+    let beforeId = request.currentSeq;
+    let fetchedMessages = 0;
+    let messages: Message[] = [];
+
+    for (let pageIndex = 0; pageIndex < CLOUD_RESTORE_MAX_PAGES; pageIndex++) {
+      const page = await this.client.getAgentContextHistory(request.topicId, {
+        beforeId,
+        limit: CLOUD_RESTORE_PAGE_SIZE,
+        signal: request.signal,
+      });
+      this.assertPageScope(page, request);
+      fetchedMessages += page.messages.length;
+
+      const pageMessages = normalizeAgentContextMessages(page.messages, request);
+      messages = coalesceAssistantSegments([...pageMessages, ...messages]);
+
+      if (
+        !page.has_more
+        || page.next_before_id <= 0
+        || page.next_before_id >= beforeId
+        || estimateMessagesTokens(messages) >= CLOUD_RESTORE_FETCH_TOKEN_BUDGET
+      ) {
+        break;
+      }
+      beforeId = page.next_before_id;
+    }
+
+    return { messages, fetchedMessages };
+  }
+
+  private assertPageScope(page: CatsAgentContextPage, request: CloudSessionRestoreRequest): void {
+    if (page.topic_id !== request.topicId) {
+      throw new Error(`agent context topic mismatch: ${page.topic_id}`);
+    }
+    if (normalizeUID(page.agent_uid) !== normalizeUID(request.agentId)) {
+      throw new Error(`agent context identity mismatch: ${page.agent_uid}`);
+    }
+  }
+
+  private async prepareForPersistence(
+    messages: Message[],
+    signal?: AbortSignal,
+  ): Promise<{ messages: Message[]; compressed: boolean }> {
+    const usedTokens = estimateMessagesTokens(messages);
+    if (usedTokens <= CLOUD_RESTORE_DIRECT_TOKEN_BUDGET) {
+      return { messages, compressed: false };
+    }
+
+    try {
+      const compressor = new ContextCompressor(this.aiService, {
+        maxContextTokens: CLOUD_RESTORE_FINAL_TOKEN_CEILING,
+        summaryContentBudget: CLOUD_RESTORE_SUMMARY_INPUT_BUDGET,
+        preserveRecentEpisodes: CLOUD_RESTORE_RECENT_EPISODES,
+        preserveRecentEpisodeTokenBudget: CLOUD_RESTORE_RECENT_TOKEN_BUDGET,
+        preserveRecentEpisodeMaxShare: 0.4,
+      });
+      const compacted = await compressor.compact(messages, {
+        signal,
+        customInstructions: [
+          '这些内容来自 CatsCompany 云端可见聊天历史，用于在新设备上恢复主会话。',
+          '保留用户目标、关键决定、已交付结果、文件名、未完成事项和重要约束。',
+          '不要声称恢复了工具调用、本地文件状态、设备授权或未出现在历史里的信息。',
+        ].join('\n'),
+      });
+      return {
+        messages: trimToTokenBudget(compacted, CLOUD_RESTORE_FINAL_TOKEN_CEILING),
+        compressed: true,
+      };
+    } catch (error) {
+      Logger.warning(`云端历史摘要失败，降级保留最近上下文: ${describeError(error)}`);
+      return {
+        messages: trimToTokenBudget(messages, CLOUD_RESTORE_DIRECT_TOKEN_BUDGET),
+        compressed: true,
+      };
+    }
+  }
+
+  private result(
+    status: CloudSessionRestoreResult['status'],
+    overrides: Partial<CloudSessionRestoreResult> = {},
+  ): CloudSessionRestoreResult {
+    return {
+      status,
+      restoredMessages: 0,
+      fetchedMessages: 0,
+      compressed: false,
+      ...overrides,
+    };
+  }
+}
+
+export function normalizeAgentContextMessages(
+  messages: CatsAgentContextMessage[],
+  request: Pick<CloudSessionRestoreRequest, 'topicType' | 'agentId'>,
+): Message[] {
+  const normalized: Message[] = [];
+  let episodeId = 'cloud:initial';
+
+  for (const message of messages) {
+    if (
+      message.context_eligible !== true
+      || normalizeUID(message.agent_id || message.agent_uid) !== normalizeUID(request.agentId)
+      || (message.context_role !== 'user' && message.context_role !== 'assistant')
+    ) {
+      continue;
+    }
+
+    let text = cloudMessageText(message);
+    if (!text || isNonAnswerPlaceholder(text)) continue;
+    if (request.topicType === 'group' && message.context_role === 'user') {
+      const speaker = cloudSpeakerLabel(message);
+      if (speaker) text = `[群聊成员 ${speaker}]\n${text}`;
+    }
+
+    if (message.context_role === 'user') {
+      episodeId = `cloud:${message.seq_id || message.id}`;
+    }
+    normalized.push({
+      role: message.context_role,
+      content: text,
+      __episodeId: episodeId,
+      ...(message.context_role === 'user' ? { __episodeInputKind: 'root' as const } : {}),
+    });
+  }
+
+  return normalized;
+}
+
+function cloudMessageText(message: CatsAgentContextMessage): string {
+  if (typeof message.content === 'string') return message.content.trim();
+  if (!message.content || typeof message.content !== 'object') return '';
+
+  const rich = message.content as Record<string, unknown>;
+  const type = String(rich.type || message.type || message.msg_type || '').trim();
+  const payload = rich.payload && typeof rich.payload === 'object'
+    ? rich.payload as Record<string, unknown>
+    : rich;
+  const name = String(payload.name || payload.file_name || '').trim();
+  const description = String(payload.text || payload.description || '').trim();
+  if (type === 'file') return `[历史文件${name ? `：${name}` : ''}]${description ? ` ${description}` : ''}`;
+  if (type === 'image') return `[历史图片${name ? `：${name}` : ''}]${description ? ` ${description}` : ''}`;
+  if (type === 'voice') return `[历史语音]${description ? ` ${description}` : ''}`;
+  return description;
+}
+
+function cloudSpeakerLabel(message: CatsAgentContextMessage): string {
+  const metadata = message.metadata;
+  if (!metadata || typeof metadata !== 'object') return normalizeUID(message.from_uid);
+  const identity = metadata.catsco_identity;
+  if (!identity || typeof identity !== 'object') return normalizeUID(message.from_uid);
+  const actor = (identity as Record<string, unknown>).actor;
+  if (!actor || typeof actor !== 'object') return normalizeUID(message.from_uid);
+  const values = actor as Record<string, unknown>;
+  return String(values.display_name || values.username || values.user_id || normalizeUID(message.from_uid)).trim();
+}
+
+function coalesceAssistantSegments(messages: Message[]): Message[] {
+  const result: Message[] = [];
+  for (const message of messages) {
+    const previous = result[result.length - 1];
+    if (
+      message.role === 'assistant'
+      && previous?.role === 'assistant'
+      && previous.__episodeId === message.__episodeId
+      && typeof previous.content === 'string'
+      && typeof message.content === 'string'
+    ) {
+      previous.content = `${previous.content}\n\n${message.content}`;
+      continue;
+    }
+    result.push({ ...message });
+  }
+  return result;
+}
+
+function trimToTokenBudget(messages: Message[], budget: number): Message[] {
+  if (estimateMessagesTokens(messages) <= budget) return messages;
+  const boundary: Message = {
+    role: 'user',
+    content: '[设备恢复提示] 更早的 CatsCompany 云端历史已截断，以避免恢复后的上下文过大。',
+  };
+  const contentBudget = Math.max(1, budget - estimateMessagesTokens([boundary]));
+  const selected: Message[] = [];
+  let used = 0;
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index];
+    const tokens = estimateMessagesTokens([message]);
+    if (tokens > contentBudget && selected.length === 0) {
+      selected.unshift(truncateMessageToTokenBudget(message, contentBudget));
+      break;
+    }
+    if (used + tokens > contentBudget) break;
+    selected.unshift(message);
+    used += tokens;
+  }
+  return [boundary, ...selected];
+}
+
+function truncateMessageToTokenBudget(message: Message, budget: number): Message {
+  const text = typeof message.content === 'string' ? message.content : String(message.content ?? '');
+  const suffix = '\n\n[该条历史消息在设备恢复时已截断]';
+  let low = 0;
+  let high = text.length;
+  let best = suffix;
+  while (low <= high) {
+    const middle = Math.floor((low + high) / 2);
+    const candidate = `${text.slice(0, middle)}${suffix}`;
+    if (estimateMessagesTokens([{ ...message, content: candidate }]) <= budget) {
+      best = candidate;
+      low = middle + 1;
+    } else {
+      high = middle - 1;
+    }
+  }
+  return { ...message, content: best };
+}
+
+function isNonAnswerPlaceholder(text: string): boolean {
+  const normalized = text.trim();
+  return normalized === '[无回复]'
+    || normalized === '[No response]'
+    || normalized.startsWith('[处理失败:');
+}
+
+function normalizeUID(value: unknown): string {
+  const raw = String(value ?? '').trim();
+  const numeric = raw.match(/^(?:usr)?(\d+)$/i);
+  return numeric ? `usr${numeric[1]}` : raw;
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/catscompany/cloud-session-restore.ts
+++ b/src/catscompany/cloud-session-restore.ts
@@ -2,6 +2,7 @@ import type { Message } from '../types';
 import type { AIService } from '../utils/ai-service';
 import { Logger } from '../utils/logger';
 import { SessionStore } from '../utils/session-store';
+import { stripAssistantTranscriptArtifacts } from '../utils/transcript-artifacts';
 import { ContextCompressor } from '../core/context-compressor';
 import { estimateMessagesTokens } from '../core/token-estimator';
 import type {
@@ -27,7 +28,6 @@ interface AgentContextHistoryClient {
 
 interface SessionContextStore {
   hasSession(sessionKey: string): boolean;
-  loadContext(sessionKey: string): Message[];
   saveContext(sessionKey: string, messages: Message[]): void;
 }
 
@@ -56,7 +56,7 @@ export class CatsCompanyCloudSessionRestorer {
   ) {}
 
   async restoreIfMissing(request: CloudSessionRestoreRequest): Promise<CloudSessionRestoreResult> {
-    if (this.hasLocalContext(request.sessionKey)) {
+    if (this.hasLocalSession(request.sessionKey)) {
       return this.result('local_present');
     }
     if (!Number.isFinite(request.currentSeq) || request.currentSeq <= 0) {
@@ -70,7 +70,7 @@ export class CatsCompanyCloudSessionRestorer {
       }
 
       const prepared = await this.prepareForPersistence(fetched.messages, request.signal);
-      if (this.hasLocalContext(request.sessionKey)) {
+      if (this.hasLocalSession(request.sessionKey)) {
         return this.result('local_present', { fetchedMessages: fetched.fetchedMessages });
       }
 
@@ -85,14 +85,17 @@ export class CatsCompanyCloudSessionRestorer {
         compressed: prepared.compressed,
       });
     } catch (error) {
-      Logger.warning(`[${request.sessionKey}] 云端主会话恢复失败，继续使用本地空白会话: ${describeError(error)}`);
+      Logger.warning(`[${request.sessionKey}] 云端主会话恢复失败，未创建本地空白会话，等待后续重试: ${describeError(error)}`);
       return this.result('failed', { error });
     }
   }
 
-  private hasLocalContext(sessionKey: string): boolean {
-    if (!this.sessionStore.hasSession(sessionKey)) return false;
-    return this.sessionStore.loadContext(sessionKey).length > 0;
+  markLocalSessionCleared(sessionKey: string): void {
+    this.sessionStore.saveContext(sessionKey, []);
+  }
+
+  private hasLocalSession(sessionKey: string): boolean {
+    return this.sessionStore.hasSession(sessionKey);
   }
 
   private async fetchHistory(request: CloudSessionRestoreRequest): Promise<{
@@ -112,11 +115,16 @@ export class CatsCompanyCloudSessionRestorer {
       this.assertPageScope(page, request);
       fetchedMessages += page.messages.length;
 
-      const pageMessages = normalizeAgentContextMessages(page.messages, request);
+      const clearBoundaryIndex = findLastClearBoundaryIndex(page.messages, request);
+      const pageMessages = normalizeAgentContextMessages(
+        clearBoundaryIndex >= 0 ? page.messages.slice(clearBoundaryIndex + 1) : page.messages,
+        request,
+      );
       messages = coalesceAssistantSegments([...pageMessages, ...messages]);
 
       if (
-        !page.has_more
+        clearBoundaryIndex >= 0
+        || !page.has_more
         || page.next_before_id <= 0
         || page.next_before_id >= beforeId
         || estimateMessagesTokens(messages) >= CLOUD_RESTORE_FETCH_TOKEN_BUDGET
@@ -207,6 +215,9 @@ export function normalizeAgentContextMessages(
     }
 
     let text = cloudMessageText(message);
+    if (message.context_role === 'assistant') {
+      text = stripAssistantTranscriptArtifacts(text);
+    }
     if (!text || isNonAnswerPlaceholder(text)) continue;
     if (request.topicType === 'group' && message.context_role === 'user') {
       const speaker = cloudSpeakerLabel(message);
@@ -227,9 +238,29 @@ export function normalizeAgentContextMessages(
   return normalized;
 }
 
+function findLastClearBoundaryIndex(
+  messages: CatsAgentContextMessage[],
+  request: Pick<CloudSessionRestoreRequest, 'agentId'>,
+): number {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index];
+    if (
+      message.context_eligible === true
+      && message.context_role === 'user'
+      && normalizeUID(message.agent_id || message.agent_uid) === normalizeUID(request.agentId)
+      && /^\/clear(?:\s|$)/i.test(cloudMessageText(message))
+    ) {
+      return index;
+    }
+  }
+  return -1;
+}
+
 function cloudMessageText(message: CatsAgentContextMessage): string {
-  if (typeof message.content === 'string') return message.content.trim();
-  if (!message.content || typeof message.content !== 'object') return '';
+  if (typeof message.content === 'string' && message.content.trim()) return message.content.trim();
+  if (!message.content || typeof message.content !== 'object') {
+    return cloudContentBlocksText(message.content_blocks);
+  }
 
   const rich = message.content as Record<string, unknown>;
   const type = String(rich.type || message.type || message.msg_type || '').trim();
@@ -241,7 +272,26 @@ function cloudMessageText(message: CatsAgentContextMessage): string {
   if (type === 'file') return `[历史文件${name ? `：${name}` : ''}]${description ? ` ${description}` : ''}`;
   if (type === 'image') return `[历史图片${name ? `：${name}` : ''}]${description ? ` ${description}` : ''}`;
   if (type === 'voice') return `[历史语音]${description ? ` ${description}` : ''}`;
-  return description;
+  return description || cloudContentBlocksText(message.content_blocks);
+}
+
+function cloudContentBlocksText(blocks: unknown[] | undefined): string {
+  if (!Array.isArray(blocks)) return '';
+  const parts: string[] = [];
+  for (const block of blocks) {
+    if (!block || typeof block !== 'object') continue;
+    const values = block as Record<string, unknown>;
+    const type = String(values.type || '').trim();
+    if (type === 'text' && typeof values.text === 'string' && values.text.trim()) {
+      parts.push(values.text.trim());
+    } else if (type === 'image') {
+      parts.push('[历史图片]');
+    } else if (type === 'file') {
+      const name = String(values.name || values.file_name || '').trim();
+      parts.push(`[历史文件${name ? `：${name}` : ''}]`);
+    }
+  }
+  return parts.join('\n');
 }
 
 function cloudSpeakerLabel(message: CatsAgentContextMessage): string {

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -49,6 +49,7 @@ import {
   buildCatsCoAttachmentCachePath,
   scheduleCatsCoAttachmentCacheCleanup,
 } from './attachment-cache';
+import { CatsCompanyCloudSessionRestorer } from './cloud-session-restore';
 
 interface PendingAttachment {
   fileName: string;
@@ -255,6 +256,10 @@ export function isCatsCompanyPassiveAcknowledgement(text: string): boolean {
   return new RegExp(`^(?:${ack}|${thanks}|${ack}${thanks}|${thanks}${ack})$`, 'i').test(compact);
 }
 
+function isClearCommand(text: string): boolean {
+  return /^\s*\/clear(?:\s|$)/i.test(String(text || ''));
+}
+
 function compactCatsSubAgentSummary(text: string, maxLength = 4000): string {
   const normalized = text.replace(/\s+\n/g, '\n').trim();
   if (normalized.length <= maxLength) return normalized;
@@ -280,6 +285,8 @@ export class CatsCompanyBot {
   private sender: MessageSender;
   private sessionManager: MessageSessionManager;
   private agentServices: AgentServices;
+  private cloudSessionRestorer: CatsCompanyCloudSessionRestorer;
+  private cloudSessionRestorePromises = new Map<string, Promise<void>>();
   /** 等待用户后续指令的附件队列，key 为 sessionKey */
   private pendingAttachments = new Map<string, PendingAttachment[]>();
   /** 主会话忙时的消息队列，key = sessionKey */
@@ -344,6 +351,7 @@ export class CatsCompanyBot {
     this.runtime = runtime;
     this.runtimeProfile = runtime.profile;
     this.agentServices = runtime.services;
+    this.cloudSessionRestorer = new CatsCompanyCloudSessionRestorer(this.bot, this.agentServices.aiService);
     const { toolManager } = this.agentServices;
 
     Logger.info(`已注册 ${toolManager.getToolCount()} 个基础工具 (message mode)`);
@@ -1160,6 +1168,9 @@ export class CatsCompanyBot {
 
   private async processParsedMessage(msg: ParsedCatsMessage, key: string): Promise<void> {
     const sessionRoute = msg.envelope ? createCatsCoSessionRoute(msg.envelope) : undefined;
+    if (sessionRoute && !isClearCommand(msg.text)) {
+      await this.ensureCloudSessionRestored(msg, sessionRoute);
+    }
     const session = this.sessionManager.getOrCreate(sessionRoute && sessionRoute.sessionKey === key ? sessionRoute : key);
 
     // 处理斜杠命令
@@ -1318,6 +1329,50 @@ export class CatsCompanyBot {
 
     // 处理忙时排队的消息
     await this.drainMessageQueue(key);
+  }
+
+  private async ensureCloudSessionRestored(
+    msg: ParsedCatsMessage,
+    sessionRoute: ReturnType<typeof createCatsCoSessionRoute>,
+  ): Promise<void> {
+    if (this.sessionManager.get(sessionRoute)) return;
+    if (sessionRoute.topicType !== 'p2p' && sessionRoute.topicType !== 'group') return;
+
+    const key = sessionRoute.sessionKey;
+    const existing = this.cloudSessionRestorePromises.get(key);
+    if (existing) {
+      await existing;
+      return;
+    }
+
+    const restore = this.restoreCloudSessionWithStatus(msg, sessionRoute)
+      .finally(() => this.cloudSessionRestorePromises.delete(key));
+    this.cloudSessionRestorePromises.set(key, restore);
+    await restore;
+  }
+
+  private async restoreCloudSessionWithStatus(
+    msg: ParsedCatsMessage,
+    sessionRoute: ReturnType<typeof createCatsCoSessionRoute>,
+  ): Promise<void> {
+    let statusTimer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      statusTimer = setTimeout(() => {
+        void this.sender.sendThinking(msg.topic, '正在恢复并整理这段对话的云端上下文...').catch((error: any) => {
+          Logger.warning(`云端会话恢复提示发送失败: ${error?.message || error}`);
+        });
+      }, 800);
+
+      await this.cloudSessionRestorer.restoreIfMissing({
+        sessionKey: sessionRoute.sessionKey,
+        topicId: sessionRoute.topicId,
+        topicType: sessionRoute.topicType === 'group' ? 'group' : 'p2p',
+        agentId: sessionRoute.agentId || this.botUid || '',
+        currentSeq: Number(msg.seq || sessionRoute.channelSeq || 0),
+      });
+    } finally {
+      if (statusTimer) clearTimeout(statusTimer);
+    }
   }
 
   /**

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -49,7 +49,10 @@ import {
   buildCatsCoAttachmentCachePath,
   scheduleCatsCoAttachmentCacheCleanup,
 } from './attachment-cache';
-import { CatsCompanyCloudSessionRestorer } from './cloud-session-restore';
+import {
+  CatsCompanyCloudSessionRestorer,
+  type CloudSessionRestoreResult,
+} from './cloud-session-restore';
 
 interface PendingAttachment {
   fileName: string;
@@ -257,7 +260,7 @@ export function isCatsCompanyPassiveAcknowledgement(text: string): boolean {
 }
 
 function isClearCommand(text: string): boolean {
-  return /^\s*\/clear(?:\s|$)/i.test(String(text || ''));
+  return /^\/clear(?:\s|$)/i.test(String(text || ''));
 }
 
 function compactCatsSubAgentSummary(text: string, maxLength = 4000): string {
@@ -286,7 +289,7 @@ export class CatsCompanyBot {
   private sessionManager: MessageSessionManager;
   private agentServices: AgentServices;
   private cloudSessionRestorer: CatsCompanyCloudSessionRestorer;
-  private cloudSessionRestorePromises = new Map<string, Promise<void>>();
+  private cloudSessionRestorePromises = new Map<string, Promise<CloudSessionRestoreResult>>();
   /** 等待用户后续指令的附件队列，key 为 sessionKey */
   private pendingAttachments = new Map<string, PendingAttachment[]>();
   /** 主会话忙时的消息队列，key = sessionKey */
@@ -1169,7 +1172,16 @@ export class CatsCompanyBot {
   private async processParsedMessage(msg: ParsedCatsMessage, key: string): Promise<void> {
     const sessionRoute = msg.envelope ? createCatsCoSessionRoute(msg.envelope) : undefined;
     if (sessionRoute && !isClearCommand(msg.text)) {
-      await this.ensureCloudSessionRestored(msg, sessionRoute);
+      const restoreResult = await this.ensureCloudSessionRestored(msg, sessionRoute);
+      if (restoreResult.status === 'failed' || restoreResult.status === 'skipped') {
+        await this.sender.reply(
+          msg.topic,
+          '这台设备暂时没能恢复这段会话，我没有新建空白上下文。请稍后再发一次。',
+        ).catch((error: any) => {
+          Logger.warning(`云端会话恢复失败提示发送失败: ${error?.message || error}`);
+        });
+        return;
+      }
     }
     const session = this.sessionManager.getOrCreate(sessionRoute && sessionRoute.sessionKey === key ? sessionRoute : key);
 
@@ -1189,6 +1201,9 @@ export class CatsCompanyBot {
       }
       if (result.handled && command.toLowerCase() === 'clear') {
         this.pendingAttachments.delete(key);
+        if (!args.includes('--all')) {
+          this.cloudSessionRestorer.markLocalSessionCleared(sessionRoute?.sessionKey || key);
+        }
       }
       if (result.handled) return;
     }
@@ -1334,27 +1349,40 @@ export class CatsCompanyBot {
   private async ensureCloudSessionRestored(
     msg: ParsedCatsMessage,
     sessionRoute: ReturnType<typeof createCatsCoSessionRoute>,
-  ): Promise<void> {
-    if (this.sessionManager.get(sessionRoute)) return;
-    if (sessionRoute.topicType !== 'p2p' && sessionRoute.topicType !== 'group') return;
+  ): Promise<CloudSessionRestoreResult> {
+    if (this.sessionManager.get(sessionRoute)) {
+      return {
+        status: 'local_present',
+        restoredMessages: 0,
+        fetchedMessages: 0,
+        compressed: false,
+      };
+    }
+    if (sessionRoute.topicType !== 'p2p' && sessionRoute.topicType !== 'group') {
+      return {
+        status: 'skipped',
+        restoredMessages: 0,
+        fetchedMessages: 0,
+        compressed: false,
+      };
+    }
 
     const key = sessionRoute.sessionKey;
     const existing = this.cloudSessionRestorePromises.get(key);
     if (existing) {
-      await existing;
-      return;
+      return existing;
     }
 
     const restore = this.restoreCloudSessionWithStatus(msg, sessionRoute)
       .finally(() => this.cloudSessionRestorePromises.delete(key));
     this.cloudSessionRestorePromises.set(key, restore);
-    await restore;
+    return restore;
   }
 
   private async restoreCloudSessionWithStatus(
     msg: ParsedCatsMessage,
     sessionRoute: ReturnType<typeof createCatsCoSessionRoute>,
-  ): Promise<void> {
+  ): Promise<CloudSessionRestoreResult> {
     let statusTimer: ReturnType<typeof setTimeout> | undefined;
     try {
       statusTimer = setTimeout(() => {
@@ -1363,12 +1391,13 @@ export class CatsCompanyBot {
         });
       }, 800);
 
-      await this.cloudSessionRestorer.restoreIfMissing({
+      return await this.cloudSessionRestorer.restoreIfMissing({
         sessionKey: sessionRoute.sessionKey,
         topicId: sessionRoute.topicId,
         topicType: sessionRoute.topicType === 'group' ? 'group' : 'p2p',
         agentId: sessionRoute.agentId || this.botUid || '',
         currentSeq: Number(msg.seq || sessionRoute.channelSeq || 0),
+        signal: AbortSignal.timeout(30_000),
       });
     } finally {
       if (statusTimer) clearTimeout(statusTimer);

--- a/tests/catscompany-client-body-id.test.ts
+++ b/tests/catscompany-client-body-id.test.ts
@@ -304,6 +304,77 @@ describe('CatsCompany client body identity', () => {
     assert.equal(request.body.apiKey, undefined);
   });
 
+  test('loads agent context history with bot auth and a stable cursor', async () => {
+    const requestPromise = new Promise<{ url?: string; headers: Record<string, string | string[] | undefined> }>((resolve, reject) => {
+      const server = createServer((req, res) => {
+        resolve({ url: req.url, headers: req.headers });
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({
+          messages: [{
+            seq: 41,
+            topic_id: 'grp-test',
+            content: 'hello',
+            context_role: 'user',
+            context_eligible: true,
+          }],
+          topic_id: 'grp-test',
+          agent_uid: 63,
+          has_more: true,
+          next_before_id: 41,
+        }));
+      });
+      httpServers.push(server);
+      server.listen(0, '127.0.0.1', () => {
+        void (async () => {
+          const address = server.address() as AddressInfo;
+          const client = new CatsClient({
+            serverUrl: 'ws://127.0.0.1:1/v0/channels',
+            httpBaseUrl: `http://127.0.0.1:${address.port}`,
+            apiKey: 'cc-test-key',
+            bodyId: 'body-test',
+          });
+          const page = await client.getAgentContextHistory('grp-test', { beforeId: 88, limit: 25 });
+          assert.equal(page.agent_uid, 63);
+          assert.equal(page.has_more, true);
+          assert.equal(page.next_before_id, 41);
+          assert.equal(page.messages[0]?.context_role, 'user');
+        })().catch(reject);
+      });
+    });
+
+    const request = await requestPromise;
+    const url = new URL(request.url || '/', 'http://localhost');
+    assert.equal(url.pathname, '/api/messages');
+    assert.equal(url.searchParams.get('topic_id'), 'grp-test');
+    assert.equal(url.searchParams.get('agent_context'), '1');
+    assert.equal(url.searchParams.get('latest'), '1');
+    assert.equal(url.searchParams.get('limit'), '25');
+    assert.equal(url.searchParams.get('before_id'), '88');
+    assert.equal(request.headers.authorization, 'ApiKey cc-test-key');
+  });
+
+  test('rejects message history from servers without the safe agent context contract', async () => {
+    const server = createServer((_req, res) => {
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ messages: [{ seq: 1, content: 'legacy history' }] }));
+    });
+    httpServers.push(server);
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+
+    const address = server.address() as AddressInfo;
+    const client = new CatsClient({
+      serverUrl: 'ws://127.0.0.1:1/v0/channels',
+      httpBaseUrl: `http://127.0.0.1:${address.port}`,
+      apiKey: 'cc-test-key',
+      bodyId: 'body-test',
+    });
+
+    await assert.rejects(
+      client.getAgentContextHistory('usr-test'),
+      /does not support safe agent context history/,
+    );
+  });
+
   test('emits device rpc requests outside the regular message stream', async () => {
     const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
     servers.push(server);

--- a/tests/catscompany-execution-scope-flow.test.ts
+++ b/tests/catscompany-execution-scope-flow.test.ts
@@ -76,11 +76,17 @@ function metadataWithDeviceSelection(actorUserId: string, topicId: string, selec
   return metadata;
 }
 
-function createHarness(options: { busy?: boolean } = {}) {
+function createHarness(options: {
+  busy?: boolean;
+  existingSession?: boolean;
+  restoreStatus?: 'local_present' | 'restored' | 'empty' | 'skipped' | 'failed';
+} = {}) {
   const bot = Object.create(CatsCompanyBot.prototype) as any;
   const handledTurns: Array<{ userMessage: unknown; options: any }> = [];
   const sessionKeys: string[] = [];
   const sessionInputs: any[] = [];
+  const replies: string[] = [];
+  const clearedSessionMarkers: string[] = [];
   let busy = options.busy ?? false;
 
   const session = {
@@ -92,6 +98,9 @@ function createHarness(options: { busy?: boolean } = {}) {
       handledTurns.push({ userMessage, options: handleOptions });
       return { visibleToUser: false, text: '' };
     },
+    handleCommand: async (command: string) => command.toLowerCase() === 'clear'
+      ? { handled: true, reply: '历史已清空' }
+      : { handled: false },
     handleRuntimeObservation: async () => ({ visibleToUser: false, text: '' }),
   };
 
@@ -101,12 +110,12 @@ function createHarness(options: { busy?: boolean } = {}) {
       sessionKeys.push(typeof input === 'string' ? input : input.sessionKey);
       return session;
     },
-    get: () => session,
+    get: () => options.existingSession === false ? null : session,
   };
   bot.sender = {
     downloadFile: async () => null,
     sendTyping: () => undefined,
-    reply: async () => undefined,
+    reply: async (_topic: string, text: string) => { replies.push(text); },
     sendFile: async () => undefined,
     sendText: async () => undefined,
     sendThinking: async () => undefined,
@@ -116,11 +125,95 @@ function createHarness(options: { busy?: boolean } = {}) {
   bot.pendingAttachments = new Map();
   bot.messageQueue = new Map();
   bot.botUid = 'usr43';
+  bot.cloudSessionRestorePromises = new Map();
+  bot.cloudSessionRestorer = {
+    restoreIfMissing: async () => ({
+      status: options.restoreStatus || 'empty',
+      restoredMessages: 0,
+      fetchedMessages: 0,
+      compressed: false,
+    }),
+    markLocalSessionCleared: (sessionKey: string) => clearedSessionMarkers.push(sessionKey),
+  };
 
-  return { bot, handledTurns, sessionKeys, sessionInputs, session };
+  return {
+    bot,
+    handledTurns,
+    sessionKeys,
+    sessionInputs,
+    session,
+    replies,
+    clearedSessionMarkers,
+  };
 }
 
 describe('CatsCompany execution scope flow', () => {
+  test('does not create a blank session when first cloud recovery fails', async () => {
+    const { bot, handledTurns, sessionKeys, replies } = createHarness({
+      existingSession: false,
+      restoreStatus: 'failed',
+    });
+
+    await (bot as any).onMessage({
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      text: '继续之前的工作',
+      content: '继续之前的工作',
+      metadata: canonicalMetadata('usr7', 'p2p_7_43'),
+      isGroup: false,
+      seq: 12,
+    });
+
+    assert.deepEqual(sessionKeys, []);
+    assert.equal(handledTurns.length, 0);
+    assert.match(replies[0] || '', /没有新建空白上下文/);
+  });
+
+  test('regular clear writes an empty sentinel while clear --all keeps files deleted', async () => {
+    const regular = createHarness();
+    await (regular.bot as any).onMessage({
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      text: '/clear',
+      content: '/clear',
+      metadata: canonicalMetadata('usr7', 'p2p_7_43'),
+      isGroup: false,
+      seq: 12,
+    });
+    assert.deepEqual(regular.clearedSessionMarkers, [
+      'session:v2:catscompany:p2p:p2p_7_43:agent:usr43',
+    ]);
+
+    const all = createHarness();
+    await (all.bot as any).onMessage({
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      text: '/clear --all',
+      content: '/clear --all',
+      metadata: canonicalMetadata('usr7', 'p2p_7_43'),
+      isGroup: false,
+      seq: 13,
+    });
+    assert.deepEqual(all.clearedSessionMarkers, []);
+  });
+
+  test('text that only resembles a clear command remains a normal user message', async () => {
+    const { bot, handledTurns, clearedSessionMarkers } = createHarness();
+
+    await (bot as any).onMessage({
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      text: ' /clear',
+      content: ' /clear',
+      metadata: canonicalMetadata('usr7', 'p2p_7_43'),
+      isGroup: false,
+      seq: 14,
+    });
+
+    assert.equal(handledTurns.length, 1);
+    assert.deepEqual(clearedSessionMarkers, []);
+  });
+
   test('passes canonical execution scope from websocket message into session turn', async () => {
     const { bot, handledTurns, sessionKeys, sessionInputs } = createHarness();
 

--- a/tests/cloud-session-restore.test.ts
+++ b/tests/cloud-session-restore.test.ts
@@ -1,0 +1,239 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { Message } from '../src/types';
+import type {
+  CatsAgentContextMessage,
+  CatsAgentContextPage,
+} from '../src/catscompany/client';
+import {
+  CatsCompanyCloudSessionRestorer,
+  normalizeAgentContextMessages,
+} from '../src/catscompany/cloud-session-restore';
+import { estimateMessagesTokens } from '../src/core/token-estimator';
+
+class MemorySessionStore {
+  readonly sessions = new Map<string, Message[]>();
+  saveCalls = 0;
+
+  hasSession(sessionKey: string): boolean {
+    return this.sessions.has(sessionKey);
+  }
+
+  loadContext(sessionKey: string): Message[] {
+    return this.sessions.get(sessionKey) || [];
+  }
+
+  saveContext(sessionKey: string, messages: Message[]): void {
+    this.saveCalls++;
+    this.sessions.set(sessionKey, messages);
+  }
+}
+
+class FakeHistoryClient {
+  calls: Array<{ topic: string; beforeId?: number }> = [];
+
+  constructor(private readonly pages: CatsAgentContextPage[] | Error) {}
+
+  async getAgentContextHistory(
+    topic: string,
+    options: { beforeId?: number } = {},
+  ): Promise<CatsAgentContextPage> {
+    this.calls.push({ topic, beforeId: options.beforeId });
+    if (this.pages instanceof Error) throw this.pages;
+    const page = this.pages[this.calls.length - 1];
+    if (!page) throw new Error('unexpected history page request');
+    return page;
+  }
+}
+
+const fakeAIService = {
+  chatStream: async (_messages: Message[], _tools: unknown, callbacks: { onText?: (text: string) => void }) => {
+    callbacks.onText?.('<summary>用户正在迁移设备；此前已经确认继续当前项目。</summary>');
+    return {
+      content: null,
+      usage: { promptTokens: 100, completionTokens: 20, totalTokens: 120 },
+    };
+  },
+} as any;
+
+function contextMessage(overrides: Partial<CatsAgentContextMessage> = {}): CatsAgentContextMessage {
+  return {
+    id: 1,
+    seq_id: 1,
+    topic_id: 'p2p_7_42',
+    from_uid: 7,
+    content: 'hello',
+    type: 'text',
+    msg_type: 'text',
+    agent_uid: 42,
+    agent_id: 'usr42',
+    context_role: 'user',
+    context_eligible: true,
+    ...overrides,
+  };
+}
+
+function page(
+  messages: CatsAgentContextMessage[],
+  overrides: Partial<CatsAgentContextPage> = {},
+): CatsAgentContextPage {
+  return {
+    messages,
+    topic_id: 'p2p_7_42',
+    agent_uid: 42,
+    has_more: false,
+    next_before_id: messages[0]?.id || 0,
+    ...overrides,
+  };
+}
+
+test('existing non-empty local session bypasses cloud history without changing it', async () => {
+  const store = new MemorySessionStore();
+  const existing: Message[] = [{ role: 'user', content: 'local history' }];
+  store.sessions.set('session-key', existing);
+  const client = new FakeHistoryClient(new Error('must not fetch'));
+  const restorer = new CatsCompanyCloudSessionRestorer(client, fakeAIService, store);
+
+  const result = await restorer.restoreIfMissing({
+    sessionKey: 'session-key',
+    topicId: 'p2p_7_42',
+    topicType: 'p2p',
+    agentId: 'usr42',
+    currentSeq: 10,
+  });
+
+  assert.equal(result.status, 'local_present');
+  assert.equal(client.calls.length, 0);
+  assert.equal(store.saveCalls, 0);
+  assert.deepEqual(store.sessions.get('session-key'), existing);
+});
+
+test('missing session restores eligible visible history and paginates oldest-first', async () => {
+  const store = new MemorySessionStore();
+  const client = new FakeHistoryClient([
+    page([
+      contextMessage({ id: 3, seq_id: 3, content: 'newer question' }),
+      contextMessage({ id: 4, seq_id: 4, from_uid: 42, content: 'part one', context_role: 'assistant' }),
+      contextMessage({ id: 5, seq_id: 5, from_uid: 42, content: 'part two', context_role: 'assistant' }),
+      contextMessage({ id: 6, seq_id: 6, content: 'working', context_eligible: false }),
+    ], { has_more: true, next_before_id: 3 }),
+    page([
+      contextMessage({ id: 1, seq_id: 1, content: 'older question' }),
+      contextMessage({ id: 2, seq_id: 2, from_uid: 42, content: 'older answer', context_role: 'assistant' }),
+    ], { next_before_id: 1 }),
+  ]);
+  const restorer = new CatsCompanyCloudSessionRestorer(client, fakeAIService, store);
+
+  const result = await restorer.restoreIfMissing({
+    sessionKey: 'session-key',
+    topicId: 'p2p_7_42',
+    topicType: 'p2p',
+    agentId: 'usr42',
+    currentSeq: 7,
+  });
+
+  assert.equal(result.status, 'restored');
+  assert.deepEqual(client.calls.map(call => call.beforeId), [7, 3]);
+  assert.deepEqual(store.sessions.get('session-key')?.map(message => message.content), [
+    'older question',
+    'older answer',
+    'newer question',
+    'part one\n\npart two',
+  ]);
+});
+
+test('group normalization keeps the speaker and rejects another agent scope', () => {
+  const normalized = normalizeAgentContextMessages([
+    contextMessage({
+      topic_id: 'grp_80',
+      metadata: {
+        catsco_identity: {
+          actor: { display_name: 'Alice', user_id: 'usr7' },
+        },
+      },
+    }),
+    contextMessage({
+      id: 2,
+      seq_id: 2,
+      topic_id: 'grp_80',
+      agent_uid: 43,
+      agent_id: 'usr43',
+      content: 'wrong agent',
+    }),
+  ], { topicType: 'group', agentId: 'usr42' });
+
+  assert.equal(normalized.length, 1);
+  assert.equal(normalized[0].content, '[群聊成员 Alice]\nhello');
+});
+
+test('large cloud transcript is summarized before it is persisted', async () => {
+  const store = new MemorySessionStore();
+  const large = 'x'.repeat(260_000);
+  const client = new FakeHistoryClient([
+    page([
+      contextMessage({ content: large }),
+      contextMessage({ id: 2, seq_id: 2, from_uid: 42, content: 'recent answer', context_role: 'assistant' }),
+    ]),
+  ]);
+  const restorer = new CatsCompanyCloudSessionRestorer(client, fakeAIService, store);
+
+  const result = await restorer.restoreIfMissing({
+    sessionKey: 'large-session',
+    topicId: 'p2p_7_42',
+    topicType: 'p2p',
+    agentId: 'usr42',
+    currentSeq: 3,
+  });
+
+  assert.equal(result.status, 'restored');
+  assert.equal(result.compressed, true);
+  const restored = store.sessions.get('large-session') || [];
+  assert.ok(restored.some(message => String(message.content).includes('用户正在迁移设备')));
+  assert.ok(restored.some(message => String(message.content).includes('recent answer')));
+});
+
+test('summary failure still bounds a single oversized history message', async () => {
+  const store = new MemorySessionStore();
+  const client = new FakeHistoryClient([
+    page([contextMessage({ content: 'x'.repeat(400_000) })]),
+  ]);
+  const failingAIService = {
+    chatStream: async () => {
+      throw new Error('summary unavailable');
+    },
+  } as any;
+  const restorer = new CatsCompanyCloudSessionRestorer(client, failingAIService, store);
+
+  const result = await restorer.restoreIfMissing({
+    sessionKey: 'oversized-session',
+    topicId: 'p2p_7_42',
+    topicType: 'p2p',
+    agentId: 'usr42',
+    currentSeq: 2,
+  });
+
+  assert.equal(result.status, 'restored');
+  assert.equal(result.compressed, true);
+  const restored = store.sessions.get('oversized-session') || [];
+  assert.ok(estimateMessagesTokens(restored) <= 60_000);
+  assert.match(String(restored[0]?.content), /设备恢复提示/);
+  assert.match(String(restored[1]?.content), /已截断/);
+});
+
+test('history failure leaves the local session untouched and allows a normal empty start', async () => {
+  const store = new MemorySessionStore();
+  const client = new FakeHistoryClient(new Error('offline'));
+  const restorer = new CatsCompanyCloudSessionRestorer(client, fakeAIService, store);
+
+  const result = await restorer.restoreIfMissing({
+    sessionKey: 'missing-session',
+    topicId: 'p2p_7_42',
+    topicType: 'p2p',
+    agentId: 'usr42',
+    currentSeq: 3,
+  });
+
+  assert.equal(result.status, 'failed');
+  assert.equal(store.hasSession('missing-session'), false);
+  assert.equal(store.saveCalls, 0);
+});

--- a/tests/cloud-session-restore.test.ts
+++ b/tests/cloud-session-restore.test.ts
@@ -14,12 +14,14 @@ import { estimateMessagesTokens } from '../src/core/token-estimator';
 class MemorySessionStore {
   readonly sessions = new Map<string, Message[]>();
   saveCalls = 0;
+  loadCalls = 0;
 
   hasSession(sessionKey: string): boolean {
     return this.sessions.has(sessionKey);
   }
 
   loadContext(sessionKey: string): Message[] {
+    this.loadCalls++;
     return this.sessions.get(sessionKey) || [];
   }
 
@@ -27,6 +29,7 @@ class MemorySessionStore {
     this.saveCalls++;
     this.sessions.set(sessionKey, messages);
   }
+
 }
 
 class FakeHistoryClient {
@@ -104,8 +107,29 @@ test('existing non-empty local session bypasses cloud history without changing i
 
   assert.equal(result.status, 'local_present');
   assert.equal(client.calls.length, 0);
+  assert.equal(store.loadCalls, 0);
   assert.equal(store.saveCalls, 0);
   assert.deepEqual(store.sessions.get('session-key'), existing);
+});
+
+test('an existing empty session file still wins over cloud history', async () => {
+  const store = new MemorySessionStore();
+  store.sessions.set('empty-session-file', []);
+  const client = new FakeHistoryClient(new Error('must not fetch'));
+  const restorer = new CatsCompanyCloudSessionRestorer(client, fakeAIService, store);
+
+  const result = await restorer.restoreIfMissing({
+    sessionKey: 'empty-session-file',
+    topicId: 'p2p_7_42',
+    topicType: 'p2p',
+    agentId: 'usr42',
+    currentSeq: 10,
+  });
+
+  assert.equal(result.status, 'local_present');
+  assert.equal(client.calls.length, 0);
+  assert.equal(store.loadCalls, 0);
+  assert.equal(store.saveCalls, 0);
 });
 
 test('missing session restores eligible visible history and paginates oldest-first', async () => {
@@ -166,6 +190,77 @@ test('group normalization keeps the speaker and rejects another agent scope', ()
   assert.equal(normalized[0].content, '[群聊成员 Alice]\nhello');
 });
 
+test('the latest clear command cuts off older cloud history on every device', async () => {
+  const store = new MemorySessionStore();
+  const client = new FakeHistoryClient([
+    page([
+      contextMessage({ id: 4, seq_id: 4, content: 'new question' }),
+      contextMessage({ id: 5, seq_id: 5, from_uid: 42, content: 'new answer', context_role: 'assistant' }),
+    ], { has_more: true, next_before_id: 4 }),
+    page([
+      contextMessage({ id: 1, seq_id: 1, content: 'old question' }),
+      contextMessage({ id: 2, seq_id: 2, from_uid: 42, content: 'old answer', context_role: 'assistant' }),
+      contextMessage({ id: 3, seq_id: 3, content: '/clear' }),
+    ], { has_more: true, next_before_id: 1 }),
+  ]);
+  const restorer = new CatsCompanyCloudSessionRestorer(client, fakeAIService, store);
+
+  const result = await restorer.restoreIfMissing({
+    sessionKey: 'cleared-session',
+    topicId: 'p2p_7_42',
+    topicType: 'p2p',
+    agentId: 'usr42',
+    currentSeq: 6,
+  });
+
+  assert.equal(result.status, 'restored');
+  assert.deepEqual(client.calls.map(call => call.beforeId), [6, 4]);
+  assert.deepEqual(store.sessions.get('cleared-session')?.map(message => message.content), [
+    'new question',
+    'new answer',
+  ]);
+});
+
+test('cloud assistant history strips internal replay artifacts before summarization', () => {
+  const normalized = normalizeAgentContextMessages([
+    contextMessage({
+      from_uid: 42,
+      context_role: 'assistant',
+      content: '[历史工具调用已完成；provider replay 隐藏内容未写入本地会话。]',
+    }),
+  ], { topicType: 'p2p', agentId: 'usr42' });
+
+  assert.deepEqual(normalized, []);
+});
+
+test('content-block-only attachments retain safe historical placeholders', () => {
+  const normalized = normalizeAgentContextMessages([
+    contextMessage({
+      content: undefined,
+      content_blocks: [{ type: 'image', source: { data: 'must-not-leak' } }],
+    }),
+  ], { topicType: 'p2p', agentId: 'usr42' });
+
+  assert.equal(normalized[0]?.content, '[历史图片]');
+  assert.doesNotMatch(JSON.stringify(normalized), /must-not-leak/);
+});
+
+test('markLocalSessionCleared persists an empty sentinel after a regular clear', () => {
+  const store = new MemorySessionStore();
+  store.sessions.set('session-key', [{ role: 'user', content: 'old history' }]);
+  const restorer = new CatsCompanyCloudSessionRestorer(
+    new FakeHistoryClient([]),
+    fakeAIService,
+    store,
+  );
+
+  restorer.markLocalSessionCleared('session-key');
+
+  assert.equal(store.hasSession('session-key'), true);
+  assert.deepEqual(store.sessions.get('session-key'), []);
+  assert.equal(store.saveCalls, 1);
+});
+
 test('large cloud transcript is summarized before it is persisted', async () => {
   const store = new MemorySessionStore();
   const large = 'x'.repeat(260_000);
@@ -220,7 +315,7 @@ test('summary failure still bounds a single oversized history message', async ()
   assert.match(String(restored[1]?.content), /已截断/);
 });
 
-test('history failure leaves the local session untouched and allows a normal empty start', async () => {
+test('history failure leaves the local session untouched for a later retry', async () => {
   const store = new MemorySessionStore();
   const client = new FakeHistoryClient(new Error('offline'));
   const restorer = new CatsCompanyCloudSessionRestorer(client, fakeAIService, store);


### PR DESCRIPTION
## 背景

CatsCompany 网页保存的是用户可见聊天消息，CatsCo 本地 JSONL 保存的是实际送给模型的 Agent 上下文。用户更换电脑、重装或本地 session 缺失时，现有链路无法利用云端聊天历史继续会话。

## 改动

- 仅当当前 CatsCompany 主会话的本地 session 文件不存在时，从云端恢复可见的用户/助手历史。
- 现有本地 session 永远优先，包括空文件；不修改 session key、文件名或现有迁移逻辑。
- 私聊按 topic + agent 恢复；群聊补充说话人身份，并过滤其他机器人、thinking、工具调用、runtime plan 等内部内容。
- 当前消息通过稳定游标排除，避免重复注入；大历史按 token 预算摘要或截断。
- 恢复失败时不创建空白 session，用户下一条消息可以重新尝试。
- 普通 `/clear` 持久化空 session；`/clear --all` 以云端命令作为历史边界，避免重启或换设备后旧历史复活。
- 恢复请求增加 30 秒总时限；附件只恢复安全占位和文件名，不恢复本地路径、二进制或设备授权。

## 兼容与上线顺序

CatsCompany 服务端接口已先行上线（`8d24b7a`）。旧桌面端不发送 `agent_context=1`，仍走原消息接口，不受影响。

本 PR 不修改 BranchAgent、子 agent 或主会话 key。一个 CatsCo 数据目录仍按现有约束绑定一个机器人；多个虚拟员工分别部署时可以加入同一群聊，云端历史会按机器人 UID 隔离。

## 验证

- `npm test`：1017 项，1013 通过，0 失败，4 跳过
- `npm run build`
- 云恢复专项：11/11
- CatsCompany 执行入口专项：14/14
- session 生命周期与客户端契约专项：49/49
- `git diff --check`

CatsCompany 服务端另已通过 `go test ./...`、`go vet ./...`、线上 CI、测试环境部署和生产健康检查。
