### PR TITLE
fix(skillhub): 保留 CatsCo 消息可信边界

### DIFF
--- a/src/tools/skillhub-tool.ts
+++ b/src/tools/skillhub-tool.ts
@@ -2,6 +2,7 @@ import type { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } 
 import { SkillHubService } from '../skillhub/service';
 import { SkillHubSubscriptionService } from '../skillhub/subscription-service';
 import type { SkillHubSearchResponse } from '../skillhub/types';
+import { isCatsCoToolGatewayContext } from './tool-gateway';
 
 export interface SkillHubCatalogGateway {
   search(query?: string, options?: { category?: string }): Promise<SkillHubSearchResponse & { installed?: unknown[] }>;
@@ -92,6 +93,8 @@ export class SkillHubTool implements Tool {
       }
 
       if (action === 'subscribe' || action === 'unsubscribe') {
+        const denied = mutationDenied(context);
+        if (denied) return denied;
         const skillId = required(args?.skillId, 'skillId');
         if (action === 'subscribe') {
           const result = await this.subscriptions.subscribe(skillId);
@@ -124,6 +127,23 @@ export class SkillHubTool implements Tool {
       };
     }
   }
+}
+
+function mutationDenied(context: ToolExecutionContext): ToolExecutionResult | undefined {
+  if (!isCatsCoToolGatewayContext(context)) return undefined;
+  const scope = context.executionScope;
+  if (
+    scope?.source === 'catscompany'
+    && scope.identityTrust === 'server_canonical'
+    && scope.isTrusted
+  ) {
+    return undefined;
+  }
+  return {
+    ok: false,
+    errorCode: 'PERMISSION_DENIED',
+    message: '当前消息身份未经服务端确认，不能添加或删除 Skill。',
+  };
 }
 
 function required(value: unknown, field: string): string {

--- a/tests/skillhub-subscription.test.ts
+++ b/tests/skillhub-subscription.test.ts
@@ -380,6 +380,38 @@ describe('SkillHub user subscriptions', () => {
     assert.equal(called, true);
   });
 
+  test('Tool rejects Skill mutations from an untrusted CatsCo actor', async () => {
+    let called = false;
+    const tool = mutationTrackingTool(() => {
+      called = true;
+    });
+
+    const result = await tool.execute(
+      { action: 'subscribe', skillId: 'alice/ppt' },
+      catsCoContext('usr9', 'untrusted'),
+    );
+
+    assert.equal(result.ok, false);
+    if (!result.ok) assert.equal(result.errorCode, 'PERMISSION_DENIED');
+    assert.equal(called, false);
+  });
+
+  test('Tool rejects Skill mutations from a legacy CatsCo context', async () => {
+    let called = false;
+    const tool = mutationTrackingTool(() => {
+      called = true;
+    });
+
+    const result = await tool.execute(
+      { action: 'unsubscribe', skillId: 'alice/ppt' },
+      catsCoContext('usr9', 'legacy_context'),
+    );
+
+    assert.equal(result.ok, false);
+    if (!result.ok) assert.equal(result.errorCode, 'PERMISSION_DENIED');
+    assert.equal(called, false);
+  });
+
   test('ToolManager does not introduce a confirmation step for SkillHub operations', async () => {
     const manager = new ToolManager(testRoot, {}, { enabledToolNames: [] });
     let confirmations = 0;
@@ -477,7 +509,27 @@ function baseContext(): ToolExecutionContext {
   return { workingDirectory: testCwd(), conversationHistory: [] };
 }
 
-function catsCoContext(actorUserId = 'usr7'): ToolExecutionContext {
+function mutationTrackingTool(onMutation: () => void): SkillHubTool {
+  return new SkillHubTool(
+    { search: async () => ({ skills: [] }) },
+    {
+      list: async () => ({ scope: 'runtime', subscriptions: [] }),
+      subscribe: async skillId => {
+        onMutation();
+        return { scope: 'runtime', action: 'installed', subscription: subscription(skillId, 'ppt', '1.0.0') };
+      },
+      unsubscribe: async skillId => {
+        onMutation();
+        return { scope: 'runtime', skillId, removed: true, subscriptionFound: true };
+      },
+    },
+  );
+}
+
+function catsCoContext(
+  actorUserId = 'usr7',
+  identityTrust: ExecutionScope['identityTrust'] = 'server_canonical',
+): ToolExecutionContext {
   const scope: ExecutionScope = {
     source: 'catscompany',
     sessionKey: 'session:v2:catscompany:p2p:p2p_7_43:agent:usr43',
@@ -486,8 +538,8 @@ function catsCoContext(actorUserId = 'usr7'): ToolExecutionContext {
     actorUserId,
     agentId: 'usr43',
     agentBodyId: 'body-main',
-    identityTrust: 'server_canonical',
-    isTrusted: true,
+    identityTrust,
+    isTrusted: identityTrust === 'server_canonical',
   };
   const localDeviceGrant: ScopedLocalDeviceGrant = {
     kind: 'catscompany_body',


### PR DESCRIPTION
## 背景

PR #238 放开了虚拟员工 Skill 增删的 owner 限制，但同时移除了 CatsCo 消息来源的可信边界，导致 `untrusted` 或 `legacy_context` 消息也能触发持久化的运行时 Skill 变更。

## 改动

- CatsCo 场景下，`subscribe` / `unsubscribe` 仅接受 `server_canonical` 且 `isTrusted` 的执行上下文。
- 不再检查发送者是否为 Agent owner，可信的普通参与者仍可管理当前虚拟员工的 Skill。
- 本地非 CatsCo 调用保持不变。
- 补充 `untrusted` 和 `legacy_context` 回归测试，确认拒绝发生在调用订阅网关之前。

## 行为边界

- 可信 non-owner CatsCo 用户：允许。
- 不可信或旧格式 CatsCo 消息：拒绝。
- SkillHub 包发布、下架和作者权限：不变。
- 安装签名、同名冲突和卸载标记保护：不变。

## 验证

- SkillHub 定向测试：16/16 通过。
- `npm run build`：通过。
