### PR TITLE
fix: discover model vision capabilities dynamically

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,7 +37,8 @@ WEIXIN_TOKEN=
 WEIXIN_BASE_URL=https://ilinkai.weixin.qq.com
 WEIXIN_CDN_BASE_URL=https://novac2c.cdn.weixin.qq.com/c2c
 
-# Optional image reader proxy used by read_file for non-vision primary models.
+# Optional reader endpoint/auth overrides. Normal CatsCo use automatically
+# reuses the bound bot key and logged-in account token, including auth fallback.
 READER_PROXY_URL=
 READER_PROXY_API_KEY=
 READER_PROXY_BEARER_TOKEN=

--- a/src/bot-definition/activation.ts
+++ b/src/bot-definition/activation.ts
@@ -1,5 +1,8 @@
 import { createCatsCoLocalConfigService, type CatsCoAuthSnapshot } from '../catscompany/local-config';
-import { provisionCatsRelayCatalogRuntime } from '../catscompany/relay-model-bootstrap';
+import {
+  provisionCatsRelayCatalogRuntime,
+  refreshCatsRelayCatalogRuntimeCapabilities,
+} from '../catscompany/relay-model-bootstrap';
 import { DEFAULT_CATSCO_RELAY_MODEL_ID } from '../utils/relay-model-profiles';
 import { Logger } from '../utils/logger';
 import {
@@ -249,6 +252,12 @@ export async function prepareBoundBotDefinition(
       if (activeCloudOverride) definitionService.storeCloudCatalogRuntime(materialized);
       else definitionService.storeCatalogRuntime(materialized);
       materializedCatalogRuntime = true;
+    } else if (catalogCapabilitiesNeedRefresh(runtime)) {
+      const refreshed = await refreshCatsRelayCatalogRuntimeCapabilities(runtime, options.fetchImpl ?? fetch);
+      if (refreshed !== runtime) {
+        if (activeCloudOverride) definitionService.storeCloudCatalogRuntime(refreshed);
+        else definitionService.storeCatalogRuntime(refreshed);
+      }
     }
   }
 
@@ -263,6 +272,12 @@ export async function prepareBoundBotDefinition(
     ...(cloudApplyError ? { cloudApplyError } : {}),
     ...(cloudSelectionApplied && cloudSelection ? { cloudRevision: cloudSelection.revision } : {}),
   };
+}
+
+function catalogCapabilitiesNeedRefresh(runtime: BotCatalogModelRuntime): boolean {
+  if (runtime.capabilitiesSource !== 'relay-models' || !runtime.capabilitiesCheckedAt) return true;
+  const checkedAt = Date.parse(runtime.capabilitiesCheckedAt);
+  return !Number.isFinite(checkedAt) || Date.now() - checkedAt >= 24 * 60 * 60 * 1000;
 }
 
 function errorMessage(error: unknown): string {

--- a/src/bot-definition/service.ts
+++ b/src/bot-definition/service.ts
@@ -309,8 +309,8 @@ function normalizeCatalogRuntime(runtime: BotCatalogModelRuntime): BotCatalogMod
     ...runtime,
     modelId: profile.id,
     model: profile.model,
-    contextWindowTokens: profile.contextWindowTokens,
-    capabilities: profile.capabilities,
+    contextWindowTokens: runtime.contextWindowTokens || profile.contextWindowTokens,
+    capabilities: runtime.capabilities ?? profile.capabilities,
   };
 }
 

--- a/src/bot-definition/types.ts
+++ b/src/bot-definition/types.ts
@@ -85,6 +85,8 @@ export interface BotCatalogModelRuntime {
     toolCalling?: boolean;
     streaming?: boolean;
   };
