### PR TITLE
feat: 实现 Bot Skill Local/Base/Cloud 三态同步（PR4）

### DIFF
--- a/src/bot-definition/repository.ts
+++ b/src/bot-definition/repository.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import * as crypto from 'node:crypto';
 import { PathResolver } from '../utils/path-resolver';
 import {
   BOT_CATALOG_MODEL_RUNTIME_SCHEMA,
@@ -12,12 +13,16 @@ import {
   type CustomBotModelDefinition,
 } from './types';
 
+const MAX_DEFINITION_BYTES = 2 * 1024 * 1024;
+
 export interface BotDefinitionRepository {
   inspectCanonical(botId: string): BotDefinitionReadResult;
   readCanonical(botId: string): BotDefinition | undefined;
   writeCanonical(definition: BotDefinition): void;
   readCache(botId: string): BotDefinition | undefined;
   writeCache(definition: BotDefinition): void;
+  /** File implementations serialize field-preserving read/modify/write updates per Bot. */
+  withCanonicalLock?<T>(botId: string, action: () => T): T;
 }
 
 export type BotDefinitionReadResult =
@@ -132,13 +137,18 @@ function isValidCustomModelProfile(profile: unknown, expectedBotId: string): pro
 }
 
 function inspectDefinition(filePath: string, expectedBotId: string): BotDefinitionReadResult {
-  if (!fs.existsSync(filePath)) return { status: 'missing' };
   try {
+    assertDefinitionDirectorySafe(path.dirname(filePath));
+    const stat = fs.lstatSync(filePath);
+    if (!stat.isFile() || stat.isSymbolicLink() || stat.size > MAX_DEFINITION_BYTES) {
+      return { status: 'invalid' };
+    }
     const parsed = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as BotDefinition;
     return isValidDefinition(parsed, expectedBotId)
       ? { status: 'valid', definition: parsed }
       : { status: 'invalid' };
-  } catch {
+  } catch (error: any) {
+    if (error?.code === 'ENOENT') return { status: 'missing' };
     return { status: 'invalid' };
   }
 }
