### PR TITLE
将 System Prompt 纳入本地 BotDefinition 并支持按 Bot 隔离

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -7239,9 +7239,15 @@
     }
 
     function renderPromptEditorPane(file){
-      const saveDisabled=promptEditorState?.writable?'':' disabled';
+      const definitionReady=promptEditorState?.system_prompt?.definitionReady===true;
+      const promptWritable=Boolean(promptEditorState?.writable&&definitionReady);
+      const saveDisabled=promptWritable?'':' disabled';
       const selectedMode=promptEditorState?.system_prompt?.selected||'default';
       const isCustom=selectedMode==='custom';
+      const modeDisabled=definitionReady?'':' disabled';
+      const editorStatus=!definitionReady
+        ?'机器人配置尚未初始化，连接完成后即可编辑。'
+        :(isCustom?'编辑后保存；下一条用户消息开始前生效。':'当前使用随 XiaoBa 更新的内置默认 Prompt。');
       return '<div class="prompt-editor-pane">'+
         '<div class="prompt-editor-head">'+
           '<div><div class="prompt-editor-title">'+escapeHtml(file.path)+'</div>'+
@@ -7249,13 +7255,13 @@
           (file.overridden?'<span class="tag green">override</span>':'<span class="tag">base</span>')+
         '</div>'+
         '<div class="settings-actions" style="justify-content:flex-start;margin-bottom:12px">'+
-          '<button class="btn'+(!isCustom?' btn-primary':'')+'" type="button" onclick="selectSystemPromptMode(\'default\')">默认 System Prompt</button>'+
-          '<button class="btn'+(isCustom?' btn-primary':'')+'" type="button" onclick="selectSystemPromptMode(\'custom\')">自定义 System Prompt</button>'+
-          '<button class="btn" type="button" onclick="insertDisplayNameTemplate()"'+(isCustom?'':' disabled')+'>插入 {{displayName}}</button>'+
+          '<button class="btn'+(!isCustom?' btn-primary':'')+'" type="button" onclick="selectSystemPromptMode(\'default\')"'+modeDisabled+'>默认 System Prompt</button>'+
+          '<button class="btn'+(isCustom?' btn-primary':'')+'" type="button" onclick="selectSystemPromptMode(\'custom\')"'+modeDisabled+'>自定义 System Prompt</button>'+
+          '<button class="btn" type="button" onclick="insertDisplayNameTemplate()"'+(isCustom&&definitionReady?'':' disabled')+'>插入 {{displayName}}</button>'+
         '</div>'+
-        '<textarea class="config-input prompt-editor-textarea" id="prompt-editor-textarea" spellcheck="false" oninput="markPromptEditorDirty()"'+(isCustom?'':' readonly')+'>'+escapeHtml(file.content||'')+'</textarea>'+
+        '<textarea class="config-input prompt-editor-textarea" id="prompt-editor-textarea" spellcheck="false" oninput="markPromptEditorDirty()"'+(isCustom&&definitionReady?'':' readonly')+'>'+escapeHtml(file.content||'')+'</textarea>'+
         '<div class="prompt-editor-actions">'+
-          '<div class="prompt-editor-status" id="prompt-editor-status">'+(isCustom?'编辑后保存；下一条用户消息开始前生效。':'当前使用随 XiaoBa 更新的内置默认 Prompt。')+'</div>'+
+          '<div class="prompt-editor-status" id="prompt-editor-status">'+editorStatus+'</div>'+
           '<div class="settings-actions">'+
             '<button class="btn btn-primary" id="prompt-editor-save-btn" onclick="savePromptEditorFile()"'+(isCustom?saveDisabled:' disabled')+'>保存自定义 Prompt</button>'+
           '</div>'+

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -7240,22 +7240,55 @@
 
     function renderPromptEditorPane(file){
       const saveDisabled=promptEditorState?.writable?'':' disabled';
-      const resetDisabled=file.overridden?'':' disabled';
+      const selectedMode=promptEditorState?.system_prompt?.selected||'default';
+      const isCustom=selectedMode==='custom';
       return '<div class="prompt-editor-pane">'+
         '<div class="prompt-editor-head">'+
           '<div><div class="prompt-editor-title">'+escapeHtml(file.path)+'</div>'+
           '<div class="prompt-editor-meta">当前 '+escapeHtml(file.effective.short_hash)+' · 基线 '+escapeHtml(file.base.short_hash)+' · '+(file.overridden?'已有本地覆盖':'使用内置基线')+'</div></div>'+
           (file.overridden?'<span class="tag green">override</span>':'<span class="tag">base</span>')+
         '</div>'+
-        '<textarea class="config-input prompt-editor-textarea" id="prompt-editor-textarea" spellcheck="false" oninput="markPromptEditorDirty()">'+escapeHtml(file.content||'')+'</textarea>'+
+        '<div class="settings-actions" style="justify-content:flex-start;margin-bottom:12px">'+
+          '<button class="btn'+(!isCustom?' btn-primary':'')+'" type="button" onclick="selectSystemPromptMode(\'default\')">默认 System Prompt</button>'+
+          '<button class="btn'+(isCustom?' btn-primary':'')+'" type="button" onclick="selectSystemPromptMode(\'custom\')">自定义 System Prompt</button>'+
+          '<button class="btn" type="button" onclick="insertDisplayNameTemplate()"'+(isCustom?'':' disabled')+'>插入 {{displayName}}</button>'+
+        '</div>'+
+        '<textarea class="config-input prompt-editor-textarea" id="prompt-editor-textarea" spellcheck="false" oninput="markPromptEditorDirty()"'+(isCustom?'':' readonly')+'>'+escapeHtml(file.content||'')+'</textarea>'+
         '<div class="prompt-editor-actions">'+
-          '<div class="prompt-editor-status" id="prompt-editor-status">'+(promptEditorState?.writable?'编辑后保存覆盖版本；下一条用户消息开始前生效。':'当前环境没有配置覆盖目录，不能保存。')+'</div>'+
+          '<div class="prompt-editor-status" id="prompt-editor-status">'+(isCustom?'编辑后保存；下一条用户消息开始前生效。':'当前使用随 XiaoBa 更新的内置默认 Prompt。')+'</div>'+
           '<div class="settings-actions">'+
-            '<button class="btn" onclick="resetPromptEditorFile()"'+resetDisabled+'>重置为内置</button>'+
-            '<button class="btn btn-primary" id="prompt-editor-save-btn" onclick="savePromptEditorFile()"'+saveDisabled+'>保存覆盖</button>'+
+            '<button class="btn btn-primary" id="prompt-editor-save-btn" onclick="savePromptEditorFile()"'+(isCustom?saveDisabled:' disabled')+'>保存自定义 Prompt</button>'+
           '</div>'+
         '</div>'+
       '</div>';
+    }
+
+    async function selectSystemPromptMode(selected){
+      if(promptEditorDirty && !confirm('当前 Prompt 有未保存改动，确定切换吗？'))return;
+      const status=document.getElementById('prompt-editor-status');
+      try{
+        if(status)status.textContent='正在切换...';
+        await parseSimpleResponse(await fetch(API+'/api/prompts/system',{
+          method:'PUT',
+          headers:{'Content-Type':'application/json'},
+          body:JSON.stringify({selected:selected})
+        }));
+        await refreshPromptWorkbench('system-prompt.md',{preserveFileListScroll:true});
+      }catch(e){
+        if(status)status.textContent='切换失败：'+(e.message||String(e));
+      }
+    }
+
+    function insertDisplayNameTemplate(){
+      const textarea=document.getElementById('prompt-editor-textarea');
+      if(!textarea || textarea.readOnly)return;
+      const value='{{displayName}}';
+      const start=textarea.selectionStart||0;
+      const end=textarea.selectionEnd||start;
+      textarea.value=textarea.value.slice(0,start)+value+textarea.value.slice(end);
+      textarea.selectionStart=textarea.selectionEnd=start+value.length;
+      textarea.focus();
+      markPromptEditorDirty();
     }
 
     function markPromptEditorDirty(){

--- a/prompts/sidecars/prompt-companion-advisor.md
+++ b/prompts/sidecars/prompt-companion-advisor.md
@@ -29,7 +29,7 @@
 也可以使用精确替换：
 {
   "skip": false,
-  "target_path": "runtime-context.md",
+  "target_path": "system-prompt.md",
   "operation": "replace",
   "title": "40 字以内标题",
   "issue": "先写清楚要解决的问题，160 字以内",

--- a/skills/catsco-prompt-editor/SKILL.md
+++ b/skills/catsco-prompt-editor/SKILL.md
@@ -11,7 +11,7 @@ Use this skill to improve CatsCo prompts without distracting the main agent from
 
 - Treat prompt editing as a side workflow: diagnose, propose, ask for confirmation, then apply.
 - Prefer local prompt overrides over editing built-in prompt files. Built-in files are the baseline; overrides are the experiment layer.
-- Only edit existing prompt `.md` paths exposed by Prompt Lab, such as `system-prompt.md`, `runtime-context.md`, `compact-system.md`, `transient/*.md`, `subagents/*.md`, and `sidecars/*.md`.
+- Only edit `system-prompt.md`. Runtime, sidecar, and sub-agent prompts are fixed implementation details.
 - Do not edit `src/`, tool schemas, provider adapters, credentials, or user data unless the user explicitly asks for code changes.
 - Never put secrets, private file contents, long chat transcripts, screenshots, or API keys into prompt files.
 
@@ -20,12 +20,8 @@ Use this skill to improve CatsCo prompts without distracting the main agent from
 1. Inspect the current prompt state.
    - Prefer `GET http://127.0.0.1:3800/api/prompts` when the local Dashboard API is running.
    - Otherwise ask the user for the Prompt Lab state or the override directory path.
-2. Pick the smallest prompt file that matches the behavior being tuned.
-   - Global behavior: `system-prompt.md`.
-   - Runtime facts and current directory wording: `runtime-context.md` or `transient/current-directory.md`.
-   - Compression quality: `compact-system.md`.
-   - Sub-agent behavior: `subagents/*`.
-   - Small side model calls: `sidecars/*`.
+2. Confirm that the requested behavior belongs in the main `system-prompt.md`.
+   - Runtime facts, compression rules, sub-agent behavior, and sidecar protocols are not user-editable prompts.
 3. Propose the change before writing it.
    - Explain the target file, the intended behavioral change, and the risk.
    - Ask for a clear apply/cancel confirmation if the user has not already approved.

--- a/src/bot-definition/activation.ts
+++ b/src/bot-definition/activation.ts
@@ -11,6 +11,7 @@ import {
   type BotDefinitionSyncServiceOptions,
 } from './service';
 import type { BotCatalogModelRuntime, BotDefinition, BotDefinitionSyncResult } from './types';
+import { getPromptReconcileCoordinator } from './prompt-sync';
 import {
   acknowledgeCloudBotModelSelection,
   pullCloudBotModelSelection,
@@ -262,6 +263,17 @@ export async function prepareBoundBotDefinition(
   }
 
   definitionService.clearLegacyModelConfigurationWhenReady(definition);
+  if (!definitionService.read(botId)) {
+    definitionService.publish(botId, {
+      kind: 'catalog',
+      modelId: DEFAULT_CATSCO_RELAY_MODEL_ID,
+    });
+  }
+  await getPromptReconcileCoordinator({
+    runtimeRoot: options.runtimeRoot,
+    env: options.env,
+    definitionService,
+  }).activateBot(botId);
   return {
     botId,
     definition,

--- a/src/bot-definition/prompt-sync.ts
+++ b/src/bot-definition/prompt-sync.ts
@@ -75,8 +75,32 @@ export class PromptReconcileCoordinator {
   }
 
   getSelection(botId: string): PromptSelectionState {
-    const definition = this.requireDefinition(botId);
     const bundledDefaultSystemPrompt = this.readBundledDefault();
+    const definition = this.definitionService.read(botId);
+    if (!definition) {
+      const state = this.readState();
+      const active = this.readActivePrompt({ force: true });
+      const activeBelongsToBot = Boolean(
+        active
+        && (
+          !state
+          || (
+            state.activeBotId === botId
+            && (
+              state.materializedSelection === 'custom'
+              || active.hash !== state.lastSyncedHash
+            )
+          )
+        ),
+      );
+      return {
+        botId,
+        selected: activeBelongsToBot ? 'custom' : 'default',
+        ...(activeBelongsToBot ? { customSystemPrompt: active!.text } : {}),
+        effectiveSystemPrompt: activeBelongsToBot ? active!.text : bundledDefaultSystemPrompt,
+        bundledDefaultSystemPrompt,
+      };
+    }
     const prompt = definition.prompt ?? { selected: 'default' as const };
     const effectiveSystemPrompt = prompt.selected === 'custom'
       ? prompt.customSystemPrompt || bundledDefaultSystemPrompt

--- a/src/bot-definition/prompt-sync.ts
+++ b/src/bot-definition/prompt-sync.ts
@@ -24,6 +24,7 @@ export interface ActivePromptSyncState {
 
 export interface PromptSelectionState {
   botId: string;
+  definitionReady: boolean;
   selected: 'default' | 'custom';
   customSystemPrompt?: string;
   effectiveSystemPrompt: string;
@@ -95,6 +96,7 @@ export class PromptReconcileCoordinator {
       );
       return {
         botId,
+        definitionReady: false,
         selected: activeBelongsToBot ? 'custom' : 'default',
         ...(activeBelongsToBot ? { customSystemPrompt: active!.text } : {}),
         effectiveSystemPrompt: activeBelongsToBot ? active!.text : bundledDefaultSystemPrompt,
@@ -107,6 +109,7 @@ export class PromptReconcileCoordinator {
       : bundledDefaultSystemPrompt;
     return {
       botId,
+      definitionReady: true,
       selected: prompt.selected,
       ...(prompt.customSystemPrompt ? { customSystemPrompt: prompt.customSystemPrompt } : {}),
       effectiveSystemPrompt,
@@ -342,6 +345,7 @@ export class PromptReconcileCoordinator {
     const prompt = definition.prompt ?? { selected: 'default' as const };
     return {
       botId: definition.botId,
+      definitionReady: true,
       selected: prompt.selected,
       ...(prompt.customSystemPrompt ? { customSystemPrompt: prompt.customSystemPrompt } : {}),
       effectiveSystemPrompt,

--- a/src/bot-definition/prompt-sync.ts
+++ b/src/bot-definition/prompt-sync.ts
@@ -1,0 +1,398 @@
+import { createHash } from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+import { createCatsCoLocalConfigService } from '../catscompany/local-config';
+import { Logger } from '../utils/logger';
+import { PathResolver } from '../utils/path-resolver';
+import {
+  normalizePromptText,
+  readRequiredBundledPromptFile,
+  SYSTEM_PROMPT_RELATIVE_PATH,
+} from '../utils/prompt-template';
+import { createBotDefinitionSyncService, type BotDefinitionSyncService } from './service';
+import type { BotDefinition, BotPromptDefinition } from './types';
+
+const PROMPT_SYNC_STATE_SCHEMA = 'xiaoba.active-prompt-sync.v1';
+const RECENT_WRITE_GRACE_MS = 100;
+
+export interface ActivePromptSyncState {
+  schema: typeof PROMPT_SYNC_STATE_SCHEMA;
+  activeBotId: string;
+  lastSyncedHash: string;
+  materializedSelection: 'default' | 'custom';
+}
+
+export interface PromptSelectionState {
+  botId: string;
+  selected: 'default' | 'custom';
+  customSystemPrompt?: string;
+  effectiveSystemPrompt: string;
+  bundledDefaultSystemPrompt: string;
+}
+
+export interface ActivePromptSnapshot {
+  fileExisted: boolean;
+  content?: string;
+  state?: ActivePromptSyncState;
+}
+
+export interface PromptReconcileCoordinatorOptions {
+  runtimeRoot?: string;
+  env?: NodeJS.ProcessEnv;
+  definitionService?: BotDefinitionSyncService;
+}
+
+export class PromptReconcileCoordinator {
+  private readonly runtimeRoot: string;
+  private readonly env: NodeJS.ProcessEnv;
+  private readonly definitionService: BotDefinitionSyncService;
+  private tail: Promise<unknown> = Promise.resolve();
+
+  constructor(options: PromptReconcileCoordinatorOptions = {}) {
+    this.runtimeRoot = path.resolve(options.runtimeRoot ?? PathResolver.getRuntimeDataRoot());
+    this.env = options.env ?? process.env;
+    this.definitionService = options.definitionService ?? createBotDefinitionSyncService({
+      runtimeRoot: this.runtimeRoot,
+      env: this.env,
+    });
+  }
+
+  getActivePromptPath(): string {
+    return path.join(this.runtimeRoot, 'prompt-overrides', SYSTEM_PROMPT_RELATIVE_PATH);
+  }
+
+  getStatePath(): string {
+    return path.join(this.runtimeRoot, 'data', 'bot-prompt-sync', 'active.json');
+  }
+
+  getCurrentBotId(): string | undefined {
+    const localConfig = createCatsCoLocalConfigService({
+      runtimeRoot: this.runtimeRoot,
+      env: this.env,
+    }).load();
+    const botId = String(localConfig.currentBot?.uid || '').trim();
+    return botId || undefined;
+  }
+
+  getSelection(botId: string): PromptSelectionState {
+    const definition = this.requireDefinition(botId);
+    const bundledDefaultSystemPrompt = this.readBundledDefault();
+    const prompt = definition.prompt ?? { selected: 'default' as const };
+    const effectiveSystemPrompt = prompt.selected === 'custom'
+      ? prompt.customSystemPrompt || bundledDefaultSystemPrompt
+      : bundledDefaultSystemPrompt;
+    return {
+      botId,
+      selected: prompt.selected,
+      ...(prompt.customSystemPrompt ? { customSystemPrompt: prompt.customSystemPrompt } : {}),
+      effectiveSystemPrompt,
+      bundledDefaultSystemPrompt,
+    };
+  }
+
+  activateBot(botId: string): Promise<PromptSelectionState> {
+    return this.enqueue(() => this.activateBotNow(botId));
+  }
+
+  reconcileCurrent(options: { force?: boolean } = {}): Promise<boolean> {
+    return this.enqueue(async () => {
+      const botId = this.getCurrentBotId();
+      if (!botId) return false;
+      return this.reconcileBotNow(botId, options);
+    });
+  }
+
+  prepareCurrentBotForSwitch(): Promise<PromptSelectionState | undefined> {
+    return this.enqueue(async () => {
+      const botId = this.getCurrentBotId();
+      if (!botId) return undefined;
+      if (!this.definitionService.read(botId)) {
+        this.definitionService.pullOrBootstrap(botId);
+      }
+      if (!this.definitionService.read(botId)) {
+        const active = await this.readStableActivePrompt();
+        if (active) {
+          this.writeState({
+            schema: PROMPT_SYNC_STATE_SCHEMA,
+            activeBotId: botId,
+            lastSyncedHash: active.hash,
+            materializedSelection: 'custom',
+          });
+        }
+        return undefined;
+      }
+      return this.activateBotNow(botId);
+    });
+  }
+
+  scheduleCurrent(): void {
+    void this.reconcileCurrent().catch(error => {
+      Logger.warning(`Prompt sync retry deferred: ${errorMessage(error)}`);
+    });
+  }
+
+  select(
+    botId: string,
+    selected: 'default' | 'custom',
+    customSystemPrompt?: string,
+  ): Promise<PromptSelectionState> {
+    return this.enqueue(async () => {
+      const definition = this.requireDefinition(botId);
+      const bundledDefault = this.readBundledDefault();
+      const previousCustom = definition.prompt?.customSystemPrompt;
+      const normalizedCustom = customSystemPrompt === undefined
+        ? previousCustom
+        : normalizePromptText(customSystemPrompt);
+      if (customSystemPrompt !== undefined && !normalizedCustom) {
+        throw new Error('Custom system prompt cannot be empty');
+      }
+      const prompt: BotPromptDefinition = {
+        selected,
+        ...(normalizedCustom || previousCustom
+          ? { customSystemPrompt: normalizedCustom || previousCustom }
+          : selected === 'custom'
+            ? { customSystemPrompt: bundledDefault }
+            : {}),
+      };
+      const effective = selected === 'custom'
+        ? prompt.customSystemPrompt || bundledDefault
+        : bundledDefault;
+      const snapshot = this.captureActiveSnapshot();
+      try {
+        this.writeActivePrompt(effective);
+        this.writeState({
+          schema: PROMPT_SYNC_STATE_SCHEMA,
+          activeBotId: botId,
+          lastSyncedHash: hashPrompt(effective),
+          materializedSelection: selected,
+        });
+        this.definitionService.updatePrompt(botId, prompt);
+      } catch (error) {
+        this.restoreActiveSnapshot(snapshot);
+        throw error;
+      }
+      return this.getSelection(botId);
+    });
+  }
+
+  captureActiveSnapshot(): ActivePromptSnapshot {
+    const filePath = this.getActivePromptPath();
+    const state = this.readState();
+    return {
+      fileExisted: fs.existsSync(filePath),
+      ...(fs.existsSync(filePath) ? { content: fs.readFileSync(filePath, 'utf-8') } : {}),
+      ...(state ? { state } : {}),
+    };
+  }
+
+  restoreActiveSnapshot(snapshot: ActivePromptSnapshot): void {
+    const filePath = this.getActivePromptPath();
+    if (snapshot.fileExisted) {
+      this.writeFileAtomic(filePath, snapshot.content || '');
+    } else {
+      fs.rmSync(filePath, { force: true });
+    }
+    if (snapshot.state) {
+      this.writeState(snapshot.state);
+    } else {
+      fs.rmSync(this.getStatePath(), { force: true });
+    }
+  }
+
+  private async activateBotNow(botId: string): Promise<PromptSelectionState> {
+    let definition = this.requireDefinition(botId);
+    const state = this.readState();
+    const active = await this.readStableActivePrompt();
+
+    if (!definition.prompt) {
+      const canMigrateActive = Boolean(active && (!state || state.activeBotId === botId));
+      const prompt: BotPromptDefinition = canMigrateActive
+        ? { selected: 'custom', customSystemPrompt: active!.text }
+        : { selected: 'default' };
+      definition = this.definitionService.updatePrompt(botId, prompt).definition;
+    }
+
+    const bundledDefault = this.readBundledDefault();
+    const prompt = definition.prompt!;
+    const expected = prompt.selected === 'custom'
+      ? prompt.customSystemPrompt || bundledDefault
+      : bundledDefault;
+    const activeHasUnsyncedChange = Boolean(
+      active
+      && (
+        (state?.activeBotId === botId && active.hash !== state.lastSyncedHash)
+        || (!state && active.hash !== hashPrompt(expected))
+      ),
+    );
+    if (active && activeHasUnsyncedChange) {
+      const migrated = this.definitionService.updatePrompt(botId, {
+        selected: 'custom',
+        customSystemPrompt: active.text,
+      }).definition;
+      this.writeState({
+        schema: PROMPT_SYNC_STATE_SCHEMA,
+        activeBotId: botId,
+        lastSyncedHash: active.hash,
+        materializedSelection: 'custom',
+      });
+      return this.toSelection(migrated, bundledDefault, active.text);
+    }
+
+    const effective = prompt.selected === 'custom'
+      ? prompt.customSystemPrompt || bundledDefault
+      : bundledDefault;
+    if (prompt.selected === 'custom' && !prompt.customSystemPrompt) {
+      definition = this.definitionService.updatePrompt(botId, {
+        selected: 'custom',
+        customSystemPrompt: effective,
+      }).definition;
+    }
+    this.writeActivePrompt(effective);
+    this.writeState({
+      schema: PROMPT_SYNC_STATE_SCHEMA,
+      activeBotId: botId,
+      lastSyncedHash: hashPrompt(effective),
+      materializedSelection: prompt.selected,
+    });
+    return this.toSelection(definition, bundledDefault, effective);
+  }
+
+  private async reconcileBotNow(botId: string, options: { force?: boolean }): Promise<boolean> {
+    const state = this.readState();
+    if (!state || state.activeBotId !== botId) return false;
+    const active = this.readActivePrompt(options);
+    if (!active || active.hash === state.lastSyncedHash) return false;
+
+    this.requireDefinition(botId);
+    this.definitionService.updatePrompt(botId, {
+      selected: 'custom',
+      customSystemPrompt: active.text,
+    });
+    this.writeState({
+      schema: PROMPT_SYNC_STATE_SCHEMA,
+      activeBotId: botId,
+      lastSyncedHash: active.hash,
+      materializedSelection: 'custom',
+    });
+    return true;
+  }
+
+  private readActivePrompt(options: { force?: boolean }): { text: string; hash: string } | undefined {
+    const filePath = this.getActivePromptPath();
+    if (!fs.existsSync(filePath)) return undefined;
+    const stat = fs.statSync(filePath);
+    if (!options.force && Date.now() - stat.mtimeMs < RECENT_WRITE_GRACE_MS) return undefined;
+    const text = normalizePromptText(fs.readFileSync(filePath, 'utf-8'));
+    if (!text) return undefined;
+    return { text, hash: hashPrompt(text) };
+  }
+
+  private async readStableActivePrompt(): Promise<{ text: string; hash: string } | undefined> {
+    const filePath = this.getActivePromptPath();
+    if (!fs.existsSync(filePath)) return undefined;
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      const first = this.readActivePrompt({ force: true });
+      await new Promise(resolve => setTimeout(resolve, RECENT_WRITE_GRACE_MS));
+      const second = this.readActivePrompt({ force: true });
+      if (!first && !second) return undefined;
+      if (first && second && first.hash === second.hash) return second;
+    }
+    throw new Error('System prompt is still being written; retry after the current edit finishes');
+  }
+
+  private readBundledDefault(): string {
+    return readRequiredBundledPromptFile(SYSTEM_PROMPT_RELATIVE_PATH, this.env);
+  }
+
+  private requireDefinition(botId: string): BotDefinition {
+    const definition = this.definitionService.read(botId);
+    if (!definition) throw new Error(`BotDefinition does not exist for bot ${botId}`);
+    return definition;
+  }
+
+  private toSelection(
+    definition: BotDefinition,
+    bundledDefaultSystemPrompt: string,
+    effectiveSystemPrompt: string,
+  ): PromptSelectionState {
+    const prompt = definition.prompt ?? { selected: 'default' as const };
+    return {
+      botId: definition.botId,
+      selected: prompt.selected,
+      ...(prompt.customSystemPrompt ? { customSystemPrompt: prompt.customSystemPrompt } : {}),
+      effectiveSystemPrompt,
+      bundledDefaultSystemPrompt,
+    };
+  }
+
+  private writeActivePrompt(text: string): void {
+    const normalized = normalizePromptText(text);
+    if (!normalized) throw new Error('System prompt cannot be empty');
+    this.writeFileAtomic(this.getActivePromptPath(), `${normalized}\n`);
+  }
+
+  private readState(): ActivePromptSyncState | undefined {
+    const statePath = this.getStatePath();
+    if (!fs.existsSync(statePath)) return undefined;
+    try {
+      const value = JSON.parse(fs.readFileSync(statePath, 'utf-8')) as ActivePromptSyncState;
+      if (
+        value.schema !== PROMPT_SYNC_STATE_SCHEMA
+        || !String(value.activeBotId || '').trim()
+        || !/^[a-f0-9]{64}$/.test(String(value.lastSyncedHash || ''))
+        || (value.materializedSelection !== 'default' && value.materializedSelection !== 'custom')
+      ) {
+        return undefined;
+      }
+      return value;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private writeState(state: ActivePromptSyncState): void {
+    this.writeFileAtomic(this.getStatePath(), `${JSON.stringify(state, null, 2)}\n`);
+  }
+
+  private writeFileAtomic(filePath: string, content: string): void {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    const temporary = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+    fs.writeFileSync(temporary, content, 'utf-8');
+    fs.renameSync(temporary, filePath);
+  }
+
+  private enqueue<T>(operation: () => Promise<T> | T): Promise<T> {
+    const next = this.tail.then(operation, operation);
+    this.tail = next.then(() => undefined, () => undefined);
+    return next;
+  }
+}
+
+const coordinators = new Map<string, PromptReconcileCoordinator>();
+
+export function getPromptReconcileCoordinator(
+  options: PromptReconcileCoordinatorOptions = {},
+): PromptReconcileCoordinator {
+  const runtimeRoot = path.resolve(options.runtimeRoot ?? PathResolver.getRuntimeDataRoot());
+  const existing = coordinators.get(runtimeRoot);
+  if (existing && !options.definitionService && !options.env) return existing;
+  const coordinator = new PromptReconcileCoordinator({ ...options, runtimeRoot });
+  if (!options.definitionService && !options.env) coordinators.set(runtimeRoot, coordinator);
+  return coordinator;
+}
+
+export function reconcileCurrentBotPromptBeforeTurn(): Promise<boolean> {
+  return getPromptReconcileCoordinator().reconcileCurrent();
+}
+
+export function scheduleCurrentBotPromptReconcile(): void {
+  getPromptReconcileCoordinator().scheduleCurrent();
+}
+
+export function hashPrompt(text: string): string {
+  return createHash('sha256').update(normalizePromptText(text), 'utf-8').digest('hex');
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/bot-definition/repository.ts
+++ b/src/bot-definition/repository.ts
@@ -7,6 +7,7 @@ import {
   type BotCatalogModelRuntime,
   type BotCustomModelProfile,
   type BotDefinition,
+  type BotPromptDefinition,
   type CustomBotModelDefinition,
 } from './types';
 
@@ -15,6 +16,7 @@ export interface BotDefinitionRepository {
   writeCanonical(definition: BotDefinition): void;
   readCache(botId: string): BotDefinition | undefined;
   writeCache(definition: BotDefinition): void;
+  withWriteLock?<T>(botId: string, operation: () => T): T;
 }
 
 export interface BotCloudModelOverrideRepository {
@@ -61,11 +63,21 @@ function isValidDefinition(definition: unknown, expectedBotId: string): definiti
   if (!value || value.schema !== 'xiaoba.bot-definition.v1' || value.botId !== expectedBotId || !value.model) {
     return false;
   }
+  if (value.prompt !== undefined && !isValidPromptDefinition(value.prompt)) {
+    return false;
+  }
   if (value.model.kind === 'catalog') {
     return Boolean(String(value.model.modelId || '').trim());
   }
   if (value.model.kind !== 'custom') return false;
   return isValidCustomModel(value.model);
+}
+
+function isValidPromptDefinition(prompt: unknown): prompt is BotPromptDefinition {
+  const value = prompt as BotPromptDefinition | undefined;
+  if (!value || (value.selected !== 'default' && value.selected !== 'custom')) return false;
+  if (value.customSystemPrompt === undefined) return true;
+  return Boolean(String(value.customSystemPrompt || '').trim());
 }
 
 function isValidCustomModel(model: unknown): model is CustomBotModelDefinition {
@@ -179,6 +191,7 @@ function writeCustomModelProfile(filePath: string, profile: BotCustomModelProfil
 export class FileBotDefinitionRepository implements BotDefinitionRepository {
   private readonly canonicalRoot: string;
   private readonly cacheRoot: string;
+  private readonly lockRoot: string;
 
   constructor(options: FileBotDefinitionRepositoryOptions = {}) {
     const runtimeRoot = path.resolve(options.runtimeRoot ?? PathResolver.getRuntimeDataRoot());
@@ -191,6 +204,7 @@ export class FileBotDefinitionRepository implements BotDefinitionRepository {
       options.cacheRoot
         ?? path.join(runtimeRoot, 'data', 'bot-definition-cache'),
     );
+    this.lockRoot = path.join(runtimeRoot, 'data', 'bot-definition-locks');
   }
 
   readCanonical(botId: string): BotDefinition | undefined {
@@ -213,6 +227,37 @@ export class FileBotDefinitionRepository implements BotDefinitionRepository {
     writeDefinition(this.definitionPath(this.cacheRoot, botId), definition);
   }
 
+  withWriteLock<T>(botId: string, operation: () => T): T {
+    const normalized = normalizeBotId(botId);
+    fs.mkdirSync(this.lockRoot, { recursive: true });
+    const lockPath = path.join(this.lockRoot, `${normalized}.lock`);
+    const deadline = Date.now() + 5_000;
+
+    while (true) {
+      try {
+        const descriptor = fs.openSync(lockPath, 'wx', 0o600);
+        try {
+          fs.writeFileSync(descriptor, `${process.pid}\n`, 'utf-8');
+          return operation();
+        } finally {
+          fs.closeSync(descriptor);
+          try {
+            fs.unlinkSync(lockPath);
+          } catch {
+            // A stale-lock cleanup may already have removed the file.
+          }
+        }
+      } catch (error: any) {
+        if (error?.code !== 'EEXIST') throw error;
+        if (removeStaleDefinitionLock(lockPath)) continue;
+        if (Date.now() >= deadline) {
+          throw new Error(`Timed out waiting for BotDefinition write lock: ${normalized}`);
+        }
+        sleepSync(20);
+      }
+    }
+  }
+
   getCanonicalPath(botId: string): string {
     return this.definitionPath(this.canonicalRoot, normalizeBotId(botId));
   }
@@ -224,6 +269,33 @@ export class FileBotDefinitionRepository implements BotDefinitionRepository {
   private definitionPath(root: string, botId: string): string {
     return path.join(root, 'bots', `${botId}.json`);
   }
+}
+
+function removeStaleDefinitionLock(lockPath: string): boolean {
+  try {
+    const pid = Number.parseInt(fs.readFileSync(lockPath, 'utf-8').trim(), 10);
+    const stat = fs.statSync(lockPath);
+    const processExited = Number.isInteger(pid) && pid > 0 && !isProcessAlive(pid);
+    if (!processExited && Date.now() - stat.mtimeMs < 30_000) return false;
+    fs.unlinkSync(lockPath);
+    return true;
+  } catch (error: any) {
+    return error?.code === 'ENOENT';
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error: any) {
+    return error?.code === 'EPERM';
+  }
+}
+
+function sleepSync(milliseconds: number): void {
+  const signal = new Int32Array(new SharedArrayBuffer(4));
+  Atomics.wait(signal, 0, 0, milliseconds);
 }
 
 /** Device-local cloud override. The canonical/cache repositories remain the user's local preference. */

--- a/src/bot-definition/service.ts
+++ b/src/bot-definition/service.ts
@@ -18,6 +18,7 @@ import {
   type BotDefinition,
   type BotDefinitionSyncResult,
   type BotModelDefinition,
+  type BotPromptDefinition,
   type CustomBotModelDefinition,
   type LocalModelProfile,
 } from './types';
@@ -299,7 +300,19 @@ function normalizeBotModelDefinition(model: BotModelDefinition): BotModelDefinit
 
 function normalizeBotDefinition(definition: BotDefinition): BotDefinition {
   const model = normalizeBotModelDefinition(definition.model);
-  return model === definition.model ? definition : { ...definition, model };
+  const prompt = definition.prompt && normalizePromptDefinition(definition.prompt);
+  return model === definition.model && prompt === definition.prompt
+    ? definition
+    : { ...definition, model, ...(prompt ? { prompt } : {}) };
+}
+
+function normalizePromptDefinition(prompt: BotPromptDefinition): BotPromptDefinition {
+  const customSystemPrompt = prompt.customSystemPrompt?.trim();
+  if (customSystemPrompt === prompt.customSystemPrompt) return prompt;
+  return {
+    selected: prompt.selected,
+    ...(customSystemPrompt ? { customSystemPrompt } : {}),
+  };
 }
 
 function normalizeCatalogRuntime(runtime: BotCatalogModelRuntime): BotCatalogModelRuntime {
@@ -380,44 +393,80 @@ export class BotDefinitionSyncService {
   }
 
   pull(botId: string): BotDefinition | undefined {
-    const previousCache = this.repository.readCache(botId);
-    const rawDefinition = this.repository.readCanonical(botId);
-    const definition = rawDefinition && normalizeBotDefinition(rawDefinition);
-    if (definition) {
-      if (previousCache?.model.kind === 'custom') {
-        this.storeCustomModelProfile(botId, previousCache.model);
+    return this.withDefinitionWriteLock(botId, () => {
+      const previousCache = this.repository.readCache(botId);
+      const rawDefinition = this.repository.readCanonical(botId);
+      const definition = rawDefinition && normalizeBotDefinition(rawDefinition);
+      if (definition) {
+        if (previousCache?.model.kind === 'custom') {
+          this.storeCustomModelProfile(botId, previousCache.model);
+        }
+        if (definition !== rawDefinition) this.repository.writeCanonical(definition);
+        this.repository.writeCache(definition);
+        if (definition.model.kind === 'custom') {
+          this.storeCustomModelProfile(definition.botId, definition.model);
+        }
       }
-      if (definition !== rawDefinition) this.repository.writeCanonical(definition);
-      this.repository.writeCache(definition);
-      if (definition.model.kind === 'custom') {
-        this.storeCustomModelProfile(definition.botId, definition.model);
-      }
-    }
-    return definition;
+      return definition;
+    });
+  }
+
+  read(botId: string): BotDefinition | undefined {
+    const cached = this.repository.readCache(botId);
+    return cached ? normalizeBotDefinition(cached) : this.pull(botId);
   }
 
   publish(botId: string, model: BotModelDefinition): BotDefinitionSyncResult {
-    const previous = this.repository.readCache(botId) ?? this.repository.readCanonical(botId);
-    if (previous?.model.kind === 'custom') {
-      this.storeCustomModelProfile(botId, previous.model);
-    }
-    const normalizedModel = normalizeBotModelDefinition(model);
-    if (normalizedModel.kind === 'custom') {
-      this.storeCustomModelProfile(botId, normalizedModel);
-    }
-    const definition: BotDefinition = {
-      schema: BOT_DEFINITION_SCHEMA,
-      botId,
-      model: normalizedModel,
-    };
-    this.repository.writeCanonical(definition);
-    this.repository.writeCache(definition);
-    this.clearLegacyModelConfigurationWhenReady(definition);
-    return {
-      botId,
-      direction: 'local_to_simulated_cloud',
-      definition,
-    };
+    return this.withDefinitionWriteLock(botId, () => {
+      const previous = this.repository.readCache(botId) ?? this.repository.readCanonical(botId);
+      if (previous?.model.kind === 'custom') {
+        this.storeCustomModelProfile(botId, previous.model);
+      }
+      const normalizedModel = normalizeBotModelDefinition(model);
+      if (normalizedModel.kind === 'custom') {
+        this.storeCustomModelProfile(botId, normalizedModel);
+      }
+      const definition: BotDefinition = {
+        ...previous,
+        schema: BOT_DEFINITION_SCHEMA,
+        botId,
+        model: normalizedModel,
+      };
+      this.repository.writeCanonical(definition);
+      this.repository.writeCache(definition);
+      this.clearLegacyModelConfigurationWhenReady(definition);
+      return {
+        botId,
+        direction: 'local_to_simulated_cloud',
+        definition,
+      };
+    });
+  }
+
+  updateModel(botId: string, model: BotModelDefinition): BotDefinitionSyncResult {
+    return this.publish(botId, model);
+  }
+
+  updatePrompt(botId: string, prompt: BotPromptDefinition): BotDefinitionSyncResult {
+    return this.withDefinitionWriteLock(botId, () => {
+      const previous = this.repository.readCache(botId) ?? this.repository.readCanonical(botId);
+      if (!previous) {
+        throw new Error(`BotDefinition does not exist for bot ${botId}`);
+      }
+      const definition: BotDefinition = {
+        ...previous,
+        schema: BOT_DEFINITION_SCHEMA,
+        botId,
+        prompt: normalizePromptDefinition(prompt),
+      };
+      this.repository.writeCache(definition);
+      this.repository.writeCanonical(definition);
+      return {
+        botId,
+        direction: 'local_to_simulated_cloud',
+        definition,
+      };
+    });
   }
 
   acceptCloud(botId: string, model: BotModelDefinition): BotDefinitionSyncResult {
@@ -539,6 +588,12 @@ export class BotDefinitionSyncService {
     const localConfig = createCatsCoLocalConfigService({ runtimeRoot: this.runtimeRoot, env: this.env }).load();
     const botId = String(localConfig.currentBot?.uid || '').trim();
     return botId ? this.pullOrBootstrap(botId) : undefined;
+  }
+
+  private withDefinitionWriteLock<T>(botId: string, operation: () => T): T {
+    return this.repository.withWriteLock
+      ? this.repository.withWriteLock(botId, operation)
+      : operation();
   }
 
   private bootstrapCatalogRuntimeFromLocalProfile(

--- a/src/bot-definition/types.ts
+++ b/src/bot-definition/types.ts
@@ -32,14 +32,19 @@ export interface CustomBotModelDefinition {
 
 export type BotModelDefinition = CatalogBotModelDefinition | CustomBotModelDefinition;
 
+export interface BotPromptDefinition {
+  selected: 'default' | 'custom';
+  customSystemPrompt?: string;
+}
+
 /**
- * The deliberately small, portable part of a bot. Prompt and skill fields are
- * intentionally deferred until their source/version contracts are settled.
+ * The deliberately small, portable part of a bot.
  */
 export interface BotDefinition {
   schema: typeof BOT_DEFINITION_SCHEMA;
   botId: string;
   model: BotModelDefinition;
+  prompt?: BotPromptDefinition;
 }
 
 export interface LocalModelProfile {

--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -48,6 +48,10 @@ import { stripAssistantArtifactsFromMessages } from '../utils/transcript-artifac
 import type { PromptTraceSnapshot } from '../utils/prompt-observability';
 import { toPromptTurnMetadata } from '../utils/prompt-observability';
 import type { StreamRetryInfo } from '../providers/provider';
+import {
+  reconcileCurrentBotPromptBeforeTurn,
+  scheduleCurrentBotPromptReconcile,
+} from '../bot-definition/prompt-sync';
 
 export type { RuntimeFeedbackInput, RuntimeFeedbackOptions } from './runtime-feedback-inbox';
 
@@ -520,6 +524,7 @@ export class AgentSession {
       this.lastActiveAt = Date.now();
 
       try {
+        await reconcileCurrentBotPromptBeforeTurn();
         await this.refreshSystemPromptIfNeeded(lifecycleGeneration, this.activeAbortController.signal);
       } catch (error: any) {
         Logger.warning(`[会话 ${this.key}] Prompt 热加载失败，继续使用上一版: ${error?.message || error}`);
@@ -637,6 +642,7 @@ export class AgentSession {
         return { text: errorReply, visibleToUser: true, taskOutcome: 'failed' };
       } finally {
         this.planRuntime.clear();
+        scheduleCurrentBotPromptReconcile();
         this.busy = false;
         this.activeAbortController = null;
       }

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -55,6 +55,7 @@ import { inferCatsUploadType, uploadCatsLocalFile } from '../../catscompany/uplo
 import { createCatsCoLocalConfigService } from '../../catscompany/local-config';
 import { catalogRuntimeMatchesModelId, createBotDefinitionSyncService } from '../../bot-definition/service';
 import { prepareBoundBotDefinition } from '../../bot-definition/activation';
+import { getPromptReconcileCoordinator } from '../../bot-definition/prompt-sync';
 import {
   customModelDefinitionToConfig,
   modelRuntimeToConfig,
@@ -871,6 +872,9 @@ async function commitCatsBotBindingAndStartConnector(
 }> {
   ensureCatsDeviceId();
   const rollback = createCatsCoLocalConfigRollback();
+  const promptCoordinator = getPromptReconcileCoordinator({ runtimeRoot: runtimeDataRoot() });
+  await promptCoordinator.prepareCurrentBotForSwitch();
+  const promptSnapshot = promptCoordinator.captureActiveSnapshot();
   try {
     const warnings = await ensureCatsFriendBinding(state, input.userUid, input.botUid, input.apiKey);
     const updated = writeCatsBotBinding(state, input);
@@ -911,6 +915,7 @@ async function commitCatsBotBindingAndStartConnector(
     };
   } catch (error) {
     rollback();
+    promptCoordinator.restoreActiveSnapshot(promptSnapshot);
     throw error;
   }
 }
@@ -2207,7 +2212,13 @@ export function createApiRouter(
 
   router.get('/prompts', async (_req, res) => {
     try {
-      res.json(await getPromptEditorState());
+      const state = await getPromptEditorState();
+      const coordinator = getPromptReconcileCoordinator({ runtimeRoot: runtimeDataRoot() });
+      const botId = coordinator.getCurrentBotId();
+      res.json({
+        ...state,
+        ...(botId ? { system_prompt: coordinator.getSelection(botId) } : {}),
+      });
     } catch (e: any) {
       res.status(500).json({ error: e?.message || String(e) });
     }
@@ -2475,7 +2486,18 @@ export function createApiRouter(
   router.put('/prompts/file', (req, res) => {
     try {
       if (!requireJsonWrite(req, res)) return;
-      res.json(writePromptOverride(String(req.body?.path || ''), String(req.body?.content ?? '')));
+      const relativePath = String(req.body?.path || '');
+      const content = String(req.body?.content ?? '');
+      const coordinator = getPromptReconcileCoordinator({ runtimeRoot: runtimeDataRoot() });
+      const botId = coordinator.getCurrentBotId();
+      if (botId && relativePath === 'system-prompt.md') {
+        void coordinator.select(botId, 'custom', content).then(
+          () => res.json(getPromptEditorFile(relativePath)),
+          error => res.status(400).json({ error: error instanceof Error ? error.message : String(error) }),
+        );
+        return;
+      }
+      res.json(writePromptOverride(relativePath, content));
     } catch (e: any) {
       res.status(400).json({ error: e?.message || String(e) });
     }
@@ -2484,7 +2506,41 @@ export function createApiRouter(
   router.delete('/prompts/file', (req, res) => {
     try {
       if (!requireJsonWrite(req, res)) return;
-      res.json(deletePromptOverride(String(req.body?.path || req.query.path || '')));
+      const relativePath = String(req.body?.path || req.query.path || '');
+      const coordinator = getPromptReconcileCoordinator({ runtimeRoot: runtimeDataRoot() });
+      const botId = coordinator.getCurrentBotId();
+      if (botId && relativePath === 'system-prompt.md') {
+        void coordinator.select(botId, 'default').then(
+          () => res.json(getPromptEditorFile(relativePath)),
+          error => res.status(400).json({ error: error instanceof Error ? error.message : String(error) }),
+        );
+        return;
+      }
+      res.json(deletePromptOverride(relativePath));
+    } catch (e: any) {
+      res.status(400).json({ error: e?.message || String(e) });
+    }
+  });
+
+  router.put('/prompts/system', (req, res) => {
+    try {
+      if (!requireJsonWrite(req, res)) return;
+      const coordinator = getPromptReconcileCoordinator({ runtimeRoot: runtimeDataRoot() });
+      const botId = coordinator.getCurrentBotId();
+      if (!botId) {
+        res.status(409).json({ error: 'No bound bot is available for prompt selection' });
+        return;
+      }
+      const selected = req.body?.selected;
+      if (selected !== 'default' && selected !== 'custom') {
+        res.status(400).json({ error: 'selected must be default or custom' });
+        return;
+      }
+      const content = req.body?.content === undefined ? undefined : String(req.body.content);
+      void coordinator.select(botId, selected, content).then(
+        result => res.json(result),
+        error => res.status(400).json({ error: error instanceof Error ? error.message : String(error) }),
+      );
     } catch (e: any) {
       res.status(400).json({ error: e?.message || String(e) });
     }

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -2491,6 +2491,10 @@ export function createApiRouter(
       const coordinator = getPromptReconcileCoordinator({ runtimeRoot: runtimeDataRoot() });
       const botId = coordinator.getCurrentBotId();
       if (botId && relativePath === 'system-prompt.md') {
+        if (!coordinator.getSelection(botId).definitionReady) {
+          res.status(409).json({ error: '机器人配置尚未初始化，连接完成后即可编辑' });
+          return;
+        }
         void coordinator.select(botId, 'custom', content).then(
           () => res.json(getPromptEditorFile(relativePath)),
           error => res.status(400).json({ error: error instanceof Error ? error.message : String(error) }),
@@ -2510,6 +2514,10 @@ export function createApiRouter(
       const coordinator = getPromptReconcileCoordinator({ runtimeRoot: runtimeDataRoot() });
       const botId = coordinator.getCurrentBotId();
       if (botId && relativePath === 'system-prompt.md') {
+        if (!coordinator.getSelection(botId).definitionReady) {
+          res.status(409).json({ error: '机器人配置尚未初始化，连接完成后即可编辑' });
+          return;
+        }
         void coordinator.select(botId, 'default').then(
           () => res.json(getPromptEditorFile(relativePath)),
           error => res.status(400).json({ error: error instanceof Error ? error.message : String(error) }),
@@ -2529,6 +2537,10 @@ export function createApiRouter(
       const botId = coordinator.getCurrentBotId();
       if (!botId) {
         res.status(409).json({ error: 'No bound bot is available for prompt selection' });
+        return;
+      }
+      if (!coordinator.getSelection(botId).definitionReady) {
+        res.status(409).json({ error: '机器人配置尚未初始化，连接完成后即可编辑' });
         return;
       }
       const selected = req.body?.selected;

--- a/src/pet/prompt-companion.ts
+++ b/src/pet/prompt-companion.ts
@@ -573,12 +573,7 @@ function normalizeAdvisorTargetPath(value: unknown, state: PromptEditorStateSnap
 }
 
 function shouldIncludePromptExcerpt(filePath: string): boolean {
-  return filePath === 'system-prompt.md'
-    || filePath === 'runtime-context.md'
-    || filePath === 'compact-system.md'
-    || filePath === 'sidecars/prompt-companion-advisor.md'
-    || filePath.startsWith('subagents/')
-    || filePath.startsWith('transient/');
+  return filePath === 'system-prompt.md';
 }
 
 function createBriefProposal(current: string, baseHash: string, signals: PromptCompanionSignals): PromptCompanionProposal {

--- a/src/utils/prompt-editor.ts
+++ b/src/utils/prompt-editor.ts
@@ -3,12 +3,15 @@ import * as path from 'path';
 import { PromptManager } from './prompt-manager';
 import {
   assertSafePromptOverridesDir,
+  getBundledPromptsDir,
   getPromptOverridesDir,
   isSafePromptOverridesDir,
   normalizePromptRelativePath,
   normalizePromptText,
+  readRequiredBundledPromptFile,
   readPromptFile,
   resolvePromptPathWithin,
+  SYSTEM_PROMPT_RELATIVE_PATH,
 } from './prompt-template';
 import { buildPromptTraceSnapshot, hashText } from './prompt-observability';
 import { BRANCH_AGENTS_ENABLED_ENV } from '../core/branch-agent-settings';
@@ -60,7 +63,7 @@ export async function getPromptEditorState(): Promise<PromptEditorState> {
   const writable = Boolean(overridesDir && isSafePromptOverridesDir(baseDir, overridesDir));
 
   return {
-    base_dir: labelLocalPath(baseDir),
+    base_dir: labelLocalPath(getBundledPromptsDir()),
     overrides_dir: overridesDir ? labelLocalPath(overridesDir) : undefined,
     writable,
     trace: buildPromptTraceSnapshot({
@@ -84,8 +87,7 @@ export function getPromptBranchAgentsState(): PromptBranchAgentsState {
 export function getPromptEditorFile(relativePath: string): PromptEditorFileDetail {
   const normalized = normalizeEditablePromptPath(relativePath);
   const baseDir = PromptManager.getPromptsDir();
-  const basePath = resolvePromptPathWithin(baseDir, normalized);
-  const baseContent = normalizePromptText(fs.readFileSync(basePath, 'utf-8'));
+  const baseContent = readRequiredBundledPromptFile(normalized);
   const content = readPromptFile(baseDir, normalized);
   const file = buildPromptEditorFile(normalized, baseContent, content);
   return {
@@ -130,9 +132,8 @@ export function deletePromptOverride(relativePath: string): PromptEditorFileDeta
 
 function listPromptEditorFiles(): PromptEditorFile[] {
   const baseDir = PromptManager.getPromptsDir();
-  return listBasePromptPaths(baseDir).map(relativePath => {
-    const basePath = resolvePromptPathWithin(baseDir, relativePath);
-    const baseContent = normalizePromptText(fs.readFileSync(basePath, 'utf-8'));
+  return [SYSTEM_PROMPT_RELATIVE_PATH].map(relativePath => {
+    const baseContent = readRequiredBundledPromptFile(relativePath);
     const effectiveContent = readPromptFile(baseDir, relativePath);
     return buildPromptEditorFile(relativePath, baseContent, effectiveContent);
   });
@@ -143,7 +144,7 @@ function buildPromptEditorFile(relativePath: string, baseContent: string, effect
   const effectiveHash = hashText(effectiveContent);
   return {
     path: relativePath,
-    overridden: baseHash !== effectiveHash || promptOverrideExists(relativePath),
+    overridden: baseHash !== effectiveHash,
     base: textDigest(baseContent),
     effective: textDigest(effectiveContent),
   };
@@ -161,29 +162,10 @@ function textDigest(text: string): PromptEditorFile['effective'] {
 
 function normalizeEditablePromptPath(relativePath: string): string {
   const normalized = normalizePromptRelativePath(relativePath);
-  const available = new Set(listBasePromptPaths(PromptManager.getPromptsDir()));
-  if (!available.has(normalized)) {
+  if (normalized !== SYSTEM_PROMPT_RELATIVE_PATH) {
     throw new Error(`Prompt file is not editable: ${relativePath}`);
   }
   return normalized;
-}
-
-function listBasePromptPaths(baseDir: string): string[] {
-  const root = path.resolve(baseDir);
-  if (!fs.existsSync(root)) return [];
-  const results: string[] = [];
-  walk(root, filePath => {
-    if (path.extname(filePath).toLowerCase() !== '.md') return;
-    results.push(path.relative(root, filePath).split(path.sep).join('/'));
-  });
-  return results.sort((a, b) => a.localeCompare(b));
-}
-
-function promptOverrideExists(relativePath: string): boolean {
-  const overridesDir = getPromptOverridesDir();
-  if (!overridesDir) return false;
-  if (!isSafePromptOverridesDir(PromptManager.getPromptsDir(), overridesDir)) return false;
-  return fs.existsSync(resolvePromptPathWithin(overridesDir, relativePath));
 }
 
 function pruneEmptyPromptDirs(startDir: string, rootDir: string): void {
@@ -196,17 +178,6 @@ function pruneEmptyPromptDirs(startDir: string, rootDir: string): void {
       return;
     }
     current = path.dirname(current);
-  }
-}
-
-function walk(directory: string, visit: (filePath: string) => void): void {
-  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
-    const filePath = path.join(directory, entry.name);
-    if (entry.isDirectory()) {
-      walk(filePath, visit);
-    } else if (entry.isFile()) {
-      visit(filePath);
-    }
   }
 }
 

--- a/src/utils/prompt-template.ts
+++ b/src/utils/prompt-template.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { PathResolver } from './path-resolver';
 
 export const DEFAULT_PROMPTS_DIR = path.join(__dirname, '../../prompts');
+export const SYSTEM_PROMPT_RELATIVE_PATH = 'system-prompt.md';
 
 export function getPromptBaseDir(env: NodeJS.ProcessEnv = process.env): string {
   const explicit = (env.XIAOBA_PROMPTS_DIR || env.CATSCO_PROMPTS_DIR || '').trim();
@@ -10,6 +11,10 @@ export function getPromptBaseDir(env: NodeJS.ProcessEnv = process.env): string {
 }
 
 export function getPromptOverridesDir(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  if (hasBoundBotIdentity(env)) {
+    const runtimeRoot = (env.XIAOBA_RUNTIME_ROOT || '').trim();
+    return runtimeRoot ? path.resolve(runtimeRoot, 'prompt-overrides') : PathResolver.getPromptOverridesPath();
+  }
   if (/^(1|true|yes|on)$/i.test(String(env.XIAOBA_DISABLE_PROMPT_OVERRIDES || '').trim())) {
     return undefined;
   }
@@ -77,9 +82,11 @@ export function resolvePromptPathWithin(rootDir: string, relativePath: string): 
 
 export function resolvePromptOverrideFilePath(promptsDir: string, relativePath: string): string | undefined {
   if (!shouldUsePromptOverrides(promptsDir)) return undefined;
+  const normalized = normalizePromptRelativePath(relativePath);
+  if (normalized !== SYSTEM_PROMPT_RELATIVE_PATH && hasBoundBotIdentity()) return undefined;
   const overridesDir = getPromptOverridesDir();
   if (overridesDir && !isSafePromptOverridesDir(promptsDir, overridesDir)) return undefined;
-  return overridesDir ? resolvePromptPathWithin(overridesDir, relativePath) : undefined;
+  return overridesDir ? resolvePromptPathWithin(overridesDir, normalized) : undefined;
 }
 
 export function readPromptFile(promptsDir: string, relativePath: string): string {
@@ -112,6 +119,35 @@ export function readDefaultPromptFile(relativePath: string): string {
 
 export function readRequiredDefaultPromptFile(relativePath: string): string {
   return readRequiredPromptFile(getPromptBaseDir(), relativePath);
+}
+
+/**
+ * Reads a prompt shipped with the current XiaoBa installation. Unlike the
+ * generic prompt readers, this deliberately ignores prompt directories and
+ * overrides supplied by the user.
+ */
+export function readRequiredBundledPromptFile(
+  relativePath: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const normalized = normalizePromptRelativePath(relativePath);
+  const promptsDir = getBundledPromptsDir(env);
+  const filePath = resolvePromptPathWithin(promptsDir, normalized);
+  try {
+    const text = normalizePromptText(fs.readFileSync(filePath, 'utf-8'));
+    if (!text) throw new Error(`Bundled prompt file is empty: ${normalized}`);
+    return text;
+  } catch (error: any) {
+    if (error?.message?.startsWith('Bundled prompt file is empty:')) throw error;
+    throw new Error(`Bundled prompt file is missing or unreadable: ${normalized}`);
+  }
+}
+
+export function getBundledPromptsDir(env: NodeJS.ProcessEnv = process.env): string {
+  const appRoot = String(env.XIAOBA_APP_ROOT || '').trim();
+  return appRoot
+    ? path.resolve(appRoot, 'prompts')
+    : path.resolve(DEFAULT_PROMPTS_DIR);
 }
 
 export function readDefaultPromptLines(relativePath: string): string[] {
@@ -174,6 +210,10 @@ function shouldUsePromptOverrides(promptsDir: string): boolean {
   if (!overridesDir) return false;
   const resolved = path.resolve(promptsDir);
   return resolved === path.resolve(getPromptBaseDir()) || resolved === path.resolve(DEFAULT_PROMPTS_DIR);
+}
+
+function hasBoundBotIdentity(env: NodeJS.ProcessEnv = process.env): boolean {
+  return Boolean(String(env.CATSCO_BOT_UID || env.CATSCOMPANY_BOT_UID || '').trim());
 }
 
 function canonicalPath(value: string): string {

--- a/tests/bot-definition-activation.test.ts
+++ b/tests/bot-definition-activation.test.ts
@@ -559,8 +559,14 @@ describe('BotDefinition activation', () => {
 
     assert.equal(cloudPrepared?.cloudRevision, 11);
     assert.equal(resolveActiveBotLLMConfig({ runtimeRoot, env })?.config.model, 'cloud-model');
-    assert.deepStrictEqual(definitions.readCanonical('43'), localDefinition);
-    assert.deepStrictEqual(definitions.readCache('43'), localDefinition);
+    assert.deepStrictEqual(definitions.readCanonical('43'), {
+      ...localDefinition,
+      prompt: { selected: 'default' },
+    });
+    assert.deepStrictEqual(definitions.readCache('43'), {
+      ...localDefinition,
+      prompt: { selected: 'default' },
+    });
     assert.deepStrictEqual(new FileBotCustomModelProfileRepository({ runtimeRoot }).read('43')?.model, localModel);
     assert.equal(new FileBotCloudModelOverrideRepository({ runtimeRoot }).read('43')?.model.kind, 'custom');
 
@@ -584,7 +590,10 @@ describe('BotDefinition activation', () => {
     assert.equal(localPrepared?.cloudRevision, 12);
     assert.equal(resolveActiveBotLLMConfig({ runtimeRoot, env })?.config.model, 'local-model');
     assert.equal(new FileBotCloudModelOverrideRepository({ runtimeRoot }).read('43'), undefined);
-    assert.deepStrictEqual(definitions.readCanonical('43'), localDefinition);
+    assert.deepStrictEqual(definitions.readCanonical('43'), {
+      ...localDefinition,
+      prompt: { selected: 'default' },
+    });
     assert.deepStrictEqual(new FileBotCustomModelProfileRepository({ runtimeRoot }).read('43')?.model, localModel);
   });
 

--- a/tests/bot-definition-prompt-sync.test.ts
+++ b/tests/bot-definition-prompt-sync.test.ts
@@ -1,0 +1,323 @@
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { createCatsCoLocalConfigService } from '../src/catscompany/local-config';
+import { PromptReconcileCoordinator } from '../src/bot-definition/prompt-sync';
+import { FileBotDefinitionRepository } from '../src/bot-definition/repository';
+import { createBotDefinitionSyncService } from '../src/bot-definition/service';
+import { BOT_DEFINITION_SCHEMA, type BotDefinition } from '../src/bot-definition/types';
+import { getPromptOverridesDir, readRequiredBundledPromptFile } from '../src/utils/prompt-template';
+
+class FailingCanonicalRepository extends FileBotDefinitionRepository {
+  failCanonicalWrite = false;
+
+  override writeCanonical(definition: BotDefinition): void {
+    if (this.failCanonicalWrite) throw new Error('simulated canonical write failure');
+    super.writeCanonical(definition);
+  }
+}
+
+describe('BotDefinition system prompt sync', () => {
+  let runtimeRoot: string;
+  let simulatedCloudRoot: string;
+  let appRoot: string;
+  let env: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-prompt-sync-runtime-'));
+    simulatedCloudRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-prompt-sync-cloud-'));
+    appRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-prompt-sync-app-'));
+    fs.mkdirSync(path.join(appRoot, 'prompts'), { recursive: true });
+    fs.writeFileSync(path.join(appRoot, 'prompts', 'system-prompt.md'), 'bundled v1\n', 'utf-8');
+    env = {
+      XIAOBA_APP_ROOT: appRoot,
+      XIAOBA_USER_DATA_DIR: runtimeRoot,
+      XIAOBA_BOT_DEFINITION_SIMULATED_CLOUD_DIR: simulatedCloudRoot,
+    } as NodeJS.ProcessEnv;
+  });
+
+  afterEach(() => {
+    fs.rmSync(runtimeRoot, { recursive: true, force: true });
+    fs.rmSync(simulatedCloudRoot, { recursive: true, force: true });
+    fs.rmSync(appRoot, { recursive: true, force: true });
+  });
+
+  function createCoordinator(
+    botId = 'bot-a',
+    repository = new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot }),
+  ): {
+    coordinator: PromptReconcileCoordinator;
+    repository: FileBotDefinitionRepository;
+  } {
+    createCatsCoLocalConfigService({ runtimeRoot, env }).save({
+      version: 1,
+      currentBot: {
+        uid: botId,
+        apiKey: 'bot-api-key',
+        boundByUserUid: 'owner-a',
+        bindingSource: 'test',
+      },
+    });
+    repository.writeCanonical({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId,
+      model: { kind: 'catalog', modelId: 'minimax-m3' },
+    });
+    repository.writeCache(repository.readCanonical(botId)!);
+    const definitionService = createBotDefinitionSyncService({
+      runtimeRoot,
+      simulatedCloudRoot,
+      env,
+      repository,
+    });
+    return {
+      coordinator: new PromptReconcileCoordinator({ runtimeRoot, env, definitionService }),
+      repository,
+    };
+  }
+
+  test('bundled reader ignores prompt and override directories', () => {
+    const fakePrompts = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-prompt-fake-'));
+    const fakeOverrides = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-prompt-override-'));
+    try {
+      fs.writeFileSync(path.join(fakePrompts, 'system-prompt.md'), 'wrong base\n', 'utf-8');
+      fs.writeFileSync(path.join(fakeOverrides, 'system-prompt.md'), 'wrong override\n', 'utf-8');
+      assert.equal(readRequiredBundledPromptFile('system-prompt.md', {
+        ...env,
+        XIAOBA_PROMPTS_DIR: fakePrompts,
+        XIAOBA_PROMPT_OVERRIDES_DIR: fakeOverrides,
+      }), 'bundled v1');
+    } finally {
+      fs.rmSync(fakePrompts, { recursive: true, force: true });
+      fs.rmSync(fakeOverrides, { recursive: true, force: true });
+    }
+  });
+
+  test('bound bots always use the runtime-root prompt override directory', () => {
+    assert.equal(getPromptOverridesDir({
+      ...env,
+      CATSCO_BOT_UID: 'bot-a',
+      XIAOBA_RUNTIME_ROOT: runtimeRoot,
+      XIAOBA_PROMPT_OVERRIDES_DIR: path.join(runtimeRoot, 'wrong-overrides'),
+    }), path.join(runtimeRoot, 'prompt-overrides'));
+  });
+
+  test('initializes default and follows a newer bundled prompt', async () => {
+    const { coordinator, repository } = createCoordinator();
+    await coordinator.activateBot('bot-a');
+
+    assert.equal(repository.readCanonical('bot-a')?.prompt?.selected, 'default');
+    assert.equal(fs.readFileSync(coordinator.getActivePromptPath(), 'utf-8'), 'bundled v1\n');
+
+    fs.writeFileSync(path.join(appRoot, 'prompts', 'system-prompt.md'), 'bundled v2\n', 'utf-8');
+    await coordinator.activateBot('bot-a');
+
+    assert.equal(fs.readFileSync(coordinator.getActivePromptPath(), 'utf-8'), 'bundled v2\n');
+    assert.equal(repository.readCanonical('bot-a')?.prompt?.selected, 'default');
+  });
+
+  test('captures a locally edited default as custom instead of overwriting it', async () => {
+    const { coordinator, repository } = createCoordinator();
+    await coordinator.activateBot('bot-a');
+    fs.writeFileSync(coordinator.getActivePromptPath(), 'agent edited prompt\n', 'utf-8');
+
+    await coordinator.activateBot('bot-a');
+
+    assert.deepStrictEqual(repository.readCanonical('bot-a')?.prompt, {
+      selected: 'custom',
+      customSystemPrompt: 'agent edited prompt',
+    });
+    assert.equal(fs.readFileSync(coordinator.getActivePromptPath(), 'utf-8'), 'agent edited prompt\n');
+  });
+
+  test('keeps custom text across upgrades and restores it after using default', async () => {
+    const { coordinator, repository } = createCoordinator();
+    await coordinator.activateBot('bot-a');
+    await coordinator.select('bot-a', 'custom', 'my custom prompt');
+    fs.writeFileSync(path.join(appRoot, 'prompts', 'system-prompt.md'), 'bundled v2\n', 'utf-8');
+
+    await coordinator.activateBot('bot-a');
+    assert.equal(fs.readFileSync(coordinator.getActivePromptPath(), 'utf-8'), 'my custom prompt\n');
+
+    await coordinator.select('bot-a', 'default');
+    assert.equal(fs.readFileSync(coordinator.getActivePromptPath(), 'utf-8'), 'bundled v2\n');
+    assert.equal(repository.readCanonical('bot-a')?.prompt?.customSystemPrompt, 'my custom prompt');
+
+    await coordinator.select('bot-a', 'custom');
+    assert.equal(fs.readFileSync(coordinator.getActivePromptPath(), 'utf-8'), 'my custom prompt\n');
+  });
+
+  test('keeps an unsynced custom file edit across restart activation', async () => {
+    const { coordinator, repository } = createCoordinator();
+    await coordinator.activateBot('bot-a');
+    await coordinator.select('bot-a', 'custom', 'saved custom prompt');
+    fs.writeFileSync(coordinator.getActivePromptPath(), 'last local edit\n', 'utf-8');
+
+    await coordinator.activateBot('bot-a');
+
+    assert.deepStrictEqual(repository.readCanonical('bot-a')?.prompt, {
+      selected: 'custom',
+      customSystemPrompt: 'last local edit',
+    });
+    assert.equal(fs.readFileSync(coordinator.getActivePromptPath(), 'utf-8'), 'last local edit\n');
+  });
+
+  test('model and prompt field updates preserve each other', async () => {
+    const { coordinator, repository } = createCoordinator();
+    await coordinator.activateBot('bot-a');
+    await coordinator.select('bot-a', 'custom', 'portable prompt');
+    const service = createBotDefinitionSyncService({
+      runtimeRoot,
+      simulatedCloudRoot,
+      env,
+      repository,
+    });
+
+    service.updateModel('bot-a', { kind: 'catalog', modelId: 'deepseek-v4-flash' });
+    assert.equal(repository.readCanonical('bot-a')?.prompt?.customSystemPrompt, 'portable prompt');
+
+    service.updatePrompt('bot-a', { selected: 'default', customSystemPrompt: 'portable prompt' });
+    assert.deepStrictEqual(repository.readCanonical('bot-a')?.model, {
+      kind: 'catalog',
+      modelId: 'deepseek-v4-flash',
+    });
+  });
+
+  test('separate process services merge model and prompt fields from the latest Definition', async () => {
+    const { coordinator, repository } = createCoordinator();
+    await coordinator.activateBot('bot-a');
+    const dashboardService = createBotDefinitionSyncService({
+      runtimeRoot,
+      simulatedCloudRoot,
+      env,
+      repository: new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot }),
+    });
+    const connectorService = createBotDefinitionSyncService({
+      runtimeRoot,
+      simulatedCloudRoot,
+      env,
+      repository: new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot }),
+    });
+
+    dashboardService.updateModel('bot-a', { kind: 'catalog', modelId: 'deepseek-v4-flash' });
+    connectorService.updatePrompt('bot-a', {
+      selected: 'custom',
+      customSystemPrompt: 'cross-process prompt',
+    });
+
+    assert.deepStrictEqual(repository.readCanonical('bot-a'), {
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-a',
+      model: { kind: 'catalog', modelId: 'deepseek-v4-flash' },
+      prompt: {
+        selected: 'custom',
+        customSystemPrompt: 'cross-process prompt',
+      },
+    });
+  });
+
+  test('does not replace Definition with an empty active file', async () => {
+    const { coordinator, repository } = createCoordinator();
+    await coordinator.activateBot('bot-a');
+    fs.writeFileSync(coordinator.getActivePromptPath(), '  \n\n', 'utf-8');
+
+    assert.equal(await coordinator.reconcileCurrent({ force: true }), false);
+    assert.deepStrictEqual(repository.readCanonical('bot-a')?.prompt, { selected: 'default' });
+  });
+
+  test('does not advance the sync baseline when canonical persistence fails', async () => {
+    const repository = new FailingCanonicalRepository({ runtimeRoot, simulatedCloudRoot });
+    const { coordinator } = createCoordinator('bot-a', repository);
+    await coordinator.activateBot('bot-a');
+    const stateBefore = fs.readFileSync(coordinator.getStatePath(), 'utf-8');
+    fs.writeFileSync(coordinator.getActivePromptPath(), 'retry this prompt\n', 'utf-8');
+    repository.failCanonicalWrite = true;
+
+    await assert.rejects(
+      () => coordinator.reconcileCurrent({ force: true }),
+      /simulated canonical write failure/,
+    );
+    assert.equal(fs.readFileSync(coordinator.getStatePath(), 'utf-8'), stateBefore);
+    assert.deepStrictEqual(repository.readCanonical('bot-a')?.prompt, { selected: 'default' });
+
+    repository.failCanonicalWrite = false;
+    assert.equal(await coordinator.reconcileCurrent({ force: true }), true);
+    assert.deepStrictEqual(repository.readCanonical('bot-a')?.prompt, {
+      selected: 'custom',
+      customSystemPrompt: 'retry this prompt',
+    });
+  });
+
+  test('restores the active prompt when an explicit selection cannot persist', async () => {
+    const repository = new FailingCanonicalRepository({ runtimeRoot, simulatedCloudRoot });
+    const { coordinator } = createCoordinator('bot-a', repository);
+    await coordinator.activateBot('bot-a');
+    const promptBefore = fs.readFileSync(coordinator.getActivePromptPath(), 'utf-8');
+    const stateBefore = fs.readFileSync(coordinator.getStatePath(), 'utf-8');
+    repository.failCanonicalWrite = true;
+
+    await assert.rejects(
+      () => coordinator.select('bot-a', 'custom', 'should roll back'),
+      /simulated canonical write failure/,
+    );
+    assert.equal(fs.readFileSync(coordinator.getActivePromptPath(), 'utf-8'), promptBefore);
+    assert.equal(fs.readFileSync(coordinator.getStatePath(), 'utf-8'), stateBefore);
+    assert.deepStrictEqual(repository.readCanonical('bot-a')?.prompt, { selected: 'default' });
+  });
+
+  test('migrates an existing active override only for the active bot', async () => {
+    const { coordinator, repository } = createCoordinator('bot-a');
+    fs.mkdirSync(path.dirname(coordinator.getActivePromptPath()), { recursive: true });
+    fs.writeFileSync(coordinator.getActivePromptPath(), 'legacy override\n', 'utf-8');
+
+    await coordinator.activateBot('bot-a');
+    assert.equal(repository.readCanonical('bot-a')?.prompt?.selected, 'custom');
+    assert.equal(repository.readCanonical('bot-a')?.prompt?.customSystemPrompt, 'legacy override');
+
+    repository.writeCanonical({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-b',
+      model: { kind: 'catalog', modelId: 'minimax-m3' },
+    });
+    repository.writeCache(repository.readCanonical('bot-b')!);
+    await coordinator.activateBot('bot-b');
+
+    assert.equal(repository.readCanonical('bot-b')?.prompt?.selected, 'default');
+    assert.equal(fs.readFileSync(coordinator.getActivePromptPath(), 'utf-8'), 'bundled v1\n');
+  });
+
+  test('assigns a legacy override to the old bot before the first switch', async () => {
+    const { coordinator, repository } = createCoordinator('bot-a');
+    repository.writeCanonical({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-b',
+      model: { kind: 'catalog', modelId: 'minimax-m3' },
+    });
+    repository.writeCache(repository.readCanonical('bot-b')!);
+    fs.mkdirSync(path.dirname(coordinator.getActivePromptPath()), { recursive: true });
+    fs.writeFileSync(coordinator.getActivePromptPath(), 'legacy prompt from bot A\n', 'utf-8');
+
+    await coordinator.prepareCurrentBotForSwitch();
+    createCatsCoLocalConfigService({ runtimeRoot, env }).save({
+      version: 1,
+      currentBot: {
+        uid: 'bot-b',
+        apiKey: 'bot-api-key',
+        boundByUserUid: 'owner-a',
+        bindingSource: 'test',
+      },
+    });
+    await coordinator.activateBot('bot-b');
+
+    assert.deepStrictEqual(repository.readCanonical('bot-a')?.prompt, {
+      selected: 'custom',
+      customSystemPrompt: 'legacy prompt from bot A',
+    });
+    assert.deepStrictEqual(repository.readCanonical('bot-b')?.prompt, {
+      selected: 'default',
+    });
+    assert.equal(fs.readFileSync(coordinator.getActivePromptPath(), 'utf-8'), 'bundled v1\n');
+  });
+});

--- a/tests/bot-definition-prompt-sync.test.ts
+++ b/tests/bot-definition-prompt-sync.test.ts
@@ -47,6 +47,7 @@ describe('BotDefinition system prompt sync', () => {
   function createCoordinator(
     botId = 'bot-a',
     repository = new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot }),
+    initializeDefinition = true,
   ): {
     coordinator: PromptReconcileCoordinator;
     repository: FileBotDefinitionRepository;
@@ -60,12 +61,14 @@ describe('BotDefinition system prompt sync', () => {
         bindingSource: 'test',
       },
     });
-    repository.writeCanonical({
-      schema: BOT_DEFINITION_SCHEMA,
-      botId,
-      model: { kind: 'catalog', modelId: 'minimax-m3' },
-    });
-    repository.writeCache(repository.readCanonical(botId)!);
+    if (initializeDefinition) {
+      repository.writeCanonical({
+        schema: BOT_DEFINITION_SCHEMA,
+        botId,
+        model: { kind: 'catalog', modelId: 'minimax-m3' },
+      });
+      repository.writeCache(repository.readCanonical(botId)!);
+    }
     const definitionService = createBotDefinitionSyncService({
       runtimeRoot,
       simulatedCloudRoot,
@@ -93,6 +96,40 @@ describe('BotDefinition system prompt sync', () => {
       fs.rmSync(fakePrompts, { recursive: true, force: true });
       fs.rmSync(fakeOverrides, { recursive: true, force: true });
     }
+  });
+
+  test('returns a default read view when the bound bot Definition is not initialized yet', () => {
+    const { coordinator, repository } = createCoordinator(
+      'legacy-bound-bot',
+      new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot }),
+      false,
+    );
+
+    const selection = coordinator.getSelection('legacy-bound-bot');
+
+    assert.equal(selection.selected, 'default');
+    assert.equal(selection.effectiveSystemPrompt, 'bundled v1');
+    assert.equal(selection.customSystemPrompt, undefined);
+    assert.equal(repository.readCache('legacy-bound-bot'), undefined);
+    assert.equal(repository.readCanonical('legacy-bound-bot'), undefined);
+  });
+
+  test('preserves a legacy system override as a custom read view before Definition bootstrap', () => {
+    const { coordinator, repository } = createCoordinator(
+      'legacy-custom-bot',
+      new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot }),
+      false,
+    );
+    fs.mkdirSync(path.dirname(coordinator.getActivePromptPath()), { recursive: true });
+    fs.writeFileSync(coordinator.getActivePromptPath(), 'Legacy custom prompt\n', 'utf-8');
+
+    const selection = coordinator.getSelection('legacy-custom-bot');
+
+    assert.equal(selection.selected, 'custom');
+    assert.equal(selection.customSystemPrompt, 'Legacy custom prompt');
+    assert.equal(selection.effectiveSystemPrompt, 'Legacy custom prompt');
+    assert.equal(repository.readCache('legacy-custom-bot'), undefined);
+    assert.equal(repository.readCanonical('legacy-custom-bot'), undefined);
   });
 
   test('bound bots always use the runtime-root prompt override directory', () => {

--- a/tests/bot-definition-prompt-sync.test.ts
+++ b/tests/bot-definition-prompt-sync.test.ts
@@ -107,6 +107,7 @@ describe('BotDefinition system prompt sync', () => {
 
     const selection = coordinator.getSelection('legacy-bound-bot');
 
+    assert.equal(selection.definitionReady, false);
     assert.equal(selection.selected, 'default');
     assert.equal(selection.effectiveSystemPrompt, 'bundled v1');
     assert.equal(selection.customSystemPrompt, undefined);
@@ -125,6 +126,7 @@ describe('BotDefinition system prompt sync', () => {
 
     const selection = coordinator.getSelection('legacy-custom-bot');
 
+    assert.equal(selection.definitionReady, false);
     assert.equal(selection.selected, 'custom');
     assert.equal(selection.customSystemPrompt, 'Legacy custom prompt');
     assert.equal(selection.effectiveSystemPrompt, 'Legacy custom prompt');
@@ -145,6 +147,7 @@ describe('BotDefinition system prompt sync', () => {
     const { coordinator, repository } = createCoordinator();
     await coordinator.activateBot('bot-a');
 
+    assert.equal(coordinator.getSelection('bot-a').definitionReady, true);
     assert.equal(repository.readCanonical('bot-a')?.prompt?.selected, 'default');
     assert.equal(fs.readFileSync(coordinator.getActivePromptPath(), 'utf-8'), 'bundled v1\n');
 

--- a/tests/dashboard-catsco-auth-status.test.ts
+++ b/tests/dashboard-catsco-auth-status.test.ts
@@ -136,6 +136,29 @@ describe('dashboard CatsCo account status', () => {
     assert.equal(data.topicId, '');
   });
 
+  test('GET /prompts remains available for a bound legacy bot without a Definition', async () => {
+    createCatsCoLocalConfigService({ runtimeRoot: testRoot }).save({
+      version: 1,
+      currentBot: {
+        uid: 'legacy-bound-bot',
+        name: 'Legacy Bot',
+        apiKey: 'legacy-agent-key',
+      },
+    });
+
+    const response = await fetch(`${dashboardBaseUrl}/api/prompts`);
+    const text = await response.text();
+    const data = JSON.parse(text) as any;
+
+    assert.equal(response.status, 200, text);
+    assert.equal(data.system_prompt.botId, 'legacy-bound-bot');
+    assert.equal(data.system_prompt.selected, 'default');
+    assert.equal(
+      new FileBotDefinitionRepository({ runtimeRoot: testRoot }).readCache('legacy-bound-bot'),
+      undefined,
+    );
+  });
+
   test('PUT /settings immediately restarts a running connector after a bound custom model update', async () => {
     if (dashboardServer) {
       await close(dashboardServer);

--- a/tests/dashboard-catsco-auth-status.test.ts
+++ b/tests/dashboard-catsco-auth-status.test.ts
@@ -152,11 +152,22 @@ describe('dashboard CatsCo account status', () => {
 
     assert.equal(response.status, 200, text);
     assert.equal(data.system_prompt.botId, 'legacy-bound-bot');
+    assert.equal(data.system_prompt.definitionReady, false);
     assert.equal(data.system_prompt.selected, 'default');
     assert.equal(
       new FileBotDefinitionRepository({ runtimeRoot: testRoot }).readCache('legacy-bound-bot'),
       undefined,
     );
+
+    const writeResponse = await fetch(`${dashboardBaseUrl}/api/prompts/system`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ selected: 'custom' }),
+    });
+    const writeData = await writeResponse.json() as any;
+
+    assert.equal(writeResponse.status, 409);
+    assert.match(writeData.error, /机器人配置尚未初始化/);
   });
 
   test('PUT /settings immediately restarts a running connector after a bound custom model update', async () => {

--- a/tests/dashboard-productization-html.test.ts
+++ b/tests/dashboard-productization-html.test.ts
@@ -136,6 +136,16 @@ test('Companion prompt ask preserves the current proposal when no new diff is ge
   assert.match(dashboardHtml, /else \{\s*promptCompanionProposal = null;\s*promptCompanionAdvisor = null;\s*promptCompanionAdvisorNotice = '';\s*\}/);
 });
 
+test('Prompt editor exposes only the BotDefinition system prompt choices', () => {
+  assert.match(dashboardHtml, /默认 System Prompt/);
+  assert.match(dashboardHtml, /自定义 System Prompt/);
+  assert.match(dashboardHtml, /插入 \{\{displayName\}\}/);
+  assert.match(dashboardHtml, /function selectSystemPromptMode\(selected\)/);
+  assert.match(dashboardHtml, /\/api\/prompts\/system/);
+  assert.match(dashboardHtml, /function insertDisplayNameTemplate\(\)/);
+  assert.doesNotMatch(dashboardHtml, /重置为内置/);
+});
+
 test('SkillHub Skills page is separate from Companion Hub and owns publishing controls', () => {
   assert.match(dashboardHtml, /onclick="switchPage\('store'\)" data-page="store"/);
   assert.match(dashboardHtml, /<div class="page" id="page-store">/);

--- a/tests/dashboard-productization-html.test.ts
+++ b/tests/dashboard-productization-html.test.ts
@@ -143,6 +143,9 @@ test('Prompt editor exposes only the BotDefinition system prompt choices', () =>
   assert.match(dashboardHtml, /function selectSystemPromptMode\(selected\)/);
   assert.match(dashboardHtml, /\/api\/prompts\/system/);
   assert.match(dashboardHtml, /function insertDisplayNameTemplate\(\)/);
+  assert.match(dashboardHtml, /const definitionReady=promptEditorState\?\.system_prompt\?\.definitionReady===true/);
+  assert.match(dashboardHtml, /const modeDisabled=definitionReady\?'':' disabled'/);
+  assert.match(dashboardHtml, /isCustom&&definitionReady\?'':' readonly'/);
   assert.doesNotMatch(dashboardHtml, /重置为内置/);
 });
 

--- a/tests/prompt-editor.test.ts
+++ b/tests/prompt-editor.test.ts
@@ -12,10 +12,13 @@ import {
 
 describe('prompt-editor', () => {
   test('writes and resets prompt overrides without editing bundled prompts', async () => {
-    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-prompt-editor-base-'));
+    const appRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-prompt-editor-app-'));
+    const base = path.join(appRoot, 'prompts');
     const overrides = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-prompt-editor-overrides-'));
     const previous = capturePromptEnv();
     try {
+      fs.mkdirSync(base, { recursive: true });
+      process.env.XIAOBA_APP_ROOT = appRoot;
       process.env.XIAOBA_PROMPTS_DIR = base;
       process.env.XIAOBA_PROMPT_OVERRIDES_DIR = overrides;
       process.env.XIAOBA_USER_DATA_DIR = base;
@@ -28,7 +31,7 @@ describe('prompt-editor', () => {
       assert.equal(initial.writable, true);
       assert.deepStrictEqual(
         initial.files.map(file => file.path),
-        ['runtime-context.md', 'system-prompt.md'],
+        ['system-prompt.md'],
       );
       assert.equal(getPromptEditorFile('system-prompt.md').content, 'base prompt');
 
@@ -44,16 +47,19 @@ describe('prompt-editor', () => {
       assert.equal(fs.existsSync(path.join(overrides, 'system-prompt.md')), false);
     } finally {
       restorePromptEnv(previous);
-      fs.rmSync(base, { recursive: true, force: true });
+      fs.rmSync(appRoot, { recursive: true, force: true });
       fs.rmSync(overrides, { recursive: true, force: true });
     }
   });
 
   test('rejects traversal and non-existing prompt paths', () => {
-    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-prompt-editor-base-'));
+    const appRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-prompt-editor-app-'));
+    const base = path.join(appRoot, 'prompts');
     const overrides = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-prompt-editor-overrides-'));
     const previous = capturePromptEnv();
     try {
+      fs.mkdirSync(base, { recursive: true });
+      process.env.XIAOBA_APP_ROOT = appRoot;
       process.env.XIAOBA_PROMPTS_DIR = base;
       process.env.XIAOBA_PROMPT_OVERRIDES_DIR = overrides;
       process.env.XIAOBA_USER_DATA_DIR = base;
@@ -68,17 +74,24 @@ describe('prompt-editor', () => {
         () => writePromptOverride('unknown.md', 'nope'),
         /Prompt file is not editable/,
       );
+      assert.throws(
+        () => writePromptOverride('runtime-context.md', 'nope'),
+        /Prompt file is not editable/,
+      );
     } finally {
       restorePromptEnv(previous);
-      fs.rmSync(base, { recursive: true, force: true });
+      fs.rmSync(appRoot, { recursive: true, force: true });
       fs.rmSync(overrides, { recursive: true, force: true });
     }
   });
 
   test('rejects override directory that points at bundled prompts', async () => {
-    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-prompt-editor-base-'));
+    const appRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-prompt-editor-app-'));
+    const base = path.join(appRoot, 'prompts');
     const previous = capturePromptEnv();
     try {
+      fs.mkdirSync(base, { recursive: true });
+      process.env.XIAOBA_APP_ROOT = appRoot;
       process.env.XIAOBA_PROMPTS_DIR = base;
       process.env.XIAOBA_PROMPT_OVERRIDES_DIR = base;
       process.env.XIAOBA_USER_DATA_DIR = base;
@@ -102,13 +115,14 @@ describe('prompt-editor', () => {
       assert.equal(fs.existsSync(path.join(base, 'system-prompt.md')), true);
     } finally {
       restorePromptEnv(previous);
-      fs.rmSync(base, { recursive: true, force: true });
+      fs.rmSync(appRoot, { recursive: true, force: true });
     }
   });
 });
 
 function capturePromptEnv(): Record<string, string | undefined> {
   return {
+    XIAOBA_APP_ROOT: process.env.XIAOBA_APP_ROOT,
     XIAOBA_PROMPTS_DIR: process.env.XIAOBA_PROMPTS_DIR,
     XIAOBA_PROMPT_OVERRIDES_DIR: process.env.XIAOBA_PROMPT_OVERRIDES_DIR,
     XIAOBA_USER_DATA_DIR: process.env.XIAOBA_USER_DATA_DIR,


### PR DESCRIPTION
## 这次解决什么

此前主 System Prompt 主要依赖本机的一份 override 文件，不属于 BotDefinition。结果是同一台电脑切换不同 Bot 时，难以稳定区分每个 Bot 使用默认 Prompt 还是自己的自定义 Prompt。

本 PR 完成本地 BotDefinition 的 Prompt 解耦，并收敛为两种模式：

- **默认 Prompt**：始终使用当前 XiaoBa 安装版本内置的最新默认 Prompt。
- **自定义 Prompt**：为当前 Bot 完整保存一份自定义文本。

默认模式不会复制保存官方 Prompt 全文；切回默认也不会删除此前保存的自定义内容，之后可以直接恢复。

## 范围说明

本 PR 解决的是：

- 同一台电脑上不同 Bot 的 Prompt 隔离。
- BotDefinition、本地缓存、活动 Markdown 文件之间的同步基础设施。
- 未来接入 CatsCompany 云端 BotDefinition 所需的本地接口。

本 PR **尚未实现真实跨设备同步**。当前 canonical Definition 仍由 `FileBotDefinitionRepository` 在本机模拟；后续将该仓库替换为 CatsCompany 持久化实现后，才会支持新设备自动恢复 Prompt。

## 用户可以感受到的变化

- Dashboard 的提示词页面只开放“默认 System Prompt”和“自定义 System Prompt”。
- 默认 Prompt 会随 XiaoBa 版本自动升级。
- 自定义 Prompt 可由 Dashboard、用户或 Agent 直接修改普通 Markdown 文件。
- 修改后的 Prompt 从下一轮开始生效，并自动写回当前 Bot 的本地 Definition。
- 同机切换不同 Bot 时，各自的 Prompt 选择和内容不会串用。
- 切回默认后仍保留自定义内容，再次选择自定义即可恢复。
- 提供“插入 `{{displayName}}`”按钮，Bot 名称继续由运行时自动注入。

## 实现方式

- 在 BotDefinition 中增加 `prompt.selected` 与 `prompt.customSystemPrompt`。
- 模型与 Prompt 使用字段级更新，修改一方不会清除另一方。
- 官方默认 Prompt 始终从当前安装版本的只读资源读取，不受 override 和用户目录影响。
- 新增 Bot 级 Prompt reconcile coordinator：
  - 使用标准化文本和 SHA-256 判断真实变化。
  - 原子写入当前 Bot 的活动 Prompt 文件。
  - 同步失败时保留现有文件和基线，后续继续重试。
- 每轮结束后后台扫描，下一轮开始前做本地兜底扫描，不增加文件监听器。
- 启动和切换 Bot 时完成向下读取与物化；切换失败会恢复原 Bot 的活动 Prompt。
- 旧版已存在的主 System Prompt override 会为当前绑定 Bot 幂等迁移为自定义 Prompt。

## 旧版兼容修复

旧用户可能已经绑定 Bot，但 connector 尚未创建该 Bot 的 Definition。此前此时打开提示词页面会直接返回 500。

现在 GET 页面采用只读兼容视图：

- 找到旧 system override：显示为自定义 Prompt，并保留原内容。
- 没有旧 override：显示当前版本默认 Prompt。
- 页面读取不会创建缺少模型配置的不完整 Definition。
- 完整 Definition 仍由既有 connector bootstrap 流程初始化。

## 验证

人工验证：

1. 自定义 Prompt 生效。
2. 切回默认后，自定义规则不再生效。
3. 再切回自定义后，原内容完整恢复。
4. 完全重启 XiaoBa 后状态保持。
5. 同机切换其他 Bot，Prompt 相互隔离。

自动验证：

- 相关定向测试：`92/92` 通过。
- 新增“已绑定但 Definition 尚未初始化”的 Dashboard 与 coordinator 回归测试。
- `npm run build` 通过。
- 分支基于 `buildsense-ai/XiaoBa-CLI@895e9a3`（v1.4.6）。
