### PR TITLE
feat: 动态注入 CatsCo 会话附件目录

### DIFF
--- a/src/catscompany/attachment-cache.ts
+++ b/src/catscompany/attachment-cache.ts
@@ -34,13 +34,17 @@ export function buildCatsCoAttachmentCachePath(
   fileName: string,
   now = new Date(),
 ): string {
-  const sessionSegment = sanitizePathSegment(sessionKey || 'unknown-session');
-  const dir = path.join(getCatsCoAttachmentCacheRoot(), sessionSegment);
+  const dir = getCatsCoAttachmentCacheSessionRoot(sessionKey);
 
   const safeName = sanitizeFileName(fileName || 'attachment');
   const stamp = formatTimestamp(now);
   const nonce = randomUUID().slice(0, 8);
   return path.join(dir, `${stamp}_${nonce}_${safeName}`);
+}
+
+export function getCatsCoAttachmentCacheSessionRoot(sessionKey: string | undefined): string {
+  const sessionSegment = sanitizePathSegment(sessionKey || 'unknown-session');
+  return path.join(getCatsCoAttachmentCacheRoot(), sessionSegment);
 }
 
 export function isInsideCatsCoAttachmentCacheRoot(filePath: string): boolean {

--- a/src/core/runtime-context-builder.ts
+++ b/src/core/runtime-context-builder.ts
@@ -11,6 +11,7 @@ import type {
 } from '../types/session-identity';
 import type { TargetRoute, TargetRoutes } from '../types/tool';
 import { parseSessionKeyV2 } from './session-router';
+import { getCatsCoAttachmentCacheSessionRoot } from '../catscompany/attachment-cache';
 
 export const TRANSIENT_RUNTIME_CONTEXT_PREFIX = '[transient_runtime_context]';
 
@@ -55,7 +56,10 @@ export interface ExecutionContextSnapshot {
 
 export function buildRuntimeContextMessage(params: BuildRuntimeContextParams): Message | null {
   if (!shouldInjectRuntimeContext(params)) return null;
-  const content = buildRuntimeContextText(params.targetRoutes);
+  const content = buildRuntimeContextText(
+    params.targetRoutes,
+    getCatsCoAttachmentCacheSessionRoot(params.sessionKey),
+  );
   if (!content) return null;
   return { role: 'system', content };
 }
@@ -68,9 +72,14 @@ function shouldInjectRuntimeContext(params: BuildRuntimeContextParams): boolean 
   return source === 'catscompany';
 }
 
-function buildRuntimeContextText(targetRoutes?: TargetRoutes): string {
+function buildRuntimeContextText(targetRoutes?: TargetRoutes, attachmentDirectory?: string): string {
   const routes = targetRoutes?.routes || [];
   const lines = [TRANSIENT_RUNTIME_CONTEXT_PREFIX];
+  if (attachmentDirectory) {
+    lines.push(`当前会话附件目录：${attachmentDirectory}`);
+    lines.push('需要历史附件时直接用 glob 查看该目录，并把具体文件路径传给现有文件工具或本机脚本。');
+    lines.push('');
+  }
   if (routes.length > 0) {
     lines.push('可操作的用户电脑：');
     for (const route of routes) {

--- a/src/core/runtime-context-builder.ts
+++ b/src/core/runtime-context-builder.ts
@@ -76,8 +76,8 @@ function buildRuntimeContextText(targetRoutes?: TargetRoutes, attachmentDirector
   const routes = targetRoutes?.routes || [];
   const lines = [TRANSIENT_RUNTIME_CONTEXT_PREFIX];
   if (attachmentDirectory) {
-    lines.push(`当前会话附件目录：${attachmentDirectory}`);
-    lines.push('需要历史附件时直接用 glob 查看该目录，并把具体文件路径传给现有文件工具或本机脚本。');
+    lines.push(`当前会话附件缓存目录（XiaoBa 本地运行体）：${attachmentDirectory}`);
+    lines.push('需要查找本会话历史附件时，用不带 target 的 glob 查看该目录；找到具体文件后再传给 read_file、grep 或本机脚本。');
     lines.push('');
   }
   if (routes.length > 0) {

--- a/tests/catscompany-attachment-cache.test.ts
+++ b/tests/catscompany-attachment-cache.test.ts
@@ -7,6 +7,7 @@ import {
   buildCatsCoAttachmentCachePath,
   cleanupCatsCoAttachmentCache,
   getCatsCoAttachmentCacheRoot,
+  getCatsCoAttachmentCacheSessionRoot,
 } from '../src/catscompany/attachment-cache';
 
 async function withRuntimeRoot<T>(run: (root: string) => T | Promise<T>): Promise<T> {
@@ -33,7 +34,9 @@ describe('CatsCo attachment cache', () => {
   test('builds stable cache paths under the runtime data root', () => {
     return withRuntimeRoot((root) => {
       const filePath = buildCatsCoAttachmentCachePath('cc_group:grp/123', '../image.png', new Date(2026, 6, 3, 1, 2, 3, 4));
+      const sessionRoot = getCatsCoAttachmentCacheSessionRoot('cc_group:grp/123');
 
+      assert.equal(path.dirname(filePath), sessionRoot);
       assert.equal(path.dirname(path.dirname(filePath)), getCatsCoAttachmentCacheRoot());
       assert.ok(filePath.startsWith(path.join(root, 'data', 'attachments', 'catscompany')));
       assert.match(path.basename(filePath), /^20260703_010203_004_[a-f0-9-]{8}_image\.png$/);

--- a/tests/runtime-context-builder.test.ts
+++ b/tests/runtime-context-builder.test.ts
@@ -6,6 +6,7 @@ import * as path from 'path';
 import { AgentSession } from '../src/core/agent-session';
 import { TurnContextBuilder } from '../src/core/turn-context-builder';
 import { TRANSIENT_RUNTIME_CONTEXT_PREFIX } from '../src/core/runtime-context-builder';
+import { getCatsCoAttachmentCacheSessionRoot } from '../src/catscompany/attachment-cache';
 import { createDeviceGrant, createUserDevice } from '../src/core/device-grants';
 import { createExecutionScopeFromRoute, createSessionRoute } from '../src/core/session-router';
 import type { Message } from '../src/types';
@@ -70,6 +71,8 @@ describe('runtime context builder', () => {
     const runtimeText = String(result.messages[runtimeIndex].content || '');
     assert.match(runtimeText, /^\[transient_runtime_context\]/);
     assert.match(runtimeText, /\[\/transient_runtime_context\]$/);
+    assert.ok(runtimeText.includes(`当前会话附件目录：${getCatsCoAttachmentCacheSessionRoot(route.sessionKey)}`));
+    assert.match(runtimeText, /需要历史附件时直接用 glob 查看该目录/);
     assert.match(runtimeText, /默认不要传 target/);
     assert.match(runtimeText, /你的电脑\/XiaoBa 的电脑\/bot 的电脑/);
     assert.doesNotMatch(runtimeText, /可在用户电脑执行的工具/);

--- a/tests/runtime-context-builder.test.ts
+++ b/tests/runtime-context-builder.test.ts
@@ -71,8 +71,8 @@ describe('runtime context builder', () => {
     const runtimeText = String(result.messages[runtimeIndex].content || '');
     assert.match(runtimeText, /^\[transient_runtime_context\]/);
     assert.match(runtimeText, /\[\/transient_runtime_context\]$/);
-    assert.ok(runtimeText.includes(`当前会话附件目录：${getCatsCoAttachmentCacheSessionRoot(route.sessionKey)}`));
-    assert.match(runtimeText, /需要历史附件时直接用 glob 查看该目录/);
+    assert.ok(runtimeText.includes(`当前会话附件缓存目录（XiaoBa 本地运行体）：${getCatsCoAttachmentCacheSessionRoot(route.sessionKey)}`));
+    assert.match(runtimeText, /用不带 target 的 glob 查看该目录/);
     assert.match(runtimeText, /默认不要传 target/);
     assert.match(runtimeText, /你的电脑\/XiaoBa 的电脑\/bot 的电脑/);
     assert.doesNotMatch(runtimeText, /可在用户电脑执行的工具/);


### PR DESCRIPTION
## 背景

CatsCo 已经把用户上传的文件和图片按会话保存在稳定附件目录中，但该目录入口不会在后续轮次重新提供给模型。历史消息被压缩后，模型可能记得用户提过附件，却无法可靠找到原文件路径。

## 改动

- 导出原有 CatsCo 会话附件目录的路径解析函数，并让附件落盘继续复用同一实现。
- 在现有 `transient_runtime_context` 中，每轮动态注入当前会话附件目录。
- 提示模型需要历史附件时直接使用现有 `glob` 查找，再把普通文件路径交给现有文件工具或本机脚本。
- 补充附件目录和瞬时上下文测试。

本 PR 不新增文件管理 Tool、文件 ID、索引、托管副本、版本关系或生命周期逻辑，也不修改 `read_file`、`send_file`、子 Agent 和附件清理规则。

## 影响

上下文压缩或跨轮追问后，模型仍能重新获得会话附件目录入口。原有 Agent 工作目录注入、文件工具参数和 CatsCo 附件缓存策略保持不变。

## 验证

- `npm run build`：通过。
- `npx tsx --test tests/catscompany-attachment-cache.test.ts tests/runtime-context-builder.test.ts`：4/4 通过。
- `npm test`：1071 通过、4 跳过、4 失败。4 个失败均为现有 Windows `ReadTool` 测试清理临时目录时的 `ENOTEMPTY`，单独运行 `tests/tool-result-read-tool.test.ts` 也可复现；本 PR 未修改该链路。
