### PR TITLE
fix: preserve prompt cache prefixes

### DIFF
--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -480,6 +480,12 @@ export class ConversationRunner {
       if (promptTrimmed && callbacks?.onThinking) {
         await callbacks.onThinking(PROMPT_BUDGET_TRIM_MESSAGE);
       }
+      // Freeze the exact final provider representation before the call, then copy
+      // those immutable bytes back into caller-owned durable history. Provider
+      // failures therefore cannot persist raw or turn-dependent tool results.
+      this.stabilizeToolResultHistory(requestMessages, [], turns);
+      this.syncStableToolResultsToHistory(requestMessages, messages, newMessages);
+      this.stabilizeToolResultHistory(messages, newMessages, turns);
       this.logProviderMessagesForDebug(requestMessages, requestTools, turns);
       this.promptTraceLogger.recordRequest(turns, requestMessages, requestTools);
       const aiStartTime = Date.now();
@@ -772,10 +778,19 @@ export class ConversationRunner {
   }
 
   private finalizeRunResult(result: RunResult, turn: number): RunResult {
+    this.stabilizeToolResultHistory(result.messages, result.newMessages, turn);
+    return result;
+  }
+
+  private stabilizeToolResultHistory(
+    messages: Message[],
+    newMessages: Message[],
+    turn: number,
+  ): void {
     const artifactStore = this.resolveToolResultArtifactStoreOptions(turn);
     const stats = stabilizeToolResultsForHistory(
-      result.messages,
-      result.newMessages,
+      messages,
+      newMessages,
       { ...resolveReadFileMessageFoldingOptions(), artifactStore },
       { ...resolveExecuteShellMessageFoldingOptions(), artifactStore },
     );
@@ -787,7 +802,27 @@ export class ConversationRunner {
         + `execute_shell_truncated=${stats.executeShellFoldedCount}`,
       );
     }
-    return result;
+  }
+
+  private syncStableToolResultsToHistory(
+    providerMessages: Message[],
+    messages: Message[],
+    newMessages: Message[],
+  ): void {
+    const stableByCallId = new Map<string, Message>();
+    for (const message of providerMessages) {
+      if (message.role === 'tool' && message.tool_call_id && message.__toolResultStable) {
+        stableByCallId.set(message.tool_call_id, message);
+      }
+    }
+    const sync = (message: Message): Message => {
+      const stable = message.tool_call_id ? stableByCallId.get(message.tool_call_id) : undefined;
+      return stable
+        ? { ...message, content: stable.content, __toolResultStable: true }
+        : message;
+    };
+    this.replaceMessages(messages, messages.map(sync));
+    this.replaceMessages(newMessages, newMessages.map(sync));
   }
 
   private async appendPendingUserInput(
@@ -1229,6 +1264,7 @@ export class ConversationRunner {
   }
 
   private transientMessageKey(message: Message): string | null {
+    if (message.role !== 'system' && !message.__injected) return null;
     if (typeof message.content !== 'string') return null;
     const firstLine = message.content.split('\n', 1)[0].trim();
     return /^\[transient_[a-z0-9_-]+\]$/i.test(firstLine) ? firstLine.toLowerCase() : null;

--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -25,6 +25,7 @@ import {
   resolveAdaptiveToolResultFoldingOptions,
 } from './adaptive-tool-result-folder';
 import { resolveToolResultArtifactStoreOptions } from './tool-result-artifact-store';
+import { stabilizeToolResultsForHistory } from './stable-tool-result-history';
 import {
   buildExplicitPlanRequestHintIfUseful,
   buildInitialDecisionHintIfUseful,
@@ -314,12 +315,12 @@ export class ConversationRunner {
       }
       if (this.maxTurns && turns > this.maxTurns) {
         Logger.warning(`[${this.sessionLabel}] 已达到最大推理轮次 ${this.maxTurns}，正在收束`);
-        return {
+        return this.finalizeRunResult({
           response: `已达到本次后台任务的轮次预算（${this.maxTurns} 轮），我先基于已完成的信息收束。`,
           finalResponseVisible: true,
           messages,
           newMessages,
-        };
+        }, turns);
       }
       this.injectSyntheticObservations(messages, turns);
       const runtimeTransientHints = this.drainRuntimeTransientMessages(turns);
@@ -510,21 +511,21 @@ export class ConversationRunner {
           messages.push(assistantMessage);
           newMessages.push(assistantMessage);
           Logger.warning(`[${this.sessionLabel}Turn ${turns}] 图片被模型安全策略拒绝，已发送可见收束提示: ${formatProviderErrorForLog(error)}`);
-          return {
+          return this.finalizeRunResult({
             response: MODEL_IMAGE_SAFETY_MESSAGE,
             finalResponseVisible: true,
             messages,
             newMessages,
-          };
+          }, turns);
         }
         if (hasDeliveredMessageOutThisRun && this.isMessageSurface()) {
           Logger.warning(`[${this.sessionLabel}Turn ${turns}] 已有外发消息送达，后续推理失败后直接收束: ${formatProviderErrorForLog(error)}`);
-          return {
+          return this.finalizeRunResult({
             response: '',
             finalResponseVisible: false,
             messages,
             newMessages,
-          };
+          }, turns);
         }
         throw error;
       }
@@ -616,24 +617,24 @@ export class ConversationRunner {
             }
           }
 
-          return {
+          return this.finalizeRunResult({
             response: finalText,
             finalResponseVisible: true,
             messages,
             newMessages,
-          };
+          }, turns);
         }
 
         let cleanedResponse = visibleContent;
         cleanedResponse = cleanedResponse.replace(/^\[已发送信息\]\s*/, '');
         cleanedResponse = cleanedResponse.replace(/^\[已发送文件\]\s*/, '');
 
