### PR TITLE
fix: isolate test runtime data from production

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1,10 +1,13 @@
 #!/usr/bin/env node
 
+import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 import { glob } from 'glob';
+import { buildIsolatedTestEnvironment } from './test-environment.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, '..');
@@ -53,13 +56,28 @@ if (selectedTests.length === 0) {
 }
 
 const tsxCli = require.resolve('tsx/cli');
+const testSandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-test-runner-'));
+const testHome = path.join(testSandbox, 'home');
+const testTemp = path.join(testSandbox, 'tmp');
+const testDotenv = path.join(testSandbox, '.env');
+fs.mkdirSync(testHome, { recursive: true });
+fs.mkdirSync(testTemp, { recursive: true });
+fs.writeFileSync(testDotenv, '', 'utf8');
+
 const child = spawn(process.execPath, [tsxCli, '--test', ...selectedTests], {
   cwd: rootDir,
+  env: buildIsolatedTestEnvironment(process.env, {
+    homeDir: testHome,
+    tempDir: testTemp,
+    appRoot: rootDir,
+    dotenvPath: testDotenv,
+  }),
   stdio: 'inherit',
   shell: false,
 });
 
 child.on('exit', (code, signal) => {
+  cleanupTestSandbox();
   if (signal) {
     console.error(`[test] terminated by ${signal}`);
     process.exit(1);
@@ -68,9 +86,14 @@ child.on('exit', (code, signal) => {
 });
 
 child.on('error', error => {
+  cleanupTestSandbox();
   console.error(`[test] failed to start: ${error.message}`);
   process.exit(1);
 });
+
+function cleanupTestSandbox() {
+  fs.rmSync(testSandbox, { recursive: true, force: true });
+}
 
 function normalizeTestPath(file) {
   return file.replace(/\\/g, '/');

--- a/scripts/test-environment.mjs
+++ b/scripts/test-environment.mjs
@@ -1,0 +1,44 @@
+export const RUNTIME_WRITE_PATH_ENV_KEYS = Object.freeze([
+  'XIAOBA_USER_DATA_DIR',
+  'CATSCO_USER_DATA_DIR',
+  'XIAOBA_ELECTRON_USER_DATA_DIR',
+  'XIAOBA_RUNTIME_ROOT',
+  'CATSCO_LOCAL_CONFIG_PATH',
+  'CATSCO_CONFIG_PATH',
+  'XIAOBA_CONFIG_PATH',
+  'XIAOBA_SKILLS_DIR',
+  'XIAOBA_BOT_DEFINITION_SIMULATED_CLOUD_DIR',
+  'XIAOBA_TOOL_RESULT_ARTIFACT_DIR',
+  'XIAOBA_PET_DATA_DIR',
+  'XIAOBA_PROMPT_OVERRIDES_DIR',
+  'CATSCO_PROMPT_OVERRIDES_DIR',
+  'XIAOBA_PROMPT_TRACE_DIR',
+]);
+
+export function buildIsolatedTestEnvironment(
+  source = process.env,
+  options = {},
+) {
+  const env = { ...source };
+  for (const key of RUNTIME_WRITE_PATH_ENV_KEYS) delete env[key];
+
+  const homeDir = String(options.homeDir || '').trim();
+  const tempDir = String(options.tempDir || '').trim();
+  const appRoot = String(options.appRoot || '').trim();
+  const dotenvPath = String(options.dotenvPath || '').trim();
+  if (homeDir) {
+    env.HOME = homeDir;
+    env.USERPROFILE = homeDir;
+  }
+  if (tempDir) {
+    env.TMPDIR = tempDir;
+    env.TMP = tempDir;
+    env.TEMP = tempDir;
+  }
+  if (appRoot) env.XIAOBA_APP_ROOT = appRoot;
+  if (dotenvPath) env.DOTENV_CONFIG_PATH = dotenvPath;
+  else delete env.DOTENV_CONFIG_PATH;
+  env.NODE_ENV = 'test';
+  env.XIAOBA_TEST_RUNNER = '1';
+  return env;
+}

--- a/src/utils/path-resolver.ts
+++ b/src/utils/path-resolver.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 import * as fs from 'fs';
+import * as os from 'os';
 
 export class PathResolver {
   static getRuntimeDataRoot(
@@ -16,6 +17,17 @@ export class PathResolver {
     ]
       .map(value => String(value || '').trim())
       .find(Boolean);
+
+    if (
+      explicit
+      && env.NODE_TEST_CONTEXT
+      && env.XIAOBA_ALLOW_NON_TEMP_TEST_RUNTIME_ROOT !== '1'
+      && !isPathInside(path.resolve(explicit), path.resolve(os.tmpdir()))
+    ) {
+      throw new Error(
+        `Refusing Node test runtime data root outside the OS temporary directory: ${path.resolve(explicit)}`,
+      );
+    }
 
     return path.resolve(explicit || cwd);
   }
@@ -74,4 +86,9 @@ export class PathResolver {
 
     return results;
   }
+}
+
+function isPathInside(candidate: string, parent: string): boolean {
+  const relative = path.relative(parent, candidate);
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
 }

--- a/tests/catscompany-device-rpc-tools.test.ts
+++ b/tests/catscompany-device-rpc-tools.test.ts
@@ -1,6 +1,7 @@
-import { describe, test } from 'node:test';
+import { after, before, describe, test } from 'node:test';
 import * as assert from 'node:assert';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { CatsCompanyBot } from '../src/catscompany';
 import type { CatsDeviceRpcMessage, CatsThinToolRpcMessage } from '../src/catscompany/client';
@@ -86,6 +87,17 @@ function serverGrant(overrides: Partial<ScopedDeviceGrant> = {}): ScopedDeviceGr
 }
 
 describe('CatsCompany Device RPC file tools', () => {
+  let testRoot: string;
+
+  before(() => {
+    testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-device-rpc-tools-'));
+    fs.mkdirSync(path.join(testRoot, 'tmp'), { recursive: true });
+  });
+
+  after(() => {
+    if (testRoot) fs.rmSync(testRoot, { recursive: true, force: true });
+  });
+
   test('materializes trusted remote upload metadata without publishing a chat attachment', async () => {
     let downloaded: any;
     const bot = Object.create(CatsCompanyBot.prototype) as any;
@@ -257,7 +269,7 @@ describe('CatsCompany Device RPC file tools', () => {
   test('executes read_file on the target local device and returns a normalized result', async () => {
     const captured: { result?: any } = {};
     const bot = botWithDevice(captured);
-    const tmpRoot = path.join(process.cwd(), 'tmp');
+    const tmpRoot = path.join(testRoot, 'tmp');
     fs.mkdirSync(tmpRoot, { recursive: true });
     const dir = fs.mkdtempSync(path.join(tmpRoot, 'device-rpc-read-'));
     const filePath = path.join(dir, 'notes.txt');
@@ -277,7 +289,7 @@ describe('CatsCompany Device RPC file tools', () => {
   test('uploads the original file bytes for a thin import_file request', async () => {
     const captured: { uploaded?: { path: string; type: string; bytes: Buffer } } = {};
     const bot = botWithDevice(captured);
-    const tmpRoot = path.join(process.cwd(), 'tmp');
+    const tmpRoot = path.join(testRoot, 'tmp');
     fs.mkdirSync(tmpRoot, { recursive: true });
     const dir = fs.mkdtempSync(path.join(tmpRoot, 'thin-rpc-import-file-'));
     const filePath = path.join(dir, 'original.bin');
@@ -310,7 +322,7 @@ describe('CatsCompany Device RPC file tools', () => {
   test('accepts import_file through authorized Device RPC and returns upload metadata', async () => {
     const captured: { result?: any; uploaded?: { path: string; type: string; bytes: Buffer } } = {};
     const bot = botWithDevice(captured);
-    const tmpRoot = path.join(process.cwd(), 'tmp');
+    const tmpRoot = path.join(testRoot, 'tmp');
     fs.mkdirSync(tmpRoot, { recursive: true });
     const dir = fs.mkdtempSync(path.join(tmpRoot, 'device-rpc-import-file-'));
     const filePath = path.join(dir, 'report.txt');
@@ -338,7 +350,7 @@ describe('CatsCompany Device RPC file tools', () => {
   test('executes write_file on the target local device when RPC scope is valid', async () => {
     const captured: { result?: any } = {};
     const bot = botWithDevice(captured);
-    const tmpRoot = path.join(process.cwd(), 'tmp');
+    const tmpRoot = path.join(testRoot, 'tmp');
     fs.mkdirSync(tmpRoot, { recursive: true });
     const dir = fs.mkdtempSync(path.join(tmpRoot, 'device-rpc-write-'));
     const filePath = path.join(dir, 'created.txt');
@@ -359,7 +371,7 @@ describe('CatsCompany Device RPC file tools', () => {
   test('executes edit_file on the target local device when RPC scope is valid', async () => {
     const captured: { result?: any } = {};
     const bot = botWithDevice(captured);
-    const tmpRoot = path.join(process.cwd(), 'tmp');
+    const tmpRoot = path.join(testRoot, 'tmp');
     fs.mkdirSync(tmpRoot, { recursive: true });
     const dir = fs.mkdtempSync(path.join(tmpRoot, 'device-rpc-edit-'));
     const filePath = path.join(dir, 'edit.txt');
@@ -381,25 +393,26 @@ describe('CatsCompany Device RPC file tools', () => {
   test('executes Device RPC requests even when owner identity is omitted', async () => {
     const captured: { result?: any } = {};
     const bot = botWithDevice(captured);
+    const filePath = path.join(testRoot, 'tmp', 'missing-owner.txt');
 
     await bot.handleDeviceRpcRequest(request({
       request_id: 'rpc-missing-owner-1',
       owner_user_id: '',
       operation: 'write_file',
       tool_name: 'write_file',
-      payload: { args: { file_path: path.join(process.cwd(), 'tmp', 'missing-owner.txt'), content: 'nope' } },
+      payload: { args: { file_path: filePath, content: 'nope' } },
     }));
 
     assert.ok(captured.result);
     assert.equal(captured.result.error, undefined);
     assert.equal(captured.result.result.ok, true);
-    assert.equal(fs.readFileSync(path.join(process.cwd(), 'tmp', 'missing-owner.txt'), 'utf8'), 'nope');
+    assert.equal(fs.readFileSync(filePath, 'utf8'), 'nope');
   });
 
   test('executes Device RPC requests without owner mismatch checks after target delivery', async () => {
     const captured: { result?: any } = {};
     const bot = botWithDevice(captured);
-    const filePath = path.join(process.cwd(), 'tmp', 'wrong-owner.txt');
+    const filePath = path.join(testRoot, 'tmp', 'wrong-owner.txt');
 
     await bot.handleDeviceRpcRequest(request({
       request_id: 'rpc-wrong-owner-1',
@@ -419,6 +432,7 @@ describe('CatsCompany Device RPC file tools', () => {
   test('executes delegated Device RPC requests without channel identity permission checks after target delivery', async () => {
     const captured: { result?: any } = {};
     const bot = botWithDevice(captured);
+    const filePath = path.join(testRoot, 'tmp', 'bad-delegated.txt');
 
     await bot.handleDeviceRpcRequest(request({
       request_id: 'rpc-bad-delegation-1',
@@ -427,13 +441,13 @@ describe('CatsCompany Device RPC file tools', () => {
       identity_source: 'metadata.catsco_identity',
       operation: 'write_file',
       tool_name: 'write_file',
-      payload: { args: { file_path: path.join(process.cwd(), 'tmp', 'bad-delegated.txt'), content: 'nope' } },
+      payload: { args: { file_path: filePath, content: 'nope' } },
     }));
 
     assert.ok(captured.result);
     assert.equal(captured.result.error, undefined);
     assert.equal(captured.result.result.ok, true);
-    assert.equal(fs.readFileSync(path.join(process.cwd(), 'tmp', 'bad-delegated.txt'), 'utf8'), 'nope');
+    assert.equal(fs.readFileSync(filePath, 'utf8'), 'nope');
   });
 
   test('executes shell Device RPC operations on the selected local device', async () => {

--- a/tests/path-resolver-boundaries.test.ts
+++ b/tests/path-resolver-boundaries.test.ts
@@ -35,4 +35,27 @@ describe('PathResolver runtime data boundary', () => {
 
     assert.equal(PathResolver.getRuntimeDataRoot(env, testRoot), legacyDataRoot);
   });
+
+  test('Node tests refuse an explicit runtime root outside the OS temp directory', () => {
+    const unsafeRoot = path.resolve(path.parse(testRoot).root, 'srv', 'catsco-agent');
+    const env = {
+      NODE_TEST_CONTEXT: 'child-v8',
+      XIAOBA_USER_DATA_DIR: unsafeRoot,
+    } as NodeJS.ProcessEnv;
+
+    assert.throws(
+      () => PathResolver.getRuntimeDataRoot(env, testRoot),
+      /Refusing Node test runtime data root outside the OS temporary directory/,
+    );
+  });
+
+  test('Node tests may use an explicit runtime root inside the OS temp directory', () => {
+    const safeRoot = path.join(testRoot, 'isolated-runtime');
+    const env = {
+      NODE_TEST_CONTEXT: 'child-v8',
+      XIAOBA_USER_DATA_DIR: safeRoot,
+    } as NodeJS.ProcessEnv;
+
+    assert.equal(PathResolver.getRuntimeDataRoot(env, testRoot), path.resolve(safeRoot));
+  });
 });

--- a/tests/subagent-runtime-events.test.ts
+++ b/tests/subagent-runtime-events.test.ts
@@ -1703,6 +1703,7 @@ describe('subagent runtime events', () => {
   test('subagent runner uses maxTurns only when the main agent specifies it', async () => {
     const observedMaxTurns: Array<number | undefined> = [];
     const originalRun = ConversationRunner.prototype.run;
+    const workingDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-subagent-max-turns-'));
     (ConversationRunner.prototype as any).run = async function runMock() {
       observedMaxTurns.push((this as any).maxTurns);
       return {
@@ -1718,7 +1719,7 @@ describe('subagent runtime events', () => {
         agentType: 'explorer',
         taskDescription: 'bounded',
         userMessage: 'bounded',
-        workingDirectory: process.cwd(),
+        workingDirectory,
         maxTurns: 7,
       });
       await bounded.run();
@@ -1727,19 +1728,21 @@ describe('subagent runtime events', () => {
         agentType: 'explorer',
         taskDescription: 'unbounded',
         userMessage: 'unbounded',
-        workingDirectory: process.cwd(),
+        workingDirectory,
       });
       await unbounded.run();
 
       assert.deepEqual(observedMaxTurns, [7, undefined]);
     } finally {
       ConversationRunner.prototype.run = originalRun;
+      fs.rmSync(workingDirectory, { recursive: true, force: true });
     }
   });
 
   test('subagent runner inherits delegated tool authorization context', async () => {
     let observedContext: any;
     const originalRun = ConversationRunner.prototype.run;
+    const workingDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-subagent-delegated-'));
     (ConversationRunner.prototype as any).run = async function runMock() {
       observedContext = (this as any).toolExecutionContext;
       return {
@@ -1772,7 +1775,7 @@ describe('subagent runtime events', () => {
       const session = new SubAgentSession('sub-delegated-context', {} as any, {} as any, {
         taskDescription: 'delegated context',
         userMessage: 'delegated context',
-        workingDirectory: process.cwd(),
+        workingDirectory,
         delegatedToolContext: {
           surface: 'catscompany',
           executionScope: executionScope as any,
@@ -1793,6 +1796,7 @@ describe('subagent runtime events', () => {
       assert.equal(typeof observedContext.requestParentInput, 'function');
     } finally {
       ConversationRunner.prototype.run = originalRun;
+      fs.rmSync(workingDirectory, { recursive: true, force: true });
     }
   });
 

--- a/tests/test-environment.test.ts
+++ b/tests/test-environment.test.ts
@@ -1,0 +1,42 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import {
+  buildIsolatedTestEnvironment,
+  RUNTIME_WRITE_PATH_ENV_KEYS,
+} from '../scripts/test-environment.mjs';
+
+describe('test runner environment isolation', () => {
+  test('removes every external runtime write path without mutating the source', () => {
+    const source: Record<string, string> = {
+      PATH: '/usr/bin',
+      KEEP_ME: 'yes',
+      DOTENV_CONFIG_PATH: '/production/.env',
+    };
+    for (const key of RUNTIME_WRITE_PATH_ENV_KEYS) {
+      source[key] = `/production/${key.toLowerCase()}`;
+    }
+
+    const isolated = buildIsolatedTestEnvironment(source, {
+      homeDir: '/tmp/xiaoba-test-home',
+      tempDir: '/tmp/xiaoba-test-tmp',
+      appRoot: '/workspace/xiaoba',
+      dotenvPath: '/tmp/xiaoba-test-runner/.env',
+    });
+
+    for (const key of RUNTIME_WRITE_PATH_ENV_KEYS) {
+      assert.equal(isolated[key], undefined, key);
+      assert.ok(source[key], `source ${key} should remain unchanged`);
+    }
+    assert.equal(isolated.KEEP_ME, 'yes');
+    assert.equal(isolated.HOME, '/tmp/xiaoba-test-home');
+    assert.equal(isolated.USERPROFILE, '/tmp/xiaoba-test-home');
+    assert.equal(isolated.TMPDIR, '/tmp/xiaoba-test-tmp');
+    assert.equal(isolated.TMP, '/tmp/xiaoba-test-tmp');
+    assert.equal(isolated.TEMP, '/tmp/xiaoba-test-tmp');
+    assert.equal(isolated.XIAOBA_APP_ROOT, '/workspace/xiaoba');
+    assert.equal(isolated.DOTENV_CONFIG_PATH, '/tmp/xiaoba-test-runner/.env');
+    assert.equal(source.DOTENV_CONFIG_PATH, '/production/.env');
+    assert.equal(isolated.NODE_ENV, 'test');
+    assert.equal(isolated.XIAOBA_TEST_RUNNER, '1');
+  });
+});


### PR DESCRIPTION
## 背景

生产环境中的云端 Agent 曾在自身代码检出目录内执行 `npm test`。测试子进程继承了服务进程的运行目录环境变量（例如 `XIAOBA_USER_DATA_DIR`），导致测试夹具生成的账号、Bot Definition、会话及 `.env` 数据被写入真实运行目录。

这不是外部入侵，而是测试进程和生产运行态没有隔离。测试自身虽然会 `chdir` 到临时目录，但 `PathResolver` 优先采用显式环境变量，因此临时工作目录无法阻止写入生产路径。

## 安全复现

请只使用仓库内的哨兵目录，不要指向真实运行目录：

```bash
XIAOBA_USER_DATA_DIR="$PWD/.test-runtime-leak-sentinel" \
  node --import tsx --test tests/dashboard-catsco-auth-status.test.ts
```

修复前，测试会在哨兵目录生成 `.env`、`.xiaoba/catsco.json` 等运行态文件。生产事故中同一机制将测试夹具写入了 Agent 的真实数据目录。

## 根因

1. `scripts/run-tests.mjs` 启动 Node 测试子进程时完整继承父进程环境。
2. `ConfigManager` 可能从当前代码目录的生产 `.env` 再次载入运行配置。
3. `PathResolver.getRuntimeDataRoot()` 无测试边界，显式运行目录会覆盖测试临时工作目录。
4. 少数测试仍将临时文件写到 `process.cwd()/tmp`，全量测试会在仓库留下残余。

## 改动

- 为测试运行器创建独立沙箱：独立 HOME、临时目录及空 `.env`，清除运行态写入路径变量，退出后同步清理。
- 在 `PathResolver` 增加第二层保护：Node test context 下，显式 runtime root 必须位于 OS 临时目录内；正常 CLI、Dashboard 和打包版不受影响。
- 将 Device RPC 与 subagent 测试残余迁移到 OS 临时目录，并在用例结束后清理。
- 增加测试环境清洗和路径边界回归测试。

## 用户与运维影响

合并部署后，生产 Agent 即使从带有运行态环境变量的服务上下文执行普通 `npm test`，测试配置和文件也不会写回真实 Agent 数据目录。

该 PR 不负责清理事故前已经产生的生产残余数据；清理应继续通过运维审计单独执行。

## 验证

在最新 `upstream/main` 上完成：

- `npm test`：1190 tests，1186 passed，4 skipped，0 failed
- `npm run build`：通过
- 将所有已知 runtime path 变量故意指向仓库哨兵目录后执行全量测试：
  - 哨兵目录未创建
  - 仓库 `tmp/` 未创建
  - 测试 runner 沙箱残余为 0
- `git diff --check`：通过