### PR TITLE
PR5：接入 Bot 私有 Skill 云端同步与安全恢复

### DIFF
--- a/src/bot-definition/repository.ts
+++ b/src/bot-definition/repository.ts
@@ -12,6 +12,7 @@ import {
   type BotSkillRef,
   type CustomBotModelDefinition,
 } from './types';
+import { isValidBotSkillRef } from './skill-ref';
 
 const MAX_DEFINITION_BYTES = 2 * 1024 * 1024;
 
@@ -83,13 +84,12 @@ function isValidDefinition(definition: unknown, expectedBotId: string): definiti
 }
 
 function isValidSkillRefs(skills: unknown): skills is BotSkillRef[] {
-  if (!Array.isArray(skills)) return false;
+  if (!Array.isArray(skills) || skills.length > 256) return false;
   const versionsBySkillId = new Map<string, string>();
   for (const entry of skills) {
-    const value = entry as Partial<BotSkillRef> | null;
-    const skillId = typeof value?.skillId === 'string' ? value.skillId.trim() : '';
-    const version = typeof value?.version === 'string' ? value.version.trim() : '';
-    if (!skillId || !version) return false;
+    if (!isValidBotSkillRef(entry)) return false;
+    const skillId = entry.skillId.trim();
+    const version = entry.version.trim();
     const previousVersion = versionsBySkillId.get(skillId);
     if (previousVersion && previousVersion !== version) return false;
     versionsBySkillId.set(skillId, version);

--- a/src/bot-definition/service.ts
+++ b/src/bot-definition/service.ts
@@ -36,6 +36,7 @@ import {
   type BotDefinitionRepository,
   type FileBotDefinitionRepositoryOptions,
 } from './repository';
+import { normalizeBotSkillRef } from './skill-ref';
 
 const CUSTOM_DEFAULT_CONTEXT_WINDOW_TOKENS = 200_000;
 
@@ -304,15 +305,12 @@ export function normalizeBotSkillRefs(skills: readonly BotSkillRef[]): BotSkillR
   if (!Array.isArray(skills)) {
     throw new Error('BotDefinition skills must be an array');
   }
-  const normalized = skills.map(entry => ({
-    skillId: typeof entry?.skillId === 'string' ? entry.skillId.trim() : '',
-    version: typeof entry?.version === 'string' ? entry.version.trim() : '',
-  }));
+  if (skills.length > 256) {
+    throw new Error('BotDefinition cannot reference more than 256 Skills');
+  }
+  const normalized = skills.map(entry => normalizeBotSkillRef(entry));
   const versionsBySkillId = new Map<string, string>();
   for (const entry of normalized) {
-    if (!entry.skillId || !entry.version) {
-      throw new Error('BotDefinition Skill references require a non-empty skillId and version');
-    }
     const previousVersion = versionsBySkillId.get(entry.skillId);
     if (previousVersion && previousVersion !== entry.version) {
       throw new Error(`BotDefinition cannot reference multiple versions of Skill ${entry.skillId}`);

--- a/src/bot-definition/skill-ref.ts
+++ b/src/bot-definition/skill-ref.ts
@@ -1,0 +1,60 @@
+import type { BotSkillRef } from './types';
+
+const MAX_SKILL_ID_BYTES = 512;
+const MAX_SKILL_VERSION_BYTES = 256;
+const MAX_SKILL_ID_SEGMENTS = 32;
+
+export function normalizeBotSkillRef(ref: BotSkillRef): BotSkillRef {
+  const skillId = normalizeSkillId(ref?.skillId);
+  const version = normalizeSkillVersion(ref?.version);
+  return { skillId, version };
+}
+
+export function isValidBotSkillRef(ref: unknown): ref is BotSkillRef {
+  try {
+    normalizeBotSkillRef(ref as BotSkillRef);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function isPrivateBotSkillRef(ref: BotSkillRef): boolean {
+  return normalizeBotSkillRef(ref).skillId.startsWith('private:');
+}
+
+function normalizeSkillId(value: unknown): string {
+  const skillId = text(value, 'skillId', MAX_SKILL_ID_BYTES);
+  const segments = skillId.split('/');
+  if (
+    /[\u0000-\u001f\u007f\\?#]/u.test(skillId)
+    || skillId.startsWith('/')
+    || skillId.endsWith('/')
+    || segments.length > MAX_SKILL_ID_SEGMENTS
+    || segments.some(segment => !segment || segment === '.' || segment === '..')
+  ) {
+    throw new Error('BotDefinition Skill skillId is not a safe portable identifier');
+  }
+  return skillId;
+}
+
+function normalizeSkillVersion(value: unknown): string {
+  const version = text(value, 'version', MAX_SKILL_VERSION_BYTES);
+  if (
+    /[\u0000-\u001f\u007f/\\?#]/u.test(version)
+    || version === '.'
+    || version === '..'
+  ) {
+    throw new Error('BotDefinition Skill version is not a safe portable identifier');
+  }
+  return version;
+}
+
+function text(value: unknown, field: string, maxBytes: number): string {
+  const normalized = typeof value === 'string' ? value.trim() : '';
+  if (!normalized) throw new Error('BotDefinition Skill references require non-empty skillId and version');
+  if (Buffer.byteLength(normalized, 'utf8') > maxBytes) {
+    throw new Error(`BotDefinition Skill ${field} is too long`);
+  }
+  return normalized;
+}

--- a/src/bot-skills/artifact-transport.ts
+++ b/src/bot-skills/artifact-transport.ts
@@ -1,0 +1,28 @@
+import type { BotSkillRef } from '../bot-definition/types';
+import type { SimulatedSkillArtifact } from './simulated-artifact-store';
+
+export interface BotSkillArtifactTransportContext {
+  botId: string;
+  workspaceId: string;
+}
+
+export interface BotSkillPrivateUploadInput extends BotSkillArtifactTransportContext {
+  artifact: SimulatedSkillArtifact;
+  forkedFrom?: BotSkillRef;
+}
+
+/**
+ * Remote transport boundary for Bot Skill synchronization.
+ *
+ * Production uses Bot-authenticated SkillHub private storage. Tests may inject a
+ * deterministic fake. The transport must return only fully downloaded and
+ * signature-verified artifacts; the sync service commits Definition/Base after
+ * this promise resolves.
+ */
+export interface BotSkillArtifactTransport {
+  upsertPrivate(input: BotSkillPrivateUploadInput): Promise<SimulatedSkillArtifact>;
+  fetchVerified(
+    ref: BotSkillRef,
+    context: BotSkillArtifactTransportContext,
+  ): Promise<SimulatedSkillArtifact>;
+}

--- a/src/bot-skills/local-manifest.ts
+++ b/src/bot-skills/local-manifest.ts
@@ -44,6 +44,7 @@ export interface LocalSkillManifestEntry {
   version?: string;
   installedChecksum?: string;
   installedContentHash?: string;
+  sourceVisibility?: 'public' | 'private';
 }
 
 export interface LocalSkillManifest {
@@ -178,6 +179,7 @@ export function scanLocalSkillManifest(
           version: marker.version,
           installedChecksum: marker.packageChecksumSha256,
           installedContentHash: marker.installedContentHash,
+          sourceVisibility: marker.visibility ?? 'public',
         } : {}),
       };
       result.entries.push(entry);

--- a/src/bot-skills/simulated-artifact-store.ts
+++ b/src/bot-skills/simulated-artifact-store.ts
@@ -2,6 +2,7 @@ import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { BotSkillRef } from '../bot-definition/types';
+import { normalizeBotSkillRef } from '../bot-definition/skill-ref';
 import {
   BOT_SKILL_LOCAL_IDENTITY_FILE,
   type LocalSkillManifestEntry,
@@ -36,7 +37,7 @@ export interface SimulatedSkillArtifact {
   botId: string;
   localSkillId: string;
   ref: BotSkillRef;
-  storage: 'skillhub-mirror' | 'simulated-private';
+  storage: 'skillhub-mirror' | 'simulated-private' | 'skillhub-private';
   name: string;
   installName: string;
   contentHash: string;
@@ -53,9 +54,23 @@ export interface PutSimulatedSkillArtifactOptions {
 }
 
 export interface SimulatedSkillArtifactStore {
+  snapshot(options: PutSimulatedSkillArtifactOptions): SimulatedSkillArtifact;
   put(options: PutSimulatedSkillArtifactOptions): SimulatedSkillArtifact;
   read(ref: BotSkillRef): SimulatedSkillArtifact;
   materialize(artifact: SimulatedSkillArtifact, targetDir: string): void;
+  cacheVerified(options: CacheVerifiedSkillArtifactOptions): SimulatedSkillArtifact;
+}
+
+export interface CacheVerifiedSkillArtifactOptions {
+  ref: BotSkillRef;
+  botId: string;
+  localSkillId: string;
+  storage: 'skillhub-mirror' | 'skillhub-private';
+  name: string;
+  installName: string;
+  contentHash: string;
+  files: SimulatedSkillArtifactFile[];
+  installMarker: SkillHubPackageInstallMarker;
 }
 
 export interface FileSimulatedSkillArtifactStoreOptions {
@@ -83,6 +98,10 @@ export class FileSimulatedSkillArtifactStore implements SimulatedSkillArtifactSt
   }
 
   put(options: PutSimulatedSkillArtifactOptions): SimulatedSkillArtifact {
+    return this.persistArtifact(this.snapshot(options));
+  }
+
+  snapshot(options: PutSimulatedSkillArtifactOptions): SimulatedSkillArtifact {
     const botId = required(options.botId, 'botId');
     const root = path.resolve(options.skillsRoot);
     const relative = normalizeRelativePath(options.entry.path);
@@ -139,11 +158,15 @@ export class FileSimulatedSkillArtifactStore implements SimulatedSkillArtifactSt
       files,
       ...(installMarker ? { installMarker } : {}),
     };
-    const filePath = this.filePath(ref);
-    const existing = this.inspectFile(filePath, ref);
+    return artifact;
+  }
+
+  private persistArtifact(artifact: SimulatedSkillArtifact): SimulatedSkillArtifact {
+    const filePath = this.filePath(artifact.ref);
+    const existing = this.inspectFile(filePath, artifact.ref);
     if (existing) {
       if (existing.artifactDigest !== artifact.artifactDigest) {
-        throw new Error(`Immutable Skill artifact conflict for ${ref.skillId}@${ref.version}`);
+        throw new Error(`Immutable Skill artifact conflict for ${artifact.ref.skillId}@${artifact.ref.version}`);
       }
       return existing;
     }
@@ -191,6 +214,53 @@ export class FileSimulatedSkillArtifactStore implements SimulatedSkillArtifactSt
     }
   }
 
+  cacheVerified(options: CacheVerifiedSkillArtifactOptions): SimulatedSkillArtifact {
+    const ref = normalizeRef(options.ref);
+    const files = options.files.map(file => ({ ...file }));
+    const installMarker = { ...options.installMarker };
+    const candidate = {
+      schema: SIMULATED_SKILL_ARTIFACT_SCHEMA,
+      botId: required(options.botId, 'botId'),
+      localSkillId: required(options.localSkillId, 'localSkillId'),
+      ref,
+      storage: options.storage,
+      name: required(options.name, 'name').normalize('NFC'),
+      installName: normalizeInstallName(options.installName),
+      contentHash: requiredHash(options.contentHash, 'contentHash'),
+      files,
+      installMarker,
+    };
+    const artifactDigest = digest({
+      botId: candidate.botId,
+      localSkillId: candidate.localSkillId,
+      storage: candidate.storage,
+      name: candidate.name,
+      installName: candidate.installName,
+      contentHash: candidate.contentHash,
+      files: files.map(file => ({
+        path: file.path,
+        size: file.size,
+        sha256: file.sha256,
+      })),
+      installMarker,
+    });
+    const artifact = parseArtifact(
+      { ...candidate, artifactDigest },
+      ref,
+    );
+    if (!artifact) throw new Error(`Verified Skill artifact is invalid: ${ref.skillId}@${ref.version}`);
+    const filePath = this.filePath(ref);
+    const existing = this.inspectFile(filePath, ref);
+    if (existing) {
+      if (existing.artifactDigest !== artifact.artifactDigest) {
+        throw new Error(`Immutable Skill artifact conflict for ${ref.skillId}@${ref.version}`);
+      }
+      return existing;
+    }
+    writeJsonAtomic(this.root, filePath, artifact);
+    return artifact;
+  }
+
   getPath(ref: BotSkillRef): string {
     return this.filePath(normalizeRef(ref));
   }
@@ -226,21 +296,26 @@ export class FileSimulatedSkillArtifactStore implements SimulatedSkillArtifactSt
 
 function collectArtifactFiles(skillDir: string): SimulatedSkillArtifactFile[] {
   assertRealDirectory(skillDir, 'Skill artifact source');
-  const paths: string[] = [];
-  const visit = (current: string): void => {
-    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
-      const fullPath = path.join(current, entry.name);
-      const stat = fs.lstatSync(fullPath);
-      if (stat.isSymbolicLink()) throw new Error(`Skill artifact source contains a link: ${fullPath}`);
-      if (stat.isDirectory()) {
-        if (!SKIP_DIRECTORIES.has(entry.name)) visit(fullPath);
-        continue;
+  const listPaths = (): string[] => {
+    const paths: string[] = [];
+    const visit = (current: string): void => {
+      assertRealDirectory(current, 'Skill artifact source directory');
+      for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+        const fullPath = path.join(current, entry.name);
+        const stat = fs.lstatSync(fullPath);
+        if (stat.isSymbolicLink()) throw new Error(`Skill artifact source contains a link: ${fullPath}`);
+        if (stat.isDirectory()) {
+          if (!SKIP_DIRECTORIES.has(entry.name)) visit(fullPath);
+          continue;
+        }
+        if (!stat.isFile()) throw new Error(`Skill artifact source contains a non-file: ${fullPath}`);
+        if (!SKIP_FILES.has(entry.name)) paths.push(fullPath);
       }
-      if (!stat.isFile()) throw new Error(`Skill artifact source contains a non-file: ${fullPath}`);
-      if (!SKIP_FILES.has(entry.name)) paths.push(fullPath);
-    }
+    };
+    visit(skillDir);
+    return paths.sort(compareUtf8);
   };
-  visit(skillDir);
+  const paths = listPaths();
   if (paths.length === 0 || paths.length > MAX_FILES) {
     throw new Error(`Skill artifact file count is invalid: ${paths.length}`);
   }
@@ -277,6 +352,13 @@ function collectArtifactFiles(skillDir: string): SimulatedSkillArtifactFile[] {
       contentBase64: content.toString('base64'),
     };
   });
+  const afterPaths = listPaths();
+  if (
+    paths.length !== afterPaths.length
+    || paths.some((filePath, index) => !samePath(filePath, afterPaths[index]))
+  ) {
+    throw new Error('Skill changed while creating its artifact: file list changed');
+  }
   return files.sort((left, right) => compareUtf8(left.path, right.path));
 }
 
@@ -289,7 +371,11 @@ function parseArtifact(value: unknown, expectedRef: BotSkillRef): SimulatedSkill
       || !Array.isArray(raw.files)
       || raw.files.length === 0
       || raw.files.length > MAX_FILES
-      || (raw.storage !== 'skillhub-mirror' && raw.storage !== 'simulated-private')
+      || (
+        raw.storage !== 'skillhub-mirror'
+        && raw.storage !== 'simulated-private'
+        && raw.storage !== 'skillhub-private'
+      )
     ) return undefined;
     const ref = normalizeRef(raw.ref);
     if (ref.skillId !== expectedRef.skillId || ref.version !== expectedRef.version) return undefined;
@@ -330,12 +416,16 @@ function parseArtifact(value: unknown, expectedRef: BotSkillRef): SimulatedSkill
     if (!files.some(file => file.path === 'SKILL.md')) return undefined;
     const installMarker = raw.installMarker;
     if (
-      raw.storage === 'skillhub-mirror'
+      (raw.storage === 'skillhub-mirror' || raw.storage === 'skillhub-private')
       && (
         !isValidInstallMarker(installMarker)
         || installMarker.skillId !== ref.skillId
         || installMarker.version !== ref.version
         || installMarker.installName !== installName
+        || (raw.storage === 'skillhub-mirror' && installMarker.visibility === 'private')
+        || (raw.storage === 'skillhub-private' && installMarker.visibility !== 'private')
+        || (raw.storage === 'skillhub-private' && installMarker.ownerBotId !== botId)
+        || (raw.storage === 'skillhub-private' && installMarker.localSkillId !== localSkillId)
       )
     ) return undefined;
     if (raw.storage === 'simulated-private' && installMarker) return undefined;
@@ -446,10 +536,7 @@ function portablePath(relative: string): string {
 }
 
 function normalizeRef(ref: BotSkillRef): BotSkillRef {
-  return {
-    skillId: required(ref?.skillId, 'skillId'),
-    version: required(ref?.version, 'version'),
-  };
+  return normalizeBotSkillRef(ref);
 }
 
 function isValidInstallMarker(
@@ -487,6 +574,7 @@ function canonicalPublicInstallMarker(
   ).toISOString();
   return {
     source: 'skillhub',
+    visibility: 'public',
     skillId: required(marker.skillId, 'marker.skillId'),
     name: required(marker.name, 'marker.name').normalize('NFC'),
     installName: normalizeInstallName(marker.installName),

--- a/src/bot-skills/skillhub-artifact-transport.ts
+++ b/src/bot-skills/skillhub-artifact-transport.ts
@@ -1,0 +1,471 @@
+import * as crypto from 'node:crypto';
+import * as path from 'node:path';
+import { normalizeBotSkillRef } from '../bot-definition/skill-ref';
+import type { BotSkillRef } from '../bot-definition/types';
+import { createCatsCoLocalConfigService } from '../catscompany/local-config';
+import { SkillHubClient } from '../skillhub/client';
+import {
+  verifySkillHubPackage,
+  type SkillHubPackageFile,
+} from '../skillhub/package-verifier';
+import type {
+  SkillHubBotCredential,
+  SkillHubPackageInstallMarker,
+  SkillHubPrivateSkillResponse,
+  SkillHubRegistryEntry,
+} from '../skillhub/types';
+import type {
+  BotSkillArtifactTransport,
+  BotSkillArtifactTransportContext,
+  BotSkillPrivateUploadInput,
+} from './artifact-transport';
+import {
+  type SimulatedSkillArtifact,
+  type SimulatedSkillArtifactFile,
+  type SimulatedSkillArtifactStore,
+} from './simulated-artifact-store';
+
+const GENERATED_PACKAGE_FILES = new Set([
+  'skill.json',
+  'REVIEW.json',
+  'SBOM.json',
+  '.xiaoba-bundled-skill.json',
+  '.xiaoba-skillhub-install.json',
+  '.xiaoba-local-skill.json',
+]);
+
+export interface SkillHubBotSkillArtifactTransportOptions {
+  runtimeRoot: string;
+  env?: NodeJS.ProcessEnv;
+  artifactStore: SimulatedSkillArtifactStore;
+  client?: SkillHubClient;
+}
+
+export class SkillHubBotSkillArtifactTransport implements BotSkillArtifactTransport {
+  private readonly runtimeRoot: string;
+  private readonly env: NodeJS.ProcessEnv;
+  private readonly artifactStore: SimulatedSkillArtifactStore;
+  private readonly client: SkillHubClient;
+
+  constructor(options: SkillHubBotSkillArtifactTransportOptions) {
+    this.runtimeRoot = path.resolve(options.runtimeRoot);
+    this.env = options.env ?? process.env;
+    this.artifactStore = options.artifactStore;
+    this.client = options.client ?? new SkillHubClient({
+      baseUrl: firstNonEmpty(
+        this.env.CATSCO_SKILLHUB_BASE_URL,
+        this.env.SKILLHUB_BASE_URL,
+      ),
+    });
+  }
+
+  async upsertPrivate(input: BotSkillPrivateUploadInput): Promise<SimulatedSkillArtifact> {
+    const credential = this.credential(input.botId);
+    const snapshot = input.artifact;
+    if (
+      snapshot.storage !== 'simulated-private'
+      || snapshot.botId !== input.botId
+      || !snapshot.localSkillId
+    ) {
+      throw transportError(
+        'Private Skill upload received an invalid local snapshot.',
+        'BOT_SKILL_PRIVATE_SNAPSHOT_INVALID',
+      );
+    }
+    assertNoSensitiveContent(snapshot.files);
+    const response = await this.client.upsertPrivateSkill({
+      botId: input.botId,
+      workspaceId: input.workspaceId,
+      localSkillId: snapshot.localSkillId,
+      contentHash: snapshot.contentHash,
+      name: snapshot.name,
+      installName: snapshot.installName,
+      ...(input.forkedFrom ? { forkedFrom: normalizeBotSkillRef(input.forkedFrom) } : {}),
+      files: snapshot.files.map(file => ({ ...file })),
+    }, credential) as SkillHubPrivateSkillResponse;
+    const entry = requirePrivateEntry(response?.skill, {
+      botId: input.botId,
+      localSkillId: snapshot.localSkillId,
+      contentHash: snapshot.contentHash,
+      installName: snapshot.installName,
+    });
+    const verified = await this.fetchEntryVerified(
+      entry,
+      { botId: input.botId, workspaceId: input.workspaceId },
+      credential,
+    );
+    if (
+      verified.localSkillId !== snapshot.localSkillId
+      || verified.contentHash !== snapshot.contentHash
+      || filesDigest(verified.files) !== filesDigest(snapshot.files)
+    ) {
+      throw transportError(
+        'SkillHub returned a package different from the uploaded private Skill snapshot.',
+        'BOT_SKILL_PRIVATE_UPLOAD_VERIFY_MISMATCH',
+      );
+    }
+    return verified;
+  }
+
+  async fetchVerified(
+    refValue: BotSkillRef,
+    context: BotSkillArtifactTransportContext,
+  ): Promise<SimulatedSkillArtifact> {
+    const ref = normalizeBotSkillRef(refValue);
+    const privateHint = ref.skillId.startsWith('private:');
+    const credential = privateHint ? this.credential(context.botId) : undefined;
+    const detail = await this.client.getVersion(ref.skillId, ref.version, credential);
+    const entry = normalizeExactEntry(detail?.version ?? detail?.skill, ref);
+    if (entry.visibility === 'private' && !credential) {
+      throw transportError(
+        'Private Skill metadata was returned without Bot authorization.',
+        'BOT_SKILL_PRIVATE_AUTH_REQUIRED',
+      );
+    }
+    if (entry.visibility !== 'private' && privateHint) {
+      throw transportError(
+        'Reserved private Skill reference did not resolve to a private artifact.',
+        'BOT_SKILL_PRIVATE_REF_MISMATCH',
+      );
+    }
+    return this.fetchEntryVerified(
+      entry,
+      context,
+      entry.visibility === 'private' ? credential ?? this.credential(context.botId) : undefined,
+    );
+  }
+
+  private async fetchEntryVerified(
+    registryEntry: SkillHubRegistryEntry,
+    context: BotSkillArtifactTransportContext,
+    credential?: SkillHubBotCredential,
+  ): Promise<SimulatedSkillArtifact> {
+    const [trust, packageBytes] = await Promise.all([
+      this.client.getTrust(credential),
+      this.client.downloadPackage(registryEntry, credential),
+    ]);
+    const verification = verifySkillHubPackage({
+      packageBytes,
+      registryEntry,
+      trust,
+    });
+    const payload = verification.packageObject.payload as typeof verification.packageObject.payload & {
+      privateMetadata?: {
+        visibility?: unknown;
+        ownerBotId?: unknown;
+        localSkillId?: unknown;
+        contentHash?: unknown;
+        installName?: unknown;
+      };
+      contentHash?: unknown;
+      installName?: unknown;
+    };
+    const ref = normalizeBotSkillRef({
+      skillId: registryEntry.skillId,
+      version: registryEntry.latestVersion,
+    });
+    const files = payload.files.map(toArtifactFile);
+    const computedContentHash = contentHashOfPackageFiles(payload.files);
+    const signatureTime = registryEntry.signature.signedAt
+      ?? verification.packageObject.signature.signedAt;
+    if (
+      registryEntry.visibility !== undefined
+      && registryEntry.visibility !== 'public'
+      && registryEntry.visibility !== 'private'
+    ) {
+      throw transportError(
+        'SkillHub returned an invalid Skill visibility.',
+        'BOT_SKILL_REMOTE_VISIBILITY_INVALID',
+      );
+    }
+
+    if (registryEntry.visibility === 'private') {
+      const signedAt = stableIso(signatureTime);
+      const signed = payload.privateMetadata;
+      if (
+        signed?.visibility !== 'private'
+        || text(signed.ownerBotId) !== context.botId
+        || text(signed.ownerBotId) !== text(registryEntry.ownerBotId)
+        || text(signed.localSkillId) !== text(registryEntry.localSkillId)
+        || hash(signed.contentHash) !== hash(registryEntry.contentHash)
+        || hash(signed.contentHash) !== computedContentHash
+        || text(signed.installName) !== text(registryEntry.installName)
+      ) {
+        throw transportError(
+          'Signed private Skill scope does not match the requested Bot.',
+          'BOT_SKILL_PRIVATE_SCOPE_MISMATCH',
+        );
+      }
+      const marker = installMarker(
+        registryEntry,
+        signedAt,
+        computedContentHash,
+        {
+          name: payload.manifest.name,
+          installName: text(signed.installName),
+        },
+        {
+          visibility: 'private',
+          ownerBotId: context.botId,
+          localSkillId: text(signed.localSkillId),
+        },
+      );
+      return this.artifactStore.cacheVerified({
+        ref,
+        botId: context.botId,
+        localSkillId: text(signed.localSkillId),
+        storage: 'skillhub-private',
+        name: payload.manifest.name,
+        installName: text(signed.installName),
+        contentHash: computedContentHash,
+        files,
+        installMarker: marker,
+      });
+    }
+
+    if (payload.privateMetadata || registryEntry.ownerBotId || registryEntry.localSkillId) {
+      throw transportError(
+        'Public Skill package contains private scope metadata.',
+        'BOT_SKILL_PUBLIC_SCOPE_INVALID',
+      );
+    }
+    const signedContentHash = hash(payload.contentHash || computedContentHash);
+    if (signedContentHash !== computedContentHash) {
+      throw transportError(
+        'Public Skill package content hash does not match its files.',
+        'BOT_SKILL_PUBLIC_CONTENT_HASH_MISMATCH',
+      );
+    }
+    const installName = text(payload.installName || payload.manifest.name);
+    if (registryEntry.installName && text(registryEntry.installName) !== installName) {
+      throw transportError(
+        'Public Skill install name does not match signed package metadata.',
+        'BOT_SKILL_PUBLIC_INSTALL_NAME_MISMATCH',
+      );
+    }
+    const signedAt = optionalStableIso(signatureTime)
+      ?? '1970-01-01T00:00:00.000Z';
+    return this.artifactStore.cacheVerified({
+      ref,
+      botId: 'public',
+      localSkillId: 'public',
+      storage: 'skillhub-mirror',
+      name: payload.manifest.name,
+      installName,
+      contentHash: computedContentHash,
+      files,
+      installMarker: installMarker(registryEntry, signedAt, computedContentHash, {
+        name: payload.manifest.name,
+        installName,
+      }, {
+        visibility: 'public',
+      }),
+    });
+  }
+
+  private credential(botIdValue: string): SkillHubBotCredential {
+    const botId = text(botIdValue);
+    const auth = createCatsCoLocalConfigService({
+      runtimeRoot: this.runtimeRoot,
+      env: this.env,
+    }).getAuthState();
+    if (text(auth.botUid) !== botId || !text(auth.apiKey)) {
+      throw transportError(
+        `Bot credential is unavailable for private Skill synchronization (${botId}).`,
+        'BOT_SKILL_PRIVATE_BOT_AUTH_REQUIRED',
+      );
+    }
+    return { botId, apiKey: text(auth.apiKey) };
+  }
+}
+
+export function createSkillHubBotSkillArtifactTransport(
+  options: SkillHubBotSkillArtifactTransportOptions,
+): BotSkillArtifactTransport {
+  return new SkillHubBotSkillArtifactTransport(options);
+}
+
+function normalizeExactEntry(
+  value: SkillHubRegistryEntry | undefined,
+  ref: BotSkillRef,
+): SkillHubRegistryEntry {
+  if (!value) {
+    throw transportError('SkillHub exact version response is missing.', 'BOT_SKILL_REMOTE_VERSION_MISSING');
+  }
+  const actual = normalizeBotSkillRef({
+    skillId: value.skillId,
+    version: value.latestVersion,
+  });
+  if (actual.skillId !== ref.skillId || actual.version !== ref.version) {
+    throw transportError('SkillHub exact version response does not match the requested ref.', 'BOT_SKILL_REMOTE_REF_MISMATCH');
+  }
+  return value;
+}
+
+function requirePrivateEntry(
+  value: SkillHubRegistryEntry | undefined,
+  expected: {
+    botId: string;
+    localSkillId: string;
+    contentHash: string;
+    installName: string;
+  },
+): SkillHubRegistryEntry {
+  if (
+    !value
+    || value.visibility !== 'private'
+    || !String(value.skillId || '').startsWith('private:')
+    || text(value.ownerBotId) !== expected.botId
+    || text(value.localSkillId) !== expected.localSkillId
+    || hash(value.contentHash) !== expected.contentHash
+    || text(value.installName) !== expected.installName
+  ) {
+    throw transportError(
+      'SkillHub private upsert response does not match the requested Bot Skill.',
+      'BOT_SKILL_PRIVATE_UPSERT_MISMATCH',
+    );
+  }
+  normalizeBotSkillRef({ skillId: value.skillId, version: value.latestVersion });
+  return value;
+}
+
+function installMarker(
+  entry: SkillHubRegistryEntry,
+  signedAt: string,
+  contentHash: string,
+  identity: { name: string; installName: string },
+  scope:
+    | { visibility: 'public' }
+    | { visibility: 'private'; ownerBotId: string; localSkillId: string },
+): SkillHubPackageInstallMarker {
+  return {
+    source: 'skillhub',
+    ...scope,
+    skillId: entry.skillId,
+    name: text(identity.name),
+    installName: text(identity.installName),
+    version: entry.latestVersion,
+    packageChecksumSha256: hash(entry.checksumSha256),
+    installedContentHash: contentHash,
+    signature: {
+      ...entry.signature,
+      signedAt,
+    },
+    packageUrl: `skillhub:${entry.skillId}@${entry.latestVersion}`,
+    installedAt: signedAt,
+  };
+}
+
+function toArtifactFile(file: SkillHubPackageFile): SimulatedSkillArtifactFile {
+  return {
+    path: file.path,
+    size: file.size,
+    sha256: file.sha256.toLowerCase(),
+    contentBase64: file.contentBase64,
+  };
+}
+
+function contentHashOfPackageFiles(files: SkillHubPackageFile[]): string {
+  const entries = files
+    .filter(file => !GENERATED_PACKAGE_FILES.has(file.path))
+    .map(file => {
+      const raw = Buffer.from(file.contentBase64, 'base64');
+      const content = file.path === 'SKILL.md'
+        ? Buffer.from(raw.toString('utf8').replace(/\r\n/g, '\n'), 'utf8')
+        : raw;
+      return {
+        path: file.path === 'SKILL.md.disabled' ? 'SKILL.md' : file.path,
+        size: content.length,
+        sha256: sha256(content),
+      };
+    })
+    .sort((left, right) => Buffer.compare(
+      Buffer.from(left.path, 'utf8'),
+      Buffer.from(right.path, 'utf8'),
+    ));
+  return sha256(Buffer.from(JSON.stringify(entries), 'utf8'));
+}
+
+function filesDigest(files: SimulatedSkillArtifactFile[]): string {
+  return sha256(Buffer.from(JSON.stringify(
+    files.filter(file => !GENERATED_PACKAGE_FILES.has(file.path)).map(file => ({
+      path: file.path,
+      size: file.size,
+      sha256: file.sha256,
+    })).sort((left, right) => left.path.localeCompare(right.path)),
+  ), 'utf8'));
+}
+
+function assertNoSensitiveContent(files: SimulatedSkillArtifactFile[]): void {
+  for (const file of files) {
+    const lower = file.path.toLowerCase();
+    const basename = lower.split('/').pop() || lower;
+    const content = Buffer.from(file.contentBase64, 'base64').toString('utf8');
+    const blockedPath = (
+      basename === '.env'
+      || basename.startsWith('.env.')
+      || ['.npmrc', '.pypirc', 'credentials', 'service-account.json', 'id_rsa', 'id_ed25519'].includes(basename)
+    );
+    const blockedContent = (
+      /-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----/u.test(content)
+      || /\bAKIA[0-9A-Z]{16}\b/u.test(content)
+      || /\bgh[pousr]_[A-Za-z0-9]{30,}\b/u.test(content)
+      || /\bsk-[A-Za-z0-9_-]{24,}\b/u.test(content)
+      || /\bxox[baprs]-[A-Za-z0-9-]{20,}\b/u.test(content)
+      || /\bAIza[0-9A-Za-z_-]{35}\b/u.test(content)
+      || /\b(?:sk|rk)_live_[A-Za-z0-9]{20,}\b/u.test(content)
+      || /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/u.test(content)
+      || /["']?(?:api[_-]?key|access[_-]?token|client[_-]?secret|password)["']?\s*[:=]\s*["']?[A-Za-z0-9_./+=-]{20,}/iu.test(content)
+    );
+    if (blockedPath || blockedContent) {
+      throw transportError(
+        `Private Skill contains blocked sensitive content: ${file.path}`,
+        'BOT_SKILL_PRIVATE_CONTENT_BLOCKED',
+      );
+    }
+  }
+}
+
+function stableIso(value: unknown): string {
+  const raw = text(value);
+  const time = Date.parse(raw);
+  if (!Number.isFinite(time)) {
+    throw transportError('SkillHub signature has no stable signedAt timestamp.', 'BOT_SKILL_SIGNATURE_TIME_INVALID');
+  }
+  return new Date(time).toISOString();
+}
+
+function optionalStableIso(value: unknown): string | undefined {
+  if (!text(value)) return undefined;
+  return stableIso(value);
+}
+
+function hash(value: unknown): string {
+  const normalized = text(value).toLowerCase();
+  if (!/^[0-9a-f]{64}$/u.test(normalized)) {
+    throw transportError('SkillHub returned an invalid SHA-256 value.', 'BOT_SKILL_REMOTE_HASH_INVALID');
+  }
+  return normalized;
+}
+
+function text(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function firstNonEmpty(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    const normalized = text(value);
+    if (normalized) return normalized;
+  }
+  return undefined;
+}
+
+function sha256(value: Buffer): string {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function transportError(message: string, code: string): Error {
+  const error: any = new Error(message);
+  error.code = code;
+  return error;
+}

--- a/src/bot-skills/sync-base.ts
+++ b/src/bot-skills/sync-base.ts
@@ -16,6 +16,7 @@ export interface BotSkillSyncLocalSourceRef {
   version: string;
   installedChecksum?: string;
   installedContentHash?: string;
+  visibility?: 'public' | 'private';
 }
 
 export interface BotSkillSyncLocalEntry {
@@ -31,7 +32,7 @@ export interface BotSkillSyncLocalEntry {
 export interface BotSkillSyncBinding {
   localSkillId: string;
   ref: BotSkillRef;
-  storage: 'skillhub-mirror' | 'simulated-private';
+  storage: 'skillhub-mirror' | 'simulated-private' | 'skillhub-private';
   artifactDigest: string;
 }
 
@@ -214,6 +215,9 @@ function projectLocalEntry(entry: LocalSkillManifestEntry): BotSkillSyncLocalEnt
         ...(entry.installedContentHash
           ? { installedContentHash: requiredHash(entry.installedContentHash, 'installedContentHash') }
           : {}),
+        ...(entry.sourceVisibility
+          ? { visibility: entry.sourceVisibility }
+          : {}),
       },
     } : {}),
   };
@@ -231,6 +235,14 @@ function normalizeLocalEntries(
     if (source !== 'local' && source !== 'skillhub') {
       throw new Error(`Invalid Local Skill source for ${localSkillId}`);
     }
+    if (
+      raw.sourceRef
+      && raw.sourceRef.visibility !== undefined
+      && raw.sourceRef.visibility !== 'public'
+      && raw.sourceRef.visibility !== 'private'
+    ) {
+      throw new Error(`Invalid sourceRef.visibility for ${localSkillId}`);
+    }
     const sourceRef = raw.sourceRef && {
       skillId: required(raw.sourceRef.skillId, 'sourceRef.skillId'),
       version: required(raw.sourceRef.version, 'sourceRef.version'),
@@ -239,6 +251,9 @@ function normalizeLocalEntries(
         : {}),
       ...(raw.sourceRef.installedContentHash
         ? { installedContentHash: requiredHash(raw.sourceRef.installedContentHash, 'installedContentHash') }
+        : {}),
+      ...(raw.sourceRef.visibility === 'public' || raw.sourceRef.visibility === 'private'
+        ? { visibility: raw.sourceRef.visibility }
         : {}),
     };
     if (source === 'skillhub' && !sourceRef) {
@@ -270,7 +285,11 @@ function normalizeBindings(
     }
     if (seen.has(localSkillId)) throw new Error(`Duplicate binding: ${localSkillId}`);
     seen.add(localSkillId);
-    if (raw.storage !== 'skillhub-mirror' && raw.storage !== 'simulated-private') {
+    if (
+      raw.storage !== 'skillhub-mirror'
+      && raw.storage !== 'simulated-private'
+      && raw.storage !== 'skillhub-private'
+    ) {
       throw new Error(`Invalid binding storage: ${String(raw.storage)}`);
     }
     return {

--- a/src/bot-skills/sync-service.ts
+++ b/src/bot-skills/sync-service.ts
@@ -33,6 +33,8 @@ import {
   type SimulatedSkillArtifact,
   type SimulatedSkillArtifactStore,
 } from './simulated-artifact-store';
+import type { BotSkillArtifactTransport } from './artifact-transport';
+import { createSkillHubBotSkillArtifactTransport } from './skillhub-artifact-transport';
 import type { LocalSkillManifest, LocalSkillManifestEntry } from './local-manifest';
 import {
   createBotSkillWorkspaceService,
@@ -58,6 +60,7 @@ export interface BotSkillSyncResult {
     | 'cloud_missing'
     | 'workspace_restore'
     | 'legacy_migration'
+    | 'transport_migration'
     | 'base_initialized';
   manifest: LocalSkillManifest;
   base: BotSkillSyncBase;
@@ -88,6 +91,7 @@ export interface BotSkillSyncServiceOptions {
   definitionService?: BotDefinitionSyncService;
   baseRepository?: BotSkillSyncBaseRepository;
   artifactStore?: SimulatedSkillArtifactStore;
+  artifactTransport?: BotSkillArtifactTransport | null;
   onPullPhasePersisted?: Parameters<typeof reconcileBotSkillWorkspace>[0]['onPhasePersisted'];
 }
 
@@ -103,6 +107,7 @@ export class BotSkillSyncService {
   private readonly definitionService: BotDefinitionSyncService;
   private readonly baseRepository: BotSkillSyncBaseRepository;
   private readonly artifactStore: SimulatedSkillArtifactStore;
+  private readonly artifactTransport?: BotSkillArtifactTransport;
   private readonly onPullPhasePersisted?: BotSkillSyncServiceOptions['onPullPhasePersisted'];
 
   constructor(options: BotSkillSyncServiceOptions = {}) {
@@ -133,6 +138,15 @@ export class BotSkillSyncService {
         simulatedCloudRoot: options.simulatedCloudRoot,
         env: this.env,
       });
+    this.artifactTransport = options.artifactTransport === undefined
+      ? (options.artifactStore || options.simulatedCloudRoot
+        ? undefined
+        : createSkillHubBotSkillArtifactTransport({
+          runtimeRoot: this.runtimeRoot,
+          env: this.env,
+          artifactStore: this.artifactStore,
+        }))
+      : options.artifactTransport ?? undefined;
     this.onPullPhasePersisted = options.onPullPhasePersisted;
   }
 
@@ -233,7 +247,7 @@ export class BotSkillSyncService {
         ) {
           return this.pullSafely(botSkills, context, manifest, cloud, baseRead, false);
         }
-        const prepared = this.preparePush(manifest, undefined);
+        const prepared = await this.preparePush(manifest, context, undefined);
         if (
           cloudProjectionDigest(prepared.cloudSkills)
           === cloudProjectionDigest(cloudSkills)
@@ -276,6 +290,12 @@ export class BotSkillSyncService {
       }
       if (cloudDigest !== baseRead.base.cloud.digest) {
         return this.pullSafely(botSkills, context, manifest, cloud, baseRead, false);
+      }
+      if (
+        this.artifactTransport
+        && baseRead.base.bindings.some(binding => binding.storage === 'simulated-private')
+      ) {
+        return this.push(botSkills, context, 'transport_migration', manifest, baseRead);
       }
       const committedCloud = this.writeCacheFromLatestCanonical(
         botId,
@@ -351,7 +371,7 @@ export class BotSkillSyncService {
   private async push(
     botSkills: BotSkillService,
     context: { botId: string; workspaceId: string },
-    reason: 'local_changed' | 'cloud_missing' | 'legacy_migration',
+    reason: PushReason,
     knownManifest?: LocalSkillManifest,
     knownBase?: BotSkillSyncBaseReadResult,
     knownPrepared?: PreparedPush,
@@ -381,7 +401,7 @@ export class BotSkillSyncService {
   private async pushUnsafe(
     botSkills: BotSkillService,
     context: { botId: string; workspaceId: string },
-    reason: 'local_changed' | 'cloud_missing' | 'legacy_migration',
+    reason: PushReason,
     knownManifest?: LocalSkillManifest,
     knownBase?: BotSkillSyncBaseReadResult,
     knownPrepared?: PreparedPush,
@@ -397,8 +417,9 @@ export class BotSkillSyncService {
         manifest,
       );
     }
-    const prepared = knownPrepared ?? this.preparePush(
+    const prepared = knownPrepared ?? await this.preparePush(
       manifest,
+      context,
       baseRead.status === 'valid' ? baseRead.base : undefined,
     );
     const confirmed = await botSkills.scanManifest();
@@ -408,7 +429,7 @@ export class BotSkillSyncService {
       !== localProjectionDigest(prepared.localEntries)
     ) {
       throw new BotSkillSyncError(
-        'Local Skills changed while the simulated upload was being prepared.',
+        'Local Skills changed while the upload was being prepared.',
         'BOT_SKILL_SYNC_LOCAL_CHANGED',
         true,
         confirmed,
@@ -442,32 +463,69 @@ export class BotSkillSyncService {
     };
   }
 
-  private preparePush(
+  private async preparePush(
     manifest: LocalSkillManifest,
+    context: { botId: string; workspaceId: string },
     previousBase?: BotSkillSyncBase,
-  ): PreparedPush {
+  ): Promise<PreparedPush> {
     const localEntries = projectLocalManifest(manifest);
     const bindings: BotSkillSyncBinding[] = [];
     const cloudSkills: BotSkillRef[] = [];
     const previousBindings = new Map(
       (previousBase?.bindings ?? []).map(binding => [binding.localSkillId, binding]),
     );
+    const previousLocalEntries = new Map(
+      (previousBase?.local.entries ?? []).map(entry => [entry.localSkillId, entry]),
+    );
     for (const entry of manifest.entries) {
       const publicRef = unmodifiedPublicRef(entry);
-      const artifact = this.artifactStore.put({
+      const previous = previousBindings.get(entry.localSkillId);
+      const previousLocal = previousLocalEntries.get(entry.localSkillId);
+      const reusablePrivate = (
+        !publicRef
+        && this.artifactTransport
+        && previous?.storage === 'skillhub-private'
+        && previousLocal?.contentHash === entry.contentHash
+      );
+      if (reusablePrivate) {
+        bindings.push({ ...previous, ref: { ...previous.ref } });
+        if (entry.enabled) cloudSkills.push(previous.ref);
+        continue;
+      }
+      const snapshotOptions = {
         botId: required(manifest.botId, 'manifest.botId'),
         skillsRoot: this.skillsRoot(),
         entry,
         ...(publicRef ? { publicRef } : {}),
-      });
-      const previous = previousBindings.get(entry.localSkillId);
+      };
+      const artifact = await this.prepareArtifactForPush(
+        snapshotOptions,
+        entry,
+        publicRef,
+        context,
+      );
       if (
         previous
-        && previous.storage === 'simulated-private'
-        && artifact.storage === 'simulated-private'
+        && (
+          previous.storage === 'simulated-private'
+          || previous.storage === 'skillhub-private'
+        )
+        && artifact.storage === previous.storage
         && previous.ref.skillId !== artifact.ref.skillId
       ) {
         throw new Error(`Private Skill identity changed for ${entry.localSkillId}`);
+      }
+      if (
+        !publicRef
+        && this.artifactTransport
+        && (
+          artifact.storage !== 'skillhub-private'
+          || artifact.botId !== context.botId
+          || artifact.localSkillId !== entry.localSkillId
+          || artifact.contentHash !== entry.contentHash
+        )
+      ) {
+        throw new Error(`Private Skill upload verification failed for ${entry.localSkillId}`);
       }
       bindings.push({
         localSkillId: entry.localSkillId,
@@ -484,13 +542,32 @@ export class BotSkillSyncService {
     };
   }
 
-  private pull(
+  private async prepareArtifactForPush(
+    snapshotOptions: Parameters<SimulatedSkillArtifactStore['snapshot']>[0],
+    entry: LocalSkillManifestEntry,
+    publicRef: BotSkillRef | undefined,
+    context: { botId: string; workspaceId: string },
+  ): Promise<SimulatedSkillArtifact> {
+    const snapshot = !publicRef && this.artifactTransport
+      ? this.artifactStore.snapshot(snapshotOptions)
+      : this.artifactStore.put(snapshotOptions);
+    if (publicRef || !this.artifactTransport) return snapshot;
+    return this.artifactTransport.upsertPrivate({
+      ...context,
+      artifact: snapshot,
+      ...(entry.skillId && entry.version
+        ? { forkedFrom: { skillId: entry.skillId, version: entry.version } }
+        : {}),
+    });
+  }
+
+  private async pull(
     _botSkills: BotSkillService,
     context: { botId: string; workspaceId: string },
     manifest: LocalSkillManifest,
     cloud: BotDefinition,
     baseRead: BotSkillSyncBaseReadResult,
-  ): BotSkillSyncResult {
+  ): Promise<BotSkillSyncResult> {
     this.requireCompleteLocal(manifest, context.botId, context.workspaceId);
     const cloudSkills = projectCloudSkills(cloud.skills ?? []);
     const previousBase = baseRead.status === 'valid' ? baseRead.base : undefined;
@@ -504,8 +581,11 @@ export class BotSkillSyncService {
     const desired: BotSkillWorkspaceDesiredEntry[] = [];
     const desiredArtifacts = new Map<string, SimulatedSkillArtifact>();
     for (const ref of cloudSkills) {
-      const artifact = this.artifactStore.read(ref);
-      if (artifact.storage === 'simulated-private' && artifact.botId !== context.botId) {
+      const artifact = await this.resolveArtifact(ref, context);
+      if (
+        (artifact.storage === 'simulated-private' || artifact.storage === 'skillhub-private')
+        && artifact.botId !== context.botId
+      ) {
         throw new BotSkillSyncError(
           `Private Skill artifact belongs to another Bot: ${ref.skillId}@${ref.version}`,
           'BOT_SKILL_ARTIFACT_OWNER_MISMATCH',
@@ -516,7 +596,10 @@ export class BotSkillSyncService {
       const previous = bindingsByExactRef.get(refKey(ref))
         ?? bindingsBySkillId.get(ref.skillId);
       const localSkillId = previous?.localSkillId
-        ?? (artifact.storage === 'simulated-private'
+        ?? ((
+          artifact.storage === 'simulated-private'
+          || artifact.storage === 'skillhub-private'
+        )
           ? artifact.localSkillId
           : restoredPublicLocalSkillId(context.workspaceId, ref));
       desired.push({
@@ -545,7 +628,7 @@ export class BotSkillSyncService {
             manifest,
           );
         }
-        const artifact = this.artifactStore.read(binding.ref);
+        const artifact = await this.resolveArtifact(binding.ref, context);
         desired.push({
           artifact,
           localSkillId: local.localSkillId,
@@ -609,16 +692,16 @@ export class BotSkillSyncService {
     };
   }
 
-  private pullSafely(
+  private async pullSafely(
     botSkills: BotSkillService,
     context: { botId: string; workspaceId: string },
     manifest: LocalSkillManifest,
     cloud: BotDefinition,
     baseRead: BotSkillSyncBaseReadResult,
     safeToUseLocal: boolean,
-  ): BotSkillSyncResult {
+  ): Promise<BotSkillSyncResult> {
     try {
-      return this.pull(botSkills, context, manifest, cloud, baseRead);
+      return await this.pull(botSkills, context, manifest, cloud, baseRead);
     } catch (error) {
       if (error instanceof BotSkillSyncError) {
         if (error.safeToUseLocal === safeToUseLocal) throw error;
@@ -640,6 +723,32 @@ export class BotSkillSyncService {
       (wrapped as any).cause = error;
       throw wrapped;
     }
+  }
+
+  private async resolveArtifact(
+    ref: BotSkillRef,
+    context: { botId: string; workspaceId: string },
+  ): Promise<SimulatedSkillArtifact> {
+    try {
+      return this.artifactStore.read(ref);
+    } catch (error: any) {
+      if (error?.code !== 'SIMULATED_SKILL_ARTIFACT_MISSING') throw error;
+    }
+    if (ref.skillId.startsWith('sim-private:')) {
+      const error: NodeJS.ErrnoException = new Error(
+        `Legacy private Skill artifact is missing: ${ref.skillId}@${ref.version}; its original device must migrate it before another device can restore it.`,
+      );
+      error.code = 'BOT_SKILL_LEGACY_ARTIFACT_MIGRATION_REQUIRED';
+      throw error;
+    }
+    if (!this.artifactTransport) {
+      const error: NodeJS.ErrnoException = new Error(
+        `Skill artifact is not cached: ${ref.skillId}@${ref.version}`,
+      );
+      error.code = 'BOT_SKILL_ARTIFACT_TRANSPORT_UNAVAILABLE';
+      throw error;
+    }
+    return this.artifactTransport.fetchVerified(ref, context);
   }
 
   private requireCloud(botId: string, manifest: LocalSkillManifest): BotDefinition {
@@ -716,6 +825,12 @@ interface PreparedPush {
   cloudSkills: BotSkillRef[];
 }
 
+type PushReason =
+  | 'local_changed'
+  | 'cloud_missing'
+  | 'legacy_migration'
+  | 'transport_migration';
+
 export function createBotSkillSyncService(
   options: BotSkillSyncServiceOptions = {},
 ): BotSkillSyncService {
@@ -725,6 +840,7 @@ export function createBotSkillSyncService(
 function unmodifiedPublicRef(entry: LocalSkillManifestEntry): BotSkillRef | undefined {
   if (
     entry.source !== 'skillhub'
+    || entry.sourceVisibility === 'private'
     || !entry.skillId
     || !entry.version
     || !entry.installedContentHash

--- a/src/skillhub/client.ts
+++ b/src/skillhub/client.ts
@@ -1,8 +1,12 @@
+import * as crypto from 'node:crypto';
 import { loadSkillHubConfig, SkillHubConfig } from './config';
 import { SkillHubSessionStore } from './session-store';
 import type {
   SkillHubAuthState,
+  SkillHubBotCredential,
   SkillHubDeveloperDashboard,
+  SkillHubPrivateSkillResponse,
+  SkillHubPrivateUpsertInput,
   SkillHubRegistryEntry,
   SkillHubSearchResponse,
   SkillHubSkillDetailResponse,
@@ -36,6 +40,7 @@ export interface SkillHubCatsCoExchangeInput {
 }
 
 const MAX_SKILLHUB_PACKAGE_BYTES = 32 * 1024 * 1024;
+const MAX_SKILLHUB_JSON_BYTES = 2 * 1024 * 1024;
 
 export class SkillHubClient {
   readonly config: SkillHubConfig;
@@ -44,6 +49,7 @@ export class SkillHubClient {
 
   constructor(options: SkillHubClientOptions = {}) {
     this.config = loadSkillHubConfig({ baseUrl: options.baseUrl });
+    assertSafeSkillHubBaseUrl(this.config.baseUrl);
     this.sessionStore = new SkillHubSessionStore(this.config);
     this.timeoutMs = options.timeoutMs ?? 15_000;
   }
@@ -104,42 +110,81 @@ export class SkillHubClient {
   }
 
   async getSkill(skillId: string): Promise<SkillHubSkillDetailResponse> {
-    return this.request<SkillHubSkillDetailResponse>('GET', `/api/skills/${encodeSkillIdPath(skillId)}`);
-  }
-
-  async getVersion(skillId: string, version: string): Promise<SkillHubSkillDetailResponse> {
+    const normalizedSkillId = validateSkillId(skillId);
     return this.request<SkillHubSkillDetailResponse>(
       'GET',
-      `/api/skills/${encodeSkillIdPath(skillId)}/versions/${encodeURIComponent(version)}`,
+      `/api/skills/${encodeSkillIdPath(normalizedSkillId)}`,
     );
   }
 
-  async getTrust(): Promise<SkillHubTrustResponse> {
-    return this.request<SkillHubTrustResponse>('GET', '/api/trust/public-keys');
+  async getVersion(
+    skillId: string,
+    version: string,
+    credential?: SkillHubBotCredential,
+  ): Promise<SkillHubSkillDetailResponse> {
+    const ref = validateSkillRef(skillId, version);
+    return this.request<SkillHubSkillDetailResponse>(
+      'GET',
+      `/api/skills/${encodeSkillIdPath(ref.skillId)}/versions/${encodeURIComponent(ref.version)}`,
+      undefined,
+      credential,
+    );
   }
 
-  async downloadPackage(entry: SkillHubRegistryEntry): Promise<Buffer> {
-    const path = `/api/skills/${encodeSkillIdPath(entry.skillId)}/versions/${encodeURIComponent(entry.latestVersion)}/download`;
-    const response = await this.fetchRaw('GET', path);
-    const declaredLength = Number(response.headers.get('content-length') || 0);
-    if (Number.isFinite(declaredLength) && declaredLength > MAX_SKILLHUB_PACKAGE_BYTES) {
-      throw packageTooLarge();
-    }
-    if (!response.body) return Buffer.alloc(0);
-    const reader = response.body.getReader();
-    const chunks: Buffer[] = [];
-    let total = 0;
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      total += value.byteLength;
-      if (total > MAX_SKILLHUB_PACKAGE_BYTES) {
-        await reader.cancel().catch(() => undefined);
-        throw packageTooLarge();
-      }
-      chunks.push(Buffer.from(value));
-    }
-    return Buffer.concat(chunks, total);
+  async upsertPrivateSkill(
+    input: SkillHubPrivateUpsertInput,
+    credential: SkillHubBotCredential,
+  ): Promise<SkillHubPrivateSkillResponse> {
+    const botId = validatePathSegment(input?.botId, 'botId');
+    const workspaceId = validatePathSegment(input?.workspaceId, 'workspaceId');
+    const localSkillId = validatePathSegment(input?.localSkillId, 'localSkillId');
+    const contentHash = validateSha256(input?.contentHash, 'contentHash');
+    const name = validateText(input?.name, 'name');
+    const installName = validatePathSegment(input?.installName, 'installName');
+    const files = validatePrivateSourceFiles(input?.files);
+    const normalizedCredential = validateBotCredential(credential, botId);
+    const forkedFrom = input.forkedFrom
+      ? validateSkillRef(input.forkedFrom.skillId, input.forkedFrom.version)
+      : undefined;
+    return this.request<SkillHubPrivateSkillResponse>(
+      'PUT',
+      `/api/bots/${encodeURIComponent(botId)}/private-skills/${encodeURIComponent(localSkillId)}/versions/${contentHash}`,
+      {
+        botId,
+        workspaceId,
+        localSkillId,
+        contentHash,
+        name,
+        installName,
+        ...(forkedFrom ? { forkedFrom } : {}),
+        files,
+      },
+      normalizedCredential,
+    );
+  }
+
+  async getTrust(credential?: SkillHubBotCredential): Promise<SkillHubTrustResponse> {
+    return this.request<SkillHubTrustResponse>(
+      'GET',
+      '/api/trust/public-keys',
+      undefined,
+      credential,
+    );
+  }
+
+  async downloadPackage(
+    entry: SkillHubRegistryEntry,
+    credential?: SkillHubBotCredential,
+  ): Promise<Buffer> {
+    const ref = validateSkillRef(entry?.skillId, entry?.latestVersion);
+    const apiPath = `/api/skills/${encodeSkillIdPath(ref.skillId)}/versions/${encodeURIComponent(ref.version)}/download`;
+    const response = await this.fetchRaw('GET', apiPath, undefined, credential);
+    return readBoundedResponseBytes(
+      response,
+      MAX_SKILLHUB_PACKAGE_BYTES,
+      this.timeoutMs,
+      packageTooLarge,
+    );
   }
 
   async getDeveloperDashboard(): Promise<SkillHubDeveloperDashboard> {
@@ -205,19 +250,39 @@ export class SkillHubClient {
     );
   }
 
-  private async request<T>(method: string, apiPath: string, body?: unknown): Promise<T> {
-    const response = await this.fetchRaw(method, apiPath, body);
-    const text = await response.text();
+  private async request<T>(
+    method: string,
+    apiPath: string,
+    body?: unknown,
+    credential?: SkillHubBotCredential,
+  ): Promise<T> {
+    const response = await this.fetchRaw(method, apiPath, body, credential);
+    const text = await readBoundedResponseText(
+      response,
+      MAX_SKILLHUB_JSON_BYTES,
+      this.timeoutMs,
+    );
     return text ? JSON.parse(text) as T : {} as T;
   }
 
-  private async fetchRaw(method: string, apiPath: string, body?: unknown): Promise<Response> {
+  private async fetchRaw(
+    method: string,
+    apiPath: string,
+    body?: unknown,
+    credential?: SkillHubBotCredential,
+  ): Promise<Response> {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), this.timeoutMs);
     const headers: Record<string, string> = {};
     if (body !== undefined) headers['Content-Type'] = 'application/json';
-    const cookie = this.sessionStore.getCookieHeader(this.config.baseUrl);
-    if (cookie) headers.Cookie = cookie;
+    const botCredential = credential && validateBotCredential(credential);
+    if (botCredential) {
+      headers.Authorization = `ApiKey ${botCredential.apiKey}`;
+      headers['X-CatsCo-Bot-Id'] = botCredential.botId;
+    } else {
+      const cookie = this.sessionStore.getCookieHeader(this.config.baseUrl);
+      if (cookie) headers.Cookie = cookie;
+    }
 
     let response: Response;
     try {
@@ -226,6 +291,7 @@ export class SkillHubClient {
         headers,
         body: body === undefined ? undefined : JSON.stringify(body),
         signal: controller.signal,
+        redirect: botCredential ? 'error' : 'follow',
       });
     } catch (error: any) {
       if (error?.name === 'AbortError') {
@@ -236,10 +302,20 @@ export class SkillHubClient {
       clearTimeout(timer);
     }
 
-    this.sessionStore.storeSetCookieHeaders(this.config.baseUrl, response.headers);
+    if (!botCredential) {
+      this.sessionStore.storeSetCookieHeaders(this.config.baseUrl, response.headers);
+    }
 
     if (!response.ok) {
-      const text = await response.text().catch(() => '');
+      const text = await readBoundedResponseText(
+        response,
+        MAX_SKILLHUB_JSON_BYTES,
+        this.timeoutMs,
+      )
+        .catch(error => {
+          if ((error as any)?.code === 'skillhub.response_too_large') throw error;
+          return '';
+        });
       let message = `SkillHub request failed: HTTP ${response.status}`;
       let code = 'skillhub.request_failed';
       if (text) {
@@ -261,11 +337,260 @@ export class SkillHubClient {
 }
 
 function encodeSkillIdPath(skillId: string): string {
-  return String(skillId || '')
+  return skillId
     .split('/')
-    .filter(Boolean)
     .map(part => encodeURIComponent(part))
     .join('/');
+}
+
+function validateSkillRef(skillIdValue: unknown, versionValue: unknown): {
+  skillId: string;
+  version: string;
+} {
+  const skillId = validateSkillId(skillIdValue);
+  const version = validatePathSegment(versionValue, 'version');
+  return { skillId, version };
+}
+
+function validateSkillId(value: unknown): string {
+  const skillId = String(value ?? '').trim();
+  if (
+    !skillId
+    || Buffer.byteLength(skillId, 'utf8') > 512
+    || skillId.split('/').length > 32
+    || skillId.includes('\\')
+    || skillId.includes('?')
+    || skillId.includes('#')
+    || skillId.split('/').some(part => !part || part === '.' || part === '..')
+    || /[\u0000-\u001f\u007f]/.test(skillId)
+  ) {
+    throw invalidReference('skillId');
+  }
+  return skillId;
+}
+
+function validatePathSegment(value: unknown, field: string): string {
+  const text = String(value ?? '').trim();
+  if (
+    !text
+    || Buffer.byteLength(text, 'utf8') > 512
+    || text === '.'
+    || text === '..'
+    || /[\/\\?#\u0000-\u001f\u007f]/.test(text)
+  ) {
+    throw invalidReference(field);
+  }
+  return text;
+}
+
+function validateText(value: unknown, field: string): string {
+  const text = String(value ?? '').trim();
+  if (
+    !text
+    || Buffer.byteLength(text, 'utf8') > 1024
+    || /[\u0000-\u001f\u007f]/u.test(text)
+  ) {
+    throw invalidReference(field);
+  }
+  return text;
+}
+
+function validatePrivateSourceFiles(
+  value: SkillHubPrivateUpsertInput['files'] | undefined,
+): SkillHubPrivateUpsertInput['files'] {
+  if (!Array.isArray(value) || value.length === 0 || value.length > 256) {
+    throw invalidReference('files');
+  }
+  let total = 0;
+  const seen = new Set<string>();
+  const normalized = value.map(file => {
+    const filePath = String(file?.path ?? '').normalize('NFC');
+    const segments = filePath.split('/');
+    if (
+      !filePath
+      || Buffer.byteLength(filePath, 'utf8') > 512
+      || filePath.includes('\\')
+      || filePath.startsWith('/')
+      || segments.length > 24
+      || segments.some(segment => (
+        !segment
+        || segment === '.'
+        || segment === '..'
+        || /[<>:"|?*\u0000-\u001f\u007f]/u.test(segment)
+        || /[ .]$/u.test(segment)
+        || /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\.|$)/iu.test(segment)
+      ))
+    ) {
+      throw invalidReference('files.path');
+    }
+    const portable = filePath.toLocaleLowerCase('en-US');
+    if (seen.has(portable)) throw invalidReference('files.path');
+    seen.add(portable);
+    const contentBase64 = String(file?.contentBase64 ?? '');
+    if (
+      contentBase64.length % 4 !== 0
+      || !/^[A-Za-z0-9+/]*={0,2}$/u.test(contentBase64)
+      || Buffer.from(contentBase64, 'base64').toString('base64') !== contentBase64
+    ) {
+      throw invalidReference('files.contentBase64');
+    }
+    const content = Buffer.from(contentBase64, 'base64');
+    if (
+      !Number.isSafeInteger(file?.size)
+      || file.size !== content.length
+      || content.length > 8 * 1024 * 1024
+      || validateSha256(file?.sha256, 'files.sha256')
+        !== cryptoSha256(content)
+    ) {
+      throw invalidReference('files');
+    }
+    total += content.length;
+    if (total > 20 * 1024 * 1024) throw invalidReference('files');
+    return {
+      path: filePath,
+      size: content.length,
+      sha256: cryptoSha256(content),
+      contentBase64,
+    };
+  });
+  if (normalized.filter(file => file.path === 'SKILL.md').length !== 1) {
+    throw invalidReference('files.SKILL.md');
+  }
+  return normalized;
+}
+
+function cryptoSha256(value: Buffer): string {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function validateSha256(value: unknown, field: string): string {
+  const text = String(value ?? '').trim().toLowerCase();
+  if (!/^[0-9a-f]{64}$/.test(text)) throw invalidReference(field);
+  return text;
+}
+
+function validateBotCredential(
+  value: SkillHubBotCredential | undefined,
+  expectedBotId?: string,
+): SkillHubBotCredential {
+  const botId = validatePathSegment(value?.botId, 'credential.botId');
+  const apiKey = String(value?.apiKey ?? '').trim();
+  if (!apiKey || Buffer.byteLength(apiKey, 'utf8') > 8192 || /[\r\n]/.test(apiKey)) {
+    throw invalidReference('credential.apiKey');
+  }
+  if (expectedBotId && botId !== expectedBotId) {
+    throw invalidReference('credential.botId');
+  }
+  return { botId, apiKey };
+}
+
+function invalidReference(field: string): Error {
+  const error = withStatus(new Error(`Invalid SkillHub ${field}.`), 400);
+  (error as any).code = 'skillhub.invalid_reference';
+  return error;
+}
+
+function assertSafeSkillHubBaseUrl(value: string): void {
+  const url = new URL(value);
+  if (url.username || url.password) {
+    throw new Error('SkillHub base URL must not contain credentials.');
+  }
+  if (url.protocol === 'https:') return;
+  if (url.protocol === 'http:' && isLoopbackHostname(url.hostname)) return;
+  throw new Error('SkillHub requires HTTPS except on a loopback address.');
+}
+
+function isLoopbackHostname(value: string): boolean {
+  const hostname = value.replace(/^\[|\]$/g, '').toLowerCase();
+  if (hostname === 'localhost' || hostname === '::1') return true;
+  const parts = hostname.split('.');
+  return parts.length === 4
+    && parts.every(part => /^\d{1,3}$/.test(part) && Number(part) <= 255)
+    && Number(parts[0]) === 127;
+}
+
+async function readBoundedResponseText(
+  response: Response,
+  maxBytes: number,
+  timeoutMs: number,
+): Promise<string> {
+  return (await readBoundedResponseBytes(
+    response,
+    maxBytes,
+    timeoutMs,
+    () => responseTooLarge(maxBytes),
+  )).toString('utf8');
+}
+
+async function readBoundedResponseBytes(
+  response: Response,
+  maxBytes: number,
+  timeoutMs: number,
+  tooLarge: () => Error,
+): Promise<Buffer> {
+  const declaredLength = Number(response.headers.get('content-length') || 0);
+  if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+    await response.body?.cancel().catch(() => undefined);
+    throw tooLarge();
+  }
+  if (!response.body) return Buffer.alloc(0);
+  const reader = response.body.getReader();
+  const chunks: Buffer[] = [];
+  let total = 0;
+  const deadline = Date.now() + timeoutMs;
+  while (true) {
+    let result: { done: boolean; value?: Uint8Array };
+    try {
+      result = await readBeforeDeadline(reader, deadline);
+    } catch (error) {
+      await reader.cancel().catch(() => undefined);
+      throw error;
+    }
+    const { done, value } = result;
+    if (done) break;
+    if (!value) continue;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      await reader.cancel().catch(() => undefined);
+      throw tooLarge();
+    }
+    chunks.push(Buffer.from(value));
+  }
+  return Buffer.concat(chunks, total);
+}
+
+async function readBeforeDeadline(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  deadline: number,
+): Promise<{ done: boolean; value?: Uint8Array }> {
+  const remaining = deadline - Date.now();
+  if (remaining <= 0) throw responseTimeout();
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      reader.read(),
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(responseTimeout()), remaining);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+function responseTooLarge(maxBytes: number): Error {
+  const error = withStatus(
+    new Error(`SkillHub JSON response exceeds ${maxBytes} bytes.`),
+    502,
+  );
+  (error as any).code = 'skillhub.response_too_large';
+  return error;
+}
+
+function responseTimeout(): Error {
+  const error = withStatus(new Error('SkillHub response body timed out.'), 408);
+  (error as any).code = 'skillhub.response_timeout';
+  return error;
 }
 
 function withStatus(error: Error, status: number): Error {

--- a/src/skillhub/install-marker.ts
+++ b/src/skillhub/install-marker.ts
@@ -1,10 +1,14 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import { normalizeBotSkillRef } from '../bot-definition/skill-ref';
 import { PathResolver } from '../utils/path-resolver';
 import type { SkillHubPackageInstallMarker } from './types';
 
 export const SKILLHUB_INSTALL_MARKER_FILE = '.xiaoba-skillhub-install.json';
 const MAX_INSTALL_MARKER_BYTES = 64 * 1024;
+const MAX_MARKER_TEXT_BYTES = 1024;
+const MAX_PACKAGE_URL_BYTES = 4096;
+const MAX_SIGNATURE_BYTES = 16 * 1024;
 
 export function readSkillHubInstallMarker(skillDir: string): SkillHubPackageInstallMarker | null {
   const markerPath = path.join(skillDir, SKILLHUB_INSTALL_MARKER_FILE);
@@ -14,28 +18,43 @@ export function readSkillHubInstallMarker(skillDir: string): SkillHubPackageInst
     if (!stat.isFile() || stat.isSymbolicLink() || stat.size > MAX_INSTALL_MARKER_BYTES) {
       return null;
     }
-    const value = JSON.parse(fs.readFileSync(markerPath, 'utf8')) as Partial<SkillHubPackageInstallMarker>;
-    if (
-      value?.source !== 'skillhub'
-      || !stringValue(value.skillId)
-      || !stringValue(value.name)
-      || !stringValue(value.installName)
-      || !stringValue(value.version)
-      || (value.installedContentHash !== undefined && !stringValue(value.installedContentHash))
-    ) {
-      return null;
-    }
-    return value as SkillHubPackageInstallMarker;
+    return normalizeInstallMarker(JSON.parse(fs.readFileSync(markerPath, 'utf8')));
   } catch {
     return null;
   }
 }
 
 export function writeSkillHubInstallMarker(skillDir: string, marker: SkillHubPackageInstallMarker): void {
+  let rawSerialized: string;
+  try {
+    rawSerialized = `${JSON.stringify(marker, null, 2)}\n`;
+  } catch (cause) {
+    const error: any = new Error('SkillHub install marker is invalid.');
+    error.code = 'INSTALL_MARKER_INVALID';
+    error.status = 422;
+    error.cause = cause;
+    throw error;
+  }
+  if (Buffer.byteLength(rawSerialized, 'utf8') > MAX_INSTALL_MARKER_BYTES) {
+    const error: any = new Error('SkillHub install marker exceeds the local metadata limit.');
+    error.code = 'INSTALL_MARKER_TOO_LARGE';
+    error.status = 422;
+    throw error;
+  }
+  let normalized: SkillHubPackageInstallMarker;
+  try {
+    normalized = normalizeInstallMarker(marker);
+  } catch (cause) {
+    const error: any = new Error('SkillHub install marker is invalid.');
+    error.code = 'INSTALL_MARKER_INVALID';
+    error.status = 422;
+    error.cause = cause;
+    throw error;
+  }
   fs.mkdirSync(skillDir, { recursive: true });
   const markerPath = path.join(skillDir, SKILLHUB_INSTALL_MARKER_FILE);
   const tempPath = `${markerPath}.tmp-${process.pid}-${Date.now()}`;
-  const serialized = `${JSON.stringify(marker, null, 2)}\n`;
+  const serialized = `${JSON.stringify(normalized, null, 2)}\n`;
   if (Buffer.byteLength(serialized, 'utf8') > MAX_INSTALL_MARKER_BYTES) {
     const error: any = new Error('SkillHub install marker exceeds the local metadata limit.');
     error.code = 'INSTALL_MARKER_TOO_LARGE';
@@ -65,4 +84,134 @@ export function listInstalledSkillHubSkills(userId?: string): SkillHubPackageIns
 
 function stringValue(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeInstallMarker(value: unknown): SkillHubPackageInstallMarker {
+  if (!isRecord(value) || value.source !== 'skillhub') {
+    throw new Error('marker.source must be skillhub');
+  }
+
+  const ref = normalizeBotSkillRef({
+    skillId: value.skillId as string,
+    version: value.version as string,
+  });
+  const visibility = value.visibility === undefined ? 'public' : value.visibility;
+  if (visibility !== 'public' && visibility !== 'private') {
+    throw new Error('marker.visibility must be public or private');
+  }
+
+  const hasOwnerBotId = Object.prototype.hasOwnProperty.call(value, 'ownerBotId');
+  const hasLocalSkillId = Object.prototype.hasOwnProperty.call(value, 'localSkillId');
+  if (visibility === 'public' && (hasOwnerBotId || hasLocalSkillId)) {
+    throw new Error('public marker must not contain private ownership fields');
+  }
+
+  const signature = value.signature;
+  if (!isRecord(signature) || signature.algorithm !== 'ed25519') {
+    throw new Error('marker.signature.algorithm must be ed25519');
+  }
+
+  return {
+    source: 'skillhub',
+    visibility,
+    ...(value.userId !== undefined
+      ? { userId: requiredText(value.userId, 'marker.userId') }
+      : {}),
+    ...(visibility === 'private'
+      ? {
+        ownerBotId: requiredText(value.ownerBotId, 'marker.ownerBotId'),
+        localSkillId: requiredText(value.localSkillId, 'marker.localSkillId'),
+      }
+      : {}),
+    skillId: ref.skillId,
+    name: requiredText(value.name, 'marker.name').normalize('NFC'),
+    installName: normalizeInstallName(value.installName),
+    version: ref.version,
+    packageChecksumSha256: requiredHash(
+      value.packageChecksumSha256,
+      'marker.packageChecksumSha256',
+    ),
+    ...(value.installedContentHash !== undefined
+      ? {
+        installedContentHash: requiredHash(
+          value.installedContentHash,
+          'marker.installedContentHash',
+        ),
+      }
+      : {}),
+    signature: {
+      algorithm: 'ed25519',
+      keyId: requiredText(signature.keyId, 'marker.signature.keyId'),
+      signature: requiredText(
+        signature.signature,
+        'marker.signature.signature',
+        MAX_SIGNATURE_BYTES,
+      ),
+      // Older public packages did not expose signedAt in registry metadata.
+      // Canonicalize those markers with the local install timestamp while
+      // requiring private packages to carry a stable signed timestamp.
+      signedAt: normalizeTimestamp(
+        signature.signedAt ?? (visibility === 'public' ? value.installedAt : undefined),
+        'marker.signature.signedAt',
+      ),
+    },
+    packageUrl: requiredText(value.packageUrl, 'marker.packageUrl', MAX_PACKAGE_URL_BYTES),
+    installedAt: normalizeTimestamp(value.installedAt, 'marker.installedAt'),
+  };
+}
+
+function normalizeInstallName(value: unknown): string {
+  const name = requiredText(value, 'marker.installName').normalize('NFC');
+  if (
+    name !== path.posix.basename(name)
+    || name !== path.win32.basename(name)
+    || name === '.'
+    || name === '..'
+    || /[<>:"/\\|?*\u0000-\u001f\u007f]/u.test(name)
+    || /[ .]$/u.test(name)
+    || /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\.|$)/iu.test(name)
+  ) {
+    throw new Error('marker.installName is not a safe portable directory name');
+  }
+  return name;
+}
+
+function requiredText(
+  value: unknown,
+  field: string,
+  maxBytes = MAX_MARKER_TEXT_BYTES,
+): string {
+  const text = stringValue(value);
+  if (
+    !text
+    || Buffer.byteLength(text, 'utf8') > maxBytes
+    || /[\u0000-\u001f\u007f]/u.test(text)
+  ) {
+    throw new Error(`${field} is missing, too long, or contains control characters`);
+  }
+  return text;
+}
+
+function requiredHash(value: unknown, field: string): string {
+  const hash = requiredText(value, field).toLowerCase();
+  if (!/^[0-9a-f]{64}$/u.test(hash)) {
+    throw new Error(`${field} must be a SHA-256 hex digest`);
+  }
+  return hash;
+}
+
+function normalizeTimestamp(value: unknown, field: string): string {
+  const timestamp = requiredText(value, field);
+  const match = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(?:\.(\d{1,3}))?Z$/u.exec(timestamp);
+  if (!match) throw new Error(`${field} must be an ISO-8601 UTC timestamp`);
+  const parsed = new Date(timestamp);
+  const normalized = `${match[1]}.${(match[2] ?? '').padEnd(3, '0')}Z`;
+  if (!Number.isFinite(parsed.getTime()) || parsed.toISOString() !== normalized) {
+    throw new Error(`${field} must be a valid timestamp`);
+  }
+  return normalized;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
 }

--- a/src/skillhub/types.ts
+++ b/src/skillhub/types.ts
@@ -61,7 +61,10 @@ export type SkillHubSubscriptionScope =
 
 export interface SkillHubPackageInstallMarker {
   source: 'skillhub';
+  visibility?: 'public' | 'private';
   userId?: string;
+  ownerBotId?: string;
+  localSkillId?: string;
   skillId: string;
   name: string;
   installName: string;
@@ -75,6 +78,10 @@ export interface SkillHubPackageInstallMarker {
 }
 
 export type SkillHubRegistryEntry = VerifierRegistryEntry & {
+  visibility?: 'public' | 'private';
+  ownerBotId?: string;
+  localSkillId?: string;
+  installName?: string;
   contentHash?: string;
   description?: string;
   categories?: string[];
@@ -83,6 +90,37 @@ export type SkillHubRegistryEntry = VerifierRegistryEntry & {
   runtime?: Record<string, unknown>;
   riskLevel?: string;
 };
+
+export interface SkillHubBotCredential {
+  botId: string;
+  apiKey: string;
+}
+
+export interface SkillHubPrivateUpsertInput {
+  botId: string;
+  workspaceId: string;
+  localSkillId: string;
+  contentHash: string;
+  name: string;
+  installName: string;
+  forkedFrom?: { skillId: string; version: string };
+  files: Array<{
+    path: string;
+    size: number;
+    sha256: string;
+    contentBase64: string;
+  }>;
+}
+
+export interface SkillHubPrivateSkillResponse {
+  skill: SkillHubRegistryEntry & {
+    visibility: 'private';
+    ownerBotId: string;
+    localSkillId: string;
+    installName: string;
+    contentHash: string;
+  };
+}
 
 export interface UserSkillSubscription {
   skillId: string;

--- a/src/tools/share-skillhub-skill-tool.ts
+++ b/src/tools/share-skillhub-skill-tool.ts
@@ -1,5 +1,9 @@
 import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import { SkillHubService } from '../skillhub/service';
+import {
+  isCatsCoLocalOwnerSelfContext,
+  isCatsCoToolGatewayContext,
+} from './tool-gateway';
 
 export class ShareSkillHubSkillTool implements Tool {
   definition: ToolDefinition = {
@@ -29,7 +33,19 @@ export class ShareSkillHubSkillTool implements Tool {
     },
   };
 
-  async execute(args: any, _context: ToolExecutionContext): Promise<ToolExecutionResult> {
+  async execute(args: any, context: ToolExecutionContext): Promise<ToolExecutionResult> {
+    if (
+      isCatsCoToolGatewayContext(context)
+      && !isCatsCoLocalOwnerSelfContext(context)
+    ) {
+      return {
+        ok: false,
+        errorCode: 'PERMISSION_DENIED',
+        message: 'Only the local CatsCo owner can share local Skills to SkillHub.',
+        retryable: false,
+      };
+    }
+
     const skillName = String(args?.skillName || args?.skill || args?.name || '').trim();
     if (!skillName) {
       return {

--- a/tests/bot-skill-private-sync.test.ts
+++ b/tests/bot-skill-private-sync.test.ts
@@ -1,0 +1,417 @@
+import assert from 'node:assert/strict';
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import { FileBotDefinitionRepository } from '../src/bot-definition/repository';
+import { createBotDefinitionSyncService } from '../src/bot-definition/service';
+import { BOT_DEFINITION_SCHEMA, type BotSkillRef } from '../src/bot-definition/types';
+import type {
+  BotSkillArtifactTransport,
+  BotSkillArtifactTransportContext,
+  BotSkillPrivateUploadInput,
+} from '../src/bot-skills/artifact-transport';
+import { FileSimulatedSkillArtifactStore, type SimulatedSkillArtifact } from '../src/bot-skills/simulated-artifact-store';
+import { SkillHubBotSkillArtifactTransport } from '../src/bot-skills/skillhub-artifact-transport';
+import { scanLocalSkillManifest } from '../src/bot-skills/local-manifest';
+import { FileBotSkillSyncBaseRepository } from '../src/bot-skills/sync-base';
+import { BotSkillSyncError, createBotSkillSyncService } from '../src/bot-skills/sync-service';
+import { createBotSkillWorkspaceService } from '../src/bot-skills/workspace-service';
+import { createCatsCoLocalConfigService } from '../src/catscompany/local-config';
+import { computeLocalSkillContentHash } from '../src/skillhub/local-skill-metadata';
+import { writeSkillHubInstallMarker } from '../src/skillhub/install-marker';
+
+describe('Bot private Skill synchronization', () => {
+  let root: string;
+  let cloudRoot: string;
+  let artifactRoot: string;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-private-sync-'));
+    cloudRoot = path.join(root, 'cloud');
+    artifactRoot = path.join(cloudRoot, 'artifacts');
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('upserts a verified private version, stays quiet when unchanged, and versions edits', async () => {
+    const runtimeRoot = path.join(root, 'runtime-a');
+    const artifacts = artifactStore(runtimeRoot);
+    const transport = new FakePrivateTransport(artifacts);
+    const fixture = createFixture(runtimeRoot, artifacts, transport);
+    const skillFile = writeSkill(fixture.skillsRoot, '# v1\n');
+
+    const first = await fixture.sync.syncOnStartup('bot_A');
+    assert.equal(transport.upserts, 1);
+    assert.match(first.definition.skills![0].skillId, /^private:/);
+    assert.equal(first.base.bindings[0].storage, 'skillhub-private');
+    assert.equal(await fixture.sync.syncAfterTurn('bot_A').then(result => result.direction), 'none');
+    assert.equal(transport.upserts, 1);
+
+    fs.appendFileSync(skillFile, '\nlocal edit\n');
+    const second = await fixture.sync.syncAfterTurn('bot_A');
+    assert.equal(transport.upserts, 2);
+    assert.equal(second.definition.skills![0].skillId, first.definition.skills![0].skillId);
+    assert.notEqual(second.definition.skills![0].version, first.definition.skills![0].version);
+  });
+
+  test('treats a directory-only rename as workspace state without creating a duplicate private version', async () => {
+    const runtimeRoot = path.join(root, 'runtime-rename');
+    const artifacts = artifactStore(runtimeRoot);
+    const transport = new FakePrivateTransport(artifacts);
+    const fixture = createFixture(runtimeRoot, artifacts, transport);
+    writeSkill(fixture.skillsRoot, '# rename me\n');
+    const first = await fixture.sync.syncOnStartup('bot_A');
+    fs.rmSync(artifacts.getPath(first.definition.skills![0]));
+    transport.failUpload = true;
+
+    fs.renameSync(
+      path.join(fixture.skillsRoot, 'notes'),
+      path.join(fixture.skillsRoot, 'renamed-notes'),
+    );
+    const renamed = await fixture.sync.syncAfterTurn('bot_A');
+
+    assert.equal(transport.upserts, 1);
+    assert.deepEqual(renamed.definition.skills, first.definition.skills);
+    assert.equal(renamed.base.local.entries[0].path, 'renamed-notes');
+    assert.equal(renamed.base.bindings[0].localSkillId, first.base.bindings[0].localSkillId);
+  });
+
+  test('migrates a PR4 simulated-private binding even when Local and Cloud otherwise match Base', async () => {
+    const runtimeRoot = path.join(root, 'runtime-migration');
+    const artifacts = artifactStore(runtimeRoot);
+    const legacy = createFixture(runtimeRoot, artifacts, null);
+    writeSkill(legacy.skillsRoot, '# legacy\n');
+    const before = await legacy.sync.syncOnStartup('bot_A');
+    assert.match(before.definition.skills![0].skillId, /^sim-private:/);
+
+    const transport = new FakePrivateTransport(artifacts);
+    const migratedSync = createBotSkillSyncService({
+      runtimeRoot,
+      expectedBotId: 'bot_A',
+      workspaceService: legacy.workspace,
+      definitionRepository: legacy.definitions,
+      definitionService: legacy.definitionService,
+      baseRepository: legacy.base,
+      artifactStore: artifacts,
+      artifactTransport: transport,
+    });
+    const migrated = await migratedSync.syncOnStartup('bot_A');
+
+    assert.equal(migrated.reason, 'transport_migration');
+    assert.match(migrated.definition.skills![0].skillId, /^private:/);
+    assert.equal(migrated.base.bindings[0].storage, 'skillhub-private');
+    assert.equal(transport.upserts, 1);
+  });
+
+  test('turns a modified public Skill into a private fork without changing the public ref', async () => {
+    const runtimeRoot = path.join(root, 'runtime-public-fork');
+    const artifacts = artifactStore(runtimeRoot);
+    const transport = new FakePrivateTransport(artifacts);
+    const fixture = createFixture(runtimeRoot, artifacts, transport);
+    const skillFile = writeSkill(fixture.skillsRoot, '# public\n');
+    const skillDir = path.dirname(skillFile);
+    const publicRef = { skillId: 'alice/notes', version: '1.0.0' };
+    writeSkillHubInstallMarker(skillDir, {
+      source: 'skillhub',
+      visibility: 'public',
+      ...publicRef,
+      name: 'notes',
+      installName: 'notes',
+      packageChecksumSha256: 'a'.repeat(64),
+      installedContentHash: computeLocalSkillContentHash(skillDir),
+      signature: {
+        algorithm: 'ed25519',
+        keyId: 'public-key',
+        signature: 'public-signature',
+        signedAt: '2026-07-01T00:00:00.000Z',
+      },
+      packageUrl: 'skillhub:alice/notes@1.0.0',
+      installedAt: '2026-07-01T00:00:00.000Z',
+    });
+    const installed = await fixture.sync.syncOnStartup('bot_A');
+    assert.deepEqual(installed.definition.skills, [publicRef]);
+    assert.equal(transport.upserts, 0);
+
+    fs.appendFileSync(skillFile, '\nprivate edit\n');
+    const forked = await fixture.sync.syncAfterTurn('bot_A');
+
+    assert.equal(transport.upserts, 1);
+    assert.deepEqual(transport.lastForkedFrom, publicRef);
+    assert.match(forked.definition.skills![0].skillId, /^private:/);
+    assert.equal(forked.base.bindings[0].storage, 'skillhub-private');
+  });
+
+  test('does not let transport migration overwrite a Cloud change made after PR4 Base', async () => {
+    const runtimeRoot = path.join(root, 'runtime-migration-cloud-change');
+    const artifacts = artifactStore(runtimeRoot);
+    const legacy = createFixture(runtimeRoot, artifacts, null);
+    writeSkill(legacy.skillsRoot, '# legacy local\n');
+    await legacy.sync.syncOnStartup('bot_A');
+    const cloudRef = { skillId: 'alice/cloud-newer', version: '2.0.0' };
+    legacy.definitionService.updateSkills('bot_A', [cloudRef]);
+
+    const transport = new FakePrivateTransport(artifacts);
+    const migratedSync = createBotSkillSyncService({
+      runtimeRoot,
+      expectedBotId: 'bot_A',
+      workspaceService: legacy.workspace,
+      definitionRepository: legacy.definitions,
+      definitionService: legacy.definitionService,
+      baseRepository: legacy.base,
+      artifactStore: artifacts,
+      artifactTransport: transport,
+    });
+
+    await assert.rejects(
+      () => migratedSync.syncOnStartup('bot_A'),
+      (error: any) => error?.code === 'BOT_SKILL_PULL_FAILED',
+    );
+    assert.equal(transport.upserts, 0);
+    assert.deepEqual(legacy.definitions.readCanonical('bot_A')?.skills, [cloudRef]);
+  });
+
+  test('restores the same private localSkillId on a second workspace', async () => {
+    const firstRuntime = path.join(root, 'runtime-first');
+    const firstArtifacts = artifactStore(firstRuntime, path.join(root, 'cache-first'));
+    const remoteArtifacts = new Map<string, SimulatedSkillArtifact>();
+    const firstTransport = new FakePrivateTransport(firstArtifacts, remoteArtifacts);
+    const first = createFixture(firstRuntime, firstArtifacts, firstTransport);
+    writeSkill(first.skillsRoot, '# portable private\n');
+    const uploaded = await first.sync.syncOnStartup('bot_A');
+
+    const secondRuntime = path.join(root, 'runtime-second');
+    const secondArtifacts = artifactStore(secondRuntime, path.join(root, 'cache-second'));
+    const second = createFixture(
+      secondRuntime,
+      secondArtifacts,
+      new FakePrivateTransport(secondArtifacts, remoteArtifacts),
+      true,
+    );
+    const restored = await second.sync.syncOnStartup('bot_A', { workspaceWasMissing: true });
+
+    assert.equal(restored.direction, 'cloud_to_local');
+    assert.equal(restored.manifest.entries[0].localSkillId, uploaded.manifest.entries[0].localSkillId);
+    assert.notEqual(restored.workspaceId, uploaded.workspaceId);
+    assert.match(fs.readFileSync(path.join(second.skillsRoot, 'notes', 'SKILL.md'), 'utf8'), /portable private/);
+  });
+
+  test('keeps Local usable and does not advance Definition or Base when private upload fails', async () => {
+    const runtimeRoot = path.join(root, 'runtime-offline');
+    const artifacts = artifactStore(runtimeRoot);
+    const transport = new FakePrivateTransport(artifacts);
+    transport.failUpload = true;
+    const fixture = createFixture(runtimeRoot, artifacts, transport);
+    const skillFile = writeSkill(fixture.skillsRoot, '# offline edit\n');
+    const canonicalBefore = fs.readFileSync(fixture.definitions.getCanonicalPath('bot_A'), 'utf8');
+
+    await assert.rejects(
+      () => fixture.sync.syncOnStartup('bot_A'),
+      (error: any) => (
+        error instanceof BotSkillSyncError
+        && error.code === 'BOT_SKILL_PUSH_FAILED'
+        && error.safeToUseLocal
+      ),
+    );
+    assert.equal(fs.readFileSync(fixture.definitions.getCanonicalPath('bot_A'), 'utf8'), canonicalBefore);
+    assert.equal(fixture.base.inspect('bot_A', fixture.workspaceId).status, 'missing');
+    assert.match(fs.readFileSync(skillFile, 'utf8'), /offline edit/);
+  });
+
+  test('blocks high-confidence credentials before any private SkillHub request is sent', async () => {
+    const runtimeRoot = path.join(root, 'runtime-sensitive');
+    const artifacts = artifactStore(runtimeRoot);
+    const fixture = createFixture(runtimeRoot, artifacts, null);
+    writeSkill(fixture.skillsRoot, '# secret should stay local\n');
+    fs.writeFileSync(
+      path.join(fixture.skillsRoot, 'notes', 'config.json'),
+      '{"api_key":"abcdefghijklmnopqrstuvwxyz123456"}\n',
+    );
+    const manifest = scanLocalSkillManifest({
+      skillsRoot: fixture.skillsRoot,
+      botId: 'bot_A',
+      workspaceId: fixture.workspaceId,
+      createIdentities: true,
+    });
+    assert.equal(manifest.status, 'complete');
+    const snapshot = artifacts.snapshot({
+      botId: 'bot_A',
+      skillsRoot: fixture.skillsRoot,
+      entry: manifest.entries[0],
+    });
+    let requests = 0;
+    const client = {
+      upsertPrivateSkill: async () => {
+        requests += 1;
+        throw new Error('must not be reached');
+      },
+    };
+    const transport = new SkillHubBotSkillArtifactTransport({
+      runtimeRoot,
+      artifactStore: artifacts,
+      client: client as any,
+    });
+
+    await assert.rejects(
+      () => transport.upsertPrivate({
+        botId: 'bot_A',
+        workspaceId: fixture.workspaceId,
+        artifact: snapshot,
+      }),
+      (error: any) => error?.code === 'BOT_SKILL_PRIVATE_CONTENT_BLOCKED',
+    );
+    assert.equal(requests, 0);
+    assert.equal(fs.existsSync(artifacts.getPath(snapshot.ref)), false);
+  });
+
+  function artifactStore(
+    runtimeRoot: string,
+    rootPath = artifactRoot,
+  ): FileSimulatedSkillArtifactStore {
+    return new FileSimulatedSkillArtifactStore({ runtimeRoot, root: rootPath });
+  }
+
+  function createFixture(
+    runtimeRoot: string,
+    artifacts: FileSimulatedSkillArtifactStore,
+    transport: BotSkillArtifactTransport | null,
+    canonicalAlreadyExists = false,
+  ) {
+    fs.mkdirSync(runtimeRoot, { recursive: true });
+    createCatsCoLocalConfigService({ runtimeRoot }).save({
+      version: 1,
+      currentBot: { uid: 'bot_A', apiKey: 'bot-secret' },
+    });
+    const workspace = createBotSkillWorkspaceService({ runtimeRoot });
+    const state = workspace.ensureActive('bot_A', { allowCreate: true });
+    const definitions = new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot: cloudRoot });
+    if (!canonicalAlreadyExists) {
+      definitions.writeCanonical({
+        schema: BOT_DEFINITION_SCHEMA,
+        botId: 'bot_A',
+        model: { kind: 'catalog', modelId: 'test-model' },
+      });
+    }
+    const definitionService = createBotDefinitionSyncService({
+      runtimeRoot,
+      repository: definitions,
+      simulatedCloudRoot: cloudRoot,
+    });
+    const base = new FileBotSkillSyncBaseRepository({ runtimeRoot });
+    return {
+      skillsRoot: path.join(runtimeRoot, 'skills'),
+      workspaceId: state.workspaceId,
+      workspace,
+      definitions,
+      definitionService,
+      base,
+      sync: createBotSkillSyncService({
+        runtimeRoot,
+        expectedBotId: 'bot_A',
+        workspaceService: workspace,
+        definitionRepository: definitions,
+        definitionService,
+        baseRepository: base,
+        artifactStore: artifacts,
+        artifactTransport: transport,
+      }),
+    };
+  }
+});
+
+class FakePrivateTransport implements BotSkillArtifactTransport {
+  upserts = 0;
+  failUpload = false;
+  lastForkedFrom?: BotSkillRef;
+
+  constructor(
+    private readonly artifacts: FileSimulatedSkillArtifactStore,
+    private readonly remote = new Map<string, SimulatedSkillArtifact>(),
+  ) {}
+
+  async upsertPrivate(input: BotSkillPrivateUploadInput): Promise<SimulatedSkillArtifact> {
+    this.upserts += 1;
+    this.lastForkedFrom = input.forkedFrom && { ...input.forkedFrom };
+    if (this.failUpload) throw new Error('private SkillHub offline');
+    const ref = {
+      skillId: `private:${sha256(`${input.botId}\0${input.artifact.localSkillId}`)}`,
+      version: `content-${input.artifact.contentHash}`,
+    };
+    const artifact = this.artifacts.cacheVerified({
+      ref,
+      botId: input.botId,
+      localSkillId: input.artifact.localSkillId,
+      storage: 'skillhub-private',
+      name: input.artifact.name,
+      installName: input.artifact.installName,
+      contentHash: input.artifact.contentHash,
+      files: input.artifact.files,
+      installMarker: privateMarker(ref, input),
+    });
+    this.remote.set(refKey(ref), artifact);
+    return artifact;
+  }
+
+  async fetchVerified(
+    ref: BotSkillRef,
+    context: BotSkillArtifactTransportContext,
+  ): Promise<SimulatedSkillArtifact> {
+    const remote = this.remote.get(refKey(ref));
+    if (!remote) throw new Error('remote private artifact missing');
+    if (remote.botId !== context.botId) throw new Error('private owner mismatch');
+    return this.artifacts.cacheVerified({
+      ref: remote.ref,
+      botId: remote.botId,
+      localSkillId: remote.localSkillId,
+      storage: 'skillhub-private',
+      name: remote.name,
+      installName: remote.installName,
+      contentHash: remote.contentHash,
+      files: remote.files,
+      installMarker: remote.installMarker!,
+    });
+  }
+}
+
+function refKey(ref: BotSkillRef): string {
+  return `${ref.skillId}\0${ref.version}`;
+}
+
+function privateMarker(ref: BotSkillRef, input: BotSkillPrivateUploadInput) {
+  const signedAt = '2026-07-01T00:00:00.000Z';
+  return {
+    source: 'skillhub' as const,
+    visibility: 'private' as const,
+    ownerBotId: input.botId,
+    localSkillId: input.artifact.localSkillId,
+    skillId: ref.skillId,
+    name: input.artifact.name,
+    installName: input.artifact.installName,
+    version: ref.version,
+    packageChecksumSha256: sha256(`package\0${ref.skillId}\0${ref.version}`),
+    installedContentHash: input.artifact.contentHash,
+    signature: {
+      algorithm: 'ed25519' as const,
+      keyId: 'fake-key',
+      signature: Buffer.from('fake-signature').toString('base64'),
+      signedAt,
+    },
+    packageUrl: `skillhub:${ref.skillId}@${ref.version}`,
+    installedAt: signedAt,
+  };
+}
+
+function writeSkill(skillsRoot: string, body: string): string {
+  const directory = path.join(skillsRoot, 'notes');
+  fs.mkdirSync(directory, { recursive: true });
+  const file = path.join(directory, 'SKILL.md');
+  fs.writeFileSync(file, ['---', 'name: notes', 'description: notes', '---', '', body].join('\n'));
+  return file;
+}
+
+function sha256(value: string): string {
+  return crypto.createHash('sha256').update(value, 'utf8').digest('hex');
+}

--- a/tests/bot-skill-sync.test.ts
+++ b/tests/bot-skill-sync.test.ts
@@ -194,6 +194,42 @@ describe('BotSkillSyncService', () => {
     );
   });
 
+  test('keeps the workspace localSkillId when Cloud upgrades the same public Skill', async () => {
+    const fixture = createFixture(runtimeRoot, cloudRoot, artifactRoot, 'bot_A');
+    const skillDir = path.join(fixture.skillsRoot, 'browser');
+    writeSkill(skillDir, 'browser', '# public v1\n');
+    writeSkillHubInstallMarker(skillDir, publicMarker(computeLocalSkillContentHash(skillDir)));
+    const first = await fixture.sync.syncOnStartup('bot_A');
+    const originalLocalSkillId = first.manifest.entries[0].localSkillId;
+    const originalSkill = fs.readFileSync(path.join(skillDir, 'SKILL.md'), 'utf8');
+    const originalMarker = fs.readFileSync(
+      path.join(skillDir, '.xiaoba-skillhub-install.json'),
+      'utf8',
+    );
+
+    writeSkill(skillDir, 'browser', '# public v2\n');
+    writeSkillHubInstallMarker(skillDir, {
+      ...publicMarker(computeLocalSkillContentHash(skillDir)),
+      version: '1.0.4',
+    });
+    const v2Manifest = await fixture.botSkills.scanManifest();
+    const v2Artifact = fixture.artifacts.put({
+      botId: 'bot_A',
+      skillsRoot: fixture.skillsRoot,
+      entry: v2Manifest.entries[0],
+      publicRef: { skillId: 'alice/browser', version: '1.0.4' },
+    });
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'), originalSkill);
+    fs.writeFileSync(path.join(skillDir, '.xiaoba-skillhub-install.json'), originalMarker);
+    fixture.definitionService.updateSkills('bot_A', [v2Artifact.ref]);
+
+    const pulled = await fixture.sync.syncOnStartup('bot_A');
+
+    assert.equal(pulled.direction, 'cloud_to_local');
+    assert.equal(pulled.manifest.entries[0].localSkillId, originalLocalSkillId);
+    assert.match(fs.readFileSync(path.join(skillDir, 'SKILL.md'), 'utf8'), /public v2/);
+  });
+
   test('pulls a Cloud-only version when Local still equals Base', async () => {
     const fixture = createFixture(runtimeRoot, cloudRoot, artifactRoot, 'bot_A');
     const skillFile = path.join(fixture.skillsRoot, 'notes', 'SKILL.md');

--- a/tests/dashboard-catsco-auth-status.test.ts
+++ b/tests/dashboard-catsco-auth-status.test.ts
@@ -1202,11 +1202,14 @@ describe('dashboard CatsCo account status', () => {
       fs.readFileSync(path.join(workspace.getParkedPath('188'), 'same-name', 'SKILL.md'), 'utf8'),
       offlineSkillContent,
     );
-    assert.equal(definitions.readCanonical('188')?.skills?.length, 1);
+    // Private SkillHub is deliberately unavailable in this switch fixture.
+    // Switching still parks the local workspace, but must not pretend the
+    // failed upload advanced canonical Definition or Base.
+    assert.equal(definitions.readCanonical('188')?.skills?.length, 0);
     assert.equal(
       new FileBotSkillSyncBaseRepository({ runtimeRoot: testRoot })
         .inspect('188', sourceWorkspaceId).status,
-      'valid',
+      'missing',
     );
     assert.equal(
       new FileBotSkillSyncBaseRepository({ runtimeRoot: testRoot })

--- a/tests/dashboard-skillhub-connected-api.test.ts
+++ b/tests/dashboard-skillhub-connected-api.test.ts
@@ -149,11 +149,12 @@ describe('dashboard connected SkillHub API', () => {
         name: 'quick-demo',
         installName: 'quick-demo',
         version: '1.0.0',
-        packageChecksumSha256: 'test-checksum',
+        packageChecksumSha256: 'a'.repeat(64),
         signature: {
           algorithm: 'ed25519',
           keyId: 'test-key',
           signature: 'test-signature',
+          signedAt: '2026-01-01T00:00:00.000Z',
         },
         packageUrl: 'https://example.test/quick-demo.skillpkg',
         installedAt: '2026-01-01T00:00:00.000Z',

--- a/tests/share-skillhub-skill-tool.test.ts
+++ b/tests/share-skillhub-skill-tool.test.ts
@@ -1,0 +1,112 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert/strict';
+import { ShareSkillHubSkillTool } from '../src/tools/share-skillhub-skill-tool';
+import type { ToolExecutionContext } from '../src/types/tool';
+import type {
+  ExecutionScope,
+  ScopedLocalDeviceGrant,
+} from '../src/types/session-identity';
+
+describe('ShareSkillHubSkillTool CatsCo permissions', () => {
+  test('allows the local owner-self context to reach argument validation', async () => {
+    const result = await new ShareSkillHubSkillTool().execute({}, catsContext({
+      executionScope: catsScope({ actorUserId: 'usr7' }),
+      localDeviceGrant: catsLocalDevice({ ownerUserId: 'usr7' }),
+    }));
+
+    assert.equal(result.ok, false);
+    assert.equal(result.errorCode, 'INVALID_TOOL_ARGUMENTS');
+  });
+
+  test('rejects an external CatsCo visitor before sharing', async () => {
+    const result = await new ShareSkillHubSkillTool().execute(
+      { skillName: 'private-local-skill' },
+      catsContext({
+        executionScope: catsScope({
+          actorUserId: 'usr8',
+          agentBodyId: 'body-remote',
+        }),
+        localDeviceGrant: catsLocalDevice({ ownerUserId: 'usr7' }),
+      }),
+    );
+
+    assert.equal(result.ok, false);
+    assert.equal(result.errorCode, 'PERMISSION_DENIED');
+    assert.equal(result.retryable, false);
+  });
+
+  test('rejects a non-owner CatsCo agent even when it runs on the local body', async () => {
+    const result = await new ShareSkillHubSkillTool().execute(
+      { skillName: 'private-local-skill' },
+      catsContext({
+        executionScope: catsScope({
+          actorUserId: 'usr8',
+          agentBodyId: 'body-local',
+        }),
+        localDeviceGrant: catsLocalDevice({
+          ownerUserId: 'usr7',
+          bodyId: 'body-local',
+        }),
+      }),
+    );
+
+    assert.equal(result.ok, false);
+    assert.equal(result.errorCode, 'PERMISSION_DENIED');
+    assert.equal(result.retryable, false);
+  });
+
+  test('keeps non-CatsCo callers on the existing validation path', async () => {
+    const result = await new ShareSkillHubSkillTool().execute({}, {
+      workingDirectory: process.cwd(),
+      conversationHistory: [],
+      surface: 'cli',
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.errorCode, 'INVALID_TOOL_ARGUMENTS');
+  });
+});
+
+function catsContext(
+  overrides: Partial<ToolExecutionContext> = {},
+): ToolExecutionContext {
+  return {
+    workingDirectory: process.cwd(),
+    conversationHistory: [],
+    surface: 'catscompany',
+    executionScope: catsScope(),
+    localDeviceGrant: catsLocalDevice(),
+    ...overrides,
+  };
+}
+
+function catsScope(overrides: Partial<ExecutionScope> = {}): ExecutionScope {
+  return {
+    source: 'catscompany',
+    sessionKey: 'session:v2:catscompany:p2p:p2p_7_43:agent:usr43',
+    topicId: 'p2p_7_43',
+    topicType: 'p2p',
+    actorUserId: 'usr7',
+    agentId: 'usr43',
+    agentBodyId: 'body-local',
+    permissionsSource: 'server_canonical_message',
+    identityTrust: 'server_canonical',
+    isTrusted: true,
+    ...overrides,
+  };
+}
+
+function catsLocalDevice(
+  overrides: Partial<ScopedLocalDeviceGrant> = {},
+): ScopedLocalDeviceGrant {
+  return {
+    kind: 'catscompany_body',
+    source: 'catscompany',
+    ownerUserId: 'usr7',
+    bodyId: 'body-local',
+    installationId: 'install-local',
+    deviceId: 'install-local',
+    createdAt: Date.now(),
+    ...overrides,
+  };
+}

--- a/tests/skillhub-client-private-transport.test.ts
+++ b/tests/skillhub-client-private-transport.test.ts
@@ -1,0 +1,360 @@
+import * as assert from 'node:assert/strict';
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as http from 'node:http';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import { SkillHubClient } from '../src/skillhub/client';
+import type {
+  SkillHubBotCredential,
+  SkillHubPrivateUpsertInput,
+  SkillHubRegistryEntry,
+} from '../src/skillhub/types';
+
+describe('SkillHubClient Bot private transport', () => {
+  let root: string;
+  let originalUserDataDir: string | undefined;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-skillhub-client-'));
+    originalUserDataDir = process.env.XIAOBA_USER_DATA_DIR;
+    process.env.XIAOBA_USER_DATA_DIR = root;
+  });
+
+  afterEach(() => {
+    if (originalUserDataDir === undefined) delete process.env.XIAOBA_USER_DATA_DIR;
+    else process.env.XIAOBA_USER_DATA_DIR = originalUserDataDir;
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('uses isolated Bot credentials for private PUT, metadata, trust, and download', async () => {
+    const observed: Array<{
+      method: string;
+      url: string;
+      authorization?: string;
+      botId?: string;
+      cookie?: string;
+      body: string;
+    }> = [];
+    const server = await startServer(async (request, response) => {
+      const body = await readRequestBody(request);
+      observed.push({
+        method: request.method || '',
+        url: request.url || '',
+        authorization: header(request, 'authorization'),
+        botId: header(request, 'x-catsco-bot-id'),
+        cookie: header(request, 'cookie'),
+        body,
+      });
+      if (request.url === '/api/auth/login') {
+        response.setHeader('Set-Cookie', 'user_session=before-bot; Path=/; HttpOnly');
+        return json(response, {});
+      }
+      if (request.url === '/api/auth/me') {
+        return json(response, {
+          user: { id: 'user-1', email: 'user@example.com', displayName: 'User' },
+          roles: [],
+          permissions: [],
+        });
+      }
+      if (request.method === 'PUT' && request.url?.startsWith('/api/bots/')) {
+        response.setHeader('Set-Cookie', 'bot_session=must-not-persist; Path=/; HttpOnly');
+        return json(response, { skill: { skillId: 'private/skill', latestVersion: HASH } });
+      }
+      if (request.url === '/api/skills/private/skill/versions/content-version') {
+        return json(response, { version: { skillId: 'private/skill', latestVersion: 'content-version' } });
+      }
+      if (request.url === '/api/skills/private/skill/versions/content-version/download') {
+        response.writeHead(200, { 'Content-Type': 'application/octet-stream' });
+        response.end('private-package');
+        return;
+      }
+      if (request.url === '/api/trust/public-keys') {
+        return json(response, { trustModel: 'root-signed-signing-keys', keys: [] });
+      }
+      if (request.url === '/api/skills') {
+        return json(response, { skills: [] });
+      }
+      response.writeHead(404);
+      response.end();
+    });
+    try {
+      const client = new SkillHubClient({ baseUrl: server.baseUrl });
+      await client.login({
+        email: 'user@example.com',
+        password: 'password',
+      });
+      const credential = botCredential();
+      await client.upsertPrivateSkill(privateInput(), credential);
+      await client.getVersion('private/skill', 'content-version', credential);
+      const packageBytes = await client.downloadPackage(
+        registryEntry('private/skill', 'content-version'),
+        credential,
+      );
+      await client.getTrust(credential);
+      await client.searchSkills();
+
+      assert.equal(packageBytes.toString('utf8'), 'private-package');
+      const botRequests = observed.filter(item => (
+        item.url.startsWith('/api/bots/')
+        || item.url.includes('/versions/content-version')
+        || item.url === '/api/trust/public-keys'
+      ));
+      assert.equal(botRequests.length, 4);
+      for (const request of botRequests) {
+        assert.equal(request.authorization, 'ApiKey bot-secret-key');
+        assert.equal(request.botId, 'bot A');
+        assert.equal(request.cookie, undefined);
+      }
+      const put = botRequests.find(item => item.method === 'PUT');
+      assert.equal(
+        put?.url,
+        `/api/bots/bot%20A/private-skills/${LOCAL_SKILL_ID}/versions/${HASH}`,
+      );
+      assert.deepEqual(JSON.parse(put?.body || '{}'), privateInput());
+
+      const userRequestAfterBot = observed.at(-1);
+      assert.equal(userRequestAfterBot?.url, '/api/skills');
+      assert.match(userRequestAfterBot?.cookie || '', /user_session=before-bot/);
+      assert.doesNotMatch(userRequestAfterBot?.cookie || '', /bot_session/);
+      assert.equal(userRequestAfterBot?.authorization, undefined);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('rejects redirects for Bot-authenticated calls', async () => {
+    let redirectedRequests = 0;
+    const server = await startServer((_request, response) => {
+      if (_request.url === '/redirect-target') redirectedRequests += 1;
+      response.writeHead(302, { Location: '/redirect-target' });
+      response.end();
+    });
+    try {
+      const client = new SkillHubClient({ baseUrl: server.baseUrl });
+      await assert.rejects(
+        () => client.getVersion('private/skill', 'v1', botCredential()),
+        (error: any) => error?.status === 502,
+      );
+      assert.equal(redirectedRequests, 0);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('rejects invalid refs before constructing or sending a request', async () => {
+    let requests = 0;
+    const server = await startServer((_request, response) => {
+      requests += 1;
+      json(response, {});
+    });
+    try {
+      const client = new SkillHubClient({ baseUrl: server.baseUrl });
+      await assert.rejects(
+        () => client.getVersion('../secret', 'v1', botCredential()),
+        invalidReference,
+      );
+      await assert.rejects(
+        () => client.downloadPackage(registryEntry('private/skill', '../v1'), botCredential()),
+        invalidReference,
+      );
+      await assert.rejects(
+        () => client.upsertPrivateSkill(
+          { ...privateInput(), contentHash: 'not-a-hash' },
+          botCredential(),
+        ),
+        invalidReference,
+      );
+      await assert.rejects(
+        () => client.upsertPrivateSkill(
+          {
+            ...privateInput(),
+            files: [{ ...privateInput().files[0], sha256: 'd'.repeat(64) }],
+          },
+          botCredential(),
+        ),
+        invalidReference,
+      );
+      await assert.rejects(
+        () => client.upsertPrivateSkill(
+          { ...privateInput(), workspaceId: '../other-workspace' },
+          botCredential(),
+        ),
+        invalidReference,
+      );
+      await assert.rejects(
+        () => client.upsertPrivateSkill(
+          privateInput(),
+          { ...botCredential(), botId: 'another-bot' },
+        ),
+        invalidReference,
+      );
+      assert.equal(requests, 0);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('limits declared and streamed JSON responses to 2 MiB', async () => {
+    const limit = 2 * 1024 * 1024;
+    const server = await startServer((request, response) => {
+      if (request.url?.endsWith('/declared')) {
+        response.writeHead(200, {
+          'Content-Type': 'application/json',
+          'Content-Length': String(limit + 1),
+        });
+        response.end('{}');
+        return;
+      }
+      response.writeHead(200, { 'Content-Type': 'application/json' });
+      response.write('{"padding":"');
+      response.end(`${'x'.repeat(limit)}"}`);
+    });
+    try {
+      const client = new SkillHubClient({ baseUrl: server.baseUrl });
+      for (const version of ['declared', 'streamed']) {
+        await assert.rejects(
+          () => client.getVersion('private/skill', version, botCredential()),
+          (error: any) => (
+            error?.status === 502
+            && error?.code === 'skillhub.response_too_large'
+          ),
+        );
+      }
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('times out while a response body is still streaming', async () => {
+    const server = await startServer((_request, response) => {
+      response.writeHead(200, { 'Content-Type': 'application/json' });
+      response.write('{"trustModel":');
+      setTimeout(() => response.end('"root-signed-signing-keys","keys":[]}'), 150);
+    });
+    try {
+      const client = new SkillHubClient({ baseUrl: server.baseUrl, timeoutMs: 30 });
+      await assert.rejects(
+        () => client.getTrust(botCredential()),
+        (error: any) => (
+          error?.status === 408
+          && error?.code === 'skillhub.response_timeout'
+        ),
+      );
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('allows HTTP only for loopback SkillHub servers', () => {
+    assert.throws(
+      () => new SkillHubClient({ baseUrl: 'http://example.com' }),
+      /requires HTTPS/,
+    );
+    assert.doesNotThrow(
+      () => new SkillHubClient({ baseUrl: 'http://localhost:3800' }),
+    );
+    assert.doesNotThrow(
+      () => new SkillHubClient({ baseUrl: 'http://127.9.8.7:3800' }),
+    );
+    assert.doesNotThrow(
+      () => new SkillHubClient({ baseUrl: 'https://skillhub.example.com' }),
+    );
+  });
+});
+
+const HASH = 'a'.repeat(64);
+const LOCAL_SKILL_ID = '123e4567-e89b-42d3-a456-426614174000';
+
+function botCredential(): SkillHubBotCredential {
+  return {
+    botId: 'bot A',
+    apiKey: 'bot-secret-key',
+  };
+}
+
+function privateInput(): SkillHubPrivateUpsertInput {
+  return {
+    botId: 'bot A',
+    workspaceId: 'workspace-1',
+    localSkillId: LOCAL_SKILL_ID,
+    contentHash: HASH,
+    name: 'private-skill',
+    installName: 'private-skill',
+    forkedFrom: {
+      skillId: 'public/source',
+      version: '1.0.0',
+    },
+    files: [{
+      path: 'SKILL.md',
+      size: 7,
+      sha256: crypto.createHash('sha256').update('# skill', 'utf8').digest('hex'),
+      contentBase64: 'IyBza2lsbA==',
+    }],
+  };
+}
+
+function registryEntry(skillId: string, latestVersion: string): SkillHubRegistryEntry {
+  return {
+    skillId,
+    latestVersion,
+    packageUrl: '/unused',
+    checksumSha256: 'c'.repeat(64),
+    signature: {
+      algorithm: 'ed25519',
+      keyId: 'key',
+      signature: 'signature',
+    },
+  };
+}
+
+function invalidReference(error: any): boolean {
+  return error?.status === 400 && error?.code === 'skillhub.invalid_reference';
+}
+
+async function startServer(
+  handler: (
+    request: http.IncomingMessage,
+    response: http.ServerResponse,
+  ) => void | Promise<void>,
+): Promise<{ baseUrl: string; close(): Promise<void> }> {
+  const server = http.createServer((request, response) => {
+    Promise.resolve(handler(request, response)).catch(error => {
+      response.writeHead(500);
+      response.end(error instanceof Error ? error.message : String(error));
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address();
+  assert.ok(address && typeof address !== 'string');
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    close: () => new Promise<void>((resolve, reject) => {
+      server.close(error => error ? reject(error) : resolve());
+    }),
+  };
+}
+
+async function readRequestBody(request: http.IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) chunks.push(Buffer.from(chunk));
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+function header(request: http.IncomingMessage, name: string): string | undefined {
+  const value = request.headers[name];
+  return Array.isArray(value) ? value.join(', ') : value;
+}
+
+function json(response: http.ServerResponse, body: unknown): void {
+  const text = JSON.stringify(body);
+  response.writeHead(200, {
+    'Content-Type': 'application/json',
+    'Content-Length': Buffer.byteLength(text),
+  });
+  response.end(text);
+}

--- a/tests/skillhub-install-marker.test.ts
+++ b/tests/skillhub-install-marker.test.ts
@@ -1,0 +1,154 @@
+import { test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { createBotSkillSyncBase } from '../src/bot-skills/sync-base';
+import {
+  readSkillHubInstallMarker,
+  SKILLHUB_INSTALL_MARKER_FILE,
+  writeSkillHubInstallMarker,
+} from '../src/skillhub/install-marker';
+import type { SkillHubPackageInstallMarker } from '../src/skillhub/types';
+
+test('install marker accepts canonical public and bound private identities', t => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-marker-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  const publicDir = path.join(root, 'public-skill');
+  writeSkillHubInstallMarker(publicDir, marker());
+  const publicMarker = readSkillHubInstallMarker(publicDir);
+  assert.equal(publicMarker?.visibility, 'public');
+  assert.equal(publicMarker?.ownerBotId, undefined);
+  assert.equal(publicMarker?.localSkillId, undefined);
+
+  const privateDir = path.join(root, 'private-skill');
+  writeSkillHubInstallMarker(privateDir, marker({
+    visibility: 'private',
+    ownerBotId: 'bot_A',
+    localSkillId: 'local-skill-1',
+  }));
+  const privateMarker = readSkillHubInstallMarker(privateDir);
+  assert.equal(privateMarker?.visibility, 'private');
+  assert.equal(privateMarker?.ownerBotId, 'bot_A');
+  assert.equal(privateMarker?.localSkillId, 'local-skill-1');
+});
+
+test('install marker canonicalizes legacy public metadata without visibility or signedAt', t => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-marker-legacy-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const skillDir = path.join(root, 'legacy-public');
+  fs.mkdirSync(skillDir);
+  const legacy = marker();
+  delete (legacy.signature as any).signedAt;
+  fs.writeFileSync(
+    path.join(skillDir, SKILLHUB_INSTALL_MARKER_FILE),
+    `${JSON.stringify(legacy)}\n`,
+    'utf8',
+  );
+
+  const restored = readSkillHubInstallMarker(skillDir);
+
+  assert.equal(restored?.visibility, 'public');
+  assert.equal(restored?.signature.signedAt, restored?.installedAt);
+});
+
+test('install marker rejects malformed identity, refs, hashes, signatures, times, and installName', t => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-marker-invalid-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  const cases: Array<[string, Record<string, unknown>]> = [
+    ['visibility', { visibility: 'shared' }],
+    ['public-private-fields', { visibility: 'public', ownerBotId: 'bot_A' }],
+    ['private-owner', { visibility: 'private', localSkillId: 'local-skill-1' }],
+    ['private-local-id', { visibility: 'private', ownerBotId: 'bot_A' }],
+    ['skill-ref', { skillId: '../outside' }],
+    ['version-ref', { version: '../1.0.0' }],
+    ['checksum', { packageChecksumSha256: 'not-a-sha256' }],
+    ['content-hash', { installedContentHash: 'not-a-sha256' }],
+    ['signature', { signature: { ...marker().signature, algorithm: 'rsa' } }],
+    ['signed-at', { signature: { ...marker().signature, signedAt: 'not-a-time' } }],
+    ['installed-at', { installedAt: 'not-a-time' }],
+    ['impossible-date', { installedAt: '2026-02-30T00:00:00.000Z' }],
+    ['install-name', { installName: '../outside' }],
+  ];
+
+  for (const [name, overrides] of cases) {
+    const skillDir = path.join(root, name);
+    fs.mkdirSync(skillDir);
+    fs.writeFileSync(
+      path.join(skillDir, SKILLHUB_INSTALL_MARKER_FILE),
+      JSON.stringify({ ...marker(), ...overrides }),
+      'utf8',
+    );
+    assert.equal(readSkillHubInstallMarker(skillDir), null, name);
+  }
+});
+
+test('install marker writer validates before creating or replacing metadata', t => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-marker-write-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const skillDir = path.join(root, 'invalid');
+
+  assert.throws(
+    () => writeSkillHubInstallMarker(
+      skillDir,
+      marker({ installName: 'CON' }) as SkillHubPackageInstallMarker,
+    ),
+    (error: any) => error?.code === 'INSTALL_MARKER_INVALID',
+  );
+  assert.equal(fs.existsSync(skillDir), false);
+});
+
+test('sync-base rejects an invalid Local sourceRef visibility', () => {
+  assert.throws(
+    () => createBotSkillSyncBase({
+      botId: 'bot_A',
+      workspaceId: 'workspace_A',
+      localEntries: [{
+        localSkillId: 'local-skill-1',
+        name: 'notes',
+        path: 'notes',
+        enabled: true,
+        contentHash: 'a'.repeat(64),
+        source: 'skillhub',
+        sourceRef: {
+          skillId: 'alice/notes',
+          version: '1.0.0',
+          visibility: 'shared' as 'public',
+        },
+      }],
+      bindings: [{
+        localSkillId: 'local-skill-1',
+        ref: { skillId: 'alice/notes', version: '1.0.0' },
+        storage: 'skillhub-mirror',
+        artifactDigest: 'b'.repeat(64),
+      }],
+      cloudSkills: [{ skillId: 'alice/notes', version: '1.0.0' }],
+    }),
+    /Invalid sourceRef\.visibility/,
+  );
+});
+
+function marker(
+  overrides: Partial<SkillHubPackageInstallMarker> = {},
+): SkillHubPackageInstallMarker {
+  return {
+    source: 'skillhub',
+    skillId: 'alice/notes',
+    name: 'notes',
+    installName: 'notes',
+    version: '1.0.0',
+    packageChecksumSha256: 'a'.repeat(64),
+    installedContentHash: 'b'.repeat(64),
+    signature: {
+      algorithm: 'ed25519',
+      keyId: 'test-key',
+      signature: 'test-signature',
+      signedAt: '2026-01-01T00:00:00.000Z',
+    },
+    packageUrl: '/package',
+    installedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}

--- a/tests/skillhub-subscription.test.ts
+++ b/tests/skillhub-subscription.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, test } from 'node:test';
 import * as assert from 'node:assert/strict';
+import * as crypto from 'node:crypto';
 import * as fs from 'fs';
 import { createServer } from 'http';
 import * as os from 'os';
@@ -472,7 +473,7 @@ function installResult(
 
 function packageOptions(skillId: string, name: string, version: string, content: string, userId?: string): any {
   const encoded = Buffer.from(content).toString('base64');
-  const checksum = `${skillId}:${version}:${content}`;
+  const checksum = crypto.createHash('sha256').update(content, 'utf8').digest('hex');
   return {
     userId,
     allowUpdate: true,


### PR DESCRIPTION
## 为什么要做

PR4 已建立 Local / Base / Cloud 三态判断和本地模拟 artifact，但私有 Skill 仍不是真正可鉴权、可验签、可跨设备恢复的云端版本。PR5 将自动同步接到 Bot 私有 SkillHub，同时明确隔离两条路径：自动同步只生成私有版本；公开分享仍由用户显式触发。

## 做了什么

### Bot 私有传输

- 新增 `BotSkillArtifactTransport`，同步状态机不直接依赖 SkillHub 实现。
- 新增幂等 upsert 契约：`PUT /api/bots/:botId/private-skills/:localSkillId/versions/:contentHash`。
- 使用 Bot API Key：`Authorization: ApiKey ...` + `X-CatsCo-Bot-Id`。
- Bot 请求不带用户 Cookie、不接收 Set-Cookie、禁止重定向；生产强制 HTTPS，HTTP 仅允许 loopback。
- JSON/package 有大小限制，响应头和响应体读取都有超时。

### 上传后精确下载验签

upsert 成功不会立即推进 Definition/Base，而是继续：

1. 精确下载该版本；
2. 校验 package checksum、Ed25519 包签名和 root-signed signing key；
3. 校验已签 payload 中的 `visibility / ownerBotId / localSkillId / contentHash / installName`；
4. 重算实际文件的 canonical contentHash；
5. 确认下载内容等于上传快照；
6. 成功后才缓存 verified artifact 并提交 Definition/Base。

### 严格快照和敏感内容保护

- 文件数、单文件/总大小、路径深度、跨平台非法路径、软链接/联接、特殊文件、读取期间变化全部 fail-closed，不静默截断。
- 真实私有上传先生成不落盘 snapshot 并扫描；只有远端精确版本验签成功后才写 verified cache。
- 阻止 `.env`、私钥及常见 AWS/GitHub/Slack/Google/Stripe/JWT、API key、access token、client secret、password 等高置信凭证。
- 被阻止的 Skill 仍可本地使用，错误不输出秘密内容。

### 接入 Local / Base / Cloud 状态机

- 本地新增/修改：按稳定 `localSkillId` upsert 私有不可变版本；内容不变不重复上传。
- 目录重命名/启停：作为工作区状态写 Base，复用原 private ref；离线且 cache 被清理时也不重复上传。
- 未修改公开 Skill 保留公开 ref；修改公开 Skill 时携带 `forkedFrom` 创建当前 Bot 私有 fork。
- PR4 `simulated-private` 仅在 Local 和 Cloud 都仍等于 Base 时迁移，避免覆盖更新过的 Cloud。
- 新设备恢复保留原 `localSkillId`，只更换 `workspaceId`。
- 未迁移 `sim-private:` 且本机无旧 artifact 时明确要求原设备先迁移，不伪装成功。
- 上传失败保留 Local，Base 不前移；切 Bot 仍停车保存旧工作区。
- 删除只移除 Definition 引用，不删除历史版本。

### 数据契约和权限

- Base 增加 `skillhub-private`，兼容 PR4 的 `skillhub-mirror / simulated-private`。
- marker 增加 `visibility / ownerBotId / localSkillId`；private 必须完整绑定，public 禁止夹带私有字段。
- 兼容旧 public marker 缺少 visibility 或 signature.signedAt。
- Skill ref 统一限制 UTF-8 字节、段数、控制字符和路径穿越；Definition 最多 256 个 refs。
- CatsCo 公开分享只允许 server-canonical 的本机 owner-self；visitor 和非 owner agent 拒绝。CLI/非 CatsCo 显式调用保持原行为。

## 为什么没有复用公开分享

自动同步不会调用 `/api/skills/share`，也不会写 `skillhub_author / skillhub_version / skillhub_uploaded_at` 到 `SKILL.md`。否则可能把私有内容公开，且上传后修改 Local hash 产生二次版本。

## 兼容和边界

- 本 PR 基线是 `codex/bot-skill-local-sync-pr4`，依赖 PR4。
- 服务端需实现上述 Bot 私有 endpoint，并把 privateMetadata 放进已签 payload；客户端不会在接口不存在时回退公开分享或伪造成功。
- PR5 仍使用 PR4 的文件 canonical Definition。真实 CatsCompany Definition API、revision/ETag 和字段级 PATCH 留给 PR6。
- canonical Definition 是提交点，Base 只在 Definition 条件提交成功后更新；提交点后的瞬时本地 cache/Base 写失败由下一次幂等同步重新收敛。

## 审阅和测试

已做产品、同步语义、安全三轮 subagent 审阅，修正了迁移覆盖 Cloud、公开升级丢 localSkillId、敏感快照先落盘、响应体无超时、三元优先级、旧公开 signedAt、目录重命名重复版本等问题。

定向覆盖：私有 upsert/去重/新版本、目录 rename/启停、公开修改私有 fork、PR4 迁移、迁移与 Cloud 竞争、独立 cache 的第二设备恢复、上传失败、敏感内容、Bot Cookie 隔离、重定向、非法 ref、响应大小/慢流超时、marker 公私身份、owner-self 分享、公开升级身份保持、Dashboard 切 Bot、安装订阅回归。

- `npm run build`：通过。
- PR5 定向测试：全部通过。
- 全量 runtime：1303 项中 1297 通过、4 跳过；仅 2 个既有 PDF 视觉回退测试失败，单独重跑仍失败，相关文件不在本 PR 范围。
- `git diff --check`：通过。

## 下一步

PR6 将接入真实 CatsCompany BotDefinition API：字段级 Skills PATCH、revision/ETag 条件提交、共享 Definition 的跨设备发现、竞争更新恢复；同时补充 private sync 的 pending / lastError / lastSuccess Dashboard 状态。