-        return {
+        return this.finalizeRunResult({
           response: cleanedResponse,
           finalResponseVisible: true,
           messages,
           newMessages,
-        };
+        }, turns);
       }
 
       if (response.content) {
@@ -751,23 +752,42 @@ export class ConversationRunner {
 
       if (shouldPauseTurn) {
         Logger.info(`[${this.sessionLabel}Turn ${turns}] pause_turn 已触发，本轮收束`);
-        return {
+        return this.finalizeRunResult({
           response: '',
           finalResponseVisible: false,
           messages,
           newMessages,
-        };
+        }, turns);
       }
 
       await this.appendPendingUserInput(messages, newMessages, turns);
     }
 
-    return {
+    return this.finalizeRunResult({
       response: '',
       finalResponseVisible: false,
       messages,
       newMessages,
-    };
+    }, Math.max(1, turns));
+  }
+
+  private finalizeRunResult(result: RunResult, turn: number): RunResult {
+    const artifactStore = this.resolveToolResultArtifactStoreOptions(turn);
+    const stats = stabilizeToolResultsForHistory(
+      result.messages,
+      result.newMessages,
+      { ...resolveReadFileMessageFoldingOptions(), artifactStore },
+      { ...resolveExecuteShellMessageFoldingOptions(), artifactStore },
+    );
+    if (stats.stabilizedCount > 0) {
+      Logger.info(
+        `[${this.sessionLabel}] stable tool_result history: `
+        + `stabilized=${stats.stabilizedCount}, `
+        + `read_file_truncated=${stats.readFileFoldedCount}, `
+        + `execute_shell_truncated=${stats.executeShellFoldedCount}`,
+      );
+    }
+    return result;
   }
 
   private async appendPendingUserInput(
@@ -1185,14 +1205,33 @@ export class ConversationRunner {
   }
 
   private insertProviderTransientHints(messages: Message[], hints: Message[]): Message[] {
-    if (hints.length === 0) return messages;
+    if (hints.length === 0) return this.dedupeTransientMessages(messages);
 
     const insertIndex = this.findCurrentDirectoryHintInsertIndex(messages);
-    return [
+    return this.dedupeTransientMessages([
       ...messages.slice(0, insertIndex),
       ...hints,
       ...messages.slice(insertIndex),
-    ];
+    ]);
+  }
+
+  private dedupeTransientMessages(messages: Message[]): Message[] {
+    const seen = new Set<string>();
+    const dedupedReversed: Message[] = [];
+    for (let index = messages.length - 1; index >= 0; index--) {
+      const message = messages[index];
+      const key = this.transientMessageKey(message);
+      if (key && seen.has(key)) continue;
+      if (key) seen.add(key);
+      dedupedReversed.push(message);
+    }
+    return dedupedReversed.reverse();
+  }
+
+  private transientMessageKey(message: Message): string | null {
+    if (typeof message.content !== 'string') return null;
+    const firstLine = message.content.split('\n', 1)[0].trim();
+    return /^\[transient_[a-z0-9_-]+\]$/i.test(firstLine) ? firstLine.toLowerCase() : null;
   }
 
   private findCurrentDirectoryHintInsertIndex(messages: Message[]): number {

--- a/src/core/execute-shell-message-folder.ts
+++ b/src/core/execute-shell-message-folder.ts
@@ -122,7 +122,7 @@ export function foldHistoricalExecuteShellMessages(
   let protectedCurrentTurnCount = 0;
 
   messages.forEach((message, index) => {
-    if (!isExecuteShellToolResult(message)) return;
+    if (!isExecuteShellToolResult(message) || message.__toolResultStable) return;
     const currentRun = index > lastUserIndex;
     if (currentRun && !resolved.foldCurrentRun) {
       skippedCurrentTurnCount++;

--- a/src/core/read-file-message-folder.ts
+++ b/src/core/read-file-message-folder.ts
@@ -106,7 +106,7 @@ export function foldHistoricalReadFileMessages(
   let protectedCurrentTurnCount = 0;
 
   messages.forEach((message, index) => {
-    if (!isReadFileToolResult(message)) return;
+    if (!isReadFileToolResult(message) || message.__toolResultStable) return;
     const currentRun = index > lastUserIndex;
     if (currentRun && !resolved.foldCurrentRun) {
       skippedCurrentTurnCount++;

--- a/src/core/stable-tool-result-history.ts
+++ b/src/core/stable-tool-result-history.ts
@@ -1,0 +1,76 @@
+import { Message } from '../types';
+import {
+  foldHistoricalReadFileMessages,
+  ReadFileMessageFoldingOptions,
+} from './read-file-message-folder';
+import {
+  ExecuteShellMessageFoldingOptions,
+  foldHistoricalExecuteShellMessages,
+} from './execute-shell-message-folder';
+
+export interface StableToolResultStats {
+  readFileFoldedCount: number;
+  executeShellFoldedCount: number;
+  stabilizedCount: number;
+}
+
+/**
+ * Normalizes supported tool results exactly once before a completed run is persisted.
+ * Later prompt-budget passes must leave these historical bytes unchanged.
+ */
+export function stabilizeToolResultsForHistory(
+  messages: Message[],
+  newMessages: Message[],
+  readFileOptions: ReadFileMessageFoldingOptions,
+  executeShellOptions: ExecuteShellMessageFoldingOptions,
+): StableToolResultStats {
+  const readResult = foldHistoricalReadFileMessages(messages, {
+    ...readFileOptions,
+    foldCurrentRun: true,
+    keepRecentHistoricalReads: 0,
+    protectedCurrentRunToolResultIndexes: undefined,
+  });
+  const shellResult = foldHistoricalExecuteShellMessages(readResult.messages, {
+    ...executeShellOptions,
+    foldCurrentRun: true,
+    keepRecentHistoricalShells: 0,
+    protectedCurrentRunToolResultIndexes: undefined,
+  });
+
+  const stableByCallId = new Map<string, Message>();
+  let stabilizedCount = 0;
+  const stableMessages = shellResult.messages.map(message => {
+    if (!isSupportedToolResult(message)) return message;
+    const stable = message.__toolResultStable ? message : { ...message, __toolResultStable: true };
+    if (!message.__toolResultStable) stabilizedCount++;
+    if (stable.tool_call_id) stableByCallId.set(stable.tool_call_id, stable);
+    return stable;
+  });
+
+  replaceMessages(messages, stableMessages);
+  replaceMessages(newMessages, newMessages.map(message => {
+    const stable = message.tool_call_id ? stableByCallId.get(message.tool_call_id) : undefined;
+    return stable ? { ...message, content: stable.content, __toolResultStable: true } : message;
+  }));
+
+  return {
+    readFileFoldedCount: readResult.stats.folded_count,
+    executeShellFoldedCount: shellResult.stats.folded_count,
+    stabilizedCount,
+  };
+}
+
+function isSupportedToolResult(message: Message): boolean {
+  if (message.role !== 'tool') return false;
+  const name = message.name?.toLowerCase();
+  return name === 'read_file'
+    || name === 'execute_shell'
+    || name === 'bash'
+    || name === 'shell'
+    || name === 'execute_bash';
+}
+
+function replaceMessages(target: Message[], next: Message[]): void {
+  target.length = 0;
+  target.push(...next);
+}

--- a/src/core/stable-tool-result-history.ts
+++ b/src/core/stable-tool-result-history.ts
@@ -64,6 +64,7 @@ function isSupportedToolResult(message: Message): boolean {
   if (message.role !== 'tool') return false;
   const name = message.name?.toLowerCase();
   return name === 'read_file'
+    || name === 'read'
     || name === 'execute_shell'
     || name === 'bash'
     || name === 'shell'

--- a/src/core/tool-result-artifact-store.ts
+++ b/src/core/tool-result-artifact-store.ts
@@ -55,12 +55,12 @@ export function persistToolResultArtifact(
   }
 
   const sessionSegment = sanitizeFileSegment(resolved.sessionId || 'unknown-session');
-  const turnSegment = typeof resolved.turn === 'number' && Number.isFinite(resolved.turn)
-    ? `turn-${String(Math.max(0, Math.floor(resolved.turn))).padStart(4, '0')}`
-    : 'turn-unknown';
-  const directory = path.resolve(resolved.rootDirectory, sessionSegment, turnSegment);
+  // Artifact references are part of provider-visible historical tool results. Keep
+  // them independent of the current inference turn so folding the same durable
+  // history remains byte-identical across requests.
+  const directory = path.resolve(resolved.rootDirectory, sessionSegment);
   const filePath = path.join(directory, `${artifactId}.txt`);
-  const ref = `tool-result://${sessionSegment}/${turnSegment}/${artifactId}`;
+  const ref = `tool-result://${sessionSegment}/${artifactId}`;
 
   try {
     fs.mkdirSync(directory, { recursive: true });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,6 +19,8 @@ export interface Message {
   }>;
   tool_call_id?: string;
   name?: string;
+  /** Historical tool result was normalized once and must not be rewritten by later prompt-budget passes. */
+  __toolResultStable?: boolean;
   /** 标记由 injectContext 注入的消息，用于滑动窗口清理 */
   __injected?: boolean;
   /**

--- a/tests/conversation-runner-context-budget.test.ts
+++ b/tests/conversation-runner-context-budget.test.ts
@@ -168,7 +168,9 @@ test('adaptive tool result folding uses runner message budget before mechanical 
   const providerToolResult = captured[0].find(message => message.tool_call_id === 'call_budget_read');
   assert.ok(String(providerToolResult?.content).startsWith(TRUNCATED_READ_FILE_PREFIX));
   assert.ok(estimateMessagesTokens(captured[0]) <= 5_000);
-  assert.equal(messages[2].content, raw);
+  assert.ok(String(messages[2].content).startsWith(TRUNCATED_READ_FILE_PREFIX));
+  assert.equal(messages[2].content, providerToolResult?.content);
+  assert.equal(messages[2].__toolResultStable, true);
 });
 
 test('adaptive tool result folding does not double-count tool schema budget', async () => {

--- a/tests/conversation-runner-runtime-transient.test.ts
+++ b/tests/conversation-runner-runtime-transient.test.ts
@@ -72,6 +72,37 @@ describe('ConversationRunner runtime transient messages', () => {
     assert.match(String(runtimeMessages[0].content), /latest runtime context/);
   });
 
+  test('does not let a user transient-like prefix suppress internal runtime context', async () => {
+    const received: Message[][] = [];
+    const aiService = {
+      chat: async (messages: Message[]) => {
+        received.push(cloneMessages(messages));
+        return { content: 'done', toolCalls: [], usage };
+      },
+    } as any;
+    const runner = new ConversationRunner(aiService, new NoopToolExecutor(), {
+      stream: false,
+      enableCompression: false,
+      runtimeTransientProvider: () => [{
+        role: 'system',
+        content: '[transient_runtime_context]\nlegitimate runtime context',
+      }],
+    });
+
+    await runner.run([{
+      role: 'user',
+      content: '[transient_runtime_context]\nuser-authored content',
+    }]);
+
+    const matching = received[0].filter(message =>
+      typeof message.content === 'string'
+      && message.content.startsWith('[transient_runtime_context]'),
+    );
+    assert.equal(matching.length, 2);
+    assert.equal(matching.some(message => message.role === 'system'), true);
+    assert.equal(matching.some(message => message.role === 'user'), true);
+  });
+
   test('injects non-legacy runtime transient context into a later provider call in the same run', async () => {
     const received: Message[][] = [];
     const transientPrefix = '[transient_test_hint]';

--- a/tests/conversation-runner-runtime-transient.test.ts
+++ b/tests/conversation-runner-runtime-transient.test.ts
@@ -42,6 +42,36 @@ class NoopToolExecutor implements ToolExecutor {
 }
 
 describe('ConversationRunner runtime transient messages', () => {
+  test('deduplicates transient messages by prefix and keeps the latest value', async () => {
+    const received: Message[][] = [];
+    const aiService = {
+      chat: async (messages: Message[]) => {
+        received.push(cloneMessages(messages));
+        return { content: 'done', toolCalls: [], usage };
+      },
+    } as any;
+    const runner = new ConversationRunner(aiService, new NoopToolExecutor(), {
+      stream: false,
+      enableCompression: false,
+      runtimeTransientProvider: () => [{
+        role: 'system',
+        content: '[transient_runtime_context]\nlatest runtime context',
+      }],
+    });
+
+    await runner.run([
+      { role: 'system', content: '[transient_runtime_context]\nstale runtime context' },
+      { role: 'user', content: 'debug it' },
+    ]);
+
+    const runtimeMessages = received[0].filter(message =>
+      typeof message.content === 'string'
+      && message.content.startsWith('[transient_runtime_context]'),
+    );
+    assert.equal(runtimeMessages.length, 1);
+    assert.match(String(runtimeMessages[0].content), /latest runtime context/);
+  });
+
   test('injects non-legacy runtime transient context into a later provider call in the same run', async () => {
     const received: Message[][] = [];
     const transientPrefix = '[transient_test_hint]';

--- a/tests/conversation-runner-tool-result-stability.test.ts
+++ b/tests/conversation-runner-tool-result-stability.test.ts
@@ -1,0 +1,117 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ConversationRunner } from '../src/core/conversation-runner';
+import { TRUNCATED_READ_FILE_PREFIX } from '../src/core/read-file-message-folder';
+import type { ChatResponse, Message } from '../src/types';
+import type { ToolCall, ToolDefinition, ToolExecutor, ToolResult } from '../src/types/tool';
+
+const usage = { promptTokens: 1, completionTokens: 1, totalTokens: 2 };
+const longReadOutput = ['File: /repo/a.ts', 'Path: /repo/a.ts', '', '1→ const value = 1;\n'.repeat(2500)].join('\n');
+
+function cloneMessages(messages: Message[]): Message[] {
+  return JSON.parse(JSON.stringify(messages));
+}
+
+function toolCall(id: string, name = 'Read'): ToolCall {
+  return {
+    id,
+    type: 'function',
+    function: { name, arguments: '{}' },
+  };
+}
+
+class ReadExecutor implements ToolExecutor {
+  getToolDefinitions(): ToolDefinition[] {
+    return [
+      { name: 'Read', description: 'read', parameters: { type: 'object', properties: {} } },
+      { name: 'noop', description: 'noop', parameters: { type: 'object', properties: {} } },
+    ];
+  }
+
+  async executeTool(call: ToolCall): Promise<ToolResult> {
+    return {
+      tool_call_id: call.id,
+      role: 'tool',
+      name: call.function.name,
+      content: call.function.name === 'Read' ? longReadOutput : 'ok',
+      ok: true,
+    };
+  }
+}
+
+function makeRunner(aiService: any, workspaceRoot: string): ConversationRunner {
+  return new ConversationRunner(aiService, new ReadExecutor(), {
+    stream: false,
+    enableCompression: false,
+    toolExecutionContext: {
+      workingDirectory: workspaceRoot,
+      workspaceRoot,
+      sessionId: 'stable-prefix-test',
+    } as any,
+  });
+}
+
+function stableRead(messages: Message[]): Message {
+  const result = messages.find(message => message.role === 'tool' && message.name === 'Read');
+  assert.ok(result);
+  return result;
+}
+
+test('keeps a tool result byte-identical across subsequent provider calls', async () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-prefix-stable-'));
+  try {
+    const received: Message[][] = [];
+    const responses: ChatResponse[] = [
+      { content: null, toolCalls: [toolCall('read_1')], usage },
+      { content: null, toolCalls: [toolCall('noop_1', 'noop')], usage },
+      { content: 'done', toolCalls: [], usage },
+    ];
+    const aiService = {
+      chat: async (messages: Message[]) => {
+        received.push(cloneMessages(messages));
+        return responses[received.length - 1];
+      },
+    } as any;
+
+    await makeRunner(aiService, workspace).run([{ role: 'user', content: 'inspect it' }]);
+
+    assert.equal(received.length, 3);
+    const second = stableRead(received[1]);
+    const third = stableRead(received[2]);
+    assert.equal(second.__toolResultStable, true);
+    assert.ok(String(second.content).startsWith(TRUNCATED_READ_FILE_PREFIX));
+    assert.match(String(second.content), /full_output_ref:/);
+    assert.equal(third.content, second.content);
+  } finally {
+    fs.rmSync(workspace, { recursive: true, force: true });
+  }
+});
+
+test('stabilizes caller-owned partial history before a provider failure', async () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-prefix-error-'));
+  try {
+    let calls = 0;
+    const aiService = {
+      chat: async () => {
+        calls += 1;
+        if (calls === 1) {
+          return { content: null, toolCalls: [toolCall('read_1')], usage };
+        }
+        throw new Error('provider unavailable');
+      },
+    } as any;
+    const messages: Message[] = [{ role: 'user', content: 'inspect it' }];
+
+    await assert.rejects(makeRunner(aiService, workspace).run(messages), /provider unavailable/);
+
+    const persisted = stableRead(messages);
+    assert.equal(persisted.__toolResultStable, true);
+    assert.ok(String(persisted.content).startsWith(TRUNCATED_READ_FILE_PREFIX));
+    assert.match(String(persisted.content), /full_output_ref:/);
+  } finally {
+    fs.rmSync(workspace, { recursive: true, force: true });
+  }
+});

--- a/tests/execute-shell-message-folder.test.ts
+++ b/tests/execute-shell-message-folder.test.ts
@@ -264,7 +264,7 @@ test('environment options are deterministic and can disable folding', () => {
   assert.equal(options.keepRecentHistoricalShells, 2);
 });
 
-test('runner folds execute_shell only in provider input and leaves durable session messages raw', async () => {
+test('runner folds provider input and persists the same stable execute_shell result', async () => {
   const previousThreshold = process.env.XIAOBA_EXECUTE_SHELL_FOLD_THRESHOLD_TOKENS;
   process.env.XIAOBA_EXECUTE_SHELL_FOLD_THRESHOLD_TOKENS = '20';
 
@@ -301,5 +301,6 @@ test('runner folds execute_shell only in provider input and leaves durable sessi
 
   const providerToolResult = captured[0].find(message => message.role === 'tool');
   assert.ok(String(providerToolResult?.content).startsWith(TRUNCATED_EXECUTE_SHELL_PREFIX));
-  assert.equal(messages[2].content, raw);
+  assert.equal(messages[2].content, providerToolResult?.content);
+  assert.equal(messages[2].__toolResultStable, true);
 });

--- a/tests/execute-shell-message-folder.test.ts
+++ b/tests/execute-shell-message-folder.test.ts
@@ -137,7 +137,7 @@ test('writes truncated execute_shell full output to a linkable artifact', () => 
     const fullOutputPath = content.match(/^full_output_path: (.+)$/m)?.[1];
 
     assert.ok(content.startsWith(TRUNCATED_EXECUTE_SHELL_PREFIX));
-    assert.match(content, /full_output_ref: tool-result:\/\/test_session\/turn-0009\/sh_[a-f0-9]{16}/);
+    assert.match(content, /full_output_ref: tool-result:\/\/test_session\/sh_[a-f0-9]{16}/);
     assert.match(content, /full_output_link: file:\/\//);
     assert.ok(fullOutputPath);
     assert.equal(fs.readFileSync(fullOutputPath, 'utf8').includes(raw), true);

--- a/tests/read-file-message-folder.test.ts
+++ b/tests/read-file-message-folder.test.ts
@@ -96,12 +96,111 @@ test('writes truncated read_file full output to a linkable artifact', () => {
     const fullOutputPath = content.match(/^full_output_path: (.+)$/m)?.[1];
 
     assert.ok(content.startsWith(TRUNCATED_READ_FILE_PREFIX));
-    assert.match(content, /full_output_ref: tool-result:\/\/test_session\/turn-0007\/rf_[a-f0-9]{16}/);
+    assert.match(content, /full_output_ref: tool-result:\/\/test_session\/rf_[a-f0-9]{16}/);
     assert.match(content, /full_output_link: file:\/\//);
     assert.ok(fullOutputPath);
     assert.equal(fs.readFileSync(fullOutputPath, 'utf8').includes(raw), true);
   } finally {
     fs.rmSync(artifactRoot, { recursive: true, force: true });
+  }
+});
+
+test('keeps folded historical artifact references byte-identical across inference turns', () => {
+  const artifactRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-stable-read-artifacts-'));
+  const raw = makeReadFileOutput('E:/repo/stable-large.ts', 90);
+  const messages: Message[] = [
+    { role: 'user', content: 'read stable-large.ts' },
+    makeToolCallMessage('call_stable_read', 'E:/repo/stable-large.ts'),
+    { role: 'tool', name: 'read_file', tool_call_id: 'call_stable_read', content: raw },
+    { role: 'assistant', content: 'read complete' },
+    { role: 'user', content: 'continue' },
+  ];
+
+  try {
+    const foldAtTurn = (turn: number) => foldHistoricalReadFileMessages(messages, {
+      thresholdTokens: 20,
+      artifactStore: {
+        enabled: true,
+        rootDirectory: artifactRoot,
+        sessionId: 'stable session',
+        turn,
+      },
+    }).messages[2];
+
+    const first = foldAtTurn(1);
+    const second = foldAtTurn(2);
+
+    assert.equal(JSON.stringify(second), JSON.stringify(first));
+    assert.match(String(first.content), /full_output_ref: tool-result:\/\/stable_session\/rf_[a-f0-9]{16}/);
+    assert.equal(String(first.content).includes('/turn-'), false);
+  } finally {
+    fs.rmSync(artifactRoot, { recursive: true, force: true });
+  }
+});
+
+test('runner keeps the same historical provider tool result byte-identical across tool-loop turns', async () => {
+  const previousThreshold = process.env.XIAOBA_READ_FILE_FOLD_THRESHOLD_TOKENS;
+  process.env.XIAOBA_READ_FILE_FOLD_THRESHOLD_TOKENS = '20';
+  const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-runner-stable-prefix-'));
+  const raw = makeReadFileOutput('E:/repo/runner-stable.ts', 90);
+  const messages: Message[] = [
+    { role: 'user', content: 'read runner-stable.ts' },
+    makeToolCallMessage('call_historical_read', 'E:/repo/runner-stable.ts'),
+    { role: 'tool', name: 'read_file', tool_call_id: 'call_historical_read', content: raw },
+    { role: 'assistant', content: 'historical read complete' },
+    { role: 'user', content: 'continue with one more read' },
+  ];
+  const captured: Message[][] = [];
+  const aiService = {
+    async chat(requestMessages: Message[]) {
+      captured.push(JSON.parse(JSON.stringify(requestMessages)));
+      if (captured.length === 1) {
+        return {
+          content: null,
+          toolCalls: [{
+            id: 'call_current_read',
+            type: 'function' as const,
+            function: { name: 'read_file', arguments: JSON.stringify({ file_path: 'E:/repo/current.ts' }) },
+          }],
+        };
+      }
+      return { content: 'done', toolCalls: [] };
+    },
+  };
+  const executor: ToolExecutor = {
+    getToolDefinitions: () => [{
+      name: 'read_file',
+      description: 'read a file',
+      parameters: { type: 'object', properties: {} },
+    }],
+    executeTool: async toolCall => ({
+      tool_call_id: toolCall.id,
+      role: 'tool',
+      name: 'read_file',
+      content: 'current read output',
+    }),
+  };
+
+  try {
+    const runner = new ConversationRunner(aiService as any, executor, {
+      stream: false,
+      enableCompression: false,
+      toolExecutionContext: {
+        workspaceRoot,
+        sessionId: 'stable-runner-session',
+      },
+    });
+    await runner.run(messages);
+
+    assert.equal(captured.length, 2);
+    const historicalAtTurn1 = captured[0].find(message => message.tool_call_id === 'call_historical_read');
+    const historicalAtTurn2 = captured[1].find(message => message.tool_call_id === 'call_historical_read');
+    assert.equal(JSON.stringify(historicalAtTurn2), JSON.stringify(historicalAtTurn1));
+    assert.match(String(historicalAtTurn1?.content), /full_output_ref: tool-result:\/\/stable-runner-session\/rf_[a-f0-9]{16}/);
+  } finally {
+    if (previousThreshold === undefined) delete process.env.XIAOBA_READ_FILE_FOLD_THRESHOLD_TOKENS;
+    else process.env.XIAOBA_READ_FILE_FOLD_THRESHOLD_TOKENS = previousThreshold;
+    fs.rmSync(workspaceRoot, { recursive: true, force: true });
   }
 });
 

--- a/tests/read-file-message-folder.test.ts
+++ b/tests/read-file-message-folder.test.ts
@@ -334,7 +334,7 @@ test('runner folds provider input and persists the same stable historical read_f
   assert.equal(messages[2].__toolResultStable, true);
 });
 
-test('runner delayed-folds older current-run tool results and keeps recent ones raw', async () => {
+test('runner freezes both older and recent current-run tool results after delayed folding', async () => {
   const previousThreshold = process.env.XIAOBA_READ_FILE_FOLD_THRESHOLD_TOKENS;
   const previousCurrentRunFolding = process.env.XIAOBA_CURRENT_RUN_TOOL_RESULT_FOLDING;
   const previousKeepRecent = process.env.XIAOBA_CURRENT_RUN_TOOL_RESULT_FOLD_KEEP_RECENT;
@@ -382,9 +382,9 @@ test('runner delayed-folds older current-run tool results and keeps recent ones 
   const providerOld = captured[0].find(message => message.tool_call_id === 'call_current_provider_old');
   const providerRecent = captured[0].find(message => message.tool_call_id === 'call_current_provider_recent');
   assert.ok(String(providerOld?.content).startsWith(TRUNCATED_READ_FILE_PREFIX));
-  assert.equal(providerRecent?.content, secondRaw);
-  assert.ok(String(messages[2].content).startsWith(TRUNCATED_READ_FILE_PREFIX));
-  assert.ok(String(messages[5].content).startsWith(TRUNCATED_READ_FILE_PREFIX));
+  assert.ok(String(providerRecent?.content).startsWith(TRUNCATED_READ_FILE_PREFIX));
+  assert.equal(messages[2].content, providerOld?.content);
+  assert.equal(messages[5].content, providerRecent?.content);
   assert.equal(messages[2].__toolResultStable, true);
   assert.equal(messages[5].__toolResultStable, true);
 });

--- a/tests/read-file-message-folder.test.ts
+++ b/tests/read-file-message-folder.test.ts
@@ -194,7 +194,7 @@ test('environment options are deterministic and can disable folding', () => {
   assert.equal(options.keepRecentHistoricalReads, 2);
 });
 
-test('runner folds only provider input and leaves durable session messages raw', async () => {
+test('runner folds provider input and persists the same stable historical read_file result', async () => {
   const previousThreshold = process.env.XIAOBA_READ_FILE_FOLD_THRESHOLD_TOKENS;
   process.env.XIAOBA_READ_FILE_FOLD_THRESHOLD_TOKENS = '20';
 
@@ -231,7 +231,8 @@ test('runner folds only provider input and leaves durable session messages raw',
 
   const providerToolResult = captured[0].find(message => message.role === 'tool');
   assert.ok(String(providerToolResult?.content).startsWith(TRUNCATED_READ_FILE_PREFIX));
-  assert.equal(messages[2].content, raw);
+  assert.equal(messages[2].content, providerToolResult?.content);
+  assert.equal(messages[2].__toolResultStable, true);
 });
 
 test('runner delayed-folds older current-run tool results and keeps recent ones raw', async () => {
@@ -283,6 +284,8 @@ test('runner delayed-folds older current-run tool results and keeps recent ones 
   const providerRecent = captured[0].find(message => message.tool_call_id === 'call_current_provider_recent');
   assert.ok(String(providerOld?.content).startsWith(TRUNCATED_READ_FILE_PREFIX));
   assert.equal(providerRecent?.content, secondRaw);
-  assert.equal(messages[2].content, firstRaw);
-  assert.equal(messages[5].content, secondRaw);
+  assert.ok(String(messages[2].content).startsWith(TRUNCATED_READ_FILE_PREFIX));
+  assert.ok(String(messages[5].content).startsWith(TRUNCATED_READ_FILE_PREFIX));
+  assert.equal(messages[2].__toolResultStable, true);
+  assert.equal(messages[5].__toolResultStable, true);
 });

--- a/tests/stable-tool-result-history.test.ts
+++ b/tests/stable-tool-result-history.test.ts
@@ -99,3 +99,23 @@ test('small supported results are also frozen instead of being rewritten by a la
   assert.equal(later.stats.folded_count, 0);
   assert.equal(later.messages[2].content, original);
 });
+
+test('freezes the supported Read alias before adaptive folding can rewrite it', () => {
+  const messages: Message[] = [
+    { role: 'user', content: 'inspect it' },
+    makeToolCall('read_alias', 'Read'),
+    { role: 'tool', name: 'Read', tool_call_id: 'read_alias', content: 'short alias output' },
+  ];
+
+  stabilizeToolResultsForHistory(messages, [], readOptions, shellOptions);
+  const original = messages[2].content;
+  messages.push({ role: 'user', content: 'continue' });
+  const later = foldHistoricalReadFileMessages(messages, {
+    ...readOptions,
+    thresholdTokens: 1,
+  });
+
+  assert.equal(messages[2].__toolResultStable, true);
+  assert.equal(later.stats.folded_count, 0);
+  assert.equal(later.messages[2].content, original);
+});

--- a/tests/stable-tool-result-history.test.ts
+++ b/tests/stable-tool-result-history.test.ts
@@ -1,0 +1,101 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Message } from '../src/types';
+import { stabilizeToolResultsForHistory } from '../src/core/stable-tool-result-history';
+import { foldHistoricalReadFileMessages, TRUNCATED_READ_FILE_PREFIX } from '../src/core/read-file-message-folder';
+
+function makeToolCall(id: string, name: string): Message {
+  return {
+    role: 'assistant',
+    content: null,
+    tool_calls: [{
+      id,
+      type: 'function',
+      function: { name, arguments: '{}' },
+    }],
+  };
+}
+
+const readOptions = {
+  enabled: true,
+  thresholdTokens: 100,
+  maxPreviewLines: 2,
+  maxSymbolLines: 2,
+  keepRecentHistoricalReads: 0,
+  foldCurrentRun: false,
+};
+
+const shellOptions = {
+  enabled: true,
+  thresholdTokens: 100,
+  maxHeadLines: 2,
+  maxTailLines: 2,
+  maxKeyLines: 2,
+  keepRecentHistoricalShells: 0,
+  foldCurrentRun: false,
+};
+
+test('stabilizes a tool result once and keeps the persisted prefix byte-identical', () => {
+  const raw = ['File: /repo/a.ts', 'Path: /repo/a.ts', '', '1→ const value = 1;\n'.repeat(300)].join('\n');
+  const toolResult: Message = {
+    role: 'tool',
+    name: 'read_file',
+    tool_call_id: 'read_1',
+    content: raw,
+  };
+  const messages: Message[] = [
+    { role: 'user', content: 'inspect it' },
+    makeToolCall('read_1', 'read_file'),
+    toolResult,
+    { role: 'assistant', content: 'done' },
+  ];
+  const newMessages = messages.slice(1);
+
+  const first = stabilizeToolResultsForHistory(messages, newMessages, readOptions, shellOptions);
+  const stableContent = String(messages[2].content);
+
+  assert.equal(first.readFileFoldedCount, 1);
+  assert.equal(messages[2].__toolResultStable, true);
+  assert.equal(newMessages[1].__toolResultStable, true);
+  assert.ok(stableContent.startsWith(TRUNCATED_READ_FILE_PREFIX));
+  assert.equal(newMessages[1].content, stableContent);
+
+  messages.push({ role: 'user', content: 'continue' });
+  const second = stabilizeToolResultsForHistory(messages, [], {
+    ...readOptions,
+    thresholdTokens: 1,
+    maxPreviewLines: 1,
+    maxSymbolLines: 1,
+  }, shellOptions);
+  const adaptiveAttempt = foldHistoricalReadFileMessages(messages, {
+    ...readOptions,
+    thresholdTokens: 1,
+    maxPreviewLines: 1,
+    maxSymbolLines: 1,
+  });
+
+  assert.equal(second.readFileFoldedCount, 0);
+  assert.equal(adaptiveAttempt.stats.folded_count, 0);
+  assert.equal(messages[2].content, stableContent);
+  assert.equal(adaptiveAttempt.messages[2].content, stableContent);
+});
+
+test('small supported results are also frozen instead of being rewritten by a later lower threshold', () => {
+  const messages: Message[] = [
+    { role: 'user', content: 'inspect it' },
+    makeToolCall('read_small', 'read_file'),
+    { role: 'tool', name: 'read_file', tool_call_id: 'read_small', content: 'short output' },
+  ];
+
+  stabilizeToolResultsForHistory(messages, [], readOptions, shellOptions);
+  const original = messages[2].content;
+  messages.push({ role: 'user', content: 'continue' });
+  const later = foldHistoricalReadFileMessages(messages, {
+    ...readOptions,
+    thresholdTokens: 1,
+  });
+
+  assert.equal(messages[2].__toolResultStable, true);
+  assert.equal(later.stats.folded_count, 0);
+  assert.equal(later.messages[2].content, original);
+});


### PR DESCRIPTION
## Summary
- normalize supported `read_file` and `execute_shell` results once before completed runs are persisted
- mark normalized results so later adaptive prompt-budget passes cannot rewrite historical prefix bytes
- keep full raw outputs available through the existing artifact store
- de-duplicate transient provider messages by internal prefix, keeping the latest value

## Why
Anthropic prompt caching is prefix-based. Re-folding old tool results as a conversation grows changes earlier serialized bytes and invalidates cache reuse for the remaining prompt. Duplicate transient blocks further reduce the stable-prefix share.

Fixes #279

## Verification
- `npm run build`
- targeted cache/history tests: 20 passed
- adjacent context, transcript, and Anthropic cache tests: 64 passed
- `git diff --check`

The broad runtime suite was also sampled; unrelated existing bot-definition authentication assertions fail under the local ambient CatsCo credentials, while the changed and adjacent suites pass in isolated test data roots.
## Follow-up: stable artifact identity
Incorporated the concrete reproduction from the issue discussion:
- remove the current inference turn from `full_output_ref`, `full_output_path`, and `full_output_link`
- derive provider-visible artifact references from stable session + content-derived artifact id
- add a direct folding regression comparing turn 1 vs turn 2 byte-for-byte
- add a `ConversationRunner -> AIService` regression comparing the same historical tool result across consecutive tool-loop turns

Additional verification:
- targeted tool-result/history tests: 20 passed
- adjacent cache/context regressions: 69 passed
- `npm run build`
- `git diff --check`
