### PR TITLE
fix: 自动导入远程图片和 PDF 后本机读取

### DIFF
--- a/src/tools/import-file-tool.ts
+++ b/src/tools/import-file-tool.ts
@@ -20,6 +20,11 @@ type UploadImportFileSource = (
   fileName: string,
 ) => Promise<UploadedFileResult>;
 
+export type RemoteImportFileResult = ToolExecutionResult & {
+  /** Internal-only local path used when another tool continues processing the imported file. */
+  importedLocalPath?: string;
+};
+
 export class ImportFileTool implements Tool {
   definition: ToolDefinition = {
     name: 'import_file',
@@ -51,6 +56,21 @@ export class ImportFileTool implements Tool {
   };
 
   async execute(args: any, context: ToolExecutionContext): Promise<ToolExecutionResult> {
+    return importRemoteFileToAgentWorkspace(args, context);
+  }
+}
+
+/**
+ * Imports one original file from a participant computer into this agent runtime.
+ *
+ * `import_file` exposes this operation to the model. Other tools may reuse it when
+ * they need to continue processing a remote file locally without making the model
+ * coordinate a second tool call.
+ */
+export async function importRemoteFileToAgentWorkspace(
+  args: Record<string, unknown>,
+  context: ToolExecutionContext,
+): Promise<RemoteImportFileResult> {
     const validation = validateImportFileArgs(args, true);
     if (!validation.ok) return validation;
 
@@ -130,6 +150,7 @@ export class ImportFileTool implements Tool {
           operation: 'send_file',
           cwd: path.dirname(localPath),
         }),
+        importedLocalPath: localPath,
       };
     } catch (error: any) {
       Logger.error(`远程文件保存到当前运行体失败: ${error.message}`);
@@ -140,7 +161,6 @@ export class ImportFileTool implements Tool {
         targetContext: result.targetContext,
       };
     }
-  }
 }
 
 function rewriteUnsupportedImportFileError(

--- a/src/tools/read-tool.ts
+++ b/src/tools/read-tool.ts
@@ -14,6 +14,7 @@ import { formatPathForLog } from '../utils/log-redaction';
 import { resolveLocalFileAccess, resolveLocalFileReference } from './local-file-gateway';
 import { formatCatsCoVisiblePath } from './tool-gateway';
 import { executeRouteIfRemote, resolveExecutionRoute, targetParameterDescription } from './execution-router';
+import { importRemoteFileToAgentWorkspace } from './import-file-tool';
 
 export const DEFAULT_TEXT_READ_LIMIT = 200;
 export const MAX_TEXT_READ_LIMIT = 2000;
@@ -123,7 +124,8 @@ export class ReadTool implements Tool {
       '读取一个本地文件。CatsCo 附件请优先使用消息中显示的本地缓存路径。',
       '通常先用 glob 定位候选路径，或用 grep 找到包含目标内容的文件，再读取具体文件。',
       '支持文本/代码、PDF、图片和 Jupyter notebook。文本默认只读前若干行，可用 offset/limit 分页。',
-        'PDF 会先提取文本层；如果文本层为空、解析失败，或用户明显关心图片/签章/手写/版式等视觉内容，会自动把少量页面转成图片并走读图链路。',
+      'PDF 会先提取文本层；如果文本层为空、解析失败，或用户明显关心图片/签章/手写/版式等视觉内容，会自动把少量页面转成图片并走读图链路。',
+      '读取聊天参与者电脑上的图片或 PDF 时，工具会先将原文件导入 XiaoBa 本机，再由当前 agent 在本机处理。',
         'catsco_attachment:<id> 仅用于兼容当前轮旧附件引用；后续追问应使用历史消息里的本地缓存路径。',
         '图片会按当前模型能力处理：视觉模型收到图片块，非视觉模型收到 reader proxy 的文字解析结果。',
     ].join('\n'),
@@ -228,6 +230,11 @@ export class ReadTool implements Tool {
           message: route.message,
         };
       }
