### PR TITLE
feat: 统一 Bot Skill 本地管理与 Local Manifest（PR3）

### DIFF
--- a/src/bot-skills/local-manifest.ts
+++ b/src/bot-skills/local-manifest.ts
@@ -1,0 +1,469 @@
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { SkillParser } from '../skills/skill-parser';
+import {
+  SKILLHUB_INSTALL_MARKER_FILE,
+  readSkillHubInstallMarker,
+} from '../skillhub/install-marker';
+import { computeLocalSkillContentHash } from '../skillhub/local-skill-metadata';
+
+export const BOT_SKILL_LOCAL_MANIFEST_SCHEMA = 'xiaoba.bot-skill-local-manifest.v1';
+export const BOT_SKILL_LOCAL_IDENTITY_SCHEMA = 'xiaoba.local-skill-identity.v1';
+export const BOT_SKILL_LOCAL_IDENTITY_FILE = '.xiaoba-local-skill.json';
+
+const MAX_IDENTITY_BYTES = 64 * 1024;
+const LOCAL_SKILL_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const SKIP_DIRECTORIES = new Set([
+  '.git',
+  'node_modules',
+  '__pycache__',
+]);
+
+export type LocalSkillManifestStatus =
+  | 'missing'
+  | 'complete'
+  | 'partial'
+  | 'unreadable';
+
+export interface LocalSkillManifestIssue {
+  code: string;
+  message: string;
+  path?: string;
+}
+
+export interface LocalSkillManifestEntry {
+  localSkillId: string;
+  key: string;
+  name: string;
+  path: string;
+  enabled: boolean;
+  contentHash: string;
+  source: 'skillhub' | 'local';
+  skillId?: string;
+  version?: string;
+  installedChecksum?: string;
+  installedContentHash?: string;
+}
+
+export interface LocalSkillManifest {
+  schema: typeof BOT_SKILL_LOCAL_MANIFEST_SCHEMA;
+  status: LocalSkillManifestStatus;
+  botId?: string;
+  workspaceId?: string;
+  entries: LocalSkillManifestEntry[];
+  issues: LocalSkillManifestIssue[];
+}
+
+export interface LocalSkillIdentity {
+  schema: typeof BOT_SKILL_LOCAL_IDENTITY_SCHEMA;
+  localSkillId: string;
+  workspaceId?: string;
+  identityName: string;
+  createdAt: string;
+}
+
+export interface ScanLocalSkillManifestOptions {
+  skillsRoot: string;
+  botId?: string;
+  workspaceId?: string;
+  createIdentities?: boolean;
+}
+
+export function scanLocalSkillManifest(
+  options: ScanLocalSkillManifestOptions,
+): LocalSkillManifest {
+  const root = path.resolve(options.skillsRoot);
+  const base = (): LocalSkillManifest => ({
+    schema: BOT_SKILL_LOCAL_MANIFEST_SCHEMA,
+    status: 'complete',
+    botId: normalizedOptional(options.botId),
+    workspaceId: normalizedOptional(options.workspaceId),
+    entries: [],
+    issues: [],
+  });
+  if (!fs.existsSync(root)) return { ...base(), status: 'missing' };
+
+  try {
+    assertRealDirectory(root, root, 'Skill workspace root');
+    fs.accessSync(root, fs.constants.R_OK);
+  } catch (error) {
+    return {
+      ...base(),
+      status: 'unreadable',
+      issues: [issue('ROOT_UNREADABLE', error, root)],
+    };
+  }
+
+  const result = base();
+  let skillFiles: Array<{ filePath: string; enabled: boolean }> = [];
+  try {
+    skillFiles = findSkillFilesStrict(root, result.issues);
+  } catch (error) {
+    return {
+      ...result,
+      status: 'unreadable',
+      issues: [...result.issues, issue('ROOT_SCAN_FAILED', error, root)],
+    };
+  }
+
+  const seenLocalIds = new Map<string, string>();
+  const seenKeys = new Map<string, string>();
+  const seenNames = new Map<string, string>();
+  for (const candidate of skillFiles) {
+    const skillDir = path.dirname(candidate.filePath);
+    const relativeDir = normalizedRelativePath(root, skillDir);
+    try {
+      assertRealDirectory(root, skillDir, 'Skill directory');
+      const skillFileStat = fs.lstatSync(candidate.filePath);
+      if (!skillFileStat.isFile() || skillFileStat.isSymbolicLink()) {
+        throw new Error('Skill entry file must be a regular file.');
+      }
+      const skill = SkillParser.parse(candidate.filePath);
+      const name = String(skill.metadata.name || '').trim();
+      const identity = resolveLocalSkillIdentity({
+        skillDir,
+        name,
+        workspaceId: options.workspaceId,
+        create: options.createIdentities !== false,
+      });
+      if (!identity) {
+        throw new Error(`Local Skill identity is missing: ${BOT_SKILL_LOCAL_IDENTITY_FILE}`);
+      }
+
+      const duplicateIdentityPath = seenLocalIds.get(identity.localSkillId);
+      if (duplicateIdentityPath) {
+        result.issues.push({
+          code: 'DUPLICATE_LOCAL_SKILL_ID',
+          message: `Local Skill identity is also used by ${duplicateIdentityPath}.`,
+          path: relativeDir,
+        });
+        continue;
+      }
+
+      const markerPath = path.join(skillDir, SKILLHUB_INSTALL_MARKER_FILE);
+      const marker = readSkillHubInstallMarker(skillDir);
+      if (fs.existsSync(markerPath) && !marker) {
+        throw new Error('SkillHub install marker is invalid.');
+      }
+      if (marker && marker.installName !== path.basename(skillDir)) {
+        throw new Error('SkillHub install marker installName does not match its directory.');
+      }
+
+      const key = marker ? `skillhub:${marker.skillId}` : `local:${name}`;
+      const duplicateKeyPath = seenKeys.get(portableKey(key));
+      const duplicateNamePath = seenNames.get(nameKey(name));
+      if (duplicateKeyPath || duplicateNamePath) {
+        result.issues.push({
+          code: duplicateKeyPath ? 'DUPLICATE_SKILL_KEY' : 'DUPLICATE_SKILL_NAME',
+          message: duplicateKeyPath
+            ? `Skill key is also used by ${duplicateKeyPath}.`
+            : `Skill name is also used by ${duplicateNamePath}.`,
+          path: relativeDir,
+        });
+        continue;
+      }
+
+      assertTreeHasNoLinks(skillDir);
+      const entry: LocalSkillManifestEntry = {
+        localSkillId: identity.localSkillId,
+        key,
+        name,
+        path: relativeDir,
+        enabled: candidate.enabled,
+        contentHash: computeLocalSkillContentHash(skillDir),
+        source: marker ? 'skillhub' : 'local',
+        ...(marker ? {
+          skillId: marker.skillId,
+          version: marker.version,
+          installedChecksum: marker.packageChecksumSha256,
+          installedContentHash: marker.installedContentHash,
+        } : {}),
+      };
+      result.entries.push(entry);
+      seenLocalIds.set(identity.localSkillId, relativeDir);
+      seenKeys.set(portableKey(key), relativeDir);
+      seenNames.set(nameKey(name), relativeDir);
+    } catch (error) {
+      result.issues.push(issue('SKILL_SCAN_FAILED', error, relativeDir));
+    }
+  }
+
+  result.entries.sort((left, right) =>
+    left.key.localeCompare(right.key) || left.path.localeCompare(right.path));
+  result.status = result.issues.length ? 'partial' : 'complete';
+  return result;
+}
+
+export function readLocalSkillIdentity(skillDir: string): LocalSkillIdentity | undefined {
+  const markerPath = path.join(skillDir, BOT_SKILL_LOCAL_IDENTITY_FILE);
+  if (!fs.existsSync(markerPath)) return undefined;
+  const stat = fs.lstatSync(markerPath);
+  if (!stat.isFile() || stat.isSymbolicLink() || stat.size > MAX_IDENTITY_BYTES) {
+    throw new Error(`Local Skill identity is invalid: ${markerPath}`);
+  }
+  let value: Partial<LocalSkillIdentity>;
+  try {
+    value = JSON.parse(fs.readFileSync(markerPath, 'utf8')) as Partial<LocalSkillIdentity>;
+  } catch (error) {
+    throw new Error(`Local Skill identity is not valid JSON: ${errorMessage(error)}`);
+  }
+  if (
+    value.schema !== BOT_SKILL_LOCAL_IDENTITY_SCHEMA
+    || !LOCAL_SKILL_ID_PATTERN.test(stringValue(value.localSkillId))
+    || !stringValue(value.identityName)
+    || stringValue(value.identityName).length > 256
+    || !stringValue(value.createdAt)
+    || (value.workspaceId !== undefined && !stringValue(value.workspaceId))
+  ) {
+    throw new Error(`Local Skill identity has invalid fields: ${markerPath}`);
+  }
+  return value as LocalSkillIdentity;
+}
+
+export function writeLocalSkillIdentity(
+  skillDir: string,
+  identity: LocalSkillIdentity,
+): void {
+  if (
+    identity.schema !== BOT_SKILL_LOCAL_IDENTITY_SCHEMA
+    || !LOCAL_SKILL_ID_PATTERN.test(stringValue(identity.localSkillId))
+    || !stringValue(identity.identityName)
+    || !stringValue(identity.createdAt)
+  ) {
+    throw new Error('Local Skill identity is invalid.');
+  }
+  atomicWriteJson(path.join(skillDir, BOT_SKILL_LOCAL_IDENTITY_FILE), identity);
+}
+
+export function newLocalSkillIdentity(
+  name: string,
+  workspaceId?: string,
+  localSkillId: string = crypto.randomUUID(),
+): LocalSkillIdentity {
+  return {
+    schema: BOT_SKILL_LOCAL_IDENTITY_SCHEMA,
+    localSkillId,
+    workspaceId: normalizedOptional(workspaceId),
+    identityName: stringValue(name),
+    createdAt: new Date().toISOString(),
+  };
+}
+
+function resolveLocalSkillIdentity(options: {
+  skillDir: string;
+  name: string;
+  workspaceId?: string;
+  create: boolean;
+}): LocalSkillIdentity | undefined {
+  const existing = readLocalSkillIdentity(options.skillDir);
+  const expectedWorkspaceId = normalizedOptional(options.workspaceId);
+  if (
+    existing
+    && (
+      !expectedWorkspaceId
+      || !existing.workspaceId
+      || existing.workspaceId === expectedWorkspaceId
+    )
+  ) {
+    if (
+      options.create
+      && (
+        existing.identityName !== options.name
+        || (!existing.workspaceId && expectedWorkspaceId)
+      )
+    ) {
+      const updated = {
+        ...existing,
+        identityName: options.name,
+        workspaceId: existing.workspaceId ?? expectedWorkspaceId,
+      };
+      writeLocalSkillIdentity(options.skillDir, updated);
+      return updated;
+    }
+    return existing;
+  }
+  if (!options.create) return existing;
+  const identity = newLocalSkillIdentity(options.name, expectedWorkspaceId);
+  writeLocalSkillIdentity(options.skillDir, identity);
+  return identity;
+}
+
+function findSkillFilesStrict(
+  root: string,
+  issues: LocalSkillManifestIssue[],
+): Array<{ filePath: string; enabled: boolean }> {
+  const results: Array<{ filePath: string; enabled: boolean }> = [];
+  const visit = (directory: string): void => {
+    const entries = fs.readdirSync(directory, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(directory, entry.name);
+      if (entry.isSymbolicLink()) {
+        issues.push({
+          code: 'SYMLINK_UNSUPPORTED',
+          message: 'Skill workspaces cannot contain symlinks or junctions.',
+          path: normalizedRelativePath(root, fullPath),
+        });
+        continue;
+      }
+      if (!entry.isDirectory()) continue;
+      if (SKIP_DIRECTORIES.has(entry.name) || isOperationDirectory(entry.name)) continue;
+      try {
+        assertRealDirectory(root, fullPath, 'Skill workspace child');
+      } catch (error) {
+        issues.push(issue('UNSAFE_DIRECTORY', error, normalizedRelativePath(root, fullPath)));
+        continue;
+      }
+      const active = path.join(fullPath, 'SKILL.md');
+      const disabled = path.join(fullPath, 'SKILL.md.disabled');
+      if (fs.existsSync(active) && fs.existsSync(disabled)) {
+        issues.push({
+          code: 'AMBIGUOUS_SKILL_STATE',
+          message: 'Both SKILL.md and SKILL.md.disabled exist.',
+          path: normalizedRelativePath(root, fullPath),
+        });
+      } else if (fs.existsSync(active)) {
+        results.push({ filePath: active, enabled: true });
+      } else if (fs.existsSync(disabled)) {
+        results.push({ filePath: disabled, enabled: false });
+      }
+      if (fs.existsSync(active) || fs.existsSync(disabled)) {
+        for (const nested of findNestedSkillEntries(fullPath)) {
+          issues.push({
+            code: 'NESTED_SKILL_UNSUPPORTED',
+            message: 'A Skill directory cannot contain another Skill entrypoint.',
+            path: normalizedRelativePath(root, nested),
+          });
+        }
+      } else {
+        visit(fullPath);
+      }
+    }
+  };
+  visit(root);
+  return results;
+}
+
+function assertTreeHasNoLinks(root: string): void {
+  const visit = (directory: string): void => {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const fullPath = path.join(directory, entry.name);
+      const stat = fs.lstatSync(fullPath);
+      if (stat.isSymbolicLink()) {
+        throw new Error(`Skill contains a symlink or junction: ${fullPath}`);
+      }
+      if (stat.isDirectory() && !SKIP_DIRECTORIES.has(entry.name)) visit(fullPath);
+    }
+  };
+  visit(root);
+}
+
+function assertRealDirectory(root: string, target: string, label: string): void {
+  const stat = fs.lstatSync(target);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new Error(`${label} must be a real directory: ${target}`);
+  }
+  const resolvedRoot = path.resolve(root);
+  const resolvedTarget = path.resolve(target);
+  const relative = path.relative(resolvedRoot, resolvedTarget);
+  if (relative === '..' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    throw new Error(`${label} escapes the Skill workspace: ${target}`);
+  }
+  const realRoot = fs.realpathSync.native(resolvedRoot);
+  const realTarget = fs.realpathSync.native(resolvedTarget);
+  const realRelative = path.relative(realRoot, realTarget);
+  if (
+    realRelative === '..'
+    || realRelative.startsWith(`..${path.sep}`)
+    || path.isAbsolute(realRelative)
+    || !samePath(resolvedTarget, realTarget)
+  ) {
+    throw new Error(`${label} traverses a symlink or junction: ${target}`);
+  }
+}
+
+function atomicWriteJson(filePath: string, value: unknown): void {
+  const parent = path.dirname(filePath);
+  const parentStat = fs.lstatSync(parent);
+  if (!parentStat.isDirectory() || parentStat.isSymbolicLink()) {
+    throw new Error(`Local Skill identity parent is unsafe: ${parent}`);
+  }
+  const temporary = path.join(
+    parent,
+    `.${path.basename(filePath)}.${process.pid}.${crypto.randomUUID()}.tmp`,
+  );
+  fs.writeFileSync(temporary, `${JSON.stringify(value, null, 2)}\n`, {
+    encoding: 'utf8',
+    mode: 0o600,
+    flag: 'wx',
+  });
+  try {
+    fs.renameSync(temporary, filePath);
+  } catch (error) {
+    fs.rmSync(temporary, { force: true });
+    throw error;
+  }
+}
+
+function normalizedRelativePath(root: string, target: string): string {
+  const relative = path.relative(root, target).replace(/\\/g, '/');
+  return relative || '.';
+}
+
+function nameKey(value: string): string {
+  return portableKey(value);
+}
+
+function portableKey(value: string): string {
+  return value.normalize('NFC').toLocaleLowerCase('en-US');
+}
+
+function findNestedSkillEntries(root: string): string[] {
+  const found: string[] = [];
+  const visit = (directory: string): void => {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      if (!entry.isDirectory() || entry.isSymbolicLink() || SKIP_DIRECTORIES.has(entry.name)) continue;
+      const child = path.join(directory, entry.name);
+      const active = path.join(child, 'SKILL.md');
+      const disabled = path.join(child, 'SKILL.md.disabled');
+      if (fs.existsSync(active)) found.push(active);
+      if (fs.existsSync(disabled)) found.push(disabled);
+      visit(child);
+    }
+  };
+  visit(root);
+  return found;
+}
+
+function isOperationDirectory(name: string): boolean {
+  return /^\.skillhub-(install|backup|trash)-/.test(name)
+    || /^\.xiaoba-skill-(install|backup|trash)-/.test(name);
+}
+
+function normalizedOptional(value: unknown): string | undefined {
+  return stringValue(value) || undefined;
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function issue(code: string, error: unknown, issuePath?: string): LocalSkillManifestIssue {
+  return {
+    code,
+    message: errorMessage(error),
+    path: issuePath,
+  };
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function samePath(left: string, right: string): boolean {
+  const normalizedLeft = path.resolve(left);
+  const normalizedRight = path.resolve(right);
+  return process.platform === 'win32'
+    ? normalizedLeft.toLowerCase() === normalizedRight.toLowerCase()
+    : normalizedLeft === normalizedRight;
+}

--- a/src/bot-skills/service.ts
+++ b/src/bot-skills/service.ts
@@ -1,0 +1,1068 @@
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import matter from 'gray-matter';
+import { createCatsCoLocalConfigService } from '../catscompany/local-config';
+import { SkillParser } from '../skills/skill-parser';
+import {
+  readSkillHubInstallMarker,
+} from '../skillhub/install-marker';
+import {
+  SkillHubInstallError,
+  claimSkillHubPackageOwnership,
+  installVerifiedSkillHubPackage,
+  recoverSkillHubPackageOperations,
+  type ClaimSkillHubPackageOwnershipOptions,
+  type InstallVerifiedSkillHubPackageOptions,
+  type InstallVerifiedSkillHubPackageResult,
+  type UninstallSkillHubPackageOptions,
+} from '../skillhub/package-installer';
+import {
+  computeLocalSkillContentHash,
+  writeSkillHubLocalMetadata,
+  type SkillHubLocalMetadata,
+} from '../skillhub/local-skill-metadata';
+import { PathResolver } from '../utils/path-resolver';
+import {
+  BotSkillWorkspaceService,
+  createBotSkillWorkspaceService,
+  type BotSkillWorkspaceActivationLock,
+  type BotSkillWorkspaceState,
+} from './workspace-service';
+import {
+  BOT_SKILL_LOCAL_IDENTITY_FILE,
+  newLocalSkillIdentity,
+  readLocalSkillIdentity,
+  scanLocalSkillManifest,
+  writeLocalSkillIdentity,
+  type LocalSkillManifest,
+} from './local-manifest';
+
+export interface BotSkillServiceOptions {
+  runtimeRoot?: string;
+  skillsRoot?: string;
+  operationsRoot?: string;
+  env?: NodeJS.ProcessEnv;
+  expectedBotId?: string;
+  workspaceService?: BotSkillWorkspaceService;
+  activationLock?: BotSkillWorkspaceActivationLock;
+  activationTransactionId?: string;
+  allowUnmanagedWorkspace?: boolean;
+}
+
+export interface BotSkillMutationResult<T = unknown> {
+  result: T;
+  manifest: LocalSkillManifest;
+}
+
+export class BotSkillServiceError extends Error {
+  constructor(
+    message: string,
+    public readonly code: string,
+    public readonly status = 409,
+    public readonly manifest?: LocalSkillManifest,
+  ) {
+    super(message);
+    this.name = 'BotSkillServiceError';
+  }
+}
+
+export class BotSkillService {
+  readonly runtimeRoot: string;
+  readonly skillsRoot: string;
+  readonly operationsRoot: string;
+  readonly expectedBotId?: string;
+
+  private readonly env: NodeJS.ProcessEnv;
+  private readonly workspaceService: BotSkillWorkspaceService;
+  private readonly managedWorkspace: boolean;
+  private readonly localLockPath: string;
+  private readonly existingActivationLock?: BotSkillWorkspaceActivationLock;
+  private readonly allowUnmanagedWorkspace: boolean;
+  private readonly activationTransactionId?: string;
+
+  constructor(options: BotSkillServiceOptions = {}) {
+    this.env = options.env ?? process.env;
+    this.runtimeRoot = path.resolve(
+      options.runtimeRoot ?? PathResolver.getRuntimeDataRoot(this.env),
+    );
+    this.skillsRoot = path.resolve(
+      options.skillsRoot
+        ?? (options.runtimeRoot ? path.join(this.runtimeRoot, 'skills') : PathResolver.getSkillsPath()),
+    );
+    const managedSkillsRoot = path.join(this.runtimeRoot, 'skills');
+    this.managedWorkspace = samePath(this.skillsRoot, managedSkillsRoot);
+    this.workspaceService = options.workspaceService
+      ?? createBotSkillWorkspaceService({
+        runtimeRoot: this.runtimeRoot,
+        env: this.managedWorkspace ? this.env : { ...this.env, XIAOBA_SKILLS_DIR: undefined },
+      });
+    this.expectedBotId = normalizedOptional(options.expectedBotId)
+      ?? (this.managedWorkspace ? currentBotId(this.runtimeRoot) : undefined);
+    const workspaceState = this.managedWorkspace
+      ? this.workspaceService.readState()
+      : undefined;
+    const pendingSwitch = workspaceState?.switchJournal;
+    const operationScope = (
+      pendingSwitch && pendingSwitch.to.botId === this.expectedBotId
+        ? pendingSwitch.to.workspaceId
+        : workspaceState?.workspaceId
+    ) ?? this.skillsRoot;
+    const operationsBase = sameFilesystem(this.runtimeRoot, this.skillsRoot)
+      ? path.join(this.runtimeRoot, 'data', 'bot-skills', 'operations')
+      : path.join(path.dirname(this.skillsRoot), '.xiaoba-skill-operations');
+    this.operationsRoot = path.resolve(
+      options.operationsRoot
+        ?? path.join(operationsBase, `w_${sha256(operationScope)}`),
+    );
+    this.localLockPath = path.join(this.operationsRoot, 'service.lock');
+    this.existingActivationLock = options.activationLock;
+    this.activationTransactionId = normalizedOptional(options.activationTransactionId);
+    this.allowUnmanagedWorkspace = options.allowUnmanagedWorkspace === true;
+  }
+
+  async scanManifest(): Promise<LocalSkillManifest> {
+    return this.runExclusive(() => this.scanManifestUnlocked());
+  }
+
+  async withWorkspaceLock<T>(action: () => Promise<T> | T): Promise<T> {
+    return this.runExclusive(async () => {
+      this.requireCompleteManifest();
+      return action();
+    });
+  }
+
+  async installVerifiedSkillHubPackage(
+    options: InstallVerifiedSkillHubPackageOptions,
+  ): Promise<BotSkillMutationResult<InstallVerifiedSkillHubPackageResult>> {
+    return this.runExclusive(() => {
+      const current = this.requireCompleteManifest();
+      const incoming = this.inspectVerifiedPackage(options);
+      this.assertProspectiveEntry(current, incoming);
+      const targetDir = this.resolveDirectChild(incoming.path);
+      const existingIdentity = fs.existsSync(targetDir)
+        ? readLocalSkillIdentity(targetDir)
+        : undefined;
+      const workspace = this.workspaceContext();
+      const localIdentity = existingIdentity
+        ? {
+          ...existingIdentity,
+          identityName: incoming.name,
+          workspaceId: existingIdentity.workspaceId ?? workspace.workspaceId,
+        }
+        : newLocalSkillIdentity(incoming.name, workspace.workspaceId);
+      const result = installVerifiedSkillHubPackage({
+        ...options,
+        skillsRoot: this.skillsRoot,
+        operationsRoot: this.operationsRoot,
+        localIdentity,
+      });
+      return { result, manifest: this.scanManifestUnlocked() };
+    });
+  }
+
+  async uninstallSkillHubPackage(
+    options: UninstallSkillHubPackageOptions,
+  ): Promise<BotSkillMutationResult<{ removed: boolean; path: string }>> {
+    return this.runExclusive(() => {
+      const current = this.requireCompleteManifest();
+      const targetDir = this.resolveDirectChild(options.installName);
+      if (!fs.existsSync(targetDir)) {
+        return {
+          result: { removed: false, path: targetDir },
+          manifest: current,
+        };
+      }
+      this.assertSafeSkillDirectory(targetDir);
+      const marker = readSkillHubInstallMarker(targetDir);
+      if (!marker || marker.skillId !== options.skillId) {
+        throw new SkillHubInstallError(
+          'The target directory is not the requested SkillHub Skill.',
+          'UNINSTALL_TARGET_MISMATCH',
+        );
+      }
+      if (options.userId && marker.userId && marker.userId !== options.userId) {
+        throw new SkillHubInstallError(
+          'The target Skill belongs to another SkillHub user.',
+          'USER_CONFLICT',
+        );
+      }
+      this.quarantineRemove(targetDir);
+      return {
+        result: { removed: true, path: targetDir },
+        manifest: this.scanManifestUnlocked(),
+      };
+    });
+  }
+
+  async claimInstalledSkillOwnership(
+    options: ClaimSkillHubPackageOwnershipOptions,
+  ): Promise<boolean> {
+    return this.runExclusive(() => claimSkillHubPackageOwnership({
+      ...options,
+      skillsRoot: this.skillsRoot,
+    }));
+  }
+
+  async installLocalDirectory(options: {
+    sourceDir: string;
+    installName: string;
+    overwrite?: boolean;
+  }): Promise<BotSkillMutationResult<{
+    installed: boolean;
+    existing: boolean;
+    path: string;
+  }>> {
+    return this.runExclusive(() => {
+      const current = this.requireCompleteManifest();
+      const sourceDir = path.resolve(options.sourceDir);
+      this.assertRealTree(sourceDir, 'Local Skill source');
+      const targetDir = this.resolveDirectChild(options.installName);
+      if (fs.existsSync(targetDir) && !options.overwrite) {
+        return {
+          result: { installed: false, existing: true, path: targetDir },
+          manifest: current,
+        };
+      }
+      if (fs.existsSync(targetDir)) this.assertSafeSkillDirectory(targetDir);
+      const existingWasDisabled = fs.existsSync(path.join(targetDir, 'SKILL.md.disabled'))
+        && !fs.existsSync(path.join(targetDir, 'SKILL.md'));
+
+      const operationDir = this.newOperationDirectory('local-install');
+      const stagedDir = path.join(operationDir, 'staged');
+      try {
+        copyDirectoryStrict(sourceDir, stagedDir);
+        const stagedSkillFile = path.join(stagedDir, 'SKILL.md');
+        if (!fs.existsSync(stagedSkillFile)) {
+          throw new BotSkillServiceError(
+            'Local Skill source is missing SKILL.md.',
+            'LOCAL_SKILL_ENTRY_MISSING',
+            400,
+          );
+        }
+        const stagedSkill = SkillParser.parse(stagedSkillFile);
+        const existingIdentity = fs.existsSync(targetDir)
+          ? readLocalSkillIdentity(targetDir)
+          : undefined;
+        const workspace = this.workspaceContext();
+        const identity = existingIdentity?.identityName === stagedSkill.metadata.name
+          ? {
+            ...existingIdentity,
+            workspaceId: existingIdentity.workspaceId ?? workspace.workspaceId,
+          }
+          : newLocalSkillIdentity(stagedSkill.metadata.name, workspace.workspaceId);
+        writeLocalSkillIdentity(stagedDir, identity);
+        if (existingWasDisabled) {
+          fs.renameSync(stagedSkillFile, `${stagedSkillFile}.disabled`);
+        }
+        const stagedManifest = scanLocalSkillManifest({
+          skillsRoot: operationDir,
+          botId: workspace.botId,
+          workspaceId: workspace.workspaceId,
+          createIdentities: false,
+        });
+        if (stagedManifest.status !== 'complete' || stagedManifest.entries.length !== 1) {
+          throw new BotSkillServiceError(
+            'Local Skill source does not produce one complete Skill manifest entry.',
+            'LOCAL_SKILL_SOURCE_INVALID',
+            400,
+            stagedManifest,
+          );
+        }
+        const stagedEntry = stagedManifest.entries[0];
+        this.assertProspectiveEntry(current, {
+          name: stagedEntry.name,
+          key: stagedEntry.key,
+          path: path.basename(targetDir),
+        });
+        this.commitStagedDirectory(operationDir, stagedDir, targetDir);
+      } catch (error) {
+        this.recoverLocalOperations();
+        throw error;
+      }
+      return {
+        result: {
+          installed: true,
+          existing: false,
+          path: targetDir,
+        },
+        manifest: this.scanManifestUnlocked(),
+      };
+    });
+  }
+
+  async removeByName(
+    name: string,
+  ): Promise<BotSkillMutationResult<{ removed: boolean; path: string }>> {
+    return this.runExclusive(() => {
+      const entry = this.findUniqueEntry(name);
+      const targetDir = path.join(this.skillsRoot, ...entry.path.split('/'));
+      this.assertSafeSkillDirectory(targetDir);
+      this.quarantineRemove(targetDir);
+      return {
+        result: { removed: true, path: targetDir },
+        manifest: this.scanManifestUnlocked(),
+      };
+    });
+  }
+
+  async setEnabledByName(
+    name: string,
+    enabled: boolean,
+  ): Promise<BotSkillMutationResult<{ enabled: boolean; path: string }>> {
+    return this.runExclusive(() => {
+      const entry = this.findUniqueEntry(name);
+      const targetDir = path.join(this.skillsRoot, ...entry.path.split('/'));
+      this.assertSafeSkillDirectory(targetDir);
+      const active = path.join(targetDir, 'SKILL.md');
+      const disabled = path.join(targetDir, 'SKILL.md.disabled');
+      const source = enabled ? disabled : active;
+      const destination = enabled ? active : disabled;
+      if (!fs.existsSync(source)) {
+        throw new BotSkillServiceError(
+          enabled ? 'Disabled Skill not found.' : 'Active Skill not found.',
+          'SKILL_STATE_MISMATCH',
+          404,
+        );
+      }
+      assertRegularFile(source, 'Skill entry file');
+      if (fs.existsSync(destination)) {
+        throw new BotSkillServiceError(
+          'Both enabled and disabled Skill entry files exist.',
+          'SKILL_STATE_AMBIGUOUS',
+        );
+      }
+      fs.renameSync(source, destination);
+      return {
+        result: { enabled, path: destination },
+        manifest: this.scanManifestUnlocked(),
+      };
+    });
+  }
+
+  async writeSharedMetadata(
+    name: string,
+    metadata: Required<SkillHubLocalMetadata>,
+  ): Promise<LocalSkillManifest> {
+    return this.runExclusive(() => {
+      const matches = PathResolver.findSkillFiles(this.skillsRoot)
+        .map(filePath => ({ filePath, skill: SkillParser.parse(filePath) }))
+        .filter(item => item.skill.metadata.name === String(name || '').trim());
+      if (matches.length !== 1) {
+        throw new BotSkillServiceError(
+          matches.length ? 'Skill name is ambiguous.' : 'Skill not found.',
+          matches.length ? 'SKILL_NAME_AMBIGUOUS' : 'SKILL_NOT_FOUND',
+          matches.length ? 409 : 404,
+        );
+      }
+      const skillDir = path.dirname(matches[0].filePath);
+      this.assertSafeSkillDirectory(skillDir);
+      const skillFile = matches[0].filePath;
+      assertRegularFile(skillFile, 'Skill entry file');
+      writeSkillHubLocalMetadata(skillFile, metadata);
+      return this.scanManifestUnlocked();
+    });
+  }
+
+  private async runExclusive<T>(action: () => Promise<T> | T): Promise<T> {
+    let activationLock: BotSkillWorkspaceActivationLock | undefined;
+    let localLockId: string | undefined;
+    if (this.existingActivationLock) {
+      activationLock = this.existingActivationLock;
+    } else if (this.managedWorkspace) {
+      activationLock = this.workspaceService.acquireActivationLock();
+    } else {
+      localLockId = this.acquireLocalLock();
+    }
+    try {
+      this.guardExpectedWorkspace(activationLock);
+      ensureDirectoryWithoutLinks(this.operationsRoot);
+      this.assertOperationsRoot();
+      this.recoverLocalOperations();
+      recoverSkillHubPackageOperations({
+        skillsRoot: this.skillsRoot,
+        operationsRoot: this.operationsRoot,
+      });
+      return await action();
+    } finally {
+      if (activationLock && activationLock !== this.existingActivationLock) {
+        activationLock.release();
+      }
+      if (localLockId) this.releaseLocalLock(localLockId);
+    }
+  }
+
+  private guardExpectedWorkspace(
+    lock?: BotSkillWorkspaceActivationLock,
+  ): void {
+    const state = this.managedWorkspace ? this.workspaceService.readState() : undefined;
+    if (!state) {
+      if (this.managedWorkspace && !this.allowUnmanagedWorkspace) {
+        throw new BotSkillServiceError(
+          'The managed Skill workspace has not been claimed by an active Bot.',
+          'SKILL_WORKSPACE_UNCLAIMED',
+          409,
+        );
+      }
+      if (!fs.existsSync(this.skillsRoot)) {
+        throw new BotSkillServiceError(
+          'The active Skill workspace does not exist.',
+          'SKILL_WORKSPACE_MISSING',
+          409,
+        );
+      }
+      this.assertWorkspaceRoot();
+      return;
+    }
+    if (!this.expectedBotId) {
+      throw new BotSkillServiceError(
+        'A Bot-managed Skill workspace has no active Bot binding.',
+        'SKILL_WORKSPACE_UNBOUND',
+        409,
+      );
+    }
+    const current = currentBotId(this.runtimeRoot);
+    if (current !== this.expectedBotId) {
+      throw new BotSkillServiceError(
+        `The active Bot changed from ${this.expectedBotId || '(none)'} to ${current || '(none)'} before the Skill operation committed.`,
+        'SKILL_WORKSPACE_OWNER_CHANGED',
+        409,
+      );
+    }
+    if (state.switchJournal) {
+      if (!this.activationTransactionId) {
+        throw new BotSkillServiceError(
+          'The Bot Skill workspace is currently switching.',
+          'SKILL_WORKSPACE_SWITCHING',
+          423,
+        );
+      }
+      this.workspaceService.assertPendingTarget(
+        this.activationTransactionId,
+        this.expectedBotId,
+      );
+    } else {
+      this.workspaceService.assertActive(this.expectedBotId);
+    }
+    this.assertWorkspaceRoot();
+    if (lock) {
+      const owner = readLockOwner(this.workspaceService.lockPath);
+      if (!owner || owner.lockId !== lock.lockId || owner.pid !== process.pid) {
+        throw new BotSkillServiceError(
+          'The Bot Skill activation lock is no longer owned by this process.',
+          'SKILL_WORKSPACE_LOCK_LOST',
+          409,
+        );
+      }
+    }
+  }
+
+  private scanManifestUnlocked(): LocalSkillManifest {
+    const workspace = this.workspaceContext();
+    return scanLocalSkillManifest({
+      skillsRoot: this.skillsRoot,
+      botId: workspace.botId,
+      workspaceId: workspace.workspaceId,
+      createIdentities: true,
+    });
+  }
+
+  private requireCompleteManifest(): LocalSkillManifest {
+    const manifest = this.scanManifestUnlocked();
+    if (manifest.status !== 'complete') {
+      throw new BotSkillServiceError(
+        `Local Skill manifest is ${manifest.status}; refusing to treat it as a complete desired state.`,
+        'LOCAL_SKILL_MANIFEST_INCOMPLETE',
+        409,
+        manifest,
+      );
+    }
+    return manifest;
+  }
+
+  private findUniqueEntry(name: string) {
+    const manifest = this.requireCompleteManifest();
+    const normalized = String(name || '').trim();
+    const matches = manifest.entries.filter(entry => entry.name === normalized);
+    if (matches.length !== 1) {
+      throw new BotSkillServiceError(
+        matches.length ? 'Skill name is ambiguous.' : 'Skill not found.',
+        matches.length ? 'SKILL_NAME_AMBIGUOUS' : 'SKILL_NOT_FOUND',
+        matches.length ? 409 : 404,
+      );
+    }
+    return matches[0];
+  }
+
+  private inspectVerifiedPackage(
+    options: InstallVerifiedSkillHubPackageOptions,
+  ): { name: string; key: string; path: string } {
+    const packageObject = options.verification.packageObject;
+    const packageManifest = packageObject.payload.manifest as any;
+    const entry = packageObject.payload.files.find(file => file.path === 'SKILL.md');
+    if (!entry) {
+      throw new BotSkillServiceError(
+        'SkillHub package is missing a root SKILL.md.',
+        'SKILLHUB_SKILL_ENTRY_MISSING',
+        400,
+      );
+    }
+    let data: Record<string, any>;
+    try {
+      data = matter(Buffer.from(entry.contentBase64, 'base64').toString('utf8')).data;
+    } catch (error) {
+      throw new BotSkillServiceError(
+        `SkillHub SKILL.md frontmatter is invalid: ${error instanceof Error ? error.message : String(error)}`,
+        'SKILLHUB_SKILL_ENTRY_INVALID',
+        400,
+      );
+    }
+    const name = normalizedOptional(data.name);
+    const description = normalizedOptional(data.description);
+    const skillId = normalizedOptional(packageManifest.id)
+      ?? normalizedOptional(options.registryEntry.skillId);
+    const installName = normalizedOptional(packageManifest.name)
+      ?? normalizedOptional(options.registryEntry.name);
+    if (!name || !description || !skillId || !installName) {
+      throw new BotSkillServiceError(
+        'SkillHub package SKILL.md or manifest is missing required fields.',
+        'SKILLHUB_SKILL_ENTRY_INVALID',
+        400,
+      );
+    }
+    return {
+      name,
+      key: `skillhub:${skillId}`,
+      path: path.basename(this.resolveDirectChild(installName)),
+    };
+  }
+
+  private assertProspectiveEntry(
+    current: LocalSkillManifest,
+    incoming: { name: string; key: string; path: string },
+  ): void {
+    const targetPath = portableKey(incoming.path);
+    const conflict = current.entries.find(entry =>
+      portableKey(entry.path) !== targetPath
+      && (
+        portableKey(entry.name) === portableKey(incoming.name)
+        || portableKey(entry.key) === portableKey(incoming.key)
+      ));
+    if (conflict) {
+      throw new BotSkillServiceError(
+        `Incoming Skill conflicts with ${conflict.name} at ${conflict.path}.`,
+        'SKILL_MANIFEST_CONFLICT',
+        409,
+        current,
+      );
+    }
+  }
+
+  private workspaceContext(): {
+    botId?: string;
+    workspaceId?: string;
+  } {
+    const state: BotSkillWorkspaceState | undefined = this.managedWorkspace
+      ? this.workspaceService.readState()
+      : undefined;
+    const pendingTarget = state?.switchJournal?.to;
+    if (
+      pendingTarget
+      && pendingTarget.botId === this.expectedBotId
+      && this.activationTransactionId
+    ) {
+      return {
+        botId: pendingTarget.botId,
+        workspaceId: pendingTarget.workspaceId,
+      };
+    }
+    return {
+      botId: state?.workspaceOwnerBotId ?? this.expectedBotId,
+      workspaceId: state?.workspaceId,
+    };
+  }
+
+  private quarantineRemove(targetDir: string): void {
+    const operationDir = this.newOperationDirectory('remove');
+    const trashDir = path.join(operationDir, 'trash');
+    writeJsonAtomic(path.join(operationDir, 'remove-journal.json'), {
+      schema: 'xiaoba.local-skill-remove.v1',
+      phase: 'prepared',
+      targetDir,
+    });
+    fs.renameSync(targetDir, trashDir);
+    try {
+      writeJsonAtomic(path.join(operationDir, 'remove-journal.json'), {
+        schema: 'xiaoba.local-skill-remove.v1',
+        phase: 'removed',
+        targetDir,
+      });
+    } catch {
+      // The target-to-trash rename is the removal commit point.
+    }
+    try {
+      fs.rmSync(operationDir, { recursive: true, force: true });
+    } catch {
+      // Removal was committed by rename; stale trash is cleaned next time.
+    }
+  }
+
+  private commitStagedDirectory(
+    operationDir: string,
+    stagedDir: string,
+    targetDir: string,
+  ): void {
+    const backupDir = path.join(operationDir, 'backup');
+    const journalPath = path.join(operationDir, 'local-install-journal.json');
+    const stagedIdentity = readLocalSkillIdentity(stagedDir);
+    const journalBase = {
+      schema: 'xiaoba.local-skill-install.v1' as const,
+      targetDir,
+      targetExisted: fs.existsSync(targetDir),
+      expectedLocalSkillId: stagedIdentity?.localSkillId,
+      expectedContentHash: computeLocalSkillContentHash(stagedDir),
+    };
+    writeJsonAtomic(journalPath, {
+      ...journalBase,
+      phase: 'prepared',
+    });
+    if (fs.existsSync(targetDir)) {
+      fs.renameSync(targetDir, backupDir);
+      writeJsonAtomic(journalPath, {
+        ...journalBase,
+        phase: 'target-backed-up',
+      });
+    }
+    fs.renameSync(stagedDir, targetDir);
+    try {
+      writeJsonAtomic(journalPath, {
+        ...journalBase,
+        phase: 'target-active',
+      });
+    } catch {
+      // The target rename is the commit point. The prior journal phase is
+      // sufficient for recovery to keep the new active target.
+    }
+    try {
+      fs.rmSync(operationDir, { recursive: true, force: true });
+    } catch {
+      // The target rename committed the install. Stale operation data is
+      // recoverable and must not turn a successful local install into failure.
+    }
+  }
+
+  private recoverLocalOperations(): void {
+    if (!fs.existsSync(this.operationsRoot)) return;
+    this.assertOperationsRoot();
+    for (const entry of fs.readdirSync(this.operationsRoot, { withFileTypes: true })) {
+      if (!entry.isDirectory() || entry.isSymbolicLink()) continue;
+      const operationDir = path.join(this.operationsRoot, entry.name);
+      if (entry.name.startsWith('remove-')) {
+        fs.rmSync(operationDir, { recursive: true, force: true });
+        continue;
+      }
+      if (!entry.name.startsWith('local-install-')) continue;
+      const journalPath = path.join(operationDir, 'local-install-journal.json');
+      const stagedDir = path.join(operationDir, 'staged');
+      const backupDir = path.join(operationDir, 'backup');
+      if (!fs.existsSync(journalPath)) {
+        fs.rmSync(operationDir, { recursive: true, force: true });
+        continue;
+      }
+      const journal = readJsonFile(journalPath) as {
+        schema?: string;
+        phase?: string;
+        targetDir?: string;
+        targetExisted?: boolean;
+        expectedLocalSkillId?: string;
+        expectedContentHash?: string;
+      };
+      if (
+        journal.schema !== 'xiaoba.local-skill-install.v1'
+        || !['prepared', 'target-backed-up', 'target-active'].includes(String(journal.phase))
+        || !journal.targetDir
+        || (journal.targetExisted !== undefined && typeof journal.targetExisted !== 'boolean')
+        || (
+          journal.expectedLocalSkillId !== undefined
+          && typeof journal.expectedLocalSkillId !== 'string'
+        )
+        || (
+          journal.expectedContentHash !== undefined
+          && typeof journal.expectedContentHash !== 'string'
+        )
+      ) {
+        throw new BotSkillServiceError(
+          'Local Skill install transaction journal is invalid.',
+          'LOCAL_INSTALL_JOURNAL_INVALID',
+        );
+      }
+      const targetDir = this.assertContainedTarget(journal.targetDir);
+      if (fs.existsSync(stagedDir)) {
+        assertRealDirectoryContained(operationDir, stagedDir, 'Recovered staged Skill');
+      }
+      if (fs.existsSync(backupDir)) {
+        assertRealDirectoryContained(operationDir, backupDir, 'Recovered backup Skill');
+      }
+      if (
+        ['prepared', 'target-backed-up'].includes(String(journal.phase))
+        && !fs.existsSync(targetDir)
+        && fs.existsSync(backupDir)
+      ) {
+        fs.renameSync(backupDir, targetDir);
+      }
+      if (
+        journal.phase === 'target-active'
+        && !fs.existsSync(targetDir)
+        && fs.existsSync(backupDir)
+      ) {
+        throw new BotSkillServiceError(
+          'The committed local Skill target is missing while its backup still exists.',
+          'LOCAL_INSTALL_RECOVERY_AMBIGUOUS',
+        );
+      }
+      const targetExists = fs.existsSync(targetDir);
+      const backupExists = fs.existsSync(backupDir);
+      if (
+        targetExists
+        && (
+          backupExists
+          || journal.targetExisted === false
+          || journal.phase === 'target-active'
+        )
+      ) {
+        this.assertRecoveredLocalTarget(targetDir, journal, backupExists);
+      }
+      if (fs.existsSync(stagedDir)) fs.rmSync(stagedDir, { recursive: true, force: true });
+      if (fs.existsSync(backupDir) && fs.existsSync(targetDir)) {
+        fs.rmSync(backupDir, { recursive: true, force: true });
+      }
+      fs.rmSync(operationDir, { recursive: true, force: true });
+    }
+  }
+
+  private assertRecoveredLocalTarget(
+    targetDir: string,
+    journal: {
+      expectedLocalSkillId?: string;
+      expectedContentHash?: string;
+    },
+    hasBackup: boolean,
+  ): void {
+    this.assertSafeSkillDirectory(targetDir);
+    if (!journal.expectedLocalSkillId || !journal.expectedContentHash) {
+      if (hasBackup) {
+        throw new BotSkillServiceError(
+          'Cannot verify the recovered active Skill while a unique backup exists.',
+          'LOCAL_INSTALL_RECOVERY_AMBIGUOUS',
+        );
+      }
+      return;
+    }
+    const identity = readLocalSkillIdentity(targetDir);
+    if (
+      identity?.localSkillId !== journal.expectedLocalSkillId
+      || computeLocalSkillContentHash(targetDir) !== journal.expectedContentHash
+    ) {
+      throw new BotSkillServiceError(
+        'Recovered active Skill does not match its transaction journal.',
+        'LOCAL_INSTALL_RECOVERY_AMBIGUOUS',
+      );
+    }
+  }
+
+  private newOperationDirectory(prefix: string): string {
+    const operationDir = path.join(
+      this.operationsRoot,
+      `${prefix}-${process.pid}-${Date.now()}-${crypto.randomBytes(6).toString('hex')}`,
+    );
+    fs.mkdirSync(operationDir, { recursive: false, mode: 0o700 });
+    return operationDir;
+  }
+
+  private resolveDirectChild(installName: string): string {
+    const normalized = String(installName || '').trim();
+    if (
+      !/^[a-zA-Z0-9][a-zA-Z0-9._-]{0,79}$/.test(normalized)
+      || /[. ]$/.test(normalized)
+      || isWindowsReservedName(normalized)
+    ) {
+      throw new BotSkillServiceError(
+        `Unsafe Skill install name: ${installName}`,
+        'SKILL_INSTALL_NAME_UNSAFE',
+        400,
+      );
+    }
+    return this.assertContainedTarget(path.join(this.skillsRoot, normalized));
+  }
+
+  private assertContainedTarget(target: string): string {
+    const resolved = path.resolve(target);
+    const relative = path.relative(this.skillsRoot, resolved);
+    if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
+      throw new BotSkillServiceError(
+        `Skill target escapes the active workspace: ${target}`,
+        'SKILL_PATH_UNSAFE',
+        400,
+      );
+    }
+    return resolved;
+  }
+
+  private assertWorkspaceRoot(): void {
+    assertRealDirectoryContained(this.skillsRoot, this.skillsRoot, 'Skill workspace');
+  }
+
+  private assertOperationsRoot(): void {
+    assertRealDirectoryContained(this.operationsRoot, this.operationsRoot, 'Skill operation root');
+    if (!sameFilesystem(this.operationsRoot, this.skillsRoot)) {
+      throw new BotSkillServiceError(
+        'Skill operation staging must use the same filesystem as the workspace.',
+        'SKILL_OPERATION_FILESYSTEM_MISMATCH',
+      );
+    }
+  }
+
+  private assertSafeSkillDirectory(target: string): void {
+    assertRealDirectoryContained(this.skillsRoot, target, 'Skill directory');
+  }
+
+  private assertRealTree(target: string, label: string): void {
+    assertRealDirectoryContained(target, target, label);
+    const visit = (directory: string): void => {
+      for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+        const entryPath = path.join(directory, entry.name);
+        const stat = fs.lstatSync(entryPath);
+        if (stat.isSymbolicLink()) {
+          throw new BotSkillServiceError(
+            `${label} contains a symlink or junction: ${entryPath}`,
+            'SKILL_SOURCE_LINK_UNSAFE',
+            400,
+          );
+        }
+        if (stat.isDirectory()) visit(entryPath);
+      }
+    };
+    visit(target);
+  }
+
+  private acquireLocalLock(): string {
+    ensureDirectoryWithoutLinks(this.operationsRoot);
+    this.assertOperationsRoot();
+    const lockId = crypto.randomUUID();
+    try {
+      fs.mkdirSync(this.localLockPath, { mode: 0o700 });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+      const owner = readLockOwner(this.localLockPath);
+      if (owner && isProcessAlive(owner.pid)) {
+        throw new BotSkillServiceError(
+          `Another Skill operation is active in pid ${owner.pid}.`,
+          'SKILL_OPERATION_LOCKED',
+          423,
+        );
+      }
+      if (!owner && Date.now() - fs.statSync(this.localLockPath).mtimeMs < 30_000) {
+        throw new BotSkillServiceError(
+          'Another Skill operation lock is still being initialized.',
+          'SKILL_OPERATION_LOCKED',
+          423,
+        );
+      }
+      const stale = `${this.localLockPath}.stale.${crypto.randomUUID()}`;
+      try {
+        fs.renameSync(this.localLockPath, stale);
+      } catch {
+        throw new BotSkillServiceError(
+          'The Skill operation lock changed while checking stale ownership.',
+          'SKILL_OPERATION_LOCKED',
+          423,
+        );
+      }
+      fs.rmSync(stale, { recursive: true, force: true });
+      fs.mkdirSync(this.localLockPath, { mode: 0o700 });
+    }
+    writeJsonAtomic(path.join(this.localLockPath, 'owner.json'), {
+      lockId,
+      pid: process.pid,
+      acquiredAt: new Date().toISOString(),
+    });
+    return lockId;
+  }
+
+  private releaseLocalLock(lockId: string): void {
+    const owner = readLockOwner(this.localLockPath);
+    if (owner?.lockId === lockId && owner.pid === process.pid) {
+      fs.rmSync(this.localLockPath, { recursive: true, force: true });
+    }
+  }
+}
+
+export function createBotSkillService(
+  options: BotSkillServiceOptions = {},
+): BotSkillService {
+  return new BotSkillService(options);
+}
+
+function currentBotId(runtimeRoot: string): string | undefined {
+  return normalizedOptional(
+    createCatsCoLocalConfigService({ runtimeRoot }).load().currentBot?.uid,
+  );
+}
+
+function copyDirectoryStrict(sourceDir: string, targetDir: string): void {
+  fs.cpSync(sourceDir, targetDir, {
+    recursive: true,
+    errorOnExist: true,
+    force: false,
+    filter: source => {
+      const name = path.basename(source);
+      if (['.git', 'node_modules', '__pycache__'].includes(name)) return false;
+      if ([
+        BOT_SKILL_LOCAL_IDENTITY_FILE,
+        '.xiaoba-skillhub-install.json',
+      ].includes(name)) return false;
+      const stat = fs.lstatSync(source);
+      if (stat.isSymbolicLink()) {
+        throw new BotSkillServiceError(
+          `Local Skill source contains a symlink or junction: ${source}`,
+          'SKILL_SOURCE_LINK_UNSAFE',
+          400,
+        );
+      }
+      return true;
+    },
+  });
+}
+
+function assertRegularFile(filePath: string, label: string): void {
+  const stat = fs.lstatSync(filePath);
+  if (!stat.isFile() || stat.isSymbolicLink()) {
+    throw new BotSkillServiceError(`${label} must be a regular file.`, 'SKILL_PATH_UNSAFE', 400);
+  }
+}
+
+function assertRealDirectoryContained(root: string, target: string, label: string): void {
+  const rootPath = path.resolve(root);
+  const targetPath = path.resolve(target);
+  const targetStat = fs.lstatSync(targetPath);
+  if (!targetStat.isDirectory() || targetStat.isSymbolicLink()) {
+    throw new BotSkillServiceError(`${label} must be a real directory.`, 'SKILL_PATH_UNSAFE', 400);
+  }
+  const relative = path.relative(rootPath, targetPath);
+  if (relative === '..' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    throw new BotSkillServiceError(`${label} escapes its root.`, 'SKILL_PATH_UNSAFE', 400);
+  }
+  const realRoot = fs.realpathSync.native(rootPath);
+  const realTarget = fs.realpathSync.native(targetPath);
+  const realRelative = path.relative(realRoot, realTarget);
+  if (
+    realRelative === '..'
+    || realRelative.startsWith(`..${path.sep}`)
+    || path.isAbsolute(realRelative)
+    || !samePath(targetPath, realTarget)
+  ) {
+    throw new BotSkillServiceError(
+      `${label} traverses a symlink or junction.`,
+      'SKILL_PATH_UNSAFE',
+      400,
+    );
+  }
+}
+
+function ensureDirectoryWithoutLinks(target: string): void {
+  const resolved = path.resolve(target);
+  const parsed = path.parse(resolved);
+  let current = parsed.root;
+  for (const segment of resolved.slice(parsed.root.length).split(path.sep).filter(Boolean)) {
+    current = path.join(current, segment);
+    if (!fs.existsSync(current)) {
+      fs.mkdirSync(current, { mode: 0o700 });
+    }
+    const stat = fs.lstatSync(current);
+    if (!stat.isDirectory() || stat.isSymbolicLink() || !samePath(current, fs.realpathSync.native(current))) {
+      throw new BotSkillServiceError(
+        `Skill operation path traverses a symlink or junction: ${current}`,
+        'SKILL_OPERATION_PATH_UNSAFE',
+        400,
+      );
+    }
+  }
+}
+
+function writeJsonAtomic(filePath: string, value: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
+  const temporary = `${filePath}.${process.pid}.${crypto.randomUUID()}.tmp`;
+  fs.writeFileSync(temporary, `${JSON.stringify(value, null, 2)}\n`, {
+    encoding: 'utf8',
+    mode: 0o600,
+    flag: 'wx',
+  });
+  fs.renameSync(temporary, filePath);
+}
+
+function readJsonFile(filePath: string): unknown {
+  const stat = fs.lstatSync(filePath);
+  if (!stat.isFile() || stat.isSymbolicLink() || stat.size > 256 * 1024) {
+    throw new BotSkillServiceError('Skill operation metadata is invalid.', 'SKILL_OPERATION_METADATA_INVALID');
+  }
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function readLockOwner(lockPath: string): { lockId: string; pid: number } | undefined {
+  const filePath = path.join(lockPath, 'owner.json');
+  if (!fs.existsSync(filePath)) return undefined;
+  try {
+    const value = readJsonFile(filePath) as { lockId?: unknown; pid?: unknown };
+    if (typeof value.lockId === 'string' && Number.isInteger(value.pid) && Number(value.pid) > 0) {
+      return { lockId: value.lockId, pid: Number(value.pid) };
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+function normalizedOptional(value: unknown): string | undefined {
+  const normalized = typeof value === 'string' ? value.trim() : '';
+  return normalized || undefined;
+}
+
+function sameFilesystem(left: string, right: string): boolean {
+  try {
+    return fs.statSync(left).dev === fs.statSync(right).dev;
+  } catch {
+    // Fall back to volume roots before both paths have been materialized.
+  }
+  return path.parse(path.resolve(left)).root.toLowerCase()
+    === path.parse(path.resolve(right)).root.toLowerCase();
+}
+
+function samePath(left: string, right: string): boolean {
+  const normalizedLeft = path.resolve(left);
+  const normalizedRight = path.resolve(right);
+  return process.platform === 'win32'
+    ? normalizedLeft.toLowerCase() === normalizedRight.toLowerCase()
+    : normalizedLeft === normalizedRight;
+}
+
+function sha256(value: string): string {
+  return crypto.createHash('sha256').update(value, 'utf8').digest('hex');
+}
+
+function portableKey(value: string): string {
+  return String(value).normalize('NFC').toLocaleLowerCase('en-US');
+}
+
+function isWindowsReservedName(value: string): boolean {
+  const stem = value.replace(/[. ]+$/g, '').split('.')[0].toUpperCase();
+  return /^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])$/.test(stem);
+}

--- a/src/commands/catscompany.ts
+++ b/src/commands/catscompany.ts
@@ -19,6 +19,7 @@ import { CloudBotModelRuntimeReloadController } from '../bot-definition/runtime-
 import { createBotDefinitionSyncService } from '../bot-definition/service';
 import { createBotSkillWorkspaceService } from '../bot-skills/workspace-service';
 import { recoverBotSkillActivation } from '../bot-skills/activation-recovery';
+import { createBotSkillService } from '../bot-skills/service';
 import * as fs from 'node:fs';
 
 const CONNECTOR_OWNER_POLL_MS = 2000;
@@ -64,6 +65,17 @@ export async function catscompanyCommand(): Promise<void> {
       allowCreate: Array.isArray(preparedBot?.definition.skills) &&
         preparedBot.definition.skills.length === 0,
     });
+  }
+  if (configuredBotId && !process.env.XIAOBA_BOT_SKILL_ACTIVATION_TX) {
+    const manifest = await createBotSkillService({ runtimeRoot }).scanManifest();
+    if (manifest.status !== 'complete') {
+      const issues = manifest.issues
+        .map(issue => `[${issue.code}]${issue.path ? ` ${issue.path}:` : ''} ${issue.message}`)
+        .join('; ');
+      throw new Error(
+        `Active Bot Skill manifest is ${manifest.status}.${issues ? ` ${issues}` : ''}`,
+      );
+    }
   }
   if (preparedBot?.cloudRevision !== undefined) {
     Logger.info(`CatsCo bot ${preparedBot.botId} 已准备云端模型配置 revision=${preparedBot.cloudRevision}。`);

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -2,11 +2,12 @@ import { Command } from 'commander';
 import { Logger } from '../utils/logger';
 import { styles } from '../theme/colors';
 import { SkillManager } from '../skills/skill-manager';
-import { PathResolver } from '../utils/path-resolver';
-import { execSync } from 'child_process';
+import { createBotSkillService } from '../bot-skills/service';
+import { execFileSync, execSync } from 'child_process';
 import chalk from 'chalk';
 import * as path from 'path';
 import * as fs from 'fs';
+import * as os from 'os';
 import inquirer from 'inquirer';
 
 /**
@@ -46,8 +47,9 @@ export function registerSkillCommand(program: Command): void {
   skillCmd
     .command('install-github <repo>')
     .description('从 GitHub 仓库安装 skill (格式: owner/repo)')
-    .action(async (repo: string) => {
-      await installGithubSkill(repo);
+    .option('--skill <name>', '从集合仓库中选择一个 Skill 目录')
+    .action(async (repo: string, options: { skill?: string }) => {
+      await installGithubSkill(repo, options.skill);
     });
 
   // skill remove - 移除 skill
@@ -165,60 +167,102 @@ async function showSkillInfo(name: string): Promise<void> {
 /**
  * 从 GitHub 安装 skill
  */
-async function installGithubSkill(repo: string): Promise<void> {
+async function installGithubSkill(repo: string, selectedSkill?: string): Promise<void> {
+  const botSkills = createBotSkillService();
   Logger.title(`从 GitHub 安装 Skill: ${repo}`);
 
   // 解析仓库地址
-  const repoMatch = repo.match(/^([^\/]+)\/([^\/]+)$/);
+  const repoMatch = repo.match(/^([A-Za-z0-9](?:[A-Za-z0-9-]{0,38}))\/([A-Za-z0-9][A-Za-z0-9._-]{0,99})$/);
   if (!repoMatch) {
     Logger.error('仓库地址格式错误，应为: owner/repo');
-    Logger.info('例如: obra/superpowers');
+    Logger.info('例如: obra/superpowers --skill brainstorming');
     process.exit(1);
   }
 
   const [, owner, repoName] = repoMatch;
   const githubUrl = `https://github.com/${owner}/${repoName}.git`;
 
-  // 统一安装到 ~/.xiaoba/skills/
-  const targetDir = PathResolver.getSkillsPath();
-  PathResolver.ensureDir(targetDir);
-
-  const skillPath = path.join(targetDir, repoName);
-
-  // 检查目录是否已存在
-  if (fs.existsSync(skillPath)) {
-    Logger.warning(`Skill 目录已存在: ${skillPath}`);
-    Logger.info('如需重新安装，请先删除该目录');
-    process.exit(1);
-  }
-
+  const temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-skill-github-'));
+  const repositoryDir = path.join(temporaryRoot, 'source');
   try {
     Logger.info(`\n克隆仓库: ${chalk.gray(githubUrl)}`);
-    Logger.info(`目标目录: ${chalk.gray(skillPath)} (项目 skills 目录)\n`);
 
     // 克隆仓库
-    execSync(`git clone ${githubUrl} "${skillPath}"`, {
+    execFileSync('git', ['clone', '--depth', '1', '--', githubUrl, repositoryDir], {
       stdio: 'inherit',
-      cwd: targetDir
+    });
+    const selection = selectGithubSkillDirectory(
+      repositoryDir,
+      repoName,
+      selectedSkill,
+    );
+    const mutation = await botSkills.installLocalDirectory({
+      sourceDir: selection.sourceDir,
+      installName: selection.installName,
     });
 
-    Logger.success(`\n✓ Skill ${styles.highlight(repoName)} 安装成功！`);
-    Logger.info(`安装位置: ${skillPath}`);
+    Logger.success(`\n✓ Skill ${styles.highlight(selection.installName)} 安装成功！`);
+    Logger.info(`安装位置: ${mutation.result.path}`);
     Logger.info('\n使用 catsco skill list 查看已安装的 skills');
   } catch (error: any) {
     Logger.error(`安装失败: ${error.message}`);
 
     // 清理失败的安装
-    if (fs.existsSync(skillPath)) {
+    if (fs.existsSync(temporaryRoot)) {
       try {
-        fs.rmSync(skillPath, { recursive: true, force: true });
-      } catch (cleanupError) {
-        // 忽略清理错误
+        fs.rmSync(temporaryRoot, { recursive: true, force: true });
+      } catch {
+        // Ignore temporary clone cleanup errors.
       }
     }
-
     process.exit(1);
+  } finally {
+    fs.rmSync(temporaryRoot, { recursive: true, force: true });
   }
+}
+
+function selectGithubSkillDirectory(
+  repositoryDir: string,
+  repoName: string,
+  selectedSkill?: string,
+): { sourceDir: string; installName: string } {
+  const rootEntry = path.join(repositoryDir, 'SKILL.md');
+  const requested = String(selectedSkill || '').trim();
+  if (fs.existsSync(rootEntry) && !requested) {
+    return { sourceDir: repositoryDir, installName: repoName };
+  }
+
+  const candidates: Array<{ sourceDir: string; installName: string }> = [];
+  const visit = (directory: string): void => {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      if (entry.isSymbolicLink()) continue;
+      if (!entry.isDirectory() || ['.git', 'node_modules', '__pycache__'].includes(entry.name)) {
+        continue;
+      }
+      const child = path.join(directory, entry.name);
+      if (fs.existsSync(path.join(child, 'SKILL.md'))) {
+        candidates.push({ sourceDir: child, installName: entry.name });
+      } else {
+        visit(child);
+      }
+    }
+  };
+  visit(repositoryDir);
+  const matches = requested
+    ? candidates.filter(candidate => candidate.installName === requested)
+    : candidates;
+  if (matches.length === 1) return matches[0];
+
+  const available = candidates.map(candidate => candidate.installName).sort().join(', ');
+  if (!requested && candidates.length > 1) {
+    throw new Error(
+      `该仓库包含多个 Skills，请使用 --skill <name> 选择一个：${available}`,
+    );
+  }
+  throw new Error(
+    `未找到可安装的 Skill${requested ? `：${requested}` : ''}`
+    + `${available ? `。可选：${available}` : '；仓库根目录或子目录必须包含 SKILL.md'}`,
+  );
 }
 
 /**
@@ -283,6 +327,7 @@ async function removeNpmSkill(packageName: string, force?: boolean): Promise<voi
  * 移除本地 skill
  */
 async function removeLocalSkill(name: string, force?: boolean): Promise<void> {
+  const botSkills = createBotSkillService();
   const manager = new SkillManager();
   await manager.loadSkills();
   const skill = manager.getSkill(name);
@@ -317,7 +362,7 @@ async function removeLocalSkill(name: string, force?: boolean): Promise<void> {
 
   try {
     Logger.info(`\n正在移除: ${chalk.gray(skillDir)}`);
-    fs.rmSync(skillDir, { recursive: true, force: true });
+    await botSkills.removeByName(name);
     Logger.success(`\n✓ Skill ${styles.highlight(name)} 已成功移除！`);
     Logger.info(`已删除目录: ${skillDir}`);
   } catch (error: any) {

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -71,10 +71,13 @@ import { registerSkillHubRoutes } from './skillhub';
 import { registerPetRoutes } from './pet';
 import type { DashboardAuthStatus } from '../auth';
 import { SkillHubService } from '../../skillhub/service';
+import { bootstrapDefaultSkillHubSkillsOnce } from '../../skillhub/default-skill-bootstrap';
+import { Logger } from '../../utils/logger';
 import {
   computeLocalSkillContentHash,
   readSkillHubLocalMetadata,
 } from '../../skillhub/local-skill-metadata';
+import { createBotSkillService } from '../../bot-skills/service';
 import {
   deletePromptOverride,
   getPromptEditorFile,
@@ -943,6 +946,13 @@ async function commitCatsBotBindingAndStartConnector(
         allowCreate: false,
         lock: activationLock,
       });
+      const sourceManifest = await createBotSkillService({
+        runtimeRoot,
+        expectedBotId: previousBotId,
+        workspaceService,
+        activationLock,
+      }).scanManifest();
+      assertBotSkillManifestReady(sourceManifest);
     } else {
       workspaceService.ensureActive(input.botUid, {
         allowCreate: allowCreateSkillWorkspace,
@@ -969,6 +979,16 @@ async function commitCatsBotBindingAndStartConnector(
     }
 
     const updated = writeCatsBotBinding(state, input);
+    if (switchChanged || initialClaimed) {
+      const targetManifest = await createBotSkillService({
+        runtimeRoot,
+        expectedBotId: input.botUid,
+        workspaceService,
+        activationLock,
+        activationTransactionId: switchTransactionId,
+      }).scanManifest();
+      assertBotSkillManifestReady(targetManifest);
+    }
     let service: any;
     let startPreflight = targetPreflight;
     let connectorStarted = false;
@@ -1027,6 +1047,21 @@ async function commitCatsBotBindingAndStartConnector(
         // snapshot is safe to remove during the next startup recovery.
       }
       bindingSnapshotPersisted = false;
+    }
+    if (switchChanged || initialClaimed) {
+      const activeState = workspaceService.readState();
+      const scopedBotSkills = createBotSkillService({
+        runtimeRoot,
+        expectedBotId: input.botUid,
+        workspaceService,
+        activationLock,
+      });
+      await bootstrapDefaultSkillHubSkillsOnce({
+        workspaceId: activeState?.workspaceId,
+        service: new SkillHubService({ botSkillService: scopedBotSkills }),
+      }).catch(error => {
+        Logger.warning(`Default SkillHub bootstrap failed after Bot activation: ${error?.message || String(error)}`);
+      });
     }
     return {
       updated,
@@ -1099,6 +1134,25 @@ async function commitCatsBotBindingAndStartConnector(
       }
     }
   }
+}
+
+function assertBotSkillManifestReady(manifest: {
+  status: string;
+  issues?: unknown[];
+}): void {
+  if (manifest.status === 'complete') return;
+  const error = httpError(
+    `Bot Skill workspace manifest is ${manifest.status}.`,
+    409,
+  ) as Error & { code?: string; data?: unknown };
+  error.code = 'bot_skill_manifest_not_ready';
+  error.data = {
+    manifest: {
+      status: manifest.status,
+      issues: manifest.issues ?? [],
+    },
+  };
+  throw error;
 }
 
 function normalizeRelayModelProtocol(value: unknown): RelayModelProtocol {
@@ -2114,6 +2168,33 @@ function sanitizeCatsErrorData(data: unknown): unknown {
       };
       continue;
     }
+    if (key === 'manifest' && value && typeof value === 'object') {
+      const manifest = value as Record<string, unknown>;
+      safe.manifest = {
+        ...(typeof manifest.status === 'string' ? { status: manifest.status } : {}),
+        ...(Array.isArray(manifest.issues)
+          ? {
+            issues: manifest.issues
+              .filter(item => item && typeof item === 'object')
+              .map(item => {
+                const issue = item as Record<string, unknown>;
+                return {
+                  ...(typeof issue.code === 'string'
+                    ? { code: sanitizeCatsErrorMessage(issue.code) }
+                    : {}),
+                  ...(typeof issue.message === 'string'
+                    ? { message: sanitizeCatsErrorMessage(issue.message) }
+                    : {}),
+                  ...(typeof issue.path === 'string'
+                    ? { path: sanitizeCatsErrorMessage(issue.path) }
+                    : {}),
+                };
+              }),
+          }
+          : {}),
+      };
+      continue;
+    }
     const lower = key.toLowerCase();
     if (
       lower.includes('key')
@@ -2144,6 +2225,7 @@ function sanitizeCatsErrorMessage(value: unknown): string {
 
 function catsErrorResponse(error: any): { status: number; body: Record<string, unknown> } {
   const body: Record<string, unknown> = { error: sanitizeCatsErrorMessage(error.message) };
+  if (typeof error?.code === 'string') body.code = sanitizeCatsErrorMessage(error.code);
   const data = sanitizeCatsErrorData(error.data);
   if (data) body.data = data;
   return { status: error.status || 500, body };
@@ -2602,14 +2684,18 @@ export function createApiRouter(
     }
   });
 
-  router.post('/prompts/editor-skill/install', (req, res) => {
+  router.post('/prompts/editor-skill/install', async (req, res) => {
     try {
       if (!requireJsonWrite(req, res)) return;
-      res.json(installPromptEditorSeedSkill({
+      res.json(await installPromptEditorSeedSkill({
         overwrite: req.body?.overwrite === true,
       }));
     } catch (e: any) {
-      res.status(400).json({ error: e?.message || String(e) });
+      res.status(e?.status || 400).json({
+        error: e?.message || String(e),
+        code: e?.code,
+        manifest: e?.manifest,
+      });
     }
   });
 
@@ -3183,8 +3269,7 @@ export function createApiRouter(
   router.get('/skills-root', async (_req, res) => {
     try {
       const skillsRoot = PathResolver.getSkillsPath();
-      PathResolver.ensureDir(skillsRoot);
-      res.json({ ok: true, path: skillsRoot });
+      res.json({ ok: true, path: skillsRoot, exists: fs.existsSync(skillsRoot) });
     } catch (e: any) {
       res.status(500).json({ error: e.message });
     }
@@ -3212,6 +3297,7 @@ export function createApiRouter(
 
   router.delete('/skills/:name', async (req, res) => {
     try {
+      const botSkills = createBotSkillService();
       const manager = new SkillManager();
       await manager.loadSkills();
       const skill = manager.getSkill(req.params.name);
@@ -3222,7 +3308,7 @@ export function createApiRouter(
           if (!management.canDelete) {
             return res.status(403).json({ error: formatSkillDeleteBlockedMessage(management) });
           }
-          fs.rmSync(path.dirname(disabled), { recursive: true, force: true });
+          await botSkills.removeByName(req.params.name);
           return res.json({ ok: true });
         }
         return res.status(404).json({ error: 'Skill not found' });
@@ -3231,15 +3317,20 @@ export function createApiRouter(
       if (!management.canDelete) {
         return res.status(403).json({ error: formatSkillDeleteBlockedMessage(management) });
       }
-      fs.rmSync(path.dirname(skill.filePath), { recursive: true, force: true });
+      await botSkills.removeByName(req.params.name);
       res.json({ ok: true });
     } catch (e: any) {
-      res.status(500).json({ error: e.message });
+      res.status(e?.status || 500).json({
+        error: e.message,
+        code: e?.code,
+        manifest: e?.manifest,
+      });
     }
   });
 
   router.post('/skills/:name/disable', async (req, res) => {
     try {
+      const botSkills = createBotSkillService();
       const manager = new SkillManager();
       await manager.loadSkills();
       const skill = manager.getSkill(req.params.name);
@@ -3248,21 +3339,30 @@ export function createApiRouter(
       if (!management.canDisable) {
         return res.status(403).json({ error: '系统 Skill 不能禁用。' });
       }
-      fs.renameSync(skill.filePath, skill.filePath + '.disabled');
+      await botSkills.setEnabledByName(req.params.name, false);
       res.json({ ok: true });
     } catch (e: any) {
-      res.status(500).json({ error: e.message });
+      res.status(e?.status || 500).json({
+        error: e.message,
+        code: e?.code,
+        manifest: e?.manifest,
+      });
     }
   });
 
   router.post('/skills/:name/enable', async (req, res) => {
     try {
+      const botSkills = createBotSkillService();
       const f = findDisabledSkillByName(PathResolver.getSkillsPath(), req.params.name);
       if (!f) return res.status(404).json({ error: 'Disabled skill not found' });
-      fs.renameSync(f, f.replace('.disabled', ''));
+      await botSkills.setEnabledByName(req.params.name, true);
       res.json({ ok: true });
     } catch (e: any) {
-      res.status(500).json({ error: e.message });
+      res.status(e?.status || 500).json({
+        error: e.message,
+        code: e?.code,
+        manifest: e?.manifest,
+      });
     }
   });
 
@@ -4341,52 +4441,31 @@ function sanitizeServerUrl(serverUrl?: string): string | undefined {
   }
 }
 
-function installPromptEditorSeedSkill(options: { overwrite?: boolean } = {}): any {
+async function installPromptEditorSeedSkill(options: { overwrite?: boolean } = {}): Promise<any> {
   const sourceDir = resolvePromptEditorSeedSkillDir();
   const sourceSkillFile = path.join(sourceDir, 'SKILL.md');
   if (!fs.existsSync(sourceSkillFile)) {
     throw new Error('Prompt editor seed skill is missing from this build.');
   }
 
-  const skillsRoot = PathResolver.getSkillsPath();
-  PathResolver.ensureDir(skillsRoot);
-  const targetDir = resolveChildDirectory(skillsRoot, PROMPT_EDITOR_SKILL_NAME);
-  const targetSkillFile = path.join(targetDir, 'SKILL.md');
-  const disabledSkillFile = targetSkillFile + '.disabled';
-  const targetDirExists = fs.existsSync(targetDir);
-  const existing = targetDirExists || fs.existsSync(targetSkillFile) || fs.existsSync(disabledSkillFile);
-
-  if (existing && !options.overwrite) {
-    return {
-      ok: true,
-      installed: false,
-      existing: true,
-      name: PROMPT_EDITOR_SKILL_NAME,
-      path: fs.existsSync(targetSkillFile)
-        ? targetSkillFile
-        : (fs.existsSync(disabledSkillFile) ? disabledSkillFile : targetDir),
-      disabled: !fs.existsSync(targetSkillFile),
-    };
-  }
-
-  if (targetDirExists) {
-    fs.rmSync(targetDir, { recursive: true, force: true });
-  }
-  fs.mkdirSync(path.dirname(targetSkillFile), { recursive: true });
-  fs.cpSync(sourceDir, targetDir, {
-    recursive: true,
-    filter: source => {
-      const name = path.basename(source).toLowerCase();
-      return name !== '.git' && name !== 'node_modules' && name !== '__pycache__';
-    },
+  const mutation = await createBotSkillService().installLocalDirectory({
+    sourceDir,
+    installName: PROMPT_EDITOR_SKILL_NAME,
+    overwrite: options.overwrite,
   });
+  const targetDir = mutation.result.path;
+  const activeSkillFile = path.join(targetDir, 'SKILL.md');
+  const disabledSkillFile = path.join(targetDir, 'SKILL.md.disabled');
 
   return {
     ok: true,
-    installed: true,
-    existing: false,
+    installed: mutation.result.installed,
+    existing: mutation.result.existing,
     name: PROMPT_EDITOR_SKILL_NAME,
-    path: targetSkillFile,
+    path: fs.existsSync(activeSkillFile)
+      ? activeSkillFile
+      : (fs.existsSync(disabledSkillFile) ? disabledSkillFile : targetDir),
+    disabled: !fs.existsSync(activeSkillFile),
   };
 }
 
@@ -4411,16 +4490,6 @@ function resolvePromptEditorSeedSkillDir(): string {
   }
 
   return path.join(path.resolve(candidates[0] || process.cwd()), 'skills', PROMPT_EDITOR_SKILL_NAME);
-}
-
-function resolveChildDirectory(rootDir: string, childName: string): string {
-  const root = path.resolve(rootDir);
-  const target = path.resolve(root, childName);
-  const relative = path.relative(root, target);
-  if (relative.startsWith('..') || path.isAbsolute(relative)) {
-    throw new Error(`Unsafe target path: ${childName}`);
-  }
-  return target;
 }
 
 // ==================== Helpers ====================

--- a/src/dashboard/routes/skillhub.ts
+++ b/src/dashboard/routes/skillhub.ts
@@ -192,5 +192,17 @@ function sendSkillHubError(res: any, error: any): void {
   res.status(status).json({
     error: error?.message || String(error),
     code: error?.code || 'skillhub.error',
+    ...(error?.manifest ? {
+      manifest: {
+        status: error.manifest.status,
+        issues: Array.isArray(error.manifest.issues)
+          ? error.manifest.issues.map((issue: any) => ({
+            code: issue?.code,
+            message: issue?.message,
+            path: issue?.path,
+          }))
+          : [],
+      },
+    } : {}),
   });
 }

--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -12,6 +12,7 @@ import { createBotSkillWorkspaceService } from '../bot-skills/workspace-service'
 import { recoverBotSkillActivation } from '../bot-skills/activation-recovery';
 import * as fs from 'node:fs';
 import { FileBotDefinitionRepository } from '../bot-definition/repository';
+import { createBotSkillService } from '../bot-skills/service';
 
 const DEFAULT_PORT = 3800;
 const activeServers: Server[] = [];
@@ -51,6 +52,7 @@ export async function startDashboard(
   ) || fs.existsSync(
     path.join(runtimeRoot, 'data', 'bot-skills', 'binding-rollback.json'),
   );
+  let activeBotWorkspaceReady = false;
   if (initialBotId || workspaceMetadataExists) {
     const workspaceService = createBotSkillWorkspaceService({ runtimeRoot });
     recoverBotSkillActivation(runtimeRoot, workspaceService);
@@ -73,11 +75,25 @@ export async function startDashboard(
         allowCreate: Array.isArray(definition?.skills) && definition.skills.length === 0,
       });
     }
+    const manifest = await createBotSkillService({ runtimeRoot }).scanManifest();
+    if (manifest.status === 'partial') {
+      Logger.warning(
+        `Active Bot Skill manifest is partial; Dashboard will start in degraded mode. ${formatManifestIssues(manifest.issues)}`,
+      );
+    } else if (manifest.status !== 'complete') {
+      throw new Error(`Active Bot Skill manifest is ${manifest.status}.`);
+    } else {
+      activeBotWorkspaceReady = true;
+    }
   }
 
-  await bootstrapDefaultSkillHubSkillsOnce().catch(error => {
-    Logger.warning(`Default SkillHub bootstrap failed: ${error?.message || String(error)}`);
-  });
+  if (activeBotWorkspaceReady) {
+    const workspaceId = createBotSkillWorkspaceService({ runtimeRoot })
+      .readState()?.workspaceId;
+    await bootstrapDefaultSkillHubSkillsOnce({ workspaceId }).catch(error => {
+      Logger.warning(`Default SkillHub bootstrap failed: ${error?.message || String(error)}`);
+    });
+  }
 
   // Configure and apply dashboard authentication.
   // Trim the env var so whitespace-only values are treated as "not set"
@@ -132,6 +148,14 @@ export async function startDashboard(
       await Promise.all(activeServers.splice(0).map(closeServer));
     },
   };
+}
+
+function formatManifestIssues(
+  issues: Array<{ code: string; message: string; path?: string }>,
+): string {
+  return issues
+    .map(issue => `[${issue.code}]${issue.path ? ` ${issue.path}:` : ''} ${issue.message}`)
+    .join('; ');
 }
 
 function closeServer(server: Server): Promise<void> {

--- a/src/skillhub/client.ts
+++ b/src/skillhub/client.ts
@@ -35,6 +35,8 @@ export interface SkillHubCatsCoExchangeInput {
   };
 }
 
+const MAX_SKILLHUB_PACKAGE_BYTES = 32 * 1024 * 1024;
+
 export class SkillHubClient {
   readonly config: SkillHubConfig;
   private readonly sessionStore: SkillHubSessionStore;
@@ -119,7 +121,25 @@ export class SkillHubClient {
   async downloadPackage(entry: SkillHubRegistryEntry): Promise<Buffer> {
     const path = `/api/skills/${encodeSkillIdPath(entry.skillId)}/versions/${encodeURIComponent(entry.latestVersion)}/download`;
     const response = await this.fetchRaw('GET', path);
-    return Buffer.from(await response.arrayBuffer());
+    const declaredLength = Number(response.headers.get('content-length') || 0);
+    if (Number.isFinite(declaredLength) && declaredLength > MAX_SKILLHUB_PACKAGE_BYTES) {
+      throw packageTooLarge();
+    }
+    if (!response.body) return Buffer.alloc(0);
+    const reader = response.body.getReader();
+    const chunks: Buffer[] = [];
+    let total = 0;
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > MAX_SKILLHUB_PACKAGE_BYTES) {
+        await reader.cancel().catch(() => undefined);
+        throw packageTooLarge();
+      }
+      chunks.push(Buffer.from(value));
+    }
+    return Buffer.concat(chunks, total);
   }
 
   async getDeveloperDashboard(): Promise<SkillHubDeveloperDashboard> {
@@ -250,5 +270,14 @@ function encodeSkillIdPath(skillId: string): string {
 
 function withStatus(error: Error, status: number): Error {
   (error as any).status = status;
+  return error;
+}
+
+function packageTooLarge(): Error {
+  const error = withStatus(
+    new Error(`SkillHub package exceeds ${MAX_SKILLHUB_PACKAGE_BYTES} bytes.`),
+    502,
+  );
+  (error as any).code = 'skillhub.package_too_large';
   return error;
 }

--- a/src/skillhub/default-skill-bootstrap.ts
+++ b/src/skillhub/default-skill-bootstrap.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import * as crypto from 'crypto';
 import { PathResolver } from '../utils/path-resolver';
 import { Logger } from '../utils/logger';
 import { loadSkillHubConfig } from './config';
@@ -42,21 +43,25 @@ export interface DefaultSkillBootstrapResult {
 export interface DefaultSkillBootstrapOptions {
   skills?: DefaultSkillHubSkill[];
   service?: Pick<SkillHubService, 'install'>;
+  workspaceId?: string;
   now?: () => Date;
 }
 
-let bootstrapInFlight: Promise<DefaultSkillBootstrapResult[]> | null = null;
+const bootstrapInFlight = new Map<string, Promise<DefaultSkillBootstrapResult[]>>();
 
 export function bootstrapDefaultSkillHubSkillsOnce(
   options: DefaultSkillBootstrapOptions = {},
 ): Promise<DefaultSkillBootstrapResult[]> {
-  if (!bootstrapInFlight) {
-    bootstrapInFlight = bootstrapDefaultSkillHubSkills(options)
+  const statePath = getDefaultSkillBootstrapStatePath(options.workspaceId);
+  let inFlight = bootstrapInFlight.get(statePath);
+  if (!inFlight) {
+    inFlight = bootstrapDefaultSkillHubSkills(options)
       .finally(() => {
-        bootstrapInFlight = null;
+        bootstrapInFlight.delete(statePath);
       });
+    bootstrapInFlight.set(statePath, inFlight);
   }
-  return bootstrapInFlight;
+  return inFlight;
 }
 
 export async function bootstrapDefaultSkillHubSkills(
@@ -67,7 +72,8 @@ export async function bootstrapDefaultSkillHubSkills(
 
   const service = options.service ?? new SkillHubService();
   const now = options.now ?? (() => new Date());
-  const statePath = getDefaultSkillBootstrapStatePath();
+  const statePath = getDefaultSkillBootstrapStatePath(options.workspaceId);
+  migrateLegacyStateIfNeeded(statePath, options.workspaceId);
   const state = readStateFile(statePath);
   const results: DefaultSkillBootstrapResult[] = [];
   let changed = false;
@@ -142,8 +148,20 @@ export async function bootstrapDefaultSkillHubSkills(
   return results;
 }
 
-export function getDefaultSkillBootstrapStatePath(): string {
-  return path.join(loadSkillHubConfig().dataDir, 'default-skills-state.json');
+export function getDefaultSkillBootstrapStatePath(workspaceId?: string): string {
+  const dataDir = loadSkillHubConfig().dataDir;
+  const normalized = String(workspaceId || '').trim();
+  if (!normalized) return path.join(dataDir, 'default-skills-state.json');
+  const scope = crypto.createHash('sha256').update(normalized, 'utf8').digest('hex');
+  return path.join(dataDir, 'default-skills', `w_${scope}.json`);
+}
+
+function migrateLegacyStateIfNeeded(statePath: string, workspaceId?: string): void {
+  if (!String(workspaceId || '').trim() || fs.existsSync(statePath)) return;
+  const legacyPath = getDefaultSkillBootstrapStatePath();
+  if (!fs.existsSync(legacyPath)) return;
+  fs.mkdirSync(path.dirname(statePath), { recursive: true });
+  fs.renameSync(legacyPath, statePath);
 }
 
 function isValidDefaultSkill(item: DefaultSkillHubSkill): boolean {

--- a/src/skillhub/install-marker.ts
+++ b/src/skillhub/install-marker.ts
@@ -4,11 +4,16 @@ import { PathResolver } from '../utils/path-resolver';
 import type { SkillHubPackageInstallMarker } from './types';
 
 export const SKILLHUB_INSTALL_MARKER_FILE = '.xiaoba-skillhub-install.json';
+const MAX_INSTALL_MARKER_BYTES = 64 * 1024;
 
 export function readSkillHubInstallMarker(skillDir: string): SkillHubPackageInstallMarker | null {
   const markerPath = path.join(skillDir, SKILLHUB_INSTALL_MARKER_FILE);
   if (!fs.existsSync(markerPath)) return null;
   try {
+    const stat = fs.lstatSync(markerPath);
+    if (!stat.isFile() || stat.isSymbolicLink() || stat.size > MAX_INSTALL_MARKER_BYTES) {
+      return null;
+    }
     const value = JSON.parse(fs.readFileSync(markerPath, 'utf8')) as Partial<SkillHubPackageInstallMarker>;
     if (
       value?.source !== 'skillhub'
@@ -16,6 +21,7 @@ export function readSkillHubInstallMarker(skillDir: string): SkillHubPackageInst
       || !stringValue(value.name)
       || !stringValue(value.installName)
       || !stringValue(value.version)
+      || (value.installedContentHash !== undefined && !stringValue(value.installedContentHash))
     ) {
       return null;
     }
@@ -29,7 +35,14 @@ export function writeSkillHubInstallMarker(skillDir: string, marker: SkillHubPac
   fs.mkdirSync(skillDir, { recursive: true });
   const markerPath = path.join(skillDir, SKILLHUB_INSTALL_MARKER_FILE);
   const tempPath = `${markerPath}.tmp-${process.pid}-${Date.now()}`;
-  fs.writeFileSync(tempPath, `${JSON.stringify(marker, null, 2)}\n`, 'utf8');
+  const serialized = `${JSON.stringify(marker, null, 2)}\n`;
+  if (Buffer.byteLength(serialized, 'utf8') > MAX_INSTALL_MARKER_BYTES) {
+    const error: any = new Error('SkillHub install marker exceeds the local metadata limit.');
+    error.code = 'INSTALL_MARKER_TOO_LARGE';
+    error.status = 422;
+    throw error;
+  }
+  fs.writeFileSync(tempPath, serialized, 'utf8');
   fs.renameSync(tempPath, markerPath);
 }
 

--- a/src/skillhub/local-skill-metadata.ts
+++ b/src/skillhub/local-skill-metadata.ts
@@ -18,6 +18,7 @@ const SKILLHUB_METADATA_KEYS = {
 const SOURCE_SKIP_DIRS = new Set([
   '.git',
   'node_modules',
+  '__pycache__',
 ]);
 
 const GENERATED_PACKAGE_FILES = new Set([
@@ -26,6 +27,7 @@ const GENERATED_PACKAGE_FILES = new Set([
   'SBOM.json',
   '.xiaoba-bundled-skill.json',
   '.xiaoba-skillhub-install.json',
+  '.xiaoba-local-skill.json',
 ]);
 
 export function readSkillHubLocalMetadata(skillFilePath: string): SkillHubLocalMetadata | null {
@@ -37,7 +39,19 @@ export function readSkillHubLocalMetadata(skillFilePath: string): SkillHubLocalM
 
 export function writeSkillHubLocalMetadata(skillFilePath: string, metadata: Required<SkillHubLocalMetadata>): void {
   const raw = fs.readFileSync(skillFilePath, 'utf8');
-  fs.writeFileSync(skillFilePath, applySkillHubLocalMetadata(raw, metadata), 'utf8');
+  const updated = applySkillHubLocalMetadata(raw, metadata);
+  matter(updated);
+  const temporary = path.join(
+    path.dirname(skillFilePath),
+    `.${path.basename(skillFilePath)}.${process.pid}.${crypto.randomBytes(8).toString('hex')}.tmp`,
+  );
+  fs.writeFileSync(temporary, updated, { encoding: 'utf8', flag: 'wx' });
+  try {
+    fs.renameSync(temporary, skillFilePath);
+  } catch (error) {
+    fs.rmSync(temporary, { force: true });
+    throw error;
+  }
 }
 
 export function applySkillHubLocalMetadata(markdown: string, metadata: Required<SkillHubLocalMetadata>): string {
@@ -60,23 +74,66 @@ export function applySkillHubLocalMetadata(markdown: string, metadata: Required<
 
 export function computeLocalSkillContentHash(skillDir: string): string {
   const root = path.resolve(skillDir);
-  const entries = walkSkillFiles(root)
+  const files = walkSkillFiles(root);
+  const initialFingerprint = fingerprintFiles(root, files);
+  const entries = files
     .map(filePath => {
       const relative = path.relative(root, filePath).replace(/\\/g, '/');
-      const buffer = skillHashBuffer(relative, fs.readFileSync(filePath));
+      const hashPath = canonicalSkillHashPath(relative);
+      const before = fs.lstatSync(filePath);
+      if (!before.isFile() || before.isSymbolicLink()) {
+        throw new Error(`Skill hash input is not a regular file: ${filePath}`);
+      }
+      const buffer = skillHashBuffer(hashPath, fs.readFileSync(filePath));
+      const after = fs.lstatSync(filePath);
+      if (
+        !after.isFile()
+        || after.isSymbolicLink()
+        || before.size !== after.size
+        || before.mtimeMs !== after.mtimeMs
+        || before.ino !== after.ino
+      ) {
+        throw new Error(`Skill changed while its content hash was being computed: ${filePath}`);
+      }
       return {
-        path: relative,
+        path: hashPath,
         size: buffer.length,
         sha256: sha256(buffer),
       };
     })
-    .sort((a, b) => a.path.localeCompare(b.path));
+    .sort((a, b) => compareUtf8(a.path, b.path));
+  const afterFiles = walkSkillFiles(root);
+  const afterFingerprint = fingerprintFiles(root, afterFiles);
+  if (initialFingerprint !== afterFingerprint) {
+    throw new Error(`Skill changed while its file list was being hashed: ${root}`);
+  }
   return sha256(Buffer.from(JSON.stringify(entries), 'utf8'));
+}
+
+function fingerprintFiles(root: string, files: string[]): string {
+  return JSON.stringify(files.map(filePath => {
+    const stat = fs.lstatSync(filePath);
+    return {
+      path: canonicalSkillHashPath(path.relative(root, filePath).replace(/\\/g, '/')),
+      size: stat.size,
+      mtimeMs: stat.mtimeMs,
+      ino: stat.ino,
+      regular: stat.isFile() && !stat.isSymbolicLink(),
+    };
+  }).sort((left, right) => compareUtf8(left.path, right.path)));
 }
 
 function skillHashBuffer(relativePath: string, buffer: Buffer): Buffer {
   if (relativePath !== 'SKILL.md') return buffer;
   return Buffer.from(buffer.toString('utf8').replace(/\r\n/g, '\n'), 'utf8');
+}
+
+function canonicalSkillHashPath(relativePath: string): string {
+  return relativePath === 'SKILL.md.disabled' ? 'SKILL.md' : relativePath;
+}
+
+function compareUtf8(left: string, right: string): number {
+  return Buffer.compare(Buffer.from(left, 'utf8'), Buffer.from(right, 'utf8'));
 }
 
 function fromMatterData(data: Record<string, any>): SkillHubLocalMetadata {

--- a/src/skillhub/package-installer.ts
+++ b/src/skillhub/package-installer.ts
@@ -2,6 +2,13 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as crypto from 'crypto';
 import { PathResolver } from '../utils/path-resolver';
+import {
+  BOT_SKILL_LOCAL_IDENTITY_FILE,
+  type LocalSkillIdentity,
+  readLocalSkillIdentity,
+  writeLocalSkillIdentity,
+} from '../bot-skills/local-manifest';
+import { computeLocalSkillContentHash } from './local-skill-metadata';
 import type { SkillHubPackageVerificationResult } from './package-verifier';
 import type { SkillHubPackageInstallMarker, SkillHubRegistryEntry } from './types';
 import {
@@ -14,6 +21,10 @@ export interface InstallVerifiedSkillHubPackageOptions {
   registryEntry: SkillHubRegistryEntry;
   userId?: string;
   allowUpdate?: boolean;
+  skillsRoot?: string;
+  operationsRoot?: string;
+  localIdentity?: LocalSkillIdentity;
+  onPhasePersisted?: (phase: SkillHubInstallTransactionPhase) => void;
   now?: () => Date;
 }
 
@@ -30,12 +41,14 @@ export interface UninstallSkillHubPackageOptions {
   userId?: string;
   skillId: string;
   installName: string;
+  skillsRoot?: string;
 }
 
 export interface ClaimSkillHubPackageOwnershipOptions {
   userId: string;
   skillId: string;
   installName: string;
+  skillsRoot?: string;
 }
 
 export interface UninstallSkillHubPackageResult {
@@ -44,6 +57,8 @@ export interface UninstallSkillHubPackageResult {
 }
 
 export class SkillHubInstallError extends Error {
+  readonly status = 409;
+
   constructor(message: string, public readonly code: string) {
     super(message);
     this.name = 'SkillHubInstallError';
@@ -56,7 +71,24 @@ const PACKAGE_METADATA_FILES = new Set([
   'SBOM.json',
   '.xiaoba-bundled-skill.json',
   '.xiaoba-skillhub-install.json',
+  BOT_SKILL_LOCAL_IDENTITY_FILE,
 ]);
+
+export type SkillHubInstallTransactionPhase =
+  | 'prepared'
+  | 'target-backed-up'
+  | 'target-active';
+
+interface SkillHubInstallTransactionJournal {
+  schema: 'xiaoba.skillhub-install-transaction.v1';
+  phase: SkillHubInstallTransactionPhase;
+  targetDir: string;
+  targetExisted: boolean;
+  expectedSkillId?: string;
+  expectedVersion?: string;
+  expectedChecksumSha256?: string;
+  expectedLocalSkillId?: string;
+}
 
 export function installVerifiedSkillHubPackage(
   options: InstallVerifiedSkillHubPackageOptions,
@@ -76,13 +108,26 @@ export function installVerifiedSkillHubPackage(
     throw new SkillHubInstallError(`SkillHub package is missing entry file ${entryFile}.`, 'ENTRY_FILE_MISSING');
   }
 
-  const skillsRoot = path.resolve(PathResolver.getSkillsPath());
+  const skillsRoot = path.resolve(options.skillsRoot ?? PathResolver.getSkillsPath());
   PathResolver.ensureDir(skillsRoot);
+  assertRealDirectory(skillsRoot, 'Skill workspace');
+  const operationsRoot = path.resolve(
+    options.operationsRoot
+      ?? PathResolver.getDataPath('bot-skills', 'operations'),
+  );
+  ensureOperationsRoot(skillsRoot, operationsRoot);
+  recoverSkillHubPackageOperations({ skillsRoot, operationsRoot });
   const targetDir = safeJoin(skillsRoot, installName);
   const operationId = `${process.pid}-${Date.now()}-${crypto.randomBytes(6).toString('hex')}`;
-  const tempDir = safeJoin(skillsRoot, `.skillhub-install-${operationId}`);
-  const backupDir = safeJoin(skillsRoot, `.skillhub-backup-${operationId}`);
+  const operationDir = path.join(operationsRoot, `install-${operationId}`);
+  const tempDir = path.join(operationDir, 'staged');
+  const backupDir = path.join(operationDir, 'backup');
+  const journalPath = path.join(operationDir, 'journal.json');
+  if (fs.existsSync(targetDir)) assertRealDirectory(targetDir, 'Installed Skill target');
   const existingMarker = fs.existsSync(targetDir) ? readSkillHubInstallMarker(targetDir) : null;
+  const existingIdentity = fs.existsSync(targetDir) ? readLocalSkillIdentity(targetDir) : undefined;
+  const existingWasDisabled = fs.existsSync(path.join(targetDir, 'SKILL.md.disabled'))
+    && !fs.existsSync(path.join(targetDir, 'SKILL.md'));
 
   if (fs.existsSync(targetDir)) {
     if (!options.allowUpdate) {
@@ -110,6 +155,18 @@ export function installVerifiedSkillHubPackage(
         action: 'unchanged',
       };
     }
+    if (!existingMarker.installedContentHash) {
+      throw new SkillHubInstallError(
+        'This Skill was installed before local-content baselines were recorded; refusing to overwrite it automatically.',
+        'LOCAL_BASELINE_MISSING',
+      );
+    }
+    if (computeLocalSkillContentHash(targetDir) !== existingMarker.installedContentHash) {
+      throw new SkillHubInstallError(
+        'The installed Skill has local changes; refusing to overwrite them with a SkillHub update.',
+        'LOCAL_MODIFICATIONS',
+      );
+    }
   }
 
   try {
@@ -120,8 +177,19 @@ export function installVerifiedSkillHubPackage(
       fs.mkdirSync(path.dirname(destination), { recursive: true });
       fs.writeFileSync(destination, Buffer.from(file.contentBase64, 'base64'));
     }
+    if (existingWasDisabled) {
+      const stagedEntry = path.join(tempDir, 'SKILL.md');
+      if (!fs.existsSync(stagedEntry)) {
+        throw new SkillHubInstallError(
+          'The staged Skill is missing its root SKILL.md.',
+          'ENTRY_FILE_MISSING',
+        );
+      }
+      fs.renameSync(stagedEntry, `${stagedEntry}.disabled`);
+    }
 
     const displayName = String(manifest.displayName || registryEntry.displayName || registryEntry.name || manifest.name || skillId);
+    const installedContentHash = computeLocalSkillContentHash(tempDir);
     writeSkillHubInstallMarker(tempDir, {
       source: 'skillhub',
       userId: String(options.userId || '').trim() || undefined,
@@ -130,30 +198,49 @@ export function installVerifiedSkillHubPackage(
       installName,
       version,
       packageChecksumSha256: registryEntry.checksumSha256,
+      installedContentHash,
       signature: registryEntry.signature,
       packageUrl: registryEntry.packageUrl,
       installedAt: (options.now?.() || new Date()).toISOString(),
     });
+    const identity = options.localIdentity ?? existingIdentity;
+    if (identity) writeLocalSkillIdentity(tempDir, identity);
+
+    persistInstallJournal(journalPath, {
+      schema: 'xiaoba.skillhub-install-transaction.v1',
+      phase: 'prepared',
+      targetDir,
+      targetExisted: fs.existsSync(targetDir),
+      expectedSkillId: skillId,
+      expectedVersion: version,
+      expectedChecksumSha256: registryEntry.checksumSha256,
+      expectedLocalSkillId: identity?.localSkillId,
+    });
+    options.onPhasePersisted?.('prepared');
 
     fs.mkdirSync(path.dirname(targetDir), { recursive: true });
     let action: InstallVerifiedSkillHubPackageResult['action'] = 'installed';
     if (fs.existsSync(targetDir)) {
       fs.renameSync(targetDir, backupDir);
-      disableBackupSkill(backupDir);
-      try {
-        fs.renameSync(tempDir, targetDir);
-        action = 'updated';
-      } catch (error) {
-        restoreBackupSkill(backupDir, targetDir);
-        throw error;
-      }
-      try {
-        fs.rmSync(backupDir, { recursive: true, force: true });
-      } catch {
-        // The active update has succeeded. A disabled backup is safe to leave for later cleanup.
-      }
+      updateInstallJournal(journalPath, 'target-backed-up');
+      options.onPhasePersisted?.('target-backed-up');
+      fs.renameSync(tempDir, targetDir);
+      action = 'updated';
     } else {
       fs.renameSync(tempDir, targetDir);
+    }
+    try {
+      updateInstallJournal(journalPath, 'target-active');
+    } catch {
+      // The target rename is the commit point. A stale earlier phase still
+      // converges to the active target during recovery.
+    }
+    options.onPhasePersisted?.('target-active');
+    try {
+      fs.rmSync(operationDir, { recursive: true, force: true });
+    } catch {
+      // The target rename is the commit point. Recovery will clean stale
+      // operation data without reporting a committed install as failed.
     }
     return {
       skillId,
@@ -164,19 +251,27 @@ export function installVerifiedSkillHubPackage(
       action,
     };
   } catch (error: any) {
-    if (fs.existsSync(tempDir)) fs.rmSync(tempDir, { recursive: true, force: true });
-    restoreBackupSkill(backupDir, targetDir);
+    try {
+      recoverSkillHubPackageOperations({ skillsRoot, operationsRoot });
+    } catch {
+      // Preserve the transaction journal for recovery by the next operation.
+    }
     if (error instanceof SkillHubInstallError) throw error;
-    throw new SkillHubInstallError(error?.message || String(error), 'INSTALL_FAILED');
+    throw new SkillHubInstallError(
+      error?.message || String(error),
+      String(error?.code || 'INSTALL_FAILED'),
+    );
   }
 }
 
 export function uninstallSkillHubPackage(
   options: UninstallSkillHubPackageOptions,
 ): UninstallSkillHubPackageResult {
-  const skillsRoot = path.resolve(PathResolver.getSkillsPath());
+  const skillsRoot = path.resolve(options.skillsRoot ?? PathResolver.getSkillsPath());
+  assertRealDirectory(skillsRoot, 'Skill workspace');
   const targetDir = safeJoin(skillsRoot, options.installName);
   if (!fs.existsSync(targetDir)) return { removed: false, path: targetDir };
+  assertRealDirectory(targetDir, 'Skill uninstall target');
 
   const marker = readSkillHubInstallMarker(targetDir);
   if (!marker || marker.skillId !== options.skillId) {
@@ -191,9 +286,11 @@ export function uninstallSkillHubPackage(
 }
 
 export function claimSkillHubPackageOwnership(options: ClaimSkillHubPackageOwnershipOptions): boolean {
-  const skillsRoot = path.resolve(PathResolver.getSkillsPath());
+  const skillsRoot = path.resolve(options.skillsRoot ?? PathResolver.getSkillsPath());
+  assertRealDirectory(skillsRoot, 'Skill workspace');
   const targetDir = safeJoin(skillsRoot, options.installName);
   if (!fs.existsSync(targetDir)) return false;
+  assertRealDirectory(targetDir, 'Skill ownership target');
 
   const marker = readSkillHubInstallMarker(targetDir);
   if (!marker || marker.skillId !== options.skillId) return false;
@@ -213,26 +310,220 @@ function markerOwnedByUser(
   return { ...current, userId };
 }
 
-function disableBackupSkill(backupDir: string): void {
-  const activeSkillFile = path.join(backupDir, 'SKILL.md');
-  if (fs.existsSync(activeSkillFile)) fs.renameSync(activeSkillFile, `${activeSkillFile}.disabled`);
+export function recoverSkillHubPackageOperations(options: {
+  skillsRoot: string;
+  operationsRoot: string;
+}): void {
+  const skillsRoot = path.resolve(options.skillsRoot);
+  const operationsRoot = path.resolve(options.operationsRoot);
+  if (!fs.existsSync(operationsRoot)) return;
+  assertRealDirectory(operationsRoot, 'Skill operation root');
+  for (const entry of fs.readdirSync(operationsRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory() || entry.isSymbolicLink() || !entry.name.startsWith('install-')) continue;
+    const operationDir = path.join(operationsRoot, entry.name);
+    const journalPath = path.join(operationDir, 'journal.json');
+    const staged = path.join(operationDir, 'staged');
+    const backup = path.join(operationDir, 'backup');
+    if (!fs.existsSync(journalPath)) {
+      fs.rmSync(operationDir, { recursive: true, force: true });
+      continue;
+    }
+    const journal = readInstallJournal(journalPath);
+    assertContained(skillsRoot, journal.targetDir, 'Recovered Skill target');
+    if (fs.existsSync(staged)) assertRealDirectory(staged, 'Recovered staged Skill');
+    if (fs.existsSync(backup)) assertRealDirectory(backup, 'Recovered backup Skill');
+    if (journal.phase === 'prepared' || journal.phase === 'target-backed-up') {
+      if (!fs.existsSync(journal.targetDir) && fs.existsSync(backup)) {
+        fs.renameSync(backup, journal.targetDir);
+      }
+    }
+    if (
+      journal.phase === 'target-active'
+      && !fs.existsSync(journal.targetDir)
+      && fs.existsSync(backup)
+    ) {
+      throw new SkillHubInstallError(
+        'The committed Skill target is missing while its backup still exists.',
+        'INSTALL_RECOVERY_AMBIGUOUS',
+      );
+    }
+    const targetExists = fs.existsSync(journal.targetDir);
+    const backupExists = fs.existsSync(backup);
+    if (
+      targetExists
+      && (
+        backupExists
+        || !journal.targetExisted
+        || journal.phase === 'target-active'
+      )
+    ) {
+      assertRecoveredPackageTarget(journal.targetDir, journal, backupExists);
+    }
+    if (fs.existsSync(staged)) fs.rmSync(staged, { recursive: true, force: true });
+    if (fs.existsSync(backup) && fs.existsSync(journal.targetDir)) {
+      fs.rmSync(backup, { recursive: true, force: true });
+    }
+    fs.rmSync(operationDir, { recursive: true, force: true });
+  }
 }
 
-function restoreBackupSkill(backupDir: string, targetDir: string): void {
-  if (fs.existsSync(targetDir) || !fs.existsSync(backupDir)) return;
-  const disabledSkillFile = path.join(backupDir, 'SKILL.md.disabled');
-  if (fs.existsSync(disabledSkillFile)) fs.renameSync(disabledSkillFile, path.join(backupDir, 'SKILL.md'));
-  fs.renameSync(backupDir, targetDir);
+function assertRecoveredPackageTarget(
+  targetDir: string,
+  journal: SkillHubInstallTransactionJournal,
+  hasBackup: boolean,
+): void {
+  assertRealDirectory(targetDir, 'Recovered active Skill');
+  if (
+    !journal.expectedSkillId
+    || !journal.expectedVersion
+    || !journal.expectedChecksumSha256
+  ) {
+    if (hasBackup) {
+      throw new SkillHubInstallError(
+        'Cannot verify the recovered active Skill while a unique backup exists.',
+        'INSTALL_RECOVERY_AMBIGUOUS',
+      );
+    }
+    return;
+  }
+  const marker = readSkillHubInstallMarker(targetDir);
+  const identity = readLocalSkillIdentity(targetDir);
+  if (
+    !marker
+    || marker.skillId !== journal.expectedSkillId
+    || marker.version !== journal.expectedVersion
+    || marker.packageChecksumSha256 !== journal.expectedChecksumSha256
+    || (
+      journal.expectedLocalSkillId
+      && identity?.localSkillId !== journal.expectedLocalSkillId
+    )
+  ) {
+    throw new SkillHubInstallError(
+      'Recovered active Skill does not match its transaction journal.',
+      'INSTALL_RECOVERY_AMBIGUOUS',
+    );
+  }
+}
+
+function ensureOperationsRoot(skillsRoot: string, operationsRoot: string): void {
+  if (path.parse(skillsRoot).root.toLowerCase() !== path.parse(operationsRoot).root.toLowerCase()) {
+    throw new SkillHubInstallError(
+      'Skill staging must use the same filesystem as the active workspace.',
+      'INSTALL_FILESYSTEM_MISMATCH',
+    );
+  }
+  ensureDirectoryWithoutLinks(operationsRoot);
+  assertRealDirectory(operationsRoot, 'Skill operation root');
+  if (fs.statSync(skillsRoot).dev !== fs.statSync(operationsRoot).dev) {
+    throw new SkillHubInstallError(
+      'Skill staging must use the same filesystem as the active workspace.',
+      'INSTALL_FILESYSTEM_MISMATCH',
+    );
+  }
+}
+
+function persistInstallJournal(
+  journalPath: string,
+  journal: SkillHubInstallTransactionJournal,
+): void {
+  const temporary = `${journalPath}.${process.pid}.${crypto.randomBytes(6).toString('hex')}.tmp`;
+  fs.writeFileSync(temporary, `${JSON.stringify(journal, null, 2)}\n`, {
+    encoding: 'utf8',
+    mode: 0o600,
+    flag: 'wx',
+  });
+  fs.renameSync(temporary, journalPath);
+}
+
+function updateInstallJournal(
+  journalPath: string,
+  phase: SkillHubInstallTransactionPhase,
+): void {
+  const journal = readInstallJournal(journalPath);
+  persistInstallJournal(journalPath, { ...journal, phase });
+}
+
+function readInstallJournal(journalPath: string): SkillHubInstallTransactionJournal {
+  const stat = fs.lstatSync(journalPath);
+  if (!stat.isFile() || stat.isSymbolicLink() || stat.size > 64 * 1024) {
+    throw new SkillHubInstallError('Skill install transaction journal is invalid.', 'INSTALL_JOURNAL_INVALID');
+  }
+  const value = JSON.parse(fs.readFileSync(journalPath, 'utf8')) as SkillHubInstallTransactionJournal;
+  if (
+    value?.schema !== 'xiaoba.skillhub-install-transaction.v1'
+    || !['prepared', 'target-backed-up', 'target-active'].includes(value.phase)
+    || typeof value.targetDir !== 'string'
+    || typeof value.targetExisted !== 'boolean'
+    || (value.expectedSkillId !== undefined && typeof value.expectedSkillId !== 'string')
+    || (value.expectedVersion !== undefined && typeof value.expectedVersion !== 'string')
+    || (
+      value.expectedChecksumSha256 !== undefined
+      && typeof value.expectedChecksumSha256 !== 'string'
+    )
+    || (
+      value.expectedLocalSkillId !== undefined
+      && typeof value.expectedLocalSkillId !== 'string'
+    )
+  ) {
+    throw new SkillHubInstallError('Skill install transaction journal is invalid.', 'INSTALL_JOURNAL_INVALID');
+  }
+  return value;
+}
+
+function assertRealDirectory(target: string, label: string): void {
+  const stat = fs.lstatSync(target);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new SkillHubInstallError(`${label} must be a real directory.`, 'INSTALL_PATH_UNSAFE');
+  }
+  if (!samePath(path.resolve(target), fs.realpathSync.native(target))) {
+    throw new SkillHubInstallError(`${label} traverses a symlink or junction.`, 'INSTALL_PATH_UNSAFE');
+  }
+}
+
+function samePath(left: string, right: string): boolean {
+  const resolvedLeft = path.resolve(left);
+  const resolvedRight = path.resolve(right);
+  return process.platform === 'win32'
+    ? resolvedLeft.toLowerCase() === resolvedRight.toLowerCase()
+    : resolvedLeft === resolvedRight;
+}
+
+function assertContained(root: string, target: string, label: string): void {
+  const relative = path.relative(path.resolve(root), path.resolve(target));
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new SkillHubInstallError(`${label} escapes the Skill workspace.`, 'INSTALL_PATH_UNSAFE');
+  }
+}
+
+function ensureDirectoryWithoutLinks(target: string): void {
+  const resolved = path.resolve(target);
+  const parsed = path.parse(resolved);
+  let current = parsed.root;
+  for (const segment of resolved.slice(parsed.root.length).split(path.sep).filter(Boolean)) {
+    current = path.join(current, segment);
+    if (!fs.existsSync(current)) fs.mkdirSync(current, { mode: 0o700 });
+    assertRealDirectory(current, 'Skill operation path');
+  }
 }
 
 function safeSkillDirName(value: string): string {
-  if (/^[a-zA-Z0-9][a-zA-Z0-9._-]{0,79}$/.test(value)) return value;
+  if (
+    /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,79}$/.test(value)
+    && !/[. ]$/.test(value)
+    && !isWindowsReservedName(value)
+  ) return value;
   const ascii = value
     .toLowerCase()
     .replace(/[^a-z0-9._-]+/g, '-')
     .replace(/^-+|-+$/g, '')
     .slice(0, 80);
-  return ascii || `skill-${Buffer.from(value).toString('hex').slice(0, 24)}`;
+  const candidate = ascii || `skill-${Buffer.from(value).toString('hex').slice(0, 24)}`;
+  return isWindowsReservedName(candidate) ? `skill-${candidate}` : candidate;
+}
+
+function isWindowsReservedName(value: string): boolean {
+  const stem = value.replace(/[. ]+$/g, '').split('.')[0].toUpperCase();
+  return /^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])$/.test(stem);
 }
 
 function safeJoin(root: string, relativePath: string): string {

--- a/src/skillhub/package-verifier.ts
+++ b/src/skillhub/package-verifier.ts
@@ -96,13 +96,28 @@ export interface SkillHubPackageVerificationResult {
 }
 
 export class SkillHubVerificationError extends Error {
+  readonly status = 422;
+
   constructor(message: string, public readonly code: string) {
     super(message);
     this.name = 'SkillHubVerificationError';
   }
 }
 
+const MAX_PACKAGE_BYTES = 32 * 1024 * 1024;
+const MAX_PACKAGE_FILES = 256;
+const MAX_PACKAGE_FILE_BYTES = 8 * 1024 * 1024;
+const MAX_PACKAGE_TOTAL_FILE_BYTES = 20 * 1024 * 1024;
+const MAX_PACKAGE_PATH_BYTES = 512;
+const MAX_PACKAGE_PATH_DEPTH = 16;
+
 export function verifySkillHubPackage(input: SkillHubPackageVerificationInput): SkillHubPackageVerificationResult {
+  if (input.packageBytes.length > MAX_PACKAGE_BYTES) {
+    throw new SkillHubVerificationError(
+      `SkillHub package exceeds ${MAX_PACKAGE_BYTES} bytes.`,
+      'PACKAGE_TOO_LARGE',
+    );
+  }
   const trustedRoots = input.trustedRoots ?? CATSCO_SKILLHUB_ROOT_PUBLIC_KEYS;
   if (trustedRoots.length === 0) {
     throw new SkillHubVerificationError('CatsCo SkillHub root public key is not embedded in this Agent build.', 'TRUST_ROOT_MISSING');
@@ -147,6 +162,17 @@ export function verifySkillHubPackage(input: SkillHubPackageVerificationInput): 
     throw new SkillHubVerificationError('Package version does not match registry metadata.', 'MANIFEST_VERSION_MISMATCH');
   }
 
+  const entryFile = String(
+    (packageObject.payload.manifest as any).entrypoints?.skillFile
+      || (packageObject.payload.manifest as any).entry
+      || 'SKILL.md',
+  );
+  if (entryFile !== 'SKILL.md') {
+    throw new SkillHubVerificationError(
+      'SkillHub packages must use the root SKILL.md as their only runtime entrypoint.',
+      'PACKAGE_ENTRYPOINT_UNSUPPORTED',
+    );
+  }
   verifyPackageFiles(packageObject.payload.files);
   return { packageObject, signingKey, root };
 }
@@ -163,10 +189,15 @@ export function verifySigningKeyCertificate(
   if (!certificate.usages.includes('skillpkg.sign')) {
     throw new SkillHubVerificationError('Signing key certificate is not valid for skill package signing.', 'CERT_USAGE_INVALID');
   }
-  if (new Date(certificate.issuedAt).getTime() > now.getTime()) {
+  const issuedAt = new Date(certificate.issuedAt).getTime();
+  const expiresAt = new Date(certificate.expiresAt).getTime();
+  if (!Number.isFinite(issuedAt) || !Number.isFinite(expiresAt)) {
+    throw new SkillHubVerificationError('Signing key certificate dates are invalid.', 'CERT_DATE_INVALID');
+  }
+  if (issuedAt > now.getTime()) {
     throw new SkillHubVerificationError('Signing key certificate is not valid yet.', 'CERT_NOT_YET_VALID');
   }
-  if (new Date(certificate.expiresAt).getTime() <= now.getTime()) {
+  if (expiresAt <= now.getTime()) {
     throw new SkillHubVerificationError('Signing key certificate has expired.', 'CERT_EXPIRED');
   }
   if (certificate.subject.keyId !== signingKey.keyId || certificate.subject.publicKeyPem !== signingKey.publicKeyPem) {
@@ -234,20 +265,80 @@ function verifyPackageFiles(files: SkillHubPackageFile[]): void {
   if (!Array.isArray(files) || files.length === 0) {
     throw new SkillHubVerificationError('SkillHub package has no files.', 'PACKAGE_FILES_MISSING');
   }
+  if (files.length > MAX_PACKAGE_FILES) {
+    throw new SkillHubVerificationError(
+      `SkillHub package contains more than ${MAX_PACKAGE_FILES} files.`,
+      'PACKAGE_FILE_COUNT_EXCEEDED',
+    );
+  }
   const seen = new Set<string>();
+  let skillEntryCount = 0;
+  let totalDecodedBytes = 0;
   for (const file of files) {
+    if (
+      typeof file?.path !== 'string'
+      || !Number.isSafeInteger(file.size)
+      || file.size < 0
+      || typeof file.sha256 !== 'string'
+      || !/^[0-9a-f]{64}$/i.test(file.sha256)
+      || typeof file.contentBase64 !== 'string'
+      || !isCanonicalBase64(file.contentBase64)
+    ) {
+      throw new SkillHubVerificationError(
+        'SkillHub package contains invalid file metadata.',
+        'PACKAGE_FILE_METADATA_INVALID',
+      );
+    }
     const safePath = normalizePackagePath(file.path);
-    if (seen.has(safePath)) {
+    const portableKey = safePath.normalize('NFC').toLocaleLowerCase('en-US');
+    if (seen.has(portableKey)) {
       throw new SkillHubVerificationError(`Duplicate package file path: ${safePath}`, 'PACKAGE_FILE_DUPLICATE');
     }
-    seen.add(safePath);
+    seen.add(portableKey);
+    if (pathBasename(safePath).toLowerCase() === 'skill.md') {
+      skillEntryCount += 1;
+      if (safePath !== 'SKILL.md') {
+        throw new SkillHubVerificationError(
+          `Nested Skill entrypoints are not supported: ${safePath}`,
+          'PACKAGE_NESTED_SKILL_UNSUPPORTED',
+        );
+      }
+    }
     const content = Buffer.from(file.contentBase64, 'base64');
+    if (content.length > MAX_PACKAGE_FILE_BYTES) {
+      throw new SkillHubVerificationError(
+        `Package file is too large: ${safePath}`,
+        'PACKAGE_FILE_TOO_LARGE',
+      );
+    }
+    totalDecodedBytes += content.length;
+    if (totalDecodedBytes > MAX_PACKAGE_TOTAL_FILE_BYTES) {
+      throw new SkillHubVerificationError(
+        `Package files exceed ${MAX_PACKAGE_TOTAL_FILE_BYTES} decoded bytes.`,
+        'PACKAGE_TOTAL_SIZE_EXCEEDED',
+      );
+    }
     if (content.length !== file.size) {
       throw new SkillHubVerificationError(`Package file size mismatch: ${safePath}`, 'PACKAGE_FILE_SIZE_MISMATCH');
     }
     if (sha256Hex(content) !== file.sha256) {
       throw new SkillHubVerificationError(`Package file checksum mismatch: ${safePath}`, 'PACKAGE_FILE_CHECKSUM_MISMATCH');
     }
+  }
+  if (skillEntryCount !== 1) {
+    throw new SkillHubVerificationError(
+      'SkillHub packages must contain exactly one root SKILL.md.',
+      'PACKAGE_SKILL_ENTRY_COUNT_INVALID',
+    );
+  }
+}
+
+function isCanonicalBase64(value: string): boolean {
+  if (value.length % 4 !== 0 || !/^[A-Za-z0-9+/]*={0,2}$/.test(value)) return false;
+  try {
+    return Buffer.from(value, 'base64').toString('base64') === value;
+  } catch {
+    return false;
   }
 }
 
@@ -257,10 +348,42 @@ function normalizePackagePath(packagePath: string): string {
     throw new SkillHubVerificationError(`Unsafe package file path: ${raw}`, 'PACKAGE_FILE_PATH_UNSAFE');
   }
   const parts = raw.split('/');
+  if (
+    Buffer.byteLength(raw, 'utf8') > MAX_PACKAGE_PATH_BYTES
+    || parts.length > MAX_PACKAGE_PATH_DEPTH
+  ) {
+    throw new SkillHubVerificationError(`Package file path is too long: ${raw}`, 'PACKAGE_FILE_PATH_UNSAFE');
+  }
   if (parts.some(part => part === '' || part === '.' || part === '..')) {
     throw new SkillHubVerificationError(`Unsafe package file path: ${raw}`, 'PACKAGE_FILE_PATH_UNSAFE');
   }
+  if (parts.some(part =>
+    part.includes(':')
+    || /[<>"|?*\u0000-\u001f]/.test(part)
+    || /[. ]$/.test(part)
+    || isWindowsReservedName(part))) {
+    throw new SkillHubVerificationError(`Unsafe portable package file path: ${raw}`, 'PACKAGE_FILE_PATH_UNSAFE');
+  }
+  if (parts.some(part => [
+    '.xiaoba-skillhub-install.json',
+    '.xiaoba-local-skill.json',
+  ].includes(part.toLowerCase()))) {
+    throw new SkillHubVerificationError(
+      `Package cannot provide reserved local metadata: ${raw}`,
+      'PACKAGE_RESERVED_FILE',
+    );
+  }
   return parts.join('/');
+}
+
+function isWindowsReservedName(segment: string): boolean {
+  const stem = segment.replace(/[. ]+$/g, '').split('.')[0].toUpperCase();
+  return /^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])$/.test(stem);
+}
+
+function pathBasename(value: string): string {
+  const parts = value.split('/');
+  return parts[parts.length - 1] || '';
 }
 
 function sha256Hex(bytes: Buffer): string {

--- a/src/skillhub/service.ts
+++ b/src/skillhub/service.ts
@@ -4,15 +4,16 @@ import { createCatsCoLocalConfigService } from '../catscompany/local-config';
 import { SkillParser } from '../skills/skill-parser';
 import type { Skill } from '../types/skill';
 import { PathResolver } from '../utils/path-resolver';
+import {
+  BotSkillService,
+  createBotSkillService,
+} from '../bot-skills/service';
+import { readLocalSkillIdentity } from '../bot-skills/local-manifest';
 import { SkillHubClient } from './client';
 import {
+  computeLocalSkillContentHash,
   writeSkillHubLocalMetadata,
 } from './local-skill-metadata';
-import {
-  claimSkillHubPackageOwnership,
-  installVerifiedSkillHubPackage,
-  uninstallSkillHubPackage,
-} from './package-installer';
 import { listInstalledSkillHubSkills } from './install-marker';
 import { verifySkillHubPackage } from './package-verifier';
 import { CATSCO_SKILLHUB_ROOT_PUBLIC_KEYS } from './trusted-keys';
@@ -28,9 +29,11 @@ import type {
 
 export class SkillHubService {
   private readonly client: SkillHubClient;
+  private readonly botSkills: BotSkillService;
 
-  constructor(options: { baseUrl?: string } = {}) {
+  constructor(options: { baseUrl?: string; botSkillService?: BotSkillService } = {}) {
     this.client = new SkillHubClient(options);
+    this.botSkills = options.botSkillService ?? createBotSkillService();
   }
 
   async status(): Promise<SkillHubAuthState & { trustReady: boolean; installed: SkillHubPackageInstallMarker[] }> {
@@ -146,12 +149,13 @@ export class SkillHubService {
       registryEntry,
       trust,
     });
-    const installed = installVerifiedSkillHubPackage({
+    const mutation = await this.botSkills.installVerifiedSkillHubPackage({
       verification,
       registryEntry,
       userId: options.userId,
       allowUpdate: options.allowUpdate,
     });
+    const installed = mutation.result;
     return {
       ok: true,
       skill: installed,
@@ -160,12 +164,12 @@ export class SkillHubService {
     };
   }
 
-  uninstall(input: { userId?: string; skillId: string; installName: string }): { removed: boolean; path: string } {
-    return uninstallSkillHubPackage(input);
+  async uninstall(input: { userId?: string; skillId: string; installName: string }): Promise<{ removed: boolean; path: string }> {
+    return (await this.botSkills.uninstallSkillHubPackage(input)).result;
   }
 
-  claimInstalledSkillOwnership(input: { userId: string; skillId: string; installName: string }): boolean {
-    return claimSkillHubPackageOwnership(input);
+  claimInstalledSkillOwnership(input: { userId: string; skillId: string; installName: string }): Promise<boolean> {
+    return this.botSkills.claimInstalledSkillOwnership(input);
   }
 
   developerDashboard(): Promise<any> {
@@ -240,62 +244,74 @@ export class SkillHubService {
       throw error;
     }
 
-    const localSkill = findLocalShareableSkill(skillName);
-    if (!localSkill) {
-      const available = listLocalSkillNames().join(', ');
-      const error: any = new Error(`Local skill not found: ${skillName}${available ? `. Available skills: ${available}` : ''}`);
-      error.status = 404;
-      error.code = 'skillhub.local_skill_not_found';
-      throw error;
-    }
+    return this.botSkills.withWorkspaceLock(async () => {
+      const localSkill = findLocalShareableSkill(skillName);
+      if (!localSkill) {
+        const available = listLocalSkillNames().join(', ');
+        const error: any = new Error(`Local skill not found: ${skillName}${available ? `. Available skills: ${available}` : ''}`);
+        error.status = 404;
+        error.code = 'skillhub.local_skill_not_found';
+        throw error;
+      }
 
-    const { skill } = localSkill;
-    const localPath = path.dirname(skill.filePath);
-    const files = collectSkillSourceFiles(localPath);
-    if (!files.length) {
-      const error: any = new Error('Local skill package has no shareable files.');
-      error.status = 400;
-      error.code = 'skillhub.local_skill_empty';
-      throw error;
-    }
-    const submission = await this.client.quickShare({
-      manifest: {
-        id: skill.metadata.name,
-        name: skill.metadata.name,
-        displayName: skill.metadata.name,
-        version: '1.0.0',
-        description: skill.metadata.description,
-        keywords: [skill.metadata.name, ...splitWords(skill.metadata.description)].slice(0, 8),
-        triggerExamples: skill.metadata.argumentHint ? [`/${skill.metadata.name} ${skill.metadata.argumentHint}`] : [`/${skill.metadata.name}`],
-        minAgentVersion: '0.0.0',
-        platforms: [],
-      },
-      notes: String(input.notes || 'Quick shared from local XiaoBa Skills.'),
-      confirmVersionPublish: input.confirmVersionPublish === true || input.confirmPublish === true,
-      source: {
-        type: 'files',
-        files,
-      },
+      const { skill } = localSkill;
+      const localPath = path.dirname(skill.filePath);
+      const initialIdentity = readLocalSkillIdentity(localPath)?.localSkillId;
+      const initialContentHash = computeLocalSkillContentHash(localPath);
+      const files = collectSkillSourceFiles(localPath);
+      if (!files.length) {
+        const error: any = new Error('Local skill package has no shareable files.');
+        error.status = 400;
+        error.code = 'skillhub.local_skill_empty';
+        throw error;
+      }
+      const submission = await this.client.quickShare({
+        manifest: {
+          id: skill.metadata.name,
+          name: skill.metadata.name,
+          displayName: skill.metadata.name,
+          version: '1.0.0',
+          description: skill.metadata.description,
+          keywords: [skill.metadata.name, ...splitWords(skill.metadata.description)].slice(0, 8),
+          triggerExamples: skill.metadata.argumentHint ? [`/${skill.metadata.name} ${skill.metadata.argumentHint}`] : [`/${skill.metadata.name}`],
+          minAgentVersion: '0.0.0',
+          platforms: [],
+        },
+        notes: String(input.notes || 'Quick shared from local XiaoBa Skills.'),
+        confirmVersionPublish: input.confirmVersionPublish === true || input.confirmPublish === true,
+        source: {
+          type: 'files',
+          files,
+        },
+      });
+      const skillHubMetadata = skillHubMetadataFromShareResponse(submission);
+      const localUnchanged = (
+        readLocalSkillIdentity(localPath)?.localSkillId === initialIdentity
+        && computeLocalSkillContentHash(localPath) === initialContentHash
+      );
+      if (skillHubMetadata && localUnchanged) {
+        writeSkillHubLocalMetadata(skill.filePath, skillHubMetadata);
+      }
+
+      return {
+        ok: true,
+        skill: {
+          id: submission?.skill?.skillId || submission?.upload?.skillId || submission?.submission?.normalizedManifest?.id || skill.metadata.name,
+          name: skill.metadata.name,
+          description: skill.metadata.description,
+          path: localPath,
+        },
+        submission: submission?.submission || submission,
+        existing: submission?.existing,
+        requiresConfirmation: submission?.requiresConfirmation,
+        latestVersion: submission?.latestVersion,
+        contentHash: submission?.contentHash,
+        localMetadataUpdated: Boolean(skillHubMetadata && localUnchanged),
+        warning: localUnchanged
+          ? undefined
+          : 'Local Skill changed while it was being shared; remote upload succeeded but local metadata was not updated.',
+      };
     });
-    const skillHubMetadata = skillHubMetadataFromShareResponse(submission);
-    if (skillHubMetadata) {
-      writeSkillHubLocalMetadata(skill.filePath, skillHubMetadata);
-    }
-
-    return {
-      ok: true,
-      skill: {
-        id: submission?.skill?.skillId || submission?.upload?.skillId || submission?.submission?.normalizedManifest?.id || skill.metadata.name,
-        name: skill.metadata.name,
-        description: skill.metadata.description,
-        path: localPath,
-      },
-      submission: submission?.submission || submission,
-      existing: submission?.existing,
-      requiresConfirmation: submission?.requiresConfirmation,
-      latestVersion: submission?.latestVersion,
-      contentHash: submission?.contentHash,
-    };
   }
 
   async getPublishedVersion(skillId: string, version: string): Promise<SkillHubRegistryEntry | undefined> {
@@ -349,6 +365,7 @@ function normalizeRegistryEntryVersion(entry: SkillHubRegistryEntry | undefined,
 const SOURCE_SKIP_DIRS = new Set([
   '.git',
   'node_modules',
+  '__pycache__',
 ]);
 const SOURCE_SKIP_FILES = new Set([
   'skill.json',
@@ -356,6 +373,7 @@ const SOURCE_SKIP_FILES = new Set([
   'SBOM.json',
   '.xiaoba-bundled-skill.json',
   '.xiaoba-skillhub-install.json',
+  '.xiaoba-local-skill.json',
 ]);
 const MAX_SOURCE_FILES = 200;
 const MAX_SOURCE_TOTAL_BYTES = 20 * 1024 * 1024;

--- a/src/skillhub/subscription-service.ts
+++ b/src/skillhub/subscription-service.ts
@@ -17,8 +17,12 @@ export interface SkillHubSubscriptionGateway {
     version?: string,
     options?: { userId?: string; allowUpdate?: boolean },
   ): Promise<SkillHubInstallResult>;
-  uninstall(input: { userId?: string; skillId: string; installName: string }): { removed: boolean; path: string };
-  claimInstalledSkillOwnership?(input: { userId: string; skillId: string; installName: string }): boolean;
+  uninstall(input: { userId?: string; skillId: string; installName: string }):
+    | { removed: boolean; path: string }
+    | Promise<{ removed: boolean; path: string }>;
+  claimInstalledSkillOwnership?(input: { userId: string; skillId: string; installName: string }):
+    | boolean
+    | Promise<boolean>;
 }
 
 export interface SkillHubSubscriptionListResult {
@@ -61,7 +65,7 @@ export class SkillHubSubscriptionService {
     const userId = scope.userId;
     const subscriptions = this.store.list(userId);
     for (const subscription of subscriptions) {
-      this.gateway.claimInstalledSkillOwnership?.({
+      await this.gateway.claimInstalledSkillOwnership?.({
         userId,
         skillId: subscription.skillId,
         installName: subscription.installName,
@@ -111,7 +115,7 @@ export class SkillHubSubscriptionService {
       };
     }
 
-    const result = this.gateway.uninstall({
+    const result = await this.gateway.uninstall({
       skillId: normalizedSkillId,
       installName: subscription.installName,
       ...(scope.kind === 'user' ? { userId: scope.userId } : {}),

--- a/src/skillhub/types.ts
+++ b/src/skillhub/types.ts
@@ -67,6 +67,8 @@ export interface SkillHubPackageInstallMarker {
   installName: string;
   version: string;
   packageChecksumSha256: string;
+  /** Hash of the installed editable tree at the time this package was committed. */
+  installedContentHash?: string;
   signature: VerifierRegistryEntry['signature'];
   packageUrl: string;
   installedAt: string;

--- a/tests/bot-skill-service.test.ts
+++ b/tests/bot-skill-service.test.ts
@@ -1,0 +1,730 @@
+import assert from 'node:assert/strict';
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import { createBotSkillService } from '../src/bot-skills/service';
+import {
+  BOT_SKILL_LOCAL_IDENTITY_FILE,
+  scanLocalSkillManifest,
+} from '../src/bot-skills/local-manifest';
+import { BotSkillWorkspaceService } from '../src/bot-skills/workspace-service';
+import { createCatsCoLocalConfigService } from '../src/catscompany/local-config';
+import type { SkillHubRegistryEntry } from '../src/skillhub/types';
+
+describe('BotSkillService', () => {
+  let testRoot: string;
+  let runtimeRoot: string;
+  let skillsRoot: string;
+
+  beforeEach(() => {
+    testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-bot-skill-service-'));
+    runtimeRoot = path.join(testRoot, 'runtime');
+    skillsRoot = path.join(testRoot, 'editable-skills');
+    fs.mkdirSync(runtimeRoot, { recursive: true });
+    fs.mkdirSync(skillsRoot, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(testRoot, { recursive: true, force: true });
+  });
+
+  test('distinguishes a missing workspace from a valid empty manifest', () => {
+    const missing = scanLocalSkillManifest({
+      skillsRoot: path.join(testRoot, 'missing'),
+    });
+    const empty = scanLocalSkillManifest({ skillsRoot });
+
+    assert.equal(missing.status, 'missing');
+    assert.deepEqual(missing.entries, []);
+    assert.equal(empty.status, 'complete');
+    assert.deepEqual(empty.entries, []);
+  });
+
+  test('refuses an unclaimed managed workspace even when XIAOBA_SKILLS_DIR points to it', async () => {
+    const managedSkills = path.join(runtimeRoot, 'skills');
+    fs.mkdirSync(managedSkills, { recursive: true });
+    const service = createBotSkillService({
+      runtimeRoot,
+      env: { XIAOBA_SKILLS_DIR: managedSkills },
+    });
+
+    await assert.rejects(
+      () => service.scanManifest(),
+      (error: any) => error?.code === 'SKILL_WORKSPACE_UNCLAIMED',
+    );
+  });
+
+  test('builds deterministic local and SkillHub entries with stable local ids', async () => {
+    writeSkill(path.join(skillsRoot, 'local-demo'), 'local-demo', '# v1\n');
+    const service = createBotSkillService({ runtimeRoot, skillsRoot });
+    const first = await service.scanManifest();
+    const local = first.entries[0];
+
+    assert.equal(first.status, 'complete');
+    assert.equal(local.key, 'local:local-demo');
+    assert.equal(local.source, 'local');
+    assert.equal(local.enabled, true);
+    assert.match(local.localSkillId, /^[0-9a-f-]{36}$/);
+    assert.equal(local.path, 'local-demo');
+
+    fs.appendFileSync(path.join(skillsRoot, 'local-demo', 'notes.txt'), 'changed\n');
+    const changed = await service.scanManifest();
+    assert.equal(changed.entries[0].localSkillId, local.localSkillId);
+    assert.notEqual(changed.entries[0].contentHash, local.contentHash);
+
+    await service.setEnabledByName('local-demo', false);
+    const disabled = await service.scanManifest();
+    assert.equal(disabled.entries[0].enabled, false);
+    assert.equal(disabled.entries[0].localSkillId, local.localSkillId);
+    assert.equal(disabled.entries[0].contentHash, changed.entries[0].contentHash);
+  });
+
+  test('keeps localSkillId when SKILL.md metadata is renamed in place', async () => {
+    const directory = path.join(skillsRoot, 'local-demo');
+    writeSkill(directory, 'local-demo', '# v1\n');
+    const service = createBotSkillService({ runtimeRoot, skillsRoot });
+    const before = await service.scanManifest();
+
+    writeSkill(directory, 'renamed-demo', '# v2\n');
+    const after = await service.scanManifest();
+
+    assert.equal(after.entries[0].name, 'renamed-demo');
+    assert.equal(after.entries[0].localSkillId, before.entries[0].localSkillId);
+  });
+
+  test('preserves disabled state while updating an unmodified SkillHub Skill', async () => {
+    const service = createBotSkillService({ runtimeRoot, skillsRoot });
+    await service.installVerifiedSkillHubPackage(
+      packageFixture('alice/demo', 'demo', '1.0.0', '# one\n'),
+    );
+    await service.setEnabledByName('demo', false);
+
+    const updated = await service.installVerifiedSkillHubPackage({
+      ...packageFixture('alice/demo', 'demo', '2.0.0', '# two\n'),
+      allowUpdate: true,
+    });
+
+    assert.equal(updated.manifest.entries[0].enabled, false);
+    assert.equal(
+      updated.manifest.entries[0].contentHash,
+      updated.manifest.entries[0].installedContentHash,
+    );
+    assert.match(
+      fs.readFileSync(path.join(skillsRoot, 'demo', 'SKILL.md.disabled'), 'utf8'),
+      /# two/,
+    );
+  });
+
+  test('keeps localSkillId when a SkillHub update changes SKILL.md name', async () => {
+    const service = createBotSkillService({ runtimeRoot, skillsRoot });
+    const installed = await service.installVerifiedSkillHubPackage(
+      packageFixture('alice/demo', 'demo', '1.0.0', '# one\n'),
+    );
+    const update = packageFixture('alice/demo', 'demo', '2.0.0', '# two\n');
+    const renamedSkill = Buffer.from([
+      '---',
+      'name: renamed-demo',
+      'description: renamed description',
+      '---',
+      '',
+      '# two',
+    ].join('\n'));
+    const entry = update.verification.packageObject.payload.files[0];
+    entry.size = renamedSkill.length;
+    entry.sha256 = crypto.createHash('sha256').update(renamedSkill).digest('hex');
+    entry.contentBase64 = renamedSkill.toString('base64');
+
+    const changed = await service.installVerifiedSkillHubPackage({
+      ...update,
+      allowUpdate: true,
+    });
+
+    assert.equal(changed.manifest.entries[0].name, 'renamed-demo');
+    assert.equal(
+      changed.manifest.entries[0].localSkillId,
+      installed.manifest.entries[0].localSkillId,
+    );
+  });
+
+  test('records an installed content baseline and protects local changes from update', async () => {
+    const service = createBotSkillService({ runtimeRoot, skillsRoot });
+    const first = packageFixture('alice/demo', 'demo', '1.0.0', '# one\n');
+    const installed = await service.installVerifiedSkillHubPackage(first);
+    const entry = installed.manifest.entries[0];
+
+    assert.equal(entry.source, 'skillhub');
+    assert.equal(entry.skillId, 'alice/demo');
+    assert.equal(entry.version, '1.0.0');
+    assert.equal(entry.installedContentHash, entry.contentHash);
+
+    const skillFile = path.join(skillsRoot, 'demo', 'SKILL.md');
+    fs.appendFileSync(skillFile, '\nlocal edit\n');
+    const second = packageFixture('alice/demo', 'demo', '2.0.0', '# two\n');
+    await assert.rejects(
+      () => service.installVerifiedSkillHubPackage({ ...second, allowUpdate: true }),
+      (error: any) => error?.code === 'LOCAL_MODIFICATIONS',
+    );
+    assert.match(fs.readFileSync(skillFile, 'utf8'), /local edit/);
+  });
+
+  test('rejects oversized install metadata before committing the target directory', async () => {
+    const service = createBotSkillService({ runtimeRoot, skillsRoot });
+    const incoming = packageFixture('alice/oversized', 'oversized', '1.0.0', '# one\n');
+    incoming.registryEntry.packageUrl = `https://example.test/${'x'.repeat(70 * 1024)}`;
+
+    await assert.rejects(
+      () => service.installVerifiedSkillHubPackage(incoming),
+      (error: any) => error?.code === 'INSTALL_MARKER_TOO_LARGE',
+    );
+    assert.equal(fs.existsSync(path.join(skillsRoot, 'oversized')), false);
+  });
+
+  test('keeps staging and backup directories outside the runtime catalog', async () => {
+    const service = createBotSkillService({ runtimeRoot, skillsRoot });
+    await service.installVerifiedSkillHubPackage(
+      packageFixture('alice/demo', 'demo', '1.0.0', '# one\n'),
+    );
+
+    assert.deepEqual(
+      fs.readdirSync(skillsRoot).filter(name => name.startsWith('.skillhub-')),
+      [],
+    );
+    assert.equal(fs.existsSync(path.join(runtimeRoot, 'data', 'bot-skills', 'operations')), true);
+  });
+
+  test('recovers a complete old or new package across update rename failures', async () => {
+    const service = createBotSkillService({ runtimeRoot, skillsRoot });
+    await service.installVerifiedSkillHubPackage(
+      packageFixture('alice/demo', 'demo', '1.0.0', '# one\n'),
+    );
+    const update = packageFixture('alice/demo', 'demo', '2.0.0', '# two\n');
+
+    await assert.rejects(
+      () => service.installVerifiedSkillHubPackage({
+        ...update,
+        allowUpdate: true,
+        onPhasePersisted: phase => {
+          if (phase === 'target-backed-up') throw new Error('simulated crash');
+        },
+      }),
+      /simulated crash/,
+    );
+    assert.match(
+      fs.readFileSync(path.join(skillsRoot, 'demo', 'SKILL.md'), 'utf8'),
+      /# one/,
+    );
+
+    await assert.rejects(
+      () => service.installVerifiedSkillHubPackage({
+        ...update,
+        allowUpdate: true,
+        onPhasePersisted: phase => {
+          if (phase === 'target-active') throw new Error('simulated crash');
+        },
+      }),
+      /simulated crash/,
+    );
+    assert.match(
+      fs.readFileSync(path.join(skillsRoot, 'demo', 'SKILL.md'), 'utf8'),
+      /# two/,
+    );
+    const recovered = await service.scanManifest();
+    assert.equal(recovered.status, 'complete');
+    assert.equal(recovered.entries[0].version, '2.0.0');
+  });
+
+  test('preserves a unique package backup when the recovered target is ambiguous', async () => {
+    const service = createBotSkillService({ runtimeRoot, skillsRoot });
+    await service.installVerifiedSkillHubPackage(
+      packageFixture('alice/demo', 'demo', '1.0.0', '# one\n'),
+    );
+    const operationDir = path.join(service.operationsRoot, 'install-ambiguous');
+    const backupDir = path.join(operationDir, 'backup');
+    fs.mkdirSync(operationDir, { recursive: true });
+    fs.renameSync(path.join(skillsRoot, 'demo'), backupDir);
+    writeSkill(path.join(skillsRoot, 'demo'), 'unexpected', '# replacement\n');
+    fs.writeFileSync(path.join(operationDir, 'journal.json'), `${JSON.stringify({
+      schema: 'xiaoba.skillhub-install-transaction.v1',
+      phase: 'target-backed-up',
+      targetDir: path.join(skillsRoot, 'demo'),
+      targetExisted: true,
+      expectedSkillId: 'alice/demo',
+      expectedVersion: '2.0.0',
+      expectedChecksumSha256: 'expected-v2',
+    })}\n`);
+
+    await assert.rejects(
+      () => service.scanManifest(),
+      (error: any) => error?.code === 'INSTALL_RECOVERY_AMBIGUOUS',
+    );
+    assert.equal(fs.existsSync(path.join(backupDir, 'SKILL.md')), true);
+    assert.equal(fs.existsSync(path.join(operationDir, 'journal.json')), true);
+  });
+
+  test('preserves a package backup when a target-active journal has no target', async () => {
+    const service = createBotSkillService({ runtimeRoot, skillsRoot });
+    await service.installVerifiedSkillHubPackage(
+      packageFixture('alice/demo', 'demo', '1.0.0', '# one\n'),
+    );
+    const operationDir = path.join(service.operationsRoot, 'install-active-missing');
+    const backupDir = path.join(operationDir, 'backup');
+    fs.mkdirSync(operationDir, { recursive: true });
+    fs.renameSync(path.join(skillsRoot, 'demo'), backupDir);
+    fs.writeFileSync(path.join(operationDir, 'journal.json'), `${JSON.stringify({
+      schema: 'xiaoba.skillhub-install-transaction.v1',
+      phase: 'target-active',
+      targetDir: path.join(skillsRoot, 'demo'),
+      targetExisted: true,
+      expectedSkillId: 'alice/demo',
+      expectedVersion: '2.0.0',
+      expectedChecksumSha256: 'expected-v2',
+    })}\n`);
+
+    await assert.rejects(
+      () => service.scanManifest(),
+      (error: any) => error?.code === 'INSTALL_RECOVERY_AMBIGUOUS',
+    );
+    assert.equal(fs.existsSync(path.join(backupDir, 'SKILL.md')), true);
+  });
+
+  test('preserves a unique local backup when the recovered target is ambiguous', async () => {
+    writeSkill(path.join(skillsRoot, 'demo'), 'demo', '# one\n');
+    const service = createBotSkillService({ runtimeRoot, skillsRoot });
+    const before = await service.scanManifest();
+    const operationDir = path.join(service.operationsRoot, 'local-install-ambiguous');
+    const backupDir = path.join(operationDir, 'backup');
+    fs.mkdirSync(operationDir, { recursive: true });
+    fs.renameSync(path.join(skillsRoot, 'demo'), backupDir);
+    writeSkill(path.join(skillsRoot, 'demo'), 'unexpected', '# replacement\n');
+    fs.writeFileSync(
+      path.join(operationDir, 'local-install-journal.json'),
+      `${JSON.stringify({
+        schema: 'xiaoba.local-skill-install.v1',
+        phase: 'target-backed-up',
+        targetDir: path.join(skillsRoot, 'demo'),
+        targetExisted: true,
+        expectedLocalSkillId: before.entries[0].localSkillId,
+        expectedContentHash: before.entries[0].contentHash,
+      })}\n`,
+    );
+
+    await assert.rejects(
+      () => service.scanManifest(),
+      (error: any) => error?.code === 'LOCAL_INSTALL_RECOVERY_AMBIGUOUS',
+    );
+    assert.equal(fs.existsSync(path.join(backupDir, 'SKILL.md')), true);
+    assert.equal(
+      fs.existsSync(path.join(operationDir, 'local-install-journal.json')),
+      true,
+    );
+  });
+
+  test('preserves a local backup when a target-active journal has no target', async () => {
+    writeSkill(path.join(skillsRoot, 'demo'), 'demo', '# one\n');
+    const service = createBotSkillService({ runtimeRoot, skillsRoot });
+    const before = await service.scanManifest();
+    const operationDir = path.join(service.operationsRoot, 'local-install-active-missing');
+    const backupDir = path.join(operationDir, 'backup');
+    fs.mkdirSync(operationDir, { recursive: true });
+    fs.renameSync(path.join(skillsRoot, 'demo'), backupDir);
+    fs.writeFileSync(
+      path.join(operationDir, 'local-install-journal.json'),
+      `${JSON.stringify({
+        schema: 'xiaoba.local-skill-install.v1',
+        phase: 'target-active',
+        targetDir: path.join(skillsRoot, 'demo'),
+        targetExisted: true,
+        expectedLocalSkillId: before.entries[0].localSkillId,
+        expectedContentHash: before.entries[0].contentHash,
+      })}\n`,
+    );
+
+    await assert.rejects(
+      () => service.scanManifest(),
+      (error: any) => error?.code === 'LOCAL_INSTALL_RECOVERY_AMBIGUOUS',
+    );
+    assert.equal(fs.existsSync(path.join(backupDir, 'SKILL.md')), true);
+  });
+
+  test('reports copied local identities and symlinks as partial instead of complete deletion state', async t => {
+    writeSkill(path.join(skillsRoot, 'one'), 'one', '# one\n');
+    writeSkill(path.join(skillsRoot, 'two'), 'two', '# two\n');
+    const service = createBotSkillService({ runtimeRoot, skillsRoot });
+    await service.scanManifest();
+    fs.copyFileSync(
+      path.join(skillsRoot, 'one', BOT_SKILL_LOCAL_IDENTITY_FILE),
+      path.join(skillsRoot, 'two', BOT_SKILL_LOCAL_IDENTITY_FILE),
+    );
+
+    const duplicate = scanLocalSkillManifest({ skillsRoot, createIdentities: false });
+    assert.equal(duplicate.status, 'partial');
+    assert.ok(duplicate.issues.some(item => item.code === 'DUPLICATE_LOCAL_SKILL_ID'));
+
+    const outside = path.join(testRoot, 'outside');
+    fs.mkdirSync(outside);
+    const link = path.join(skillsRoot, 'linked');
+    try {
+      fs.symlinkSync(outside, link, process.platform === 'win32' ? 'junction' : 'dir');
+    } catch (error: any) {
+      if (process.platform === 'win32' && ['EPERM', 'EACCES'].includes(error?.code)) {
+        t.skip('Creating a junction requires additional Windows privileges.');
+        return;
+      }
+      throw error;
+    }
+    const unsafe = scanLocalSkillManifest({ skillsRoot, createIdentities: false });
+    assert.equal(unsafe.status, 'partial');
+    assert.ok(unsafe.issues.some(item => item.code === 'SYMLINK_UNSUPPORTED'));
+  });
+
+  test('treats nested Skill roots as a blocking manifest issue', () => {
+    writeSkill(path.join(skillsRoot, 'outer'), 'outer', '# outer\n');
+    writeSkill(path.join(skillsRoot, 'outer', 'inner'), 'inner', '# inner\n');
+
+    const manifest = scanLocalSkillManifest({ skillsRoot });
+
+    assert.equal(manifest.status, 'partial');
+    assert.ok(manifest.issues.some(item => item.code === 'NESTED_SKILL_UNSUPPORTED'));
+    assert.deepEqual(manifest.entries.map(entry => entry.name), ['outer']);
+  });
+
+  test('rejects a prospective name conflict before installing local content', async () => {
+    writeSkill(path.join(skillsRoot, 'existing'), 'shared-name', '# existing\n');
+    const source = path.join(testRoot, 'incoming');
+    writeSkill(source, 'shared-name', '# incoming\n');
+    const service = createBotSkillService({ runtimeRoot, skillsRoot });
+
+    await assert.rejects(
+      () => service.installLocalDirectory({
+        sourceDir: source,
+        installName: 'other-directory',
+      }),
+      (error: any) => error?.code === 'SKILL_MANIFEST_CONFLICT',
+    );
+    assert.equal(fs.existsSync(path.join(skillsRoot, 'other-directory')), false);
+    assert.match(
+      fs.readFileSync(path.join(skillsRoot, 'existing', 'SKILL.md'), 'utf8'),
+      /existing/,
+    );
+  });
+
+  test('rejects a prospective name conflict before installing a SkillHub package', async () => {
+    writeSkill(path.join(skillsRoot, 'existing'), 'shared-name', '# existing\n');
+    const incoming = packageFixture(
+      'alice/cloud-demo',
+      'shared-name',
+      '1.0.0',
+      '# incoming\n',
+    );
+    incoming.verification.packageObject.payload.manifest.name = 'cloud-demo';
+    incoming.registryEntry.name = 'cloud-demo';
+    const service = createBotSkillService({ runtimeRoot, skillsRoot });
+
+    await assert.rejects(
+      () => service.installVerifiedSkillHubPackage(incoming),
+      (error: any) => error?.code === 'SKILL_MANIFEST_CONFLICT',
+    );
+    assert.equal(fs.existsSync(path.join(skillsRoot, 'cloud-demo')), false);
+  });
+
+  test('does not uninstall after discovering an unrelated partial manifest', async () => {
+    const service = createBotSkillService({ runtimeRoot, skillsRoot });
+    await service.installVerifiedSkillHubPackage(
+      packageFixture('alice/demo', 'demo', '1.0.0', '# demo\n'),
+    );
+    writeSkill(path.join(skillsRoot, 'outer'), 'outer', '# outer\n');
+    writeSkill(path.join(skillsRoot, 'outer', 'inner'), 'inner', '# inner\n');
+
+    await assert.rejects(
+      () => service.uninstallSkillHubPackage({
+        skillId: 'alice/demo',
+        installName: 'demo',
+      }),
+      (error: any) => error?.code === 'LOCAL_SKILL_MANIFEST_INCOMPLETE',
+    );
+    assert.equal(fs.existsSync(path.join(skillsRoot, 'demo', 'SKILL.md')), true);
+  });
+
+  test('uses the PR2 activation lock and revalidates the Bot owner before writing identity', async () => {
+    const managedSkills = path.join(runtimeRoot, 'skills');
+    writeSkill(path.join(managedSkills, 'demo'), 'demo', '# demo\n');
+    const config = createCatsCoLocalConfigService({ runtimeRoot, env: {} });
+    config.save(botConfig('bot_A'));
+    const workspace = new BotSkillWorkspaceService({ runtimeRoot, env: {} });
+    workspace.ensureActive('bot_A');
+    const service = createBotSkillService({
+      runtimeRoot,
+      skillsRoot: managedSkills,
+      env: {},
+      workspaceService: workspace,
+    });
+
+    const held = workspace.acquireActivationLock();
+    try {
+      await assert.rejects(
+        () => service.scanManifest(),
+        /already locked/,
+      );
+      assert.equal(
+        fs.existsSync(path.join(managedSkills, 'demo', BOT_SKILL_LOCAL_IDENTITY_FILE)),
+        false,
+      );
+    } finally {
+      held.release();
+    }
+
+    config.save(botConfig('bot_B'));
+    await assert.rejects(
+      () => service.scanManifest(),
+      (error: any) => error?.code === 'SKILL_WORKSPACE_OWNER_CHANGED',
+    );
+    assert.equal(
+      fs.existsSync(path.join(managedSkills, 'demo', BOT_SKILL_LOCAL_IDENTITY_FILE)),
+      false,
+    );
+  });
+
+  test('adopts an unbound local identity without changing localSkillId', async () => {
+    const managedSkills = path.join(runtimeRoot, 'skills');
+    writeSkill(path.join(managedSkills, 'demo'), 'demo', '# demo\n');
+    const unmanaged = createBotSkillService({
+      runtimeRoot,
+      skillsRoot: managedSkills,
+      env: {},
+      allowUnmanagedWorkspace: true,
+    });
+    const before = await unmanaged.scanManifest();
+    const localSkillId = before.entries[0].localSkillId;
+
+    const config = createCatsCoLocalConfigService({ runtimeRoot, env: {} });
+    config.save(botConfig('bot_A'));
+    const workspace = new BotSkillWorkspaceService({ runtimeRoot, env: {} });
+    const state = workspace.ensureActive('bot_A');
+    const after = await createBotSkillService({
+      runtimeRoot,
+      env: {},
+      workspaceService: workspace,
+    }).scanManifest();
+
+    assert.equal(after.entries[0].localSkillId, localSkillId);
+    const identity = JSON.parse(fs.readFileSync(
+      path.join(managedSkills, 'demo', BOT_SKILL_LOCAL_IDENTITY_FILE),
+      'utf8',
+    ));
+    assert.equal(identity.workspaceId, state.workspaceId);
+  });
+
+  test('keeps interrupted operations isolated by workspace across Bot switches', async () => {
+    const managedSkills = path.join(runtimeRoot, 'skills');
+    writeSkill(path.join(managedSkills, 'demo'), 'demo', '# A\n');
+    const config = createCatsCoLocalConfigService({ runtimeRoot, env: {} });
+    config.save(botConfig('bot_A'));
+    const workspace = new BotSkillWorkspaceService({ runtimeRoot, env: {} });
+    workspace.ensureActive('bot_A');
+    const serviceA = createBotSkillService({
+      runtimeRoot,
+      env: {},
+      workspaceService: workspace,
+    });
+    const operationDir = path.join(serviceA.operationsRoot, 'install-crash');
+    const backupDir = path.join(operationDir, 'backup');
+    fs.mkdirSync(operationDir, { recursive: true });
+    fs.renameSync(path.join(managedSkills, 'demo'), backupDir);
+    fs.writeFileSync(path.join(operationDir, 'journal.json'), `${JSON.stringify({
+      schema: 'xiaoba.skillhub-install-transaction.v1',
+      phase: 'prepared',
+      targetDir: path.join(managedSkills, 'demo'),
+      targetExisted: true,
+    })}\n`);
+
+    const toB = workspace.beginSwitch('bot_B', { allowCreate: true });
+    workspace.commitSwitch(toB.transactionId!);
+    config.save(botConfig('bot_B'));
+    const serviceB = createBotSkillService({
+      runtimeRoot,
+      env: {},
+      workspaceService: workspace,
+    });
+    assert.notEqual(serviceB.operationsRoot, serviceA.operationsRoot);
+    const manifestB = await serviceB.scanManifest();
+    assert.deepEqual(manifestB.entries, []);
+    assert.equal(fs.existsSync(backupDir), true);
+    assert.equal(fs.existsSync(path.join(managedSkills, 'demo')), false);
+
+    const toA = workspace.beginSwitch('bot_A');
+    workspace.commitSwitch(toA.transactionId!);
+    config.save(botConfig('bot_A'));
+    const recoveredA = await createBotSkillService({
+      runtimeRoot,
+      env: {},
+      workspaceService: workspace,
+    }).scanManifest();
+    assert.equal(recoveredA.entries[0].name, 'demo');
+    assert.match(
+      fs.readFileSync(path.join(managedSkills, 'demo', 'SKILL.md'), 'utf8'),
+      /# A/,
+    );
+  });
+
+  test('uses the pending target identity while validating a workspace switch', async () => {
+    const managedSkills = path.join(runtimeRoot, 'skills');
+    fs.mkdirSync(managedSkills, { recursive: true });
+    const config = createCatsCoLocalConfigService({ runtimeRoot, env: {} });
+    config.save(botConfig('bot_A'));
+    const workspace = new BotSkillWorkspaceService({ runtimeRoot, env: {} });
+    workspace.ensureActive('bot_A');
+    const lock = workspace.acquireActivationLock();
+    try {
+      const switching = workspace.beginSwitch('bot_B', {
+        allowCreate: true,
+        lock,
+      });
+      config.save(botConfig('bot_B'));
+      writeSkill(path.join(managedSkills, 'target-skill'), 'target-skill', '# B\n');
+
+      const manifest = await createBotSkillService({
+        runtimeRoot,
+        env: {},
+        expectedBotId: 'bot_B',
+        workspaceService: workspace,
+        activationLock: lock,
+        activationTransactionId: switching.transactionId,
+      }).scanManifest();
+
+      const pending = workspace.readState()?.switchJournal?.to;
+      assert.equal(manifest.botId, 'bot_B');
+      assert.equal(manifest.workspaceId, pending?.workspaceId);
+      const identity = JSON.parse(fs.readFileSync(
+        path.join(managedSkills, 'target-skill', BOT_SKILL_LOCAL_IDENTITY_FILE),
+        'utf8',
+      ));
+      assert.equal(identity.workspaceId, pending?.workspaceId);
+    } finally {
+      lock.release();
+    }
+  });
+
+  test('local directory overwrite is atomic and keeps identity for the same Skill', async () => {
+    const sourceOne = path.join(testRoot, 'source-one');
+    const sourceTwo = path.join(testRoot, 'source-two');
+    writeSkill(sourceOne, 'prompt-editor', '# one\n');
+    writeSkill(sourceTwo, 'prompt-editor', '# two\n');
+    const service = createBotSkillService({ runtimeRoot, skillsRoot });
+
+    const first = await service.installLocalDirectory({
+      sourceDir: sourceOne,
+      installName: 'prompt-editor',
+    });
+    const firstId = first.manifest.entries[0].localSkillId;
+    const second = await service.installLocalDirectory({
+      sourceDir: sourceTwo,
+      installName: 'prompt-editor',
+      overwrite: true,
+    });
+
+    assert.equal(second.manifest.entries[0].localSkillId, firstId);
+    assert.match(
+      fs.readFileSync(path.join(skillsRoot, 'prompt-editor', 'SKILL.md'), 'utf8'),
+      /# two/,
+    );
+  });
+
+  test('accepts Windows path casing differences without treating them as links', {
+    skip: process.platform !== 'win32',
+  }, async () => {
+    const lowerSkillsRoot = skillsRoot.toLowerCase();
+    const service = createBotSkillService({
+      runtimeRoot,
+      skillsRoot: lowerSkillsRoot,
+    });
+
+    const installed = await service.installVerifiedSkillHubPackage(
+      packageFixture('alice/casing', 'casing', '1.0.0', '# casing\n'),
+    );
+
+    assert.equal(installed.manifest.entries[0].name, 'casing');
+  });
+});
+
+function writeSkill(directory: string, name: string, body: string): void {
+  fs.mkdirSync(directory, { recursive: true });
+  fs.writeFileSync(path.join(directory, 'SKILL.md'), [
+    '---',
+    `name: ${name}`,
+    `description: ${name} description`,
+    '---',
+    '',
+    body,
+  ].join('\n'));
+}
+
+function packageFixture(
+  skillId: string,
+  name: string,
+  version: string,
+  body: string,
+) {
+  const skill = Buffer.from([
+    '---',
+    `name: ${name}`,
+    `description: ${name} description`,
+    '---',
+    '',
+    body,
+  ].join('\n'));
+  const registryEntry = {
+    skillId,
+    name,
+    displayName: name,
+    latestVersion: version,
+    packageUrl: '/package',
+    checksumSha256: crypto.createHash('sha256').update(`${skillId}:${version}`).digest('hex'),
+    signature: {
+      algorithm: 'ed25519' as const,
+      keyId: 'test-key',
+      signature: 'test-signature',
+      signedAt: '2026-01-01T00:00:00.000Z',
+    },
+  } as SkillHubRegistryEntry;
+  return {
+    registryEntry,
+    verification: {
+      packageObject: {
+        payload: {
+          manifest: {
+            id: skillId,
+            name,
+            displayName: name,
+            version,
+            entrypoints: { skillFile: 'SKILL.md' },
+          },
+          files: [{
+            path: 'SKILL.md',
+            size: skill.length,
+            sha256: crypto.createHash('sha256').update(skill).digest('hex'),
+            contentBase64: skill.toString('base64'),
+          }],
+        },
+      },
+    } as any,
+  };
+}
+
+function botConfig(botId: string) {
+  return {
+    version: 1 as const,
+    currentBot: {
+      uid: botId,
+      apiKey: `key-${botId}`,
+      boundByUserUid: 'user-1',
+      bindingSource: 'test',
+    },
+    device: {
+      deviceId: 'device-1',
+      bodyId: 'device-1',
+      installationId: 'device-1',
+    },
+  };
+}

--- a/tests/dashboard-catsco-auth-status.test.ts
+++ b/tests/dashboard-catsco-auth-status.test.ts
@@ -1105,8 +1105,16 @@ describe('dashboard CatsCo account status', () => {
       device: { deviceId: 'device-1', bodyId: 'body-1', installationId: 'install-1' },
     });
     const activeSkill = path.join(testRoot, 'skills', 'same-name');
+    const offlineSkillContent = [
+      '---',
+      'name: same-name',
+      'description: offline edit fixture',
+      '---',
+      '',
+      'offline edit from A',
+    ].join('\n');
     fs.mkdirSync(activeSkill, { recursive: true });
-    fs.writeFileSync(path.join(activeSkill, 'SKILL.md'), 'offline edit from A');
+    fs.writeFileSync(path.join(activeSkill, 'SKILL.md'), offlineSkillContent);
     const workspace = new BotSkillWorkspaceService({ runtimeRoot: testRoot, env: {} });
     workspace.ensureActive('188');
 
@@ -1177,7 +1185,7 @@ describe('dashboard CatsCo account status', () => {
     assert.equal(workspace.readState()?.workspaceOwnerBotId, '188');
     assert.equal(
       fs.readFileSync(path.join(testRoot, 'skills', 'same-name', 'SKILL.md'), 'utf8'),
-      'offline edit from A',
+      offlineSkillContent,
     );
     assert.equal(recoveryStartCalled, 1);
 
@@ -1191,7 +1199,7 @@ describe('dashboard CatsCo account status', () => {
     assert.equal(fs.existsSync(path.join(testRoot, 'skills', 'same-name')), false);
     assert.equal(
       fs.readFileSync(path.join(workspace.getParkedPath('188'), 'same-name', 'SKILL.md'), 'utf8'),
-      'offline edit from A',
+      offlineSkillContent,
     );
     assert.equal(stopCalled, 2);
     assert.equal(readyStartCalled, 2);

--- a/tests/dashboard-skillhub-connected-api.test.ts
+++ b/tests/dashboard-skillhub-connected-api.test.ts
@@ -7,6 +7,8 @@ import * as path from 'path';
 import express from 'express';
 import type { Server } from 'http';
 import { createApiRouter } from '../src/dashboard/routes/api';
+import { createCatsCoLocalConfigService } from '../src/catscompany/local-config';
+import { BotSkillWorkspaceService } from '../src/bot-skills/workspace-service';
 import { loadSkillHubConfig } from '../src/skillhub/config';
 import { CATSCO_SKILLHUB_ROOT_PUBLIC_KEYS, SkillHubTrustedRootKey } from '../src/skillhub/trusted-keys';
 
@@ -30,6 +32,7 @@ describe('dashboard connected SkillHub API', () => {
     process.chdir(testRoot);
     process.env.XIAOBA_SKILLS_DIR = path.join(testRoot, 'skills');
     fs.mkdirSync(path.join(testRoot, 'skills'), { recursive: true });
+    claimTestBotWorkspace(testRoot);
   });
 
   afterEach(async () => {
@@ -132,7 +135,24 @@ describe('dashboard connected SkillHub API', () => {
     fs.writeFileSync(path.join(testRoot, 'skills', 'quick-demo', 'REVIEW.json'), '{}\n');
     fs.writeFileSync(path.join(testRoot, 'skills', 'quick-demo', 'SBOM.json'), '{}\n');
     fs.writeFileSync(path.join(testRoot, 'skills', 'quick-demo', '.xiaoba-bundled-skill.json'), '{}\n');
-    fs.writeFileSync(path.join(testRoot, 'skills', 'quick-demo', '.xiaoba-skillhub-install.json'), '{}\n');
+    fs.writeFileSync(
+      path.join(testRoot, 'skills', 'quick-demo', '.xiaoba-skillhub-install.json'),
+      `${JSON.stringify({
+        source: 'skillhub',
+        skillId: 'lin/quick-demo',
+        name: 'quick-demo',
+        installName: 'quick-demo',
+        version: '1.0.0',
+        packageChecksumSha256: 'test-checksum',
+        signature: {
+          algorithm: 'ed25519',
+          keyId: 'test-key',
+          signature: 'test-signature',
+        },
+        packageUrl: 'https://example.test/quick-demo.skillpkg',
+        installedAt: '2026-01-01T00:00:00.000Z',
+      })}\n`,
+    );
 
     const fixture = createFixture();
     await startCloud(fixture);
@@ -161,6 +181,33 @@ describe('dashboard connected SkillHub API', () => {
     assert.match(skillText, /skillhub_author:\s+["']?lin["']?/);
     assert.match(skillText, /skillhub_version:\s+["']?1\.0\.0["']?/);
     assert.match(skillText, /skillhub_uploaded_at:/);
+  });
+
+  test('returns partial manifest diagnostics when a local Skill blocks sharing', async () => {
+    const skillDir = path.join(testRoot, 'skills', 'broken-demo');
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'), [
+      '---',
+      'name: broken-demo',
+      'description: Broken demo skill',
+      '---',
+      '',
+      '# Broken Demo',
+    ].join('\n'));
+    fs.writeFileSync(path.join(skillDir, '.xiaoba-skillhub-install.json'), '{}\n');
+    await startDashboard();
+
+    const share = await post('/api/skillhub/share-local-skill', {
+      skillName: 'broken-demo',
+    });
+
+    assert.equal(share.status, 409);
+    assert.equal(share.body.code, 'LOCAL_SKILL_MANIFEST_INCOMPLETE');
+    assert.equal(share.body.manifest.status, 'partial');
+    assert.ok(
+      share.body.manifest.issues.some((issue: any) =>
+        issue.code === 'SKILL_SCAN_FAILED' && issue.path === 'broken-demo'),
+    );
   });
 
   test('connects SkillHub with the current CatsCo login token', async () => {
@@ -359,6 +406,25 @@ describe('dashboard connected SkillHub API', () => {
     return { status: response.status, body: await response.json() };
   }
 });
+
+function claimTestBotWorkspace(runtimeRoot: string): void {
+  createCatsCoLocalConfigService({ runtimeRoot, env: process.env }).save({
+    version: 1,
+    currentBot: {
+      uid: 'bot_skillhub_test',
+      apiKey: 'test-api-key',
+      boundByUserUid: 'test-user',
+      bindingSource: 'test',
+    },
+    device: {
+      deviceId: 'test-device',
+      bodyId: 'test-device',
+      installationId: 'test-device',
+    },
+  });
+  new BotSkillWorkspaceService({ runtimeRoot, env: process.env })
+    .ensureActive('bot_skillhub_test');
+}
 
 function createFixture() {
   const rootKeys = crypto.generateKeyPairSync('ed25519');

--- a/tests/skillhub-default-skills.test.ts
+++ b/tests/skillhub-default-skills.test.ts
@@ -122,6 +122,38 @@ describe('default SkillHub bootstrap', () => {
     assert.equal(result.find(item => item.key === secondSkill.key)?.action, 'installed');
     assert.deepEqual(calls, ['catsco/agent-browser@1.0.0', 'catsco/officecli@1.0.0']);
   });
+
+  test('keeps default bootstrap state isolated by Bot workspace', async () => {
+    const calls: string[] = [];
+    const skill = defaultSkill('agent-browser');
+    const service = fakeInstallService(calls);
+    const workspaceA = path.join(testRoot, 'skills-a');
+    const workspaceB = path.join(testRoot, 'skills-b');
+
+    process.env.XIAOBA_SKILLS_DIR = workspaceA;
+    await bootstrapDefaultSkillHubSkills({
+      skills: [skill],
+      service,
+      workspaceId: 'workspace-a',
+    });
+    process.env.XIAOBA_SKILLS_DIR = workspaceB;
+    await bootstrapDefaultSkillHubSkills({
+      skills: [skill],
+      service,
+      workspaceId: 'workspace-b',
+    });
+
+    assert.deepEqual(calls, [
+      'catsco/agent-browser@1.0.0',
+      'catsco/agent-browser@1.0.0',
+    ]);
+    assert.notEqual(
+      getDefaultSkillBootstrapStatePath('workspace-a'),
+      getDefaultSkillBootstrapStatePath('workspace-b'),
+    );
+    assert.equal(fs.existsSync(path.join(workspaceA, 'agent-browser', 'SKILL.md')), true);
+    assert.equal(fs.existsSync(path.join(workspaceB, 'agent-browser', 'SKILL.md')), true);
+  });
 });
 
 function defaultSkill(name: string): DefaultSkillHubSkill {

--- a/tests/skillhub-package-verification.test.ts
+++ b/tests/skillhub-package-verification.test.ts
@@ -58,9 +58,101 @@ describe('SkillHub package trust chain verification', () => {
       /checksum mismatch/,
     );
   });
+
+  test('rejects portable path collisions, reserved metadata, and nested Skill entrypoints', () => {
+    const cases = [
+      {
+        files: [
+          makeFile('SKILL.md', '# Skill'),
+          makeFile('readme.txt', 'one'),
+          makeFile('README.TXT', 'two'),
+        ],
+        code: 'PACKAGE_FILE_DUPLICATE',
+      },
+      {
+        files: [
+          makeFile('SKILL.md', '# Skill'),
+          makeFile('nested/.xiaoba-local-skill.json', '{}'),
+        ],
+        code: 'PACKAGE_RESERVED_FILE',
+      },
+      {
+        files: [
+          makeFile('SKILL.md', '# Skill'),
+          makeFile('nested/SKILL.md', '# Nested'),
+        ],
+        code: 'PACKAGE_NESTED_SKILL_UNSUPPORTED',
+      },
+      {
+        files: [
+          makeFile('SKILL.md', '# Skill'),
+          makeFile('CON.txt', 'unsafe'),
+        ],
+        code: 'PACKAGE_FILE_PATH_UNSAFE',
+      },
+      {
+        files: [
+          makeFile('SKILL.md', '# Skill'),
+          makeFile('unsafe.', 'unsafe'),
+        ],
+        code: 'PACKAGE_FILE_PATH_UNSAFE',
+      },
+      {
+        files: [
+          makeFile('SKILL.md', '# Skill'),
+          makeFile('unsafe ', 'unsafe'),
+        ],
+        code: 'PACKAGE_FILE_PATH_UNSAFE',
+      },
+    ];
+
+    for (const item of cases) {
+      const fixture = createFixture(item.files);
+      assert.throws(
+        () => verifySkillHubPackage({
+          packageBytes: fixture.packageBytes,
+          registryEntry: fixture.registryEntry,
+          trust: fixture.trust,
+          trustedRoots: [fixture.rootPublic],
+          now: new Date('2026-06-01T00:00:00.000Z'),
+        }),
+        (error: any) => error?.code === item.code,
+      );
+    }
+  });
+
+  test('rejects excessive file counts and invalid certificate dates', () => {
+    const tooMany = [
+      makeFile('SKILL.md', '# Skill'),
+      ...Array.from({ length: 256 }, (_, index) =>
+        makeFile(`files/${index}.txt`, String(index))),
+    ];
+    const oversizedFixture = createFixture(tooMany);
+    assert.throws(
+      () => verifySkillHubPackage({
+        packageBytes: oversizedFixture.packageBytes,
+        registryEntry: oversizedFixture.registryEntry,
+        trust: oversizedFixture.trust,
+        trustedRoots: [oversizedFixture.rootPublic],
+      }),
+      (error: any) => error?.code === 'PACKAGE_FILE_COUNT_EXCEEDED',
+    );
+
+    const invalidDateFixture = createFixture();
+    invalidDateFixture.trust.keys[0].certificate.issuedAt = 'not-a-date';
+    assert.throws(
+      () => verifySkillHubPackage({
+        packageBytes: invalidDateFixture.packageBytes,
+        registryEntry: invalidDateFixture.registryEntry,
+        trust: invalidDateFixture.trust,
+        trustedRoots: [invalidDateFixture.rootPublic],
+      }),
+      (error: any) => error?.code === 'CERT_DATE_INVALID',
+    );
+  });
 });
 
-function createFixture(): {
+function createFixture(files?: ReturnType<typeof makeFile>[]): {
   rootPublic: SkillHubTrustedRootKey;
   trust: SkillHubTrustResponse;
   registryEntry: SkillHubRegistryEntry;
@@ -98,7 +190,7 @@ function createFixture(): {
       name: 'contract-review',
       version: '1.0.0',
     },
-    files: [
+    files: files ?? [
       makeFile('skill.json', JSON.stringify({ id: 'contract-review', version: '1.0.0' })),
       makeFile('SKILL.md', '# Contract Review\n\nReview contract risks.'),
     ],

--- a/tests/skillhub-service-install.test.ts
+++ b/tests/skillhub-service-install.test.ts
@@ -7,6 +7,8 @@ import * as path from 'path';
 import express from 'express';
 import type { Server } from 'http';
 import { SkillHubService } from '../src/skillhub/service';
+import { createCatsCoLocalConfigService } from '../src/catscompany/local-config';
+import { BotSkillWorkspaceService } from '../src/bot-skills/workspace-service';
 import type { SkillHubTrustedRootKey } from '../src/skillhub/trusted-keys';
 import { CATSCO_SKILLHUB_ROOT_PUBLIC_KEYS } from '../src/skillhub/trusted-keys';
 
@@ -26,6 +28,7 @@ describe('SkillHub connected install service', () => {
     process.chdir(testRoot);
     process.env.XIAOBA_SKILLS_DIR = path.join(testRoot, 'skills');
     fs.mkdirSync(path.join(testRoot, 'skills'), { recursive: true });
+    claimTestBotWorkspace(testRoot);
   });
 
   afterEach(async () => {
@@ -148,6 +151,25 @@ describe('SkillHub connected install service', () => {
     baseUrl = `http://127.0.0.1:${address.port}`;
   }
 });
+
+function claimTestBotWorkspace(runtimeRoot: string): void {
+  createCatsCoLocalConfigService({ runtimeRoot, env: process.env }).save({
+    version: 1,
+    currentBot: {
+      uid: 'bot_skillhub_test',
+      apiKey: 'test-api-key',
+      boundByUserUid: 'test-user',
+      bindingSource: 'test',
+    },
+    device: {
+      deviceId: 'test-device',
+      bodyId: 'test-device',
+      installationId: 'test-device',
+    },
+  });
+  new BotSkillWorkspaceService({ runtimeRoot, env: process.env })
+    .ensureActive('bot_skillhub_test');
+}
 
 function createFixture() {
   const rootKeys = crypto.generateKeyPairSync('ed25519');


### PR DESCRIPTION
## 为什么做

PR1 已经为 Bot Definition 增加了精确的 Skill 引用模型，PR2 已经完成了“每个 Bot 独立本地 Skill 工作区”的归属、切换和崩溃恢复。

在进入 Local / Base / Cloud 三方比较与同步之前，还需要先统一所有本地 Skill 的读取和写入入口，并建立稳定、可校验的 Local Manifest。否则 Dashboard、CLI、SkillHub、默认 Skill 初始化分别直接操作目录时，会出现以下风险：

- Xiaoba 离线期间的修改无法稳定归属到原 Bot；
- 同一个 Skill 改名后可能被误判成新 Skill；
- 工作区处于部分损坏状态时仍继续删除、覆盖或切换；
- 安装、升级或崩溃恢复过程中可能留下半成品或错误清理备份；
- 后续 Base 无法可靠保存 Local Skill 与 Cloud Skill 的对应关系。

因此，PR3 的目标是先把“本地事实层”和“本地写入边界”做稳，为后续 PR4/PR5 的同步状态机提供可靠输入。

## 做了什么

### 1. 增加 Local Manifest 与稳定本地身份

- 新增严格的 Local Manifest 扫描器，区分 `missing`、`complete`、`partial`、`unreadable`。
- 为每个本地 Skill 写入 `.xiaoba-local-skill.json`，生成稳定的 `localSkillId`。
- Skill 在原目录内改名时保留 `localSkillId`；跨工作区复制时重新生成身份，避免把复制品误认成同一 Skill。
- Manifest 同时记录本地名称、路径、启用状态、内容哈希、来源，以及 SkillHub 安装信息，供后续 Base 建立 Local / Cloud 映射。
- 对重复名称、重复 ID、大小写或 Unicode 可移植冲突、嵌套 Skill、软链接/目录联接、启用与禁用副本并存等情况返回明确的 partial issues。

### 2. 新增统一的 `BotSkillService`

- 将本地安装、SkillHub 安装、卸载、删除、启用/禁用、分享前读取等操作统一收口。
- Dashboard、CLI、SkillHub 服务和默认 Skill 初始化不再各自绕过服务直接修改活动目录。
- 所有受管工作区写入都复用 PR2 的 activation lock，并在真正写入前重新校验 workspace owner。
- 对当前 Manifest 和变更后的 prospective Manifest 都做前置校验，发现不完整状态时拒绝继续破坏性写入。
- 待切换目标工作区使用目标 Bot 的身份扫描，避免将目标目录错误归属给当前 Bot。

### 3. 安装、更新与恢复改为原子流程

- 本地安装和 SkillHub 安装都采用 staging、backup、journal 三阶段流程。
- 操作目录按 workspace 隔离，避免 Bot A 的中断操作在切换后污染 Bot B。
- 恢复时校验目标 marker、identity 和内容哈希；无法唯一判断时保留 journal 与 backup，并返回可诊断错误，不做猜测性删除。
- 保留 Skill 原来的禁用状态；安装提交后即使后续扫描发现新的 partial，也返回真实的已提交结果，避免调用方误以为安装未发生。
- SkillHub 安装 marker 增加 `installedContentHash`，更新前保护用户的本地修改。

### 4. 加固 SkillHub 包验证与下载边界

- 增加下载大小、文件数、单文件大小、解码后总大小、路径长度和目录深度限制。
- 严格校验 Base64、文件元数据、签名证书日期以及根授权关系。
- 拒绝路径穿越、大小写/Unicode 冲突、Windows 保留名称、尾随点或空格、保留本地元数据文件、嵌套 Skill 和非根入口。
- 下载改为流式读取并执行硬上限，避免仅依赖远端 `Content-Length`。

### 5. 保持现有产品入口兼容

- Dashboard 的删除、启用/禁用、Prompt Skill 初始化、SkillHub 安装/卸载/分享统一接入新服务。
- Manifest 为 `partial` 时 Dashboard 可以降级启动并展示具体问题；`missing` 或 `unreadable` 仍阻止伪装成完整启动。
- Connector 启动、Bot 绑定/切换和 SkillHub 分享在 Manifest 不完整时返回结构化诊断。
- CLI GitHub 安装先克隆到临时目录，再由统一服务提交；多 Skill 仓库支持 `--skill <name>` 选择目标。
- 默认 Skill 的初始化状态按 workspace 隔离，并兼容迁移旧的全局状态。

## 重要行为与兼容性说明

- 受 PR2 管理但尚未完成 workspace claim 的目录会返回冲突，不再因 `XIAOBA_SKILLS_DIR` 恰好指向该目录就被当成外部目录直接写入。
- 首次完整扫描会为现有 Skill 补充本地身份 sidecar；这是后续同步需要的稳定标识。
- Manifest 为 partial 时，删除、覆盖、切换、Connector 启动和分享等操作会被阻止，并返回具体 issues。
- 旧 SkillHub marker 没有 `installedContentHash` 时，不会自动覆盖升级，而是返回 `LOCAL_BASELINE_MISSING`，避免误删本地修改。
- GitHub 多 Skill 仓库需要显式传入 `--skill`；单 Skill 仓库的原有用法保持不变。
- `/api/skills-root` 只读取目录，不再通过查询接口隐式创建目录。
- SkillHub 的 uninstall / claim 路径现在通过异步统一服务执行。
- `subscriptions` 在本 PR 中只保留迁移兼容用途，不作为未来 Bot Definition 同步关系的事实来源。

## 测试与审核

- `npm run build`：通过。
- PR3 定向回归：137/137 通过。
- `git diff --check`：通过。
- 三个独立方向复审（同步状态、安全/后端、产品兼容性）：均未发现剩余 P0/P1。
- 全量运行时回归共 1255 项：1248 通过、4 跳过、3 失败。其中 CatsCompany 网络失败用例为偶发端口竞争，本轮单项及定向套件均通过；另外 2 项为主线已有的 PDF 视觉读取基线失败，与本 PR 变更范围无关。

覆盖的关键场景包括：

- Skill 改名、复制、跨 workspace 切换与身份稳定性；
- 离线修改、禁用状态、已有本地修改保护；
- 当前和目标 Manifest 的 partial 阻断；
- 本地包和 SkillHub 包在不同崩溃阶段的恢复；
- target-active 但目标缺失时保留备份；
- 包体资源耗尽、路径冲突、保留文件与签名异常；
- 默认 Skill workspace 隔离；
- Dashboard、Connector 和 SkillHub 的结构化错误透传。

## 本 PR 不做什么

- 不写入 `BotDefinition.skills`。
- 不创建或更新 sync-base。
- 不实现 Local / Base / Cloud 的方向判断与冲突合并。
- 不实现私有版本上传或自动云同步。

## 下一步

1. PR4：实现 Base 快照，保存每个 Skill 的 Local / Cloud 映射、内容基线与版本信息。
2. PR5：实现 Local / Base / Cloud 比较、上传/下载方向判断、双变冲突策略，以及 Bot Definition 的字段级 PATCH + 强制 ETag。
3. 在正式切换到 Definition 引用模型后，收敛或迁移现有 user-level subscription 兼容逻辑。
