### PR TITLE
fix: preserve Responses reasoning within live sessions

### DIFF
--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -500,7 +500,13 @@ export class ConversationRunner {
         Logger.info(`[${this.sessionLabel}Turn ${turns}] AI最终回复: ${ConversationRunner.truncateForLog(visibleContent, 300)}`);
 
         if (visibleContent) {
-          const finalAssistantMessage: Message = { role: 'assistant', content: visibleContent };
+          const finalAssistantMessage: Message = {
+            role: 'assistant',
+            content: visibleContent,
+            ...(response.providerContent?.length
+              ? { providerContent: response.providerContent }
+              : {}),
+          };
           messages.push(finalAssistantMessage);
           newMessages.push(finalAssistantMessage);
         }
@@ -984,11 +990,11 @@ export class ConversationRunner {
     assistantMsg: Message,
     transcriptToolCalls: Message['tool_calls'],
   ): Message['providerContent'] {
-    if (!Array.isArray(assistantMsg.providerContent) || !transcriptToolCalls?.length) {
+    if (!Array.isArray(assistantMsg.providerContent)) {
       return undefined;
     }
 
-    const transcriptToolCallIds = new Set(transcriptToolCalls.map(toolCall => toolCall.id));
+    const transcriptToolCallIds = new Set((transcriptToolCalls ?? []).map(toolCall => toolCall.id));
     const blocks: NonNullable<Message['providerContent']> = [];
     let hasMatchingToolCall = false;
 
@@ -1004,10 +1010,16 @@ export class ConversationRunner {
         if (!transcriptToolCallIds.has(callId)) continue;
         hasMatchingToolCall = true;
       }
+      if (block.type === 'reasoning') {
+        blocks.push(block);
+        continue;
+      }
       blocks.push(block);
     }
 
-    return hasMatchingToolCall ? blocks : undefined;
+    return hasMatchingToolCall || blocks.some(block => block?.type === 'reasoning')
+      ? blocks
+      : undefined;
   }
 
   private shouldKeepAssistantDraft(
@@ -1617,7 +1629,14 @@ export class ConversationRunner {
 
       const content = contentToString(message.content).trim();
       if (content) {
-        repaired.push({ ...message, tool_calls: undefined, providerContent: undefined });
+        const reasoningBlocks = Array.isArray(message.providerContent)
+          ? message.providerContent.filter(block => block && typeof block === 'object' && block.type === 'reasoning')
+          : undefined;
+        repaired.push({
+          ...message,
+          tool_calls: undefined,
+          providerContent: reasoningBlocks?.length ? reasoningBlocks : undefined,
+        });
       }
     }
 

--- a/src/providers/openai-provider.ts
+++ b/src/providers/openai-provider.ts
@@ -415,18 +415,32 @@ export class OpenAIProvider implements AIProvider {
         continue;
       }
 
-      if (message.role === 'assistant' && message.tool_calls?.length) {
+      if (message.role === 'assistant') {
         const replayItems = (message.providerContent || [])
           .filter(item => this.isResponsesReplayItem(item))
           .map(item => JSON.parse(JSON.stringify(item)));
         if (replayItems.length > 0) {
           input.push(...replayItems);
-          continue;
         }
 
+        const hasReplayedMessage = replayItems.some(item => item.type === 'message');
+        const replayedCallIds = new Set(
+          replayItems
+            .filter(item => item.type === 'function_call')
+            .map(item => String(item.call_id || ''))
+            .filter(Boolean),
+        );
+
+        // Responses reasoning is provider-native state. Pure-text assistant
+        // turns still need their visible message after the reasoning item.
+        // For tool turns with native replay items, preserve the previous exact
+        // replay behavior and only synthesize function calls that are missing.
         const text = this.contentAsText(message.content);
-        if (text) input.push({ role: 'assistant', content: text });
-        for (const toolCall of message.tool_calls) {
+        if (text && !hasReplayedMessage && (replayItems.length === 0 || !message.tool_calls?.length)) {
+          input.push({ role: 'assistant', content: text });
+        }
+        for (const toolCall of message.tool_calls ?? []) {
+          if (replayedCallIds.has(toolCall.id)) continue;
           input.push({
             type: 'function_call',
             call_id: toolCall.id,
@@ -616,8 +630,14 @@ export class OpenAIProvider implements AIProvider {
     const stopReason = response?.status === 'incomplete'
       ? incompleteReason === 'max_output_tokens' ? 'length' : incompleteReason || 'incomplete'
       : toolCalls.length > 0 ? 'tool_calls' : response?.status || undefined;
-    const providerContent = toolCalls.length > 0
-      ? output.filter((item: any) => this.isResponsesReplayItem(item)).map((item: any) => JSON.parse(JSON.stringify(item)))
+    // Keep reasoning independently from tool calls. Thinking-mode Responses
+    // providers require this item to be replayed on the next live request,
+    // including after a pure-text assistant response.
+    const replayItems = output.filter((item: any) =>
+      this.isResponsesReplayItem(item) && item?.type !== 'message',
+    );
+    const providerContent = replayItems.length > 0
+      ? replayItems.map((item: any) => JSON.parse(JSON.stringify(item)))
       : undefined;
 
     return {

--- a/tests/conversation-runner-transcript-normalization.test.ts
+++ b/tests/conversation-runner-transcript-normalization.test.ts
@@ -459,6 +459,39 @@ test('runner keeps Responses reasoning and matching function calls in the tool t
   assert.deepEqual(secondRequestAssistant?.providerContent, providerContent);
 });
 
+test('runner keeps pure-text Responses reasoning for the next live request', async () => {
+  const reasoning = {
+    type: 'reasoning',
+    id: 'rs_text_1',
+    content: [{ type: 'reasoning_text', text: 'private reasoning' }],
+    summary: [],
+  };
+  const mock = createMockAI([
+    {
+      ...makeFinalResponse('first answer'),
+      providerContent: [reasoning],
+    },
+    makeFinalResponse('second answer'),
+  ]);
+  const runner = new ConversationRunner(mock.aiService, new MockToolExecutor([], {}), {
+    stream: false,
+    enableCompression: false,
+  });
+
+  const first = await runner.run([{ role: 'user', content: 'first question' }]);
+  const firstAssistant = first.messages.find(message => message.role === 'assistant');
+  assert.deepEqual(firstAssistant?.providerContent, [reasoning]);
+
+  await runner.run([
+    ...first.messages,
+    { role: 'user', content: 'follow up' },
+  ]);
+  const secondRequestAssistant = mock.getReceivedMessages()[1]
+    .find(message => message.role === 'assistant');
+
+  assert.deepEqual(secondRequestAssistant?.providerContent, [reasoning]);
+});
+
 test('runner injects tool target context into provider transcript only', async () => {
   const responses = [
     makeToolResponse(makeToolCall('call_1', 'execute_shell', { command: 'echo ok' })),

--- a/tests/openai-provider-responses.test.ts
+++ b/tests/openai-provider-responses.test.ts
@@ -380,6 +380,98 @@ describe('OpenAIProvider Responses API mode', () => {
     }
   });
 
+  test('replays reasoning from a pure-text assistant turn', async () => {
+    const originalPost = axios.post;
+    const bodies: any[] = [];
+    const reasoning = {
+      type: 'reasoning',
+      id: 'reasoning_text_1',
+      status: 'completed',
+      content: [{ type: 'reasoning_text', text: 'private reasoning' }],
+      summary: [],
+    };
+    (axios as any).post = async (_url: string, body: any) => {
+      bodies.push(body);
+      return {
+        data: bodies.length === 1
+          ? {
+              status: 'completed',
+              output: [
+                reasoning,
+                {
+                  type: 'message',
+                  role: 'assistant',
+                  content: [{ type: 'output_text', text: 'first answer' }],
+                },
+              ],
+            }
+          : {
+              status: 'completed',
+              output: [{
+                type: 'message',
+                role: 'assistant',
+                content: [{ type: 'output_text', text: 'second answer' }],
+              }],
+            },
+      };
+    };
+
+    try {
+      const provider = createProvider();
+      const first = await provider.chat([{ role: 'user', content: 'first question' }]);
+      await provider.chat([
+        { role: 'user', content: 'first question' },
+        { role: 'assistant', content: first.content, providerContent: first.providerContent },
+        { role: 'user', content: 'follow up' },
+      ]);
+
+      assert.deepEqual(first.providerContent, [reasoning]);
+      assert.deepEqual(bodies[1].input, [
+        { role: 'user', content: 'first question' },
+        reasoning,
+        { role: 'assistant', content: 'first answer' },
+        { role: 'user', content: 'follow up' },
+      ]);
+    } finally {
+      (axios as any).post = originalPost;
+    }
+  });
+
+  test('reconstructs canonical function calls when replay only contains reasoning', () => {
+    const provider = createProvider();
+    const reasoning = {
+      type: 'reasoning',
+      id: 'reasoning_tool_1',
+      status: 'completed',
+      content: [{ type: 'reasoning_text', text: 'private reasoning' }],
+      summary: [],
+    };
+    const body = (provider as any).buildResponsesRequestBody([
+      {
+        role: 'assistant',
+        content: null,
+        tool_calls: [{
+          id: 'call_1',
+          type: 'function',
+          function: { name: 'lookup', arguments: '{"query":"cats"}' },
+        }],
+        providerContent: [reasoning],
+      },
+      { role: 'tool', tool_call_id: 'call_1', content: 'found cats' },
+    ], [lookupTool]);
+
+    assert.deepEqual(body.input, [
+      reasoning,
+      {
+        type: 'function_call',
+        call_id: 'call_1',
+        name: 'lookup',
+        arguments: '{"query":"cats"}',
+      },
+      { type: 'function_call_output', call_id: 'call_1', output: 'found cats' },
+    ]);
+  });
+
   test('streams visible text and resolves from the terminal Responses event', async () => {
     const originalPost = axios.post;
     const terminalResponse = {

--- a/tests/session-lifecycle-manager.test.ts
+++ b/tests/session-lifecycle-manager.test.ts
@@ -420,6 +420,36 @@ describe('AgentSession lifecycle', () => {
     assert.doesNotMatch(raw, /private openai tool result/);
   });
 
+  test('session persistence strips Responses reasoning text for model-portable restore', () => {
+    const { SessionStore } = loadSessionModules();
+    SessionStore.getInstance().saveContext('user:lifecycle-responses-reasoning', [
+      { role: 'user', content: 'first question' },
+      {
+        role: 'assistant',
+        content: 'public answer',
+        providerContent: [{
+          type: 'reasoning',
+          id: 'reasoning_1',
+          content: [{ type: 'reasoning_text', text: 'private Responses reasoning' }],
+          summary: [],
+        }],
+      },
+    ]);
+
+    const restored = SessionStore.getInstance().loadContext('user:lifecycle-responses-reasoning');
+    const raw = fs.readFileSync(
+      path.join(testRoot, 'data', 'sessions', 'user_lifecycle-responses-reasoning.jsonl'),
+      'utf-8',
+    );
+
+    assert.deepStrictEqual(restored.map((message: any) => message.content), [
+      'first question',
+      'public answer',
+    ]);
+    assert.equal(restored.some((message: any) => Array.isArray(message.providerContent)), false);
+    assert.doesNotMatch(raw, /private Responses reasoning|reasoning_1/);
+  });
+
   test('loading legacy sessions migrates provider replay hidden thinking off disk', async () => {
     const { SessionStore } = loadSessionModules();
     const sessionFile = path.join(testRoot, 'data', 'sessions', 'user_lifecycle-legacy-provider-replay.jsonl');


### PR DESCRIPTION
## What changed

- Preserve Responses reasoning items for pure-text assistant turns and tool transcripts during a live session.
- Reconstruct canonical `function_call` items when provider replay contains reasoning but is missing a matching call.
- Keep provider-native reasoning out of durable session files so restored history stays private and portable across model switches.

## Root cause

The Responses replay path was incomplete in three places: the provider only retained replay items when tools were present, the runner dropped replay state from final text responses, and the next-request builder treated any partial replay as complete. That could omit required reasoning or swallow the matching function call and produce a deterministic 400 on the next turn.

Persisting raw reasoning is not used as a workaround: it can contain plaintext private reasoning and has no model provenance, so carrying it across a model switch can send one model's private wire format to another.

## Impact

Thinking-mode Responses sessions can continue across text and tool turns without corrupting the next request. Restarts and model switches continue to restore the canonical conversation rather than stale provider-private state.

## Validation

- `npm run build`
- 91 targeted provider/runner/session tests passed
- Full runtime suite: 1287 passed, 8 skipped; one unrelated PDF async-race failure passed 15/15 when rerun alone
