### PR TITLE
fix(dashboard): preserve custom model source

### DIFF
--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -2212,7 +2212,10 @@ export function createApiRouter(
       const activeBotConfig = resolveActiveBotLLMConfig({ runtimeRoot: runtimeDataRoot() });
       res.json(getDashboardSettings({
         runtimeRoot: runtimeDataRoot(),
-        ...(activeBotConfig ? { modelConfig: activeBotConfig.config } : {}),
+        ...(activeBotConfig ? {
+          modelConfig: activeBotConfig.config,
+          modelConfigSource: activeBotConfig.source === 'custom_definition' ? 'custom' : 'relay',
+        } : {}),
       }));
     } catch (e: any) {
       res.status(500).json({ error: e.message });

--- a/src/dashboard/settings.ts
+++ b/src/dashboard/settings.ts
@@ -72,6 +72,8 @@ export interface DashboardSettingsOptions {
   now?: Date;
   /** The bound bot's resolved Definition config, when one is active. */
   modelConfig?: Pick<ChatConfig, 'provider' | 'apiUrl' | 'apiKey' | 'model' | 'contextWindowTokens' | 'reasoningEffort' | 'openaiApiMode'>;
+  /** Preserve Definition semantics even when a custom model uses the CatsCo relay URL. */
+  modelConfigSource?: 'relay' | 'custom';
 }
 
 interface NormalizedSettingUpdate {
@@ -357,6 +359,7 @@ function modelConfigValue(
 
 function modelConfigSnapshot(
   config: NonNullable<DashboardSettingsOptions['modelConfig']>,
+  source?: DashboardSettingsOptions['modelConfigSource'],
 ): DashboardModelStartupSnapshot {
   const effective: DashboardModelProfileSnapshot = {
     provider: config.provider,
@@ -368,13 +371,14 @@ function modelConfigSnapshot(
     apiKeyPresent: Boolean(config.apiKey),
     configured: Boolean(config.provider && config.apiUrl && config.model && config.apiKey),
   };
-  const relay = isCatsRelayApiBase(config.apiUrl)
+  const effectiveIsRelay = source ? source === 'relay' : isCatsRelayApiBase(config.apiUrl);
+  const relay = effectiveIsRelay
     ? { ...effective, reasoningEffort: effective.reasoningEffort === 'default' ? 'high' as const : effective.reasoningEffort }
     : { apiKeyPresent: false, configured: false };
-  const custom = isCatsRelayApiBase(config.apiUrl)
+  const custom = effectiveIsRelay
     ? { apiKeyPresent: false, configured: false }
     : effective;
-  return { source: isCatsRelayApiBase(config.apiUrl) ? 'relay' : 'custom', effective, custom, relay };
+  return { source: effectiveIsRelay ? 'relay' : 'custom', effective, custom, relay };
 }
 
 export function getDashboardSettings(
@@ -388,7 +392,7 @@ export function getDashboardSettings(
     runtimeRoot,
     generatedAt: (options.now ?? new Date()).toISOString(),
     modelStartup: options.modelConfig
-      ? modelConfigSnapshot(options.modelConfig)
+      ? modelConfigSnapshot(options.modelConfig, options.modelConfigSource)
       : buildModelStartupSnapshot(fileEnv, env),
     fields: DASHBOARD_SETTING_DEFINITIONS.map(definition => {
       const value = isModelSetting(definition.id)

--- a/tests/dashboard-settings-api.test.ts
+++ b/tests/dashboard-settings-api.test.ts
@@ -384,6 +384,39 @@ describe('dashboard typed settings API', () => {
     assert.equal(text.includes('sk-runtime-root-secret'), false);
   });
 
+  test('GET /settings preserves a bound custom Definition that uses the CatsCo relay URL', async () => {
+    createCatsCoLocalConfigService({ runtimeRoot: testRoot }).save({
+      version: 1,
+      currentBot: {
+        uid: 'bound-custom-relay-url',
+        apiKey: 'catsco-bot-api-key',
+        boundByUserUid: 'user-definition-test',
+        bindingSource: 'test',
+      },
+    });
+    createBotDefinitionSyncService({ runtimeRoot: testRoot }).publish('bound-custom-relay-url', {
+      kind: 'custom',
+      protocol: 'openai-responses',
+      apiBase: 'https://relay.catsco.cc/v1',
+      model: 'gpt-5.6-terra',
+      apiKey: 'sk-custom-relay-secret',
+      contextWindowTokens: 256_000,
+      reasoningEffort: 'default',
+    });
+
+    const response = await fetch(`${baseUrl}/api/settings`);
+    const text = await response.text();
+    const settings = JSON.parse(text) as any;
+
+    assert.equal(response.status, 200, text);
+    assert.equal(settings.modelStartup.source, 'custom');
+    assert.equal(settings.modelStartup.custom.configured, true);
+    assert.equal(settings.modelStartup.custom.model, 'gpt-5.6-terra');
+    assert.equal(settings.modelStartup.custom.apiBase, 'https://relay.catsco.cc/v1');
+    assert.equal(settings.modelStartup.relay.configured, false);
+    assert.equal(text.includes('sk-custom-relay-secret'), false);
+  });
+
   test('PUT /model/reasoning-effort updates a bound custom Definition without changing legacy env', async () => {
     createCatsCoLocalConfigService({ runtimeRoot: testRoot }).save({
       version: 1,


### PR DESCRIPTION
## Summary
- preserve the resolved BotDefinition source when building Dashboard settings
- keep explicitly custom models classified as custom even when their API base uses relay.catsco.cc
- add a regression test for a custom OpenAI Responses model behind the CatsCo relay URL

## Root cause
The connector runtime correctly selected the custom gpt-5.6-terra BotDefinition, but GET /api/settings inferred the source from the API URL alone. Because the custom definition used relay.catsco.cc, Dashboard mislabeled it as a relay catalog model and displayed the MiniMax M2.7 fallback as active.

## Verification
- node --import tsx --test tests/dashboard-settings-api.test.ts (42 passed)
- node --import tsx --test tests/dashboard-productization-html.test.ts tests/dashboard-model-source-html.test.ts (18 passed)
- npm run build
- git diff --check

This is complementary to #217: that PR separates connector data roots from bundled executable roots, while this PR fixes the Dashboard's source classification.