### PR TITLE
统一 GPT-5.6 官方上下文规格

### DIFF
--- a/src/utils/relay-model-profiles.ts
+++ b/src/utils/relay-model-profiles.ts
@@ -95,7 +95,7 @@ export const RELAY_MODEL_PROFILES: RelayModelProfile[] = [
     quotaClass: 'gpt-5.6',
     preferredProvider: 'openai' as const,
     openaiApiMode: 'responses' as const,
-    contextWindowTokens: 1_000_000,
+    contextWindowTokens: 256_000,
     modelsDevProvider: 'openai',
     modelsDevModel: `gpt-5.6-${variant}`,
     capabilities: {

--- a/tests/bot-definition-activation.test.ts
+++ b/tests/bot-definition-activation.test.ts
@@ -229,6 +229,7 @@ describe('BotDefinition activation', () => {
     assert.equal(runtime?.provider, 'openai');
     assert.equal(runtime?.openaiApiMode, 'responses');
     assert.equal(runtime?.model, 'gpt-5.6-terra');
+    assert.equal(runtime?.contextWindowTokens, 256_000);
     assert.equal(runtime?.reasoningEffort, 'xhigh');
     assert.equal(runtime?.capabilities?.vision, true);
     assert.equal(runtime?.capabilitiesSource, 'relay-models');
@@ -373,15 +374,15 @@ describe('BotDefinition activation', () => {
           configured: true,
           desired: {
             kind: 'custom',
-            model_id: 'private-reasoner',
+            model_id: 'gpt-5.6-sol',
             reasoning_effort: 'high',
             revision: 9,
             custom: {
               protocol: 'openai-responses',
               api_base: 'https://models.example.test/v1/',
-              model: 'private-reasoner',
+              model: 'gpt-5.6-sol',
               api_key: 'sk-runtime-only-secret',
-              context_window_tokens: 256000,
+              context_window_tokens: 1000000,
               max_tokens: 8192,
               temperature: 0.4,
               reasoning_effort: 'high',
@@ -403,9 +404,9 @@ describe('BotDefinition activation', () => {
       kind: 'custom',
       protocol: 'openai-responses',
       apiBase: 'https://models.example.test/v1',
-      model: 'private-reasoner',
+      model: 'gpt-5.6-sol',
       apiKey: 'sk-runtime-only-secret',
-      contextWindowTokens: 256000,
+      contextWindowTokens: 1000000,
       maxTokens: 8192,
       temperature: 0.4,
       reasoningEffort: 'high',
@@ -417,7 +418,7 @@ describe('BotDefinition activation', () => {
     assert.deepStrictEqual(requests.find(item => item.path === '/api/bot/model-config/ack')?.body, {
       revision: 9,
       kind: 'custom',
-      model_id: 'private-reasoner',
+      model_id: 'gpt-5.6-sol',
       reasoning_effort: 'high',
     });
   });

--- a/tests/bot-definition-local-repository.test.ts
+++ b/tests/bot-definition-local-repository.test.ts
@@ -121,6 +121,35 @@ describe('BotDefinition local simulation', () => {
     assert.deepStrictEqual(repository.readCache('bot-alpha'), result?.definition);
   });
 
+  test('keeps an explicit 1M window for a local custom GPT-5.6 model', () => {
+    bindCurrentBot();
+    const env = {
+      CATSCO_MODEL_SOURCE: 'custom',
+      CATSCO_CUSTOM_LLM_PROVIDER: 'openai',
+      CATSCO_CUSTOM_LLM_API_BASE: 'https://relay.catsco.cc/v1',
+      CATSCO_CUSTOM_LLM_MODEL: 'gpt-5.6-sol',
+      CATSCO_CUSTOM_LLM_API_KEY: 'sk-custom-gpt56',
+      CATSCO_CUSTOM_LLM_CONTEXT_WINDOW_TOKENS: '1000000',
+      CATSCO_CUSTOM_LLM_OPENAI_API_MODE: 'responses',
+    } as NodeJS.ProcessEnv;
+
+    const result = createBotDefinitionSyncService({ runtimeRoot, simulatedCloudRoot, env })
+      .publishCurrentBoundBot();
+
+    assert.deepStrictEqual(result?.definition.model, {
+      kind: 'custom',
+      protocol: 'openai-responses',
+      apiBase: 'https://relay.catsco.cc/v1',
+      model: 'gpt-5.6-sol',
+      apiKey: 'sk-custom-gpt56',
+      contextWindowTokens: 1_000_000,
+    });
+    assert.equal(
+      resolveActiveBotLLMConfig({ runtimeRoot, env })?.config.contextWindowTokens,
+      1_000_000,
+    );
+  });
+
   test('pull uses canonical data over stale cache and does not overwrite canonical data', () => {
     const repository = new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot });
     const canonical: BotDefinition = {

--- a/tests/model-capabilities.test.ts
+++ b/tests/model-capabilities.test.ts
@@ -62,9 +62,9 @@ describe('model capabilities', () => {
         { model: 'MiniMax-M2.7', provider: 'anthropic', vision: false, context: 204_800 },
         { model: 'MiniMax-M3', provider: 'anthropic', vision: true, context: 1_000_000 },
         { model: 'deepseek-v4-flash', provider: 'anthropic', vision: false, context: 1_000_000 },
-        { model: 'gpt-5.6-terra', provider: 'openai', vision: true, context: 1_000_000 },
-        { model: 'gpt-5.6-sol', provider: 'openai', vision: true, context: 1_000_000 },
-        { model: 'gpt-5.6-luna', provider: 'openai', vision: true, context: 1_000_000 },
+        { model: 'gpt-5.6-terra', provider: 'openai', vision: true, context: 256_000 },
+        { model: 'gpt-5.6-sol', provider: 'openai', vision: true, context: 256_000 },
+        { model: 'gpt-5.6-luna', provider: 'openai', vision: true, context: 256_000 },
       ],
     );
     assert.strictEqual(findRelayModelProfile('minimax-m3')?.capabilities.vision, true);

--- a/tests/model-context-window.test.ts
+++ b/tests/model-context-window.test.ts
@@ -34,6 +34,12 @@ test('relay catalog models resolve to their official context windows', () => {
     model: 'deepseek-v4-flash',
     provider: 'anthropic',
   }, { CATSCO_MODEL_SOURCE: 'relay' } as NodeJS.ProcessEnv).contextWindowTokens, 1_000_000);
+
+  assert.equal(resolveModelContextWindow({
+    apiUrl: 'https://relay.catsco.cc/v1',
+    model: 'gpt-5.6-sol',
+    provider: 'openai',
+  }, { CATSCO_MODEL_SOURCE: 'relay' } as NodeJS.ProcessEnv).contextWindowTokens, 256_000);
 });
 
 test('custom models keep the safe default even if the model name resembles a known relay model', () => {
@@ -47,6 +53,20 @@ test('custom models keep the safe default even if the model name resembles a kno
   assert.equal(resolved.contextWindowTokens, CUSTOM_MODEL_DEFAULT_CONTEXT_WINDOW_TOKENS);
   assert.equal(resolved.summaryBudgetTokens, 50_000);
   assert.ok(resolved.promptBudgetTokens < CUSTOM_MODEL_DEFAULT_CONTEXT_WINDOW_TOKENS);
+});
+
+test('an explicit custom GPT-5.6 window is not clamped to the relay catalog window', () => {
+  const resolved = resolveModelContextWindow({
+    apiUrl: 'https://relay.catsco.cc/v1',
+    model: 'gpt-5.6-sol',
+    provider: 'openai',
+  }, {
+    CATSCO_MODEL_SOURCE: 'custom',
+    GAUZ_LLM_CONTEXT_WINDOW_TOKENS: '1000000',
+  } as NodeJS.ProcessEnv);
+
+  assert.equal(resolved.source, 'explicit');
+  assert.equal(resolved.contextWindowTokens, 1_000_000);
 });
 
 test('explicit context window override still keeps a safety reserve', () => {


### PR DESCRIPTION
待人工审核，未经授权不合并。\n\n将 CatsCo 官方目录中的 GPT-5.6 Terra/Sol/Luna 上下文统一为 256K，与云端模型列表一致。自定义模型逻辑保持不变：本地和云端自定义 GPT-5.6 均可显式选择 1M，且不会被目录规格截断。\n\n既有验证：npm test（1181 通过、4 跳过、0 失败）；npm run build；官方目录 256K、云端自定义 1M、本地自定义 1M 回归均通过。