### PR TITLE
fix: preflight provider tool exchange structure

### DIFF
--- a/src/observability/cache-trace.ts
+++ b/src/observability/cache-trace.ts
@@ -65,6 +65,14 @@ export interface CacheTraceEntryV4 {
     tools_count: number;
     tools_sha256: string;
     request_sha256: string;
+    preflight?: {
+      repaired: true;
+      issue_codes: string[];
+      dropped_messages: number;
+      dropped_tool_calls: number;
+      dropped_tool_results: number;
+      provider_replay_fallbacks: number;
+    };
     request_snapshot?: {
       kind: 'wire-input';
       messages: Array<Record<string, unknown>>;
@@ -239,6 +247,16 @@ export class CacheTraceObserver implements CacheTraceSink {
         tools_count: event.request.tools.length,
         tools_sha256: toolsSha256,
         request_sha256: requestSha256,
+        ...(event.request.preflight ? {
+          preflight: {
+            repaired: true as const,
+            issue_codes: [...event.request.preflight.issueCodes],
+            dropped_messages: event.request.preflight.droppedMessages,
+            dropped_tool_calls: event.request.preflight.droppedToolCalls,
+            dropped_tool_results: event.request.preflight.droppedToolResults,
+            provider_replay_fallbacks: event.request.preflight.providerReplayFallbacks,
+          },
+        } : {}),
         ...(includeContent ? {
           request_snapshot: {
             kind: 'wire-input' as const,

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -1,5 +1,6 @@
 import { Message, ChatResponse } from '../types';
 import { ToolDefinition } from '../types/tool';
+import type { ProviderRequestPreflightSummary } from './request-preflight';
 
 /**
  * Streaming 回调
@@ -74,6 +75,7 @@ export interface ModelAttemptEvent {
   request: {
     messages: readonly Message[];
     tools: readonly ToolDefinition[];
+    preflight?: ProviderRequestPreflightSummary;
   };
   durationMs?: number;
   response?: ChatResponse;

--- a/src/providers/request-preflight.ts
+++ b/src/providers/request-preflight.ts
@@ -9,6 +9,7 @@ export type ProviderRequestPreflightIssueCode =
   | 'missing_tool_result'
   | 'orphan_tool_result'
   | 'duplicate_tool_result'
+  | 'normalized_tool_exchange_id'
   | 'provider_replay_mismatch';
 
 export interface ProviderRequestPreflightSummary {
@@ -88,7 +89,8 @@ export function prepareProviderRequestMessages(
         continue;
       }
       candidateCallIds.add(id);
-      validCalls.push(toolCall);
+      if (id !== toolCall.id) recordIssue('normalized_tool_exchange_id');
+      validCalls.push(id === toolCall.id ? toolCall : { ...toolCall, id });
     }
 
     const validCallIds = new Set(validCalls.map(toolCall => toolCall.id));
@@ -108,7 +110,12 @@ export function prepareProviderRequestMessages(
         recordIssue('duplicate_tool_result');
       } else {
         resultIds.add(resultId);
-        retainedResults.push(toolResult);
+        if (resultId !== toolResult.tool_call_id) recordIssue('normalized_tool_exchange_id');
+        retainedResults.push(
+          resultId === toolResult.tool_call_id
+            ? toolResult
+            : { ...toolResult, tool_call_id: resultId },
+        );
       }
       nextIndex++;
     }
@@ -123,7 +130,8 @@ export function prepareProviderRequestMessages(
 
     let retainedAssistant: Message | undefined;
     if (retainedCalls.length > 0) {
-      const callsChanged = retainedCalls.length !== message.tool_calls.length;
+      const callsChanged = retainedCalls.length !== message.tool_calls.length
+        || retainedCalls.some((toolCall, callIndex) => toolCall !== message.tool_calls?.[callIndex]);
       const replayMismatch = Boolean(
         message.providerContent?.length
         && !providerReplayMatchesToolCalls(message.providerContent, retainedCalls),

--- a/src/providers/request-preflight.ts
+++ b/src/providers/request-preflight.ts
@@ -1,0 +1,255 @@
+import type { Message } from '../types';
+
+type ToolCall = NonNullable<Message['tool_calls']>[number];
+
+export type ProviderRequestPreflightIssueCode =
+  | 'empty_tool_calls'
+  | 'invalid_tool_call'
+  | 'duplicate_tool_call_id'
+  | 'missing_tool_result'
+  | 'orphan_tool_result'
+  | 'duplicate_tool_result'
+  | 'provider_replay_mismatch';
+
+export interface ProviderRequestPreflightSummary {
+  repaired: true;
+  issueCodes: ProviderRequestPreflightIssueCode[];
+  droppedMessages: number;
+  droppedToolCalls: number;
+  droppedToolResults: number;
+  providerReplayFallbacks: number;
+}
+
+export interface ProviderRequestPreflightResult {
+  messages: Message[];
+  summary?: ProviderRequestPreflightSummary;
+}
+
+/**
+ * Repairs only provider-invalid tool exchange structure. Ordinary conversation
+ * messages and valid requests retain their original references.
+ */
+export function prepareProviderRequestMessages(
+  messages: Message[],
+): ProviderRequestPreflightResult {
+  const issues = new Set<ProviderRequestPreflightIssueCode>();
+  const output: Message[] = [];
+  const seenToolCallIds = new Set<string>();
+  let droppedMessages = 0;
+  let droppedToolCalls = 0;
+  let droppedToolResults = 0;
+  let providerReplayFallbacks = 0;
+
+  const recordIssue = (code: ProviderRequestPreflightIssueCode): void => {
+    issues.add(code);
+  };
+
+  for (let index = 0; index < messages.length; index++) {
+    const message = messages[index];
+
+    if (message.role === 'tool') {
+      droppedMessages++;
+      droppedToolResults++;
+      recordIssue('orphan_tool_result');
+      continue;
+    }
+
+    if (message.role !== 'assistant' || !message.tool_calls?.length) {
+      if (message.role === 'assistant' && Array.isArray(message.tool_calls)) {
+        recordIssue('empty_tool_calls');
+        const hasProviderReplay = Boolean(message.providerContent?.length || message.providerState);
+        if (hasProviderReplay) {
+          providerReplayFallbacks++;
+          recordIssue('provider_replay_mismatch');
+        }
+        output.push({
+          ...message,
+          tool_calls: undefined,
+          ...(hasProviderReplay ? { providerContent: undefined, providerState: undefined } : {}),
+        });
+      } else {
+        output.push(message);
+      }
+      continue;
+    }
+
+    const validCalls: ToolCall[] = [];
+    const candidateCallIds = new Set<string>();
+    for (const toolCall of message.tool_calls) {
+      if (!isValidToolCall(toolCall)) {
+        droppedToolCalls++;
+        recordIssue('invalid_tool_call');
+        continue;
+      }
+      const id = toolCall.id.trim();
+      if (seenToolCallIds.has(id) || candidateCallIds.has(id)) {
+        droppedToolCalls++;
+        recordIssue('duplicate_tool_call_id');
+        continue;
+      }
+      candidateCallIds.add(id);
+      validCalls.push(toolCall);
+    }
+
+    const validCallIds = new Set(validCalls.map(toolCall => toolCall.id));
+    const retainedResults: Message[] = [];
+    const resultIds = new Set<string>();
+    let nextIndex = index + 1;
+    while (nextIndex < messages.length && messages[nextIndex].role === 'tool') {
+      const toolResult = messages[nextIndex];
+      const resultId = String(toolResult.tool_call_id || '').trim();
+      if (!resultId || !validCallIds.has(resultId)) {
+        droppedMessages++;
+        droppedToolResults++;
+        recordIssue('orphan_tool_result');
+      } else if (resultIds.has(resultId)) {
+        droppedMessages++;
+        droppedToolResults++;
+        recordIssue('duplicate_tool_result');
+      } else {
+        resultIds.add(resultId);
+        retainedResults.push(toolResult);
+      }
+      nextIndex++;
+    }
+
+    const retainedCalls = validCalls.filter(toolCall => resultIds.has(toolCall.id));
+    for (const toolCall of retainedCalls) seenToolCallIds.add(toolCall.id);
+    const missingResultCount = validCalls.length - retainedCalls.length;
+    if (missingResultCount > 0) {
+      droppedToolCalls += missingResultCount;
+      recordIssue('missing_tool_result');
+    }
+
+    let retainedAssistant: Message | undefined;
+    if (retainedCalls.length > 0) {
+      const callsChanged = retainedCalls.length !== message.tool_calls.length;
+      const replayMismatch = Boolean(
+        message.providerContent?.length
+        && !providerReplayMatchesToolCalls(message.providerContent, retainedCalls),
+      );
+      if (callsChanged || replayMismatch) {
+        if (message.providerContent?.length || message.providerState) {
+          providerReplayFallbacks++;
+          recordIssue('provider_replay_mismatch');
+        }
+        retainedAssistant = {
+          ...message,
+          tool_calls: retainedCalls,
+          providerContent: undefined,
+          providerState: undefined,
+        };
+      } else {
+        retainedAssistant = message;
+      }
+    } else if (hasVisibleContent(message)) {
+      if (message.providerContent?.length || message.providerState) {
+        providerReplayFallbacks++;
+        recordIssue('provider_replay_mismatch');
+      }
+      retainedAssistant = {
+        ...message,
+        tool_calls: undefined,
+        providerContent: undefined,
+        providerState: undefined,
+      };
+    } else {
+      droppedMessages++;
+    }
+
+    if (retainedAssistant) output.push(retainedAssistant);
+    output.push(...retainedResults);
+    index = nextIndex - 1;
+  }
+
+  if (issues.size === 0) {
+    return { messages };
+  }
+
+  return {
+    messages: output,
+    summary: {
+      repaired: true,
+      issueCodes: Array.from(issues).sort(),
+      droppedMessages,
+      droppedToolCalls,
+      droppedToolResults,
+      providerReplayFallbacks,
+    },
+  };
+}
+
+function isValidToolCall(value: ToolCall): boolean {
+  return Boolean(
+    value
+    && value.type === 'function'
+    && typeof value.id === 'string'
+    && value.id.trim()
+    && value.function
+    && typeof value.function.name === 'string'
+    && value.function.name.trim()
+    && typeof value.function.arguments === 'string',
+  );
+}
+
+function hasVisibleContent(message: Message): boolean {
+  if (typeof message.content === 'string') return Boolean(message.content.trim());
+  return Array.isArray(message.content) && message.content.length > 0;
+}
+
+function providerReplayMatchesToolCalls(
+  blocks: NonNullable<Message['providerContent']>,
+  toolCalls: ToolCall[],
+): boolean {
+  const canonical = new Map(toolCalls.map(toolCall => [toolCall.id, {
+    name: toolCall.function.name,
+    arguments: stableArguments(toolCall.function.arguments),
+  }]));
+  const replay = new Map<string, { name: string; arguments: string }>();
+
+  for (const block of blocks) {
+    if (!block || typeof block !== 'object') continue;
+    const type = String(block.type || '');
+    const id = type === 'tool_use'
+      ? safeString(block.id)
+      : type === 'function_call'
+        ? safeString(block.call_id)
+        : '';
+    if (!id) continue;
+    if (replay.has(id)) return false;
+    replay.set(id, {
+      name: safeString(block.name),
+      arguments: type === 'tool_use'
+        ? stableValue(block.input)
+        : stableArguments(safeString(block.arguments)),
+    });
+  }
+
+  if (replay.size !== canonical.size) return false;
+  for (const [id, call] of canonical) {
+    const item = replay.get(id);
+    if (!item || item.name !== call.name || item.arguments !== call.arguments) return false;
+  }
+  return true;
+}
+
+function stableArguments(value: string): string {
+  try {
+    return stableValue(JSON.parse(value || '{}'));
+  } catch {
+    return `raw:${value}`;
+  }
+}
+
+function stableValue(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(item => stableValue(item)).join(',')}]`;
+  if (!value || typeof value !== 'object') return JSON.stringify(value) ?? 'undefined';
+  return `{${Object.keys(value as Record<string, unknown>)
+    .sort()
+    .map(key => `${JSON.stringify(key)}:${stableValue((value as Record<string, unknown>)[key])}`)
+    .join(',')}}`;
+}
+
+function safeString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}

--- a/src/utils/ai-service.ts
+++ b/src/utils/ai-service.ts
@@ -12,6 +12,10 @@ import {
 } from '../providers/provider';
 import { AnthropicProvider } from '../providers/anthropic-provider';
 import { OpenAIProvider } from '../providers/openai-provider';
+import {
+  prepareProviderRequestMessages,
+  type ProviderRequestPreflightSummary,
+} from '../providers/request-preflight';
 import { Logger } from './logger';
 import { isPrimaryModelToolCallingCapable } from './model-capabilities';
 import { resolveModelContextWindow } from './model-context-window';
@@ -59,6 +63,7 @@ interface ModelAttemptRun {
   messages: readonly Message[];
   tools: readonly ToolDefinition[];
   stream: boolean;
+  preflight?: ProviderRequestPreflightSummary;
 }
 
 export class AIService {
@@ -134,13 +139,14 @@ export class AIService {
       throw new Error('API密钥未配置。请先运行: catsco config');
     }
 
+    const prepared = this.prepareProviderRequest(messages);
     try {
       return await this.withRetry(
-        async () => this.requireUsableResponse(await this.provider.chat(messages, tools, options)),
+        async () => this.requireUsableResponse(await this.provider.chat(prepared.messages, tools, options)),
         undefined,
         options.signal,
         undefined,
-        this.createModelAttemptRun(messages, tools, false, options),
+        this.createModelAttemptRun(prepared.messages, tools, false, options, prepared.summary),
       );
     } catch (error: any) {
       throw this.wrapError(error);
@@ -163,6 +169,7 @@ export class AIService {
     }
 
     const allowStreamRetry = process.env.GAUZ_STREAM_RETRY === 'true';
+    const prepared = this.prepareProviderRequest(messages);
     let hasStreamedText = false;
     const providerCallbacks = this.createProviderStreamCallbacks(callbacks, () => {
       hasStreamedText = true;
@@ -171,12 +178,12 @@ export class AIService {
     try {
       const result = await this.withRetry(
         async () => this.requireUsableResponse(
-          await this.provider.chatStream(messages, tools, providerCallbacks, options),
+          await this.provider.chatStream(prepared.messages, tools, providerCallbacks, options),
         ),
         callbacks,
         options.signal,
         () => allowStreamRetry || !hasStreamedText,
-        this.createModelAttemptRun(messages, tools, true, options),
+        this.createModelAttemptRun(prepared.messages, tools, true, options, prepared.summary),
       );
       callbacks?.onComplete?.(result);
       return result;
@@ -198,6 +205,20 @@ export class AIService {
         callbacks.onText?.(text);
       },
     };
+  }
+
+  private prepareProviderRequest(messages: Message[]): ReturnType<typeof prepareProviderRequestMessages> {
+    const prepared = prepareProviderRequestMessages(messages);
+    if (prepared.summary) {
+      Logger.warning(
+        `Provider request preflight repaired message structure: issues=${prepared.summary.issueCodes.join(',')}`
+        + ` dropped_messages=${prepared.summary.droppedMessages}`
+        + ` dropped_tool_calls=${prepared.summary.droppedToolCalls}`
+        + ` dropped_tool_results=${prepared.summary.droppedToolResults}`
+        + ` replay_fallbacks=${prepared.summary.providerReplayFallbacks}`,
+      );
+    }
+    return prepared;
   }
 
   private requireUsableResponse(response: ChatResponse): ChatResponse {
@@ -517,6 +538,7 @@ export class AIService {
     tools: readonly ToolDefinition[] | undefined,
     stream: boolean,
     options: AIRequestOptions,
+    preflight?: ProviderRequestPreflightSummary,
   ): ModelAttemptRun | undefined {
     if (!options.modelAttemptSink) return undefined;
     modelAttemptCallSequence = (modelAttemptCallSequence + 1) % Number.MAX_SAFE_INTEGER;
@@ -527,6 +549,7 @@ export class AIService {
       messages,
       tools: tools || [],
       stream,
+      ...(preflight ? { preflight } : {}),
     };
   }
 
@@ -556,6 +579,7 @@ export class AIService {
       request: {
         messages: run.messages,
         tools: run.tools,
+        ...(run.preflight ? { preflight: run.preflight } : {}),
       },
       ...(fields.durationMs === undefined ? {} : { durationMs: fields.durationMs }),
       ...(fields.response === undefined ? {} : { response: fields.response }),

--- a/tests/cache-trace-monitoring.test.ts
+++ b/tests/cache-trace-monitoring.test.ts
@@ -220,6 +220,47 @@ test('observer stores request content only on the started line when explicitly e
   }
 });
 
+test('observer records provider request preflight repairs without storing message content', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-cache-preflight-'));
+  try {
+    const observer = new CacheTraceObserver({
+      sessionId: 'cache:preflight',
+      traceDir: dir,
+      env: { XIAOBA_CACHE_TRACE: 'true' },
+    });
+    observer.observe(attemptEvent({
+      outcome: 'started',
+      request: {
+        messages: [{ role: 'user', content: 'secret content' }],
+        tools: [],
+        preflight: {
+          repaired: true,
+          issueCodes: ['missing_tool_result', 'provider_replay_mismatch'],
+          droppedMessages: 1,
+          droppedToolCalls: 2,
+          droppedToolResults: 1,
+          providerReplayFallbacks: 1,
+        },
+      },
+    }));
+    await observer.drain();
+
+    const entry = JSON.parse(fs.readFileSync(listTraceFiles(dir)[0], 'utf8').trim());
+    assert.deepEqual(entry.request.preflight, {
+      repaired: true,
+      issue_codes: ['missing_tool_result', 'provider_replay_mismatch'],
+      dropped_messages: 1,
+      dropped_tool_calls: 2,
+      dropped_tool_results: 1,
+      provider_replay_fallbacks: 1,
+    });
+    assert.equal(entry.request.request_snapshot, undefined);
+    assert.doesNotMatch(JSON.stringify(entry), /secret content/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('one attempt keeps one JSONL file when it crosses midnight', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-cache-midnight-'));
   try {

--- a/tests/model-attempt-lifecycle.test.ts
+++ b/tests/model-attempt-lifecycle.test.ts
@@ -100,6 +100,51 @@ test('records a non-retryable provider rejection as the terminal attempt', async
   assert.equal(events[1].error instanceof Error, true);
 });
 
+test('repairs malformed tool exchanges before invocation and records the preflight summary', async () => {
+  const service = createTestService();
+  const events: ModelAttemptEvent[] = [];
+  let providerMessages: Message[] | undefined;
+  (service as any).provider = {
+    chat: async (messages: Message[]) => {
+      providerMessages = messages;
+      return { content: 'recovered locally' };
+    },
+    chatStream: async () => ({ content: 'unused' }),
+  };
+  const messages: Message[] = [
+    { role: 'user', content: 'first' },
+    {
+      role: 'assistant',
+      content: 'tool attempt',
+      tool_calls: [{
+        id: 'call_1',
+        type: 'function',
+        function: { name: 'lookup', arguments: '{}' },
+      }],
+    },
+    { role: 'user', content: 'continue without a result' },
+    { role: 'tool', tool_call_id: 'call_1', content: 'late' },
+  ];
+
+  const result = await service.chat(messages, undefined, {
+    modelAttemptSink: collectingSink(events),
+  });
+
+  assert.equal(result.content, 'recovered locally');
+  assert.deepEqual(providerMessages?.map(message => message.role), ['user', 'assistant', 'user']);
+  assert.equal(providerMessages?.[1].tool_calls, undefined);
+  assert.deepEqual(events.map(event => event.outcome), ['started', 'succeeded']);
+  assert.equal(events[0].request.messages, providerMessages);
+  assert.deepEqual(events[0].request.preflight, {
+    repaired: true,
+    issueCodes: ['missing_tool_result', 'orphan_tool_result'],
+    droppedMessages: 1,
+    droppedToolCalls: 1,
+    droppedToolResults: 1,
+    providerReplayFallbacks: 0,
+  });
+});
+
 test('distinguishes a stream failure after visible output from a retryable failure', async () => {
   const service = createTestService();
   const events: ModelAttemptEvent[] = [];

--- a/tests/provider-request-preflight.test.ts
+++ b/tests/provider-request-preflight.test.ts
@@ -141,3 +141,84 @@ test('interrupted exchanges and empty tool call arrays are repaired locally', ()
     'orphan_tool_result',
   ]);
 });
+
+test('preflight normalizes padded tool exchange IDs without dropping the pair', () => {
+  const messages: Message[] = [
+    { role: 'assistant', content: null, tool_calls: [toolCall(' call_1 ')] },
+    { role: 'tool', tool_call_id: ' call_1 ', content: 'ok' },
+  ];
+
+  const result = prepareProviderRequestMessages(messages);
+
+  assert.notEqual(result.messages, messages);
+  assert.equal(result.messages[0].tool_calls?.[0].id, 'call_1');
+  assert.equal(result.messages[1].tool_call_id, 'call_1');
+  assert.deepEqual(result.summary, {
+    repaired: true,
+    issueCodes: ['normalized_tool_exchange_id'],
+    droppedMessages: 0,
+    droppedToolCalls: 0,
+    droppedToolResults: 0,
+    providerReplayFallbacks: 0,
+  });
+});
+
+test('sanitized restored Responses history preserves all 16 canonical tool pairs', () => {
+  const messages: Message[] = [
+    { role: 'user', content: 'checkpoint one' },
+    { role: 'assistant', content: 'ack one' },
+    { role: 'user', content: 'checkpoint two' },
+    { role: 'assistant', content: 'ack two' },
+    { role: 'user', content: 'checkpoint three' },
+    { role: 'assistant', content: 'ack three' },
+    { role: 'user', content: 'checkpoint four' },
+    { role: 'user', content: 'checkpoint five' },
+  ];
+  let callNumber = 0;
+  for (let exchange = 0; exchange < 10; exchange++) {
+    const calls = Array.from({ length: exchange < 6 ? 2 : 1 }, () => {
+      callNumber++;
+      return toolCall(`call_${callNumber}`, 'lookup', JSON.stringify({ item: callNumber }));
+    });
+    messages.push({
+      role: 'assistant',
+      content: null,
+      tool_calls: calls,
+      providerContent: [
+        { type: 'reasoning', id: `reasoning_${exchange + 1}`, encrypted_content: 'opaque' },
+      ],
+    });
+    for (const call of calls) {
+      messages.push({
+        role: 'tool',
+        tool_call_id: call.id,
+        name: call.function.name,
+        content: `result ${call.id}`,
+      });
+    }
+  }
+  assert.equal(messages.length, 34);
+  assert.equal(callNumber, 16);
+
+  const result = prepareProviderRequestMessages(messages);
+  const retainedCalls = result.messages.flatMap(message => message.tool_calls || []);
+  const retainedResults = result.messages.filter(message => message.role === 'tool');
+  const retainedCallIds = new Set(retainedCalls.map(call => call.id));
+
+  assert.equal(result.messages.length, 34);
+  assert.equal(retainedCalls.length, 16);
+  assert.equal(retainedResults.length, 16);
+  assert.equal(retainedCallIds.size, 16);
+  assert.ok(retainedResults.every(message => retainedCallIds.has(String(message.tool_call_id))));
+  assert.ok(result.messages
+    .filter(message => message.role === 'assistant' && message.tool_calls?.length)
+    .every(message => message.providerContent === undefined));
+  assert.deepEqual(result.summary, {
+    repaired: true,
+    issueCodes: ['provider_replay_mismatch'],
+    droppedMessages: 0,
+    droppedToolCalls: 0,
+    droppedToolResults: 0,
+    providerReplayFallbacks: 10,
+  });
+});

--- a/tests/provider-request-preflight.test.ts
+++ b/tests/provider-request-preflight.test.ts
@@ -1,0 +1,143 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import type { Message } from '../src/types';
+import { prepareProviderRequestMessages } from '../src/providers/request-preflight';
+
+function toolCall(id: string, name = 'lookup', args = '{"q":"cats"}') {
+  return { id, type: 'function' as const, function: { name, arguments: args } };
+}
+
+test('valid tool exchanges pass preflight without cloning the request', () => {
+  const messages: Message[] = [
+    { role: 'user', content: 'find cats' },
+    { role: 'assistant', content: null, tool_calls: [toolCall('call_1')] },
+    { role: 'tool', tool_call_id: 'call_1', name: 'lookup', content: 'cats' },
+  ];
+
+  const result = prepareProviderRequestMessages(messages);
+
+  assert.equal(result.messages, messages);
+  assert.equal(result.summary, undefined);
+});
+
+test('preflight keeps only contiguous one-to-one tool call/result pairs', () => {
+  const messages: Message[] = [
+    { role: 'user', content: 'find cats' },
+    {
+      role: 'assistant',
+      content: 'checking',
+      tool_calls: [
+        toolCall('call_1'),
+        toolCall('call_2'),
+        toolCall('', 'broken'),
+      ],
+      providerContent: [
+        { type: 'reasoning', id: 'rs_1', encrypted_content: 'opaque' },
+        { type: 'function_call', call_id: 'call_1', name: 'lookup', arguments: '{"q":"cats"}' },
+        { type: 'function_call', call_id: 'call_2', name: 'lookup', arguments: '{"q":"cats"}' },
+      ],
+      providerState: {
+        schema: 'xiaoba.provider_state.v1',
+        apiType: 'openai-responses',
+        model: 'gpt-test',
+        endpointFingerprint: '0123456789abcdef',
+      },
+    },
+    { role: 'tool', tool_call_id: 'call_1', name: 'lookup', content: 'cats' },
+    { role: 'tool', tool_call_id: 'call_1', name: 'lookup', content: 'duplicate' },
+    { role: 'tool', tool_call_id: 'unknown', name: 'lookup', content: 'orphan' },
+    { role: 'user', content: 'continue' },
+    { role: 'tool', tool_call_id: 'call_2', name: 'lookup', content: 'too late' },
+  ];
+
+  const result = prepareProviderRequestMessages(messages);
+
+  assert.deepEqual(result.messages.map(message => message.role), ['user', 'assistant', 'tool', 'user']);
+  assert.deepEqual(result.messages[1].tool_calls?.map(call => call.id), ['call_1']);
+  assert.equal(result.messages[1].providerContent, undefined);
+  assert.equal(result.messages[1].providerState, undefined);
+  assert.deepEqual(result.summary, {
+    repaired: true,
+    issueCodes: [
+      'duplicate_tool_result',
+      'invalid_tool_call',
+      'missing_tool_result',
+      'orphan_tool_result',
+      'provider_replay_mismatch',
+    ],
+    droppedMessages: 3,
+    droppedToolCalls: 2,
+    droppedToolResults: 3,
+    providerReplayFallbacks: 1,
+  });
+});
+
+test('preflight falls back from mismatched opaque replay without losing canonical tools', () => {
+  const state = {
+    schema: 'xiaoba.provider_state.v1' as const,
+    apiType: 'anthropic-messages' as const,
+    model: 'claude-test',
+    endpointFingerprint: '0123456789abcdef',
+  };
+  const messages: Message[] = [
+    {
+      role: 'assistant',
+      content: null,
+      tool_calls: [toolCall('call_1', 'lookup', '{"a":1,"b":2}')],
+      providerContent: [
+        { type: 'thinking', thinking: 'opaque', signature: 'sig' },
+        { type: 'tool_use', id: 'call_1', name: 'wrong_name', input: { b: 2, a: 1 } },
+      ],
+      providerState: state,
+    },
+    { role: 'tool', tool_call_id: 'call_1', content: 'ok' },
+  ];
+
+  const result = prepareProviderRequestMessages(messages);
+
+  assert.equal(result.messages[0].tool_calls?.[0].id, 'call_1');
+  assert.equal(result.messages[0].providerContent, undefined);
+  assert.equal(result.messages[0].providerState, undefined);
+  assert.deepEqual(result.summary?.issueCodes, ['provider_replay_mismatch']);
+});
+
+test('matching opaque replay survives normalized JSON argument comparison', () => {
+  const messages: Message[] = [
+    {
+      role: 'assistant',
+      content: null,
+      tool_calls: [toolCall('call_1', 'lookup', '{"a":1,"b":2}')],
+      providerContent: [
+        { type: 'thinking', thinking: 'opaque', signature: 'sig' },
+        { type: 'tool_use', id: 'call_1', name: 'lookup', input: { b: 2, a: 1 } },
+      ],
+    },
+    { role: 'tool', tool_call_id: 'call_1', content: 'ok' },
+  ];
+
+  const result = prepareProviderRequestMessages(messages);
+
+  assert.equal(result.messages, messages);
+  assert.equal(result.summary, undefined);
+});
+
+test('interrupted exchanges and empty tool call arrays are repaired locally', () => {
+  const messages: Message[] = [
+    { role: 'assistant', content: null, tool_calls: [toolCall('call_1')] },
+    { role: 'user', content: 'new topic' },
+    { role: 'tool', tool_call_id: 'call_1', content: 'late result' },
+    { role: 'assistant', content: 'done', tool_calls: [] },
+  ];
+
+  const result = prepareProviderRequestMessages(messages);
+
+  assert.deepEqual(result.messages, [
+    { role: 'user', content: 'new topic' },
+    { role: 'assistant', content: 'done', tool_calls: undefined },
+  ]);
+  assert.deepEqual(result.summary?.issueCodes, [
+    'empty_tool_calls',
+    'missing_tool_result',
+    'orphan_tool_result',
+  ]);
+});


### PR DESCRIPTION
## Why

Malformed live or restored tool history could reach the provider unchanged: missing results, late/orphan results, duplicate IDs, padded IDs, or opaque replay blocks that no longer matched canonical tool calls. OpenAI Chat Completions, OpenAI Responses, Anthropic Messages, and DeepSeek-compatible endpoints can reject these structures with an otherwise vague 400.

## What changed

- add one provider-boundary preflight shared by streaming and non-streaming calls
- leave valid requests and their object identity unchanged
- normalize canonical tool-call IDs and matching `tool_call_id` values before pairing
- keep only contiguous, one-to-one assistant tool-call / tool-result pairs
- remove invalid, duplicate, missing, and orphan tool exchange fragments
- preserve ordinary assistant text when a broken tool exchange can be downgraded
- fall back from mismatched opaque provider replay to canonical tool calls
- record repair codes and counts on the exact model attempt and Cache Trace request
- avoid storing message content unless the existing explicit trace-content switch is enabled

## Restored-session regression

A sanitized fixture matching the `cc_group:grp_1249` restored-session structure covers 34 messages, 10 assistant tool exchanges, 16 canonical calls, 16 tool results, and stale reasoning replay on every exchange. Preflight preserves all 16 call/result pairs, leaves zero orphan, missing, or duplicate pairs, drops no calls or results, and records 10 provider-replay fallbacks.

A separate regression confirms that padded call/result IDs are normalized without dropping the valid pair.

## Validation

- focused preflight tests: 7 passed, 0 failed
- TypeScript build: passed
- clean-environment rerun of the five initially failing files: 61 passed, 0 failed
- clean-environment full runtime: 172 files, 1333 tests, 1325 passed, 8 skipped, 0 failed
- focused independent diff review: no findings

The first full runtime inherited host CatsCo credentials/configuration and produced 8 failures outside the PR295 paths. Clearing the host environment made both the targeted rerun and full runtime green; credential-bearing raw output was not attached or committed.

## Current local integration evidence (2026-08-03)

- Local-only integration branch: `integration/pr-294-295-local` (not pushed).
- Verified order and commits: `origin/main` (`b9647fc3`) → local PR294 merge (`6e4bdf36`) → local PR295 merge (`e317343a`).
- Minimal inherited-environment build: exit 0.
- Minimal inherited-environment full runtime: 174 files, 1,372 tests, 1,364 passed, 8 skipped, 0 failed.
- A later supplemental run inherited host CatsCo/provider variables and produced 6 failures. The same local integration passes in a minimal environment. This supports host-environment contamination as the explanation, but does not establish it as the unique root cause because the original six-failure list was not retained.

Commands used for the clean rerun:

```bash
env -i PATH="$PATH" HOME=<isolated-home> USER="$USER" LOGNAME="$LOGNAME" TMPDIR=<isolated-tmp> CI=1 npm run build
env -i PATH="$PATH" HOME=<isolated-home> USER="$USER" LOGNAME="$LOGNAME" TMPDIR=<isolated-tmp> CI=1 npm test
```

## Limitation

No real OpenAI request was sent. The validation establishes that the restored-session wire invariant that caused the HTTP 400 is repaired; it does not claim a live provider end-to-end replay.

## Stack and merge order

The prerequisite stack (#293 → #290 → #291) is already merged into `main`. PR295 still depends on PR294 and intentionally remains based on `agent/provider-message-boundary` while the stack is under review.

Local integration is complete on the unpushed branch `integration/pr-294-295-local`: `origin/main` (`b9647fc3`) → PR294 merge (`6e4bdf36`) → PR295 merge (`e317343a`).

Remote `main` order:

1. Rebase or rebuild PR294 on the latest `origin/main`, verify that the diff is limited to the provider replay-boundary change, rerun CI, and merge PR294 first.
2. Wait for `origin/main` to update and confirm its checks.
3. Rebase or rebuild PR295 on that updated `origin/main`, verify that only its two provider-preflight commits remain, rerun CI, and merge PR295 second.
4. Do not merge PR295 before PR294.

If PR294 is merged with a merge commit and PR295 retains the resulting ancestry, PR295 can naturally collapse to its two additional commits. If PR294 is squash-merged or rebase-merged, PR295 must be rebased or rebuilt on the new `main` before it is merged.

## UI

No UI changes; visual testing is not applicable.
