### PR TITLE
修复：飞书群触发前恢复普通群聊上下文

### DIFF
--- a/src/catscompany/agent-context-history.ts
+++ b/src/catscompany/agent-context-history.ts
@@ -22,19 +22,29 @@ export function selectNativeFeishuGroupContext(
   history: CatsAgentContextMessage[],
   afterSeq = 0,
 ): string[] {
-  const ordered = [...history].sort((a, b) => messageSeq(a) - messageSeq(b));
+  const ordered = [...history].sort((a, b) => agentContextMessageSeq(a) - agentContextMessageSeq(b));
+  const clearBoundarySeq = ordered.reduce((latest, message) => (
+    isNativeFeishuClearBoundary(message) ? Math.max(latest, agentContextMessageSeq(message)) : latest
+  ), 0);
+  const effectiveAfterSeq = Math.max(afterSeq, clearBoundarySeq);
   return ordered
-    .filter(message => messageSeq(message) > afterSeq)
+    .filter(message => agentContextMessageSeq(message) > effectiveAfterSeq)
     .filter(message => isEligibleParticipantMessage(message))
     .map(formatParticipantMessage)
     .filter((message): message is string => Boolean(message));
 }
 
 function isEligibleParticipantMessage(message: CatsAgentContextMessage): boolean {
-  const metadata = asRecord(message.metadata);
   return message.context_eligible === true
     && message.context_role === 'user'
-    && !booleanField(metadata, 'channel_native_group_triggered');
+    && message.context_reason === 'participant_message';
+}
+
+export function isNativeFeishuClearBoundary(message: CatsAgentContextMessage): boolean {
+  return message.context_eligible === true
+    && message.context_role === 'user'
+    && message.context_reason === 'group_message_targets_agent'
+    && /^\/clear(?:\s|$)/i.test(extractMessageText(message));
 }
 
 function formatParticipantMessage(message: CatsAgentContextMessage): string {
@@ -75,7 +85,7 @@ function extractMessageText(message: CatsAgentContextMessage): string {
   return '';
 }
 
-function messageSeq(message: CatsAgentContextMessage): number {
+export function agentContextMessageSeq(message: CatsAgentContextMessage): number {
   return Number(message.seq_id || message.id || 0);
 }
 

--- a/src/catscompany/agent-context-history.ts
+++ b/src/catscompany/agent-context-history.ts
@@ -1,0 +1,115 @@
+import type { ParsedCatsMessage } from './types';
+
+type UnknownRecord = Record<string, unknown>;
+
+export interface CatsAgentContextHistoryMessage {
+  id?: number;
+  seq_id?: number;
+  from_uid?: number | string;
+  content?: unknown;
+  content_blocks?: unknown[];
+  metadata?: UnknownRecord;
+  context_role?: string;
+  context_eligible?: boolean;
+  context_reason?: string;
+}
+
+export interface CatsAgentContextHistoryResponse {
+  messages: CatsAgentContextHistoryMessage[];
+  topic_id?: string;
+  agent_uid?: number | string;
+  has_more?: boolean;
+  next_before_id?: number;
+}
+
+export function isNativeFeishuGroupTrigger(
+  msg: Pick<ParsedCatsMessage, 'chatType' | 'metadata' | 'seq'>,
+): boolean {
+  if (msg.chatType !== 'group' || msg.seq <= 0) return false;
+  const metadata = asRecord(msg.metadata);
+  return stringField(metadata, 'source_channel').toLowerCase() === 'feishu'
+    && numberField(metadata, 'channel_native_group_binding_id') > 0
+    && booleanField(metadata, 'channel_native_group_triggered');
+}
+
+/**
+ * Returns record-only Feishu group messages since the previous model trigger.
+ * The server has already removed tool/runtime messages and messages targeting
+ * another participant; this client-side pass keeps replay bounded and idempotent.
+ */
+export function selectNativeFeishuGroupContext(
+  history: CatsAgentContextHistoryMessage[],
+  afterSeq = 0,
+): string[] {
+  const ordered = [...history].sort((a, b) => messageSeq(a) - messageSeq(b));
+  return ordered
+    .filter(message => messageSeq(message) > afterSeq)
+    .filter(message => isEligibleParticipantMessage(message))
+    .map(formatParticipantMessage)
+    .filter((message): message is string => Boolean(message));
+}
+
+function isEligibleParticipantMessage(message: CatsAgentContextHistoryMessage): boolean {
+  return message.context_eligible === true && message.context_role === 'user';
+}
+
+function formatParticipantMessage(message: CatsAgentContextHistoryMessage): string {
+  const text = extractMessageText(message);
+  if (!text) return '';
+  const metadata = asRecord(message.metadata);
+  const identity = asRecord(metadata.catsco_identity);
+  const actor = asRecord(identity.actor);
+  const speaker = stringField(actor, 'display_name')
+    || stringField(actor, 'username')
+    || stringField(actor, 'user_id')
+    || String(message.from_uid || '').trim()
+    || 'User';
+  return `[发言人: ${speaker}]\n${text}`;
+}
+
+function extractMessageText(message: CatsAgentContextHistoryMessage): string {
+  if (Array.isArray(message.content_blocks)) {
+    const blockText = message.content_blocks
+      .map(block => asRecord(block))
+      .filter(block => stringField(block, 'type') === 'text')
+      .map(block => stringField(block, 'text'))
+      .filter(Boolean)
+      .join('\n\n')
+      .trim();
+    if (blockText) return blockText;
+  }
+  if (typeof message.content === 'string') {
+    const text = message.content.trim();
+    if (!text) return '';
+    try {
+      const parsed = JSON.parse(text);
+      return typeof parsed === 'string' ? parsed.trim() : text;
+    } catch {
+      return text;
+    }
+  }
+  return '';
+}
+
+function messageSeq(message: CatsAgentContextHistoryMessage): number {
+  return Number(message.seq_id || message.id || 0);
+}
+
+function asRecord(value: unknown): UnknownRecord {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as UnknownRecord
+    : {};
+}
+
+function stringField(record: UnknownRecord, key: string): string {
+  return typeof record[key] === 'string' ? String(record[key]).trim() : '';
+}
+
+function numberField(record: UnknownRecord, key: string): number {
+  const value = Number(record[key]);
+  return Number.isFinite(value) ? value : 0;
+}
+
+function booleanField(record: UnknownRecord, key: string): boolean {
+  return record[key] === true || record[key] === 1 || record[key] === '1' || record[key] === 'true';
+}

--- a/src/catscompany/client.ts
+++ b/src/catscompany/client.ts
@@ -4,6 +4,7 @@ import { EventEmitter } from 'events';
 import crypto from 'crypto';
 import { Logger } from '../utils/logger';
 import { uploadCatsLocalFile, type UploadResult } from './upload';
+import type { CatsAgentContextHistoryResponse } from './agent-context-history';
 
 export type { UploadResult } from './upload';
 
@@ -730,6 +731,29 @@ export class CatsClient extends EventEmitter {
       throw new Error(`CatsCompany device registration failed: ${res.status}`);
     }
     return res.json().catch(() => ({}));
+  }
+
+  async fetchAgentContextHistory(
+    topic: string,
+    beforeId: number,
+    limit = 100,
+  ): Promise<CatsAgentContextHistoryResponse> {
+    const params = new URLSearchParams({
+      topic_id: topic,
+      agent_context: '1',
+      before_id: String(beforeId),
+      limit: String(limit),
+    });
+    const res = await fetch(`${this.httpBaseUrl()}/api/messages?${params.toString()}`, {
+      headers: {
+        'Authorization': `ApiKey ${this.config.apiKey}`,
+      },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) {
+      throw new Error(`CatsCompany agent context history failed: ${res.status}`);
+    }
+    return res.json() as Promise<CatsAgentContextHistoryResponse>;
   }
 
   async sendImage(topic: string, upload: UploadResult): Promise<number> {

--- a/src/catscompany/cloud-session-restore.ts
+++ b/src/catscompany/cloud-session-restore.ts
@@ -65,11 +65,13 @@ export class CatsCompanyCloudSessionRestorer {
 
     try {
       const fetched = await this.fetchHistory(request);
+      request.signal?.throwIfAborted();
       if (fetched.messages.length === 0) {
         return this.result('empty', { fetchedMessages: fetched.fetchedMessages });
       }
 
       const prepared = await this.prepareForPersistence(fetched.messages, request.signal);
+      request.signal?.throwIfAborted();
       if (this.hasLocalSession(request.sessionKey)) {
         return this.result('local_present', { fetchedMessages: fetched.fetchedMessages });
       }
@@ -104,7 +106,8 @@ export class CatsCompanyCloudSessionRestorer {
   }> {
     let beforeId = request.currentSeq;
     let fetchedMessages = 0;
-    let messages: Message[] = [];
+    let rawMessages: CatsAgentContextMessage[] = [];
+    const seenMessageIds = new Set<number>();
 
     for (let pageIndex = 0; pageIndex < CLOUD_RESTORE_MAX_PAGES; pageIndex++) {
       const page = await this.client.getAgentContextHistory(request.topicId, {
@@ -115,25 +118,40 @@ export class CatsCompanyCloudSessionRestorer {
       this.assertPageScope(page, request);
       fetchedMessages += page.messages.length;
 
-      const clearBoundaryIndex = findLastClearBoundaryIndex(page.messages, request);
-      const pageMessages = normalizeAgentContextMessages(
-        clearBoundaryIndex >= 0 ? page.messages.slice(clearBoundaryIndex + 1) : page.messages,
+      const orderedPage = [...page.messages]
+        .sort((left, right) => agentContextMessageSeq(left) - agentContextMessageSeq(right))
+        .filter(message => {
+          const id = Number(message.id || message.seq_id || 0);
+          if (id <= 0 || seenMessageIds.has(id)) return false;
+          seenMessageIds.add(id);
+          return true;
+        });
+      const clearBoundaryIndex = findLastClearBoundaryIndex(orderedPage, request);
+      const pageMessages = clearBoundaryIndex >= 0
+        ? orderedPage.slice(clearBoundaryIndex + 1)
+        : orderedPage;
+      rawMessages = [...pageMessages, ...rawMessages];
+      const normalizedMessages = coalesceAssistantSegments(normalizeAgentContextMessages(
+        [...rawMessages].sort((left, right) => agentContextMessageSeq(left) - agentContextMessageSeq(right)),
         request,
-      );
-      messages = coalesceAssistantSegments([...pageMessages, ...messages]);
+      ));
 
       if (
         clearBoundaryIndex >= 0
         || !page.has_more
         || page.next_before_id <= 0
         || page.next_before_id >= beforeId
-        || estimateMessagesTokens(messages) >= CLOUD_RESTORE_FETCH_TOKEN_BUDGET
+        || estimateMessagesTokens(normalizedMessages) >= CLOUD_RESTORE_FETCH_TOKEN_BUDGET
       ) {
         break;
       }
       beforeId = page.next_before_id;
     }
 
+    const messages = coalesceAssistantSegments(normalizeAgentContextMessages(
+      [...rawMessages].sort((left, right) => agentContextMessageSeq(left) - agentContextMessageSeq(right)),
+      request,
+    ));
     return { messages, fetchedMessages };
   }
 
@@ -240,14 +258,18 @@ export function normalizeAgentContextMessages(
 
 function findLastClearBoundaryIndex(
   messages: CatsAgentContextMessage[],
-  request: Pick<CloudSessionRestoreRequest, 'agentId'>,
+  request: Pick<CloudSessionRestoreRequest, 'agentId' | 'topicType'>,
 ): number {
   for (let index = messages.length - 1; index >= 0; index--) {
     const message = messages[index];
+    const clearReasonMatches = request.topicType === 'group'
+      ? message.context_reason === 'group_message_targets_agent'
+      : message.context_reason === undefined || message.context_reason === 'participant_message';
     if (
       message.context_eligible === true
       && message.context_role === 'user'
       && normalizeUID(message.agent_id || message.agent_uid) === normalizeUID(request.agentId)
+      && clearReasonMatches
       && /^\/clear(?:\s|$)/i.test(cloudMessageText(message))
     ) {
       return index;
@@ -256,8 +278,20 @@ function findLastClearBoundaryIndex(
   return -1;
 }
 
+function agentContextMessageSeq(message: CatsAgentContextMessage): number {
+  return Number(message.seq_id || message.id || 0);
+}
+
 function cloudMessageText(message: CatsAgentContextMessage): string {
-  if (typeof message.content === 'string' && message.content.trim()) return message.content.trim();
+  if (typeof message.content === 'string' && message.content.trim()) {
+    const text = message.content.trim();
+    try {
+      const parsed = JSON.parse(text);
+      return typeof parsed === 'string' ? parsed.trim() : text;
+    } catch {
+      return text;
+    }
+  }
   if (!message.content || typeof message.content !== 'object') {
     return cloudContentBlocksText(message.content_blocks);
   }

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -1,4 +1,10 @@
-import { CatsClient, MessageContext, type CatsDeviceRpcMessage, type CatsThinToolRpcMessage } from './client';
+import {
+  CatsClient,
+  MessageContext,
+  type CatsAgentContextMessage,
+  type CatsDeviceRpcMessage,
+  type CatsThinToolRpcMessage,
+} from './client';
 import { CatsCompanyConfig, ParsedCatsMessage, CatsFileInfo } from './types';
 import { MessageSender } from './message-sender';
 import { extractContentBlocks } from './content-blocks';
@@ -50,7 +56,9 @@ import {
   scheduleCatsCoAttachmentCacheCleanup,
 } from './attachment-cache';
 import {
+  agentContextMessageSeq,
   isNativeFeishuGroupTrigger,
+  isNativeFeishuClearBoundary,
   selectNativeFeishuGroupContext,
 } from './agent-context-history';
 import {
@@ -66,6 +74,14 @@ interface PendingAttachment {
   localFileGrant?: ScopedLocalFileGrant;
 }
 
+type NativeFeishuGroupTriggerMessage = Pick<ParsedCatsMessage, 'topic' | 'chatType' | 'seq' | 'metadata'>;
+
+interface NativeFeishuContextHydration {
+  message: NativeFeishuGroupTriggerMessage;
+  cloudRestoreStatus?: CloudSessionRestoreResult['status'];
+  clearGeneration: number;
+}
+
 interface QueuedMessage {
   userMessage: string | ContentBlock[];
   topic: string;
@@ -79,6 +95,10 @@ interface QueuedMessage {
   receivedAt: number;
   source?: 'user' | 'subagent_feedback';
   runtimeFeedback?: RuntimeFeedbackInput[];
+  nativeFeishuContext?: NativeFeishuContextHydration;
+  attempts?: number;
+  deliveryOnly?: boolean;
+  deliveryAttempts?: number;
 }
 
 interface SubAgentEventRoute {
@@ -102,6 +122,7 @@ interface BackgroundSubAgentCompletionBatch {
   channelSource?: string;
   executionScope?: ParsedCatsMessage['executionScope'];
   firstAt: number;
+  clearGeneration: number;
   items: Map<string, BackgroundSubAgentCompletionItem>;
   timer?: ReturnType<typeof setTimeout>;
 }
@@ -109,6 +130,9 @@ interface BackgroundSubAgentCompletionBatch {
 const TYPING_HEARTBEAT_INTERVAL_MS = 5_000;
 const BACKGROUND_SUBAGENT_COMPLETION_DEBOUNCE_MS = 1_500;
 const BACKGROUND_SUBAGENT_COMPLETION_MAX_DELAY_MS = 15_000;
+const SUBAGENT_FALLBACK_MAX_DELIVERY_ATTEMPTS = 3;
+const NATIVE_FEISHU_CONTEXT_PAGE_SIZE = 100;
+const NATIVE_FEISHU_CONTEXT_MAX_PAGES = 10;
 const BACKGROUND_SUBAGENT_COMPLETION_MAX_ITEMS = 6;
 const DEVICE_REGISTRATION_REFRESH_MS = 120_000;
 const DEVICE_RPC_DEFAULT_TTL_MS = 60_000;
@@ -273,6 +297,38 @@ function compactCatsSubAgentSummary(text: string, maxLength = 4000): string {
   return `${normalized.slice(0, maxLength)}\n\n[内容较长，已截断；完整内容请查看本地日志]`;
 }
 
+function normalizeCatsUid(value: unknown): string {
+  const raw = String(value ?? '').trim();
+  const numeric = raw.match(/^(?:usr)?(\d+)$/i);
+  return numeric ? `usr${numeric[1]}` : raw;
+}
+
+function combineAbortSignals(signals: AbortSignal[]): AbortSignal {
+  const controller = new AbortController();
+  const listeners = new Map<AbortSignal, () => void>();
+  const onAbort = (signal: AbortSignal) => {
+    for (const candidate of signals) {
+      const listener = listeners.get(candidate);
+      if (listener) candidate.removeEventListener('abort', listener);
+    }
+    controller.abort(signal.reason);
+  };
+
+  for (const signal of signals) {
+    if (signal.aborted) {
+      for (const [candidate, listener] of listeners) {
+        candidate.removeEventListener('abort', listener);
+      }
+      controller.abort(signal.reason);
+      return controller.signal;
+    }
+    const listener = () => onAbort(signal);
+    listeners.set(signal, listener);
+    signal.addEventListener('abort', listener, { once: true });
+  }
+  return controller.signal;
+}
+
 export function createCatsCompanyRuntime(sessionTTL?: number): AdapterRuntimeBundle {
   return createAdapterRuntime({
     surface: 'catscompany',
@@ -298,6 +354,12 @@ export class CatsCompanyBot {
   private pendingAttachments = new Map<string, PendingAttachment[]>();
   /** 主会话忙时的消息队列，key = sessionKey */
   private messageQueue = new Map<string, QueuedMessage[]>();
+  /** Serializes history hydration and all model turns for one CatsCo session. */
+  private sessionExecutionReservations = new Set<string>();
+  /** Invalidates queued or in-flight pre-turn hydration after /clear. */
+  private sessionClearGenerations = new Map<string, number>();
+  /** Lets /clear cancel an initial cloud restore before it can recreate old history. */
+  private cloudSessionRestoreAbortControllers = new Map<string, AbortController>();
   /** 子 Agent 事件应沿用 spawn 时的通道能力，不能被同 session 后续消息覆盖 */
   private subAgentEventRoutes = new Map<string, SubAgentEventRoute>();
   /** no-wait 子 Agent 完成后的批量回流，避免逐条唤醒主模型刷屏 */
@@ -1174,10 +1236,13 @@ export class CatsCompanyBot {
   }
 
   private async processParsedMessage(msg: ParsedCatsMessage, key: string): Promise<void> {
+    const entryClearGeneration = this.getSessionClearGeneration(key);
+    const nativeFeishuTrigger = isNativeFeishuGroupTrigger(msg);
     const sessionRoute = msg.envelope ? createCatsCoSessionRoute(msg.envelope) : undefined;
     let cloudRestoreResult: CloudSessionRestoreResult | undefined;
     if (sessionRoute && !isClearCommand(msg.text)) {
       cloudRestoreResult = await this.ensureCloudSessionRestored(msg, sessionRoute);
+      if (entryClearGeneration !== this.getSessionClearGeneration(key)) return;
       if (cloudRestoreResult.status === 'failed' || cloudRestoreResult.status === 'skipped') {
         await this.sender.reply(
           msg.topic,
@@ -1190,26 +1255,34 @@ export class CatsCompanyBot {
     }
     const session = this.sessionManager.getOrCreate(sessionRoute && sessionRoute.sessionKey === key ? sessionRoute : key);
 
-    await this.hydrateNativeFeishuGroupContext(session, msg, key, cloudRestoreResult?.status);
-
     // 处理斜杠命令
     if (typeof msg.text === 'string' && msg.text.startsWith('/')) {
       const parts = msg.text.slice(1).split(/\s+/);
       const command = parts[0];
       const args = parts.slice(1);
+      const isClear = command.toLowerCase() === 'clear';
+
+      if (isClear) {
+        this.pendingAttachments.delete(key);
+        this.messageQueue.delete(key);
+        this.bumpSessionClearGeneration(key);
+        const completionBatch = this.subAgentCompletionBatches.get(key);
+        if (completionBatch?.timer) clearTimeout(completionBatch.timer);
+        this.subAgentCompletionBatches.delete(key);
+        this.cloudSessionRestoreAbortControllers?.get(key)?.abort();
+        this.cloudSessionRestorePromises.delete(key);
+        session.requestInterrupt?.();
+      }
 
       const result = await session.handleCommand(command, args);
+      if (result.handled && isClear && !args.includes('--all')) {
+        this.cloudSessionRestorer.markLocalSessionCleared(sessionRoute?.sessionKey || key);
+      }
       if (result.handled && result.reply) {
         try {
           await this.sender.reply(msg.topic, result.reply);
         } catch (err: any) {
           Logger.warning(`命令回复发送失败: ${err.message}`);
-        }
-      }
-      if (result.handled && command.toLowerCase() === 'clear') {
-        this.pendingAttachments.delete(key);
-        if (!args.includes('--all')) {
-          this.cloudSessionRestorer.markLocalSessionCleared(sessionRoute?.sessionKey || key);
         }
       }
       if (result.handled) return;
@@ -1282,9 +1355,22 @@ export class CatsCompanyBot {
     }
 
     // 并发保护：忙时消息静默入队，空闲后自动处理
+    if (entryClearGeneration !== this.getSessionClearGeneration(key)) return;
     userMessage = prefixCatsUserMessage(speakerNameFromMetadata(msg), userMessage);
+    const nativeFeishuContext: NativeFeishuContextHydration | undefined = nativeFeishuTrigger
+      ? {
+        message: {
+          topic: msg.topic,
+          chatType: msg.chatType,
+          seq: msg.seq,
+          metadata: msg.metadata,
+        },
+        cloudRestoreStatus: cloudRestoreResult?.status,
+        clearGeneration: entryClearGeneration,
+      }
+      : undefined;
 
-    if (session.isBusy()) {
+    if (!this.tryReserveSessionExecution(key, session)) {
       const queue = this.messageQueue.get(key) ?? [];
       queue.push({
         userMessage,
@@ -1299,6 +1385,7 @@ export class CatsCompanyBot {
         receivedAt: Date.now(),
         source: 'user',
         runtimeFeedback,
+        nativeFeishuContext,
       });
       this.messageQueue.set(key, queue);
       Logger.info(`[${key}] 主会话忙，消息已入队 (队列长度: ${queue.length})`);
@@ -1317,35 +1404,46 @@ export class CatsCompanyBot {
     const stopTypingHeartbeat = this.startTypingHeartbeat(msg.topic);
 
     try {
-      const result = await session.handleMessage(userMessage, {
-        channel,
-        sessionRoute,
-        executionScope: msg.executionScope,
-        localDeviceGrant: this.localDeviceGrant,
-        deviceGrants: msg.deviceGrants,
-        deviceSelection: msg.deviceSelection,
-        targetRoutes: msg.targetRoutes,
-        deviceRpc: this.buildDeviceRpcTransport(),
-        thinToolRpc: this.maybeBuildThinToolRpcTransport(),
-        localFileGrants,
-        runtimeFeedback,
-        pendingUserInputProvider: () => this.consumeQueuedUserInput(key, msg.executionScope),
-        callbacks: this.buildSessionCallbacks(msg.topic, {
-          sessionKey: key,
-          senderId: msg.senderId,
-          channelSource: msg.executionScope?.channelSource,
-        }),
-      });
+      let shouldProcess = true;
+      if (nativeFeishuContext) {
+        shouldProcess = await this.hydrateNativeFeishuGroupContext(
+          session,
+          nativeFeishuContext,
+          key,
+        );
+      }
+      if (shouldProcess) {
+        const result = await session.handleMessage(userMessage, {
+          channel,
+          sessionRoute,
+          executionScope: msg.executionScope,
+          localDeviceGrant: this.localDeviceGrant,
+          deviceGrants: msg.deviceGrants,
+          deviceSelection: msg.deviceSelection,
+          targetRoutes: msg.targetRoutes,
+          deviceRpc: this.buildDeviceRpcTransport(),
+          thinToolRpc: this.maybeBuildThinToolRpcTransport(),
+          localFileGrants,
+          runtimeFeedback,
+          pendingUserInputProvider: () => this.consumeQueuedUserInput(key, msg.executionScope),
+          callbacks: this.buildSessionCallbacks(msg.topic, {
+            sessionKey: key,
+            senderId: msg.senderId,
+            channelSource: msg.executionScope?.channelSource,
+          }),
+        });
 
-      // 最终文本回复
-      if (result.visibleToUser && result.text) {
-        try {
-          await this.sender.reply(msg.topic, result.text);
-        } catch (err: any) {
-          Logger.warning(`前端通知发送失败 (text): ${err.message}`);
+        // 最终文本回复
+        if (result.visibleToUser && result.text) {
+          try {
+            await this.sender.reply(msg.topic, result.text);
+          } catch (err: any) {
+            Logger.warning(`前端通知发送失败 (text): ${err.message}`);
+          }
         }
       }
     } finally {
+      this.releaseSessionExecution(key);
       stopTypingHeartbeat();
     }
 
@@ -1359,34 +1457,114 @@ export class CatsCompanyBot {
       getRemoteContextCursor(source: string): number;
       saveRemoteContextCursor(source: string, cursor: number): void;
     },
-    msg: ParsedCatsMessage,
+    hydration: NativeFeishuContextHydration,
     sessionKey: string,
-    cloudRestoreStatus?: CloudSessionRestoreResult['status'],
-  ): Promise<void> {
-    if (!isNativeFeishuGroupTrigger(msg)) return;
+  ): Promise<boolean> {
+    const { message: msg, cloudRestoreStatus, clearGeneration } = hydration;
+    if (!isNativeFeishuGroupTrigger(msg)) return true;
+    if (clearGeneration !== this.getSessionClearGeneration(sessionKey)) return false;
     const cursorKey = 'catscompany.agent_context';
     if (cloudRestoreStatus === 'restored' || cloudRestoreStatus === 'empty') {
-      session.saveRemoteContextCursor(cursorKey, msg.seq);
-      return;
+      if (clearGeneration !== this.getSessionClearGeneration(sessionKey)) return false;
+      session.saveRemoteContextCursor(
+        cursorKey,
+        Math.max(session.getRemoteContextCursor(cursorKey), msg.seq),
+      );
+      return true;
     }
     try {
       const previousCursor = session.getRemoteContextCursor(cursorKey);
-      const history = await this.bot.getAgentContextHistory(msg.topic, {
-        beforeId: msg.seq,
-        limit: 100,
-        signal: AbortSignal.timeout(10_000),
-      });
-      const contextMessages = selectNativeFeishuGroupContext(history.messages || [], previousCursor);
+      const history = await this.fetchNativeFeishuGroupContextHistory(msg.topic, msg.seq, previousCursor);
+      if (clearGeneration !== this.getSessionClearGeneration(sessionKey)) return false;
+      const contextMessages = selectNativeFeishuGroupContext(history, previousCursor);
       for (const message of contextMessages) {
         session.injectContext(message);
       }
-      session.saveRemoteContextCursor(cursorKey, msg.seq);
+      session.saveRemoteContextCursor(cursorKey, Math.max(previousCursor, msg.seq));
       if (contextMessages.length > 0) {
         Logger.info(`[${sessionKey}] 已补入 ${contextMessages.length} 条飞书群普通消息上下文`);
       }
+      return true;
     } catch (err: any) {
       Logger.warning(`[${sessionKey}] 飞书群历史上下文恢复失败，继续处理当前消息: ${err?.message || err}`);
+      return clearGeneration === this.getSessionClearGeneration(sessionKey);
     }
+  }
+
+  private async fetchNativeFeishuGroupContextHistory(
+    topic: string,
+    beforeId: number,
+    afterSeq: number,
+  ): Promise<CatsAgentContextMessage[]> {
+    const messagesBySeq = new Map<number, CatsAgentContextMessage>();
+    let pageBeforeId = beforeId;
+    const signal = AbortSignal.timeout(10_000);
+
+    for (let pageIndex = 0; pageIndex < NATIVE_FEISHU_CONTEXT_MAX_PAGES; pageIndex++) {
+      const page = await this.bot.getAgentContextHistory(topic, {
+        beforeId: pageBeforeId,
+        limit: NATIVE_FEISHU_CONTEXT_PAGE_SIZE,
+        signal,
+      });
+      if (page.topic_id !== topic) {
+        throw new Error(`agent context topic mismatch: ${page.topic_id}`);
+      }
+      if (normalizeCatsUid(page.agent_uid) !== normalizeCatsUid(this.botUid)) {
+        throw new Error(`agent context identity mismatch: ${page.agent_uid}`);
+      }
+      for (const message of page.messages || []) {
+        const seq = agentContextMessageSeq(message);
+        if (seq > 0 && !messagesBySeq.has(seq)) messagesBySeq.set(seq, message);
+      }
+
+      const pageMessages = page.messages || [];
+      const reachedPreviousCursor = afterSeq > 0
+        && pageMessages.some(message => agentContextMessageSeq(message) <= afterSeq);
+      const reachedClearBoundary = pageMessages.some(isNativeFeishuClearBoundary);
+      if (
+        reachedPreviousCursor
+        || reachedClearBoundary
+        || !page.has_more
+        || page.next_before_id <= 0
+      ) {
+        return [...messagesBySeq.values()]
+          .sort((left, right) => agentContextMessageSeq(left) - agentContextMessageSeq(right));
+      }
+      if (page.next_before_id >= pageBeforeId) {
+        throw new Error(`agent context pagination did not advance: ${page.next_before_id}`);
+      }
+      pageBeforeId = page.next_before_id;
+    }
+
+    Logger.warning(
+      `[${topic}] 飞书群历史超过 ${NATIVE_FEISHU_CONTEXT_MAX_PAGES * NATIVE_FEISHU_CONTEXT_PAGE_SIZE} 条，`
+      + '仅补入最近一段并推进游标',
+    );
+    return [...messagesBySeq.values()]
+      .sort((left, right) => agentContextMessageSeq(left) - agentContextMessageSeq(right));
+  }
+
+  private tryReserveSessionExecution(
+    sessionKey: string,
+    session: { isBusy?: () => boolean },
+  ): boolean {
+    const reservations = this.sessionExecutionReservations ??= new Set<string>();
+    if (reservations.has(sessionKey) || session.isBusy?.()) return false;
+    reservations.add(sessionKey);
+    return true;
+  }
+
+  private releaseSessionExecution(sessionKey: string): void {
+    this.sessionExecutionReservations?.delete(sessionKey);
+  }
+
+  private getSessionClearGeneration(sessionKey: string): number {
+    return this.sessionClearGenerations?.get(sessionKey) ?? 0;
+  }
+
+  private bumpSessionClearGeneration(sessionKey: string): void {
+    const generations = this.sessionClearGenerations ??= new Map<string, number>();
+    generations.set(sessionKey, this.getSessionClearGeneration(sessionKey) + 1);
   }
 
   private async ensureCloudSessionRestored(
@@ -1413,11 +1591,29 @@ export class CatsCompanyBot {
     const key = sessionRoute.sessionKey;
     const existing = this.cloudSessionRestorePromises.get(key);
     if (existing) {
-      return existing;
+      const result = await existing;
+      if (result.status === 'restored' || result.status === 'empty' || result.status === 'local_present') {
+        return {
+          status: 'local_present',
+          restoredMessages: 0,
+          fetchedMessages: 0,
+          compressed: false,
+        };
+      }
+      return result;
     }
 
-    const restore = this.restoreCloudSessionWithStatus(msg, sessionRoute)
-      .finally(() => this.cloudSessionRestorePromises.delete(key));
+    const abortController = new AbortController();
+    (this.cloudSessionRestoreAbortControllers ??= new Map()).set(key, abortController);
+    const restore = this.restoreCloudSessionWithStatus(msg, sessionRoute, abortController.signal)
+      .finally(() => {
+        if (this.cloudSessionRestorePromises.get(key) === restore) {
+          this.cloudSessionRestorePromises.delete(key);
+        }
+        if (this.cloudSessionRestoreAbortControllers?.get(key) === abortController) {
+          this.cloudSessionRestoreAbortControllers.delete(key);
+        }
+      });
     this.cloudSessionRestorePromises.set(key, restore);
     return restore;
   }
@@ -1425,6 +1621,7 @@ export class CatsCompanyBot {
   private async restoreCloudSessionWithStatus(
     msg: ParsedCatsMessage,
     sessionRoute: ReturnType<typeof createCatsCoSessionRoute>,
+    clearSignal?: AbortSignal,
   ): Promise<CloudSessionRestoreResult> {
     let statusTimer: ReturnType<typeof setTimeout> | undefined;
     try {
@@ -1434,13 +1631,17 @@ export class CatsCompanyBot {
         });
       }, 800);
 
+      const timeoutSignal = AbortSignal.timeout(30_000);
+      const signal = clearSignal
+        ? combineAbortSignals([clearSignal, timeoutSignal])
+        : timeoutSignal;
       return await this.cloudSessionRestorer.restoreIfMissing({
         sessionKey: sessionRoute.sessionKey,
         topicId: sessionRoute.topicId,
         topicType: sessionRoute.topicType === 'group' ? 'group' : 'p2p',
         agentId: sessionRoute.agentId || this.botUid || '',
         currentSeq: Number(msg.seq || sessionRoute.channelSeq || 0),
-        signal: AbortSignal.timeout(30_000),
+        signal,
       });
     } finally {
       if (statusTimer) clearTimeout(statusTimer);
@@ -1578,12 +1779,6 @@ export class CatsCompanyBot {
 
     const session = this.sessionManager.getOrCreate(sessionKey);
 
-    if (session.isBusy()) {
-      this.enqueueSubAgentFeedback(sessionKey, topic, senderId, text, executionScope);
-      Logger.info(`[${sessionKey}] 主会话忙，子智能体反馈已入队`);
-      return;
-    }
-
     this.registerSubAgentPlatformCallbacks(sessionKey, topic, senderId, executionScope);
 
     const channel = this.buildChannel(topic, {
@@ -1597,6 +1792,12 @@ export class CatsCompanyBot {
     if (suppressFinalResponse) {
       this.scheduleSubAgentCompletionBatch(sessionKey, topic, senderId, text, executionScope);
       await this.drainMessageQueue(sessionKey);
+      return;
+    }
+
+    if (!this.tryReserveSessionExecution(sessionKey, session)) {
+      this.enqueueSubAgentFeedback(sessionKey, topic, senderId, text, executionScope);
+      Logger.info(`[${sessionKey}] 主会话忙，子智能体反馈已入队`);
       return;
     }
 
@@ -1626,27 +1827,31 @@ export class CatsCompanyBot {
       if (result.text === BUSY_MESSAGE) {
         this.enqueueSubAgentFeedback(sessionKey, topic, senderId, text, executionScope);
         Logger.info(`[${sessionKey}] 主会话竞态忙碌，子智能体反馈已入队`);
-        return;
-      }
-      subAgentManager.markResultObservationHandledForParent(sessionKey, text);
-      if (result.text.startsWith('处理消息时出错:')) {
-        try {
-          await this.sender.reply(topic, result.text);
-        } catch (err: any) {
-          Logger.warning(`错误消息发送失败: ${err.message}`);
+      } else {
+        subAgentManager.markResultObservationHandledForParent(sessionKey, text);
+        if (result.text.startsWith('处理消息时出错:')) {
+          try {
+            await this.sender.reply(topic, result.text);
+          } catch (err: any) {
+            Logger.warning(`错误消息发送失败: ${err.message}`);
+          }
+        } else if (result.visibleToUser && result.text) {
+          try {
+            await this.sender.reply(topic, result.text);
+          } catch (err: any) {
+            Logger.warning(`子智能体结果回复发送失败: ${err.message}`);
+          }
         }
-      } else if (result.visibleToUser && result.text) {
-        try {
-          await this.sender.reply(topic, result.text);
-        } catch (err: any) {
-          Logger.warning(`子智能体结果回复发送失败: ${err.message}`);
-        }
       }
-      stopTypingHeartbeatOnce();
-      await this.drainMessageQueue(sessionKey);
+    } catch (err: any) {
+      this.enqueueSubAgentFeedback(sessionKey, topic, senderId, text, executionScope, 1);
+      Logger.warning(`[${sessionKey}] 子智能体反馈执行异常，已入队重试: ${err?.message || err}`);
     } finally {
+      this.releaseSessionExecution(sessionKey);
       stopTypingHeartbeatOnce();
     }
+
+    await this.drainMessageQueue(sessionKey);
   }
 
   private enqueueSubAgentFeedback(
@@ -1655,6 +1860,7 @@ export class CatsCompanyBot {
     senderId: string,
     text: string,
     executionScope?: ParsedCatsMessage['executionScope'],
+    attempts = 0,
   ): void {
     const queue = this.messageQueue.get(sessionKey) ?? [];
     queue.push({
@@ -1669,6 +1875,7 @@ export class CatsCompanyBot {
       })),
       receivedAt: Date.now(),
       source: 'subagent_feedback',
+      attempts,
     });
     this.messageQueue.set(sessionKey, queue);
   }
@@ -1684,13 +1891,20 @@ export class CatsCompanyBot {
     if (!item) return;
 
     const now = Date.now();
-    const existing = this.subAgentCompletionBatches.get(sessionKey);
+    const clearGeneration = this.getSessionClearGeneration(sessionKey);
+    let existing = this.subAgentCompletionBatches.get(sessionKey);
+    if (existing && existing.clearGeneration !== clearGeneration) {
+      if (existing.timer) clearTimeout(existing.timer);
+      this.subAgentCompletionBatches.delete(sessionKey);
+      existing = undefined;
+    }
     const batch: BackgroundSubAgentCompletionBatch = existing ?? {
       topic,
       senderId,
       channelSource: executionScope?.channelSource,
       executionScope,
       firstAt: now,
+      clearGeneration,
       items: new Map(),
     };
     batch.topic = topic;
@@ -1710,12 +1924,13 @@ export class CatsCompanyBot {
   private async flushSubAgentCompletionBatch(sessionKey: string, force = false): Promise<void> {
     const batch = this.subAgentCompletionBatches.get(sessionKey);
     if (!batch || batch.items.size === 0) return;
-
-    const session = this.sessionManager.get?.(sessionKey) || this.sessionManager.getOrCreate(sessionKey);
-    if (!force && session?.isBusy?.()) {
-      this.rescheduleSubAgentCompletionBatch(sessionKey, batch);
+    if (batch.clearGeneration !== this.getSessionClearGeneration(sessionKey)) {
+      if (batch.timer) clearTimeout(batch.timer);
+      this.subAgentCompletionBatches.delete(sessionKey);
       return;
     }
+
+    const session = this.sessionManager.get?.(sessionKey) || this.sessionManager.getOrCreate(sessionKey);
 
     const manager = SubAgentManager.getInstance();
     const activeSubAgents = manager
@@ -1727,23 +1942,29 @@ export class CatsCompanyBot {
       return;
     }
 
-    this.subAgentCompletionBatches.delete(sessionKey);
-    if (batch.timer) clearTimeout(batch.timer);
+    if (!this.tryReserveSessionExecution(sessionKey, session)) {
+      this.rescheduleSubAgentCompletionBatch(sessionKey, batch);
+      return;
+    }
 
     const items = [...batch.items.values()];
-    const observation = this.formatSubAgentCompletionBatchObservation(items, activeSubAgents.length);
-    if (!observation) return;
-
-    this.registerSubAgentPlatformCallbacks(sessionKey, batch.topic, batch.senderId, batch.executionScope);
-
-    const channel = this.buildChannel(batch.topic, {
-      sessionKey,
-      senderId: batch.senderId,
-      channelSource: batch.channelSource,
-    });
-    const stopTypingHeartbeat = this.startTypingHeartbeat(batch.topic);
+    let stopTypingHeartbeat: () => void = () => undefined;
 
     try {
+      this.subAgentCompletionBatches.delete(sessionKey);
+      if (batch.timer) clearTimeout(batch.timer);
+
+      const observation = this.formatSubAgentCompletionBatchObservation(items, activeSubAgents.length);
+      if (!observation) return;
+
+      this.registerSubAgentPlatformCallbacks(sessionKey, batch.topic, batch.senderId, batch.executionScope);
+      const channel = this.buildChannel(batch.topic, {
+        sessionKey,
+        senderId: batch.senderId,
+        channelSource: batch.channelSource,
+      });
+      stopTypingHeartbeat = this.startTypingHeartbeat(batch.topic);
+
       const result = await session.handleRuntimeObservation(observation, {
         channel,
         callbacks: this.buildSessionCallbacks(batch.topic, {
@@ -1763,6 +1984,7 @@ export class CatsCompanyBot {
         this.rescheduleSubAgentCompletionBatch(sessionKey, batch);
         return;
       }
+      if (batch.clearGeneration !== this.getSessionClearGeneration(sessionKey)) return;
 
       for (const item of items) {
         manager.markResultObservationHandledForParent(sessionKey, item.observation);
@@ -1773,23 +1995,39 @@ export class CatsCompanyBot {
       } else if (result.visibleToUser && result.text) {
         await this.sender.reply(batch.topic, result.text);
       }
-      await this.drainMessageQueue(sessionKey);
     } catch (err: any) {
       Logger.warning(`后台子任务批量回流失败: ${err.message}`);
+      if (batch.clearGeneration !== this.getSessionClearGeneration(sessionKey)) return;
       const fallback = this.formatSubAgentCompletionNotice(items, activeSubAgents.length);
+      let fallbackDelivered = false;
       if (fallback) {
         try {
           await this.sender.reply(batch.topic, fallback);
           for (const item of items) {
             manager.markResultObservationHandledForParent(sessionKey, item.observation);
           }
+          fallbackDelivered = true;
         } catch (sendErr: any) {
           Logger.warning(`后台子任务兜底通知发送失败: ${sendErr.message}`);
         }
       }
+      if (!fallbackDelivered && batch.clearGeneration === this.getSessionClearGeneration(sessionKey)) {
+        const pendingBatch = this.subAgentCompletionBatches.get(sessionKey);
+        if (pendingBatch && pendingBatch !== batch) {
+          for (const [itemKey, item] of batch.items) pendingBatch.items.set(itemKey, item);
+          pendingBatch.firstAt = Math.min(pendingBatch.firstAt, batch.firstAt);
+          this.rescheduleSubAgentCompletionBatch(sessionKey, pendingBatch);
+        } else {
+          this.subAgentCompletionBatches.set(sessionKey, batch);
+          this.rescheduleSubAgentCompletionBatch(sessionKey, batch);
+        }
+      }
     } finally {
+      this.releaseSessionExecution(sessionKey);
       stopTypingHeartbeat();
     }
+
+    await this.drainMessageQueue(sessionKey);
   }
 
   private rescheduleSubAgentCompletionBatch(
@@ -2147,33 +2385,27 @@ export class CatsCompanyBot {
     const queue = this.messageQueue.get(sessionKey);
     if (!queue || queue.length === 0) return;
 
-    const msg = queue.shift()!;
-    if (queue.length === 0) {
-      this.messageQueue.delete(sessionKey);
-    }
+    const msg = queue[0];
 
     const subAgentManager = SubAgentManager.getInstance();
     const queuedResultObservationHandling = msg.source === 'subagent_feedback'
       ? subAgentManager.getResultObservationHandlingForParent(sessionKey, msg.userMessage as string)
       : 'silent';
     if (queuedResultObservationHandling === 'drop') {
+      queue.shift();
+      if (queue.length === 0) this.messageQueue.delete(sessionKey);
       Logger.info(`[${sessionKey}] 队列中的子智能体完成 observation 已由 wait_subagents 消费，跳过回流处理`);
       await this.drainMessageQueue(sessionKey);
       return;
     }
 
     const session = this.sessionManager.getOrCreate(sessionKey);
-    this.registerSubAgentPlatformCallbacks(sessionKey, msg.topic, msg.senderId, msg.executionScope);
-    const channel = this.buildChannel(msg.topic, {
-      sessionKey,
-      senderId: msg.senderId,
-      channelSource: msg.executionScope?.channelSource,
-    });
-
     const suppressSubAgentFinalResponse = msg.source === 'subagent_feedback'
       && queuedResultObservationHandling !== 'notify'
       && shouldSuppressSubAgentObservationReply(msg.userMessage as string);
     if (suppressSubAgentFinalResponse) {
+      queue.shift();
+      if (queue.length === 0) this.messageQueue.delete(sessionKey);
       this.scheduleSubAgentCompletionBatch(
         sessionKey,
         msg.topic,
@@ -2185,64 +2417,144 @@ export class CatsCompanyBot {
       return;
     }
 
+    if (msg.source === 'subagent_feedback' && msg.deliveryOnly) {
+      queue.shift();
+      if (queue.length === 0) this.messageQueue.delete(sessionKey);
+      const fallback = `后台子任务已完成，但暂时无法写入主会话上下文：\n\n${String(msg.userMessage)}`;
+      try {
+        await this.sender.reply(msg.topic, fallback);
+        subAgentManager.markResultObservationHandledForParent(sessionKey, msg.userMessage as string);
+        await this.drainMessageQueue(sessionKey);
+      } catch (err: any) {
+        const deliveryAttempts = (msg.deliveryAttempts ?? 0) + 1;
+        if (deliveryAttempts < SUBAGENT_FALLBACK_MAX_DELIVERY_ATTEMPTS) {
+          const pending = this.messageQueue.get(sessionKey) ?? [];
+          pending.unshift({ ...msg, deliveryAttempts });
+          this.messageQueue.set(sessionKey, pending);
+          const retryDelay = BACKGROUND_SUBAGENT_COMPLETION_DEBOUNCE_MS * (2 ** (deliveryAttempts - 1));
+          Logger.warning(`[${sessionKey}] 子智能体结果兜底通知发送失败，将在 ${retryDelay}ms 后重试: ${err?.message || err}`);
+          const timer = setTimeout(() => void this.drainMessageQueue(sessionKey), retryDelay);
+          timer.unref?.();
+        } else {
+          Logger.error(`[${sessionKey}] 子智能体结果兜底通知连续失败 ${deliveryAttempts} 次，已停止重试: ${err?.message || err}`);
+        }
+      }
+      return;
+    }
+
+    if (!this.tryReserveSessionExecution(sessionKey, session)) return;
+
+    queue.shift();
+    if (queue.length === 0) this.messageQueue.delete(sessionKey);
+
+    this.registerSubAgentPlatformCallbacks(sessionKey, msg.topic, msg.senderId, msg.executionScope);
+    const channel = this.buildChannel(msg.topic, {
+      sessionKey,
+      senderId: msg.senderId,
+      channelSource: msg.executionScope?.channelSource,
+    });
     const stopTypingHeartbeat = suppressSubAgentFinalResponse ? () => undefined : this.startTypingHeartbeat(msg.topic);
 
+    let retryLater = false;
     try {
-      const result = msg.source === 'subagent_feedback'
-        ? await session.handleRuntimeObservation(msg.userMessage as string, {
-          channel,
-          callbacks: suppressSubAgentFinalResponse ? undefined : this.buildSessionCallbacks(msg.topic, {
-            sessionKey,
-            senderId: msg.senderId,
-            channelSource: msg.executionScope?.channelSource,
-          }),
-          source: 'subagent_result',
-          suppressFinalResponse: suppressSubAgentFinalResponse,
-          executionScope: msg.executionScope,
-          localDeviceGrant: this.localDeviceGrant,
-          deviceSelection: msg.deviceSelection,
-          targetRoutes: msg.targetRoutes,
-          deviceRpc: this.buildDeviceRpcTransport(),
-          thinToolRpc: this.maybeBuildThinToolRpcTransport(),
-        })
-        : await session.handleMessage(msg.userMessage, {
-          channel,
-          executionScope: msg.executionScope,
-          localDeviceGrant: this.localDeviceGrant,
-          deviceGrants: msg.deviceGrants,
-          deviceSelection: msg.deviceSelection,
-          targetRoutes: msg.targetRoutes,
-          deviceRpc: this.buildDeviceRpcTransport(),
-          thinToolRpc: this.maybeBuildThinToolRpcTransport(),
-          runtimeFeedback: msg.runtimeFeedback,
-          localFileGrants: msg.localFileGrants,
-          pendingUserInputProvider: () => this.consumeQueuedUserInput(sessionKey, msg.executionScope),
-          callbacks: this.buildSessionCallbacks(msg.topic, {
-            sessionKey,
-            senderId: msg.senderId,
-            channelSource: msg.executionScope?.channelSource,
-          }),
-        });
-      if (result.text.startsWith('处理消息时出错:')) {
-        try {
-          await this.sender.reply(msg.topic, result.text);
-        } catch (err: any) {
-          Logger.warning(`错误消息发送失败: ${err.message}`);
-        }
-      } else if (result.text !== BUSY_MESSAGE && result.visibleToUser && result.text) {
-        try {
-          await this.sender.reply(msg.topic, result.text);
-        } catch (err: any) {
-          Logger.warning(`队列消息回复发送失败: ${err.message}`);
+      let shouldProcess = true;
+      if (msg.nativeFeishuContext) {
+        shouldProcess = await this.hydrateNativeFeishuGroupContext(
+          session,
+          msg.nativeFeishuContext,
+          sessionKey,
+        );
+      }
+      if (shouldProcess) {
+        const result = msg.source === 'subagent_feedback'
+          ? await session.handleRuntimeObservation(msg.userMessage as string, {
+            channel,
+            callbacks: suppressSubAgentFinalResponse ? undefined : this.buildSessionCallbacks(msg.topic, {
+              sessionKey,
+              senderId: msg.senderId,
+              channelSource: msg.executionScope?.channelSource,
+            }),
+            source: 'subagent_result',
+            suppressFinalResponse: suppressSubAgentFinalResponse,
+            executionScope: msg.executionScope,
+            localDeviceGrant: this.localDeviceGrant,
+            deviceSelection: msg.deviceSelection,
+            targetRoutes: msg.targetRoutes,
+            deviceRpc: this.buildDeviceRpcTransport(),
+            thinToolRpc: this.maybeBuildThinToolRpcTransport(),
+          })
+          : await session.handleMessage(msg.userMessage, {
+            channel,
+            executionScope: msg.executionScope,
+            localDeviceGrant: this.localDeviceGrant,
+            deviceGrants: msg.deviceGrants,
+            deviceSelection: msg.deviceSelection,
+            targetRoutes: msg.targetRoutes,
+            deviceRpc: this.buildDeviceRpcTransport(),
+            thinToolRpc: this.maybeBuildThinToolRpcTransport(),
+            runtimeFeedback: msg.runtimeFeedback,
+            localFileGrants: msg.localFileGrants,
+            pendingUserInputProvider: () => this.consumeQueuedUserInput(sessionKey, msg.executionScope),
+            callbacks: this.buildSessionCallbacks(msg.topic, {
+              sessionKey,
+              senderId: msg.senderId,
+              channelSource: msg.executionScope?.channelSource,
+            }),
+          });
+        if (result.text === BUSY_MESSAGE) {
+          const pending = this.messageQueue.get(sessionKey) ?? [];
+          pending.unshift(msg);
+          this.messageQueue.set(sessionKey, pending);
+          retryLater = true;
+          Logger.info(`[${sessionKey}] 队列执行遇到竞态忙碌，消息保留等待重试`);
+        } else {
+          if (result.text.startsWith('处理消息时出错:')) {
+            try {
+              await this.sender.reply(msg.topic, result.text);
+            } catch (err: any) {
+              Logger.warning(`错误消息发送失败: ${err.message}`);
+            }
+          } else if (result.visibleToUser && result.text) {
+            try {
+              await this.sender.reply(msg.topic, result.text);
+            } catch (err: any) {
+              Logger.warning(`队列消息回复发送失败: ${err.message}`);
+            }
+          }
+          if (msg.source === 'subagent_feedback') {
+            subAgentManager.markResultObservationHandledForParent(sessionKey, msg.userMessage as string);
+          }
         }
       }
-      if (result.text !== BUSY_MESSAGE && msg.source === 'subagent_feedback') {
-        subAgentManager.markResultObservationHandledForParent(sessionKey, msg.userMessage as string);
+    } catch (err: any) {
+      const attempts = (msg.attempts ?? 0) + 1;
+      if (attempts <= 2) {
+        const pending = this.messageQueue.get(sessionKey) ?? [];
+        pending.unshift({ ...msg, attempts });
+        this.messageQueue.set(sessionKey, pending);
+        retryLater = true;
+        Logger.warning(`[${sessionKey}] 队列消息执行异常，保留等待重试: ${err?.message || err}`);
+      } else {
+        Logger.error(`[${sessionKey}] 队列消息连续执行失败，停止重试: ${err?.message || err}`);
+        if (msg.source === 'subagent_feedback') {
+          const pending = this.messageQueue.get(sessionKey) ?? [];
+          pending.unshift({ ...msg, attempts, deliveryOnly: true });
+          this.messageQueue.set(sessionKey, pending);
+          retryLater = true;
+        } else {
+          await this.sender.reply(msg.topic, '处理消息时出错，请稍后重试。').catch(() => undefined);
+        }
       }
     } finally {
+      this.releaseSessionExecution(sessionKey);
       stopTypingHeartbeat();
     }
 
+    if (retryLater) {
+      const timer = setTimeout(() => void this.drainMessageQueue(sessionKey), 100);
+      timer.unref?.();
+      return;
+    }
     await this.drainMessageQueue(sessionKey);
   }
 
@@ -2258,6 +2570,7 @@ export class CatsCompanyBot {
     for (; firstRemainingIndex < queue.length; firstRemainingIndex++) {
       const item = queue[firstRemainingIndex];
       if (item.source === 'subagent_feedback') break;
+      if (item.nativeFeishuContext) break;
       if (!this.canMergeQueuedMessage(currentScope, item.executionScope)) break;
       userMessages.push(item);
     }
@@ -2347,6 +2660,10 @@ export class CatsCompanyBot {
     await this.sessionManager.destroy();
     this.pendingAttachments.clear();
     this.messageQueue.clear();
+    this.sessionExecutionReservations?.clear();
+    this.sessionClearGenerations?.clear();
+    for (const controller of this.cloudSessionRestoreAbortControllers?.values() ?? []) controller.abort();
+    this.cloudSessionRestoreAbortControllers?.clear();
     this.subAgentEventRoutes.clear();
     for (const batch of this.subAgentCompletionBatches.values()) {
       if (batch.timer) clearTimeout(batch.timer);

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -49,6 +49,10 @@ import {
   buildCatsCoAttachmentCachePath,
   scheduleCatsCoAttachmentCacheCleanup,
 } from './attachment-cache';
+import {
+  isNativeFeishuGroupTrigger,
+  selectNativeFeishuGroupContext,
+} from './agent-context-history';
 
 interface PendingAttachment {
   fileName: string;
@@ -1162,6 +1166,8 @@ export class CatsCompanyBot {
     const sessionRoute = msg.envelope ? createCatsCoSessionRoute(msg.envelope) : undefined;
     const session = this.sessionManager.getOrCreate(sessionRoute && sessionRoute.sessionKey === key ? sessionRoute : key);
 
+    await this.hydrateNativeFeishuGroupContext(session, msg, key);
+
     // 处理斜杠命令
     if (typeof msg.text === 'string' && msg.text.startsWith('/')) {
       const parts = msg.text.slice(1).split(/\s+/);
@@ -1318,6 +1324,33 @@ export class CatsCompanyBot {
 
     // 处理忙时排队的消息
     await this.drainMessageQueue(key);
+  }
+
+  private async hydrateNativeFeishuGroupContext(
+    session: {
+      injectContext(text: string): void;
+      getRemoteContextCursor(source: string): number;
+      saveRemoteContextCursor(source: string, cursor: number): void;
+    },
+    msg: ParsedCatsMessage,
+    sessionKey: string,
+  ): Promise<void> {
+    if (!isNativeFeishuGroupTrigger(msg)) return;
+    try {
+      const cursorKey = 'catscompany.agent_context';
+      const previousCursor = session.getRemoteContextCursor(cursorKey);
+      const history = await this.bot.fetchAgentContextHistory(msg.topic, msg.seq);
+      const contextMessages = selectNativeFeishuGroupContext(history.messages || [], previousCursor);
+      for (const message of contextMessages) {
+        session.injectContext(message);
+      }
+      session.saveRemoteContextCursor(cursorKey, msg.seq);
+      if (contextMessages.length > 0) {
+        Logger.info(`[${sessionKey}] 已补入 ${contextMessages.length} 条飞书群普通消息上下文`);
+      }
+    } catch (err: any) {
+      Logger.warning(`[${sessionKey}] 飞书群历史上下文恢复失败，继续处理当前消息: ${err?.message || err}`);
+    }
   }
 
   /**

--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -321,7 +321,13 @@ export class AgentSession {
   /** 构建系统提示词（幂等初始化；已初始化会话在下一轮开始前可热加载） */
   async init(options: InitSessionOptions = {}): Promise<void> {
     if (this.initialized) return;
+    const lifecycleGeneration = this.lifecycleGeneration;
+    const initSignal = options.signal ?? this.activeAbortController?.signal;
     const { systemPrompt, promptTrace } = await this.buildCurrentSystemPrompt();
+    if (initSignal?.aborted || this.interruptRequested || lifecycleGeneration !== this.lifecycleGeneration) {
+      Logger.info(`[会话 ${this.key}] 初始化期间会话已重置，忽略旧初始化结果`);
+      return;
+    }
     this.applyPromptTrace(promptTrace, 'init');
     this.initialized = true;
     const initialSystemMessages: Message[] = [];
@@ -348,7 +354,7 @@ export class AgentSession {
       const usage = this.contextWindowManager.getUsageInfo(this.messages);
       Logger.info(`[${this.key}] 恢复后上下文: ${usage.usedTokens}/${usage.maxTokens} tokens (${usage.usagePercent}%)`);
 
-      const compactionSignal = options.signal ?? this.activeAbortController?.signal;
+      const compactionSignal = initSignal;
       const messagesBeforeRestoreCompaction = stripAssistantArtifactsFromMessages(this.messages);
       const compactedMessages = await this.contextWindowManager.compactIfNeeded(messagesBeforeRestoreCompaction, {
         sessionKey: this.key,
@@ -505,7 +511,7 @@ export class AgentSession {
       this.lastActiveAt = Date.now();
 
       try {
-        await this.refreshSystemPromptIfNeeded();
+        await this.refreshSystemPromptIfNeeded(lifecycleGeneration, this.activeAbortController.signal);
       } catch (error: any) {
         Logger.warning(`[会话 ${this.key}] Prompt 热加载失败，继续使用上一版: ${error?.message || error}`);
       }
@@ -783,10 +789,17 @@ export class AgentSession {
     return { systemPrompt, promptTrace };
   }
 
-  private async refreshSystemPromptIfNeeded(): Promise<void> {
+  private async refreshSystemPromptIfNeeded(
+    lifecycleGeneration: number,
+    signal?: AbortSignal,
+  ): Promise<void> {
     if (!this.initialized || !this.promptTrace) return;
 
     const { systemPrompt, promptTrace } = await this.buildCurrentSystemPrompt();
+    if (signal?.aborted || this.interruptRequested || lifecycleGeneration !== this.lifecycleGeneration) {
+      Logger.info(`[会话 ${this.key}] Prompt 热加载期间会话已重置，忽略旧热加载结果`);
+      return;
+    }
     const changed = this.diffPromptTrace(promptTrace);
     if (!changed.any) return;
 

--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -162,6 +162,7 @@ export class AgentSession {
   /** 外部请求中断当前 run（例如用户在 busy 时发送"停止"） */
   private interruptRequested = false;
   private activeAbortController: AbortController | null = null;
+  private lifecycleGeneration = 0;
   lastActiveAt: number = Date.now();
   private sessionTurnLogger: SessionTurnLogger;
   private turnLogRecorder: TurnLogRecorder;
@@ -347,13 +348,19 @@ export class AgentSession {
       const usage = this.contextWindowManager.getUsageInfo(this.messages);
       Logger.info(`[${this.key}] 恢复后上下文: ${usage.usedTokens}/${usage.maxTokens} tokens (${usage.usagePercent}%)`);
 
-      this.messages = stripAssistantArtifactsFromMessages(this.messages);
-      this.messages = await this.contextWindowManager.compactIfNeeded(this.messages, {
+      const compactionSignal = options.signal ?? this.activeAbortController?.signal;
+      const messagesBeforeRestoreCompaction = stripAssistantArtifactsFromMessages(this.messages);
+      const compactedMessages = await this.contextWindowManager.compactIfNeeded(messagesBeforeRestoreCompaction, {
         sessionKey: this.key,
         reason: '恢复后',
-        signal: options.signal ?? this.activeAbortController?.signal,
+        signal: compactionSignal,
         onStatus: this.createContextCompactionNotifier(options.callbacks),
       });
+      if (compactionSignal?.aborted || this.interruptRequested) {
+        Logger.info(`[会话 ${this.key}] 当前请求已取消，忽略恢复压缩在中断后的返回`);
+        return;
+      }
+      this.messages = compactedMessages;
     }
 
     if (injectedContext.length > 0) {
@@ -485,6 +492,7 @@ export class AgentSession {
       if (this.busy) {
         return { text: BUSY_MESSAGE, visibleToUser: true };
       }
+      const lifecycleGeneration = this.lifecycleGeneration;
 
       const runtimeFeedback = this.consumeRuntimeFeedback(runtimeFeedbackInputs);
 
@@ -512,7 +520,7 @@ export class AgentSession {
         });
         if (this.interruptRequested || this.activeAbortController.signal.aborted) {
           Logger.info(`[会话 ${this.key}] 当前请求已取消，忽略压缩在中断后的返回`);
-          this.lifecycleManager.saveContext(this.messages);
+          this.saveInterruptedContextIfCurrent(lifecycleGeneration);
           return { text: '已停止当前请求。', visibleToUser: true };
         }
         this.messages = compactedMessages;
@@ -521,6 +529,11 @@ export class AgentSession {
           callbacks,
           signal: this.activeAbortController.signal,
         });
+        if (this.interruptRequested || this.activeAbortController.signal.aborted) {
+          Logger.info(`[会话 ${this.key}] 当前请求已取消，不再启动模型回合`);
+          this.saveInterruptedContextIfCurrent(lifecycleGeneration);
+          return { text: '已停止当前请求。', visibleToUser: true };
+        }
         const result = await this.turnController.run({
           input: text,
           messages: this.messages,
@@ -545,7 +558,7 @@ export class AgentSession {
         if (this.interruptRequested || this.activeAbortController.signal.aborted) {
           Logger.info(`[会话 ${this.key}] 当前请求已取消，忽略模型在中断后的返回`);
           this.messages = this.turnContextBuilder.removeTransientMessages(this.messages);
-          this.lifecycleManager.saveContext(this.messages);
+          this.saveInterruptedContextIfCurrent(lifecycleGeneration);
           return { text: '已停止当前请求。', visibleToUser: true };
         }
         this.messages = result.messages;
@@ -555,7 +568,7 @@ export class AgentSession {
         if (this.isAbortError(err) || this.interruptRequested || this.activeAbortController.signal.aborted) {
           Logger.info(`[会话 ${this.key}] 当前请求已取消`);
           this.messages = this.turnContextBuilder.removeTransientMessages(this.messages);
-          this.lifecycleManager.saveContext(this.messages);
+          this.saveInterruptedContextIfCurrent(lifecycleGeneration);
           return { text: '已停止当前请求。', visibleToUser: true };
         }
 
@@ -667,6 +680,7 @@ export class AgentSession {
 
   /** 重置会话状态（仅清内存，保留历史文件） */
   reset(): void {
+    this.lifecycleGeneration++;
     this.planRuntime.clear();
     this.stopSubAgents('父会话 reset');
     this.messages = [];
@@ -680,6 +694,7 @@ export class AgentSession {
 
   /** 清空历史（同时删除文件） */
   clear(): void {
+    this.lifecycleGeneration++;
     this.planRuntime.clear();
     this.stopSubAgents('父会话 clear');
     this.messages = [];
@@ -738,6 +753,11 @@ export class AgentSession {
     if (!this.busy) return;
     this.interruptRequested = true;
     this.activeAbortController?.abort();
+  }
+
+  private saveInterruptedContextIfCurrent(lifecycleGeneration: number): void {
+    if (lifecycleGeneration !== this.lifecycleGeneration) return;
+    this.lifecycleManager.saveContext(this.messages);
   }
 
   /** 从 DB 恢复消息（进程重启后调用） */

--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -502,15 +502,21 @@ export class AgentSession {
         Logger.warning(`[会话 ${this.key}] Prompt 热加载失败，继续使用上一版: ${error?.message || error}`);
       }
 
-      this.messages = stripAssistantArtifactsFromMessages(this.messages);
-      this.messages = await this.contextWindowManager.compactIfNeeded(this.messages, {
-        sessionKey: this.key,
-        reason: '处理前',
-        signal: this.activeAbortController.signal,
-        onStatus: this.createContextCompactionNotifier(callbacks),
-      });
-
       try {
+        const messagesBeforeCompaction = stripAssistantArtifactsFromMessages(this.messages);
+        const compactedMessages = await this.contextWindowManager.compactIfNeeded(messagesBeforeCompaction, {
+          sessionKey: this.key,
+          reason: '处理前',
+          signal: this.activeAbortController.signal,
+          onStatus: this.createContextCompactionNotifier(callbacks),
+        });
+        if (this.interruptRequested || this.activeAbortController.signal.aborted) {
+          Logger.info(`[会话 ${this.key}] 当前请求已取消，忽略压缩在中断后的返回`);
+          this.lifecycleManager.saveContext(this.messages);
+          return { text: '已停止当前请求。', visibleToUser: true };
+        }
+        this.messages = compactedMessages;
+
         await this.init({
           callbacks,
           signal: this.activeAbortController.signal,
@@ -536,6 +542,12 @@ export class AgentSession {
           abortSignal: this.activeAbortController.signal,
           shouldContinue: () => !this.interruptRequested,
         });
+        if (this.interruptRequested || this.activeAbortController.signal.aborted) {
+          Logger.info(`[会话 ${this.key}] 当前请求已取消，忽略模型在中断后的返回`);
+          this.messages = this.turnContextBuilder.removeTransientMessages(this.messages);
+          this.lifecycleManager.saveContext(this.messages);
+          return { text: '已停止当前请求。', visibleToUser: true };
+        }
         this.messages = result.messages;
         this.lifecycleManager.saveContext(this.messages);
         return result;
@@ -618,6 +630,7 @@ export class AgentSession {
 
       // /clear
       if (commandName === 'clear') {
+        this.requestInterrupt();
         if (args.includes('--all')) {
           this.clear();
           return { handled: true, reply: '历史已清空，文件已删除' };

--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -372,6 +372,14 @@ export class AgentSession {
     this.enforceInjectedContextLimit();
   }
 
+  getRemoteContextCursor(source: string): number {
+    return this.lifecycleManager.loadRemoteContextCursor(source);
+  }
+
+  saveRemoteContextCursor(source: string, cursor: number): void {
+    this.lifecycleManager.saveRemoteContextCursor(source, cursor);
+  }
+
   /**
    * 注入给 agent 可见的运行时反馈。
    * 反馈会暂存在 turn-scoped buffer，下一次真正执行 handleMessage 时才进入本轮上下文。

--- a/src/core/session-lifecycle-manager.ts
+++ b/src/core/session-lifecycle-manager.ts
@@ -94,7 +94,27 @@ export class SessionLifecycleManager {
   }
 
   saveCurrentDirectory(currentDirectory: string): void {
-    this.sessionStore.saveRuntimeState(this.options.sessionKey, { currentDirectory });
+    this.sessionStore.saveRuntimeState(this.options.sessionKey, {
+      ...this.sessionStore.loadRuntimeState(this.options.sessionKey),
+      currentDirectory,
+    });
+  }
+
+  loadRemoteContextCursor(source: string): number {
+    const cursor = Number(this.sessionStore.loadRuntimeState(this.options.sessionKey).remoteContextCursors?.[source]);
+    return Number.isFinite(cursor) && cursor > 0 ? cursor : 0;
+  }
+
+  saveRemoteContextCursor(source: string, cursor: number): void {
+    if (!source || !Number.isFinite(cursor) || cursor <= 0) return;
+    const state = this.sessionStore.loadRuntimeState(this.options.sessionKey);
+    this.sessionStore.saveRuntimeState(this.options.sessionKey, {
+      ...state,
+      remoteContextCursors: {
+        ...(state.remoteContextCursors || {}),
+        [source]: cursor,
+      },
+    });
   }
 
   persistAndClear(messages: Message[]): PersistAndClearResult {

--- a/src/utils/session-store.ts
+++ b/src/utils/session-store.ts
@@ -125,6 +125,7 @@ function serializeMessages(messages: Message[]): string {
 
 export interface SessionRuntimeState {
   currentDirectory?: string;
+  remoteContextCursors?: Record<string, number>;
   updatedAt?: string;
 }
 

--- a/tests/agent-session-abort-signal.test.ts
+++ b/tests/agent-session-abort-signal.test.ts
@@ -117,6 +117,77 @@ test('AgentSession clear ignores stale context compaction that resolves after ab
   assert.match(historyResult.reply || '', /当前历史长度: 0 条消息/);
 });
 
+test('AgentSession clear ignores stale restore compaction during first initialization', async () => {
+  let restoreCompactionSignal: AbortSignal | undefined;
+  let releaseRestoreCompaction!: () => void;
+  let compactionCalls = 0;
+  let modelCalls = 0;
+  const restoreCompactionGate = new Promise<void>(resolve => { releaseRestoreCompaction = resolve; });
+  const session = new AgentSession('user:clear-restore-compaction', buildMockServices({
+    aiService: {
+      async chatStream() {
+        modelCalls++;
+        return { content: 'unexpected', toolCalls: [] };
+      },
+    },
+  }), 'catscompany');
+  session.setSystemPromptProvider(() => 'system prompt');
+  (session as any).lifecycleManager.consumePendingRestore = () => [
+    { role: 'user', content: '不应恢复的云端旧历史' },
+  ];
+  (session as any).contextWindowManager.compactIfNeeded = async (messages: any[], options: any) => {
+    compactionCalls++;
+    if (compactionCalls === 1) return messages;
+    restoreCompactionSignal = options.signal;
+    await restoreCompactionGate;
+    return [...messages, { role: 'assistant', content: '不应恢复的旧恢复压缩结果' }];
+  };
+
+  const runPromise = session.handleMessage('触发首次初始化');
+  await waitFor(() => Boolean(restoreCompactionSignal));
+  const clearResult = await session.handleCommand('clear', []);
+  releaseRestoreCompaction();
+  const runResult = await runPromise;
+  const historyResult = await session.handleCommand('history', []);
+
+  assert.equal(clearResult.reply, '历史已清空');
+  assert.equal(restoreCompactionSignal?.aborted, true);
+  assert.equal(runResult.text, '已停止当前请求。');
+  assert.equal(modelCalls, 0);
+  assert.match(historyResult.reply || '', /当前历史长度: 0 条消息/);
+});
+
+test('clear commands prevent an interrupted restore turn from persisting after reset', async () => {
+  for (const clearArgs of [[], ['--all']]) {
+    let restoreCompactionSignal: AbortSignal | undefined;
+    let releaseRestoreCompaction!: () => void;
+    let compactionCalls = 0;
+    let saveCalls = 0;
+    const restoreCompactionGate = new Promise<void>(resolve => { releaseRestoreCompaction = resolve; });
+    const session = new AgentSession(`user:clear-restore-persist:${clearArgs.join('-') || 'regular'}`, buildMockServices(), 'catscompany');
+    session.setSystemPromptProvider(() => 'system prompt');
+    (session as any).lifecycleManager.consumePendingRestore = () => [
+      { role: 'user', content: '不应在清空后保存的云端旧历史' },
+    ];
+    (session as any).lifecycleManager.saveContext = () => { saveCalls++; };
+    (session as any).contextWindowManager.compactIfNeeded = async (messages: any[], options: any) => {
+      compactionCalls++;
+      if (compactionCalls === 1) return messages;
+      restoreCompactionSignal = options.signal;
+      await restoreCompactionGate;
+      return messages;
+    };
+
+    const runPromise = session.handleMessage('触发首次初始化');
+    await waitFor(() => Boolean(restoreCompactionSignal));
+    await session.handleCommand('clear', clearArgs);
+    releaseRestoreCompaction();
+    await runPromise;
+
+    assert.equal(saveCalls, 0, `stale turn persisted after /clear ${clearArgs.join(' ')}`);
+  }
+});
+
 function buildMockServices(overrides: any = {}): any {
   return {
     aiService: overrides.aiService ?? {},

--- a/tests/agent-session-abort-signal.test.ts
+++ b/tests/agent-session-abort-signal.test.ts
@@ -188,6 +188,69 @@ test('clear commands prevent an interrupted restore turn from persisting after r
   }
 });
 
+test('clear commands discard a first initialization still building its system prompt', async () => {
+  for (const clearArgs of [[], ['--all']]) {
+    let promptStarted = false;
+    let releasePrompt!: () => void;
+    const promptGate = new Promise<void>(resolve => { releasePrompt = resolve; });
+    const session = new AgentSession(`user:clear-init-prompt:${clearArgs.join('-') || 'regular'}`, buildMockServices(), 'catscompany');
+    (session as any).buildCurrentSystemPrompt = async () => {
+      promptStarted = true;
+      await promptGate;
+      return { systemPrompt: '不应在清空后写回的系统提示词', promptTrace: undefined };
+    };
+
+    const runPromise = session.handleMessage('触发首次初始化');
+    await waitFor(() => promptStarted);
+    await session.handleCommand('clear', clearArgs);
+    releasePrompt();
+    const runResult = await runPromise;
+    const historyResult = await session.handleCommand('history', []);
+
+    assert.equal(runResult.text, '已停止当前请求。');
+    assert.equal((session as any).initialized, false);
+    assert.match(historyResult.reply || '', /当前历史长度: 0 条消息/);
+  }
+});
+
+test('clear commands discard an initialized session prompt hot reload', async () => {
+  for (const clearArgs of [[], ['--all']]) {
+    let promptCalls = 0;
+    let reloadStarted = false;
+    let releaseReload!: () => void;
+    let modelCalls = 0;
+    const reloadGate = new Promise<void>(resolve => { releaseReload = resolve; });
+    const session = new AgentSession(`user:clear-prompt-reload:${clearArgs.join('-') || 'regular'}`, buildMockServices({
+      aiService: {
+        async chatStream() {
+          modelCalls++;
+          return { content: 'unexpected', toolCalls: [] };
+        },
+      },
+    }), 'catscompany');
+    session.setSystemPromptProvider(async () => {
+      promptCalls++;
+      if (promptCalls === 1) return 'system prompt v1';
+      reloadStarted = true;
+      await reloadGate;
+      return '不应在清空后写回的 system prompt v2';
+    });
+    await session.init();
+
+    const runPromise = session.handleMessage('触发 prompt 热加载');
+    await waitFor(() => reloadStarted);
+    await session.handleCommand('clear', clearArgs);
+    releaseReload();
+    const runResult = await runPromise;
+    const historyResult = await session.handleCommand('history', []);
+
+    assert.equal(runResult.text, '已停止当前请求。');
+    assert.equal((session as any).initialized, false);
+    assert.equal(modelCalls, 0);
+    assert.match(historyResult.reply || '', /当前历史长度: 0 条消息/);
+  }
+});
+
 function buildMockServices(overrides: any = {}): any {
   return {
     aiService: overrides.aiService ?? {},

--- a/tests/agent-session-abort-signal.test.ts
+++ b/tests/agent-session-abort-signal.test.ts
@@ -27,6 +27,96 @@ test('AgentSession requestInterrupt aborts an in-flight model request', async ()
   assert.equal(result.text, '已停止当前请求。');
 });
 
+test('AgentSession clear interrupts an active turn before clearing its history', async () => {
+  let observedSignal: AbortSignal | undefined;
+  const session = new AgentSession('user:clear-active-turn', buildMockServices({
+    aiService: {
+      async chatStream(_messages: any[], _tools: any[], _callbacks: any, options: any = {}) {
+        observedSignal = options.signal;
+        return await new Promise((_resolve, reject) => {
+          options.signal?.addEventListener('abort', () => reject(new Error('aborted by clear')), { once: true });
+        });
+      },
+    },
+  }), 'catscompany');
+  session.setSystemPromptProvider(() => 'system prompt');
+
+  const runPromise = session.handleMessage('清空前正在处理的消息');
+  await waitFor(() => Boolean(observedSignal));
+
+  const clearResult = await session.handleCommand('clear', []);
+  const runResult = await runPromise;
+  const historyResult = await session.handleCommand('history', []);
+
+  assert.equal(clearResult.reply, '历史已清空');
+  assert.equal(observedSignal?.aborted, true);
+  assert.equal(runResult.text, '已停止当前请求。');
+  assert.match(historyResult.reply || '', /当前历史长度: 0 条消息/);
+});
+
+test('AgentSession clear ignores a stale model result even when the provider resolves after abort', async () => {
+  let observedSignal: AbortSignal | undefined;
+  let releaseModel!: () => void;
+  const modelGate = new Promise<void>(resolve => { releaseModel = resolve; });
+  const session = new AgentSession('user:clear-provider-resolves', buildMockServices({
+    aiService: {
+      async chatStream(_messages: any[], _tools: any[], _callbacks: any, options: any = {}) {
+        observedSignal = options.signal;
+        await modelGate;
+        return { content: '这个旧回复不应恢复到历史里', toolCalls: [] };
+      },
+    },
+  }), 'catscompany');
+  session.setSystemPromptProvider(() => 'system prompt');
+
+  const runPromise = session.handleMessage('清空前的旧请求');
+  await waitFor(() => Boolean(observedSignal));
+  const clearResult = await session.handleCommand('clear', []);
+  releaseModel();
+  const runResult = await runPromise;
+  const historyResult = await session.handleCommand('history', []);
+
+  assert.equal(clearResult.reply, '历史已清空');
+  assert.equal(observedSignal?.aborted, true);
+  assert.equal(runResult.text, '已停止当前请求。');
+  assert.match(historyResult.reply || '', /当前历史长度: 0 条消息/);
+});
+
+test('AgentSession clear ignores stale context compaction that resolves after abort', async () => {
+  let compactionSignal: AbortSignal | undefined;
+  let releaseCompaction!: () => void;
+  let modelCalls = 0;
+  const compactionGate = new Promise<void>(resolve => { releaseCompaction = resolve; });
+  const session = new AgentSession('user:clear-compaction-resolves', buildMockServices({
+    aiService: {
+      async chatStream() {
+        modelCalls++;
+        return { content: 'unexpected', toolCalls: [] };
+      },
+    },
+  }), 'catscompany');
+  session.setSystemPromptProvider(() => 'system prompt');
+  (session as any).messages = [{ role: 'user', content: '压缩前的旧历史' }];
+  (session as any).contextWindowManager.compactIfNeeded = async (messages: any[], options: any) => {
+    compactionSignal = options.signal;
+    await compactionGate;
+    return [...messages, { role: 'assistant', content: '不应恢复的旧压缩结果' }];
+  };
+
+  const runPromise = session.handleMessage('压缩期间的新请求');
+  await waitFor(() => Boolean(compactionSignal));
+  const clearResult = await session.handleCommand('clear', []);
+  releaseCompaction();
+  const runResult = await runPromise;
+  const historyResult = await session.handleCommand('history', []);
+
+  assert.equal(clearResult.reply, '历史已清空');
+  assert.equal(compactionSignal?.aborted, true);
+  assert.equal(runResult.text, '已停止当前请求。');
+  assert.equal(modelCalls, 0);
+  assert.match(historyResult.reply || '', /当前历史长度: 0 条消息/);
+});
+
 function buildMockServices(overrides: any = {}): any {
   return {
     aiService: overrides.aiService ?? {},

--- a/tests/catscompany-agent-context-history.test.ts
+++ b/tests/catscompany-agent-context-history.test.ts
@@ -51,6 +51,7 @@ describe('CatsCompany native Feishu group context', () => {
         content: '更早的讨论',
         context_eligible: true,
         context_role: 'user',
+        context_reason: 'participant_message',
         metadata: { catsco_identity: nativeMetadata().catsco_identity },
       },
       {
@@ -58,6 +59,7 @@ describe('CatsCompany native Feishu group context', () => {
         content: '@机器人 总结一下',
         context_eligible: true,
         context_role: 'user',
+        context_reason: 'group_message_targets_agent',
         metadata: { catsco_identity: nativeMetadata().catsco_identity },
       },
       {
@@ -65,6 +67,7 @@ describe('CatsCompany native Feishu group context', () => {
         content: '上一轮回复',
         context_eligible: true,
         context_role: 'assistant',
+        context_reason: 'current_agent_message',
         metadata: { catsco_identity: nativeMetadata().catsco_identity },
       },
       {
@@ -72,6 +75,7 @@ describe('CatsCompany native Feishu group context', () => {
         content: '给我发一个 txt 文件',
         context_eligible: true,
         context_role: 'user',
+        context_reason: 'participant_message',
         metadata: { catsco_identity: nativeMetadata({ speaker: '陈大为' }).catsco_identity },
       },
       {
@@ -79,6 +83,7 @@ describe('CatsCompany native Feishu group context', () => {
         content_blocks: [{ type: 'text', text: '里面写一句诗' }],
         context_eligible: true,
         context_role: 'user',
+        context_reason: 'participant_message',
         metadata: { catsco_identity: nativeMetadata({ speaker: '林益' }).catsco_identity },
       },
       {
@@ -86,6 +91,7 @@ describe('CatsCompany native Feishu group context', () => {
         content: 'working...',
         context_eligible: false,
         context_role: 'assistant',
+        context_reason: 'current_agent_message',
         metadata: { catsco_identity: nativeMetadata().catsco_identity },
       },
       {
@@ -93,6 +99,7 @@ describe('CatsCompany native Feishu group context', () => {
         content: '游标之前的消息',
         context_eligible: true,
         context_role: 'user',
+        context_reason: 'participant_message',
         metadata: { catsco_identity: nativeMetadata().catsco_identity },
       },
     ], 3);
@@ -110,6 +117,7 @@ describe('CatsCompany native Feishu group context', () => {
       content: '@机器人 总结上面的讨论',
       context_eligible: true,
       context_role: 'user',
+      context_reason: 'group_message_targets_agent',
       agent_uid: 42,
       agent_id: 'usr42',
       metadata: nativeMetadata({ triggered: true }),
@@ -118,8 +126,47 @@ describe('CatsCompany native Feishu group context', () => {
     assert.deepEqual(context, []);
   });
 
+  test('keeps only ordinary group messages after the latest clear boundary', () => {
+    const context = selectNativeFeishuGroupContext([
+      {
+        id: 10,
+        seq_id: 10,
+        content: '清空前的普通讨论',
+        context_eligible: true,
+        context_role: 'user',
+        context_reason: 'participant_message',
+        agent_uid: 42,
+        agent_id: 'usr42',
+      },
+      {
+        id: 11,
+        seq_id: 11,
+        content: '/clear',
+        context_eligible: true,
+        context_role: 'user',
+        context_reason: 'group_message_targets_agent',
+        agent_uid: 42,
+        agent_id: 'usr42',
+      },
+      {
+        id: 12,
+        seq_id: 12,
+        content: '清空后的新讨论',
+        context_eligible: true,
+        context_role: 'user',
+        context_reason: 'participant_message',
+        agent_uid: 42,
+        agent_id: 'usr42',
+        metadata: { catsco_identity: nativeMetadata({ speaker: '林益' }).catsco_identity },
+      },
+    ], 0);
+
+    assert.deepEqual(context, ['[发言人: 林益]\n清空后的新讨论']);
+  });
+
   test('injects restored ordinary messages before processing the trigger turn', async () => {
     const bot = Object.create(CatsCompanyBot.prototype) as any;
+    bot.botUid = 'usr42';
     const injected: string[] = [];
     const savedCursors: Array<[string, number]> = [];
     bot.bot = {
@@ -133,6 +180,7 @@ describe('CatsCompany native Feishu group context', () => {
             content: '回答我上面的问题',
             context_eligible: true,
             context_role: 'user',
+            context_reason: 'participant_message',
             agent_uid: 42,
             agent_id: 'usr42',
             metadata: { catsco_identity: nativeMetadata({ speaker: '林益' }).catsco_identity },
@@ -150,10 +198,13 @@ describe('CatsCompany native Feishu group context', () => {
       getRemoteContextCursor: () => 80,
       saveRemoteContextCursor: (source: string, cursor: number) => savedCursors.push([source, cursor]),
     }, {
-      topic: 'grp_9',
-      chatType: 'group',
-      seq: 88,
-      metadata: nativeMetadata({ triggered: true }),
+      message: {
+        topic: 'grp_9',
+        chatType: 'group',
+        seq: 88,
+        metadata: nativeMetadata({ triggered: true }),
+      },
+      clearGeneration: 0,
     }, 'cc_group:grp_9');
 
     assert.deepEqual(injected, ['[发言人: 林益]\n回答我上面的问题']);
@@ -173,16 +224,179 @@ describe('CatsCompany native Feishu group context', () => {
 
     await bot.hydrateNativeFeishuGroupContext({
       injectContext: () => assert.fail('restored history must not be injected twice'),
-      getRemoteContextCursor: () => 0,
+      getRemoteContextCursor: () => 100,
       saveRemoteContextCursor: (source: string, cursor: number) => savedCursors.push([source, cursor]),
     }, {
-      topic: 'grp_9',
-      chatType: 'group',
-      seq: 88,
-      metadata: nativeMetadata({ triggered: true }),
-    }, 'cc_group:grp_9', 'restored');
+      message: {
+        topic: 'grp_9',
+        chatType: 'group',
+        seq: 88,
+        metadata: nativeMetadata({ triggered: true }),
+      },
+      cloudRestoreStatus: 'restored',
+      clearGeneration: 0,
+    }, 'cc_group:grp_9');
 
     assert.equal(fetchCount, 0);
-    assert.deepEqual(savedCursors, [['catscompany.agent_context', 88]]);
+    assert.deepEqual(savedCursors, [['catscompany.agent_context', 100]]);
+  });
+
+  test('paginates native group history back to the previous cursor before advancing it', async () => {
+    const bot = Object.create(CatsCompanyBot.prototype) as any;
+    bot.botUid = 'usr42';
+    const injected: string[] = [];
+    const beforeIds: number[] = [];
+    let savedCursor = 5;
+    const makeMessage = (seq: number) => ({
+      id: seq,
+      seq_id: seq,
+      content: `message-${seq}`,
+      context_eligible: true,
+      context_role: 'user' as const,
+      context_reason: 'participant_message',
+      agent_uid: 42,
+      agent_id: 'usr42',
+      metadata: { catsco_identity: nativeMetadata({ speaker: '林益' }).catsco_identity },
+    });
+    bot.bot = {
+      getAgentContextHistory: async (_topic: string, options: { beforeId: number }) => {
+        beforeIds.push(options.beforeId);
+        if (options.beforeId === 205) {
+          return {
+            messages: Array.from({ length: 100 }, (_, index) => makeMessage(105 + index)).reverse(),
+            topic_id: 'grp_9',
+            agent_uid: 42,
+            has_more: true,
+            next_before_id: 105,
+          };
+        }
+        return {
+          messages: Array.from({ length: 100 }, (_, index) => makeMessage(5 + index)).reverse(),
+          topic_id: 'grp_9',
+          agent_uid: 42,
+          has_more: false,
+          next_before_id: 5,
+        };
+      },
+    };
+
+    const valid = await bot.hydrateNativeFeishuGroupContext({
+      injectContext: (message: string) => injected.push(message),
+      getRemoteContextCursor: () => savedCursor,
+      saveRemoteContextCursor: (_source: string, cursor: number) => { savedCursor = cursor; },
+    }, {
+      message: {
+        topic: 'grp_9',
+        chatType: 'group',
+        seq: 205,
+        metadata: nativeMetadata({ triggered: true }),
+      },
+      clearGeneration: 0,
+    }, 'cc_group:grp_9');
+
+    assert.equal(valid, true);
+    assert.deepEqual(beforeIds, [205, 105]);
+    assert.equal(injected.length, 199);
+    assert.match(injected[0], /message-6$/);
+    assert.match(injected.at(-1) || '', /message-204$/);
+    assert.equal(savedCursor, 205);
+  });
+
+  test('uses a bounded recent-history fallback and advances the cursor for very large gaps', async () => {
+    const bot = Object.create(CatsCompanyBot.prototype) as any;
+    bot.botUid = 'usr42';
+    const injected: string[] = [];
+    let fetches = 0;
+    let savedCursor = 0;
+    bot.bot = {
+      getAgentContextHistory: async (_topic: string, options: { beforeId: number }) => {
+        fetches++;
+        const newest = options.beforeId - 1;
+        const oldest = newest - 99;
+        return {
+          messages: Array.from({ length: 100 }, (_, index) => ({
+            id: oldest + index,
+            seq_id: oldest + index,
+            content: `message-${oldest + index}`,
+            context_eligible: true,
+            context_role: 'user' as const,
+            context_reason: 'participant_message',
+            agent_uid: 42,
+            agent_id: 'usr42',
+          })),
+          topic_id: 'grp_9',
+          agent_uid: 42,
+          has_more: true,
+          next_before_id: oldest,
+        };
+      },
+    };
+
+    const valid = await bot.hydrateNativeFeishuGroupContext({
+      injectContext: (message: string) => injected.push(message),
+      getRemoteContextCursor: () => savedCursor,
+      saveRemoteContextCursor: (_source: string, cursor: number) => { savedCursor = cursor; },
+    }, {
+      message: {
+        topic: 'grp_9',
+        chatType: 'group',
+        seq: 1001,
+        metadata: nativeMetadata({ triggered: true }),
+      },
+      clearGeneration: 0,
+    }, 'cc_group:grp_9');
+
+    assert.equal(valid, true);
+    assert.equal(fetches, 10);
+    assert.equal(injected.length, 1000);
+    assert.equal(savedCursor, 1001);
+  });
+
+  test('rejects native history pages from another topic or agent without advancing the cursor', async () => {
+    for (const pageScope of [
+      { topic_id: 'grp_other', agent_uid: 42 },
+      { topic_id: 'grp_9', agent_uid: 99 },
+    ]) {
+      const bot = Object.create(CatsCompanyBot.prototype) as any;
+      bot.botUid = 'usr42';
+      bot.bot = {
+        getAgentContextHistory: async () => ({
+          messages: [{
+            id: 87,
+            seq_id: 87,
+            topic_id: pageScope.topic_id,
+            content: 'wrong scope',
+            context_eligible: true,
+            context_role: 'user',
+            context_reason: 'participant_message',
+            agent_uid: pageScope.agent_uid,
+            agent_id: `usr${pageScope.agent_uid}`,
+          }],
+          ...pageScope,
+          has_more: false,
+          next_before_id: 0,
+        }),
+      };
+      const injected: string[] = [];
+      const savedCursors: number[] = [];
+
+      const valid = await bot.hydrateNativeFeishuGroupContext({
+        injectContext: (message: string) => injected.push(message),
+        getRemoteContextCursor: () => 80,
+        saveRemoteContextCursor: (_source: string, cursor: number) => savedCursors.push(cursor),
+      }, {
+        message: {
+          topic: 'grp_9',
+          chatType: 'group',
+          seq: 88,
+          metadata: nativeMetadata({ triggered: true }),
+        },
+        clearGeneration: 0,
+      }, 'cc_group:grp_9');
+
+      assert.equal(valid, true);
+      assert.deepEqual(injected, []);
+      assert.deepEqual(savedCursors, []);
+    }
   });
 });

--- a/tests/catscompany-agent-context-history.test.ts
+++ b/tests/catscompany-agent-context-history.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import {
+  isNativeFeishuGroupTrigger,
+  selectNativeFeishuGroupContext,
+} from '../src/catscompany/agent-context-history';
+import { CatsClient } from '../src/catscompany/client';
+import { CatsCompanyBot } from '../src/catscompany';
+
+function nativeMetadata(options: {
+  triggered?: boolean;
+  speaker?: string;
+  source?: string;
+  bindingId?: number;
+} = {}) {
+  return {
+    source_channel: options.source ?? 'feishu',
+    channel_native_group_binding_id: options.bindingId ?? 17,
+    channel_native_group_triggered: options.triggered ?? false,
+    catsco_identity: {
+      actor: {
+        display_name: options.speaker ?? '陈大为',
+        user_id: 'usr7',
+      },
+    },
+  };
+}
+
+describe('CatsCompany native Feishu group context', () => {
+  const servers: Server[] = [];
+
+  afterEach(() => {
+    for (const server of servers.splice(0)) server.close();
+  });
+
+  test('recognizes only a triggered native Feishu group message', () => {
+    assert.equal(isNativeFeishuGroupTrigger({
+      chatType: 'group',
+      seq: 12,
+      metadata: nativeMetadata({ triggered: true }),
+    }), true);
+    assert.equal(isNativeFeishuGroupTrigger({
+      chatType: 'group',
+      seq: 12,
+      metadata: nativeMetadata(),
+    }), false);
+    assert.equal(isNativeFeishuGroupTrigger({
+      chatType: 'p2p',
+      seq: 12,
+      metadata: nativeMetadata({ triggered: true }),
+    }), false);
+  });
+
+  test('replays eligible member messages after the persisted cursor', () => {
+    const context = selectNativeFeishuGroupContext([
+      {
+        seq_id: 1,
+        content: '更早的讨论',
+        context_eligible: true,
+        context_role: 'user',
+        metadata: { catsco_identity: nativeMetadata().catsco_identity },
+      },
+      {
+        seq_id: 2,
+        content: '@机器人 总结一下',
+        context_eligible: true,
+        context_role: 'user',
+        metadata: { catsco_identity: nativeMetadata().catsco_identity },
+      },
+      {
+        seq_id: 3,
+        content: '上一轮回复',
+        context_eligible: true,
+        context_role: 'assistant',
+        metadata: { catsco_identity: nativeMetadata().catsco_identity },
+      },
+      {
+        seq_id: 4,
+        content: '给我发一个 txt 文件',
+        context_eligible: true,
+        context_role: 'user',
+        metadata: { catsco_identity: nativeMetadata({ speaker: '陈大为' }).catsco_identity },
+      },
+      {
+        seq_id: 5,
+        content_blocks: [{ type: 'text', text: '里面写一句诗' }],
+        context_eligible: true,
+        context_role: 'user',
+        metadata: { catsco_identity: nativeMetadata({ speaker: '林益' }).catsco_identity },
+      },
+      {
+        seq_id: 6,
+        content: 'working...',
+        context_eligible: false,
+        context_role: 'assistant',
+        metadata: { catsco_identity: nativeMetadata().catsco_identity },
+      },
+      {
+        seq_id: 3,
+        content: '游标之前的消息',
+        context_eligible: true,
+        context_role: 'user',
+        metadata: { catsco_identity: nativeMetadata().catsco_identity },
+      },
+    ], 3);
+
+    assert.deepEqual(context, [
+      '[发言人: 陈大为]\n给我发一个 txt 文件',
+      '[发言人: 林益]\n里面写一句诗',
+    ]);
+  });
+
+  test('requests stable history before the current trigger with bot credentials', async () => {
+    let requestUrl = '';
+    let authorization = '';
+    const server = createServer((request, response) => {
+      requestUrl = request.url || '';
+      authorization = String(request.headers.authorization || '');
+      response.setHeader('Content-Type', 'application/json');
+      response.end(JSON.stringify({ messages: [], topic_id: 'grp_9', agent_uid: 42 }));
+    });
+    servers.push(server);
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address() as AddressInfo;
+    const client = new CatsClient({
+      serverUrl: 'ws://127.0.0.1:1/v0/channels',
+      httpBaseUrl: `http://127.0.0.1:${address.port}`,
+      apiKey: 'cc_bot_secret',
+    });
+
+    await client.fetchAgentContextHistory('grp_9', 88, 50);
+
+    assert.equal(authorization, 'ApiKey cc_bot_secret');
+    const parsed = new URL(requestUrl, 'http://localhost');
+    assert.equal(parsed.pathname, '/api/messages');
+    assert.equal(parsed.searchParams.get('topic_id'), 'grp_9');
+    assert.equal(parsed.searchParams.get('agent_context'), '1');
+    assert.equal(parsed.searchParams.get('before_id'), '88');
+    assert.equal(parsed.searchParams.get('limit'), '50');
+  });
+
+  test('injects restored ordinary messages before processing the trigger turn', async () => {
+    const bot = Object.create(CatsCompanyBot.prototype) as any;
+    const injected: string[] = [];
+    const savedCursors: Array<[string, number]> = [];
+    bot.bot = {
+      fetchAgentContextHistory: async (topic: string, beforeId: number) => {
+        assert.equal(topic, 'grp_9');
+        assert.equal(beforeId, 88);
+        return {
+          messages: [{
+            seq_id: 87,
+            content: '回答我上面的问题',
+            context_eligible: true,
+            context_role: 'user',
+            metadata: { catsco_identity: nativeMetadata({ speaker: '林益' }).catsco_identity },
+          }],
+        };
+      },
+    };
+
+    await bot.hydrateNativeFeishuGroupContext({
+      injectContext: (message: string) => injected.push(message),
+      getRemoteContextCursor: () => 80,
+      saveRemoteContextCursor: (source: string, cursor: number) => savedCursors.push([source, cursor]),
+    }, {
+      topic: 'grp_9',
+      chatType: 'group',
+      seq: 88,
+      metadata: nativeMetadata({ triggered: true }),
+    }, 'cc_group:grp_9');
+
+    assert.deepEqual(injected, ['[发言人: 林益]\n回答我上面的问题']);
+    assert.deepEqual(savedCursors, [['catscompany.agent_context', 88]]);
+  });
+});

--- a/tests/catscompany-content-blocks.test.ts
+++ b/tests/catscompany-content-blocks.test.ts
@@ -1213,6 +1213,73 @@ describe('CatsCo content blocks', () => {
     assert.deepStrictEqual(replies, []);
   });
 
+  test('keeps a completion batch when both model回流 and fallback delivery fail', async () => {
+    const { bot, session } = createProcessHarness();
+    const sessionKey = 'session:v2:catscompany:p2p:p2p_38_110:agent:usr43';
+    session.handleRuntimeObservation = async () => {
+      throw new Error('model observation failed');
+    };
+    bot.sender.reply = async () => {
+      throw new Error('fallback delivery failed');
+    };
+
+    await (bot as any).handleSubAgentFeedback(
+      sessionKey,
+      'p2p_38_110',
+      'usr38',
+      '[子agent1 已完成]\n任务：审查\n结果摘要：审查完成',
+    );
+    await (bot as any).flushSubAgentCompletionBatch(sessionKey, true);
+
+    const retained = bot.subAgentCompletionBatches.get(sessionKey);
+    assert.ok(retained);
+    assert.equal(retained.items.size, 1);
+    if (retained.timer) clearTimeout(retained.timer);
+    bot.subAgentCompletionBatches.delete(sessionKey);
+  });
+
+  test('drops an in-flight completion batch result when clear advances its generation', async () => {
+    const { bot, session, replies } = createProcessHarness();
+    const sessionKey = 'session:v2:catscompany:p2p:p2p_38_110:agent:usr43';
+    session.handleRuntimeObservation = async () => {
+      bot.bumpSessionClearGeneration(sessionKey);
+      return { visibleToUser: true, text: '不应在 clear 后出现的旧结果' };
+    };
+
+    await bot.handleSubAgentFeedback(
+      sessionKey,
+      'p2p_38_110',
+      'usr38',
+      '[子agent1 已完成]\n任务：审查\n结果摘要：旧结果',
+    );
+    await bot.flushSubAgentCompletionBatch(sessionKey, true);
+
+    assert.deepStrictEqual(replies, []);
+    assert.equal(bot.subAgentCompletionBatches.has(sessionKey), false);
+    assert.equal(bot.sessionExecutionReservations.has(sessionKey), false);
+  });
+
+  test('completion batch setup failures still release the session reservation', async () => {
+    const { bot, replies } = createProcessHarness();
+    const sessionKey = 'session:v2:catscompany:p2p:p2p_38_110:agent:usr43';
+
+    await bot.handleSubAgentFeedback(
+      sessionKey,
+      'p2p_38_110',
+      'usr38',
+      '[子agent1 已完成]\n任务：审查\n结果摘要：需要兜底的结果',
+    );
+    bot.registerSubAgentPlatformCallbacks = () => {
+      throw new Error('callback setup failed');
+    };
+    await bot.flushSubAgentCompletionBatch(sessionKey, true);
+
+    assert.equal(bot.sessionExecutionReservations.has(sessionKey), false);
+    assert.equal(replies.length, 1);
+    assert.match(replies[0].text, /后台子任务已回传/);
+    assert.match(replies[0].text, /审查（已完成）/);
+  });
+
   test('consumed subagent completion feedback is dropped before runtime observation', async () => {
     const { bot, runtimeObservations, replies, sentTyping } = createProcessHarness();
     const manager = SubAgentManager.getInstance();

--- a/tests/catscompany-execution-scope-flow.test.ts
+++ b/tests/catscompany-execution-scope-flow.test.ts
@@ -14,6 +14,15 @@ function canonicalMetadata(actorUserId: string, topicId: string, agentId = 'usr4
   };
 }
 
+function nativeFeishuMetadata(actorUserId: string, topicId: string, agentId = 'usr43') {
+  return {
+    ...canonicalMetadata(actorUserId, topicId, agentId),
+    source_channel: 'feishu',
+    channel_native_group_binding_id: 17,
+    channel_native_group_triggered: true,
+  };
+}
+
 function expectedCatsCoSessionKey(actorUserId: string, topicId: string, agentId = 'usr43') {
   const topicType = topicId.startsWith('grp_') ? 'group' : 'p2p';
   if (topicType === 'group') return `cc_group:${topicId}`;
@@ -87,7 +96,11 @@ function createHarness(options: {
   const sessionInputs: any[] = [];
   const replies: string[] = [];
   const clearedSessionMarkers: string[] = [];
+  const injectedContext: string[] = [];
+  const contextEvents: string[] = [];
+  const savedContextCursors: Array<[string, number]> = [];
   let busy = options.busy ?? false;
+  let remoteContextCursor = 0;
 
   const session = {
     isBusy: () => busy,
@@ -95,6 +108,7 @@ function createHarness(options: {
       busy = next;
     },
     handleMessage: async (userMessage: unknown, handleOptions: any) => {
+      contextEvents.push('handle');
       handledTurns.push({ userMessage, options: handleOptions });
       return { visibleToUser: false, text: '' };
     },
@@ -102,6 +116,15 @@ function createHarness(options: {
       ? { handled: true, reply: '历史已清空' }
       : { handled: false },
     handleRuntimeObservation: async () => ({ visibleToUser: false, text: '' }),
+    injectContext: (text: string) => {
+      contextEvents.push('inject');
+      injectedContext.push(text);
+    },
+    getRemoteContextCursor: () => remoteContextCursor,
+    saveRemoteContextCursor: (source: string, cursor: number) => {
+      remoteContextCursor = cursor;
+      savedContextCursors.push([source, cursor]);
+    },
   };
 
   bot.sessionManager = {
@@ -124,8 +147,21 @@ function createHarness(options: {
   };
   bot.pendingAttachments = new Map();
   bot.messageQueue = new Map();
+  bot.sessionExecutionReservations = new Set();
+  bot.sessionClearGenerations = new Map();
   bot.botUid = 'usr43';
+  bot.bot = {
+    getAgentContextHistory: async () => ({
+      messages: [],
+      topic_id: 'grp_80',
+      agent_uid: 43,
+      has_more: false,
+      next_before_id: 0,
+    }),
+  };
   bot.cloudSessionRestorePromises = new Map();
+  bot.cloudSessionRestoreAbortControllers = new Map();
+  bot.subAgentCompletionBatches = new Map();
   bot.cloudSessionRestorer = {
     restoreIfMissing: async () => ({
       status: options.restoreStatus || 'empty',
@@ -144,6 +180,9 @@ function createHarness(options: {
     session,
     replies,
     clearedSessionMarkers,
+    injectedContext,
+    contextEvents,
+    savedContextCursors,
   };
 }
 
@@ -167,6 +206,145 @@ describe('CatsCompany execution scope flow', () => {
     assert.deepEqual(sessionKeys, []);
     assert.equal(handledTurns.length, 0);
     assert.match(replies[0] || '', /没有新建空白上下文/);
+  });
+
+  test('a trigger waiting on another initial cloud restore performs incremental hydration later', async () => {
+    const harness = createHarness({ existingSession: false });
+    let finishRestore!: (result: any) => void;
+    const restore = new Promise<any>(resolve => { finishRestore = resolve; });
+    harness.bot.cloudSessionRestorePromises.set('cc_group:grp_80', restore);
+
+    const waiting = harness.bot.ensureCloudSessionRestored({} as any, {
+      sessionKey: 'cc_group:grp_80',
+      topicType: 'group',
+    } as any);
+    finishRestore({
+      status: 'restored',
+      restoredMessages: 3,
+      fetchedMessages: 3,
+      compressed: false,
+    });
+
+    assert.deepEqual(await waiting, {
+      status: 'local_present',
+      restoredMessages: 0,
+      fetchedMessages: 0,
+      compressed: false,
+    });
+  });
+
+  test('clear cancels an older initial cloud restore before the old trigger can run', async () => {
+    for (const clearCommand of ['/clear', '/clear --all']) {
+      const harness = createHarness({ existingSession: false });
+      let finishRestore!: () => void;
+      let restoreStarted!: () => void;
+      let restoreSignal: AbortSignal | undefined;
+      const restoreStartedPromise = new Promise<void>(resolve => { restoreStarted = resolve; });
+      const restoreGate = new Promise<void>(resolve => { finishRestore = resolve; });
+      harness.bot.cloudSessionRestorer.restoreIfMissing = async (request: { signal?: AbortSignal }) => {
+        restoreSignal = request.signal;
+        restoreStarted();
+        await restoreGate;
+        return {
+          status: 'restored',
+          restoredMessages: 3,
+          fetchedMessages: 3,
+          compressed: false,
+        };
+      };
+
+      const oldTrigger = harness.bot.onMessage({
+        topic: 'grp_80',
+        senderId: 'usr8',
+        text: '@usr43 old trigger',
+        content: '@usr43 old trigger',
+        metadata: nativeFeishuMetadata('usr8', 'grp_80'),
+        isGroup: true,
+        seq: 20,
+      });
+      await restoreStartedPromise;
+      await harness.bot.onMessage({
+        topic: 'grp_80',
+        senderId: 'usr8',
+        text: clearCommand,
+        content: clearCommand,
+        metadata: nativeFeishuMetadata('usr8', 'grp_80'),
+        isGroup: true,
+        seq: 21,
+      });
+      finishRestore();
+      await oldTrigger;
+
+      assert.equal(restoreSignal?.aborted, true, clearCommand);
+      assert.equal(harness.handledTurns.length, 0, clearCommand);
+    }
+  });
+
+  test('a message after clear starts a fresh restore without waiting for the aborted promise', async () => {
+    const harness = createHarness({ existingSession: false });
+    const restoreResolvers: Array<(result: any) => void> = [];
+    harness.bot.cloudSessionRestorer.restoreIfMissing = async () => await new Promise(resolve => {
+      restoreResolvers.push(resolve);
+    });
+    const route = {
+      sessionKey: 'session:v2:catscompany:p2p:p2p_7_43:agent:usr43',
+      topicId: 'p2p_7_43',
+      topicType: 'p2p',
+      agentId: 'usr43',
+    };
+
+    const oldRestore = harness.bot.ensureCloudSessionRestored({ topic: 'p2p_7_43', seq: 12 } as any, route as any);
+    await Promise.resolve();
+    assert.equal(restoreResolvers.length, 1);
+
+    await harness.bot.onMessage({
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      text: '/clear',
+      content: '/clear',
+      metadata: canonicalMetadata('usr7', 'p2p_7_43'),
+      isGroup: false,
+      seq: 13,
+    });
+
+    const newRestore = harness.bot.ensureCloudSessionRestored({ topic: 'p2p_7_43', seq: 14 } as any, route as any);
+    await Promise.resolve();
+    assert.equal(restoreResolvers.length, 2);
+
+    restoreResolvers[0]({ status: 'failed', restoredMessages: 0, fetchedMessages: 0, compressed: false });
+    await oldRestore;
+    assert.equal(harness.bot.cloudSessionRestorePromises.has(route.sessionKey), true);
+
+    restoreResolvers[1]({ status: 'restored', restoredMessages: 2, fetchedMessages: 2, compressed: false });
+    assert.equal((await newRestore).status, 'restored');
+    assert.equal(harness.bot.cloudSessionRestorePromises.has(route.sessionKey), false);
+  });
+
+  test('clear discards a pending subagent completion batch', async () => {
+    const harness = createHarness();
+    const sessionKey = 'session:v2:catscompany:p2p:p2p_7_43:agent:usr43';
+    const timer = setTimeout(() => assert.fail('cleared batch timer must not fire'), 10_000);
+    timer.unref?.();
+    harness.bot.subAgentCompletionBatches.set(sessionKey, {
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      firstAt: Date.now(),
+      clearGeneration: 0,
+      items: new Map([['old', { observation: 'old result' }]]),
+      timer,
+    });
+
+    await harness.bot.onMessage({
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      text: '/clear',
+      content: '/clear',
+      metadata: canonicalMetadata('usr7', 'p2p_7_43'),
+      isGroup: false,
+      seq: 12,
+    });
+
+    assert.equal(harness.bot.subAgentCompletionBatches.has(sessionKey), false);
   });
 
   test('regular clear writes an empty sentinel while clear --all keeps files deleted', async () => {
@@ -269,6 +447,397 @@ describe('CatsCompany execution scope flow', () => {
     assert.equal(handledTurns[0].options.executionScope.actorUserId, 'usr8');
     assert.equal(handledTurns[0].options.executionScope.topicId, 'p2p_8_43');
     assert.equal(handledTurns[0].options.executionScope.isTrusted, true);
+  });
+
+  test('keeps a drained user message queued when the session call rejects once', async () => {
+    const harness = createHarness({ busy: true });
+    let calls = 0;
+    harness.session.handleMessage = async (userMessage: unknown, options: any) => {
+      calls++;
+      if (calls === 1) throw new Error('transient session failure');
+      harness.handledTurns.push({ userMessage, options });
+      return { visibleToUser: false, text: '' };
+    };
+
+    await harness.bot.onMessage({
+      topic: 'p2p_8_43',
+      senderId: 'usr8',
+      text: '不能丢失的消息',
+      content: '不能丢失的消息',
+      metadata: canonicalMetadata('usr8', 'p2p_8_43'),
+      isGroup: false,
+      seq: 12,
+    });
+    harness.session.setBusy(false);
+    const sessionKey = 'session:v2:catscompany:p2p:p2p_8_43:agent:usr43';
+    await harness.bot.drainMessageQueue(sessionKey);
+    assert.equal(harness.bot.messageQueue.get(sessionKey)?.length, 1);
+
+    await harness.bot.drainMessageQueue(sessionKey);
+    assert.equal(calls, 2);
+    assert.equal(harness.handledTurns.length, 1);
+    assert.equal(harness.bot.messageQueue.has(sessionKey), false);
+  });
+
+  test('retries direct subagent feedback through the queue after a rejected call', async () => {
+    const harness = createHarness();
+    let calls = 0;
+    harness.session.handleRuntimeObservation = async () => {
+      calls++;
+      if (calls === 1) throw new Error('transient observation failure');
+      return { visibleToUser: false, text: '' };
+    };
+
+    await harness.bot.handleSubAgentFeedback(
+      'cc_group:grp_80',
+      'grp_80',
+      'usr8',
+      '需要回流的普通 observation',
+      createExecutionScope(createCatsCoMessageEnvelope({ topic: 'grp_80', senderId: 'usr8', text: 'observation' })),
+    );
+
+    assert.equal(calls, 2);
+    assert.equal(harness.bot.messageQueue.has('cc_group:grp_80'), false);
+  });
+
+  test('falls back to a user-visible subagent result after model injection retries are exhausted', async () => {
+    const harness = createHarness();
+    let calls = 0;
+    harness.session.handleRuntimeObservation = async () => {
+      calls++;
+      throw new Error('persistent observation failure');
+    };
+    const sessionKey = 'cc_group:grp_80';
+
+    await harness.bot.handleSubAgentFeedback(
+      sessionKey,
+      'grp_80',
+      'usr8',
+      '需要保留的普通 observation',
+      createExecutionScope(createCatsCoMessageEnvelope({ topic: 'grp_80', senderId: 'usr8', text: 'observation' })),
+    );
+    await harness.bot.drainMessageQueue(sessionKey);
+    await harness.bot.drainMessageQueue(sessionKey);
+
+    assert.equal(calls, 3);
+    assert.match(harness.replies.at(-1) || '', /需要保留的普通 observation/);
+    assert.equal(harness.bot.messageQueue.has(sessionKey), false);
+  });
+
+  test('bounds delivery-only subagent fallback retries when replies keep failing', async () => {
+    const harness = createHarness();
+    const sessionKey = 'cc_group:grp_80';
+    let deliveryCalls = 0;
+    harness.bot.sender.reply = async () => {
+      deliveryCalls++;
+      throw new Error('persistent delivery failure');
+    };
+    harness.bot.messageQueue.set(sessionKey, [{
+      userMessage: '无法发送的子任务结果',
+      topic: 'grp_80',
+      senderId: 'usr8',
+      seq: 0,
+      executionScope: createExecutionScope(createCatsCoMessageEnvelope({
+        topic: 'grp_80',
+        senderId: 'usr8',
+        text: 'observation',
+      })),
+      receivedAt: Date.now(),
+      source: 'subagent_feedback',
+      deliveryOnly: true,
+    }]);
+
+    await harness.bot.drainMessageQueue(sessionKey);
+    await harness.bot.drainMessageQueue(sessionKey);
+    await harness.bot.drainMessageQueue(sessionKey);
+
+    assert.equal(deliveryCalls, 3);
+    assert.equal(harness.bot.messageQueue.has(sessionKey), false);
+  });
+
+  test('hydrates a busy native Feishu trigger only when its queued turn executes', async () => {
+    const harness = createHarness({ busy: true });
+    let historyFetches = 0;
+    harness.bot.bot.getAgentContextHistory = async (_topic: string, options: { beforeId?: number }) => {
+      historyFetches++;
+      assert.equal(options.beforeId, 20);
+      return {
+        messages: [{
+          id: 19,
+          seq_id: 19,
+          from_uid: 8,
+          content: '上面那句普通群消息',
+          context_eligible: true,
+          context_role: 'user',
+          context_reason: 'participant_message',
+          agent_uid: 43,
+          agent_id: 'usr43',
+          metadata: {
+            catsco_identity: { actor: { display_name: '林益', user_id: 'usr8' } },
+          },
+        }],
+        topic_id: 'grp_80',
+        agent_uid: 43,
+        has_more: false,
+        next_before_id: 0,
+      };
+    };
+
+    await harness.bot.onMessage({
+      topic: 'grp_80',
+      senderId: 'usr8',
+      text: '@usr43 回答上面的问题',
+      content: '@usr43 回答上面的问题',
+      metadata: nativeFeishuMetadata('usr8', 'grp_80'),
+      isGroup: true,
+      seq: 20,
+    });
+
+    assert.equal(historyFetches, 0);
+    assert.deepEqual(harness.injectedContext, []);
+    assert.deepEqual(harness.savedContextCursors, []);
+    assert.equal(harness.handledTurns.length, 0);
+
+    harness.session.setBusy(false);
+    await harness.bot.drainMessageQueue('cc_group:grp_80');
+
+    assert.equal(historyFetches, 1);
+    assert.deepEqual(harness.injectedContext, ['[发言人: 林益]\n上面那句普通群消息']);
+    assert.deepEqual(harness.savedContextCursors, [['catscompany.agent_context', 20]]);
+    assert.deepEqual(harness.contextEvents, ['inject', 'handle']);
+    assert.equal(harness.handledTurns.length, 1);
+  });
+
+  test('serializes native history hydration with subagent feedback for the same session', async () => {
+    const harness = createHarness();
+    let releaseHistory!: () => void;
+    let historyStarted!: () => void;
+    const historyStartedPromise = new Promise<void>(resolve => { historyStarted = resolve; });
+    const historyGate = new Promise<void>(resolve => { releaseHistory = resolve; });
+    harness.bot.bot.getAgentContextHistory = async () => {
+      historyStarted();
+      await historyGate;
+      return {
+        messages: [{
+          id: 19,
+          seq_id: 19,
+          from_uid: 8,
+          content: '群里的普通发言',
+          context_eligible: true,
+          context_role: 'user',
+          context_reason: 'participant_message',
+          agent_uid: 43,
+          agent_id: 'usr43',
+        }],
+        topic_id: 'grp_80',
+        agent_uid: 43,
+        has_more: false,
+        next_before_id: 0,
+      };
+    };
+    harness.session.handleRuntimeObservation = async () => {
+      harness.contextEvents.push('observation');
+      return { visibleToUser: false, text: '' };
+    };
+
+    const trigger = harness.bot.onMessage({
+      topic: 'grp_80',
+      senderId: 'usr8',
+      text: '@usr43 总结一下',
+      content: '@usr43 总结一下',
+      metadata: nativeFeishuMetadata('usr8', 'grp_80'),
+      isGroup: true,
+      seq: 20,
+    });
+    await historyStartedPromise;
+
+    await harness.bot.handleSubAgentFeedback(
+      'cc_group:grp_80',
+      'grp_80',
+      'usr8',
+      '子任务补充结果',
+      createExecutionScope(createCatsCoMessageEnvelope({ topic: 'grp_80', senderId: 'usr8', text: '子任务补充结果' })),
+    );
+    assert.deepEqual(harness.contextEvents, []);
+
+    releaseHistory();
+    await trigger;
+
+    assert.deepEqual(harness.contextEvents, ['inject', 'handle', 'observation']);
+  });
+
+  test('does not let pending user input consume a queued native Feishu trigger', async () => {
+    const harness = createHarness();
+    let releaseFirstTurn!: () => void;
+    let firstTurnStarted!: () => void;
+    const firstTurnStartedPromise = new Promise<void>(resolve => { firstTurnStarted = resolve; });
+    const firstTurnGate = new Promise<void>(resolve => { releaseFirstTurn = resolve; });
+    let pendingInputProvider: (() => unknown) | undefined;
+    harness.session.handleMessage = async (userMessage: unknown, options: any) => {
+      harness.contextEvents.push('handle');
+      harness.handledTurns.push({ userMessage, options });
+      if (harness.handledTurns.length === 1) {
+        pendingInputProvider = options.pendingUserInputProvider;
+        firstTurnStarted();
+        await firstTurnGate;
+      }
+      return { visibleToUser: false, text: '' };
+    };
+
+    const firstTurn = harness.bot.onMessage({
+      topic: 'grp_80',
+      senderId: 'usr8',
+      text: '先处理这个任务',
+      content: '先处理这个任务',
+      metadata: canonicalMetadata('usr8', 'grp_80'),
+      isGroup: true,
+      seq: 19,
+    });
+    await firstTurnStartedPromise;
+
+    await harness.bot.onMessage({
+      topic: 'grp_80',
+      senderId: 'usr8',
+      text: '@usr43 回答群里的讨论',
+      content: '@usr43 回答群里的讨论',
+      metadata: nativeFeishuMetadata('usr8', 'grp_80'),
+      isGroup: true,
+      seq: 20,
+    });
+
+    assert.equal(pendingInputProvider?.(), null);
+    assert.equal(harness.bot.messageQueue.get('cc_group:grp_80')?.length, 1);
+    releaseFirstTurn();
+    await firstTurn;
+
+    assert.equal(harness.handledTurns.length, 2);
+    assert.equal(harness.bot.messageQueue.has('cc_group:grp_80'), false);
+  });
+
+  test('clear and clear --all discard queued native triggers before they can hydrate', async () => {
+    for (const clearCommand of ['/clear', '/clear --all']) {
+      const harness = createHarness({ busy: true });
+      let historyFetches = 0;
+      harness.bot.bot.getAgentContextHistory = async () => {
+        historyFetches++;
+        throw new Error('cleared trigger must not fetch history');
+      };
+
+      await harness.bot.onMessage({
+        topic: 'grp_80',
+        senderId: 'usr8',
+        text: '@usr43 old trigger',
+        content: '@usr43 old trigger',
+        metadata: nativeFeishuMetadata('usr8', 'grp_80'),
+        isGroup: true,
+        seq: 20,
+      });
+      await harness.bot.onMessage({
+        topic: 'grp_80',
+        senderId: 'usr8',
+        text: clearCommand,
+        content: clearCommand,
+        metadata: nativeFeishuMetadata('usr8', 'grp_80'),
+        isGroup: true,
+        seq: 21,
+      });
+
+      harness.session.setBusy(false);
+      await harness.bot.drainMessageQueue('cc_group:grp_80');
+      assert.equal(historyFetches, 0, clearCommand);
+      assert.equal(harness.handledTurns.length, 0, clearCommand);
+      assert.equal(harness.bot.messageQueue.has('cc_group:grp_80'), false, clearCommand);
+    }
+  });
+
+  test('clear invalidates an in-flight hydration and lets a newer trigger run', async () => {
+    const harness = createHarness();
+    let releaseOldHistory!: () => void;
+    let oldHistoryStarted!: () => void;
+    const oldHistoryStartedPromise = new Promise<void>(resolve => { oldHistoryStarted = resolve; });
+    const oldHistoryGate = new Promise<void>(resolve => { releaseOldHistory = resolve; });
+    let releaseClearReply!: () => void;
+    let clearReplyStarted!: () => void;
+    const clearReplyStartedPromise = new Promise<void>(resolve => { clearReplyStarted = resolve; });
+    const clearReplyGate = new Promise<void>(resolve => { releaseClearReply = resolve; });
+    const fetchedBeforeIds: number[] = [];
+    harness.bot.sender.reply = async (_topic: string, text: string) => {
+      if (text === '历史已清空') {
+        clearReplyStarted();
+        await clearReplyGate;
+      }
+    };
+    harness.bot.bot.getAgentContextHistory = async (_topic: string, options: { beforeId: number }) => {
+      fetchedBeforeIds.push(options.beforeId);
+      if (options.beforeId === 20) {
+        oldHistoryStarted();
+        await oldHistoryGate;
+        return {
+          messages: [{
+            id: 19,
+            seq_id: 19,
+            from_uid: 8,
+            content: 'must not be injected after clear',
+            context_eligible: true,
+            context_role: 'user',
+            context_reason: 'participant_message',
+            agent_uid: 43,
+            agent_id: 'usr43',
+          }],
+          topic_id: 'grp_80',
+          agent_uid: 43,
+          has_more: false,
+          next_before_id: 0,
+        };
+      }
+      return {
+        messages: [],
+        topic_id: 'grp_80',
+        agent_uid: 43,
+        has_more: false,
+        next_before_id: 0,
+      };
+    };
+
+    const oldTrigger = harness.bot.onMessage({
+      topic: 'grp_80',
+      senderId: 'usr8',
+      text: '@usr43 old trigger',
+      content: '@usr43 old trigger',
+      metadata: nativeFeishuMetadata('usr8', 'grp_80'),
+      isGroup: true,
+      seq: 20,
+    });
+    await oldHistoryStartedPromise;
+    const clear = harness.bot.onMessage({
+      topic: 'grp_80',
+      senderId: 'usr8',
+      text: '/clear',
+      content: '/clear',
+      metadata: nativeFeishuMetadata('usr8', 'grp_80'),
+      isGroup: true,
+      seq: 21,
+    });
+    await clearReplyStartedPromise;
+    await harness.bot.onMessage({
+      topic: 'grp_80',
+      senderId: 'usr8',
+      text: '@usr43 new trigger',
+      content: '@usr43 new trigger',
+      metadata: nativeFeishuMetadata('usr8', 'grp_80'),
+      isGroup: true,
+      seq: 22,
+    });
+
+    releaseOldHistory();
+    await oldTrigger;
+    releaseClearReply();
+    await clear;
+
+    assert.deepEqual(fetchedBeforeIds, [20, 22]);
+    assert.deepEqual(harness.injectedContext, []);
+    assert.equal(harness.handledTurns.length, 1);
+    assert.match(String(harness.handledTurns[0].userMessage), /new trigger/);
   });
 
   test('group turn uses legacy group session key while preserving actor in scope', async () => {

--- a/tests/cloud-session-restore.test.ts
+++ b/tests/cloud-session-restore.test.ts
@@ -200,7 +200,7 @@ test('the latest clear command cuts off older cloud history on every device', as
     page([
       contextMessage({ id: 1, seq_id: 1, content: 'old question' }),
       contextMessage({ id: 2, seq_id: 2, from_uid: 42, content: 'old answer', context_role: 'assistant' }),
-      contextMessage({ id: 3, seq_id: 3, content: '/clear' }),
+      contextMessage({ id: 3, seq_id: 3, content: JSON.stringify('/clear') }),
     ], { has_more: true, next_before_id: 1 }),
   ]);
   const restorer = new CatsCompanyCloudSessionRestorer(client, fakeAIService, store);
@@ -218,6 +218,91 @@ test('the latest clear command cuts off older cloud history on every device', as
   assert.deepEqual(store.sessions.get('cleared-session')?.map(message => message.content), [
     'new question',
     'new answer',
+  ]);
+});
+
+test('an ordinary group member saying /clear does not truncate group history', async () => {
+  const store = new MemorySessionStore();
+  const client = new FakeHistoryClient([
+    page([
+      contextMessage({ id: 1, seq_id: 1, topic_id: 'grp_80', content: 'old discussion' }),
+      contextMessage({ id: 2, seq_id: 2, topic_id: 'grp_80', content: '/clear' }),
+      contextMessage({ id: 3, seq_id: 3, topic_id: 'grp_80', content: 'new discussion' }),
+    ], { topic_id: 'grp_80' }),
+  ]);
+  const restorer = new CatsCompanyCloudSessionRestorer(client, fakeAIService, store);
+
+  const result = await restorer.restoreIfMissing({
+    sessionKey: 'ordinary-clear-group',
+    topicId: 'grp_80',
+    topicType: 'group',
+    agentId: 'usr42',
+    currentSeq: 4,
+  });
+
+  assert.equal(result.status, 'restored');
+  assert.deepEqual(store.sessions.get('ordinary-clear-group')?.map(message => message.content), [
+    '[群聊成员 usr7]\nold discussion',
+    '[群聊成员 usr7]\n/clear',
+    '[群聊成员 usr7]\nnew discussion',
+  ]);
+});
+
+test('a group clear targeting the agent truncates older group history', async () => {
+  const store = new MemorySessionStore();
+  const client = new FakeHistoryClient([
+    page([
+      contextMessage({ id: 3, seq_id: 3, topic_id: 'grp_80', content: 'new discussion' }),
+      contextMessage({
+        id: 2,
+        seq_id: 2,
+        topic_id: 'grp_80',
+        content: '/clear --all',
+        context_reason: 'group_message_targets_agent',
+      }),
+      contextMessage({ id: 1, seq_id: 1, topic_id: 'grp_80', content: 'old discussion' }),
+    ], { topic_id: 'grp_80' }),
+  ]);
+  const restorer = new CatsCompanyCloudSessionRestorer(client, fakeAIService, store);
+
+  const result = await restorer.restoreIfMissing({
+    sessionKey: 'targeted-clear-group',
+    topicId: 'grp_80',
+    topicType: 'group',
+    agentId: 'usr42',
+    currentSeq: 4,
+  });
+
+  assert.equal(result.status, 'restored');
+  assert.deepEqual(store.sessions.get('targeted-clear-group')?.map(message => message.content), [
+    '[群聊成员 usr7]\nnew discussion',
+  ]);
+});
+
+test('cloud restore sorts a descending history page before rebuilding turns', async () => {
+  const store = new MemorySessionStore();
+  const client = new FakeHistoryClient([
+    page([
+      contextMessage({ id: 3, seq_id: 3, content: 'second question' }),
+      contextMessage({ id: 2, seq_id: 2, from_uid: 42, content: 'first answer', context_role: 'assistant' }),
+      contextMessage({ id: 1, seq_id: 1, content: 'first question' }),
+    ]),
+  ]);
+  const restorer = new CatsCompanyCloudSessionRestorer(client, fakeAIService, store);
+
+  const result = await restorer.restoreIfMissing({
+    sessionKey: 'descending-page',
+    topicId: 'p2p_7_42',
+    topicType: 'p2p',
+    agentId: 'usr42',
+    currentSeq: 4,
+  });
+
+  assert.equal(result.status, 'restored');
+  assert.deepEqual(store.sessions.get('descending-page')?.map(message => message.content), [
+    'first question',
+    'first answer',
+    'second question',
   ]);
 });
 
@@ -330,5 +415,39 @@ test('history failure leaves the local session untouched for a later retry', asy
 
   assert.equal(result.status, 'failed');
   assert.equal(store.hasSession('missing-session'), false);
+  assert.equal(store.saveCalls, 0);
+});
+
+test('an aborted cloud restore cannot recreate a session after clear', async () => {
+  const store = new MemorySessionStore();
+  let releaseHistory!: () => void;
+  let historyStarted!: () => void;
+  const historyStartedPromise = new Promise<void>(resolve => { historyStarted = resolve; });
+  const historyGate = new Promise<void>(resolve => { releaseHistory = resolve; });
+  const client = {
+    async getAgentContextHistory() {
+      historyStarted();
+      await historyGate;
+      return page([contextMessage({ content: 'old cloud history' })]);
+    },
+  };
+  const controller = new AbortController();
+  const restorer = new CatsCompanyCloudSessionRestorer(client, fakeAIService, store);
+
+  const restoring = restorer.restoreIfMissing({
+    sessionKey: 'cleared-during-restore',
+    topicId: 'p2p_7_42',
+    topicType: 'p2p',
+    agentId: 'usr42',
+    currentSeq: 2,
+    signal: controller.signal,
+  });
+  await historyStartedPromise;
+  controller.abort();
+  releaseHistory();
+
+  const result = await restoring;
+  assert.equal(result.status, 'failed');
+  assert.equal(store.hasSession('cleared-during-restore'), false);
   assert.equal(store.saveCalls, 0);
 });

--- a/tests/session-lifecycle-manager.test.ts
+++ b/tests/session-lifecycle-manager.test.ts
@@ -107,6 +107,28 @@ describe('AgentSession lifecycle', () => {
     assert.equal(SessionStore.getInstance().loadRuntimeState('user:lifecycle-cwd').currentDirectory, defaultDir);
   });
 
+  test('remote context cursor survives restart without overwriting current directory', async () => {
+    const { AgentSession } = loadSessionModules();
+    const defaultDir = fs.mkdtempSync(path.join(testRoot, 'cursor-default-'));
+    const nestedDir = path.join(defaultDir, 'nested');
+    fs.mkdirSync(nestedDir);
+    const services = buildMockServices({
+      toolManager: {
+        getWorkspaceRoot() { return defaultDir; },
+        getToolDefinitions() { return []; },
+        executeTool() { throw new Error('not expected'); },
+      },
+    });
+
+    const session = new AgentSession('cc_group:cursor-test', services, 'catscompany');
+    (session as any).updateCurrentDirectory(nestedDir);
+    session.saveRemoteContextCursor('catscompany.agent_context', 88);
+
+    const restored = new AgentSession('cc_group:cursor-test', services, 'catscompany');
+    assert.equal(restored.getRemoteContextCursor('catscompany.agent_context'), 88);
+    assert.equal((restored as any).currentDirectory, nestedDir);
+  });
+
   test('current directory inside Electron userData is preserved when explicitly persisted', async () => {
     const { AgentSession, SessionStore } = loadSessionModules();
     const originalUserDataDir = process.env.XIAOBA_USER_DATA_DIR;


### PR DESCRIPTION
## 问题背景

飞书原生群中的普通消息会被 CatsCo 服务端记录，但不会触发虚拟员工。此前猫壳在后续收到 `@机器人` 消息时，没有调用服务端已经提供的群聊上下文接口，因此虚拟员工只能看到本次被 @ 的内容，无法理解“回答我上面的问题”之类的请求。

## 本次修改

- 在飞书群正式触发虚拟员工前，使用虚拟员工凭据读取当前消息之前的群聊上下文。
- 仅恢复服务端判定可进入上下文的群成员消息，并保留成员显示名。
- `working`、工具执行过程、其他虚拟员工消息以及发给其他成员的消息仍不会进入模型上下文。
- 为每个 CatsCo 群会话持久化远端消息游标，只补入上次处理之后的新消息，避免连续触发或猫壳重启后重复恢复历史。
- 历史读取失败时继续处理当前消息，不影响原有聊天链路。
- 普通群消息仍然只记录、不触发模型，只有 @ 机器人才会启动推理。

## 用户侧效果

修复后，群成员可以先正常讨论，再通过 `@catsco_飞书专用` 要求虚拟员工总结或处理前文；虚拟员工能够区分发言成员并理解刚才的群聊内容。

## 验证结果

- `npm run build`
- `npm test`
- 完整运行时测试：1005 项通过，0 项失败，4 项跳过
- 新增群历史筛选、成员身份、接口鉴权与游标参数、触发前注入、游标持久化测试

## 边界说明

本 PR 只修改猫壳代码，不包含生产环境、部署配置或 CatsCo 服务端变更。飞书群内禁用本机设备操作属于后续独立事项，不在本 PR 范围内。