### PR TITLE
fix: scope provider replay state to model boundary

### DIFF
--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -495,6 +495,7 @@ export class ConversationRunner {
               content: restored.visibleText || null,
               toolCalls: restoredToolCalls,
               providerContent: undefined,
+              providerState: undefined,
             };
           }
         }
@@ -595,6 +596,7 @@ export class ConversationRunner {
         content: stripAssistantTranscriptArtifacts(response.content || ''),
         tool_calls: response.toolCalls,
         providerContent: response.providerContent,
+        providerState: response.providerState,
       };
       const executionRecords: ToolExecutionRecord[] = [];
       let shouldPauseTurn = false;
@@ -938,7 +940,7 @@ export class ConversationRunner {
         ? { tool_calls: transcriptToolCalls }
         : {}),
       ...(providerContent?.length
-        ? { providerContent }
+        ? { providerContent, providerState: assistantMsg.providerState }
         : {}),
     };
 
@@ -1644,13 +1646,19 @@ export class ConversationRunner {
           ...message,
           tool_calls: toolCalls,
           providerContent,
+          providerState: providerContent ? message.providerState : undefined,
         });
         continue;
       }
 
       const content = contentToString(message.content).trim();
       if (content) {
-        repaired.push({ ...message, tool_calls: undefined, providerContent: undefined });
+        repaired.push({
+          ...message,
+          tool_calls: undefined,
+          providerContent: undefined,
+          providerState: undefined,
+        });
       }
     }
 
@@ -1670,6 +1678,7 @@ export class ConversationRunner {
       content: `${content.slice(0, maxChars)}\n...[已截断以适配模型上下文预算，原始 ${content.length} 字符]`,
       tool_calls: undefined,
       providerContent: undefined,
+      providerState: undefined,
     };
   }
 
