### PR TITLE
完善自定义模型迁移与自动生效

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -9324,7 +9324,7 @@
       }
       const signature=customModelPayloadSignature(payload);
       if(auto && signature===customModelAutoSaveLastSignature && secretUpdate.action==='keep'){
-        setModelSourceStatus('已自动保存，等待启用。','success');
+        setModelSourceStatus('已自动保存为当前自定义配置。','success');
         return;
       }
       if(customModelAutoSaveInFlight){
@@ -9340,7 +9340,7 @@
       try{
         customModelAutoSaveInFlight=true;
         setModelSourceStatus(auto?'自动保存中...':'保存中...','muted');
-        const requestPayload={...payload,modelProfileSource:'custom',activateConnector:!auto};
+        const requestPayload={...payload,modelProfileSource:'custom',activateConnector:true};
         const r=await fetch(API+'/api/settings',{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify(requestPayload)});
         const d=await r.json();
         if(!r.ok||d.error)throw new Error(d.error||'保存失败');
@@ -9352,7 +9352,7 @@
             ? '模型配置已保存，但 connector 激活失败：'+(d.restartError||d.startError)
             : '';
         const appliedMessage=auto
-          ? '已自动保存，等待启用。'
+          ? '已自动保存为当前自定义配置。'
           : activationError||(
           d.connectorRestarted
             ? '已保存自定义模型，并已请求重启 CatsCo agent 使用新配置。'

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -9067,6 +9067,17 @@
       });
     }
 
