### PR TITLE
fix: prevent tool retry and grep blocking

### DIFF
--- a/src/agents/agent-tool-executor.ts
+++ b/src/agents/agent-tool-executor.ts
@@ -1,5 +1,6 @@
 import { Tool, ToolDefinition, ToolCall, ToolResult, ToolExecutionContext, ToolExecutor, ToolExecutionResult } from '../types/tool';
 import { mergeToolExecutionContext } from '../utils/tool-context';
+import { getStructuredRateLimitErrorCode } from '../utils/rate-limit-error';
 import { confirmLocalToolExecution } from '../tools/local-tool-risk';
 
 const TOOL_NAME_ALIASES: Record<string, string> = {
@@ -115,14 +116,16 @@ export class AgentToolExecutor implements ToolExecutor {
         controlSignal: tool.definition.controlMode,
       };
     } catch (error: any) {
+      const message = String(error?.message || error || '');
+      const rateLimitErrorCode = getStructuredRateLimitErrorCode(error);
       return {
         tool_call_id: toolCall.id,
         role: 'tool',
         name: requestedName,
-        content: `工具执行错误: ${error.message}`,
+        content: `工具执行错误: ${message}`,
         ok: false,
-        errorCode: 'TOOL_EXECUTION_ERROR',
-        retryable: false,
+        errorCode: rateLimitErrorCode || 'TOOL_EXECUTION_ERROR',
+        retryable: Boolean(rateLimitErrorCode),
       };
     }
   }

--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -5,6 +5,7 @@ import { AIService } from '../utils/ai-service';
 import { ToolCall, ToolDefinition, ToolExecutionContext, ToolExecutor, ToolResult, ToolTranscriptMode } from '../types/tool';
 import { StreamCallbacks, StreamRetryInfo } from '../providers/provider';
 import { Logger } from '../utils/logger';
+import { isRateLimitErrorCode } from '../utils/rate-limit-error';
 import { Metrics } from '../utils/metrics';
 import { ContextCompressor } from './context-compressor';
 import { estimateMessagesTokens, estimateToolsTokens } from './token-estimator';
