### PR TITLE
fix: 让视觉模型直接读取扫描 PDF 页面

### DIFF
--- a/src/tools/read-tool.ts
+++ b/src/tools/read-tool.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import * as readline from 'readline';
 import { execFileSync } from 'child_process';
 import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
+import { ContentBlock } from '../types';
 import { isReadPathAllowed } from '../utils/safety';
 import { createImageBlock } from '../utils/image-utils';
 import { ConfigManager } from '../utils/config';
@@ -101,7 +102,6 @@ interface PdfCanvasAndContext {
 }
 
 interface ReadImageOptions {
-  forceReaderProxy?: boolean;
   metadataType?: string;
   proxyIntro?: string;
 }
@@ -770,20 +770,22 @@ export class ReadTool implements Tool {
     selection: PdfPageSelection,
     prompt?: string,
     options?: PdfRenderedImageReadOptions,
-  ): Promise<string> {
+  ): Promise<string | ContentBlock[]> {
     const pages = this.getPdfRenderedImagePages(selection, options?.totalPages);
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'catsco-pdf-pages-'));
 
     try {
       const renderedPages = await this.renderPdfPagesToImages(absolutePath, pages, tempDir);
       const isSupplement = options?.reason === 'visual_supplement';
+      const visionCapable = isPrimaryModelVisionCapable(ConfigManager.getConfigReadonly());
       const parts = [
         isSupplement
           ? 'PDF 文本层已提取；由于用户任务可能涉及图片、签名、印章、手写、版式或表格，已额外转成页面图片补充读取。'
           : 'PDF 文本层未提取到内容，已自动转成页面图片继续读取。',
         `${isSupplement ? '视觉补充页码' : '转图片页码'}: ${renderedPages.map(page => page.pageNumber).join(', ')}`,
-        `读取方式: ${renderedPages[0]?.renderer === 'pdftoppm' ? '系统 pdftoppm 渲染 + Cats reader proxy 读图' : '内置 PDF.js 渲染 + Cats reader proxy 读图'}`,
+        `读取方式: ${renderedPages[0]?.renderer === 'pdftoppm' ? '系统 pdftoppm 渲染' : '内置 PDF.js 渲染'} + ${visionCapable ? '当前主模型读图' : 'Cats reader proxy 读图'}`,
       ];
+      const imageBlocks: ContentBlock[] = [];
 
       if (pages.length > renderedPages.length) {
         const renderedSet = new Set(renderedPages.map(page => page.pageNumber));
@@ -814,14 +816,25 @@ export class ReadTool implements Tool {
           context,
           pagePrompt,
           {
-            forceReaderProxy: true,
             metadataType: 'PDF 页面图片',
             proxyIntro: isSupplement
               ? '视觉补充结果（PDF 文本层可能漏掉图片、签章、手写或版式信息）：'
               : '读图结果（PDF 文本层不可用，已转为页面图片解析）：',
           },
         );
-        parts.push('', `--- 第 ${page.pageNumber} 页 ---`, String(analysis));
+        if (this.isDirectImageReadResult(analysis)) {
+          imageBlocks.push(
+            { type: 'text', text: `--- 第 ${page.pageNumber} 页（PDF 页面图片）---` },
+            analysis.imageBlock,
+          );
+        } else {
+          parts.push('', `--- 第 ${page.pageNumber} 页 ---`, String(analysis));
+        }
+      }
+
+      if (imageBlocks.length > 0) {
+        parts.push('', '以下附有上述 PDF 页面图片，按页码顺序查看。');
+        return [{ type: 'text', text: parts.join('\n') }, ...imageBlocks];
       }
 
       return parts.join('\n');
@@ -847,7 +860,7 @@ export class ReadTool implements Tool {
     context: ToolExecutionContext,
     pages?: string,
     prompt?: string,
-  ): Promise<string> {
+  ): Promise<string | ContentBlock[]> {
     const stats = fs.statSync(absolutePath);
     const sizeMB = (stats.size / 1024 / 1024).toFixed(2);
     const selection = this.parsePdfPages(pages);
@@ -889,13 +902,14 @@ export class ReadTool implements Tool {
       }
 
       if (!rawText) {
-        lines.push(
-          '',
-          await this.readPdfViaRenderedImages(absolutePath, filePath, visiblePath, context, selection, prompt, {
-            reason: 'missing_text',
-            totalPages: parsed.numpages,
-          }),
-        );
+        const visualContent = await this.readPdfViaRenderedImages(absolutePath, filePath, visiblePath, context, selection, prompt, {
+          reason: 'missing_text',
+          totalPages: parsed.numpages,
+        });
+        if (Array.isArray(visualContent)) {
+          return [{ type: 'text', text: lines.join('\n') }, ...visualContent];
+        }
+        lines.push('', visualContent);
         return lines.join('\n');
       }
 
@@ -915,34 +929,43 @@ export class ReadTool implements Tool {
       }
 
       if (this.shouldSupplementPdfVisualRead(context, prompt)) {
-        lines.push(
-          '',
-          await this.readPdfViaRenderedImages(absolutePath, filePath, visiblePath, context, selection, prompt, {
-            reason: 'visual_supplement',
-            totalPages: parsed.numpages,
-          }),
-        );
+        const visualContent = await this.readPdfViaRenderedImages(absolutePath, filePath, visiblePath, context, selection, prompt, {
+          reason: 'visual_supplement',
+          totalPages: parsed.numpages,
+        });
+        if (Array.isArray(visualContent)) {
+          return [{ type: 'text', text: lines.join('\n') }, ...visualContent];
+        }
+        lines.push('', visualContent);
       }
 
       return lines.join('\n');
     } catch (error: any) {
       const rawMessage = String(error?.message || error || 'unknown error').trim();
       const message = rawMessage.length > 500 ? `${rawMessage.slice(0, 500)}...` : rawMessage;
-      lines.push(
-        '',
-        'PDF 解析失败，read_file 未能提取正文。',
-        `原因: ${message}`,
-        '',
-        await this.readPdfViaRenderedImages(absolutePath, filePath, visiblePath, context, selection, prompt, {
-          reason: 'parse_failed',
-        }),
-      );
+      lines.push('', 'PDF 解析失败，read_file 未能提取正文。', `原因: ${message}`);
+      const visualContent = await this.readPdfViaRenderedImages(absolutePath, filePath, visiblePath, context, selection, prompt, {
+        reason: 'parse_failed',
+      });
+      if (Array.isArray(visualContent)) {
+        return [{ type: 'text', text: lines.join('\n') }, ...visualContent];
+      }
+      lines.push('', visualContent);
       return lines.join('\n');
     }
   }
 
   private isImageExt(ext: string): boolean {
     return ['.png', '.jpg', '.jpeg', '.gif', '.bmp', '.webp'].includes(ext);
+  }
+
+  private isDirectImageReadResult(content: unknown): content is { _imageForNewMessage: true; imageBlock: ContentBlock } {
+    return Boolean(
+      content
+      && typeof content === 'object'
+      && (content as any)._imageForNewMessage === true
+      && (content as any).imageBlock?.type === 'image',
+    );
   }
 
   private shouldImportRemoteMedia(filePath: string): boolean {
@@ -1089,10 +1112,9 @@ export class ReadTool implements Tool {
     const config = ConfigManager.getConfigReadonly();
     const imagePrompt = this.getImageReadPrompt(context, prompt);
     const visionCapable = isPrimaryModelVisionCapable(config);
-    const forceReaderProxy = Boolean(options?.forceReaderProxy);
     const modelName = config.model || 'unknown';
 
-    if (visionCapable && !forceReaderProxy) {
+    if (visionCapable) {
       const imageBlock = await createImageBlock(absolutePath);
       const logFile = formatPathForLog(absolutePath || filePath);
       if (imageBlock) {
@@ -1118,7 +1140,7 @@ export class ReadTool implements Tool {
       return [
         this.formatImageMetadata(absolutePath, filePath, visiblePath, options?.metadataType),
         '',
-        options?.proxyIntro || (visionCapable && !forceReaderProxy
+        options?.proxyIntro || (visionCapable
           ? '主模型图片块生成失败，已自动改用 Cats reader proxy 解析：'
           : '读图结果（由 Cats reader proxy 解析，已作为 read_file 结果返回给当前非多模态主模型）：'),
         proxyResult.analysis,
@@ -1128,7 +1150,7 @@ export class ReadTool implements Tool {
     return [
       this.formatImageMetadata(absolutePath, filePath, visiblePath, options?.metadataType),
       '',
-      this.formatReaderProxyFailure(proxyResult, visionCapable && !forceReaderProxy),
+      this.formatReaderProxyFailure(proxyResult, visionCapable),
     ].join('\n');
   }
 

--- a/tests/tool-result-read-tool.test.ts
+++ b/tests/tool-result-read-tool.test.ts
@@ -380,7 +380,7 @@ describe('ReadTool - ToolExecutionResult', () => {
     );
   });
 
-  test('无文本层 PDF 会转图片并通过 reader proxy 读取', async () => {
+  test('无文本层 PDF 会在非视觉模型下转图片并通过 reader proxy 读取', async () => {
     const previousConfigPath = process.env.XIAOBA_CONFIG_PATH;
     const previousReaderUrl = process.env.CATSCOMPANY_READER_API_URL;
     const previousApiKey = process.env.CATSCOMPANY_API_KEY;
@@ -449,6 +449,48 @@ describe('ReadTool - ToolExecutionResult', () => {
       }
       if (previousConfigPath === undefined) delete process.env.XIAOBA_CONFIG_PATH;
       else process.env.XIAOBA_CONFIG_PATH = previousConfigPath;
+      if (previousReaderUrl === undefined) delete process.env.CATSCOMPANY_READER_API_URL;
+      else process.env.CATSCOMPANY_READER_API_URL = previousReaderUrl;
+      if (previousApiKey === undefined) delete process.env.CATSCOMPANY_API_KEY;
+      else process.env.CATSCOMPANY_API_KEY = previousApiKey;
+    }
+  });
+
+  test('无文本层 PDF 会在视觉模型下直接附带渲染页，不调用 reader proxy', async () => {
+    const previousConfigPath = process.env.XIAOBA_CONFIG_PATH;
+    const previousProvider = process.env.GAUZ_LLM_PROVIDER;
+    const previousApiBase = process.env.GAUZ_LLM_API_BASE;
+    const previousModel = process.env.GAUZ_LLM_MODEL;
+    const previousReaderUrl = process.env.CATSCOMPANY_READER_API_URL;
+    const previousApiKey = process.env.CATSCOMPANY_API_KEY;
+
+    try {
+      process.env.XIAOBA_CONFIG_PATH = path.join(testRoot, 'missing-config.json');
+      process.env.GAUZ_LLM_PROVIDER = 'anthropic';
+      process.env.GAUZ_LLM_API_BASE = 'https://relay.catsco.cc/anthropic';
+      process.env.GAUZ_LLM_MODEL = 'MiniMax-M3';
+      delete process.env.CATSCOMPANY_READER_API_URL;
+      delete process.env.CATSCOMPANY_API_KEY;
+
+      const filePath = path.join(testRoot, 'scan-like-vision.pdf');
+      writeInlineImagePdf(filePath);
+      const result = await tool.execute({ file_path: filePath }, context);
+
+      assert.strictEqual(result.ok, true);
+      assert.ok(Array.isArray(result.content));
+      const content = result.content as Array<{ type: string; text?: string; source?: { type: string; media_type: string; data: string } }>;
+      assert.ok(content.some(block => block.type === 'text' && block.text?.includes('PDF 文本层未提取到内容')));
+      assert.ok(content.some(block => block.type === 'image' && block.source?.type === 'base64' && block.source.data.length > 0));
+      assert.ok(!content.some(block => block.type === 'text' && block.text?.includes('reader proxy')));
+    } finally {
+      if (previousConfigPath === undefined) delete process.env.XIAOBA_CONFIG_PATH;
+      else process.env.XIAOBA_CONFIG_PATH = previousConfigPath;
+      if (previousProvider === undefined) delete process.env.GAUZ_LLM_PROVIDER;
+      else process.env.GAUZ_LLM_PROVIDER = previousProvider;
+      if (previousApiBase === undefined) delete process.env.GAUZ_LLM_API_BASE;
+      else process.env.GAUZ_LLM_API_BASE = previousApiBase;
+      if (previousModel === undefined) delete process.env.GAUZ_LLM_MODEL;
+      else process.env.GAUZ_LLM_MODEL = previousModel;
       if (previousReaderUrl === undefined) delete process.env.CATSCOMPANY_READER_API_URL;
       else process.env.CATSCOMPANY_READER_API_URL = previousReaderUrl;
       if (previousApiKey === undefined) delete process.env.CATSCOMPANY_API_KEY;


### PR DESCRIPTION
## 背景\n\n远程 PDF 已由 #213 导入 bot 本机，但扫描版 PDF 在本机渲染为页面图片后仍被强制送往 reader proxy。视觉模型本可直接读取这些页面，因此缺少 reader proxy 配置时会出现不必要的失败。\n\n## 修改\n\n- PDF 渲染页按当前主模型视觉能力选择读取方式。\n- 视觉模型直接接收页面图片块，不再调用 reader proxy。\n- 非视觉模型及图片块构造失败时，保留 reader proxy 回退。\n- PDF 多页结果改为说明文本与页面图片块组合，避免将图片对象拼入字符串。\n\n## 验证\n\n- 
pm run build\n- 
px tsx --test tests/tool-result-read-tool.test.ts tests/remote-media-read.test.ts\n\nFixes #199