### PR TITLE
Emit correlated model attempt lifecycles

### DIFF
--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -25,8 +25,71 @@ export interface StreamRetryInfo {
   message?: string;
 }
 
+export type ModelAttemptApiType = 'anthropic-messages' | 'openai-chat-completions' | 'openai-responses';
+export type ModelAttemptOutcome = 'started' | 'succeeded' | 'retrying' | 'failed' | 'cancelled';
+export type ModelAttemptStopReason =
+  | 'non_retryable'
+  | 'retry_limit_exhausted'
+  | 'retry_window_exhausted'
+  | 'stream_output_started'
+  | 'aborted';
+
+export interface ModelAttemptContext {
+  sessionId?: string;
+  sessionType?: string;
+  surface?: string;
+  episodeId?: string;
+  episodeNumber?: number;
+}
+
+export interface ModelAttemptRetry {
+  retryNumber: number;
+  maxRetries: number;
+  elapsedMs: number;
+  maxElapsedMs: number;
+  delayMs?: number;
+  stopReason?: ModelAttemptStopReason;
+}
+
+/**
+ * One event in the lifecycle of an actual provider invocation.
+ *
+ * A started event is followed by exactly one terminal event for the same
+ * attemptId: succeeded, retrying, failed, or cancelled. Request values are
+ * live in-memory references; sinks that persist them must snapshot and redact
+ * synchronously inside observe().
+ */
+export interface ModelAttemptEvent {
+  schema: 'xiaoba.model_attempt.v1';
+  callId: string;
+  attemptId: string;
+  attemptNumber: number;
+  timestamp: string;
+  outcome: ModelAttemptOutcome;
+  provider: 'openai' | 'anthropic';
+  model: string;
+  apiType: ModelAttemptApiType;
+  stream: boolean;
+  context?: ModelAttemptContext;
+  request: {
+    messages: readonly Message[];
+    tools: readonly ToolDefinition[];
+  };
+  durationMs?: number;
+  response?: ChatResponse;
+  error?: unknown;
+  retry?: ModelAttemptRetry;
+}
+
+export interface ModelAttemptSink {
+  observe(event: ModelAttemptEvent): void | Promise<void>;
+}
+
 export interface AIRequestOptions {
   signal?: AbortSignal;
+  /** Optional best-effort observer; it can never alter request control flow. */
+  modelAttemptSink?: ModelAttemptSink;
+  modelAttemptContext?: ModelAttemptContext;
 }
 
 /**

--- a/src/utils/ai-service.ts
+++ b/src/utils/ai-service.ts
@@ -1,7 +1,15 @@
 import { Message, ChatConfig, ChatResponse } from '../types';
 import { ConfigManager } from './config';
 import { ToolDefinition } from '../types/tool';
-import { AIProvider, AIRequestOptions, StreamCallbacks, StreamRetryInfo } from '../providers/provider';
+import {
+  AIProvider,
+  AIRequestOptions,
+  ModelAttemptEvent,
+  ModelAttemptSink,
+  ModelAttemptStopReason,
+  StreamCallbacks,
+  StreamRetryInfo,
+} from '../providers/provider';
 import { AnthropicProvider } from '../providers/anthropic-provider';
 import { OpenAIProvider } from '../providers/openai-provider';
 import { Logger } from './logger';
@@ -28,6 +36,7 @@ const EMPTY_RESPONSE_ERROR_CODE = 'EMPTY_MODEL_RESPONSE';
 const EMPTY_RESPONSE_MAX_RETRIES = 2;
 const EMPTY_RESPONSE_MAX_ELAPSED_MS = 2 * 60 * 1000;
 const EMPTY_RESPONSE_MAX_DELAY_MS = 2000;
+let modelAttemptCallSequence = 0;
 
 type ProviderKind = 'openai' | 'anthropic';
 
@@ -36,6 +45,15 @@ interface RetryPolicy {
   maxElapsedMs: number;
   baseDelayMs: number;
   maxDelayMs: number;
+}
+
+interface ModelAttemptRun {
+  callId: string;
+  sink?: ModelAttemptSink;
+  context?: AIRequestOptions['modelAttemptContext'];
+  messages: readonly Message[];
+  tools: readonly ToolDefinition[];
+  stream: boolean;
 }
 
 export class AIService {
@@ -116,6 +134,8 @@ export class AIService {
         async () => this.requireUsableResponse(await this.provider.chat(messages, tools, options)),
         undefined,
         options.signal,
+        undefined,
+        this.createModelAttemptRun(messages, tools, false, options),
       );
     } catch (error: any) {
       throw this.wrapError(error);
@@ -151,6 +171,7 @@ export class AIService {
         callbacks,
         options.signal,
         () => allowStreamRetry || !hasStreamedText,
+        this.createModelAttemptRun(messages, tools, true, options),
       );
       callbacks?.onComplete?.(result);
       return result;
@@ -341,39 +362,83 @@ export class AIService {
     callbacks?: StreamCallbacks,
     signal?: AbortSignal,
     shouldRetry?: (error: any, attempt: number) => boolean,
+    attemptRun?: ModelAttemptRun,
   ): Promise<T> {
-    let lastError: any;
-    const policy = this.resolveRetryPolicy();
     const startedAt = Date.now();
 
     for (let attempt = 0; ; attempt++) {
+      this.throwIfAborted(signal);
+      const attemptStartedAt = Date.now();
+      const attemptNumber = attempt + 1;
+      this.emitModelAttempt(attemptRun, attemptNumber, {
+        outcome: 'started',
+      });
       try {
-        this.throwIfAborted(signal);
-        return await fn();
+        const result = await fn();
+        this.emitModelAttempt(attemptRun, attemptNumber, {
+          outcome: 'succeeded',
+          durationMs: Date.now() - attemptStartedAt,
+          response: result as ChatResponse,
+        });
+        return result;
       } catch (error: any) {
-        lastError = error;
-
         if (this.isAbortError(error) || signal?.aborted) {
+          const policy = this.resolveRetryPolicy(error);
+          this.emitModelAttempt(attemptRun, attemptNumber, {
+            outcome: 'cancelled',
+            durationMs: Date.now() - attemptStartedAt,
+            error,
+            retry: {
+              retryNumber: attempt,
+              maxRetries: policy.maxRetries,
+              elapsedMs: Date.now() - startedAt,
+              maxElapsedMs: policy.maxElapsedMs,
+              stopReason: 'aborted',
+            },
+          });
           throw this.createAbortError();
         }
 
         const policy = this.resolveRetryPolicy(error);
         const retryAttempt = attempt + 1;
-        if (
-          retryAttempt > policy.maxRetries
-          || !this.isRetryable(error)
-          || shouldRetry?.(error, retryAttempt) === false
-        ) {
-          throw error;
-        }
-
         const elapsedMs = Date.now() - startedAt;
-        if (elapsedMs >= policy.maxElapsedMs) {
+        const stopReason = this.resolveRetryStopReason(
+          error,
+          retryAttempt,
+          policy,
+          elapsedMs,
+          shouldRetry,
+        );
+        if (stopReason) {
+          this.emitModelAttempt(attemptRun, attemptNumber, {
+            outcome: 'failed',
+            durationMs: Date.now() - attemptStartedAt,
+            error,
+            retry: {
+              retryNumber: attempt,
+              maxRetries: policy.maxRetries,
+              elapsedMs,
+              maxElapsedMs: policy.maxElapsedMs,
+              stopReason,
+            },
+          });
           throw error;
         }
 
         // 计算等待时间：优先用 Retry-After，否则指数退避
         const delay = this.resolveRetryDelayMs(error, retryAttempt, policy, elapsedMs);
+        this.emitModelAttempt(attemptRun, attemptNumber, {
+          outcome: 'retrying',
+          durationMs: Date.now() - attemptStartedAt,
+          error,
+          retry: {
+            retryNumber: retryAttempt,
+            maxRetries: policy.maxRetries,
+            delayMs: delay,
+            elapsedMs,
+            maxElapsedMs: policy.maxElapsedMs,
+          },
+        });
 
         const status = this.extractStatus(error) || this.extractErrorCode(error) || 'unknown';
         const retryInfo: StreamRetryInfo = {
@@ -395,8 +460,81 @@ export class AIService {
         await this.sleepWithAbort(delay, signal);
       }
     }
+  }
 
-    throw lastError;
+  private resolveRetryStopReason(
+    error: any,
+    retryAttempt: number,
+    policy: RetryPolicy,
+    elapsedMs: number,
+    shouldRetry?: (error: any, attempt: number) => boolean,
+  ): ModelAttemptStopReason | undefined {
+    if (!this.isRetryable(error)) return 'non_retryable';
+    if (shouldRetry?.(error, retryAttempt) === false) return 'stream_output_started';
+    if (retryAttempt > policy.maxRetries) return 'retry_limit_exhausted';
+    if (elapsedMs >= policy.maxElapsedMs) return 'retry_window_exhausted';
+    return undefined;
+  }
+
+  private createModelAttemptRun(
+    messages: readonly Message[],
+    tools: readonly ToolDefinition[] | undefined,
+    stream: boolean,
+    options: AIRequestOptions,
+  ): ModelAttemptRun | undefined {
+    if (!options.modelAttemptSink) return undefined;
+    modelAttemptCallSequence = (modelAttemptCallSequence + 1) % Number.MAX_SAFE_INTEGER;
+    return {
+      callId: `${Date.now().toString(36)}-${process.pid.toString(36)}-${modelAttemptCallSequence.toString(36)}`,
+      sink: options.modelAttemptSink,
+      context: options.modelAttemptContext ? { ...options.modelAttemptContext } : undefined,
+      messages,
+      tools: tools || [],
+      stream,
+    };
+  }
+
+  private emitModelAttempt(
+    run: ModelAttemptRun | undefined,
+    attemptNumber: number,
+    fields: Pick<ModelAttemptEvent, 'outcome'>
+      & Partial<Pick<ModelAttemptEvent, 'durationMs' | 'response' | 'error' | 'retry'>>,
+  ): void {
+    if (!run?.sink) return;
+    const event: ModelAttemptEvent = {
+      schema: 'xiaoba.model_attempt.v1',
+      callId: run.callId,
+      attemptId: `${run.callId}:${attemptNumber}`,
+      attemptNumber,
+      timestamp: new Date().toISOString(),
+      outcome: fields.outcome,
+      provider: this.config.provider as ProviderKind,
+      model: this.config.model || 'unknown',
+      apiType: this.config.provider === 'anthropic'
+        ? 'anthropic-messages'
+        : this.config.openaiApiMode === 'responses'
+          ? 'openai-responses'
+          : 'openai-chat-completions',
+      stream: run.stream,
+      ...(run.context ? { context: run.context } : {}),
+      request: {
+        messages: run.messages,
+        tools: run.tools,
+      },
+      ...(fields.durationMs === undefined ? {} : { durationMs: fields.durationMs }),
+      ...(fields.response === undefined ? {} : { response: fields.response }),
+      ...(fields.error === undefined ? {} : { error: fields.error }),
+      ...(fields.retry === undefined ? {} : { retry: fields.retry }),
+    };
+
+    try {
+      const result = run.sink.observe(event);
+      if (result && typeof (result as Promise<void>).then === 'function') {
+        Promise.resolve(result).catch(() => undefined);
+      }
+    } catch {
+      // Diagnostics about diagnostics must never affect the provider request.
+    }
   }
 
   private resolveRetryPolicy(error?: any): RetryPolicy {

--- a/tests/model-attempt-lifecycle.test.ts
+++ b/tests/model-attempt-lifecycle.test.ts
@@ -1,0 +1,207 @@
+import { afterEach, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AIService } from '../src/utils/ai-service';
+import type {
+  ModelAttemptEvent,
+  ModelAttemptSink,
+  StreamCallbacks,
+} from '../src/providers/provider';
+import type { ChatResponse, Message } from '../src/types';
+import type { ToolDefinition } from '../src/types/tool';
+
+const originalMaxRetries = process.env.CATSCO_MODEL_RETRY_MAX_RETRIES;
+
+afterEach(() => {
+  restoreEnv('CATSCO_MODEL_RETRY_MAX_RETRIES', originalMaxRetries);
+});
+
+test('records every provider retry as a correlated attempt lifecycle', async () => {
+  const service = createTestService({ openaiApiMode: 'responses' });
+  const events: ModelAttemptEvent[] = [];
+  let calls = 0;
+  const response: ChatResponse = {
+    content: 'recovered',
+    usage: {
+      promptTokens: 100,
+      completionTokens: 10,
+      totalTokens: 110,
+      cachedReadTokens: 60,
+    },
+  };
+  (service as any).sleepWithAbort = async () => undefined;
+  (service as any).provider = {
+    chat: async () => {
+      calls += 1;
+      if (calls === 1) {
+        throw Object.assign(new Error('temporary outage'), {
+          response: { status: 503, headers: { 'retry-after': '0' } },
+        });
+      }
+      return response;
+    },
+    chatStream: async () => response,
+  };
+  const messages: Message[] = [{ role: 'user', content: 'hello' }];
+  const tools: ToolDefinition[] = [{
+    name: 'lookup',
+    description: 'look something up',
+    parameters: { type: 'object', properties: {} },
+  }];
+
+  const result = await service.chat(messages, tools, {
+    modelAttemptSink: collectingSink(events),
+    modelAttemptContext: {
+      sessionId: 'session:test',
+      surface: 'cli',
+      episodeNumber: 4,
+    },
+  });
+
+  assert.equal(result, response);
+  assert.deepEqual(events.map(event => event.outcome), [
+    'started',
+    'retrying',
+    'started',
+    'succeeded',
+  ]);
+  assert.equal(new Set(events.map(event => event.callId)).size, 1);
+  assert.deepEqual(events.map(event => event.attemptNumber), [1, 1, 2, 2]);
+  assert.equal(events[0].attemptId, events[1].attemptId);
+  assert.equal(events[2].attemptId, events[3].attemptId);
+  assert.notEqual(events[0].attemptId, events[2].attemptId);
+  assert.equal(events[0].apiType, 'openai-responses');
+  assert.equal(events[0].request.messages, messages);
+  assert.equal(events[0].request.tools, tools);
+  assert.equal(events[0].context?.episodeNumber, 4);
+  assert.equal(events[1].retry?.retryNumber, 1);
+  assert.equal(events[1].retry?.delayMs, 0);
+  assert.equal(events[3].response?.usage?.cachedReadTokens, 60);
+});
+
+test('records a non-retryable provider rejection as the terminal attempt', async () => {
+  process.env.CATSCO_MODEL_RETRY_MAX_RETRIES = '0';
+  const service = createTestService();
+  const events: ModelAttemptEvent[] = [];
+  (service as any).provider = {
+    chat: async () => {
+      throw Object.assign(new Error('invalid schema'), { response: { status: 400 } });
+    },
+    chatStream: async () => ({ content: 'unused' }),
+  };
+
+  await assert.rejects(
+    () => service.chat([], undefined, { modelAttemptSink: collectingSink(events) }),
+    /API错误 \(400\): invalid schema/,
+  );
+
+  assert.deepEqual(events.map(event => event.outcome), ['started', 'failed']);
+  assert.equal(events[1].retry?.stopReason, 'non_retryable');
+  assert.equal(events[1].retry?.retryNumber, 0);
+  assert.equal(events[1].error instanceof Error, true);
+});
+
+test('distinguishes a stream failure after visible output from a retryable failure', async () => {
+  const service = createTestService();
+  const events: ModelAttemptEvent[] = [];
+  let calls = 0;
+  (service as any).provider = {
+    chat: async () => ({ content: 'unused' }),
+    chatStream: async (_messages: unknown, _tools: unknown, callbacks?: StreamCallbacks) => {
+      calls += 1;
+      callbacks?.onText?.('partial');
+      throw Object.assign(new Error('stream interrupted'), { response: { status: 503 } });
+    },
+  };
+
+  await assert.rejects(
+    () => service.chatStream([], undefined, { onText: () => undefined }, {
+      modelAttemptSink: collectingSink(events),
+    }),
+    /API错误 \(503\): stream interrupted/,
+  );
+
+  assert.equal(calls, 1);
+  assert.deepEqual(events.map(event => event.outcome), ['started', 'failed']);
+  assert.equal(events[1].retry?.stopReason, 'stream_output_started');
+  assert.equal(events[0].stream, true);
+});
+
+test('records an in-flight abort but does not invent a provider attempt before invocation', async () => {
+  const service = createTestService();
+  const events: ModelAttemptEvent[] = [];
+  const controller = new AbortController();
+  let calls = 0;
+  (service as any).provider = {
+    chat: async () => {
+      calls += 1;
+      const error = new Error('cancelled by caller');
+      error.name = 'AbortError';
+      throw error;
+    },
+    chatStream: async () => ({ content: 'unused' }),
+  };
+
+  await assert.rejects(
+    () => service.chat([], undefined, {
+      signal: controller.signal,
+      modelAttemptSink: collectingSink(events),
+    }),
+    /请求已取消/,
+  );
+  assert.equal(calls, 1);
+  assert.deepEqual(events.map(event => event.outcome), ['started', 'cancelled']);
+  assert.equal(events[1].retry?.stopReason, 'aborted');
+
+  events.length = 0;
+  controller.abort();
+  await assert.rejects(
+    () => service.chat([], undefined, {
+      signal: controller.signal,
+      modelAttemptSink: collectingSink(events),
+    }),
+    /请求已取消/,
+  );
+  assert.equal(calls, 1);
+  assert.deepEqual(events, []);
+});
+
+test('sync throws and async rejections from a sink never alter the model result', async () => {
+  const service = createTestService();
+  (service as any).provider = {
+    chat: async () => ({ content: 'ok' }),
+    chatStream: async () => ({ content: 'unused' }),
+  };
+  let observations = 0;
+  const sink: ModelAttemptSink = {
+    observe(event) {
+      observations += 1;
+      if (event.outcome === 'started') return Promise.reject(new Error('async observer failure'));
+      throw new Error('sync observer failure');
+    },
+  };
+
+  const result = await service.chat([], undefined, { modelAttemptSink: sink });
+  await new Promise(resolve => setImmediate(resolve));
+
+  assert.deepEqual(result, { content: 'ok' });
+  assert.equal(observations, 2);
+});
+
+function collectingSink(events: ModelAttemptEvent[]): ModelAttemptSink {
+  return { observe: event => { events.push(event); } };
+}
+
+function createTestService(overrides: Record<string, unknown> = {}): AIService {
+  return new AIService({
+    provider: 'openai',
+    apiUrl: 'https://primary.example.test/v1',
+    apiKey: 'primary-key',
+    model: 'primary-model',
+    ...overrides,
+  });
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}


### PR DESCRIPTION
## What changed

- Add a typed, optional `ModelAttemptSink` at the AIService/provider boundary.
- Correlate every real provider invocation with a call ID, attempt ID, and one-based attempt number.
- Emit `started` followed by exactly one terminal outcome: `succeeded`, `retrying`, `failed`, or `cancelled`.
- Include provider/API dialect, session/episode context, exact request references, successful usage, retry timing, and the original in-memory error for downstream sanitization.
- Distinguish non-retryable failures, exhausted retry counts/windows, streamed-output stops, and aborts.
- Consume both synchronous throws and asynchronous rejections from observers so diagnostics can never alter model control flow.
- Avoid creating attempt IDs or doing observer work when no sink is configured.

## Why

The existing Cache Trace is recorded only after a whole model call succeeds, while interruption diagnostics are recorded only after the whole conversation turn fails. Retries that recover, failed provider attempts, and cancellations therefore cannot be correlated or measured reliably. This PR creates a small, storage-agnostic lifecycle boundary that both sidecars can consume without coupling logging or Dashboard code to retry logic.

## Impact

- No observer is enabled by default and no files or UI are added here.
- Existing retry and user-facing behavior remain unchanged.
- Request objects are live in-memory references. A persistence sink must snapshot and redact synchronously, as documented by the interface.
- This is the foundation for follow-up integration into Cache Trace PR #290 and interruption diagnostics PR #291.

## Validation

- `npm run build`
- Existing AIService suite plus new attempt lifecycle suite: 21/21 passed
- Independent compiled-runtime smoke: `503 -> retry -> success` produced `started, retrying, started, succeeded` and preserved cache usage
- Pre-aborted requests produce no invented wire attempt
- In-flight aborts produce a correlated cancelled terminal event
- Sync and async observer failures do not alter a successful model response
- Independent CLI `--help` startup passed
- `git diff --check`

Repository-wide test result: 1,288 passed, 0 cancelled, 8 skipped, with the same one legacy `pdf-parse` asynchronous rejection already reproduced on `origin/main`. That unrelated baseline failure is intentionally not mixed into this PR.
