### PR TITLE
fix: isolate Anthropic dynamic system cache state

### DIFF
--- a/docs/ANTHROPIC_PROMPT_CACHE_CANARY.md
+++ b/docs/ANTHROPIC_PROMPT_CACHE_CANARY.md
@@ -1,0 +1,46 @@
+# Anthropic Prompt Cache Canary
+
+This canary verifies the native Anthropic prompt-caching request path with two requests that share
+the same stable system prefix and use different dynamic system suffixes.
+
+## Safety boundary
+
+The script always targets `https://api.anthropic.com`; a relay URL cannot be configured. It emits
+only:
+
+- the request and message IDs;
+- the model and API path;
+- SHA-256 hashes of the stable and dynamic system blocks;
+- input, cache creation/read, and output token usage.
+
+Prompt bodies and credentials are never written to the evidence record. Error output is limited to
+the error type, HTTP status, and request ID.
+
+## Run
+
+Use a dedicated official Anthropic credential and choose a currently supported model:
+
+```bash
+ANTHROPIC_CANARY_API_KEY=... \
+ANTHROPIC_CANARY_MODEL=... \
+npm run canary:anthropic-prompt-cache -- \
+  --run \
+  --output .scratch/anthropic-prompt-cache-canary.json
+```
+
+The command makes two billable API requests. The output file is created with owner-only
+permissions. Inspect the record before attaching it to an issue or pull request; do not attach
+environment files or debug logs.
+
+## Interpret
+
+A useful record has:
+
+- the same `stable_system_sha256` for the pair;
+- different `dynamic_system_sha256` values;
+- `/v1/messages?beta=prompt_caching` as each `api_path`;
+- non-zero `cache_creation_input_tokens` on cache creation and non-zero
+  `cache_read_input_tokens` when the stable prefix is reused.
+
+Cache availability and minimum cacheable-prefix rules are controlled by Anthropic. A zero cache
+read is a failed canary result, not evidence of a cache gain.

--- a/docs/prompt-stack-format.md
+++ b/docs/prompt-stack-format.md
@@ -50,6 +50,16 @@ Runtime context only. Not a user request.
 - Work state：计划状态、子 agent 状态、后台观察结果、恢复提示。
 - Recovery hints：重复外发、空 max_tokens、工具失败后的单轮纠偏。
 
+### Provider-specific system priority
+
+`role: "user"` 是动态注入的默认传输形式，不覆盖明确要求 system priority 的 provider 适配规则。
+
+原生 Anthropic Messages 是当前的例外：plan、subagent、runner、skills 和 runtime 等已经标记为
+`role: "system"` 的临时上下文，仍作为 top-level system text blocks 发送。稳定 system 前缀使用
+`cache_control: { type: "ephemeral" }`，动态 system 后缀位于 cache breakpoint 之后且不缓存。
+这些消息仍然是 turn-scoped provider input，不写入 durable history。Anthropic-compatible relay 在确认
+支持 prompt-caching blocks 之前继续使用原有的单字符串 system request shape。
+
 ## Add-New-Requirement Checklist
 
 新增一条 prompt 需求时，先回答：

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test:legacy": "node scripts/run-tests.mjs legacy",
     "test:all": "node scripts/run-tests.mjs all",
     "test:list": "node scripts/run-tests.mjs runtime --list",
+    "canary:anthropic-prompt-cache": "node scripts/anthropic-prompt-cache-canary.mjs",
     "report": "node dist/index.js chat --exec '/report'",
     "clean-logs": "node scripts/clean-logs.mjs",
     "prepare:runtime": "node scripts/prepare-runtime.mjs",

