### PR TITLE
修复模型空响应导致无回复

### DIFF
--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -55,6 +55,7 @@ export const BUSY_MESSAGE = '正在处理上一条消息，请稍候...';
 export const ERROR_MESSAGE = '不好意思，刚才处理出了点问题，你再试一次？';
 export const MODEL_TIMEOUT_MESSAGE = '模型中转请求超时了，我已经保留本轮已完成的工具结果和上下文。你可以直接说“继续”，我会从这里接上。';
 export const MODEL_TRANSIENT_ERROR_MESSAGE = '当前模型服务临时异常，刚才这次请求没有完成。我已经保留上下文；你可以稍后重试，或临时切换到其他模型继续。';
+export const EMPTY_MODEL_RESPONSE_MESSAGE = '模型本轮未返回有效内容，自动重试后仍未恢复。请重新发送上一条消息；若仍失败，请切换模型或稍后再试。';
 export const CONTEXT_COMPACTION_START_MESSAGE = '正在压缩上下文，整理较早的对话内容。';
 export const CONTEXT_COMPACTION_COMPLETE_MESSAGE = '上下文压缩完成，继续处理当前请求。';
 export const CONTEXT_COMPACTION_ERROR_MESSAGE = '上下文压缩失败，已保留原上下文继续处理。';
@@ -601,6 +602,7 @@ export class AgentSession {
         const isVisionError = !isImageSafetyError && errorMsg.match(/image|vision|multimodal|media_type|base64.*not supported/i);
         const isModelTimeoutError = this.isModelTimeoutError(err);
         const isTransientProviderError = this.isTransientProviderError(err);
+        const isEmptyModelResponseError = this.isEmptyModelResponseError(err);
         const relayBudgetErrorReply = this.formatRelayBudgetErrorReply(err);
 
         let errorReply = ERROR_MESSAGE;
@@ -612,6 +614,8 @@ export class AgentSession {
           errorReply = '当前模型不支持图片识别。请使用支持多模态的模型（如 Claude 3.5 Sonnet 或 GPT-4V），或者用文字描述图片内容。';
         } else if (isModelTimeoutError) {
           errorReply = MODEL_TIMEOUT_MESSAGE;
+        } else if (isEmptyModelResponseError) {
+          errorReply = EMPTY_MODEL_RESPONSE_MESSAGE;
         } else if (isTransientProviderError) {
           errorReply = this.formatTransientProviderErrorReply();
         }
@@ -623,6 +627,7 @@ export class AgentSession {
             isModelTimeoutError,
             isImageSafetyError,
             isTransientProviderError,
+            isEmptyModelResponseError,
           }),
           __internalErrorArtifact: true,
         });
@@ -950,6 +955,14 @@ export class AgentSession {
     return /unknown error,\s*520|overloaded_error|service unavailable|bad gateway|gateway timeout|upstream (?:error|timeout)|MaxRetriesExceededError|Connection error|ECONNRESET|ETIMEDOUT|EAI_AGAIN|fetch failed|socket hang up|network error|premature close/i.test(text);
   }
 
+  private isEmptyModelResponseError(error: any): boolean {
+    const code = String(error?.code || error?.cause?.code || '').toUpperCase();
+    if (code === 'EMPTY_MODEL_RESPONSE') {
+      return true;
+    }
+    return /模型未返回有效内容|模型返回了空响应/i.test(String(error?.message || error || ''));
+  }
+
   private formatRelayBudgetErrorReply(error: any): string | null {
     const text = String(error?.message || error || '');
     const status = this.extractErrorStatus(error);
@@ -1008,6 +1021,7 @@ export class AgentSession {
       isModelTimeoutError?: boolean;
       isImageSafetyError?: boolean;
       isTransientProviderError?: boolean;
+      isEmptyModelResponseError?: boolean;
     },
   ): string {
     const detail = this.sanitizeErrorMessage(error?.message || String(error));
@@ -1019,6 +1033,9 @@ export class AgentSession {
     }
     if (flags.isTransientProviderError) {
       return `[处理中断: 模型服务临时异常或上游网关错误。已保留本轮上下文；如果用户要求继续，请从当前状态继续，不要重复已经完成的工具步骤。错误摘要: ${detail}]`;
+    }
+    if (flags.isEmptyModelResponseError) {
+      return `[处理中断: 模型未返回正文或工具调用，自动重试后仍未恢复。已保留本轮上下文；如果用户重试，请正常处理上一条请求。错误摘要: ${detail}]`;
     }
     return `[处理失败: ${detail}]`;
   }

