### PR TITLE
chore(release): configure macOS signing and notarization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,9 @@ jobs:
         arch: [x64, arm64]
     env:
       XIAOBA_UPDATE_BASE_URL: https://github-release.tos-cn-guangzhou.volces.com/update/macos-${{ matrix.arch }}
+      APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+      APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -85,6 +88,50 @@ jobs:
             echo "npm ci failed on attempt $attempt, retrying in 15 seconds..."
             sleep 15
           done
+
+      - name: Prepare macOS signing and notarization credentials
+        shell: bash
+        env:
+          MAC_CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
+          MAC_CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
+          APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
+        run: |
+          set -euo pipefail
+          : "${MAC_CSC_LINK:?MAC_CSC_LINK is required}"
+          : "${MAC_CSC_KEY_PASSWORD:?MAC_CSC_KEY_PASSWORD is required}"
+          : "${APPLE_API_KEY_BASE64:?APPLE_API_KEY_BASE64 is required}"
+          : "${APPLE_API_KEY_ID:?APPLE_API_KEY_ID is required}"
+          : "${APPLE_API_ISSUER:?APPLE_API_ISSUER is required}"
+          : "${APPLE_TEAM_ID:?APPLE_TEAM_ID is required}"
+
+          KEYCHAIN_PATH="$RUNNER_TEMP/catsco-signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -hex 24)"
+          CERTIFICATE_PATH="$RUNNER_TEMP/catsco-signing.p12"
+          API_KEY_PATH="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY_ID}.p8"
+
+          python3 -c 'import base64, os, sys; open(sys.argv[1], "wb").write(base64.b64decode(os.environ["MAC_CSC_LINK"]))' "$CERTIFICATE_PATH"
+          python3 -c 'import base64, os, sys; open(sys.argv[1], "wb").write(base64.b64decode(os.environ["APPLE_API_KEY_BASE64"]))' "$API_KEY_PATH"
+          chmod 600 "$CERTIFICATE_PATH" "$API_KEY_PATH"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERTIFICATE_PATH" \
+            -P "$MAC_CSC_KEY_PASSWORD" \
+            -A \
+            -t cert \
+            -f pkcs12 \
+            -k "$KEYCHAIN_PATH"
+          security set-key-partition-list \
+            -S apple-tool:,apple:,codesign: \
+            -s \
+            -k "$KEYCHAIN_PASSWORD" \
+            "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH" login.keychain-db
+
+          echo "CSC_KEYCHAIN=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
+          echo "APPLE_API_KEY=$API_KEY_PATH" >> "$GITHUB_ENV"
+          security find-identity -v -p codesigning "$KEYCHAIN_PATH" | grep "Developer ID Application:"
 
       - name: Inject version into source
         run: node scripts/inject-version.js

--- a/build-resources/entitlements.mac.inherit.plist
+++ b/build-resources/entitlements.mac.inherit.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.inherit</key>
+  <true/>
+</dict>
+</plist>

--- a/build-resources/entitlements.mac.plist
+++ b/build-resources/entitlements.mac.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+</dict>
+</plist>

--- a/package.json
+++ b/package.json
@@ -156,7 +156,11 @@
         "zip"
       ],
       "icon": "build-resources/icons/icon.icns",
-      "artifactName": "${productName}-${version}-mac-${arch}.${ext}"
+      "artifactName": "${productName}-${version}-mac-${arch}.${ext}",
+      "hardenedRuntime": true,
+      "gatekeeperAssess": false,
+      "entitlements": "build-resources/entitlements.mac.plist",
+      "entitlementsInherit": "build-resources/entitlements.mac.inherit.plist"
     },
     "win": {
       "target": [

--- a/scripts/prune-electron-optional-native.mjs
+++ b/scripts/prune-electron-optional-native.mjs
@@ -3,6 +3,11 @@ import path from "node:path";
 
 const repoRoot = process.cwd();
 const optionalNativePackages = ["canvas", "path2d"];
+const obsoleteDeasyncBinaries = [
+  "darwin-x64-node-0.10",
+  "darwin-x64-node-0.11",
+  "darwin-x64-node-0.12",
+];
 
 for (const packageName of optionalNativePackages) {
   const packagePath = path.resolve(repoRoot, "node_modules", packageName);
@@ -18,4 +23,19 @@ for (const packageName of optionalNativePackages) {
 
   fs.rmSync(packagePath, { recursive: true, force: true });
   console.log(`Pruned optional native package for Electron build: ${packageName}`);
+}
+
+const deasyncBinRoot = path.resolve(repoRoot, "node_modules", "deasync", "bin");
+for (const binaryDirectory of obsoleteDeasyncBinaries) {
+  const binaryPath = path.resolve(deasyncBinRoot, binaryDirectory);
+  if (!binaryPath.startsWith(deasyncBinRoot + path.sep)) {
+    throw new Error(`Refusing to prune outside deasync/bin: ${binaryPath}`);
+  }
+
+  if (!fs.existsSync(binaryPath)) {
+    continue;
+  }
+
+  fs.rmSync(binaryPath, { recursive: true, force: true });
+  console.log(`Pruned obsolete deasync binary from Electron build: ${binaryDirectory}`);
 }


### PR DESCRIPTION
## Summary
- enable hardened runtime and Electron entitlements for macOS builds
- import Developer ID and App Store Connect API credentials in release CI
- prune obsolete deasync binaries that fail Apple notarization
- verify signed macOS update artifacts before upload

## Validation
- local arm64 app and DMG signed with Developer ID
- Apple notarization status: Accepted
- stapler validation: passed
- Gatekeeper assessment: accepted, Notarized Developer ID
- six credentials stored as release-prod environment secrets