### PR TITLE
feat: guard group sessions with structured mentions

### DIFF
--- a/src/catscompany/client.ts
+++ b/src/catscompany/client.ts
@@ -379,8 +379,10 @@ export class CatsClient extends EventEmitter {
         mentions: Array.isArray(msg.data.mentions)
           ? msg.data.mentions.filter((value: unknown): value is string => typeof value === 'string')
           : undefined,
-        memberCount: Number.isFinite(Number(msg.data.member_count))
-          ? Number(msg.data.member_count)
+        memberCount: typeof msg.data.member_count === 'number'
+          && Number.isSafeInteger(msg.data.member_count)
+          && msg.data.member_count > 0
+          ? msg.data.member_count
           : undefined,
       };
       this.emit('message', ctx);

--- a/src/catscompany/client.ts
+++ b/src/catscompany/client.ts
@@ -95,6 +95,8 @@ export interface MessageContext {
   isGroup: boolean;
   from?: string;  // 原始 Cats 发送方字段，供兼容和排查使用
   seq?: number;   // Cats 服务端消息序号，用于排序和补充消息合并
+  mentions?: string[]; // 服务端确认的结构化 @mention 目标
+  memberCount?: number; // 群成员数；用于运行时在创建 session 前兜底门控
 }
 
 export interface CatsAgentContextMessage {
@@ -374,6 +376,12 @@ export class CatsClient extends EventEmitter {
         mode: typeof msg.data.mode === 'string' ? msg.data.mode : undefined,
         isGroup: msg.data.topic?.startsWith('grp_') ?? false,
         seq: Number(msg.data.seq || 0),
+        mentions: Array.isArray(msg.data.mentions)
+          ? msg.data.mentions.filter((value: unknown): value is string => typeof value === 'string')
+          : undefined,
+        memberCount: Number.isFinite(Number(msg.data.member_count))
+          ? Number(msg.data.member_count)
+          : undefined,
       };
       this.emit('message', ctx);
     } else if (msg.pres) {

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -361,8 +361,11 @@ export function shouldActivateCatsCompanyMessage(
       || metadata.channel_native_group_triggered === 'true';
   }
 
-  const memberCount = Number(message.memberCount);
-  if (Number.isFinite(memberCount) && memberCount > 0 && memberCount <= 2) return true;
+  const memberCount = message.memberCount;
+  if (typeof memberCount === 'number'
+    && Number.isSafeInteger(memberCount)
+    && memberCount > 0
+    && memberCount <= 2) return true;
 
   const targetUid = normalizeCatsUid(botUid);
   if (!targetUid) return false;

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -75,7 +75,7 @@ interface PendingAttachment {
   localFileGrant?: ScopedLocalFileGrant;
 }
 
-type NativeFeishuGroupTriggerMessage = Pick<ParsedCatsMessage, 'topic' | 'chatType' | 'seq' | 'metadata'>;
+type NativeFeishuGroupTriggerMessage = Pick<ParsedCatsMessage, 'topic' | 'chatType' | 'seq' | 'metadata' | 'mentions' | 'memberCount'>;
 
 interface NativeFeishuContextHydration {
   message: NativeFeishuGroupTriggerMessage;
@@ -342,6 +342,43 @@ export function createCatsCompanyRuntime(sessionTTL?: number): AdapterRuntimeBun
     sessionTTL,
     promptSnapshotMode: 'mutable-identity',
   });
