### PR TITLE
Separate runtime data from Git worktrees

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # CatsCo local runtime configuration.
-# Copy this file to .env when running from source. The packaged desktop app
-# creates a user-local .env from this template on first launch.
+# Copy this file to the active Data Root as .env when running from source
+# (default: ~/.xiaoba/.env). The packaged desktop app creates a user-local .env
+# from this template on first launch.
 
 # Main LLM provider. Supported values: anthropic, openai.
 GAUZ_LLM_PROVIDER=anthropic

--- a/README.md
+++ b/README.md
@@ -183,6 +183,26 @@ node dist/index.js chat --interactive
 
 本地 Agent 不要求部署 CatsCo Platform。
 
+源代码目录、Agent 工作目录和运行数据目录彼此独立。CLI 默认把登录配置、会话和日志保存在 `~/.xiaoba`，不会因为切换 Git worktree 而变化。启动时会打印三个目录；也可以显式选择实验 profile：
+
+```bash
+node dist/index.js --profile cache-baseline data status
+node dist/index.js --profile cache-baseline chat --interactive
+```
+
+需要完全指定目录时使用 `--data-dir` 或进程环境变量 `XIAOBA_USER_DATA_DIR`。两者必须在启动命令或 shell 中设置，不能只写在目标目录自己的 `.env` 中：
+
+```bash
+XIAOBA_USER_DATA_DIR=/Users/me/.xiaoba-dev/profiles/default node dist/index.js dashboard
+```
+
+从旧版仓库内 Data Dir 迁移前可先预览；迁移只复制已知运行数据，不覆盖冲突文件，也不删除来源：
+
+```bash
+node dist/index.js --data-dir /Users/me/.xiaoba-dev/profiles/default data migrate --from /path/to/old/XiaoBa-CLI
+node dist/index.js --data-dir /Users/me/.xiaoba-dev/profiles/default data migrate --from /path/to/old/XiaoBa-CLI --apply
+```
+
 ### 连接 CatsCo Platform
 
 ```bash

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -2038,6 +2038,90 @@
       margin-bottom: 20px;
     }
 
+    .runtime-identity-card {
+      margin-bottom: 20px;
+      padding: 18px 20px;
+      border-radius: 22px;
+      background: linear-gradient(135deg, rgba(25, 30, 54, 0.96), rgba(40, 55, 91, 0.94));
+      color: #fff;
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      box-shadow: 0 18px 42px rgba(27, 35, 64, 0.18);
+    }
+
+    .runtime-identity-head {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      margin-bottom: 14px;
+    }
+
+    .runtime-identity-title {
+      font-size: 15px;
+      font-weight: 800;
+    }
+
+    .runtime-identity-badges {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+      gap: 6px;
+    }
+
+    .runtime-identity-badge {
+      padding: 5px 9px;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.1);
+      color: rgba(255, 255, 255, 0.82);
+      font-size: 11px;
+      font-weight: 700;
+    }
+
+    .runtime-identity-grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 10px;
+    }
+
+    .runtime-identity-item {
+      min-width: 0;
+      padding: 11px 12px;
+      border-radius: 14px;
+      background: rgba(255, 255, 255, 0.07);
+      border: 1px solid rgba(255, 255, 255, 0.07);
+    }
+
+    .runtime-identity-label {
+      margin-bottom: 6px;
+      color: rgba(255, 255, 255, 0.56);
+      font-size: 10px;
+      font-weight: 800;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .runtime-identity-path {
+      color: rgba(255, 255, 255, 0.94);
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      font-size: 11px;
+      line-height: 1.5;
+      overflow-wrap: anywhere;
+    }
+
+    .runtime-identity-copy {
+      border: 0;
+      background: rgba(255, 255, 255, 0.1);
+      color: rgba(255, 255, 255, 0.86);
+      padding: 6px 9px;
+      border-radius: 10px;
+      font: inherit;
+      font-size: 11px;
+      font-weight: 700;
+      cursor: pointer;
+    }
+
+    .runtime-identity-copy:hover { background: rgba(255, 255, 255, 0.17); }
+
     .status-card,
     .service-card {
       border-radius: 22px;
@@ -2746,6 +2830,8 @@
         grid-template-columns: 1fr;
         gap: 6px;
       }
+
+      .runtime-identity-grid { grid-template-columns: 1fr; }
     }
 
     @media (max-width: 640px) {
@@ -2768,6 +2854,20 @@
 
       body::after {
         left: -80px;
+      }
+
+      .runtime-identity-card { padding: 16px; }
+      .runtime-identity-head {
+        align-items: flex-start;
+        flex-direction: column;
+      }
+      .runtime-identity-badges {
+        justify-content: flex-start;
+        width: 100%;
+      }
+      .runtime-identity-badge {
+        max-width: 100%;
+        overflow-wrap: anywhere;
       }
 
       .topbar {
@@ -5331,6 +5431,18 @@
           </div>
           <button class="btn btn-primary" onclick="fetchStatus()">刷新状态</button>
         </div>
+        <section class="runtime-identity-card" id="runtime-identity-card" aria-label="当前运行目录">
+          <div class="runtime-identity-head">
+            <div class="runtime-identity-title">当前运行目录</div>
+            <div class="runtime-identity-badges" id="runtime-identity-badges"><span class="runtime-identity-badge">正在读取...</span></div>
+          </div>
+          <div class="runtime-identity-grid">
+            <div class="runtime-identity-item"><div class="runtime-identity-label">Data Root</div><div class="runtime-identity-path" id="runtime-data-root">正在读取...</div></div>
+            <div class="runtime-identity-item"><div class="runtime-identity-label">Code Root</div><div class="runtime-identity-path" id="runtime-code-root">正在读取...</div></div>
+            <div class="runtime-identity-item"><div class="runtime-identity-label">Workspace Root</div><div class="runtime-identity-path" id="runtime-workspace-root">正在读取...</div></div>
+          </div>
+          <div style="display:flex;justify-content:flex-end;margin-top:10px"><button class="runtime-identity-copy" id="copy-runtime-data-root" onclick="copyRuntimeDataRoot()">复制 Data Root</button></div>
+        </section>
         <div class="services-grid robot-grid" id="services-grid"><div class="loading">加载中...</div></div>
 
         <div class="settings-header" style="margin-top:28px">
@@ -7473,12 +7585,45 @@
 
     function renderStatus(d) {
       const grid = document.getElementById('status-grid');
+      renderRuntimeIdentity(d.runtimeIdentity || {});
       if (!grid) return;
       grid.innerHTML =
         '<div class="status-card"><div class="label">Version</div><div class="value">'+escapeHtml(d.version||'-')+'</div></div>'+
         '<div class="status-card"><div class="label">Runtime</div><div class="value">'+escapeHtml(d.platform||'-')+'</div><div class="readiness-summary">Host: '+escapeHtml(d.hostname||'-')+'</div></div>'+
         '<div class="status-card"><div class="label">Model</div><div class="value">'+escapeHtml(d.model||'-')+'</div><div class="readiness-summary">'+escapeHtml(d.provider||'-')+'</div></div>'+
         '<div class="status-card"><div class="label">Skills Path</div><div class="value" style="font-size:12px;word-break:break-all">'+escapeHtml(d.skillsPath||'-')+'</div></div>';
+    }
+
+    function renderRuntimeIdentity(identity) {
+      const dataRoot = document.getElementById('runtime-data-root');
+      const codeRoot = document.getElementById('runtime-code-root');
+      const workspaceRoot = document.getElementById('runtime-workspace-root');
+      const badges = document.getElementById('runtime-identity-badges');
+      if(dataRoot)dataRoot.textContent=identity.dataRoot||'-';
+      if(codeRoot)codeRoot.textContent=identity.codeRoot||'-';
+      if(workspaceRoot)workspaceRoot.textContent=identity.workspaceRoot||'-';
+      if(badges){
+        const code=identity.code||{};
+        const revision=code.commit?((code.branch||'detached')+'@'+String(code.commit).slice(0,8)):'no-git';
+        badges.innerHTML='<span class="runtime-identity-badge">profile: '+escapeHtml(identity.profile||'default')+'</span>'+
+          '<span class="runtime-identity-badge">'+escapeHtml(revision)+(code.dirty?' · dirty':'')+'</span>';
+      }
+    }
+
+    async function copyRuntimeDataRoot(){
+      const value=document.getElementById('runtime-data-root')?.textContent||'';
+      const button=document.getElementById('copy-runtime-data-root');
+      if(!value||value==='-'||value==='正在读取...')return;
+      try{
+        await copyTextToClipboard(value);
+        if(button)button.textContent='已复制';
+        pulsePetState('success','Data Root 已复制',1200);
+      }catch(error){
+        if(button)button.textContent='复制失败';
+        pulsePetState('error','Data Root 复制失败',1800);
+      }finally{
+        setTimeout(()=>{if(button)button.textContent='复制 Data Root';},1400);
+      }
     }
 
     function renderReadiness(data) {

--- a/scripts/test-environment.mjs
+++ b/scripts/test-environment.mjs
@@ -1,3 +1,5 @@
+import path from 'node:path';
+
 export const RUNTIME_WRITE_PATH_ENV_KEYS = Object.freeze([
   'XIAOBA_USER_DATA_DIR',
   'CATSCO_USER_DATA_DIR',
@@ -29,11 +31,14 @@ export function buildIsolatedTestEnvironment(
   if (homeDir) {
     env.HOME = homeDir;
     env.USERPROFILE = homeDir;
+    env.XIAOBA_TEST_SANDBOX_ROOT = path.dirname(homeDir);
   }
   if (tempDir) {
     env.TMPDIR = tempDir;
     env.TMP = tempDir;
     env.TEMP = tempDir;
+    env.XIAOBA_USER_DATA_DIR = path.join(tempDir, 'runtime-data');
+    env.XIAOBA_TEST_DEFAULT_DATA_DIR = env.XIAOBA_USER_DATA_DIR;
   }
   if (appRoot) env.XIAOBA_APP_ROOT = appRoot;
   if (dotenvPath) env.DOTENV_CONFIG_PATH = dotenvPath;

--- a/src/commands/data.ts
+++ b/src/commands/data.ts
@@ -1,0 +1,80 @@
+import * as path from 'path';
+import type { Command } from 'commander';
+import { Logger } from '../utils/logger';
+import { PathResolver } from '../utils/path-resolver';
+import { resolveRuntimeIdentity } from '../runtime/runtime-identity';
+import {
+  applyRuntimeDataMigration,
+  findLegacyRuntimeArtifacts,
+  planRuntimeDataMigration,
+  RuntimeDataMigrationPlan,
+} from '../runtime/data-migration';
+
+export function registerDataCommand(program: Command): void {
+  const data = program.command('data').description('Inspect or migrate XiaoBa runtime data');
+
+  data
+    .command('status', { isDefault: true })
+    .description('Show code, workspace, and runtime data roots')
+    .action(showDataStatus);
+
+  data
+    .command('migrate')
+    .description('Safely copy legacy runtime data without deleting or overwriting files')
+    .option('--from <path>', 'Legacy runtime root; defaults to the current workspace')
+    .option('--apply', 'Apply the migration; without this flag only a preview is shown')
+    .action((options: { from?: string; apply?: boolean }) => migrateData(options));
+}
+
+function showDataStatus(): void {
+  const identity = resolveRuntimeIdentity();
+  const legacyArtifacts = identity.workspaceRoot === identity.dataRoot
+    ? []
+    : findLegacyRuntimeArtifacts(identity.workspaceRoot);
+  Logger.title('Runtime Data');
+  Logger.info(`Code root: ${identity.codeRoot}`);
+  Logger.info(`Workspace root: ${identity.workspaceRoot}`);
+  Logger.info(`Data root: ${identity.dataRoot}`);
+  Logger.info(`Profile: ${identity.profile} (${identity.dataRootSource})`);
+  if (legacyArtifacts.length > 0) {
+    Logger.warning(`Legacy runtime artifacts remain in the workspace: ${legacyArtifacts.join(', ')}`);
+    Logger.info('Preview a safe copy with: catsco data migrate');
+  } else {
+    Logger.success('No legacy runtime artifacts were detected in the workspace.');
+  }
+}
+
+function migrateData(options: { from?: string; apply?: boolean }): void {
+  const sourceRoot = path.resolve(options.from || process.cwd());
+  const targetRoot = PathResolver.getRuntimeDataRoot();
+  const plan = planRuntimeDataMigration(sourceRoot, targetRoot);
+  printMigrationPlan(plan);
+
+  if (!options.apply) {
+    Logger.info('Preview only. Re-run with --apply to copy files. The source is never deleted.');
+    return;
+  }
+  const result = applyRuntimeDataMigration(plan);
+  Logger.success(`Migration copied ${result.totals.copy} files without overwriting existing data.`);
+  if (result.totals.conflict > 0) {
+    Logger.warning(`${result.totals.conflict} conflicting files were left unchanged.`);
+  }
+  Logger.info(`Migration manifest: ${result.manifestPath}`);
+}
+
+function printMigrationPlan(plan: RuntimeDataMigrationPlan): void {
+  Logger.title('Runtime Data Migration');
+  Logger.info(`Source: ${plan.sourceRoot}`);
+  Logger.info(`Target: ${plan.targetRoot}`);
+  Logger.info(`Copy: ${plan.totals.copy} files (${formatBytes(plan.copyBytes)})`);
+  Logger.info(`Already identical: ${plan.totals.same}`);
+  if (plan.totals.conflict > 0) Logger.warning(`Conflicts (will not overwrite): ${plan.totals.conflict}`);
+  if (plan.totals.unsupported > 0) Logger.warning(`Unsupported entries (will skip): ${plan.totals.unsupported}`);
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KiB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MiB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GiB`;
+}

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -15,6 +15,7 @@ import type { ChatConfig, OpenAIApiMode, ReasoningEffort } from '../../types';
 import type { ToolDefinition } from '../../types/tool';
 import { AIService } from '../../utils/ai-service';
 import { createRuntimeConfigSnapshot } from '../../runtime/runtime-config-snapshot';