--- a/src/core/agent-turn-controller.ts
+++ b/src/core/agent-turn-controller.ts
@@ -40,6 +40,8 @@ import {
 } from './synthetic-observation';
 import { MemorySidecarBranchHandle, startMemorySidecarBranch } from './sidecar-memory-branch';
 
+const EMPTY_FINAL_RESPONSE_MESSAGE = '模型本轮未返回有效内容。请重新发送上一条消息；若仍失败，请切换模型或稍后再试。';
+
 export interface AgentTurnServices {
   aiService: AIService;
   memoryBranch?: {
@@ -238,7 +240,7 @@ export class AgentTurnController {
     }
 
     return {
-      text: finalResponseVisible ? (result.response || '[无回复]') : '',
+      text: finalResponseVisible ? (result.response || EMPTY_FINAL_RESPONSE_MESSAGE) : '',
       visibleToUser: finalResponseVisible,
       newMessages: result.newMessages,
       messages: nextMessages,

--- a/src/providers/anthropic-provider.ts
+++ b/src/providers/anthropic-provider.ts
@@ -322,9 +322,15 @@ export class AnthropicProvider implements AIProvider {
   private parseResponse(response: Anthropic.Message): ChatResponse {
     const textParts: string[] = [];
     let toolCalls: ChatResponse['toolCalls'] = undefined;
-    const providerContent = this.preserveAssistantProviderContent(response.content as any[]);
+    const rawContent = (response as any)?.content;
+    const contentBlocks = Array.isArray(rawContent)
+      ? rawContent
+      : typeof rawContent === 'string'
+        ? [{ type: 'text', text: rawContent }]
+        : [];
+    const providerContent = this.preserveAssistantProviderContent(contentBlocks);
 
-    for (const block of response.content) {
+    for (const block of contentBlocks) {
       if (block.type === 'text') {
         textParts.push(block.text);
       } else if (block.type === 'tool_use') {
@@ -341,17 +347,18 @@ export class AnthropicProvider implements AIProvider {
     }
 
     // 提取 token 用量
-    const usage = response.usage ? {
-      promptTokens: response.usage.input_tokens ?? 0,
-      completionTokens: response.usage.output_tokens ?? 0,
-      totalTokens: (response.usage.input_tokens ?? 0) + (response.usage.output_tokens ?? 0),
+    const responseUsage = (response as any)?.usage;
+    const usage = responseUsage ? {
+      promptTokens: responseUsage.input_tokens ?? 0,
+      completionTokens: responseUsage.output_tokens ?? 0,
+      totalTokens: (responseUsage.input_tokens ?? 0) + (responseUsage.output_tokens ?? 0),
     } : undefined;
 
     return {
       content: textParts.length > 0 ? textParts.join('') : null,
       toolCalls,
       usage,
-      stopReason: response.stop_reason || undefined,
+      stopReason: (response as any)?.stop_reason || undefined,
       ...(providerContent.length > 0 ? { providerContent } : {}),
     };
   }

--- a/src/utils/ai-service.ts
+++ b/src/utils/ai-service.ts
@@ -24,6 +24,10 @@ const SHORT_NETWORK_RETRY_CODES = new Set(['ENOTFOUND', 'ECONNREFUSED']);
 const SHORT_NETWORK_MAX_RETRIES = 3;
 const SHORT_NETWORK_MAX_ELAPSED_MS = 30 * 1000;
 const SHORT_NETWORK_MAX_DELAY_MS = 5000;
+const EMPTY_RESPONSE_ERROR_CODE = 'EMPTY_MODEL_RESPONSE';
+const EMPTY_RESPONSE_MAX_RETRIES = 2;
+const EMPTY_RESPONSE_MAX_ELAPSED_MS = 2 * 60 * 1000;
+const EMPTY_RESPONSE_MAX_DELAY_MS = 2000;
 
 type ProviderKind = 'openai' | 'anthropic';
 
@@ -108,7 +112,11 @@ export class AIService {
     }
 
     try {
-      return await this.withRetry(() => this.provider.chat(messages, tools, options), undefined, options.signal);
+      return await this.withRetry(
+        async () => this.requireUsableResponse(await this.provider.chat(messages, tools, options)),
+        undefined,
+        options.signal,
+      );
     } catch (error: any) {
       throw this.wrapError(error);
     }
@@ -136,12 +144,16 @@ export class AIService {
     });
 
     try {
-      return await this.withRetry(
-        () => this.provider.chatStream(messages, tools, providerCallbacks, options),
+      const result = await this.withRetry(
+        async () => this.requireUsableResponse(
+          await this.provider.chatStream(messages, tools, providerCallbacks, options),
+        ),
         callbacks,
         options.signal,
         () => allowStreamRetry || !hasStreamedText,
       );
+      callbacks?.onComplete?.(result);
+      return result;
     } catch (error: any) {
       const wrapped = this.wrapError(error);
       callbacks?.onError?.(wrapped);
@@ -159,8 +171,26 @@ export class AIService {
         if (text) onTextObserved?.();
         callbacks.onText?.(text);
       },
-      onComplete: callbacks.onComplete,
     };
+  }
+
+  private requireUsableResponse(response: ChatResponse): ChatResponse {
+    const content = typeof response?.content === 'string' ? response.content.trim() : '';
+    if (content || (response?.toolCalls?.length ?? 0) > 0 || this.isTokenLimitResponse(response)) {
+      return response;
+    }
+
+    const error = new Error('模型未返回有效内容（没有正文或工具调用）');
+    error.name = 'EmptyModelResponseError';
+    (error as Error & { code?: string }).code = EMPTY_RESPONSE_ERROR_CODE;
+    throw error;
+  }
+
+  private isTokenLimitResponse(response: ChatResponse): boolean {
+    const stopReason = String(response?.stopReason || '').toLowerCase();
+    return stopReason === 'max_tokens'
+      || stopReason === 'max_output_tokens'
+      || stopReason === 'length';
   }
 
   /**
@@ -181,11 +211,14 @@ export class AIService {
     const status = this.extractStatus(error);
     const errorMessage = this.extractErrorMessage(error);
 
-    if (status) {
-      return new Error(`API错误 (${status}): ${errorMessage}`);
+    const wrapped = status
+      ? new Error(`API错误 (${status}): ${errorMessage}`)
+      : new Error(`请求失败: ${errorMessage}`);
+    const code = this.extractErrorCode(error);
+    if (code) {
+      (wrapped as Error & { code?: string }).code = code;
     }
-
-    return new Error(`请求失败: ${errorMessage}`);
+    return wrapped;
   }
 
   /**
@@ -198,6 +231,10 @@ export class AIService {
 
     if (this.isKnownNonRetryableProviderError(error)) {
       return false;
+    }
+
+    if (this.isEmptyModelResponseError(error)) {
+      return true;
     }
 
     // HTTP 状态码可重试
@@ -385,6 +422,15 @@ export class AIService {
       baseDelayMs: BASE_DELAY_MS,
     };
 
+    if (this.isEmptyModelResponseError(error)) {
+      return {
+        ...policy,
+        maxRetries: Math.min(policy.maxRetries, EMPTY_RESPONSE_MAX_RETRIES),
+        maxElapsedMs: Math.min(policy.maxElapsedMs, EMPTY_RESPONSE_MAX_ELAPSED_MS),
+        maxDelayMs: Math.min(policy.maxDelayMs, EMPTY_RESPONSE_MAX_DELAY_MS),
+      };
+    }
+
     if (!this.isShortNetworkRetryError(error)) {
       return policy;
     }
@@ -428,6 +474,10 @@ export class AIService {
 
   private extractErrorCode(error: any): string {
     return String(error?.code || error?.cause?.code || '').toUpperCase();
+  }
+
+  private isEmptyModelResponseError(error: any): boolean {
+    return this.extractErrorCode(error) === EMPTY_RESPONSE_ERROR_CODE;
   }
 
   private isShortNetworkRetryError(error: any): boolean {

--- a/tests/ai-service.test.ts
+++ b/tests/ai-service.test.ts
@@ -195,6 +195,108 @@ test('AIService still honors explicit full stream retry opt-in', async () => {
   assert.deepStrictEqual(chunks, ['partial', 'ok']);
 });
 
+test('AIService retries a successful response with no text or tool calls', async () => {
+  const service = createTestService();
+  let attempts = 0;
+  (service as any).sleepWithAbort = async () => undefined;
+  (service as any).provider = {
+    chat: async () => {
+      attempts += 1;
+      if (attempts < 3) {
+        return {
+          content: null,
+          stopReason: 'completed',
+          usage: { promptTokens: 100, completionTokens: 30, totalTokens: 130 },
+        };
+      }
+      return { content: 'recovered' };
+    },
+    chatStream: async () => ({ content: 'unused' }),
+  };
+
+  const result = await service.chat([]);
+
+  assert.deepStrictEqual(result, { content: 'recovered' });
+  assert.equal(attempts, 3);
+});
+
+test('AIService stops bounded empty-response retries with an explicit error', async () => {
+  const service = createTestService();
+  let attempts = 0;
+  (service as any).sleepWithAbort = async () => undefined;
+  (service as any).provider = {
+    chat: async () => {
+      attempts += 1;
+      return { content: '', stopReason: 'stop' };
+    },
+    chatStream: async () => ({ content: 'unused' }),
+  };
+
+  await assert.rejects(
+    () => service.chat([]),
+    /请求失败: 模型未返回有效内容（没有正文或工具调用）/,
+  );
+  assert.equal(attempts, 3);
+});
+
+test('AIService accepts tool calls and token-limit recovery responses without semantic retries', async () => {
+  const service = createTestService();
+  let attempts = 0;
+  (service as any).provider = {
+    chat: async () => {
+      attempts += 1;
+      return attempts === 1
+        ? {
+            content: null,
+            toolCalls: [{
+              id: 'call_1',
+              type: 'function' as const,
+              function: { name: 'read_file', arguments: '{}' },
+            }],
+          }
+        : { content: null, stopReason: 'max_tokens' };
+    },
+    chatStream: async () => ({ content: 'unused' }),
+  };
+
+  const toolResponse = await service.chat([]);
+  const tokenLimitResponse = await service.chat([]);
+
+  assert.equal(toolResponse.toolCalls?.[0]?.function.name, 'read_file');
+  assert.equal(tokenLimitResponse.stopReason, 'max_tokens');
+  assert.equal(attempts, 2);
+});
+
+test('AIService emits stream completion only after an empty response has recovered', async () => {
+  const service = createTestService();
+  let attempts = 0;
+  let completions = 0;
+  const retries: Array<[number, number, string | number | undefined]> = [];
+  (service as any).sleepWithAbort = async () => undefined;
+  (service as any).provider = {
+    chat: async () => ({ content: 'unused' }),
+    chatStream: async (_messages: unknown, _tools: unknown, callbacks?: StreamCallbacks) => {
+      attempts += 1;
+      const response: ChatResponse = attempts === 1
+        ? { content: null, stopReason: 'completed' }
+        : { content: 'recovered' };
+      if (response.content) callbacks?.onText?.(response.content);
+      callbacks?.onComplete?.(response);
+      return response;
+    },
+  };
+
+  const result = await service.chatStream([], undefined, {
+    onComplete: () => { completions += 1; },
+    onRetry: (attempt, maxRetries, info) => retries.push([attempt, maxRetries, info?.status]),
+  });
+
+  assert.equal(result.content, 'recovered');
+  assert.equal(attempts, 2);
+  assert.equal(completions, 1);
+  assert.deepStrictEqual(retries, [[1, 2, 'EMPTY_MODEL_RESPONSE']]);
+});
+
 test('AIService does not treat bare token counts as retryable status codes', async () => {
   const service = createTestService();
   let attempts = 0;

--- a/tests/anthropic-provider-runtime-feedback.test.ts
+++ b/tests/anthropic-provider-runtime-feedback.test.ts
@@ -295,6 +295,29 @@ describe('AnthropicProvider runtime feedback boundary', () => {
     assert.equal((provider as any).maxTokens, 32768);
   });
 
+  test('tolerates empty or string content from Anthropic-compatible endpoints', () => {
+    const provider = new AnthropicProvider({
+      apiKey: 'test-key',
+      apiUrl: 'https://example.test/v1/messages',
+      model: 'custom-compatible-model',
+    });
+
+    const empty = (provider as any).parseResponse({
+      content: null,
+      stop_reason: 'end_turn',
+      usage: { input_tokens: 8, output_tokens: 0 },
+    });
+    const text = (provider as any).parseResponse({
+      content: 'compatible response',
+      stop_reason: 'end_turn',
+    });
+
+    assert.equal(empty.content, null);
+    assert.equal(empty.stopReason, 'end_turn');
+    assert.equal(empty.usage.totalTokens, 8);
+    assert.equal(text.content, 'compatible response');
+  });
+
   test('preserves MiniMax M3 thinking blocks for tool-use replay', () => {
     const provider = new AnthropicProvider({
       apiKey: 'test-key',

--- a/tests/session-lifecycle-manager.test.ts
+++ b/tests/session-lifecycle-manager.test.ts
@@ -816,6 +816,28 @@ describe('AgentSession lifecycle', () => {
     assert.doesNotMatch(result.text, /unknown error|request_id|API错误|520/);
   });
 
+  test('handleMessage tells the user how to recover after empty model responses are exhausted', async () => {
+    const { AgentSession, EMPTY_MODEL_RESPONSE_MESSAGE } = loadSessionModules();
+    const session = new AgentSession('catscompany:lifecycle-empty-model-response', buildMockServices({
+      aiService: {
+        async chatStream() {
+          throw Object.assign(
+            new Error('请求失败: 模型未返回有效内容（没有正文或工具调用）'),
+            { code: 'EMPTY_MODEL_RESPONSE' },
+          );
+        },
+      },
+    }), 'catscompany');
+    session.setSystemPromptProvider(() => 'system prompt');
+
+    const result = await session.handleMessage('继续上一条');
+
+    assert.equal(result.text, EMPTY_MODEL_RESPONSE_MESSAGE);
+    assert.match(result.text, /重新发送上一条消息/);
+    assert.match(result.text, /切换模型或稍后再试/);
+    assert.doesNotMatch(result.text, /EMPTY_MODEL_RESPONSE|请求失败/);
+  });
+
   test('handleMessage treats wrapped 503 request errors as transient provider failures', async () => {
     const { AgentSession } = loadSessionModules();
     const session = new AgentSession('catscompany:lifecycle-transient-503', buildMockServices({
@@ -906,6 +928,7 @@ function loadSessionModules(): any {
     ERROR_MESSAGE: require('../src/core/agent-session').ERROR_MESSAGE,
     MODEL_TIMEOUT_MESSAGE: require('../src/core/agent-session').MODEL_TIMEOUT_MESSAGE,
     MODEL_TRANSIENT_ERROR_MESSAGE: require('../src/core/agent-session').MODEL_TRANSIENT_ERROR_MESSAGE,
+    EMPTY_MODEL_RESPONSE_MESSAGE: require('../src/core/agent-session').EMPTY_MODEL_RESPONSE_MESSAGE,
     CONTEXT_COMPACTION_START_MESSAGE: require('../src/core/agent-session').CONTEXT_COMPACTION_START_MESSAGE,
     CONTEXT_COMPACTION_COMPLETE_MESSAGE: require('../src/core/agent-session').CONTEXT_COMPACTION_COMPLETE_MESSAGE,
     SessionStore: require('../src/utils/session-store').SessionStore,


### PR DESCRIPTION
## 问题

线上日志确认部分 OpenAI/Anthropic 兼容端点会返回 HTTP 200，但最终响应没有正文、没有工具调用。此前该结果会被当作正常完成，用户最终看到 [无回复]。

## 修改

- 对无正文且无工具调用的成功响应自动重试，最多 2 次
- 保留工具调用和 max_tokens 续写响应，不改变正常工具链
- 重试耗尽后提示用户重新发送上一条消息，并建议切换模型或稍后再试
- 兼容 Anthropic 端点返回 content: null 或字符串，避免解析器直接报错
- 流式重试只在最终有效响应后触发完成回调，避免 Working 提前结束

## 影响范围

适用于内置模型和自定义模型。未修改模型请求格式、BranchAgent、子 Agent 或 CatsCompany 协议。

## 验证

- npm test：1110 passed，4 skipped，0 failed
- npm run build
- git diff --check