### PR TITLE
feat(skillhub): 允许所有用户管理虚拟员工 Skill

### DIFF
--- a/src/tools/skillhub-tool.ts
+++ b/src/tools/skillhub-tool.ts
@@ -2,10 +2,6 @@ import type { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } 
 import { SkillHubService } from '../skillhub/service';
 import { SkillHubSubscriptionService } from '../skillhub/subscription-service';
 import type { SkillHubSearchResponse } from '../skillhub/types';
-import {
-  isCatsCoLocalOwnerSelfContext,
-  isCatsCoToolGatewayContext,
-} from './tool-gateway';
 
 export interface SkillHubCatalogGateway {
   search(query?: string, options?: { category?: string }): Promise<SkillHubSearchResponse & { installed?: unknown[] }>;
@@ -30,7 +26,7 @@ export class SkillHubTool implements Tool {
       'browse/search 用于查看可用 Skill；list_subscriptions 查看当前运行环境已添加的 Skill。',
       '只有当用户在当前请求中明确要求订阅、安装、取消订阅或删除时，才能调用 subscribe/unsubscribe。',
       'subscribe 总是获取 latest：未安装时安装，已有同一 Skill 时更新或保持最新；同名异源会安全拒绝。',
-      '在虚拟员工中，subscribe/unsubscribe 只表示为当前员工添加或删除 Skill，不需要 SkillHub 登录。',
+      '在虚拟员工中，任何明确提出请求的用户都可以通过 subscribe/unsubscribe 为当前员工添加或删除 Skill，不需要 SkillHub 登录。',
       '一次只调用一个 subscribe/unsubscribe；多个 Skill 必须串行处理，任一操作失败后停止，不要并行或重试。',
       'unsubscribe 只删除带有匹配 SkillHub 安装标记的本地 Skill。不要把发布者删除版本的请求交给本工具。',
     ].join('\n'),
@@ -96,8 +92,6 @@ export class SkillHubTool implements Tool {
       }
 
       if (action === 'subscribe' || action === 'unsubscribe') {
-        const denied = mutationDenied(context);
-        if (denied) return denied;
         const skillId = required(args?.skillId, 'skillId');
         if (action === 'subscribe') {
           const result = await this.subscriptions.subscribe(skillId);
@@ -130,15 +124,6 @@ export class SkillHubTool implements Tool {
       };
     }
   }
-}
-
-function mutationDenied(context: ToolExecutionContext): ToolExecutionResult | undefined {
-  if (!isCatsCoToolGatewayContext(context) || isCatsCoLocalOwnerSelfContext(context)) return undefined;
-  return {
-    ok: false,
-    errorCode: 'PERMISSION_DENIED',
-    message: '只有当前 Agent 的所有者可以添加或删除 Skill。',
-  };
 }
 
 function required(value: unknown, field: string): string {

--- a/tests/skillhub-subscription.test.ts
+++ b/tests/skillhub-subscription.test.ts
@@ -308,7 +308,7 @@ describe('SkillHub user subscriptions', () => {
     assert.equal('agentId' in claimed, false);
   });
 
-  test('Tool can browse and owner can subscribe without a confirmation step', async () => {
+  test('Tool can browse and a non-owner CatsCo actor can subscribe without a confirmation step', async () => {
     const calls: string[] = [];
     const tool = new SkillHubTool(
       {
@@ -339,7 +339,7 @@ describe('SkillHub user subscriptions', () => {
     assert.equal(browse.ok, true);
     assert.match(String(browse.ok && browse.content), /alice\/ppt/);
 
-    const subscribed = await tool.execute({ action: 'subscribe', skillId: 'alice/ppt' }, ownerContext());
+    const subscribed = await tool.execute({ action: 'subscribe', skillId: 'alice/ppt' }, catsCoContext('usr9'));
     assert.equal(subscribed.ok, true);
     assert.deepEqual(calls, ['alice/ppt']);
     assert.doesNotMatch(String(subscribed.ok && subscribed.content), /usr43/);
@@ -352,9 +352,10 @@ describe('SkillHub user subscriptions', () => {
     assert.match(tool.definition.description, /一次只调用一个 subscribe\/unsubscribe/);
     assert.match(tool.definition.description, /任一操作失败后停止/);
     assert.match(tool.definition.description, /不要并行或重试/);
+    assert.match(tool.definition.description, /任何明确提出请求的用户/);
   });
 
-  test('Tool rejects subscription mutations from a non-owner CatsCo actor', async () => {
+  test('Tool allows a non-owner CatsCo actor to unsubscribe', async () => {
     let called = false;
     const tool = new SkillHubTool(
       { search: async () => ({ skills: [] }) },
@@ -370,14 +371,13 @@ describe('SkillHub user subscriptions', () => {
         },
       },
     );
-    const context = ownerContext();
-    context.executionScope = { ...context.executionScope!, actorUserId: 'usr9' };
+    const result = await tool.execute(
+      { action: 'unsubscribe', skillId: 'alice/ppt' },
+      catsCoContext('usr9'),
+    );
 
-    const result = await tool.execute({ action: 'unsubscribe', skillId: 'alice/ppt' }, context);
-
-    assert.equal(result.ok, false);
-    if (!result.ok) assert.equal(result.errorCode, 'PERMISSION_DENIED');
-    assert.equal(called, false);
+    assert.equal(result.ok, true);
+    assert.equal(called, true);
   });
 
   test('ToolManager does not introduce a confirmation step for SkillHub operations', async () => {
@@ -477,13 +477,13 @@ function baseContext(): ToolExecutionContext {
   return { workingDirectory: testCwd(), conversationHistory: [] };
 }
 
-function ownerContext(): ToolExecutionContext {
+function catsCoContext(actorUserId = 'usr7'): ToolExecutionContext {
   const scope: ExecutionScope = {
     source: 'catscompany',
     sessionKey: 'session:v2:catscompany:p2p:p2p_7_43:agent:usr43',
     topicId: 'p2p_7_43',
     topicType: 'p2p',
-    actorUserId: 'usr7',
+    actorUserId,
     agentId: 'usr43',
     agentBodyId: 'body-main',
     identityTrust: 'server_canonical',


### PR DESCRIPTION
## 背景

云端虚拟员工的 Skill 使用 runtime-local 共享状态，但 `SkillHubTool` 入口额外限制只有 Agent owner 才能执行 `subscribe` / `unsubscribe`，导致其他对话用户只能查看、不能为当前员工增删 Skill。

## 改动

- 移除 SkillHub 增删操作的 owner 专属门禁。
- 明确工具语义：任何在当前请求中明确提出操作的用户，都可以为当前虚拟员工添加或删除 Skill。
- 更新测试，覆盖非 owner CatsCo actor 的订阅和取消订阅。

## 保留边界

- 用户仍需在当前请求中明确提出安装或删除。
- 保留签名校验、同名异源冲突检查和安装标记校验。
- 不改变 SkillHub 包的发布、下架和作者权限。
- 不改变个人登录模式下的 SkillHub 用户归属。

## 验证

- SkillHub 定向测试：14/14 通过。
- `npm run build`：通过。
- 完整 runtime 测试：1151 项中 1142 通过、4 跳过、5 失败；失败来自 logger 临时日志 `ENOENT` 和 ReadTool 临时目录清理 `ENOTEMPTY`，与本次修改无关。