+
+      if (route.mode === 'remote' && this.shouldImportRemoteMedia(file_path)) {
+        return this.readImportedRemoteMedia(args, context);
+      }
+
       const remoteResult = await executeRouteIfRemote(context, route, 'read_file', 'read_file', args);
       if (remoteResult) return remoteResult;
 
@@ -936,6 +943,48 @@ export class ReadTool implements Tool {
 
   private isImageExt(ext: string): boolean {
     return ['.png', '.jpg', '.jpeg', '.gif', '.bmp', '.webp'].includes(ext);
+  }
+
+  private shouldImportRemoteMedia(filePath: string): boolean {
+    const normalized = filePath.replace(/\\/g, '/');
+    const ext = path.posix.extname(normalized).toLowerCase();
+    return ext === '.pdf' || this.isImageExt(ext);
+  }
+
+  private async readImportedRemoteMedia(
+    args: Record<string, unknown>,
+    context: ToolExecutionContext,
+  ): Promise<ToolExecutionResult> {
+    const sourcePath = String(args.file_path || '').trim();
+    const importResult = await importRemoteFileToAgentWorkspace({
+      file_path: sourcePath,
+      file_name: this.remoteMediaFileName(sourcePath),
+      target: args.target,
+    }, context);
+
+    if (!importResult.ok) return importResult;
+    if (!importResult.importedLocalPath) {
+      return {
+        ok: false,
+        errorCode: 'TOOL_EXECUTION_ERROR',
+        message: '远程媒体文件已经上传，但当前 agent 未获得本地缓存路径。',
+        targetContext: importResult.targetContext,
+      };
+    }
+
+    const localArgs = {
+      ...args,
+      file_path: importResult.importedLocalPath,
+    };
+    delete (localArgs as Record<string, unknown>).target;
+    return this.execute(localArgs, context);
+  }
+
+  private remoteMediaFileName(filePath: string): string {
+    const normalized = filePath.replace(/\\/g, '/');
+    const baseName = path.posix.basename(normalized).trim();
+    if (baseName && baseName !== '.' && baseName !== '/') return baseName;
+    return 'remote-media';
   }
 
   private getLatestUserText(context: ToolExecutionContext): string {

--- a/tests/remote-media-read.test.ts
+++ b/tests/remote-media-read.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { ReadTool } from '../src/tools/read-tool';
+import type { TargetRoute, ToolExecutionContext } from '../src/types/tool';
+
+const temporaryRoots: string[] = [];
+
+afterEach(() => {
+  while (temporaryRoots.length > 0) {
+    fs.rmSync(temporaryRoots.pop()!, { recursive: true, force: true });
+  }
+});
+
+describe('remote media reads', () => {
+  test('imports a remote PDF into the agent runtime before reading it locally', async () => {
+    const { context, importedPath, rpcCalls } = createRemoteMediaContext('report.pdf');
+    const tool = new ReadTool();
+    let locallyReadPath = '';
+    (tool as any).readPDF = async (absolutePath: string) => {
+      locallyReadPath = absolutePath;
+      return `local PDF read: ${absolutePath}`;
+    };
+
+    const result = await tool.execute({
+      file_path: 'C:\\Users\\Alice\\Desktop\\report.pdf',
+      target: 'Alice',
+    }, context);
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(rpcCalls.map(call => call.toolName), ['import_file']);
+    assert.equal(rpcCalls[0].args.file_path, 'C:\\Users\\Alice\\Desktop\\report.pdf');
+    assert.equal(rpcCalls[0].args.file_name, 'report.pdf');
+    assert.equal(locallyReadPath, importedPath);
+    assert.match(result.ok ? String(result.content) : '', new RegExp(escapeRegExp(importedPath)));
+  });
+
+  test('imports a remote image into the agent runtime before reading it locally', async () => {
+    const { context, importedPath, rpcCalls } = createRemoteMediaContext('chart.png');
+    const tool = new ReadTool();
+    let locallyReadPath = '';
+    (tool as any).readImage = async (absolutePath: string) => {
+      locallyReadPath = absolutePath;
+      return `local image read: ${absolutePath}`;
+    };
+
+    const result = await tool.execute({
+      file_path: '/Users/alice/Desktop/chart.png',
+      target: 'Alice',
+    }, context);
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(rpcCalls.map(call => call.toolName), ['import_file']);
+    assert.equal(rpcCalls[0].args.file_name, 'chart.png');
+    assert.equal(locallyReadPath, importedPath);
+  });
+
+  test('keeps remote text reads on the normal remote read_file route', async () => {
+    const { context, rpcCalls } = createRemoteMediaContext('notes.txt');
+    const tool = new ReadTool();
+
+    const result = await tool.execute({
+      file_path: 'C:\\Users\\Alice\\Desktop\\notes.txt',
+      target: 'Alice',
+    }, context);
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(rpcCalls.map(call => call.toolName), ['read_file']);
+  });
+});
+
+function createRemoteMediaContext(fileName: string): {
+  context: ToolExecutionContext;
+  importedPath: string;
+  rpcCalls: Array<{ toolName: string; args: Record<string, unknown> }>;
+} {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'remote-media-read-'));
+  temporaryRoots.push(root);
+  const importedPath = path.join(root, fileName);
+  const route: TargetRoute = {
+    userId: 'usr-alice',
+    userName: 'Alice',
+    ownerUserId: 'usr-alice',
+    deviceId: 'alice-device',
+    label: 'Alice 的电脑',
+    os: 'windows',
+    status: 'ready',
+  };
+  const rpcCalls: Array<{ toolName: string; args: Record<string, unknown> }> = [];
+
+  return {
+    importedPath,
+    rpcCalls,
+    context: {
+      workingDirectory: root,
+      workspaceRoot: root,
+      conversationHistory: [],
+      surface: 'catscompany',
+      targetRoutes: {
+        routes: [route],
+        byName: new Map([['alice', [route]]]),
+        byUserId: new Map([['usr-alice', [route]]]),
+      },
+      thinToolRpc: {
+        executeTool: async request => {
+          rpcCalls.push({ toolName: request.toolName, args: request.args });
+          if (request.toolName === 'read_file') {
+            return { ok: true, content: 'remote text content' };
+          }
+          return {
+            ok: true,
+            content: 'remote upload complete',
+            uploadedFile: {
+              url: '/uploads/remote-media',
+              name: fileName,
+              size: 4,
+              type: 'file',
+            },
+          };
+        },
+      },
+      channel: {
+        chatId: 'p2p_alice_agent',
+        reply: async () => {},
+        sendFile: async () => {},
+        receiveUploadedFile: async () => {
+          fs.writeFileSync(importedPath, 'test');
+          return importedPath;
+        },
+      },
+    },
+  };
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}


