### PR TITLE
fix(openai): preserve UTF-8 across streamed chunks

### DIFF
--- a/src/providers/openai-provider.ts
+++ b/src/providers/openai-provider.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { createHash } from 'crypto';
+import { StringDecoder } from 'string_decoder';
 import { Message, ChatConfig, ChatResponse, ContentBlock } from '../types';
 import { ToolDefinition } from '../types/tool';
 import { AIProvider, AIRequestOptions, StreamCallbacks } from './provider';
@@ -235,6 +236,7 @@ export class OpenAIProvider implements AIProvider {
       let contentStripper = new OpenAIThinkingStripper();
       const toolCallsMap = new Map<number, { id: string; type: 'function'; function: { name: string; arguments: string } }>();
       let buffer = '';
+      const decoder = new StringDecoder('utf8');
       let streamUsage: ChatResponse['usage'] = undefined;
       let finishReason: string | undefined;
 
@@ -249,7 +251,7 @@ export class OpenAIProvider implements AIProvider {
       }
 
       stream.on('data', (chunk: Buffer) => {
-        buffer += chunk.toString();
+        buffer += decoder.write(chunk);
         const lines = buffer.split('\n');
         buffer = lines.pop() || '';
 
@@ -324,6 +326,7 @@ export class OpenAIProvider implements AIProvider {
       });
 
       stream.on('end', () => {
+        buffer += decoder.end();
         options?.signal?.removeEventListener('abort', onAbort);
         const tail = contentStripper.flush();
         if (tail) {
@@ -629,6 +632,7 @@ export class OpenAIProvider implements AIProvider {
       const outputItems: any[] = [];
       let streamedVisibleText = '';
       let buffer = '';
+      const decoder = new StringDecoder('utf8');
       let finalResponse: any;
       let settled = false;
 
@@ -675,7 +679,7 @@ export class OpenAIProvider implements AIProvider {
       };
 
       stream.on('data', (chunk: Buffer) => {
-        buffer += chunk.toString();
+        buffer += decoder.write(chunk);
         const lines = buffer.split('\n');
         buffer = lines.pop() || '';
         for (const line of lines) {
@@ -692,6 +696,7 @@ export class OpenAIProvider implements AIProvider {
       });
 
       stream.on('end', () => {
+        buffer += decoder.end();
         options?.signal?.removeEventListener('abort', onAbort);
         if (settled) return;
         const tail = contentStripper.flush();

--- a/tests/openai-provider-responses.test.ts
+++ b/tests/openai-provider-responses.test.ts
@@ -305,6 +305,43 @@ describe('OpenAIProvider Responses API mode', () => {
     }
   });
 
+  test('preserves UTF-8 when Responses SSE splits a character across chunks', async () => {
+    const originalPost = axios.post;
+    const terminalResponse = {
+      status: 'completed',
+      output: [{
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'output_text', text: '中文' }],
+      }],
+    };
+    const splitEvent = splitInsideUtf8Character(
+      sse({ type: 'response.output_text.delta', delta: '中文' }),
+      '中',
+    );
+    (axios as any).post = async () => ({
+      data: Readable.from([
+        ...splitEvent,
+        Buffer.from(sse({ type: 'response.completed', response: terminalResponse }), 'utf8'),
+      ]),
+    });
+
+    try {
+      const chunks: string[] = [];
+      const result = await createProvider().chatStream(
+        [{ role: 'user', content: 'hello' }],
+        undefined,
+        { onText: value => chunks.push(value) },
+      );
+
+      assert.deepEqual(chunks, ['中文']);
+      assert.equal(result.content, '中文');
+      assert.equal(JSON.stringify(result).includes('�'), false);
+    } finally {
+      (axios as any).post = originalPost;
+    }
+  });
+
   test('preserves streamed text when the terminal response omits its message', async () => {
     const originalPost = axios.post;
     (axios as any).post = async () => ({
@@ -408,4 +445,15 @@ describe('OpenAIProvider Responses API mode', () => {
 
 function sse(payload: unknown): string {
   return `data: ${JSON.stringify(payload)}\n\n`;
+}
+
+function splitInsideUtf8Character(value: string, character: string): Buffer[] {
+  const buffer = Buffer.from(value, 'utf8');
+  const characterBytes = Buffer.from(character, 'utf8');
+  const offset = buffer.indexOf(characterBytes);
+  assert.notEqual(offset, -1);
+  return [
+    buffer.subarray(0, offset + 1),
+    buffer.subarray(offset + 1),
+  ];
 }

--- a/tests/openai-provider-runtime-feedback.test.ts
+++ b/tests/openai-provider-runtime-feedback.test.ts
@@ -381,6 +381,41 @@ describe('OpenAIProvider runtime feedback boundary', () => {
     }
   });
 
+  test('preserves UTF-8 when Chat Completions SSE splits a character across chunks', async () => {
+    const originalPost = axios.post;
+    const splitEvent = splitInsideUtf8Character(
+      'data: {"choices":[{"delta":{"content":"中文"},"finish_reason":"stop"}]}\n\n',
+      '中',
+    );
+    (axios as any).post = async () => ({
+      data: Readable.from([
+        ...splitEvent,
+        Buffer.from('data: [DONE]\n\n', 'utf8'),
+      ]),
+    });
+
+    try {
+      const provider = new OpenAIProvider({
+        apiKey: 'test-key',
+        apiUrl: 'https://example.test/v1/chat/completions',
+        model: 'test-model',
+      });
+      const chunks: string[] = [];
+
+      const result = await provider.chatStream(
+        [{ role: 'user', content: 'hello' }],
+        undefined,
+        { onText: chunk => chunks.push(chunk) },
+      );
+
+      assert.equal(result.content, '中文');
+      assert.deepEqual(chunks, ['中文']);
+      assert.equal(JSON.stringify(result).includes('�'), false);
+    } finally {
+      (axios as any).post = originalPost;
+    }
+  });
+
   test('hides OpenAI-compatible reasoning fields and split think tags in stream responses', async () => {
     const originalPost = axios.post;
     (axios as any).post = async () => ({
@@ -469,6 +504,17 @@ describe('OpenAIProvider runtime feedback boundary', () => {
     }
   });
 });
+
+function splitInsideUtf8Character(value: string, character: string): Buffer[] {
+  const buffer = Buffer.from(value, 'utf8');
+  const characterBytes = Buffer.from(character, 'utf8');
+  const offset = buffer.indexOf(characterBytes);
+  assert.notEqual(offset, -1);
+  return [
+    buffer.subarray(0, offset + 1),
+    buffer.subarray(offset + 1),
+  ];
+}
 
 function sse(payload: unknown): string {
   return `data: ${JSON.stringify(payload)}\n\n`;


### PR DESCRIPTION
## Summary
- Decode streamed OpenAI SSE buffers with a stateful UTF-8 decoder instead of per-chunk Buffer.toString()
- Cover both Chat Completions and Responses streaming paths
- Add regression tests that split a Chinese UTF-8 character across network chunks and assert no replacement character is emitted

## Verification
- ./node_modules/.bin/tsx --test tests/openai-provider-runtime-feedback.test.ts
- ./node_modules/.bin/tsx --test tests/openai-provider-responses.test.ts
- ./node_modules/.bin/tsc --noEmit
- npm run build