### PR TITLE
feat(bot-definition): 增加 Skill 精确引用与字段级更新（PR1）

### DIFF
--- a/docs/bot-definition-local-simulation.md
+++ b/docs/bot-definition-local-simulation.md
@@ -1,6 +1,6 @@
 # BotDefinition 本地模拟与模型配置解耦
 
-这是 BotDefinition 的第一块落地实现，刻意保持很小：它当前只定义一个 CatsCo bot 选择了什么模型。Prompt 与 skill 快照仍待后续确定各自的版本契约后再加入。
+这是 BotDefinition 的第一块落地实现。它定义一个 CatsCo bot 选择了什么模型，以及这个 Bot 应恢复哪些确定版本的 Skill。Skill 文件本身仍由 SkillHub 保存，Definition 只保存 `skillId + version` 引用。
 
 ## 定义范围
 
@@ -11,7 +11,9 @@
 
 目录模型的 endpoint 与 relay key 不属于可迁移的 BotDefinition。它们是当前设备取得的运行时材料，单独保存；未来接入 CatsCompany Definition API 后，新设备会按 `modelId` 重新获取这份设备运行时材料。
 
-第一版不纳入显示名、设备身份、session、额度、工作目录、prompt 或 skill 数据。
+第一版不纳入显示名、设备身份、session、额度、工作目录、prompt 或 Skill 文件内容。
+
+`skills` 字段缺失表示老 Definition 尚未完成 Skill 迁移，空数组表示已经迁移且当前 Bot 明确没有 Skill。模型和 Skill 使用字段保留更新：修改模型不能清空 `skills`，修改 Skill 引用也不能覆盖 `model`。
 
 ## 本地文件接口
 

--- a/src/bot-definition/activation.ts
+++ b/src/bot-definition/activation.ts
@@ -10,7 +10,12 @@ import {
   createBotDefinitionSyncService,
   type BotDefinitionSyncServiceOptions,
 } from './service';
