### PR TITLE
Fix UTF-8 decoding across SSE chunks

### DIFF
--- a/src/providers/openai-provider.ts
+++ b/src/providers/openai-provider.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { createHash } from 'crypto';
+import { StringDecoder } from 'string_decoder';
 import { Message, ChatConfig, ChatResponse, ContentBlock } from '../types';
 import { ToolDefinition } from '../types/tool';
 import { AIProvider, AIRequestOptions, StreamCallbacks } from './provider';
@@ -235,6 +236,7 @@ export class OpenAIProvider implements AIProvider {
       let contentStripper = new OpenAIThinkingStripper();
       const toolCallsMap = new Map<number, { id: string; type: 'function'; function: { name: string; arguments: string } }>();
       let buffer = '';
+      const decoder = new StringDecoder('utf8');
       let streamUsage: ChatResponse['usage'] = undefined;
       let finishReason: string | undefined;
 
@@ -249,7 +251,7 @@ export class OpenAIProvider implements AIProvider {
       }
 
       stream.on('data', (chunk: Buffer) => {
-        buffer += chunk.toString();
+        buffer += decoder.write(chunk);
         const lines = buffer.split('\n');
         buffer = lines.pop() || '';
 
@@ -325,6 +327,7 @@ export class OpenAIProvider implements AIProvider {
 
       stream.on('end', () => {
         options?.signal?.removeEventListener('abort', onAbort);
+        buffer += decoder.end();
         const tail = contentStripper.flush();
         if (tail) {
           fullContent += tail;
@@ -629,6 +632,7 @@ export class OpenAIProvider implements AIProvider {
       const outputItems: any[] = [];
       let streamedVisibleText = '';
       let buffer = '';
+      const decoder = new StringDecoder('utf8');
       let finalResponse: any;
       let settled = false;
 
@@ -675,7 +679,7 @@ export class OpenAIProvider implements AIProvider {
       };
 
       stream.on('data', (chunk: Buffer) => {
-        buffer += chunk.toString();
+        buffer += decoder.write(chunk);
         const lines = buffer.split('\n');
         buffer = lines.pop() || '';
         for (const line of lines) {
@@ -693,6 +697,7 @@ export class OpenAIProvider implements AIProvider {
 
       stream.on('end', () => {
         options?.signal?.removeEventListener('abort', onAbort);
+        buffer += decoder.end();
         if (settled) return;
         const tail = contentStripper.flush();
         emitVisibleText(tail);

--- a/tests/openai-provider-responses.test.ts
+++ b/tests/openai-provider-responses.test.ts
@@ -404,8 +404,83 @@ describe('OpenAIProvider Responses API mode', () => {
       (axios as any).post = originalPost;
     }
   });
+
+  test('preserves Chinese text when a UTF-8 character crosses Responses SSE chunks', async () => {
+    const originalPost = axios.post;
+    (axios as any).post = async () => ({
+      data: Readable.from([
+        ...splitSseInsideUtf8({ type: 'response.output_text.delta', delta: '中文' }, '中'),
+        sse({
+          type: 'response.completed',
+          response: {
+            status: 'completed',
+            output: [{
+              type: 'message',
+              role: 'assistant',
+              content: [{ type: 'output_text', text: '中文' }],
+            }],
+          },
+        }),
+      ]),
+    });
+
+    try {
+      const chunks: string[] = [];
+      const result = await createProvider().chatStream(
+        [{ role: 'user', content: 'hello' }],
+        undefined,
+        { onText: value => chunks.push(value) },
+      );
+
+      assert.equal(chunks.join(''), '中文');
+      assert.equal(result.content, '中文');
+    } finally {
+      (axios as any).post = originalPost;
+    }
+  });
+
+  test('preserves Chinese text when a UTF-8 character crosses Chat Completions SSE chunks', async () => {
+    const originalPost = axios.post;
+    (axios as any).post = async () => ({
+      data: Readable.from([
+        ...splitSseInsideUtf8({
+          choices: [{ index: 0, delta: { content: '中文' }, finish_reason: null }],
+        }, '中'),
+        sse({ choices: [{ index: 0, delta: {}, finish_reason: 'stop' }] }),
+      ]),
+    });
+
+    const provider = new OpenAIProvider({
+      apiKey: 'test-key',
+      apiUrl: 'https://example.test/v1/chat/completions',
+      model: 'gpt-test',
+      openaiApiMode: 'chat_completions',
+    });
+
+    try {
+      const chunks: string[] = [];
+      const result = await provider.chatStream(
+        [{ role: 'user', content: 'hello' }],
+        undefined,
+        { onText: value => chunks.push(value) },
+      );
+
+      assert.equal(chunks.join(''), '中文');
+      assert.equal(result.content, '中文');
+    } finally {
+      (axios as any).post = originalPost;
+    }
+  });
 });
 
 function sse(payload: unknown): string {
   return `data: ${JSON.stringify(payload)}\n\n`;
+}
+
+function splitSseInsideUtf8(payload: unknown, character: string): Buffer[] {
+  const bytes = Buffer.from(sse(payload), 'utf8');
+  const characterBytes = Buffer.from(character, 'utf8');
+  const index = bytes.indexOf(characterBytes);
+  assert.notEqual(index, -1, `expected ${character} in SSE payload`);
+  return [bytes.subarray(0, index + 1), bytes.subarray(index + 1)];
 }


### PR DESCRIPTION
Use StringDecoder in both OpenAI SSE parsing paths so UTF-8 characters split across network chunks are preserved. Flush decoder state at stream end and add regression coverage for Responses and Chat Completions streaming.