@@ -1784,48 +1785,9 @@ export class ConversationRunner {
 
   private static readonly MAX_RETRIES = 2;
   private static readonly RETRY_BASE_DELAY_MS = 5000;
-  private static readonly RATE_LIMIT_ERROR_CODES = new Set([
-    'RATE_LIMIT',
-    'HTTP_429',
-    'TOO_MANY_REQUESTS',
-  ]);
-
-  private static hasRateLimitMarkers(text: string): boolean {
-    if (!text) {
-      return false;
-    }
-
-    const lower = text.toLowerCase();
-    if (
-      lower.includes('rate limit')
-      || lower.includes('too many requests')
-      || lower.includes('频率受限')
-      || lower.includes('限流')
-    ) {
-      return true;
-    }
-
-    return /(status(?:\s*code)?|http(?:\s*status)?|错误码|code)\s*[:=]?\s*429\b/i.test(text)
-      || /\b429\b.{0,24}(too many requests|rate limit|频率受限|限流)/i.test(text)
-      || /(too many requests|rate limit|频率受限|限流).{0,24}\b429\b/i.test(text);
-  }
-
-  /** 检测工具结果是否为 429 限流错误（避免把正文里的数字 429 误判为限流） */
+  /** 检测工具结果是否为 429 限流错误；正文和通用 retryable 标记都不能驱动限流退避。 */
   private static isRateLimitError(result: ToolResult): boolean {
-    const content = String(result.content || '');
-    if (result.errorCode && ConversationRunner.RATE_LIMIT_ERROR_CODES.has(result.errorCode)) {
-      return true;
-    }
-
-    const isFailure = result.ok === false
-      || Boolean(result.errorCode)
-      || result.retryable === true;
-
-    if (!isFailure) {
-      return false;
-    }
-
-    return ConversationRunner.hasRateLimitMarkers(content);
+    return isRateLimitErrorCode(result.errorCode);
   }
 
   /** 带 429 重试的工具执行 */

--- a/src/tools/device-rpc-tool.ts
+++ b/src/tools/device-rpc-tool.ts
@@ -1,5 +1,6 @@
 import type { DeviceGrantOperation } from '../types/session-identity';
 import type { ToolErrorCode, ToolExecutionContext, ToolExecutionResult, UploadedFileResult } from '../types/tool';
+import { isRateLimitErrorCode } from '../utils/rate-limit-error';
 import type { ToolGatewayDecision } from './tool-gateway';
 
 const REMOTE_TOOL_DEFAULT_TIMEOUT_MS = 60_000;
@@ -214,11 +215,11 @@ function truncateText(value: string, options: DeviceRpcNormalizeOptions = {}): s
 
 function normalizeErrorCode(value: unknown): ToolErrorCode {
   const text = String(value || '').trim();
+  if (isRateLimitErrorCode(text)) return 'RATE_LIMIT';
   if (
     text === 'TOOL_NOT_FOUND'
     || text === 'INVALID_TOOL_ARGUMENTS'
     || text === 'TOOL_EXECUTION_ERROR'
-    || text === 'RATE_LIMIT'
     || text === 'PERMISSION_DENIED'
     || text === 'FILE_NOT_FOUND'
     || text === 'EXECUTION_TIMEOUT'

--- a/src/tools/grep-tool.ts
+++ b/src/tools/grep-tool.ts
@@ -1,4 +1,5 @@
-import { execFileSync, spawnSync } from 'child_process';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
 import * as path from 'path';
 import * as fs from 'fs';
 import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
@@ -8,6 +9,7 @@ import { executeRouteIfRemote, resolveExecutionRoute, targetParameterDescription
 
 const VCS_DIRECTORIES_TO_EXCLUDE = ['.git', '.svn', '.hg', '.bzr'] as const;
 const DEFAULT_LIMIT = 250;
+const execFileAsync = promisify(execFile);
 
 interface GrepResult {
   mode: 'content' | 'files' | 'count';
@@ -62,15 +64,6 @@ function toRelativePath(absolutePath: string, cwd: string): string {
   }
 
   return relative.replace(/\\/g, '/');
-}
-
-function isCommandAvailable(command: string): boolean {
-  try {
-    const result = spawnSync(command, ['--version'], { stdio: 'pipe' });
-    return result.status === 0;
-  } catch {
-    return false;
-  }
 }
 
 export class GrepTool implements Tool {
@@ -147,6 +140,9 @@ export class GrepTool implements Tool {
         lastError = null; // 重置错误，因为空结果是正常情况
         continue;
       } catch (error: any) {
+        if (context.abortSignal?.aborted || error?.message === '搜索已取消') {
+          return { ok: false, errorCode: 'EXECUTION_ERROR', message: '搜索已取消' };
+        }
         lastError = error;
         // 如果有多个 fallback，继续尝试下一个
         continue;
@@ -160,7 +156,7 @@ export class GrepTool implements Tool {
   }
 
   private async executeWithRipgrep(args: any, searchPath: string, context: ToolExecutionContext, visibleSearchPath?: string): Promise<FallbackResult> {
-    const { pattern, path: originalPath, glob: globPattern, type: fileType, case_insensitive = false, context: contextLines, output_mode = 'files', limit = DEFAULT_LIMIT, offset = 0 } = args;
+    const { pattern, path: originalPath, glob: globPattern, type: fileType, case_insensitive = false, context: contextLines, output_mode = 'files' } = args;
     const rgArgs: string[] = ['--color=never', '--no-heading', '--hidden'];
 
     for (const dir of VCS_DIRECTORIES_TO_EXCLUDE) rgArgs.push('--glob', `!${dir}`);
@@ -178,21 +174,25 @@ export class GrepTool implements Tool {
     rgArgs.push(originalPath ? searchPath : '.');
 
     try {
-      const output = execFileSync('rg', rgArgs, { cwd: context.workingDirectory, encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024, stdio: ['pipe', 'pipe', 'pipe'] }) as string;
-      return { content: this.processOutput(output, args, context, visibleSearchPath) };
+      const { stdout } = await execFileAsync('rg', rgArgs, {
+        cwd: context.workingDirectory,
+        encoding: 'utf-8',
+        maxBuffer: 10 * 1024 * 1024,
+        signal: context.abortSignal,
+      });
+      return { content: this.processOutput(stdout, args, context, visibleSearchPath) };
     } catch (error: any) {
-      if (error.status === 1) {
-        // 无匹配，返回格式化的"未找到"
+      if (this.isAborted(error, context)) throw new Error('搜索已取消');
+      if (error.code === 1) {
         return { content: this.formatNoMatch(pattern, visibleSearchPath ?? originalPath, globPattern, fileType) };
       }
-      // exit code 2 或其他错误，抛出让 execute 统一处理
-      const errorMsg = error.stderr || `rg 执行失败 (exit ${error.status})`;
+      const errorMsg = error.stderr || `rg 执行失败 (exit ${error.code})`;
       throw new Error(errorMsg);
     }
   }
 
   private async executeWithSystemGrep(args: any, searchPath: string, context: ToolExecutionContext, visibleSearchPath?: string): Promise<FallbackResult> {
-    const { pattern, path: originalPath, glob: globPattern, type: fileType, case_insensitive = false, context: contextLines, output_mode = 'files', limit = DEFAULT_LIMIT, offset = 0 } = args;
+    const { pattern, path: originalPath, glob: globPattern, type: fileType, case_insensitive = false, context: contextLines, output_mode = 'files' } = args;
     const grepArgs: string[] = [];
 
     if (case_insensitive) grepArgs.push('-i');
@@ -205,67 +205,94 @@ export class GrepTool implements Tool {
     grepArgs.push(pattern, searchPath);
 
     try {
-      const output = execFileSync('grep', grepArgs, { cwd: context.workingDirectory, encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024, stdio: ['pipe', 'pipe', 'pipe'] }) as string;
-      let processedOutput = output;
+      const { stdout } = await execFileAsync('grep', grepArgs, {
+        cwd: context.workingDirectory,
+        encoding: 'utf-8',
+        maxBuffer: 10 * 1024 * 1024,
+        signal: context.abortSignal,
+      });
+      let processedOutput = stdout;
 
       if (globPattern) {
-        const lines = output.trim().split('\n').filter(Boolean);
+        const lines = stdout.trim().split('\n').filter(Boolean);
         const globRegex = new RegExp(globPattern.replace(/\*/g, '.*').replace(/\?/g, '.'));
         processedOutput = lines.filter(line => globRegex.test(path.basename(line.split(':')[0]))).join('\n');
       }
 
       return { content: this.processOutput(processedOutput, args, context, visibleSearchPath) };
     } catch (error: any) {
-      if (error.status === 1) {
+      if (this.isAborted(error, context)) throw new Error('搜索已取消');
+      if (error.code === 1) {
         return { content: this.formatNoMatch(pattern, visibleSearchPath ?? originalPath, globPattern, fileType) };
       }
-      const errorMsg = error.stderr || `grep 执行失败 (exit ${error.status})`;
+      const errorMsg = error.stderr || `grep 执行失败 (exit ${error.code})`;
       throw new Error(errorMsg);
     }
   }
 
   private async executeWithNodeJS(args: any, searchPath: string, context: ToolExecutionContext, visibleSearchPath?: string): Promise<FallbackResult> {
-    const { pattern, path: originalPath, glob: globPattern, type: fileType, case_insensitive = false, context: contextLines, output_mode = 'files', limit = DEFAULT_LIMIT, offset = 0 } = args;
-
-    if (!fs.existsSync(searchPath)) {
-      throw new Error(`目录不存在: ${searchPath}`);
-    }
-
-    const escapeRegex = (str: string) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const { pattern, glob: globPattern, case_insensitive = false, output_mode = 'files' } = args;
+    const escapeRegex = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     const regex = new RegExp(escapeRegex(pattern), case_insensitive ? 'i' : '');
+    const globRegex = globPattern
+      ? new RegExp('^' + globPattern.replace(/\*/g, '.*').replace(/\?/g, '.') + '$')
+      : undefined;
     const results: string[] = [];
 
-    const walkDir = (dir: string) => {
-      if (!fs.existsSync(dir)) return;
+    const ensureNotAborted = () => {
+      if (context.abortSignal?.aborted) throw new Error('搜索已取消');
+    };
+
+    const searchFile = async (fullPath: string, fileName: string): Promise<void> => {
+      ensureNotAborted();
+      if (globRegex && !globRegex.test(fileName)) return;
       try {
-        for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-          const fullPath = path.join(dir, entry.name);
-          if (VCS_DIRECTORIES_TO_EXCLUDE.includes(entry.name as any)) continue;
-          if (entry.isDirectory()) { walkDir(fullPath); continue; }
-          if (entry.isFile()) {
-            if (globPattern) {
-              const globRegex = new RegExp('^' + globPattern.replace(/\*/g, '.*').replace(/\?/g, '.') + '$');
-              if (!globRegex.test(entry.name)) continue;
-            }
-            try {
-              const lines = fs.readFileSync(fullPath, 'utf-8').split('\n');
-              for (let i = 0; i < lines.length; i++) {
-                if (regex.test(lines[i])) {
-                  if (output_mode === 'files') { results.push(fullPath); break; }
-                  else if (output_mode === 'count') { results.push(`${fullPath}:1`); break; }
-                  else results.push(`${fullPath}:${i + 1}:${lines[i]}`);
-                }
-              }
-            } catch {}
-          }
+        const lines = (await fs.promises.readFile(fullPath, 'utf-8')).split('\n');
+        for (let i = 0; i < lines.length; i++) {
+          if (!regex.test(lines[i])) continue;
+          if (output_mode === 'files') { results.push(fullPath); break; }
+          if (output_mode === 'count') { results.push(`${fullPath}:1`); break; }
+          results.push(`${fullPath}:${i + 1}:${lines[i]}`);
         }
       } catch (error: any) {
-        throw new Error(`读取目录失败: ${error.message}`);
+        if (context.abortSignal?.aborted) throw new Error('搜索已取消');
+        if (!['EACCES', 'EPERM', 'EISDIR'].includes(error?.code)) throw error;
       }
     };
 
-    walkDir(searchPath);
+    const walkDir = async (dir: string): Promise<void> => {
+      ensureNotAborted();
+      let entries: fs.Dirent[];
+      try {
+        entries = await fs.promises.readdir(dir, { withFileTypes: true });
+      } catch (error: any) {
+        throw new Error(`读取目录失败: ${error.message}`);
+      }
+
+      for (const entry of entries) {
+        ensureNotAborted();
+        if (VCS_DIRECTORIES_TO_EXCLUDE.includes(entry.name as any)) continue;
+        const fullPath = path.join(dir, entry.name);
+        if (entry.isDirectory()) await walkDir(fullPath);
+        else if (entry.isFile()) await searchFile(fullPath, entry.name);
+      }
+    };
+
+    let stats: fs.Stats;
+    try {
+      stats = await fs.promises.stat(searchPath);
+    } catch (error: any) {
+      if (error?.code === 'ENOENT') throw new Error(`目录不存在: ${searchPath}`);
+      throw error;
+    }
+
+    if (stats.isDirectory()) await walkDir(searchPath);
+    else if (stats.isFile()) await searchFile(searchPath, path.basename(searchPath));
     return { content: this.processOutput(results.join('\n'), args, context, visibleSearchPath) };
+  }
+
+  private isAborted(error: any, context: ToolExecutionContext): boolean {
+    return context.abortSignal?.aborted || error?.name === 'AbortError' || error?.code === 'ABORT_ERR';
   }
 
   private processOutput(output: string, args: any, context: ToolExecutionContext, visibleSearchPath?: string): string {

--- a/src/tools/grep-tool.ts
+++ b/src/tools/grep-tool.ts
@@ -8,8 +8,18 @@ import { formatCatsCoVisiblePath, redactCatsCoVisiblePath } from './tool-gateway
 import { executeRouteIfRemote, resolveExecutionRoute, targetParameterDescription } from './execution-router';
 
 const VCS_DIRECTORIES_TO_EXCLUDE = ['.git', '.svn', '.hg', '.bzr'] as const;
+const SKIPPABLE_FILE_READ_ERROR_CODES = new Set(['EACCES', 'EPERM', 'EISDIR', 'ENOENT', 'ESTALE']);
 const DEFAULT_LIMIT = 250;
 const execFileAsync = promisify(execFile);
+
+class GrepSearchCancelledError extends Error {
+  readonly code = 'ABORT_ERR';
+
+  constructor() {
+    super('搜索已取消');
+    this.name = 'AbortError';
+  }
+}
 
 interface GrepResult {
   mode: 'content' | 'files' | 'count';
@@ -140,7 +150,7 @@ export class GrepTool implements Tool {
         lastError = null; // 重置错误，因为空结果是正常情况
         continue;
       } catch (error: any) {
-        if (context.abortSignal?.aborted || error?.message === '搜索已取消') {
+        if (this.isAborted(error, context)) {
           return { ok: false, errorCode: 'EXECUTION_ERROR', message: '搜索已取消' };
         }
         lastError = error;
@@ -182,7 +192,7 @@ export class GrepTool implements Tool {
       });
       return { content: this.processOutput(stdout, args, context, visibleSearchPath) };
     } catch (error: any) {
-      if (this.isAborted(error, context)) throw new Error('搜索已取消');
+      if (this.isAborted(error, context)) throw new GrepSearchCancelledError();
       if (error.code === 1) {
         return { content: this.formatNoMatch(pattern, visibleSearchPath ?? originalPath, globPattern, fileType) };
       }
@@ -221,7 +231,7 @@ export class GrepTool implements Tool {
 
       return { content: this.processOutput(processedOutput, args, context, visibleSearchPath) };
     } catch (error: any) {
-      if (this.isAborted(error, context)) throw new Error('搜索已取消');
+      if (this.isAborted(error, context)) throw new GrepSearchCancelledError();
       if (error.code === 1) {
         return { content: this.formatNoMatch(pattern, visibleSearchPath ?? originalPath, globPattern, fileType) };
       }
@@ -240,14 +250,17 @@ export class GrepTool implements Tool {
     const results: string[] = [];
 
     const ensureNotAborted = () => {
-      if (context.abortSignal?.aborted) throw new Error('搜索已取消');
+      if (context.abortSignal?.aborted) throw new GrepSearchCancelledError();
     };
 
     const searchFile = async (fullPath: string, fileName: string): Promise<void> => {
       ensureNotAborted();
       if (globRegex && !globRegex.test(fileName)) return;
       try {
-        const lines = (await fs.promises.readFile(fullPath, 'utf-8')).split('\n');
+        const lines = (await fs.promises.readFile(fullPath, {
+          encoding: 'utf-8',
+          signal: context.abortSignal,
+        })).split('\n');
         for (let i = 0; i < lines.length; i++) {
           if (!regex.test(lines[i])) continue;
           if (output_mode === 'files') { results.push(fullPath); break; }
@@ -255,8 +268,8 @@ export class GrepTool implements Tool {
           results.push(`${fullPath}:${i + 1}:${lines[i]}`);
         }
       } catch (error: any) {
-        if (context.abortSignal?.aborted) throw new Error('搜索已取消');
-        if (!['EACCES', 'EPERM', 'EISDIR'].includes(error?.code)) throw error;
+        if (this.isAborted(error, context)) throw new GrepSearchCancelledError();
+        if (!SKIPPABLE_FILE_READ_ERROR_CODES.has(error?.code)) throw error;
       }
     };
 

--- a/src/tools/tool-manager.ts
+++ b/src/tools/tool-manager.ts
@@ -1,5 +1,6 @@
 import { Tool, ToolDefinition, ToolCall, ToolResult, ToolExecutionContext, ToolExecutor, ToolExecutionResult } from '../types/tool';
 import { Logger } from '../utils/logger';
+import { getStructuredRateLimitErrorCode } from '../utils/rate-limit-error';
 import { ReadTool } from './read-tool';
 import { WriteTool } from './write-tool';
 import { ShellTool } from './bash-tool';
@@ -44,17 +45,6 @@ const TOOL_NAME_ALIASES: Record<string, string> = {
 
 function resolveToolName(name: string): string {
   return TOOL_NAME_ALIASES[name] ?? name;
-}
-
-function isRateLimitLikeMessage(message: string): boolean {
-  const lower = message.toLowerCase();
-  return lower.includes('rate limit')
-    || lower.includes('too many requests')
-    || lower.includes('频率受限')
-    || lower.includes('限流')
-    || /(status(?:\s*code)?|http(?:\s*status)?|错误码|code)\s*[:=]?\s*429\b/i.test(message)
-    || /\b429\b.{0,24}(too many requests|rate limit|频率受限|限流)/i.test(message)
-    || /(too many requests|rate limit|频率受限|限流).{0,24}\b429\b/i.test(message);
 }
 
 /**
@@ -230,7 +220,7 @@ export class ToolManager implements ToolExecutor {
           targetContext,
           ok: false,
           errorCode: output.errorCode,
-          retryable: output.retryable ?? isRateLimitLikeMessage(output.message),
+          retryable: output.retryable ?? false,
         };
       }
 
@@ -245,15 +235,15 @@ export class ToolManager implements ToolExecutor {
       };
     } catch (error: any) {
       const message = String(error?.message || error || '');
-      const isRateLimit = isRateLimitLikeMessage(message);
+      const rateLimitErrorCode = getStructuredRateLimitErrorCode(error);
       return {
         tool_call_id: toolCall.id,
         role: 'tool',
         name: toolCall.function.name,
         content: `工具执行错误: ${message}`,
         ok: false,
-        errorCode: isRateLimit ? 'RATE_LIMIT' : 'TOOL_EXECUTION_ERROR',
-        retryable: isRateLimit,
+        errorCode: rateLimitErrorCode || 'TOOL_EXECUTION_ERROR',
+        retryable: Boolean(rateLimitErrorCode),
       };
     }
   }

--- a/src/utils/rate-limit-error.ts
+++ b/src/utils/rate-limit-error.ts
@@ -1,0 +1,36 @@
+const RATE_LIMIT_ERROR_CODES = new Set([
+  'RATE_LIMIT',
+  'HTTP_429',
+  'TOO_MANY_REQUESTS',
+]);
+
+export function isRateLimitErrorCode(value: unknown): boolean {
+  if (typeof value !== 'string') return false;
+  return RATE_LIMIT_ERROR_CODES.has(value.trim().toUpperCase());
+}
+
+/**
+ * Read rate-limit state from transport metadata only. Error messages may contain
+ * arbitrary command output or source text and must never drive retry policy.
+ */
+export function getStructuredRateLimitErrorCode(error: any): string | undefined {
+  const statusCandidates = [
+    error?.status,
+    error?.statusCode,
+    error?.response?.status,
+    error?.cause?.status,
+    error?.cause?.response?.status,
+  ];
+  if (statusCandidates.some(status => Number(status) === 429)) {
+    return 'HTTP_429';
+  }
+
+  const codeCandidates = [
+    error?.errorCode,
+    error?.code,
+    error?.response?.data?.code,
+    error?.cause?.errorCode,
+    error?.cause?.code,
+  ];
+  return codeCandidates.find(isRateLimitErrorCode)?.trim().toUpperCase();
+}

--- a/tests/conversation-runner-transcript-normalization.test.ts
+++ b/tests/conversation-runner-transcript-normalization.test.ts
@@ -1381,6 +1381,39 @@ test('runner keeps repeated send_file calls in the same assistant response as le
   );
 });
 
+test('runner does not infer rate limiting from ordinary failed tool output', () => {
+  const result: ToolResult = {
+    tool_call_id: 'call_shell',
+    role: 'tool',
+    name: 'execute_shell',
+    content: [
+      'Command failed',
+      "command: sed -n '1,80p' src/openai-provider.ts",
+      "stdout: throw new Error('rate limit response')",
+      'stderr: Segmentation fault',
+    ].join('\n'),
+    ok: false,
+    errorCode: 'TOOL_EXECUTION_ERROR',
+    retryable: true,
+  };
+
+  assert.equal((ConversationRunner as any).isRateLimitError(result), false);
+});
+
+test('runner still recognizes structured rate-limit errors', () => {
+  const result: ToolResult = {
+    tool_call_id: 'call_remote',
+    role: 'tool',
+    name: 'remote_api',
+    content: 'request rejected',
+    ok: false,
+    errorCode: 'RATE_LIMIT',
+    retryable: true,
+  };
+
+  assert.equal((ConversationRunner as any).isRateLimitError(result), true);
+});
+
 test('runner does not locally retry failed outbound file sends unless the failure is rate limited', async () => {
   const responses = [
     makeToolResponse(makeToolCall('call_file', 'send_file', {

--- a/tests/device-rpc-tool.test.ts
+++ b/tests/device-rpc-tool.test.ts
@@ -55,6 +55,30 @@ describe('Device RPC tool helpers', () => {
     assert.equal(result.ok ? result.content : '', content);
   });
 
+  test('preserves every recognized rate-limit code across Device RPC', () => {
+    for (const errorCode of ['RATE_LIMIT', 'HTTP_429', 'TOO_MANY_REQUESTS']) {
+      const transportResult = normalizeDeviceRpcToolResultForTransport({
+        ok: false,
+        errorCode,
+        message: 'request rejected',
+        retryable: true,
+      });
+      assert.equal(transportResult.ok, false);
+      assert.equal(transportResult.ok ? undefined : transportResult.errorCode, 'RATE_LIMIT');
+      assert.equal(transportResult.ok ? undefined : transportResult.retryable, true);
+
+      const payloadResult = normalizeDeviceRpcToolResultPayload({
+        ok: false,
+        errorCode,
+        message: 'request rejected',
+        retryable: true,
+      });
+      assert.equal(payloadResult.ok, false);
+      assert.equal(payloadResult.ok ? undefined : payloadResult.errorCode, 'RATE_LIMIT');
+      assert.equal(payloadResult.ok ? undefined : payloadResult.retryable, true);
+    }
+  });
+
   test('preserves valid uploaded file metadata and rejects malformed metadata', () => {
     const valid = normalizeDeviceRpcToolResultPayload({
       ok: true,

--- a/tests/grep-tool.test.ts
+++ b/tests/grep-tool.test.ts
@@ -64,6 +64,63 @@ describe('GrepTool', () => {
   });
 
   describe('基础搜索功能', () => {
+    test('ripgrep 执行期间不应阻塞共享事件循环', async () => {
+      if (process.platform === 'win32') return;
+
+      const fakeBin = fs.mkdtempSync(path.join(os.tmpdir(), 'grep-fake-bin-'));
+      const fakeRg = path.join(fakeBin, 'rg');
+      fs.writeFileSync(fakeRg, [
+        '#!/bin/sh',
+        'sleep 0.15',
+        `printf '%s\\n' '${path.join(testDir, 'test1.js').replace(/'/g, "'\\''")}'`,
+      ].join('\n'));
+      fs.chmodSync(fakeRg, 0o755);
+
+      const originalPath = process.env.PATH;
+      process.env.PATH = `${fakeBin}:${originalPath || ''}`;
+      let timerFired = false;
+      const timer = setTimeout(() => { timerFired = true; }, 10);
+
+      try {
+        const result = await grepTool.execute({ pattern: 'Hello', output_mode: 'files' }, context);
+        assert.strictEqual(result.ok, true);
+        assert.strictEqual(timerFired, true, 'grep 子进程运行时事件循环应该继续处理其他 session');
+      } finally {
+        clearTimeout(timer);
+        process.env.PATH = originalPath;
+        fs.rmSync(fakeBin, { recursive: true, force: true });
+      }
+    });
+
+    test('取消搜索时应立即终止异步 ripgrep', async () => {
+      if (process.platform === 'win32') return;
+
+      const fakeBin = fs.mkdtempSync(path.join(os.tmpdir(), 'grep-abort-bin-'));
+      const fakeRg = path.join(fakeBin, 'rg');
+      fs.writeFileSync(fakeRg, '#!/bin/sh\nsleep 5\nprintf "never\\n"\n');
+      fs.chmodSync(fakeRg, 0o755);
+
+      const originalPath = process.env.PATH;
+      process.env.PATH = `${fakeBin}:${originalPath || ''}`;
+      const controller = new AbortController();
+      const startedAt = Date.now();
+      const timer = setTimeout(() => controller.abort(), 20);
+
+      try {
+        const result = await grepTool.execute(
+          { pattern: 'Hello', output_mode: 'files' },
+          { ...context, abortSignal: controller.signal },
+        );
+        assert.strictEqual(result.ok, false);
+        assert.match(result.ok ? '' : result.message, /搜索已取消/);
+        assert.ok(Date.now() - startedAt < 500, '取消后不应继续尝试其他 fallback');
+      } finally {
+        clearTimeout(timer);
+        process.env.PATH = originalPath;
+        fs.rmSync(fakeBin, { recursive: true, force: true });
+      }
+    });
+
     test('应该能找到匹配的文件（files模式）', async () => {
       const result = await grepTool.execute({
         pattern: 'Hello',

--- a/tests/grep-tool.test.ts
+++ b/tests/grep-tool.test.ts
@@ -12,6 +12,20 @@ function getContent(result: { ok: boolean; content: unknown }): string {
   return result.content as string;
 }
 
+async function withReadFileStub<T>(
+  stub: (originalReadFile: (...args: any[]) => Promise<any>, ...args: any[]) => Promise<any>,
+  run: () => Promise<T>,
+): Promise<T> {
+  const originalReadFile = fs.promises.readFile;
+  const callOriginalReadFile = (...args: any[]) => originalReadFile.apply(fs.promises, args as any);
+  (fs.promises as any).readFile = (...args: any[]) => stub(callOriginalReadFile, ...args);
+  try {
+    return await run();
+  } finally {
+    (fs.promises as any).readFile = originalReadFile;
+  }
+}
+
 describe('GrepTool', () => {
   let grepTool: GrepTool;
   let testDir: string;
@@ -119,6 +133,64 @@ describe('GrepTool', () => {
         process.env.PATH = originalPath;
         fs.rmSync(fakeBin, { recursive: true, force: true });
       }
+    });
+
+    test('Node.js fallback 应将取消信号传入进行中的文件读取', async () => {
+      const controller = new AbortController();
+      let receivedSignal: AbortSignal | undefined;
+      const timer = setTimeout(() => controller.abort(), 20);
+
+      try {
+        await withReadFileStub(
+          async (_originalReadFile, _filePath, options) => {
+            receivedSignal = options?.signal;
+            if (!receivedSignal) throw new Error('readFile missing AbortSignal');
+            await new Promise<void>((_resolve, reject) => {
+              const rejectAsAborted = () => reject(Object.assign(new Error('aborted'), {
+                name: 'AbortError',
+                code: 'ABORT_ERR',
+              }));
+              if (receivedSignal?.aborted) rejectAsAborted();
+              else receivedSignal?.addEventListener('abort', rejectAsAborted, { once: true });
+            });
+            return '';
+          },
+          async () => {
+            await assert.rejects(
+              () => (grepTool as any).executeWithNodeJS(
+                { pattern: 'Hello', output_mode: 'files' },
+                testDir,
+                { ...context, abortSignal: controller.signal },
+                '.',
+              ),
+              /搜索已取消/,
+            );
+          },
+        );
+      } finally {
+        clearTimeout(timer);
+      }
+
+      assert.strictEqual(receivedSignal, controller.signal);
+    });
+
+    test('Node.js fallback 应跳过搜索期间消失的单个文件', async () => {
+      const result = await withReadFileStub(
+        async (originalReadFile, filePath, options) => {
+          if (path.basename(String(filePath)) === 'test1.js') {
+            throw Object.assign(new Error('file disappeared'), { code: 'ENOENT' });
+          }
+          return originalReadFile(filePath, options);
+        },
+        () => (grepTool as any).executeWithNodeJS(
+          { pattern: 'Hello', output_mode: 'files' },
+          testDir,
+          context,
+          '.',
+        ),
+      );
+
+      assert.match(result.content, /test2\.ts/);
     });
 
     test('应该能找到匹配的文件（files模式）', async () => {

--- a/tests/tool-manager.test.ts
+++ b/tests/tool-manager.test.ts
@@ -111,6 +111,47 @@ function catsDeviceSelection(
 }
 
 describe('ToolManager', () => {
+  test('does not infer retryability from a failed tool result body', async () => {
+    const manager = new ToolManager('/tmp/xiaoba-tool-manager', {}, { enabledToolNames: [] });
+    manager.registerTool(fakeTool('execute_shell', async () => ({
+      ok: false,
+      errorCode: 'TOOL_EXECUTION_ERROR',
+      message: [
+        'Command failed',
+        "command: sed -n '1,80p' src/openai-provider.ts",
+        "stdout: throw new Error('rate limit response')",
+        'stderr: Segmentation fault',
+      ].join('\n'),
+    })));
+
+    const result = await manager.executeTool({
+      id: 'call-shell-failed-source-read',
+      type: 'function',
+      function: { name: 'execute_shell', arguments: JSON.stringify({ command: 'exit 139' }) },
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.errorCode, 'TOOL_EXECUTION_ERROR');
+    assert.equal(result.retryable, false);
+  });
+
+  test('classifies structured HTTP 429 errors as retryable', async () => {
+    const manager = new ToolManager('/tmp/xiaoba-tool-manager', {}, { enabledToolNames: [] });
+    manager.registerTool(fakeTool('remote_api', async () => {
+      throw Object.assign(new Error('request rejected'), { response: { status: 429 } });
+    }));
+
+    const result = await manager.executeTool({
+      id: 'call-http-429',
+      type: 'function',
+      function: { name: 'remote_api', arguments: '{}' },
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.errorCode, 'HTTP_429');
+    assert.equal(result.retryable, true);
+  });
+
   test('registers all default tools when no enabled list is provided', () => {
     const manager = new ToolManager('/tmp/xiaoba-tool-manager');
 

--- a/tests/tool-manager.test.ts
+++ b/tests/tool-manager.test.ts
@@ -152,6 +152,24 @@ describe('ToolManager', () => {
     assert.equal(result.retryable, true);
   });
 
+  test('AgentToolExecutor preserves structured HTTP 429 errors for retry', async () => {
+    const executor = new AgentToolExecutor([
+      fakeTool('remote_api', async () => {
+        throw Object.assign(new Error('request rejected'), { response: { status: 429 } });
+      }),
+    ], '/tmp/xiaoba-agent-tool-executor');
+
+    const result = await executor.executeTool({
+      id: 'call-agent-http-429',
+      type: 'function',
+      function: { name: 'remote_api', arguments: '{}' },
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.errorCode, 'HTTP_429');
+    assert.equal(result.retryable, true);
+  });
+
   test('registers all default tools when no enabled list is provided', () => {
     const manager = new ToolManager('/tmp/xiaoba-tool-manager');
 


### PR DESCRIPTION
## Summary
- run grep through an asynchronous, cancellable child process to avoid blocking the shared event loop
- retry shell/tool failures only when the error has an explicit structured rate-limit signal
- preserve exponential retry behavior for recognized 429/rate-limit failures

## Validation
- targeted tests: 77 passing
- TypeScript type check: passing
- isolated full suite: 1155/1157 passing

## Notes
The two full-suite failures are pre-existing path/environment cases. This PR does not change the WebSocket ACK/reconnection display layer; that issue needs a separately evidenced fix.