### PR TITLE
fix: harden cloud model switching reliability

### DIFF
--- a/src/bot-definition/activation.ts
+++ b/src/bot-definition/activation.ts
@@ -3,6 +3,8 @@ import {
   provisionCatsRelayCatalogRuntime,
   refreshCatsRelayCatalogRuntimeCapabilities,
   validateCatsRelayCatalogRuntimeCredential,
+  RelayCredentialRejectedError,
+  RelayCredentialUnreachableError,
 } from '../catscompany/relay-model-bootstrap';
 import { DEFAULT_CATSCO_RELAY_MODEL_ID } from '../utils/relay-model-profiles';
 import { Logger } from '../utils/logger';
@@ -307,13 +309,38 @@ export async function prepareBoundBotDefinition(
           definitionService.storeCloudCatalogRuntime(materialized);
           materializedCatalogRuntime = true;
         } else {
-          await validateCatsRelayCatalogRuntimeCredential(runtime, options.fetchImpl ?? fetch);
+          let effectiveRuntime = runtime;
+          try {
+            await validateCatsRelayCatalogRuntimeCredential(runtime, options.fetchImpl ?? fetch);
+          } catch (error) {
+            if (error instanceof RelayCredentialRejectedError) {
+              // 凭据确实被吊销：有登录态则重新物化，否则交由外层回滚
+              if (!auth?.token) throw error;
+              effectiveRuntime = await provisionCatsRelayCatalogRuntime({
+                botId,
+                modelId: cloudSelection.modelId,
+                reasoningEffort: cloudSelection.reasoningEffort,
+                existingRuntime: runtime,
+                auth,
+                fetchImpl: options.fetchImpl,
+              });
+              definitionService.storeCloudCatalogRuntime(effectiveRuntime);
+              materializedCatalogRuntime = true;
+            } else if (error instanceof RelayCredentialUnreachableError) {
+              // 暂时不可达（5xx/超时/网络）：不阻断，继续使用当前 runtime
+              Logger.warning(
+                `CatsCo relay 凭据暂时无法验证，继续使用当前模型: ${errorMessage(error)}`,
+              );
+            } else {
+              throw error;
+            }
+          }
           if (
             cloudSelection.reasoningEffort
-            && runtime.reasoningEffort !== cloudSelection.reasoningEffort
+            && effectiveRuntime.reasoningEffort !== cloudSelection.reasoningEffort
           ) {
             definitionService.storeCloudCatalogRuntime({
-              ...runtime,
+              ...effectiveRuntime,
               reasoningEffort: cloudSelection.reasoningEffort,
             });
           }

--- a/src/bot-definition/activation.ts
+++ b/src/bot-definition/activation.ts
@@ -2,6 +2,7 @@ import { createCatsCoLocalConfigService, type CatsCoAuthSnapshot } from '../cats
 import {
   provisionCatsRelayCatalogRuntime,
   refreshCatsRelayCatalogRuntimeCapabilities,
+  validateCatsRelayCatalogRuntimeCredential,
 } from '../catscompany/relay-model-bootstrap';
 import { DEFAULT_CATSCO_RELAY_MODEL_ID } from '../utils/relay-model-profiles';
 import { Logger } from '../utils/logger';
@@ -53,7 +54,7 @@ export interface PreparedBoundBotDefinition {
 export async function prepareBoundBotDefinition(
   options: PrepareBoundBotDefinitionOptions,
 ): Promise<PreparedBoundBotDefinition | undefined> {
-  const localConfig = createCatsCoLocalConfigService({ runtimeRoot: options.runtimeRoot }).load();
+  const localConfig = createCatsCoLocalConfigService({ runtimeRoot: options.runtimeRoot, env: options.env }).load();
   const botId = String(options.botId || localConfig.currentBot?.uid || '').trim();
   if (!botId) return undefined;
 
@@ -65,7 +66,7 @@ export async function prepareBoundBotDefinition(
   let sync = definitionService.pullOrBootstrap(botId);
   let localDefinition = sync?.definition;
   let initializedDefaultFromEmpty = false;
-  const auth = options.auth ?? createCatsCoLocalConfigService({ runtimeRoot: options.runtimeRoot }).getAuthState();
+  const auth = options.auth ?? createCatsCoLocalConfigService({ runtimeRoot: options.runtimeRoot, env: options.env }).getAuthState();
   const cloudDefinitionSync = createBotDefinitionCloudSyncService({
     runtimeRoot: options.runtimeRoot,
     env: options.env,
@@ -305,14 +306,17 @@ export async function prepareBoundBotDefinition(
           });
           definitionService.storeCloudCatalogRuntime(materialized);
           materializedCatalogRuntime = true;
-        } else if (
-          cloudSelection.reasoningEffort
-          && runtime.reasoningEffort !== cloudSelection.reasoningEffort
-        ) {
-          definitionService.storeCloudCatalogRuntime({
-            ...runtime,
-            reasoningEffort: cloudSelection.reasoningEffort,
-          });
+        } else {
+          await validateCatsRelayCatalogRuntimeCredential(runtime, options.fetchImpl ?? fetch);
+          if (
+            cloudSelection.reasoningEffort
+            && runtime.reasoningEffort !== cloudSelection.reasoningEffort
+          ) {
+            definitionService.storeCloudCatalogRuntime({
+              ...runtime,
+              reasoningEffort: cloudSelection.reasoningEffort,
+            });
+          }
         }
         sync = definitionService.acceptCloud(botId, cloudModel);
         definition = sync.definition;

--- a/src/bot-definition/activation.ts
+++ b/src/bot-definition/activation.ts
@@ -132,6 +132,7 @@ export async function prepareBoundBotDefinition(
               botId,
               modelId: definition.model.modelId,
               reasoningEffort: definition.model.reasoningEffort,
+              existingRuntime: runtime,
               auth,
               fetchImpl: options.fetchImpl,
             });
@@ -270,6 +271,7 @@ export async function prepareBoundBotDefinition(
             const materialized = await provisionCatsRelayCatalogRuntime({
               botId,
               modelId: localDefinition.model.modelId,
+              existingRuntime: runtime,
               auth,
               fetchImpl: options.fetchImpl,
             });
@@ -297,6 +299,7 @@ export async function prepareBoundBotDefinition(
             botId,
             modelId: cloudSelection.modelId,
             reasoningEffort: cloudSelection.reasoningEffort,
+            existingRuntime: runtime ?? definitionService.readCatalogRuntime(botId),
             auth,
             fetchImpl: options.fetchImpl,
           });
@@ -400,6 +403,7 @@ export async function prepareBoundBotDefinition(
       const materialized = await provisionCatsRelayCatalogRuntime({
         botId,
         modelId: definition.model.modelId,
+        existingRuntime: runtime,
         auth,
         fetchImpl: options.fetchImpl,
       });

--- a/src/bot-definition/types.ts
+++ b/src/bot-definition/types.ts
@@ -84,6 +84,8 @@ export interface LocalModelProfile {
 export interface BotCatalogModelRuntime {
   schema: typeof BOT_CATALOG_MODEL_RUNTIME_SCHEMA;
   botId: string;
+  /** Owner binding for relay credentials. Legacy records may omit it and must not be reused without login. */
+  ownerUid?: string;
   modelId: string;
   provider: 'anthropic' | 'openai';
   apiBase: string;

--- a/src/catscompany/local-config.ts
+++ b/src/catscompany/local-config.ts
@@ -52,6 +52,7 @@ export interface CatsCoAuthSnapshot {
   httpBaseUrl: string;
   serverUrl: string;
   botUid?: string;
+  ownerUid?: string;
   apiKey?: string;
 }
 
@@ -296,6 +297,11 @@ export class CatsCoLocalConfigService {
         legacy.CATSCO_BOT_UID,
         this.env.CATSCOMPANY_BOT_UID,
         legacy.CATSCOMPANY_BOT_UID,
+      ),
+      ownerUid: firstNonEmpty(
+        overrides.ownerUid,
+        bot?.boundByUserUid,
+        account?.uid,
       ),
       apiKey: firstNonEmpty(
         overrides.apiKey,

--- a/src/catscompany/relay-model-bootstrap.ts
+++ b/src/catscompany/relay-model-bootstrap.ts
@@ -126,8 +126,9 @@ export function retargetCatsRelayCatalogRuntime(
     contextWindowTokens: profile.contextWindowTokens,
     reasoningEffort: reasoningEffort ?? 'high',
     openaiApiMode: profile.openaiApiMode ?? 'chat_completions',
-    capabilities: { ...profile.capabilities },
-    capabilitiesSource: 'static',
+    capabilities: existing.capabilities ?? { ...profile.capabilities },
+    capabilitiesSource: existing.capabilitiesSource ?? 'static',
+    ...(existing.capabilitiesCheckedAt ? { capabilitiesCheckedAt: existing.capabilitiesCheckedAt } : {}),
   };
 }
 
@@ -236,10 +237,17 @@ async function fetchRelayModelCapabilities(
   }
 }
 
-class RelayCredentialRejectedError extends Error {
+export class RelayCredentialRejectedError extends Error {
   constructor() {
     super('The existing CatsCo relay credential was rejected.');
     this.name = 'RelayCredentialRejectedError';
+  }
+}
+
+export class RelayCredentialUnreachableError extends Error {
+  constructor(message?: string) {
+    super(message || 'The CatsCo relay credential could not be verified right now.');
+    this.name = 'RelayCredentialUnreachableError';
   }
 }
 
@@ -259,12 +267,14 @@ export async function validateCatsRelayCatalogRuntimeCredential(
       throw new RelayCredentialRejectedError();
     }
     if (!response.ok) {
-      throw new Error(`CatsCo relay credential could not be verified (HTTP ${response.status}).`);
+      throw new RelayCredentialUnreachableError(
+        `CatsCo relay credential could not be verified (HTTP ${response.status}).`,
+      );
     }
   } catch (error) {
     if (error instanceof RelayCredentialRejectedError) throw error;
-    if (error instanceof Error && error.message.startsWith('CatsCo relay credential could not be verified')) throw error;
-    throw new Error('CatsCo relay credential could not be verified before applying the model.');
+    if (error instanceof RelayCredentialUnreachableError) throw error;
+    throw new RelayCredentialUnreachableError();
   } finally {
     clearTimeout(timeout);
   }

--- a/src/catscompany/relay-model-bootstrap.ts
+++ b/src/catscompany/relay-model-bootstrap.ts
@@ -16,6 +16,7 @@ export interface CatsRelayBootstrapOptions {
   modelId: string;
   auth: CatsCoAuthSnapshot;
   reasoningEffort?: ReasoningEffort;
+  existingRuntime?: BotCatalogModelRuntime;
   fetchImpl?: typeof fetch;
 }
 
@@ -37,6 +38,16 @@ export async function provisionCatsRelayCatalogRuntime(
   if (!botId) throw new Error('Cannot initialize a catalog model without botId.');
   if (!profile) throw new Error(`Unknown CatsCo relay model: ${modelId}`);
   if (!token || !httpBaseUrl) {
+    if (
+      options.existingRuntime?.botId === botId
+      && String(options.existingRuntime.apiKey || '').trim()
+    ) {
+      return retargetCatsRelayCatalogRuntime(
+        options.existingRuntime,
+        profile.id,
+        options.reasoningEffort,
+      );
+    }
     throw new Error('CatsCo account login is required before the default model can be initialized.');
   }
 
@@ -80,6 +91,31 @@ export async function provisionCatsRelayCatalogRuntime(
     capabilities,
     capabilitiesSource,
     ...(capabilitiesSource !== 'static' ? { capabilitiesCheckedAt: new Date().toISOString() } : {}),
+  };
+}
+
+export function retargetCatsRelayCatalogRuntime(
+  existing: BotCatalogModelRuntime,
+  modelId: string,
+  reasoningEffort?: ReasoningEffort,
+): BotCatalogModelRuntime {
+  const profile = findRelayModelProfile(modelId);
+  if (!profile) throw new Error(`Unknown CatsCo relay model: ${modelId}`);
+  const apiKey = String(existing.apiKey || '').trim();
+  if (!apiKey) throw new Error('Existing CatsCo relay runtime does not contain a reusable credential.');
+  return {
+    schema: 'xiaoba.bot-catalog-model-runtime.v1',
+    botId: existing.botId,
+    modelId: profile.id,
+    provider: profile.preferredProvider,
+    apiBase: retargetRelayEndpoint(existing, profile.preferredProvider),
+    apiKey,
+    model: profile.model,
+    contextWindowTokens: profile.contextWindowTokens,
+    reasoningEffort: reasoningEffort ?? 'high',
+    openaiApiMode: profile.openaiApiMode ?? 'chat_completions',
+    capabilities: { ...profile.capabilities },
+    capabilitiesSource: 'static',
   };
 }
 
@@ -242,6 +278,29 @@ function relayEndpointForProvider(config: any, provider: RelayModelProvider): st
     ? relayModelProviderBaseUrl(provider)
     : provider === 'openai' ? `${baseUrl}/v1` : `${baseUrl}/anthropic`;
   return String(endpoint?.base_url || fallback).trim().replace(/\/+$/, '');
+}
+
+function retargetRelayEndpoint(
+  existing: BotCatalogModelRuntime,
+  provider: RelayModelProvider,
+): string {
+  try {
+    const parsed = new URL(existing.apiBase);
+    const path = parsed.pathname.replace(/\/+$/, '');
+    if (/\/anthropic$/i.test(path) || /\/v1$/i.test(path)) {
+      parsed.pathname = path.replace(
+        /\/(?:anthropic|v1)$/i,
+        provider === 'openai' ? '/v1' : '/anthropic',
+      );
+      parsed.search = '';
+      parsed.hash = '';
+      return parsed.toString().replace(/\/+$/, '');
+    }
+    if (existing.provider === provider) return existing.apiBase.replace(/\/+$/, '');
+  } catch {
+    // Invalid legacy endpoints fall back to the current CatsCo relay address.
+  }
+  return relayModelProviderBaseUrl(provider);
 }
 
 async function catsRequest(

--- a/src/catscompany/relay-model-bootstrap.ts
+++ b/src/catscompany/relay-model-bootstrap.ts
@@ -34,24 +34,34 @@ export async function provisionCatsRelayCatalogRuntime(
   const modelId = String(options.modelId || '').trim();
   const token = String(options.auth.token || '').trim();
   const httpBaseUrl = String(options.auth.httpBaseUrl || '').trim().replace(/\/+$/, '');
+  const ownerUid = relayOwnerUid(options.auth);
   const profile = findRelayModelProfile(modelId);
   if (!botId) throw new Error('Cannot initialize a catalog model without botId.');
   if (!profile) throw new Error(`Unknown CatsCo relay model: ${modelId}`);
+  if (token && options.auth.uid && options.auth.ownerUid && options.auth.uid !== options.auth.ownerUid) {
+    throw new Error('CatsCo account login does not match the bound bot owner.');
+  }
+  const fetchImpl = options.fetchImpl ?? fetch;
   if (!token || !httpBaseUrl) {
+    if (!ownerUid) {
+      throw new Error('CatsCo account login is required because the bound bot owner is unknown.');
+    }
     if (
       options.existingRuntime?.botId === botId
+      && options.existingRuntime.ownerUid === ownerUid
       && String(options.existingRuntime.apiKey || '').trim()
     ) {
-      return retargetCatsRelayCatalogRuntime(
+      const retargeted = retargetCatsRelayCatalogRuntime(
         options.existingRuntime,
         profile.id,
         options.reasoningEffort,
       );
+      await validateCatsRelayCatalogRuntimeCredential(retargeted, fetchImpl);
+      return retargeted;
     }
-    throw new Error('CatsCo account login is required before the default model can be initialized.');
+    throw new Error('CatsCo account login is required before an unbound relay credential can be reused.');
   }
 
-  const fetchImpl = options.fetchImpl ?? fetch;
   const relayConfig = await catsRequest(fetchImpl, httpBaseUrl, token, 'GET', '/api/relay/config');
   if (relayConfig?.self_service_enabled === false) {
     throw new Error('CatsCo relay self-service is unavailable, so the default model cannot be initialized.');
@@ -80,6 +90,7 @@ export async function provisionCatsRelayCatalogRuntime(
   return {
     schema: 'xiaoba.bot-catalog-model-runtime.v1',
     botId,
+    ...(ownerUid ? { ownerUid } : {}),
     modelId: profile.id,
     provider: profile.preferredProvider,
     apiBase: relayEndpointForProvider(relayConfig, profile.preferredProvider),
@@ -106,6 +117,7 @@ export function retargetCatsRelayCatalogRuntime(
   return {
     schema: 'xiaoba.bot-catalog-model-runtime.v1',
     botId: existing.botId,
+    ...(existing.ownerUid ? { ownerUid: existing.ownerUid } : {}),
     modelId: profile.id,
     provider: profile.preferredProvider,
     apiBase: retargetRelayEndpoint(existing, profile.preferredProvider),
@@ -224,6 +236,44 @@ async function fetchRelayModelCapabilities(
   }
 }
 
+class RelayCredentialRejectedError extends Error {
+  constructor() {
+    super('The existing CatsCo relay credential was rejected.');
+    this.name = 'RelayCredentialRejectedError';
+  }
+}
+
+export async function validateCatsRelayCatalogRuntimeCredential(
+  runtime: BotCatalogModelRuntime,
+  fetchImpl: typeof fetch = fetch,
+): Promise<void> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), CAPABILITY_REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetchImpl(relayModelsUrl(runtime.apiBase), {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${runtime.apiKey}` },
+      signal: controller.signal,
+    });
+    if (response.status === 401 || response.status === 403) {
+      throw new RelayCredentialRejectedError();
+    }
+    if (!response.ok) {
+      throw new Error(`CatsCo relay credential could not be verified (HTTP ${response.status}).`);
+    }
+  } catch (error) {
+    if (error instanceof RelayCredentialRejectedError) throw error;
+    if (error instanceof Error && error.message.startsWith('CatsCo relay credential could not be verified')) throw error;
+    throw new Error('CatsCo relay credential could not be verified before applying the model.');
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function relayOwnerUid(auth: CatsCoAuthSnapshot): string {
+  return String(auth.ownerUid || auth.uid || '').trim();
+}
+
 async function ensurePlainRelayKey(
   fetchImpl: typeof fetch,
   httpBaseUrl: string,
@@ -284,23 +334,25 @@ function retargetRelayEndpoint(
   existing: BotCatalogModelRuntime,
   provider: RelayModelProvider,
 ): string {
+  let parsed: URL;
   try {
-    const parsed = new URL(existing.apiBase);
-    const path = parsed.pathname.replace(/\/+$/, '');
-    if (/\/anthropic$/i.test(path) || /\/v1$/i.test(path)) {
-      parsed.pathname = path.replace(
-        /\/(?:anthropic|v1)$/i,
-        provider === 'openai' ? '/v1' : '/anthropic',
-      );
-      parsed.search = '';
-      parsed.hash = '';
-      return parsed.toString().replace(/\/+$/, '');
-    }
-    if (existing.provider === provider) return existing.apiBase.replace(/\/+$/, '');
+    parsed = new URL(existing.apiBase);
   } catch {
-    // Invalid legacy endpoints fall back to the current CatsCo relay address.
+    throw new Error('Existing CatsCo relay endpoint is invalid and cannot be safely reused.');
   }
-  return relayModelProviderBaseUrl(provider);
+  if (!['http:', 'https:'].includes(parsed.protocol) || parsed.username || parsed.password || parsed.search || parsed.hash) {
+    throw new Error('Existing CatsCo relay endpoint is not safe to reuse.');
+  }
+  const path = parsed.pathname.replace(/\/+$/, '');
+  if (/\/anthropic$/i.test(path) || /\/v1$/i.test(path)) {
+    parsed.pathname = path.replace(
+      /\/(?:anthropic|v1)$/i,
+      provider === 'openai' ? '/v1' : '/anthropic',
+    );
+    return parsed.toString().replace(/\/+$/, '');
+  }
+  if (existing.provider === provider) return parsed.toString().replace(/\/+$/, '');
+  throw new Error('Existing CatsCo relay endpoint cannot be retargeted across protocols without login.');
 }
 
 async function catsRequest(

--- a/tests/bot-definition-activation.test.ts
+++ b/tests/bot-definition-activation.test.ts
@@ -369,6 +369,77 @@ describe('BotDefinition activation', () => {
     });
   });
 
+  test('switches a long-running bot to an uncached catalog model without an account login', async () => {
+    const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-cloud-no-login-switch-runtime-'));
+    const simulatedCloudRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-cloud-no-login-switch-canonical-'));
+    roots.push(runtimeRoot, simulatedCloudRoot);
+    const env = {} as NodeJS.ProcessEnv;
+    createCatsCoLocalConfigService({ runtimeRoot, env }).save({
+      version: 1,
+      endpoints: { httpBaseUrl: 'https://cats.example.test', serverUrl: 'wss://cats.example.test/v0/channels' },
+      currentBot: { uid: '43', apiKey: 'bot-api-key', boundByUserUid: '7', bindingSource: 'test' },
+    });
+    new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot }).writeCanonical({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: '43',
+      model: { kind: 'catalog', modelId: 'gpt-5.6-sol' },
+    });
+    new FileBotCatalogModelRuntimeRepository({ runtimeRoot }).write({
+      schema: 'xiaoba.bot-catalog-model-runtime.v1',
+      botId: '43',
+      modelId: 'gpt-5.6-sol',
+      provider: 'openai',
+      apiBase: 'https://relay.example.test/v1',
+      apiKey: 'sk-existing-owner-key',
+      model: 'gpt-5.6-sol',
+      contextWindowTokens: 1_000_000,
+      openaiApiMode: 'responses',
+    });
+    const requests: Array<{ path: string; body?: any }> = [];
+    const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(String(input));
+      requests.push({
+        path: url.pathname,
+        body: init?.body ? JSON.parse(String(init.body)) : undefined,
+      });
+      if (url.pathname === '/api/bot/model-config/ack') {
+        return Response.json({ status: 'applied' });
+      }
+      if (url.pathname === '/api/bot/definition/skills') {
+        return Response.json({ error: 'not deployed' }, { status: 404 });
+      }
+      return Response.json({ error: 'unexpected request' }, { status: 500 });
+    }) as typeof fetch;
+
+    const prepared = await prepareBoundBotDefinition({
+      runtimeRoot,
+      simulatedCloudRoot,
+      env,
+      fetchImpl,
+      cloudSelection: {
+        kind: 'catalog',
+        modelId: 'deepseek-v4-flash',
+        reasoningEffort: 'max',
+        revision: 12,
+      },
+    });
+    const runtime = new FileBotCloudCatalogModelRuntimeRepository({ runtimeRoot }).read('43');
+
+    assert.equal(prepared?.cloudApplyError, undefined);
+    assert.equal(prepared?.cloudRevision, 12);
+    assert.equal(runtime?.modelId, 'deepseek-v4-flash');
+    assert.equal(runtime?.provider, 'anthropic');
+    assert.equal(runtime?.apiBase, 'https://relay.example.test/anthropic');
+    assert.equal(runtime?.apiKey, 'sk-existing-owner-key');
+    assert.equal(runtime?.reasoningEffort, 'max');
+    assert.equal(requests.some(item => item.path === '/api/relay/config'), false);
+    assert.equal(requests.some(item => item.path === '/api/relay/key'), false);
+    assert.deepStrictEqual(
+      requests.find(item => item.path === '/api/bot/model-config/ack')?.body,
+      { revision: 12, model_id: 'deepseek-v4-flash', reasoning_effort: 'max' },
+    );
+  });
+
   test('prepares an exact runtime reload selection without polling or acknowledging early', async () => {
     const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-cloud-runtime-reload-'));
     const simulatedCloudRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-cloud-runtime-reload-canonical-'));

--- a/tests/bot-definition-activation.test.ts
+++ b/tests/bot-definition-activation.test.ts
@@ -271,6 +271,9 @@ describe('BotDefinition activation', () => {
       if (url.pathname === '/api/relay/key') {
         return Response.json({ key: { state: 'active', key: 'sk-cloud-model' } });
       }
+      if (url.pathname === '/v1/models') {
+        return Response.json({ data: [{ id: 'deepseek-v4-flash' }] });
+      }
       if (url.pathname === '/api/bot/model-config/ack') {
         return Response.json({ status: 'applied' });
       }
@@ -387,6 +390,7 @@ describe('BotDefinition activation', () => {
     new FileBotCatalogModelRuntimeRepository({ runtimeRoot }).write({
       schema: 'xiaoba.bot-catalog-model-runtime.v1',
       botId: '43',
+      ownerUid: '7',
       modelId: 'gpt-5.6-sol',
       provider: 'openai',
       apiBase: 'https://relay.example.test/v1',
@@ -402,6 +406,9 @@ describe('BotDefinition activation', () => {
         path: url.pathname,
         body: init?.body ? JSON.parse(String(init.body)) : undefined,
       });
+      if (url.pathname === '/v1/models') {
+        return Response.json({ data: [{ id: 'deepseek-v4-flash' }] });
+      }
       if (url.pathname === '/api/bot/model-config/ack') {
         return Response.json({ status: 'applied' });
       }
@@ -434,6 +441,7 @@ describe('BotDefinition activation', () => {
     assert.equal(runtime?.reasoningEffort, 'max');
     assert.equal(requests.some(item => item.path === '/api/relay/config'), false);
     assert.equal(requests.some(item => item.path === '/api/relay/key'), false);
+    assert.equal(requests.some(item => item.path === '/v1/models'), true);
     assert.deepStrictEqual(
       requests.find(item => item.path === '/api/bot/model-config/ack')?.body,
       { revision: 12, model_id: 'deepseek-v4-flash', reasoning_effort: 'max' },
@@ -539,6 +547,71 @@ describe('BotDefinition activation', () => {
     assert.equal(failureAck.revision, 4);
     assert.equal(failureAck.model_id, 'unknown-model');
     assert.match(failureAck.error, /Unknown CatsCo relay model/);
+  });
+
+  test('reports failure instead of success when a reused owner relay key is rejected', async () => {
+    const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-cloud-rejected-relay-key-'));
+    const simulatedCloudRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-cloud-rejected-relay-key-canonical-'));
+    roots.push(runtimeRoot, simulatedCloudRoot);
+    const env = {} as NodeJS.ProcessEnv;
+    createCatsCoLocalConfigService({ runtimeRoot, env }).save({
+      version: 1,
+      endpoints: { httpBaseUrl: 'https://cats.example.test', serverUrl: 'wss://cats.example.test/v0/channels' },
+      currentBot: { uid: '43', apiKey: 'bot-api-key', boundByUserUid: '7', bindingSource: 'test' },
+    });
+    new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot }).writeCanonical({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: '43',
+      model: { kind: 'catalog', modelId: 'gpt-5.6-sol' },
+    });
+    new FileBotCatalogModelRuntimeRepository({ runtimeRoot }).write({
+      schema: 'xiaoba.bot-catalog-model-runtime.v1',
+      botId: '43',
+      ownerUid: '7',
+      modelId: 'gpt-5.6-sol',
+      provider: 'openai',
+      apiBase: 'https://relay.example.test/v1',
+      apiKey: 'sk-revoked-owner-key',
+      model: 'gpt-5.6-sol',
+      contextWindowTokens: 1_000_000,
+      openaiApiMode: 'responses',
+    });
+    let failureAck: any;
+    const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(String(input));
+      if (url.pathname === '/v1/models') {
+        return new Response('unauthorized', { status: 401 });
+      }
+      if (url.pathname === '/api/bot/model-config/ack') {
+        failureAck = JSON.parse(String(init?.body));
+        return Response.json({ status: 'failed' });
+      }
+      if (url.pathname === '/api/bot/definition/skills') {
+        return Response.json({ error: 'not deployed' }, { status: 404 });
+      }
+      return Response.json({ error: 'unexpected request' }, { status: 500 });
+    }) as typeof fetch;
+
+    const prepared = await prepareBoundBotDefinition({
+      runtimeRoot,
+      simulatedCloudRoot,
+      env,
+      fetchImpl,
+      cloudSelection: {
+        kind: 'catalog',
+        modelId: 'deepseek-v4-flash',
+        reasoningEffort: 'high',
+        revision: 13,
+      },
+    });
+
+    assert.deepStrictEqual(prepared?.definition.model, { kind: 'catalog', modelId: 'gpt-5.6-sol' });
+    assert.match(prepared?.cloudApplyError || '', /relay credential was rejected/);
+    assert.equal(prepared?.cloudRevision, undefined);
+    assert.equal(new FileBotCloudCatalogModelRuntimeRepository({ runtimeRoot }).read('43'), undefined);
+    assert.equal(failureAck.revision, 13);
+    assert.equal(failureAck.model_id, 'deepseek-v4-flash');
+    assert.match(failureAck.error, /relay credential was rejected/);
   });
 
   test('redacts a cloud custom model API key from runtime errors', () => {

--- a/tests/bot-definition-activation.test.ts
+++ b/tests/bot-definition-activation.test.ts
@@ -1025,6 +1025,146 @@ describe('BotDefinition activation', () => {
     assert.equal(resolveActiveBotLLMConfig({ runtimeRoot, env })?.config.model, 'cloud-model');
     assert.equal(new FileBotCatalogModelRuntimeRepository({ runtimeRoot }).read('43'), undefined);
   });
+
+  test('keeps the matched cloud catalog runtime when relay credential validation is temporarily unreachable', async () => {
+    const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-steady-unreachable-runtime-'));
+    const simulatedCloudRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-steady-unreachable-canonical-'));
+    roots.push(runtimeRoot, simulatedCloudRoot);
+    const env = {} as NodeJS.ProcessEnv;
+    createCatsCoLocalConfigService({ runtimeRoot, env }).save({
+      version: 1,
+      endpoints: { httpBaseUrl: 'https://cats.example.test', serverUrl: 'wss://cats.example.test/v0/channels' },
+      account: { token: 'user-token', uid: '7' },
+      currentBot: { uid: '43', apiKey: 'bot-api-key', boundByUserUid: '7', bindingSource: 'test' },
+    });
+    new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot }).writeCanonical({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: '43',
+      model: { kind: 'catalog', modelId: 'minimax-m3' },
+    });
+    new FileBotCloudCatalogModelRuntimeRepository({ runtimeRoot }).write({
+      schema: 'xiaoba.bot-catalog-model-runtime.v1',
+      botId: '43',
+      ownerUid: '7',
+      modelId: 'minimax-m3',
+      provider: 'anthropic',
+      apiBase: 'https://relay.example.test/anthropic',
+      apiKey: 'sk-existing-relay',
+      model: 'MiniMax-M3',
+      contextWindowTokens: 1_000_000,
+      reasoningEffort: 'high',
+      openaiApiMode: 'chat_completions',
+      capabilities: { vision: true, toolCalling: true, streaming: true },
+      capabilitiesSource: 'static',
+    });
+
+    let ackBody: any;
+    const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(String(input));
+      if (url.pathname === '/v1/models') {
+        return Response.json({ error: 'relay temporarily unavailable' }, { status: 503 });
+      }
+      if (url.pathname === '/api/bot/model-config/ack') {
+        ackBody = init?.body ? JSON.parse(String(init.body)) : {};
+        return Response.json({ status: 'applied' });
+      }
+      if (url.pathname === '/api/bot/definition/skills') {
+        return Response.json({ error: 'not deployed' }, { status: 404 });
+      }
+      return Response.json({ error: 'unexpected request' }, { status: 500 });
+    }) as typeof fetch;
+
+    const prepared = await prepareBoundBotDefinition({
+      runtimeRoot,
+      simulatedCloudRoot,
+      env,
+      fetchImpl,
+      cloudSelection: { kind: 'catalog', modelId: 'minimax-m3', reasoningEffort: 'high', revision: 5 },
+    });
+
+    // 稳态：relay 暂时不可达（5xx）时不应回滚、不应标记失败、不应 ack 失败
+    assert.equal(prepared?.cloudApplyError, undefined);
+    assert.equal(prepared?.materializedCatalogRuntime, false);
+    assert.ok(ackBody, 'expected a success ack to be sent');
+    assert.equal(ackBody?.error, undefined, 'success ack must not carry an apply error');
+    const runtime = new FileBotCloudCatalogModelRuntimeRepository({ runtimeRoot }).read('43');
+    assert.equal(runtime?.apiKey, 'sk-existing-relay');
+    assert.equal(resolveActiveBotLLMConfig({ runtimeRoot, env })?.config.model, 'MiniMax-M3');
+  });
+
+  test('re-materializes the cloud catalog runtime when the cached credential is rejected but a login token exists', async () => {
+    const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-steady-rejected-runtime-'));
+    const simulatedCloudRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-steady-rejected-canonical-'));
+    roots.push(runtimeRoot, simulatedCloudRoot);
+    const env = {} as NodeJS.ProcessEnv;
+    createCatsCoLocalConfigService({ runtimeRoot, env }).save({
+      version: 1,
+      endpoints: { httpBaseUrl: 'https://cats.example.test', serverUrl: 'wss://cats.example.test/v0/channels' },
+      account: { token: 'user-token', uid: '7' },
+      currentBot: { uid: '43', apiKey: 'bot-api-key', boundByUserUid: '7', bindingSource: 'test' },
+    });
+    new FileBotDefinitionRepository({ runtimeRoot, simulatedCloudRoot }).writeCanonical({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: '43',
+      model: { kind: 'catalog', modelId: 'minimax-m3' },
+    });
+    new FileBotCloudCatalogModelRuntimeRepository({ runtimeRoot }).write({
+      schema: 'xiaoba.bot-catalog-model-runtime.v1',
+      botId: '43',
+      ownerUid: '7',
+      modelId: 'minimax-m3',
+      provider: 'anthropic',
+      apiBase: 'https://relay.example.test/anthropic',
+      apiKey: 'sk-revoked-relay',
+      model: 'MiniMax-M3',
+      contextWindowTokens: 1_000_000,
+      reasoningEffort: 'high',
+      openaiApiMode: 'chat_completions',
+      capabilities: { vision: true, toolCalling: true, streaming: true },
+      capabilitiesSource: 'static',
+    });
+
+    const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(String(input));
+      if (url.pathname === '/v1/models') {
+        return Response.json({ error: 'unauthorized' }, { status: 401 });
+      }
+      if (url.pathname === '/api/relay/config') {
+        return Response.json({
+          self_service_enabled: true,
+          base_url: 'https://relay.example.test',
+          endpoints: [{ protocol: 'Anthropic-compatible', base_url: 'https://relay.example.test/anthropic' }],
+        });
+      }
+      if (url.pathname === '/api/relay/key') {
+        return Response.json({ key: { state: 'active', key: 'sk-fresh-relay-key' } });
+      }
+      if (url.pathname === '/api/bot/model-config/ack') {
+        return Response.json({ status: 'applied' });
+      }
+      if (url.pathname === '/api/bot/definition/skills') {
+        return Response.json({ error: 'not deployed' }, { status: 404 });
+      }
+      return Response.json({ error: 'unexpected request' }, { status: 500 });
+    }) as typeof fetch;
+
+    const prepared = await prepareBoundBotDefinition({
+      runtimeRoot,
+      simulatedCloudRoot,
+      env,
+      fetchImpl,
+      cloudSelection: { kind: 'catalog', modelId: 'minimax-m3', reasoningEffort: 'high', revision: 6 },
+    });
+
+    // 稳态：缓存凭据被拒（401）且本地有登录 token 时，应重新物化而不是回滚
+    assert.equal(prepared?.cloudApplyError, undefined);
+    assert.equal(prepared?.materializedCatalogRuntime, true);
+    const runtime = new FileBotCloudCatalogModelRuntimeRepository({ runtimeRoot }).read('43');
+    assert.equal(runtime?.apiKey, 'sk-fresh-relay-key');
+    assert.equal(runtime?.modelId, 'minimax-m3');
+    assert.equal(resolveActiveBotLLMConfig({ runtimeRoot, env })?.config.model, 'MiniMax-M3');
+    assert.equal(resolveActiveBotLLMConfig({ runtimeRoot, env })?.config.apiKey, 'sk-fresh-relay-key');
+  });
 });
 
 const skillEndpointUnavailable = (async (input: string | URL | Request) => (

--- a/tests/catscompany-relay-model-bootstrap.test.ts
+++ b/tests/catscompany-relay-model-bootstrap.test.ts
@@ -287,4 +287,26 @@ describe('CatsCo default relay model bootstrap', () => {
     }), /relay credential was rejected/);
   });
 
+  test('retarget preserves discovered capabilities instead of resetting them to static', () => {
+    const runtime = retargetCatsRelayCatalogRuntime({
+      schema: 'xiaoba.bot-catalog-model-runtime.v1',
+      botId: 'bot-1',
+      modelId: 'gpt-5.6-sol',
+      provider: 'openai',
+      apiBase: 'https://relay.example.test/v1',
+      apiKey: 'sk-existing-owner-key',
+      model: 'gpt-5.6-sol',
+      contextWindowTokens: 1_000_000,
+      openaiApiMode: 'responses',
+      capabilities: { vision: true, toolCalling: true, streaming: false },
+      capabilitiesSource: 'relay-models',
+      capabilitiesCheckedAt: '2026-01-01T00:00:00.000Z',
+    }, 'deepseek-v4-flash', 'max');
+
+    assert.equal(runtime.modelId, 'deepseek-v4-flash');
+    assert.equal(runtime.capabilitiesSource, 'relay-models');
+    assert.deepStrictEqual(runtime.capabilities, { vision: true, toolCalling: true, streaming: false });
+    assert.equal(runtime.capabilitiesCheckedAt, '2026-01-01T00:00:00.000Z');
+  });
+
 });

--- a/tests/catscompany-relay-model-bootstrap.test.ts
+++ b/tests/catscompany-relay-model-bootstrap.test.ts
@@ -3,6 +3,7 @@ import * as assert from 'node:assert';
 import {
   provisionCatsRelayCatalogRuntime,
   refreshCatsRelayCatalogRuntimeCapabilities,
+  retargetCatsRelayCatalogRuntime,
 } from '../src/catscompany/relay-model-bootstrap';
 
 describe('CatsCo default relay model bootstrap', () => {
@@ -96,6 +97,70 @@ describe('CatsCo default relay model bootstrap', () => {
     assert.equal(runtime.capabilities?.vision, true);
     assert.equal(runtime.capabilitiesSource, 'relay-models');
     assert.ok(runtime.capabilitiesCheckedAt);
+  });
+
+  test('retargets an existing owner relay credential across provider protocols', () => {
+    const runtime = retargetCatsRelayCatalogRuntime({
+      schema: 'xiaoba.bot-catalog-model-runtime.v1',
+      botId: 'bot-1',
+      modelId: 'gpt-5.6-sol',
+      provider: 'openai',
+      apiBase: 'https://relay.example.test/v1',
+      apiKey: 'sk-existing-owner-key',
+      model: 'gpt-5.6-sol',
+      contextWindowTokens: 1_000_000,
+      openaiApiMode: 'responses',
+    }, 'deepseek-v4-flash', 'max');
+
+    assert.equal(runtime.modelId, 'deepseek-v4-flash');
+    assert.equal(runtime.provider, 'anthropic');
+    assert.equal(runtime.apiBase, 'https://relay.example.test/anthropic');
+    assert.equal(runtime.apiKey, 'sk-existing-owner-key');
+    assert.equal(runtime.model, 'deepseek-v4-flash');
+    assert.equal(runtime.reasoningEffort, 'max');
+    assert.equal(runtime.openaiApiMode, 'chat_completions');
+    assert.deepStrictEqual(runtime.capabilities, {
+      toolCalling: true,
+      vision: false,
+      streaming: true,
+    });
+    assert.equal(runtime.capabilitiesSource, 'static');
+  });
+
+  test('uses an existing owner relay credential when a long-running bot has no account login', async () => {
+    let requested = false;
+    const runtime = await provisionCatsRelayCatalogRuntime({
+      botId: 'bot-1',
+      modelId: 'gpt-5.6-terra',
+      reasoningEffort: 'xhigh',
+      auth: {
+        httpBaseUrl: 'https://cats.example.test',
+        serverUrl: 'wss://cats.example.test/v0/channels',
+        botUid: 'bot-1',
+        apiKey: 'bot-api-key',
+      },
+      existingRuntime: {
+        schema: 'xiaoba.bot-catalog-model-runtime.v1',
+        botId: 'bot-1',
+        modelId: 'minimax-m3',
+        provider: 'anthropic',
+        apiBase: 'https://relay.example.test/anthropic',
+        apiKey: 'sk-existing-owner-key',
+        model: 'MiniMax-M3',
+        contextWindowTokens: 1_000_000,
+      },
+      fetchImpl: (async () => {
+        requested = true;
+        return new Response('unexpected', { status: 500 });
+      }) as typeof fetch,
+    });
+
+    assert.equal(requested, false);
+    assert.equal(runtime.modelId, 'gpt-5.6-terra');
+    assert.equal(runtime.apiBase, 'https://relay.example.test/v1');
+    assert.equal(runtime.apiKey, 'sk-existing-owner-key');
+    assert.equal(runtime.openaiApiMode, 'responses');
+    assert.equal(runtime.reasoningEffort, 'xhigh');
   });
 
   test('replaces legacy GPT vision=false from static catalog metadata when relay metadata is unavailable', async () => {

--- a/tests/catscompany-relay-model-bootstrap.test.ts
+++ b/tests/catscompany-relay-model-bootstrap.test.ts
@@ -134,6 +134,7 @@ describe('CatsCo default relay model bootstrap', () => {
       modelId: 'gpt-5.6-terra',
       reasoningEffort: 'xhigh',
       auth: {
+        ownerUid: 'owner-1',
         httpBaseUrl: 'https://cats.example.test',
         serverUrl: 'wss://cats.example.test/v0/channels',
         botUid: 'bot-1',
@@ -142,6 +143,7 @@ describe('CatsCo default relay model bootstrap', () => {
       existingRuntime: {
         schema: 'xiaoba.bot-catalog-model-runtime.v1',
         botId: 'bot-1',
+        ownerUid: 'owner-1',
         modelId: 'minimax-m3',
         provider: 'anthropic',
         apiBase: 'https://relay.example.test/anthropic',
@@ -149,13 +151,14 @@ describe('CatsCo default relay model bootstrap', () => {
         model: 'MiniMax-M3',
         contextWindowTokens: 1_000_000,
       },
-      fetchImpl: (async () => {
+      fetchImpl: (async (input: string | URL | Request) => {
         requested = true;
-        return new Response('unexpected', { status: 500 });
+        assert.equal(new URL(String(input)).pathname, '/v1/models');
+        return Response.json({ data: [{ id: 'gpt-5.6-terra' }] });
       }) as typeof fetch,
     });
 
-    assert.equal(requested, false);
+    assert.equal(requested, true);
     assert.equal(runtime.modelId, 'gpt-5.6-terra');
     assert.equal(runtime.apiBase, 'https://relay.example.test/v1');
     assert.equal(runtime.apiKey, 'sk-existing-owner-key');
@@ -217,4 +220,71 @@ describe('CatsCo default relay model bootstrap', () => {
     assert.equal(runtime.capabilitiesSource, 'models-dev');
     assert.ok(runtime.capabilitiesCheckedAt);
   });
+
+  test('rejects a cached relay credential owned by another account', async () => {
+    await assert.rejects(() => provisionCatsRelayCatalogRuntime({
+      botId: 'bot-1',
+      modelId: 'gpt-5.6-terra',
+      auth: {
+        ownerUid: 'owner-b',
+        httpBaseUrl: 'https://cats.example.test',
+        serverUrl: 'wss://cats.example.test/v0/channels',
+        botUid: 'bot-1',
+        apiKey: 'bot-api-key',
+      },
+      existingRuntime: {
+        schema: 'xiaoba.bot-catalog-model-runtime.v1',
+        botId: 'bot-1',
+        ownerUid: 'owner-a',
+        modelId: 'minimax-m3',
+        provider: 'anthropic',
+        apiBase: 'https://relay.example.test/anthropic',
+        apiKey: 'sk-owner-a',
+        model: 'MiniMax-M3',
+        contextWindowTokens: 1_000_000,
+      },
+      fetchImpl: (async () => Response.json({ data: [] })) as typeof fetch,
+    }), /unbound relay credential/);
+  });
+
+  test('rejects cross-protocol retargeting for a non-standard relay path', () => {
+    assert.throws(() => retargetCatsRelayCatalogRuntime({
+      schema: 'xiaoba.bot-catalog-model-runtime.v1',
+      botId: 'bot-1',
+      ownerUid: 'owner-1',
+      modelId: 'minimax-m3',
+      provider: 'anthropic',
+      apiBase: 'https://private-relay.example.test/proxy/models',
+      apiKey: 'sk-private-relay',
+      model: 'MiniMax-M3',
+      contextWindowTokens: 1_000_000,
+    }, 'gpt-5.6-terra'), /cannot be retargeted across protocols/);
+  });
+
+  test('rejects an invalid cached relay key before applying a retargeted model', async () => {
+    await assert.rejects(() => provisionCatsRelayCatalogRuntime({
+      botId: 'bot-1',
+      modelId: 'gpt-5.6-terra',
+      auth: {
+        ownerUid: 'owner-1',
+        httpBaseUrl: 'https://cats.example.test',
+        serverUrl: 'wss://cats.example.test/v0/channels',
+        botUid: 'bot-1',
+        apiKey: 'bot-api-key',
+      },
+      existingRuntime: {
+        schema: 'xiaoba.bot-catalog-model-runtime.v1',
+        botId: 'bot-1',
+        ownerUid: 'owner-1',
+        modelId: 'minimax-m3',
+        provider: 'anthropic',
+        apiBase: 'https://relay.example.test/anthropic',
+        apiKey: 'sk-revoked',
+        model: 'MiniMax-M3',
+        contextWindowTokens: 1_000_000,
+      },
+      fetchImpl: (async () => new Response('unauthorized', { status: 401 })) as typeof fetch,
+    }), /relay credential was rejected/);
+  });
+
 });


### PR DESCRIPTION
## 修改内容
- 将可复用的 relay runtime 凭证同时绑定到机器人和所有者，防止跨账号误复用
- 应用云模型前验证 relay 凭证，失效凭证不再误报切换成功
- 拒绝可能把密钥泄露到其他 origin 的不安全 endpoint 改写
- 凭证验证失败时保留当前模型，并回写明确的失败状态
- 在 activation 流程中正确传递指定的环境变量，保证行为与测试可控
- 补充所有者隔离、安全 endpoint 处理及失效凭证的回归测试

## 验证结果
- 定向测试 40/40 通过
- 构建通过
- 全量测试 1292 项通过
- 两项并发抖动用例单独运行 26/26 通过