--- a/scripts/anthropic-prompt-cache-canary.mjs
+++ b/scripts/anthropic-prompt-cache-canary.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import Anthropic from '@anthropic-ai/sdk';
+
+const CANONICAL_API_ORIGIN = 'https://api.anthropic.com';
+const CANARY_SCHEMA = 'xiaoba.anthropic-prompt-cache-canary.v1';
+const REQUEST_ID_HEADERS = ['request-id', 'x-request-id'];
+
+export function sha256(text) {
+  return createHash('sha256').update(text, 'utf8').digest('hex');
+}
+
+export function buildCanarySystem(stableText, dynamicText) {
+  return [
+    {
+      type: 'text',
+      text: stableText,
+      cache_control: { type: 'ephemeral' },
+    },
+    {
+      type: 'text',
+      text: dynamicText,
+    },
+  ];
+}
+
+export function buildAttemptEvidence({ response, message, dynamicText }) {
+  const responseUrl = new URL(response.url);
+  const usage = message?.usage || {};
+  const requestId = REQUEST_ID_HEADERS
+    .map(header => response.headers.get(header))
+    .find(Boolean);
+
+  return {
+    request_id: requestId || null,
+    message_id: typeof message?.id === 'string' ? message.id : null,
+    api_path: `${responseUrl.pathname}${responseUrl.search}`,
+    dynamic_system_sha256: sha256(dynamicText),
+    usage: {
+      input_tokens: Number(usage.input_tokens ?? 0),
+      cache_creation_input_tokens: Number(usage.cache_creation_input_tokens ?? 0),
+      cache_read_input_tokens: Number(usage.cache_read_input_tokens ?? 0),
+      output_tokens: Number(usage.output_tokens ?? 0),
+    },
+  };
+}
+
+export function buildCanaryEvidence({ model, stableText, attempts, recordedAt = new Date() }) {
+  return {
+    schema: CANARY_SCHEMA,
+    recorded_at: recordedAt.toISOString(),
+    api_origin: CANONICAL_API_ORIGIN,
+    model,
+    stable_system_sha256: sha256(stableText),
+    attempts,
+  };
+}
+
+export async function runCanary({ apiKey, model, stableText }) {
+  const client = new Anthropic({
+    apiKey,
+    baseURL: CANONICAL_API_ORIGIN,
+    timeout: 10 * 60 * 1000,
+  });
+  const dynamicVariants = [
+    '[transient_plan_status]\nPrompt-cache canary state A.',
+    '[transient_plan_status]\nPrompt-cache canary state B.',
+  ];
+  const attempts = [];
+
+  for (const dynamicText of dynamicVariants) {
+    const pending = client.beta.promptCaching.messages.create({
+      model,
+      max_tokens: 1,
+      system: buildCanarySystem(stableText, dynamicText),
+      messages: [{
+        role: 'user',
+        content: 'Reply with one character.',
+      }],
+    });
+    const { data: message, response } = await pending.withResponse();
+    attempts.push(buildAttemptEvidence({ response, message, dynamicText }));
+  }
+
+  return buildCanaryEvidence({ model, stableText, attempts });
+}
+
+function parseOutputPath(args) {
+  const inline = args.find(arg => arg.startsWith('--output='));
+  if (inline) return inline.slice('--output='.length);
+  const index = args.indexOf('--output');
+  return index >= 0 ? args[index + 1] : undefined;
+}
+
+function printUsage() {
+  console.error([
+    'Usage:',
+    '  ANTHROPIC_CANARY_API_KEY=... ANTHROPIC_CANARY_MODEL=... \\',
+    '    npm run canary:anthropic-prompt-cache -- --run [--output evidence.json]',
+    '',
+    'The command makes two canonical Anthropic API requests and never records prompt bodies or credentials.',
+  ].join('\n'));
+}
+
+function sanitizeError(error) {
+  const source = error && typeof error === 'object' ? error : {};
+  return {
+    name: typeof source.name === 'string' ? source.name : 'Error',
+    status: typeof source.status === 'number' ? source.status : null,
+    request_id: typeof source.request_id === 'string' ? source.request_id : null,
+    type: typeof source.error?.type === 'string' ? source.error.type : null,
+  };
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (!args.includes('--run')) {
+    printUsage();
+    process.exitCode = 2;
+    return;
+  }
+
+  const apiKey = process.env.ANTHROPIC_CANARY_API_KEY;
+  const model = process.env.ANTHROPIC_CANARY_MODEL;
+  if (!apiKey || !model) {
+    console.error('ANTHROPIC_CANARY_API_KEY and ANTHROPIC_CANARY_MODEL are required.');
+    process.exitCode = 2;
+    return;
+  }
+
+  const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+  const stableText = fs.readFileSync(path.join(scriptDir, '..', 'prompts', 'system-prompt.md'), 'utf8');
+
+  try {
+    const evidence = await runCanary({ apiKey, model, stableText });
+    const serialized = `${JSON.stringify(evidence, null, 2)}\n`;
+    const outputPath = parseOutputPath(args);
+    if (outputPath) {
+      const resolvedOutput = path.resolve(outputPath);
+      fs.mkdirSync(path.dirname(resolvedOutput), { recursive: true });
+      fs.writeFileSync(resolvedOutput, serialized, { mode: 0o600 });
+      console.log(`Redacted canary evidence written to ${resolvedOutput}`);
+      return;
+    }
+    process.stdout.write(serialized);
+  } catch (error) {
+    console.error(JSON.stringify({
+      schema: CANARY_SCHEMA,
+      error: sanitizeError(error),
+    }));
+    process.exitCode = 1;
+  }
+}
+
+const invokedAsScript = process.argv[1]
+  && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url;
+if (invokedAsScript) {
+  main().catch((error) => {
+    console.error(JSON.stringify({
+      schema: CANARY_SCHEMA,
+      error: sanitizeError(error),
+    }));
+    process.exitCode = 1;
+  });
+}