-import type { BotCatalogModelRuntime, BotDefinition, BotDefinitionSyncResult } from './types';
+import type {
+  BotCatalogModelRuntime,
+  BotCloudModelOverride,
+  BotDefinition,
+  BotDefinitionSyncResult,
+} from './types';
 import {
   acknowledgeCloudBotModelSelection,
   pullCloudBotModelSelection,
@@ -59,7 +64,7 @@ export async function prepareBoundBotDefinition(
   let localDefinition = sync?.definition;
   const previousCloudDefinition = definitionService.readCloudModelOverride(botId);
   const previousCloudRuntime = definitionService.readCloudCatalogRuntime(botId);
-  let definition = previousCloudDefinition ?? localDefinition;
+  let definition = applyCloudModelOverride(localDefinition, previousCloudDefinition);
   const auth = options.auth ?? createCatsCoLocalConfigService({ runtimeRoot: options.runtimeRoot }).getAuthState();
   let initializedDefault = false;
   let materializedCatalogRuntime = false;
@@ -176,7 +181,7 @@ export async function prepareBoundBotDefinition(
       try {
         if (previousCloudDefinition) {
           definitionService.acceptCloud(botId, previousCloudDefinition.model);
-          definition = previousCloudDefinition;
+          definition = applyCloudModelOverride(localDefinition, previousCloudDefinition);
         } else {
           definitionService.clearCloudModelOverride(botId);
           definition = localDefinition;
@@ -215,7 +220,7 @@ export async function prepareBoundBotDefinition(
       modelId: selectedCatalogRuntime.modelId,
     });
     localDefinition = sync.definition;
-    definition = definitionService.readCloudModelOverride(botId) ?? sync.definition;
+    definition = applyCloudModelOverride(sync.definition, definitionService.readCloudModelOverride(botId));
     materializedCatalogRuntime = true;
   }
 
@@ -237,7 +242,7 @@ export async function prepareBoundBotDefinition(
   }
 
   const activeCloudOverride = definitionService.readCloudModelOverride(botId);
-  if (activeCloudOverride) definition = activeCloudOverride;
+  if (activeCloudOverride) definition = applyCloudModelOverride(localDefinition ?? definition, activeCloudOverride)!;
   if (definition.model.kind === 'catalog') {
     const runtime = activeCloudOverride
       ? definitionService.readCloudCatalogRuntime(botId)
@@ -272,6 +277,16 @@ export async function prepareBoundBotDefinition(
     ...(cloudApplyError ? { cloudApplyError } : {}),
     ...(cloudSelectionApplied && cloudSelection ? { cloudRevision: cloudSelection.revision } : {}),
   };
+}
+
+function applyCloudModelOverride(
+  localDefinition: BotDefinition | undefined,
+  override: BotCloudModelOverride | undefined,
+): BotDefinition | undefined {
+  if (!override) return localDefinition;
+  return localDefinition
+    ? { ...localDefinition, model: override.model }
+    : override;
 }
 
 function catalogCapabilitiesNeedRefresh(runtime: BotCatalogModelRuntime): boolean {

--- a/src/bot-definition/repository.ts
+++ b/src/bot-definition/repository.ts
@@ -5,21 +5,29 @@ import {
   BOT_CATALOG_MODEL_RUNTIME_SCHEMA,
   BOT_CUSTOM_MODEL_PROFILE_SCHEMA,
   type BotCatalogModelRuntime,
+  type BotCloudModelOverride,
   type BotCustomModelProfile,
   type BotDefinition,
+  type BotSkillRef,
   type CustomBotModelDefinition,
 } from './types';
 
 export interface BotDefinitionRepository {
+  inspectCanonical(botId: string): BotDefinitionReadResult;
   readCanonical(botId: string): BotDefinition | undefined;
   writeCanonical(definition: BotDefinition): void;
   readCache(botId: string): BotDefinition | undefined;
   writeCache(definition: BotDefinition): void;
 }
 
+export type BotDefinitionReadResult =
+  | { status: 'missing' }
+  | { status: 'invalid' }
+  | { status: 'valid'; definition: BotDefinition };
+
 export interface BotCloudModelOverrideRepository {
-  read(botId: string): BotDefinition | undefined;
-  write(definition: BotDefinition): void;
+  read(botId: string): BotCloudModelOverride | undefined;
+  write(definition: BotCloudModelOverride): void;
   delete(botId: string): void;
 }
 
@@ -61,11 +69,27 @@ function isValidDefinition(definition: unknown, expectedBotId: string): definiti
   if (!value || value.schema !== 'xiaoba.bot-definition.v1' || value.botId !== expectedBotId || !value.model) {
     return false;
   }
+  if (value.skills !== undefined && !isValidSkillRefs(value.skills)) return false;
   if (value.model.kind === 'catalog') {
     return Boolean(String(value.model.modelId || '').trim());
   }
   if (value.model.kind !== 'custom') return false;
   return isValidCustomModel(value.model);
+}
+
+function isValidSkillRefs(skills: unknown): skills is BotSkillRef[] {
+  if (!Array.isArray(skills)) return false;
+  const versionsBySkillId = new Map<string, string>();
+  for (const entry of skills) {
+    const value = entry as Partial<BotSkillRef> | null;
+    const skillId = typeof value?.skillId === 'string' ? value.skillId.trim() : '';
+    const version = typeof value?.version === 'string' ? value.version.trim() : '';
+    if (!skillId || !version) return false;
+    const previousVersion = versionsBySkillId.get(skillId);
+    if (previousVersion && previousVersion !== version) return false;
+    versionsBySkillId.set(skillId, version);
+  }
+  return true;
 }
 
 function isValidCustomModel(model: unknown): model is CustomBotModelDefinition {
@@ -107,14 +131,21 @@ function isValidCustomModelProfile(profile: unknown, expectedBotId: string): pro
   );
 }
 
-function readDefinition(filePath: string, expectedBotId: string): BotDefinition | undefined {
-  if (!fs.existsSync(filePath)) return undefined;
+function inspectDefinition(filePath: string, expectedBotId: string): BotDefinitionReadResult {
+  if (!fs.existsSync(filePath)) return { status: 'missing' };
   try {
     const parsed = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as BotDefinition;
-    return isValidDefinition(parsed, expectedBotId) ? parsed : undefined;
+    return isValidDefinition(parsed, expectedBotId)
+      ? { status: 'valid', definition: parsed }
+      : { status: 'invalid' };
   } catch {
-    return undefined;
+    return { status: 'invalid' };
   }
+}
+
+function readDefinition(filePath: string, expectedBotId: string): BotDefinition | undefined {
+  const result = inspectDefinition(filePath, expectedBotId);
+  return result.status === 'valid' ? result.definition : undefined;
 }
 
 function writeDefinition(filePath: string, definition: BotDefinition): void {
@@ -193,14 +224,19 @@ export class FileBotDefinitionRepository implements BotDefinitionRepository {
     );
   }
 
-  readCanonical(botId: string): BotDefinition | undefined {
+  inspectCanonical(botId: string): BotDefinitionReadResult {
     const normalized = normalizeBotId(botId);
-    return readDefinition(this.definitionPath(this.canonicalRoot, normalized), normalized);
+    return inspectDefinition(this.definitionPath(this.canonicalRoot, normalized), normalized);
+  }
+
+  readCanonical(botId: string): BotDefinition | undefined {
+    const result = this.inspectCanonical(botId);
+    return result.status === 'valid' ? result.definition : undefined;
   }
 
   writeCanonical(definition: BotDefinition): void {
     const botId = normalizeBotId(definition.botId);
-    writeDefinition(this.definitionPath(this.canonicalRoot, botId), definition);
+    writeDefinition(this.definitionPath(this.canonicalRoot, botId), { ...definition, botId });
   }
 
   readCache(botId: string): BotDefinition | undefined {
@@ -210,7 +246,7 @@ export class FileBotDefinitionRepository implements BotDefinitionRepository {
 
   writeCache(definition: BotDefinition): void {
     const botId = normalizeBotId(definition.botId);
-    writeDefinition(this.definitionPath(this.cacheRoot, botId), definition);
+    writeDefinition(this.definitionPath(this.cacheRoot, botId), { ...definition, botId });
   }
 
   getCanonicalPath(botId: string): string {
@@ -237,14 +273,23 @@ export class FileBotCloudModelOverrideRepository implements BotCloudModelOverrid
     );
   }
 
-  read(botId: string): BotDefinition | undefined {
+  read(botId: string): BotCloudModelOverride | undefined {
     const normalized = normalizeBotId(botId);
-    return readDefinition(this.overridePath(normalized), normalized);
+    const definition = readDefinition(this.overridePath(normalized), normalized);
+    return definition && {
+      schema: definition.schema,
+      botId: definition.botId,
+      model: definition.model,
+    };
   }
 
-  write(definition: BotDefinition): void {
+  write(definition: BotCloudModelOverride): void {
     const botId = normalizeBotId(definition.botId);
-    writeDefinition(this.overridePath(botId), definition);
+    writeDefinition(this.overridePath(botId), {
+      schema: definition.schema,
+      botId,
+      model: definition.model,
+    });
   }
 
   delete(botId: string): void {

--- a/src/bot-definition/service.ts
+++ b/src/bot-definition/service.ts
@@ -15,9 +15,12 @@ import {
   BOT_CUSTOM_MODEL_PROFILE_SCHEMA,
   BOT_DEFINITION_SCHEMA,
   type BotCatalogModelRuntime,
+  type BotCloudModelOverride,
   type BotDefinition,
+  type BotDefinitionPatch,
   type BotDefinitionSyncResult,
   type BotModelDefinition,
+  type BotSkillRef,
   type CustomBotModelDefinition,
   type LocalModelProfile,
 } from './types';
@@ -297,9 +300,38 @@ function normalizeBotModelDefinition(model: BotModelDefinition): BotModelDefinit
   return modelId && modelId !== model.modelId ? { ...model, modelId } : model;
 }
 
-function normalizeBotDefinition(definition: BotDefinition): BotDefinition {
+export function normalizeBotSkillRefs(skills: readonly BotSkillRef[]): BotSkillRef[] {
+  if (!Array.isArray(skills)) {
+    throw new Error('BotDefinition skills must be an array');
+  }
+  const normalized = skills.map(entry => ({
+    skillId: typeof entry?.skillId === 'string' ? entry.skillId.trim() : '',
+    version: typeof entry?.version === 'string' ? entry.version.trim() : '',
+  }));
+  const versionsBySkillId = new Map<string, string>();
+  for (const entry of normalized) {
+    if (!entry.skillId || !entry.version) {
+      throw new Error('BotDefinition Skill references require a non-empty skillId and version');
+    }
+    const previousVersion = versionsBySkillId.get(entry.skillId);
+    if (previousVersion && previousVersion !== entry.version) {
+      throw new Error(`BotDefinition cannot reference multiple versions of Skill ${entry.skillId}`);
+    }
+    versionsBySkillId.set(entry.skillId, entry.version);
+  }
+  return Array.from(versionsBySkillId, ([skillId, version]) => ({ skillId, version }))
+    .sort((left, right) => left.skillId < right.skillId ? -1 : left.skillId > right.skillId ? 1 : 0);
+}
+
+export function normalizeBotDefinition(definition: BotDefinition): BotDefinition {
   const model = normalizeBotModelDefinition(definition.model);
-  return model === definition.model ? definition : { ...definition, model };
+  const skills = definition.skills === undefined
+    ? undefined
+    : normalizeBotSkillRefs(definition.skills);
+  const skillsChanged = skills !== undefined && JSON.stringify(skills) !== JSON.stringify(definition.skills);
+  return model === definition.model && !skillsChanged
+    ? definition
+    : { ...definition, model, ...(skills === undefined ? {} : { skills }) };
 }
 
 function normalizeCatalogRuntime(runtime: BotCatalogModelRuntime): BotCatalogModelRuntime {
@@ -381,13 +413,21 @@ export class BotDefinitionSyncService {
 
   pull(botId: string): BotDefinition | undefined {
     const previousCache = this.repository.readCache(botId);
-    const rawDefinition = this.repository.readCanonical(botId);
+    const canonical = this.repository.inspectCanonical(botId);
+    if (canonical.status === 'invalid' && !previousCache) {
+      throw new Error(`BotDefinition canonical record is invalid for bot ${botId}; refusing to overwrite it`);
+    }
+    const usingCacheFallback = canonical.status === 'invalid';
+    const rawDefinition = canonical.status === 'valid'
+      ? canonical.definition
+      : usingCacheFallback
+        ? previousCache
+        : undefined;
     const definition = rawDefinition && normalizeBotDefinition(rawDefinition);
     if (definition) {
       if (previousCache?.model.kind === 'custom') {
         this.storeCustomModelProfile(botId, previousCache.model);
       }
-      if (definition !== rawDefinition) this.repository.writeCanonical(definition);
       this.repository.writeCache(definition);
       if (definition.model.kind === 'custom') {
         this.storeCustomModelProfile(definition.botId, definition.model);
@@ -396,20 +436,37 @@ export class BotDefinitionSyncService {
     return definition;
   }
 
-  publish(botId: string, model: BotModelDefinition): BotDefinitionSyncResult {
-    const previous = this.repository.readCache(botId) ?? this.repository.readCanonical(botId);
-    if (previous?.model.kind === 'custom') {
-      this.storeCustomModelProfile(botId, previous.model);
+  updateDefinition(botId: string, patch: BotDefinitionPatch): BotDefinitionSyncResult {
+    const canonical = this.repository.inspectCanonical(botId);
+    if (canonical.status === 'invalid') {
+      throw new Error(`BotDefinition canonical record is invalid for bot ${botId}; refusing to overwrite it`);
     }
-    const normalizedModel = normalizeBotModelDefinition(model);
+    const canonicalDefinition = canonical.status === 'valid' ? canonical.definition : undefined;
+    const cachedDefinition = this.repository.readCache(botId);
+    const previous = canonicalDefinition ?? cachedDefinition;
+    if (!previous && !patch.model) {
+      throw new Error('Cannot update BotDefinition skills before its model has been initialized');
+    }
+    if (cachedDefinition?.model.kind === 'custom') {
+      this.storeCustomModelProfile(botId, cachedDefinition.model);
+    }
+    const previousModel = previous?.model;
+    if (previousModel?.kind === 'custom' && previousModel !== cachedDefinition?.model) {
+      this.storeCustomModelProfile(botId, previousModel);
+    }
+    const normalizedModel = patch.model
+      ? normalizeBotModelDefinition(patch.model)
+      : previousModel!;
     if (normalizedModel.kind === 'custom') {
       this.storeCustomModelProfile(botId, normalizedModel);
     }
-    const definition: BotDefinition = {
+    const definition = normalizeBotDefinition({
+      ...(previous ?? {}),
       schema: BOT_DEFINITION_SCHEMA,
       botId,
       model: normalizedModel,
-    };
+      ...(patch.skills === undefined ? {} : { skills: patch.skills }),
+    });
     this.repository.writeCanonical(definition);
     this.repository.writeCache(definition);
     this.clearLegacyModelConfigurationWhenReady(definition);
@@ -420,13 +477,30 @@ export class BotDefinitionSyncService {
     };
   }
 
+  updateModel(botId: string, model: BotModelDefinition): BotDefinitionSyncResult {
+    return this.updateDefinition(botId, { model });
+  }
+
+  updateSkills(botId: string, skills: BotSkillRef[]): BotDefinitionSyncResult {
+    return this.updateDefinition(botId, { skills });
+  }
+
+  /** Compatibility alias for callers not yet converted to field-level updates. */
+  publish(botId: string, model: BotModelDefinition): BotDefinitionSyncResult {
+    return this.updateModel(botId, model);
+  }
+
   acceptCloud(botId: string, model: BotModelDefinition): BotDefinitionSyncResult {
-    const definition: BotDefinition = {
+    const override: BotCloudModelOverride = {
       schema: BOT_DEFINITION_SCHEMA,
       botId,
       model: normalizeBotModelDefinition(model),
     };
-    this.cloudOverrideRepository.write(definition);
+    this.cloudOverrideRepository.write(override);
+    const localDefinition = this.repository.readCache(botId) ?? this.repository.readCanonical(botId);
+    const definition: BotDefinition = localDefinition
+      ? { ...localDefinition, model: override.model }
+      : override;
     return {
       botId,
       direction: 'cloud_to_local',
@@ -434,10 +508,11 @@ export class BotDefinitionSyncService {
     };
   }
 
-  readCloudModelOverride(botId: string): BotDefinition | undefined {
+  readCloudModelOverride(botId: string): BotCloudModelOverride | undefined {
     const raw = this.cloudOverrideRepository.read(botId);
     if (!raw) return undefined;
-    const normalized = normalizeBotDefinition(raw);
+    const model = normalizeBotModelDefinition(raw.model);
+    const normalized = model === raw.model ? raw : { ...raw, model };
     if (normalized !== raw) this.cloudOverrideRepository.write(normalized);
     return normalized;
   }

--- a/src/bot-definition/types.ts
+++ b/src/bot-definition/types.ts
@@ -32,15 +32,35 @@ export interface CustomBotModelDefinition {
 
 export type BotModelDefinition = CatalogBotModelDefinition | CustomBotModelDefinition;
 
+/** A portable, exact SkillHub package reference owned by one bot definition. */
+export interface BotSkillRef {
+  skillId: string;
+  version: string;
+}
+
 /**
- * The deliberately small, portable part of a bot. Prompt and skill fields are
- * intentionally deferred until their source/version contracts are settled.
+ * The deliberately small, portable part of a bot. Skill contents remain in
+ * SkillHub; the definition stores only exact, restorable package references.
  */
 export interface BotDefinition {
   schema: typeof BOT_DEFINITION_SCHEMA;
   botId: string;
   model: BotModelDefinition;
+  /** Missing means a legacy definition that has not completed Skill migration. */
+  skills?: BotSkillRef[];
 }
+
+/**
+ * Field-level definition update. Omitted fields are preserved; an empty skills
+ * array explicitly means that the bot has no Skills.
+ */
+export interface BotDefinitionPatch {
+  model?: BotModelDefinition;
+  skills?: BotSkillRef[];
+}
+
+/** Device-local model selection layered over the portable local definition. */
+export type BotCloudModelOverride = Pick<BotDefinition, 'schema' | 'botId' | 'model'>;
 
 export interface LocalModelProfile {
   source: 'catalog' | 'custom';

--- a/tests/bot-definition-activation.test.ts
+++ b/tests/bot-definition-activation.test.ts
@@ -14,7 +14,7 @@ import {
   FileBotDefinitionRepository,
 } from '../src/bot-definition/repository';
 import { resolveActiveBotLLMConfig } from '../src/bot-definition/llm-config-resolver';
-import { BOT_DEFINITION_SCHEMA } from '../src/bot-definition/types';
+import { BOT_DEFINITION_SCHEMA, type BotDefinition } from '../src/bot-definition/types';
 
 describe('BotDefinition activation', () => {
   const roots: string[] = [];
@@ -532,7 +532,12 @@ describe('BotDefinition activation', () => {
       apiKey: 'sk-local-model',
       contextWindowTokens: 128_000,
     };
-    const localDefinition = { schema: BOT_DEFINITION_SCHEMA, botId: '43', model: localModel } as const;
+    const localDefinition: BotDefinition = {
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: '43',
+      model: localModel,
+      skills: [{ skillId: 'alice/browser', version: '1.0.3' }],
+    };
     const definitions = new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot });
     definitions.writeCanonical(localDefinition);
 
@@ -557,6 +562,7 @@ describe('BotDefinition activation', () => {
     });
 
     assert.equal(cloudPrepared?.cloudRevision, 11);
+    assert.deepStrictEqual(cloudPrepared?.definition.skills, localDefinition.skills);
     assert.equal(resolveActiveBotLLMConfig({ runtimeRoot, env })?.config.model, 'cloud-model');
     assert.deepStrictEqual(definitions.readCanonical('43'), localDefinition);
     assert.deepStrictEqual(definitions.readCache('43'), localDefinition);
@@ -571,6 +577,7 @@ describe('BotDefinition activation', () => {
       acknowledgeCloudSelection: false,
     });
     assert.equal(restartPrepared?.definition.model.kind, 'custom');
+    assert.deepStrictEqual(restartPrepared?.definition.skills, localDefinition.skills);
     assert.equal(resolveActiveBotLLMConfig({ runtimeRoot, env })?.config.model, 'cloud-model');
 
     const localPrepared = await prepareBoundBotDefinition({
@@ -581,6 +588,7 @@ describe('BotDefinition activation', () => {
       acknowledgeCloudSelection: false,
     });
     assert.equal(localPrepared?.cloudRevision, 12);
+    assert.deepStrictEqual(localPrepared?.definition.skills, localDefinition.skills);
     assert.equal(resolveActiveBotLLMConfig({ runtimeRoot, env })?.config.model, 'local-model');
     assert.equal(new FileBotCloudModelOverrideRepository({ runtimeRoot }).read('43'), undefined);
     assert.deepStrictEqual(definitions.readCanonical('43'), localDefinition);

--- a/tests/bot-definition-skills.test.ts
+++ b/tests/bot-definition-skills.test.ts
@@ -1,0 +1,433 @@
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import { FileBotDefinitionRepository } from '../src/bot-definition/repository';
+import {
+  createBotDefinitionSyncService,
+  normalizeBotSkillRefs,
+} from '../src/bot-definition/service';
+import { BOT_DEFINITION_SCHEMA } from '../src/bot-definition/types';
+
+describe('BotDefinition Skill contract', () => {
+  let runtimeRoot: string;
+  let simulatedCloudRoot: string;
+
+  beforeEach(() => {
+    runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-bot-skills-definition-'));
+    simulatedCloudRoot = path.join(runtimeRoot, 'cloud');
+  });
+
+  afterEach(() => {
+    fs.rmSync(runtimeRoot, { recursive: true, force: true });
+  });
+
+  test('distinguishes a legacy missing skills field from an explicit empty list', () => {
+    const repository = new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot });
+    repository.writeCanonical({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-alpha',
+      model: { kind: 'catalog', modelId: 'model-a' },
+    });
+    repository.writeCache({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-beta',
+      model: { kind: 'catalog', modelId: 'model-b' },
+      skills: [],
+    });
+
+    assert.equal(repository.readCanonical('bot-alpha')?.skills, undefined);
+    assert.deepStrictEqual(repository.readCache('bot-beta')?.skills, []);
+  });
+
+  test('normalizes exact Skill references with stable ordering and duplicate removal', () => {
+    assert.deepStrictEqual(normalizeBotSkillRefs([
+      { skillId: ' zed/weather ', version: ' 2.0.0 ' },
+      { skillId: 'alice/browser', version: '1.0.3' },
+      { skillId: 'alice/browser', version: '1.0.3' },
+      { skillId: '中/skill', version: '1.0.0' },
+    ]), [
+      { skillId: 'alice/browser', version: '1.0.3' },
+      { skillId: 'zed/weather', version: '2.0.0' },
+      { skillId: '中/skill', version: '1.0.0' },
+    ]);
+    assert.throws(
+      () => normalizeBotSkillRefs([
+        { skillId: 'alice/browser', version: '1.0.3' },
+        { skillId: 'alice/browser', version: '2.0.0' },
+      ]),
+      /multiple versions/,
+    );
+    assert.throws(
+      () => normalizeBotSkillRefs([{ skillId: 123, version: {} }] as unknown as Array<{ skillId: string; version: string }>),
+      /non-empty skillId and version/,
+    );
+    assert.throws(
+      () => normalizeBotSkillRefs('not-an-array' as unknown as Array<{ skillId: string; version: string }>),
+      /must be an array/,
+    );
+  });
+
+  test('normalizes botId consistently in the file path and persisted Definition', () => {
+    const repository = new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot });
+    repository.writeCanonical({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: ' bot-alpha ',
+      model: { kind: 'catalog', modelId: 'model-a' },
+    });
+
+    assert.deepStrictEqual(repository.readCanonical('bot-alpha'), {
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-alpha',
+      model: { kind: 'catalog', modelId: 'model-a' },
+    });
+  });
+
+  test('rejects malformed Skill references in persisted definitions', () => {
+    const repository = new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot });
+    const canonicalPath = repository.getCanonicalPath('bot-alpha');
+    fs.mkdirSync(path.dirname(canonicalPath), { recursive: true });
+    fs.writeFileSync(canonicalPath, JSON.stringify({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-alpha',
+      model: { kind: 'catalog', modelId: 'model-a' },
+      skills: [{ skillId: 'alice/browser', version: '' }],
+    }));
+
+    assert.equal(repository.readCanonical('bot-alpha'), undefined);
+
+    fs.writeFileSync(canonicalPath, JSON.stringify({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-alpha',
+      model: { kind: 'catalog', modelId: 'model-a' },
+      skills: 'not-an-array',
+    }));
+    assert.equal(repository.readCanonical('bot-alpha'), undefined);
+
+    fs.writeFileSync(canonicalPath, JSON.stringify({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-alpha',
+      model: { kind: 'catalog', modelId: 'model-a' },
+      skills: [
+        { skillId: 'alice/browser', version: '1.0.3' },
+        { skillId: 'alice/browser', version: '2.0.0' },
+      ],
+    }));
+    assert.equal(repository.readCanonical('bot-alpha'), undefined);
+  });
+
+  test('normalizes harmless duplicate references into cache without mutating canonical on pull', () => {
+    const repository = new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot });
+    const canonicalPath = repository.getCanonicalPath('bot-alpha');
+    fs.mkdirSync(path.dirname(canonicalPath), { recursive: true });
+    fs.writeFileSync(canonicalPath, JSON.stringify({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-alpha',
+      model: { kind: 'catalog', modelId: 'model-a' },
+      skills: [
+        { skillId: 'alice/browser', version: '1.0.3' },
+        { skillId: 'alice/browser', version: '1.0.3' },
+      ],
+    }));
+    const service = createBotDefinitionSyncService({ runtimeRoot, simulatedCloudRoot, repository });
+
+    const definition = service.pull('bot-alpha');
+
+    assert.deepStrictEqual(definition?.skills, [
+      { skillId: 'alice/browser', version: '1.0.3' },
+    ]);
+    assert.equal(repository.readCanonical('bot-alpha')?.skills?.length, 2);
+    assert.deepStrictEqual(repository.readCache('bot-alpha'), definition);
+  });
+
+  test('never bootstraps over an invalid canonical Definition', () => {
+    const repository = new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot });
+    const canonicalPath = repository.getCanonicalPath('bot-alpha');
+    const original = JSON.stringify({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-alpha',
+      model: { kind: 'catalog', modelId: 'model-a' },
+      skills: [{ skillId: 'alice/browser', version: '' }],
+    });
+    fs.mkdirSync(path.dirname(canonicalPath), { recursive: true });
+    fs.writeFileSync(canonicalPath, original);
+    const service = createBotDefinitionSyncService({
+      runtimeRoot,
+      simulatedCloudRoot,
+      repository,
+      env: {
+        CATSCO_MODEL_SOURCE: 'relay',
+        CATSCO_RELAY_LLM_MODEL: 'gpt-5.6-terra',
+      },
+    });
+
+    assert.throws(
+      () => service.pullOrBootstrap('bot-alpha'),
+      /canonical record is invalid.*refusing to overwrite/,
+    );
+    assert.equal(fs.readFileSync(canonicalPath, 'utf-8'), original);
+  });
+
+  test('uses a valid local cache when canonical is invalid without overwriting canonical', () => {
+    const repository = new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot });
+    repository.writeCache({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-alpha',
+      model: { kind: 'catalog', modelId: 'local-model' },
+      skills: [{ skillId: 'local/current', version: '2.0.0' }],
+    });
+    const canonicalPath = repository.getCanonicalPath('bot-alpha');
+    const original = '{"schema":"xiaoba.bot-definition.v1","broken":true}';
+    fs.mkdirSync(path.dirname(canonicalPath), { recursive: true });
+    fs.writeFileSync(canonicalPath, original);
+    const service = createBotDefinitionSyncService({ runtimeRoot, simulatedCloudRoot, repository });
+
+    const result = service.pullOrBootstrap('bot-alpha');
+
+    assert.deepStrictEqual(result?.definition, repository.readCache('bot-alpha'));
+    assert.deepStrictEqual(result?.definition.skills, [
+      { skillId: 'local/current', version: '2.0.0' },
+    ]);
+    assert.equal(fs.readFileSync(canonicalPath, 'utf-8'), original);
+  });
+
+  test('rejects updates over invalid canonical while preserving the local cache', () => {
+    const repository = new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot });
+    const localDefinition = {
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-alpha',
+      model: { kind: 'catalog' as const, modelId: 'local-model' },
+      skills: [{ skillId: 'local/current', version: '2.0.0' }],
+    };
+    repository.writeCache(localDefinition);
+    const canonicalPath = repository.getCanonicalPath('bot-alpha');
+    const original = '{"schema":"xiaoba.bot-definition.v1","broken":true}';
+    fs.mkdirSync(path.dirname(canonicalPath), { recursive: true });
+    fs.writeFileSync(canonicalPath, original);
+    const service = createBotDefinitionSyncService({ runtimeRoot, simulatedCloudRoot, repository });
+
+    assert.throws(
+      () => service.updateModel('bot-alpha', { kind: 'catalog', modelId: 'new-model' }),
+      /canonical record is invalid.*refusing to overwrite/,
+    );
+    assert.deepStrictEqual(repository.readCache('bot-alpha'), localDefinition);
+    assert.equal(fs.readFileSync(canonicalPath, 'utf-8'), original);
+  });
+
+  test('updating a legacy model does not mark Skill migration complete', () => {
+    const repository = new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot });
+    repository.writeCache({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-alpha',
+      model: { kind: 'catalog', modelId: 'old-model' },
+    });
+    const service = createBotDefinitionSyncService({ runtimeRoot, simulatedCloudRoot, repository });
+
+    const result = service.updateModel('bot-alpha', { kind: 'catalog', modelId: 'new-model' });
+
+    assert.equal(Object.prototype.hasOwnProperty.call(result.definition, 'skills'), false);
+  });
+
+  test('updating the model preserves Skill references', () => {
+    const repository = new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot });
+    repository.writeCache({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-alpha',
+      model: { kind: 'catalog', modelId: 'old-model' },
+      skills: [{ skillId: 'alice/browser', version: '1.0.3' }],
+    });
+    const service = createBotDefinitionSyncService({ runtimeRoot, simulatedCloudRoot, repository });
+
+    const result = service.updateModel('bot-alpha', { kind: 'catalog', modelId: 'new-model' });
+
+    assert.deepStrictEqual(result.definition.skills, [
+      { skillId: 'alice/browser', version: '1.0.3' },
+    ]);
+    assert.deepStrictEqual(repository.readCanonical('bot-alpha'), result.definition);
+    assert.deepStrictEqual(repository.readCache('bot-alpha'), result.definition);
+  });
+
+  test('updating the model preserves canonical Skill state over stale cache state', () => {
+    const repository = new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot });
+    repository.writeCanonical({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-alpha',
+      model: { kind: 'catalog', modelId: 'canonical-model' },
+      skills: [{ skillId: 'cloud/old', version: '1.0.0' }],
+    });
+    repository.writeCache({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-alpha',
+      model: { kind: 'catalog', modelId: 'local-model' },
+      skills: [{ skillId: 'local/current', version: '2.0.0' }],
+    });
+    const service = createBotDefinitionSyncService({ runtimeRoot, simulatedCloudRoot, repository });
+
+    const result = service.updateModel('bot-alpha', { kind: 'catalog', modelId: 'new-model' });
+
+    assert.deepStrictEqual(result.definition.skills, [
+      { skillId: 'cloud/old', version: '1.0.0' },
+    ]);
+  });
+
+  test('updating the model inherits canonical Skills when a legacy cache has no Skills field', () => {
+    const repository = new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot });
+    repository.writeCanonical({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-alpha',
+      model: { kind: 'catalog', modelId: 'canonical-model' },
+      skills: [{ skillId: 'cloud/current', version: '2.0.0' }],
+    });
+    repository.writeCache({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-alpha',
+      model: { kind: 'catalog', modelId: 'legacy-cache-model' },
+    });
+    const service = createBotDefinitionSyncService({ runtimeRoot, simulatedCloudRoot, repository });
+
+    const result = service.updateModel('bot-alpha', { kind: 'catalog', modelId: 'new-model' });
+
+    assert.deepStrictEqual(result.definition.skills, [
+      { skillId: 'cloud/current', version: '2.0.0' },
+    ]);
+  });
+
+  test('updating the model falls back to canonical Skill references when cache is missing', () => {
+    const repository = new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot });
+    repository.writeCanonical({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-alpha',
+      model: { kind: 'catalog', modelId: 'old-model' },
+      skills: [{ skillId: 'alice/browser', version: '1.0.3' }],
+    });
+    const service = createBotDefinitionSyncService({ runtimeRoot, simulatedCloudRoot, repository });
+
+    const result = service.publish('bot-alpha', { kind: 'catalog', modelId: 'new-model' });
+
+    assert.deepStrictEqual(result.definition.skills, [
+      { skillId: 'alice/browser', version: '1.0.3' },
+    ]);
+  });
+
+  test('updating Skill references preserves the model and normalizes the list', () => {
+    const repository = new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot });
+    repository.writeCanonical({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-alpha',
+      model: { kind: 'catalog', modelId: 'model-a', reasoningEffort: 'high' },
+    });
+    const service = createBotDefinitionSyncService({ runtimeRoot, simulatedCloudRoot, repository });
+
+    const result = service.updateSkills('bot-alpha', [
+      { skillId: 'zed/weather', version: '2.0.0' },
+      { skillId: 'alice/browser', version: '1.0.3' },
+    ]);
+
+    assert.deepStrictEqual(result.definition.model, {
+      kind: 'catalog',
+      modelId: 'model-a',
+      reasoningEffort: 'high',
+    });
+    assert.deepStrictEqual(result.definition.skills, [
+      { skillId: 'alice/browser', version: '1.0.3' },
+      { skillId: 'zed/weather', version: '2.0.0' },
+    ]);
+  });
+
+  test('updating Skill references preserves a complete custom model', () => {
+    const repository = new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot });
+    const customModel = {
+      kind: 'custom' as const,
+      protocol: 'openai-responses' as const,
+      apiBase: 'https://models.example.test/v1',
+      model: 'custom-model',
+      apiKey: 'sk-custom',
+      contextWindowTokens: 200_000,
+      reasoningEffort: 'high' as const,
+    };
+    repository.writeCache({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-alpha',
+      model: customModel,
+    });
+    const service = createBotDefinitionSyncService({ runtimeRoot, simulatedCloudRoot, repository });
+
+    const result = service.updateSkills('bot-alpha', []);
+
+    assert.deepStrictEqual(result.definition.model, customModel);
+    assert.deepStrictEqual(result.definition.skills, []);
+  });
+
+  test('keeps an explicit empty Skill list through later model updates and pulls', () => {
+    const repository = new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot });
+    repository.writeCanonical({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-alpha',
+      model: { kind: 'catalog', modelId: 'model-a' },
+    });
+    const service = createBotDefinitionSyncService({ runtimeRoot, simulatedCloudRoot, repository });
+
+    service.updateSkills('bot-alpha', []);
+    service.updateModel('bot-alpha', { kind: 'catalog', modelId: 'model-b' });
+    const definition = service.pull('bot-alpha');
+
+    assert.deepStrictEqual(definition?.skills, []);
+  });
+
+  test('pull keeps canonical Skill references authoritative over a stale cache', () => {
+    const repository = new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot });
+    repository.writeCanonical({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-alpha',
+      model: { kind: 'catalog', modelId: 'model-a' },
+      skills: [{ skillId: 'cloud/weather', version: '2.0.0' }],
+    });
+    repository.writeCache({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-alpha',
+      model: { kind: 'catalog', modelId: 'stale-model' },
+      skills: [{ skillId: 'local/old', version: '1.0.0' }],
+    });
+    const service = createBotDefinitionSyncService({ runtimeRoot, simulatedCloudRoot, repository });
+
+    const definition = service.pull('bot-alpha');
+
+    assert.deepStrictEqual(definition?.skills, [{ skillId: 'cloud/weather', version: '2.0.0' }]);
+    assert.deepStrictEqual(repository.readCache('bot-alpha'), definition);
+  });
+
+  test('does not create an incomplete Definition from Skill references alone', () => {
+    const service = createBotDefinitionSyncService({ runtimeRoot, simulatedCloudRoot });
+    assert.throws(
+      () => service.updateSkills('bot-alpha', [{ skillId: 'alice/browser', version: '1.0.3' }]),
+      /before its model has been initialized/,
+    );
+  });
+
+  test('keeps cloud model overrides model-only while returning an effective definition with local Skills', () => {
+    const repository = new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot });
+    repository.writeCache({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-alpha',
+      model: { kind: 'catalog', modelId: 'local-model' },
+      skills: [{ skillId: 'alice/browser', version: '1.0.3' }],
+    });
+    const service = createBotDefinitionSyncService({ runtimeRoot, simulatedCloudRoot, repository });
+
+    const result = service.acceptCloud('bot-alpha', { kind: 'catalog', modelId: 'cloud-model' });
+    const persistedOverride = service.readCloudModelOverride('bot-alpha');
+
+    assert.deepStrictEqual(result.definition, {
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-alpha',
+      model: { kind: 'catalog', modelId: 'cloud-model' },
+      skills: [{ skillId: 'alice/browser', version: '1.0.3' }],
+    });
+    assert.deepStrictEqual(persistedOverride, {
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-alpha',
+      model: { kind: 'catalog', modelId: 'cloud-model' },
+    });
+  });
+});


