### PR TITLE
修复 Dashboard 并发 401 清除新 API Key

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -5821,9 +5821,9 @@
       return promptForDashboardApiKey(message);
     }
     function withDashboardApiKey(input, init){
-      if(!isDashboardApiUrl(input))return { input, init };
+      if(!isDashboardApiUrl(input))return { input, init, dashboardApiKey:'' };
       const key = getDashboardStoredApiKey();
-      if(!key)return { input, init };
+      if(!key)return { input, init, dashboardApiKey:'' };
       const nextInit = Object.assign({}, init || {});
       const sourceHeaders = nextInit.headers || (typeof Request !== 'undefined' && input instanceof Request ? input.headers : {});
       const headers = new Headers(sourceHeaders || {});
@@ -5831,7 +5831,7 @@
         headers.set('X-API-Key', key);
       }
       nextInit.headers = headers;
-      return { input, init: nextInit };
+      return { input, init: nextInit, dashboardApiKey:key };
     }
     async function isDashboardAuthFailure(response){
       if(response.status !== 401 && response.status !== 403 && response.status !== 429)return false;
@@ -5862,8 +5862,10 @@
         if(response.status === 429){
           return response;
         }
-        setDashboardStoredApiKey('');
-        const key = await promptForDashboardApiKey('Dashboard API Key 无效或缺失，请重新输入');
+        if(getDashboardStoredApiKey() === request.dashboardApiKey){
+          setDashboardStoredApiKey('');
+        }
+        const key = await ensureDashboardApiKey('Dashboard API Key 无效或缺失，请重新输入');
         if(key){
           request = withDashboardApiKey(retryInput, init);
           response = await nativeFetch(request.input, request.init);

--- a/tests/dashboard-auth-client.test.ts
+++ b/tests/dashboard-auth-client.test.ts
@@ -1,0 +1,97 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as vm from 'node:vm';
+
+const dashboardHtml = readFileSync(join(process.cwd(), 'dashboard/index.html'), 'utf8');
+
+function extractDashboardAuthClient(): string {
+  const start = dashboardHtml.indexOf("const DASHBOARD_API_KEY_STORAGE_KEY = 'catsco.dashboardApiKey';");
+  const end = dashboardHtml.indexOf('    function formatDashboardApiError', start);
+  assert.ok(start >= 0, 'dashboard auth client start marker should exist');
+  assert.ok(end > start, 'dashboard auth client end marker should exist');
+  return dashboardHtml.slice(start, end);
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(next => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+function authFailure(): Response {
+  return new Response(JSON.stringify({ code: 'dashboard_auth_required' }), {
+    status: 401,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('dashboard auth client', () => {
+  test('a stale concurrent 401 does not clear a newly entered API key', async () => {
+    const storage = new Map<string, string>();
+    const initialResponses = [deferred<Response>(), deferred<Response>()];
+    const requests: Array<{ url: string; apiKey: string }> = [];
+    let initialRequestCount = 0;
+    let promptCount = 0;
+
+    const nativeFetch = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      const headers = new Headers(init?.headers ?? (input instanceof Request ? input.headers : undefined));
+      const apiKey = headers.get('X-API-Key') ?? '';
+      requests.push({ url, apiKey });
+      if (!apiKey && initialRequestCount < initialResponses.length) {
+        return initialResponses[initialRequestCount++].promise;
+      }
+      return new Response(JSON.stringify({ ok: apiKey === 'correct-key' }), {
+        status: apiKey === 'correct-key' ? 200 : 403,
+        headers: { 'content-type': 'application/json' },
+      });
+    };
+
+    const window = {
+      location: new URL('http://127.0.0.1:3800/'),
+      sessionStorage: {
+        getItem: (key: string) => storage.get(key) ?? null,
+        setItem: (key: string, value: string) => storage.set(key, value),
+        removeItem: (key: string) => storage.delete(key),
+      },
+      prompt: () => {
+        promptCount += 1;
+        return 'correct-key';
+      },
+      fetch: nativeFetch,
+    };
+
+    vm.runInNewContext(extractDashboardAuthClient(), {
+      window,
+      API: '',
+      URL,
+      Request,
+      Response,
+      Headers,
+      Promise,
+    });
+
+    const first = window.fetch('/api/first');
+    const stale = window.fetch('/api/stale');
+
+    initialResponses[0].resolve(authFailure());
+    assert.equal((await first).status, 200);
+    assert.equal(storage.get('catsco.dashboardApiKey'), 'correct-key');
+
+    initialResponses[1].resolve(authFailure());
+    assert.equal((await stale).status, 200);
+
+    assert.equal(promptCount, 1);
+    assert.equal(storage.get('catsco.dashboardApiKey'), 'correct-key');
+    assert.deepEqual(requests.map(request => request.apiKey), [
+      '',
+      '',
+      'correct-key',
+      'correct-key',
+    ]);
+  });
+});


### PR DESCRIPTION
## 问题

Dashboard 启用 API Key 认证后，首屏会并发请求多个受保护接口。用户在第一个 401 响应后输入正确 Key，较晚返回的旧 401 仍会无条件清空 `sessionStorage` 中刚保存的新 Key，导致重复弹出“API Key 无效或缺失”。

## 修复

- 在请求发出时记录该请求使用的 Dashboard API Key。
- 仅当当前存储的 Key 仍等于失败请求使用的旧 Key 时才清除。
- 如果其他并发请求已经写入新 Key，则直接复用新 Key 重试，不再重复弹窗。
- 新增浏览器侧并发回归测试，稳定编排两个错序返回的 401。

## 用户影响

启用 Dashboard API 认证时，首次输入正确 Key 后不会再被较晚的旧响应覆盖，也不会重复要求输入。

## 验证

- `npx tsx --test tests/dashboard-auth-client.test.ts tests/dashboard-auth.test.ts`：7 项通过
- `npx tsc --noEmit`：通过
- `npm test`：1184 项，1177 通过，7 跳过，0 失败
- `git diff --check`：通过
- Standards / Spec 双轴审查：均无代码发现