@@ -1698,6 +1707,7 @@ export class ConversationRunner {
 
     if (content.length > maxChars || aggressive) {
       delete next.providerContent;
+      delete next.providerState;
     }
 
     return next;

--- a/src/providers/anthropic-provider.ts
+++ b/src/providers/anthropic-provider.ts
@@ -1,10 +1,11 @@
 import Anthropic from '@anthropic-ai/sdk';
-import { Message, ChatConfig, ChatResponse, ContentBlock } from '../types';
+import { Message, ChatConfig, ChatResponse, ContentBlock, type ProviderStateReference } from '../types';
 import { ToolDefinition } from '../types/tool';
 import { AIProvider, AIRequestOptions, StreamCallbacks } from './provider';
 import { ContextDebugLogger } from '../utils/context-debug-logger';
 import { resolveMaxTokens } from './output-limits';
 import { applyAnthropicReasoningOptions } from '../utils/reasoning-effort';
+import { createProviderStateReference, isProviderStateCompatible } from './provider-state';
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === 'object' && !Array.isArray(value));
@@ -55,6 +56,14 @@ export class AnthropicProvider implements AIProvider {
    */
   private normalizeBaseURL(url: string): string {
     return url.replace(/\/+$/, '').replace(/\/v1\/messages$/, '').replace(/\/v1$/, '');
+  }
+
+  private providerStateReference(): ProviderStateReference {
+    return createProviderStateReference({
+      apiType: 'anthropic-messages',
+      endpoint: this.normalizeBaseURL(this.apiUrl),
+      model: this.model,
+    });
   }
 
   /**
@@ -331,6 +340,9 @@ export class AnthropicProvider implements AIProvider {
     if (!Array.isArray(msg.providerContent) || msg.providerContent.length === 0) {
       return undefined;
     }
+    if (!isProviderStateCompatible(msg.providerState, this.providerStateReference())) {
+      return undefined;
+    }
 
     const retainedToolCallIds = new Set((msg.tool_calls || []).map(toolCall => toolCall.id));
     const blocks: any[] = [];
@@ -431,6 +443,7 @@ export class AnthropicProvider implements AIProvider {
       usage,
       stopReason: (response as any)?.stop_reason || undefined,
       ...(providerContent.length > 0 ? { providerContent } : {}),
+      ...(providerContent.length > 0 ? { providerState: this.providerStateReference() } : {}),
     };
   }
 

--- a/src/providers/openai-provider.ts
+++ b/src/providers/openai-provider.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { createHash } from 'crypto';
 import { StringDecoder } from 'string_decoder';
-import { Message, ChatConfig, ChatResponse, ContentBlock } from '../types';
+import { Message, ChatConfig, ChatResponse, ContentBlock, type ProviderApiType, type ProviderStateReference } from '../types';
 import { ToolDefinition } from '../types/tool';
 import { AIProvider, AIRequestOptions, StreamCallbacks } from './provider';
 import { ContextDebugLogger } from '../utils/context-debug-logger';
@@ -13,6 +13,7 @@ import {
   supportsReasoningSwitch,
 } from '../utils/reasoning-effort';
 import { openAIApiModeOrDefault } from '../utils/openai-api-mode';
+import { createProviderStateReference, isProviderStateCompatible } from './provider-state';
 
 /**
  * OpenAI Provider
@@ -112,6 +113,7 @@ export class OpenAIProvider implements AIProvider {
 
   private extractOpenAIReasoningContent(message: Message): string | undefined {
     if (!this.shouldReplayOpenAIReasoningContent()) return undefined;
+    if (!this.canReplayProviderContent(message, 'openai-chat-completions')) return undefined;
     if (!Array.isArray(message.providerContent) || !message.tool_calls?.length) return undefined;
     const block = message.providerContent.find(item =>
       item
@@ -130,6 +132,18 @@ export class OpenAIProvider implements AIProvider {
       apiUrl: this.apiUrl,
       model: this.model,
     });
+  }
+
+  private providerStateReference(apiType: ProviderApiType): ProviderStateReference {
+    return createProviderStateReference({
+      apiType,
+      endpoint: apiType === 'openai-responses' ? this.responsesUrl : this.chatCompletionsUrl,
+      model: this.model,
+    });
+  }
+
+  private canReplayProviderContent(message: Message, apiType: ProviderApiType): boolean {
+    return isProviderStateCompatible(message.providerState, this.providerStateReference(apiType));
   }
 
   private sanitizeContent(content: Message['content']): any {
@@ -337,14 +351,18 @@ export class OpenAIProvider implements AIProvider {
           ? Array.from(toolCallsMap.values())
           : undefined;
 
+        const providerContent = toolCalls && fullReasoningContent.trim()
+          ? buildOpenAIProviderContentFromToolCalls(toolCalls, fullReasoningContent.trim())
+          : undefined;
         const result: ChatResponse = {
           content: fullContent || null,
           toolCalls,
           usage: streamUsage,
           stopReason: finishReason,
-          ...(toolCalls && fullReasoningContent.trim()
-            ? { providerContent: buildOpenAIProviderContentFromToolCalls(toolCalls, fullReasoningContent.trim()) }
-            : {}),
+          ...(providerContent ? {
+            providerContent,
+            providerState: this.providerStateReference('openai-chat-completions'),
+          } : {}),
         };
 
         ContextDebugLogger.dumpSdkBoundary('after', undefined, {
@@ -416,7 +434,9 @@ export class OpenAIProvider implements AIProvider {
       }
 
       if (message.role === 'assistant' && message.tool_calls?.length) {
-        const replayItems = (message.providerContent || [])
+        const replayItems = (this.canReplayProviderContent(message, 'openai-responses')
+          ? message.providerContent || []
+          : [])
           .filter(item => this.isResponsesReplayItem(item))
           .map(item => JSON.parse(JSON.stringify(item)));
         if (replayItems.length > 0) {
@@ -626,6 +646,7 @@ export class OpenAIProvider implements AIProvider {
       usage: this.parseResponsesUsage(response?.usage),
       stopReason,
       ...(providerContent?.length ? { providerContent } : {}),
+      ...(providerContent?.length ? { providerState: this.providerStateReference('openai-responses') } : {}),
     };
   }
 
@@ -770,7 +791,7 @@ export class OpenAIProvider implements AIProvider {
     });
   }
 
-  private buildOpenAIProviderContent(message: any): Pick<ChatResponse, 'providerContent'> {
+  private buildOpenAIProviderContent(message: any): Pick<ChatResponse, 'providerContent' | 'providerState'> {
     const toolCalls = Array.isArray(message?.tool_calls) ? message.tool_calls : [];
     const reasoningContent = typeof message?.reasoning_content === 'string'
       ? message.reasoning_content.trim()
@@ -778,6 +799,7 @@ export class OpenAIProvider implements AIProvider {
     if (!toolCalls.length || !reasoningContent) return {};
     return {
       providerContent: buildOpenAIProviderContentFromToolCalls(toolCalls, reasoningContent),
+      providerState: this.providerStateReference('openai-chat-completions'),
     };
   }
 }

--- a/src/providers/provider-state.ts
+++ b/src/providers/provider-state.ts
@@ -1,0 +1,41 @@
+import { createHash } from 'crypto';
+import type { ProviderApiType, ProviderStateReference } from '../types';
+
+export function createProviderStateReference(input: {
+  apiType: ProviderApiType;
+  endpoint: string;
+  model: string;
+}): ProviderStateReference {
+  return {
+    schema: 'xiaoba.provider_state.v1',
+    apiType: input.apiType,
+    model: String(input.model || '').trim(),
+    endpointFingerprint: createHash('sha256')
+      .update(normalizeEndpointIdentity(input.endpoint))
+      .digest('hex')
+      .slice(0, 16),
+  };
+}
+
+export function isProviderStateCompatible(
+  actual: ProviderStateReference | undefined,
+  expected: ProviderStateReference,
+): boolean {
+  return actual?.schema === expected.schema
+    && actual.apiType === expected.apiType
+    && actual.model === expected.model
+    && actual.endpointFingerprint === expected.endpointFingerprint;
+}
+
+function normalizeEndpointIdentity(raw: string): string {
+  const trimmed = String(raw || '').trim();
+  try {
+    const url = new URL(trimmed);
+    url.protocol = url.protocol.toLowerCase();
+    url.hostname = url.hostname.toLowerCase();
+    url.hash = '';
+    return url.toString();
+  } catch {
+    return trimmed;
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,6 +3,15 @@ export type ContentBlock =
   | { type: 'image'; source: { type: 'base64'; media_type: 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp'; data: string } };
 
 export type ProviderContentBlock = Record<string, unknown> & { type: string };
+export type ProviderApiType = 'anthropic-messages' | 'openai-chat-completions' | 'openai-responses';
+
+/** Opaque scope that prevents provider-only replay state crossing model/API boundaries. */
+export interface ProviderStateReference {
+  schema: 'xiaoba.provider_state.v1';
+  apiType: ProviderApiType;
+  model: string;
+  endpointFingerprint: string;
+}
 export type ReasoningEffort = 'default' | 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'disabled';
 export type OpenAIApiMode = 'chat_completions' | 'responses';
 
@@ -53,6 +62,8 @@ export interface Message {
   __remoteContextWatermarks?: Record<string, number>;
   /** Provider 原始 assistant content blocks，仅用于下次请求回放，不展示给用户。 */
   providerContent?: ProviderContentBlock[];
+  /** Identity of the provider boundary that produced providerContent. Never sent verbatim. */
+  providerState?: ProviderStateReference;
 }
 
 export interface ChatConfig {
@@ -122,6 +133,8 @@ export interface ChatResponse {
   stopReason?: string;
   /** Provider 原始 assistant content blocks，仅用于下次请求回放，不展示给用户。 */
   providerContent?: ProviderContentBlock[];
+  /** Identity of the provider boundary that produced providerContent. Never sent verbatim. */
+  providerState?: ProviderStateReference;
 }
 
 export interface CommandOptions {

--- a/src/utils/session-store.ts
+++ b/src/utils/session-store.ts
@@ -70,12 +70,13 @@ function sanitizeForPersistence(messages: Message[]): Message[] {
         ...message,
         content: summarizeHiddenReplayToolResult(message),
         providerContent: undefined,
+        providerState: undefined,
       });
       continue;
     }
 
     if (message.role !== 'assistant') {
-      durable.push({ ...message, providerContent: undefined });
+      durable.push({ ...message, providerContent: undefined, providerState: undefined });
       continue;
     }
 
@@ -88,6 +89,7 @@ function sanitizeForPersistence(messages: Message[]): Message[] {
         ...message,
         content: publicText || null,
         providerContent: undefined,
+        providerState: undefined,
       });
       continue;
     }
