### PR TITLE
修复自定义模型保存后未立即激活 Connector

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -8869,7 +8869,7 @@
               <button class="btn btn-primary" onclick="saveCustomModelSettings()">保存自定义模型</button>
               <span class="config-saved" id="model-source-saved">已保存</span>
             </div>
-            <div id="model-source-status" style="color:var(--text2);font-size:13px">凭证仅保存到本地 .env；自定义模型上下文会写入本地配置，新 session 或下一次启动 connector 后生效。</div>
+            <div id="model-source-status" style="color:var(--text2);font-size:13px">自定义模型会保存到当前 bot 的本地 Definition 缓存，并立即重启或启动 connector 生效。</div>
           </div>
         </details>
       </div>`;
@@ -9306,6 +9306,7 @@
 
     async function saveCustomModelSettings(options){
       const auto=Boolean(options&&options.auto);
+      if(!auto)clearTimeout(customModelAutoSaveTimer);
       let built;
       try{
         built=buildCustomModelSettingsPayload();
@@ -9323,31 +9324,41 @@
       }
       const signature=customModelPayloadSignature(payload);
       if(auto && signature===customModelAutoSaveLastSignature && secretUpdate.action==='keep'){
-        setModelSourceStatus('已保存。新 session 或下一次启动 connector 后生效。','success');
+        setModelSourceStatus('已保存并已提交启用。','success');
         return;
       }
-      if(auto && customModelAutoSaveInFlight){
+      if(customModelAutoSaveInFlight){
         customModelAutoSaveQueued=true;
+        if(!auto)setModelSourceStatus('正在完成上一项模型配置，随后会启用当前配置...','muted');
         return;
       }
       const sensitive=secretUpdate.action!=='keep';
       const message=sensitive
-        ? '保存并启用自定义模型？访问凭证会写入本地 .env，仅用于本机 runtime。若 CatsCo agent 正在运行，会请求重启以使用新配置。'
+        ? '保存并启用自定义模型？访问凭证会写入当前 bot 的本地 Definition 缓存。若 CatsCo agent 正在运行，会请求重启以使用新配置。'
         : '保存并启用自定义模型？若 CatsCo agent 正在运行，会请求重启以使用新配置。';
       if(!auto && !confirm(message))return;
       try{
         customModelAutoSaveInFlight=true;
         setModelSourceStatus(auto?'自动保存中...':'保存中...','muted');
-        const requestPayload={...payload,restartConnector:!auto};
+        const requestPayload={...payload,activateConnector:true};
         const r=await fetch(API+'/api/settings',{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify(requestPayload)});
         const d=await r.json();
         if(!r.ok||d.error)throw new Error(d.error||'保存失败');
         customModelAutoSaveLastSignature=signature;
         updateReasoningEffortSnapshots(payload.settings['model.reasoningEffort']||'default','custom');
-        const appliedMessage=!auto&&d.connectorRestarted
-          ? '已保存，并已请求重启 CatsCo agent 使用新配置。'
-          : (auto?'已自动保存自定义配置。':'已保存自定义配置。')+'配置完整时会切换为自定义启动。';
-        setModelSourceStatus(appliedMessage,'success');
+        const activationError=d.connectorStartBlocked
+          ? '模型配置已保存，但 connector 启动检查未通过。请查看 CatsCo 连接检查项。'
+          : d.restartError||d.startError
+            ? '模型配置已保存，但 connector 激活失败：'+(d.restartError||d.startError)
+            : '';
+        const appliedMessage=activationError||(
+          d.connectorRestarted
+            ? '已保存自定义模型，并已请求重启 CatsCo agent 使用新配置。'
+            : d.connectorStarted
+              ? '已保存自定义模型，并已启动 CatsCo agent 使用新配置。'
+              : '已保存自定义模型。connector 状态未改变。'
+        );
+        setModelSourceStatus(appliedMessage,activationError?'error':'success');
         const secretInput=document.getElementById('model-secret-setting');
         const clearInput=document.getElementById('model-secret-clear-setting');
         if(secretInput && secretUpdate.action==='replace'){
@@ -9360,7 +9371,7 @@
         if(!auto){
           setModelSourceStatus('已保存，正在刷新启动状态...','muted');
           await Promise.all([fetchDashboardSettings(),fetchStatus(),fetchReadiness(),fetchCatsStatus()]);
-          setModelSourceStatus(d.connectorRestarted?'已保存，并已请求重启 CatsCo agent 使用自定义模型。':'已保存自定义配置。配置完整时会切换为自定义启动。','success');
+          setModelSourceStatus(appliedMessage,activationError?'error':'success');
         }
       }catch(e){
         setModelSourceStatus('保存失败：'+formatDashboardApiError(e,'/api/settings'),'error');
@@ -9898,9 +9909,13 @@
       setCatsAction(message);
       setTimeout(async()=>{
         try{
-          await setupCatsBot({forceLegacySetup:true, automatic:true});
+          if(reason==='binding'){
+            await setupCatsBot({forceLegacySetup:true, automatic:true});
+          }else{
+            await startCurrentCatsConnector({automatic:true});
+          }
         }catch(e){
-          setCatsAction('自动启动失败：'+formatDashboardApiError(e,'/api/cats/setup'), true);
+          setCatsAction('自动启动失败：'+formatDashboardApiError(e,reason==='binding'?'/api/cats/setup':'/api/cats/connector/start'), true);
         }finally{
           setCatsAutoStartBusy(false);
         }
@@ -10222,7 +10237,36 @@
         setCatsAction('CatsCompany connector 已在运行。');
         return;
       }
-      return bindCatsBot(catsState.botUid, catsState.botName || catsState.bot?.name || catsState.botUid, document.getElementById('cats-setup-btn'), { confirm: false });
+      return startCurrentCatsConnector();
+    }
+
+    async function startCurrentCatsConnector(options={}) {
+      if(catsSetupInFlight){
+        setCatsAction('正在配置 CatsCo 连接，请稍候...');
+        return;
+      }
+      if(relayModelApplyInFlight){
+        setCatsAction('模型切换正在进行，请稍候...');
+        return;
+      }
+      setCatsSetupBusy(true);
+      setCatsStatusMutationBusy(true);
+      invalidateCatsStatusRequests();
+      setCatsAction('正在按当前 agent 配置启动 CatsCompany connector...');
+      try{
+        const data=await parseCatsResponse(await fetch(API+'/api/cats/connector/start',{method:'POST'}));
+        const stage=await refreshCatsChatAfterMutation({focusInput:options.automatic!==true});
+        if(stage.key==='ready'){
+          setCatsAction(data.connectorStarted?'CatsCompany connector 已启动。':'CatsCompany connector 已在运行。');
+          if(options.automatic!==true)pulsePetState('success','已连接',1800);
+        }else{
+          setCatsAction(stage.copy||'connector 已启动，请按当前检查项继续。',stage.status==='blocked');
+        }
+        return data;
+      }finally{
+        setCatsStatusMutationBusy(false);
+        setCatsSetupBusy(false);
+      }
     }
 
     async function sendCatsCode(){

--- a/src/bot-definition/service.ts
+++ b/src/bot-definition/service.ts
@@ -335,8 +335,8 @@ export class BotDefinitionSyncService {
       botId,
       model: normalizeBotModelDefinition(model),
     };
-    this.repository.writeCanonical(definition);
     this.repository.writeCache(definition);
+    this.repository.writeCanonical(definition);
     this.clearLegacyModelConfigurationWhenReady(definition);
     return {
       botId,

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -51,6 +51,7 @@ import {
 } from '../tools/tool-target-context';
 import { formatPathForLog } from '../utils/log-redaction';
 import { resolveCatsDeviceModelStatus } from './model-status';
+import { resolveActiveBotLLMConfig } from '../bot-definition/llm-config-resolver';
 import {
   buildCatsCoAttachmentCachePath,
   scheduleCatsCoAttachmentCacheCleanup,
@@ -496,7 +497,13 @@ export class CatsCompanyBot {
     const config = typeof getConfig === 'function'
       ? getConfig.call(this.agentServices.aiService)
       : undefined;
-    return resolveCatsDeviceModelStatus({ config });
+    const activeBotConfig = resolveActiveBotLLMConfig();
+    const source = activeBotConfig?.source === 'custom_definition'
+      ? 'custom' as const
+      : activeBotConfig?.source === 'catalog_runtime'
+        ? 'relay' as const
+        : undefined;
+    return resolveCatsDeviceModelStatus({ config, source });
   }
 
   private startDeviceRegistrationRefresh(): void {

--- a/src/catscompany/model-status.ts
+++ b/src/catscompany/model-status.ts
@@ -8,6 +8,7 @@ export interface CatsDeviceModelStatus {
 
 interface ModelStatusOptions {
   env?: NodeJS.ProcessEnv;
+  source?: 'relay' | 'custom';
   config?: {
     provider?: string;
     apiUrl?: string;
@@ -41,6 +42,17 @@ export function resolveCatsDeviceModelStatus(options: ModelStatusOptions = {}): 
   const apiKey = firstNonEmpty(config.apiKey, env.GAUZ_LLM_API_KEY);
   const model = firstNonEmpty(config.model, env.GAUZ_LLM_MODEL);
   const now = options.now || Date.now;
+
+  if (options.source === 'relay') {
+    if (!model) return undefined;
+    return { source: 'relay', model, updated_at: now() };
+  }
+
+  if (options.source === 'custom') {
+    const hasCustomSignal = Boolean(model || apiBase || apiKey);
+    if (!hasCustomSignal) return undefined;
+    return { source: 'custom', model: model || '鑷畾涔夋ā鍨?', updated_at: now() };
+  }
 
   if (isCatsRelayApiBase(apiBase)) {
     if (!model) return undefined;

--- a/src/catscompany/model-status.ts
+++ b/src/catscompany/model-status.ts
@@ -51,7 +51,7 @@ export function resolveCatsDeviceModelStatus(options: ModelStatusOptions = {}): 
   if (options.source === 'custom') {
     const hasCustomSignal = Boolean(model || apiBase || apiKey);
     if (!hasCustomSignal) return undefined;
-    return { source: 'custom', model: model || '鑷畾涔夋ā鍨?', updated_at: now() };
+    return { source: 'custom', model: model || '自定义模型', updated_at: now() };
   }
 
   if (isCatsRelayApiBase(apiBase)) {

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -2212,7 +2212,10 @@ export function createApiRouter(
       const activeBotConfig = resolveActiveBotLLMConfig({ runtimeRoot: runtimeDataRoot() });
       res.json(getDashboardSettings({
         runtimeRoot: runtimeDataRoot(),
-        ...(activeBotConfig ? { modelConfig: activeBotConfig.config } : {}),
+        ...(activeBotConfig ? {
+          modelConfig: activeBotConfig.config,
+          modelConfigSource: activeBotConfig.source,
+        } : {}),
       }));
     } catch (e: any) {
       res.status(500).json({ error: e.message });
@@ -2240,14 +2243,21 @@ export function createApiRouter(
       const legacyDefinitionSync = changedModelSettings && !boundBot
         ? publishCurrentBotDefinitionPayload()
         : undefined;
-      const restartInfo = req.body?.restartConnector === true && changedModelSettings
-        ? activateCatsCompanyConnector(serviceManager)
+      const shouldActivateBoundModel = Boolean(boundBot && changedModelSettings);
+      const restartInfo = changedModelSettings
+        && (shouldActivateBoundModel || req.body?.restartConnector === true || req.body?.activateConnector === true)
+        ? activateCatsCompanyConnector(serviceManager, {
+          startIfStopped: shouldActivateBoundModel || req.body?.activateConnector === true,
+        })
         : { wasRunning: false, restartRequested: false, startRequested: false, startBlocked: false };
       res.json({
         ...result,
         botDefinitionSync: botDefinitionSync ?? legacyDefinitionSync,
         connectorRestarted: restartInfo.restartRequested,
+        connectorStarted: restartInfo.startRequested,
+        connectorStartBlocked: restartInfo.startBlocked,
         restartError: restartInfo.restartError ? sanitizeCatsErrorMessage(restartInfo.restartError) : undefined,
+        startError: restartInfo.startError ? sanitizeCatsErrorMessage(restartInfo.startError) : undefined,
       });
     } catch (e: any) {
       res.status(400).json({ error: e.message });
@@ -2921,6 +2931,45 @@ export function createApiRouter(
     } catch (e: any) {
       const payload = catsErrorResponse(e);
       res.status(payload.status).json(payload.body);
+    }
+  });
+
+  router.post('/cats/connector/start', async (_req, res) => {
+    try {
+      const botId = currentBoundBotId();
+      if (!botId) {
+        return res.status(409).json({ error: 'No CatsCo bot is bound on this device' });
+      }
+      const preparedBot = await prepareBoundBotDefinition({
+        runtimeRoot: runtimeDataRoot(),
+        botId,
+      });
+      const result = await startCatsCompanyConnectorIfReady(serviceManager);
+      if (!result.service) {
+        return res.status(409).json({ error: 'CatsCompany connector service is unavailable' });
+      }
+      if (result.preflight?.status === 'blocked') {
+        return res.status(400).json({
+          error: 'CatsCo connector preflight blocked',
+          preflight: {
+            status: result.preflight.status,
+            blockingChecks: result.preflight.blockingChecks,
+            warningChecks: result.preflight.warningChecks,
+          },
+        });
+      }
+      return res.json({
+        ok: true,
+        botUid: botId,
+        service: result.service,
+        preflight: result.preflight,
+        connectorStarted: result.connectorStarted,
+        connectorAlreadyRunning: result.service.status === 'running' && !result.connectorStarted,
+        botDefinitionSync: toBotDefinitionSyncPayload(preparedBot?.sync),
+      });
+    } catch (e: any) {
+      const payload = catsErrorResponse(e);
+      return res.status(payload.status).json(payload.body);
     }
   });
 

--- a/src/dashboard/settings.ts
+++ b/src/dashboard/settings.ts
@@ -72,6 +72,8 @@ export interface DashboardSettingsOptions {
   now?: Date;
   /** The bound bot's resolved Definition config, when one is active. */
   modelConfig?: Pick<ChatConfig, 'provider' | 'apiUrl' | 'apiKey' | 'model' | 'contextWindowTokens' | 'reasoningEffort' | 'openaiApiMode'>;
+  /** Explicit source from the bound bot Definition. URL inference is legacy fallback only. */
+  modelConfigSource?: 'custom_definition' | 'catalog_runtime';
 }
 
 interface NormalizedSettingUpdate {
@@ -357,6 +359,7 @@ function modelConfigValue(
 
 function modelConfigSnapshot(
   config: NonNullable<DashboardSettingsOptions['modelConfig']>,
+  source?: DashboardSettingsOptions['modelConfigSource'],
 ): DashboardModelStartupSnapshot {
   const effective: DashboardModelProfileSnapshot = {
     provider: config.provider,
@@ -368,13 +371,16 @@ function modelConfigSnapshot(
     apiKeyPresent: Boolean(config.apiKey),
     configured: Boolean(config.provider && config.apiUrl && config.model && config.apiKey),
   };
-  const relay = isCatsRelayApiBase(config.apiUrl)
+  const isRelay = source
+    ? source === 'catalog_runtime'
+    : isCatsRelayApiBase(config.apiUrl);
+  const relay = isRelay
     ? { ...effective, reasoningEffort: effective.reasoningEffort === 'default' ? 'high' as const : effective.reasoningEffort }
     : { apiKeyPresent: false, configured: false };
-  const custom = isCatsRelayApiBase(config.apiUrl)
+  const custom = isRelay
     ? { apiKeyPresent: false, configured: false }
     : effective;
-  return { source: isCatsRelayApiBase(config.apiUrl) ? 'relay' : 'custom', effective, custom, relay };
+  return { source: isRelay ? 'relay' : 'custom', effective, custom, relay };
 }
 
 export function getDashboardSettings(
@@ -388,7 +394,7 @@ export function getDashboardSettings(
     runtimeRoot,
     generatedAt: (options.now ?? new Date()).toISOString(),
     modelStartup: options.modelConfig
-      ? modelConfigSnapshot(options.modelConfig)
+      ? modelConfigSnapshot(options.modelConfig, options.modelConfigSource)
       : buildModelStartupSnapshot(fileEnv, env),
     fields: DASHBOARD_SETTING_DEFINITIONS.map(definition => {
       const value = isModelSetting(definition.id)

--- a/tests/catscompany-model-status.test.ts
+++ b/tests/catscompany-model-status.test.ts
@@ -54,6 +54,25 @@ test('uses effective runtime config before stale env values', () => {
   });
 });
 
+test('explicit custom Definition source wins over a relay gateway URL', () => {
+  const status = resolveCatsDeviceModelStatus({
+    source: 'custom',
+    env: {} as NodeJS.ProcessEnv,
+    config: {
+      apiUrl: 'https://relay.catsco.cc/v1',
+      apiKey: 'sk-custom-secret',
+      model: 'gpt-5.6-sol',
+    },
+    now: () => 1782790000008,
+  });
+
+  assert.deepEqual(status, {
+    source: 'custom',
+    model: 'gpt-5.6-sol',
+    updated_at: 1782790000008,
+  });
+});
+
 test('does not let stale relay source override a custom endpoint', () => {
   const status = resolveCatsDeviceModelStatus({
     env: {

--- a/tests/catscompany-model-status.test.ts
+++ b/tests/catscompany-model-status.test.ts
@@ -73,6 +73,24 @@ test('explicit custom Definition source wins over a relay gateway URL', () => {
   });
 });
 
+test('explicit custom Definition source uses a readable fallback label', () => {
+  const status = resolveCatsDeviceModelStatus({
+    source: 'custom',
+    env: {} as NodeJS.ProcessEnv,
+    config: {
+      apiUrl: 'https://example.com/v1',
+      apiKey: 'sk-custom-secret',
+    },
+    now: () => 1782790000009,
+  });
+
+  assert.deepEqual(status, {
+    source: 'custom',
+    model: '自定义模型',
+    updated_at: 1782790000009,
+  });
+});
+
 test('does not let stale relay source override a custom endpoint', () => {
   const status = resolveCatsDeviceModelStatus({
     env: {

--- a/tests/dashboard-catsco-auth-status.test.ts
+++ b/tests/dashboard-catsco-auth-status.test.ts
@@ -134,6 +134,166 @@ describe('dashboard CatsCo account status', () => {
     assert.equal(data.topicId, '');
   });
 
+  test('PUT /settings immediately restarts a running connector after a bound custom model update', async () => {
+    if (dashboardServer) {
+      await close(dashboardServer);
+      dashboardServer = undefined;
+    }
+
+    createCatsCoLocalConfigService({ runtimeRoot: testRoot }).save({
+      version: 1,
+      currentBot: {
+        uid: '117',
+        name: 'Friday',
+        apiKey: 'cats-agent-key',
+        boundByUserUid: '116',
+        bindingSource: 'test',
+      },
+      device: {
+        deviceId: 'device-model-switch',
+        bodyId: 'body-model-switch',
+        installationId: 'install-model-switch',
+      },
+    });
+
+    const service = {
+      name: 'catscompany',
+      label: 'CatsCo agent',
+      command: process.execPath,
+      args: [],
+      status: 'running',
+    };
+    let restartCalled = 0;
+    const app = express();
+    app.use(express.json());
+    app.use('/api', createApiRouter({
+      getAll: () => [service],
+      getService: (name: string) => (name === 'catscompany' ? service : undefined),
+      restart: (name: string) => {
+        assert.equal(name, 'catscompany');
+        restartCalled += 1;
+        return service;
+      },
+    } as any));
+    dashboardServer = await listen(app);
+    dashboardBaseUrl = serverBaseUrl(dashboardServer);
+
+    const response = await fetch(`${dashboardBaseUrl}/api/settings`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        settings: {
+          'model.provider': 'openai',
+          'model.openaiApiMode': 'responses',
+          'model.apiBase': 'https://relay.catsco.cc/v1',
+          'model.model': 'gpt-5.6-sol',
+          'model.contextWindowTokens': '256000',
+          'model.apiKey': { action: 'replace', value: 'sk-custom-model-secret' },
+        },
+      }),
+    });
+    const text = await response.text();
+    const data = JSON.parse(text) as any;
+    const definition = new FileBotDefinitionRepository({ runtimeRoot: testRoot }).readCache('117');
+
+    assert.equal(response.status, 200, text);
+    assert.equal(data.connectorRestarted, true);
+    assert.equal(data.connectorStarted, false);
+    assert.equal(data.connectorStartBlocked, false);
+    assert.equal(restartCalled, 1);
+    assert.equal(definition?.model.kind, 'custom');
+    assert.equal(definition?.model.model, 'gpt-5.6-sol');
+    assert.equal(text.includes('sk-custom-model-secret'), false);
+  });
+
+  test('POST /cats/connector/start requires an existing bot binding', async () => {
+    const response = await fetch(`${dashboardBaseUrl}/api/cats/connector/start`, {
+      method: 'POST',
+    });
+    const data = await response.json() as any;
+
+    assert.equal(response.status, 409);
+    assert.match(data.error, /No CatsCo bot is bound/);
+  });
+
+  test('POST /cats/connector/start starts the bound Definition without legacy model setup', async () => {
+    createCatsCoLocalConfigService({ runtimeRoot: testRoot }).save({
+      version: 1,
+      endpoints: {
+        httpBaseUrl: 'https://app.catsco.cc',
+        serverUrl: 'wss://app.catsco.cc/v0/channels',
+      },
+      account: {
+        token: 'user-token',
+        uid: '38',
+      },
+      currentBot: {
+        uid: '320',
+        name: 'Friday',
+        apiKey: 'cats_svc_test',
+        boundByUserUid: '38',
+        bindingSource: 'test',
+      },
+      device: {
+        deviceId: 'device-connector-start',
+        bodyId: 'body-connector-start',
+        installationId: 'install-connector-start',
+      },
+    });
+    new FileBotDefinitionRepository({ runtimeRoot: testRoot }).writeCanonical({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: '320',
+      model: {
+        kind: 'custom',
+        protocol: 'openai-responses',
+        apiBase: 'https://relay.catsco.cc/v1',
+        model: 'gpt-5.6-sol',
+        apiKey: 'sk-custom-secret',
+        contextWindowTokens: 256_000,
+      },
+    });
+
+    const service = {
+      name: 'catscompany',
+      label: 'CatsCompany',
+      status: 'stopped',
+      command: process.execPath,
+    };
+    let startCalled = 0;
+    const app = express();
+    app.use(express.json());
+    app.use('/api', createApiRouter({
+      getAll: () => [service],
+      getService: (name: string) => name === 'catscompany' ? service : undefined,
+      start: (name: string) => {
+        assert.equal(name, 'catscompany');
+        startCalled += 1;
+        service.status = 'running';
+        return service;
+      },
+    } as any));
+    const localServer = await listen(app);
+
+    try {
+      const response = await fetch(`${serverBaseUrl(localServer)}/api/cats/connector/start`, {
+        method: 'POST',
+      });
+      const text = await response.text();
+      const data = JSON.parse(text) as any;
+      const definition = new FileBotDefinitionRepository({ runtimeRoot: testRoot }).readCanonical('320');
+
+      assert.equal(response.status, 200, text);
+      assert.equal(data.ok, true);
+      assert.equal(data.connectorStarted, true);
+      assert.equal(startCalled, 1);
+      assert.equal(definition?.model.kind, 'custom');
+      assert.equal(definition?.model.kind === 'custom' ? definition.model.model : '', 'gpt-5.6-sol');
+      assert.equal(fs.existsSync(path.join(testRoot, '.env')), false);
+    } finally {
+      await close(localServer);
+    }
+  });
+
   test('GET /cats/status validates the shared CatsCompany account token', async () => {
     await startCatsServer((req, res) => {
       assert.equal(req.header('authorization'), 'Bearer valid-user-token');

--- a/tests/dashboard-productization-html.test.ts
+++ b/tests/dashboard-productization-html.test.ts
@@ -171,7 +171,10 @@ test('CatsCo Chat page is driven by readiness state instead of loose controls', 
   assert.match(dashboardHtml, /function maybeAutoStartCats\(stage\)/);
   assert.match(dashboardHtml, /function catsAutoStartReason\(stage\)/);
   assert.match(dashboardHtml, /function catsAutoStartReadinessSafe\(reason\)/);
+  assert.match(dashboardHtml, /if\(reason==='binding'\)\{/);
   assert.match(dashboardHtml, /setupCatsBot\(\{forceLegacySetup:true, automatic:true\}\)/);
+  assert.match(dashboardHtml, /startCurrentCatsConnector\(\{automatic:true\}\)/);
+  assert.match(dashboardHtml, /\/api\/cats\/connector\/start/);
   assert.match(dashboardHtml, /maybeAutoStartCats\(stage\)/);
   assert.match(dashboardHtml, /function focusCatsMessageInputSoon\(\)/);
   assert.match(dashboardHtml, /function invalidateRelayModelConfigRequests\(\)/);
@@ -270,7 +273,9 @@ test('custom model save refreshes simplified state before Chat remains locked', 
     dashboardHtml,
     /fetchDashboardSettings\(\),fetchStatus\(\),fetchRuntimeConfig\(\),fetchReadiness\(\),fetchCatsStatus\(\)/,
   );
-  assert.match(dashboardHtml, /已保存。新 session 或下一次启动 connector 后生效。/);
+  assert.match(dashboardHtml, /const requestPayload=\{\.\.\.payload,activateConnector:true\}/);
+  assert.match(dashboardHtml, /已保存并已提交启用。/);
+  assert.doesNotMatch(dashboardHtml, /restartConnector:!auto/);
 });
 
 test('CatsCo Chat setup refreshes readiness before unlocking the composer', () => {
@@ -292,6 +297,16 @@ test('CatsCo Chat setup refreshes readiness before unlocking the composer', () =
   assert.match(setupBlock, /setCatsSetupBusy\(false\)/);
   assert.match(setupBlock, /const stage=await refreshCatsChatAfterMutation\(\{focusInput:true\}\)/);
   assert.match(setupBlock, /await loadCatsMessages\(true, \{reset:true, forceBottom:true\}\)/);
+});
+
+test('bound CatsCo connector recovery does not re-enter legacy setup or rebind the bot', () => {
+  const handler = dashboardHtml.match(
+    /async function handleCatsSetupAction\(\) \{[\s\S]*?async function sendCatsCode/,
+  )?.[0] || '';
+  assert.match(handler, /return startCurrentCatsConnector\(\)/);
+  assert.match(handler, /fetch\(API\+'\/api\/cats\/connector\/start',\{method:'POST'\}\)/);
+  assert.doesNotMatch(handler, /return bindCatsBot\(catsState\.botUid/);
+  assert.doesNotMatch(handler, /fetch\(API\+'\/api\/cats\/setup'/);
 });
 
 test('CatsCo bot binding carries selected relay model setup', () => {

--- a/tests/dashboard-settings-api.test.ts
+++ b/tests/dashboard-settings-api.test.ts
@@ -329,8 +329,46 @@ describe('dashboard typed settings API', () => {
     assert.equal(data.botDefinitionSync.direction, 'local_to_simulated_cloud');
     assert.equal(data.botDefinitionSync.model.kind, 'custom');
     assert.equal(data.botDefinitionSync.model.model, 'gpt-portable');
+    assert.equal(data.connectorRestarted, false);
+    assert.equal(data.connectorStarted, false);
     assert.equal(text.includes('sk-portable-secret'), false);
     assert.equal(definition.model.apiKey, 'sk-portable-secret');
+  });
+
+  test('GET /settings keeps a bound custom Definition custom on the CatsCo relay host', async () => {
+    createCatsCoLocalConfigService({ runtimeRoot: testRoot }).save({
+      version: 1,
+      currentBot: {
+        uid: 'custom-relay-host-bot',
+        apiKey: 'catsco-bot-api-key',
+        boundByUserUid: 'user-definition-test',
+        bindingSource: 'test',
+      },
+      device: {
+        deviceId: 'device-definition-test',
+        bodyId: 'body-definition-test',
+        installationId: 'install-definition-test',
+      },
+    });
+    createBotDefinitionSyncService({ runtimeRoot: testRoot }).publish('custom-relay-host-bot', {
+      kind: 'custom',
+      protocol: 'openai-responses',
+      apiBase: 'https://relay.catsco.cc/v1',
+      model: 'gpt-5.6-sol',
+      apiKey: 'sk-custom-relay-host-secret',
+      contextWindowTokens: 256_000,
+    });
+
+    const response = await fetch(`${baseUrl}/api/settings`);
+    const text = await response.text();
+    const data = JSON.parse(text) as any;
+
+    assert.equal(response.status, 200, text);
+    assert.equal(data.modelStartup.source, 'custom');
+    assert.equal(data.modelStartup.custom.configured, true);
+    assert.equal(data.modelStartup.custom.model, 'gpt-5.6-sol');
+    assert.equal(data.modelStartup.relay.configured, false);
+    assert.equal(text.includes('sk-custom-relay-host-secret'), false);
   });
 
   test('PUT /settings uses the explicit runtime data root for bound bot state and Definition storage', async () => {


### PR DESCRIPTION
## 背景

Dashboard 保存自定义模型后，配置虽然写入了当前 bot 的 BotDefinition，但运行中的 CatsCompany connector 未必立即使用新配置。用户会看到界面已切换为自定义模型，实际会话却仍由旧模型处理；后续启动流程还可能再次显示为目录默认模型。

## 修改内容

- 当前 bot 已绑定时，Dashboard 的模型修改直接写入该 bot 的 BotDefinition，不再把 `.env` 作为第二份模型配置来源。
- 自定义模型保存成功后，立即请求重启正在运行的 connector；connector 未运行时则尝试直接启动。
- connector 启动前先准备当前 bot 的 Definition 和本机运行材料，再执行 preflight 和启动。
- 新增轻量的 `/api/cats/connector/start` 路径，仅启动当前已绑定 bot，不再重复走旧 setup 流程。
- Dashboard 明确展示当前模型来源，避免把自定义模型错误显示成 MiniMax 等目录模型。
- 保留旧 `.env` 配置的一次性迁移兼容；已有 Definition 时始终以 Definition 为准。
- 修复自定义模型状态兜底文案的乱码，并增加回归测试。

## 预期效果

用户保存或切换自定义模型后，当前 bot 的 Definition、Dashboard 显示和新启动的 connector 使用同一份配置。切换不再因为 connector 重连而回退到默认目录模型。

## 验证

- 定向测试：90/90 通过。
- `npm run build` 通过。
- 手动验证 bot `usr117`：从 MiniMax M3 切换到 OpenAI Responses 自定义模型 `gpt-5.6-sol` 后，Definition 与实际 runtime 均为 `openai-responses / gpt-5.6-sol`。