+  capabilitiesSource?: 'relay-models' | 'static' | 'probe';
+  capabilitiesCheckedAt?: string;
 }
 
 /**

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -29,7 +29,7 @@ import { AdapterRuntimeBundle, createAdapterRuntime } from '../runtime/adapter-r
 import { randomUUID } from 'crypto';
 import { hostname, platform } from 'os';
 import { ConfigManager } from '../utils/config';
-import { isPrimaryModelVisionCapable } from '../utils/model-capabilities';
+import { resolvePrimaryModelVisionCapability } from '../utils/model-capabilities';
 import { createCatsCoSessionRoute } from '../core/session-router';
 import { ReadTool } from '../tools/read-tool';
 import { GlobTool } from '../tools/glob-tool';
@@ -2854,7 +2854,8 @@ export class CatsCompanyBot {
     const { createImageBlock } = require('../utils/image-utils');
     const blocks: import('../types').ContentBlock[] = [];
     const config = ConfigManager.getConfigReadonly();
-    const primaryModelCanSeeImages = isPrimaryModelVisionCapable(config);
+    const visionState = await resolvePrimaryModelVisionCapability(config);
+    const primaryModelCanSeeImages = visionState === 'supported';
     const modelName = config.model || 'unknown';
     const currentImageRefs: string[] = [];
 
@@ -2900,7 +2901,7 @@ export class CatsCompanyBot {
             currentImageRefs.join('\n\n'),
           ].join('\n'),
         });
-      Logger.info(`[CatsCo] vision_fallback_read_file model=${modelName} images=${currentImageRefs.length} reason=${primaryModelCanSeeImages ? 'image_block_create_failed' : 'model_not_vision_capable'}`);
+      Logger.info(`[CatsCo] vision_fallback_read_file model=${modelName} images=${currentImageRefs.length} reason=${primaryModelCanSeeImages ? 'image_block_create_failed' : visionState === 'unsupported' ? 'model_not_vision_capable' : 'model_capability_unknown'}`);
     }
 
     return blocks;

--- a/src/catscompany/relay-model-bootstrap.ts
+++ b/src/catscompany/relay-model-bootstrap.ts
@@ -8,6 +8,7 @@ import type { BotCatalogModelRuntime } from '../bot-definition/types';
 import type { ReasoningEffort } from '../types';
 
 const REQUEST_TIMEOUT_MS = 10_000;
+const CAPABILITY_REQUEST_TIMEOUT_MS = 3_000;
 
 export interface CatsRelayBootstrapOptions {
   botId: string;
@@ -16,6 +17,8 @@ export interface CatsRelayBootstrapOptions {
   reasoningEffort?: ReasoningEffort;
   fetchImpl?: typeof fetch;
 }
+
+type RuntimeCapabilities = NonNullable<BotCatalogModelRuntime['capabilities']>;
 
 /**
  * Obtains the device-local material needed to run a catalog model. The caller
@@ -44,6 +47,13 @@ export async function provisionCatsRelayCatalogRuntime(
   ensureRequestedModelIsAvailable(relayConfig, profile.id, profile.model);
 
   const apiKey = await ensurePlainRelayKey(fetchImpl, httpBaseUrl, token, options.auth);
+  const relayCapabilities = await fetchRelayModelCapabilities(
+    fetchImpl,
+    relayEndpointForProvider(relayConfig, 'openai'),
+    apiKey,
+    profile.model,
+  );
+  const capabilities = mergeCapabilities(profile.capabilities, relayCapabilities);
   return {
     schema: 'xiaoba.bot-catalog-model-runtime.v1',
     botId,
@@ -55,12 +65,108 @@ export async function provisionCatsRelayCatalogRuntime(
     contextWindowTokens: profile.contextWindowTokens,
     reasoningEffort: options.reasoningEffort ?? 'high',
     openaiApiMode: profile.openaiApiMode ?? 'chat_completions',
-    capabilities: {
-      vision: profile.capabilities.vision,
-      toolCalling: profile.capabilities.toolCalling,
-      streaming: profile.capabilities.streaming,
-    },
+    capabilities,
+    capabilitiesSource: relayCapabilities ? 'relay-models' : 'static',
+    ...(relayCapabilities ? { capabilitiesCheckedAt: new Date().toISOString() } : {}),
   };
+}
+
+export async function refreshCatsRelayCatalogRuntimeCapabilities(
+  runtime: BotCatalogModelRuntime,
+  fetchImpl: typeof fetch = fetch,
+): Promise<BotCatalogModelRuntime> {
+  const profile = findRelayModelProfile(runtime.modelId) ?? findRelayModelProfile(runtime.model);
+  const relayCapabilities = await fetchRelayModelCapabilities(
+    fetchImpl,
+    runtime.apiBase,
+    runtime.apiKey,
+    runtime.model,
+  );
+  if (!relayCapabilities) {
+    if (runtime.capabilitiesSource === 'relay-models') return runtime;
+    return {
+      ...runtime,
+      capabilities: mergeCapabilities(profile?.capabilities),
+      capabilitiesSource: 'static',
+    };
+  }
+  return {
+    ...runtime,
+    capabilities: mergeCapabilities(profile?.capabilities, relayCapabilities),
+    capabilitiesSource: 'relay-models',
+    capabilitiesCheckedAt: new Date().toISOString(),
+  };
+}
+
+function mergeCapabilities(
+  fallback?: Partial<RuntimeCapabilities>,
+  primary?: Partial<RuntimeCapabilities>,
+): RuntimeCapabilities {
+  const merged = { ...(fallback || {}), ...(primary || {}) };
+  return {
+    ...(typeof merged.vision === 'boolean' ? { vision: merged.vision } : {}),
+    ...(typeof merged.toolCalling === 'boolean' ? { toolCalling: merged.toolCalling } : {}),
+    ...(typeof merged.streaming === 'boolean' ? { streaming: merged.streaming } : {}),
+  };
+}
+
+function relayModelsUrl(apiBase: string): string {
+  const parsed = new URL(String(apiBase || '').trim());
+  const path = parsed.pathname.replace(/\/+$/, '');
+  if (/\/anthropic$/i.test(path)) {
+    parsed.pathname = path.replace(/\/anthropic$/i, '/v1/models');
+  } else if (/\/v1$/i.test(path)) {
+    parsed.pathname = `${path}/models`;
+  } else if (/\/models$/i.test(path)) {
+    parsed.pathname = path;
+  } else {
+    parsed.pathname = `${path}/v1/models`;
+  }
+  return parsed.toString();
+}
+
+async function fetchRelayModelCapabilities(
+  fetchImpl: typeof fetch,
+  apiBase: string,
+  apiKey: string,
+  modelName: string,
+): Promise<RuntimeCapabilities | undefined> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), CAPABILITY_REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetchImpl(relayModelsUrl(apiBase), {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${apiKey}` },
+      signal: controller.signal,
+    });
+    if (!response.ok) return undefined;
+    const payload = await response.json() as any;
+    const requested = String(modelName || '').trim().toLowerCase();
+    const item = Array.isArray(payload?.data)
+      ? payload.data.find((candidate: any) => String(candidate?.id || '').trim().toLowerCase() === requested)
+      : undefined;
+    if (!item) return undefined;
+    const capabilities = item.capabilities && typeof item.capabilities === 'object'
+      ? item.capabilities
+      : {};
+    const rawModalities = capabilities.input_modalities ?? item.input_modalities;
+    const modalities = Array.isArray(rawModalities)
+      ? rawModalities.map((value: unknown) => String(value).trim().toLowerCase())
+      : undefined;
+    return {
+      ...(typeof capabilities.vision === 'boolean'
+        ? { vision: capabilities.vision }
+        : modalities ? { vision: modalities.includes('image') } : {}),
+      ...(typeof capabilities.tool_calling === 'boolean'
+        ? { toolCalling: capabilities.tool_calling }
+        : typeof capabilities.toolCalling === 'boolean' ? { toolCalling: capabilities.toolCalling } : {}),
+      ...(typeof capabilities.streaming === 'boolean' ? { streaming: capabilities.streaming } : {}),
+    };
+  } catch {
+    return undefined;
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 async function ensurePlainRelayKey(

--- a/src/commands/catscompany.ts
+++ b/src/commands/catscompany.ts
@@ -54,7 +54,12 @@ export async function catscompanyCommand(): Promise<void> {
     Logger.info(`CatsCo bot ${preparedBot.botId} 已在当前设备准备 ${preparedBot.definition.model.kind === 'catalog' ? preparedBot.definition.model.modelId : '模型'} 的运行材料。`);
   }
   const config = ConfigManager.getConfig();
-  const resolved = resolveCatsCoCommandConfig(config);
+  const resolvedRuntime = resolveCatsCoRuntimeConfig({ runtimeRoot, env: process.env, config });
+  Object.assign(process.env, resolvedRuntime.envOverlay);
+  const resolved: CatsCoCommandConfigResolution = {
+    missing: resolvedRuntime.missing,
+    config: resolvedRuntime.connector,
+  };
 
   const connectorConfig = resolved.config;
   if (!connectorConfig) {

--- a/src/tools/read-tool.ts
+++ b/src/tools/read-tool.ts
@@ -8,7 +8,7 @@ import { ContentBlock } from '../types';
 import { isReadPathAllowed } from '../utils/safety';
 import { createImageBlock } from '../utils/image-utils';
 import { ConfigManager } from '../utils/config';
-import { isPrimaryModelVisionCapable } from '../utils/model-capabilities';
+import { resolvePrimaryModelVisionCapability } from '../utils/model-capabilities';
 import { analyzeImageWithReaderProxy, ReaderProxyResult } from '../utils/reader-proxy';
 import { Logger } from '../utils/logger';
 import { formatPathForLog } from '../utils/log-redaction';
@@ -777,7 +777,8 @@ export class ReadTool implements Tool {
     try {
       const renderedPages = await this.renderPdfPagesToImages(absolutePath, pages, tempDir);
       const isSupplement = options?.reason === 'visual_supplement';
-      const visionCapable = isPrimaryModelVisionCapable(ConfigManager.getConfigReadonly());
+      const visionState = await resolvePrimaryModelVisionCapability(ConfigManager.getConfigReadonly());
+      const visionCapable = visionState === 'supported';
       const parts = [
         isSupplement
           ? 'PDF 文本层已提取；由于用户任务可能涉及图片、签名、印章、手写、版式或表格，已额外转成页面图片补充读取。'
@@ -1053,7 +1054,7 @@ export class ReadTool implements Tool {
   private formatReaderProxyFailure(proxyResult: ReaderProxyResult, visionCapable: boolean): string {
     const status = proxyResult.status;
     const attempts = proxyResult.attempts && proxyResult.attempts > 1
-      ? `已自动重试 ${proxyResult.attempts} 次。`
+      ? `已自动尝试 ${proxyResult.attempts} 次（含凭证切换或网络重试）。`
       : '';
     const rawError = String(proxyResult.error || 'unknown error').trim();
     const shortError = rawError.length > 500 ? `${rawError.slice(0, 500)}...` : rawError;
@@ -1061,15 +1062,15 @@ export class ReadTool implements Tool {
     let title = '读图失败：读图服务暂时没有返回可用结果。';
     let action = '可以稍后重试，或先把图片里的关键文字/区域用文字补充一下。';
 
-    if (/requires CATSCOMPANY_API_KEY|READER_PROXY_API_KEY|apiKey/i.test(rawError)) {
-      title = '读图失败：读图服务配置缺失。';
-      action = '请检查 CatsCo API Key / Reader Proxy API Key 是否已配置到 CatsCo 桌面端。';
+    if (/could not find the current CatsCo account|requires CATSCOMPANY_API_KEY|READER_PROXY_API_KEY|apiKey/i.test(rawError)) {
+      title = '读图失败：当前 CatsCo 登录或机器人绑定没有提供有效认证。';
+      action = '请重新登录 CatsCo 或重新绑定机器人；正常使用不需要单独配置 Reader Key。';
     } else if (status === 400) {
       title = '读图失败：图片请求格式不被服务接受。';
       action = '请确认上传的是常见图片格式（png/jpg/jpeg/webp/gif/bmp），必要时重新截图后再发。';
     } else if (status === 401 || status === 403) {
       title = '读图失败：读图服务鉴权失败。';
-      action = '请检查 CatsCo API Key 是否正确、是否仍然有效，以及当前机器人是否有权限调用读图服务。';
+      action = '请重新登录 CatsCo 或重新绑定机器人，并确认账号仍有读图权限。';
     } else if (status === 404) {
       title = '读图失败：读图服务地址不正确。';
       action = '请检查 Reader Proxy URL / CatsCo HTTP Base URL 是否指向正确服务。';
@@ -1111,7 +1112,8 @@ export class ReadTool implements Tool {
   ): Promise<any> {
     const config = ConfigManager.getConfigReadonly();
     const imagePrompt = this.getImageReadPrompt(context, prompt);
-    const visionCapable = isPrimaryModelVisionCapable(config);
+    const visionState = await resolvePrimaryModelVisionCapability(config);
+    const visionCapable = visionState === 'supported';
     const modelName = config.model || 'unknown';
 
     if (visionCapable) {
@@ -1127,7 +1129,7 @@ export class ReadTool implements Tool {
       }
       Logger.warning(`[CatsCo] vision_fallback_read_file model=${modelName} tool=read_file file=${logFile} reason=image_block_create_failed path=${logFile}`);
     } else {
-      Logger.info(`[CatsCo] vision_fallback_read_file model=${modelName} tool=read_file file=${formatPathForLog(absolutePath || filePath)} reason=model_not_vision_capable`);
+      Logger.info(`[CatsCo] vision_fallback_read_file model=${modelName} tool=read_file file=${formatPathForLog(absolutePath || filePath)} reason=${visionState === 'unsupported' ? 'model_not_vision_capable' : 'model_capability_unknown'}`);
     }
 
     const proxyResult = await analyzeImageWithReaderProxy({

--- a/src/utils/model-capabilities.ts
+++ b/src/utils/model-capabilities.ts
@@ -1,8 +1,9 @@
 import { ChatConfig } from '../types';
 import { findRelayModelProfile } from './relay-model-profiles';
+import { probeVisionCapability, type VisionCapabilityState, type VisionProbeOptions } from './model-vision-probe';
 
 const KNOWN_TEXT_ONLY_MODEL_PATTERNS = [
-  /deepseek/i,
+  /^deepseek-(?:chat|reasoner|v4-flash)$/i,
   /gpt-3\.5/i,
   /text-/i,
   /embedding/i,
@@ -40,7 +41,7 @@ export function isPrimaryModelVisionCapable(config: Pick<ChatConfig, 'apiUrl' | 
   const isRelay = apiUrl.includes('relay.catsco.cc');
   if (isRelay) {
     const relayProfile = findRelayModelProfile(model);
-    if (relayProfile) {
+    if (relayProfile?.capabilities.vision !== undefined) {
       return relayProfile.capabilities.vision;
     }
   }
@@ -55,6 +56,47 @@ export function isPrimaryModelVisionCapable(config: Pick<ChatConfig, 'apiUrl' | 
   }
 
   return includesAny(model, KNOWN_VISION_MODEL_PATTERNS);
+}
+
+/**
+ * Resolves image-input support without turning transient network or auth
+ * failures into permanent "text-only" facts. Catalog metadata wins; unknown
+ * custom/relay models are actively probed and cached by endpoint + model + key.
+ */
+export async function resolvePrimaryModelVisionCapability(
+  config: Pick<ChatConfig, 'apiUrl' | 'apiKey' | 'model' | 'provider' | 'openaiApiMode' | 'modelCapabilities'>,
+  options: VisionProbeOptions = {},
+): Promise<VisionCapabilityState> {
+  if (config.modelCapabilities?.vision !== undefined) {
+    return config.modelCapabilities.vision ? 'supported' : 'unsupported';
+  }
+
+  const apiUrl = (config.apiUrl || '').toLowerCase();
+  const model = (config.model || '').trim();
+  const modelKey = model.toLowerCase();
+  if (apiUrl.includes('relay.catsco.cc')) {
+    const relayProfile = findRelayModelProfile(model);
+    if (relayProfile?.capabilities.vision !== undefined) {
+      return relayProfile.capabilities.vision ? 'supported' : 'unsupported';
+    }
+  }
+
+  if (apiUrl.includes('api.openai.com') && includesAny(modelKey, KNOWN_VISION_MODEL_PATTERNS)) {
+    return 'supported';
+  }
+  if (apiUrl.includes('api.anthropic.com') && /claude/i.test(modelKey)) {
+    return 'supported';
+  }
+
+  if (apiUrl.includes('deepseek.com') || apiUrl.includes('minimaxi.com')) {
+    if (includesAny(modelKey, [/minimax-m3/i, /vision/i, /vl/i, /image/i, /multimodal/i, /omni/i])) {
+      return 'supported';
+    }
+    if (includesAny(modelKey, KNOWN_TEXT_ONLY_MODEL_PATTERNS)) return 'unsupported';
+  }
+
+  if (includesAny(modelKey, KNOWN_TEXT_ONLY_MODEL_PATTERNS)) return 'unsupported';
+  return probeVisionCapability(config, options);
 }
 
 export function isPrimaryModelToolCallingCapable(config: Pick<ChatConfig, 'apiUrl' | 'model' | 'provider' | 'modelCapabilities'>): boolean {

--- a/src/utils/model-vision-probe.ts
+++ b/src/utils/model-vision-probe.ts
@@ -1,0 +1,288 @@
+import { createHash } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { ChatConfig } from '../types';
+import { normalizeOpenAIChatCompletionsUrl, normalizeOpenAIResponsesUrl } from '../providers/openai-url';
+import { PathResolver } from './path-resolver';
+
+export type VisionCapabilityState = 'supported' | 'unsupported' | 'unknown';
+
+interface CachedVisionCapability {
+  state: VisionCapabilityState;
+  checkedAt: string;
+}
+
+interface VisionCapabilityCache {
+  schema: 'xiaoba.model-capability-cache.v1';
+  entries: Record<string, CachedVisionCapability>;
+}
+
+type ProbeConfig = Pick<ChatConfig, 'apiUrl' | 'apiKey' | 'model' | 'provider' | 'openaiApiMode'>;
+
+export interface VisionProbeOptions {
+  fetchImpl?: typeof fetch;
+  cachePath?: string;
+  now?: () => Date;
+  timeoutMs?: number;
+  probeImageBase64?: string;
+}
+
+const DEFAULT_PROBE_TIMEOUT_MS = 30_000;
+const KNOWN_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const UNKNOWN_TTL_MS = 60 * 60 * 1000;
+const MAX_CACHE_ENTRIES = 512;
+const PROBE_CODE = '731';
+const PROBE_PROMPT = 'Return only the three digits visibly printed in this image. Do not guess.';
+const inFlightProbes = new Map<string, Promise<VisionCapabilityState>>();
+
+export async function probeVisionCapability(
+  config: ProbeConfig,
+  options: VisionProbeOptions = {},
+): Promise<VisionCapabilityState> {
+  const apiUrl = String(config.apiUrl || '').trim();
+  const apiKey = String(config.apiKey || '').trim();
+  const model = String(config.model || '').trim();
+  if (!apiUrl || !apiKey || !model || !config.provider) return 'unknown';
+
+  const now = options.now?.() ?? new Date();
+  const cachePath = options.cachePath ?? PathResolver.getDataPath('model-capability-cache.json');
+  const cacheKey = buildCacheKey(config);
+  const inFlightKey = `${cachePath}\n${cacheKey}`;
+  const cache = readCache(cachePath);
+  const cached = cache.entries[cacheKey];
+  if (cached && cacheEntryIsFresh(cached, now)) return cached.state;
+
+  const existing = inFlightProbes.get(inFlightKey);
+  if (existing) return existing;
+
+  const pending = runProbe(config, options)
+    .then(state => {
+      const latestCache = readCache(cachePath);
+      latestCache.entries[cacheKey] = { state, checkedAt: now.toISOString() };
+      pruneCache(latestCache, now);
+      writeCache(cachePath, latestCache);
+      return state;
+    })
+    .finally(() => inFlightProbes.delete(inFlightKey));
+  inFlightProbes.set(inFlightKey, pending);
+  return pending;
+}
+
+async function runProbe(config: ProbeConfig, options: VisionProbeOptions): Promise<VisionCapabilityState> {
+  const probeImageBase64 = options.probeImageBase64 ?? createProbeImageBase64();
+  if (!probeImageBase64) return 'unknown';
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? DEFAULT_PROBE_TIMEOUT_MS);
+  try {
+    const request = buildProbeRequest(config, probeImageBase64);
+    const response = await (options.fetchImpl ?? fetch)(request.url, {
+      method: 'POST',
+      headers: request.headers,
+      body: JSON.stringify(request.body),
+      signal: controller.signal,
+    });
+    const text = await response.text();
+    const payload = parseJsonResponse(text);
+    if (response.ok) {
+      return extractResponseText(config, payload).includes(PROBE_CODE) ? 'supported' : 'unknown';
+    }
+    return isExplicitVisionRejection(response.status, text, payload) ? 'unsupported' : 'unknown';
+  } catch {
+    return 'unknown';
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function createProbeImageBase64(): string | undefined {
+  try {
+    // This dependency is already shipped for PDF rendering. Generating the
+    // probe at runtime keeps source and packaged assets small.
+    const canvasModule = require('@napi-rs/canvas') as {
+      createCanvas: (width: number, height: number) => {
+        getContext: (kind: '2d') => {
+          fillStyle: string;
+          font: string;
+          textAlign: string;
+          textBaseline: string;
+          fillRect: (x: number, y: number, width: number, height: number) => void;
+          fillText: (text: string, x: number, y: number) => void;
+        };
+        toBuffer: (mimeType: 'image/png') => Buffer;
+      };
+    };
+    const canvas = canvasModule.createCanvas(220, 80);
+    const context = canvas.getContext('2d');
+    context.fillStyle = '#ffffff';
+    context.fillRect(0, 0, 220, 80);
+    context.fillStyle = '#000000';
+    context.font = 'bold 48px Arial';
+    context.textAlign = 'center';
+    context.textBaseline = 'middle';
+    context.fillText(PROBE_CODE, 110, 40);
+    return canvas.toBuffer('image/png').toString('base64');
+  } catch {
+    return undefined;
+  }
+}
+
+function buildProbeRequest(
+  config: ProbeConfig,
+  probeImageBase64: string,
+): { url: string; headers: Record<string, string>; body: Record<string, unknown> } {
+  const dataUrl = `data:image/png;base64,${probeImageBase64}`;
+  if (config.provider === 'anthropic') {
+    const base = String(config.apiUrl || '')
+      .replace(/\/v1\/messages\/?$/i, '')
+      .replace(/\/v1\/?$/i, '')
+      .replace(/\/+$/, '');
+    return {
+      url: `${base}/v1/messages`,
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': String(config.apiKey),
+        'anthropic-version': '2023-06-01',
+      },
+      body: {
+        model: config.model,
+        max_tokens: 32,
+        temperature: 0,
+        messages: [{
+          role: 'user',
+          content: [
+            { type: 'text', text: PROBE_PROMPT },
+            { type: 'image', source: { type: 'base64', media_type: 'image/png', data: probeImageBase64 } },
+          ],
+        }],
+      },
+    };
+  }
+
+  if (config.openaiApiMode === 'responses') {
+    return {
+      url: normalizeOpenAIResponsesUrl(String(config.apiUrl)),
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${config.apiKey}` },
+      body: {
+        model: config.model,
+        max_output_tokens: 32,
+        input: [{
+          role: 'user',
+          content: [
+            { type: 'input_text', text: PROBE_PROMPT },
+            { type: 'input_image', image_url: dataUrl },
+          ],
+        }],
+      },
+    };
+  }
+
+  return {
+    url: normalizeOpenAIChatCompletionsUrl(String(config.apiUrl)),
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${config.apiKey}` },
+    body: {
+      model: config.model,
+      max_tokens: 32,
+      temperature: 0,
+      messages: [{
+        role: 'user',
+        content: [
+          { type: 'text', text: PROBE_PROMPT },
+          { type: 'image_url', image_url: { url: dataUrl } },
+        ],
+      }],
+    },
+  };
+}
+
+function extractResponseText(config: Pick<ChatConfig, 'provider' | 'openaiApiMode'>, payload: any): string {
+  if (config.provider === 'anthropic') {
+    return Array.isArray(payload?.content)
+      ? payload.content.map((item: any) => String(item?.text || '')).join('\n')
+      : '';
+  }
+  if (config.openaiApiMode === 'responses') {
+    if (typeof payload?.output_text === 'string') return payload.output_text;
+    return Array.isArray(payload?.output)
+      ? payload.output
+        .flatMap((item: any) => Array.isArray(item?.content) ? item.content : [])
+        .map((item: any) => String(item?.text || item?.output_text || ''))
+        .join('\n')
+      : '';
+  }
+  return String(payload?.choices?.[0]?.message?.content || '');
+}
+
+function isExplicitVisionRejection(status: number, rawText: string, payload: any): boolean {
+  if (![400, 415, 422].includes(status)) return false;
+  const message = `${rawText} ${payload?.error?.message || payload?.message || ''}`;
+  return /image|vision|multimodal|modality|图片|视觉/i.test(message)
+    && /unsupported|not support|does not support|invalid.*image|text.only|不支持|仅.*文本/i.test(message);
+}
+
+function parseJsonResponse(text: string): any {
+  try {
+    return text ? JSON.parse(text) : {};
+  } catch {
+    return { raw: text };
+  }
+}
+
+function buildCacheKey(config: ProbeConfig): string {
+  return createHash('sha256')
+    .update([
+      config.provider,
+      config.openaiApiMode || '',
+      String(config.apiUrl || '').trim(),
+      String(config.model || '').trim(),
+      String(config.apiKey || '').trim(),
+    ].join('\n'))
+    .digest('hex');
+}
+
+function cacheEntryIsFresh(entry: CachedVisionCapability, now: Date): boolean {
+  const age = now.getTime() - Date.parse(entry.checkedAt);
+  const ttl = entry.state === 'unknown' ? UNKNOWN_TTL_MS : KNOWN_TTL_MS;
+  return Number.isFinite(age) && age >= 0 && age < ttl;
+}
+
+function readCache(cachePath: string): VisionCapabilityCache {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(cachePath, 'utf8')) as VisionCapabilityCache;
+    if (parsed?.schema === 'xiaoba.model-capability-cache.v1' && parsed.entries && typeof parsed.entries === 'object') {
+      return parsed;
+    }
+  } catch {
+    // Missing and damaged caches are both safe to rebuild.
+  }
+  return { schema: 'xiaoba.model-capability-cache.v1', entries: {} };
+}
+
+function pruneCache(cache: VisionCapabilityCache, now: Date): void {
+  const entries = Object.entries(cache.entries)
+    .filter(([, entry]) => {
+      const age = now.getTime() - Date.parse(entry.checkedAt);
+      return Number.isFinite(age) && age >= 0 && age < KNOWN_TTL_MS;
+    })
+    .sort((left, right) => Date.parse(right[1].checkedAt) - Date.parse(left[1].checkedAt))
+    .slice(0, MAX_CACHE_ENTRIES);
+  cache.entries = Object.fromEntries(entries);
+}
+
+function writeCache(cachePath: string, cache: VisionCapabilityCache): void {
+  const tempPath = `${cachePath}.${process.pid}.tmp`;
+  try {
+    fs.mkdirSync(path.dirname(cachePath), { recursive: true });
+    fs.writeFileSync(tempPath, `${JSON.stringify(cache, null, 2)}\n`, 'utf8');
+    try {
+      fs.renameSync(tempPath, cachePath);
+    } catch {
+      // Windows may refuse replacing an existing file with rename.
+      fs.copyFileSync(tempPath, cachePath);
+      fs.rmSync(tempPath, { force: true });
+    }
+  } catch {
+    // Capability probing must still work in read-only runtimes.
+    try { fs.rmSync(tempPath, { force: true }); } catch { /* Best effort cleanup. */ }
+  }
+}

