### PR TITLE
feat: 对接 CatsCompany 云端 BotDefinition

### DIFF
--- a/src/bot-definition/activation.ts
+++ b/src/bot-definition/activation.ts
@@ -72,10 +72,7 @@ export async function prepareBoundBotDefinition(
 
   if (!options.cloudSelection) {
     try {
-      const pending = cloudDefinitionSync.readState(botId);
-      let cloudSnapshot = pending.pendingModel || pending.pendingPrompt
-        ? await cloudDefinitionSync.flushPending(botId, auth)
-        : await cloudDefinitionSync.pull(botId, auth);
+      let cloudSnapshot = await cloudDefinitionSync.reconcileStartup(botId, auth);
       if (cloudSnapshot) {
         if (selectedCatalogRuntime) {
           definitionService.storeCatalogRuntime(selectedCatalogRuntime);
@@ -147,7 +144,7 @@ export async function prepareBoundBotDefinition(
           env: options.env,
           definitionService,
         });
-        await promptCoordinator.activateBot(botId);
+        await promptCoordinator.activateBot(botId, { preferDefinition: true });
         definition = definitionService.read(botId)!;
         if (!cloudSnapshot.definition?.prompt && definition.prompt) {
           cloudDefinitionSync.markPromptPending(botId);

--- a/src/bot-definition/activation.ts
+++ b/src/bot-definition/activation.ts
@@ -13,11 +13,14 @@ import {
 import type { BotCatalogModelRuntime, BotDefinition, BotDefinitionSyncResult } from './types';
 import { getPromptReconcileCoordinator } from './prompt-sync';
 import {
+  acknowledgeCloudBotDefinition,
   acknowledgeCloudBotModelSelection,
+  pullLegacyCloudBotModelSelection,
   pullCloudBotModelSelection,
   redactCloudBotModelError,
   type CloudBotModelSelection,
 } from './cloud-client';
+import { createBotDefinitionCloudSyncService } from './cloud-sync';
 
 export interface PrepareBoundBotDefinitionOptions extends BotDefinitionSyncServiceOptions {
   runtimeRoot: string;
@@ -58,10 +61,144 @@ export async function prepareBoundBotDefinition(
   }
   let sync = definitionService.pullOrBootstrap(botId);
   let localDefinition = sync?.definition;
+  let initializedDefaultFromEmpty = false;
+  const auth = options.auth ?? createCatsCoLocalConfigService({ runtimeRoot: options.runtimeRoot }).getAuthState();
+  const cloudDefinitionSync = createBotDefinitionCloudSyncService({
+    runtimeRoot: options.runtimeRoot,
+    env: options.env,
+    definitionService,
+    fetchImpl: options.fetchImpl,
+  });
+
+  if (!options.cloudSelection) {
+    try {
+      const pending = cloudDefinitionSync.readState(botId);
+      let cloudSnapshot = pending.pendingModel || pending.pendingPrompt
+        ? await cloudDefinitionSync.flushPending(botId, auth)
+        : await cloudDefinitionSync.pull(botId, auth);
+      if (cloudSnapshot) {
+        if (selectedCatalogRuntime) {
+          definitionService.storeCatalogRuntime(selectedCatalogRuntime);
+          sync = definitionService.updateModel(botId, {
+            kind: 'catalog',
+            modelId: selectedCatalogRuntime.modelId,
+          });
+          cloudDefinitionSync.markModelPending(botId);
+          cloudSnapshot = await cloudDefinitionSync.pushModel(botId, auth, sync.definition.model)
+            ?? cloudSnapshot;
+        }
+
+        if (!cloudSnapshot.configured) {
+          localDefinition = definitionService.read(botId) ?? definitionService.pullOrBootstrap(botId)?.definition;
+          if (!localDefinition) {
+            const runtime = await provisionCatsRelayCatalogRuntime({
+              botId,
+              modelId: DEFAULT_CATSCO_RELAY_MODEL_ID,
+              auth,
+              fetchImpl: options.fetchImpl,
+            });
+            definitionService.storeCatalogRuntime(runtime);
+            sync = definitionService.updateModel(botId, {
+              kind: 'catalog',
+              modelId: DEFAULT_CATSCO_RELAY_MODEL_ID,
+            });
+            localDefinition = sync.definition;
+            initializedDefaultFromEmpty = true;
+          }
+          await getPromptReconcileCoordinator({
+            runtimeRoot: options.runtimeRoot,
+            env: options.env,
+            definitionService,
+          }).activateBot(botId);
+          const migrated = definitionService.read(botId)!;
+          cloudDefinitionSync.markModelPending(botId);
+          await cloudDefinitionSync.pushModel(botId, auth, migrated.model);
+          if (migrated.prompt) {
+            cloudDefinitionSync.markPromptPending(botId);
+            cloudSnapshot = await cloudDefinitionSync.pushPrompt(botId, auth, migrated.prompt)
+              ?? cloudSnapshot;
+          }
+          cloudSnapshot = await cloudDefinitionSync.pull(botId, auth) ?? cloudSnapshot;
+        }
+
+        let definition = definitionService.read(botId);
+        if (!definition) throw new Error('CatsCo cloud BotDefinition did not produce a local cache.');
+        definitionService.clearCloudModelOverride(botId);
+        let materializedCatalogRuntime = false;
+        if (definition.model.kind === 'catalog') {
+          const runtime = definitionService.readCatalogRuntime(botId);
+          if (!runtime || !catalogRuntimeMatchesModelId(runtime, definition.model.modelId)) {
+            const materialized = await provisionCatsRelayCatalogRuntime({
+              botId,
+              modelId: definition.model.modelId,
+              reasoningEffort: definition.model.reasoningEffort,
+              auth,
+              fetchImpl: options.fetchImpl,
+            });
+            definitionService.storeCatalogRuntime(materialized);
+            materializedCatalogRuntime = true;
+          } else if (catalogCapabilitiesNeedRefresh(runtime)) {
+            const refreshed = await refreshCatsRelayCatalogRuntimeCapabilities(runtime, options.fetchImpl ?? fetch);
+            if (refreshed !== runtime) definitionService.storeCatalogRuntime(refreshed);
+          }
+        }
+        const promptCoordinator = getPromptReconcileCoordinator({
+          runtimeRoot: options.runtimeRoot,
+          env: options.env,
+          definitionService,
+        });
+        await promptCoordinator.activateBot(botId);
+        definition = definitionService.read(botId)!;
+        if (!cloudSnapshot.definition?.prompt && definition.prompt) {
+          cloudDefinitionSync.markPromptPending(botId);
+          cloudSnapshot = await cloudDefinitionSync.pushPrompt(botId, auth, definition.prompt)
+            ?? cloudSnapshot;
+        }
+        definitionService.clearLegacyModelConfigurationWhenReady(definition);
+        if (options.acknowledgeCloudSelection !== false && cloudSnapshot.configured) {
+          try {
+            await acknowledgeCloudBotDefinition(
+              { botId, auth, fetchImpl: options.fetchImpl },
+              cloudSnapshot.revision,
+            );
+          } catch (error) {
+            Logger.warning(`CatsCo BotDefinition apply acknowledgement failed: ${errorMessage(error)}`);
+          }
+        }
+        return {
+          botId,
+          definition,
+          sync,
+          initializedDefault: initializedDefaultFromEmpty,
+          materializedCatalogRuntime,
+          cloudRevision: cloudSnapshot.revision,
+          cloudSelection: definition.model.kind === 'custom'
+            ? {
+              kind: 'custom',
+              modelId: definition.model.model,
+              customModel: definition.model,
+              revision: cloudSnapshot.revision,
+              definition,
+            }
+            : {
+              kind: 'catalog',
+              modelId: definition.model.modelId,
+              ...(definition.model.reasoningEffort
+                ? { reasoningEffort: definition.model.reasoningEffort }
+                : {}),
+              revision: cloudSnapshot.revision,
+              definition,
+            },
+        };
+      }
+    } catch (error) {
+      Logger.warning(`CatsCo BotDefinition cloud sync is temporarily unavailable; using local cache: ${errorMessage(error)}`);
+    }
+  }
+
   const previousCloudDefinition = definitionService.readCloudModelOverride(botId);
   const previousCloudRuntime = definitionService.readCloudCatalogRuntime(botId);
   let definition = previousCloudDefinition ?? localDefinition;
-  const auth = options.auth ?? createCatsCoLocalConfigService({ runtimeRoot: options.runtimeRoot }).getAuthState();
   let initializedDefault = false;
   let materializedCatalogRuntime = false;
   let cloudSelection = options.cloudSelection;
@@ -72,7 +209,7 @@ export async function prepareBoundBotDefinition(
 
   if (!cloudSelection) {
     try {
-      cloudSelection = await pullCloudBotModelSelection({
+      cloudSelection = await pullLegacyCloudBotModelSelection({
         botId,
         auth,
         fetchImpl: options.fetchImpl,

--- a/src/bot-definition/cloud-client.ts
+++ b/src/bot-definition/cloud-client.ts
@@ -1,7 +1,13 @@
 import type { CatsCoAuthSnapshot } from '../catscompany/local-config';
 import { normalizeReasoningEffort } from '../utils/reasoning-effort';
 import type { ReasoningEffort } from '../types';
-import type { CustomBotModelDefinition } from './types';
+import {
+  BOT_DEFINITION_SCHEMA,
+  type BotDefinition,
+  type BotModelDefinition,
+  type BotPromptDefinition,
+  type CustomBotModelDefinition,
+} from './types';
 
 const CLOUD_MODEL_REQUEST_TIMEOUT_MS = 10_000;
 
@@ -12,6 +18,14 @@ export interface CloudBotModelSelection {
   reasoningEffort?: ReasoningEffort;
   revision: number;
   customModel?: CustomBotModelDefinition;
+  definition?: BotDefinition;
+}
+
+export interface CloudBotDefinitionSnapshot {
+  configured: boolean;
+  revision: number;
+  definition?: BotDefinition;
+  runtime?: Record<string, unknown>;
 }
 
 export interface CloudBotModelClientOptions {
@@ -21,6 +35,33 @@ export interface CloudBotModelClientOptions {
 }
 
 export async function pullCloudBotModelSelection(
+  options: CloudBotModelClientOptions,
+): Promise<CloudBotModelSelection | undefined> {
+  const definitionSnapshot = await pullCloudBotDefinition(options);
+  if (definitionSnapshot) {
+    if (!definitionSnapshot.configured || !definitionSnapshot.definition) return undefined;
+    const model = definitionSnapshot.definition.model;
+    return model.kind === 'custom'
+      ? {
+        kind: 'custom',
+        modelId: model.model,
+        revision: definitionSnapshot.revision,
+        customModel: model,
+        definition: definitionSnapshot.definition,
+        ...(model.reasoningEffort ? { reasoningEffort: model.reasoningEffort } : {}),
+      }
+      : {
+        kind: 'catalog',
+        modelId: model.modelId,
+        revision: definitionSnapshot.revision,
+        definition: definitionSnapshot.definition,
+        ...(model.reasoningEffort ? { reasoningEffort: model.reasoningEffort } : {}),
+      };
+  }
+  return pullLegacyCloudBotModelSelection(options);
+}
+
+export async function pullLegacyCloudBotModelSelection(
   options: CloudBotModelClientOptions,
 ): Promise<CloudBotModelSelection | undefined> {
   const response = await cloudModelRequest(options, 'GET', '/api/bot/model-config');
@@ -61,11 +102,73 @@ export async function pullCloudBotModelSelection(
   return { kind: 'catalog', modelId, revision, ...(reasoningEffort ? { reasoningEffort } : {}) };
 }
 
+export async function pullCloudBotDefinition(
+  options: CloudBotModelClientOptions,
+): Promise<CloudBotDefinitionSnapshot | undefined> {
+  const response = await cloudDefinitionRequest(options, 'bot', 'GET', '/api/bot/definition');
+  if (response === undefined) return undefined;
+  if (!isBotDefinitionResponse(response)) return undefined;
+  return parseCloudBotDefinitionSnapshot(response, options.botId);
+}
+
+export async function patchCloudBotDefinitionModel(
+  options: CloudBotModelClientOptions,
+  model: BotModelDefinition,
+  revision?: number,
+): Promise<number | undefined> {
+  const response = await cloudDefinitionRequest(
+    options,
+    'owner',
+    'PATCH',
+    `/api/bots/definition/model?uid=${encodeURIComponent(options.botId)}`,
+    {
+      ...(revision !== undefined ? { revision } : {}),
+      model,
+    },
+  );
+  if (response === undefined) return undefined;
+  return parseRevision(response);
+}
+
+export async function patchCloudBotDefinitionPrompt(
+  options: CloudBotModelClientOptions,
+  prompt: BotPromptDefinition,
+  revision?: number,
+): Promise<number | undefined> {
+  const response = await cloudDefinitionRequest(
+    options,
+    'owner',
+    'PATCH',
+    `/api/bots/definition/prompt?uid=${encodeURIComponent(options.botId)}`,
+    {
+      ...(revision !== undefined ? { revision } : {}),
+      prompt,
+    },
+  );
+  if (response === undefined) return undefined;
+  return parseRevision(response);
+}
+
+export async function acknowledgeCloudBotDefinition(
+  options: CloudBotModelClientOptions,
+  revision: number,
+  applyError = '',
+): Promise<void> {
+  await cloudDefinitionRequest(options, 'bot', 'POST', '/api/bot/definition/ack', {
+    revision,
+    ...(applyError ? { error: applyError } : {}),
+  });
+}
+
 export async function acknowledgeCloudBotModelSelection(
   options: CloudBotModelClientOptions,
   selection: CloudBotModelSelection,
   applyError = '',
 ): Promise<void> {
+  if (selection.definition) {
+    await acknowledgeCloudBotDefinition(options, selection.revision, applyError);
+    return;
+  }
   await cloudModelRequest(options, 'POST', '/api/bot/model-config/ack', {
     revision: selection.revision,
     ...(selection.kind === 'custom' || selection.kind === 'local' ? { kind: selection.kind } : {}),
@@ -95,15 +198,15 @@ function normalizeCloudModelKind(value: unknown): 'catalog' | 'custom' {
 function parseCloudCustomModel(value: unknown): CustomBotModelDefinition {
   const input = value as Record<string, unknown> | undefined;
   const protocol = String(input?.protocol || '').trim().toLowerCase();
-  const apiBase = String(input?.api_base || '').trim().replace(/\/+$/, '');
+  const apiBase = String(input?.apiBase || input?.api_base || '').trim().replace(/\/+$/, '');
   const model = String(input?.model || '').trim();
-  const apiKey = String(input?.api_key || '').trim();
-  const contextWindowTokens = Number(input?.context_window_tokens);
-  const maxTokens = Number(input?.max_tokens);
+  const apiKey = String(input?.apiKey || input?.api_key || '').trim();
+  const contextWindowTokens = Number(input?.contextWindowTokens ?? input?.context_window_tokens);
+  const maxTokens = Number(input?.maxTokens ?? input?.max_tokens);
   const temperature = input?.temperature === undefined || input?.temperature === null
     ? undefined
     : Number(input.temperature);
-  const rawReasoning = String(input?.reasoning_effort || '').trim();
+  const rawReasoning = String(input?.reasoningEffort || input?.reasoning_effort || '').trim();
   const reasoningEffort = rawReasoning ? normalizeReasoningEffort(rawReasoning) : undefined;
   if (!['anthropic', 'openai-chat-completions', 'openai-responses'].includes(protocol)) {
     throw new Error('CatsCo cloud returned an unsupported custom model protocol.');
@@ -134,6 +237,131 @@ function parseCloudCustomModel(value: unknown): CustomBotModelDefinition {
     ...(temperature !== undefined ? { temperature } : {}),
     ...(reasoningEffort ? { reasoningEffort } : {}),
   };
+}
+
+function parseCloudBotDefinitionSnapshot(
+  response: any,
+  expectedBotId: string,
+): CloudBotDefinitionSnapshot {
+  const revision = parseRevision(response);
+  if (response?.configured !== true) {
+    return { configured: false, revision };
+  }
+  const raw = response?.definition as Record<string, unknown> | undefined;
+  const botId = String(raw?.botId || '').trim();
+  if (!raw || raw.schema !== BOT_DEFINITION_SCHEMA || botId !== String(expectedBotId).trim()) {
+    throw new Error('CatsCo cloud returned an invalid BotDefinition identity.');
+  }
+  const rawModel = raw.model as Record<string, unknown> | undefined;
+  const kind = String(rawModel?.kind || '').trim().toLowerCase();
+  let model: BotModelDefinition;
+  if (kind === 'custom') {
+    model = parseCloudCustomModel(rawModel);
+  } else if (!kind || kind === 'catalog') {
+    const modelId = String(rawModel?.modelId || '').trim();
+    const rawReasoning = String(rawModel?.reasoningEffort || '').trim();
+    const reasoningEffort = rawReasoning ? normalizeReasoningEffort(rawReasoning) : undefined;
+    if (!modelId || (rawReasoning && !reasoningEffort)) {
+      throw new Error('CatsCo cloud returned an invalid catalog BotDefinition.');
+    }
+    model = {
+      kind: 'catalog',
+      modelId,
+      ...(reasoningEffort ? { reasoningEffort } : {}),
+    };
+  } else {
+    throw new Error(`CatsCo cloud returned an unsupported BotDefinition model kind: ${kind}`);
+  }
+  const prompt = parseCloudPromptDefinition(raw.prompt);
+  return {
+    configured: true,
+    revision,
+    definition: {
+      schema: BOT_DEFINITION_SCHEMA,
+      botId,
+      model,
+      ...(prompt ? { prompt } : {}),
+    },
+    ...(response?.runtime && typeof response.runtime === 'object'
+      ? { runtime: response.runtime as Record<string, unknown> }
+      : {}),
+  };
+}
+
+function parseCloudPromptDefinition(value: unknown): BotPromptDefinition | undefined {
+  if (value === undefined || value === null) return undefined;
+  const raw = value as Record<string, unknown>;
+  const selected = String(raw.selected || '').trim().toLowerCase();
+  const customSystemPrompt = String(raw.customSystemPrompt || '');
+  if (selected !== 'default' && selected !== 'custom') {
+    throw new Error('CatsCo cloud returned an invalid prompt selection.');
+  }
+  if (selected === 'custom' && !customSystemPrompt.trim()) {
+    throw new Error('CatsCo cloud returned an empty custom system prompt.');
+  }
+  return {
+    selected,
+    ...(customSystemPrompt ? { customSystemPrompt } : {}),
+  };
+}
+
+function isBotDefinitionResponse(response: unknown): boolean {
+  if (!response || typeof response !== 'object') return false;
+  const value = response as Record<string, unknown>;
+  return Object.prototype.hasOwnProperty.call(value, 'revision')
+    && Object.prototype.hasOwnProperty.call(value, 'configured');
+}
+
+function parseRevision(response: any): number {
+  const revision = Number(response?.revision);
+  if (!Number.isInteger(revision) || revision < 0) {
+    throw new Error('CatsCo cloud returned an invalid BotDefinition revision.');
+  }
+  return revision;
+}
+
+async function cloudDefinitionRequest(
+  options: CloudBotModelClientOptions,
+  authMode: 'owner' | 'bot',
+  method: string,
+  apiPath: string,
+  body?: unknown,
+): Promise<any | undefined> {
+  const credential = String(authMode === 'owner' ? options.auth.token : options.auth.apiKey || '').trim();
+  const httpBaseUrl = String(options.auth.httpBaseUrl || '').trim().replace(/\/+$/, '');
+  if (!credential || !httpBaseUrl) return undefined;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), CLOUD_MODEL_REQUEST_TIMEOUT_MS);
+  try {
+    const response = await (options.fetchImpl ?? fetch)(`${httpBaseUrl}${apiPath}`, {
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: authMode === 'owner' ? `Bearer ${credential}` : `ApiKey ${credential}`,
+      },
+      body: body === undefined ? undefined : JSON.stringify(body),
+      signal: controller.signal,
+    });
+    if ([404, 405, 501].includes(response.status)) return undefined;
+    const text = await response.text();
+    let data: any = {};
+    if (text) {
+      try {
+        data = JSON.parse(text);
+      } catch {
+        data = { raw: text };
+      }
+    }
+    if (!response.ok) {
+      const error = new Error(String(data?.error || data?.message || `CatsCo BotDefinition request failed: ${response.status}`));
+      (error as Error & { status?: number }).status = response.status;
+      throw error;
+    }
+    return data;
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 async function cloudModelRequest(

--- a/src/bot-definition/cloud-sync.ts
+++ b/src/bot-definition/cloud-sync.ts
@@ -1,0 +1,277 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import type { CatsCoAuthSnapshot } from '../catscompany/local-config';
+import { PathResolver } from '../utils/path-resolver';
+import {
+  acknowledgeCloudBotDefinition,
+  patchCloudBotDefinitionModel,
+  patchCloudBotDefinitionPrompt,
+  pullCloudBotDefinition,
+  type CloudBotDefinitionSnapshot,
+} from './cloud-client';
+import { createBotDefinitionSyncService, type BotDefinitionSyncService } from './service';
+import type { BotDefinition, BotModelDefinition, BotPromptDefinition } from './types';
+
+const CLOUD_SYNC_STATE_SCHEMA = 'xiaoba.bot-definition-cloud-sync.v1';
+
+export interface BotDefinitionCloudSyncState {
+  schema: typeof CLOUD_SYNC_STATE_SCHEMA;
+  botId: string;
+  revision: number;
+  pendingModel: boolean;
+  pendingPrompt: boolean;
+}
+
+export interface BotDefinitionCloudSyncOptions {
+  runtimeRoot?: string;
+  env?: NodeJS.ProcessEnv;
+  definitionService?: BotDefinitionSyncService;
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Keeps the existing local Definition cache as the runtime input while
+ * treating CatsCompany as the canonical source. Only revision and retry flags
+ * are stored here; model and prompt data remain in the normal cache.
+ */
+export class BotDefinitionCloudSyncService {
+  private readonly runtimeRoot: string;
+  private readonly env: NodeJS.ProcessEnv;
+  private readonly definitionService: BotDefinitionSyncService;
+  private readonly fetchImpl?: typeof fetch;
+  private readonly tails = new Map<string, Promise<unknown>>();
+
+  constructor(options: BotDefinitionCloudSyncOptions = {}) {
+    this.runtimeRoot = path.resolve(options.runtimeRoot ?? PathResolver.getRuntimeDataRoot());
+    this.env = options.env ?? process.env;
+    this.definitionService = options.definitionService ?? createBotDefinitionSyncService({
+      runtimeRoot: this.runtimeRoot,
+      env: this.env,
+    });
+    this.fetchImpl = options.fetchImpl;
+  }
+
+  pull(botId: string, auth: CatsCoAuthSnapshot): Promise<CloudBotDefinitionSnapshot | undefined> {
+    return this.enqueue(botId, async () => {
+      const snapshot = await pullCloudBotDefinition({
+        botId,
+        auth,
+        fetchImpl: this.fetchImpl,
+      });
+      if (!snapshot) return undefined;
+      if (snapshot.configured && snapshot.definition) {
+        this.definitionService.acceptCanonical(snapshot.definition);
+      }
+      this.writeState({
+        ...this.readState(botId),
+        schema: CLOUD_SYNC_STATE_SCHEMA,
+        botId,
+        revision: snapshot.revision,
+      });
+      return snapshot;
+    });
+  }
+
+  markModelPending(botId: string): void {
+    const state = this.readState(botId);
+    this.writeState({ ...state, pendingModel: true });
+  }
+
+  markPromptPending(botId: string): void {
+    const state = this.readState(botId);
+    this.writeState({ ...state, pendingPrompt: true });
+  }
+
+  pushModel(
+    botId: string,
+    auth: CatsCoAuthSnapshot,
+    model?: BotModelDefinition,
+  ): Promise<CloudBotDefinitionSnapshot | undefined> {
+    return this.enqueue(botId, async () => {
+      const selected = model ?? this.requireLocal(botId).model;
+      this.markModelPending(botId);
+      return this.pushField(botId, auth, 'model', selected);
+    });
+  }
+
+  pushPrompt(
+    botId: string,
+    auth: CatsCoAuthSnapshot,
+    prompt?: BotPromptDefinition,
+  ): Promise<CloudBotDefinitionSnapshot | undefined> {
+    return this.enqueue(botId, async () => {
+      const selected = prompt ?? this.requireLocal(botId).prompt;
+      if (!selected) throw new Error(`BotDefinition prompt does not exist for bot ${botId}`);
+      this.markPromptPending(botId);
+      return this.pushField(botId, auth, 'prompt', selected);
+    });
+  }
+
+  flushPending(
+    botId: string,
+    auth: CatsCoAuthSnapshot,
+  ): Promise<CloudBotDefinitionSnapshot | undefined> {
+    return this.enqueue(botId, async () => {
+      let snapshot: CloudBotDefinitionSnapshot | undefined;
+      const state = this.readState(botId);
+      const definition = this.definitionService.read(botId);
+      if (!definition) return this.pullUnlocked(botId, auth);
+      if (state.pendingModel) {
+        snapshot = await this.pushFieldUnlocked(botId, auth, 'model', definition.model);
+      }
+      const current = this.definitionService.read(botId) ?? definition;
+      if (this.readState(botId).pendingPrompt && current.prompt) {
+        snapshot = await this.pushFieldUnlocked(botId, auth, 'prompt', current.prompt);
+      }
+      return snapshot ?? this.pullUnlocked(botId, auth);
+    });
+  }
+
+  acknowledge(
+    botId: string,
+    auth: CatsCoAuthSnapshot,
+    revision: number,
+    applyError = '',
+  ): Promise<void> {
+    return acknowledgeCloudBotDefinition(
+      { botId, auth, fetchImpl: this.fetchImpl },
+      revision,
+      applyError,
+    );
+  }
+
+  readState(botId: string): BotDefinitionCloudSyncState {
+    const filePath = this.statePath(botId);
+    if (fs.existsSync(filePath)) {
+      try {
+        const parsed = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as BotDefinitionCloudSyncState;
+        if (
+          parsed.schema === CLOUD_SYNC_STATE_SCHEMA
+          && parsed.botId === botId
+          && Number.isInteger(parsed.revision)
+          && parsed.revision >= 0
+        ) {
+          return parsed;
+        }
+      } catch {
+        // Recreate malformed local sync metadata without touching Definition data.
+      }
+    }
+    return {
+      schema: CLOUD_SYNC_STATE_SCHEMA,
+      botId,
+      revision: 0,
+      pendingModel: false,
+      pendingPrompt: false,
+    };
+  }
+
+  private pushField(
+    botId: string,
+    auth: CatsCoAuthSnapshot,
+    field: 'model' | 'prompt',
+    value: BotModelDefinition | BotPromptDefinition,
+  ): Promise<CloudBotDefinitionSnapshot | undefined> {
+    return this.pushFieldUnlocked(botId, auth, field, value);
+  }
+
+  private async pushFieldUnlocked(
+    botId: string,
+    auth: CatsCoAuthSnapshot,
+    field: 'model' | 'prompt',
+    value: BotModelDefinition | BotPromptDefinition,
+  ): Promise<CloudBotDefinitionSnapshot | undefined> {
+    let state = this.readState(botId);
+    let revision: number | undefined;
+    try {
+      revision = await this.patchField(botId, auth, field, value, state.revision);
+    } catch (error) {
+      if (errorStatus(error) !== 409) throw error;
+      const latest = await this.pullUnlocked(botId, auth);
+      state = this.readState(botId);
+      revision = await this.patchField(botId, auth, field, value, latest?.revision ?? state.revision);
+    }
+    if (revision === undefined) return undefined;
+
+    state = this.readState(botId);
+    this.writeState({
+      ...state,
+      revision,
+      ...(field === 'model' ? { pendingModel: false } : { pendingPrompt: false }),
+    });
+    const snapshot = await this.pullUnlocked(botId, auth);
+    return snapshot ?? {
+      configured: true,
+      revision,
+      definition: this.requireLocal(botId),
+    };
+  }
+
+  private patchField(
+    botId: string,
+    auth: CatsCoAuthSnapshot,
+    field: 'model' | 'prompt',
+    value: BotModelDefinition | BotPromptDefinition,
+    revision: number,
+  ): Promise<number | undefined> {
+    const options = { botId, auth, fetchImpl: this.fetchImpl };
+    return field === 'model'
+      ? patchCloudBotDefinitionModel(options, value as BotModelDefinition, revision)
+      : patchCloudBotDefinitionPrompt(options, value as BotPromptDefinition, revision);
+  }
+
+  private async pullUnlocked(
+    botId: string,
+    auth: CatsCoAuthSnapshot,
+  ): Promise<CloudBotDefinitionSnapshot | undefined> {
+    const snapshot = await pullCloudBotDefinition({
+      botId,
+      auth,
+      fetchImpl: this.fetchImpl,
+    });
+    if (!snapshot) return undefined;
+    if (snapshot.configured && snapshot.definition) {
+      this.definitionService.acceptCanonical(snapshot.definition);
+    }
+    this.writeState({
+      ...this.readState(botId),
+      revision: snapshot.revision,
+    });
+    return snapshot;
+  }
+
+  private requireLocal(botId: string): BotDefinition {
+    const definition = this.definitionService.read(botId);
+    if (!definition) throw new Error(`BotDefinition does not exist for bot ${botId}`);
+    return definition;
+  }
+
+  private statePath(botId: string): string {
+    return path.join(this.runtimeRoot, 'data', 'bot-definition-sync', 'bots', `${botId}.json`);
+  }
+
+  private writeState(state: BotDefinitionCloudSyncState): void {
+    const filePath = this.statePath(state.botId);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    const temporary = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+    fs.writeFileSync(temporary, `${JSON.stringify(state, null, 2)}\n`, 'utf-8');
+    fs.renameSync(temporary, filePath);
+  }
+
+  private enqueue<T>(botId: string, operation: () => Promise<T>): Promise<T> {
+    const tail = this.tails.get(botId) ?? Promise.resolve();
+    const next = tail.then(operation, operation);
+    this.tails.set(botId, next.then(() => undefined, () => undefined));
+    return next;
+  }
+}
+
+export function createBotDefinitionCloudSyncService(
+  options: BotDefinitionCloudSyncOptions = {},
+): BotDefinitionCloudSyncService {
+  return new BotDefinitionCloudSyncService(options);
+}
+
+function errorStatus(error: unknown): number | undefined {
+  return (error as { status?: number } | undefined)?.status;
+}

--- a/src/bot-definition/cloud-sync.ts
+++ b/src/bot-definition/cloud-sync.ts
@@ -116,14 +116,59 @@ export class BotDefinitionCloudSyncService {
       const state = this.readState(botId);
       const definition = this.definitionService.read(botId);
       if (!definition) return this.pullUnlocked(botId, auth);
+      const pendingPrompt = definition.prompt;
       if (state.pendingModel) {
         snapshot = await this.pushFieldUnlocked(botId, auth, 'model', definition.model);
       }
-      const current = this.definitionService.read(botId) ?? definition;
-      if (this.readState(botId).pendingPrompt && current.prompt) {
-        snapshot = await this.pushFieldUnlocked(botId, auth, 'prompt', current.prompt);
+      if (this.readState(botId).pendingPrompt && pendingPrompt) {
+        snapshot = await this.pushFieldUnlocked(botId, auth, 'prompt', pendingPrompt);
       }
       return snapshot ?? this.pullUnlocked(botId, auth);
+    });
+  }
+
+  reconcileStartup(
+    botId: string,
+    auth: CatsCoAuthSnapshot,
+  ): Promise<CloudBotDefinitionSnapshot | undefined> {
+    return this.enqueue(botId, async () => {
+      const state = this.readState(botId);
+      const pendingDefinition = (
+        state.pendingModel || state.pendingPrompt
+          ? this.definitionService.read(botId)
+          : undefined
+      );
+      const snapshot = await this.pullUnlocked(botId, auth);
+      if (!snapshot || (!state.pendingModel && !state.pendingPrompt)) return snapshot;
+
+      if (snapshot.revision !== state.revision) {
+        this.writeState({
+          ...this.readState(botId),
+          pendingModel: false,
+          pendingPrompt: false,
+        });
+        return snapshot;
+      }
+      if (!pendingDefinition) return snapshot;
+
+      let applied = snapshot;
+      if (state.pendingModel) {
+        applied = await this.pushFieldUnlocked(
+          botId,
+          auth,
+          'model',
+          pendingDefinition.model,
+        ) ?? applied;
+      }
+      if (state.pendingPrompt && pendingDefinition.prompt) {
+        applied = await this.pushFieldUnlocked(
+          botId,
+          auth,
+          'prompt',
+          pendingDefinition.prompt,
+        ) ?? applied;
+      }
+      return applied;
     });
   }
 

--- a/src/bot-definition/llm-config-resolver.ts
+++ b/src/bot-definition/llm-config-resolver.ts
@@ -81,8 +81,12 @@ export function resolveActiveBotLLMConfig(
   if (!botId) return undefined;
 
   const definitions = new FileBotDefinitionRepository({ runtimeRoot });
+  const cachedDefinition = definitions.readCache(botId);
+  // The real Definition path clears this legacy override after a successful
+  // pull. If it still exists, the connected server is using the old
+  // model-config contract and the override remains its active selection.
   const cloudOverride = new FileBotCloudModelOverrideRepository({ runtimeRoot }).read(botId);
-  const definition = cloudOverride ?? definitions.readCache(botId);
+  const definition = cloudOverride ?? cachedDefinition;
   if (!definition) return undefined;
 
   if (definition.model.kind === 'custom') {

--- a/src/bot-definition/prompt-sync.ts
+++ b/src/bot-definition/prompt-sync.ts
@@ -10,6 +10,10 @@ import {
   SYSTEM_PROMPT_RELATIVE_PATH,
 } from '../utils/prompt-template';
 import { createBotDefinitionSyncService, type BotDefinitionSyncService } from './service';
+import {
+  createBotDefinitionCloudSyncService,
+  type BotDefinitionCloudSyncService,
+} from './cloud-sync';
 import type { BotDefinition, BotPromptDefinition } from './types';
 
 const PROMPT_SYNC_STATE_SCHEMA = 'xiaoba.active-prompt-sync.v1';
@@ -41,12 +45,14 @@ export interface PromptReconcileCoordinatorOptions {
   runtimeRoot?: string;
   env?: NodeJS.ProcessEnv;
   definitionService?: BotDefinitionSyncService;
+  cloudSyncService?: BotDefinitionCloudSyncService;
 }
 
 export class PromptReconcileCoordinator {
   private readonly runtimeRoot: string;
   private readonly env: NodeJS.ProcessEnv;
   private readonly definitionService: BotDefinitionSyncService;
+  private readonly cloudSyncService: BotDefinitionCloudSyncService;
   private tail: Promise<unknown> = Promise.resolve();
 
   constructor(options: PromptReconcileCoordinatorOptions = {}) {
@@ -55,6 +61,11 @@ export class PromptReconcileCoordinator {
     this.definitionService = options.definitionService ?? createBotDefinitionSyncService({
       runtimeRoot: this.runtimeRoot,
       env: this.env,
+    });
+    this.cloudSyncService = options.cloudSyncService ?? createBotDefinitionCloudSyncService({
+      runtimeRoot: this.runtimeRoot,
+      env: this.env,
+      definitionService: this.definitionService,
     });
   }
 
@@ -198,6 +209,15 @@ export class PromptReconcileCoordinator {
         this.restoreActiveSnapshot(snapshot);
         throw error;
       }
+      try {
+        const auth = createCatsCoLocalConfigService({
+          runtimeRoot: this.runtimeRoot,
+          env: this.env,
+        }).getAuthState();
+        await this.cloudSyncService.pushPrompt(botId, auth, prompt);
+      } catch (error) {
+        Logger.warning(`Prompt cloud sync deferred: ${errorMessage(error)}`);
+      }
       return this.getSelection(botId);
     });
   }
@@ -291,10 +311,16 @@ export class PromptReconcileCoordinator {
     if (!active || active.hash === state.lastSyncedHash) return false;
 
     this.requireDefinition(botId);
-    this.definitionService.updatePrompt(botId, {
+    const prompt: BotPromptDefinition = {
       selected: 'custom',
       customSystemPrompt: active.text,
-    });
+    };
+    this.definitionService.updatePrompt(botId, prompt);
+    const auth = createCatsCoLocalConfigService({
+      runtimeRoot: this.runtimeRoot,
+      env: this.env,
+    }).getAuthState();
+    await this.cloudSyncService.pushPrompt(botId, auth, prompt);
     this.writeState({
       schema: PROMPT_SYNC_STATE_SCHEMA,
       activeBotId: botId,
@@ -403,9 +429,11 @@ export function getPromptReconcileCoordinator(
 ): PromptReconcileCoordinator {
   const runtimeRoot = path.resolve(options.runtimeRoot ?? PathResolver.getRuntimeDataRoot());
   const existing = coordinators.get(runtimeRoot);
-  if (existing && !options.definitionService && !options.env) return existing;
+  if (existing && !options.definitionService && !options.cloudSyncService && !options.env) return existing;
   const coordinator = new PromptReconcileCoordinator({ ...options, runtimeRoot });
-  if (!options.definitionService && !options.env) coordinators.set(runtimeRoot, coordinator);
+  if (!options.definitionService && !options.cloudSyncService && !options.env) {
+    coordinators.set(runtimeRoot, coordinator);
+  }
   return coordinator;
 }
 

--- a/src/bot-definition/prompt-sync.ts
+++ b/src/bot-definition/prompt-sync.ts
@@ -54,6 +54,7 @@ export class PromptReconcileCoordinator {
   private readonly definitionService: BotDefinitionSyncService;
   private readonly cloudSyncService: BotDefinitionCloudSyncService;
   private tail: Promise<unknown> = Promise.resolve();
+  private readonly cloudRetries = new Set<string>();
 
   constructor(options: PromptReconcileCoordinatorOptions = {}) {
     this.runtimeRoot = path.resolve(options.runtimeRoot ?? PathResolver.getRuntimeDataRoot());
@@ -128,14 +129,18 @@ export class PromptReconcileCoordinator {
     };
   }
 
-  activateBot(botId: string): Promise<PromptSelectionState> {
-    return this.enqueue(() => this.activateBotNow(botId));
+  activateBot(
+    botId: string,
+    options: { preferDefinition?: boolean } = {},
+  ): Promise<PromptSelectionState> {
+    return this.enqueue(() => this.activateBotNow(botId, options));
   }
 
   reconcileCurrent(options: { force?: boolean } = {}): Promise<boolean> {
     return this.enqueue(async () => {
       const botId = this.getCurrentBotId();
       if (!botId) return false;
+      this.schedulePendingCloudRetry(botId);
       return this.reconcileBotNow(botId, options);
     });
   }
@@ -159,6 +164,7 @@ export class PromptReconcileCoordinator {
         }
         return undefined;
       }
+      await this.reconcileBotNow(botId, { force: true });
       return this.activateBotNow(botId);
     });
   }
@@ -217,6 +223,7 @@ export class PromptReconcileCoordinator {
         await this.cloudSyncService.pushPrompt(botId, auth, prompt);
       } catch (error) {
         Logger.warning(`Prompt cloud sync deferred: ${errorMessage(error)}`);
+        this.schedulePendingCloudRetry(botId);
       }
       return this.getSelection(botId);
     });
@@ -246,25 +253,63 @@ export class PromptReconcileCoordinator {
     }
   }
 
-  private async activateBotNow(botId: string): Promise<PromptSelectionState> {
+  private async activateBotNow(
+    botId: string,
+    options: { preferDefinition?: boolean } = {},
+  ): Promise<PromptSelectionState> {
     let definition = this.requireDefinition(botId);
     const state = this.readState();
     const active = await this.readStableActivePrompt();
+    const bundledDefault = this.readBundledDefault();
+    let migratedLegacyDefault = false;
 
     if (!definition.prompt) {
       const canMigrateActive = Boolean(active && (!state || state.activeBotId === botId));
+      const activeIsTrackedCustom = Boolean(
+        active
+        && state?.activeBotId === botId
+        && (
+          state.materializedSelection === 'custom'
+          || active.hash !== state.lastSyncedHash
+        ),
+      );
       const prompt: BotPromptDefinition = canMigrateActive
-        ? { selected: 'custom', customSystemPrompt: active!.text }
+        ? activeIsTrackedCustom
+          ? { selected: 'custom', customSystemPrompt: active!.text }
+          : { selected: 'default', customSystemPrompt: active!.text }
         : { selected: 'default' };
       definition = this.definitionService.updatePrompt(botId, prompt).definition;
+      migratedLegacyDefault = canMigrateActive && !activeIsTrackedCustom;
+    } else if (
+      active
+      && !state
+      && definition.prompt.selected === 'default'
+    ) {
+      definition = this.definitionService.updatePrompt(botId, {
+        ...definition.prompt,
+        customSystemPrompt: definition.prompt.customSystemPrompt || active.text,
+      }).definition;
+      migratedLegacyDefault = true;
     }
 
-    const bundledDefault = this.readBundledDefault();
+    if (migratedLegacyDefault) {
+      this.writeActivePrompt(bundledDefault);
+      this.writeState({
+        schema: PROMPT_SYNC_STATE_SCHEMA,
+        activeBotId: botId,
+        lastSyncedHash: hashPrompt(bundledDefault),
+        materializedSelection: 'default',
+      });
+      return this.toSelection(definition, bundledDefault, bundledDefault);
+    }
+
     const prompt = definition.prompt!;
     const expected = prompt.selected === 'custom'
       ? prompt.customSystemPrompt || bundledDefault
       : bundledDefault;
     const activeHasUnsyncedChange = Boolean(
+      !options.preferDefinition
+      &&
       active
       && (
         (state?.activeBotId === botId && active.hash !== state.lastSyncedHash)
@@ -419,6 +464,27 @@ export class PromptReconcileCoordinator {
     const next = this.tail.then(operation, operation);
     this.tail = next.then(() => undefined, () => undefined);
     return next;
+  }
+
+  private schedulePendingCloudRetry(botId: string): void {
+    if (
+      this.cloudRetries.has(botId)
+      || !this.cloudSyncService.readState(botId).pendingPrompt
+    ) {
+      return;
+    }
+    this.cloudRetries.add(botId);
+    const auth = createCatsCoLocalConfigService({
+      runtimeRoot: this.runtimeRoot,
+      env: this.env,
+    }).getAuthState();
+    void this.cloudSyncService.flushPending(botId, auth)
+      .catch(error => {
+        Logger.warning(`Prompt cloud sync retry deferred: ${errorMessage(error)}`);
+      })
+      .finally(() => {
+        this.cloudRetries.delete(botId);
+      });
   }
 }
 

--- a/src/bot-definition/service.ts
+++ b/src/bot-definition/service.ts
@@ -307,12 +307,7 @@ function normalizeBotDefinition(definition: BotDefinition): BotDefinition {
 }
 
 function normalizePromptDefinition(prompt: BotPromptDefinition): BotPromptDefinition {
-  const customSystemPrompt = prompt.customSystemPrompt?.trim();
-  if (customSystemPrompt === prompt.customSystemPrompt) return prompt;
-  return {
-    selected: prompt.selected,
-    ...(customSystemPrompt ? { customSystemPrompt } : {}),
-  };
+  return prompt;
 }
 
 function normalizeCatalogRuntime(runtime: BotCatalogModelRuntime): BotCatalogModelRuntime {
@@ -401,7 +396,6 @@ export class BotDefinitionSyncService {
         if (previousCache?.model.kind === 'custom') {
           this.storeCustomModelProfile(botId, previousCache.model);
         }
-        if (definition !== rawDefinition) this.repository.writeCanonical(definition);
         this.repository.writeCache(definition);
         if (definition.model.kind === 'custom') {
           this.storeCustomModelProfile(definition.botId, definition.model);
@@ -432,12 +426,11 @@ export class BotDefinitionSyncService {
         botId,
         model: normalizedModel,
       };
-      this.repository.writeCanonical(definition);
       this.repository.writeCache(definition);
       this.clearLegacyModelConfigurationWhenReady(definition);
       return {
         botId,
-        direction: 'local_to_simulated_cloud',
+        direction: 'local_cache_update',
         definition,
       };
     });
@@ -460,13 +453,40 @@ export class BotDefinitionSyncService {
         prompt: normalizePromptDefinition(prompt),
       };
       this.repository.writeCache(definition);
-      this.repository.writeCanonical(definition);
       return {
         botId,
-        direction: 'local_to_simulated_cloud',
+        direction: 'local_cache_update',
         definition,
       };
     });
+  }
+
+  /**
+   * Accepts the canonical cloud snapshot as the only runnable local cache.
+   * The old simulated canonical file is intentionally not rewritten.
+   */
+  acceptCanonical(definition: BotDefinition): BotDefinitionSyncResult {
+    return this.withDefinitionWriteLock(definition.botId, () => {
+      const normalized = normalizeBotDefinition(definition);
+      const previous = this.repository.readCache(normalized.botId);
+      if (previous?.model.kind === 'custom') {
+        this.storeCustomModelProfile(normalized.botId, previous.model);
+      }
+      this.repository.writeCache(normalized);
+      if (normalized.model.kind === 'custom') {
+        this.storeCustomModelProfile(normalized.botId, normalized.model);
+      }
+      return {
+        botId: normalized.botId,
+        direction: 'cloud_to_local',
+        definition: normalized,
+      };
+    });
+  }
+
+  readLegacyCanonical(botId: string): BotDefinition | undefined {
+    const definition = this.repository.readCanonical(botId);
+    return definition ? normalizeBotDefinition(definition) : undefined;
   }
 
   acceptCloud(botId: string, model: BotModelDefinition): BotDefinitionSyncResult {
@@ -545,15 +565,27 @@ export class BotDefinitionSyncService {
   }
 
   pullOrBootstrap(botId: string): BotDefinitionSyncResult | undefined {
-    const existing = this.pull(botId);
-    if (existing) {
+    const cached = this.repository.readCache(botId);
+    if (cached) {
+      const existing = normalizeBotDefinition(cached);
       this.migrateLegacyCustomModelProfile(existing.botId);
       this.migrateLegacyCatalogRuntime(existing);
       this.clearLegacyModelConfigurationWhenReady(existing);
       return {
         botId,
-        direction: 'simulated_cloud_to_local',
+        direction: 'local_cache_update',
         definition: existing,
+      };
+    }
+    const legacyCanonical = this.pull(botId);
+    if (legacyCanonical) {
+      this.migrateLegacyCustomModelProfile(legacyCanonical.botId);
+      this.migrateLegacyCatalogRuntime(legacyCanonical);
+      this.clearLegacyModelConfigurationWhenReady(legacyCanonical);
+      return {
+        botId,
+        direction: 'legacy_simulated_cloud_to_local',
+        definition: legacyCanonical,
       };
     }
     const profile = readLegacyLocalModelProfile(this.runtimeRoot, this.env);
@@ -567,7 +599,7 @@ export class BotDefinitionSyncService {
     this.clearLegacyModelConfigurationWhenReady(definition);
     return {
       botId,
-      direction: 'bootstrap_to_simulated_cloud',
+      direction: 'legacy_bootstrap_to_local',
       definition,
     };
   }

--- a/src/bot-definition/types.ts
+++ b/src/bot-definition/types.ts
@@ -107,6 +107,13 @@ export interface BotCustomModelProfile {
 
 export interface BotDefinitionSyncResult {
   botId: string;
-  direction: 'local_to_simulated_cloud' | 'simulated_cloud_to_local' | 'bootstrap_to_simulated_cloud' | 'cloud_to_local';
+  direction:
+    | 'local_cache_update'
+    | 'legacy_simulated_cloud_to_local'
+    | 'legacy_bootstrap_to_local'
+    | 'cloud_to_local'
+    | 'local_to_simulated_cloud'
+    | 'simulated_cloud_to_local'
+    | 'bootstrap_to_simulated_cloud';
   definition: BotDefinition;
 }

--- a/src/commands/catscompany.ts
+++ b/src/commands/catscompany.ts
@@ -17,6 +17,7 @@ import {
 } from '../bot-definition/cloud-client';
 import { CloudBotModelRuntimeReloadController } from '../bot-definition/runtime-reload';
 import { createBotDefinitionSyncService } from '../bot-definition/service';
+import { getPromptReconcileCoordinator } from '../bot-definition/prompt-sync';
 
 const CONNECTOR_OWNER_POLL_MS = 2000;
 const CLOUD_MODEL_POLL_MS = 5000;
@@ -263,6 +264,9 @@ async function applyCloudModelRuntimeSelection(
 ): Promise<'applied' | 'deferred'> {
   const botId = options.botId;
   if (!botId || !options.canApply()) return 'deferred';
+  if (options.selection.definition) {
+    return applyCloudBotDefinitionSelection(options);
+  }
   const definitionService = createBotDefinitionSyncService({ runtimeRoot: options.runtimeRoot });
   definitionService.pullOrBootstrap(botId);
   const previousCloudDefinition = definitionService.readCloudModelOverride(botId);
@@ -352,6 +356,109 @@ async function applyCloudModelRuntimeSelection(
   return 'applied';
 }
 
+async function applyCloudBotDefinitionSelection(
+  options: ApplyCloudModelRuntimeSelectionOptions,
+): Promise<'applied' | 'deferred'> {
+  const incoming = options.selection.definition!;
+  const definitionService = createBotDefinitionSyncService({ runtimeRoot: options.runtimeRoot });
+  const previousDefinition = definitionService.read(options.botId)
+    ?? definitionService.pullOrBootstrap(options.botId)?.definition;
+  const previousCatalogRuntime = definitionService.readCatalogRuntime(options.botId);
+  const promptCoordinator = getPromptReconcileCoordinator({
+    runtimeRoot: options.runtimeRoot,
+    definitionService,
+  });
+  const previousPrompt = promptCoordinator.captureActiveSnapshot();
+  const modelChanged = !previousDefinition
+    || JSON.stringify(previousDefinition.model) !== JSON.stringify(incoming.model);
+
+  if (modelChanged && (!options.canApply() || !options.currentBot().isIdleForRuntimeReload())) {
+    return 'deferred';
+  }
+
+  const restorePreviousRuntime = () => {
+    if (previousDefinition) definitionService.acceptCanonical(previousDefinition);
+    if (previousCatalogRuntime) definitionService.storeCatalogRuntime(previousCatalogRuntime);
+    promptCoordinator.restoreActiveSnapshot(previousPrompt);
+  };
+
+  let prepared: Awaited<ReturnType<typeof prepareBoundBotDefinition>>;
+  try {
+    definitionService.acceptCanonical(incoming);
+    prepared = await prepareBoundBotDefinition({
+      runtimeRoot: options.runtimeRoot,
+      botId: options.botId,
+      auth: options.auth,
+      acknowledgeCloudSelection: false,
+    });
+  } catch (error) {
+    restorePreviousRuntime();
+    const message = redactCloudBotModelError(error, options.selection);
+    await acknowledgeCloudModelApply(options, message);
+    throw new Error(message);
+  }
+
+  if (!prepared || prepared.cloudRevision !== options.selection.revision || prepared.cloudApplyError) {
+    const message = prepared?.cloudApplyError || 'Cloud BotDefinition runtime preparation did not complete.';
+    restorePreviousRuntime();
+    await acknowledgeCloudModelApply(options, message);
+    throw new Error(message);
+  }
+
+  let latestSelection: CloudBotModelSelection | undefined;
+  try {
+    latestSelection = await pullCloudBotModelSelection({
+      botId: options.botId,
+      auth: options.auth,
+    });
+  } catch (error) {
+    restorePreviousRuntime();
+    Logger.warning(`CatsCo BotDefinition revision check failed; applying it was deferred: ${errorMessage(error)}`);
+    return 'deferred';
+  }
+  if (!cloudSelectionsMatch(latestSelection, options.selection)) {
+    restorePreviousRuntime();
+    return 'deferred';
+  }
+
+  if (!modelChanged) {
+    await acknowledgeCloudModelApply(options);
+    Logger.success(`CatsCo applied Prompt revision=${options.selection.revision} without restarting the connector.`);
+    return 'applied';
+  }
+
+  const previousBot = options.currentBot();
+  let nextBot: CatsCompanyBot | undefined;
+  try {
+    await previousBot.destroy();
+    nextBot = new CatsCompanyBot(options.connectorConfig);
+    await nextBot.start();
+    await nextBot.waitUntilReady();
+    options.replaceBot(nextBot);
+  } catch (error) {
+    if (nextBot) {
+      await nextBot.destroy().catch(cleanupError => {
+        Logger.warning(`Failed to clean up an unstarted CatsCo connector: ${errorMessage(cleanupError)}`);
+      });
+    }
+    restorePreviousRuntime();
+    const message = redactCloudBotModelError(error, options.selection);
+    await acknowledgeCloudModelApply(options, message);
+    await recoverCloudModelFallbackConnector({
+      canApply: options.canApply,
+      createBot: () => new CatsCompanyBot(options.connectorConfig),
+      replaceBot: options.replaceBot,
+    });
+    throw new Error(message);
+  }
+
+  await acknowledgeCloudModelApply(options);
+  Logger.success(
+    `CatsCo applied BotDefinition model ${options.selection.modelId}, revision=${options.selection.revision}.`,
+  );
+  return 'applied';
+}
+
 interface RecoverCloudModelFallbackConnectorOptions {
   canApply(): boolean;
   createBot(): CatsCompanyBot;
@@ -414,6 +521,10 @@ function cloudSelectionsMatch(
   current: CloudBotModelSelection | undefined,
   expected: CloudBotModelSelection,
 ): boolean {
+  if (current?.definition || expected.definition) {
+    return current?.revision === expected.revision
+      && JSON.stringify(current?.definition) === JSON.stringify(expected.definition);
+  }
   return current?.revision === expected.revision
     && (current.kind || 'catalog') === (expected.kind || 'catalog')
     && current.modelId === expected.modelId

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -55,6 +55,7 @@ import { inferCatsUploadType, uploadCatsLocalFile } from '../../catscompany/uplo
 import { createCatsCoLocalConfigService } from '../../catscompany/local-config';
 import { catalogRuntimeMatchesModelId, createBotDefinitionSyncService } from '../../bot-definition/service';
 import { prepareBoundBotDefinition } from '../../bot-definition/activation';
+import { createBotDefinitionCloudSyncService } from '../../bot-definition/cloud-sync';
 import { getPromptReconcileCoordinator } from '../../bot-definition/prompt-sync';
 import {
   customModelDefinitionToConfig,
@@ -65,6 +66,7 @@ import {
   BOT_CATALOG_MODEL_RUNTIME_SCHEMA,
   type BotCatalogModelRuntime,
   type BotDefinitionSyncResult,
+  type BotModelDefinition,
   type CustomBotModelDefinition,
 } from '../../bot-definition/types';
 import { resolveCatsCoRuntimeConfig } from '../../catscompany/runtime-config';
@@ -1398,10 +1400,10 @@ function dashboardSecretValue(raw: unknown, current: string | undefined, id: str
 }
 
 /** Saves the custom profile independently and only selects it when activation is explicit. */
-function updateBoundBotCustomModelFromDashboardSettings(
+async function updateBoundBotCustomModelFromDashboardSettings(
   body: any,
   options: { publishActive: boolean },
-): Record<string, unknown> | undefined {
+): Promise<Record<string, unknown> | undefined> {
   const botId = currentBoundBotId();
   if (!botId || !hasDashboardModelUpdates(body)) return undefined;
   if (body?.modelProfileSource !== undefined && body.modelProfileSource !== 'custom') {
@@ -1447,8 +1449,36 @@ function updateBoundBotCustomModelFromDashboardSettings(
   };
   service.storeCustomModelProfile(botId, customModel);
   return options.publishActive
-    ? toBotDefinitionSyncPayload(service.publish(botId, customModel))
+    ? syncBoundBotModelToCloud(botId, customModel)
     : undefined;
+}
+
+async function syncBoundBotModelToCloud(
+  botId: string,
+  model: BotModelDefinition,
+): Promise<Record<string, unknown>> {
+  const runtimeRoot = runtimeDataRoot();
+  const definitionService = createBotDefinitionSyncService({ runtimeRoot });
+  const result = definitionService.updateModel(botId, model);
+  const payload = toBotDefinitionSyncPayload(result) ?? {};
+  const cloudSync = createBotDefinitionCloudSyncService({ runtimeRoot, definitionService });
+  cloudSync.markModelPending(botId);
+  try {
+    const snapshot = await cloudSync.pushModel(botId, getCatsAuthState(), result.definition.model);
+    return {
+      ...payload,
+      cloudSynced: Boolean(snapshot),
+      cloudPending: !snapshot,
+      ...(snapshot ? { cloudRevision: snapshot.revision } : {}),
+    };
+  } catch (error) {
+    return {
+      ...payload,
+      cloudSynced: false,
+      cloudPending: true,
+      cloudError: sanitizeCatsErrorMessage(error instanceof Error ? error.message : String(error)),
+    };
+  }
 }
 
 function publishCurrentBotDefinition(): BotDefinitionSyncResult | undefined {
@@ -1474,22 +1504,21 @@ function publishCurrentBotDefinitionPayload(): Record<string, unknown> | undefin
   return toBotDefinitionSyncPayload(publishCurrentBotDefinition());
 }
 
-function updateCurrentCustomDefinitionReasoningEffort(
+async function updateCurrentCustomDefinitionReasoningEffort(
   reasoningEffort: ReasoningEffort,
-): Record<string, unknown> | undefined {
+): Promise<Record<string, unknown> | undefined> {
   const service = createBotDefinitionSyncService({ runtimeRoot: runtimeDataRoot() });
   const definition = service.pullOrBootstrapCurrentBoundBot()?.definition;
   if (!definition || definition.model.kind !== 'custom') return undefined;
-  const result = service.publish(definition.botId, {
+  return syncBoundBotModelToCloud(definition.botId, {
     ...definition.model,
     reasoningEffort,
   });
-  return toBotDefinitionSyncPayload(result);
 }
 
-function updateCurrentCatalogRuntimeReasoningEffort(
+async function updateCurrentCatalogRuntimeReasoningEffort(
   reasoningEffort: ReasoningEffort,
-): Record<string, unknown> | undefined {
+): Promise<Record<string, unknown> | undefined> {
   const service = createBotDefinitionSyncService({ runtimeRoot: runtimeDataRoot() });
   const definition = service.pullOrBootstrapCurrentBoundBot()?.definition;
   if (!definition || definition.model.kind !== 'catalog') return undefined;
@@ -1498,7 +1527,10 @@ function updateCurrentCatalogRuntimeReasoningEffort(
     throw httpError('The selected catalog model is not materialized on this device.', 409);
   }
   service.storeCatalogRuntime({ ...runtime, reasoningEffort });
-  return toBotDefinitionSyncPayload(service.publish(definition.botId, definition.model));
+  return syncBoundBotModelToCloud(definition.botId, {
+    ...definition.model,
+    reasoningEffort,
+  });
 }
 
 function modelProfileFromStoredEnv(
@@ -2810,7 +2842,7 @@ export function createApiRouter(
     }
   });
 
-  router.put('/settings', (req, res) => {
+  router.put('/settings', async (req, res) => {
     try {
       const previousModel = modelProfileFromCurrentConfig();
       const previousSource = storedModelSource();
@@ -2820,7 +2852,7 @@ export function createApiRouter(
       // Bound bots never write a second model source to .env. Non-model
       // dashboard settings keep their existing machine-local behavior.
       const botDefinitionSync = boundBot
-        ? updateBoundBotCustomModelFromDashboardSettings(req.body, { publishActive: publishBoundCustom })
+        ? await updateBoundBotCustomModelFromDashboardSettings(req.body, { publishActive: publishBoundCustom })
         : undefined;
       const result = updateDashboardSettings(
         boundBot ? withoutDashboardModelUpdates(req.body) : req.body,
@@ -2854,14 +2886,14 @@ export function createApiRouter(
     }
   });
 
-  router.put('/model/reasoning-effort', (req, res) => {
+  router.put('/model/reasoning-effort', async (req, res) => {
     try {
       const requested = requestedReasoningEffort(req.body?.reasoningEffort);
       const activeBotConfig = resolveActiveBotLLMConfig({ runtimeRoot: runtimeDataRoot() });
       if (activeBotConfig?.source === 'custom_definition') {
         const previousReasoningEffort = activeBotConfig.config.reasoningEffort ?? 'default';
         const reasoningEffort = requested ?? previousReasoningEffort;
-        const botDefinitionSync = updateCurrentCustomDefinitionReasoningEffort(reasoningEffort);
+        const botDefinitionSync = await updateCurrentCustomDefinitionReasoningEffort(reasoningEffort);
         const restartInfo = req.body?.restartConnector === true || req.body?.activateConnector === true
           ? activateCatsCompanyConnector(serviceManager, {
             startIfStopped: req.body?.activateConnector === true || req.body?.startConnector === true,
@@ -2886,7 +2918,7 @@ export function createApiRouter(
       if (activeBotConfig?.source === 'catalog_runtime') {
         const previousReasoningEffort = activeBotConfig.config.reasoningEffort ?? 'high';
         const reasoningEffort = relayReasoningEffortOrHigh(requested ?? previousReasoningEffort);
-        const botDefinitionSync = updateCurrentCatalogRuntimeReasoningEffort(reasoningEffort);
+        const botDefinitionSync = await updateCurrentCatalogRuntimeReasoningEffort(reasoningEffort);
         const restartInfo = req.body?.restartConnector === true || req.body?.activateConnector === true
           ? activateCatsCompanyConnector(serviceManager, {
             startIfStopped: req.body?.activateConnector === true || req.body?.startConnector === true,
@@ -2917,7 +2949,7 @@ export function createApiRouter(
         : requested ?? previousReasoningEffort;
       const result = writeStartupReasoningEffort(reasoningEffort);
       const botDefinitionSync = result.source === 'custom'
-        ? updateCurrentCustomDefinitionReasoningEffort(reasoningEffort)
+        ? await updateCurrentCustomDefinitionReasoningEffort(reasoningEffort)
         : undefined;
       const restartInfo = req.body?.restartConnector === true || req.body?.activateConnector === true
         ? activateCatsCompanyConnector(serviceManager, {
@@ -2944,7 +2976,7 @@ export function createApiRouter(
     }
   });
 
-  router.post('/model-source/custom/apply', (req, res) => {
+  router.post('/model-source/custom/apply', async (req, res) => {
     try {
       const activeBotConfig = resolveActiveBotLLMConfig({ runtimeRoot: runtimeDataRoot() });
       const botId = currentBoundBotId();
@@ -2962,7 +2994,7 @@ export function createApiRouter(
           if (!savedCustom) {
             throw httpError('Set custom model fields in Settings before selecting the custom source.', 409);
           }
-          botDefinitionSync = toBotDefinitionSyncPayload(definitionService.publish(botId, savedCustom));
+          botDefinitionSync = await syncBoundBotModelToCloud(botId, savedCustom);
         }
         const activation = activateCatsCompanyConnector(serviceManager, {
           startIfStopped: req.body?.activateConnector === true || req.body?.startConnector === true,
@@ -4081,9 +4113,11 @@ export function createApiRouter(
         definitionService.storeCatalogRuntime(
           selectedRelayCatalogRuntime(botId, selectedModel, ensured.plainKey, reasoningEffort),
         );
-        botDefinitionSync = toBotDefinitionSyncPayload(
-          definitionService.publish(botId, { kind: 'catalog', modelId: selectedModel.id }),
-        );
+        botDefinitionSync = await syncBoundBotModelToCloud(botId, {
+          kind: 'catalog',
+          modelId: selectedModel.id,
+          reasoningEffort,
+        });
       }
       const restartInfo = activateCatsCompanyConnector(serviceManager, {
         startIfStopped: req.body?.activateConnector === true || req.body?.startConnector === true,

--- a/tests/bot-definition-activation.test.ts
+++ b/tests/bot-definition-activation.test.ts
@@ -60,6 +60,9 @@ describe('BotDefinition activation', () => {
     const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
       const url = new URL(String(input));
       requests.push(`${init?.method || 'GET'} ${url.pathname}`);
+      if (url.pathname === '/api/bot/definition') {
+        return Response.json({ error: 'not deployed' }, { status: 404 });
+      }
       if (url.pathname === '/api/bot/model-config') {
         return Response.json({ error: 'not deployed' }, { status: 404 });
       }
@@ -96,12 +99,123 @@ describe('BotDefinition activation', () => {
     assert.equal(resolveActiveBotLLMConfig({ runtimeRoot, env })?.config.apiKey, 'sk-bravo-relay-material');
     assert.equal(env.CATSCO_RELAY_LLM_API_KEY, undefined);
     assert.deepStrictEqual(requests, [
+      'GET /api/bot/definition',
       'GET /api/bot/model-config',
       'GET /api/relay/config',
       'GET /api/relay/key',
       'GET /api.json',
       'GET /v1/models',
     ]);
+  });
+
+  test('uploads a local legacy Definition when the cloud bot is not configured yet', async () => {
+    const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-definition-cloud-bootstrap-runtime-'));
+    const simulatedCloudRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-definition-cloud-bootstrap-legacy-'));
+    roots.push(runtimeRoot, simulatedCloudRoot);
+    const env = {} as NodeJS.ProcessEnv;
+    createCatsCoLocalConfigService({ runtimeRoot, env }).save({
+      version: 1,
+      endpoints: {
+        httpBaseUrl: 'https://cats.example.test',
+        serverUrl: 'wss://cats.example.test/v0/channels',
+      },
+      account: { token: 'owner-token', uid: '7', displayName: 'Alice' },
+      currentBot: {
+        uid: '43',
+        apiKey: 'bot-api-key',
+        boundByUserUid: '7',
+        bindingSource: 'test',
+      },
+    });
+    const legacyDefinition = {
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: '43',
+      model: {
+        kind: 'custom' as const,
+        protocol: 'openai-responses' as const,
+        apiBase: 'https://models.example.test/v1',
+        apiKey: 'sk-local-legacy',
+        model: 'legacy-custom-model',
+        contextWindowTokens: 256_000,
+        maxTokens: 8192,
+      },
+      prompt: {
+        selected: 'custom' as const,
+        customSystemPrompt: 'Legacy custom system prompt.',
+      },
+    };
+    new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot }).writeCanonical(legacyDefinition);
+
+    let revision = 0;
+    let cloudDefinition: typeof legacyDefinition | undefined;
+    const requests: Array<{ method: string; path: string; authorization: string; body?: any }> = [];
+    const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(String(input));
+      const method = init?.method || 'GET';
+      const authorization = new Headers(init?.headers).get('Authorization') || '';
+      const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+      requests.push({ method, path: url.pathname, authorization, body });
+
+      if (url.pathname === '/api/bot/definition' && method === 'GET') {
+        return Response.json(cloudDefinition
+          ? { configured: true, revision, definition: cloudDefinition }
+          : { configured: false, revision: 0 });
+      }
+      if (url.pathname === '/api/bots/definition/model' && method === 'PATCH') {
+        assert.equal(authorization, 'Bearer owner-token');
+        assert.equal(body.revision, revision);
+        revision += 1;
+        cloudDefinition = {
+          schema: BOT_DEFINITION_SCHEMA,
+          botId: '43',
+          model: body.model,
+          prompt: { selected: 'default' },
+        };
+        return Response.json({ revision });
+      }
+      if (url.pathname === '/api/bots/definition/prompt' && method === 'PATCH') {
+        assert.equal(authorization, 'Bearer owner-token');
+        assert.equal(body.revision, revision);
+        revision += 1;
+        cloudDefinition = {
+          ...cloudDefinition!,
+          prompt: body.prompt,
+        };
+        return Response.json({ revision });
+      }
+      if (url.pathname === '/api/bot/definition/ack' && method === 'POST') {
+        assert.equal(authorization, 'ApiKey bot-api-key');
+        assert.equal(body.revision, revision);
+        return Response.json({ status: 'applied' });
+      }
+      if (url.pathname === '/api/bot/model-config') {
+        assert.fail('new BotDefinition initialization must not use the legacy model-config endpoint');
+      }
+      return Response.json({ error: `unexpected ${method} ${url.pathname}` }, { status: 500 });
+    }) as typeof fetch;
+
+    const prepared = await prepareBoundBotDefinition({
+      runtimeRoot,
+      simulatedCloudRoot,
+      env,
+      fetchImpl,
+    });
+
+    assert.equal(prepared?.cloudRevision, 2);
+    assert.deepStrictEqual(prepared?.definition, legacyDefinition);
+    assert.deepStrictEqual(cloudDefinition, legacyDefinition);
+    assert.equal(
+      requests.filter(item => item.path === '/api/bots/definition/model').length,
+      1,
+    );
+    assert.equal(
+      requests.filter(item => item.path === '/api/bots/definition/prompt').length,
+      1,
+    );
+    assert.equal(
+      requests.filter(item => item.path === '/api/bot/definition/ack').length,
+      1,
+    );
   });
 
   test('applies and acknowledges a cloud-selected model after its local runtime is ready', async () => {
@@ -133,6 +247,9 @@ describe('BotDefinition activation', () => {
         body,
         authorization: new Headers(init?.headers).get('Authorization') || undefined,
       });
+      if (url.pathname === '/api/bot/definition') {
+        return Response.json({ error: 'not deployed' }, { status: 404 });
+      }
       if (url.pathname === '/api/bot/model-config') {
         return Response.json({
           uid: 43,
@@ -192,6 +309,9 @@ describe('BotDefinition activation', () => {
     let ackBody: any;
     const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
       const url = new URL(String(input));
+      if (url.pathname === '/api/bot/definition') {
+        return Response.json({ error: 'not deployed' }, { status: 404 });
+      }
       if (url.pathname === '/api/bot/model-config') {
         return Response.json({
           uid: 43,
@@ -312,6 +432,9 @@ describe('BotDefinition activation', () => {
     let failureAck: any;
     const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
       const url = new URL(String(input));
+      if (url.pathname === '/api/bot/definition') {
+        return Response.json({ error: 'not deployed' }, { status: 404 });
+      }
       if (url.pathname === '/api/bot/model-config') {
         return Response.json({ uid: 43, configured: true, desired: { model_id: 'unknown-model', revision: 4 } });
       }
@@ -367,6 +490,9 @@ describe('BotDefinition activation', () => {
     const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
       const url = new URL(String(input));
       requests.push({ path: url.pathname, body: init?.body ? JSON.parse(String(init.body)) : undefined });
+      if (url.pathname === '/api/bot/definition') {
+        return Response.json({ error: 'not deployed' }, { status: 404 });
+      }
       if (url.pathname === '/api/bot/model-config') {
         return Response.json({
           uid: 43,
@@ -450,6 +576,9 @@ describe('BotDefinition activation', () => {
     });
     const fetchImpl = (async (input: string | URL | Request) => {
       const url = new URL(String(input));
+      if (url.pathname === '/api/bot/definition') {
+        return Response.json({ error: 'not deployed' }, { status: 404 });
+      }
       if (url.pathname === '/api/bot/model-config') {
         return Response.json({
           uid: 43,
@@ -497,6 +626,9 @@ describe('BotDefinition activation', () => {
     let acknowledged = false;
     const fetchImpl = (async (input: string | URL | Request) => {
       const url = new URL(String(input));
+      if (url.pathname === '/api/bot/definition') {
+        return Response.json({ error: 'not deployed' }, { status: 404 });
+      }
       if (url.pathname === '/api/bot/model-config') {
         return Response.json({
           uid: 43,
@@ -559,10 +691,7 @@ describe('BotDefinition activation', () => {
 
     assert.equal(cloudPrepared?.cloudRevision, 11);
     assert.equal(resolveActiveBotLLMConfig({ runtimeRoot, env })?.config.model, 'cloud-model');
-    assert.deepStrictEqual(definitions.readCanonical('43'), {
-      ...localDefinition,
-      prompt: { selected: 'default' },
-    });
+    assert.deepStrictEqual(definitions.readCanonical('43'), localDefinition);
     assert.deepStrictEqual(definitions.readCache('43'), {
       ...localDefinition,
       prompt: { selected: 'default' },
@@ -590,7 +719,8 @@ describe('BotDefinition activation', () => {
     assert.equal(localPrepared?.cloudRevision, 12);
     assert.equal(resolveActiveBotLLMConfig({ runtimeRoot, env })?.config.model, 'local-model');
     assert.equal(new FileBotCloudModelOverrideRepository({ runtimeRoot }).read('43'), undefined);
-    assert.deepStrictEqual(definitions.readCanonical('43'), {
+    assert.deepStrictEqual(definitions.readCanonical('43'), localDefinition);
+    assert.deepStrictEqual(definitions.readCache('43'), {
       ...localDefinition,
       prompt: { selected: 'default' },
     });

--- a/tests/bot-definition-cloud-sync.test.ts
+++ b/tests/bot-definition-cloud-sync.test.ts
@@ -103,6 +103,117 @@ describe('BotDefinition cloud synchronization', () => {
     assert.equal(sync.readState('43').pendingModel, false);
   });
 
+  test('flushes model and prompt from the same pending local snapshot', async () => {
+    const runtimeRoot = makeRoot();
+    const definitionService = createBotDefinitionSyncService({ runtimeRoot, env: {} });
+    const local = definition('gpt-5.6-sol', 'local prompt');
+    definitionService.publish('43', local.model);
+    definitionService.updatePrompt('43', local.prompt!);
+    let cloud = definition('minimax-m3', 'cloud prompt');
+    let revision = 1;
+    const fetchImpl = (async (input, init) => {
+      const url = String(input);
+      if (url.includes('/api/bots/definition/model')) {
+        const body = JSON.parse(String(init?.body));
+        cloud = { ...cloud, model: body.model };
+        revision++;
+        return Response.json({ revision });
+      }
+      if (url.includes('/api/bots/definition/prompt')) {
+        const body = JSON.parse(String(init?.body));
+        cloud = { ...cloud, prompt: body.prompt };
+        revision++;
+        return Response.json({ revision });
+      }
+      return response(revision, cloud);
+    }) as typeof fetch;
+    const sync = new BotDefinitionCloudSyncService({
+      runtimeRoot,
+      env: {},
+      definitionService,
+      fetchImpl,
+    });
+    sync.markModelPending('43');
+    sync.markPromptPending('43');
+
+    const snapshot = await sync.flushPending('43', auth);
+
+    assert.equal(snapshot?.revision, 3);
+    assert.deepStrictEqual(cloud, local);
+    assert.equal(sync.readState('43').pendingModel, false);
+    assert.equal(sync.readState('43').pendingPrompt, false);
+  });
+
+  test('retries startup pending data only when the cloud revision is unchanged', async () => {
+    const runtimeRoot = makeRoot();
+    const definitionService = createBotDefinitionSyncService({ runtimeRoot, env: {} });
+    definitionService.publish('43', definition('gpt-5.6-sol').model);
+    let cloud = definition('minimax-m3');
+    let revision = 1;
+    let patchCount = 0;
+    const fetchImpl = (async (input, init) => {
+      const url = String(input);
+      if (url.includes('/api/bots/definition/model')) {
+        patchCount++;
+        const body = JSON.parse(String(init?.body));
+        cloud = { ...cloud, model: body.model };
+        revision++;
+        return Response.json({ revision });
+      }
+      return response(revision, cloud);
+    }) as typeof fetch;
+    const sync = new BotDefinitionCloudSyncService({
+      runtimeRoot,
+      env: {},
+      definitionService,
+      fetchImpl,
+    });
+    await sync.pull('43', auth);
+    definitionService.updateModel('43', definition('gpt-5.6-sol').model);
+    sync.markModelPending('43');
+
+    const snapshot = await sync.reconcileStartup('43', auth);
+
+    assert.equal(snapshot?.revision, 2);
+    assert.equal(patchCount, 1);
+    assert.deepStrictEqual(definitionService.read('43')?.model, definition('gpt-5.6-sol').model);
+    assert.equal(sync.readState('43').pendingModel, false);
+  });
+
+  test('does not overwrite a newer cloud revision with stale startup pending data', async () => {
+    const runtimeRoot = makeRoot();
+    const definitionService = createBotDefinitionSyncService({ runtimeRoot, env: {} });
+    let cloud = definition('minimax-m3');
+    let revision = 1;
+    let patchCount = 0;
+    const fetchImpl = (async input => {
+      const url = String(input);
+      if (url.includes('/api/bots/definition/model')) {
+        patchCount++;
+        return Response.json({ error: 'unexpected patch' }, { status: 500 });
+      }
+      return response(revision, cloud);
+    }) as typeof fetch;
+    const sync = new BotDefinitionCloudSyncService({
+      runtimeRoot,
+      env: {},
+      definitionService,
+      fetchImpl,
+    });
+    await sync.pull('43', auth);
+    definitionService.updateModel('43', definition('gpt-5.6-sol').model);
+    sync.markModelPending('43');
+    cloud = definition('deepseek-v4-flash');
+    revision = 2;
+
+    const snapshot = await sync.reconcileStartup('43', auth);
+
+    assert.equal(snapshot?.revision, 2);
+    assert.equal(patchCount, 0);
+    assert.deepStrictEqual(definitionService.read('43'), cloud);
+    assert.equal(sync.readState('43').pendingModel, false);
+  });
+
   test('retries one explicit local field update after a stale revision', async () => {
     const runtimeRoot = makeRoot();
     const definitionService = createBotDefinitionSyncService({ runtimeRoot, env: {} });

--- a/tests/bot-definition-cloud-sync.test.ts
+++ b/tests/bot-definition-cloud-sync.test.ts
@@ -1,0 +1,148 @@
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, test } from 'node:test';
+import { BotDefinitionCloudSyncService } from '../src/bot-definition/cloud-sync';
+import { createBotDefinitionSyncService } from '../src/bot-definition/service';
+import type { BotDefinition } from '../src/bot-definition/types';
+
+const roots: string[] = [];
+const auth = {
+  token: 'owner-token',
+  apiKey: 'bot-api-key',
+  httpBaseUrl: 'https://cats.example.test',
+  serverUrl: 'wss://cats.example.test/v0/channels',
+} as any;
+
+function makeRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-cloud-definition-'));
+  roots.push(root);
+  return root;
+}
+
+function definition(modelId: string, prompt = 'default'): BotDefinition {
+  return {
+    schema: 'xiaoba.bot-definition.v1',
+    botId: '43',
+    model: { kind: 'catalog', modelId },
+    prompt: prompt === 'default'
+      ? { selected: 'default' }
+      : { selected: 'custom', customSystemPrompt: prompt },
+  };
+}
+
+function response(revision: number, value: BotDefinition): Response {
+  return Response.json({
+    uid: 43,
+    configured: true,
+    revision,
+    definition: value,
+    runtime: { desiredRevision: revision },
+  });
+}
+
+afterEach(() => {
+  while (roots.length) fs.rmSync(roots.pop()!, { recursive: true, force: true });
+});
+
+describe('BotDefinition cloud synchronization', () => {
+  test('pull stores the cloud definition in the runnable local cache', async () => {
+    const runtimeRoot = makeRoot();
+    const definitionService = createBotDefinitionSyncService({ runtimeRoot, env: {} });
+    const sync = new BotDefinitionCloudSyncService({
+      runtimeRoot,
+      env: {},
+      definitionService,
+      fetchImpl: (async () => response(5, definition('gpt-5.6-sol'))) as typeof fetch,
+    });
+
+    const snapshot = await sync.pull('43', auth);
+
+    assert.equal(snapshot?.revision, 5);
+    assert.deepStrictEqual(definitionService.read('43'), definition('gpt-5.6-sol'));
+    assert.deepStrictEqual(sync.readState('43'), {
+      schema: 'xiaoba.bot-definition-cloud-sync.v1',
+      botId: '43',
+      revision: 5,
+      pendingModel: false,
+      pendingPrompt: false,
+    });
+  });
+
+  test('keeps a failed local update pending and retries it later', async () => {
+    const runtimeRoot = makeRoot();
+    const definitionService = createBotDefinitionSyncService({ runtimeRoot, env: {} });
+    definitionService.publish('43', definition('gpt-5.6-sol').model);
+    let available = false;
+    let revision = 1;
+    const fetchImpl = (async (input) => {
+      const url = String(input);
+      if (!available && url.includes('/api/bots/definition/model')) {
+        return Response.json({ error: 'offline' }, { status: 503 });
+      }
+      if (url.includes('/api/bots/definition/model')) {
+        revision++;
+        return Response.json({ revision });
+      }
+      return response(revision, definition('gpt-5.6-sol'));
+    }) as typeof fetch;
+    const sync = new BotDefinitionCloudSyncService({
+      runtimeRoot,
+      env: {},
+      definitionService,
+      fetchImpl,
+    });
+
+    await assert.rejects(sync.pushModel('43', auth), /offline/);
+    assert.equal(sync.readState('43').pendingModel, true);
+
+    available = true;
+    const snapshot = await sync.flushPending('43', auth);
+    assert.equal(snapshot?.revision, 2);
+    assert.equal(sync.readState('43').pendingModel, false);
+  });
+
+  test('retries one explicit local field update after a stale revision', async () => {
+    const runtimeRoot = makeRoot();
+    const definitionService = createBotDefinitionSyncService({ runtimeRoot, env: {} });
+    definitionService.publish('43', definition('gpt-5.6-sol').model);
+    let patchCount = 0;
+    let cloud = definition('minimax-m3');
+    let revision = 2;
+    const fetchImpl = (async (input, init) => {
+      const url = String(input);
+      if (url.includes('/api/bots/definition/model')) {
+        patchCount++;
+        const body = JSON.parse(String(init?.body));
+        if (patchCount === 1) {
+          cloud = definition('deepseek-v4-flash');
+          revision = 3;
+          return Response.json({ error: 'stale' }, { status: 409 });
+        }
+        assert.equal(body.revision, 3);
+        cloud = {
+          ...cloud,
+          model: body.model,
+        };
+        revision = 4;
+        return Response.json({ revision });
+      }
+      return response(revision, cloud);
+    }) as typeof fetch;
+    const sync = new BotDefinitionCloudSyncService({
+      runtimeRoot,
+      env: {},
+      definitionService,
+      fetchImpl,
+    });
+
+    const snapshot = await sync.pushModel('43', auth, definition('gpt-5.6-sol').model);
+
+    assert.equal(patchCount, 2);
+    assert.equal(snapshot?.revision, 4);
+    assert.equal(definitionService.read('43')?.model.kind, 'catalog');
+    assert.equal((definitionService.read('43')?.model as any).modelId, 'gpt-5.6-sol');
+    assert.equal(sync.readState('43').pendingModel, false);
+  });
+});

--- a/tests/bot-definition-local-repository.test.ts
+++ b/tests/bot-definition-local-repository.test.ts
@@ -93,7 +93,7 @@ describe('BotDefinition local simulation', () => {
     });
   }
 
-  test('publishes a custom model on local change and refreshes the local cache', () => {
+  test('bootstraps a custom model into the local cache without rewriting legacy simulated cloud', () => {
     bindCurrentBot();
     const env = {
       CATSCO_MODEL_SOURCE: 'custom',
@@ -106,7 +106,7 @@ describe('BotDefinition local simulation', () => {
     const service = createBotDefinitionSyncService({ runtimeRoot, simulatedCloudRoot, env });
 
     const result = service.publishCurrentBoundBot();
-    assert.equal(result?.direction, 'bootstrap_to_simulated_cloud');
+    assert.equal(result?.direction, 'legacy_bootstrap_to_local');
     assert.deepStrictEqual(result?.definition.model, {
       kind: 'custom',
       protocol: 'anthropic',
@@ -117,11 +117,34 @@ describe('BotDefinition local simulation', () => {
     });
 
     const repository = new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot });
-    assert.deepStrictEqual(repository.readCanonical('bot-alpha'), result?.definition);
+    assert.equal(repository.readCanonical('bot-alpha'), undefined);
     assert.deepStrictEqual(repository.readCache('bot-alpha'), result?.definition);
   });
 
-  test('pull uses canonical data over stale cache and does not overwrite canonical data', () => {
+  test('an existing local cache remains the runtime truth over legacy simulated cloud', () => {
+    const repository = new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot });
+    const canonical: BotDefinition = {
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-alpha',
+      model: { kind: 'catalog', modelId: 'gpt-5.6-terra' },
+    };
+    const cached: BotDefinition = {
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-alpha',
+      model: { kind: 'catalog', modelId: 'old-model' },
+    };
+    repository.writeCanonical(canonical);
+    repository.writeCache(cached);
+    const service = createBotDefinitionSyncService({ runtimeRoot, simulatedCloudRoot });
+
+    const result = service.pullOrBootstrap('bot-alpha');
+    assert.equal(result?.direction, 'local_cache_update');
+    assert.deepStrictEqual(result?.definition, cached);
+    assert.deepStrictEqual(repository.readCanonical('bot-alpha'), canonical);
+    assert.deepStrictEqual(repository.readCache('bot-alpha'), cached);
+  });
+
+  test('migrates legacy simulated cloud once when no local cache exists', () => {
     const repository = new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot });
     const canonical: BotDefinition = {
       schema: BOT_DEFINITION_SCHEMA,
@@ -129,15 +152,11 @@ describe('BotDefinition local simulation', () => {
       model: { kind: 'catalog', modelId: 'gpt-5.6-terra' },
     };
     repository.writeCanonical(canonical);
-    repository.writeCache({
-      schema: BOT_DEFINITION_SCHEMA,
-      botId: 'bot-alpha',
-      model: { kind: 'catalog', modelId: 'old-model' },
-    });
     const service = createBotDefinitionSyncService({ runtimeRoot, simulatedCloudRoot });
 
     const result = service.pullOrBootstrap('bot-alpha');
-    assert.equal(result?.direction, 'simulated_cloud_to_local');
+
+    assert.equal(result?.direction, 'legacy_simulated_cloud_to_local');
     assert.deepStrictEqual(result?.definition, canonical);
     assert.deepStrictEqual(repository.readCanonical('bot-alpha'), canonical);
     assert.deepStrictEqual(repository.readCache('bot-alpha'), canonical);
@@ -476,5 +495,23 @@ describe('BotDefinition local simulation', () => {
     assert.equal(cleanedConfig.apiKey, undefined);
     assert.equal(cleanedConfig.model, undefined);
     assert.deepStrictEqual(cleanedConfig.catscompany, { enabled: true });
+  });
+
+  test('preserves the complete custom system prompt received from canonical storage', () => {
+    const repository = new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot });
+    const service = createBotDefinitionSyncService({ runtimeRoot, simulatedCloudRoot });
+    const customSystemPrompt = '\nPreserve leading and trailing lines.\n';
+
+    service.acceptCanonical({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-alpha',
+      model: { kind: 'catalog', modelId: 'minimax-m3' },
+      prompt: { selected: 'custom', customSystemPrompt },
+    });
+
+    assert.equal(
+      repository.readCache('bot-alpha')?.prompt?.customSystemPrompt,
+      customSystemPrompt,
+    );
   });
 });

--- a/tests/bot-definition-prompt-sync.test.ts
+++ b/tests/bot-definition-prompt-sync.test.ts
@@ -10,12 +10,12 @@ import { createBotDefinitionSyncService } from '../src/bot-definition/service';
 import { BOT_DEFINITION_SCHEMA, type BotDefinition } from '../src/bot-definition/types';
 import { getPromptOverridesDir, readRequiredBundledPromptFile } from '../src/utils/prompt-template';
 
-class FailingCanonicalRepository extends FileBotDefinitionRepository {
-  failCanonicalWrite = false;
+class FailingCacheRepository extends FileBotDefinitionRepository {
+  failCacheWrite = false;
 
-  override writeCanonical(definition: BotDefinition): void {
-    if (this.failCanonicalWrite) throw new Error('simulated canonical write failure');
-    super.writeCanonical(definition);
+  override writeCache(definition: BotDefinition): void {
+    if (this.failCacheWrite) throw new Error('simulated cache write failure');
+    super.writeCache(definition);
   }
 }
 
@@ -148,14 +148,14 @@ describe('BotDefinition system prompt sync', () => {
     await coordinator.activateBot('bot-a');
 
     assert.equal(coordinator.getSelection('bot-a').definitionReady, true);
-    assert.equal(repository.readCanonical('bot-a')?.prompt?.selected, 'default');
+    assert.equal(repository.readCache('bot-a')?.prompt?.selected, 'default');
     assert.equal(fs.readFileSync(coordinator.getActivePromptPath(), 'utf-8'), 'bundled v1\n');
 
     fs.writeFileSync(path.join(appRoot, 'prompts', 'system-prompt.md'), 'bundled v2\n', 'utf-8');
     await coordinator.activateBot('bot-a');
 
     assert.equal(fs.readFileSync(coordinator.getActivePromptPath(), 'utf-8'), 'bundled v2\n');
-    assert.equal(repository.readCanonical('bot-a')?.prompt?.selected, 'default');
+    assert.equal(repository.readCache('bot-a')?.prompt?.selected, 'default');
   });
 
   test('captures a locally edited default as custom instead of overwriting it', async () => {
@@ -165,7 +165,7 @@ describe('BotDefinition system prompt sync', () => {
 
     await coordinator.activateBot('bot-a');
 
-    assert.deepStrictEqual(repository.readCanonical('bot-a')?.prompt, {
+    assert.deepStrictEqual(repository.readCache('bot-a')?.prompt, {
       selected: 'custom',
       customSystemPrompt: 'agent edited prompt',
     });
@@ -183,7 +183,7 @@ describe('BotDefinition system prompt sync', () => {
 
     await coordinator.select('bot-a', 'default');
     assert.equal(fs.readFileSync(coordinator.getActivePromptPath(), 'utf-8'), 'bundled v2\n');
-    assert.equal(repository.readCanonical('bot-a')?.prompt?.customSystemPrompt, 'my custom prompt');
+    assert.equal(repository.readCache('bot-a')?.prompt?.customSystemPrompt, 'my custom prompt');
 
     await coordinator.select('bot-a', 'custom');
     assert.equal(fs.readFileSync(coordinator.getActivePromptPath(), 'utf-8'), 'my custom prompt\n');
@@ -197,7 +197,7 @@ describe('BotDefinition system prompt sync', () => {
 
     await coordinator.activateBot('bot-a');
 
-    assert.deepStrictEqual(repository.readCanonical('bot-a')?.prompt, {
+    assert.deepStrictEqual(repository.readCache('bot-a')?.prompt, {
       selected: 'custom',
       customSystemPrompt: 'last local edit',
     });
@@ -216,10 +216,10 @@ describe('BotDefinition system prompt sync', () => {
     });
 
     service.updateModel('bot-a', { kind: 'catalog', modelId: 'deepseek-v4-flash' });
-    assert.equal(repository.readCanonical('bot-a')?.prompt?.customSystemPrompt, 'portable prompt');
+    assert.equal(repository.readCache('bot-a')?.prompt?.customSystemPrompt, 'portable prompt');
 
     service.updatePrompt('bot-a', { selected: 'default', customSystemPrompt: 'portable prompt' });
-    assert.deepStrictEqual(repository.readCanonical('bot-a')?.model, {
+    assert.deepStrictEqual(repository.readCache('bot-a')?.model, {
       kind: 'catalog',
       modelId: 'deepseek-v4-flash',
     });
@@ -247,7 +247,7 @@ describe('BotDefinition system prompt sync', () => {
       customSystemPrompt: 'cross-process prompt',
     });
 
-    assert.deepStrictEqual(repository.readCanonical('bot-a'), {
+    assert.deepStrictEqual(repository.readCache('bot-a'), {
       schema: BOT_DEFINITION_SCHEMA,
       botId: 'bot-a',
       model: { kind: 'catalog', modelId: 'deepseek-v4-flash' },
@@ -264,47 +264,47 @@ describe('BotDefinition system prompt sync', () => {
     fs.writeFileSync(coordinator.getActivePromptPath(), '  \n\n', 'utf-8');
 
     assert.equal(await coordinator.reconcileCurrent({ force: true }), false);
-    assert.deepStrictEqual(repository.readCanonical('bot-a')?.prompt, { selected: 'default' });
+    assert.deepStrictEqual(repository.readCache('bot-a')?.prompt, { selected: 'default' });
   });
 
   test('does not advance the sync baseline when canonical persistence fails', async () => {
-    const repository = new FailingCanonicalRepository({ runtimeRoot, simulatedCloudRoot });
+    const repository = new FailingCacheRepository({ runtimeRoot, simulatedCloudRoot });
     const { coordinator } = createCoordinator('bot-a', repository);
     await coordinator.activateBot('bot-a');
     const stateBefore = fs.readFileSync(coordinator.getStatePath(), 'utf-8');
     fs.writeFileSync(coordinator.getActivePromptPath(), 'retry this prompt\n', 'utf-8');
-    repository.failCanonicalWrite = true;
+    repository.failCacheWrite = true;
 
     await assert.rejects(
       () => coordinator.reconcileCurrent({ force: true }),
-      /simulated canonical write failure/,
+      /simulated cache write failure/,
     );
     assert.equal(fs.readFileSync(coordinator.getStatePath(), 'utf-8'), stateBefore);
-    assert.deepStrictEqual(repository.readCanonical('bot-a')?.prompt, { selected: 'default' });
+    assert.deepStrictEqual(repository.readCache('bot-a')?.prompt, { selected: 'default' });
 
-    repository.failCanonicalWrite = false;
+    repository.failCacheWrite = false;
     assert.equal(await coordinator.reconcileCurrent({ force: true }), true);
-    assert.deepStrictEqual(repository.readCanonical('bot-a')?.prompt, {
+    assert.deepStrictEqual(repository.readCache('bot-a')?.prompt, {
       selected: 'custom',
       customSystemPrompt: 'retry this prompt',
     });
   });
 
   test('restores the active prompt when an explicit selection cannot persist', async () => {
-    const repository = new FailingCanonicalRepository({ runtimeRoot, simulatedCloudRoot });
+    const repository = new FailingCacheRepository({ runtimeRoot, simulatedCloudRoot });
     const { coordinator } = createCoordinator('bot-a', repository);
     await coordinator.activateBot('bot-a');
     const promptBefore = fs.readFileSync(coordinator.getActivePromptPath(), 'utf-8');
     const stateBefore = fs.readFileSync(coordinator.getStatePath(), 'utf-8');
-    repository.failCanonicalWrite = true;
+    repository.failCacheWrite = true;
 
     await assert.rejects(
       () => coordinator.select('bot-a', 'custom', 'should roll back'),
-      /simulated canonical write failure/,
+      /simulated cache write failure/,
     );
     assert.equal(fs.readFileSync(coordinator.getActivePromptPath(), 'utf-8'), promptBefore);
     assert.equal(fs.readFileSync(coordinator.getStatePath(), 'utf-8'), stateBefore);
-    assert.deepStrictEqual(repository.readCanonical('bot-a')?.prompt, { selected: 'default' });
+    assert.deepStrictEqual(repository.readCache('bot-a')?.prompt, { selected: 'default' });
   });
 
   test('migrates an existing active override only for the active bot', async () => {
@@ -313,8 +313,8 @@ describe('BotDefinition system prompt sync', () => {
     fs.writeFileSync(coordinator.getActivePromptPath(), 'legacy override\n', 'utf-8');
 
     await coordinator.activateBot('bot-a');
-    assert.equal(repository.readCanonical('bot-a')?.prompt?.selected, 'custom');
-    assert.equal(repository.readCanonical('bot-a')?.prompt?.customSystemPrompt, 'legacy override');
+    assert.equal(repository.readCache('bot-a')?.prompt?.selected, 'custom');
+    assert.equal(repository.readCache('bot-a')?.prompt?.customSystemPrompt, 'legacy override');
 
     repository.writeCanonical({
       schema: BOT_DEFINITION_SCHEMA,
@@ -324,7 +324,7 @@ describe('BotDefinition system prompt sync', () => {
     repository.writeCache(repository.readCanonical('bot-b')!);
     await coordinator.activateBot('bot-b');
 
-    assert.equal(repository.readCanonical('bot-b')?.prompt?.selected, 'default');
+    assert.equal(repository.readCache('bot-b')?.prompt?.selected, 'default');
     assert.equal(fs.readFileSync(coordinator.getActivePromptPath(), 'utf-8'), 'bundled v1\n');
   });
 
@@ -351,11 +351,11 @@ describe('BotDefinition system prompt sync', () => {
     });
     await coordinator.activateBot('bot-b');
 
-    assert.deepStrictEqual(repository.readCanonical('bot-a')?.prompt, {
+    assert.deepStrictEqual(repository.readCache('bot-a')?.prompt, {
       selected: 'custom',
       customSystemPrompt: 'legacy prompt from bot A',
     });
-    assert.deepStrictEqual(repository.readCanonical('bot-b')?.prompt, {
+    assert.deepStrictEqual(repository.readCache('bot-b')?.prompt, {
       selected: 'default',
     });
     assert.equal(fs.readFileSync(coordinator.getActivePromptPath(), 'utf-8'), 'bundled v1\n');

--- a/tests/bot-definition-prompt-sync.test.ts
+++ b/tests/bot-definition-prompt-sync.test.ts
@@ -204,6 +204,24 @@ describe('BotDefinition system prompt sync', () => {
     assert.equal(fs.readFileSync(coordinator.getActivePromptPath(), 'utf-8'), 'last local edit\n');
   });
 
+  test('materializes the cloud-selected prompt over an offline file edit', async () => {
+    const { coordinator, repository } = createCoordinator();
+    await coordinator.activateBot('bot-a');
+    fs.writeFileSync(coordinator.getActivePromptPath(), 'offline local edit\n', 'utf-8');
+    repository.writeCache({
+      ...repository.readCache('bot-a')!,
+      prompt: { selected: 'custom', customSystemPrompt: 'cloud prompt' },
+    });
+
+    await coordinator.activateBot('bot-a', { preferDefinition: true });
+
+    assert.deepStrictEqual(repository.readCache('bot-a')?.prompt, {
+      selected: 'custom',
+      customSystemPrompt: 'cloud prompt',
+    });
+    assert.equal(fs.readFileSync(coordinator.getActivePromptPath(), 'utf-8'), 'cloud prompt\n');
+  });
+
   test('model and prompt field updates preserve each other', async () => {
     const { coordinator, repository } = createCoordinator();
     await coordinator.activateBot('bot-a');
@@ -307,14 +325,18 @@ describe('BotDefinition system prompt sync', () => {
     assert.deepStrictEqual(repository.readCache('bot-a')?.prompt, { selected: 'default' });
   });
 
-  test('migrates an existing active override only for the active bot', async () => {
+  test('backs up a legacy active override while selecting the current bundled default', async () => {
     const { coordinator, repository } = createCoordinator('bot-a');
     fs.mkdirSync(path.dirname(coordinator.getActivePromptPath()), { recursive: true });
     fs.writeFileSync(coordinator.getActivePromptPath(), 'legacy override\n', 'utf-8');
 
     await coordinator.activateBot('bot-a');
-    assert.equal(repository.readCache('bot-a')?.prompt?.selected, 'custom');
+    assert.equal(repository.readCache('bot-a')?.prompt?.selected, 'default');
     assert.equal(repository.readCache('bot-a')?.prompt?.customSystemPrompt, 'legacy override');
+    assert.equal(fs.readFileSync(coordinator.getActivePromptPath(), 'utf-8'), 'bundled v1\n');
+    await coordinator.select('bot-a', 'custom');
+    assert.equal(fs.readFileSync(coordinator.getActivePromptPath(), 'utf-8'), 'legacy override\n');
+    await coordinator.select('bot-a', 'default');
 
     repository.writeCanonical({
       schema: BOT_DEFINITION_SCHEMA,
@@ -325,6 +347,27 @@ describe('BotDefinition system prompt sync', () => {
     await coordinator.activateBot('bot-b');
 
     assert.equal(repository.readCache('bot-b')?.prompt?.selected, 'default');
+    assert.equal(fs.readFileSync(coordinator.getActivePromptPath(), 'utf-8'), 'bundled v1\n');
+  });
+
+  test('backs up a legacy override even when cloud bootstrap already supplied default prompt', async () => {
+    const { coordinator, repository } = createCoordinator('bot-a');
+    repository.writeCanonical({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: 'bot-a',
+      model: { kind: 'catalog', modelId: 'minimax-m3' },
+      prompt: { selected: 'default' },
+    });
+    repository.writeCache(repository.readCanonical('bot-a')!);
+    fs.mkdirSync(path.dirname(coordinator.getActivePromptPath()), { recursive: true });
+    fs.writeFileSync(coordinator.getActivePromptPath(), 'legacy override\n', 'utf-8');
+
+    await coordinator.activateBot('bot-a');
+
+    assert.deepStrictEqual(repository.readCache('bot-a')?.prompt, {
+      selected: 'default',
+      customSystemPrompt: 'legacy override',
+    });
     assert.equal(fs.readFileSync(coordinator.getActivePromptPath(), 'utf-8'), 'bundled v1\n');
   });
 
@@ -352,7 +395,7 @@ describe('BotDefinition system prompt sync', () => {
     await coordinator.activateBot('bot-b');
 
     assert.deepStrictEqual(repository.readCache('bot-a')?.prompt, {
-      selected: 'custom',
+      selected: 'default',
       customSystemPrompt: 'legacy prompt from bot A',
     });
     assert.deepStrictEqual(repository.readCache('bot-b')?.prompt, {

--- a/tests/cloud-bot-model-client.test.ts
+++ b/tests/cloud-bot-model-client.test.ts
@@ -1,7 +1,11 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import {
+  acknowledgeCloudBotDefinition,
   acknowledgeCloudBotModelSelection,
+  patchCloudBotDefinitionModel,
+  patchCloudBotDefinitionPrompt,
+  pullCloudBotDefinition,
   pullCloudBotModelSelection,
 } from '../src/bot-definition/cloud-client';
 
@@ -11,6 +15,150 @@ const auth = {
 } as any;
 
 describe('cloud bot model client local handoff', () => {
+  test('reads the canonical BotDefinition with the bot credential', async () => {
+    let authorization = '';
+    const snapshot = await pullCloudBotDefinition({
+      botId: '43',
+      auth,
+      fetchImpl: (async (input, init) => {
+        assert.equal(String(input), 'https://cats.example.test/api/bot/definition');
+        authorization = String((init?.headers as Record<string, string>)?.Authorization || '');
+        return Response.json({
+          uid: 43,
+          configured: true,
+          revision: 4,
+          definition: {
+            schema: 'xiaoba.bot-definition.v1',
+            botId: '43',
+            model: { kind: 'catalog', modelId: 'minimax-m3' },
+            prompt: { selected: 'default' },
+          },
+          runtime: { desiredRevision: 4, appliedRevision: 3 },
+        });
+      }) as typeof fetch,
+    });
+
+    assert.equal(authorization, 'ApiKey bot-api-key');
+    assert.deepStrictEqual(snapshot, {
+      configured: true,
+      revision: 4,
+      definition: {
+        schema: 'xiaoba.bot-definition.v1',
+        botId: '43',
+        model: { kind: 'catalog', modelId: 'minimax-m3' },
+        prompt: { selected: 'default' },
+      },
+      runtime: { desiredRevision: 4, appliedRevision: 3 },
+    });
+  });
+
+  test('restores a cloud custom model and preserves custom prompt text exactly', async () => {
+    const snapshot = await pullCloudBotDefinition({
+      botId: '43',
+      auth,
+      fetchImpl: (async () => Response.json({
+        uid: 43,
+        configured: true,
+        revision: 5,
+        definition: {
+          schema: 'xiaoba.bot-definition.v1',
+          botId: '43',
+          model: {
+            kind: 'custom',
+            protocol: 'openai-responses',
+            apiBase: 'https://relay.example.test/v1',
+            model: 'gpt-private',
+            apiKey: 'secret-key',
+            contextWindowTokens: 256000,
+            maxTokens: 8192,
+            temperature: 0.7,
+            reasoningEffort: 'high',
+          },
+          prompt: {
+            selected: 'custom',
+            customSystemPrompt: '\nPreserve this spacing.\n',
+          },
+        },
+      })) as typeof fetch,
+    });
+
+    assert.deepStrictEqual(snapshot?.definition, {
+      schema: 'xiaoba.bot-definition.v1',
+      botId: '43',
+      model: {
+        kind: 'custom',
+        protocol: 'openai-responses',
+        apiBase: 'https://relay.example.test/v1',
+        model: 'gpt-private',
+        apiKey: 'secret-key',
+        contextWindowTokens: 256000,
+        maxTokens: 8192,
+        temperature: 0.7,
+        reasoningEffort: 'high',
+      },
+      prompt: {
+        selected: 'custom',
+        customSystemPrompt: '\nPreserve this spacing.\n',
+      },
+    });
+  });
+
+  test('patches model and prompt with owner auth and acknowledges with bot auth', async () => {
+    const requests: Array<{ url: string; authorization: string; body: any }> = [];
+    const fetchImpl = (async (input, init) => {
+      requests.push({
+        url: String(input),
+        authorization: String((init?.headers as Record<string, string>)?.Authorization || ''),
+        body: init?.body ? JSON.parse(String(init.body)) : undefined,
+      });
+      return Response.json({ revision: requests.length });
+    }) as typeof fetch;
+    const ownerAndBotAuth = {
+      ...auth,
+      token: 'owner-token',
+    } as any;
+
+    assert.equal(await patchCloudBotDefinitionModel({
+      botId: '43',
+      auth: ownerAndBotAuth,
+      fetchImpl,
+    }, { kind: 'catalog', modelId: 'gpt-5.6-sol', reasoningEffort: 'high' }, 7), 1);
+    assert.equal(await patchCloudBotDefinitionPrompt({
+      botId: '43',
+      auth: ownerAndBotAuth,
+      fetchImpl,
+    }, { selected: 'custom', customSystemPrompt: 'Custom prompt.' }, 8), 2);
+    await acknowledgeCloudBotDefinition({
+      botId: '43',
+      auth: ownerAndBotAuth,
+      fetchImpl,
+    }, 9, 'apply failed');
+
+    assert.deepStrictEqual(requests, [
+      {
+        url: 'https://cats.example.test/api/bots/definition/model?uid=43',
+        authorization: 'Bearer owner-token',
+        body: {
+          revision: 7,
+          model: { kind: 'catalog', modelId: 'gpt-5.6-sol', reasoningEffort: 'high' },
+        },
+      },
+      {
+        url: 'https://cats.example.test/api/bots/definition/prompt?uid=43',
+        authorization: 'Bearer owner-token',
+        body: {
+          revision: 8,
+          prompt: { selected: 'custom', customSystemPrompt: 'Custom prompt.' },
+        },
+      },
+      {
+        url: 'https://cats.example.test/api/bot/definition/ack',
+        authorization: 'ApiKey bot-api-key',
+        body: { revision: 9, error: 'apply failed' },
+      },
+    ]);
+  });
+
   test('returns an explicit local revision after cloud management is disabled', async () => {
     const selection = await pullCloudBotModelSelection({
       botId: '43',

--- a/tests/dashboard-catsco-auth-status.test.ts
+++ b/tests/dashboard-catsco-auth-status.test.ts
@@ -1280,7 +1280,7 @@ describe('dashboard CatsCo account status', () => {
     const data = JSON.parse(text) as any;
     const env = dotenv.parse(fs.readFileSync(path.join(testRoot, '.env'), 'utf-8'));
     const runtime = new FileBotCatalogModelRuntimeRepository({ runtimeRoot: testRoot }).read('188');
-    const definition = definitionRepository.readCanonical('188');
+    const definition = definitionRepository.readCache('188');
     const resolved = resolveActiveBotLLMConfig({ runtimeRoot: testRoot });
 
     assert.equal(response.status, 200, text);
@@ -1410,7 +1410,7 @@ describe('dashboard CatsCo account status', () => {
     const text = await response.text();
     const data = JSON.parse(text) as any;
     const runtime = new FileBotCatalogModelRuntimeRepository({ runtimeRoot: testRoot }).read('188');
-    const definition = definitionRepository.readCanonical('188');
+    const definition = definitionRepository.readCache('188');
     const resolved = resolveActiveBotLLMConfig({ runtimeRoot: testRoot });
 
     assert.equal(response.status, 200, text);

--- a/tests/dashboard-settings-api.test.ts
+++ b/tests/dashboard-settings-api.test.ts
@@ -388,19 +388,12 @@ describe('dashboard typed settings API', () => {
     });
     const text = await response.text();
     const data = JSON.parse(text) as any;
-    const definitionPath = path.join(
-      testRoot,
-      'data',
-      'bot-definition-simulated-cloud',
-      'bots',
-      'bot-definition-test.json',
-    );
-
     assert.equal(response.status, 200, text);
     assert.ok(data.botDefinitionSync, text);
-    const definition = JSON.parse(fs.readFileSync(definitionPath, 'utf-8')) as any;
+    const definition = new FileBotDefinitionRepository({ runtimeRoot: testRoot })
+      .readCache('bot-definition-test') as any;
     assert.equal(data.botDefinitionSync.botId, 'bot-definition-test');
-    assert.equal(data.botDefinitionSync.direction, 'local_to_simulated_cloud');
+    assert.equal(data.botDefinitionSync.direction, 'local_cache_update');
     assert.equal(data.botDefinitionSync.model.kind, 'custom');
     assert.equal(data.botDefinitionSync.model.model, 'gpt-portable');
     assert.equal(data.connectorRestarted, false);
@@ -655,7 +648,7 @@ describe('dashboard typed settings API', () => {
     assert.equal(data.reasoningEffort, 'high');
     assert.equal(definition.model.reasoningEffort, 'high');
     assert.equal(env.GAUZ_LLM_REASONING_EFFORT, undefined);
-    assert.equal(data.botDefinitionSync.direction, 'local_to_simulated_cloud');
+    assert.equal(data.botDefinitionSync.direction, 'local_cache_update');
   });
 
   test('PUT /model/reasoning-effort updates the active relay source without touching custom startup', async () => {


### PR DESCRIPTION
## 这次做了什么

把 XiaoBa 的 canonical BotDefinition 从本地模拟目录切换到 CatsCompany 云端，同时保留本地 cache 作为实际运行输入和离线兜底。

对应服务端依赖：buildsense-ai/cats-company#122

## 保持不变的用户体验

- 模型与 Prompt 仍由现有 BotDefinition、LLM resolver、Prompt coordinator 和 connector 流程应用。
- 本地 Dashboard 修改后先更新本地 cache，再同步云端。
- 启动、切换 Bot 与 Web 修改后由云端向本地同步。
- 云端暂时不可用时继续使用最后一次本地 cache。
- Prompt 文件仍可被用户或 Agent 直接修改，并通过现有回合后/下一轮前的哈希扫描同步。

## 主要改动

- 新增薄层 `BotDefinitionCloudClient` / `BotDefinitionCloudSyncService`，不重写现有运行框架。
- 云端读取使用 bot API Key；owner 侧字段更新使用登录 token。
- model 与 prompt 独立 PATCH，revision 过期时拉取最新版并只重放当前字段。
- 本地 simulated canonical 降级为一次性迁移来源，本地 cache 成为唯一运行输入。
- 启动与切换 Bot：先拉云端 Definition，再物化 Prompt、准备目录模型 runtime，最后启动 connector。
- Web 每 5 秒轮询云端 revision：Prompt-only 变化下一轮生效且不重启；模型变化准备成功后只重启 connector 一次。
- 应用失败时恢复上一份可运行 Definition/runtime/Prompt，并向云端 ACK 错误。
- Dashboard 的模型、推理强度和 Prompt 修改写入本地后向云端同步；失败保留本地 pending 状态供后续重试。
- 新服务端不可用时保留旧 `/api/bot/model-config` fallback。
- 自定义 Prompt 全文原样保留，不会因 canonical 同步丢失首尾换行。

## 初始化与迁移

云端没有 Definition 时，沿用现有本地来源完成一次性补齐：

1. 本地 simulated Definition
2. 旧 `.env` 模型配置
3. 旧 system prompt override
4. 都不存在时初始化 `minimax-m3` 与默认 Prompt

迁移只在云端缺失字段时发生，不覆盖已有云端 model/prompt。

## 验证

- `npm run build` 通过
- `npm test`：1196 项，1192 pass、4 skip、0 fail
- 覆盖云端拉取/推送、409 revision 重试、pending 重试、离线 cache、迁移、Prompt 哈希同步、Prompt-only 热应用、模型单次重启、Dashboard 写入与旧接口 fallback

## 合并顺序

请先合并并部署 buildsense-ai/cats-company#122，再进行本 PR 的真实云端验收。服务端未更新时客户端仍会使用旧接口 fallback。