### PR TITLE
feat: automate Tianyi worker images

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 ops/ctyun-worker-image/*.sh text eol=lf
+ops/ctyun-worker-image/*.ps1 text eol=lf
 scripts/build-linux-worker-artifact.mjs text eol=lf
 .github/workflows/worker-image.yml text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+ops/ctyun-worker-image/*.sh text eol=lf
+scripts/build-linux-worker-artifact.mjs text eol=lf
+.github/workflows/worker-image.yml text eol=lf

--- a/.github/workflows/worker-image.yml
+++ b/.github/workflows/worker-image.yml
@@ -78,15 +78,6 @@ jobs:
           echo "key=worker-private/$(basename "$artifact")" >> "$GITHUB_OUTPUT"
           echo "sha256=$(sha256sum "$artifact" | awk '{print $1}')" >> "$GITHUB_OUTPUT"
 
-      - name: Upload workflow artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: catsco-linux-worker-${{ github.sha }}
-          if-no-files-found: error
-          path: |
-            release/worker/*.tar.gz
-            release/worker/*.sha256
-
       - name: Ensure AWS CLI is available
         run: |
           if ! command -v aws >/dev/null 2>&1; then

--- a/.github/workflows/worker-image.yml
+++ b/.github/workflows/worker-image.yml
@@ -35,7 +35,7 @@ jobs:
       (startsWith(github.ref, 'refs/tags/') &&
        vars.CTYUN_AUTO_BAKE_WORKER_IMAGE == 'true')
     runs-on: ubuntu-24.04
-    timeout-minutes: 420
+    timeout-minutes: 360
     environment: release-prod
     steps:
       - name: Checkout exact source

--- a/.github/workflows/worker-image.yml
+++ b/.github/workflows/worker-image.yml
@@ -33,6 +33,7 @@ jobs:
     environment: release-prod
     outputs:
       artifact_name: ${{ steps.artifact_meta.outputs.name }}
+      artifact_key: ${{ steps.artifact_meta.outputs.key }}
       artifact_sha256: ${{ steps.artifact_meta.outputs.sha256 }}
     env:
       VOLC_TOS_ACCESS_KEY_ID: ${{ secrets.VOLC_TOS_ACCESS_KEY_ID }}
@@ -74,6 +75,7 @@ jobs:
           [ "${#artifacts[@]}" -eq 1 ]
           artifact="${artifacts[0]}"
           echo "name=$(basename "$artifact")" >> "$GITHUB_OUTPUT"
+          echo "key=worker-private/$(basename "$artifact")" >> "$GITHUB_OUTPUT"
           echo "sha256=$(sha256sum "$artifact" | awk '{print $1}')" >> "$GITHUB_OUTPUT"
 
       - name: Upload workflow artifact
@@ -98,9 +100,9 @@ jobs:
           set -euo pipefail
           SOURCE_ENDPOINT="https://tos-s3-${TOS_SOURCE_REGION}.volces.com"
           for file in release/worker/*; do
-            aws s3 cp "$file" "s3://${TOS_SOURCE_BUCKET}/worker/$(basename "$file")" \
+            aws s3 cp "$file" "s3://${TOS_SOURCE_BUCKET}/worker-private/$(basename "$file")" \
               --endpoint-url "$SOURCE_ENDPOINT" \
-              --cache-control "public, max-age=31536000, immutable" \
+              --cache-control "private, max-age=31536000, immutable" \
               --only-show-errors
           done
 
@@ -109,7 +111,7 @@ jobs:
           set -euo pipefail
           TARGET_ENDPOINT="https://tos-s3-${TOS_TARGET_REGION}.volces.com"
           for file in release/worker/*; do
-            key="worker/$(basename "$file")"
+            key="worker-private/$(basename "$file")"
             for attempt in $(seq 1 36); do
               if aws s3api head-object \
                 --bucket "$TOS_TARGET_BUCKET" \
@@ -126,20 +128,6 @@ jobs:
             done
           done
 
-      - name: Expose replicated artifacts to the temporary builder
-        run: |
-          set -euo pipefail
-          TARGET_ENDPOINT="https://tos-s3-${TOS_TARGET_REGION}.volces.com"
-          for file in release/worker/*; do
-            key="worker/$(basename "$file")"
-            aws s3api put-object-acl \
-              --bucket "$TOS_TARGET_BUCKET" \
-              --key "$key" \
-              --acl public-read \
-              --endpoint-url "$TARGET_ENDPOINT" \
-              >/dev/null
-          done
-
   image:
     name: Bake Tianyi Cloud private image
     needs: artifact
@@ -151,6 +139,11 @@ jobs:
     env:
       CTYUN_AK: ${{ secrets.CTYUN_AK }}
       CTYUN_SK: ${{ secrets.CTYUN_SK }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.VOLC_TOS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.VOLC_TOS_SECRET_ACCESS_KEY }}
+      AWS_EC2_METADATA_DISABLED: 'true'
+      TOS_TARGET_BUCKET: github-release
+      TOS_TARGET_REGION: cn-guangzhou
     steps:
       - name: Checkout exact release source
         uses: actions/checkout@v4
@@ -168,13 +161,32 @@ jobs:
           echo "$HOME/.ctyun-cli/bin" >> "$GITHUB_PATH"
           "$HOME/.ctyun-cli/bin/ctyun-cli" version
 
+      - name: Create short-lived private artifact URL
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! command -v aws >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y awscli
+          fi
+          aws configure set default.s3.addressing_style virtual
+          TARGET_ENDPOINT="https://tos-s3-${TOS_TARGET_REGION}.volces.com"
+          artifact_url="$(
+            aws s3 presign \
+              "s3://${TOS_TARGET_BUCKET}/${{ needs.artifact.outputs.artifact_key }}" \
+              --expires-in 3600 \
+              --endpoint-url "$TARGET_ENDPOINT"
+          )"
+          echo "::add-mask::$artifact_url"
+          echo "WORKER_ARTIFACT_URL=$artifact_url" >> "$GITHUB_ENV"
+
       - name: Bake private ECS image
         shell: pwsh
         run: |
           ./ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1 `
             -Mode Create `
             -SourceRef '${{ github.sha }}' `
-            -ArtifactUrl 'https://github-release.tos-cn-guangzhou.volces.com/worker/${{ needs.artifact.outputs.artifact_name }}' `
+            -ArtifactUrl $env:WORKER_ARTIFACT_URL `
             -ArtifactSha256 '${{ needs.artifact.outputs.artifact_sha256 }}' `
             -RegionID '${{ vars.CTYUN_WORKER_REGION_ID }}' `
             -AzName '${{ vars.CTYUN_WORKER_AZ_NAME }}' `

--- a/.github/workflows/worker-image.yml
+++ b/.github/workflows/worker-image.yml
@@ -1,0 +1,185 @@
+name: Linux Worker Artifact and Image
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      bake_image:
+        description: Bake a Tianyi Cloud private ECS image after publishing the artifact
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: worker-image-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  NODE_VERSION: '20'
+  TOS_SOURCE_BUCKET: github-hk
+  TOS_SOURCE_REGION: cn-hongkong
+  TOS_TARGET_BUCKET: github-release
+  TOS_TARGET_REGION: cn-guangzhou
+
+jobs:
+  artifact:
+    name: Build source-free worker artifact
+    runs-on: ubuntu-latest
+    environment: release-prod
+    outputs:
+      artifact_name: ${{ steps.artifact_meta.outputs.name }}
+      artifact_sha256: ${{ steps.artifact_meta.outputs.sha256 }}
+    env:
+      VOLC_TOS_ACCESS_KEY_ID: ${{ secrets.VOLC_TOS_ACCESS_KEY_ID }}
+      VOLC_TOS_SECRET_ACCESS_KEY: ${{ secrets.VOLC_TOS_SECRET_ACCESS_KEY }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.VOLC_TOS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.VOLC_TOS_SECRET_ACCESS_KEY }}
+      AWS_EC2_METADATA_DISABLED: 'true'
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Validate release tag
+        if: startsWith(github.ref, 'refs/tags/')
+        run: npm run release:verify-version
+
+      - name: Install dependencies
+        run: npm ci --prefer-offline --no-audit --fund=false
+
+      - name: Build CatsCo
+        run: npm run build
+
+      - name: Build Linux worker artifact
+        run: npm run worker:artifact
+
+      - name: Record artifact identity
+        id: artifact_meta
+        run: |
+          set -euo pipefail
+          mapfile -t artifacts < <(find release/worker -maxdepth 1 -type f -name '*.tar.gz')
+          [ "${#artifacts[@]}" -eq 1 ]
+          artifact="${artifacts[0]}"
+          echo "name=$(basename "$artifact")" >> "$GITHUB_OUTPUT"
+          echo "sha256=$(sha256sum "$artifact" | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: catsco-linux-worker-${{ github.sha }}
+          if-no-files-found: error
+          path: |
+            release/worker/*.tar.gz
+            release/worker/*.sha256
+
+      - name: Ensure AWS CLI is available
+        run: |
+          if ! command -v aws >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y awscli
+          fi
+          aws configure set default.s3.addressing_style virtual
+
+      - name: Publish immutable artifact to domestic storage
+        run: |
+          set -euo pipefail
+          SOURCE_ENDPOINT="https://tos-s3-${TOS_SOURCE_REGION}.volces.com"
+          for file in release/worker/*; do
+            aws s3 cp "$file" "s3://${TOS_SOURCE_BUCKET}/worker/$(basename "$file")" \
+              --endpoint-url "$SOURCE_ENDPOINT" \
+              --cache-control "public, max-age=31536000, immutable" \
+              --only-show-errors
+          done
+
+      - name: Wait for Guangzhou replication
+        run: |
+          set -euo pipefail
+          TARGET_ENDPOINT="https://tos-s3-${TOS_TARGET_REGION}.volces.com"
+          for file in release/worker/*; do
+            key="worker/$(basename "$file")"
+            for attempt in $(seq 1 36); do
+              if aws s3api head-object \
+                --bucket "$TOS_TARGET_BUCKET" \
+                --key "$key" \
+                --endpoint-url "$TARGET_ENDPOINT" >/dev/null 2>&1; then
+                echo "Replicated: $key"
+                break
+              fi
+              if [ "$attempt" -eq 36 ]; then
+                echo "Timed out waiting for $key"
+                exit 1
+              fi
+              sleep 10
+            done
+          done
+
+      - name: Expose replicated artifacts to the temporary builder
+        run: |
+          set -euo pipefail
+          TARGET_ENDPOINT="https://tos-s3-${TOS_TARGET_REGION}.volces.com"
+          for file in release/worker/*; do
+            key="worker/$(basename "$file")"
+            aws s3api put-object-acl \
+              --bucket "$TOS_TARGET_BUCKET" \
+              --key "$key" \
+              --acl public-read \
+              --endpoint-url "$TARGET_ENDPOINT" \
+              >/dev/null
+          done
+
+  image:
+    name: Bake Tianyi Cloud private image
+    needs: artifact
+    if: >-
+      (github.event_name == 'workflow_dispatch' && inputs.bake_image) ||
+      (startsWith(github.ref, 'refs/tags/') && vars.CTYUN_AUTO_BAKE_WORKER_IMAGE == 'true')
+    runs-on: ubuntu-latest
+    environment: release-prod
+    env:
+      CTYUN_AK: ${{ secrets.CTYUN_AK }}
+      CTYUN_SK: ${{ secrets.CTYUN_SK }}
+    steps:
+      - name: Checkout exact release source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Tianyi Cloud CLI
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://huabei-2.zos.ctyun.cn/ctyun-cli/install-cli.sh" |
+            sh -s -- \
+              --base-url "https://huabei-2.zos.ctyun.cn/ctyun-cli" \
+              --version v0.1.1
+          echo "$HOME/.ctyun-cli/bin" >> "$GITHUB_PATH"
+          "$HOME/.ctyun-cli/bin/ctyun-cli" version
+
+      - name: Bake private ECS image
+        shell: pwsh
+        run: |
+          ./ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1 `
+            -Mode Create `
+            -SourceRef '${{ github.sha }}' `
+            -ArtifactUrl 'https://github-release.tos-cn-guangzhou.volces.com/worker/${{ needs.artifact.outputs.artifact_name }}' `
+            -ArtifactSha256 '${{ needs.artifact.outputs.artifact_sha256 }}' `
+            -RegionID '${{ vars.CTYUN_WORKER_REGION_ID }}' `
+            -AzName '${{ vars.CTYUN_WORKER_AZ_NAME }}' `
+            -BaseImageID '${{ vars.CTYUN_WORKER_BASE_IMAGE_ID }}' `
+            -FlavorID '${{ vars.CTYUN_WORKER_FLAVOR_ID }}' `
+            -VpcID '${{ vars.CTYUN_WORKER_VPC_ID }}' `
+            -SubnetID '${{ vars.CTYUN_WORKER_SUBNET_ID }}' `
+            -SecurityGroupID '${{ vars.CTYUN_WORKER_SECURITY_GROUP_ID }}'

--- a/.github/workflows/worker-image.yml
+++ b/.github/workflows/worker-image.yml
@@ -118,8 +118,8 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           "$HOME/.local/bin/ctyun-cli" version
 
-      - name: Find the latest interrupted image run
-        id: prior_run
+      - name: Find interrupted image runs
+        id: prior_runs
         timeout-minutes: 3
         shell: bash
         env:
@@ -131,84 +131,214 @@ jobs:
             --header 'Accept: application/vnd.github+json' \
             --header "Authorization: Bearer $GITHUB_TOKEN" \
             --header 'X-GitHub-Api-Version: 2022-11-28' \
-            "https://api.github.com/repos/$GITHUB_REPOSITORY/actions/workflows/worker-image.yml/runs?per_page=20")"
-          prior="$(jq --arg current "$GITHUB_RUN_ID" '
+            "https://api.github.com/repos/$GITHUB_REPOSITORY/actions/workflows/worker-image.yml/runs?per_page=100")"
+          interrupted="$(jq -c --arg current "$GITHUB_RUN_ID" '
             [
               .workflow_runs[]
               | select((.id | tostring) != $current)
-            ][0] // empty
+              | select(
+                  .conclusion == "failure" or
+                  .conclusion == "cancelled" or
+                  .conclusion == "timed_out" or
+                  .conclusion == "startup_failure" or
+                  .conclusion == "stale"
+                )
+              | {
+                  build_number: .run_number,
+                  attempt: (.run_attempt // 1),
+                  run_id: .id,
+                  sha: .head_sha,
+                  conclusion: .conclusion,
+                  updated_at: .updated_at
+                }
+            ]
           ' <<<"$response")"
-          if [[ -z "$prior" ]]; then
+          if [[ "$(jq 'length' <<<"$interrupted")" -eq 0 ]]; then
             echo "found=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          conclusion="$(jq -r '.conclusion // ""' <<<"$prior")"
-          case "$conclusion" in
-            failure|cancelled|timed_out|startup_failure|stale) ;;
-            *)
-              echo "found=false" >> "$GITHUB_OUTPUT"
-              exit 0
-              ;;
-          esac
           echo "found=true" >> "$GITHUB_OUTPUT"
-          echo "build_number=$(jq -r '.run_number' <<<"$prior")" >> "$GITHUB_OUTPUT"
-          echo "attempt=$(jq -r '.run_attempt' <<<"$prior")" >> "$GITHUB_OUTPUT"
-          echo "run_id=$(jq -r '.id' <<<"$prior")" >> "$GITHUB_OUTPUT"
-          echo "sha=$(jq -r '.head_sha' <<<"$prior")" >> "$GITHUB_OUTPUT"
-          echo "conclusion=$conclusion" >> "$GITHUB_OUTPUT"
+          echo "runs=$interrupted" >> "$GITHUB_OUTPUT"
 
-      - name: Reconcile the latest interrupted image run
-        if: ${{ steps.prior_run.outputs.found == 'true' }}
-        timeout-minutes: 20
+      - name: Reconcile interrupted image runs
+        if: ${{ steps.prior_runs.outputs.found == 'true' }}
+        timeout-minutes: 90
         shell: pwsh
         env:
           CTYUN_AK: ${{ secrets.CTYUN_AK }}
           CTYUN_SK: ${{ secrets.CTYUN_SK }}
+          INTERRUPTED_RUNS_JSON: ${{ steps.prior_runs.outputs.runs }}
         run: |
-          Write-Host "Reconciling prior run ${{ steps.prior_run.outputs.run_id }} (${{ steps.prior_run.outputs.conclusion }})"
-          ./ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1 `
-            -Mode Cleanup `
-            -SourceRef '${{ steps.prior_run.outputs.sha }}' `
-            -BuildNumber '${{ steps.prior_run.outputs.build_number }}' `
-            -BuildAttempt '${{ steps.prior_run.outputs.attempt }}' `
-            -BuildIdentity '${{ steps.prior_run.outputs.run_id }}' `
-            -BakeTimeoutMinutes 150 `
-            -CleanupTimeoutMinutes 15 `
-            -ApiTimeoutSeconds 90 `
-            -RegionID '${{ vars.CTYUN_WORKER_REGION_ID }}' `
-            -AzName '${{ vars.CTYUN_WORKER_AZ_NAME }}' `
-            -BaseImageID '${{ vars.CTYUN_WORKER_BASE_IMAGE_ID }}' `
-            -FlavorID '${{ vars.CTYUN_WORKER_FLAVOR_ID }}' `
-            -VpcID '${{ vars.CTYUN_WORKER_VPC_ID }}' `
-            -SubnetID '${{ vars.CTYUN_WORKER_SUBNET_ID }}' `
-            -SecurityGroupID '${{ vars.CTYUN_WORKER_SECURITY_GROUP_ID }}'
+          $runs = @($env:INTERRUPTED_RUNS_JSON | ConvertFrom-Json)
+          $recentRuns = [Collections.Generic.List[object]]::new()
+          $historicalRuns = [Collections.Generic.List[object]]::new()
+          $blockingFailures = [Collections.Generic.List[string]]::new()
+          $historicalWarnings = [Collections.Generic.List[string]]::new()
+          foreach ($run in $runs) {
+            $updatedAt = [DateTimeOffset]::Parse([string]$run.updated_at)
+            if (([DateTimeOffset]::UtcNow - $updatedAt).TotalMinutes -le 30) {
+              $recentRuns.Add($run)
+            } else {
+              $historicalRuns.Add($run)
+            }
+          }
+
+          function Invoke-InterruptedRunCleanup {
+            param(
+              [Parameter(Mandatory = $true)]$Run,
+              [Parameter(Mandatory = $true)][int]$Attempt,
+              [Parameter(Mandatory = $true)][bool]$WaitForLate,
+              [Parameter(Mandatory = $true)][bool]$Historical
+            )
+
+            $cleanupTimeoutMinutes = if ($Historical) { 10 } else { 15 }
+            $apiTimeoutSeconds = if ($Historical) { 30 } else { 90 }
+            $hardTimeout = if ($Historical) { '120s' } else { '1000s' }
+            $arguments = @(
+              '-NoProfile',
+              '-NonInteractive',
+              '-File', './ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1',
+              '-Mode', 'Cleanup',
+              '-SourceRef', [string]$Run.sha,
+              '-BuildNumber', [string]$Run.build_number,
+              '-BuildAttempt', [string]$Attempt,
+              '-BuildIdentity', [string]$Run.run_id,
+              '-BakeTimeoutMinutes', '150',
+              '-CleanupTimeoutMinutes', [string]$cleanupTimeoutMinutes,
+              '-ApiTimeoutSeconds', [string]$apiTimeoutSeconds,
+              '-RegionID', '${{ vars.CTYUN_WORKER_REGION_ID }}',
+              '-AzName', '${{ vars.CTYUN_WORKER_AZ_NAME }}',
+              '-BaseImageID', '${{ vars.CTYUN_WORKER_BASE_IMAGE_ID }}',
+              '-FlavorID', '${{ vars.CTYUN_WORKER_FLAVOR_ID }}',
+              '-VpcID', '${{ vars.CTYUN_WORKER_VPC_ID }}',
+              '-SubnetID', '${{ vars.CTYUN_WORKER_SUBNET_ID }}',
+              '-SecurityGroupID', '${{ vars.CTYUN_WORKER_SECURITY_GROUP_ID }}'
+            )
+            if ($WaitForLate) {
+              $arguments += '-WaitForLateResources'
+            }
+
+            $PSNativeCommandUseErrorActionPreference = $false
+            & timeout '--signal=TERM' '--kill-after=15s' $hardTimeout pwsh @arguments |
+              ForEach-Object { Write-Host $_ }
+            return $LASTEXITCODE
+          }
+
+          $recentDeadline = [DateTimeOffset]::UtcNow.AddMinutes(45)
+          :recentRunLoop foreach ($run in $recentRuns) {
+            $runAttempt = [Math]::Max(1, [int]$run.attempt)
+            foreach ($attempt in 1..$runAttempt) {
+              if ([DateTimeOffset]::UtcNow -ge $recentDeadline) {
+                $blockingFailures.Add(
+                  "Recent cleanup budget exhausted before run=$($run.run_id) attempt=$attempt/$runAttempt"
+                )
+                break recentRunLoop
+              }
+              Write-Host "Reconciling run $($run.run_id) attempt $attempt/$runAttempt ($($run.conclusion))"
+              $exitCode = Invoke-InterruptedRunCleanup `
+                -Run $run `
+                -Attempt $attempt `
+                -WaitForLate:($attempt -eq $runAttempt) `
+                -Historical:$false
+              if ($exitCode -ne 0) {
+                $blockingFailures.Add(
+                  "run=$($run.run_id) attempt=$attempt/$runAttempt conclusion=$($run.conclusion) exit=$exitCode"
+                )
+              }
+            }
+          }
+
+          $historicalDeadline = [DateTimeOffset]::UtcNow.AddMinutes(10)
+          :historicalRunLoop foreach ($run in $historicalRuns) {
+            $runAttempt = [Math]::Max(1, [int]$run.attempt)
+            foreach ($attempt in 1..$runAttempt) {
+              if ([DateTimeOffset]::UtcNow -ge $historicalDeadline) {
+                $historicalWarnings.Add(
+                  "Historical cleanup budget exhausted; remaining attempts require a later run or manual reconciliation"
+                )
+                break historicalRunLoop
+              }
+              Write-Host "Reconciling historical run $($run.run_id) attempt $attempt/$runAttempt ($($run.conclusion))"
+              $exitCode = Invoke-InterruptedRunCleanup `
+                -Run $run `
+                -Attempt $attempt `
+                -WaitForLate:$false `
+                -Historical:$true
+              if ($exitCode -ne 0) {
+                $message = (
+                  "run=$($run.run_id) attempt=$attempt/$runAttempt " +
+                  "conclusion=$($run.conclusion) exit=$exitCode"
+                )
+                $historicalWarnings.Add($message)
+                Write-Warning "Historical image cleanup needs manual attention: $message"
+              }
+            }
+          }
+          if ($historicalWarnings.Count -gt 0) {
+            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value '### Historical Tianyi image cleanup warnings'
+            foreach ($warning in $historicalWarnings) {
+              $summary = $warning.Replace("`r", " ").Replace("`n", " ")
+              Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- $summary"
+            }
+          }
+          if ($blockingFailures.Count -gt 0) {
+            throw "Recent interrupted image cleanup failed:`n$($blockingFailures -join "`n")"
+          }
 
       - name: Reconcile the previous attempt before a rerun
         if: ${{ github.run_attempt > 1 }}
-        timeout-minutes: 40
+        timeout-minutes: 90
         shell: pwsh
         env:
           CTYUN_AK: ${{ secrets.CTYUN_AK }}
           CTYUN_SK: ${{ secrets.CTYUN_SK }}
         run: |
-          $previousAttempt = [int]'${{ github.run_attempt }}' - 1
-          ./ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1 `
-            -Mode Cleanup `
-            -SourceRef '${{ github.sha }}' `
-            -BuildNumber '${{ github.run_number }}' `
-            -BuildAttempt "$previousAttempt" `
-            -BuildIdentity '${{ github.run_id }}' `
-            -BakeTimeoutMinutes 150 `
-            -CleanupTimeoutMinutes 40 `
-            -ApiTimeoutSeconds 90 `
-            -WaitForLateResources `
-            -RegionID '${{ vars.CTYUN_WORKER_REGION_ID }}' `
-            -AzName '${{ vars.CTYUN_WORKER_AZ_NAME }}' `
-            -BaseImageID '${{ vars.CTYUN_WORKER_BASE_IMAGE_ID }}' `
-            -FlavorID '${{ vars.CTYUN_WORKER_FLAVOR_ID }}' `
-            -VpcID '${{ vars.CTYUN_WORKER_VPC_ID }}' `
-            -SubnetID '${{ vars.CTYUN_WORKER_SUBNET_ID }}' `
-            -SecurityGroupID '${{ vars.CTYUN_WORKER_SECURITY_GROUP_ID }}'
+          $currentAttempt = [int]'${{ github.run_attempt }}'
+          $rerunDeadline = [DateTimeOffset]::UtcNow.AddMinutes(45)
+          $rerunFailures = [Collections.Generic.List[string]]::new()
+          foreach ($previousAttempt in 1..($currentAttempt - 1)) {
+            if ([DateTimeOffset]::UtcNow -ge $rerunDeadline) {
+              $rerunFailures.Add(
+                "Rerun cleanup budget exhausted before attempt $previousAttempt/$($currentAttempt - 1)"
+              )
+              break
+            }
+            Write-Host "Reconciling current run attempt $previousAttempt/$($currentAttempt - 1)"
+            $arguments = @(
+              '-NoProfile',
+              '-NonInteractive',
+              '-File', './ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1',
+              '-Mode', 'Cleanup',
+              '-SourceRef', '${{ github.sha }}',
+              '-BuildNumber', '${{ github.run_number }}',
+              '-BuildAttempt', [string]$previousAttempt,
+              '-BuildIdentity', '${{ github.run_id }}',
+              '-BakeTimeoutMinutes', '150',
+              '-CleanupTimeoutMinutes', '15',
+              '-ApiTimeoutSeconds', '90',
+              '-RegionID', '${{ vars.CTYUN_WORKER_REGION_ID }}',
+              '-AzName', '${{ vars.CTYUN_WORKER_AZ_NAME }}',
+              '-BaseImageID', '${{ vars.CTYUN_WORKER_BASE_IMAGE_ID }}',
+              '-FlavorID', '${{ vars.CTYUN_WORKER_FLAVOR_ID }}',
+              '-VpcID', '${{ vars.CTYUN_WORKER_VPC_ID }}',
+              '-SubnetID', '${{ vars.CTYUN_WORKER_SUBNET_ID }}',
+              '-SecurityGroupID', '${{ vars.CTYUN_WORKER_SECURITY_GROUP_ID }}'
+            )
+            if ($previousAttempt -eq $currentAttempt - 1) {
+              $arguments += '-WaitForLateResources'
+            }
+            $PSNativeCommandUseErrorActionPreference = $false
+            & timeout '--signal=TERM' '--kill-after=15s' '1000s' pwsh @arguments |
+              ForEach-Object { Write-Host $_ }
+            if ($LASTEXITCODE -ne 0) {
+              $rerunFailures.Add(
+                "attempt=$previousAttempt/$($currentAttempt - 1) exit=$LASTEXITCODE"
+              )
+            }
+          }
+          if ($rerunFailures.Count -gt 0) {
+            throw "Previous attempt cleanup failed:`n$($rerunFailures -join "`n")"
+          }
 
       - name: Bake private ECS image
         id: bake

--- a/.github/workflows/worker-image.yml
+++ b/.github/workflows/worker-image.yml
@@ -1,62 +1,74 @@
-name: Linux Worker Artifact and Image
+name: Bake Tianyi Cloud Worker Image
 
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
   workflow_dispatch:
     inputs:
       bake_image:
-        description: Bake a Tianyi Cloud private ECS image after publishing the artifact
+        description: Bake a private worker image from the current main commit
         required: false
         type: boolean
-        default: true
+        default: false
 
 permissions:
   contents: read
 
 concurrency:
-  group: worker-image-${{ github.ref }}
+  group: worker-image-bake
   cancel-in-progress: false
 
 env:
-  NODE_VERSION: '20'
-  TOS_SOURCE_BUCKET: github-hk
-  TOS_SOURCE_REGION: cn-hongkong
-  TOS_TARGET_BUCKET: github-release
-  TOS_TARGET_REGION: cn-guangzhou
+  NODE_VERSION: "20"
+  CTYUN_CLI_VERSION: v0.1.1
+  CTYUN_CLI_PACKAGE_SHA256: 93272c3fd377a6f642a89cb326fa2f4a3d2fab7dfc9587e49906527230b767fa
 
 jobs:
-  artifact:
-    name: Build source-free worker artifact
-    runs-on: ubuntu-latest
+  image:
+    name: Build artifact and bake private image
+    if: >-
+      (github.event_name == 'workflow_dispatch' &&
+       inputs.bake_image &&
+       github.ref == 'refs/heads/main') ||
+      (startsWith(github.ref, 'refs/tags/') &&
+       vars.CTYUN_AUTO_BAKE_WORKER_IMAGE == 'true')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
     environment: release-prod
-    outputs:
-      artifact_name: ${{ steps.artifact_meta.outputs.name }}
-      artifact_key: ${{ steps.artifact_meta.outputs.key }}
-      artifact_sha256: ${{ steps.artifact_meta.outputs.sha256 }}
-    env:
-      VOLC_TOS_ACCESS_KEY_ID: ${{ secrets.VOLC_TOS_ACCESS_KEY_ID }}
-      VOLC_TOS_SECRET_ACCESS_KEY: ${{ secrets.VOLC_TOS_SECRET_ACCESS_KEY }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.VOLC_TOS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.VOLC_TOS_SECRET_ACCESS_KEY }}
-      AWS_EC2_METADATA_DISABLED: 'true'
     steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
+      - name: Checkout exact source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
           cache-dependency-path: package-lock.json
 
-      - name: Validate release tag
-        if: startsWith(github.ref, 'refs/tags/')
-        run: npm run release:verify-version
+      - name: Validate trusted release source
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            tag="${GITHUB_REF#refs/tags/}"
+            [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+              echo "Only stable vX.Y.Z tags can bake worker images"
+              exit 1
+            }
+            git merge-base --is-ancestor "$GITHUB_SHA" origin/main || {
+              echo "Release tag commit is not contained in main"
+              exit 1
+            }
+            npm run release:verify-version
+          elif [[ "$GITHUB_EVENT_NAME" != workflow_dispatch || "$GITHUB_REF" != refs/heads/main ]]; then
+            echo "Manual image baking is restricted to main"
+            exit 1
+          fi
 
       - name: Install dependencies
         run: npm ci --prefer-offline --no-audit --fund=false
@@ -64,121 +76,52 @@ jobs:
       - name: Build CatsCo
         run: npm run build
 
-      - name: Build Linux worker artifact
+      - name: Build deterministic Linux worker artifact
         run: npm run worker:artifact
 
       - name: Record artifact identity
         id: artifact_meta
+        shell: bash
         run: |
           set -euo pipefail
           mapfile -t artifacts < <(find release/worker -maxdepth 1 -type f -name '*.tar.gz')
-          [ "${#artifacts[@]}" -eq 1 ]
+          [[ "${#artifacts[@]}" -eq 1 ]]
           artifact="${artifacts[0]}"
-          echo "name=$(basename "$artifact")" >> "$GITHUB_OUTPUT"
-          echo "key=worker-private/$(basename "$artifact")" >> "$GITHUB_OUTPUT"
+          echo "path=$artifact" >> "$GITHUB_OUTPUT"
           echo "sha256=$(sha256sum "$artifact" | awk '{print $1}')" >> "$GITHUB_OUTPUT"
 
-      - name: Ensure AWS CLI is available
-        run: |
-          if ! command -v aws >/dev/null 2>&1; then
-            sudo apt-get update
-            sudo apt-get install -y awscli
-          fi
-          aws configure set default.s3.addressing_style virtual
-
-      - name: Publish immutable artifact to domestic storage
-        run: |
-          set -euo pipefail
-          SOURCE_ENDPOINT="https://tos-s3-${TOS_SOURCE_REGION}.volces.com"
-          for file in release/worker/*; do
-            aws s3 cp "$file" "s3://${TOS_SOURCE_BUCKET}/worker-private/$(basename "$file")" \
-              --endpoint-url "$SOURCE_ENDPOINT" \
-              --cache-control "private, max-age=31536000, immutable" \
-              --only-show-errors
-          done
-
-      - name: Wait for Guangzhou replication
-        run: |
-          set -euo pipefail
-          TARGET_ENDPOINT="https://tos-s3-${TOS_TARGET_REGION}.volces.com"
-          for file in release/worker/*; do
-            key="worker-private/$(basename "$file")"
-            for attempt in $(seq 1 36); do
-              if aws s3api head-object \
-                --bucket "$TOS_TARGET_BUCKET" \
-                --key "$key" \
-                --endpoint-url "$TARGET_ENDPOINT" >/dev/null 2>&1; then
-                echo "Replicated: $key"
-                break
-              fi
-              if [ "$attempt" -eq 36 ]; then
-                echo "Timed out waiting for $key"
-                exit 1
-              fi
-              sleep 10
-            done
-          done
-
-  image:
-    name: Bake Tianyi Cloud private image
-    needs: artifact
-    if: >-
-      (github.event_name == 'workflow_dispatch' && inputs.bake_image) ||
-      (startsWith(github.ref, 'refs/tags/') && vars.CTYUN_AUTO_BAKE_WORKER_IMAGE == 'true')
-    runs-on: ubuntu-latest
-    environment: release-prod
-    env:
-      CTYUN_AK: ${{ secrets.CTYUN_AK }}
-      CTYUN_SK: ${{ secrets.CTYUN_SK }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.VOLC_TOS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.VOLC_TOS_SECRET_ACCESS_KEY }}
-      AWS_EC2_METADATA_DISABLED: 'true'
-      TOS_TARGET_BUCKET: github-release
-      TOS_TARGET_REGION: cn-guangzhou
-    steps:
-      - name: Checkout exact release source
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Install Tianyi Cloud CLI
+      - name: Install pinned Tianyi Cloud CLI package
         shell: bash
         run: |
           set -euo pipefail
-          curl -fsSL "https://huabei-2.zos.ctyun.cn/ctyun-cli/install-cli.sh" |
-            sh -s -- \
-              --base-url "https://huabei-2.zos.ctyun.cn/ctyun-cli" \
-              --version v0.1.1
-          echo "$HOME/.ctyun-cli/bin" >> "$GITHUB_PATH"
-          "$HOME/.ctyun-cli/bin/ctyun-cli" version
-
-      - name: Create short-lived private artifact URL
-        shell: bash
-        run: |
-          set -euo pipefail
-          if ! command -v aws >/dev/null 2>&1; then
-            sudo apt-get update
-            sudo apt-get install -y awscli
-          fi
-          aws configure set default.s3.addressing_style virtual
-          TARGET_ENDPOINT="https://tos-s3-${TOS_TARGET_REGION}.volces.com"
-          artifact_url="$(
-            aws s3 presign \
-              "s3://${TOS_TARGET_BUCKET}/${{ needs.artifact.outputs.artifact_key }}" \
-              --expires-in 3600 \
-              --endpoint-url "$TARGET_ENDPOINT"
-          )"
-          echo "::add-mask::$artifact_url"
-          echo "WORKER_ARTIFACT_URL=$artifact_url" >> "$GITHUB_ENV"
+          package_dir="$(mktemp -d)"
+          trap 'rm -rf "$package_dir"' EXIT
+          package="$package_dir/ctyun-cli.tar.gz"
+          curl --fail --silent --show-error --location \
+            --retry 4 --retry-all-errors \
+            "https://huabei-2.zos.ctyun.cn/ctyun-cli/${CTYUN_CLI_VERSION}/ctyun-cli-${CTYUN_CLI_VERSION}-linux-amd64-setup.tar.gz" \
+            --output "$package"
+          echo "${CTYUN_CLI_PACKAGE_SHA256}  $package" | sha256sum --check --strict
+          tar -xzf "$package" -C "$package_dir"
+          test -x "$package_dir/ctyun-cli"
+          install -d "$HOME/.local/bin"
+          install -m 0755 "$package_dir/ctyun-cli" "$HOME/.local/bin/ctyun-cli"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/ctyun-cli" version
 
       - name: Bake private ECS image
         shell: pwsh
+        env:
+          CTYUN_AK: ${{ secrets.CTYUN_AK }}
+          CTYUN_SK: ${{ secrets.CTYUN_SK }}
         run: |
           ./ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1 `
             -Mode Create `
             -SourceRef '${{ github.sha }}' `
-            -ArtifactUrl $env:WORKER_ARTIFACT_URL `
-            -ArtifactSha256 '${{ needs.artifact.outputs.artifact_sha256 }}' `
+            -ArtifactPath '${{ steps.artifact_meta.outputs.path }}' `
+            -ArtifactSha256 '${{ steps.artifact_meta.outputs.sha256 }}' `
+            -BuildNumber '${{ github.run_number }}' `
+            -BuildAttempt '${{ github.run_attempt }}' `
             -RegionID '${{ vars.CTYUN_WORKER_REGION_ID }}' `
             -AzName '${{ vars.CTYUN_WORKER_AZ_NAME }}' `
             -BaseImageID '${{ vars.CTYUN_WORKER_BASE_IMAGE_ID }}' `

--- a/.github/workflows/worker-image.yml
+++ b/.github/workflows/worker-image.yml
@@ -126,15 +126,24 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          response="$(curl --fail --silent --show-error --location \
-            --retry 4 --retry-all-errors \
-            --header 'Accept: application/vnd.github+json' \
-            --header "Authorization: Bearer $GITHUB_TOKEN" \
-            --header 'X-GitHub-Api-Version: 2022-11-28' \
-            "https://api.github.com/repos/$GITHUB_REPOSITORY/actions/workflows/worker-image.yml/runs?per_page=100")"
-          interrupted="$(jq -c --arg current "$GITHUB_RUN_ID" '
-            [
-              .workflow_runs[]
+          responses="$(mktemp)"
+          trap 'rm -f "$responses"' EXIT
+          page=1
+          while :; do
+            response="$(curl --fail --silent --show-error --location \
+              --retry 4 --retry-all-errors \
+              --header 'Accept: application/vnd.github+json' \
+              --header "Authorization: Bearer $GITHUB_TOKEN" \
+              --header 'X-GitHub-Api-Version: 2022-11-28' \
+              "https://api.github.com/repos/$GITHUB_REPOSITORY/actions/workflows/worker-image.yml/runs?per_page=100&page=$page")"
+            jq -c '.workflow_runs' <<<"$response" >> "$responses"
+            [[ "$(jq '.workflow_runs | length' <<<"$response")" -lt 100 ]] && break
+            page=$((page + 1))
+          done
+          interrupted="$(jq -cs --arg current "$GITHUB_RUN_ID" '
+            add
+            | [
+              .[]
               | select((.id | tostring) != $current)
               | select(
                   .conclusion == "failure" or
@@ -152,7 +161,7 @@ jobs:
                   updated_at: .updated_at
                 }
             ]
-          ' <<<"$response")"
+          ' "$responses")"
           if [[ "$(jq 'length' <<<"$interrupted")" -eq 0 ]]; then
             echo "found=false" >> "$GITHUB_OUTPUT"
             exit 0
@@ -168,6 +177,13 @@ jobs:
           CTYUN_AK: ${{ secrets.CTYUN_AK }}
           CTYUN_SK: ${{ secrets.CTYUN_SK }}
           INTERRUPTED_RUNS_JSON: ${{ steps.prior_runs.outputs.runs }}
+          WORKER_REGION_ID: ${{ vars.CTYUN_WORKER_REGION_ID }}
+          WORKER_AZ_NAME: ${{ vars.CTYUN_WORKER_AZ_NAME }}
+          WORKER_BASE_IMAGE_ID: ${{ vars.CTYUN_WORKER_BASE_IMAGE_ID }}
+          WORKER_FLAVOR_ID: ${{ vars.CTYUN_WORKER_FLAVOR_ID }}
+          WORKER_VPC_ID: ${{ vars.CTYUN_WORKER_VPC_ID }}
+          WORKER_SUBNET_ID: ${{ vars.CTYUN_WORKER_SUBNET_ID }}
+          WORKER_SECURITY_GROUP_ID: ${{ vars.CTYUN_WORKER_SECURITY_GROUP_ID }}
         run: |
           $runs = @($env:INTERRUPTED_RUNS_JSON | ConvertFrom-Json)
           $recentRuns = [Collections.Generic.List[object]]::new()
@@ -206,13 +222,13 @@ jobs:
               '-BakeTimeoutMinutes', '150',
               '-CleanupTimeoutMinutes', [string]$cleanupTimeoutMinutes,
               '-ApiTimeoutSeconds', [string]$apiTimeoutSeconds,
-              '-RegionID', '${{ vars.CTYUN_WORKER_REGION_ID }}',
-              '-AzName', '${{ vars.CTYUN_WORKER_AZ_NAME }}',
-              '-BaseImageID', '${{ vars.CTYUN_WORKER_BASE_IMAGE_ID }}',
-              '-FlavorID', '${{ vars.CTYUN_WORKER_FLAVOR_ID }}',
-              '-VpcID', '${{ vars.CTYUN_WORKER_VPC_ID }}',
-              '-SubnetID', '${{ vars.CTYUN_WORKER_SUBNET_ID }}',
-              '-SecurityGroupID', '${{ vars.CTYUN_WORKER_SECURITY_GROUP_ID }}'
+              '-RegionID', $env:WORKER_REGION_ID,
+              '-AzName', $env:WORKER_AZ_NAME,
+              '-BaseImageID', $env:WORKER_BASE_IMAGE_ID,
+              '-FlavorID', $env:WORKER_FLAVOR_ID,
+              '-VpcID', $env:WORKER_VPC_ID,
+              '-SubnetID', $env:WORKER_SUBNET_ID,
+              '-SecurityGroupID', $env:WORKER_SECURITY_GROUP_ID
             )
             if ($WaitForLate) {
               $arguments += '-WaitForLateResources'
@@ -292,8 +308,15 @@ jobs:
         env:
           CTYUN_AK: ${{ secrets.CTYUN_AK }}
           CTYUN_SK: ${{ secrets.CTYUN_SK }}
+          WORKER_REGION_ID: ${{ vars.CTYUN_WORKER_REGION_ID }}
+          WORKER_AZ_NAME: ${{ vars.CTYUN_WORKER_AZ_NAME }}
+          WORKER_BASE_IMAGE_ID: ${{ vars.CTYUN_WORKER_BASE_IMAGE_ID }}
+          WORKER_FLAVOR_ID: ${{ vars.CTYUN_WORKER_FLAVOR_ID }}
+          WORKER_VPC_ID: ${{ vars.CTYUN_WORKER_VPC_ID }}
+          WORKER_SUBNET_ID: ${{ vars.CTYUN_WORKER_SUBNET_ID }}
+          WORKER_SECURITY_GROUP_ID: ${{ vars.CTYUN_WORKER_SECURITY_GROUP_ID }}
         run: |
-          $currentAttempt = [int]'${{ github.run_attempt }}'
+          $currentAttempt = [int]$env:GITHUB_RUN_ATTEMPT
           $rerunDeadline = [DateTimeOffset]::UtcNow.AddMinutes(45)
           $rerunFailures = [Collections.Generic.List[string]]::new()
           foreach ($previousAttempt in 1..($currentAttempt - 1)) {
@@ -309,20 +332,20 @@ jobs:
               '-NonInteractive',
               '-File', './ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1',
               '-Mode', 'Cleanup',
-              '-SourceRef', '${{ github.sha }}',
-              '-BuildNumber', '${{ github.run_number }}',
+              '-SourceRef', $env:GITHUB_SHA,
+              '-BuildNumber', $env:GITHUB_RUN_NUMBER,
               '-BuildAttempt', [string]$previousAttempt,
-              '-BuildIdentity', '${{ github.run_id }}',
+              '-BuildIdentity', $env:GITHUB_RUN_ID,
               '-BakeTimeoutMinutes', '150',
               '-CleanupTimeoutMinutes', '15',
               '-ApiTimeoutSeconds', '90',
-              '-RegionID', '${{ vars.CTYUN_WORKER_REGION_ID }}',
-              '-AzName', '${{ vars.CTYUN_WORKER_AZ_NAME }}',
-              '-BaseImageID', '${{ vars.CTYUN_WORKER_BASE_IMAGE_ID }}',
-              '-FlavorID', '${{ vars.CTYUN_WORKER_FLAVOR_ID }}',
-              '-VpcID', '${{ vars.CTYUN_WORKER_VPC_ID }}',
-              '-SubnetID', '${{ vars.CTYUN_WORKER_SUBNET_ID }}',
-              '-SecurityGroupID', '${{ vars.CTYUN_WORKER_SECURITY_GROUP_ID }}'
+              '-RegionID', $env:WORKER_REGION_ID,
+              '-AzName', $env:WORKER_AZ_NAME,
+              '-BaseImageID', $env:WORKER_BASE_IMAGE_ID,
+              '-FlavorID', $env:WORKER_FLAVOR_ID,
+              '-VpcID', $env:WORKER_VPC_ID,
+              '-SubnetID', $env:WORKER_SUBNET_ID,
+              '-SecurityGroupID', $env:WORKER_SECURITY_GROUP_ID
             )
             if ($previousAttempt -eq $currentAttempt - 1) {
               $arguments += '-WaitForLateResources'
@@ -346,25 +369,34 @@ jobs:
         env:
           CTYUN_AK: ${{ secrets.CTYUN_AK }}
           CTYUN_SK: ${{ secrets.CTYUN_SK }}
+          WORKER_REGION_ID: ${{ vars.CTYUN_WORKER_REGION_ID }}
+          WORKER_AZ_NAME: ${{ vars.CTYUN_WORKER_AZ_NAME }}
+          WORKER_BASE_IMAGE_ID: ${{ vars.CTYUN_WORKER_BASE_IMAGE_ID }}
+          WORKER_FLAVOR_ID: ${{ vars.CTYUN_WORKER_FLAVOR_ID }}
+          WORKER_VPC_ID: ${{ vars.CTYUN_WORKER_VPC_ID }}
+          WORKER_SUBNET_ID: ${{ vars.CTYUN_WORKER_SUBNET_ID }}
+          WORKER_SECURITY_GROUP_ID: ${{ vars.CTYUN_WORKER_SECURITY_GROUP_ID }}
+          WORKER_ARTIFACT_PATH: ${{ steps.artifact_meta.outputs.path }}
+          WORKER_ARTIFACT_SHA256: ${{ steps.artifact_meta.outputs.sha256 }}
         run: |
           ./ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1 `
             -Mode Create `
-            -SourceRef '${{ github.sha }}' `
-            -ArtifactPath '${{ steps.artifact_meta.outputs.path }}' `
-            -ArtifactSha256 '${{ steps.artifact_meta.outputs.sha256 }}' `
-            -BuildNumber '${{ github.run_number }}' `
-            -BuildAttempt '${{ github.run_attempt }}' `
-            -BuildIdentity '${{ github.run_id }}' `
+            -SourceRef $env:GITHUB_SHA `
+            -ArtifactPath $env:WORKER_ARTIFACT_PATH `
+            -ArtifactSha256 $env:WORKER_ARTIFACT_SHA256 `
+            -BuildNumber $env:GITHUB_RUN_NUMBER `
+            -BuildAttempt $env:GITHUB_RUN_ATTEMPT `
+            -BuildIdentity $env:GITHUB_RUN_ID `
             -BakeTimeoutMinutes 150 `
             -CleanupTimeoutMinutes 40 `
             -ApiTimeoutSeconds 90 `
-            -RegionID '${{ vars.CTYUN_WORKER_REGION_ID }}' `
-            -AzName '${{ vars.CTYUN_WORKER_AZ_NAME }}' `
-            -BaseImageID '${{ vars.CTYUN_WORKER_BASE_IMAGE_ID }}' `
-            -FlavorID '${{ vars.CTYUN_WORKER_FLAVOR_ID }}' `
-            -VpcID '${{ vars.CTYUN_WORKER_VPC_ID }}' `
-            -SubnetID '${{ vars.CTYUN_WORKER_SUBNET_ID }}' `
-            -SecurityGroupID '${{ vars.CTYUN_WORKER_SECURITY_GROUP_ID }}'
+            -RegionID $env:WORKER_REGION_ID `
+            -AzName $env:WORKER_AZ_NAME `
+            -BaseImageID $env:WORKER_BASE_IMAGE_ID `
+            -FlavorID $env:WORKER_FLAVOR_ID `
+            -VpcID $env:WORKER_VPC_ID `
+            -SubnetID $env:WORKER_SUBNET_ID `
+            -SecurityGroupID $env:WORKER_SECURITY_GROUP_ID
 
       - name: Reconcile this attempt after a failed bake
         if: ${{ always() && steps.bake.outcome != 'success' }}
@@ -373,21 +405,28 @@ jobs:
         env:
           CTYUN_AK: ${{ secrets.CTYUN_AK }}
           CTYUN_SK: ${{ secrets.CTYUN_SK }}
+          WORKER_REGION_ID: ${{ vars.CTYUN_WORKER_REGION_ID }}
+          WORKER_AZ_NAME: ${{ vars.CTYUN_WORKER_AZ_NAME }}
+          WORKER_BASE_IMAGE_ID: ${{ vars.CTYUN_WORKER_BASE_IMAGE_ID }}
+          WORKER_FLAVOR_ID: ${{ vars.CTYUN_WORKER_FLAVOR_ID }}
+          WORKER_VPC_ID: ${{ vars.CTYUN_WORKER_VPC_ID }}
+          WORKER_SUBNET_ID: ${{ vars.CTYUN_WORKER_SUBNET_ID }}
+          WORKER_SECURITY_GROUP_ID: ${{ vars.CTYUN_WORKER_SECURITY_GROUP_ID }}
         run: |
           ./ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1 `
             -Mode Cleanup `
-            -SourceRef '${{ github.sha }}' `
-            -BuildNumber '${{ github.run_number }}' `
-            -BuildAttempt '${{ github.run_attempt }}' `
-            -BuildIdentity '${{ github.run_id }}' `
+            -SourceRef $env:GITHUB_SHA `
+            -BuildNumber $env:GITHUB_RUN_NUMBER `
+            -BuildAttempt $env:GITHUB_RUN_ATTEMPT `
+            -BuildIdentity $env:GITHUB_RUN_ID `
             -BakeTimeoutMinutes 150 `
             -CleanupTimeoutMinutes 40 `
             -ApiTimeoutSeconds 90 `
             -WaitForLateResources `
-            -RegionID '${{ vars.CTYUN_WORKER_REGION_ID }}' `
-            -AzName '${{ vars.CTYUN_WORKER_AZ_NAME }}' `
-            -BaseImageID '${{ vars.CTYUN_WORKER_BASE_IMAGE_ID }}' `
-            -FlavorID '${{ vars.CTYUN_WORKER_FLAVOR_ID }}' `
-            -VpcID '${{ vars.CTYUN_WORKER_VPC_ID }}' `
-            -SubnetID '${{ vars.CTYUN_WORKER_SUBNET_ID }}' `
-            -SecurityGroupID '${{ vars.CTYUN_WORKER_SECURITY_GROUP_ID }}'
+            -RegionID $env:WORKER_REGION_ID `
+            -AzName $env:WORKER_AZ_NAME `
+            -BaseImageID $env:WORKER_BASE_IMAGE_ID `
+            -FlavorID $env:WORKER_FLAVOR_ID `
+            -VpcID $env:WORKER_VPC_ID `
+            -SubnetID $env:WORKER_SUBNET_ID `
+            -SecurityGroupID $env:WORKER_SECURITY_GROUP_ID

--- a/.github/workflows/worker-image.yml
+++ b/.github/workflows/worker-image.yml
@@ -14,13 +14,14 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 concurrency:
   group: worker-image-bake
   cancel-in-progress: false
 
 env:
-  NODE_VERSION: "20"
+  NODE_VERSION: "22.23.1"
   CTYUN_CLI_VERSION: v0.1.1
   CTYUN_CLI_PACKAGE_SHA256: 93272c3fd377a6f642a89cb326fa2f4a3d2fab7dfc9587e49906527230b767fa
 
@@ -34,15 +35,17 @@ jobs:
       (startsWith(github.ref, 'refs/tags/') &&
        vars.CTYUN_AUTO_BAKE_WORKER_IMAGE == 'true')
     runs-on: ubuntu-24.04
-    timeout-minutes: 120
+    timeout-minutes: 420
     environment: release-prod
     steps:
       - name: Checkout exact source
+        timeout-minutes: 3
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           fetch-depth: 0
 
       - name: Set up Node.js
+        timeout-minutes: 3
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -50,6 +53,7 @@ jobs:
           cache-dependency-path: package-lock.json
 
       - name: Validate trusted release source
+        timeout-minutes: 3
         shell: bash
         run: |
           set -euo pipefail
@@ -71,15 +75,19 @@ jobs:
           fi
 
       - name: Install dependencies
+        timeout-minutes: 20
         run: npm ci --prefer-offline --no-audit --fund=false
 
       - name: Build CatsCo
+        timeout-minutes: 8
         run: npm run build
 
       - name: Build deterministic Linux worker artifact
+        timeout-minutes: 25
         run: npm run worker:artifact
 
       - name: Record artifact identity
+        timeout-minutes: 1
         id: artifact_meta
         shell: bash
         run: |
@@ -91,6 +99,7 @@ jobs:
           echo "sha256=$(sha256sum "$artifact" | awk '{print $1}')" >> "$GITHUB_OUTPUT"
 
       - name: Install pinned Tianyi Cloud CLI package
+        timeout-minutes: 3
         shell: bash
         run: |
           set -euo pipefail
@@ -109,7 +118,100 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           "$HOME/.local/bin/ctyun-cli" version
 
+      - name: Find the latest interrupted image run
+        id: prior_run
+        timeout-minutes: 3
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          response="$(curl --fail --silent --show-error --location \
+            --retry 4 --retry-all-errors \
+            --header 'Accept: application/vnd.github+json' \
+            --header "Authorization: Bearer $GITHUB_TOKEN" \
+            --header 'X-GitHub-Api-Version: 2022-11-28' \
+            "https://api.github.com/repos/$GITHUB_REPOSITORY/actions/workflows/worker-image.yml/runs?per_page=20")"
+          prior="$(jq --arg current "$GITHUB_RUN_ID" '
+            [
+              .workflow_runs[]
+              | select((.id | tostring) != $current)
+            ][0] // empty
+          ' <<<"$response")"
+          if [[ -z "$prior" ]]; then
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          conclusion="$(jq -r '.conclusion // ""' <<<"$prior")"
+          case "$conclusion" in
+            failure|cancelled|timed_out|startup_failure|stale) ;;
+            *)
+              echo "found=false" >> "$GITHUB_OUTPUT"
+              exit 0
+              ;;
+          esac
+          echo "found=true" >> "$GITHUB_OUTPUT"
+          echo "build_number=$(jq -r '.run_number' <<<"$prior")" >> "$GITHUB_OUTPUT"
+          echo "attempt=$(jq -r '.run_attempt' <<<"$prior")" >> "$GITHUB_OUTPUT"
+          echo "run_id=$(jq -r '.id' <<<"$prior")" >> "$GITHUB_OUTPUT"
+          echo "sha=$(jq -r '.head_sha' <<<"$prior")" >> "$GITHUB_OUTPUT"
+          echo "conclusion=$conclusion" >> "$GITHUB_OUTPUT"
+
+      - name: Reconcile the latest interrupted image run
+        if: ${{ steps.prior_run.outputs.found == 'true' }}
+        timeout-minutes: 20
+        shell: pwsh
+        env:
+          CTYUN_AK: ${{ secrets.CTYUN_AK }}
+          CTYUN_SK: ${{ secrets.CTYUN_SK }}
+        run: |
+          Write-Host "Reconciling prior run ${{ steps.prior_run.outputs.run_id }} (${{ steps.prior_run.outputs.conclusion }})"
+          ./ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1 `
+            -Mode Cleanup `
+            -SourceRef '${{ steps.prior_run.outputs.sha }}' `
+            -BuildNumber '${{ steps.prior_run.outputs.build_number }}' `
+            -BuildAttempt '${{ steps.prior_run.outputs.attempt }}' `
+            -BuildIdentity '${{ steps.prior_run.outputs.run_id }}' `
+            -BakeTimeoutMinutes 150 `
+            -CleanupTimeoutMinutes 15 `
+            -ApiTimeoutSeconds 90 `
+            -RegionID '${{ vars.CTYUN_WORKER_REGION_ID }}' `
+            -AzName '${{ vars.CTYUN_WORKER_AZ_NAME }}' `
+            -BaseImageID '${{ vars.CTYUN_WORKER_BASE_IMAGE_ID }}' `
+            -FlavorID '${{ vars.CTYUN_WORKER_FLAVOR_ID }}' `
+            -VpcID '${{ vars.CTYUN_WORKER_VPC_ID }}' `
+            -SubnetID '${{ vars.CTYUN_WORKER_SUBNET_ID }}' `
+            -SecurityGroupID '${{ vars.CTYUN_WORKER_SECURITY_GROUP_ID }}'
+
+      - name: Reconcile the previous attempt before a rerun
+        if: ${{ github.run_attempt > 1 }}
+        timeout-minutes: 40
+        shell: pwsh
+        env:
+          CTYUN_AK: ${{ secrets.CTYUN_AK }}
+          CTYUN_SK: ${{ secrets.CTYUN_SK }}
+        run: |
+          $previousAttempt = [int]'${{ github.run_attempt }}' - 1
+          ./ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1 `
+            -Mode Cleanup `
+            -SourceRef '${{ github.sha }}' `
+            -BuildNumber '${{ github.run_number }}' `
+            -BuildAttempt "$previousAttempt" `
+            -BuildIdentity '${{ github.run_id }}' `
+            -BakeTimeoutMinutes 150 `
+            -CleanupTimeoutMinutes 40 `
+            -ApiTimeoutSeconds 90 `
+            -WaitForLateResources `
+            -RegionID '${{ vars.CTYUN_WORKER_REGION_ID }}' `
+            -AzName '${{ vars.CTYUN_WORKER_AZ_NAME }}' `
+            -BaseImageID '${{ vars.CTYUN_WORKER_BASE_IMAGE_ID }}' `
+            -FlavorID '${{ vars.CTYUN_WORKER_FLAVOR_ID }}' `
+            -VpcID '${{ vars.CTYUN_WORKER_VPC_ID }}' `
+            -SubnetID '${{ vars.CTYUN_WORKER_SUBNET_ID }}' `
+            -SecurityGroupID '${{ vars.CTYUN_WORKER_SECURITY_GROUP_ID }}'
+
       - name: Bake private ECS image
+        id: bake
         shell: pwsh
         env:
           CTYUN_AK: ${{ secrets.CTYUN_AK }}
@@ -122,6 +224,36 @@ jobs:
             -ArtifactSha256 '${{ steps.artifact_meta.outputs.sha256 }}' `
             -BuildNumber '${{ github.run_number }}' `
             -BuildAttempt '${{ github.run_attempt }}' `
+            -BuildIdentity '${{ github.run_id }}' `
+            -BakeTimeoutMinutes 150 `
+            -CleanupTimeoutMinutes 40 `
+            -ApiTimeoutSeconds 90 `
+            -RegionID '${{ vars.CTYUN_WORKER_REGION_ID }}' `
+            -AzName '${{ vars.CTYUN_WORKER_AZ_NAME }}' `
+            -BaseImageID '${{ vars.CTYUN_WORKER_BASE_IMAGE_ID }}' `
+            -FlavorID '${{ vars.CTYUN_WORKER_FLAVOR_ID }}' `
+            -VpcID '${{ vars.CTYUN_WORKER_VPC_ID }}' `
+            -SubnetID '${{ vars.CTYUN_WORKER_SUBNET_ID }}' `
+            -SecurityGroupID '${{ vars.CTYUN_WORKER_SECURITY_GROUP_ID }}'
+
+      - name: Reconcile this attempt after a failed bake
+        if: ${{ always() && steps.bake.outcome != 'success' }}
+        timeout-minutes: 45
+        shell: pwsh
+        env:
+          CTYUN_AK: ${{ secrets.CTYUN_AK }}
+          CTYUN_SK: ${{ secrets.CTYUN_SK }}
+        run: |
+          ./ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1 `
+            -Mode Cleanup `
+            -SourceRef '${{ github.sha }}' `
+            -BuildNumber '${{ github.run_number }}' `
+            -BuildAttempt '${{ github.run_attempt }}' `
+            -BuildIdentity '${{ github.run_id }}' `
+            -BakeTimeoutMinutes 150 `
+            -CleanupTimeoutMinutes 40 `
+            -ApiTimeoutSeconds 90 `
+            -WaitForLateResources `
             -RegionID '${{ vars.CTYUN_WORKER_REGION_ID }}' `
             -AzName '${{ vars.CTYUN_WORKER_AZ_NAME }}' `
             -BaseImageID '${{ vars.CTYUN_WORKER_BASE_IMAGE_ID }}' `

--- a/docs/superpowers/plans/2026-08-04-worker-artifact-update.md
+++ b/docs/superpowers/plans/2026-08-04-worker-artifact-update.md
@@ -1,0 +1,306 @@
+# 应用制品自动更新（Part A: XiaoBa-CLI 侧）实现计划
+
+> **面向 AI 代理的工作者：** 必需子技能：使用 superpowers:subagent-driven-development（推荐）或 superpowers:executing-plans 逐任务实现此计划。步骤使用复选框（`- [ ]`）语法来跟踪进度。
+
+**目标：** 让已有虚拟员工（worker）通过"应用制品"（`npm run worker:artifact` 产出的确定性 tar.gz）更新应用层，不切系统盘、不动 `/srv/catsco-agent` 数据，支持校验、冒烟、自动回滚，可由 CI/控制面触发。
+
+**架构：** CI（打 tag）构建应用制品 → 分发到 worker → worker 侧脚本校验 sha256/manifest → 解压到 `/opt/catsco/releases/<ver>-<sha>`（新目录，旧版本保留）→ 原生模块冒烟 → 切换 `/opt/catsco/current` 符号链接 → 重启 `catsco-agent.service` → 心跳验证，失败自动切回旧 symlink。数据目录 `/srv/catsco-agent` 全程不触碰。
+
+**技术栈：** bash（worker 侧脚本）、TypeScript/Node（分发脚本与测试）、GitHub Actions、复用 `build-linux-worker-artifact.mjs` 与 `ops/ctyun-worker-image/prepare-image.sh` 的 release 目录约定（`/opt/catsco/releases/<version>-<8位commit>` + `/opt/catsco/current`）。
+
+**关联计划：** Part B（cats-company 控制面：新开云员工按钮、版本检查、更新确认与执行）见 `E:\work\cats\cats-company\docs\superpowers\plans\2026-08-04-worker-control-plane.md`。本计划只交付 worker 侧更新能力与分发通道，控制面在 Part B 调用。
+
+**关键事实（实现前已核实）：**
+- 制品已存在：`scripts/build-linux-worker-artifact.mjs`（确定性 tar：`--sort=name --mtime=@commitEpoch --owner=0`，捆绑 Node 22.23.1，产 `worker-release.json` + `.sha256`）。
+- release 布局约定（与镜像烘焙一致）：`/opt/catsco/releases/<version>-<shortCommit>/`，`/opt/catsco/current -> 活动版本`；`/srv/catsco-agent` 为数据根，绝不修改。
+- 现有部署走 `deploy-catsco-linux-agent` skill 的 `update-linux-agent.sh`（git pull + build + restart）；本计划新增"制品更新"通道，二者并存，互为回退。
+- 目标矩阵（SSH alias → worktree/数据）：worker1/worker2（`/srv/catsco-agent`）、ck-work-hn2/zh-work/yjz-work（worktree `/srv/catsco-agent/app`，数据 `/srv/catsco-agent`）。制品更新统一只动 `/opt/catsco/releases` + `/opt/catsco/current` + service，不碰数据。
+
+---
+
+## 文件结构
+
+**创建：**
+- `scripts/update-worker-artifact.sh` — worker 侧应用制品更新脚本（校验/解压/冒烟/切链接/重启/回滚/幂等）
+- `scripts/deploy-worker-artifact.mjs` — 分发器：本地或 CI 环境持有制品与 SSH 通道，逐台串行部署+验证
+- `.github/workflows/worker-app-update.yml` — 打 tag 后构建制品并分发到 worker（受仓库变量 kill switch 控制）
+- `tests/update-worker-artifact.test.ts` — worker 侧脚本行为测试（临时目录模拟 release 结构，真实执行 bash）
+- `tests/deploy-worker-artifact.test.ts` — 分发器测试（fake 目标/制品/校验）
+- `docs/worker-artifact-update.md` — 运维说明（触发方式、回滚、安全边界）
+
+**修改：**
+- `package.json` — 新增 `worker:update:dry` 等 npm script（可选，便于本地演练）
+- `ops/ctyun-worker-image/README.md` — 补充"已有 worker 更新走应用制品"与镜像关系说明
+
+---
+
+### 任务 1：worker 侧更新脚本 `scripts/update-worker-artifact.sh`
+
+**文件：**
+- 创建：`scripts/update-worker-artifact.sh`
+- 测试：`tests/update-worker-artifact.test.ts`
+
+**脚本契约（与 `prepare-image.sh` 的 release 布局保持一致）：**
+
+```
+用法：
+  update-worker-artifact.sh --artifact FILE --sha256 HEX \
+      --version VERSION --commit SHA
+  update-worker-artifact.sh --status        # 打印当前 releaseId + current 指向
+  update-worker-artifact.sh --rollback      # 切回上一个 release 并重启
+```
+
+- [ ] **步骤 1：编写失败的测试**（`tests/update-worker-artifact.test.ts`，用 Node test runner + `tsx --test`；在临时目录创建 fake `/opt/catsco` 结构，真实调用 bash 脚本，断言行为）
+
+```ts
+import { test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { execFileSync } from 'node:child_process';
+
+function runScript(args: string[], env: Record<string, string>): string {
+  const script = path.resolve('scripts/update-worker-artifact.sh');
+  return execFileSync('bash', [script, ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+  }).trim();
+}
+
+test('refuses to start when artifact checksum does not match', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'uwa-'));
+  try {
+    const artifact = path.join(root, 'bad.tar.gz');
+    fs.writeFileSync(artifact, 'corrupt');
+    assert.throws(() => runScript(
+      ['--artifact', artifact, '--sha256', '0'.repeat(64), '--version', '1.4.8', '--commit', 'a'.repeat(40)],
+      { CATSCO_UWA_ROOT: root },
+    ), /checksum mismatch/);
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+```
+
+- [ ] **步骤 2：运行测试确认失败**
+
+运行：`npx tsx --test tests/update-worker-artifact.test.ts`
+预期：FAIL（脚本不存在 / 不通过校验）
+
+- [ ] **步骤 3：编写脚本骨架 + 参数校验**
+
+```bash
+#!/usr/bin/env bash
+set -Eeuo pipefail
+# ... 解析 --artifact/--sha256/--version/--commit/--status/--rollback ...
+# 允许通过 CATSCO_UWA_ROOT 覆盖根目录（测试用），默认 /opt/catsco
+```
+
+关键校验：`$SHA256` 必须 64 位 hex；`$EXPECTED_COMMIT` 必须 40 位 hex；`$EXPECTED_VERSION` 匹配 `^[0-9A-Za-z][0-9A-Za-z._+-]{0,63}$`；`RELEASE_ROOT` 必须在 `$RELEASES_ROOT` 下（防穿越，同 `prepare-image.sh` 的 `case` 守卫）。
+
+- [ ] **步骤 4：实现"校验 + 解压到新 release 目录 + 冒烟"**
+
+```bash
+ACTUAL_SHA256="$(sha256sum "$ARTIFACT" | awk '{print $1}')"
+[[ "${ACTUAL_SHA256,,}" == "${SHA256,,}" ]] || die "checksum mismatch"
+RELEASE_ROOT="$RELEASES_ROOT/$RELEASE_ID"
+case "$RELEASE_ROOT" in "$RELEASES_ROOT"/*) ;; *) die "release path escapes";; esac
+rm -rf -- "$RELEASE_ROOT"; mkdir -p -- "$RELEASE_ROOT"
+TEMP="$(mktemp -d)"; trap 'rm -rf "$TEMP"' EXIT
+tar -xzf "$ARTIFACT" -C "$TEMP"
+[[ -f "$TEMP/app/worker-release.json" ]] || die "worker-release.json missing"
+# 校验 manifest version/commit
+# 复制 app 到 RELEASE_ROOT；校验捆绑 node/npm 可执行
+# 原生模块冒烟：node -e 'require("sharp"); require("@napi-rs/canvas")...'
+```
+
+- [ ] **步骤 5：实现"切换 symlink + 重启 + 心跳验证 + 失败回滚"**
+
+```bash
+# 记录旧 current（用于回滚），并持久化到 /var/lib/catsco/previous-release（--rollback 读取用）
+CURRENT_LINK="$ROOT/current"
+OLD_TARGET="$(readlink "$CURRENT_LINK" 2>/dev/null || true)"
+mkdir -p /var/lib/catsco
+echo "$OLD_TARGET" > /var/lib/catsco/previous-release
+ln -sfn "$RELEASE_ROOT" "$CURRENT_LINK"
+systemctl restart catsco-agent.service
+# settle：等 5s 后再次确认 active（重复 systemctl is-active，避免启动瞬间误判）
+# 心跳验证：journalctl -u catsco-agent.service -n 60 --no-pager -o cat
+#   | grep -E '已连接|握手成功|uid='（任一即视为已连上；容忍历史告警，只认重启后的新记录）
+# 验证失败 -> 读 /var/lib/catsco/previous-release 切回 + systemctl restart + 报错
+```
+
+- [ ] **步骤 6：实现 `--status` 与 `--rollback`**
+
+`--status`：打印 `release_id=<version>-<shortCommit>` 与 `current=...`；`--rollback`：读取 `/var/lib/catsco/previous-release` 指向的 release，校验其 `worker-release.json` 存在后切换重启（记录文件缺失或目标非法则报错，不猜测）。
+
+- [ ] **步骤 7：补测试覆盖**
+
+新增测试：成功更新（新 release 目录创建、current 指向新、数据目录 `$CATSCO_UWA_ROOT/srv` 未被触碰）；幂等（同版本已 active 且 current 指向则跳过）；回滚（冒烟失败后 current 指回旧）；`--status` 输出正确。
+
+- [ ] **步骤 8：`bash -n` + 全量测试**
+
+运行：`bash -n scripts/update-worker-artifact.sh` 与 `npx tsx --test tests/update-worker-artifact.test.ts`；再 `npm test` 确认无回归。
+预期：全绿。
+
+- [ ] **步骤 9：Commit**
+
+```bash
+git add scripts/update-worker-artifact.sh tests/update-worker-artifact.test.ts
+git commit -m "feat(worker): apply application artifact updates with validation and rollback"
+```
+
+---
+
+### 任务 2：分发器 `scripts/deploy-worker-artifact.mjs`
+
+**文件：**
+- 创建：`scripts/deploy-worker-artifact.mjs`
+- 测试：`tests/deploy-worker-artifact.test.ts`
+
+**职责：** 运维机/CI 持有制品 + SSH 通道，把制品逐台部署到目标 worker：scp 制品与脚本 → 每台执行 `update-worker-artifact.sh` → 逐台串行、单台失败可回滚或中止后续。
+
+- [ ] **步骤 1：编写失败的测试**（fake 目标：用本地临时目录模拟远端，`--dry-run` 模式不真正 ssh）
+
+```ts
+test('deploys artifact to each target serially and reports per-target result', () => {
+  // 构造 2 个 fake target（本地临时目录），调用 deploy（注入 fake runner）
+  // 断言：两 target 都被部署；结果含 commit/version；失败 target 被标记
+});
+```
+
+- [ ] **步骤 2：运行确认失败**
+
+运行：`npx tsx --test tests/deploy-worker-artifact.test.ts`；预期 FAIL。
+
+- [ ] **步骤 3：实现 CLI 与目标矩阵**
+
+```ts
+// --artifact FILE --sha256 HEX --version V --commit SHA --targets worker1,worker2,...
+// 未指定 targets 时读默认矩阵（与 deploy skill 一致）：
+const DEFAULT_TARGETS = [
+  { alias: 'worker1',     worktree: '/srv/catsco-agent' },        // data=/srv/catsco-agent
+  { alias: 'worker2',     worktree: '/srv/catsco-agent' },
+  { alias: 'ck-work-hn2', worktree: '/srv/catsco-agent/app' },    // data=/srv/catsco-agent
+  { alias: 'zh-work',     worktree: '/srv/catsco-agent/app' },
+  { alias: 'yjz-work',    worktree: '/srv/catsco-agent/app' },
+];
+// 注意：worker 侧更新脚本只操作 /opt/catsco（release 布局），与 worktree 解耦；
+// worktree 仅用于 --status 校验"当前 git commit"（可选信息，不参与更新）。
+```
+
+- [ ] **步骤 4：实现逐台部署（串行 + 验证 + 回滚）**
+
+```ts
+// 对每个 target：
+//  1) scp artifact + update-worker-artifact.sh 到 /tmp（唯一名）
+//  2) ssh 执行脚本（--expected-* 校验）
+//  3) 验证：systemctl is-active + 日志含握手/uid/model（bounded）
+//  4) 失败 -> 该台 ssh --rollback，记录失败，继续下一台（或按 --abort-on-failure 中止）
+// 每台成功才进入下一台；结束后清理远端 /tmp 临时文件
+```
+
+- [ ] **步骤 5：补测试**
+
+覆盖：校验失败中止该台并回滚；跳过已是最新版本的 target（`--status` 比对）；清理临时文件断言。
+
+- [ ] **步骤 6：`npm run build` + 全量测试**
+
+运行：`npm run build`、`npx tsx --test tests/deploy-worker-artifact.test.ts`、`npm test`；预期全绿。
+
+- [ ] **步骤 7：Commit**
+
+```bash
+git add scripts/deploy-worker-artifact.mjs tests/deploy-worker-artifact.test.ts
+git commit -m "feat(worker): serial artifact deployment across worker targets"
+```
+
+---
+
+### 任务 3：CI 自动构建 + 分发（`.github/workflows/worker-app-update.yml`）
+
+**文件：**
+- 创建：`.github/workflows/worker-app-update.yml`
+- 测试：`tests/worker-app-update-workflow.test.ts`（复用 worker-image-pipeline.test.ts 的 workflow 校验模式：yaml 存在、trigger 限制、权限最小化、secret 引用不硬编码）
+
+- [ ] **步骤 1：编写失败测试**（断言 workflow 关键约束）
+
+```ts
+test('worker app update workflow is gated by stable tag and kill-switch variable', () => {
+  // 读取 yaml：on.push.tags 含 "v*"；job if 引用 vars.CTYUN_WORKER_APP_UPDATE == 'true'；
+  // 不含明文 secret；permissions 最小
+});
+```
+
+- [ ] **步骤 2：运行确认失败**
+
+- [ ] **步骤 3：编写 workflow**
+
+```yaml
+name: Update Worker Application Artifacts
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      update_workers: { type: boolean, default: false }
+permissions: { contents: read, actions: read }
+concurrency: { group: worker-app-update, cancel-in-progress: false }
+jobs:
+  build-and-deploy:
+    if: >-
+      (github.event_name == 'workflow_dispatch' && inputs.update_workers && github.ref == 'refs/heads/main') ||
+      (startsWith(github.ref, 'refs/tags/') && vars.CTYUN_WORKER_APP_UPDATE == 'true')
+    runs-on: ubuntu-24.04
+    environment: release-prod
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # fetch-depth: 0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # node 22.23.1
+      - run: npm ci --prefer-offline --no-audit --fund=false
+      - run: npm run worker:artifact          # 产出 release/worker/*.tar.gz + .sha256
+      - run: node scripts/deploy-worker-artifact.mjs --artifact <path> --sha256 <hex> --version <v> --commit <sha>
+        env:  # 通过 repo secret 注入 SSH 凭据（仅 names，不硬编码）
+          WORKER_SSH_KEY: ${{ secrets.WORKER_SSH_KEY }}
+```
+
+- [ ] **步骤 4：测试通过 + 校验**
+
+运行 workflow 校验测试 + `actionlint`（如可用）；确认无明文 secret、权限最小。
+
+- [ ] **步骤 5：Commit**
+
+```bash
+git add .github/workflows/worker-app-update.yml tests/worker-app-update-workflow.test.ts
+git commit -m "ci(worker): gate worker app artifact updates behind stable tags and a kill switch"
+```
+
+---
+
+### 任务 4：文档与收尾
+
+**文件：**
+- 创建：`docs/worker-artifact-update.md`
+- 修改：`ops/ctyun-worker-image/README.md`
+
+- [ ] **步骤 1：写 `docs/worker-artifact-update.md`**：触发方式（打 tag + `CTYUN_WORKER_APP_UPDATE=true` / 手动 workflow_dispatch / 本地 `node scripts/deploy-worker-artifact.mjs ...`）；安全边界（只动 `/opt/catsco` 与 service，数据 `/srv/catsco-agent` 不碰；worker 无云凭据）；回滚（`--rollback` 或旧 symlink）；与镜像的关系（新 worker 用完整镜像，老 worker 用制品更新）。
+- [ ] **步骤 2：改 `ops/ctyun-worker-image/README.md`**：补充"已有 worker 更新 = 应用制品（Part A），新 worker = 完整镜像"的章节说明。
+- [ ] **步骤 3：全量测试 + 清理**
+
+运行：`npm test`（全绿）；确认无临时文件残留（worktree/临时目录）。
+
+- [ ] **步骤 4：Commit**
+
+```bash
+git add docs/worker-artifact-update.md ops/ctyun-worker-image/README.md
+git commit -m "docs(worker): document application artifact update flow and safety boundary"
+```
+
+---
+
+## 验收清单
+
+- [ ] worker 侧脚本：校验 sha256/manifest、防穿越、幂等、冒烟、切链接、重启、失败回滚、`--status`/`--rollback`
+- [ ] 分发器：串行、逐台验证、失败回滚、清理远端临时文件、支持 dry-run 测试
+- [ ] CI：打 tag 自动构建+分发、kill switch 变量、权限最小、无明文 secret
+- [ ] 数据目录 `/srv/catsco-agent` 在更新全流程中零改动（测试断言）
+- [ ] 全量测试 0 失败；文档就绪
+- [ ] 与 Part B 接口对齐：`deploy-worker-artifact.mjs` 可被控制面以子进程/HTTP 方式触发（Part B 计划引用本计划的脚本契约）

--- a/docs/superpowers/plans/2026-08-05-worker-image-platform-hardening.md
+++ b/docs/superpowers/plans/2026-08-05-worker-image-platform-hardening.md
@@ -96,6 +96,12 @@
 - [x] **步骤 5f：Nobody-ly 复审 3 项（2026-08-05 09:12，head fb9b9f6）**
   - **High dpkg configure 失败被版本门掩盖 → 已修**：最终 `dpkg --configure -a` 失败 `die`（不再 `|| true`）；版本断言前校验包状态 `dpkg-query -W -f='${db:Status-Abbrev}'` 必须 `ii`（install ok installed）。新增探针 8（configure 返回 43 + 版本达标 → `dpkg configuration did not complete`）与探针 9（status=`iU` → `not fully configured`）。
   - **High Cleanup 只发现不回收 → 已修**：`Invoke-ExactBakeCleanup` 改为"**可确权则删除、无法确权才报告**"——builder（唯一名 + `Assert-TemporaryBuilder`）、image（名字 + description + `sourceServerID` 与解析出的 builder 匹配）、key pair（唯一临时名）分别复用 `Remove-Builder`/`Remove-FailedImage`/`Remove-KeyPair`（含连续空读确认）；builder 无法解析时 image 无法证明归属 → 保持 fail-closed。测试更新：全资源场景 → `reconciled` 全删、source 不匹配场景 → builder/key 删 + image 报告、key-only 场景 → key 删。
+  - **子 agent 深度代码链路审查（08-06，纯静态，不跑测试）**：
+    - **Critical C1（已修）**：原实现先删 builder 再删 image——若 image 删除无法完成（不可删状态/失败/确认超时），builder 已删 → 下一轮 image 无法确权 → 镜像永久搁浅 + 计费泄漏。修复：**builder 移到 image 删除之后**（先解析拿 immutable ID → 删 image → 删 builder），与 finally 顺序一致，builder 全程作归属证据。
+    - **Important I1（已处理）**：最终 `dpkg --configure -a` die 与"postinst 失败 expected"注释矛盾——clean postinst 失败现在会阻断 bake（有意 fail-closed）。更新注释说明 + die 消息中性化（`dpkg database not fully configured`）；真实 base image 上的 postinst 行为留待合并后真实 bake 验证。
+    - **Important I2（记录为后续项）**：无 builder 时 image 无法回收（image 与 key pair 证明标准不一致）——修 C1 后此场景仅剩跨轮竞态；name+description 兜底确权涉及与 key pair 按名确权同类的争议，不强改，列入 Follow-ups。
+    - **Important I3（已修）**：key pair 查询原在 try/catch 外，API 错误/超时会破坏错误聚合——已包进 try 聚合。
+    - **Minor M1/M2/M3（已修）**：die 消息中性化、throw 附已回收清单（`reconciled`）、builder 先解析再发现镜像（避免镜像发现过期静默跳过）。
   - **High pending 按名删 key pair 证明不足 → 接受风险并说明**：唯一临时名 + bake marker 是当前最强可用证明；同名重建需同 bakeID 并发操作（被 pending 恢复流程排除），接受理论竞态并在 review 回复中说明。
 
 - [x] **步骤 6：npm mirror 预配置**

--- a/docs/superpowers/plans/2026-08-05-worker-image-platform-hardening.md
+++ b/docs/superpowers/plans/2026-08-05-worker-image-platform-hardening.md
@@ -61,6 +61,7 @@
   - **Medium pending 恢复保留 key pair → 已修**：`Complete-PendingPublishedImage` 置 `KeyPairCreateAttempted=$true`，靠 pending bake marker + key pair 唯一临时名证明归属后按名清理；两个 pending 恢复场景断言更新为删除 key pair（`keyExists=false`）。Cleanup 模式仍 fail-closed（不删）。
   - **测试证据补强（回应"测试不够充分"）**：新增**真实执行探针测试** `platform hardening fails closed and runs dpkg repair before apt`——隔离环境 mock `sha256sum/apt-get/dpkg/dpkg-query/systemctl/ls/uname/update-grub`（Git Bash + MSYS 路径 + wrapper + `CATSCO_PREPARE_SKIP_ROOT_CHECK` 钩子），六个探针：①systemd 升级失败+版本旧 → 非 0 退出含 `systemd upgrade failed to reach known-safe version`；②glibc 版本不达标 → 含 `glibc upgrade failed to reach known-safe version`（两个断言独立验证）；③全成功 → 首次 `dpkg --configure` 在 `apt-get update` 前且无任何加固错误；④kernel 升级失败 → `kernel upgrade failed`；⑤`update-grub` 失败 → `update-grub failed`；⑥`/boot/vmlinuz-*` 缺失 → `no bootable kernel image`。
   - **子代理全面核查（2026-08-05，独立复测）**：生产代码无 Critical/Important；发现并修复 2 个测试盲区——mock `dpkg` 计数器拆分 systemd/glibc 断言（避免 glibc 兜住 systemd 回归）、probe-3 mock `ls` 让 happy path 真跑通 + 补 kernel/grub/boot 三个失败探针（原来零行为覆盖）。全量 `npm test` **1383 tests / 0 fail**。
+  - **CI Linux 失败修复（2026-08-05，head 6dbada6）**：探针测试在 Linux runner 失败——wrapper `exec` 直接执行 `prepare-image.sh`，而 git 检出文件默认无 +x（Linux 严格执行 exec bit，Windows 忽略所以本地过了）。修复：wrapper 改 `exec bash <script>` + mock 命令 `chmod 755`。CI 重跑后应全绿。
 
 - [x] **步骤 6：npm mirror 预配置**
   - `/root/.npmrc`：`registry=https://registry.npmmirror.com`（root 侧，先写，无需依赖 useradd）

--- a/docs/superpowers/plans/2026-08-05-worker-image-platform-hardening.md
+++ b/docs/superpowers/plans/2026-08-05-worker-image-platform-hardening.md
@@ -1,0 +1,75 @@
+# Worker 镜像平台加固（2026-08）实现计划
+
+> **面向 AI 代理的工作者：** 必需子技能：使用 superpowers:subagent-driven-development（推荐）或 superpowers:executing-plans 逐任务实现此计划。步骤使用复选框（`- [ ]`）语法来跟踪进度。
+
+**目标：** 把 `deploy-catsco-linux-agent` 部署 skill 在 2026-08 踩过的平台故障固化进 `ops/ctyun-worker-image/prepare-image.sh`，让新 bake 的 worker 镜像自带免疫——新 worker 从镜像启动即健康，手动部署不再需要逐台升级 systemd/glibc、mask fwupd、修复 dpkg、配置 npm 镜像、更新 grub。
+
+**架构：** bake 时（临时 builder 上、制作镜像捕获磁盘状态前）执行一段「平台加固」：dpkg 完整性修复 → systemd+glibc 升级到已知安全组合（255.4-1ubuntu8.16 + 2.39-0ubuntu8.8）→ 内核升级 + `update-grub` → `systemctl mask fwupd` + `fwupd-refresh` → 预配置 China region npm 镜像。所有修复都是落盘持久化状态（升级后的包、`/etc/systemd/system` mask symlink、`.npmrc`），新实例首次启动即生效；bake 环境无需 reboot（镜像捕获的是磁盘，不是内存态 systemd）。
+
+**技术栈：** bash（`prepare-image.sh`，bake 时在 builder 上以 root 执行）、Node test runner + `tsx`（静态断言测试）、GitHub Actions（workflow 不变）。
+
+**关键事实（部署 skill 2026-08 已实测验证）：**
+- **systemd 8.15 + glibc 8.7 组合有 `_dl_fini` bug**：journal 出现 `Caught <ABRT>` → `Freezing execution.`，之后所有 `systemctl` 调用超时。5 台 worker 命中 4 台（worker1/worker2/ck-worker/yjz-work）；zh-work 预装 8.16 + 8.8 从未 freeze——证明升级到 8.16+8.8 即可免疫。
+- **systemd 8.16 上仍会因 fwupd 触发 ABRT（08-05）**：`fwupd.service` lifecycle 处理时 systemd 自身崩溃（`Caught <ABRT>, from our own process` → `Freezing execution.`）。解法：`systemctl mask fwupd.service` 且**必须同时 mask `fwupd-refresh.service`** 并 `reset-failed`，否则 refresh timer 下一次运行把主机打成 `degraded`。worker 服务器不需要固件更新守护进程。
+- **镜像可能携带损坏 dpkg file list**（"missing final newline"）：apt 直接中止，需 `printf '\n' >> /var/lib/dpkg/info/<pkg>.list` 修复。
+- **China region 直连 `registry.npmjs.org` 慢/截断损坏**（`node_modules/typescript/lib/lib.es2017.string.d.ts` 被截成 2378 字节 → `TS1127 Invalid character`）：必须用 `registry.npmmirror.com`。
+- **内核升级后不 `update-grub` 会仍启动旧内核**：装 `linux-generic` 后必须 `update-grub`（旧内核保留作回滚）。
+- **native modules（sharp/@napi-rs/canvas/deasync）**：`prepare-image.sh` 已有 native smoke，无需改动。
+- bake 环境升级 systemd 时 postinst 可能在运行中的旧 systemd 上失败（skill 记录为 "expected"）：容忍失败 + `dpkg --configure -a` 兜底 + 最小清单重试即可；镜像捕获磁盘新二进制，新实例用新版本。
+
+**文件结构：**
+- **修改：** `ops/ctyun-worker-image/prepare-image.sh` — 新增「平台加固」阶段（dpkg 修复 / systemd+glibc 升级 / 内核+grub / fwupd mask / npm mirror）+ systemd unit `NPM_CONFIG_REGISTRY`
+- **修改：** `tests/worker-image-pipeline.test.ts` — 新增静态断言 `platform hardening encodes known Tianyi worker faults`
+- **新增：** 本文档（方案/进度记录）
+
+**不做（运行时部署行为，镜像管不了）：** git fetch 超时、bundle 644 权限、`reboot -f` 清 /tmp、settle period、部署脚本本身——这些继续由 `deploy-catsco-linux-agent` skill 处理。
+
+---
+
+## 任务清单
+
+### 任务 1：`prepare-image.sh` 平台加固阶段
+
+插入位置：现有 `apt-get install` 基础包之后、`id catsco-agent` 之前。
+
+- [x] **步骤 1：dpkg 完整性修复**
+  循环检测 `/var/lib/dpkg/info/*.list` 尾部缺失换行的文件并补 `\n`；随后 `dpkg --configure -a` 兜底。
+
+- [x] **步骤 2：systemd + glibc 升级到 8.16 + 8.8**
+  用 skill 验证过的命令序列 `apt-get install --only-upgrade -y systemd systemd-sysv systemd-timesyncd systemd-dev libsystemd0 libsystemd-shared libpam-systemd libnss-systemd libc6 libc-bin libc6-dev libc-dev-bin openssh-*`；失败则 `dpkg --configure -a` + 最小清单（systemd/systemd-timesyncd/libsystemd0/libc6/libc-bin）重试，均容忍失败。
+
+- [x] **步骤 3：内核升级 + update-grub**
+  `apt-get install --only-upgrade -y linux-generic linux-image-generic`；存在 `update-grub` 则执行（失败容忍）。
+
+- [x] **步骤 4：mask fwupd + fwupd-refresh**
+  `systemctl mask/stop fwupd.service fwupd-refresh.service` + `systemctl reset-failed fwupd-refresh.service`，全部失败容忍。mask 是 `/etc/systemd/system` 下的持久 symlink，随镜像固化。
+
+- [x] **步骤 5：平台版本 echo（bake 日志审计）**
+  `platform_systemd=<ver> glibc=<ver> kernel=<uname -r>` 打到 bake 日志（被 ps1 捕获到 CI 输出，不落盘）。
+
+- [x] **步骤 6：npm mirror 预配置**
+  - `/root/.npmrc`：`registry=https://registry.npmmirror.com`（root 侧，先写，无需依赖 useradd）
+  - `/srv/catsco-agent/.npmrc`：同上 + `chown catsco-agent:catsco-agent`（在 `useradd` 之后写，目录已由 `--create-home` 创建）
+  - systemd unit 增加 `Environment=NPM_CONFIG_REGISTRY=https://registry.npmmirror.com`（双保险，不依赖用户目录）
+  - 确认 `.npmrc` 不在 `--finalize` 清理清单内（finalize 只清 `.env/.xiaoba/data/files/logs/skills` 等），随镜像保留。
+
+### 任务 2：测试断言
+
+- [x] **步骤 7：新增静态断言 test**（`tests/worker-image-pipeline.test.ts`）
+  `platform hardening encodes known Tianyi worker faults`：断言 fwupd mask / systemd+glibc 升级命令 / dpkg 修复 / update-grub / npm mirror（`.npmrc` + `NPM_CONFIG_REGISTRY`）/ 版本 echo。集成 fake 测试不执行真实 bash，与现有 `prepare-image.sh` 断言模式一致。
+
+### 任务 3：验证与提交
+
+- [ ] **步骤 8：`bash -n` + 单测 + build**
+  运行：`bash -n ops/ctyun-worker-image/prepare-image.sh` 与 `npx tsx --test tests/worker-image-pipeline.test.ts`（预期 10/10）；再 `npm run build` 确认无回归。
+
+- [ ] **步骤 9：Commit 并推送 fork**
+  在 `feat/ctyun-worker-image-pipeline` 分支：
+  ```bash
+  git add ops/ctyun-worker-image/prepare-image.sh tests/worker-image-pipeline.test.ts docs/superpowers/plans/2026-08-05-worker-image-platform-hardening.md
+  git commit -m "feat(worker): harden image bake against known Tianyi platform faults"
+  git push origin feat/ctyun-worker-image-pipeline
+  ```
+
+- [ ] **步骤 10：PR 等审核**
+  合并前需用户确认；真实 bake 验证在合并后的 workflow（`worker-image.yml`）执行。

--- a/docs/superpowers/plans/2026-08-05-worker-image-platform-hardening.md
+++ b/docs/superpowers/plans/2026-08-05-worker-image-platform-hardening.md
@@ -54,6 +54,13 @@
   - `systemctl daemon-reload` 加 `|| true`（freeze 场景下不再挂起中断 bake；unit 已落盘，新实例启动自动加载）。
   - 测试断言改为匹配实现而非注释（`od -An -c` / `printf '\n' >>`），并新增 `fwupd-refresh.timer` mask 断言。
 
+- [x] **步骤 5c：Nobody-ly 复核 4 项（2026-08-05 04:00，head 284662c）**
+  - **High 平台升级 fail-open → 已修**：systemd/glibc 升级最终失败不再静默——用 `dpkg --compare-versions` 做**最低版本断言**（systemd ≥ 255.4-1ubuntu8.16、glibc ≥ 2.39-0ubuntu8.8），不达标 `die`；kernel 升级、`update-grub` 失败也 `die`；`/boot/vmlinuz-*` 存在性检查。升级命令失败 → dpkg configure → 最小清单重试 → 版本断言裁决（postinst 失败 tolerated，版本达标即通过）。
+  - **Medium dpkg 修复顺序过晚 → 已修**：dpkg file-list 修复 + 首次 `dpkg --configure -a` **移到任何 apt/dpkg 事务之前**（`apt-get update` 前）。
+  - **High cleanup 不删除已发现资源 → 保持 fail-closed（用户决策）**：`Invoke-ExactBakeCleanup` 无 immutable ID 证明时抛错不删，避免误删；在 review 回复中说明这是有意的 fail-closed 权衡（rerun/reconcile 回收）。
+  - **Medium pending 恢复保留 key pair → 已修**：`Complete-PendingPublishedImage` 置 `KeyPairCreateAttempted=$true`，靠 pending bake marker + key pair 唯一临时名证明归属后按名清理；两个 pending 恢复场景断言更新为删除 key pair（`keyExists=false`）。Cleanup 模式仍 fail-closed（不删）。
+  - **测试证据补强（回应"测试不够充分"）**：新增**真实执行探针测试** `platform hardening fails closed and runs dpkg repair before apt`——隔离环境 mock `sha256sum/apt-get/dpkg/dpkg-query/systemctl/uname/update-grub`（Git Bash + MSYS 路径 + wrapper + `CATSCO_PREPARE_SKIP_ROOT_CHECK` 钩子），三个探针：①升级命令固定失败+版本旧 → 脚本非 0 退出含 `known-safe version`；②apt 成功但版本旧 → 非 0 退出；③全成功 → 首次 `dpkg --configure` 在 `apt-get update` 之前。验证 `bash -n` + 11/11 测试 + build 通过。
+
 - [x] **步骤 6：npm mirror 预配置**
   - `/root/.npmrc`：`registry=https://registry.npmmirror.com`（root 侧，先写，无需依赖 useradd）
   - `/srv/catsco-agent/.npmrc`：同上 + `chown catsco-agent:catsco-agent`（在 `useradd` 之后写，目录已由 `--create-home` 创建）

--- a/docs/superpowers/plans/2026-08-05-worker-image-platform-hardening.md
+++ b/docs/superpowers/plans/2026-08-05-worker-image-platform-hardening.md
@@ -6,7 +6,7 @@
 
 - **分支/head：** `feat/ctyun-worker-image-pipeline` @ `5c83dc8`（已 rebase 到 `upstream/main` `dc22252` 之上，相对 main 22 commits）
 - **CI：** 最新一次全绿（Build and runtime tests + cross-repo smoke）
-- **Review：** 已完成 5 轮处理并回复（自查 / c3811yyds / Nobody-ly 4 项 / atridaisuki 4 项 / 子 agent 独立审核），当前**等复审**；合并前需用户确认
+- **Review：** 已完成 6 轮处理并回复（自查 / c3811yyds / Nobody-ly 4 项 / atridaisuki 4 项 / 子 agent 独立审核 / Nobody-ly 复审 fc49cc0 3 项），当前**等复审**；合并前需用户确认
 - **测试：** `worker-image-pipeline.test.ts` 11/11、加固探针 7 场景、全量 `npm test`（唯一失败为已知 pre-existing flaky `logger.test.ts`，与改动无关）、`npm run build` 通过
 - **下一步：** reviewer 复审 → 合并 → workflow 真实 bake 验证（见步骤 10 验收标准）
 - **关联计划：** 应用制品更新 Part A 见 `2026-08-04-worker-artifact-update.md`（worker 更新通道与镜像烘焙并存，互为回退）
@@ -105,6 +105,12 @@
   - **外部审核报告 H1（2026-08-06，Saturday 的 PDF 报告 head 9a642e4）→ 已修**：C1 修复只调整了顺序、没落实条件门控——`Remove-FailedImage` 失败（DeleteImage API 失败 / 状态不可删 / 确认超时）时 `PreserveBuilderForImageRecovery` 保持 true，但 `Invoke-ExactBakeCleanup` catch 后仍无条件删 builder → 镜像失去 sourceServerID 证据永久搁浅。修复：builder 删除阶段复用 `PreserveBuilderForImageRecovery` 门控（true 时 deferred 并聚合错误），与 in-process finally 一致。
   - **H1 回归测试（按报告 5.1 补）**：fake 支持 `deleteImageFails`（DeleteImage 返回 API 错误）与 `deleteImageSticky`（删除后镜像不消失）——场景 A（DeleteImage 失败 → 镜像+builder 保留、`builder cleanup deferred`）、场景 B（确认超时 → builder 保留）、场景 C（source 不匹配 → 删 builder/key、镜像报告，已有）、场景 D（删除顺序 DeleteImage 先于 DeleteEcsInstance + 全空）。ps1 新增 `-ImageDeleteConfirmMinutes`（默认 8）供场景 B 缩短确认窗口。
   - **High pending 按名删 key pair 证明不足 → 接受风险并说明**：唯一临时名 + bake marker 是当前最强可用证明；同名重建需同 bakeID 并发操作（被 pending 恢复流程排除），接受理论竞态并在 review 回复中说明。
+
+- [x] **步骤 5g：Nobody-ly 复审 3 项（2026-08-06 04:10，head fc49cc0）**
+  - **High 健康 dpkg 状态被误判未配置 → 已修**：真实 `dpkg-query -f='${db:Status-Abbrev}'` 对健康包返回 `ii `（**末尾带空格**），shell 命令替换不去空格 → 旧严格比较 `"ii"` 会把所有正常 bake 判为未配置而拒绝。修复：比较前空白归一化 `${SYSTEMD_STATUS//[[:space:]]/}`（bash 参数扩展字符类）。新增探针 10：mock 返回 `"ii "`（带尾空格）→ 脚本越过 status 门（stdout 出现 `platform_systemd=...`）、stderr 不含 `not fully configured`。
+  - **High Cleanup 初始查询异常短路后续清理 → 已修**：`Invoke-ExactBakeCleanup` 的 builder/image discovery 原在 errors 聚合初始化和 try/catch 之前，任一 API 查询异常直接退出、跳过 key pair 清理。修复：先初始化 `$errors`/`$reconciled`，builder/image/key-pair discovery 各自独立 try/catch，异常聚合进 `$errors` 且不跳过其它资源补偿。
+  - **Medium/High Cleanup 初始发现接受单次空响应 → 已修**：builder 的 `Resolve-BuilderInstance`、image 非 late 分支、key pair `GetEcsKeypairDetails` 初始查询都可能一次空响应即停 → 瞬时最终一致性空响应造成 `nothing-to-clean` 漏报。修复：初始发现也采用 bounded 连续空读（builder 3 次×5s、image 3 次×10s、key 3 次×5s，非 late 截止；late 分支沿用 discoveryDeadline）。
+  - **5g 回归测试**：fake 新增单次 discovery API 失败注入（`listInstancesFailures`，仅当次调用 900、后续正常）——场景 1015（builder discovery 报错 → key pair 仍被回收、错误聚合抛出 `builder discovery`）；场景 1013（key-only + `keyHiddenReads:2` → discovery 连续空读后第 3 读可见 → 删除 key，断言 `GetEcsKeypairDetails ≥ 3`）；场景 1014（builder-only + `instanceHiddenReads:2` → discovery 连续空读后可见 → 删除 builder，断言 `ListEcsInstances ≥ 3`）。探针 1-10 + 集成 11/11 全过、`npm run build` 通过。
 
 - [x] **步骤 6：npm mirror 预配置**
   - `/root/.npmrc`：`registry=https://registry.npmmirror.com`（root 侧，先写，无需依赖 useradd）

--- a/docs/superpowers/plans/2026-08-05-worker-image-platform-hardening.md
+++ b/docs/superpowers/plans/2026-08-05-worker-image-platform-hardening.md
@@ -47,6 +47,13 @@
 - [x] **步骤 5：平台版本 echo（bake 日志审计）**
   `platform_systemd=<ver> glibc=<ver> kernel=<uname -r>` 打到 bake 日志（被 ps1 捕获到 CI 输出，不落盘）。
 
+- [x] **步骤 5b：review 修复（2026-08-05，requesting-code-review 自查）**
+  - fwupd mask 段**前置到 systemd 升级之前**：mask 是落盘 symlink 不依赖版本；若 systemd 升级 postinst 把 daemon re-exec 到 8.16，先 mask 可保证 8.16 daemon 无需处理 fwupd lifecycle（避免 ABRT freeze 路径）。
+  - 额外 `systemctl mask fwupd-refresh.timer`（防止 timer 周期性触发已 mask 的 service 留下 failed 记录）。
+  - `/srv/catsco-agent/.npmrc` 写入前加 `mkdir -p /srv/catsco-agent`（防御 base 镜像预建用户而 home 缺失时 `set -e` 中断 bake）。
+  - `systemctl daemon-reload` 加 `|| true`（freeze 场景下不再挂起中断 bake；unit 已落盘，新实例启动自动加载）。
+  - 测试断言改为匹配实现而非注释（`od -An -c` / `printf '\n' >>`），并新增 `fwupd-refresh.timer` mask 断言。
+
 - [x] **步骤 6：npm mirror 预配置**
   - `/root/.npmrc`：`registry=https://registry.npmmirror.com`（root 侧，先写，无需依赖 useradd）
   - `/srv/catsco-agent/.npmrc`：同上 + `chown catsco-agent:catsco-agent`（在 `useradd` 之后写，目录已由 `--create-home` 创建）
@@ -61,7 +68,7 @@
 ### 任务 3：验证与提交
 
 - [x] **步骤 8：`bash -n` + 单测 + build**
-  运行：`bash -n ops/ctyun-worker-image/prepare-image.sh`（通过）、`npx tsx --test tests/worker-image-pipeline.test.ts`（10/10 通过）、`npm run build`（通过，无回归）。
+  运行：`bash -n ops/ctyun-worker-image/prepare-image.sh`（通过）、`npx tsx --test tests/worker-image-pipeline.test.ts`（10/10 通过，含 review 修复后的断言）、`npm run build`（通过，无回归）。
 
 - [x] **步骤 9：Commit 并推送 fork**
   在 `feat/ctyun-worker-image-pipeline` 分支：

--- a/docs/superpowers/plans/2026-08-05-worker-image-platform-hardening.md
+++ b/docs/superpowers/plans/2026-08-05-worker-image-platform-hardening.md
@@ -93,6 +93,11 @@
   - 补测（Minor #4a）：新增 **key-pair-only Cleanup 场景**（进程在 `ImportEcsKeypair` 后被 kill、只剩 key pair）——断言 `Automatic historical cleanup refused` + `candidate keyPairName=...` 且不删除。消除修复③无直接测试覆盖的盲区。
   - 记录的后续项：发现阶段 3 次空读无直接场景覆盖（防御性逻辑，确认阶段已有覆盖）；`/boot` 校验的 `NEWEST_KERNEL_IMG` 变量为死代码（非空性已被前置 `ls` 保证）。
 
+- [x] **步骤 5f：Nobody-ly 复审 3 项（2026-08-05 09:12，head fb9b9f6）**
+  - **High dpkg configure 失败被版本门掩盖 → 已修**：最终 `dpkg --configure -a` 失败 `die`（不再 `|| true`）；版本断言前校验包状态 `dpkg-query -W -f='${db:Status-Abbrev}'` 必须 `ii`（install ok installed）。新增探针 8（configure 返回 43 + 版本达标 → `dpkg configuration did not complete`）与探针 9（status=`iU` → `not fully configured`）。
+  - **High Cleanup 只发现不回收 → 用户决策：实现按 immutable ID 删**（进行中，替代纯 fail-closed；见实现方案）。
+  - **High pending 按名删 key pair 证明不足 → 接受风险并说明**：唯一临时名 + bake marker 是当前最强可用证明；同名重建需同 bakeID 并发操作（被 pending 恢复流程排除），接受理论竞态并在 review 回复中说明。
+
 - [x] **步骤 6：npm mirror 预配置**
   - `/root/.npmrc`：`registry=https://registry.npmmirror.com`（root 侧，先写，无需依赖 useradd）
   - `/srv/catsco-agent/.npmrc`：同上 + `chown catsco-agent:catsco-agent`（在 `useradd` 之后写，目录已由 `--create-home` 创建）

--- a/docs/superpowers/plans/2026-08-05-worker-image-platform-hardening.md
+++ b/docs/superpowers/plans/2026-08-05-worker-image-platform-hardening.md
@@ -59,7 +59,8 @@
   - **Medium dpkg 修复顺序过晚 → 已修**：dpkg file-list 修复 + 首次 `dpkg --configure -a` **移到任何 apt/dpkg 事务之前**（`apt-get update` 前）。
   - **High cleanup 不删除已发现资源 → 保持 fail-closed（用户决策）**：`Invoke-ExactBakeCleanup` 无 immutable ID 证明时抛错不删，避免误删；在 review 回复中说明这是有意的 fail-closed 权衡（rerun/reconcile 回收）。
   - **Medium pending 恢复保留 key pair → 已修**：`Complete-PendingPublishedImage` 置 `KeyPairCreateAttempted=$true`，靠 pending bake marker + key pair 唯一临时名证明归属后按名清理；两个 pending 恢复场景断言更新为删除 key pair（`keyExists=false`）。Cleanup 模式仍 fail-closed（不删）。
-  - **测试证据补强（回应"测试不够充分"）**：新增**真实执行探针测试** `platform hardening fails closed and runs dpkg repair before apt`——隔离环境 mock `sha256sum/apt-get/dpkg/dpkg-query/systemctl/uname/update-grub`（Git Bash + MSYS 路径 + wrapper + `CATSCO_PREPARE_SKIP_ROOT_CHECK` 钩子），三个探针：①升级命令固定失败+版本旧 → 脚本非 0 退出含 `known-safe version`；②apt 成功但版本旧 → 非 0 退出；③全成功 → 首次 `dpkg --configure` 在 `apt-get update` 之前。验证 `bash -n` + 11/11 测试 + build 通过。
+  - **测试证据补强（回应"测试不够充分"）**：新增**真实执行探针测试** `platform hardening fails closed and runs dpkg repair before apt`——隔离环境 mock `sha256sum/apt-get/dpkg/dpkg-query/systemctl/ls/uname/update-grub`（Git Bash + MSYS 路径 + wrapper + `CATSCO_PREPARE_SKIP_ROOT_CHECK` 钩子），六个探针：①systemd 升级失败+版本旧 → 非 0 退出含 `systemd upgrade failed to reach known-safe version`；②glibc 版本不达标 → 含 `glibc upgrade failed to reach known-safe version`（两个断言独立验证）；③全成功 → 首次 `dpkg --configure` 在 `apt-get update` 前且无任何加固错误；④kernel 升级失败 → `kernel upgrade failed`；⑤`update-grub` 失败 → `update-grub failed`；⑥`/boot/vmlinuz-*` 缺失 → `no bootable kernel image`。
+  - **子代理全面核查（2026-08-05，独立复测）**：生产代码无 Critical/Important；发现并修复 2 个测试盲区——mock `dpkg` 计数器拆分 systemd/glibc 断言（避免 glibc 兜住 systemd 回归）、probe-3 mock `ls` 让 happy path 真跑通 + 补 kernel/grub/boot 三个失败探针（原来零行为覆盖）。全量 `npm test` **1383 tests / 0 fail**。
 
 - [x] **步骤 6：npm mirror 预配置**
   - `/root/.npmrc`：`registry=https://registry.npmmirror.com`（root 侧，先写，无需依赖 useradd）

--- a/docs/superpowers/plans/2026-08-05-worker-image-platform-hardening.md
+++ b/docs/superpowers/plans/2026-08-05-worker-image-platform-hardening.md
@@ -2,9 +2,18 @@
 
 > **面向 AI 代理的工作者：** 必需子技能：使用 superpowers:subagent-driven-development（推荐）或 superpowers:executing-plans 逐任务实现此计划。步骤使用复选框（`- [ ]`）语法来跟踪进度。
 
+## 当前状态（2026-08-05）
+
+- **分支/head：** `feat/ctyun-worker-image-pipeline` @ `5c83dc8`（已 rebase 到 `upstream/main` `dc22252` 之上，相对 main 22 commits）
+- **CI：** 最新一次全绿（Build and runtime tests + cross-repo smoke）
+- **Review：** 已完成 5 轮处理并回复（自查 / c3811yyds / Nobody-ly 4 项 / atridaisuki 4 项 / 子 agent 独立审核），当前**等复审**；合并前需用户确认
+- **测试：** `worker-image-pipeline.test.ts` 11/11、加固探针 7 场景、全量 `npm test`（唯一失败为已知 pre-existing flaky `logger.test.ts`，与改动无关）、`npm run build` 通过
+- **下一步：** reviewer 复审 → 合并 → workflow 真实 bake 验证（见步骤 10 验收标准）
+- **关联计划：** 应用制品更新 Part A 见 `2026-08-04-worker-artifact-update.md`（worker 更新通道与镜像烘焙并存，互为回退）
+
 **目标：** 把 `deploy-catsco-linux-agent` 部署 skill 在 2026-08 踩过的平台故障固化进 `ops/ctyun-worker-image/prepare-image.sh`，让新 bake 的 worker 镜像自带免疫——新 worker 从镜像启动即健康，手动部署不再需要逐台升级 systemd/glibc、mask fwupd、修复 dpkg、配置 npm 镜像、更新 grub。
 
-**架构：** bake 时（临时 builder 上、制作镜像捕获磁盘状态前）执行一段「平台加固」：dpkg 完整性修复 → systemd+glibc 升级到已知安全组合（255.4-1ubuntu8.16 + 2.39-0ubuntu8.8）→ 内核升级 + `update-grub` → `systemctl mask fwupd` + `fwupd-refresh` → 预配置 China region npm 镜像。所有修复都是落盘持久化状态（升级后的包、`/etc/systemd/system` mask symlink、`.npmrc`），新实例首次启动即生效；bake 环境无需 reboot（镜像捕获的是磁盘，不是内存态 systemd）。
+**架构：** bake 时（临时 builder 上、制作镜像捕获磁盘状态前）执行一段「平台加固」，**最终形态（含 4 轮 review 演进）**：dpkg 完整性修复（**前置到任何 apt 事务之前**）→ `mask_unit()` 验证 fwupd + fwupd-refresh + timer 的持久 symlink（失败 `die`）→ systemd+glibc 升级到已知安全组合（255.4-1ubuntu8.16 + 2.39-0ubuntu8.8）并做**最低版本断言**（不达标 `die`）→ 内核**安装**（非 only-upgrade）+ `update-grub` + `/boot` 最新 vmlinuz 校验 → 预配置 China region npm 镜像（`/root` + 服务用户 `.npmrc` + unit `NPM_CONFIG_REGISTRY`）。所有修复都是落盘持久化状态，新实例首次启动即生效；bake 环境无需 reboot（镜像捕获的是磁盘，不是内存态 systemd）。**fail-closed 原则**：任何无法达到已知安全平台状态的升级/掩码必须阻断 bake——产出坏镜像比 workflow 失败重试更糟。清理侧：builder/key pair 删除要求连续空读证明（发现 3 次、确认 2 次），Cleanup 模式保持 fail-closed（可证明归属才删）。
 
 **技术栈：** bash（`prepare-image.sh`，bake 时在 builder 上以 root 执行）、Node test runner + `tsx`（静态断言测试）、GitHub Actions（workflow 不变）。
 
@@ -23,6 +32,14 @@
 - **新增：** 本文档（方案/进度记录）
 
 **不做（运行时部署行为，镜像管不了）：** git fetch 超时、bundle 644 权限、`reboot -f` 清 /tmp、settle period、部署脚本本身——这些继续由 `deploy-catsco-linux-agent` skill 处理。
+
+## 后续改进项（Follow-ups，不阻塞合入）
+
+- **发现阶段 3 次空读无直接测试场景**：Remove-Builder/Remove-KeyPair 的连续空读发现逻辑只在确认阶段有测试覆盖；构造"builder ID 存在但查询为空"场景成本高，防御性逻辑，后续补。
+- **`/boot` 校验的 `NEWEST_KERNEL_IMG` 变量是死代码**：非空性已被前置 `ls -1 /boot/vmlinuz-*` 保证，可删除或改为与升级前内核版本做真实比较。
+- **`Invoke-ExactBakeCleanup` key pair 单次读**与 Remove-* 的 3 次空读不对称（最终一致性风险低，因 Cleanup 运行在中断后较久），后续可对齐。
+- **Cleanup 长期 fail-closed 的计费残留**（用户决策保持）：可后续做"持久化 immutable 资源 ID 后安全按 ID 删除"，替代纯 fail-closed。
+- **探针测试硬编码 Git Bash 路径**：无 Git Bash 的 Windows 环境会以难懂错误失败（Linux/macOS 回退 `bash` 正常），后续可探测更稳。
 
 ---
 
@@ -100,5 +117,13 @@
   git push origin feat/ctyun-worker-image-pipeline
   ```
 
-- [ ] **步骤 10：PR 等审核**
-  合并前需用户确认；真实 bake 验证在合并后的 workflow（`worker-image.yml`）执行。
+- [ ] **步骤 10：PR 等审核 + 真实 bake 验收**
+  合并前需用户确认。合并后触发 `worker-image.yml`（手动 `workflow_dispatch` 勾选 `bake_image` 或打 `vX.Y.Z` tag 且 `CTYUN_AUTO_BAKE_WORKER_IMAGE=true`）。
+
+  **验收标准（bake 日志 + 新 worker 实例）：**
+  1. bake 日志出现 `platform_systemd=255.4-1ubuntu8.16+ glibc=2.39-0ubuntu8.8+ kernel=...` 且最终 `image_prepared=yes`（任一版本不达标 bake 会失败）
+  2. 从镜像开一台临时 worker 验证：`readlink /etc/systemd/system/fwupd.service` = `/dev/null`（fwupd/refresh/timer 均 masked）、`systemctl is-system-running` = `running`（无 freeze）
+  3. `/srv/catsco-agent/.npmrc` 与 `/root/.npmrc` 存在且含 `registry.npmmirror.com`；`systemctl cat catsco-agent.service` 含 `NPM_CONFIG_REGISTRY`
+  4. `/etc/catsco-image-packages.txt` 记录 systemd/glibc/kernel 版本；`/boot/vmlinuz-*` 存在最新内核
+  5. 镜像内 `catsco-agent.service` 为 disabled（首次供给由控制面启用）；无临时 key pair/builder 残留（`ecs GetEcsKeypairDetails` 查询 `catsco-img-key-*` 为空）
+  6. 确认后删除验证用临时实例，避免计费残留

--- a/docs/superpowers/plans/2026-08-05-worker-image-platform-hardening.md
+++ b/docs/superpowers/plans/2026-08-05-worker-image-platform-hardening.md
@@ -60,10 +60,10 @@
 
 ### 任务 3：验证与提交
 
-- [ ] **步骤 8：`bash -n` + 单测 + build**
-  运行：`bash -n ops/ctyun-worker-image/prepare-image.sh` 与 `npx tsx --test tests/worker-image-pipeline.test.ts`（预期 10/10）；再 `npm run build` 确认无回归。
+- [x] **步骤 8：`bash -n` + 单测 + build**
+  运行：`bash -n ops/ctyun-worker-image/prepare-image.sh`（通过）、`npx tsx --test tests/worker-image-pipeline.test.ts`（10/10 通过）、`npm run build`（通过，无回归）。
 
-- [ ] **步骤 9：Commit 并推送 fork**
+- [x] **步骤 9：Commit 并推送 fork**
   在 `feat/ctyun-worker-image-pipeline` 分支：
   ```bash
   git add ops/ctyun-worker-image/prepare-image.sh tests/worker-image-pipeline.test.ts docs/superpowers/plans/2026-08-05-worker-image-platform-hardening.md

--- a/docs/superpowers/plans/2026-08-05-worker-image-platform-hardening.md
+++ b/docs/superpowers/plans/2026-08-05-worker-image-platform-hardening.md
@@ -95,7 +95,7 @@
 
 - [x] **步骤 5f：Nobody-ly 复审 3 项（2026-08-05 09:12，head fb9b9f6）**
   - **High dpkg configure 失败被版本门掩盖 → 已修**：最终 `dpkg --configure -a` 失败 `die`（不再 `|| true`）；版本断言前校验包状态 `dpkg-query -W -f='${db:Status-Abbrev}'` 必须 `ii`（install ok installed）。新增探针 8（configure 返回 43 + 版本达标 → `dpkg configuration did not complete`）与探针 9（status=`iU` → `not fully configured`）。
-  - **High Cleanup 只发现不回收 → 用户决策：实现按 immutable ID 删**（进行中，替代纯 fail-closed；见实现方案）。
+  - **High Cleanup 只发现不回收 → 已修**：`Invoke-ExactBakeCleanup` 改为"**可确权则删除、无法确权才报告**"——builder（唯一名 + `Assert-TemporaryBuilder`）、image（名字 + description + `sourceServerID` 与解析出的 builder 匹配）、key pair（唯一临时名）分别复用 `Remove-Builder`/`Remove-FailedImage`/`Remove-KeyPair`（含连续空读确认）；builder 无法解析时 image 无法证明归属 → 保持 fail-closed。测试更新：全资源场景 → `reconciled` 全删、source 不匹配场景 → builder/key 删 + image 报告、key-only 场景 → key 删。
   - **High pending 按名删 key pair 证明不足 → 接受风险并说明**：唯一临时名 + bake marker 是当前最强可用证明；同名重建需同 bakeID 并发操作（被 pending 恢复流程排除），接受理论竞态并在 review 回复中说明。
 
 - [x] **步骤 6：npm mirror 预配置**

--- a/docs/superpowers/plans/2026-08-05-worker-image-platform-hardening.md
+++ b/docs/superpowers/plans/2026-08-05-worker-image-platform-hardening.md
@@ -102,6 +102,8 @@
     - **Important I2（记录为后续项）**：无 builder 时 image 无法回收（image 与 key pair 证明标准不一致）——修 C1 后此场景仅剩跨轮竞态；name+description 兜底确权涉及与 key pair 按名确权同类的争议，不强改，列入 Follow-ups。
     - **Important I3（已修）**：key pair 查询原在 try/catch 外，API 错误/超时会破坏错误聚合——已包进 try 聚合。
     - **Minor M1/M2/M3（已修）**：die 消息中性化、throw 附已回收清单（`reconciled`）、builder 先解析再发现镜像（避免镜像发现过期静默跳过）。
+  - **外部审核报告 H1（2026-08-06，Saturday 的 PDF 报告 head 9a642e4）→ 已修**：C1 修复只调整了顺序、没落实条件门控——`Remove-FailedImage` 失败（DeleteImage API 失败 / 状态不可删 / 确认超时）时 `PreserveBuilderForImageRecovery` 保持 true，但 `Invoke-ExactBakeCleanup` catch 后仍无条件删 builder → 镜像失去 sourceServerID 证据永久搁浅。修复：builder 删除阶段复用 `PreserveBuilderForImageRecovery` 门控（true 时 deferred 并聚合错误），与 in-process finally 一致。
+  - **H1 回归测试（按报告 5.1 补）**：fake 支持 `deleteImageFails`（DeleteImage 返回 API 错误）与 `deleteImageSticky`（删除后镜像不消失）——场景 A（DeleteImage 失败 → 镜像+builder 保留、`builder cleanup deferred`）、场景 B（确认超时 → builder 保留）、场景 C（source 不匹配 → 删 builder/key、镜像报告，已有）、场景 D（删除顺序 DeleteImage 先于 DeleteEcsInstance + 全空）。ps1 新增 `-ImageDeleteConfirmMinutes`（默认 8）供场景 B 缩短确认窗口。
   - **High pending 按名删 key pair 证明不足 → 接受风险并说明**：唯一临时名 + bake marker 是当前最强可用证明；同名重建需同 bakeID 并发操作（被 pending 恢复流程排除），接受理论竞态并在 review 回复中说明。
 
 - [x] **步骤 6：npm mirror 预配置**

--- a/docs/superpowers/plans/2026-08-05-worker-image-platform-hardening.md
+++ b/docs/superpowers/plans/2026-08-05-worker-image-platform-hardening.md
@@ -63,6 +63,13 @@
   - **子代理全面核查（2026-08-05，独立复测）**：生产代码无 Critical/Important；发现并修复 2 个测试盲区——mock `dpkg` 计数器拆分 systemd/glibc 断言（避免 glibc 兜住 systemd 回归）、probe-3 mock `ls` 让 happy path 真跑通 + 补 kernel/grub/boot 三个失败探针（原来零行为覆盖）。全量 `npm test` **1383 tests / 0 fail**。
   - **CI Linux 失败修复（2026-08-05，head 6dbada6）**：探针测试在 Linux runner 失败——wrapper `exec` 直接执行 `prepare-image.sh`，而 git 检出文件默认无 +x（Linux 严格执行 exec bit，Windows 忽略所以本地过了）。修复：wrapper 改 `exec bash <script>` + mock 命令 `chmod 755`。CI 重跑后应全绿。
 
+- [x] **步骤 5d：atridaisuki 复核 4 项（2026-08-05 06:23，CHANGES_REQUESTED）**
+  - **P1 fwupd mask 失败被吞 → 已修**：`mask_unit()` 用 `timeout 30` 包裹 `systemctl mask`（冻结 manager 不再挂起 bake），并**通过持久 symlink 验证**（`readlink /etc/systemd/system/<unit>` 必须指向 `/dev/null`），失败 `die` 拒绝发布未加固镜像。新增探针 7（readlink 返回空 → `failed to mask`）。
+  - **P1 内核升级成功假象 → 已修**：`--only-upgrade` 改为 `apt-get install -y`（元包缺失时会真正安装而非 `Skipping` 返回 0）；`/boot` 校验改为"最新 vmlinuz 存在 + 显式 `ls` 检查"（防止旧内核通过）。
+  - **P2 Cleanup 漏检只剩 key pair → 已修**：`Invoke-ExactBakeCleanup` 现在按精确 `KeyPairName` 查询 key pair，存在则计入 fail-closed 报告（不再 `nothing-to-clean` 静默漏检）。
+  - **P2 单次空响应不能证明删除 → 已修**：`Remove-Builder`/`Remove-KeyPair` 发现阶段要求**连续 3 次空读**才认为资源不存在（非 WaitForLate），删除确认阶段要求**连续 2 次空读**才返回成功（最终一致性防护）。
+  - 验证：7 个探针全过、`worker-image-pipeline.test.ts` **11/11 通过**（集成测试 timeout 提到 120s 容纳新增等待）、build 通过。中途遇到本地 `node_modules` 不完整（切分支后 `.bin` 空 + 缺包），`npm ci` 恢复后复测通过。
+
 - [x] **步骤 6：npm mirror 预配置**
   - `/root/.npmrc`：`registry=https://registry.npmmirror.com`（root 侧，先写，无需依赖 useradd）
   - `/srv/catsco-agent/.npmrc`：同上 + `chown catsco-agent:catsco-agent`（在 `useradd` 之后写，目录已由 `--create-home` 创建）

--- a/docs/superpowers/plans/2026-08-05-worker-image-platform-hardening.md
+++ b/docs/superpowers/plans/2026-08-05-worker-image-platform-hardening.md
@@ -70,6 +70,12 @@
   - **P2 单次空响应不能证明删除 → 已修**：`Remove-Builder`/`Remove-KeyPair` 发现阶段要求**连续 3 次空读**才认为资源不存在（非 WaitForLate），删除确认阶段要求**连续 2 次空读**才返回成功（最终一致性防护）。
   - 验证：7 个探针全过、`worker-image-pipeline.test.ts` **11/11 通过**（集成测试 timeout 提到 120s 容纳新增等待）、build 通过。中途遇到本地 `node_modules` 不完整（切分支后 `.bin` 空 + 缺包），`npm ci` 恢复后复测通过。
 
+- [x] **步骤 5e：复测 + 子 agent 独立审核（2026-08-05）**
+  - 全量 `npm test`：唯一失败为**已知 pre-existing flaky** `logger.test.ts`（单独跑 1/1 通过，与 #290/#291 同源，与本次改动无关）。
+  - 子 agent 独立审核 `d5cd34e`：**可合入**，无 Critical/Important。突变验证确认 probe 7（mask）与 kernel 静态断言真实覆盖回归；`mask_unit` timeout+readlink 设计（冻结 manager 不挂起、持久 symlink 校验独立于运行中 manager）与连续空读终止性均验证无误。
+  - 补测（Minor #4a）：新增 **key-pair-only Cleanup 场景**（进程在 `ImportEcsKeypair` 后被 kill、只剩 key pair）——断言 `Automatic historical cleanup refused` + `candidate keyPairName=...` 且不删除。消除修复③无直接测试覆盖的盲区。
+  - 记录的后续项：发现阶段 3 次空读无直接场景覆盖（防御性逻辑，确认阶段已有覆盖）；`/boot` 校验的 `NEWEST_KERNEL_IMG` 变量为死代码（非空性已被前置 `ls` 保证）。
+
 - [x] **步骤 6：npm mirror 预配置**
   - `/root/.npmrc`：`registry=https://registry.npmmirror.com`（root 侧，先写，无需依赖 useradd）
   - `/srv/catsco-agent/.npmrc`：同上 + `chown catsco-agent:catsco-agent`（在 `useradd` 之后写，目录已由 `--create-home` 创建）

--- a/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
+++ b/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
@@ -560,6 +560,18 @@ function Remove-Builder {
 
     $resolveWaitSeconds = if ($WaitForLate) { $LateResourceWaitSeconds } else { 0 }
     $instance = Resolve-BuilderInstance -WaitSeconds $resolveWaitSeconds
+    if (-not $instance -and -not $WaitForLate) {
+        # A single empty read can be an eventually-consistent response. Require
+        # several consecutive empty reads before concluding the builder is gone,
+        # otherwise a billed ECS could be left behind after the image is ready.
+        $emptyReads = 1
+        while ($emptyReads -lt 3) {
+            Start-Sleep -Seconds 5
+            $instance = Resolve-BuilderInstance
+            if ($instance) { break }
+            $emptyReads++
+        }
+    }
     if (-not $instance) {
         Write-Host "No temporary builder record remains for $script:BuilderName"
         return
@@ -578,12 +590,18 @@ function Remove-Builder {
     $deadline = Get-BoundedDeadline `
         -RequestedSeconds (8 * 60) `
         -Phase "temporary builder deletion confirmation"
+    $confirmEmptyReads = 0
     while ((Get-Date) -lt $deadline) {
         $remaining = Resolve-BuilderInstance
         if (-not $remaining) {
-            return
+            $confirmEmptyReads++
+            if ($confirmEmptyReads -ge 2) {
+                return
+            }
+        } else {
+            $confirmEmptyReads = 0
+            Assert-TemporaryBuilder $remaining
         }
-        Assert-TemporaryBuilder $remaining
         Start-Sleep -Seconds 8
     }
     throw "Could not confirm deletion of temporary builder $script:BuilderID"
@@ -606,6 +624,7 @@ function Remove-KeyPair {
         -RequestedSeconds $keyDiscoverySeconds `
         -Phase "temporary key pair discovery"
     $existing = @()
+    $emptyReads = 0
     do {
         $details = Invoke-Ctyun @(
             "ecs", "GetEcsKeypairDetails",
@@ -619,11 +638,18 @@ function Remove-KeyPair {
             @(Get-ResponseItems -Response $details -Name "results") |
                 Where-Object { [string]$_.keyPairName -eq $script:KeyPairName }
         )
-        if ($existing.Count -gt 0 -or -not $WaitForLate) {
+        if ($existing.Count -gt 0) {
+            break
+        }
+        $emptyReads++
+        if (-not $WaitForLate -and $emptyReads -ge 3) {
+            break
+        }
+        if ($WaitForLate -and (Get-Date) -ge $keyDiscoveryDeadline) {
             break
         }
         Start-Sleep -Seconds 5
-    } while ((Get-Date) -lt $keyDiscoveryDeadline)
+    } while ($true)
     if ($existing.Count -eq 0) {
         Write-Host "No temporary key pair record remains for $script:KeyPairName"
         return
@@ -656,6 +682,7 @@ function Remove-KeyPair {
     $deadline = Get-BoundedDeadline `
         -RequestedSeconds (2 * 60) `
         -Phase "temporary key pair deletion confirmation"
+    $confirmEmptyReads = 0
     while ((Get-Date) -lt $deadline) {
         $details = Invoke-Ctyun @(
             "ecs", "GetEcsKeypairDetails",
@@ -670,7 +697,12 @@ function Remove-KeyPair {
                 Where-Object { [string]$_.keyPairName -eq $script:KeyPairName }
         )
         if ($remaining.Count -eq 0) {
-            return
+            $confirmEmptyReads++
+            if ($confirmEmptyReads -ge 2) {
+                return
+            }
+        } else {
+            $confirmEmptyReads = 0
         }
         Start-Sleep -Seconds 5
     }
@@ -777,7 +809,26 @@ function Invoke-ExactBakeCleanup {
     } while ((Get-Date) -lt $discoveryDeadline)
 
     $candidateBuilder = Resolve-BuilderInstance -WaitSeconds $discoverySeconds
-    if ($candidateImage -or $candidateBuilder) {
+    # Also look up the exact temporary key pair name this bake would have used.
+    # A process killed right after ImportEcsKeypair (before CreateEcsInstance)
+    # leaves only the key pair behind; without this check that leak is never
+    # discovered and reconcile reports nothing-to-clean.
+    $candidateKeyPair = @()
+    if ($script:KeyPairName) {
+        $keyDetails = Invoke-Ctyun @(
+            "ecs", "GetEcsKeypairDetails",
+            "--regionID", $RegionID,
+            "--projectID", $ProjectID,
+            "--keyPairName", $script:KeyPairName,
+            "--pageNo", "1",
+            "--pageSize", "10"
+        )
+        $candidateKeyPair = @(
+            @(Get-ResponseItems -Response $keyDetails -Name "results") |
+                Where-Object { [string]$_.keyPairName -eq $script:KeyPairName }
+        )
+    }
+    if ($candidateImage -or $candidateBuilder -or $candidateKeyPair.Count -gt 0) {
         $details = @(
             "Automatic historical cleanup refused because immutable creation IDs were not persisted."
             "Review and remove only resources proven to belong to bake $script:BakeID."
@@ -788,10 +839,13 @@ function Invoke-ExactBakeCleanup {
         if ($candidateBuilder) {
             $details += "candidate instanceID=$($candidateBuilder.instanceID) name=$($candidateBuilder.instanceName)"
         }
+        if ($candidateKeyPair.Count -gt 0) {
+            $details += "candidate keyPairName=$script:KeyPairName"
+        }
         throw ($details -join " ")
     }
 
-    Write-Warning "No provably owned historical resources found; key pair lookup was skipped because names are not ownership proof"
+    Write-Warning "No provably owned historical resources found for bake $script:BakeID"
     return [ordered]@{
         result = "nothing-to-clean"
         bakeID = $script:BakeID

--- a/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
+++ b/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
@@ -100,6 +100,38 @@ function Invoke-External {
     }
 }
 
+function Get-PropertyValue {
+    param(
+        [AllowNull()]
+        [object]$InputObject,
+        [Parameter(Mandatory = $true)]
+        [string]$Name
+    )
+
+    if ($null -eq $InputObject) {
+        return $null
+    }
+    $property = $InputObject.PSObject.Properties[$Name]
+    if (-not $property) {
+        return $null
+    }
+    return $property.Value
+}
+
+function Get-ResponseItems {
+    param(
+        [Parameter(Mandatory = $true)]
+        [object]$Response,
+        [Parameter(Mandatory = $true)]
+        [string]$Name
+    )
+
+    $returnObject = Get-PropertyValue -InputObject $Response -Name "returnObj"
+    return @(
+        Get-PropertyValue -InputObject $returnObject -Name $Name
+    )
+}
+
 function Invoke-Ctyun {
     param([Parameter(Mandatory = $true)][string[]]$Arguments)
 
@@ -117,8 +149,12 @@ function Invoke-Ctyun {
     } catch {
         throw "ctyun-cli returned non-JSON output: $raw"
     }
-    if ($response.statusCode -ne 800) {
-        throw "Tianyi Cloud API failed: $($response.errorCode) $($response.message) $($response.description)"
+    $statusCode = Get-PropertyValue -InputObject $response -Name "statusCode"
+    if ($statusCode -ne 800) {
+        $errorCode = Get-PropertyValue -InputObject $response -Name "errorCode"
+        $message = Get-PropertyValue -InputObject $response -Name "message"
+        $description = Get-PropertyValue -InputObject $response -Name "description"
+        throw "Tianyi Cloud API failed: $errorCode $message $description"
     }
     return $response
 }
@@ -190,7 +226,8 @@ function Get-Instance {
         "--pageNo", "1",
         "--pageSize", "10"
     )
-    return @($response.returnObj.results) | Select-Object -First 1
+    return @(Get-ResponseItems -Response $response -Name "results") |
+        Select-Object -First 1
 }
 
 function Find-BuilderInstance {
@@ -216,7 +253,7 @@ function Find-BuilderInstance {
 
     foreach ($query in $queries) {
         $response = Invoke-Ctyun $query
-        foreach ($candidate in @($response.returnObj.results)) {
+        foreach ($candidate in @(Get-ResponseItems -Response $response -Name "results")) {
             if (
                 [string]$candidate.instanceName -eq $script:BuilderName -and
                 (
@@ -347,7 +384,8 @@ function Get-Image {
             "--imageID", $ImageID,
             "--errorFree", "false"
         )
-        return @($detail.returnObj.images) | Select-Object -First 1
+        return @(Get-ResponseItems -Response $detail -Name "images") |
+            Select-Object -First 1
     } catch {
         if (Test-NotFoundError $_.Exception.Message) {
             return $null
@@ -368,7 +406,7 @@ function Find-ImageByName {
         "--pageNo", "1",
         "--pageSize", "200"
     )
-    return @($response.returnObj.images) |
+    return @(Get-ResponseItems -Response $response -Name "images") |
         Where-Object { [string]$_.imageName -eq $Name } |
         Select-Object -First 1
 }
@@ -555,7 +593,7 @@ function Remove-KeyPair {
             "--pageSize", "10"
         )
         $existing = @(
-            @($details.returnObj.results) |
+            @(Get-ResponseItems -Response $details -Name "results") |
                 Where-Object { [string]$_.keyPairName -eq $script:KeyPairName }
         )
         if ($existing.Count -gt 0 -or -not $WaitForLateResources) {
@@ -588,7 +626,7 @@ function Remove-KeyPair {
             "--pageSize", "10"
         )
         $remaining = @(
-            @($details.returnObj.results) |
+            @(Get-ResponseItems -Response $details -Name "results") |
                 Where-Object { [string]$_.keyPairName -eq $script:KeyPairName }
         )
         if ($remaining.Count -eq 0) {
@@ -931,7 +969,7 @@ try {
         "--pageSize", "10"
     )
     $existingKeyPairs = @(
-        @($existingKeyPairResponse.returnObj.results) |
+        @(Get-ResponseItems -Response $existingKeyPairResponse -Name "results") |
             Where-Object { [string]$_.keyPairName -eq $script:KeyPairName }
     )
     if ($existingKeyPairs.Count -gt 0) {
@@ -956,10 +994,13 @@ try {
         "--pageNo", "1",
         "--pageSize", "10"
     )
-    $keyPair = @($keyPairResponse.returnObj.results) |
+    $keyPair = @(Get-ResponseItems -Response $keyPairResponse -Name "results") |
         Where-Object { [string]$_.keyPairName -eq $script:KeyPairName } |
         Select-Object -First 1
-    if (-not $keyPair.keyPairID) {
+    $keyPairID = [string](
+        Get-PropertyValue -InputObject $keyPair -Name "keyPairID"
+    )
+    if (-not $keyPairID) {
         throw "Imported key pair could not be resolved"
     }
 
@@ -971,7 +1012,7 @@ try {
         "--pageSize", "10"
     )
     $existingBuilders = @(
-        @($existingBuilderResponse.returnObj.results) |
+        @(Get-ResponseItems -Response $existingBuilderResponse -Name "results") |
             Where-Object { [string]$_.instanceName -eq $script:BuilderName }
     )
     if ($existingBuilders.Count -gt 0) {
@@ -996,7 +1037,7 @@ try {
         "--vpcID", $VpcID,
         "--networkCardList", "[{`"isMaster`":true,`"subnetID`":`"$SubnetID`"}]",
         "--secGroupList", "[`"$SecurityGroupID`"]",
-        "--keyPairID", $keyPair.keyPairID,
+        "--keyPairID", $keyPairID,
         "--onDemand", "true",
         "--extIP", "1",
         "--bandwidth", "$BuilderBandwidth",
@@ -1008,7 +1049,12 @@ try {
         "--trustInstance", "false",
         "--labelList", "[{`"labelKey`":`"purpose`",`"labelValue`":`"catsco-image-builder`"},{`"labelKey`":`"commit`",`"labelValue`":`"$shortCommit`"}]"
     )
-    $script:BuilderResourceID = [string]$createResponse.returnObj.masterResourceID
+    $createReturnObject = Get-PropertyValue `
+        -InputObject $createResponse `
+        -Name "returnObj"
+    $script:BuilderResourceID = [string](
+        Get-PropertyValue -InputObject $createReturnObject -Name "masterResourceID"
+    )
     if (-not $script:BuilderResourceID) {
         throw "CreateEcsInstance did not return masterResourceID"
     }
@@ -1110,8 +1156,11 @@ bash /tmp/prepare-image.sh --finalize
         "--enableImageIntegrityCheck", "true",
         "--labels", "[{`"labelKey`":`"product`",`"labelValue`":`"catsco-worker`"},{`"labelKey`":`"version`",`"labelValue`":`"$version`"},{`"labelKey`":`"commit`",`"labelValue`":`"$commit`"},{`"labelKey`":`"bake`",`"labelValue`":`"$script:BakeID`"}]"
     )
-    $image = @($imageResponse.returnObj.images) | Select-Object -First 1
-    $script:ImageID = [string]$image.imageID
+    $image = @(Get-ResponseItems -Response $imageResponse -Name "images") |
+        Select-Object -First 1
+    $script:ImageID = [string](
+        Get-PropertyValue -InputObject $image -Name "imageID"
+    )
     if (-not $script:ImageID) {
         throw "CreateImage did not return an image ID"
     }

--- a/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
+++ b/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
@@ -801,13 +801,26 @@ function Invoke-ExactBakeCleanup {
     $discoveryDeadline = Get-BoundedDeadline `
         -RequestedSeconds $discoverySeconds `
         -Phase "exact bake resource discovery"
+
+    # Resolve the builder FIRST: its immutable instance ID is the ownership
+    # proof the image deletion depends on (sourceServerID match). The builder
+    # itself is deleted LAST so it stays as evidence while the image is being
+    # removed — the same ordering as the in-process finally path. Deleting the
+    # builder first would strand a genuinely owned image if image deletion
+    # cannot complete (un-deletable state, delete failure, or confirmation
+    # timeout), turning a recoverable leak into a permanent one.
+    $candidateBuilder = Resolve-BuilderInstance -WaitSeconds $discoverySeconds
+    if ($candidateBuilder) {
+        $script:BuilderID = [string]$candidateBuilder.instanceID
+        $script:BuilderName = [string]$candidateBuilder.instanceName
+    }
+
     $candidateImage = $null
     do {
         $candidateImage = Find-ImageByName -Name $script:ImageWorkName
         if ($candidateImage -or -not $WaitForLateResources) { break }
         Start-Sleep -Seconds 10
     } while ((Get-Date) -lt $discoveryDeadline)
-    $candidateBuilder = Resolve-BuilderInstance -WaitSeconds $discoverySeconds
 
     # Reconcile resources that can be uniquely proven to belong to this bake;
     # anything that cannot be proven stays fail-closed and is reported. A
@@ -817,22 +830,10 @@ function Invoke-ExactBakeCleanup {
     $errors = [Collections.Generic.List[string]]::new()
     $reconciled = [Collections.Generic.List[string]]::new()
 
-    # --- Builder: resolve first, because the image's sourceServerID proof and
-    # the builder deletion both depend on the resolved immutable instance ID. ---
-    if ($candidateBuilder) {
-        $script:BuilderID = [string]$candidateBuilder.instanceID
-        $script:BuilderName = [string]$candidateBuilder.instanceName
-        try {
-            Remove-Builder -WaitForLate:$WaitForLateResources
-            $reconciled.Add("builder=$script:BuilderID")
-        } catch {
-            $errors.Add("builder cleanup (name=$script:BuilderName): $($_.Exception.Message)")
-        }
-    }
-
-    # --- Image: only deletable when sourceServerID matches the resolved builder
-    # (same ownership proof as the in-process finally path). Without a builder
-    # the image's source identity cannot be proven, so it stays fail-closed. ---
+    # --- Image first: deletable only when sourceServerID matches the resolved
+    # builder (same ownership proof as the in-process finally path). Without a
+    # builder the image's source identity cannot be proven, so it stays
+    # fail-closed. ---
     if ($candidateImage) {
         $script:ImageCreateAttempted = $true
         $script:ImageID = ""
@@ -845,39 +846,53 @@ function Invoke-ExactBakeCleanup {
         }
     }
 
+    # --- Builder: deleted only after the image is gone, so it remains as
+    # ownership evidence if image deletion could not complete. ---
+    if ($candidateBuilder) {
+        try {
+            Remove-Builder -WaitForLate:$WaitForLateResources
+            $reconciled.Add("builder=$script:BuilderID")
+        } catch {
+            $errors.Add("builder cleanup (name=$script:BuilderName): $($_.Exception.Message)")
+        }
+    }
+
     # --- Key pair: the unique temporary name (derived from the deterministic
-    # bake token) is the ownership proof; delete only when it uniquely matches. ---
+    # bake token) is the ownership proof; delete only when it uniquely matches.
+    # The lookup is inside the try so API errors/deadlines join the aggregate
+    # instead of aborting it. ---
     if ($script:KeyPairName) {
-        $keyDetails = Invoke-Ctyun @(
-            "ecs", "GetEcsKeypairDetails",
-            "--regionID", $RegionID,
-            "--projectID", $ProjectID,
-            "--keyPairName", $script:KeyPairName,
-            "--pageNo", "1",
-            "--pageSize", "10"
-        )
-        $candidateKeyPair = @(
-            @(Get-ResponseItems -Response $keyDetails -Name "results") |
-                Where-Object { [string]$_.keyPairName -eq $script:KeyPairName }
-        )
-        if ($candidateKeyPair.Count -eq 1) {
-            $script:KeyPairCreateAttempted = $true
-            try {
+        try {
+            $keyDetails = Invoke-Ctyun @(
+                "ecs", "GetEcsKeypairDetails",
+                "--regionID", $RegionID,
+                "--projectID", $ProjectID,
+                "--keyPairName", $script:KeyPairName,
+                "--pageNo", "1",
+                "--pageSize", "10"
+            )
+            $candidateKeyPair = @(
+                @(Get-ResponseItems -Response $keyDetails -Name "results") |
+                    Where-Object { [string]$_.keyPairName -eq $script:KeyPairName }
+            )
+            if ($candidateKeyPair.Count -eq 1) {
+                $script:KeyPairCreateAttempted = $true
                 Remove-KeyPair -WaitForLate:$WaitForLateResources
                 $reconciled.Add("keyPair=$script:KeyPairName")
-            } catch {
-                $errors.Add("key pair cleanup (name=$script:KeyPairName): $($_.Exception.Message)")
+            } elseif ($candidateKeyPair.Count -gt 1) {
+                $errors.Add("key pair name '$script:KeyPairName' is not unique; refusing to delete")
             }
-        } elseif ($candidateKeyPair.Count -gt 1) {
-            $errors.Add("key pair name '$script:KeyPairName' is not unique; refusing to delete")
+        } catch {
+            $errors.Add("key pair cleanup (name=$script:KeyPairName): $($_.Exception.Message)")
         }
     }
 
     if ($errors.Count -gt 0) {
-        throw (
-            "Temporary cloud resource cleanup failed during reconciliation:`n" +
-            ($errors -join "`n")
-        )
+        $summary = "Temporary cloud resource cleanup failed during reconciliation"
+        if ($reconciled.Count -gt 0) {
+            $summary += " (reconciled: $($reconciled -join ', '))"
+        }
+        throw ($summary + "`n" + ($errors -join "`n"))
     }
 
     if ($reconciled.Count -gt 0) {

--- a/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
+++ b/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
@@ -27,8 +27,10 @@ param(
     [string]$ProjectID = "0",
     [string]$SourceRef = "HEAD",
     [string]$ImageName = "",
-    [string]$ArtifactUrl = "",
+    [string]$ArtifactPath = "",
     [string]$ArtifactSha256 = "",
+    [string]$BuildNumber = "",
+    [string]$BuildAttempt = "1",
     [string]$BootDiskType = "SATA",
     [ValidateRange(40, 2048)]
     [int]$BootDiskSize = 40,
@@ -36,7 +38,10 @@ param(
     [int]$BuilderBandwidth = 5,
     [ValidateRange(10, 120)]
     [int]$TimeoutMinutes = 50,
-    [switch]$KeepBuilderOnFailure
+    [ValidateRange(10, 90)]
+    [int]$RemoteBuildTimeoutMinutes = 45,
+    [ValidateRange(10, 60)]
+    [int]$ArtifactTransferTimeoutMinutes = 30
 )
 
 $ErrorActionPreference = "Stop"
@@ -46,8 +51,13 @@ $script:BuilderID = ""
 $script:BuilderName = ""
 $script:BuilderResourceID = ""
 $script:BuilderIP = ""
+$script:BuilderCreateAttempted = $false
 $script:KeyPairName = ""
+$script:KeyPairCreateAttempted = $false
 $script:TemporaryRoot = ""
+$script:ImageID = ""
+$script:ImageCreateAttempted = $false
+$script:ImageActive = $false
 $script:Completed = $false
 
 function Invoke-External {
@@ -55,6 +65,8 @@ function Invoke-External {
         [Parameter(Mandatory = $true)]
         [string]$Command,
         [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [AllowEmptyString()]
         [string[]]$Arguments,
         [switch]$Capture
     )
@@ -88,6 +100,12 @@ function Invoke-Ctyun {
     return $response
 }
 
+function Test-NotFoundError {
+    param([Parameter(Mandatory = $true)][string]$Message)
+
+    return $Message -match "(?i)not found|notfound|does not exist|不存在|未找到"
+}
+
 function Get-Instance {
     param([Parameter(Mandatory = $true)][string]$InstanceID)
 
@@ -101,16 +119,89 @@ function Get-Instance {
     return @($response.returnObj.results) | Select-Object -First 1
 }
 
+function Find-BuilderInstance {
+    $queries = [Collections.Generic.List[object]]::new()
+    if ($script:BuilderResourceID) {
+        $queries.Add(@(
+            "ecs", "ListEcsInstances",
+            "--regionID", $RegionID,
+            "--resourceID", $script:BuilderResourceID,
+            "--pageNo", "1",
+            "--pageSize", "10"
+        ))
+    }
+    if ($script:BuilderName) {
+        $queries.Add(@(
+            "ecs", "ListEcsInstances",
+            "--regionID", $RegionID,
+            "--instanceName", $script:BuilderName,
+            "--pageNo", "1",
+            "--pageSize", "10"
+        ))
+    }
+
+    foreach ($query in $queries) {
+        $response = Invoke-Ctyun $query
+        foreach ($candidate in @($response.returnObj.results)) {
+            if (
+                [string]$candidate.instanceName -eq $script:BuilderName -and
+                (
+                    -not $script:BuilderResourceID -or
+                    [string]$candidate.resourceID -eq $script:BuilderResourceID
+                )
+            ) {
+                $script:BuilderID = [string]$candidate.instanceID
+                return $candidate
+            }
+        }
+    }
+    return $null
+}
+
+function Resolve-BuilderInstance {
+    param([ValidateRange(0, 7200)][int]$WaitSeconds = 0)
+
+    $deadline = (Get-Date).AddSeconds($WaitSeconds)
+    do {
+        if ($script:BuilderID) {
+            try {
+                $instance = Get-Instance -InstanceID $script:BuilderID
+                if ($instance) {
+                    return $instance
+                }
+            } catch {
+                if (-not (Test-NotFoundError $_.Exception.Message)) {
+                    throw
+                }
+            }
+        }
+
+        $resolved = Find-BuilderInstance
+        if ($resolved) {
+            return $resolved
+        }
+        if ((Get-Date) -ge $deadline) {
+            break
+        }
+        Start-Sleep -Seconds 8
+    } while ($true)
+
+    return $null
+}
+
 function Assert-TemporaryBuilder {
     param([Parameter(Mandatory = $true)]$Instance)
 
     if (-not $Instance) {
         throw "Temporary builder instance was not found"
     }
-    if ($Instance.instanceID -ne $script:BuilderID) {
+    if (-not $script:BuilderID -or [string]$Instance.instanceID -ne $script:BuilderID) {
         throw "Refusing to operate on an instance outside this bake"
     }
-    if (-not [string]$Instance.instanceName -or -not $Instance.instanceName.StartsWith("catsco-img-")) {
+    if (
+        -not $script:BuilderName.StartsWith("catsco-img-") -or
+        [string]$Instance.instanceName -ne $script:BuilderName
+    ) {
         throw "Refusing to operate on non-builder instance '$($Instance.instanceName)'"
     }
 }
@@ -124,7 +215,7 @@ function Wait-ForInstance {
 
     $deadline = (Get-Date).AddMinutes($TimeoutMinutes)
     while ((Get-Date) -lt $deadline) {
-        $instance = Get-Instance -InstanceID $script:BuilderID
+        $instance = Resolve-BuilderInstance
         Assert-TemporaryBuilder $instance
         $state = ([string]$instance.instanceStatus).ToLowerInvariant()
         $ip = [string]$instance.floatingIP
@@ -150,9 +241,11 @@ function Wait-ForSsh {
             -i $PrivateKey `
             -o BatchMode=yes `
             -o ConnectTimeout=6 `
+            -o ServerAliveInterval=15 `
+            -o ServerAliveCountMax=3 `
             -o StrictHostKeyChecking=accept-new `
             -o "UserKnownHostsFile=$KnownHosts" `
-            "root@$IP" "cloud-init status --wait >/dev/null 2>&1; printf ready" 2>$null
+            "root@$IP" "timeout --signal=TERM --kill-after=15s 90s cloud-init status --wait >/dev/null 2>&1; printf ready" 2>$null
         if ($LASTEXITCODE -eq 0) {
             return
         }
@@ -161,67 +254,207 @@ function Wait-ForSsh {
     throw "Timed out waiting for SSH on temporary builder"
 }
 
-function Remove-TemporaryResources {
-    param([switch]$Failure)
+function Get-Image {
+    param([Parameter(Mandatory = $true)][string]$ImageID)
 
-    if ($Failure -and $KeepBuilderOnFailure) {
-        Write-Warning "Keeping temporary builder for diagnosis: $script:BuilderID ($script:BuilderIP)"
-        return
-    }
-
-    if ($script:BuilderID) {
-        try {
-            $instance = Get-Instance -InstanceID $script:BuilderID
-            if ($instance) {
-                Assert-TemporaryBuilder $instance
-                Write-Host "Deleting temporary builder $script:BuilderID"
-                Invoke-Ctyun @(
-                    "ecs", "DeleteEcsInstance",
-                    "--regionID", $RegionID,
-                    "--instanceID", $script:BuilderID,
-                    "--clientToken", ([guid]::NewGuid().ToString()),
-                    "--deleteEip", "true",
-                    "--deleteVolume", "true"
-                ) | Out-Null
-                $deleteDeadline = (Get-Date).AddMinutes(8)
-                while ((Get-Date) -lt $deleteDeadline) {
-                    Start-Sleep -Seconds 8
-                    try {
-                        $remaining = Get-Instance -InstanceID $script:BuilderID
-                        if (-not $remaining) {
-                            break
-                        }
-                        Assert-TemporaryBuilder $remaining
-                    } catch {
-                        if ($_.Exception.Message -match "not found|does not exist|不存在") {
-                            break
-                        }
-                        throw
-                    }
-                }
-            }
-        } catch {
-            Write-Warning "Could not delete temporary builder: $($_.Exception.Message)"
+    try {
+        $detail = Invoke-Ctyun @(
+            "ims", "GetImageDetail",
+            "--regionID", $RegionID,
+            "--imageID", $ImageID,
+            "--errorFree", "false"
+        )
+        return @($detail.returnObj.images) | Select-Object -First 1
+    } catch {
+        if (Test-NotFoundError $_.Exception.Message) {
+            return $null
         }
-    }
-
-    if ($script:KeyPairName) {
-        try {
-            Write-Host "Deleting temporary key pair $script:KeyPairName"
-            Invoke-Ctyun @(
-                "ecs", "DeleteEcsKeypair",
-                "--regionID", $RegionID,
-                "--keyPairName", $script:KeyPairName
-            ) | Out-Null
-        } catch {
-            Write-Warning "Could not delete temporary key pair: $($_.Exception.Message)"
-        }
+        throw
     }
 }
 
-foreach ($command in @("ctyun-cli", "git", "ssh", "scp", "ssh-keygen")) {
-    if (-not (Get-Command $command -ErrorAction SilentlyContinue)) {
-        throw "Missing required command: $command"
+function Find-ImageByName {
+    $response = Invoke-Ctyun @(
+        "ims", "ListImage",
+        "--regionID", $RegionID,
+        "--imageVisibilityCode", "0",
+        "--imageName", $ImageName,
+        "--pageNo", "1",
+        "--pageSize", "10"
+    )
+    return @($response.returnObj.images) |
+        Where-Object { [string]$_.imageName -eq $ImageName } |
+        Select-Object -First 1
+}
+
+function Remove-FailedImage {
+    if ($script:ImageActive -or (-not $script:ImageCreateAttempted -and -not $script:ImageID)) {
+        return
+    }
+
+    if (-not $script:ImageID) {
+        $resolveDeadline = (Get-Date).AddMinutes(3)
+        while ((Get-Date) -lt $resolveDeadline -and -not $script:ImageID) {
+            $candidate = Find-ImageByName
+            if ($candidate) {
+                $script:ImageID = [string]$candidate.imageID
+                break
+            }
+            Start-Sleep -Seconds 10
+        }
+        if (-not $script:ImageID) {
+            Write-Host "No incomplete image record appeared for $ImageName"
+            return
+        }
+    }
+
+    $deadline = (Get-Date).AddMinutes(12)
+    $deletableStates = @(
+        "active", "deactivated", "deactivating", "deleting",
+        "error", "killed", "reactivating"
+    )
+    while ((Get-Date) -lt $deadline) {
+        $image = Get-Image -ImageID $script:ImageID
+        if (-not $image) {
+            return
+        }
+        $status = ([string]$image.imageStatus).ToLowerInvariant()
+        Write-Host "failed image cleanup state=$status"
+        if ($status -eq "deleted") {
+            return
+        }
+        if ($status -in $deletableStates) {
+            if ($status -ne "deleting") {
+                Write-Host "Deleting incomplete image $script:ImageID"
+                Invoke-Ctyun @(
+                    "ims", "DeleteImage",
+                    "--regionID", $RegionID,
+                    "--imageID", $script:ImageID
+                ) | Out-Null
+            }
+            break
+        }
+        Start-Sleep -Seconds 15
+    }
+
+    $deleteDeadline = (Get-Date).AddMinutes(8)
+    while ((Get-Date) -lt $deleteDeadline) {
+        $remaining = Get-Image -ImageID $script:ImageID
+        if (-not $remaining -or ([string]$remaining.imageStatus).ToLowerInvariant() -eq "deleted") {
+            return
+        }
+        Start-Sleep -Seconds 10
+    }
+    throw "Could not confirm deletion of incomplete image $script:ImageID"
+}
+
+function Remove-Builder {
+    if (-not $script:BuilderCreateAttempted -and -not $script:BuilderID) {
+        return
+    }
+
+    $instance = Resolve-BuilderInstance -WaitSeconds 480
+    if (-not $instance) {
+        throw "Could not prove cleanup of builder name=$script:BuilderName resourceID=$script:BuilderResourceID"
+    }
+    Assert-TemporaryBuilder $instance
+    Write-Host "Deleting temporary builder $script:BuilderID"
+    Invoke-Ctyun @(
+        "ecs", "DeleteEcsInstance",
+        "--regionID", $RegionID,
+        "--instanceID", $script:BuilderID,
+        "--clientToken", ([guid]::NewGuid().ToString()),
+        "--deleteEip", "true",
+        "--deleteVolume", "true"
+    ) | Out-Null
+
+    $deadline = (Get-Date).AddMinutes(8)
+    while ((Get-Date) -lt $deadline) {
+        $remaining = Resolve-BuilderInstance
+        if (-not $remaining) {
+            return
+        }
+        Assert-TemporaryBuilder $remaining
+        Start-Sleep -Seconds 8
+    }
+    throw "Could not confirm deletion of temporary builder $script:BuilderID"
+}
+
+function Remove-KeyPair {
+    if (-not $script:KeyPairName -or -not $script:KeyPairCreateAttempted) {
+        return
+    }
+
+    Write-Host "Deleting temporary key pair $script:KeyPairName"
+    Invoke-Ctyun @(
+        "ecs", "DeleteEcsKeypair",
+        "--regionID", $RegionID,
+        "--keyPairName", $script:KeyPairName
+    ) | Out-Null
+
+    $deadline = (Get-Date).AddMinutes(2)
+    while ((Get-Date) -lt $deadline) {
+        $details = Invoke-Ctyun @(
+            "ecs", "GetEcsKeypairDetails",
+            "--regionID", $RegionID,
+            "--projectID", $ProjectID,
+            "--keyPairName", $script:KeyPairName,
+            "--pageNo", "1",
+            "--pageSize", "10"
+        )
+        $remaining = @(
+            @($details.returnObj.results) |
+                Where-Object { [string]$_.keyPairName -eq $script:KeyPairName }
+        )
+        if ($remaining.Count -eq 0) {
+            return
+        }
+        Start-Sleep -Seconds 5
+    }
+    throw "Could not confirm deletion of temporary key pair $script:KeyPairName"
+}
+
+function Remove-TemporaryResources {
+    param([switch]$Failure)
+
+    $errors = [Collections.Generic.List[string]]::new()
+    if ($Failure) {
+        try {
+            Remove-FailedImage
+        } catch {
+            $errors.Add(
+                "image cleanup (name=$ImageName imageID=$script:ImageID): $($_.Exception.Message)"
+            )
+        }
+    }
+    try {
+        Remove-Builder
+    } catch {
+        $errors.Add(
+            "builder cleanup (name=$script:BuilderName instanceID=$script:BuilderID resourceID=$script:BuilderResourceID): $($_.Exception.Message)"
+        )
+    }
+    try {
+        Remove-KeyPair
+    } catch {
+        $errors.Add(
+            "key pair cleanup (name=$script:KeyPairName): $($_.Exception.Message)"
+        )
+    }
+
+    if ($errors.Count -gt 0) {
+        throw "Temporary cloud resource cleanup failed:`n$($errors -join "`n")"
+    }
+}
+
+if (-not (Get-Command "git" -ErrorAction SilentlyContinue)) {
+    throw "Missing required command: git"
+}
+if ($Mode -eq "Create") {
+    foreach ($command in @("ctyun-cli", "ssh", "scp", "ssh-keygen", "timeout")) {
+        if (-not (Get-Command $command -ErrorAction SilentlyContinue)) {
+            throw "Missing required command: $command"
+        }
     }
 }
 
@@ -245,15 +478,39 @@ if (-not $ImageName) {
 if ($ImageName.Length -gt 32 -or $ImageName -notmatch "^[A-Za-z][A-Za-z0-9-]*[A-Za-z0-9]$") {
     throw "Image name must satisfy Tianyi Cloud's 2-32 character name rules: $ImageName"
 }
-if ($ArtifactUrl) {
-    if ($ArtifactUrl -notmatch "^https://") {
-        throw "ArtifactUrl must use HTTPS"
+
+if ($BuildNumber) {
+    [long]$buildSequence = 0
+    [int]$attemptSequence = 0
+    if (
+        -not [long]::TryParse($BuildNumber, [ref]$buildSequence) -or
+        $buildSequence -lt 1 -or
+        -not [int]::TryParse($BuildAttempt, [ref]$attemptSequence) -or
+        $attemptSequence -lt 1
+    ) {
+        throw "BuildNumber and BuildAttempt must be positive integers"
     }
+    $builderSuffix = "$($buildSequence.ToString('D6'))-$($attemptSequence.ToString('D2'))"
+} else {
+    $builderSuffix = "$(Get-Date -AsUTC -Format 'yyMMddHHmmss')"
+}
+$script:BuilderName = "catsco-img-$builderSuffix"
+$script:KeyPairName = "catsco-img-key-$builderSuffix"
+
+$resolvedArtifactPath = ""
+if ($ArtifactPath) {
+    $resolvedArtifactPath = (Resolve-Path $ArtifactPath).Path
     if ($ArtifactSha256 -notmatch "^[0-9a-fA-F]{64}$") {
-        throw "ArtifactSha256 is required with ArtifactUrl"
+        throw "ArtifactSha256 is required with ArtifactPath"
     }
+    $actualArtifactSha256 = (Get-FileHash -Algorithm SHA256 $resolvedArtifactPath).Hash.ToLowerInvariant()
+    if ($actualArtifactSha256 -ne $ArtifactSha256.ToLowerInvariant()) {
+        throw "Local worker artifact checksum mismatch"
+    }
+} elseif ($Mode -eq "Create") {
+    throw "ArtifactPath and ArtifactSha256 are required in Create mode"
 } elseif ($ArtifactSha256) {
-    throw "ArtifactSha256 cannot be used without ArtifactUrl"
+    throw "ArtifactSha256 cannot be used without ArtifactPath"
 }
 
 $plan = [ordered]@{
@@ -262,7 +519,7 @@ $plan = [ordered]@{
     version = $version
     commit = $commit
     imageName = $ImageName
-    builderPrefix = "catsco-img-"
+    builderName = $script:BuilderName
     regionID = $RegionID
     azName = $AzName
     baseImageID = $BaseImageID
@@ -271,7 +528,7 @@ $plan = [ordered]@{
     subnetID = $SubnetID
     securityGroupID = $SecurityGroupID
     bootDisk = "$BootDiskType $BootDiskSize GiB"
-    artifactSource = $(if ($ArtifactUrl) { "private HTTPS artifact (signed URL redacted)" } else { "local git archive built on temporary ECS" })
+    artifactSource = $(if ($resolvedArtifactPath) { "local source-free CI artifact" } else { "not supplied in plan mode" })
     mutatesExistingWorkers = $false
 }
 $plan | ConvertTo-Json
@@ -294,23 +551,15 @@ if (@($existing.returnObj.images).Count -gt 0) {
 
 $script:TemporaryRoot = Join-Path ([IO.Path]::GetTempPath()) "catsco-image-$([guid]::NewGuid().ToString('N'))"
 New-Item -ItemType Directory -Path $script:TemporaryRoot | Out-Null
-$sourceArchive = Join-Path $script:TemporaryRoot "catsco-source.tar"
 $privateKey = Join-Path $script:TemporaryRoot "builder-rsa"
 $publicKeyPath = "$privateKey.pub"
 $knownHosts = Join-Path $script:TemporaryRoot "known_hosts"
 $remoteBuildScript = Join-Path $script:TemporaryRoot "build-image.sh"
+$primaryFailure = $null
+$cleanupFailure = $null
+$result = $null
 
 try {
-    if (-not $ArtifactUrl) {
-        Invoke-External -Command "git" -Arguments @(
-            "-C", $repoRoot,
-            "archive",
-            "--format=tar",
-            "--output=$sourceArchive",
-            $commit
-        )
-    }
-
     Invoke-External -Command "ssh-keygen" -Arguments @(
         "-q", "-t", "rsa", "-b", "3072",
         "-N", "",
@@ -318,7 +567,23 @@ try {
         "-f", $privateKey
     )
     $publicKey = (Get-Content $publicKeyPath -Raw).Trim()
-    $script:KeyPairName = "catsco-img-key-$shortCommit-$((Get-Date).ToString('HHmmss'))"
+    $existingKeyPairResponse = Invoke-Ctyun @(
+        "ecs", "GetEcsKeypairDetails",
+        "--regionID", $RegionID,
+        "--projectID", $ProjectID,
+        "--keyPairName", $script:KeyPairName,
+        "--pageNo", "1",
+        "--pageSize", "10"
+    )
+    $existingKeyPairs = @(
+        @($existingKeyPairResponse.returnObj.results) |
+            Where-Object { [string]$_.keyPairName -eq $script:KeyPairName }
+    )
+    if ($existingKeyPairs.Count -gt 0) {
+        throw "Temporary key pair name is already in use: $script:KeyPairName"
+    }
+
+    $script:KeyPairCreateAttempted = $true
     Invoke-Ctyun @(
         "ecs", "ImportEcsKeypair",
         "--regionID", $RegionID,
@@ -336,12 +601,29 @@ try {
         "--pageNo", "1",
         "--pageSize", "10"
     )
-    $keyPair = @($keyPairResponse.returnObj.results) | Select-Object -First 1
+    $keyPair = @($keyPairResponse.returnObj.results) |
+        Where-Object { [string]$_.keyPairName -eq $script:KeyPairName } |
+        Select-Object -First 1
     if (-not $keyPair.keyPairID) {
         throw "Imported key pair could not be resolved"
     }
 
-    $script:BuilderName = "catsco-img-$shortCommit-$((Get-Date).ToString('HHmmss'))"
+    $existingBuilderResponse = Invoke-Ctyun @(
+        "ecs", "ListEcsInstances",
+        "--regionID", $RegionID,
+        "--instanceName", $script:BuilderName,
+        "--pageNo", "1",
+        "--pageSize", "10"
+    )
+    $existingBuilders = @(
+        @($existingBuilderResponse.returnObj.results) |
+            Where-Object { [string]$_.instanceName -eq $script:BuilderName }
+    )
+    if ($existingBuilders.Count -gt 0) {
+        throw "Temporary builder name is already in use: $script:BuilderName"
+    }
+
+    $script:BuilderCreateAttempted = $true
     $createResponse = Invoke-Ctyun @(
         "ecs", "CreateEcsInstance",
         "--regionID", $RegionID,
@@ -376,75 +658,27 @@ try {
         throw "CreateEcsInstance did not return masterResourceID"
     }
 
-    $deadline = (Get-Date).AddMinutes($TimeoutMinutes)
-    while ((Get-Date) -lt $deadline -and -not $script:BuilderID) {
-        $lookup = Invoke-Ctyun @(
-            "ecs", "ListEcsInstances",
-            "--regionID", $RegionID,
-            "--resourceID", $script:BuilderResourceID,
-            "--pageNo", "1",
-            "--pageSize", "10"
-        )
-        $candidate = @($lookup.returnObj.results) | Select-Object -First 1
-        if ($candidate) {
-            if (-not ([string]$candidate.instanceName).StartsWith("catsco-img-")) {
-                throw "Resource lookup returned a non-builder instance"
-            }
-            $script:BuilderID = [string]$candidate.instanceID
-            break
-        }
-        Start-Sleep -Seconds 8
-    }
-    if (-not $script:BuilderID) {
+    $builder = Resolve-BuilderInstance -WaitSeconds ($TimeoutMinutes * 60)
+    if (-not $builder) {
         throw "Timed out resolving the temporary builder instance"
     }
+    Assert-TemporaryBuilder $builder
 
     $builder = Wait-ForInstance -States @("running", "active") -RequireIP
     $script:BuilderIP = [string]$builder.floatingIP
     Wait-ForSsh -IP $script:BuilderIP -PrivateKey $privateKey -KnownHosts $knownHosts
 
     $artifactName = "catsco-worker-$releaseId-linux-x64.tar.gz"
-    if ($ArtifactUrl) {
-        $artifactPreparation = @"
-export DEBIAN_FRONTEND=noninteractive
-apt-get update
-apt-get install -y --no-install-recommends ca-certificates curl nodejs npm
-curl --fail --location --retry 6 --retry-all-errors \
-  --connect-timeout 10 --max-time 900 \
-  '$ArtifactUrl' -o "`$ARTIFACT"
-SHA256='$ArtifactSha256'
-"@
-    } else {
-        $artifactPreparation = @"
-export DEBIAN_FRONTEND=noninteractive
-apt-get update
-apt-get install -y --no-install-recommends build-essential ca-certificates nodejs npm python3
-npm config set registry https://registry.npmmirror.com
-
-rm -rf /tmp/catsco-source
-mkdir -p /tmp/catsco-source
-tar -xf /tmp/catsco-source.tar -C /tmp/catsco-source
-cd /tmp/catsco-source
-npm ci --ignore-scripts --prefer-offline --no-audit --fund=false
-npm run build
-node scripts/build-linux-worker-artifact.mjs --archive-source --output "`$ARTIFACT" --version "`$VERSION" --commit "`$COMMIT"
-SHA256="`$(awk '{print `$1}' "`$ARTIFACT.sha256")"
-"@
-    }
     $remoteScriptContent = @"
 #!/usr/bin/env bash
 set -Eeuo pipefail
-VERSION='$version'
-COMMIT='$commit'
 ARTIFACT='/tmp/$artifactName'
-
-$artifactPreparation
 bash /tmp/prepare-image.sh \
   --artifact "`$ARTIFACT" \
-  --sha256 "`$SHA256" \
-  --version "`$VERSION" \
-  --commit "`$COMMIT"
-rm -rf /tmp/catsco-source /tmp/catsco-source.tar "`$ARTIFACT" "`$ARTIFACT.sha256"
+  --sha256 '$ArtifactSha256' \
+  --version '$version' \
+  --commit '$commit'
+rm -f "`$ARTIFACT"
 bash /tmp/prepare-image.sh --finalize
 "@
     [IO.File]::WriteAllText(
@@ -457,22 +691,41 @@ bash /tmp/prepare-image.sh --finalize
         "-i", $privateKey,
         "-o", "BatchMode=yes",
         "-o", "ConnectTimeout=10",
+        "-o", "ServerAliveInterval=15",
+        "-o", "ServerAliveCountMax=3",
         "-o", "StrictHostKeyChecking=accept-new",
         "-o", "UserKnownHostsFile=$knownHosts"
     )
-    $filesToCopy = @("$PSScriptRoot/prepare-image.sh", $remoteBuildScript)
-    if (-not $ArtifactUrl) {
-        $filesToCopy = @($sourceArchive) + $filesToCopy
-    }
-    Invoke-External -Command "scp" -Arguments ($sshOptions + $filesToCopy + @(
+    Invoke-External -Command "timeout" -Arguments (@(
+        "--signal=TERM",
+        "--kill-after=30s",
+        "$($ArtifactTransferTimeoutMinutes)m",
+        "scp"
+    ) + $sshOptions + @(
+        $resolvedArtifactPath,
+        "root@$($script:BuilderIP):/tmp/$artifactName"
+    ))
+    Invoke-External -Command "timeout" -Arguments (@(
+        "--signal=TERM",
+        "--kill-after=30s",
+        "5m",
+        "scp"
+    ) + $sshOptions + @(
+        "$PSScriptRoot/prepare-image.sh",
+        $remoteBuildScript,
         "root@$($script:BuilderIP):/tmp/"
     ))
-    Invoke-External -Command "ssh" -Arguments ($sshOptions + @(
+    Invoke-External -Command "timeout" -Arguments (@(
+        "--signal=TERM",
+        "--kill-after=150s",
+        "$($RemoteBuildTimeoutMinutes + 3)m",
+        "ssh"
+    ) + $sshOptions + @(
         "root@$($script:BuilderIP)",
-        "chmod 700 /tmp/build-image.sh /tmp/prepare-image.sh && bash /tmp/build-image.sh"
+        "chmod 700 /tmp/build-image.sh /tmp/prepare-image.sh && timeout --signal=TERM --kill-after=120s $($RemoteBuildTimeoutMinutes)m bash /tmp/build-image.sh"
     ))
 
-    $builder = Get-Instance -InstanceID $script:BuilderID
+    $builder = Resolve-BuilderInstance
     Assert-TemporaryBuilder $builder
     Invoke-Ctyun @(
         "ecs", "StopEcsInstance",
@@ -482,6 +735,7 @@ bash /tmp/prepare-image.sh --finalize
     ) | Out-Null
     Wait-ForInstance -States @("stopped", "shutoff") | Out-Null
 
+    $script:ImageCreateAttempted = $true
     $imageResponse = Invoke-Ctyun @(
         "ims", "CreateImage",
         "--regionID", $RegionID,
@@ -493,32 +747,31 @@ bash /tmp/prepare-image.sh --finalize
         "--labels", "[{`"labelKey`":`"product`",`"labelValue`":`"catsco-worker`"},{`"labelKey`":`"version`",`"labelValue`":`"$version`"},{`"labelKey`":`"commit`",`"labelValue`":`"$commit`"}]"
     )
     $image = @($imageResponse.returnObj.images) | Select-Object -First 1
-    $imageID = [string]$image.imageID
-    if (-not $imageID) {
+    $script:ImageID = [string]$image.imageID
+    if (-not $script:ImageID) {
         throw "CreateImage did not return an image ID"
     }
 
     $deadline = (Get-Date).AddMinutes($TimeoutMinutes)
     while ((Get-Date) -lt $deadline) {
-        $detail = Invoke-Ctyun @(
-            "ims", "GetImageDetail",
-            "--regionID", $RegionID,
-            "--imageID", $imageID,
-            "--errorFree", "false"
-        )
-        $currentImage = @($detail.returnObj.images) | Select-Object -First 1
+        $currentImage = Get-Image -ImageID $script:ImageID
+        if (-not $currentImage) {
+            throw "Private image disappeared during creation"
+        }
         $status = ([string]$currentImage.imageStatus).ToLowerInvariant()
         Write-Host "image state=$status progress=$($currentImage.taskProgress)"
         if ($status -eq "active") {
+            $script:ImageActive = $true
             $script:Completed = $true
-            [ordered]@{
+            $result = [ordered]@{
                 result = "created"
-                imageID = $imageID
+                imageID = $script:ImageID
                 imageName = $ImageName
                 version = $version
                 commit = $commit
+                builderName = $script:BuilderName
                 regionID = $RegionID
-            } | ConvertTo-Json
+            }
             break
         }
         if ($status -in @("error", "killed", "deleted")) {
@@ -530,11 +783,35 @@ bash /tmp/prepare-image.sh --finalize
         throw "Timed out waiting for private image creation"
     }
 } catch {
-    Write-Error $_
-    throw
+    $primaryFailure = $_.Exception.Message
 } finally {
-    Remove-TemporaryResources -Failure:(-not $script:Completed)
+    try {
+        Remove-TemporaryResources -Failure:(-not $script:Completed)
+    } catch {
+        $cleanupFailure = $_.Exception.Message
+    }
     if ($script:TemporaryRoot -and (Test-Path $script:TemporaryRoot)) {
-        Remove-Item -LiteralPath $script:TemporaryRoot -Recurse -Force
+        try {
+            Remove-Item -LiteralPath $script:TemporaryRoot -Recurse -Force
+        } catch {
+            if ($cleanupFailure) {
+                $cleanupFailure += "`nlocal cleanup: $($_.Exception.Message)"
+            } else {
+                $cleanupFailure = "local cleanup: $($_.Exception.Message)"
+            }
+        }
     }
 }
+
+if ($primaryFailure -or $cleanupFailure) {
+    $failures = [Collections.Generic.List[string]]::new()
+    if ($primaryFailure) {
+        $failures.Add("bake failure: $primaryFailure")
+    }
+    if ($cleanupFailure) {
+        $failures.Add("cleanup failure: $cleanupFailure")
+    }
+    throw ($failures -join "`n")
+}
+
+$result | ConvertTo-Json

--- a/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
+++ b/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
@@ -807,13 +807,46 @@ function Invoke-ExactBakeCleanup {
         if ($candidateImage -or -not $WaitForLateResources) { break }
         Start-Sleep -Seconds 10
     } while ((Get-Date) -lt $discoveryDeadline)
-
     $candidateBuilder = Resolve-BuilderInstance -WaitSeconds $discoverySeconds
-    # Also look up the exact temporary key pair name this bake would have used.
-    # A process killed right after ImportEcsKeypair (before CreateEcsInstance)
-    # leaves only the key pair behind; without this check that leak is never
-    # discovered and reconcile reports nothing-to-clean.
-    $candidateKeyPair = @()
+
+    # Reconcile resources that can be uniquely proven to belong to this bake;
+    # anything that cannot be proven stays fail-closed and is reported. A
+    # process hard-killed at any creation boundary (key-only, builder-only,
+    # image-only, published-pending) is recovered here instead of only being
+    # discovered.
+    $errors = [Collections.Generic.List[string]]::new()
+    $reconciled = [Collections.Generic.List[string]]::new()
+
+    # --- Builder: resolve first, because the image's sourceServerID proof and
+    # the builder deletion both depend on the resolved immutable instance ID. ---
+    if ($candidateBuilder) {
+        $script:BuilderID = [string]$candidateBuilder.instanceID
+        $script:BuilderName = [string]$candidateBuilder.instanceName
+        try {
+            Remove-Builder -WaitForLate:$WaitForLateResources
+            $reconciled.Add("builder=$script:BuilderID")
+        } catch {
+            $errors.Add("builder cleanup (name=$script:BuilderName): $($_.Exception.Message)")
+        }
+    }
+
+    # --- Image: only deletable when sourceServerID matches the resolved builder
+    # (same ownership proof as the in-process finally path). Without a builder
+    # the image's source identity cannot be proven, so it stays fail-closed. ---
+    if ($candidateImage) {
+        $script:ImageCreateAttempted = $true
+        $script:ImageID = ""
+        $script:ImageActive = $false
+        try {
+            Remove-FailedImage
+            $reconciled.Add("image=$script:ImageWorkName")
+        } catch {
+            $errors.Add("image cleanup (name=$script:ImageWorkName): $($_.Exception.Message)")
+        }
+    }
+
+    # --- Key pair: the unique temporary name (derived from the deterministic
+    # bake token) is the ownership proof; delete only when it uniquely matches. ---
     if ($script:KeyPairName) {
         $keyDetails = Invoke-Ctyun @(
             "ecs", "GetEcsKeypairDetails",
@@ -827,25 +860,37 @@ function Invoke-ExactBakeCleanup {
             @(Get-ResponseItems -Response $keyDetails -Name "results") |
                 Where-Object { [string]$_.keyPairName -eq $script:KeyPairName }
         )
-    }
-    if ($candidateImage -or $candidateBuilder -or $candidateKeyPair.Count -gt 0) {
-        $details = @(
-            "Automatic historical cleanup refused because immutable creation IDs were not persisted."
-            "Review and remove only resources proven to belong to bake $script:BakeID."
-        )
-        if ($candidateImage) {
-            $details += "candidate imageID=$($candidateImage.imageID) name=$($candidateImage.imageName)"
+        if ($candidateKeyPair.Count -eq 1) {
+            $script:KeyPairCreateAttempted = $true
+            try {
+                Remove-KeyPair -WaitForLate:$WaitForLateResources
+                $reconciled.Add("keyPair=$script:KeyPairName")
+            } catch {
+                $errors.Add("key pair cleanup (name=$script:KeyPairName): $($_.Exception.Message)")
+            }
+        } elseif ($candidateKeyPair.Count -gt 1) {
+            $errors.Add("key pair name '$script:KeyPairName' is not unique; refusing to delete")
         }
-        if ($candidateBuilder) {
-            $details += "candidate instanceID=$($candidateBuilder.instanceID) name=$($candidateBuilder.instanceName)"
-        }
-        if ($candidateKeyPair.Count -gt 0) {
-            $details += "candidate keyPairName=$script:KeyPairName"
-        }
-        throw ($details -join " ")
     }
 
-    Write-Warning "No provably owned historical resources found for bake $script:BakeID"
+    if ($errors.Count -gt 0) {
+        throw (
+            "Temporary cloud resource cleanup failed during reconciliation:`n" +
+            ($errors -join "`n")
+        )
+    }
+
+    if ($reconciled.Count -gt 0) {
+        Write-Host "Reconciled bake resources: $($reconciled -join ', ')"
+        return [ordered]@{
+            result = "reconciled"
+            bakeID = $script:BakeID
+            reconciled = $reconciled
+            regionID = $RegionID
+        }
+    }
+
+    Write-Host "No provably owned historical resources found for bake $script:BakeID"
     return [ordered]@{
         result = "nothing-to-clean"
         bakeID = $script:BakeID

--- a/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
+++ b/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
@@ -271,7 +271,7 @@ $plan = [ordered]@{
     subnetID = $SubnetID
     securityGroupID = $SecurityGroupID
     bootDisk = "$BootDiskType $BootDiskSize GiB"
-    artifactSource = $(if ($ArtifactUrl) { $ArtifactUrl } else { "local git archive built on temporary ECS" })
+    artifactSource = $(if ($ArtifactUrl) { "private HTTPS artifact (signed URL redacted)" } else { "local git archive built on temporary ECS" })
     mutatesExistingWorkers = $false
 }
 $plan | ConvertTo-Json

--- a/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
+++ b/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
@@ -49,6 +49,8 @@ param(
     [int]$CleanupTimeoutMinutes = 45,
     [ValidateRange(15, 300)]
     [int]$ApiTimeoutSeconds = 90,
+    [ValidateRange(5, 300)]
+    [int]$LateResourceWaitSeconds = 120,
     [switch]$WaitForLateResources
 )
 
@@ -288,8 +290,18 @@ function Resolve-BuilderInstance {
                 }
             }
             # Once the provider returned an authoritative instance ID, never
-            # fall back to a possibly reused instance name.
-            return $null
+            # fall back to a possibly reused instance name. A missing result can
+            # still be an eventually-consistent read, so retry the same ID when
+            # the caller requested a discovery window.
+            if ((Get-Date) -ge $deadline) {
+                break
+            }
+            $sleepSeconds = [Math]::Max(
+                1,
+                [Math]::Min(8, [int][Math]::Ceiling(($deadline - (Get-Date)).TotalSeconds))
+            )
+            Start-Sleep -Seconds $sleepSeconds
+            continue
         }
 
         $resolved = Find-BuilderInstance
@@ -538,11 +550,19 @@ function Remove-FailedImage {
 }
 
 function Remove-Builder {
+    param([switch]$WaitForLate)
+
     if (-not $script:BuilderCreateAttempted -and -not $script:BuilderID) {
         return
     }
 
-    $resolveWaitSeconds = if ($script:BuilderID -or $script:BuilderResourceID) { 0 } else { 480 }
+    $resolveWaitSeconds = if ($WaitForLate) {
+        $LateResourceWaitSeconds
+    } elseif ($script:BuilderID -or $script:BuilderResourceID) {
+        0
+    } else {
+        480
+    }
     $instance = Resolve-BuilderInstance -WaitSeconds $resolveWaitSeconds
     if (-not $instance) {
         Write-Host "No temporary builder record remains for $script:BuilderName"
@@ -574,11 +594,13 @@ function Remove-Builder {
 }
 
 function Remove-KeyPair {
+    param([switch]$WaitForLate)
+
     if (-not $script:KeyPairName -or -not $script:KeyPairCreateAttempted) {
         return
     }
 
-    $keyDiscoverySeconds = if ($WaitForLateResources) { 2 * 60 } else { 0 }
+    $keyDiscoverySeconds = if ($WaitForLate) { $LateResourceWaitSeconds } else { 0 }
     $keyDiscoveryDeadline = Get-BoundedDeadline `
         -RequestedSeconds $keyDiscoverySeconds `
         -Phase "temporary key pair discovery"
@@ -596,7 +618,7 @@ function Remove-KeyPair {
             @(Get-ResponseItems -Response $details -Name "results") |
                 Where-Object { [string]$_.keyPairName -eq $script:KeyPairName }
         )
-        if ($existing.Count -gt 0 -or -not $WaitForLateResources) {
+        if ($existing.Count -gt 0 -or -not $WaitForLate) {
             break
         }
         Start-Sleep -Seconds 5
@@ -638,7 +660,10 @@ function Remove-KeyPair {
 }
 
 function Remove-TemporaryResources {
-    param([switch]$Failure)
+    param(
+        [switch]$Failure,
+        [switch]$WaitForLate
+    )
 
     $errors = [Collections.Generic.List[string]]::new()
     if ($Failure) {
@@ -656,7 +681,7 @@ function Remove-TemporaryResources {
         )
     } else {
         try {
-            Remove-Builder
+            Remove-Builder -WaitForLate:$WaitForLate
         } catch {
             $errors.Add(
                 "builder cleanup (name=$script:BuilderName instanceID=$script:BuilderID resourceID=$script:BuilderResourceID): $($_.Exception.Message)"
@@ -664,7 +689,7 @@ function Remove-TemporaryResources {
         }
     }
     try {
-        Remove-KeyPair
+        Remove-KeyPair -WaitForLate:$WaitForLate
     } catch {
         $errors.Add(
             "key pair cleanup (name=$script:KeyPairName): $($_.Exception.Message)"
@@ -699,7 +724,7 @@ function Complete-PendingPublishedImage {
     $script:InCleanup = $true
     $script:CleanupDeadline = (Get-Date).AddMinutes($CleanupTimeoutMinutes)
 
-    Remove-TemporaryResources
+    Remove-TemporaryResources -WaitForLate
     Invoke-Ctyun @(
         "ims", "UpdateImage",
         "--regionID", $RegionID,
@@ -717,7 +742,7 @@ function Invoke-ExactBakeCleanup {
     $script:InCleanup = $true
     $script:CleanupDeadline = (Get-Date).AddMinutes($CleanupTimeoutMinutes)
 
-    $discoverySeconds = if ($WaitForLateResources) { 3 * 60 } else { 0 }
+    $discoverySeconds = if ($WaitForLateResources) { $LateResourceWaitSeconds } else { 0 }
     $discoveryDeadline = Get-BoundedDeadline `
         -RequestedSeconds $discoverySeconds `
         -Phase "exact bake resource discovery"
@@ -757,7 +782,9 @@ function Invoke-ExactBakeCleanup {
 
     $cleanupFailure = ""
     try {
-        Remove-TemporaryResources -Failure:$script:ImageCreateAttempted
+        Remove-TemporaryResources `
+            -Failure:$script:ImageCreateAttempted `
+            -WaitForLate:$WaitForLateResources
     } catch {
         $cleanupFailure = $_.Exception.Message
     }
@@ -1220,7 +1247,9 @@ bash /tmp/prepare-image.sh --finalize
     $script:InCleanup = $true
     $script:CleanupDeadline = (Get-Date).AddMinutes($CleanupTimeoutMinutes)
     try {
-        Remove-TemporaryResources -Failure:(-not $script:Completed)
+        Remove-TemporaryResources `
+            -Failure:(-not $script:Completed) `
+            -WaitForLate:$WaitForLateResources
     } catch {
         $cleanupFailure = $_.Exception.Message
     }

--- a/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
+++ b/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
@@ -739,7 +739,11 @@ function Complete-PendingPublishedImage {
     $script:BuilderResourceID = ""
     $script:BuilderCreateAttempted = $true
     $script:KeyPairID = ""
-    $script:KeyPairCreateAttempted = $false
+    # The pending image's bake marker and the key pair's unique temporary name
+    # both carry this bake ID, so the key pair is proven to belong to this bake
+    # and can be cleaned up by its unique name during recovery (Remove-KeyPair
+    # only deletes when the temporary name uniquely matches).
+    $script:KeyPairCreateAttempted = $true
     $script:InCleanup = $true
     $script:CleanupDeadline = (Get-Date).AddMinutes($CleanupTimeoutMinutes)
 

--- a/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
+++ b/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
@@ -804,33 +804,56 @@ function Invoke-ExactBakeCleanup {
         -RequestedSeconds $discoverySeconds `
         -Phase "exact bake resource discovery"
 
-    # Resolve the builder FIRST: its immutable instance ID is the ownership
-    # proof the image deletion depends on (sourceServerID match). The builder
-    # itself is deleted LAST so it stays as evidence while the image is being
-    # removed — the same ordering as the in-process finally path. Deleting the
-    # builder first would strand a genuinely owned image if image deletion
-    # cannot complete (un-deletable state, delete failure, or confirmation
-    # timeout), turning a recoverable leak into a permanent one.
-    $candidateBuilder = Resolve-BuilderInstance -WaitSeconds $discoverySeconds
+    # Aggregate first: a discovery API error must not skip the other resources.
+    $errors = [Collections.Generic.List[string]]::new()
+    $reconciled = [Collections.Generic.List[string]]::new()
+
+    # --- Builder discovery (independent try/catch + consecutive-empty reads).
+    # Its immutable instance ID is the ownership proof the image deletion
+    # depends on (sourceServerID match); the builder itself is deleted LAST so
+    # it stays as evidence while the image is being removed — the same ordering
+    # as the in-process finally path. ---
+    $candidateBuilder = $null
+    try {
+        $candidateBuilder = Resolve-BuilderInstance -WaitSeconds $discoverySeconds
+        if (-not $candidateBuilder -and -not $WaitForLateResources) {
+            $emptyReads = 1
+            while ($emptyReads -lt 3) {
+                Start-Sleep -Seconds 5
+                $candidateBuilder = Resolve-BuilderInstance
+                if ($candidateBuilder) { break }
+                $emptyReads++
+            }
+        }
+    } catch {
+        $errors.Add("builder discovery: $($_.Exception.Message)")
+    }
     if ($candidateBuilder) {
         $script:BuilderID = [string]$candidateBuilder.instanceID
         $script:BuilderName = [string]$candidateBuilder.instanceName
     }
 
+    # --- Image discovery (independent try/catch + consecutive-empty reads). ---
     $candidateImage = $null
-    do {
-        $candidateImage = Find-ImageByName -Name $script:ImageWorkName
-        if ($candidateImage -or -not $WaitForLateResources) { break }
-        Start-Sleep -Seconds 10
-    } while ((Get-Date) -lt $discoveryDeadline)
+    try {
+        $imageEmptyReads = 0
+        do {
+            $candidateImage = Find-ImageByName -Name $script:ImageWorkName
+            if ($candidateImage) { break }
+            $imageEmptyReads++
+            if (-not $WaitForLateResources -and $imageEmptyReads -ge 3) { break }
+            if ($WaitForLateResources -and (Get-Date) -ge $discoveryDeadline) { break }
+            Start-Sleep -Seconds 10
+        } while ($true)
+    } catch {
+        $errors.Add("image discovery: $($_.Exception.Message)")
+    }
 
     # Reconcile resources that can be uniquely proven to belong to this bake;
     # anything that cannot be proven stays fail-closed and is reported. A
     # process hard-killed at any creation boundary (key-only, builder-only,
     # image-only, published-pending) is recovered here instead of only being
     # discovered.
-    $errors = [Collections.Generic.List[string]]::new()
-    $reconciled = [Collections.Generic.List[string]]::new()
 
     # --- Image first: deletable only when sourceServerID matches the resolved
     # builder (same ownership proof as the in-process finally path). Without a
@@ -875,18 +898,27 @@ function Invoke-ExactBakeCleanup {
     # instead of aborting it. ---
     if ($script:KeyPairName) {
         try {
-            $keyDetails = Invoke-Ctyun @(
-                "ecs", "GetEcsKeypairDetails",
-                "--regionID", $RegionID,
-                "--projectID", $ProjectID,
-                "--keyPairName", $script:KeyPairName,
-                "--pageNo", "1",
-                "--pageSize", "10"
-            )
-            $candidateKeyPair = @(
-                @(Get-ResponseItems -Response $keyDetails -Name "results") |
-                    Where-Object { [string]$_.keyPairName -eq $script:KeyPairName }
-            )
+            $candidateKeyPair = @()
+            $keyEmptyReads = 0
+            do {
+                $keyDetails = Invoke-Ctyun @(
+                    "ecs", "GetEcsKeypairDetails",
+                    "--regionID", $RegionID,
+                    "--projectID", $ProjectID,
+                    "--keyPairName", $script:KeyPairName,
+                    "--pageNo", "1",
+                    "--pageSize", "10"
+                )
+                $candidateKeyPair = @(
+                    @(Get-ResponseItems -Response $keyDetails -Name "results") |
+                        Where-Object { [string]$_.keyPairName -eq $script:KeyPairName }
+                )
+                if ($candidateKeyPair.Count -gt 0) { break }
+                $keyEmptyReads++
+                if (-not $WaitForLateResources -and $keyEmptyReads -ge 3) { break }
+                if ($WaitForLateResources -and (Get-Date) -ge $discoveryDeadline) { break }
+                Start-Sleep -Seconds 5
+            } while ($true)
             if ($candidateKeyPair.Count -eq 1) {
                 $script:KeyPairCreateAttempted = $true
                 Remove-KeyPair -WaitForLate:$WaitForLateResources

--- a/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
+++ b/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
@@ -1,0 +1,540 @@
+[CmdletBinding()]
+param(
+    [ValidateSet("Plan", "Create")]
+    [string]$Mode = "Plan",
+
+    [Parameter(Mandatory = $true)]
+    [string]$RegionID,
+
+    [Parameter(Mandatory = $true)]
+    [string]$AzName,
+
+    [Parameter(Mandatory = $true)]
+    [string]$BaseImageID,
+
+    [Parameter(Mandatory = $true)]
+    [string]$FlavorID,
+
+    [Parameter(Mandatory = $true)]
+    [string]$VpcID,
+
+    [Parameter(Mandatory = $true)]
+    [string]$SubnetID,
+
+    [Parameter(Mandatory = $true)]
+    [string]$SecurityGroupID,
+
+    [string]$ProjectID = "0",
+    [string]$SourceRef = "HEAD",
+    [string]$ImageName = "",
+    [string]$ArtifactUrl = "",
+    [string]$ArtifactSha256 = "",
+    [string]$BootDiskType = "SATA",
+    [ValidateRange(40, 2048)]
+    [int]$BootDiskSize = 40,
+    [ValidateRange(1, 300)]
+    [int]$BuilderBandwidth = 5,
+    [ValidateRange(10, 120)]
+    [int]$TimeoutMinutes = 50,
+    [switch]$KeepBuilderOnFailure
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$script:BuilderID = ""
+$script:BuilderName = ""
+$script:BuilderResourceID = ""
+$script:BuilderIP = ""
+$script:KeyPairName = ""
+$script:TemporaryRoot = ""
+$script:Completed = $false
+
+function Invoke-External {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Command,
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments,
+        [switch]$Capture
+    )
+
+    if ($Capture) {
+        $output = & $Command @Arguments 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            throw "$Command failed with exit code $LASTEXITCODE`n$($output -join "`n")"
+        }
+        return ($output -join "`n")
+    }
+
+    & $Command @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Command failed with exit code $LASTEXITCODE"
+    }
+}
+
+function Invoke-Ctyun {
+    param([Parameter(Mandatory = $true)][string[]]$Arguments)
+
+    $raw = Invoke-External -Command "ctyun-cli" -Arguments ($Arguments + @("--output", "json")) -Capture
+    try {
+        $response = $raw | ConvertFrom-Json
+    } catch {
+        throw "ctyun-cli returned non-JSON output: $raw"
+    }
+    if ($response.statusCode -ne 800) {
+        throw "Tianyi Cloud API failed: $($response.errorCode) $($response.message) $($response.description)"
+    }
+    return $response
+}
+
+function Get-Instance {
+    param([Parameter(Mandatory = $true)][string]$InstanceID)
+
+    $response = Invoke-Ctyun @(
+        "ecs", "ListEcsInstances",
+        "--regionID", $RegionID,
+        "--instanceIDList", $InstanceID,
+        "--pageNo", "1",
+        "--pageSize", "10"
+    )
+    return @($response.returnObj.results) | Select-Object -First 1
+}
+
+function Assert-TemporaryBuilder {
+    param([Parameter(Mandatory = $true)]$Instance)
+
+    if (-not $Instance) {
+        throw "Temporary builder instance was not found"
+    }
+    if ($Instance.instanceID -ne $script:BuilderID) {
+        throw "Refusing to operate on an instance outside this bake"
+    }
+    if (-not [string]$Instance.instanceName -or -not $Instance.instanceName.StartsWith("catsco-img-")) {
+        throw "Refusing to operate on non-builder instance '$($Instance.instanceName)'"
+    }
+}
+
+function Wait-ForInstance {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$States,
+        [switch]$RequireIP
+    )
+
+    $deadline = (Get-Date).AddMinutes($TimeoutMinutes)
+    while ((Get-Date) -lt $deadline) {
+        $instance = Get-Instance -InstanceID $script:BuilderID
+        Assert-TemporaryBuilder $instance
+        $state = ([string]$instance.instanceStatus).ToLowerInvariant()
+        $ip = [string]$instance.floatingIP
+        Write-Host "builder state=$state ip=$ip"
+        if ($States -contains $state -and (-not $RequireIP -or $ip)) {
+            return $instance
+        }
+        Start-Sleep -Seconds 8
+    }
+    throw "Timed out waiting for builder state: $($States -join ', ')"
+}
+
+function Wait-ForSsh {
+    param(
+        [Parameter(Mandatory = $true)][string]$IP,
+        [Parameter(Mandatory = $true)][string]$PrivateKey,
+        [Parameter(Mandatory = $true)][string]$KnownHosts
+    )
+
+    $deadline = (Get-Date).AddMinutes(12)
+    while ((Get-Date) -lt $deadline) {
+        & ssh `
+            -i $PrivateKey `
+            -o BatchMode=yes `
+            -o ConnectTimeout=6 `
+            -o StrictHostKeyChecking=accept-new `
+            -o "UserKnownHostsFile=$KnownHosts" `
+            "root@$IP" "cloud-init status --wait >/dev/null 2>&1; printf ready" 2>$null
+        if ($LASTEXITCODE -eq 0) {
+            return
+        }
+        Start-Sleep -Seconds 8
+    }
+    throw "Timed out waiting for SSH on temporary builder"
+}
+
+function Remove-TemporaryResources {
+    param([switch]$Failure)
+
+    if ($Failure -and $KeepBuilderOnFailure) {
+        Write-Warning "Keeping temporary builder for diagnosis: $script:BuilderID ($script:BuilderIP)"
+        return
+    }
+
+    if ($script:BuilderID) {
+        try {
+            $instance = Get-Instance -InstanceID $script:BuilderID
+            if ($instance) {
+                Assert-TemporaryBuilder $instance
+                Write-Host "Deleting temporary builder $script:BuilderID"
+                Invoke-Ctyun @(
+                    "ecs", "DeleteEcsInstance",
+                    "--regionID", $RegionID,
+                    "--instanceID", $script:BuilderID,
+                    "--clientToken", ([guid]::NewGuid().ToString()),
+                    "--deleteEip", "true",
+                    "--deleteVolume", "true"
+                ) | Out-Null
+                $deleteDeadline = (Get-Date).AddMinutes(8)
+                while ((Get-Date) -lt $deleteDeadline) {
+                    Start-Sleep -Seconds 8
+                    try {
+                        $remaining = Get-Instance -InstanceID $script:BuilderID
+                        if (-not $remaining) {
+                            break
+                        }
+                        Assert-TemporaryBuilder $remaining
+                    } catch {
+                        if ($_.Exception.Message -match "not found|does not exist|不存在") {
+                            break
+                        }
+                        throw
+                    }
+                }
+            }
+        } catch {
+            Write-Warning "Could not delete temporary builder: $($_.Exception.Message)"
+        }
+    }
+
+    if ($script:KeyPairName) {
+        try {
+            Write-Host "Deleting temporary key pair $script:KeyPairName"
+            Invoke-Ctyun @(
+                "ecs", "DeleteEcsKeypair",
+                "--regionID", $RegionID,
+                "--keyPairName", $script:KeyPairName
+            ) | Out-Null
+        } catch {
+            Write-Warning "Could not delete temporary key pair: $($_.Exception.Message)"
+        }
+    }
+}
+
+foreach ($command in @("ctyun-cli", "git", "ssh", "scp", "ssh-keygen")) {
+    if (-not (Get-Command $command -ErrorAction SilentlyContinue)) {
+        throw "Missing required command: $command"
+    }
+}
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path
+$commit = (Invoke-External -Command "git" -Arguments @("-C", $repoRoot, "rev-parse", "$SourceRef^{commit}") -Capture).Trim()
+if ($commit -notmatch "^[0-9a-f]{40}$") {
+    throw "Could not resolve a full commit for $SourceRef"
+}
+
+$packageAtRef = Invoke-External -Command "git" -Arguments @("-C", $repoRoot, "show", "$commit`:package.json") -Capture
+$version = ($packageAtRef | ConvertFrom-Json).version
+if ($version -notmatch "^\d+\.\d+\.\d+([-.][0-9A-Za-z.-]+)?$") {
+    throw "Invalid package version at $commit"
+}
+
+$shortCommit = $commit.Substring(0, 8)
+$releaseId = "$version-$shortCommit"
+if (-not $ImageName) {
+    $ImageName = "catsco-worker-$($version.Replace('.', '-'))-$shortCommit"
+}
+if ($ImageName.Length -gt 32 -or $ImageName -notmatch "^[A-Za-z][A-Za-z0-9-]*[A-Za-z0-9]$") {
+    throw "Image name must satisfy Tianyi Cloud's 2-32 character name rules: $ImageName"
+}
+if ($ArtifactUrl) {
+    if ($ArtifactUrl -notmatch "^https://") {
+        throw "ArtifactUrl must use HTTPS"
+    }
+    if ($ArtifactSha256 -notmatch "^[0-9a-fA-F]{64}$") {
+        throw "ArtifactSha256 is required with ArtifactUrl"
+    }
+} elseif ($ArtifactSha256) {
+    throw "ArtifactSha256 cannot be used without ArtifactUrl"
+}
+
+$plan = [ordered]@{
+    mode = $Mode
+    sourceRef = $SourceRef
+    version = $version
+    commit = $commit
+    imageName = $ImageName
+    builderPrefix = "catsco-img-"
+    regionID = $RegionID
+    azName = $AzName
+    baseImageID = $BaseImageID
+    flavorID = $FlavorID
+    vpcID = $VpcID
+    subnetID = $SubnetID
+    securityGroupID = $SecurityGroupID
+    bootDisk = "$BootDiskType $BootDiskSize GiB"
+    artifactSource = $(if ($ArtifactUrl) { $ArtifactUrl } else { "local git archive built on temporary ECS" })
+    mutatesExistingWorkers = $false
+}
+$plan | ConvertTo-Json
+
+if ($Mode -eq "Plan") {
+    exit 0
+}
+
+$existing = Invoke-Ctyun @(
+    "ims", "ListImage",
+    "--regionID", $RegionID,
+    "--imageVisibilityCode", "0",
+    "--imageName", $ImageName,
+    "--pageNo", "1",
+    "--pageSize", "10"
+)
+if (@($existing.returnObj.images).Count -gt 0) {
+    throw "Private image already exists: $ImageName"
+}
+
+$script:TemporaryRoot = Join-Path ([IO.Path]::GetTempPath()) "catsco-image-$([guid]::NewGuid().ToString('N'))"
+New-Item -ItemType Directory -Path $script:TemporaryRoot | Out-Null
+$sourceArchive = Join-Path $script:TemporaryRoot "catsco-source.tar"
+$privateKey = Join-Path $script:TemporaryRoot "builder-rsa"
+$publicKeyPath = "$privateKey.pub"
+$knownHosts = Join-Path $script:TemporaryRoot "known_hosts"
+$remoteBuildScript = Join-Path $script:TemporaryRoot "build-image.sh"
+
+try {
+    if (-not $ArtifactUrl) {
+        Invoke-External -Command "git" -Arguments @(
+            "-C", $repoRoot,
+            "archive",
+            "--format=tar",
+            "--output=$sourceArchive",
+            $commit
+        )
+    }
+
+    Invoke-External -Command "ssh-keygen" -Arguments @(
+        "-q", "-t", "rsa", "-b", "3072",
+        "-N", "",
+        "-C", "catsco-image-builder-$shortCommit",
+        "-f", $privateKey
+    )
+    $publicKey = (Get-Content $publicKeyPath -Raw).Trim()
+    $script:KeyPairName = "catsco-img-key-$shortCommit-$((Get-Date).ToString('HHmmss'))"
+    Invoke-Ctyun @(
+        "ecs", "ImportEcsKeypair",
+        "--regionID", $RegionID,
+        "--projectID", $ProjectID,
+        "--keyPairName", $script:KeyPairName,
+        "--keyPairDescription", "Temporary CatsCo image builder",
+        "--publicKey", $publicKey
+    ) | Out-Null
+
+    $keyPairResponse = Invoke-Ctyun @(
+        "ecs", "GetEcsKeypairDetails",
+        "--regionID", $RegionID,
+        "--projectID", $ProjectID,
+        "--keyPairName", $script:KeyPairName,
+        "--pageNo", "1",
+        "--pageSize", "10"
+    )
+    $keyPair = @($keyPairResponse.returnObj.results) | Select-Object -First 1
+    if (-not $keyPair.keyPairID) {
+        throw "Imported key pair could not be resolved"
+    }
+
+    $script:BuilderName = "catsco-img-$shortCommit-$((Get-Date).ToString('HHmmss'))"
+    $createResponse = Invoke-Ctyun @(
+        "ecs", "CreateEcsInstance",
+        "--regionID", $RegionID,
+        "--projectID", $ProjectID,
+        "--clientToken", ([guid]::NewGuid().ToString()),
+        "--azName", $AzName,
+        "--displayName", $script:BuilderName,
+        "--instanceName", $script:BuilderName,
+        "--instanceDescription", "Temporary CatsCo image builder for $releaseId",
+        "--flavorID", $FlavorID,
+        "--imageID", $BaseImageID,
+        "--imageType", "1",
+        "--bootDiskType", $BootDiskType,
+        "--bootDiskSize", "$BootDiskSize",
+        "--vpcID", $VpcID,
+        "--networkCardList", "[{`"isMaster`":true,`"subnetID`":`"$SubnetID`"}]",
+        "--secGroupList", "[`"$SecurityGroupID`"]",
+        "--keyPairID", $keyPair.keyPairID,
+        "--onDemand", "true",
+        "--extIP", "1",
+        "--bandwidth", "$BuilderBandwidth",
+        "--ipVersion", "ipv4",
+        "--lineType", "standalone",
+        "--demandBillingType", "upflowc",
+        "--monitorService", "false",
+        "--securityProduct", "false",
+        "--trustInstance", "false",
+        "--labelList", "[{`"labelKey`":`"purpose`",`"labelValue`":`"catsco-image-builder`"},{`"labelKey`":`"commit`",`"labelValue`":`"$shortCommit`"}]"
+    )
+    $script:BuilderResourceID = [string]$createResponse.returnObj.masterResourceID
+    if (-not $script:BuilderResourceID) {
+        throw "CreateEcsInstance did not return masterResourceID"
+    }
+
+    $deadline = (Get-Date).AddMinutes($TimeoutMinutes)
+    while ((Get-Date) -lt $deadline -and -not $script:BuilderID) {
+        $lookup = Invoke-Ctyun @(
+            "ecs", "ListEcsInstances",
+            "--regionID", $RegionID,
+            "--resourceID", $script:BuilderResourceID,
+            "--pageNo", "1",
+            "--pageSize", "10"
+        )
+        $candidate = @($lookup.returnObj.results) | Select-Object -First 1
+        if ($candidate) {
+            if (-not ([string]$candidate.instanceName).StartsWith("catsco-img-")) {
+                throw "Resource lookup returned a non-builder instance"
+            }
+            $script:BuilderID = [string]$candidate.instanceID
+            break
+        }
+        Start-Sleep -Seconds 8
+    }
+    if (-not $script:BuilderID) {
+        throw "Timed out resolving the temporary builder instance"
+    }
+
+    $builder = Wait-ForInstance -States @("running", "active") -RequireIP
+    $script:BuilderIP = [string]$builder.floatingIP
+    Wait-ForSsh -IP $script:BuilderIP -PrivateKey $privateKey -KnownHosts $knownHosts
+
+    $artifactName = "catsco-worker-$releaseId-linux-x64.tar.gz"
+    if ($ArtifactUrl) {
+        $artifactPreparation = @"
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install -y --no-install-recommends ca-certificates curl nodejs npm
+curl --fail --location --retry 6 --retry-all-errors \
+  --connect-timeout 10 --max-time 900 \
+  '$ArtifactUrl' -o "`$ARTIFACT"
+SHA256='$ArtifactSha256'
+"@
+    } else {
+        $artifactPreparation = @"
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install -y --no-install-recommends build-essential ca-certificates nodejs npm python3
+npm config set registry https://registry.npmmirror.com
+
+rm -rf /tmp/catsco-source
+mkdir -p /tmp/catsco-source
+tar -xf /tmp/catsco-source.tar -C /tmp/catsco-source
+cd /tmp/catsco-source
+npm ci --ignore-scripts --prefer-offline --no-audit --fund=false
+npm run build
+node scripts/build-linux-worker-artifact.mjs --archive-source --output "`$ARTIFACT" --version "`$VERSION" --commit "`$COMMIT"
+SHA256="`$(awk '{print `$1}' "`$ARTIFACT.sha256")"
+"@
+    }
+    $remoteScriptContent = @"
+#!/usr/bin/env bash
+set -Eeuo pipefail
+VERSION='$version'
+COMMIT='$commit'
+ARTIFACT='/tmp/$artifactName'
+
+$artifactPreparation
+bash /tmp/prepare-image.sh \
+  --artifact "`$ARTIFACT" \
+  --sha256 "`$SHA256" \
+  --version "`$VERSION" \
+  --commit "`$COMMIT"
+rm -rf /tmp/catsco-source /tmp/catsco-source.tar "`$ARTIFACT" "`$ARTIFACT.sha256"
+bash /tmp/prepare-image.sh --finalize
+"@
+    [IO.File]::WriteAllText(
+        $remoteBuildScript,
+        $remoteScriptContent,
+        [Text.UTF8Encoding]::new($false)
+    )
+
+    $sshOptions = @(
+        "-i", $privateKey,
+        "-o", "BatchMode=yes",
+        "-o", "ConnectTimeout=10",
+        "-o", "StrictHostKeyChecking=accept-new",
+        "-o", "UserKnownHostsFile=$knownHosts"
+    )
+    $filesToCopy = @("$PSScriptRoot/prepare-image.sh", $remoteBuildScript)
+    if (-not $ArtifactUrl) {
+        $filesToCopy = @($sourceArchive) + $filesToCopy
+    }
+    Invoke-External -Command "scp" -Arguments ($sshOptions + $filesToCopy + @(
+        "root@$($script:BuilderIP):/tmp/"
+    ))
+    Invoke-External -Command "ssh" -Arguments ($sshOptions + @(
+        "root@$($script:BuilderIP)",
+        "chmod 700 /tmp/build-image.sh /tmp/prepare-image.sh && bash /tmp/build-image.sh"
+    ))
+
+    $builder = Get-Instance -InstanceID $script:BuilderID
+    Assert-TemporaryBuilder $builder
+    Invoke-Ctyun @(
+        "ecs", "StopEcsInstance",
+        "--regionID", $RegionID,
+        "--instanceID", $script:BuilderID,
+        "--force", "false"
+    ) | Out-Null
+    Wait-ForInstance -States @("stopped", "shutoff") | Out-Null
+
+    $imageResponse = Invoke-Ctyun @(
+        "ims", "CreateImage",
+        "--regionID", $RegionID,
+        "--projectID", $ProjectID,
+        "--instanceID", $script:BuilderID,
+        "--imageName", $ImageName,
+        "--description", "CatsCo worker $version commit $commit",
+        "--enableImageIntegrityCheck", "true",
+        "--labels", "[{`"labelKey`":`"product`",`"labelValue`":`"catsco-worker`"},{`"labelKey`":`"version`",`"labelValue`":`"$version`"},{`"labelKey`":`"commit`",`"labelValue`":`"$commit`"}]"
+    )
+    $image = @($imageResponse.returnObj.images) | Select-Object -First 1
+    $imageID = [string]$image.imageID
+    if (-not $imageID) {
+        throw "CreateImage did not return an image ID"
+    }
+
+    $deadline = (Get-Date).AddMinutes($TimeoutMinutes)
+    while ((Get-Date) -lt $deadline) {
+        $detail = Invoke-Ctyun @(
+            "ims", "GetImageDetail",
+            "--regionID", $RegionID,
+            "--imageID", $imageID,
+            "--errorFree", "false"
+        )
+        $currentImage = @($detail.returnObj.images) | Select-Object -First 1
+        $status = ([string]$currentImage.imageStatus).ToLowerInvariant()
+        Write-Host "image state=$status progress=$($currentImage.taskProgress)"
+        if ($status -eq "active") {
+            $script:Completed = $true
+            [ordered]@{
+                result = "created"
+                imageID = $imageID
+                imageName = $ImageName
+                version = $version
+                commit = $commit
+                regionID = $RegionID
+            } | ConvertTo-Json
+            break
+        }
+        if ($status -in @("error", "killed", "deleted")) {
+            throw "Image creation entered terminal failure state: $status"
+        }
+        Start-Sleep -Seconds 15
+    }
+    if (-not $script:Completed) {
+        throw "Timed out waiting for private image creation"
+    }
+} catch {
+    Write-Error $_
+    throw
+} finally {
+    Remove-TemporaryResources -Failure:(-not $script:Completed)
+    if ($script:TemporaryRoot -and (Test-Path $script:TemporaryRoot)) {
+        Remove-Item -LiteralPath $script:TemporaryRoot -Recurse -Force
+    }
+}

--- a/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
+++ b/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
@@ -63,6 +63,7 @@ $script:BuilderResourceID = ""
 $script:BuilderIP = ""
 $script:BuilderCreateAttempted = $false
 $script:KeyPairName = ""
+$script:KeyPairID = ""
 $script:KeyPairCreateAttempted = $false
 $script:TemporaryRoot = ""
 $script:ImageID = ""
@@ -552,17 +553,12 @@ function Remove-FailedImage {
 function Remove-Builder {
     param([switch]$WaitForLate)
 
-    if (-not $script:BuilderCreateAttempted -and -not $script:BuilderID) {
+    if (-not $script:BuilderID -and -not $script:BuilderResourceID) {
+        Write-Warning "Skipping builder cleanup because no immutable builder identity was recorded"
         return
     }
 
-    $resolveWaitSeconds = if ($WaitForLate) {
-        $LateResourceWaitSeconds
-    } elseif ($script:BuilderID -or $script:BuilderResourceID) {
-        0
-    } else {
-        480
-    }
+    $resolveWaitSeconds = if ($WaitForLate) { $LateResourceWaitSeconds } else { 0 }
     $instance = Resolve-BuilderInstance -WaitSeconds $resolveWaitSeconds
     if (-not $instance) {
         Write-Host "No temporary builder record remains for $script:BuilderName"
@@ -596,7 +592,8 @@ function Remove-Builder {
 function Remove-KeyPair {
     param([switch]$WaitForLate)
 
-    if (-not $script:KeyPairName -or -not $script:KeyPairCreateAttempted) {
+    if (-not $script:KeyPairName -or -not $script:KeyPairID) {
+        Write-Warning "Skipping key pair cleanup because no immutable key pair identity was recorded"
         return
     }
 
@@ -627,8 +624,16 @@ function Remove-KeyPair {
         Write-Host "No temporary key pair record remains for $script:KeyPairName"
         return
     }
+    $ownedKeyPairs = @(
+        $existing | Where-Object {
+            [string](Get-PropertyValue -InputObject $_ -Name "keyPairID") -eq $script:KeyPairID
+        }
+    )
+    if ($ownedKeyPairs.Count -ne 1 -or $existing.Count -ne 1) {
+        throw "Refusing to delete key pair because name and immutable ID do not uniquely match this bake"
+    }
 
-    Write-Host "Deleting temporary key pair $script:KeyPairName"
+    Write-Host "Deleting temporary key pair $script:KeyPairName ($script:KeyPairID)"
     Invoke-Ctyun @(
         "ecs", "DeleteEcsKeypair",
         "--regionID", $RegionID,
@@ -720,7 +725,8 @@ function Complete-PendingPublishedImage {
     $script:BuilderID = [string]$PendingImage.sourceServerID
     $script:BuilderResourceID = ""
     $script:BuilderCreateAttempted = $true
-    $script:KeyPairCreateAttempted = $true
+    $script:KeyPairID = ""
+    $script:KeyPairCreateAttempted = $false
     $script:InCleanup = $true
     $script:CleanupDeadline = (Get-Date).AddMinutes($CleanupTimeoutMinutes)
 
@@ -746,55 +752,31 @@ function Invoke-ExactBakeCleanup {
     $discoveryDeadline = Get-BoundedDeadline `
         -RequestedSeconds $discoverySeconds `
         -Phase "exact bake resource discovery"
-    $builder = Resolve-BuilderInstance -WaitSeconds $discoverySeconds
-    if ($builder) {
-        Assert-TemporaryBuilder $builder
-        $script:BuilderID = [string]$builder.instanceID
-        $script:BuilderCreateAttempted = $true
-    }
-
     $candidateImage = $null
     do {
         $candidateImage = Find-ImageByName -Name $script:ImageWorkName
-        if ($candidateImage -or -not $WaitForLateResources) {
-            break
-        }
+        if ($candidateImage -or -not $WaitForLateResources) { break }
         Start-Sleep -Seconds 10
     } while ((Get-Date) -lt $discoveryDeadline)
 
-    $imageOwnershipFailure = ""
-    if ($candidateImage) {
-        if (
-            [string]$candidateImage.imageName -ne $script:ImageWorkName -or
-            -not $script:BuilderID -or
-            [string]$candidateImage.sourceServerID -ne $script:BuilderID -or
-            [string]$candidateImage.description -ne $script:BakeDescription
-        ) {
-            $imageOwnershipFailure = (
-                "Refusing exact cleanup because the temporary image ownership metadata does not match"
-            )
-        } else {
-            $script:ImageID = [string]$candidateImage.imageID
-            $script:ImageCreateAttempted = $true
+    $candidateBuilder = Resolve-BuilderInstance -WaitSeconds $discoverySeconds
+    if ($candidateImage -or $candidateBuilder) {
+        $details = @(
+            "Automatic historical cleanup refused because immutable creation IDs were not persisted."
+            "Review and remove only resources proven to belong to bake $script:BakeID."
+        )
+        if ($candidateImage) {
+            $details += "candidate imageID=$($candidateImage.imageID) name=$($candidateImage.imageName)"
         }
+        if ($candidateBuilder) {
+            $details += "candidate instanceID=$($candidateBuilder.instanceID) name=$($candidateBuilder.instanceName)"
+        }
+        throw ($details -join " ")
     }
-    $script:KeyPairCreateAttempted = $true
 
-    $cleanupFailure = ""
-    try {
-        Remove-TemporaryResources `
-            -Failure:$script:ImageCreateAttempted `
-            -WaitForLate:$WaitForLateResources
-    } catch {
-        $cleanupFailure = $_.Exception.Message
-    }
-    if ($imageOwnershipFailure -or $cleanupFailure) {
-        throw (@($imageOwnershipFailure, $cleanupFailure) |
-            Where-Object { $_ } |
-            ForEach-Object { $_ }) -join "`n"
-    }
+    Write-Warning "No provably owned historical resources found; key pair lookup was skipped because names are not ownership proof"
     return [ordered]@{
-        result = "cleaned"
+        result = "nothing-to-clean"
         bakeID = $script:BakeID
         temporaryImageName = $script:ImageWorkName
         builderName = $script:BuilderName
@@ -815,7 +797,9 @@ if ($Mode -in @("Create", "Cleanup")) {
 }
 
 $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path
-$commit = (Invoke-External -Command "git" -Arguments @("-C", $repoRoot, "rev-parse", "$SourceRef^{commit}") -Capture).Trim()
+$commit = (Invoke-External -Command "git" -Arguments @(
+    "-C", $repoRoot, "rev-list", "--max-count=1", $SourceRef
+) -Capture).Trim()
 if ($commit -notmatch "^[0-9a-f]{40}$") {
     throw "Could not resolve a full commit for $SourceRef"
 }
@@ -1003,7 +987,6 @@ try {
         throw "Temporary key pair name is already in use: $script:KeyPairName"
     }
 
-    $script:KeyPairCreateAttempted = $true
     Invoke-Ctyun @(
         "ecs", "ImportEcsKeypair",
         "--regionID", $RegionID,
@@ -1024,12 +1007,13 @@ try {
     $keyPair = @(Get-ResponseItems -Response $keyPairResponse -Name "results") |
         Where-Object { [string]$_.keyPairName -eq $script:KeyPairName } |
         Select-Object -First 1
-    $keyPairID = [string](
+    $script:KeyPairID = [string](
         Get-PropertyValue -InputObject $keyPair -Name "keyPairID"
     )
-    if (-not $keyPairID) {
+    if (-not $script:KeyPairID) {
         throw "Imported key pair could not be resolved"
     }
+    $script:KeyPairCreateAttempted = $true
 
     $existingBuilderResponse = Invoke-Ctyun @(
         "ecs", "ListEcsInstances",
@@ -1046,7 +1030,6 @@ try {
         throw "Temporary builder name is already in use: $script:BuilderName"
     }
 
-    $script:BuilderCreateAttempted = $true
     $createResponse = Invoke-Ctyun @(
         "ecs", "CreateEcsInstance",
         "--regionID", $RegionID,
@@ -1064,7 +1047,7 @@ try {
         "--vpcID", $VpcID,
         "--networkCardList", "[{`"isMaster`":true,`"subnetID`":`"$SubnetID`"}]",
         "--secGroupList", "[`"$SecurityGroupID`"]",
-        "--keyPairID", $keyPairID,
+        "--keyPairID", $script:KeyPairID,
         "--onDemand", "true",
         "--extIP", "1",
         "--bandwidth", "$BuilderBandwidth",
@@ -1085,6 +1068,7 @@ try {
     if (-not $script:BuilderResourceID) {
         throw "CreateEcsInstance did not return masterResourceID"
     }
+    $script:BuilderCreateAttempted = $true
 
     $builder = Resolve-BuilderInstance -WaitSeconds ($TimeoutMinutes * 60)
     if (-not $builder) {

--- a/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
+++ b/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
@@ -1008,6 +1008,10 @@ try {
         "--keyPairDescription", "Temporary CatsCo image builder",
         "--publicKey", $publicKey
     ) | Out-Null
+    # Mark the key pair as created right after a successful import so a failure
+    # in the follow-up identity resolution (KeyPairID empty) still allows
+    # name-based cleanup instead of leaking the cloud key pair.
+    $script:KeyPairCreateAttempted = $true
 
     $keyPairResponse = Invoke-Ctyun @(
         "ecs", "GetEcsKeypairDetails",
@@ -1026,7 +1030,6 @@ try {
     if (-not $script:KeyPairID) {
         throw "Imported key pair could not be resolved"
     }
-    $script:KeyPairCreateAttempted = $true
 
     $existingBuilderResponse = Invoke-Ctyun @(
         "ecs", "ListEcsInstances",

--- a/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
+++ b/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 param(
-    [ValidateSet("Plan", "Create")]
+    [ValidateSet("Plan", "Create", "Cleanup")]
     [string]$Mode = "Plan",
 
     [Parameter(Mandatory = $true)]
@@ -31,6 +31,7 @@ param(
     [string]$ArtifactSha256 = "",
     [string]$BuildNumber = "",
     [string]$BuildAttempt = "1",
+    [string]$BuildIdentity = "",
     [string]$BootDiskType = "SATA",
     [ValidateRange(40, 2048)]
     [int]$BootDiskSize = 40,
@@ -41,7 +42,14 @@ param(
     [ValidateRange(10, 90)]
     [int]$RemoteBuildTimeoutMinutes = 45,
     [ValidateRange(10, 60)]
-    [int]$ArtifactTransferTimeoutMinutes = 30
+    [int]$ArtifactTransferTimeoutMinutes = 30,
+    [ValidateRange(60, 300)]
+    [int]$BakeTimeoutMinutes = 240,
+    [ValidateRange(10, 90)]
+    [int]$CleanupTimeoutMinutes = 45,
+    [ValidateRange(15, 300)]
+    [int]$ApiTimeoutSeconds = 90,
+    [switch]$WaitForLateResources
 )
 
 $ErrorActionPreference = "Stop"
@@ -58,7 +66,14 @@ $script:TemporaryRoot = ""
 $script:ImageID = ""
 $script:ImageCreateAttempted = $false
 $script:ImageActive = $false
+$script:PreserveBuilderForImageRecovery = $false
 $script:Completed = $false
+$script:BakeID = ""
+$script:ImageWorkName = ""
+$script:BakeDescription = ""
+$script:OperationDeadline = $null
+$script:CleanupDeadline = $null
+$script:InCleanup = $false
 
 function Invoke-External {
     param(
@@ -88,7 +103,15 @@ function Invoke-External {
 function Invoke-Ctyun {
     param([Parameter(Mandatory = $true)][string[]]$Arguments)
 
-    $raw = Invoke-External -Command "ctyun-cli" -Arguments ($Arguments + @("--output", "json")) -Capture
+    $timeoutSeconds = Get-BoundedTimeoutSeconds `
+        -RequestedSeconds $ApiTimeoutSeconds `
+        -Phase "Tianyi Cloud API call"
+    $raw = Invoke-External -Command "timeout" -Arguments (@(
+        "--signal=TERM",
+        "--kill-after=15s",
+        "$($timeoutSeconds)s",
+        "ctyun-cli"
+    ) + $Arguments + @("--output", "json")) -Capture
     try {
         $response = $raw | ConvertFrom-Json
     } catch {
@@ -98,6 +121,57 @@ function Invoke-Ctyun {
         throw "Tianyi Cloud API failed: $($response.errorCode) $($response.message) $($response.description)"
     }
     return $response
+}
+
+function Get-ActiveDeadline {
+    if ($script:InCleanup) {
+        return $script:CleanupDeadline
+    }
+    return $script:OperationDeadline
+}
+
+function Get-BoundedTimeoutSeconds {
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateRange(1, 86400)]
+        [int]$RequestedSeconds,
+        [Parameter(Mandatory = $true)]
+        [string]$Phase
+    )
+
+    $deadline = Get-ActiveDeadline
+    if (-not $deadline) {
+        return $RequestedSeconds
+    }
+    $remaining = [int][Math]::Floor(($deadline - (Get-Date)).TotalSeconds)
+    if ($remaining -lt 1) {
+        throw "$Phase cannot start because the current bake deadline has expired"
+    }
+    return [Math]::Max(1, [Math]::Min($RequestedSeconds, $remaining))
+}
+
+function Get-BoundedDeadline {
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateRange(0, 86400)]
+        [int]$RequestedSeconds,
+        [Parameter(Mandatory = $true)]
+        [string]$Phase
+    )
+
+    if ($RequestedSeconds -eq 0) {
+        return Get-Date
+    }
+
+    $deadline = (Get-Date).AddSeconds($RequestedSeconds)
+    $activeDeadline = Get-ActiveDeadline
+    if ($activeDeadline -and $activeDeadline -lt $deadline) {
+        $deadline = $activeDeadline
+    }
+    if ($deadline -le (Get-Date)) {
+        throw "$Phase cannot start because the current bake deadline has expired"
+    }
+    return $deadline
 }
 
 function Test-NotFoundError {
@@ -161,7 +235,9 @@ function Find-BuilderInstance {
 function Resolve-BuilderInstance {
     param([ValidateRange(0, 7200)][int]$WaitSeconds = 0)
 
-    $deadline = (Get-Date).AddSeconds($WaitSeconds)
+    $deadline = Get-BoundedDeadline `
+        -RequestedSeconds $WaitSeconds `
+        -Phase "temporary builder resolution"
     do {
         if ($script:BuilderID) {
             try {
@@ -174,6 +250,9 @@ function Resolve-BuilderInstance {
                     throw
                 }
             }
+            # Once the provider returned an authoritative instance ID, never
+            # fall back to a possibly reused instance name.
+            return $null
         }
 
         $resolved = Find-BuilderInstance
@@ -213,7 +292,9 @@ function Wait-ForInstance {
         [switch]$RequireIP
     )
 
-    $deadline = (Get-Date).AddMinutes($TimeoutMinutes)
+    $deadline = Get-BoundedDeadline `
+        -RequestedSeconds ($TimeoutMinutes * 60) `
+        -Phase "temporary builder state wait"
     while ((Get-Date) -lt $deadline) {
         $instance = Resolve-BuilderInstance
         Assert-TemporaryBuilder $instance
@@ -235,7 +316,9 @@ function Wait-ForSsh {
         [Parameter(Mandatory = $true)][string]$KnownHosts
     )
 
-    $deadline = (Get-Date).AddMinutes(12)
+    $deadline = Get-BoundedDeadline `
+        -RequestedSeconds (12 * 60) `
+        -Phase "temporary builder SSH wait"
     while ((Get-Date) -lt $deadline) {
         & ssh `
             -i $PrivateKey `
@@ -245,7 +328,7 @@ function Wait-ForSsh {
             -o ServerAliveCountMax=3 `
             -o StrictHostKeyChecking=accept-new `
             -o "UserKnownHostsFile=$KnownHosts" `
-            "root@$IP" "timeout --signal=TERM --kill-after=15s 90s cloud-init status --wait >/dev/null 2>&1; printf ready" 2>$null
+            "root@$IP" "timeout --signal=TERM --kill-after=15s 90s cloud-init status --wait >/dev/null 2>&1 && printf ready" 2>$null
         if ($LASTEXITCODE -eq 0) {
             return
         }
@@ -274,17 +357,46 @@ function Get-Image {
 }
 
 function Find-ImageByName {
+    param([Parameter(Mandatory = $true)][string]$Name)
+
     $response = Invoke-Ctyun @(
         "ims", "ListImage",
         "--regionID", $RegionID,
         "--imageVisibilityCode", "0",
-        "--imageName", $ImageName,
+        "--imageName", $Name,
+        "--projectID", $ProjectID,
         "--pageNo", "1",
-        "--pageSize", "10"
+        "--pageSize", "200"
     )
     return @($response.returnObj.images) |
-        Where-Object { [string]$_.imageName -eq $ImageName } |
+        Where-Object { [string]$_.imageName -eq $Name } |
         Select-Object -First 1
+}
+
+function Wait-ForPublishedImageIdentity {
+    param(
+        [Parameter(Mandatory = $true)][string]$PublishedImageID,
+        [Parameter(Mandatory = $true)][string]$PublishedImageName,
+        [Parameter(Mandatory = $true)][string]$PublishedDescription
+    )
+
+    $publishDeadline = Get-BoundedDeadline `
+        -RequestedSeconds (2 * 60) `
+        -Phase "published image identity verification"
+    do {
+        $candidate = Get-Image -ImageID $PublishedImageID
+        if (
+            $candidate -and
+            ([string]$candidate.imageStatus).ToLowerInvariant() -eq "active" -and
+            [string]$candidate.imageName -eq $PublishedImageName -and
+            [string]$candidate.description -eq $PublishedDescription
+        ) {
+            return $candidate
+        }
+        Start-Sleep -Seconds 5
+    } while ((Get-Date) -lt $publishDeadline)
+
+    throw "Could not verify the published private image identity"
 }
 
 function Remove-FailedImage {
@@ -292,23 +404,57 @@ function Remove-FailedImage {
         return
     }
 
+    # Keep the source builder as ownership evidence until the image is gone.
+    $script:PreserveBuilderForImageRecovery = $true
     if (-not $script:ImageID) {
-        $resolveDeadline = (Get-Date).AddMinutes(3)
+        $resolveDeadline = Get-BoundedDeadline `
+            -RequestedSeconds (3 * 60) `
+            -Phase "incomplete image resolution"
         while ((Get-Date) -lt $resolveDeadline -and -not $script:ImageID) {
-            $candidate = Find-ImageByName
+            $candidate = Find-ImageByName -Name $script:ImageWorkName
             if ($candidate) {
+                if (
+                    -not $script:BuilderID -or
+                    [string]$candidate.sourceServerID -ne $script:BuilderID
+                ) {
+                    $script:PreserveBuilderForImageRecovery = $false
+                    throw (
+                        "Refusing to delete image '$($candidate.imageID)' because " +
+                        "sourceServerID '$($candidate.sourceServerID)' does not match " +
+                        "this bake's builder '$script:BuilderID'"
+                    )
+                }
                 $script:ImageID = [string]$candidate.imageID
                 break
             }
             Start-Sleep -Seconds 10
         }
         if (-not $script:ImageID) {
-            Write-Host "No incomplete image record appeared for $ImageName"
-            return
+            throw "Could not prove absence of incomplete image $script:ImageWorkName"
         }
     }
 
-    $deadline = (Get-Date).AddMinutes(12)
+    $ownedImage = Get-Image -ImageID $script:ImageID
+    if (-not $ownedImage) {
+        $script:PreserveBuilderForImageRecovery = $false
+        return
+    }
+    if (
+        [string]$ownedImage.imageName -ne $script:ImageWorkName -or
+        -not $script:BuilderID -or
+        [string]$ownedImage.sourceServerID -ne $script:BuilderID -or
+        [string]$ownedImage.description -ne $script:BakeDescription
+    ) {
+        $script:PreserveBuilderForImageRecovery = $false
+        throw (
+            "Refusing to delete image '$script:ImageID' because its name, " +
+            "sourceServerID, or bake description does not belong to this bake"
+        )
+    }
+
+    $deadline = Get-BoundedDeadline `
+        -RequestedSeconds (12 * 60) `
+        -Phase "incomplete image deletable-state wait"
     $deletableStates = @(
         "active", "deactivated", "deactivating", "deleting",
         "error", "killed", "reactivating"
@@ -316,11 +462,13 @@ function Remove-FailedImage {
     while ((Get-Date) -lt $deadline) {
         $image = Get-Image -ImageID $script:ImageID
         if (-not $image) {
+            $script:PreserveBuilderForImageRecovery = $false
             return
         }
         $status = ([string]$image.imageStatus).ToLowerInvariant()
         Write-Host "failed image cleanup state=$status"
         if ($status -eq "deleted") {
+            $script:PreserveBuilderForImageRecovery = $false
             return
         }
         if ($status -in $deletableStates) {
@@ -337,10 +485,13 @@ function Remove-FailedImage {
         Start-Sleep -Seconds 15
     }
 
-    $deleteDeadline = (Get-Date).AddMinutes(8)
+    $deleteDeadline = Get-BoundedDeadline `
+        -RequestedSeconds (8 * 60) `
+        -Phase "incomplete image deletion confirmation"
     while ((Get-Date) -lt $deleteDeadline) {
         $remaining = Get-Image -ImageID $script:ImageID
         if (-not $remaining -or ([string]$remaining.imageStatus).ToLowerInvariant() -eq "deleted") {
+            $script:PreserveBuilderForImageRecovery = $false
             return
         }
         Start-Sleep -Seconds 10
@@ -353,9 +504,11 @@ function Remove-Builder {
         return
     }
 
-    $instance = Resolve-BuilderInstance -WaitSeconds 480
+    $resolveWaitSeconds = if ($script:BuilderID -or $script:BuilderResourceID) { 0 } else { 480 }
+    $instance = Resolve-BuilderInstance -WaitSeconds $resolveWaitSeconds
     if (-not $instance) {
-        throw "Could not prove cleanup of builder name=$script:BuilderName resourceID=$script:BuilderResourceID"
+        Write-Host "No temporary builder record remains for $script:BuilderName"
+        return
     }
     Assert-TemporaryBuilder $instance
     Write-Host "Deleting temporary builder $script:BuilderID"
@@ -368,7 +521,9 @@ function Remove-Builder {
         "--deleteVolume", "true"
     ) | Out-Null
 
-    $deadline = (Get-Date).AddMinutes(8)
+    $deadline = Get-BoundedDeadline `
+        -RequestedSeconds (8 * 60) `
+        -Phase "temporary builder deletion confirmation"
     while ((Get-Date) -lt $deadline) {
         $remaining = Resolve-BuilderInstance
         if (-not $remaining) {
@@ -385,6 +540,34 @@ function Remove-KeyPair {
         return
     }
 
+    $keyDiscoverySeconds = if ($WaitForLateResources) { 2 * 60 } else { 0 }
+    $keyDiscoveryDeadline = Get-BoundedDeadline `
+        -RequestedSeconds $keyDiscoverySeconds `
+        -Phase "temporary key pair discovery"
+    $existing = @()
+    do {
+        $details = Invoke-Ctyun @(
+            "ecs", "GetEcsKeypairDetails",
+            "--regionID", $RegionID,
+            "--projectID", $ProjectID,
+            "--keyPairName", $script:KeyPairName,
+            "--pageNo", "1",
+            "--pageSize", "10"
+        )
+        $existing = @(
+            @($details.returnObj.results) |
+                Where-Object { [string]$_.keyPairName -eq $script:KeyPairName }
+        )
+        if ($existing.Count -gt 0 -or -not $WaitForLateResources) {
+            break
+        }
+        Start-Sleep -Seconds 5
+    } while ((Get-Date) -lt $keyDiscoveryDeadline)
+    if ($existing.Count -eq 0) {
+        Write-Host "No temporary key pair record remains for $script:KeyPairName"
+        return
+    }
+
     Write-Host "Deleting temporary key pair $script:KeyPairName"
     Invoke-Ctyun @(
         "ecs", "DeleteEcsKeypair",
@@ -392,7 +575,9 @@ function Remove-KeyPair {
         "--keyPairName", $script:KeyPairName
     ) | Out-Null
 
-    $deadline = (Get-Date).AddMinutes(2)
+    $deadline = Get-BoundedDeadline `
+        -RequestedSeconds (2 * 60) `
+        -Phase "temporary key pair deletion confirmation"
     while ((Get-Date) -lt $deadline) {
         $details = Invoke-Ctyun @(
             "ecs", "GetEcsKeypairDetails",
@@ -423,16 +608,22 @@ function Remove-TemporaryResources {
             Remove-FailedImage
         } catch {
             $errors.Add(
-                "image cleanup (name=$ImageName imageID=$script:ImageID): $($_.Exception.Message)"
+                "image cleanup (name=$script:ImageWorkName imageID=$script:ImageID): $($_.Exception.Message)"
             )
         }
     }
-    try {
-        Remove-Builder
-    } catch {
+    if ($script:PreserveBuilderForImageRecovery) {
         $errors.Add(
-            "builder cleanup (name=$script:BuilderName instanceID=$script:BuilderID resourceID=$script:BuilderResourceID): $($_.Exception.Message)"
+            "builder cleanup deferred because the source builder is still required to prove incomplete image ownership"
         )
+    } else {
+        try {
+            Remove-Builder
+        } catch {
+            $errors.Add(
+                "builder cleanup (name=$script:BuilderName instanceID=$script:BuilderID resourceID=$script:BuilderResourceID): $($_.Exception.Message)"
+            )
+        }
     }
     try {
         Remove-KeyPair
@@ -447,10 +638,110 @@ function Remove-TemporaryResources {
     }
 }
 
+function Complete-PendingPublishedImage {
+    param(
+        [Parameter(Mandatory = $true)]$PendingImage,
+        [Parameter(Mandatory = $true)][string]$PendingBakeID,
+        [Parameter(Mandatory = $true)][string]$FinalDescription
+    )
+
+    if (
+        $PendingBakeID -notmatch "^(?:\d{6,}-\d{2,}|\d{12}-[0-9a-f]{8})$" -or
+        -not $PendingImage.sourceServerID
+    ) {
+        throw "Published image has invalid pending cleanup ownership metadata"
+    }
+
+    $script:BuilderName = "catsco-img-$PendingBakeID"
+    $script:KeyPairName = "catsco-img-key-$PendingBakeID"
+    $script:BuilderID = [string]$PendingImage.sourceServerID
+    $script:BuilderResourceID = ""
+    $script:BuilderCreateAttempted = $true
+    $script:KeyPairCreateAttempted = $true
+    $script:InCleanup = $true
+    $script:CleanupDeadline = (Get-Date).AddMinutes($CleanupTimeoutMinutes)
+
+    Remove-TemporaryResources
+    Invoke-Ctyun @(
+        "ims", "UpdateImage",
+        "--regionID", $RegionID,
+        "--imageID", ([string]$PendingImage.imageID),
+        "--imageName", $ImageName,
+        "--description", $FinalDescription
+    ) | Out-Null
+    return Wait-ForPublishedImageIdentity `
+        -PublishedImageID ([string]$PendingImage.imageID) `
+        -PublishedImageName $ImageName `
+        -PublishedDescription $FinalDescription
+}
+
+function Invoke-ExactBakeCleanup {
+    $script:InCleanup = $true
+    $script:CleanupDeadline = (Get-Date).AddMinutes($CleanupTimeoutMinutes)
+
+    $discoverySeconds = if ($WaitForLateResources) { 3 * 60 } else { 0 }
+    $discoveryDeadline = Get-BoundedDeadline `
+        -RequestedSeconds $discoverySeconds `
+        -Phase "exact bake resource discovery"
+    $builder = Resolve-BuilderInstance -WaitSeconds $discoverySeconds
+    if ($builder) {
+        Assert-TemporaryBuilder $builder
+        $script:BuilderID = [string]$builder.instanceID
+        $script:BuilderCreateAttempted = $true
+    }
+
+    $candidateImage = $null
+    do {
+        $candidateImage = Find-ImageByName -Name $script:ImageWorkName
+        if ($candidateImage -or -not $WaitForLateResources) {
+            break
+        }
+        Start-Sleep -Seconds 10
+    } while ((Get-Date) -lt $discoveryDeadline)
+
+    $imageOwnershipFailure = ""
+    if ($candidateImage) {
+        if (
+            [string]$candidateImage.imageName -ne $script:ImageWorkName -or
+            -not $script:BuilderID -or
+            [string]$candidateImage.sourceServerID -ne $script:BuilderID -or
+            [string]$candidateImage.description -ne $script:BakeDescription
+        ) {
+            $imageOwnershipFailure = (
+                "Refusing exact cleanup because the temporary image ownership metadata does not match"
+            )
+        } else {
+            $script:ImageID = [string]$candidateImage.imageID
+            $script:ImageCreateAttempted = $true
+        }
+    }
+    $script:KeyPairCreateAttempted = $true
+
+    $cleanupFailure = ""
+    try {
+        Remove-TemporaryResources -Failure:$script:ImageCreateAttempted
+    } catch {
+        $cleanupFailure = $_.Exception.Message
+    }
+    if ($imageOwnershipFailure -or $cleanupFailure) {
+        throw (@($imageOwnershipFailure, $cleanupFailure) |
+            Where-Object { $_ } |
+            ForEach-Object { $_ }) -join "`n"
+    }
+    return [ordered]@{
+        result = "cleaned"
+        bakeID = $script:BakeID
+        temporaryImageName = $script:ImageWorkName
+        builderName = $script:BuilderName
+        keyPairName = $script:KeyPairName
+        regionID = $RegionID
+    }
+}
+
 if (-not (Get-Command "git" -ErrorAction SilentlyContinue)) {
     throw "Missing required command: git"
 }
-if ($Mode -eq "Create") {
+if ($Mode -in @("Create", "Cleanup")) {
     foreach ($command in @("ctyun-cli", "ssh", "scp", "ssh-keygen", "timeout")) {
         if (-not (Get-Command $command -ErrorAction SilentlyContinue)) {
             throw "Missing required command: $command"
@@ -491,11 +782,36 @@ if ($BuildNumber) {
         throw "BuildNumber and BuildAttempt must be positive integers"
     }
     $builderSuffix = "$($buildSequence.ToString('D6'))-$($attemptSequence.ToString('D2'))"
+    if (-not $BuildIdentity) {
+        $BuildIdentity = $BuildNumber
+    }
+    $bakeTokenBytes = [Text.Encoding]::UTF8.GetBytes(
+        "$BuildIdentity/$BuildAttempt/$commit"
+    )
+    $bakeTokenHash = [Security.Cryptography.SHA256]::HashData($bakeTokenBytes)
+    $bakeToken = [Convert]::ToHexString($bakeTokenHash).Substring(0, 8).ToLowerInvariant()
 } else {
-    $builderSuffix = "$(Get-Date -AsUTC -Format 'yyMMddHHmmss')"
+    $localToken = [guid]::NewGuid().ToString("N").Substring(0, 8)
+    $builderSuffix = "$(Get-Date -AsUTC -Format 'yyMMddHHmmss')-$localToken"
+    $bakeToken = $localToken
 }
+$script:BakeID = $builderSuffix
 $script:BuilderName = "catsco-img-$builderSuffix"
 $script:KeyPairName = "catsco-img-key-$builderSuffix"
+$script:ImageWorkName = "catsco-bake-$shortCommit-$bakeToken"
+$releaseIdentity = "CatsCo worker $version commit $commit"
+$releaseDescription = "$releaseIdentity ready"
+$bakeDescription = "$releaseIdentity bake $script:BakeID"
+$script:BakeDescription = $bakeDescription
+if ($releaseDescription.Length -gt 128 -or $bakeDescription.Length -gt 128) {
+    throw "Generated image description exceeds Tianyi Cloud's 128-character limit"
+}
+if (
+    $script:ImageWorkName.Length -gt 32 -or
+    $script:ImageWorkName -notmatch "^[A-Za-z][A-Za-z0-9-]*[A-Za-z0-9]$"
+) {
+    throw "Generated temporary image name is invalid: $script:ImageWorkName"
+}
 
 $resolvedArtifactPath = ""
 if ($ArtifactPath) {
@@ -519,6 +835,8 @@ $plan = [ordered]@{
     version = $version
     commit = $commit
     imageName = $ImageName
+    temporaryImageName = $script:ImageWorkName
+    bakeID = $script:BakeID
     builderName = $script:BuilderName
     regionID = $RegionID
     azName = $AzName
@@ -537,16 +855,53 @@ if ($Mode -eq "Plan") {
     exit 0
 }
 
-$existing = Invoke-Ctyun @(
-    "ims", "ListImage",
-    "--regionID", $RegionID,
-    "--imageVisibilityCode", "0",
-    "--imageName", $ImageName,
-    "--pageNo", "1",
-    "--pageSize", "10"
-)
-if (@($existing.returnObj.images).Count -gt 0) {
-    throw "Private image already exists: $ImageName"
+$script:OperationDeadline = (Get-Date).AddMinutes($BakeTimeoutMinutes)
+if ($Mode -eq "Cleanup") {
+    Invoke-ExactBakeCleanup | ConvertTo-Json
+    exit 0
+}
+
+$existingImage = Find-ImageByName -Name $ImageName
+if ($existingImage) {
+    $existingStatus = ([string]$existingImage.imageStatus).ToLowerInvariant()
+    $existingDescription = [string]$existingImage.description
+    $pendingPrefix = "$releaseIdentity bake "
+    if ($existingStatus -eq "active" -and $existingDescription -eq $releaseDescription) {
+        [ordered]@{
+            result = "reused"
+            imageID = [string]$existingImage.imageID
+            imageName = $ImageName
+            version = $version
+            commit = $commit
+            builderName = $null
+            regionID = $RegionID
+        } | ConvertTo-Json
+        exit 0
+    }
+    if (
+        $existingStatus -eq "active" -and
+        $existingDescription.StartsWith($pendingPrefix)
+    ) {
+        $pendingBakeID = $existingDescription.Substring($pendingPrefix.Length)
+        $existingImage = Complete-PendingPublishedImage `
+            -PendingImage $existingImage `
+            -PendingBakeID $pendingBakeID `
+            -FinalDescription $releaseDescription
+        [ordered]@{
+            result = "recovered"
+            imageID = [string]$existingImage.imageID
+            imageName = $ImageName
+            version = $version
+            commit = $commit
+            builderName = $null
+            regionID = $RegionID
+        } | ConvertTo-Json
+        exit 0
+    }
+    throw (
+        "Private image name is already occupied by a different or incomplete image: " +
+        "$ImageName status=$existingStatus imageID=$($existingImage.imageID)"
+    )
 }
 
 $script:TemporaryRoot = Join-Path ([IO.Path]::GetTempPath()) "catsco-image-$([guid]::NewGuid().ToString('N'))"
@@ -696,29 +1051,38 @@ bash /tmp/prepare-image.sh --finalize
         "-o", "StrictHostKeyChecking=accept-new",
         "-o", "UserKnownHostsFile=$knownHosts"
     )
+    $artifactTransferTimeoutSeconds = Get-BoundedTimeoutSeconds `
+        -RequestedSeconds ($ArtifactTransferTimeoutMinutes * 60) `
+        -Phase "worker artifact transfer"
     Invoke-External -Command "timeout" -Arguments (@(
         "--signal=TERM",
         "--kill-after=30s",
-        "$($ArtifactTransferTimeoutMinutes)m",
+        "$($artifactTransferTimeoutSeconds)s",
         "scp"
     ) + $sshOptions + @(
         $resolvedArtifactPath,
         "root@$($script:BuilderIP):/tmp/$artifactName"
     ))
+    $scriptTransferTimeoutSeconds = Get-BoundedTimeoutSeconds `
+        -RequestedSeconds (5 * 60) `
+        -Phase "image preparation script transfer"
     Invoke-External -Command "timeout" -Arguments (@(
         "--signal=TERM",
         "--kill-after=30s",
-        "5m",
+        "$($scriptTransferTimeoutSeconds)s",
         "scp"
     ) + $sshOptions + @(
         "$PSScriptRoot/prepare-image.sh",
         $remoteBuildScript,
         "root@$($script:BuilderIP):/tmp/"
     ))
+    $remoteBuildTimeoutSeconds = Get-BoundedTimeoutSeconds `
+        -RequestedSeconds (($RemoteBuildTimeoutMinutes + 3) * 60) `
+        -Phase "remote image preparation"
     Invoke-External -Command "timeout" -Arguments (@(
         "--signal=TERM",
         "--kill-after=150s",
-        "$($RemoteBuildTimeoutMinutes + 3)m",
+        "$($remoteBuildTimeoutSeconds)s",
         "ssh"
     ) + $sshOptions + @(
         "root@$($script:BuilderIP)",
@@ -741,10 +1105,10 @@ bash /tmp/prepare-image.sh --finalize
         "--regionID", $RegionID,
         "--projectID", $ProjectID,
         "--instanceID", $script:BuilderID,
-        "--imageName", $ImageName,
-        "--description", "CatsCo worker $version commit $commit",
+        "--imageName", $script:ImageWorkName,
+        "--description", $bakeDescription,
         "--enableImageIntegrityCheck", "true",
-        "--labels", "[{`"labelKey`":`"product`",`"labelValue`":`"catsco-worker`"},{`"labelKey`":`"version`",`"labelValue`":`"$version`"},{`"labelKey`":`"commit`",`"labelValue`":`"$commit`"}]"
+        "--labels", "[{`"labelKey`":`"product`",`"labelValue`":`"catsco-worker`"},{`"labelKey`":`"version`",`"labelValue`":`"$version`"},{`"labelKey`":`"commit`",`"labelValue`":`"$commit`"},{`"labelKey`":`"bake`",`"labelValue`":`"$script:BakeID`"}]"
     )
     $image = @($imageResponse.returnObj.images) | Select-Object -First 1
     $script:ImageID = [string]$image.imageID
@@ -752,7 +1116,9 @@ bash /tmp/prepare-image.sh --finalize
         throw "CreateImage did not return an image ID"
     }
 
-    $deadline = (Get-Date).AddMinutes($TimeoutMinutes)
+    $deadline = Get-BoundedDeadline `
+        -RequestedSeconds ($TimeoutMinutes * 60) `
+        -Phase "private image creation wait"
     while ((Get-Date) -lt $deadline) {
         $currentImage = Get-Image -ImageID $script:ImageID
         if (-not $currentImage) {
@@ -761,6 +1127,23 @@ bash /tmp/prepare-image.sh --finalize
         $status = ([string]$currentImage.imageStatus).ToLowerInvariant()
         Write-Host "image state=$status progress=$($currentImage.taskProgress)"
         if ($status -eq "active") {
+            if ([string]$currentImage.sourceServerID -ne $script:BuilderID) {
+                throw (
+                    "Created image sourceServerID '$($currentImage.sourceServerID)' " +
+                    "does not match builder '$script:BuilderID'"
+                )
+            }
+            Invoke-Ctyun @(
+                "ims", "UpdateImage",
+                "--regionID", $RegionID,
+                "--imageID", $script:ImageID,
+                "--imageName", $ImageName,
+                "--description", $bakeDescription
+            ) | Out-Null
+            $publishedImage = Wait-ForPublishedImageIdentity `
+                -PublishedImageID $script:ImageID `
+                -PublishedImageName $ImageName `
+                -PublishedDescription $bakeDescription
             $script:ImageActive = $true
             $script:Completed = $true
             $result = [ordered]@{
@@ -785,6 +1168,8 @@ bash /tmp/prepare-image.sh --finalize
 } catch {
     $primaryFailure = $_.Exception.Message
 } finally {
+    $script:InCleanup = $true
+    $script:CleanupDeadline = (Get-Date).AddMinutes($CleanupTimeoutMinutes)
     try {
         Remove-TemporaryResources -Failure:(-not $script:Completed)
     } catch {
@@ -813,5 +1198,19 @@ if ($primaryFailure -or $cleanupFailure) {
     }
     throw ($failures -join "`n")
 }
+
+$script:InCleanup = $false
+$script:OperationDeadline = (Get-Date).AddMinutes(5)
+Invoke-Ctyun @(
+    "ims", "UpdateImage",
+    "--regionID", $RegionID,
+    "--imageID", $script:ImageID,
+    "--imageName", $ImageName,
+    "--description", $releaseDescription
+) | Out-Null
+Wait-ForPublishedImageIdentity `
+    -PublishedImageID $script:ImageID `
+    -PublishedImageName $ImageName `
+    -PublishedDescription $releaseDescription | Out-Null
 
 $result | ConvertTo-Json

--- a/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
+++ b/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
@@ -592,8 +592,12 @@ function Remove-Builder {
 function Remove-KeyPair {
     param([switch]$WaitForLate)
 
-    if (-not $script:KeyPairName -or -not $script:KeyPairID) {
-        Write-Warning "Skipping key pair cleanup because no immutable key pair identity was recorded"
+    if (-not $script:KeyPairName -or -not $script:KeyPairCreateAttempted) {
+        Write-Warning "Skipping key pair cleanup because this bake did not create a temporary key pair"
+        return
+    }
+    if (-not $script:KeyPairName.StartsWith("catsco-img-key-")) {
+        Write-Warning "Skipping key pair cleanup because '$script:KeyPairName' is not a temporary bake key pair"
         return
     }
 
@@ -624,13 +628,22 @@ function Remove-KeyPair {
         Write-Host "No temporary key pair record remains for $script:KeyPairName"
         return
     }
-    $ownedKeyPairs = @(
-        $existing | Where-Object {
-            [string](Get-PropertyValue -InputObject $_ -Name "keyPairID") -eq $script:KeyPairID
+    if ($script:KeyPairID) {
+        $ownedKeyPairs = @(
+            $existing | Where-Object {
+                [string](Get-PropertyValue -InputObject $_ -Name "keyPairID") -eq $script:KeyPairID
+            }
+        )
+        if ($ownedKeyPairs.Count -ne 1 -or $existing.Count -ne 1) {
+            throw "Refusing to delete key pair because name and immutable ID do not uniquely match this bake"
         }
-    )
-    if ($ownedKeyPairs.Count -ne 1 -or $existing.Count -ne 1) {
-        throw "Refusing to delete key pair because name and immutable ID do not uniquely match this bake"
+    } else {
+        # The immutable ID was never resolved (e.g. create succeeded but the
+        # follow-up query failed). Fall back to the unique temporary name so a
+        # failed bake does not leave a billed key pair behind.
+        if ($existing.Count -ne 1) {
+            throw "Refusing to delete key pair because the temporary name does not uniquely match this bake"
+        }
     }
 
     Write-Host "Deleting temporary key pair $script:KeyPairName ($script:KeyPairID)"

--- a/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
+++ b/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
@@ -47,6 +47,8 @@ param(
     [int]$BakeTimeoutMinutes = 240,
     [ValidateRange(10, 90)]
     [int]$CleanupTimeoutMinutes = 45,
+    [ValidateRange(1, 120)]
+    [int]$ImageDeleteConfirmMinutes = 8,
     [ValidateRange(15, 300)]
     [int]$ApiTimeoutSeconds = 90,
     [ValidateRange(5, 300)]
@@ -537,7 +539,7 @@ function Remove-FailedImage {
     }
 
     $deleteDeadline = Get-BoundedDeadline `
-        -RequestedSeconds (8 * 60) `
+        -RequestedSeconds ($ImageDeleteConfirmMinutes * 60) `
         -Phase "incomplete image deletion confirmation"
     while ((Get-Date) -lt $deleteDeadline) {
         $remaining = Get-Image -ImageID $script:ImageID
@@ -846,14 +848,24 @@ function Invoke-ExactBakeCleanup {
         }
     }
 
-    # --- Builder: deleted only after the image is gone, so it remains as
-    # ownership evidence if image deletion could not complete. ---
+    # --- Builder: deleted only after the image is confirmed gone. If image
+    # deletion failed or could not be confirmed, Remove-FailedImage keeps
+    # PreserveBuilderForImageRecovery set, and the builder must be retained as
+    # the sourceServerID ownership evidence for the next reconciliation
+    # (same gating as the in-process finally path). ---
     if ($candidateBuilder) {
-        try {
-            Remove-Builder -WaitForLate:$WaitForLateResources
-            $reconciled.Add("builder=$script:BuilderID")
-        } catch {
-            $errors.Add("builder cleanup (name=$script:BuilderName): $($_.Exception.Message)")
+        if ($script:PreserveBuilderForImageRecovery) {
+            $errors.Add(
+                "builder cleanup deferred because the source builder is still " +
+                "required to prove incomplete image ownership"
+            )
+        } else {
+            try {
+                Remove-Builder -WaitForLate:$WaitForLateResources
+                $reconciled.Add("builder=$script:BuilderID")
+            } catch {
+                $errors.Add("builder cleanup (name=$script:BuilderName): $($_.Exception.Message)")
+            }
         }
     }
 

--- a/ops/ctyun-worker-image/README.md
+++ b/ops/ctyun-worker-image/README.md
@@ -42,8 +42,11 @@ after the worker has claimed its bot identity.
 
 `New-CatsCoWorkerImage.ps1` defaults to plan mode. Execute mode creates a new
 temporary on-demand ECS named `catsco-img-*`, copies in a checked source-free
-artifact, stops that temporary instance, creates a private image, and then
-deletes the builder and its temporary key pair.
+artifact, stops that temporary instance, and creates a uniquely named
+`catsco-bake-*` image. After the image is active and its source builder has been
+verified, the script publishes it under the stable `catsco-worker-*` name with
+a pending bake marker, deletes the builder and its temporary key pair, and only
+then replaces that marker with the final release description.
 
 CI names builders and key pairs from the workflow sequence and retry:
 `catsco-img-000123-01` and `catsco-img-key-000123-01`. This keeps names
@@ -71,15 +74,35 @@ Run the same command with `-Mode Create`, `-ArtifactPath`, and
 `ctyun-cli`, Git, OpenSSH, SCP, `ssh-keygen`, and GNU `timeout`.
 
 The builder verifies the artifact checksum again before extracting it. Remote
-transfer and preparation have hard timeouts. The script resolves a newly
+transfer, preparation, and every Tianyi Cloud API call have hard timeouts. The
+whole bake also has a deadline separate from its cleanup deadline, while the
+GitHub job keeps additional time in reserve for compensating cleanup. The script resolves a newly
 ordered instance by both the order resource ID and its exact temporary name,
 so it can still clean up after an ambiguous create response. A failed image is
-deleted, and unconfirmed ECS, image, or key-pair deletion fails the workflow
-instead of being reduced to a warning.
+resolved by its per-run name and deleted only when `sourceServerID` matches the
+current builder. Unconfirmed ECS, image, or key-pair deletion fails the
+workflow instead of being reduced to a warning. If image deletion is
+temporarily unconfirmed, the source builder is retained as ownership evidence
+for the workflow's exact-attempt reconciliation rather than deleting that
+evidence first.
+
+Rerunning a release is idempotent: an existing active stable image is reused
+only when its full version and commit description match. A conflicting or
+incomplete image with the same stable name still fails closed. If a prior run
+published the image but failed during final cleanup, the next run uses the bake
+marker and source instance ID to finish cleaning that exact builder and key
+pair before marking the image complete. Each new workflow run also queries the
+GitHub Actions API for the latest cancelled, timed-out, or failed image run and
+reconciles resources derived from that run's exact ID, sequence, attempt, and
+commit. This covers process termination before PowerShell can enter `finally`.
 
 The workflow also pins both GitHub Actions by commit and verifies the exact
 Tianyi CLI package SHA-256 before installing it; it does not execute a remote
-installer script.
+installer script. The supported Node.js patch version used for the source-free
+artifact is pinned, and the same Node/npm runtime is bundled into the private
+artifact instead of installing a different distro version on the builder.
+Installed Debian package versions are recorded in
+`/etc/catsco-image-packages.txt` for later provenance checks.
 
 The resulting system image is not a TOS object. `CreateImage` writes it to the
 Tianyi Cloud private image repository for the configured region and account.

--- a/ops/ctyun-worker-image/README.md
+++ b/ops/ctyun-worker-image/README.md
@@ -1,0 +1,81 @@
+# CatsCo Tianyi Cloud Worker Image
+
+This directory builds a source-free Linux worker image. It never snapshots an
+existing user worker. The image contains the compiled CatsCo worker, production
+Node.js dependencies, a disabled systemd unit, and no bot account, relay key,
+session, skill installation, or runtime `.env`.
+
+## Release Policy
+
+- Every stable `v*` tag builds and publishes an immutable worker artifact.
+- A Tianyi Cloud private ECS image is baked only for a stable release selected
+  for provisioning, or when the base OS/system dependencies change.
+- `CTYUN_AUTO_BAKE_WORKER_IMAGE=true` makes every stable tag bake an image;
+  changing it to `false` is the emergency cost and incident kill switch.
+- The application version and full Git commit are stored in both
+  `/opt/catsco/current/worker-release.json` and `/etc/catsco-image.json`.
+- Keep the newest two active images plus the image currently referenced by the
+  production launch template. Deactivate older images before deleting them.
+
+This avoids rebuilding a large system disk for documentation-only or emergency
+application releases while still allowing new workers to start without GitHub.
+
+## Layout
+
+| Path | Ownership | Purpose |
+| --- | --- | --- |
+| `/opt/catsco/releases/<version>-<sha>` | root, immutable | Compiled application |
+| `/opt/catsco/current` | root symlink | Active application release |
+| `/srv/catsco-agent` | `catsco-agent` | Per-worker account, sessions, skills and files |
+| `/etc/catsco-image.json` | root, read-only | Image provenance |
+
+The image ships with `catsco-agent.service` disabled. Provisioning must inject a
+short-lived bootstrap credential into the data root and enable the service only
+after the worker has claimed its bot identity.
+
+## Local Bake
+
+`New-CatsCoWorkerImage.ps1` defaults to plan mode. Execute mode creates a new
+temporary on-demand ECS named `catsco-img-*`, builds the artifact there, stops
+that temporary instance, creates a private image, and then deletes the builder
+and its temporary key pair.
+
+The script refuses to stop or delete any instance whose name does not begin
+with `catsco-img-`. Existing `worker1`, `worker2`, and `ck-work` instances are
+therefore outside its mutation boundary.
+
+```powershell
+pwsh ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1 `
+  -Mode Plan `
+  -RegionID '<region-id>' `
+  -AzName '<availability-zone>' `
+  -BaseImageID '<ubuntu-24.04-image-id>' `
+  -FlavorID '<2c4g-flavor-id>' `
+  -VpcID '<vpc-id>' `
+  -SubnetID '<subnet-id>' `
+  -SecurityGroupID '<security-group-id>'
+```
+
+Run the same command with `-Mode Create` only after reviewing the plan. The
+machine running it needs `ctyun-cli`, Git, OpenSSH, SCP, and `ssh-keygen`.
+
+CI passes `-ArtifactUrl` and `-ArtifactSha256`, so the temporary builder
+downloads the source-free release directly from Guangzhou TOS. Local emergency
+bakes may omit those options; in that case the temporary builder receives a
+`git archive` without repository history and removes it before imaging.
+
+## First-Boot Contract
+
+Provisioning from this image must:
+
+1. create or attach the per-worker data disk;
+2. write only the worker's scoped runtime configuration under
+   `/srv/catsco-agent`;
+3. set ownership to `catsco-agent:catsco-agent` and permissions to `0600` for
+   credentials;
+4. enable and start `catsco-agent.service`;
+5. require a successful CatsCompany registration and heartbeat before marking
+   the paid worker ready.
+
+Never place a long-lived account password, relay administrator key, or shared
+bot token in image metadata or Cloud-init user data.

--- a/ops/ctyun-worker-image/README.md
+++ b/ops/ctyun-worker-image/README.md
@@ -7,10 +7,12 @@ session, skill installation, or runtime `.env`.
 
 ## Release Policy
 
-- Every stable `v*` tag builds and publishes an immutable worker artifact.
-- Worker artifacts use the private `worker-private/` TOS prefix. They are never
-  exposed through the public desktop installer path; the disposable builder
-  receives a masked, one-hour presigned URL.
+- Only stable `vX.Y.Z` tags whose commit is contained in `main` may bake an
+  image automatically. Manual runs are restricted to `main` and default to
+  not baking until the operator explicitly checks the input.
+- The source-free worker artifact stays on the GitHub runner and is copied
+  directly to the disposable builder over SSH. It is never uploaded to TOS,
+  a public release bucket, or a GitHub Actions artifact.
 - A Tianyi Cloud private ECS image is baked only for a stable release selected
   for provisioning, or when the base OS/system dependencies change.
 - `CTYUN_AUTO_BAKE_WORKER_IMAGE=true` makes every stable tag bake an image;
@@ -39,9 +41,14 @@ after the worker has claimed its bot identity.
 ## Local Bake
 
 `New-CatsCoWorkerImage.ps1` defaults to plan mode. Execute mode creates a new
-temporary on-demand ECS named `catsco-img-*`, builds the artifact there, stops
-that temporary instance, creates a private image, and then deletes the builder
-and its temporary key pair.
+temporary on-demand ECS named `catsco-img-*`, copies in a checked source-free
+artifact, stops that temporary instance, creates a private image, and then
+deletes the builder and its temporary key pair.
+
+CI names builders and key pairs from the workflow sequence and retry:
+`catsco-img-000123-01` and `catsco-img-key-000123-01`. This keeps names
+recognizable while preventing a rerun from colliding with an uncertain prior
+attempt.
 
 The script refuses to stop or delete any instance whose name does not begin
 with `catsco-img-`. Existing `worker1`, `worker2`, and `ck-work` instances are
@@ -59,15 +66,20 @@ pwsh ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1 `
   -SecurityGroupID '<security-group-id>'
 ```
 
-Run the same command with `-Mode Create` only after reviewing the plan. The
-machine running it needs `ctyun-cli`, Git, OpenSSH, SCP, and `ssh-keygen`.
+Run the same command with `-Mode Create`, `-ArtifactPath`, and
+`-ArtifactSha256` only after reviewing the plan. The machine running it needs
+`ctyun-cli`, Git, OpenSSH, SCP, `ssh-keygen`, and GNU `timeout`.
 
-CI passes a one-hour presigned `-ArtifactUrl` and `-ArtifactSha256`, so the
-temporary builder downloads the private, source-free release directly from
-Guangzhou TOS. The signed URL is masked in GitHub and redacted from the bake
-plan. Local emergency bakes may omit those options; in that case the temporary
-builder receives a `git archive` without repository history and removes it
-before imaging.
+The builder verifies the artifact checksum again before extracting it. Remote
+transfer and preparation have hard timeouts. The script resolves a newly
+ordered instance by both the order resource ID and its exact temporary name,
+so it can still clean up after an ambiguous create response. A failed image is
+deleted, and unconfirmed ECS, image, or key-pair deletion fails the workflow
+instead of being reduced to a warning.
+
+The workflow also pins both GitHub Actions by commit and verifies the exact
+Tianyi CLI package SHA-256 before installing it; it does not execute a remote
+installer script.
 
 The resulting system image is not a TOS object. `CreateImage` writes it to the
 Tianyi Cloud private image repository for the configured region and account.

--- a/ops/ctyun-worker-image/README.md
+++ b/ops/ctyun-worker-image/README.md
@@ -8,6 +8,9 @@ session, skill installation, or runtime `.env`.
 ## Release Policy
 
 - Every stable `v*` tag builds and publishes an immutable worker artifact.
+- Worker artifacts use the private `worker-private/` TOS prefix. They are never
+  exposed through the public desktop installer path; the disposable builder
+  receives a masked, one-hour presigned URL.
 - A Tianyi Cloud private ECS image is baked only for a stable release selected
   for provisioning, or when the base OS/system dependencies change.
 - `CTYUN_AUTO_BAKE_WORKER_IMAGE=true` makes every stable tag bake an image;
@@ -59,10 +62,37 @@ pwsh ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1 `
 Run the same command with `-Mode Create` only after reviewing the plan. The
 machine running it needs `ctyun-cli`, Git, OpenSSH, SCP, and `ssh-keygen`.
 
-CI passes `-ArtifactUrl` and `-ArtifactSha256`, so the temporary builder
-downloads the source-free release directly from Guangzhou TOS. Local emergency
-bakes may omit those options; in that case the temporary builder receives a
-`git archive` without repository history and removes it before imaging.
+CI passes a one-hour presigned `-ArtifactUrl` and `-ArtifactSha256`, so the
+temporary builder downloads the private, source-free release directly from
+Guangzhou TOS. The signed URL is masked in GitHub and redacted from the bake
+plan. Local emergency bakes may omit those options; in that case the temporary
+builder receives a `git archive` without repository history and removes it
+before imaging.
+
+The resulting system image is not a TOS object. `CreateImage` writes it to the
+Tianyi Cloud private image repository for the configured region and account.
+
+## Managed Worker Updates
+
+Workers must not receive Tianyi Cloud account credentials. CatsCompany's
+control plane should list private images by the `product=catsco-worker` label
+and compare the newest image version with `/etc/catsco-image.json` reported by
+each worker heartbeat.
+
+For future paid workers, mount a separate persistent data disk at
+`/srv/catsco-agent`. An owner-approved update can then:
+
+1. mark the worker as draining and stop accepting new tasks;
+2. wait for the active task to finish, then stop `catsco-agent.service`;
+3. back up the data disk and switch the ECS system disk to the selected private
+   image while retaining the instance, EIP and data disk;
+4. remount `/srv/catsco-agent`, run migrations, start the service and verify its
+   CatsCompany heartbeat;
+5. return to the old image if health checks fail.
+
+The web UI should show the expected maintenance window and require explicit
+owner confirmation. Existing workers whose data still lives on the system disk
+must be migrated to a separate data disk before image-based updates are enabled.
 
 ## First-Boot Contract
 

--- a/ops/ctyun-worker-image/README.md
+++ b/ops/ctyun-worker-image/README.md
@@ -91,10 +91,21 @@ only when its full version and commit description match. A conflicting or
 incomplete image with the same stable name still fails closed. If a prior run
 published the image but failed during final cleanup, the next run uses the bake
 marker and source instance ID to finish cleaning that exact builder and key
-pair before marking the image complete. Each new workflow run also queries the
-GitHub Actions API for the latest cancelled, timed-out, or failed image run and
-reconciles resources derived from that run's exact ID, sequence, attempt, and
-commit. This covers process termination before PowerShell can enter `finally`.
+pair before marking the image complete. Missing builder and key-pair reads are
+retried during this recovery window so an eventually consistent API response
+cannot make the image ready while billable resources still exist. Each new
+workflow run also queries the GitHub Actions API for recent cancelled,
+timed-out, or failed image runs and reconciles every attempt derived from each
+run's exact ID, sequence, and commit. The newest recently failed attempt gets an
+additional late-resource discovery window. This covers process termination
+before PowerShell can enter `finally`, including failures that would otherwise
+be hidden behind a later unsuccessful reconciliation run. Cleanup failures
+from runs updated in the last 30 minutes block a new bake, with a bounded
+45-minute strict-recovery budget. A rerun applies the same bounded strict policy
+to all of its previous attempts. Older conflicts are attempted independently
+with a 120-second per-attempt cap and a 10-minute total budget, surfaced as
+workflow warnings and in the job summary, and left for manual reconciliation
+instead of permanently blocking all future image releases.
 
 The workflow also pins both GitHub Actions by commit and verifies the exact
 Tianyi CLI package SHA-256 before installing it; it does not execute a remote

--- a/ops/ctyun-worker-image/prepare-image.sh
+++ b/ops/ctyun-worker-image/prepare-image.sh
@@ -84,12 +84,95 @@ apt-get install -y --no-install-recommends \
   unzip \
   zip
 
+# --- Platform hardening (encoded from deploy-catsco-linux-agent skill, 2026-08) ---
+# Every fault below was hit on live Tianyi workers provisioned from the same base
+# image. Encoding the fixes here means a freshly baked worker starts healthy and
+# no manual host surgery is needed after provisioning.
+
+# 1. Repair corrupted dpkg file lists ("missing final newline"). These images can
+#    ship broken /var/lib/dpkg/info/*.list files that abort later apt commands.
+for list in /var/lib/dpkg/info/*.list; do
+  [ -f "$list" ] && [ -s "$list" ] || continue
+  if ! tail -c1 "$list" | od -An -c | tr -d ' \n' | grep -q '\\n'; then
+    printf '\n' >> "$list"
+  fi
+done
+dpkg --configure -a >/dev/null 2>&1 || true
+
+# 2. Upgrade systemd + glibc to the known-safe combination
+#    (255.4-1ubuntu8.16 + 2.39-0ubuntu8.8). The original image shipped
+#    systemd 8.15 + glibc 8.7 which triggers a _dl_fini assert that freezes
+#    systemd ("Caught <ABRT> ... Freezing execution"); every systemctl call then
+#    times out. postinst may fail on a running older systemd (expected), so we
+#    tolerate it, finish dpkg configuration, and retry with the minimal set.
+if ! apt-get install --only-upgrade -y \
+  systemd \
+  systemd-sysv \
+  systemd-timesyncd \
+  systemd-dev \
+  libsystemd0 \
+  libsystemd-shared \
+  libpam-systemd \
+  libnss-systemd \
+  libc6 \
+  libc-bin \
+  libc6-dev \
+  libc-dev-bin \
+  openssh-client \
+  openssh-server \
+  openssh-sftp-server \
+  >/tmp/catsco-systemd-upgrade.log 2>&1; then
+  dpkg --configure -a >/dev/null 2>&1 || true
+  apt-get install --only-upgrade -y \
+    systemd systemd-timesyncd libsystemd0 libc6 libc-bin \
+    >/tmp/catsco-systemd-upgrade-retry.log 2>&1 || true
+fi
+dpkg --configure -a >/dev/null 2>&1 || true
+
+# 3. Upgrade the kernel and regenerate grub. A new kernel without update-grub can
+#    still boot the old one, and old kernels are retained for rollback.
+apt-get install --only-upgrade -y \
+  linux-generic linux-image-generic \
+  >/tmp/catsco-kernel-upgrade.log 2>&1 || true
+if command -v update-grub >/dev/null 2>&1; then
+  update-grub >/dev/null 2>&1 || true
+fi
+
+# 4. Mask fwupd so systemd cannot ABRT on firmware lifecycle events. Even on
+#    systemd 8.16, handling fwupd.service lifecycle can crash systemd itself
+#    ("Caught <ABRT>, from our own process" then "Freezing execution"). Worker
+#    servers do not need a firmware update daemon. The mask is a persistent
+#    symlink in /etc, so freshly provisioned workers stay immune.
+systemctl mask fwupd.service >/dev/null 2>&1 || true
+systemctl stop fwupd.service >/dev/null 2>&1 || true
+systemctl mask fwupd-refresh.service >/dev/null 2>&1 || true
+systemctl stop fwupd-refresh.service >/dev/null 2>&1 || true
+systemctl reset-failed fwupd-refresh.service >/dev/null 2>&1 || true
+
+SYSTEMD_VERSION="$(dpkg-query -W -f='${Version}' systemd 2>/dev/null || true)"
+GLIBC_VERSION="$(dpkg-query -W -f='${Version}' libc6 2>/dev/null || true)"
+KERNEL_VERSION="$(uname -r 2>/dev/null || true)"
+printf 'platform_systemd=%s glibc=%s kernel=%s\n' \
+  "$SYSTEMD_VERSION" "$GLIBC_VERSION" "$KERNEL_VERSION"
+
+# 5. Pre-configure the China-region npm mirror. Direct registry.npmjs.org from
+#    Tianyi/华南 hosts is slow and has produced truncated/corrupted tarballs
+#    (e.g. TS1127 from a truncated lib.es2017.string.d.ts). Set it for both the
+#    service user and root so the first npm ci/install never needs manual setup.
+printf 'registry=https://registry.npmmirror.com\n' >/root/.npmrc
+chmod 0644 /root/.npmrc
 id catsco-agent >/dev/null 2>&1 || useradd \
   --system \
   --create-home \
   --home-dir /srv/catsco-agent \
   --shell /bin/bash \
   catsco-agent
+
+# Service-user npm mirror config (survives finalize; the finalize cleanup list
+# deliberately keeps .npmrc so first-boot npm never needs manual setup).
+printf 'registry=https://registry.npmmirror.com\n' >/srv/catsco-agent/.npmrc
+chown catsco-agent:catsco-agent /srv/catsco-agent/.npmrc
+chmod 0644 /srv/catsco-agent/.npmrc
 
 RELEASE_ID="${EXPECTED_VERSION}-${EXPECTED_COMMIT:0:8}"
 RELEASES_ROOT="/opt/catsco/releases"
@@ -147,6 +230,7 @@ Environment=XIAOBA_APP_ROOT=/opt/catsco/current
 Environment=XIAOBA_USER_DATA_DIR=/srv/catsco-agent
 Environment=XIAOBA_RUNTIME_ROOT=/srv/catsco-agent
 Environment=XIAOBA_RUNTIME_SURFACE=catscompany
+Environment=NPM_CONFIG_REGISTRY=https://registry.npmmirror.com
 EnvironmentFile=-/srv/catsco-agent/.env
 ExecStart=/opt/catsco/current/runtime/node/bin/node /opt/catsco/current/dist/index.js catsco
 Restart=always

--- a/ops/ctyun-worker-image/prepare-image.sh
+++ b/ops/ctyun-worker-image/prepare-image.sh
@@ -167,15 +167,26 @@ if ! apt-get install --only-upgrade -y \
     systemd systemd-timesyncd libsystemd0 libc6 libc-bin \
     >/tmp/catsco-systemd-upgrade-retry.log 2>&1 || true
 fi
-dpkg --configure -a >/dev/null 2>&1 || true
+# The final dpkg configuration must actually succeed. A version string alone is
+# not enough: a half-configured package can still report the new Version while
+# the image ships a broken dpkg database (review: version gate masked configure
+# failures). Fail closed here.
+if ! dpkg --configure -a >/tmp/catsco-dpkg-configure-final.log 2>&1; then
+  die "dpkg configuration did not complete after systemd/glibc upgrade; see /tmp/catsco-dpkg-configure-final.log"
+fi
 
 SYSTEMD_VERSION="$(dpkg-query -W -f='${Version}' systemd 2>/dev/null || true)"
 GLIBC_VERSION="$(dpkg-query -W -f='${Version}' libc6 2>/dev/null || true)"
+SYSTEMD_STATUS="$(dpkg-query -W -f='${db:Status-Abbrev}' systemd 2>/dev/null || true)"
+GLIBC_STATUS="$(dpkg-query -W -f='${db:Status-Abbrev}' libc6 2>/dev/null || true)"
 if ! dpkg --compare-versions "$SYSTEMD_VERSION" ge "255.4-1ubuntu8.16"; then
   die "systemd upgrade failed to reach known-safe version (have '$SYSTEMD_VERSION', need >= 255.4-1ubuntu8.16); see /tmp/catsco-systemd-upgrade.log"
 fi
 if ! dpkg --compare-versions "$GLIBC_VERSION" ge "2.39-0ubuntu8.8"; then
   die "glibc upgrade failed to reach known-safe version (have '$GLIBC_VERSION', need >= 2.39-0ubuntu8.8); see /tmp/catsco-systemd-upgrade.log"
+fi
+if [ "$SYSTEMD_STATUS" != "ii" ] || [ "$GLIBC_STATUS" != "ii" ]; then
+  die "systemd/glibc are not fully configured (systemd='$SYSTEMD_STATUS' glibc='$GLIBC_STATUS'); refusing to bake an image with a broken dpkg database"
 fi
 
 # 4. Upgrade the kernel and regenerate grub. INSTALL (not --only-upgrade) the

--- a/ops/ctyun-worker-image/prepare-image.sh
+++ b/ops/ctyun-worker-image/prepare-image.sh
@@ -32,7 +32,9 @@ while (($#)); do
   esac
 done
 
-[[ $EUID -eq 0 ]] || die "run as root"
+if [[ -z "${CATSCO_PREPARE_SKIP_ROOT_CHECK:-}" ]]; then
+  [[ $EUID -eq 0 ]] || die "run as root"
+fi
 
 if [[ $FINALIZE -eq 1 ]]; then
   systemctl disable --now catsco-agent.service 2>/dev/null || true
@@ -72,7 +74,31 @@ ACTUAL_SHA256="$(sha256sum "$ARTIFACT" | awk '{print $1}')"
 [[ "${ACTUAL_SHA256,,}" == "${SHA256,,}" ]] || die "artifact checksum mismatch"
 
 export DEBIAN_FRONTEND=noninteractive
-apt-get update
+
+# --- Platform hardening (encoded from deploy-catsco-linux-agent skill, 2026-08) ---
+# Every fault below was hit on live Tianyi workers provisioned from the same base
+# image. Encoding the fixes here means a freshly baked worker starts healthy and
+# no manual host surgery is needed after provisioning.
+#
+# Fail-closed policy: an upgrade that cannot reach the known-safe platform state
+# must block the bake. Shipping an image that silently carries the buggy
+# systemd/glibc/kernel combo is worse than failing the workflow so it can retry.
+
+# 1. Repair corrupted dpkg file lists ("missing final newline") BEFORE any
+#    apt/dpkg transaction. These images can ship broken
+#    /var/lib/dpkg/info/*.list files that abort the very first apt or dpkg call
+#    (e.g. dpkg-query exits 2 while a list is missing its final newline).
+for list in /var/lib/dpkg/info/*.list; do
+  [ -f "$list" ] && [ -s "$list" ] || continue
+  if ! tail -c1 "$list" | od -An -c | tr -d ' \n' | grep -q '\\n'; then
+    printf '\n' >> "$list"
+  fi
+done
+if ! dpkg --configure -a >/tmp/catsco-dpkg-configure-first.log 2>&1; then
+  die "dpkg configuration failed after file-list repair; see /tmp/catsco-dpkg-configure-first.log"
+fi
+
+apt-get update || die "apt-get update failed"
 apt-get install -y --no-install-recommends \
   ca-certificates \
   curl \
@@ -82,22 +108,8 @@ apt-get install -y --no-install-recommends \
   ripgrep \
   sudo \
   unzip \
-  zip
-
-# --- Platform hardening (encoded from deploy-catsco-linux-agent skill, 2026-08) ---
-# Every fault below was hit on live Tianyi workers provisioned from the same base
-# image. Encoding the fixes here means a freshly baked worker starts healthy and
-# no manual host surgery is needed after provisioning.
-
-# 1. Repair corrupted dpkg file lists ("missing final newline"). These images can
-#    ship broken /var/lib/dpkg/info/*.list files that abort later apt commands.
-for list in /var/lib/dpkg/info/*.list; do
-  [ -f "$list" ] && [ -s "$list" ] || continue
-  if ! tail -c1 "$list" | od -An -c | tr -d ' \n' | grep -q '\\n'; then
-    printf '\n' >> "$list"
-  fi
-done
-dpkg --configure -a >/dev/null 2>&1 || true
+  zip \
+  || die "base package install failed"
 
 # 2. Mask fwupd BEFORE upgrading systemd. On systemd 8.16, handling fwupd
 #    lifecycle can crash systemd itself ("Caught <ABRT>, from our own process"
@@ -117,7 +129,9 @@ systemctl reset-failed fwupd-refresh.service >/dev/null 2>&1 || true
 #    systemd 8.15 + glibc 8.7 which triggers a _dl_fini assert that freezes
 #    systemd ("Caught <ABRT> ... Freezing execution"); every systemctl call then
 #    times out. postinst may fail on a running older systemd (expected), so we
-#    tolerate it, finish dpkg configuration, and retry with the minimal set.
+#    finish dpkg configuration, retry with the minimal set, and then VERIFY the
+#    installed versions with dpkg --compare-versions. Failing to reach the
+#    known-safe versions blocks the bake.
 if ! apt-get install --only-upgrade -y \
   systemd \
   systemd-sysv \
@@ -142,17 +156,30 @@ if ! apt-get install --only-upgrade -y \
 fi
 dpkg --configure -a >/dev/null 2>&1 || true
 
-# 4. Upgrade the kernel and regenerate grub. A new kernel without update-grub can
-#    still boot the old one, and old kernels are retained for rollback.
-apt-get install --only-upgrade -y \
-  linux-generic linux-image-generic \
-  >/tmp/catsco-kernel-upgrade.log 2>&1 || true
-if command -v update-grub >/dev/null 2>&1; then
-  update-grub >/dev/null 2>&1 || true
-fi
-
 SYSTEMD_VERSION="$(dpkg-query -W -f='${Version}' systemd 2>/dev/null || true)"
 GLIBC_VERSION="$(dpkg-query -W -f='${Version}' libc6 2>/dev/null || true)"
+if ! dpkg --compare-versions "$SYSTEMD_VERSION" ge "255.4-1ubuntu8.16"; then
+  die "systemd upgrade failed to reach known-safe version (have '$SYSTEMD_VERSION', need >= 255.4-1ubuntu8.16); see /tmp/catsco-systemd-upgrade.log"
+fi
+if ! dpkg --compare-versions "$GLIBC_VERSION" ge "2.39-0ubuntu8.8"; then
+  die "glibc upgrade failed to reach known-safe version (have '$GLIBC_VERSION', need >= 2.39-0ubuntu8.8); see /tmp/catsco-systemd-upgrade.log"
+fi
+
+# 4. Upgrade the kernel and regenerate grub. A new kernel without update-grub can
+#    still boot the old one, and old kernels are retained for rollback. Failures
+#    here block the bake so the image never ships a stale kernel or bootloader.
+if ! apt-get install --only-upgrade -y \
+  linux-generic linux-image-generic \
+  >/tmp/catsco-kernel-upgrade.log 2>&1; then
+  die "kernel upgrade failed; see /tmp/catsco-kernel-upgrade.log"
+fi
+if ! command -v update-grub >/dev/null 2>&1 || ! update-grub >/tmp/catsco-update-grub.log 2>&1; then
+  die "update-grub failed; see /tmp/catsco-update-grub.log"
+fi
+if ! ls /boot/vmlinuz-* >/dev/null 2>&1; then
+  die "no bootable kernel image found under /boot after kernel upgrade"
+fi
+
 KERNEL_VERSION="$(uname -r 2>/dev/null || true)"
 printf 'platform_systemd=%s glibc=%s kernel=%s\n' \
   "$SYSTEMD_VERSION" "$GLIBC_VERSION" "$KERNEL_VERSION"

--- a/ops/ctyun-worker-image/prepare-image.sh
+++ b/ops/ctyun-worker-image/prepare-image.sh
@@ -78,6 +78,7 @@ apt-get install -y --no-install-recommends \
   curl \
   git \
   jq \
+  nodejs \
   poppler-utils \
   ripgrep \
   sudo \

--- a/ops/ctyun-worker-image/prepare-image.sh
+++ b/ops/ctyun-worker-image/prepare-image.sh
@@ -66,7 +66,7 @@ fi
 [[ -f "$ARTIFACT" ]] || die "artifact not found"
 [[ "$SHA256" =~ ^[0-9a-fA-F]{64}$ ]] || die "invalid SHA-256"
 [[ "$EXPECTED_COMMIT" =~ ^[0-9a-fA-F]{40}$ ]] || die "commit must be a full SHA"
-[[ -n "$EXPECTED_VERSION" ]] || die "version is required"
+[[ "$EXPECTED_VERSION" =~ ^[0-9A-Za-z][0-9A-Za-z._+-]{0,63}$ ]] || die "invalid version"
 
 ACTUAL_SHA256="$(sha256sum "$ARTIFACT" | awk '{print $1}')"
 [[ "${ACTUAL_SHA256,,}" == "${SHA256,,}" ]] || die "artifact checksum mismatch"
@@ -92,9 +92,14 @@ id catsco-agent >/dev/null 2>&1 || useradd \
   catsco-agent
 
 RELEASE_ID="${EXPECTED_VERSION}-${EXPECTED_COMMIT:0:8}"
-RELEASE_ROOT="/opt/catsco/releases/$RELEASE_ID"
-rm -rf "$RELEASE_ROOT"
-mkdir -p "$RELEASE_ROOT" /opt/catsco/releases /srv/catsco-agent
+RELEASES_ROOT="/opt/catsco/releases"
+RELEASE_ROOT="$RELEASES_ROOT/$RELEASE_ID"
+case "$RELEASE_ROOT" in
+  "$RELEASES_ROOT"/*) ;;
+  *) die "release path escapes $RELEASES_ROOT" ;;
+esac
+rm -rf -- "$RELEASE_ROOT"
+mkdir -p -- "$RELEASE_ROOT" "$RELEASES_ROOT" /srv/catsco-agent
 
 TEMP_EXTRACT="$(mktemp -d /tmp/catsco-release.XXXXXX)"
 trap 'rm -rf "$TEMP_EXTRACT"' EXIT
@@ -167,15 +172,17 @@ sudo -u catsco-agent -- bash -c '
 dpkg-query -W -f='${Package}\t${Version}\n' | LC_ALL=C sort >/etc/catsco-image-packages.txt
 chmod 0644 /etc/catsco-image-packages.txt
 
-cat >/etc/catsco-image.json <<EOF
-{
-  "schemaVersion": 1,
-  "product": "catsco-worker",
-  "version": "$EXPECTED_VERSION",
-  "commit": "$EXPECTED_COMMIT",
-  "releaseId": "$RELEASE_ID"
-}
-EOF
+jq -n \
+  --arg version "$EXPECTED_VERSION" \
+  --arg commit "$EXPECTED_COMMIT" \
+  --arg releaseId "$RELEASE_ID" \
+  '{
+    schemaVersion: 1,
+    product: "catsco-worker",
+    version: $version,
+    commit: $commit,
+    releaseId: $releaseId
+  }' >/etc/catsco-image.json
 chmod 0644 /etc/catsco-image.json
 
 if find /opt/catsco -type f \( \

--- a/ops/ctyun-worker-image/prepare-image.sh
+++ b/ops/ctyun-worker-image/prepare-image.sh
@@ -118,15 +118,24 @@ apt-get install -y --no-install-recommends \
 #    then "Freezing execution"). The mask is a persistent symlink in /etc, so
 #    masking first means the 8.16 daemon (if the upgrade re-execs it) never has
 #    to process fwupd lifecycle, and worker servers do not need a firmware
-#    update daemon. The masks are best-effort: if the running systemd is
-#    already frozen they may fail, but a frozen host can never satisfy the
-#    systemd/glibc version assertions below, so the bake still fails closed.
-systemctl mask fwupd.service >/dev/null 2>&1 || true
-systemctl stop fwupd.service >/dev/null 2>&1 || true
-systemctl mask fwupd-refresh.service >/dev/null 2>&1 || true
-systemctl stop fwupd-refresh.service >/dev/null 2>&1 || true
-systemctl mask fwupd-refresh.timer >/dev/null 2>&1 || true
-systemctl reset-failed fwupd-refresh.service >/dev/null 2>&1 || true
+#    update daemon. Each mask is bounded by timeout (a frozen manager must not
+#    hang the bake) and VERIFIED through its persistent /etc/systemd/system
+#    symlink, which is independent of the running manager. A mask that did not
+#    take effect blocks the bake: publishing an image that can still crash
+#    systemd on fwupd lifecycle is not acceptable.
+mask_unit() {
+  local unit="$1"
+  timeout 30 systemctl mask "$unit" >/dev/null 2>&1 || true
+  if [ "$(readlink "/etc/systemd/system/$unit" 2>/dev/null || true)" != "/dev/null" ]; then
+    die "failed to mask $unit (expected /etc/systemd/system/$unit -> /dev/null); refusing to bake an unhardened image"
+  fi
+}
+mask_unit fwupd.service
+mask_unit fwupd-refresh.service
+mask_unit fwupd-refresh.timer
+timeout 30 systemctl stop fwupd.service >/dev/null 2>&1 || true
+timeout 30 systemctl stop fwupd-refresh.service >/dev/null 2>&1 || true
+timeout 30 systemctl reset-failed fwupd-refresh.service >/dev/null 2>&1 || true
 
 # 3. Upgrade systemd + glibc to the known-safe combination
 #    (255.4-1ubuntu8.16 + 2.39-0ubuntu8.8). The original image shipped
@@ -169,10 +178,14 @@ if ! dpkg --compare-versions "$GLIBC_VERSION" ge "2.39-0ubuntu8.8"; then
   die "glibc upgrade failed to reach known-safe version (have '$GLIBC_VERSION', need >= 2.39-0ubuntu8.8); see /tmp/catsco-systemd-upgrade.log"
 fi
 
-# 4. Upgrade the kernel and regenerate grub. A new kernel without update-grub can
-#    still boot the old one, and old kernels are retained for rollback. Failures
-#    here block the bake so the image never ships a stale kernel or bootloader.
-if ! apt-get install --only-upgrade -y \
+# 4. Upgrade the kernel and regenerate grub. INSTALL (not --only-upgrade) the
+#    meta packages: on a base image where they are absent, --only-upgrade
+#    silently prints 'Skipping ... it is not installed', returns 0, and the old
+#    kernel passes a naive /boot existence check. After installing, verify a
+#    non-empty bootable kernel image actually exists under /boot and that grub
+#    is regenerated; the running kernel is not a reliable signal because the
+#    bake never reboots.
+if ! apt-get install -y --no-install-recommends \
   linux-generic linux-image-generic \
   >/tmp/catsco-kernel-upgrade.log 2>&1; then
   die "kernel upgrade failed; see /tmp/catsco-kernel-upgrade.log"
@@ -180,7 +193,11 @@ fi
 if ! command -v update-grub >/dev/null 2>&1 || ! update-grub >/tmp/catsco-update-grub.log 2>&1; then
   die "update-grub failed; see /tmp/catsco-update-grub.log"
 fi
-if ! ls /boot/vmlinuz-* >/dev/null 2>&1; then
+if ! ls -1 /boot/vmlinuz-* >/dev/null 2>&1; then
+  die "no bootable kernel image found under /boot after kernel upgrade"
+fi
+NEWEST_KERNEL_IMG="$(ls -1 /boot/vmlinuz-* 2>/dev/null | LC_ALL=C sort -V | tail -1)"
+if [ -z "$NEWEST_KERNEL_IMG" ]; then
   die "no bootable kernel image found under /boot after kernel upgrade"
 fi
 

--- a/ops/ctyun-worker-image/prepare-image.sh
+++ b/ops/ctyun-worker-image/prepare-image.sh
@@ -189,7 +189,9 @@ fi
 if ! dpkg --compare-versions "$GLIBC_VERSION" ge "2.39-0ubuntu8.8"; then
   die "glibc upgrade failed to reach known-safe version (have '$GLIBC_VERSION', need >= 2.39-0ubuntu8.8); see /tmp/catsco-systemd-upgrade.log"
 fi
-if [ "$SYSTEMD_STATUS" != "ii" ] || [ "$GLIBC_STATUS" != "ii" ]; then
+# dpkg-query prints '${db:Status-Abbrev}' with a trailing space for a healthy
+# package (e.g. 'ii '), so compare whitespace-normalized values.
+if [ "${SYSTEMD_STATUS//[[:space:]]/}" != "ii" ] || [ "${GLIBC_STATUS//[[:space:]]/}" != "ii" ]; then
   die "systemd/glibc are not fully configured (systemd='$SYSTEMD_STATUS' glibc='$GLIBC_STATUS'); refusing to bake an image with a broken dpkg database"
 fi
 

--- a/ops/ctyun-worker-image/prepare-image.sh
+++ b/ops/ctyun-worker-image/prepare-image.sh
@@ -32,6 +32,8 @@ while (($#)); do
   esac
 done
 
+# Root is required in production. CATSCO_PREPARE_SKIP_ROOT_CHECK is a
+# test-only hook used by the isolated probe tests (worker-image-pipeline.test.ts).
 if [[ -z "${CATSCO_PREPARE_SKIP_ROOT_CHECK:-}" ]]; then
   [[ $EUID -eq 0 ]] || die "run as root"
 fi
@@ -116,7 +118,9 @@ apt-get install -y --no-install-recommends \
 #    then "Freezing execution"). The mask is a persistent symlink in /etc, so
 #    masking first means the 8.16 daemon (if the upgrade re-execs it) never has
 #    to process fwupd lifecycle, and worker servers do not need a firmware
-#    update daemon.
+#    update daemon. The masks are best-effort: if the running systemd is
+#    already frozen they may fail, but a frozen host can never satisfy the
+#    systemd/glibc version assertions below, so the bake still fails closed.
 systemctl mask fwupd.service >/dev/null 2>&1 || true
 systemctl stop fwupd.service >/dev/null 2>&1 || true
 systemctl mask fwupd-refresh.service >/dev/null 2>&1 || true

--- a/ops/ctyun-worker-image/prepare-image.sh
+++ b/ops/ctyun-worker-image/prepare-image.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ARTIFACT=""
+SHA256=""
+EXPECTED_COMMIT=""
+EXPECTED_VERSION=""
+FINALIZE=0
+
+usage() {
+  cat <<'EOF'
+Usage:
+  prepare-image.sh --artifact FILE --sha256 HEX --version VERSION --commit SHA
+  prepare-image.sh --finalize
+EOF
+}
+
+die() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+while (($#)); do
+  case "$1" in
+    --artifact) ARTIFACT="${2:-}"; shift 2 ;;
+    --sha256) SHA256="${2:-}"; shift 2 ;;
+    --version) EXPECTED_VERSION="${2:-}"; shift 2 ;;
+    --commit) EXPECTED_COMMIT="${2:-}"; shift 2 ;;
+    --finalize) FINALIZE=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+[[ $EUID -eq 0 ]] || die "run as root"
+
+if [[ $FINALIZE -eq 1 ]]; then
+  systemctl disable --now catsco-agent.service 2>/dev/null || true
+  rm -rf \
+    /srv/catsco-agent/.env \
+    /srv/catsco-agent/.xiaoba \
+    /srv/catsco-agent/data \
+    /srv/catsco-agent/files \
+    /srv/catsco-agent/logs \
+    /srv/catsco-agent/skills \
+    /root/.ssh/authorized_keys \
+    /home/*/.ssh/authorized_keys \
+    /tmp/catsco-* \
+    /tmp/build-image.sh \
+    /tmp/prepare-image.sh \
+    /var/tmp/*
+  find /var/log -type f -exec truncate -s 0 {} \; 2>/dev/null || true
+  rm -f /etc/ssh/ssh_host_* /root/.bash_history /home/*/.bash_history
+  apt-get clean
+  rm -rf /var/lib/apt/lists/*
+  if command -v cloud-init >/dev/null 2>&1; then
+    cloud-init clean --logs --seed
+  fi
+  truncate -s 0 /etc/machine-id
+  rm -f /var/lib/dbus/machine-id
+  sync
+  printf 'image_finalized=yes\n'
+  exit 0
+fi
+
+[[ -f "$ARTIFACT" ]] || die "artifact not found"
+[[ "$SHA256" =~ ^[0-9a-fA-F]{64}$ ]] || die "invalid SHA-256"
+[[ "$EXPECTED_COMMIT" =~ ^[0-9a-fA-F]{40}$ ]] || die "commit must be a full SHA"
+[[ -n "$EXPECTED_VERSION" ]] || die "version is required"
+
+ACTUAL_SHA256="$(sha256sum "$ARTIFACT" | awk '{print $1}')"
+[[ "${ACTUAL_SHA256,,}" == "${SHA256,,}" ]] || die "artifact checksum mismatch"
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install -y --no-install-recommends \
+  ca-certificates \
+  curl \
+  git \
+  jq \
+  poppler-utils \
+  ripgrep \
+  sudo \
+  unzip \
+  zip
+
+id catsco-agent >/dev/null 2>&1 || useradd \
+  --system \
+  --create-home \
+  --home-dir /srv/catsco-agent \
+  --shell /bin/bash \
+  catsco-agent
+
+RELEASE_ID="${EXPECTED_VERSION}-${EXPECTED_COMMIT:0:8}"
+RELEASE_ROOT="/opt/catsco/releases/$RELEASE_ID"
+rm -rf "$RELEASE_ROOT"
+mkdir -p "$RELEASE_ROOT" /opt/catsco/releases /srv/catsco-agent
+
+TEMP_EXTRACT="$(mktemp -d /tmp/catsco-release.XXXXXX)"
+trap 'rm -rf "$TEMP_EXTRACT"' EXIT
+tar -xzf "$ARTIFACT" -C "$TEMP_EXTRACT"
+[[ -f "$TEMP_EXTRACT/app/worker-release.json" ]] || die "worker-release.json missing"
+
+MANIFEST_VERSION="$(jq -r '.version' "$TEMP_EXTRACT/app/worker-release.json")"
+MANIFEST_COMMIT="$(jq -r '.commit' "$TEMP_EXTRACT/app/worker-release.json")"
+[[ "$MANIFEST_VERSION" == "$EXPECTED_VERSION" ]] || die "artifact version mismatch"
+[[ "$MANIFEST_COMMIT" == "$EXPECTED_COMMIT" ]] || die "artifact commit mismatch"
+
+cp -a "$TEMP_EXTRACT/app/." "$RELEASE_ROOT/"
+ln -sfn "$RELEASE_ROOT" /opt/catsco/current
+chown -R root:root /opt/catsco
+chown -R catsco-agent:catsco-agent /srv/catsco-agent
+chmod 0755 /opt/catsco /opt/catsco/releases "$RELEASE_ROOT"
+
+cat >/usr/local/bin/catsco-agent <<'EOF'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+exec /usr/bin/node /opt/catsco/current/dist/index.js "$@"
+EOF
+chmod 0755 /usr/local/bin/catsco-agent
+
+cat >/etc/systemd/system/catsco-agent.service <<'EOF'
+[Unit]
+Description=CatsCo virtual employee
+After=network-online.target
+Wants=network-online.target
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+User=catsco-agent
+Group=catsco-agent
+WorkingDirectory=/srv/catsco-agent
+Environment=HOME=/srv/catsco-agent
+Environment=NODE_ENV=production
+Environment=XIAOBA_APP_ROOT=/opt/catsco/current
+Environment=XIAOBA_USER_DATA_DIR=/srv/catsco-agent
+Environment=XIAOBA_RUNTIME_ROOT=/srv/catsco-agent
+Environment=XIAOBA_RUNTIME_SURFACE=catscompany
+EnvironmentFile=-/srv/catsco-agent/.env
+ExecStart=/usr/bin/node /opt/catsco/current/dist/index.js catsco
+Restart=always
+RestartSec=5
+TimeoutStopSec=30
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+systemctl disable --now catsco-agent.service 2>/dev/null || true
+
+sudo -u catsco-agent -- bash -c '
+  cd /opt/catsco/current
+  node -e '\''require("sharp"); const canvas = require("@napi-rs/canvas"); canvas.createCanvas(2, 2); require("deasync")'\''
+  node dist/index.js --version >/dev/null
+'
+
+cat >/etc/catsco-image.json <<EOF
+{
+  "schemaVersion": 1,
+  "product": "catsco-worker",
+  "version": "$EXPECTED_VERSION",
+  "commit": "$EXPECTED_COMMIT",
+  "releaseId": "$RELEASE_ID"
+}
+EOF
+chmod 0644 /etc/catsco-image.json
+
+if find /opt/catsco -type f \( \
+  -name '.env' \
+  -o -name '.env.local' \
+  -o -name 'id_rsa' \
+  -o -name 'id_ed25519' \
+  -o -name '*.p12' \
+  -o -name '*.pfx' \
+\) -print -quit | grep -q .; then
+  die "secret-like files found under /opt/catsco"
+fi
+
+printf 'image_prepared=yes release_id=%s\n' "$RELEASE_ID"

--- a/ops/ctyun-worker-image/prepare-image.sh
+++ b/ops/ctyun-worker-image/prepare-image.sh
@@ -170,9 +170,13 @@ fi
 # The final dpkg configuration must actually succeed. A version string alone is
 # not enough: a half-configured package can still report the new Version while
 # the image ships a broken dpkg database (review: version gate masked configure
-# failures). Fail closed here.
+# failures). Fail closed here. Note this also means a CLEAN postinst failure
+# (as opposed to a timeout) on the running older systemd now blocks the bake
+# instead of being silently tolerated — producing an image with an unconfigured
+# dpkg database is not acceptable, and a hung manager is already bounded by the
+# outer timeouts.
 if ! dpkg --configure -a >/tmp/catsco-dpkg-configure-final.log 2>&1; then
-  die "dpkg configuration did not complete after systemd/glibc upgrade; see /tmp/catsco-dpkg-configure-final.log"
+  die "dpkg database not fully configured after platform upgrade; see /tmp/catsco-dpkg-configure-final.log"
 fi
 
 SYSTEMD_VERSION="$(dpkg-query -W -f='${Version}' systemd 2>/dev/null || true)"

--- a/ops/ctyun-worker-image/prepare-image.sh
+++ b/ops/ctyun-worker-image/prepare-image.sh
@@ -99,7 +99,20 @@ for list in /var/lib/dpkg/info/*.list; do
 done
 dpkg --configure -a >/dev/null 2>&1 || true
 
-# 2. Upgrade systemd + glibc to the known-safe combination
+# 2. Mask fwupd BEFORE upgrading systemd. On systemd 8.16, handling fwupd
+#    lifecycle can crash systemd itself ("Caught <ABRT>, from our own process"
+#    then "Freezing execution"). The mask is a persistent symlink in /etc, so
+#    masking first means the 8.16 daemon (if the upgrade re-execs it) never has
+#    to process fwupd lifecycle, and worker servers do not need a firmware
+#    update daemon.
+systemctl mask fwupd.service >/dev/null 2>&1 || true
+systemctl stop fwupd.service >/dev/null 2>&1 || true
+systemctl mask fwupd-refresh.service >/dev/null 2>&1 || true
+systemctl stop fwupd-refresh.service >/dev/null 2>&1 || true
+systemctl mask fwupd-refresh.timer >/dev/null 2>&1 || true
+systemctl reset-failed fwupd-refresh.service >/dev/null 2>&1 || true
+
+# 3. Upgrade systemd + glibc to the known-safe combination
 #    (255.4-1ubuntu8.16 + 2.39-0ubuntu8.8). The original image shipped
 #    systemd 8.15 + glibc 8.7 which triggers a _dl_fini assert that freezes
 #    systemd ("Caught <ABRT> ... Freezing execution"); every systemctl call then
@@ -129,7 +142,7 @@ if ! apt-get install --only-upgrade -y \
 fi
 dpkg --configure -a >/dev/null 2>&1 || true
 
-# 3. Upgrade the kernel and regenerate grub. A new kernel without update-grub can
+# 4. Upgrade the kernel and regenerate grub. A new kernel without update-grub can
 #    still boot the old one, and old kernels are retained for rollback.
 apt-get install --only-upgrade -y \
   linux-generic linux-image-generic \
@@ -137,17 +150,6 @@ apt-get install --only-upgrade -y \
 if command -v update-grub >/dev/null 2>&1; then
   update-grub >/dev/null 2>&1 || true
 fi
-
-# 4. Mask fwupd so systemd cannot ABRT on firmware lifecycle events. Even on
-#    systemd 8.16, handling fwupd.service lifecycle can crash systemd itself
-#    ("Caught <ABRT>, from our own process" then "Freezing execution"). Worker
-#    servers do not need a firmware update daemon. The mask is a persistent
-#    symlink in /etc, so freshly provisioned workers stay immune.
-systemctl mask fwupd.service >/dev/null 2>&1 || true
-systemctl stop fwupd.service >/dev/null 2>&1 || true
-systemctl mask fwupd-refresh.service >/dev/null 2>&1 || true
-systemctl stop fwupd-refresh.service >/dev/null 2>&1 || true
-systemctl reset-failed fwupd-refresh.service >/dev/null 2>&1 || true
 
 SYSTEMD_VERSION="$(dpkg-query -W -f='${Version}' systemd 2>/dev/null || true)"
 GLIBC_VERSION="$(dpkg-query -W -f='${Version}' libc6 2>/dev/null || true)"
@@ -170,6 +172,7 @@ id catsco-agent >/dev/null 2>&1 || useradd \
 
 # Service-user npm mirror config (survives finalize; the finalize cleanup list
 # deliberately keeps .npmrc so first-boot npm never needs manual setup).
+mkdir -p /srv/catsco-agent
 printf 'registry=https://registry.npmmirror.com\n' >/srv/catsco-agent/.npmrc
 chown catsco-agent:catsco-agent /srv/catsco-agent/.npmrc
 chmod 0644 /srv/catsco-agent/.npmrc
@@ -243,7 +246,7 @@ StandardError=journal
 WantedBy=multi-user.target
 EOF
 
-systemctl daemon-reload
+systemctl daemon-reload >/dev/null 2>&1 || true
 systemctl disable --now catsco-agent.service 2>/dev/null || true
 
 sudo -u catsco-agent -- bash -c '

--- a/ops/ctyun-worker-image/prepare-image.sh
+++ b/ops/ctyun-worker-image/prepare-image.sh
@@ -78,7 +78,6 @@ apt-get install -y --no-install-recommends \
   curl \
   git \
   jq \
-  nodejs \
   poppler-utils \
   ripgrep \
   sudo \
@@ -108,6 +107,8 @@ MANIFEST_COMMIT="$(jq -r '.commit' "$TEMP_EXTRACT/app/worker-release.json")"
 [[ "$MANIFEST_COMMIT" == "$EXPECTED_COMMIT" ]] || die "artifact commit mismatch"
 
 cp -a "$TEMP_EXTRACT/app/." "$RELEASE_ROOT/"
+[[ -x "$RELEASE_ROOT/runtime/node/bin/node" ]] || die "bundled Node.js runtime missing"
+[[ -x "$RELEASE_ROOT/runtime/node/bin/npm" ]] || die "bundled npm runtime missing"
 ln -sfn "$RELEASE_ROOT" /opt/catsco/current
 chown -R root:root /opt/catsco
 chown -R catsco-agent:catsco-agent /srv/catsco-agent
@@ -116,9 +117,12 @@ chmod 0755 /opt/catsco /opt/catsco/releases "$RELEASE_ROOT"
 cat >/usr/local/bin/catsco-agent <<'EOF'
 #!/usr/bin/env bash
 set -Eeuo pipefail
-exec /usr/bin/node /opt/catsco/current/dist/index.js "$@"
+exec /opt/catsco/current/runtime/node/bin/node /opt/catsco/current/dist/index.js "$@"
 EOF
 chmod 0755 /usr/local/bin/catsco-agent
+ln -sfn /opt/catsco/current/runtime/node/bin/node /usr/local/bin/node
+ln -sfn /opt/catsco/current/runtime/node/bin/npm /usr/local/bin/npm
+ln -sfn /opt/catsco/current/runtime/node/bin/npx /usr/local/bin/npx
 
 cat >/etc/systemd/system/catsco-agent.service <<'EOF'
 [Unit]
@@ -139,7 +143,7 @@ Environment=XIAOBA_USER_DATA_DIR=/srv/catsco-agent
 Environment=XIAOBA_RUNTIME_ROOT=/srv/catsco-agent
 Environment=XIAOBA_RUNTIME_SURFACE=catscompany
 EnvironmentFile=-/srv/catsco-agent/.env
-ExecStart=/usr/bin/node /opt/catsco/current/dist/index.js catsco
+ExecStart=/opt/catsco/current/runtime/node/bin/node /opt/catsco/current/dist/index.js catsco
 Restart=always
 RestartSec=5
 TimeoutStopSec=30
@@ -155,9 +159,13 @@ systemctl disable --now catsco-agent.service 2>/dev/null || true
 
 sudo -u catsco-agent -- bash -c '
   cd /opt/catsco/current
-  node -e '\''require("sharp"); const canvas = require("@napi-rs/canvas"); canvas.createCanvas(2, 2); require("deasync")'\''
-  node dist/index.js --version >/dev/null
+  runtime/node/bin/node -e '\''require("sharp"); const canvas = require("@napi-rs/canvas"); canvas.createCanvas(2, 2); require("deasync")'\''
+  runtime/node/bin/node dist/index.js --version >/dev/null
+  runtime/node/bin/npm --version >/dev/null
 '
+
+dpkg-query -W -f='${Package}\t${Version}\n' | LC_ALL=C sort >/etc/catsco-image-packages.txt
+chmod 0644 /etc/catsco-image-packages.txt
 
 cat >/etc/catsco-image.json <<EOF
 {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "electron:build:mac:arm64": "npm run build && node scripts/prepare-runtime.mjs darwin arm64 && npm run prune:electron-optionals && electron-builder --config electron-builder.config.cjs --mac --arm64 --publish never",
     "release:check": "node scripts/check-release-branding.mjs",
     "release:verify-version": "node scripts/verify-release-version.js",
+    "worker:artifact": "node scripts/build-linux-worker-artifact.mjs",
     "skillhub:trust-root": "node scripts/update-skillhub-root-key.mjs",
     "version:sync": "node scripts/inject-version.js"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "xiaoba": "dist/index.js"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && tsc",
     "dev": "tsx src/index.ts",
     "start": "node dist/index.js",
     "start:cli": "node dist/index.js",

--- a/scripts/build-linux-worker-artifact.mjs
+++ b/scripts/build-linux-worker-artifact.mjs
@@ -1,90 +1,150 @@
 #!/usr/bin/env node
 
-import { execFileSync } from 'node:child_process';
-import crypto from 'node:crypto';
-import fs from 'node:fs';
-import os from 'node:os';
-import path from 'node:path';
-import process from 'node:process';
+import { execFileSync } from "node:child_process";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
 
 const options = parseArgs(process.argv.slice(2));
 const root = path.resolve(options.root || process.cwd());
-const packageJson = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
+const packageJson = JSON.parse(
+  fs.readFileSync(path.join(root, "package.json"), "utf8"),
+);
 const version = options.version || packageJson.version;
-const commit = options.commit || git(root, ['rev-parse', 'HEAD']).trim();
+const commit = options.commit || git(root, ["rev-parse", "HEAD"]).trim();
+if (!/^[0-9a-f]{40}$/i.test(commit)) {
+  throw new Error(
+    `Commit must be a full 40-character Git object ID: ${commit}`,
+  );
+}
+const commitEpoch = Number.parseInt(
+  git(root, ["show", "-s", "--format=%ct", commit]).trim(),
+  10,
+);
+if (!Number.isSafeInteger(commitEpoch) || commitEpoch <= 0) {
+  throw new Error(`Could not resolve the commit timestamp for ${commit}`);
+}
 const shortCommit = commit.slice(0, 8);
 const releaseId = `${version}-${shortCommit}`;
-const outputDir = path.resolve(options.outputDir || path.join(root, 'release', 'worker'));
+const outputDir = path.resolve(
+  options.outputDir || path.join(root, "release", "worker"),
+);
 const artifactPath = path.resolve(
-  options.output || path.join(outputDir, `catsco-worker-${releaseId}-linux-x64.tar.gz`),
+  options.output ||
+    path.join(outputDir, `catsco-worker-${releaseId}-linux-x64.tar.gz`),
 );
 
-if (process.platform !== 'linux' || process.arch !== 'x64') {
+if (process.platform !== "linux" || process.arch !== "x64") {
   throw new Error(
     `Worker artifacts must be built on linux-x64; current platform is ${process.platform}-${process.arch}`,
   );
 }
 
-for (const required of ['dist', 'package.json', 'package-lock.json']) {
+for (const required of ["dist", "package.json", "package-lock.json"]) {
   if (!fs.existsSync(path.join(root, required))) {
     throw new Error(`Missing required build input: ${required}`);
   }
 }
 
 fs.mkdirSync(path.dirname(artifactPath), { recursive: true });
-const stagingRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'catsco-worker-artifact-'));
-const appRoot = path.join(stagingRoot, 'app');
+const stagingRoot = fs.mkdtempSync(
+  path.join(os.tmpdir(), "catsco-worker-artifact-"),
+);
+const appRoot = path.join(stagingRoot, "app");
 
 try {
   fs.mkdirSync(appRoot, { recursive: true });
-  fs.cpSync(path.join(root, 'dist'), path.join(appRoot, 'dist'), {
+  fs.cpSync(path.join(root, "dist"), path.join(appRoot, "dist"), {
     recursive: true,
     dereference: false,
   });
-  copyTrackedFiles(root, appRoot, [
-    '.env.example',
-    'dashboard',
-    'package-lock.json',
-    'package.json',
-    'prompts',
-    'skills',
-  ], options.archiveSource);
+  copyTrackedFiles(
+    root,
+    appRoot,
+    [
+      ".env.example",
+      "dashboard",
+      "package-lock.json",
+      "package.json",
+      "prompts",
+      "skills",
+    ],
+    options.archiveSource,
+  );
 
-  run('npm', [
-    'ci',
-    '--omit=dev',
-    '--ignore-scripts',
-    '--prefer-offline',
-    '--no-audit',
-    '--fund=false',
-  ], { cwd: appRoot });
+  run(
+    "npm",
+    [
+      "ci",
+      "--omit=dev",
+      "--ignore-scripts",
+      "--prefer-offline",
+      "--no-audit",
+      "--fund=false",
+    ],
+    { cwd: appRoot },
+  );
 
-  run('node', [
-    '-e',
-    'require("sharp"); const canvas = require("@napi-rs/canvas"); canvas.createCanvas(2, 2); require("deasync");',
-  ], { cwd: appRoot });
+  run(
+    "node",
+    [
+      "-e",
+      'require("sharp"); const canvas = require("@napi-rs/canvas"); canvas.createCanvas(2, 2); require("deasync");',
+    ],
+    { cwd: appRoot },
+  );
 
   const manifest = {
     schemaVersion: 1,
-    product: 'catsco-worker',
+    product: "catsco-worker",
     version,
     commit,
     releaseId,
-    platform: 'linux',
-    arch: 'x64',
+    platform: "linux",
+    arch: "x64",
     node: process.version,
-    createdAt: new Date().toISOString(),
+    createdAt: new Date(commitEpoch * 1000).toISOString(),
   };
   fs.writeFileSync(
-    path.join(appRoot, 'worker-release.json'),
+    path.join(appRoot, "worker-release.json"),
     `${JSON.stringify(manifest, null, 2)}\n`,
-    'utf8',
+    "utf8",
   );
 
-  run('tar', ['-C', stagingRoot, '-czf', artifactPath, 'app']);
+  const tarPath = path.join(stagingRoot, "catsco-worker.tar");
+  run("tar", [
+    "--sort=name",
+    `--mtime=@${commitEpoch}`,
+    "--owner=0",
+    "--group=0",
+    "--numeric-owner",
+    "--format=posix",
+    "--pax-option=delete=atime,delete=ctime",
+    "-C",
+    stagingRoot,
+    "-cf",
+    tarPath,
+    "app",
+  ]);
+  const artifactFd = fs.openSync(artifactPath, "w");
+  try {
+    run("gzip", ["-n", "-9", "-c", tarPath], {
+      stdio: ["ignore", artifactFd, "inherit"],
+    });
+  } finally {
+    fs.closeSync(artifactFd);
+  }
   const sha256 = hashFile(artifactPath);
-  fs.writeFileSync(`${artifactPath}.sha256`, `${sha256}  ${path.basename(artifactPath)}\n`, 'utf8');
-  process.stdout.write(`${JSON.stringify({ ...manifest, artifactPath, sha256 }, null, 2)}\n`);
+  fs.writeFileSync(
+    `${artifactPath}.sha256`,
+    `${sha256}  ${path.basename(artifactPath)}\n`,
+    "utf8",
+  );
+  process.stdout.write(
+    `${JSON.stringify({ ...manifest, artifactPath, sha256 }, null, 2)}\n`,
+  );
 } finally {
   fs.rmSync(stagingRoot, { recursive: true, force: true });
 }
@@ -93,31 +153,37 @@ function parseArgs(args) {
   const parsed = {};
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
-    if (arg === '--help' || arg === '-h') {
+    if (arg === "--help" || arg === "-h") {
       process.stdout.write(
-        'Usage: node scripts/build-linux-worker-artifact.mjs [--root PATH] [--output PATH] [--output-dir PATH] [--version VERSION] [--commit SHA] [--archive-source]\n',
+        "Usage: node scripts/build-linux-worker-artifact.mjs [--root PATH] [--output PATH] [--output-dir PATH] [--version VERSION] [--commit SHA] [--archive-source]\n",
       );
       process.exit(0);
     }
-    if (arg === '--archive-source') {
+    if (arg === "--archive-source") {
       parsed.archiveSource = true;
       continue;
     }
     const key = {
-      '--root': 'root',
-      '--output': 'output',
-      '--output-dir': 'outputDir',
-      '--version': 'version',
-      '--commit': 'commit',
+      "--root": "root",
+      "--output": "output",
+      "--output-dir": "outputDir",
+      "--version": "version",
+      "--commit": "commit",
     }[arg];
-    if (!key || !args[index + 1]) throw new Error(`Unknown or incomplete argument: ${arg}`);
+    if (!key || !args[index + 1])
+      throw new Error(`Unknown or incomplete argument: ${arg}`);
     parsed[key] = args[index + 1];
     index += 1;
   }
   return parsed;
 }
 
-function copyTrackedFiles(sourceRoot, destinationRoot, pathspecs, archiveSource = false) {
+function copyTrackedFiles(
+  sourceRoot,
+  destinationRoot,
+  pathspecs,
+  archiveSource = false,
+) {
   if (archiveSource) {
     for (const relativePath of pathspecs) {
       const source = path.join(sourceRoot, relativePath);
@@ -129,8 +195,8 @@ function copyTrackedFiles(sourceRoot, destinationRoot, pathspecs, archiveSource 
     return;
   }
 
-  const tracked = git(sourceRoot, ['ls-files', '-z', '--', ...pathspecs])
-    .split('\0')
+  const tracked = git(sourceRoot, ["ls-files", "-z", "--", ...pathspecs])
+    .split("\0")
     .filter(Boolean);
   for (const relativePath of tracked) {
     const source = path.join(sourceRoot, relativePath);
@@ -142,18 +208,18 @@ function copyTrackedFiles(sourceRoot, destinationRoot, pathspecs, archiveSource 
 }
 
 function git(cwd, args) {
-  return execFileSync('git', args, { cwd, encoding: 'utf8' });
+  return execFileSync("git", args, { cwd, encoding: "utf8" });
 }
 
 function run(command, args, options = {}) {
   execFileSync(command, args, {
     ...options,
-    stdio: options.stdio || 'inherit',
+    stdio: options.stdio || "inherit",
   });
 }
 
 function hashFile(filePath) {
-  const hash = crypto.createHash('sha256');
+  const hash = crypto.createHash("sha256");
   hash.update(fs.readFileSync(filePath));
-  return hash.digest('hex');
+  return hash.digest("hex");
 }

--- a/scripts/build-linux-worker-artifact.mjs
+++ b/scripts/build-linux-worker-artifact.mjs
@@ -13,12 +13,21 @@ const packageJson = JSON.parse(
   fs.readFileSync(path.join(root, "package.json"), "utf8"),
 );
 const version = options.version || packageJson.version;
-const commit = options.commit || git(root, ["rev-parse", "HEAD"]).trim();
+if (!/^[0-9A-Za-z][0-9A-Za-z._+-]{0,63}$/.test(version)) {
+  throw new Error(`Invalid release version: ${version}`);
+}
+const headCommit = git(root, ["rev-parse", "HEAD"]).trim();
+const commit = options.commit || headCommit;
 if (!/^[0-9a-f]{40}$/i.test(commit)) {
   throw new Error(
     `Commit must be a full 40-character Git object ID: ${commit}`,
   );
 }
+if (commit.toLowerCase() !== headCommit.toLowerCase()) {
+  throw new Error(`Requested commit ${commit} does not match checked out HEAD ${headCommit}`);
+}
+assertCleanTrackedTree(root);
+
 const commitEpoch = Number.parseInt(
   git(root, ["show", "-s", "--format=%ct", commit]).trim(),
   10,
@@ -42,6 +51,8 @@ if (process.platform !== "linux" || process.arch !== "x64") {
   );
 }
 
+run("npm", ["run", "build"], { cwd: root });
+
 for (const required of ["dist", "package.json", "package-lock.json"]) {
   if (!fs.existsSync(path.join(root, required))) {
     throw new Error(`Missing required build input: ${required}`);
@@ -57,6 +68,7 @@ const appRoot = path.join(stagingRoot, "app");
 try {
   fs.mkdirSync(appRoot, { recursive: true });
   const stagedNode = stageNodeRuntime(appRoot);
+  assertSafeTree(path.join(root, "dist"), root);
   fs.cpSync(path.join(root, "dist"), path.join(appRoot, "dist"), {
     recursive: true,
     dereference: false,
@@ -179,6 +191,37 @@ function parseArgs(args) {
   return parsed;
 }
 
+function assertCleanTrackedTree(sourceRoot) {
+  for (const args of [
+    ["diff", "--quiet", "--ignore-submodules", "--"],
+    ["diff", "--cached", "--quiet", "--ignore-submodules", "--"],
+  ]) {
+    try {
+      execFileSync("git", args, { cwd: sourceRoot, stdio: "ignore" });
+    } catch {
+      throw new Error("Refusing to build an artifact from a dirty tracked tree");
+    }
+  }
+}
+
+function assertSafeTree(treeRoot, repositoryRoot) {
+  const visit = (entryPath) => {
+    const entryStat = fs.lstatSync(entryPath);
+    if (entryStat.isSymbolicLink()) {
+      const target = fs.readlinkSync(entryPath);
+      const resolved = path.resolve(path.dirname(entryPath), target);
+      const relative = path.relative(repositoryRoot, resolved);
+      if (path.isAbsolute(target) || relative.startsWith("..") || path.isAbsolute(relative)) {
+        throw new Error(`Refusing unsafe symbolic link in dist: ${entryPath} -> ${target}`);
+      }
+      throw new Error(`Refusing symbolic link in dist: ${entryPath} -> ${target}`);
+    }
+    if (!entryStat.isDirectory()) return;
+    for (const name of fs.readdirSync(entryPath)) visit(path.join(entryPath, name));
+  };
+  visit(treeRoot);
+}
+
 function copyTrackedFiles(
   sourceRoot,
   destinationRoot,
@@ -189,6 +232,7 @@ function copyTrackedFiles(
     for (const relativePath of pathspecs) {
       const source = path.join(sourceRoot, relativePath);
       if (!fs.existsSync(source)) continue;
+      assertSafeTree(source, sourceRoot);
       const destination = path.join(destinationRoot, relativePath);
       fs.mkdirSync(path.dirname(destination), { recursive: true });
       fs.cpSync(source, destination, { recursive: true, dereference: false });
@@ -201,7 +245,11 @@ function copyTrackedFiles(
     .filter(Boolean);
   for (const relativePath of tracked) {
     const source = path.join(sourceRoot, relativePath);
-    if (!fs.statSync(source).isFile()) continue;
+    const sourceStat = fs.lstatSync(source);
+    if (sourceStat.isSymbolicLink()) {
+      throw new Error(`Refusing tracked symbolic link: ${relativePath}`);
+    }
+    if (!sourceStat.isFile()) continue;
     const destination = path.join(destinationRoot, relativePath);
     fs.mkdirSync(path.dirname(destination), { recursive: true });
     fs.copyFileSync(source, destination);

--- a/scripts/build-linux-worker-artifact.mjs
+++ b/scripts/build-linux-worker-artifact.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+
+const options = parseArgs(process.argv.slice(2));
+const root = path.resolve(options.root || process.cwd());
+const packageJson = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
+const version = options.version || packageJson.version;
+const commit = options.commit || git(root, ['rev-parse', 'HEAD']).trim();
+const shortCommit = commit.slice(0, 8);
+const releaseId = `${version}-${shortCommit}`;
+const outputDir = path.resolve(options.outputDir || path.join(root, 'release', 'worker'));
+const artifactPath = path.resolve(
+  options.output || path.join(outputDir, `catsco-worker-${releaseId}-linux-x64.tar.gz`),
+);
+
+if (process.platform !== 'linux' || process.arch !== 'x64') {
+  throw new Error(
+    `Worker artifacts must be built on linux-x64; current platform is ${process.platform}-${process.arch}`,
+  );
+}
+
+for (const required of ['dist', 'package.json', 'package-lock.json']) {
+  if (!fs.existsSync(path.join(root, required))) {
+    throw new Error(`Missing required build input: ${required}`);
+  }
+}
+
+fs.mkdirSync(path.dirname(artifactPath), { recursive: true });
+const stagingRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'catsco-worker-artifact-'));
+const appRoot = path.join(stagingRoot, 'app');
+
+try {
+  fs.mkdirSync(appRoot, { recursive: true });
+  fs.cpSync(path.join(root, 'dist'), path.join(appRoot, 'dist'), {
+    recursive: true,
+    dereference: false,
+  });
+  copyTrackedFiles(root, appRoot, [
+    '.env.example',
+    'dashboard',
+    'package-lock.json',
+    'package.json',
+    'prompts',
+    'skills',
+  ], options.archiveSource);
+
+  run('npm', [
+    'ci',
+    '--omit=dev',
+    '--ignore-scripts',
+    '--prefer-offline',
+    '--no-audit',
+    '--fund=false',
+  ], { cwd: appRoot });
+
+  run('node', [
+    '-e',
+    'require("sharp"); const canvas = require("@napi-rs/canvas"); canvas.createCanvas(2, 2); require("deasync");',
+  ], { cwd: appRoot });
+
+  const manifest = {
+    schemaVersion: 1,
+    product: 'catsco-worker',
+    version,
+    commit,
+    releaseId,
+    platform: 'linux',
+    arch: 'x64',
+    node: process.version,
+    createdAt: new Date().toISOString(),
+  };
+  fs.writeFileSync(
+    path.join(appRoot, 'worker-release.json'),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+    'utf8',
+  );
+
+  run('tar', ['-C', stagingRoot, '-czf', artifactPath, 'app']);
+  const sha256 = hashFile(artifactPath);
+  fs.writeFileSync(`${artifactPath}.sha256`, `${sha256}  ${path.basename(artifactPath)}\n`, 'utf8');
+  process.stdout.write(`${JSON.stringify({ ...manifest, artifactPath, sha256 }, null, 2)}\n`);
+} finally {
+  fs.rmSync(stagingRoot, { recursive: true, force: true });
+}
+
+function parseArgs(args) {
+  const parsed = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--help' || arg === '-h') {
+      process.stdout.write(
+        'Usage: node scripts/build-linux-worker-artifact.mjs [--root PATH] [--output PATH] [--output-dir PATH] [--version VERSION] [--commit SHA] [--archive-source]\n',
+      );
+      process.exit(0);
+    }
+    if (arg === '--archive-source') {
+      parsed.archiveSource = true;
+      continue;
+    }
+    const key = {
+      '--root': 'root',
+      '--output': 'output',
+      '--output-dir': 'outputDir',
+      '--version': 'version',
+      '--commit': 'commit',
+    }[arg];
+    if (!key || !args[index + 1]) throw new Error(`Unknown or incomplete argument: ${arg}`);
+    parsed[key] = args[index + 1];
+    index += 1;
+  }
+  return parsed;
+}
+
+function copyTrackedFiles(sourceRoot, destinationRoot, pathspecs, archiveSource = false) {
+  if (archiveSource) {
+    for (const relativePath of pathspecs) {
+      const source = path.join(sourceRoot, relativePath);
+      if (!fs.existsSync(source)) continue;
+      const destination = path.join(destinationRoot, relativePath);
+      fs.mkdirSync(path.dirname(destination), { recursive: true });
+      fs.cpSync(source, destination, { recursive: true, dereference: false });
+    }
+    return;
+  }
+
+  const tracked = git(sourceRoot, ['ls-files', '-z', '--', ...pathspecs])
+    .split('\0')
+    .filter(Boolean);
+  for (const relativePath of tracked) {
+    const source = path.join(sourceRoot, relativePath);
+    if (!fs.statSync(source).isFile()) continue;
+    const destination = path.join(destinationRoot, relativePath);
+    fs.mkdirSync(path.dirname(destination), { recursive: true });
+    fs.copyFileSync(source, destination);
+  }
+}
+
+function git(cwd, args) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' });
+}
+
+function run(command, args, options = {}) {
+  execFileSync(command, args, {
+    ...options,
+    stdio: options.stdio || 'inherit',
+  });
+}
+
+function hashFile(filePath) {
+  const hash = crypto.createHash('sha256');
+  hash.update(fs.readFileSync(filePath));
+  return hash.digest('hex');
+}

--- a/scripts/build-linux-worker-artifact.mjs
+++ b/scripts/build-linux-worker-artifact.mjs
@@ -56,6 +56,7 @@ const appRoot = path.join(stagingRoot, "app");
 
 try {
   fs.mkdirSync(appRoot, { recursive: true });
+  const stagedNode = stageNodeRuntime(appRoot);
   fs.cpSync(path.join(root, "dist"), path.join(appRoot, "dist"), {
     recursive: true,
     dereference: false,
@@ -88,7 +89,7 @@ try {
   );
 
   run(
-    "node",
+    stagedNode,
     [
       "-e",
       'require("sharp"); const canvas = require("@napi-rs/canvas"); canvas.createCanvas(2, 2); require("deasync");',
@@ -205,6 +206,39 @@ function copyTrackedFiles(
     fs.mkdirSync(path.dirname(destination), { recursive: true });
     fs.copyFileSync(source, destination);
   }
+}
+
+function stageNodeRuntime(destinationRoot) {
+  const runtimeRoot = path.join(destinationRoot, "runtime", "node");
+  const runtimeBin = path.join(runtimeRoot, "bin");
+  const runtimeModules = path.join(runtimeRoot, "lib", "node_modules");
+  fs.mkdirSync(runtimeBin, { recursive: true });
+  fs.mkdirSync(runtimeModules, { recursive: true });
+
+  const stagedNode = path.join(runtimeBin, "node");
+  fs.copyFileSync(process.execPath, stagedNode);
+  fs.chmodSync(stagedNode, 0o755);
+
+  const globalModules = execFileSync("npm", ["root", "--global"], {
+    encoding: "utf8",
+  }).trim();
+  const npmSource = path.join(globalModules, "npm");
+  if (!fs.existsSync(npmSource)) {
+    throw new Error(`Could not locate npm runtime under ${globalModules}`);
+  }
+  fs.cpSync(npmSource, path.join(runtimeModules, "npm"), {
+    recursive: true,
+    dereference: false,
+  });
+  fs.symlinkSync(
+    "../lib/node_modules/npm/bin/npm-cli.js",
+    path.join(runtimeBin, "npm"),
+  );
+  fs.symlinkSync(
+    "../lib/node_modules/npm/bin/npx-cli.js",
+    path.join(runtimeBin, "npx"),
+  );
+  return stagedNode;
 }
 
 function git(cwd, args) {

--- a/tests/worker-image-pipeline.test.ts
+++ b/tests/worker-image-pipeline.test.ts
@@ -732,7 +732,16 @@ if (operation === "ims ListImage") {
   state.imageDescription = value("--description");
   state.imageStatus = "active";
 } else if (operation === "ims DeleteImage") {
-  state.imageExists = false;
+  if (state.deleteImageFails) {
+    // Simulate a DeleteImage API failure: the image stays and the call errors.
+    state.imageExists = true;
+    state.fakeApiError = true;
+  } else if (state.deleteImageSticky) {
+    // Simulate a delete that never becomes visible (confirmation timeout).
+    state.imageExists = true;
+  } else {
+    state.imageExists = false;
+  }
 } else if (operation === "ecs DeleteEcsInstance") {
   state.instanceExists = false;
 } else if (operation === "ecs DeleteEcsKeypair") {
@@ -743,9 +752,9 @@ if (operation === "ims ListImage") {
 }
 fs.writeFileSync(statePath, JSON.stringify(state));
 process.stdout.write(JSON.stringify({
-  statusCode: 800,
-  message: "SUCCESS",
-  description: "success",
+  statusCode: state.fakeApiError ? 900 : 800,
+  message: state.fakeApiError ? "ERROR" : "SUCCESS",
+  description: state.fakeApiError ? "fake api error" : "success",
   returnObj,
 }));
 `,
@@ -843,7 +852,11 @@ process.exit(result.status ?? 1);
           },
         );
 
-      const runCleanup = (buildNumber: string, imageName: string) =>
+      const runCleanup = (
+        buildNumber: string,
+        imageName: string,
+        extraArgs: string[] = [],
+      ) =>
         spawnSync(
           "pwsh",
           [
@@ -875,6 +888,7 @@ process.exit(result.status ?? 1);
             "subnet-test",
             "-SecurityGroupID",
             "security-group-test",
+            ...extraArgs,
           ],
           {
             cwd: root,
@@ -1237,6 +1251,13 @@ process.exit(result.status ?? 1);
       assert.match(cleanupCalls, /ims DeleteImage/);
       assert.match(cleanupCalls, /ecs DeleteEcsInstance/);
       assert.match(cleanupCalls, /ecs DeleteEcsKeypair/);
+      // The image must be deleted before the builder, which stays as the
+      // sourceServerID ownership evidence until the image is gone.
+      assert.ok(
+        cleanupCalls.indexOf("ims DeleteImage") <
+          cleanupCalls.indexOf("ecs DeleteEcsInstance"),
+        "image must be deleted before the builder (ownership evidence)",
+      );
       const cleanupState = JSON.parse(fs.readFileSync(statePath, "utf8"));
       assert.equal(cleanupState.imageExists, false);
       assert.equal(cleanupState.instanceExists, false);
@@ -1331,6 +1352,93 @@ process.exit(result.status ?? 1);
         fs.readFileSync(statePath, "utf8"),
       );
       assert.equal(keyOnlyCleanupState.keyExists, false);
+
+      // Scenario A: DeleteImage fails -> the image stays and the builder must
+      // be retained as ownership evidence for the next reconciliation.
+      const failImageBuildNumber = "1011";
+      const failImageBakeId = "001011-01";
+      const failImageToken = crypto
+        .createHash("sha256")
+        .update(`${failImageBuildNumber}/1/${commit}`)
+        .digest("hex")
+        .slice(0, 8);
+      fs.writeFileSync(logPath, "");
+      fs.writeFileSync(
+        statePath,
+        JSON.stringify({
+          instanceExists: true,
+          keyExists: true,
+          keyPairName: `catsco-img-key-${failImageBakeId}`,
+          imageExists: true,
+          imageName: `catsco-bake-${commit.slice(0, 8)}-${failImageToken}`,
+          imageDescription: `${releaseIdentity} bake ${failImageBakeId}`,
+          imageSourceServerID: "instance-1",
+          imageStatus: "error",
+          deleteImageFails: true,
+          instanceName: `catsco-img-${failImageBakeId}`,
+          instanceStatus: "stopped",
+        }),
+      );
+      const failImageResult = runCleanup(
+        failImageBuildNumber,
+        "catsco-worker-cleanup-failimage",
+      );
+      assert.notEqual(failImageResult.status, 0);
+      assert.match(
+        `${failImageResult.stdout}\n${failImageResult.stderr}`,
+        /builder cleanup deferred/,
+      );
+      const failImageCalls = fs.readFileSync(logPath, "utf8");
+      assert.match(failImageCalls, /ims DeleteImage/);
+      assert.doesNotMatch(failImageCalls, /ecs DeleteEcsInstance/);
+      const failImageState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+      assert.equal(failImageState.imageExists, true);
+      assert.equal(failImageState.instanceExists, true);
+
+      // Scenario B: DeleteImage succeeds but the image never disappears until
+      // the confirmation window times out -> the builder must be retained.
+      // CleanupTimeoutMinutes is reduced so the bounded confirmation window
+      // fits inside the test timeout.
+      const stickyBuildNumber = "1012";
+      const stickyBakeId = "001012-01";
+      const stickyToken = crypto
+        .createHash("sha256")
+        .update(`${stickyBuildNumber}/1/${commit}`)
+        .digest("hex")
+        .slice(0, 8);
+      fs.writeFileSync(logPath, "");
+      fs.writeFileSync(
+        statePath,
+        JSON.stringify({
+          instanceExists: true,
+          keyExists: true,
+          keyPairName: `catsco-img-key-${stickyBakeId}`,
+          imageExists: true,
+          imageName: `catsco-bake-${commit.slice(0, 8)}-${stickyToken}`,
+          imageDescription: `${releaseIdentity} bake ${stickyBakeId}`,
+          imageSourceServerID: "instance-1",
+          imageStatus: "error",
+          deleteImageSticky: true,
+          instanceName: `catsco-img-${stickyBakeId}`,
+          instanceStatus: "stopped",
+        }),
+      );
+      const stickyResult = runCleanup(
+        stickyBuildNumber,
+        "catsco-worker-cleanup-sticky",
+        ["-ImageDeleteConfirmMinutes", "1"],
+      );
+      assert.notEqual(stickyResult.status, 0);
+      assert.match(
+        `${stickyResult.stdout}\n${stickyResult.stderr}`,
+        /builder cleanup deferred/,
+      );
+      const stickyCalls = fs.readFileSync(logPath, "utf8");
+      assert.match(stickyCalls, /ims DeleteImage/);
+      assert.doesNotMatch(stickyCalls, /ecs DeleteEcsInstance/);
+      const stickyState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+      assert.equal(stickyState.imageExists, true);
+      assert.equal(stickyState.instanceExists, true);
     } finally {
       fs.rmSync(sandbox, { recursive: true, force: true });
     }

--- a/tests/worker-image-pipeline.test.ts
+++ b/tests/worker-image-pipeline.test.ts
@@ -73,6 +73,7 @@ describe("Tianyi Cloud worker image pipeline", () => {
     // fwupd masks prevent the systemd ABRT freeze on 8.16 hosts
     assert.match(imagePreparer, /systemctl mask fwupd\.service/);
     assert.match(imagePreparer, /systemctl mask fwupd-refresh\.service/);
+    assert.match(imagePreparer, /systemctl mask fwupd-refresh\.timer/);
     assert.match(imagePreparer, /systemctl reset-failed fwupd-refresh\.service/);
     // systemd + glibc upgrade to the known-safe 8.16/8.8 combo (_dl_fini freeze)
     assert.match(
@@ -82,8 +83,9 @@ describe("Tianyi Cloud worker image pipeline", () => {
     assert.match(imagePreparer, /libsystemd0 \\/);
     assert.match(imagePreparer, /libc6 \\/);
     assert.match(imagePreparer, /dpkg --configure -a/);
-    // corrupted dpkg file-list repair
-    assert.match(imagePreparer, /missing final newline/);
+    // corrupted dpkg file-list repair (assert the implementation, not the comment)
+    assert.match(imagePreparer, /od -An -c/);
+    assert.match(imagePreparer, /printf '\\n' >>/);
     // kernel upgrade + grub regeneration
     assert.match(imagePreparer, /linux-generic linux-image-generic/);
     assert.match(imagePreparer, /update-grub/);

--- a/tests/worker-image-pipeline.test.ts
+++ b/tests/worker-image-pipeline.test.ts
@@ -69,6 +69,35 @@ describe("Tianyi Cloud worker image pipeline", () => {
     assert.match(imagePreparer, /cloud-init clean --logs --seed/);
   });
 
+  test("platform hardening encodes known Tianyi worker faults", () => {
+    // fwupd masks prevent the systemd ABRT freeze on 8.16 hosts
+    assert.match(imagePreparer, /systemctl mask fwupd\.service/);
+    assert.match(imagePreparer, /systemctl mask fwupd-refresh\.service/);
+    assert.match(imagePreparer, /systemctl reset-failed fwupd-refresh\.service/);
+    // systemd + glibc upgrade to the known-safe 8.16/8.8 combo (_dl_fini freeze)
+    assert.match(
+      imagePreparer,
+      /apt-get install --only-upgrade -y \\\n\s+systemd \\\n\s+systemd-sysv \\\n\s+systemd-timesyncd/,
+    );
+    assert.match(imagePreparer, /libsystemd0 \\/);
+    assert.match(imagePreparer, /libc6 \\/);
+    assert.match(imagePreparer, /dpkg --configure -a/);
+    // corrupted dpkg file-list repair
+    assert.match(imagePreparer, /missing final newline/);
+    // kernel upgrade + grub regeneration
+    assert.match(imagePreparer, /linux-generic linux-image-generic/);
+    assert.match(imagePreparer, /update-grub/);
+    // china-region npm mirror pre-configuration for root and service user
+    assert.match(imagePreparer, /registry\.npmmirror\.com/);
+    assert.match(
+      imagePreparer,
+      /NPM_CONFIG_REGISTRY=https:\/\/registry\.npmmirror\.com/,
+    );
+    // observable platform versions in bake logs
+    assert.match(imagePreparer, /platform_systemd=/);
+    assert.match(imagePreparer, /platform_systemd=%s glibc=%s kernel=%s/);
+  });
+
   test("orchestrator only mutates the exact temporary builder for this bake", () => {
     assert.match(imageOrchestrator, /StartsWith\("catsco-img-"\)/);
     assert.match(imageOrchestrator, /instanceName -ne \$script:BuilderName/);

--- a/tests/worker-image-pipeline.test.ts
+++ b/tests/worker-image-pipeline.test.ts
@@ -510,7 +510,7 @@ process.exit(result.status ?? 1);
       assert.notEqual(foreignResult.status, 0);
       assert.match(
         `${foreignResult.stdout}\n${foreignResult.stderr}`,
-        /Refusing to delete image .*sourceServerID 'instance-foreign'/,
+        /Refusing to delete image[\s\S]*sourceServerID 'instance-foreign'/,
       );
       const foreignCalls = fs.readFileSync(logPath, "utf8");
       assert.doesNotMatch(foreignCalls, /ims DeleteImage/);

--- a/tests/worker-image-pipeline.test.ts
+++ b/tests/worker-image-pipeline.test.ts
@@ -1222,6 +1222,49 @@ process.exit(result.status ?? 1);
       assert.equal(foreignCleanupState.imageExists, true);
       assert.equal(foreignCleanupState.instanceExists, true);
       assert.equal(foreignCleanupState.keyExists, true);
+
+      // Cleanup must detect a bake interrupted right after ImportEcsKeypair:
+      // only the temporary key pair exists (no image, no builder). It must
+      // fail closed with the key pair identity instead of silently reporting
+      // nothing-to-clean.
+      const keyOnlyCleanupBuildNumber = "1010";
+      const keyOnlyCleanupBakeId = "001010-01";
+      fs.writeFileSync(logPath, "");
+      fs.writeFileSync(
+        statePath,
+        JSON.stringify({
+          instanceExists: false,
+          keyExists: true,
+          keyPairName: `catsco-img-key-${keyOnlyCleanupBakeId}`,
+          imageExists: false,
+          imageName: "",
+          imageDescription: "",
+          imageSourceServerID: "",
+          imageStatus: "error",
+          instanceName: "",
+          instanceStatus: "stopped",
+        }),
+      );
+      const keyOnlyCleanupResult = runCleanup(
+        keyOnlyCleanupBuildNumber,
+        "catsco-worker-cleanup-keyonly",
+      );
+      assert.notEqual(keyOnlyCleanupResult.status, 0);
+      assert.match(
+        `${keyOnlyCleanupResult.stdout}\n${keyOnlyCleanupResult.stderr}`,
+        /Automatic historical cleanup refused/,
+      );
+      assert.match(
+        `${keyOnlyCleanupResult.stdout}\n${keyOnlyCleanupResult.stderr}`,
+        /candidate keyPairName=catsco-img-key-001010-01/,
+      );
+      const keyOnlyCleanupCalls = fs.readFileSync(logPath, "utf8");
+      assert.match(keyOnlyCleanupCalls, /ecs GetEcsKeypairDetails/);
+      assert.doesNotMatch(keyOnlyCleanupCalls, /ecs DeleteEcsKeypair/);
+      const keyOnlyCleanupState = JSON.parse(
+        fs.readFileSync(statePath, "utf8"),
+      );
+      assert.equal(keyOnlyCleanupState.keyExists, true);
     } finally {
       fs.rmSync(sandbox, { recursive: true, force: true });
     }

--- a/tests/worker-image-pipeline.test.ts
+++ b/tests/worker-image-pipeline.test.ts
@@ -149,7 +149,9 @@ describe("Tianyi Cloud worker image pipeline", () => {
         [
           "#!/usr/bin/env bash",
           `export PATH="${toMsys(bin)}:$PATH"`,
-          `exec "${toMsys(preparer)}" "$@"`,
+          // exec bash explicitly: the repo's prepare-image.sh may not carry the
+          // executable bit on a fresh Linux checkout, and CI runners enforce it.
+          `exec bash "${toMsys(preparer)}" "$@"`,
           "",
         ].join("\n"),
         "utf8",
@@ -211,7 +213,10 @@ describe("Tianyi Cloud worker image pipeline", () => {
         ].join("\n"),
       };
       for (const [name, body] of Object.entries(mocks)) {
-        fs.writeFileSync(path.join(bin, name), body, "utf8");
+        const mockPath = path.join(bin, name);
+        fs.writeFileSync(mockPath, body, "utf8");
+        // CI runners (Linux) enforce the executable bit; Windows does not.
+        fs.chmodSync(mockPath, 0o755);
       }
 
       const countPath = path.join(sandbox, "compare-count");

--- a/tests/worker-image-pipeline.test.ts
+++ b/tests/worker-image-pipeline.test.ts
@@ -777,7 +777,7 @@ process.exit(result.status ?? 1);
       assert.notEqual(foreignCleanupResult.status, 0);
       assert.match(
         `${foreignCleanupResult.stdout}\n${foreignCleanupResult.stderr}`,
-        /Refusing exact cleanup[\s\S]*ownership metadata does not match/,
+        /Refusing exact cleanup[\s\S]*does not match/,
       );
       const foreignCleanupCalls = fs.readFileSync(logPath, "utf8");
       assert.doesNotMatch(foreignCleanupCalls, /ims DeleteImage/);

--- a/tests/worker-image-pipeline.test.ts
+++ b/tests/worker-image-pipeline.test.ts
@@ -139,10 +139,22 @@ describe("Tianyi Cloud worker image pipeline", () => {
     assert.match(workflow, /-Mode Cleanup/);
     assert.match(workflow, /steps\.bake\.outcome != 'success'/);
     assert.match(workflow, /actions: read/);
-    assert.match(workflow, /Find the latest interrupted image run/);
+    assert.match(workflow, /Find interrupted image runs/);
+    assert.match(workflow, /per_page=100/);
+    assert.match(workflow, /foreach \(\$run in \$runs\)/);
+    assert.match(workflow, /foreach \(\$attempt in 1\.\.\$runAttempt\)/);
+    assert.match(workflow, /foreach \(\$previousAttempt in 1\.\./);
+    assert.match(workflow, /Historical image cleanup needs manual attention/);
+    assert.match(workflow, /GITHUB_STEP_SUMMARY/);
+    assert.match(workflow, /Recent interrupted image cleanup failed/);
+    assert.match(workflow, /recentDeadline[\s\S]*AddMinutes\(45\)/);
+    assert.match(workflow, /historicalDeadline[\s\S]*AddMinutes\(10\)/);
+    assert.match(workflow, /rerunDeadline[\s\S]*AddMinutes\(45\)/);
+    assert.match(workflow, /Previous attempt cleanup failed/);
+    assert.match(workflow, /\$Historical\) \{ '120s' \} else \{ '1000s' \}/);
     assert.match(
       workflow,
-      /steps\.prior_run\.outputs\.run_id[\s\S]*BuildIdentity/,
+      /steps\.prior_runs\.outputs\.runs[\s\S]*INTERRUPTED_RUNS_JSON/,
     );
     assert.doesNotMatch(
       workflow,
@@ -231,8 +243,10 @@ if (operation === "ims ListImage") {
   state.keyExists = true;
   state.keyPairName = value("--keyPairName");
 } else if (operation === "ecs GetEcsKeypairDetails") {
+  const keyVisible = state.keyExists && !(state.keyHiddenReads > 0);
+  if (state.keyHiddenReads > 0) state.keyHiddenReads -= 1;
   returnObj = {
-    results: state.keyExists
+    results: keyVisible
       ? [{ keyPairID: "key-1", keyPairName: state.keyPairName }]
       : [],
   };
@@ -245,9 +259,12 @@ if (operation === "ims ListImage") {
   const requestedID = value("--instanceIDList");
   const requestedName = value("--instanceName");
   const orderLookupStillPending = args.includes("--resourceID");
+  const instanceVisible =
+    state.instanceExists && !(state.instanceHiddenReads > 0);
+  if (state.instanceHiddenReads > 0) state.instanceHiddenReads -= 1;
   returnObj = {
     results:
-      state.instanceExists &&
+      instanceVisible &&
       !orderLookupStillPending &&
       (!requestedID || requestedID === instanceID) &&
       (!requestedName || requestedName === state.instanceName)
@@ -374,6 +391,8 @@ process.exit(result.status ?? 1);
             buildNumber,
             "-BuildAttempt",
             "1",
+            "-LateResourceWaitSeconds",
+            "10",
             "-ImageName",
             imageName,
             "-RegionID",
@@ -591,7 +610,9 @@ process.exit(result.status ?? 1);
         statePath,
         JSON.stringify({
           instanceExists: true,
+          instanceHiddenReads: 1,
           keyExists: true,
+          keyHiddenReads: 1,
           keyPairName: "catsco-img-key-001003-01",
           imageExists: true,
           imageName: "catsco-worker-pending",
@@ -611,6 +632,12 @@ process.exit(result.status ?? 1);
       assert.match(recoveryResult.stdout, /"result":\s*"recovered"/);
       const recoveryCalls = fs.readFileSync(logPath, "utf8");
       assert.doesNotMatch(recoveryCalls, /ecs CreateEcsInstance/);
+      assert.ok(
+        (recoveryCalls.match(/ecs ListEcsInstances/g) || []).length >= 2,
+      );
+      assert.ok(
+        (recoveryCalls.match(/ecs GetEcsKeypairDetails/g) || []).length >= 2,
+      );
       assert.match(recoveryCalls, /ecs DeleteEcsInstance/);
       assert.match(recoveryCalls, /ecs DeleteEcsKeypair/);
       assert.match(recoveryCalls, /ims UpdateImage/);

--- a/tests/worker-image-pipeline.test.ts
+++ b/tests/worker-image-pipeline.test.ts
@@ -147,7 +147,7 @@ describe("Tianyi Cloud worker image pipeline", () => {
     assert.match(workflow, /-ArtifactPath \$env:WORKER_ARTIFACT_PATH/);
     assert.match(workflow, /-BuildNumber \$env:GITHUB_RUN_NUMBER/);
     assert.match(workflow, /-BuildIdentity \$env:GITHUB_RUN_ID/);
-    assert.match(workflow, /timeout-minutes: 420/);
+    assert.match(workflow, /timeout-minutes: 360/);
     assert.match(workflow, /-BakeTimeoutMinutes 150/);
     assert.match(workflow, /-CleanupTimeoutMinutes 40/);
     assert.match(workflow, /-Mode Cleanup/);

--- a/tests/worker-image-pipeline.test.ts
+++ b/tests/worker-image-pipeline.test.ts
@@ -510,7 +510,7 @@ process.exit(result.status ?? 1);
       assert.notEqual(foreignResult.status, 0);
       assert.match(
         `${foreignResult.stdout}\n${foreignResult.stderr}`,
-        /Refusing to delete image[\s\S]*sourceServerID 'instance-foreign'/,
+        /Refusing to delete[\s\S]*sourceServerID 'instance-foreign'/,
       );
       const foreignCalls = fs.readFileSync(logPath, "utf8");
       assert.doesNotMatch(foreignCalls, /ims DeleteImage/);
@@ -545,7 +545,7 @@ process.exit(result.status ?? 1);
       assert.notEqual(foreignIdResult.status, 0);
       assert.match(
         `${foreignIdResult.stdout}\n${foreignIdResult.stderr}`,
-        /Refusing to delete image[\s\S]*does not belong to this bake/,
+        /Refusing to delete[\s\S]*does not belong to this bake/,
       );
       const foreignIdCalls = fs.readFileSync(logPath, "utf8");
       assert.doesNotMatch(foreignIdCalls, /ims DeleteImage/);
@@ -777,7 +777,7 @@ process.exit(result.status ?? 1);
       assert.notEqual(foreignCleanupResult.status, 0);
       assert.match(
         `${foreignCleanupResult.stdout}\n${foreignCleanupResult.stderr}`,
-        /Refusing exact cleanup because the temporary image ownership metadata does not match/,
+        /Refusing exact cleanup[\s\S]*ownership metadata does not match/,
       );
       const foreignCleanupCalls = fs.readFileSync(logPath, "utf8");
       assert.doesNotMatch(foreignCleanupCalls, /ims DeleteImage/);

--- a/tests/worker-image-pipeline.test.ts
+++ b/tests/worker-image-pipeline.test.ts
@@ -98,6 +98,190 @@ describe("Tianyi Cloud worker image pipeline", () => {
     // observable platform versions in bake logs
     assert.match(imagePreparer, /platform_systemd=/);
     assert.match(imagePreparer, /platform_systemd=%s glibc=%s kernel=%s/);
+    // fail-closed version assertions (review: required upgrades must block the bake)
+    assert.match(imagePreparer, /dpkg --compare-versions/);
+    assert.match(imagePreparer, /known-safe version/);
+    assert.ok(
+      imagePreparer.indexOf("od -An -c") < imagePreparer.indexOf("apt-get update"),
+      "dpkg list repair must precede the first apt transaction",
+    );
+  });
+
+  test("platform hardening fails closed and runs dpkg repair before apt", () => {
+    const sandbox = fs.mkdtempSync(
+      path.join(os.tmpdir(), "catsco-harden-probe-"),
+    );
+    try {
+      const bin = path.join(sandbox, "bin");
+      fs.mkdirSync(bin, { recursive: true });
+      const mockLog = path.join(sandbox, "calls.log");
+      // Prefer Git Bash over the WSL bash (C:\Windows\system32\bash.exe) that
+      // would not understand Windows drive paths. All paths handed to bash are
+      // converted to MSYS form (/c/...), and a wrapper exports a Unix-style
+      // PATH so the mocked commands are found inside the script.
+      const bashCandidates = [
+        "C:\\Program Files\\Git\\bin\\bash.exe",
+        "C:\\Program Files (x86)\\Git\\bin\\bash.exe",
+        process.env.LOCALAPPDATA
+          ? path.join(
+              process.env.LOCALAPPDATA,
+              "Programs",
+              "Git",
+              "bin",
+              "bash.exe",
+            )
+          : "",
+      ].filter((p) => p && fs.existsSync(p));
+      const bashExe = bashCandidates[0] || "bash";
+      const toMsys = (p: string) =>
+        p
+          .replace(/\\/g, "/")
+          .replace(/^([A-Za-z]):/, (_m: string, d: string) => `/${d.toLowerCase()}`);
+      const preparer = path.join(
+        root,
+        "ops/ctyun-worker-image/prepare-image.sh",
+      );
+      const artifact = path.join(sandbox, "worker.tar.gz");
+      fs.writeFileSync(artifact, "");
+      const wrapper = path.join(sandbox, "run.sh");
+      fs.writeFileSync(
+        wrapper,
+        [
+          "#!/usr/bin/env bash",
+          `export PATH="${toMsys(bin)}:$PATH"`,
+          `exec "${toMsys(preparer)}" "$@"`,
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+      const sha = "a".repeat(64);
+
+      const mocks: Record<string, string> = {
+        sha256sum: [
+          "#!/usr/bin/env bash",
+          'echo "$CATSCO_MOCK_SHA  $1"',
+        ].join("\n"),
+        "apt-get": [
+          "#!/usr/bin/env bash",
+          'echo "apt-get:$*" >> "$CATSCO_MOCK_LOG"',
+          'if [[ "$*" == *update* ]]; then exit "${CATSCO_MOCK_APT_UPDATE_RC:-0}"; fi',
+          'if [[ "$*" == *--only-upgrade* ]]; then exit "${CATSCO_MOCK_APT_ONLY_UPGRADE_RC:-0}"; fi',
+          "exit 0",
+        ].join("\n"),
+        dpkg: [
+          "#!/usr/bin/env bash",
+          'echo "dpkg:$*" >> "$CATSCO_MOCK_LOG"',
+          'if [[ "$*" == *"--compare-versions"* ]]; then exit "${CATSCO_MOCK_VERSION_OK:-0}"; fi',
+          'if [[ "$*" == *"--configure"* ]]; then exit "${CATSCO_MOCK_DPKG_CONFIGURE_RC:-0}"; fi',
+          "exit 0",
+        ].join("\n"),
+        "dpkg-query": [
+          "#!/usr/bin/env bash",
+          'echo "dpkg-query:$*" >> "$CATSCO_MOCK_LOG"',
+          '[[ "$*" == *systemd* ]] && echo "$CATSCO_MOCK_SYSTEMD_VER"',
+          '[[ "$*" == *libc6* ]] && echo "$CATSCO_MOCK_GLIBC_VER"',
+          "exit 0",
+        ].join("\n"),
+        systemctl: [
+          "#!/usr/bin/env bash",
+          'echo "systemctl:$*" >> "$CATSCO_MOCK_LOG"',
+          "exit 0",
+        ].join("\n"),
+        uname: [
+          "#!/usr/bin/env bash",
+          'echo "uname:$*" >> "$CATSCO_MOCK_LOG"',
+          'echo "6.8.0-136-generic"',
+          "exit 0",
+        ].join("\n"),
+        "update-grub": [
+          "#!/usr/bin/env bash",
+          'echo "update-grub:$*" >> "$CATSCO_MOCK_LOG"',
+          'exit "${CATSCO_MOCK_UPDATE_GRUB_RC:-0}"',
+        ].join("\n"),
+      };
+      for (const [name, body] of Object.entries(mocks)) {
+        fs.writeFileSync(path.join(bin, name), body, "utf8");
+      }
+
+      const runHardening = (extra: Record<string, string>) => {
+        const result = spawnSync(
+          bashExe,
+          [
+            toMsys(wrapper),
+            "--artifact", toMsys(artifact),
+            "--sha256", sha,
+            "--version", "1.4.7",
+            "--commit", "a".repeat(40),
+          ],
+          {
+            encoding: "utf8",
+            env: {
+              ...process.env,
+              PATH: `${bin}${path.delimiter}${process.env.PATH || ""}`,
+              CATSCO_MOCK_LOG: mockLog,
+              CATSCO_MOCK_SHA: sha,
+              CATSCO_PREPARE_SKIP_ROOT_CHECK: "1",
+              ...extra,
+            },
+          },
+        );
+        return result;
+      };
+
+      // Probe 1: every --only-upgrade attempt fails AND versions stay old ->
+      // the bake must fail closed with the known-safe version error.
+      fs.rmSync(mockLog, { force: true });
+      const failResult = runHardening({
+        CATSCO_MOCK_APT_ONLY_UPGRADE_RC: "42",
+        CATSCO_MOCK_VERSION_OK: "1",
+        CATSCO_MOCK_SYSTEMD_VER: "255.4-1ubuntu8.15",
+        CATSCO_MOCK_GLIBC_VER: "2.39-0ubuntu8.7",
+      });
+      assert.notEqual(
+        failResult.status,
+        0,
+        `${failResult.stdout}\n${failResult.stderr}`,
+      );
+      assert.match(failResult.stderr, /known-safe version/);
+
+      // Probe 2: apt succeeds but versions still miss the floor -> fail closed
+      // (the silent broken-image risk the review reproduced).
+      fs.rmSync(mockLog, { force: true });
+      const staleResult = runHardening({
+        CATSCO_MOCK_APT_ONLY_UPGRADE_RC: "0",
+        CATSCO_MOCK_VERSION_OK: "1",
+        CATSCO_MOCK_SYSTEMD_VER: "255.4-1ubuntu8.15",
+        CATSCO_MOCK_GLIBC_VER: "2.39-0ubuntu8.8",
+      });
+      assert.notEqual(
+        staleResult.status,
+        0,
+        `${staleResult.stdout}\n${staleResult.stderr}`,
+      );
+      assert.match(staleResult.stderr, /known-safe version/);
+
+      // Probe 3: with everything healthy the version gate passes, and the
+      // first dpkg --configure runs before the first apt-get transaction.
+      fs.rmSync(mockLog, { force: true });
+      const orderResult = runHardening({
+        CATSCO_MOCK_APT_ONLY_UPGRADE_RC: "0",
+        CATSCO_MOCK_VERSION_OK: "0",
+        CATSCO_MOCK_SYSTEMD_VER: "255.4-1ubuntu8.16",
+        CATSCO_MOCK_GLIBC_VER: "2.39-0ubuntu8.8",
+      });
+      const orderCalls = fs.readFileSync(mockLog, "utf8");
+      const firstConfigure = orderCalls.indexOf("dpkg:--configure");
+      const firstAptUpdate = orderCalls.indexOf("apt-get:update");
+      assert.ok(firstConfigure >= 0, orderCalls);
+      assert.ok(firstAptUpdate >= 0, orderCalls);
+      assert.ok(
+        firstConfigure < firstAptUpdate,
+        `dpkg repair must run before the first apt transaction\n${orderCalls}`,
+      );
+      assert.doesNotMatch(orderResult.stderr, /known-safe version/);
+    } finally {
+      fs.rmSync(sandbox, { recursive: true, force: true });
+    }
   });
 
   test("orchestrator only mutates the exact temporary builder for this bake", () => {
@@ -733,15 +917,15 @@ process.exit(result.status ?? 1);
       assert.ok(
         (recoveryCalls.match(/ecs ListEcsInstances/g) || []).length >= 2,
       );
-      assert.doesNotMatch(recoveryCalls, /ecs GetEcsKeypairDetails/);
+      assert.match(recoveryCalls, /ecs GetEcsKeypairDetails/);
       assert.match(recoveryCalls, /ecs DeleteEcsInstance/);
-      assert.doesNotMatch(recoveryCalls, /ecs DeleteEcsKeypair/);
+      assert.match(recoveryCalls, /ecs DeleteEcsKeypair/);
       assert.match(recoveryCalls, /ims UpdateImage/);
       const recoveryState = JSON.parse(fs.readFileSync(statePath, "utf8"));
       assert.equal(recoveryState.imageExists, true);
       assert.equal(recoveryState.imageDescription, releaseDescription);
       assert.equal(recoveryState.instanceExists, false);
-      assert.equal(recoveryState.keyExists, true);
+      assert.equal(recoveryState.keyExists, false);
 
       fs.writeFileSync(logPath, "");
       fs.writeFileSync(
@@ -774,12 +958,16 @@ process.exit(result.status ?? 1);
         reusedNameRecoveryCalls,
         /ecs DeleteEcsInstance/,
       );
-      assert.doesNotMatch(reusedNameRecoveryCalls, /ecs DeleteEcsKeypair/);
+      // The instance is protected (source ID mismatch), but the key pair's
+      // unique temporary name is proven by the pending bake marker, so the
+      // recovery deletes it instead of leaking a billed key pair.
+      assert.match(reusedNameRecoveryCalls, /ecs DeleteEcsKeypair/);
       const reusedNameRecoveryState = JSON.parse(
         fs.readFileSync(statePath, "utf8"),
       );
       assert.equal(reusedNameRecoveryState.instanceExists, true);
       assert.equal(reusedNameRecoveryState.instanceID, "instance-new");
+      assert.equal(reusedNameRecoveryState.keyExists, false);
       assert.equal(
         reusedNameRecoveryState.imageDescription,
         releaseDescription,

--- a/tests/worker-image-pipeline.test.ts
+++ b/tests/worker-image-pipeline.test.ts
@@ -1,31 +1,49 @@
-import { describe, test } from 'node:test';
-import * as assert from 'node:assert';
-import * as fs from 'node:fs';
-import * as path from 'node:path';
+import { execFileSync, spawnSync } from "node:child_process";
+import crypto from "node:crypto";
+import { describe, test } from "node:test";
+import * as assert from "node:assert";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 
-const root = path.resolve(__dirname, '..');
+const root = path.resolve(__dirname, "..");
 
-describe('Tianyi Cloud worker image pipeline', () => {
-  const artifactBuilder = read('scripts/build-linux-worker-artifact.mjs');
-  const imagePreparer = read('ops/ctyun-worker-image/prepare-image.sh');
-  const imageOrchestrator = read('ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1');
-  const workflow = read('.github/workflows/worker-image.yml');
+describe("Tianyi Cloud worker image pipeline", () => {
+  const artifactBuilder = read("scripts/build-linux-worker-artifact.mjs");
+  const imagePreparer = read("ops/ctyun-worker-image/prepare-image.sh");
+  const imageOrchestratorPath = path.join(
+    root,
+    "ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1",
+  );
+  const imageOrchestrator = fs.readFileSync(imageOrchestratorPath, "utf8");
+  const workflow = read(".github/workflows/worker-image.yml");
 
-  test('artifact copies tracked source assets and never packages repository history', () => {
-    assert.match(artifactBuilder, /git\(sourceRoot, \['ls-files'/);
-    assert.match(artifactBuilder, /'dist'/);
-    assert.doesNotMatch(artifactBuilder, /fs\.cpSync\(path\.join\(root, '\.git'/);
+  test("artifact is source-free and reproducible for one commit", () => {
+    assert.match(artifactBuilder, /git\(sourceRoot, \[["']ls-files["']/);
+    assert.match(artifactBuilder, /["']dist["']/);
+    assert.doesNotMatch(
+      artifactBuilder,
+      /fs\.cpSync\(path\.join\(root, ["']\.git["']/,
+    );
     assert.match(artifactBuilder, /--omit=dev/);
+    assert.match(artifactBuilder, /--sort=name/);
+    assert.match(artifactBuilder, /--mtime=@\$\{commitEpoch\}/);
+    assert.match(artifactBuilder, /gzip["'], \[["']-n["']/);
+    assert.match(artifactBuilder, /createdAt: new Date\(commitEpoch \* 1000\)/);
   });
 
-  test('image keeps immutable application files separate from runtime data', () => {
+  test("image keeps immutable application files separate from runtime data", () => {
     assert.match(imagePreparer, /RELEASE_ROOT="\/opt\/catsco\/releases\//);
     assert.match(imagePreparer, /XIAOBA_USER_DATA_DIR=\/srv\/catsco-agent/);
     assert.match(imagePreparer, /WorkingDirectory=\/srv\/catsco-agent/);
-    assert.match(imagePreparer, /systemctl disable --now catsco-agent\.service/);
+    assert.match(
+      imagePreparer,
+      /systemctl disable --now catsco-agent\.service/,
+    );
+    assert.match(imagePreparer, /nodejs/);
   });
 
-  test('finalization removes worker identity and machine identity before imaging', () => {
+  test("finalization removes worker identity and machine identity before imaging", () => {
     assert.match(imagePreparer, /\/srv\/catsco-agent\/\.env/);
     assert.match(imagePreparer, /\/srv\/catsco-agent\/\.xiaoba/);
     assert.match(imagePreparer, /\/etc\/ssh\/ssh_host_\*/);
@@ -33,30 +51,293 @@ describe('Tianyi Cloud worker image pipeline', () => {
     assert.match(imagePreparer, /cloud-init clean --logs --seed/);
   });
 
-  test('orchestrator can mutate only a temporary catsco image builder', () => {
+  test("orchestrator only mutates the exact temporary builder for this bake", () => {
     assert.match(imageOrchestrator, /StartsWith\("catsco-img-"\)/);
-    assert.match(imageOrchestrator, /Refusing to operate on non-builder instance/);
+    assert.match(imageOrchestrator, /instanceName -ne \$script:BuilderName/);
+    assert.match(
+      imageOrchestrator,
+      /Refusing to operate on non-builder instance/,
+    );
     assert.match(imageOrchestrator, /mutatesExistingWorkers = \$false/);
     assert.doesNotMatch(imageOrchestrator, /worker1|worker2|ck-work/);
   });
 
-  test('tag workflow publishes a private China artifact before optional image baking', () => {
-    assert.match(workflow, /tags:\s*\n\s*- 'v\*'/);
-    assert.match(workflow, /worker-private\//);
-    assert.match(workflow, /aws s3 presign/);
-    assert.match(workflow, /--expires-in 3600/);
-    assert.doesNotMatch(workflow, /public-read/);
-    assert.doesNotMatch(workflow, /actions\/upload-artifact/);
-    assert.match(workflow, /needs: artifact/);
-    assert.match(workflow, /CTYUN_AUTO_BAKE_WORKER_IMAGE/);
+  test("ambiguous creates and failed images have strict compensating cleanup", () => {
+    assert.match(
+      imageOrchestrator,
+      /"--resourceID", \$script:BuilderResourceID/,
+    );
+    assert.match(imageOrchestrator, /"--instanceName", \$script:BuilderName/);
+    assert.match(imageOrchestrator, /Could not prove cleanup of builder/);
+    assert.match(imageOrchestrator, /ImageCreateAttempted/);
+    assert.match(imageOrchestrator, /Find-ImageByName/);
+    assert.match(imageOrchestrator, /"ims", "DeleteImage"/);
+    assert.match(
+      imageOrchestrator,
+      /Could not confirm deletion of incomplete image/,
+    );
+    assert.match(
+      imageOrchestrator,
+      /Could not confirm deletion of temporary builder/,
+    );
+    assert.doesNotMatch(
+      imageOrchestrator,
+      /Could not delete temporary builder/,
+    );
   });
 
-  test('orchestrator never prints the private artifact URL', () => {
-    assert.match(imageOrchestrator, /signed URL redacted/);
-    assert.doesNotMatch(imageOrchestrator, /artifactSource = \$ArtifactUrl/);
+  test("remote transfer and image preparation cannot run indefinitely", () => {
+    assert.match(imageOrchestrator, /ArtifactTransferTimeoutMinutes/);
+    assert.match(imageOrchestrator, /RemoteBuildTimeoutMinutes/);
+    assert.match(imageOrchestrator, /ServerAliveInterval=15/);
+    assert.match(imageOrchestrator, /--kill-after=120s/);
+  });
+
+  test("workflow is restricted, secret-scoped, and never publishes the artifact", () => {
+    assert.match(workflow, /\^v\[0-9\]\+\\\.\[0-9\]\+\\\.\[0-9\]\+\$/);
+    assert.match(workflow, /github\.ref == 'refs\/heads\/main'/);
+    assert.match(workflow, /default: false/);
+    assert.match(
+      workflow,
+      /git merge-base --is-ancestor "\$GITHUB_SHA" origin\/main/,
+    );
+    assert.match(workflow, /CTYUN_CLI_PACKAGE_SHA256/);
+    assert.match(workflow, /sha256sum --check --strict/);
+    assert.match(
+      workflow,
+      /ArtifactPath '\$\{\{ steps\.artifact_meta\.outputs\.path \}\}'/,
+    );
+    assert.match(workflow, /BuildNumber '\$\{\{ github\.run_number \}\}'/);
+    assert.doesNotMatch(
+      workflow,
+      /TOS_|aws s3|presign|upload-artifact|public-read/,
+    );
+    assert.doesNotMatch(workflow, /^    env:\s*\n\s+CTYUN_AK:/m);
+    assert.match(
+      workflow,
+      /- name: Bake private ECS image[\s\S]*?env:\s*\n\s+CTYUN_AK:/,
+    );
+  });
+
+  test("PowerShell image orchestrator parses successfully", () => {
+    const escapedPath = imageOrchestratorPath.replaceAll("'", "''");
+    execFileSync(
+      "pwsh",
+      [
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        `[scriptblock]::Create((Get-Content -Raw -LiteralPath '${escapedPath}')) | Out-Null`,
+      ],
+      { stdio: "pipe" },
+    );
+  });
+
+  test("failed image bake deletes the image, builder, and key pair", () => {
+    const sandbox = fs.mkdtempSync(
+      path.join(os.tmpdir(), "catsco-worker-image-test-"),
+    );
+    try {
+      const statePath = path.join(sandbox, "state.json");
+      const logPath = path.join(sandbox, "calls.log");
+      const artifactPath = path.join(sandbox, "worker.tar.gz");
+      fs.writeFileSync(
+        statePath,
+        JSON.stringify({
+          instanceExists: false,
+          keyExists: false,
+          imageExists: false,
+          instanceName: "",
+          instanceStatus: "running",
+        }),
+      );
+      fs.writeFileSync(artifactPath, "source-free-worker-artifact");
+      const artifactSha = crypto
+        .createHash("sha256")
+        .update(fs.readFileSync(artifactPath))
+        .digest("hex");
+
+      writeCommand(
+        sandbox,
+        "ctyun-cli",
+        `
+import fs from "node:fs";
+const statePath = process.env.FAKE_CTYUN_STATE;
+const logPath = process.env.FAKE_CTYUN_LOG;
+const args = process.argv.slice(2);
+const operation = args.slice(0, 2).join(" ");
+const state = JSON.parse(fs.readFileSync(statePath, "utf8"));
+const value = flag => {
+  const index = args.indexOf(flag);
+  return index >= 0 ? args[index + 1] : "";
+};
+fs.appendFileSync(logPath, operation + "\\n");
+let returnObj = {};
+if (operation === "ims ListImage") {
+  returnObj = {
+    images: state.imageExists
+      ? [{ imageID: "image-1", imageName: "catsco-worker-test-999" }]
+      : [],
+  };
+} else if (operation === "ecs ImportEcsKeypair") {
+  state.keyExists = true;
+} else if (operation === "ecs GetEcsKeypairDetails") {
+  returnObj = {
+    results: state.keyExists
+      ? [{ keyPairID: "key-1", keyPairName: "catsco-img-key-000999-01" }]
+      : [],
+  };
+} else if (operation === "ecs CreateEcsInstance") {
+  state.instanceExists = true;
+  state.instanceName = value("--instanceName");
+  returnObj = { masterResourceID: "resource-1" };
+} else if (operation === "ecs ListEcsInstances") {
+  const orderLookupStillPending = args.includes("--resourceID");
+  returnObj = {
+    results: state.instanceExists && !orderLookupStillPending
+      ? [{
+          instanceID: "instance-1",
+          resourceID: "resource-1",
+          instanceName: state.instanceName,
+          instanceStatus: state.instanceStatus,
+          floatingIP: "127.0.0.1",
+        }]
+      : [],
+  };
+} else if (operation === "ecs StopEcsInstance") {
+  state.instanceStatus = "stopped";
+} else if (operation === "ims CreateImage") {
+  state.imageExists = true;
+  returnObj = { images: [] };
+} else if (operation === "ims GetImageDetail") {
+  returnObj = {
+    images: state.imageExists
+      ? [{ imageID: "image-1", imageStatus: "error", taskProgress: "100" }]
+      : [],
+  };
+} else if (operation === "ims DeleteImage") {
+  state.imageExists = false;
+} else if (operation === "ecs DeleteEcsInstance") {
+  state.instanceExists = false;
+} else if (operation === "ecs DeleteEcsKeypair") {
+  state.keyExists = false;
+} else {
+  process.stderr.write("unexpected fake operation: " + operation + "\\n");
+  process.exit(2);
+}
+fs.writeFileSync(statePath, JSON.stringify(state));
+process.stdout.write(JSON.stringify({
+  statusCode: 800,
+  message: "SUCCESS",
+  description: "success",
+  returnObj,
+}));
+`,
+      );
+      writeCommand(
+        sandbox,
+        "ssh-keygen",
+        `
+import fs from "node:fs";
+const args = process.argv.slice(2);
+const output = args[args.indexOf("-f") + 1];
+fs.writeFileSync(output, "private");
+fs.writeFileSync(output + ".pub", "ssh-rsa AAAA catsco-test");
+`,
+      );
+      for (const command of ["ssh", "scp", "timeout"]) {
+        writeCommand(sandbox, command, "process.exit(0);");
+      }
+
+      const result = spawnSync(
+        "pwsh",
+        [
+          "-NoProfile",
+          "-NonInteractive",
+          "-File",
+          imageOrchestratorPath,
+          "-Mode",
+          "Create",
+          "-SourceRef",
+          "HEAD",
+          "-ArtifactPath",
+          artifactPath,
+          "-ArtifactSha256",
+          artifactSha,
+          "-BuildNumber",
+          "999",
+          "-BuildAttempt",
+          "1",
+          "-ImageName",
+          "catsco-worker-test-999",
+          "-RegionID",
+          "region-test",
+          "-AzName",
+          "az-test",
+          "-BaseImageID",
+          "base-image-test",
+          "-FlavorID",
+          "flavor-test",
+          "-VpcID",
+          "vpc-test",
+          "-SubnetID",
+          "subnet-test",
+          "-SecurityGroupID",
+          "security-group-test",
+        ],
+        {
+          cwd: root,
+          encoding: "utf8",
+          timeout: 30_000,
+          env: {
+            ...process.env,
+            PATH: `${sandbox}${path.delimiter}${process.env.PATH || ""}`,
+            FAKE_CTYUN_STATE: statePath,
+            FAKE_CTYUN_LOG: logPath,
+          },
+        },
+      );
+
+      assert.notEqual(
+        result.status,
+        0,
+        `expected the image error to fail the bake\n${result.stdout}\n${result.stderr}`,
+      );
+      const calls = fs.readFileSync(logPath, "utf8");
+      assert.match(
+        calls,
+        /ims DeleteImage/,
+        `${result.stdout}\n${result.stderr}`,
+      );
+      assert.match(calls, /ecs DeleteEcsInstance/);
+      assert.match(calls, /ecs DeleteEcsKeypair/);
+      assert.ok(
+        calls.indexOf("ims DeleteImage") <
+          calls.indexOf("ecs DeleteEcsInstance"),
+      );
+      assert.deepEqual(JSON.parse(fs.readFileSync(statePath, "utf8")), {
+        instanceExists: false,
+        keyExists: false,
+        imageExists: false,
+        instanceName: "catsco-img-000999-01",
+        instanceStatus: "stopped",
+      });
+    } finally {
+      fs.rmSync(sandbox, { recursive: true, force: true });
+    }
   });
 });
 
 function read(relativePath: string): string {
-  return fs.readFileSync(path.join(root, relativePath), 'utf8');
+  return fs.readFileSync(path.join(root, relativePath), "utf8");
+}
+
+function writeCommand(directory: string, name: string, body: string): void {
+  const commandPath = path.join(directory, name);
+  fs.writeFileSync(commandPath, `#!/usr/bin/env node\n${body.trim()}\n`);
+  fs.chmodSync(commandPath, 0o755);
+  fs.writeFileSync(
+    `${commandPath}.cmd`,
+    `@echo off\r\nnode "%~dp0${name}" %*\r\n`,
+  );
 }

--- a/tests/worker-image-pipeline.test.ts
+++ b/tests/worker-image-pipeline.test.ts
@@ -458,6 +458,35 @@ describe("Tianyi Cloud worker image pipeline", () => {
         `${statusResult.stdout}\n${statusResult.stderr}`,
       );
       assert.match(statusResult.stderr, /not fully configured/);
+
+      // Probe 10: real dpkg-query prints '${db:Status-Abbrev}' with a trailing
+      // space for a healthy package (e.g. 'ii '). The whitespace-normalized
+      // comparison must accept it, otherwise every healthy bake is rejected.
+      fs.rmSync(mockLog, { force: true });
+      const trailingSpaceResult = runHardening({
+        CATSCO_MOCK_APT_ONLY_UPGRADE_RC: "0",
+        CATSCO_MOCK_VERSION_SYSTEMD_OK: "0",
+        CATSCO_MOCK_VERSION_GLIBC_OK: "0",
+        CATSCO_MOCK_SYSTEMD_VER: "255.4-1ubuntu8.16",
+        CATSCO_MOCK_GLIBC_VER: "2.39-0ubuntu8.8",
+        CATSCO_MOCK_SYSTEMD_STATUS: "ii ",
+        CATSCO_MOCK_GLIBC_STATUS: "ii ",
+      });
+      assert.doesNotMatch(
+        trailingSpaceResult.stderr,
+        /not fully configured/,
+        `${trailingSpaceResult.stdout}\n${trailingSpaceResult.stderr}`,
+      );
+      // The status gate is passed (execution continues past it and prints the
+      // platform line). The script then configures /root/.npmrc, which does
+      // not exist in the non-root test sandbox, so the overall exit code is
+      // not asserted here (the healthy-status probe is about the gate, not
+      // about the sandbox's missing /root).
+      assert.match(
+        trailingSpaceResult.stdout,
+        /platform_systemd=255\.4-1ubuntu8\.16/,
+        `${trailingSpaceResult.stdout}\n${trailingSpaceResult.stderr}`,
+      );
     } finally {
       fs.rmSync(sandbox, { recursive: true, force: true });
     }
@@ -672,6 +701,19 @@ if (operation === "ims ListImage") {
   state.instanceName = value("--instanceName");
   returnObj = { masterResourceID: "resource-1" };
 } else if (operation === "ecs ListEcsInstances") {
+  if (state.listInstancesFailures > 0) {
+    // Single-shot discovery API failure: this call errors but later calls
+    // succeed, so a discovery failure must not be mistaken for "gone".
+    state.listInstancesFailures -= 1;
+    fs.writeFileSync(statePath, JSON.stringify(state));
+    process.stdout.write(JSON.stringify({
+      statusCode: 900,
+      message: "ERROR",
+      description: "fake discovery error",
+      returnObj: {},
+    }));
+    process.exit(0);
+  }
   const instanceID = state.instanceID || "instance-1";
   const requestedID = value("--instanceIDList");
   const requestedName = value("--instanceName");
@@ -1439,6 +1481,129 @@ process.exit(result.status ?? 1);
       const stickyState = JSON.parse(fs.readFileSync(statePath, "utf8"));
       assert.equal(stickyState.imageExists, true);
       assert.equal(stickyState.instanceExists, true);
+
+      // Cleanup discovery must not trust a single empty read: the key pair is
+      // hidden for the first reads (eventual consistency), so discovery must
+      // retry with consecutive-empty reads before concluding it is gone.
+      const hiddenKeyBuildNumber = "1013";
+      const hiddenKeyBakeId = "001013-01";
+      fs.writeFileSync(logPath, "");
+      fs.writeFileSync(
+        statePath,
+        JSON.stringify({
+          instanceExists: false,
+          keyExists: true,
+          keyHiddenReads: 2, // hide the discovery reads; visible on the 3rd
+          keyPairName: `catsco-img-key-${hiddenKeyBakeId}`,
+          imageExists: false,
+          imageName: "",
+          imageDescription: "",
+          imageSourceServerID: "",
+          imageStatus: "error",
+          instanceName: "",
+          instanceStatus: "stopped",
+        }),
+      );
+      const hiddenKeyResult = runCleanup(
+        hiddenKeyBuildNumber,
+        "catsco-worker-cleanup-hiddenkey",
+      );
+      assert.equal(
+        hiddenKeyResult.status,
+        0,
+        `${hiddenKeyResult.stdout}\n${hiddenKeyResult.stderr}`,
+      );
+      assert.match(hiddenKeyResult.stdout, /"result":\s*"reconciled"/);
+      const hiddenKeyCalls = fs.readFileSync(logPath, "utf8");
+      assert.ok(
+        (hiddenKeyCalls.match(/ecs GetEcsKeypairDetails/g) || []).length >= 3,
+        `expected consecutive-empty key discovery reads\n${hiddenKeyCalls}`,
+      );
+      assert.match(hiddenKeyCalls, /ecs DeleteEcsKeypair/);
+      const hiddenKeyState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+      assert.equal(hiddenKeyState.keyExists, false);
+
+      // Cleanup builder discovery must also survive eventually-consistent
+      // empty reads: the builder is hidden for the first reads, then found by
+      // its unique temporary name and reconciled.
+      const hiddenBuilderBuildNumber = "1014";
+      const hiddenBuilderBakeId = "001014-01";
+      fs.writeFileSync(logPath, "");
+      fs.writeFileSync(
+        statePath,
+        JSON.stringify({
+          instanceExists: true,
+          instanceHiddenReads: 2,
+          keyExists: false,
+          keyPairName: "",
+          imageExists: false,
+          imageName: "",
+          imageDescription: "",
+          imageSourceServerID: "",
+          imageStatus: "error",
+          instanceName: `catsco-img-${hiddenBuilderBakeId}`,
+          instanceStatus: "stopped",
+        }),
+      );
+      const hiddenBuilderResult = runCleanup(
+        hiddenBuilderBuildNumber,
+        "catsco-worker-cleanup-hbuilder",
+      );
+      assert.equal(
+        hiddenBuilderResult.status,
+        0,
+        `${hiddenBuilderResult.stdout}\n${hiddenBuilderResult.stderr}`,
+      );
+      assert.match(hiddenBuilderResult.stdout, /"result":\s*"reconciled"/);
+      const hiddenBuilderCalls = fs.readFileSync(logPath, "utf8");
+      assert.ok(
+        (hiddenBuilderCalls.match(/ecs ListEcsInstances/g) || []).length >= 3,
+        `expected consecutive-empty builder discovery reads\n${hiddenBuilderCalls}`,
+      );
+      assert.match(hiddenBuilderCalls, /ecs DeleteEcsInstance/);
+      const hiddenBuilderState = JSON.parse(
+        fs.readFileSync(statePath, "utf8"),
+      );
+      assert.equal(hiddenBuilderState.instanceExists, false);
+
+      // A builder-discovery API failure must not skip the other resources:
+      // the key pair is still reconciled even though the builder query
+      // errored. The error joins the aggregate and the run fails closed
+      // naming it, instead of aborting before the key pair is touched.
+      const discoveryErrorBuildNumber = "1015";
+      const discoveryErrorBakeId = "001015-01";
+      fs.writeFileSync(logPath, "");
+      fs.writeFileSync(
+        statePath,
+        JSON.stringify({
+          instanceExists: true,
+          listInstancesFailures: 1, // first ListEcsInstances call errors
+          keyExists: true,
+          keyPairName: `catsco-img-key-${discoveryErrorBakeId}`,
+          imageExists: false,
+          imageName: "",
+          imageDescription: "",
+          imageSourceServerID: "",
+          imageStatus: "error",
+          instanceName: `catsco-img-${discoveryErrorBakeId}`,
+          instanceStatus: "stopped",
+        }),
+      );
+      const discoveryErrorResult = runCleanup(
+        discoveryErrorBuildNumber,
+        "catsco-worker-cleanup-discerr",
+      );
+      assert.notEqual(discoveryErrorResult.status, 0);
+      assert.match(
+        `${discoveryErrorResult.stdout}\n${discoveryErrorResult.stderr}`,
+        /builder discovery/,
+      );
+      const discoveryErrorCalls = fs.readFileSync(logPath, "utf8");
+      assert.match(discoveryErrorCalls, /ecs DeleteEcsKeypair/);
+      const discoveryErrorState = JSON.parse(
+        fs.readFileSync(statePath, "utf8"),
+      );
+      assert.equal(discoveryErrorState.keyExists, false);
     } finally {
       fs.rmSync(sandbox, { recursive: true, force: true });
     }

--- a/tests/worker-image-pipeline.test.ts
+++ b/tests/worker-image-pipeline.test.ts
@@ -106,7 +106,7 @@ describe("Tianyi Cloud worker image pipeline", () => {
     // version gate masked configure failures)
     assert.match(imagePreparer, /db:Status-Abbrev/);
     assert.match(imagePreparer, /not fully configured/);
-    assert.match(imagePreparer, /dpkg configuration did not complete/);
+    assert.match(imagePreparer, /dpkg database not fully configured/);
     // fwupd masks are verified through their persistent /etc symlink and a
     // failed mask blocks the bake (review: swallowed mask failures)
     assert.match(imagePreparer, /readlink/);
@@ -438,7 +438,7 @@ describe("Tianyi Cloud worker image pipeline", () => {
       );
       assert.match(
         dpkgResult.stderr,
-        /dpkg configuration did not complete/,
+        /dpkg database not fully configured/,
       );
 
       // Probe 9: a half-configured package (status not 'ii') blocks the bake

--- a/tests/worker-image-pipeline.test.ts
+++ b/tests/worker-image-pipeline.test.ts
@@ -40,13 +40,19 @@ describe('Tianyi Cloud worker image pipeline', () => {
     assert.doesNotMatch(imageOrchestrator, /worker1|worker2|ck-work/);
   });
 
-  test('tag workflow publishes in China before optional image baking', () => {
+  test('tag workflow publishes a private China artifact before optional image baking', () => {
     assert.match(workflow, /tags:\s*\n\s*- 'v\*'/);
-    assert.match(workflow, /tos-cn-guangzhou\.volces\.com\/worker/);
-    assert.match(workflow, /put-object-acl/);
-    assert.match(workflow, /--acl public-read/);
+    assert.match(workflow, /worker-private\//);
+    assert.match(workflow, /aws s3 presign/);
+    assert.match(workflow, /--expires-in 3600/);
+    assert.doesNotMatch(workflow, /public-read/);
     assert.match(workflow, /needs: artifact/);
     assert.match(workflow, /CTYUN_AUTO_BAKE_WORKER_IMAGE/);
+  });
+
+  test('orchestrator never prints the private artifact URL', () => {
+    assert.match(imageOrchestrator, /signed URL redacted/);
+    assert.doesNotMatch(imageOrchestrator, /artifactSource = \$ArtifactUrl/);
   });
 });
 

--- a/tests/worker-image-pipeline.test.ts
+++ b/tests/worker-image-pipeline.test.ts
@@ -473,7 +473,10 @@ describe("Tianyi Cloud worker image pipeline", () => {
     assert.match(imageOrchestrator, /mutatesExistingWorkers = \$false/);
     assert.match(imageOrchestrator, /no immutable builder identity was recorded/);
     assert.match(imageOrchestrator, /name and immutable ID do not uniquely match/);
-    assert.match(imageOrchestrator, /Automatic historical cleanup refused/);
+    assert.match(
+      imageOrchestrator,
+      /Temporary cloud resource cleanup failed during reconciliation/,
+    );
     assert.doesNotMatch(imageOrchestrator, /worker1|worker2|ck-work/);
   });
 
@@ -1222,19 +1225,22 @@ process.exit(result.status ?? 1);
         cleanupBuildNumber,
         "catsco-worker-cleanup",
       );
-      assert.notEqual(cleanupResult.status, 0);
-      assert.match(
+      // All three resources are uniquely owned by this bake, so reconcile
+      // deletes them (review: cleanup must actually recover, not only report).
+      assert.equal(
+        cleanupResult.status,
+        0,
         `${cleanupResult.stdout}\n${cleanupResult.stderr}`,
-        /Automatic historical cleanup refused/,
       );
+      assert.match(cleanupResult.stdout, /"result":\s*"reconciled"/);
       const cleanupCalls = fs.readFileSync(logPath, "utf8");
-      assert.doesNotMatch(cleanupCalls, /ims DeleteImage/);
-      assert.doesNotMatch(cleanupCalls, /ecs DeleteEcsInstance/);
-      assert.doesNotMatch(cleanupCalls, /ecs DeleteEcsKeypair/);
+      assert.match(cleanupCalls, /ims DeleteImage/);
+      assert.match(cleanupCalls, /ecs DeleteEcsInstance/);
+      assert.match(cleanupCalls, /ecs DeleteEcsKeypair/);
       const cleanupState = JSON.parse(fs.readFileSync(statePath, "utf8"));
-      assert.equal(cleanupState.imageExists, true);
-      assert.equal(cleanupState.instanceExists, true);
-      assert.equal(cleanupState.keyExists, true);
+      assert.equal(cleanupState.imageExists, false);
+      assert.equal(cleanupState.instanceExists, false);
+      assert.equal(cleanupState.keyExists, false);
 
       const foreignCleanupBuildNumber = "1007";
       const foreignCleanupBakeId = "001007-01";
@@ -1265,21 +1271,24 @@ process.exit(result.status ?? 1);
         foreignCleanupBuildNumber,
         "catsco-worker-cleanup-foreign",
       );
+      // The builder (unique name) and key pair are reconciled, but the image's
+      // sourceServerID does not match the resolved builder, so it cannot be
+      // proven and stays fail-closed.
       assert.notEqual(foreignCleanupResult.status, 0);
       assert.match(
         `${foreignCleanupResult.stdout}\n${foreignCleanupResult.stderr}`,
-        /Automatic historical cleanup refused/,
+        /Temporary cloud resource cleanup failed during reconciliation/,
       );
       const foreignCleanupCalls = fs.readFileSync(logPath, "utf8");
       assert.doesNotMatch(foreignCleanupCalls, /ims DeleteImage/);
-      assert.doesNotMatch(foreignCleanupCalls, /ecs DeleteEcsInstance/);
-      assert.doesNotMatch(foreignCleanupCalls, /ecs DeleteEcsKeypair/);
+      assert.match(foreignCleanupCalls, /ecs DeleteEcsInstance/);
+      assert.match(foreignCleanupCalls, /ecs DeleteEcsKeypair/);
       const foreignCleanupState = JSON.parse(
         fs.readFileSync(statePath, "utf8"),
       );
       assert.equal(foreignCleanupState.imageExists, true);
-      assert.equal(foreignCleanupState.instanceExists, true);
-      assert.equal(foreignCleanupState.keyExists, true);
+      assert.equal(foreignCleanupState.instanceExists, false);
+      assert.equal(foreignCleanupState.keyExists, false);
 
       // Cleanup must detect a bake interrupted right after ImportEcsKeypair:
       // only the temporary key pair exists (no image, no builder). It must
@@ -1307,22 +1316,21 @@ process.exit(result.status ?? 1);
         keyOnlyCleanupBuildNumber,
         "catsco-worker-cleanup-keyonly",
       );
-      assert.notEqual(keyOnlyCleanupResult.status, 0);
-      assert.match(
+      // The key pair's unique temporary name is owned by this bake, so reconcile
+      // deletes it instead of only reporting it.
+      assert.equal(
+        keyOnlyCleanupResult.status,
+        0,
         `${keyOnlyCleanupResult.stdout}\n${keyOnlyCleanupResult.stderr}`,
-        /Automatic historical cleanup refused/,
       );
-      assert.match(
-        `${keyOnlyCleanupResult.stdout}\n${keyOnlyCleanupResult.stderr}`,
-        /candidate keyPairName=catsco-img-key-001010-01/,
-      );
+      assert.match(keyOnlyCleanupResult.stdout, /"result":\s*"reconciled"/);
       const keyOnlyCleanupCalls = fs.readFileSync(logPath, "utf8");
       assert.match(keyOnlyCleanupCalls, /ecs GetEcsKeypairDetails/);
-      assert.doesNotMatch(keyOnlyCleanupCalls, /ecs DeleteEcsKeypair/);
+      assert.match(keyOnlyCleanupCalls, /ecs DeleteEcsKeypair/);
       const keyOnlyCleanupState = JSON.parse(
         fs.readFileSync(statePath, "utf8"),
       );
-      assert.equal(keyOnlyCleanupState.keyExists, true);
+      assert.equal(keyOnlyCleanupState.keyExists, false);
     } finally {
       fs.rmSync(sandbox, { recursive: true, force: true });
     }

--- a/tests/worker-image-pipeline.test.ts
+++ b/tests/worker-image-pipeline.test.ts
@@ -1,0 +1,55 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const root = path.resolve(__dirname, '..');
+
+describe('Tianyi Cloud worker image pipeline', () => {
+  const artifactBuilder = read('scripts/build-linux-worker-artifact.mjs');
+  const imagePreparer = read('ops/ctyun-worker-image/prepare-image.sh');
+  const imageOrchestrator = read('ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1');
+  const workflow = read('.github/workflows/worker-image.yml');
+
+  test('artifact copies tracked source assets and never packages repository history', () => {
+    assert.match(artifactBuilder, /git\(sourceRoot, \['ls-files'/);
+    assert.match(artifactBuilder, /'dist'/);
+    assert.doesNotMatch(artifactBuilder, /fs\.cpSync\(path\.join\(root, '\.git'/);
+    assert.match(artifactBuilder, /--omit=dev/);
+  });
+
+  test('image keeps immutable application files separate from runtime data', () => {
+    assert.match(imagePreparer, /RELEASE_ROOT="\/opt\/catsco\/releases\//);
+    assert.match(imagePreparer, /XIAOBA_USER_DATA_DIR=\/srv\/catsco-agent/);
+    assert.match(imagePreparer, /WorkingDirectory=\/srv\/catsco-agent/);
+    assert.match(imagePreparer, /systemctl disable --now catsco-agent\.service/);
+  });
+
+  test('finalization removes worker identity and machine identity before imaging', () => {
+    assert.match(imagePreparer, /\/srv\/catsco-agent\/\.env/);
+    assert.match(imagePreparer, /\/srv\/catsco-agent\/\.xiaoba/);
+    assert.match(imagePreparer, /\/etc\/ssh\/ssh_host_\*/);
+    assert.match(imagePreparer, /truncate -s 0 \/etc\/machine-id/);
+    assert.match(imagePreparer, /cloud-init clean --logs --seed/);
+  });
+
+  test('orchestrator can mutate only a temporary catsco image builder', () => {
+    assert.match(imageOrchestrator, /StartsWith\("catsco-img-"\)/);
+    assert.match(imageOrchestrator, /Refusing to operate on non-builder instance/);
+    assert.match(imageOrchestrator, /mutatesExistingWorkers = \$false/);
+    assert.doesNotMatch(imageOrchestrator, /worker1|worker2|ck-work/);
+  });
+
+  test('tag workflow publishes in China before optional image baking', () => {
+    assert.match(workflow, /tags:\s*\n\s*- 'v\*'/);
+    assert.match(workflow, /tos-cn-guangzhou\.volces\.com\/worker/);
+    assert.match(workflow, /put-object-acl/);
+    assert.match(workflow, /--acl public-read/);
+    assert.match(workflow, /needs: artifact/);
+    assert.match(workflow, /CTYUN_AUTO_BAKE_WORKER_IMAGE/);
+  });
+});
+
+function read(relativePath: string): string {
+  return fs.readFileSync(path.join(root, relativePath), 'utf8');
+}

--- a/tests/worker-image-pipeline.test.ts
+++ b/tests/worker-image-pipeline.test.ts
@@ -165,15 +165,26 @@ describe("Tianyi Cloud worker image pipeline", () => {
           "#!/usr/bin/env bash",
           'echo "apt-get:$*" >> "$CATSCO_MOCK_LOG"',
           'if [[ "$*" == *update* ]]; then exit "${CATSCO_MOCK_APT_UPDATE_RC:-0}"; fi',
+          'if [[ "$*" == *linux-generic* ]]; then exit "${CATSCO_MOCK_KERNEL_UPGRADE_RC:-0}"; fi',
           'if [[ "$*" == *--only-upgrade* ]]; then exit "${CATSCO_MOCK_APT_ONLY_UPGRADE_RC:-0}"; fi',
           "exit 0",
         ].join("\n"),
         dpkg: [
           "#!/usr/bin/env bash",
           'echo "dpkg:$*" >> "$CATSCO_MOCK_LOG"',
-          'if [[ "$*" == *"--compare-versions"* ]]; then exit "${CATSCO_MOCK_VERSION_OK:-0}"; fi',
+          'if [[ "$*" == *"--compare-versions"* ]]; then',
+          '  n=$(cat "$CATSCO_MOCK_COUNT" 2>/dev/null || echo 0)',
+          '  echo $((n + 1)) > "$CATSCO_MOCK_COUNT"',
+          '  if [[ $n -eq 0 ]]; then exit "${CATSCO_MOCK_VERSION_SYSTEMD_OK:-0}"; fi',
+          '  exit "${CATSCO_MOCK_VERSION_GLIBC_OK:-0}"',
+          'fi',
           'if [[ "$*" == *"--configure"* ]]; then exit "${CATSCO_MOCK_DPKG_CONFIGURE_RC:-0}"; fi',
           "exit 0",
+        ].join("\n"),
+        ls: [
+          "#!/usr/bin/env bash",
+          'echo "ls:$*" >> "$CATSCO_MOCK_LOG"',
+          'exit "${CATSCO_MOCK_LS_RC:-0}"',
         ].join("\n"),
         "dpkg-query": [
           "#!/usr/bin/env bash",
@@ -203,7 +214,9 @@ describe("Tianyi Cloud worker image pipeline", () => {
         fs.writeFileSync(path.join(bin, name), body, "utf8");
       }
 
+      const countPath = path.join(sandbox, "compare-count");
       const runHardening = (extra: Record<string, string>) => {
+        fs.rmSync(countPath, { force: true });
         const result = spawnSync(
           bashExe,
           [
@@ -220,6 +233,7 @@ describe("Tianyi Cloud worker image pipeline", () => {
               PATH: `${bin}${path.delimiter}${process.env.PATH || ""}`,
               CATSCO_MOCK_LOG: mockLog,
               CATSCO_MOCK_SHA: sha,
+              CATSCO_MOCK_COUNT: countPath,
               CATSCO_PREPARE_SKIP_ROOT_CHECK: "1",
               ...extra,
             },
@@ -228,44 +242,54 @@ describe("Tianyi Cloud worker image pipeline", () => {
         return result;
       };
 
-      // Probe 1: every --only-upgrade attempt fails AND versions stay old ->
-      // the bake must fail closed with the known-safe version error.
+      // Probe 1: every --only-upgrade attempt fails AND systemd stays old ->
+      // the bake must fail closed naming systemd.
       fs.rmSync(mockLog, { force: true });
       const failResult = runHardening({
         CATSCO_MOCK_APT_ONLY_UPGRADE_RC: "42",
-        CATSCO_MOCK_VERSION_OK: "1",
+        CATSCO_MOCK_VERSION_SYSTEMD_OK: "1",
+        CATSCO_MOCK_VERSION_GLIBC_OK: "0",
         CATSCO_MOCK_SYSTEMD_VER: "255.4-1ubuntu8.15",
-        CATSCO_MOCK_GLIBC_VER: "2.39-0ubuntu8.7",
+        CATSCO_MOCK_GLIBC_VER: "2.39-0ubuntu8.8",
       });
       assert.notEqual(
         failResult.status,
         0,
         `${failResult.stdout}\n${failResult.stderr}`,
       );
-      assert.match(failResult.stderr, /known-safe version/);
+      assert.match(
+        failResult.stderr,
+        /systemd upgrade failed to reach known-safe version/,
+      );
 
-      // Probe 2: apt succeeds but versions still miss the floor -> fail closed
-      // (the silent broken-image risk the review reproduced).
+      // Probe 2: apt succeeds but glibc still misses the floor -> fail closed
+      // naming glibc (proves both assertions are enforced independently).
       fs.rmSync(mockLog, { force: true });
       const staleResult = runHardening({
         CATSCO_MOCK_APT_ONLY_UPGRADE_RC: "0",
-        CATSCO_MOCK_VERSION_OK: "1",
-        CATSCO_MOCK_SYSTEMD_VER: "255.4-1ubuntu8.15",
-        CATSCO_MOCK_GLIBC_VER: "2.39-0ubuntu8.8",
+        CATSCO_MOCK_VERSION_SYSTEMD_OK: "0",
+        CATSCO_MOCK_VERSION_GLIBC_OK: "1",
+        CATSCO_MOCK_SYSTEMD_VER: "255.4-1ubuntu8.16",
+        CATSCO_MOCK_GLIBC_VER: "2.39-0ubuntu8.7",
       });
       assert.notEqual(
         staleResult.status,
         0,
         `${staleResult.stdout}\n${staleResult.stderr}`,
       );
-      assert.match(staleResult.stderr, /known-safe version/);
+      assert.match(
+        staleResult.stderr,
+        /glibc upgrade failed to reach known-safe version/,
+      );
 
-      // Probe 3: with everything healthy the version gate passes, and the
-      // first dpkg --configure runs before the first apt-get transaction.
+      // Probe 3: everything healthy -> version gates pass, no hardening error
+      // (ls is mocked so the /boot check is satisfied), and the first dpkg
+      // --configure runs before the first apt-get transaction.
       fs.rmSync(mockLog, { force: true });
       const orderResult = runHardening({
         CATSCO_MOCK_APT_ONLY_UPGRADE_RC: "0",
-        CATSCO_MOCK_VERSION_OK: "0",
+        CATSCO_MOCK_VERSION_SYSTEMD_OK: "0",
+        CATSCO_MOCK_VERSION_GLIBC_OK: "0",
         CATSCO_MOCK_SYSTEMD_VER: "255.4-1ubuntu8.16",
         CATSCO_MOCK_GLIBC_VER: "2.39-0ubuntu8.8",
       });
@@ -278,7 +302,61 @@ describe("Tianyi Cloud worker image pipeline", () => {
         firstConfigure < firstAptUpdate,
         `dpkg repair must run before the first apt transaction\n${orderCalls}`,
       );
-      assert.doesNotMatch(orderResult.stderr, /known-safe version/);
+      assert.doesNotMatch(
+        orderResult.stderr,
+        /known-safe version|kernel upgrade failed|update-grub failed|no bootable kernel image/,
+      );
+
+      // Probe 4: kernel upgrade failure blocks the bake.
+      fs.rmSync(mockLog, { force: true });
+      const kernelResult = runHardening({
+        CATSCO_MOCK_APT_ONLY_UPGRADE_RC: "0",
+        CATSCO_MOCK_KERNEL_UPGRADE_RC: "1",
+        CATSCO_MOCK_VERSION_SYSTEMD_OK: "0",
+        CATSCO_MOCK_VERSION_GLIBC_OK: "0",
+        CATSCO_MOCK_SYSTEMD_VER: "255.4-1ubuntu8.16",
+        CATSCO_MOCK_GLIBC_VER: "2.39-0ubuntu8.8",
+      });
+      assert.notEqual(
+        kernelResult.status,
+        0,
+        `${kernelResult.stdout}\n${kernelResult.stderr}`,
+      );
+      assert.match(kernelResult.stderr, /kernel upgrade failed/);
+
+      // Probe 5: update-grub failure blocks the bake.
+      fs.rmSync(mockLog, { force: true });
+      const grubResult = runHardening({
+        CATSCO_MOCK_APT_ONLY_UPGRADE_RC: "0",
+        CATSCO_MOCK_UPDATE_GRUB_RC: "1",
+        CATSCO_MOCK_VERSION_SYSTEMD_OK: "0",
+        CATSCO_MOCK_VERSION_GLIBC_OK: "0",
+        CATSCO_MOCK_SYSTEMD_VER: "255.4-1ubuntu8.16",
+        CATSCO_MOCK_GLIBC_VER: "2.39-0ubuntu8.8",
+      });
+      assert.notEqual(
+        grubResult.status,
+        0,
+        `${grubResult.stdout}\n${grubResult.stderr}`,
+      );
+      assert.match(grubResult.stderr, /update-grub failed/);
+
+      // Probe 6: missing /boot kernel image blocks the bake.
+      fs.rmSync(mockLog, { force: true });
+      const bootResult = runHardening({
+        CATSCO_MOCK_APT_ONLY_UPGRADE_RC: "0",
+        CATSCO_MOCK_LS_RC: "2",
+        CATSCO_MOCK_VERSION_SYSTEMD_OK: "0",
+        CATSCO_MOCK_VERSION_GLIBC_OK: "0",
+        CATSCO_MOCK_SYSTEMD_VER: "255.4-1ubuntu8.16",
+        CATSCO_MOCK_GLIBC_VER: "2.39-0ubuntu8.8",
+      });
+      assert.notEqual(
+        bootResult.status,
+        0,
+        `${bootResult.stdout}\n${bootResult.stderr}`,
+      );
+      assert.match(bootResult.stderr, /no bootable kernel image/);
     } finally {
       fs.rmSync(sandbox, { recursive: true, force: true });
     }

--- a/tests/worker-image-pipeline.test.ts
+++ b/tests/worker-image-pipeline.test.ts
@@ -595,6 +595,49 @@ process.exit(result.status ?? 1);
       assert.match(foreignIdCalls, /ecs DeleteEcsInstance/);
       assert.match(foreignIdCalls, /ecs DeleteEcsKeypair/);
 
+      // Key pair identity resolution failure: ImportEcsKeypair succeeds on the
+      // cloud, but the follow-up GetEcsKeypairDetails returns nothing, so
+      // KeyPairID stays empty. The failed bake must still clean up the created
+      // key pair by its unique name (KeyPairCreateAttempted is set right after
+      // the import, before the resolution read).
+      fs.writeFileSync(logPath, "");
+      fs.writeFileSync(
+        statePath,
+        JSON.stringify({
+          instanceExists: false,
+          keyExists: false,
+          keyPairName: "",
+          keyHiddenReads: 2, // hide the existing-check and the ID-resolution reads
+          imageExists: false,
+          imageName: "",
+          imageDescription: "",
+          imageSourceServerID: "",
+          imageStatus: "error",
+          instanceName: "",
+          instanceStatus: "running",
+        }),
+      );
+      const keyResolutionFailResult = runBake(
+        "1012",
+        "catsco-worker-test-1012",
+      );
+      assert.notEqual(
+        keyResolutionFailResult.status,
+        0,
+        `${keyResolutionFailResult.stdout}\n${keyResolutionFailResult.stderr}`,
+      );
+      assert.match(
+        `${keyResolutionFailResult.stdout}\n${keyResolutionFailResult.stderr}`,
+        /Imported key pair could not be resolved/,
+      );
+      const keyResolutionFailCalls = fs.readFileSync(logPath, "utf8");
+      assert.match(keyResolutionFailCalls, /ecs ImportEcsKeypair/);
+      assert.match(keyResolutionFailCalls, /ecs DeleteEcsKeypair/);
+      const keyResolutionFailState = JSON.parse(
+        fs.readFileSync(statePath, "utf8"),
+      );
+      assert.equal(keyResolutionFailState.keyExists, false);
+
       const commit = execFileSync("git", ["rev-parse", "HEAD"], {
         cwd: root,
         encoding: "utf8",

--- a/tests/worker-image-pipeline.test.ts
+++ b/tests/worker-image-pipeline.test.ts
@@ -102,6 +102,11 @@ describe("Tianyi Cloud worker image pipeline", () => {
     // fail-closed version assertions (review: required upgrades must block the bake)
     assert.match(imagePreparer, /dpkg --compare-versions/);
     assert.match(imagePreparer, /known-safe version/);
+    // dpkg configuration must complete and packages must be 'ii' (review:
+    // version gate masked configure failures)
+    assert.match(imagePreparer, /db:Status-Abbrev/);
+    assert.match(imagePreparer, /not fully configured/);
+    assert.match(imagePreparer, /dpkg configuration did not complete/);
     // fwupd masks are verified through their persistent /etc symlink and a
     // failed mask blocks the bake (review: swallowed mask failures)
     assert.match(imagePreparer, /readlink/);
@@ -191,7 +196,24 @@ describe("Tianyi Cloud worker image pipeline", () => {
           '  if [[ $n -eq 0 ]]; then exit "${CATSCO_MOCK_VERSION_SYSTEMD_OK:-0}"; fi',
           '  exit "${CATSCO_MOCK_VERSION_GLIBC_OK:-0}"',
           'fi',
-          'if [[ "$*" == *"--configure"* ]]; then exit "${CATSCO_MOCK_DPKG_CONFIGURE_RC:-0}"; fi',
+          'if [[ "$*" == *"--configure"* ]]; then',
+          '  n=$(cat "$CATSCO_MOCK_CONFIG_COUNT" 2>/dev/null || echo 0)',
+          '  echo $((n + 1)) > "$CATSCO_MOCK_CONFIG_COUNT"',
+          '  if [[ $n -eq 0 ]]; then exit "${CATSCO_MOCK_DPKG_CONFIGURE_FIRST_RC:-0}"; fi',
+          '  exit "${CATSCO_MOCK_DPKG_CONFIGURE_FINAL_RC:-0}"',
+          'fi',
+          "exit 0",
+        ].join("\n"),
+        "dpkg-query": [
+          "#!/usr/bin/env bash",
+          'echo "dpkg-query:$*" >> "$CATSCO_MOCK_LOG"',
+          'if [[ "$*" == *Status* ]]; then',
+          '  [[ "$*" == *systemd* ]] && echo "${CATSCO_MOCK_SYSTEMD_STATUS:-ii}"',
+          '  [[ "$*" == *libc6* ]] && echo "${CATSCO_MOCK_GLIBC_STATUS:-ii}"',
+          '  exit 0',
+          'fi',
+          '[[ "$*" == *systemd* ]] && echo "$CATSCO_MOCK_SYSTEMD_VER"',
+          '[[ "$*" == *libc6* ]] && echo "$CATSCO_MOCK_GLIBC_VER"',
           "exit 0",
         ].join("\n"),
         ls: [
@@ -199,13 +221,6 @@ describe("Tianyi Cloud worker image pipeline", () => {
           'echo "ls:$*" >> "$CATSCO_MOCK_LOG"',
           'if [[ "${CATSCO_MOCK_LS_RC:-0}" != "0" ]]; then exit "${CATSCO_MOCK_LS_RC}"; fi',
           'echo "/boot/vmlinuz-6.8.0-136-generic"',
-          "exit 0",
-        ].join("\n"),
-        "dpkg-query": [
-          "#!/usr/bin/env bash",
-          'echo "dpkg-query:$*" >> "$CATSCO_MOCK_LOG"',
-          '[[ "$*" == *systemd* ]] && echo "$CATSCO_MOCK_SYSTEMD_VER"',
-          '[[ "$*" == *libc6* ]] && echo "$CATSCO_MOCK_GLIBC_VER"',
           "exit 0",
         ].join("\n"),
         systemctl: [
@@ -240,8 +255,10 @@ describe("Tianyi Cloud worker image pipeline", () => {
       }
 
       const countPath = path.join(sandbox, "compare-count");
+      const configCountPath = path.join(sandbox, "config-count");
       const runHardening = (extra: Record<string, string>) => {
         fs.rmSync(countPath, { force: true });
+        fs.rmSync(configCountPath, { force: true });
         const result = spawnSync(
           bashExe,
           [
@@ -259,6 +276,7 @@ describe("Tianyi Cloud worker image pipeline", () => {
               CATSCO_MOCK_LOG: mockLog,
               CATSCO_MOCK_SHA: sha,
               CATSCO_MOCK_COUNT: countPath,
+              CATSCO_MOCK_CONFIG_COUNT: configCountPath,
               CATSCO_PREPARE_SKIP_ROOT_CHECK: "1",
               ...extra,
             },
@@ -400,6 +418,46 @@ describe("Tianyi Cloud worker image pipeline", () => {
         `${maskResult.stdout}\n${maskResult.stderr}`,
       );
       assert.match(maskResult.stderr, /failed to mask/);
+
+      // Probe 8: the final dpkg configuration must complete even when the
+      // versions are fine (a half-configured package still reports the new
+      // version; review: version gate masked configure failures).
+      fs.rmSync(mockLog, { force: true });
+      const dpkgResult = runHardening({
+        CATSCO_MOCK_APT_ONLY_UPGRADE_RC: "0",
+        CATSCO_MOCK_DPKG_CONFIGURE_FINAL_RC: "43",
+        CATSCO_MOCK_VERSION_SYSTEMD_OK: "0",
+        CATSCO_MOCK_VERSION_GLIBC_OK: "0",
+        CATSCO_MOCK_SYSTEMD_VER: "255.4-1ubuntu8.16",
+        CATSCO_MOCK_GLIBC_VER: "2.39-0ubuntu8.8",
+      });
+      assert.notEqual(
+        dpkgResult.status,
+        0,
+        `${dpkgResult.stdout}\n${dpkgResult.stderr}`,
+      );
+      assert.match(
+        dpkgResult.stderr,
+        /dpkg configuration did not complete/,
+      );
+
+      // Probe 9: a half-configured package (status not 'ii') blocks the bake
+      // even when the version gate would pass.
+      fs.rmSync(mockLog, { force: true });
+      const statusResult = runHardening({
+        CATSCO_MOCK_APT_ONLY_UPGRADE_RC: "0",
+        CATSCO_MOCK_VERSION_SYSTEMD_OK: "0",
+        CATSCO_MOCK_VERSION_GLIBC_OK: "0",
+        CATSCO_MOCK_SYSTEMD_VER: "255.4-1ubuntu8.16",
+        CATSCO_MOCK_GLIBC_VER: "2.39-0ubuntu8.8",
+        CATSCO_MOCK_SYSTEMD_STATUS: "iU",
+      });
+      assert.notEqual(
+        statusResult.status,
+        0,
+        `${statusResult.stdout}\n${statusResult.stderr}`,
+      );
+      assert.match(statusResult.stderr, /not fully configured/);
     } finally {
       fs.rmSync(sandbox, { recursive: true, force: true });
     }

--- a/tests/worker-image-pipeline.test.ts
+++ b/tests/worker-image-pipeline.test.ts
@@ -30,6 +30,9 @@ describe("Tianyi Cloud worker image pipeline", () => {
     assert.match(artifactBuilder, /--mtime=@\$\{commitEpoch\}/);
     assert.match(artifactBuilder, /gzip["'], \[["']-n["']/);
     assert.match(artifactBuilder, /createdAt: new Date\(commitEpoch \* 1000\)/);
+    assert.match(workflow, /NODE_VERSION: ["']22\.23\.1["']/);
+    assert.match(artifactBuilder, /stageNodeRuntime\(appRoot\)/);
+    assert.match(artifactBuilder, /npm["'], \[["']root["'], ["']--global["']\]/);
   });
 
   test("image keeps immutable application files separate from runtime data", () => {
@@ -40,7 +43,12 @@ describe("Tianyi Cloud worker image pipeline", () => {
       imagePreparer,
       /systemctl disable --now catsco-agent\.service/,
     );
-    assert.match(imagePreparer, /nodejs/);
+    assert.doesNotMatch(imagePreparer, /^\s+nodejs \\/m);
+    assert.match(
+      imagePreparer,
+      /runtime\/node\/bin\/node .*dist\/index\.js catsco/,
+    );
+    assert.match(imagePreparer, /catsco-image-packages\.txt/);
   });
 
   test("finalization removes worker identity and machine identity before imaging", () => {
@@ -68,7 +76,10 @@ describe("Tianyi Cloud worker image pipeline", () => {
       /"--resourceID", \$script:BuilderResourceID/,
     );
     assert.match(imageOrchestrator, /"--instanceName", \$script:BuilderName/);
-    assert.match(imageOrchestrator, /Could not prove cleanup of builder/);
+    assert.match(
+      imageOrchestrator,
+      /No temporary builder record remains/,
+    );
     assert.match(imageOrchestrator, /ImageCreateAttempted/);
     assert.match(imageOrchestrator, /Find-ImageByName/);
     assert.match(imageOrchestrator, /"ims", "DeleteImage"/);
@@ -89,8 +100,21 @@ describe("Tianyi Cloud worker image pipeline", () => {
   test("remote transfer and image preparation cannot run indefinitely", () => {
     assert.match(imageOrchestrator, /ArtifactTransferTimeoutMinutes/);
     assert.match(imageOrchestrator, /RemoteBuildTimeoutMinutes/);
+    assert.match(imageOrchestrator, /ApiTimeoutSeconds/);
+    assert.match(
+      imageOrchestrator,
+      /"timeout"[\s\S]*?"ctyun-cli"/,
+    );
     assert.match(imageOrchestrator, /ServerAliveInterval=15/);
     assert.match(imageOrchestrator, /--kill-after=120s/);
+    assert.match(
+      imageOrchestrator,
+      /cloud-init status --wait[^"\r\n]+&& printf ready/,
+    );
+    assert.doesNotMatch(
+      imageOrchestrator,
+      /cloud-init status --wait[^"\r\n]+; printf ready/,
+    );
   });
 
   test("workflow is restricted, secret-scoped, and never publishes the artifact", () => {
@@ -108,6 +132,18 @@ describe("Tianyi Cloud worker image pipeline", () => {
       /ArtifactPath '\$\{\{ steps\.artifact_meta\.outputs\.path \}\}'/,
     );
     assert.match(workflow, /BuildNumber '\$\{\{ github\.run_number \}\}'/);
+    assert.match(workflow, /BuildIdentity '\$\{\{ github\.run_id \}\}'/);
+    assert.match(workflow, /timeout-minutes: 420/);
+    assert.match(workflow, /-BakeTimeoutMinutes 150/);
+    assert.match(workflow, /-CleanupTimeoutMinutes 40/);
+    assert.match(workflow, /-Mode Cleanup/);
+    assert.match(workflow, /steps\.bake\.outcome != 'success'/);
+    assert.match(workflow, /actions: read/);
+    assert.match(workflow, /Find the latest interrupted image run/);
+    assert.match(
+      workflow,
+      /steps\.prior_run\.outputs\.run_id[\s\S]*BuildIdentity/,
+    );
     assert.doesNotMatch(
       workflow,
       /TOS_|aws s3|presign|upload-artifact|public-read/,
@@ -133,7 +169,7 @@ describe("Tianyi Cloud worker image pipeline", () => {
     );
   });
 
-  test("failed image bake deletes the image, builder, and key pair", () => {
+  test("image bake lifecycle is owned, idempotent, and strictly cleaned", () => {
     const sandbox = fs.mkdtempSync(
       path.join(os.tmpdir(), "catsco-worker-image-test-"),
     );
@@ -146,7 +182,12 @@ describe("Tianyi Cloud worker image pipeline", () => {
         JSON.stringify({
           instanceExists: false,
           keyExists: false,
+          keyPairName: "",
           imageExists: false,
+          imageName: "",
+          imageDescription: "",
+          imageSourceServerID: "",
+          imageStatus: "error",
           instanceName: "",
           instanceStatus: "running",
         }),
@@ -174,17 +215,25 @@ const value = flag => {
 fs.appendFileSync(logPath, operation + "\\n");
 let returnObj = {};
 if (operation === "ims ListImage") {
+  const requestedName = value("--imageName");
   returnObj = {
-    images: state.imageExists
-      ? [{ imageID: "image-1", imageName: "catsco-worker-test-999" }]
+    images: state.imageExists && state.imageName === requestedName
+      ? [{
+          imageID: "image-1",
+          imageName: state.imageName,
+          imageStatus: state.imageStatus,
+          description: state.imageDescription,
+          sourceServerID: state.imageSourceServerID,
+        }]
       : [],
   };
 } else if (operation === "ecs ImportEcsKeypair") {
   state.keyExists = true;
+  state.keyPairName = value("--keyPairName");
 } else if (operation === "ecs GetEcsKeypairDetails") {
   returnObj = {
     results: state.keyExists
-      ? [{ keyPairID: "key-1", keyPairName: "catsco-img-key-000999-01" }]
+      ? [{ keyPairID: "key-1", keyPairName: state.keyPairName }]
       : [],
   };
 } else if (operation === "ecs CreateEcsInstance") {
@@ -192,11 +241,18 @@ if (operation === "ims ListImage") {
   state.instanceName = value("--instanceName");
   returnObj = { masterResourceID: "resource-1" };
 } else if (operation === "ecs ListEcsInstances") {
+  const instanceID = state.instanceID || "instance-1";
+  const requestedID = value("--instanceIDList");
+  const requestedName = value("--instanceName");
   const orderLookupStillPending = args.includes("--resourceID");
   returnObj = {
-    results: state.instanceExists && !orderLookupStillPending
+    results:
+      state.instanceExists &&
+      !orderLookupStillPending &&
+      (!requestedID || requestedID === instanceID) &&
+      (!requestedName || requestedName === state.instanceName)
       ? [{
-          instanceID: "instance-1",
+          instanceID,
           resourceID: "resource-1",
           instanceName: state.instanceName,
           instanceStatus: state.instanceStatus,
@@ -208,13 +264,39 @@ if (operation === "ims ListImage") {
   state.instanceStatus = "stopped";
 } else if (operation === "ims CreateImage") {
   state.imageExists = true;
-  returnObj = { images: [] };
+  state.imageName = value("--imageName");
+  state.imageDescription = value("--description");
+  state.imageSourceServerID =
+    process.env.FAKE_CTYUN_SCENARIO === "foreign-image" ||
+    process.env.FAKE_CTYUN_SCENARIO === "foreign-id"
+      ? "instance-foreign"
+      : "instance-1";
+  state.imageStatus =
+    process.env.FAKE_CTYUN_SCENARIO === "success" ? "active" : "error";
+  returnObj = {
+    images:
+      process.env.FAKE_CTYUN_SCENARIO === "success"
+        || process.env.FAKE_CTYUN_SCENARIO === "foreign-id"
+        ? [{ imageID: "image-1" }]
+        : [],
+  };
 } else if (operation === "ims GetImageDetail") {
   returnObj = {
     images: state.imageExists
-      ? [{ imageID: "image-1", imageStatus: "error", taskProgress: "100" }]
+      ? [{
+          imageID: "image-1",
+          imageName: state.imageName,
+          imageStatus: state.imageStatus,
+          taskProgress: "100",
+          description: state.imageDescription,
+          sourceServerID: state.imageSourceServerID,
+        }]
       : [],
   };
+} else if (operation === "ims UpdateImage") {
+  state.imageName = value("--imageName");
+  state.imageDescription = value("--description");
+  state.imageStatus = "active";
 } else if (operation === "ims DeleteImage") {
   state.imageExists = false;
 } else if (operation === "ecs DeleteEcsInstance") {
@@ -245,58 +327,131 @@ fs.writeFileSync(output, "private");
 fs.writeFileSync(output + ".pub", "ssh-rsa AAAA catsco-test");
 `,
       );
-      for (const command of ["ssh", "scp", "timeout"]) {
+      for (const command of ["ssh", "scp"]) {
         writeCommand(sandbox, command, "process.exit(0);");
       }
-
-      const result = spawnSync(
-        "pwsh",
-        [
-          "-NoProfile",
-          "-NonInteractive",
-          "-File",
-          imageOrchestratorPath,
-          "-Mode",
-          "Create",
-          "-SourceRef",
-          "HEAD",
-          "-ArtifactPath",
-          artifactPath,
-          "-ArtifactSha256",
-          artifactSha,
-          "-BuildNumber",
-          "999",
-          "-BuildAttempt",
-          "1",
-          "-ImageName",
-          "catsco-worker-test-999",
-          "-RegionID",
-          "region-test",
-          "-AzName",
-          "az-test",
-          "-BaseImageID",
-          "base-image-test",
-          "-FlavorID",
-          "flavor-test",
-          "-VpcID",
-          "vpc-test",
-          "-SubnetID",
-          "subnet-test",
-          "-SecurityGroupID",
-          "security-group-test",
-        ],
-        {
-          cwd: root,
-          encoding: "utf8",
-          timeout: 30_000,
-          env: {
-            ...process.env,
-            PATH: `${sandbox}${path.delimiter}${process.env.PATH || ""}`,
-            FAKE_CTYUN_STATE: statePath,
-            FAKE_CTYUN_LOG: logPath,
-          },
-        },
+      writeCommand(
+        sandbox,
+        "timeout",
+        `
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+const args = process.argv.slice(2);
+const durationIndex = args.findIndex(arg => !arg.startsWith("-"));
+if (durationIndex < 0 || !args[durationIndex + 1]) process.exit(2);
+const command = args[durationIndex + 1];
+const commandPath = path.join(path.dirname(process.argv[1]), command);
+const result = spawnSync(
+  process.execPath,
+  [commandPath, ...args.slice(durationIndex + 2)],
+  { stdio: "inherit" },
+);
+process.exit(result.status ?? 1);
+`,
       );
+
+      const runBake = (
+        buildNumber: string,
+        imageName: string,
+        scenario = "",
+      ) =>
+        spawnSync(
+          "pwsh",
+          [
+            "-NoProfile",
+            "-NonInteractive",
+            "-File",
+            imageOrchestratorPath,
+            "-Mode",
+            "Create",
+            "-SourceRef",
+            "HEAD",
+            "-ArtifactPath",
+            artifactPath,
+            "-ArtifactSha256",
+            artifactSha,
+            "-BuildNumber",
+            buildNumber,
+            "-BuildAttempt",
+            "1",
+            "-ImageName",
+            imageName,
+            "-RegionID",
+            "region-test",
+            "-AzName",
+            "az-test",
+            "-BaseImageID",
+            "base-image-test",
+            "-FlavorID",
+            "flavor-test",
+            "-VpcID",
+            "vpc-test",
+            "-SubnetID",
+            "subnet-test",
+            "-SecurityGroupID",
+            "security-group-test",
+          ],
+          {
+            cwd: root,
+            encoding: "utf8",
+            timeout: 30_000,
+            env: {
+              ...process.env,
+              PATH: `${sandbox}${path.delimiter}${process.env.PATH || ""}`,
+              FAKE_CTYUN_STATE: statePath,
+              FAKE_CTYUN_LOG: logPath,
+              FAKE_CTYUN_SCENARIO: scenario,
+            },
+          },
+        );
+
+      const runCleanup = (buildNumber: string, imageName: string) =>
+        spawnSync(
+          "pwsh",
+          [
+            "-NoProfile",
+            "-NonInteractive",
+            "-File",
+            imageOrchestratorPath,
+            "-Mode",
+            "Cleanup",
+            "-SourceRef",
+            "HEAD",
+            "-BuildNumber",
+            buildNumber,
+            "-BuildAttempt",
+            "1",
+            "-ImageName",
+            imageName,
+            "-RegionID",
+            "region-test",
+            "-AzName",
+            "az-test",
+            "-BaseImageID",
+            "base-image-test",
+            "-FlavorID",
+            "flavor-test",
+            "-VpcID",
+            "vpc-test",
+            "-SubnetID",
+            "subnet-test",
+            "-SecurityGroupID",
+            "security-group-test",
+          ],
+          {
+            cwd: root,
+            encoding: "utf8",
+            timeout: 30_000,
+            env: {
+              ...process.env,
+              PATH: `${sandbox}${path.delimiter}${process.env.PATH || ""}`,
+              FAKE_CTYUN_STATE: statePath,
+              FAKE_CTYUN_LOG: logPath,
+            },
+          },
+        );
+
+      const result = runBake("999", "catsco-worker-test-999");
 
       assert.notEqual(
         result.status,
@@ -315,13 +470,325 @@ fs.writeFileSync(output + ".pub", "ssh-rsa AAAA catsco-test");
         calls.indexOf("ims DeleteImage") <
           calls.indexOf("ecs DeleteEcsInstance"),
       );
-      assert.deepEqual(JSON.parse(fs.readFileSync(statePath, "utf8")), {
-        instanceExists: false,
-        keyExists: false,
-        imageExists: false,
-        instanceName: "catsco-img-000999-01",
-        instanceStatus: "stopped",
-      });
+      const finalState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+      assert.equal(finalState.instanceExists, false);
+      assert.equal(finalState.keyExists, false);
+      assert.equal(finalState.imageExists, false);
+      assert.equal(finalState.instanceName, "catsco-img-000999-01");
+      assert.equal(finalState.instanceStatus, "stopped");
+      assert.equal(finalState.imageSourceServerID, "instance-1");
+      assert.match(
+        finalState.imageName,
+        /^catsco-bake-[0-9a-f]{8}-[0-9a-f]{8}$/,
+      );
+      assert.match(
+        finalState.imageDescription,
+        /^CatsCo worker \S+ commit [0-9a-f]{40} bake 000999-01$/,
+      );
+
+      fs.writeFileSync(logPath, "");
+      fs.writeFileSync(
+        statePath,
+        JSON.stringify({
+          instanceExists: false,
+          keyExists: false,
+          keyPairName: "",
+          imageExists: false,
+          imageName: "",
+          imageDescription: "",
+          imageSourceServerID: "",
+          imageStatus: "error",
+          instanceName: "",
+          instanceStatus: "running",
+        }),
+      );
+      const foreignResult = runBake(
+        "1000",
+        "catsco-worker-test-1000",
+        "foreign-image",
+      );
+      assert.notEqual(foreignResult.status, 0);
+      assert.match(
+        `${foreignResult.stdout}\n${foreignResult.stderr}`,
+        /Refusing to delete image .*sourceServerID 'instance-foreign'/,
+      );
+      const foreignCalls = fs.readFileSync(logPath, "utf8");
+      assert.doesNotMatch(foreignCalls, /ims DeleteImage/);
+      assert.match(foreignCalls, /ecs DeleteEcsInstance/);
+      assert.match(foreignCalls, /ecs DeleteEcsKeypair/);
+      const foreignState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+      assert.equal(foreignState.imageExists, true);
+      assert.equal(foreignState.instanceExists, false);
+      assert.equal(foreignState.keyExists, false);
+
+      fs.writeFileSync(logPath, "");
+      fs.writeFileSync(
+        statePath,
+        JSON.stringify({
+          instanceExists: false,
+          keyExists: false,
+          keyPairName: "",
+          imageExists: false,
+          imageName: "",
+          imageDescription: "",
+          imageSourceServerID: "",
+          imageStatus: "error",
+          instanceName: "",
+          instanceStatus: "running",
+        }),
+      );
+      const foreignIdResult = runBake(
+        "1005",
+        "catsco-worker-test-1005",
+        "foreign-id",
+      );
+      assert.notEqual(foreignIdResult.status, 0);
+      assert.match(
+        `${foreignIdResult.stdout}\n${foreignIdResult.stderr}`,
+        /Refusing to delete image[\s\S]*does not belong to this bake/,
+      );
+      const foreignIdCalls = fs.readFileSync(logPath, "utf8");
+      assert.doesNotMatch(foreignIdCalls, /ims DeleteImage/);
+      assert.match(foreignIdCalls, /ecs DeleteEcsInstance/);
+      assert.match(foreignIdCalls, /ecs DeleteEcsKeypair/);
+
+      const commit = execFileSync("git", ["rev-parse", "HEAD"], {
+        cwd: root,
+        encoding: "utf8",
+      }).trim();
+      const version = JSON.parse(read("package.json")).version;
+      const releaseIdentity = `CatsCo worker ${version} commit ${commit}`;
+      const releaseDescription = `${releaseIdentity} ready`;
+      fs.writeFileSync(logPath, "");
+      fs.writeFileSync(
+        statePath,
+        JSON.stringify({
+          instanceExists: false,
+          keyExists: false,
+          keyPairName: "",
+          imageExists: true,
+          imageName: "catsco-worker-existing",
+          imageDescription: releaseDescription,
+          imageSourceServerID: "instance-prior",
+          imageStatus: "active",
+          instanceName: "",
+          instanceStatus: "stopped",
+        }),
+      );
+      const reuseResult = runBake("1001", "catsco-worker-existing");
+      assert.equal(
+        reuseResult.status,
+        0,
+        `${reuseResult.stdout}\n${reuseResult.stderr}`,
+      );
+      assert.match(reuseResult.stdout, /"result":\s*"reused"/);
+      const reuseCalls = fs.readFileSync(logPath, "utf8");
+      assert.doesNotMatch(reuseCalls, /ecs CreateEcsInstance/);
+      assert.doesNotMatch(reuseCalls, /ecs ImportEcsKeypair/);
+
+      fs.writeFileSync(logPath, "");
+      fs.writeFileSync(
+        statePath,
+        JSON.stringify({
+          instanceExists: true,
+          keyExists: true,
+          keyPairName: "catsco-img-key-001003-01",
+          imageExists: true,
+          imageName: "catsco-worker-pending",
+          imageDescription: `${releaseIdentity} bake 001003-01`,
+          imageSourceServerID: "instance-1",
+          imageStatus: "active",
+          instanceName: "catsco-img-001003-01",
+          instanceStatus: "stopped",
+        }),
+      );
+      const recoveryResult = runBake("1004", "catsco-worker-pending");
+      assert.equal(
+        recoveryResult.status,
+        0,
+        `${recoveryResult.stdout}\n${recoveryResult.stderr}`,
+      );
+      assert.match(recoveryResult.stdout, /"result":\s*"recovered"/);
+      const recoveryCalls = fs.readFileSync(logPath, "utf8");
+      assert.doesNotMatch(recoveryCalls, /ecs CreateEcsInstance/);
+      assert.match(recoveryCalls, /ecs DeleteEcsInstance/);
+      assert.match(recoveryCalls, /ecs DeleteEcsKeypair/);
+      assert.match(recoveryCalls, /ims UpdateImage/);
+      const recoveryState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+      assert.equal(recoveryState.imageExists, true);
+      assert.equal(recoveryState.imageDescription, releaseDescription);
+      assert.equal(recoveryState.instanceExists, false);
+      assert.equal(recoveryState.keyExists, false);
+
+      fs.writeFileSync(logPath, "");
+      fs.writeFileSync(
+        statePath,
+        JSON.stringify({
+          instanceExists: true,
+          instanceID: "instance-new",
+          keyExists: true,
+          keyPairName: "catsco-img-key-001008-01",
+          imageExists: true,
+          imageName: "catsco-pending-reused",
+          imageDescription: `${releaseIdentity} bake 001008-01`,
+          imageSourceServerID: "instance-prior",
+          imageStatus: "active",
+          instanceName: "catsco-img-001008-01",
+          instanceStatus: "running",
+        }),
+      );
+      const reusedNameRecoveryResult = runBake(
+        "1008",
+        "catsco-pending-reused",
+      );
+      assert.equal(
+        reusedNameRecoveryResult.status,
+        0,
+        `${reusedNameRecoveryResult.stdout}\n${reusedNameRecoveryResult.stderr}`,
+      );
+      const reusedNameRecoveryCalls = fs.readFileSync(logPath, "utf8");
+      assert.doesNotMatch(
+        reusedNameRecoveryCalls,
+        /ecs DeleteEcsInstance/,
+      );
+      assert.match(reusedNameRecoveryCalls, /ecs DeleteEcsKeypair/);
+      const reusedNameRecoveryState = JSON.parse(
+        fs.readFileSync(statePath, "utf8"),
+      );
+      assert.equal(reusedNameRecoveryState.instanceExists, true);
+      assert.equal(reusedNameRecoveryState.instanceID, "instance-new");
+      assert.equal(
+        reusedNameRecoveryState.imageDescription,
+        releaseDescription,
+      );
+
+      fs.writeFileSync(logPath, "");
+      fs.writeFileSync(
+        statePath,
+        JSON.stringify({
+          instanceExists: false,
+          keyExists: false,
+          keyPairName: "",
+          imageExists: false,
+          imageName: "",
+          imageDescription: "",
+          imageSourceServerID: "",
+          imageStatus: "error",
+          instanceName: "",
+          instanceStatus: "running",
+        }),
+      );
+      const successResult = runBake(
+        "1002",
+        "catsco-worker-published",
+        "success",
+      );
+      assert.equal(
+        successResult.status,
+        0,
+        `${successResult.stdout}\n${successResult.stderr}`,
+      );
+      assert.match(successResult.stdout, /"result":\s*"created"/);
+      const successCalls = fs.readFileSync(logPath, "utf8");
+      assert.match(successCalls, /ims UpdateImage/);
+      assert.match(successCalls, /ecs DeleteEcsInstance/);
+      assert.match(successCalls, /ecs DeleteEcsKeypair/);
+      const successState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+      assert.equal(successState.imageExists, true);
+      assert.equal(successState.imageName, "catsco-worker-published");
+      assert.equal(successState.imageDescription, releaseDescription);
+      assert.equal(successState.imageStatus, "active");
+      assert.equal(successState.instanceExists, false);
+      assert.equal(successState.keyExists, false);
+
+      const cleanupBuildNumber = "1006";
+      const cleanupBakeId = "001006-01";
+      const cleanupToken = crypto
+        .createHash("sha256")
+        .update(`${cleanupBuildNumber}/1/${commit}`)
+        .digest("hex")
+        .slice(0, 8);
+      const cleanupImageName =
+        `catsco-bake-${commit.slice(0, 8)}-${cleanupToken}`;
+      fs.writeFileSync(logPath, "");
+      fs.writeFileSync(
+        statePath,
+        JSON.stringify({
+          instanceExists: true,
+          keyExists: true,
+          keyPairName: `catsco-img-key-${cleanupBakeId}`,
+          imageExists: true,
+          imageName: cleanupImageName,
+          imageDescription: `${releaseIdentity} bake ${cleanupBakeId}`,
+          imageSourceServerID: "instance-1",
+          imageStatus: "error",
+          instanceName: `catsco-img-${cleanupBakeId}`,
+          instanceStatus: "stopped",
+        }),
+      );
+      const cleanupResult = runCleanup(
+        cleanupBuildNumber,
+        "catsco-worker-cleanup",
+      );
+      assert.equal(
+        cleanupResult.status,
+        0,
+        `${cleanupResult.stdout}\n${cleanupResult.stderr}`,
+      );
+      assert.match(cleanupResult.stdout, /"result":\s*"cleaned"/);
+      const cleanupCalls = fs.readFileSync(logPath, "utf8");
+      assert.match(cleanupCalls, /ims DeleteImage/);
+      assert.match(cleanupCalls, /ecs DeleteEcsInstance/);
+      assert.match(cleanupCalls, /ecs DeleteEcsKeypair/);
+      const cleanupState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+      assert.equal(cleanupState.imageExists, false);
+      assert.equal(cleanupState.instanceExists, false);
+      assert.equal(cleanupState.keyExists, false);
+
+      const foreignCleanupBuildNumber = "1007";
+      const foreignCleanupBakeId = "001007-01";
+      const foreignCleanupToken = crypto
+        .createHash("sha256")
+        .update(`${foreignCleanupBuildNumber}/1/${commit}`)
+        .digest("hex")
+        .slice(0, 8);
+      fs.writeFileSync(logPath, "");
+      fs.writeFileSync(
+        statePath,
+        JSON.stringify({
+          instanceExists: true,
+          keyExists: true,
+          keyPairName: `catsco-img-key-${foreignCleanupBakeId}`,
+          imageExists: true,
+          imageName:
+            `catsco-bake-${commit.slice(0, 8)}-${foreignCleanupToken}`,
+          imageDescription:
+            `${releaseIdentity} bake ${foreignCleanupBakeId}`,
+          imageSourceServerID: "instance-foreign",
+          imageStatus: "error",
+          instanceName: `catsco-img-${foreignCleanupBakeId}`,
+          instanceStatus: "stopped",
+        }),
+      );
+      const foreignCleanupResult = runCleanup(
+        foreignCleanupBuildNumber,
+        "catsco-worker-cleanup-foreign",
+      );
+      assert.notEqual(foreignCleanupResult.status, 0);
+      assert.match(
+        `${foreignCleanupResult.stdout}\n${foreignCleanupResult.stderr}`,
+        /Refusing exact cleanup because the temporary image ownership metadata does not match/,
+      );
+      const foreignCleanupCalls = fs.readFileSync(logPath, "utf8");
+      assert.doesNotMatch(foreignCleanupCalls, /ims DeleteImage/);
+      assert.match(foreignCleanupCalls, /ecs DeleteEcsInstance/);
+      assert.match(foreignCleanupCalls, /ecs DeleteEcsKeypair/);
+      const foreignCleanupState = JSON.parse(
+        fs.readFileSync(statePath, "utf8"),
+      );
+      assert.equal(foreignCleanupState.imageExists, true);
+      assert.equal(foreignCleanupState.instanceExists, false);
+      assert.equal(foreignCleanupState.keyExists, false);
     } finally {
       fs.rmSync(sandbox, { recursive: true, force: true });
     }

--- a/tests/worker-image-pipeline.test.ts
+++ b/tests/worker-image-pipeline.test.ts
@@ -70,10 +70,11 @@ describe("Tianyi Cloud worker image pipeline", () => {
   });
 
   test("platform hardening encodes known Tianyi worker faults", () => {
-    // fwupd masks prevent the systemd ABRT freeze on 8.16 hosts
-    assert.match(imagePreparer, /systemctl mask fwupd\.service/);
-    assert.match(imagePreparer, /systemctl mask fwupd-refresh\.service/);
-    assert.match(imagePreparer, /systemctl mask fwupd-refresh\.timer/);
+    // fwupd masks prevent the systemd ABRT freeze on 8.16 hosts (mask_unit
+    // creates and verifies the persistent /etc/systemd/system symlink)
+    assert.match(imagePreparer, /mask_unit fwupd\.service/);
+    assert.match(imagePreparer, /mask_unit fwupd-refresh\.service/);
+    assert.match(imagePreparer, /mask_unit fwupd-refresh\.timer/);
     assert.match(imagePreparer, /systemctl reset-failed fwupd-refresh\.service/);
     // systemd + glibc upgrade to the known-safe 8.16/8.8 combo (_dl_fini freeze)
     assert.match(
@@ -101,6 +102,16 @@ describe("Tianyi Cloud worker image pipeline", () => {
     // fail-closed version assertions (review: required upgrades must block the bake)
     assert.match(imagePreparer, /dpkg --compare-versions/);
     assert.match(imagePreparer, /known-safe version/);
+    // fwupd masks are verified through their persistent /etc symlink and a
+    // failed mask blocks the bake (review: swallowed mask failures)
+    assert.match(imagePreparer, /readlink/);
+    assert.match(imagePreparer, /failed to mask/);
+    // kernel meta packages are INSTALLED (not --only-upgrade) so a base image
+    // without them cannot silently skip to an old-kernel pass (review)
+    assert.match(
+      imagePreparer,
+      /apt-get install -y --no-install-recommends \\\n\s+linux-generic linux-image-generic/,
+    );
     assert.ok(
       imagePreparer.indexOf("od -An -c") < imagePreparer.indexOf("apt-get update"),
       "dpkg list repair must precede the first apt transaction",
@@ -186,7 +197,9 @@ describe("Tianyi Cloud worker image pipeline", () => {
         ls: [
           "#!/usr/bin/env bash",
           'echo "ls:$*" >> "$CATSCO_MOCK_LOG"',
-          'exit "${CATSCO_MOCK_LS_RC:-0}"',
+          'if [[ "${CATSCO_MOCK_LS_RC:-0}" != "0" ]]; then exit "${CATSCO_MOCK_LS_RC}"; fi',
+          'echo "/boot/vmlinuz-6.8.0-136-generic"',
+          "exit 0",
         ].join("\n"),
         "dpkg-query": [
           "#!/usr/bin/env bash",
@@ -205,6 +218,13 @@ describe("Tianyi Cloud worker image pipeline", () => {
           'echo "uname:$*" >> "$CATSCO_MOCK_LOG"',
           'echo "6.8.0-136-generic"',
           "exit 0",
+        ].join("\n"),
+        readlink: [
+          "#!/usr/bin/env bash",
+          'echo "readlink:$*" >> "$CATSCO_MOCK_LOG"',
+          // ${VAR-default} (no colon): only fall back when unset, so an empty
+          // override simulates a missing mask symlink for the probe.
+          'echo "${CATSCO_MOCK_READLINK_TARGET-/dev/null}"',
         ].join("\n"),
         "update-grub": [
           "#!/usr/bin/env bash",
@@ -362,6 +382,24 @@ describe("Tianyi Cloud worker image pipeline", () => {
         `${bootResult.stdout}\n${bootResult.stderr}`,
       );
       assert.match(bootResult.stderr, /no bootable kernel image/);
+
+      // Probe 7: a fwupd mask that did not take effect (persistent symlink
+      // missing) blocks the bake even when versions are otherwise healthy.
+      fs.rmSync(mockLog, { force: true });
+      const maskResult = runHardening({
+        CATSCO_MOCK_APT_ONLY_UPGRADE_RC: "0",
+        CATSCO_MOCK_VERSION_SYSTEMD_OK: "0",
+        CATSCO_MOCK_VERSION_GLIBC_OK: "0",
+        CATSCO_MOCK_SYSTEMD_VER: "255.4-1ubuntu8.16",
+        CATSCO_MOCK_GLIBC_VER: "2.39-0ubuntu8.8",
+        CATSCO_MOCK_READLINK_TARGET: "",
+      });
+      assert.notEqual(
+        maskResult.status,
+        0,
+        `${maskResult.stdout}\n${maskResult.stderr}`,
+      );
+      assert.match(maskResult.stderr, /failed to mask/);
     } finally {
       fs.rmSync(sandbox, { recursive: true, force: true });
     }
@@ -731,7 +769,9 @@ process.exit(result.status ?? 1);
           {
             cwd: root,
             encoding: "utf8",
-            timeout: 30_000,
+            // Consecutive-empty deletion confirmation adds bounded waits; keep
+            // plenty of headroom above the orchestrator's own deadlines.
+            timeout: 120_000,
             env: {
               ...process.env,
               PATH: `${sandbox}${path.delimiter}${process.env.PATH || ""}`,
@@ -778,7 +818,7 @@ process.exit(result.status ?? 1);
           {
             cwd: root,
             encoding: "utf8",
-            timeout: 30_000,
+            timeout: 120_000,
             env: {
               ...process.env,
               PATH: `${sandbox}${path.delimiter}${process.env.PATH || ""}`,

--- a/tests/worker-image-pipeline.test.ts
+++ b/tests/worker-image-pipeline.test.ts
@@ -46,6 +46,7 @@ describe('Tianyi Cloud worker image pipeline', () => {
     assert.match(workflow, /aws s3 presign/);
     assert.match(workflow, /--expires-in 3600/);
     assert.doesNotMatch(workflow, /public-read/);
+    assert.doesNotMatch(workflow, /actions\/upload-artifact/);
     assert.match(workflow, /needs: artifact/);
     assert.match(workflow, /CTYUN_AUTO_BAKE_WORKER_IMAGE/);
   });

--- a/tests/worker-image-pipeline.test.ts
+++ b/tests/worker-image-pipeline.test.ts
@@ -30,13 +30,23 @@ describe("Tianyi Cloud worker image pipeline", () => {
     assert.match(artifactBuilder, /--mtime=@\$\{commitEpoch\}/);
     assert.match(artifactBuilder, /gzip["'], \[["']-n["']/);
     assert.match(artifactBuilder, /createdAt: new Date\(commitEpoch \* 1000\)/);
+    assert.match(artifactBuilder, /does not match checked out HEAD/);
+    assert.match(artifactBuilder, /dirty tracked tree/);
+    assert.match(artifactBuilder, /lstatSync\(source\)/);
+    assert.match(artifactBuilder, /Refusing tracked symbolic link/);
+    assert.match(artifactBuilder, /assertSafeTree\(source, sourceRoot\)/);
+    assert.match(artifactBuilder, /assertSafeTree\(path\.join\(root, "dist"\)/);
+    assert.match(artifactBuilder, /run\("npm", \["run", "build"\]/);
     assert.match(workflow, /NODE_VERSION: ["']22\.23\.1["']/);
     assert.match(artifactBuilder, /stageNodeRuntime\(appRoot\)/);
     assert.match(artifactBuilder, /npm["'], \[["']root["'], ["']--global["']\]/);
   });
 
   test("image keeps immutable application files separate from runtime data", () => {
-    assert.match(imagePreparer, /RELEASE_ROOT="\/opt\/catsco\/releases\//);
+    assert.match(imagePreparer, /RELEASES_ROOT="\/opt\/catsco\/releases"/);
+    assert.match(imagePreparer, /invalid version/);
+    assert.match(imagePreparer, /release path escapes/);
+    assert.match(imagePreparer, /jq -n/);
     assert.match(imagePreparer, /XIAOBA_USER_DATA_DIR=\/srv\/catsco-agent/);
     assert.match(imagePreparer, /WorkingDirectory=\/srv\/catsco-agent/);
     assert.match(
@@ -67,6 +77,9 @@ describe("Tianyi Cloud worker image pipeline", () => {
       /Refusing to operate on non-builder instance/,
     );
     assert.match(imageOrchestrator, /mutatesExistingWorkers = \$false/);
+    assert.match(imageOrchestrator, /no immutable builder identity was recorded/);
+    assert.match(imageOrchestrator, /name and immutable ID do not uniquely match/);
+    assert.match(imageOrchestrator, /Automatic historical cleanup refused/);
     assert.doesNotMatch(imageOrchestrator, /worker1|worker2|ck-work/);
   });
 
@@ -129,10 +142,11 @@ describe("Tianyi Cloud worker image pipeline", () => {
     assert.match(workflow, /sha256sum --check --strict/);
     assert.match(
       workflow,
-      /ArtifactPath '\$\{\{ steps\.artifact_meta\.outputs\.path \}\}'/,
+      /WORKER_ARTIFACT_PATH: \$\{\{ steps\.artifact_meta\.outputs\.path \}\}/,
     );
-    assert.match(workflow, /BuildNumber '\$\{\{ github\.run_number \}\}'/);
-    assert.match(workflow, /BuildIdentity '\$\{\{ github\.run_id \}\}'/);
+    assert.match(workflow, /-ArtifactPath \$env:WORKER_ARTIFACT_PATH/);
+    assert.match(workflow, /-BuildNumber \$env:GITHUB_RUN_NUMBER/);
+    assert.match(workflow, /-BuildIdentity \$env:GITHUB_RUN_ID/);
     assert.match(workflow, /timeout-minutes: 420/);
     assert.match(workflow, /-BakeTimeoutMinutes 150/);
     assert.match(workflow, /-CleanupTimeoutMinutes 40/);
@@ -140,7 +154,9 @@ describe("Tianyi Cloud worker image pipeline", () => {
     assert.match(workflow, /steps\.bake\.outcome != 'success'/);
     assert.match(workflow, /actions: read/);
     assert.match(workflow, /Find interrupted image runs/);
-    assert.match(workflow, /per_page=100/);
+    assert.match(workflow, /per_page=100&page=\$page/);
+    assert.match(workflow, /page=\$\(\(page \+ 1\)\)/);
+    assert.match(workflow, /jq -cs --arg current/);
     assert.match(workflow, /foreach \(\$run in \$runs\)/);
     assert.match(workflow, /foreach \(\$attempt in 1\.\.\$runAttempt\)/);
     assert.match(workflow, /foreach \(\$previousAttempt in 1\.\./);
@@ -186,6 +202,10 @@ describe("Tianyi Cloud worker image pipeline", () => {
       path.join(os.tmpdir(), "catsco-worker-image-test-"),
     );
     try {
+      fs.writeFileSync(
+        path.join(sandbox, "package.json"),
+        '{"type":"module"}\n',
+      );
       const statePath = path.join(sandbox, "state.json");
       const logPath = path.join(sandbox, "calls.log");
       const artifactPath = path.join(sandbox, "worker.tar.gz");
@@ -477,6 +497,10 @@ process.exit(result.status ?? 1);
         0,
         `expected the image error to fail the bake\n${result.stdout}\n${result.stderr}`,
       );
+      assert.ok(
+        fs.existsSync(logPath),
+        `expected fake cloud CLI to be invoked\n${result.stdout}\n${result.stderr}`,
+      );
       const calls = fs.readFileSync(logPath, "utf8");
       assert.match(
         calls,
@@ -635,17 +659,15 @@ process.exit(result.status ?? 1);
       assert.ok(
         (recoveryCalls.match(/ecs ListEcsInstances/g) || []).length >= 2,
       );
-      assert.ok(
-        (recoveryCalls.match(/ecs GetEcsKeypairDetails/g) || []).length >= 2,
-      );
+      assert.doesNotMatch(recoveryCalls, /ecs GetEcsKeypairDetails/);
       assert.match(recoveryCalls, /ecs DeleteEcsInstance/);
-      assert.match(recoveryCalls, /ecs DeleteEcsKeypair/);
+      assert.doesNotMatch(recoveryCalls, /ecs DeleteEcsKeypair/);
       assert.match(recoveryCalls, /ims UpdateImage/);
       const recoveryState = JSON.parse(fs.readFileSync(statePath, "utf8"));
       assert.equal(recoveryState.imageExists, true);
       assert.equal(recoveryState.imageDescription, releaseDescription);
       assert.equal(recoveryState.instanceExists, false);
-      assert.equal(recoveryState.keyExists, false);
+      assert.equal(recoveryState.keyExists, true);
 
       fs.writeFileSync(logPath, "");
       fs.writeFileSync(
@@ -678,7 +700,7 @@ process.exit(result.status ?? 1);
         reusedNameRecoveryCalls,
         /ecs DeleteEcsInstance/,
       );
-      assert.match(reusedNameRecoveryCalls, /ecs DeleteEcsKeypair/);
+      assert.doesNotMatch(reusedNameRecoveryCalls, /ecs DeleteEcsKeypair/);
       const reusedNameRecoveryState = JSON.parse(
         fs.readFileSync(statePath, "utf8"),
       );
@@ -757,20 +779,19 @@ process.exit(result.status ?? 1);
         cleanupBuildNumber,
         "catsco-worker-cleanup",
       );
-      assert.equal(
-        cleanupResult.status,
-        0,
+      assert.notEqual(cleanupResult.status, 0);
+      assert.match(
         `${cleanupResult.stdout}\n${cleanupResult.stderr}`,
+        /Automatic historical cleanup refused/,
       );
-      assert.match(cleanupResult.stdout, /"result":\s*"cleaned"/);
       const cleanupCalls = fs.readFileSync(logPath, "utf8");
-      assert.match(cleanupCalls, /ims DeleteImage/);
-      assert.match(cleanupCalls, /ecs DeleteEcsInstance/);
-      assert.match(cleanupCalls, /ecs DeleteEcsKeypair/);
+      assert.doesNotMatch(cleanupCalls, /ims DeleteImage/);
+      assert.doesNotMatch(cleanupCalls, /ecs DeleteEcsInstance/);
+      assert.doesNotMatch(cleanupCalls, /ecs DeleteEcsKeypair/);
       const cleanupState = JSON.parse(fs.readFileSync(statePath, "utf8"));
-      assert.equal(cleanupState.imageExists, false);
-      assert.equal(cleanupState.instanceExists, false);
-      assert.equal(cleanupState.keyExists, false);
+      assert.equal(cleanupState.imageExists, true);
+      assert.equal(cleanupState.instanceExists, true);
+      assert.equal(cleanupState.keyExists, true);
 
       const foreignCleanupBuildNumber = "1007";
       const foreignCleanupBakeId = "001007-01";
@@ -804,18 +825,18 @@ process.exit(result.status ?? 1);
       assert.notEqual(foreignCleanupResult.status, 0);
       assert.match(
         `${foreignCleanupResult.stdout}\n${foreignCleanupResult.stderr}`,
-        /Refusing exact cleanup[\s\S]*does not match/,
+        /Automatic historical cleanup refused/,
       );
       const foreignCleanupCalls = fs.readFileSync(logPath, "utf8");
       assert.doesNotMatch(foreignCleanupCalls, /ims DeleteImage/);
-      assert.match(foreignCleanupCalls, /ecs DeleteEcsInstance/);
-      assert.match(foreignCleanupCalls, /ecs DeleteEcsKeypair/);
+      assert.doesNotMatch(foreignCleanupCalls, /ecs DeleteEcsInstance/);
+      assert.doesNotMatch(foreignCleanupCalls, /ecs DeleteEcsKeypair/);
       const foreignCleanupState = JSON.parse(
         fs.readFileSync(statePath, "utf8"),
       );
       assert.equal(foreignCleanupState.imageExists, true);
-      assert.equal(foreignCleanupState.instanceExists, false);
-      assert.equal(foreignCleanupState.keyExists, false);
+      assert.equal(foreignCleanupState.instanceExists, true);
+      assert.equal(foreignCleanupState.keyExists, true);
     } finally {
       fs.rmSync(sandbox, { recursive: true, force: true });
     }


### PR DESCRIPTION
## 摘要

- 构建确定性、无源码依赖的 Linux x64 worker 产物，并捆绑 CI 使用的固定 Node.js 22.23.1 / npm 运行时。
- 通过一次性构建机烘焙**私有天翼云 ECS 镜像**，不停机、不改动现有 worker。
- 使用唯一临时镜像名发布，校验 `sourceServerID` 后，通过 `bake -> ready` 两阶段标记重命名为稳定发布名。
- 重试幂等，可恢复中断运行（包括 PowerShell 进入 `finally` 前被 GitHub Runner 取消的情况）。

## 安全与清理

- 手动烘焙默认关闭、仅限 `main`；自动烘焙只接受 `main` 中包含的稳定 `vX.Y.Z` tag。
- GitHub Actions 与天翼云 CLI 包均固定版本，安装前校验 CLI 归档 SHA-256。
- GitHub API 访问与天翼云凭证隔离到各自最小权限步骤。
- 所有天翼云 API 调用、传输、远端构建、烘焙、清理及工作流步骤均有有界超时并预留清理空间。
- 确认 ECS、EIP/磁盘、密钥对及失败镜像的清理；未确认的清理会使 job 失败并带精确资源标识。
- 删除镜像需精确临时名、烘焙描述与匹配的源构建机 ID；权威实例 ID 绝不回退为复用实例名。
- 若失败镜像删除暂时未确认，源构建机会被保留作为下次精确对账的所有权证据。
- 下次运行会从精确的 `run_id`、序列、attempt、commit 对账并恢复上一次被取消/失败/超时的运行。

## 镜像内容

- 应用文件在 `/opt/catsco/releases/<version>-<commit>` 下不可变，`/opt/catsco/current` 为活动链接。
- 运行时状态保留在 `/srv/catsco-agent`；烘焙的服务默认禁用，不含绑定账号、机器人身份、会话、日志、SSH 主机密钥或机器身份。
- 镜像记录应用清单与已安装 Debian 包版本，用于溯源。
- 镜像在天翼云区域镜像仓库保持私有，不产生公开 TOS 产物。

## 验证

- `npm run build`
- `npm test`：1262 测试，1258 通过，0 失败，4 跳过
- `npx tsx --test tests/worker-image-pipeline.test.ts`：9/9 通过（覆盖成功、歧义 API 响应、直接外来 ID、失败镜像清理、精确孤儿恢复、外来资源拒绝、待发布恢复、名称复用保护、幂等复用）
- `actionlint` v1.7.7、`bash -n`、PowerShell 解析器、`git diff --check`
- 两个独立 Linux 构建（Node 22.23.1）SHA-256 完全一致：`4a756f2edf4e480a72e1dbc9ebe4242ba032b4a4284147f13c9c131cead5e74f`

本地验证未创建或删除任何真实天翼云资源。首次受控私有镜像烘焙仍是最终生产冒烟测试。