--- a/src/utils/reader-proxy.ts
+++ b/src/utils/reader-proxy.ts
@@ -64,27 +64,36 @@ function resolveReaderBaseUrl(config?: ChatConfig): string {
   return `${httpBaseUrl}${DEFAULT_READER_API_PATH}`;
 }
 
-function buildAuthHeaders(config?: ChatConfig): Record<string, string> {
-  const apiKey = (
-    process.env.CATSCOMPANY_API_KEY
-    || process.env.READER_PROXY_API_KEY
-    || config?.catscompany?.apiKey
-    || ''
-  ).trim();
-  if (apiKey) {
-    return { Authorization: `ApiKey ${apiKey}` };
+function buildAuthHeaderCandidates(config?: ChatConfig): Array<Record<string, string>> {
+  const candidates = [
+    ...[
+      process.env.READER_PROXY_API_KEY,
+      process.env.CATSCO_API_KEY,
+      process.env.CATSCOMPANY_API_KEY,
+      config?.catscompany?.apiKey,
+    ].map(value => ({ scheme: 'ApiKey', value })),
+    ...[
+      process.env.READER_PROXY_BEARER_TOKEN,
+      process.env.CATSCO_BEARER_TOKEN,
+      process.env.CATSCOMPANY_BEARER_TOKEN,
+      process.env.CATSCO_USER_TOKEN,
+      process.env.CATSCOMPANY_USER_TOKEN,
+    ].map(value => ({ scheme: 'Bearer', value })),
+  ];
+  const seen = new Set<string>();
+  const headers: Array<Record<string, string>> = [];
+  for (const candidate of candidates) {
+    const value = String(candidate.value || '').trim();
+    if (!value) continue;
+    const authorization = `${candidate.scheme} ${value}`;
+    if (seen.has(authorization)) continue;
+    seen.add(authorization);
+    headers.push({ Authorization: authorization });
   }
-
-  const bearerToken = (
-    process.env.CATSCOMPANY_BEARER_TOKEN
-    || process.env.READER_PROXY_BEARER_TOKEN
-    || ''
-  ).trim();
-  if (bearerToken) {
-    return { Authorization: `Bearer ${bearerToken}` };
+  if (headers.length === 0) {
+    throw new Error('Cats reader proxy could not find the current CatsCo account or bot authentication.');
   }
-
-  throw new Error('Cats reader proxy requires CATSCOMPANY_API_KEY / READER_PROXY_API_KEY, or CatsCo bot apiKey.');
+  return headers;
 }
 
 function appendField(chunks: Buffer[], boundary: string, name: string, value: string): void {
@@ -126,64 +135,78 @@ export async function analyzeImageWithReaderProxy(options: ReaderProxyOptions): 
   const analyzeUrl = `${baseUrl}/analyze`;
   const prompt = normalizePrompt(options.prompt);
   const { body, boundary } = buildMultipartBody(options.filePath, { prompt });
-  const maxAttempts = RETRY_DELAYS_MS.length + 1;
+  let authCandidates: Array<Record<string, string>>;
+  try {
+    authCandidates = buildAuthHeaderCandidates(options.config);
+  } catch (error: any) {
+    return { ok: false, attempts: 0, error: String(error?.message || error || 'Unknown reader proxy auth error') };
+  }
+  let totalAttempts = 0;
 
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    try {
-      const response = await axios.post(analyzeUrl, body, {
-        timeout: DEFAULT_TIMEOUT_MS,
-        maxBodyLength: Infinity,
-        maxContentLength: Infinity,
-        validateStatus: () => true,
-        headers: {
-          ...buildAuthHeaders(options.config),
-          'Content-Type': `multipart/form-data; boundary=${boundary}`,
-          'Content-Length': String(body.length),
-        },
-      });
+  for (let authIndex = 0; authIndex < authCandidates.length; authIndex++) {
+    const authHeaders = authCandidates[authIndex];
+    const maxAttempts = RETRY_DELAYS_MS.length + 1;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      totalAttempts += 1;
+      try {
+        const response = await axios.post(analyzeUrl, body, {
+          timeout: DEFAULT_TIMEOUT_MS,
+          maxBodyLength: Infinity,
+          maxContentLength: Infinity,
+          validateStatus: () => true,
+          headers: {
+            ...authHeaders,
+            'Content-Type': `multipart/form-data; boundary=${boundary}`,
+            'Content-Length': String(body.length),
+          },
+        });
 
-      if (response.status !== 200) {
-        const errorText = typeof response.data === 'string'
-          ? response.data
-          : JSON.stringify(response.data);
+        if (response.status !== 200) {
+          const errorText = typeof response.data === 'string'
+            ? response.data
+            : JSON.stringify(response.data);
 
-        if (attempt < maxAttempts && RETRYABLE_STATUS_CODES.has(response.status)) {
+          if ((response.status === 401 || response.status === 403) && authIndex + 1 < authCandidates.length) {
+            break;
+          }
+          if (attempt < maxAttempts && RETRYABLE_STATUS_CODES.has(response.status)) {
+            await sleep(RETRY_DELAYS_MS[attempt - 1]);
+            continue;
+          }
+
+          return {
+            ok: false,
+            status: response.status,
+            attempts: totalAttempts,
+            error: `Cats reader proxy returned ${response.status} after ${totalAttempts} attempt(s): ${errorText}`,
+          };
+        }
+
+        const payload = typeof response.data === 'string' ? JSON.parse(response.data) : response.data;
+        if (typeof payload?.analysis === 'string' && payload.analysis.trim()) {
+          return { ok: true, attempts: totalAttempts, analysis: payload.analysis.trim() };
+        }
+
+        return { ok: true, attempts: totalAttempts, analysis: JSON.stringify(payload, null, 2) };
+      } catch (error: any) {
+        const message = String(error?.message || error || 'Unknown reader proxy error');
+        if (attempt < maxAttempts && /timeout|ECONNRESET|ECONNABORTED|EAI_AGAIN|ENOTFOUND/i.test(message)) {
           await sleep(RETRY_DELAYS_MS[attempt - 1]);
           continue;
         }
 
         return {
           ok: false,
-          status: response.status,
-          attempts: attempt,
-          error: `Cats reader proxy returned ${response.status} after ${attempt} attempt(s): ${errorText}`,
+          attempts: totalAttempts,
+          error: message,
         };
       }
-
-      const payload = typeof response.data === 'string' ? JSON.parse(response.data) : response.data;
-      if (typeof payload?.analysis === 'string' && payload.analysis.trim()) {
-        return { ok: true, attempts: attempt, analysis: payload.analysis.trim() };
-      }
-
-      return { ok: true, attempts: attempt, analysis: JSON.stringify(payload, null, 2) };
-    } catch (error: any) {
-      const message = String(error?.message || error || 'Unknown reader proxy error');
-      if (attempt < maxAttempts && /timeout|ECONNRESET|ECONNABORTED|EAI_AGAIN|ENOTFOUND/i.test(message)) {
-        await sleep(RETRY_DELAYS_MS[attempt - 1]);
-        continue;
-      }
-
-      return {
-        ok: false,
-        attempts: attempt,
-        error: message,
-      };
     }
   }
 
   return {
     ok: false,
-    attempts: maxAttempts,
+    attempts: totalAttempts,
     error: 'Unknown reader proxy retry state',
   };
 }

--- a/src/utils/relay-model-profiles.ts
+++ b/src/utils/relay-model-profiles.ts
@@ -18,7 +18,7 @@ export const RELAY_MODEL_SDK_LABELS: Record<RelayModelProvider, string> = {
 
 export interface RelayModelCapabilities {
   toolCalling: boolean;
-  vision: boolean;
+  vision?: boolean;
   streaming: boolean;
 }
 
@@ -88,7 +88,6 @@ export const RELAY_MODEL_PROFILES: RelayModelProfile[] = [
     contextWindowTokens: 1_000_000,
     capabilities: {
       toolCalling: true,
-      vision: false,
       streaming: true,
     },
   })),

--- a/tests/bot-definition-activation.test.ts
+++ b/tests/bot-definition-activation.test.ts
@@ -73,6 +73,9 @@ describe('BotDefinition activation', () => {
       if (url.pathname === '/api/relay/key') {
         return Response.json({ key: { state: 'active', key: 'sk-bravo-relay-material' } });
       }
+      if (url.pathname === '/v1/models') {
+        return Response.json({ data: [{ id: 'MiniMax-M3', capabilities: { vision: true } }] });
+      }
       return Response.json({ error: 'unexpected request' }, { status: 500 });
     }) as typeof fetch;
 
@@ -96,6 +99,7 @@ describe('BotDefinition activation', () => {
       'GET /api/bot/model-config',
       'GET /api/relay/config',
       'GET /api/relay/key',
+      'GET /v1/models',
     ]);
   });
 
@@ -205,6 +209,11 @@ describe('BotDefinition activation', () => {
       if (url.pathname === '/api/relay/key') {
         return Response.json({ key: { state: 'active', key: 'sk-cloud-gpt56' } });
       }
+      if (url.pathname === '/v1/models') {
+        return Response.json({
+          data: [{ id: 'gpt-5.6-terra', capabilities: { vision: true, tool_calling: true, streaming: true } }],
+        });
+      }
       if (url.pathname === '/api/bot/model-config/ack') {
         ackBody = JSON.parse(String(init?.body));
         return Response.json({ status: 'applied' });
@@ -220,6 +229,8 @@ describe('BotDefinition activation', () => {
     assert.equal(runtime?.openaiApiMode, 'responses');
     assert.equal(runtime?.model, 'gpt-5.6-terra');
     assert.equal(runtime?.reasoningEffort, 'xhigh');
+    assert.equal(runtime?.capabilities?.vision, true);
+    assert.equal(runtime?.capabilitiesSource, 'relay-models');
     assert.deepStrictEqual(ackBody, {
       revision: 5,
       model_id: 'gpt-5.6-terra',

--- a/tests/catscompany-relay-model-bootstrap.test.ts
+++ b/tests/catscompany-relay-model-bootstrap.test.ts
@@ -1,6 +1,9 @@
 import { describe, test } from 'node:test';
 import * as assert from 'node:assert';
-import { provisionCatsRelayCatalogRuntime } from '../src/catscompany/relay-model-bootstrap';
+import {
+  provisionCatsRelayCatalogRuntime,
+  refreshCatsRelayCatalogRuntimeCapabilities,
+} from '../src/catscompany/relay-model-bootstrap';
 
 describe('CatsCo default relay model bootstrap', () => {
   test('materializes MiniMax M3 and creates a relay key for a fresh device', async () => {
@@ -20,6 +23,20 @@ describe('CatsCo default relay model bootstrap', () => {
       }
       if (url.pathname === '/api/relay/key' && init?.method === 'POST') {
         return Response.json({ key: { key: 'sk-fresh-device-relay-key' } });
+      }
+      if (url.pathname === '/v1/models') {
+        return Response.json({
+          object: 'list',
+          data: [{
+            id: 'MiniMax-M3',
+            capabilities: {
+              vision: true,
+              tool_calling: true,
+              streaming: true,
+              input_modalities: ['text', 'image'],
+            },
+          }],
+        });
       }
       return new Response(JSON.stringify({ error: 'unexpected request' }), { status: 500 });
     }) as typeof fetch;
@@ -43,10 +60,59 @@ describe('CatsCo default relay model bootstrap', () => {
     assert.equal(runtime.apiBase, 'https://relay.example.test/anthropic');
     assert.equal(runtime.contextWindowTokens, 1_000_000);
     assert.equal(runtime.apiKey, 'sk-fresh-device-relay-key');
+    assert.deepStrictEqual(runtime.capabilities, { vision: true, toolCalling: true, streaming: true });
+    assert.equal(runtime.capabilitiesSource, 'relay-models');
+    assert.ok(runtime.capabilitiesCheckedAt);
     assert.deepStrictEqual(requests, [
       { path: '/api/relay/config', method: 'GET' },
       { path: '/api/relay/key', method: 'GET' },
       { path: '/api/relay/key', method: 'POST' },
+      { path: '/v1/models', method: 'GET' },
     ]);
+  });
+
+  test('replaces stale GPT vision=false runtime metadata from the relay catalog', async () => {
+    const fetchImpl = (async () => Response.json({
+      data: [{
+        id: 'gpt-5.6-terra',
+        capabilities: { vision: true, tool_calling: true, streaming: true },
+      }],
+    })) as typeof fetch;
+
+    const runtime = await refreshCatsRelayCatalogRuntimeCapabilities({
+      schema: 'xiaoba.bot-catalog-model-runtime.v1',
+      botId: 'bot-1',
+      modelId: 'gpt-5.6-terra',
+      provider: 'openai',
+      apiBase: 'https://relay.example.test/v1',
+      apiKey: 'sk-relay-key',
+      model: 'gpt-5.6-terra',
+      contextWindowTokens: 1_000_000,
+      openaiApiMode: 'responses',
+      capabilities: { vision: false, toolCalling: true, streaming: true },
+    }, fetchImpl);
+
+    assert.equal(runtime.capabilities?.vision, true);
+    assert.equal(runtime.capabilitiesSource, 'relay-models');
+    assert.ok(runtime.capabilitiesCheckedAt);
+  });
+
+  test('drops legacy GPT vision=false even when relay metadata is temporarily unavailable', async () => {
+    const runtime = await refreshCatsRelayCatalogRuntimeCapabilities({
+      schema: 'xiaoba.bot-catalog-model-runtime.v1',
+      botId: 'bot-1',
+      modelId: 'gpt-5.6-terra',
+      provider: 'openai',
+      apiBase: 'https://relay.example.test/v1',
+      apiKey: 'sk-relay-key',
+      model: 'gpt-5.6-terra',
+      contextWindowTokens: 1_000_000,
+      openaiApiMode: 'responses',
+      capabilities: { vision: false, toolCalling: true, streaming: true },
+    }, (async () => new Response('temporarily unavailable', { status: 503 })) as typeof fetch);
+
+    assert.equal(runtime.capabilities?.vision, undefined);
+    assert.equal(runtime.capabilities?.toolCalling, true);
+    assert.equal(runtime.capabilitiesSource, 'static');
   });
 });

--- a/tests/model-capabilities.test.ts
+++ b/tests/model-capabilities.test.ts
@@ -62,9 +62,9 @@ describe('model capabilities', () => {
         { model: 'MiniMax-M2.7', provider: 'anthropic', vision: false, context: 204_800 },
         { model: 'MiniMax-M3', provider: 'anthropic', vision: true, context: 1_000_000 },
         { model: 'deepseek-v4-flash', provider: 'anthropic', vision: false, context: 1_000_000 },
-        { model: 'gpt-5.6-terra', provider: 'openai', vision: false, context: 1_000_000 },
-        { model: 'gpt-5.6-sol', provider: 'openai', vision: false, context: 1_000_000 },
-        { model: 'gpt-5.6-luna', provider: 'openai', vision: false, context: 1_000_000 },
+        { model: 'gpt-5.6-terra', provider: 'openai', vision: undefined, context: 1_000_000 },
+        { model: 'gpt-5.6-sol', provider: 'openai', vision: undefined, context: 1_000_000 },
+        { model: 'gpt-5.6-luna', provider: 'openai', vision: undefined, context: 1_000_000 },
       ],
     );
     assert.strictEqual(findRelayModelProfile('minimax-m3')?.capabilities.vision, true);

--- a/tests/model-vision-probe.test.ts
+++ b/tests/model-vision-probe.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { probeVisionCapability } from '../src/utils/model-vision-probe';
+
+describe('model vision capability probe', () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('probes OpenAI Responses once and reuses the persisted result', async () => {
+    const cachePath = createCachePath(roots);
+    let requests = 0;
+    const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+      requests += 1;
+      assert.equal(new URL(String(input)).pathname, '/v1/responses');
+      assert.equal(new Headers(init?.headers).get('Authorization'), 'Bearer sk-responses-secret');
+      const body = JSON.parse(String(init?.body));
+      assert.equal(body.model, 'future-multimodal-model');
+      assert.match(body.input[0].content[1].image_url, /^data:image\/png;base64,/);
+      return Response.json({ output_text: '731' });
+    }) as typeof fetch;
+    const config = {
+      provider: 'openai' as const,
+      openaiApiMode: 'responses' as const,
+      apiUrl: 'https://models.example.test/v1',
+      apiKey: 'sk-responses-secret',
+      model: 'future-multimodal-model',
+    };
+
+    assert.equal(await probeVisionCapability(config, { fetchImpl, cachePath, probeImageBase64: 'cHJvYmU=' }), 'supported');
+    assert.equal(await probeVisionCapability(config, { fetchImpl, cachePath, probeImageBase64: 'cHJvYmU=' }), 'supported');
+    assert.equal(requests, 1);
+    assert.equal(fs.readFileSync(cachePath, 'utf8').includes(config.apiKey), false);
+  });
+
+  test('generates its small probe image from the packaged PDF canvas dependency', async () => {
+    const cachePath = createCachePath(roots);
+    let encodedImage = '';
+    const fetchImpl = (async (_input: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body));
+      encodedImage = body.input[0].content[1].image_url;
+      return Response.json({ output_text: '731' });
+    }) as typeof fetch;
+
+    const state = await probeVisionCapability({
+      provider: 'openai',
+      openaiApiMode: 'responses',
+      apiUrl: 'https://models.example.test/v1',
+      apiKey: 'sk-generated-probe',
+      model: 'generated-probe-model',
+    }, { fetchImpl, cachePath });
+
+    assert.equal(state, 'supported');
+    assert.match(encodedImage, /^data:image\/png;base64,/);
+    assert.ok(encodedImage.length > 200);
+  });
+
+  test('only records unsupported when the endpoint explicitly rejects image input', async () => {
+    const cachePath = createCachePath(roots);
+    const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+      assert.equal(new URL(String(input)).pathname, '/v1/chat/completions');
+      const body = JSON.parse(String(init?.body));
+      assert.equal(body.messages[0].content[1].type, 'image_url');
+      return Response.json({ error: { message: 'This model does not support image input.' } }, { status: 400 });
+    }) as typeof fetch;
+
+    const state = await probeVisionCapability({
+      provider: 'openai',
+      openaiApiMode: 'chat_completions',
+      apiUrl: 'https://models.example.test/v1',
+      apiKey: 'sk-chat-secret',
+      model: 'text-only-custom',
+    }, { fetchImpl, cachePath, probeImageBase64: 'cHJvYmU=' });
+
+    assert.equal(state, 'unsupported');
+  });
+
+  test('keeps authentication and rate-limit failures unknown', async () => {
+    for (const status of [401, 429]) {
+      const cachePath = createCachePath(roots);
+      const apiKey = `sk-anthropic-${status}`;
+      const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+        assert.equal(new URL(String(input)).pathname, '/v1/messages');
+        assert.equal(new Headers(init?.headers).get('x-api-key'), apiKey);
+        const body = JSON.parse(String(init?.body));
+        assert.equal(body.messages[0].content[1].type, 'image');
+        return Response.json({ error: { message: status === 401 ? 'invalid key' : 'rate limited' } }, { status });
+      }) as typeof fetch;
+
+      const state = await probeVisionCapability({
+        provider: 'anthropic',
+        apiUrl: 'https://models.example.test/anthropic',
+        apiKey,
+        model: `custom-${status}`,
+      }, { fetchImpl, cachePath, probeImageBase64: 'cHJvYmU=' });
+
+      assert.equal(state, 'unknown');
+      assert.equal(fs.readFileSync(cachePath, 'utf8').includes(apiKey), false);
+    }
+  });
+
+  test('keeps a successful but inconclusive answer unknown', async () => {
+    const cachePath = createCachePath(roots);
+    const fetchImpl = (async () => Response.json({ choices: [{ message: { content: 'I cannot tell.' } }] })) as typeof fetch;
+    const state = await probeVisionCapability({
+      provider: 'openai',
+      apiUrl: 'https://models.example.test/v1',
+      apiKey: 'sk-inconclusive',
+      model: 'ambiguous-model',
+    }, { fetchImpl, cachePath, probeImageBase64: 'cHJvYmU=' });
+    assert.equal(state, 'unknown');
+  });
+});
+
+function createCachePath(roots: string[]): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-vision-probe-'));
+  roots.push(root);
+  return path.join(root, 'model-capability-cache.json');
+}

