### PR TITLE
feat: 预装基础 SkillHub 能力

### DIFF
--- a/src/skillhub/default-skills.ts
+++ b/src/skillhub/default-skills.ts
@@ -8,7 +8,7 @@ export interface DefaultSkillHubSkill {
 export const DEFAULT_SKILLHUB_SKILLS: DefaultSkillHubSkill[] = [
   { key: 'lin/agent-browser', skillId: 'lin/agent-browser', version: '1.0.3', installName: 'agent-browser' },
   { key: 'atridaisuki/web-search', skillId: 'atridaisuki/web-search', version: '1.0.2', installName: 'web-search' },
-  { key: 'atridaisuki/deep-research', skillId: 'atridaisuki/deep-research', version: '1.0.4', installName: 'deep-research' },
+  { key: 'atridaisuki/deep-research', skillId: 'atridaisuki/deep-research', version: '1.0.5', installName: 'deep-research' },
   { key: 'atridaisuki/read-pdf', skillId: 'atridaisuki/read-pdf', version: '1.0.15', installName: 'read-pdf' },
   { key: 'atridaisuki/pdf-author-editor', skillId: 'atridaisuki/pdf-author-editor', version: '1.2.5', installName: 'pdf-author-editor' },
   { key: 'atridaisuki/image-asset-generator', skillId: 'atridaisuki/image-asset-generator', version: '1.0.13', installName: 'image-asset-generator' },

--- a/src/skillhub/default-skills.ts
+++ b/src/skillhub/default-skills.ts
@@ -7,4 +7,9 @@ export interface DefaultSkillHubSkill {
 
 export const DEFAULT_SKILLHUB_SKILLS: DefaultSkillHubSkill[] = [
   { key: 'lin/agent-browser', skillId: 'lin/agent-browser', version: '1.0.3', installName: 'agent-browser' },
+  { key: 'atridaisuki/web-search', skillId: 'atridaisuki/web-search', version: '1.0.2', installName: 'web-search' },
+  { key: 'atridaisuki/deep-research', skillId: 'atridaisuki/deep-research', version: '1.0.4', installName: 'deep-research' },
+  { key: 'atridaisuki/read-pdf', skillId: 'atridaisuki/read-pdf', version: '1.0.15', installName: 'read-pdf' },
+  { key: 'atridaisuki/pdf-author-editor', skillId: 'atridaisuki/pdf-author-editor', version: '1.2.5', installName: 'pdf-author-editor' },
+  { key: 'atridaisuki/image-asset-generator', skillId: 'atridaisuki/image-asset-generator', version: '1.0.13', installName: 'image-asset-generator' },
 ];

--- a/src/skillhub/default-skills.ts
+++ b/src/skillhub/default-skills.ts
@@ -8,7 +8,6 @@ export interface DefaultSkillHubSkill {
 export const DEFAULT_SKILLHUB_SKILLS: DefaultSkillHubSkill[] = [
   { key: 'lin/agent-browser', skillId: 'lin/agent-browser', version: '1.0.3', installName: 'agent-browser' },
   { key: 'atridaisuki/web-search', skillId: 'atridaisuki/web-search', version: '1.0.2', installName: 'web-search' },
-  { key: 'atridaisuki/deep-research', skillId: 'atridaisuki/deep-research', version: '1.0.5', installName: 'deep-research' },
   { key: 'atridaisuki/read-pdf', skillId: 'atridaisuki/read-pdf', version: '1.0.15', installName: 'read-pdf' },
   { key: 'atridaisuki/pdf-author-editor', skillId: 'atridaisuki/pdf-author-editor', version: '1.2.5', installName: 'pdf-author-editor' },
   { key: 'atridaisuki/image-asset-generator', skillId: 'atridaisuki/image-asset-generator', version: '1.0.13', installName: 'image-asset-generator' },

--- a/tests/skillhub-default-skills.test.ts
+++ b/tests/skillhub-default-skills.test.ts
@@ -7,7 +7,18 @@ import {
   bootstrapDefaultSkillHubSkills,
   getDefaultSkillBootstrapStatePath,
 } from '../src/skillhub/default-skill-bootstrap';
-import type { DefaultSkillHubSkill } from '../src/skillhub/default-skills';
+import {
+  DEFAULT_SKILLHUB_SKILLS,
+  type DefaultSkillHubSkill,
+} from '../src/skillhub/default-skills';
+
+const ATRIDAISUKI_DEFAULTS = [
+  'atridaisuki/web-search@1.0.2',
+  'atridaisuki/deep-research@1.0.4',
+  'atridaisuki/read-pdf@1.0.15',
+  'atridaisuki/pdf-author-editor@1.2.5',
+  'atridaisuki/image-asset-generator@1.0.13',
+];
 
 describe('default SkillHub bootstrap', () => {
   let testRoot: string;
@@ -27,6 +38,21 @@ describe('default SkillHub bootstrap', () => {
     if (originalSkillsEnv === undefined) delete process.env.XIAOBA_SKILLS_DIR;
     else process.env.XIAOBA_SKILLS_DIR = originalSkillsEnv;
     if (fs.existsSync(testRoot)) fs.rmSync(testRoot, { recursive: true, force: true });
+  });
+
+  test('ships the selected atridaisuki defaults without cloud HTML artifact', () => {
+    const configured = DEFAULT_SKILLHUB_SKILLS
+      .filter(skill => skill.skillId.startsWith('atridaisuki/'))
+      .map(skill => `${skill.skillId}@${skill.version}`);
+
+    assert.deepEqual(configured, ATRIDAISUKI_DEFAULTS);
+    assert.equal(configured.some(skill => skill.includes('artifact')), false);
+  });
+
+  test('keeps default identifiers and install directories unique', () => {
+    assertUnique(DEFAULT_SKILLHUB_SKILLS.map(skill => skill.key), 'key');
+    assertUnique(DEFAULT_SKILLHUB_SKILLS.map(skill => skill.skillId), 'skillId');
+    assertUnique(DEFAULT_SKILLHUB_SKILLS.map(skill => skill.installName), 'installName');
   });
 
   test('installs a missing default skill once and records central state', async () => {
@@ -133,4 +159,8 @@ function fakeInstallService(calls: string[]) {
 
 function readState(): any {
   return JSON.parse(fs.readFileSync(getDefaultSkillBootstrapStatePath(), 'utf-8'));
+}
+
+function assertUnique(values: string[], label: string): void {
+  assert.equal(new Set(values).size, values.length, `Default SkillHub ${label} values must be unique.`);
 }

--- a/tests/skillhub-default-skills.test.ts
+++ b/tests/skillhub-default-skills.test.ts
@@ -14,7 +14,7 @@ import {
 
 const ATRIDAISUKI_DEFAULTS = [
   'atridaisuki/web-search@1.0.2',
-  'atridaisuki/deep-research@1.0.4',
+  'atridaisuki/deep-research@1.0.5',
   'atridaisuki/read-pdf@1.0.15',
   'atridaisuki/pdf-author-editor@1.2.5',
   'atridaisuki/image-asset-generator@1.0.13',

--- a/tests/skillhub-default-skills.test.ts
+++ b/tests/skillhub-default-skills.test.ts
@@ -14,7 +14,6 @@ import {
 
 const ATRIDAISUKI_DEFAULTS = [
   'atridaisuki/web-search@1.0.2',
-  'atridaisuki/deep-research@1.0.5',
   'atridaisuki/read-pdf@1.0.15',
   'atridaisuki/pdf-author-editor@1.2.5',
   'atridaisuki/image-asset-generator@1.0.13',


### PR DESCRIPTION
## 背景

XiaoBa 已有默认 SkillHub 启动安装机制，但当前只预装 `lin/agent-browser`。这次将 `atridaisuki` 名下四项适合本地直接安装的通用基础能力加入默认清单，让新老用户在启动后零配置获得网页检索、PDF 读写和生图能力。

`cloud-html-artifact` 按产品边界明确不加入默认清单。`deep-research` 依赖完整的 `gpt-researcher` 本地运行环境，首次使用自动安装仍不能满足默认预装应有的稳定体验，因此也不加入默认清单，继续作为可选 SkillHub Skill 提供。

## 改动

- 固定预装 `web-search@1.0.2`
- 固定预装 `read-pdf@1.0.15`
- 固定预装 `pdf-author-editor@1.2.5`
- 固定预装 `image-asset-generator@1.0.13`
- 增加生产默认清单测试，锁定上述 Skill 和版本，并检查 `key`、`skillId`、`installName` 不重复

## 用户影响

- XiaoBa 启动时通过现有 SkillHub bootstrap 异步安装缺失项，不阻塞界面启动。
- 已有同名目录不会被覆盖；用户删除或禁用后不会被强制恢复。
- 版本保持固定，不改变现有“首次默认安装但不自动升级”的策略。
- 不会在用户首次使用 Deep Research 时临时下载大型 Python 依赖。

## 验证

- `node --import tsx --test tests/skillhub-default-skills.test.ts`：6/6 通过
- `npm run build`：通过
- `git diff --check`：通过