### PR TITLE
fix: stabilize GPT-5.6 Responses cache identity and metrics

### DIFF
--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -1357,6 +1357,7 @@ export class ConversationRunner {
     return {
       role: 'system',
       content: `${TRANSIENT_RUNNER_HINT_PREFIX}\n${renderRequiredDefaultPromptFile('transient/runner-duplicate-outbound.md', { content })}`,
+      __cacheScope: 'dynamic',
     };
   }
 
@@ -1375,6 +1376,7 @@ export class ConversationRunner {
         TRANSIENT_RUNNER_HINT_PREFIX,
         renderRequiredDefaultPromptFile('transient/runner-empty-max-tokens.md', {}),
       ].join('\n'),
+      __cacheScope: 'dynamic',
     };
   }
 

--- a/src/core/pending-user-input-boundary.ts
+++ b/src/core/pending-user-input-boundary.ts
@@ -7,5 +7,6 @@ export function buildPendingUserInputBoundaryMessage(): Message {
   return {
     role: 'system',
     content: `${TRANSIENT_PENDING_USER_INPUT_PREFIX}\n${renderRequiredDefaultPromptFile('transient/pending-user-input-boundary.md', {})}`,
+    __cacheScope: 'dynamic',
   };
 }

--- a/src/core/runner-orchestration-policy.ts
+++ b/src/core/runner-orchestration-policy.ts
@@ -124,6 +124,7 @@ export function makeRunnerHint(lines: string[]): Message {
   return {
     role: 'system',
     content: [TRANSIENT_RUNNER_HINT_PREFIX, ...lines].join('\n'),
+    __cacheScope: 'dynamic',
   };
 }
 

--- a/src/core/sub-agent-observation.ts
+++ b/src/core/sub-agent-observation.ts
@@ -37,6 +37,7 @@ export function buildSubAgentStatusMessage(
         sections: sections.join('\n\n'),
       }),
     ].join('\n\n'),
+    __cacheScope: 'dynamic',
   };
 }
 

--- a/src/core/turn-context-builder.ts
+++ b/src/core/turn-context-builder.ts
@@ -73,7 +73,7 @@ export class TurnContextBuilder {
       await params.skillRuntime.reloadSkills();
       const skillsListMsg = params.skillRuntime.buildSkillsListMessage();
       if (skillsListMsg) {
-        this.insertBeforeLastUser(contextMessages, skillsListMsg);
+        this.insertBeforeLastUser(contextMessages, { ...skillsListMsg, __cacheScope: 'dynamic' });
       }
     }
 
@@ -114,7 +114,7 @@ export class TurnContextBuilder {
       localFileGrants: params.localFileGrants,
     });
     if (!message) return;