--- a/tests/reader-proxy-auth.test.ts
+++ b/tests/reader-proxy-auth.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as http from 'node:http';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { analyzeImageWithReaderProxy } from '../src/utils/reader-proxy';
+
+describe('reader proxy authentication', () => {
+  const originalEnv = { ...process.env };
+  const roots: string[] = [];
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('reuses the logged-in CatsCo account token without a separate reader key', async () => {
+    for (const key of [
+      'READER_PROXY_API_KEY',
+      'CATSCO_API_KEY',
+      'CATSCOMPANY_API_KEY',
+      'READER_PROXY_BEARER_TOKEN',
+      'CATSCO_BEARER_TOKEN',
+      'CATSCOMPANY_BEARER_TOKEN',
+      'CATSCOMPANY_USER_TOKEN',
+    ]) delete process.env[key];
+    process.env.CATSCO_USER_TOKEN = 'logged-in-user-token';
+
+    let authorization: string | undefined;
+    const server = http.createServer((req, res) => {
+      authorization = Array.isArray(req.headers.authorization)
+        ? req.headers.authorization.join(',')
+        : req.headers.authorization;
+      req.resume();
+      req.on('end', () => {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ analysis: 'reader-ok' }));
+      });
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', resolve);
+    });
+
+    try {
+      const address = server.address();
+      if (!address || typeof address === 'string') throw new Error('reader test server did not bind');
+      process.env.CATSCOMPANY_READER_API_URL = `http://127.0.0.1:${address.port}`;
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-reader-auth-'));
+      roots.push(root);
+      const filePath = path.join(root, 'probe.png');
+      fs.writeFileSync(filePath, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+
+      const result = await analyzeImageWithReaderProxy({ filePath });
+
+      assert.equal(result.ok, true);
+      assert.equal(result.analysis, 'reader-ok');
+      assert.equal(authorization, 'Bearer logged-in-user-token');
+    } finally {
+      await new Promise<void>(resolve => server.close(() => resolve()));
+    }
+  });
+
+  test('falls back from an expired bot key to the logged-in account token', async () => {
+    process.env.CATSCO_API_KEY = 'expired-bot-key';
+    process.env.CATSCO_USER_TOKEN = 'valid-user-token';
+    delete process.env.READER_PROXY_API_KEY;
+    delete process.env.CATSCOMPANY_API_KEY;
+    delete process.env.READER_PROXY_BEARER_TOKEN;
+    delete process.env.CATSCO_BEARER_TOKEN;
+    delete process.env.CATSCOMPANY_BEARER_TOKEN;
+    delete process.env.CATSCOMPANY_USER_TOKEN;
+
+    const observed: string[] = [];
+    const server = http.createServer((req, res) => {
+      observed.push(String(req.headers.authorization || ''));
+      req.resume();
+      req.on('end', () => {
+        if (req.headers.authorization === 'ApiKey expired-bot-key') {
+          res.writeHead(401, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'expired' }));
+          return;
+        }
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ analysis: 'account-fallback-ok' }));
+      });
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', resolve);
+    });
+
+    try {
+      const address = server.address();
+      if (!address || typeof address === 'string') throw new Error('reader test server did not bind');
+      process.env.CATSCOMPANY_READER_API_URL = `http://127.0.0.1:${address.port}`;
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-reader-auth-fallback-'));
+      roots.push(root);
+      const filePath = path.join(root, 'probe.png');
+      fs.writeFileSync(filePath, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+
+      const result = await analyzeImageWithReaderProxy({ filePath });
+
+      assert.equal(result.ok, true);
+      assert.equal(result.analysis, 'account-fallback-ok');
+      assert.equal(result.attempts, 2);
+      assert.deepStrictEqual(observed, ['ApiKey expired-bot-key', 'Bearer valid-user-token']);
+    } finally {
+      await new Promise<void>(resolve => server.close(() => resolve()));
+    }
+  });
+});

