### PR TITLE
feat: 完成 Bot Skill 工作区三方同步链路

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test:legacy": "node scripts/run-tests.mjs legacy",
     "test:all": "node scripts/run-tests.mjs all",
     "test:list": "node scripts/run-tests.mjs runtime --list",
+    "test:e2e:bot-skill-live": "tsx scripts/bot-skill-live-e2e.ts",
     "report": "node dist/index.js chat --exec '/report'",
     "clean-logs": "node scripts/clean-logs.mjs",
     "prepare:runtime": "node scripts/prepare-runtime.mjs",

--- a/scripts/bot-skill-live-e2e.ts
+++ b/scripts/bot-skill-live-e2e.ts
@@ -1,0 +1,316 @@
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { BOT_DEFINITION_SCHEMA } from '../src/bot-definition/types';
+import {
+  BotDefinitionCloudError,
+  HttpBotDefinitionCloudClient,
+} from '../src/bot-skills/definition-cloud';
+import { HttpBotPrivateSkillPackageClient } from '../src/bot-skills/http-private-package';
+import { BotSkillRuntime, type BotSkillRuntimeSyncOutcome } from '../src/bot-skills/runtime';
+import { BOT_SKILL_WORKSPACE_IDENTITY_FILE } from '../src/bot-skills/workspace';
+
+const catsCoBaseUrl = requiredEnv('BOT_SKILL_E2E_CATSCO_BASE_URL');
+const skillHubBaseUrl = requiredEnv('BOT_SKILL_E2E_SKILLHUB_BASE_URL');
+const botId = requiredEnv('BOT_SKILL_E2E_BOT_ID');
+const apiKey = requiredEnv('BOT_SKILL_E2E_API_KEY');
+const disposableConfirmation = requiredEnv('BOT_SKILL_E2E_CONFIRM_DISPOSABLE_BOT');
+assertLoopbackBaseUrl(catsCoBaseUrl, 'BOT_SKILL_E2E_CATSCO_BASE_URL');
+assertLoopbackBaseUrl(skillHubBaseUrl, 'BOT_SKILL_E2E_SKILLHUB_BASE_URL');
+if (disposableConfirmation !== 'YES_MUTATE_DISPOSABLE_BOT') {
+  throw new Error(
+    'BOT_SKILL_E2E_CONFIRM_DISPOSABLE_BOT must be YES_MUTATE_DISPOSABLE_BOT',
+  );
+}
+const keepRoots = /^(1|true|yes)$/i.test(process.env.BOT_SKILL_E2E_KEEP_ROOTS || '');
+
+const auth = {
+  httpBaseUrl: catsCoBaseUrl,
+  serverUrl: `${catsCoBaseUrl.replace(/^http/, 'ws')}/v0/channels`,
+  botUid: botId,
+  apiKey,
+};
+const definitionForCreate = {
+  schema: BOT_DEFINITION_SCHEMA,
+  botId,
+  model: { kind: 'catalog' as const, modelId: 'local' },
+};
+const packages = new HttpBotPrivateSkillPackageClient({
+  baseUrl: skillHubBaseUrl,
+  botId,
+  apiKey,
+  allowInsecureHttp: true,
+});
+const cloud = new HttpBotDefinitionCloudClient({
+  botId,
+  auth,
+  allowInsecureHttp: true,
+});
+const deviceARoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-bot-skill-live-a-'));
+const deviceBRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-bot-skill-live-b-'));
+const steps: Array<Record<string, unknown>> = [];
+
+function runtime(runtimeRoot: string): BotSkillRuntime {
+  return new BotSkillRuntime({
+    runtimeRoot,
+    auth,
+    skillHubBaseUrl,
+    packages,
+    debounceMs: 60_000,
+  });
+}
+
+function writeSkill(runtimeRoot: string, name: string, body: string): void {
+  const directory = path.join(runtimeRoot, 'skills', name);
+  fs.mkdirSync(directory, { recursive: true });
+  fs.writeFileSync(path.join(directory, 'SKILL.md'), [
+    '---',
+    `name: ${name}`,
+    `description: ${name} live e2e`,
+    '---',
+    '',
+    body,
+    '',
+  ].join('\n'));
+}
+
+function appendSkill(runtimeRoot: string, name: string, body: string): void {
+  fs.appendFileSync(path.join(runtimeRoot, 'skills', name, 'SKILL.md'), `\n${body}\n`);
+}
+
+function readSkill(runtimeRoot: string, name: string): string {
+  return fs.readFileSync(path.join(runtimeRoot, 'skills', name, 'SKILL.md'), 'utf8');
+}
+
+function record(name: string, outcome: BotSkillRuntimeSyncOutcome): void {
+  steps.push({
+    name,
+    action: outcome.result.action,
+    reason: outcome.result.reason,
+    blockedSkills: outcome.result.blockedSkills?.map(item => ({
+      name: item.name,
+      code: item.code,
+      relativePaths: item.relativePaths,
+    })),
+    skills: outcome.definition?.skills,
+  });
+}
+
+async function main(): Promise<void> {
+  const initialCloud = await cloud.read();
+  assert.equal(
+    initialCloud.kind === 'missing' || initialCloud.definition.skills === undefined,
+    true,
+    'live E2E requires a disposable Bot with either a missing or legacy Cloud Definition',
+  );
+  const initialMode = initialCloud.kind === 'missing' ? 'fresh' : 'legacy-revision-zero';
+
+  let deviceA = runtime(deviceARoot);
+  const created = await deviceA.sync({
+    definitionForCreate,
+    allowNewWorkspaceCreate: true,
+  });
+  record('definition-initialize', created);
+  assert.equal(created.result.action, 'created_cloud');
+  assert.deepStrictEqual(created.definition?.skills, []);
+  const nonSkillFields = {
+    model: initialCloud.kind === 'found' ? initialCloud.definition.model : created.definition?.model,
+    prompt: initialCloud.kind === 'found' ? initialCloud.definition.prompt : created.definition?.prompt,
+  };
+  assert.deepStrictEqual({
+    model: created.definition?.model,
+    prompt: created.definition?.prompt,
+  }, nonSkillFields);
+  const migratedCloud = await cloud.read();
+  assert.equal(migratedCloud.kind, 'found');
+  if (migratedCloud.kind !== 'found') return;
+  assert.deepStrictEqual(migratedCloud.definition.skills, []);
+  const staleEtag = initialCloud.kind === 'found' ? initialCloud.etag : migratedCloud.etag;
+
+  await deviceA.mutate(() => writeSkill(deviceARoot, 'alpha', 'initial local content'));
+  const initialUpload = await deviceA.flush();
+  assert.ok(initialUpload);
+  record('initial-upload', initialUpload);
+  assert.equal(initialUpload.result.action, 'uploaded');
+  assert.equal(initialUpload.definition?.skills?.length, 1);
+  const initialReference = initialUpload.definition!.skills![0];
+  const beforeStalePatch = await cloud.read();
+  assert.equal(beforeStalePatch.kind, 'found');
+  if (beforeStalePatch.kind !== 'found') return;
+  await assert.rejects(
+    cloud.patchSkills(beforeStalePatch.definition.skills ?? [], staleEtag),
+    (error: unknown) => (
+      error instanceof BotDefinitionCloudError
+      && error.status === 412
+    ),
+  );
+  assert.deepStrictEqual(await cloud.read(), beforeStalePatch);
+  steps.push({ name: 'stale-etag-rejected', action: 'rejected', status: 412 });
+
+  appendSkill(deviceARoot, 'alpha', 'changed while XiaoBa was offline');
+  deviceA = runtime(deviceARoot);
+  const offlineUpload = await deviceA.sync({ definitionForCreate });
+  record('offline-restart-upload', offlineUpload);
+  assert.equal(offlineUpload.result.action, 'uploaded');
+  assert.notDeepStrictEqual(offlineUpload.definition?.skills?.[0], initialReference);
+
+  const deviceB = runtime(deviceBRoot);
+  const restoredB = await deviceB.sync({ definitionForCreate });
+  record('missing-workspace-cloud-restore', restoredB);
+  assert.equal(restoredB.result.action, 'downloaded');
+  assert.match(readSkill(deviceBRoot, 'alpha'), /changed while XiaoBa was offline/);
+
+  await deviceB.mutate(() => appendSkill(deviceBRoot, 'alpha', 'cloud edit from device B'));
+  const uploadedB = await deviceB.flush();
+  assert.ok(uploadedB);
+  record('device-b-upload', uploadedB);
+  assert.equal(uploadedB.result.action, 'uploaded');
+
+  const downloadedA = await deviceA.sync({ definitionForCreate });
+  record('unchanged-local-cloud-download', downloadedA);
+  assert.equal(downloadedA.result.action, 'downloaded');
+  assert.match(readSkill(deviceARoot, 'alpha'), /cloud edit from device B/);
+
+  appendSkill(deviceARoot, 'alpha', 'offline local wins after both changed');
+  await deviceB.mutate(() => appendSkill(deviceBRoot, 'alpha', 'concurrent cloud snapshot'));
+  const concurrentB = await deviceB.flush();
+  assert.ok(concurrentB);
+  record('concurrent-device-b-upload', concurrentB);
+  assert.equal(concurrentB.result.action, 'uploaded');
+  const preservedCloudReference = concurrentB.definition!.skills![0];
+
+  const localWins = await deviceA.sync({ definitionForCreate });
+  record('both-changed-local-priority', localWins);
+  assert.equal(localWins.result.action, 'uploaded');
+  assert.match(readSkill(deviceARoot, 'alpha'), /offline local wins after both changed/);
+  assert.notDeepStrictEqual(localWins.definition?.skills?.[0], preservedCloudReference);
+
+  const preserved = await packages.download(preservedCloudReference);
+  const preservedSkill = preserved.files.find(file => file.path === 'SKILL.md');
+  assert.ok(preservedSkill);
+  assert.match(preservedSkill.bytes.toString('utf8'), /concurrent cloud snapshot/);
+
+  const cloudBeforeSensitive = await cloud.read();
+  assert.equal(cloudBeforeSensitive.kind, 'found');
+  if (cloudBeforeSensitive.kind !== 'found') return;
+  await deviceA.mutate(() => {
+    writeSkill(deviceARoot, 'local-secret', 'local-only sensitive skill');
+    fs.writeFileSync(
+      path.join(deviceARoot, 'skills', 'local-secret', '.env'),
+      'API_KEY=live-e2e-placeholder-secret-value\n',
+    );
+    fs.writeFileSync(
+      path.join(deviceARoot, 'skills', 'local-secret', 'config.txt'),
+      'CATSCO_API_KEY=live-e2e-sensitive-value-1234567890\n',
+    );
+  });
+  const sensitive = await deviceA.flush();
+  assert.ok(sensitive);
+  record('sensitive-local-skill-blocked', sensitive);
+  assert.equal(sensitive.result.action, 'uploaded');
+  assert.equal(sensitive.result.blockedSkills?.length, 1);
+  assert.equal(sensitive.result.blockedSkills?.[0].name, 'local-secret');
+  assert.equal(fs.existsSync(path.join(deviceARoot, 'skills', 'local-secret', '.env')), true);
+  const cloudAfterSensitive = await cloud.read();
+  assert.equal(cloudAfterSensitive.kind, 'found');
+  if (cloudAfterSensitive.kind !== 'found') return;
+  assert.deepStrictEqual(
+    cloudAfterSensitive.definition.skills,
+    cloudBeforeSensitive.definition.skills,
+  );
+  const restoredAfterSensitive = await deviceB.sync({ definitionForCreate });
+  record('sensitive-skill-absent-on-other-device', restoredAfterSensitive);
+  assert.equal(restoredAfterSensitive.result.action, 'downloaded');
+  assert.equal(fs.existsSync(path.join(deviceBRoot, 'skills', 'local-secret')), false);
+  const beforeOutage = await cloud.read();
+  assert.equal(beforeOutage.kind, 'found');
+  appendSkill(deviceARoot, 'alpha', 'local content retained while SkillHub is unavailable');
+  const outagePackages = new HttpBotPrivateSkillPackageClient({
+    baseUrl: 'http://127.0.0.1:1',
+    botId,
+    apiKey,
+    allowInsecureHttp: true,
+    timeoutMs: 1_000,
+  });
+  const outageRuntime = new BotSkillRuntime({
+    runtimeRoot: deviceARoot,
+    auth,
+    packages: outagePackages,
+    debounceMs: 60_000,
+  });
+  const outage = await outageRuntime.sync({ definitionForCreate });
+  record('private-upload-outage-local-preserved', outage);
+  assert.equal(outage.result.action, 'uploaded');
+  assert.equal(outage.result.blockedSkills?.some(item => item.name === 'alpha'), true);
+  assert.match(readSkill(deviceARoot, 'alpha'), /local content retained while SkillHub is unavailable/);
+  const afterOutage = await cloud.read();
+  assert.equal(afterOutage.kind, 'found');
+  assert.deepStrictEqual(
+    afterOutage.kind === 'found' ? afterOutage.definition.skills : undefined,
+    beforeOutage.kind === 'found' ? beforeOutage.definition.skills : undefined,
+  );
+
+  const recoveredUpload = await deviceA.sync({ definitionForCreate });
+  record('private-upload-outage-retry', recoveredUpload);
+  assert.equal(recoveredUpload.result.action, 'uploaded');
+  assert.equal(recoveredUpload.result.blockedSkills?.some(item => item.name === 'alpha'), false);
+
+  const beforeUnreadable = await cloud.read();
+  assert.equal(beforeUnreadable.kind, 'found');
+  const identityPath = path.join(deviceARoot, 'skills', BOT_SKILL_WORKSPACE_IDENTITY_FILE);
+  const identity = fs.readFileSync(identityPath, 'utf8');
+  fs.writeFileSync(identityPath, '{broken');
+  const unreadable = await deviceA.sync({ definitionForCreate });
+  record('unreadable-workspace-blocked', unreadable);
+  assert.equal(unreadable.result.action, 'blocked');
+  assert.equal(unreadable.result.reason, 'LOCAL_WORKSPACE_UNREADABLE');
+  assert.deepStrictEqual(await cloud.read(), beforeUnreadable);
+  fs.writeFileSync(identityPath, identity);
+
+  const finalCloud = await cloud.read();
+  assert.equal(finalCloud.kind, 'found');
+  if (finalCloud.kind !== 'found') return;
+  assert.deepStrictEqual({
+    model: finalCloud.definition.model,
+    prompt: finalCloud.definition.prompt,
+  }, nonSkillFields);
+
+  process.stdout.write(`${JSON.stringify({
+    ok: true,
+    botId,
+    initialMode,
+    remoteArtifactsRetained: true,
+    steps,
+  }, null, 2)}\n`);
+}
+
+main()
+  .catch(error => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(() => {
+    if (keepRoots) {
+      console.error(`kept device roots: ${deviceARoot}, ${deviceBRoot}`);
+      return;
+    }
+    fs.rmSync(deviceARoot, { recursive: true, force: true });
+    fs.rmSync(deviceBRoot, { recursive: true, force: true });
+  });
+
+function requiredEnv(name: string): string {
+  const value = String(process.env[name] || '').trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function assertLoopbackBaseUrl(value: string, name: string): void {
+  const url = new URL(value);
+  if (
+    url.protocol !== 'http:'
+    || !['127.0.0.1', 'localhost', '::1'].includes(url.hostname)
+  ) {
+    throw new Error(`${name} must point to an isolated loopback staging service`);
+  }
+}

--- a/src/bot-definition/activation.ts
+++ b/src/bot-definition/activation.ts
@@ -22,6 +22,8 @@ import {
 export interface PrepareBoundBotDefinitionOptions extends BotDefinitionSyncServiceOptions {
   runtimeRoot: string;
   botId?: string;
+  /** Full Definition already reconciled through the real Bot Skill cloud API. */
+  definitionOverride?: BotDefinition;
   selectedCatalogRuntime?: BotCatalogModelRuntime;
   auth?: CatsCoAuthSnapshot;
   fetchImpl?: typeof fetch;
@@ -56,11 +58,24 @@ export async function prepareBoundBotDefinition(
   if (selectedCatalogRuntime && selectedCatalogRuntime.botId !== botId) {
     throw new Error('Selected catalog runtime does not belong to the bound bot.');
   }
-  let sync = definitionService.pullOrBootstrap(botId);
-  let localDefinition = sync?.definition;
+  if (options.definitionOverride && options.definitionOverride.botId !== botId) {
+    throw new Error('Definition override does not belong to the bound bot.');
+  }
+  let sync = options.definitionOverride
+    ? undefined
+    : definitionService.pullOrBootstrap(botId);
+  let localDefinition = options.definitionOverride
+    ? definitionService.acceptRemoteSnapshot(options.definitionOverride)
+    : sync?.definition;
   const previousCloudDefinition = definitionService.readCloudModelOverride(botId);
   const previousCloudRuntime = definitionService.readCloudCatalogRuntime(botId);
-  let definition = previousCloudDefinition ?? localDefinition;
+  let definition = previousCloudDefinition
+    ? {
+      ...previousCloudDefinition,
+      ...(localDefinition?.prompt !== undefined ? { prompt: localDefinition.prompt } : {}),
+      ...(localDefinition?.skills !== undefined ? { skills: localDefinition.skills } : {}),
+    }
+    : localDefinition;
   const auth = options.auth ?? createCatsCoLocalConfigService({ runtimeRoot: options.runtimeRoot }).getAuthState();
   let initializedDefault = false;
   let materializedCatalogRuntime = false;

--- a/src/bot-definition/repository.ts
+++ b/src/bot-definition/repository.ts
@@ -7,9 +7,9 @@ import {
   type BotCatalogModelRuntime,
   type BotCustomModelProfile,
   type BotDefinition,
-  type BotPromptDefinition,
   type CustomBotModelDefinition,
 } from './types';
+import { isValidBotDefinition } from './validation';
 
 export interface BotDefinitionRepository {
   readCanonical(botId: string): BotDefinition | undefined;
@@ -58,28 +58,6 @@ function normalizeBotId(botId: string): string {
   return value;
 }
 
-function isValidDefinition(definition: unknown, expectedBotId: string): definition is BotDefinition {
-  const value = definition as BotDefinition | undefined;
-  if (!value || value.schema !== 'xiaoba.bot-definition.v1' || value.botId !== expectedBotId || !value.model) {
-    return false;
-  }
-  if (value.prompt !== undefined && !isValidPromptDefinition(value.prompt)) {
-    return false;
-  }
-  if (value.model.kind === 'catalog') {
-    return Boolean(String(value.model.modelId || '').trim());
-  }
-  if (value.model.kind !== 'custom') return false;
-  return isValidCustomModel(value.model);
-}
-
-function isValidPromptDefinition(prompt: unknown): prompt is BotPromptDefinition {
-  const value = prompt as BotPromptDefinition | undefined;
-  if (!value || (value.selected !== 'default' && value.selected !== 'custom')) return false;
-  if (value.customSystemPrompt === undefined) return true;
-  return Boolean(String(value.customSystemPrompt || '').trim());
-}
-
 function isValidCustomModel(model: unknown): model is CustomBotModelDefinition {
   const value = model as CustomBotModelDefinition | undefined;
   return (
@@ -123,14 +101,14 @@ function readDefinition(filePath: string, expectedBotId: string): BotDefinition 
   if (!fs.existsSync(filePath)) return undefined;
   try {
     const parsed = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as BotDefinition;
-    return isValidDefinition(parsed, expectedBotId) ? parsed : undefined;
+    return isValidBotDefinition(parsed, expectedBotId) ? parsed : undefined;
   } catch {
     return undefined;
   }
 }
 
 function writeDefinition(filePath: string, definition: BotDefinition): void {
-  if (!isValidDefinition(definition, definition.botId)) {
+  if (!isValidBotDefinition(definition, definition.botId)) {
     throw new Error('BotDefinition is invalid');
   }
   const directory = path.dirname(filePath);

--- a/src/bot-definition/service.ts
+++ b/src/bot-definition/service.ts
@@ -416,9 +416,36 @@ export class BotDefinitionSyncService {
     return cached ? normalizeBotDefinition(cached) : this.pull(botId);
   }
 
+  /**
+   * Accepts the already reconciled full Definition from the real cloud
+   * transport without consulting the legacy simulated-canonical file again.
+   */
+  acceptRemoteSnapshot(definition: BotDefinition): BotDefinition {
+    return this.withDefinitionWriteLock(definition.botId, () => {
+      const normalized = normalizeBotDefinition(definition);
+      const current = this.repository.readCache(normalized.botId)
+        ?? this.repository.readCanonical(normalized.botId);
+      const merged = current?.prompt !== undefined
+        ? { ...normalized, prompt: current.prompt }
+        : normalized;
+      this.repository.writeCache(merged);
+      const override = this.cloudOverrideRepository.read(normalized.botId);
+      if (override) {
+        this.cloudOverrideRepository.write({
+          ...override,
+          ...(merged.prompt !== undefined ? { prompt: merged.prompt } : {}),
+          ...(merged.skills !== undefined ? { skills: merged.skills } : {}),
+        });
+      }
+      return merged;
+    });
+  }
+
   publish(botId: string, model: BotModelDefinition): BotDefinitionSyncResult {
     return this.withDefinitionWriteLock(botId, () => {
-      const previous = this.repository.readCache(botId) ?? this.repository.readCanonical(botId);
+      const previousCanonical = this.repository.readCanonical(botId);
+      const previousCache = this.repository.readCache(botId);
+      const previous = previousCache ?? previousCanonical;
       if (previous?.model.kind === 'custom') {
         this.storeCustomModelProfile(botId, previous.model);
       }
@@ -426,19 +453,25 @@ export class BotDefinitionSyncService {
       if (normalizedModel.kind === 'custom') {
         this.storeCustomModelProfile(botId, normalizedModel);
       }
-      const definition: BotDefinition = {
-        ...previous,
+      const canonicalDefinition: BotDefinition = {
+        ...(previousCanonical ?? previousCache),
         schema: BOT_DEFINITION_SCHEMA,
         botId,
         model: normalizedModel,
       };
-      this.repository.writeCanonical(definition);
-      this.repository.writeCache(definition);
-      this.clearLegacyModelConfigurationWhenReady(definition);
+      const cacheDefinition: BotDefinition = {
+        ...(previousCache ?? previousCanonical),
+        schema: BOT_DEFINITION_SCHEMA,
+        botId,
+        model: normalizedModel,
+      };
+      this.repository.writeCanonical(canonicalDefinition);
+      this.repository.writeCache(cacheDefinition);
+      this.clearLegacyModelConfigurationWhenReady(cacheDefinition);
       return {
         botId,
         direction: 'local_to_simulated_cloud',
-        definition,
+        definition: cacheDefinition,
       };
     });
   }
@@ -449,28 +482,38 @@ export class BotDefinitionSyncService {
 
   updatePrompt(botId: string, prompt: BotPromptDefinition): BotDefinitionSyncResult {
     return this.withDefinitionWriteLock(botId, () => {
-      const previous = this.repository.readCache(botId) ?? this.repository.readCanonical(botId);
-      if (!previous) {
+      const previousCanonical = this.repository.readCanonical(botId);
+      const previousCache = this.repository.readCache(botId);
+      if (!previousCache && !previousCanonical) {
         throw new Error(`BotDefinition does not exist for bot ${botId}`);
       }
-      const definition: BotDefinition = {
-        ...previous,
+      const normalizedPrompt = normalizePromptDefinition(prompt);
+      const canonicalDefinition: BotDefinition = {
+        ...(previousCanonical ?? previousCache!),
         schema: BOT_DEFINITION_SCHEMA,
         botId,
-        prompt: normalizePromptDefinition(prompt),
+        prompt: normalizedPrompt,
       };
-      this.repository.writeCache(definition);
-      this.repository.writeCanonical(definition);
+      const cacheDefinition: BotDefinition = {
+        ...(previousCache ?? previousCanonical!),
+        schema: BOT_DEFINITION_SCHEMA,
+        botId,
+        prompt: normalizedPrompt,
+      };
+      this.repository.writeCache(cacheDefinition);
+      this.repository.writeCanonical(canonicalDefinition);
       return {
         botId,
         direction: 'local_to_simulated_cloud',
-        definition,
+        definition: cacheDefinition,
       };
     });
   }
 
   acceptCloud(botId: string, model: BotModelDefinition): BotDefinitionSyncResult {
+    const previous = this.cloudOverrideRepository.read(botId) ?? this.repository.readCache(botId);
     const definition: BotDefinition = {
+      ...previous,
       schema: BOT_DEFINITION_SCHEMA,
       botId,
       model: normalizeBotModelDefinition(model),

--- a/src/bot-definition/types.ts
+++ b/src/bot-definition/types.ts
@@ -38,13 +38,26 @@ export interface BotPromptDefinition {
 }
 
 /**
- * The deliberately small, portable part of a bot.
+ * A portable, immutable Skill package reference. Local workspace identity and
+ * content hashes deliberately live in the device-local sync base instead of
+ * leaking into the cloud Definition.
+ */
+export interface BotSkillReference {
+  skillId: string;
+  version: string;
+}
+
+/**
+ * The deliberately small, portable part of a bot. Missing `skills` means the
+ * Definition predates Bot Skill sync and still needs one-time migration;
+ * `skills: []` is an explicit, valid empty workspace.
  */
 export interface BotDefinition {
   schema: typeof BOT_DEFINITION_SCHEMA;
   botId: string;
   model: BotModelDefinition;
   prompt?: BotPromptDefinition;
+  skills?: BotSkillReference[];
 }
 
 export interface LocalModelProfile {

--- a/src/bot-definition/validation.ts
+++ b/src/bot-definition/validation.ts
@@ -1,0 +1,146 @@
+import {
+  BOT_DEFINITION_SCHEMA,
+  type BotDefinition,
+  type BotPromptDefinition,
+  type BotSkillReference,
+  type CustomBotModelDefinition,
+} from './types';
+
+export function isValidBotDefinition(
+  definition: unknown,
+  expectedBotId: string,
+): definition is BotDefinition {
+  const value = definition as BotDefinition | undefined;
+  if (
+    !value
+    || typeof value !== 'object'
+    || value.schema !== BOT_DEFINITION_SCHEMA
+    || typeof value.botId !== 'string'
+    || value.botId !== expectedBotId
+    || !value.model
+    || !isValidBotPromptDefinition(value.prompt)
+    || !isValidBotSkillReferences(value.skills)
+  ) {
+    return false;
+  }
+  if (value.model.kind === 'catalog') {
+    return (
+      typeof value.model.modelId === 'string'
+      && validBoundedText(value.model.modelId, 160)
+      && optionalReasoningEffortIsValid(value.model.reasoningEffort)
+    );
+  }
+  return value.model.kind === 'custom' && isValidCustomModel(value.model);
+}
+
+export function isValidBotPromptDefinition(
+  prompt: unknown,
+): prompt is BotPromptDefinition | undefined {
+  if (prompt === undefined) return true;
+  if (!prompt || typeof prompt !== 'object') return false;
+  const value = prompt as BotPromptDefinition;
+  if (value.selected !== 'default' && value.selected !== 'custom') return false;
+  return value.customSystemPrompt === undefined
+    || (
+      typeof value.customSystemPrompt === 'string'
+      && validPromptText(value.customSystemPrompt, 1_000_000)
+    );
+}
+
+export function assertValidBotDefinition(
+  definition: unknown,
+  expectedBotId: string,
+): asserts definition is BotDefinition {
+  if (!isValidBotDefinition(definition, expectedBotId)) {
+    throw new Error('BotDefinition is invalid.');
+  }
+}
+
+export function isValidBotSkillReferences(
+  skills: unknown,
+): skills is BotSkillReference[] | undefined {
+  if (skills === undefined) return true;
+  if (!Array.isArray(skills) || skills.length > 256) return false;
+  const seenSkillIds = new Set<string>();
+  for (const raw of skills) {
+    if (!raw || typeof raw !== 'object') return false;
+    const keys = Object.keys(raw);
+    if (keys.some(key => key !== 'skillId' && key !== 'version')) return false;
+    if (typeof raw.skillId !== 'string' || typeof raw.version !== 'string') return false;
+    const skillId = raw.skillId.trim();
+    const version = raw.version.trim();
+    if (
+      !skillId
+      || !version
+      || skillId.length > 240
+      || version.length > 120
+      || hasControlCharacters(skillId)
+      || hasControlCharacters(version)
+      || seenSkillIds.has(skillId)
+    ) {
+      return false;
+    }
+    seenSkillIds.add(skillId);
+  }
+  return true;
+}
+
+function isValidCustomModel(model: unknown): model is CustomBotModelDefinition {
+  const value = model as CustomBotModelDefinition | undefined;
+  if (!value || typeof value !== 'object') return false;
+  const contextWindowTokens = Number(value.contextWindowTokens);
+  const maxTokens = value.maxTokens === undefined ? undefined : Number(value.maxTokens);
+  const temperature = value.temperature === undefined ? undefined : Number(value.temperature);
+  return (
+    value?.kind === 'custom'
+    && typeof value.protocol === 'string'
+    && ['anthropic', 'openai-chat-completions', 'openai-responses'].includes(value.protocol)
+    && typeof value.apiBase === 'string'
+    && validHttpUrl(value.apiBase)
+    && typeof value.model === 'string'
+    && validBoundedText(value.model, 240)
+    && typeof value.apiKey === 'string'
+    && value.apiKey.length > 0
+    && value.apiKey.length <= 8192
+    && Number.isInteger(contextWindowTokens)
+    && contextWindowTokens >= 1024
+    && contextWindowTokens <= 4_000_000
+    && (maxTokens === undefined || (Number.isInteger(maxTokens) && maxTokens > 0 && maxTokens <= 1_000_000))
+    && (temperature === undefined || (Number.isFinite(temperature) && temperature >= 0 && temperature <= 2))
+    && optionalReasoningEffortIsValid(value.reasoningEffort)
+  );
+}
+
+function hasControlCharacters(value: string): boolean {
+  return /[\u0000-\u001f\u007f]/.test(value);
+}
+
+function validBoundedText(value: string, maxLength: number): boolean {
+  const text = value.trim();
+  return Boolean(text) && text.length <= maxLength && !hasControlCharacters(text);
+}
+
+function validPromptText(value: string, maxLength: number): boolean {
+  const text = value.trim();
+  return Boolean(text)
+    && text.length <= maxLength
+    && !/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/.test(text);
+}
+
+function validHttpUrl(value: string): boolean {
+  if (value.length > 2048 || hasControlCharacters(value)) return false;
+  try {
+    const url = new URL(value);
+    return url.protocol === 'https:' || url.protocol === 'http:';
+  } catch {
+    return false;
+  }
+}
+
+function optionalReasoningEffortIsValid(value: unknown): boolean {
+  return value === undefined
+    || (
+      typeof value === 'string'
+      && ['default', 'none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra', 'disabled'].includes(value)
+    );
+}

--- a/src/bot-skills/base-store.ts
+++ b/src/bot-skills/base-store.ts
@@ -1,0 +1,119 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+import { PathResolver } from '../utils/path-resolver';
+import { normalizeBotSkillSyncBaseEntries } from './canonical';
+import {
+  BOT_SKILL_SYNC_BASE_SCHEMA,
+  type BotSkillSyncBase,
+  type BotSkillSyncBaseReadResult,
+} from './types';
+
+export interface FileBotSkillSyncBaseStoreOptions {
+  runtimeRoot?: string;
+  root?: string;
+  authority?: string;
+}
+
+export class FileBotSkillSyncBaseStore {
+  private readonly root: string;
+  private readonly authority?: string;
+
+  constructor(options: FileBotSkillSyncBaseStoreOptions = {}) {
+    const runtimeRoot = path.resolve(options.runtimeRoot ?? PathResolver.getRuntimeDataRoot());
+    this.authority = cleanOptional(options.authority);
+    const scope = authorityScope(this.authority);
+    this.root = path.resolve(options.root ?? path.join(runtimeRoot, 'data', 'bot-skill-sync-base', scope));
+  }
+
+  read(botId: string, expectedWorkspaceId?: string): BotSkillSyncBaseReadResult {
+    const filePath = this.getPath(botId);
+    if (!fs.existsSync(filePath)) return { kind: 'missing' };
+    try {
+      const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8')) as BotSkillSyncBase;
+      const base = validateBase(parsed, normalizeBotId(botId), this.authority);
+      if (expectedWorkspaceId && base.workspaceId !== expectedWorkspaceId) {
+        throw new Error('Bot Skill sync base belongs to another workspace.');
+      }
+      return { kind: 'valid', base };
+    } catch (error: any) {
+      return { kind: 'corrupt', error: error?.message || String(error) };
+    }
+  }
+
+  write(base: BotSkillSyncBase): void {
+    const normalized = validateBase(base, normalizeBotId(base.botId), this.authority);
+    const filePath = this.getPath(normalized.botId);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    const temporary = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+    fs.writeFileSync(temporary, `${JSON.stringify(normalized, null, 2)}\n`, {
+      encoding: 'utf8',
+      mode: 0o600,
+    });
+    fs.renameSync(temporary, filePath);
+    if (process.platform !== 'win32') {
+      try {
+        fs.chmodSync(filePath, 0o600);
+      } catch {
+        // Some mounted filesystems do not expose POSIX modes.
+      }
+    }
+  }
+
+  getPath(botId: string): string {
+    return path.join(this.root, `${normalizeBotId(botId)}.json`);
+  }
+}
+
+function validateBase(
+  value: BotSkillSyncBase,
+  expectedBotId: string,
+  expectedAuthority?: string,
+): BotSkillSyncBase {
+  if (
+    value?.schema !== BOT_SKILL_SYNC_BASE_SCHEMA
+    || value.botId !== expectedBotId
+    || !validId(value.workspaceId)
+    || !Array.isArray(value.entries)
+    || !Number.isFinite(Date.parse(String(value.updatedAt || '')))
+  ) {
+    throw new Error('Bot Skill sync base is invalid.');
+  }
+  const authority = cleanOptional(value.authority);
+  if (authority !== expectedAuthority) {
+    throw new Error('Bot Skill sync base belongs to another authority.');
+  }
+  const definitionETag = cleanOptional(value.definitionETag);
+  if (definitionETag && (!/^"[^"\r\n]{1,200}"$/.test(definitionETag) || definitionETag.startsWith('W/'))) {
+    throw new Error('Bot Skill sync base ETag is invalid.');
+  }
+  return {
+    schema: BOT_SKILL_SYNC_BASE_SCHEMA,
+    botId: expectedBotId,
+    workspaceId: value.workspaceId,
+    ...(authority ? { authority } : {}),
+    ...(definitionETag ? { definitionETag } : {}),
+    entries: normalizeBotSkillSyncBaseEntries(value.entries),
+    updatedAt: value.updatedAt,
+  };
+}
+
+function normalizeBotId(botId: string): string {
+  const value = String(botId || '').trim();
+  if (!/^[a-zA-Z0-9_.-]{1,160}$/.test(value)) throw new Error('botId contains unsupported characters');
+  return value;
+}
+
+function validId(value: unknown): boolean {
+  return /^[a-zA-Z0-9_.:-]{1,160}$/.test(String(value || ''));
+}
+
+function cleanOptional(value: unknown): string | undefined {
+  const text = String(value || '').trim();
+  return text || undefined;
+}
+
+function authorityScope(authority?: string): string {
+  if (!authority) return 'default';
+  return `authority-${crypto.createHash('sha256').update(authority).digest('hex').slice(0, 24)}`;
+}

--- a/src/bot-skills/canonical.ts
+++ b/src/bot-skills/canonical.ts
@@ -1,0 +1,116 @@
+import type { BotSkillReference } from '../bot-definition/types';
+import type {
+  BotLocalSkillSnapshot,
+  BotSkillSyncBase,
+  BotSkillSyncBaseEntry,
+} from './types';
+
+export function normalizeBotSkillReferences(
+  references: readonly BotSkillReference[],
+): BotSkillReference[] {
+  const normalized = references.map(reference => ({
+    skillId: String(reference.skillId || '').trim(),
+    version: String(reference.version || '').trim(),
+  }));
+  const seen = new Set<string>();
+  for (const reference of normalized) {
+    if (
+      !validCloudText(reference.skillId, 240)
+      || !validCloudText(reference.version, 120)
+    ) {
+      throw new Error('Bot Skill reference is missing skillId or version.');
+    }
+    if (seen.has(reference.skillId)) throw new Error(`Duplicate Bot Skill reference: ${reference.skillId}`);
+    seen.add(reference.skillId);
+  }
+  return normalized.sort(compareReferences);
+}
+
+export function botSkillReferencesEqual(
+  left: readonly BotSkillReference[],
+  right: readonly BotSkillReference[],
+): boolean {
+  const a = normalizeBotSkillReferences(left);
+  const b = normalizeBotSkillReferences(right);
+  return a.length === b.length && a.every((item, index) => (
+    item.skillId === b[index].skillId && item.version === b[index].version
+  ));
+}
+
+export function normalizeBotSkillSyncBaseEntries(
+  entries: readonly BotSkillSyncBaseEntry[],
+): BotSkillSyncBaseEntry[] {
+  if (!Array.isArray(entries) || entries.length > 256) {
+    throw new Error('Bot Skill sync base contains too many entries.');
+  }
+  const normalized = entries.map(entry => ({
+    localSkillId: String(entry.localSkillId || '').trim(),
+    localContentHash: String(entry.localContentHash || '').trim(),
+    cloudSkillId: String(entry.cloudSkillId || '').trim(),
+    cloudVersion: String(entry.cloudVersion || '').trim(),
+  }));
+  const localIds = new Set<string>();
+  const cloudRefs = new Set<string>();
+  for (const entry of normalized) {
+    if (
+      !/^[a-zA-Z0-9_.:-]{1,160}$/.test(entry.localSkillId)
+      || !/^[a-f0-9]{64}$/.test(entry.localContentHash)
+      || !validCloudText(entry.cloudSkillId, 240)
+      || !validCloudText(entry.cloudVersion, 120)
+    ) {
+      throw new Error('Bot Skill sync base entry is incomplete.');
+    }
+    if (localIds.has(entry.localSkillId)) {
+      throw new Error(`Duplicate localSkillId in Bot Skill sync base: ${entry.localSkillId}`);
+    }
+    const cloudKey = `${entry.cloudSkillId}\0${entry.cloudVersion}`;
+    if (cloudRefs.has(cloudKey)) {
+      throw new Error(`Duplicate cloud Skill reference in Bot Skill sync base: ${entry.cloudSkillId}@${entry.cloudVersion}`);
+    }
+    localIds.add(entry.localSkillId);
+    cloudRefs.add(cloudKey);
+  }
+  return normalized.sort((a, b) => a.localSkillId.localeCompare(b.localSkillId));
+}
+
+function validCloudText(value: string, maxLength: number): boolean {
+  return Boolean(value) && value.length <= maxLength && !/[\u0000-\u001f\u007f]/.test(value);
+}
+
+export function localSnapshotMatchesBase(
+  local: readonly BotLocalSkillSnapshot[],
+  base: Pick<BotSkillSyncBase, 'entries'>,
+): boolean {
+  const entries = normalizeBotSkillSyncBaseEntries(base.entries);
+  const normalizedLocal = [...local].sort((a, b) => a.localSkillId.localeCompare(b.localSkillId));
+  return normalizedLocal.length === entries.length && normalizedLocal.every((skill, index) => (
+    skill.localSkillId === entries[index].localSkillId
+    && skill.contentHash === entries[index].localContentHash
+  ));
+}
+
+export function cloudSnapshotMatchesBase(
+  cloud: readonly BotSkillReference[],
+  base: Pick<BotSkillSyncBase, 'entries'>,
+): boolean {
+  return botSkillReferencesEqual(
+    cloud,
+    base.entries.map(entry => ({
+      skillId: entry.cloudSkillId,
+      version: entry.cloudVersion,
+    })),
+  );
+}
+
+export function cloudReferencesFromBase(
+  base: Pick<BotSkillSyncBase, 'entries'>,
+): BotSkillReference[] {
+  return normalizeBotSkillReferences(base.entries.map(entry => ({
+    skillId: entry.cloudSkillId,
+    version: entry.cloudVersion,
+  })));
+}
+
+function compareReferences(left: BotSkillReference, right: BotSkillReference): number {
+  return left.skillId.localeCompare(right.skillId) || left.version.localeCompare(right.version);
+}

--- a/src/bot-skills/definition-cloud.ts
+++ b/src/bot-skills/definition-cloud.ts
@@ -1,0 +1,255 @@
+import type { CatsCoAuthSnapshot } from '../catscompany/local-config';
+import type { BotDefinition, BotSkillReference } from '../bot-definition/types';
+import { assertValidBotDefinition, isValidBotSkillReferences } from '../bot-definition/validation';
+import { normalizeBotSkillReferences } from './canonical';
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+const MAX_DEFINITION_RESPONSE_BYTES = 1024 * 1024;
+
+export interface BotDefinitionCloudSnapshot {
+  definition: BotDefinition;
+  etag: string;
+}
+
+export type BotDefinitionCloudReadResult =
+  | { kind: 'missing' }
+  | ({ kind: 'found' } & BotDefinitionCloudSnapshot);
+
+export interface BotDefinitionCloudClient {
+  read(): Promise<BotDefinitionCloudReadResult>;
+  create(definition: BotDefinition): Promise<BotDefinitionCloudSnapshot>;
+  patchSkills(skills: BotSkillReference[], ifMatch: string): Promise<BotDefinitionCloudSnapshot>;
+}
+
+export interface HttpBotDefinitionCloudClientOptions {
+  botId: string;
+  auth: CatsCoAuthSnapshot;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+  allowInsecureHttp?: boolean;
+}
+
+export class BotDefinitionCloudError extends Error {
+  constructor(
+    message: string,
+    public readonly code: string,
+    public readonly status?: number,
+  ) {
+    super(message);
+    this.name = 'BotDefinitionCloudError';
+  }
+}
+
+export class HttpBotDefinitionCloudClient implements BotDefinitionCloudClient {
+  private readonly botId: string;
+  private readonly apiKey: string;
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly timeoutMs: number;
+
+  constructor(options: HttpBotDefinitionCloudClientOptions) {
+    this.botId = String(options.botId || '').trim();
+    this.apiKey = String(options.auth.apiKey || '').trim();
+    this.baseUrl = String(options.auth.httpBaseUrl || '').trim().replace(/\/+$/, '');
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    if (!this.botId || !this.apiKey || !this.baseUrl) {
+      throw new BotDefinitionCloudError(
+        'CatsCo Bot Definition credentials are incomplete.',
+        'BOT_DEFINITION_AUTH_INCOMPLETE',
+      );
+    }
+    assertTrustedBaseUrl(this.baseUrl, options.allowInsecureHttp === true);
+  }
+
+  async read(): Promise<BotDefinitionCloudReadResult> {
+    const response = await this.request('GET');
+    if (response.status === 404) return { kind: 'missing' };
+    return { kind: 'found', ...await this.snapshotFrom(response) };
+  }
+
+  async create(definition: BotDefinition): Promise<BotDefinitionCloudSnapshot> {
+    assertValidBotDefinition(definition, this.botId);
+    const response = await this.request('PUT', {
+      skills: normalizeBotSkillReferences(definition.skills ?? []),
+    }, {
+      'If-None-Match': '*',
+    });
+    return this.snapshotFrom(response);
+  }
+
+  async patchSkills(
+    skills: BotSkillReference[],
+    ifMatch: string,
+  ): Promise<BotDefinitionCloudSnapshot> {
+    const normalized = normalizeBotSkillReferences(skills);
+    if (!isValidBotSkillReferences(normalized)) {
+      throw new BotDefinitionCloudError('Bot Skill references are invalid.', 'BOT_DEFINITION_SKILLS_INVALID');
+    }
+    const etag = String(ifMatch || '').trim();
+    if (!etag) {
+      throw new BotDefinitionCloudError('If-Match is required.', 'BOT_DEFINITION_ETAG_REQUIRED', 428);
+    }
+    const response = await this.request('PATCH', { skills: normalized }, {
+      'If-Match': etag,
+    });
+    return this.snapshotFrom(response);
+  }
+
+  private async request(
+    method: string,
+    body?: unknown,
+    extraHeaders: Record<string, string> = {},
+  ): Promise<BufferedCloudResponse> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+    let response: Response;
+    try {
+      response = await this.fetchImpl(`${this.baseUrl}/api/bot/definition`, {
+        method,
+        headers: {
+          Accept: 'application/json',
+          Authorization: `ApiKey ${this.apiKey}`,
+          ...(body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+          ...extraHeaders,
+        },
+        body: body === undefined ? undefined : JSON.stringify(body),
+        redirect: 'error',
+        signal: controller.signal,
+      });
+      const text = response.status === 404
+        ? ''
+        : await readResponseTextLimited(response, controller, MAX_DEFINITION_RESPONSE_BYTES);
+      if (!response.ok && response.status !== 404) {
+        const errorCode = safeServerErrorCode(text);
+        throw new BotDefinitionCloudError(
+          `CatsCo Bot Definition request failed: HTTP ${response.status}`,
+          errorCode || `BOT_DEFINITION_HTTP_${response.status}`,
+          response.status,
+        );
+      }
+      return { status: response.status, headers: response.headers, text };
+    } catch (error: any) {
+      if (error instanceof BotDefinitionCloudError) throw error;
+      const code = error?.name === 'AbortError'
+        ? 'BOT_DEFINITION_TIMEOUT'
+        : 'BOT_DEFINITION_NETWORK_ERROR';
+      throw new BotDefinitionCloudError(
+        code === 'BOT_DEFINITION_TIMEOUT'
+          ? 'CatsCo Bot Definition request timed out.'
+          : 'CatsCo Bot Definition request failed.',
+        code,
+      );
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  private async snapshotFrom(response: BufferedCloudResponse): Promise<BotDefinitionCloudSnapshot> {
+    if (response.status < 200 || response.status >= 300) {
+      throw new BotDefinitionCloudError(
+        `CatsCo Bot Definition request failed: HTTP ${response.status}`,
+        `BOT_DEFINITION_HTTP_${response.status}`,
+        response.status,
+      );
+    }
+    const etag = String(response.headers.get('etag') || '').trim();
+    if (!etag || etag.startsWith('W/')) {
+      throw new BotDefinitionCloudError(
+        'CatsCo Bot Definition response is missing a strong ETag.',
+        'BOT_DEFINITION_ETAG_INVALID',
+      );
+    }
+    let payload: unknown;
+    try {
+      payload = JSON.parse(response.text);
+    } catch {
+      throw new BotDefinitionCloudError(
+        'CatsCo Bot Definition response is not valid JSON.',
+        'BOT_DEFINITION_RESPONSE_INVALID',
+      );
+    }
+    const definition = (payload as any)?.definition ?? payload;
+    try {
+      assertValidBotDefinition(definition, this.botId);
+    } catch {
+      throw new BotDefinitionCloudError(
+        'CatsCo Bot Definition response is invalid.',
+        'BOT_DEFINITION_RESPONSE_INVALID',
+      );
+    }
+    return { definition, etag };
+  }
+}
+
+interface BufferedCloudResponse {
+  status: number;
+  headers: Headers;
+  text: string;
+}
+
+async function readResponseTextLimited(
+  response: Response,
+  controller: AbortController,
+  maxBytes: number,
+): Promise<string> {
+  const declared = Number(response.headers.get('content-length'));
+  if (Number.isFinite(declared) && declared > maxBytes) {
+    controller.abort();
+    throw new BotDefinitionCloudError(
+      'CatsCo Bot Definition response is too large.',
+      'BOT_DEFINITION_RESPONSE_TOO_LARGE',
+    );
+  }
+  if (!response.body) return '';
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const next = await reader.read();
+    if (next.done) break;
+    total += next.value.byteLength;
+    if (total > maxBytes) {
+      controller.abort();
+      throw new BotDefinitionCloudError(
+        'CatsCo Bot Definition response is too large.',
+        'BOT_DEFINITION_RESPONSE_TOO_LARGE',
+      );
+    }
+    chunks.push(next.value);
+  }
+  const bytes = Buffer.concat(chunks.map(chunk => Buffer.from(chunk)), total);
+  return bytes.toString('utf8');
+}
+
+function safeServerErrorCode(text: string): string | undefined {
+  if (!text) return undefined;
+  try {
+    const parsed = JSON.parse(text);
+    const code = String(parsed?.error?.code || parsed?.code || '').trim();
+    return /^[A-Z0-9_.-]{1,120}$/i.test(code) ? code : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function assertTrustedBaseUrl(baseUrl: string, allowInsecureHttp: boolean): void {
+  let url: URL;
+  try {
+    url = new URL(baseUrl);
+  } catch {
+    throw new BotDefinitionCloudError('CatsCo base URL is invalid.', 'BOT_DEFINITION_BASE_URL_INVALID');
+  }
+  if (url.protocol === 'https:') return;
+  if (
+    allowInsecureHttp
+    && url.protocol === 'http:'
+    && ['127.0.0.1', 'localhost', '::1'].includes(url.hostname)
+  ) {
+    return;
+  }
+  throw new BotDefinitionCloudError(
+    'CatsCo Bot Definition requires a trusted HTTPS endpoint.',
+    'BOT_DEFINITION_BASE_URL_UNTRUSTED',
+  );
+}

--- a/src/bot-skills/file-definition-cloud.ts
+++ b/src/bot-skills/file-definition-cloud.ts
@@ -1,0 +1,130 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import type { BotDefinition, BotSkillReference } from '../bot-definition/types';
+import { assertValidBotDefinition } from '../bot-definition/validation';
+import { normalizeBotSkillReferences } from './canonical';
+import {
+  BotDefinitionCloudError,
+  type BotDefinitionCloudClient,
+  type BotDefinitionCloudReadResult,
+  type BotDefinitionCloudSnapshot,
+} from './definition-cloud';
+import { withBotSkillWorkspaceLock } from './workspace-lock';
+
+interface StoredFileDefinition {
+  revision: number;
+  definition: BotDefinition;
+}
+
+export interface FileBotDefinitionCloudClientOptions {
+  root: string;
+  botId: string;
+}
+
+export class FileBotDefinitionCloudClient implements BotDefinitionCloudClient {
+  private readonly root: string;
+  private readonly botId: string;
+
+  constructor(options: FileBotDefinitionCloudClientOptions) {
+    this.root = path.resolve(options.root);
+    this.botId = normalizeBotId(options.botId);
+  }
+
+  async read(): Promise<BotDefinitionCloudReadResult> {
+    const stored = this.readStored();
+    return stored
+      ? { kind: 'found', ...snapshot(stored) }
+      : { kind: 'missing' };
+  }
+
+  async create(definition: BotDefinition): Promise<BotDefinitionCloudSnapshot> {
+    return withBotSkillWorkspaceLock(this.getPath(), async () => {
+      assertValidBotDefinition(definition, this.botId);
+      if (this.readStored()) {
+        throw new BotDefinitionCloudError(
+          'Bot Definition already exists.',
+          'BOT_DEFINITION_PRECONDITION_FAILED',
+          412,
+        );
+      }
+      const stored = { revision: 1, definition: structuredClone(definition) };
+      this.writeStored(stored);
+      return snapshot(stored);
+    });
+  }
+
+  async patchSkills(
+    skills: BotSkillReference[],
+    ifMatch: string,
+  ): Promise<BotDefinitionCloudSnapshot> {
+    return withBotSkillWorkspaceLock(this.getPath(), async () => {
+      const stored = this.readStored();
+      if (!stored) {
+        throw new BotDefinitionCloudError('Bot Definition does not exist.', 'BOT_DEFINITION_NOT_FOUND', 404);
+      }
+      if (ifMatch !== etagOf(stored.revision)) {
+        throw new BotDefinitionCloudError(
+          'Bot Definition changed since it was read.',
+          'BOT_DEFINITION_PRECONDITION_FAILED',
+          412,
+        );
+      }
+      const next: StoredFileDefinition = {
+        revision: stored.revision + 1,
+        definition: {
+          ...stored.definition,
+          skills: normalizeBotSkillReferences(skills),
+        },
+      };
+      assertValidBotDefinition(next.definition, this.botId);
+      this.writeStored(next);
+      return snapshot(next);
+    });
+  }
+
+  getPath(): string {
+    return path.join(this.root, 'bots', `${this.botId}.json`);
+  }
+
+  private readStored(): StoredFileDefinition | undefined {
+    const filePath = this.getPath();
+    if (!fs.existsSync(filePath)) return undefined;
+    let parsed: StoredFileDefinition;
+    try {
+      parsed = JSON.parse(fs.readFileSync(filePath, 'utf8')) as StoredFileDefinition;
+      if (!Number.isInteger(parsed?.revision) || parsed.revision < 1) throw new Error('revision invalid');
+      assertValidBotDefinition(parsed.definition, this.botId);
+    } catch {
+      throw new BotDefinitionCloudError(
+        'Simulated Bot Definition is corrupt.',
+        'BOT_DEFINITION_STORAGE_CORRUPT',
+      );
+    }
+    return parsed;
+  }
+
+  private writeStored(stored: StoredFileDefinition): void {
+    const filePath = this.getPath();
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    const temporary = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+    fs.writeFileSync(temporary, `${JSON.stringify(stored, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 });
+    fs.renameSync(temporary, filePath);
+  }
+}
+
+function snapshot(stored: StoredFileDefinition): BotDefinitionCloudSnapshot {
+  return {
+    definition: structuredClone(stored.definition),
+    etag: etagOf(stored.revision),
+  };
+}
+
+function etagOf(revision: number): string {
+  return `"definition-${revision}"`;
+}
+
+function normalizeBotId(botId: string): string {
+  const value = String(botId || '').trim();
+  if (!/^[a-zA-Z0-9_.-]{1,160}$/.test(value)) throw new Error('botId contains unsupported characters');
+  return value;
+}

--- a/src/bot-skills/file-private-package.ts
+++ b/src/bot-skills/file-private-package.ts
@@ -1,0 +1,358 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+import type { BotSkillReference } from '../bot-definition/types';
+import {
+  BOT_SKILL_SOURCE_MAX_FILES,
+  BOT_SKILL_SOURCE_MAX_SINGLE_FILE_BYTES,
+  BOT_SKILL_SOURCE_MAX_TOTAL_BYTES,
+  compareBotSkillSourcePath,
+} from './source-snapshot';
+import type {
+  BotPrivateSkillPackageClient,
+  BotPrivateSkillUpsertInput,
+  BotPrivateSkillVersion,
+  BotSkillDownloadedPackage,
+} from './private-package';
+
+const FILE_PRIVATE_PACKAGE_SCHEMA = 'xiaoba.file-private-skill-package.v1';
+const MAX_STORED_PACKAGE_JSON_BYTES = 30 * 1024 * 1024;
+
+interface StoredPrivatePackage {
+  schema: typeof FILE_PRIVATE_PACKAGE_SCHEMA;
+  ownerBotId: string;
+  ownerAuthority?: string;
+  localSkillId: string;
+  name: string;
+  contentHash: string;
+  skillId: string;
+  version: string;
+  createdAt: string;
+  origin?: { skillId: string; version: string };
+  files: Array<{
+    path: string;
+    size: number;
+    sha256: string;
+    contentBase64: string;
+  }>;
+}
+
+export interface FileBotPrivateSkillPackageClientOptions {
+  root: string;
+  botId: string;
+  authority?: string;
+  now?: () => Date;
+}
+
+export class FileBotPrivateSkillPackageClient implements BotPrivateSkillPackageClient {
+  private readonly root: string;
+  private readonly botId: string;
+  private readonly authority?: string;
+  private readonly now: () => Date;
+
+  constructor(options: FileBotPrivateSkillPackageClientOptions) {
+    this.root = path.resolve(options.root);
+    this.botId = normalizeId(options.botId, 'botId');
+    this.authority = cleanOptional(options.authority);
+    this.now = options.now ?? (() => new Date());
+  }
+
+  async upsert(input: BotPrivateSkillUpsertInput): Promise<BotPrivateSkillVersion> {
+    const localSkillId = normalizeId(input.localSkillId, 'localSkillId');
+    const contentHash = normalizeHash(input.snapshot.contentHash);
+    verifySnapshot(input.snapshot, contentHash);
+    const skillId = opaqueSkillId(this.authority, this.botId, localSkillId);
+    const version = opaqueVersion(this.authority, this.botId, localSkillId, contentHash);
+    const filePath = this.packagePath(skillId, version);
+    if (fs.existsSync(filePath)) {
+      const stored = readStored(filePath, this.botId, this.authority);
+      verifyStoredIdentity(stored, { localSkillId, contentHash, skillId, version });
+      verifyStoredFiles(stored);
+      return versionFromStored(stored);
+    }
+
+    const stored: StoredPrivatePackage = {
+      schema: FILE_PRIVATE_PACKAGE_SCHEMA,
+      ownerBotId: this.botId,
+      ...(this.authority ? { ownerAuthority: this.authority } : {}),
+      localSkillId,
+      name: String(input.name || '').trim() || localSkillId,
+      contentHash,
+      skillId,
+      version,
+      createdAt: this.now().toISOString(),
+      ...(input.origin ? {
+        origin: {
+          skillId: String(input.origin.skillId || '').trim(),
+          version: String(input.origin.version || '').trim(),
+        },
+      } : {}),
+      files: input.snapshot.files.map(file => ({
+        path: file.path,
+        size: file.size,
+        sha256: file.sha256,
+        contentBase64: file.bytes.toString('base64'),
+      })),
+    };
+    writeStoredAtomic(filePath, stored);
+    return versionFromStored(stored);
+  }
+
+  async download(reference: BotSkillReference): Promise<BotSkillDownloadedPackage> {
+    const skillId = normalizeOpaqueReference(reference.skillId, 'skillId');
+    const version = String(reference.version || '').trim();
+    normalizeOpaqueReference(version, 'version');
+    const filePath = this.packagePath(skillId, version);
+    if (!fs.existsSync(filePath)) {
+      throw packageError('Private Skill package was not found.', 'PRIVATE_SKILL_NOT_FOUND', 404);
+    }
+    const stored = readStored(filePath, this.botId, this.authority);
+    if (stored.skillId !== reference.skillId || stored.version !== reference.version) {
+      throw packageError('Private Skill reference does not match stored content.', 'PRIVATE_SKILL_REFERENCE_MISMATCH', 409);
+    }
+    const files = decodeStoredFiles(stored.files);
+    verifyDownloadedFiles(files, stored.contentHash);
+    return {
+      ...versionFromStored(stored),
+      files,
+    };
+  }
+
+  getPackagePath(localSkillId: string, contentHash: string): string {
+    const normalizedLocalSkillId = normalizeId(localSkillId, 'localSkillId');
+    const normalizedContentHash = normalizeHash(contentHash);
+    return this.packagePath(
+      opaqueSkillId(this.authority, this.botId, normalizedLocalSkillId),
+      opaqueVersion(this.authority, this.botId, normalizedLocalSkillId, normalizedContentHash),
+    );
+  }
+
+  private packagePath(skillId: string, version: string): string {
+    return path.join(
+      this.root,
+      authorityScope(this.authority),
+      'bots',
+      safeSegment(this.botId),
+      'skills',
+      skillId,
+      `${version}.json`,
+    );
+  }
+}
+
+function readStored(
+  filePath: string,
+  expectedBotId: string,
+  expectedAuthority?: string,
+): StoredPrivatePackage {
+  let stored: StoredPrivatePackage;
+  try {
+    if (fs.statSync(filePath).size > MAX_STORED_PACKAGE_JSON_BYTES) {
+      throw new Error('stored package too large');
+    }
+    stored = JSON.parse(fs.readFileSync(filePath, 'utf8')) as StoredPrivatePackage;
+  } catch {
+    throw packageError('Private Skill package storage is corrupt.', 'PRIVATE_SKILL_STORAGE_CORRUPT');
+  }
+  if (
+    stored?.schema !== FILE_PRIVATE_PACKAGE_SCHEMA
+    || stored.ownerBotId !== expectedBotId
+    || cleanOptional(stored.ownerAuthority) !== expectedAuthority
+    || !stored.localSkillId
+    || !stored.skillId
+    || !stored.version
+    || !Array.isArray(stored.files)
+    || !Number.isFinite(Date.parse(stored.createdAt))
+  ) {
+    throw packageError('Private Skill package storage is corrupt.', 'PRIVATE_SKILL_STORAGE_CORRUPT');
+  }
+  return stored;
+}
+
+function verifyStoredIdentity(
+  stored: StoredPrivatePackage,
+  expected: { localSkillId: string; contentHash: string; skillId: string; version: string },
+): void {
+  if (
+    stored.localSkillId !== expected.localSkillId
+    || stored.contentHash !== expected.contentHash
+    || stored.skillId !== expected.skillId
+    || stored.version !== expected.version
+  ) {
+    throw packageError('Private Skill package identity is corrupt.', 'PRIVATE_SKILL_STORAGE_CORRUPT');
+  }
+}
+
+function verifyStoredFiles(stored: StoredPrivatePackage): void {
+  const files = decodeStoredFiles(stored.files);
+  verifyDownloadedFiles(files, stored.contentHash);
+}
+
+function decodeStoredFiles(files: StoredPrivatePackage['files']): Array<{
+  path: string;
+  size: number;
+  sha256: string;
+  bytes: Buffer;
+}> {
+  if (files.length > BOT_SKILL_SOURCE_MAX_FILES) {
+    throw packageError('Private Skill package file count is invalid.', 'PRIVATE_SKILL_PACKAGE_INVALID');
+  }
+  let declaredTotal = 0;
+  return files.map(file => {
+    if (
+      !Number.isInteger(file.size)
+      || file.size < 0
+      || file.size > BOT_SKILL_SOURCE_MAX_SINGLE_FILE_BYTES
+      || typeof file.contentBase64 !== 'string'
+      || file.contentBase64.length > Math.ceil(file.size / 3) * 4 + 4
+    ) {
+      throw packageError('Private Skill package file metadata is invalid.', 'PRIVATE_SKILL_PACKAGE_INVALID');
+    }
+    declaredTotal += file.size;
+    if (declaredTotal > BOT_SKILL_SOURCE_MAX_TOTAL_BYTES) {
+      throw packageError('Private Skill package is too large.', 'PRIVATE_SKILL_PACKAGE_INVALID');
+    }
+    return {
+      path: file.path,
+      size: file.size,
+      sha256: file.sha256,
+      bytes: Buffer.from(file.contentBase64, 'base64'),
+    };
+  });
+}
+
+function writeStoredAtomic(filePath: string, stored: StoredPrivatePackage): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const temporary = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  fs.writeFileSync(temporary, `${JSON.stringify(stored, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 });
+  fs.renameSync(temporary, filePath);
+}
+
+function versionFromStored(stored: StoredPrivatePackage): BotPrivateSkillVersion {
+  return {
+    reference: { skillId: stored.skillId, version: stored.version },
+    localSkillId: stored.localSkillId,
+    name: stored.name,
+    contentHash: stored.contentHash,
+    createdAt: stored.createdAt,
+    ...(stored.origin ? { origin: stored.origin } : {}),
+  };
+}
+
+function verifySnapshot(
+  snapshot: BotPrivateSkillUpsertInput['snapshot'],
+  expectedContentHash: string,
+): void {
+  verifyDownloadedFiles(snapshot.files, expectedContentHash);
+  if (snapshot.totalBytes !== snapshot.files.reduce((sum, file) => sum + file.size, 0)) {
+    throw packageError('Private Skill snapshot size is inconsistent.', 'PRIVATE_SKILL_SNAPSHOT_INVALID');
+  }
+}
+
+function verifyDownloadedFiles(
+  files: Array<{ path: string; size: number; sha256: string; bytes: Buffer }>,
+  expectedContentHash: string,
+): void {
+  if (files.length === 0 || files.length > BOT_SKILL_SOURCE_MAX_FILES) {
+    throw packageError('Private Skill package file count is invalid.', 'PRIVATE_SKILL_PACKAGE_INVALID');
+  }
+  let total = 0;
+  const seen = new Set<string>();
+  const canonical: Array<{ path: string; size: number; sha256: string }> = [];
+  for (const file of files) {
+    validatePackagePath(file.path);
+    if (seen.has(file.path) || file.bytes.length !== file.size || file.size > BOT_SKILL_SOURCE_MAX_SINGLE_FILE_BYTES) {
+      throw packageError('Private Skill package file metadata is invalid.', 'PRIVATE_SKILL_PACKAGE_INVALID');
+    }
+    const actualSha = sha256(file.bytes);
+    if (actualSha !== file.sha256) {
+      throw packageError('Private Skill package checksum mismatch.', 'PRIVATE_SKILL_PACKAGE_CHECKSUM_MISMATCH');
+    }
+    seen.add(file.path);
+    total += file.size;
+    if (total > BOT_SKILL_SOURCE_MAX_TOTAL_BYTES) {
+      throw packageError('Private Skill package is too large.', 'PRIVATE_SKILL_PACKAGE_INVALID');
+    }
+    canonical.push({ path: file.path, size: file.size, sha256: file.sha256 });
+  }
+  canonical.sort((a, b) => compareBotSkillSourcePath(a.path, b.path));
+  if (!seen.has('SKILL.md') || sha256(Buffer.from(JSON.stringify(canonical), 'utf8')) !== expectedContentHash) {
+    throw packageError('Private Skill package content hash mismatch.', 'PRIVATE_SKILL_PACKAGE_CHECKSUM_MISMATCH');
+  }
+}
+
+function opaqueSkillId(authority: string | undefined, botId: string, localSkillId: string): string {
+  return `priv_${opaqueHash('skill', authority, botId, localSkillId).slice(0, 40)}`;
+}
+
+function opaqueVersion(
+  authority: string | undefined,
+  botId: string,
+  localSkillId: string,
+  contentHash: string,
+): string {
+  return `v_${opaqueHash('version', authority, botId, localSkillId, contentHash).slice(0, 48)}`;
+}
+
+function opaqueHash(...parts: Array<string | undefined>): string {
+  return crypto.createHash('sha256').update(parts.map(part => part || '').join('\0')).digest('hex');
+}
+
+function normalizeOpaqueReference(value: string, label: string): string {
+  const normalized = String(value || '').trim();
+  const pattern = label === 'skillId' ? /^priv_[a-f0-9]{40}$/ : /^v_[a-f0-9]{48}$/;
+  if (!pattern.test(normalized)) {
+    throw packageError(`Private Skill ${label} is invalid.`, 'PRIVATE_SKILL_REFERENCE_INVALID', 400);
+  }
+  return normalized;
+}
+
+function normalizeId(value: string, label: string): string {
+  const normalized = String(value || '').trim();
+  if (!/^[a-zA-Z0-9_.:-]{1,160}$/.test(normalized)) throw new Error(`${label} contains unsupported characters`);
+  return normalized;
+}
+
+function normalizeHash(value: string): string {
+  const normalized = String(value || '').trim().toLowerCase();
+  if (!/^[a-f0-9]{64}$/.test(normalized)) throw new Error('contentHash is invalid');
+  return normalized;
+}
+
+function safeSegment(value: string): string {
+  return Buffer.from(value, 'utf8').toString('base64url');
+}
+
+function cleanOptional(value: unknown): string | undefined {
+  const text = String(value || '').trim();
+  return text || undefined;
+}
+
+function authorityScope(authority?: string): string {
+  return authority ? `authority-${opaqueHash(authority).slice(0, 24)}` : 'default';
+}
+
+function validatePackagePath(value: string): void {
+  const pathValue = String(value || '');
+  if (
+    !pathValue
+    || pathValue.includes('\0')
+    || pathValue.includes('\\')
+    || pathValue.startsWith('/')
+    || /^[a-zA-Z]:/.test(pathValue)
+    || pathValue.split('/').some(part => part === '' || part === '.' || part === '..')
+  ) {
+    throw packageError('Private Skill package path is unsafe.', 'PRIVATE_SKILL_PACKAGE_PATH_UNSAFE');
+  }
+}
+
+function sha256(bytes: Buffer): string {
+  return crypto.createHash('sha256').update(bytes).digest('hex');
+}
+
+function packageError(message: string, code: string, status?: number): Error {
+  const error: any = new Error(message);
+  error.code = code;
+  if (status) error.status = status;
+  return error;
+}

--- a/src/bot-skills/http-private-package.ts
+++ b/src/bot-skills/http-private-package.ts
@@ -1,0 +1,338 @@
+import * as crypto from 'crypto';
+import { normalizeBotSkillReferences } from './canonical';
+import type {
+  BotPrivateSkillPackageClient,
+  BotPrivateSkillUpsertInput,
+  BotPrivateSkillVersion,
+  BotSkillDownloadedPackage,
+} from './private-package';
+import {
+  compareBotSkillSourcePath,
+  computeBotSkillFilesContentHash,
+} from './source-snapshot';
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const MAX_RESPONSE_BYTES = 30 * 1024 * 1024;
+const MAX_FILES = 200;
+const MAX_SINGLE_FILE_BYTES = 2 * 1024 * 1024;
+const MAX_TOTAL_BYTES = 20 * 1024 * 1024;
+
+export interface HttpBotPrivateSkillPackageClientOptions {
+  baseUrl: string;
+  botId: string;
+  apiKey: string;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+  allowInsecureHttp?: boolean;
+}
+
+export class HttpBotPrivateSkillPackageClient implements BotPrivateSkillPackageClient {
+  private readonly baseUrl: string;
+  private readonly botId: string;
+  private readonly apiKey: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly timeoutMs: number;
+
+  constructor(options: HttpBotPrivateSkillPackageClientOptions) {
+    this.baseUrl = String(options.baseUrl || '').trim().replace(/\/+$/, '');
+    this.botId = String(options.botId || '').trim();
+    this.apiKey = String(options.apiKey || '').trim();
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    if (!this.baseUrl || !this.botId || !this.apiKey) {
+      throw packageError('Bot private Skill package credentials are incomplete.', 'BOT_SKILL_PACKAGE_AUTH_INCOMPLETE');
+    }
+    assertTrustedBaseUrl(this.baseUrl, options.allowInsecureHttp === true);
+  }
+
+  async upsert(input: BotPrivateSkillUpsertInput): Promise<BotPrivateSkillVersion> {
+    const payload = {
+      localSkillId: input.localSkillId,
+      name: input.name,
+      contentHash: input.snapshot.contentHash,
+      ...(input.origin ? { origin: input.origin } : {}),
+      files: input.snapshot.files.map(file => ({
+        path: file.path,
+        size: file.size,
+        sha256: file.sha256,
+        contentBase64: file.bytes.toString('base64'),
+      })),
+    };
+    const value = await this.request(
+      'PUT',
+      '/api/bot/private-skill-packages',
+      payload,
+    );
+    return parseVersion(value, {
+      localSkillId: input.localSkillId,
+      name: input.name,
+      contentHash: input.snapshot.contentHash,
+      origin: input.origin,
+    });
+  }
+
+  async download(reference: { skillId: string; version: string }): Promise<BotSkillDownloadedPackage> {
+    normalizeBotSkillReferences([reference]);
+    const value = await this.request(
+      'GET',
+      `/api/bot/skill-packages/${encodeURIComponent(reference.skillId)}/versions/${encodeURIComponent(reference.version)}`,
+    );
+    const raw = unwrapPackage(value);
+    const version = parseVersion(raw);
+    if (
+      version.reference.skillId !== reference.skillId
+      || version.reference.version !== reference.version
+    ) {
+      throw packageError('Downloaded Skill package reference mismatch.', 'BOT_SKILL_PACKAGE_REFERENCE_MISMATCH');
+    }
+    const rawFiles = raw?.files;
+    if (!Array.isArray(rawFiles) || rawFiles.length === 0 || rawFiles.length > MAX_FILES) {
+      throw packageError('Downloaded Skill package file list is invalid.', 'BOT_SKILL_PACKAGE_FILES_INVALID');
+    }
+    let totalBytes = 0;
+    const seen = new Set<string>();
+    const files = rawFiles.map((raw: any) => {
+      const filePath = safePackagePath(raw?.path);
+      const portablePath = filePath.toLocaleLowerCase('en-US');
+      if (seen.has(portablePath)) {
+        throw packageError('Downloaded Skill package contains duplicate files.', 'BOT_SKILL_PACKAGE_FILES_INVALID');
+      }
+      seen.add(portablePath);
+      const declaredSize = Number(raw?.size);
+      const declaredHash = String(raw?.sha256 || '').trim();
+      const encoded = typeof raw?.contentBase64 === 'string' ? raw.contentBase64 : undefined;
+      if (
+        !Number.isInteger(declaredSize)
+        || declaredSize < 0
+        || declaredSize > MAX_SINGLE_FILE_BYTES
+        || !/^[a-f0-9]{64}$/.test(declaredHash)
+        || encoded === undefined
+        || encoded.length > Math.ceil(MAX_SINGLE_FILE_BYTES / 3) * 4 + 8
+      ) {
+        throw packageError('Downloaded Skill package file metadata is invalid.', 'BOT_SKILL_PACKAGE_FILES_INVALID');
+      }
+      const bytes = decodeBase64Exact(encoded, declaredSize);
+      totalBytes += bytes.length;
+      if (
+        bytes.length !== declaredSize
+        || totalBytes > MAX_TOTAL_BYTES
+        || sha256(bytes) !== declaredHash
+      ) {
+        throw packageError('Downloaded Skill package bytes failed verification.', 'BOT_SKILL_PACKAGE_HASH_MISMATCH');
+      }
+      return { path: filePath, size: bytes.length, sha256: declaredHash, bytes };
+    }).sort((a, b) => compareBotSkillSourcePath(a.path, b.path));
+    if (!files.some(file => file.path === 'SKILL.md')) {
+      throw packageError('Downloaded Skill package is missing SKILL.md.', 'BOT_SKILL_PACKAGE_ENTRY_MISSING');
+    }
+    if (computeBotSkillFilesContentHash(files) !== version.contentHash) {
+      throw packageError('Downloaded Skill package content hash mismatch.', 'BOT_SKILL_PACKAGE_HASH_MISMATCH');
+    }
+    return { ...version, files };
+  }
+
+  private async request(method: string, apiPath: string, body?: unknown): Promise<unknown> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const response = await this.fetchImpl(`${this.baseUrl}${apiPath}`, {
+        method,
+        headers: {
+          Accept: 'application/json',
+          Authorization: `ApiKey ${this.apiKey}`,
+          'X-CatsCo-Bot-Id': this.botId,
+          ...(body === undefined ? {} : { 'Content-Type': 'application/json' }),
+        },
+        body: body === undefined ? undefined : JSON.stringify(body),
+        redirect: 'error',
+        signal: controller.signal,
+      });
+      const text = await readResponseTextLimited(response, controller);
+      if (!response.ok) {
+        throw packageError(
+          `Bot private Skill package request failed: HTTP ${response.status}`,
+          safeServerErrorCode(text) || `BOT_SKILL_PACKAGE_HTTP_${response.status}`,
+          response.status,
+        );
+      }
+      try {
+        return JSON.parse(text);
+      } catch {
+        throw packageError('Bot private Skill package response is invalid.', 'BOT_SKILL_PACKAGE_RESPONSE_INVALID');
+      }
+    } catch (error: any) {
+      if (error?.name === 'BotPrivateSkillPackageError') throw error;
+      throw packageError(
+        error?.name === 'AbortError'
+          ? 'Bot private Skill package request timed out.'
+          : 'Bot private Skill package request failed.',
+        error?.name === 'AbortError' ? 'BOT_SKILL_PACKAGE_TIMEOUT' : 'BOT_SKILL_PACKAGE_NETWORK_ERROR',
+      );
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+function parseVersion(
+  value: unknown,
+  expected?: {
+    localSkillId: string;
+    name: string;
+    contentHash: string;
+    origin?: { skillId: string; version: string };
+  },
+): BotPrivateSkillVersion {
+  const raw = unwrapPackage(value);
+  const reference = raw?.reference;
+  normalizeBotSkillReferences([reference]);
+  const localSkillId = String(raw?.localSkillId || '').trim();
+  const name = String(raw?.name || '').trim();
+  const contentHash = String(raw?.contentHash || '').trim();
+  const createdAt = String(raw?.createdAt || '').trim();
+  if (
+    !/^[a-zA-Z0-9._:-]{1,160}$/.test(localSkillId)
+    || !name
+    || name.length > 256
+    || !/^[a-f0-9]{64}$/.test(contentHash)
+    || !Number.isFinite(Date.parse(createdAt))
+    || (expected && localSkillId !== expected.localSkillId)
+    || (expected && name !== expected.name)
+    || (expected && contentHash !== expected.contentHash)
+  ) {
+    throw packageError('Bot private Skill package response mismatch.', 'BOT_SKILL_PACKAGE_RESPONSE_MISMATCH');
+  }
+  const origin = raw?.origin;
+  if (origin !== undefined) normalizeBotSkillReferences([origin]);
+  if (
+    expected
+    && (
+      Boolean(origin) !== Boolean(expected.origin)
+      || (
+        origin
+        && expected.origin
+        && (
+          origin.skillId !== expected.origin.skillId
+          || origin.version !== expected.origin.version
+        )
+      )
+    )
+  ) {
+    throw packageError('Bot private Skill package origin mismatch.', 'BOT_SKILL_PACKAGE_RESPONSE_MISMATCH');
+  }
+  return {
+    reference,
+    localSkillId,
+    name,
+    contentHash,
+    createdAt,
+    ...(origin ? { origin } : {}),
+  };
+}
+
+function unwrapPackage(value: unknown): any {
+  return (value as any)?.package ?? value as any;
+}
+
+async function readResponseTextLimited(response: Response, controller: AbortController): Promise<string> {
+  const declared = Number(response.headers.get('content-length'));
+  if (Number.isFinite(declared) && declared > MAX_RESPONSE_BYTES) {
+    controller.abort();
+    throw packageError('Bot private Skill package response is too large.', 'BOT_SKILL_PACKAGE_RESPONSE_TOO_LARGE');
+  }
+  if (!response.body) return '';
+  const reader = response.body.getReader();
+  const chunks: Buffer[] = [];
+  let total = 0;
+  while (true) {
+    const next = await reader.read();
+    if (next.done) break;
+    total += next.value.byteLength;
+    if (total > MAX_RESPONSE_BYTES) {
+      controller.abort();
+      throw packageError('Bot private Skill package response is too large.', 'BOT_SKILL_PACKAGE_RESPONSE_TOO_LARGE');
+    }
+    chunks.push(Buffer.from(next.value));
+  }
+  return Buffer.concat(chunks, total).toString('utf8');
+}
+
+function safePackagePath(value: unknown): string {
+  const filePath = String(value || '').replace(/\\/g, '/');
+  if (
+    !filePath
+    || filePath.includes('\0')
+    || filePath.startsWith('/')
+    || /^[a-zA-Z]:/.test(filePath)
+    || filePath.split('/').some(part => (
+      part === ''
+      || part === '.'
+      || part === '..'
+      || !portableWindowsSegment(part)
+    ))
+  ) {
+    throw packageError('Downloaded Skill package path is unsafe.', 'BOT_SKILL_PACKAGE_PATH_UNSAFE');
+  }
+  return filePath;
+}
+
+function portableWindowsSegment(value: string): boolean {
+  if (!value || /[<>:"|?*]/.test(value) || /[. ]$/.test(value)) return false;
+  const stem = value.split('.')[0].toUpperCase();
+  return !/^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])$/.test(stem);
+}
+
+function decodeBase64Exact(value: string, declaredSize: number): Buffer {
+  if (
+    (value.length === 0 && declaredSize !== 0)
+    || !/^[A-Za-z0-9+/]*={0,2}$/.test(value)
+    || value.length % 4 !== 0
+  ) {
+    throw packageError('Downloaded Skill package encoding is invalid.', 'BOT_SKILL_PACKAGE_FILES_INVALID');
+  }
+  const bytes = Buffer.from(value, 'base64');
+  if (bytes.toString('base64') !== value) {
+    throw packageError('Downloaded Skill package encoding is invalid.', 'BOT_SKILL_PACKAGE_FILES_INVALID');
+  }
+  return bytes;
+}
+
+function sha256(bytes: Buffer): string {
+  return crypto.createHash('sha256').update(bytes).digest('hex');
+}
+
+function safeServerErrorCode(text: string): string | undefined {
+  try {
+    const parsed = JSON.parse(text);
+    const code = String(parsed?.error?.code || parsed?.code || '').trim();
+    return /^[A-Z0-9_.-]{1,120}$/i.test(code) ? code : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function assertTrustedBaseUrl(baseUrl: string, allowInsecureHttp: boolean): void {
+  let url: URL;
+  try {
+    url = new URL(baseUrl);
+  } catch {
+    throw packageError('SkillHub base URL is invalid.', 'BOT_SKILL_PACKAGE_BASE_URL_INVALID');
+  }
+  if (url.protocol === 'https:') return;
+  if (
+    allowInsecureHttp
+    && url.protocol === 'http:'
+    && ['127.0.0.1', 'localhost', '::1'].includes(url.hostname)
+  ) {
+    return;
+  }
+  throw packageError('SkillHub requires a trusted HTTPS endpoint.', 'BOT_SKILL_PACKAGE_BASE_URL_UNTRUSTED');
+}
+
+function packageError(message: string, code: string, status?: number): Error {
+  const error: any = new Error(message);
+  error.name = 'BotPrivateSkillPackageError';
+  error.code = code;
+  if (status !== undefined) error.status = status;
+  return error;
+}

--- a/src/bot-skills/mutation-events.ts
+++ b/src/bot-skills/mutation-events.ts
@@ -1,0 +1,21 @@
+import * as path from 'path';
+
+export type BotSkillMutationListener = (skillsRoot: string) => void;
+
+const listeners = new Set<BotSkillMutationListener>();
+
+export function onBotSkillMutation(listener: BotSkillMutationListener): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function notifyBotSkillMutation(skillsRoot: string): void {
+  const resolved = path.resolve(skillsRoot);
+  for (const listener of listeners) {
+    try {
+      listener(resolved);
+    } catch {
+      // Mutation notification is advisory; the next startup scan is the fallback.
+    }
+  }
+}

--- a/src/bot-skills/new-bot-intent.ts
+++ b/src/bot-skills/new-bot-intent.ts
@@ -1,0 +1,71 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface BotSkillNewBotIntent {
+  schema: 'xiaoba.bot-skill-new-bot-intent.v1';
+  botId: string;
+  authority: string;
+  ownerUserId: string;
+  createdAt: string;
+}
+
+export class FileBotSkillNewBotIntentStore {
+  constructor(private readonly runtimeRoot: string) {}
+
+  write(input: Omit<BotSkillNewBotIntent, 'schema' | 'createdAt'>): void {
+    const intent: BotSkillNewBotIntent = {
+      schema: 'xiaoba.bot-skill-new-bot-intent.v1',
+      botId: clean(input.botId),
+      authority: normalizeAuthority(input.authority),
+      ownerUserId: clean(input.ownerUserId),
+      createdAt: new Date().toISOString(),
+    };
+    if (!intent.botId || !intent.ownerUserId) throw new Error('New Bot intent identity is incomplete.');
+    const filePath = this.getPath(intent.botId);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    const temporary = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+    fs.writeFileSync(temporary, `${JSON.stringify(intent, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 });
+    fs.renameSync(temporary, filePath);
+  }
+
+  matches(input: { botId: string; authority: string; ownerUserId?: string }): boolean {
+    const filePath = this.getPath(input.botId);
+    if (!fs.existsSync(filePath)) return false;
+    try {
+      const value = JSON.parse(fs.readFileSync(filePath, 'utf8')) as BotSkillNewBotIntent;
+      return Boolean(
+        value?.schema === 'xiaoba.bot-skill-new-bot-intent.v1'
+        && value.botId === clean(input.botId)
+        && value.authority === normalizeAuthority(input.authority)
+        && value.ownerUserId === clean(input.ownerUserId)
+        && Date.now() - Date.parse(value.createdAt) <= 7 * 24 * 60 * 60 * 1000,
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  delete(botId: string): void {
+    fs.rmSync(this.getPath(botId), { force: true });
+  }
+
+  private getPath(botId: string): string {
+    const key = Buffer.from(clean(botId), 'utf8').toString('base64url');
+    if (!key) throw new Error('botId is required');
+    return path.join(
+      path.resolve(this.runtimeRoot),
+      'data',
+      'bot-skills',
+      'new-bot-intents',
+      `${key}.json`,
+    );
+  }
+}
+
+function normalizeAuthority(value: string): string {
+  return new URL(String(value || '').trim()).origin.toLowerCase();
+}
+
+function clean(value: unknown): string {
+  return String(value || '').trim();
+}

--- a/src/bot-skills/pending-commit-store.ts
+++ b/src/bot-skills/pending-commit-store.ts
@@ -1,0 +1,124 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { PathResolver } from '../utils/path-resolver';
+import { normalizeBotSkillReferences, normalizeBotSkillSyncBaseEntries } from './canonical';
+import type { BotSkillReference } from '../bot-definition/types';
+import type { BotSkillSyncBaseEntry } from './types';
+
+export const BOT_SKILL_PENDING_COMMIT_SCHEMA = 'xiaoba.bot-skill-pending-commit.v1';
+
+export interface BotSkillPendingCommit {
+  schema: typeof BOT_SKILL_PENDING_COMMIT_SCHEMA;
+  kind: 'cloud_update' | 'restore';
+  phase: 'prepared' | 'old_parked' | 'activated' | 'base_committed';
+  botId: string;
+  workspaceId: string;
+  authority?: string;
+  definitionETag?: string;
+  cloudReferences: BotSkillReference[];
+  entries: BotSkillSyncBaseEntry[];
+  createdAt: string;
+  updatedAt: string;
+  restore?: {
+    activeRoot: string;
+    stagingRoot: string;
+    backupRoot: string;
+    hadActive: boolean;
+  };
+}
+
+export class FileBotSkillPendingCommitStore {
+  private readonly filePath: string;
+  private readonly authority?: string;
+
+  constructor(options: {
+    runtimeRoot?: string;
+    filePath?: string;
+    authority?: string;
+    botId?: string;
+  } = {}) {
+    const runtimeRoot = path.resolve(options.runtimeRoot ?? PathResolver.getRuntimeDataRoot());
+    this.filePath = path.resolve(
+      options.filePath ?? path.join(
+        runtimeRoot,
+        'data',
+        'bot-skill-sync-pending',
+        safeScope(options.authority || 'local'),
+        options.botId ? safeScope(options.botId) : '',
+        'pending.json',
+      ),
+    );
+    this.authority = cleanOptional(options.authority);
+  }
+
+  read(): BotSkillPendingCommit | undefined {
+    if (!fs.existsSync(this.filePath)) return undefined;
+    try {
+      const parsed = JSON.parse(fs.readFileSync(this.filePath, 'utf8')) as BotSkillPendingCommit;
+      if (
+        parsed?.schema !== BOT_SKILL_PENDING_COMMIT_SCHEMA
+        || !['cloud_update', 'restore'].includes(parsed.kind)
+        || !['prepared', 'old_parked', 'activated', 'base_committed'].includes(parsed.phase)
+        || !parsed.botId
+        || !parsed.workspaceId
+        || cleanOptional(parsed.authority) !== this.authority
+        || !Array.isArray(parsed.cloudReferences)
+        || !Array.isArray(parsed.entries)
+        || !Number.isFinite(Date.parse(parsed.createdAt))
+        || !Number.isFinite(Date.parse(parsed.updatedAt))
+      ) {
+        throw new Error('invalid pending commit');
+      }
+      if (
+        parsed.kind === 'restore'
+        && (
+          !parsed.restore
+          || !path.isAbsolute(parsed.restore.activeRoot)
+          || !path.isAbsolute(parsed.restore.stagingRoot)
+          || !path.isAbsolute(parsed.restore.backupRoot)
+        )
+      ) {
+        throw new Error('invalid restore pending commit');
+      }
+      return {
+        ...parsed,
+        cloudReferences: normalizeBotSkillReferences(parsed.cloudReferences),
+        entries: normalizeBotSkillSyncBaseEntries(parsed.entries),
+      };
+    } catch {
+      const error: any = new Error('Bot Skill pending commit is corrupt.');
+      error.code = 'BOT_SKILL_PENDING_COMMIT_CORRUPT';
+      throw error;
+    }
+  }
+
+  write(pending: BotSkillPendingCommit): void {
+    const normalized: BotSkillPendingCommit = {
+      ...pending,
+      ...(this.authority ? { authority: this.authority } : {}),
+      cloudReferences: normalizeBotSkillReferences(pending.cloudReferences),
+      entries: normalizeBotSkillSyncBaseEntries(pending.entries),
+    };
+    fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
+    const temporary = `${this.filePath}.${process.pid}.${Date.now()}.tmp`;
+    fs.writeFileSync(temporary, `${JSON.stringify(normalized, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 });
+    fs.renameSync(temporary, this.filePath);
+  }
+
+  delete(): void {
+    fs.rmSync(this.filePath, { force: true });
+  }
+
+  getPath(): string {
+    return this.filePath;
+  }
+}
+
+function safeScope(value: string): string {
+  return Buffer.from(String(value || '').trim(), 'utf8').toString('base64url') || 'unknown';
+}
+
+function cleanOptional(value: unknown): string | undefined {
+  const text = String(value || '').trim();
+  return text || undefined;
+}

--- a/src/bot-skills/private-package.ts
+++ b/src/bot-skills/private-package.ts
@@ -1,0 +1,37 @@
+import type { BotSkillReference } from '../bot-definition/types';
+import type { BotSkillSourceSnapshot } from './source-snapshot';
+
+export interface BotPrivateSkillOrigin {
+  skillId: string;
+  version: string;
+}
+
+export interface BotPrivateSkillUpsertInput {
+  localSkillId: string;
+  name: string;
+  snapshot: BotSkillSourceSnapshot;
+  origin?: BotPrivateSkillOrigin;
+}
+
+export interface BotPrivateSkillVersion {
+  reference: BotSkillReference;
+  localSkillId: string;
+  name: string;
+  contentHash: string;
+  createdAt: string;
+  origin?: BotPrivateSkillOrigin;
+}
+
+export interface BotSkillDownloadedPackage extends BotPrivateSkillVersion {
+  files: Array<{
+    path: string;
+    size: number;
+    sha256: string;
+    bytes: Buffer;
+  }>;
+}
+
+export interface BotPrivateSkillPackageClient {
+  upsert(input: BotPrivateSkillUpsertInput): Promise<BotPrivateSkillVersion>;
+  download(reference: BotSkillReference): Promise<BotSkillDownloadedPackage>;
+}

--- a/src/bot-skills/runtime.ts
+++ b/src/bot-skills/runtime.ts
@@ -1,0 +1,295 @@
+import * as crypto from 'crypto';
+import * as path from 'path';
+import type { CatsCoAuthSnapshot } from '../catscompany/local-config';
+import { FileBotDefinitionRepository } from '../bot-definition/repository';
+import type { BotDefinition } from '../bot-definition/types';
+import { bootstrapDefaultSkillHubSkills } from '../skillhub/default-skill-bootstrap';
+import { loadSkillHubConfig } from '../skillhub/config';
+import { FileBotSkillSyncBaseStore } from './base-store';
+import type { BotDefinitionCloudClient } from './definition-cloud';
+import { HttpBotDefinitionCloudClient } from './definition-cloud';
+import { FileBotDefinitionCloudClient } from './file-definition-cloud';
+import { FileBotPrivateSkillPackageClient } from './file-private-package';
+import { HttpBotPrivateSkillPackageClient } from './http-private-package';
+import type { BotPrivateSkillPackageClient } from './private-package';
+import { FileBotSkillPendingCommitStore } from './pending-commit-store';
+import {
+  BotSkillSyncService,
+  type BotSkillSyncRepairStrategy,
+  type BotSkillSyncRequest,
+  type BotSkillSyncResult,
+} from './sync-service';
+import { BotSkillWorkspaceService, type BotSkillWorkspaceOwner } from './workspace';
+import { withBotSkillWorkspaceLock } from './workspace-lock';
+
+export interface BotSkillRuntimeOptions {
+  runtimeRoot: string;
+  auth: CatsCoAuthSnapshot;
+  botId?: string;
+  skillsRoot?: string;
+  cloud?: BotDefinitionCloudClient;
+  packages?: BotPrivateSkillPackageClient;
+  skillHubBaseUrl?: string;
+  transport?: 'http' | 'file';
+  fetchImpl?: typeof fetch;
+  debounceMs?: number;
+  canRunScheduledSync?(): boolean;
+  onBackgroundError?(error: unknown): void;
+}
+
+export interface BotSkillRuntimeSyncOptions {
+  definitionForCreate?: BotDefinition;
+  allowLegacyClaim?: boolean;
+  allowNewWorkspaceCreate?: boolean;
+  initializeDefaultSkill?: boolean;
+}
+
+export interface BotSkillRuntimeSyncOutcome {
+  result: BotSkillSyncResult;
+  definition?: BotDefinition;
+}
+
+export class BotSkillRuntime {
+  readonly owner: BotSkillWorkspaceOwner;
+  readonly workspace: BotSkillWorkspaceService;
+  private readonly syncService: BotSkillSyncService;
+  private readonly definitions: FileBotDefinitionRepository;
+  private readonly runtimeRoot: string;
+  private readonly debounceMs: number;
+  private timer?: NodeJS.Timeout;
+  private running?: Promise<BotSkillRuntimeSyncOutcome>;
+  private rerun = false;
+  private lastOptions: BotSkillRuntimeSyncOptions = {};
+  private readonly onBackgroundError?: (error: unknown) => void;
+  private readonly canRunScheduledSync?: () => boolean;
+
+  constructor(options: BotSkillRuntimeOptions) {
+    this.runtimeRoot = path.resolve(options.runtimeRoot);
+    const botId = String(options.botId || options.auth.botUid || '').trim();
+    const apiKey = String(options.auth.apiKey || '').trim();
+    if (!botId || !apiKey) throw runtimeError('Bound Bot credentials are incomplete.', 'BOT_SKILL_RUNTIME_AUTH_INCOMPLETE');
+    const authority = normalizeAuthority(options.auth.httpBaseUrl);
+    this.owner = {
+      botId,
+      authority,
+      ...(String(options.auth.uid || '').trim() ? { ownerUserId: String(options.auth.uid).trim() } : {}),
+    };
+    const skillsRoot = path.resolve(options.skillsRoot ?? path.join(this.runtimeRoot, 'skills'));
+    this.workspace = new BotSkillWorkspaceService({ runtimeRoot: this.runtimeRoot, skillsRoot });
+    this.definitions = new FileBotDefinitionRepository({ runtimeRoot: this.runtimeRoot });
+    const transport = options.transport ?? 'http';
+    const cloud = options.cloud ?? (transport === 'file'
+      ? new FileBotDefinitionCloudClient({
+        root: path.join(this.runtimeRoot, 'data', 'bot-skill-test-cloud', 'definitions'),
+        botId,
+      })
+      : new HttpBotDefinitionCloudClient({
+        botId,
+        auth: options.auth,
+        fetchImpl: options.fetchImpl,
+        allowInsecureHttp: isLocalHttp(options.auth.httpBaseUrl),
+      }));
+    const packages = options.packages ?? (transport === 'file'
+      ? new FileBotPrivateSkillPackageClient({
+        root: path.join(this.runtimeRoot, 'data', 'bot-skill-test-cloud', 'packages'),
+        botId,
+        authority,
+      })
+      : new HttpBotPrivateSkillPackageClient({
+        baseUrl: options.skillHubBaseUrl ?? loadSkillHubConfig().baseUrl,
+        botId,
+        apiKey,
+        fetchImpl: options.fetchImpl,
+      }));
+    this.syncService = new BotSkillSyncService({
+      workspace: this.workspace,
+      baseStore: new FileBotSkillSyncBaseStore({ runtimeRoot: this.runtimeRoot, authority }),
+      cloud,
+      packages,
+      definitionCache: this.definitions,
+      pendingStore: new FileBotSkillPendingCommitStore({
+        runtimeRoot: this.runtimeRoot,
+        authority,
+        botId,
+      }),
+    });
+    this.debounceMs = Math.max(0, options.debounceMs ?? 1_000);
+    this.onBackgroundError = options.onBackgroundError;
+    this.canRunScheduledSync = options.canRunScheduledSync;
+  }
+
+  async sync(options: BotSkillRuntimeSyncOptions = {}): Promise<BotSkillRuntimeSyncOutcome> {
+    this.lastOptions = { ...this.lastOptions, ...options };
+    const definitionForCreate = options.definitionForCreate
+      ?? this.definitions.readCache(this.owner.botId);
+    const request: BotSkillSyncRequest = {
+      owner: this.owner,
+      ...options,
+      ...(definitionForCreate ? { definitionForCreate } : {}),
+      ...(options.allowNewWorkspaceCreate && options.initializeDefaultSkill
+        ? {
+          initializeNewWorkspace: async () => {
+            const stateKey = crypto
+              .createHash('sha256')
+              .update(`${this.owner.authority}\0${this.owner.botId}`)
+              .digest('hex');
+            const results = await bootstrapDefaultSkillHubSkills({
+              skillsRoot: this.workspace.root,
+              statePath: path.join(
+                this.runtimeRoot,
+                'data',
+                'bot-skills',
+                'default-bootstrap',
+                `${stateKey}.json`,
+              ),
+            });
+            const failed = results.find(result => result.state === 'failed');
+            if (failed) {
+              throw runtimeError(
+                `Default Skill initialization failed: ${failed.key}`,
+                'BOT_SKILL_DEFAULT_INITIALIZATION_FAILED',
+              );
+            }
+          },
+        }
+        : {}),
+    };
+    const result = await this.syncService.sync(request);
+    return {
+      result,
+      definition: this.definitions.readCache(this.owner.botId),
+    };
+  }
+
+  async repair(strategy: BotSkillSyncRepairStrategy): Promise<BotSkillRuntimeSyncOutcome> {
+    const definitionForCreate = this.definitions.readCache(this.owner.botId);
+    const result = await this.syncService.repair({
+      owner: this.owner,
+      ...(definitionForCreate ? { definitionForCreate } : {}),
+    }, strategy);
+    return {
+      result,
+      definition: this.definitions.readCache(this.owner.botId),
+    };
+  }
+
+  schedule(options: BotSkillRuntimeSyncOptions = {}): void {
+    this.lastOptions = { ...this.lastOptions, ...options };
+    if (this.running) {
+      this.rerun = true;
+      return;
+    }
+    if (this.timer) clearTimeout(this.timer);
+    this.timer = setTimeout(() => {
+      this.timer = undefined;
+      if (this.canRunScheduledSync && !this.canRunScheduledSync()) {
+        this.schedule();
+        return;
+      }
+      void this.runScheduled();
+    }, this.debounceMs);
+    this.timer.unref?.();
+  }
+
+  async mutate<T>(operation: () => Promise<T> | T): Promise<T> {
+    const result = await withBotSkillWorkspaceLock(this.workspace.root, async () => operation());
+    this.schedule();
+    return result;
+  }
+
+  async flush(): Promise<BotSkillRuntimeSyncOutcome | undefined> {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = undefined;
+      return this.runScheduled();
+    }
+    return this.running;
+  }
+
+  private runScheduled(): Promise<BotSkillRuntimeSyncOutcome> {
+    if (this.running) {
+      this.rerun = true;
+      return this.running;
+    }
+    const run = this.sync(this.lastOptions);
+    this.running = run;
+    const finish = () => {
+      if (this.running === run) this.running = undefined;
+      if (this.rerun) {
+        this.rerun = false;
+        this.schedule();
+      }
+    };
+    void run.then(
+      finish,
+      error => {
+        this.onBackgroundError?.(error);
+        finish();
+      },
+    );
+    return run;
+  }
+}
+
+export function isBotSkillRuntimeEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return /^(1|true|yes|on)$/i.test(String(env.XIAOBA_BOT_SKILL_SYNC_ENABLED || '').trim());
+}
+
+export function resolveBotSkillRuntimeTransport(
+  env: NodeJS.ProcessEnv = process.env,
+): 'http' | 'file' {
+  return String(env.XIAOBA_BOT_SKILL_SYNC_TRANSPORT || '').trim().toLowerCase() === 'file'
+    ? 'file'
+    : 'http';
+}
+
+export function assertBotSkillStartupReady(
+  outcome: BotSkillRuntimeSyncOutcome,
+  workspace: BotSkillWorkspaceService,
+  owner: BotSkillWorkspaceOwner,
+): void {
+  const localIsValid = workspace.inspect(owner).kind === 'valid';
+  if (
+    outcome.result.action === 'blocked'
+    || (outcome.result.action === 'conflict' && !localIsValid)
+  ) {
+    throw runtimeError(
+      `Bot Skill workspace is not ready: ${outcome.result.reason || outcome.result.action}`,
+      'BOT_SKILL_STARTUP_BLOCKED',
+    );
+  }
+  if (outcome.result.action === 'degraded_local' && !localIsValid) {
+    throw runtimeError(
+      'Bot Skill cloud is unavailable and no valid local workspace exists.',
+      'BOT_SKILL_STARTUP_BLOCKED',
+    );
+  }
+}
+
+function normalizeAuthority(value: string): string {
+  let url: URL;
+  try {
+    url = new URL(String(value || '').trim());
+  } catch {
+    throw runtimeError('CatsCo authority is invalid.', 'BOT_SKILL_RUNTIME_AUTHORITY_INVALID');
+  }
+  if (!['https:', 'http:'].includes(url.protocol)) {
+    throw runtimeError('CatsCo authority is invalid.', 'BOT_SKILL_RUNTIME_AUTHORITY_INVALID');
+  }
+  return url.origin.toLowerCase();
+}
+
+function isLocalHttp(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' && ['localhost', '127.0.0.1', '::1'].includes(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
+function runtimeError(message: string, code: string): Error {
+  const error: any = new Error(message);
+  error.code = code;
+  return error;
+}

--- a/src/bot-skills/source-snapshot.ts
+++ b/src/bot-skills/source-snapshot.ts
@@ -317,13 +317,32 @@ function containsHighConfidenceSecret(bytes: Buffer): boolean {
   if (/\bxox[baprs]-[A-Za-z0-9-]{20,}\b/.test(text)) return true;
   if (/\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}\b/.test(text)) return true;
   const assignments = text.matchAll(
-    /\b(?:api[_-]?key|access[_-]?token|auth[_-]?token|client[_-]?secret|password)\b\s*[:=]\s*["']?([^\s"'#]{16,})/gi,
+    /(?=(?:^|[^A-Za-z0-9_-])["']?(?<key>[A-Za-z_][A-Za-z0-9_.-]{0,127})["']?\]?\s*(?:[?+]?=|:)\s*(?:"(?<double>[^"\r\n]*)"|'(?<single>[^'\r\n]*)'|(?<bare>[^\s#,;]+)))/gm,
   );
   for (const match of assignments) {
-    const candidate = String(match[1] || '').toLowerCase();
-    if (!/(example|placeholder|dummy|changeme|your[_-]|test[_-]|\*{3,})/.test(candidate)) return true;
+    const key = String(match.groups?.key || '').replace(/[^A-Za-z0-9]/g, '').toLowerCase();
+    if (!/(?:apikey|accesstoken|authtoken|clientsecret|secretaccesskey|secretkey|password|passwd|token|secret)$/.test(key)) {
+      continue;
+    }
+    const candidate = String(
+      match.groups?.double ?? match.groups?.single ?? match.groups?.bare ?? '',
+    ).toLowerCase();
+    if (!isExplicitSafeCredentialValue(key, candidate)) return true;
   }
   return false;
+}
+
+function isExplicitSafeCredentialValue(key: string, candidate: string): boolean {
+  return (
+    candidate === ''
+    || /^\$\{[a-z_][a-z0-9_]*\}$/.test(candidate)
+    || (
+      /(?:password|passwd)$/.test(key)
+      && /^(?:minimum|maximum)[-_]length[-_]\d+$/.test(candidate)
+    )
+    || /^(?:string|number|boolean|unknown|null|undefined|z\.string\(\)(?:\.min\(\d+\))?)$/.test(candidate)
+    || /^(?:example[-_](?:api[-_]?key|token|secret|password)|placeholder(?:[-_]value)?|dummy[-_]value|changeme(?:[-_]please)?|your[-_](?:api[-_]?key|token|secret|password)[-_]here|\*{3,})$/.test(candidate)
+  );
 }
 
 function sha256(bytes: Buffer): string {

--- a/src/bot-skills/source-snapshot.ts
+++ b/src/bot-skills/source-snapshot.ts
@@ -1,0 +1,331 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+
+export const BOT_SKILL_SOURCE_MAX_FILES = 200;
+export const BOT_SKILL_SOURCE_MAX_SINGLE_FILE_BYTES = 2 * 1024 * 1024;
+export const BOT_SKILL_SOURCE_MAX_TOTAL_BYTES = 20 * 1024 * 1024;
+
+export interface BotSkillSourceFile {
+  path: string;
+  size: number;
+  sha256: string;
+  bytes: Buffer;
+}
+
+export interface BotSkillSourceSnapshot {
+  root: string;
+  contentHash: string;
+  totalBytes: number;
+  files: BotSkillSourceFile[];
+}
+
+export function computeBotSkillFilesContentHash(
+  files: ReadonlyArray<Pick<BotSkillSourceFile, 'path' | 'size' | 'sha256'>>,
+): string {
+  return contentHashOf([...files].sort((a, b) => compareBotSkillSourcePath(a.path, b.path)));
+}
+
+/**
+ * Canonical Skill file ordering must not depend on the host ICU locale.
+ * Relational string comparison is stable UTF-16 code-unit ordering.
+ */
+export function compareBotSkillSourcePath(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+export class BotSkillSourceError extends Error {
+  constructor(
+    message: string,
+    public readonly code: string,
+    public readonly relativePaths: string[] = [],
+  ) {
+    super(message);
+    this.name = 'BotSkillSourceError';
+  }
+}
+
+const IGNORED_DIRECTORIES = new Set([
+  '.git',
+  'node_modules',
+  '__pycache__',
+  '.venv',
+  'venv',
+  'dist',
+  'build',
+  'release',
+]);
+
+const FORBIDDEN_DIRECTORIES = new Set([
+  '.ssh',
+  '.aws',
+  '.kube',
+  '.gnupg',
+]);
+
+const GENERATED_FILES = new Set([
+  'skill.json',
+  'REVIEW.json',
+  'SBOM.json',
+  '.xiaoba-bundled-skill.json',
+  '.xiaoba-skillhub-install.json',
+  '.xiaoba-local-skill.json',
+]);
+
+export function buildBotSkillSourceSnapshot(skillDirectory: string): BotSkillSourceSnapshot {
+  const root = path.resolve(skillDirectory);
+  const rootStat = fs.lstatSync(root);
+  if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) {
+    throw new BotSkillSourceError('Skill source root must be a real directory.', 'SKILL_SOURCE_ROOT_INVALID');
+  }
+
+  const filePaths = walkSourceFiles(root);
+  if (filePaths.length > BOT_SKILL_SOURCE_MAX_FILES) {
+    throw new BotSkillSourceError(
+      `Skill source contains more than ${BOT_SKILL_SOURCE_MAX_FILES} files.`,
+      'SKILL_SOURCE_FILE_LIMIT',
+    );
+  }
+
+  let totalBytes = 0;
+  const files: BotSkillSourceFile[] = [];
+  const sensitivePaths: string[] = [];
+  for (const filePath of filePaths) {
+    const relative = safeRelativePath(root, filePath);
+    const stat = fs.lstatSync(filePath);
+    if (!stat.isFile() || stat.isSymbolicLink()) {
+      throw new BotSkillSourceError('Skill source contains an unsupported filesystem entry.', 'SKILL_SOURCE_ENTRY_UNSAFE', [relative]);
+    }
+    if (stat.size > BOT_SKILL_SOURCE_MAX_SINGLE_FILE_BYTES) {
+      throw new BotSkillSourceError(
+        `Skill source file exceeds ${BOT_SKILL_SOURCE_MAX_SINGLE_FILE_BYTES} bytes.`,
+        'SKILL_SOURCE_FILE_TOO_LARGE',
+        [relative],
+      );
+    }
+    const bytes = readStableFile(filePath, BOT_SKILL_SOURCE_MAX_SINGLE_FILE_BYTES, stat);
+    totalBytes += bytes.length;
+    if (totalBytes > BOT_SKILL_SOURCE_MAX_TOTAL_BYTES) {
+      throw new BotSkillSourceError(
+        `Skill source exceeds ${BOT_SKILL_SOURCE_MAX_TOTAL_BYTES} bytes.`,
+        'SKILL_SOURCE_TOTAL_TOO_LARGE',
+      );
+    }
+    if (isSensitiveFileName(relative) || containsHighConfidenceSecret(bytes)) {
+      sensitivePaths.push(relative);
+      continue;
+    }
+    files.push({
+      path: relative,
+      size: bytes.length,
+      sha256: sha256(bytes),
+      bytes,
+    });
+  }
+
+  if (sensitivePaths.length > 0) {
+    throw new BotSkillSourceError(
+      'Skill source contains sensitive material and was not uploaded.',
+      'SKILL_SOURCE_SENSITIVE',
+      sensitivePaths.sort(),
+    );
+  }
+  if (!files.some(file => file.path === 'SKILL.md')) {
+    throw new BotSkillSourceError('Skill source is missing SKILL.md.', 'SKILL_SOURCE_ENTRY_MISSING');
+  }
+  files.sort((a, b) => compareBotSkillSourcePath(a.path, b.path));
+  return {
+    root,
+    contentHash: contentHashOf(files),
+    totalBytes,
+    files,
+  };
+}
+
+/**
+ * Local dirty detection uses the same byte and path canonicalization as an
+ * upload snapshot, but deliberately does not run the sensitive-content gate.
+ * A sensitive local Skill remains usable and visible as dirty while upload is
+ * blocked later.
+ */
+export function computeBotSkillSourceContentHash(skillDirectory: string): string {
+  const root = path.resolve(skillDirectory);
+  const rootStat = fs.lstatSync(root);
+  if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) {
+    throw new BotSkillSourceError('Skill source root must be a real directory.', 'SKILL_SOURCE_ROOT_INVALID');
+  }
+  const filePaths = walkSourceFiles(root);
+  if (filePaths.length > BOT_SKILL_SOURCE_MAX_FILES) {
+    throw new BotSkillSourceError('Skill source contains too many files.', 'SKILL_SOURCE_FILE_LIMIT');
+  }
+  let totalBytes = 0;
+  const files = filePaths.map(filePath => {
+    const relative = safeRelativePath(root, filePath);
+    const stat = fs.lstatSync(filePath);
+    if (!stat.isFile() || stat.isSymbolicLink()) {
+      throw new BotSkillSourceError(
+        'Skill source contains an unsupported filesystem entry.',
+        'SKILL_SOURCE_ENTRY_UNSAFE',
+        [relative],
+      );
+    }
+    const bytes = readStableFile(filePath, BOT_SKILL_SOURCE_MAX_SINGLE_FILE_BYTES, stat);
+    totalBytes += bytes.length;
+    if (totalBytes > BOT_SKILL_SOURCE_MAX_TOTAL_BYTES) {
+      throw new BotSkillSourceError('Skill source is too large.', 'SKILL_SOURCE_TOTAL_TOO_LARGE');
+    }
+    return {
+      path: relative,
+      size: bytes.length,
+      sha256: sha256(bytes),
+      bytes,
+    };
+  }).sort((a, b) => compareBotSkillSourcePath(a.path, b.path));
+  return contentHashOf(files);
+}
+
+function walkSourceFiles(root: string): string[] {
+  const result: string[] = [];
+  const visit = (current: string): void => {
+    const entries = fs.readdirSync(current, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(current, entry.name);
+      const relative = safeRelativePath(root, fullPath);
+      if (entry.isSymbolicLink()) {
+        throw new BotSkillSourceError('Skill source contains a symbolic link.', 'SKILL_SOURCE_SYMLINK', [relative]);
+      }
+      if (entry.isDirectory()) {
+        if (FORBIDDEN_DIRECTORIES.has(entry.name.toLowerCase())) {
+          throw new BotSkillSourceError(
+            'Skill source contains a sensitive credential directory.',
+            'SKILL_SOURCE_SENSITIVE',
+            [relative],
+          );
+        }
+        if (!IGNORED_DIRECTORIES.has(entry.name)) visit(fullPath);
+        continue;
+      }
+      if (entry.isFile() && !GENERATED_FILES.has(entry.name)) {
+        result.push(fullPath);
+        if (result.length > BOT_SKILL_SOURCE_MAX_FILES) return;
+      }
+    }
+  };
+  visit(root);
+  return result;
+}
+
+function readStableFile(filePath: string, maxBytes: number, expected?: fs.Stats): Buffer {
+  const flags = fs.constants.O_RDONLY | Number((fs.constants as any).O_NOFOLLOW || 0);
+  let descriptor: number | undefined;
+  try {
+    descriptor = fs.openSync(filePath, flags);
+    const before = fs.fstatSync(descriptor);
+    if (!before.isFile() || before.size > maxBytes) {
+      throw new BotSkillSourceError('Skill source file exceeds its limit.', 'SKILL_SOURCE_FILE_TOO_LARGE');
+    }
+    if (expected && !sameFileIdentity(expected, before)) {
+      throw new BotSkillSourceError('Skill source changed while being read.', 'SKILL_SOURCE_CHANGED_DURING_READ');
+    }
+    const bytes = fs.readFileSync(descriptor);
+    const after = fs.fstatSync(descriptor);
+    const current = fs.lstatSync(filePath);
+    if (
+      bytes.length > maxBytes
+      || bytes.length !== before.size
+      || after.size !== before.size
+      || after.mtimeMs !== before.mtimeMs
+      || (before.ino !== 0 && after.ino !== before.ino)
+      || current.isSymbolicLink()
+      || !current.isFile()
+      || !sameFileIdentity(after, current)
+    ) {
+      throw new BotSkillSourceError('Skill source changed while being read.', 'SKILL_SOURCE_CHANGED_DURING_READ');
+    }
+    return bytes;
+  } finally {
+    if (descriptor !== undefined) fs.closeSync(descriptor);
+  }
+}
+
+function sameFileIdentity(left: fs.Stats, right: fs.Stats): boolean {
+  if (left.dev !== right.dev) return false;
+  if (left.ino !== 0 && right.ino !== 0 && left.ino !== right.ino) return false;
+  return left.size === right.size && left.mtimeMs === right.mtimeMs;
+}
+
+function contentHashOf(files: Array<Pick<BotSkillSourceFile, 'path' | 'size' | 'sha256'>>): string {
+  return sha256(Buffer.from(JSON.stringify(files.map(file => ({
+    path: file.path,
+    size: file.size,
+    sha256: file.sha256,
+  }))), 'utf8'));
+}
+
+function safeRelativePath(root: string, filePath: string): string {
+  const relative = path.relative(root, filePath).replace(/\\/g, '/');
+  const segments = relative.split('/');
+  if (
+    !relative
+    || relative.length > 1024
+    || segments.length > 64
+    || relative.includes('\0')
+    || relative.startsWith('/')
+    || segments.some(part => (
+      part === ''
+      || part === '.'
+      || part === '..'
+      || !portableWindowsSegment(part)
+    ))
+  ) {
+    throw new BotSkillSourceError('Skill source path escapes its root.', 'SKILL_SOURCE_PATH_UNSAFE');
+  }
+  return relative;
+}
+
+function portableWindowsSegment(value: string): boolean {
+  if (!value || /[<>:"|?*]/.test(value) || /[. ]$/.test(value)) return false;
+  const stem = value.split('.')[0].toUpperCase();
+  return !/^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])$/.test(stem);
+}
+
+function isSensitiveFileName(relativePath: string): boolean {
+  const name = path.posix.basename(relativePath).toLowerCase();
+  return (
+    name === '.env'
+    || name.startsWith('.env.')
+    || name === '.npmrc'
+    || name === '.pypirc'
+    || name === 'credentials'
+    || name === 'credentials.json'
+    || name === 'kubeconfig'
+    || name === 'id_rsa'
+    || name === 'id_ed25519'
+    || name.endsWith('.pem')
+    || name.endsWith('.key')
+    || name.endsWith('.p12')
+    || name.endsWith('.pfx')
+  );
+}
+
+function containsHighConfidenceSecret(bytes: Buffer): boolean {
+  if (bytes.includes(0)) return false;
+  const text = bytes.toString('utf8');
+  if (/-----BEGIN (?:[A-Z0-9 ]+ )?PRIVATE KEY-----/.test(text)) return true;
+  if (/\bAKIA[0-9A-Z]{16}\b/.test(text)) return true;
+  if (/\bgh[pousr]_[A-Za-z0-9]{20,}\b/.test(text)) return true;
+  if (/\bxox[baprs]-[A-Za-z0-9-]{20,}\b/.test(text)) return true;
+  if (/\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}\b/.test(text)) return true;
+  const assignments = text.matchAll(
+    /\b(?:api[_-]?key|access[_-]?token|auth[_-]?token|client[_-]?secret|password)\b\s*[:=]\s*["']?([^\s"'#]{16,})/gi,
+  );
+  for (const match of assignments) {
+    const candidate = String(match[1] || '').toLowerCase();
+    if (!/(example|placeholder|dummy|changeme|your[_-]|test[_-]|\*{3,})/.test(candidate)) return true;
+  }
+  return false;
+}
+
+function sha256(bytes: Buffer): string {
+  return crypto.createHash('sha256').update(bytes).digest('hex');
+}

--- a/src/bot-skills/switch-journal.ts
+++ b/src/bot-skills/switch-journal.ts
@@ -1,0 +1,110 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { PathResolver } from '../utils/path-resolver';
+
+export const BOT_SKILL_SWITCH_JOURNAL_SCHEMA = 'xiaoba.bot-skill-switch-journal.v1';
+
+export type BotSkillSwitchPhase =
+  | 'PREPARING_TARGET'
+  | 'OLD_CONNECTOR_STOPPED'
+  | 'PARKING_OLD'
+  | 'OLD_WORKSPACE_PARKED'
+  | 'ACTIVATING_TARGET'
+  | 'TARGET_ACTIVATED'
+  | 'TARGET_PREFLIGHT_OK'
+  | 'COMMITTING_BINDING'
+  | 'BINDING_COMMITTED'
+  | 'COMMITTED';
+
+export interface BotSkillSwitchJournal {
+  schema: typeof BOT_SKILL_SWITCH_JOURNAL_SCHEMA;
+  transactionId: string;
+  phase: BotSkillSwitchPhase;
+  fromBotId: string;
+  fromWorkspaceId: string;
+  toBotId: string;
+  toWorkspaceId?: string;
+  oldConnectorWasRunning?: boolean;
+  activeRoot: string;
+  fromParkedRoot: string;
+  targetPreparedRoot: string;
+  startedAt: string;
+  updatedAt: string;
+}
+
+export class FileBotSkillSwitchJournalStore {
+  private readonly filePath: string;
+
+  constructor(options: { runtimeRoot?: string; filePath?: string } = {}) {
+    const runtimeRoot = path.resolve(options.runtimeRoot ?? PathResolver.getRuntimeDataRoot());
+    this.filePath = path.resolve(
+      options.filePath ?? path.join(runtimeRoot, 'data', 'bot-skill-switch', 'journal.json'),
+    );
+  }
+
+  read(): BotSkillSwitchJournal | undefined {
+    if (!fs.existsSync(this.filePath)) return undefined;
+    let value: BotSkillSwitchJournal;
+    try {
+      value = JSON.parse(fs.readFileSync(this.filePath, 'utf8')) as BotSkillSwitchJournal;
+    } catch {
+      throw journalError('Bot Skill switch journal is corrupt.', 'BOT_SKILL_SWITCH_JOURNAL_CORRUPT');
+    }
+    if (
+      value?.schema !== BOT_SKILL_SWITCH_JOURNAL_SCHEMA
+      || !value.transactionId
+      || !isPhase(value.phase)
+      || !value.fromBotId
+      || !value.fromWorkspaceId
+      || !value.toBotId
+      || !path.isAbsolute(value.activeRoot)
+      || !path.isAbsolute(value.fromParkedRoot)
+      || !path.isAbsolute(value.targetPreparedRoot)
+      || !Number.isFinite(Date.parse(value.startedAt))
+      || !Number.isFinite(Date.parse(value.updatedAt))
+    ) {
+      throw journalError('Bot Skill switch journal is invalid.', 'BOT_SKILL_SWITCH_JOURNAL_CORRUPT');
+    }
+    return value;
+  }
+
+  write(journal: BotSkillSwitchJournal): void {
+    const filePath = this.filePath;
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    const temporary = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+    fs.writeFileSync(temporary, `${JSON.stringify(journal, null, 2)}\n`, {
+      encoding: 'utf8',
+      mode: 0o600,
+    });
+    fs.renameSync(temporary, filePath);
+  }
+
+  delete(): void {
+    fs.rmSync(this.filePath, { force: true });
+  }
+
+  getPath(): string {
+    return this.filePath;
+  }
+}
+
+function isPhase(value: string): value is BotSkillSwitchPhase {
+  return [
+    'PREPARING_TARGET',
+    'OLD_CONNECTOR_STOPPED',
+    'PARKING_OLD',
+    'OLD_WORKSPACE_PARKED',
+    'ACTIVATING_TARGET',
+    'TARGET_ACTIVATED',
+    'TARGET_PREFLIGHT_OK',
+    'COMMITTING_BINDING',
+    'BINDING_COMMITTED',
+    'COMMITTED',
+  ].includes(value);
+}
+
+function journalError(message: string, code: string): Error {
+  const error: any = new Error(message);
+  error.code = code;
+  return error;
+}

--- a/src/bot-skills/switch-service.ts
+++ b/src/bot-skills/switch-service.ts
@@ -1,0 +1,291 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  BOT_SKILL_SWITCH_JOURNAL_SCHEMA,
+  FileBotSkillSwitchJournalStore,
+  type BotSkillSwitchJournal,
+  type BotSkillSwitchPhase,
+} from './switch-journal';
+import {
+  BOT_SKILL_WORKSPACE_IDENTITY_FILE,
+  BotSkillWorkspaceService,
+  type BotSkillWorkspaceOwner,
+} from './workspace';
+import { withBotSkillWorkspaceLock } from './workspace-lock';
+
+export interface BotSkillWorkspaceSwitchRequest {
+  fromOwner: BotSkillWorkspaceOwner;
+  toOwner: BotSkillWorkspaceOwner;
+  fromParkedRoot: string;
+  targetPreparedRoot: string;
+  oldConnectorWasRunning?: boolean;
+  prepareTarget(targetRoot: string): Promise<void>;
+  stopOldConnector(): Promise<void>;
+  syncOldWorkspace(): Promise<unknown>;
+  preflightTarget(): Promise<void>;
+  commitTargetBinding(): Promise<void>;
+  rollbackSourceBinding?(): Promise<void>;
+  startTargetConnector(): Promise<void>;
+  stopTargetConnector?(): Promise<void>;
+  restartOldConnector?(): Promise<void>;
+}
+
+export interface BotSkillWorkspaceSwitchRecoveryOptions {
+  currentBotId?: string;
+  restartConnector?(result: 'rolled_back' | 'committed'): Promise<void>;
+}
+
+export interface BotSkillWorkspaceSwitchServiceOptions {
+  workspace: BotSkillWorkspaceService;
+  journalStore: FileBotSkillSwitchJournalStore;
+  createId?: () => string;
+  now?: () => Date;
+}
+
+export class BotSkillWorkspaceSwitchService {
+  private readonly workspace: BotSkillWorkspaceService;
+  private readonly journalStore: FileBotSkillSwitchJournalStore;
+  private readonly createId: () => string;
+  private readonly now: () => Date;
+
+  constructor(options: BotSkillWorkspaceSwitchServiceOptions) {
+    this.workspace = options.workspace;
+    this.journalStore = options.journalStore;
+    this.createId = options.createId ?? (() => crypto.randomUUID());
+    this.now = options.now ?? (() => new Date());
+  }
+
+  async switch(request: BotSkillWorkspaceSwitchRequest): Promise<void> {
+    const activeRoot = path.resolve(this.workspace.root);
+    const fromParkedRoot = path.resolve(request.fromParkedRoot);
+    const targetPreparedRoot = path.resolve(request.targetPreparedRoot);
+    let journal: BotSkillSwitchJournal | undefined;
+    let bindingCommitAttempted = false;
+    let oldStopped = false;
+    let targetStarted = false;
+    try {
+      await withBotSkillWorkspaceLock(this.workspace.root, async () => {
+        if (this.journalStore.read()) {
+          throw switchError('An unfinished Bot Skill switch must be recovered first.', 'BOT_SKILL_SWITCH_IN_PROGRESS');
+        }
+        const source = this.workspace.inspect(request.fromOwner);
+        if (source.kind !== 'valid') {
+          throw switchError('Source Bot Skill workspace is not safe to switch.', 'BOT_SKILL_SWITCH_SOURCE_INVALID');
+        }
+        assertSameVolume(activeRoot, fromParkedRoot, targetPreparedRoot);
+        if (fs.existsSync(fromParkedRoot)) {
+          throw switchError('Source parked workspace already exists.', 'BOT_SKILL_SWITCH_PATH_COLLISION');
+        }
+        const timestamp = this.now().toISOString();
+        journal = {
+          schema: BOT_SKILL_SWITCH_JOURNAL_SCHEMA,
+          transactionId: this.createId(),
+          phase: 'PREPARING_TARGET',
+          fromBotId: request.fromOwner.botId,
+          fromWorkspaceId: source.identity.workspaceId,
+          toBotId: request.toOwner.botId,
+          ...(request.oldConnectorWasRunning !== undefined
+            ? { oldConnectorWasRunning: request.oldConnectorWasRunning }
+            : {}),
+          activeRoot,
+          fromParkedRoot,
+          targetPreparedRoot,
+          startedAt: timestamp,
+          updatedAt: timestamp,
+        };
+        this.journalStore.write(journal);
+
+        await request.prepareTarget(targetPreparedRoot);
+        const target = new BotSkillWorkspaceService({ skillsRoot: targetPreparedRoot })
+          .inspect(request.toOwner);
+        if (target.kind !== 'valid') {
+          throw switchError('Target Bot Skill workspace failed preparation.', 'BOT_SKILL_SWITCH_TARGET_INVALID');
+        }
+        journal = {
+          ...journal,
+          toWorkspaceId: target.identity.workspaceId,
+          updatedAt: this.now().toISOString(),
+        };
+        this.journalStore.write(journal);
+      });
+
+      // A graceful child shutdown may flush a pending sync. Stop it without
+      // holding the active workspace lock, then perform the parent's final sync.
+      await request.stopOldConnector();
+      oldStopped = true;
+      await withBotSkillWorkspaceLock(this.workspace.root, async () => {
+        const persisted = this.journalStore.read();
+        if (!persisted || persisted.transactionId !== journal?.transactionId) {
+          throw switchError('Bot Skill switch journal changed before workspace activation.', 'BOT_SKILL_SWITCH_JOURNAL_MISMATCH');
+        }
+        journal = persisted;
+        journal = this.advance(journal, 'OLD_CONNECTOR_STOPPED');
+        await request.syncOldWorkspace();
+
+        journal = this.advance(journal, 'PARKING_OLD');
+        fs.mkdirSync(path.dirname(fromParkedRoot), { recursive: true });
+        fs.renameSync(activeRoot, fromParkedRoot);
+        journal = this.advance(journal, 'OLD_WORKSPACE_PARKED');
+
+        journal = this.advance(journal, 'ACTIVATING_TARGET');
+        fs.mkdirSync(path.dirname(activeRoot), { recursive: true });
+        fs.renameSync(targetPreparedRoot, activeRoot);
+        journal = this.advance(journal, 'TARGET_ACTIVATED');
+
+        await request.preflightTarget();
+        journal = this.advance(journal, 'TARGET_PREFLIGHT_OK');
+        journal = this.advance(journal, 'COMMITTING_BINDING');
+        bindingCommitAttempted = true;
+        await request.commitTargetBinding();
+        journal = this.advance(journal, 'BINDING_COMMITTED');
+      });
+
+      // The connector performs its own startup sync and therefore must never
+      // be started while the parent process owns the cross-process workspace lock.
+      await request.startTargetConnector();
+      targetStarted = true;
+      await withBotSkillWorkspaceLock(this.workspace.root, async () => {
+        const persisted = this.journalStore.read();
+        if (!persisted || persisted.transactionId !== journal?.transactionId) {
+          throw switchError('Bot Skill switch journal changed before connector commit.', 'BOT_SKILL_SWITCH_JOURNAL_MISMATCH');
+        }
+        journal = persisted;
+        journal = this.advance(journal, 'COMMITTED');
+        this.journalStore.delete();
+      });
+    } catch (error) {
+      try {
+        if (targetStarted) await request.stopTargetConnector?.();
+        await withBotSkillWorkspaceLock(this.workspace.root, async () => {
+          const persisted = this.journalStore.read();
+          if (persisted) journal = persisted;
+          if (!journal) return;
+          if (bindingCommitAttempted) await request.rollbackSourceBinding?.();
+          this.rollbackDirectories(journal);
+          this.journalStore.delete();
+        });
+        if (oldStopped) await request.restartOldConnector?.();
+      } catch (rollbackError: any) {
+        const failure = switchError(
+          'Bot Skill switch failed and rollback could not complete.',
+          'BOT_SKILL_SWITCH_ROLLBACK_FAILED',
+        ) as Error & { cause?: unknown; originalError?: unknown };
+        failure.cause = rollbackError;
+        failure.originalError = error;
+        throw failure;
+      }
+      throw error;
+    }
+  }
+
+  async recover(
+    options: BotSkillWorkspaceSwitchRecoveryOptions = {},
+  ): Promise<'none' | 'rolled_back' | 'committed'> {
+    let shouldRestart = false;
+    const result = await withBotSkillWorkspaceLock(this.workspace.root, async () => {
+      const journal = this.journalStore.read();
+      if (!journal) return 'none';
+      const currentBotId = String(options.currentBotId || '').trim();
+      const bindingPointsToTarget = currentBotId === journal.toBotId;
+      const bindingPointsToSource = currentBotId === journal.fromBotId;
+      if (
+        ((journal.phase === 'BINDING_COMMITTED' || journal.phase === 'COMMITTED') && bindingPointsToTarget)
+        || (journal.phase === 'COMMITTING_BINDING' && bindingPointsToTarget)
+      ) {
+        this.assertCommittedLayout(journal);
+        this.journalStore.delete();
+        shouldRestart = true;
+        return 'committed';
+      }
+      if (
+        (journal.phase === 'BINDING_COMMITTED' || journal.phase === 'COMMITTED')
+        && !bindingPointsToSource
+      ) {
+        throw switchError(
+          'Bot binding does not match either side of the unfinished workspace switch.',
+          'BOT_SKILL_SWITCH_BINDING_MISMATCH',
+        );
+      }
+      if (
+        bindingPointsToTarget
+        && journal.phase !== 'COMMITTING_BINDING'
+      ) {
+        throw switchError(
+          'Bot binding advanced before the workspace switch reached its commit phase.',
+          'BOT_SKILL_SWITCH_BINDING_MISMATCH',
+        );
+      }
+      this.rollbackDirectories(journal);
+      this.journalStore.delete();
+      shouldRestart = Boolean(journal.oldConnectorWasRunning);
+      return 'rolled_back';
+    });
+    if (shouldRestart && result !== 'none') await options.restartConnector?.(result);
+    return result;
+  }
+
+  private advance(
+    journal: BotSkillSwitchJournal,
+    phase: BotSkillSwitchPhase,
+  ): BotSkillSwitchJournal {
+    const next = { ...journal, phase, updatedAt: this.now().toISOString() };
+    this.journalStore.write(next);
+    return next;
+  }
+
+  private rollbackDirectories(journal: BotSkillSwitchJournal): void {
+    const activeExists = fs.existsSync(journal.activeRoot);
+    const sourceParkedExists = fs.existsSync(journal.fromParkedRoot);
+    const targetPreparedExists = fs.existsSync(journal.targetPreparedRoot);
+    const sourceStillActive = activeExists && !sourceParkedExists;
+    if (sourceStillActive) return;
+
+    if (activeExists && sourceParkedExists) {
+      if (targetPreparedExists) {
+        throw switchError('Target workspace collision prevents rollback.', 'BOT_SKILL_SWITCH_PATH_COLLISION');
+      }
+      fs.renameSync(journal.activeRoot, journal.targetPreparedRoot);
+    }
+    if (!fs.existsSync(journal.activeRoot) && fs.existsSync(journal.fromParkedRoot)) {
+      fs.mkdirSync(path.dirname(journal.activeRoot), { recursive: true });
+      fs.renameSync(journal.fromParkedRoot, journal.activeRoot);
+    }
+    if (!fs.existsSync(journal.activeRoot)) {
+      throw switchError('Source workspace could not be restored.', 'BOT_SKILL_SWITCH_ROLLBACK_FAILED');
+    }
+  }
+
+  private assertCommittedLayout(journal: BotSkillSwitchJournal): void {
+    if (!fs.existsSync(journal.activeRoot) || fs.existsSync(journal.targetPreparedRoot)) {
+      throw switchError('Committed Bot Skill switch layout is inconsistent.', 'BOT_SKILL_SWITCH_LAYOUT_INVALID');
+    }
+    try {
+      const identity = JSON.parse(fs.readFileSync(
+        path.join(journal.activeRoot, BOT_SKILL_WORKSPACE_IDENTITY_FILE),
+        'utf8',
+      ));
+      if (
+        identity?.workspaceOwnerBotId !== journal.toBotId
+        || (journal.toWorkspaceId && identity?.workspaceId !== journal.toWorkspaceId)
+      ) {
+        throw new Error('identity mismatch');
+      }
+    } catch {
+      throw switchError('Committed Bot Skill workspace identity is inconsistent.', 'BOT_SKILL_SWITCH_LAYOUT_INVALID');
+    }
+  }
+}
+
+function assertSameVolume(...roots: string[]): void {
+  const volumes = new Set(roots.map(root => path.parse(root).root.toLowerCase()));
+  if (volumes.size !== 1) {
+    throw switchError('Bot Skill workspaces must be on the same volume.', 'BOT_SKILL_SWITCH_CROSS_VOLUME');
+  }
+}
+
+function switchError(message: string, code: string): Error {
+  const error: any = new Error(message);
+  error.code = code;
+  return error;
+}

--- a/src/bot-skills/sync-service.ts
+++ b/src/bot-skills/sync-service.ts
@@ -1,0 +1,1143 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import type { BotDefinition, BotSkillReference } from '../bot-definition/types';
+import type { BotDefinitionRepository } from '../bot-definition/repository';
+import {
+  botSkillReferencesEqual,
+  normalizeBotSkillReferences,
+  cloudSnapshotMatchesBase,
+  localSnapshotMatchesBase,
+} from './canonical';
+import type { FileBotSkillSyncBaseStore } from './base-store';
+import {
+  BotDefinitionCloudError,
+  type BotDefinitionCloudClient,
+  type BotDefinitionCloudSnapshot,
+} from './definition-cloud';
+import type { BotPrivateSkillPackageClient } from './private-package';
+import {
+  BOT_SKILL_PENDING_COMMIT_SCHEMA,
+  type BotSkillPendingCommit,
+  type FileBotSkillPendingCommitStore,
+} from './pending-commit-store';
+import { buildBotSkillSourceSnapshot, BotSkillSourceError } from './source-snapshot';
+import {
+  BOT_SKILL_SYNC_BASE_SCHEMA,
+  type BotLocalSkillSnapshot,
+  type BotSkillSyncBase,
+  type BotSkillSyncBaseEntry,
+  type BotSkillWorkspaceInspection,
+} from './types';
+import {
+  BotSkillWorkspaceService,
+  type BotSkillWorkspaceOwner,
+} from './workspace';
+import { restoreBotSkillWorkspace } from './workspace-restore';
+import { withBotSkillWorkspaceLock } from './workspace-lock';
+
+export interface BotSkillSyncServiceOptions {
+  workspace: BotSkillWorkspaceService;
+  baseStore: Pick<FileBotSkillSyncBaseStore, 'read' | 'write'>;
+  cloud: BotDefinitionCloudClient;
+  packages: BotPrivateSkillPackageClient;
+  definitionCache?: Pick<BotDefinitionRepository, 'writeCache'>
+    & Partial<Pick<BotDefinitionRepository, 'readCache' | 'readCanonical' | 'withWriteLock'>>;
+  pendingStore?: Pick<FileBotSkillPendingCommitStore, 'read' | 'write' | 'delete'>;
+  now?: () => Date;
+}
+
+export interface BotSkillSyncRequest {
+  owner: BotSkillWorkspaceOwner;
+  /**
+   * Required only when an owned local workspace must recreate a missing cloud
+   * Definition, or an explicit new-Bot flow creates it for the first time.
+   */
+  definitionForCreate?: BotDefinition;
+  allowLegacyClaim?: boolean;
+  allowNewWorkspaceCreate?: boolean;
+  /** Installs the one-time default Skill for an explicit new Bot flow. */
+  initializeNewWorkspace?(): Promise<void>;
+}
+
+export type BotSkillSyncRepairStrategy = 'local-wins' | 'cloud-wins';
+
+export interface BotSkillSyncBlockedSkill {
+  localSkillId: string;
+  name: string;
+  code: string;
+  relativePaths?: string[];
+}
+
+export interface BotSkillSyncResult {
+  action:
+    | 'noop'
+    | 'uploaded'
+    | 'downloaded'
+    | 'created_cloud'
+    | 'migrated'
+    | 'degraded_local'
+    | 'blocked'
+    | 'conflict';
+  botId: string;
+  workspaceId?: string;
+  definitionETag?: string;
+  blockedSkills?: BotSkillSyncBlockedSkill[];
+  reason?: string;
+}
+
+export class BotSkillSyncService {
+  private readonly workspace: BotSkillWorkspaceService;
+  private readonly baseStore: BotSkillSyncServiceOptions['baseStore'];
+  private readonly cloud: BotDefinitionCloudClient;
+  private readonly packages: BotPrivateSkillPackageClient;
+  private readonly definitionCache?: BotSkillSyncServiceOptions['definitionCache'];
+  private readonly pendingStore?: BotSkillSyncServiceOptions['pendingStore'];
+  private readonly now: () => Date;
+
+  constructor(options: BotSkillSyncServiceOptions) {
+    this.workspace = options.workspace;
+    this.baseStore = options.baseStore;
+    this.cloud = options.cloud;
+    this.packages = options.packages;
+    this.definitionCache = options.definitionCache;
+    this.pendingStore = options.pendingStore;
+    this.now = options.now ?? (() => new Date());
+  }
+
+  sync(request: BotSkillSyncRequest): Promise<BotSkillSyncResult> {
+    return withBotSkillWorkspaceLock(this.workspace.root, () => this.syncUnlocked(request));
+  }
+
+  repair(
+    request: BotSkillSyncRequest,
+    strategy: BotSkillSyncRepairStrategy,
+  ): Promise<BotSkillSyncResult> {
+    return withBotSkillWorkspaceLock(
+      this.workspace.root,
+      () => this.repairUnlocked(request, strategy),
+    );
+  }
+
+  private async repairUnlocked(
+    request: BotSkillSyncRequest,
+    strategy: BotSkillSyncRepairStrategy,
+  ): Promise<BotSkillSyncResult> {
+    const botId = String(request.owner.botId || '').trim();
+    if (strategy !== 'local-wins' && strategy !== 'cloud-wins') {
+      return blocked(botId, 'SYNC_REPAIR_STRATEGY_INVALID');
+    }
+    let pending: BotSkillPendingCommit | undefined;
+    try {
+      pending = this.pendingStore?.read();
+    } catch (error: any) {
+      return blocked(botId, safeErrorCode(error, 'PENDING_COMMIT_CORRUPT'));
+    }
+    if (pending) return blocked(botId, 'SYNC_REPAIR_PENDING_COMMIT_EXISTS');
+
+    const inspected = this.workspace.inspect(request.owner);
+    if (inspected.kind === 'unreadable') return blocked(botId, 'LOCAL_WORKSPACE_UNREADABLE');
+    if (inspected.kind === 'owner_mismatch') return blocked(botId, 'LOCAL_WORKSPACE_OWNER_MISMATCH');
+    if (inspected.kind !== 'valid') return blocked(botId, 'SYNC_REPAIR_LOCAL_WORKSPACE_INVALID');
+
+    let cloudRead;
+    try {
+      cloudRead = await this.cloud.read();
+    } catch (error: any) {
+      return blocked(botId, safeErrorCode(error, 'CLOUD_UNAVAILABLE'));
+    }
+    if (cloudRead.kind !== 'found') return blocked(botId, 'SYNC_REPAIR_CLOUD_DEFINITION_MISSING');
+    if (cloudRead.definition.skills === undefined) {
+      return blocked(botId, 'SYNC_REPAIR_CLOUD_SKILLS_MISSING');
+    }
+
+    const baseRead = this.baseStore.read(botId, inspected.identity.workspaceId);
+    if (baseRead.kind === 'valid') {
+      return {
+        action: 'conflict',
+        botId,
+        workspaceId: inspected.identity.workspaceId,
+        definitionETag: cloudRead.etag,
+        reason: 'SYNC_REPAIR_NOT_REQUIRED',
+      };
+    }
+    const repaired = strategy === 'local-wins'
+      ? await this.uploadSnapshot(request, inspected, cloudRead, undefined, true)
+      : await this.download(request, inspected, cloudRead, undefined, true);
+    return {
+      ...repaired,
+      reason: repaired.action === 'uploaded' || repaired.action === 'downloaded'
+        ? (strategy === 'local-wins'
+          ? 'BASE_REPAIRED_LOCAL_WINS'
+          : 'BASE_REPAIRED_CLOUD_WINS')
+        : repaired.reason,
+    };
+  }
+
+  private async syncUnlocked(request: BotSkillSyncRequest): Promise<BotSkillSyncResult> {
+    const botId = String(request.owner.botId || '').trim();
+    let pending: BotSkillPendingCommit | undefined;
+    try {
+      pending = this.pendingStore?.read();
+    } catch (error: any) {
+      return blocked(botId, safeErrorCode(error, 'PENDING_COMMIT_CORRUPT'));
+    }
+    let inspected = this.workspace.inspect(request.owner);
+    const hasPendingRestore = pending?.kind === 'restore' && pending.botId === botId;
+    if (inspected.kind === 'unreadable' && !hasPendingRestore) {
+      return blocked(botId, 'LOCAL_WORKSPACE_UNREADABLE');
+    }
+    if (inspected.kind === 'owner_mismatch' && !hasPendingRestore) {
+      return blocked(botId, 'LOCAL_WORKSPACE_OWNER_MISMATCH');
+    }
+
+    let cloudRead;
+    try {
+      cloudRead = await this.cloud.read();
+    } catch (error: any) {
+      if (inspected.kind === 'valid') {
+        return {
+          action: 'degraded_local',
+          botId,
+          workspaceId: inspected.identity.workspaceId,
+          reason: safeErrorCode(error, 'CLOUD_UNAVAILABLE'),
+        };
+      }
+      return blocked(botId, safeErrorCode(error, 'CLOUD_UNAVAILABLE'));
+    }
+
+    if (pending && pending.botId === botId && cloudRead.kind === 'found') {
+      let recovered: boolean;
+      try {
+        recovered = this.recoverPendingCommit(pending, inspected, cloudRead, request.owner.authority);
+      } catch (error: any) {
+        return blocked(botId, safeErrorCode(error, 'PENDING_RESTORE_RECOVERY_BLOCKED'));
+      }
+      if (recovered) {
+        inspected = this.workspace.inspect(request.owner);
+      } else if (pending.kind === 'restore') {
+        inspected = this.workspace.inspect(request.owner);
+      }
+    }
+    if (inspected.kind === 'unreadable') {
+      return blocked(botId, 'LOCAL_WORKSPACE_UNREADABLE');
+    }
+    if (inspected.kind === 'owner_mismatch') {
+      return blocked(botId, 'LOCAL_WORKSPACE_OWNER_MISMATCH');
+    }
+
+    if (inspected.kind === 'missing') {
+      if (cloudRead.kind === 'found' && cloudRead.definition.skills !== undefined) {
+        return this.download(request, inspected, cloudRead);
+      }
+      if (
+        cloudRead.kind === 'found'
+        && cloudRead.definition.skills === undefined
+        && request.allowNewWorkspaceCreate
+        && request.definitionForCreate
+      ) {
+        this.workspace.initializeEmpty(request.owner);
+        await request.initializeNewWorkspace?.();
+        const initialized = this.workspace.inspect(request.owner);
+        if (initialized.kind !== 'valid') {
+          return blocked(botId, 'NEW_WORKSPACE_INITIALIZATION_FAILED');
+        }
+        const uploaded = await this.uploadSnapshot(request, initialized, cloudRead, undefined);
+        return {
+          ...uploaded,
+          action: uploaded.action === 'uploaded' ? 'created_cloud' : uploaded.action,
+        };
+      }
+      if (
+        cloudRead.kind === 'missing'
+        && request.allowNewWorkspaceCreate
+        && request.definitionForCreate
+      ) {
+        const identity = this.workspace.initializeEmpty(request.owner);
+        await request.initializeNewWorkspace?.();
+        const initialized = this.workspace.inspect(request.owner);
+        if (initialized.kind !== 'valid' || initialized.identity.workspaceId !== identity.workspaceId) {
+          return blocked(botId, 'NEW_WORKSPACE_INITIALIZATION_FAILED');
+        }
+        const created = await this.createCloudFromSnapshot(request, initialized);
+        return { ...created, action: 'created_cloud' };
+      }
+      return blocked(
+        botId,
+        cloudRead.kind === 'found'
+          ? 'CLOUD_DEFINITION_REQUIRES_MIGRATION_BUT_LOCAL_IS_MISSING'
+          : 'LOCAL_AND_CLOUD_MISSING',
+      );
+    }
+
+    if (inspected.kind === 'unowned') {
+      const mayClaimLegacy = request.allowLegacyClaim
+        && cloudRead.kind === 'found'
+        && cloudRead.definition.skills === undefined;
+      const mayCreateNew = request.allowNewWorkspaceCreate
+        && cloudRead.kind === 'missing'
+        && request.definitionForCreate;
+      if (!mayClaimLegacy && !mayCreateNew) {
+        return {
+          action: 'conflict',
+          botId,
+          reason: 'UNOWNED_LOCAL_WORKSPACE',
+        };
+      }
+      const identity = this.workspace.claimExisting(request.owner);
+      const claimed = this.workspace.inspect(request.owner);
+      if (claimed.kind !== 'valid') return blocked(botId, 'LOCAL_WORKSPACE_CLAIM_FAILED');
+      if (mayCreateNew) {
+        const created = await this.createCloudFromSnapshot(request, claimed);
+        return { ...created, action: 'created_cloud' };
+      }
+      if (cloudRead.kind !== 'found') return blocked(botId, 'CLOUD_DEFINITION_MISSING');
+      const migrated = await this.uploadSnapshot(request, claimed, cloudRead, undefined);
+      return { ...migrated, action: migrated.action === 'uploaded' ? 'migrated' : migrated.action };
+    }
+
+    const baseRead = this.baseStore.read(botId, inspected.identity.workspaceId);
+    if (baseRead.kind === 'corrupt') {
+      return {
+        action: 'conflict',
+        botId,
+        workspaceId: inspected.identity.workspaceId,
+        reason: 'BASE_CORRUPT',
+      };
+    }
+
+    if (cloudRead.kind === 'missing') {
+      if (!request.definitionForCreate) {
+        return blocked(botId, 'CLOUD_DEFINITION_MISSING_WITHOUT_LOCAL_MODEL');
+      }
+      let localForCreate = inspected;
+      if (request.allowNewWorkspaceCreate && request.initializeNewWorkspace) {
+        await request.initializeNewWorkspace();
+        const initialized = this.workspace.inspect(request.owner);
+        if (initialized.kind !== 'valid') {
+          return blocked(botId, 'NEW_WORKSPACE_INITIALIZATION_FAILED');
+        }
+        localForCreate = initialized;
+      }
+      const created = await this.createCloudFromSnapshot(
+        request,
+        localForCreate,
+        baseRead.kind === 'valid' ? baseRead.base : undefined,
+      );
+      return { ...created, action: 'created_cloud' };
+    }
+
+    if (cloudRead.definition.skills === undefined) {
+      if (!request.allowLegacyClaim && !request.allowNewWorkspaceCreate) {
+        return {
+          action: 'conflict',
+          botId,
+          workspaceId: inspected.identity.workspaceId,
+          reason: 'CLOUD_DEFINITION_LEGACY_UNCONFIRMED',
+        };
+      }
+      let localForMigration = inspected;
+      if (request.allowNewWorkspaceCreate && request.initializeNewWorkspace) {
+        await request.initializeNewWorkspace();
+        const initialized = this.workspace.inspect(request.owner);
+        if (initialized.kind !== 'valid') {
+          return blocked(botId, 'NEW_WORKSPACE_INITIALIZATION_FAILED');
+        }
+        localForMigration = initialized;
+      }
+      const migrated = await this.uploadSnapshot(
+        request,
+        localForMigration,
+        cloudRead,
+        baseRead.kind === 'valid' ? baseRead.base : undefined,
+      );
+      return {
+        ...migrated,
+        action: migrated.action === 'uploaded'
+          ? (request.allowNewWorkspaceCreate ? 'created_cloud' : 'migrated')
+          : migrated.action,
+      };
+    }
+
+    if (baseRead.kind === 'missing') {
+      return {
+        action: 'conflict',
+        botId,
+        workspaceId: inspected.identity.workspaceId,
+        definitionETag: cloudRead.etag,
+        reason: 'BASE_UNKNOWN_CONFLICT',
+      };
+    }
+
+    const localMatches = localSnapshotMatchesBase(inspected.skills, baseRead.base);
+    const cloudMatches = cloudSnapshotMatchesBase(cloudRead.definition.skills, baseRead.base);
+    if (localMatches && cloudMatches) {
+      this.writeDefinitionCacheBestEffort(cloudRead.definition);
+      return {
+        action: 'noop',
+        botId,
+        workspaceId: inspected.identity.workspaceId,
+        definitionETag: cloudRead.etag,
+      };
+    }
+    if (localMatches) {
+      return this.download(request, inspected, cloudRead, baseRead.base);
+    }
+    return this.uploadSnapshot(request, inspected, cloudRead, baseRead.base);
+  }
+
+  private async uploadSnapshot(
+    request: BotSkillSyncRequest,
+    local: Extract<BotSkillWorkspaceInspection, { kind: 'valid' }>,
+    cloud: BotDefinitionCloudSnapshot,
+    base?: BotSkillSyncBase,
+    requireComplete = false,
+  ): Promise<BotSkillSyncResult> {
+    const botId = request.owner.botId;
+    const baseByLocalId = new Map((base?.entries ?? []).map(entry => [entry.localSkillId, entry]));
+    const nextEntries: BotSkillSyncBaseEntry[] = [];
+    const blockedSkills: BotSkillSyncBlockedSkill[] = [];
+    for (const skill of local.skills) {
+      const previous = baseByLocalId.get(skill.localSkillId);
+      if (previous?.localContentHash === skill.contentHash) {
+        nextEntries.push(previous);
+        continue;
+      }
+      try {
+        nextEntries.push(await this.resolveCloudEntry(skill, previous));
+      } catch (error: any) {
+        blockedSkills.push({
+          localSkillId: skill.localSkillId,
+          name: skill.name,
+          code: safeErrorCode(error, 'PRIVATE_SKILL_UPLOAD_FAILED'),
+          ...(error instanceof BotSkillSourceError && error.relativePaths.length
+            ? { relativePaths: error.relativePaths }
+            : {}),
+        });
+        if (previous) nextEntries.push(previous);
+      }
+    }
+
+    if (requireComplete && blockedSkills.length) {
+      return {
+        action: 'blocked',
+        botId,
+        workspaceId: local.identity.workspaceId,
+        definitionETag: cloud.etag,
+        reason: 'SYNC_REPAIR_LOCAL_SKILLS_BLOCKED',
+        blockedSkills,
+      };
+    }
+
+    try {
+      this.assertLocalSnapshotUnchanged(request.owner, local);
+    } catch (error: any) {
+      return {
+        action: 'degraded_local',
+        botId,
+        workspaceId: local.identity.workspaceId,
+        reason: safeErrorCode(error, 'LOCAL_CHANGED_DURING_SYNC'),
+        ...(blockedSkills.length ? { blockedSkills } : {}),
+      };
+    }
+    const references = normalizeBotSkillReferences(nextEntries.map(entry => ({
+      skillId: entry.cloudSkillId,
+      version: entry.cloudVersion,
+    })));
+    this.writePendingCloudUpdate(
+      botId,
+      local.identity.workspaceId,
+      request.owner.authority,
+      references,
+      nextEntries,
+    );
+    let updated: BotDefinitionCloudSnapshot;
+    try {
+      updated = await this.cloud.patchSkills(references, cloud.etag);
+    } catch (error: any) {
+      if (error instanceof BotDefinitionCloudError && error.status === 412) {
+        try {
+          const refreshed = await this.cloud.read();
+          if (refreshed.kind === 'missing') {
+            this.pendingStore?.delete();
+            return {
+              action: 'degraded_local',
+              botId,
+              workspaceId: local.identity.workspaceId,
+              reason: 'CLOUD_ETAG_CONFLICT',
+              ...(blockedSkills.length ? { blockedSkills } : {}),
+            };
+          }
+          updated = refreshed.definition.skills !== undefined
+            && botSkillReferencesEqual(refreshed.definition.skills, references)
+            ? refreshed
+            : await this.cloud.patchSkills(references, refreshed.etag);
+        } catch {
+          return {
+            action: 'degraded_local',
+            botId,
+            workspaceId: local.identity.workspaceId,
+            reason: 'CLOUD_ETAG_CONFLICT',
+            ...(blockedSkills.length ? { blockedSkills } : {}),
+          };
+        }
+      } else {
+        const status = Number(error?.status);
+        if (status >= 400 && status < 500) this.pendingStore?.delete();
+        return {
+          action: 'degraded_local',
+          botId,
+          workspaceId: local.identity.workspaceId,
+          reason: safeErrorCode(error, 'CLOUD_UPDATE_FAILED'),
+          ...(blockedSkills.length ? { blockedSkills } : {}),
+        };
+      }
+    }
+    if (
+      updated.definition.botId !== botId
+      || updated.definition.skills === undefined
+      || !botSkillReferencesEqual(updated.definition.skills, references)
+    ) {
+      this.pendingStore?.delete();
+      return {
+        action: 'degraded_local',
+        botId,
+        workspaceId: local.identity.workspaceId,
+        reason: 'CLOUD_UPDATE_RESPONSE_MISMATCH',
+        ...(blockedSkills.length ? { blockedSkills } : {}),
+      };
+    }
+    this.writeBase(botId, local.identity.workspaceId, request.owner.authority, updated.etag, nextEntries);
+    this.pendingStore?.delete();
+    this.writeDefinitionCacheBestEffort(updated.definition);
+    return {
+      action: 'uploaded',
+      botId,
+      workspaceId: local.identity.workspaceId,
+      definitionETag: updated.etag,
+      ...(blockedSkills.length ? { blockedSkills } : {}),
+    };
+  }
+
+  private async createCloudFromSnapshot(
+    request: BotSkillSyncRequest,
+    local: Extract<BotSkillWorkspaceInspection, { kind: 'valid' }>,
+    base?: BotSkillSyncBase,
+  ): Promise<BotSkillSyncResult> {
+    const desired = await this.prepareLocalUpload(local, base);
+    this.assertLocalSnapshotUnchanged(request.owner, local);
+    if (!request.definitionForCreate) return blocked(request.owner.botId, 'LOCAL_MODEL_REQUIRED');
+    let created: BotDefinitionCloudSnapshot;
+    this.writePendingCloudUpdate(
+      request.owner.botId,
+      local.identity.workspaceId,
+      request.owner.authority,
+      desired.references,
+      desired.entries,
+    );
+    try {
+      created = await this.cloud.create({
+        ...request.definitionForCreate,
+        botId: request.owner.botId,
+        skills: desired.references,
+      });
+    } catch (error: any) {
+      if (error instanceof BotDefinitionCloudError && error.status === 412) {
+        this.pendingStore?.delete();
+        return {
+          action: 'conflict',
+          botId: request.owner.botId,
+          workspaceId: local.identity.workspaceId,
+          reason: 'CLOUD_CREATE_CONFLICT',
+          ...(desired.blockedSkills.length ? { blockedSkills: desired.blockedSkills } : {}),
+        };
+      }
+      const status = Number(error?.status);
+      if (status >= 400 && status < 500) this.pendingStore?.delete();
+      return {
+        action: 'degraded_local',
+        botId: request.owner.botId,
+        workspaceId: local.identity.workspaceId,
+        reason: safeErrorCode(error, 'CLOUD_CREATE_FAILED'),
+        ...(desired.blockedSkills.length ? { blockedSkills: desired.blockedSkills } : {}),
+      };
+    }
+    if (
+      created.definition.botId !== request.owner.botId
+      || created.definition.skills === undefined
+      || !botSkillReferencesEqual(created.definition.skills, desired.references)
+    ) {
+      this.pendingStore?.delete();
+      return {
+        action: 'degraded_local',
+        botId: request.owner.botId,
+        workspaceId: local.identity.workspaceId,
+        reason: 'CLOUD_CREATE_RESPONSE_MISMATCH',
+        ...(desired.blockedSkills.length ? { blockedSkills: desired.blockedSkills } : {}),
+      };
+    }
+    this.writeBase(
+      request.owner.botId,
+      local.identity.workspaceId,
+      request.owner.authority,
+      created.etag,
+      desired.entries,
+    );
+    this.pendingStore?.delete();
+    this.writeDefinitionCacheBestEffort(created.definition);
+    return {
+      action: 'created_cloud',
+      botId: request.owner.botId,
+      workspaceId: local.identity.workspaceId,
+      definitionETag: created.etag,
+      ...(desired.blockedSkills.length ? { blockedSkills: desired.blockedSkills } : {}),
+    };
+  }
+
+  private async createCloudFromLocal(
+    request: BotSkillSyncRequest,
+    workspaceId: string,
+    entries: BotSkillSyncBaseEntry[],
+  ): Promise<BotSkillSyncResult> {
+    if (!request.definitionForCreate) return blocked(request.owner.botId, 'LOCAL_MODEL_REQUIRED');
+    try {
+      const created = await this.cloud.create({
+        ...request.definitionForCreate,
+        botId: request.owner.botId,
+        skills: entries.map(entry => ({
+          skillId: entry.cloudSkillId,
+          version: entry.cloudVersion,
+        })),
+      });
+      this.writeBase(
+        request.owner.botId,
+        workspaceId,
+        request.owner.authority,
+        created.etag,
+        entries,
+      );
+      this.writeDefinitionCacheBestEffort(created.definition);
+      return {
+        action: 'created_cloud',
+        botId: request.owner.botId,
+        workspaceId,
+        definitionETag: created.etag,
+      };
+    } catch (error: any) {
+      return {
+        action: error instanceof BotDefinitionCloudError && error.status === 412 ? 'conflict' : 'degraded_local',
+        botId: request.owner.botId,
+        workspaceId,
+        reason: safeErrorCode(error, 'CLOUD_CREATE_FAILED'),
+      };
+    }
+  }
+
+  private async prepareLocalUpload(
+    local: Extract<BotSkillWorkspaceInspection, { kind: 'valid' }>,
+    base?: BotSkillSyncBase,
+  ): Promise<{
+    entries: BotSkillSyncBaseEntry[];
+    references: BotSkillReference[];
+    blockedSkills: BotSkillSyncBlockedSkill[];
+  }> {
+    const baseByLocalId = new Map((base?.entries ?? []).map(entry => [entry.localSkillId, entry]));
+    const entries: BotSkillSyncBaseEntry[] = [];
+    const blockedSkills: BotSkillSyncBlockedSkill[] = [];
+    for (const skill of local.skills) {
+      const previous = baseByLocalId.get(skill.localSkillId);
+      if (previous?.localContentHash === skill.contentHash) {
+        entries.push(previous);
+        continue;
+      }
+      try {
+        entries.push(await this.resolveCloudEntry(skill, previous));
+      } catch (error: any) {
+        blockedSkills.push({
+          localSkillId: skill.localSkillId,
+          name: skill.name,
+          code: safeErrorCode(error, 'PRIVATE_SKILL_UPLOAD_FAILED'),
+          ...(error instanceof BotSkillSourceError && error.relativePaths.length
+            ? { relativePaths: error.relativePaths }
+            : {}),
+        });
+        if (previous) entries.push(previous);
+      }
+    }
+    return {
+      entries,
+      references: normalizeBotSkillReferences(entries.map(entry => ({
+        skillId: entry.cloudSkillId,
+        version: entry.cloudVersion,
+      }))),
+      blockedSkills,
+    };
+  }
+
+  private async download(
+    request: BotSkillSyncRequest,
+    local: Extract<BotSkillWorkspaceInspection, { kind: 'valid' | 'missing' }>,
+    cloud: BotDefinitionCloudSnapshot,
+    base?: BotSkillSyncBase,
+    requireCloudStable = false,
+  ): Promise<BotSkillSyncResult> {
+    const references = cloud.definition.skills;
+    if (references === undefined) return blocked(request.owner.botId, 'CLOUD_DEFINITION_SKILLS_MISSING');
+    const initial = local.kind === 'valid' ? local : undefined;
+    try {
+      const restored = await restoreBotSkillWorkspace({
+        skillsRoot: this.workspace.root,
+        owner: request.owner,
+        references,
+        packageClient: this.packages,
+        existingWorkspaceId: initial?.identity.workspaceId,
+        baseEntries: base?.entries,
+        beforeCommit: async () => {
+          const latest = this.workspace.inspect(request.owner);
+          if (initial) {
+            if (
+              latest.kind !== 'valid'
+              || latest.identity.workspaceId !== initial.identity.workspaceId
+              || !sameLocalSnapshot(latest.skills, initial.skills)
+            ) {
+              throw syncError('Local workspace changed during cloud restore.', 'LOCAL_CHANGED_DURING_DOWNLOAD');
+            }
+          } else if (latest.kind !== 'missing') {
+            throw syncError('Local workspace appeared during cloud restore.', 'LOCAL_CHANGED_DURING_DOWNLOAD');
+          }
+          if (requireCloudStable) {
+            const latestCloud = await this.cloud.read();
+            if (
+              latestCloud.kind !== 'found'
+              || latestCloud.etag !== cloud.etag
+              || latestCloud.definition.skills === undefined
+              || !botSkillReferencesEqual(latestCloud.definition.skills, references)
+            ) {
+              throw syncError(
+                'Cloud Definition changed during sync repair.',
+                'CLOUD_CHANGED_DURING_DOWNLOAD',
+              );
+            }
+          }
+        },
+        now: this.now,
+        onPrepared: (result, paths) => {
+          this.pendingStore?.write({
+            schema: BOT_SKILL_PENDING_COMMIT_SCHEMA,
+            kind: 'restore',
+            phase: 'prepared',
+            botId: request.owner.botId,
+            workspaceId: result.identity.workspaceId,
+            ...(String(request.owner.authority || '').trim()
+              ? { authority: String(request.owner.authority).trim() }
+              : {}),
+            definitionETag: cloud.etag,
+            cloudReferences: references,
+            entries: result.entries,
+            createdAt: this.now().toISOString(),
+            updatedAt: this.now().toISOString(),
+            restore: paths,
+          });
+        },
+        onPhase: (phase, result, paths) => {
+          const existing = this.pendingStore?.read();
+          if (!existing) return;
+          this.pendingStore?.write({
+            ...existing,
+            phase,
+            workspaceId: result.identity.workspaceId,
+            entries: result.entries,
+            restore: paths,
+            updatedAt: this.now().toISOString(),
+          });
+        },
+        afterActivate: result => {
+          this.writeBase(
+            request.owner.botId,
+            result.identity.workspaceId,
+            request.owner.authority,
+            cloud.etag,
+            result.entries,
+          );
+          const existing = this.pendingStore?.read();
+          if (existing?.kind === 'restore' && existing.botId === request.owner.botId) {
+            this.pendingStore?.write({
+              ...existing,
+              phase: 'base_committed',
+              updatedAt: this.now().toISOString(),
+            });
+          }
+        },
+      });
+      this.pendingStore?.delete();
+      this.writeDefinitionCacheBestEffort(cloud.definition);
+      return {
+        action: 'downloaded',
+        botId: request.owner.botId,
+        workspaceId: restored.identity.workspaceId,
+        definitionETag: cloud.etag,
+      };
+    } catch (error: any) {
+      return {
+        action: initial ? 'degraded_local' : 'blocked',
+        botId: request.owner.botId,
+        workspaceId: initial?.identity.workspaceId,
+        reason: safeErrorCode(error, 'CLOUD_RESTORE_FAILED'),
+      };
+    }
+  }
+
+  private assertLocalSnapshotUnchanged(
+    owner: BotSkillWorkspaceOwner,
+    original: Extract<BotSkillWorkspaceInspection, { kind: 'valid' }>,
+  ): void {
+    const latest = this.workspace.inspect(owner);
+    if (
+      latest.kind !== 'valid'
+      || latest.identity.workspaceId !== original.identity.workspaceId
+      || !sameLocalSnapshot(latest.skills, original.skills)
+    ) {
+      throw syncError('Local workspace changed during upload.', 'LOCAL_CHANGED_DURING_SYNC');
+    }
+  }
+
+  private writeBase(
+    botId: string,
+    workspaceId: string,
+    authority: string | undefined,
+    definitionETag: string | undefined,
+    entries: BotSkillSyncBaseEntry[],
+  ): void {
+    this.baseStore.write({
+      schema: BOT_SKILL_SYNC_BASE_SCHEMA,
+      botId,
+      workspaceId,
+      ...(String(authority || '').trim() ? { authority: String(authority).trim() } : {}),
+      ...(definitionETag ? { definitionETag } : {}),
+      entries,
+      updatedAt: this.now().toISOString(),
+    });
+  }
+
+  private async resolveCloudEntry(
+    skill: BotLocalSkillSnapshot,
+    previous?: BotSkillSyncBaseEntry,
+  ): Promise<BotSkillSyncBaseEntry> {
+    if (!previous && skill.cloudOrigin) {
+      let originPackage;
+      try {
+        originPackage = await this.packages.download(skill.cloudOrigin);
+      } catch {
+        throw syncError(
+          'The installed public Skill origin could not be verified.',
+          'PUBLIC_SKILL_ORIGIN_VERIFICATION_FAILED',
+        );
+      }
+      if (
+        originPackage.reference.skillId !== skill.cloudOrigin.skillId
+        || originPackage.reference.version !== skill.cloudOrigin.version
+      ) {
+        throw syncError('Public Skill origin response is inconsistent.', 'PUBLIC_SKILL_ORIGIN_MISMATCH');
+      }
+      if (originPackage.contentHash === skill.contentHash) {
+        return {
+          localSkillId: skill.localSkillId,
+          localContentHash: skill.contentHash,
+          cloudSkillId: skill.cloudOrigin.skillId,
+          cloudVersion: skill.cloudOrigin.version,
+        };
+      }
+    }
+    const snapshot = buildBotSkillSourceSnapshot(skill.directoryPath);
+    if (snapshot.contentHash !== skill.contentHash) {
+      throw syncError('Local Skill changed while its upload snapshot was being created.', 'LOCAL_CHANGED_DURING_SYNC');
+    }
+    const origin = previous
+      ? { skillId: previous.cloudSkillId, version: previous.cloudVersion }
+      : skill.cloudOrigin;
+    const uploaded = await this.packages.upsert({
+      localSkillId: skill.localSkillId,
+      name: skill.name,
+      snapshot,
+      ...(origin ? { origin } : {}),
+    });
+    assertUploadedVersionMatches(skill, snapshot.contentHash, uploaded);
+    return {
+      localSkillId: skill.localSkillId,
+      localContentHash: skill.contentHash,
+      cloudSkillId: uploaded.reference.skillId,
+      cloudVersion: uploaded.reference.version,
+    };
+  }
+
+  private writePendingCloudUpdate(
+    botId: string,
+    workspaceId: string,
+    authority: string | undefined,
+    cloudReferences: BotSkillReference[],
+    entries: BotSkillSyncBaseEntry[],
+  ): void {
+    if (!this.pendingStore) return;
+    const timestamp = this.now().toISOString();
+    this.pendingStore.write({
+      schema: BOT_SKILL_PENDING_COMMIT_SCHEMA,
+      kind: 'cloud_update',
+      phase: 'prepared',
+      botId,
+      workspaceId,
+      ...(String(authority || '').trim() ? { authority: String(authority).trim() } : {}),
+      cloudReferences,
+      entries,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+  }
+
+  private recoverPendingCommit(
+    pending: BotSkillPendingCommit,
+    inspected: BotSkillWorkspaceInspection,
+    cloud: BotDefinitionCloudSnapshot,
+    authority?: string,
+  ): boolean {
+    if (
+      cloud.definition.skills === undefined
+      || !botSkillReferencesEqual(cloud.definition.skills, pending.cloudReferences)
+    ) {
+      if (
+        pending.kind === 'restore'
+        && this.preserveActivatedRestore(pending, authority)
+      ) {
+        return false;
+      }
+      if (pending.kind === 'restore') this.rollbackPendingRestore(pending);
+      this.pendingStore?.delete();
+      return false;
+    }
+    if (pending.kind === 'restore') {
+      return this.recoverPendingRestore(pending, cloud, authority);
+    }
+    if (
+      inspected.kind !== 'valid'
+      || inspected.identity.workspaceId !== pending.workspaceId
+    ) {
+      this.pendingStore?.delete();
+      return false;
+    }
+    this.writeBase(pending.botId, pending.workspaceId, authority, cloud.etag, pending.entries);
+    if (pending.restore?.backupRoot && fs.existsSync(pending.restore.backupRoot)) {
+      fs.rmSync(pending.restore.backupRoot, { recursive: true, force: true });
+    }
+    this.pendingStore?.delete();
+    return true;
+  }
+
+  private recoverPendingRestore(
+    pending: BotSkillPendingCommit,
+    cloud: BotDefinitionCloudSnapshot,
+    authority?: string,
+  ): boolean {
+    const restore = pending.restore;
+    if (!restore) {
+      this.pendingStore?.delete();
+      return false;
+    }
+    this.assertPendingRestorePaths(restore);
+    let active = this.workspace.inspect({
+      botId: pending.botId,
+      ...(authority ? { authority } : {}),
+    });
+    if (active.kind !== 'valid' || active.identity.workspaceId !== pending.workspaceId) {
+      if (!fs.existsSync(restore.stagingRoot)) {
+        this.rollbackPendingRestore(pending);
+        this.pendingStore?.delete();
+        return false;
+      }
+      const staged = new BotSkillWorkspaceService({ skillsRoot: restore.stagingRoot }).inspect({
+        botId: pending.botId,
+        ...(authority ? { authority } : {}),
+      });
+      if (staged.kind !== 'valid' || staged.identity.workspaceId !== pending.workspaceId) {
+        this.rollbackPendingRestore(pending);
+        this.pendingStore?.delete();
+        return false;
+      }
+      if (fs.existsSync(restore.activeRoot)) {
+        if (!restore.hadActive || fs.existsSync(restore.backupRoot)) {
+          this.rollbackPendingRestore(pending);
+          this.pendingStore?.delete();
+          return false;
+        }
+        fs.renameSync(restore.activeRoot, restore.backupRoot);
+      }
+      fs.renameSync(restore.stagingRoot, restore.activeRoot);
+      active = this.workspace.inspect({
+        botId: pending.botId,
+        ...(authority ? { authority } : {}),
+      });
+      if (active.kind !== 'valid' || active.identity.workspaceId !== pending.workspaceId) {
+        this.rollbackPendingRestore(pending);
+        this.pendingStore?.delete();
+        return false;
+      }
+    }
+    this.writeBase(pending.botId, pending.workspaceId, authority, cloud.etag, pending.entries);
+    if (fs.existsSync(restore.backupRoot)) {
+      fs.rmSync(restore.backupRoot, { recursive: true, force: true });
+    }
+    if (fs.existsSync(restore.stagingRoot)) {
+      fs.rmSync(restore.stagingRoot, { recursive: true, force: true });
+    }
+    this.pendingStore?.delete();
+    return true;
+  }
+
+  private rollbackPendingRestore(pending: BotSkillPendingCommit): void {
+    const restore = pending.restore;
+    if (!restore) return;
+    this.assertPendingRestorePaths(restore);
+    if (fs.existsSync(restore.backupRoot)) {
+      if (fs.existsSync(restore.activeRoot)) {
+        const failed = `${restore.stagingRoot}.recovery`;
+        if (fs.existsSync(failed)) fs.rmSync(failed, { recursive: true, force: true });
+        fs.renameSync(restore.activeRoot, failed);
+        fs.renameSync(restore.backupRoot, restore.activeRoot);
+        fs.rmSync(failed, { recursive: true, force: true });
+      } else {
+        fs.renameSync(restore.backupRoot, restore.activeRoot);
+      }
+    } else if (!restore.hadActive && fs.existsSync(restore.activeRoot)) {
+      const active = this.workspace.inspect({ botId: pending.botId, authority: pending.authority });
+      if (active.kind === 'valid' && active.identity.workspaceId === pending.workspaceId) {
+        fs.rmSync(restore.activeRoot, { recursive: true, force: true });
+      }
+    }
+    if (fs.existsSync(restore.stagingRoot)) {
+      fs.rmSync(restore.stagingRoot, { recursive: true, force: true });
+    }
+  }
+
+  private preserveActivatedRestore(
+    pending: BotSkillPendingCommit,
+    authority?: string,
+  ): boolean {
+    if (!['activated', 'base_committed'].includes(pending.phase) || !pending.restore) return false;
+    this.assertPendingRestorePaths(pending.restore);
+    const active = this.workspace.inspect({
+      botId: pending.botId,
+      ...(authority ? { authority } : {}),
+    });
+    if (
+      active.kind !== 'valid'
+      || active.identity.workspaceId !== pending.workspaceId
+    ) {
+      if (active.kind !== 'missing') {
+        throw syncError(
+          'Activated Bot Skill workspace cannot be safely inspected during recovery.',
+          'PENDING_RESTORE_ACTIVE_UNSAFE',
+        );
+      }
+      return false;
+    }
+    this.writeBase(
+      pending.botId,
+      pending.workspaceId,
+      authority,
+      pending.definitionETag,
+      pending.entries,
+    );
+    if (fs.existsSync(pending.restore.backupRoot)) {
+      fs.rmSync(pending.restore.backupRoot, { recursive: true, force: true });
+    }
+    if (fs.existsSync(pending.restore.stagingRoot)) {
+      fs.rmSync(pending.restore.stagingRoot, { recursive: true, force: true });
+    }
+    this.pendingStore?.delete();
+    return true;
+  }
+
+  private writeDefinitionCacheBestEffort(definition: BotDefinition): void {
+    try {
+      const merge = () => {
+        const cached = this.definitionCache?.readCache?.(definition.botId)
+          ?? this.definitionCache?.readCanonical?.(definition.botId);
+        this.definitionCache?.writeCache(
+          cached
+            ? {
+              ...cached,
+              ...(definition.skills !== undefined ? { skills: definition.skills } : {}),
+            }
+            : definition,
+        );
+      };
+      if (this.definitionCache?.withWriteLock) {
+        this.definitionCache.withWriteLock(definition.botId, merge);
+      } else {
+        merge();
+      }
+    } catch {
+      // Base and the active workspace remain authoritative. The next cloud
+      // read can repair this local convenience cache.
+    }
+  }
+
+  private assertPendingRestorePaths(restore: NonNullable<BotSkillPendingCommit['restore']>): void {
+    const activeRoot = path.resolve(this.workspace.root);
+    const parent = path.dirname(activeRoot);
+    const stagingRoot = path.resolve(restore.stagingRoot);
+    const backupRoot = path.resolve(restore.backupRoot);
+    if (
+      path.resolve(restore.activeRoot) !== activeRoot
+      || path.dirname(stagingRoot) !== parent
+      || path.dirname(backupRoot) !== parent
+      || !path.basename(stagingRoot).startsWith('.bot-skill-restore-')
+      || !path.basename(backupRoot).startsWith('.bot-skill-backup-')
+    ) {
+      throw syncError('Pending restore paths are outside the Bot Skill workspace.', 'PENDING_RESTORE_PATH_INVALID');
+    }
+  }
+}
+
+function sameLocalSnapshot(
+  left: readonly BotLocalSkillSnapshot[],
+  right: readonly BotLocalSkillSnapshot[],
+): boolean {
+  const a = [...left].sort((x, y) => x.localSkillId.localeCompare(y.localSkillId));
+  const b = [...right].sort((x, y) => x.localSkillId.localeCompare(y.localSkillId));
+  return a.length === b.length && a.every((skill, index) => (
+    skill.localSkillId === b[index].localSkillId
+    && skill.contentHash === b[index].contentHash
+  ));
+}
+
+function blocked(botId: string, reason: string, detail?: string): BotSkillSyncResult {
+  return {
+    action: 'blocked',
+    botId,
+    reason: detail ? `${reason}: ${detail}` : reason,
+  };
+}
+
+function safeErrorCode(error: unknown, fallback: string): string {
+  const code = String((error as any)?.code || '').trim();
+  return code || fallback;
+}
+
+function syncError(message: string, code: string): Error {
+  const error: any = new Error(message);
+  error.code = code;
+  return error;
+}
+
+function assertUploadedVersionMatches(
+  skill: BotLocalSkillSnapshot,
+  expectedContentHash: string,
+  uploaded: Awaited<ReturnType<BotPrivateSkillPackageClient['upsert']>>,
+): void {
+  if (
+    uploaded.localSkillId !== skill.localSkillId
+    || uploaded.contentHash !== expectedContentHash
+    || !uploaded.reference
+  ) {
+    throw syncError('Private Skill upload response does not match the local snapshot.', 'PRIVATE_SKILL_UPLOAD_MISMATCH');
+  }
+  normalizeBotSkillReferences([uploaded.reference]);
+}

--- a/src/bot-skills/types.ts
+++ b/src/bot-skills/types.ts
@@ -1,0 +1,69 @@
+export const BOT_SKILL_WORKSPACE_SCHEMA = 'xiaoba.bot-skill-workspace.v1';
+export const BOT_LOCAL_SKILL_SCHEMA = 'xiaoba.local-skill.v1';
+export const BOT_SKILL_SYNC_BASE_SCHEMA = 'xiaoba.bot-skill-sync-base.v1';
+
+export interface BotSkillWorkspaceIdentity {
+  schema: typeof BOT_SKILL_WORKSPACE_SCHEMA;
+  workspaceId: string;
+  workspaceOwnerBotId: string;
+  /**
+   * Stable server/account namespace. It prevents a Bot id from another
+   * CatsCo deployment or account being mistaken for the same owner.
+   */
+  authority?: string;
+  ownerUserId?: string;
+  createdAt: string;
+}
+
+export interface BotLocalSkillIdentity {
+  schema: typeof BOT_LOCAL_SKILL_SCHEMA;
+  localSkillId: string;
+  createdAt: string;
+}
+
+export interface BotLocalSkillSnapshot {
+  localSkillId: string;
+  name: string;
+  directoryName: string;
+  directoryPath: string;
+  skillFilePath: string;
+  contentHash: string;
+  cloudOrigin?: {
+    skillId: string;
+    version: string;
+  };
+}
+
+export interface BotSkillSyncBaseEntry {
+  localSkillId: string;
+  localContentHash: string;
+  cloudSkillId: string;
+  cloudVersion: string;
+}
+
+export interface BotSkillSyncBase {
+  schema: typeof BOT_SKILL_SYNC_BASE_SCHEMA;
+  botId: string;
+  workspaceId: string;
+  authority?: string;
+  definitionETag?: string;
+  entries: BotSkillSyncBaseEntry[];
+  updatedAt: string;
+}
+
+export type BotSkillWorkspaceInspection =
+  | { kind: 'missing'; root: string }
+  | { kind: 'unowned'; root: string; skillCount: number }
+  | { kind: 'owner_mismatch'; root: string; identity: BotSkillWorkspaceIdentity }
+  | { kind: 'unreadable'; root: string; error: string }
+  | {
+      kind: 'valid';
+      root: string;
+      identity: BotSkillWorkspaceIdentity;
+      skills: BotLocalSkillSnapshot[];
+    };
+
+export type BotSkillSyncBaseReadResult =
+  | { kind: 'missing' }
+  | { kind: 'corrupt'; error: string }
+  | { kind: 'valid'; base: BotSkillSyncBase };

--- a/src/bot-skills/workspace-lock.ts
+++ b/src/bot-skills/workspace-lock.ts
@@ -1,0 +1,108 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+import { AsyncLocalStorage } from 'async_hooks';
+
+const workspaceTails = new Map<string, Promise<void>>();
+const heldWorkspaceLocks = new AsyncLocalStorage<ReadonlySet<string>>();
+const CORRUPT_LOCK_STALE_MS = 5_000;
+
+export async function withBotSkillWorkspaceLock<T>(
+  workspaceKey: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const normalizedKey = normalizeWorkspaceKey(workspaceKey);
+  const inheritedLocks = heldWorkspaceLocks.getStore();
+  if (inheritedLocks?.has(normalizedKey)) return operation();
+
+  const previous = workspaceTails.get(normalizedKey) ?? Promise.resolve();
+  let release!: () => void;
+  const current = new Promise<void>(resolve => {
+    release = resolve;
+  });
+  const tail = previous.catch(() => undefined).then(() => current);
+  workspaceTails.set(normalizedKey, tail);
+  await previous.catch(() => undefined);
+  const fileLock = await acquireWorkspaceFileLock(normalizedKey);
+  try {
+    const nextLocks = new Set(inheritedLocks ?? []);
+    nextLocks.add(normalizedKey);
+    return await heldWorkspaceLocks.run(nextLocks, operation);
+  } finally {
+    fileLock.release();
+    release();
+    if (workspaceTails.get(normalizedKey) === tail) workspaceTails.delete(normalizedKey);
+  }
+}
+
+async function acquireWorkspaceFileLock(workspaceKey: string): Promise<{ release(): void }> {
+  const lockPath = path.join(
+    path.dirname(workspaceKey),
+    `.${path.basename(workspaceKey)}.bot-skill.lock`,
+  );
+  fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+  const nonce = crypto.randomUUID();
+  const deadline = Date.now() + 30_000;
+  while (true) {
+    try {
+      const descriptor = fs.openSync(lockPath, 'wx', 0o600);
+      fs.writeFileSync(descriptor, JSON.stringify({ pid: process.pid, nonce, createdAt: new Date().toISOString() }));
+      return {
+        release(): void {
+          try {
+            fs.closeSync(descriptor);
+          } finally {
+            try {
+              const current = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
+              if (current?.nonce === nonce) fs.rmSync(lockPath, { force: true });
+            } catch {
+              // Never remove a lock we cannot prove belongs to this holder.
+            }
+          }
+        },
+      };
+    } catch (error: any) {
+      if (error?.code !== 'EEXIST') throw error;
+      removeStaleLock(lockPath);
+      if (Date.now() >= deadline) {
+        const timeout: any = new Error('Timed out waiting for the Bot Skill workspace lock.');
+        timeout.code = 'BOT_SKILL_WORKSPACE_LOCK_TIMEOUT';
+        throw timeout;
+      }
+      await new Promise(resolve => setTimeout(resolve, 25));
+    }
+  }
+}
+
+function normalizeWorkspaceKey(workspaceKey: string): string {
+  const resolved = path.resolve(workspaceKey);
+  return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
+}
+
+function removeStaleLock(lockPath: string): void {
+  try {
+    const value = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
+    const pid = Number(value?.pid);
+    if (!Number.isInteger(pid) || pid < 1 || !isProcessAlive(pid)) {
+      fs.rmSync(lockPath, { force: true });
+    }
+  } catch {
+    // A fresh partial write may belong to a live acquirer. A sufficiently old
+    // unreadable file can only be crash residue and must not brick the workspace.
+    try {
+      const ageMs = Date.now() - fs.statSync(lockPath).mtimeMs;
+      if (ageMs >= CORRUPT_LOCK_STALE_MS) fs.rmSync(lockPath, { force: true });
+    } catch {
+      // The lock disappeared or cannot be inspected; retry acquisition.
+    }
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error: any) {
+    return error?.code === 'EPERM';
+  }
+}

--- a/src/bot-skills/workspace-restore.ts
+++ b/src/bot-skills/workspace-restore.ts
@@ -1,0 +1,282 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+import type { BotSkillReference } from '../bot-definition/types';
+import {
+  BOT_LOCAL_SKILL_IDENTITY_FILE,
+  BOT_SKILL_WORKSPACE_IDENTITY_FILE,
+  BotSkillWorkspaceService,
+  type BotSkillWorkspaceOwner,
+} from './workspace';
+import type { BotPrivateSkillPackageClient, BotSkillDownloadedPackage } from './private-package';
+import {
+  BOT_LOCAL_SKILL_SCHEMA,
+  BOT_SKILL_WORKSPACE_SCHEMA,
+  type BotSkillSyncBaseEntry,
+  type BotSkillWorkspaceIdentity,
+} from './types';
+
+export interface BotSkillWorkspaceRestoreOptions {
+  skillsRoot: string;
+  owner: BotSkillWorkspaceOwner;
+  references: BotSkillReference[];
+  packageClient: Pick<BotPrivateSkillPackageClient, 'download'>;
+  existingWorkspaceId?: string;
+  baseEntries?: BotSkillSyncBaseEntry[];
+  beforeCommit?: () => Promise<void> | void;
+  onPrepared?: (
+    result: BotSkillWorkspaceRestoreResult,
+    paths: BotSkillRestorePaths,
+  ) => Promise<void> | void;
+  onPhase?: (
+    phase: 'old_parked' | 'activated',
+    result: BotSkillWorkspaceRestoreResult,
+    paths: BotSkillRestorePaths,
+  ) => Promise<void> | void;
+  afterActivate?: (result: BotSkillWorkspaceRestoreResult) => Promise<void> | void;
+  createId?: () => string;
+  now?: () => Date;
+}
+
+export interface BotSkillWorkspaceRestoreResult {
+  identity: BotSkillWorkspaceIdentity;
+  entries: BotSkillSyncBaseEntry[];
+}
+
+export interface BotSkillRestorePaths {
+  activeRoot: string;
+  stagingRoot: string;
+  backupRoot: string;
+  hadActive: boolean;
+}
+
+const MAX_WORKSPACE_SKILLS = 256;
+const MAX_WORKSPACE_FILES = 2_000;
+const MAX_WORKSPACE_BYTES = 100 * 1024 * 1024;
+
+export async function restoreBotSkillWorkspace(
+  options: BotSkillWorkspaceRestoreOptions,
+): Promise<BotSkillWorkspaceRestoreResult> {
+  const skillsRoot = path.resolve(options.skillsRoot);
+  const parent = path.dirname(skillsRoot);
+  const createId = options.createId ?? (() => crypto.randomUUID());
+  const now = options.now ?? (() => new Date());
+  const operationId = `${process.pid}-${Date.now()}-${createId()}`;
+  const staging = path.join(parent, `.bot-skill-restore-${operationId}`);
+  const backup = path.join(parent, `.bot-skill-backup-${operationId}`);
+  if (fs.existsSync(staging) || fs.existsSync(backup)) {
+    throw restoreError('Bot Skill restore path collision.', 'BOT_SKILL_RESTORE_PATH_COLLISION');
+  }
+  fs.mkdirSync(parent, { recursive: true });
+
+  const baseByReference = new Map(
+    (options.baseEntries ?? []).map(entry => [
+      `${entry.cloudSkillId}\0${entry.cloudVersion}`,
+      entry,
+    ]),
+  );
+  const baseBySkillId = new Map(
+    (options.baseEntries ?? []).map(entry => [entry.cloudSkillId, entry]),
+  );
+  try {
+    if (options.references.length > MAX_WORKSPACE_SKILLS) {
+      throw restoreError('Cloud Definition contains too many Skills.', 'BOT_SKILL_RESTORE_SKILL_LIMIT');
+    }
+    fs.mkdirSync(staging, { recursive: false });
+    const usedNames = new Set<string>();
+    const usedLocalIds = new Set<string>();
+    const entries: BotSkillSyncBaseEntry[] = [];
+    let totalFiles = 0;
+    let totalBytes = 0;
+    for (const reference of options.references) {
+      const item = await options.packageClient.download(reference);
+      validateDownloadBinding(reference, item);
+      totalFiles += item.files.length;
+      totalBytes += item.files.reduce((sum, file) => sum + file.size, 0);
+      if (totalFiles > MAX_WORKSPACE_FILES || totalBytes > MAX_WORKSPACE_BYTES) {
+        throw restoreError('Downloaded Skill workspace exceeds its aggregate budget.', 'BOT_SKILL_RESTORE_BUDGET_EXCEEDED');
+      }
+      const installName = safeSkillDirectoryName(item.name);
+      const portableInstallName = installName.toLocaleLowerCase('en-US');
+      if (usedNames.has(portableInstallName)) {
+        throw restoreError(`Duplicate Skill install name: ${installName}`, 'BOT_SKILL_RESTORE_NAME_CONFLICT');
+      }
+      const previous = baseByReference.get(`${item.reference.skillId}\0${item.reference.version}`)
+        ?? baseBySkillId.get(item.reference.skillId);
+      const localSkillId = previous?.localSkillId || item.localSkillId || createId();
+      if (usedLocalIds.has(localSkillId)) {
+        throw restoreError('Duplicate localSkillId in downloaded workspace.', 'BOT_SKILL_RESTORE_ID_CONFLICT');
+      }
+      usedNames.add(portableInstallName);
+      usedLocalIds.add(localSkillId);
+      const target = path.join(staging, installName);
+      fs.mkdirSync(target);
+      for (const file of item.files) {
+        const destination = safeJoin(target, file.path);
+        fs.mkdirSync(path.dirname(destination), { recursive: true });
+        fs.writeFileSync(destination, file.bytes);
+      }
+      writeJsonAtomic(path.join(target, BOT_LOCAL_SKILL_IDENTITY_FILE), {
+        schema: BOT_LOCAL_SKILL_SCHEMA,
+        localSkillId,
+        createdAt: now().toISOString(),
+      });
+      entries.push({
+        localSkillId,
+        localContentHash: item.contentHash,
+        cloudSkillId: item.reference.skillId,
+        cloudVersion: item.reference.version,
+      });
+    }
+    const identity: BotSkillWorkspaceIdentity = {
+      schema: BOT_SKILL_WORKSPACE_SCHEMA,
+      workspaceId: options.existingWorkspaceId || createId(),
+      workspaceOwnerBotId: String(options.owner.botId).trim(),
+      ...(String(options.owner.authority || '').trim()
+        ? { authority: String(options.owner.authority).trim() }
+        : {}),
+      ...(String(options.owner.ownerUserId || '').trim()
+        ? { ownerUserId: String(options.owner.ownerUserId).trim() }
+        : {}),
+      createdAt: now().toISOString(),
+    };
+    writeJsonAtomic(path.join(staging, BOT_SKILL_WORKSPACE_IDENTITY_FILE), identity);
+
+    const stagedInspection = new BotSkillWorkspaceService({
+      skillsRoot: staging,
+      createId,
+      now,
+    }).inspect(options.owner);
+    if (stagedInspection.kind !== 'valid') {
+      throw restoreError('Downloaded Skill workspace failed validation.', 'BOT_SKILL_RESTORE_VALIDATION_FAILED');
+    }
+    const actualHashById = new Map(stagedInspection.skills.map(skill => [skill.localSkillId, skill.contentHash]));
+    if (entries.some(entry => actualHashById.get(entry.localSkillId) !== entry.localContentHash)) {
+      throw restoreError('Downloaded Skill workspace content hash does not match its package.', 'BOT_SKILL_RESTORE_HASH_MISMATCH');
+    }
+    const result = {
+      identity,
+      entries: entries.sort((a, b) => a.localSkillId.localeCompare(b.localSkillId)),
+    };
+    await options.beforeCommit?.();
+    const hadActive = fs.existsSync(skillsRoot);
+    const restorePaths = {
+      activeRoot: skillsRoot,
+      stagingRoot: staging,
+      backupRoot: backup,
+      hadActive,
+    };
+    await options.onPrepared?.(result, restorePaths);
+    if (hadActive) fs.renameSync(skillsRoot, backup);
+    if (hadActive) await options.onPhase?.('old_parked', result, restorePaths);
+    try {
+      fs.renameSync(staging, skillsRoot);
+    } catch (error) {
+      if (hadActive && !fs.existsSync(skillsRoot) && fs.existsSync(backup)) {
+        fs.renameSync(backup, skillsRoot);
+      }
+      throw error;
+    }
+    await options.onPhase?.('activated', result, restorePaths);
+    await options.afterActivate?.(result);
+    if (hadActive && fs.existsSync(backup)) {
+      try {
+        fs.rmSync(backup, { recursive: true, force: true });
+      } catch {
+        // A disabled backup is safer than risking the newly activated workspace.
+      }
+    }
+    return result;
+  } catch (error) {
+    try {
+      if (fs.existsSync(backup)) {
+        if (fs.existsSync(skillsRoot)) {
+          const failedActive = `${staging}.failed-active`;
+          if (fs.existsSync(failedActive)) fs.rmSync(failedActive, { recursive: true, force: true });
+          fs.renameSync(skillsRoot, failedActive);
+          fs.renameSync(backup, skillsRoot);
+          fs.rmSync(failedActive, { recursive: true, force: true });
+        } else {
+          fs.renameSync(backup, skillsRoot);
+        }
+      }
+      if (fs.existsSync(staging)) fs.rmSync(staging, { recursive: true, force: true });
+    } catch {
+      // Preserve every remaining directory for startup recovery.
+    }
+    throw error;
+  }
+}
+
+function validateDownloadBinding(
+  requested: BotSkillReference,
+  downloaded: BotSkillDownloadedPackage,
+): void {
+  if (
+    downloaded.reference.skillId !== requested.skillId
+    || downloaded.reference.version !== requested.version
+    || !/^[a-f0-9]{64}$/.test(downloaded.contentHash)
+    || !downloaded.files.some(file => file.path === 'SKILL.md')
+  ) {
+    throw restoreError('Downloaded Skill package does not match its Cloud reference.', 'BOT_SKILL_RESTORE_REFERENCE_MISMATCH');
+  }
+}
+
+function safeSkillDirectoryName(value: string): string {
+  const raw = String(value || '').trim();
+  if (
+    /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,79}$/.test(raw)
+    && portableWindowsSegment(raw)
+  ) return raw;
+  const normalized = raw
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80);
+  if (!normalized || !portableWindowsSegment(normalized)) {
+    throw restoreError('Downloaded Skill name is unsafe.', 'BOT_SKILL_RESTORE_NAME_INVALID');
+  }
+  return normalized;
+}
+
+function safeJoin(root: string, relativePath: string): string {
+  const normalized = String(relativePath || '').replace(/\\/g, '/');
+  if (
+    !normalized
+    || normalized.includes('\0')
+    || normalized.startsWith('/')
+    || /^[a-zA-Z]:/.test(normalized)
+    || normalized.split('/').some(part => (
+      part === ''
+      || part === '.'
+      || part === '..'
+      || !portableWindowsSegment(part)
+    ))
+  ) {
+    throw restoreError('Downloaded Skill path is unsafe.', 'BOT_SKILL_RESTORE_PATH_UNSAFE');
+  }
+  const resolved = path.resolve(root, ...normalized.split('/'));
+  const relative = path.relative(root, resolved);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw restoreError('Downloaded Skill path escapes its directory.', 'BOT_SKILL_RESTORE_PATH_UNSAFE');
+  }
+  return resolved;
+}
+
+function portableWindowsSegment(value: string): boolean {
+  if (!value || /[<>:"|?*]/.test(value) || /[. ]$/.test(value)) return false;
+  const stem = value.split('.')[0].toUpperCase();
+  return !/^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])$/.test(stem);
+}
+
+function writeJsonAtomic(filePath: string, value: unknown): void {
+  const temporary = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  fs.writeFileSync(temporary, `${JSON.stringify(value, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 });
+  fs.renameSync(temporary, filePath);
+}
+
+function restoreError(message: string, code: string): Error {
+  const error: any = new Error(message);
+  error.code = code;
+  return error;
+}

--- a/src/bot-skills/workspace.ts
+++ b/src/bot-skills/workspace.ts
@@ -1,0 +1,239 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+import { SkillParser } from '../skills/skill-parser';
+import { computeLocalSkillContentHash } from '../skillhub/local-skill-metadata';
+import { readSkillHubInstallMarker } from '../skillhub/install-marker';
+import { PathResolver } from '../utils/path-resolver';
+import {
+  BOT_LOCAL_SKILL_SCHEMA,
+  BOT_SKILL_WORKSPACE_SCHEMA,
+  type BotLocalSkillIdentity,
+  type BotLocalSkillSnapshot,
+  type BotSkillWorkspaceIdentity,
+  type BotSkillWorkspaceInspection,
+} from './types';
+
+export const BOT_SKILL_WORKSPACE_IDENTITY_FILE = '.xiaoba-workspace.json';
+export const BOT_LOCAL_SKILL_IDENTITY_FILE = '.xiaoba-local-skill.json';
+
+export interface BotSkillWorkspaceOwner {
+  botId: string;
+  authority?: string;
+  ownerUserId?: string;
+}
+
+export interface BotSkillWorkspaceServiceOptions {
+  runtimeRoot?: string;
+  skillsRoot?: string;
+  now?: () => Date;
+  createId?: () => string;
+}
+
+export class BotSkillWorkspaceService {
+  readonly root: string;
+  private readonly now: () => Date;
+  private readonly createId: () => string;
+
+  constructor(options: BotSkillWorkspaceServiceOptions = {}) {
+    const runtimeRoot = path.resolve(options.runtimeRoot ?? PathResolver.getRuntimeDataRoot());
+    this.root = path.resolve(options.skillsRoot ?? path.join(runtimeRoot, 'skills'));
+    this.now = options.now ?? (() => new Date());
+    this.createId = options.createId ?? (() => crypto.randomUUID());
+  }
+
+  inspect(expectedOwner?: BotSkillWorkspaceOwner): BotSkillWorkspaceInspection {
+    if (!fs.existsSync(this.root)) return { kind: 'missing', root: this.root };
+    try {
+      const rootStat = fs.lstatSync(this.root);
+      if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) {
+        return { kind: 'unreadable', root: this.root, error: 'Skill workspace root is not a real directory.' };
+      }
+      fs.accessSync(this.root, fs.constants.R_OK);
+      const skillFiles = PathResolver.findSkillFiles(this.root);
+      const identityPath = path.join(this.root, BOT_SKILL_WORKSPACE_IDENTITY_FILE);
+      if (!fs.existsSync(identityPath)) {
+        return { kind: 'unowned', root: this.root, skillCount: skillFiles.length };
+      }
+      const identity = readWorkspaceIdentity(identityPath);
+      if (expectedOwner && !workspaceOwnerMatches(identity, expectedOwner)) {
+        return { kind: 'owner_mismatch', root: this.root, identity };
+      }
+      const skills = this.scanSkillFiles(skillFiles, true);
+      return { kind: 'valid', root: this.root, identity, skills };
+    } catch (error: any) {
+      return {
+        kind: 'unreadable',
+        root: this.root,
+        error: error?.message || String(error),
+      };
+    }
+  }
+
+  initializeEmpty(owner: BotSkillWorkspaceOwner): BotSkillWorkspaceIdentity {
+    validateOwner(owner);
+    if (fs.existsSync(this.root)) {
+      const entries = fs.readdirSync(this.root);
+      if (entries.length > 0) {
+        throw new Error('Cannot initialize a non-empty Skill workspace.');
+      }
+    } else {
+      fs.mkdirSync(this.root, { recursive: true });
+    }
+    const identity = this.newWorkspaceIdentity(owner);
+    writeJsonAtomic(path.join(this.root, BOT_SKILL_WORKSPACE_IDENTITY_FILE), identity);
+    return identity;
+  }
+
+  /**
+   * Explicit one-time migration for a legacy workspace. Per-Skill identities
+   * are committed first and the workspace owner marker last, so a crash cannot
+   * leave a partially identified directory looking fully owned.
+   */
+  claimExisting(owner: BotSkillWorkspaceOwner): BotSkillWorkspaceIdentity {
+    validateOwner(owner);
+    if (!fs.existsSync(this.root)) throw new Error('Cannot claim a missing Skill workspace.');
+    const rootStat = fs.lstatSync(this.root);
+    if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) {
+      throw new Error('Cannot claim a Skill workspace that is not a real directory.');
+    }
+    const identityPath = path.join(this.root, BOT_SKILL_WORKSPACE_IDENTITY_FILE);
+    if (fs.existsSync(identityPath)) {
+      const existing = readWorkspaceIdentity(identityPath);
+      if (!workspaceOwnerMatches(existing, owner)) {
+        throw new Error('Skill workspace is already owned by another Bot or authority.');
+      }
+      return existing;
+    }
+    this.scanSkillFiles(PathResolver.findSkillFiles(this.root), true);
+    const identity = this.newWorkspaceIdentity(owner);
+    writeJsonAtomic(identityPath, identity);
+    return identity;
+  }
+
+  private scanSkillFiles(skillFiles: string[], assignMissingIds: boolean): BotLocalSkillSnapshot[] {
+    const snapshots: BotLocalSkillSnapshot[] = [];
+    const seenIds = new Set<string>();
+    const seenNames = new Set<string>();
+    for (const skillFilePath of skillFiles.sort((a, b) => a.localeCompare(b))) {
+      const directoryPath = path.dirname(skillFilePath);
+      const localIdentity = this.readOrCreateLocalSkillIdentity(directoryPath, assignMissingIds);
+      if (seenIds.has(localIdentity.localSkillId)) {
+        throw new Error(`Duplicate localSkillId detected in Skill workspace: ${localIdentity.localSkillId}`);
+      }
+      const skill = SkillParser.parse(skillFilePath);
+      const name = String(skill.metadata.name || '').trim();
+      const portableName = name.toLocaleLowerCase('en-US');
+      if (seenNames.has(portableName)) {
+        throw new Error(`Duplicate Skill name detected in Skill workspace: ${name}`);
+      }
+      seenIds.add(localIdentity.localSkillId);
+      seenNames.add(portableName);
+      const installMarker = readSkillHubInstallMarker(directoryPath);
+      snapshots.push({
+        localSkillId: localIdentity.localSkillId,
+        name,
+        directoryName: path.basename(directoryPath),
+        directoryPath,
+        skillFilePath,
+        contentHash: computeLocalSkillContentHash(directoryPath),
+        ...(installMarker ? {
+          cloudOrigin: {
+            skillId: installMarker.skillId,
+            version: installMarker.version,
+          },
+        } : {}),
+      });
+    }
+    return snapshots.sort((a, b) => a.localSkillId.localeCompare(b.localSkillId));
+  }
+
+  private readOrCreateLocalSkillIdentity(
+    directoryPath: string,
+    assignMissing: boolean,
+  ): BotLocalSkillIdentity {
+    const markerPath = path.join(directoryPath, BOT_LOCAL_SKILL_IDENTITY_FILE);
+    if (fs.existsSync(markerPath)) return readLocalSkillIdentity(markerPath);
+    if (!assignMissing) throw new Error(`Skill identity is missing: ${directoryPath}`);
+    const identity: BotLocalSkillIdentity = {
+      schema: BOT_LOCAL_SKILL_SCHEMA,
+      localSkillId: this.createId(),
+      createdAt: this.now().toISOString(),
+    };
+    writeJsonAtomic(markerPath, identity);
+    return identity;
+  }
+
+  private newWorkspaceIdentity(owner: BotSkillWorkspaceOwner): BotSkillWorkspaceIdentity {
+    return {
+      schema: BOT_SKILL_WORKSPACE_SCHEMA,
+      workspaceId: this.createId(),
+      workspaceOwnerBotId: String(owner.botId).trim(),
+      ...(String(owner.authority || '').trim() ? { authority: String(owner.authority).trim() } : {}),
+      ...(String(owner.ownerUserId || '').trim() ? { ownerUserId: String(owner.ownerUserId).trim() } : {}),
+      createdAt: this.now().toISOString(),
+    };
+  }
+}
+
+function readWorkspaceIdentity(filePath: string): BotSkillWorkspaceIdentity {
+  const value = JSON.parse(fs.readFileSync(filePath, 'utf8')) as BotSkillWorkspaceIdentity;
+  if (
+    value?.schema !== BOT_SKILL_WORKSPACE_SCHEMA
+    || !validId(value.workspaceId)
+    || !String(value.workspaceOwnerBotId || '').trim()
+    || !validTimestamp(value.createdAt)
+  ) {
+    throw new Error('Skill workspace identity is invalid.');
+  }
+  return value;
+}
+
+function readLocalSkillIdentity(filePath: string): BotLocalSkillIdentity {
+  const value = JSON.parse(fs.readFileSync(filePath, 'utf8')) as BotLocalSkillIdentity;
+  if (
+    value?.schema !== BOT_LOCAL_SKILL_SCHEMA
+    || !validId(value.localSkillId)
+    || !validTimestamp(value.createdAt)
+  ) {
+    throw new Error(`Local Skill identity is invalid: ${filePath}`);
+  }
+  return value;
+}
+
+function validateOwner(owner: BotSkillWorkspaceOwner): void {
+  if (!String(owner.botId || '').trim()) throw new Error('workspace owner botId is required');
+}
+
+function workspaceOwnerMatches(
+  identity: BotSkillWorkspaceIdentity,
+  expected: BotSkillWorkspaceOwner,
+): boolean {
+  return (
+    identity.workspaceOwnerBotId === String(expected.botId).trim()
+    && String(identity.authority || '') === String(expected.authority || '').trim()
+    && (!expected.ownerUserId || identity.ownerUserId === String(expected.ownerUserId).trim())
+  );
+}
+
+function validId(value: unknown): boolean {
+  return /^[a-zA-Z0-9_.:-]{1,160}$/.test(String(value || ''));
+}
+
+function validTimestamp(value: unknown): boolean {
+  return Number.isFinite(Date.parse(String(value || '')));
+}
+
+function writeJsonAtomic(filePath: string, value: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const temporary = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  fs.writeFileSync(temporary, `${JSON.stringify(value, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 });
+  fs.renameSync(temporary, filePath);
+  if (process.platform !== 'win32') {
+    try {
+      fs.chmodSync(filePath, 0o600);
+    } catch {
+      // Some mounted filesystems do not expose POSIX modes.
+    }
+  }
+}

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -384,6 +384,10 @@ function shouldHydrateCatsCompanyGroupContext(
   return !sourceChannel || isNativeFeishuGroupTrigger(message);
 }
 
+export interface CatsCompanyBotLifecycleHooks {
+  onTurnSettled?(): void;
+}
+
 /**
  * CatsCompanyBot 主类
  * 初始化官方 SDK，注册事件，编排消息处理流程
@@ -434,8 +438,10 @@ export class CatsCompanyBot {
     capabilities: string[];
     model_status?: ReturnType<typeof resolveCatsDeviceModelStatus>;
   };
+  private readonly lifecycleHooks: CatsCompanyBotLifecycleHooks;
 
-  constructor(config: CatsCompanyConfig) {
+  constructor(config: CatsCompanyConfig, lifecycleHooks: CatsCompanyBotLifecycleHooks = {}) {
+    this.lifecycleHooks = lifecycleHooks;
     this.botUid = String(config.botUid || '').trim() || null;
     const localDeviceId = config.installationId || config.bodyId;
     const deviceRegistration = localDeviceId
@@ -1758,6 +1764,11 @@ export class CatsCompanyBot {
 
   private releaseSessionExecution(sessionKey: string): void {
     this.sessionExecutionReservations?.delete(sessionKey);
+    try {
+      this.lifecycleHooks.onTurnSettled?.();
+    } catch {
+      // Background Skill sync notification must never affect a completed turn.
+    }
   }
 
   private getSessionClearGeneration(sessionKey: string): number {

--- a/src/commands/catscompany.ts
+++ b/src/commands/catscompany.ts
@@ -17,6 +17,14 @@ import {
 } from '../bot-definition/cloud-client';
 import { CloudBotModelRuntimeReloadController } from '../bot-definition/runtime-reload';
 import { createBotDefinitionSyncService } from '../bot-definition/service';
+import {
+  assertBotSkillStartupReady,
+  BotSkillRuntime,
+  isBotSkillRuntimeEnabled,
+  resolveBotSkillRuntimeTransport,
+} from '../bot-skills/runtime';
+import { FileBotSkillNewBotIntentStore } from '../bot-skills/new-bot-intent';
+import { onBotSkillMutation } from '../bot-skills/mutation-events';
 
 const CONNECTOR_OWNER_POLL_MS = 2000;
 const CLOUD_MODEL_POLL_MS = 5000;
@@ -42,7 +50,7 @@ export function resolveCatsCoCommandConfig(
  */
 export async function catscompanyCommand(): Promise<void> {
   const runtimeRoot = PathResolver.getRuntimeDataRoot();
-  const preparedBot = await prepareBoundBotDefinition({
+  let preparedBot = await prepareBoundBotDefinition({
     runtimeRoot,
     acknowledgeCloudSelection: false,
   });
@@ -93,8 +101,80 @@ export async function catscompanyCommand(): Promise<void> {
     return;
   }
 
-  let bot = new CatsCompanyBot(connectorConfig);
   let lock: CatsCoConnectorLock | null = connectorLock;
+  let botSkillRuntime: BotSkillRuntime | undefined;
+  let unsubscribeBotSkillMutations: (() => void) | undefined;
+  let bot!: CatsCompanyBot;
+  let botSkillIdleRetryTimer: NodeJS.Timeout | null = null;
+  const scheduleBotSkillSyncWhenIdle = () => {
+    if (!botSkillRuntime) return;
+    if (bot?.isIdleForRuntimeReload()) {
+      if (botSkillIdleRetryTimer) clearTimeout(botSkillIdleRetryTimer);
+      botSkillIdleRetryTimer = null;
+      botSkillRuntime.schedule();
+      return;
+    }
+    if (botSkillIdleRetryTimer) return;
+    botSkillIdleRetryTimer = setTimeout(() => {
+      botSkillIdleRetryTimer = null;
+      scheduleBotSkillSyncWhenIdle();
+    }, 250);
+    botSkillIdleRetryTimer.unref?.();
+  };
+  try {
+    if (isBotSkillRuntimeEnabled()) {
+      const auth = createCatsCoLocalConfigService({ runtimeRoot }).getAuthState({
+        botUid: connectorConfig.botUid,
+        apiKey: connectorConfig.apiKey,
+        httpBaseUrl: connectorConfig.httpBaseUrl,
+      });
+      botSkillRuntime = new BotSkillRuntime({
+        runtimeRoot,
+        auth,
+        botId: connectorConfig.botUid,
+        transport: resolveBotSkillRuntimeTransport(),
+        canRunScheduledSync: () => Boolean(bot?.isIdleForRuntimeReload()),
+      });
+      unsubscribeBotSkillMutations = onBotSkillMutation(skillsRoot => {
+        if (botSkillRuntime && skillsRoot === botSkillRuntime.workspace.root) {
+          scheduleBotSkillSyncWhenIdle();
+        }
+      });
+      const newBotIntents = new FileBotSkillNewBotIntentStore(runtimeRoot);
+      const isExplicitNewBot = newBotIntents.matches({
+        botId: botSkillRuntime.owner.botId,
+        authority: botSkillRuntime.owner.authority || auth.httpBaseUrl,
+        ownerUserId: botSkillRuntime.owner.ownerUserId,
+      });
+      const outcome = await botSkillRuntime.sync({
+        definitionForCreate: preparedBot?.definition,
+        allowLegacyClaim: true,
+        allowNewWorkspaceCreate: isExplicitNewBot,
+        initializeDefaultSkill: isExplicitNewBot,
+      });
+      assertBotSkillStartupReady(outcome, botSkillRuntime.workspace, botSkillRuntime.owner);
+      if (outcome.result.action === 'created_cloud') {
+        newBotIntents.delete(botSkillRuntime.owner.botId);
+      }
+      if (outcome.definition) {
+        preparedBot = await prepareBoundBotDefinition({
+          runtimeRoot,
+          botId: connectorConfig.botUid,
+          auth,
+          definitionOverride: outcome.definition,
+          acknowledgeCloudSelection: false,
+        });
+      }
+    }
+  } catch (error) {
+    unsubscribeBotSkillMutations?.();
+    unsubscribeBotSkillMutations = undefined;
+    lock.release();
+    lock = null;
+    throw error;
+  }
+  const onTurnSettled = scheduleBotSkillSyncWhenIdle;
+  bot = new CatsCompanyBot(connectorConfig, { onTurnSettled });
   let ownerWatchTimer: NodeJS.Timeout | null = null;
   let cloudModelWatchTimer: NodeJS.Timeout | null = null;
   let cloudModelReloadPromise: Promise<void> | null = null;
@@ -113,11 +193,18 @@ export async function catscompanyCommand(): Promise<void> {
       clearInterval(cloudModelWatchTimer);
       cloudModelWatchTimer = null;
     }
+    if (botSkillIdleRetryTimer) {
+      clearTimeout(botSkillIdleRetryTimer);
+      botSkillIdleRetryTimer = null;
+    }
     try {
       await cloudModelReloadPromise;
+      await flushBotSkillRuntime(botSkillRuntime);
       await stopRuntimeCommandSupport();
       await bot.destroy();
     } finally {
+      unsubscribeBotSkillMutations?.();
+      unsubscribeBotSkillMutations = undefined;
       lock?.release();
       lock = null;
       process.exit(0);
@@ -140,6 +227,8 @@ export async function catscompanyCommand(): Promise<void> {
 
   try {
     await bot.start();
+    await bot.waitUntilReady();
+    Logger.info('[CATSCO_READY]');
     await startRuntimeCommandSupport();
     const auth = createCatsCoLocalConfigService({ runtimeRoot }).getAuthState();
     const modelBotId = String(preparedBot?.botId || connectorConfig.botUid || '').trim();
@@ -181,6 +270,7 @@ export async function catscompanyCommand(): Promise<void> {
         replaceBot: next => { bot = next; },
         botId: modelBotId,
         canApply: () => !shuttingDown,
+        onTurnSettled,
         scheduleAckRetry: (selection, applyError) => {
           pendingCloudModelAck = { selection, applyError, attempts: 0 };
         },
@@ -246,6 +336,7 @@ interface ApplyCloudModelRuntimeSelectionOptions {
   replaceBot(bot: CatsCompanyBot): void;
   botId: string;
   canApply(): boolean;
+  onTurnSettled?(): void;
   scheduleAckRetry(selection: CloudBotModelSelection, applyError: string): void;
   clearAckRetry(selection: CloudBotModelSelection): void;
   selection: CloudBotModelSelection;
@@ -322,7 +413,9 @@ async function applyCloudModelRuntimeSelection(
   let nextBot: CatsCompanyBot | undefined;
   try {
     await previousBot.destroy();
-    nextBot = new CatsCompanyBot(options.connectorConfig);
+    nextBot = new CatsCompanyBot(options.connectorConfig, {
+      onTurnSettled: options.onTurnSettled,
+    });
     await nextBot.start();
     await nextBot.waitUntilReady();
     options.replaceBot(nextBot);
@@ -337,7 +430,9 @@ async function applyCloudModelRuntimeSelection(
     await acknowledgeCloudModelApply(options, safeMessage);
     await recoverCloudModelFallbackConnector({
       canApply: options.canApply,
-      createBot: () => new CatsCompanyBot(options.connectorConfig),
+      createBot: () => new CatsCompanyBot(options.connectorConfig, {
+        onTurnSettled: options.onTurnSettled,
+      }),
       replaceBot: options.replaceBot,
     });
     throw new Error(safeMessage);
@@ -388,6 +483,22 @@ export async function recoverCloudModelFallbackConnector(
 
 function delay(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, Math.max(0, ms)));
+}
+
+async function flushBotSkillRuntime(runtime?: BotSkillRuntime): Promise<void> {
+  if (!runtime) return;
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    await Promise.race([
+      runtime.flush(),
+      new Promise<void>(resolve => {
+        timer = setTimeout(resolve, 5_000);
+        timer.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 async function acknowledgeCloudModelApply(

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -8,6 +8,14 @@ import chalk from 'chalk';
 import * as path from 'path';
 import * as fs from 'fs';
 import inquirer from 'inquirer';
+import { withBotSkillWorkspaceLock } from '../bot-skills/workspace-lock';
+import { notifyBotSkillMutation } from '../bot-skills/mutation-events';
+import {
+  BotSkillRuntime,
+  isBotSkillRuntimeEnabled,
+  resolveBotSkillRuntimeTransport,
+} from '../bot-skills/runtime';
+import { createCatsCoLocalConfigService } from '../catscompany/local-config';
 
 /**
  * Skill 命令处理器
@@ -58,6 +66,17 @@ export function registerSkillCommand(program: Command): void {
     .option('--npm', '移除 npm 包形式的 skill')
     .action(async (name: string, options: { force?: boolean; npm?: boolean }) => {
       await removeSkill(name, options);
+    });
+
+  skillCmd
+    .command('sync-repair <strategy>')
+    .description('Repair a missing/corrupt Bot Skill sync Base with local-wins or cloud-wins')
+    .option('-f, --force', 'Apply the selected repair strategy without confirmation')
+    .action(async (
+      strategy: string,
+      options: { force?: boolean },
+    ) => {
+      await repairBotSkillSync(strategy, options.force);
     });
 }
 
@@ -181,7 +200,7 @@ async function installGithubSkill(repo: string): Promise<void> {
 
   // 统一安装到 ~/.xiaoba/skills/
   const targetDir = PathResolver.getSkillsPath();
-  PathResolver.ensureDir(targetDir);
+  const expectedRuntime = currentCliBotSkillRuntime(targetDir);
 
   const skillPath = path.join(targetDir, repoName);
 
@@ -197,10 +216,20 @@ async function installGithubSkill(repo: string): Promise<void> {
     Logger.info(`目标目录: ${chalk.gray(skillPath)} (项目 skills 目录)\n`);
 
     // 克隆仓库
-    execSync(`git clone ${githubUrl} "${skillPath}"`, {
-      stdio: 'inherit',
-      cwd: targetDir
+    await withBotSkillWorkspaceLock(targetDir, async () => {
+      assertCliBotSkillOwnerUnchanged(expectedRuntime, targetDir);
+      PathResolver.ensureDir(targetDir);
+      if (fs.existsSync(skillPath)) {
+        const error: any = new Error(`Skill directory already exists: ${skillPath}`);
+        error.code = 'SKILL_ALREADY_EXISTS';
+        throw error;
+      }
+      execSync(`git clone ${githubUrl} "${skillPath}"`, {
+        stdio: 'inherit',
+        cwd: targetDir,
+      });
     });
+    await notifyAndSyncBotSkills(targetDir);
 
     Logger.success(`\n✓ Skill ${styles.highlight(repoName)} 安装成功！`);
     Logger.info(`安装位置: ${skillPath}`);
@@ -211,7 +240,10 @@ async function installGithubSkill(repo: string): Promise<void> {
     // 清理失败的安装
     if (fs.existsSync(skillPath)) {
       try {
-        fs.rmSync(skillPath, { recursive: true, force: true });
+        await withBotSkillWorkspaceLock(targetDir, async () => {
+          assertCliBotSkillOwnerUnchanged(expectedRuntime, targetDir);
+          fs.rmSync(skillPath, { recursive: true, force: true });
+        });
       } catch (cleanupError) {
         // 忽略清理错误
       }
@@ -283,6 +315,8 @@ async function removeNpmSkill(packageName: string, force?: boolean): Promise<voi
  * 移除本地 skill
  */
 async function removeLocalSkill(name: string, force?: boolean): Promise<void> {
+  const skillsRoot = PathResolver.getSkillsPath();
+  const expectedRuntime = currentCliBotSkillRuntime(skillsRoot);
   const manager = new SkillManager();
   await manager.loadSkills();
   const skill = manager.getSkill(name);
@@ -317,11 +351,129 @@ async function removeLocalSkill(name: string, force?: boolean): Promise<void> {
 
   try {
     Logger.info(`\n正在移除: ${chalk.gray(skillDir)}`);
-    fs.rmSync(skillDir, { recursive: true, force: true });
+    await withBotSkillWorkspaceLock(skillsRoot, async () => {
+      assertCliBotSkillOwnerUnchanged(expectedRuntime, skillsRoot);
+      const latestManager = new SkillManager();
+      await latestManager.loadSkills();
+      const latestSkill = latestManager.getSkill(name);
+      if (!latestSkill) {
+        const error: any = new Error(`Skill no longer exists: ${name}`);
+        error.code = 'SKILL_CHANGED_DURING_CONFIRMATION';
+        throw error;
+      }
+      fs.rmSync(path.dirname(latestSkill.filePath), { recursive: true, force: true });
+    });
+    await notifyAndSyncBotSkills(skillsRoot);
     Logger.success(`\n✓ Skill ${styles.highlight(name)} 已成功移除！`);
     Logger.info(`已删除目录: ${skillDir}`);
   } catch (error: any) {
     Logger.error(`移除失败: ${error.message}`);
     process.exit(1);
+  }
+}
+
+async function notifyAndSyncBotSkills(skillsRoot: string): Promise<void> {
+  notifyBotSkillMutation(skillsRoot);
+  if (!isBotSkillRuntimeEnabled()) return;
+  try {
+    const runtimeRoot = PathResolver.getRuntimeDataRoot();
+    const auth = createCatsCoLocalConfigService({ runtimeRoot }).getAuthState();
+    if (!auth.botUid || !auth.apiKey) return;
+    const runtime = new BotSkillRuntime({
+      runtimeRoot,
+      skillsRoot,
+      auth,
+      transport: resolveBotSkillRuntimeTransport(),
+    });
+    const outcome = await runtime.sync({ allowLegacyClaim: true });
+    if (outcome.result.action === 'blocked' || outcome.result.action === 'conflict') {
+      Logger.warning(`Bot Skill cloud sync is pending: ${outcome.result.reason || outcome.result.action}`);
+    }
+  } catch (error: any) {
+    Logger.warning(`Bot Skill cloud sync is pending: ${error?.code || error?.message || String(error)}`);
+  }
+}
+
+async function repairBotSkillSync(strategyValue: string, force?: boolean): Promise<void> {
+  const strategy = String(strategyValue || '').trim().toLowerCase();
+  if (strategy !== 'local-wins' && strategy !== 'cloud-wins') {
+    Logger.error('Strategy must be local-wins or cloud-wins.');
+    process.exitCode = 1;
+    return;
+  }
+  if (!isBotSkillRuntimeEnabled()) {
+    Logger.error('Bot Skill sync is not enabled.');
+    process.exitCode = 1;
+    return;
+  }
+  const runtime = currentCliBotSkillRuntime(PathResolver.getSkillsPath());
+  if (!runtime) {
+    Logger.error('A bound CatsCo Bot is required to repair Bot Skill sync.');
+    process.exitCode = 1;
+    return;
+  }
+  if (!force) {
+    const direction = strategy === 'local-wins'
+      ? 'replace the Cloud Skill references with the current local workspace'
+      : 'replace the current local workspace with the Cloud Skill references';
+    const { confirmed } = await inquirer.prompt([{
+      type: 'confirm',
+      name: 'confirmed',
+      message: `This will ${direction}. Continue?`,
+      default: false,
+    }]);
+    if (!confirmed) {
+      Logger.info('Bot Skill sync repair was cancelled.');
+      return;
+    }
+  }
+  const outcome = await runtime.repair(strategy);
+  if (outcome.result.action !== 'uploaded' && outcome.result.action !== 'downloaded') {
+    const blocked = outcome.result.blockedSkills?.map(skill => skill.name).join(', ');
+    Logger.error(
+      `Bot Skill sync repair did not complete: ${outcome.result.reason || outcome.result.action}`
+      + (blocked ? ` (${blocked})` : ''),
+    );
+    if (outcome.result.reason === 'SYNC_REPAIR_PENDING_COMMIT_EXISTS') {
+      Logger.info('Run a normal Bot Skill sync first so its pending commit can be recovered.');
+    }
+    process.exitCode = 1;
+    return;
+  }
+  Logger.success(
+    strategy === 'local-wins'
+      ? 'Bot Skill sync Base repaired from the local workspace.'
+      : 'Bot Skill sync Base repaired from Cloud.',
+  );
+}
+
+function currentCliBotSkillRuntime(skillsRoot: string): BotSkillRuntime | undefined {
+  if (!isBotSkillRuntimeEnabled()) return undefined;
+  const runtimeRoot = PathResolver.getRuntimeDataRoot();
+  const auth = createCatsCoLocalConfigService({ runtimeRoot }).getAuthState();
+  if (!auth.botUid || !auth.apiKey) return undefined;
+  return new BotSkillRuntime({
+    runtimeRoot,
+    skillsRoot,
+    auth,
+    transport: resolveBotSkillRuntimeTransport(),
+  });
+}
+
+function assertCliBotSkillOwnerUnchanged(
+  expected: BotSkillRuntime | undefined,
+  skillsRoot: string,
+): void {
+  if (!expected) return;
+  const current = currentCliBotSkillRuntime(skillsRoot);
+  if (
+    !current
+    || current.owner.botId !== expected.owner.botId
+    || current.owner.authority !== expected.owner.authority
+    || current.workspace.inspect(current.owner).kind !== 'valid'
+  ) {
+    const error: any = new Error('The active Bot changed while waiting to modify its Skill workspace.');
+    error.code = 'BOT_SKILL_ACTIVE_OWNER_CHANGED';
+    throw error;
   }
 }

--- a/src/dashboard/bot-skill-runtime.ts
+++ b/src/dashboard/bot-skill-runtime.ts
@@ -1,0 +1,56 @@
+import { createCatsCoLocalConfigService } from '../catscompany/local-config';
+import {
+  BotSkillRuntime,
+  isBotSkillRuntimeEnabled,
+  resolveBotSkillRuntimeTransport,
+} from '../bot-skills/runtime';
+import { PathResolver } from '../utils/path-resolver';
+import { Logger } from '../utils/logger';
+
+export async function mutateCurrentBotSkills<T>(
+  operation: () => Promise<T> | T,
+): Promise<T> {
+  const runtime = currentBotSkillRuntime();
+  if (!runtime) return operation();
+  return runtime.mutate(async () => {
+    const current = currentBotSkillRuntime();
+    if (
+      !current
+      || current.owner.botId !== runtime.owner.botId
+      || current.owner.authority !== runtime.owner.authority
+      || runtime.workspace.inspect(runtime.owner).kind !== 'valid'
+    ) {
+      const error: any = new Error('The active Bot changed while its Skill workspace was waiting for mutation.');
+      error.code = 'BOT_SKILL_ACTIVE_OWNER_CHANGED';
+      error.status = 409;
+      throw error;
+    }
+    return operation();
+  });
+}
+
+export function scheduleCurrentBotSkillSync(): void {
+  currentBotSkillRuntime()?.schedule({ allowLegacyClaim: true });
+}
+
+function currentBotSkillRuntime(): BotSkillRuntime | undefined {
+  if (!isBotSkillRuntimeEnabled()) return undefined;
+  const runtimeRoot = PathResolver.getRuntimeDataRoot();
+  const auth = createCatsCoLocalConfigService({ runtimeRoot }).getAuthState();
+  if (!auth.botUid || !auth.apiKey) return undefined;
+  try {
+    return new BotSkillRuntime({
+      runtimeRoot,
+      auth,
+      transport: resolveBotSkillRuntimeTransport(),
+      onBackgroundError: error => {
+        const code = String((error as any)?.code || 'BOT_SKILL_BACKGROUND_SYNC_FAILED');
+        Logger.warning(`Bot Skill background sync failed: ${code}`);
+      },
+    });
+  } catch (error) {
+    const code = String((error as any)?.code || 'BOT_SKILL_RUNTIME_UNAVAILABLE');
+    Logger.warning(`Bot Skill runtime is unavailable: ${code}`);
+    return undefined;
+  }
+}

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -71,6 +71,18 @@ import { resolveCatsCoRuntimeConfig } from '../../catscompany/runtime-config';
 import { consumeLocalFileGrant, validateLocalFileGrant } from '../local-file-grants';
 import { registerSkillHubRoutes } from './skillhub';
 import { registerPetRoutes } from './pet';
+import { mutateCurrentBotSkills } from '../bot-skill-runtime';
+import {
+  assertBotSkillStartupReady,
+  BotSkillRuntime,
+  isBotSkillRuntimeEnabled,
+  resolveBotSkillRuntimeTransport,
+} from '../../bot-skills/runtime';
+import { FileBotSkillSwitchJournalStore } from '../../bot-skills/switch-journal';
+import { BotSkillWorkspaceSwitchService } from '../../bot-skills/switch-service';
+import { BotSkillWorkspaceService } from '../../bot-skills/workspace';
+import { FileBotSkillNewBotIntentStore } from '../../bot-skills/new-bot-intent';
+import { withBotSkillWorkspaceLock } from '../../bot-skills/workspace-lock';
 import type { DashboardAuthStatus } from '../auth';
 import { SkillHubService } from '../../skillhub/service';
 import {
@@ -81,6 +93,7 @@ import {
   deletePromptOverride,
   getPromptEditorFile,
   getPromptEditorState,
+  normalizeEditablePromptPath,
   writePromptOverride,
 } from '../../utils/prompt-editor';
 import {
@@ -861,16 +874,31 @@ async function commitCatsBotBindingAndStartConnector(
   serviceManager: ServiceManager,
   state: CatsAuthState,
   input: CatsBotBindingInput,
-): Promise<{
-  updated: string[];
-  warnings: string[];
-  service: any;
-  preflight: any;
-  connectorStarted: boolean;
-  connectorRestarted: boolean;
-  botDefinitionSync?: Record<string, unknown>;
-}> {
+): Promise<CatsBotSwitchTransactionResult> {
   ensureCatsDeviceId();
+  if (isBotSkillRuntimeEnabled()) {
+    const runtimeRoot = runtimeDataRoot();
+    const transactionLock = path.join(runtimeRoot, 'data', 'bot-skill-switch', 'transaction');
+    return withBotSkillWorkspaceLock(transactionLock, () => (
+      commitCatsBotBindingAndStartConnectorLocked(serviceManager, state, input)
+    ));
+  }
+  return commitCatsBotBindingAndStartConnectorLocked(serviceManager, state, input);
+}
+
+async function commitCatsBotBindingAndStartConnectorLocked(
+  serviceManager: ServiceManager,
+  state: CatsAuthState,
+  input: CatsBotBindingInput,
+): Promise<CatsBotSwitchTransactionResult> {
+  const currentBinding = createCatsCoLocalConfigService({ runtimeRoot: runtimeDataRoot() }).load().currentBot;
+  if (
+    isBotSkillRuntimeEnabled()
+    && currentBinding?.uid
+    && currentBinding.uid !== input.botUid
+  ) {
+    return commitCatsBotSwitchTransaction(serviceManager, state, input);
+  }
   const rollback = createCatsCoLocalConfigRollback();
   const promptCoordinator = getPromptReconcileCoordinator({ runtimeRoot: runtimeDataRoot() });
   await promptCoordinator.prepareCurrentBotForSwitch();
@@ -918,6 +946,224 @@ async function commitCatsBotBindingAndStartConnector(
     promptCoordinator.restoreActiveSnapshot(promptSnapshot);
     throw error;
   }
+}
+
+interface CatsBotSwitchTransactionResult {
+  updated: string[];
+  warnings: string[];
+  service: any;
+  preflight: any;
+  connectorStarted: boolean;
+  connectorRestarted: boolean;
+  botDefinitionSync?: Record<string, unknown>;
+}
+
+async function commitCatsBotSwitchTransaction(
+  serviceManager: ServiceManager,
+  state: CatsAuthState,
+  input: CatsBotBindingInput,
+): Promise<CatsBotSwitchTransactionResult> {
+  const runtimeRoot = runtimeDataRoot();
+  const activeRoot = PathResolver.getSkillsPath();
+  const transactionLock = path.join(runtimeRoot, 'data', 'bot-skill-switch', 'transaction');
+  return withBotSkillWorkspaceLock(transactionLock, () => commitCatsBotSwitchTransactionLocked(
+    serviceManager,
+    state,
+    input,
+    runtimeRoot,
+    activeRoot,
+  ));
+}
+
+async function commitCatsBotSwitchTransactionLocked(
+  serviceManager: ServiceManager,
+  state: CatsAuthState,
+  input: CatsBotBindingInput,
+  runtimeRoot: string,
+  activeRoot: string,
+): Promise<CatsBotSwitchTransactionResult> {
+  const localConfigService = createCatsCoLocalConfigService({ runtimeRoot });
+  const current = localConfigService.load().currentBot;
+  if (!current?.uid || !current.apiKey) {
+    throw httpError('Current Bot binding is incomplete; cannot switch workspaces safely', 409);
+  }
+  if (current.uid === input.botUid) {
+    return {
+      updated: [],
+      warnings: [],
+      service: serviceManager.getService('catscompany'),
+      preflight: getServicePreflight(serviceManager, 'catscompany', {
+        runtimeRoot,
+        config: ConfigManager.getConfigReadonly(),
+      }),
+      connectorStarted: false,
+      connectorRestarted: false,
+    };
+  }
+  const rollbackBinding = createCatsCoLocalConfigRollback();
+  const sourceAuth = localConfigService.getAuthState({
+    botUid: current.uid,
+    apiKey: current.apiKey,
+  });
+  const targetAuth = localConfigService.getAuthState({
+    token: state.token,
+    uid: input.userUid,
+    httpBaseUrl: state.httpBaseUrl,
+    serverUrl: state.serverUrl,
+    botUid: input.botUid,
+    apiKey: input.apiKey,
+  });
+  const newBotIntents = new FileBotSkillNewBotIntentStore(runtimeRoot);
+  const isExplicitNewBot = newBotIntents.matches({
+    botId: input.botUid,
+    authority: targetAuth.httpBaseUrl,
+    ownerUserId: input.userUid,
+  });
+  const transport = resolveBotSkillRuntimeTransport();
+  const sourceRuntime = new BotSkillRuntime({
+    runtimeRoot,
+    skillsRoot: activeRoot,
+    auth: sourceAuth,
+    botId: current.uid,
+    transport,
+  });
+  const sourcePrepared = await prepareBoundBotDefinition({
+    runtimeRoot,
+    botId: current.uid,
+    auth: sourceAuth,
+    acknowledgeCloudSelection: false,
+  });
+  const sourceReady = await sourceRuntime.sync({
+    definitionForCreate: sourcePrepared?.definition,
+    allowLegacyClaim: true,
+  });
+  assertBotSkillStartupReady(sourceReady, sourceRuntime.workspace, sourceRuntime.owner);
+
+  const sourceParkedRoot = parkedBotSkillWorkspaceRoot(runtimeRoot, current.uid);
+  const targetParkedRoot = parkedBotSkillWorkspaceRoot(runtimeRoot, input.botUid);
+  const connectorWasRunning = serviceManager.getService('catscompany')?.status === 'running';
+  const warnings = await ensureCatsFriendBinding(state, input.userUid, input.botUid, input.apiKey);
+  let updated: string[] = [];
+  let targetPrepared: Awaited<ReturnType<typeof prepareBoundBotDefinition>>;
+  let targetSyncPayload: Record<string, unknown> | undefined;
+  let startPreflight: any;
+  let service: any = serviceManager.getService('catscompany');
+  let connectorStarted = false;
+
+  const switchService = new BotSkillWorkspaceSwitchService({
+    workspace: new BotSkillWorkspaceService({ runtimeRoot, skillsRoot: activeRoot }),
+    journalStore: new FileBotSkillSwitchJournalStore({ runtimeRoot }),
+  });
+  try {
+    await switchService.switch({
+      fromOwner: sourceRuntime.owner,
+      toOwner: {
+        botId: input.botUid,
+        authority: targetAuth.httpBaseUrl ? new URL(targetAuth.httpBaseUrl).origin.toLowerCase() : undefined,
+        ownerUserId: input.userUid,
+      },
+      fromParkedRoot: sourceParkedRoot,
+      targetPreparedRoot: targetParkedRoot,
+      oldConnectorWasRunning: connectorWasRunning,
+      prepareTarget: async targetRoot => {
+        const preliminary = await prepareBoundBotDefinition({
+          runtimeRoot,
+          botId: input.botUid,
+          auth: targetAuth,
+          selectedCatalogRuntime: input.selectedCatalogRuntime,
+          acknowledgeCloudSelection: false,
+        });
+        const targetRuntime = new BotSkillRuntime({
+          runtimeRoot,
+          skillsRoot: targetRoot,
+          auth: targetAuth,
+          botId: input.botUid,
+          transport,
+        });
+        const outcome = await targetRuntime.sync({
+          definitionForCreate: preliminary?.definition,
+          allowLegacyClaim: true,
+          allowNewWorkspaceCreate: isExplicitNewBot,
+          initializeDefaultSkill: isExplicitNewBot,
+        });
+        assertBotSkillStartupReady(outcome, targetRuntime.workspace, targetRuntime.owner);
+        targetSyncPayload = {
+          botId: outcome.result.botId,
+          action: outcome.result.action,
+          definitionETag: outcome.result.definitionETag,
+          blockedSkills: outcome.result.blockedSkills,
+        };
+        targetPrepared = outcome.definition
+          ? await prepareBoundBotDefinition({
+            runtimeRoot,
+            botId: input.botUid,
+            auth: targetAuth,
+            definitionOverride: outcome.definition,
+            selectedCatalogRuntime: input.selectedCatalogRuntime,
+            acknowledgeCloudSelection: false,
+          })
+          : preliminary;
+      },
+      stopOldConnector: async () => {
+        if (connectorWasRunning) await serviceManager.stopAndWait('catscompany');
+      },
+      syncOldWorkspace: async () => {
+        const outcome = await sourceRuntime.sync({
+          definitionForCreate: sourcePrepared?.definition,
+          allowLegacyClaim: true,
+        });
+        assertBotSkillStartupReady(outcome, sourceRuntime.workspace, sourceRuntime.owner);
+      },
+      preflightTarget: async () => {
+        if (!targetPrepared?.definition) {
+          throw httpError('Target Bot Definition could not be prepared', 409);
+        }
+      },
+      commitTargetBinding: async () => {
+        updated = writeCatsBotBinding(state, input);
+      },
+      rollbackSourceBinding: async () => {
+        rollbackBinding();
+      },
+      startTargetConnector: async () => {
+        startPreflight = getServicePreflight(serviceManager, 'catscompany', {
+          runtimeRoot,
+          config: ConfigManager.getConfigReadonly(),
+        });
+        if (startPreflight.status === 'blocked') {
+          throw httpError('CatsCo connector preflight blocked', 400);
+        }
+        service = await serviceManager.startAndWait('catscompany');
+        connectorStarted = true;
+      },
+      stopTargetConnector: async () => {
+        if (serviceManager.getService('catscompany')?.status === 'running') {
+          await serviceManager.stopAndWait('catscompany');
+        }
+      },
+      restartOldConnector: async () => {
+        if (connectorWasRunning) await serviceManager.startAndWait('catscompany');
+      },
+    });
+  } catch (error) {
+    throw error;
+  }
+  if (isExplicitNewBot) newBotIntents.delete(input.botUid);
+  return {
+    updated,
+    warnings,
+    service,
+    preflight: startPreflight,
+    connectorStarted,
+    connectorRestarted: connectorWasRunning,
+    botDefinitionSync: targetSyncPayload,
+  };
+}
+
+function parkedBotSkillWorkspaceRoot(runtimeRoot: string, botId: string): string {
+  const key = Buffer.from(String(botId || '').trim(), 'utf8').toString('base64url');
+  if (!key) throw httpError('Bot uid is required for its Skill workspace', 400);
+  return path.join(runtimeRoot, 'data', 'bot-skill-workspaces', `bot_${key}`);
 }
 
 function normalizeRelayModelProtocol(value: unknown): RelayModelProtocol {
@@ -2166,7 +2412,10 @@ export function createApiRouter(
 ): Router {
   const router = Router();
   const modelsDevFetch = options.modelsDevFetch ?? fetch;
-  registerSkillHubRoutes(router, { getCatsCoAuth: getCatsCoAuthForSkillHub });
+  registerSkillHubRoutes(router, {
+    getCatsCoAuth: getCatsCoAuthForSkillHub,
+    mutate: mutateCurrentBotSkills,
+  });
   registerPetRoutes(router);
 
   // ==================== 总览 ====================
@@ -2487,21 +2736,26 @@ export function createApiRouter(
     try {
       if (!requireJsonWrite(req, res)) return;
       const relativePath = String(req.body?.path || '');
+      const normalizedPath = normalizeEditablePromptPath(relativePath);
       const content = String(req.body?.content ?? '');
       const coordinator = getPromptReconcileCoordinator({ runtimeRoot: runtimeDataRoot() });
       const botId = coordinator.getCurrentBotId();
-      if (botId && relativePath === 'system-prompt.md') {
+      if (normalizedPath === 'system-prompt.md') {
+        if (!botId) {
+          res.status(409).json({ error: 'No bound bot is available for prompt selection' });
+          return;
+        }
         if (!coordinator.getSelection(botId).definitionReady) {
           res.status(409).json({ error: '机器人配置尚未初始化，连接完成后即可编辑' });
           return;
         }
         void coordinator.select(botId, 'custom', content).then(
-          () => res.json(getPromptEditorFile(relativePath)),
+          () => res.json(getPromptEditorFile(normalizedPath)),
           error => res.status(400).json({ error: error instanceof Error ? error.message : String(error) }),
         );
         return;
       }
-      res.json(writePromptOverride(relativePath, content));
+      res.json(writePromptOverride(normalizedPath, content));
     } catch (e: any) {
       res.status(400).json({ error: e?.message || String(e) });
     }
@@ -2511,20 +2765,25 @@ export function createApiRouter(
     try {
       if (!requireJsonWrite(req, res)) return;
       const relativePath = String(req.body?.path || req.query.path || '');
+      const normalizedPath = normalizeEditablePromptPath(relativePath);
       const coordinator = getPromptReconcileCoordinator({ runtimeRoot: runtimeDataRoot() });
       const botId = coordinator.getCurrentBotId();
-      if (botId && relativePath === 'system-prompt.md') {
+      if (normalizedPath === 'system-prompt.md') {
+        if (!botId) {
+          res.status(409).json({ error: 'No bound bot is available for prompt selection' });
+          return;
+        }
         if (!coordinator.getSelection(botId).definitionReady) {
           res.status(409).json({ error: '机器人配置尚未初始化，连接完成后即可编辑' });
           return;
         }
         void coordinator.select(botId, 'default').then(
-          () => res.json(getPromptEditorFile(relativePath)),
+          () => res.json(getPromptEditorFile(normalizedPath)),
           error => res.status(400).json({ error: error instanceof Error ? error.message : String(error) }),
         );
         return;
       }
-      res.json(deletePromptOverride(relativePath));
+      res.json(deletePromptOverride(normalizedPath));
     } catch (e: any) {
       res.status(400).json({ error: e?.message || String(e) });
     }
@@ -2558,12 +2817,14 @@ export function createApiRouter(
     }
   });
 
-  router.post('/prompts/editor-skill/install', (req, res) => {
+  router.post('/prompts/editor-skill/install', async (req, res) => {
     try {
       if (!requireJsonWrite(req, res)) return;
-      res.json(installPromptEditorSeedSkill({
-        overwrite: req.body?.overwrite === true,
-      }));
+      res.json(await mutateCurrentBotSkills(() => (
+        installPromptEditorSeedSkill({
+          overwrite: req.body?.overwrite === true,
+        })
+      )));
     } catch (e: any) {
       res.status(400).json({ error: e?.message || String(e) });
     }
@@ -3168,34 +3429,38 @@ export function createApiRouter(
 
   router.delete('/skills/:name', async (req, res) => {
     try {
-      const manager = new SkillManager();
-      await manager.loadSkills();
-      const skill = manager.getSkill(req.params.name);
-      if (!skill) {
-        const disabled = findDisabledSkillByName(PathResolver.getSkillsPath(), req.params.name);
-        if (disabled) {
-          const management = getSkillManagementInfo(disabled);
-          if (!management.canDelete) {
-            return res.status(403).json({ error: formatSkillDeleteBlockedMessage(management) });
+      const result = await mutateCurrentBotSkills(async () => {
+        const manager = new SkillManager();
+        await manager.loadSkills();
+        const skill = manager.getSkill(req.params.name);
+        if (!skill) {
+          const disabled = findDisabledSkillByName(PathResolver.getSkillsPath(), req.params.name);
+          if (disabled) {
+            const management = getSkillManagementInfo(disabled);
+            if (!management.canDelete) {
+              return { status: 403, body: { error: formatSkillDeleteBlockedMessage(management) } };
+            }
+            fs.rmSync(path.dirname(disabled), { recursive: true, force: true });
+            return { status: 200, body: { ok: true } };
           }
-          fs.rmSync(path.dirname(disabled), { recursive: true, force: true });
-          return res.json({ ok: true });
+          return { status: 404, body: { error: 'Skill not found' } };
         }
-        return res.status(404).json({ error: 'Skill not found' });
-      }
-      const management = getSkillManagementInfo(skill.filePath);
-      if (!management.canDelete) {
-        return res.status(403).json({ error: formatSkillDeleteBlockedMessage(management) });
-      }
-      fs.rmSync(path.dirname(skill.filePath), { recursive: true, force: true });
-      res.json({ ok: true });
+        const management = getSkillManagementInfo(skill.filePath);
+        if (!management.canDelete) {
+          return { status: 403, body: { error: formatSkillDeleteBlockedMessage(management) } };
+        }
+        fs.rmSync(path.dirname(skill.filePath), { recursive: true, force: true });
+        return { status: 200, body: { ok: true } };
+      });
+      res.status(result.status).json(result.body);
     } catch (e: any) {
-      res.status(500).json({ error: e.message });
+      res.status(Number(e?.status) || 500).json({ error: e.message });
     }
   });
 
   router.post('/skills/:name/disable', async (req, res) => {
     try {
+      await mutateCurrentBotSkills(async () => {
       const manager = new SkillManager();
       await manager.loadSkills();
       const skill = manager.getSkill(req.params.name);
@@ -3204,21 +3469,24 @@ export function createApiRouter(
       if (!management.canDisable) {
         return res.status(403).json({ error: '系统 Skill 不能禁用。' });
       }
-      fs.renameSync(skill.filePath, skill.filePath + '.disabled');
-      res.json({ ok: true });
+        fs.renameSync(skill.filePath, skill.filePath + '.disabled');
+        return res.json({ ok: true });
+      });
     } catch (e: any) {
-      res.status(500).json({ error: e.message });
+      res.status(Number(e?.status) || 500).json({ error: e.message });
     }
   });
 
   router.post('/skills/:name/enable', async (req, res) => {
     try {
-      const f = findDisabledSkillByName(PathResolver.getSkillsPath(), req.params.name);
-      if (!f) return res.status(404).json({ error: 'Disabled skill not found' });
-      fs.renameSync(f, f.replace('.disabled', ''));
-      res.json({ ok: true });
+      await mutateCurrentBotSkills(() => {
+        const f = findDisabledSkillByName(PathResolver.getSkillsPath(), req.params.name);
+        if (!f) return res.status(404).json({ error: 'Disabled skill not found' });
+        fs.renameSync(f, f.replace('.disabled', ''));
+        return res.json({ ok: true });
+      });
     } catch (e: any) {
-      res.status(500).json({ error: e.message });
+      res.status(Number(e?.status) || 500).json({ error: e.message });
     }
   });
 
@@ -3783,12 +4051,20 @@ export function createApiRouter(
         username,
         display_name: displayName,
       }, state.token);
+      const createdBotId = String(created.uid || created.id || '').trim();
+      if (isBotSkillRuntimeEnabled() && createdBotId) {
+        new FileBotSkillNewBotIntentStore(runtimeDataRoot()).write({
+          botId: createdBotId,
+          authority: state.httpBaseUrl,
+          ownerUserId: userUid,
+        });
+      }
 
       res.json({
         ok: true,
         deviceId,
         bot: {
-          uid: String(created.uid || created.id || ''),
+          uid: createdBotId,
           username: created.username || username,
           display_name: created.display_name || displayName,
           hasApiKey: Boolean(created.api_key),

--- a/src/dashboard/routes/skillhub.ts
+++ b/src/dashboard/routes/skillhub.ts
@@ -13,6 +13,7 @@ export interface SkillHubCatsCoAuthPayload {
 
 export interface SkillHubRouteOptions {
   getCatsCoAuth?: () => Promise<SkillHubCatsCoAuthPayload> | SkillHubCatsCoAuthPayload;
+  mutate?<T>(operation: () => Promise<T> | T): Promise<T>;
 }
 
 export function registerSkillHubRoutes(router: Router, options: SkillHubRouteOptions = {}): void {
@@ -87,7 +88,11 @@ export function registerSkillHubRoutes(router: Router, options: SkillHubRouteOpt
     try {
       const skillId = String(req.body?.skillId || '').trim();
       if (!skillId) return res.status(400).json({ error: 'skillId required' });
-      res.json(await serviceFrom(req.body).install(skillId, String(req.body?.version || '').trim() || undefined));
+      const install = () => serviceFrom(req.body).install(
+        skillId,
+        String(req.body?.version || '').trim() || undefined,
+      );
+      res.json(await (options.mutate ? options.mutate(install) : install()));
     } catch (error: any) {
       sendSkillHubError(res, error);
     }
@@ -136,7 +141,8 @@ export function registerSkillHubRoutes(router: Router, options: SkillHubRouteOpt
 
   router.post('/skillhub/developer/share-local-skill', async (req, res) => {
     try {
-      res.status(201).json(await serviceFrom(req.body).shareLocalSkill(req.body || {}));
+      const share = () => serviceFrom(req.body).shareLocalSkill(req.body || {});
+      res.status(201).json(await (options.mutate ? options.mutate(share) : share()));
     } catch (error: any) {
       sendSkillHubError(res, error);
     }
@@ -144,7 +150,8 @@ export function registerSkillHubRoutes(router: Router, options: SkillHubRouteOpt
 
   router.post('/skillhub/share-local-skill', async (req, res) => {
     try {
-      res.status(201).json(await serviceFrom(req.body).shareLocalSkill(req.body || {}));
+      const share = () => serviceFrom(req.body).shareLocalSkill(req.body || {});
+      res.status(201).json(await (options.mutate ? options.mutate(share) : share()));
     } catch (error: any) {
       sendSkillHubError(res, error);
     }

--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -2,10 +2,16 @@ import express from 'express';
 import * as path from 'path';
 import type { Server } from 'http';
 import { Logger } from '../utils/logger';
+import { PathResolver } from '../utils/path-resolver';
+import { isBotSkillRuntimeEnabled } from '../bot-skills/runtime';
+import { BotSkillWorkspaceService } from '../bot-skills/workspace';
+import { FileBotSkillSwitchJournalStore } from '../bot-skills/switch-journal';
+import { BotSkillWorkspaceSwitchService } from '../bot-skills/switch-service';
+import { createCatsCoLocalConfigService } from '../catscompany/local-config';
 import { createApiRouter } from './routes/api';
 import { ServiceManager } from './service-manager';
-import { bootstrapDefaultSkillHubSkillsOnce } from '../skillhub/default-skill-bootstrap';
 import { createDashboardAuth } from './auth';
+import { bootstrapDefaultSkillHubSkillsOnce } from '../skillhub/default-skill-bootstrap';
 
 const DEFAULT_PORT = 3800;
 const activeServers: Server[] = [];
@@ -33,12 +39,34 @@ export async function startDashboard(
   const envPackaged = /^(1|true|yes)$/i.test(process.env.XIAOBA_IS_PACKAGED || '');
   const projectRoot = controllers.projectRoot || (envPackaged ? process.env.XIAOBA_APP_ROOT : undefined) || process.cwd();
   const serviceManager = new ServiceManager(projectRoot);
+  if (!isBotSkillRuntimeEnabled()) {
+    void bootstrapDefaultSkillHubSkillsOnce().catch(error => {
+      Logger.warning(`Default Skill bootstrap failed: ${error instanceof Error ? error.message : String(error)}`);
+    });
+  } else {
+    const runtimeRoot = PathResolver.getRuntimeDataRoot();
+    const auth = createCatsCoLocalConfigService({ runtimeRoot }).getAuthState();
+    const recovery = await new BotSkillWorkspaceSwitchService({
+      workspace: new BotSkillWorkspaceService({ runtimeRoot }),
+      journalStore: new FileBotSkillSwitchJournalStore({ runtimeRoot }),
+    }).recover({
+      currentBotId: auth.botUid,
+      restartConnector: async result => {
+        try {
+          await serviceManager.startAndWait('catscompany');
+        } catch (error) {
+          Logger.warning(
+            `Recovered Bot Skill switch (${result}), but the CatsCo connector could not restart: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+        }
+      },
+    });
+    if (recovery !== 'none') Logger.info(`Recovered Bot Skill workspace switch: ${recovery}`);
+  }
 
   app.use(express.json({ limit: '25mb' }));
-
-  bootstrapDefaultSkillHubSkillsOnce().catch(error => {
-    Logger.warning(`Default SkillHub bootstrap failed: ${error?.message || String(error)}`);
-  });
 
   // Configure and apply dashboard authentication.
   // Trim the env var so whitespace-only values are treated as "not set"

--- a/src/dashboard/service-manager.ts
+++ b/src/dashboard/service-manager.ts
@@ -307,6 +307,9 @@ export class ServiceManager extends EventEmitter {
     const appendLog = (data: Buffer) => {
       const lines = data.toString().split('\n').filter(l => l.trim());
       svc.logs.push(...lines);
+      if (lines.some(line => line.includes('[CATSCO_READY]'))) {
+        this.emit('service-ready', name);
+      }
       if (svc.logs.length > MAX_LOG_LINES) {
         svc.logs = svc.logs.slice(-MAX_LOG_LINES);
       }
@@ -376,17 +379,101 @@ export class ServiceManager extends EventEmitter {
       this.killProcess(svc.process, true);
     } else {
       svc.expectedExit = 'stop';
-      svc.process.kill('SIGTERM');
+      const child = svc.process;
+      child.kill('SIGTERM');
 
       // 5秒后强制kill
       const forceKillTimer = setTimeout(() => {
-        if (svc.process && !svc.process.killed) {
-          svc.process.kill('SIGKILL');
+        if (svc.process === child) {
+          child.kill('SIGKILL');
         }
       }, 5000);
       forceKillTimer.unref?.();
     }
 
+    return this.getService(name)!;
+  }
+
+  async stopAndWait(name: string, timeoutMs = 10_000): Promise<ServiceInfo> {
+    const svc = this.services.get(name);
+    if (!svc) throw new Error(`Service "${name}" not found`);
+    if (svc.info.status !== 'running' || !svc.process) return this.getService(name)!;
+    const child = svc.process;
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        child.off('exit', onExit);
+        reject(new Error(`Timed out waiting for service "${name}" to stop`));
+      }, timeoutMs);
+      timer.unref?.();
+      const onExit = () => {
+        clearTimeout(timer);
+        resolve();
+      };
+      child.once('exit', onExit);
+      try {
+        this.stop(name);
+      } catch (error) {
+        clearTimeout(timer);
+        child.off('exit', onExit);
+        reject(error);
+      }
+    });
+    return this.getService(name)!;
+  }
+
+  async startAndWait(name: string, timeoutMs = 35_000): Promise<ServiceInfo> {
+    const existing = this.services.get(name);
+    if (!existing) throw new Error(`Service "${name}" not found`);
+    if (existing.info.status === 'running' && existing.logs.some(line => line.includes('[CATSCO_READY]'))) {
+      return this.getService(name)!;
+    }
+    this.start(name);
+    const service = this.services.get(name)!;
+    if (service.logs.some(line => line.includes('[CATSCO_READY]'))) return this.getService(name)!;
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const onReady = (readyName: string) => {
+          if (readyName !== name) return;
+          cleanup();
+          resolve();
+        };
+        const onStopped = (stoppedName: string) => {
+          if (stoppedName !== name) return;
+          cleanup();
+          reject(new Error(`Service "${name}" stopped before it became ready`));
+        };
+        const onError = (errorName: string, error: unknown) => {
+          if (errorName !== name) return;
+          cleanup();
+          reject(error instanceof Error ? error : new Error(String(error)));
+        };
+        const timer = setTimeout(() => {
+          cleanup();
+          reject(new Error(`Timed out waiting for service "${name}" to become ready`));
+        }, timeoutMs);
+        timer.unref?.();
+        const cleanup = () => {
+          clearTimeout(timer);
+          this.off('service-ready', onReady);
+          this.off('service-stopped', onStopped);
+          this.off('service-error', onError);
+        };
+        this.on('service-ready', onReady);
+        this.on('service-stopped', onStopped);
+        this.on('service-error', onError);
+      });
+    } catch (error) {
+      const current = this.services.get(name);
+      if (current && current.process === service.process && current.info.status === 'running') {
+        try {
+          await this.stopAndWait(name, Math.min(10_000, Math.max(1_000, timeoutMs)));
+        } catch {
+          // Preserve the original readiness failure; stopAndWait already
+          // escalates to the platform's force-stop path.
+        }
+      }
+      throw error;
+    }
     return this.getService(name)!;
   }
 

--- a/src/skillhub/default-skill-bootstrap.ts
+++ b/src/skillhub/default-skill-bootstrap.ts
@@ -43,6 +43,8 @@ export interface DefaultSkillBootstrapOptions {
   skills?: DefaultSkillHubSkill[];
   service?: Pick<SkillHubService, 'install'>;
   now?: () => Date;
+  skillsRoot?: string;
+  statePath?: string;
 }
 
 let bootstrapInFlight: Promise<DefaultSkillBootstrapResult[]> | null = null;
@@ -65,16 +67,17 @@ export async function bootstrapDefaultSkillHubSkills(
   const defaults = (options.skills ?? DEFAULT_SKILLHUB_SKILLS).filter(isValidDefaultSkill);
   if (!defaults.length) return [];
 
-  const service = options.service ?? new SkillHubService();
+  const skillsRoot = path.resolve(options.skillsRoot ?? PathResolver.getSkillsPath());
+  const service = options.service ?? new SkillHubService({ skillsRoot });
   const now = options.now ?? (() => new Date());
-  const statePath = getDefaultSkillBootstrapStatePath();
+  const statePath = options.statePath ?? getDefaultSkillBootstrapStatePath();
   const state = readStateFile(statePath);
   const results: DefaultSkillBootstrapResult[] = [];
   let changed = false;
 
   for (const item of defaults) {
     const itemState = state.items[item.key];
-    const targetDir = resolveSkillDirectory(item.installName);
+    const targetDir = resolveSkillDirectory(item.installName, skillsRoot);
     const activeSkillFile = path.join(targetDir, 'SKILL.md');
     const disabledSkillFile = `${activeSkillFile}.disabled`;
 
@@ -103,7 +106,7 @@ export async function bootstrapDefaultSkillHubSkills(
     if (fs.existsSync(targetDir)) {
       state.items[item.key] = {
         ...nextState(item, 'name_conflict', now),
-        relativePath: path.relative(PathResolver.getSkillsPath(), targetDir),
+        relativePath: path.relative(skillsRoot, targetDir),
       };
       changed = true;
       results.push({ key: item.key, state: 'name_conflict', action: 'recorded', reason: 'local_same_name_exists' });
@@ -115,7 +118,7 @@ export async function bootstrapDefaultSkillHubSkills(
       const installed = await service.install(item.skillId, item.version);
       state.items[item.key] = {
         ...nextState(item, 'installed', now),
-        relativePath: path.relative(PathResolver.getSkillsPath(), installed.skill.path),
+        relativePath: path.relative(skillsRoot, installed.skill.path),
         installedAt: attemptedAt,
         lastAttemptAt: attemptedAt,
       };
@@ -189,8 +192,8 @@ function writeStateFile(filePath: string, state: DefaultSkillBootstrapStateFile)
   fs.renameSync(tmpPath, filePath);
 }
 
-function resolveSkillDirectory(installName: string): string {
-  const root = path.resolve(PathResolver.getSkillsPath());
+function resolveSkillDirectory(installName: string, skillsRoot?: string): string {
+  const root = path.resolve(skillsRoot ?? PathResolver.getSkillsPath());
   const target = path.resolve(root, installName);
   const relative = path.relative(root, target);
   if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {

--- a/src/skillhub/install-marker.ts
+++ b/src/skillhub/install-marker.ts
@@ -33,8 +33,11 @@ export function writeSkillHubInstallMarker(skillDir: string, marker: SkillHubPac
   fs.renameSync(tempPath, markerPath);
 }
 
-export function listInstalledSkillHubSkills(userId?: string): SkillHubPackageInstallMarker[] {
-  const root = path.resolve(PathResolver.getSkillsPath());
+export function listInstalledSkillHubSkills(
+  userId?: string,
+  skillsRoot: string = PathResolver.getSkillsPath(),
+): SkillHubPackageInstallMarker[] {
+  const root = path.resolve(skillsRoot);
   if (!fs.existsSync(root)) return [];
   const expectedUserId = stringValue(userId);
   const markers: SkillHubPackageInstallMarker[] = [];

--- a/src/skillhub/local-skill-metadata.ts
+++ b/src/skillhub/local-skill-metadata.ts
@@ -1,7 +1,6 @@
-import * as crypto from 'crypto';
 import * as fs from 'fs';
-import * as path from 'path';
 import matter from 'gray-matter';
+import { computeBotSkillSourceContentHash } from '../bot-skills/source-snapshot';
 
 export interface SkillHubLocalMetadata {
   author?: string;
@@ -14,19 +13,6 @@ const SKILLHUB_METADATA_KEYS = {
   version: 'skillhub_version',
   uploadedAt: 'skillhub_uploaded_at',
 } as const;
-
-const SOURCE_SKIP_DIRS = new Set([
-  '.git',
-  'node_modules',
-]);
-
-const GENERATED_PACKAGE_FILES = new Set([
-  'skill.json',
-  'REVIEW.json',
-  'SBOM.json',
-  '.xiaoba-bundled-skill.json',
-  '.xiaoba-skillhub-install.json',
-]);
 
 export function readSkillHubLocalMetadata(skillFilePath: string): SkillHubLocalMetadata | null {
   if (!fs.existsSync(skillFilePath)) return null;
@@ -59,24 +45,7 @@ export function applySkillHubLocalMetadata(markdown: string, metadata: Required<
 }
 
 export function computeLocalSkillContentHash(skillDir: string): string {
-  const root = path.resolve(skillDir);
-  const entries = walkSkillFiles(root)
-    .map(filePath => {
-      const relative = path.relative(root, filePath).replace(/\\/g, '/');
-      const buffer = skillHashBuffer(relative, fs.readFileSync(filePath));
-      return {
-        path: relative,
-        size: buffer.length,
-        sha256: sha256(buffer),
-      };
-    })
-    .sort((a, b) => a.path.localeCompare(b.path));
-  return sha256(Buffer.from(JSON.stringify(entries), 'utf8'));
-}
-
-function skillHashBuffer(relativePath: string, buffer: Buffer): Buffer {
-  if (relativePath !== 'SKILL.md') return buffer;
-  return Buffer.from(buffer.toString('utf8').replace(/\r\n/g, '\n'), 'utf8');
+  return computeBotSkillSourceContentHash(skillDir);
 }
 
 function fromMatterData(data: Record<string, any>): SkillHubLocalMetadata {
@@ -85,24 +54,6 @@ function fromMatterData(data: Record<string, any>): SkillHubLocalMetadata {
     version: stringOrUndefined(data[SKILLHUB_METADATA_KEYS.version]),
     uploadedAt: stringOrUndefined(data[SKILLHUB_METADATA_KEYS.uploadedAt]),
   };
-}
-
-function walkSkillFiles(root: string): string[] {
-  const result: string[] = [];
-  const visit = (current: string): void => {
-    if (!fs.existsSync(current)) return;
-    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
-      if (entry.isSymbolicLink()) continue;
-      const fullPath = path.join(current, entry.name);
-      if (entry.isDirectory()) {
-        if (!SOURCE_SKIP_DIRS.has(entry.name)) visit(fullPath);
-      } else if (entry.isFile() && !GENERATED_PACKAGE_FILES.has(entry.name)) {
-        result.push(fullPath);
-      }
-    }
-  };
-  visit(root);
-  return result;
 }
 
 function stringOrUndefined(value: any): string | undefined {
@@ -114,8 +65,4 @@ function frontmatterLines(fields: Record<string, string>): string {
   return Object.entries(fields)
     .map(([key, value]) => `${key}: ${JSON.stringify(String(value))}\n`)
     .join('');
-}
-
-function sha256(value: Buffer): string {
-  return crypto.createHash('sha256').update(value).digest('hex');
 }

--- a/src/skillhub/package-installer.ts
+++ b/src/skillhub/package-installer.ts
@@ -15,6 +15,7 @@ export interface InstallVerifiedSkillHubPackageOptions {
   userId?: string;
   allowUpdate?: boolean;
   now?: () => Date;
+  skillsRoot?: string;
 }
 
 export interface InstallVerifiedSkillHubPackageResult {
@@ -30,12 +31,14 @@ export interface UninstallSkillHubPackageOptions {
   userId?: string;
   skillId: string;
   installName: string;
+  skillsRoot?: string;
 }
 
 export interface ClaimSkillHubPackageOwnershipOptions {
   userId: string;
   skillId: string;
   installName: string;
+  skillsRoot?: string;
 }
 
 export interface UninstallSkillHubPackageResult {
@@ -76,7 +79,7 @@ export function installVerifiedSkillHubPackage(
     throw new SkillHubInstallError(`SkillHub package is missing entry file ${entryFile}.`, 'ENTRY_FILE_MISSING');
   }
 
-  const skillsRoot = path.resolve(PathResolver.getSkillsPath());
+  const skillsRoot = path.resolve(options.skillsRoot ?? PathResolver.getSkillsPath());
   PathResolver.ensureDir(skillsRoot);
   const targetDir = safeJoin(skillsRoot, installName);
   const operationId = `${process.pid}-${Date.now()}-${crypto.randomBytes(6).toString('hex')}`;
@@ -174,7 +177,7 @@ export function installVerifiedSkillHubPackage(
 export function uninstallSkillHubPackage(
   options: UninstallSkillHubPackageOptions,
 ): UninstallSkillHubPackageResult {
-  const skillsRoot = path.resolve(PathResolver.getSkillsPath());
+  const skillsRoot = path.resolve(options.skillsRoot ?? PathResolver.getSkillsPath());
   const targetDir = safeJoin(skillsRoot, options.installName);
   if (!fs.existsSync(targetDir)) return { removed: false, path: targetDir };
 
@@ -191,7 +194,7 @@ export function uninstallSkillHubPackage(
 }
 
 export function claimSkillHubPackageOwnership(options: ClaimSkillHubPackageOwnershipOptions): boolean {
-  const skillsRoot = path.resolve(PathResolver.getSkillsPath());
+  const skillsRoot = path.resolve(options.skillsRoot ?? PathResolver.getSkillsPath());
   const targetDir = safeJoin(skillsRoot, options.installName);
   if (!fs.existsSync(targetDir)) return false;
 

--- a/src/skillhub/service.ts
+++ b/src/skillhub/service.ts
@@ -25,12 +25,16 @@ import type {
   SkillHubSubscriptionScope,
   SkillHubUser,
 } from './types';
+import { withBotSkillWorkspaceLock } from '../bot-skills/workspace-lock';
+import { notifyBotSkillMutation } from '../bot-skills/mutation-events';
 
 export class SkillHubService {
   private readonly client: SkillHubClient;
+  private readonly skillsRoot?: string;
 
-  constructor(options: { baseUrl?: string } = {}) {
+  constructor(options: { baseUrl?: string; skillsRoot?: string } = {}) {
     this.client = new SkillHubClient(options);
+    this.skillsRoot = options.skillsRoot ? path.resolve(options.skillsRoot) : undefined;
   }
 
   async status(): Promise<SkillHubAuthState & { trustReady: boolean; installed: SkillHubPackageInstallMarker[] }> {
@@ -38,7 +42,7 @@ export class SkillHubService {
     return {
       ...status,
       trustReady: CATSCO_SKILLHUB_ROOT_PUBLIC_KEYS.length > 0,
-      installed: listInstalledSkillHubSkills(),
+      installed: listInstalledSkillHubSkills(undefined, this.skillsRoot),
     };
   }
 
@@ -146,12 +150,17 @@ export class SkillHubService {
       registryEntry,
       trust,
     });
-    const installed = installVerifiedSkillHubPackage({
-      verification,
-      registryEntry,
-      userId: options.userId,
-      allowUpdate: options.allowUpdate,
-    });
+    const skillsRoot = this.skillsRoot ?? PathResolver.getSkillsPath();
+    const installed = await withBotSkillWorkspaceLock(skillsRoot, async () => (
+      installVerifiedSkillHubPackage({
+        verification,
+        registryEntry,
+        userId: options.userId,
+        allowUpdate: options.allowUpdate,
+        skillsRoot,
+      })
+    ));
+    notifyBotSkillMutation(skillsRoot);
     return {
       ok: true,
       skill: installed,
@@ -160,12 +169,17 @@ export class SkillHubService {
     };
   }
 
-  uninstall(input: { userId?: string; skillId: string; installName: string }): { removed: boolean; path: string } {
-    return uninstallSkillHubPackage(input);
+  async uninstall(input: { userId?: string; skillId: string; installName: string }): Promise<{ removed: boolean; path: string }> {
+    const skillsRoot = this.skillsRoot ?? PathResolver.getSkillsPath();
+    const result = await withBotSkillWorkspaceLock(skillsRoot, async () => (
+      uninstallSkillHubPackage({ ...input, skillsRoot })
+    ));
+    if (result.removed) notifyBotSkillMutation(skillsRoot);
+    return result;
   }
 
   claimInstalledSkillOwnership(input: { userId: string; skillId: string; installName: string }): boolean {
-    return claimSkillHubPackageOwnership(input);
+    return claimSkillHubPackageOwnership({ ...input, skillsRoot: this.skillsRoot });
   }
 
   developerDashboard(): Promise<any> {
@@ -279,7 +293,11 @@ export class SkillHubService {
     });
     const skillHubMetadata = skillHubMetadataFromShareResponse(submission);
     if (skillHubMetadata) {
-      writeSkillHubLocalMetadata(skill.filePath, skillHubMetadata);
+      const skillsRoot = this.skillsRoot ?? PathResolver.getSkillsPath();
+      await withBotSkillWorkspaceLock(skillsRoot, async () => {
+        writeSkillHubLocalMetadata(skill.filePath, skillHubMetadata);
+      });
+      notifyBotSkillMutation(skillsRoot);
     }
 
     return {

--- a/src/skillhub/subscription-service.ts
+++ b/src/skillhub/subscription-service.ts
@@ -17,7 +17,7 @@ export interface SkillHubSubscriptionGateway {
     version?: string,
     options?: { userId?: string; allowUpdate?: boolean },
   ): Promise<SkillHubInstallResult>;
-  uninstall(input: { userId?: string; skillId: string; installName: string }): { removed: boolean; path: string };
+  uninstall(input: { userId?: string; skillId: string; installName: string }): Promise<{ removed: boolean; path: string }>;
   claimInstalledSkillOwnership?(input: { userId: string; skillId: string; installName: string }): boolean;
 }
 
@@ -111,7 +111,7 @@ export class SkillHubSubscriptionService {
       };
     }
 
-    const result = this.gateway.uninstall({
+    const result = await this.gateway.uninstall({
       skillId: normalizedSkillId,
       installName: subscription.installName,
       ...(scope.kind === 'user' ? { userId: scope.userId } : {}),

--- a/src/utils/prompt-editor.ts
+++ b/src/utils/prompt-editor.ts
@@ -160,7 +160,7 @@ function textDigest(text: string): PromptEditorFile['effective'] {
   };
 }
 
-function normalizeEditablePromptPath(relativePath: string): string {
+export function normalizeEditablePromptPath(relativePath: string): string {
   const normalized = normalizePromptRelativePath(relativePath);
   if (normalized !== SYSTEM_PROMPT_RELATIVE_PATH) {
     throw new Error(`Prompt file is not editable: ${relativePath}`);

--- a/tests/bot-definition-activation.test.ts
+++ b/tests/bot-definition-activation.test.ts
@@ -104,6 +104,45 @@ describe('BotDefinition activation', () => {
     ]);
   });
 
+  test('activates an already reconciled Definition without replacing its Skill references from legacy simulated cloud', async () => {
+    const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-definition-override-runtime-'));
+    const simulatedCloudRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-definition-override-cloud-'));
+    roots.push(runtimeRoot, simulatedCloudRoot);
+    const env = {} as NodeJS.ProcessEnv;
+    createCatsCoLocalConfigService({ runtimeRoot, env }).save({
+      version: 1,
+      endpoints: { httpBaseUrl: 'https://cats.example.test', serverUrl: 'wss://cats.example.test/v0/channels' },
+      account: { token: 'user-token', uid: '7' },
+      currentBot: { uid: '43', apiKey: 'bot-api-key', boundByUserUid: '7', bindingSource: 'test' },
+    });
+    const definitions = new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot });
+    definitions.writeCanonical({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: '43',
+      model: { kind: 'custom', protocol: 'openai-responses', apiBase: 'https://legacy.example.test/v1', model: 'legacy', apiKey: 'legacy-key', contextWindowTokens: 64_000 },
+      skills: [{ skillId: 'legacy-skill', version: 'legacy-version' }],
+    });
+    const reconciled = {
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: '43',
+      model: { kind: 'custom' as const, protocol: 'openai-responses' as const, apiBase: 'https://current.example.test/v1', model: 'current', apiKey: 'current-key', contextWindowTokens: 128_000 },
+      skills: [{ skillId: 'priv_0123456789abcdef0123456789abcdef01234567', version: 'v_0123456789abcdef0123456789abcdef0123456789abcdef' }],
+    };
+
+    const prepared = await prepareBoundBotDefinition({
+      runtimeRoot,
+      simulatedCloudRoot,
+      env,
+      definitionOverride: reconciled,
+      cloudSelection: { kind: 'local', modelId: 'local', revision: 1 },
+      acknowledgeCloudSelection: false,
+    });
+
+    assert.deepStrictEqual(prepared?.definition.skills, reconciled.skills);
+    assert.deepStrictEqual(definitions.readCache('43')?.skills, reconciled.skills);
+    assert.deepStrictEqual(definitions.readCanonical('43')?.skills, [{ skillId: 'legacy-skill', version: 'legacy-version' }]);
+  });
+
   test('applies and acknowledges a cloud-selected model after its local runtime is ready', async () => {
     const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-cloud-model-runtime-'));
     const simulatedCloudRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-cloud-model-canonical-'));

--- a/tests/bot-definition-cloud.test.ts
+++ b/tests/bot-definition-cloud.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { BOT_DEFINITION_SCHEMA, type BotDefinition } from '../src/bot-definition/types';
+import {
+  BotDefinitionCloudError,
+  HttpBotDefinitionCloudClient,
+} from '../src/bot-skills/definition-cloud';
+import { FileBotDefinitionCloudClient } from '../src/bot-skills/file-definition-cloud';
+
+describe('Bot Definition cloud contract', () => {
+  let root: string;
+  const definition: BotDefinition = {
+    schema: BOT_DEFINITION_SCHEMA,
+    botId: 'bot-a',
+    model: { kind: 'catalog', modelId: 'model-a' },
+    skills: [{ skillId: 'private/a', version: '1' }],
+  };
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-definition-cloud-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('file cloud distinguishes 404, creates once, and enforces strong ETag on field-level PATCH', async () => {
+    const cloud = new FileBotDefinitionCloudClient({ root, botId: 'bot-a' });
+    assert.deepStrictEqual(await cloud.read(), { kind: 'missing' });
+
+    const created = await cloud.create(definition);
+    assert.equal(created.etag, '"definition-1"');
+    await assert.rejects(
+      cloud.create(definition),
+      (error: any) => error instanceof BotDefinitionCloudError && error.status === 412,
+    );
+    await assert.rejects(
+      cloud.patchSkills([], '"definition-stale"'),
+      (error: any) => error.status === 412,
+    );
+
+    const patched = await cloud.patchSkills([], created.etag);
+    assert.equal(patched.etag, '"definition-2"');
+    assert.deepStrictEqual(patched.definition.skills, []);
+    assert.deepStrictEqual(patched.definition.model, definition.model);
+  });
+
+  test('file cloud reports corrupt storage as an error instead of a missing Definition', async () => {
+    const cloud = new FileBotDefinitionCloudClient({ root, botId: 'bot-a' });
+    fs.mkdirSync(path.dirname(cloud.getPath()), { recursive: true });
+    fs.writeFileSync(cloud.getPath(), '{broken');
+
+    await assert.rejects(
+      cloud.read(),
+      (error: any) => error.code === 'BOT_DEFINITION_STORAGE_CORRUPT',
+    );
+  });
+
+  test('HTTP cloud sends Bot API Key and conditional headers without accepting weak/missing ETags', async () => {
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchImpl: typeof fetch = async (url, init) => {
+      requests.push({ url: String(url), init });
+      if (init?.method === 'GET') {
+        return new Response(JSON.stringify(definition), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json', ETag: '"definition-7"' },
+        });
+      }
+      return new Response(JSON.stringify({
+        ...definition,
+        skills: [],
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json', ETag: '"definition-8"' },
+      });
+    };
+    const cloud = new HttpBotDefinitionCloudClient({
+      botId: 'bot-a',
+      auth: {
+        apiKey: 'bot-secret',
+        httpBaseUrl: 'https://cats.example',
+        serverUrl: 'wss://cats.example',
+      },
+      fetchImpl,
+    });
+
+    const read = await cloud.read();
+    assert.equal(read.kind, 'found');
+    await cloud.patchSkills([], '"definition-7"');
+    assert.equal((requests[0].init?.headers as any).Authorization, 'ApiKey bot-secret');
+    assert.equal((requests[1].init?.headers as any)['If-Match'], '"definition-7"');
+    assert.deepStrictEqual(JSON.parse(String(requests[1].init?.body)), { skills: [] });
+
+    const invalidCloud = new HttpBotDefinitionCloudClient({
+      botId: 'bot-a',
+      auth: {
+        apiKey: 'bot-secret',
+        httpBaseUrl: 'https://cats.example',
+        serverUrl: 'wss://cats.example',
+      },
+      fetchImpl: async () => new Response(JSON.stringify(definition), { status: 200 }),
+    });
+    await assert.rejects(
+      invalidCloud.read(),
+      (error: any) => error.code === 'BOT_DEFINITION_ETAG_INVALID',
+    );
+  });
+
+  test('HTTP create sends only the server-owned skills field and does not overwrite model or prompt', async () => {
+    let requestBody: unknown;
+    const cloud = new HttpBotDefinitionCloudClient({
+      botId: 'bot-a',
+      auth: {
+        apiKey: 'bot-secret',
+        httpBaseUrl: 'https://cats.example',
+        serverUrl: 'wss://cats.example',
+      },
+      fetchImpl: async (_url, init) => {
+        requestBody = JSON.parse(String(init?.body));
+        return new Response(JSON.stringify({
+          ...definition,
+          prompt: { selected: 'custom', customSystemPrompt: 'server-owned prompt' },
+        }), {
+          status: 201,
+          headers: { 'Content-Type': 'application/json', ETag: '"definition-9"' },
+        });
+      },
+    });
+
+    await cloud.create({
+      ...definition,
+      prompt: { selected: 'custom', customSystemPrompt: 'local prompt' },
+    });
+
+    assert.deepStrictEqual(requestBody, { skills: definition.skills });
+  });
+
+  test('HTTP cloud treats only an explicit 404 as missing', async () => {
+    const cloud404 = new HttpBotDefinitionCloudClient({
+      botId: 'bot-a',
+      auth: { apiKey: 'key', httpBaseUrl: 'https://cats.example', serverUrl: '' },
+      fetchImpl: async () => new Response('', { status: 404 }),
+    });
+    assert.deepStrictEqual(await cloud404.read(), { kind: 'missing' });
+
+    const cloud500 = new HttpBotDefinitionCloudClient({
+      botId: 'bot-a',
+      auth: { apiKey: 'key', httpBaseUrl: 'https://cats.example', serverUrl: '' },
+      fetchImpl: async () => new Response('failed', { status: 500 }),
+    });
+    await assert.rejects(
+      cloud500.read(),
+      (error: any) => error.status === 500,
+    );
+  });
+
+  test('HTTP cloud migrates an existing legacy Bot through revision-zero PATCH', async () => {
+    const requests: RequestInit[] = [];
+    const cloud = new HttpBotDefinitionCloudClient({
+      botId: 'bot-a',
+      auth: { apiKey: 'key', httpBaseUrl: 'https://cats.example', serverUrl: '' },
+      fetchImpl: async (_url, init) => {
+        requests.push(init || {});
+        if (init?.method === 'GET') {
+          return new Response(JSON.stringify({
+            schema: BOT_DEFINITION_SCHEMA,
+            botId: 'bot-a',
+            model: { kind: 'catalog', modelId: 'model-a' },
+          }), {
+            status: 200,
+            headers: { ETag: '"bot-definition-1-m3-s0"' },
+          });
+        }
+        return new Response(JSON.stringify({
+          schema: BOT_DEFINITION_SCHEMA,
+          botId: 'bot-a',
+          model: { kind: 'catalog', modelId: 'model-a' },
+          skills: [],
+        }), {
+          status: 200,
+          headers: { ETag: '"bot-definition-1-m3-s1"' },
+        });
+      },
+    });
+
+    const legacy = await cloud.read();
+    assert.equal(legacy.kind, 'found');
+    assert.equal(legacy.kind === 'found' && legacy.definition.skills, undefined);
+    await cloud.patchSkills([], legacy.kind === 'found' ? legacy.etag : '');
+    assert.equal((requests[1].headers as any)['If-Match'], '"bot-definition-1-m3-s0"');
+  });
+});

--- a/tests/bot-definition-local-repository.test.ts
+++ b/tests/bot-definition-local-repository.test.ts
@@ -143,6 +143,114 @@ describe('BotDefinition local simulation', () => {
     assert.deepStrictEqual(repository.readCache('bot-alpha'), canonical);
   });
 
+  test('model and prompt updates preserve Definition fields owned by the other subsystem', () => {
+    const repository = new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot });
+    repository.writeCanonical({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-alpha',
+      model: { kind: 'catalog', modelId: 'old-model' },
+      prompt: { selected: 'custom', customSystemPrompt: 'keep me' },
+      skills: [
+        { skillId: 'private/skill-a', version: 'sha256:aaa' },
+        { skillId: 'public/skill-b', version: '1.2.3' },
+      ],
+    });
+    const service = createBotDefinitionSyncService({
+      runtimeRoot,
+      simulatedCloudRoot,
+      repository,
+    });
+
+    const result = service.publish('bot-alpha', { kind: 'catalog', modelId: 'new-model' });
+
+    assert.deepStrictEqual(result.definition.skills, [
+      { skillId: 'private/skill-a', version: 'sha256:aaa' },
+      { skillId: 'public/skill-b', version: '1.2.3' },
+    ]);
+    assert.deepStrictEqual(result.definition.prompt, {
+      selected: 'custom',
+      customSystemPrompt: 'keep me',
+    });
+    assert.deepStrictEqual(repository.readCanonical('bot-alpha')?.skills, result.definition.skills);
+
+    const promptResult = service.updatePrompt('bot-alpha', { selected: 'default' });
+    assert.deepStrictEqual(promptResult.definition.model, { kind: 'catalog', modelId: 'new-model' });
+    assert.deepStrictEqual(promptResult.definition.skills, result.definition.skills);
+  });
+
+  test('accepting an older Skill snapshot keeps the latest locked local prompt', () => {
+    const repository = new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot });
+    repository.writeCanonical({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-alpha',
+      model: { kind: 'catalog', modelId: 'canonical-model' },
+      prompt: { selected: 'custom', customSystemPrompt: 'canonical prompt' },
+      skills: [{ skillId: 'canonical-skill', version: '1' }],
+    });
+    repository.writeCache({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-alpha',
+      model: { kind: 'catalog', modelId: 'latest-model' },
+      prompt: { selected: 'custom', customSystemPrompt: 'latest prompt' },
+      skills: [{ skillId: 'old-skill', version: '1' }],
+    });
+    const service = createBotDefinitionSyncService({
+      runtimeRoot,
+      simulatedCloudRoot,
+      repository,
+    });
+
+    const accepted = service.acceptRemoteSnapshot({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-alpha',
+      model: { kind: 'catalog', modelId: 'remote-model' },
+      prompt: { selected: 'custom', customSystemPrompt: 'stale prompt' },
+      skills: [{ skillId: 'remote-skill', version: '2' }],
+    });
+
+    assert.deepStrictEqual(accepted.prompt, {
+      selected: 'custom',
+      customSystemPrompt: 'latest prompt',
+    });
+    assert.deepStrictEqual(accepted.skills, [{ skillId: 'remote-skill', version: '2' }]);
+    assert.deepStrictEqual(repository.readCache('bot-alpha'), accepted);
+  });
+
+  test('distinguishes a migrated empty Skill list from a legacy missing field', () => {
+    const repository = new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot });
+    repository.writeCanonical({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-alpha',
+      model: { kind: 'catalog', modelId: 'model-a' },
+      skills: [],
+    });
+    repository.writeCanonical({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-legacy',
+      model: { kind: 'catalog', modelId: 'model-b' },
+    });
+
+    assert.deepStrictEqual(repository.readCanonical('bot-alpha')?.skills, []);
+    assert.equal(repository.readCanonical('bot-legacy')?.skills, undefined);
+  });
+
+  test('rejects malformed or duplicate Skill references', () => {
+    const repository = new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot });
+    const canonicalPath = repository.getCanonicalPath('bot-alpha');
+    fs.mkdirSync(path.dirname(canonicalPath), { recursive: true });
+    fs.writeFileSync(canonicalPath, JSON.stringify({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-alpha',
+      model: { kind: 'catalog', modelId: 'model-a' },
+      skills: [
+        { skillId: 'same', version: '1' },
+        { skillId: 'same', version: '1' },
+      ],
+    }));
+
+    assert.equal(repository.readCanonical('bot-alpha'), undefined);
+  });
+
   test('pull preserves the previous custom profile outside the active Definition and runtime roots stay isolated', () => {
     const repository = new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot });
     const customModel = {

--- a/tests/bot-definition-prompt-sync.test.ts
+++ b/tests/bot-definition-prompt-sync.test.ts
@@ -175,18 +175,21 @@ describe('BotDefinition system prompt sync', () => {
   test('keeps custom text across upgrades and restores it after using default', async () => {
     const { coordinator, repository } = createCoordinator();
     await coordinator.activateBot('bot-a');
-    await coordinator.select('bot-a', 'custom', 'my custom prompt');
+    await coordinator.select('bot-a', 'custom', '# My prompt\n\n- item\tvalue');
     fs.writeFileSync(path.join(appRoot, 'prompts', 'system-prompt.md'), 'bundled v2\n', 'utf-8');
 
     await coordinator.activateBot('bot-a');
-    assert.equal(fs.readFileSync(coordinator.getActivePromptPath(), 'utf-8'), 'my custom prompt\n');
+    assert.equal(fs.readFileSync(coordinator.getActivePromptPath(), 'utf-8'), '# My prompt\n\n- item\tvalue\n');
 
     await coordinator.select('bot-a', 'default');
     assert.equal(fs.readFileSync(coordinator.getActivePromptPath(), 'utf-8'), 'bundled v2\n');
-    assert.equal(repository.readCanonical('bot-a')?.prompt?.customSystemPrompt, 'my custom prompt');
+    assert.equal(
+      repository.readCanonical('bot-a')?.prompt?.customSystemPrompt,
+      '# My prompt\n\n- item\tvalue',
+    );
 
     await coordinator.select('bot-a', 'custom');
-    assert.equal(fs.readFileSync(coordinator.getActivePromptPath(), 'utf-8'), 'my custom prompt\n');
+    assert.equal(fs.readFileSync(coordinator.getActivePromptPath(), 'utf-8'), '# My prompt\n\n- item\tvalue\n');
   });
 
   test('keeps an unsynced custom file edit across restart activation', async () => {

--- a/tests/bot-private-skill-http.test.ts
+++ b/tests/bot-private-skill-http.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { HttpBotPrivateSkillPackageClient } from '../src/bot-skills/http-private-package';
+import { buildBotSkillSourceSnapshot } from '../src/bot-skills/source-snapshot';
+
+describe('HTTP Bot private Skill package transport', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-private-http-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('binds upload and download responses to the exact bytes and Cloud reference', async () => {
+    fs.writeFileSync(path.join(root, 'SKILL.md'), [
+      '---', 'name: alpha', 'description: alpha skill', '---', '', '# alpha', '',
+    ].join('\n'));
+    const snapshot = buildBotSkillSourceSnapshot(root);
+    const reference = {
+      skillId: `priv_${'a'.repeat(40)}`,
+      version: `v_${'b'.repeat(48)}`,
+    };
+    const version = {
+      reference,
+      localSkillId: 'local-alpha',
+      name: 'alpha',
+      contentHash: snapshot.contentHash,
+      createdAt: '2026-07-24T00:00:00.000Z',
+    };
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchImpl: typeof fetch = async (input, init) => {
+      requests.push({ url: String(input), init });
+      return new Response(JSON.stringify(
+        init?.method === 'PUT'
+          ? version
+          : {
+            ...version,
+            files: snapshot.files.map(file => ({
+              path: file.path,
+              size: file.size,
+              sha256: file.sha256,
+              contentBase64: file.bytes.toString('base64'),
+            })),
+          },
+      ), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    };
+    const client = new HttpBotPrivateSkillPackageClient({
+      baseUrl: 'https://skillhub.example',
+      botId: 'bot-a',
+      apiKey: 'secret-key',
+      fetchImpl,
+    });
+
+    assert.deepStrictEqual(await client.upsert({
+      localSkillId: 'local-alpha',
+      name: 'alpha',
+      snapshot,
+    }), version);
+    const downloaded = await client.download(reference);
+
+    assert.equal(downloaded.files[0].bytes.equals(snapshot.files[0].bytes), true);
+    assert.equal(requests.length, 2);
+    assert.equal(new Headers(requests[0].init?.headers).get('authorization'), 'ApiKey secret-key');
+    assert.equal(new Headers(requests[0].init?.headers).get('x-catsco-bot-id'), 'bot-a');
+    assert.equal(requests[0].init?.redirect, 'error');
+  });
+
+  test('rejects mismatched references and tampered file bytes', async () => {
+    const requested = {
+      skillId: `priv_${'a'.repeat(40)}`,
+      version: `v_${'b'.repeat(48)}`,
+    };
+    const response = {
+      reference: requested,
+      localSkillId: 'local-alpha',
+      name: 'alpha',
+      contentHash: 'c'.repeat(64),
+      createdAt: '2026-07-24T00:00:00.000Z',
+      files: [{
+        path: 'SKILL.md',
+        size: 3,
+        sha256: 'd'.repeat(64),
+        contentBase64: Buffer.from('bad').toString('base64'),
+      }],
+    };
+    const client = new HttpBotPrivateSkillPackageClient({
+      baseUrl: 'https://skillhub.example',
+      botId: 'bot-a',
+      apiKey: 'secret-key',
+      fetchImpl: async () => new Response(JSON.stringify(response), { status: 200 }),
+    });
+
+    await assert.rejects(
+      client.download(requested),
+      (error: any) => error?.code === 'BOT_SKILL_PACKAGE_HASH_MISMATCH',
+    );
+
+    const mismatchClient = new HttpBotPrivateSkillPackageClient({
+      baseUrl: 'https://skillhub.example',
+      botId: 'bot-a',
+      apiKey: 'secret-key',
+      fetchImpl: async () => new Response(JSON.stringify({
+        ...response,
+        reference: { ...requested, skillId: `priv_${'e'.repeat(40)}` },
+      }), { status: 200 }),
+    });
+    await assert.rejects(
+      mismatchClient.download(requested),
+      (error: any) => error?.code === 'BOT_SKILL_PACKAGE_REFERENCE_MISMATCH',
+    );
+  });
+
+  test('accepts wrapped downloads, zero-byte files, and 160-character local ids', async () => {
+    fs.writeFileSync(path.join(root, 'SKILL.md'), '# alpha\n');
+    fs.writeFileSync(path.join(root, 'empty.txt'), '');
+    const snapshot = buildBotSkillSourceSnapshot(root);
+    const localSkillId = 'a'.repeat(160);
+    const reference = {
+      skillId: `priv_${'a'.repeat(40)}`,
+      version: `v_${'b'.repeat(48)}`,
+    };
+    const packageValue = {
+      reference,
+      localSkillId,
+      name: 'alpha',
+      contentHash: snapshot.contentHash,
+      createdAt: '2026-07-24T00:00:00.000Z',
+      files: snapshot.files.map(file => ({
+        path: file.path,
+        size: file.size,
+        sha256: file.sha256,
+        contentBase64: file.bytes.toString('base64'),
+      })),
+    };
+    const client = new HttpBotPrivateSkillPackageClient({
+      baseUrl: 'https://skillhub.example',
+      botId: 'bot-a',
+      apiKey: 'secret-key',
+      fetchImpl: async (_input, init) => new Response(JSON.stringify(
+        init?.method === 'PUT'
+          ? { package: packageValue }
+          : { package: packageValue },
+      ), { status: 200 }),
+    });
+
+    await client.upsert({ localSkillId, name: 'alpha', snapshot });
+    const downloaded = await client.download(reference);
+    assert.equal(downloaded.files.find(file => file.path === 'empty.txt')?.bytes.length, 0);
+  });
+
+  test('rejects upload responses whose name or origin does not match the request', async () => {
+    fs.writeFileSync(path.join(root, 'SKILL.md'), '# alpha\n');
+    const snapshot = buildBotSkillSourceSnapshot(root);
+    const response = {
+      reference: {
+        skillId: `priv_${'a'.repeat(40)}`,
+        version: `v_${'b'.repeat(48)}`,
+      },
+      localSkillId: 'local-alpha',
+      name: 'substituted',
+      contentHash: snapshot.contentHash,
+      createdAt: '2026-07-24T00:00:00.000Z',
+    };
+    const client = new HttpBotPrivateSkillPackageClient({
+      baseUrl: 'https://skillhub.example',
+      botId: 'bot-a',
+      apiKey: 'secret-key',
+      fetchImpl: async () => new Response(JSON.stringify(response), { status: 200 }),
+    });
+
+    await assert.rejects(
+      client.upsert({ localSkillId: 'local-alpha', name: 'alpha', snapshot }),
+      (error: any) => error?.code === 'BOT_SKILL_PACKAGE_RESPONSE_MISMATCH',
+    );
+  });
+});

--- a/tests/bot-private-skill-package.test.ts
+++ b/tests/bot-private-skill-package.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { FileBotPrivateSkillPackageClient } from '../src/bot-skills/file-private-package';
+import { buildBotSkillSourceSnapshot } from '../src/bot-skills/source-snapshot';
+
+describe('file-backed private Skill package transport', () => {
+  let root: string;
+  let packageRoot: string;
+  let skillDir: string;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-private-skill-'));
+    packageRoot = path.join(root, 'cloud');
+    skillDir = path.join(root, 'skill');
+    fs.mkdirSync(skillDir);
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'), [
+      '---',
+      'name: demo',
+      'description: demo skill',
+      '---',
+      '',
+      '# Demo',
+      '',
+    ].join('\n'));
+    fs.writeFileSync(path.join(skillDir, 'script.js'), 'console.log("demo");\n');
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('upserts immutable content by bot/localSkillId/contentHash and never rewrites Local', async () => {
+    const client = new FileBotPrivateSkillPackageClient({
+      root: packageRoot,
+      botId: 'bot-a',
+      now: () => new Date('2026-07-24T00:00:00.000Z'),
+    });
+    const original = fs.readFileSync(path.join(skillDir, 'SKILL.md'), 'utf8');
+    const snapshot = buildBotSkillSourceSnapshot(skillDir);
+
+    const first = await client.upsert({ localSkillId: 'local-a', name: 'demo', snapshot });
+    const second = await client.upsert({ localSkillId: 'local-a', name: 'demo-renamed', snapshot });
+
+    assert.deepStrictEqual(second, first);
+    assert.match(first.reference.skillId, /^priv_[a-f0-9]{40}$/);
+    assert.match(first.reference.version, /^v_[a-f0-9]{48}$/);
+    assert.doesNotMatch(first.reference.skillId, /bot-a|local-a/);
+    assert.doesNotMatch(first.reference.version, new RegExp(snapshot.contentHash));
+    assert.equal(fs.readFileSync(path.join(skillDir, 'SKILL.md'), 'utf8'), original);
+    assert.equal(fs.existsSync(client.getPackagePath('local-a', snapshot.contentHash)), true);
+  });
+
+  test('downloads and revalidates exact bytes, while another Bot cannot read the package', async () => {
+    const owner = new FileBotPrivateSkillPackageClient({ root: packageRoot, botId: 'bot-a' });
+    const snapshot = buildBotSkillSourceSnapshot(skillDir);
+    const version = await owner.upsert({ localSkillId: 'local-a', name: 'demo', snapshot });
+
+    const downloaded = await owner.download(version.reference);
+
+    assert.equal(downloaded.contentHash, snapshot.contentHash);
+    assert.deepStrictEqual(
+      downloaded.files.map(file => [file.path, file.bytes.toString('utf8')]),
+      snapshot.files.map(file => [file.path, file.bytes.toString('utf8')]),
+    );
+    const otherBot = new FileBotPrivateSkillPackageClient({ root: packageRoot, botId: 'bot-b' });
+    await assert.rejects(
+      otherBot.download(version.reference),
+      (error: any) => error.code === 'PRIVATE_SKILL_NOT_FOUND',
+    );
+  });
+
+  test('detects storage tampering before materialization', async () => {
+    const client = new FileBotPrivateSkillPackageClient({ root: packageRoot, botId: 'bot-a' });
+    const snapshot = buildBotSkillSourceSnapshot(skillDir);
+    const version = await client.upsert({ localSkillId: 'local-a', name: 'demo', snapshot });
+    const packagePath = client.getPackagePath('local-a', snapshot.contentHash);
+    const stored = JSON.parse(fs.readFileSync(packagePath, 'utf8'));
+    stored.files[0].contentBase64 = Buffer.from('tampered').toString('base64');
+    fs.writeFileSync(packagePath, JSON.stringify(stored));
+
+    await assert.rejects(
+      client.download(version.reference),
+      (error: any) => error.code === 'PRIVATE_SKILL_PACKAGE_INVALID'
+        || error.code === 'PRIVATE_SKILL_PACKAGE_CHECKSUM_MISMATCH',
+    );
+  });
+});

--- a/tests/bot-skill-base-store.test.ts
+++ b/tests/bot-skill-base-store.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { BOT_SKILL_SYNC_BASE_SCHEMA } from '../src/bot-skills/types';
+import { FileBotSkillSyncBaseStore } from '../src/bot-skills/base-store';
+import {
+  botSkillReferencesEqual,
+  cloudSnapshotMatchesBase,
+  localSnapshotMatchesBase,
+} from '../src/bot-skills/canonical';
+
+describe('Bot Skill sync base', () => {
+  let runtimeRoot: string;
+
+  beforeEach(() => {
+    runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-bot-skill-base-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(runtimeRoot, { recursive: true, force: true });
+  });
+
+  test('round-trips a normalized per-Skill Local/Cloud mapping atomically', () => {
+    const store = new FileBotSkillSyncBaseStore({
+      runtimeRoot,
+      authority: 'https://cats.example/user-1',
+    });
+    store.write({
+      schema: BOT_SKILL_SYNC_BASE_SCHEMA,
+      botId: 'bot-a',
+      workspaceId: 'workspace-a',
+      authority: 'https://cats.example/user-1',
+      definitionETag: '"definition-3"',
+      entries: [
+        {
+          localSkillId: 'local-b',
+          localContentHash: 'b'.repeat(64),
+          cloudSkillId: 'private/b',
+          cloudVersion: 'hash-b',
+        },
+        {
+          localSkillId: 'local-a',
+          localContentHash: 'a'.repeat(64),
+          cloudSkillId: 'public/a',
+          cloudVersion: '1.0.0',
+        },
+      ],
+      updatedAt: '2026-07-24T00:00:00.000Z',
+    });
+
+    const result = store.read('bot-a', 'workspace-a');
+
+    assert.equal(result.kind, 'valid');
+    if (result.kind === 'valid') {
+      assert.deepStrictEqual(result.base.entries.map(entry => entry.localSkillId), ['local-a', 'local-b']);
+      assert.equal(result.base.definitionETag, '"definition-3"');
+    }
+  });
+
+  test('keeps missing, corrupt, workspace mismatch, and authority mismatch distinct from a valid Base', () => {
+    const store = new FileBotSkillSyncBaseStore({ runtimeRoot, authority: 'authority-a' });
+    assert.equal(store.read('bot-a').kind, 'missing');
+
+    fs.mkdirSync(path.dirname(store.getPath('bot-a')), { recursive: true });
+    fs.writeFileSync(store.getPath('bot-a'), '{broken');
+    assert.equal(store.read('bot-a').kind, 'corrupt');
+
+    store.write({
+      schema: BOT_SKILL_SYNC_BASE_SCHEMA,
+      botId: 'bot-a',
+      workspaceId: 'workspace-a',
+      authority: 'authority-a',
+      entries: [],
+      updatedAt: '2026-07-24T00:00:00.000Z',
+    });
+    assert.equal(store.read('bot-a', 'workspace-b').kind, 'corrupt');
+
+    const otherAuthority = new FileBotSkillSyncBaseStore({ runtimeRoot, authority: 'authority-b' });
+    assert.equal(otherAuthority.read('bot-a').kind, 'missing');
+  });
+
+  test('compares Local and Cloud independently and ignores reference ordering', () => {
+    const base = {
+      entries: [
+        {
+          localSkillId: 'local-a',
+          localContentHash: 'a'.repeat(64),
+          cloudSkillId: 'cloud/a',
+          cloudVersion: '1',
+        },
+        {
+          localSkillId: 'local-b',
+          localContentHash: 'b'.repeat(64),
+          cloudSkillId: 'cloud/b',
+          cloudVersion: '2',
+        },
+      ],
+    };
+    const local = [
+      {
+        localSkillId: 'local-b',
+        contentHash: 'b'.repeat(64),
+        name: 'b',
+        directoryName: 'b',
+        directoryPath: '/b',
+        skillFilePath: '/b/SKILL.md',
+      },
+      {
+        localSkillId: 'local-a',
+        contentHash: 'a'.repeat(64),
+        name: 'a',
+        directoryName: 'a',
+        directoryPath: '/a',
+        skillFilePath: '/a/SKILL.md',
+      },
+    ];
+
+    assert.equal(localSnapshotMatchesBase(local, base), true);
+    assert.equal(cloudSnapshotMatchesBase([
+      { skillId: 'cloud/b', version: '2' },
+      { skillId: 'cloud/a', version: '1' },
+    ], base), true);
+    assert.equal(botSkillReferencesEqual(
+      [{ skillId: 'b', version: '2' }, { skillId: 'a', version: '1' }],
+      [{ skillId: 'a', version: '1' }, { skillId: 'b', version: '2' }],
+    ), true);
+
+    assert.equal(localSnapshotMatchesBase([{ ...local[0], contentHash: 'c'.repeat(64) }, local[1]], base), false);
+    assert.equal(cloudSnapshotMatchesBase([{ skillId: 'cloud/a', version: '9' }], base), false);
+  });
+});

--- a/tests/bot-skill-runtime.test.ts
+++ b/tests/bot-skill-runtime.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { BOT_DEFINITION_SCHEMA } from '../src/bot-definition/types';
+import { FileBotSkillNewBotIntentStore } from '../src/bot-skills/new-bot-intent';
+import { FileBotDefinitionCloudClient } from '../src/bot-skills/file-definition-cloud';
+import {
+  assertBotSkillStartupReady,
+  BotSkillRuntime,
+} from '../src/bot-skills/runtime';
+
+describe('Bot Skill runtime coordinator', () => {
+  let runtimeRoot: string;
+  const auth = {
+    httpBaseUrl: 'https://cats.example',
+    serverUrl: 'wss://cats.example/v0/channels',
+    botUid: 'bot-a',
+    apiKey: 'bot-key',
+    uid: 'user-a',
+  };
+
+  beforeEach(() => {
+    runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-bot-runtime-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(runtimeRoot, { recursive: true, force: true });
+  });
+
+  test('creates an explicitly new empty Bot once and safely reuses its Base', async () => {
+    const runtime = new BotSkillRuntime({
+      runtimeRoot,
+      auth,
+      transport: 'file',
+      debounceMs: 0,
+    });
+    const definition = {
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-a',
+      model: { kind: 'catalog' as const, modelId: 'model-a' },
+    };
+    const first = await runtime.sync({
+      definitionForCreate: definition,
+      allowNewWorkspaceCreate: true,
+    });
+    assert.equal(first.result.action, 'created_cloud');
+    assert.deepStrictEqual(first.definition?.skills, []);
+    assertBotSkillStartupReady(first, runtime.workspace, runtime.owner);
+
+    const second = await runtime.sync();
+    assert.equal(second.result.action, 'noop');
+  });
+
+  test('allows an existing valid local Bot to start while a Cloud conflict is pending', () => {
+    const runtime = new BotSkillRuntime({
+      runtimeRoot,
+      auth,
+      transport: 'file',
+    });
+    runtime.workspace.initializeEmpty(runtime.owner);
+
+    assert.doesNotThrow(() => assertBotSkillStartupReady({
+      result: {
+        action: 'conflict',
+        botId: runtime.owner.botId,
+        reason: 'CLOUD_ETAG_CONFLICT',
+      },
+    }, runtime.workspace, runtime.owner));
+  });
+
+  test('serializes a local mutation and flushes its scheduled upload', async () => {
+    const runtime = new BotSkillRuntime({
+      runtimeRoot,
+      auth,
+      transport: 'file',
+      debounceMs: 60_000,
+    });
+    await runtime.sync({
+      definitionForCreate: {
+        schema: BOT_DEFINITION_SCHEMA,
+        botId: 'bot-a',
+        model: { kind: 'catalog', modelId: 'model-a' },
+      },
+      allowNewWorkspaceCreate: true,
+    });
+    await runtime.mutate(() => {
+      const directory = path.join(runtime.workspace.root, 'alpha');
+      fs.mkdirSync(directory);
+      fs.writeFileSync(path.join(directory, 'SKILL.md'), [
+        '---', 'name: alpha', 'description: alpha skill', '---', '', '# alpha', '',
+      ].join('\n'));
+    });
+
+    const flushed = await runtime.flush();
+    assert.equal(flushed?.result.action, 'uploaded');
+    assert.equal(flushed?.definition?.skills?.length, 1);
+  });
+
+  test('new-Bot intent is authority/user bound and consumable', () => {
+    const store = new FileBotSkillNewBotIntentStore(runtimeRoot);
+    store.write({
+      botId: 'bot-a',
+      authority: 'https://cats.example/path',
+      ownerUserId: 'user-a',
+    });
+    assert.equal(store.matches({
+      botId: 'bot-a',
+      authority: 'https://cats.example',
+      ownerUserId: 'user-a',
+    }), true);
+    assert.equal(store.matches({
+      botId: 'bot-a',
+      authority: 'https://other.example',
+      ownerUserId: 'user-a',
+    }), false);
+    store.delete('bot-a');
+    assert.equal(store.matches({
+      botId: 'bot-a',
+      authority: 'https://cats.example',
+      ownerUserId: 'user-a',
+    }), false);
+  });
+
+  test('uploads an offline local edit to the workspace owner Bot after restart, never another Bot', async () => {
+    const definitionFor = (botId: string) => ({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId,
+      model: { kind: 'catalog' as const, modelId: 'model-a' },
+    });
+    const botA = new BotSkillRuntime({
+      runtimeRoot,
+      auth,
+      transport: 'file',
+    });
+    await botA.sync({
+      definitionForCreate: definitionFor('bot-a'),
+      allowNewWorkspaceCreate: true,
+    });
+    await botA.mutate(() => {
+      const directory = path.join(botA.workspace.root, 'offline-skill');
+      fs.mkdirSync(directory);
+      fs.writeFileSync(path.join(directory, 'SKILL.md'), [
+        '---', 'name: offline-skill', 'description: offline skill', '---', '', 'before shutdown', '',
+      ].join('\n'));
+    });
+    await botA.flush();
+
+    const botBRoot = path.join(runtimeRoot, 'data', 'bot-b-workspace');
+    const botB = new BotSkillRuntime({
+      runtimeRoot,
+      skillsRoot: botBRoot,
+      auth: { ...auth, botUid: 'bot-b', apiKey: 'bot-b-key' },
+      transport: 'file',
+    });
+    await botB.sync({
+      definitionForCreate: definitionFor('bot-b'),
+      allowNewWorkspaceCreate: true,
+    });
+    const botBCloud = new FileBotDefinitionCloudClient({
+      root: path.join(runtimeRoot, 'data', 'bot-skill-test-cloud', 'definitions'),
+      botId: 'bot-b',
+    });
+    const botBBefore = await botBCloud.read();
+
+    fs.appendFileSync(
+      path.join(botA.workspace.root, 'offline-skill', 'SKILL.md'),
+      '\nchanged while XiaoBa was offline\n',
+    );
+    const restartedA = new BotSkillRuntime({
+      runtimeRoot,
+      auth,
+      transport: 'file',
+    });
+    const recovered = await restartedA.sync({ definitionForCreate: definitionFor('bot-a') });
+
+    assert.equal(recovered.result.action, 'uploaded');
+    assert.notDeepStrictEqual(recovered.definition?.skills, []);
+    assert.deepStrictEqual(await botBCloud.read(), botBBefore);
+    assert.equal(restartedA.workspace.inspect(restartedA.owner).kind, 'valid');
+  });
+});

--- a/tests/bot-skill-source-snapshot.test.ts
+++ b/tests/bot-skill-source-snapshot.test.ts
@@ -69,6 +69,65 @@ describe('Bot Skill source snapshot security boundary', () => {
     );
   });
 
+  test('blocks service-prefixed, AWS, generic, and camelCase credential assignments', () => {
+    const assignments = [
+      'CATSCO_API_KEY=not-a-real-catsco-key-1234567890',
+      'AWS_SECRET_ACCESS_KEY=not-a-real-aws-secret-1234567890',
+      'MY_SERVICE_TOKEN=not-a-real-service-token-1234567890',
+      '{"catscoApiKey":"not-a-real-json-key-1234567890"}',
+      'DJANGO_SECRET_KEY=django-insecure-abcdefghijklmnopqrstuvwxyz1234567890',
+      'API_KEY=abcd1234',
+      'password=S3cur3Pass!',
+      'SAFE=${SAFE};PASSWORD=realpassword',
+      'config["apiKey"]="realpassword"',
+      'API_KEY?=realpassword',
+      'API_KEY+=realpassword',
+      'connect(api_key="realpassword")',
+      'API_KEY="${SAFE_ENV} actual-secret-value"',
+      'SAFE=x&&PASSWORD=realpassword',
+      'SAFE=x&PASSWORD=realpassword',
+      'https://x.test/?access_token=realpassword',
+    ];
+
+    for (const [index, assignment] of assignments.entries()) {
+      const filePath = path.join(skillDir, `config-${index}.txt`);
+      fs.writeFileSync(filePath, `${assignment}\n`);
+      assert.throws(
+        () => buildBotSkillSourceSnapshot(skillDir),
+        (error: any) => (
+          error.code === 'SKILL_SOURCE_SENSITIVE'
+          && error.relativePaths.includes(`config-${index}.txt`)
+          && !error.message.includes('not-a-real')
+        ),
+      );
+      fs.rmSync(filePath);
+    }
+  });
+
+  test('allows only explicit safe credential references, placeholders, and schema values', () => {
+    fs.writeFileSync(path.join(skillDir, 'example.txt'), [
+      'CATSCO_API_KEY=your_api_key_here',
+      'MY_SERVICE_TOKEN=placeholder-value',
+      'clientSecret=****************',
+      'STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY}',
+      'password=minimum_length_16',
+      'interface Config { apiKey: string; }',
+      '{ password: z.string().min(8) }',
+      'clientSecret: null',
+      'API_KEY=""',
+    ].join('\n'));
+
+    assert.doesNotThrow(() => buildBotSkillSourceSnapshot(skillDir));
+  });
+
+  test('does not treat a password-only policy value as a general secret placeholder', () => {
+    fs.writeFileSync(path.join(skillDir, 'unsafe-policy.txt'), 'STRIPE_SECRET_KEY=minimum_length_16\n');
+    assert.throws(
+      () => buildBotSkillSourceSnapshot(skillDir),
+      (error: any) => error.code === 'SKILL_SOURCE_SENSITIVE',
+    );
+  });
+
   test('fails the whole snapshot on file count or file size limits instead of truncating it', () => {
     for (let index = 0; index < BOT_SKILL_SOURCE_MAX_FILES; index += 1) {
       fs.writeFileSync(path.join(skillDir, `file-${index}.txt`), String(index));

--- a/tests/bot-skill-source-snapshot.test.ts
+++ b/tests/bot-skill-source-snapshot.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  BOT_SKILL_SOURCE_MAX_FILES,
+  BOT_SKILL_SOURCE_MAX_SINGLE_FILE_BYTES,
+  BotSkillSourceError,
+  buildBotSkillSourceSnapshot,
+  computeBotSkillSourceContentHash,
+} from '../src/bot-skills/source-snapshot';
+
+describe('Bot Skill source snapshot security boundary', () => {
+  let root: string;
+  let skillDir: string;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-bot-skill-source-'));
+    skillDir = path.join(root, 'demo');
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'), [
+      '---',
+      'name: demo',
+      'description: demo skill',
+      '---',
+      '',
+      '# Demo',
+      '',
+    ].join('\n'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('hashes and uploads the exact same ordered bytes without local identity metadata', () => {
+    fs.mkdirSync(path.join(skillDir, 'scripts'));
+    fs.writeFileSync(path.join(skillDir, 'scripts', 'run.js'), 'console.log("ok");\r\n');
+    fs.writeFileSync(path.join(skillDir, '.xiaoba-local-skill.json'), '{"localSkillId":"not-source"}');
+
+    const snapshot = buildBotSkillSourceSnapshot(skillDir);
+
+    assert.equal(snapshot.contentHash, computeBotSkillSourceContentHash(skillDir));
+    assert.deepStrictEqual(snapshot.files.map(file => file.path), ['SKILL.md', 'scripts/run.js']);
+    assert.equal(snapshot.files.find(file => file.path === 'scripts/run.js')?.bytes.toString('utf8'), 'console.log("ok");\r\n');
+  });
+
+  test('blocks sensitive names and content without including the secret value in the error', () => {
+    const secret = 'sk-proj-1234567890abcdefghijklmnop';
+    fs.writeFileSync(path.join(skillDir, '.env'), `API_KEY=${secret}\n`);
+
+    assert.throws(
+      () => buildBotSkillSourceSnapshot(skillDir),
+      (error: any) => {
+        assert.equal(error instanceof BotSkillSourceError, true);
+        assert.equal(error.code, 'SKILL_SOURCE_SENSITIVE');
+        assert.deepStrictEqual(error.relativePaths, ['.env']);
+        assert.doesNotMatch(error.message, new RegExp(secret));
+        return true;
+      },
+    );
+
+    fs.rmSync(path.join(skillDir, '.env'));
+    fs.writeFileSync(path.join(skillDir, 'config.txt'), `access_token=${secret}\n`);
+    assert.throws(
+      () => buildBotSkillSourceSnapshot(skillDir),
+      (error: any) => error.code === 'SKILL_SOURCE_SENSITIVE' && !error.message.includes(secret),
+    );
+  });
+
+  test('fails the whole snapshot on file count or file size limits instead of truncating it', () => {
+    for (let index = 0; index < BOT_SKILL_SOURCE_MAX_FILES; index += 1) {
+      fs.writeFileSync(path.join(skillDir, `file-${index}.txt`), String(index));
+    }
+    assert.throws(
+      () => buildBotSkillSourceSnapshot(skillDir),
+      (error: any) => error.code === 'SKILL_SOURCE_FILE_LIMIT',
+    );
+
+    for (const name of fs.readdirSync(skillDir)) {
+      if (name !== 'SKILL.md') fs.rmSync(path.join(skillDir, name), { recursive: true, force: true });
+    }
+    fs.writeFileSync(
+      path.join(skillDir, 'large.bin'),
+      Buffer.alloc(BOT_SKILL_SOURCE_MAX_SINGLE_FILE_BYTES + 1),
+    );
+    assert.throws(
+      () => buildBotSkillSourceSnapshot(skillDir),
+      (error: any) => error.code === 'SKILL_SOURCE_FILE_TOO_LARGE',
+    );
+  });
+
+  test('rejects source paths deeper than the private package contract', () => {
+    const deepRoot = path.join(skillDir, ...Array.from({ length: 65 }, (_, index) => `d${index}`));
+    fs.mkdirSync(deepRoot, { recursive: true });
+    fs.writeFileSync(path.join(deepRoot, 'deep.txt'), 'too deep');
+    assert.throws(
+      () => buildBotSkillSourceSnapshot(skillDir),
+      (error: any) => error.code === 'SKILL_SOURCE_PATH_UNSAFE',
+    );
+  });
+
+  test('rejects symlinks when the platform permits creating them', (t) => {
+    const target = path.join(root, 'outside.txt');
+    fs.writeFileSync(target, 'outside');
+    try {
+      fs.symlinkSync(target, path.join(skillDir, 'linked.txt'));
+    } catch {
+      t.skip('symlink creation is unavailable on this platform');
+      return;
+    }
+    assert.throws(
+      () => buildBotSkillSourceSnapshot(skillDir),
+      (error: any) => error.code === 'SKILL_SOURCE_SYMLINK',
+    );
+  });
+});

--- a/tests/bot-skill-switch-service.test.ts
+++ b/tests/bot-skill-switch-service.test.ts
@@ -1,0 +1,244 @@
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  BOT_SKILL_SWITCH_JOURNAL_SCHEMA,
+  FileBotSkillSwitchJournalStore,
+} from '../src/bot-skills/switch-journal';
+import { BotSkillWorkspaceSwitchService } from '../src/bot-skills/switch-service';
+import { BotSkillWorkspaceService } from '../src/bot-skills/workspace';
+
+describe('Bot Skill workspace switch transaction', () => {
+  let root: string;
+  let runtimeRoot: string;
+  let activeRoot: string;
+  let parkedA: string;
+  let preparedB: string;
+  let journalStore: FileBotSkillSwitchJournalStore;
+  let nextId: number;
+  const ownerA = { botId: 'bot-a', authority: 'authority/user' };
+  const ownerB = { botId: 'bot-b', authority: 'authority/user' };
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-skill-switch-'));
+    runtimeRoot = path.join(root, 'runtime');
+    activeRoot = path.join(runtimeRoot, 'skills');
+    parkedA = path.join(runtimeRoot, 'data', 'bot-skill-workspaces', 'bot-a', 'workspace-a');
+    preparedB = path.join(runtimeRoot, 'data', 'bot-skill-workspaces', 'bot-b', 'workspace-b');
+    nextId = 1;
+    journalStore = new FileBotSkillSwitchJournalStore({ runtimeRoot });
+    const active = workspaceAt(activeRoot);
+    active.initializeEmpty(ownerA);
+    fs.writeFileSync(path.join(activeRoot, 'owner-a.txt'), 'A');
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  function workspaceAt(skillsRoot: string): BotSkillWorkspaceService {
+    return new BotSkillWorkspaceService({
+      skillsRoot,
+      createId: () => `id-${nextId++}`,
+      now: () => new Date('2026-07-24T00:00:00.000Z'),
+    });
+  }
+
+  function service(): BotSkillWorkspaceSwitchService {
+    return new BotSkillWorkspaceSwitchService({
+      workspace: workspaceAt(activeRoot),
+      journalStore,
+      createId: () => `tx-${nextId++}`,
+      now: () => new Date('2026-07-24T00:00:00.000Z'),
+    });
+  }
+
+  test('prepares B before stopping A, then parks A and commits B', async () => {
+    const events: string[] = [];
+    await service().switch({
+      fromOwner: ownerA,
+      toOwner: ownerB,
+      fromParkedRoot: parkedA,
+      targetPreparedRoot: preparedB,
+      prepareTarget: async target => {
+        events.push('prepare-b');
+        workspaceAt(target).initializeEmpty(ownerB);
+        fs.writeFileSync(path.join(target, 'owner-b.txt'), 'B');
+      },
+      stopOldConnector: async () => {
+        assert.equal(fs.existsSync(path.join(runtimeRoot, '.skills.bot-skill.lock')), false);
+        events.push('stop-a');
+      },
+      syncOldWorkspace: async () => { events.push('sync-a'); },
+      preflightTarget: async () => { events.push('preflight-b'); },
+      commitTargetBinding: async () => { events.push('commit-b'); },
+      startTargetConnector: async () => {
+        assert.equal(fs.existsSync(path.join(runtimeRoot, '.skills.bot-skill.lock')), false);
+        events.push('start-b');
+      },
+    });
+
+    assert.deepStrictEqual(events, ['prepare-b', 'stop-a', 'sync-a', 'preflight-b', 'commit-b', 'start-b']);
+    assert.equal(fs.readFileSync(path.join(activeRoot, 'owner-b.txt'), 'utf8'), 'B');
+    assert.equal(fs.readFileSync(path.join(parkedA, 'owner-a.txt'), 'utf8'), 'A');
+    assert.equal(journalStore.read(), undefined);
+  });
+
+  test('preflight failure restores A and keeps the prepared B workspace', async () => {
+    const events: string[] = [];
+    await assert.rejects(service().switch({
+      fromOwner: ownerA,
+      toOwner: ownerB,
+      fromParkedRoot: parkedA,
+      targetPreparedRoot: preparedB,
+      prepareTarget: async target => {
+        workspaceAt(target).initializeEmpty(ownerB);
+        fs.writeFileSync(path.join(target, 'owner-b.txt'), 'B');
+      },
+      stopOldConnector: async () => { events.push('stop-a'); },
+      syncOldWorkspace: async () => undefined,
+      preflightTarget: async () => { throw new Error('B preflight failed'); },
+      commitTargetBinding: async () => undefined,
+      startTargetConnector: async () => undefined,
+      restartOldConnector: async () => {
+        assert.equal(fs.existsSync(path.join(runtimeRoot, '.skills.bot-skill.lock')), false);
+        events.push('restart-a');
+      },
+    }), /preflight failed/);
+
+    assert.equal(fs.readFileSync(path.join(activeRoot, 'owner-a.txt'), 'utf8'), 'A');
+    assert.equal(fs.readFileSync(path.join(preparedB, 'owner-b.txt'), 'utf8'), 'B');
+    assert.deepStrictEqual(events, ['stop-a', 'restart-a']);
+    assert.equal(journalStore.read(), undefined);
+  });
+
+  test('rolls binding back even when its write callback partially commits and then throws', async () => {
+    const events: string[] = [];
+    await assert.rejects(service().switch({
+      fromOwner: ownerA,
+      toOwner: ownerB,
+      fromParkedRoot: parkedA,
+      targetPreparedRoot: preparedB,
+      prepareTarget: async target => {
+        workspaceAt(target).initializeEmpty(ownerB);
+        fs.writeFileSync(path.join(target, 'owner-b.txt'), 'B');
+      },
+      stopOldConnector: async () => { events.push('stop-a'); },
+      syncOldWorkspace: async () => undefined,
+      preflightTarget: async () => undefined,
+      commitTargetBinding: async () => {
+        events.push('write-b-partially');
+        throw new Error('env write failed');
+      },
+      rollbackSourceBinding: async () => { events.push('rollback-a-binding'); },
+      startTargetConnector: async () => { events.push('start-b'); },
+      restartOldConnector: async () => { events.push('restart-a'); },
+    }), /env write failed/);
+
+    assert.deepStrictEqual(events, [
+      'stop-a',
+      'write-b-partially',
+      'rollback-a-binding',
+      'restart-a',
+    ]);
+    assert.equal(fs.readFileSync(path.join(activeRoot, 'owner-a.txt'), 'utf8'), 'A');
+    assert.equal(fs.readFileSync(path.join(preparedB, 'owner-b.txt'), 'utf8'), 'B');
+  });
+
+  test('recovery rolls an interrupted activation back to A without overwriting B', async () => {
+    workspaceAt(preparedB).initializeEmpty(ownerB);
+    fs.writeFileSync(path.join(preparedB, 'owner-b.txt'), 'B');
+    fs.mkdirSync(path.dirname(parkedA), { recursive: true });
+    fs.renameSync(activeRoot, parkedA);
+    fs.renameSync(preparedB, activeRoot);
+    journalStore.write({
+      schema: BOT_SKILL_SWITCH_JOURNAL_SCHEMA,
+      transactionId: 'tx-recovery',
+      phase: 'TARGET_ACTIVATED',
+      fromBotId: 'bot-a',
+      fromWorkspaceId: 'id-1',
+      toBotId: 'bot-b',
+      toWorkspaceId: 'id-2',
+      activeRoot,
+      fromParkedRoot: parkedA,
+      targetPreparedRoot: preparedB,
+      startedAt: '2026-07-24T00:00:00.000Z',
+      updatedAt: '2026-07-24T00:00:00.000Z',
+    });
+
+    const result = await service().recover({ currentBotId: 'bot-a' });
+
+    assert.equal(result, 'rolled_back');
+    assert.equal(fs.readFileSync(path.join(activeRoot, 'owner-a.txt'), 'utf8'), 'A');
+    assert.equal(fs.readFileSync(path.join(preparedB, 'owner-b.txt'), 'utf8'), 'B');
+  });
+
+  test('recovery completes forward when binding already points to B', async () => {
+    workspaceAt(preparedB).initializeEmpty(ownerB);
+    fs.writeFileSync(path.join(preparedB, 'owner-b.txt'), 'B');
+    fs.mkdirSync(path.dirname(parkedA), { recursive: true });
+    fs.renameSync(activeRoot, parkedA);
+    fs.renameSync(preparedB, activeRoot);
+    journalStore.write({
+      schema: BOT_SKILL_SWITCH_JOURNAL_SCHEMA,
+      transactionId: 'tx-commit',
+      phase: 'COMMITTING_BINDING',
+      fromBotId: 'bot-a',
+      fromWorkspaceId: 'id-1',
+      toBotId: 'bot-b',
+      toWorkspaceId: 'id-2',
+      activeRoot,
+      fromParkedRoot: parkedA,
+      targetPreparedRoot: preparedB,
+      startedAt: '2026-07-24T00:00:00.000Z',
+      updatedAt: '2026-07-24T00:00:00.000Z',
+    });
+
+    const restarts: string[] = [];
+    const result = await service().recover({
+      currentBotId: 'bot-b',
+      restartConnector: async outcome => { restarts.push(outcome); },
+    });
+
+    assert.equal(result, 'committed');
+    assert.deepStrictEqual(restarts, ['committed']);
+    assert.equal(fs.readFileSync(path.join(activeRoot, 'owner-b.txt'), 'utf8'), 'B');
+    assert.equal(fs.readFileSync(path.join(parkedA, 'owner-a.txt'), 'utf8'), 'A');
+  });
+
+  test('rolls directories back when a committed journal finds the binding restored to A', async () => {
+    workspaceAt(preparedB).initializeEmpty(ownerB);
+    fs.writeFileSync(path.join(preparedB, 'owner-b.txt'), 'B');
+    fs.mkdirSync(path.dirname(parkedA), { recursive: true });
+    fs.renameSync(activeRoot, parkedA);
+    fs.renameSync(preparedB, activeRoot);
+    journalStore.write({
+      schema: BOT_SKILL_SWITCH_JOURNAL_SCHEMA,
+      transactionId: 'tx-binding-rolled-back',
+      phase: 'BINDING_COMMITTED',
+      fromBotId: 'bot-a',
+      fromWorkspaceId: 'id-1',
+      toBotId: 'bot-b',
+      toWorkspaceId: 'id-2',
+      oldConnectorWasRunning: true,
+      activeRoot,
+      fromParkedRoot: parkedA,
+      targetPreparedRoot: preparedB,
+      startedAt: '2026-07-24T00:00:00.000Z',
+      updatedAt: '2026-07-24T00:00:00.000Z',
+    });
+    const restarts: string[] = [];
+
+    const result = await service().recover({
+      currentBotId: 'bot-a',
+      restartConnector: async outcome => { restarts.push(outcome); },
+    });
+
+    assert.equal(result, 'rolled_back');
+    assert.deepStrictEqual(restarts, ['rolled_back']);
+    assert.equal(fs.readFileSync(path.join(activeRoot, 'owner-a.txt'), 'utf8'), 'A');
+    assert.equal(fs.readFileSync(path.join(preparedB, 'owner-b.txt'), 'utf8'), 'B');
+  });
+});

--- a/tests/bot-skill-sync-service.test.ts
+++ b/tests/bot-skill-sync-service.test.ts
@@ -1,0 +1,921 @@
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { FileBotDefinitionRepository } from '../src/bot-definition/repository';
+import { BOT_DEFINITION_SCHEMA, type BotDefinition } from '../src/bot-definition/types';
+import { FileBotSkillSyncBaseStore } from '../src/bot-skills/base-store';
+import {
+  BotDefinitionCloudError,
+  type BotDefinitionCloudClient,
+} from '../src/bot-skills/definition-cloud';
+import { FileBotDefinitionCloudClient } from '../src/bot-skills/file-definition-cloud';
+import { FileBotPrivateSkillPackageClient } from '../src/bot-skills/file-private-package';
+import { FileBotSkillPendingCommitStore } from '../src/bot-skills/pending-commit-store';
+import { buildBotSkillSourceSnapshot } from '../src/bot-skills/source-snapshot';
+import { BotSkillSyncService } from '../src/bot-skills/sync-service';
+import { restoreBotSkillWorkspace } from '../src/bot-skills/workspace-restore';
+import {
+  BOT_LOCAL_SKILL_IDENTITY_FILE,
+  BOT_SKILL_WORKSPACE_IDENTITY_FILE,
+  BotSkillWorkspaceService,
+} from '../src/bot-skills/workspace';
+import { writeSkillHubInstallMarker } from '../src/skillhub/install-marker';
+
+describe('Bot Skill Local/Base/Cloud synchronization', () => {
+  let root: string;
+  let runtimeRoot: string;
+  let skillsRoot: string;
+  let cloudRoot: string;
+  let packageRoot: string;
+  let nextId: number;
+  const authority = 'https://cats.example/user-1';
+  const owner = { botId: 'bot-a', authority };
+  const definition: BotDefinition = {
+    schema: BOT_DEFINITION_SCHEMA,
+    botId: 'bot-a',
+    model: { kind: 'catalog', modelId: 'model-a' },
+  };
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-bot-skill-sync-'));
+    runtimeRoot = path.join(root, 'runtime');
+    skillsRoot = path.join(runtimeRoot, 'skills');
+    cloudRoot = path.join(root, 'definition-cloud');
+    packageRoot = path.join(root, 'package-cloud');
+    nextId = 1;
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  function workspace(): BotSkillWorkspaceService {
+    return new BotSkillWorkspaceService({
+      runtimeRoot,
+      skillsRoot,
+      createId: () => `id-${nextId++}`,
+      now: () => new Date('2026-07-24T00:00:00.000Z'),
+    });
+  }
+
+  function baseStore(): FileBotSkillSyncBaseStore {
+    return new FileBotSkillSyncBaseStore({ runtimeRoot, authority });
+  }
+
+  function cloud(): FileBotDefinitionCloudClient {
+    return new FileBotDefinitionCloudClient({ root: cloudRoot, botId: 'bot-a' });
+  }
+
+  function packages(botId = 'bot-a'): FileBotPrivateSkillPackageClient {
+    return new FileBotPrivateSkillPackageClient({
+      root: packageRoot,
+      botId,
+      now: () => new Date('2026-07-24T00:00:00.000Z'),
+    });
+  }
+
+  function pendingStore(): FileBotSkillPendingCommitStore {
+    return new FileBotSkillPendingCommitStore({ runtimeRoot, authority });
+  }
+
+  function syncService(
+    cloudClient: BotDefinitionCloudClient = cloud(),
+    definitionCache?: {
+      readCache?(botId: string): BotDefinition | undefined;
+      writeCache(definition: BotDefinition): void;
+    },
+  ): BotSkillSyncService {
+    return new BotSkillSyncService({
+      workspace: workspace(),
+      baseStore: baseStore(),
+      cloud: cloudClient,
+      packages: packages(),
+      definitionCache,
+      pendingStore: pendingStore(),
+      now: () => new Date('2026-07-24T00:00:00.000Z'),
+    });
+  }
+
+  function writeSkill(directoryName: string, name = directoryName, body = 'initial'): string {
+    const directory = path.join(skillsRoot, directoryName);
+    fs.mkdirSync(directory, { recursive: true });
+    fs.writeFileSync(path.join(directory, 'SKILL.md'), [
+      '---',
+      `name: ${name}`,
+      `description: ${name} skill`,
+      '---',
+      '',
+      `# ${name}`,
+      '',
+      body,
+      '',
+    ].join('\n'));
+    return directory;
+  }
+
+  async function establishBase(): Promise<void> {
+    writeSkill('alpha');
+    workspace().claimExisting(owner);
+    const result = await syncService().sync({ owner, definitionForCreate: definition });
+    assert.equal(result.action, 'created_cloud');
+  }
+
+  test('Skill-only cloud refresh locks the cache and preserves locally owned model and prompt fields', async () => {
+    await establishBase();
+    const localDefinition: BotDefinition = {
+      ...definition,
+      model: { kind: 'catalog', modelId: 'latest-local-model' },
+      prompt: { selected: 'custom', customSystemPrompt: 'keep local prompt' },
+    };
+    let written: BotDefinition | undefined;
+    let locked = false;
+
+    const result = await syncService(cloud(), {
+      withWriteLock: (_botId, operation) => {
+        assert.equal(locked, false);
+        locked = true;
+        try {
+          return operation();
+        } finally {
+          locked = false;
+        }
+      },
+      readCache: () => {
+        assert.equal(locked, true);
+        return localDefinition;
+      },
+      writeCache: value => {
+        assert.equal(locked, true);
+        written = value;
+      },
+    }).sync({ owner, definitionForCreate: localDefinition });
+
+    assert.equal(result.action, 'noop');
+    assert.deepStrictEqual(written?.prompt, localDefinition.prompt);
+    assert.deepStrictEqual(written?.model, localDefinition.model);
+    assert.deepStrictEqual(written?.skills?.length, 1);
+  });
+
+  test('Skill cache repair falls back to canonical Definition when the cache is missing', async () => {
+    await establishBase();
+    const repository = new FileBotDefinitionRepository({
+      runtimeRoot,
+      simulatedCloudRoot: path.join(root, 'definition-canonical'),
+    });
+    repository.writeCanonical({
+      ...definition,
+      model: { kind: 'catalog', modelId: 'canonical-model' },
+      prompt: { selected: 'custom', customSystemPrompt: 'canonical prompt' },
+    });
+
+    const result = await syncService(cloud(), repository).sync({
+      owner,
+      definitionForCreate: definition,
+    });
+
+    assert.equal(result.action, 'noop');
+    assert.deepStrictEqual(repository.readCache('bot-a')?.model, {
+      kind: 'catalog',
+      modelId: 'canonical-model',
+    });
+    assert.deepStrictEqual(repository.readCache('bot-a')?.prompt, {
+      selected: 'custom',
+      customSystemPrompt: 'canonical prompt',
+    });
+    assert.deepStrictEqual(repository.readCache('bot-a')?.skills?.length, 1);
+  });
+
+  async function uploadRemoteVersion(name: string, localSkillId: string, body: string) {
+    const source = path.join(root, `remote-${localSkillId}-${body.replace(/\W/g, '')}`);
+    fs.mkdirSync(source);
+    fs.writeFileSync(path.join(source, 'SKILL.md'), [
+      '---',
+      `name: ${name}`,
+      `description: ${name} remote`,
+      '---',
+      '',
+      body,
+      '',
+    ].join('\n'));
+    return packages().upsert({
+      localSkillId,
+      name,
+      snapshot: buildBotSkillSourceSnapshot(source),
+    });
+  }
+
+  test('does nothing when Local, Base, and Cloud agree', async () => {
+    await establishBase();
+    const beforeCloud = await cloud().read();
+    const beforePackages = fs.readdirSync(path.dirname(packages().getPackagePath(
+      (workspace().inspect(owner) as any).skills[0].localSkillId,
+      (workspace().inspect(owner) as any).skills[0].contentHash,
+    ))).length;
+
+    const result = await syncService().sync({ owner, definitionForCreate: definition });
+
+    assert.equal(result.action, 'noop');
+    assert.deepStrictEqual(await cloud().read(), beforeCloud);
+    assert.equal(fs.readdirSync(path.dirname(packages().getPackagePath(
+      (workspace().inspect(owner) as any).skills[0].localSkillId,
+      (workspace().inspect(owner) as any).skills[0].contentHash,
+    ))).length, beforePackages);
+  });
+
+  test('uploads Local changes and uses Local priority when Cloud changed too', async () => {
+    await establishBase();
+    const initialCloud = await cloud().read();
+    assert.equal(initialCloud.kind, 'found');
+    if (initialCloud.kind !== 'found') return;
+    const localInspection = workspace().inspect(owner);
+    assert.equal(localInspection.kind, 'valid');
+    if (localInspection.kind !== 'valid') return;
+    const remote = await uploadRemoteVersion('alpha', 'remote-alpha', 'remote change');
+    await cloud().patchSkills([remote.reference], initialCloud.etag);
+    fs.appendFileSync(localInspection.skills[0].skillFilePath, '\nlocal change\n');
+
+    const result = await syncService().sync({ owner, definitionForCreate: definition });
+
+    assert.equal(result.action, 'uploaded');
+    const finalCloud = await cloud().read();
+    assert.equal(finalCloud.kind, 'found');
+    if (finalCloud.kind === 'found') {
+      assert.notDeepStrictEqual(finalCloud.definition.skills, [remote.reference]);
+      assert.match(finalCloud.definition.skills?.[0].skillId || '', /^priv_[a-f0-9]{40}$/);
+      assert.doesNotMatch(finalCloud.definition.skills?.[0].skillId || '', new RegExp(localInspection.skills[0].localSkillId));
+    }
+  });
+
+  test('downloads Cloud changes only when Local still matches Base', async () => {
+    await establishBase();
+    const initialCloud = await cloud().read();
+    assert.equal(initialCloud.kind, 'found');
+    if (initialCloud.kind !== 'found') return;
+    const remote = await uploadRemoteVersion('alpha', 'remote-alpha', 'cloud wins');
+    await cloud().patchSkills([remote.reference], initialCloud.etag);
+
+    const result = await syncService().sync({ owner, definitionForCreate: definition });
+
+    assert.equal(result.action, 'downloaded');
+    assert.match(fs.readFileSync(path.join(skillsRoot, 'alpha', 'SKILL.md'), 'utf8'), /cloud wins/);
+    const next = await syncService().sync({ owner, definitionForCreate: definition });
+    assert.equal(next.action, 'noop');
+  });
+
+  test('restores a missing workspace from Cloud and treats an explicit empty Cloud list as valid', async () => {
+    await establishBase();
+    fs.rmSync(skillsRoot, { recursive: true, force: true });
+    const restored = await syncService().sync({ owner, definitionForCreate: definition });
+    assert.equal(restored.action, 'downloaded');
+    assert.equal(fs.existsSync(path.join(skillsRoot, 'alpha', 'SKILL.md')), true);
+
+    const currentCloud = await cloud().read();
+    assert.equal(currentCloud.kind, 'found');
+    if (currentCloud.kind !== 'found') return;
+    await cloud().patchSkills([], currentCloud.etag);
+    const pulledEmpty = await syncService().sync({ owner, definitionForCreate: definition });
+    assert.equal(pulledEmpty.action, 'downloaded');
+    const inspection = workspace().inspect(owner);
+    assert.equal(inspection.kind === 'valid' && inspection.skills.length, 0);
+  });
+
+  test('uploads a valid empty Local workspace as deletion of all Skill references', async () => {
+    await establishBase();
+    const inspection = workspace().inspect(owner);
+    assert.equal(inspection.kind, 'valid');
+    if (inspection.kind !== 'valid') return;
+    fs.rmSync(inspection.skills[0].directoryPath, { recursive: true, force: true });
+
+    const result = await syncService().sync({ owner, definitionForCreate: definition });
+
+    assert.equal(result.action, 'uploaded');
+    const finalCloud = await cloud().read();
+    assert.equal(finalCloud.kind === 'found' && finalCloud.definition.skills?.length, 0);
+    const base = baseStore().read('bot-a', inspection.identity.workspaceId);
+    assert.equal(base.kind === 'valid' && base.base.entries.length, 0);
+  });
+
+  test('partially advances safe Skills while sensitive Skills remain local and dirty', async () => {
+    await establishBase();
+    const inspection = workspace().inspect(owner);
+    assert.equal(inspection.kind, 'valid');
+    if (inspection.kind !== 'valid') return;
+    fs.appendFileSync(inspection.skills[0].skillFilePath, '\nsafe update\n');
+    const sensitive = writeSkill('sensitive');
+    fs.writeFileSync(path.join(sensitive, '.env'), 'API_KEY=sk-proj-1234567890abcdefghijklmnop\n');
+
+    const result = await syncService().sync({ owner, definitionForCreate: definition });
+
+    assert.equal(result.action, 'uploaded');
+    assert.equal(result.blockedSkills?.length, 1);
+    assert.equal(result.blockedSkills?.[0].code, 'SKILL_SOURCE_SENSITIVE');
+    assert.deepStrictEqual(result.blockedSkills?.[0].relativePaths, ['.env']);
+    const finalCloud = await cloud().read();
+    assert.equal(finalCloud.kind === 'found' && finalCloud.definition.skills?.length, 1);
+    const again = await syncService().sync({ owner, definitionForCreate: definition });
+    assert.equal(again.action, 'uploaded');
+    assert.equal(again.blockedSkills?.[0].code, 'SKILL_SOURCE_SENSITIVE');
+  });
+
+  test('does not advance Base when Definition PATCH fails or the ETag is stale', async () => {
+    await establishBase();
+    const inspection = workspace().inspect(owner);
+    assert.equal(inspection.kind, 'valid');
+    if (inspection.kind !== 'valid') return;
+    const originalBase = baseStore().read('bot-a', inspection.identity.workspaceId);
+    fs.appendFileSync(inspection.skills[0].skillFilePath, '\nchanged\n');
+    const realCloud = cloud();
+    const failingCloud: BotDefinitionCloudClient = {
+      read: () => realCloud.read(),
+      create: definition => realCloud.create(definition),
+      patchSkills: async () => {
+        throw new BotDefinitionCloudError('failed', 'TEST_PATCH_FAILED', 500);
+      },
+    };
+
+    const failed = await syncService(failingCloud).sync({ owner, definitionForCreate: definition });
+    assert.equal(failed.action, 'degraded_local');
+    assert.deepStrictEqual(baseStore().read('bot-a', inspection.identity.workspaceId), originalBase);
+
+    const staleCloud: BotDefinitionCloudClient = {
+      read: () => realCloud.read(),
+      create: definition => realCloud.create(definition),
+      patchSkills: async () => {
+        throw new BotDefinitionCloudError('stale', 'BOT_DEFINITION_PRECONDITION_FAILED', 412);
+      },
+    };
+    const stale = await syncService(staleCloud).sync({ owner, definitionForCreate: definition });
+    assert.equal(stale.action, 'degraded_local');
+    assert.equal(stale.reason, 'CLOUD_ETAG_CONFLICT');
+    assert.deepStrictEqual(baseStore().read('bot-a', inspection.identity.workspaceId), originalBase);
+  });
+
+  test('re-reads Cloud and retries a local-priority upload once after an ETag race', async () => {
+    await establishBase();
+    const inspection = workspace().inspect(owner);
+    assert.equal(inspection.kind, 'valid');
+    if (inspection.kind !== 'valid') return;
+    fs.appendFileSync(inspection.skills[0].skillFilePath, '\nlocal edit during model race\n');
+    const realCloud = cloud();
+    let firstPatch = true;
+    const racingCloud: BotDefinitionCloudClient = {
+      read: () => realCloud.read(),
+      create: value => realCloud.create(value),
+      patchSkills: async (skills, etag) => {
+        if (firstPatch) {
+          firstPatch = false;
+          const current = await realCloud.read();
+          assert.equal(current.kind, 'found');
+          if (current.kind !== 'found') throw new Error('cloud missing');
+          await realCloud.patchSkills(current.definition.skills || [], current.etag);
+          throw new BotDefinitionCloudError('stale', 'BOT_DEFINITION_PRECONDITION_FAILED', 412);
+        }
+        return realCloud.patchSkills(skills, etag);
+      },
+    };
+
+    const result = await syncService(racingCloud).sync({ owner, definitionForCreate: definition });
+    assert.equal(result.action, 'uploaded');
+    const finalCloud = await realCloud.read();
+    assert.equal(finalCloud.kind, 'found');
+    assert.equal(finalCloud.kind === 'found' && finalCloud.definition.skills?.length, 1);
+  });
+
+  test('keeps a downloaded workspace and Base committed when Definition cache repair fails', async () => {
+    await establishBase();
+    const currentCloud = await cloud().read();
+    assert.equal(currentCloud.kind, 'found');
+    if (currentCloud.kind !== 'found') return;
+    const remote = await uploadRemoteVersion('alpha', 'remote-cache-failure', 'cloud survives cache failure');
+    await cloud().patchSkills([remote.reference], currentCloud.etag);
+
+    const result = await syncService(cloud(), {
+      writeCache: () => { throw new Error('cache directory is read-only'); },
+    }).sync({ owner, definitionForCreate: definition });
+
+    assert.equal(result.action, 'downloaded');
+    assert.match(fs.readFileSync(path.join(skillsRoot, 'alpha', 'SKILL.md'), 'utf8'), /cloud survives cache failure/);
+    const inspection = workspace().inspect(owner);
+    assert.equal(inspection.kind, 'valid');
+    if (inspection.kind === 'valid') {
+      assert.equal(baseStore().read('bot-a', inspection.identity.workspaceId).kind, 'valid');
+    }
+  });
+
+  test('recovers Base when Cloud committed but the client lost the response', async () => {
+    await establishBase();
+    const inspection = workspace().inspect(owner);
+    assert.equal(inspection.kind, 'valid');
+    if (inspection.kind !== 'valid') return;
+    const originalBase = baseStore().read('bot-a', inspection.identity.workspaceId);
+    fs.appendFileSync(inspection.skills[0].skillFilePath, '\ncommit then disconnect\n');
+    const realCloud = cloud();
+    const lostResponseCloud: BotDefinitionCloudClient = {
+      read: () => realCloud.read(),
+      create: definition => realCloud.create(definition),
+      patchSkills: async (skills, etag) => {
+        await realCloud.patchSkills(skills, etag);
+        const error: any = new Error('connection reset after commit');
+        error.code = 'BOT_DEFINITION_NETWORK_ERROR';
+        error.status = 503;
+        throw error;
+      },
+    };
+
+    const first = await syncService(lostResponseCloud).sync({ owner, definitionForCreate: definition });
+    assert.equal(first.action, 'degraded_local');
+    assert.deepStrictEqual(baseStore().read('bot-a', inspection.identity.workspaceId), originalBase);
+    assert.equal(fs.existsSync(pendingStore().getPath()), true);
+
+    const recovered = await syncService().sync({ owner, definitionForCreate: definition });
+    assert.equal(recovered.action, 'noop');
+    assert.equal(fs.existsSync(pendingStore().getPath()), false);
+    const finalBase = baseStore().read('bot-a', inspection.identity.workspaceId);
+    assert.equal(finalBase.kind, 'valid');
+    if (finalBase.kind === 'valid') {
+      assert.notDeepStrictEqual(finalBase.base.entries, (originalBase as any).base.entries);
+    }
+  });
+
+  test('stops on corrupt or unknown Base and degrades locally on Cloud outage', async () => {
+    await establishBase();
+    const inspection = workspace().inspect(owner);
+    assert.equal(inspection.kind, 'valid');
+    if (inspection.kind !== 'valid') return;
+    fs.writeFileSync(baseStore().getPath('bot-a'), '{broken');
+    const corrupt = await syncService().sync({ owner, definitionForCreate: definition });
+    assert.equal(corrupt.action, 'conflict');
+    assert.equal(corrupt.reason, 'BASE_CORRUPT');
+
+    const offlineCloud: BotDefinitionCloudClient = {
+      read: async () => { throw new Error('offline'); },
+      create: async () => { throw new Error('offline'); },
+      patchSkills: async () => { throw new Error('offline'); },
+    };
+    const offline = await syncService(offlineCloud).sync({ owner, definitionForCreate: definition });
+    assert.equal(offline.action, 'degraded_local');
+
+    fs.rmSync(baseStore().getPath('bot-a'));
+    const unknown = await syncService().sync({ owner, definitionForCreate: definition });
+    assert.equal(unknown.action, 'conflict');
+    assert.equal(unknown.reason, 'BASE_UNKNOWN_CONFLICT');
+  });
+
+  test('repairs a missing Base only through an explicit local-wins or cloud-wins choice', async () => {
+    await establishBase();
+    const inspection = workspace().inspect(owner);
+    assert.equal(inspection.kind, 'valid');
+    if (inspection.kind !== 'valid') return;
+    const currentCloud = await cloud().read();
+    assert.equal(currentCloud.kind, 'found');
+    if (currentCloud.kind !== 'found') return;
+
+    const remote = await uploadRemoteVersion('alpha', 'remote-alpha', 'cloud repair choice');
+    await cloud().patchSkills([remote.reference], currentCloud.etag);
+    fs.appendFileSync(inspection.skills[0].skillFilePath, '\nlocal repair choice\n');
+    fs.rmSync(baseStore().getPath('bot-a'));
+
+    const unresolved = await syncService().sync({ owner, definitionForCreate: definition });
+    assert.equal(unresolved.action, 'conflict');
+    assert.equal(unresolved.reason, 'BASE_UNKNOWN_CONFLICT');
+
+    const localRepair = await syncService().repair(
+      { owner, definitionForCreate: definition },
+      'local-wins',
+    );
+    assert.equal(localRepair.action, 'uploaded');
+    assert.equal(localRepair.reason, 'BASE_REPAIRED_LOCAL_WINS');
+    const afterLocalCloud = await cloud().read();
+    assert.equal(afterLocalCloud.kind, 'found');
+    if (afterLocalCloud.kind !== 'found') return;
+    assert.notDeepStrictEqual(afterLocalCloud.definition.skills, [remote.reference]);
+    assert.equal(baseStore().read('bot-a', inspection.identity.workspaceId).kind, 'valid');
+
+    const secondRemote = await uploadRemoteVersion('alpha', 'remote-alpha-2', 'second cloud choice');
+    await cloud().patchSkills([secondRemote.reference], afterLocalCloud.etag);
+    fs.appendFileSync(inspection.skills[0].skillFilePath, '\nsecond local choice\n');
+    fs.rmSync(baseStore().getPath('bot-a'));
+
+    const cloudRepair = await syncService().repair(
+      { owner, definitionForCreate: definition },
+      'cloud-wins',
+    );
+    assert.equal(cloudRepair.action, 'downloaded');
+    assert.equal(cloudRepair.reason, 'BASE_REPAIRED_CLOUD_WINS');
+    assert.match(
+      fs.readFileSync(path.join(skillsRoot, 'alpha', 'SKILL.md'), 'utf8'),
+      /second cloud choice/,
+    );
+    const repairedInspection = workspace().inspect(owner);
+    assert.equal(repairedInspection.kind, 'valid');
+    if (repairedInspection.kind === 'valid') {
+      assert.equal(baseStore().read('bot-a', repairedInspection.identity.workspaceId).kind, 'valid');
+    }
+  });
+
+  test('does not partially overwrite Cloud when local-wins repair cannot upload every Skill', async () => {
+    writeSkill('alpha');
+    writeSkill('blocked');
+    const inspection = workspace().claimExisting(owner);
+    const originalCloud = await cloud().create({ ...definition, skills: [] });
+    const realPackages = packages();
+    const failingPackages = {
+      download: realPackages.download.bind(realPackages),
+      upsert: async (input: any) => {
+        if (input.name === 'blocked') {
+          const error: any = new Error('sensitive package');
+          error.code = 'PRIVATE_SKILL_SENSITIVE_REJECTED';
+          throw error;
+        }
+        return realPackages.upsert(input);
+      },
+    };
+    const service = new BotSkillSyncService({
+      workspace: workspace(),
+      baseStore: baseStore(),
+      cloud: cloud(),
+      packages: failingPackages,
+      pendingStore: pendingStore(),
+      now: () => new Date('2026-07-24T00:00:00.000Z'),
+    });
+
+    const repaired = await service.repair(
+      { owner, definitionForCreate: definition },
+      'local-wins',
+    );
+    assert.equal(repaired.action, 'blocked');
+    assert.equal(repaired.reason, 'SYNC_REPAIR_LOCAL_SKILLS_BLOCKED');
+    assert.deepStrictEqual(repaired.blockedSkills?.map(item => item.name), ['blocked']);
+    assert.deepStrictEqual(await cloud().read(), { kind: 'found', ...originalCloud });
+    assert.equal(baseStore().read('bot-a', inspection.workspaceId).kind, 'missing');
+  });
+
+  test('cloud-wins repair refuses to activate a Cloud snapshot that changed during download', async () => {
+    await establishBase();
+    const inspection = workspace().inspect(owner);
+    assert.equal(inspection.kind, 'valid');
+    if (inspection.kind !== 'valid') return;
+    const initialCloud = await cloud().read();
+    assert.equal(initialCloud.kind, 'found');
+    if (initialCloud.kind !== 'found') return;
+    const firstRemote = await uploadRemoteVersion('alpha', 'remote-first', 'first remote');
+    const firstCloud = await cloud().patchSkills([firstRemote.reference], initialCloud.etag);
+    const secondRemote = await uploadRemoteVersion('alpha', 'remote-second', 'second remote');
+    fs.appendFileSync(inspection.skills[0].skillFilePath, '\nkeep this local copy\n');
+    fs.rmSync(baseStore().getPath('bot-a'));
+    const realCloud = cloud();
+    let reads = 0;
+    const racingCloud: BotDefinitionCloudClient = {
+      read: async () => {
+        reads += 1;
+        if (reads === 1) return realCloud.read();
+        await realCloud.patchSkills([secondRemote.reference], firstCloud.etag);
+        return realCloud.read();
+      },
+      create: value => realCloud.create(value),
+      patchSkills: (skills, etag) => realCloud.patchSkills(skills, etag),
+    };
+
+    const repaired = await syncService(racingCloud).repair(
+      { owner, definitionForCreate: definition },
+      'cloud-wins',
+    );
+    assert.equal(repaired.action, 'degraded_local');
+    assert.equal(repaired.reason, 'CLOUD_CHANGED_DURING_DOWNLOAD');
+    assert.match(fs.readFileSync(inspection.skills[0].skillFilePath, 'utf8'), /keep this local copy/);
+    assert.equal(baseStore().read('bot-a', inspection.identity.workspaceId).kind, 'missing');
+  });
+
+  test('explicitly claims and migrates a legacy local workspace only when Cloud lacks skills', async () => {
+    writeSkill('legacy');
+    await cloud().create(definition);
+
+    const blocked = await syncService().sync({ owner, definitionForCreate: definition });
+    assert.equal(blocked.action, 'conflict');
+    assert.equal(fs.existsSync(path.join(skillsRoot, 'legacy', BOT_LOCAL_SKILL_IDENTITY_FILE)), false);
+
+    const migrated = await syncService().sync({
+      owner,
+      definitionForCreate: definition,
+      allowLegacyClaim: true,
+    });
+    assert.equal(migrated.action, 'migrated');
+    assert.equal(fs.existsSync(path.join(skillsRoot, 'legacy', BOT_LOCAL_SKILL_IDENTITY_FILE)), true);
+    const finalCloud = await cloud().read();
+    assert.equal(finalCloud.kind === 'found' && finalCloud.definition.skills?.length, 1);
+  });
+
+  test('initializes a default Skill once only for an explicit new Bot flow', async () => {
+    let initializationCount = 0;
+    const created = await syncService().sync({
+      owner,
+      definitionForCreate: definition,
+      allowNewWorkspaceCreate: true,
+      initializeNewWorkspace: async () => {
+        initializationCount += 1;
+        writeSkill('default-skill');
+      },
+    });
+    assert.equal(created.action, 'created_cloud');
+    assert.equal(initializationCount, 1);
+    const createdCloud = await cloud().read();
+    assert.equal(createdCloud.kind === 'found' && createdCloud.definition.skills?.length, 1);
+
+    const second = await syncService().sync({
+      owner,
+      definitionForCreate: definition,
+      allowNewWorkspaceCreate: true,
+      initializeNewWorkspace: async () => {
+        initializationCount += 1;
+      },
+    });
+    assert.equal(second.action, 'noop');
+    assert.equal(initializationCount, 1);
+  });
+
+  test('retries failed new-Bot default initialization before creating Cloud', async () => {
+    let initializationCount = 0;
+    await cloud().create(definition);
+    await assert.rejects(
+      syncService().sync({
+        owner,
+        definitionForCreate: definition,
+        allowNewWorkspaceCreate: true,
+        initializeNewWorkspace: async () => {
+          initializationCount += 1;
+          throw new Error('temporary default package outage');
+        },
+      }),
+      /temporary default package outage/,
+    );
+    const legacyCloud = await cloud().read();
+    assert.equal(legacyCloud.kind, 'found');
+    assert.equal(legacyCloud.kind === 'found' && legacyCloud.definition.skills, undefined);
+    assert.equal(workspace().inspect(owner).kind, 'valid');
+
+    const recovered = await syncService().sync({
+      owner,
+      definitionForCreate: definition,
+      allowNewWorkspaceCreate: true,
+      initializeNewWorkspace: async () => {
+        initializationCount += 1;
+        writeSkill('default-after-retry');
+      },
+    });
+    assert.equal(recovered.action, 'created_cloud');
+    assert.equal(initializationCount, 2);
+    const finalCloud = await cloud().read();
+    assert.equal(finalCloud.kind === 'found' && finalCloud.definition.skills?.length, 1);
+  });
+
+  test('keeps an unchanged SkillHub reference and forks it privately after a local edit', async () => {
+    const source = path.join(root, 'public-source');
+    fs.mkdirSync(source);
+    fs.writeFileSync(path.join(source, 'SKILL.md'), [
+      '---',
+      'name: public-skill',
+      'description: public skill',
+      '---',
+      '',
+      '# public-skill',
+      '',
+    ].join('\n'));
+    const published = await packages().upsert({
+      localSkillId: 'public-source-id',
+      name: 'public-skill',
+      snapshot: buildBotSkillSourceSnapshot(source),
+    });
+    fs.cpSync(source, path.join(skillsRoot, 'public-skill'), { recursive: true });
+    writeSkillHubInstallMarker(path.join(skillsRoot, 'public-skill'), {
+      source: 'skillhub',
+      skillId: published.reference.skillId,
+      name: 'public-skill',
+      installName: 'public-skill',
+      version: published.reference.version,
+      packageChecksumSha256: published.contentHash,
+      signature: {
+        algorithm: 'ed25519',
+        keyId: 'test-key',
+        value: 'test-signature',
+      },
+      packageUrl: 'https://skillhub.example/public-skill.tgz',
+      installedAt: '2026-07-24T00:00:00.000Z',
+    });
+    workspace().claimExisting(owner);
+
+    const initial = await syncService().sync({ owner, definitionForCreate: definition });
+    assert.equal(initial.action, 'created_cloud');
+    const initialCloud = await cloud().read();
+    assert.equal(initialCloud.kind, 'found');
+    if (initialCloud.kind !== 'found') return;
+    assert.deepStrictEqual(initialCloud.definition.skills, [published.reference]);
+
+    fs.appendFileSync(path.join(skillsRoot, 'public-skill', 'SKILL.md'), '\nlocal fork\n');
+    const forked = await syncService().sync({ owner, definitionForCreate: definition });
+    assert.equal(forked.action, 'uploaded');
+    const forkedCloud = await cloud().read();
+    assert.equal(forkedCloud.kind, 'found');
+    if (forkedCloud.kind === 'found') {
+      assert.notDeepStrictEqual(forkedCloud.definition.skills, [published.reference]);
+      assert.match(forkedCloud.definition.skills?.[0].skillId || '', /^priv_[a-f0-9]{40}$/);
+    }
+  });
+
+  test('recovers a restore interrupted before and just after target activation', async () => {
+    await establishBase();
+    const oldInspection = workspace().inspect(owner);
+    assert.equal(oldInspection.kind, 'valid');
+    if (oldInspection.kind !== 'valid') return;
+    const oldWorkspaceId = oldInspection.identity.workspaceId;
+    const currentCloud = await cloud().read();
+    assert.equal(currentCloud.kind, 'found');
+    if (currentCloud.kind !== 'found') return;
+    const remote = await uploadRemoteVersion('alpha', 'remote-alpha', 'restored cloud content');
+    const nextCloud = await cloud().patchSkills([remote.reference], currentCloud.etag);
+
+    const stagingRoot = path.join(runtimeRoot, '.bot-skill-restore-crash');
+    const backupRoot = path.join(runtimeRoot, '.bot-skill-backup-crash');
+    const staged = await restoreBotSkillWorkspace({
+      skillsRoot: stagingRoot,
+      owner,
+      references: [remote.reference],
+      packageClient: packages(),
+    });
+    const writePending = (phase: 'prepared' | 'old_parked') => pendingStore().write({
+      schema: 'xiaoba.bot-skill-pending-commit.v1',
+      kind: 'restore',
+      phase,
+      botId: owner.botId,
+      workspaceId: staged.identity.workspaceId,
+      authority,
+      cloudReferences: [remote.reference],
+      entries: staged.entries,
+      createdAt: '2026-07-24T00:00:00.000Z',
+      updatedAt: '2026-07-24T00:00:00.000Z',
+      restore: {
+        activeRoot: skillsRoot,
+        stagingRoot,
+        backupRoot,
+        hadActive: true,
+      },
+    });
+
+    writePending('prepared');
+    const resumedBeforeRename = await syncService().sync({ owner, definitionForCreate: definition });
+    assert.equal(resumedBeforeRename.action, 'noop');
+    assert.match(fs.readFileSync(path.join(skillsRoot, 'alpha', 'SKILL.md'), 'utf8'), /restored cloud content/);
+    assert.equal(fs.existsSync(backupRoot), false);
+    assert.equal(fs.existsSync(pendingStore().getPath()), false);
+
+    fs.renameSync(skillsRoot, stagingRoot);
+    const oldRoot = path.join(root, 'old-workspace-rebuilt');
+    const oldWorkspace = new BotSkillWorkspaceService({
+      skillsRoot: oldRoot,
+      createId: () => oldWorkspaceId,
+    });
+    oldWorkspace.initializeEmpty(owner);
+    fs.mkdirSync(path.join(oldRoot, 'alpha'));
+    fs.writeFileSync(path.join(oldRoot, 'alpha', 'SKILL.md'), [
+      '---', 'name: alpha', 'description: alpha skill', '---', '', 'old local content', '',
+    ].join('\n'));
+    oldWorkspace.inspect(owner);
+    fs.renameSync(oldRoot, backupRoot);
+    fs.renameSync(stagingRoot, skillsRoot);
+    writePending('old_parked');
+
+    const resumedAfterRename = await syncService().sync({ owner, definitionForCreate: definition });
+    assert.equal(resumedAfterRename.action, 'noop');
+    assert.equal(resumedAfterRename.definitionETag, nextCloud.etag);
+    assert.match(fs.readFileSync(path.join(skillsRoot, 'alpha', 'SKILL.md'), 'utf8'), /restored cloud content/);
+    assert.equal(fs.existsSync(backupRoot), false);
+    assert.equal(fs.existsSync(pendingStore().getPath()), false);
+
+    const c1Base = baseStore().read('bot-a', staged.identity.workspaceId);
+    assert.equal(c1Base.kind, 'valid');
+    if (c1Base.kind !== 'valid') return;
+    const remoteC2 = await uploadRemoteVersion('alpha', 'remote-alpha-c2', 'newer cloud content');
+    const cloudBeforeC2 = await cloud().read();
+    assert.equal(cloudBeforeC2.kind, 'found');
+    if (cloudBeforeC2.kind !== 'found') return;
+    await cloud().patchSkills([remoteC2.reference], cloudBeforeC2.etag);
+    fs.cpSync(skillsRoot, backupRoot, { recursive: true });
+    fs.writeFileSync(path.join(backupRoot, 'alpha', 'SKILL.md'), [
+      '---', 'name: alpha', 'description: alpha skill', '---', '', 'obsolete backup content', '',
+    ].join('\n'));
+    pendingStore().write({
+      schema: 'xiaoba.bot-skill-pending-commit.v1',
+      kind: 'restore',
+      phase: 'base_committed',
+      botId: owner.botId,
+      workspaceId: staged.identity.workspaceId,
+      authority,
+      definitionETag: nextCloud.etag,
+      cloudReferences: [remote.reference],
+      entries: c1Base.base.entries,
+      createdAt: '2026-07-24T00:00:00.000Z',
+      updatedAt: '2026-07-24T00:00:00.000Z',
+      restore: {
+        activeRoot: skillsRoot,
+        stagingRoot,
+        backupRoot,
+        hadActive: true,
+      },
+    });
+
+    const resumedAfterCloudAdvanced = await syncService().sync({ owner, definitionForCreate: definition });
+    assert.equal(resumedAfterCloudAdvanced.action, 'downloaded');
+    assert.match(fs.readFileSync(path.join(skillsRoot, 'alpha', 'SKILL.md'), 'utf8'), /newer cloud content/);
+    assert.doesNotMatch(fs.readFileSync(path.join(skillsRoot, 'alpha', 'SKILL.md'), 'utf8'), /obsolete backup/);
+    assert.equal(fs.existsSync(backupRoot), false);
+    assert.equal(fs.existsSync(pendingStore().getPath()), false);
+
+    const c2Inspection = workspace().inspect(owner);
+    assert.equal(c2Inspection.kind, 'valid');
+    if (c2Inspection.kind !== 'valid') return;
+    const c2Base = baseStore().read('bot-a', c2Inspection.identity.workspaceId);
+    assert.equal(c2Base.kind, 'valid');
+    if (c2Base.kind !== 'valid') return;
+    const cloudAtC2 = await cloud().read();
+    assert.equal(cloudAtC2.kind, 'found');
+    if (cloudAtC2.kind !== 'found') return;
+    const remoteC3 = await uploadRemoteVersion('alpha', 'remote-alpha-c3', 'third cloud content');
+    await cloud().patchSkills([remoteC3.reference], cloudAtC2.etag);
+    fs.cpSync(skillsRoot, backupRoot, { recursive: true });
+    fs.appendFileSync(path.join(skillsRoot, 'alpha', 'SKILL.md'), '\noffline local edit must survive\n');
+    pendingStore().write({
+      schema: 'xiaoba.bot-skill-pending-commit.v1',
+      kind: 'restore',
+      phase: 'base_committed',
+      botId: owner.botId,
+      workspaceId: c2Inspection.identity.workspaceId,
+      authority,
+      definitionETag: cloudAtC2.etag,
+      cloudReferences: [remoteC2.reference],
+      entries: c2Base.base.entries,
+      createdAt: '2026-07-24T00:00:00.000Z',
+      updatedAt: '2026-07-24T00:00:00.000Z',
+      restore: {
+        activeRoot: skillsRoot,
+        stagingRoot,
+        backupRoot,
+        hadActive: true,
+      },
+    });
+
+    const resumedWithOfflineEdit = await syncService().sync({ owner, definitionForCreate: definition });
+    assert.equal(resumedWithOfflineEdit.action, 'uploaded');
+    assert.match(fs.readFileSync(path.join(skillsRoot, 'alpha', 'SKILL.md'), 'utf8'), /offline local edit must survive/);
+    const cloudAfterOfflineEdit = await cloud().read();
+    assert.equal(cloudAfterOfflineEdit.kind, 'found');
+    if (cloudAfterOfflineEdit.kind === 'found') {
+      assert.notDeepStrictEqual(cloudAfterOfflineEdit.definition.skills, [remoteC3.reference]);
+    }
+    assert.equal(fs.existsSync(backupRoot), false);
+    assert.equal(fs.existsSync(pendingStore().getPath()), false);
+
+    const finalInspection = workspace().inspect(owner);
+    assert.equal(finalInspection.kind, 'valid');
+    if (finalInspection.kind !== 'valid') return;
+    const finalBase = baseStore().read('bot-a', finalInspection.identity.workspaceId);
+    assert.equal(finalBase.kind, 'valid');
+    if (finalBase.kind !== 'valid') return;
+    const finalCloud = await cloud().read();
+    assert.equal(finalCloud.kind, 'found');
+    if (finalCloud.kind !== 'found') return;
+    const remoteC4 = await uploadRemoteVersion('alpha', 'remote-alpha-c4', 'fourth cloud content');
+    await cloud().patchSkills([remoteC4.reference], finalCloud.etag);
+    fs.cpSync(skillsRoot, backupRoot, { recursive: true });
+    pendingStore().write({
+      schema: 'xiaoba.bot-skill-pending-commit.v1',
+      kind: 'restore',
+      phase: 'base_committed',
+      botId: owner.botId,
+      workspaceId: finalInspection.identity.workspaceId,
+      authority,
+      definitionETag: finalCloud.etag,
+      cloudReferences: finalBase.base.entries.map(entry => ({
+        skillId: entry.cloudSkillId,
+        version: entry.cloudVersion,
+      })),
+      entries: finalBase.base.entries,
+      createdAt: '2026-07-24T00:00:00.000Z',
+      updatedAt: '2026-07-24T00:00:00.000Z',
+      restore: {
+        activeRoot: skillsRoot,
+        stagingRoot,
+        backupRoot,
+        hadActive: true,
+      },
+    });
+    fs.writeFileSync(path.join(skillsRoot, BOT_SKILL_WORKSPACE_IDENTITY_FILE), '{broken');
+
+    const blockedUnreadable = await syncService().sync({ owner, definitionForCreate: definition });
+    assert.equal(blockedUnreadable.action, 'blocked');
+    assert.equal(blockedUnreadable.reason, 'PENDING_RESTORE_ACTIVE_UNSAFE');
+    assert.match(fs.readFileSync(path.join(skillsRoot, 'alpha', 'SKILL.md'), 'utf8'), /offline local edit must survive/);
+    assert.equal(fs.existsSync(backupRoot), true);
+    assert.equal(fs.existsSync(pendingStore().getPath()), true);
+  });
+});

--- a/tests/bot-skill-workspace-lock.test.ts
+++ b/tests/bot-skill-workspace-lock.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { withBotSkillWorkspaceLock } from '../src/bot-skills/workspace-lock';
+
+describe('Bot Skill workspace lock', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-bot-skill-lock-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('can lock a not-yet-created workspace and re-enter the same lock', async () => {
+    const workspaceRoot = path.join(root, 'runtime', '.skills');
+    const events: string[] = [];
+
+    await withBotSkillWorkspaceLock(workspaceRoot, async () => {
+      events.push('outer');
+      await withBotSkillWorkspaceLock(workspaceRoot.toUpperCase(), async () => {
+        events.push('inner');
+      });
+    });
+
+    assert.deepStrictEqual(events, ['outer', 'inner']);
+    assert.equal(fs.existsSync(workspaceRoot), false);
+    assert.equal(
+      fs.existsSync(path.join(path.dirname(workspaceRoot), '.skills.bot-skill.lock')),
+      false,
+    );
+  });
+
+  test('serializes concurrent operations for the same workspace', async () => {
+    const workspaceRoot = path.join(root, 'skills');
+    const events: string[] = [];
+    let releaseFirst!: () => void;
+    const firstMayFinish = new Promise<void>(resolve => {
+      releaseFirst = resolve;
+    });
+
+    const first = withBotSkillWorkspaceLock(workspaceRoot, async () => {
+      events.push('first-start');
+      await firstMayFinish;
+      events.push('first-end');
+    });
+    const second = withBotSkillWorkspaceLock(workspaceRoot, async () => {
+      events.push('second');
+    });
+    await new Promise(resolve => setImmediate(resolve));
+    assert.deepStrictEqual(events, ['first-start']);
+    releaseFirst();
+    await Promise.all([first, second]);
+    assert.deepStrictEqual(events, ['first-start', 'first-end', 'second']);
+  });
+
+  test('self-heals an old truncated lock left by a crashed process', async () => {
+    const workspaceRoot = path.join(root, 'skills');
+    const lockPath = path.join(root, '.skills.bot-skill.lock');
+    fs.writeFileSync(lockPath, '{"pid":');
+    const stale = new Date(Date.now() - 10 * 60_000);
+    fs.utimesSync(lockPath, stale, stale);
+
+    let entered = false;
+    await withBotSkillWorkspaceLock(workspaceRoot, async () => {
+      entered = true;
+    });
+
+    assert.equal(entered, true);
+    assert.equal(fs.existsSync(lockPath), false);
+  });
+});

--- a/tests/bot-skill-workspace-lock.test.ts
+++ b/tests/bot-skill-workspace-lock.test.ts
@@ -18,11 +18,14 @@ describe('Bot Skill workspace lock', () => {
 
   test('can lock a not-yet-created workspace and re-enter the same lock', async () => {
     const workspaceRoot = path.join(root, 'runtime', '.skills');
+    const equivalentWorkspaceRoot = process.platform === 'win32'
+      ? workspaceRoot.toUpperCase()
+      : path.join(workspaceRoot, '.');
     const events: string[] = [];
 
     await withBotSkillWorkspaceLock(workspaceRoot, async () => {
       events.push('outer');
-      await withBotSkillWorkspaceLock(workspaceRoot.toUpperCase(), async () => {
+      await withBotSkillWorkspaceLock(equivalentWorkspaceRoot, async () => {
         events.push('inner');
       });
     });

--- a/tests/bot-skill-workspace-restore.test.ts
+++ b/tests/bot-skill-workspace-restore.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { FileBotPrivateSkillPackageClient } from '../src/bot-skills/file-private-package';
+import { buildBotSkillSourceSnapshot } from '../src/bot-skills/source-snapshot';
+import { restoreBotSkillWorkspace } from '../src/bot-skills/workspace-restore';
+import { BotSkillWorkspaceService } from '../src/bot-skills/workspace';
+
+describe('transactional Bot Skill workspace restore', () => {
+  let root: string;
+  let packageRoot: string;
+  let activeRoot: string;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-skill-restore-'));
+    packageRoot = path.join(root, 'cloud');
+    activeRoot = path.join(root, 'runtime', 'skills');
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  async function upload(name: string, localSkillId: string) {
+    const source = path.join(root, `source-${name}`);
+    fs.mkdirSync(source);
+    fs.writeFileSync(path.join(source, 'SKILL.md'), [
+      '---',
+      `name: ${name}`,
+      `description: ${name} skill`,
+      '---',
+      '',
+      `# ${name}`,
+      '',
+    ].join('\n'));
+    const client = new FileBotPrivateSkillPackageClient({ root: packageRoot, botId: 'bot-a' });
+    return client.upsert({
+      localSkillId,
+      name,
+      snapshot: buildBotSkillSourceSnapshot(source),
+    });
+  }
+
+  test('downloads everything to staging and activates one complete workspace', async () => {
+    const a = await upload('alpha', 'local-a');
+    const b = await upload('beta', 'local-b');
+    const client = new FileBotPrivateSkillPackageClient({ root: packageRoot, botId: 'bot-a' });
+
+    const restored = await restoreBotSkillWorkspace({
+      skillsRoot: activeRoot,
+      owner: { botId: 'bot-a', authority: 'authority-a' },
+      references: [b.reference, a.reference],
+      packageClient: client,
+      createId: (() => {
+        let value = 1;
+        return () => `restore-${value++}`;
+      })(),
+      now: () => new Date('2026-07-24T00:00:00.000Z'),
+    });
+
+    const inspected = new BotSkillWorkspaceService({ skillsRoot: activeRoot })
+      .inspect({ botId: 'bot-a', authority: 'authority-a' });
+    assert.equal(inspected.kind, 'valid');
+    assert.deepStrictEqual(restored.entries.map(entry => entry.localSkillId), ['local-a', 'local-b']);
+    assert.equal(fs.existsSync(path.join(activeRoot, 'alpha', 'SKILL.md')), true);
+    assert.equal(fs.existsSync(path.join(activeRoot, 'beta', 'SKILL.md')), true);
+  });
+
+  test('leaves the active workspace byte-for-byte intact when a download or guard fails', async () => {
+    fs.mkdirSync(activeRoot, { recursive: true });
+    fs.writeFileSync(path.join(activeRoot, 'sentinel.txt'), 'keep me');
+    const version = await upload('alpha', 'local-a');
+    const client = new FileBotPrivateSkillPackageClient({ root: packageRoot, botId: 'bot-a' });
+
+    await assert.rejects(
+      restoreBotSkillWorkspace({
+        skillsRoot: activeRoot,
+        owner: { botId: 'bot-a' },
+        references: [version.reference, { skillId: `priv_${'a'.repeat(40)}`, version: `v_${'b'.repeat(48)}` }],
+        packageClient: client,
+      }),
+    );
+    assert.equal(fs.readFileSync(path.join(activeRoot, 'sentinel.txt'), 'utf8'), 'keep me');
+
+    await assert.rejects(
+      restoreBotSkillWorkspace({
+        skillsRoot: activeRoot,
+        owner: { botId: 'bot-a' },
+        references: [version.reference],
+        packageClient: client,
+        beforeCommit: () => {
+          throw new Error('local changed');
+        },
+      }),
+    );
+    assert.equal(fs.readFileSync(path.join(activeRoot, 'sentinel.txt'), 'utf8'), 'keep me');
+  });
+
+  test('preserves localSkillId when the same Cloud Skill advances to a new version', async () => {
+    const initial = await upload('alpha', 'server-local-id');
+    const client = new FileBotPrivateSkillPackageClient({ root: packageRoot, botId: 'bot-a' });
+    const downloaded = await client.download(initial.reference);
+    const nextReference = {
+      skillId: initial.reference.skillId,
+      version: `v_${'c'.repeat(48)}`,
+    };
+
+    const restored = await restoreBotSkillWorkspace({
+      skillsRoot: activeRoot,
+      owner: { botId: 'bot-a' },
+      references: [nextReference],
+      baseEntries: [{
+        localSkillId: 'stable-local-id',
+        localContentHash: downloaded.contentHash,
+        cloudSkillId: initial.reference.skillId,
+        cloudVersion: initial.reference.version,
+      }],
+      packageClient: {
+        download: async reference => ({
+          ...downloaded,
+          reference,
+          localSkillId: 'different-server-local-id',
+        }),
+      },
+    });
+
+    assert.equal(restored.entries[0].localSkillId, 'stable-local-id');
+    const inspected = new BotSkillWorkspaceService({ skillsRoot: activeRoot })
+      .inspect({ botId: 'bot-a' });
+    assert.equal(
+      inspected.kind === 'valid' && inspected.skills[0].localSkillId,
+      'stable-local-id',
+    );
+  });
+
+  test('rejects a download response bound to a different Cloud reference', async () => {
+    const version = await upload('alpha', 'local-a');
+    const client = new FileBotPrivateSkillPackageClient({ root: packageRoot, botId: 'bot-a' });
+    const downloaded = await client.download(version.reference);
+
+    await assert.rejects(
+      restoreBotSkillWorkspace({
+        skillsRoot: activeRoot,
+        owner: { botId: 'bot-a' },
+        references: [version.reference],
+        packageClient: {
+          download: async () => ({
+            ...downloaded,
+            reference: {
+              skillId: `priv_${'d'.repeat(40)}`,
+              version: version.reference.version,
+            },
+          }),
+        },
+      }),
+      (error: any) => error?.code === 'BOT_SKILL_RESTORE_REFERENCE_MISMATCH',
+    );
+    assert.equal(fs.existsSync(activeRoot), false);
+  });
+
+  test('rejects package paths that are unsafe on Windows even when restored elsewhere', async () => {
+    const version = await upload('alpha', 'local-a');
+    const client = new FileBotPrivateSkillPackageClient({ root: packageRoot, botId: 'bot-a' });
+    const downloaded = await client.download(version.reference);
+    const unsafe = {
+      ...downloaded,
+      files: [
+        ...downloaded.files,
+        {
+          path: 'CON.txt',
+          size: 1,
+          sha256: '0'.repeat(64),
+          bytes: Buffer.from('x'),
+        },
+      ],
+    };
+
+    await assert.rejects(
+      restoreBotSkillWorkspace({
+        skillsRoot: activeRoot,
+        owner: { botId: 'bot-a' },
+        references: [version.reference],
+        packageClient: { download: async () => unsafe },
+      }),
+      (error: any) => error?.code === 'BOT_SKILL_RESTORE_PATH_UNSAFE',
+    );
+  });
+});

--- a/tests/bot-skill-workspace.test.ts
+++ b/tests/bot-skill-workspace.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  BOT_LOCAL_SKILL_IDENTITY_FILE,
+  BOT_SKILL_WORKSPACE_IDENTITY_FILE,
+  BotSkillWorkspaceService,
+} from '../src/bot-skills/workspace';
+
+describe('Bot Skill workspace identity and inspection', () => {
+  let root: string;
+  let skillsRoot: string;
+  let nextId: number;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-bot-skill-workspace-'));
+    skillsRoot = path.join(root, 'skills');
+    nextId = 1;
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  function service(): BotSkillWorkspaceService {
+    return new BotSkillWorkspaceService({
+      runtimeRoot: root,
+      skillsRoot,
+      createId: () => `id-${nextId++}`,
+      now: () => new Date('2026-07-24T00:00:00.000Z'),
+    });
+  }
+
+  function writeSkill(directoryName: string, name = directoryName, extra = ''): string {
+    const directory = path.join(skillsRoot, directoryName);
+    fs.mkdirSync(directory, { recursive: true });
+    fs.writeFileSync(path.join(directory, 'SKILL.md'), [
+      '---',
+      `name: ${name}`,
+      `description: ${name} description`,
+      '---',
+      '',
+      `# ${name}`,
+      extra,
+      '',
+    ].join('\n'));
+    return directory;
+  }
+
+  test('distinguishes missing, unowned, and valid empty workspaces', () => {
+    const workspace = service();
+    assert.equal(workspace.inspect().kind, 'missing');
+
+    fs.mkdirSync(skillsRoot, { recursive: true });
+    assert.deepStrictEqual(workspace.inspect(), { kind: 'unowned', root: skillsRoot, skillCount: 0 });
+
+    const identity = workspace.claimExisting({ botId: 'bot-a', authority: 'cats.example/user-1' });
+    const inspected = workspace.inspect({ botId: 'bot-a', authority: 'cats.example/user-1' });
+    assert.equal(inspected.kind, 'valid');
+    if (inspected.kind === 'valid') {
+      assert.deepStrictEqual(inspected.skills, []);
+      assert.equal(inspected.identity.workspaceId, identity.workspaceId);
+    }
+  });
+
+  test('claims a legacy workspace and keeps localSkillId stable across rename and content changes', () => {
+    const oldDirectory = writeSkill('old-directory', 'renameable');
+    const workspace = service();
+    workspace.claimExisting({ botId: 'bot-a', authority: 'cats.example/user-1' });
+    const first = workspace.inspect({ botId: 'bot-a', authority: 'cats.example/user-1' });
+    assert.equal(first.kind, 'valid');
+    if (first.kind !== 'valid') return;
+    const originalId = first.skills[0].localSkillId;
+    const originalHash = first.skills[0].contentHash;
+
+    const newDirectory = path.join(skillsRoot, 'new-directory');
+    fs.renameSync(oldDirectory, newDirectory);
+    fs.appendFileSync(path.join(newDirectory, 'SKILL.md'), '\nchanged\n');
+    const second = workspace.inspect({ botId: 'bot-a', authority: 'cats.example/user-1' });
+
+    assert.equal(second.kind, 'valid');
+    if (second.kind === 'valid') {
+      assert.equal(second.skills[0].localSkillId, originalId);
+      assert.notEqual(second.skills[0].contentHash, originalHash);
+      assert.equal(second.skills[0].directoryName, 'new-directory');
+    }
+  });
+
+  test('assigns an identity to a manually added Skill without changing its content hash', () => {
+    const workspace = service();
+    workspace.initializeEmpty({ botId: 'bot-a' });
+    const directory = writeSkill('manual');
+    const before = fs.readFileSync(path.join(directory, 'SKILL.md'), 'utf8');
+
+    const inspected = workspace.inspect({ botId: 'bot-a' });
+
+    assert.equal(inspected.kind, 'valid');
+    assert.equal(fs.existsSync(path.join(directory, BOT_LOCAL_SKILL_IDENTITY_FILE)), true);
+    assert.equal(fs.readFileSync(path.join(directory, 'SKILL.md'), 'utf8'), before);
+    if (inspected.kind === 'valid') {
+      const hashAfterMarker = inspected.skills[0].contentHash;
+      fs.rmSync(path.join(directory, BOT_LOCAL_SKILL_IDENTITY_FILE));
+      workspace.inspect({ botId: 'bot-a' });
+      const rescanned = workspace.inspect({ botId: 'bot-a' });
+      assert.equal(rescanned.kind === 'valid' && rescanned.skills[0].contentHash, hashAfterMarker);
+    }
+  });
+
+  test('refuses an owner mismatch instead of relabeling the active directory', () => {
+    const workspace = service();
+    workspace.initializeEmpty({ botId: 'bot-a', authority: 'server-a/user-a' });
+
+    const inspected = workspace.inspect({ botId: 'bot-b', authority: 'server-a/user-a' });
+
+    assert.equal(inspected.kind, 'owner_mismatch');
+    const persisted = JSON.parse(
+      fs.readFileSync(path.join(skillsRoot, BOT_SKILL_WORKSPACE_IDENTITY_FILE), 'utf8'),
+    );
+    assert.equal(persisted.workspaceOwnerBotId, 'bot-a');
+  });
+
+  test('treats malformed identity and duplicate localSkillId as unreadable, never as empty', () => {
+    const workspace = service();
+    workspace.initializeEmpty({ botId: 'bot-a' });
+    fs.writeFileSync(path.join(skillsRoot, BOT_SKILL_WORKSPACE_IDENTITY_FILE), '{broken');
+    assert.equal(workspace.inspect({ botId: 'bot-a' }).kind, 'unreadable');
+
+    fs.rmSync(path.join(skillsRoot, BOT_SKILL_WORKSPACE_IDENTITY_FILE));
+    const first = writeSkill('first');
+    const second = writeSkill('second');
+    workspace.claimExisting({ botId: 'bot-a' });
+    fs.copyFileSync(
+      path.join(first, BOT_LOCAL_SKILL_IDENTITY_FILE),
+      path.join(second, BOT_LOCAL_SKILL_IDENTITY_FILE),
+    );
+    assert.equal(workspace.inspect({ botId: 'bot-a' }).kind, 'unreadable');
+  });
+});

--- a/tests/dashboard-catsco-auth-status.test.ts
+++ b/tests/dashboard-catsco-auth-status.test.ts
@@ -12,6 +12,7 @@ import { FileBotCatalogModelRuntimeRepository, FileBotDefinitionRepository } fro
 import { createBotDefinitionSyncService } from '../src/bot-definition/service';
 import { resolveActiveBotLLMConfig } from '../src/bot-definition/llm-config-resolver';
 import { BOT_CATALOG_MODEL_RUNTIME_SCHEMA, BOT_DEFINITION_SCHEMA } from '../src/bot-definition/types';
+import { BotSkillRuntime } from '../src/bot-skills/runtime';
 
 describe('dashboard CatsCo account status', () => {
   let testRoot: string;
@@ -61,6 +62,8 @@ describe('dashboard CatsCo account status', () => {
     'CATSCOMPANY_INSTALLATION_ID',
     'CATSCO_ALLOW_LOCAL_ENDPOINTS',
     'CATSCOMPANY_ALLOW_LOCAL_ENDPOINTS',
+    'XIAOBA_BOT_SKILL_SYNC_ENABLED',
+    'XIAOBA_BOT_SKILL_SYNC_TRANSPORT',
   ];
   const originalEnv: Record<string, string | undefined> = {};
 
@@ -1118,6 +1121,151 @@ describe('dashboard CatsCo account status', () => {
     assert.equal(data.data?.preflight?.blockingChecks.includes('runtime.command'), true);
     assert.equal(localConfig.load().currentBot?.uid, '188');
     assert.equal(restartCalled, 0);
+  });
+
+  test('POST /cats/switch-bot stops A, swaps complete workspaces, binds B, then starts B', async () => {
+    if (dashboardServer) {
+      await close(dashboardServer);
+      dashboardServer = undefined;
+    }
+    process.env.XIAOBA_BOT_SKILL_SYNC_ENABLED = '1';
+    process.env.XIAOBA_BOT_SKILL_SYNC_TRANSPORT = 'file';
+
+    const events: string[] = [];
+    const service = {
+      name: 'catscompany',
+      label: 'CatsCo agent',
+      command: process.execPath,
+      args: [],
+      status: 'running',
+    };
+    const dashboardApp = express();
+    dashboardApp.use(express.json());
+    dashboardApp.use('/api', createApiRouter({
+      getAll: () => [service],
+      getService: (name: string) => (name === 'catscompany' ? service : undefined),
+      stopAndWait: async () => {
+        events.push('stop-a');
+        service.status = 'stopped';
+        return service;
+      },
+      startAndWait: async () => {
+        events.push('start-b');
+        service.status = 'running';
+        return service;
+      },
+    } as any));
+    dashboardServer = await listen(dashboardApp);
+    dashboardBaseUrl = serverBaseUrl(dashboardServer);
+
+    await startCatsServer((req, res) => {
+      if (req.path === '/api/me') {
+        return res.json({ uid: 88, username: 'owner', display_name: 'Owner' });
+      }
+      if (req.path === '/api/bots' && req.method === 'GET') {
+        return res.json({
+          bots: [{ uid: 199, username: 'bot-b', display_name: 'Bot B', api_key: 'bot-b-key' }],
+        });
+      }
+      if (
+        req.path === '/api/friends/request'
+        || req.path === '/api/friends/accept'
+      ) {
+        return res.json({ ok: true });
+      }
+      return res.status(404).json({ error: 'not found' });
+    });
+
+    const localConfig = createCatsCoLocalConfigService({ runtimeRoot: testRoot });
+    localConfig.save({
+      version: 1,
+      endpoints: { httpBaseUrl: catsBaseUrl, serverUrl: 'wss://app.catsco.cc/v0/channels' },
+      account: { token: 'user-token', uid: '88', username: 'owner', displayName: 'Owner' },
+      currentBot: {
+        uid: '188',
+        name: 'Bot A',
+        apiKey: 'bot-a-key',
+        boundByUserUid: '88',
+        bindingSource: 'test',
+      },
+      device: { deviceId: 'device-1', bodyId: 'device-1', installationId: 'device-1' },
+    });
+    const definitions = new FileBotDefinitionRepository({ runtimeRoot: testRoot });
+    for (const botId of ['188', '199']) {
+      const definition = {
+        schema: BOT_DEFINITION_SCHEMA,
+        botId,
+        model: { kind: 'catalog' as const, modelId: 'minimax-m3' },
+      };
+      definitions.writeCanonical(definition);
+      definitions.writeCache(definition);
+      new FileBotCatalogModelRuntimeRepository({ runtimeRoot: testRoot }).write({
+        schema: BOT_CATALOG_MODEL_RUNTIME_SCHEMA,
+        botId,
+        modelId: 'minimax-m3',
+        provider: 'anthropic',
+        apiBase: 'https://relay.example.test/anthropic',
+        apiKey: `runtime-${botId}`,
+        model: 'MiniMax-M3',
+        contextWindowTokens: 200000,
+      });
+    }
+    const activeRoot = path.join(testRoot, 'skills');
+    const targetRoot = path.join(
+      testRoot,
+      'data',
+      'bot-skill-workspaces',
+      `bot_${Buffer.from('199').toString('base64url')}`,
+    );
+    const authority = new URL(catsBaseUrl).origin.toLowerCase();
+    const makeRuntime = (botId: string, apiKey: string, skillsRoot: string) => new BotSkillRuntime({
+      runtimeRoot: testRoot,
+      skillsRoot,
+      auth: {
+        httpBaseUrl: catsBaseUrl,
+        serverUrl: 'wss://app.catsco.cc/v0/channels',
+        botUid: botId,
+        apiKey,
+        uid: '88',
+      },
+      transport: 'file',
+    });
+    const botA = makeRuntime('188', 'bot-a-key', activeRoot);
+    const botB = makeRuntime('199', 'bot-b-key', targetRoot);
+    for (const [runtime, name] of [[botA, 'skill-a'], [botB, 'skill-b']] as const) {
+      runtime.workspace.initializeEmpty({
+        botId: runtime.owner.botId,
+        authority,
+        ownerUserId: '88',
+      });
+      const directory = path.join(runtime.workspace.root, name);
+      fs.mkdirSync(directory);
+      fs.writeFileSync(path.join(directory, 'SKILL.md'), [
+        '---', `name: ${name}`, `description: ${name}`, '---', '', `# ${name}`, '',
+      ].join('\n'));
+      const outcome = await runtime.sync({ definitionForCreate: definitions.readCache(runtime.owner.botId) });
+      assert.equal(outcome.result.action, 'created_cloud');
+    }
+
+    const response = await fetch(`${dashboardBaseUrl}/api/cats/switch-bot`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ botUid: '199' }),
+    });
+    const text = await response.text();
+
+    assert.equal(response.status, 200, text);
+    assert.deepStrictEqual(events, ['stop-a', 'start-b']);
+    assert.equal(localConfig.load().currentBot?.uid, '199');
+    assert.equal(fs.existsSync(path.join(activeRoot, 'skill-b', 'SKILL.md')), true);
+    const sourceParked = path.join(
+      testRoot,
+      'data',
+      'bot-skill-workspaces',
+      `bot_${Buffer.from('188').toString('base64url')}`,
+    );
+    assert.equal(fs.existsSync(path.join(sourceParked, 'skill-a', 'SKILL.md')), true);
+    assert.equal(fs.existsSync(targetRoot), false);
   });
 
   test('PUT /model/reasoning-effort accepts and normalizes a legacy catalog runtime alias', async () => {

--- a/tests/dashboard-service-manager.test.ts
+++ b/tests/dashboard-service-manager.test.ts
@@ -231,6 +231,44 @@ describe('dashboard service manager', () => {
     assert.equal(service?.status, 'stopped');
     assert.equal(service?.lastError, undefined);
   });
+
+  test('waits for the CatsCo ready marker and for the child to fully stop', async () => {
+    const manager = new ServiceManager(process.cwd());
+    const serviceRecord = (manager as any).services.get('catscompany');
+    serviceRecord.info.command = process.execPath;
+    serviceRecord.info.args = [
+      '-e',
+      "setTimeout(() => console.log('[CATSCO_READY]'), 25); setInterval(() => {}, 1000);",
+    ];
+
+    try {
+      const running = await manager.startAndWait('catscompany', 5_000);
+      assert.equal(running.status, 'running');
+      assert.ok(manager.getLogs('catscompany').some(line => line.includes('[CATSCO_READY]')));
+
+      const stopped = await manager.stopAndWait('catscompany', 5_000);
+      assert.equal(stopped.status, 'stopped');
+      assert.equal((manager as any).services.get('catscompany').process, undefined);
+    } finally {
+      if (manager.getService('catscompany')?.status === 'running') {
+        await manager.stopAndWait('catscompany', 5_000);
+      }
+    }
+  });
+
+  test('stops a connector that never becomes ready before returning the timeout', async () => {
+    const manager = new ServiceManager(process.cwd());
+    const serviceRecord = (manager as any).services.get('catscompany');
+    serviceRecord.info.command = process.execPath;
+    serviceRecord.info.args = ['-e', 'setInterval(() => {}, 1000);'];
+
+    await assert.rejects(
+      manager.startAndWait('catscompany', 100),
+      /Timed out waiting for service "catscompany" to become ready/,
+    );
+    assert.notEqual(manager.getService('catscompany')?.status, 'running');
+    assert.equal((manager as any).services.get('catscompany').process, undefined);
+  });
 });
 
 function normalize(value: string): string {

--- a/tests/dashboard-skills-api.test.ts
+++ b/tests/dashboard-skills-api.test.ts
@@ -185,6 +185,29 @@ describe('dashboard skills API', () => {
     assert.equal(applyProposal.status, 415);
   });
 
+  test('legacy prompt file writes remain read-only until a Bot Definition is available', async () => {
+    for (const promptPath of [
+      'system-prompt.md',
+      './system-prompt.md',
+      'foo/../system-prompt.md',
+      '.\\system-prompt.md',
+    ]) {
+      const writePrompt = await fetch(`${baseUrl}/api/prompts/file`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ path: promptPath, content: 'must not persist' }),
+      });
+      assert.equal(writePrompt.status, 409, promptPath);
+
+      const deletePrompt = await fetch(`${baseUrl}/api/prompts/file`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ path: promptPath }),
+      });
+      assert.equal(deletePrompt.status, 409, promptPath);
+    }
+  });
+
   function writeSkill(relativePath: string, name: string, description: string): void {
     const filePath = path.join(testRoot, relativePath);
     fs.mkdirSync(path.dirname(filePath), { recursive: true });


### PR DESCRIPTION
## 为什么要做

当前 XiaoBa 的 Skill 主要依赖设备本地目录。Bot 切换、离线修改、多设备恢复和云端版本变化之间没有统一的一致性模型，容易出现本地改动被覆盖、离线修改归属不明、上传/下载方向无法可靠判断等问题。

本 PR 落实 Local / Base / Cloud 三方模型：

- **Local**：当前 Bot 在本机的完整 Skill 工作区。
- **Base**：上一次成功提交或恢复后的本地基准，保存逐 Skill 的 Local/Cloud 映射。
- **Cloud**：CatsCo Bot Definition 中的不可变 Skill 引用。

核心原则是：本地未修改时接受云端；本地已修改时保护本地并尝试上传；无法安全判断时显式冲突或降级，不静默覆盖。

## 做了什么

### 1. 按 Bot 隔离本地工作区

- 使用 `workspaceOwnerBotId + workspaceId + switch journal` 确认工作区归属。
- 每个本地 Skill 保存稳定 `localSkillId`，目录改名不改变身份。
- Bot 切换使用 journal、staging、备份和恢复流程，中断后可以继续恢复。
- 本地工作区不存在时允许从云端恢复；工作区不可读或归属不符时停止同步并给出明确原因。

### 2. 实现 Local / Base / Cloud 判定

- `Local == Base && Cloud == Base`：不操作。
- `Local == Base && Cloud != Base`：从云端恢复。
- `Local != Base`：本地优先上传。
- Local 与 Cloud 同时变化时，第一阶段保持本地优先，并保留 Cloud 历史快照。
- Base 缺失或损坏时不自动猜测，提供明确的 `local-wins` / `cloud-wins` 修复入口。
- Base 只在 Definition 条件提交成功，或云端恢复完整激活后更新。

### 3. 接入真实 CatsCo 与 SkillHub

- CatsCo Bot Definition PUT/PATCH 只发送服务端负责的 `skills` 字段。
- 强制强 ETag；412 后重读并按同步规则重试或报告冲突。
- SkillHub 私有包上传/下载使用 Bot API Key 和实际 Bot 身份双重绑定。
- 未修改的公共 Skill 保持公共引用；本地修改后 fork 为私有不可变版本。
- 历史包不做物理覆盖，旧 Cloud 快照仍可精确下载。

### 4. 处理离线、启动与失败恢复

- XiaoBa 离线期间的修改继续归属于关机前工作区绑定的 Bot。
- 重启后根据工作区 owner、当前绑定 Bot、Base 和 Cloud 决定同步方向。
- 上传失败不阻止已有本地 Bot 使用，本地内容不会丢失。
- 下载恢复失败不会伪装成完整启动。
- 使用 pending commit、工作区锁和按 Bot 的 Definition 跨进程锁，防止崩溃或并发更新导致 Base、Prompt、Skills 错位。
- 默认 Skill 只在显式新 Bot 流程初始化一次。

### 5. CLI、Runtime 与 Dashboard 共用同一逻辑

- Bot 绑定、切换、启动前执行相应的一致性检查和恢复。
- 增加显式同步修复入口与确认流程。
- 保持现有 Model、System Prompt 和 SkillHub 订阅逻辑兼容。
- Model、Prompt、Skills 分字段更新；Skill 同步不会覆盖 Model/Prompt。

### 6. 收紧自动上传安全边界

- 敏感文件、凭据目录、私钥和常见 Token 格式阻止上传，但不影响本地 Skill 使用。
- 客户端和 SkillHub 采用同一套凭据赋值识别规则。
- 覆盖服务前缀、驼峰 JSON、AWS Secret、`SECRET_KEY`、短凭据、Makefile、方括号属性、函数参数、URL query、连续赋值和带空格引号值。
- 只允许严格环境变量引用、固定占位符、空值和有限的安全 Schema 值。
- 已知剩余 P2：复杂 JSON Schema / Zod 表达式可能被保守误拦；这是可用性问题，不会造成凭据泄漏。

### 7. 增加可重复执行方式明确的真实 E2E 脚本

- 新增 `npm run test:e2e:bot-skill-live`。
- 必须显式传入一次性 Bot 确认值，并且只接受 loopback HTTP staging 地址。
- 开始前要求 Cloud 为 missing 或历史 revision-zero 状态，避免误改已有正式 Bot。
- 测试会创建不可变 staging 包，因此只允许专用一次性测试 Bot。

## 审核与测试结果

### XiaoBa 本地

- `npm test`：1261 项；1256 通过、5 跳过、0 失败。
- `npm run build`：通过。
- `git diff --check`：通过。
- Linux CI 路径用例已修复；Windows 路径等价语义保持不变。

### CatsCo / SkillHub

- CatsCo `go test ./...`：通过。
- CatsCo `go vet ./...`：通过。
- SkillHub `npm test`：16 项；14 通过、2 项因本地未配置 PostgreSQL 测试库而跳过。
- 隔离 staging 实际使用独立 PostgreSQL、测试 CatsCo MySQL 和专用 Bot 完成真实 HTTP 联调。
- SkillHub staging 归档 SHA-256：`41CDE5D5AF16F434BE5AADCE4CF3E2583B799BDCDCBE8D7155B49B1D5A700B9B`。

### 真实三端端到端

一次性测试 Bot 共执行 14 个步骤，全部通过：

- 历史 Definition revision-zero 迁移；
- 首次本地 Skill 上传；
- 真实旧 ETag PATCH 返回 412，Cloud 保持不变；
- 离线修改后 XiaoBa 重启并上传；
- 本地工作区缺失时从 Cloud 恢复；
- 另一设备上传、原设备下载；
- Local / Cloud 同时变化时本地优先；
- 旧私有包仍可下载；
- `.env` 和普通文件内凭据都被阻止，另一设备没有收到敏感 Skill；
- SkillHub 上传故障时 Cloud 不前移且本地内容保留；
- 服务恢复后重试成功；
- 工作区身份损坏时停止同步，Cloud 不变。

### 独立复审

- 多角度语义、并发和安全复审最终结论：无 P0/P1。
- 保留的 P2：
  - 复杂 Schema 表达式可能被保守误拦；
  - SkillHub 慢请求和每 Bot 上传槽位可后续继续加固，不阻断本链路。

## 依赖与合并顺序

1. CatsCo 后端 PR：[buildsense-ai/cats-company#104](https://github.com/buildsense-ai/cats-company/pull/104)
2. SkillHub 正式版本需要在负责人明确确认后发布。
3. XiaoBa 应在 CatsCo 接口可用、SkillHub 正式版本发布完成后再合并或启用。

## 建议的后续顺序

1. 团队现在可以同时审核 CatsCo PR #104 和本 PR。
2. 由有权限的团队成员先合并 CatsCo PR #104。
3. 验证 CatsCo 目标环境后，经负责人明确确认再发布 SkillHub。
4. 最后由团队合并本 PR。

> 本 PR 不会由当前提交账号自行合并，也没有执行任何生产发布。
