### PR TITLE
fix(dashboard): keep explicit model selection consistent

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -8330,8 +8330,8 @@
     let catsAutoStartAttemptAt=0;
     const CUSTOM_MODEL_AUTO_SAVE_DELAY=900;
     const RELAY_FALLBACK_MODELS=[
-      {id:'minimax-m2.7',label:'MiniMax M2.7',model:'MiniMax-M2.7',provider:'anthropic',protocol:'Anthropic-compatible',base_url:'https://relay.catsco.cc/anthropic',sdk_label:'Anthropic SDK',quota_class:'standard',context_window_tokens:204800,context_label:'204.8K',default:true},
-      {id:'minimax-m3',label:'MiniMax M3',model:'MiniMax-M3',provider:'anthropic',protocol:'Anthropic-compatible',base_url:'https://relay.catsco.cc/anthropic',sdk_label:'Anthropic SDK',quota_class:'multimodal',context_window_tokens:1000000,context_label:'1M'},
+      {id:'minimax-m2.7',label:'MiniMax M2.7',model:'MiniMax-M2.7',provider:'anthropic',protocol:'Anthropic-compatible',base_url:'https://relay.catsco.cc/anthropic',sdk_label:'Anthropic SDK',quota_class:'standard',context_window_tokens:204800,context_label:'204.8K'},
+      {id:'minimax-m3',label:'MiniMax M3',model:'MiniMax-M3',provider:'anthropic',protocol:'Anthropic-compatible',base_url:'https://relay.catsco.cc/anthropic',sdk_label:'Anthropic SDK',quota_class:'multimodal',context_window_tokens:1000000,context_label:'1M',default:true},
       {id:'deepseek-v4-flash',label:'DeepSeek V4 Flash',model:'deepseek-v4-flash',provider:'anthropic',protocol:'Anthropic-compatible',base_url:'https://relay.catsco.cc/anthropic',sdk_label:'Anthropic SDK',quota_class:'flash-low',context_window_tokens:1000000,context_label:'1M'},
     ];
     const CUSTOM_MODEL_CONTEXT_WINDOW_OPTIONS=[

--- a/src/bot-definition/activation.ts
+++ b/src/bot-definition/activation.ts
@@ -6,11 +6,12 @@ import {
   createBotDefinitionSyncService,
   type BotDefinitionSyncServiceOptions,
 } from './service';
-import type { BotDefinition, BotDefinitionSyncResult } from './types';
+import type { BotCatalogModelRuntime, BotDefinition, BotDefinitionSyncResult } from './types';
 
 export interface PrepareBoundBotDefinitionOptions extends BotDefinitionSyncServiceOptions {
   runtimeRoot: string;
   botId?: string;
+  selectedCatalogRuntime?: BotCatalogModelRuntime;
   auth?: CatsCoAuthSnapshot;
   fetchImpl?: typeof fetch;
 }
@@ -35,11 +36,27 @@ export async function prepareBoundBotDefinition(
   if (!botId) return undefined;
 
   const definitionService = createBotDefinitionSyncService(options);
-  let sync = definitionService.pullOrBootstrap(botId);
+  const selectedCatalogRuntime = options.selectedCatalogRuntime;
+  if (selectedCatalogRuntime && selectedCatalogRuntime.botId !== botId) {
+    throw new Error('Selected catalog runtime does not belong to the bound bot.');
+  }
+  let sync = selectedCatalogRuntime
+    ? undefined
+    : definitionService.pullOrBootstrap(botId);
   let definition = sync?.definition;
   const auth = options.auth ?? createCatsCoLocalConfigService({ runtimeRoot: options.runtimeRoot }).getAuthState();
   let initializedDefault = false;
   let materializedCatalogRuntime = false;
+
+  if (selectedCatalogRuntime) {
+    definitionService.storeCatalogRuntime(selectedCatalogRuntime);
+    sync = definitionService.publish(botId, {
+      kind: 'catalog',
+      modelId: selectedCatalogRuntime.modelId,
+    });
+    definition = sync.definition;
+    materializedCatalogRuntime = true;
+  }
 
   if (!definition) {
     const runtime = await provisionCatsRelayCatalogRuntime({

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -52,7 +52,11 @@ import { createCatsCoLocalConfigService } from '../../catscompany/local-config';
 import { catalogRuntimeMatchesModelId, createBotDefinitionSyncService } from '../../bot-definition/service';
 import { prepareBoundBotDefinition } from '../../bot-definition/activation';
 import { resolveActiveBotLLMConfig } from '../../bot-definition/llm-config-resolver';
-import type { BotDefinitionSyncResult } from '../../bot-definition/types';
+import {
+  BOT_CATALOG_MODEL_RUNTIME_SCHEMA,
+  type BotCatalogModelRuntime,
+  type BotDefinitionSyncResult,
+} from '../../bot-definition/types';
 import { resolveCatsCoRuntimeConfig } from '../../catscompany/runtime-config';
 import { consumeLocalFileGrant, validateLocalFileGrant } from '../local-file-grants';
 import { registerSkillHubRoutes } from './skillhub';
@@ -127,6 +131,12 @@ interface CatsBotBindingInput {
   botUsername?: string;
   apiKey: string;
   bindingSource?: string;
+  selectedCatalogRuntime?: BotCatalogModelRuntime;
+}
+
+interface CatsRelayModelSetupResult {
+  response: Record<string, unknown>;
+  selectedCatalogRuntime?: BotCatalogModelRuntime;
 }
 
 interface CatsRequestOptions {
@@ -851,6 +861,7 @@ async function commitCatsBotBindingAndStartConnector(
     const preparedBot = await prepareBoundBotDefinition({
       runtimeRoot: runtimeDataRoot(),
       botId: input.botUid,
+      selectedCatalogRuntime: input.selectedCatalogRuntime,
     });
     const botDefinitionSync = toBotDefinitionSyncPayload(preparedBot?.sync);
     const {
@@ -1494,6 +1505,31 @@ function writeRelayModelStartupConfig(
   };
 }
 
+function selectedRelayCatalogRuntime(
+  botId: string,
+  model: RelayModelConfig,
+  apiKey: string,
+  reasoningEffort: ReasoningEffort,
+): BotCatalogModelRuntime {
+  return {
+    schema: BOT_CATALOG_MODEL_RUNTIME_SCHEMA,
+    botId,
+    modelId: model.id,
+    provider: model.provider,
+    apiBase: model.baseUrl,
+    apiKey,
+    model: model.model,
+    contextWindowTokens: model.contextWindowTokens ?? resolveKnownModelContextWindowTokens(model.model) ?? 200_000,
+    reasoningEffort,
+    openaiApiMode: 'chat_completions',
+    capabilities: model.capabilities ? {
+      ...(model.capabilities.vision !== undefined ? { vision: model.capabilities.vision } : {}),
+      ...(model.capabilities.tool_calling !== undefined ? { toolCalling: model.capabilities.tool_calling } : {}),
+      ...(model.capabilities.streaming !== undefined ? { streaming: model.capabilities.streaming } : {}),
+    } : undefined,
+  };
+}
+
 function sanitizeRelayKeyInfo(key: any): any {
   if (!key || typeof key !== 'object') return key || null;
   const safe: Record<string, unknown> = {};
@@ -1657,15 +1693,18 @@ function matchesRelayKeyPrefix(apiKey: string, prefix: string): boolean {
 
 async function setupCatsRelayModelForDesktop(
   state: CatsAuthState,
+  botId: string,
   requestedModel: unknown,
   options: { rotateExisting?: boolean; reasoningEffort?: ReasoningEffort } = {},
-): Promise<Record<string, unknown>> {
+): Promise<CatsRelayModelSetupResult> {
   const config = await fetchCatsRelayConfig(state);
   if (config?.self_service_enabled === false) {
     return {
-      ok: false,
-      skipped: true,
-      reason: 'CatsCo 中转自助 Key 尚未启用',
+      response: {
+        ok: false,
+        skipped: true,
+        reason: 'CatsCo 中转自助 Key 尚未启用',
+      },
     };
   }
 
@@ -1680,19 +1719,27 @@ async function setupCatsRelayModelForDesktop(
   });
 
   return {
-    ok: true,
-    protocol: normalizeRelayModelProtocol(selectedModel.provider),
-    provider: selectedModel.provider,
-    apiBase: selectedModel.baseUrl,
-    model: selectedModel.model,
-    modelId: selectedModel.id,
-    reasoningEffort,
-    selectedModel: relayModelPayload(selectedModel),
-    updated: settingsResult.updated,
-    key: sanitizeRelayKeyInfo(ensured.response?.key),
-    createdKey: ensured.created,
-    rotatedKey: ensured.rotated,
-    revealedKey: ensured.revealed,
+    response: {
+      ok: true,
+      protocol: normalizeRelayModelProtocol(selectedModel.provider),
+      provider: selectedModel.provider,
+      apiBase: selectedModel.baseUrl,
+      model: selectedModel.model,
+      modelId: selectedModel.id,
+      reasoningEffort,
+      selectedModel: relayModelPayload(selectedModel),
+      updated: settingsResult.updated,
+      key: sanitizeRelayKeyInfo(ensured.response?.key),
+      createdKey: ensured.created,
+      rotatedKey: ensured.rotated,
+      revealedKey: ensured.revealed,
+    },
+    selectedCatalogRuntime: selectedRelayCatalogRuntime(
+      botId,
+      selectedModel,
+      ensured.plainKey,
+      reasoningEffort,
+    ),
   };
 }
 
@@ -2981,16 +3028,20 @@ export function createApiRouter(
         displayName: me.display_name || me.username || state.displayName || '',
       };
       let relayModelSetup: Record<string, unknown> | undefined;
+      let selectedCatalogRuntime: BotCatalogModelRuntime | undefined;
       if (req.body?.setupRelayModel !== false) {
         try {
-          relayModelSetup = await setupCatsRelayModelForDesktop(
+          const setup = await setupCatsRelayModelForDesktop(
             relayState,
+            botUid,
             req.body?.relayModelId || req.body?.modelId || req.body?.model,
             {
               rotateExisting: req.body?.rotateRelayKey === true || req.body?.rotateExisting === true,
               reasoningEffort: requestedReasoningEffort(req.body?.reasoningEffort),
             },
           );
+          relayModelSetup = setup.response;
+          selectedCatalogRuntime = setup.selectedCatalogRuntime;
         } catch (relayError: any) {
           const message = sanitizeCatsErrorMessage(relayError?.message || relayError);
           const status = relayError?.status || 500;
@@ -3029,6 +3080,7 @@ export function createApiRouter(
         botUsername: bot.username || preferredUsername,
         apiKey,
         bindingSource: 'legacy-setup',
+        selectedCatalogRuntime,
       });
 
       res.json({
@@ -3144,16 +3196,20 @@ export function createApiRouter(
         displayName: me.display_name || me.username || state.displayName || '',
       };
       let relayModelSetup: Record<string, unknown> | undefined;
+      let selectedCatalogRuntime: BotCatalogModelRuntime | undefined;
       if (req.body?.setupRelayModel !== false) {
         try {
-          relayModelSetup = await setupCatsRelayModelForDesktop(
+          const setup = await setupCatsRelayModelForDesktop(
             relayState,
+            botUid,
             req.body?.relayModelId || req.body?.modelId || req.body?.model,
             {
               rotateExisting: req.body?.rotateRelayKey === true || req.body?.rotateExisting === true,
               reasoningEffort: requestedReasoningEffort(req.body?.reasoningEffort),
             },
           );
+          relayModelSetup = setup.response;
+          selectedCatalogRuntime = setup.selectedCatalogRuntime;
         } catch (relayError: any) {
           const message = sanitizeCatsErrorMessage(relayError?.message || relayError);
           const status = relayError?.status || 500;
@@ -3191,6 +3247,7 @@ export function createApiRouter(
         botUsername: targetBot.username || '',
         apiKey,
         bindingSource: 'explicit-bind',
+        selectedCatalogRuntime,
       });
       const botName = String(targetBot.display_name || targetBot.username || 'Bot');
 
@@ -3389,23 +3446,9 @@ export function createApiRouter(
         : writeRelayModelStartupConfig(selectedModel, ensured.plainKey, { reasoningEffort });
       let botDefinitionSync: Record<string, unknown> | undefined;
       if (botId) {
-        definitionService.storeCatalogRuntime({
-          schema: 'xiaoba.bot-catalog-model-runtime.v1',
-          botId,
-          modelId: selectedModel.id,
-          provider: selectedModel.provider,
-          apiBase: selectedModel.baseUrl,
-          apiKey: ensured.plainKey,
-          model: selectedModel.model,
-          contextWindowTokens: selectedModel.contextWindowTokens ?? 200_000,
-          reasoningEffort,
-          openaiApiMode: 'chat_completions',
-          capabilities: selectedModel.capabilities ? {
-            ...(selectedModel.capabilities.vision !== undefined ? { vision: selectedModel.capabilities.vision } : {}),
-            ...(selectedModel.capabilities.tool_calling !== undefined ? { toolCalling: selectedModel.capabilities.tool_calling } : {}),
-            ...(selectedModel.capabilities.streaming !== undefined ? { streaming: selectedModel.capabilities.streaming } : {}),
-          } : undefined,
-        });
+        definitionService.storeCatalogRuntime(
+          selectedRelayCatalogRuntime(botId, selectedModel, ensured.plainKey, reasoningEffort),
+        );
         botDefinitionSync = toBotDefinitionSyncPayload(
           definitionService.publish(botId, { kind: 'catalog', modelId: selectedModel.id }),
         );

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -2260,7 +2260,10 @@ export function createApiRouter(
       res.json(getDashboardSettings({
         runtimeRoot: runtimeDataRoot(),
         ...(activeBotConfig
-          ? { modelConfig: activeBotConfig.config }
+          ? {
+            modelConfig: activeBotConfig.config,
+            modelConfigSource: activeBotConfig.source === 'custom_definition' ? 'custom' as const : 'relay' as const,
+          }
           : { effectiveModelConfig: getModelConfigReadonly() }),
       }));
     } catch (e: any) {

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -2259,7 +2259,9 @@ export function createApiRouter(
       const activeBotConfig = resolveActiveBotLLMConfig({ runtimeRoot: runtimeDataRoot() });
       res.json(getDashboardSettings({
         runtimeRoot: runtimeDataRoot(),
-        ...(activeBotConfig ? { modelConfig: activeBotConfig.config } : {}),
+        ...(activeBotConfig
+          ? { modelConfig: activeBotConfig.config }
+          : { effectiveModelConfig: getModelConfigReadonly() }),
       }));
     } catch (e: any) {
       res.status(500).json({ error: e.message });

--- a/src/dashboard/settings.ts
+++ b/src/dashboard/settings.ts
@@ -72,6 +72,8 @@ export interface DashboardSettingsOptions {
   now?: Date;
   /** The bound bot's resolved Definition config, when one is active. */
   modelConfig?: Pick<ChatConfig, 'provider' | 'apiUrl' | 'apiKey' | 'model' | 'contextWindowTokens' | 'reasoningEffort' | 'openaiApiMode'>;
+  /** The Runtime's effective model when legacy env is not its source of truth. */
+  effectiveModelConfig?: Pick<ChatConfig, 'provider' | 'apiUrl' | 'apiKey' | 'model' | 'contextWindowTokens' | 'reasoningEffort' | 'openaiApiMode'>;
 }
 
 interface NormalizedSettingUpdate {
@@ -305,9 +307,17 @@ function readCustomModelProfile(
 function buildModelStartupSnapshot(
   fileEnv: Record<string, string>,
   env: NodeJS.ProcessEnv,
+  effectiveModelConfig?: NonNullable<DashboardSettingsOptions['effectiveModelConfig']>,
 ): DashboardModelStartupSnapshot {
-  const effective = readModelProfile(EFFECTIVE_MODEL_ENV_KEYS, fileEnv, env);
-  const custom = readCustomModelProfile(fileEnv, env);
+  const storedEffective = readModelProfile(EFFECTIVE_MODEL_ENV_KEYS, fileEnv, env);
+  const runtimeEffective = effectiveModelConfig && modelProfileSnapshot(effectiveModelConfig);
+  const effective = storedEffective.configured ? storedEffective : runtimeEffective ?? storedEffective;
+  const storedCustom = readCustomModelProfile(fileEnv, env);
+  const custom = storedCustom.configured
+    ? storedCustom
+    : effective.configured && !isCatsRelayApiBase(effective.apiBase)
+      ? effective
+      : storedCustom;
   const storedRelay = readModelProfile(RELAY_MODEL_ENV_KEYS, fileEnv, env);
   const requestedSource = firstNonEmpty(fileEnv[MODEL_SOURCE_ENV_KEY], env[MODEL_SOURCE_ENV_KEY]);
   const effectiveIsRelay = isCatsRelayApiBase(effective.apiBase);
@@ -355,10 +365,10 @@ function modelConfigValue(
   }
 }
 
-function modelConfigSnapshot(
+function modelProfileSnapshot(
   config: NonNullable<DashboardSettingsOptions['modelConfig']>,
-): DashboardModelStartupSnapshot {
-  const effective: DashboardModelProfileSnapshot = {
+): DashboardModelProfileSnapshot {
+  return {
     provider: config.provider,
     apiBase: sanitizeUrlSettingValue(config.apiUrl ?? ''),
     model: config.model,
@@ -368,6 +378,12 @@ function modelConfigSnapshot(
     apiKeyPresent: Boolean(config.apiKey),
     configured: Boolean(config.provider && config.apiUrl && config.model && config.apiKey),
   };
+}
+
+function modelConfigSnapshot(
+  config: NonNullable<DashboardSettingsOptions['modelConfig']>,
+): DashboardModelStartupSnapshot {
+  const effective = modelProfileSnapshot(config);
   const relay = isCatsRelayApiBase(config.apiUrl)
     ? { ...effective, reasoningEffort: effective.reasoningEffort === 'default' ? 'high' as const : effective.reasoningEffort }
     : { apiKeyPresent: false, configured: false };
@@ -389,7 +405,7 @@ export function getDashboardSettings(
     generatedAt: (options.now ?? new Date()).toISOString(),
     modelStartup: options.modelConfig
       ? modelConfigSnapshot(options.modelConfig)
-      : buildModelStartupSnapshot(fileEnv, env),
+      : buildModelStartupSnapshot(fileEnv, env, options.effectiveModelConfig),
     fields: DASHBOARD_SETTING_DEFINITIONS.map(definition => {
       const value = isModelSetting(definition.id)
         ? options.modelConfig

--- a/src/dashboard/settings.ts
+++ b/src/dashboard/settings.ts
@@ -72,6 +72,8 @@ export interface DashboardSettingsOptions {
   now?: Date;
   /** The bound bot's resolved Definition config, when one is active. */
   modelConfig?: Pick<ChatConfig, 'provider' | 'apiUrl' | 'apiKey' | 'model' | 'contextWindowTokens' | 'reasoningEffort' | 'openaiApiMode'>;
+  /** Whether the bound bot config came from a custom Definition or catalog runtime. */
+  modelConfigSource?: DashboardModelStartupSnapshot['source'];
   /** The Runtime's effective model when legacy env is not its source of truth. */
   effectiveModelConfig?: Pick<ChatConfig, 'provider' | 'apiUrl' | 'apiKey' | 'model' | 'contextWindowTokens' | 'reasoningEffort' | 'openaiApiMode'>;
 }
@@ -382,15 +384,16 @@ function modelProfileSnapshot(
 
 function modelConfigSnapshot(
   config: NonNullable<DashboardSettingsOptions['modelConfig']>,
+  source: NonNullable<DashboardSettingsOptions['modelConfigSource']>,
 ): DashboardModelStartupSnapshot {
   const effective = modelProfileSnapshot(config);
-  const relay = isCatsRelayApiBase(config.apiUrl)
+  const relay = source === 'relay'
     ? { ...effective, reasoningEffort: effective.reasoningEffort === 'default' ? 'high' as const : effective.reasoningEffort }
     : { apiKeyPresent: false, configured: false };
-  const custom = isCatsRelayApiBase(config.apiUrl)
+  const custom = source === 'relay'
     ? { apiKeyPresent: false, configured: false }
     : effective;
-  return { source: isCatsRelayApiBase(config.apiUrl) ? 'relay' : 'custom', effective, custom, relay };
+  return { source, effective, custom, relay };
 }
 
 export function getDashboardSettings(
@@ -404,7 +407,10 @@ export function getDashboardSettings(
     runtimeRoot,
     generatedAt: (options.now ?? new Date()).toISOString(),
     modelStartup: options.modelConfig
-      ? modelConfigSnapshot(options.modelConfig)
+      ? modelConfigSnapshot(
+        options.modelConfig,
+        options.modelConfigSource ?? (isCatsRelayApiBase(options.modelConfig.apiUrl) ? 'relay' : 'custom'),
+      )
       : buildModelStartupSnapshot(fileEnv, env, options.effectiveModelConfig),
     fields: DASHBOARD_SETTING_DEFINITIONS.map(definition => {
       const value = isModelSetting(definition.id)

--- a/tests/dashboard-catsco-auth-status.test.ts
+++ b/tests/dashboard-catsco-auth-status.test.ts
@@ -9,6 +9,7 @@ import type { Server } from 'http';
 import { createApiRouter } from '../src/dashboard/routes/api';
 import { createCatsCoLocalConfigService } from '../src/catscompany/local-config';
 import { FileBotCatalogModelRuntimeRepository, FileBotDefinitionRepository } from '../src/bot-definition/repository';
+import { resolveActiveBotLLMConfig } from '../src/bot-definition/llm-config-resolver';
 import { BOT_CATALOG_MODEL_RUNTIME_SCHEMA, BOT_DEFINITION_SCHEMA } from '../src/bot-definition/types';
 
 describe('dashboard CatsCo account status', () => {
@@ -884,6 +885,12 @@ describe('dashboard CatsCo account status', () => {
       'CATSCO_USER_NAME=fresh',
       'CATSCO_USER_DISPLAY_NAME=Fresh User',
     ]);
+    const definitionRepository = new FileBotDefinitionRepository({ runtimeRoot: testRoot });
+    definitionRepository.writeCanonical({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: '188',
+      model: { kind: 'catalog', modelId: 'minimax-m2.7' },
+    });
 
     const response = await fetch(`${dashboardBaseUrl}/api/cats/bind-bot`, {
       method: 'POST',
@@ -899,6 +906,8 @@ describe('dashboard CatsCo account status', () => {
     const data = JSON.parse(text) as any;
     const env = dotenv.parse(fs.readFileSync(path.join(testRoot, '.env'), 'utf-8'));
     const runtime = new FileBotCatalogModelRuntimeRepository({ runtimeRoot: testRoot }).read('188');
+    const definition = definitionRepository.readCanonical('188');
+    const resolved = resolveActiveBotLLMConfig({ runtimeRoot: testRoot });
 
     assert.equal(response.status, 200, text);
     assert.equal(data.ok, true);
@@ -907,13 +916,15 @@ describe('dashboard CatsCo account status', () => {
     assert.equal(data.relayModelSetup.reasoningEffort, 'high');
     assert.equal(data.relayModelSetup.createdKey, true);
     assert.equal(text.includes('sk-bf-existing-bot-secret'), false);
-    assert.equal(relayKeyCreated, 1);
     assert.equal(runtime?.modelId, 'minimax-m3');
     assert.equal(runtime?.provider, 'anthropic');
     assert.equal(runtime?.apiBase, 'https://relay.catsco.cc/anthropic');
     assert.equal(runtime?.model, 'MiniMax-M3');
     assert.equal(runtime?.apiKey, 'sk-bf-existing-bot-secret');
     assert.equal(runtime?.reasoningEffort, 'high');
+    assert.deepStrictEqual(definition?.model, { kind: 'catalog', modelId: 'minimax-m3' });
+    assert.equal(resolved?.config.model, 'MiniMax-M3');
+    assert.equal(relayKeyCreated, 1);
     assert.equal(env.CATSCO_BOT_UID, '188');
     assert.equal(env.CATSCO_API_KEY, 'cats-agent-key');
     assert.equal(startCalled, 1);
@@ -968,16 +979,27 @@ describe('dashboard CatsCo account status', () => {
         return res.json({
           base_url: 'https://relay.catsco.cc',
           self_service_enabled: true,
-          models: [{
-            id: 'minimax-m2.7',
-            label: 'MiniMax M2.7',
-            model: 'MiniMax-M2.7',
-            provider: 'anthropic',
-            protocol: 'Anthropic-compatible',
-            base_url: 'https://relay.catsco.cc/anthropic',
-            enabled: true,
-            default: true,
-          }],
+          models: [
+            {
+              id: 'minimax-m2.7',
+              label: 'MiniMax M2.7',
+              model: 'MiniMax-M2.7',
+              provider: 'anthropic',
+              protocol: 'Anthropic-compatible',
+              base_url: 'https://relay.catsco.cc/anthropic',
+              enabled: true,
+              default: true,
+            },
+            {
+              id: 'minimax-m3',
+              label: 'MiniMax M3',
+              model: 'MiniMax-M3',
+              provider: 'anthropic',
+              protocol: 'Anthropic-compatible',
+              base_url: 'https://relay.catsco.cc/anthropic',
+              enabled: true,
+            },
+          ],
         });
       }
       if (req.path === '/api/relay/key' && req.method === 'GET') {
@@ -995,6 +1017,12 @@ describe('dashboard CatsCo account status', () => {
       'CATSCO_USER_UID=88',
       'CATSCO_USER_NAME=fresh',
     ]);
+    const definitionRepository = new FileBotDefinitionRepository({ runtimeRoot: testRoot });
+    definitionRepository.writeCanonical({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: '188',
+      model: { kind: 'catalog', modelId: 'minimax-m2.7' },
+    });
 
     const response = await fetch(`${dashboardBaseUrl}/api/cats/setup`, {
       method: 'POST',
@@ -1002,12 +1030,20 @@ describe('dashboard CatsCo account status', () => {
       body: JSON.stringify({
         httpBaseUrl: catsBaseUrl,
         serverUrl: 'wss://app.catsco.cc/v0/channels',
+        relayModelId: 'minimax-m3',
       }),
     });
     const text = await response.text();
     const data = JSON.parse(text) as any;
+    const runtime = new FileBotCatalogModelRuntimeRepository({ runtimeRoot: testRoot }).read('188');
+    const definition = definitionRepository.readCanonical('188');
+    const resolved = resolveActiveBotLLMConfig({ runtimeRoot: testRoot });
 
     assert.equal(response.status, 200, text);
+    assert.equal(data.relayModelSetup.modelId, 'minimax-m3');
+    assert.equal(runtime?.modelId, 'minimax-m3');
+    assert.deepStrictEqual(definition?.model, { kind: 'catalog', modelId: 'minimax-m3' });
+    assert.equal(resolved?.config.model, 'MiniMax-M3');
     assert.equal(data.connectorRestarted, true);
     assert.equal(data.connectorStarted, false);
     assert.equal(restartCalled, 1);

--- a/tests/dashboard-productization-html.test.ts
+++ b/tests/dashboard-productization-html.test.ts
@@ -138,6 +138,16 @@ test('CatsCo Chat page is driven by readiness state instead of loose controls', 
   assert.match(dashboardHtml, /let pendingStartupSource = ''/);
   assert.match(dashboardHtml, /let pendingRelayReasoningEffort = ''/);
   assert.match(dashboardHtml, /function relayModelIdForSetup\(\)/);
+  assert.match(
+    dashboardHtml,
+    /id:'minimax-m3'[^\n]*default:true/,
+    'Dashboard fallback catalog must select the product default MiniMax M3 before the authenticated catalog loads',
+  );
+  assert.doesNotMatch(
+    dashboardHtml,
+    /id:'minimax-m2\.7'[^\n]*default:true/,
+    'The legacy first catalog entry must not silently become the Dashboard default',
+  );
   assert.match(dashboardHtml, /function relayReasoningEffortForSetup\(\)/);
   assert.match(dashboardHtml, /登录后会自动接入/);
   assert.match(dashboardHtml, /function buildCatsChatStage\(\)/);

--- a/tests/dashboard-settings-api.test.ts
+++ b/tests/dashboard-settings-api.test.ts
@@ -65,6 +65,7 @@ describe('dashboard typed settings API', () => {
     'CATSCOMPANY_BODY_ID',
     'CATSCOMPANY_INSTALLATION_ID',
     'XIAOBA_USER_DATA_DIR',
+    'XIAOBA_CONFIG_PATH',
   ];
   const originalEnv: Record<string, string | undefined> = {};
 
@@ -212,6 +213,31 @@ describe('dashboard typed settings API', () => {
     assert.deepStrictEqual(openaiApiMode.options, ['chat_completions', 'responses']);
     assert.equal(data.modelStartup.effective.openaiApiMode, 'responses');
     assert.equal(data.modelStartup.custom.openaiApiMode, 'responses');
+  });
+
+  test('GET /settings reports the effective ConfigManager custom model when legacy env is empty', async () => {
+    const configPath = path.join(testRoot, 'runtime-config.json');
+    fs.writeFileSync(configPath, JSON.stringify({
+      provider: 'openai',
+      apiUrl: 'https://model.example.test/v1',
+      apiKey: 'sk-effective-custom-secret',
+      model: 'gpt-5.6-sol',
+      contextWindowTokens: 256_000,
+      openaiApiMode: 'responses',
+    }));
+    process.env.XIAOBA_CONFIG_PATH = configPath;
+
+    const response = await fetch(`${baseUrl}/api/settings`);
+    const text = await response.text();
+    const settings = JSON.parse(text) as any;
+
+    assert.equal(response.status, 200, text);
+    assert.equal(settings.modelStartup.source, 'custom');
+    assert.equal(settings.modelStartup.effective.configured, true);
+    assert.equal(settings.modelStartup.effective.model, 'gpt-5.6-sol');
+    assert.equal(settings.modelStartup.custom.configured, true);
+    assert.equal(settings.modelStartup.custom.model, 'gpt-5.6-sol');
+    assert.equal(text.includes('sk-effective-custom-secret'), false);
   });
 
   test('GET /settings carries legacy relay reasoning effort into startup snapshot', async () => {

--- a/tests/dashboard-settings-api.test.ts
+++ b/tests/dashboard-settings-api.test.ts
@@ -147,6 +147,44 @@ describe('dashboard typed settings API', () => {
     assert.equal(text.includes('abc'), false);
   });
 
+  test('GET /settings preserves a bound custom model served through the relay gateway', async () => {
+    createCatsCoLocalConfigService({ runtimeRoot: testRoot }).save({
+      version: 1,
+      currentBot: {
+        uid: 'custom-relay-gateway-bot',
+        apiKey: 'catsco-bot-api-key',
+        boundByUserUid: 'user-custom-relay-gateway',
+        bindingSource: 'test',
+      },
+      device: {
+        deviceId: 'device-custom-relay-gateway',
+        bodyId: 'body-custom-relay-gateway',
+        installationId: 'install-custom-relay-gateway',
+      },
+    });
+    createBotDefinitionSyncService({ runtimeRoot: testRoot }).publish('custom-relay-gateway-bot', {
+      kind: 'custom',
+      protocol: 'openai-responses',
+      apiBase: 'https://relay.catsco.cc/v1',
+      model: 'gpt-5.6-sol',
+      apiKey: 'sk-custom-relay-gateway',
+      contextWindowTokens: 256_000,
+      reasoningEffort: 'default',
+    });
+
+    const response = await fetch(`${baseUrl}/api/settings`);
+    const text = await response.text();
+    const data = JSON.parse(text) as any;
+
+    assert.equal(response.status, 200, text);
+    assert.equal(data.modelStartup.source, 'custom');
+    assert.equal(data.modelStartup.effective.model, 'gpt-5.6-sol');
+    assert.equal(data.modelStartup.custom.configured, true);
+    assert.equal(data.modelStartup.custom.model, 'gpt-5.6-sol');
+    assert.equal(data.modelStartup.relay.configured, false);
+    assert.equal(text.includes('sk-custom-relay-gateway'), false);
+  });
+
   test('PUT /cats/config/preferences persists close button behavior', async () => {
     const initialResponse = await fetch(`${baseUrl}/api/cats/config`);
     const initial = await initialResponse.json() as any;


### PR DESCRIPTION
## Summary

This draft fixes the complete model-selection consistency path relative to `main`:

- Preserve an explicitly selected relay catalog runtime during bot binding and setup instead of allowing an older cached BotDefinition to overwrite it.
- Default the Dashboard relay catalog fallback to MiniMax M3 instead of MiniMax M2.7.
- Report the effective runtime model when legacy environment fields are incomplete.
- Preserve the authoritative BotDefinition source so a custom model behind `relay.catsco.cc` is not misclassified as a relay catalog model.

## Root cause

The issue had two independent overwrite and misclassification paths:

1. During bot binding, the selected relay model was materialized first. `prepareBoundBotDefinition` then treated an existing cached Definition as authoritative and rematerialized its older model.
2. For custom models, `GET /api/settings` discarded whether the resolved config came from a custom Definition or a catalog runtime. Dashboard inferred the source from the API hostname. A custom `gpt-5.6-sol` Definition using `relay.catsco.cc` was therefore mislabeled as relay. Because that model was not in the relay catalog, the UI displayed the default MiniMax entry even though the connector continued calling `gpt-5.6-sol`.

The fix uses the Definition/runtime source as the authority:

- `custom_definition` → `custom`
- `catalog_runtime` → `relay`

## Changes relative to main

- `src/bot-definition/activation.ts`
  - Carry the explicitly selected catalog runtime through bot binding.
  - Publish one authoritative catalog Definition without rematerializing an old selection.
- `src/dashboard/routes/api.ts`
  - Pass the resolved model source into typed Dashboard settings.
  - Share selected relay runtime materialization across setup, bind, and direct apply paths.
- `src/dashboard/settings.ts`
  - Expose the effective ConfigManager model when legacy environment fields are empty.
  - Build custom/relay snapshots from the authoritative source instead of hostname inference.
- `dashboard/index.html`
  - Use MiniMax M3 for the unauthenticated fallback catalog.
- Add regression coverage for stale M2.7 Definitions, custom models behind the relay gateway, effective runtime display, relay-key reuse, connector startup, and secret sanitization.

## Verification

- 90/90 relevant tests passed:
  - `tests/dashboard-catsco-auth-status.test.ts`
  - `tests/dashboard-settings-api.test.ts`
  - `tests/dashboard-productization-html.test.ts`
  - `tests/bot-definition-activation.test.ts`
  - `tests/bot-definition-local-repository.test.ts`
- TypeScript build passed.
- `git diff --check` passed.
- Live localhost verification returned `source=custom`, `model=gpt-5.6-sol`, and `relayConfigured=false` after applying the custom model and restarting the connector.

## Relationship to existing PRs

- This includes the source-classification fix proposed independently in #219, while broadening the draft to cover the complete selection, persistence, and display chain.
- #217 and #218 address connector startup isolation and macOS path handling; they do not by themselves prevent this model-selection fallback.