--- a/src/providers/anthropic-provider.ts
+++ b/src/providers/anthropic-provider.ts
@@ -54,7 +54,7 @@ export class AnthropicProvider implements AIProvider {
    * 标准化 base URL（去掉末尾的 /v1/messages 等路径）
    */
   private normalizeBaseURL(url: string): string {
-    return url.replace(/\/v1\/messages\/?$/, '').replace(/\/v1\/?$/, '');
+    return url.replace(/\/+$/, '').replace(/\/v1\/messages$/, '').replace(/\/v1$/, '');
   }
 
   /**

--- a/src/providers/anthropic-provider.ts
+++ b/src/providers/anthropic-provider.ts
@@ -10,6 +10,12 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === 'object' && !Array.isArray(value));
 }
 
+type AnthropicSystemBlock = Anthropic.TextBlockParam & {
+  cache_control?: { type: 'ephemeral' };
+};
+
+type AnthropicSystemPrompt = string | AnthropicSystemBlock[];
+
 /**
  * Anthropic Provider
  * 使用官方 SDK 替代 axios 手动调用，支持 streaming
@@ -54,10 +60,8 @@ export class AnthropicProvider implements AIProvider {
   /**
    * 转换消息为 Anthropic 格式
    */
-  private transformMessages(messages: Message[]): { system?: string; messages: Anthropic.MessageParam[] } {
-    const systemMessages = messages.filter(msg => msg.role === 'system');
-    const systemPrompt = systemMessages.map(msg => typeof msg.content === 'string' ? msg.content : '').join('\n\n');
-
+  private transformMessages(messages: Message[]): { system?: AnthropicSystemPrompt; messages: Anthropic.MessageParam[] } {
+    const systemPrompt = this.buildSystemPrompt(messages);
     const nonSystemMessages = messages.filter(msg => msg.role !== 'system');
     const transformedMessages: Anthropic.MessageParam[] = [];
     let pendingToolResults: Anthropic.ToolResultBlockParam[] = [];
@@ -171,9 +175,69 @@ export class AnthropicProvider implements AIProvider {
     flushToolResults();
 
     return {
-      system: systemPrompt || undefined,
+      system: systemPrompt,
       messages: this.coalesceAdjacentUserMessages(transformedMessages)
     };
+  }
+
+  private buildSystemPrompt(messages: Message[]): AnthropicSystemPrompt | undefined {
+    const systemMessages = messages.filter(message => (
+      message.role === 'system'
+      && typeof message.content === 'string'
+      && message.content.length > 0
+    ));
+    if (systemMessages.length === 0) return undefined;
+
+    if (!this.supportsNativePromptCaching()) {
+      return systemMessages.map(message => message.content as string).join('\n\n');
+    }
+
+    const firstDynamicIndex = systemMessages.findIndex(message => this.isDynamicSystemMessage(message));
+    if (firstDynamicIndex === 0) {
+      return [{
+        type: 'text',
+        text: systemMessages.map(message => message.content as string).join('\n\n'),
+      }];
+    }
+
+    const stableEnd = firstDynamicIndex < 0 ? systemMessages.length : firstDynamicIndex;
+    const blocks: AnthropicSystemBlock[] = [{
+      type: 'text',
+      text: systemMessages.slice(0, stableEnd).map(message => message.content as string).join('\n\n'),
+      cache_control: { type: 'ephemeral' },
+    }];
+    if (stableEnd < systemMessages.length) {
+      blocks.push({
+        type: 'text',
+        text: systemMessages.slice(stableEnd).map(message => message.content as string).join('\n\n'),
+      });
+    }
+    return blocks;
+  }
+
+  private supportsNativePromptCaching(): boolean {
+    try {
+      const url = new URL(this.apiUrl);
+      const normalizedPath = url.pathname.replace(/\/+$/, '') || '/';
+      return url.protocol === 'https:'
+        && url.hostname.toLowerCase() === 'api.anthropic.com'
+        && (url.port === '' || url.port === '443')
+        && !url.username
+        && !url.password
+        && !url.search
+        && !url.hash
+        && ['/', '/v1', '/v1/messages'].includes(normalizedPath);
+    } catch {
+      return false;
+    }
+  }
+
+  private isDynamicSystemMessage(message: Message): boolean {
+    const cacheScope = message.__cacheScope;
+    if (cacheScope === 'dynamic') return true;
+    if (cacheScope === 'stable') return false;
+    return typeof message.content === 'string'
+      && /^\[(?:transient_[^\]]+|compact_boundary)\]/.test(message.content);
   }
 
   private coalesceAdjacentUserMessages(messages: Anthropic.MessageParam[]): Anthropic.MessageParam[] {
@@ -348,10 +412,17 @@ export class AnthropicProvider implements AIProvider {
 
     // 提取 token 用量
     const responseUsage = (response as any)?.usage;
+    const uncachedInputTokens = Number(responseUsage?.input_tokens ?? 0);
+    const cachedReadTokens = Number(responseUsage?.cache_read_input_tokens ?? 0);
+    const cachedWriteTokens = Number(responseUsage?.cache_creation_input_tokens ?? 0);
+    const promptTokens = uncachedInputTokens + cachedReadTokens + cachedWriteTokens;
+    const completionTokens = Number(responseUsage?.output_tokens ?? 0);
     const usage = responseUsage ? {
-      promptTokens: responseUsage.input_tokens ?? 0,
-      completionTokens: responseUsage.output_tokens ?? 0,
-      totalTokens: (responseUsage.input_tokens ?? 0) + (responseUsage.output_tokens ?? 0),
+      promptTokens,
+      completionTokens,
+      totalTokens: promptTokens + completionTokens,
+      cachedReadTokens,
+      cachedWriteTokens,
     } : undefined;
 
     return {
@@ -407,6 +478,22 @@ export class AnthropicProvider implements AIProvider {
     return blocks;
   }
 
+  private createMessage(params: Anthropic.MessageCreateParamsNonStreaming, options?: AIRequestOptions): Promise<any> {
+    const requestOptions = { signal: options?.signal } as any;
+    if (this.supportsNativePromptCaching()) {
+      return this.client.beta.promptCaching.messages.create(params as any, requestOptions) as any;
+    }
+    return this.client.messages.create(params, requestOptions) as any;
+  }
+
+  private createMessageStream(params: Anthropic.MessageCreateParamsStreaming, options?: AIRequestOptions): any {
+    const requestOptions = { signal: options?.signal } as any;
+    if (this.supportsNativePromptCaching()) {
+      return this.client.beta.promptCaching.messages.stream(params as any, requestOptions);
+    }
+    return this.client.messages.stream(params, requestOptions);
+  }
+
   /**
    * 普通调用
    */
@@ -434,7 +521,7 @@ export class AnthropicProvider implements AIProvider {
       params
     });
 
-    const response = await this.client.messages.create(params, { signal: options?.signal } as any);
+    const response = await this.createMessage(params, options);
 
     // [CONTEXT_DEBUG] SDK 调用后：记录完整的响应
     ContextDebugLogger.dumpSdkBoundary('after', undefined, { response });
@@ -476,10 +563,10 @@ export class AnthropicProvider implements AIProvider {
         params
       });
 
-      const stream = this.client.messages.stream(params, { signal: options?.signal } as any);
+      const stream = this.createMessageStream(params, options);
 
       // 逐 token 回调文本
-      stream.on('text', (text) => {
+      stream.on('text', (text: string) => {
         callbacks?.onText?.(text);
       });
 

--- a/tests/anthropic-prompt-cache-canary.test.ts
+++ b/tests/anthropic-prompt-cache-canary.test.ts
@@ -1,0 +1,65 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildAttemptEvidence,
+  buildCanaryEvidence,
+  buildCanarySystem,
+  sha256,
+} from '../scripts/anthropic-prompt-cache-canary.mjs';
+
+describe('Anthropic prompt-cache canary evidence', () => {
+  test('builds a stable cached prefix followed by an uncached dynamic suffix', () => {
+    const system = buildCanarySystem('stable secret prompt', 'dynamic secret state');
+
+    assert.deepEqual(system, [
+      {
+        type: 'text',
+        text: 'stable secret prompt',
+        cache_control: { type: 'ephemeral' },
+      },
+      {
+        type: 'text',
+        text: 'dynamic secret state',
+      },
+    ]);
+  });
+
+  test('records required evidence without prompt bodies', () => {
+    const stableText = 'stable secret prompt';
+    const dynamicText = 'dynamic secret state';
+    const response = {
+      url: 'https://api.anthropic.com/v1/messages?beta=prompt_caching',
+      headers: new Headers({ 'request-id': 'req_123' }),
+    } as Response;
+    const message = {
+      id: 'msg_123',
+      usage: {
+        input_tokens: 10,
+        cache_creation_input_tokens: 20,
+        cache_read_input_tokens: 30,
+        output_tokens: 1,
+      },
+    };
+    const attempt = buildAttemptEvidence({ response, message, dynamicText });
+    const evidence = buildCanaryEvidence({
+      model: 'claude-test',
+      stableText,
+      attempts: [attempt],
+      recordedAt: new Date('2026-07-30T00:00:00.000Z'),
+    });
+    const serialized = JSON.stringify(evidence);
+
+    assert.equal(evidence.stable_system_sha256, sha256(stableText));
+    assert.equal(attempt.dynamic_system_sha256, sha256(dynamicText));
+    assert.equal(attempt.request_id, 'req_123');
+    assert.equal(attempt.api_path, '/v1/messages?beta=prompt_caching');
+    assert.deepEqual(attempt.usage, {
+      input_tokens: 10,
+      cache_creation_input_tokens: 20,
+      cache_read_input_tokens: 30,
+      output_tokens: 1,
+    });
+    assert.equal(serialized.includes(stableText), false);
+    assert.equal(serialized.includes(dynamicText), false);
+  });
+});

--- a/tests/anthropic-provider-prompt-cache.test.ts
+++ b/tests/anthropic-provider-prompt-cache.test.ts
@@ -108,6 +108,7 @@ describe('AnthropicProvider prompt caching', () => {
       'https://api.anthropic.com/',
       'https://api.anthropic.com/v1',
       'https://api.anthropic.com/v1/messages',
+      'https://api.anthropic.com/v1/messages//',
       'https://api.anthropic.com:443/v1/messages',
     ];
     const nonNativeUrls = [
@@ -124,6 +125,13 @@ describe('AnthropicProvider prompt caching', () => {
     for (const url of nonNativeUrls) {
       assert.equal((createProvider(url) as any).supportsNativePromptCaching(), false, url);
     }
+  });
+
+  test('normalizes repeated trailing slashes before configuring the native Anthropic client', () => {
+    const provider = createProvider('https://api.anthropic.com/v1/messages//');
+
+    assert.equal((provider as any).client.baseURL, 'https://api.anthropic.com');
+    assert.equal((provider as any).supportsNativePromptCaching(), true);
   });
 
   test('uses native prompt-caching create and preserves cache usage totals', async () => {

--- a/tests/anthropic-provider-prompt-cache.test.ts
+++ b/tests/anthropic-provider-prompt-cache.test.ts
@@ -1,0 +1,250 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AnthropicProvider } from '../src/providers/anthropic-provider';
+import { Message } from '../src/types';
+
+function createProvider(apiUrl = 'https://api.anthropic.com/v1/messages'): AnthropicProvider {
+  return new AnthropicProvider({
+    apiKey: 'test-key',
+    apiUrl,
+    model: 'claude-sonnet-4-20250514',
+  });
+}
+
+function nativeMessages(dynamic: string): Message[] {
+  return [
+    { role: 'system', content: 'Stable policy.' },
+    { role: 'system', content: dynamic },
+    { role: 'user', content: 'Latest query' },
+  ];
+}
+
+describe('AnthropicProvider prompt caching', () => {
+  test('places a cache breakpoint after the stable system prefix on native Anthropic', () => {
+    const provider = createProvider();
+    const transformed = (provider as any).transformMessages(nativeMessages(
+      '[transient_plan_status]\n1. [in_progress] inspect provider',
+    ));
+
+    assert.deepEqual(transformed.system, [
+      {
+        type: 'text',
+        text: 'Stable policy.',
+        cache_control: { type: 'ephemeral' },
+      },
+      {
+        type: 'text',
+        text: '[transient_plan_status]\n1. [in_progress] inspect provider',
+      },
+    ]);
+    assert.deepEqual(transformed.messages, [{ role: 'user', content: 'Latest query' }]);
+  });
+
+  test('keeps the cached system block stable when plan and subagent state changes', () => {
+    const provider = createProvider();
+    const variants = [
+      '[transient_plan_status]\n1. [pending] inspect provider',
+      '[transient_plan_status]\n1. [completed] inspect provider',
+      '[transient_subagent_status]\nsub-1 is running',
+      '[transient_runner_hint]\nuse a subagent',
+      '[transient_runtime_context]\ndevice-a',
+    ];
+
+    const systems = variants.map(dynamic => (
+      (provider as any).transformMessages(nativeMessages(dynamic)).system
+    ));
+    for (const system of systems) {
+      assert.deepEqual(system[0], {
+        type: 'text',
+        text: 'Stable policy.',
+        cache_control: { type: 'ephemeral' },
+      });
+    }
+    assert.equal(new Set(systems.map(system => system[1].text)).size, variants.length);
+  });
+
+  test('honors explicit dynamic cache scope when PR 266 lands', () => {
+    const provider = createProvider();
+    const transformed = (provider as any).transformMessages([
+      { role: 'system', content: 'Stable policy.' },
+      { role: 'system', content: 'Runtime snapshot without a transient prefix', __cacheScope: 'dynamic' },
+      { role: 'user', content: 'Latest query' },
+    ] as any);
+
+    assert.equal(transformed.system[0].text, 'Stable policy.');
+    assert.deepEqual(transformed.system[0].cache_control, { type: 'ephemeral' });
+    assert.equal(transformed.system[1].text, 'Runtime snapshot without a transient prefix');
+  });
+
+  test('does not reorder system content and skips a cache breakpoint when dynamic content comes first', () => {
+    const provider = createProvider();
+    const transformed = (provider as any).transformMessages([
+      { role: 'system', content: '[transient_plan_status]\nfirst' },
+      { role: 'system', content: 'Later system content' },
+      { role: 'user', content: 'Latest query' },
+    ] as Message[]);
+
+    assert.deepEqual(transformed.system, [{
+      type: 'text',
+      text: '[transient_plan_status]\nfirst\n\nLater system content',
+    }]);
+  });
+
+  test('keeps the legacy string system shape for Anthropic-compatible endpoints', () => {
+    const provider = createProvider('https://relay.catsco.cc/anthropic');
+    const transformed = (provider as any).transformMessages(nativeMessages(
+      '[transient_subagent_status]\nsub-1 is running',
+    ));
+
+    assert.equal(
+      transformed.system,
+      'Stable policy.\n\n[transient_subagent_status]\nsub-1 is running',
+    );
+  });
+
+  test('only enables native prompt caching for canonical Anthropic endpoints', () => {
+    const nativeUrls = [
+      'https://api.anthropic.com',
+      'https://api.anthropic.com/',
+      'https://api.anthropic.com/v1',
+      'https://api.anthropic.com/v1/messages',
+      'https://api.anthropic.com:443/v1/messages',
+    ];
+    const nonNativeUrls = [
+      'http://api.anthropic.com/v1/messages',
+      'https://api.anthropic.com:8443/v1/messages',
+      'https://api.anthropic.com/custom/path',
+      'https://api.anthropic.com/v1/messages?relay=1',
+      'https://user@api.anthropic.com/v1/messages',
+    ];
+
+    for (const url of nativeUrls) {
+      assert.equal((createProvider(url) as any).supportsNativePromptCaching(), true, url);
+    }
+    for (const url of nonNativeUrls) {
+      assert.equal((createProvider(url) as any).supportsNativePromptCaching(), false, url);
+    }
+  });
+
+  test('uses native prompt-caching create and preserves cache usage totals', async () => {
+    const provider = createProvider();
+    let nativeParams: any;
+    let compatibleCalled = false;
+    (provider as any).client.beta.promptCaching.messages.create = async (params: any) => {
+      nativeParams = params;
+      return {
+        content: [{ type: 'text', text: 'ok' }],
+        stop_reason: 'end_turn',
+        usage: {
+          input_tokens: 100,
+          cache_creation_input_tokens: 400,
+          cache_read_input_tokens: 500,
+          output_tokens: 20,
+        },
+      };
+    };
+    (provider as any).client.messages.create = async () => {
+      compatibleCalled = true;
+      throw new Error('standard create should not be used');
+    };
+
+    const response = await provider.chat(nativeMessages('[transient_plan_status]\nrunning'));
+
+    assert.equal(compatibleCalled, false);
+    assert.deepEqual(nativeParams.system[0].cache_control, { type: 'ephemeral' });
+    assert.deepEqual(response.usage, {
+      promptTokens: 1000,
+      completionTokens: 20,
+      totalTokens: 1020,
+      cachedReadTokens: 500,
+      cachedWriteTokens: 400,
+    });
+  });
+
+  test('uses the standard create path for compatible endpoints', async () => {
+    const provider = createProvider('https://relay.catsco.cc/anthropic');
+    let seenParams: any;
+    let betaCalled = false;
+    (provider as any).client.messages.create = async (params: any) => {
+      seenParams = params;
+      return {
+        content: [{ type: 'text', text: 'ok' }],
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 3, output_tokens: 1 },
+      };
+    };
+    (provider as any).client.beta.promptCaching.messages.create = async () => {
+      betaCalled = true;
+      throw new Error('beta create should not be used');
+    };
+
+    await provider.chat(nativeMessages('[transient_plan_status]\nrunning'));
+
+    assert.equal(betaCalled, false);
+    assert.equal(typeof seenParams.system, 'string');
+  });
+
+  test('uses the standard streaming path for compatible endpoints', async () => {
+    const provider = createProvider('https://relay.catsco.cc/anthropic');
+    let betaCalled = false;
+    let seenParams: any;
+    (provider as any).client.messages.stream = (params: any) => {
+      seenParams = params;
+      return {
+        on() { return this; },
+        async finalMessage() {
+          return {
+            content: [{ type: 'text', text: 'streamed' }],
+            stop_reason: 'end_turn',
+            usage: { input_tokens: 3, output_tokens: 1 },
+          };
+        },
+      };
+    };
+    (provider as any).client.beta.promptCaching.messages.stream = () => {
+      betaCalled = true;
+      throw new Error('beta stream should not be used');
+    };
+
+    await provider.chatStream(nativeMessages('[transient_plan_status]\nrunning'));
+
+    assert.equal(betaCalled, false);
+    assert.equal(typeof seenParams.system, 'string');
+  });
+
+  test('uses native prompt-caching streaming and preserves cache usage', async () => {
+    const provider = createProvider();
+    let standardCalled = false;
+    const finalMessage = {
+      content: [{ type: 'text', text: 'streamed' }],
+      stop_reason: 'end_turn',
+      usage: {
+        input_tokens: 10,
+        cache_creation_input_tokens: 20,
+        cache_read_input_tokens: 70,
+        output_tokens: 5,
+      },
+    };
+    (provider as any).client.beta.promptCaching.messages.stream = () => ({
+      on() { return this; },
+      async finalMessage() { return finalMessage; },
+    });
+    (provider as any).client.messages.stream = () => {
+      standardCalled = true;
+      throw new Error('standard stream should not be used');
+    };
+
+    const response = await provider.chatStream(nativeMessages(
+      '[transient_subagent_status]\nsub-1 is waiting',
+    ));
+
+    assert.equal(standardCalled, false);
+    assert.deepEqual(response.usage, {
+      promptTokens: 100,
+      completionTokens: 5,
+      totalTokens: 105,
+      cachedReadTokens: 70,
+      cachedWriteTokens: 20,
+    });
+  });
+});

--- a/tests/bot-definition-prompt-sync.test.ts
+++ b/tests/bot-definition-prompt-sync.test.ts
@@ -5,7 +5,6 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { createCatsCoLocalConfigService } from '../src/catscompany/local-config';
 import { PromptReconcileCoordinator } from '../src/bot-definition/prompt-sync';
-import type { BotDefinitionCloudSyncService } from '../src/bot-definition/cloud-sync';
 import { FileBotDefinitionRepository } from '../src/bot-definition/repository';
 import { createBotDefinitionSyncService } from '../src/bot-definition/service';
 import { BOT_DEFINITION_SCHEMA, type BotDefinition } from '../src/bot-definition/types';
@@ -36,8 +35,6 @@ describe('BotDefinition system prompt sync', () => {
       XIAOBA_APP_ROOT: appRoot,
       XIAOBA_USER_DATA_DIR: runtimeRoot,
       XIAOBA_BOT_DEFINITION_SIMULATED_CLOUD_DIR: simulatedCloudRoot,
-      CATSCO_HTTP_BASE_URL: 'https://example.invalid',
-      CATSCO_USER_TOKEN: 'host-token-that-must-not-be-used',
     } as NodeJS.ProcessEnv;
   });
 
@@ -78,24 +75,8 @@ describe('BotDefinition system prompt sync', () => {
       env,
       repository,
     });
-    const cloudSyncService = {
-      pushPrompt: async () => undefined,
-      readState: (uid: string) => ({
-        schema: 'xiaoba.bot-definition-cloud-sync.v1',
-        botId: uid,
-        revision: 0,
-        pendingModel: false,
-        pendingPrompt: false,
-      }),
-      flushPending: async () => undefined,
-    } as unknown as BotDefinitionCloudSyncService;
     return {
-      coordinator: new PromptReconcileCoordinator({
-        runtimeRoot,
-        env,
-        definitionService,
-        cloudSyncService,
-      }),
+      coordinator: new PromptReconcileCoordinator({ runtimeRoot, env, definitionService }),
       repository,
     };
   }

--- a/tests/bot-definition-prompt-sync.test.ts
+++ b/tests/bot-definition-prompt-sync.test.ts
@@ -5,6 +5,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { createCatsCoLocalConfigService } from '../src/catscompany/local-config';
 import { PromptReconcileCoordinator } from '../src/bot-definition/prompt-sync';
+import type { BotDefinitionCloudSyncService } from '../src/bot-definition/cloud-sync';
 import { FileBotDefinitionRepository } from '../src/bot-definition/repository';
 import { createBotDefinitionSyncService } from '../src/bot-definition/service';
 import { BOT_DEFINITION_SCHEMA, type BotDefinition } from '../src/bot-definition/types';
@@ -35,6 +36,8 @@ describe('BotDefinition system prompt sync', () => {
       XIAOBA_APP_ROOT: appRoot,
       XIAOBA_USER_DATA_DIR: runtimeRoot,
       XIAOBA_BOT_DEFINITION_SIMULATED_CLOUD_DIR: simulatedCloudRoot,
+      CATSCO_HTTP_BASE_URL: 'https://example.invalid',
+      CATSCO_USER_TOKEN: 'host-token-that-must-not-be-used',
     } as NodeJS.ProcessEnv;
   });
 
@@ -75,8 +78,24 @@ describe('BotDefinition system prompt sync', () => {
       env,
       repository,
     });
+    const cloudSyncService = {
+      pushPrompt: async () => undefined,
+      readState: (uid: string) => ({
+        schema: 'xiaoba.bot-definition-cloud-sync.v1',
+        botId: uid,
+        revision: 0,
+        pendingModel: false,
+        pendingPrompt: false,
+      }),
+      flushPending: async () => undefined,
+    } as unknown as BotDefinitionCloudSyncService;
     return {
-      coordinator: new PromptReconcileCoordinator({ runtimeRoot, env, definitionService }),
+      coordinator: new PromptReconcileCoordinator({
+        runtimeRoot,
+        env,
+        definitionService,
+        cloudSyncService,
+      }),
       repository,
     };
   }


### PR DESCRIPTION
## Summary

- split native Anthropic top-level system content into a stable cached prefix and a dynamic uncached suffix
- keep transient plan, subagent, runner, skills, and runtime state at system priority
- use the SDK prompt-caching create/stream surface only for canonical `api.anthropic.com` endpoints
- preserve the legacy string system shape and standard SDK path for Anthropic-compatible endpoints
- retain Anthropic cache creation/read usage in unified metrics
- normalize repeated trailing slashes before configuring the Anthropic SDK base URL
- isolate the prompt-sync unit suite from the real CatsCo cloud API so CI remains deterministic

Relates to #267

## Validation

- `npm run build`
- focused suites — 28/28 passed (Anthropic prompt cache 11; BotDefinition prompt sync 17)
- isolated runtime suite after cloud-test isolation — 1198 passed; the only two local failures are pre-existing service-runner path assertions caused by this workspace's non-standard `tsx` dependency layout
- GitHub Actions rerun is expected to use a fresh dependency install and is the merge gate
- `git diff --check origin/main`

## Runtime evidence boundary

A real native Anthropic canary has not been run because no official Anthropic credential is configured in the current environment. The SDK request path, cache breakpoint payload, streaming path, compatible-endpoint fallback, and cache usage totals are covered by regression tests. No production cache-gain claim is made without canary evidence.