### PR TITLE
fix(runtime): isolate connector startup state

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -499,7 +499,7 @@ async function startServer() {
   // 闂備礁鎲＄粙鎴︽晝閵娾晜鍎?dashboard server app 闂備焦鐪归崝宀€鈧凹鍓熼幃鍧楀礋椤栨稈鎸冮梺鍛婁緱閸撴稓绮旂€靛摜纾介柛鎰劤濞呮瑧绱掓潏銊у磼sar 闂備礁鎲￠崝鏇㈠箯閹寸姵顫?
   process.env.XIAOBA_APP_ROOT = appRoot;
   process.env.XIAOBA_IS_PACKAGED = app.isPackaged ? '1' : '0';
-  process.env.XIAOBA_RUNTIME_ROOT = getRuntimeRoot();
+  process.env.XIAOBA_BUNDLED_EXECUTABLES_DIR = getRuntimeRoot();
   if (!String(process.env.XIAOBA_PROMPT_OVERRIDES_DIR || '').trim()) {
     process.env.XIAOBA_PROMPT_OVERRIDES_DIR = path.join(userDataPath, 'prompt-overrides');
   }
@@ -517,7 +517,7 @@ async function startServer() {
   const runtimeEnvironment = resolveRuntimeEnvironment({
     env: process.env,
     appRoot,
-    runtimeRoot: process.env.XIAOBA_RUNTIME_ROOT,
+    bundledExecutablesDir: process.env.XIAOBA_BUNDLED_EXECUTABLES_DIR,
     isPackaged: app.isPackaged,
   });
   if (runtimeEnvironment.binaries.node.executable) {

--- a/src/commands/runtime.ts
+++ b/src/commands/runtime.ts
@@ -8,10 +8,10 @@ export async function runtimeCommand(): Promise<void> {
 
   Logger.title('Runtime Diagnostics');
 
-  if (runtimeEnvironment.runtimeRoot) {
-    Logger.info(`Runtime root: ${runtimeEnvironment.runtimeRoot}`);
+  if (runtimeEnvironment.bundledExecutablesDir) {
+    Logger.info(`Bundled executables: ${runtimeEnvironment.bundledExecutablesDir}`);
   } else {
-    Logger.warning('Runtime root: not detected');
+    Logger.warning('Bundled executables: not detected');
   }
 
   if (runtimeEnvironment.shimDirectory) {

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -768,12 +768,17 @@ async function getCatsBotBodyStatus(
     );
     const platformBodyId = String(data?.body_id || data?.bodyId || '').trim();
     const active = Boolean(data?.active);
-    const bodyMismatch = platformBodyId && platformBodyId !== normalizedLocalBodyId;
+    // A stale platform body id is historical metadata when active=false. It is
+    // a conflict only when another body currently owns the active lease.
+    const activeLeaseOwnedByOtherBody = Boolean(
+      active && platformBodyId && platformBodyId !== normalizedLocalBodyId,
+    );
     return {
-      state: bodyMismatch ? 'conflict' : active ? 'online' : 'offline',
+      state: activeLeaseOwnedByOtherBody ? 'conflict' : active ? 'online' : 'offline',
       active,
       localBodyId: normalizedLocalBodyId,
       platformBodyId: platformBodyId || undefined,
+      conflictReason: activeLeaseOwnedByOtherBody ? 'active_lease_owned_by_other_body' : undefined,
       connectedAt: typeof data?.connected_at === 'string' ? data.connected_at : undefined,
       checkedAt: new Date().toISOString(),
     };

--- a/src/dashboard/service-manager.ts
+++ b/src/dashboard/service-manager.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs';
 import * as dotenv from 'dotenv';
 import { EventEmitter } from 'events';
 import { resolveRuntimeEnvironment } from '../utils/runtime-environment';
+import { PathResolver } from '../utils/path-resolver';
 import { resolveCatsCoRuntimeConfig } from '../catscompany/runtime-config';
 import { weixinBindingEnvOverlay } from './weixin-channel-binding';
 
@@ -139,7 +140,7 @@ export class ServiceManager extends EventEmitter {
     const runtimeEnvironment = resolveRuntimeEnvironment({
       env: process.env,
       appRoot,
-      runtimeRoot: process.env.XIAOBA_RUNTIME_ROOT,
+      bundledExecutablesDir: process.env.XIAOBA_BUNDLED_EXECUTABLES_DIR,
       isPackaged: packaged,
       probeVersion: false,
     });
@@ -225,16 +226,18 @@ export class ServiceManager extends EventEmitter {
     if (!svc) throw new Error(`Service "${name}" not found`);
     if (svc.info.status === 'running') return this.getService(name)!;
 
-    // cwd 统一用 process.cwd()，Electron 主进程已 chdir 到 userData 目录
-    // 这样子进程创建的 skill 文件和 Dashboard 读取的在同一个目录
+    // cwd remains the user's working directory. Runtime data is an explicit
+    // process contract and must not be inferred again by the child.
     const spawnCwd = process.cwd();
+    const runtimeDataRoot = PathResolver.getRuntimeDataRoot();
 
     // 每次启动时实时读取 .env。开发根目录提供默认值，runtime root 是运行态权威配置。
     let envVars = { ...process.env };
-    const envRoots = Array.from(new Set([this.projectRoot, spawnCwd]));
+    const envRoots = Array.from(new Set([this.projectRoot, spawnCwd, runtimeDataRoot]));
     for (const root of envRoots) {
       envVars = { ...envVars, ...readEnvFile(root) };
     }
+    envVars.XIAOBA_USER_DATA_DIR = runtimeDataRoot;
 
     // 打包版：确保子进程能找到 node_modules
     if (this.isPackaged() && process.env.XIAOBA_NODE_MODULES) {
@@ -243,7 +246,7 @@ export class ServiceManager extends EventEmitter {
 
     if (name === 'catscompany') {
       const catsCoRuntime = resolveCatsCoRuntimeConfig({
-        runtimeRoot: spawnCwd,
+        runtimeRoot: runtimeDataRoot,
         env: envVars,
         migrateLegacyEnvBinding: true,
       });
@@ -256,21 +259,21 @@ export class ServiceManager extends EventEmitter {
 
     if (name === 'weixin') {
       const catsCoRuntime = resolveCatsCoRuntimeConfig({
-        runtimeRoot: spawnCwd,
+        runtimeRoot: runtimeDataRoot,
         env: envVars,
         migrateLegacyEnvBinding: true,
       });
       envVars = {
         ...envVars,
         ...catsCoRuntime.envOverlay,
-        ...weixinBindingEnvOverlay({ runtimeRoot: spawnCwd, env: envVars }),
+        ...weixinBindingEnvOverlay({ runtimeRoot: runtimeDataRoot, env: envVars }),
       };
     }
 
     const runtimeEnvironment = resolveRuntimeEnvironment({
       env: envVars,
       appRoot: this.getAppRoot(),
-      runtimeRoot: envVars.XIAOBA_RUNTIME_ROOT,
+      bundledExecutablesDir: envVars.XIAOBA_BUNDLED_EXECUTABLES_DIR,
       isPackaged: this.isPackaged(),
       probeVersion: false,
     });

--- a/src/utils/path-resolver.ts
+++ b/src/utils/path-resolver.ts
@@ -2,17 +2,22 @@ import * as path from 'path';
 import * as fs from 'fs';
 
 export class PathResolver {
-  static getRuntimeDataRoot(): string {
+  static getRuntimeDataRoot(
+    env: NodeJS.ProcessEnv = process.env,
+    cwd: string = process.cwd(),
+  ): string {
     const explicit = [
-      process.env.XIAOBA_USER_DATA_DIR,
-      process.env.CATSCO_USER_DATA_DIR,
-      process.env.XIAOBA_ELECTRON_USER_DATA_DIR,
-      process.env.XIAOBA_RUNTIME_ROOT,
+      env.XIAOBA_USER_DATA_DIR,
+      env.CATSCO_USER_DATA_DIR,
+      env.XIAOBA_ELECTRON_USER_DATA_DIR,
+      // Legacy data-root compatibility only. Bundled executable discovery uses
+      // XIAOBA_BUNDLED_EXECUTABLES_DIR and must not write this variable.
+      env.XIAOBA_RUNTIME_ROOT,
     ]
       .map(value => String(value || '').trim())
       .find(Boolean);
 
-    return path.resolve(explicit || process.cwd());
+    return path.resolve(explicit || cwd);
   }
 
   static getDataPath(...segments: string[]): string {

--- a/src/utils/runtime-environment.ts
+++ b/src/utils/runtime-environment.ts
@@ -19,6 +19,8 @@ export interface RuntimeBinary {
 export interface RuntimeEnvironmentOptions {
   env?: NodeJS.ProcessEnv;
   appRoot?: string;
+  bundledExecutablesDir?: string;
+  /** @deprecated Use bundledExecutablesDir. Kept for internal call-site compatibility. */
   runtimeRoot?: string;
   isPackaged?: boolean;
   includeSystemFallback?: boolean;
@@ -31,6 +33,8 @@ export interface RuntimeEnvironment {
   binaries: Record<RuntimeBinaryName, RuntimeBinary>;
   pathKey: string;
   prependedPaths: string[];
+  bundledExecutablesDir?: string;
+  /** @deprecated Use bundledExecutablesDir. */
   runtimeRoot?: string;
   shimDirectory?: string;
 }
@@ -68,14 +72,14 @@ const SHIM_COMMAND_NAMES: Record<RuntimeBinaryName, string[]> = {
 export function resolveRuntimeEnvironment(options: RuntimeEnvironmentOptions = {}): RuntimeEnvironment {
   const env: NodeJS.ProcessEnv = { ...(options.env || process.env) };
   const pathKey = getPathKey(env);
-  const runtimeRoot = resolveRuntimeRoot(env, options);
+  const bundledExecutablesDir = resolveBundledExecutablesDir(env, options);
   const includeSystemFallback = options.includeSystemFallback !== false;
   const probeVersion = options.probeVersion !== false;
 
   const binaries: Record<RuntimeBinaryName, RuntimeBinary> = {
-    node: resolveBinary('node', env, runtimeRoot, includeSystemFallback, probeVersion),
-    python: resolveBinary('python', env, runtimeRoot, includeSystemFallback, probeVersion),
-    git: resolveBinary('git', env, runtimeRoot, includeSystemFallback, probeVersion),
+    node: resolveBinary('node', env, bundledExecutablesDir, includeSystemFallback, probeVersion),
+    python: resolveBinary('python', env, bundledExecutablesDir, includeSystemFallback, probeVersion),
+    git: resolveBinary('git', env, bundledExecutablesDir, includeSystemFallback, probeVersion),
   };
 
   const shimDirectory = ensureRuntimeShims(
@@ -99,8 +103,10 @@ export function resolveRuntimeEnvironment(options: RuntimeEnvironmentOptions = {
     setPathValue(env, pathKey, nextPath.join(path.delimiter));
   }
 
-  if (runtimeRoot) {
-    env.XIAOBA_RUNTIME_ROOT = runtimeRoot;
+  if (bundledExecutablesDir) {
+    // Bundled executable discovery must never overwrite XIAOBA_RUNTIME_ROOT. That legacy
+    // variable is still accepted by PathResolver as a runtime *data* root.
+    env.XIAOBA_BUNDLED_EXECUTABLES_DIR = bundledExecutablesDir;
   }
 
   if (shimDirectory) {
@@ -112,7 +118,8 @@ export function resolveRuntimeEnvironment(options: RuntimeEnvironmentOptions = {
     binaries,
     pathKey,
     prependedPaths,
-    runtimeRoot,
+    bundledExecutablesDir,
+    runtimeRoot: bundledExecutablesDir,
     shimDirectory,
   };
 }
@@ -129,12 +136,12 @@ export function formatRuntimeSummary(binary: RuntimeBinary): string {
 function resolveBinary(
   name: RuntimeBinaryName,
   env: NodeJS.ProcessEnv,
-  runtimeRoot: string | undefined,
+  bundledExecutablesDir: string | undefined,
   includeSystemFallback: boolean,
   probeVersion: boolean,
 ): RuntimeBinary {
   const diagnostics: string[] = [];
-  const searchRoots = collectSearchRoots(runtimeRoot);
+  const searchRoots = collectSearchRoots(bundledExecutablesDir);
 
   for (const root of searchRoots) {
     for (const relativePath of BUNDLED_RELATIVE_PATHS[name]) {
@@ -186,11 +193,12 @@ function finalizeBinary(
   };
 }
 
-function resolveRuntimeRoot(env: NodeJS.ProcessEnv, options: RuntimeEnvironmentOptions): string | undefined {
+function resolveBundledExecutablesDir(env: NodeJS.ProcessEnv, options: RuntimeEnvironmentOptions): string | undefined {
   const candidates = orderedUnique(
     [
+      options.bundledExecutablesDir,
       options.runtimeRoot,
-      env.XIAOBA_RUNTIME_ROOT,
+      env.XIAOBA_BUNDLED_EXECUTABLES_DIR,
       options.appRoot ? path.join(options.appRoot, 'build-resources', 'runtime') : undefined,
       DEFAULT_DEV_RUNTIME_ROOT,
     ].filter((value): value is string => Boolean(value)),
@@ -205,9 +213,9 @@ function resolveRuntimeRoot(env: NodeJS.ProcessEnv, options: RuntimeEnvironmentO
   return candidates[0];
 }
 
-function collectSearchRoots(runtimeRoot: string | undefined): string[] {
-  if (runtimeRoot) {
-    return [runtimeRoot];
+function collectSearchRoots(bundledExecutablesDir: string | undefined): string[] {
+  if (bundledExecutablesDir) {
+    return [bundledExecutablesDir];
   }
 
   return orderedUnique([DEFAULT_DEV_RUNTIME_ROOT, LEGACY_DEV_RUNTIME_ROOT]);

--- a/tests/bot-definition-local-repository.test.ts
+++ b/tests/bot-definition-local-repository.test.ts
@@ -20,6 +20,7 @@ import {
 
 const managedEnvKeys = [
   'XIAOBA_USER_DATA_DIR',
+  'XIAOBA_BUNDLED_EXECUTABLES_DIR',
   'XIAOBA_BOT_DEFINITION_SIMULATED_CLOUD_DIR',
   'CATSCO_MODEL_SOURCE',
   'CATSCO_CUSTOM_LLM_PROVIDER',
@@ -199,6 +200,7 @@ describe('BotDefinition local simulation', () => {
     };
     repository.writeCache(definition);
     process.env.XIAOBA_USER_DATA_DIR = runtimeRoot;
+    process.env.XIAOBA_BUNDLED_EXECUTABLES_DIR = path.join(simulatedCloudRoot, 'bundled-executables');
     process.env.GAUZ_LLM_PROVIDER = 'anthropic';
     process.env.GAUZ_LLM_API_BASE = 'https://stale.example.test/v1';
     process.env.GAUZ_LLM_MODEL = 'stale-model';

--- a/tests/catsco-command-config.test.ts
+++ b/tests/catsco-command-config.test.ts
@@ -11,6 +11,8 @@ describe('CatsCo command config resolution', () => {
   let tempDir: string;
   let originalCwd: string;
   let originalRuntimeRoot: string | undefined;
+  let originalUserDataDir: string | undefined;
+  let originalBundledExecutablesDir: string | undefined;
 
   const baseConfig: ChatConfig = {
     catscompany: {
@@ -24,6 +26,11 @@ describe('CatsCo command config resolution', () => {
   beforeEach(() => {
     originalCwd = process.cwd();
     originalRuntimeRoot = process.env.XIAOBA_RUNTIME_ROOT;
+    originalUserDataDir = process.env.XIAOBA_USER_DATA_DIR;
+    originalBundledExecutablesDir = process.env.XIAOBA_BUNDLED_EXECUTABLES_DIR;
+    delete process.env.XIAOBA_RUNTIME_ROOT;
+    delete process.env.XIAOBA_USER_DATA_DIR;
+    delete process.env.XIAOBA_BUNDLED_EXECUTABLES_DIR;
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'catsco-command-config-'));
     process.chdir(tempDir);
   });
@@ -35,6 +42,10 @@ describe('CatsCo command config resolution', () => {
     } else {
       process.env.XIAOBA_RUNTIME_ROOT = originalRuntimeRoot;
     }
+    if (originalUserDataDir === undefined) delete process.env.XIAOBA_USER_DATA_DIR;
+    else process.env.XIAOBA_USER_DATA_DIR = originalUserDataDir;
+    if (originalBundledExecutablesDir === undefined) delete process.env.XIAOBA_BUNDLED_EXECUTABLES_DIR;
+    else process.env.XIAOBA_BUNDLED_EXECUTABLES_DIR = originalBundledExecutablesDir;
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
@@ -105,6 +116,28 @@ describe('CatsCo command config resolution', () => {
     assert.deepEqual(resolved.missing, []);
     assert.equal(resolved.config?.apiKey, 'local-bot-key');
     assert.equal(resolved.config?.bodyId, 'body-local');
+  });
+
+  test('keeps first-class user data separate from bundled executables', () => {
+    const runtimeDataRoot = path.join(tempDir, 'runtime-data');
+    const bundledExecutablesDir = path.join(tempDir, 'bundled-executables');
+    process.env.XIAOBA_USER_DATA_DIR = runtimeDataRoot;
+    process.env.XIAOBA_BUNDLED_EXECUTABLES_DIR = bundledExecutablesDir;
+    saveConfirmedBinding(runtimeDataRoot);
+
+    const resolved = resolveCatsCoCommandConfig({}, {
+      CATSCO_USER_TOKEN: 'env-token',
+      CATSCO_USER_UID: 'user-1',
+      CATSCO_SERVER_URL: 'wss://catsco.example/v0/channels',
+      CATSCO_API_KEY: 'catsco-key',
+      XIAOBA_USER_DATA_DIR: runtimeDataRoot,
+      XIAOBA_BUNDLED_EXECUTABLES_DIR: bundledExecutablesDir,
+    });
+
+    assert.deepEqual(resolved.missing, []);
+    assert.equal(resolved.config?.apiKey, 'local-bot-key');
+    assert.equal(resolved.config?.bodyId, 'body-local');
+    assert.equal(fs.existsSync(path.join(bundledExecutablesDir, '.xiaoba', 'catsco.json')), false);
   });
 
   function saveConfirmedBinding(runtimeRoot = tempDir): void {

--- a/tests/dashboard-catsco-auth-status.test.ts
+++ b/tests/dashboard-catsco-auth-status.test.ts
@@ -221,6 +221,51 @@ describe('dashboard CatsCo account status', () => {
     assert.equal(data.topicId, 'p2p_42_110');
   });
 
+  test('GET /cats/status does not report conflict for an inactive historical body', async () => {
+    await startCatsServer((req, res) => {
+      if (req.path === '/api/me') {
+        return res.json({ uid: 42, username: 'webuser', display_name: 'Web User' });
+      }
+      if (req.path === '/api/bots/body-status') {
+        return res.json({ body_id: 'body-from-old-installation', active: false });
+      }
+      return res.status(404).json({ error: 'not found' });
+    });
+    saveConfirmedLocalBinding('body-local');
+
+    const response = await fetch(`${dashboardBaseUrl}/api/cats/status`);
+    const data = await response.json() as any;
+
+    assert.equal(response.status, 200);
+    assert.equal(data.bodyStatus.state, 'offline');
+    assert.equal(data.bodyStatus.active, false);
+    assert.equal(data.bodyStatus.platformBodyId, 'body-from-old-installation');
+    assert.equal(data.bodyStatus.conflictReason, undefined);
+    assert.equal(data.chatReady, true);
+  });
+
+  test('GET /cats/status keeps a real active-body conflict blocking', async () => {
+    await startCatsServer((req, res) => {
+      if (req.path === '/api/me') {
+        return res.json({ uid: 42, username: 'webuser', display_name: 'Web User' });
+      }
+      if (req.path === '/api/bots/body-status') {
+        return res.json({ body_id: 'body-from-other-installation', active: true });
+      }
+      return res.status(404).json({ error: 'not found' });
+    });
+    saveConfirmedLocalBinding('body-local');
+
+    const response = await fetch(`${dashboardBaseUrl}/api/cats/status`);
+    const data = await response.json() as any;
+
+    assert.equal(response.status, 200);
+    assert.equal(data.bodyStatus.state, 'conflict');
+    assert.equal(data.bodyStatus.active, true);
+    assert.equal(data.bodyStatus.conflictReason, 'active_lease_owned_by_other_body');
+    assert.equal(data.chatReady, false);
+  });
+
   test('POST /cats/auth/login writes both CatsCo and CatsCompany env aliases', async () => {
     await startCatsServer((req, res) => {
       if (req.path === '/api/auth/login') {
@@ -1127,6 +1172,35 @@ describe('dashboard CatsCo account status', () => {
     app.use(handler);
     catsServer = await listen(app);
     catsBaseUrl = serverBaseUrl(catsServer);
+  }
+
+  function saveConfirmedLocalBinding(bodyId: string): void {
+    createCatsCoLocalConfigService({ runtimeRoot: testRoot }).save({
+      version: 1,
+      endpoints: {
+        httpBaseUrl: catsBaseUrl,
+        serverUrl: 'wss://app.catsco.cc/v0/channels',
+      },
+      account: {
+        token: 'valid-user-token',
+        uid: '42',
+        username: 'webuser',
+        displayName: 'Web User',
+      },
+      currentBot: {
+        uid: '110',
+        name: 'CatsCo',
+        username: 'catsco_42',
+        apiKey: 'agent-api-key',
+        boundByUserUid: '42',
+        bindingSource: 'test',
+      },
+      device: {
+        deviceId: `device-for-${bodyId}`,
+        bodyId,
+        installationId: `installation-for-${bodyId}`,
+      },
+    });
   }
 
   function writeEnv(lines: string[]): void {

--- a/tests/dashboard-service-manager.test.ts
+++ b/tests/dashboard-service-manager.test.ts
@@ -11,6 +11,7 @@ describe('dashboard service manager', () => {
       'XIAOBA_APP_ROOT',
       'XIAOBA_IS_PACKAGED',
       'XIAOBA_NODE_EXECUTABLE',
+      'XIAOBA_BUNDLED_EXECUTABLES_DIR',
       'XIAOBA_RUNTIME_ROOT',
       'npm_node_execpath',
     ];
@@ -19,6 +20,7 @@ describe('dashboard service manager', () => {
     process.env.XIAOBA_APP_ROOT = process.cwd();
     process.env.XIAOBA_IS_PACKAGED = '0';
     delete process.env.XIAOBA_RUNTIME_ROOT;
+    delete process.env.XIAOBA_BUNDLED_EXECUTABLES_DIR;
     process.env.npm_node_execpath = process.execPath;
 
     try {
@@ -44,6 +46,7 @@ describe('dashboard service manager', () => {
       'XIAOBA_APP_ROOT',
       'XIAOBA_IS_PACKAGED',
       'XIAOBA_NODE_EXECUTABLE',
+      'XIAOBA_BUNDLED_EXECUTABLES_DIR',
       'XIAOBA_RUNTIME_ROOT',
       'npm_node_execpath',
     ];
@@ -58,6 +61,7 @@ describe('dashboard service manager', () => {
     process.env.XIAOBA_APP_ROOT = appRoot;
     process.env.XIAOBA_IS_PACKAGED = '1';
     delete process.env.XIAOBA_RUNTIME_ROOT;
+    delete process.env.XIAOBA_BUNDLED_EXECUTABLES_DIR;
     process.env.npm_node_execpath = process.execPath;
 
     try {
@@ -83,6 +87,7 @@ describe('dashboard service manager', () => {
       'XIAOBA_APP_ROOT',
       'XIAOBA_IS_PACKAGED',
       'XIAOBA_NODE_EXECUTABLE',
+      'XIAOBA_BUNDLED_EXECUTABLES_DIR',
       'XIAOBA_RUNTIME_ROOT',
       'npm_node_execpath',
     ];
@@ -98,6 +103,7 @@ describe('dashboard service manager', () => {
     process.env.XIAOBA_NODE_EXECUTABLE = realNode;
     process.env.npm_node_execpath = path.join(runtimeRoot, process.platform === 'win32' ? 'node.cmd' : 'node-shim');
     delete process.env.XIAOBA_RUNTIME_ROOT;
+    delete process.env.XIAOBA_BUNDLED_EXECUTABLES_DIR;
 
     try {
       const manager = new ServiceManager(process.cwd());
@@ -161,6 +167,47 @@ describe('dashboard service manager', () => {
 
     assert.ok(manager.getLogs('catscompany').includes(`owner=${process.pid}`));
     assert.equal(manager.getService('catscompany')?.status, 'stopped');
+  });
+
+  test('passes separate runtime data and bundled executable directories to the child', async () => {
+    const keys = ['XIAOBA_USER_DATA_DIR', 'XIAOBA_BUNDLED_EXECUTABLES_DIR', 'XIAOBA_RUNTIME_ROOT'];
+    const previous = new Map(keys.map(key => [key, process.env[key]]));
+    const runtimeDataRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-service-data-'));
+    const bundledExecutablesDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-service-executables-'));
+
+    process.env.XIAOBA_USER_DATA_DIR = runtimeDataRoot;
+    process.env.XIAOBA_BUNDLED_EXECUTABLES_DIR = bundledExecutablesDir;
+    delete process.env.XIAOBA_RUNTIME_ROOT;
+
+    try {
+      const manager = new ServiceManager(process.cwd());
+      const serviceRecord = (manager as any).services.get('catscompany');
+      serviceRecord.info.command = process.execPath;
+      serviceRecord.info.args = [
+        '-e',
+        "console.log(JSON.stringify({ data: process.env.XIAOBA_USER_DATA_DIR, executables: process.env.XIAOBA_BUNDLED_EXECUTABLES_DIR, legacy: process.env.XIAOBA_RUNTIME_ROOT || null }));",
+      ];
+
+      const stopped = new Promise<void>(resolve => {
+        manager.once('service-stopped', () => resolve());
+      });
+
+      manager.start('catscompany');
+      await stopped;
+
+      const payload = JSON.parse(manager.getLogs('catscompany').find(line => line.startsWith('{')) || '{}');
+      assert.equal(payload.data, runtimeDataRoot);
+      assert.equal(payload.executables, bundledExecutablesDir);
+      assert.equal(payload.legacy, null);
+    } finally {
+      for (const key of keys) {
+        const value = previous.get(key);
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+      fs.rmSync(runtimeDataRoot, { recursive: true, force: true });
+      fs.rmSync(bundledExecutablesDir, { recursive: true, force: true });
+    }
   });
 
   test('treats dashboard-requested service stop as stopped even when the child exits non-zero', async () => {

--- a/tests/path-resolver-boundaries.test.ts
+++ b/tests/path-resolver-boundaries.test.ts
@@ -1,0 +1,38 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { PathResolver } from '../src/utils/path-resolver';
+
+describe('PathResolver runtime data boundary', () => {
+  const testRoot = path.join(os.tmpdir(), 'xiaoba-path-boundary');
+
+  test('bundled executables directory never becomes runtime data root', () => {
+    const bundledExecutablesDir = path.join(testRoot, 'bundled-executables');
+    const env = { XIAOBA_BUNDLED_EXECUTABLES_DIR: bundledExecutablesDir } as NodeJS.ProcessEnv;
+
+    assert.equal(PathResolver.getRuntimeDataRoot(env, testRoot), path.resolve(testRoot));
+  });
+
+  test('explicit user data root wins over all compatibility roots', () => {
+    const userDataRoot = path.join(testRoot, 'user-data');
+    const env = {
+      XIAOBA_USER_DATA_DIR: userDataRoot,
+      CATSCO_USER_DATA_DIR: path.join(testRoot, 'catsco-data'),
+      XIAOBA_RUNTIME_ROOT: path.join(testRoot, 'legacy-data'),
+      XIAOBA_BUNDLED_EXECUTABLES_DIR: path.join(testRoot, 'bundled-executables'),
+    } as NodeJS.ProcessEnv;
+
+    assert.equal(PathResolver.getRuntimeDataRoot(env, testRoot), userDataRoot);
+  });
+
+  test('legacy runtime root remains a data-only compatibility input', () => {
+    const legacyDataRoot = path.join(testRoot, 'legacy-data');
+    const env = {
+      XIAOBA_RUNTIME_ROOT: legacyDataRoot,
+      XIAOBA_BUNDLED_EXECUTABLES_DIR: path.join(testRoot, 'bundled-executables'),
+    } as NodeJS.ProcessEnv;
+
+    assert.equal(PathResolver.getRuntimeDataRoot(env, testRoot), legacyDataRoot);
+  });
+});

--- a/tests/runtime-environment.test.ts
+++ b/tests/runtime-environment.test.ts
@@ -42,6 +42,33 @@ describe('resolveRuntimeEnvironment', () => {
 
     assert.strictEqual(runtimeEnvironment.binaries.node.executable, nodeBinaryPath);
     assert.strictEqual(runtimeEnvironment.binaries.node.source, 'bundled');
+    assert.strictEqual(runtimeEnvironment.bundledExecutablesDir, testRoot);
+    assert.strictEqual(runtimeEnvironment.env.XIAOBA_BUNDLED_EXECUTABLES_DIR, testRoot);
+    assert.strictEqual(runtimeEnvironment.env.XIAOBA_RUNTIME_ROOT, undefined);
+  });
+
+  test('does not reinterpret the legacy runtime data root as the bundled executables directory', () => {
+    const runtimeDataRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-runtime-data-'));
+    try {
+      const runtimeEnvironment = resolveRuntimeEnvironment({
+        env: {
+          PATH: '',
+          XIAOBA_RUNTIME_ROOT: runtimeDataRoot,
+        },
+        includeSystemFallback: false,
+        probeVersion: false,
+        shimDirectory: shimRoot,
+      });
+
+      assert.notStrictEqual(runtimeEnvironment.bundledExecutablesDir, runtimeDataRoot);
+      assert.strictEqual(runtimeEnvironment.env.XIAOBA_RUNTIME_ROOT, runtimeDataRoot);
+      assert.strictEqual(
+        runtimeEnvironment.env.XIAOBA_BUNDLED_EXECUTABLES_DIR,
+        runtimeEnvironment.bundledExecutablesDir,
+      );
+    } finally {
+      fs.rmSync(runtimeDataRoot, { recursive: true, force: true });
+    }
   });
 
   test('does not duplicate bundled node directory in PATH', () => {


### PR DESCRIPTION
## 这份 PR 要解决什么

这份 PR 处理两个看起来无关、实际上都发生在 Connector 启动边界上的问题：

1. 用户已经保存了可用的第三方自定义模型，但从 Connector 控制界面启动 Agent Runtime 后，子进程可能读到另一套目录里的配置，表现为请求失败、模型回到默认模型，或开发版与安装版互相“污染”。
2. 平台只保留了另一个历史 `body_id`、且明确返回 `active=false` 时，本地仍然把它显示成“另一个设备正在运行这个 Agent”。

这里的 Connector 是同一个桌面应用。当前实现只是内部由 Connector Control Host（包含现有 Dashboard 控制界面）启动 Agent Runtime 子进程，并不是 Dashboard 和 Connector 两套并列产品。

## 为什么会发生

### 1. 一个目录变量承担了两种完全不同的职责

旧代码把 `XIAOBA_RUNTIME_ROOT` 同时用成了两类目录：

- “档案柜”：保存 `.env`、账号绑定、自定义模型、Session、skills、日志等用户运行数据。
- “应用程序箱”：保存安装包随附的 Node、Python、Git，用来启动子进程和执行命令。

这就像在一张地址单上同时写“我的档案柜在这里”和“Node 可执行文件在这里”。父进程想告诉子进程去哪里找 Node，子进程却可能把同一个地址理解为去哪里找自定义模型配置。

结果不是第三方接口失效，而是启动出来的 Agent Runtime 可能根本没有读取用户刚刚保存的那份配置。它会看到空配置、旧配置或默认配置，于是表面上像是“自动跳回 MiniMax M2.7”或“安装版也被污染”。

### 2. Body 状态判断只比较 ID，没有先看它是否真的 active

旧逻辑基本等价于：

> 只要平台记录的 `body_id` 和本地不同，就判定 conflict。

但平台返回的 `body_id` 可能只是最后一次运行留下的历史记录。`active=false` 已经说明它当前没有持有运行权。历史记录不同不等于另一个 Body 正在运行。

## 这份 PR 怎么修

### 明确拆开两个目录协议

- `XIAOBA_USER_DATA_DIR`：唯一明确的用户运行数据目录，也就是“档案柜”。
- `XIAOBA_BUNDLED_EXECUTABLES_DIR`：安装包内置 Node/Python/Git 的只读目录，也就是“应用程序箱”。它不是 skill 目录，也不是 Agent 工具目录。
- `XIAOBA_RUNTIME_ROOT`：迁移期只保留为旧版用户数据目录的兼容输入；新启动代码不再写它，也不再用它定位内置程序。

Connector Control Host 启动 Agent Runtime 子进程时，现在会显式传递同一个 `XIAOBA_USER_DATA_DIR`。父进程预检、自定义模型解析、CatsCo/微信绑定和子进程执行因此使用同一个数据根，不再依赖 `cwd` 或一个含义模糊的环境变量进行猜测。

### 只把真实的 active-other-body 判为 conflict

新的状态规则是：

| 平台状态 | Body ID | 本地结果 |
| --- | --- | --- |
| `active=true` | 与本地相同 | `online` |
| `active=true` | 与本地不同 | `conflict`，阻止自动启动 |
| `active=false` | 任意历史 ID | `offline`，不制造假冲突 |

真实冲突会附带稳定原因码 `active_lease_owned_by_other_body`，便于控制界面和日志准确解释问题。

## 这不会破坏“一 Agent 一 active Body”原则

本 PR 没有放宽 Body 排他规则。恰恰相反，它让规则更准确：

- 另一个 Body 真的 `active=true` 时，仍然严格阻止启动。
- 只有平台已经确认 `active=false` 的历史 Body 才不再被误判为冲突。
- 最终 acquire/lease 仍由平台裁决，本地界面不会自行授予运行权。

因此它不会造成两个 Body 同时回复，也不会把多 Session 错误实现成多 Body。

## 用户影响

- 自定义模型配置会从预期的数据目录进入实际 Agent Runtime，不再因为内置 Node 目录覆盖数据目录而静默回退。
- 开发版和安装版可以各自使用自己的 `XIAOBA_USER_DATA_DIR`，降低互相读取配置、Session 和绑定信息的风险。
- 平台上已经离线的旧 Body 不再让本地一直显示 conflict。
- 真正正在运行的另一个 Body 仍然会被识别和阻止。

已有正在运行的旧进程不会热加载这次修复，需要重启 Connector 后才会使用新目录协议。

## 本次刻意不做什么

- 不修改 reviewer/sub-agent runtime。
- 不实现新的云端配置同步。
- 不清空、覆盖或自动迁移用户 `.env`、API key、Session、skills。
- 不在这个止血 PR 中引入完整 lease epoch/fencing 协议。
- 不把 Dashboard 重构成另一套产品；它仍是 Connector 内部当前的控制界面。

## 验证

- `npm run build`：通过。
- 完整 runtime 测试：143 个测试文件，1068 项测试；1061 通过，0 失败，7 项按平台条件跳过。
- 新增覆盖：
  - 内置可执行程序目录永远不会成为用户数据目录。
  - Control Host 与 Agent Runtime 子进程拿到相同用户数据目录。
  - `active=false` 的历史 Body 不产生 conflict。
  - `active=true` 的其他 Body 仍产生 conflict 并阻止 chat ready。

## 风险与回滚

改动集中在启动时的环境变量组装、路径解析和 Body 状态展示，没有修改用户数据格式。若需要回滚，可以独立回滚本 PR；不会要求回滚 reviewer runtime 或模型实现。
