### PR TITLE
[Draft] 接入 BotDefinition Local/Base/Cloud 同步链路

### DIFF
--- a/src/bot-definition/activation.ts
+++ b/src/bot-definition/activation.ts
@@ -18,6 +18,12 @@ import {
   redactCloudBotModelError,
   type CloudBotModelSelection,
 } from './cloud-client';
+import {
+  BotDefinitionRevisionConflictError,
+  pullCloudBotDefinition,
+  redactBotDefinitionError,
+} from './definition-client';
+import type { CloudBotDefinitionSnapshot } from './types';
 
 export interface PrepareBoundBotDefinitionOptions extends BotDefinitionSyncServiceOptions {
   runtimeRoot: string;
@@ -27,6 +33,7 @@ export interface PrepareBoundBotDefinitionOptions extends BotDefinitionSyncServi
   fetchImpl?: typeof fetch;
   cloudSelection?: CloudBotModelSelection;
   acknowledgeCloudSelection?: boolean;
+  stageCloudDefinition?: boolean;
 }
 
 export interface PreparedBoundBotDefinition {
@@ -36,6 +43,11 @@ export interface PreparedBoundBotDefinition {
   initializedDefault: boolean;
   materializedCatalogRuntime: boolean;
   cloudRevision?: number;
+  cloudDefinitionSnapshot?: CloudBotDefinitionSnapshot;
+  cloudDefinitionApplyError?: string;
+  cloudDefinitionHasPendingLocal?: boolean;
+  cloudDefinitionManaged?: boolean;
+  stagedCatalogRuntime?: BotCatalogModelRuntime;
   cloudSelection?: CloudBotModelSelection;
   cloudApplyError?: string;
 }
@@ -62,15 +74,121 @@ export async function prepareBoundBotDefinition(
   const previousCloudRuntime = definitionService.readCloudCatalogRuntime(botId);
   let definition = previousCloudDefinition ?? localDefinition;
   const auth = options.auth ?? createCatsCoLocalConfigService({ runtimeRoot: options.runtimeRoot }).getAuthState();
+  let cloudDefinitionSnapshot: CloudBotDefinitionSnapshot | undefined;
+  let fullDefinitionActive = false;
+  let usingPendingDefinition = false;
   let initializedDefault = false;
   let materializedCatalogRuntime = false;
+  let stagedCatalogRuntime: BotCatalogModelRuntime | undefined;
   let cloudSelection = options.cloudSelection;
   let cloudApplyError: string | undefined;
   let cloudSelectionApplied = false;
   let selectedCatalogRuntimeApplied = false;
   const shouldAcknowledgeCloudSelection = options.acknowledgeCloudSelection !== false;
 
-  if (!cloudSelection) {
+  try {
+    await definitionService.retryPendingCloudAck(botId, auth, options.fetchImpl);
+  } catch (error) {
+    Logger.warning(`CatsCo BotDefinition ACK 暂时无法重试，继续使用本地配置: ${errorMessage(error)}`);
+  }
+
+  const cloudState = definitionService.readCloudState(botId);
+  const previousAppliedSnapshot = cloudState.appliedSnapshot;
+  const previousLocalDefinition = localDefinition;
+  if (cloudState.definitionProtocolSeen || cloudState.snapshot || cloudState.appliedSnapshot) {
+    fullDefinitionActive = true;
+  }
+  if (previousAppliedSnapshot) {
+    const effective = cloudState.pendingPatch
+      ? definitionService.applyPendingChanges(
+        previousAppliedSnapshot.definition,
+        cloudState.pendingPatch.changes,
+      )
+      : previousAppliedSnapshot.definition;
+    if (cloudState.pendingPatch) {
+      definitionService.restoreLocalDefinitionCache(effective);
+      usingPendingDefinition = true;
+    } else {
+      definitionService.promoteCloudDefinition(previousAppliedSnapshot);
+    }
+    cloudDefinitionSnapshot = previousAppliedSnapshot;
+    definition = effective;
+    localDefinition = definition;
+    fullDefinitionActive = true;
+  }
+  if (cloudState.pendingPatch?.status === 'conflicted') {
+    Logger.warning(
+      `CatsCo BotDefinition 本地修改与云端 revision=${cloudState.pendingPatch.conflictRevision ?? 'unknown'} 冲突，`
+      + '已保留本地修改并停止自动覆盖。',
+    );
+  } else {
+    try {
+      if (cloudState.pendingPatch) {
+        cloudDefinitionSnapshot = await definitionService.flushPendingCloudPatch(
+          botId,
+          auth,
+          options.fetchImpl,
+        );
+      } else {
+        const remote = await pullCloudBotDefinition({ botId, auth, fetchImpl: options.fetchImpl });
+        if (remote.kind === 'found') {
+          cloudDefinitionSnapshot = remote.snapshot;
+          definitionService.acceptCloudDefinition(remote.snapshot);
+        } else if (remote.kind === 'migration_required') {
+          definitionService.markCloudDefinitionProtocolSeen(botId);
+          fullDefinitionActive = true;
+          if (remote.legacyModel) {
+            if (localDefinition) {
+              localDefinition = definitionService.updateModel(botId, remote.legacyModel).definition;
+            } else {
+              localDefinition = definitionService.publish(botId, remote.legacyModel).definition;
+            }
+          }
+          if (!localDefinition) {
+            localDefinition = definitionService.publish(botId, {
+              kind: 'catalog',
+              modelId: DEFAULT_CATSCO_RELAY_MODEL_ID,
+            }).definition;
+            initializedDefault = true;
+          }
+          if (!localDefinition.prompt) {
+            localDefinition = definitionService.updatePrompt(botId, { selected: 'default' }).definition;
+          }
+          definitionService.updateModel(botId, localDefinition.model);
+          definitionService.updatePrompt(botId, localDefinition.prompt!);
+          cloudDefinitionSnapshot = await definitionService.flushPendingCloudPatch(
+            botId,
+            auth,
+            options.fetchImpl,
+          );
+        }
+      }
+      if (cloudDefinitionSnapshot) {
+        fullDefinitionActive = true;
+        const latestPending = definitionService.readCloudState(botId).pendingPatch;
+        definition = latestPending
+          ? definitionService.applyPendingChanges(cloudDefinitionSnapshot.definition, latestPending.changes)
+          : cloudDefinitionSnapshot.definition;
+        usingPendingDefinition = Boolean(latestPending);
+        localDefinition = definition;
+      }
+    } catch (error) {
+      if (error instanceof BotDefinitionRevisionConflictError) {
+        fullDefinitionActive = true;
+        Logger.warning(
+          `CatsCo BotDefinition revision 冲突（云端 ${error.currentRevision ?? 'unknown'}），`
+          + '已保留本地 pending 修改，未用云端值覆盖。',
+        );
+      } else {
+        Logger.warning(
+          `CatsCo BotDefinition 暂时不可用，继续使用上次本地缓存: `
+          + redactBotDefinitionError(error, definition),
+        );
+      }
+    }
+  }
+
+  if (!fullDefinitionActive && !cloudSelection) {
     try {
       cloudSelection = await pullCloudBotModelSelection({
         botId,
@@ -82,7 +200,7 @@ export async function prepareBoundBotDefinition(
     }
   }
 
-  if (cloudSelection) {
+  if (!fullDefinitionActive && cloudSelection) {
     try {
       if (cloudSelection.kind === 'local') {
         if (selectedCatalogRuntime) {
@@ -237,43 +355,102 @@ export async function prepareBoundBotDefinition(
     materializedCatalogRuntime = true;
   }
 
-  const activeCloudOverride = definitionService.readCloudModelOverride(botId);
-  if (activeCloudOverride) definition = activeCloudOverride;
-  if (definition.model.kind === 'catalog') {
-    const runtime = activeCloudOverride
-      ? definitionService.readCloudCatalogRuntime(botId)
-      : definitionService.readCatalogRuntime(botId);
-    if (!runtime || !catalogRuntimeMatchesModelId(runtime, definition.model.modelId)) {
-      const materialized = await provisionCatsRelayCatalogRuntime({
-        botId,
-        modelId: definition.model.modelId,
-        auth,
-        fetchImpl: options.fetchImpl,
-      });
-      if (activeCloudOverride) definitionService.storeCloudCatalogRuntime(materialized);
-      else definitionService.storeCatalogRuntime(materialized);
-      materializedCatalogRuntime = true;
-    } else if (catalogCapabilitiesNeedRefresh(runtime)) {
-      const refreshed = await refreshCatsRelayCatalogRuntimeCapabilities(runtime, options.fetchImpl ?? fetch);
-      if (refreshed !== runtime) {
-        if (activeCloudOverride) definitionService.storeCloudCatalogRuntime(refreshed);
-        else definitionService.storeCatalogRuntime(refreshed);
+  let cloudDefinitionApplyError: string | undefined;
+  try {
+    const activeCloudOverride = fullDefinitionActive
+      ? undefined
+      : definitionService.readCloudModelOverride(botId);
+    if (activeCloudOverride) definition = activeCloudOverride;
+    if (definition.model.kind === 'catalog') {
+      const runtime = activeCloudOverride
+        ? definitionService.readCloudCatalogRuntime(botId)
+        : definitionService.readCatalogRuntime(botId);
+      if (!runtime || !catalogRuntimeMatchesModelId(runtime, definition.model.modelId)) {
+        const materialized = await provisionCatsRelayCatalogRuntime({
+          botId,
+          modelId: definition.model.modelId,
+          auth,
+          fetchImpl: options.fetchImpl,
+        });
+        if (options.stageCloudDefinition && fullDefinitionActive) {
+          stagedCatalogRuntime = materialized;
+        } else if (activeCloudOverride) {
+          definitionService.storeCloudCatalogRuntime(materialized);
+        } else {
+          definitionService.storeCatalogRuntime(materialized);
+        }
+        materializedCatalogRuntime = true;
+      } else if (catalogCapabilitiesNeedRefresh(runtime)) {
+        const refreshed = await refreshCatsRelayCatalogRuntimeCapabilities(runtime, options.fetchImpl ?? fetch);
+        if (refreshed !== runtime) {
+          if (options.stageCloudDefinition && fullDefinitionActive) {
+            stagedCatalogRuntime = refreshed;
+          } else if (activeCloudOverride) {
+            definitionService.storeCloudCatalogRuntime(refreshed);
+          } else {
+            definitionService.storeCatalogRuntime(refreshed);
+          }
+        }
       }
     }
-  }
 
-  definitionService.clearLegacyModelConfigurationWhenReady(definition);
-  if (!definitionService.read(botId)) {
-    definitionService.publish(botId, {
-      kind: 'catalog',
-      modelId: DEFAULT_CATSCO_RELAY_MODEL_ID,
-    });
+    if (!fullDefinitionActive) {
+      definitionService.clearLegacyModelConfigurationWhenReady(definition);
+    }
+    if (!definitionService.read(botId)) {
+      definitionService.publish(botId, {
+        kind: 'catalog',
+        modelId: DEFAULT_CATSCO_RELAY_MODEL_ID,
+      });
+    }
+    if (fullDefinitionActive && cloudDefinitionSnapshot && !options.stageCloudDefinition) {
+      if (usingPendingDefinition) {
+        definitionService.restoreLocalDefinitionCache(definition);
+      } else {
+        definitionService.promoteCloudDefinition(cloudDefinitionSnapshot);
+        definition = cloudDefinitionSnapshot.definition;
+      }
+    }
+    if (!options.stageCloudDefinition) {
+      await getPromptReconcileCoordinator({
+        runtimeRoot: options.runtimeRoot,
+        env: options.env,
+        definitionService,
+      }).activateBot(botId);
+    }
+  } catch (error) {
+    if (!fullDefinitionActive || !cloudDefinitionSnapshot) throw error;
+    cloudDefinitionApplyError = redactBotDefinitionError(error, cloudDefinitionSnapshot.definition);
+    if (previousAppliedSnapshot) {
+      definitionService.promoteCloudDefinition(previousAppliedSnapshot);
+      definition = previousAppliedSnapshot.definition;
+    } else if (previousLocalDefinition) {
+      definitionService.restoreLocalDefinitionCache(previousLocalDefinition);
+      definition = previousLocalDefinition;
+    } else {
+      throw error;
+    }
+    try {
+      await definitionService.acknowledgeCloudDefinition(
+        botId,
+        cloudDefinitionSnapshot.revision,
+        auth,
+        cloudDefinitionApplyError,
+        options.fetchImpl,
+      );
+    } catch {
+      // The failed ACK remains durable and is retried after reconnect.
+    }
+    await getPromptReconcileCoordinator({
+      runtimeRoot: options.runtimeRoot,
+      env: options.env,
+      definitionService,
+    }).activateBot(botId);
+    Logger.warning(
+      `CatsCo BotDefinition revision=${cloudDefinitionSnapshot.revision} 应用失败，`
+      + `已恢复上一份本地配置: ${cloudDefinitionApplyError}`,
+    );
   }
-  await getPromptReconcileCoordinator({
-    runtimeRoot: options.runtimeRoot,
-    env: options.env,
-    definitionService,
-  }).activateBot(botId);
   return {
     botId,
     definition,
@@ -281,6 +458,11 @@ export async function prepareBoundBotDefinition(
     initializedDefault,
     materializedCatalogRuntime,
     ...(cloudSelection ? { cloudSelection } : {}),
+    ...(cloudDefinitionSnapshot ? { cloudDefinitionSnapshot } : {}),
+    ...(cloudDefinitionApplyError ? { cloudDefinitionApplyError } : {}),
+    ...(usingPendingDefinition ? { cloudDefinitionHasPendingLocal: true } : {}),
+    ...(fullDefinitionActive ? { cloudDefinitionManaged: true } : {}),
+    ...(stagedCatalogRuntime ? { stagedCatalogRuntime } : {}),
     ...(cloudApplyError ? { cloudApplyError } : {}),
     ...(cloudSelectionApplied && cloudSelection ? { cloudRevision: cloudSelection.revision } : {}),
   };

--- a/src/bot-definition/cloud-state.ts
+++ b/src/bot-definition/cloud-state.ts
@@ -1,0 +1,298 @@
+import { randomUUID } from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+import type {
+  BotDefinitionFieldPatch,
+  CloudBotDefinitionSnapshot,
+  LocalBotDefinitionCloudState,
+  PendingBotDefinitionAck,
+  PendingBotDefinitionPatch,
+} from './types';
+
+const STATE_SCHEMA = 'xiaoba.bot-definition-cloud-state.v1' as const;
+
+export class FileBotDefinitionCloudStateRepository {
+  private readonly root: string;
+  private readonly lockRoot: string;
+
+  constructor(runtimeRoot: string) {
+    this.root = path.join(path.resolve(runtimeRoot), 'data', 'bot-definition-cloud-state');
+    this.lockRoot = path.join(this.root, '.locks');
+  }
+
+  read(botId: string): LocalBotDefinitionCloudState {
+    return this.readUnlocked(botId);
+  }
+
+  write(state: LocalBotDefinitionCloudState): void {
+    this.withWriteLock(state.botId, () => this.writeUnlocked(state));
+  }
+
+  recordSnapshot(botId: string, snapshot: CloudBotDefinitionSnapshot): LocalBotDefinitionCloudState {
+    return this.mutate(botId, state => ({ ...state, snapshot, definitionProtocolSeen: true }));
+  }
+
+  markDefinitionProtocolSeen(botId: string): void {
+    this.mutate(botId, state => ({ ...state, definitionProtocolSeen: true }));
+  }
+
+  queuePatch(
+    botId: string,
+    expectedRevision: number,
+    changes: BotDefinitionFieldPatch,
+    source: PendingBotDefinitionPatch['source'] = 'user',
+  ): PendingBotDefinitionPatch {
+    let queued!: PendingBotDefinitionPatch;
+    this.mutate(botId, state => {
+      const previous = state.pendingPatch;
+      queued = {
+        botId,
+        expectedRevision: previous?.expectedRevision ?? expectedRevision,
+        changes: { ...previous?.changes, ...changes },
+        source: previous?.source === 'user' ? 'user' : source,
+        idempotencyKey: previous?.idempotencyKey ?? randomUUID(),
+        createdAt: previous?.createdAt ?? new Date().toISOString(),
+        status: previous?.status ?? 'pending',
+        ...(previous?.conflictRevision !== undefined
+          ? { conflictRevision: previous.conflictRevision }
+          : {}),
+      };
+      return { ...state, pendingPatch: queued };
+    });
+    return queued;
+  }
+
+  markPatchConflicted(botId: string, conflictRevision?: number): void {
+    this.mutate(botId, state => {
+      if (!state.pendingPatch) return state;
+      return {
+        ...state,
+        pendingPatch: {
+          ...state.pendingPatch,
+          status: 'conflicted',
+          ...(conflictRevision !== undefined ? { conflictRevision } : {}),
+        },
+      };
+    });
+  }
+
+  clearPatch(botId: string): void {
+    this.mutate(botId, state => {
+      if (!state.pendingPatch) return state;
+      const { pendingPatch: _pendingPatch, ...next } = state;
+      return next;
+    });
+  }
+
+  acceptCloudAndClearConflict(
+    botId: string,
+    expectedPending: PendingBotDefinitionPatch,
+    snapshot: CloudBotDefinitionSnapshot,
+  ): boolean {
+    let accepted = false;
+    this.mutate(botId, state => {
+      if (
+        !state.pendingPatch
+        || state.pendingPatch.status !== 'conflicted'
+        || JSON.stringify(state.pendingPatch) !== JSON.stringify(expectedPending)
+      ) {
+        return state;
+      }
+      const { pendingPatch: _pendingPatch, ...next } = state;
+      accepted = true;
+      return { ...next, snapshot, definitionProtocolSeen: true };
+    });
+    return accepted;
+  }
+
+  completePatch(
+    botId: string,
+    submitted: PendingBotDefinitionPatch,
+    committedRevision: number,
+  ): void {
+    this.mutate(botId, state => {
+      const current = state.pendingPatch;
+      if (!current) return state;
+      const remaining: BotDefinitionFieldPatch = {};
+      for (const field of ['model', 'savedCustomModel', 'prompt'] as const) {
+        const currentValue = current.changes[field];
+        if (currentValue === undefined) continue;
+        const submittedValue = submitted.changes[field];
+        if (
+          submittedValue === undefined
+          || JSON.stringify(currentValue) !== JSON.stringify(submittedValue)
+        ) {
+          (remaining as any)[field] = currentValue;
+        }
+      }
+      if (Object.keys(remaining).length === 0) {
+        const { pendingPatch: _pendingPatch, ...next } = state;
+        return next;
+      }
+      return {
+        ...state,
+        pendingPatch: {
+          botId,
+          expectedRevision: committedRevision,
+          changes: remaining,
+          source: current.source,
+          idempotencyKey: randomUUID(),
+          createdAt: new Date().toISOString(),
+          status: 'pending',
+        },
+      };
+    });
+  }
+
+  rebasePatch(botId: string, expectedRevision: number): PendingBotDefinitionPatch | undefined {
+    let rebased: PendingBotDefinitionPatch | undefined;
+    this.mutate(botId, state => {
+      if (!state.pendingPatch) return state;
+      const { conflictRevision: _conflictRevision, ...pending } = state.pendingPatch;
+      rebased = {
+        ...pending,
+        expectedRevision,
+        status: 'pending',
+        idempotencyKey: randomUUID(),
+      };
+      return { ...state, pendingPatch: rebased };
+    });
+    return rebased;
+  }
+
+  markApplied(botId: string, revision: number): void {
+    this.mutate(botId, state => ({
+      ...state,
+      appliedRevision: revision,
+      ...(state.snapshot?.revision === revision ? { appliedSnapshot: state.snapshot } : {}),
+    }));
+  }
+
+  queueAck(botId: string, revision: number, error = ''): PendingBotDefinitionAck {
+    const pendingAck: PendingBotDefinitionAck = {
+      revision,
+      ...(error ? { error } : {}),
+      createdAt: new Date().toISOString(),
+    };
+    this.mutate(botId, state => ({ ...state, pendingAck }));
+    return pendingAck;
+  }
+
+  clearAck(botId: string, revision: number): void {
+    this.mutate(botId, state => {
+      if (state.pendingAck?.revision !== revision) return state;
+      const { pendingAck: _pendingAck, ...next } = state;
+      return next;
+    });
+  }
+
+  private mutate(
+    botId: string,
+    update: (state: LocalBotDefinitionCloudState) => LocalBotDefinitionCloudState,
+  ): LocalBotDefinitionCloudState {
+    return this.withWriteLock(botId, () => {
+      const next = update(this.readUnlocked(botId));
+      this.writeUnlocked(next);
+      return next;
+    });
+  }
+
+  private readUnlocked(botId: string): LocalBotDefinitionCloudState {
+    const filePath = this.filePath(botId);
+    if (!fs.existsSync(filePath)) return this.empty(botId);
+    try {
+      const parsed = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as LocalBotDefinitionCloudState;
+      if (parsed?.schema === STATE_SCHEMA && parsed.botId === botId) return parsed;
+    } catch {
+      // Preserve unreadable durable work for diagnostics instead of silently
+      // treating pending writes/ACKs as if they never existed.
+    }
+    const corruptPath = `${filePath}.corrupt-${Date.now()}`;
+    try {
+      fs.renameSync(filePath, corruptPath);
+    } catch {
+      // Another process may already have quarantined it.
+    }
+    return this.empty(botId);
+  }
+
+  private writeUnlocked(state: LocalBotDefinitionCloudState): void {
+    const filePath = this.filePath(state.botId);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
+    const temporary = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+    fs.writeFileSync(temporary, `${JSON.stringify(state, null, 2)}\n`, { encoding: 'utf-8', mode: 0o600 });
+    fs.renameSync(temporary, filePath);
+    if (process.platform !== 'win32') {
+      try {
+        fs.chmodSync(filePath, 0o600);
+      } catch {
+        // Best effort on filesystems without POSIX permissions.
+      }
+    }
+  }
+
+  private empty(botId: string): LocalBotDefinitionCloudState {
+    return { schema: STATE_SCHEMA, botId };
+  }
+
+  private filePath(botId: string): string {
+    const normalized = String(botId || '').trim();
+    if (!/^[a-zA-Z0-9_.-]+$/.test(normalized)) throw new Error('botId contains unsupported characters');
+    return path.join(this.root, `${normalized}.json`);
+  }
+
+  private withWriteLock<T>(botId: string, operation: () => T): T {
+    const normalized = String(botId || '').trim();
+    if (!/^[a-zA-Z0-9_.-]+$/.test(normalized)) throw new Error('botId contains unsupported characters');
+    fs.mkdirSync(this.lockRoot, { recursive: true, mode: 0o700 });
+    const lockPath = path.join(this.lockRoot, `${normalized}.lock`);
+    const deadline = Date.now() + 5_000;
+    while (true) {
+      try {
+        const descriptor = fs.openSync(lockPath, 'wx', 0o600);
+        try {
+          fs.writeFileSync(descriptor, `${process.pid}\n`, 'utf-8');
+          return operation();
+        } finally {
+          fs.closeSync(descriptor);
+          try {
+            fs.unlinkSync(lockPath);
+          } catch {
+            // A stale-lock cleanup may already have removed it.
+          }
+        }
+      } catch (error: any) {
+        if (error?.code !== 'EEXIST') throw error;
+        if (this.removeStaleLock(lockPath)) continue;
+        if (Date.now() >= deadline) {
+          throw new Error(`Timed out waiting for BotDefinition cloud-state lock: ${normalized}`);
+        }
+        const until = Date.now() + 20;
+        while (Date.now() < until) {
+          // Synchronous repository API: keep the wait short and bounded.
+        }
+      }
+    }
+  }
+
+  private removeStaleLock(lockPath: string): boolean {
+    try {
+      const pid = Number.parseInt(fs.readFileSync(lockPath, 'utf-8').trim(), 10);
+      const stat = fs.statSync(lockPath);
+      let processAlive = false;
+      if (Number.isInteger(pid) && pid > 0) {
+        try {
+          process.kill(pid, 0);
+          processAlive = true;
+        } catch {
+          processAlive = false;
+        }
+      }
+      if (processAlive || Date.now() - stat.mtimeMs < 30_000) return false;
+      fs.unlinkSync(lockPath);
+      return true;
+    } catch (error: any) {
+      return error?.code === 'ENOENT';
+    }
+  }
+}

--- a/src/bot-definition/definition-client.ts
+++ b/src/bot-definition/definition-client.ts
@@ -1,0 +1,279 @@
+import type { CatsCoAuthSnapshot } from '../catscompany/local-config';
+import { normalizeReasoningEffort } from '../utils/reasoning-effort';
+import {
+  BOT_DEFINITION_SCHEMA,
+  type BotDefinition,
+  type BotDefinitionFieldPatch,
+  type BotModelDefinition,
+  type BotPromptDefinition,
+  type CloudBotDefinitionSnapshot,
+  type CustomBotModelDefinition,
+} from './types';
+
+const DEFINITION_REQUEST_TIMEOUT_MS = 10_000;
+
+export type CloudBotDefinitionPullResult =
+  | { kind: 'found'; snapshot: CloudBotDefinitionSnapshot }
+  | { kind: 'migration_required'; legacyModel?: BotModelDefinition }
+  | { kind: 'unsupported' };
+
+export class BotDefinitionRevisionConflictError extends Error {
+  constructor(public readonly currentRevision?: number) {
+    super('CatsCo BotDefinition revision conflict.');
+    this.name = 'BotDefinitionRevisionConflictError';
+  }
+}
+
+export interface CloudBotDefinitionClientOptions {
+  botId: string;
+  auth: CatsCoAuthSnapshot;
+  fetchImpl?: typeof fetch;
+}
+
+export async function pullCloudBotDefinition(
+  options: CloudBotDefinitionClientOptions,
+): Promise<CloudBotDefinitionPullResult> {
+  const response = await request(options, 'runtime', 'GET', '/api/bot/definition');
+  if (response.kind === 'unsupported') return response;
+  if (response.kind === 'migration_required') {
+    return {
+      kind: 'migration_required',
+      ...(response.data?.legacy_model
+        ? { legacyModel: parseModel(response.data.legacy_model, true) }
+        : {}),
+    };
+  }
+  if (response.kind !== 'ok') {
+    throw new BotDefinitionRevisionConflictError(response.currentRevision);
+  }
+  return { kind: 'found', snapshot: parseSnapshot(response.data, options.botId, true) };
+}
+
+export async function patchCloudBotDefinition(
+  options: CloudBotDefinitionClientOptions,
+  expectedRevision: number,
+  changes: BotDefinitionFieldPatch,
+): Promise<CloudBotDefinitionSnapshot> {
+  const response = await request(
+    options,
+    'owner',
+    'PATCH',
+    `/api/bots/definition?uid=${encodeURIComponent(options.botId)}`,
+    {
+      expected_revision: expectedRevision,
+      ...(changes.model ? { model: changes.model } : {}),
+      ...(changes.savedCustomModel ? { savedCustomModel: changes.savedCustomModel } : {}),
+      ...(changes.prompt ? { prompt: changes.prompt } : {}),
+    },
+  );
+  if (response.kind === 'conflict') {
+    throw new BotDefinitionRevisionConflictError(response.currentRevision);
+  }
+  if (response.kind !== 'ok') {
+    throw new Error('CatsCo BotDefinition PATCH is unavailable.');
+  }
+  const committedRevision = Number(response.data?.revision);
+  const runtime = await pullCloudBotDefinition(options);
+  if (
+    runtime.kind !== 'found'
+    || !Number.isInteger(committedRevision)
+    || runtime.snapshot.revision !== committedRevision
+  ) {
+    throw new Error('CatsCo committed BotDefinition but the runtime snapshot is not yet readable.');
+  }
+  return runtime.snapshot;
+}
+
+export async function acknowledgeCloudBotDefinition(
+  options: CloudBotDefinitionClientOptions,
+  revision: number,
+  applyError = '',
+): Promise<void> {
+  const response = await request(options, 'runtime', 'POST', '/api/bot/definition/ack', {
+    revision,
+    ...(applyError ? { error: applyError } : {}),
+  });
+  if (response.kind === 'conflict') {
+    throw new BotDefinitionRevisionConflictError(response.currentRevision);
+  }
+  if (response.kind !== 'ok') {
+    throw new Error('CatsCo BotDefinition ACK is unavailable.');
+  }
+}
+
+export function redactBotDefinitionError(error: unknown, definition?: BotDefinition): string {
+  let message = error instanceof Error ? error.message : String(error);
+  const secrets = [
+    definition?.model.kind === 'custom' ? definition.model.apiKey : '',
+    definition?.savedCustomModel?.apiKey || '',
+  ].filter(Boolean);
+  for (const secret of secrets) message = message.split(secret).join('[REDACTED]');
+  return message;
+}
+
+function parseSnapshot(value: any, expectedBotId: string, runtime: boolean): CloudBotDefinitionSnapshot {
+  const revision = Number(value?.revision);
+  const definition = parseDefinition(value?.definition, expectedBotId, runtime);
+  if (!Number.isInteger(revision) || revision <= 0) {
+    throw new Error('CatsCo returned an invalid BotDefinition revision.');
+  }
+  return {
+    definition,
+    revision,
+    ...(String(value?.updatedAt || '').trim() ? { updatedAt: String(value.updatedAt).trim() } : {}),
+  };
+}
+
+function parseDefinition(value: any, expectedBotId: string, runtime: boolean): BotDefinition {
+  const schema = String(value?.schema || '').trim();
+  const botId = String(value?.botId || '').trim();
+  if (schema !== BOT_DEFINITION_SCHEMA || botId !== expectedBotId) {
+    throw new Error('CatsCo returned a BotDefinition for a different bot or schema.');
+  }
+  const prompt = parsePrompt(value?.prompt);
+  const model = parseModel(value?.model, runtime);
+  const savedCustomModel = value?.savedCustomModel
+    ? parseCustomModel(value.savedCustomModel, runtime)
+    : undefined;
+  return {
+    schema: BOT_DEFINITION_SCHEMA,
+    botId,
+    model,
+    ...(savedCustomModel ? { savedCustomModel } : {}),
+    prompt,
+  };
+}
+
+function parsePrompt(value: any): BotPromptDefinition {
+  const selected = String(value?.selected || '').trim();
+  const customSystemPrompt = value?.customSystemPrompt === undefined
+    ? undefined
+    : String(value.customSystemPrompt).trim();
+  if (selected !== 'default' && selected !== 'custom') {
+    throw new Error('CatsCo returned an invalid BotDefinition prompt selection.');
+  }
+  if (selected === 'custom' && !customSystemPrompt) {
+    throw new Error('CatsCo returned an empty custom system prompt.');
+  }
+  return {
+    selected,
+    ...(customSystemPrompt ? { customSystemPrompt } : {}),
+  };
+}
+
+function parseModel(value: any, runtime: boolean): BotModelDefinition {
+  const kind = String(value?.kind || '').trim().toLowerCase();
+  if (kind === 'catalog') {
+    const modelId = String(value?.modelId || '').trim();
+    const rawReasoning = String(value?.reasoningEffort || '').trim();
+    const reasoningEffort = rawReasoning ? normalizeReasoningEffort(rawReasoning) : undefined;
+    if (!modelId || (rawReasoning && !reasoningEffort)) {
+      throw new Error('CatsCo returned an invalid catalog model definition.');
+    }
+    return { kind: 'catalog', modelId, ...(reasoningEffort ? { reasoningEffort } : {}) };
+  }
+  if (kind !== 'custom') {
+    throw new Error('CatsCo returned an unsupported BotDefinition model kind.');
+  }
+  return parseCustomModel(value, runtime);
+}
+
+function parseCustomModel(value: any, runtime: boolean): CustomBotModelDefinition {
+  const protocol = String(value?.protocol || '').trim().toLowerCase();
+  const apiBase = String(value?.apiBase || '').trim().replace(/\/+$/, '');
+  const model = String(value?.model || '').trim();
+  const apiKey = String(value?.apiKey || '').trim();
+  const contextWindowTokens = Number(value?.contextWindowTokens);
+  const maxTokens = value?.maxTokens === undefined ? undefined : Number(value.maxTokens);
+  const temperature = value?.temperature === undefined ? undefined : Number(value.temperature);
+  const rawReasoning = String(value?.reasoningEffort || '').trim();
+  const reasoningEffort = rawReasoning ? normalizeReasoningEffort(rawReasoning) : undefined;
+  if (!['anthropic', 'openai-chat-completions', 'openai-responses'].includes(protocol)) {
+    throw new Error('CatsCo returned an unsupported custom model protocol.');
+  }
+  if (!apiBase || !/^https?:\/\//i.test(apiBase) || !model || (runtime && !apiKey)) {
+    throw new Error('CatsCo returned an incomplete custom model definition.');
+  }
+  if (!Number.isInteger(contextWindowTokens) || contextWindowTokens < 1024 || contextWindowTokens > 4_000_000) {
+    throw new Error('CatsCo returned an invalid custom model context window.');
+  }
+  if (maxTokens !== undefined && (!Number.isInteger(maxTokens) || maxTokens < 0 || maxTokens > 1_000_000)) {
+    throw new Error('CatsCo returned invalid custom model max tokens.');
+  }
+  if (temperature !== undefined && (!Number.isFinite(temperature) || temperature < 0 || temperature > 2)) {
+    throw new Error('CatsCo returned invalid custom model temperature.');
+  }
+  if (rawReasoning && !reasoningEffort) {
+    throw new Error('CatsCo returned an unsupported custom model reasoning effort.');
+  }
+  return {
+    kind: 'custom',
+    protocol: protocol as CustomBotModelDefinition['protocol'],
+    apiBase,
+    model,
+    apiKey,
+    contextWindowTokens,
+    ...(maxTokens ? { maxTokens } : {}),
+    ...(temperature !== undefined ? { temperature } : {}),
+    ...(reasoningEffort ? { reasoningEffort } : {}),
+  };
+}
+
+type RequestResult =
+  | { kind: 'ok'; data: any }
+  | { kind: 'migration_required'; data: any }
+  | { kind: 'conflict'; currentRevision?: number }
+  | { kind: 'unsupported' };
+
+async function request(
+  options: CloudBotDefinitionClientOptions,
+  authKind: 'owner' | 'runtime',
+  method: string,
+  apiPath: string,
+  body?: unknown,
+): Promise<RequestResult> {
+  const httpBaseUrl = String(options.auth.httpBaseUrl || '').trim().replace(/\/+$/, '');
+  const credential = authKind === 'owner'
+    ? String(options.auth.token || '').trim()
+    : String(options.auth.apiKey || '').trim();
+  if (!httpBaseUrl || !credential) return { kind: 'unsupported' };
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), DEFINITION_REQUEST_TIMEOUT_MS);
+  try {
+    const response = await (options.fetchImpl ?? fetch)(`${httpBaseUrl}${apiPath}`, {
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: authKind === 'owner' ? `Bearer ${credential}` : `ApiKey ${credential}`,
+      },
+      body: body === undefined ? undefined : JSON.stringify(body),
+      signal: controller.signal,
+    });
+    const text = await response.text();
+    let data: any = {};
+    if (text) {
+      try {
+        data = JSON.parse(text);
+      } catch {
+        data = { raw: text };
+      }
+    }
+    if ([404, 405, 501].includes(response.status)) return { kind: 'unsupported' };
+    if (response.status === 409 && data?.error === 'migration_required') {
+      return { kind: 'migration_required', data };
+    }
+    if (response.status === 409 && data?.error === 'revision_conflict') {
+      const currentRevision = Number(data?.current_revision);
+      return {
+        kind: 'conflict',
+        ...(Number.isInteger(currentRevision) && currentRevision >= 0 ? { currentRevision } : {}),
+      };
+    }
+    if (!response.ok) {
+      throw new Error(String(data?.error || data?.message || `CatsCo BotDefinition request failed: ${response.status}`));
+    }
+    return { kind: 'ok', data };
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/src/bot-definition/service.ts
+++ b/src/bot-definition/service.ts
@@ -21,6 +21,7 @@ import {
   type BotPromptDefinition,
   type CustomBotModelDefinition,
   type LocalModelProfile,
+  type PendingBotDefinitionPatch,
 } from './types';
 import {
   FileBotCatalogModelRuntimeRepository,
@@ -34,6 +35,15 @@ import {
   type BotDefinitionRepository,
   type FileBotDefinitionRepositoryOptions,
 } from './repository';
+import { FileBotDefinitionCloudStateRepository } from './cloud-state';
+import {
+  acknowledgeCloudBotDefinition,
+  BotDefinitionRevisionConflictError,
+  patchCloudBotDefinition,
+  pullCloudBotDefinition,
+} from './definition-client';
+import type { CatsCoAuthSnapshot } from '../catscompany/local-config';
+import type { CloudBotDefinitionSnapshot } from './types';
 
 const CUSTOM_DEFAULT_CONTEXT_WINDOW_TOKENS = 200_000;
 
@@ -362,6 +372,7 @@ export interface BotDefinitionSyncServiceOptions extends FileBotDefinitionReposi
   cloudOverrideRepository?: BotCloudModelOverrideRepository;
   cloudCatalogRuntimeRepository?: BotCatalogModelRuntimeRepository;
   customModelProfileRepository?: BotCustomModelProfileRepository;
+  cloudStateRepository?: FileBotDefinitionCloudStateRepository;
   env?: NodeJS.ProcessEnv;
 }
 
@@ -377,6 +388,7 @@ export class BotDefinitionSyncService {
   private readonly cloudOverrideRepository: BotCloudModelOverrideRepository;
   private readonly cloudCatalogRuntimeRepository: BotCatalogModelRuntimeRepository;
   private readonly customModelProfileRepository: BotCustomModelProfileRepository;
+  private readonly cloudStateRepository: FileBotDefinitionCloudStateRepository;
 
   constructor(options: BotDefinitionSyncServiceOptions = {}) {
     this.runtimeRoot = path.resolve(options.runtimeRoot ?? process.cwd());
@@ -390,11 +402,16 @@ export class BotDefinitionSyncService {
       ?? new FileBotCloudCatalogModelRuntimeRepository({ runtimeRoot: this.runtimeRoot });
     this.customModelProfileRepository = options.customModelProfileRepository
       ?? new FileBotCustomModelProfileRepository({ runtimeRoot: this.runtimeRoot });
+    this.cloudStateRepository = options.cloudStateRepository
+      ?? new FileBotDefinitionCloudStateRepository(this.runtimeRoot);
   }
 
   pull(botId: string): BotDefinition | undefined {
     return this.withDefinitionWriteLock(botId, () => {
       const previousCache = this.repository.readCache(botId);
+      if (this.cloudSyncConfigured() && previousCache) {
+        return normalizeBotDefinition(previousCache);
+      }
       const rawDefinition = this.repository.readCanonical(botId);
       const definition = rawDefinition && normalizeBotDefinition(rawDefinition);
       if (definition) {
@@ -431,10 +448,20 @@ export class BotDefinitionSyncService {
         schema: BOT_DEFINITION_SCHEMA,
         botId,
         model: normalizedModel,
+        ...(normalizedModel.kind === 'custom'
+          ? { savedCustomModel: normalizedModel }
+          : previous?.savedCustomModel
+            ? { savedCustomModel: previous.savedCustomModel }
+            : {}),
       };
-      this.repository.writeCanonical(definition);
+      this.queueCloudPatch(botId, {
+        model: normalizedModel,
+        ...(definition.savedCustomModel ? { savedCustomModel: definition.savedCustomModel } : {}),
+      });
+      if (!this.cloudSyncConfigured()) {
+        this.repository.writeCanonical(definition);
+      }
       this.repository.writeCache(definition);
-      this.clearLegacyModelConfigurationWhenReady(definition);
       return {
         botId,
         direction: 'local_to_simulated_cloud',
@@ -459,8 +486,11 @@ export class BotDefinitionSyncService {
         botId,
         prompt: normalizePromptDefinition(prompt),
       };
+      this.queueCloudPatch(botId, { prompt: definition.prompt! });
       this.repository.writeCache(definition);
-      this.repository.writeCanonical(definition);
+      if (!this.cloudSyncConfigured()) {
+        this.repository.writeCanonical(definition);
+      }
       return {
         botId,
         direction: 'local_to_simulated_cloud',
@@ -481,6 +511,199 @@ export class BotDefinitionSyncService {
       direction: 'cloud_to_local',
       definition,
     };
+  }
+
+  acceptCloudDefinition(snapshot: CloudBotDefinitionSnapshot): BotDefinitionSyncResult {
+    return this.withDefinitionWriteLock(snapshot.definition.botId, () => {
+      const definition = normalizeBotDefinition(snapshot.definition);
+      this.cloudStateRepository.recordSnapshot(definition.botId, {
+        ...snapshot,
+        definition,
+      });
+      return {
+        botId: definition.botId,
+        direction: 'cloud_to_local',
+        definition,
+      };
+    });
+  }
+
+  /** Publishes a verified snapshot as the effective local runtime Definition. */
+  promoteCloudDefinition(snapshot: CloudBotDefinitionSnapshot): BotDefinitionSyncResult {
+    return this.withDefinitionWriteLock(snapshot.definition.botId, () => {
+      const definition = normalizeBotDefinition(snapshot.definition);
+      this.cloudStateRepository.recordSnapshot(definition.botId, { ...snapshot, definition });
+      this.repository.writeCache(definition);
+      if (definition.model.kind === 'custom') {
+        this.storeCustomModelProfile(definition.botId, definition.model);
+      } else if (definition.savedCustomModel) {
+        this.storeCustomModelProfile(definition.botId, definition.savedCustomModel);
+      }
+      return { botId: definition.botId, direction: 'cloud_to_local', definition };
+    });
+  }
+
+  commitCloudDefinitionIfNoPending(
+    snapshot: CloudBotDefinitionSnapshot,
+    stagedCatalogRuntime?: BotCatalogModelRuntime,
+  ): boolean {
+    return this.withDefinitionWriteLock(snapshot.definition.botId, () => {
+      if (this.cloudStateRepository.read(snapshot.definition.botId).pendingPatch) return false;
+      const definition = normalizeBotDefinition(snapshot.definition);
+      this.cloudStateRepository.recordSnapshot(definition.botId, { ...snapshot, definition });
+      if (stagedCatalogRuntime) {
+        this.catalogRuntimeRepository.write(normalizeCatalogRuntime(stagedCatalogRuntime));
+      }
+      this.repository.writeCache(definition);
+      if (definition.model.kind === 'custom') {
+        this.storeCustomModelProfile(definition.botId, definition.model);
+      } else if (definition.savedCustomModel) {
+        this.storeCustomModelProfile(definition.botId, definition.savedCustomModel);
+      }
+      return true;
+    });
+  }
+
+  applyPendingChanges(
+    base: BotDefinition,
+    changes: {
+      model?: BotModelDefinition;
+      savedCustomModel?: CustomBotModelDefinition;
+      prompt?: BotPromptDefinition;
+    },
+  ): BotDefinition {
+    return normalizeBotDefinition({
+      ...base,
+      ...(changes.model ? { model: changes.model } : {}),
+      ...(changes.savedCustomModel ? { savedCustomModel: changes.savedCustomModel } : {}),
+      ...(changes.prompt ? { prompt: changes.prompt } : {}),
+    });
+  }
+
+  restoreLocalDefinitionCache(definition: BotDefinition): void {
+    this.repository.writeCache(normalizeBotDefinition(definition));
+  }
+
+  readCloudState(botId: string) {
+    return this.cloudStateRepository.read(botId);
+  }
+
+  async flushPendingCloudPatch(
+    botId: string,
+    auth: CatsCoAuthSnapshot,
+    fetchImpl?: typeof fetch,
+  ): Promise<CloudBotDefinitionSnapshot | undefined> {
+    const state = this.cloudStateRepository.read(botId);
+    const pending = state.pendingPatch;
+    if (!pending || pending.status === 'conflicted') return state.snapshot;
+    try {
+      const snapshot = await patchCloudBotDefinition(
+        { botId, auth, fetchImpl },
+        pending.expectedRevision,
+        pending.changes,
+      );
+      this.acceptCloudDefinition(snapshot);
+      this.cloudStateRepository.completePatch(botId, pending, snapshot.revision);
+      return snapshot;
+    } catch (error) {
+      if (error instanceof BotDefinitionRevisionConflictError) {
+        this.cloudStateRepository.markDefinitionProtocolSeen(botId);
+        const current = await pullCloudBotDefinition({ botId, auth, fetchImpl });
+        if (
+          current.kind === 'found'
+          && pendingChangesMatchSnapshot(pending.changes, current.snapshot)
+        ) {
+          this.acceptCloudDefinition(current.snapshot);
+          this.cloudStateRepository.completePatch(botId, pending, current.snapshot.revision);
+          return current.snapshot;
+        }
+        this.cloudStateRepository.markPatchConflicted(botId, error.currentRevision);
+      }
+      throw error;
+    }
+  }
+
+  markCloudDefinitionApplied(botId: string, revision: number): void {
+    this.cloudStateRepository.markApplied(botId, revision);
+  }
+
+  markCloudDefinitionAppliedIfNoPending(botId: string, revision: number): boolean {
+    return this.withDefinitionWriteLock(botId, () => {
+      const state = this.cloudStateRepository.read(botId);
+      if (state.pendingPatch || state.snapshot?.revision !== revision) return false;
+      this.cloudStateRepository.markApplied(botId, revision);
+      return true;
+    });
+  }
+
+  markCloudDefinitionProtocolSeen(botId: string): void {
+    this.cloudStateRepository.markDefinitionProtocolSeen(botId);
+  }
+
+  discardPendingCloudPatch(
+    botId: string,
+    acceptedCloudSnapshot: CloudBotDefinitionSnapshot,
+    expectedPending: PendingBotDefinitionPatch,
+  ): void {
+    if (acceptedCloudSnapshot.definition.botId !== botId) {
+      throw new Error('Cannot accept a BotDefinition snapshot for a different bot.');
+    }
+    this.withDefinitionWriteLock(botId, () => {
+      if (!this.cloudStateRepository.acceptCloudAndClearConflict(
+        botId,
+        expectedPending,
+        acceptedCloudSnapshot,
+      )) {
+        throw new Error('BotDefinition conflict changed while it was being resolved; review it again.');
+      }
+    });
+  }
+
+  rebasePendingCloudPatch(botId: string, confirmedCloudRevision: number): void {
+    if (!Number.isInteger(confirmedCloudRevision) || confirmedCloudRevision <= 0) {
+      throw new Error('A positive confirmed cloud revision is required.');
+    }
+    this.cloudStateRepository.rebasePatch(botId, confirmedCloudRevision);
+  }
+
+  async acknowledgeCloudDefinition(
+    botId: string,
+    revision: number,
+    auth: CatsCoAuthSnapshot,
+    applyError = '',
+    fetchImpl?: typeof fetch,
+  ): Promise<void> {
+    this.cloudStateRepository.queueAck(botId, revision, applyError);
+    await acknowledgeCloudBotDefinition({ botId, auth, fetchImpl }, revision, applyError);
+    this.cloudStateRepository.clearAck(botId, revision);
+  }
+
+  async retryPendingCloudAck(
+    botId: string,
+    auth: CatsCoAuthSnapshot,
+    fetchImpl?: typeof fetch,
+  ): Promise<boolean> {
+    const pending = this.cloudStateRepository.read(botId).pendingAck;
+    if (!pending) return false;
+    try {
+      await acknowledgeCloudBotDefinition(
+        { botId, auth, fetchImpl },
+        pending.revision,
+        pending.error || '',
+      );
+      this.cloudStateRepository.clearAck(botId, pending.revision);
+      return true;
+    } catch (error) {
+      if (
+        error instanceof BotDefinitionRevisionConflictError
+        && error.currentRevision !== undefined
+        && error.currentRevision > pending.revision
+      ) {
+        this.cloudStateRepository.clearAck(botId, pending.revision);
+        return false;
+      }
+      throw error;
+    }
   }
 
   readCloudModelOverride(botId: string): BotDefinition | undefined {
@@ -549,7 +772,9 @@ export class BotDefinitionSyncService {
     if (existing) {
       this.migrateLegacyCustomModelProfile(existing.botId);
       this.migrateLegacyCatalogRuntime(existing);
-      this.clearLegacyModelConfigurationWhenReady(existing);
+      if (!this.cloudSyncConfigured()) {
+        this.clearLegacyModelConfigurationWhenReady(existing);
+      }
       return {
         botId,
         direction: 'simulated_cloud_to_local',
@@ -564,7 +789,9 @@ export class BotDefinitionSyncService {
       this.storeCustomModelProfile(botId, legacySavedCustomModel);
     }
     this.bootstrapCatalogRuntimeFromLocalProfile(definition, profile);
-    this.clearLegacyModelConfigurationWhenReady(definition);
+    if (!this.cloudSyncConfigured()) {
+      this.clearLegacyModelConfigurationWhenReady(definition);
+    }
     return {
       botId,
       direction: 'bootstrap_to_simulated_cloud',
@@ -596,6 +823,31 @@ export class BotDefinitionSyncService {
       : operation();
   }
 
+  private queueCloudPatch(
+    botId: string,
+    changes: {
+      model?: BotModelDefinition;
+      savedCustomModel?: CustomBotModelDefinition;
+      prompt?: BotPromptDefinition;
+    },
+  ): void {
+    const state = this.cloudStateRepository.read(botId);
+    this.cloudStateRepository.queuePatch(
+      botId,
+      state.snapshot?.revision ?? 0,
+      changes,
+      state.snapshot ? 'user' : 'legacy',
+    );
+  }
+
+  private cloudSyncConfigured(): boolean {
+    const auth = createCatsCoLocalConfigService({
+      runtimeRoot: this.runtimeRoot,
+      env: this.env,
+    }).getAuthState();
+    return Boolean(auth.token && auth.apiKey && auth.httpBaseUrl);
+  }
+
   private bootstrapCatalogRuntimeFromLocalProfile(
     definition: BotDefinition,
     knownProfile?: LocalModelProfile,
@@ -623,7 +875,6 @@ export class BotDefinitionSyncService {
     const runtime = catalogRuntimeFromLocalProfile(definition.botId, definition.model.modelId, profile);
     if (!runtime) return;
     this.storeCatalogRuntime(runtime);
-    this.clearLegacyModelConfiguration();
   }
 
   private migrateLegacyCustomModelProfile(botId: string): void {
@@ -703,4 +954,35 @@ export function readCachedDefinitionForCurrentBot(
   const botId = String(localConfig.currentBot?.uid || '').trim();
   if (!botId) return undefined;
   return new FileBotDefinitionRepository({ runtimeRoot }).readCache(botId);
+}
+
+function pendingChangesMatchSnapshot(
+  changes: {
+    model?: BotModelDefinition;
+    savedCustomModel?: CustomBotModelDefinition;
+    prompt?: BotPromptDefinition;
+  },
+  snapshot: CloudBotDefinitionSnapshot,
+): boolean {
+  const definition = normalizeBotDefinition(snapshot.definition);
+  if (
+    changes.model
+    && JSON.stringify(normalizeBotModelDefinition(changes.model)) !== JSON.stringify(definition.model)
+  ) {
+    return false;
+  }
+  if (
+    changes.savedCustomModel
+    && JSON.stringify(normalizeBotModelDefinition(changes.savedCustomModel))
+      !== JSON.stringify(definition.savedCustomModel)
+  ) {
+    return false;
+  }
+  if (
+    changes.prompt
+    && JSON.stringify(normalizePromptDefinition(changes.prompt)) !== JSON.stringify(definition.prompt)
+  ) {
+    return false;
+  }
+  return true;
 }

--- a/src/bot-definition/types.ts
+++ b/src/bot-definition/types.ts
@@ -44,7 +44,48 @@ export interface BotDefinition {
   schema: typeof BOT_DEFINITION_SCHEMA;
   botId: string;
   model: BotModelDefinition;
+  savedCustomModel?: CustomBotModelDefinition;
   prompt?: BotPromptDefinition;
+}
+
+export interface CloudBotDefinitionSnapshot {
+  definition: BotDefinition;
+  revision: number;
+  updatedAt?: string;
+}
+
+export interface BotDefinitionFieldPatch {
+  model?: BotModelDefinition;
+  savedCustomModel?: CustomBotModelDefinition;
+  prompt?: BotPromptDefinition;
+}
+
+export interface PendingBotDefinitionPatch {
+  botId: string;
+  expectedRevision: number;
+  changes: BotDefinitionFieldPatch;
+  source: 'user' | 'legacy';
+  idempotencyKey: string;
+  createdAt: string;
+  status: 'pending' | 'conflicted';
+  conflictRevision?: number;
+}
+
+export interface PendingBotDefinitionAck {
+  revision: number;
+  error?: string;
+  createdAt: string;
+}
+
+export interface LocalBotDefinitionCloudState {
+  schema: 'xiaoba.bot-definition-cloud-state.v1';
+  botId: string;
+  snapshot?: CloudBotDefinitionSnapshot;
+  appliedRevision?: number;
+  appliedSnapshot?: CloudBotDefinitionSnapshot;
+  definitionProtocolSeen?: boolean;
+  pendingPatch?: PendingBotDefinitionPatch;
+  pendingAck?: PendingBotDefinitionAck;
 }
 
 export interface LocalModelProfile {

--- a/src/commands/catscompany.ts
+++ b/src/commands/catscompany.ts
@@ -17,6 +17,17 @@ import {
 } from '../bot-definition/cloud-client';
 import { CloudBotModelRuntimeReloadController } from '../bot-definition/runtime-reload';
 import { createBotDefinitionSyncService } from '../bot-definition/service';
+import {
+  BotDefinitionRevisionConflictError,
+  pullCloudBotDefinition,
+  redactBotDefinitionError,
+} from '../bot-definition/definition-client';
+import type {
+  BotCatalogModelRuntime,
+  BotDefinition,
+  CloudBotDefinitionSnapshot,
+} from '../bot-definition/types';
+import { getPromptReconcileCoordinator } from '../bot-definition/prompt-sync';
 
 const CONNECTOR_OWNER_POLL_MS = 2000;
 const CLOUD_MODEL_POLL_MS = 5000;
@@ -140,10 +151,39 @@ export async function catscompanyCommand(): Promise<void> {
 
   try {
     await bot.start();
+    await bot.waitUntilReady();
     await startRuntimeCommandSupport();
     const auth = createCatsCoLocalConfigService({ runtimeRoot }).getAuthState();
     const modelBotId = String(preparedBot?.botId || connectorConfig.botUid || '').trim();
-    if (preparedBot?.cloudSelection) {
+    const definitionService = createBotDefinitionSyncService({ runtimeRoot });
+    if (preparedBot?.cloudDefinitionSnapshot) {
+      const initial = preparedBot.cloudDefinitionSnapshot;
+      if (preparedBot.cloudDefinitionApplyError) {
+        Logger.warning(
+          `CatsCo BotDefinition revision=${initial.revision} 未应用，继续使用上一份配置: `
+          + preparedBot.cloudDefinitionApplyError,
+        );
+      } else if (
+        !preparedBot.cloudDefinitionHasPendingLocal
+        && definitionService.markCloudDefinitionAppliedIfNoPending(modelBotId, initial.revision)
+      ) {
+        try {
+          await definitionService.acknowledgeCloudDefinition(modelBotId, initial.revision, auth);
+        } catch (error) {
+          Logger.warning(
+            `CatsCo BotDefinition revision=${initial.revision} ACK 失败，已持久化等待重试: `
+            + redactBotDefinitionError(error, initial.definition),
+          );
+        }
+        try {
+          definitionService.clearCloudModelOverride(modelBotId);
+          definitionService.clearLegacyModelConfigurationWhenReady(initial.definition);
+        } catch (error) {
+          Logger.warning(`CatsCo BotDefinition 旧配置清理失败: ${errorMessage(error)}`);
+        }
+      }
+    }
+    if (!preparedBot?.cloudDefinitionSnapshot && preparedBot?.cloudSelection) {
       const initialApplyError = preparedBot.cloudApplyError || '';
       try {
         await acknowledgeCloudBotModelSelection(
@@ -161,6 +201,57 @@ export async function catscompanyCommand(): Promise<void> {
       }
     }
     let lastCloudPollWarningAt = 0;
+    if (preparedBot?.cloudDefinitionManaged) {
+      cloudModelWatchTimer = setInterval(() => {
+        if (cloudModelReloadPromise) return;
+        const run = (async () => {
+          try {
+            try {
+              await definitionService.retryPendingCloudAck(modelBotId, auth);
+            } catch (error) {
+              Logger.warning(
+                `CatsCo BotDefinition ACK 暂时无法重试，将继续检查新版本: ${errorMessage(error)}`,
+              );
+            }
+            const state = definitionService.readCloudState(modelBotId);
+            const previousDefinition = definitionService.read(modelBotId);
+            if (state.pendingPatch?.status === 'conflicted') return;
+            let snapshot: CloudBotDefinitionSnapshot | undefined;
+            if (state.pendingPatch) {
+              snapshot = await definitionService.flushPendingCloudPatch(modelBotId, auth);
+            } else {
+              const remote = await pullCloudBotDefinition({ botId: modelBotId, auth });
+              if (remote.kind === 'found') snapshot = remote.snapshot;
+            }
+            if (!snapshot || snapshot.revision <= (state.appliedRevision ?? 0)) return;
+            if (!bot.isIdleForRuntimeReload() || shuttingDown) return;
+            await applyCloudDefinitionRuntimeSnapshot({
+              runtimeRoot,
+              connectorConfig,
+              currentBot: () => bot,
+              replaceBot: next => { bot = next; },
+              botId: modelBotId,
+              canApply: () => !shuttingDown,
+              snapshot,
+              previousSnapshot: state.appliedSnapshot
+                ?? (state.appliedRevision === state.snapshot?.revision ? state.snapshot : undefined),
+              previousDefinition,
+              auth,
+            });
+          } catch (error) {
+            const now = Date.now();
+            if (error instanceof BotDefinitionRevisionConflictError || now - lastCloudPollWarningAt >= 60_000) {
+              lastCloudPollWarningAt = now;
+              Logger.warning(`CatsCo BotDefinition 轮询/应用失败: ${errorMessage(error)}`);
+            }
+          }
+        })();
+        cloudModelReloadPromise = run;
+        void run.finally(() => {
+          if (cloudModelReloadPromise === run) cloudModelReloadPromise = null;
+        });
+      }, CLOUD_MODEL_POLL_MS);
+    } else {
     const reloadController = new CloudBotModelRuntimeReloadController({
       initialRevision: preparedBot?.cloudSelection?.revision,
       pullSelection: async () => {
@@ -228,6 +319,7 @@ export async function catscompanyCommand(): Promise<void> {
         if (cloudModelReloadPromise === run) cloudModelReloadPromise = null;
       });
     }, CLOUD_MODEL_POLL_MS);
+    }
   } catch (error) {
     if (ownerWatchTimer) {
       clearInterval(ownerWatchTimer);
@@ -236,6 +328,151 @@ export async function catscompanyCommand(): Promise<void> {
     lock?.release();
     lock = null;
     throw error;
+  }
+}
+
+interface ApplyCloudDefinitionRuntimeSnapshotOptions {
+  runtimeRoot: string;
+  connectorConfig: CatsCompanyConfig;
+  currentBot(): CatsCompanyBot;
+  replaceBot(bot: CatsCompanyBot): void;
+  botId: string;
+  canApply(): boolean;
+  snapshot: CloudBotDefinitionSnapshot;
+  previousSnapshot?: CloudBotDefinitionSnapshot;
+  previousDefinition?: BotDefinition;
+  auth: CatsCoAuthSnapshot;
+}
+
+async function applyCloudDefinitionRuntimeSnapshot(
+  options: ApplyCloudDefinitionRuntimeSnapshotOptions,
+): Promise<void> {
+  const service = createBotDefinitionSyncService({ runtimeRoot: options.runtimeRoot });
+  const previousState = service.readCloudState(options.botId);
+  const previousSnapshot = options.previousSnapshot ?? previousState.appliedSnapshot;
+  const previousDefinition = options.previousDefinition ?? service.read(options.botId);
+  const previousRuntime = service.readCatalogRuntime(options.botId);
+  const promptCoordinator = getPromptReconcileCoordinator({
+    runtimeRoot: options.runtimeRoot,
+    definitionService: service,
+  });
+  const previousPrompt = promptCoordinator.captureActiveSnapshot();
+  const restoreFiles = () => {
+    if (previousSnapshot) service.promoteCloudDefinition(previousSnapshot);
+    else if (previousDefinition) service.restoreLocalDefinitionCache(previousDefinition);
+    if (previousRuntime) service.storeCatalogRuntime(previousRuntime);
+    promptCoordinator.restoreActiveSnapshot(previousPrompt);
+  };
+
+  let stagedCatalogRuntime: BotCatalogModelRuntime | undefined;
+  try {
+    service.acceptCloudDefinition(options.snapshot);
+    const prepared = await prepareBoundBotDefinition({
+      runtimeRoot: options.runtimeRoot,
+      botId: options.botId,
+      auth: options.auth,
+      acknowledgeCloudSelection: false,
+      stageCloudDefinition: true,
+    });
+    if (
+      !prepared?.cloudDefinitionSnapshot
+      || prepared.cloudDefinitionSnapshot.revision !== options.snapshot.revision
+    ) {
+      restoreFiles();
+      return;
+    }
+    stagedCatalogRuntime = prepared.stagedCatalogRuntime;
+  } catch (error) {
+    restoreFiles();
+    const message = redactBotDefinitionError(error, options.snapshot.definition);
+    await service.acknowledgeCloudDefinition(
+      options.botId,
+      options.snapshot.revision,
+      options.auth,
+      message,
+    ).catch(() => undefined);
+    throw new Error(message);
+  }
+
+  const latest = await pullCloudBotDefinition({ botId: options.botId, auth: options.auth });
+  if (latest.kind !== 'found' || latest.snapshot.revision !== options.snapshot.revision) {
+    restoreFiles();
+    return;
+  }
+  if (service.readCloudState(options.botId).pendingPatch) {
+    // A newer local edit won while this cloud revision was being staged.
+    // Leave the running connector untouched; the next poll uploads that edit
+    // and stages the combined revision.
+    return;
+  }
+  const previousBot = options.currentBot();
+  if (!options.canApply() || !previousBot.isIdleForRuntimeReload()) {
+    restoreFiles();
+    return;
+  }
+
+  let nextBot: CatsCompanyBot | undefined;
+  try {
+    await previousBot.destroy();
+    if (!service.commitCloudDefinitionIfNoPending(options.snapshot, stagedCatalogRuntime)) {
+      const localWinner = new CatsCompanyBot(options.connectorConfig);
+      await localWinner.start();
+      await localWinner.waitUntilReady();
+      options.replaceBot(localWinner);
+      return;
+    }
+    await promptCoordinator.activateBot(options.botId);
+    nextBot = new CatsCompanyBot(options.connectorConfig);
+    await nextBot.start();
+    await nextBot.waitUntilReady();
+    options.replaceBot(nextBot);
+    if (!service.markCloudDefinitionAppliedIfNoPending(options.botId, options.snapshot.revision)) {
+      // A local edit landed after the connector became ready. Keep that edit
+      // and the running connector, but do not claim the pure cloud revision was
+      // applied; the next poll will upload and apply the combined revision.
+      return;
+    }
+  } catch (error) {
+    if (nextBot) {
+      await nextBot.destroy().catch(() => undefined);
+    }
+    restoreFiles();
+    if (options.canApply()) {
+      const fallback = new CatsCompanyBot(options.connectorConfig);
+      await fallback.start();
+      await fallback.waitUntilReady();
+      options.replaceBot(fallback);
+    }
+    const message = redactBotDefinitionError(error, options.snapshot.definition);
+    await service.acknowledgeCloudDefinition(
+      options.botId,
+      options.snapshot.revision,
+      options.auth,
+      message,
+    ).catch(() => undefined);
+    throw new Error(message);
+  }
+
+  try {
+    await service.acknowledgeCloudDefinition(
+      options.botId,
+      options.snapshot.revision,
+      options.auth,
+    );
+  } catch (error) {
+    Logger.warning(
+      `CatsCo BotDefinition revision=${options.snapshot.revision} ACK 失败，`
+      + `新配置保持运行并等待重试: ${redactBotDefinitionError(error, options.snapshot.definition)}`,
+    );
+    return;
+  }
+  try {
+    service.clearCloudModelOverride(options.botId);
+    service.clearLegacyModelConfigurationWhenReady(options.snapshot.definition);
+  } catch (error) {
+    Logger.warning(
+      `CatsCo BotDefinition 已应用并 ACK，但清理旧配置失败: ${errorMessage(error)}`,
+    );
   }
 }
 

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -55,6 +55,7 @@ import { inferCatsUploadType, uploadCatsLocalFile } from '../../catscompany/uplo
 import { createCatsCoLocalConfigService } from '../../catscompany/local-config';
 import { catalogRuntimeMatchesModelId, createBotDefinitionSyncService } from '../../bot-definition/service';
 import { prepareBoundBotDefinition } from '../../bot-definition/activation';
+import { pullCloudBotDefinition } from '../../bot-definition/definition-client';
 import { getPromptReconcileCoordinator } from '../../bot-definition/prompt-sync';
 import {
   customModelDefinitionToConfig,
@@ -3348,6 +3349,53 @@ export function createApiRouter(
   });
 
   // ==================== CatsCo webapp 本地连接器 ====================
+
+  router.get('/bot-definition/conflict', (_req, res) => {
+    const local = createCatsCoLocalConfigService({ runtimeRoot: runtimeDataRoot() });
+    const auth = local.getAuthState();
+    const botId = String(auth.botUid || '').trim();
+    if (!botId) return res.status(409).json({ error: 'no_bound_bot' });
+    const pending = createBotDefinitionSyncService({ runtimeRoot: runtimeDataRoot() })
+      .readCloudState(botId).pendingPatch;
+    return res.json({
+      botId,
+      conflicted: pending?.status === 'conflicted',
+      expectedRevision: pending?.expectedRevision,
+      conflictRevision: pending?.conflictRevision,
+      changedFields: pending ? Object.keys(pending.changes) : [],
+    });
+  });
+
+  router.post('/bot-definition/conflict', async (req, res) => {
+    try {
+      const action = String(req.body?.action || '').trim();
+      if (action !== 'accept-cloud' && action !== 'keep-local') {
+        return res.status(400).json({ error: 'action must be accept-cloud or keep-local' });
+      }
+      const local = createCatsCoLocalConfigService({ runtimeRoot: runtimeDataRoot() });
+      const auth = local.getAuthState();
+      const botId = String(auth.botUid || '').trim();
+      if (!botId) return res.status(409).json({ error: 'no_bound_bot' });
+      const service = createBotDefinitionSyncService({ runtimeRoot: runtimeDataRoot() });
+      const pending = service.readCloudState(botId).pendingPatch;
+      if (!pending || pending.status !== 'conflicted') {
+        return res.status(409).json({ error: 'no_definition_conflict' });
+      }
+      const remote = await pullCloudBotDefinition({ botId, auth });
+      if (remote.kind !== 'found') {
+        return res.status(409).json({ error: 'cloud_definition_unavailable', state: remote.kind });
+      }
+      if (action === 'accept-cloud') {
+        service.discardPendingCloudPatch(botId, remote.snapshot, pending);
+        return res.json({ ok: true, action, revision: remote.snapshot.revision });
+      }
+      service.rebasePendingCloudPatch(botId, remote.snapshot.revision);
+      const committed = await service.flushPendingCloudPatch(botId, auth);
+      return res.json({ ok: true, action, revision: committed?.revision });
+    } catch (error: any) {
+      return res.status(409).json({ error: String(error?.message || error) });
+    }
+  });
 
   router.get('/cats/status', async (_req, res) => {
     const runtime = resolveCatsCoRuntimeConfig({

--- a/tests/bot-definition-activation.test.ts
+++ b/tests/bot-definition-activation.test.ts
@@ -15,6 +15,7 @@ import {
 } from '../src/bot-definition/repository';
 import { resolveActiveBotLLMConfig } from '../src/bot-definition/llm-config-resolver';
 import { BOT_DEFINITION_SCHEMA } from '../src/bot-definition/types';
+import { FileBotDefinitionCloudStateRepository } from '../src/bot-definition/cloud-state';
 
 describe('BotDefinition activation', () => {
   const roots: string[] = [];
@@ -96,6 +97,7 @@ describe('BotDefinition activation', () => {
     assert.equal(resolveActiveBotLLMConfig({ runtimeRoot, env })?.config.apiKey, 'sk-bravo-relay-material');
     assert.equal(env.CATSCO_RELAY_LLM_API_KEY, undefined);
     assert.deepStrictEqual(requests, [
+      'GET /api/bot/definition',
       'GET /api/bot/model-config',
       'GET /api/relay/config',
       'GET /api/relay/key',
@@ -711,5 +713,216 @@ describe('BotDefinition activation', () => {
     assert.deepStrictEqual(new FileBotCloudModelOverrideRepository({ runtimeRoot }).read('43')?.model, cloudModel);
     assert.equal(resolveActiveBotLLMConfig({ runtimeRoot, env })?.config.model, 'cloud-model');
     assert.equal(new FileBotCatalogModelRuntimeRepository({ runtimeRoot }).read('43'), undefined);
+  });
+
+  test('offline startup restores the last applied snapshot instead of a newer fetched snapshot', async () => {
+    const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-definition-offline-applied-'));
+    roots.push(runtimeRoot);
+    const env = {} as NodeJS.ProcessEnv;
+    createCatsCoLocalConfigService({ runtimeRoot, env }).save({
+      version: 1,
+      endpoints: { httpBaseUrl: 'https://cats.example.test', serverUrl: 'wss://cats.example.test/v0/channels' },
+      account: { token: 'user-token', uid: '7' },
+      currentBot: { uid: '43', apiKey: 'bot-api-key', boundByUserUid: '7', bindingSource: 'test' },
+    });
+    const applied = {
+      definition: {
+        schema: BOT_DEFINITION_SCHEMA,
+        botId: '43',
+        model: {
+          kind: 'custom' as const,
+          protocol: 'openai-chat-completions' as const,
+          apiBase: 'https://applied.example.test/v1',
+          model: 'applied-model',
+          apiKey: 'sk-applied',
+          contextWindowTokens: 128_000,
+        },
+        prompt: { selected: 'default' as const },
+      },
+      revision: 8,
+    };
+    const fetched = {
+      definition: {
+        ...applied.definition,
+        model: { ...applied.definition.model, model: 'not-yet-applied' },
+      },
+      revision: 9,
+    };
+    const cloudState = new FileBotDefinitionCloudStateRepository(runtimeRoot);
+    cloudState.recordSnapshot('43', applied);
+    cloudState.markApplied('43', 8);
+    cloudState.recordSnapshot('43', fetched);
+
+    const prepared = await prepareBoundBotDefinition({
+      runtimeRoot,
+      env,
+      fetchImpl: (async () => Response.json({ error: 'offline' }, { status: 503 })) as typeof fetch,
+    });
+
+    assert.equal(prepared?.definition.model.kind, 'custom');
+    assert.equal(prepared?.definition.model.kind === 'custom' && prepared.definition.model.model, 'applied-model');
+    assert.equal(resolveActiveBotLLMConfig({ runtimeRoot, env })?.config.model, 'applied-model');
+    assert.equal(prepared?.cloudDefinitionSnapshot?.revision, 8);
+  });
+
+  test('offline startup overlays durable local pending fields on the applied snapshot', async () => {
+    const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-definition-offline-pending-'));
+    roots.push(runtimeRoot);
+    const env = {} as NodeJS.ProcessEnv;
+    createCatsCoLocalConfigService({ runtimeRoot, env }).save({
+      version: 1,
+      endpoints: { httpBaseUrl: 'https://cats.example.test', serverUrl: 'wss://cats.example.test/v0/channels' },
+      account: { token: 'user-token', uid: '7' },
+      currentBot: { uid: '43', apiKey: 'bot-api-key', boundByUserUid: '7', bindingSource: 'test' },
+    });
+    const applied = {
+      definition: {
+        schema: BOT_DEFINITION_SCHEMA,
+        botId: '43',
+        model: {
+          kind: 'custom' as const,
+          protocol: 'openai-chat-completions' as const,
+          apiBase: 'https://applied.example.test/v1',
+          model: 'applied-model',
+          apiKey: 'sk-applied',
+          contextWindowTokens: 128_000,
+        },
+        prompt: { selected: 'custom' as const, customSystemPrompt: 'old prompt' },
+      },
+      revision: 8,
+    };
+    const cloudState = new FileBotDefinitionCloudStateRepository(runtimeRoot);
+    cloudState.recordSnapshot('43', applied);
+    cloudState.markApplied('43', 8);
+    cloudState.queuePatch('43', 8, {
+      prompt: { selected: 'custom', customSystemPrompt: 'offline local edit' },
+    });
+
+    const prepared = await prepareBoundBotDefinition({
+      runtimeRoot,
+      env,
+      fetchImpl: (async () => Response.json({ error: 'offline' }, { status: 503 })) as typeof fetch,
+    });
+
+    assert.deepStrictEqual(prepared?.definition.prompt, {
+      selected: 'custom',
+      customSystemPrompt: 'offline local edit',
+    });
+    assert.equal(prepared?.cloudDefinitionHasPendingLocal, true);
+    assert.equal(
+      new FileBotDefinitionRepository({ runtimeRoot }).readCache('43')?.prompt?.customSystemPrompt,
+      'offline local edit',
+    );
+    assert.equal(cloudState.read('43').pendingPatch?.status, 'pending');
+  });
+
+  test('a first-migration conflict stays on the Definition path without falling back to model-config', async () => {
+    const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-definition-first-conflict-'));
+    roots.push(runtimeRoot);
+    const env = {} as NodeJS.ProcessEnv;
+    createCatsCoLocalConfigService({ runtimeRoot, env }).save({
+      version: 1,
+      endpoints: { httpBaseUrl: 'https://cats.example.test', serverUrl: 'wss://cats.example.test/v0/channels' },
+      account: { token: 'user-token', uid: '7' },
+      currentBot: { uid: '43', apiKey: 'bot-api-key', boundByUserUid: '7', bindingSource: 'test' },
+    });
+    const localDefinition = {
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: '43',
+      model: {
+        kind: 'custom' as const,
+        protocol: 'openai-chat-completions' as const,
+        apiBase: 'https://local.example.test/v1',
+        model: 'local-pending-model',
+        apiKey: 'sk-local',
+        contextWindowTokens: 128_000,
+      },
+      prompt: { selected: 'default' as const },
+    };
+    new FileBotDefinitionRepository({ runtimeRoot }).writeCache(localDefinition);
+    const cloudState = new FileBotDefinitionCloudStateRepository(runtimeRoot);
+    cloudState.queuePatch('43', 0, { model: localDefinition.model, prompt: localDefinition.prompt });
+    cloudState.markPatchConflicted('43', 1);
+    cloudState.markDefinitionProtocolSeen('43');
+    const requests: string[] = [];
+
+    const prepared = await prepareBoundBotDefinition({
+      runtimeRoot,
+      env,
+      fetchImpl: (async input => {
+        requests.push(new URL(String(input)).pathname);
+        return Response.json({ error: 'unexpected request' }, { status: 500 });
+      }) as typeof fetch,
+    });
+
+    assert.equal(prepared?.cloudDefinitionManaged, true);
+    assert.equal(prepared?.cloudDefinitionSnapshot, undefined);
+    assert.equal(prepared?.definition.model.kind === 'custom' && prepared.definition.model.model, 'local-pending-model');
+    assert.equal(requests.includes('/api/bot/model-config'), false);
+  });
+
+  test('migration uses the server legacy model and only fills missing Definition fields locally', async () => {
+    const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-definition-legacy-model-'));
+    roots.push(runtimeRoot);
+    const env = {} as NodeJS.ProcessEnv;
+    createCatsCoLocalConfigService({ runtimeRoot, env }).save({
+      version: 1,
+      endpoints: { httpBaseUrl: 'https://cats.example.test', serverUrl: 'wss://cats.example.test/v0/channels' },
+      account: { token: 'user-token', uid: '7' },
+      currentBot: { uid: '43', apiKey: 'bot-api-key', boundByUserUid: '7', bindingSource: 'test' },
+    });
+    new FileBotDefinitionRepository({ runtimeRoot }).writeCanonical({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: '43',
+      model: {
+        kind: 'custom',
+        protocol: 'openai-chat-completions',
+        apiBase: 'https://local.example.test/v1',
+        model: 'local-model',
+        apiKey: 'sk-local',
+        contextWindowTokens: 128_000,
+      },
+      prompt: { selected: 'default' },
+    });
+    const legacyModel = {
+      kind: 'custom' as const,
+      protocol: 'openai-chat-completions' as const,
+      apiBase: 'https://legacy.example.test/v1',
+      model: 'legacy-cloud-model',
+      apiKey: 'sk-legacy',
+      contextWindowTokens: 128_000,
+    };
+    let patchedModel: unknown;
+    let runtimeReads = 0;
+    const fetchImpl = (async (input, init) => {
+      const url = new URL(String(input));
+      if (url.pathname === '/api/bot/definition' && (!init?.method || init.method === 'GET')) {
+        runtimeReads += 1;
+        if (runtimeReads === 1) {
+          return Response.json({ error: 'migration_required', legacy_model: legacyModel }, { status: 409 });
+        }
+        return Response.json({
+          definition: {
+            schema: BOT_DEFINITION_SCHEMA,
+            botId: '43',
+            model: legacyModel,
+            prompt: { selected: 'default' },
+          },
+          revision: 1,
+        });
+      }
+      if (url.pathname === '/api/bots/definition' && init?.method === 'PATCH') {
+        patchedModel = JSON.parse(String(init.body)).model;
+        return Response.json({ revision: 1 });
+      }
+      return Response.json({ error: 'unexpected request' }, { status: 500 });
+    }) as typeof fetch;
+
+    const prepared = await prepareBoundBotDefinition({ runtimeRoot, env, fetchImpl });
+    assert.deepStrictEqual(patchedModel, legacyModel);
+    assert.equal(
+      prepared?.definition.model.kind === 'custom' && prepared.definition.model.model,
+      'legacy-cloud-model',
+    );
   });
 });

--- a/tests/bot-definition-cloud-sync.test.ts
+++ b/tests/bot-definition-cloud-sync.test.ts
@@ -1,0 +1,328 @@
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import { FileBotDefinitionCloudStateRepository } from '../src/bot-definition/cloud-state';
+import {
+  acknowledgeCloudBotDefinition,
+  BotDefinitionRevisionConflictError,
+  patchCloudBotDefinition,
+  pullCloudBotDefinition,
+} from '../src/bot-definition/definition-client';
+import { BOT_DEFINITION_SCHEMA, type BotDefinition } from '../src/bot-definition/types';
+import { createBotDefinitionSyncService } from '../src/bot-definition/service';
+
+const auth = {
+  token: 'owner-token',
+  apiKey: 'bot-api-key',
+  httpBaseUrl: 'https://app.example.test',
+  serverUrl: 'wss://app.example.test/v0/channels',
+};
+
+const definition: BotDefinition = {
+  schema: BOT_DEFINITION_SCHEMA,
+  botId: '43',
+  model: {
+    kind: 'custom',
+    protocol: 'openai-chat-completions',
+    apiBase: 'https://models.example.test/v1',
+    model: 'portable-model',
+    apiKey: 'sk-runtime-only',
+    contextWindowTokens: 128000,
+    reasoningEffort: 'high',
+  },
+  savedCustomModel: {
+    kind: 'custom',
+    protocol: 'openai-chat-completions',
+    apiBase: 'https://models.example.test/v1',
+    model: 'portable-model',
+    apiKey: 'sk-runtime-only',
+    contextWindowTokens: 128000,
+    reasoningEffort: 'high',
+  },
+  prompt: { selected: 'custom', customSystemPrompt: 'You are portable.' },
+};
+
+describe('CatsCo BotDefinition cloud contract', () => {
+  test('runtime GET validates a complete model and prompt snapshot', async () => {
+    const result = await pullCloudBotDefinition({
+      botId: '43',
+      auth,
+      fetchImpl: (async (url, init) => {
+        assert.equal(String(url), 'https://app.example.test/api/bot/definition');
+        assert.equal((init?.headers as Record<string, string>).Authorization, 'ApiKey bot-api-key');
+        return Response.json({ definition, revision: 8, updatedAt: '2026-07-28T00:00:00Z' });
+      }) as typeof fetch,
+    });
+    assert.equal(result.kind, 'found');
+    if (result.kind === 'found') {
+      assert.equal(result.snapshot.revision, 8);
+      assert.deepStrictEqual(result.snapshot.definition, definition);
+    }
+  });
+
+  test('missing Definition is distinct from an unsupported server', async () => {
+    const migration = await pullCloudBotDefinition({
+      botId: '43',
+      auth,
+      fetchImpl: (async () => Response.json({
+        error: 'migration_required',
+        legacy_model: { kind: 'catalog', modelId: 'minimax-m3' },
+      }, { status: 409 })) as typeof fetch,
+    });
+    assert.deepStrictEqual(migration, {
+      kind: 'migration_required',
+      legacyModel: { kind: 'catalog', modelId: 'minimax-m3' },
+    });
+
+    const unsupported = await pullCloudBotDefinition({
+      botId: '43',
+      auth,
+      fetchImpl: (async () => Response.json({ error: 'not found' }, { status: 404 })) as typeof fetch,
+    });
+    assert.deepStrictEqual(unsupported, { kind: 'unsupported' });
+  });
+
+  test('owner PATCH sends a field patch with expected revision and surfaces conflicts', async () => {
+    let captured: any;
+    const snapshot = await patchCloudBotDefinition({
+      botId: '43',
+      auth,
+      fetchImpl: (async (url, init) => {
+        if (String(url).endsWith('/api/bot/definition')) {
+          return Response.json({
+            definition: { ...definition, prompt: { selected: 'default', customSystemPrompt: 'You are portable.' } },
+            revision: 9,
+          });
+        }
+        assert.equal((init?.headers as Record<string, string>).Authorization, 'Bearer owner-token');
+        captured = JSON.parse(String(init?.body));
+        return Response.json({
+          definition: { ...definition, prompt: { selected: 'default', customSystemPrompt: 'You are portable.' } },
+          revision: 9,
+        });
+      }) as typeof fetch,
+    }, 8, { prompt: { selected: 'default', customSystemPrompt: 'You are portable.' } });
+    assert.equal(snapshot.revision, 9);
+    assert.deepStrictEqual(captured, {
+      expected_revision: 8,
+      prompt: { selected: 'default', customSystemPrompt: 'You are portable.' },
+    });
+
+    await assert.rejects(
+      patchCloudBotDefinition({
+        botId: '43',
+        auth,
+        fetchImpl: (async () => Response.json({
+          error: 'revision_conflict',
+          current_revision: 12,
+        }, { status: 409 })) as typeof fetch,
+      }, 8, { prompt: { selected: 'default' } }),
+      (error: unknown) => error instanceof BotDefinitionRevisionConflictError
+        && error.currentRevision === 12,
+    );
+  });
+
+  test('ACK uses bot credentials and the exact full Definition revision', async () => {
+    let captured: any;
+    await acknowledgeCloudBotDefinition({
+      botId: '43',
+      auth,
+      fetchImpl: (async (_url, init) => {
+        assert.equal((init?.headers as Record<string, string>).Authorization, 'ApiKey bot-api-key');
+        captured = JSON.parse(String(init?.body));
+        return Response.json({ ok: true });
+      }) as typeof fetch,
+    }, 9, 'prompt materialization failed');
+    assert.deepStrictEqual(captured, { revision: 9, error: 'prompt materialization failed' });
+  });
+});
+
+describe('BotDefinition local durable cloud state', () => {
+  let runtimeRoot: string;
+
+  beforeEach(() => {
+    runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'bot-definition-cloud-state-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(runtimeRoot, { recursive: true, force: true });
+  });
+
+  test('merges local field patches and preserves conflicts without auto-merge', () => {
+    const repository = new FileBotDefinitionCloudStateRepository(runtimeRoot);
+    repository.recordSnapshot('43', { definition, revision: 8 });
+    repository.queuePatch('43', 8, {
+      model: { kind: 'catalog', modelId: 'minimax-m3' },
+    });
+    repository.queuePatch('43', 8, {
+      prompt: { selected: 'default', customSystemPrompt: 'You are portable.' },
+    });
+    repository.markPatchConflicted('43', 9);
+
+    const state = repository.read('43');
+    assert.equal(state.pendingPatch?.expectedRevision, 8);
+    assert.equal(state.pendingPatch?.status, 'conflicted');
+    assert.equal(state.pendingPatch?.conflictRevision, 9);
+    assert.deepStrictEqual(state.pendingPatch?.changes.model, { kind: 'catalog', modelId: 'minimax-m3' });
+    assert.deepStrictEqual(state.pendingPatch?.changes.prompt, {
+      selected: 'default',
+      customSystemPrompt: 'You are portable.',
+    });
+  });
+
+  test('persists fetched, applied and pending ACK states independently', () => {
+    const repository = new FileBotDefinitionCloudStateRepository(runtimeRoot);
+    repository.recordSnapshot('43', { definition, revision: 8 });
+    repository.markApplied('43', 7);
+    repository.queueAck('43', 7);
+
+    let state = new FileBotDefinitionCloudStateRepository(runtimeRoot).read('43');
+    assert.equal(state.snapshot?.revision, 8);
+    assert.equal(state.appliedRevision, 7);
+    assert.equal(state.pendingAck?.revision, 7);
+
+    repository.clearAck('43', 7);
+    state = repository.read('43');
+    assert.equal(state.pendingAck, undefined);
+    assert.equal(state.snapshot?.revision, 8);
+    assert.equal(state.appliedRevision, 7);
+  });
+
+  test('promotes only the exact fetched revision to the offline applied snapshot', () => {
+    const repository = new FileBotDefinitionCloudStateRepository(runtimeRoot);
+    repository.recordSnapshot('43', { definition, revision: 8 });
+    repository.markApplied('43', 8);
+    repository.recordSnapshot('43', {
+      definition: { ...definition, prompt: { selected: 'default' } },
+      revision: 9,
+    });
+
+    const state = repository.read('43');
+    assert.equal(state.snapshot?.revision, 9);
+    assert.equal(state.appliedRevision, 8);
+    assert.equal(state.appliedSnapshot?.revision, 8);
+    assert.deepStrictEqual(state.appliedSnapshot?.definition.prompt, definition.prompt);
+  });
+
+  test('requires an explicit rebase before retrying a conflicted local patch', () => {
+    const repository = new FileBotDefinitionCloudStateRepository(runtimeRoot);
+    repository.queuePatch('43', 8, { prompt: { selected: 'default' } });
+    repository.markPatchConflicted('43', 9);
+    const oldKey = repository.read('43').pendingPatch?.idempotencyKey;
+
+    const rebased = repository.rebasePatch('43', 9);
+    assert.equal(rebased?.status, 'pending');
+    assert.equal(rebased?.expectedRevision, 9);
+    assert.equal(rebased?.conflictRevision, undefined);
+    assert.notEqual(rebased?.idempotencyKey, oldKey);
+    assert.deepStrictEqual(rebased?.changes.prompt, { selected: 'default' });
+  });
+
+  test('keeps edits made while an older field patch is in flight', () => {
+    const repository = new FileBotDefinitionCloudStateRepository(runtimeRoot);
+    const submitted = repository.queuePatch('43', 8, {
+      model: { kind: 'catalog', modelId: 'minimax-m3' },
+    });
+    repository.queuePatch('43', 8, {
+      prompt: { selected: 'default' },
+    });
+
+    repository.completePatch('43', submitted, 9);
+    const pending = repository.read('43').pendingPatch;
+    assert.equal(pending?.expectedRevision, 9);
+    assert.equal(pending?.changes.model, undefined);
+    assert.deepStrictEqual(pending?.changes.prompt, { selected: 'default' });
+    assert.notEqual(pending?.idempotencyKey, submitted.idempotencyKey);
+  });
+
+  test('does not discard a conflict if its local changes moved during resolution', () => {
+    const repository = new FileBotDefinitionCloudStateRepository(runtimeRoot);
+    repository.queuePatch('43', 8, { prompt: { selected: 'default' } });
+    repository.markPatchConflicted('43', 9);
+    const reviewed = repository.read('43').pendingPatch!;
+    repository.queuePatch('43', 8, {
+      prompt: { selected: 'custom', customSystemPrompt: 'newer local edit' },
+    });
+
+    const accepted = repository.acceptCloudAndClearConflict(
+      '43',
+      reviewed,
+      { definition, revision: 9 },
+    );
+    assert.equal(accepted, false);
+    assert.equal(
+      repository.read('43').pendingPatch?.changes.prompt?.customSystemPrompt,
+      'newer local edit',
+    );
+  });
+
+  test('quarantines malformed durable state instead of silently deleting it', () => {
+    const repository = new FileBotDefinitionCloudStateRepository(runtimeRoot);
+    const stateRoot = path.join(runtimeRoot, 'data', 'bot-definition-cloud-state');
+    fs.mkdirSync(stateRoot, { recursive: true });
+    fs.writeFileSync(path.join(stateRoot, '43.json'), '{broken', 'utf-8');
+
+    assert.equal(repository.read('43').snapshot, undefined);
+    assert.equal(
+      fs.readdirSync(stateRoot).some(name => name.startsWith('43.json.corrupt-')),
+      true,
+    );
+  });
+
+  test('recovers a lost PATCH response when the committed cloud fields already match', async () => {
+    const service = createBotDefinitionSyncService({ runtimeRoot });
+    service.acceptCloudDefinition({ definition, revision: 8 });
+    service.promoteCloudDefinition({ definition, revision: 8 });
+    service.updatePrompt('43', { selected: 'default' });
+    const committed = {
+      ...definition,
+      prompt: { selected: 'default' as const },
+    };
+    const snapshot = await service.flushPendingCloudPatch(
+      '43',
+      auth,
+      (async (input, init) => {
+        const url = new URL(String(input));
+        if (url.pathname === '/api/bots/definition' && init?.method === 'PATCH') {
+          return Response.json({ error: 'revision_conflict', current_revision: 9 }, { status: 409 });
+        }
+        if (url.pathname === '/api/bot/definition') {
+          return Response.json({ definition: committed, revision: 9 });
+        }
+        return Response.json({ error: 'unexpected request' }, { status: 500 });
+      }) as typeof fetch,
+    );
+    assert.equal(snapshot?.revision, 9);
+    assert.equal(service.readCloudState('43').pendingPatch, undefined);
+  });
+
+  test('does not mark or ACK a cloud revision after a concurrent local edit', () => {
+    const service = createBotDefinitionSyncService({ runtimeRoot });
+    service.acceptCloudDefinition({ definition, revision: 8 });
+
+    assert.equal(service.markCloudDefinitionAppliedIfNoPending('43', 8), true);
+    assert.equal(service.readCloudState('43').appliedRevision, 8);
+
+    const revision9 = {
+      ...definition,
+      prompt: { selected: 'default' as const },
+    };
+    assert.equal(
+      service.commitCloudDefinitionIfNoPending({ definition: revision9, revision: 9 }),
+      true,
+    );
+    service.updatePrompt('43', {
+      selected: 'custom',
+      customSystemPrompt: 'concurrent local edit',
+    });
+
+    assert.equal(service.markCloudDefinitionAppliedIfNoPending('43', 9), false);
+    assert.equal(service.readCloudState('43').appliedRevision, 8);
+    assert.equal(
+      service.readCloudState('43').pendingPatch?.changes.prompt?.customSystemPrompt,
+      'concurrent local edit',
+    );
+  });
+});

--- a/tests/bot-definition-local-repository.test.ts
+++ b/tests/bot-definition-local-repository.test.ts
@@ -143,6 +143,41 @@ describe('BotDefinition local simulation', () => {
     assert.deepStrictEqual(repository.readCache('bot-alpha'), canonical);
   });
 
+  test('bound cloud mode keeps a verified remote cache above the migration-only simulated canonical', () => {
+    const localConfig = createCatsCoLocalConfigService({ runtimeRoot, env: {} as NodeJS.ProcessEnv });
+    localConfig.save({
+      version: 1,
+      account: { uid: 'user-alpha', token: 'owner-token' },
+      currentBot: {
+        uid: 'bot-alpha',
+        apiKey: 'bot-api-key',
+        boundByUserUid: 'user-alpha',
+        bindingSource: 'test',
+      },
+    });
+    const repository = new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot });
+    const simulated: BotDefinition = {
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-alpha',
+      model: { kind: 'catalog', modelId: 'minimax-m2.7' },
+      prompt: { selected: 'default' },
+    };
+    const remote: BotDefinition = {
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-alpha',
+      model: { kind: 'catalog', modelId: 'minimax-m3' },
+      prompt: { selected: 'custom', customSystemPrompt: 'remote prompt' },
+    };
+    repository.writeCanonical(simulated);
+    repository.writeCache(remote);
+
+    const service = createBotDefinitionSyncService({ runtimeRoot, simulatedCloudRoot });
+    assert.deepStrictEqual(service.pull('bot-alpha'), remote);
+    service.updatePrompt('bot-alpha', { selected: 'custom', customSystemPrompt: 'local pending prompt' });
+    assert.deepStrictEqual(repository.readCanonical('bot-alpha'), simulated);
+    assert.equal(repository.readCache('bot-alpha')?.prompt?.customSystemPrompt, 'local pending prompt');
+  });
+
   test('pull preserves the previous custom profile outside the active Definition and runtime roots stay isolated', () => {
     const repository = new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot });
     const customModel = {
@@ -431,7 +466,7 @@ describe('BotDefinition local simulation', () => {
     assert.equal(resolveActiveBotLLMConfig({ runtimeRoot, env }), undefined);
   });
 
-  test('captures legacy model settings once, then removes only model keys', () => {
+  test('captures legacy model settings but keeps them until cloud apply is acknowledged', () => {
     bindCurrentBot();
     const configPath = path.join(runtimeRoot, 'legacy-config.json');
     fs.writeFileSync(path.join(runtimeRoot, '.env'), [
@@ -470,11 +505,11 @@ describe('BotDefinition local simulation', () => {
     }
     const envContents = fs.readFileSync(path.join(runtimeRoot, '.env'), 'utf-8');
     assert.match(envContents, /CATSCO_USER_TOKEN=user-token-must-remain/);
-    assert.doesNotMatch(envContents, /CATSCO_(MODEL_SOURCE|CUSTOM_LLM_)|GAUZ_LLM_/);
-    assert.equal(env.CATSCO_CUSTOM_LLM_API_KEY, undefined);
+    assert.match(envContents, /CATSCO_CUSTOM_LLM_API_KEY=sk-portable/);
+    assert.equal(env.CATSCO_CUSTOM_LLM_API_KEY, 'sk-portable');
     const cleanedConfig = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    assert.equal(cleanedConfig.apiKey, undefined);
-    assert.equal(cleanedConfig.model, undefined);
+    assert.equal(cleanedConfig.apiKey, 'stale-config-key');
+    assert.equal(cleanedConfig.model, 'stale-config-model');
     assert.deepStrictEqual(cleanedConfig.catscompany, { enabled: true });
   });
 });

--- a/tests/dashboard-catsco-auth-status.test.ts
+++ b/tests/dashboard-catsco-auth-status.test.ts
@@ -1280,7 +1280,7 @@ describe('dashboard CatsCo account status', () => {
     const data = JSON.parse(text) as any;
     const env = dotenv.parse(fs.readFileSync(path.join(testRoot, '.env'), 'utf-8'));
     const runtime = new FileBotCatalogModelRuntimeRepository({ runtimeRoot: testRoot }).read('188');
-    const definition = definitionRepository.readCanonical('188');
+    const definition = definitionRepository.readCache('188');
     const resolved = resolveActiveBotLLMConfig({ runtimeRoot: testRoot });
 
     assert.equal(response.status, 200, text);
@@ -1410,7 +1410,7 @@ describe('dashboard CatsCo account status', () => {
     const text = await response.text();
     const data = JSON.parse(text) as any;
     const runtime = new FileBotCatalogModelRuntimeRepository({ runtimeRoot: testRoot }).read('188');
-    const definition = definitionRepository.readCanonical('188');
+    const definition = definitionRepository.readCache('188');
     const resolved = resolveActiveBotLLMConfig({ runtimeRoot: testRoot });
 
     assert.equal(response.status, 200, text);
@@ -1529,6 +1529,60 @@ describe('dashboard CatsCo account status', () => {
     assert.equal(response.status, 502);
     assert.match(data.error, /CatsCo\/CatsCompany 服务/);
     assert.equal(data.data.host, '127.0.0.1:9');
+  });
+
+  test('BotDefinition conflict API exposes no secrets and can explicitly accept cloud', async () => {
+    const cloudDefinition = {
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: '43',
+      model: {
+        kind: 'custom' as const,
+        protocol: 'openai-chat-completions' as const,
+        apiBase: 'https://models.example.test/v1',
+        model: 'cloud-model',
+        apiKey: 'sk-cloud-secret',
+        contextWindowTokens: 128_000,
+      },
+      prompt: { selected: 'default' as const },
+    };
+    await startCatsServer((req, res) => {
+      if (req.path === '/api/bot/definition' && req.method === 'GET') {
+        return res.json({ definition: cloudDefinition, revision: 9 });
+      }
+      return res.status(404).json({ error: 'not found' });
+    });
+    createCatsCoLocalConfigService({ runtimeRoot: testRoot }).save({
+      version: 1,
+      endpoints: { httpBaseUrl: catsBaseUrl, serverUrl: 'ws://127.0.0.1/v0/channels' },
+      account: { token: 'owner-token', uid: '7' },
+      currentBot: { uid: '43', apiKey: 'bot-api-key', boundByUserUid: '7', bindingSource: 'test' },
+    });
+    const service = createBotDefinitionSyncService({ runtimeRoot: testRoot });
+    service.promoteCloudDefinition({ definition: cloudDefinition, revision: 8 });
+    service.markCloudDefinitionApplied('43', 8);
+    service.updatePrompt('43', { selected: 'custom', customSystemPrompt: 'local edit' });
+    const cloudStatePath = path.join(testRoot, 'data', 'bot-definition-cloud-state', '43.json');
+    const cloudState = JSON.parse(fs.readFileSync(cloudStatePath, 'utf-8'));
+    cloudState.pendingPatch.status = 'conflicted';
+    cloudState.pendingPatch.conflictRevision = 9;
+    fs.writeFileSync(cloudStatePath, `${JSON.stringify(cloudState, null, 2)}\n`);
+
+    const status = await fetch(`${dashboardBaseUrl}/api/bot-definition/conflict`);
+    const statusText = await status.text();
+    assert.equal(status.status, 200, statusText);
+    assert.equal(statusText.includes('sk-cloud-secret'), false);
+    assert.deepStrictEqual(JSON.parse(statusText).changedFields, ['prompt']);
+
+    const resolved = await fetch(`${dashboardBaseUrl}/api/bot-definition/conflict`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'accept-cloud' }),
+    });
+    const resolvedText = await resolved.text();
+    assert.equal(resolved.status, 200, resolvedText);
+    assert.equal(resolvedText.includes('sk-cloud-secret'), false);
+    assert.equal(service.readCloudState('43').pendingPatch, undefined);
+    assert.equal(service.readCloudState('43').snapshot?.revision, 9);
   });
 
   async function startCatsServer(handler: express.RequestHandler): Promise<void> {


### PR DESCRIPTION
## ⚠️ 审阅说明

这是完整 BotDefinition 云同步链路中的 **XiaoBa Runtime 部分**，当前仅用于团队对齐和代码审查。

- 请暂时不要合并，也不要发布新版 XiaoBa。
- 配套 CatsCo 后端 Draft PR：[buildsense-ai/cats-company#118](https://github.com/buildsense-ai/cats-company/pull/118)。
- 两个 PR 需要一起审阅；CatsCo 提供云端契约，XiaoBa 实现 Local / Base / Cloud 同步和运行时应用。

## 为什么要做

模型选择、私有模型和 Prompt 目前主要由本地 Dashboard 管理。为了后续把配置入口迁移到 WebApp，需要让 XiaoBa 能够可靠地：

- 拉取 Bot 所属的云端 Definition。
- 在本地修改后上传字段级变更。
- 离线时继续使用最后成功应用的配置。
- 避免本地修改被云端覆盖。
- 在模型、Prompt 和连接器都真正准备完成后 ACK 精确 revision。

当前阶段仍保留 Dashboard，不迁移 SkillHub，也不增加完整 WebApp 页面。

## 同步语义

XiaoBa 为每个 Bot 维护 Local / Base / Cloud 三个状态：

- **Local**：当前本地有效配置，以及尚未上传的本地修改。
- **Base**：上一次已经确认的云端基线/映射。
- **Cloud**：服务端最新 BotDefinition revision。

主要判断规则：

1. `Local == Base` 且 `Cloud == Base`：不处理。
2. `Local == Base` 且 `Cloud != Base`：下载并应用 Cloud。
3. `Local != Base`：优先保护 Local，上传字段级 PATCH。
4. Local 与 Cloud 同时变化：不自动合并、不静默覆盖，进入显式冲突状态。
5. 本地工作区不存在：由 Cloud 恢复。
6. 本地状态无法读取：停止同步并报告错误，不假装恢复成功。

离线时以最后成功应用的 snapshot 为运行基线，再叠加 durable pending patch；仅拉取但尚未成功应用的 Cloud 不会成为离线配置。

## 本 PR 做了什么

### 1. BotDefinition 类型与真实云端客户端

- 使用 `xiaoba.bot-definition.v1`。
- `botId` 使用 CatsCo `bot_uid` 的十进制字符串。
- 支持目录模型、私有模型、保存的私有模型和 Prompt。
- Owner PATCH 使用 Bearer Token；Runtime GET/ACK 使用 Bot API Key。
- PATCH 后重新通过 Runtime GET 验证实际提交的完整 revision，避免使用 Owner 脱敏响应作为运行配置。

### 2. 每 Bot 的持久同步状态

新增独立的 durable cloud state，记录：

- 最新 fetched snapshot。
- 最后成功 applied snapshot/revision。
- pending field patch。
- pending ACK。
- revision conflict。
- 是否已经确认服务端支持 Definition 协议。

状态写入具有：

- 进程内及跨进程写锁。
- 原子更新。
- 损坏文件隔离，而不是静默删除。
- 稳定 Definition 身份，不依赖临时路径判断归属。

### 3. 本地修改上传

Dashboard 修改模型或 Prompt 时：

1. 先持久化 pending patch，确保异常退出后不会丢失。
2. 再更新本地有效 cache。
3. 在线时按 `expected_revision` 上传。
4. 上传成功后只清除本次已经提交的字段；上传期间产生的新修改继续保留。
5. PATCH 响应丢失时，通过拉取 Cloud 并精确比较字段判断是否已成功提交。

### 4. 云端下载与运行时应用

- 先拉取并校验完整 Definition。
- 在不影响当前连接器的前提下预备模型和 Prompt。
- 新连接器 ready 后才切换运行实例。
- 应用成功后才标记 applied revision 并 ACK。
- ACK 失败不会回滚已经运行成功的新连接器，而是持久化 pending ACK 等待重试。
- 清理旧兼容配置属于 best effort，不参与主事务回滚。

### 5. Local 优先和并发安全

热更新过程中增加多处 CAS/锁检查：

- Cloud staging 期间出现本地修改时，不覆盖 Local。
- 新连接器启动前再次确认 pending 状态。
- 新连接器 ready 后，在 Definition 锁内再次确认 snapshot revision 与 pending；只有 CAS 成功才 mark applied/ACK。
- `accept-cloud` 在同一锁内比较用户审阅过的完整 pending patch，避免冲突解决期间误删更新后的本地修改。

### 6. 显式冲突处理接口

Dashboard 增加：

- `GET /api/bot-definition/conflict`
  - 只返回 Bot、revision 和变更字段，不泄漏私有模型密钥。
- `POST /api/bot-definition/conflict`
  - `accept-cloud`：显式丢弃已审阅的本地冲突并接受 Cloud。
  - `keep-local`：显式把本地修改 rebase 到确认后的 Cloud revision，再重新上传。

当前只提供后端接口，不新增 UI。

### 7. 迁移与兼容

- 服务端返回 `migration_required` 时，优先采用服务端已有 legacy model，本地只补齐缺少的 Prompt。
- 不让首次迁移冲突退回旧 `/model-config` 轮询。
- 未支持 Definition 的旧服务端仍可走原有 model-config 兼容路径。
- 旧 cloud model override 只有在完整 Definition 成功 ACK 后才清理。

## 明确不包含

- SkillHub 或 Skill 目录同步。
- Bot 与 Skill 云端绑定。
- 完整 WebApp BotDefinition UI。
- 删除 Dashboard 现有模型、Prompt 或 Skill 功能。
- 生产部署与自动数据迁移。

## 验证结果

### 自动化测试

- 定向 BotDefinition/Activation/Dashboard 回归：69 项全部通过。
- XiaoBa Runtime 全量：1206 项测试；1202 通过、0 失败、4 跳过。
- `npm run build`：通过。
- 两轮独立架构与并发审阅：未发现剩余 P0/P1。

### 真实跨仓 E2E

配合 [buildsense-ai/cats-company#118](https://github.com/buildsense-ai/cats-company/pull/118)，在测试服务器建立完全隔离的 CatsCo/MySQL 测试栈，并由本机当前 XiaoBa 分支通过 SSH 隧道调用真实后端：

1. 拉取新 Bot 默认 Definition revision 1。
2. 本地修改 Prompt，并由 durable pending PATCH 上传到 revision 2。
3. 标记 applied 并 ACK revision 2。
4. 上传私有模型并拉取运行密钥到 revision 3。
5. 制造并识别 revision 4 并发冲突，本地修改保持有效。
6. 显式选择接受 Cloud，冲突状态清除。

服务端同时验证：Owner 响应不含 API Key 明文，数据库明文命中为 0，密文存在。

## 建议重点审阅

1. Local / Base / Cloud 的语义是否与产品预期一致。
2. 离线时使用 applied snapshot + pending overlay 是否合理。
3. Local/Cloud 双变时“停止自动覆盖、显式解决”的边界是否足够清楚。
4. 热更新的 staging、connector ready、mark applied、ACK 顺序是否正确。
5. pending patch / pending ACK 的崩溃恢复语义是否完整。
6. 首次迁移和旧 model-config fallback 是否影响现有用户。
7. Dashboard 冲突接口的信息是否足够，同时是否避免泄漏密钥。

## 推荐审阅顺序

1. 先审 [buildsense-ai/cats-company#118](https://github.com/buildsense-ai/cats-company/pull/118)，确认数据模型和 HTTP 契约。
2. 再审本 PR 的 cloud client 与 durable state。
3. 最后审 activation / connector 热更新 / Dashboard 冲突接口。

## 下一步

- 根据两个 Draft PR 的评论继续在当前分支修正并补充测试。
- 两边审阅完成后再决定合并；当前建议先合并 CatsCo 后端，再合并 XiaoBa Runtime。
- 合并后先走隔离测试环境和人工确认，再安排生产发布。
