### PR TITLE
fix: restore bounded cloud context after summary timeout

### DIFF
--- a/src/catscompany/cloud-session-restore.ts
+++ b/src/catscompany/cloud-session-restore.ts
@@ -71,7 +71,12 @@ export class CatsCompanyCloudSessionRestorer {
       }
 
       const prepared = await this.prepareForPersistence(fetched.messages, request.signal);
-      request.signal?.throwIfAborted();
+      if (
+        request.signal?.aborted
+        && !(prepared.summaryFallback && isTimeoutAbortReason(request.signal.reason))
+      ) {
+        request.signal.throwIfAborted();
+      }
       if (this.hasLocalSession(request.sessionKey)) {
         return this.result('local_present', { fetchedMessages: fetched.fetchedMessages });
       }
@@ -167,10 +172,10 @@ export class CatsCompanyCloudSessionRestorer {
   private async prepareForPersistence(
     messages: Message[],
     signal?: AbortSignal,
-  ): Promise<{ messages: Message[]; compressed: boolean }> {
+  ): Promise<{ messages: Message[]; compressed: boolean; summaryFallback: boolean }> {
     const usedTokens = estimateMessagesTokens(messages);
     if (usedTokens <= CLOUD_RESTORE_DIRECT_TOKEN_BUDGET) {
-      return { messages, compressed: false };
+      return { messages, compressed: false, summaryFallback: false };
     }
 
     try {
@@ -192,12 +197,14 @@ export class CatsCompanyCloudSessionRestorer {
       return {
         messages: trimToTokenBudget(compacted, CLOUD_RESTORE_FINAL_TOKEN_CEILING),
         compressed: true,
+        summaryFallback: false,
       };
     } catch (error) {
       Logger.warning(`云端历史摘要失败，降级保留最近上下文: ${describeError(error)}`);
       return {
         messages: trimToTokenBudget(messages, CLOUD_RESTORE_DIRECT_TOKEN_BUDGET),
         compressed: true,
+        summaryFallback: true,
       };
     }
   }
@@ -415,4 +422,10 @@ function normalizeUID(value: unknown): string {
 
 function describeError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function isTimeoutAbortReason(reason: unknown): boolean {
+  return !!reason
+    && typeof reason === 'object'
+    && (reason as { name?: unknown }).name === 'TimeoutError';
 }

--- a/tests/cloud-session-restore.test.ts
+++ b/tests/cloud-session-restore.test.ts
@@ -400,6 +400,96 @@ test('summary failure still bounds a single oversized history message', async ()
   assert.match(String(restored[1]?.content), /已截断/);
 });
 
+test('summary timeout persists the bounded fallback instead of failing every retry', async () => {
+  const store = new MemorySessionStore();
+  const client = new FakeHistoryClient([
+    page([contextMessage({ content: 'x'.repeat(400_000) })]),
+  ]);
+  const timedOutAIService = {
+    chatStream: async (
+      _messages: Message[],
+      _tools: unknown,
+      _callbacks: unknown,
+      options: { signal?: AbortSignal } = {},
+    ) => await new Promise((_resolve, reject) => {
+      const signal = options.signal;
+      if (!signal) {
+        reject(new Error('missing summary timeout signal'));
+        return;
+      }
+      if (signal.aborted) {
+        reject(signal.reason);
+        return;
+      }
+      signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+    }),
+  } as any;
+  const restorer = new CatsCompanyCloudSessionRestorer(client, timedOutAIService, store);
+
+  const result = await restorer.restoreIfMissing({
+    sessionKey: 'summary-timeout-session',
+    topicId: 'p2p_7_42',
+    topicType: 'p2p',
+    agentId: 'usr42',
+    currentSeq: 2,
+    signal: AbortSignal.timeout(10),
+  });
+
+  assert.equal(result.status, 'restored');
+  assert.equal(result.compressed, true);
+  assert.equal(store.saveCalls, 1);
+  const restored = store.sessions.get('summary-timeout-session') || [];
+  assert.ok(estimateMessagesTokens(restored) <= 60_000);
+  assert.match(String(restored[0]?.content), /设备恢复提示/);
+});
+
+test('explicit cancellation during summary still prevents stale history persistence', async () => {
+  const store = new MemorySessionStore();
+  const client = new FakeHistoryClient([
+    page([contextMessage({ content: 'x'.repeat(400_000) })]),
+  ]);
+  let summaryStarted!: () => void;
+  const summaryStartedPromise = new Promise<void>(resolve => { summaryStarted = resolve; });
+  const cancelledAIService = {
+    chatStream: async (
+      _messages: Message[],
+      _tools: unknown,
+      _callbacks: unknown,
+      options: { signal?: AbortSignal } = {},
+    ) => await new Promise((_resolve, reject) => {
+      summaryStarted();
+      const signal = options.signal;
+      if (!signal) {
+        reject(new Error('missing cancellation signal'));
+        return;
+      }
+      if (signal.aborted) {
+        reject(signal.reason);
+        return;
+      }
+      signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+    }),
+  } as any;
+  const controller = new AbortController();
+  const restorer = new CatsCompanyCloudSessionRestorer(client, cancelledAIService, store);
+
+  const restoring = restorer.restoreIfMissing({
+    sessionKey: 'summary-cancelled-session',
+    topicId: 'p2p_7_42',
+    topicType: 'p2p',
+    agentId: 'usr42',
+    currentSeq: 2,
+    signal: controller.signal,
+  });
+  await summaryStartedPromise;
+  controller.abort();
+  const result = await restoring;
+
+  assert.equal(result.status, 'failed');
+  assert.equal(store.hasSession('summary-cancelled-session'), false);
+  assert.equal(store.saveCalls, 0);
+});
+
 test('history failure leaves the local session untouched for a later retry', async () => {
   const store = new MemorySessionStore();
   const client = new FakeHistoryClient(new Error('offline'));


### PR DESCRIPTION
## 问题\n\nCatsCompany 新设备恢复超长会话时，历史摘要与恢复共用 30 秒截止时间。摘要超时后恢复器已经生成了最近 60K token 的有界降级上下文，但随后的 	hrowIfAborted() 又将它丢弃，导致每次重试都在同一位置失败，安装版无法继续对话。\n\n## 修复\n\n- 记录上下文准备是否由摘要失败降级而来。\n- 仅在该降级路径且中止原因是 TimeoutError 时保存有界上下文。\n- 普通接口失败与显式取消（包括 /clear）仍禁止写回，避免旧会话复活。\n- 增加摘要超时成功降级、摘要期间主动取消不落盘的回归测试。\n\n## 验证\n\n- 
ode --import tsx --test tests/cloud-session-restore.test.ts：17/17 通过\n- 
pm test：1112 通过，4 跳过，0 失败\n- 
pm run build：通过\n- Windows win-unpacked 已生成并确认包含修复；最终 installer 阶段因本机未授权创建 electron-builder 缓存内的 macOS 符号链接而中止，与代码无关。