### PR TITLE
Remove agent-browser and web-search defaults

### DIFF
--- a/docs/branch-session-architecture.md
+++ b/docs/branch-session-architecture.md
@@ -38,6 +38,6 @@ synthetic observations back to the parent runner. A concrete branch only needs t
 - a disposition function that decides whether to inject or suppress
 - a payload-to-`SyntheticObservation` formatter
 
-`MemorySearchBranchSession` is the first concrete implementation. Future branches, such as
-web search, should extend `ObservationBranchSession` instead of reimplementing publish,
-suppress, drop, and cancel bookkeeping.
+`MemorySearchBranchSession` is the first concrete implementation. Future observation-producing
+branches should extend `ObservationBranchSession` instead of reimplementing publish, suppress,
+drop, and cancel bookkeeping.

--- a/src/core/memory-search-branch-session.ts
+++ b/src/core/memory-search-branch-session.ts
@@ -145,7 +145,7 @@ function buildMemorySearchSystemPrompt(): string {
     '- 不要把多个中文词或多个概念用空格拼进同一个 keyword；那会被当成一个完整字符串，导致大量漏召回。',
     '- 好例子：["生日", "包间", "蛋糕", "低预算", "6-8人", "安静"]。',
     '- 坏例子：["生日 包间 蛋糕 低预算 6-8人 安静"]。',
-    '- 例外：固定名称、工具名、文件名、项目名可以作为完整 keyword，例如 "agent-browser"、"MemorySearchBranchSession"。',
+    '- 例外：固定名称、工具名、文件名、项目名可以作为完整 keyword，例如 "XiaoBa-CLI"、"MemorySearchBranchSession"。',
     '',
     '工具结果约定：memory tools 都返回紧凑 JSON 字符串。你需要解析 JSON 后继续判断。',
     'canonical refs 可以手动调整：如果看到 ...#42，你可以读取 ...#41 或 ...#43 来查看相邻 episode。',

--- a/src/core/synthetic-observation.ts
+++ b/src/core/synthetic-observation.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'crypto';
 import { Message } from '../types';
 
-export type SyntheticObservationSource = 'memory' | 'web' | 'runtime' | 'subagent' | 'skill_context';
+export type SyntheticObservationSource = 'memory' | 'runtime' | 'subagent' | 'skill_context';
 export type SyntheticObservationStatus = 'completed' | 'partial' | 'failed' | 'cancelled';
 export type SyntheticObservationRelevance = 'high' | 'medium' | 'low';
 export type SyntheticObservationTiming = 'current_turn' | 'late_previous_turn';

--- a/src/core/transient-injection-policy.ts
+++ b/src/core/transient-injection-policy.ts
@@ -80,7 +80,7 @@ const SELF_EVOLUTION_SIGNAL =
   /创建.*skill|新建.*skill|自我进化|扩展能力|写.*工具|新增.*工具|self[-_ ]?evolution/i;
 
 const SKILL_SIGNAL =
-  /skill|技能|能力列表|工具列表|会什么|能做什么|调用.*工具|使用.*工具|agent-browser|coding-context|memory-search|officecli|self-evolution/i;
+  /skill|技能|能力列表|工具列表|会什么|能做什么|调用.*工具|使用.*工具|coding-context|memory-search|officecli|self-evolution/i;
 
 const COMPLEX_WORK_SIGNAL =
   /完整|全面|系统性|评估|优化|重构|方案|策略|架构|多阶段|长期|端到端|测试覆盖|上线|发布|梳理|审查|review|comprehensive|end-to-end|architecture|strategy/i;

--- a/src/skillhub/default-skills.ts
+++ b/src/skillhub/default-skills.ts
@@ -6,8 +6,6 @@ export interface DefaultSkillHubSkill {
 }
 
 export const DEFAULT_SKILLHUB_SKILLS: DefaultSkillHubSkill[] = [
-  { key: 'lin/agent-browser', skillId: 'lin/agent-browser', version: '1.0.3', installName: 'agent-browser' },
-  { key: 'atridaisuki/web-search', skillId: 'atridaisuki/web-search', version: '1.0.2', installName: 'web-search' },
   { key: 'atridaisuki/read-pdf', skillId: 'atridaisuki/read-pdf', version: '1.0.15', installName: 'read-pdf' },
   { key: 'atridaisuki/pdf-author-editor', skillId: 'atridaisuki/pdf-author-editor', version: '1.2.5', installName: 'pdf-author-editor' },
   { key: 'atridaisuki/image-asset-generator', skillId: 'atridaisuki/image-asset-generator', version: '1.0.13', installName: 'image-asset-generator' },

--- a/tests/skillhub-default-skills.test.ts
+++ b/tests/skillhub-default-skills.test.ts
@@ -12,8 +12,7 @@ import {
   type DefaultSkillHubSkill,
 } from '../src/skillhub/default-skills';
 
-const ATRIDAISUKI_DEFAULTS = [
-  'atridaisuki/web-search@1.0.2',
+const EXPECTED_DEFAULTS = [
   'atridaisuki/read-pdf@1.0.15',
   'atridaisuki/pdf-author-editor@1.2.5',
   'atridaisuki/image-asset-generator@1.0.13',
@@ -39,12 +38,11 @@ describe('default SkillHub bootstrap', () => {
     if (fs.existsSync(testRoot)) fs.rmSync(testRoot, { recursive: true, force: true });
   });
 
-  test('ships the selected atridaisuki defaults without cloud HTML artifact', () => {
+  test('ships only the selected defaults without cloud HTML artifact', () => {
     const configured = DEFAULT_SKILLHUB_SKILLS
-      .filter(skill => skill.skillId.startsWith('atridaisuki/'))
       .map(skill => `${skill.skillId}@${skill.version}`);
 
-    assert.deepEqual(configured, ATRIDAISUKI_DEFAULTS);
+    assert.deepEqual(configured, EXPECTED_DEFAULTS);
     assert.equal(configured.some(skill => skill.includes('artifact')), false);
   });
 
@@ -56,7 +54,7 @@ describe('default SkillHub bootstrap', () => {
 
   test('installs a missing default skill once and records central state', async () => {
     const calls: string[] = [];
-    const skill = defaultSkill('agent-browser');
+    const skill = defaultSkill('starter');
     const service = fakeInstallService(calls);
 
     const first = await bootstrapDefaultSkillHubSkills({ skills: [skill], service });
@@ -64,11 +62,11 @@ describe('default SkillHub bootstrap', () => {
 
     assert.deepEqual(first.map(item => item.action), ['installed']);
     assert.deepEqual(second.map(item => item.reason), ['already_installed']);
-    assert.deepEqual(calls, ['catsco/agent-browser@1.0.0']);
+    assert.deepEqual(calls, ['catsco/starter@1.0.0']);
     const state = readState();
     assert.equal(state.items[skill.key].state, 'installed');
-    assert.equal(state.items[skill.key].relativePath, 'agent-browser');
-    assert.equal(fs.existsSync(path.join(testRoot, 'skills', 'agent-browser', 'SKILL.md')), true);
+    assert.equal(state.items[skill.key].relativePath, 'starter');
+    assert.equal(fs.existsSync(path.join(testRoot, 'skills', 'starter', 'SKILL.md')), true);
   });
 
   test('does not reinstall a default skill after the user removes it', async () => {
@@ -105,12 +103,12 @@ describe('default SkillHub bootstrap', () => {
 
   test('installs newly added defaults without reviving removed defaults', async () => {
     const calls: string[] = [];
-    const firstSkill = defaultSkill('agent-browser');
+    const firstSkill = defaultSkill('starter');
     const secondSkill = defaultSkill('officecli');
     const service = fakeInstallService(calls);
 
     await bootstrapDefaultSkillHubSkills({ skills: [firstSkill], service });
-    fs.rmSync(path.join(testRoot, 'skills', 'agent-browser'), { recursive: true, force: true });
+    fs.rmSync(path.join(testRoot, 'skills', 'starter'), { recursive: true, force: true });
     await bootstrapDefaultSkillHubSkills({ skills: [firstSkill], service });
 
     const result = await bootstrapDefaultSkillHubSkills({
@@ -120,7 +118,7 @@ describe('default SkillHub bootstrap', () => {
 
     assert.equal(result.find(item => item.key === firstSkill.key)?.state, 'user_removed');
     assert.equal(result.find(item => item.key === secondSkill.key)?.action, 'installed');
-    assert.deepEqual(calls, ['catsco/agent-browser@1.0.0', 'catsco/officecli@1.0.0']);
+    assert.deepEqual(calls, ['catsco/starter@1.0.0', 'catsco/officecli@1.0.0']);
   });
 });
 


### PR DESCRIPTION
## Summary

- remove `agent-browser` and `web-search` from the default SkillHub bootstrap list
- remove their dedicated prompt, documentation, and synthetic-observation scaffolding references
- update bootstrap tests to assert the complete remaining default skill set

## Testing

- `mise exec -- ./node_modules/.bin/tsx --test tests/skillhub-default-skills.test.ts tests/transient-injection-policy.test.ts tests/synthetic-observation.test.ts`
- `mise exec -- ./node_modules/.bin/tsc`