### PR TITLE
支持网页端安全切换机器人模型

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -9047,9 +9047,16 @@
       const catsConnected=isCatsLoggedIn();
       const models=relayModelCatalog();
       const source=activeStartupSource();
-      const relayActiveId=source==='relay'?selectedRelayModelId():'';
+      const cloudModel=catsState.cloudModelOverride||null;
+      const cloudOverrideActive=Boolean(cloudModel && cloudModel.kind!=='local');
+      const cloudModelLabel=String(cloudModel?.model||cloudModel?.modelId||'云端模型');
+      const cloudReasoning=String(cloudModel?.reasoningEffort||'');
+      const cloudNotice=cloudOverrideActive
+        ? '<div class="runtime-note success" style="margin:8px 0 10px">云端当前覆盖：<strong>'+escapeHtml(cloudModelLabel)+'</strong>'+(cloudReasoning?' · 推理 '+escapeHtml(cloudReasoning):'')+'。下面保留设备本地配置，切回“设备本地配置”后重新生效。</div>'
+        : '';
+      const relayActiveId=!cloudOverrideActive && source==='relay'?selectedRelayModelId():'';
       const selectedRelayId=selectedRelayModelId();
-      const activeModel=source==='relay'
+      const activeModel=!cloudOverrideActive && source==='relay'
         ? (models.find(model=>String(model.id||model.model||'')===selectedRelayId)||null)
         : null;
       const service=catsState.service||{};
@@ -9061,15 +9068,15 @@
           : catsConnected?'先选模型，再检查启动。':'先选模型，登录后自动接入。';
       if(!models.length){
         panel.innerHTML='<div class="chat-relay-model-head"><div><div class="chat-relay-model-title">启动模型</div><div class="chat-muted">'+escapeHtml(activationCopy)+'</div></div>'
-          +(source==='custom'?'<span class="tag green">自定义</span>':'<span class="tag warm">可选择</span>')
-          +'</div><div class="relay-model-list">'+customModelChoiceHtml(source==='custom','chat')+'</div>'
+          +(cloudOverrideActive?'<span class="tag green">云端 · '+escapeHtml(cloudModelLabel)+'</span>':source==='custom'?'<span class="tag green">自定义</span>':'<span class="tag warm">可选择</span>')
+          +'</div>'+cloudNotice+'<div class="relay-model-list">'+customModelChoiceHtml(!cloudOverrideActive && source==='custom','chat')+'</div>'
           +'<div class="runtime-note warning" style="margin-top:8px">CatsCo 中转暂未提供可用模型。</div>';
         return;
       }
       panel.innerHTML='<div class="chat-relay-model-head"><div><div class="chat-relay-model-title">启动模型</div><div class="chat-muted">'+escapeHtml(activationCopy)+'</div></div>'
-        +(source==='custom'?'<span class="tag green">自定义</span>':activeModel?'<span class="tag green">'+escapeHtml(activeModel.model||activeModel.label||'已选择')+'</span>':'<span class="tag warm">可选择</span>')
-        +'</div><div class="relay-model-list">'
-        +customModelChoiceHtml(source==='custom','chat')
+        +(cloudOverrideActive?'<span class="tag green">云端 · '+escapeHtml(cloudModelLabel)+'</span>':source==='custom'?'<span class="tag green">自定义</span>':activeModel?'<span class="tag green">'+escapeHtml(activeModel.model||activeModel.label||'已选择')+'</span>':'<span class="tag warm">可选择</span>')
+        +'</div>'+cloudNotice+'<div class="relay-model-list">'
+        +customModelChoiceHtml(!cloudOverrideActive && source==='custom','chat')
         +models.map(model=>relayModelChoiceHtml(model, relayActiveId, catsConnected, 'chat')).join('')
         +'</div>';
     }

--- a/src/bot-definition/activation.ts
+++ b/src/bot-definition/activation.ts
@@ -11,6 +11,7 @@ import type { BotCatalogModelRuntime, BotDefinition, BotDefinitionSyncResult } f
 import {
   acknowledgeCloudBotModelSelection,
   pullCloudBotModelSelection,
+  redactCloudBotModelError,
   type CloudBotModelSelection,
 } from './cloud-client';
 