### PR DESCRIPTION
## 概要

修复远程 `read_file` 读取图片或 PDF 时，视觉/页面内容无法被主 agent 正常使用的问题。

复用 #211 的 `import_file` 传输链路：当 `read_file` 显式指向聊天参与者电脑，且路径是支持的图片格式或 PDF 时，运行时自动将原文件导入当前 agent 本机，再沿用现有本机读取流程处理。

Fixes #199

## 行为

- 远程图片：自动导入 bot 本机，再由当前 agent 的模型配置执行正常读图。
- 远程 PDF：自动导入 bot 本机，再执行本机 PDF 文本提取及视觉回退。
- 远程文本/代码等其他文件：继续直接在目标电脑执行 `read_file`，不产生传输。
- `import_file` 仍保留为模型可显式调用的原文件导入工具。

## 实现

- 将 #211 的“远程文件导入到当前 agent runtime”抽为内部复用函数。
- `read_file` 在确认目标为远程设备且扩展名为 `.pdf` 或当前支持的图片格式时，自动调用该函数，再使用导入后的本地绝对路径继续读取。
- 不修改 CatsCompany 服务端协议，不恢复旧 Device RPC 的图片二进制 result 转发，也不改变普通文本远程读取路径。

## 验证

- `npm run build`
- `npm test`：1000 passed，4 skipped，0 failed
- 新增回归测试：远程 PDF、远程图片均只走 `import_file` 后本机读取；远程文本仍走原有 `read_file` RPC。