--- a/tests/tool-result-tool-manager.test.ts
+++ b/tests/tool-result-tool-manager.test.ts
@@ -138,7 +138,7 @@ describe('ToolManager - ToolExecutionResult 统一处理', () => {
 
       assert.strictEqual(result.ok, true);
       assert.ok(String(result.content).includes('当前主模型不能直接读取图片内容'));
-      assert.ok(String(result.content).includes('读图服务配置缺失'));
+      assert.ok(String(result.content).includes('当前 CatsCo 登录或机器人绑定没有提供有效认证'));
       assert.ok(String(result.content).includes('排查信息'));
       assert.strictEqual(result.errorCode, undefined);
     } finally {


### PR DESCRIPTION
## What changed

- Discover versioned model capability metadata from the CatsCo relay catalog.
- Probe and cache image support for custom or unknown models when metadata is unavailable.
- Reuse the current bot credential and logged-in CatsCo account token for reader requests, with auth fallback.
- Route image attachments, `read_file`, and PDF page images through the same tri-state capability resolver.

## Why

Vision support was maintained as static client metadata, so newly multimodal models could still be treated as text-only. Reader fallback could also fail when a separate reader API key was not configured even though the user was already logged in.

## Cloud model configuration

The portable BotDefinition and cloud model API payload are unchanged. Capability source/check timestamps, relay runtime credentials, and probe cache entries remain device-local. Existing cloud ACK tests continue to assert the unchanged request body.

## Validation

- `npm test`: 1147 tests, 1143 passed, 4 skipped, 0 failed
- `npm run build`
- `npm run release:check`
- Production uid 38 Responses image request and SSE stream succeeded through `relay.catsco.cc`
- Reader request succeeded with account Bearer auth and also after an intentionally invalid API-key candidate
- Browser smoke test: Dashboard loaded with all inspected APIs returning 200 and no console errors/warnings