+    function customModelActivationError(result){
+      const response=result||{};
+      if(response.connectorStartBlocked){
+        return '模型配置已保存，但 connector 启动检查未通过。请查看 CatsCo 连接检查项后重试。';
+      }
+      const error=response.restartError||response.startError;
+      return error
+        ? '模型配置已保存，但 connector 激活失败：'+error+'。请检查后重试。'
+        : '';
+    }
+
     function enableCatsRelayModelFromButton(button, options={}){
       const context=button?.dataset?.relayModelContext || 'settings';
       if(!isCatsLoggedIn() && context==='chat'){
@@ -9344,24 +9355,21 @@
         const r=await fetch(API+'/api/settings',{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify(requestPayload)});
         const d=await r.json();
         if(!r.ok||d.error)throw new Error(d.error||'保存失败');
-        customModelAutoSaveLastSignature=signature;
         updateReasoningEffortSnapshots(payload.settings['model.reasoningEffort']||'default','custom');
-        const activationError=d.connectorStartBlocked
-          ? '模型配置已保存，但 connector 启动检查未通过。请查看 CatsCo 连接检查项。'
-          : d.restartError||d.startError
-            ? '模型配置已保存，但 connector 激活失败：'+(d.restartError||d.startError)
-            : '';
-        const appliedMessage=auto
+        const activationError=customModelActivationError(d);
+        if(!activationError)customModelAutoSaveLastSignature=signature;
+        const appliedMessage=activationError||(
+          auto
           ? '已自动保存为当前自定义配置。'
-          : activationError||(
+          : (
           d.connectorRestarted
             ? '已保存自定义模型，并已请求重启 CatsCo agent 使用新配置。'
             : d.connectorStarted
               ? '已保存自定义模型，并已启动 CatsCo agent 使用新配置。'
               : '已保存自定义模型。connector 状态未改变。'
-          );
+          ));
         if(auto)await fetchDashboardSettings();
-        setModelSourceStatus(appliedMessage,!auto&&activationError?'error':'success');
+        setModelSourceStatus(appliedMessage,activationError?'error':'success');
         const secretInput=document.getElementById('model-secret-setting');
         const clearInput=document.getElementById('model-secret-clear-setting');
         if(secretInput && secretUpdate.action==='replace'){

--- a/src/bot-definition/service.ts
+++ b/src/bot-definition/service.ts
@@ -204,6 +204,43 @@ export function readLegacyLocalModelProfile(
   };
 }
 
+function readLegacySavedCustomModel(
+  runtimeRoot: string,
+  env: NodeJS.ProcessEnv = process.env,
+): CustomBotModelDefinition | undefined {
+  const values = readRuntimeEnv(runtimeRoot, env);
+  const provider = firstNonEmpty(values.CATSCO_CUSTOM_LLM_PROVIDER);
+  const apiBase = firstNonEmpty(values.CATSCO_CUSTOM_LLM_API_BASE);
+  const model = firstNonEmpty(values.CATSCO_CUSTOM_LLM_MODEL);
+  const apiKey = firstNonEmpty(values.CATSCO_CUSTOM_LLM_API_KEY);
+  if ((provider !== 'anthropic' && provider !== 'openai') || !apiBase || !model || !apiKey) return undefined;
+
+  const openaiApiMode = normalizeOpenAIApiMode(values.CATSCO_CUSTOM_LLM_OPENAI_API_MODE);
+  const contextWindowTokens = parsePositiveInteger(values.CATSCO_CUSTOM_LLM_CONTEXT_WINDOW_TOKENS)
+    ?? CUSTOM_DEFAULT_CONTEXT_WINDOW_TOKENS;
+  const maxTokens = parsePositiveInteger(firstNonEmpty(
+    values.CATSCO_CUSTOM_LLM_MAX_OUTPUT_TOKENS,
+    values.CATSCO_CUSTOM_LLM_MAX_TOKENS,
+  ));
+  const temperature = parseTemperature(values.CATSCO_CUSTOM_LLM_TEMPERATURE);
+  const reasoningEffort = normalizeReasoningEffort(values.CATSCO_CUSTOM_LLM_REASONING_EFFORT);
+  return {
+    kind: 'custom',
+    protocol: provider === 'anthropic'
+      ? 'anthropic'
+      : openaiApiMode === 'responses'
+        ? 'openai-responses'
+        : 'openai-chat-completions',
+    apiBase,
+    model,
+    apiKey,
+    contextWindowTokens,
+    ...(maxTokens ? { maxTokens } : {}),
+    ...(temperature !== undefined ? { temperature } : {}),
+    ...(reasoningEffort ? { reasoningEffort } : {}),
+  };
+}
+
 /** @deprecated Use readLegacyLocalModelProfile. */
 export const readLocalModelProfile = readLegacyLocalModelProfile;
 
@@ -406,6 +443,7 @@ export class BotDefinitionSyncService {
   pullOrBootstrap(botId: string): BotDefinitionSyncResult | undefined {
     const existing = this.pull(botId);
     if (existing) {
+      this.migrateLegacyCustomModelProfile(existing.botId);
       this.migrateLegacyCatalogRuntime(existing);
       this.clearLegacyModelConfigurationWhenReady(existing);
       return {
@@ -416,7 +454,11 @@ export class BotDefinitionSyncService {
     }
     const profile = readLegacyLocalModelProfile(this.runtimeRoot, this.env);
     if (!profile) return undefined;
+    const legacySavedCustomModel = readLegacySavedCustomModel(this.runtimeRoot, this.env);
     const definition = this.publish(botId, botModelDefinitionFromLocalProfile(profile)).definition;
+    if (!this.readCustomModelProfile(botId) && legacySavedCustomModel) {
+      this.storeCustomModelProfile(botId, legacySavedCustomModel);
+    }
     this.bootstrapCatalogRuntimeFromLocalProfile(definition, profile);
     this.clearLegacyModelConfigurationWhenReady(definition);
     return {
@@ -472,6 +514,12 @@ export class BotDefinitionSyncService {
     if (!runtime) return;
     this.storeCatalogRuntime(runtime);
     this.clearLegacyModelConfiguration();
+  }
+
+  private migrateLegacyCustomModelProfile(botId: string): void {
+    if (this.readCustomModelProfile(botId)) return;
+    const legacySavedCustomModel = readLegacySavedCustomModel(this.runtimeRoot, this.env);
+    if (legacySavedCustomModel) this.storeCustomModelProfile(botId, legacySavedCustomModel);
   }
 
   /** Clears old model fields only after the selected Definition is runnable. */

--- a/tests/bot-definition-local-repository.test.ts
+++ b/tests/bot-definition-local-repository.test.ts
@@ -336,6 +336,33 @@ describe('BotDefinition local simulation', () => {
     assert.equal(second?.config.apiKey, 'sk-legacy-relay-material');
   });
 
+  test('legacy migration preserves an inactive custom profile while a catalog model is selected', () => {
+    bindCurrentBot();
+    const env = {
+      CATSCO_MODEL_SOURCE: 'relay',
+      CATSCO_RELAY_LLM_PROVIDER: 'anthropic',
+      CATSCO_RELAY_LLM_API_BASE: 'https://relay.example.test/anthropic',
+      CATSCO_RELAY_LLM_MODEL: 'minimax-m3',
+      CATSCO_RELAY_LLM_API_KEY: 'sk-legacy-relay-material',
+      CATSCO_CUSTOM_LLM_PROVIDER: 'openai',
+      CATSCO_CUSTOM_LLM_API_BASE: 'https://custom.example.test/v1',
+      CATSCO_CUSTOM_LLM_MODEL: 'gpt-custom-saved',
+      CATSCO_CUSTOM_LLM_API_KEY: 'sk-legacy-custom-material',
+      CATSCO_CUSTOM_LLM_CONTEXT_WINDOW_TOKENS: '256000',
+      CATSCO_CUSTOM_LLM_OPENAI_API_MODE: 'responses',
+    } as NodeJS.ProcessEnv;
+
+    const service = createBotDefinitionSyncService({ runtimeRoot, simulatedCloudRoot, env });
+    const result = service.pullOrBootstrap('bot-alpha');
+    const savedCustomModel = service.readCustomModelProfile('bot-alpha');
+
+    assert.deepStrictEqual(result?.definition.model, { kind: 'catalog', modelId: 'minimax-m3' });
+    assert.equal(savedCustomModel?.model, 'gpt-custom-saved');
+    assert.equal(savedCustomModel?.apiKey, 'sk-legacy-custom-material');
+    assert.equal(savedCustomModel?.protocol, 'openai-responses');
+    assert.equal(env.CATSCO_CUSTOM_LLM_API_KEY, undefined);
+  });
+
   test('normalizes a relay-facing legacy model name to the catalog id during migration', () => {
     bindCurrentBot();
     new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot }).writeCanonical({

--- a/tests/dashboard-productization-html.test.ts
+++ b/tests/dashboard-productization-html.test.ts
@@ -289,7 +289,34 @@ test('custom model save refreshes simplified state before Chat remains locked', 
   );
   assert.match(dashboardHtml, /已自动保存为当前自定义配置。/);
   assert.match(dashboardHtml, /if\(auto\)await fetchDashboardSettings\(\)/);
+  assert.match(dashboardHtml, /if\(!activationError\)customModelAutoSaveLastSignature=signature/);
+  assert.match(dashboardHtml, /setModelSourceStatus\(appliedMessage,activationError\?'error':'success'\)/);
   assert.doesNotMatch(dashboardHtml, /restartConnector:!auto/);
+});
+
+test('custom model activation failures remain retryable and visible', () => {
+  const functionSource = dashboardHtml.match(
+    /function customModelActivationError\(result\)\{[\s\S]*?\n    \}/,
+  )?.[0];
+  assert.ok(functionSource);
+
+  const activationError = vm.runInNewContext(
+    `${functionSource}; customModelActivationError`,
+  ) as (result: Record<string, unknown>) => string;
+
+  assert.match(
+    activationError({ connectorStartBlocked: true }),
+    /connector 启动检查未通过/,
+  );
+  assert.match(
+    activationError({ restartError: 'restart failed' }),
+    /connector 激活失败：restart failed/,
+  );
+  assert.match(
+    activationError({ startError: 'start failed' }),
+    /connector 激活失败：start failed/,
+  );
+  assert.equal(activationError({ connectorRestarted: true }), '');
 });
 
 test('CatsCo Chat setup refreshes readiness before unlocking the composer', () => {

--- a/tests/dashboard-productization-html.test.ts
+++ b/tests/dashboard-productization-html.test.ts
@@ -285,9 +285,9 @@ test('custom model save refreshes simplified state before Chat remains locked', 
   );
   assert.match(
     dashboardHtml,
-    /const requestPayload=\{\.\.\.payload,modelProfileSource:'custom',activateConnector:!auto\}/,
+    /const requestPayload=\{\.\.\.payload,modelProfileSource:'custom',activateConnector:true\}/,
   );
-  assert.match(dashboardHtml, /已自动保存，等待启用。/);
+  assert.match(dashboardHtml, /已自动保存为当前自定义配置。/);
   assert.match(dashboardHtml, /if\(auto\)await fetchDashboardSettings\(\)/);
   assert.doesNotMatch(dashboardHtml, /restartConnector:!auto/);
 });

--- a/tests/dashboard-settings-api.test.ts
+++ b/tests/dashboard-settings-api.test.ts
@@ -521,6 +521,11 @@ describe('dashboard typed settings API', () => {
     assert.equal(savedSettings.modelStartup.custom.model, 'gpt-custom-draft');
     assert.equal(savedSettings.modelStartup.custom.contextWindowTokens, 512_000);
 
+    fs.rmSync(
+      new FileBotCatalogModelRuntimeRepository({ runtimeRoot: testRoot }).getPath('profile-isolation-bot'),
+      { force: true },
+    );
+
     const applyResponse = await fetch(`${baseUrl}/api/model-source/custom/apply`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## 这个 PR 继续解决什么

#225 已经让每个 bot 分别保存自己的自定义模型配置，并支持在 MiniMax 等已有模型和自定义模型之间来回切换。

本 PR 基于 #225，只补两个仍然存在的问题。

### 1. 升级时保留旧自定义模型配置

旧版本可能同时保存着：

- 当前正在使用的 MiniMax 等已有模型；
- 用户以前填写过、但当前没有启用的自定义模型。

升级后，系统现在会先把旧自定义模型迁移到该 bot 的独立配置中，再清理旧 `.env` 字段，避免升级时丢失这份备用配置。

### 2. 修改自定义模型后立即生效

以前自动保存只保存表单内容，实际运行的 connector 仍可能继续使用旧模型。

现在用户填写完整配置并停止输入后，会继续使用现有自动保存机制，同时立即激活新配置并重启 connector。页面显示与实际运行配置保持一致，不需要再点击一次保存按钮。

## 用户看到的效果

```text
配置并使用自定义模型 A
-> 切换到 MiniMax M3
-> 修改或保留自定义模型配置
-> 再切回自定义模型
-> 自动恢复并实际使用最新的自定义模型配置
```

即使当前目录模型的本地 runtime 文件缺失，只要此前保存过自定义模型，也仍然可以直接切回。该能力由 #225 提供，本 PR 增加了回归测试确认它不会被后续修改破坏。

## 改动范围

- 继续使用 #225 的每 bot 自定义模型 profile，不增加第二套存储结构。
- 增加旧 `.env` 自定义配置的一次性迁移。
- 自动保存完整配置时立即激活并重启 connector。
- 保留现有 debounce，不增加全局锁、任务队列或额外等待时间。
- 不修改 CatsCompany 服务端和 connector 整体架构。

## 验证

- `npm run build` 通过。
- 完整测试：1081 通过，0 失败，4 跳过。
- 定向测试：78 通过，0 失败。
- 覆盖旧配置迁移、自动保存后立即生效，以及目录 runtime 缺失时切回自定义模型。