@@ -99,11 +101,12 @@ function sanitizeForPersistence(messages: Message[]): Message[] {
           ...message,
           content: cleanedText,
           providerContent: undefined,
+          providerState: undefined,
         });
         continue;
       }
     } else if (message.content !== null) {
-      durable.push({ ...message, providerContent: undefined });
+      durable.push({ ...message, providerContent: undefined, providerState: undefined });
       continue;
     }
 
@@ -112,6 +115,7 @@ function sanitizeForPersistence(messages: Message[]): Message[] {
         ...message,
         content: null,
         providerContent: undefined,
+        providerState: undefined,
       });
     }
   }

--- a/tests/anthropic-provider-runtime-feedback.test.ts
+++ b/tests/anthropic-provider-runtime-feedback.test.ts
@@ -366,6 +366,7 @@ describe('AnthropicProvider runtime feedback boundary', () => {
           { type: 'thinking', thinking: 'hidden chain', signature: 'sig_123' },
           { type: 'tool_use', id: 'call_1', name: 'execute_shell', input: { command: 'git status' } },
         ],
+        providerState: (provider as any).providerStateReference(),
       },
       {
         role: 'tool',
@@ -382,6 +383,47 @@ describe('AnthropicProvider runtime feedback boundary', () => {
         { type: 'thinking', thinking: 'hidden chain', signature: 'sig_123' },
         { type: 'tool_use', id: 'call_1', name: 'execute_shell', input: { command: 'git status' } },
       ],
+    });
+  });
+
+  test('falls back to canonical tool calls after an Anthropic model switch', () => {
+    const source = new AnthropicProvider({
+      apiKey: 'test-key',
+      apiUrl: 'https://relay.catsco.cc/anthropic/v1/messages',
+      model: 'MiniMax-M3',
+    });
+    const target = new AnthropicProvider({
+      apiKey: 'test-key',
+      apiUrl: 'https://relay.catsco.cc/anthropic/v1/messages',
+      model: 'claude-sonnet-compatible',
+    });
+    const transformed = (target as any).transformMessages([
+      { role: 'user', content: 'clean repo' },
+      {
+        role: 'assistant',
+        content: null,
+        tool_calls: [{
+          id: 'call_1',
+          type: 'function',
+          function: { name: 'execute_shell', arguments: '{"command":"git status"}' },
+        }],
+        providerContent: [
+          { type: 'thinking', thinking: 'hidden chain', signature: 'sig_123' },
+          { type: 'tool_use', id: 'call_1', name: 'execute_shell', input: { command: 'git status' } },
+        ],
+        providerState: (source as any).providerStateReference(),
+      },
+      { role: 'tool', tool_call_id: 'call_1', name: 'execute_shell', content: 'clean' },
+    ]);
+
+    assert.deepStrictEqual(transformed.messages[1], {
+      role: 'assistant',
+      content: [{
+        type: 'tool_use',
+        id: 'call_1',
+        name: 'execute_shell',
+        input: { command: 'git status' },
+      }],
     });
   });
 });