@@ -60,6 +61,7 @@ export async function prepareBoundBotDefinition(
   let materializedCatalogRuntime = false;
   let cloudSelection = options.cloudSelection;
   let cloudApplyError: string | undefined;
+  let cloudSelectionApplied = false;
   const shouldAcknowledgeCloudSelection = options.acknowledgeCloudSelection !== false;
 
   if (!cloudSelection) {
@@ -76,33 +78,42 @@ export async function prepareBoundBotDefinition(
 
   if (cloudSelection) {
     try {
-      const cloudModel = {
-        kind: 'catalog' as const,
-        modelId: cloudSelection.modelId,
-        ...(cloudSelection.reasoningEffort ? { reasoningEffort: cloudSelection.reasoningEffort } : {}),
-      };
-      const runtime = definitionService.readCatalogRuntime(botId);
-      if (!runtime || !catalogRuntimeMatchesModelId(runtime, cloudSelection.modelId)) {
-        const materialized = await provisionCatsRelayCatalogRuntime({
-          botId,
+      if (cloudSelection.kind === 'custom') {
+        if (!cloudSelection.customModel) {
+          throw new Error('CatsCo cloud custom model configuration is missing.');
+        }
+        definitionService.storeCustomModelProfile(botId, cloudSelection.customModel);
+        sync = definitionService.acceptCloud(botId, cloudSelection.customModel);
+      } else {
+        const cloudModel = {
+          kind: 'catalog' as const,
           modelId: cloudSelection.modelId,
-          reasoningEffort: cloudSelection.reasoningEffort,
-          auth,
-          fetchImpl: options.fetchImpl,
-        });
-        definitionService.storeCatalogRuntime(materialized);
-        materializedCatalogRuntime = true;
-      } else if (
-        cloudSelection.reasoningEffort
-        && runtime.reasoningEffort !== cloudSelection.reasoningEffort
-      ) {
-        definitionService.storeCatalogRuntime({
-          ...runtime,
-          reasoningEffort: cloudSelection.reasoningEffort,
-        });
+          ...(cloudSelection.reasoningEffort ? { reasoningEffort: cloudSelection.reasoningEffort } : {}),
+        };
+        const runtime = definitionService.readCatalogRuntime(botId);
+        if (!runtime || !catalogRuntimeMatchesModelId(runtime, cloudSelection.modelId)) {
+          const materialized = await provisionCatsRelayCatalogRuntime({
+            botId,
+            modelId: cloudSelection.modelId,
+            reasoningEffort: cloudSelection.reasoningEffort,
+            auth,
+            fetchImpl: options.fetchImpl,
+          });
+          definitionService.storeCatalogRuntime(materialized);
+          materializedCatalogRuntime = true;
+        } else if (
+          cloudSelection.reasoningEffort
+          && runtime.reasoningEffort !== cloudSelection.reasoningEffort
+        ) {
+          definitionService.storeCatalogRuntime({
+            ...runtime,
+            reasoningEffort: cloudSelection.reasoningEffort,
+          });
+        }
+        sync = definitionService.acceptCloud(botId, cloudModel);
       }
-      sync = definitionService.acceptCloud(botId, cloudModel);
       definition = sync.definition;
+      cloudSelectionApplied = true;
       if (shouldAcknowledgeCloudSelection) {
         try {
           await acknowledgeCloudBotModelSelection({
@@ -115,7 +126,7 @@ export async function prepareBoundBotDefinition(
         }
       }
     } catch (error) {
-      const message = errorMessage(error);
+      const message = redactCloudBotModelError(error, cloudSelection);
       cloudApplyError = message;
       Logger.warning(`CatsCo 云端模型 ${cloudSelection.modelId} 应用失败，保留上一份本地配置: ${message}`);
       if (shouldAcknowledgeCloudSelection) {
@@ -132,7 +143,7 @@ export async function prepareBoundBotDefinition(
     }
   }
 
-  if (selectedCatalogRuntime) {
+  if (selectedCatalogRuntime && !cloudSelectionApplied) {
     definitionService.storeCatalogRuntime(selectedCatalogRuntime);
     sync = definitionService.publish(botId, {
       kind: 'catalog',

--- a/src/bot-definition/activation.ts
+++ b/src/bot-definition/activation.ts
@@ -52,9 +52,7 @@ export async function prepareBoundBotDefinition(
   if (selectedCatalogRuntime && selectedCatalogRuntime.botId !== botId) {
     throw new Error('Selected catalog runtime does not belong to the bound bot.');
   }
-  let sync = selectedCatalogRuntime
-    ? undefined
-    : definitionService.pullOrBootstrap(botId);
+  let sync = definitionService.pullOrBootstrap(botId);
   let localDefinition = sync?.definition;
   const previousCloudDefinition = definitionService.readCloudModelOverride(botId);
   const previousCloudRuntime = definitionService.readCloudCatalogRuntime(botId);
@@ -65,6 +63,7 @@ export async function prepareBoundBotDefinition(
   let cloudSelection = options.cloudSelection;
   let cloudApplyError: string | undefined;
   let cloudSelectionApplied = false;
+  let selectedCatalogRuntimeApplied = false;
   const shouldAcknowledgeCloudSelection = options.acknowledgeCloudSelection !== false;
 
   if (!cloudSelection) {
@@ -82,6 +81,45 @@ export async function prepareBoundBotDefinition(
   if (cloudSelection) {
     try {
       if (cloudSelection.kind === 'local') {
+        if (selectedCatalogRuntime) {
+          definitionService.storeCatalogRuntime(selectedCatalogRuntime);
+          sync = definitionService.publish(botId, {
+            kind: 'catalog',
+            modelId: selectedCatalogRuntime.modelId,
+          });
+          localDefinition = sync.definition;
+          materializedCatalogRuntime = true;
+          selectedCatalogRuntimeApplied = true;
+        }
+        if (!localDefinition) {
+          const runtime = await provisionCatsRelayCatalogRuntime({
+            botId,
+            modelId: DEFAULT_CATSCO_RELAY_MODEL_ID,
+            auth,
+            fetchImpl: options.fetchImpl,
+          });
+          definitionService.storeCatalogRuntime(runtime);
+          sync = definitionService.publish(botId, {
+            kind: 'catalog',
+            modelId: DEFAULT_CATSCO_RELAY_MODEL_ID,
+          });
+          localDefinition = sync.definition;
+          initializedDefault = true;
+          materializedCatalogRuntime = true;
+        }
+        if (localDefinition.model.kind === 'catalog') {
+          const runtime = definitionService.readCatalogRuntime(botId);
+          if (!runtime || !catalogRuntimeMatchesModelId(runtime, localDefinition.model.modelId)) {
+            const materialized = await provisionCatsRelayCatalogRuntime({
+              botId,
+              modelId: localDefinition.model.modelId,
+              auth,
+              fetchImpl: options.fetchImpl,
+            });
+            definitionService.storeCatalogRuntime(materialized);
+            materializedCatalogRuntime = true;
+          }
+        }
         definitionService.clearCloudModelOverride(botId);
         definition = localDefinition;
       } else if (cloudSelection.kind === 'custom') {
@@ -163,7 +201,11 @@ export async function prepareBoundBotDefinition(
     }
   }
 
-  if (selectedCatalogRuntime && (!cloudSelectionApplied || cloudSelection?.kind === 'local')) {
+  if (
+    selectedCatalogRuntime
+    && !selectedCatalogRuntimeApplied
+    && (!cloudSelectionApplied || cloudSelection?.kind === 'local')
+  ) {
     definitionService.storeCatalogRuntime(selectedCatalogRuntime);
     sync = definitionService.publish(botId, {
       kind: 'catalog',

--- a/src/bot-definition/activation.ts
+++ b/src/bot-definition/activation.ts
@@ -1,12 +1,18 @@
 import { createCatsCoLocalConfigService, type CatsCoAuthSnapshot } from '../catscompany/local-config';
 import { provisionCatsRelayCatalogRuntime } from '../catscompany/relay-model-bootstrap';
 import { DEFAULT_CATSCO_RELAY_MODEL_ID } from '../utils/relay-model-profiles';
+import { Logger } from '../utils/logger';
 import {
   catalogRuntimeMatchesModelId,
   createBotDefinitionSyncService,
   type BotDefinitionSyncServiceOptions,
 } from './service';
 import type { BotCatalogModelRuntime, BotDefinition, BotDefinitionSyncResult } from './types';
+import {
+  acknowledgeCloudBotModelSelection,
+  pullCloudBotModelSelection,
+  type CloudBotModelSelection,
+} from './cloud-client';
 
 export interface PrepareBoundBotDefinitionOptions extends BotDefinitionSyncServiceOptions {
   runtimeRoot: string;
@@ -14,6 +20,8 @@ export interface PrepareBoundBotDefinitionOptions extends BotDefinitionSyncServi
   selectedCatalogRuntime?: BotCatalogModelRuntime;
   auth?: CatsCoAuthSnapshot;
   fetchImpl?: typeof fetch;
+  cloudSelection?: CloudBotModelSelection;
+  acknowledgeCloudSelection?: boolean;
 }
 
 export interface PreparedBoundBotDefinition {
@@ -22,6 +30,9 @@ export interface PreparedBoundBotDefinition {
   sync?: BotDefinitionSyncResult;
   initializedDefault: boolean;
   materializedCatalogRuntime: boolean;
+  cloudRevision?: number;
+  cloudSelection?: CloudBotModelSelection;
+  cloudApplyError?: string;
 }
 
 /**
@@ -47,6 +58,79 @@ export async function prepareBoundBotDefinition(
   const auth = options.auth ?? createCatsCoLocalConfigService({ runtimeRoot: options.runtimeRoot }).getAuthState();
   let initializedDefault = false;
   let materializedCatalogRuntime = false;
+  let cloudSelection = options.cloudSelection;
+  let cloudApplyError: string | undefined;
+  const shouldAcknowledgeCloudSelection = options.acknowledgeCloudSelection !== false;
+
+  if (!cloudSelection) {
+    try {
+      cloudSelection = await pullCloudBotModelSelection({
+        botId,
+        auth,
+        fetchImpl: options.fetchImpl,
+      });
+    } catch (error) {
+      Logger.warning(`CatsCo 云端模型配置暂时不可用，继续使用本地配置: ${errorMessage(error)}`);
+    }
+  }
+
+  if (cloudSelection) {
+    try {
+      const cloudModel = {
+        kind: 'catalog' as const,
+        modelId: cloudSelection.modelId,
+        ...(cloudSelection.reasoningEffort ? { reasoningEffort: cloudSelection.reasoningEffort } : {}),
+      };
+      const runtime = definitionService.readCatalogRuntime(botId);
+      if (!runtime || !catalogRuntimeMatchesModelId(runtime, cloudSelection.modelId)) {
+        const materialized = await provisionCatsRelayCatalogRuntime({
+          botId,
+          modelId: cloudSelection.modelId,
+          reasoningEffort: cloudSelection.reasoningEffort,
+          auth,
+          fetchImpl: options.fetchImpl,
+        });
+        definitionService.storeCatalogRuntime(materialized);
+        materializedCatalogRuntime = true;
+      } else if (
+        cloudSelection.reasoningEffort
+        && runtime.reasoningEffort !== cloudSelection.reasoningEffort
+      ) {
+        definitionService.storeCatalogRuntime({
+          ...runtime,
+          reasoningEffort: cloudSelection.reasoningEffort,
+        });
+      }
+      sync = definitionService.acceptCloud(botId, cloudModel);
+      definition = sync.definition;
+      if (shouldAcknowledgeCloudSelection) {
+        try {
+          await acknowledgeCloudBotModelSelection({
+            botId,
+            auth,
+            fetchImpl: options.fetchImpl,
+          }, cloudSelection);
+        } catch (error) {
+          Logger.warning(`CatsCo 云端模型应用状态回报失败，不影响本次启动: ${errorMessage(error)}`);
+        }
+      }
+    } catch (error) {
+      const message = errorMessage(error);
+      cloudApplyError = message;
+      Logger.warning(`CatsCo 云端模型 ${cloudSelection.modelId} 应用失败，保留上一份本地配置: ${message}`);
+      if (shouldAcknowledgeCloudSelection) {
+        try {
+          await acknowledgeCloudBotModelSelection({
+            botId,
+            auth,
+            fetchImpl: options.fetchImpl,
+          }, cloudSelection, message);
+        } catch (ackError) {
+          Logger.warning(`CatsCo 云端模型失败状态回报失败: ${errorMessage(ackError)}`);
+        }
+      }
+    }
+  }
 
   if (selectedCatalogRuntime) {
     definitionService.storeCatalogRuntime(selectedCatalogRuntime);
@@ -90,5 +174,18 @@ export async function prepareBoundBotDefinition(
   }
 
   definitionService.clearLegacyModelConfigurationWhenReady(definition);
-  return { botId, definition, sync, initializedDefault, materializedCatalogRuntime };
+  return {
+    botId,
+    definition,
+    sync,
+    initializedDefault,
+    materializedCatalogRuntime,
+    ...(cloudSelection ? { cloudSelection } : {}),
+    ...(cloudApplyError ? { cloudApplyError } : {}),
+    ...(cloudSelection && sync?.direction === 'cloud_to_local' ? { cloudRevision: cloudSelection.revision } : {}),
+  };
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/src/bot-definition/activation.ts
+++ b/src/bot-definition/activation.ts
@@ -55,7 +55,10 @@ export async function prepareBoundBotDefinition(
   let sync = selectedCatalogRuntime
     ? undefined
     : definitionService.pullOrBootstrap(botId);
-  let definition = sync?.definition;
+  let localDefinition = sync?.definition;
+  const previousCloudDefinition = definitionService.readCloudModelOverride(botId);
+  const previousCloudRuntime = definitionService.readCloudCatalogRuntime(botId);
+  let definition = previousCloudDefinition ?? localDefinition;
   const auth = options.auth ?? createCatsCoLocalConfigService({ runtimeRoot: options.runtimeRoot }).getAuthState();
   let initializedDefault = false;
   let materializedCatalogRuntime = false;
@@ -78,19 +81,22 @@ export async function prepareBoundBotDefinition(
 
   if (cloudSelection) {
     try {
-      if (cloudSelection.kind === 'custom') {
+      if (cloudSelection.kind === 'local') {
+        definitionService.clearCloudModelOverride(botId);
+        definition = localDefinition;
+      } else if (cloudSelection.kind === 'custom') {
         if (!cloudSelection.customModel) {
           throw new Error('CatsCo cloud custom model configuration is missing.');
         }
-        definitionService.storeCustomModelProfile(botId, cloudSelection.customModel);
         sync = definitionService.acceptCloud(botId, cloudSelection.customModel);
+        definition = sync.definition;
       } else {
         const cloudModel = {
           kind: 'catalog' as const,
           modelId: cloudSelection.modelId,
           ...(cloudSelection.reasoningEffort ? { reasoningEffort: cloudSelection.reasoningEffort } : {}),
         };
-        const runtime = definitionService.readCatalogRuntime(botId);
+        const runtime = definitionService.readCloudCatalogRuntime(botId);
         if (!runtime || !catalogRuntimeMatchesModelId(runtime, cloudSelection.modelId)) {
           const materialized = await provisionCatsRelayCatalogRuntime({
             botId,
@@ -99,20 +105,20 @@ export async function prepareBoundBotDefinition(
             auth,
             fetchImpl: options.fetchImpl,
           });
-          definitionService.storeCatalogRuntime(materialized);
+          definitionService.storeCloudCatalogRuntime(materialized);
           materializedCatalogRuntime = true;
         } else if (
           cloudSelection.reasoningEffort
           && runtime.reasoningEffort !== cloudSelection.reasoningEffort
         ) {
-          definitionService.storeCatalogRuntime({
+          definitionService.storeCloudCatalogRuntime({
             ...runtime,
             reasoningEffort: cloudSelection.reasoningEffort,
           });
         }
         sync = definitionService.acceptCloud(botId, cloudModel);
+        definition = sync.definition;
       }
-      definition = sync.definition;
       cloudSelectionApplied = true;
       if (shouldAcknowledgeCloudSelection) {
         try {
@@ -126,6 +132,20 @@ export async function prepareBoundBotDefinition(
         }
       }
     } catch (error) {
+      try {
+        if (previousCloudDefinition) {
+          definitionService.acceptCloud(botId, previousCloudDefinition.model);
+          definition = previousCloudDefinition;
+        } else {
+          definitionService.clearCloudModelOverride(botId);
+          definition = localDefinition;
+        }
+        if (previousCloudRuntime) {
+          definitionService.storeCloudCatalogRuntime(previousCloudRuntime);
+        }
+      } catch (restoreError) {
+        Logger.warning(`CatsCo 云端模型覆盖恢复失败: ${errorMessage(restoreError)}`);
+      }
       const message = redactCloudBotModelError(error, cloudSelection);
       cloudApplyError = message;
       Logger.warning(`CatsCo 云端模型 ${cloudSelection.modelId} 应用失败，保留上一份本地配置: ${message}`);
@@ -143,13 +163,14 @@ export async function prepareBoundBotDefinition(
     }
   }
 
-  if (selectedCatalogRuntime && !cloudSelectionApplied) {
+  if (selectedCatalogRuntime && (!cloudSelectionApplied || cloudSelection?.kind === 'local')) {
     definitionService.storeCatalogRuntime(selectedCatalogRuntime);
     sync = definitionService.publish(botId, {
       kind: 'catalog',
       modelId: selectedCatalogRuntime.modelId,
     });
-    definition = sync.definition;
+    localDefinition = sync.definition;
+    definition = definitionService.readCloudModelOverride(botId) ?? sync.definition;
     materializedCatalogRuntime = true;
   }
 
@@ -170,8 +191,12 @@ export async function prepareBoundBotDefinition(
     materializedCatalogRuntime = true;
   }
 
+  const activeCloudOverride = definitionService.readCloudModelOverride(botId);
+  if (activeCloudOverride) definition = activeCloudOverride;
   if (definition.model.kind === 'catalog') {
-    const runtime = definitionService.readCatalogRuntime(botId);
+    const runtime = activeCloudOverride
+      ? definitionService.readCloudCatalogRuntime(botId)
+      : definitionService.readCatalogRuntime(botId);
     if (!runtime || !catalogRuntimeMatchesModelId(runtime, definition.model.modelId)) {
       const materialized = await provisionCatsRelayCatalogRuntime({
         botId,
@@ -179,7 +204,8 @@ export async function prepareBoundBotDefinition(
         auth,
         fetchImpl: options.fetchImpl,
       });
-      definitionService.storeCatalogRuntime(materialized);
+      if (activeCloudOverride) definitionService.storeCloudCatalogRuntime(materialized);
+      else definitionService.storeCatalogRuntime(materialized);
       materializedCatalogRuntime = true;
     }
   }
@@ -193,7 +219,7 @@ export async function prepareBoundBotDefinition(
     materializedCatalogRuntime,
     ...(cloudSelection ? { cloudSelection } : {}),
     ...(cloudApplyError ? { cloudApplyError } : {}),
-    ...(cloudSelection && sync?.direction === 'cloud_to_local' ? { cloudRevision: cloudSelection.revision } : {}),
+    ...(cloudSelectionApplied && cloudSelection ? { cloudRevision: cloudSelection.revision } : {}),
   };
 }
 

--- a/src/bot-definition/cloud-client.ts
+++ b/src/bot-definition/cloud-client.ts
@@ -1,13 +1,17 @@
 import type { CatsCoAuthSnapshot } from '../catscompany/local-config';
 import { normalizeReasoningEffort } from '../utils/reasoning-effort';
 import type { ReasoningEffort } from '../types';
+import type { CustomBotModelDefinition } from './types';
 
 const CLOUD_MODEL_REQUEST_TIMEOUT_MS = 10_000;
 
 export interface CloudBotModelSelection {
+  /** Missing means catalog for compatibility with selections created by older callers. */
+  kind?: 'catalog' | 'custom';
   modelId: string;
   reasoningEffort?: ReasoningEffort;
   revision: number;
+  customModel?: CustomBotModelDefinition;
 }
 
 export interface CloudBotModelClientOptions {
@@ -23,6 +27,7 @@ export async function pullCloudBotModelSelection(
   if (response === undefined) return undefined;
   if (response?.configured !== true) return undefined;
   const responseBotId = String(response?.uid ?? '').trim();
+  const kind = normalizeCloudModelKind(response?.desired?.kind);
   const modelId = String(response?.desired?.model_id || '').trim();
   const revision = Number(response?.desired?.revision);
   const rawReasoning = String(response?.desired?.reasoning_effort || '').trim();
@@ -33,7 +38,23 @@ export async function pullCloudBotModelSelection(
   if (rawReasoning && !reasoningEffort) {
     throw new Error(`CatsCo cloud returned an unsupported reasoning effort: ${rawReasoning}`);
   }
-  return { modelId, revision, ...(reasoningEffort ? { reasoningEffort } : {}) };
+  if (kind === 'custom') {
+    const customModel = parseCloudCustomModel(response?.desired?.custom);
+    if (customModel.model !== modelId) {
+      throw new Error('CatsCo cloud custom model does not match its selected model id.');
+    }
+    if ((customModel.reasoningEffort || '') !== (reasoningEffort || '')) {
+      throw new Error('CatsCo cloud custom model reasoning does not match its selected reasoning effort.');
+    }
+    return {
+      kind,
+      modelId,
+      revision,
+      customModel,
+      ...(reasoningEffort ? { reasoningEffort } : {}),
+    };
+  }
+  return { kind: 'catalog', modelId, revision, ...(reasoningEffort ? { reasoningEffort } : {}) };
 }
 
 export async function acknowledgeCloudBotModelSelection(
@@ -43,10 +64,72 @@ export async function acknowledgeCloudBotModelSelection(
 ): Promise<void> {
   await cloudModelRequest(options, 'POST', '/api/bot/model-config/ack', {
     revision: selection.revision,
+    ...(selection.kind === 'custom' ? { kind: 'custom' } : {}),
     model_id: selection.modelId,
     reasoning_effort: selection.reasoningEffort || '',
     ...(applyError ? { error: applyError } : {}),
   });
+}
+
+export function redactCloudBotModelError(
+  error: unknown,
+  selection?: CloudBotModelSelection,
+): string {
+  let message = error instanceof Error ? error.message : String(error);
+  const secret = selection?.customModel?.apiKey;
+  if (secret) message = message.split(secret).join('[REDACTED]');
+  return message;
+}
+
+function normalizeCloudModelKind(value: unknown): 'catalog' | 'custom' {
+  const kind = String(value || '').trim().toLowerCase();
+  if (!kind || kind === 'catalog') return 'catalog';
+  if (kind === 'custom') return 'custom';
+  throw new Error(`CatsCo cloud returned an unsupported model kind: ${kind}`);
+}
+
+function parseCloudCustomModel(value: unknown): CustomBotModelDefinition {
+  const input = value as Record<string, unknown> | undefined;
+  const protocol = String(input?.protocol || '').trim().toLowerCase();
+  const apiBase = String(input?.api_base || '').trim().replace(/\/+$/, '');
+  const model = String(input?.model || '').trim();
+  const apiKey = String(input?.api_key || '').trim();
+  const contextWindowTokens = Number(input?.context_window_tokens);
+  const maxTokens = Number(input?.max_tokens);
+  const temperature = input?.temperature === undefined || input?.temperature === null
+    ? undefined
+    : Number(input.temperature);
+  const rawReasoning = String(input?.reasoning_effort || '').trim();
+  const reasoningEffort = rawReasoning ? normalizeReasoningEffort(rawReasoning) : undefined;
+  if (!['anthropic', 'openai-chat-completions', 'openai-responses'].includes(protocol)) {
+    throw new Error('CatsCo cloud returned an unsupported custom model protocol.');
+  }
+  if (!apiBase || !/^https?:\/\//i.test(apiBase) || !model || !apiKey) {
+    throw new Error('CatsCo cloud returned an incomplete custom model configuration.');
+  }
+  if (!Number.isInteger(contextWindowTokens) || contextWindowTokens < 1024 || contextWindowTokens > 4_000_000) {
+    throw new Error('CatsCo cloud returned an invalid custom model context window.');
+  }
+  if (Number.isFinite(maxTokens) && (maxTokens < 0 || maxTokens > 1_000_000)) {
+    throw new Error('CatsCo cloud returned invalid custom model max tokens.');
+  }
+  if (temperature !== undefined && (!Number.isFinite(temperature) || temperature < 0 || temperature > 2)) {
+    throw new Error('CatsCo cloud returned an invalid custom model temperature.');
+  }
+  if (rawReasoning && !reasoningEffort) {
+    throw new Error(`CatsCo cloud returned an unsupported reasoning effort: ${rawReasoning}`);
+  }
+  return {
+    kind: 'custom',
+    protocol: protocol as CustomBotModelDefinition['protocol'],
+    apiBase,
+    model,
+    apiKey,
+    contextWindowTokens,
+    ...(Number.isInteger(maxTokens) && maxTokens > 0 ? { maxTokens } : {}),
+    ...(temperature !== undefined ? { temperature } : {}),
+    ...(reasoningEffort ? { reasoningEffort } : {}),
+  };
 }
 
 async function cloudModelRequest(

--- a/src/bot-definition/cloud-client.ts
+++ b/src/bot-definition/cloud-client.ts
@@ -1,0 +1,91 @@
+import type { CatsCoAuthSnapshot } from '../catscompany/local-config';
+import { normalizeReasoningEffort } from '../utils/reasoning-effort';
+import type { ReasoningEffort } from '../types';
+
+const CLOUD_MODEL_REQUEST_TIMEOUT_MS = 10_000;
+
+export interface CloudBotModelSelection {
+  modelId: string;
+  reasoningEffort?: ReasoningEffort;
+  revision: number;
+}
+
+export interface CloudBotModelClientOptions {
+  botId: string;
+  auth: CatsCoAuthSnapshot;
+  fetchImpl?: typeof fetch;
+}
+
+export async function pullCloudBotModelSelection(
+  options: CloudBotModelClientOptions,
+): Promise<CloudBotModelSelection | undefined> {
+  const response = await cloudModelRequest(options, 'GET', '/api/bot/model-config');
+  if (response === undefined) return undefined;
+  if (response?.configured !== true) return undefined;
+  const responseBotId = String(response?.uid ?? '').trim();
+  const modelId = String(response?.desired?.model_id || '').trim();
+  const revision = Number(response?.desired?.revision);
+  const rawReasoning = String(response?.desired?.reasoning_effort || '').trim();
+  const reasoningEffort = rawReasoning ? normalizeReasoningEffort(rawReasoning) : undefined;
+  if (responseBotId !== String(options.botId).trim() || !modelId || !Number.isInteger(revision) || revision < 0) {
+    throw new Error('CatsCo cloud returned an invalid bot model configuration.');
+  }
+  if (rawReasoning && !reasoningEffort) {
+    throw new Error(`CatsCo cloud returned an unsupported reasoning effort: ${rawReasoning}`);
+  }
+  return { modelId, revision, ...(reasoningEffort ? { reasoningEffort } : {}) };
+}
+
+export async function acknowledgeCloudBotModelSelection(
+  options: CloudBotModelClientOptions,
+  selection: CloudBotModelSelection,
+  applyError = '',
+): Promise<void> {
+  await cloudModelRequest(options, 'POST', '/api/bot/model-config/ack', {
+    revision: selection.revision,
+    model_id: selection.modelId,
+    reasoning_effort: selection.reasoningEffort || '',
+    ...(applyError ? { error: applyError } : {}),
+  });
+}
+
+async function cloudModelRequest(
+  options: CloudBotModelClientOptions,
+  method: string,
+  apiPath: string,
+  body?: unknown,
+): Promise<any | undefined> {
+  const apiKey = String(options.auth.apiKey || '').trim();
+  const httpBaseUrl = String(options.auth.httpBaseUrl || '').trim().replace(/\/+$/, '');
+  if (!apiKey || !httpBaseUrl) return undefined;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), CLOUD_MODEL_REQUEST_TIMEOUT_MS);
+  try {
+    const response = await (options.fetchImpl ?? fetch)(`${httpBaseUrl}${apiPath}`, {
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `ApiKey ${apiKey}`,
+      },
+      body: body === undefined ? undefined : JSON.stringify(body),
+      signal: controller.signal,
+    });
+    if ([404, 405, 501].includes(response.status)) return undefined;
+    const text = await response.text();
+    let data: any = {};
+    if (text) {
+      try {
+        data = JSON.parse(text);
+      } catch {
+        data = { raw: text };
+      }
+    }
+    if (!response.ok) {
+      throw new Error(String(data?.error || data?.message || `CatsCo cloud model request failed: ${response.status}`));
+    }
+    return data;
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/src/bot-definition/cloud-client.ts
+++ b/src/bot-definition/cloud-client.ts
@@ -7,7 +7,7 @@ const CLOUD_MODEL_REQUEST_TIMEOUT_MS = 10_000;
 
 export interface CloudBotModelSelection {
   /** Missing means catalog for compatibility with selections created by older callers. */
-  kind?: 'catalog' | 'custom';
+  kind?: 'catalog' | 'custom' | 'local';
   modelId: string;
   reasoningEffort?: ReasoningEffort;
   revision: number;
@@ -25,16 +25,20 @@ export async function pullCloudBotModelSelection(
 ): Promise<CloudBotModelSelection | undefined> {
   const response = await cloudModelRequest(options, 'GET', '/api/bot/model-config');
   if (response === undefined) return undefined;
-  if (response?.configured !== true) return undefined;
   const responseBotId = String(response?.uid ?? '').trim();
-  const kind = normalizeCloudModelKind(response?.desired?.kind);
   const modelId = String(response?.desired?.model_id || '').trim();
   const revision = Number(response?.desired?.revision);
-  const rawReasoning = String(response?.desired?.reasoning_effort || '').trim();
-  const reasoningEffort = rawReasoning ? normalizeReasoningEffort(rawReasoning) : undefined;
   if (responseBotId !== String(options.botId).trim() || !modelId || !Number.isInteger(revision) || revision < 0) {
     throw new Error('CatsCo cloud returned an invalid bot model configuration.');
   }
+  if (response?.configured !== true) {
+    return revision > 0 && modelId === 'local'
+      ? { kind: 'local', modelId: 'local', revision }
+      : undefined;
+  }
+  const kind = normalizeCloudModelKind(response?.desired?.kind);
+  const rawReasoning = String(response?.desired?.reasoning_effort || '').trim();
+  const reasoningEffort = rawReasoning ? normalizeReasoningEffort(rawReasoning) : undefined;
   if (rawReasoning && !reasoningEffort) {
     throw new Error(`CatsCo cloud returned an unsupported reasoning effort: ${rawReasoning}`);
   }
@@ -64,7 +68,7 @@ export async function acknowledgeCloudBotModelSelection(
 ): Promise<void> {
   await cloudModelRequest(options, 'POST', '/api/bot/model-config/ack', {
     revision: selection.revision,
-    ...(selection.kind === 'custom' ? { kind: 'custom' } : {}),
+    ...(selection.kind === 'custom' || selection.kind === 'local' ? { kind: selection.kind } : {}),
     model_id: selection.modelId,
     reasoning_effort: selection.reasoningEffort || '',
     ...(applyError ? { error: applyError } : {}),

--- a/src/bot-definition/llm-config-resolver.ts
+++ b/src/bot-definition/llm-config-resolver.ts
@@ -2,7 +2,12 @@ import * as path from 'path';
 import { createCatsCoLocalConfigService } from '../catscompany/local-config';
 import type { ChatConfig } from '../types';
 import { PathResolver } from '../utils/path-resolver';
-import { FileBotCatalogModelRuntimeRepository, FileBotDefinitionRepository } from './repository';
+import {
+  FileBotCatalogModelRuntimeRepository,
+  FileBotCloudCatalogModelRuntimeRepository,
+  FileBotCloudModelOverrideRepository,
+  FileBotDefinitionRepository,
+} from './repository';
 import { catalogRuntimeMatchesModelId } from './service';
 import type { CustomBotModelDefinition } from './types';
 
@@ -76,7 +81,8 @@ export function resolveActiveBotLLMConfig(
   if (!botId) return undefined;
 
   const definitions = new FileBotDefinitionRepository({ runtimeRoot });
-  const definition = definitions.readCache(botId);
+  const cloudOverride = new FileBotCloudModelOverrideRepository({ runtimeRoot }).read(botId);
+  const definition = cloudOverride ?? definitions.readCache(botId);
   if (!definition) return undefined;
 
   if (definition.model.kind === 'custom') {
@@ -87,7 +93,9 @@ export function resolveActiveBotLLMConfig(
     };
   }
 
-  const catalogRuntime = new FileBotCatalogModelRuntimeRepository({ runtimeRoot });
+  const catalogRuntime = cloudOverride
+    ? new FileBotCloudCatalogModelRuntimeRepository({ runtimeRoot })
+    : new FileBotCatalogModelRuntimeRepository({ runtimeRoot });
   const runtime = catalogRuntime.read(botId);
   if (!runtime || !catalogRuntimeMatchesModelId(runtime, definition.model.modelId)) return undefined;
   return {

--- a/src/bot-definition/repository.ts
+++ b/src/bot-definition/repository.ts
@@ -17,6 +17,12 @@ export interface BotDefinitionRepository {
   writeCache(definition: BotDefinition): void;
 }
 
+export interface BotCloudModelOverrideRepository {
+  read(botId: string): BotDefinition | undefined;
+  write(definition: BotDefinition): void;
+  delete(botId: string): void;
+}
+
 /**
  * Per-device catalog runtime material. This is intentionally a separate
  * repository because relay credentials are not part of the portable bot
@@ -36,6 +42,9 @@ export interface FileBotDefinitionRepositoryOptions {
   runtimeRoot?: string;
   simulatedCloudRoot?: string;
   cacheRoot?: string;
+  catalogRuntimeRoot?: string;
+  cloudOverrideRoot?: string;
+  cloudCatalogRuntimeRoot?: string;
 }
 
 function normalizeBotId(botId: string): string {
@@ -217,12 +226,49 @@ export class FileBotDefinitionRepository implements BotDefinitionRepository {
   }
 }
 
+/** Device-local cloud override. The canonical/cache repositories remain the user's local preference. */
+export class FileBotCloudModelOverrideRepository implements BotCloudModelOverrideRepository {
+  private readonly root: string;
+
+  constructor(options: FileBotDefinitionRepositoryOptions = {}) {
+    const runtimeRoot = path.resolve(options.runtimeRoot ?? PathResolver.getRuntimeDataRoot());
+    this.root = path.resolve(
+      options.cloudOverrideRoot ?? path.join(runtimeRoot, 'data', 'bot-cloud-model-override'),
+    );
+  }
+
+  read(botId: string): BotDefinition | undefined {
+    const normalized = normalizeBotId(botId);
+    return readDefinition(this.overridePath(normalized), normalized);
+  }
+
+  write(definition: BotDefinition): void {
+    const botId = normalizeBotId(definition.botId);
+    writeDefinition(this.overridePath(botId), definition);
+  }
+
+  delete(botId: string): void {
+    const normalized = normalizeBotId(botId);
+    fs.rmSync(this.overridePath(normalized), { force: true });
+  }
+
+  getPath(botId: string): string {
+    return this.overridePath(normalizeBotId(botId));
+  }
+
+  private overridePath(botId: string): string {
+    return path.join(this.root, 'bots', `${botId}.json`);
+  }
+}
+
 export class FileBotCatalogModelRuntimeRepository implements BotCatalogModelRuntimeRepository {
   private readonly root: string;
 
   constructor(options: FileBotDefinitionRepositoryOptions = {}) {
     const runtimeRoot = path.resolve(options.runtimeRoot ?? PathResolver.getRuntimeDataRoot());
-    this.root = path.resolve(path.join(runtimeRoot, 'data', 'bot-catalog-model-runtime'));
+    this.root = path.resolve(
+      options.catalogRuntimeRoot ?? path.join(runtimeRoot, 'data', 'bot-catalog-model-runtime'),
+    );
   }
 
   read(botId: string): BotCatalogModelRuntime | undefined {
@@ -248,6 +294,17 @@ export class FileBotCatalogModelRuntimeRepository implements BotCatalogModelRunt
 
   private runtimePath(botId: string): string {
     return path.join(this.root, 'bots', `${botId}.json`);
+  }
+}
+
+export class FileBotCloudCatalogModelRuntimeRepository extends FileBotCatalogModelRuntimeRepository {
+  constructor(options: FileBotDefinitionRepositoryOptions = {}) {
+    const runtimeRoot = path.resolve(options.runtimeRoot ?? PathResolver.getRuntimeDataRoot());
+    super({
+      ...options,
+      catalogRuntimeRoot: options.cloudCatalogRuntimeRoot
+        ?? path.join(runtimeRoot, 'data', 'bot-cloud-catalog-model-runtime'),
+    });
   }
 }
 

--- a/src/bot-definition/runtime-reload.ts
+++ b/src/bot-definition/runtime-reload.ts
@@ -1,0 +1,59 @@
+import type { CloudBotModelSelection } from './cloud-client';
+
+export interface CloudBotModelRuntimeReloadControllerOptions {
+  initialRevision?: number;
+  pullSelection(): Promise<CloudBotModelSelection | undefined>;
+  isIdle(): boolean;
+  applySelection(selection: CloudBotModelSelection): Promise<'applied' | 'deferred'>;
+  onError?(error: unknown, selection?: CloudBotModelSelection): void;
+}
+
+/** Serializes cloud model polling and applies only the newest unhandled revision. */
+export class CloudBotModelRuntimeReloadController {
+  private handledRevision: number;
+  private pendingSelection?: CloudBotModelSelection;
+  private polling = false;
+
+  constructor(private readonly options: CloudBotModelRuntimeReloadControllerOptions) {
+    this.handledRevision = options.initialRevision ?? -1;
+  }
+
+  async pollOnce(): Promise<void> {
+    if (this.polling) return;
+    this.polling = true;
+    let selection: CloudBotModelSelection | undefined;
+    try {
+      selection = await this.options.pullSelection();
+      if (!selection) {
+        this.pendingSelection = undefined;
+        return;
+      }
+      if (selection.revision > this.handledRevision) {
+        if (!this.pendingSelection || selection.revision >= this.pendingSelection.revision) {
+          this.pendingSelection = selection;
+        }
+      }
+      const pending = this.pendingSelection;
+      if (!pending || !this.options.isIdle()) return;
+
+      try {
+        const outcome = await this.options.applySelection(pending);
+        if (outcome === 'deferred') return;
+        this.handledRevision = Math.max(this.handledRevision, pending.revision);
+        if (this.pendingSelection?.revision === pending.revision) {
+          this.pendingSelection = undefined;
+        }
+      } catch (error) {
+        this.handledRevision = Math.max(this.handledRevision, pending.revision);
+        if (this.pendingSelection?.revision === pending.revision) {
+          this.pendingSelection = undefined;
+        }
+        this.options.onError?.(error, pending);
+      }
+    } catch (error) {
+      this.options.onError?.(error, selection);
+    } finally {
+      this.polling = false;
+    }
+  }
+}

--- a/src/bot-definition/service.ts
+++ b/src/bot-definition/service.ts
@@ -314,7 +314,11 @@ function normalizeCatalogRuntime(runtime: BotCatalogModelRuntime): BotCatalogMod
 export function botModelDefinitionFromLocalProfile(profile: LocalModelProfile): BotModelDefinition {
   if (profile.source === 'catalog') {
     if (!profile.modelId) throw new Error('catalog modelId is required');
-    return { kind: 'catalog', modelId: canonicalRelayModelId(profile.modelId) ?? profile.modelId };
+    return {
+      kind: 'catalog',
+      modelId: canonicalRelayModelId(profile.modelId) ?? profile.modelId,
+      ...(profile.reasoningEffort ? { reasoningEffort: profile.reasoningEffort } : {}),
+    };
   }
   if (!profile.provider || !profile.apiBase || !profile.model || !profile.apiKey || !profile.contextWindowTokens) {
     throw new Error('custom model profile is incomplete');
@@ -401,6 +405,22 @@ export class BotDefinitionSyncService {
     return {
       botId,
       direction: 'local_to_simulated_cloud',
+      definition,
+    };
+  }
+
+  acceptCloud(botId: string, model: BotModelDefinition): BotDefinitionSyncResult {
+    const definition: BotDefinition = {
+      schema: BOT_DEFINITION_SCHEMA,
+      botId,
+      model: normalizeBotModelDefinition(model),
+    };
+    this.repository.writeCanonical(definition);
+    this.repository.writeCache(definition);
+    this.clearLegacyModelConfigurationWhenReady(definition);
+    return {
+      botId,
+      direction: 'cloud_to_local',
       definition,
     };
   }

--- a/src/bot-definition/service.ts
+++ b/src/bot-definition/service.ts
@@ -23,9 +23,12 @@ import {
 } from './types';
 import {
   FileBotCatalogModelRuntimeRepository,
+  FileBotCloudCatalogModelRuntimeRepository,
+  FileBotCloudModelOverrideRepository,
   FileBotCustomModelProfileRepository,
   FileBotDefinitionRepository,
   type BotCatalogModelRuntimeRepository,
+  type BotCloudModelOverrideRepository,
   type BotCustomModelProfileRepository,
   type BotDefinitionRepository,
   type FileBotDefinitionRepositoryOptions,
@@ -343,6 +346,8 @@ export function botModelDefinitionFromLocalProfile(profile: LocalModelProfile): 
 export interface BotDefinitionSyncServiceOptions extends FileBotDefinitionRepositoryOptions {
   repository?: BotDefinitionRepository;
   catalogRuntimeRepository?: BotCatalogModelRuntimeRepository;
+  cloudOverrideRepository?: BotCloudModelOverrideRepository;
+  cloudCatalogRuntimeRepository?: BotCatalogModelRuntimeRepository;
   customModelProfileRepository?: BotCustomModelProfileRepository;
   env?: NodeJS.ProcessEnv;
 }
@@ -356,6 +361,8 @@ export class BotDefinitionSyncService {
   private readonly env: NodeJS.ProcessEnv;
   private readonly repository: BotDefinitionRepository;
   private readonly catalogRuntimeRepository: BotCatalogModelRuntimeRepository;
+  private readonly cloudOverrideRepository: BotCloudModelOverrideRepository;
+  private readonly cloudCatalogRuntimeRepository: BotCatalogModelRuntimeRepository;
   private readonly customModelProfileRepository: BotCustomModelProfileRepository;
 
   constructor(options: BotDefinitionSyncServiceOptions = {}) {
@@ -364,6 +371,10 @@ export class BotDefinitionSyncService {
     this.repository = options.repository ?? new FileBotDefinitionRepository(options);
     this.catalogRuntimeRepository = options.catalogRuntimeRepository
       ?? new FileBotCatalogModelRuntimeRepository({ runtimeRoot: this.runtimeRoot });
+    this.cloudOverrideRepository = options.cloudOverrideRepository
+      ?? new FileBotCloudModelOverrideRepository({ runtimeRoot: this.runtimeRoot });
+    this.cloudCatalogRuntimeRepository = options.cloudCatalogRuntimeRepository
+      ?? new FileBotCloudCatalogModelRuntimeRepository({ runtimeRoot: this.runtimeRoot });
     this.customModelProfileRepository = options.customModelProfileRepository
       ?? new FileBotCustomModelProfileRepository({ runtimeRoot: this.runtimeRoot });
   }
@@ -415,14 +426,24 @@ export class BotDefinitionSyncService {
       botId,
       model: normalizeBotModelDefinition(model),
     };
-    this.repository.writeCanonical(definition);
-    this.repository.writeCache(definition);
-    this.clearLegacyModelConfigurationWhenReady(definition);
+    this.cloudOverrideRepository.write(definition);
     return {
       botId,
       direction: 'cloud_to_local',
       definition,
     };
+  }
+
+  readCloudModelOverride(botId: string): BotDefinition | undefined {
+    const raw = this.cloudOverrideRepository.read(botId);
+    if (!raw) return undefined;
+    const normalized = normalizeBotDefinition(raw);
+    if (normalized !== raw) this.cloudOverrideRepository.write(normalized);
+    return normalized;
+  }
+
+  clearCloudModelOverride(botId: string): void {
+    this.cloudOverrideRepository.delete(botId);
   }
 
   storeCatalogRuntime(runtime: BotCatalogModelRuntime): void {
@@ -435,6 +456,20 @@ export class BotDefinitionSyncService {
     const normalized = normalizeCatalogRuntime(runtime);
     if (JSON.stringify(normalized) !== JSON.stringify(runtime)) {
       this.catalogRuntimeRepository.write(normalized);
+    }
+    return normalized;
+  }
+
+  storeCloudCatalogRuntime(runtime: BotCatalogModelRuntime): void {
+    this.cloudCatalogRuntimeRepository.write(normalizeCatalogRuntime(runtime));
+  }
+
+  readCloudCatalogRuntime(botId: string): BotCatalogModelRuntime | undefined {
+    const runtime = this.cloudCatalogRuntimeRepository.read(botId);
+    if (!runtime) return undefined;
+    const normalized = normalizeCatalogRuntime(runtime);
+    if (JSON.stringify(normalized) !== JSON.stringify(runtime)) {
+      this.cloudCatalogRuntimeRepository.write(normalized);
     }
     return normalized;
   }

--- a/src/bot-definition/types.ts
+++ b/src/bot-definition/types.ts
@@ -11,6 +11,7 @@ export const BOT_CUSTOM_MODEL_PROFILE_SCHEMA = 'xiaoba.bot-custom-model-profile.
 export interface CatalogBotModelDefinition {
   kind: 'catalog';
   modelId: string;
+  reasoningEffort?: ReasoningEffort;
 }
 
 /**
@@ -99,6 +100,6 @@ export interface BotCustomModelProfile {
 
 export interface BotDefinitionSyncResult {
   botId: string;
-  direction: 'local_to_simulated_cloud' | 'simulated_cloud_to_local' | 'bootstrap_to_simulated_cloud';
+  direction: 'local_to_simulated_cloud' | 'simulated_cloud_to_local' | 'bootstrap_to_simulated_cloud' | 'cloud_to_local';
   definition: BotDefinition;
 }

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -379,6 +379,7 @@ export class CatsCompanyBot {
   private subAgentCompletionBatches = new Map<string, BackgroundSubAgentCompletionBatch>();
   /** Bot 自身的 uid，用于过滤自己发出的消息 */
   private botUid: string | null = null;
+  private connectorReady = false;
   private runtime: AdapterRuntimeBundle;
   private runtimeProfile: AdapterRuntimeBundle['profile'];
   private localDeviceGrant?: ScopedLocalDeviceGrant;
@@ -459,6 +460,7 @@ export class CatsCompanyBot {
 
     // 注册事件
     this.bot.on('ready', (info: { uid: string; name: string }) => {
+      this.connectorReady = true;
       this.botUid = String(info.uid || '').trim() || this.botUid;
       const botName = info.name.trim() || '(未设置)';
       this.runtimeProfile.displayName = botName;
@@ -489,6 +491,21 @@ export class CatsCompanyBot {
 
     this.bot.connect();
     Logger.success('CatsCo agent 已启动，等待消息...');
+  }
+
+  async waitUntilReady(timeoutMs = 30_000): Promise<void> {
+    if (this.connectorReady) return;
+    await new Promise<void>((resolve, reject) => {
+      const onReady = () => {
+        clearTimeout(timer);
+        resolve();
+      };
+      const timer = setTimeout(() => {
+        this.bot.off('ready', onReady);
+        reject(new Error(`CatsCo connector handshake timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+      this.bot.once('ready', onReady);
+    });
   }
 
   /** Runtime model reloads must not interrupt a turn, queued message, restore, or child result. */
@@ -2795,6 +2812,7 @@ export class CatsCompanyBot {
    * 停止机器人
    */
   async destroy(): Promise<void> {
+    this.connectorReady = false;
     this.stopDeviceRegistrationRefresh();
     this.bot.disconnect();
     await this.sessionManager.destroy();

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -367,6 +367,8 @@ export class CatsCompanyBot {
   private taskStatusTasks = new Map<string, Promise<void>>();
   /** Tracks the visible user turn for cancellation and retry handling. */
   private activeConversationTasks = new Map<string, ActiveConversationTask>();
+  /** Covers message parsing, cloud restore, attachment download, commands, and the model turn. */
+  private activeMessageHandlers = 0;
   /** Invalidates queued or in-flight pre-turn hydration after /clear. */
   private sessionClearGenerations = new Map<string, number>();
   /** Lets /clear cancel an initial cloud restore before it can recreate old history. */
@@ -487,6 +489,16 @@ export class CatsCompanyBot {
 
     this.bot.connect();
     Logger.success('CatsCo agent 已启动，等待消息...');
+  }
+
+  /** Runtime model reloads must not interrupt a turn, queued message, restore, or child result. */
+  isIdleForRuntimeReload(): boolean {
+    return this.activeMessageHandlers === 0
+      && this.sessionExecutionReservations.size === 0
+      && Array.from(this.messageQueue.values()).every(queue => queue.length === 0)
+      && this.cloudSessionRestorePromises.size === 0
+      && this.subAgentCompletionBatches.size === 0
+      && this.sessionManager.isIdle();
   }
 
   private async registerCurrentDevice(): Promise<void> {
@@ -1233,7 +1245,12 @@ export class CatsCompanyBot {
 
     const key = msg.envelope.sessionKey;
 
-    await this.processParsedMessage(msg, key);
+    this.activeMessageHandlers += 1;
+    try {
+      await this.processParsedMessage(msg, key);
+    } finally {
+      this.activeMessageHandlers = Math.max(0, this.activeMessageHandlers - 1);
+    }
   }
 
   private registerSubAgentPlatformCallbacks(

--- a/src/catscompany/relay-model-bootstrap.ts
+++ b/src/catscompany/relay-model-bootstrap.ts
@@ -5,6 +5,7 @@ import {
   type RelayModelProvider,
 } from '../utils/relay-model-profiles';
 import type { BotCatalogModelRuntime } from '../bot-definition/types';
+import type { ReasoningEffort } from '../types';
 
 const REQUEST_TIMEOUT_MS = 10_000;
 
@@ -12,6 +13,7 @@ export interface CatsRelayBootstrapOptions {
   botId: string;
   modelId: string;
   auth: CatsCoAuthSnapshot;
+  reasoningEffort?: ReasoningEffort;
   fetchImpl?: typeof fetch;
 }
 
@@ -51,8 +53,8 @@ export async function provisionCatsRelayCatalogRuntime(
     apiKey,
     model: profile.model,
     contextWindowTokens: profile.contextWindowTokens,
-    reasoningEffort: 'high',
-    openaiApiMode: 'chat_completions',
+    reasoningEffort: options.reasoningEffort ?? 'high',
+    openaiApiMode: profile.openaiApiMode ?? 'chat_completions',
     capabilities: {
       vision: profile.capabilities.vision,
       toolCalling: profile.capabilities.toolCalling,

--- a/src/commands/catscompany.ts
+++ b/src/commands/catscompany.ts
@@ -268,13 +268,21 @@ async function applyCloudModelRuntimeSelection(
     if (previousCloudRuntime) definitionService.storeCloudCatalogRuntime(previousCloudRuntime);
   };
 
-  const prepared = await prepareBoundBotDefinition({
-    runtimeRoot: options.runtimeRoot,
-    botId,
-    auth: options.auth,
-    cloudSelection: options.selection,
-    acknowledgeCloudSelection: false,
-  });
+  let prepared: Awaited<ReturnType<typeof prepareBoundBotDefinition>>;
+  try {
+    prepared = await prepareBoundBotDefinition({
+      runtimeRoot: options.runtimeRoot,
+      botId,
+      auth: options.auth,
+      cloudSelection: options.selection,
+      acknowledgeCloudSelection: false,
+    });
+  } catch (error) {
+    restorePreviousModelFiles();
+    const message = redactCloudBotModelError(error, options.selection);
+    await acknowledgeCloudModelApply(options, message);
+    throw new Error(message);
+  }
   if (!prepared || prepared.cloudRevision !== options.selection.revision || prepared.cloudApplyError) {
     const message = prepared?.cloudApplyError || '云端模型运行材料未能完成准备。';
     restorePreviousModelFiles();
@@ -311,6 +319,7 @@ async function applyCloudModelRuntimeSelection(
     await previousBot.destroy();
     nextBot = new CatsCompanyBot(options.connectorConfig);
     await nextBot.start();
+    await nextBot.waitUntilReady();
     options.replaceBot(nextBot);
   } catch (error) {
     if (nextBot) {
@@ -319,16 +328,13 @@ async function applyCloudModelRuntimeSelection(
       });
     }
     restorePreviousModelFiles();
-    const fallbackBot = new CatsCompanyBot(options.connectorConfig);
-    try {
-      await fallbackBot.start();
-      options.replaceBot(fallbackBot);
-    } catch (fallbackError) {
-      await fallbackBot.destroy().catch(() => undefined);
-      Logger.error(`CatsCo 模型切换回滚后 connector 恢复失败: ${errorMessage(fallbackError)}`);
-    }
     const safeMessage = redactCloudBotModelError(error, options.selection);
     await acknowledgeCloudModelApply(options, safeMessage);
+    await recoverCloudModelFallbackConnector({
+      canApply: options.canApply,
+      createBot: () => new CatsCompanyBot(options.connectorConfig),
+      replaceBot: options.replaceBot,
+    });
     throw new Error(safeMessage);
   }
 
@@ -339,6 +345,44 @@ async function applyCloudModelRuntimeSelection(
       + `，revision=${options.selection.revision}。`,
   );
   return 'applied';
+}
+
+interface RecoverCloudModelFallbackConnectorOptions {
+  canApply(): boolean;
+  createBot(): CatsCompanyBot;
+  replaceBot(bot: CatsCompanyBot): void;
+  retryDelayMs?: number;
+}
+
+export async function recoverCloudModelFallbackConnector(
+  options: RecoverCloudModelFallbackConnectorOptions,
+): Promise<void> {
+  let attempt = 0;
+  while (options.canApply()) {
+    attempt += 1;
+    let fallbackBot: CatsCompanyBot | undefined;
+    try {
+      fallbackBot = options.createBot();
+      await fallbackBot.start();
+      options.replaceBot(fallbackBot);
+      try {
+        await fallbackBot.waitUntilReady();
+      } catch (error) {
+        Logger.error(`CatsCo 模型切换回滚后握手仍未恢复，connector 将继续自动重连: ${errorMessage(error)}`);
+      }
+      return;
+    } catch (error) {
+      if (fallbackBot) await fallbackBot.destroy().catch(() => undefined);
+      Logger.error(`CatsCo 模型切换回滚后 connector 第 ${attempt} 次启动失败，将自动重试: ${errorMessage(error)}`);
+      if (!options.canApply()) break;
+      await delay(options.retryDelayMs ?? Math.min(30_000, attempt * 5_000));
+    }
+  }
+  throw new Error('CatsCo connector fallback recovery was cancelled.');
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, Math.max(0, ms)));
 }
 
 async function acknowledgeCloudModelApply(

--- a/src/commands/catscompany.ts
+++ b/src/commands/catscompany.ts
@@ -12,6 +12,7 @@ import { createCatsCoLocalConfigService, type CatsCoAuthSnapshot } from '../cats
 import {
   acknowledgeCloudBotModelSelection,
   pullCloudBotModelSelection,
+  redactCloudBotModelError,
   type CloudBotModelSelection,
 } from '../bot-definition/cloud-client';
 import { CloudBotModelRuntimeReloadController } from '../bot-definition/runtime-reload';
@@ -322,8 +323,9 @@ async function applyCloudModelRuntimeSelection(
       await fallbackBot.destroy().catch(() => undefined);
       Logger.error(`CatsCo 模型切换回滚后 connector 恢复失败: ${errorMessage(fallbackError)}`);
     }
-    await acknowledgeCloudModelApply(options, errorMessage(error));
-    throw error;
+    const safeMessage = redactCloudBotModelError(error, options.selection);
+    await acknowledgeCloudModelApply(options, safeMessage);
+    throw new Error(safeMessage);
   }
 
   await acknowledgeCloudModelApply(options);
@@ -360,6 +362,7 @@ function cloudSelectionsMatch(
   expected: CloudBotModelSelection,
 ): boolean {
   return current?.revision === expected.revision
+    && (current.kind || 'catalog') === (expected.kind || 'catalog')
     && current.modelId === expected.modelId
     && (current.reasoningEffort || '') === (expected.reasoningEffort || '');
 }

--- a/src/commands/catscompany.ts
+++ b/src/commands/catscompany.ts
@@ -8,8 +8,17 @@ import { resolveCatsCoRuntimeConfig } from '../catscompany/runtime-config';
 import { CatsCoConnectorLock, acquireCatsCoConnectorLock, isProcessAlive } from '../catscompany/connector-lock';
 import { PathResolver } from '../utils/path-resolver';
 import { prepareBoundBotDefinition } from '../bot-definition/activation';
+import { createCatsCoLocalConfigService, type CatsCoAuthSnapshot } from '../catscompany/local-config';
+import {
+  acknowledgeCloudBotModelSelection,
+  pullCloudBotModelSelection,
+  type CloudBotModelSelection,
+} from '../bot-definition/cloud-client';
+import { CloudBotModelRuntimeReloadController } from '../bot-definition/runtime-reload';
+import { createBotDefinitionSyncService } from '../bot-definition/service';
 
 const CONNECTOR_OWNER_POLL_MS = 2000;
+const CLOUD_MODEL_POLL_MS = 5000;
 
 export interface CatsCoCommandConfigResolution {
   config?: CatsCompanyConfig;
@@ -32,8 +41,13 @@ export function resolveCatsCoCommandConfig(
  */
 export async function catscompanyCommand(): Promise<void> {
   const runtimeRoot = PathResolver.getRuntimeDataRoot();
-  const preparedBot = await prepareBoundBotDefinition({ runtimeRoot });
-  if (preparedBot?.initializedDefault) {
+  const preparedBot = await prepareBoundBotDefinition({
+    runtimeRoot,
+    acknowledgeCloudSelection: false,
+  });
+  if (preparedBot?.cloudRevision !== undefined) {
+    Logger.info(`CatsCo bot ${preparedBot.botId} 已准备云端模型配置 revision=${preparedBot.cloudRevision}。`);
+  } else if (preparedBot?.initializedDefault) {
     Logger.info(`CatsCo bot ${preparedBot.botId} 已自动初始化默认模型 MiniMax M3。`);
   } else if (preparedBot?.materializedCatalogRuntime) {
     Logger.info(`CatsCo bot ${preparedBot.botId} 已在当前设备准备 ${preparedBot.definition.model.kind === 'catalog' ? preparedBot.definition.model.modelId : '模型'} 的运行材料。`);
@@ -73,9 +87,12 @@ export async function catscompanyCommand(): Promise<void> {
     return;
   }
 
-  const bot = new CatsCompanyBot(connectorConfig);
+  let bot = new CatsCompanyBot(connectorConfig);
   let lock: CatsCoConnectorLock | null = connectorLock;
   let ownerWatchTimer: NodeJS.Timeout | null = null;
+  let cloudModelWatchTimer: NodeJS.Timeout | null = null;
+  let cloudModelReloadPromise: Promise<void> | null = null;
+  let pendingCloudModelAck: PendingCloudModelAck | null = null;
   let shuttingDown = false;
 
   // 优雅退出
@@ -86,7 +103,12 @@ export async function catscompanyCommand(): Promise<void> {
       clearInterval(ownerWatchTimer);
       ownerWatchTimer = null;
     }
+    if (cloudModelWatchTimer) {
+      clearInterval(cloudModelWatchTimer);
+      cloudModelWatchTimer = null;
+    }
     try {
+      await cloudModelReloadPromise;
       await stopRuntimeCommandSupport();
       await bot.destroy();
     } finally {
@@ -113,6 +135,93 @@ export async function catscompanyCommand(): Promise<void> {
   try {
     await bot.start();
     await startRuntimeCommandSupport();
+    const auth = createCatsCoLocalConfigService({ runtimeRoot }).getAuthState();
+    const modelBotId = String(preparedBot?.botId || connectorConfig.botUid || '').trim();
+    if (preparedBot?.cloudSelection) {
+      const initialApplyError = preparedBot.cloudApplyError || '';
+      try {
+        await acknowledgeCloudBotModelSelection(
+          { botId: modelBotId, auth },
+          preparedBot.cloudSelection,
+          initialApplyError,
+        );
+      } catch (error) {
+        pendingCloudModelAck = {
+          selection: preparedBot.cloudSelection,
+          applyError: initialApplyError,
+          attempts: 0,
+        };
+        Logger.warning(`CatsCo 启动模型状态回报失败，将自动重试: ${errorMessage(error)}`);
+      }
+    }
+    let lastCloudPollWarningAt = 0;
+    const reloadController = new CloudBotModelRuntimeReloadController({
+      initialRevision: preparedBot?.cloudSelection?.revision,
+      pullSelection: async () => {
+        const selection = await pullCloudBotModelSelection({ botId: modelBotId, auth });
+        if (
+          pendingCloudModelAck
+          && (!selection || selection.revision > pendingCloudModelAck.selection.revision)
+        ) {
+          pendingCloudModelAck = null;
+        }
+        return selection;
+      },
+      isIdle: () => !shuttingDown && bot.isIdleForRuntimeReload(),
+      applySelection: async selection => applyCloudModelRuntimeSelection({
+        runtimeRoot,
+        connectorConfig,
+        currentBot: () => bot,
+        replaceBot: next => { bot = next; },
+        botId: modelBotId,
+        canApply: () => !shuttingDown,
+        scheduleAckRetry: (selection, applyError) => {
+          pendingCloudModelAck = { selection, applyError, attempts: 0 };
+        },
+        clearAckRetry: selection => {
+          if (pendingCloudModelAck?.selection.revision === selection.revision) {
+            pendingCloudModelAck = null;
+          }
+        },
+        selection,
+        auth,
+      }),
+      onError: (error, selection) => {
+        const now = Date.now();
+        if (selection || now - lastCloudPollWarningAt >= 60_000) {
+          lastCloudPollWarningAt = now;
+          Logger.warning(
+            selection
+              ? `CatsCo 云端模型 revision=${selection.revision} 运行时切换失败: ${errorMessage(error)}`
+              : `CatsCo 云端模型轮询失败，继续使用当前模型: ${errorMessage(error)}`,
+          );
+        }
+      },
+    });
+    cloudModelWatchTimer = setInterval(() => {
+      if (cloudModelReloadPromise) return;
+      const run = (async () => {
+        if (pendingCloudModelAck) {
+          const pending = pendingCloudModelAck;
+          try {
+            await acknowledgeCloudBotModelSelection({ botId: modelBotId, auth }, pending.selection, pending.applyError);
+            if (pendingCloudModelAck === pending) pendingCloudModelAck = null;
+          } catch (error) {
+            pending.attempts += 1;
+            if (pending.attempts % 12 === 0 && pendingCloudModelAck === pending) {
+              Logger.warning(
+                `CatsCo 云端模型 revision=${pending.selection.revision} 状态回报仍在重试: ${errorMessage(error)}`,
+              );
+            }
+          }
+        }
+        await reloadController.pollOnce();
+      })();
+      cloudModelReloadPromise = run;
+      void run.finally(() => {
+        if (cloudModelReloadPromise === run) cloudModelReloadPromise = null;
+      });
+    }, CLOUD_MODEL_POLL_MS);
   } catch (error) {
     if (ownerWatchTimer) {
       clearInterval(ownerWatchTimer);
@@ -122,4 +231,135 @@ export async function catscompanyCommand(): Promise<void> {
     lock = null;
     throw error;
   }
+}
+
+interface ApplyCloudModelRuntimeSelectionOptions {
+  runtimeRoot: string;
+  connectorConfig: CatsCompanyConfig;
+  currentBot(): CatsCompanyBot;
+  replaceBot(bot: CatsCompanyBot): void;
+  botId: string;
+  canApply(): boolean;
+  scheduleAckRetry(selection: CloudBotModelSelection, applyError: string): void;
+  clearAckRetry(selection: CloudBotModelSelection): void;
+  selection: CloudBotModelSelection;
+  auth: CatsCoAuthSnapshot;
+}
+
+interface PendingCloudModelAck {
+  selection: CloudBotModelSelection;
+  applyError: string;
+  attempts: number;
+}
+
+async function applyCloudModelRuntimeSelection(
+  options: ApplyCloudModelRuntimeSelectionOptions,
+): Promise<'applied' | 'deferred'> {
+  const botId = options.botId;
+  if (!botId || !options.canApply()) return 'deferred';
+  const definitionService = createBotDefinitionSyncService({ runtimeRoot: options.runtimeRoot });
+  const previousDefinition = definitionService.pullOrBootstrap(botId)?.definition;
+  const previousRuntime = previousDefinition?.model.kind === 'catalog'
+    ? definitionService.readCatalogRuntime(botId)
+    : undefined;
+  const restorePreviousModelFiles = () => {
+    if (!previousDefinition) return;
+    definitionService.acceptCloud(botId, previousDefinition.model);
+    if (previousRuntime) definitionService.storeCatalogRuntime(previousRuntime);
+  };
+
+  const prepared = await prepareBoundBotDefinition({
+    runtimeRoot: options.runtimeRoot,
+    botId,
+    auth: options.auth,
+    cloudSelection: options.selection,
+    acknowledgeCloudSelection: false,
+  });
+  if (!prepared || prepared.cloudRevision !== options.selection.revision || prepared.cloudApplyError) {
+    const message = prepared?.cloudApplyError || '云端模型运行材料未能完成准备。';
+    restorePreviousModelFiles();
+    await acknowledgeCloudModelApply(options, message);
+    throw new Error(message);
+  }
+
+  let latestSelection: CloudBotModelSelection | undefined;
+  try {
+    latestSelection = await pullCloudBotModelSelection({ botId, auth: options.auth });
+  } catch (error) {
+    restorePreviousModelFiles();
+    Logger.warning(`CatsCo 模型切换复核失败，已延后本次切换: ${errorMessage(error)}`);
+    return 'deferred';
+  }
+  if (!cloudSelectionsMatch(latestSelection, options.selection)) {
+    restorePreviousModelFiles();
+    return 'deferred';
+  }
+
+  const previousBot = options.currentBot();
+  if (!options.canApply() || !previousBot.isIdleForRuntimeReload()) {
+    restorePreviousModelFiles();
+    return 'deferred';
+  }
+
+  let nextBot: CatsCompanyBot | undefined;
+  try {
+    await previousBot.destroy();
+    nextBot = new CatsCompanyBot(options.connectorConfig);
+    await nextBot.start();
+    options.replaceBot(nextBot);
+  } catch (error) {
+    if (nextBot) {
+      await nextBot.destroy().catch(cleanupError => {
+        Logger.warning(`CatsCo 未启动的新 connector 清理失败: ${errorMessage(cleanupError)}`);
+      });
+    }
+    restorePreviousModelFiles();
+    const fallbackBot = new CatsCompanyBot(options.connectorConfig);
+    try {
+      await fallbackBot.start();
+      options.replaceBot(fallbackBot);
+    } catch (fallbackError) {
+      await fallbackBot.destroy().catch(() => undefined);
+      Logger.error(`CatsCo 模型切换回滚后 connector 恢复失败: ${errorMessage(fallbackError)}`);
+    }
+    await acknowledgeCloudModelApply(options, errorMessage(error));
+    throw error;
+  }
+
+  await acknowledgeCloudModelApply(options);
+  Logger.success(
+    `CatsCo 已在线切换模型到 ${options.selection.modelId}`
+      + `${options.selection.reasoningEffort ? ` (${options.selection.reasoningEffort})` : ''}`
+      + `，revision=${options.selection.revision}。`,
+  );
+  return 'applied';
+}
+
+async function acknowledgeCloudModelApply(
+  options: ApplyCloudModelRuntimeSelectionOptions,
+  applyError = '',
+): Promise<void> {
+  try {
+    await acknowledgeCloudBotModelSelection({
+      botId: options.botId,
+      auth: options.auth,
+    }, options.selection, applyError);
+    options.clearAckRetry(options.selection);
+  } catch (error) {
+    options.scheduleAckRetry(options.selection, applyError);
+    Logger.warning(`CatsCo 云端模型应用状态回报失败: ${errorMessage(error)}`);
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function cloudSelectionsMatch(
+  current: CloudBotModelSelection | undefined,
+  expected: CloudBotModelSelection,
+): boolean {
+  return current?.revision === expected.revision
+    && current.modelId === expected.modelId
+    && (current.reasoningEffort || '') === (expected.reasoningEffort || '');
 }

--- a/src/commands/catscompany.ts
+++ b/src/commands/catscompany.ts
@@ -259,14 +259,13 @@ async function applyCloudModelRuntimeSelection(
   const botId = options.botId;
   if (!botId || !options.canApply()) return 'deferred';
   const definitionService = createBotDefinitionSyncService({ runtimeRoot: options.runtimeRoot });
-  const previousDefinition = definitionService.pullOrBootstrap(botId)?.definition;
-  const previousRuntime = previousDefinition?.model.kind === 'catalog'
-    ? definitionService.readCatalogRuntime(botId)
-    : undefined;
+  definitionService.pullOrBootstrap(botId);
+  const previousCloudDefinition = definitionService.readCloudModelOverride(botId);
+  const previousCloudRuntime = definitionService.readCloudCatalogRuntime(botId);
   const restorePreviousModelFiles = () => {
-    if (!previousDefinition) return;
-    definitionService.acceptCloud(botId, previousDefinition.model);
-    if (previousRuntime) definitionService.storeCatalogRuntime(previousRuntime);
+    if (previousCloudDefinition) definitionService.acceptCloud(botId, previousCloudDefinition.model);
+    else definitionService.clearCloudModelOverride(botId);
+    if (previousCloudRuntime) definitionService.storeCloudCatalogRuntime(previousCloudRuntime);
   };
 
   const prepared = await prepareBoundBotDefinition({
@@ -294,6 +293,11 @@ async function applyCloudModelRuntimeSelection(
   if (!cloudSelectionsMatch(latestSelection, options.selection)) {
     restorePreviousModelFiles();
     return 'deferred';
+  }
+
+  if (options.selection.kind === 'local' && !previousCloudDefinition) {
+    await acknowledgeCloudModelApply(options);
+    return 'applied';
   }
 
   const previousBot = options.currentBot();

--- a/src/core/message-session-manager.ts
+++ b/src/core/message-session-manager.ts
@@ -106,6 +106,15 @@ export class MessageSessionManager {
     session.injectContext(text);
   }
 
+  /** True only when no model turn, cleanup, or child agent is active. */
+  isIdle(): boolean {
+    if (this.destroying.size > 0) return false;
+    for (const [key, session] of this.sessions) {
+      if (session.isBusy() || SubAgentManager.getInstance().hasActiveForParent(key)) return false;
+    }
+    return true;
+  }
+
   private normalizeSessionInput(input: SessionKeyInput): { key: string; route?: SessionRoute } {
     if (isSessionRoute(input)) {
       return { key: input.sessionKey, route: input };

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -3257,6 +3257,18 @@ export function createApiRouter(
     const bodyStatus = await getCatsBotBodyStatus(state, state.botUid, localBodyId);
     const bodyBlocking = bodyStatus.state === 'conflict' || bodyStatus.state === 'auth_error';
     const chatReady = connected && runtime.bodyConfigured && !bodyBlocking;
+    const boundBotId = String(state.botUid || '').trim();
+    const cloudDefinition = boundBotId
+      ? createBotDefinitionSyncService({ runtimeRoot: runtimeDataRoot() }).readCloudModelOverride(boundBotId)
+      : undefined;
+    const cloudModelOverride = cloudDefinition ? {
+      kind: cloudDefinition.model.kind,
+      modelId: cloudDefinition.model.kind === 'catalog' ? cloudDefinition.model.modelId : 'custom',
+      model: cloudDefinition.model.kind === 'catalog'
+        ? cloudDefinition.model.modelId
+        : cloudDefinition.model.model,
+      reasoningEffort: cloudDefinition.model.reasoningEffort || '',
+    } : null;
 
     res.json({
       connected,
@@ -3277,6 +3289,7 @@ export function createApiRouter(
       } : null,
       device: runtime.localConfig.device || null,
       bodyStatus,
+      cloudModelOverride,
       conflicts: runtime.conflicts,
       topicId: chatReady && user?.uid && state.botUid ? p2pTopicId(user.uid, state.botUid) : '',
       httpBaseUrl: state.httpBaseUrl,

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -876,6 +876,7 @@ async function commitCatsBotBindingAndStartConnector(
       runtimeRoot: runtimeDataRoot(),
       botId: input.botUid,
       selectedCatalogRuntime: input.selectedCatalogRuntime,
+      acknowledgeCloudSelection: false,
     });
     const botDefinitionSync = toBotDefinitionSyncPayload(preparedBot?.sync);
     const {
@@ -3402,6 +3403,7 @@ export function createApiRouter(
       const preparedBot = await prepareBoundBotDefinition({
         runtimeRoot: runtimeDataRoot(),
         botId,
+        acknowledgeCloudSelection: false,
       });
       const result = await startCatsCompanyConnectorIfReady(serviceManager);
       if (!result.service) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,7 +3,7 @@ export type ContentBlock =
   | { type: 'image'; source: { type: 'base64'; media_type: 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp'; data: string } };
 
 export type ProviderContentBlock = Record<string, unknown> & { type: string };
-export type ReasoningEffort = 'default' | 'high' | 'max' | 'disabled';
+export type ReasoningEffort = 'default' | 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'disabled';
 export type OpenAIApiMode = 'chat_completions' | 'responses';
 
 export interface Message {

--- a/src/utils/reasoning-effort.ts
+++ b/src/utils/reasoning-effort.ts
@@ -7,11 +7,24 @@ export const REASONING_EFFORT_OPTIONS: ReasoningEffort[] = [
   'disabled',
 ];
 
-type ReasoningModelFamily = 'deepseek' | 'glm';
+export const OPENAI_REASONING_EFFORT_OPTIONS: ReasoningEffort[] = [
+  'none',
+  'minimal',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+];
+
+const NORMALIZABLE_REASONING_EFFORTS = [
+  ...new Set([...REASONING_EFFORT_OPTIONS, ...OPENAI_REASONING_EFFORT_OPTIONS]),
+];
+
+type ReasoningModelFamily = 'deepseek' | 'glm' | 'gpt56';
 
 export function normalizeReasoningEffort(value: unknown): ReasoningEffort | undefined {
   const text = String(value || '').trim().toLowerCase();
-  return REASONING_EFFORT_OPTIONS.includes(text as ReasoningEffort)
+  return NORMALIZABLE_REASONING_EFFORTS.includes(text as ReasoningEffort)
     ? text as ReasoningEffort
     : undefined;
 }
@@ -26,6 +39,12 @@ export function applyOpenAIReasoningOptions(body: Record<string, unknown>, confi
 
   const family = inferReasoningModelFamily(config);
   if (!family) return;
+
+  if (family === 'gpt56') {
+    body.reasoning_effort = effort === 'max' ? 'xhigh' : effort === 'disabled' ? 'none' : effort;
+    delete body.thinking;
+    return;
+  }
 
   if (effort === 'disabled') {
     body.thinking = { type: 'disabled' };
@@ -45,6 +64,7 @@ export function applyAnthropicReasoningOptions(params: Record<string, unknown>, 
 
   const family = inferReasoningModelFamily(config);
   if (!family) return;
+  if (family === 'gpt56') return;
 
   if (effort === 'disabled') {
     params.thinking = { type: 'disabled' };
@@ -68,6 +88,7 @@ export function supportsOpenAIReasoningReplay(config: Pick<ChatConfig, 'model' |
 
 function inferReasoningModelFamily(config: Pick<ChatConfig, 'model' | 'apiUrl'>): ReasoningModelFamily | undefined {
   const text = `${config.model || ''} ${config.apiUrl || ''}`.toLowerCase();
+  if (/\bgpt-5\.6-(terra|sol|luna)\b/.test(text)) return 'gpt56';
   if (text.includes('deepseek')) return 'deepseek';
   if (/\bglm\b|glm-/.test(text)) return 'glm';
   return undefined;

--- a/src/utils/relay-model-profiles.ts
+++ b/src/utils/relay-model-profiles.ts
@@ -1,4 +1,4 @@
-export type RelayModelFamily = 'minimax' | 'deepseek';
+export type RelayModelFamily = 'minimax' | 'deepseek' | 'gpt';
 export type RelayModelProvider = 'anthropic' | 'openai';
 
 export const RELAY_MODEL_BASE_URLS: Record<RelayModelProvider, string> = {
@@ -29,6 +29,7 @@ export interface RelayModelProfile {
   family: RelayModelFamily;
   quotaClass: string;
   preferredProvider: RelayModelProvider;
+  openaiApiMode?: 'chat_completions' | 'responses';
   contextWindowTokens: number;
   capabilities: RelayModelCapabilities;
 }
@@ -76,6 +77,21 @@ export const RELAY_MODEL_PROFILES: RelayModelProfile[] = [
       streaming: true,
     },
   },
+  ...(['terra', 'sol', 'luna'] as const).map(variant => ({
+    id: `gpt-5.6-${variant}`,
+    label: `GPT-5.6 ${variant[0].toUpperCase()}${variant.slice(1)}`,
+    model: `gpt-5.6-${variant}`,
+    family: 'gpt' as const,
+    quotaClass: 'gpt-5.6',
+    preferredProvider: 'openai' as const,
+    openaiApiMode: 'responses' as const,
+    contextWindowTokens: 1_000_000,
+    capabilities: {
+      toolCalling: true,
+      vision: false,
+      streaming: true,
+    },
+  })),
 ];
 
 /** The first-run CatsCo model when the user has not chosen one yet. */

--- a/tests/bot-definition-activation.test.ts
+++ b/tests/bot-definition-activation.test.ts
@@ -4,6 +4,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { prepareBoundBotDefinition } from '../src/bot-definition/activation';
+import { redactCloudBotModelError } from '../src/bot-definition/cloud-client';
 import { createCatsCoLocalConfigService } from '../src/catscompany/local-config';
 import { FileBotCatalogModelRuntimeRepository, FileBotDefinitionRepository } from '../src/bot-definition/repository';
 import { resolveActiveBotLLMConfig } from '../src/bot-definition/llm-config-resolver';
@@ -309,6 +310,146 @@ describe('BotDefinition activation', () => {
     assert.equal(failureAck.revision, 4);
     assert.equal(failureAck.model_id, 'unknown-model');
     assert.match(failureAck.error, /Unknown CatsCo relay model/);
+  });
+
+  test('redacts a cloud custom model API key from runtime errors', () => {
+    const selection = {
+      kind: 'custom' as const,
+      modelId: 'private-model',
+      revision: 3,
+      customModel: {
+        kind: 'custom' as const,
+        protocol: 'openai-responses' as const,
+        apiBase: 'https://models.example.test/v1',
+        model: 'private-model',
+        apiKey: 'sk-secret-value',
+        contextWindowTokens: 128000,
+      },
+    };
+    assert.equal(
+      redactCloudBotModelError(new Error('request failed for sk-secret-value'), selection),
+      'request failed for [REDACTED]',
+    );
+  });
+
+  test('applies an encrypted-at-server custom model without requesting relay runtime material', async () => {
+    const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-cloud-custom-runtime-'));
+    const simulatedCloudRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-cloud-custom-canonical-'));
+    roots.push(runtimeRoot, simulatedCloudRoot);
+    const env = {} as NodeJS.ProcessEnv;
+    createCatsCoLocalConfigService({ runtimeRoot, env }).save({
+      version: 1,
+      endpoints: { httpBaseUrl: 'https://cats.example.test', serverUrl: 'wss://cats.example.test/v0/channels' },
+      account: { token: 'user-token', uid: '7' },
+      currentBot: { uid: '43', apiKey: 'bot-api-key', boundByUserUid: '7', bindingSource: 'test' },
+    });
+
+    const requests: Array<{ path: string; body?: any }> = [];
+    const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(String(input));
+      requests.push({ path: url.pathname, body: init?.body ? JSON.parse(String(init.body)) : undefined });
+      if (url.pathname === '/api/bot/model-config') {
+        return Response.json({
+          uid: 43,
+          configured: true,
+          desired: {
+            kind: 'custom',
+            model_id: 'private-reasoner',
+            reasoning_effort: 'high',
+            revision: 9,
+            custom: {
+              protocol: 'openai-responses',
+              api_base: 'https://models.example.test/v1/',
+              model: 'private-reasoner',
+              api_key: 'sk-runtime-only-secret',
+              context_window_tokens: 256000,
+              max_tokens: 8192,
+              temperature: 0.4,
+              reasoning_effort: 'high',
+            },
+          },
+        });
+      }
+      if (url.pathname === '/api/bot/model-config/ack') {
+        return Response.json({ status: 'applied' });
+      }
+      return Response.json({ error: 'unexpected request' }, { status: 500 });
+    }) as typeof fetch;
+
+    const prepared = await prepareBoundBotDefinition({ runtimeRoot, simulatedCloudRoot, env, fetchImpl });
+    const resolved = resolveActiveBotLLMConfig({ runtimeRoot, env });
+
+    assert.equal(prepared?.cloudRevision, 9);
+    assert.deepStrictEqual(prepared?.definition.model, {
+      kind: 'custom',
+      protocol: 'openai-responses',
+      apiBase: 'https://models.example.test/v1',
+      model: 'private-reasoner',
+      apiKey: 'sk-runtime-only-secret',
+      contextWindowTokens: 256000,
+      maxTokens: 8192,
+      temperature: 0.4,
+      reasoningEffort: 'high',
+    });
+    assert.equal(resolved?.source, 'custom_definition');
+    assert.equal(resolved?.config.openaiApiMode, 'responses');
+    assert.equal(resolved?.config.apiKey, 'sk-runtime-only-secret');
+    assert.equal(requests.some(item => item.path === '/api/relay/config' || item.path === '/api/relay/key'), false);
+    assert.deepStrictEqual(requests.find(item => item.path === '/api/bot/model-config/ack')?.body, {
+      revision: 9,
+      kind: 'custom',
+      model_id: 'private-reasoner',
+      reasoning_effort: 'high',
+    });
+  });
+
+  test('rejects an incomplete cloud custom model and preserves the previous local definition', async () => {
+    const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-invalid-cloud-custom-runtime-'));
+    const simulatedCloudRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-invalid-cloud-custom-canonical-'));
+    roots.push(runtimeRoot, simulatedCloudRoot);
+    const env = {} as NodeJS.ProcessEnv;
+    createCatsCoLocalConfigService({ runtimeRoot, env }).save({
+      version: 1,
+      endpoints: { httpBaseUrl: 'https://cats.example.test', serverUrl: 'wss://cats.example.test/v0/channels' },
+      currentBot: { uid: '43', apiKey: 'bot-api-key', boundByUserUid: '7', bindingSource: 'test' },
+    });
+    const previous = { kind: 'catalog' as const, modelId: 'minimax-m3' };
+    new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot }).writeCanonical({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: '43',
+      model: previous,
+    });
+    new FileBotCatalogModelRuntimeRepository({ runtimeRoot }).write({
+      schema: 'xiaoba.bot-catalog-model-runtime.v1',
+      botId: '43',
+      modelId: 'minimax-m3',
+      provider: 'anthropic',
+      apiBase: 'https://relay.example.test/anthropic',
+      apiKey: 'sk-existing',
+      model: 'MiniMax-M3',
+      contextWindowTokens: 1_000_000,
+    });
+    const fetchImpl = (async (input: string | URL | Request) => {
+      const url = new URL(String(input));
+      if (url.pathname === '/api/bot/model-config') {
+        return Response.json({
+          uid: 43,
+          configured: true,
+          desired: {
+            kind: 'custom', model_id: 'private-model', revision: 10,
+            custom: {
+              protocol: 'openai-responses', api_base: 'https://models.example.test/v1',
+              model: 'private-model', api_key: '', context_window_tokens: 128000,
+            },
+          },
+        });
+      }
+      return Response.json({ error: 'unexpected request' }, { status: 500 });
+    }) as typeof fetch;
+
+    const prepared = await prepareBoundBotDefinition({ runtimeRoot, simulatedCloudRoot, env, fetchImpl });
+    assert.deepStrictEqual(prepared?.definition.model, previous);
+    assert.equal(prepared?.cloudRevision, undefined);
   });
 
   test('does not replace an existing local custom model until the owner enables cloud management', async () => {

--- a/tests/bot-definition-activation.test.ts
+++ b/tests/bot-definition-activation.test.ts
@@ -645,4 +645,50 @@ describe('BotDefinition activation', () => {
     assert.equal(restored?.config.apiKey, 'sk-local-relay');
     assert.equal(localRuntimes.read('43')?.apiKey, 'sk-local-relay');
   });
+
+  test('keeps the cloud override when returning to a local catalog model cannot prepare its runtime', async () => {
+    const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-cloud-local-rollback-runtime-'));
+    const simulatedCloudRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-cloud-local-rollback-canonical-'));
+    roots.push(runtimeRoot, simulatedCloudRoot);
+    const env = {} as NodeJS.ProcessEnv;
+    createCatsCoLocalConfigService({ runtimeRoot, env }).save({
+      version: 1,
+      endpoints: { httpBaseUrl: 'https://cats.example.test', serverUrl: 'wss://cats.example.test/v0/channels' },
+      account: { token: 'user-token', uid: '7' },
+      currentBot: { uid: '43', apiKey: 'bot-api-key', boundByUserUid: '7', bindingSource: 'test' },
+    });
+    new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot }).writeCanonical({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: '43',
+      model: { kind: 'catalog', modelId: 'minimax-m3' },
+    });
+    const cloudModel = {
+      kind: 'custom' as const,
+      protocol: 'openai-responses' as const,
+      apiBase: 'https://cloud.example.test/v1',
+      model: 'cloud-model',
+      apiKey: 'sk-cloud-model',
+      contextWindowTokens: 256_000,
+    };
+    new FileBotCloudModelOverrideRepository({ runtimeRoot }).write({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: '43',
+      model: cloudModel,
+    });
+
+    const prepared = await prepareBoundBotDefinition({
+      runtimeRoot,
+      simulatedCloudRoot,
+      env,
+      fetchImpl: (async () => Response.json({ error: 'relay temporarily unavailable' }, { status: 503 })) as typeof fetch,
+      cloudSelection: { kind: 'local', modelId: 'local', revision: 22 },
+      acknowledgeCloudSelection: false,
+    });
+
+    assert.match(prepared?.cloudApplyError || '', /relay temporarily unavailable/);
+    assert.equal(prepared?.cloudRevision, undefined);
+    assert.deepStrictEqual(new FileBotCloudModelOverrideRepository({ runtimeRoot }).read('43')?.model, cloudModel);
+    assert.equal(resolveActiveBotLLMConfig({ runtimeRoot, env })?.config.model, 'cloud-model');
+    assert.equal(new FileBotCatalogModelRuntimeRepository({ runtimeRoot }).read('43'), undefined);
+  });
 });

--- a/tests/bot-definition-activation.test.ts
+++ b/tests/bot-definition-activation.test.ts
@@ -53,6 +53,9 @@ describe('BotDefinition activation', () => {
     const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
       const url = new URL(String(input));
       requests.push(`${init?.method || 'GET'} ${url.pathname}`);
+      if (url.pathname === '/api/bot/model-config') {
+        return Response.json({ error: 'not deployed' }, { status: 404 });
+      }
       if (url.pathname === '/api/relay/config') {
         return Response.json({
           self_service_enabled: true,
@@ -83,8 +86,272 @@ describe('BotDefinition activation', () => {
     assert.equal(resolveActiveBotLLMConfig({ runtimeRoot, env })?.config.apiKey, 'sk-bravo-relay-material');
     assert.equal(env.CATSCO_RELAY_LLM_API_KEY, undefined);
     assert.deepStrictEqual(requests, [
+      'GET /api/bot/model-config',
       'GET /api/relay/config',
       'GET /api/relay/key',
     ]);
+  });
+
+  test('applies and acknowledges a cloud-selected model after its local runtime is ready', async () => {
+    const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-cloud-model-runtime-'));
+    const simulatedCloudRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-cloud-model-canonical-'));
+    roots.push(runtimeRoot, simulatedCloudRoot);
+    const env = {} as NodeJS.ProcessEnv;
+    createCatsCoLocalConfigService({ runtimeRoot, env }).save({
+      version: 1,
+      endpoints: { httpBaseUrl: 'https://cats.example.test', serverUrl: 'wss://cats.example.test/v0/channels' },
+      account: { token: 'user-token', uid: '7', displayName: 'Alice' },
+      currentBot: {
+        uid: '43', apiKey: 'bot-api-key', boundByUserUid: '7', bindingSource: 'test',
+      },
+    });
+    new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot }).writeCanonical({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: '43',
+      model: { kind: 'catalog', modelId: 'minimax-m3' },
+    });
+
+    const requests: Array<{ method: string; path: string; body?: any; authorization?: string }> = [];
+    const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(String(input));
+      const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+      requests.push({
+        method: init?.method || 'GET',
+        path: url.pathname,
+        body,
+        authorization: new Headers(init?.headers).get('Authorization') || undefined,
+      });
+      if (url.pathname === '/api/bot/model-config') {
+        return Response.json({
+          uid: 43,
+          configured: true,
+          desired: { model_id: 'deepseek-v4-flash', reasoning_effort: 'max', revision: 2 },
+        });
+      }
+      if (url.pathname === '/api/relay/config') {
+        return Response.json({
+          self_service_enabled: true,
+          base_url: 'https://relay.example.test',
+          endpoints: [{ protocol: 'Anthropic-compatible', base_url: 'https://relay.example.test/anthropic' }],
+        });
+      }
+      if (url.pathname === '/api/relay/key') {
+        return Response.json({ key: { state: 'active', key: 'sk-cloud-model' } });
+      }
+      if (url.pathname === '/api/bot/model-config/ack') {
+        return Response.json({ status: 'applied' });
+      }
+      return Response.json({ error: 'unexpected request' }, { status: 500 });
+    }) as typeof fetch;
+
+    const prepared = await prepareBoundBotDefinition({ runtimeRoot, simulatedCloudRoot, env, fetchImpl });
+
+    assert.equal(prepared?.cloudRevision, 2);
+    assert.deepStrictEqual(prepared?.definition.model, {
+      kind: 'catalog', modelId: 'deepseek-v4-flash', reasoningEffort: 'max',
+    });
+    const runtime = new FileBotCatalogModelRuntimeRepository({ runtimeRoot }).read('43');
+    assert.equal(runtime?.modelId, 'deepseek-v4-flash');
+    assert.equal(runtime?.reasoningEffort, 'max');
+    const ack = requests.find(item => item.path === '/api/bot/model-config/ack');
+    assert.deepStrictEqual(ack?.body, {
+      revision: 2,
+      model_id: 'deepseek-v4-flash',
+      reasoning_effort: 'max',
+    });
+    assert.equal(requests.find(item => item.path === '/api/bot/model-config')?.authorization, 'ApiKey bot-api-key');
+    assert.equal(ack?.authorization, 'ApiKey bot-api-key');
+    assert.equal(requests.find(item => item.path === '/api/relay/config')?.authorization, 'Bearer user-token');
+  });
+
+  test('materializes a cloud-selected GPT-5.6 model through OpenAI Responses', async () => {
+    const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-cloud-gpt56-runtime-'));
+    const simulatedCloudRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-cloud-gpt56-canonical-'));
+    roots.push(runtimeRoot, simulatedCloudRoot);
+    const env = {} as NodeJS.ProcessEnv;
+    createCatsCoLocalConfigService({ runtimeRoot, env }).save({
+      version: 1,
+      endpoints: { httpBaseUrl: 'https://cats.example.test', serverUrl: 'wss://cats.example.test/v0/channels' },
+      account: { token: 'user-token', uid: '7', displayName: 'Alice' },
+      currentBot: { uid: '43', apiKey: 'bot-api-key', boundByUserUid: '7', bindingSource: 'test' },
+    });
+
+    let ackBody: any;
+    const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(String(input));
+      if (url.pathname === '/api/bot/model-config') {
+        return Response.json({
+          uid: 43,
+          configured: true,
+          desired: { model_id: 'gpt-5.6-terra', reasoning_effort: 'xhigh', revision: 5 },
+        });
+      }
+      if (url.pathname === '/api/relay/config') {
+        return Response.json({
+          self_service_enabled: true,
+          base_url: 'https://relay.example.test',
+          models: [{ id: 'gpt-5.6-terra', model: 'gpt-5.6-terra', enabled: true }],
+          endpoints: [{ protocol: 'OpenAI-compatible', base_url: 'https://relay.example.test/v1' }],
+        });
+      }
+      if (url.pathname === '/api/relay/key') {
+        return Response.json({ key: { state: 'active', key: 'sk-cloud-gpt56' } });
+      }
+      if (url.pathname === '/api/bot/model-config/ack') {
+        ackBody = JSON.parse(String(init?.body));
+        return Response.json({ status: 'applied' });
+      }
+      return Response.json({ error: 'unexpected request' }, { status: 500 });
+    }) as typeof fetch;
+
+    const prepared = await prepareBoundBotDefinition({ runtimeRoot, simulatedCloudRoot, env, fetchImpl });
+    const runtime = new FileBotCatalogModelRuntimeRepository({ runtimeRoot }).read('43');
+
+    assert.equal(prepared?.cloudRevision, 5);
+    assert.equal(runtime?.provider, 'openai');
+    assert.equal(runtime?.openaiApiMode, 'responses');
+    assert.equal(runtime?.model, 'gpt-5.6-terra');
+    assert.equal(runtime?.reasoningEffort, 'xhigh');
+    assert.deepStrictEqual(ackBody, {
+      revision: 5,
+      model_id: 'gpt-5.6-terra',
+      reasoning_effort: 'xhigh',
+    });
+  });
+
+  test('prepares an exact runtime reload selection without polling or acknowledging early', async () => {
+    const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-cloud-runtime-reload-'));
+    const simulatedCloudRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-cloud-runtime-reload-canonical-'));
+    roots.push(runtimeRoot, simulatedCloudRoot);
+    const env = {} as NodeJS.ProcessEnv;
+    createCatsCoLocalConfigService({ runtimeRoot, env }).save({
+      version: 1,
+      endpoints: { httpBaseUrl: 'https://cats.example.test', serverUrl: 'wss://cats.example.test/v0/channels' },
+      account: { token: 'user-token', uid: '7' },
+      currentBot: { uid: '43', apiKey: 'bot-api-key', boundByUserUid: '7', bindingSource: 'test' },
+    });
+    const requestedPaths: string[] = [];
+    const fetchImpl = (async (input: string | URL | Request) => {
+      const url = new URL(String(input));
+      requestedPaths.push(url.pathname);
+      if (url.pathname === '/api/relay/config') {
+        return Response.json({
+          self_service_enabled: true,
+          base_url: 'https://relay.example.test',
+          models: [{ id: 'gpt-5.6-luna', model: 'gpt-5.6-luna', enabled: true }],
+          endpoints: [{ protocol: 'OpenAI-compatible', base_url: 'https://relay.example.test/v1' }],
+        });
+      }
+      if (url.pathname === '/api/relay/key') {
+        return Response.json({ key: { state: 'active', key: 'sk-runtime-reload' } });
+      }
+      return Response.json({ error: 'unexpected request' }, { status: 500 });
+    }) as typeof fetch;
+
+    const prepared = await prepareBoundBotDefinition({
+      runtimeRoot,
+      simulatedCloudRoot,
+      env,
+      auth: createCatsCoLocalConfigService({ runtimeRoot, env }).getAuthState(),
+      fetchImpl,
+      cloudSelection: { modelId: 'gpt-5.6-luna', reasoningEffort: 'medium', revision: 8 },
+      acknowledgeCloudSelection: false,
+    });
+
+    assert.equal(prepared?.cloudRevision, 8);
+    assert.equal(requestedPaths.includes('/api/bot/model-config'), false);
+    assert.equal(requestedPaths.includes('/api/bot/model-config/ack'), false);
+  });
+
+  test('keeps the last runnable local model when a cloud selection cannot be applied', async () => {
+    const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-cloud-model-fallback-runtime-'));
+    const simulatedCloudRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-cloud-model-fallback-canonical-'));
+    roots.push(runtimeRoot, simulatedCloudRoot);
+    const env = {} as NodeJS.ProcessEnv;
+    createCatsCoLocalConfigService({ runtimeRoot, env }).save({
+      version: 1,
+      endpoints: { httpBaseUrl: 'https://cats.example.test', serverUrl: 'wss://cats.example.test/v0/channels' },
+      account: { token: 'user-token', uid: '7' },
+      currentBot: { uid: '43', apiKey: 'bot-api-key', boundByUserUid: '7', bindingSource: 'test' },
+    });
+    new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot }).writeCanonical({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: '43',
+      model: { kind: 'catalog', modelId: 'minimax-m3' },
+    });
+    new FileBotCatalogModelRuntimeRepository({ runtimeRoot }).write({
+      schema: 'xiaoba.bot-catalog-model-runtime.v1',
+      botId: '43',
+      modelId: 'minimax-m3',
+      provider: 'anthropic',
+      apiBase: 'https://relay.example.test/anthropic',
+      apiKey: 'sk-existing',
+      model: 'MiniMax-M3',
+      contextWindowTokens: 1_000_000,
+    });
+    let failureAck: any;
+    const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(String(input));
+      if (url.pathname === '/api/bot/model-config') {
+        return Response.json({ uid: 43, configured: true, desired: { model_id: 'unknown-model', revision: 4 } });
+      }
+      if (url.pathname === '/api/bot/model-config/ack') {
+        failureAck = JSON.parse(String(init?.body));
+        return Response.json({ status: 'failed' });
+      }
+      return Response.json({ error: 'unexpected request' }, { status: 500 });
+    }) as typeof fetch;
+
+    const prepared = await prepareBoundBotDefinition({ runtimeRoot, simulatedCloudRoot, env, fetchImpl });
+
+    assert.deepStrictEqual(prepared?.definition.model, { kind: 'catalog', modelId: 'minimax-m3' });
+    assert.equal(new FileBotCatalogModelRuntimeRepository({ runtimeRoot }).read('43')?.apiKey, 'sk-existing');
+    assert.equal(failureAck.revision, 4);
+    assert.equal(failureAck.model_id, 'unknown-model');
+    assert.match(failureAck.error, /Unknown CatsCo relay model/);
+  });
+
+  test('does not replace an existing local custom model until the owner enables cloud management', async () => {
+    const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-cloud-model-opt-in-runtime-'));
+    const simulatedCloudRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-cloud-model-opt-in-canonical-'));
+    roots.push(runtimeRoot, simulatedCloudRoot);
+    const env = {} as NodeJS.ProcessEnv;
+    createCatsCoLocalConfigService({ runtimeRoot, env }).save({
+      version: 1,
+      endpoints: { httpBaseUrl: 'https://cats.example.test', serverUrl: 'wss://cats.example.test/v0/channels' },
+      currentBot: { uid: '43', apiKey: 'bot-api-key', boundByUserUid: '7', bindingSource: 'test' },
+    });
+    const customModel = {
+      kind: 'custom' as const,
+      protocol: 'openai-responses' as const,
+      apiBase: 'https://custom.example.test/v1',
+      apiKey: 'sk-local-custom',
+      model: 'custom-model',
+      contextWindowTokens: 128_000,
+    };
+    new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot }).writeCanonical({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: '43',
+      model: customModel,
+    });
+    let acknowledged = false;
+    const fetchImpl = (async (input: string | URL | Request) => {
+      const url = new URL(String(input));
+      if (url.pathname === '/api/bot/model-config') {
+        return Response.json({
+          uid: 43,
+          configured: false,
+          desired: { model_id: 'minimax-m3', reasoning_effort: '', revision: 0 },
+        });
+      }
+      if (url.pathname === '/api/bot/model-config/ack') acknowledged = true;
+      return Response.json({ error: 'unexpected request' }, { status: 500 });
+    }) as typeof fetch;
+
+    const prepared = await prepareBoundBotDefinition({ runtimeRoot, simulatedCloudRoot, env, fetchImpl });
+
+    assert.deepStrictEqual(prepared?.definition.model, customModel);
+    assert.equal(prepared?.cloudRevision, undefined);
+    assert.equal(acknowledged, false);
   });
 });

--- a/tests/bot-definition-activation.test.ts
+++ b/tests/bot-definition-activation.test.ts
@@ -6,7 +6,13 @@ import * as path from 'node:path';
 import { prepareBoundBotDefinition } from '../src/bot-definition/activation';
 import { redactCloudBotModelError } from '../src/bot-definition/cloud-client';
 import { createCatsCoLocalConfigService } from '../src/catscompany/local-config';
-import { FileBotCatalogModelRuntimeRepository, FileBotDefinitionRepository } from '../src/bot-definition/repository';
+import {
+  FileBotCatalogModelRuntimeRepository,
+  FileBotCloudCatalogModelRuntimeRepository,
+  FileBotCloudModelOverrideRepository,
+  FileBotCustomModelProfileRepository,
+  FileBotDefinitionRepository,
+} from '../src/bot-definition/repository';
 import { resolveActiveBotLLMConfig } from '../src/bot-definition/llm-config-resolver';
 import { BOT_DEFINITION_SCHEMA } from '../src/bot-definition/types';
 
@@ -151,9 +157,10 @@ describe('BotDefinition activation', () => {
     assert.deepStrictEqual(prepared?.definition.model, {
       kind: 'catalog', modelId: 'deepseek-v4-flash', reasoningEffort: 'max',
     });
-    const runtime = new FileBotCatalogModelRuntimeRepository({ runtimeRoot }).read('43');
+    const runtime = new FileBotCloudCatalogModelRuntimeRepository({ runtimeRoot }).read('43');
     assert.equal(runtime?.modelId, 'deepseek-v4-flash');
     assert.equal(runtime?.reasoningEffort, 'max');
+    assert.equal(new FileBotCatalogModelRuntimeRepository({ runtimeRoot }).read('43'), undefined);
     const ack = requests.find(item => item.path === '/api/bot/model-config/ack');
     assert.deepStrictEqual(ack?.body, {
       revision: 2,
@@ -206,7 +213,7 @@ describe('BotDefinition activation', () => {
     }) as typeof fetch;
 
     const prepared = await prepareBoundBotDefinition({ runtimeRoot, simulatedCloudRoot, env, fetchImpl });
-    const runtime = new FileBotCatalogModelRuntimeRepository({ runtimeRoot }).read('43');
+    const runtime = new FileBotCloudCatalogModelRuntimeRepository({ runtimeRoot }).read('43');
 
     assert.equal(prepared?.cloudRevision, 5);
     assert.equal(runtime?.provider, 'openai');
@@ -494,5 +501,148 @@ describe('BotDefinition activation', () => {
     assert.deepStrictEqual(prepared?.definition.model, customModel);
     assert.equal(prepared?.cloudRevision, undefined);
     assert.equal(acknowledged, false);
+  });
+
+  test('keeps local model state separate across cloud apply, restart, and return to device local', async () => {
+    const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-cloud-overlay-runtime-'));
+    const simulatedCloudRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-cloud-overlay-canonical-'));
+    roots.push(runtimeRoot, simulatedCloudRoot);
+    const env = {} as NodeJS.ProcessEnv;
+    createCatsCoLocalConfigService({ runtimeRoot, env }).save({
+      version: 1,
+      endpoints: { httpBaseUrl: 'https://cats.example.test', serverUrl: 'wss://cats.example.test/v0/channels' },
+      currentBot: { uid: '43', apiKey: 'bot-api-key', boundByUserUid: '7', bindingSource: 'test' },
+    });
+    const localModel = {
+      kind: 'custom' as const,
+      protocol: 'openai-responses' as const,
+      apiBase: 'https://local.example.test/v1',
+      model: 'local-model',
+      apiKey: 'sk-local-model',
+      contextWindowTokens: 128_000,
+    };
+    const localDefinition = { schema: BOT_DEFINITION_SCHEMA, botId: '43', model: localModel } as const;
+    const definitions = new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot });
+    definitions.writeCanonical(localDefinition);
+
+    const cloudModel = {
+      kind: 'custom' as const,
+      protocol: 'openai-responses' as const,
+      apiBase: 'https://cloud.example.test/v1',
+      model: 'cloud-model',
+      apiKey: 'sk-cloud-model',
+      contextWindowTokens: 256_000,
+      reasoningEffort: 'high' as const,
+    };
+    const cloudPrepared = await prepareBoundBotDefinition({
+      runtimeRoot,
+      simulatedCloudRoot,
+      env,
+      cloudSelection: {
+        kind: 'custom', modelId: 'cloud-model', revision: 11,
+        reasoningEffort: 'high', customModel: cloudModel,
+      },
+      acknowledgeCloudSelection: false,
+    });
+
+    assert.equal(cloudPrepared?.cloudRevision, 11);
+    assert.equal(resolveActiveBotLLMConfig({ runtimeRoot, env })?.config.model, 'cloud-model');
+    assert.deepStrictEqual(definitions.readCanonical('43'), localDefinition);
+    assert.deepStrictEqual(definitions.readCache('43'), localDefinition);
+    assert.deepStrictEqual(new FileBotCustomModelProfileRepository({ runtimeRoot }).read('43')?.model, localModel);
+    assert.equal(new FileBotCloudModelOverrideRepository({ runtimeRoot }).read('43')?.model.kind, 'custom');
+
+    const restartPrepared = await prepareBoundBotDefinition({
+      runtimeRoot,
+      simulatedCloudRoot,
+      env,
+      fetchImpl: (async () => Response.json({ error: 'temporary outage' }, { status: 500 })) as typeof fetch,
+      acknowledgeCloudSelection: false,
+    });
+    assert.equal(restartPrepared?.definition.model.kind, 'custom');
+    assert.equal(resolveActiveBotLLMConfig({ runtimeRoot, env })?.config.model, 'cloud-model');
+
+    const localPrepared = await prepareBoundBotDefinition({
+      runtimeRoot,
+      simulatedCloudRoot,
+      env,
+      cloudSelection: { kind: 'local', modelId: 'local', revision: 12 },
+      acknowledgeCloudSelection: false,
+    });
+    assert.equal(localPrepared?.cloudRevision, 12);
+    assert.equal(resolveActiveBotLLMConfig({ runtimeRoot, env })?.config.model, 'local-model');
+    assert.equal(new FileBotCloudModelOverrideRepository({ runtimeRoot }).read('43'), undefined);
+    assert.deepStrictEqual(definitions.readCanonical('43'), localDefinition);
+    assert.deepStrictEqual(new FileBotCustomModelProfileRepository({ runtimeRoot }).read('43')?.model, localModel);
+  });
+
+  test('restores the untouched local catalog runtime after a cloud catalog round trip', async () => {
+    const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-cloud-catalog-roundtrip-runtime-'));
+    const simulatedCloudRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-cloud-catalog-roundtrip-canonical-'));
+    roots.push(runtimeRoot, simulatedCloudRoot);
+    const env = {} as NodeJS.ProcessEnv;
+    createCatsCoLocalConfigService({ runtimeRoot, env }).save({
+      version: 1,
+      endpoints: { httpBaseUrl: 'https://cats.example.test', serverUrl: 'wss://cats.example.test/v0/channels' },
+      account: { token: 'user-token', uid: '7' },
+      currentBot: { uid: '43', apiKey: 'bot-api-key', boundByUserUid: '7', bindingSource: 'test' },
+    });
+    const definitions = new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot });
+    definitions.writeCanonical({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: '43',
+      model: { kind: 'catalog', modelId: 'minimax-m3' },
+    });
+    const localRuntimes = new FileBotCatalogModelRuntimeRepository({ runtimeRoot });
+    localRuntimes.write({
+      schema: 'xiaoba.bot-catalog-model-runtime.v1',
+      botId: '43',
+      modelId: 'minimax-m3',
+      provider: 'anthropic',
+      apiBase: 'https://relay.example.test/anthropic',
+      apiKey: 'sk-local-relay',
+      model: 'MiniMax-M3',
+      contextWindowTokens: 1_000_000,
+    });
+    const fetchImpl = (async (input: string | URL | Request) => {
+      const url = new URL(String(input));
+      if (url.pathname === '/api/relay/config') {
+        return Response.json({
+          self_service_enabled: true,
+          base_url: 'https://relay.example.test',
+          endpoints: [{ protocol: 'Anthropic-compatible', base_url: 'https://relay.example.test/anthropic' }],
+        });
+      }
+      if (url.pathname === '/api/relay/key') {
+        return Response.json({ key: { state: 'active', key: 'sk-cloud-relay' } });
+      }
+      if (url.pathname === '/api/bot/model-config/ack') {
+        return Response.json({ status: 'applied' });
+      }
+      return Response.json({ error: 'unexpected request' }, { status: 500 });
+    }) as typeof fetch;
+
+    await prepareBoundBotDefinition({
+      runtimeRoot,
+      simulatedCloudRoot,
+      env,
+      fetchImpl,
+      cloudSelection: { kind: 'catalog', modelId: 'deepseek-v4-flash', reasoningEffort: 'max', revision: 20 },
+    });
+    assert.equal(resolveActiveBotLLMConfig({ runtimeRoot, env })?.config.model, 'deepseek-v4-flash');
+    assert.equal(resolveActiveBotLLMConfig({ runtimeRoot, env })?.config.apiKey, 'sk-cloud-relay');
+    assert.equal(localRuntimes.read('43')?.apiKey, 'sk-local-relay');
+
+    await prepareBoundBotDefinition({
+      runtimeRoot,
+      simulatedCloudRoot,
+      env,
+      fetchImpl,
+      cloudSelection: { kind: 'local', modelId: 'local', revision: 21 },
+    });
+    const restored = resolveActiveBotLLMConfig({ runtimeRoot, env });
+    assert.equal(restored?.config.model, 'MiniMax-M3');
+    assert.equal(restored?.config.apiKey, 'sk-local-relay');
+    assert.equal(localRuntimes.read('43')?.apiKey, 'sk-local-relay');
   });
 });

--- a/tests/catscompany-runtime-ready.test.ts
+++ b/tests/catscompany-runtime-ready.test.ts
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { describe, test } from 'node:test';
+import { CatsCompanyBot } from '../src/catscompany';
+import { recoverCloudModelFallbackConnector } from '../src/commands/catscompany';
+
+describe('CatsCompanyBot runtime readiness', () => {
+  test('waits for the connector handshake before resolving', async () => {
+    const events = new EventEmitter();
+    const bot = Object.create(CatsCompanyBot.prototype) as any;
+    bot.bot = events;
+    bot.connectorReady = false;
+
+    let resolved = false;
+    const pending = bot.waitUntilReady(1_000).then(() => { resolved = true; });
+    await new Promise(resolve => setTimeout(resolve, 10));
+    assert.equal(resolved, false);
+
+    bot.connectorReady = true;
+    events.emit('ready', { uid: '43', name: 'Bot' });
+    await pending;
+    assert.equal(resolved, true);
+  });
+
+  test('rejects when the connector never completes its handshake', async () => {
+    const bot = Object.create(CatsCompanyBot.prototype) as any;
+    bot.bot = new EventEmitter();
+    bot.connectorReady = false;
+
+    await assert.rejects(bot.waitUntilReady(20), /handshake timed out/);
+    assert.equal(bot.bot.listenerCount('ready'), 0);
+  });
+
+  test('retries fallback construction until an old-model connector can start', async () => {
+    let attempts = 0;
+    let destroyed = 0;
+    let replacement: unknown;
+    const recovered = {
+      start: async () => undefined,
+      waitUntilReady: async () => undefined,
+      destroy: async () => { destroyed += 1; },
+    };
+
+    await recoverCloudModelFallbackConnector({
+      canApply: () => true,
+      retryDelayMs: 0,
+      createBot: () => {
+        attempts += 1;
+        if (attempts < 3) {
+          return {
+            start: async () => { throw new Error('temporary startup failure'); },
+            waitUntilReady: async () => undefined,
+            destroy: async () => { destroyed += 1; },
+          } as any;
+        }
+        return recovered as any;
+      },
+      replaceBot: bot => { replacement = bot; },
+    });
+
+    assert.equal(attempts, 3);
+    assert.equal(destroyed, 2);
+    assert.equal(replacement, recovered);
+  });
+
+  test('keeps a started fallback alive when its websocket will continue reconnecting', async () => {
+    let destroyed = 0;
+    let replacement: unknown;
+    const fallback = {
+      start: async () => undefined,
+      waitUntilReady: async () => { throw new Error('handshake timeout'); },
+      destroy: async () => { destroyed += 1; },
+    };
+
+    await recoverCloudModelFallbackConnector({
+      canApply: () => true,
+      retryDelayMs: 0,
+      createBot: () => fallback as any,
+      replaceBot: bot => { replacement = bot; },
+    });
+
+    assert.equal(replacement, fallback);
+    assert.equal(destroyed, 0);
+  });
+});

--- a/tests/cloud-bot-model-client.test.ts
+++ b/tests/cloud-bot-model-client.test.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  acknowledgeCloudBotModelSelection,
+  pullCloudBotModelSelection,
+} from '../src/bot-definition/cloud-client';
+
+const auth = {
+  apiKey: 'bot-api-key',
+  httpBaseUrl: 'https://cats.example.test',
+} as any;
+
+describe('cloud bot model client local handoff', () => {
+  test('returns an explicit local revision after cloud management is disabled', async () => {
+    const selection = await pullCloudBotModelSelection({
+      botId: '43',
+      auth,
+      fetchImpl: (async () => Response.json({
+        uid: 43,
+        configured: false,
+        desired: { kind: 'local', model_id: 'local', revision: 7 },
+      })) as typeof fetch,
+    });
+
+    assert.deepStrictEqual(selection, { kind: 'local', modelId: 'local', revision: 7 });
+  });
+
+  test('keeps an untouched revision zero configuration as local-only state', async () => {
+    const selection = await pullCloudBotModelSelection({
+      botId: '43',
+      auth,
+      fetchImpl: (async () => Response.json({
+        uid: 43,
+        configured: false,
+        desired: { kind: 'local', model_id: 'local', revision: 0 },
+      })) as typeof fetch,
+    });
+
+    assert.equal(selection, undefined);
+  });
+
+  test('acknowledges a local handoff with its revision', async () => {
+    let requestBody: any;
+    await acknowledgeCloudBotModelSelection({
+      botId: '43',
+      auth,
+      fetchImpl: (async (_input, init) => {
+        requestBody = JSON.parse(String(init?.body));
+        return Response.json({ status: 'applied' });
+      }) as typeof fetch,
+    }, { kind: 'local', modelId: 'local', revision: 8 });
+
+    assert.deepStrictEqual(requestBody, {
+      revision: 8,
+      kind: 'local',
+      model_id: 'local',
+      reasoning_effort: '',
+    });
+  });
+});

--- a/tests/cloud-bot-model-runtime-reload.test.ts
+++ b/tests/cloud-bot-model-runtime-reload.test.ts
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { CloudBotModelRuntimeReloadController } from '../src/bot-definition/runtime-reload';
+import type { CloudBotModelSelection } from '../src/bot-definition/cloud-client';
+
+describe('CloudBotModelRuntimeReloadController', () => {
+  test('applies each new revision once', async () => {
+    let selection: CloudBotModelSelection | undefined = { modelId: 'minimax-m3', revision: 2 };
+    const applied: number[] = [];
+    const controller = new CloudBotModelRuntimeReloadController({
+      initialRevision: 1,
+      pullSelection: async () => selection,
+      isIdle: () => true,
+      applySelection: async value => {
+        applied.push(value.revision);
+        return 'applied';
+      },
+    });
+
+    await controller.pollOnce();
+    await controller.pollOnce();
+    selection = { modelId: 'gpt-5.6-terra', reasoningEffort: 'high', revision: 3 };
+    await controller.pollOnce();
+
+    assert.deepStrictEqual(applied, [2, 3]);
+  });
+
+  test('keeps the latest revision pending until the runtime is idle', async () => {
+    let idle = false;
+    let selection: CloudBotModelSelection | undefined = { modelId: 'minimax-m3', revision: 2 };
+    const applied: CloudBotModelSelection[] = [];
+    const controller = new CloudBotModelRuntimeReloadController({
+      pullSelection: async () => selection,
+      isIdle: () => idle,
+      applySelection: async value => {
+        applied.push(value);
+        return 'applied';
+      },
+    });
+
+    await controller.pollOnce();
+    selection = { modelId: 'gpt-5.6-sol', reasoningEffort: 'medium', revision: 3 };
+    await controller.pollOnce();
+    idle = true;
+    await controller.pollOnce();
+
+    assert.deepStrictEqual(applied, [selection]);
+  });
+
+  test('does not loop a failed revision and allows a newer retry revision', async () => {
+    let selection: CloudBotModelSelection = { modelId: 'gpt-5.6-luna', revision: 4 };
+    const attempts: number[] = [];
+    const errors: number[] = [];
+    const controller = new CloudBotModelRuntimeReloadController({
+      pullSelection: async () => selection,
+      isIdle: () => true,
+      applySelection: async value => {
+        attempts.push(value.revision);
+        throw new Error('reload failed');
+      },
+      onError: (_error, value) => errors.push(value?.revision ?? -1),
+    });
+
+    await controller.pollOnce();
+    await controller.pollOnce();
+    selection = { ...selection, revision: 5 };
+    await controller.pollOnce();
+
+    assert.deepStrictEqual(attempts, [4, 5]);
+    assert.deepStrictEqual(errors, [4, 5]);
+  });
+
+  test('drops a deferred cloud selection after cloud management is disabled', async () => {
+    let selection: CloudBotModelSelection | undefined = { modelId: 'minimax-m3', revision: 2 };
+    let idle = false;
+    let applyCount = 0;
+    const controller = new CloudBotModelRuntimeReloadController({
+      pullSelection: async () => selection,
+      isIdle: () => idle,
+      applySelection: async () => {
+        applyCount += 1;
+        return 'applied';
+      },
+    });
+
+    await controller.pollOnce();
+    selection = undefined;
+    await controller.pollOnce();
+    idle = true;
+    await controller.pollOnce();
+
+    assert.equal(applyCount, 0);
+  });
+});

--- a/tests/dashboard-catsco-auth-status.test.ts
+++ b/tests/dashboard-catsco-auth-status.test.ts
@@ -9,6 +9,7 @@ import type { Server } from 'http';
 import { createApiRouter } from '../src/dashboard/routes/api';
 import { createCatsCoLocalConfigService } from '../src/catscompany/local-config';
 import { FileBotCatalogModelRuntimeRepository, FileBotDefinitionRepository } from '../src/bot-definition/repository';
+import { createBotDefinitionSyncService } from '../src/bot-definition/service';
 import { resolveActiveBotLLMConfig } from '../src/bot-definition/llm-config-resolver';
 import { BOT_CATALOG_MODEL_RUNTIME_SCHEMA, BOT_DEFINITION_SCHEMA } from '../src/bot-definition/types';
 
@@ -432,6 +433,11 @@ describe('dashboard CatsCo account status', () => {
         installationId: 'body-local',
       },
     });
+    createBotDefinitionSyncService({ runtimeRoot: testRoot }).acceptCloud('110', {
+      kind: 'catalog',
+      modelId: 'gpt-5.6-sol',
+      reasoningEffort: 'high',
+    });
 
     const response = await fetch(`${dashboardBaseUrl}/api/cats/status`);
     const data = await response.json() as any;
@@ -444,6 +450,12 @@ describe('dashboard CatsCo account status', () => {
     assert.equal(data.unconfirmedBotBinding, false);
     assert.equal(data.botUid, '110');
     assert.equal(data.bodyStatus.state, 'online');
+    assert.deepStrictEqual(data.cloudModelOverride, {
+      kind: 'catalog',
+      modelId: 'gpt-5.6-sol',
+      model: 'gpt-5.6-sol',
+      reasoningEffort: 'high',
+    });
     assert.equal(data.topicId, 'p2p_42_110');
   });
 

--- a/tests/dashboard-productization-html.test.ts
+++ b/tests/dashboard-productization-html.test.ts
@@ -189,6 +189,8 @@ test('CatsCo Chat page is driven by readiness state instead of loose controls', 
   assert.match(dashboardHtml, /if\(!connected\)\{\s*list\.classList\.remove\('compact'\);\s*list\.innerHTML='';\s*return;\s*\}/);
   assert.match(dashboardHtml, /diagnostics\.style\.display=connected\?'block':'none'/);
   assert.match(dashboardHtml, /function renderCatsRelayModelPanel\(\)/);
+  assert.match(dashboardHtml, /云端当前覆盖/);
+  assert.match(dashboardHtml, /cloudModelOverride/);
   assert.match(dashboardHtml, /function runCatsNextAction\(\)/);
   assert.match(dashboardHtml, /先完成模型来源/);
   assert.match(dashboardHtml, /启动模型/);

--- a/tests/message-session-manager.test.ts
+++ b/tests/message-session-manager.test.ts
@@ -213,6 +213,31 @@ describe('MessageSessionManager', () => {
     }
   });
 
+  test('reports idle only when sessions and their subagents are inactive', async () => {
+    const { MessageSessionManager, SubAgentManager } = loadSessionManagerModules();
+    const manager = new MessageSessionManager(buildMockServices(), 'runtime-reload-idle-test');
+    const subAgentManager = SubAgentManager.getInstance();
+    const originalHasActiveForParent = subAgentManager.hasActiveForParent.bind(subAgentManager);
+
+    try {
+      assert.equal(manager.isIdle(), true);
+      const session = manager.getOrCreate('user:runtime-reload');
+      const originalIsBusy = session.isBusy.bind(session);
+      (session as any).isBusy = () => true;
+      assert.equal(manager.isIdle(), false);
+
+      (session as any).isBusy = originalIsBusy;
+      (subAgentManager as any).hasActiveForParent = (key: string) => key === session.key;
+      assert.equal(manager.isIdle(), false);
+
+      (subAgentManager as any).hasActiveForParent = () => false;
+      assert.equal(manager.isIdle(), true);
+    } finally {
+      (subAgentManager as any).hasActiveForParent = originalHasActiveForParent;
+      await manager.destroy();
+    }
+  });
+
   test('ttl cleanup saves expired sessions without hidden AI wakeup', async () => {
     const { MessageSessionManager, SessionStore } = loadSessionManagerModules();
     let aiCalls = 0;

--- a/tests/model-capabilities.test.ts
+++ b/tests/model-capabilities.test.ts
@@ -62,10 +62,14 @@ describe('model capabilities', () => {
         { model: 'MiniMax-M2.7', provider: 'anthropic', vision: false, context: 204_800 },
         { model: 'MiniMax-M3', provider: 'anthropic', vision: true, context: 1_000_000 },
         { model: 'deepseek-v4-flash', provider: 'anthropic', vision: false, context: 1_000_000 },
+        { model: 'gpt-5.6-terra', provider: 'openai', vision: false, context: 1_000_000 },
+        { model: 'gpt-5.6-sol', provider: 'openai', vision: false, context: 1_000_000 },
+        { model: 'gpt-5.6-luna', provider: 'openai', vision: false, context: 1_000_000 },
       ],
     );
     assert.strictEqual(findRelayModelProfile('minimax-m3')?.capabilities.vision, true);
     assert.strictEqual(findRelayModelProfile('MiniMax-M2.7')?.capabilities.vision, false);
+    assert.strictEqual(findRelayModelProfile('gpt-5.6-terra')?.openaiApiMode, 'responses');
   });
 
   test('keeps relay tool calling enabled for public MiniMax and DeepSeek models', () => {

--- a/tests/openai-provider-runtime-feedback.test.ts
+++ b/tests/openai-provider-runtime-feedback.test.ts
@@ -90,6 +90,30 @@ describe('OpenAIProvider runtime feedback boundary', () => {
     assert.equal(minimaxBody.reasoning_effort, undefined);
   });
 
+  test('maps GPT-5.6 reasoning effort to Chat Completions and Responses fields', () => {
+    const chatProvider = new OpenAIProvider({
+      apiKey: 'test-key',
+      apiUrl: 'https://relay.catsco.cc/v1',
+      model: 'gpt-5.6-terra',
+      reasoningEffort: 'minimal',
+      openaiApiMode: 'chat_completions',
+    });
+    const responsesProvider = new OpenAIProvider({
+      apiKey: 'test-key',
+      apiUrl: 'https://relay.catsco.cc/v1',
+      model: 'gpt-5.6-luna',
+      reasoningEffort: 'xhigh',
+      openaiApiMode: 'responses',
+    });
+
+    const chatBody = (chatProvider as any).buildRequestBody([{ role: 'user', content: 'hello' }]);
+    const responsesBody = (responsesProvider as any).buildResponsesRequestBody([{ role: 'user', content: 'hello' }]);
+
+    assert.equal(chatBody.reasoning_effort, 'minimal');
+    assert.equal(chatBody.thinking, undefined);
+    assert.deepStrictEqual(responsesBody.reasoning, { effort: 'xhigh' });
+  });
+
   test('sends explicit OpenAI-compatible reasoning disable', () => {
     const provider = new OpenAIProvider({
       apiKey: 'test-key',


### PR DESCRIPTION
## 改动说明
- CatsCo 运行时轮询 CatsCompany 的机器人模型配置，空闲时在线切换并在真实握手成功后 ACK
- 支持目录模型、自定义模型和推理强度，GPT-5.6 目录模型使用 OpenAI Responses
- 云端配置使用独立覆盖层和独立目录模型运行凭据，不改写最新 main 的本地模型、自定义模型档或 Branch/Memory Agent 配置
- 支持从云端切回设备本地模型，页面保持 pending，直到客户端完成切回确认
- 切换失败恢复上一份覆盖；本地运行材料缺失时不提前清除云端覆盖；fallback 启动失败会自动退避重建
- Dashboard 预检不提前 ACK，避免 connector 尚未启动就显示已应用
- Dashboard 明确显示当前云端覆盖模型，同时保留并区分设备本地回退配置

## 兼容性
- 已 rebase 最新 upstream/main，保留自定义模型档迁移与激活错误处理
- 旧 CatsCo 不注册 cloud-model-v1 能力，CatsCompany 会显示暂时无法切换，不影响原有连接和聊天
- Branch Agent/Memory Branch 独立配置未被云端覆盖
- 配套 CatsCompany 后端与网页端已部署，支持本地切回 ACK、新任务入口和真实云端模型状态显示

## 验证
- npm test：1128 passed，0 failed，4 skipped
- npm run build
- git diff --check
- 真实生产 E2E（测试 bot 110）：本地 gpt-5.6-terra → 云端 gpt-5.6-luna/high → 本地 gpt-5.6-terra
- 追加真实切换与聊天冒烟：云端 gpt-5.6-sol/high，6 秒返回 SOL_SWITCH_RUNTIME_OK
- Dashboard 状态接口与页面均显示 gpt-5.6-sol/high；本地 Terra 配置保持不变，作为切回目标