### PR TITLE
fix: bound retries for opaque 400 and 403 responses

### DIFF
--- a/src/utils/ai-service.ts
+++ b/src/utils/ai-service.ts
@@ -32,6 +32,10 @@ const EMPTY_RESPONSE_MAX_DELAY_MS = 2000;
 const BARE_400_MAX_RETRIES = 2;
 const BARE_400_MAX_ELAPSED_MS = 15 * 1000;
 const BARE_400_MAX_DELAY_MS = 2000;
+// 裸 403 可能来自模型切换后的短暂权限传播延迟；只补一次短重试。
+const BARE_403_MAX_RETRIES = 1;
+const BARE_403_MAX_ELAPSED_MS = 8 * 1000;
+const BARE_403_MAX_DELAY_MS = 2000;
 
 type ProviderKind = 'openai' | 'anthropic';
 
@@ -252,6 +256,10 @@ export class AIService {
       return true;
     }
 
+    if (this.isBare403(error)) {
+      return true;
+    }
+
     // 网络错误可重试
     const code = this.extractErrorCode(error);
     if ([
@@ -289,24 +297,20 @@ export class AIService {
 
   private isKnownNonRetryableProviderError(error: any): boolean {
     const status = this.extractStatus(error);
-    // 401/403/404/413/422 是确定性的配置/权限/资源/参数错误，重试无意义。
+    // 401/404/413/422 是确定性的配置/资源/参数错误，重试无意义。
     // 400 特殊处理：只有错误文本明确指向请求格式问题时才不可重试；
     // 裸 400（如 axios 默认消息）大多是上游瞬态或 reasoning 回传问题，
     // 重试/说"继续"即可恢复，交给 isRetryable 决定。
-    if (status && [401, 403, 404, 413, 422].includes(status)) {
+    // 403 只有在上游给出明确权限语义时才直接失败；裸 403 允许一次短重试，
+    // 覆盖模型切换后权限传播尚未完成的窗口。
+    if (status && [401, 404, 413, 422].includes(status)) {
+      return true;
+    }
+    if (status === 403 && !this.isBare403(error)) {
       return true;
     }
 
-    const message = [
-      error?.response?.data?.error?.code,
-      error?.response?.data?.error?.type,
-      error?.response?.data?.error?.message,
-      error?.response?.data?.message,
-      error?.error?.code,
-      error?.error?.type,
-      error?.error?.message,
-      error?.message,
-    ].filter(Boolean).join(' ');
+    const message = this.providerErrorText(error);
 
     if (status === 400
       && /invalid[_\s-]?request|bad request|invalid (?:parameter|input|argument)|schema is invalid|tool schema|malformed|invalid json|unexpected token/i.test(message)) {
@@ -323,7 +327,29 @@ export class AIService {
   private isBareOrReasoning400(error: any): boolean {
     const status = this.extractStatus(error);
     if (status !== 400) return false;
-    const message = [
+    const message = this.providerErrorText(error);
+    // reasoning 必须回传（reasoning_content/reasoning_text）属于可修复后重试，
+    // 例如消息已被重建或上游瞬态时，重试一次即可通过。
+    if (/reasoning[_\s-]?(?:content|text).{0,60}(must be passed back|must be echoed|not passed back|expected)/i.test(message)
+      || /thinking mode.{0,60}reasoning/i.test(message)) {
+      return true;
+    }
+    // 裸 400：没有明确格式错误标记（格式错误在 isKnownNonRetryableProviderError 已拦截）
+    return !/invalid[_\s-]?request|bad request|invalid (?:parameter|input|argument)|schema is invalid|tool schema|malformed|invalid json|unexpected token/i.test(message);
+  }
+
+  /**
+   * 仅把没有明确权限语义的 403 当作短暂错误。
+   * 真正的鉴权/授权失败仍然立即返回，避免无意义地反复请求。
+   */
+  private isBare403(error: any): boolean {
+    if (this.extractStatus(error) !== 403) return false;
+    const message = this.providerErrorText(error);
+    return !/invalid[_\s-]?api[_\s-]?key|unauthorized|forbidden|permission denied|access denied|not authorized|insufficient[_\s-]?scope|(?:do not|does not|don't|doesn't|no) have access|model .{0,40}not (?:allowed|available|authorized)/i.test(message);
+  }
+
+  private providerErrorText(error: any): string {
+    return [
       error?.response?.data?.error?.code,
       error?.response?.data?.error?.type,
       error?.response?.data?.error?.message,
@@ -333,14 +359,6 @@ export class AIService {
       error?.error?.message,
       error?.message,
     ].filter(Boolean).join(' ');
-    // reasoning 必须回传（reasoning_content/reasoning_text）属于可修复后重试，
-    // 例如消息已被重建或上游瞬态时，重试一次即可通过。
-    if (/reasoning[_\s-]?(?:content|text).{0,60}(must be passed back|must be echoed|not passed back|expected)/i.test(message)
-      || /thinking mode.{0,60}reasoning/i.test(message)) {
-      return true;
-    }
-    // 裸 400：没有明确格式错误标记（格式错误在 isKnownNonRetryableProviderError 已拦截）
-    return !/invalid[_\s-]?request|bad request|invalid (?:parameter|input|argument)|schema is invalid|tool schema|malformed|invalid json|unexpected token/i.test(message);
   }
 
   /**
@@ -481,6 +499,15 @@ export class AIService {
         maxRetries: Math.min(policy.maxRetries, BARE_400_MAX_RETRIES),
         maxElapsedMs: Math.min(policy.maxElapsedMs, BARE_400_MAX_ELAPSED_MS),
         maxDelayMs: Math.min(policy.maxDelayMs, BARE_400_MAX_DELAY_MS),
+      };
+    }
+
+    if (this.isBare403(error)) {
+      return {
+        ...policy,
+        maxRetries: Math.min(policy.maxRetries, BARE_403_MAX_RETRIES),
+        maxElapsedMs: Math.min(policy.maxElapsedMs, BARE_403_MAX_ELAPSED_MS),
+        maxDelayMs: Math.min(policy.maxDelayMs, BARE_403_MAX_DELAY_MS),
       };
     }
 

--- a/src/utils/ai-service.ts
+++ b/src/utils/ai-service.ts
@@ -28,6 +28,10 @@ const EMPTY_RESPONSE_ERROR_CODE = 'EMPTY_MODEL_RESPONSE';
 const EMPTY_RESPONSE_MAX_RETRIES = 2;
 const EMPTY_RESPONSE_MAX_ELAPSED_MS = 2 * 60 * 1000;
 const EMPTY_RESPONSE_MAX_DELAY_MS = 2000;
+// 裸 400 / reasoning 回传 400：快速有限重试，避免浪费 token 又覆盖瞬态场景
+const BARE_400_MAX_RETRIES = 2;
+const BARE_400_MAX_ELAPSED_MS = 15 * 1000;
+const BARE_400_MAX_DELAY_MS = 2000;
 
 type ProviderKind = 'openai' | 'anthropic';
 
@@ -243,6 +247,11 @@ export class AIService {
       return true;
     }
 
+    // 裸 400 / reasoning 回传 400：有限次数快速重试（上游瞬态或消息已修复时一次即过）
+    if (this.isBareOrReasoning400(error)) {
+      return true;
+    }
+
     // 网络错误可重试
     const code = this.extractErrorCode(error);
     if ([
@@ -280,7 +289,11 @@ export class AIService {
 
   private isKnownNonRetryableProviderError(error: any): boolean {
     const status = this.extractStatus(error);
-    if (status && [400, 401, 403, 404, 413, 422].includes(status)) {
+    // 401/403/404/413/422 是确定性的配置/权限/资源/参数错误，重试无意义。
+    // 400 特殊处理：只有错误文本明确指向请求格式问题时才不可重试；
+    // 裸 400（如 axios 默认消息）大多是上游瞬态或 reasoning 回传问题，
+    // 重试/说"继续"即可恢复，交给 isRetryable 决定。
+    if (status && [401, 403, 404, 413, 422].includes(status)) {
       return true;
     }
 
@@ -295,8 +308,39 @@ export class AIService {
       error?.message,
     ].filter(Boolean).join(' ');
 
+    if (status === 400
+      && /invalid[_\s-]?request|bad request|invalid (?:parameter|input|argument)|schema is invalid|tool schema|malformed|invalid json|unexpected token/i.test(message)) {
+      return true;
+    }
+
     return /insufficient[_\s-]?quota|quota[_\s-]?exceeded|billing|(?:insufficient|low|exhausted)[_\s-]?(?:credit|balance)|(?:credit|balance)[_\s-]?(?:exhausted|insufficient|too low)|账户余额|余额不足|额度不足|额度已用尽|context length|maximum context|max(?:imum)? tokens?|prompt too long|invalid[_\s-]?request|invalid[_\s-]?api[_\s-]?key|unauthorized|forbidden|permission denied|model .*not found|model_not_found|tool schema|schema is invalid|content policy|safety/i
       .test(message);
+  }
+
+  /**
+   * 裸 400 / reasoning 回传 400：可快速自动重试（瞬态或消息已修复时一次即过）。
+   */
+  private isBareOrReasoning400(error: any): boolean {
+    const status = this.extractStatus(error);
+    if (status !== 400) return false;
+    const message = [
+      error?.response?.data?.error?.code,
+      error?.response?.data?.error?.type,
+      error?.response?.data?.error?.message,
+      error?.response?.data?.message,
+      error?.error?.code,
+      error?.error?.type,
+      error?.error?.message,
+      error?.message,
+    ].filter(Boolean).join(' ');
+    // reasoning 必须回传（reasoning_content/reasoning_text）属于可修复后重试，
+    // 例如消息已被重建或上游瞬态时，重试一次即可通过。
+    if (/reasoning[_\s-]?(?:content|text).{0,60}(must be passed back|must be echoed|not passed back|expected)/i.test(message)
+      || /thinking mode.{0,60}reasoning/i.test(message)) {
+      return true;
+    }
+    // 裸 400：没有明确格式错误标记（格式错误在 isKnownNonRetryableProviderError 已拦截）
+    return !/invalid[_\s-]?request|bad request|invalid (?:parameter|input|argument)|schema is invalid|tool schema|malformed|invalid json|unexpected token/i.test(message);
   }
 
   /**
@@ -428,6 +472,15 @@ export class AIService {
         maxRetries: Math.min(policy.maxRetries, EMPTY_RESPONSE_MAX_RETRIES),
         maxElapsedMs: Math.min(policy.maxElapsedMs, EMPTY_RESPONSE_MAX_ELAPSED_MS),
         maxDelayMs: Math.min(policy.maxDelayMs, EMPTY_RESPONSE_MAX_DELAY_MS),
+      };
+    }
+
+    if (this.isBareOrReasoning400(error)) {
+      return {
+        ...policy,
+        maxRetries: Math.min(policy.maxRetries, BARE_400_MAX_RETRIES),
+        maxElapsedMs: Math.min(policy.maxElapsedMs, BARE_400_MAX_ELAPSED_MS),
+        maxDelayMs: Math.min(policy.maxDelayMs, BARE_400_MAX_DELAY_MS),
       };
     }
 

--- a/tests/ai-service.test.ts
+++ b/tests/ai-service.test.ts
@@ -341,6 +341,98 @@ test('AIService does not retry quota exhaustion even when provider uses HTTP 429
   assert.equal(attempts, 1);
 });
 
+test('AIService retries a bare 400 with a short bounded policy', async () => {
+  const service = createTestService();
+  let attempts = 0;
+  const bare400 = Object.assign(new Error('Request failed with status code 400'), {
+    response: { status: 400, headers: {} },
+  });
+  (service as any).sleepWithAbort = async () => undefined;
+  (service as any).provider = {
+    chat: async () => {
+      attempts += 1;
+      if (attempts === 1) throw bare400;
+      return { content: 'recovered' };
+    },
+    chatStream: async () => ({ content: null }),
+  };
+
+  const result = await service.chat([]);
+  const policy = (service as any).resolveRetryPolicy(bare400);
+
+  assert.deepStrictEqual(result, { content: 'recovered' });
+  assert.equal(attempts, 2);
+  assert.equal(policy.maxRetries, 2);
+  assert.equal(policy.maxElapsedMs, 15 * 1000);
+});
+
+test('AIService does not retry an explicit invalid-request 400', async () => {
+  const service = createTestService();
+  let attempts = 0;
+  const invalidRequest = Object.assign(new Error('Request failed with status code 400'), {
+    response: {
+      status: 400,
+      data: { error: { type: 'invalid_request_error', message: 'tool schema is invalid' } },
+    },
+  });
+  (service as any).provider = {
+    chat: async () => {
+      attempts += 1;
+      throw invalidRequest;
+    },
+    chatStream: async () => ({ content: null }),
+  };
+
+  await assert.rejects(() => service.chat([]), /API错误 \(400\): tool schema is invalid/);
+  assert.equal(attempts, 1);
+});
+
+test('AIService retries a bare 403 once for model-switch propagation', async () => {
+  const service = createTestService();
+  let attempts = 0;
+  const bare403 = Object.assign(new Error('Request failed with status code 403'), {
+    response: { status: 403, headers: {} },
+  });
+  (service as any).sleepWithAbort = async () => undefined;
+  (service as any).provider = {
+    chat: async () => {
+      attempts += 1;
+      if (attempts === 1) throw bare403;
+      return { content: 'recovered after switch' };
+    },
+    chatStream: async () => ({ content: null }),
+  };
+
+  const result = await service.chat([]);
+  const policy = (service as any).resolveRetryPolicy(bare403);
+
+  assert.deepStrictEqual(result, { content: 'recovered after switch' });
+  assert.equal(attempts, 2);
+  assert.equal(policy.maxRetries, 1);
+  assert.equal(policy.maxElapsedMs, 8 * 1000);
+});
+
+test('AIService does not retry an explicit permission-denied 403', async () => {
+  const service = createTestService();
+  let attempts = 0;
+  const denied = Object.assign(new Error('Request failed with status code 403'), {
+    response: {
+      status: 403,
+      data: { error: { message: 'permission denied for this model' } },
+    },
+  });
+  (service as any).provider = {
+    chat: async () => {
+      attempts += 1;
+      throw denied;
+    },
+    chatStream: async () => ({ content: null }),
+  };
+
+  await assert.rejects(() => service.chat([]), /API错误 \(403\): permission denied for this model/);
+  assert.equal(attempts, 1);
+});
+
 test('AIService still retries transient load balancer failures', async () => {
   process.env.CATSCO_MODEL_RETRY_MAX_RETRIES = '1';
   const service = createTestService();


### PR DESCRIPTION
## What changed

- Retry opaque HTTP 400 responses with a short cap of two retries and a 15-second total window.
- Retry an opaque HTTP 403 once within an 8-second window to cover model-switch permission propagation.
- Continue to fail immediately for explicit invalid request, authentication, permission, quota, schema, and model-access errors.
- Add coverage for recoverable and deterministic 400/403 cases.

## Root cause

The retry layer previously treated every 400 and 403 as deterministic. In practice, the relay can briefly return only `Request failed with status code 400/403`, especially around model changes, and the same request often succeeds moments later. The opposite extreme is also unsafe: repeatedly retrying a clear schema or permission error only delays the real failure.

## Impact

Opaque transient client errors can self-heal without turning into an infinite retry loop. Explicit request and access errors remain fast and actionable.

## Validation

- `npm run build`
- `tests/ai-service.test.ts`: 20/20 passed
