### PR TITLE
feat: 为每个 Bot 隔离本地 Skill 工作区（PR2）

### DIFF
--- a/src/bot-definition/llm-config-resolver.ts
+++ b/src/bot-definition/llm-config-resolver.ts
@@ -22,6 +22,7 @@ export interface ResolvedBotLLMConfig {
 export interface ResolveBotLLMConfigOptions {
   runtimeRoot?: string;
   env?: NodeJS.ProcessEnv;
+  botId?: string;
 }
 
 export function modelRuntimeToConfig(runtime: {
@@ -77,7 +78,7 @@ export function resolveActiveBotLLMConfig(
   const runtimeRoot = path.resolve(options.runtimeRoot ?? PathResolver.getRuntimeDataRoot());
   const env = options.env ?? process.env;
   const localConfig = createCatsCoLocalConfigService({ runtimeRoot, env }).load();
-  const botId = String(localConfig.currentBot?.uid || '').trim();
+  const botId = String(options.botId || localConfig.currentBot?.uid || '').trim();
   if (!botId) return undefined;
 
   const definitions = new FileBotDefinitionRepository({ runtimeRoot });

--- a/src/bot-skills/activation-recovery.ts
+++ b/src/bot-skills/activation-recovery.ts
@@ -1,0 +1,343 @@
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { createCatsCoLocalConfigService } from '../catscompany/local-config';
+import {
+  BotSkillWorkspaceActivationLock,
+  BotSkillWorkspaceService,
+  createBotSkillWorkspaceService,
+} from './workspace-service';
+
+const SNAPSHOT_SCHEMA = 'xiaoba.bot-skill-binding-rollback.v1';
+const MAX_SNAPSHOT_BYTES = 2 * 1024 * 1024;
+
+interface FileSnapshot {
+  exists: boolean;
+  content?: string;
+}
+
+interface BindingEnvSnapshot {
+  fileExisted: boolean;
+  values: Record<string, string | null>;
+  processValues: Record<string, string | null>;
+}
+
+interface BotSkillBindingRollbackSnapshot {
+  schema: typeof SNAPSHOT_SCHEMA;
+  transactionId: string;
+  createdAt: string;
+  configPath: string;
+  config: FileSnapshot;
+  env: BindingEnvSnapshot;
+}
+
+const BINDING_ENV_KEYS = [
+  'CATSCO_HTTP_BASE_URL',
+  'CATSCO_SERVER_URL',
+  'CATSCO_USER_TOKEN',
+  'CATSCO_USER_UID',
+  'CATSCO_USER_NAME',
+  'CATSCO_USER_DISPLAY_NAME',
+  'CATSCO_BOT_UID',
+  'CATSCO_API_KEY',
+  'CATSCO_DEVICE_ID',
+  'CATSCO_BODY_ID',
+  'CATSCO_INSTALLATION_ID',
+  'CATSCOMPANY_HTTP_BASE_URL',
+  'CATSCOMPANY_SERVER_URL',
+  'CATSCOMPANY_USER_TOKEN',
+  'CATSCOMPANY_USER_UID',
+  'CATSCOMPANY_USER_NAME',
+  'CATSCOMPANY_USER_DISPLAY_NAME',
+  'CATSCOMPANY_BOT_UID',
+  'CATSCOMPANY_API_KEY',
+  'CATSCOMPANY_DEVICE_ID',
+  'CATSCOMPANY_BODY_ID',
+  'CATSCOMPANY_INSTALLATION_ID',
+] as const;
+
+export interface BotSkillActivationRecoveryResult {
+  recovered: boolean;
+  restoredBotId?: string;
+  pendingTargetBotId?: string;
+}
+
+export function persistBotSkillBindingRollback(
+  runtimeRoot: string,
+  transactionId: string,
+): void {
+  const service = createCatsCoLocalConfigService({ runtimeRoot });
+  const snapshot: BotSkillBindingRollbackSnapshot = {
+    schema: SNAPSHOT_SCHEMA,
+    transactionId,
+    createdAt: new Date().toISOString(),
+    configPath: path.resolve(service.getConfigPath()),
+    config: snapshotFile(service.getConfigPath()),
+    env: snapshotBindingEnv(path.join(runtimeRoot, '.env')),
+  };
+  atomicWriteSnapshot(snapshotPath(runtimeRoot), snapshot);
+}
+
+export function discardBotSkillBindingRollback(
+  runtimeRoot: string,
+  transactionId?: string,
+): void {
+  const filePath = snapshotPath(runtimeRoot);
+  if (!fs.existsSync(filePath)) return;
+  if (transactionId) {
+    const snapshot = readSnapshot(filePath);
+    if (snapshot.transactionId !== transactionId) {
+      throw new Error('Refusing to discard a different Bot binding rollback snapshot.');
+    }
+  }
+  fs.rmSync(filePath, { force: true });
+}
+
+/**
+ * Restores binding first and workspace second. If the process stops between the
+ * two operations, the still-open workspace journal makes the next recovery
+ * repeat the idempotent binding restore before touching directories.
+ */
+export function recoverBotSkillActivation(
+  runtimeRoot: string,
+  workspaceService: BotSkillWorkspaceService = createBotSkillWorkspaceService({ runtimeRoot }),
+  options: {
+    expectedLiveTransactionId?: string;
+    lock?: BotSkillWorkspaceActivationLock;
+  } = {},
+): BotSkillActivationRecoveryResult {
+  const expectedTransactionId = String(options.expectedLiveTransactionId || '').trim();
+  const initialJournal = workspaceService.readState()?.switchJournal;
+  if (expectedTransactionId && initialJournal?.transactionId === expectedTransactionId) {
+    const currentBotId = String(
+      createCatsCoLocalConfigService({ runtimeRoot }).load().currentBot?.uid || '',
+    ).trim();
+    workspaceService.assertPendingTarget(expectedTransactionId, currentBotId);
+    return {
+      recovered: false,
+      pendingTargetBotId: currentBotId,
+    };
+  }
+  if (expectedTransactionId.startsWith('initial:') && !initialJournal) {
+    const currentBotId = String(
+      createCatsCoLocalConfigService({ runtimeRoot }).load().currentBot?.uid || '',
+    ).trim();
+    workspaceService.assertActive(currentBotId);
+    return {
+      recovered: false,
+      pendingTargetBotId: currentBotId,
+    };
+  }
+
+  const lock = options.lock ?? workspaceService.acquireActivationLock();
+  const ownsLock = !options.lock;
+  try {
+    const state = workspaceService.readState();
+    const journal = state?.switchJournal;
+    const filePath = snapshotPath(runtimeRoot);
+
+    if (!journal) {
+      if (fs.existsSync(filePath)) fs.rmSync(filePath, { force: true });
+      return { recovered: false };
+    }
+
+    if (!fs.existsSync(filePath)) {
+      throw new Error(
+        `Bot Skill workspace transaction ${journal.transactionId} is missing its binding rollback snapshot.`,
+      );
+    }
+    const snapshot = readSnapshot(filePath);
+    if (snapshot.transactionId !== journal.transactionId) {
+      throw new Error('Bot Skill workspace journal and binding rollback snapshot do not match.');
+    }
+    const currentConfigPath = path.resolve(
+      createCatsCoLocalConfigService({ runtimeRoot }).getConfigPath(),
+    );
+    if (currentConfigPath !== snapshot.configPath) {
+      throw new Error('Bot binding config path changed during an interrupted Skill workspace switch.');
+    }
+
+    restoreFile(snapshot.configPath, snapshot.config);
+    restoreBindingEnv(path.join(runtimeRoot, '.env'), snapshot.env);
+    restoreBindingProcessEnv(snapshot.env);
+    const restored = workspaceService.rollbackSwitch(journal.transactionId, lock);
+    fs.rmSync(filePath, { force: true });
+    return {
+      recovered: true,
+      restoredBotId: restored?.workspaceOwnerBotId,
+    };
+  } finally {
+    if (ownsLock) lock.release();
+  }
+}
+
+function snapshotPath(runtimeRoot: string): string {
+  return path.join(path.resolve(runtimeRoot), 'data', 'bot-skills', 'binding-rollback.json');
+}
+
+function snapshotFile(filePath: string): FileSnapshot {
+  if (!fs.existsSync(filePath)) return { exists: false };
+  const stat = fs.lstatSync(filePath);
+  if (!stat.isFile() || stat.isSymbolicLink() || stat.size > MAX_SNAPSHOT_BYTES) {
+    throw new Error(`Bot binding file is invalid or too large to snapshot: ${filePath}`);
+  }
+  return { exists: true, content: fs.readFileSync(filePath, 'utf8') };
+}
+
+function snapshotBindingEnv(filePath: string): BindingEnvSnapshot {
+  const file = snapshotFile(filePath);
+  const content = file.content ?? '';
+  const values: Record<string, string | null> = {};
+  const processValues: Record<string, string | null> = {};
+  for (const key of BINDING_ENV_KEYS) {
+    const match = content.match(new RegExp(`^${key}=(.*)$`, 'm'));
+    values[key] = match ? match[1].replace(/\r$/, '') : null;
+    processValues[key] = process.env[key] ?? null;
+  }
+  return { fileExisted: file.exists, values, processValues };
+}
+
+function restoreBindingEnv(filePath: string, snapshot: BindingEnvSnapshot): void {
+  if (fs.existsSync(filePath) && fs.lstatSync(filePath).isSymbolicLink()) {
+    throw new Error(`Refusing to restore Bot binding through a symlink: ${filePath}`);
+  }
+  let content = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf8') : '';
+  for (const key of BINDING_ENV_KEYS) {
+    content = content.replace(new RegExp(`^${key}=.*(?:\\r?\\n|$)`, 'gm'), '');
+  }
+  const restoredLines = BINDING_ENV_KEYS
+    .filter(key => snapshot.values[key] !== null)
+    .map(key => `${key}=${snapshot.values[key]}`);
+  content = content.replace(/^\s*\r?\n/gm, '').replace(/\s+$/, '');
+  if (restoredLines.length > 0) {
+    content = `${content}${content ? '\n' : ''}${restoredLines.join('\n')}\n`;
+  } else if (content) {
+    content = `${content}\n`;
+  }
+  if (!snapshot.fileExisted && !content) {
+    fs.rmSync(filePath, { force: true });
+    return;
+  }
+  restoreFile(filePath, { exists: true, content });
+}
+
+function restoreBindingProcessEnv(snapshot: BindingEnvSnapshot): void {
+  for (const key of BINDING_ENV_KEYS) {
+    const value = snapshot.processValues[key];
+    if (value === null) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+function restoreFile(filePath: string, snapshot: FileSnapshot): void {
+  if (fs.existsSync(filePath) && fs.lstatSync(filePath).isSymbolicLink()) {
+    throw new Error(`Refusing to restore Bot binding through a symlink: ${filePath}`);
+  }
+  if (!snapshot.exists) {
+    fs.rmSync(filePath, { force: true });
+    return;
+  }
+  fs.mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
+  const tempPath = `${filePath}.${process.pid}.${crypto.randomUUID()}.restore.tmp`;
+  fs.writeFileSync(tempPath, snapshot.content ?? '', {
+    encoding: 'utf8',
+    mode: 0o600,
+    flag: 'wx',
+  });
+  try {
+    fs.renameSync(tempPath, filePath);
+  } catch (error) {
+    fs.rmSync(tempPath, { force: true });
+    throw error;
+  }
+  if (process.platform !== 'win32') {
+    try {
+      fs.chmodSync(filePath, 0o600);
+    } catch {
+      // Restore rename is the commit point.
+    }
+  }
+}
+
+function atomicWriteSnapshot(
+  filePath: string,
+  snapshot: BotSkillBindingRollbackSnapshot,
+): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
+  const tempPath = `${filePath}.${process.pid}.${crypto.randomUUID()}.tmp`;
+  const serialized = `${JSON.stringify(snapshot, null, 2)}\n`;
+  if (Buffer.byteLength(serialized, 'utf8') > MAX_SNAPSHOT_BYTES) {
+    throw new Error('Bot binding rollback snapshot exceeds the safe size limit.');
+  }
+  fs.writeFileSync(tempPath, serialized, {
+    encoding: 'utf8',
+    mode: 0o600,
+    flag: 'wx',
+  });
+  try {
+    fs.renameSync(tempPath, filePath);
+    if (process.platform !== 'win32') {
+      try {
+        fs.chmodSync(filePath, 0o600);
+      } catch {
+        // Snapshot rename is the commit point.
+      }
+    }
+  } catch (error) {
+    fs.rmSync(tempPath, { force: true });
+    throw error;
+  }
+}
+
+function readSnapshot(filePath: string): BotSkillBindingRollbackSnapshot {
+  const stat = fs.lstatSync(filePath);
+  if (!stat.isFile() || stat.isSymbolicLink() || stat.size > MAX_SNAPSHOT_BYTES) {
+    throw new Error('Bot binding rollback snapshot is invalid or too large.');
+  }
+  let parsed: Partial<BotSkillBindingRollbackSnapshot>;
+  try {
+    parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    throw new Error('Bot binding rollback snapshot is not valid JSON.');
+  }
+  if (
+    parsed.schema !== SNAPSHOT_SCHEMA ||
+    typeof parsed.transactionId !== 'string' ||
+    !parsed.transactionId ||
+    typeof parsed.createdAt !== 'string' ||
+    typeof parsed.configPath !== 'string' ||
+    !isFileSnapshot(parsed.config) ||
+    !isBindingEnvSnapshot(parsed.env)
+  ) {
+    throw new Error('Bot binding rollback snapshot has invalid fields.');
+  }
+  return parsed as BotSkillBindingRollbackSnapshot;
+}
+
+function isBindingEnvSnapshot(value: unknown): value is BindingEnvSnapshot {
+  if (!value || typeof value !== 'object') return false;
+  const snapshot = value as Partial<BindingEnvSnapshot>;
+  if (
+    typeof snapshot.fileExisted !== 'boolean' ||
+    !snapshot.values ||
+    typeof snapshot.values !== 'object' ||
+    !snapshot.processValues ||
+    typeof snapshot.processValues !== 'object'
+  ) {
+    return false;
+  }
+  return BINDING_ENV_KEYS.every(key =>
+    [snapshot.values?.[key], snapshot.processValues?.[key]]
+      .every(entry => entry === null || typeof entry === 'string'),
+  );
+}
+
+function isFileSnapshot(value: unknown): value is FileSnapshot {
+  if (!value || typeof value !== 'object') return false;
+  const snapshot = value as Partial<FileSnapshot>;
+  return typeof snapshot.exists === 'boolean' &&
+    (!snapshot.exists || typeof snapshot.content === 'string');
+}

--- a/src/bot-skills/workspace-service.ts
+++ b/src/bot-skills/workspace-service.ts
@@ -1,0 +1,778 @@
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+export const BOT_SKILL_WORKSPACE_MARKER_SCHEMA = 'xiaoba.bot-skill-workspace.v1';
+export const BOT_SKILL_WORKSPACE_STATE_SCHEMA = 'xiaoba.bot-skill-workspace-state.v1';
+
+export type BotSkillWorkspaceSwitchPhase =
+  | 'prepared'
+  | 'source-parked'
+  | 'target-active';
+
+export interface BotSkillWorkspaceIdentity {
+  botId: string;
+  workspaceId: string;
+}
+
+export interface BotSkillWorkspaceMarker {
+  schema: typeof BOT_SKILL_WORKSPACE_MARKER_SCHEMA;
+  workspaceOwnerBotId: string;
+  workspaceId: string;
+  createdAt: string;
+}
+
+export interface BotSkillWorkspaceSwitchJournal {
+  transactionId: string;
+  from: BotSkillWorkspaceIdentity;
+  to: BotSkillWorkspaceIdentity;
+  phase: BotSkillWorkspaceSwitchPhase;
+  targetWasCreated: boolean;
+  startedAt: string;
+}
+
+export interface BotSkillWorkspaceState {
+  schema: typeof BOT_SKILL_WORKSPACE_STATE_SCHEMA;
+  revision: number;
+  workspaceOwnerBotId: string;
+  workspaceId: string;
+  switchJournal?: BotSkillWorkspaceSwitchJournal;
+}
+
+export interface BotSkillWorkspaceSwitch {
+  transactionId?: string;
+  fromBotId: string;
+  toBotId: string;
+  changed: boolean;
+}
+
+export interface BotSkillWorkspaceActivationLock {
+  lockId: string;
+  release: () => void;
+}
+
+export interface BotSkillWorkspaceServiceOptions {
+  runtimeRoot: string;
+  env?: NodeJS.ProcessEnv;
+  /**
+   * Test-only crash injection point. Production callers should not set this.
+   */
+  onPhasePersisted?: (phase: BotSkillWorkspaceSwitchPhase) => void;
+}
+
+const MARKER_FILE = '.xiaoba-bot-workspace.json';
+const MAX_JSON_BYTES = 256 * 1024;
+
+export class BotSkillWorkspaceService {
+  readonly runtimeRoot: string;
+  readonly activePath: string;
+  readonly dataRoot: string;
+  readonly parkedRoot: string;
+  readonly statePath: string;
+  readonly lockPath: string;
+
+  private readonly phaseHook?: (phase: BotSkillWorkspaceSwitchPhase) => void;
+
+  constructor(options: BotSkillWorkspaceServiceOptions) {
+    this.runtimeRoot = path.resolve(options.runtimeRoot);
+    this.activePath = path.join(this.runtimeRoot, 'skills');
+    this.dataRoot = path.join(this.runtimeRoot, 'data', 'bot-skills');
+    this.parkedRoot = path.join(this.dataRoot, 'by-bot');
+    this.statePath = path.join(this.dataRoot, 'workspace-state.json');
+    this.lockPath = path.join(this.dataRoot, 'switch.lock');
+    this.phaseHook = options.onPhasePersisted;
+
+    const override = String((options.env ?? process.env).XIAOBA_SKILLS_DIR || '').trim();
+    if (override && !samePath(path.resolve(override), this.activePath)) {
+      throw new Error(
+        `Bot-managed Skill workspaces require XIAOBA_SKILLS_DIR to resolve to ${this.activePath}.`,
+      );
+    }
+    this.assertSafeRoot(this.runtimeRoot, 'runtime root');
+  }
+
+  readState(): BotSkillWorkspaceState | undefined {
+    if (!fs.existsSync(this.statePath)) return undefined;
+    return parseState(readJsonFile(this.statePath));
+  }
+
+  getParkedPath(botId: string): string {
+    const normalized = normalizeBotId(botId);
+    const digest = crypto.createHash('sha256').update(normalized, 'utf8').digest('hex');
+    return path.join(this.parkedRoot, `b_${digest}`);
+  }
+
+  /**
+   * Adopts the legacy active directory for the currently bound Bot. No content
+   * is copied or moved, so offline edits remain owned by that Bot.
+   */
+  ensureActive(
+    botId: string,
+    options: { allowCreate?: boolean; lock?: BotSkillWorkspaceActivationLock } = {},
+  ): BotSkillWorkspaceState {
+    return this.withLock(() => {
+      this.recoverInterruptedSwitchUnlocked();
+      const normalizedBotId = normalizeBotId(botId);
+      const state = this.readState();
+      if (state) {
+        const marker = this.readRequiredMarker(this.activePath);
+        assertIdentity(marker, {
+          botId: state.workspaceOwnerBotId,
+          workspaceId: state.workspaceId,
+        }, 'active workspace');
+        if (state.workspaceOwnerBotId !== normalizedBotId) {
+          throw new Error(
+            `Active Skill workspace belongs to Bot ${state.workspaceOwnerBotId}, not ${normalizedBotId}.`,
+          );
+        }
+        return state;
+      }
+
+      this.ensureManagedRoots();
+      if (!fs.existsSync(this.activePath)) {
+        if (!options.allowCreate) {
+          throw new Error(
+            `No active Skill workspace exists for Bot ${normalizedBotId}; explicit creation or restore is required.`,
+          );
+        }
+        fs.mkdirSync(this.activePath, { recursive: false, mode: 0o700 });
+      }
+      this.assertDirectoryIsSafe(this.activePath, 'active Skill workspace');
+
+      const existingMarker = this.readMarker(this.activePath);
+      if (existingMarker && existingMarker.workspaceOwnerBotId !== normalizedBotId) {
+        throw new Error(
+          `Active Skill workspace marker belongs to Bot ${existingMarker.workspaceOwnerBotId}.`,
+        );
+      }
+      if (!existingMarker && this.hasParkedWorkspaces()) {
+        throw new Error(
+          'Cannot claim an unmarked active Skill workspace while parked workspaces already exist.',
+        );
+      }
+      const marker = existingMarker ?? this.createMarker(this.activePath, normalizedBotId);
+      const initial: BotSkillWorkspaceState = {
+        schema: BOT_SKILL_WORKSPACE_STATE_SCHEMA,
+        revision: 1,
+        workspaceOwnerBotId: normalizedBotId,
+        workspaceId: marker.workspaceId,
+      };
+      this.writeState(initial);
+      return initial;
+    }, options.lock);
+  }
+
+  /**
+   * Activates a target Bot but leaves the journal open. Call commitSwitch only
+   * after binding/preflight/connector startup succeeds. A crash before commit
+   * is recovered to the previous Bot.
+   */
+  beginSwitch(
+    botId: string,
+    options: {
+      allowCreate?: boolean;
+      transactionId?: string;
+      lock?: BotSkillWorkspaceActivationLock;
+    } = {},
+  ): BotSkillWorkspaceSwitch {
+    return this.withLock(() => {
+      this.recoverInterruptedSwitchUnlocked();
+      const targetBotId = normalizeBotId(botId);
+      const state = this.readState();
+      if (!state) {
+        const claimed = this.ensureActiveUnlocked(targetBotId, options.allowCreate === true);
+        return {
+          fromBotId: claimed.workspaceOwnerBotId,
+          toBotId: targetBotId,
+          changed: false,
+        };
+      }
+      if (state.workspaceOwnerBotId === targetBotId) {
+        this.assertActiveMatches(state);
+        return {
+          fromBotId: targetBotId,
+          toBotId: targetBotId,
+          changed: false,
+        };
+      }
+
+      this.assertActiveMatches(state);
+      this.ensureManagedRoots();
+      const sourcePath = this.getParkedPath(state.workspaceOwnerBotId);
+      const targetPath = this.getParkedPath(targetBotId);
+      if (fs.existsSync(sourcePath)) {
+        throw new Error(`Cannot park source Skill workspace because destination already exists: ${sourcePath}`);
+      }
+
+      let targetWasCreated = false;
+      if (!fs.existsSync(targetPath)) {
+        if (!options.allowCreate) {
+          throw new Error(
+            `No local Skill workspace exists for Bot ${targetBotId}; restore or explicit empty creation is required.`,
+          );
+        }
+        fs.mkdirSync(targetPath, { recursive: false, mode: 0o700 });
+        this.createMarker(targetPath, targetBotId);
+        targetWasCreated = true;
+      }
+      this.assertDirectoryIsSafe(targetPath, 'target parked Skill workspace');
+      const targetMarker = this.readRequiredMarker(targetPath);
+      if (targetMarker.workspaceOwnerBotId !== targetBotId) {
+        throw new Error(`Target Skill workspace marker does not belong to Bot ${targetBotId}.`);
+      }
+
+      const journal: BotSkillWorkspaceSwitchJournal = {
+        transactionId: options.transactionId || crypto.randomUUID(),
+        from: {
+          botId: state.workspaceOwnerBotId,
+          workspaceId: state.workspaceId,
+        },
+        to: {
+          botId: targetBotId,
+          workspaceId: targetMarker.workspaceId,
+        },
+        phase: 'prepared',
+        targetWasCreated,
+        startedAt: new Date().toISOString(),
+      };
+      this.persistJournal(state, journal);
+
+      fs.renameSync(this.activePath, sourcePath);
+      journal.phase = 'source-parked';
+      this.persistJournal(state, journal);
+
+      fs.renameSync(targetPath, this.activePath);
+      journal.phase = 'target-active';
+      this.persistJournal(state, journal);
+
+      return {
+        transactionId: journal.transactionId,
+        fromBotId: journal.from.botId,
+        toBotId: journal.to.botId,
+        changed: true,
+      };
+    }, options.lock);
+  }
+
+  commitSwitch(
+    transactionId: string,
+    lock?: BotSkillWorkspaceActivationLock,
+  ): BotSkillWorkspaceState {
+    return this.withLock(() => {
+      const state = this.readState();
+      const journal = state?.switchJournal;
+      if (!state || !journal || journal.transactionId !== transactionId) {
+        throw new Error('Bot Skill workspace switch transaction is missing or no longer current.');
+      }
+      if (journal.phase !== 'target-active') {
+        throw new Error(`Bot Skill workspace switch is not ready to commit (${journal.phase}).`);
+      }
+      const marker = this.readRequiredMarker(this.activePath);
+      assertIdentity(marker, journal.to, 'active target workspace');
+      const committed: BotSkillWorkspaceState = {
+        schema: BOT_SKILL_WORKSPACE_STATE_SCHEMA,
+        revision: state.revision + 1,
+        workspaceOwnerBotId: journal.to.botId,
+        workspaceId: journal.to.workspaceId,
+      };
+      this.writeState(committed);
+      return committed;
+    }, lock);
+  }
+
+  rollbackSwitch(
+    transactionId?: string,
+    lock?: BotSkillWorkspaceActivationLock,
+  ): BotSkillWorkspaceState | undefined {
+    return this.withLock(() => {
+      const state = this.readState();
+      if (transactionId && state?.switchJournal?.transactionId !== transactionId) {
+        throw new Error('Refusing to roll back a different Bot Skill workspace transaction.');
+      }
+      return this.recoverInterruptedSwitchUnlocked();
+    }, lock);
+  }
+
+  recoverInterruptedSwitch(
+    lock?: BotSkillWorkspaceActivationLock,
+  ): BotSkillWorkspaceState | undefined {
+    return this.withLock(() => this.recoverInterruptedSwitchUnlocked(), lock);
+  }
+
+  acquireActivationLock(): BotSkillWorkspaceActivationLock {
+    this.ensureManagedRoots();
+    const lockId = this.acquireLock();
+    let released = false;
+    return {
+      lockId,
+      release: () => {
+        if (released) return;
+        released = true;
+        this.releaseLock(lockId);
+      },
+    };
+  }
+
+  assertPendingTarget(transactionId: string, botId: string): BotSkillWorkspaceSwitchJournal {
+    const state = this.readState();
+    const journal = state?.switchJournal;
+    if (
+      !journal ||
+      journal.transactionId !== transactionId ||
+      journal.phase !== 'target-active' ||
+      journal.to.botId !== normalizeBotId(botId)
+    ) {
+      throw new Error('Connector activation transaction does not match the pending target workspace.');
+    }
+    const marker = this.readRequiredMarker(this.activePath);
+    assertIdentity(marker, journal.to, 'pending target Skill workspace');
+    return journal;
+  }
+
+  assertActive(botId: string): BotSkillWorkspaceState {
+    const normalizedBotId = normalizeBotId(botId);
+    const state = this.readState();
+    if (!state || state.switchJournal || state.workspaceOwnerBotId !== normalizedBotId) {
+      throw new Error(`Stable active Skill workspace does not belong to Bot ${normalizedBotId}.`);
+    }
+    this.assertActiveMatches(state);
+    return state;
+  }
+
+  releaseInitialClaim(
+    botId: string,
+    lock?: BotSkillWorkspaceActivationLock,
+  ): void {
+    this.withLock(() => {
+      const state = this.readState();
+      if (
+        !state ||
+        state.switchJournal ||
+        state.revision !== 1 ||
+        state.workspaceOwnerBotId !== normalizeBotId(botId) ||
+        this.hasParkedWorkspaces()
+      ) {
+        throw new Error('Initial Skill workspace claim can no longer be safely released.');
+      }
+      const marker = this.readRequiredMarker(this.activePath);
+      assertIdentity(marker, {
+        botId: state.workspaceOwnerBotId,
+        workspaceId: state.workspaceId,
+      }, 'initial Skill workspace');
+      fs.rmSync(path.join(this.activePath, MARKER_FILE), { force: true });
+      fs.rmSync(this.statePath, { force: true });
+    }, lock);
+  }
+
+  private ensureActiveUnlocked(botId: string, allowCreate: boolean): BotSkillWorkspaceState {
+    const state = this.readState();
+    if (state) return state;
+    this.ensureManagedRoots();
+    if (!fs.existsSync(this.activePath)) {
+      if (!allowCreate) {
+        throw new Error(
+          `No active Skill workspace exists for Bot ${botId}; explicit creation or restore is required.`,
+        );
+      }
+      fs.mkdirSync(this.activePath, { recursive: false, mode: 0o700 });
+    }
+    this.assertDirectoryIsSafe(this.activePath, 'active Skill workspace');
+    const existingMarker = this.readMarker(this.activePath);
+    if (existingMarker && existingMarker.workspaceOwnerBotId !== botId) {
+      throw new Error(`Active Skill workspace marker belongs to Bot ${existingMarker.workspaceOwnerBotId}.`);
+    }
+    if (!existingMarker && this.hasParkedWorkspaces()) {
+      throw new Error(
+        'Cannot claim an unmarked active Skill workspace while parked workspaces already exist.',
+      );
+    }
+    const marker = existingMarker ?? this.createMarker(this.activePath, botId);
+    const initial: BotSkillWorkspaceState = {
+      schema: BOT_SKILL_WORKSPACE_STATE_SCHEMA,
+      revision: 1,
+      workspaceOwnerBotId: botId,
+      workspaceId: marker.workspaceId,
+    };
+    this.writeState(initial);
+    return initial;
+  }
+
+  private recoverInterruptedSwitchUnlocked(): BotSkillWorkspaceState | undefined {
+    const state = this.readState();
+    const journal = state?.switchJournal;
+    if (!state || !journal) return state;
+
+    const sourcePath = this.getParkedPath(journal.from.botId);
+    const targetPath = this.getParkedPath(journal.to.botId);
+    const activeExists = fs.existsSync(this.activePath);
+    const sourceExists = fs.existsSync(sourcePath);
+    const targetExists = fs.existsSync(targetPath);
+    const active = this.readMarker(this.activePath);
+    const source = this.readMarker(sourcePath);
+    const target = this.readMarker(targetPath);
+
+    const activeIsSource = markerMatches(active, journal.from);
+    const activeIsTarget = markerMatches(active, journal.to);
+    const parkedSourceMatches = markerMatches(source, journal.from);
+    const parkedTargetMatches = markerMatches(target, journal.to);
+
+    if (activeIsSource && !sourceExists && parkedTargetMatches) {
+      return this.clearJournal(state);
+    }
+    if (!activeExists && parkedSourceMatches && parkedTargetMatches) {
+      fs.renameSync(sourcePath, this.activePath);
+      return this.clearJournal(state);
+    }
+    if (activeIsTarget && parkedSourceMatches && !targetExists) {
+      fs.renameSync(this.activePath, targetPath);
+      fs.renameSync(sourcePath, this.activePath);
+      return this.clearJournal(state);
+    }
+
+    throw new Error(
+      `Cannot safely recover Bot Skill workspace transaction ${journal.transactionId}; directory markers are ambiguous.`,
+    );
+  }
+
+  private clearJournal(state: BotSkillWorkspaceState): BotSkillWorkspaceState {
+    const restored: BotSkillWorkspaceState = {
+      schema: BOT_SKILL_WORKSPACE_STATE_SCHEMA,
+      revision: state.revision + 1,
+      workspaceOwnerBotId: state.workspaceOwnerBotId,
+      workspaceId: state.workspaceId,
+    };
+    this.writeState(restored);
+    return restored;
+  }
+
+  private assertActiveMatches(state: BotSkillWorkspaceState): void {
+    const marker = this.readRequiredMarker(this.activePath);
+    assertIdentity(marker, {
+      botId: state.workspaceOwnerBotId,
+      workspaceId: state.workspaceId,
+    }, 'active Skill workspace');
+  }
+
+  private persistJournal(
+    state: BotSkillWorkspaceState,
+    journal: BotSkillWorkspaceSwitchJournal,
+  ): void {
+    this.writeState({
+      ...state,
+      revision: state.revision + 1,
+      switchJournal: { ...journal },
+    });
+    state.revision += 1;
+    this.phaseHook?.(journal.phase);
+  }
+
+  private ensureManagedRoots(): void {
+    const dataParent = path.join(this.runtimeRoot, 'data');
+    this.ensureManagedDirectory(dataParent, 'runtime data directory');
+    this.ensureManagedDirectory(this.dataRoot, 'Bot Skill workspace data root');
+    this.ensureManagedDirectory(this.parkedRoot, 'parked Skill workspace root');
+  }
+
+  private ensureManagedDirectory(target: string, label: string): void {
+    if (fs.existsSync(target)) {
+      this.assertDirectoryIsSafe(target, label);
+      return;
+    }
+    fs.mkdirSync(target, { recursive: false, mode: 0o700 });
+    this.assertDirectoryIsSafe(target, label);
+  }
+
+  private hasParkedWorkspaces(): boolean {
+    if (!fs.existsSync(this.parkedRoot)) return false;
+    return fs.readdirSync(this.parkedRoot).length > 0;
+  }
+
+  private createMarker(workspacePath: string, botId: string): BotSkillWorkspaceMarker {
+    const marker: BotSkillWorkspaceMarker = {
+      schema: BOT_SKILL_WORKSPACE_MARKER_SCHEMA,
+      workspaceOwnerBotId: normalizeBotId(botId),
+      workspaceId: crypto.randomUUID(),
+      createdAt: new Date().toISOString(),
+    };
+    atomicWriteJson(path.join(workspacePath, MARKER_FILE), marker);
+    return marker;
+  }
+
+  private readMarker(workspacePath: string): BotSkillWorkspaceMarker | undefined {
+    if (!fs.existsSync(workspacePath)) return undefined;
+    this.assertDirectoryIsSafe(workspacePath, 'Skill workspace');
+    const markerPath = path.join(workspacePath, MARKER_FILE);
+    if (!fs.existsSync(markerPath)) return undefined;
+    return parseMarker(readJsonFile(markerPath));
+  }
+
+  private readRequiredMarker(workspacePath: string): BotSkillWorkspaceMarker {
+    const marker = this.readMarker(workspacePath);
+    if (!marker) throw new Error(`Skill workspace marker is missing: ${workspacePath}`);
+    return marker;
+  }
+
+  private writeState(state: BotSkillWorkspaceState): void {
+    this.ensureManagedRoots();
+    atomicWriteJson(this.statePath, state);
+  }
+
+  private withLock<T>(
+    action: () => T,
+    existingLock?: BotSkillWorkspaceActivationLock,
+  ): T {
+    this.ensureManagedRoots();
+    if (existingLock) {
+      const owner = readLockOwner(this.lockPath);
+      if (
+        !owner ||
+        owner.lockId !== existingLock.lockId ||
+        owner.pid !== process.pid
+      ) {
+        throw new Error('Bot Skill workspace activation lock is no longer owned by this process.');
+      }
+      return action();
+    }
+    const lockId = this.acquireLock();
+    try {
+      return action();
+    } finally {
+      this.releaseLock(lockId);
+    }
+  }
+
+  private acquireLock(): string {
+    const lockId = crypto.randomUUID();
+    try {
+      fs.mkdirSync(this.lockPath, { mode: 0o700 });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+      const owner = readLockOwner(this.lockPath);
+      if (!owner) {
+        const ageMs = Date.now() - fs.statSync(this.lockPath).mtimeMs;
+        if (ageMs < 30_000) {
+          throw new Error('Bot Skill workspace switch lock is being initialized.');
+        }
+      } else if (isProcessAlive(owner.pid)) {
+        throw new Error(`Bot Skill workspace switch is already locked by pid ${owner.pid}.`);
+      }
+      const stalePath = `${this.lockPath}.stale.${crypto.randomUUID()}`;
+      try {
+        fs.renameSync(this.lockPath, stalePath);
+      } catch {
+        throw new Error('Bot Skill workspace switch lock changed while checking stale ownership.');
+      }
+      fs.rmSync(stalePath, { recursive: true, force: true });
+      fs.mkdirSync(this.lockPath, { mode: 0o700 });
+    }
+    try {
+      atomicWriteJson(path.join(this.lockPath, 'owner.json'), {
+        lockId,
+        pid: process.pid,
+        acquiredAt: new Date().toISOString(),
+      });
+    } catch (error) {
+      fs.rmSync(this.lockPath, { recursive: true, force: true });
+      throw error;
+    }
+    return lockId;
+  }
+
+  private releaseLock(lockId: string): void {
+    const owner = readLockOwner(this.lockPath);
+    if (owner?.lockId === lockId && owner.pid === process.pid) {
+      fs.rmSync(this.lockPath, { recursive: true, force: true });
+    }
+  }
+
+  private assertSafeRoot(target: string, label: string): void {
+    if (!fs.existsSync(target)) return;
+    this.assertDirectoryIsSafe(target, label);
+  }
+
+  private assertDirectoryIsSafe(target: string, label: string): void {
+    const stat = fs.lstatSync(target);
+    if (!stat.isDirectory() || stat.isSymbolicLink()) {
+      throw new Error(`${label} must be a real directory, not a symlink or file: ${target}`);
+    }
+    const resolved = path.resolve(target);
+    if (resolved !== this.runtimeRoot && !resolved.startsWith(`${this.runtimeRoot}${path.sep}`)) {
+      throw new Error(`${label} escapes the runtime root: ${target}`);
+    }
+    const realRuntimeRoot = fs.realpathSync.native(this.runtimeRoot);
+    const realTarget = fs.realpathSync.native(target);
+    const relative = path.relative(realRuntimeRoot, realTarget);
+    if (relative === '..' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+      throw new Error(`${label} resolves outside the runtime root: ${target}`);
+    }
+    if (!samePath(resolved, realTarget)) {
+      throw new Error(`${label} traverses a symlink or junction: ${target}`);
+    }
+  }
+}
+
+export function createBotSkillWorkspaceService(
+  options: BotSkillWorkspaceServiceOptions,
+): BotSkillWorkspaceService {
+  return new BotSkillWorkspaceService(options);
+}
+
+function normalizeBotId(botId: string): string {
+  const normalized = String(botId || '').trim();
+  if (!normalized) throw new Error('Bot id is required for Skill workspace ownership.');
+  if (normalized.length > 512 || /[\0\r\n]/.test(normalized)) {
+    throw new Error('Bot id is invalid for Skill workspace ownership.');
+  }
+  return normalized;
+}
+
+function atomicWriteJson(filePath: string, value: unknown): void {
+  const parent = path.dirname(filePath);
+  fs.mkdirSync(parent, { recursive: true, mode: 0o700 });
+  const tempPath = path.join(parent, `.${path.basename(filePath)}.${process.pid}.${crypto.randomUUID()}.tmp`);
+  fs.writeFileSync(tempPath, `${JSON.stringify(value, null, 2)}\n`, {
+    encoding: 'utf8',
+    mode: 0o600,
+    flag: 'wx',
+  });
+  try {
+    fs.renameSync(tempPath, filePath);
+    if (process.platform !== 'win32') {
+      try {
+        fs.chmodSync(filePath, 0o600);
+      } catch {
+        // Rename is the commit point; permission hardening must not report a
+        // committed metadata write as failed.
+      }
+    }
+  } catch (error) {
+    fs.rmSync(tempPath, { force: true });
+    throw error;
+  }
+}
+
+function readJsonFile(filePath: string): unknown {
+  const stat = fs.lstatSync(filePath);
+  if (!stat.isFile() || stat.isSymbolicLink() || stat.size > MAX_JSON_BYTES) {
+    throw new Error(`Bot Skill workspace metadata is invalid or too large: ${filePath}`);
+  }
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Bot Skill workspace metadata is not valid JSON: ${filePath}: ${message}`);
+  }
+}
+
+function parseMarker(value: unknown): BotSkillWorkspaceMarker {
+  const marker = value as Partial<BotSkillWorkspaceMarker>;
+  if (
+    !marker ||
+    marker.schema !== BOT_SKILL_WORKSPACE_MARKER_SCHEMA ||
+    typeof marker.workspaceOwnerBotId !== 'string' ||
+    !marker.workspaceOwnerBotId.trim() ||
+    typeof marker.workspaceId !== 'string' ||
+    !marker.workspaceId.trim() ||
+    typeof marker.createdAt !== 'string'
+  ) {
+    throw new Error('Bot Skill workspace marker has an unsupported schema or invalid fields.');
+  }
+  return marker as BotSkillWorkspaceMarker;
+}
+
+function parseState(value: unknown): BotSkillWorkspaceState {
+  const state = value as Partial<BotSkillWorkspaceState>;
+  if (
+    !state ||
+    state.schema !== BOT_SKILL_WORKSPACE_STATE_SCHEMA ||
+    !Number.isInteger(state.revision) ||
+    Number(state.revision) < 1 ||
+    typeof state.workspaceOwnerBotId !== 'string' ||
+    !state.workspaceOwnerBotId.trim() ||
+    typeof state.workspaceId !== 'string' ||
+    !state.workspaceId.trim()
+  ) {
+    throw new Error('Bot Skill workspace state has an unsupported schema or invalid fields.');
+  }
+  if (state.switchJournal) {
+    const journal = state.switchJournal as Partial<BotSkillWorkspaceSwitchJournal>;
+    if (
+      typeof journal.transactionId !== 'string' ||
+      !journal.transactionId ||
+      !journal.from ||
+      !journal.to ||
+      typeof journal.from.botId !== 'string' ||
+      typeof journal.from.workspaceId !== 'string' ||
+      typeof journal.to.botId !== 'string' ||
+      typeof journal.to.workspaceId !== 'string' ||
+      !['prepared', 'source-parked', 'target-active'].includes(String(journal.phase)) ||
+      typeof journal.targetWasCreated !== 'boolean' ||
+      typeof journal.startedAt !== 'string'
+    ) {
+      throw new Error('Bot Skill workspace switch journal has invalid fields.');
+    }
+    if (
+      journal.from.botId !== state.workspaceOwnerBotId ||
+      journal.from.workspaceId !== state.workspaceId ||
+      journal.from.botId === journal.to.botId
+    ) {
+      throw new Error('Bot Skill workspace switch journal is inconsistent with committed state.');
+    }
+  }
+  return state as BotSkillWorkspaceState;
+}
+
+function assertIdentity(
+  marker: BotSkillWorkspaceMarker,
+  identity: BotSkillWorkspaceIdentity,
+  label: string,
+): void {
+  if (
+    marker.workspaceOwnerBotId !== identity.botId ||
+    marker.workspaceId !== identity.workspaceId
+  ) {
+    throw new Error(`${label} identity does not match workspace state.`);
+  }
+}
+
+function markerMatches(
+  marker: BotSkillWorkspaceMarker | undefined,
+  identity: BotSkillWorkspaceIdentity,
+): boolean {
+  return Boolean(
+    marker &&
+    marker.workspaceOwnerBotId === identity.botId &&
+    marker.workspaceId === identity.workspaceId,
+  );
+}
+
+function readLockOwner(lockPath: string): { lockId: string; pid: number } | undefined {
+  const ownerPath = path.join(lockPath, 'owner.json');
+  if (!fs.existsSync(ownerPath)) return undefined;
+  try {
+    const value = readJsonFile(ownerPath) as { lockId?: unknown; pid?: unknown };
+    if (typeof value.lockId === 'string' && Number.isInteger(value.pid) && Number(value.pid) > 0) {
+      return { lockId: value.lockId, pid: Number(value.pid) };
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+function samePath(left: string, right: string): boolean {
+  const normalizedLeft = path.resolve(left);
+  const normalizedRight = path.resolve(right);
+  return process.platform === 'win32'
+    ? normalizedLeft.toLowerCase() === normalizedRight.toLowerCase()
+    : normalizedLeft === normalizedRight;
+}

--- a/src/commands/catscompany.ts
+++ b/src/commands/catscompany.ts
@@ -17,6 +17,9 @@ import {
 } from '../bot-definition/cloud-client';
 import { CloudBotModelRuntimeReloadController } from '../bot-definition/runtime-reload';
 import { createBotDefinitionSyncService } from '../bot-definition/service';
+import { createBotSkillWorkspaceService } from '../bot-skills/workspace-service';
+import { recoverBotSkillActivation } from '../bot-skills/activation-recovery';
+import * as fs from 'node:fs';
 
 const CONNECTOR_OWNER_POLL_MS = 2000;
 const CLOUD_MODEL_POLL_MS = 5000;
@@ -42,10 +45,26 @@ export function resolveCatsCoCommandConfig(
  */
 export async function catscompanyCommand(): Promise<void> {
   const runtimeRoot = PathResolver.getRuntimeDataRoot();
+  const localConfigService = createCatsCoLocalConfigService({ runtimeRoot });
+  const workspaceService = createBotSkillWorkspaceService({ runtimeRoot });
+  const activationRecovery = recoverBotSkillActivation(runtimeRoot, workspaceService, {
+    expectedLiveTransactionId: process.env.XIAOBA_BOT_SKILL_ACTIVATION_TX,
+  });
+  const configuredBotId = String(localConfigService.load().currentBot?.uid || '').trim();
+  const hadWorkspace = Boolean(workspaceService.readState() || fs.existsSync(workspaceService.activePath));
+  if (configuredBotId && !activationRecovery.pendingTargetBotId && hadWorkspace) {
+    workspaceService.ensureActive(configuredBotId);
+  }
   const preparedBot = await prepareBoundBotDefinition({
     runtimeRoot,
     acknowledgeCloudSelection: false,
   });
+  if (configuredBotId && !activationRecovery.pendingTargetBotId && !hadWorkspace) {
+    workspaceService.ensureActive(configuredBotId, {
+      allowCreate: Array.isArray(preparedBot?.definition.skills) &&
+        preparedBot.definition.skills.length === 0,
+    });
+  }
   if (preparedBot?.cloudRevision !== undefined) {
     Logger.info(`CatsCo bot ${preparedBot.botId} 已准备云端模型配置 revision=${preparedBot.cloudRevision}。`);
   } else if (preparedBot?.initializedDefault) {
@@ -140,6 +159,8 @@ export async function catscompanyCommand(): Promise<void> {
 
   try {
     await bot.start();
+    await bot.waitUntilReady();
+    process.stdout.write('XIAOBA_CONNECTOR_READY\n');
     await startRuntimeCommandSupport();
     const auth = createCatsCoLocalConfigService({ runtimeRoot }).getAuthState();
     const modelBotId = String(preparedBot?.botId || connectorConfig.botUid || '').trim();

--- a/src/dashboard/readiness.ts
+++ b/src/dashboard/readiness.ts
@@ -64,6 +64,7 @@ export interface DashboardReadinessOptions {
   env?: NodeJS.ProcessEnv;
   config?: ChatConfig;
   catsCoOverrides?: Record<string, unknown>;
+  botId?: string;
   now?: Date;
 }
 
@@ -80,7 +81,7 @@ export async function getDashboardReadiness(
   const runtimeRoot = path.resolve(options.runtimeRoot ?? process.cwd());
   const config = options.config ?? {};
   const env = getEffectiveCatsCoRuntimeEnv(runtimeRoot, getEffectiveDashboardEnv(runtimeRoot, options.env), config, options.catsCoOverrides);
-  const modelInputs = resolveReadinessModelInputs(runtimeRoot, env, config);
+  const modelInputs = resolveReadinessModelInputs(runtimeRoot, env, config, options.botId);
   const services = serviceManager.getAll().map(service => getServicePreflight(
     serviceManager,
     service.name,
@@ -115,7 +116,7 @@ export function getServicePreflight(
   const runtimeRoot = path.resolve(options.runtimeRoot ?? process.cwd());
   const config = options.config ?? {};
   const env = getEffectiveCatsCoRuntimeEnv(runtimeRoot, getEffectiveDashboardEnv(runtimeRoot, options.env), config, options.catsCoOverrides);
-  const modelInputs = resolveReadinessModelInputs(runtimeRoot, env, config);
+  const modelInputs = resolveReadinessModelInputs(runtimeRoot, env, config, options.botId);
   const service = serviceManager.getService(name);
   if (!service) {
     throw new Error(`Service "${name}" not found`);
@@ -151,9 +152,14 @@ function resolveReadinessModelInputs(
   runtimeRoot: string,
   env: NodeJS.ProcessEnv,
   config: ChatConfig,
+  botId?: string,
 ): { env: NodeJS.ProcessEnv; config: ChatConfig } {
-  const active = resolveActiveBotLLMConfig({ runtimeRoot, env });
-  if (!active) return { env, config };
+  const active = resolveActiveBotLLMConfig({ runtimeRoot, env, botId });
+  if (!active) {
+    // An explicit target Bot must never inherit the currently bound Bot's
+    // legacy model credentials during switch preflight.
+    return botId ? { env: {}, config: {} } : { env, config };
+  }
 
   // A bound bot is Definition-owned. Hide stale legacy model fields from model
   // readiness while keeping CatsCo account and connector settings available.

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -88,6 +88,13 @@ import {
   type BranchModelRuntime,
 } from '../../core/branch-agent-config';
 import { normalizeReasoningEffort, reasoningEffortOrDefault } from '../../utils/reasoning-effort';
+import * as crypto from 'node:crypto';
+import { createBotSkillWorkspaceService } from '../../bot-skills/workspace-service';
+import {
+  discardBotSkillBindingRollback,
+  persistBotSkillBindingRollback,
+  recoverBotSkillActivation,
+} from '../../bot-skills/activation-recovery';
 import { normalizeOpenAIApiMode, openAIApiModeOrDefault } from '../../utils/openai-api-mode';
 import {
   BindWeixinChannelResult,
@@ -141,6 +148,7 @@ interface CatsBotBindingInput {
   apiKey: string;
   bindingSource?: string;
   selectedCatalogRuntime?: BotCatalogModelRuntime;
+  allowCreateSkillWorkspace?: boolean;
 }
 
 interface CatsRelayModelSetupResult {
@@ -867,26 +875,137 @@ async function commitCatsBotBindingAndStartConnector(
   connectorRestarted: boolean;
   botDefinitionSync?: Record<string, unknown>;
 }> {
+  const runtimeRoot = runtimeDataRoot();
+  const workspaceService = createBotSkillWorkspaceService({ runtimeRoot });
+  const activationLock = workspaceService.acquireActivationLock();
+  try {
+    recoverBotSkillActivation(runtimeRoot, workspaceService, { lock: activationLock });
+  } catch (error) {
+    activationLock.release();
+    throw error;
+  }
   ensureCatsDeviceId();
-  const rollback = createCatsCoLocalConfigRollback();
+  const rollbackBinding = createCatsCoLocalConfigRollback();
+  const localConfigService = createCatsCoLocalConfigService({ runtimeRoot });
+  const previousBotId = String(localConfigService.load().currentBot?.uid || '').trim();
+  let switchTransactionId: string | undefined;
+  let switchChanged = false;
+  let bindingSnapshotPersisted = false;
+  let connectorWasRunning = false;
+  let workspaceCommitted = false;
+  let initialClaimed = false;
+  let restartPreviousConnectorAfterRelease = false;
+  const initialMarkerPath = path.join(workspaceService.activePath, '.xiaoba-bot-workspace.json');
+  const initialMarkerExisted = fs.existsSync(initialMarkerPath);
   try {
     const warnings = await ensureCatsFriendBinding(state, input.userUid, input.botUid, input.apiKey);
-    const updated = writeCatsBotBinding(state, input);
     const preparedBot = await prepareBoundBotDefinition({
-      runtimeRoot: runtimeDataRoot(),
+      runtimeRoot,
       botId: input.botUid,
       selectedCatalogRuntime: input.selectedCatalogRuntime,
       acknowledgeCloudSelection: false,
     });
     const botDefinitionSync = toBotDefinitionSyncPayload(preparedBot?.sync);
-    const {
-      service,
-      preflight: startPreflight,
-      connectorStarted,
-      connectorRestarted,
-    } = await startCatsCompanyConnectorIfReady(serviceManager, {
-      restartIfRunning: true,
-    });
+    const allowCreateSkillWorkspace = input.allowCreateSkillWorkspace === true ||
+      (Array.isArray(preparedBot?.definition.skills) && preparedBot.definition.skills.length === 0);
+
+    const existingService = serviceManager.getService('catscompany');
+    const targetPreflight = existingService
+      ? getServicePreflight(serviceManager, 'catscompany', {
+        runtimeRoot,
+        config: ConfigManager.getConfigReadonly(),
+        botId: input.botUid,
+        catsCoOverrides: {
+          httpBaseUrl: state.httpBaseUrl,
+          serverUrl: state.serverUrl,
+          token: state.token,
+          uid: input.userUid,
+          botUid: input.botUid,
+          apiKey: input.apiKey,
+        },
+      })
+      : undefined;
+    if (targetPreflight?.status === 'blocked') {
+      const error = httpError('CatsCo connector preflight blocked', 400) as Error & { data?: unknown };
+      error.data = {
+        preflight: {
+          status: targetPreflight.status,
+          blockingChecks: targetPreflight.blockingChecks,
+          warningChecks: targetPreflight.warningChecks,
+        },
+      };
+      throw error;
+    }
+
+    const stateBeforeClaim = workspaceService.readState();
+    if (previousBotId) {
+      workspaceService.ensureActive(previousBotId, {
+        allowCreate: false,
+        lock: activationLock,
+      });
+    } else {
+      workspaceService.ensureActive(input.botUid, {
+        allowCreate: allowCreateSkillWorkspace,
+        lock: activationLock,
+      });
+      initialClaimed = !stateBeforeClaim;
+    }
+
+    connectorWasRunning = existingService?.status === 'running';
+    const currentWorkspaceOwner = workspaceService.readState()?.workspaceOwnerBotId;
+    if (currentWorkspaceOwner && currentWorkspaceOwner !== input.botUid) {
+      switchTransactionId = crypto.randomUUID();
+      persistBotSkillBindingRollback(runtimeRoot, switchTransactionId);
+      bindingSnapshotPersisted = true;
+      if (connectorWasRunning) {
+        await serviceManager.stopAndWait('catscompany');
+      }
+      const switching = workspaceService.beginSwitch(input.botUid, {
+        allowCreate: allowCreateSkillWorkspace,
+        transactionId: switchTransactionId,
+        lock: activationLock,
+      });
+      switchChanged = switching.changed;
+    }
+
+    const updated = writeCatsBotBinding(state, input);
+    let service: any;
+    let startPreflight = targetPreflight;
+    let connectorStarted = false;
+    let connectorRestarted = false;
+    if (switchChanged || (initialClaimed && !connectorWasRunning)) {
+      const previousActivationTx = process.env.XIAOBA_BOT_SKILL_ACTIVATION_TX;
+      const liveActivationTransactionId = switchTransactionId ??
+        `initial:${crypto.randomUUID()}`;
+      process.env.XIAOBA_BOT_SKILL_ACTIVATION_TX = liveActivationTransactionId;
+      try {
+        service = existingService
+          ? await (
+            typeof (serviceManager as any).startAndWaitReady === 'function'
+              ? serviceManager.startAndWaitReady('catscompany')
+              : Promise.resolve(serviceManager.start('catscompany'))
+          )
+          : existingService;
+        connectorStarted = Boolean(existingService);
+        connectorRestarted = switchChanged && connectorWasRunning && connectorStarted;
+      } finally {
+        if (previousActivationTx === undefined) {
+          delete process.env.XIAOBA_BOT_SKILL_ACTIVATION_TX;
+        } else {
+          process.env.XIAOBA_BOT_SKILL_ACTIVATION_TX = previousActivationTx;
+        }
+      }
+    } else {
+      ({
+        service,
+        preflight: startPreflight,
+        connectorStarted,
+        connectorRestarted,
+      } = await startCatsCompanyConnectorIfReady(serviceManager, {
+        restartIfRunning: true,
+        preflight: targetPreflight,
+      }));
+    }
     if (startPreflight?.status === 'blocked') {
       const error = httpError('CatsCo connector preflight blocked', 400) as Error & { data?: unknown };
       error.data = {
@@ -898,6 +1017,17 @@ async function commitCatsBotBindingAndStartConnector(
       };
       throw error;
     }
+    if (switchChanged && switchTransactionId) {
+      workspaceService.commitSwitch(switchTransactionId, activationLock);
+      workspaceCommitted = true;
+      try {
+        discardBotSkillBindingRollback(runtimeRoot, switchTransactionId);
+      } catch {
+        // The committed workspace and binding are authoritative. A stale
+        // snapshot is safe to remove during the next startup recovery.
+      }
+      bindingSnapshotPersisted = false;
+    }
     return {
       updated,
       warnings,
@@ -908,8 +1038,66 @@ async function commitCatsBotBindingAndStartConnector(
       botDefinitionSync,
     };
   } catch (error) {
-    rollback();
+    if (workspaceCommitted) throw error;
+    let workspaceRollbackError: unknown;
+    if (switchChanged || initialClaimed) {
+      try {
+        const currentService = serviceManager.getService('catscompany');
+        if (currentService?.status === 'running') {
+          await serviceManager.stopAndWait('catscompany');
+        }
+      } catch (stopError) {
+        workspaceRollbackError = stopError;
+      }
+    }
+    if (!workspaceRollbackError) {
+      rollbackBinding();
+      const journal = workspaceService.readState()?.switchJournal;
+      if (switchTransactionId && journal?.transactionId === switchTransactionId) {
+        try {
+          workspaceService.rollbackSwitch(switchTransactionId, activationLock);
+        } catch (rollbackError) {
+          workspaceRollbackError = rollbackError;
+        }
+      }
+    }
+    if (
+      !workspaceRollbackError &&
+      initialClaimed &&
+      !initialMarkerExisted &&
+      !previousBotId
+    ) {
+      try {
+        workspaceService.releaseInitialClaim(input.botUid, activationLock);
+      } catch (rollbackError) {
+        workspaceRollbackError = rollbackError;
+      }
+    }
+    if (!workspaceRollbackError && bindingSnapshotPersisted) {
+      discardBotSkillBindingRollback(runtimeRoot, switchTransactionId);
+      bindingSnapshotPersisted = false;
+    }
+    restartPreviousConnectorAfterRelease = connectorWasRunning && !workspaceRollbackError;
+    if (workspaceRollbackError) {
+      const message = workspaceRollbackError instanceof Error
+        ? workspaceRollbackError.message
+        : String(workspaceRollbackError);
+      throw new Error(`Bot binding failed and Skill workspace rollback also failed: ${message}`);
+    }
     throw error;
+  } finally {
+    activationLock.release();
+    if (restartPreviousConnectorAfterRelease) {
+      try {
+        const currentService = serviceManager.getService('catscompany');
+        if (currentService && currentService.status !== 'running') {
+          serviceManager.start('catscompany');
+        }
+      } catch {
+        // Restored binding/workspace remains authoritative even if the
+        // best-effort old Connector restart fails.
+      }
+    }
   }
 }
 
@@ -3557,6 +3745,7 @@ export function createApiRouter(
         apiKey,
         bindingSource: 'legacy-setup',
         selectedCatalogRuntime,
+        allowCreateSkillWorkspace: botSelectionSource === 'created-default',
       });
 
       res.json({

--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -6,6 +6,12 @@ import { createApiRouter } from './routes/api';
 import { ServiceManager } from './service-manager';
 import { bootstrapDefaultSkillHubSkillsOnce } from '../skillhub/default-skill-bootstrap';
 import { createDashboardAuth } from './auth';
+import { PathResolver } from '../utils/path-resolver';
+import { createCatsCoLocalConfigService } from '../catscompany/local-config';
+import { createBotSkillWorkspaceService } from '../bot-skills/workspace-service';
+import { recoverBotSkillActivation } from '../bot-skills/activation-recovery';
+import * as fs from 'node:fs';
+import { FileBotDefinitionRepository } from '../bot-definition/repository';
 
 const DEFAULT_PORT = 3800;
 const activeServers: Server[] = [];
@@ -36,7 +42,40 @@ export async function startDashboard(
 
   app.use(express.json({ limit: '25mb' }));
 
-  bootstrapDefaultSkillHubSkillsOnce().catch(error => {
+  const runtimeRoot = PathResolver.getRuntimeDataRoot();
+  const initialBotId = String(
+    createCatsCoLocalConfigService({ runtimeRoot }).load().currentBot?.uid || '',
+  ).trim();
+  const workspaceMetadataExists = fs.existsSync(
+    path.join(runtimeRoot, 'data', 'bot-skills', 'workspace-state.json'),
+  ) || fs.existsSync(
+    path.join(runtimeRoot, 'data', 'bot-skills', 'binding-rollback.json'),
+  );
+  if (initialBotId || workspaceMetadataExists) {
+    const workspaceService = createBotSkillWorkspaceService({ runtimeRoot });
+    recoverBotSkillActivation(runtimeRoot, workspaceService);
+    const recoveredBotId = String(
+      createCatsCoLocalConfigService({ runtimeRoot }).load().currentBot?.uid || '',
+    ).trim();
+    if (!recoveredBotId) {
+      throw new Error('Bot binding disappeared during Skill workspace recovery.');
+    }
+    const hasLocalWorkspace = Boolean(
+      workspaceService.readState() || fs.existsSync(workspaceService.activePath),
+    );
+    if (hasLocalWorkspace) {
+      workspaceService.ensureActive(recoveredBotId);
+    } else {
+      const definitions = new FileBotDefinitionRepository({ runtimeRoot });
+      const definition = definitions.readCache(recoveredBotId) ??
+        definitions.readCanonical(recoveredBotId);
+      workspaceService.ensureActive(recoveredBotId, {
+        allowCreate: Array.isArray(definition?.skills) && definition.skills.length === 0,
+      });
+    }
+  }
+
+  await bootstrapDefaultSkillHubSkillsOnce().catch(error => {
     Logger.warning(`Default SkillHub bootstrap failed: ${error?.message || String(error)}`);
   });
 

--- a/src/dashboard/service-manager.ts
+++ b/src/dashboard/service-manager.ts
@@ -31,6 +31,7 @@ interface ManagedService {
 
 const MAX_LOG_LINES = 500;
 const MAX_LAST_ERROR_LENGTH = 500;
+const CONNECTOR_READY_MARKER = 'XIAOBA_CONNECTOR_READY';
 
 function stripAnsi(value: string): string {
   // eslint-disable-next-line no-control-regex
@@ -307,6 +308,9 @@ export class ServiceManager extends EventEmitter {
     const appendLog = (data: Buffer) => {
       const lines = data.toString().split('\n').filter(l => l.trim());
       svc.logs.push(...lines);
+      if (name === 'catscompany' && lines.some(line => line.includes(CONNECTOR_READY_MARKER))) {
+        this.emit('service-ready', name);
+      }
       if (svc.logs.length > MAX_LOG_LINES) {
         svc.logs = svc.logs.slice(-MAX_LOG_LINES);
       }
@@ -387,6 +391,92 @@ export class ServiceManager extends EventEmitter {
       forceKillTimer.unref?.();
     }
 
+    return this.getService(name)!;
+  }
+
+  async stopAndWait(name: string, timeoutMs: number = 10_000): Promise<ServiceInfo> {
+    const service = this.getService(name);
+    if (!service) throw new Error(`Service "${name}" not found`);
+    if (service.status !== 'running') return service;
+
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const finish = (error?: Error) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        this.off('service-stopped', onStopped);
+        this.off('service-error', onError);
+        if (error) reject(error);
+        else resolve();
+      };
+      const onStopped = (stoppedName: string) => {
+        if (stoppedName === name) finish();
+      };
+      const onError = (failedName: string, error: unknown) => {
+        if (failedName === name) {
+          finish(error instanceof Error ? error : new Error(String(error)));
+        }
+      };
+      const timer = setTimeout(() => {
+        finish(new Error(`Timed out waiting for service "${name}" to stop.`));
+      }, timeoutMs);
+      timer.unref?.();
+      this.on('service-stopped', onStopped);
+      this.on('service-error', onError);
+      try {
+        this.stop(name);
+      } catch (error) {
+        finish(error instanceof Error ? error : new Error(String(error)));
+      }
+    });
+
+    return this.getService(name)!;
+  }
+
+  async startAndWaitReady(name: string, timeoutMs: number = 35_000): Promise<ServiceInfo> {
+    const existing = this.getService(name);
+    if (!existing) throw new Error(`Service "${name}" not found`);
+    if (existing.status === 'running') return existing;
+
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const finish = (error?: Error) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        this.off('service-ready', onReady);
+        this.off('service-stopped', onStopped);
+        this.off('service-error', onError);
+        if (error) reject(error);
+        else resolve();
+      };
+      const onReady = (readyName: string) => {
+        if (readyName === name) finish();
+      };
+      const onStopped = (stoppedName: string, code: number | null) => {
+        if (stoppedName === name) {
+          finish(new Error(`Service "${name}" exited before ready (code ${code ?? 'unknown'}).`));
+        }
+      };
+      const onError = (failedName: string, error: unknown) => {
+        if (failedName === name) {
+          finish(error instanceof Error ? error : new Error(String(error)));
+        }
+      };
+      const timer = setTimeout(() => {
+        finish(new Error(`Timed out waiting for service "${name}" to become ready.`));
+      }, timeoutMs);
+      timer.unref?.();
+      this.on('service-ready', onReady);
+      this.on('service-stopped', onStopped);
+      this.on('service-error', onError);
+      try {
+        this.start(name);
+      } catch (error) {
+        finish(error instanceof Error ? error : new Error(String(error)));
+      }
+    });
     return this.getService(name)!;
   }
 

--- a/tests/bot-skill-activation-recovery.test.ts
+++ b/tests/bot-skill-activation-recovery.test.ts
@@ -1,0 +1,178 @@
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import { createCatsCoLocalConfigService } from '../src/catscompany/local-config';
+import {
+  discardBotSkillBindingRollback,
+  persistBotSkillBindingRollback,
+  recoverBotSkillActivation,
+} from '../src/bot-skills/activation-recovery';
+import { BotSkillWorkspaceService } from '../src/bot-skills/workspace-service';
+
+describe('Bot Skill activation recovery', () => {
+  let runtimeRoot: string;
+
+  beforeEach(() => {
+    runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-bot-activation-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(runtimeRoot, { recursive: true, force: true });
+  });
+
+  test('restores binding and the previous workspace after an interrupted switch', () => {
+    const config = createCatsCoLocalConfigService({ runtimeRoot, env: {} });
+    config.save(botConfig('bot_A', 'key_A'));
+    fs.writeFileSync(
+      path.join(runtimeRoot, '.env'),
+      'UNRELATED_PROVIDER_SECRET=do-not-copy\nCATSCO_BOT_UID=bot_A\nCATSCO_API_KEY=key_A\n',
+    );
+    writeSkill(path.join(runtimeRoot, 'skills'), 'owner', 'A');
+    const workspace = new BotSkillWorkspaceService({ runtimeRoot, env: {} });
+    workspace.ensureActive('bot_A');
+
+    const transactionId = 'tx-recover-A';
+    persistBotSkillBindingRollback(runtimeRoot, transactionId);
+    assert.equal(
+      fs.readFileSync(
+        path.join(runtimeRoot, 'data', 'bot-skills', 'binding-rollback.json'),
+        'utf8',
+      ).includes('do-not-copy'),
+      false,
+    );
+    workspace.beginSwitch('bot_B', { allowCreate: true, transactionId });
+    config.save(botConfig('bot_B', 'key_B'));
+    fs.writeFileSync(
+      path.join(runtimeRoot, '.env'),
+      'UNRELATED_PROVIDER_SECRET=do-not-copy\nCATSCO_BOT_UID=bot_B\nCATSCO_API_KEY=key_B\n',
+    );
+    writeSkill(path.join(runtimeRoot, 'skills'), 'draft', 'B draft');
+
+    const result = recoverBotSkillActivation(runtimeRoot, workspace);
+
+    assert.equal(result.recovered, true);
+    assert.equal(result.restoredBotId, 'bot_A');
+    assert.equal(config.load().currentBot?.uid, 'bot_A');
+    const recoveredEnv = fs.readFileSync(path.join(runtimeRoot, '.env'), 'utf8');
+    assert.match(recoveredEnv, /CATSCO_BOT_UID=bot_A/);
+    assert.match(recoveredEnv, /UNRELATED_PROVIDER_SECRET=do-not-copy/);
+    assert.equal(fs.readFileSync(path.join(runtimeRoot, 'skills', 'owner', 'SKILL.md'), 'utf8'), 'A');
+    assert.equal(
+      fs.readFileSync(path.join(workspace.getParkedPath('bot_B'), 'draft', 'SKILL.md'), 'utf8'),
+      'B draft',
+    );
+    assert.equal(
+      fs.existsSync(path.join(runtimeRoot, 'data', 'bot-skills', 'binding-rollback.json')),
+      false,
+    );
+  });
+
+  test('refuses workspace recovery when the matching binding snapshot is missing', () => {
+    fs.mkdirSync(path.join(runtimeRoot, 'skills'));
+    const workspace = new BotSkillWorkspaceService({ runtimeRoot, env: {} });
+    workspace.ensureActive('bot_A');
+    workspace.beginSwitch('bot_B', {
+      allowCreate: true,
+      transactionId: 'tx-missing-snapshot',
+    });
+
+    assert.throws(
+      () => recoverBotSkillActivation(runtimeRoot, workspace),
+      /missing its binding rollback snapshot/,
+    );
+    assert.equal(workspace.readState()?.switchJournal?.transactionId, 'tx-missing-snapshot');
+  });
+
+  test('discards a stale binding snapshot after the workspace transaction committed', () => {
+    const config = createCatsCoLocalConfigService({ runtimeRoot, env: {} });
+    config.save(botConfig('bot_A', 'key_A'));
+    fs.mkdirSync(path.join(runtimeRoot, 'skills'));
+    const workspace = new BotSkillWorkspaceService({ runtimeRoot, env: {} });
+    workspace.ensureActive('bot_A');
+
+    persistBotSkillBindingRollback(runtimeRoot, 'tx-stale');
+    const result = recoverBotSkillActivation(runtimeRoot, workspace);
+
+    assert.equal(result.recovered, false);
+    assert.equal(
+      fs.existsSync(path.join(runtimeRoot, 'data', 'bot-skills', 'binding-rollback.json')),
+      false,
+    );
+  });
+
+  test('does not discard a snapshot belonging to a different transaction', () => {
+    const config = createCatsCoLocalConfigService({ runtimeRoot, env: {} });
+    config.save(botConfig('bot_A', 'key_A'));
+    persistBotSkillBindingRollback(runtimeRoot, 'tx-A');
+
+    assert.throws(
+      () => discardBotSkillBindingRollback(runtimeRoot, 'tx-B'),
+      /different Bot binding rollback snapshot/,
+    );
+  });
+
+  test('target Connector validates a live parent transaction without rolling it back', () => {
+    const config = createCatsCoLocalConfigService({ runtimeRoot, env: {} });
+    config.save(botConfig('bot_A', 'key_A'));
+    fs.mkdirSync(path.join(runtimeRoot, 'skills'));
+    const workspace = new BotSkillWorkspaceService({ runtimeRoot, env: {} });
+    workspace.ensureActive('bot_A');
+    persistBotSkillBindingRollback(runtimeRoot, 'tx-live');
+    workspace.beginSwitch('bot_B', {
+      allowCreate: true,
+      transactionId: 'tx-live',
+    });
+    config.save(botConfig('bot_B', 'key_B'));
+
+    const result = recoverBotSkillActivation(runtimeRoot, workspace, {
+      expectedLiveTransactionId: 'tx-live',
+    });
+
+    assert.equal(result.recovered, false);
+    assert.equal(result.pendingTargetBotId, 'bot_B');
+    assert.equal(workspace.readState()?.switchJournal?.transactionId, 'tx-live');
+  });
+
+  test('first-binding Connector validates a stable initial claim while the parent lock is held', () => {
+    const config = createCatsCoLocalConfigService({ runtimeRoot, env: {} });
+    config.save(botConfig('bot_A', 'key_A'));
+    fs.mkdirSync(path.join(runtimeRoot, 'skills'));
+    const workspace = new BotSkillWorkspaceService({ runtimeRoot, env: {} });
+    const lock = workspace.acquireActivationLock();
+    try {
+      workspace.ensureActive('bot_A', { lock });
+      const result = recoverBotSkillActivation(runtimeRoot, workspace, {
+        expectedLiveTransactionId: 'initial:test-token',
+      });
+      assert.equal(result.pendingTargetBotId, 'bot_A');
+      assert.equal(workspace.readState()?.workspaceOwnerBotId, 'bot_A');
+    } finally {
+      lock.release();
+    }
+  });
+});
+
+function botConfig(botId: string, apiKey: string) {
+  return {
+    version: 1 as const,
+    currentBot: {
+      uid: botId,
+      apiKey,
+      boundByUserUid: 'user-1',
+      bindingSource: 'test',
+    },
+    device: {
+      deviceId: 'device-1',
+      bodyId: 'device-1',
+      installationId: 'device-1',
+    },
+  };
+}
+
+function writeSkill(skillsRoot: string, name: string, content: string): void {
+  const skillPath = path.join(skillsRoot, name);
+  fs.mkdirSync(skillPath, { recursive: true });
+  fs.writeFileSync(path.join(skillPath, 'SKILL.md'), content, 'utf8');
+}

--- a/tests/bot-skill-workspace.test.ts
+++ b/tests/bot-skill-workspace.test.ts
@@ -1,0 +1,264 @@
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import {
+  BOT_SKILL_WORKSPACE_MARKER_SCHEMA,
+  BotSkillWorkspaceService,
+} from '../src/bot-skills/workspace-service';
+
+describe('BotSkillWorkspaceService', () => {
+  let runtimeRoot: string;
+
+  beforeEach(() => {
+    runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-bot-workspace-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(runtimeRoot, { recursive: true, force: true });
+  });
+
+  test('claims an existing legacy skills directory without moving offline edits', () => {
+    const activePath = path.join(runtimeRoot, 'skills');
+    writeSkill(activePath, 'offline-edit', 'belongs to bot A');
+
+    const service = new BotSkillWorkspaceService({ runtimeRoot, env: {} });
+    const state = service.ensureActive('bot_A');
+
+    assert.equal(state.workspaceOwnerBotId, 'bot_A');
+    assert.equal(fs.readFileSync(path.join(activePath, 'offline-edit', 'SKILL.md'), 'utf8'), 'belongs to bot A');
+    const marker = JSON.parse(fs.readFileSync(path.join(activePath, '.xiaoba-bot-workspace.json'), 'utf8'));
+    assert.equal(marker.schema, BOT_SKILL_WORKSPACE_MARKER_SCHEMA);
+    assert.equal(marker.workspaceOwnerBotId, 'bot_A');
+  });
+
+  test('isolates same-named skills across Bot workspaces', () => {
+    const activePath = path.join(runtimeRoot, 'skills');
+    writeSkill(activePath, 'shared-name', 'A content');
+    const service = new BotSkillWorkspaceService({ runtimeRoot, env: {} });
+    service.ensureActive('bot_A');
+
+    const toB = service.beginSwitch('bot_B', { allowCreate: true });
+    assert.equal(toB.changed, true);
+    writeSkill(activePath, 'shared-name', 'B content');
+    service.commitSwitch(toB.transactionId!);
+
+    const toA = service.beginSwitch('bot_A');
+    assert.equal(fs.readFileSync(path.join(activePath, 'shared-name', 'SKILL.md'), 'utf8'), 'A content');
+    service.commitSwitch(toA.transactionId!);
+
+    const backToB = service.beginSwitch('bot_B');
+    assert.equal(fs.readFileSync(path.join(activePath, 'shared-name', 'SKILL.md'), 'utf8'), 'B content');
+    service.commitSwitch(backToB.transactionId!);
+  });
+
+  test('does not treat a missing target workspace as an empty workspace', () => {
+    fs.mkdirSync(path.join(runtimeRoot, 'skills'));
+    const service = new BotSkillWorkspaceService({ runtimeRoot, env: {} });
+    service.ensureActive('bot_A');
+
+    assert.throws(
+      () => service.beginSwitch('bot_B'),
+      /No local Skill workspace exists/,
+    );
+    assert.equal(service.readState()?.workspaceOwnerBotId, 'bot_A');
+    assert.equal(fs.existsSync(path.join(runtimeRoot, 'skills')), true);
+  });
+
+  test('same Bot activation is idempotent', () => {
+    fs.mkdirSync(path.join(runtimeRoot, 'skills'));
+    const service = new BotSkillWorkspaceService({ runtimeRoot, env: {} });
+    const first = service.ensureActive('bot_A');
+    const second = service.beginSwitch('bot_A');
+
+    assert.equal(second.changed, false);
+    assert.equal(service.readState()?.workspaceId, first.workspaceId);
+  });
+
+  for (const crashPhase of ['prepared', 'source-parked', 'target-active'] as const) {
+    test(`recovers the previous Bot after a crash at ${crashPhase}`, () => {
+      const activePath = path.join(runtimeRoot, 'skills');
+      writeSkill(activePath, 'owner', 'A');
+      new BotSkillWorkspaceService({ runtimeRoot, env: {} }).ensureActive('bot_A');
+
+      const crashing = new BotSkillWorkspaceService({
+        runtimeRoot,
+        env: {},
+        onPhasePersisted: phase => {
+          if (phase === crashPhase) throw new Error(`crash:${phase}`);
+        },
+      });
+      assert.throws(
+        () => crashing.beginSwitch('bot_B', { allowCreate: true }),
+        new RegExp(`crash:${crashPhase}`),
+      );
+
+      const recovered = new BotSkillWorkspaceService({ runtimeRoot, env: {} }).recoverInterruptedSwitch();
+      assert.equal(recovered?.workspaceOwnerBotId, 'bot_A');
+      assert.equal(recovered?.switchJournal, undefined);
+      assert.equal(fs.readFileSync(path.join(activePath, 'owner', 'SKILL.md'), 'utf8'), 'A');
+    });
+  }
+
+  test('rollback returns the target workspace to parking without losing changes', () => {
+    const activePath = path.join(runtimeRoot, 'skills');
+    writeSkill(activePath, 'owner', 'A');
+    const service = new BotSkillWorkspaceService({ runtimeRoot, env: {} });
+    service.ensureActive('bot_A');
+    const switching = service.beginSwitch('bot_B', { allowCreate: true });
+    writeSkill(activePath, 'draft', 'B draft');
+
+    service.rollbackSwitch(switching.transactionId);
+
+    assert.equal(fs.readFileSync(path.join(activePath, 'owner', 'SKILL.md'), 'utf8'), 'A');
+    assert.equal(
+      fs.readFileSync(path.join(service.getParkedPath('bot_B'), 'draft', 'SKILL.md'), 'utf8'),
+      'B draft',
+    );
+  });
+
+  test('hashes hostile Bot ids instead of placing them in paths', () => {
+    fs.mkdirSync(path.join(runtimeRoot, 'skills'));
+    const service = new BotSkillWorkspaceService({ runtimeRoot, env: {} });
+    service.ensureActive('bot_A');
+    const hostile = '..\\CON/../../other';
+    const parkedPath = service.getParkedPath(hostile);
+
+    assert.equal(path.dirname(parkedPath), path.join(runtimeRoot, 'data', 'bot-skills', 'by-bot'));
+    assert.match(path.basename(parkedPath), /^b_[a-f0-9]{64}$/);
+    const switching = service.beginSwitch(hostile, { allowCreate: true });
+    service.commitSwitch(switching.transactionId!);
+    assert.equal(service.readState()?.workspaceOwnerBotId, hostile);
+  });
+
+  test('rejects an external XIAOBA_SKILLS_DIR override', () => {
+    assert.throws(
+      () => new BotSkillWorkspaceService({
+        runtimeRoot,
+        env: { XIAOBA_SKILLS_DIR: path.join(runtimeRoot, 'external-skills') },
+      }),
+      /require XIAOBA_SKILLS_DIR/,
+    );
+  });
+
+  test('does not merge into an existing source parking destination', () => {
+    fs.mkdirSync(path.join(runtimeRoot, 'skills'));
+    const service = new BotSkillWorkspaceService({ runtimeRoot, env: {} });
+    service.ensureActive('bot_A');
+    const sourceParked = service.getParkedPath('bot_A');
+    fs.mkdirSync(sourceParked, { recursive: true });
+
+    assert.throws(
+      () => service.beginSwitch('bot_B', { allowCreate: true }),
+      /destination already exists/,
+    );
+    assert.equal(service.readState()?.workspaceOwnerBotId, 'bot_A');
+  });
+
+  test('holds the activation lock across begin and commit so another caller cannot rollback it', () => {
+    fs.mkdirSync(path.join(runtimeRoot, 'skills'));
+    const first = new BotSkillWorkspaceService({ runtimeRoot, env: {} });
+    const lock = first.acquireActivationLock();
+    try {
+      first.ensureActive('bot_A', { lock });
+      const switching = first.beginSwitch('bot_B', {
+        allowCreate: true,
+        transactionId: 'tx-live-switch',
+        lock,
+      });
+
+      const second = new BotSkillWorkspaceService({ runtimeRoot, env: {} });
+      assert.throws(
+        () => second.recoverInterruptedSwitch(),
+        /already locked/,
+      );
+      assert.equal(first.readState()?.switchJournal?.transactionId, 'tx-live-switch');
+      assert.equal(
+        first.assertPendingTarget('tx-live-switch', 'bot_B').to.botId,
+        'bot_B',
+      );
+      first.commitSwitch(switching.transactionId!, lock);
+    } finally {
+      lock.release();
+    }
+
+    assert.equal(first.readState()?.workspaceOwnerBotId, 'bot_B');
+  });
+
+  test('can release a failed first claim without deleting shared Skill content', () => {
+    writeSkill(path.join(runtimeRoot, 'skills'), 'legacy', 'keep me');
+    const service = new BotSkillWorkspaceService({ runtimeRoot, env: {} });
+    const lock = service.acquireActivationLock();
+    try {
+      service.ensureActive('bot_A', { lock });
+      service.releaseInitialClaim('bot_A', lock);
+    } finally {
+      lock.release();
+    }
+
+    assert.equal(service.readState(), undefined);
+    assert.equal(
+      fs.readFileSync(path.join(runtimeRoot, 'skills', 'legacy', 'SKILL.md'), 'utf8'),
+      'keep me',
+    );
+    assert.equal(
+      fs.existsSync(path.join(runtimeRoot, 'skills', '.xiaoba-bot-workspace.json')),
+      false,
+    );
+  });
+
+  test('rejects a data-directory symlink or junction before writing outside runtimeRoot', () => {
+    const external = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-bot-workspace-external-'));
+    try {
+      fs.symlinkSync(
+        external,
+        path.join(runtimeRoot, 'data'),
+        process.platform === 'win32' ? 'junction' : 'dir',
+      );
+      const service = new BotSkillWorkspaceService({ runtimeRoot, env: {} });
+      assert.throws(
+        () => service.ensureActive('bot_A', { allowCreate: true }),
+        /real directory|symlink|junction/,
+      );
+      assert.equal(fs.existsSync(path.join(external, 'bot-skills')), false);
+    } finally {
+      fs.rmSync(external, { recursive: true, force: true });
+    }
+  });
+
+  test('does not overwrite an unmarked active directory during recovery', () => {
+    fs.mkdirSync(path.join(runtimeRoot, 'skills'));
+    new BotSkillWorkspaceService({ runtimeRoot, env: {} }).ensureActive('bot_A');
+    const crashing = new BotSkillWorkspaceService({
+      runtimeRoot,
+      env: {},
+      onPhasePersisted: phase => {
+        if (phase === 'source-parked') throw new Error('crash');
+      },
+    });
+    assert.throws(
+      () => crashing.beginSwitch('bot_B', { allowCreate: true }),
+      /crash/,
+    );
+    fs.mkdirSync(path.join(runtimeRoot, 'skills'));
+    fs.writeFileSync(path.join(runtimeRoot, 'skills', 'unowned.txt'), 'do not overwrite');
+
+    const service = new BotSkillWorkspaceService({ runtimeRoot, env: {} });
+    assert.throws(
+      () => service.recoverInterruptedSwitch(),
+      /ambiguous/,
+    );
+    assert.equal(
+      fs.readFileSync(path.join(runtimeRoot, 'skills', 'unowned.txt'), 'utf8'),
+      'do not overwrite',
+    );
+    assert.ok(service.readState()?.switchJournal);
+  });
+});
+
+function writeSkill(skillsRoot: string, name: string, content: string): void {
+  const skillPath = path.join(skillsRoot, name);
+  fs.mkdirSync(skillPath, { recursive: true });
+  fs.writeFileSync(path.join(skillPath, 'SKILL.md'), content, 'utf8');
+}

--- a/tests/dashboard-catsco-auth-status.test.ts
+++ b/tests/dashboard-catsco-auth-status.test.ts
@@ -12,6 +12,7 @@ import { FileBotCatalogModelRuntimeRepository, FileBotDefinitionRepository } fro
 import { createBotDefinitionSyncService } from '../src/bot-definition/service';
 import { resolveActiveBotLLMConfig } from '../src/bot-definition/llm-config-resolver';
 import { BOT_CATALOG_MODEL_RUNTIME_SCHEMA, BOT_DEFINITION_SCHEMA } from '../src/bot-definition/types';
+import { BotSkillWorkspaceService } from '../src/bot-skills/workspace-service';
 
 describe('dashboard CatsCo account status', () => {
   let testRoot: string;
@@ -68,6 +69,7 @@ describe('dashboard CatsCo account status', () => {
     originalCwd = process.cwd();
     testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-dashboard-catsco-auth-'));
     process.chdir(testRoot);
+    fs.mkdirSync(path.join(testRoot, 'skills'));
 
     for (const key of envKeys) {
       originalEnv[key] = process.env[key];
@@ -1026,6 +1028,173 @@ describe('dashboard CatsCo account status', () => {
     assert.equal(data.data?.preflight?.blockingChecks.includes('runtime.command'), true);
     assert.equal(localConfig.load().currentBot?.uid, '188');
     assert.equal(restartCalled, 0);
+  });
+
+  test('POST /cats/switch-bot parks offline edits and activates only the target Bot workspace', async () => {
+    if (dashboardServer) {
+      await close(dashboardServer);
+      dashboardServer = undefined;
+    }
+
+    const service = {
+      name: 'catscompany',
+      label: 'CatsCo agent',
+      command: process.execPath,
+      args: [],
+      status: 'running',
+    };
+    let stopCalled = 0;
+    let readyStartCalled = 0;
+    let recoveryStartCalled = 0;
+    let failBeforeReady = true;
+    const dashboardApp = express();
+    dashboardApp.use(express.json());
+    dashboardApp.use('/api', createApiRouter({
+      getAll: () => [service],
+      getService: (name: string) => (name === 'catscompany' ? service : undefined),
+      stopAndWait: async () => {
+        stopCalled += 1;
+        service.status = 'stopped';
+        return service;
+      },
+      start: () => {
+        recoveryStartCalled += 1;
+        service.status = 'running';
+        return service;
+      },
+      startAndWaitReady: async () => {
+        readyStartCalled += 1;
+        if (failBeforeReady) {
+          service.status = 'error';
+          throw new Error('connector exited before ready');
+        }
+        service.status = 'running';
+        return service;
+      },
+    } as any));
+    dashboardServer = await listen(dashboardApp);
+    dashboardBaseUrl = serverBaseUrl(dashboardServer);
+
+    await startCatsServer((req, res) => {
+      if (req.path === '/api/me') {
+        return res.json({ uid: 88, username: 'fresh', display_name: 'Fresh User' });
+      }
+      if (req.path === '/api/bots' && req.method === 'GET') {
+        return res.json({
+          bots: [{ uid: 199, username: 'target-agent', display_name: 'Target Agent', api_key: 'target-key' }],
+        });
+      }
+      if (req.path === '/api/friends/request' || req.path === '/api/friends/accept') {
+        return res.json({ ok: true });
+      }
+      return res.status(404).json({ error: 'not found' });
+    });
+
+    const localConfig = createCatsCoLocalConfigService({ runtimeRoot: testRoot });
+    localConfig.save({
+      version: 1,
+      endpoints: { httpBaseUrl: catsBaseUrl, serverUrl: 'wss://app.catsco.cc/v0/channels' },
+      account: { token: 'user-token', uid: '88', username: 'fresh', displayName: 'Fresh User' },
+      currentBot: {
+        uid: '188',
+        name: 'Active Agent',
+        apiKey: 'active-key',
+        boundByUserUid: '88',
+        bindingSource: 'test',
+      },
+      device: { deviceId: 'device-1', bodyId: 'body-1', installationId: 'install-1' },
+    });
+    const activeSkill = path.join(testRoot, 'skills', 'same-name');
+    fs.mkdirSync(activeSkill, { recursive: true });
+    fs.writeFileSync(path.join(activeSkill, 'SKILL.md'), 'offline edit from A');
+    const workspace = new BotSkillWorkspaceService({ runtimeRoot: testRoot, env: {} });
+    workspace.ensureActive('188');
+
+    const definitions = new FileBotDefinitionRepository({ runtimeRoot: testRoot });
+    definitions.writeCanonical({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: '188',
+      model: { kind: 'catalog', modelId: 'minimax-m3' },
+      skills: [],
+    });
+    definitions.writeCache({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: '188',
+      model: { kind: 'catalog', modelId: 'minimax-m3' },
+      skills: [],
+    });
+    definitions.writeCanonical({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: '199',
+      model: { kind: 'catalog', modelId: 'minimax-m3' },
+      skills: [],
+    });
+    definitions.writeCache({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: '199',
+      model: { kind: 'catalog', modelId: 'minimax-m3' },
+      skills: [],
+    });
+    const runtimes = new FileBotCatalogModelRuntimeRepository({ runtimeRoot: testRoot });
+    runtimes.write({
+      schema: BOT_CATALOG_MODEL_RUNTIME_SCHEMA,
+      botId: '188',
+      modelId: 'minimax-m3',
+      provider: 'anthropic',
+      apiBase: 'https://relay.example.test/anthropic',
+      apiKey: 'sk-active-runtime',
+      model: 'MiniMax-M3',
+      contextWindowTokens: 200000,
+      reasoningEffort: 'high',
+    });
+    const targetRuntime = {
+      schema: BOT_CATALOG_MODEL_RUNTIME_SCHEMA,
+      botId: '199',
+      modelId: 'minimax-m3',
+      provider: 'anthropic',
+      apiBase: 'https://relay.example.test/anthropic',
+      apiKey: 'sk-target-runtime',
+      model: 'MiniMax-M3',
+      contextWindowTokens: 200000,
+      reasoningEffort: 'high',
+    } as const;
+
+    const switchRequest = () => fetch(`${dashboardBaseUrl}/api/cats/switch-bot`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        httpBaseUrl: catsBaseUrl,
+        serverUrl: 'wss://app.catsco.cc/v0/channels',
+        botUid: '199',
+      }),
+    });
+    runtimes.write(targetRuntime);
+    const failedResponse = await switchRequest();
+    const failedText = await failedResponse.text();
+
+    assert.equal(failedResponse.status, 500, failedText);
+    assert.equal(localConfig.load().currentBot?.uid, '188');
+    assert.equal(workspace.readState()?.workspaceOwnerBotId, '188');
+    assert.equal(
+      fs.readFileSync(path.join(testRoot, 'skills', 'same-name', 'SKILL.md'), 'utf8'),
+      'offline edit from A',
+    );
+    assert.equal(recoveryStartCalled, 1);
+
+    failBeforeReady = false;
+    const response = await switchRequest();
+    const text = await response.text();
+
+    assert.equal(response.status, 200, text);
+    assert.equal(localConfig.load().currentBot?.uid, '199');
+    assert.equal(workspace.readState()?.workspaceOwnerBotId, '199');
+    assert.equal(fs.existsSync(path.join(testRoot, 'skills', 'same-name')), false);
+    assert.equal(
+      fs.readFileSync(path.join(workspace.getParkedPath('188'), 'same-name', 'SKILL.md'), 'utf8'),
+      'offline edit from A',
+    );
+    assert.equal(stopCalled, 2);
+    assert.equal(readyStartCalled, 2);
   });
 
   test('PUT /model/reasoning-effort accepts and normalizes a legacy catalog runtime alias', async () => {

--- a/tests/dashboard-service-manager.test.ts
+++ b/tests/dashboard-service-manager.test.ts
@@ -231,6 +231,35 @@ describe('dashboard service manager', () => {
     assert.equal(service?.status, 'stopped');
     assert.equal(service?.lastError, undefined);
   });
+
+  test('waits for the Connector ready marker before resolving startup', async () => {
+    const manager = new ServiceManager(process.cwd());
+    const serviceRecord = (manager as any).services.get('catscompany');
+    serviceRecord.info.command = process.execPath;
+    serviceRecord.info.args = [
+      '-e',
+      "setTimeout(() => console.log('XIAOBA_CONNECTOR_READY'), 50); setTimeout(() => process.exit(0), 150);",
+    ];
+
+    const startedAt = Date.now();
+    await manager.startAndWaitReady('catscompany', 5000);
+    assert.ok(Date.now() - startedAt >= 35);
+    assert.equal(manager.getService('catscompany')?.status, 'running');
+    await new Promise<void>(resolve => manager.once('service-stopped', () => resolve()));
+  });
+
+  test('rejects when the Connector exits before its ready marker', async () => {
+    const manager = new ServiceManager(process.cwd());
+    const serviceRecord = (manager as any).services.get('catscompany');
+    serviceRecord.info.command = process.execPath;
+    serviceRecord.info.args = ['-e', 'process.exit(23);'];
+
+    await assert.rejects(
+      () => manager.startAndWaitReady('catscompany', 5000),
+      /exited before ready/,
+    );
+    assert.equal(manager.getService('catscompany')?.status, 'error');
+  });
 });
 
 function normalize(value: string): string {


### PR DESCRIPTION
## 为什么做

当前所有 Bot 共用 `<runtimeRoot>/skills/`，导致切换 Bot 时，本地 Skill 和离线期间的修改无法明确归属：Bot A 离线后产生的修改，可能在 Bot B 启动时被错误加载；同名 Skill 也无法隔离。

本 PR 是整体 Bot Skill 同步方案的 PR2，建立“每个 Bot 一个本地工作区”的基础设施。它叠加在 PR1 #236 之上，暂不实现 Local/Base/Cloud 内容同步，也不接入真实 SkillHub 私有上传下载。

## 做了什么

### 1. 新增 BotSkillWorkspaceService

- 活动目录继续使用现有 `<runtimeRoot>/skills/`，SkillManager 和 catalog 注入逻辑无需修改。
- 非活动 Bot 的工作区停放到 `<runtimeRoot>/data/bot-skills/by-bot/b_<sha256(botId)>`。
- 每个工作区写入 `.xiaoba-bot-workspace.json`，保存稳定的 `workspaceId` 和 `workspaceOwnerBotId`。
- 首次启用时，已有共享 `skills/` 原地归属当前绑定 Bot，不复制、不移动，离线修改自然归原 Bot。
- Bot ID 只参与哈希，不直接进入路径，避免路径穿越、Windows 保留名和大小写问题。

### 2. 增加可恢复的切换事务

- 切换使用同盘 rename，不做 copy/delete fallback，也不合并或覆盖已有停放目录。
- 状态文件记录 `prepared -> source-parked -> target-active` 阶段和 transactionId。
- 进程中断后根据真实目录 marker 恢复到切换前 Bot；目录缺失、无 marker 或身份歧义时停止恢复并保留日志，避免猜测性覆盖。
- 完整 activation lock 覆盖 binding snapshot、目录切换、Connector ready、提交/回滚和清理，防止并发请求或第二进程误恢复正在进行的事务。
- 拒绝 symlink/junction 逃逸、外部 `XIAOBA_SKILLS_DIR`、来源停放目录冲突和不一致 state/marker。

### 3. 绑定和工作区联合回滚

- 切换前持久化 CatsCo binding 回滚快照，并与 workspace transactionId 绑定。
- `.env` 快照只保存 CatsCo/CatsCompany binding 相关键，不复制无关模型或供应商密钥；配置、state、marker 和快照均采用私有权限与临时文件 rename。
- Dashboard 或 Connector 重启时先联合恢复 binding 和工作区，再读取 Definition 或加载 Skill。
- 提交后清理快照失败不会反向恢复旧 binding，避免 workspace=B、binding=A 的 split-brain。

### 4. 接入 Dashboard 和 Connector 生命周期

- Dashboard 绑定/切换前按目标 botId 准备 Definition 和执行 preflight，避免错误复用旧 Bot 的模型配置。
- 旧 Connector 先停止并确认退出，再切换活动工作区。
- 父进程把 activation transactionId 传给目标 Connector；子进程只校验 pending target，不会把正常切换误判成崩溃事务。
- Connector 完成工作区校验、Skill 加载和 WebSocket ready 后输出 ready marker；ServiceManager 收到 ready 后才提交新 Bot 工作区。
- ready 前退出、报错或超时会停止目标 Connector，恢复旧 binding/工作区，并在释放 activation lock 后尽力重启旧 Connector。
- Dashboard 启动时先恢复工作区，再执行默认 Skill bootstrap；bootstrap 完成后才开放 API，避免初始化期间切换目录。

## 关键行为

- A 离线期间修改 `skills/`：修改仍属于 A；切换 B 时整个 A 工作区被停放。
- A/B 有同名 Skill：内容完全隔离，来回切换后各自保持不变。
- 目标停放目录存在但为空：允许激活。
- 目标目录缺失：只有明确新建 Bot 或 Definition 显式 `skills: []` 才允许建立空工作区；普通 A→B 切换不会把“缺失”误判为“空”。
- 目标恢复、预检或 ready 失败：保持或恢复旧 Bot，不伪装成完整启动。
- 外部 `XIAOBA_SKILLS_DIR`：Bot 托管工作区要求活动目录固定为 `<runtimeRoot>/skills/`，否则明确报错，避免跨卷 rename 和非原子切换。

## 测试与审核

已通过：

- `npm run build`
- 53 个重点用例：workspace 状态机、三个崩溃阶段恢复、binding 联合恢复、并发 activation lock、首次 claim、pending target、junction/symlink、无 marker 防覆盖、Dashboard A→B 切换、ready 前失败回滚、ServiceManager ready/exit。
- 全量 runtime：1226 个用例中 1219 通过、4 跳过；2 个既有 PDF 视觉回退用例仍受本机依赖环境影响失败，与本 PR 修改文件无差异；另有一次随机测试端口被 undici 判定为 bad port，单独重跑对应 Weixin 套件 3/3 通过。
- 产品、同步状态机、安全/后端三个角度多轮复审；最终安全复审确认无剩余 P0/P1。

## 本 PR 不做什么

- 不生成 Local manifest/contentHash。
- 不实现 Local/Base/Cloud 三方判断和上下行同步。
- 不统一 Dashboard、SkillHub 工具和默认 Skill的写入口。
- 不实现真实 SkillHub 私有包上传、下载和版本不可变校验。

## 下一步

PR3 将新增统一的 BotSkillService，让 Dashboard、Agent SkillHub 工具和默认 Skill安装统一走同一入口，并建立本地 manifest/contentHash；之后 PR4 再实现 Local/Base/Cloud 判断、迁移和本地模拟同步。

> 这是叠加 PR：当前 base 为 `codex/bot-skill-sync-pr1`。PR1 合并后再将本 PR retarget 到 `main`。