+}
+
+export function shouldActivateCatsCompanyMessage(
+  message: Pick<MessageContext, 'isGroup' | 'metadata' | 'mentions' | 'memberCount'>,
+  botUid: string | null | undefined,
+): boolean {
+  if (!message.isGroup) return true;
+
+  const metadata = message.metadata && typeof message.metadata === 'object' ? message.metadata : {};
+  const sourceChannel = typeof metadata.source_channel === 'string'
+    ? metadata.source_channel.trim()
+    : '';
+  if (sourceChannel) {
+    return metadata.channel_native_group_triggered === true
+      || metadata.channel_native_group_triggered === 1
+      || metadata.channel_native_group_triggered === '1'
+      || metadata.channel_native_group_triggered === 'true';
+  }
+
+  const memberCount = Number(message.memberCount);
+  if (Number.isFinite(memberCount) && memberCount > 0 && memberCount <= 2) return true;
+
+  const targetUid = normalizeCatsUid(botUid);
+  if (!targetUid) return false;
+  return Array.isArray(message.mentions)
+    && message.mentions.some(mention => normalizeCatsUid(mention) === targetUid);
+}
+
+function shouldHydrateCatsCompanyGroupContext(
+  message: Pick<ParsedCatsMessage, 'chatType' | 'metadata' | 'seq'>,
+): boolean {
+  if (message.chatType !== 'group' || message.seq <= 0) return false;
+  const metadata = message.metadata && typeof message.metadata === 'object' ? message.metadata : {};
+  const sourceChannel = typeof metadata.source_channel === 'string'
+    ? metadata.source_channel.trim()
+    : '';
+  return !sourceChannel || isNativeFeishuGroupTrigger(message);
 }
 
 /**
@@ -1254,11 +1291,17 @@ export class CatsCompanyBot {
       return;
     }
 
+    // 过滤 bot 自己发出的消息，防止循环。
+    if (this.botUid && normalizeCatsUid(ctx.senderId) === normalizeCatsUid(this.botUid)) return;
+
+    // 群聊激活门控必须发生在 parse 后续的云恢复和 session 创建之前。
+    if (!shouldActivateCatsCompanyMessage(ctx, this.botUid)) {
+      Logger.info(`[CatsCompany] 群消息未命中当前 AI 的结构化 mention，跳过: topic=${ctx.topic}, seq=${ctx.seq || 0}`);
+      return;
+    }
+
     const msg = this.parseMessage(ctx);
     if (!msg) return;
-
-    // 过滤 bot 自己发出的消息，防止循环
-    if (this.botUid && msg.senderId === this.botUid) return;
 
     const key = msg.envelope.sessionKey;
 
@@ -1288,7 +1331,7 @@ export class CatsCompanyBot {
 
   private async processParsedMessage(msg: ParsedCatsMessage, key: string): Promise<void> {
     const entryClearGeneration = this.getSessionClearGeneration(key);
-    const nativeFeishuTrigger = isNativeFeishuGroupTrigger(msg);
+    const nativeFeishuTrigger = shouldHydrateCatsCompanyGroupContext(msg);
     const sessionRoute = msg.envelope ? createCatsCoSessionRoute(msg.envelope) : undefined;
     let cloudRestoreResult: CloudSessionRestoreResult | undefined;
     if (sessionRoute && !isClearCommand(msg.text)) {
@@ -1416,6 +1459,8 @@ export class CatsCompanyBot {
           chatType: msg.chatType,
           seq: msg.seq,
           metadata: msg.metadata,
+          mentions: msg.mentions,
+          memberCount: msg.memberCount,
         },
         cloudRestoreStatus: cloudRestoreResult?.status,
         clearGeneration: entryClearGeneration,
@@ -1525,9 +1570,20 @@ export class CatsCompanyBot {
     sessionKey: string,
   ): Promise<boolean> {
     const { message: msg, cloudRestoreStatus, clearGeneration } = hydration;
-    if (!isNativeFeishuGroupTrigger(msg)) return true;
+    if (!shouldHydrateCatsCompanyGroupContext(msg)) return true;
     if (clearGeneration !== this.getSessionClearGeneration(sessionKey)) return false;
     const cursorKey = 'catscompany.agent_context';
+    const memberCount = Number(msg.memberCount);
+    const sourceChannel = typeof msg.metadata?.source_channel === 'string'
+      ? msg.metadata.source_channel.trim()
+      : '';
+    if (!sourceChannel && Number.isFinite(memberCount) && memberCount > 0 && memberCount <= 2) {
+      session.saveRemoteContextCursor(
+        cursorKey,
+        Math.max(session.getRemoteContextCursor(cursorKey), msg.seq),
+      );
+      return true;
+    }
     if (cloudRestoreStatus === 'restored' || cloudRestoreStatus === 'empty') {
       if (clearGeneration !== this.getSessionClearGeneration(sessionKey)) return false;
       session.saveRemoteContextCursor(
@@ -1546,11 +1602,11 @@ export class CatsCompanyBot {
       }
       session.saveRemoteContextCursor(cursorKey, Math.max(previousCursor, msg.seq));
       if (contextMessages.length > 0) {
-        Logger.info(`[${sessionKey}] 已补入 ${contextMessages.length} 条飞书群普通消息上下文`);
+        Logger.info(`[${sessionKey}] 已补入 ${contextMessages.length} 条群聊普通消息上下文`);
       }
       return true;
     } catch (err: any) {
-      Logger.warning(`[${sessionKey}] 飞书群历史上下文恢复失败，继续处理当前消息: ${err?.message || err}`);
+      Logger.warning(`[${sessionKey}] 群聊历史上下文恢复失败，继续处理当前消息: ${err?.message || err}`);
       return clearGeneration === this.getSessionClearGeneration(sessionKey);
     }
   }
@@ -1601,7 +1657,7 @@ export class CatsCompanyBot {
     }
 
     Logger.warning(
-      `[${topic}] 飞书群历史超过 ${NATIVE_FEISHU_CONTEXT_MAX_PAGES * NATIVE_FEISHU_CONTEXT_PAGE_SIZE} 条，`
+      `[${topic}] 群聊历史超过 ${NATIVE_FEISHU_CONTEXT_MAX_PAGES * NATIVE_FEISHU_CONTEXT_PAGE_SIZE} 条，`
       + '仅补入最近一段并推进游标',
     );
     return [...messagesBySeq.values()]
@@ -1891,6 +1947,8 @@ export class CatsCompanyBot {
       senderId: ctx.senderId,
       seq: ctx.seq ?? 0,
       text: messageText,
+      mentions: ctx.mentions,
+      memberCount: ctx.memberCount,
       rawContent: ctx.content,
       metadata: ctx.metadata,
       envelope,

--- a/src/catscompany/types.ts
+++ b/src/catscompany/types.ts
@@ -41,6 +41,10 @@ export interface ParsedCatsMessage {
   text: string;
   /** 原始 content（可能是 string 或 RichContent） */
   rawContent: unknown;
