### PR TITLE
fix: decode external agent output incrementally

### DIFF
--- a/src/runtime/external-agent/process-runner.ts
+++ b/src/runtime/external-agent/process-runner.ts
@@ -1,4 +1,5 @@
 import { ChildProcessWithoutNullStreams, spawn } from 'child_process';
+import { StringDecoder } from 'string_decoder';
 
 export interface ProcessRunOptions {
   id?: string;
@@ -42,6 +43,8 @@ export class ProcessRunner {
       });
       let stdout = '';
       let stderr = '';
+      const stdoutDecoder = new StringDecoder('utf8');
+      const stderrDecoder = new StringDecoder('utf8');
       let settled = false;
 
       this.active.set(id, child);
@@ -66,10 +69,10 @@ export class ProcessRunner {
       }
 
       child.stdout.on('data', chunk => {
-        stdout += chunk.toString();
+        stdout += stdoutDecoder.write(chunk);
       });
       child.stderr.on('data', chunk => {
-        stderr += chunk.toString();
+        stderr += stderrDecoder.write(chunk);
       });
 
       child.on('error', error => {
@@ -87,6 +90,8 @@ export class ProcessRunner {
         this.active.delete(id);
         if (timeout) clearTimeout(timeout);
         if (options.signal) options.signal.removeEventListener('abort', abort);
+        stdout += stdoutDecoder.end();
+        stderr += stderrDecoder.end();
         resolve({
           id,
           command: options.command,

--- a/tests/external-agent-process-runner.test.ts
+++ b/tests/external-agent-process-runner.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { ProcessRunner } from '../src/runtime/external-agent/process-runner';
+
+async function runChunkedOutput(stdout: string, stderr: string): Promise<{ stdout: string; stderr: string }> {
+  const script = [
+    'const pause=()=>new Promise(resolve=>setTimeout(resolve,1));',
+    'async function write(stream,text){for(const character of text){const bytes=Buffer.from(character);for(let i=0;i<bytes.length;i+=1){stream.write(bytes.subarray(i,i+1));await pause();}}}',
+    `(async()=>{await write(process.stdout,${JSON.stringify(stdout)});await write(process.stderr,${JSON.stringify(stderr)});})().catch(error=>{console.error(error);process.exitCode=1;});`,
+  ].join('');
+
+  return new ProcessRunner().run({
+    command: process.execPath,
+    args: ['-e', script],
+    cwd: process.cwd(),
+  });
+}
+
+describe('ProcessRunner UTF-8 stream decoding', () => {
+  test('preserves stdout and stderr split inside multi-byte characters', async () => {
+    const result = await runChunkedOutput('标准输出中文🙂', '标准错误中文🚫');
+
+    assert.equal(result.stdout, '标准输出中文🙂');
+    assert.equal(result.stderr, '标准错误中文🚫');
+    assert.equal(result.stdout.includes('\uFFFD'), false);
+    assert.equal(result.stderr.includes('\uFFFD'), false);
+  });
+
+  test('preserves normal ASCII and genuine replacement characters', async () => {
+    const result = await runChunkedOutput('stdout � ok', 'stderr � ok');
+
+    assert.equal(result.stdout, 'stdout � ok');
+    assert.equal(result.stderr, 'stderr � ok');
+  });
+});


### PR DESCRIPTION
Summary
- decode external coding-agent stdout and stderr with independent UTF-8 StringDecoder instances
- flush decoder tails before returning the completed process result
- add regression coverage for split Chinese and emoji bytes, ASCII, and genuine U+FFFD content

Why
PR #256 fixed the OpenAI SSE paths, but ProcessRunner still called chunk.toString() per stdout/stderr chunk. Multi-byte UTF-8 characters split across OS pipe chunks could therefore become replacement characters.

Validation
- pre-fix regression: 0/2 passed, both cases reproduced corruption
- focused ProcessRunner tests: 2/2 passed
- external-agent related tests: 10/10 passed
- npm run build: passed
- isolated npm test: 1180 passed, 0 failed, 7 skipped