### PR TITLE
fix: stabilize folded tool-result cache prefixes

### DIFF
--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -404,7 +404,7 @@ export class ConversationRunner {
         requestMessages,
         currentRunToolResultFoldingOptions,
       );
-      const toolResultArtifactStoreOptions = this.resolveToolResultArtifactStoreOptions(turns);
+      const toolResultArtifactStoreOptions = this.resolveToolResultArtifactStoreOptions();
       const readFileFoldingOptions = {
         ...resolveReadFileMessageFoldingOptions(),
         foldCurrentRun: currentRunToolResultFoldingOptions.enabled,
@@ -1547,7 +1547,7 @@ export class ConversationRunner {
     };
   }
 
-  private resolveToolResultArtifactStoreOptions(turn: number) {
+  private resolveToolResultArtifactStoreOptions() {
     const workspaceRoot = this.toolExecutionContext?.workspaceRoot
       || this.toolExecutionContext?.workingDirectory;
     const defaultRoot = workspaceRoot
@@ -1558,7 +1558,6 @@ export class ConversationRunner {
       rootDirectory: defaultRoot,
       sessionId: this.toolExecutionContext?.sessionId
         || this.toolExecutionContext?.executionScope?.sessionKey,
-      turn,
     });
   }
 

--- a/src/core/execute-shell-message-folder.ts
+++ b/src/core/execute-shell-message-folder.ts
@@ -227,7 +227,6 @@ function buildFoldedExecuteShellContent(
   const artifact = persistToolResultArtifact({
     artifactId: `sh_${hash.slice(0, 16)}`,
     toolName: 'execute_shell',
-    toolCallId: candidate.message.tool_call_id,
     sha256: hash,
     rawText: candidate.rawText,
     store: options.artifactStore,

--- a/src/core/read-file-message-folder.ts
+++ b/src/core/read-file-message-folder.ts
@@ -210,7 +210,6 @@ function buildFoldedReadFileContent(
   const artifact = persistToolResultArtifact({
     artifactId: `rf_${hash.slice(0, 16)}`,
     toolName: 'read_file',
-    toolCallId: candidate.message.tool_call_id,
     sha256: hash,
     rawText: candidate.rawText,
     store: options.artifactStore,

--- a/src/core/tool-result-artifact-store.ts
+++ b/src/core/tool-result-artifact-store.ts
@@ -5,6 +5,7 @@ export interface ToolResultArtifactStoreOptions {
   enabled: boolean;
   rootDirectory?: string;
   sessionId?: string;
+  /** @deprecated Artifact paths are content-addressed and no longer scoped by model turn. */
   turn?: number;
 }
 
@@ -19,7 +20,6 @@ export interface ToolResultArtifactReference {
 export interface PersistToolResultArtifactParams {
   artifactId: string;
   toolName: string;
-  toolCallId?: string;
   sha256: string;
   rawText: string;
   store?: Partial<ToolResultArtifactStoreOptions>;
@@ -55,12 +55,9 @@ export function persistToolResultArtifact(
   }
 
   const sessionSegment = sanitizeFileSegment(resolved.sessionId || 'unknown-session');
-  const turnSegment = typeof resolved.turn === 'number' && Number.isFinite(resolved.turn)
-    ? `turn-${String(Math.max(0, Math.floor(resolved.turn))).padStart(4, '0')}`
-    : 'turn-unknown';
-  const directory = path.resolve(resolved.rootDirectory, sessionSegment, turnSegment);
+  const directory = path.resolve(resolved.rootDirectory, sessionSegment);
   const filePath = path.join(directory, `${artifactId}.txt`);
-  const ref = `tool-result://${sessionSegment}/${turnSegment}/${artifactId}`;
+  const ref = `tool-result://${sessionSegment}/${artifactId}`;
 
   try {
     fs.mkdirSync(directory, { recursive: true });
@@ -85,7 +82,6 @@ export function persistToolResultArtifact(
 function buildArtifactPayload(params: PersistToolResultArtifactParams): string {
   return [
     `tool_name: ${params.toolName}`,
-    params.toolCallId ? `tool_call_id: ${params.toolCallId}` : '',
     `sha256: ${params.sha256}`,
     '',
     params.rawText,

--- a/tests/execute-shell-message-folder.test.ts
+++ b/tests/execute-shell-message-folder.test.ts
@@ -137,10 +137,42 @@ test('writes truncated execute_shell full output to a linkable artifact', () => 
     const fullOutputPath = content.match(/^full_output_path: (.+)$/m)?.[1];
 
     assert.ok(content.startsWith(TRUNCATED_EXECUTE_SHELL_PREFIX));
-    assert.match(content, /full_output_ref: tool-result:\/\/test_session\/turn-0009\/sh_[a-f0-9]{16}/);
+    assert.match(content, /full_output_ref: tool-result:\/\/test_session\/sh_[a-f0-9]{16}/);
     assert.match(content, /full_output_link: file:\/\//);
     assert.ok(fullOutputPath);
     assert.equal(fs.readFileSync(fullOutputPath, 'utf8').includes(raw), true);
+  } finally {
+    fs.rmSync(artifactRoot, { recursive: true, force: true });
+  }
+});
+
+test('keeps folded execute_shell artifact references stable across model turns', () => {
+  const artifactRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-shell-cache-prefix-'));
+  const raw = makeShellOutput('npm test -- cache-prefix', 100, true);
+  const messages: Message[] = [
+    { role: 'user', content: 'run cache-prefix tests' },
+    makeToolCallMessage('call_shell_cache_prefix', 'npm test -- cache-prefix'),
+    { role: 'tool', name: 'execute_shell', tool_call_id: 'call_shell_cache_prefix', content: raw },
+    { role: 'assistant', content: 'tests failed' },
+    { role: 'user', content: 'continue' },
+  ];
+
+  try {
+    const foldForTurn = (turn: number) => foldHistoricalExecuteShellMessages(messages, {
+      thresholdTokens: 20,
+      artifactStore: {
+        enabled: true,
+        rootDirectory: artifactRoot,
+        sessionId: 'stable session',
+        turn,
+      },
+    }).messages[2];
+
+    const firstFolded = foldForTurn(1);
+    const secondFolded = foldForTurn(2);
+
+    assert.ok(String(firstFolded.content).startsWith(TRUNCATED_EXECUTE_SHELL_PREFIX));
+    assert.equal(JSON.stringify(secondFolded), JSON.stringify(firstFolded));
   } finally {
     fs.rmSync(artifactRoot, { recursive: true, force: true });
   }

--- a/tests/read-file-message-folder.test.ts
+++ b/tests/read-file-message-folder.test.ts
@@ -96,7 +96,7 @@ test('writes truncated read_file full output to a linkable artifact', () => {
     const fullOutputPath = content.match(/^full_output_path: (.+)$/m)?.[1];
 
     assert.ok(content.startsWith(TRUNCATED_READ_FILE_PREFIX));
-    assert.match(content, /full_output_ref: tool-result:\/\/test_session\/turn-0007\/rf_[a-f0-9]{16}/);
+    assert.match(content, /full_output_ref: tool-result:\/\/test_session\/rf_[a-f0-9]{16}/);
     assert.match(content, /full_output_link: file:\/\//);
     assert.ok(fullOutputPath);
     assert.equal(fs.readFileSync(fullOutputPath, 'utf8').includes(raw), true);
@@ -232,6 +232,77 @@ test('runner folds only provider input and leaves durable session messages raw',
   const providerToolResult = captured[0].find(message => message.role === 'tool');
   assert.ok(String(providerToolResult?.content).startsWith(TRUNCATED_READ_FILE_PREFIX));
   assert.equal(messages[2].content, raw);
+});
+
+test('runner keeps folded historical read_file output stable across model turns', async () => {
+  const previousThreshold = process.env.XIAOBA_READ_FILE_FOLD_THRESHOLD_TOKENS;
+  const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-cache-prefix-'));
+  process.env.XIAOBA_READ_FILE_FOLD_THRESHOLD_TOKENS = '20';
+
+  const raw = makeReadFileOutput('E:/repo/cache-prefix.ts', 90);
+  const messages: Message[] = [
+    { role: 'user', content: 'read cache-prefix.ts' },
+    makeToolCallMessage('call_cache_prefix', 'E:/repo/cache-prefix.ts'),
+    { role: 'tool', name: 'read_file', tool_call_id: 'call_cache_prefix', content: raw },
+    { role: 'assistant', content: 'read complete' },
+    { role: 'user', content: 'continue with one tool call' },
+  ];
+  const captured: Message[][] = [];
+  let callCount = 0;
+  const aiService = {
+    async chat(requestMessages: Message[]) {
+      captured.push(JSON.parse(JSON.stringify(requestMessages)));
+      callCount++;
+      if (callCount === 1) {
+        return {
+          content: null,
+          toolCalls: [{
+            id: 'call_noop',
+            type: 'function',
+            function: { name: 'noop', arguments: '{}' },
+          }],
+        };
+      }
+      return { content: 'done', toolCalls: [] };
+    },
+  };
+  const executor: ToolExecutor = {
+    getToolDefinitions: () => [{
+      name: 'noop',
+      description: 'No-op tool used to force a second model turn',
+      parameters: { type: 'object', properties: {} },
+    }],
+    executeTool: async () => ({
+      ok: true,
+      tool_call_id: 'call_noop',
+      role: 'tool',
+      name: 'noop',
+      content: 'ok',
+    }),
+  };
+
+  try {
+    const runner = new ConversationRunner(aiService as any, executor, {
+      stream: false,
+      enableCompression: false,
+      toolExecutionContext: {
+        workingDirectory: workspaceRoot,
+        workspaceRoot,
+        sessionId: 'stable-session',
+      },
+    });
+    await runner.run(messages);
+  } finally {
+    if (previousThreshold === undefined) delete process.env.XIAOBA_READ_FILE_FOLD_THRESHOLD_TOKENS;
+    else process.env.XIAOBA_READ_FILE_FOLD_THRESHOLD_TOKENS = previousThreshold;
+    fs.rmSync(workspaceRoot, { recursive: true, force: true });
+  }
+
+  assert.equal(captured.length, 2);
+  const firstFolded = captured[0].find(message => message.tool_call_id === 'call_cache_prefix');
+  const secondFolded = captured[1].find(message => message.tool_call_id === 'call_cache_prefix');
+  assert.ok(String(firstFolded?.content).startsWith(TRUNCATED_READ_FILE_PREFIX));
+  assert.equal(JSON.stringify(secondFolded), JSON.stringify(firstFolded));
 });
 
 test('runner delayed-folds older current-run tool results and keeps recent ones raw', async () => {


### PR DESCRIPTION
## Summary

- make folded tool-result artifact paths stable across model turns
- address artifacts by session plus deterministic artifact ID instead of the current inference turn
- remove call-specific metadata from content-addressed artifact payloads
- add serialized-message stability regressions for both `read_file` and `execute_shell`

## Problem

Historical tool results are folded again before each provider request. The artifact store previously embedded the current model turn in every folded reference:

```text
tool-result://stable-session/turn-0001/rf_...
tool-result://stable-session/turn-0002/rf_...
```

That changed an old `function_call_output` on every tool-loop turn even when durable history was unchanged. `prompt_cache_key` could remain stable while the actual Responses/Anthropic prompt prefix changed.

## Fix

Artifact references and paths now use:

```text
tool-result://stable-session/rf_...
```

The existing `turn` option remains as a deprecated compatibility field, but no longer affects persistence. The runner also stops passing its current model turn into artifact storage.

This is a focused fix for the confirmed per-turn prefix drift. It does not attempt to complete the broader compaction-idempotence or transient-context work in #279.

## Validation

- `node --import tsx --test tests/read-file-message-folder.test.ts tests/execute-shell-message-folder.test.ts tests/openai-provider-responses.test.ts`
- `npm run build`
- `npm test`
  - 1,255 tests
  - 1,248 passed
  - 7 skipped
  - 0 failed

Refs #279