--- a/tests/conversation-runner-transcript-normalization.test.ts
+++ b/tests/conversation-runner-transcript-normalization.test.ts
@@ -421,11 +421,18 @@ test('runner keeps Responses reasoning and matching function calls in the tool t
       arguments: '{"command":"echo ok"}',
     },
   ];
+  const providerState = {
+    schema: 'xiaoba.provider_state.v1' as const,
+    apiType: 'openai-responses' as const,
+    model: 'gpt-test',
+    endpointFingerprint: '0123456789abcdef',
+  };
   const mock = createMockAI([
     {
       content: null,
       toolCalls: [toolCall],
       providerContent,
+      providerState,
       usage: {
         promptTokens: 100,
         completionTokens: 20,
@@ -457,6 +464,8 @@ test('runner keeps Responses reasoning and matching function calls in the tool t
   assert.equal(result.response, 'done');
   assert.deepEqual(assistantWithTool?.providerContent, providerContent);
   assert.deepEqual(secondRequestAssistant?.providerContent, providerContent);
+  assert.deepEqual(assistantWithTool?.providerState, providerState);
+  assert.deepEqual(secondRequestAssistant?.providerState, providerState);
 });
 
 test('runner injects tool target context into provider transcript only', async () => {

--- a/tests/openai-provider-responses.test.ts
+++ b/tests/openai-provider-responses.test.ts
@@ -357,6 +357,7 @@ describe('OpenAIProvider Responses API mode', () => {
           content: first.content,
           tool_calls: first.toolCalls,
           providerContent: first.providerContent,
+          providerState: first.providerState,
         },
         { role: 'tool', tool_call_id: 'call_1', content: 'found cats' },
       ];
@@ -378,6 +379,38 @@ describe('OpenAIProvider Responses API mode', () => {
     } finally {
       (axios as any).post = originalPost;
     }
+  });
+
+  test('falls back to canonical function calls when Responses replay state came from another endpoint', () => {
+    const source = createProvider();
+    const target = new OpenAIProvider({
+      apiKey: 'test-key',
+      apiUrl: 'https://other.example.test/v1',
+      model: 'gpt-test',
+      provider: 'openai',
+      openaiApiMode: 'responses',
+    });
+    const body = (target as any).buildResponsesRequestBody([{
+      role: 'assistant',
+      content: null,
+      tool_calls: [{
+        id: 'call_1',
+        type: 'function',
+        function: { name: 'lookup', arguments: '{"query":"cats"}' },
+      }],
+      providerContent: [
+        { type: 'reasoning', id: 'rs_1', encrypted_content: 'opaque' },
+        { type: 'function_call', id: 'fc_1', call_id: 'call_1', name: 'lookup', arguments: '{"query":"cats"}' },
+      ],
+      providerState: (source as any).providerStateReference('openai-responses'),
+    }]);
+
+    assert.deepEqual(body.input, [{
+      type: 'function_call',
+      call_id: 'call_1',
+      name: 'lookup',
+      arguments: '{"query":"cats"}',
+    }]);
   });
 
   test('streams visible text and resolves from the terminal Responses event', async () => {

--- a/tests/openai-provider-runtime-feedback.test.ts
+++ b/tests/openai-provider-runtime-feedback.test.ts
@@ -293,6 +293,7 @@ describe('OpenAIProvider runtime feedback boundary', () => {
         content: null,
         tool_calls: result.toolCalls,
         providerContent: result.providerContent,
+        providerState: result.providerState,
       }]);
 
       assert.equal(replayBody.messages[0].reasoning_content, 'private chain for replay');
@@ -321,6 +322,7 @@ describe('OpenAIProvider runtime feedback boundary', () => {
         { type: 'openai_reasoning', reasoning_content: 'private deepseek chain' },
         { type: 'tool_use', id: 'call_1', name: 'lookup', input: { query: 'cats' } },
       ],
+      providerState: (provider as any).providerStateReference('openai-chat-completions'),
     }]);
 
     assert.equal(body.messages[0].reasoning_content, undefined);
@@ -345,9 +347,41 @@ describe('OpenAIProvider runtime feedback boundary', () => {
         { type: 'openai_reasoning', reasoning_content: 'private deepseek chain' },
         { type: 'tool_use', id: 'call_1', name: 'lookup', input: { query: 'cats' } },
       ],
+      providerState: (provider as any).providerStateReference('openai-chat-completions'),
     }]);
 
     assert.equal(body.messages[0].reasoning_content, 'private deepseek chain');
+  });
+
+  test('does not replay DeepSeek reasoning content from another model scope', () => {
+    const source = new OpenAIProvider({
+      apiKey: 'test-key',
+      apiUrl: 'https://api.deepseek.com/v1',
+      model: 'deepseek-v4-pro',
+    });
+    const target = new OpenAIProvider({
+      apiKey: 'test-key',
+      apiUrl: 'https://api.deepseek.com/v1',
+      model: 'deepseek-v4-flash',
+    });
+
+    const body = (target as any).buildRequestBody([{
+      role: 'assistant',
+      content: null,
+      tool_calls: [{
+        id: 'call_1',
+        type: 'function',
+        function: { name: 'lookup', arguments: '{"query":"cats"}' },
+      }],
+      providerContent: [
+        { type: 'openai_reasoning', reasoning_content: 'model-scoped chain' },
+        { type: 'tool_use', id: 'call_1', name: 'lookup', input: { query: 'cats' } },
+      ],
+      providerState: (source as any).providerStateReference('openai-chat-completions'),
+    }]);
+
+    assert.equal(body.messages[0].reasoning_content, undefined);
+    assert.equal(body.messages[0].tool_calls[0].id, 'call_1');
   });
 
   test('preserves finish reason for stream responses', async () => {
@@ -463,6 +497,7 @@ describe('OpenAIProvider runtime feedback boundary', () => {
         content: null,
         tool_calls: result.toolCalls,
         providerContent: result.providerContent,
+        providerState: result.providerState,
       }]);
 
       assert.equal(replayBody.messages[0].reasoning_content, 'private stream chain');

--- a/tests/provider-state.test.ts
+++ b/tests/provider-state.test.ts
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  createProviderStateReference,
+  isProviderStateCompatible,
+} from '../src/providers/provider-state';
+
+test('provider replay state is scoped to API type, model, and endpoint identity', () => {
+  const baseline = createProviderStateReference({
+    apiType: 'openai-responses',
+    endpoint: 'https://API.OpenAI.com/v1/responses#ignored',
+    model: 'gpt-test',
+  });
+  const equivalent = createProviderStateReference({
+    apiType: 'openai-responses',
+    endpoint: 'https://api.openai.com/v1/responses',
+    model: 'gpt-test',
+  });
+
+  assert.equal(isProviderStateCompatible(baseline, equivalent), true);
+  assert.equal(isProviderStateCompatible(undefined, equivalent), false);
+  assert.equal(isProviderStateCompatible({ ...baseline, model: 'gpt-other' }, equivalent), false);
+  assert.equal(isProviderStateCompatible({ ...baseline, apiType: 'openai-chat-completions' }, equivalent), false);
+  assert.match(baseline.endpointFingerprint, /^[a-f0-9]{16}$/);
+  assert.doesNotMatch(JSON.stringify(baseline), /api\.openai\.com/i);
+});

