### PR TITLE
fix(catsco): 让真实运行时上报对话任务状态

### DIFF
--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -6,7 +6,7 @@ import {
   type CatsThinToolRpcMessage,
 } from './client';
 import { CatsCompanyConfig, ParsedCatsMessage, CatsFileInfo } from './types';
-import { MessageSender } from './message-sender';
+import { MessageSender, type ConversationTaskStatusInput } from './message-sender';
 import { extractContentBlocks } from './content-blocks';
 import { createCatsCoMessageEnvelope, createExecutionScope } from './message-envelope';
 import { logCatsCoExecutionContextDiagnostics } from './execution-context-diagnostics';
@@ -100,6 +100,12 @@ interface QueuedMessage {
   attempts?: number;
   deliveryOnly?: boolean;
   deliveryAttempts?: number;
+}
+
+interface ActiveConversationTask {
+  runID: string;
+  topic: string;
+  finished: boolean;
 }
 
 interface SubAgentEventRoute {
@@ -357,6 +363,10 @@ export class CatsCompanyBot {
   private messageQueue = new Map<string, QueuedMessage[]>();
   /** Serializes history hydration and all model turns for one CatsCo session. */
   private sessionExecutionReservations = new Set<string>();
+  /** Serializes auxiliary status events so a terminal state cannot overtake its running state. */
+  private taskStatusTasks = new Map<string, Promise<void>>();
+  /** Tracks the visible user turn for cancellation and retry handling. */
+  private activeConversationTasks = new Map<string, ActiveConversationTask>();
   /** Invalidates queued or in-flight pre-turn hydration after /clear. */
   private sessionClearGenerations = new Map<string, number>();
   /** Lets /clear cancel an initial cloud restore before it can recreate old history. */
@@ -1279,6 +1289,7 @@ export class CatsCompanyBot {
         this.cloudSessionRestoreAbortControllers?.get(key)?.abort();
         this.cloudSessionRestorePromises.delete(key);
         session.requestInterrupt?.();
+        this.cancelConversationTask(key);
       }
 
       const result = await session.handleCommand(command, args);
@@ -1409,6 +1420,7 @@ export class CatsCompanyBot {
     });
 
     const stopTypingHeartbeat = this.startTypingHeartbeat(msg.topic);
+    let task: ActiveConversationTask | undefined;
 
     try {
       let shouldProcess = true;
@@ -1420,6 +1432,7 @@ export class CatsCompanyBot {
         );
       }
       if (shouldProcess) {
+        task = this.beginConversationTask(key, msg.topic);
         const result = await session.handleMessage(userMessage, {
           channel,
           sessionRoute,
@@ -1441,14 +1454,24 @@ export class CatsCompanyBot {
         });
 
         // 最终文本回复
+        let replyDelivered = true;
         if (result.visibleToUser && result.text) {
           try {
             await this.sender.reply(msg.topic, result.text);
           } catch (err: any) {
+            replyDelivered = false;
             Logger.warning(`前端通知发送失败 (text): ${err.message}`);
           }
         }
+        this.finishConversationTask(key, task, this.taskStatusForResult(result, replyDelivered));
       }
+    } catch (err: any) {
+      this.finishConversationTask(key, task, {
+        state: 'failed',
+        summary: '任务执行失败',
+        error: '任务执行失败',
+      });
+      throw err;
     } finally {
       this.releaseSessionExecution(key);
       stopTypingHeartbeat();
@@ -1559,6 +1582,85 @@ export class CatsCompanyBot {
     if (reservations.has(sessionKey) || session.isBusy?.()) return false;
     reservations.add(sessionKey);
     return true;
+  }
+
+  private beginConversationTask(sessionKey: string, topic: string): ActiveConversationTask {
+    const tasks = this.activeConversationTasks ??= new Map<string, ActiveConversationTask>();
+    const active = tasks.get(sessionKey);
+    if (active && !active.finished) return active;
+
+    const task: ActiveConversationTask = {
+      runID: `xiaoba-${Date.now().toString(36)}-${randomUUID().slice(0, 8)}`,
+      topic,
+      finished: false,
+    };
+    tasks.set(sessionKey, task);
+    this.enqueueConversationTaskStatus(task, {
+      state: 'running',
+      summary: '正在处理请求',
+    });
+    return task;
+  }
+
+  private finishConversationTask(
+    sessionKey: string,
+    task: ActiveConversationTask | undefined,
+    status: Omit<ConversationTaskStatusInput, 'run_id'>,
+  ): void {
+    if (!task || task.finished) return;
+    task.finished = true;
+    const tasks = this.activeConversationTasks ??= new Map<string, ActiveConversationTask>();
+    if (tasks.get(sessionKey) === task) {
+      tasks.delete(sessionKey);
+    }
+    this.enqueueConversationTaskStatus(task, status);
+  }
+
+  private cancelConversationTask(sessionKey: string, summary = '任务已停止'): void {
+    this.finishConversationTask(sessionKey, this.activeConversationTasks?.get(sessionKey), {
+      state: 'cancelled',
+      summary,
+    });
+  }
+
+  private enqueueConversationTaskStatus(
+    task: ActiveConversationTask,
+    status: Omit<ConversationTaskStatusInput, 'run_id'>,
+  ): void {
+    const payload: ConversationTaskStatusInput = { run_id: task.runID, ...status };
+    const statusTasks = this.taskStatusTasks ??= new Map<string, Promise<void>>();
+    const previous = statusTasks.get(task.topic) ?? Promise.resolve();
+    const next = previous
+      .catch(() => undefined)
+      .then(() => this.sender.sendTaskStatus(task.topic, payload))
+      .catch((error: any) => {
+        // Task status is supplementary. A connectivity problem must not affect the reply path.
+        Logger.warning(`[${task.topic}] 任务状态上报失败: ${error?.message || error}`);
+      });
+
+    statusTasks.set(task.topic, next);
+    void next.finally(() => {
+      if (statusTasks.get(task.topic) === next) {
+        statusTasks.delete(task.topic);
+      }
+    }).catch(() => undefined);
+  }
+
+  private taskStatusForResult(
+    result: { text?: string; taskOutcome?: 'completed' | 'failed' | 'cancelled' },
+    replyDelivered: boolean,
+  ): Omit<ConversationTaskStatusInput, 'run_id'> {
+    const text = String(result.text || '');
+    if (result.taskOutcome === 'cancelled' || text.startsWith('已停止当前请求')) {
+      return { state: 'cancelled', summary: '任务已停止' };
+    }
+    if (result.taskOutcome === 'failed' || text.startsWith('处理消息时出错:')) {
+      return { state: 'failed', summary: '任务执行失败', error: '任务执行失败' };
+    }
+    if (!replyDelivered) {
+      return { state: 'failed', summary: '回复发送失败', error: '回复发送失败' };
+    }
+    return { state: 'completed', summary: '任务已完成' };
   }
 
   private releaseSessionExecution(sessionKey: string): void {
@@ -2364,6 +2466,7 @@ export class CatsCompanyBot {
     }
 
     session.requestInterrupt();
+    this.cancelConversationTask(key);
     Logger.info(`[${key}] 收到 CatsCompany 取消事件，已请求中断当前回合`);
   }
 
@@ -2463,6 +2566,7 @@ export class CatsCompanyBot {
     const stopTypingHeartbeat = suppressSubAgentFinalResponse ? () => undefined : this.startTypingHeartbeat(msg.topic);
 
     let retryLater = false;
+    let task: ActiveConversationTask | undefined;
     try {
       let shouldProcess = true;
       if (msg.nativeFeishuContext) {
@@ -2473,6 +2577,9 @@ export class CatsCompanyBot {
         );
       }
       if (shouldProcess) {
+        if (msg.source === 'user') {
+          task = this.beginConversationTask(sessionKey, msg.topic);
+        }
         const result = msg.source === 'subagent_feedback'
           ? await session.handleRuntimeObservation(msg.userMessage as string, {
             channel,
@@ -2515,19 +2622,23 @@ export class CatsCompanyBot {
           retryLater = true;
           Logger.info(`[${sessionKey}] 队列执行遇到竞态忙碌，消息保留等待重试`);
         } else {
+          let replyDelivered = true;
           if (result.text.startsWith('处理消息时出错:')) {
             try {
               await this.sender.reply(msg.topic, result.text);
             } catch (err: any) {
+              replyDelivered = false;
               Logger.warning(`错误消息发送失败: ${err.message}`);
             }
           } else if (result.visibleToUser && result.text) {
             try {
               await this.sender.reply(msg.topic, result.text);
             } catch (err: any) {
+              replyDelivered = false;
               Logger.warning(`队列消息回复发送失败: ${err.message}`);
             }
           }
+          this.finishConversationTask(sessionKey, task, this.taskStatusForResult(result, replyDelivered));
           if (msg.source === 'subagent_feedback') {
             subAgentManager.markResultObservationHandledForParent(sessionKey, msg.userMessage as string);
           }
@@ -2542,7 +2653,12 @@ export class CatsCompanyBot {
         retryLater = true;
         Logger.warning(`[${sessionKey}] 队列消息执行异常，保留等待重试: ${err?.message || err}`);
       } else {
-        Logger.error(`[${sessionKey}] 队列消息连续执行失败，停止重试: ${err?.message || err}`);
+          this.finishConversationTask(sessionKey, task, {
+            state: 'failed',
+            summary: '任务执行失败',
+            error: '任务执行失败',
+          });
+          Logger.error(`[${sessionKey}] 队列消息连续执行失败，停止重试: ${err?.message || err}`);
         if (msg.source === 'subagent_feedback') {
           const pending = this.messageQueue.get(sessionKey) ?? [];
           pending.unshift({ ...msg, attempts, deliveryOnly: true });

--- a/src/catscompany/message-sender.ts
+++ b/src/catscompany/message-sender.ts
@@ -8,7 +8,16 @@ const MAX_MSG_LENGTH = 4000;
 const IDEAL_REPLY_SEGMENT_LENGTH = 520;
 const MAX_REPLY_SEGMENT_LENGTH = 1200;
 
-type CatsMessageType = 'thinking' | 'tool_use' | 'tool_result' | 'runtime_plan' | 'text' | 'image' | 'file';
+type CatsMessageType = 'thinking' | 'tool_use' | 'tool_result' | 'runtime_plan' | 'task_status' | 'text' | 'image' | 'file';
+
+export type ConversationTaskState = 'running' | 'completed' | 'failed' | 'cancelled';
+
+export interface ConversationTaskStatusInput {
+  run_id: string;
+  state: ConversationTaskState;
+  summary: string;
+  error?: string;
+}
 
 interface CatsSendBody {
   topic_id: string;
@@ -204,6 +213,15 @@ export class MessageSender {
       cleared: snapshot.steps.length === 0,
     });
     Logger.info(`Runtime plan 已发送: revision=${snapshot.revision}, steps=${snapshot.steps.length}`);
+  }
+
+  /**
+   * Publishes the latest task state for the conversation sidebar. The server
+   * stores this independently from chat history, so it must stay lightweight.
+   */
+  async sendTaskStatus(topic: string, status: ConversationTaskStatusInput): Promise<void> {
+    await this.send(topic, 'task_status', status);
+    Logger.info(`Task status 已发送: topic=${topic}, state=${status.state}, run=${status.run_id}`);
   }
 
   async sendText(topic: string, text: string): Promise<void> {

--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -131,6 +131,8 @@ export interface CommandResult {
 export interface HandleMessageResult {
   text: string;
   visibleToUser: boolean;
+  /** Explicit lifecycle result for adapters that expose per-turn task state. */
+  taskOutcome?: 'completed' | 'failed' | 'cancelled';
   /** code mode 过程数据（thinking / tool_use / tool_result） */
   newMessages?: import('../types').Message[];
 }
@@ -527,7 +529,7 @@ export class AgentSession {
         if (this.interruptRequested || this.activeAbortController.signal.aborted) {
           Logger.info(`[会话 ${this.key}] 当前请求已取消，忽略压缩在中断后的返回`);
           this.saveInterruptedContextIfCurrent(lifecycleGeneration);
-          return { text: '已停止当前请求。', visibleToUser: true };
+          return { text: '已停止当前请求。', visibleToUser: true, taskOutcome: 'cancelled' };
         }
         this.messages = compactedMessages;
 
@@ -538,7 +540,7 @@ export class AgentSession {
         if (this.interruptRequested || this.activeAbortController.signal.aborted) {
           Logger.info(`[会话 ${this.key}] 当前请求已取消，不再启动模型回合`);
           this.saveInterruptedContextIfCurrent(lifecycleGeneration);
-          return { text: '已停止当前请求。', visibleToUser: true };
+          return { text: '已停止当前请求。', visibleToUser: true, taskOutcome: 'cancelled' };
         }
         const result = await this.turnController.run({
           input: text,
@@ -565,17 +567,17 @@ export class AgentSession {
           Logger.info(`[会话 ${this.key}] 当前请求已取消，忽略模型在中断后的返回`);
           this.messages = this.turnContextBuilder.removeTransientMessages(this.messages);
           this.saveInterruptedContextIfCurrent(lifecycleGeneration);
-          return { text: '已停止当前请求。', visibleToUser: true };
+          return { text: '已停止当前请求。', visibleToUser: true, taskOutcome: 'cancelled' };
         }
         this.messages = result.messages;
         this.lifecycleManager.saveContext(this.messages);
-        return result;
+        return { ...result, taskOutcome: 'completed' };
       } catch (err: any) {
         if (this.isAbortError(err) || this.interruptRequested || this.activeAbortController.signal.aborted) {
           Logger.info(`[会话 ${this.key}] 当前请求已取消`);
           this.messages = this.turnContextBuilder.removeTransientMessages(this.messages);
           this.saveInterruptedContextIfCurrent(lifecycleGeneration);
-          return { text: '已停止当前请求。', visibleToUser: true };
+          return { text: '已停止当前请求。', visibleToUser: true, taskOutcome: 'cancelled' };
         }
 
         const recoveredMessages = this.getPartialMessagesFromError(err);
@@ -621,7 +623,7 @@ export class AgentSession {
         this.messages = stripAssistantArtifactsFromMessages(this.turnContextBuilder.removeTransientMessages(this.messages));
         this.lifecycleManager.saveContext(this.messages);
 
-        return { text: errorReply, visibleToUser: true };
+        return { text: errorReply, visibleToUser: true, taskOutcome: 'failed' };
       } finally {
         this.planRuntime.clear();
         this.busy = false;

--- a/tests/catscompany-content-blocks.test.ts
+++ b/tests/catscompany-content-blocks.test.ts
@@ -58,6 +58,7 @@ function createProcessHarness() {
   const toolUses: Array<{ topic: string; toolUseId: string; name: string; input: any; metadata?: any }> = [];
   const toolResults: Array<{ topic: string; toolUseId: string; content: string; isError?: boolean; metadata?: any }> = [];
   const runtimePlans: Array<{ topic: string; snapshot: any }> = [];
+  const taskStatuses: Array<{ topic: string; status: any }> = [];
 
   const session = {
     isBusy: () => false,
@@ -102,6 +103,9 @@ function createProcessHarness() {
     sendRuntimePlan: async (topic: string, snapshot: any) => {
       runtimePlans.push({ topic, snapshot });
     },
+    sendTaskStatus: async (topic: string, status: any) => {
+      taskStatuses.push({ topic, status });
+    },
   };
   bot.pendingAttachments = new Map();
   bot.messageQueue = new Map();
@@ -119,7 +123,7 @@ function createProcessHarness() {
     ];
   };
 
-  return { bot, downloads, multimodalCalls, handledTurns, runtimeObservations, sentTexts, replies, sentTyping, sentThinking, toolUses, toolResults, runtimePlans, session };
+  return { bot, downloads, multimodalCalls, handledTurns, runtimeObservations, sentTexts, replies, sentTyping, sentThinking, toolUses, toolResults, runtimePlans, taskStatuses, session };
 }
 
 describe('CatsCo content blocks', () => {
@@ -330,6 +334,93 @@ describe('CatsCo content blocks', () => {
       { type: 'text', text: '[file] b.pdf -> (no authorized attachment reference)' },
     ]);
     assert.deepStrictEqual(handledTurns[0].options.runtimeFeedback, []);
+  });
+
+  test('publishes ordered running and completed states for a CatsCo user turn', async () => {
+    const { bot, session, taskStatuses } = createProcessHarness();
+    session.handleMessage = async () => ({ visibleToUser: true, text: '处理完成' });
+
+    await (bot as any).processParsedMessage({
+      topic: 'p2p_1_2',
+      chatType: 'p2p',
+      senderId: 'usr1',
+      seq: 10,
+      text: '请完成这个任务',
+      rawContent: '请完成这个任务',
+    }, 'cc_user:usr1');
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    assert.deepStrictEqual(
+      taskStatuses.map(({ topic, status }) => ({ topic, state: status.state, summary: status.summary })),
+      [
+        { topic: 'p2p_1_2', state: 'running', summary: '正在处理请求' },
+        { topic: 'p2p_1_2', state: 'completed', summary: '任务已完成' },
+      ],
+    );
+    assert.strictEqual(taskStatuses[0].status.run_id, taskStatuses[1].status.run_id);
+  });
+
+  test('marks the task as failed when the final CatsCo reply cannot be delivered', async () => {
+    const { bot, session, taskStatuses } = createProcessHarness();
+    session.handleMessage = async () => ({ visibleToUser: true, text: '处理完成' });
+    bot.sender.reply = async () => { throw new Error('socket closed'); };
+
+    await (bot as any).processParsedMessage({
+      topic: 'p2p_1_2',
+      chatType: 'p2p',
+      senderId: 'usr1',
+      seq: 10,
+      text: '请完成这个任务',
+      rawContent: '请完成这个任务',
+    }, 'cc_user:usr1');
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    assert.deepStrictEqual(
+      taskStatuses.map(({ status }) => status.state),
+      ['running', 'failed'],
+    );
+    assert.strictEqual(taskStatuses[1].status.summary, '回复发送失败');
+  });
+
+  test('preserves an explicit failed session outcome even when its fallback reply is delivered', async () => {
+    const { bot, session, taskStatuses } = createProcessHarness();
+    session.handleMessage = async () => ({
+      visibleToUser: true,
+      text: '不好意思，刚才处理出了点问题，你再试一次？',
+      taskOutcome: 'failed',
+    });
+
+    await (bot as any).processParsedMessage({
+      topic: 'p2p_1_2',
+      chatType: 'p2p',
+      senderId: 'usr1',
+      seq: 10,
+      text: '请完成这个任务',
+      rawContent: '请完成这个任务',
+    }, 'cc_user:usr1');
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    assert.deepStrictEqual(taskStatuses.map(({ status }) => status.state), ['running', 'failed']);
+    assert.strictEqual(taskStatuses[1].status.summary, '任务执行失败');
+  });
+
+  test('marks an active task as cancelled when CatsCo sends a cancel control event', async () => {
+    const { bot, session, taskStatuses } = createProcessHarness();
+    let interrupted = false;
+    session.requestInterrupt = () => { interrupted = true; };
+    (bot as any).beginConversationTask('session:v2:catscompany:p2p:p2p_1_2:agent:usr43', 'p2p_1_2');
+
+    (bot as any).handleCancelMessage({
+      topic: 'p2p_1_2',
+      senderId: 'usr1',
+      text: '',
+      isGroup: false,
+      seq: 11,
+    });
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    assert.strictEqual(interrupted, true);
+    assert.deepStrictEqual(taskStatuses.map(({ status }) => status.state), ['running', 'cancelled']);
   });
 
   test('builds direct image blocks for MiniMax M3 relay model', async () => {

--- a/tests/catscompany-message-sender.test.ts
+++ b/tests/catscompany-message-sender.test.ts
@@ -4,6 +4,30 @@ import { CatsSendError } from '../src/catscompany/client';
 import { MessageSender } from '../src/catscompany/message-sender';
 
 describe('CatsCompany MessageSender retry behavior', () => {
+  test('sends task status as a dedicated transient protocol message', async () => {
+    const sent: any[] = [];
+    const sender = new MessageSender({
+      sendStructuredMessage: async (payload: any) => {
+        sent.push(payload);
+        return 0;
+      },
+    } as any, 'https://app.example.test', 'cc_test');
+
+    await sender.sendTaskStatus('p2p_1_2', {
+      run_id: 'run-1',
+      state: 'running',
+      summary: '正在处理请求',
+    });
+
+    assert.equal(sent.length, 1);
+    assert.equal(sent[0].type, 'task_status');
+    assert.deepEqual(sent[0].content, {
+      run_id: 'run-1',
+      state: 'running',
+      summary: '正在处理请求',
+    });
+  });
+
   test('falls back to HTTP after retryable ack timeout with the same client_msg_id', async () => {
     const requests: any[] = [];
     const originalFetch = globalThis.fetch;


### PR DESCRIPTION
## 背景

CatsCo 服务端与新版侧栏已经支持持久化的 task_status，但此前只接入了示例 bot。实际负责连接 CatsCo、调用模型和发送最终回复的是 XiaoBa-CLI，因此线上对话从未发送状态事件。

## 修改内容

- 在 CatsCo MessageSender 中增加 task_status 协议消息发送能力。
- 在真实用户回合开始、完成、失败、取消时上报状态；每个回合使用独立 run_id。
- 按 topic 串行状态事件，避免 running 在终态之后迟到覆盖侧栏。
- 状态发送失败只记录日志，不阻塞模型执行和最终回复。
- 为 AgentSession 增加可选的结构化 taskOutcome，明确区分成功、失败和取消。

## 边界处理

- 排队重试复用当前运行中的状态，避免失败状态闪烁。
- 用户点击停止或执行 /clear 时发布 cancelled。
- 最终回复发送失败时发布 failed。
- 模型内部异常即使被转换为友好回复，也会通过 taskOutcome: failed 正确显示需处理。

## 验证

- npm run build
- npm test（runtime 套件 143 个测试文件通过）
- 新增 CatsCo 状态协议、成功、最终回复失败、会话失败、取消的覆盖测试。

## 影响范围

仅修改 XiaoBa-CLI 的 CatsCo connector 与一个可选的会话结果字段；不修改模型配置、工具权限、会话上下文持久化或普通聊天消息协议。