+  /** 服务端确认的结构化 @mention 目标 */
+  mentions?: string[];
+  /** 群成员数；用于运行时 session 前门控 */
+  memberCount?: number;
   /** 原始 metadata，由 CatsCo 服务端透传/注入 */
   metadata?: Record<string, unknown>;
   /** 标准化后的消息信封 */

--- a/tests/catscompany-execution-scope-flow.test.ts
+++ b/tests/catscompany-execution-scope-flow.test.ts
@@ -187,6 +187,31 @@ function createHarness(options: {
 }
 
 describe('CatsCompany execution scope flow', () => {
+  test('drops an unmentioned large-group message before cloud restore or session creation', async () => {
+    const { bot, handledTurns, sessionKeys } = createHarness();
+    let restoreCalls = 0;
+    bot.ensureCloudSessionRestored = async () => {
+      restoreCalls++;
+      return { status: 'local_present', fetched: 0, restored: 0, compressed: false };
+    };
+
+    await bot.onMessage({
+      topic: 'grp_80',
+      senderId: 'usr7',
+      text: '@usr43 只是正文，不是结构化 mention',
+      content: '@usr43 只是正文，不是结构化 mention',
+      metadata: canonicalMetadata('usr7', 'grp_80'),
+      isGroup: true,
+      mentions: [],
+      memberCount: 4,
+      seq: 11,
+    });
+
+    assert.equal(restoreCalls, 0);
+    assert.deepEqual(sessionKeys, []);
+    assert.deepEqual(handledTurns, []);
+  });
+
   test('does not create a blank session when first cloud recovery fails', async () => {
     const { bot, handledTurns, sessionKeys, replies } = createHarness({
       existingSession: false,
@@ -691,6 +716,7 @@ describe('CatsCompany execution scope flow', () => {
       content: '先处理这个任务',
       metadata: canonicalMetadata('usr8', 'grp_80'),
       isGroup: true,
+      memberCount: 2,
       seq: 19,
     });
     await firstTurnStartedPromise;
@@ -850,6 +876,8 @@ describe('CatsCompany execution scope flow', () => {
       content: '@usr43 看一下',
       metadata: canonicalMetadata('usr7', 'grp_80'),
       isGroup: true,
+      mentions: ['usr43'],
+      memberCount: 3,
       seq: 12,
     });
 
@@ -903,6 +931,7 @@ describe('CatsCompany execution scope flow', () => {
         }),
       ]),
       isGroup: true,
+      memberCount: 2,
       seq: 12,
     });
 

--- a/tests/catscompany-group-activation.test.ts
+++ b/tests/catscompany-group-activation.test.ts
@@ -1,0 +1,32 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import { shouldActivateCatsCompanyMessage } from '../src/catscompany';
+
+describe('CatsCompany group activation gate', () => {
+  test('keeps p2p and two-member group behavior automatic', () => {
+    assert.equal(shouldActivateCatsCompanyMessage({ isGroup: false }, 'usr43'), true);
+    assert.equal(shouldActivateCatsCompanyMessage({ isGroup: true, memberCount: 2 }, 'usr43'), true);
+  });
+
+  test('requires the current AI in structured mentions for larger groups', () => {
+    assert.equal(shouldActivateCatsCompanyMessage({ isGroup: true, memberCount: 4 }, 'usr43'), false);
+    assert.equal(shouldActivateCatsCompanyMessage({ isGroup: true, memberCount: 4, mentions: ['usr42'] }, 'usr43'), false);
+    assert.equal(shouldActivateCatsCompanyMessage({ isGroup: true, memberCount: 4, mentions: ['usr43'] }, '43'), true);
+  });
+
+  test('fails closed when group size is missing unless the current AI is targeted', () => {
+    assert.equal(shouldActivateCatsCompanyMessage({ isGroup: true }, 'usr43'), false);
+    assert.equal(shouldActivateCatsCompanyMessage({ isGroup: true, mentions: ['usr43'] }, 'usr43'), true);
+  });
+
+  test('trusts only the structured channel trigger flag for externally managed groups', () => {
+    assert.equal(shouldActivateCatsCompanyMessage({
+      isGroup: true,
+      metadata: { source_channel: 'feishu', channel_native_group_triggered: false },
+    }, 'usr43'), false);
+    assert.equal(shouldActivateCatsCompanyMessage({
+      isGroup: true,
+      metadata: { source_channel: 'feishu', channel_native_group_triggered: true },
+    }, 'usr43'), true);
+  });
+});

--- a/tests/catscompany-group-activation.test.ts
+++ b/tests/catscompany-group-activation.test.ts
@@ -14,9 +14,17 @@ describe('CatsCompany group activation gate', () => {
     assert.equal(shouldActivateCatsCompanyMessage({ isGroup: true, memberCount: 4, mentions: ['usr43'] }, '43'), true);
   });
 
-  test('fails closed when group size is missing unless the current AI is targeted', () => {
+  test('fails closed when group size is missing or malformed unless the current AI is targeted', () => {
     assert.equal(shouldActivateCatsCompanyMessage({ isGroup: true }, 'usr43'), false);
+    assert.equal(shouldActivateCatsCompanyMessage({ isGroup: true, memberCount: 1.5 }, 'usr43'), false);
+    assert.equal(shouldActivateCatsCompanyMessage({ isGroup: true, memberCount: '2' } as any, 'usr43'), false);
+    assert.equal(shouldActivateCatsCompanyMessage({ isGroup: true, memberCount: Number.MAX_SAFE_INTEGER + 1 }, 'usr43'), false);
     assert.equal(shouldActivateCatsCompanyMessage({ isGroup: true, mentions: ['usr43'] }, 'usr43'), true);
+    assert.equal(shouldActivateCatsCompanyMessage({
+      isGroup: true,
+      memberCount: 1.5,
+      mentions: ['usr43'],
+    }, 'usr43'), true);
   });
 
   test('trusts only the structured channel trigger flag for externally managed groups', () => {

--- a/tests/catscompany-message-envelope.test.ts
+++ b/tests/catscompany-message-envelope.test.ts
@@ -161,6 +161,33 @@ describe('CatsCompany MessageEnvelope and ExecutionScope', () => {
     assert.equal(scope.agentBodyId, undefined);
   });
 
+  test('client rejects malformed member counts instead of coercing them', async () => {
+    for (const memberCount of ['2', 1.5, 0, Number.MAX_SAFE_INTEGER + 1]) {
+      const client = new CatsClient({
+        serverUrl: 'ws://127.0.0.1:1',
+        apiKey: 'cc-test',
+        bodyId: 'body-test',
+      });
+
+      const messagePromise = new Promise<any>(resolve => {
+        client.once('message', resolve);
+      });
+
+      (client as any).handleMessage({
+        data: {
+          topic: 'grp_80',
+          from: 'usr7',
+          seq: 50,
+          content: 'hello',
+          member_count: memberCount,
+        },
+      });
+
+      const ctx = await messagePromise;
+      assert.equal(ctx.memberCount, undefined, `member_count=${String(memberCount)}`);
+    }
+  });
+
   test('client forwards inbound metadata into MessageContext', async () => {
     const client = new CatsClient({
       serverUrl: 'ws://127.0.0.1:1',

--- a/tests/catscompany-message-envelope.test.ts
+++ b/tests/catscompany-message-envelope.test.ts
@@ -179,6 +179,8 @@ describe('CatsCompany MessageEnvelope and ExecutionScope', () => {
         seq: 51,
         content: 'hello',
         type: 'text',
+        mentions: ['usr43'],
+        member_count: 4,
         metadata: {
           catsco_identity: {
             actor: { user_id: 'usr7' },
@@ -193,6 +195,8 @@ describe('CatsCompany MessageEnvelope and ExecutionScope', () => {
     const ctx = await messagePromise;
     assert.equal(ctx.topic, 'p2p_7_43');
     assert.equal(ctx.senderId, 'usr7');
+    assert.deepEqual(ctx.mentions, ['usr43']);
+    assert.equal(ctx.memberCount, 4);
     assert.deepEqual((ctx.metadata as any).catsco_identity.agent, {
       agent_id: 'usr43',
       body_id: 'body-test',


### PR DESCRIPTION
## Problem

Cats Company now performs the primary server-side group Bot routing decision, but the XiaoBa runtime also needs a defensive gate before any session lifecycle work. Without that second gate, another ingress path or incomplete server rollout could still create or restore a session for an unmentioned Bot, pollute its context, and potentially produce a reply.

A Bot that is intentionally activated after being dormant also needs the group messages it missed while it was not selected, without duplicating the triggering message or mixing context between groups.

## Behavior after this change

- Direct conversations remain automatic.
- Groups with at most two members retain the existing automatic participation behavior.
- Larger groups activate this runtime only when its normalized Bot UID is present in the structured `mentions` list.
- If group size metadata is missing or invalid, the runtime fails closed unless the current Bot is explicitly mentioned.
- Mentioning another member or another Bot does not activate this runtime.
- Channel-managed group messages require the explicit server-provided `channel_native_group_triggered` flag; the presence of a source-channel string alone is not enough.
- The gate runs before cloud restore, session lookup/creation, and message execution.
- Once explicitly activated, the runtime restores the stable group session and hydrates missed group context before processing the current turn.

## What changed

### Inbound protocol

- Added structured `mentions` and authoritative `member_count` fields to the Cats Company message context types.
- Forwarded both fields from WebSocket server data into `MessageContext` without deriving targets from display text.

### Pre-session activation gate

- Added `shouldActivateCatsCompanyMessage` as a single policy function for direct, small-group, large-group, unknown-size, and channel-managed messages.
- Normalizes `usr<id>` and bare numeric UID forms before comparing mention targets to the configured/current Bot UID.
- Executes the policy immediately after self-message filtering and before parsing triggers any cloud/session work.
- Silently drops an unmentioned group message instead of creating an empty session, restoring cloud history, queuing a turn, or sending a reply.

### Group context restoration

- Extended cloud restoration from direct sessions to stable group sessions.
- Hydrates ordinary Cats Company group history for an activated Bot, not only native Feishu-triggered groups.
- Uses the group-scoped session route and remote-context cursor so history stays isolated by topic.
- Reuses the existing agent-context history validation, chronological ordering, deduplication, and cursor advancement paths.
- Keeps the current trigger outside the recovered history window to avoid inserting it twice.
- Preserves the existing clear/abort and concurrent-restore safeguards.

## Test coverage

Added or extended coverage for:

- Direct and two-member group messages remain automatic.
- Large groups require the current AI in structured mentions.
- Mentions for another AI do not activate this runtime.
- Missing member count fails closed unless explicitly targeted.
- Channel-managed groups trust only the explicit trigger flag.
- Unmentioned large-group messages exit before cloud restore or session creation.
- WebSocket message parsing forwards structured mention and member-count fields.
- Group session routing keeps a stable group key while preserving actor execution scope.

Validation completed:

- `node --import tsx --test tests/catscompany-group-activation.test.ts tests/catscompany-execution-scope-flow.test.ts tests/catscompany-message-envelope.test.ts` — 3 suites, 38 tests passed.
- `npm run build` — TypeScript build passed.
- `git diff --check origin/main...HEAD` — passed.

## Companion server/WebApp change

Depends on and complements https://github.com/buildsense-ai/cats-company/pull/101, which introduces the structured mention payload, authoritative group member count, and primary server-side Bot routing gate.