--- a/tests/session-lifecycle-manager.test.ts
+++ b/tests/session-lifecycle-manager.test.ts
@@ -360,6 +360,12 @@ describe('AgentSession lifecycle', () => {
           { type: 'thinking', thinking: 'hidden chain text', signature: 'sig_secret' },
           { type: 'tool_use', id: 'toolu_1', name: 'read_file', input: { path: 'notes.md' } },
         ],
+        providerState: {
+          schema: 'xiaoba.provider_state.v1',
+          apiType: 'anthropic-messages',
+          model: 'secret-model-scope',
+          endpointFingerprint: 'abcdef1234567890',
+        },
       },
       { role: 'tool', content: 'private tool result', tool_call_id: 'toolu_1', name: 'read_file' },
       { role: 'assistant', content: '读完了' },
@@ -376,6 +382,7 @@ describe('AgentSession lifecycle', () => {
       ['需要读文件', null, '[历史工具结果已省略；read_file 已完成。]', '读完了'],
     );
     assert.equal(restored.some((message: any) => Array.isArray(message.providerContent)), false);
+    assert.equal(restored.some((message: any) => message.providerState), false);
     assert.equal(restored.some((message: any) => message.role === 'tool'), true);
     assert.equal(restored.some((message: any) => message.tool_calls?.length), true);
     assert.equal(
@@ -386,6 +393,7 @@ describe('AgentSession lifecycle', () => {
     assert.equal(restored.some((message: any) => String(message.content || '').includes('private tool result')), false);
     assert.doesNotMatch(raw, /hidden chain text/);
     assert.doesNotMatch(raw, /sig_secret/);
+    assert.doesNotMatch(raw, /secret-model-scope|providerState/);
     assert.doesNotMatch(raw, /provider replay 隐藏内容/);
     assert.doesNotMatch(raw, /private tool result/);
   });


### PR DESCRIPTION
## Why

Provider-only replay payloads (Anthropic thinking signatures, OpenAI Responses reasoning items, and DeepSeek reasoning content) were retained in the live transcript without recording which model and endpoint produced them. Switching models inside one live session could therefore replay opaque state into an incompatible request and produce a terminal 400.

## What changed

- tag opaque replay state with API type, exact model, and a non-reversible endpoint fingerprint
- replay opaque state only inside the same provider boundary
- fall back to canonical tool calls after a model, endpoint, or API-mode switch
- propagate the scope only while the in-memory replay payload exists
- strip both replay payload and scope from durable session storage
- cover Anthropic Messages, OpenAI Chat Completions/DeepSeek, and OpenAI Responses

## Validation

- `npm run build`
- 127 focused provider/conversation/session tests passed
- compiled `dist` smoke: same DeepSeek model replays reasoning; switched model drops reasoning and preserves the canonical tool call
- full runtime suite reached 1316 passing / 8 skipped; the remaining PDF async rejection is pre-existing and passes 15/15 in isolation
- the four Cloud restore cancellations also reproduce unchanged on the parent branch and are outside this PR

## UI

No UI changes; visual testing is not applicable to this stage.

## Stack

Draft base: `codex/turn-error-observability` (#291).

## Current local integration evidence (2026-08-03)

- Local-only integration branch: `integration/pr-294-295-local` (not pushed).
- Verified order and commits: `origin/main` (`b9647fc3`) → local PR294 merge (`6e4bdf36`) → local PR295 merge (`e317343a`).
- Minimal inherited-environment build: exit 0.
- Minimal inherited-environment full runtime: 174 files, 1,372 tests, 1,364 passed, 8 skipped, 0 failed.
- A preceding supplemental run inherited host CatsCo/provider variables and produced 6 failures. The same integration passes in a minimal environment. This supports host-environment contamination as the explanation, but does not establish it as the unique root cause because the original six-failure list was not retained.

Commands used for the clean rerun:

```bash
env -i PATH="$PATH" HOME=<isolated-home> USER="$USER" LOGNAME="$LOGNAME" TMPDIR=<isolated-tmp> CI=1 npm run build
env -i PATH="$PATH" HOME=<isolated-home> USER="$USER" LOGNAME="$LOGNAME" TMPDIR=<isolated-tmp> CI=1 npm test
```

## Remote `main` merge order

1. Rebase or rebuild PR294 on the latest `origin/main`, verify that the diff is limited to the provider replay-boundary change, rerun CI, and merge PR294 first.
2. Wait for `origin/main` to update and confirm its checks.
3. Rebase or rebuild PR295 on that updated `origin/main`, verify that only its two provider-preflight commits remain, rerun CI, and merge PR295 second.
4. Do not merge PR295 before PR294.

The prerequisite stack (#293 → #290 → #291) is already merged into `main`. If PR294 is merged with a merge commit and PR295 retains the resulting ancestry, PR295 can naturally collapse to its two additional commits. If PR294 is squash-merged or rebase-merged, PR295 must be rebased or rebuilt on the new `main` before it is merged.