-    this.insertBeforeLastUser(messages, message);
+    this.insertBeforeLastUser(messages, { ...message, __cacheScope: 'dynamic' });
   }
 
   private injectRuntimeObservationRules(messages: Message[]): void {
@@ -151,6 +151,7 @@ export class TurnContextBuilder {
     this.insertBeforeLastUser(messages, {
       role: 'system',
       content: `${TRANSIENT_PLAN_STATUS_PREFIX}\n${planText}`,
+      __cacheScope: 'dynamic',
     });
   }
 

--- a/src/providers/openai-provider.ts
+++ b/src/providers/openai-provider.ts
@@ -365,16 +365,11 @@ export class OpenAIProvider implements AIProvider {
 
   private buildResponsesRequestBody(messages: Message[], tools?: ToolDefinition[], stream = false): any {
     const instructions = messages
-      .filter(message => message.role === 'system')
+      .filter(message => message.role === 'system' && !this.isDynamicCacheMessage(message))
       .map(message => this.contentAsText(message.content))
       .filter(Boolean)
       .join('\n\n');
-    const responseTools = tools?.map(tool => ({
-      type: 'function',
-      name: tool.name,
-      description: tool.description,
-      parameters: tool.parameters,
-    })) ?? [];
+    const responseTools = this.buildCanonicalResponsesTools(tools ?? []);
     const body: any = {
       model: this.model,
       input: this.buildResponsesInput(messages),
@@ -402,9 +397,13 @@ export class OpenAIProvider implements AIProvider {
 
   private buildResponsesInput(messages: Message[]): any[] {
     const input: any[] = [];
+    const dynamicSystemMessages: Message[] = [];
 
     for (const message of messages) {
-      if (message.role === 'system') continue;
+      if (message.role === 'system') {
+        if (this.isDynamicCacheMessage(message)) dynamicSystemMessages.push(message);
+        continue;
+      }
 
       if (message.role === 'tool') {
         if (!message.tool_call_id) continue;
@@ -444,7 +443,43 @@ export class OpenAIProvider implements AIProvider {
       });
     }
 
+    for (const message of dynamicSystemMessages) {
+      input.push({
+        role: 'system',
+        content: this.responsesMessageContent(message.content),
+      });
+    }
+
     return input;
+  }
+
+  private isDynamicCacheMessage(message: Message): boolean {
+    if (message.__cacheScope === 'dynamic') return true;
+    if (message.__cacheScope === 'stable') return false;
+    if (message.role !== 'system' || typeof message.content !== 'string') return false;
+    return /^\[(?:transient_[^\]]+|compact_boundary)\]/.test(message.content);
+  }
+
+  private buildCanonicalResponsesTools(tools: ToolDefinition[]): any[] {
+    return tools
+      .map(tool => ({
+        type: 'function',
+        name: tool.name,
+        description: tool.description,
+        parameters: tool.parameters,
+      }))
+      .sort((left, right) => left.name < right.name ? -1 : left.name > right.name ? 1 : 0)
+      .map(tool => this.canonicalizeJsonValue(tool));
+  }
+
+  private canonicalizeJsonValue(value: any): any {
+    if (Array.isArray(value)) return value.map(item => this.canonicalizeJsonValue(item));
+    if (!value || typeof value !== 'object') return value;
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map(key => [key, this.canonicalizeJsonValue(value[key])]),
+    );
   }
 
   private responsesMessageContent(content: Message['content']): any {
@@ -480,7 +515,12 @@ export class OpenAIProvider implements AIProvider {
 
   private buildPromptCacheKey(instructions: string, tools: any[]): string {
     const digest = createHash('sha256')
-      .update(JSON.stringify({ model: this.model, instructions, tools }))
+      .update(JSON.stringify({
+        identityVersion: 'responses-cache-v2',
+        model: this.model,
+        instructions,
+        tools,
+      }))
       .digest('hex')
       .slice(0, 48);
     return `catsco-${digest}`;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -21,6 +21,11 @@ export interface Message {
   name?: string;
   /** 标记由 injectContext 注入的消息，用于滑动窗口清理 */
   __injected?: boolean;
+  /**
+   * Provider-only cache placement hint. Dynamic system context remains system-priority
+   * but is appended to Responses input instead of destabilizing instructions.
+   */
+  __cacheScope?: 'stable' | 'dynamic';
   /** 标记注入给 agent 看的运行时反馈，仅供内部清理和日志记录使用 */
   __runtimeFeedback?: boolean;
   /** 标记内部 runtime observation，例如子 agent 完成结果；对模型仍以 user role 承载 */

--- a/src/utils/metrics.ts
+++ b/src/utils/metrics.ts
@@ -20,6 +20,10 @@ export interface MetricsSummary {
   totalPromptTokens: number;
   totalCompletionTokens: number;
   totalTokens: number;
+  totalCachedReadTokens: number;
+  totalCachedWriteTokens: number;
+  /** cached read / prompt tokens; omitted when no prompt tokens were recorded. */
+  cacheReadRatio?: number;
   toolCalls: number;
   toolDurationMs: number;
   /** 按工具名分组的调用次数和总耗时 */
@@ -50,11 +54,15 @@ export class Metrics {
     let totalPromptTokens = 0;
     let totalCompletionTokens = 0;
     let totalTokens = 0;
+    let totalCachedReadTokens = 0;
+    let totalCachedWriteTokens = 0;
 
     for (const call of this.aiCalls) {
       totalPromptTokens += call.usage.promptTokens;
       totalCompletionTokens += call.usage.completionTokens;
       totalTokens += call.usage.totalTokens;
+      totalCachedReadTokens += call.usage.cachedReadTokens ?? 0;
+      totalCachedWriteTokens += call.usage.cachedWriteTokens ?? 0;
     }
 
     let toolDurationMs = 0;
@@ -74,6 +82,9 @@ export class Metrics {
       totalPromptTokens,
       totalCompletionTokens,
       totalTokens,
+      totalCachedReadTokens,
+      totalCachedWriteTokens,
+      cacheReadRatio: totalPromptTokens > 0 ? totalCachedReadTokens / totalPromptTokens : undefined,
       toolCalls: this.toolCalls.length,
       toolDurationMs,
       toolBreakdown,

--- a/tests/metrics.test.ts
+++ b/tests/metrics.test.ts
@@ -1,0 +1,68 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Metrics } from '../src/utils/metrics';
+
+describe('Metrics cached token aggregation', () => {
+  test('aggregates cached reads and writes and computes the read ratio', () => {
+    Metrics.reset();
+    try {
+      Metrics.recordAICall('gpt-test', {
+        promptTokens: 100,
+        completionTokens: 20,
+        totalTokens: 120,
+        cachedReadTokens: 40,
+        cachedWriteTokens: 10,
+      });
+      Metrics.recordAICall('gpt-test', {
+        promptTokens: 50,
+        completionTokens: 5,
+        totalTokens: 55,
+        cachedReadTokens: 20,
+        cachedWriteTokens: 5,
+      });
+
+      const summary = Metrics.getSummary();
+      assert.equal(summary.totalCachedReadTokens, 60);
+      assert.equal(summary.totalCachedWriteTokens, 15);
+      assert.equal(summary.cacheReadRatio, 0.4);
+    } finally {
+      Metrics.reset();
+    }
+  });
+
+  test('treats missing cached fields as zero', () => {
+    Metrics.reset();
+    try {
+      Metrics.recordAICall('gpt-test', {
+        promptTokens: 25,
+        completionTokens: 5,
+        totalTokens: 30,
+      });
+
+      const summary = Metrics.getSummary();
+      assert.equal(summary.totalCachedReadTokens, 0);
+      assert.equal(summary.totalCachedWriteTokens, 0);
+      assert.equal(summary.cacheReadRatio, 0);
+    } finally {
+      Metrics.reset();
+    }
+  });
+
+  test('reset clears cached totals and omits ratio for a zero denominator', () => {
+    Metrics.reset();
+    Metrics.recordAICall('gpt-test', {
+      promptTokens: 10,
+      completionTokens: 1,
+      totalTokens: 11,
+      cachedReadTokens: 8,
+      cachedWriteTokens: 2,
+    });
+
+    Metrics.reset();
+    const summary = Metrics.getSummary();
+    assert.equal(summary.aiCalls, 0);
+    assert.equal(summary.totalCachedReadTokens, 0);
+    assert.equal(summary.totalCachedWriteTokens, 0);
+    assert.equal(summary.cacheReadRatio, undefined);
+  });
+});

--- a/tests/openai-provider-responses.test.ts
+++ b/tests/openai-provider-responses.test.ts
@@ -52,6 +52,119 @@ describe('OpenAIProvider Responses API mode', () => {
     assert.deepEqual(first.include, ['reasoning.encrypted_content']);
   });
 
+  test('keeps dynamic system context out of cache identity and appends it to input', () => {
+    const provider = createProvider();
+    const first = (provider as any).buildResponsesRequestBody([
+      { role: 'system', content: 'Stable policy.' },
+      { role: 'system', content: '[transient_plan_status]\nstep one', __cacheScope: 'dynamic' },
+      { role: 'user', content: 'first question' },
+    ], [lookupTool]);
+    const second = (provider as any).buildResponsesRequestBody([
+      { role: 'system', content: 'Stable policy.' },
+      { role: 'system', content: '[transient_plan_status]\nstep two' },
+      { role: 'user', content: 'another question' },
+    ], [lookupTool]);
+
+    assert.equal(first.instructions, 'Stable policy.');
+    assert.equal(second.instructions, 'Stable policy.');
+    assert.equal(first.prompt_cache_key, second.prompt_cache_key);
+    assert.deepEqual(first.input, [
+      { role: 'user', content: 'first question' },
+      { role: 'system', content: '[transient_plan_status]\nstep one' },
+    ]);
+    assert.deepEqual(second.input, [
+      { role: 'user', content: 'another question' },
+      { role: 'system', content: '[transient_plan_status]\nstep two' },
+    ]);
+  });
+
+  test('keeps plan, subagent, runner, and device changes out of cache identity', () => {
+    const provider = createProvider();
+    const variants = [
+      ['[transient_plan_status]\nstep one', '[transient_plan_status]\nstep two'],
+      ['[transient_subagent_status]\nrunning', '[transient_subagent_status]\ncompleted'],
+      ['[transient_runner_hint]\nfirst hint', '[transient_runner_hint]\nnext hint'],
+      ['[transient_runtime_context]\ndevice-a', '[transient_runtime_context]\ndevice-b'],
+    ];
+
+    for (const [firstDynamic, secondDynamic] of variants) {
+      const first = (provider as any).buildResponsesRequestBody([
+        { role: 'system', content: 'Stable policy.' },
+        { role: 'system', content: firstDynamic },
+        { role: 'user', content: 'hello' },
+      ], [lookupTool]);
+      const second = (provider as any).buildResponsesRequestBody([
+        { role: 'system', content: 'Stable policy.' },
+        { role: 'system', content: secondDynamic },
+        { role: 'user', content: 'hello' },
+      ], [lookupTool]);
+
+      assert.equal(first.prompt_cache_key, second.prompt_cache_key);
+      assert.equal(first.input.at(-1).role, 'system');
+      assert.equal(first.input.at(-1).content, firstDynamic);
+    }
+
+    const changedStable = (provider as any).buildResponsesRequestBody([
+      { role: 'system', content: 'Changed stable policy.' },
+      { role: 'user', content: 'hello' },
+    ], [lookupTool]);
+    const baseline = (provider as any).buildResponsesRequestBody([
+      { role: 'system', content: 'Stable policy.' },
+      { role: 'user', content: 'hello' },
+    ], [lookupTool]);
+    assert.notEqual(changedStable.prompt_cache_key, baseline.prompt_cache_key);
+  });
+
+  test('canonicalizes tool order and schema keys while detecting contract changes', () => {
+    const provider = createProvider();
+    const alpha: ToolDefinition = {
+      name: 'alpha',
+      description: 'Alpha tool',
+      parameters: {
+        type: 'object',
+        properties: {
+          zebra: { description: 'last', type: 'string' },
+          apple: { type: 'string', description: 'first' },
+        },
+        required: ['apple'],
+      },
+    };
+    const alphaReordered: ToolDefinition = {
+      name: 'alpha',
+      description: 'Alpha tool',
+      parameters: {
+        required: ['apple'],
+        properties: {
+          apple: { description: 'first', type: 'string' },
+          zebra: { type: 'string', description: 'last' },
+        },
+        type: 'object',
+      },
+    };
+    const beta: ToolDefinition = {
+      name: 'beta',
+      description: 'Beta tool',
+      parameters: { type: 'object', properties: {} },
+    };
+
+    const first = (provider as any).buildResponsesRequestBody([
+      { role: 'system', content: 'Stable policy.' },
+      { role: 'user', content: 'hello' },
+    ], [beta, alpha]);
+    const reordered = (provider as any).buildResponsesRequestBody([
+      { role: 'system', content: 'Stable policy.' },
+      { role: 'user', content: 'hello' },
+    ], [alphaReordered, beta]);
+    const changed = (provider as any).buildResponsesRequestBody([
+      { role: 'system', content: 'Stable policy.' },
+      { role: 'user', content: 'hello' },
+    ], [{ ...alphaReordered, description: 'Changed contract' }, beta]);
+
+    assert.deepEqual(first.tools.map((tool: any) => tool.name), ['alpha', 'beta']);
+    assert.equal(first.prompt_cache_key, reordered.prompt_cache_key);
+    assert.notEqual(first.prompt_cache_key, changed.prompt_cache_key);
+  });
+
   test('applies configured reasoning only to endpoints known to support it', () => {
     const provider = new OpenAIProvider({
       apiKey: 'test-key',
@@ -98,7 +211,7 @@ describe('OpenAIProvider Responses API mode', () => {
             input_tokens: 10000,
             output_tokens: 20,
             total_tokens: 10020,
-            input_tokens_details: { cached_tokens: 9472 },
+            input_tokens_details: { cached_tokens: 9472, cache_creation_tokens: 512 },
           },
         },
       };
@@ -111,6 +224,7 @@ describe('OpenAIProvider Responses API mode', () => {
       assert.equal(seenBody.stream, false);
       assert.equal(result.content, 'cached answer');
       assert.equal(result.usage?.cachedReadTokens, 9472);
+      assert.equal(result.usage?.cachedWriteTokens, 512);
       assert.equal(result.usage?.totalTokens, 10020);
     } finally {
       (axios as any).post = originalPost;

--- a/tests/openai-provider-runtime-feedback.test.ts
+++ b/tests/openai-provider-runtime-feedback.test.ts
@@ -18,6 +18,7 @@ describe('OpenAIProvider runtime feedback boundary', () => {
         role: 'user',
         content: '[运行时反馈] feishu.file_download\n错误: 文件下载失败',
         __injected: true,
+        __cacheScope: 'dynamic',
         __runtimeFeedback: true,
         __runtimeObservation: true,
         runtimeObservationSource: 'subagent_result',
@@ -50,6 +51,7 @@ describe('OpenAIProvider runtime feedback boundary', () => {
     assert.deepStrictEqual(Object.keys(body.messages[1]).sort(), ['content', 'role', 'tool_calls']);
     assert.deepStrictEqual(Object.keys(body.messages[2]).sort(), ['content', 'name', 'role', 'tool_call_id']);
     assert.equal(JSON.stringify(body.messages).includes('__injected'), false);
+    assert.equal(JSON.stringify(body.messages).includes('__cacheScope'), false);
     assert.equal(JSON.stringify(body.messages).includes('__runtimeFeedback'), false);
     assert.equal(JSON.stringify(body.messages).includes('__runtimeObservation'), false);
     assert.equal(JSON.stringify(body.messages).includes('__episodeId'), false);


### PR DESCRIPTION
## Summary

- keep versioned, stable system instructions in Responses `instructions` while moving dynamic runtime context behind the stable input prefix
- normalize the Responses tools contract before sending and deriving `prompt_cache_key`; expose budget-disabled tools as a distinct capability variant
- aggregate cached read/write token metrics and decode cached-token fields from both Responses and Chat usage payloads

## Validation

- `npm run build`
- `node scripts/run-tests.mjs tests/metrics.test.ts tests/openai-provider-responses.test.ts tests/openai-provider-runtime-feedback.test.ts`
- full suite: 1186 passed, 0 failed, 7 skipped
- three live GPT-5.6 Responses calls: cached tokens 6144, 6528, 6528; aggregate cache-read ratio 91.68%

Closes #265