### PR DESCRIPTION
## 背景

后续要实现“Skill 跟随 Bot”以及 Local / Base / Cloud 三态同步，首先需要让 `BotDefinition` 能表达一个 Bot 精确引用了哪些 Skill 版本，并保证模型配置和 Skill 引用可以独立更新。

此前 `BotDefinition` 只包含 `model`。如果直接加入 `skills`，现有整份发布和 cloud model override 流程可能在修改模型时清空 Skill 引用，或者把设备本地的云模型 override 当成完整 Definition 使用。因此本 PR 先建立数据契约和兼容边界，不提前引入工作区和内容同步。

## 本 PR 做了什么

### 1. 增加 Bot Skill 精确引用契约

- 为 `BotDefinition` 增加可选的 `skills: { skillId, version }[]`。
- Definition 只保存精确、可恢复的 SkillHub 引用，不保存 Skill 文件内容。
- 明确迁移语义：
  - `skills` 字段缺失：旧 Definition 尚未完成 Skill 迁移。
  - `skills: []`：已经迁移，并且当前 Bot 明确没有 Skill。

### 2. 增加字段级更新入口

- 新增 `BotDefinitionPatch`、`updateDefinition()`、`updateModel()` 和 `updateSkills()`。
- 保留 `publish()` 作为现有模型保存调用方的兼容别名。
- canonical 存在时，以当前 canonical 为 patch 基底，仅替换显式提供的字段。
- canonical 缺失时，才使用完整有效的本地 cache 作为创建基底。
- 修改模型不会覆盖 canonical 中的 Skill 引用；修改 Skill 引用也不会覆盖 canonical 中的模型。