@@ -152,11 +162,31 @@ function writeDefinition(filePath: string, definition: BotDefinition): void {
   if (!isValidDefinition(definition, definition.botId)) {
     throw new Error('BotDefinition is invalid');
   }
+  const serialized = `${JSON.stringify(definition, null, 2)}\n`;
+  if (Buffer.byteLength(serialized, 'utf8') > MAX_DEFINITION_BYTES) {
+    throw new Error('BotDefinition exceeds the local size limit');
+  }
   const directory = path.dirname(filePath);
   fs.mkdirSync(directory, { recursive: true });
-  const temporary = `${filePath}.${process.pid}.${Date.now()}.tmp`;
-  fs.writeFileSync(temporary, `${JSON.stringify(definition, null, 2)}\n`, { encoding: 'utf-8', mode: 0o600 });
-  fs.renameSync(temporary, filePath);
+  assertDefinitionDirectorySafe(directory);
+  if (fs.existsSync(filePath)) {
+    const current = fs.lstatSync(filePath);
+    if (!current.isFile() || current.isSymbolicLink()) {
+      throw new Error(`BotDefinition path is unsafe: ${filePath}`);
+    }
+  }
+  const temporary = `${filePath}.${process.pid}.${crypto.randomUUID()}.tmp`;
+  try {
+    fs.writeFileSync(temporary, serialized, {
+      encoding: 'utf-8',
+      mode: 0o600,
+      flag: 'wx',
+    });
+    fs.renameSync(temporary, filePath);
+  } catch (error) {
+    fs.rmSync(temporary, { force: true });
+    throw error;
+  }
   if (process.platform !== 'win32') {
     try {
       fs.chmodSync(filePath, 0o600);
@@ -210,6 +240,7 @@ function writeCustomModelProfile(filePath: string, profile: BotCustomModelProfil
 export class FileBotDefinitionRepository implements BotDefinitionRepository {
   private readonly canonicalRoot: string;
   private readonly cacheRoot: string;
+  private readonly lockRoot: string;
 
   constructor(options: FileBotDefinitionRepositoryOptions = {}) {
     const runtimeRoot = path.resolve(options.runtimeRoot ?? PathResolver.getRuntimeDataRoot());
@@ -222,6 +253,7 @@ export class FileBotDefinitionRepository implements BotDefinitionRepository {
       options.cacheRoot
         ?? path.join(runtimeRoot, 'data', 'bot-definition-cache'),
     );
+    this.lockRoot = path.join(this.canonicalRoot, '.locks');
   }
 
   inspectCanonical(botId: string): BotDefinitionReadResult {
@@ -247,6 +279,36 @@ export class FileBotDefinitionRepository implements BotDefinitionRepository {
   writeCache(definition: BotDefinition): void {
     const botId = normalizeBotId(definition.botId);
     writeDefinition(this.definitionPath(this.cacheRoot, botId), { ...definition, botId });
+  }
+
+  withCanonicalLock<T>(botId: string, action: () => T): T {
+    const normalized = normalizeBotId(botId);
+    const lockPath = path.join(
+      this.lockRoot,
+      `b_${cryptoHash(normalized)}.lock`,
+    );
+    fs.mkdirSync(this.lockRoot, { recursive: true, mode: 0o700 });
+    assertDefinitionDirectorySafe(this.lockRoot);
+    const lockId = `${process.pid}:${Date.now()}:${Math.random().toString(16).slice(2)}`;
+    while (true) {
+      try {
+        fs.mkdirSync(lockPath, { mode: 0o700 });
+        writeDefinitionLockOwner(lockPath, lockId);
+        break;
+      } catch (error: any) {
+        if (error?.code !== 'EEXIST') throw error;
+        if (reclaimStaleDefinitionLock(lockPath)) continue;
+        throw new Error(`BotDefinition update is busy for ${normalized}`);
+      }
+    }
+    try {
+      return action();
+    } finally {
+      const owner = readDefinitionLockOwner(lockPath);
+      if (owner?.lockId === lockId && owner.pid === process.pid) {
+        fs.rmSync(lockPath, { recursive: true, force: true });
+      }
+    }
   }
 
   getCanonicalPath(botId: string): string {
@@ -384,5 +446,93 @@ export class FileBotCustomModelProfileRepository implements BotCustomModelProfil
 
   private profilePath(botId: string): string {
     return path.join(this.root, 'bots', `${botId}.json`);
+  }
+}
+
+function cryptoHash(value: string): string {
+  return crypto.createHash('sha256').update(value, 'utf8').digest('hex');
+}
+
+function assertDefinitionDirectorySafe(directory: string): void {
+  const resolved = path.resolve(directory);
+  const stat = fs.lstatSync(resolved);
+  const real = fs.realpathSync.native(resolved);
+  if (
+    !stat.isDirectory()
+    || stat.isSymbolicLink()
+    || !samePath(resolved, real)
+  ) {
+    throw new Error(`BotDefinition directory is unsafe: ${directory}`);
+  }
+}
+
+function samePath(left: string, right: string): boolean {
+  return process.platform === 'win32'
+    ? path.resolve(left).toLowerCase() === path.resolve(right).toLowerCase()
+    : path.resolve(left) === path.resolve(right);
+}
+
+function writeDefinitionLockOwner(lockPath: string, lockId: string): void {
+  fs.writeFileSync(path.join(lockPath, 'owner.json'), JSON.stringify({
+    lockId,
+    pid: process.pid,
+    acquiredAt: new Date().toISOString(),
+  }), { encoding: 'utf8', mode: 0o600, flag: 'wx' });
+}
+
+function readDefinitionLockOwner(
+  lockPath: string,
+): { lockId: string; pid: number; acquiredAt: string } | undefined {
+  try {
+    const ownerPath = path.join(lockPath, 'owner.json');
+    const stat = fs.lstatSync(ownerPath);
+    if (!stat.isFile() || stat.isSymbolicLink() || stat.size > 64 * 1024) return undefined;
+    const value = JSON.parse(fs.readFileSync(ownerPath, 'utf8')) as any;
+    if (
+      typeof value?.lockId !== 'string'
+      || !Number.isSafeInteger(value?.pid)
+      || typeof value?.acquiredAt !== 'string'
+    ) return undefined;
+    return value;
+  } catch {
+    return undefined;
+  }
+}
+
+function reclaimStaleDefinitionLock(lockPath: string): boolean {
+  const owner = readDefinitionLockOwner(lockPath);
+  if (!owner) {
+    try {
+      const age = Date.now() - fs.lstatSync(lockPath).mtimeMs;
+      if (age <= 5000) return false;
+    } catch (error: any) {
+      return error?.code === 'ENOENT';
+    }
+  }
+  const acquiredAt = Date.parse(String(owner?.acquiredAt || ''));
+  const stale = (
+    !owner
+    || !Number.isFinite(acquiredAt)
+    || !isProcessAlive(owner.pid)
+  );
+  if (!stale) return false;
+  const stalePath = `${lockPath}.stale-${process.pid}-${crypto.randomUUID()}`;
+  try {
+    fs.renameSync(lockPath, stalePath);
+  } catch (error: any) {
+    if (error?.code === 'ENOENT') return true;
+    return false;
+  }
+  fs.rmSync(stalePath, { recursive: true, force: true });
+  return true;
+}
+
+function isProcessAlive(pid: number): boolean {
+  if (!Number.isSafeInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error: any) {
+    return error?.code === 'EPERM';
   }
 }

--- a/src/bot-definition/service.ts
+++ b/src/bot-definition/service.ts
@@ -436,53 +436,68 @@ export class BotDefinitionSyncService {
     return definition;
   }
 
-  updateDefinition(botId: string, patch: BotDefinitionPatch): BotDefinitionSyncResult {
-    const canonical = this.repository.inspectCanonical(botId);
-    if (canonical.status === 'invalid') {
-      throw new Error(`BotDefinition canonical record is invalid for bot ${botId}; refusing to overwrite it`);
-    }
-    const canonicalDefinition = canonical.status === 'valid' ? canonical.definition : undefined;
-    const cachedDefinition = this.repository.readCache(botId);
-    const previous = canonicalDefinition ?? cachedDefinition;
-    if (!previous && !patch.model) {
-      throw new Error('Cannot update BotDefinition skills before its model has been initialized');
-    }
-    if (cachedDefinition?.model.kind === 'custom') {
-      this.storeCustomModelProfile(botId, cachedDefinition.model);
-    }
-    const previousModel = previous?.model;
-    if (previousModel?.kind === 'custom' && previousModel !== cachedDefinition?.model) {
-      this.storeCustomModelProfile(botId, previousModel);
-    }
-    const normalizedModel = patch.model
-      ? normalizeBotModelDefinition(patch.model)
-      : previousModel!;
-    if (normalizedModel.kind === 'custom') {
-      this.storeCustomModelProfile(botId, normalizedModel);
-    }
-    const definition = normalizeBotDefinition({
-      ...(previous ?? {}),
-      schema: BOT_DEFINITION_SCHEMA,
-      botId,
-      model: normalizedModel,
-      ...(patch.skills === undefined ? {} : { skills: patch.skills }),
-    });
-    this.repository.writeCanonical(definition);
-    this.repository.writeCache(definition);
-    this.clearLegacyModelConfigurationWhenReady(definition);
-    return {
-      botId,
-      direction: 'local_to_simulated_cloud',
-      definition,
+  updateDefinition(
+    botId: string,
+    patch: BotDefinitionPatch,
+    onCommitted?: (result: BotDefinitionSyncResult) => void,
+  ): BotDefinitionSyncResult {
+    const update = (): BotDefinitionSyncResult => {
+      const canonical = this.repository.inspectCanonical(botId);
+      if (canonical.status === 'invalid') {
+        throw new Error(`BotDefinition canonical record is invalid for bot ${botId}; refusing to overwrite it`);
+      }
+      const canonicalDefinition = canonical.status === 'valid' ? canonical.definition : undefined;
+      const cachedDefinition = this.repository.readCache(botId);
+      const previous = canonicalDefinition ?? cachedDefinition;
+      if (!previous && !patch.model) {
+        throw new Error('Cannot update BotDefinition skills before its model has been initialized');
+      }
+      if (cachedDefinition?.model.kind === 'custom') {
+        this.storeCustomModelProfile(botId, cachedDefinition.model);
+      }
+      const previousModel = previous?.model;
+      if (previousModel?.kind === 'custom' && previousModel !== cachedDefinition?.model) {
+        this.storeCustomModelProfile(botId, previousModel);
+      }
+      const normalizedModel = patch.model
+        ? normalizeBotModelDefinition(patch.model)
+        : previousModel!;
+      if (normalizedModel.kind === 'custom') {
+        this.storeCustomModelProfile(botId, normalizedModel);
+      }
+      const definition = normalizeBotDefinition({
+        ...(previous ?? {}),
+        schema: BOT_DEFINITION_SCHEMA,
+        botId,
+        model: normalizedModel,
+        ...(patch.skills === undefined ? {} : { skills: patch.skills }),
+      });
+      this.repository.writeCanonical(definition);
+      this.repository.writeCache(definition);
+      this.clearLegacyModelConfigurationWhenReady(definition);
+      const result: BotDefinitionSyncResult = {
+        botId,
+        direction: 'local_to_simulated_cloud',
+        definition,
+      };
+      onCommitted?.(result);
+      return result;
     };
+    return this.repository.withCanonicalLock
+      ? this.repository.withCanonicalLock(botId, update)
+      : update();
   }
 
   updateModel(botId: string, model: BotModelDefinition): BotDefinitionSyncResult {
     return this.updateDefinition(botId, { model });
   }
 
-  updateSkills(botId: string, skills: BotSkillRef[]): BotDefinitionSyncResult {
-    return this.updateDefinition(botId, { skills });
+  updateSkills(
+    botId: string,
+    skills: BotSkillRef[],
+    onCommitted?: (result: BotDefinitionSyncResult) => void,
+  ): BotDefinitionSyncResult {
+    return this.updateDefinition(botId, { skills }, onCommitted);
   }
 
   /** Compatibility alias for callers not yet converted to field-level updates. */

--- a/src/bot-skills/service.ts
+++ b/src/bot-skills/service.ts
@@ -29,6 +29,7 @@ import {
   type BotSkillWorkspaceActivationLock,
   type BotSkillWorkspaceState,
 } from './workspace-service';
+import { scheduleBotSkillSync } from './sync-coordinator';
 import {
   BOT_SKILL_LOCAL_IDENTITY_FILE,
   newLocalSkillIdentity,
@@ -135,7 +136,7 @@ export class BotSkillService {
   async installVerifiedSkillHubPackage(
     options: InstallVerifiedSkillHubPackageOptions,
   ): Promise<BotSkillMutationResult<InstallVerifiedSkillHubPackageResult>> {
-    return this.runExclusive(() => {
+    return this.runMutationExclusive(() => {
       const current = this.requireCompleteManifest();
       const incoming = this.inspectVerifiedPackage(options);
       this.assertProspectiveEntry(current, incoming);
@@ -164,7 +165,7 @@ export class BotSkillService {
   async uninstallSkillHubPackage(
     options: UninstallSkillHubPackageOptions,
   ): Promise<BotSkillMutationResult<{ removed: boolean; path: string }>> {
-    return this.runExclusive(() => {
+    return this.runMutationExclusive(() => {
       const current = this.requireCompleteManifest();
       const targetDir = this.resolveDirectChild(options.installName);
       if (!fs.existsSync(targetDir)) {
@@ -198,7 +199,7 @@ export class BotSkillService {
   async claimInstalledSkillOwnership(
     options: ClaimSkillHubPackageOwnershipOptions,
   ): Promise<boolean> {
-    return this.runExclusive(() => claimSkillHubPackageOwnership({
+    return this.runMutationExclusive(() => claimSkillHubPackageOwnership({
       ...options,
       skillsRoot: this.skillsRoot,
     }));
@@ -213,7 +214,7 @@ export class BotSkillService {
     existing: boolean;
     path: string;
   }>> {
-    return this.runExclusive(() => {
+    return this.runMutationExclusive(() => {
       const current = this.requireCompleteManifest();
       const sourceDir = path.resolve(options.sourceDir);
       this.assertRealTree(sourceDir, 'Local Skill source');
@@ -294,7 +295,7 @@ export class BotSkillService {
   async removeByName(
     name: string,
   ): Promise<BotSkillMutationResult<{ removed: boolean; path: string }>> {
-    return this.runExclusive(() => {
+    return this.runMutationExclusive(() => {
       const entry = this.findUniqueEntry(name);
       const targetDir = path.join(this.skillsRoot, ...entry.path.split('/'));
       this.assertSafeSkillDirectory(targetDir);
@@ -310,7 +311,7 @@ export class BotSkillService {
     name: string,
     enabled: boolean,
   ): Promise<BotSkillMutationResult<{ enabled: boolean; path: string }>> {
-    return this.runExclusive(() => {
+    return this.runMutationExclusive(() => {
       const entry = this.findUniqueEntry(name);
       const targetDir = path.join(this.skillsRoot, ...entry.path.split('/'));
       this.assertSafeSkillDirectory(targetDir);
@@ -344,7 +345,7 @@ export class BotSkillService {
     name: string,
     metadata: Required<SkillHubLocalMetadata>,
   ): Promise<LocalSkillManifest> {
-    return this.runExclusive(() => {
+    return this.runMutationExclusive(() => {
       const matches = PathResolver.findSkillFiles(this.skillsRoot)
         .map(filePath => ({ filePath, skill: SkillParser.parse(filePath) }))
         .filter(item => item.skill.metadata.name === String(name || '').trim());
@@ -390,6 +391,23 @@ export class BotSkillService {
       }
       if (localLockId) this.releaseLocalLock(localLockId);
     }
+  }
+
+  private async runMutationExclusive<T>(action: () => Promise<T> | T): Promise<T> {
+    return this.runExclusive(async () => {
+      const result = await action();
+      if (this.managedWorkspace && !this.existingActivationLock) {
+        const workspace = this.workspaceContext();
+        if (workspace.botId && workspace.workspaceId) {
+          scheduleBotSkillSync({
+            runtimeRoot: this.runtimeRoot,
+            botId: workspace.botId,
+            workspaceId: workspace.workspaceId,
+          });
+        }
+      }
+      return result;
+    });
   }
 
   private guardExpectedWorkspace(

--- a/src/bot-skills/simulated-artifact-store.ts
+++ b/src/bot-skills/simulated-artifact-store.ts
@@ -1,0 +1,574 @@
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { BotSkillRef } from '../bot-definition/types';
+import {
+  BOT_SKILL_LOCAL_IDENTITY_FILE,
+  type LocalSkillManifestEntry,
+} from './local-manifest';
+import {
+  SKILLHUB_INSTALL_MARKER_FILE,
+  readSkillHubInstallMarker,
+  writeSkillHubInstallMarker,
+} from '../skillhub/install-marker';
+import type { SkillHubPackageInstallMarker } from '../skillhub/types';
+
+export const SIMULATED_SKILL_ARTIFACT_SCHEMA = 'xiaoba.simulated-skill-artifact.v1';
+
+const MAX_ARTIFACT_BYTES = 32 * 1024 * 1024;
+const MAX_FILES = 256;
+const MAX_FILE_BYTES = 8 * 1024 * 1024;
+const MAX_TOTAL_FILE_BYTES = 20 * 1024 * 1024;
+const MAX_PATH_LENGTH = 512;
+const MAX_PATH_DEPTH = 24;
+const SKIP_DIRECTORIES = new Set(['.git', 'node_modules', '__pycache__']);
+const SKIP_FILES = new Set([BOT_SKILL_LOCAL_IDENTITY_FILE, SKILLHUB_INSTALL_MARKER_FILE]);
+
+export interface SimulatedSkillArtifactFile {
+  path: string;
+  size: number;
+  sha256: string;
+  contentBase64: string;
+}
+
+export interface SimulatedSkillArtifact {
+  schema: typeof SIMULATED_SKILL_ARTIFACT_SCHEMA;
+  botId: string;
+  localSkillId: string;
+  ref: BotSkillRef;
+  storage: 'skillhub-mirror' | 'simulated-private';
+  name: string;
+  installName: string;
+  contentHash: string;
+  artifactDigest: string;
+  files: SimulatedSkillArtifactFile[];
+  installMarker?: SkillHubPackageInstallMarker;
+}
+
+export interface PutSimulatedSkillArtifactOptions {
+  botId: string;
+  skillsRoot: string;
+  entry: LocalSkillManifestEntry;
+  publicRef?: BotSkillRef;
+}
+
+export interface SimulatedSkillArtifactStore {
+  put(options: PutSimulatedSkillArtifactOptions): SimulatedSkillArtifact;
+  read(ref: BotSkillRef): SimulatedSkillArtifact;
+  materialize(artifact: SimulatedSkillArtifact, targetDir: string): void;
+}
+
+export interface FileSimulatedSkillArtifactStoreOptions {
+  runtimeRoot: string;
+  root?: string;
+  simulatedCloudRoot?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+export class FileSimulatedSkillArtifactStore implements SimulatedSkillArtifactStore {
+  readonly root: string;
+
+  constructor(options: FileSimulatedSkillArtifactStoreOptions) {
+    const runtimeRoot = path.resolve(options.runtimeRoot);
+    const simulatedCloudRoot = path.resolve(
+      options.simulatedCloudRoot
+        ?? options.env?.XIAOBA_BOT_DEFINITION_SIMULATED_CLOUD_DIR
+        ?? process.env.XIAOBA_BOT_DEFINITION_SIMULATED_CLOUD_DIR
+        ?? path.join(runtimeRoot, 'data', 'bot-definition-simulated-cloud'),
+    );
+    this.root = path.resolve(
+      options.root ?? path.join(simulatedCloudRoot, 'skill-artifacts'),
+    );
+    if (!options.root) assertContained(simulatedCloudRoot, this.root, 'simulated Skill artifact root');
+  }
+
+  put(options: PutSimulatedSkillArtifactOptions): SimulatedSkillArtifact {
+    const botId = required(options.botId, 'botId');
+    const root = path.resolve(options.skillsRoot);
+    const relative = normalizeRelativePath(options.entry.path);
+    const skillDir = path.resolve(root, ...relative.split('/'));
+    assertContained(root, skillDir, 'Skill artifact source');
+    const files = collectArtifactFiles(skillDir);
+    const publicRef = options.publicRef && normalizeRef(options.publicRef);
+    const rawInstallMarker = publicRef
+      ? readSkillHubInstallMarker(skillDir) ?? undefined
+      : undefined;
+    if (publicRef && (
+      !isValidInstallMarker(rawInstallMarker)
+      || rawInstallMarker.skillId !== publicRef.skillId
+      || rawInstallMarker.version !== publicRef.version
+    )) {
+      throw new Error(`Public Skill artifact marker does not match ${publicRef.skillId}@${publicRef.version}`);
+    }
+    const installMarker = rawInstallMarker
+      ? canonicalPublicInstallMarker(rawInstallMarker)
+      : undefined;
+    const storage = publicRef ? 'skillhub-mirror' : 'simulated-private';
+    const artifactBotId = publicRef ? 'public' : botId;
+    const artifactLocalSkillId = publicRef
+      ? 'public'
+      : required(options.entry.localSkillId, 'localSkillId');
+    const artifactDigest = digest({
+      botId: artifactBotId,
+      localSkillId: artifactLocalSkillId,
+      storage,
+      name: required(options.entry.name, 'name').normalize('NFC'),
+      installName: path.posix.basename(relative),
+      contentHash: requiredHash(options.entry.contentHash, 'contentHash'),
+      files: files.map(file => ({
+        path: file.path,
+        size: file.size,
+        sha256: file.sha256,
+      })),
+      ...(installMarker ? { installMarker } : {}),
+    });
+    const ref = publicRef ?? {
+      skillId: `sim-private:${sha256(`${botId}\0${options.entry.localSkillId}`)}`,
+      version: `content-${artifactDigest}`,
+    };
+    const artifact: SimulatedSkillArtifact = {
+      schema: SIMULATED_SKILL_ARTIFACT_SCHEMA,
+      botId: artifactBotId,
+      localSkillId: artifactLocalSkillId,
+      ref,
+      storage,
+      name: required(options.entry.name, 'name').normalize('NFC'),
+      installName: path.posix.basename(relative),
+      contentHash: requiredHash(options.entry.contentHash, 'contentHash'),
+      artifactDigest,
+      files,
+      ...(installMarker ? { installMarker } : {}),
+    };
+    const filePath = this.filePath(ref);
+    const existing = this.inspectFile(filePath, ref);
+    if (existing) {
+      if (existing.artifactDigest !== artifact.artifactDigest) {
+        throw new Error(`Immutable Skill artifact conflict for ${ref.skillId}@${ref.version}`);
+      }
+      return existing;
+    }
+    writeJsonAtomic(this.root, filePath, artifact);
+    return artifact;
+  }
+
+  read(ref: BotSkillRef): SimulatedSkillArtifact {
+    const normalized = normalizeRef(ref);
+    const artifact = this.inspectFile(this.filePath(normalized), normalized);
+    if (!artifact) {
+      const error: NodeJS.ErrnoException = new Error(
+        `Simulated Skill artifact is missing: ${normalized.skillId}@${normalized.version}`,
+      );
+      error.code = 'SIMULATED_SKILL_ARTIFACT_MISSING';
+      throw error;
+    }
+    return artifact;
+  }
+
+  materialize(artifact: SimulatedSkillArtifact, targetDir: string): void {
+    const parsed = parseArtifact(artifact, artifact.ref);
+    if (!parsed) throw new Error('Simulated Skill artifact is invalid');
+    const target = path.resolve(targetDir);
+    if (fs.existsSync(target)) {
+      throw new Error(`Artifact target already exists: ${target}`);
+    }
+    fs.mkdirSync(target, { recursive: false, mode: 0o700 });
+    try {
+      for (const file of parsed.files) {
+        const outputPath = path.resolve(target, ...file.path.split('/'));
+        assertContained(target, outputPath, 'Skill artifact output');
+        ensureMaterializeDirectory(target, path.dirname(outputPath));
+        fs.writeFileSync(outputPath, Buffer.from(file.contentBase64, 'base64'), {
+          flag: 'wx',
+          mode: 0o600,
+        });
+      }
+      if (parsed.installMarker) {
+        writeSkillHubInstallMarker(target, parsed.installMarker);
+      }
+    } catch (error) {
+      fs.rmSync(target, { recursive: true, force: true });
+      throw error;
+    }
+  }
+
+  getPath(ref: BotSkillRef): string {
+    return this.filePath(normalizeRef(ref));
+  }
+
+  private inspectFile(
+    filePath: string,
+    expectedRef: BotSkillRef,
+  ): SimulatedSkillArtifact | undefined {
+    let stat: fs.Stats;
+    try {
+      stat = fs.lstatSync(filePath);
+    } catch (error: any) {
+      if (error?.code === 'ENOENT') return undefined;
+      throw error;
+    }
+    assertRealDirectory(path.dirname(filePath), 'simulated Skill artifact directory');
+    if (!stat.isFile() || stat.isSymbolicLink()) {
+      throw new Error(`Unsafe simulated Skill artifact: ${filePath}`);
+    }
+    if (stat.size > MAX_ARTIFACT_BYTES) {
+      throw new Error(`Simulated Skill artifact exceeds ${MAX_ARTIFACT_BYTES} bytes`);
+    }
+    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8')) as unknown;
+    const artifact = parseArtifact(parsed, expectedRef);
+    if (!artifact) throw new Error(`Invalid simulated Skill artifact: ${filePath}`);
+    return artifact;
+  }
+
+  private filePath(ref: BotSkillRef): string {
+    return path.join(this.root, `${sha256(`${ref.skillId}\0${ref.version}`)}.json`);
+  }
+}
+
+function collectArtifactFiles(skillDir: string): SimulatedSkillArtifactFile[] {
+  assertRealDirectory(skillDir, 'Skill artifact source');
+  const paths: string[] = [];
+  const visit = (current: string): void => {
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const fullPath = path.join(current, entry.name);
+      const stat = fs.lstatSync(fullPath);
+      if (stat.isSymbolicLink()) throw new Error(`Skill artifact source contains a link: ${fullPath}`);
+      if (stat.isDirectory()) {
+        if (!SKIP_DIRECTORIES.has(entry.name)) visit(fullPath);
+        continue;
+      }
+      if (!stat.isFile()) throw new Error(`Skill artifact source contains a non-file: ${fullPath}`);
+      if (!SKIP_FILES.has(entry.name)) paths.push(fullPath);
+    }
+  };
+  visit(skillDir);
+  if (paths.length === 0 || paths.length > MAX_FILES) {
+    throw new Error(`Skill artifact file count is invalid: ${paths.length}`);
+  }
+  let total = 0;
+  const seen = new Set<string>();
+  const files = paths.map(filePath => {
+    let relative = normalizeRelativePath(path.relative(skillDir, filePath));
+    if (relative === 'SKILL.md.disabled') relative = 'SKILL.md';
+    assertPortableArtifactPath(relative);
+    const portable = portablePath(relative);
+    if (seen.has(portable)) throw new Error(`Duplicate portable artifact path: ${relative}`);
+    seen.add(portable);
+    const before = fs.lstatSync(filePath);
+    if (!before.isFile() || before.isSymbolicLink() || before.size > MAX_FILE_BYTES) {
+      throw new Error(`Skill artifact file is invalid or too large: ${relative}`);
+    }
+    const content = fs.readFileSync(filePath);
+    const after = fs.lstatSync(filePath);
+    if (
+      !after.isFile()
+      || after.isSymbolicLink()
+      || before.size !== after.size
+      || before.mtimeMs !== after.mtimeMs
+      || before.ino !== after.ino
+    ) {
+      throw new Error(`Skill changed while creating its artifact: ${relative}`);
+    }
+    total += content.length;
+    if (total > MAX_TOTAL_FILE_BYTES) throw new Error('Skill artifact decoded size exceeds the limit');
+    return {
+      path: relative,
+      size: content.length,
+      sha256: sha256(content),
+      contentBase64: content.toString('base64'),
+    };
+  });
+  return files.sort((left, right) => compareUtf8(left.path, right.path));
+}
+
+function parseArtifact(value: unknown, expectedRef: BotSkillRef): SimulatedSkillArtifact | undefined {
+  const raw = value as Partial<SimulatedSkillArtifact> | null;
+  try {
+    if (
+      raw?.schema !== SIMULATED_SKILL_ARTIFACT_SCHEMA
+      || !raw.ref
+      || !Array.isArray(raw.files)
+      || raw.files.length === 0
+      || raw.files.length > MAX_FILES
+      || (raw.storage !== 'skillhub-mirror' && raw.storage !== 'simulated-private')
+    ) return undefined;
+    const ref = normalizeRef(raw.ref);
+    if (ref.skillId !== expectedRef.skillId || ref.version !== expectedRef.version) return undefined;
+    const botId = required(raw.botId, 'botId');
+    const localSkillId = required(raw.localSkillId, 'localSkillId');
+    const name = required(raw.name, 'name').normalize('NFC');
+    const installName = normalizeInstallName(raw.installName);
+    const contentHash = requiredHash(raw.contentHash, 'contentHash');
+    let total = 0;
+    const seen = new Set<string>();
+    const files = raw.files.map(file => {
+      const relative = normalizeRelativePath(file?.path);
+      assertPortableArtifactPath(relative);
+      const key = portablePath(relative);
+      if (seen.has(key)) throw new Error(`Duplicate artifact path: ${relative}`);
+      seen.add(key);
+      if (
+        !Number.isSafeInteger(file?.size)
+        || Number(file.size) < 0
+        || Number(file.size) > MAX_FILE_BYTES
+        || typeof file?.contentBase64 !== 'string'
+      ) throw new Error(`Invalid artifact file metadata: ${relative}`);
+      const content = Buffer.from(file.contentBase64, 'base64');
+      if (
+        content.toString('base64') !== file.contentBase64
+        || content.length !== file.size
+        || sha256(content) !== requiredHash(file.sha256, 'file.sha256')
+      ) throw new Error(`Invalid artifact file content: ${relative}`);
+      total += content.length;
+      if (total > MAX_TOTAL_FILE_BYTES) throw new Error('Artifact decoded size exceeds the limit');
+      return {
+        path: relative,
+        size: content.length,
+        sha256: sha256(content),
+        contentBase64: file.contentBase64,
+      };
+    }).sort((left, right) => compareUtf8(left.path, right.path));
+    if (!files.some(file => file.path === 'SKILL.md')) return undefined;
+    const installMarker = raw.installMarker;
+    if (
+      raw.storage === 'skillhub-mirror'
+      && (
+        !isValidInstallMarker(installMarker)
+        || installMarker.skillId !== ref.skillId
+        || installMarker.version !== ref.version
+        || installMarker.installName !== installName
+      )
+    ) return undefined;
+    if (raw.storage === 'simulated-private' && installMarker) return undefined;
+    const artifactDigest = digest({
+      botId,
+      localSkillId,
+      storage: raw.storage,
+      name,
+      installName,
+      contentHash,
+      files: files.map(file => ({
+        path: file.path,
+        size: file.size,
+        sha256: file.sha256,
+      })),
+      ...(installMarker ? { installMarker } : {}),
+    });
+    if (artifactDigest !== requiredHash(raw.artifactDigest, 'artifactDigest')) return undefined;
+    return {
+      schema: SIMULATED_SKILL_ARTIFACT_SCHEMA,
+      botId,
+      localSkillId,
+      ref,
+      storage: raw.storage,
+      name,
+      installName,
+      contentHash,
+      artifactDigest,
+      files,
+      ...(installMarker ? { installMarker } : {}),
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function writeJsonAtomic(root: string, filePath: string, value: unknown): void {
+  const serialized = `${JSON.stringify(value, null, 2)}\n`;
+  if (Buffer.byteLength(serialized, 'utf8') > MAX_ARTIFACT_BYTES) {
+    throw new Error(`Simulated Skill artifact exceeds ${MAX_ARTIFACT_BYTES} bytes`);
+  }
+  ensureSafeDirectory(root, path.dirname(filePath));
+  const temporary = `${filePath}.${process.pid}.${crypto.randomUUID()}.tmp`;
+  try {
+    fs.writeFileSync(temporary, serialized, { encoding: 'utf8', mode: 0o600, flag: 'wx' });
+    fs.renameSync(temporary, filePath);
+  } catch (error) {
+    fs.rmSync(temporary, { force: true });
+    throw error;
+  }
+}
+
+function ensureSafeDirectory(rootPath: string, targetPath: string): void {
+  const root = path.resolve(rootPath);
+  const target = path.resolve(targetPath);
+  assertContained(root, target, 'artifact directory');
+  fs.mkdirSync(root, { recursive: true, mode: 0o700 });
+  assertRealDirectory(root, 'artifact root');
+  let current = root;
+  for (const segment of path.relative(root, target).split(path.sep).filter(Boolean)) {
+    current = path.join(current, segment);
+    if (!fs.existsSync(current)) fs.mkdirSync(current, { mode: 0o700 });
+    assertRealDirectory(current, 'artifact directory');
+  }
+}
+
+function ensureMaterializeDirectory(rootPath: string, targetPath: string): void {
+  const root = path.resolve(rootPath);
+  const target = path.resolve(targetPath);
+  assertContained(root, target, 'artifact output directory');
+  let current = root;
+  for (const segment of path.relative(root, target).split(path.sep).filter(Boolean)) {
+    current = path.join(current, segment);
+    if (!fs.existsSync(current)) fs.mkdirSync(current, { mode: 0o700 });
+    assertRealDirectory(current, 'artifact output directory');
+  }
+}
+
+function assertRealDirectory(directory: string, label: string): void {
+  const stat = fs.lstatSync(directory);
+  const resolved = path.resolve(directory);
+  const real = fs.realpathSync.native(directory);
+  if (
+    !stat.isDirectory()
+    || stat.isSymbolicLink()
+    || !samePath(resolved, real)
+  ) throw new Error(`Unsafe ${label}: ${directory}`);
+}
+
+function assertPortableArtifactPath(relative: string): void {
+  if (relative.length > MAX_PATH_LENGTH || relative.split('/').length > MAX_PATH_DEPTH) {
+    throw new Error(`Artifact path exceeds limits: ${relative}`);
+  }
+  for (const segment of relative.split('/')) {
+    const normalized = segment.normalize('NFC');
+    if (
+      /[<>:"|?*\u0000-\u001f]/u.test(normalized)
+      || /[ .]$/u.test(normalized)
+      || /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\.|$)/iu.test(normalized)
+    ) {
+      throw new Error(`Artifact path is not portable: ${relative}`);
+    }
+  }
+}
+
+function portablePath(relative: string): string {
+  return relative.normalize('NFC').toLocaleLowerCase('en-US');
+}
+
+function normalizeRef(ref: BotSkillRef): BotSkillRef {
+  return {
+    skillId: required(ref?.skillId, 'skillId'),
+    version: required(ref?.version, 'version'),
+  };
+}
+
+function isValidInstallMarker(
+  value: SkillHubPackageInstallMarker | undefined,
+): value is SkillHubPackageInstallMarker {
+  if (!value || value.source !== 'skillhub') return false;
+  try {
+    required(value.skillId, 'marker.skillId');
+    required(value.name, 'marker.name');
+    normalizeInstallName(value.installName);
+    required(value.version, 'marker.version');
+    requiredHash(value.packageChecksumSha256, 'marker.packageChecksumSha256');
+    if (value.installedContentHash) {
+      requiredHash(value.installedContentHash, 'marker.installedContentHash');
+    }
+    required(value.packageUrl, 'marker.packageUrl');
+    new Date(required(value.installedAt, 'marker.installedAt')).toISOString();
+    if (
+      value.signature?.algorithm !== 'ed25519'
+      || !required(value.signature.keyId, 'marker.signature.keyId')
+      || !required(value.signature.signature, 'marker.signature.signature')
+    ) return false;
+    new Date(required(value.signature.signedAt, 'marker.signature.signedAt')).toISOString();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function canonicalPublicInstallMarker(
+  marker: SkillHubPackageInstallMarker,
+): SkillHubPackageInstallMarker {
+  const signedAt = new Date(
+    required(marker.signature.signedAt, 'marker.signature.signedAt'),
+  ).toISOString();
+  return {
+    source: 'skillhub',
+    skillId: required(marker.skillId, 'marker.skillId'),
+    name: required(marker.name, 'marker.name').normalize('NFC'),
+    installName: normalizeInstallName(marker.installName),
+    version: required(marker.version, 'marker.version'),
+    packageChecksumSha256: requiredHash(
+      marker.packageChecksumSha256,
+      'marker.packageChecksumSha256',
+    ),
+    ...(marker.installedContentHash
+      ? {
+        installedContentHash: requiredHash(
+          marker.installedContentHash,
+          'marker.installedContentHash',
+        ),
+      }
+      : {}),
+    signature: {
+      algorithm: 'ed25519',
+      keyId: required(marker.signature.keyId, 'marker.signature.keyId'),
+      signature: required(marker.signature.signature, 'marker.signature.signature'),
+      signedAt,
+    },
+    // Public artifacts represent package identity, not a particular user's install session.
+    packageUrl: `skillhub:${marker.skillId}@${marker.version}`,
+    installedAt: signedAt,
+  };
+}
+
+function normalizeInstallName(value: unknown): string {
+  const name = required(value, 'installName').normalize('NFC');
+  if (name !== path.posix.basename(name) || name === '.' || name === '..') {
+    throw new Error(`Invalid installName: ${name}`);
+  }
+  assertPortableArtifactPath(name);
+  return name;
+}
+
+function normalizeRelativePath(value: unknown): string {
+  const relative = required(value, 'path').replace(/\\/g, '/').normalize('NFC');
+  if (
+    path.posix.isAbsolute(relative)
+    || relative === '.'
+    || relative.split('/').some(segment => !segment || segment === '.' || segment === '..')
+  ) {
+    throw new Error(`Invalid relative path: ${relative}`);
+  }
+  return relative;
+}
+
+function required(value: unknown, field: string): string {
+  const text = typeof value === 'string' ? value.trim() : '';
+  if (!text || text.length > 1024) throw new Error(`${field} is required or too long`);
+  return text;
+}
+
+function requiredHash(value: unknown, field: string): string {
+  const text = required(value, field).toLowerCase();
+  if (!/^[0-9a-f]{64}$/.test(text)) throw new Error(`${field} must be SHA-256`);
+  return text;
+}
+
+function digest(value: unknown): string {
+  return sha256(Buffer.from(JSON.stringify(value), 'utf8'));
+}
+
+function sha256(value: string | Buffer): string {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function compareUtf8(left: string, right: string): number {
+  return Buffer.compare(Buffer.from(left, 'utf8'), Buffer.from(right, 'utf8'));
+}
+
+function assertContained(root: string, target: string, label: string): void {
+  const relative = path.relative(path.resolve(root), path.resolve(target));
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(`${label} escapes its root`);
+  }
+}
+
+function samePath(left: string, right: string): boolean {
+  return process.platform === 'win32'
+    ? path.resolve(left).toLowerCase() === path.resolve(right).toLowerCase()
+    : path.resolve(left) === path.resolve(right);
+}

--- a/src/bot-skills/sync-base.ts
+++ b/src/bot-skills/sync-base.ts
@@ -1,0 +1,470 @@
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { BotSkillRef } from '../bot-definition/types';
+import type {
+  LocalSkillManifest,
+  LocalSkillManifestEntry,
+} from './local-manifest';
+
+export const BOT_SKILL_SYNC_BASE_SCHEMA = 'xiaoba.bot-skill-sync-base.v1';
+
+const MAX_SYNC_BASE_BYTES = 2 * 1024 * 1024;
+
+export interface BotSkillSyncLocalSourceRef {
+  skillId: string;
+  version: string;
+  installedChecksum?: string;
+  installedContentHash?: string;
+}
+
+export interface BotSkillSyncLocalEntry {
+  localSkillId: string;
+  name: string;
+  path: string;
+  enabled: boolean;
+  contentHash: string;
+  source: 'local' | 'skillhub';
+  sourceRef?: BotSkillSyncLocalSourceRef;
+}
+
+export interface BotSkillSyncBinding {
+  localSkillId: string;
+  ref: BotSkillRef;
+  storage: 'skillhub-mirror' | 'simulated-private';
+  artifactDigest: string;
+}
+
+export interface BotSkillSyncProjection<T> {
+  entries: T[];
+  digest: string;
+}
+
+export interface BotSkillSyncBase {
+  schema: typeof BOT_SKILL_SYNC_BASE_SCHEMA;
+  botId: string;
+  workspaceId: string;
+  local: BotSkillSyncProjection<BotSkillSyncLocalEntry>;
+  bindings: BotSkillSyncBinding[];
+  bindingsDigest: string;
+  cloud: BotSkillSyncProjection<BotSkillRef>;
+  syncedAt: string;
+}
+
+export type BotSkillSyncBaseReadResult =
+  | { status: 'missing' }
+  | { status: 'invalid'; reason: string }
+  | { status: 'valid'; base: BotSkillSyncBase };
+
+export interface BotSkillSyncBaseRepository {
+  inspect(botId: string, workspaceId: string): BotSkillSyncBaseReadResult;
+  write(base: BotSkillSyncBase): void;
+}
+
+export interface FileBotSkillSyncBaseRepositoryOptions {
+  runtimeRoot: string;
+  root?: string;
+}
+
+export class FileBotSkillSyncBaseRepository implements BotSkillSyncBaseRepository {
+  readonly root: string;
+
+  constructor(options: FileBotSkillSyncBaseRepositoryOptions) {
+    const runtimeRoot = path.resolve(options.runtimeRoot);
+    this.root = path.resolve(
+      options.root ?? path.join(runtimeRoot, 'data', 'bot-definition', 'sync-base'),
+    );
+    assertContained(runtimeRoot, this.root, 'Bot Skill sync-base root');
+  }
+
+  inspect(botId: string, workspaceId: string): BotSkillSyncBaseReadResult {
+    const filePath = this.filePath(botId, workspaceId);
+    try {
+      const stat = fs.lstatSync(filePath);
+      assertRealDirectory(path.dirname(filePath), 'sync-base directory');
+      if (!stat.isFile() || stat.isSymbolicLink()) {
+        return { status: 'invalid', reason: 'sync-base is not a regular file' };
+      }
+      if (stat.size > MAX_SYNC_BASE_BYTES) {
+        return { status: 'invalid', reason: 'sync-base exceeds the size limit' };
+      }
+      const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8')) as unknown;
+      const base = parseSyncBase(parsed, botId, workspaceId);
+      return base
+        ? { status: 'valid', base }
+        : { status: 'invalid', reason: 'sync-base schema or digest is invalid' };
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') return { status: 'missing' };
+      return {
+        status: 'invalid',
+        reason: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  write(base: BotSkillSyncBase): void {
+    const normalized = createBotSkillSyncBase({
+      botId: base.botId,
+      workspaceId: base.workspaceId,
+      localEntries: base.local.entries,
+      bindings: base.bindings,
+      cloudSkills: base.cloud.entries,
+      syncedAt: base.syncedAt,
+    });
+    const filePath = this.filePath(normalized.botId, normalized.workspaceId);
+    writeJsonAtomic(this.root, filePath, normalized, MAX_SYNC_BASE_BYTES);
+  }
+
+  getPath(botId: string, workspaceId: string): string {
+    return this.filePath(botId, workspaceId);
+  }
+
+  private filePath(botId: string, workspaceId: string): string {
+    const botScope = sha256(required(botId, 'botId'));
+    const workspaceScope = sha256(required(workspaceId, 'workspaceId'));
+    return path.join(this.root, `b_${botScope}`, `w_${workspaceScope}.json`);
+  }
+}
+
+export function projectLocalManifest(
+  manifest: LocalSkillManifest,
+): BotSkillSyncLocalEntry[] {
+  if (manifest.status !== 'complete') {
+    throw new Error(`Cannot project an incomplete Local Skill manifest: ${manifest.status}`);
+  }
+  return normalizeLocalEntries(manifest.entries.map(projectLocalEntry));
+}
+
+export function projectCloudSkills(
+  skills: readonly BotSkillRef[],
+): BotSkillRef[] {
+  const versions = new Map<string, string>();
+  for (const raw of skills) {
+    const skillId = required(raw?.skillId, 'skillId');
+    const version = required(raw?.version, 'version');
+    const previous = versions.get(skillId);
+    if (previous && previous !== version) {
+      throw new Error(`Cloud Skill ${skillId} has multiple versions`);
+    }
+    versions.set(skillId, version);
+  }
+  return [...versions.entries()]
+    .map(([skillId, version]) => ({ skillId, version }))
+    .sort((left, right) =>
+      compareUtf8(left.skillId, right.skillId)
+      || compareUtf8(left.version, right.version));
+}
+
+export function createBotSkillSyncBase(options: {
+  botId: string;
+  workspaceId: string;
+  localEntries: readonly BotSkillSyncLocalEntry[];
+  bindings: readonly BotSkillSyncBinding[];
+  cloudSkills: readonly BotSkillRef[];
+  syncedAt?: string;
+}): BotSkillSyncBase {
+  const localEntries = normalizeLocalEntries(options.localEntries);
+  const cloudSkills = projectCloudSkills(options.cloudSkills);
+  const bindings = normalizeBindings(options.bindings, localEntries);
+  validateBindingProjection(localEntries, bindings, cloudSkills);
+  const syncedAt = new Date(options.syncedAt ?? new Date().toISOString()).toISOString();
+  return {
+    schema: BOT_SKILL_SYNC_BASE_SCHEMA,
+    botId: required(options.botId, 'botId'),
+    workspaceId: required(options.workspaceId, 'workspaceId'),
+    local: {
+      entries: localEntries,
+      digest: digest(localEntries),
+    },
+    bindings,
+    bindingsDigest: digest(bindings),
+    cloud: {
+      entries: cloudSkills,
+      digest: digest(cloudSkills),
+    },
+    syncedAt,
+  };
+}
+
+export function localProjectionDigest(
+  entries: readonly BotSkillSyncLocalEntry[],
+): string {
+  return digest(normalizeLocalEntries(entries));
+}
+
+export function cloudProjectionDigest(skills: readonly BotSkillRef[]): string {
+  return digest(projectCloudSkills(skills));
+}
+
+function projectLocalEntry(entry: LocalSkillManifestEntry): BotSkillSyncLocalEntry {
+  return {
+    localSkillId: required(entry.localSkillId, 'localSkillId'),
+    name: required(entry.name, 'name').normalize('NFC'),
+    path: normalizeRelativePath(entry.path),
+    enabled: entry.enabled === true,
+    contentHash: requiredHash(entry.contentHash, 'contentHash'),
+    source: entry.source,
+    ...(entry.source === 'skillhub' ? {
+      sourceRef: {
+        skillId: required(entry.skillId, 'skillId'),
+        version: required(entry.version, 'version'),
+        ...(entry.installedChecksum
+          ? { installedChecksum: requiredHash(entry.installedChecksum, 'installedChecksum') }
+          : {}),
+        ...(entry.installedContentHash
+          ? { installedContentHash: requiredHash(entry.installedContentHash, 'installedContentHash') }
+          : {}),
+      },
+    } : {}),
+  };
+}
+
+function normalizeLocalEntries(
+  entries: readonly BotSkillSyncLocalEntry[],
+): BotSkillSyncLocalEntry[] {
+  const seen = new Set<string>();
+  const normalized = entries.map(raw => {
+    const localSkillId = required(raw?.localSkillId, 'localSkillId');
+    if (seen.has(localSkillId)) throw new Error(`Duplicate localSkillId: ${localSkillId}`);
+    seen.add(localSkillId);
+    const source = raw?.source;
+    if (source !== 'local' && source !== 'skillhub') {
+      throw new Error(`Invalid Local Skill source for ${localSkillId}`);
+    }
+    const sourceRef = raw.sourceRef && {
+      skillId: required(raw.sourceRef.skillId, 'sourceRef.skillId'),
+      version: required(raw.sourceRef.version, 'sourceRef.version'),
+      ...(raw.sourceRef.installedChecksum
+        ? { installedChecksum: requiredHash(raw.sourceRef.installedChecksum, 'installedChecksum') }
+        : {}),
+      ...(raw.sourceRef.installedContentHash
+        ? { installedContentHash: requiredHash(raw.sourceRef.installedContentHash, 'installedContentHash') }
+        : {}),
+    };
+    if (source === 'skillhub' && !sourceRef) {
+      throw new Error(`SkillHub Local Skill ${localSkillId} is missing sourceRef`);
+    }
+    return {
+      localSkillId,
+      name: required(raw.name, 'name').normalize('NFC'),
+      path: normalizeRelativePath(raw.path),
+      enabled: raw.enabled === true,
+      contentHash: requiredHash(raw.contentHash, 'contentHash'),
+      source,
+      ...(sourceRef ? { sourceRef } : {}),
+    } satisfies BotSkillSyncLocalEntry;
+  });
+  return normalized.sort((left, right) => compareUtf8(left.localSkillId, right.localSkillId));
+}
+
+function normalizeBindings(
+  bindings: readonly BotSkillSyncBinding[],
+  localEntries: readonly BotSkillSyncLocalEntry[],
+): BotSkillSyncBinding[] {
+  const localIds = new Set(localEntries.map(entry => entry.localSkillId));
+  const seen = new Set<string>();
+  return bindings.map(raw => {
+    const localSkillId = required(raw?.localSkillId, 'binding.localSkillId');
+    if (!localIds.has(localSkillId)) {
+      throw new Error(`Binding references unknown localSkillId: ${localSkillId}`);
+    }
+    if (seen.has(localSkillId)) throw new Error(`Duplicate binding: ${localSkillId}`);
+    seen.add(localSkillId);
+    if (raw.storage !== 'skillhub-mirror' && raw.storage !== 'simulated-private') {
+      throw new Error(`Invalid binding storage: ${String(raw.storage)}`);
+    }
+    return {
+      localSkillId,
+      ref: {
+        skillId: required(raw.ref?.skillId, 'binding.ref.skillId'),
+        version: required(raw.ref?.version, 'binding.ref.version'),
+      },
+      storage: raw.storage,
+      artifactDigest: requiredHash(raw.artifactDigest, 'binding.artifactDigest'),
+    } satisfies BotSkillSyncBinding;
+  }).sort((left, right) => compareUtf8(left.localSkillId, right.localSkillId));
+}
+
+function parseSyncBase(
+  value: unknown,
+  expectedBotId: string,
+  expectedWorkspaceId: string,
+): BotSkillSyncBase | undefined {
+  const raw = value as Partial<BotSkillSyncBase> | null;
+  if (
+    raw?.schema !== BOT_SKILL_SYNC_BASE_SCHEMA
+    || raw.botId !== expectedBotId
+    || raw.workspaceId !== expectedWorkspaceId
+    || !raw.local
+    || !raw.cloud
+    || !Array.isArray(raw.local.entries)
+    || !Array.isArray(raw.cloud.entries)
+    || !Array.isArray(raw.bindings)
+    || typeof raw.bindingsDigest !== 'string'
+    || typeof raw.syncedAt !== 'string'
+  ) {
+    return undefined;
+  }
+  try {
+    const base = createBotSkillSyncBase({
+      botId: raw.botId,
+      workspaceId: raw.workspaceId,
+      localEntries: raw.local.entries,
+      bindings: raw.bindings,
+      cloudSkills: raw.cloud.entries,
+      syncedAt: raw.syncedAt,
+    });
+    if (
+      base.local.digest !== raw.local.digest
+      || base.bindingsDigest !== raw.bindingsDigest
+      || base.cloud.digest !== raw.cloud.digest
+    ) {
+      return undefined;
+    }
+    return base;
+  } catch {
+    return undefined;
+  }
+}
+
+function validateBindingProjection(
+  localEntries: readonly BotSkillSyncLocalEntry[],
+  bindings: readonly BotSkillSyncBinding[],
+  cloudSkills: readonly BotSkillRef[],
+): void {
+  if (bindings.length !== localEntries.length) {
+    throw new Error('Every Local Skill must have exactly one Cloud artifact binding');
+  }
+  const bindingByLocalId = new Map(bindings.map(binding => [binding.localSkillId, binding]));
+  for (const local of localEntries) {
+    if (!bindingByLocalId.has(local.localSkillId)) {
+      throw new Error(`Local Skill has no artifact binding: ${local.localSkillId}`);
+    }
+  }
+  const expectedActiveRefs = projectCloudSkills(
+    localEntries
+      .filter(local => local.enabled)
+      .map(local => bindingByLocalId.get(local.localSkillId)!.ref),
+  );
+  if (digest(expectedActiveRefs) !== digest(cloudSkills)) {
+    throw new Error('Enabled Local Skill bindings do not match Cloud Skill refs');
+  }
+}
+
+function digest(value: unknown): string {
+  return sha256(JSON.stringify(value));
+}
+
+function sha256(value: string | Buffer): string {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function required(value: unknown, field: string): string {
+  const text = typeof value === 'string' ? value.trim() : '';
+  if (!text || text.length > 1024) throw new Error(`${field} is required or too long`);
+  return text;
+}
+
+function requiredHash(value: unknown, field: string): string {
+  const text = required(value, field).toLowerCase();
+  if (!/^[0-9a-f]{64}$/.test(text)) throw new Error(`${field} must be SHA-256`);
+  return text;
+}
+
+function normalizeRelativePath(value: unknown): string {
+  const text = required(value, 'path').replace(/\\/g, '/').normalize('NFC');
+  if (
+    path.posix.isAbsolute(text)
+    || text === '.'
+    || text.split('/').some(part => !part || part === '.' || part === '..')
+  ) {
+    throw new Error(`Invalid relative Skill path: ${text}`);
+  }
+  return text;
+}
+
+function compareUtf8(left: string, right: string): number {
+  return Buffer.compare(Buffer.from(left, 'utf8'), Buffer.from(right, 'utf8'));
+}
+
+function writeJsonAtomic(
+  safeRoot: string,
+  filePath: string,
+  value: unknown,
+  maxBytes: number,
+): void {
+  const serialized = `${JSON.stringify(value, null, 2)}\n`;
+  if (Buffer.byteLength(serialized, 'utf8') > maxBytes) {
+    throw new Error(`JSON record exceeds ${maxBytes} bytes`);
+  }
+  ensureSafeDirectory(safeRoot, path.dirname(filePath));
+  const temporary = `${filePath}.${process.pid}.${crypto.randomUUID()}.tmp`;
+  try {
+    fs.writeFileSync(temporary, serialized, { encoding: 'utf8', mode: 0o600, flag: 'wx' });
+    fs.renameSync(temporary, filePath);
+  } catch (error) {
+    fs.rmSync(temporary, { force: true });
+    throw error;
+  }
+  if (process.platform !== 'win32') {
+    try {
+      fs.chmodSync(filePath, 0o600);
+    } catch {
+      // The rename is the commit point; permission hardening is best effort.
+    }
+  }
+}
+
+function ensureSafeDirectory(safeRoot: string, directory: string): void {
+  const root = path.resolve(safeRoot);
+  const target = path.resolve(directory);
+  assertContained(root, target, 'sync-base directory');
+  fs.mkdirSync(root, { recursive: true, mode: 0o700 });
+  const rootStat = fs.lstatSync(root);
+  if (
+    !rootStat.isDirectory()
+    || rootStat.isSymbolicLink()
+    || !samePath(root, fs.realpathSync.native(root))
+  ) {
+    throw new Error(`Unsafe sync-base root: ${root}`);
+  }
+  let current = root;
+  const relative = path.relative(root, target);
+  for (const segment of relative.split(path.sep).filter(Boolean)) {
+    current = path.join(current, segment);
+    if (!fs.existsSync(current)) fs.mkdirSync(current, { mode: 0o700 });
+    const stat = fs.lstatSync(current);
+    if (
+      !stat.isDirectory()
+      || stat.isSymbolicLink()
+      || !samePath(current, fs.realpathSync.native(current))
+    ) {
+      throw new Error(`Unsafe sync-base directory: ${current}`);
+    }
+  }
+}
+
+function assertRealDirectory(directory: string, label: string): void {
+  const resolved = path.resolve(directory);
+  const stat = fs.lstatSync(resolved);
+  if (
+    !stat.isDirectory()
+    || stat.isSymbolicLink()
+    || !samePath(resolved, fs.realpathSync.native(resolved))
+  ) {
+    throw new Error(`Unsafe ${label}: ${directory}`);
+  }
+}
+
+function samePath(left: string, right: string): boolean {
+  return process.platform === 'win32'
+    ? path.resolve(left).toLowerCase() === path.resolve(right).toLowerCase()
+    : path.resolve(left) === path.resolve(right);
+}
+
+function assertContained(root: string, target: string, label: string): void {
+  const relative = path.relative(path.resolve(root), path.resolve(target));
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(`${label} escapes its root`);
+  }
+}

--- a/src/bot-skills/sync-coordinator.ts
+++ b/src/bot-skills/sync-coordinator.ts
@@ -1,0 +1,172 @@
+import * as path from 'node:path';
+import { createCatsCoLocalConfigService } from '../catscompany/local-config';
+import { Logger } from '../utils/logger';
+import { PathResolver } from '../utils/path-resolver';
+import { createBotSkillWorkspaceService } from './workspace-service';
+
+export interface BotSkillSyncRequest {
+  runtimeRoot: string;
+  botId: string;
+  workspaceId: string;
+}
+
+type SyncRunner = (request: BotSkillSyncRequest) => Promise<void>;
+
+interface QueueEntry {
+  request: BotSkillSyncRequest;
+  dirty: boolean;
+  running?: Promise<void>;
+  timer?: NodeJS.Timeout;
+}
+
+const queue = new Map<string, QueueEntry>();
+let runnerOverride: SyncRunner | undefined;
+
+export function scheduleBotSkillSync(request: BotSkillSyncRequest): void {
+  const normalized = normalizeRequest(request);
+  const key = requestKey(normalized);
+  let entry = queue.get(key);
+  if (!entry) {
+    entry = { request: normalized, dirty: true };
+    queue.set(key, entry);
+  } else {
+    entry.request = normalized;
+    entry.dirty = true;
+  }
+  if (entry.running || entry.timer) return;
+  entry.timer = setTimeout(() => {
+    entry!.timer = undefined;
+    entry!.running = drain(key, entry!)
+      .finally(() => {
+        entry!.running = undefined;
+        if (entry!.dirty) {
+          scheduleBotSkillSync(entry!.request);
+        } else {
+          queue.delete(key);
+        }
+      });
+  }, 0);
+  entry.timer.unref?.();
+}
+
+export function scheduleActiveBotSkillSync(
+  runtimeRoot = PathResolver.getRuntimeDataRoot(),
+): void {
+  const root = path.resolve(runtimeRoot);
+  try {
+    const workspace = createBotSkillWorkspaceService({ runtimeRoot: root });
+    const state = workspace.readState();
+    const botId = String(
+      createCatsCoLocalConfigService({ runtimeRoot: root }).load().currentBot?.uid || '',
+    ).trim();
+    if (
+      !state
+      || state.switchJournal
+      || !botId
+      || state.workspaceOwnerBotId !== botId
+    ) return;
+    scheduleBotSkillSync({
+      runtimeRoot: root,
+      botId,
+      workspaceId: state.workspaceId,
+    });
+  } catch (error) {
+    Logger.warning(`Bot Skill 后台同步调度失败: ${errorMessage(error)}`);
+  }
+}
+
+export async function flushBotSkillSyncQueue(runtimeRoot?: string): Promise<void> {
+  const selectedRoot = runtimeRoot ? path.resolve(runtimeRoot) : undefined;
+  while (true) {
+    for (const entry of queue.values()) {
+      if (selectedRoot && entry.request.runtimeRoot !== selectedRoot) continue;
+      if (entry.timer) {
+        clearTimeout(entry.timer);
+        entry.timer = undefined;
+        const key = requestKey(entry.request);
+        entry.running = drain(key, entry)
+          .finally(() => {
+            entry.running = undefined;
+            if (!entry.dirty) queue.delete(key);
+          });
+      }
+    }
+    const running = [...queue.values()]
+      .filter(entry => !selectedRoot || entry.request.runtimeRoot === selectedRoot)
+      .map(entry => entry.running)
+      .filter((value): value is Promise<void> => Boolean(value));
+    if (!running.length) return;
+    await Promise.all(running);
+  }
+}
+
+export function cancelPendingBotSkillSync(runtimeRoot: string): void {
+  const selectedRoot = path.resolve(runtimeRoot);
+  for (const [key, entry] of queue) {
+    if (entry.request.runtimeRoot !== selectedRoot || entry.running) continue;
+    if (entry.timer) clearTimeout(entry.timer);
+    queue.delete(key);
+  }
+}
+
+export function setBotSkillSyncRunnerForTests(runner?: SyncRunner): void {
+  runnerOverride = runner;
+}
+
+export function resetBotSkillSyncCoordinatorForTests(): void {
+  for (const entry of queue.values()) {
+    if (entry.timer) clearTimeout(entry.timer);
+  }
+  queue.clear();
+  runnerOverride = undefined;
+}
+
+async function drain(key: string, entry: QueueEntry): Promise<void> {
+  while (entry.dirty) {
+    entry.dirty = false;
+    const request = entry.request;
+    try {
+      const runner = runnerOverride ?? defaultRunner;
+      await runner(request);
+    } catch (error) {
+      Logger.warning(
+        `Bot ${request.botId} 的 Skill 后台同步暂未完成，将在下次触发时重试: ${errorMessage(error)}`,
+      );
+    }
+    const latest = queue.get(key);
+    if (latest !== entry) return;
+  }
+}
+
+async function defaultRunner(request: BotSkillSyncRequest): Promise<void> {
+  const workspace = createBotSkillWorkspaceService({ runtimeRoot: request.runtimeRoot });
+  const state = workspace.readState();
+  if (
+    !state
+    || state.switchJournal
+    || state.workspaceOwnerBotId !== request.botId
+    || state.workspaceId !== request.workspaceId
+  ) return;
+  const { createBotSkillSyncService } = await import('./sync-service');
+  await createBotSkillSyncService({
+    runtimeRoot: request.runtimeRoot,
+    expectedBotId: request.botId,
+    workspaceService: workspace,
+  }).syncAfterTurn(request.botId);
+}
+
+function normalizeRequest(request: BotSkillSyncRequest): BotSkillSyncRequest {
+  const runtimeRoot = path.resolve(request.runtimeRoot);
+  const botId = String(request.botId || '').trim();
+  const workspaceId = String(request.workspaceId || '').trim();
+  if (!botId || !workspaceId) throw new Error('Bot Skill sync request identity is incomplete');
+  return { runtimeRoot, botId, workspaceId };
+}
+
+function requestKey(request: BotSkillSyncRequest): string {
+  return `${request.runtimeRoot}\0${request.botId}\0${request.workspaceId}`;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/bot-skills/sync-service.ts
+++ b/src/bot-skills/sync-service.ts
@@ -1,0 +1,766 @@
+import * as path from 'node:path';
+import * as crypto from 'node:crypto';
+import {
+  FileBotDefinitionRepository,
+  type BotDefinitionReadResult,
+  type BotDefinitionRepository,
+} from '../bot-definition/repository';
+import {
+  createBotDefinitionSyncService,
+  type BotDefinitionSyncService,
+} from '../bot-definition/service';
+import type { BotDefinition, BotSkillRef } from '../bot-definition/types';
+import { PathResolver } from '../utils/path-resolver';
+import {
+  createBotSkillService,
+  type BotSkillService,
+} from './service';
+import {
+  FileBotSkillSyncBaseRepository,
+  cloudProjectionDigest,
+  createBotSkillSyncBase,
+  localProjectionDigest,
+  projectCloudSkills,
+  projectLocalManifest,
+  type BotSkillSyncBase,
+  type BotSkillSyncBaseReadResult,
+  type BotSkillSyncBaseRepository,
+  type BotSkillSyncBinding,
+  type BotSkillSyncLocalEntry,
+} from './sync-base';
+import {
+  FileSimulatedSkillArtifactStore,
+  type SimulatedSkillArtifact,
+  type SimulatedSkillArtifactStore,
+} from './simulated-artifact-store';
+import type { LocalSkillManifest, LocalSkillManifestEntry } from './local-manifest';
+import {
+  createBotSkillWorkspaceService,
+  type BotSkillWorkspaceActivationLock,
+  type BotSkillWorkspaceService,
+} from './workspace-service';
+import {
+  reconcileBotSkillWorkspace,
+  recoverBotSkillWorkspaceReconciles,
+  type BotSkillWorkspaceDesiredEntry,
+} from './workspace-reconciler';
+
+export type BotSkillSyncDirection = 'none' | 'local_to_cloud' | 'cloud_to_local';
+
+export interface BotSkillSyncResult {
+  botId: string;
+  workspaceId: string;
+  direction: BotSkillSyncDirection;
+  reason:
+    | 'already_synced'
+    | 'local_changed'
+    | 'cloud_changed'
+    | 'cloud_missing'
+    | 'workspace_restore'
+    | 'legacy_migration'
+    | 'base_initialized';
+  manifest: LocalSkillManifest;
+  base: BotSkillSyncBase;
+  definition: BotDefinition;
+}
+
+export class BotSkillSyncError extends Error {
+  constructor(
+    message: string,
+    public readonly code: string,
+    public readonly safeToUseLocal: boolean,
+    public readonly manifest?: LocalSkillManifest,
+  ) {
+    super(message);
+    this.name = 'BotSkillSyncError';
+  }
+}
+
+export interface BotSkillSyncServiceOptions {
+  runtimeRoot?: string;
+  env?: NodeJS.ProcessEnv;
+  simulatedCloudRoot?: string;
+  expectedBotId?: string;
+  workspaceService?: BotSkillWorkspaceService;
+  activationLock?: BotSkillWorkspaceActivationLock;
+  activationTransactionId?: string;
+  definitionRepository?: BotDefinitionRepository;
+  definitionService?: BotDefinitionSyncService;
+  baseRepository?: BotSkillSyncBaseRepository;
+  artifactStore?: SimulatedSkillArtifactStore;
+  onPullPhasePersisted?: Parameters<typeof reconcileBotSkillWorkspace>[0]['onPhasePersisted'];
+}
+
+export class BotSkillSyncService {
+  readonly runtimeRoot: string;
+
+  private readonly env: NodeJS.ProcessEnv;
+  private readonly expectedBotId?: string;
+  private readonly workspaceService: BotSkillWorkspaceService;
+  private readonly existingActivationLock?: BotSkillWorkspaceActivationLock;
+  private readonly activationTransactionId?: string;
+  private readonly definitionRepository: BotDefinitionRepository;
+  private readonly definitionService: BotDefinitionSyncService;
+  private readonly baseRepository: BotSkillSyncBaseRepository;
+  private readonly artifactStore: SimulatedSkillArtifactStore;
+  private readonly onPullPhasePersisted?: BotSkillSyncServiceOptions['onPullPhasePersisted'];
+
+  constructor(options: BotSkillSyncServiceOptions = {}) {
+    this.env = options.env ?? process.env;
+    this.runtimeRoot = path.resolve(
+      options.runtimeRoot ?? PathResolver.getRuntimeDataRoot(this.env),
+    );
+    this.expectedBotId = optional(options.expectedBotId);
+    this.workspaceService = options.workspaceService
+      ?? createBotSkillWorkspaceService({ runtimeRoot: this.runtimeRoot, env: this.env });
+    this.existingActivationLock = options.activationLock;
+    this.activationTransactionId = optional(options.activationTransactionId);
+    this.definitionRepository = options.definitionRepository
+      ?? new FileBotDefinitionRepository({
+        runtimeRoot: this.runtimeRoot,
+        simulatedCloudRoot: options.simulatedCloudRoot,
+      });
+    this.definitionService = options.definitionService
+      ?? createBotDefinitionSyncService({
+        runtimeRoot: this.runtimeRoot,
+        repository: this.definitionRepository,
+      });
+    this.baseRepository = options.baseRepository
+      ?? new FileBotSkillSyncBaseRepository({ runtimeRoot: this.runtimeRoot });
+    this.artifactStore = options.artifactStore
+      ?? new FileSimulatedSkillArtifactStore({
+        runtimeRoot: this.runtimeRoot,
+        simulatedCloudRoot: options.simulatedCloudRoot,
+        env: this.env,
+      });
+    this.onPullPhasePersisted = options.onPullPhasePersisted;
+  }
+
+  syncOnStartup(
+    botId: string,
+    options: { workspaceWasMissing?: boolean } = {},
+  ): Promise<BotSkillSyncResult> {
+    return this.sync(botId, { workspaceWasMissing: options.workspaceWasMissing === true });
+  }
+
+  syncAfterTurn(
+    botId: string,
+    _manifest?: LocalSkillManifest,
+  ): Promise<BotSkillSyncResult> {
+    // Always rescan under the workspace lock so a queued background request
+    // cannot publish a stale manifest captured before later edits.
+    return this.sync(botId);
+  }
+
+  syncBeforeSwitch(botId: string): Promise<BotSkillSyncResult> {
+    return this.sync(botId);
+  }
+
+  pushToCloud(botId: string): Promise<BotSkillSyncResult> {
+    return this.runLocked(botId, (botSkills, context) =>
+      this.push(botSkills, context, 'local_changed'));
+  }
+
+  pullToLocal(botId: string): Promise<BotSkillSyncResult> {
+    return this.runLocked(botId, async (botSkills, context) => {
+      const manifest = await botSkills.scanManifest();
+      const cloud = this.requireCloud(botId, manifest);
+      if (!Array.isArray(cloud.skills)) {
+        throw new BotSkillSyncError(
+          'Legacy BotDefinition has no Skill state to restore.',
+          'BOT_SKILL_CLOUD_NOT_MIGRATED',
+          manifest.status === 'complete',
+          manifest,
+        );
+      }
+      const baseRead = this.baseRepository.inspect(botId, context.workspaceId);
+      return this.pullSafely(botSkills, context, manifest, cloud, baseRead, false);
+    });
+  }
+
+  private sync(
+    botId: string,
+    options: {
+      workspaceWasMissing?: boolean;
+    } = {},
+  ): Promise<BotSkillSyncResult> {
+    return this.runLocked(botId, async (botSkills, context) => {
+      const manifest = await botSkills.scanManifest();
+      this.requireCompleteLocal(manifest, botId, context.workspaceId);
+      const baseRead = this.baseRepository.inspect(botId, context.workspaceId);
+      if (baseRead.status === 'invalid') {
+        throw new BotSkillSyncError(
+          `Bot Skill sync-base is invalid: ${baseRead.reason}`,
+          'BOT_SKILL_SYNC_BASE_INVALID',
+          !options.workspaceWasMissing,
+          manifest,
+        );
+      }
+      const cloudRead = this.definitionRepository.inspectCanonical(botId);
+      if (cloudRead.status === 'invalid') {
+        throw new BotSkillSyncError(
+          'Canonical BotDefinition is invalid; refusing to overwrite it from Local Skills.',
+          'BOT_SKILL_CLOUD_INVALID',
+          !options.workspaceWasMissing,
+          manifest,
+        );
+      }
+
+      if (cloudRead.status === 'missing') {
+        if (options.workspaceWasMissing && manifest.entries.length === 0) {
+          throw new BotSkillSyncError(
+            'Canonical BotDefinition is missing; an empty restored workspace cannot recreate it safely.',
+            'BOT_SKILL_CLOUD_MISSING',
+            false,
+            manifest,
+          );
+        }
+        return this.push(botSkills, context, 'cloud_missing', manifest, baseRead);
+      }
+      const cloud = cloudRead.definition;
+      if (!Array.isArray(cloud.skills)) {
+        return this.push(botSkills, context, 'legacy_migration', manifest, baseRead);
+      }
+
+      if (baseRead.status === 'missing') {
+        const cloudSkills = cloud.skills;
+        // A failed first restore leaves an intentionally empty claimed workspace behind.
+        // Treat that persistent state as restore-pending as long as Cloud still has refs,
+        // even if the next process no longer knows that the directory was just created.
+        if (
+          options.workspaceWasMissing
+          || (manifest.entries.length === 0 && cloud.skills.length > 0)
+        ) {
+          return this.pullSafely(botSkills, context, manifest, cloud, baseRead, false);
+        }
+        const prepared = this.preparePush(manifest, undefined);
+        if (
+          cloudProjectionDigest(prepared.cloudSkills)
+          === cloudProjectionDigest(cloudSkills)
+        ) {
+          let base: BotSkillSyncBase | undefined;
+          const committedCloud = this.writeCacheFromLatestCanonical(
+            botId,
+            cloudSkills,
+            manifest,
+            true,
+            () => {
+              base = createBotSkillSyncBase({
+                botId,
+                workspaceId: context.workspaceId,
+                localEntries: prepared.localEntries,
+                bindings: prepared.bindings,
+                cloudSkills,
+              });
+              this.baseRepository.write(base);
+            },
+          );
+          if (!base) throw new Error('Bot Skill Base was not committed');
+          return {
+            botId,
+            workspaceId: context.workspaceId,
+            direction: 'none',
+            reason: 'base_initialized',
+            manifest,
+            base,
+            definition: committedCloud,
+          };
+        }
+        return this.push(botSkills, context, 'local_changed', manifest, baseRead, prepared);
+      }
+
+      const localDigest = localProjectionDigest(projectLocalManifest(manifest));
+      const cloudDigest = cloudProjectionDigest(cloud.skills);
+      if (localDigest !== baseRead.base.local.digest) {
+        return this.push(botSkills, context, 'local_changed', manifest, baseRead);
+      }
+      if (cloudDigest !== baseRead.base.cloud.digest) {
+        return this.pullSafely(botSkills, context, manifest, cloud, baseRead, false);
+      }
+      const committedCloud = this.writeCacheFromLatestCanonical(
+        botId,
+        cloud.skills,
+        manifest,
+        true,
+      );
+      return {
+        botId,
+        workspaceId: context.workspaceId,
+        direction: 'none',
+        reason: 'already_synced',
+        manifest,
+        base: baseRead.base,
+        definition: committedCloud,
+      };
+    });
+  }
+
+  private async runLocked(
+    botIdValue: string,
+    action: (
+      botSkills: BotSkillService,
+      context: { botId: string; workspaceId: string },
+    ) => Promise<BotSkillSyncResult> | BotSkillSyncResult,
+  ): Promise<BotSkillSyncResult> {
+    const botId = required(botIdValue, 'botId');
+    if (this.expectedBotId && this.expectedBotId !== botId) {
+      throw new BotSkillSyncError(
+        `Bot Skill sync expected ${this.expectedBotId}, not ${botId}.`,
+        'BOT_SKILL_SYNC_BOT_MISMATCH',
+        false,
+      );
+    }
+    const activationLock = this.existingActivationLock
+      ?? this.workspaceService.acquireActivationLock();
+    try {
+      recoverBotSkillWorkspaceReconciles({
+        runtimeRoot: this.runtimeRoot,
+        definitionRepository: this.definitionRepository,
+        baseRepository: this.baseRepository,
+      });
+      const state = this.workspaceService.readState();
+      const pending = state?.switchJournal?.to;
+      const context = (
+        pending
+        && pending.botId === botId
+        && this.activationTransactionId
+      ) ? pending : state && {
+        botId: state.workspaceOwnerBotId,
+        workspaceId: state.workspaceId,
+      };
+      if (!context || context.botId !== botId) {
+        throw new BotSkillSyncError(
+          `Bot Skill workspace is not owned by ${botId}.`,
+          'BOT_SKILL_SYNC_WORKSPACE_OWNER_MISMATCH',
+          false,
+        );
+      }
+      const botSkills = createBotSkillService({
+        runtimeRoot: this.runtimeRoot,
+        expectedBotId: botId,
+        workspaceService: this.workspaceService,
+        activationLock,
+        activationTransactionId: this.activationTransactionId,
+      });
+      return await botSkills.withWorkspaceLock(() => action(botSkills, context));
+    } finally {
+      if (!this.existingActivationLock) activationLock.release();
+    }
+  }
+
+  private async push(
+    botSkills: BotSkillService,
+    context: { botId: string; workspaceId: string },
+    reason: 'local_changed' | 'cloud_missing' | 'legacy_migration',
+    knownManifest?: LocalSkillManifest,
+    knownBase?: BotSkillSyncBaseReadResult,
+    knownPrepared?: PreparedPush,
+  ): Promise<BotSkillSyncResult> {
+    try {
+      return await this.pushUnsafe(
+        botSkills,
+        context,
+        reason,
+        knownManifest,
+        knownBase,
+        knownPrepared,
+      );
+    } catch (error) {
+      if (error instanceof BotSkillSyncError) throw error;
+      const wrapped = new BotSkillSyncError(
+        `Local Skill upload did not complete: ${errorMessage(error)}`,
+        'BOT_SKILL_PUSH_FAILED',
+        true,
+        knownManifest,
+      );
+      (wrapped as any).cause = error;
+      throw wrapped;
+    }
+  }
+
+  private async pushUnsafe(
+    botSkills: BotSkillService,
+    context: { botId: string; workspaceId: string },
+    reason: 'local_changed' | 'cloud_missing' | 'legacy_migration',
+    knownManifest?: LocalSkillManifest,
+    knownBase?: BotSkillSyncBaseReadResult,
+    knownPrepared?: PreparedPush,
+  ): Promise<BotSkillSyncResult> {
+    const manifest = knownManifest ?? await botSkills.scanManifest();
+    this.requireCompleteLocal(manifest, context.botId, context.workspaceId);
+    const baseRead = knownBase ?? this.baseRepository.inspect(context.botId, context.workspaceId);
+    if (baseRead.status === 'invalid') {
+      throw new BotSkillSyncError(
+        `Bot Skill sync-base is invalid: ${baseRead.reason}`,
+        'BOT_SKILL_SYNC_BASE_INVALID',
+        true,
+        manifest,
+      );
+    }
+    const prepared = knownPrepared ?? this.preparePush(
+      manifest,
+      baseRead.status === 'valid' ? baseRead.base : undefined,
+    );
+    const confirmed = await botSkills.scanManifest();
+    this.requireCompleteLocal(confirmed, context.botId, context.workspaceId);
+    if (
+      localProjectionDigest(projectLocalManifest(confirmed))
+      !== localProjectionDigest(prepared.localEntries)
+    ) {
+      throw new BotSkillSyncError(
+        'Local Skills changed while the simulated upload was being prepared.',
+        'BOT_SKILL_SYNC_LOCAL_CHANGED',
+        true,
+        confirmed,
+      );
+    }
+    let base: BotSkillSyncBase | undefined;
+    const sync = this.definitionService.updateSkills(
+      context.botId,
+      prepared.cloudSkills,
+      committed => {
+        base = createBotSkillSyncBase({
+          botId: context.botId,
+          workspaceId: context.workspaceId,
+          localEntries: prepared.localEntries,
+          bindings: prepared.bindings,
+          cloudSkills: committed.definition.skills ?? [],
+        });
+        this.baseRepository.write(base);
+      },
+    );
+    const definition = sync.definition;
+    if (!base) throw new Error('Bot Skill Base was not committed');
+    return {
+      botId: context.botId,
+      workspaceId: context.workspaceId,
+      direction: 'local_to_cloud',
+      reason,
+      manifest: confirmed,
+      base,
+      definition,
+    };
+  }
+
+  private preparePush(
+    manifest: LocalSkillManifest,
+    previousBase?: BotSkillSyncBase,
+  ): PreparedPush {
+    const localEntries = projectLocalManifest(manifest);
+    const bindings: BotSkillSyncBinding[] = [];
+    const cloudSkills: BotSkillRef[] = [];
+    const previousBindings = new Map(
+      (previousBase?.bindings ?? []).map(binding => [binding.localSkillId, binding]),
+    );
+    for (const entry of manifest.entries) {
+      const publicRef = unmodifiedPublicRef(entry);
+      const artifact = this.artifactStore.put({
+        botId: required(manifest.botId, 'manifest.botId'),
+        skillsRoot: this.skillsRoot(),
+        entry,
+        ...(publicRef ? { publicRef } : {}),
+      });
+      const previous = previousBindings.get(entry.localSkillId);
+      if (
+        previous
+        && previous.storage === 'simulated-private'
+        && artifact.storage === 'simulated-private'
+        && previous.ref.skillId !== artifact.ref.skillId
+      ) {
+        throw new Error(`Private Skill identity changed for ${entry.localSkillId}`);
+      }
+      bindings.push({
+        localSkillId: entry.localSkillId,
+        ref: artifact.ref,
+        storage: artifact.storage,
+        artifactDigest: artifact.artifactDigest,
+      });
+      if (entry.enabled) cloudSkills.push(artifact.ref);
+    }
+    return {
+      localEntries,
+      bindings,
+      cloudSkills: projectCloudSkills(cloudSkills),
+    };
+  }
+
+  private pull(
+    _botSkills: BotSkillService,
+    context: { botId: string; workspaceId: string },
+    manifest: LocalSkillManifest,
+    cloud: BotDefinition,
+    baseRead: BotSkillSyncBaseReadResult,
+  ): BotSkillSyncResult {
+    this.requireCompleteLocal(manifest, context.botId, context.workspaceId);
+    const cloudSkills = projectCloudSkills(cloud.skills ?? []);
+    const previousBase = baseRead.status === 'valid' ? baseRead.base : undefined;
+    const previousBindings = previousBase?.bindings ?? [];
+    const bindingsByExactRef = new Map(
+      previousBindings.map(binding => [refKey(binding.ref), binding]),
+    );
+    const bindingsBySkillId = new Map(
+      previousBindings.map(binding => [binding.ref.skillId, binding]),
+    );
+    const desired: BotSkillWorkspaceDesiredEntry[] = [];
+    const desiredArtifacts = new Map<string, SimulatedSkillArtifact>();
+    for (const ref of cloudSkills) {
+      const artifact = this.artifactStore.read(ref);
+      if (artifact.storage === 'simulated-private' && artifact.botId !== context.botId) {
+        throw new BotSkillSyncError(
+          `Private Skill artifact belongs to another Bot: ${ref.skillId}@${ref.version}`,
+          'BOT_SKILL_ARTIFACT_OWNER_MISMATCH',
+          true,
+          manifest,
+        );
+      }
+      const previous = bindingsByExactRef.get(refKey(ref))
+        ?? bindingsBySkillId.get(ref.skillId);
+      const localSkillId = previous?.localSkillId
+        ?? (artifact.storage === 'simulated-private'
+          ? artifact.localSkillId
+          : restoredPublicLocalSkillId(context.workspaceId, ref));
+      desired.push({
+        artifact,
+        localSkillId,
+        enabled: true,
+      });
+      desiredArtifacts.set(localSkillId, artifact);
+    }
+
+    if (previousBase) {
+      const cloudKeys = new Set(cloudSkills.map(refKey));
+      const localById = new Map(
+        projectLocalManifest(manifest).map(entry => [entry.localSkillId, entry]),
+      );
+      for (const local of previousBase.local.entries) {
+        if (local.enabled) continue;
+        const binding = previousBindings.find(item => item.localSkillId === local.localSkillId);
+        if (!binding || cloudKeys.has(refKey(binding.ref))) continue;
+        const current = localById.get(local.localSkillId);
+        if (!current || localProjectionDigest([current]) !== localProjectionDigest([local])) {
+          throw new BotSkillSyncError(
+            `Disabled Local Skill changed before Cloud pull: ${local.name}`,
+            'BOT_SKILL_SYNC_LOCAL_CHANGED',
+            true,
+            manifest,
+          );
+        }
+        const artifact = this.artifactStore.read(binding.ref);
+        desired.push({
+          artifact,
+          localSkillId: local.localSkillId,
+          enabled: false,
+        });
+        desiredArtifacts.set(local.localSkillId, artifact);
+      }
+    }
+
+    let committedDefinition = cloud;
+    const reconciled = reconcileBotSkillWorkspace({
+      runtimeRoot: this.runtimeRoot,
+      skillsRoot: this.skillsRoot(),
+      botId: context.botId,
+      workspaceId: context.workspaceId,
+      currentManifest: manifest,
+      desired,
+      cloudSkills,
+      artifactStore: this.artifactStore,
+      onPhasePersisted: this.onPullPhasePersisted,
+    }, activeManifest => {
+      let committedBase: BotSkillSyncBase | undefined;
+      committedDefinition = this.writeCacheFromLatestCanonical(
+        context.botId,
+        cloudSkills,
+        activeManifest,
+        false,
+        () => {
+          const activeLocal = projectLocalManifest(activeManifest);
+          const bindings: BotSkillSyncBinding[] = activeLocal.map(local => {
+            const artifact = desiredArtifacts.get(local.localSkillId);
+            if (!artifact) throw new Error(`Restored Skill has no artifact binding: ${local.name}`);
+            return {
+              localSkillId: local.localSkillId,
+              ref: artifact.ref,
+              storage: artifact.storage,
+              artifactDigest: artifact.artifactDigest,
+            };
+          });
+          committedBase = createBotSkillSyncBase({
+            botId: context.botId,
+            workspaceId: context.workspaceId,
+            localEntries: activeLocal,
+            bindings,
+            cloudSkills,
+          });
+          this.baseRepository.write(committedBase);
+        },
+      );
+      if (!committedBase) throw new Error('Bot Skill Base was not committed');
+      return committedBase;
+    });
+    return {
+      botId: context.botId,
+      workspaceId: context.workspaceId,
+      direction: 'cloud_to_local',
+      reason: baseRead.status === 'missing' ? 'workspace_restore' : 'cloud_changed',
+      manifest: reconciled.manifest,
+      base: reconciled.result,
+      definition: committedDefinition,
+    };
+  }
+
+  private pullSafely(
+    botSkills: BotSkillService,
+    context: { botId: string; workspaceId: string },
+    manifest: LocalSkillManifest,
+    cloud: BotDefinition,
+    baseRead: BotSkillSyncBaseReadResult,
+    safeToUseLocal: boolean,
+  ): BotSkillSyncResult {
+    try {
+      return this.pull(botSkills, context, manifest, cloud, baseRead);
+    } catch (error) {
+      if (error instanceof BotSkillSyncError) {
+        if (error.safeToUseLocal === safeToUseLocal) throw error;
+        const wrapped = new BotSkillSyncError(
+          error.message,
+          error.code,
+          safeToUseLocal,
+          error.manifest ?? manifest,
+        );
+        (wrapped as any).cause = error;
+        throw wrapped;
+      }
+      const wrapped = new BotSkillSyncError(
+        `Cloud Skill restore did not complete: ${errorMessage(error)}`,
+        'BOT_SKILL_PULL_FAILED',
+        safeToUseLocal,
+        manifest,
+      );
+      (wrapped as any).cause = error;
+      throw wrapped;
+    }
+  }
+
+  private requireCloud(botId: string, manifest: LocalSkillManifest): BotDefinition {
+    const cloud = this.definitionRepository.inspectCanonical(botId);
+    if (cloud.status === 'valid') return cloud.definition;
+    throw new BotSkillSyncError(
+      cloud.status === 'invalid'
+        ? 'Canonical BotDefinition is invalid.'
+        : 'Canonical BotDefinition is missing.',
+      cloud.status === 'invalid' ? 'BOT_SKILL_CLOUD_INVALID' : 'BOT_SKILL_CLOUD_MISSING',
+      manifest.status === 'complete',
+      manifest,
+    );
+  }
+
+  private writeCacheFromLatestCanonical(
+    botId: string,
+    expectedSkills: readonly BotSkillRef[],
+    manifest: LocalSkillManifest,
+    safeToUseLocal: boolean,
+    afterCache?: (definition: BotDefinition) => void,
+  ): BotDefinition {
+    const commit = (): BotDefinition => {
+      const latest = this.definitionRepository.inspectCanonical(botId);
+      if (
+        latest.status !== 'valid'
+        || !Array.isArray(latest.definition.skills)
+        || cloudProjectionDigest(latest.definition.skills)
+          !== cloudProjectionDigest(expectedSkills)
+      ) {
+        throw new BotSkillSyncError(
+          'Canonical BotDefinition changed while Skill synchronization was committing.',
+          'BOT_SKILL_CLOUD_CHANGED',
+          safeToUseLocal,
+          manifest,
+        );
+      }
+      this.definitionRepository.writeCache(latest.definition);
+      afterCache?.(latest.definition);
+      return latest.definition;
+    };
+    return this.definitionRepository.withCanonicalLock
+      ? this.definitionRepository.withCanonicalLock(botId, commit)
+      : commit();
+  }
+
+  private requireCompleteLocal(
+    manifest: LocalSkillManifest,
+    botId: string,
+    workspaceId: string,
+  ): void {
+    if (
+      manifest.status !== 'complete'
+      || manifest.botId !== botId
+      || manifest.workspaceId !== workspaceId
+    ) {
+      throw new BotSkillSyncError(
+        `Local Skill manifest is ${manifest.status}; synchronization stopped.`,
+        'BOT_SKILL_LOCAL_INCOMPLETE',
+        false,
+        manifest,
+      );
+    }
+  }
+
+  private skillsRoot(): string {
+    return path.join(this.runtimeRoot, 'skills');
+  }
+}
+
+interface PreparedPush {
+  localEntries: BotSkillSyncLocalEntry[];
+  bindings: BotSkillSyncBinding[];
+  cloudSkills: BotSkillRef[];
+}
+
+export function createBotSkillSyncService(
+  options: BotSkillSyncServiceOptions = {},
+): BotSkillSyncService {
+  return new BotSkillSyncService(options);
+}
+
+function unmodifiedPublicRef(entry: LocalSkillManifestEntry): BotSkillRef | undefined {
+  if (
+    entry.source !== 'skillhub'
+    || !entry.skillId
+    || !entry.version
+    || !entry.installedContentHash
+    || entry.installedContentHash !== entry.contentHash
+  ) return undefined;
+  return { skillId: entry.skillId, version: entry.version };
+}
+
+function refKey(ref: BotSkillRef): string {
+  return `${ref.skillId}\0${ref.version}`;
+}
+
+function restoredPublicLocalSkillId(workspaceId: string, ref: BotSkillRef): string {
+  const hex = crypto.createHash('sha256')
+    .update(`${workspaceId}\0${ref.skillId}\0${ref.version}`, 'utf8')
+    .digest('hex');
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    `5${hex.slice(13, 16)}`,
+    `a${hex.slice(17, 20)}`,
+    hex.slice(20, 32),
+  ].join('-');
+}
+
+function required(value: unknown, field: string): string {
+  const text = typeof value === 'string' ? value.trim() : '';
+  if (!text) throw new Error(`${field} is required`);
+  return text;
+}
+
+function optional(value: unknown): string | undefined {
+  const text = typeof value === 'string' ? value.trim() : '';
+  return text || undefined;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/bot-skills/workspace-reconciler.ts
+++ b/src/bot-skills/workspace-reconciler.ts
@@ -1,0 +1,554 @@
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { BotDefinitionRepository } from '../bot-definition/repository';
+import type { BotSkillRef } from '../bot-definition/types';
+import {
+  BOT_SKILL_LOCAL_IDENTITY_SCHEMA,
+  scanLocalSkillManifest,
+  writeLocalSkillIdentity,
+  type LocalSkillManifest,
+} from './local-manifest';
+import {
+  BOT_SKILL_WORKSPACE_MARKER_FILE,
+  BOT_SKILL_WORKSPACE_MARKER_SCHEMA,
+} from './workspace-service';
+import {
+  cloudProjectionDigest,
+  FileBotSkillSyncBaseRepository,
+  projectLocalManifest,
+  localProjectionDigest,
+  type BotSkillSyncBaseRepository,
+} from './sync-base';
+import type {
+  SimulatedSkillArtifact,
+  SimulatedSkillArtifactStore,
+} from './simulated-artifact-store';
+
+export const BOT_SKILL_PULL_JOURNAL_SCHEMA = 'xiaoba.bot-skill-pull-journal.v1';
+
+type PullPhase = 'prepared' | 'source-backed-up' | 'target-active' | 'base-committed';
+
+interface BotSkillPullJournal {
+  schema: typeof BOT_SKILL_PULL_JOURNAL_SCHEMA;
+  transactionId: string;
+  botId: string;
+  workspaceId: string;
+  phase: PullPhase;
+  oldLocalDigest: string;
+  targetLocalDigest: string;
+  targetCloudDigest: string;
+  startedAt: string;
+}
+
+export interface BotSkillWorkspaceDesiredEntry {
+  artifact: SimulatedSkillArtifact;
+  localSkillId: string;
+  enabled: boolean;
+}
+
+export interface ReconcileBotSkillWorkspaceOptions {
+  runtimeRoot: string;
+  skillsRoot: string;
+  botId: string;
+  workspaceId: string;
+  currentManifest: LocalSkillManifest;
+  desired: BotSkillWorkspaceDesiredEntry[];
+  cloudSkills: BotSkillRef[];
+  artifactStore: SimulatedSkillArtifactStore;
+  onPhasePersisted?: (phase: PullPhase) => void;
+}
+
+export function reconcileBotSkillWorkspace<T>(
+  options: ReconcileBotSkillWorkspaceOptions,
+  commit: (manifest: LocalSkillManifest) => T,
+): { manifest: LocalSkillManifest; result: T } {
+  if (options.currentManifest.status !== 'complete') {
+    throw new Error(`Cannot reconcile Local Skill manifest: ${options.currentManifest.status}`);
+  }
+  if (
+    options.currentManifest.botId !== options.botId
+    || options.currentManifest.workspaceId !== options.workspaceId
+  ) {
+    throw new Error('Local Skill manifest identity changed before reconcile');
+  }
+  const runtimeRoot = path.resolve(options.runtimeRoot);
+  const skillsRoot = path.resolve(options.skillsRoot);
+  const operationsRoot = operationScopeRoot(runtimeRoot, options.workspaceId);
+  ensureSafeDirectory(path.join(runtimeRoot, 'data', 'bot-skills'), operationsRoot);
+  const operationDir = path.join(operationsRoot, `pull-${crypto.randomUUID()}`);
+  fs.mkdirSync(operationDir, { mode: 0o700 });
+  const stagedRoot = path.join(operationDir, 'staged');
+  const backupRoot = path.join(operationDir, 'backup');
+  const journalPath = path.join(operationDir, 'journal.json');
+
+  let journal: BotSkillPullJournal | undefined;
+  let targetManifest: LocalSkillManifest | undefined;
+  let swapped = false;
+  let committed = false;
+  try {
+    copyTreeStrict(skillsRoot, stagedRoot);
+    for (const entry of options.currentManifest.entries) {
+      const target = resolveManifestPath(stagedRoot, entry.path);
+      if (fs.existsSync(target)) fs.rmSync(target, { recursive: true, force: false });
+    }
+
+    const seenPaths = new Set<string>();
+    const seenIds = new Set<string>();
+    for (const desired of options.desired) {
+      const installName = normalizeInstallName(desired.artifact.installName);
+      const portable = installName.normalize('NFC').toLocaleLowerCase('en-US');
+      if (seenPaths.has(portable)) throw new Error(`Duplicate restored Skill path: ${installName}`);
+      if (seenIds.has(desired.localSkillId)) {
+        throw new Error(`Duplicate restored localSkillId: ${desired.localSkillId}`);
+      }
+      seenPaths.add(portable);
+      seenIds.add(desired.localSkillId);
+      const targetDir = path.join(stagedRoot, installName);
+      options.artifactStore.materialize(desired.artifact, targetDir);
+      writeLocalSkillIdentity(targetDir, {
+        schema: BOT_SKILL_LOCAL_IDENTITY_SCHEMA,
+        localSkillId: required(desired.localSkillId, 'localSkillId'),
+        workspaceId: options.workspaceId,
+        identityName: desired.artifact.name,
+        createdAt: new Date().toISOString(),
+      });
+      if (!desired.enabled) {
+        const active = path.join(targetDir, 'SKILL.md');
+        const disabled = path.join(targetDir, 'SKILL.md.disabled');
+        if (!fs.existsSync(active) || fs.existsSync(disabled)) {
+          throw new Error(`Restored Skill entrypoint is invalid: ${installName}`);
+        }
+        fs.renameSync(active, disabled);
+      }
+    }
+
+    targetManifest = scanLocalSkillManifest({
+      skillsRoot: stagedRoot,
+      botId: options.botId,
+      workspaceId: options.workspaceId,
+      createIdentities: false,
+    });
+    if (targetManifest.status !== 'complete') {
+      throw new Error(`Staged Local Skill manifest is ${targetManifest.status}`);
+    }
+    const targetLocalDigest = localProjectionDigest(projectLocalManifest(targetManifest));
+    const targetCloudDigest = cloudProjectionDigest(options.cloudSkills);
+    journal = {
+      schema: BOT_SKILL_PULL_JOURNAL_SCHEMA,
+      transactionId: crypto.randomUUID(),
+      botId: options.botId,
+      workspaceId: options.workspaceId,
+      phase: 'prepared',
+      oldLocalDigest: localProjectionDigest(projectLocalManifest(options.currentManifest)),
+      targetLocalDigest,
+      targetCloudDigest,
+      startedAt: new Date().toISOString(),
+    };
+    writeJournal(journalPath, journal);
+    options.onPhasePersisted?.('prepared');
+
+    fs.renameSync(skillsRoot, backupRoot);
+    journal.phase = 'source-backed-up';
+    writeJournal(journalPath, journal);
+    options.onPhasePersisted?.('source-backed-up');
+
+    fs.renameSync(stagedRoot, skillsRoot);
+    swapped = true;
+    journal.phase = 'target-active';
+    writeJournal(journalPath, journal);
+    options.onPhasePersisted?.('target-active');
+
+    const activeManifest = scanLocalSkillManifest({
+      skillsRoot,
+      botId: options.botId,
+      workspaceId: options.workspaceId,
+      createIdentities: false,
+    });
+    if (
+      activeManifest.status !== 'complete'
+      || localProjectionDigest(projectLocalManifest(activeManifest)) !== targetLocalDigest
+    ) {
+      throw new Error('Active Skill workspace does not match the staged target');
+    }
+    const result = commit(activeManifest);
+    committed = true;
+    try {
+      journal.phase = 'base-committed';
+      writeJournal(journalPath, journal);
+      options.onPhasePersisted?.('base-committed');
+      fs.rmSync(operationDir, { recursive: true, force: true });
+    } catch {
+      // Base is the commit point. Recovery can safely remove the stale backup.
+    }
+    return { manifest: activeManifest, result };
+  } catch (error) {
+    if (!committed && journal) {
+      rollbackAppliedWorkspace({
+        skillsRoot,
+        backupRoot,
+        operationDir,
+        journal,
+        targetMayBeActive: swapped,
+      });
+    } else if (!journal) {
+      fs.rmSync(operationDir, { recursive: true, force: true });
+    }
+    throw error;
+  }
+}
+
+export interface RecoverBotSkillWorkspaceReconcileOptions {
+  runtimeRoot: string;
+  skillsRoot?: string;
+  definitionRepository: BotDefinitionRepository;
+  baseRepository?: BotSkillSyncBaseRepository;
+}
+
+export function recoverBotSkillWorkspaceReconciles(
+  options: RecoverBotSkillWorkspaceReconcileOptions,
+): void {
+  const runtimeRoot = path.resolve(options.runtimeRoot);
+  const skillsRoot = path.resolve(options.skillsRoot ?? path.join(runtimeRoot, 'skills'));
+  const root = path.join(runtimeRoot, 'data', 'bot-skills', 'sync-operations');
+  if (!fs.existsSync(root)) return;
+  assertRealDirectory(root, 'Bot Skill sync operations root');
+  const baseRepository = options.baseRepository
+    ?? new FileBotSkillSyncBaseRepository({ runtimeRoot });
+  for (const scope of fs.readdirSync(root, { withFileTypes: true })) {
+    if (!scope.isDirectory() || scope.isSymbolicLink()) {
+      throw new Error(`Unsafe Bot Skill sync operation scope: ${scope.name}`);
+    }
+    const scopePath = path.join(root, scope.name);
+    for (const operation of fs.readdirSync(scopePath, { withFileTypes: true })) {
+      if (!operation.isDirectory() || operation.isSymbolicLink()) {
+        throw new Error(`Unsafe Bot Skill sync operation: ${operation.name}`);
+      }
+      recoverOperation({
+        operationDir: path.join(scopePath, operation.name),
+        skillsRoot,
+        definitionRepository: options.definitionRepository,
+        baseRepository,
+      });
+    }
+  }
+}
+
+function recoverOperation(options: {
+  operationDir: string;
+  skillsRoot: string;
+  definitionRepository: BotDefinitionRepository;
+  baseRepository: BotSkillSyncBaseRepository;
+}): void {
+  const journalPath = path.join(options.operationDir, 'journal.json');
+  if (!fs.existsSync(journalPath)) {
+    throw new Error(`Bot Skill sync operation has no journal: ${options.operationDir}`);
+  }
+  const journal = parseJournal(readJson(journalPath));
+  const expectedScope = `w_${sha256(journal.workspaceId)}`;
+  if (path.basename(path.dirname(options.operationDir)) !== expectedScope) {
+    throw new Error(`Bot Skill pull journal is stored in the wrong workspace scope: ${journal.transactionId}`);
+  }
+  const stagedRoot = path.join(options.operationDir, 'staged');
+  const backupRoot = path.join(options.operationDir, 'backup');
+  if (journal.phase === 'prepared') {
+    const activeDigest = inspectWorkspaceDigest(
+      options.skillsRoot,
+      journal.botId,
+      journal.workspaceId,
+    );
+    if (activeDigest === journal.oldLocalDigest) {
+      fs.rmSync(options.operationDir, { recursive: true, force: true });
+      return;
+    }
+    const backupDigest = inspectWorkspaceDigest(backupRoot, journal.botId, journal.workspaceId);
+    const stagedDigest = inspectWorkspaceDigest(stagedRoot, journal.botId, journal.workspaceId);
+    if (
+      activeDigest === undefined
+      && backupDigest === journal.oldLocalDigest
+      && stagedDigest === journal.targetLocalDigest
+      && !fs.existsSync(options.skillsRoot)
+    ) {
+      fs.renameSync(backupRoot, options.skillsRoot);
+      fs.rmSync(options.operationDir, { recursive: true, force: true });
+      return;
+    }
+    throw new Error(`Prepared Bot Skill pull is ambiguous: ${journal.transactionId}`);
+  }
+  if (journal.phase === 'source-backed-up') {
+    const backupDigest = inspectWorkspaceDigest(backupRoot, journal.botId, journal.workspaceId);
+    if (backupDigest !== journal.oldLocalDigest) {
+      throw new Error(`Bot Skill pull backup is invalid: ${journal.transactionId}`);
+    }
+    if (!fs.existsSync(options.skillsRoot)) {
+      const stagedDigest = inspectWorkspaceDigest(stagedRoot, journal.botId, journal.workspaceId);
+      if (stagedDigest !== journal.targetLocalDigest) {
+        throw new Error(`Bot Skill pull staged target is invalid: ${journal.transactionId}`);
+      }
+      fs.renameSync(backupRoot, options.skillsRoot);
+      fs.rmSync(options.operationDir, { recursive: true, force: true });
+      return;
+    }
+    const activeDigest = inspectWorkspaceDigest(
+      options.skillsRoot,
+      journal.botId,
+      journal.workspaceId,
+    );
+    if (activeDigest !== journal.targetLocalDigest || fs.existsSync(stagedRoot)) {
+      throw new Error(`Source-backed-up Bot Skill pull has an unexpected active workspace: ${journal.transactionId}`);
+    }
+    // The second rename completed before target-active was persisted. From here
+    // the same Base commit-point logic as target-active recovery is safe.
+  }
+
+  const activeDigest = inspectWorkspaceDigest(
+    options.skillsRoot,
+    journal.botId,
+    journal.workspaceId,
+  );
+  const backupDigest = inspectWorkspaceDigest(backupRoot, journal.botId, journal.workspaceId);
+  if (
+    activeDigest !== journal.targetLocalDigest
+    || backupDigest !== journal.oldLocalDigest
+  ) {
+    throw new Error(`Bot Skill pull recovery is ambiguous: ${journal.transactionId}`);
+  }
+  const base = options.baseRepository.inspect(journal.botId, journal.workspaceId);
+  const committed = (
+    base.status === 'valid'
+    && base.base.local.digest === journal.targetLocalDigest
+    && base.base.cloud.digest === journal.targetCloudDigest
+  );
+  if (committed || journal.phase === 'base-committed') {
+    fs.rmSync(options.operationDir, { recursive: true, force: true });
+    return;
+  }
+  fs.rmSync(options.skillsRoot, { recursive: true, force: false });
+  fs.renameSync(backupRoot, options.skillsRoot);
+  fs.rmSync(options.operationDir, { recursive: true, force: true });
+  if (fs.existsSync(stagedRoot)) {
+    throw new Error(`Unexpected staged workspace remained after recovery: ${stagedRoot}`);
+  }
+}
+
+function rollbackAppliedWorkspace(options: {
+  skillsRoot: string;
+  backupRoot: string;
+  operationDir: string;
+  journal: BotSkillPullJournal;
+  targetMayBeActive: boolean;
+}): void {
+  if (options.targetMayBeActive && fs.existsSync(options.skillsRoot)) {
+    const activeDigest = inspectWorkspaceDigest(
+      options.skillsRoot,
+      options.journal.botId,
+      options.journal.workspaceId,
+    );
+    if (activeDigest !== options.journal.targetLocalDigest) {
+      throw new Error(`Refusing to roll back an ambiguous Skill workspace: ${options.journal.transactionId}`);
+    }
+    fs.rmSync(options.skillsRoot, { recursive: true, force: false });
+  }
+  if (fs.existsSync(options.backupRoot)) {
+    const backupDigest = inspectWorkspaceDigest(
+      options.backupRoot,
+      options.journal.botId,
+      options.journal.workspaceId,
+    );
+    if (backupDigest !== options.journal.oldLocalDigest) {
+      throw new Error(`Refusing to restore an invalid Skill backup: ${options.journal.transactionId}`);
+    }
+    fs.renameSync(options.backupRoot, options.skillsRoot);
+  }
+  fs.rmSync(options.operationDir, { recursive: true, force: true });
+}
+
+function inspectWorkspaceDigest(
+  root: string,
+  botId: string,
+  workspaceId: string,
+): string | undefined {
+  if (!fs.existsSync(root)) return undefined;
+  if (!workspaceIdentityMatches(root, botId, workspaceId)) return undefined;
+  const manifest = scanLocalSkillManifest({
+    skillsRoot: root,
+    botId,
+    workspaceId,
+    createIdentities: false,
+  });
+  if (manifest.status !== 'complete') return undefined;
+  return localProjectionDigest(projectLocalManifest(manifest));
+}
+
+function workspaceIdentityMatches(
+  root: string,
+  botId: string,
+  workspaceId: string,
+): boolean {
+  try {
+    const markerPath = path.join(root, BOT_SKILL_WORKSPACE_MARKER_FILE);
+    const stat = fs.lstatSync(markerPath);
+    if (!stat.isFile() || stat.isSymbolicLink() || stat.size > 64 * 1024) return false;
+    const marker = JSON.parse(fs.readFileSync(markerPath, 'utf8')) as any;
+    return (
+      marker?.schema === BOT_SKILL_WORKSPACE_MARKER_SCHEMA
+      && marker.workspaceOwnerBotId === botId
+      && marker.workspaceId === workspaceId
+    );
+  } catch {
+    return false;
+  }
+}
+
+function operationScopeRoot(runtimeRoot: string, workspaceId: string): string {
+  return path.join(
+    runtimeRoot,
+    'data',
+    'bot-skills',
+    'sync-operations',
+    `w_${sha256(workspaceId)}`,
+  );
+}
+
+function resolveManifestPath(root: string, relative: string): string {
+  const normalized = relative.replace(/\\/g, '/');
+  if (
+    path.posix.isAbsolute(normalized)
+    || normalized.split('/').some(segment => !segment || segment === '.' || segment === '..')
+  ) throw new Error(`Unsafe Local Skill path: ${relative}`);
+  const resolved = path.resolve(root, ...normalized.split('/'));
+  const parent = path.dirname(resolved);
+  assertContained(root, resolved, 'Local Skill path');
+  assertRealDirectory(parent, 'Local Skill parent');
+  return resolved;
+}
+
+function copyTreeStrict(source: string, target: string): void {
+  assertRealDirectory(source, 'Skill workspace');
+  fs.mkdirSync(target, { mode: 0o700 });
+  const visit = (from: string, to: string): void => {
+    for (const entry of fs.readdirSync(from, { withFileTypes: true })) {
+      const sourcePath = path.join(from, entry.name);
+      const targetPath = path.join(to, entry.name);
+      const stat = fs.lstatSync(sourcePath);
+      if (stat.isSymbolicLink()) throw new Error(`Skill workspace contains a link: ${sourcePath}`);
+      if (stat.isDirectory()) {
+        fs.mkdirSync(targetPath, { mode: 0o700 });
+        visit(sourcePath, targetPath);
+      } else if (stat.isFile()) {
+        fs.copyFileSync(sourcePath, targetPath, fs.constants.COPYFILE_EXCL);
+      } else {
+        throw new Error(`Skill workspace contains a non-file: ${sourcePath}`);
+      }
+    }
+  };
+  try {
+    visit(source, target);
+  } catch (error) {
+    fs.rmSync(target, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+function writeJournal(filePath: string, journal: BotSkillPullJournal): void {
+  const serialized = `${JSON.stringify(journal, null, 2)}\n`;
+  const temporary = `${filePath}.${process.pid}.${crypto.randomUUID()}.tmp`;
+  try {
+    fs.writeFileSync(temporary, serialized, { encoding: 'utf8', mode: 0o600, flag: 'wx' });
+    fs.renameSync(temporary, filePath);
+  } catch (error) {
+    fs.rmSync(temporary, { force: true });
+    throw error;
+  }
+}
+
+function parseJournal(value: unknown): BotSkillPullJournal {
+  const raw = value as Partial<BotSkillPullJournal> | null;
+  if (
+    raw?.schema !== BOT_SKILL_PULL_JOURNAL_SCHEMA
+    || !['prepared', 'source-backed-up', 'target-active', 'base-committed'].includes(String(raw.phase))
+  ) throw new Error('Invalid Bot Skill pull journal');
+  return {
+    schema: BOT_SKILL_PULL_JOURNAL_SCHEMA,
+    transactionId: required(raw.transactionId, 'transactionId'),
+    botId: required(raw.botId, 'botId'),
+    workspaceId: required(raw.workspaceId, 'workspaceId'),
+    phase: raw.phase as PullPhase,
+    oldLocalDigest: requiredHash(raw.oldLocalDigest, 'oldLocalDigest'),
+    targetLocalDigest: requiredHash(raw.targetLocalDigest, 'targetLocalDigest'),
+    targetCloudDigest: requiredHash(raw.targetCloudDigest, 'targetCloudDigest'),
+    startedAt: new Date(required(raw.startedAt, 'startedAt')).toISOString(),
+  };
+}
+
+function readJson(filePath: string): unknown {
+  const stat = fs.lstatSync(filePath);
+  if (!stat.isFile() || stat.isSymbolicLink() || stat.size > 256 * 1024) {
+    throw new Error(`Invalid Bot Skill pull journal: ${filePath}`);
+  }
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function ensureSafeDirectory(rootPath: string, targetPath: string): void {
+  const root = path.resolve(rootPath);
+  const target = path.resolve(targetPath);
+  assertContained(root, target, 'Bot Skill sync operation directory');
+  fs.mkdirSync(root, { recursive: true, mode: 0o700 });
+  assertRealDirectory(root, 'Bot Skill sync operation root');
+  let current = root;
+  for (const segment of path.relative(root, target).split(path.sep).filter(Boolean)) {
+    current = path.join(current, segment);
+    if (!fs.existsSync(current)) fs.mkdirSync(current, { mode: 0o700 });
+    assertRealDirectory(current, 'Bot Skill sync operation directory');
+  }
+}
+
+function assertRealDirectory(directory: string, label: string): void {
+  const stat = fs.lstatSync(directory);
+  if (
+    !stat.isDirectory()
+    || stat.isSymbolicLink()
+    || !samePath(path.resolve(directory), fs.realpathSync.native(directory))
+  ) throw new Error(`Unsafe ${label}: ${directory}`);
+}
+
+function normalizeInstallName(value: unknown): string {
+  const name = required(value, 'installName').normalize('NFC');
+  if (
+    name !== path.basename(name)
+    || name === '.'
+    || name === '..'
+    || /[<>:"/\\|?*\u0000-\u001f]/u.test(name)
+    || /[ .]$/u.test(name)
+  ) throw new Error(`Unsafe restored Skill path: ${name}`);
+  return name;
+}
+
+function required(value: unknown, field: string): string {
+  const text = typeof value === 'string' ? value.trim() : '';
+  if (!text || text.length > 1024) throw new Error(`${field} is required or too long`);
+  return text;
+}
+
+function requiredHash(value: unknown, field: string): string {
+  const text = required(value, field).toLowerCase();
+  if (!/^[0-9a-f]{64}$/.test(text)) throw new Error(`${field} must be SHA-256`);
+  return text;
+}
+
+function sha256(value: string): string {
+  return crypto.createHash('sha256').update(value, 'utf8').digest('hex');
+}
+
+function assertContained(root: string, target: string, label: string): void {
+  const relative = path.relative(path.resolve(root), path.resolve(target));
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(`${label} escapes its root`);
+  }
+}
+
+function samePath(left: string, right: string): boolean {
+  return process.platform === 'win32'
+    ? path.resolve(left).toLowerCase() === path.resolve(right).toLowerCase()
+    : path.resolve(left) === path.resolve(right);
+}

--- a/src/bot-skills/workspace-service.ts
+++ b/src/bot-skills/workspace-service.ts
@@ -60,7 +60,8 @@ export interface BotSkillWorkspaceServiceOptions {
   onPhasePersisted?: (phase: BotSkillWorkspaceSwitchPhase) => void;
 }
 
-const MARKER_FILE = '.xiaoba-bot-workspace.json';
+export const BOT_SKILL_WORKSPACE_MARKER_FILE = '.xiaoba-bot-workspace.json';
+const MARKER_FILE = BOT_SKILL_WORKSPACE_MARKER_FILE;
 const MAX_JSON_BYTES = 256 * 1024;
 
 export class BotSkillWorkspaceService {

--- a/src/commands/catscompany.ts
+++ b/src/commands/catscompany.ts
@@ -17,9 +17,14 @@ import {
 } from '../bot-definition/cloud-client';
 import { CloudBotModelRuntimeReloadController } from '../bot-definition/runtime-reload';
 import { createBotDefinitionSyncService } from '../bot-definition/service';
+import { FileBotDefinitionRepository } from '../bot-definition/repository';
 import { createBotSkillWorkspaceService } from '../bot-skills/workspace-service';
 import { recoverBotSkillActivation } from '../bot-skills/activation-recovery';
 import { createBotSkillService } from '../bot-skills/service';
+import { BotSkillSyncError, createBotSkillSyncService } from '../bot-skills/sync-service';
+import { recoverBotSkillWorkspaceReconciles } from '../bot-skills/workspace-reconciler';
+import { bootstrapDefaultSkillHubSkillsOnce } from '../skillhub/default-skill-bootstrap';
+import { SkillHubService } from '../skillhub/service';
 import * as fs from 'node:fs';
 
 const CONNECTOR_OWNER_POLL_MS = 2000;
@@ -48,6 +53,11 @@ export async function catscompanyCommand(): Promise<void> {
   const runtimeRoot = PathResolver.getRuntimeDataRoot();
   const localConfigService = createCatsCoLocalConfigService({ runtimeRoot });
   const workspaceService = createBotSkillWorkspaceService({ runtimeRoot });
+  const definitions = new FileBotDefinitionRepository({ runtimeRoot });
+  recoverBotSkillWorkspaceReconciles({
+    runtimeRoot,
+    definitionRepository: definitions,
+  });
   const activationRecovery = recoverBotSkillActivation(runtimeRoot, workspaceService, {
     expectedLiveTransactionId: process.env.XIAOBA_BOT_SKILL_ACTIVATION_TX,
   });
@@ -62,12 +72,16 @@ export async function catscompanyCommand(): Promise<void> {
   });
   if (configuredBotId && !activationRecovery.pendingTargetBotId && !hadWorkspace) {
     workspaceService.ensureActive(configuredBotId, {
-      allowCreate: Array.isArray(preparedBot?.definition.skills) &&
-        preparedBot.definition.skills.length === 0,
+      allowCreate: Array.isArray(preparedBot?.definition.skills),
     });
   }
   if (configuredBotId && !process.env.XIAOBA_BOT_SKILL_ACTIVATION_TX) {
-    const manifest = await createBotSkillService({ runtimeRoot }).scanManifest();
+    const botSkillService = createBotSkillService({
+      runtimeRoot,
+      expectedBotId: configuredBotId,
+      workspaceService,
+    });
+    let manifest = await botSkillService.scanManifest();
     if (manifest.status !== 'complete') {
       const issues = manifest.issues
         .map(issue => `[${issue.code}]${issue.path ? ` ${issue.path}:` : ''} ${issue.message}`)
@@ -75,6 +89,33 @@ export async function catscompanyCommand(): Promise<void> {
       throw new Error(
         `Active Bot Skill manifest is ${manifest.status}.${issues ? ` ${issues}` : ''}`,
       );
+    }
+    if (preparedBot?.definition.skills === undefined) {
+      await bootstrapDefaultSkillHubSkillsOnce({
+        workspaceId: manifest.workspaceId,
+        service: new SkillHubService({ botSkillService }),
+      }).catch(error => {
+        Logger.warning(
+          `Legacy default SkillHub bootstrap failed before migration: ${error?.message || String(error)}`,
+        );
+      });
+      manifest = await botSkillService.scanManifest();
+    }
+    try {
+      await createBotSkillSyncService({
+        runtimeRoot,
+        expectedBotId: configuredBotId,
+        workspaceService,
+        definitionRepository: definitions,
+      }).syncOnStartup(configuredBotId, {
+        workspaceWasMissing: !hadWorkspace,
+      });
+    } catch (error) {
+      if (error instanceof BotSkillSyncError && error.safeToUseLocal) {
+        Logger.warning(`Bot Skill startup sync deferred; using protected Local state: ${error.message}`);
+      } else {
+        throw error;
+      }
     }
   }
   if (preparedBot?.cloudRevision !== undefined) {

--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -73,6 +73,8 @@ export interface AgentServices {
   };
   toolManager: ToolManager;
   skillManager: SkillManager;
+  /** Fire-and-forget lifecycle hook used for coalesced background maintenance. */
+  onTurnSettled?: () => void;
 
 }
 
@@ -636,6 +638,11 @@ export class AgentSession {
 
         return { text: errorReply, visibleToUser: true, taskOutcome: 'failed' };
       } finally {
+        try {
+          this.services.onTurnSettled?.();
+        } catch (error) {
+          Logger.warning(`[会话 ${this.key}] 回合结束后台任务调度失败: ${error instanceof Error ? error.message : String(error)}`);
+        }
         this.planRuntime.clear();
         this.busy = false;
         this.activeAbortController = null;

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -53,6 +53,7 @@ import {
 import { inferCatsUploadType, uploadCatsLocalFile } from '../../catscompany/upload';
 import { createCatsCoLocalConfigService } from '../../catscompany/local-config';
 import { catalogRuntimeMatchesModelId, createBotDefinitionSyncService } from '../../bot-definition/service';
+import { FileBotDefinitionRepository } from '../../bot-definition/repository';
 import { prepareBoundBotDefinition } from '../../bot-definition/activation';
 import {
   customModelDefinitionToConfig,
@@ -78,6 +79,8 @@ import {
   readSkillHubLocalMetadata,
 } from '../../skillhub/local-skill-metadata';
 import { createBotSkillService } from '../../bot-skills/service';
+import { BotSkillSyncError, createBotSkillSyncService } from '../../bot-skills/sync-service';
+import { recoverBotSkillWorkspaceReconciles } from '../../bot-skills/workspace-reconciler';
 import {
   deletePromptOverride,
   getPromptEditorFile,
@@ -882,6 +885,10 @@ async function commitCatsBotBindingAndStartConnector(
   const workspaceService = createBotSkillWorkspaceService({ runtimeRoot });
   const activationLock = workspaceService.acquireActivationLock();
   try {
+    recoverBotSkillWorkspaceReconciles({
+      runtimeRoot,
+      definitionRepository: new FileBotDefinitionRepository({ runtimeRoot }),
+    });
     recoverBotSkillActivation(runtimeRoot, workspaceService, { lock: activationLock });
   } catch (error) {
     activationLock.release();
@@ -900,6 +907,7 @@ async function commitCatsBotBindingAndStartConnector(
   let restartPreviousConnectorAfterRelease = false;
   const initialMarkerPath = path.join(workspaceService.activePath, '.xiaoba-bot-workspace.json');
   const initialMarkerExisted = fs.existsSync(initialMarkerPath);
+  const initialActiveWorkspaceExisted = fs.existsSync(workspaceService.activePath);
   try {
     const warnings = await ensureCatsFriendBinding(state, input.userUid, input.botUid, input.apiKey);
     const preparedBot = await prepareBoundBotDefinition({
@@ -910,7 +918,7 @@ async function commitCatsBotBindingAndStartConnector(
     });
     const botDefinitionSync = toBotDefinitionSyncPayload(preparedBot?.sync);
     const allowCreateSkillWorkspace = input.allowCreateSkillWorkspace === true ||
-      (Array.isArray(preparedBot?.definition.skills) && preparedBot.definition.skills.length === 0);
+      Array.isArray(preparedBot?.definition.skills);
 
     const existingService = serviceManager.getService('catscompany');
     const targetPreflight = existingService
@@ -953,6 +961,18 @@ async function commitCatsBotBindingAndStartConnector(
         activationLock,
       }).scanManifest();
       assertBotSkillManifestReady(sourceManifest);
+      try {
+        await createBotSkillSyncService({
+          runtimeRoot,
+          expectedBotId: previousBotId,
+          workspaceService,
+          activationLock,
+        }).syncBeforeSwitch(previousBotId);
+      } catch (error) {
+        Logger.warning(
+          `旧 Bot Skill 上行同步暂未完成，保留本地工作区并继续切换: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
     } else {
       workspaceService.ensureActive(input.botUid, {
         allowCreate: allowCreateSkillWorkspace,
@@ -963,6 +983,9 @@ async function commitCatsBotBindingAndStartConnector(
 
     connectorWasRunning = existingService?.status === 'running';
     const currentWorkspaceOwner = workspaceService.readState()?.workspaceOwnerBotId;
+    const targetWorkspaceExisted = currentWorkspaceOwner === input.botUid
+      ? (initialClaimed ? initialActiveWorkspaceExisted : fs.existsSync(workspaceService.activePath))
+      : fs.existsSync(workspaceService.getParkedPath(input.botUid));
     if (currentWorkspaceOwner && currentWorkspaceOwner !== input.botUid) {
       switchTransactionId = crypto.randomUUID();
       persistBotSkillBindingRollback(runtimeRoot, switchTransactionId);
@@ -980,14 +1003,40 @@ async function commitCatsBotBindingAndStartConnector(
 
     const updated = writeCatsBotBinding(state, input);
     if (switchChanged || initialClaimed) {
-      const targetManifest = await createBotSkillService({
+      const targetBotSkills = createBotSkillService({
         runtimeRoot,
         expectedBotId: input.botUid,
         workspaceService,
         activationLock,
         activationTransactionId: switchTransactionId,
-      }).scanManifest();
+      });
+      const targetManifest = await targetBotSkills.scanManifest();
       assertBotSkillManifestReady(targetManifest);
+      if (preparedBot?.definition.skills === undefined) {
+        await bootstrapDefaultSkillHubSkillsOnce({
+          workspaceId: targetManifest.workspaceId,
+          service: new SkillHubService({ botSkillService: targetBotSkills }),
+        }).catch(error => {
+          Logger.warning(`Legacy default SkillHub bootstrap failed before migration: ${error?.message || String(error)}`);
+        });
+      }
+      try {
+        await createBotSkillSyncService({
+          runtimeRoot,
+          expectedBotId: input.botUid,
+          workspaceService,
+          activationLock,
+          activationTransactionId: switchTransactionId,
+        }).syncOnStartup(input.botUid, {
+          workspaceWasMissing: !targetWorkspaceExisted,
+        });
+      } catch (error) {
+        if (error instanceof BotSkillSyncError && error.safeToUseLocal) {
+          Logger.warning(`目标 Bot Skill 上行同步暂未完成，继续使用受保护的本地工作区: ${error.message}`);
+        } else {
+          throw error;
+        }
+      }
     }
     let service: any;
     let startPreflight = targetPreflight;
@@ -1047,21 +1096,6 @@ async function commitCatsBotBindingAndStartConnector(
         // snapshot is safe to remove during the next startup recovery.
       }
       bindingSnapshotPersisted = false;
-    }
-    if (switchChanged || initialClaimed) {
-      const activeState = workspaceService.readState();
-      const scopedBotSkills = createBotSkillService({
-        runtimeRoot,
-        expectedBotId: input.botUid,
-        workspaceService,
-        activationLock,
-      });
-      await bootstrapDefaultSkillHubSkillsOnce({
-        workspaceId: activeState?.workspaceId,
-        service: new SkillHubService({ botSkillService: scopedBotSkills }),
-      }).catch(error => {
-        Logger.warning(`Default SkillHub bootstrap failed after Bot activation: ${error?.message || String(error)}`);
-      });
     }
     return {
       updated,

--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -13,6 +13,12 @@ import { recoverBotSkillActivation } from '../bot-skills/activation-recovery';
 import * as fs from 'node:fs';
 import { FileBotDefinitionRepository } from '../bot-definition/repository';
 import { createBotSkillService } from '../bot-skills/service';
+import { BotSkillSyncError, createBotSkillSyncService } from '../bot-skills/sync-service';
+import { recoverBotSkillWorkspaceReconciles } from '../bot-skills/workspace-reconciler';
+import {
+  cancelPendingBotSkillSync,
+  flushBotSkillSyncQueue,
+} from '../bot-skills/sync-coordinator';
 
 const DEFAULT_PORT = 3800;
 const activeServers: Server[] = [];
@@ -52,9 +58,13 @@ export async function startDashboard(
   ) || fs.existsSync(
     path.join(runtimeRoot, 'data', 'bot-skills', 'binding-rollback.json'),
   );
-  let activeBotWorkspaceReady = false;
   if (initialBotId || workspaceMetadataExists) {
     const workspaceService = createBotSkillWorkspaceService({ runtimeRoot });
+    const definitions = new FileBotDefinitionRepository({ runtimeRoot });
+    recoverBotSkillWorkspaceReconciles({
+      runtimeRoot,
+      definitionRepository: definitions,
+    });
     recoverBotSkillActivation(runtimeRoot, workspaceService);
     const recoveredBotId = String(
       createCatsCoLocalConfigService({ runtimeRoot }).load().currentBot?.uid || '',
@@ -68,14 +78,13 @@ export async function startDashboard(
     if (hasLocalWorkspace) {
       workspaceService.ensureActive(recoveredBotId);
     } else {
-      const definitions = new FileBotDefinitionRepository({ runtimeRoot });
       const definition = definitions.readCache(recoveredBotId) ??
         definitions.readCanonical(recoveredBotId);
       workspaceService.ensureActive(recoveredBotId, {
-        allowCreate: Array.isArray(definition?.skills) && definition.skills.length === 0,
+        allowCreate: Array.isArray(definition?.skills),
       });
     }
-    const manifest = await createBotSkillService({ runtimeRoot }).scanManifest();
+    let manifest = await createBotSkillService({ runtimeRoot }).scanManifest();
     if (manifest.status === 'partial') {
       Logger.warning(
         `Active Bot Skill manifest is partial; Dashboard will start in degraded mode. ${formatManifestIssues(manifest.issues)}`,
@@ -83,17 +92,34 @@ export async function startDashboard(
     } else if (manifest.status !== 'complete') {
       throw new Error(`Active Bot Skill manifest is ${manifest.status}.`);
     } else {
-      activeBotWorkspaceReady = true;
+      const definitionBeforeSync = definitions.readCanonical(recoveredBotId);
+      if (definitionBeforeSync && definitionBeforeSync.skills === undefined) {
+        const workspaceId = workspaceService.readState()?.workspaceId;
+        await bootstrapDefaultSkillHubSkillsOnce({ workspaceId }).catch(error => {
+          Logger.warning(`Legacy default SkillHub bootstrap failed before migration: ${error?.message || String(error)}`);
+        });
+      }
+      try {
+        const synced = await createBotSkillSyncService({
+          runtimeRoot,
+          expectedBotId: recoveredBotId,
+          workspaceService,
+          definitionRepository: definitions,
+        }).syncOnStartup(recoveredBotId, {
+          workspaceWasMissing: !hasLocalWorkspace,
+        });
+        manifest = synced.manifest;
+      } catch (error) {
+        if (error instanceof BotSkillSyncError && error.safeToUseLocal) {
+          Logger.warning(`Bot Skill startup sync deferred; using protected Local state: ${error.message}`);
+        } else {
+          throw error;
+        }
+      }
     }
   }
 
-  if (activeBotWorkspaceReady) {
-    const workspaceId = createBotSkillWorkspaceService({ runtimeRoot })
-      .readState()?.workspaceId;
-    await bootstrapDefaultSkillHubSkillsOnce({ workspaceId }).catch(error => {
-      Logger.warning(`Default SkillHub bootstrap failed: ${error?.message || String(error)}`);
-    });
-  }
+  // Default bootstrap is migration-only once Definition.skills becomes authoritative.
 
   // Configure and apply dashboard authentication.
   // Trim the env var so whitespace-only values are treated as "not set"
@@ -145,6 +171,8 @@ export async function startDashboard(
   return {
     async stop(): Promise<void> {
       serviceManager.stopAll();
+      cancelPendingBotSkillSync(runtimeRoot);
+      await flushBotSkillSyncQueue(runtimeRoot);
       await Promise.all(activeServers.splice(0).map(closeServer));
     },
   };

--- a/src/runtime/runtime-factory.ts
+++ b/src/runtime/runtime-factory.ts
@@ -13,6 +13,7 @@ import {
   assertValidRuntimeProfile,
   resolveDefaultRuntimeProfile,
 } from './runtime-profile';
+import { scheduleActiveBotSkillSync } from '../bot-skills/sync-coordinator';
 
 export interface RuntimeSessionBundle {
   profile: RuntimeProfile;
@@ -86,6 +87,7 @@ export class RuntimeFactory {
         enabledToolNames: profile.tools.enabled,
       }),
       skillManager: new SkillManager(),
+      onTurnSettled: () => scheduleActiveBotSkillSync(),
     };
   }
 

--- a/src/skillhub/subscription-service.ts
+++ b/src/skillhub/subscription-service.ts
@@ -63,7 +63,10 @@ export class SkillHubSubscriptionService {
     }
 
     const userId = scope.userId;
-    const subscriptions = this.store.list(userId);
+    const subscriptions = mergeSubscriptions(
+      this.store.list(userId),
+      installedSubscriptionsVisibleToUser(userId),
+    );
     for (const subscription of subscriptions) {
       await this.gateway.claimInstalledSkillOwnership?.({
         userId,
@@ -78,7 +81,11 @@ export class SkillHubSubscriptionService {
     const scope = await this.gateway.resolveSubscriptionScope();
     const normalizedSkillId = required(skillId, 'skillId');
     const existing = scope.kind === 'user'
-      ? this.store.get(scope.userId, normalizedSkillId)
+      ? (
+        this.store.get(scope.userId, normalizedSkillId)
+        ?? installedSubscriptionsVisibleToUser(scope.userId)
+          .find(item => item.skillId === normalizedSkillId)
+      )
       : runtimeSubscriptions().find(item => item.skillId === normalizedSkillId);
     const installed = await this.gateway.install(normalizedSkillId, undefined, {
       allowUpdate: true,
@@ -104,7 +111,11 @@ export class SkillHubSubscriptionService {
     const scope = await this.gateway.resolveSubscriptionScope();
     const normalizedSkillId = required(skillId, 'skillId');
     const subscription = scope.kind === 'user'
-      ? this.store.get(scope.userId, normalizedSkillId)
+      ? (
+        this.store.get(scope.userId, normalizedSkillId)
+        ?? installedSubscriptionsVisibleToUser(scope.userId)
+          .find(item => item.skillId === normalizedSkillId)
+      )
       : runtimeSubscriptions().find(item => item.skillId === normalizedSkillId);
     if (!subscription) {
       return {
@@ -133,7 +144,19 @@ export class SkillHubSubscriptionService {
 }
 
 function runtimeSubscriptions(): UserSkillSubscription[] {
-  return listInstalledSkillHubSkills().map(marker => ({
+  return markersToSubscriptions(listInstalledSkillHubSkills());
+}
+
+function installedSubscriptionsVisibleToUser(userId: string): UserSkillSubscription[] {
+  return markersToSubscriptions(
+    listInstalledSkillHubSkills().filter(marker => !marker.userId || marker.userId === userId),
+  );
+}
+
+function markersToSubscriptions(
+  markers: ReturnType<typeof listInstalledSkillHubSkills>,
+): UserSkillSubscription[] {
+  return markers.map(marker => ({
     skillId: marker.skillId,
     name: marker.name,
     installName: marker.installName,
@@ -142,6 +165,23 @@ function runtimeSubscriptions(): UserSkillSubscription[] {
     subscribedAt: marker.installedAt,
     updatedAt: marker.installedAt,
   }));
+}
+
+function mergeSubscriptions(
+  stored: UserSkillSubscription[],
+  installed: UserSkillSubscription[],
+): UserSkillSubscription[] {
+  const merged = new Map(installed.map(item => [item.skillId, item]));
+  for (const item of stored) {
+    const active = merged.get(item.skillId);
+    merged.set(item.skillId, active
+      ? {
+        ...active,
+        subscribedAt: item.subscribedAt,
+      }
+      : item);
+  }
+  return [...merged.values()].sort((left, right) => left.skillId.localeCompare(right.skillId));
 }
 
 function scopeResult(scope: SkillHubSubscriptionScope): { scope: 'runtime' } | { scope: 'user'; userId: string } {

--- a/tests/bot-skill-sync.test.ts
+++ b/tests/bot-skill-sync.test.ts
@@ -1,0 +1,817 @@
+import assert from 'node:assert/strict';
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import { FileBotDefinitionRepository } from '../src/bot-definition/repository';
+import { createBotDefinitionSyncService } from '../src/bot-definition/service';
+import { BOT_DEFINITION_SCHEMA } from '../src/bot-definition/types';
+import { createBotSkillService } from '../src/bot-skills/service';
+import {
+  FileBotSkillSyncBaseRepository,
+  localProjectionDigest,
+  projectLocalManifest,
+} from '../src/bot-skills/sync-base';
+import {
+  FileSimulatedSkillArtifactStore,
+} from '../src/bot-skills/simulated-artifact-store';
+import {
+  BotSkillSyncError,
+  createBotSkillSyncService,
+} from '../src/bot-skills/sync-service';
+import {
+  flushBotSkillSyncQueue,
+  resetBotSkillSyncCoordinatorForTests,
+  scheduleBotSkillSync,
+  setBotSkillSyncRunnerForTests,
+} from '../src/bot-skills/sync-coordinator';
+import { createBotSkillWorkspaceService } from '../src/bot-skills/workspace-service';
+import {
+  BOT_SKILL_PULL_JOURNAL_SCHEMA,
+  recoverBotSkillWorkspaceReconciles,
+} from '../src/bot-skills/workspace-reconciler';
+import { scanLocalSkillManifest } from '../src/bot-skills/local-manifest';
+import { createCatsCoLocalConfigService } from '../src/catscompany/local-config';
+import { computeLocalSkillContentHash } from '../src/skillhub/local-skill-metadata';
+import { writeSkillHubInstallMarker } from '../src/skillhub/install-marker';
+
+describe('BotSkillSyncService', () => {
+  let root: string;
+  let runtimeRoot: string;
+  let cloudRoot: string;
+  let artifactRoot: string;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-bot-skill-sync-'));
+    runtimeRoot = path.join(root, 'runtime-a');
+    cloudRoot = path.join(root, 'simulated-cloud');
+    artifactRoot = path.join(cloudRoot, 'artifacts');
+    fs.mkdirSync(runtimeRoot, { recursive: true });
+  });
+
+  afterEach(() => {
+    resetBotSkillSyncCoordinatorForTests();
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('migrates a local Skill to a deterministic private artifact and advances Base last', async () => {
+    const fixture = createFixture(runtimeRoot, cloudRoot, artifactRoot, 'bot_A');
+    writeSkill(path.join(fixture.skillsRoot, 'notes'), 'notes', '# v1\n');
+
+    const first = await fixture.sync.syncOnStartup('bot_A');
+    const definition = fixture.definitions.readCanonical('bot_A');
+    const base = fixture.base.inspect('bot_A', fixture.workspaceId);
+
+    assert.equal(first.direction, 'local_to_cloud');
+    assert.equal(first.reason, 'legacy_migration');
+    assert.equal(definition?.skills?.length, 1);
+    assert.match(definition!.skills![0].skillId, /^sim-private:/);
+    assert.match(definition!.skills![0].version, /^content-[0-9a-f]{64}$/);
+    assert.equal(base.status, 'valid');
+    assert.equal(base.status === 'valid' && base.base.bindings[0].localSkillId,
+      first.manifest.entries[0].localSkillId);
+    assert.ok(fs.existsSync(fixture.artifacts.getPath(definition!.skills![0])));
+
+    const second = await fixture.sync.syncAfterTurn('bot_A');
+    assert.equal(second.direction, 'none');
+    assert.equal(second.reason, 'already_synced');
+    assert.deepEqual(second.definition.skills, definition?.skills);
+  });
+
+  test('uses the same private skillId and a new immutable version after local edits', async () => {
+    const fixture = createFixture(runtimeRoot, cloudRoot, artifactRoot, 'bot_A');
+    const skillFile = path.join(fixture.skillsRoot, 'notes', 'SKILL.md');
+    writeSkill(path.dirname(skillFile), 'notes', '# v1\n');
+    const first = await fixture.sync.syncOnStartup('bot_A');
+
+    fs.appendFileSync(skillFile, '\nlocal edit\n');
+    const second = await fixture.sync.syncAfterTurn('bot_A');
+
+    assert.equal(second.direction, 'local_to_cloud');
+    assert.equal(second.reason, 'local_changed');
+    assert.equal(second.definition.skills?.[0].skillId, first.definition.skills?.[0].skillId);
+    assert.notEqual(second.definition.skills?.[0].version, first.definition.skills?.[0].version);
+    assert.ok(fs.existsSync(fixture.artifacts.getPath(first.definition.skills![0])));
+    assert.ok(fs.existsSync(fixture.artifacts.getPath(second.definition.skills![0])));
+  });
+
+  test('keeps an unmodified public ref and forks local edits into a private ref', async () => {
+    const fixture = createFixture(runtimeRoot, cloudRoot, artifactRoot, 'bot_A');
+    const skillDir = path.join(fixture.skillsRoot, 'browser');
+    const skillFile = path.join(skillDir, 'SKILL.md');
+    writeSkill(skillDir, 'browser', '# public\n');
+    const installedContentHash = computeLocalSkillContentHash(skillDir);
+    writeSkillHubInstallMarker(skillDir, {
+      source: 'skillhub',
+      skillId: 'alice/browser',
+      name: 'browser',
+      installName: 'browser',
+      version: '1.0.3',
+      packageChecksumSha256: 'a'.repeat(64),
+      installedContentHash,
+      signature: {
+        algorithm: 'ed25519',
+        keyId: 'test-key',
+        signature: 'test-signature',
+        signedAt: '2026-01-01T00:00:00.000Z',
+      },
+      packageUrl: '/package',
+      installedAt: '2026-01-01T00:00:00.000Z',
+    });
+
+    const migrated = await fixture.sync.syncOnStartup('bot_A');
+    assert.deepEqual(migrated.definition.skills, [{
+      skillId: 'alice/browser',
+      version: '1.0.3',
+    }]);
+
+    fs.appendFileSync(skillFile, '\nlocal fork\n');
+    const forked = await fixture.sync.syncAfterTurn('bot_A');
+    assert.match(forked.definition.skills![0].skillId, /^sim-private:/);
+    assert.notEqual(forked.definition.skills![0].skillId, 'alice/browser');
+  });
+
+  test('restores a mirrored public Skill with a workspace-local identity', async () => {
+    const first = createFixture(runtimeRoot, cloudRoot, artifactRoot, 'bot_A');
+    const skillDir = path.join(first.skillsRoot, 'browser');
+    writeSkill(skillDir, 'browser', '# public\n');
+    const installedContentHash = computeLocalSkillContentHash(skillDir);
+    writeSkillHubInstallMarker(skillDir, publicMarker(installedContentHash));
+    const uploaded = await first.sync.syncOnStartup('bot_A');
+
+    const secondRuntime = path.join(root, 'runtime-public-b');
+    fs.mkdirSync(secondRuntime, { recursive: true });
+    const second = createFixture(secondRuntime, cloudRoot, artifactRoot, 'bot_A', {
+      canonicalAlreadyExists: true,
+    });
+    const restored = await second.sync.syncOnStartup('bot_A', {
+      workspaceWasMissing: true,
+    });
+
+    assert.deepEqual(restored.definition.skills, [{
+      skillId: 'alice/browser',
+      version: '1.0.3',
+    }]);
+    assert.equal(restored.manifest.entries[0].source, 'skillhub');
+    assert.notEqual(restored.manifest.entries[0].localSkillId, 'public');
+    assert.notEqual(
+      restored.manifest.entries[0].localSkillId,
+      uploaded.manifest.entries[0].localSkillId,
+    );
+  });
+
+  test('deduplicates one public version across install sessions and Bots', async () => {
+    const first = createFixture(runtimeRoot, cloudRoot, artifactRoot, 'bot_A');
+    const firstDir = path.join(first.skillsRoot, 'browser');
+    writeSkill(firstDir, 'browser', '# public\n');
+    const contentHash = computeLocalSkillContentHash(firstDir);
+    writeSkillHubInstallMarker(firstDir, {
+      ...publicMarker(contentHash),
+      userId: 'user-a',
+      packageUrl: '/session-a/package',
+      installedAt: '2026-01-02T00:00:00.000Z',
+    });
+    const uploadedA = await first.sync.syncOnStartup('bot_A');
+
+    const secondRuntime = path.join(root, 'runtime-public-other-bot');
+    fs.mkdirSync(secondRuntime, { recursive: true });
+    const second = createFixture(secondRuntime, cloudRoot, artifactRoot, 'bot_B');
+    const secondDir = path.join(second.skillsRoot, 'browser');
+    writeSkill(secondDir, 'browser', '# public\n');
+    writeSkillHubInstallMarker(secondDir, {
+      ...publicMarker(computeLocalSkillContentHash(secondDir)),
+      userId: 'user-b',
+      packageUrl: '/session-b/package',
+      installedAt: '2026-02-03T00:00:00.000Z',
+    });
+    const uploadedB = await second.sync.syncOnStartup('bot_B');
+
+    assert.deepEqual(uploadedB.definition.skills, uploadedA.definition.skills);
+    assert.equal(
+      second.artifacts.getPath(uploadedB.definition.skills![0]),
+      first.artifacts.getPath(uploadedA.definition.skills![0]),
+    );
+  });
+
+  test('pulls a Cloud-only version when Local still equals Base', async () => {
+    const fixture = createFixture(runtimeRoot, cloudRoot, artifactRoot, 'bot_A');
+    const skillFile = path.join(fixture.skillsRoot, 'notes', 'SKILL.md');
+    writeSkill(path.dirname(skillFile), 'notes', '# v1\n');
+    const first = await fixture.sync.syncOnStartup('bot_A');
+    const v1 = fs.readFileSync(skillFile, 'utf8');
+
+    fs.writeFileSync(skillFile, v1.replace('# v1', '# v2'));
+    const changed = await fixture.botSkills.scanManifest();
+    const v2Artifact = fixture.artifacts.put({
+      botId: 'bot_A',
+      skillsRoot: fixture.skillsRoot,
+      entry: changed.entries[0],
+    });
+    fs.writeFileSync(skillFile, v1);
+    fixture.definitionService.updateSkills('bot_A', [v2Artifact.ref]);
+
+    const pulled = await fixture.sync.syncOnStartup('bot_A');
+
+    assert.equal(pulled.direction, 'cloud_to_local');
+    assert.equal(pulled.reason, 'cloud_changed');
+    assert.match(fs.readFileSync(skillFile, 'utf8'), /# v2/);
+    assert.equal(pulled.manifest.entries[0].localSkillId, first.manifest.entries[0].localSkillId);
+    assert.deepEqual(pulled.definition.skills, [v2Artifact.ref]);
+  });
+
+  test('protects Local when both Local and Cloud changed from Base', async () => {
+    const fixture = createFixture(runtimeRoot, cloudRoot, artifactRoot, 'bot_A');
+    const skillFile = path.join(fixture.skillsRoot, 'notes', 'SKILL.md');
+    writeSkill(path.dirname(skillFile), 'notes', '# v1\n');
+    await fixture.sync.syncOnStartup('bot_A');
+
+    const original = fs.readFileSync(skillFile, 'utf8');
+    fs.writeFileSync(skillFile, original.replace('# v1', '# cloud'));
+    const cloudManifest = await fixture.botSkills.scanManifest();
+    const cloudArtifact = fixture.artifacts.put({
+      botId: 'bot_A',
+      skillsRoot: fixture.skillsRoot,
+      entry: cloudManifest.entries[0],
+    });
+    fixture.definitionService.updateSkills('bot_A', [cloudArtifact.ref]);
+    fs.writeFileSync(skillFile, original.replace('# v1', '# local'));
+
+    const result = await fixture.sync.syncAfterTurn('bot_A');
+
+    assert.equal(result.direction, 'local_to_cloud');
+    assert.match(fs.readFileSync(skillFile, 'utf8'), /# local/);
+    assert.notDeepEqual(result.definition.skills, [cloudArtifact.ref]);
+  });
+
+  test('keeps disabled content locally while removing it from Cloud active refs', async () => {
+    const fixture = createFixture(runtimeRoot, cloudRoot, artifactRoot, 'bot_A');
+    writeSkill(path.join(fixture.skillsRoot, 'notes'), 'notes', '# v1\n');
+    await fixture.sync.syncOnStartup('bot_A');
+
+    await fixture.botSkills.setEnabledByName('notes', false);
+    const result = await fixture.sync.syncAfterTurn('bot_A');
+    const base = fixture.base.inspect('bot_A', fixture.workspaceId);
+
+    assert.deepEqual(result.definition.skills, []);
+    assert.equal(result.manifest.entries[0].enabled, false);
+    assert.equal(base.status, 'valid');
+    assert.equal(base.status === 'valid' && base.base.bindings.length, 1);
+    assert.ok(fs.existsSync(path.join(fixture.skillsRoot, 'notes', 'SKILL.md.disabled')));
+    assert.equal((await fixture.sync.syncAfterTurn('bot_A')).direction, 'none');
+  });
+
+  test('restores a missing workspace on a second device from canonical and artifacts', async () => {
+    const first = createFixture(runtimeRoot, cloudRoot, artifactRoot, 'bot_A');
+    writeSkill(path.join(first.skillsRoot, 'notes'), 'notes', '# portable\n');
+    const uploaded = await first.sync.syncOnStartup('bot_A');
+
+    const secondRuntime = path.join(root, 'runtime-b');
+    fs.mkdirSync(secondRuntime, { recursive: true });
+    const second = createFixture(secondRuntime, cloudRoot, artifactRoot, 'bot_A', {
+      canonicalAlreadyExists: true,
+    });
+    const restored = await second.sync.syncOnStartup('bot_A', {
+      workspaceWasMissing: true,
+    });
+
+    assert.equal(restored.direction, 'cloud_to_local');
+    assert.equal(restored.reason, 'workspace_restore');
+    assert.match(
+      fs.readFileSync(path.join(second.skillsRoot, 'notes', 'SKILL.md'), 'utf8'),
+      /# portable/,
+    );
+    assert.equal(restored.manifest.entries[0].localSkillId, uploaded.manifest.entries[0].localSkillId);
+  });
+
+  test('derives the default artifact repository from the shared simulated cloud root', async () => {
+    const first = createFixture(runtimeRoot, cloudRoot, artifactRoot, 'bot_A', {
+      useServiceDefaultArtifactStore: true,
+    });
+    writeSkill(path.join(first.skillsRoot, 'notes'), 'notes', '# shared default root\n');
+    await first.sync.syncOnStartup('bot_A');
+
+    const secondRuntime = path.join(root, 'runtime-default-artifact-b');
+    fs.mkdirSync(secondRuntime, { recursive: true });
+    const second = createFixture(secondRuntime, cloudRoot, artifactRoot, 'bot_A', {
+      canonicalAlreadyExists: true,
+      useServiceDefaultArtifactStore: true,
+    });
+    const restored = await second.sync.syncOnStartup('bot_A', {
+      workspaceWasMissing: true,
+    });
+
+    assert.equal(restored.direction, 'cloud_to_local');
+    assert.match(
+      fs.readFileSync(path.join(second.skillsRoot, 'notes', 'SKILL.md'), 'utf8'),
+      /shared default root/,
+    );
+    assert.equal(
+      first.artifacts.root,
+      path.join(path.resolve(cloudRoot), 'skill-artifacts'),
+    );
+    assert.equal(second.artifacts.root, first.artifacts.root);
+  });
+
+  test('keeps retrying an unfinished empty-workspace restore after process restart', async () => {
+    const first = createFixture(runtimeRoot, cloudRoot, artifactRoot, 'bot_A');
+    writeSkill(path.join(first.skillsRoot, 'notes'), 'notes', '# recover after restart\n');
+    const uploaded = await first.sync.syncOnStartup('bot_A');
+    const artifactPath = first.artifacts.getPath(uploaded.definition.skills![0]);
+    const unavailablePath = `${artifactPath}.offline`;
+    fs.renameSync(artifactPath, unavailablePath);
+
+    const secondRuntime = path.join(root, 'runtime-retry-b');
+    fs.mkdirSync(secondRuntime, { recursive: true });
+    const second = createFixture(secondRuntime, cloudRoot, artifactRoot, 'bot_A', {
+      canonicalAlreadyExists: true,
+    });
+    await assert.rejects(
+      () => second.sync.syncOnStartup('bot_A', { workspaceWasMissing: true }),
+      (error: any) => error?.code === 'BOT_SKILL_PULL_FAILED' && !error.safeToUseLocal,
+    );
+    assert.equal((await second.botSkills.scanManifest()).entries.length, 0);
+    fs.renameSync(unavailablePath, artifactPath);
+
+    const restartedSync = createBotSkillSyncService({
+      runtimeRoot: secondRuntime,
+      expectedBotId: 'bot_A',
+      workspaceService: second.workspace,
+      definitionRepository: second.definitions,
+      definitionService: second.definitionService,
+      baseRepository: second.base,
+      artifactStore: second.artifacts,
+    });
+    const retried = await restartedSync.syncOnStartup('bot_A');
+
+    assert.equal(retried.direction, 'cloud_to_local');
+    assert.match(
+      fs.readFileSync(path.join(second.skillsRoot, 'notes', 'SKILL.md'), 'utf8'),
+      /recover after restart/,
+    );
+    assert.deepEqual(second.definitions.readCanonical('bot_A')?.skills, uploaded.definition.skills);
+  });
+
+  test('does not treat an invalid Base or canonical record as an empty state', async () => {
+    const fixture = createFixture(runtimeRoot, cloudRoot, artifactRoot, 'bot_A');
+    writeSkill(path.join(fixture.skillsRoot, 'notes'), 'notes', '# v1\n');
+    await fixture.sync.syncOnStartup('bot_A');
+    const canonicalBefore = fs.readFileSync(
+      fixture.definitions.getCanonicalPath('bot_A'),
+      'utf8',
+    );
+    fs.writeFileSync(fixture.base.getPath('bot_A', fixture.workspaceId), '{"broken":true}');
+    fs.appendFileSync(path.join(fixture.skillsRoot, 'notes', 'SKILL.md'), '\nlocal\n');
+
+    await assert.rejects(
+      () => fixture.sync.syncAfterTurn('bot_A'),
+      (error: any) => (
+        error instanceof BotSkillSyncError
+        && error.code === 'BOT_SKILL_SYNC_BASE_INVALID'
+        && error.safeToUseLocal
+      ),
+    );
+    assert.equal(
+      fs.readFileSync(fixture.definitions.getCanonicalPath('bot_A'), 'utf8'),
+      canonicalBefore,
+    );
+  });
+
+  test('rejects a structurally valid-looking Base when its artifact bindings were tampered', async () => {
+    const fixture = createFixture(runtimeRoot, cloudRoot, artifactRoot, 'bot_A');
+    writeSkill(path.join(fixture.skillsRoot, 'notes'), 'notes', '# v1\n');
+    await fixture.sync.syncOnStartup('bot_A');
+    const basePath = fixture.base.getPath('bot_A', fixture.workspaceId);
+    const tampered = JSON.parse(fs.readFileSync(basePath, 'utf8'));
+    tampered.bindings[0].artifactDigest = 'e'.repeat(64);
+    fs.writeFileSync(basePath, `${JSON.stringify(tampered, null, 2)}\n`);
+
+    const inspected = fixture.base.inspect('bot_A', fixture.workspaceId);
+
+    assert.equal(inspected.status, 'invalid');
+    await assert.rejects(
+      () => fixture.sync.syncOnStartup('bot_A'),
+      (error: any) => error?.code === 'BOT_SKILL_SYNC_BASE_INVALID',
+    );
+  });
+
+  test('fails closed on an invalid canonical record even when cache and Local are valid', async () => {
+    const fixture = createFixture(runtimeRoot, cloudRoot, artifactRoot, 'bot_A');
+    const skillFile = path.join(fixture.skillsRoot, 'notes', 'SKILL.md');
+    writeSkill(path.dirname(skillFile), 'notes', '# v1\n');
+    await fixture.sync.syncOnStartup('bot_A');
+    fs.writeFileSync(
+      fixture.definitions.getCanonicalPath('bot_A'),
+      '{"schema":"xiaoba.bot-definition.v1","broken":true}',
+    );
+    fs.appendFileSync(skillFile, '\nprotected local edit\n');
+
+    await assert.rejects(
+      () => fixture.sync.syncAfterTurn('bot_A'),
+      (error: any) => (
+        error instanceof BotSkillSyncError
+        && error.code === 'BOT_SKILL_CLOUD_INVALID'
+        && error.safeToUseLocal
+      ),
+    );
+    assert.equal(
+      fs.readFileSync(fixture.definitions.getCanonicalPath('bot_A'), 'utf8'),
+      '{"schema":"xiaoba.bot-definition.v1","broken":true}',
+    );
+    assert.match(fs.readFileSync(skillFile, 'utf8'), /protected local edit/);
+  });
+
+  test('leaves Local and Base unchanged when a Cloud artifact is unavailable', async () => {
+    const fixture = createFixture(runtimeRoot, cloudRoot, artifactRoot, 'bot_A');
+    const skillFile = path.join(fixture.skillsRoot, 'notes', 'SKILL.md');
+    writeSkill(path.dirname(skillFile), 'notes', '# v1\n');
+    const first = await fixture.sync.syncOnStartup('bot_A');
+    const baseBefore = fixture.base.inspect('bot_A', fixture.workspaceId);
+    fixture.definitionService.updateSkills('bot_A', [{
+      skillId: 'sim-private:missing',
+      version: `content-${'f'.repeat(64)}`,
+    }]);
+
+    await assert.rejects(
+      () => fixture.sync.syncOnStartup('bot_A'),
+      (error: any) => (
+        error?.code === 'BOT_SKILL_PULL_FAILED'
+        && error.safeToUseLocal === false
+        && /artifact is missing/.test(error.message)
+      ),
+    );
+    assert.match(fs.readFileSync(skillFile, 'utf8'), /# v1/);
+    assert.deepEqual(fixture.base.inspect('bot_A', fixture.workspaceId), baseBefore);
+    assert.deepEqual(projectLocalManifest(await fixture.botSkills.scanManifest()), first.base.local.entries);
+  });
+
+  test('syncs deletion as a Definition ref removal without deleting immutable history', async () => {
+    const fixture = createFixture(runtimeRoot, cloudRoot, artifactRoot, 'bot_A');
+    writeSkill(path.join(fixture.skillsRoot, 'notes'), 'notes', '# v1\n');
+    const first = await fixture.sync.syncOnStartup('bot_A');
+    const oldRef = first.definition.skills![0];
+    const oldArtifact = fixture.artifacts.getPath(oldRef);
+    fs.rmSync(path.join(fixture.skillsRoot, 'notes'), { recursive: true, force: true });
+
+    const removed = await fixture.sync.syncAfterTurn('bot_A');
+
+    assert.deepEqual(removed.definition.skills, []);
+    assert.deepEqual(removed.base.local.entries, []);
+    assert.ok(fs.existsSync(oldArtifact));
+  });
+
+  test('never turns a partial Local manifest into Cloud deletion', async () => {
+    const fixture = createFixture(runtimeRoot, cloudRoot, artifactRoot, 'bot_A');
+    const source = path.join(fixture.skillsRoot, 'notes');
+    writeSkill(source, 'notes', '# v1\n');
+    await fixture.sync.syncOnStartup('bot_A');
+    const canonicalBefore = fs.readFileSync(
+      fixture.definitions.getCanonicalPath('bot_A'),
+      'utf8',
+    );
+    fs.cpSync(source, path.join(fixture.skillsRoot, 'copied-notes'), { recursive: true });
+
+    await assert.rejects(
+      () => fixture.sync.syncAfterTurn('bot_A'),
+      (error: any) => (
+        error?.code === 'LOCAL_SKILL_MANIFEST_INCOMPLETE'
+        || error?.code === 'BOT_SKILL_LOCAL_INCOMPLETE'
+      ),
+    );
+    assert.equal(
+      fs.readFileSync(fixture.definitions.getCanonicalPath('bot_A'), 'utf8'),
+      canonicalBefore,
+    );
+  });
+
+  test('reports upload failure as locally usable and leaves Base behind for retry', async () => {
+    const fixture = createFixture(runtimeRoot, cloudRoot, artifactRoot, 'bot_A');
+    const skillFile = path.join(fixture.skillsRoot, 'notes', 'SKILL.md');
+    writeSkill(path.dirname(skillFile), 'notes', '# v1\n');
+    await fixture.sync.syncOnStartup('bot_A');
+    const baseBefore = fixture.base.inspect('bot_A', fixture.workspaceId);
+    const canonicalBefore = fixture.definitions.readCanonical('bot_A');
+    fs.appendFileSync(skillFile, '\nlocal pending edit\n');
+    const originalUpdate = fixture.definitionService.updateSkills.bind(fixture.definitionService);
+    (fixture.definitionService as any).updateSkills = () => {
+      throw new Error('simulated cloud write failure');
+    };
+
+    await assert.rejects(
+      () => fixture.sync.syncAfterTurn('bot_A'),
+      (error: any) => (
+        error?.code === 'BOT_SKILL_PUSH_FAILED'
+        && error.safeToUseLocal === true
+      ),
+    );
+    (fixture.definitionService as any).updateSkills = originalUpdate;
+
+    assert.match(fs.readFileSync(skillFile, 'utf8'), /local pending edit/);
+    assert.deepEqual(fixture.base.inspect('bot_A', fixture.workspaceId), baseBefore);
+    assert.deepEqual(fixture.definitions.readCanonical('bot_A'), canonicalBefore);
+  });
+
+  test('rolls back a target-active pull failure without changing Base', async () => {
+    const fixture = createFixture(runtimeRoot, cloudRoot, artifactRoot, 'bot_A');
+    const skillFile = path.join(fixture.skillsRoot, 'notes', 'SKILL.md');
+    writeSkill(path.dirname(skillFile), 'notes', '# v1\n');
+    const first = await fixture.sync.syncOnStartup('bot_A');
+    const baseBefore = fixture.base.inspect('bot_A', fixture.workspaceId);
+    const v1 = fs.readFileSync(skillFile, 'utf8');
+
+    fs.writeFileSync(skillFile, v1.replace('# v1', '# v2'));
+    const changed = await fixture.botSkills.scanManifest();
+    const v2Artifact = fixture.artifacts.put({
+      botId: 'bot_A',
+      skillsRoot: fixture.skillsRoot,
+      entry: changed.entries[0],
+    });
+    fs.writeFileSync(skillFile, v1);
+    fixture.definitionService.updateSkills('bot_A', [v2Artifact.ref]);
+    const crashingSync = createBotSkillSyncService({
+      runtimeRoot,
+      expectedBotId: 'bot_A',
+      workspaceService: fixture.workspace,
+      definitionRepository: fixture.definitions,
+      definitionService: fixture.definitionService,
+      baseRepository: fixture.base,
+      artifactStore: fixture.artifacts,
+      onPullPhasePersisted(phase) {
+        if (phase === 'target-active') throw new Error('simulated crash');
+      },
+    });
+
+    await assert.rejects(() => crashingSync.syncOnStartup('bot_A'), /simulated crash/);
+
+    assert.equal(fs.readFileSync(skillFile, 'utf8'), v1);
+    assert.deepEqual(fixture.base.inspect('bot_A', fixture.workspaceId), baseBefore);
+    assert.deepEqual(
+      projectLocalManifest(await fixture.botSkills.scanManifest()),
+      first.base.local.entries,
+    );
+  });
+
+  test('recovers both rename-before-journal crash windows without losing Local', async () => {
+    const fixture = createFixture(runtimeRoot, cloudRoot, artifactRoot, 'bot_A');
+    const skillFile = path.join(fixture.skillsRoot, 'notes', 'SKILL.md');
+    writeSkill(path.dirname(skillFile), 'notes', '# old\n');
+    const synced = await fixture.sync.syncOnStartup('bot_A');
+    const oldContent = fs.readFileSync(skillFile, 'utf8');
+    const oldDigest = synced.base.local.digest;
+
+    for (const crashWindow of ['after-source-rename', 'after-target-rename'] as const) {
+      const operationDir = createCrashWindowOperation({
+        runtimeRoot,
+        fixture,
+        oldDigest,
+        crashWindow,
+      });
+
+      recoverBotSkillWorkspaceReconciles({
+        runtimeRoot,
+        definitionRepository: fixture.definitions,
+        baseRepository: fixture.base,
+      });
+
+      assert.equal(fs.readFileSync(skillFile, 'utf8'), oldContent);
+      assert.equal(fs.existsSync(operationDir), false);
+      assert.equal(
+        (await fixture.botSkills.scanManifest()).entries[0].contentHash,
+        synced.manifest.entries[0].contentHash,
+      );
+    }
+  });
+
+  test('coalesces repeated background triggers and keeps one trailing rerun', async () => {
+    let calls = 0;
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>(resolve => {
+      releaseFirst = resolve;
+    });
+    setBotSkillSyncRunnerForTests(async () => {
+      calls += 1;
+      if (calls === 1) await firstGate;
+    });
+    const request = {
+      runtimeRoot,
+      botId: 'bot_A',
+      workspaceId: 'workspace_A',
+    };
+    scheduleBotSkillSync(request);
+    await new Promise(resolve => setTimeout(resolve, 15));
+    assert.equal(calls, 1);
+    for (let index = 0; index < 100; index += 1) scheduleBotSkillSync(request);
+    releaseFirst();
+    await flushBotSkillSyncQueue();
+
+    assert.equal(calls, 2);
+  });
+
+  test('does not hot-loop failed background sync and retries on the next trigger', async () => {
+    let calls = 0;
+    setBotSkillSyncRunnerForTests(async () => {
+      calls += 1;
+      throw new Error('offline');
+    });
+    const request = {
+      runtimeRoot,
+      botId: 'bot_A',
+      workspaceId: 'workspace_A',
+    };
+    scheduleBotSkillSync(request);
+    await flushBotSkillSyncQueue();
+    assert.equal(calls, 1);
+
+    scheduleBotSkillSync(request);
+    await flushBotSkillSyncQueue();
+    assert.equal(calls, 2);
+  });
+
+  test('schedules managed BotSkillService mutations with the captured workspace identity', async () => {
+    const fixture = createFixture(runtimeRoot, cloudRoot, artifactRoot, 'bot_A');
+    writeSkill(path.join(fixture.skillsRoot, 'notes'), 'notes', '# v1\n');
+    await fixture.sync.syncOnStartup('bot_A');
+    let captured: any;
+    setBotSkillSyncRunnerForTests(async request => {
+      captured = request;
+    });
+
+    await fixture.botSkills.setEnabledByName('notes', false);
+    await flushBotSkillSyncQueue();
+
+    assert.equal(captured.botId, 'bot_A');
+    assert.equal(captured.workspaceId, fixture.workspaceId);
+    assert.equal(captured.runtimeRoot, path.resolve(runtimeRoot));
+  });
+});
+
+function createFixture(
+  runtimeRoot: string,
+  cloudRoot: string,
+  artifactRoot: string,
+  botId: string,
+  options: {
+    canonicalAlreadyExists?: boolean;
+    useServiceDefaultArtifactStore?: boolean;
+  } = {},
+) {
+  const localConfig = createCatsCoLocalConfigService({ runtimeRoot });
+  localConfig.save(botConfig(botId));
+  const workspace = createBotSkillWorkspaceService({ runtimeRoot });
+  const state = workspace.ensureActive(botId, { allowCreate: true });
+  const definitions = new FileBotDefinitionRepository({
+    runtimeRoot,
+    simulatedCloudRoot: cloudRoot,
+  });
+  if (!options.canonicalAlreadyExists) {
+    definitions.writeCanonical({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId,
+      model: { kind: 'catalog', modelId: 'test-model' },
+    });
+  }
+  const definitionService = createBotDefinitionSyncService({
+    runtimeRoot,
+    simulatedCloudRoot: cloudRoot,
+    repository: definitions,
+  });
+  const base = new FileBotSkillSyncBaseRepository({ runtimeRoot });
+  const artifacts = new FileSimulatedSkillArtifactStore({
+    runtimeRoot,
+    ...(options.useServiceDefaultArtifactStore
+      ? { simulatedCloudRoot: cloudRoot }
+      : { root: artifactRoot }),
+  });
+  const botSkills = createBotSkillService({
+    runtimeRoot,
+    expectedBotId: botId,
+    workspaceService: workspace,
+  });
+  const sync = createBotSkillSyncService(options.useServiceDefaultArtifactStore
+    ? {
+      runtimeRoot,
+      expectedBotId: botId,
+      workspaceService: workspace,
+      simulatedCloudRoot: cloudRoot,
+      baseRepository: base,
+    }
+    : {
+      runtimeRoot,
+      expectedBotId: botId,
+      workspaceService: workspace,
+      definitionRepository: definitions,
+      definitionService,
+      baseRepository: base,
+      artifactStore: artifacts,
+    });
+  return {
+    skillsRoot: path.join(runtimeRoot, 'skills'),
+    workspaceId: state.workspaceId,
+    workspace,
+    definitions,
+    definitionService,
+    base,
+    artifacts,
+    botSkills,
+    sync,
+  };
+}
+
+function writeSkill(directory: string, name: string, body: string): void {
+  fs.mkdirSync(directory, { recursive: true });
+  fs.writeFileSync(path.join(directory, 'SKILL.md'), [
+    '---',
+    `name: ${name}`,
+    `description: ${name} description`,
+    '---',
+    '',
+    body,
+  ].join('\n'));
+}
+
+function createCrashWindowOperation(options: {
+  runtimeRoot: string;
+  fixture: ReturnType<typeof createFixture>;
+  oldDigest: string;
+  crashWindow: 'after-source-rename' | 'after-target-rename';
+}): string {
+  const workspaceScope = crypto.createHash('sha256')
+    .update(options.fixture.workspaceId, 'utf8')
+    .digest('hex');
+  const operationDir = path.join(
+    options.runtimeRoot,
+    'data',
+    'bot-skills',
+    'sync-operations',
+    `w_${workspaceScope}`,
+    `pull-crash-${options.crashWindow}-${crypto.randomUUID()}`,
+  );
+  const stagedRoot = path.join(operationDir, 'staged');
+  const backupRoot = path.join(operationDir, 'backup');
+  fs.mkdirSync(operationDir, { recursive: true });
+  fs.cpSync(options.fixture.skillsRoot, stagedRoot, { recursive: true });
+  const stagedSkill = path.join(stagedRoot, 'notes', 'SKILL.md');
+  fs.writeFileSync(stagedSkill, fs.readFileSync(stagedSkill, 'utf8').replace('# old', '# target'));
+  const targetManifest = scanLocalSkillManifest({
+    skillsRoot: stagedRoot,
+    botId: 'bot_A',
+    workspaceId: options.fixture.workspaceId,
+    createIdentities: false,
+  });
+  assert.equal(targetManifest.status, 'complete');
+  const targetDigest = localProjectionDigest(projectLocalManifest(targetManifest));
+  const journal = {
+    schema: BOT_SKILL_PULL_JOURNAL_SCHEMA,
+    transactionId: crypto.randomUUID(),
+    botId: 'bot_A',
+    workspaceId: options.fixture.workspaceId,
+    phase: options.crashWindow === 'after-source-rename' ? 'prepared' : 'source-backed-up',
+    oldLocalDigest: options.oldDigest,
+    targetLocalDigest: targetDigest,
+    targetCloudDigest: 'f'.repeat(64),
+    startedAt: new Date().toISOString(),
+  };
+  fs.writeFileSync(path.join(operationDir, 'journal.json'), `${JSON.stringify(journal)}\n`);
+  fs.renameSync(options.fixture.skillsRoot, backupRoot);
+  if (options.crashWindow === 'after-target-rename') {
+    fs.renameSync(stagedRoot, options.fixture.skillsRoot);
+  }
+  return operationDir;
+}
+
+function publicMarker(installedContentHash: string) {
+  return {
+    source: 'skillhub' as const,
+    skillId: 'alice/browser',
+    name: 'browser',
+    installName: 'browser',
+    version: '1.0.3',
+    packageChecksumSha256: 'a'.repeat(64),
+    installedContentHash,
+    signature: {
+      algorithm: 'ed25519' as const,
+      keyId: 'test-key',
+      signature: 'test-signature',
+      signedAt: '2026-01-01T00:00:00.000Z',
+    },
+    packageUrl: '/package',
+    installedAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+function botConfig(botId: string) {
+  return {
+    version: 1 as const,
+    currentBot: {
+      uid: botId,
+      apiKey: `key-${botId}`,
+      boundByUserUid: 'user-1',
+      bindingSource: 'test',
+    },
+    device: {
+      deviceId: 'device-1',
+      bodyId: 'device-1',
+      installationId: 'device-1',
+    },
+  };
+}

--- a/tests/dashboard-catsco-auth-status.test.ts
+++ b/tests/dashboard-catsco-auth-status.test.ts
@@ -13,6 +13,7 @@ import { createBotDefinitionSyncService } from '../src/bot-definition/service';
 import { resolveActiveBotLLMConfig } from '../src/bot-definition/llm-config-resolver';
 import { BOT_CATALOG_MODEL_RUNTIME_SCHEMA, BOT_DEFINITION_SCHEMA } from '../src/bot-definition/types';
 import { BotSkillWorkspaceService } from '../src/bot-skills/workspace-service';
+import { FileBotSkillSyncBaseRepository } from '../src/bot-skills/sync-base';
 
 describe('dashboard CatsCo account status', () => {
   let testRoot: string;
@@ -1116,7 +1117,7 @@ describe('dashboard CatsCo account status', () => {
     fs.mkdirSync(activeSkill, { recursive: true });
     fs.writeFileSync(path.join(activeSkill, 'SKILL.md'), offlineSkillContent);
     const workspace = new BotSkillWorkspaceService({ runtimeRoot: testRoot, env: {} });
-    workspace.ensureActive('188');
+    const sourceWorkspaceId = workspace.ensureActive('188').workspaceId;
 
     const definitions = new FileBotDefinitionRepository({ runtimeRoot: testRoot });
     definitions.writeCanonical({
@@ -1200,6 +1201,17 @@ describe('dashboard CatsCo account status', () => {
     assert.equal(
       fs.readFileSync(path.join(workspace.getParkedPath('188'), 'same-name', 'SKILL.md'), 'utf8'),
       offlineSkillContent,
+    );
+    assert.equal(definitions.readCanonical('188')?.skills?.length, 1);
+    assert.equal(
+      new FileBotSkillSyncBaseRepository({ runtimeRoot: testRoot })
+        .inspect('188', sourceWorkspaceId).status,
+      'valid',
+    );
+    assert.equal(
+      new FileBotSkillSyncBaseRepository({ runtimeRoot: testRoot })
+        .inspect('199', workspace.readState()!.workspaceId).status,
+      'valid',
     );
     assert.equal(stopCalled, 2);
     assert.equal(readyStartCalled, 2);

--- a/tests/dashboard-skillhub-connected-api.test.ts
+++ b/tests/dashboard-skillhub-connected-api.test.ts
@@ -9,6 +9,10 @@ import type { Server } from 'http';
 import { createApiRouter } from '../src/dashboard/routes/api';
 import { createCatsCoLocalConfigService } from '../src/catscompany/local-config';
 import { BotSkillWorkspaceService } from '../src/bot-skills/workspace-service';
+import {
+  cancelPendingBotSkillSync,
+  flushBotSkillSyncQueue,
+} from '../src/bot-skills/sync-coordinator';
 import { loadSkillHubConfig } from '../src/skillhub/config';
 import { CATSCO_SKILLHUB_ROOT_PUBLIC_KEYS, SkillHubTrustedRootKey } from '../src/skillhub/trusted-keys';
 
@@ -52,6 +56,8 @@ describe('dashboard connected SkillHub API', () => {
       await close(maliciousServer);
       maliciousServer = undefined;
     }
+    cancelPendingBotSkillSync(testRoot);
+    await flushBotSkillSyncQueue(testRoot);
     process.chdir(originalCwd);
     if (originalEnv === undefined) delete process.env.CATSCO_SKILLHUB_BASE_URL;
     else process.env.CATSCO_SKILLHUB_BASE_URL = originalEnv;

--- a/tests/skillhub-subscription.test.ts
+++ b/tests/skillhub-subscription.test.ts
@@ -205,6 +205,31 @@ describe('SkillHub user subscriptions', () => {
     assert.deepEqual(store.list('user-a'), []);
   });
 
+  test('uses restored install markers when the legacy user subscription store is empty', async () => {
+    installVerifiedSkillHubPackage(
+      packageOptions('alice/ppt', 'ppt', '1.0.0', '# restored', undefined),
+    );
+    const store = new LocalUserSkillSubscriptionStore(path.join(testRoot, 'subscriptions.json'));
+    const gateway = {
+      resolveSubscriptionScope: async () => ({ kind: 'user' as const, userId: 'user-a' }),
+      install: async () => installResult('alice/ppt', '1.0.0', 'unchanged'),
+      uninstall: (input: { userId?: string; skillId: string; installName: string }) => (
+        uninstallSkillHubPackage(input)
+      ),
+      claimInstalledSkillOwnership: async input => claimSkillHubPackageOwnership(input),
+    };
+    const service = new SkillHubSubscriptionService(gateway, store);
+
+    const listed = await service.list();
+    const removed = await service.unsubscribe('alice/ppt');
+
+    assert.deepEqual(listed.subscriptions.map(item => item.skillId), ['alice/ppt']);
+    assert.equal(removed.subscriptionFound, true);
+    assert.equal(removed.removed, true);
+    assert.equal(fs.existsSync(path.join(testRoot, 'skills', 'ppt')), false);
+    assert.deepEqual(store.list('user-a'), []);
+  });
+
   test('runtime scope installs, lists, and removes Skills using only install markers', async () => {
     const storePath = path.join(testRoot, 'subscriptions.json');
     const store = new LocalUserSkillSubscriptionStore(storePath);


### PR DESCRIPTION
## 为什么要做

PR1～PR3 已经补齐 Bot Definition 的 Skill 精确引用、每 Bot 本地工作区以及统一的本地 Skill 管理入口，但 Local、Base、Cloud 三个状态之间还没有形成真正可执行的同步闭环。

这会直接影响以下场景：

- 小八离线期间用户修改本地 Skills，重新上线后需要把离线修改同步回原工作区所属 Bot；
- 新设备或本地工作区丢失时，需要根据 Bot Definition 恢复 Skills；
- Bot 切换时，必须先保护旧 Bot 的本地修改，再完成目标 Bot 的恢复，不能让 Connector 使用错误或不完整的工作区启动；
- 上传失败可以继续使用已经存在的本地 Bot，但下行恢复失败不能伪装成完整启动。

因此本 PR 落地 PR4 的本地模拟同步层，先把状态机、事务边界、恢复能力和生命周期接入验证清楚，为后续接真实 SkillHub / CatsCompany 云端接口提供稳定基础。

## 做了什么

### 1. 增加 Local / Base / Cloud 三态同步状态机

- 新增 Bot Skill sync-base，按 `botId + workspaceId` 隔离保存共同基线；
- Base 同时记录 Local 投影、Local→Cloud artifact binding、Cloud 精确引用和各自摘要；
- 增加 bindings 摘要及结构校验，要求每个 Local Skill 恰好有一个 binding，启用项的 refs 必须与 Cloud 一致；
- Base 只在 canonical Definition、cache 和本地恢复事务成功后提交，避免失败状态被误认为已同步。

第一阶段方向规则：

- Local == Base 且 Cloud == Base：不做内容同步；
- Local == Base 且 Cloud != Base：Cloud 下行恢复；
- Local != Base：Local 上行，Local/Cloud 同时变化时优先保护 Local；
- Base 缺失且本地工作区为空、Cloud 有 refs：继续下行恢复，避免首次恢复失败后重启把 Cloud 清空；
- Cloud Definition 缺失但本地有效：使用 Local 重建；
- Base、canonical 或 Local manifest 无效：fail closed，不把损坏状态当空状态。

### 2. 增加本地模拟的不可变 Skill artifact 仓库

- 本地/修改后的 Skill 使用稳定 `localSkillId` 派生私有 skillId，并按内容摘要生成不可变版本；
- 未修改的 SkillHub Skill 保留公开 `skillId@version`，本地修改后自动转成私有版本；
- 公开 artifact 去除 userId、安装时间、会话 URL 等设备相关字段，同一公开版本可跨 Bot / 设备复用；
- artifact 默认与模拟 Bot Definition 共用同一个 simulated cloud root；
- 删除只移除 Definition 引用，不物理删除历史 artifact；
- 增加文件数、单文件/总大小、路径深度、保留名、软链接/junction 和 realpath 安全检查。

### 3. 增加可恢复的 Cloud→Local 工作区事务

- 下行恢复采用 staged / backup / active 的整工作区切换；
- journal 记录 prepared、source-backed-up、target-active、base-committed 阶段；
- Base 是事务提交点，提交前失败会恢复原 Local；
- 支持两处真实的 rename 成功但 journal 尚未更新的崩溃窗口；
- recovery 同时校验 workspace scope hash、Bot/workspace marker 和内容摘要，避免旧事务误操作其他 Bot 的活动工作区；
- 部分 manifest、缺失 artifact 或 owner 不匹配时停止恢复，不会做 delete-all。

### 4. 接入启动、对话结束、本地管理和 Bot 切换生命周期

- Dashboard 启动和 CLI 启动在 Connector 前执行同步；
- Bot 切换前尽力上传旧 Bot 的离线修改，随后恢复目标 Bot，再启动 Connector；
- 本地 Skill enable/disable/uninstall/install 等受管变更会触发后台同步；
- 每轮对话结束后触发 fire-and-forget 同步；
- 后台队列支持 coalescing、running+dirty 尾随重跑、失败不热循环以及按 runtimeRoot cancel/flush；
- Definition 锁竞争改为快速失败，不再用同步等待阻塞 Node 事件循环；有效 owner 不会仅因超时被抢锁。

### 5. 保持迁移与现有行为兼容

- 默认 Skill 仅在 legacy `Definition.skills === undefined` 时执行一次迁移准备；
- CLI、Dashboard 启动和 Dashboard Bot 切换均保持相同的“先迁移、再同步、最后启动 Connector”顺序；
- disabled Skill 保留本地内容和 binding，但不出现在 Cloud active refs 中；
- `subscriptions.json` 继续作为旧数据兼容来源，同时合并当前 install markers；新设备从 Definition 恢复后，即使旧 subscription store 为空，也可以列出和取消订阅；
- 上行失败不回滚本地内容，已有 Bot 可继续使用；工作区缺失时的下行失败返回不可安全启动。

## 审核与测试

已完成三路独立只读复审：

- 同步状态机复审：未发现 P0/P1，相关 162 项通过；
- 安全/并发复审：未发现 P0/P1，相关 133 项通过；
- 产品/兼容性复审：未发现 P0/P1，相关 115 项通过。

本地验证：

- `npm run build`：通过；
- 最终 Bot Skill sync + subscription 专项：38/38 通过；
- Dashboard、Bot Definition、workspace、SkillHub 等组合回归：通过；
- `git diff --check`：通过（仅 Windows LF/CRLF 提示）；
- `npm test`：1278 项中 1272 通过、2 失败、4 跳过。两个失败均为现有 `tool-result-read-tool.test.ts` 的 PDF 视觉 fallback 用例；三路复审在最新树复跑时结果一致，与本 PR 修改路径和行为无关。

重点新增回归覆盖：

- 离线本地修改重新上线后上传；
- Local/Cloud 同时变化时 Local 优先；
- 首次恢复失败、进程重启后继续下行且不清空 Cloud；
- 第二设备使用默认 simulated cloud root 恢复；
- 公开版本跨 Bot / 安装会话去重；
- disabled、删除、partial manifest、无效 Base/canonical；
- artifact 缺失时 Local/Base 不前移；
- canonical/cache/Base 同锁提交；
- 两个 rename-before-journal 崩溃窗口恢复；
- 后台同步合并、失败重试和 Dashboard teardown。

## 本 PR 不包含

- 真实 SkillHub 私有 Skill 上传/下载；
- 真实 CatsCompany Bot Definition 网络接口、字段级 PATCH 和强制 ETag；
- 多端逐文件自动合并。本阶段发生双端变化时按既定规则优先保护 Local，并保留 Cloud 快照/不可变历史。

## 下一步

- PR5：把当前 simulated private artifact 抽象接到真实私有 SkillHub 版本接口，继续保持 contentHash 幂等、不可变版本和严格上传安全边界；
- 后续 PR：接入真实 Bot Definition Cloud API，使用字段级 PATCH + ETag/CAS，补齐网络重试、鉴权、观测和冲突交互；
- 再后续根据实际冲突数据评估逐文件三方合并，不在第一阶段提前扩大复杂度。

## PR 依赖

这是堆叠 PR，base 为尚未合并的 PR3：#241。