### PR TITLE
持久化 CatsCo 桌面登录凭证

### DIFF
--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -3406,6 +3406,7 @@ export function createApiRouter(
       const login = await catsRequest('POST', state.httpBaseUrl, '/api/auth/login', {
         account: email,
         password,
+        persistent: true,
       }, undefined, { timeoutMs: 10000 });
       persistCatsUserSession(state, login);
       res.json({
@@ -3428,7 +3429,14 @@ export function createApiRouter(
       const password = String(req.body?.password || '');
       if (!account || !password) return res.status(400).json({ error: 'account and password are required' });
 
-      const login = await catsRequest('POST', state.httpBaseUrl, '/api/auth/login', { account, password }, undefined, { timeoutMs: 10000 });
+      const login = await catsRequest(
+        'POST',
+        state.httpBaseUrl,
+        '/api/auth/login',
+        { account, password, persistent: true },
+        undefined,
+        { timeoutMs: 10000 },
+      );
       persistCatsUserSession(state, login);
       res.json({
         ok: true,

--- a/tests/dashboard-catsco-auth-status.test.ts
+++ b/tests/dashboard-catsco-auth-status.test.ts
@@ -548,6 +548,57 @@ describe('dashboard CatsCo account status', () => {
     assert.equal(persisted.account?.uid, '77');
   });
 
+  test('POST /cats/auth/register requests a persistent token after registration', async () => {
+    const requests: string[] = [];
+    await startCatsServer((req, res) => {
+      requests.push(req.path);
+      if (req.path === '/api/auth/register') {
+        assert.deepStrictEqual(req.body, {
+          email: 'new@example.com',
+          username: 'new-user',
+          password: 'passw0rd',
+          code: '123456',
+        });
+        return res.json({ ok: true });
+      }
+      if (req.path === '/api/auth/login') {
+        assert.deepStrictEqual(req.body, {
+          account: 'new@example.com',
+          password: 'passw0rd',
+          persistent: true,
+        });
+        return res.json({
+          token: 'registered-user-token',
+          uid: 78,
+          username: 'new-user',
+          display_name: 'New User',
+        });
+      }
+      return res.status(404).json({ error: 'not found' });
+    });
+
+    const response = await fetch(`${dashboardBaseUrl}/api/cats/auth/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        httpBaseUrl: catsBaseUrl,
+        serverUrl: 'wss://app.catsco.cc/v0/channels',
+        email: 'new@example.com',
+        username: 'new-user',
+        password: 'passw0rd',
+        code: '123456',
+      }),
+    });
+    const data = await response.json() as any;
+
+    assert.equal(response.status, 200);
+    assert.equal(data.ok, true);
+    assert.deepStrictEqual(requests, ['/api/auth/register', '/api/auth/login']);
+    const persisted = createCatsCoLocalConfigService({ runtimeRoot: testRoot }).load();
+    assert.equal(persisted.account?.token, 'registered-user-token');
+    assert.equal(persisted.account?.uid, '78');
+  });
+
   test('POST /cats/desktop-connect exchanges a web login code and persists CatsCo account aliases', async () => {
     await startCatsServer((req, res) => {
       if (req.path === '/api/desktop-connect/exchange') {

--- a/tests/dashboard-catsco-auth-status.test.ts
+++ b/tests/dashboard-catsco-auth-status.test.ts
@@ -507,7 +507,11 @@ describe('dashboard CatsCo account status', () => {
   test('POST /cats/auth/login writes both CatsCo and CatsCompany env aliases', async () => {
     await startCatsServer((req, res) => {
       if (req.path === '/api/auth/login') {
-        assert.deepStrictEqual(req.body, { account: 'demo@example.com', password: 'passw0rd' });
+        assert.deepStrictEqual(req.body, {
+          account: 'demo@example.com',
+          password: 'passw0rd',
+          persistent: true,
+        });
         return res.json({
           token: 'new-user-token',
           uid: 77,
@@ -539,6 +543,9 @@ describe('dashboard CatsCo account status', () => {
     assert.equal(env.CATSCOMPANY_USER_UID, '77');
     assert.equal(env.CATSCO_USER_DISPLAY_NAME, 'Demo User');
     assert.equal(env.CATSCOMPANY_USER_DISPLAY_NAME, 'Demo User');
+    const persisted = createCatsCoLocalConfigService({ runtimeRoot: testRoot }).load();
+    assert.equal(persisted.account?.token, 'new-user-token');
+    assert.equal(persisted.account?.uid, '77');
   });
 
   test('POST /cats/desktop-connect exchanges a web login code and persists CatsCo account aliases', async () => {


### PR DESCRIPTION
## 改动内容
- CatsCo 密码登录显式请求长期桌面凭证
- 注册后的自动登录同样请求长期凭证
- 继续使用现有本地配置与环境变量双重持久化
- 补充落盘后重新读取账号 token 的测试

## 服务端依赖
CatsCompany 对应支持已部署到生产：buildsense-ai/cats-company#100，main 提交 bf511bd。旧服务端会忽略新增字段，因此客户端仍保持向后兼容。

## 用户影响
升级后重新登录一次即可换取无 exp 的桌面 JWT；已有本地会话与旧 token 的读取逻辑不变。账号禁用或服务端 JWT 密钥轮换仍可撤销凭证。

## 验证
- npm test：1159 项，1155 通过，4 跳过，0 失败
- npm run build
- npx tsx --test tests/dashboard-catsco-auth-status.test.ts
- git diff --check