### 3. 规范化和校验 Skill 引用

- 要求 `skills` 必须为数组，`skillId` 和 `version` 必须原本就是非空字符串。
- 去除首尾空白，删除完全相同的重复引用。
- 拒绝同一 `skillId` 同时引用多个版本。
- 使用不依赖系统 locale 的确定性顺序，避免不同设备生成不同 Definition 顺序。
- 写入时统一规范化 `botId`，避免路径和文件内容中的 Bot ID 不一致。

### 4. 区分 canonical 缺失和损坏

- repository 读取结果区分 `missing / invalid / valid`。
- canonical 损坏且没有有效 cache 时，禁止 bootstrap 和覆盖原文件。
- canonical 损坏但本地 cache 完整时，允许使用 cache 降级启动，同时保持 canonical 原文不变。
- canonical 损坏时禁止 `updateModel()` / `updateSkills()` 向上覆盖。
- `pull()` 只更新本地 cache，不在读取过程中回写 canonical，为后续 ETag 条件更新保留正确边界。

### 5. 保持 cloud model override 为 model-only

- 将设备本地 cloud model override 收窄为 `schema + botId + model`。
- 启动、云模型应用、失败回滚、重启和切回本地模型时，均把 override 的 model 叠加到本地完整 Definition 上。
- cloud model 切换不再丢失本地 Definition 的 `skills`。