+import { resolveCodeRoot, resolveRuntimeIdentity } from '../../runtime/runtime-identity';
 import {
   CUSTOM_MODEL_DEFAULT_CONTEXT_WINDOW_TOKENS,
   calculatePromptBudgetTokens,
@@ -2225,6 +2226,9 @@ export function createApiRouter(
     const config = ConfigManager.getConfigReadonly();
     const contextWindow = resolveModelContextWindow(config);
     const services = serviceManager.getAll();
+    const codeRoot = typeof (serviceManager as any).getProjectRoot === 'function'
+      ? (serviceManager as any).getProjectRoot()
+      : resolveCodeRoot();
     res.json({
       version: APP_VERSION,
       hostname: os.hostname(),
@@ -2235,6 +2239,7 @@ export function createApiRouter(
       provider: config.provider,
       contextWindow,
       skillsPath: PathResolver.getSkillsPath(),
+      runtimeIdentity: resolveRuntimeIdentity({ codeRoot }),
       services,
       authStatus: options.getAuthStatus?.() || { enabled: false, configured: false },
     });

--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -6,6 +6,7 @@ import { createApiRouter } from './routes/api';
 import { ServiceManager } from './service-manager';
 import { bootstrapDefaultSkillHubSkillsOnce } from '../skillhub/default-skill-bootstrap';
 import { createDashboardAuth } from './auth';
+import { resolveCodeRoot } from '../runtime/runtime-identity';
 
 const DEFAULT_PORT = 3800;
 const activeServers: Server[] = [];
@@ -31,7 +32,9 @@ export async function startDashboard(
 ): Promise<DashboardServerHandle> {
   const app = express();
   const envPackaged = /^(1|true|yes)$/i.test(process.env.XIAOBA_IS_PACKAGED || '');
-  const projectRoot = controllers.projectRoot || (envPackaged ? process.env.XIAOBA_APP_ROOT : undefined) || process.cwd();
+  const projectRoot = controllers.projectRoot
+    || (envPackaged ? process.env.XIAOBA_APP_ROOT : undefined)
+    || resolveCodeRoot();
   const serviceManager = new ServiceManager(projectRoot);
 
   app.use(express.json({ limit: '25mb' }));

--- a/src/dashboard/service-manager.ts
+++ b/src/dashboard/service-manager.ts
@@ -75,6 +75,10 @@ export class ServiceManager extends EventEmitter {
     this.registerBuiltinServices();
   }
 
+  getProjectRoot(): string {
+    return this.projectRoot;
+  }
+
   private isPackaged(): boolean {
     // Electron 打包版会设置 XIAOBA_APP_ROOT
     if (process.env.XIAOBA_IS_PACKAGED !== undefined) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,22 +2,39 @@
 
 import { Command } from 'commander';
 import { Logger } from './utils/logger';
-import { chatCommand } from './commands/chat';
-import { configCommand } from './commands/config';
-import { registerSkillCommand } from './commands/skill';
-import { feishuCommand } from './commands/feishu';
-import { runtimeCommand } from './commands/runtime';
 import { APP_VERSION } from './version';
+import { applyRuntimeDataOptionsFromArgv } from './runtime/runtime-data-bootstrap';
+import { findLegacyRuntimeArtifacts } from './runtime/data-migration';
+import { resolveRuntimeIdentity } from './runtime/runtime-identity';
 
-function main() {
+async function main() {
+  applyRuntimeDataOptionsFromArgv(process.argv);
+  const [
+    { chatCommand },
+    { configCommand },
+    { registerSkillCommand },
+    { feishuCommand },
+    { runtimeCommand },
+    { registerDataCommand },
+  ] = await Promise.all([
+    import('./commands/chat'),
+    import('./commands/config'),
+    import('./commands/skill'),
+    import('./commands/feishu'),
+    import('./commands/runtime'),
+    import('./commands/data'),
+  ]);
   const program = new Command();
 
   Logger.brand();
+  logRuntimeIdentity();
 
   program
     .name('catsco')
     .description('CatsCo agent CLI')
-    .version(APP_VERSION);
+    .version(APP_VERSION)
+    .option('--data-dir <path>', 'Use an explicit runtime data directory')
+    .option('--profile <name>', 'Use a named runtime data profile');
 
   program
     .command('chat')
@@ -83,12 +100,33 @@ function main() {
     .action(runtimeCommand);
 
   registerSkillCommand(program);
+  registerDataCommand(program);
 
   program.action(() => {
     chatCommand({ interactive: true });
   });
 
-  program.parse();
+  await program.parseAsync();
 }
 
-main();
+function logRuntimeIdentity(): void {
+  const identity = resolveRuntimeIdentity();
+  const codeLabel = identity.code.commit
+    ? `${identity.code.branch || 'detached'}@${identity.code.commit.slice(0, 8)}${identity.code.dirty ? ' (dirty)' : ''}`
+    : 'not a Git checkout';
+  Logger.info(`Code root: ${identity.codeRoot} · ${codeLabel}`);
+  Logger.info(`Workspace root: ${identity.workspaceRoot}`);
+  Logger.info(`Data root: ${identity.dataRoot} · profile=${identity.profile} · source=${identity.dataRootSource}`);
+  if (identity.workspaceRoot !== identity.dataRoot) {
+    const legacyArtifacts = findLegacyRuntimeArtifacts(identity.workspaceRoot);
+    if (legacyArtifacts.length > 0) {
+      Logger.warning(`Legacy runtime data detected in the workspace: ${legacyArtifacts.join(', ')}`);
+      Logger.info('Run `catsco data migrate` to preview a safe, copy-only migration.');
+    }
+  }
+}
+
+main().catch(error => {
+  Logger.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/src/pet/pet-store.ts
+++ b/src/pet/pet-store.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import { PathResolver } from '../utils/path-resolver';
 import {
   applyPetEvent,
   cleanupPetEvents,
@@ -138,13 +139,16 @@ export function resolvePetDataDir(env: NodeJS.ProcessEnv = process.env, cwd: str
   const explicit = String(env.XIAOBA_PET_DATA_DIR || '').trim();
   if (explicit) return path.isAbsolute(explicit) ? explicit : path.resolve(cwd, explicit);
 
+  // Preserve the packaged app's existing <electron-user-data>/pet location.
+  // It is already outside the code tree and changing it would make existing
+  // companion progress appear to disappear after an upgrade.
   const electronUserData = String(env.XIAOBA_ELECTRON_USER_DATA_DIR || '').trim();
   if (electronUserData) {
     const resolved = path.isAbsolute(electronUserData) ? electronUserData : path.resolve(cwd, electronUserData);
     return path.join(resolved, 'pet');
   }
 
-  return path.join(cwd, 'data', 'pet');
+  return path.join(PathResolver.getRuntimeDataRoot(env, cwd), 'data', 'pet');
 }
 
 function createDefaultStoreData(): PetStoreData {

--- a/src/runtime/data-migration.ts
+++ b/src/runtime/data-migration.ts
@@ -1,0 +1,220 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+
+export const LEGACY_RUNTIME_ARTIFACTS = [
+  '.env',
+  '.xiaoba',
+  'branch-agents.json',
+  'config.json',
+  'data',
+  'logs',
+  'prompt-overrides',
+  'skills',
+] as const;
+
+// These are deliberately narrower than the migration allow-list. Source
+// checkouts can legitimately contain bundled data/ and skills/ directories,
+// so using those as signals would report legacy user data in every worktree.
+export const LEGACY_RUNTIME_MARKERS = [
+  '.env',
+  '.xiaoba',
+  'branch-agents.json',
+  'config.json',
+  'logs',
+  'prompt-overrides',
+  'data/sessions',
+  'data/session-state',
+  'data/session-summaries',
+  'data/catsco-log-agent-state.json',
+] as const;
+
+export type MigrationFileStatus = 'copy' | 'same' | 'conflict' | 'unsupported';
+
+export interface MigrationFilePlan {
+  relativePath: string;
+  sourcePath: string;
+  targetPath: string;
+  bytes: number;
+  status: MigrationFileStatus;
+  reason?: string;
+}
+
+export interface RuntimeDataMigrationPlan {
+  sourceRoot: string;
+  targetRoot: string;
+  files: MigrationFilePlan[];
+  missingArtifacts: string[];
+  totals: Record<MigrationFileStatus, number>;
+  copyBytes: number;
+}
+
+export interface RuntimeDataMigrationResult extends RuntimeDataMigrationPlan {
+  applied: boolean;
+  manifestPath?: string;
+}
+
+export function planRuntimeDataMigration(sourceRoot: string, targetRoot: string): RuntimeDataMigrationPlan {
+  const source = path.resolve(sourceRoot);
+  const target = path.resolve(targetRoot);
+  assertSeparateRoots(source, target);
+
+  const files: MigrationFilePlan[] = [];
+  const missingArtifacts: string[] = [];
+  for (const artifact of LEGACY_RUNTIME_ARTIFACTS) {
+    const sourcePath = path.join(source, artifact);
+    if (!fs.existsSync(sourcePath)) {
+      missingArtifacts.push(artifact);
+      continue;
+    }
+    collectMigrationFiles(sourcePath, path.join(target, artifact), artifact, files);
+  }
+
+  return summarizePlan(source, target, files, missingArtifacts);
+}
+
+export function applyRuntimeDataMigration(plan: RuntimeDataMigrationPlan): RuntimeDataMigrationResult {
+  const freshPlan = planRuntimeDataMigration(plan.sourceRoot, plan.targetRoot);
+  fs.mkdirSync(freshPlan.targetRoot, { recursive: true });
+
+  for (const file of freshPlan.files) {
+    if (file.status !== 'copy') continue;
+    fs.mkdirSync(path.dirname(file.targetPath), { recursive: true });
+    fs.copyFileSync(file.sourcePath, file.targetPath, fs.constants.COPYFILE_EXCL);
+    const sourceMode = fs.statSync(file.sourcePath).mode & 0o777;
+    fs.chmodSync(file.targetPath, file.relativePath === '.env' ? 0o600 : sourceMode);
+  }
+
+  const manifestDir = path.join(freshPlan.targetRoot, '.xiaoba', 'migrations');
+  fs.mkdirSync(manifestDir, { recursive: true });
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const manifestPath = path.join(manifestDir, `${timestamp}.json`);
+  const manifest = {
+    schema: 'xiaoba.runtime-data-migration.v1',
+    createdAt: new Date().toISOString(),
+    sourceRoot: freshPlan.sourceRoot,
+    targetRoot: freshPlan.targetRoot,
+    copied: freshPlan.files.filter(file => file.status === 'copy').map(file => file.relativePath),
+    same: freshPlan.files.filter(file => file.status === 'same').map(file => file.relativePath),
+    conflicts: freshPlan.files.filter(file => file.status === 'conflict').map(file => file.relativePath),
+    unsupported: freshPlan.files.filter(file => file.status === 'unsupported').map(file => ({
+      path: file.relativePath,
+      reason: file.reason,
+    })),
+  };
+  fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 });
+
+  return { ...freshPlan, applied: true, manifestPath };
+}
+
+export function findLegacyRuntimeArtifacts(root: string): string[] {
+  const resolved = path.resolve(root);
+  return LEGACY_RUNTIME_MARKERS.filter(artifact => fs.existsSync(path.join(resolved, artifact)));
+}
+
+function collectMigrationFiles(
+  sourcePath: string,
+  targetPath: string,
+  relativePath: string,
+  files: MigrationFilePlan[],
+): void {
+  const stat = fs.lstatSync(sourcePath);
+  if (stat.isSymbolicLink()) {
+    files.push({
+      relativePath,
+      sourcePath,
+      targetPath,
+      bytes: 0,
+      status: 'unsupported',
+      reason: 'symbolic links are not copied',
+    });
+    return;
+  }
+  if (stat.isDirectory()) {
+    for (const entry of fs.readdirSync(sourcePath).sort()) {
+      collectMigrationFiles(
+        path.join(sourcePath, entry),
+        path.join(targetPath, entry),
+        path.join(relativePath, entry),
+        files,
+      );
+    }
+    return;
+  }
+  if (!stat.isFile()) {
+    files.push({
+      relativePath,
+      sourcePath,
+      targetPath,
+      bytes: 0,
+      status: 'unsupported',
+      reason: 'only regular files are copied',
+    });
+    return;
+  }
+
+  let status: MigrationFileStatus = 'copy';
+  if (fs.existsSync(targetPath)) {
+    const targetStat = fs.lstatSync(targetPath);
+    status = targetStat.isFile() && targetStat.size === stat.size && sameFileContent(sourcePath, targetPath)
+      ? 'same'
+      : 'conflict';
+  }
+  files.push({ relativePath, sourcePath, targetPath, bytes: stat.size, status });
+}
+
+function summarizePlan(
+  sourceRoot: string,
+  targetRoot: string,
+  files: MigrationFilePlan[],
+  missingArtifacts: string[],
+): RuntimeDataMigrationPlan {
+  const totals: Record<MigrationFileStatus, number> = {
+    copy: 0,
+    same: 0,
+    conflict: 0,
+    unsupported: 0,
+  };
+  let copyBytes = 0;
+  for (const file of files) {
+    totals[file.status] += 1;
+    if (file.status === 'copy') copyBytes += file.bytes;
+  }
+  return { sourceRoot, targetRoot, files, missingArtifacts, totals, copyBytes };
+}
+
+function sameFileContent(left: string, right: string): boolean {
+  return hashFile(left) === hashFile(right);
+}
+
+function hashFile(filePath: string): string {
+  const hash = crypto.createHash('sha256');
+  const buffer = Buffer.allocUnsafe(64 * 1024);
+  const fd = fs.openSync(filePath, 'r');
+  try {
+    let bytesRead = 0;
+    do {
+      bytesRead = fs.readSync(fd, buffer, 0, buffer.length, null);
+      if (bytesRead > 0) hash.update(buffer.subarray(0, bytesRead));
+    } while (bytesRead > 0);
+  } finally {
+    fs.closeSync(fd);
+  }
+  return hash.digest('hex');
+}
+
+function assertSeparateRoots(source: string, target: string): void {
+  const sourceToTarget = path.relative(source, target);
+  const targetToSource = path.relative(target, source);
+  if (
+    source === target
+    || isInsideRelative(sourceToTarget)
+    || isInsideRelative(targetToSource)
+  ) {
+    throw new Error('Migration source and target must be separate, non-nested directories.');
+  }
+}
+
+function isInsideRelative(relative: string): boolean {
+  return relative !== '' && !relative.startsWith('..') && !path.isAbsolute(relative);
+}

--- a/src/runtime/runtime-config-snapshot.ts
+++ b/src/runtime/runtime-config-snapshot.ts
@@ -220,7 +220,7 @@ function resolveRuntimeProfileForSnapshot(options: {
     configPath: options.profileConfigPath,
     runtimeRoot: options.runtimeRoot,
     surface: options.surface,
-    workingDirectory: options.workingDirectory ?? options.runtimeRoot,
+    workingDirectory: options.workingDirectory ?? process.cwd(),
     model: {
       provider: options.config?.provider,
       apiUrl: sanitizeServerUrl(options.config?.apiUrl),

--- a/src/runtime/runtime-data-bootstrap.ts
+++ b/src/runtime/runtime-data-bootstrap.ts
@@ -1,0 +1,47 @@
+import * as path from 'path';
+import { normalizeProfileName } from '../utils/path-resolver';
+
+export interface RuntimeDataBootstrapResult {
+  dataDir?: string;
+  profile?: string;
+}
+
+/**
+ * Runtime data options must be applied before command modules are imported.
+ * Some command modules load profile configuration during module evaluation.
+ */
+export function applyRuntimeDataOptionsFromArgv(
+  argv: string[],
+  env: NodeJS.ProcessEnv = process.env,
+  cwd: string = process.cwd(),
+): RuntimeDataBootstrapResult {
+  const dataDir = readOption(argv, '--data-dir');
+  const rawProfile = readOption(argv, '--profile');
+  const profile = rawProfile === undefined ? undefined : normalizeProfileName(rawProfile);
+
+  if (dataDir !== undefined) {
+    if (!dataDir.trim()) throw new Error('--data-dir requires a non-empty path');
+    env.XIAOBA_USER_DATA_DIR = path.resolve(cwd, dataDir);
+  }
+  if (profile !== undefined) env.XIAOBA_PROFILE = profile;
+
+  return {
+    dataDir: dataDir === undefined ? undefined : env.XIAOBA_USER_DATA_DIR,
+    profile,
+  };
+}
+
+function readOption(argv: string[], name: string): string | undefined {
+  for (let index = 2; index < argv.length; index += 1) {
+    const value = argv[index];
+    if (value === name) {
+      const next = argv[index + 1];
+      if (next === undefined || next.startsWith('-')) {
+        throw new Error(`${name} requires a value`);
+      }
+      return next;
+    }
+    if (value.startsWith(`${name}=`)) return value.slice(name.length + 1);
+  }
+  return undefined;
+}

--- a/src/runtime/runtime-env.ts
+++ b/src/runtime/runtime-env.ts
@@ -1,0 +1,46 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as dotenv from 'dotenv';
+import { PathResolver } from '../utils/path-resolver';
+
+export interface RuntimeEnvLoadResult {
+  sources: string[];
+  loadedKeys: string[];
+}
+
+/**
+ * Precedence is shell/process env > Data Root .env > legacy cwd .env.
+ * DOTENV_CONFIG_PATH remains an explicit single-file override for tests and
+ * advanced launchers.
+ */
+export function loadRuntimeEnvFiles(
+  env: NodeJS.ProcessEnv = process.env,
+  cwd: string = process.cwd(),
+): RuntimeEnvLoadResult {
+  const explicit = String(env.DOTENV_CONFIG_PATH || '').trim();
+  const runtimeRoot = PathResolver.getRuntimeDataRoot(env, cwd);
+  const candidates = explicit
+    ? [path.resolve(explicit)]
+    : Array.from(new Set([
+      path.resolve(cwd, '.env'),
+      path.join(runtimeRoot, '.env'),
+    ]));
+  const originalKeys = new Set(Object.keys(env));
+  const merged: Record<string, string> = {};
+  const sources: string[] = [];
+
+  for (const filePath of candidates) {
+    if (!fs.existsSync(filePath)) continue;
+    Object.assign(merged, dotenv.parse(fs.readFileSync(filePath, 'utf8')));
+    sources.push(filePath);
+  }
+
+  const loadedKeys: string[] = [];
+  for (const [key, value] of Object.entries(merged)) {
+    if (originalKeys.has(key)) continue;
+    env[key] = value;
+    loadedKeys.push(key);
+  }
+
+  return { sources, loadedKeys };
+}

--- a/src/runtime/runtime-identity.ts
+++ b/src/runtime/runtime-identity.ts
@@ -1,0 +1,75 @@
+import * as path from 'path';
+import { spawnSync } from 'child_process';
+import { PathResolver, RuntimeDataRootSource } from '../utils/path-resolver';
+
+export interface RuntimeCodeIdentity {
+  commit?: string;
+  branch?: string;
+  dirty?: boolean;
+}
+
+export interface RuntimeIdentity {
+  codeRoot: string;
+  workspaceRoot: string;
+  dataRoot: string;
+  dataRootSource: RuntimeDataRootSource;
+  profile: string;
+  code: RuntimeCodeIdentity;
+}
+
+export interface RuntimeIdentityOptions {
+  env?: NodeJS.ProcessEnv;
+  codeRoot?: string;
+  workspaceRoot?: string;
+}
+
+export function resolveCodeRoot(env: NodeJS.ProcessEnv = process.env): string {
+  const explicit = String(env.XIAOBA_APP_ROOT || '').trim();
+  if (explicit) return path.resolve(explicit);
+  return path.resolve(__dirname, '../..');
+}
+
+export function resolveRuntimeIdentity(options: RuntimeIdentityOptions = {}): RuntimeIdentity {
+  const env = options.env ?? process.env;
+  const codeRoot = path.resolve(options.codeRoot ?? resolveCodeRoot(env));
+  const workspaceRoot = path.resolve(options.workspaceRoot ?? process.cwd());
+  const data = PathResolver.resolveRuntimeDataRoot(env, workspaceRoot);
+  return {
+    codeRoot,
+    workspaceRoot,
+    dataRoot: data.path,
+    dataRootSource: data.source,
+    profile: data.profile,
+    code: readGitIdentity(codeRoot, env),
+  };
+}
+
+function readGitIdentity(codeRoot: string, env: NodeJS.ProcessEnv): RuntimeCodeIdentity {
+  const commit = runGit(['rev-parse', 'HEAD'], codeRoot, env);
+  if (!commit) return {};
+  const branch = runGit(['branch', '--show-current'], codeRoot, env) || undefined;
+  const dirtyOutput = runGit(['status', '--porcelain', '--untracked-files=no'], codeRoot, env, true);
+  return {
+    commit,
+    branch,
+    dirty: dirtyOutput === undefined ? undefined : dirtyOutput.length > 0,
+  };
+}
+
+function runGit(
+  args: string[],
+  cwd: string,
+  env: NodeJS.ProcessEnv,
+  preserveEmpty: boolean = false,
+): string | undefined {
+  const result = spawnSync('git', args, {
+    cwd,
+    env,
+    encoding: 'utf8',
+    timeout: 1_500,
+    windowsHide: true,
+  });
+  if (result.status !== 0 || result.error) return undefined;
+  const output = String(result.stdout || '').trim();
+  return output || (preserveEmpty ? '' : undefined);
+}

--- a/src/runtime/runtime-profile-config.ts
+++ b/src/runtime/runtime-profile-config.ts
@@ -11,6 +11,7 @@ import {
 } from './runtime-profile';
 import { normalizeReasoningEffort } from '../utils/reasoning-effort';
 import { normalizeOpenAIApiMode } from '../utils/openai-api-mode';
+import { PathResolver } from '../utils/path-resolver';
 
 export const RUNTIME_PROFILE_SCHEMA_VERSION = 1;
 export const DEFAULT_RUNTIME_PROFILE_FILENAME = 'runtime-profile.json';
@@ -84,7 +85,8 @@ export function getDefaultRuntimeProfileConfigPath(
   options: Pick<ResolveRuntimeProfileFromConfigOptions, 'env' | 'runtimeRoot' | 'homeDir' | 'configPath'> = {},
 ): string {
   const env = options.env ?? process.env;
-  const runtimeRoot = options.runtimeRoot ?? process.cwd();
+  const runtimeRoot = options.runtimeRoot
+    ?? PathResolver.getRuntimeDataRoot(env, process.cwd(), options.homeDir ?? os.homedir());
   const explicitPath = options.configPath || PROFILE_PATH_ENV_KEYS
     .map(key => env[key])
     .find(value => typeof value === 'string' && value.trim().length > 0);
@@ -93,7 +95,7 @@ export function getDefaultRuntimeProfileConfigPath(
     return resolvePath(explicitPath, runtimeRoot, options.homeDir);
   }
 
-  return path.join(options.homeDir ?? os.homedir(), '.xiaoba', DEFAULT_RUNTIME_PROFILE_FILENAME);
+  return path.join(runtimeRoot, DEFAULT_RUNTIME_PROFILE_FILENAME);
 }
 
 export function loadRuntimeProfileConfigFile(

--- a/src/runtime/runtime-profile-editor.ts
+++ b/src/runtime/runtime-profile-editor.ts
@@ -88,7 +88,7 @@ export function previewRuntimeProfileEdit(
   const configDir = path.dirname(configPath);
   const baseProfile = resolveDefaultRuntimeProfile({
     env: options.env,
-    workingDirectory: options.runtimeRoot ?? process.cwd(),
+    workingDirectory: process.cwd(),
   });
   const currentFileConfig = loaded.profileConfig ?? {};
   const safeCurrentFileConfig = stripToEditableProfileConfig(currentFileConfig);

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,18 +1,13 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import * as os from 'os';
-import * as dotenv from 'dotenv';
 import { ChatConfig } from '../types';
 import { normalizeReasoningEffort } from './reasoning-effort';
 import { normalizeOpenAIApiMode } from './openai-api-mode';
 import { resolveActiveBotLLMConfig } from '../bot-definition/llm-config-resolver';
 import { PathResolver } from './path-resolver';
+import { loadRuntimeEnvFiles } from '../runtime/runtime-env';
 
-// 加载环境变量（静默模式）
-dotenv.config({ path: process.env.DOTENV_CONFIG_PATH || '.env', quiet: true });
-
-const DEFAULT_CONFIG_DIR = path.join(os.homedir(), '.xiaoba');
-const DEFAULT_CONFIG_FILE = path.join(DEFAULT_CONFIG_DIR, 'config.json');
+loadRuntimeEnvFiles();
 
 export class ConfigManager {
   private static mergeConfig(base: ChatConfig, override?: Partial<ChatConfig>): ChatConfig {
@@ -61,7 +56,9 @@ export class ConfigManager {
 
   private static getConfigFilePath(): string {
     const explicitPath = process.env.XIAOBA_CONFIG_PATH?.trim();
-    return explicitPath ? path.resolve(explicitPath) : DEFAULT_CONFIG_FILE;
+    return explicitPath
+      ? path.resolve(explicitPath)
+      : path.join(PathResolver.getRuntimeDataRoot(), 'config.json');
   }
 
   static getConfig(): ChatConfig {

--- a/src/utils/path-resolver.ts
+++ b/src/utils/path-resolver.ts
@@ -2,34 +2,90 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
 
+export type RuntimeDataRootSource =
+  | 'XIAOBA_USER_DATA_DIR'
+  | 'CATSCO_USER_DATA_DIR'
+  | 'XIAOBA_ELECTRON_USER_DATA_DIR'
+  | 'XIAOBA_RUNTIME_ROOT'
+  | 'test-workspace'
+  | 'profile'
+  | 'default';
+
+export interface RuntimeDataRootResolution {
+  path: string;
+  source: RuntimeDataRootSource;
+  profile: string;
+}
+
+const DEFAULT_PROFILE = 'default';
+const PROFILE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+
 export class PathResolver {
-  static getRuntimeDataRoot(
+  static resolveRuntimeDataRoot(
     env: NodeJS.ProcessEnv = process.env,
     cwd: string = process.cwd(),
-  ): string {
-    const explicit = [
-      env.XIAOBA_USER_DATA_DIR,
-      env.CATSCO_USER_DATA_DIR,
-      env.XIAOBA_ELECTRON_USER_DATA_DIR,
+    homeDir: string = os.homedir(),
+  ): RuntimeDataRootResolution {
+    const explicitCandidates: Array<[RuntimeDataRootSource, string | undefined]> = [
+      ['XIAOBA_USER_DATA_DIR', env.XIAOBA_USER_DATA_DIR],
+      ['CATSCO_USER_DATA_DIR', env.CATSCO_USER_DATA_DIR],
+      ['XIAOBA_ELECTRON_USER_DATA_DIR', env.XIAOBA_ELECTRON_USER_DATA_DIR],
       // Legacy data-root compatibility only. Bundled executable discovery uses
       // XIAOBA_BUNDLED_EXECUTABLES_DIR and must not write this variable.
-      env.XIAOBA_RUNTIME_ROOT,
-    ]
-      .map(value => String(value || '').trim())
-      .find(Boolean);
+      ['XIAOBA_RUNTIME_ROOT', env.XIAOBA_RUNTIME_ROOT],
+    ];
+    const explicit = explicitCandidates.find(([, value]) => String(value || '').trim());
+    const profile = normalizeProfileName(env.XIAOBA_PROFILE);
+    const defaultRoot = path.join(path.resolve(homeDir), '.xiaoba');
+    const testSandboxRoot = String(env.XIAOBA_TEST_SANDBOX_ROOT || '').trim();
+    const runnerDefaultRoot = String(env.XIAOBA_TEST_DEFAULT_DATA_DIR || '').trim();
+    const explicitIsRunnerDefault = Boolean(
+      explicit
+      && runnerDefaultRoot
+      && path.resolve(String(explicit[1]).trim()) === path.resolve(runnerDefaultRoot),
+    );
+    const isolatedTestWorkspace = env.XIAOBA_TEST_RUNNER === '1'
+      && testSandboxRoot
+      && isPathInside(path.resolve(cwd), path.resolve(testSandboxRoot))
+      && (!explicit || explicitIsRunnerDefault)
+      ? path.resolve(cwd)
+      : undefined;
+    const resolution: RuntimeDataRootResolution = isolatedTestWorkspace
+      ? { path: isolatedTestWorkspace, source: 'test-workspace', profile }
+      : explicit
+      ? {
+        path: path.resolve(String(explicit[1]).trim()),
+        source: explicit[0],
+        profile,
+      }
+      : profile === DEFAULT_PROFILE
+        ? { path: defaultRoot, source: 'default', profile }
+        : { path: path.join(defaultRoot, 'profiles', profile), source: 'profile', profile };
+
+    const allowedTestRoots = [
+      path.resolve(os.tmpdir()),
+      ...(testSandboxRoot ? [path.resolve(testSandboxRoot)] : []),
+    ];
 
     if (
-      explicit
-      && env.NODE_TEST_CONTEXT
+      env.NODE_TEST_CONTEXT
       && env.XIAOBA_ALLOW_NON_TEMP_TEST_RUNTIME_ROOT !== '1'
-      && !isPathInside(path.resolve(explicit), path.resolve(os.tmpdir()))
+      && !allowedTestRoots.some(root => isPathInside(resolution.path, root))
     ) {
       throw new Error(
-        `Refusing Node test runtime data root outside the OS temporary directory: ${path.resolve(explicit)}`,
+        `Refusing Node test runtime data root outside the OS temporary directory: ${resolution.path}`,
       );
     }
 
-    return path.resolve(explicit || cwd);
+    return resolution;
+  }
+
+  static getRuntimeDataRoot(
+    env: NodeJS.ProcessEnv = process.env,
+    cwd: string = process.cwd(),
+    homeDir: string = os.homedir(),
+  ): string {
+    return this.resolveRuntimeDataRoot(env, cwd, homeDir).path;
   }
 
   static getDataPath(...segments: string[]): string {
@@ -88,7 +144,33 @@ export class PathResolver {
   }
 }
 
+export function normalizeProfileName(value: string | undefined): string {
+  const profile = String(value || '').trim() || DEFAULT_PROFILE;
+  if (!PROFILE_PATTERN.test(profile) || profile === '.' || profile === '..') {
+    throw new Error(
+      'Invalid XiaoBa profile. Use 1-64 letters, numbers, dots, underscores, or hyphens; start with a letter or number.',
+    );
+  }
+  return profile;
+}
+
 function isPathInside(candidate: string, parent: string): boolean {
-  const relative = path.relative(parent, candidate);
+  const relative = path.relative(canonicalizeBoundaryPath(parent), canonicalizeBoundaryPath(candidate));
   return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+function canonicalizeBoundaryPath(value: string): string {
+  const missingSegments: string[] = [];
+  let cursor = path.resolve(value);
+  while (!fs.existsSync(cursor)) {
+    const parent = path.dirname(cursor);
+    if (parent === cursor) break;
+    missingSegments.unshift(path.basename(cursor));
+    cursor = parent;
+  }
+  try {
+    return path.join(fs.realpathSync(cursor), ...missingSegments);
+  } catch {
+    return path.resolve(value);
+  }
 }

--- a/src/weixin/index.ts
+++ b/src/weixin/index.ts
@@ -18,6 +18,7 @@ import {
   parseSessionKeyV2,
 } from '../core/session-router';
 import type { SessionRoute } from '../types/session-identity';
+import { PathResolver } from '../utils/path-resolver';
 
 const CHANNEL_VERSION = 'xiaoba-weixin/1.0';
 const DEFAULT_LONGPOLL_MS = 30000;
@@ -54,7 +55,7 @@ export class WeixinBot {
   constructor(private config: WeixinConfig) {
     this.handler = new MessageHandler(config.cdnBaseUrl);
     this.sender = new MessageSender(config.token, config.baseUrl, config.cdnBaseUrl);
-    this.stateDir = config.stateDir || path.join(process.cwd(), 'data', 'weixin');
+    this.stateDir = config.stateDir || PathResolver.getDataPath('weixin');
 
     const runtime = createWeixinRuntime();
     this.runtime = runtime;

--- a/tests/context-debug-logger.test.ts
+++ b/tests/context-debug-logger.test.ts
@@ -3,12 +3,13 @@ import assert from 'node:assert/strict';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { ContextDebugLogger } from '../src/utils/context-debug-logger';
+import { PathResolver } from '../src/utils/path-resolver';
 
 test('SDK debug dumps redact provider hidden thinking blocks', () => {
   const previous = process.env.CONTEXT_DEBUG;
   process.env.CONTEXT_DEBUG = 'true';
   const requestId = `redact42-${Date.now()}`;
-  const debugDir = path.resolve('logs/context-debug');
+  const debugDir = PathResolver.getLogsPath('context-debug');
 
   try {
     ContextDebugLogger.dumpSdkBoundary('before', requestId, {

--- a/tests/dashboard-runtime-config.test.ts
+++ b/tests/dashboard-runtime-config.test.ts
@@ -9,12 +9,15 @@ describe('dashboard runtime config snapshot', () => {
   let testRoot: string;
   let originalCwd: string;
   let originalSkillsEnv: string | undefined;
+  let originalUserDataDir: string | undefined;
 
   beforeEach(() => {
     originalCwd = process.cwd();
     originalSkillsEnv = process.env.XIAOBA_SKILLS_DIR;
+    originalUserDataDir = process.env.XIAOBA_USER_DATA_DIR;
     testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-runtime-config-'));
     process.chdir(testRoot);
+    process.env.XIAOBA_USER_DATA_DIR = testRoot;
     process.env.XIAOBA_SKILLS_DIR = path.join(testRoot, 'skills');
     writeSkill('snapshot-demo');
   });
@@ -23,6 +26,8 @@ describe('dashboard runtime config snapshot', () => {
     process.chdir(originalCwd);
     if (originalSkillsEnv === undefined) delete process.env.XIAOBA_SKILLS_DIR;
     else process.env.XIAOBA_SKILLS_DIR = originalSkillsEnv;
+    if (originalUserDataDir === undefined) delete process.env.XIAOBA_USER_DATA_DIR;
+    else process.env.XIAOBA_USER_DATA_DIR = originalUserDataDir;
     if (testRoot && fs.existsSync(testRoot)) {
       fs.rmSync(testRoot, { recursive: true, force: true });
     }
@@ -67,7 +72,7 @@ describe('dashboard runtime config snapshot', () => {
     assert.match(snapshot.systemPrompt.text, /你在这个平台上的名字是：Desk Assistant/);
     assert.match(snapshot.systemPrompt.text, /当前目录会在每次模型请求中作为临时上下文消息提供/);
     assert.doesNotMatch(snapshot.systemPrompt.text.replace(/\\/g, '/'), new RegExp(escapeRegExp(fs.realpathSync(testRoot).replace(/\\/g, '/'))));
-    assert.equal(snapshot.logging.sessionLogDir, path.join(fs.realpathSync(testRoot), 'logs/sessions'));
+    assert.equal(snapshot.logging.sessionLogDir, path.join(path.resolve(testRoot), 'logs/sessions'));
     assert.equal(snapshot.logging.upload.enabled, true);
     assert.equal(snapshot.logging.upload.serverUrl, 'https://logs.example.test:8000');
     assert.equal(JSON.stringify(snapshot).includes('api_key=secret'), false);

--- a/tests/dashboard-runtime-identity-html.test.ts
+++ b/tests/dashboard-runtime-identity-html.test.ts
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+test('dashboard visibly distinguishes data, code, and workspace roots', () => {
+  const html = fs.readFileSync(path.join(process.cwd(), 'dashboard', 'index.html'), 'utf8');
+
+  assert.match(html, /id="runtime-identity-card"/);
+  assert.match(html, /id="runtime-data-root"/);
+  assert.match(html, /id="runtime-code-root"/);
+  assert.match(html, /id="runtime-workspace-root"/);
+  assert.match(html, /id="copy-runtime-data-root"/);
+  assert.match(html, /profile:/);
+  assert.match(html, /copyRuntimeDataRoot/);
+  assert.match(html, /已复制/);
+  assert.match(html, /复制失败/);
+});

--- a/tests/dashboard-settings-api.test.ts
+++ b/tests/dashboard-settings-api.test.ts
@@ -355,6 +355,10 @@ describe('dashboard typed settings API', () => {
     const status = await statusResponse.json() as any;
     assert.equal(status.provider, 'anthropic');
     assert.equal(status.model, 'MiniMax-M2.7-highspeed');
+    assert.equal(status.runtimeIdentity.dataRoot, fs.realpathSync(testRoot));
+    assert.equal(status.runtimeIdentity.profile, 'default');
+    assert.equal(typeof status.runtimeIdentity.codeRoot, 'string');
+    assert.equal(typeof status.runtimeIdentity.workspaceRoot, 'string');
   });
 
   test('PUT /settings publishes the bound bot model definition without exposing its API key', async () => {

--- a/tests/path-resolver-boundaries.test.ts
+++ b/tests/path-resolver-boundaries.test.ts
@@ -9,9 +9,44 @@ describe('PathResolver runtime data boundary', () => {
 
   test('bundled executables directory never becomes runtime data root', () => {
     const bundledExecutablesDir = path.join(testRoot, 'bundled-executables');
+    const homeDir = path.join(testRoot, 'home');
     const env = { XIAOBA_BUNDLED_EXECUTABLES_DIR: bundledExecutablesDir } as NodeJS.ProcessEnv;
 
-    assert.equal(PathResolver.getRuntimeDataRoot(env, testRoot), path.resolve(testRoot));
+    assert.equal(PathResolver.getRuntimeDataRoot(env, testRoot, homeDir), path.join(homeDir, '.xiaoba'));
+  });
+
+  test('named profiles use a stable directory outside the Git worktree', () => {
+    const homeDir = path.join(testRoot, 'home');
+    const env = { XIAOBA_PROFILE: 'cache-candidate' } as NodeJS.ProcessEnv;
+
+    const resolution = PathResolver.resolveRuntimeDataRoot(env, testRoot, homeDir);
+
+    assert.equal(resolution.path, path.join(homeDir, '.xiaoba', 'profiles', 'cache-candidate'));
+    assert.equal(resolution.profile, 'cache-candidate');
+    assert.equal(resolution.source, 'profile');
+  });
+
+  test('explicit data directory remains exact while profile supplies experiment identity', () => {
+    const userDataRoot = path.join(testRoot, 'experiment-data');
+    const resolution = PathResolver.resolveRuntimeDataRoot({
+      XIAOBA_USER_DATA_DIR: userDataRoot,
+      XIAOBA_PROFILE: 'baseline',
+    } as NodeJS.ProcessEnv, testRoot, path.join(testRoot, 'home'));
+
+    assert.equal(resolution.path, userDataRoot);
+    assert.equal(resolution.profile, 'baseline');
+    assert.equal(resolution.source, 'XIAOBA_USER_DATA_DIR');
+  });
+
+  test('profile names cannot escape the profile directory', () => {
+    assert.throws(
+      () => PathResolver.getRuntimeDataRoot(
+        { XIAOBA_PROFILE: '../outside' } as NodeJS.ProcessEnv,
+        testRoot,
+        path.join(testRoot, 'home'),
+      ),
+      /Invalid XiaoBa profile/,
+    );
   });
 
   test('explicit user data root wins over all compatibility roots', () => {
@@ -57,5 +92,15 @@ describe('PathResolver runtime data boundary', () => {
     } as NodeJS.ProcessEnv;
 
     assert.equal(PathResolver.getRuntimeDataRoot(env, testRoot), path.resolve(safeRoot));
+  });
+
+  test('Node tests also reject a non-temporary default home root', () => {
+    const unsafeHome = path.resolve(path.parse(testRoot).root, 'Users', 'unsafe-test-home');
+    const env = { NODE_TEST_CONTEXT: 'child-v8' } as NodeJS.ProcessEnv;
+
+    assert.throws(
+      () => PathResolver.getRuntimeDataRoot(env, testRoot, unsafeHome),
+      /Refusing Node test runtime data root outside the OS temporary directory/,
+    );
   });
 });

--- a/tests/pet-store-path.test.ts
+++ b/tests/pet-store-path.test.ts
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { resolvePetDataDir } from '../src/pet/pet-store';
+
+test('pet state follows the shared runtime data root instead of the worktree', () => {
+  const cwd = path.resolve('/tmp/xiaoba-worktree');
+  const dataRoot = path.resolve('/tmp/xiaoba-runtime-data');
+  assert.equal(
+    resolvePetDataDir({ XIAOBA_USER_DATA_DIR: dataRoot }, cwd),
+    path.join(dataRoot, 'data', 'pet'),
+  );
+});
+
+test('an explicit pet directory remains available as a compatibility override', () => {
+  const cwd = path.resolve('/tmp/xiaoba-worktree');
+  assert.equal(
+    resolvePetDataDir({ XIAOBA_PET_DATA_DIR: 'pet-experiment' }, cwd),
+    path.join(cwd, 'pet-experiment'),
+  );
+});
+
+test('the packaged app keeps its existing pet state location', () => {
+  const cwd = path.resolve('/tmp/xiaoba-worktree');
+  const electronData = path.resolve('/tmp/xiaoba-electron-data');
+  assert.equal(
+    resolvePetDataDir({ XIAOBA_ELECTRON_USER_DATA_DIR: electronData }, cwd),
+    path.join(electronData, 'pet'),
+  );
+});

--- a/tests/runtime-data-bootstrap.test.ts
+++ b/tests/runtime-data-bootstrap.test.ts
@@ -1,0 +1,30 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as path from 'node:path';
+import { applyRuntimeDataOptionsFromArgv } from '../src/runtime/runtime-data-bootstrap';
+
+describe('runtime data CLI bootstrap', () => {
+  test('applies data root and profile before command modules load', () => {
+    const env = {} as NodeJS.ProcessEnv;
+    const cwd = path.resolve('/tmp/xiaoba-bootstrap');
+    const result = applyRuntimeDataOptionsFromArgv([
+      'node',
+      'xiaoba',
+      '--data-dir',
+      './runtime',
+      '--profile=cache-a',
+      'dashboard',
+    ], env, cwd);
+
+    assert.equal(env.XIAOBA_USER_DATA_DIR, path.join(cwd, 'runtime'));
+    assert.equal(env.XIAOBA_PROFILE, 'cache-a');
+    assert.deepEqual(result, { dataDir: path.join(cwd, 'runtime'), profile: 'cache-a' });
+  });
+
+  test('rejects missing option values', () => {
+    assert.throws(
+      () => applyRuntimeDataOptionsFromArgv(['node', 'xiaoba', '--data-dir'], {} as NodeJS.ProcessEnv),
+      /--data-dir requires a value/,
+    );
+  });
+});

--- a/tests/runtime-data-migration.test.ts
+++ b/tests/runtime-data-migration.test.ts
@@ -1,0 +1,70 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  applyRuntimeDataMigration,
+  findLegacyRuntimeArtifacts,
+  planRuntimeDataMigration,
+} from '../src/runtime/data-migration';
+
+describe('runtime data migration', () => {
+  test('copies known runtime artifacts without deleting the source', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-data-migration-'));
+    const source = path.join(root, 'legacy-worktree');
+    const target = path.join(root, 'profiles', 'default');
+    fs.mkdirSync(path.join(source, 'logs', 'sessions'), { recursive: true });
+    fs.mkdirSync(path.join(source, 'data'), { recursive: true });
+    fs.writeFileSync(path.join(source, '.env'), 'SECRET=test\n', 'utf8');
+    fs.writeFileSync(path.join(source, 'logs', 'sessions', 'one.jsonl'), '{}\n', 'utf8');
+    fs.writeFileSync(path.join(source, 'data', 'state.json'), '{"ok":true}\n', 'utf8');
+
+    const preview = planRuntimeDataMigration(source, target);
+    assert.equal(preview.totals.copy, 3);
+    assert.equal(fs.existsSync(target), false);
+
+    const result = applyRuntimeDataMigration(preview);
+    assert.equal(result.applied, true);
+    assert.equal(fs.readFileSync(path.join(target, '.env'), 'utf8'), 'SECRET=test\n');
+    assert.equal(fs.readFileSync(path.join(target, 'data', 'state.json'), 'utf8'), '{"ok":true}\n');
+    assert.equal(fs.existsSync(path.join(source, '.env')), true);
+    assert.equal(fs.existsSync(result.manifestPath!), true);
+    assert.equal(fs.statSync(path.join(target, '.env')).mode & 0o777, 0o600);
+  });
+
+  test('leaves conflicting target files unchanged', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-data-conflict-'));
+    const source = path.join(root, 'source');
+    const target = path.join(root, 'target');
+    fs.mkdirSync(path.join(source, 'data'), { recursive: true });
+    fs.mkdirSync(path.join(target, 'data'), { recursive: true });
+    fs.writeFileSync(path.join(source, 'data', 'state.json'), 'source', 'utf8');
+    fs.writeFileSync(path.join(target, 'data', 'state.json'), 'target', 'utf8');
+
+    const plan = planRuntimeDataMigration(source, target);
+    assert.equal(plan.totals.conflict, 1);
+    const result = applyRuntimeDataMigration(plan);
+
+    assert.equal(result.totals.conflict, 1);
+    assert.equal(fs.readFileSync(path.join(target, 'data', 'state.json'), 'utf8'), 'target');
+  });
+
+  test('rejects nested migration roots', () => {
+    assert.throws(
+      () => planRuntimeDataMigration('/tmp/xiaoba-source', '/tmp/xiaoba-source/profile'),
+      /must be separate, non-nested directories/,
+    );
+  });
+
+  test('does not mistake bundled data and skills directories for legacy user data', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-data-markers-'));
+    fs.mkdirSync(path.join(root, 'data'), { recursive: true });
+    fs.mkdirSync(path.join(root, 'skills'), { recursive: true });
+    assert.deepEqual(findLegacyRuntimeArtifacts(root), []);
+
+    fs.mkdirSync(path.join(root, 'logs'), { recursive: true });
+    fs.mkdirSync(path.join(root, 'data', 'sessions'), { recursive: true });
+    assert.deepEqual(findLegacyRuntimeArtifacts(root), ['logs', 'data/sessions']);
+  });
+});

--- a/tests/test-environment.test.ts
+++ b/tests/test-environment.test.ts
@@ -24,7 +24,11 @@ describe('test runner environment isolation', () => {
     });
 
     for (const key of RUNTIME_WRITE_PATH_ENV_KEYS) {
-      assert.equal(isolated[key], undefined, key);
+      if (key === 'XIAOBA_USER_DATA_DIR') {
+        assert.equal(isolated[key], '/tmp/xiaoba-test-tmp/runtime-data', key);
+      } else {
+        assert.equal(isolated[key], undefined, key);
+      }
       assert.ok(source[key], `source ${key} should remain unchanged`);
     }
     assert.equal(isolated.KEEP_ME, 'yes');
@@ -34,6 +38,8 @@ describe('test runner environment isolation', () => {
     assert.equal(isolated.TMP, '/tmp/xiaoba-test-tmp');
     assert.equal(isolated.TEMP, '/tmp/xiaoba-test-tmp');
     assert.equal(isolated.XIAOBA_APP_ROOT, '/workspace/xiaoba');
+    assert.equal(isolated.XIAOBA_TEST_SANDBOX_ROOT, '/tmp');
+    assert.equal(isolated.XIAOBA_TEST_DEFAULT_DATA_DIR, '/tmp/xiaoba-test-tmp/runtime-data');
     assert.equal(isolated.DOTENV_CONFIG_PATH, '/tmp/xiaoba-test-runner/.env');
     assert.equal(source.DOTENV_CONFIG_PATH, '/production/.env');
     assert.equal(isolated.NODE_ENV, 'test');


### PR DESCRIPTION
## What changed

- Make the default runtime Data Root stable at `~/.xiaoba`, with explicit `--data-dir` and named `--profile` support.
- Load runtime configuration from the Data Root while keeping the code root and agent workspace independent.
- Move CLI, Weixin, pet, logs, prompt overrides, skills, and profile-backed state onto the shared Data Root contract.
- Add `catsco data status` and a preview-first, copy-only `catsco data migrate` flow. It never deletes the source or overwrites conflicts.
- Print code/workspace/data identity at startup, including Git branch and commit.
- Show the same identity prominently in Agent Hub with a responsive desktop/mobile layout and Data Root copy feedback.
- Isolate automated tests in OS temporary directories.

## Why

Runtime data was inferred from `process.cwd()`. Changing Git branches or worktrees therefore silently changed sessions, logs, Cache Trace data, and configuration. Several secondary stores also independently fell back to worktree-relative paths, so fixing one caller was insufficient.

## Impact

- Source worktrees now share a stable development Data Root by default.
- Experiments can opt into isolated named profiles.
- Existing worktree data is not moved automatically. The migration command is deliberately preview-first and recoverable.
- Existing packaged Electron pet state keeps its established location.
- Auth-protected Dashboard diagnostics expose absolute runtime paths; the public summary endpoint remains minimal.

## Validation

- `npm run build`
- 70 focused runtime-data, migration, Dashboard API/HTML, config, pet, and test-isolation tests: all passed
- Independent CLI startup with a temporary Data Root and profile: passed
- Preview and applied migration against temporary output: passed; manifest created, source retained
- Dashboard API identity check: passed
- Desktop visual check: passed
- 390 px mobile visual/responsive check: passed with no horizontal overflow
- Data Root copy interaction and success feedback: passed
- `git diff --check`

Known baseline suite noise is intentionally not bundled into this PR: the repository-wide run still reports one legacy `pdf-parse` asynchronous rejection and four cloud-restore timer cancellations under load. The PDF suite passes 15/15 in isolation; these will be handled as separate, traceable fixes.
