### PR TITLE
修复临时网关故障后的会话回放卡死

### DIFF
--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -27,6 +27,7 @@ import {
 import { PromptManager } from '../utils/prompt-manager';
 import { Logger } from '../utils/logger';
 import { SessionTurnLogger } from '../utils/session-turn-logger';
+import { sanitizeForProviderReplayRecovery } from '../utils/session-store';
 import { Metrics } from '../utils/metrics';
 import { ContextWindowManager, type ContextCompactionStatusEvent } from './context-window-manager';
 import {
@@ -602,6 +603,9 @@ export class AgentSession {
         const isModelTimeoutError = this.isModelTimeoutError(err);
         const isTransientProviderError = this.isTransientProviderError(err);
         const relayBudgetErrorReply = this.formatRelayBudgetErrorReply(err);
+        const providerReplayMessages = this.messages.filter(message => (
+          Array.isArray(message.providerContent) && message.providerContent.length > 0
+        )).length;
 
         let errorReply = ERROR_MESSAGE;
         if (isImageSafetyError) {
@@ -614,6 +618,9 @@ export class AgentSession {
           errorReply = MODEL_TIMEOUT_MESSAGE;
         } else if (isTransientProviderError) {
           errorReply = this.formatTransientProviderErrorReply();
+          if (providerReplayMessages > 0) {
+            errorReply += '\n\n会话回放状态已自动修复，直接回复“继续”即可从原上下文接上。';
+          }
         }
 
         // 添加错误回复到上下文，保持对话连贯性
@@ -627,6 +634,16 @@ export class AgentSession {
           __internalErrorArtifact: true,
         });
         this.messages = stripAssistantArtifactsFromMessages(this.turnContextBuilder.removeTransientMessages(this.messages));
+        if (
+          providerReplayMessages > 0
+          && (isTransientProviderError || isModelTimeoutError)
+        ) {
+          this.messages = sanitizeForProviderReplayRecovery(this.messages);
+          Logger.warning(
+            `[会话 ${this.key}] 模型临时故障后已清理 ${providerReplayMessages} 条 provider replay 状态，`
+            + '保留可见上下文供下一轮继续',
+          );
+        }
         this.lifecycleManager.saveContext(this.messages);
 
         return { text: errorReply, visibleToUser: true, taskOutcome: 'failed' };

--- a/src/utils/session-store.ts
+++ b/src/utils/session-store.ts
@@ -56,12 +56,22 @@ function summarizeHiddenReplayToolResult(message: Message): string {
   return `[历史工具结果已省略；${toolName} 已完成。]`;
 }
 
-function sanitizeForPersistence(messages: Message[]): Message[] {
+interface SanitizeSessionMessagesOptions {
+  preserveTransientMessages?: boolean;
+}
+
+function sanitizeSessionMessages(
+  messages: Message[],
+  options: SanitizeSessionMessagesOptions = {},
+): Message[] {
   const hiddenReplayToolCallIds = new Set<string>();
   const durable: Message[] = [];
 
   for (const message of messages) {
     if ((message as any).__injected || message.role === 'system') {
+      if (options.preserveTransientMessages) {
+        durable.push({ ...message, providerContent: undefined });
+      }
       continue;
     }
 
@@ -117,6 +127,19 @@ function sanitizeForPersistence(messages: Message[]): Message[] {
   }
 
   return durable;
+}
+
+function sanitizeForPersistence(messages: Message[]): Message[] {
+  return sanitizeSessionMessages(messages);
+}
+
+/**
+ * Drops provider-specific replay state after an exhausted transient failure.
+ * Visible conversation content and the current system/injected context remain
+ * available so the next turn can continue without restarting the process.
+ */
+export function sanitizeForProviderReplayRecovery(messages: Message[]): Message[] {
+  return sanitizeSessionMessages(messages, { preserveTransientMessages: true });
 }
 
 function serializeMessages(messages: Message[]): string {

--- a/tests/session-lifecycle-manager.test.ts
+++ b/tests/session-lifecycle-manager.test.ts
@@ -836,6 +836,82 @@ describe('AgentSession lifecycle', () => {
     assert.doesNotMatch(result.text, /API错误|状态码|503/);
   });
 
+  test('transient provider failure clears replay state so the next turn can continue without restart', async () => {
+    const { AgentSession, SessionStore } = loadSessionModules();
+    const providerInputs: any[][] = [];
+    let aiCalls = 0;
+    const session = new AgentSession('catscompany:lifecycle-replay-recovery', buildMockServices({
+      aiService: {
+        getConfig() {
+          return { model: 'gpt-5.6-sol', openaiApiMode: 'responses' };
+        },
+        async chatStream(messages: any[]) {
+          providerInputs.push(messages.map(message => JSON.parse(JSON.stringify(message))));
+          aiCalls++;
+          if (aiCalls === 1) {
+            throw new Error('API错误 (502): upstream temporarily unavailable');
+          }
+          return { content: '已从原上下文继续', toolCalls: [] };
+        },
+      },
+    }), 'catscompany');
+    session.setSystemPromptProvider(() => 'system prompt');
+    (session as any).messages.push(
+      { role: 'user', content: '先检查项目文件' },
+      {
+        role: 'assistant',
+        content: null,
+        tool_calls: [{
+          id: 'call_existing',
+          type: 'function',
+          function: { name: 'read_file', arguments: '{"file_path":"notes.md"}' },
+        }],
+        providerContent: [
+          { type: 'reasoning', encrypted_content: 'stale replay payload' },
+          {
+            type: 'function_call',
+            call_id: 'call_existing',
+            name: 'read_file',
+            arguments: '{"file_path":"notes.md"}',
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        name: 'read_file',
+        tool_call_id: 'call_existing',
+        content: '项目文件内容仍需保留',
+      },
+      { role: 'assistant', content: '文件已检查，下一步准备修改。' },
+    );
+    session.injectContext('当前设备授权仍有效');
+
+    const failed = await session.handleMessage('继续修改');
+
+    assert.equal(failed.taskOutcome, 'failed');
+    assert.match(failed.text, /服务临时异常/);
+    assert.match(failed.text, /会话回放状态已自动修复.*继续/);
+    const recoveredMessages = (session as any).messages as any[];
+    assert.equal(recoveredMessages.some(message => Array.isArray(message.providerContent)), false);
+    assert.equal(recoveredMessages.some(message => message.content === '项目文件内容仍需保留'), true);
+    assert.equal(recoveredMessages.some(message => message.content === '文件已检查，下一步准备修改。'), true);
+    assert.equal(recoveredMessages.some(message => message.content === '当前设备授权仍有效'), true);
+
+    const continued = await session.handleMessage('从刚才的位置继续');
+
+    assert.equal(continued.text, '已从原上下文继续');
+    assert.equal(continued.taskOutcome, 'completed');
+    assert.equal(aiCalls, 2);
+    assert.equal(providerInputs[1].some(message => Array.isArray(message.providerContent)), false);
+    assert.equal(providerInputs[1].some(message => message.content === '项目文件内容仍需保留'), true);
+    assert.equal(providerInputs[1].some(message => message.content === '文件已检查，下一步准备修改。'), true);
+
+    const persisted = SessionStore.getInstance().loadContext('catscompany:lifecycle-replay-recovery');
+    assert.equal(persisted.some(message => Array.isArray(message.providerContent)), false);
+    assert.equal(persisted.some(message => message.content === '项目文件内容仍需保留'), true);
+    assert.equal(persisted.some(message => message.content === '已从原上下文继续'), true);
+  });
+
   test('cleanup persists without invoking hidden AI wakeup checks', async () => {
     const { AgentSession, SessionStore } = loadSessionModules();
     let aiCalls = 0;


### PR DESCRIPTION
仅在 5xx/超时重试耗尽且存在 provider replay 时清理厂商回放状态，保留可见上下文、有效工具链和设备注入上下文。失败后不自动重跑工具，用户可直接回复继续。验证：session lifecycle 30/30、Responses/云端恢复/压缩/工具链 91/91、npm run build、git diff --check。