## 兼容性和用户影响

- 旧的 model-only Definition 继续有效，不会被自动标记成已完成 Skill 迁移。
- 现有 `publish()` 调用方无需立即修改。
- catalog model runtime、自定义模型 profile、云端/本地模型切换逻辑保持不变。
- 当前 Skill catalog 加载、安装、删除、`skills/` 目录结构和 SkillHub 内容流程均未改变。
- 本 PR 只建立 Definition 契约与安全更新边界，不能描述为“已经支持 Bot Skill 云端同步”。

## 提交前审核中修复的问题

- 修复 invalid canonical 被误判为不存在并由 bootstrap 覆盖的问题。
- 修复旧 cache 缺少 `skills` 时，模型更新可能清空 canonical Skill 引用的问题。
- 修复 stale cache 作为整份更新基底，可能覆盖 canonical 未修改字段的问题。
- 移除 `pull()` 归一化时回写 canonical 的读后写竞争。
- 增加 canonical 损坏时的本地降级启动和禁止覆盖行为。
- 增加非字符串 SkillRef 输入、非规范 botId 和跨设备稳定排序的校验。
- 增加完整 activation 链路的 Skill 保留测试，而不仅测试 service 返回值。

## 验证

- `npm run build`：通过。
- BotDefinition、activation、cloud model client、Dashboard 相关回归：**93/93 通过**。
- `git diff --check`：通过，仅有 Windows LF/CRLF 提示。
- 三路独立 review：同步一致性、产品兼容性、安全/后端边界均确认没有 P0-P2 阻塞项。
- GitHub Actions：`Build and runtime tests`、`CatsCo cross-repo smoke and e2e` 均通过。
- 完整 runtime 套件：1202 项中 1196 通过、4 跳过、2 失败。
  - 两个失败均来自未修改的 `tool-result-read-tool` PDF 视觉回退测试。
  - 失败在本 PR 前后均可稳定复现，与 BotDefinition / Skill 引用改动无关。

## 本 PR 不包含

- 每个 Bot 的本地独立 Skill 工作区。
- `workspaceOwnerBotId`、`workspaceId` 和可恢复 switch journal。
- Local manifest、sync-base 和 Local / Base / Cloud 决策状态机。
- SkillHub 私有版本自动上传、`localSkillId` 和 `contentHash` 幂等。
- 真实 BotDefinition HTTP API、强制 ETag、字段级远端 PATCH 和错误分类。
- 自定义模型密钥的云端 secret reference；真实云接入前仍需处理该安全边界。
- subscriptions/default-skills-state 的一次性迁移。

## 下一步

1. PR2：实现每 Bot 独立工作区、`workspaceOwnerBotId`、`workspaceId` 和可恢复切换 journal。
2. PR3：实现稳定 `localSkillId`、Local manifest 和逐 Skill sync-base 映射。
3. PR4：接入安全快照、敏感内容阻断、私有不可变版本和 `contentHash` 幂等上传。
4. PR5：实现 Local / Base / Cloud 同步编排、迁移、失败恢复与冲突快照。
5. 云端接口阶段：接入字段级 PATCH、强制 ETag/If-Match、鉴权和服务端 SkillRef 校验。
