### PR TITLE
fix: recover DeepSeek reasoning replay dialect

### DIFF
--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -275,6 +275,13 @@ function shouldSuppressStructuredToolProgress(channelSource?: string): boolean {
 }
 
 function formatModelRetryThinking(attempt: number, maxRetries: number, info?: StreamRetryInfo): string {
+  if (info?.recoveryAction === 'reasoning_history_degrade') {
+    return '检测到历史推理状态缺失，已安全降级旧工具记录，正在自动修复后重试 1/1...';
+  }
+  if (info?.recoveryAction === 'reasoning_replay_include'
+    || info?.recoveryAction === 'reasoning_replay_omit') {
+    return '检测到模型推理上下文方言不兼容，正在自动修复后重试 1/1...';
+  }
   const retryIn = info && info.delayMs >= 1000
     ? `，约 ${Math.ceil(info.delayMs / 1000)} 秒后继续`
     : '';
@@ -1228,6 +1235,7 @@ export class CatsCompanyBot {
             max_retries: maxRetries,
             delay_ms: info?.delayMs,
             status: info?.status,
+            recovery_action: info?.recoveryAction,
           });
         } catch (err: any) {
           Logger.warning(`重试提示发送失败: ${err.message}`);

--- a/src/observability/cache-trace.ts
+++ b/src/observability/cache-trace.ts
@@ -43,6 +43,7 @@ export interface CacheTraceEntryV4 {
     retry_elapsed_ms?: number;
     retry_max_elapsed_ms?: number;
     retry_stop_reason?: string;
+    retry_recovery_action?: string;
   };
   request: {
     timestamp: string;
@@ -230,6 +231,7 @@ export class CacheTraceObserver implements CacheTraceSink {
           retry_elapsed_ms: retry.elapsedMs,
           retry_max_elapsed_ms: retry.maxElapsedMs,
           ...(retry.stopReason ? { retry_stop_reason: retry.stopReason } : {}),
+          ...(retry.recoveryAction ? { retry_recovery_action: retry.recoveryAction } : {}),
         } : {}),
       },
       request: {

--- a/src/providers/deepseek-reasoning-recovery.ts
+++ b/src/providers/deepseek-reasoning-recovery.ts
@@ -1,0 +1,202 @@
+import type { ChatConfig, Message } from '../types';
+import {
+  resolveOpenAIReasoningReplayMode,
+  type OpenAIReasoningReplayMode,
+} from '../utils/reasoning-effort';
+import { normalizeOpenAIChatCompletionsUrl } from './openai-url';
+import { createProviderStateReference, isProviderStateCompatible } from './provider-state';
+
+export type ReasoningReplayRecoveryAction =
+  | 'reasoning_replay_include'
+  | 'reasoning_replay_omit'
+  | 'reasoning_history_degrade';
+
+export interface ReasoningReplayRecoveryPlan {
+  action: ReasoningReplayRecoveryAction;
+  replayMode: OpenAIReasoningReplayMode;
+  messages: Message[];
+  degradedExchanges: number;
+}
+
+export function planDeepSeekReasoningRecovery(input: {
+  error: unknown;
+  config: Pick<ChatConfig, 'provider' | 'model' | 'apiUrl' | 'openaiApiMode'>;
+  messages: Message[];
+  currentMode: OpenAIReasoningReplayMode | undefined;
+}): ReasoningReplayRecoveryPlan | undefined {
+  if (input.config.provider !== 'openai' || input.config.openaiApiMode === 'responses') {
+    return undefined;
+  }
+  const defaultMode = resolveOpenAIReasoningReplayMode(input.config);
+  if (!defaultMode) return undefined;
+
+  const desiredMode = inferDesiredReplayMode(input.error);
+  if (!desiredMode) return undefined;
+  const currentMode = input.currentMode ?? defaultMode;
+
+  if (desiredMode === 'omit') {
+    if (currentMode !== 'include') return undefined;
+    const expectedState = expectedProviderState(input.config);
+    if (!input.messages.some(message => hasCompatibleReasoning(message, expectedState))) {
+      return undefined;
+    }
+    return {
+      action: 'reasoning_replay_omit',
+      replayMode: 'omit',
+      messages: input.messages,
+      degradedExchanges: 0,
+    };
+  }
+
+  const degraded = degradeToolHistoryWithoutReasoning(input.messages, input.config);
+  if (degraded.degradedExchanges > 0) {
+    return {
+      action: 'reasoning_history_degrade',
+      replayMode: 'include',
+      messages: degraded.messages,
+      degradedExchanges: degraded.degradedExchanges,
+    };
+  }
+  if (currentMode === 'include') return undefined;
+  return {
+    action: 'reasoning_replay_include',
+    replayMode: 'include',
+    messages: input.messages,
+    degradedExchanges: 0,
+  };
+}
+
+function inferDesiredReplayMode(error: unknown): OpenAIReasoningReplayMode | undefined {
+  const status = extractStatus(error);
+  if (status !== undefined && status !== 400 && status !== 422) return undefined;
+  const evidence = extractEvidence(error);
+  if (!/reasoning[_\s-]?content/i.test(evidence)) return undefined;
+
+  const include = [
+    /reasoning[_\s-]?content.{0,120}(?:must|should|needs? to) be (?:passed back|echoed|included|provided)/i,
+    /reasoning[_\s-]?content.{0,80}(?:is|was) (?:missing|required|expected)/i,
+    /(?:missing|required|expected).{0,80}reasoning[_\s-]?content/i,
+  ].some(pattern => pattern.test(evidence));
+  if (include) return 'include';
+
+  const omit = [
+    /reasoning[_\s-]?content.{0,120}(?:unknown|unrecognized|unsupported|unexpected|not allowed|not permitted)/i,
+    /reasoning[_\s-]?content.{0,120}(?:must|should) not be (?:passed|included|provided|sent)/i,
+    /(?:unknown|unrecognized|unsupported|unexpected|extra) (?:field|parameter).{0,80}reasoning[_\s-]?content/i,
+  ].some(pattern => pattern.test(evidence));
+  return omit ? 'omit' : undefined;
+}
+
+function degradeToolHistoryWithoutReasoning(
+  messages: Message[],
+  config: Pick<ChatConfig, 'model' | 'apiUrl'>,
+): { messages: Message[]; degradedExchanges: number } {
+  const expectedState = expectedProviderState(config);
+  const output: Message[] = [];
+  let degradedExchanges = 0;
+
+  for (let index = 0; index < messages.length; index++) {
+    const message = messages[index];
+    if (message.role !== 'assistant' || !message.tool_calls?.length) {
+      output.push(message);
+      continue;
+    }
+    if (hasCompatibleReasoning(message, expectedState)) {
+      output.push(message);
+      continue;
+    }
+
+    const results: Message[] = [];
+    let nextIndex = index + 1;
+    while (nextIndex < messages.length && messages[nextIndex].role === 'tool') {
+      results.push(messages[nextIndex]);
+      nextIndex++;
+    }
+    if (results.length === 0) {
+      output.push(message);
+      continue;
+    }
+
+    degradedExchanges++;
+    if (hasVisibleContent(message)) {
+      output.push({
+        ...message,
+        tool_calls: undefined,
+        providerContent: undefined,
+        providerState: undefined,
+      });
+    }
+    output.push({
+      role: 'user',
+      content: buildDegradedHistoryNote(results),
+      __runtimeFeedback: true,
+      __cacheScope: 'dynamic',
+    });
+    index = nextIndex - 1;
+  }
+
+  return degradedExchanges > 0
+    ? { messages: output, degradedExchanges }
+    : { messages, degradedExchanges: 0 };
+}
+
+function expectedProviderState(config: Pick<ChatConfig, 'model' | 'apiUrl'>) {
+  return createProviderStateReference({
+    apiType: 'openai-chat-completions',
+    endpoint: normalizeOpenAIChatCompletionsUrl(config.apiUrl || ''),
+    model: String(config.model || ''),
+  });
+}
+
+function hasCompatibleReasoning(
+  message: Message,
+  expectedState: ReturnType<typeof createProviderStateReference>,
+): boolean {
+  if (!isProviderStateCompatible(message.providerState, expectedState)) return false;
+  return Boolean(message.providerContent?.some(block => (
+    block?.type === 'openai_reasoning'
+    && typeof block.reasoning_content === 'string'
+    && block.reasoning_content.trim()
+  )));
+}
+
+function buildDegradedHistoryNote(results: Message[]): string {
+  const lines = results.map((result, index) => {
+    const name = String(result.name || 'tool').trim() || 'tool';
+    const content = contentAsText(result.content).slice(0, 1200);
+    return `${index + 1}. ${name}: ${content || '[empty result]'}`;
+  });
+  return '[provider_recovery]\n'
+    + 'A completed historical tool exchange was converted to plain context because its opaque reasoning state is unavailable. '
+    + 'Treat the following as historical results; do not repeat the tools unless current state must be re-verified.\n'
+    + lines.join('\n');
+}
+
+function hasVisibleContent(message: Message): boolean {
+  if (typeof message.content === 'string') return Boolean(message.content.trim());
+  return Array.isArray(message.content) && message.content.length > 0;
+}
+
+function contentAsText(content: Message['content']): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  return content.map(block => block.type === 'text' ? block.text : '[image omitted]').join('\n');
+}
+
+function extractEvidence(error: any): string {
+  return [
+    error?.response?.data?.error?.code,
+    error?.response?.data?.error?.type,
+    error?.response?.data?.error?.message,
+    error?.response?.data?.message,
+    error?.error?.code,
+    error?.error?.type,
+    error?.error?.message,
+    error?.message,
+  ].filter(Boolean).join(' ');
+}
+
+function extractStatus(error: any): number | undefined {
+  const value = error?.response?.status ?? error?.status;
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}

--- a/src/providers/openai-provider.ts
+++ b/src/providers/openai-provider.ts
@@ -46,8 +46,13 @@ export class OpenAIProvider implements AIProvider {
   /**
    * 构建请求体
    */
-  private buildRequestBody(messages: Message[], tools?: ToolDefinition[], stream = false): any {
-    const sanitizedMessages = messages.map(message => this.sanitizeMessage(message));
+  private buildRequestBody(
+    messages: Message[],
+    tools?: ToolDefinition[],
+    stream = false,
+    options?: AIRequestOptions,
+  ): any {
+    const sanitizedMessages = messages.map(message => this.sanitizeMessage(message, options));
 
     const body: any = {
       model: this.model,
@@ -81,7 +86,7 @@ export class OpenAIProvider implements AIProvider {
     return body;
   }
 
-  private sanitizeMessage(message: Message): any {
+  private sanitizeMessage(message: Message, options?: AIRequestOptions): any {
     const sanitized: any = {
       role: message.role,
       content: this.sanitizeContent(message.content),
@@ -99,7 +104,7 @@ export class OpenAIProvider implements AIProvider {
           arguments: toolCall.function.arguments,
         },
       }));
-      const reasoningContent = this.extractOpenAIReasoningContent(message);
+      const reasoningContent = this.extractOpenAIReasoningContent(message, options?.reasoningReplayMode);
       if (reasoningContent) {
         sanitized.reasoning_content = reasoningContent;
       }
@@ -111,8 +116,11 @@ export class OpenAIProvider implements AIProvider {
     return sanitized;
   }
 
-  private extractOpenAIReasoningContent(message: Message): string | undefined {
-    if (!this.shouldReplayOpenAIReasoningContent()) return undefined;
+  private extractOpenAIReasoningContent(
+    message: Message,
+    replayMode?: AIRequestOptions['reasoningReplayMode'],
+  ): string | undefined {
+    if (!this.shouldReplayOpenAIReasoningContent(replayMode)) return undefined;
     if (!this.canReplayProviderContent(message, 'openai-chat-completions')) return undefined;
     if (!Array.isArray(message.providerContent) || !message.tool_calls?.length) return undefined;
     const block = message.providerContent.find(item =>
@@ -127,7 +135,8 @@ export class OpenAIProvider implements AIProvider {
     return reasoning || undefined;
   }
 
-  private shouldReplayOpenAIReasoningContent(): boolean {
+  private shouldReplayOpenAIReasoningContent(replayMode?: AIRequestOptions['reasoningReplayMode']): boolean {
+    if (replayMode) return replayMode === 'include';
     return supportsOpenAIReasoningReplay({
       apiUrl: this.apiUrl,
       model: this.model,
@@ -184,7 +193,7 @@ export class OpenAIProvider implements AIProvider {
     if (this.openaiApiMode === 'responses') {
       return this.chatResponses(messages, tools, options);
     }
-    const body = this.buildRequestBody(messages, tools, false);
+    const body = this.buildRequestBody(messages, tools, false, options);
     ContextDebugLogger.dumpSdkBoundary('before', undefined, {
       apiUrl: this.chatCompletionsUrl,
       body,
@@ -231,7 +240,7 @@ export class OpenAIProvider implements AIProvider {
     if (this.openaiApiMode === 'responses') {
       return this.chatStreamResponses(messages, tools, callbacks, options);
     }
-    const body = this.buildRequestBody(messages, tools, true);
+    const body = this.buildRequestBody(messages, tools, true, options);
 
     ContextDebugLogger.dumpSdkBoundary('before', undefined, {
       apiUrl: this.chatCompletionsUrl,

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -1,6 +1,8 @@
 import { Message, ChatResponse } from '../types';
 import { ToolDefinition } from '../types/tool';
 import type { ProviderRequestPreflightSummary } from './request-preflight';
+import type { OpenAIReasoningReplayMode } from '../utils/reasoning-effort';
+import type { ReasoningReplayRecoveryAction } from './deepseek-reasoning-recovery';
 
 /**
  * Streaming 回调
@@ -24,6 +26,7 @@ export interface StreamRetryInfo {
   maxElapsedMs: number;
   status?: string | number;
   message?: string;
+  recoveryAction?: ReasoningReplayRecoveryAction;
 }
 
 export type ModelAttemptApiType = 'anthropic-messages' | 'openai-chat-completions' | 'openai-responses';
@@ -50,6 +53,7 @@ export interface ModelAttemptRetry {
   maxElapsedMs: number;
   delayMs?: number;
   stopReason?: ModelAttemptStopReason;
+  recoveryAction?: ReasoningReplayRecoveryAction;
 }
 
 /**
@@ -89,6 +93,8 @@ export interface ModelAttemptSink {
 
 export interface AIRequestOptions {
   signal?: AbortSignal;
+  /** Internal one-attempt override used by evidence-driven DeepSeek recovery. */
+  reasoningReplayMode?: OpenAIReasoningReplayMode;
   /** Optional best-effort observer; it can never alter request control flow. */
   modelAttemptSink?: ModelAttemptSink;
   modelAttemptContext?: ModelAttemptContext;

--- a/src/utils/ai-service.ts
+++ b/src/utils/ai-service.ts
@@ -16,6 +16,11 @@ import {
   prepareProviderRequestMessages,
   type ProviderRequestPreflightSummary,
 } from '../providers/request-preflight';
+import {
+  planDeepSeekReasoningRecovery,
+  type ReasoningReplayRecoveryAction,
+} from '../providers/deepseek-reasoning-recovery';
+import type { OpenAIReasoningReplayMode } from './reasoning-effort';
 import { Logger } from './logger';
 import { isPrimaryModelToolCallingCapable } from './model-capabilities';
 import { resolveModelContextWindow } from './model-context-window';
@@ -64,6 +69,18 @@ interface ModelAttemptRun {
   tools: readonly ToolDefinition[];
   stream: boolean;
   preflight?: ProviderRequestPreflightSummary;
+}
+
+interface RetryRecoveryPlan {
+  action: ReasoningReplayRecoveryAction;
+  messages: Message[];
+  apply(): void;
+}
+
+interface ReasoningRecoveryRuntime {
+  getMessages(): Message[];
+  getOptions(): AIRequestOptions;
+  plan(error: unknown): RetryRecoveryPlan | undefined;
 }
 
 export class AIService {
@@ -140,13 +157,24 @@ export class AIService {
     }
 
     const prepared = this.prepareProviderRequest(messages);
+    const recovery = this.createReasoningRecoveryRuntime(prepared.messages, options);
+    const attemptRun = this.createModelAttemptRun(
+      recovery.getMessages(),
+      tools,
+      false,
+      options,
+      prepared.summary,
+    );
     try {
       return await this.withRetry(
-        async () => this.requireUsableResponse(await this.provider.chat(prepared.messages, tools, options)),
+        async () => this.requireUsableResponse(
+          await this.provider.chat(recovery.getMessages(), tools, recovery.getOptions()),
+        ),
         undefined,
         options.signal,
         undefined,
-        this.createModelAttemptRun(prepared.messages, tools, false, options, prepared.summary),
+        attemptRun,
+        error => recovery.plan(error),
       );
     } catch (error: any) {
       throw this.wrapError(error);
@@ -170,6 +198,7 @@ export class AIService {
 
     const allowStreamRetry = process.env.GAUZ_STREAM_RETRY === 'true';
     const prepared = this.prepareProviderRequest(messages);
+    const recovery = this.createReasoningRecoveryRuntime(prepared.messages, options);
     let hasStreamedText = false;
     const providerCallbacks = this.createProviderStreamCallbacks(callbacks, () => {
       hasStreamedText = true;
@@ -178,12 +207,18 @@ export class AIService {
     try {
       const result = await this.withRetry(
         async () => this.requireUsableResponse(
-          await this.provider.chatStream(prepared.messages, tools, providerCallbacks, options),
+          await this.provider.chatStream(
+            recovery.getMessages(),
+            tools,
+            providerCallbacks,
+            recovery.getOptions(),
+          ),
         ),
         callbacks,
         options.signal,
         () => allowStreamRetry || !hasStreamedText,
-        this.createModelAttemptRun(prepared.messages, tools, true, options, prepared.summary),
+        this.createModelAttemptRun(recovery.getMessages(), tools, true, options, prepared.summary),
+        error => recovery.plan(error),
       );
       callbacks?.onComplete?.(result);
       return result;
@@ -219,6 +254,39 @@ export class AIService {
       );
     }
     return prepared;
+  }
+
+  private createReasoningRecoveryRuntime(
+    initialMessages: Message[],
+    options: AIRequestOptions,
+  ): ReasoningRecoveryRuntime {
+    let messages = initialMessages;
+    let replayMode: OpenAIReasoningReplayMode | undefined;
+    let recoveryUsed = false;
+
+    return {
+      getMessages: () => messages,
+      getOptions: () => replayMode ? { ...options, reasoningReplayMode: replayMode } : options,
+      plan: (error: unknown) => {
+        if (recoveryUsed) return undefined;
+        const recovery = planDeepSeekReasoningRecovery({
+          error,
+          config: this.config,
+          messages,
+          currentMode: replayMode,
+        });
+        if (!recovery) return undefined;
+        return {
+          action: recovery.action,
+          messages: recovery.messages,
+          apply: () => {
+            recoveryUsed = true;
+            messages = recovery.messages;
+            replayMode = recovery.replayMode;
+          },
+        };
+      },
+    };
   }
 
   private requireUsableResponse(response: ChatResponse): ChatResponse {
@@ -407,6 +475,7 @@ export class AIService {
     signal?: AbortSignal,
     shouldRetry?: (error: any, attempt: number) => boolean,
     attemptRun?: ModelAttemptRun,
+    planRetryRecovery?: (error: unknown) => RetryRecoveryPlan | undefined,
   ): Promise<T> {
     const startedAt = Date.now();
 
@@ -443,16 +512,21 @@ export class AIService {
           throw this.createAbortError();
         }
 
-        const policy = this.resolveRetryPolicy(error);
         const retryAttempt = attempt + 1;
         const elapsedMs = Date.now() - startedAt;
-        const stopReason = this.resolveRetryStopReason(
-          error,
-          retryAttempt,
-          policy,
-          elapsedMs,
-          shouldRetry,
-        );
+        const streamAllowsRetry = shouldRetry?.(error, retryAttempt) !== false;
+        const recovery = streamAllowsRetry ? planRetryRecovery?.(error) : undefined;
+        const policy = recovery ? {
+          maxRetries: 1,
+          maxElapsedMs: 30_000,
+          baseDelayMs: 0,
+          maxDelayMs: 0,
+        } : this.resolveRetryPolicy(error);
+        const stopReason = recovery
+          ? undefined
+          : streamAllowsRetry
+            ? this.resolveRetryStopReason(error, retryAttempt, policy, elapsedMs)
+            : 'stream_output_started';
         if (stopReason) {
           attachRetrySummary(error, {
             attempt_count: attemptNumber,
@@ -483,7 +557,7 @@ export class AIService {
         }
 
         // 计算等待时间：优先用 Retry-After，否则指数退避
-        const delay = this.resolveRetryDelayMs(error, retryAttempt, policy, elapsedMs);
+        const delay = recovery ? 0 : this.resolveRetryDelayMs(error, retryAttempt, policy, elapsedMs);
         this.emitModelAttempt(attemptRun, attemptNumber, {
           outcome: 'retrying',
           durationMs: Date.now() - attemptStartedAt,
@@ -494,27 +568,37 @@ export class AIService {
             delayMs: delay,
             elapsedMs,
             maxElapsedMs: policy.maxElapsedMs,
+            ...(recovery ? { recoveryAction: recovery.action } : {}),
           },
         });
 
         const status = this.extractStatus(error) || this.extractErrorCode(error) || 'unknown';
         const retryInfo: StreamRetryInfo = {
-          attempt: retryAttempt,
+          attempt: recovery ? 1 : retryAttempt,
           maxRetries: policy.maxRetries,
           delayMs: delay,
           elapsedMs,
           maxElapsedMs: policy.maxElapsedMs,
           status,
           message: this.extractErrorMessage(error),
+          ...(recovery ? { recoveryAction: recovery.action } : {}),
         };
-        await this.notifyRetry(callbacks, retryAttempt, policy.maxRetries, retryInfo);
-
-        Logger.warning(
-          `API 调用失败 (${status})，${delay.toFixed(0)}ms 后重试 (${retryAttempt}/${policy.maxRetries})... `
-          + `[${this.config.provider}/${this.config.model || 'default'}]`
-        );
-
-        await this.sleepWithAbort(delay, signal);
+        if (recovery) {
+          recovery.apply();
+          if (attemptRun) attemptRun.messages = recovery.messages;
+          await this.notifyRetry(callbacks, 1, 1, retryInfo);
+          Logger.warning(
+            `Provider reasoning replay dialect repaired (${recovery.action}); retrying once `
+            + `[${this.config.provider}/${this.config.model || 'default'}]`,
+          );
+        } else {
+          await this.notifyRetry(callbacks, retryAttempt, policy.maxRetries, retryInfo);
+          Logger.warning(
+            `API 调用失败 (${status})，${delay.toFixed(0)}ms 后重试 (${retryAttempt}/${policy.maxRetries})... `
+            + `[${this.config.provider}/${this.config.model || 'default'}]`,
+          );
+          await this.sleepWithAbort(delay, signal);
+        }
       }
     }
   }
@@ -524,10 +608,8 @@ export class AIService {
     retryAttempt: number,
     policy: RetryPolicy,
     elapsedMs: number,
-    shouldRetry?: (error: any, attempt: number) => boolean,
   ): ModelAttemptStopReason | undefined {
     if (!this.isRetryable(error)) return 'non_retryable';
-    if (shouldRetry?.(error, retryAttempt) === false) return 'stream_output_started';
     if (retryAttempt > policy.maxRetries) return 'retry_limit_exhausted';
     if (elapsedMs >= policy.maxElapsedMs) return 'retry_window_exhausted';
     return undefined;

--- a/src/utils/model-error-classifier.ts
+++ b/src/utils/model-error-classifier.ts
@@ -133,6 +133,11 @@ export function classifyModelError(
   if (known.isEmptyResponse) return result('empty_response', 'empty_model_response', 'high', 'transport', 'retry_same_context');
   if (known.isTransient) return result('transient', 'transient_provider_error', 'high', 'transport', 'retry_later');
 
+  if (/reasoning[_\s-]?content.{0,100}(?:unknown|unrecognized|unsupported|unexpected|not allowed|not permitted|must not be)/i.test(evidence)
+    || /(?:unknown|unrecognized|unsupported|unexpected|extra) (?:field|parameter).{0,80}reasoning[_\s-]?content/i.test(evidence)) {
+    return result('reasoning_replay_required', 'reasoning_replay_incompatible', 'high', 'fix_and_retry_once', 'repair_session');
+  }
+
   if (/reasoning[_\s-]?(?:content|text).{0,80}(must be passed back|must be echoed|not passed back|required|expected)/i.test(evidence)
     || /thinking mode.{0,80}reasoning/i.test(evidence)) {
     return result('reasoning_replay_required', 'reasoning_replay_required', 'high', 'fix_and_retry_once', 'repair_session');

--- a/src/utils/reasoning-effort.ts
+++ b/src/utils/reasoning-effort.ts
@@ -21,6 +21,7 @@ const NORMALIZABLE_REASONING_EFFORTS = [
 ];
 
 type ReasoningModelFamily = 'deepseek' | 'glm' | 'gpt56';
+export type OpenAIReasoningReplayMode = 'include' | 'omit';
 
 export function normalizeReasoningEffort(value: unknown): ReasoningEffort | undefined {
   const text = String(value || '').trim().toLowerCase();
@@ -83,7 +84,20 @@ export function supportsReasoningSwitch(config: Pick<ChatConfig, 'model' | 'apiU
 }
 
 export function supportsOpenAIReasoningReplay(config: Pick<ChatConfig, 'model' | 'apiUrl'>): boolean {
-  return inferReasoningModelFamily(config) === 'deepseek';
+  return resolveOpenAIReasoningReplayMode(config) === 'include';
+}
+
+/**
+ * DeepSeek has two incompatible Chat Completions dialects: legacy
+ * deepseek-reasoner rejects replay, while current thinking/tool-call models
+ * require it. Explicit provider evidence may override this default once.
+ */
+export function resolveOpenAIReasoningReplayMode(
+  config: Pick<ChatConfig, 'model' | 'apiUrl'>,
+): OpenAIReasoningReplayMode | undefined {
+  if (inferReasoningModelFamily(config) !== 'deepseek') return undefined;
+  const model = String(config.model || '').trim().toLowerCase();
+  return /^deepseek-reasoner(?:$|[-_:])/.test(model) ? 'omit' : 'include';
 }
 
 function inferReasoningModelFamily(config: Pick<ChatConfig, 'model' | 'apiUrl'>): ReasoningModelFamily | undefined {

--- a/tests/cache-trace-monitoring.test.ts
+++ b/tests/cache-trace-monitoring.test.ts
@@ -261,6 +261,41 @@ test('observer records provider request preflight repairs without storing messag
   }
 });
 
+test('observer records evidence-driven reasoning recovery on the exact retry attempt', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-cache-reasoning-recovery-'));
+  try {
+    const observer = new CacheTraceObserver({
+      sessionId: 'cache:reasoning-recovery',
+      traceDir: dir,
+      env: { XIAOBA_CACHE_TRACE: 'true' },
+    });
+    observer.observe(attemptEvent({ outcome: 'started' }));
+    observer.observe(attemptEvent({
+      outcome: 'retrying',
+      error: Object.assign(new Error('reasoning_content is required'), { response: { status: 400 } }),
+      retry: {
+        retryNumber: 1,
+        maxRetries: 1,
+        elapsedMs: 3,
+        maxElapsedMs: 30_000,
+        delayMs: 0,
+        recoveryAction: 'reasoning_history_degrade',
+      },
+    }));
+    await observer.drain();
+
+    const lines = fs.readFileSync(listTraceFiles(dir)[0], 'utf8')
+      .trim()
+      .split(/\r?\n/)
+      .map(line => JSON.parse(line));
+    assert.equal(lines[0].lifecycle.retry_recovery_action, undefined);
+    assert.equal(lines[1].lifecycle.retry_recovery_action, 'reasoning_history_degrade');
+    assert.equal(lines[1].failure.http_status, 400);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('one attempt keeps one JSONL file when it crosses midnight', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-cache-midnight-'));
   try {

--- a/tests/catscompany-content-blocks.test.ts
+++ b/tests/catscompany-content-blocks.test.ts
@@ -171,6 +171,25 @@ describe('CatsCo content blocks', () => {
     assert.equal(sentThinking[0].metadata.delay_ms, 8000);
   });
 
+  test('reasoning dialect recovery is explained as a local repair, not a connection failure', async () => {
+    const { bot, sentThinking, replies } = createProcessHarness();
+    const callbacks = (bot as any).buildSessionCallbacks('p2p_repair');
+
+    await callbacks.onRetry(1, 1, {
+      attempt: 1,
+      maxRetries: 1,
+      delayMs: 0,
+      elapsedMs: 20,
+      maxElapsedMs: 30_000,
+      status: 400,
+      recoveryAction: 'reasoning_history_degrade',
+    });
+
+    assert.equal(replies.length, 0);
+    assert.equal(sentThinking[0].text, '检测到历史推理状态缺失，已安全降级旧工具记录，正在自动修复后重试 1/1...');
+    assert.equal(sentThinking[0].metadata.recovery_action, 'reasoning_history_degrade');
+  });
+
   test('parses text and multiple attachments from one CatsCompany message', () => {
     const bot = Object.create(CatsCompanyBot.prototype);
 

--- a/tests/deepseek-reasoning-recovery.test.ts
+++ b/tests/deepseek-reasoning-recovery.test.ts
@@ -1,0 +1,124 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import type { Message } from '../src/types';
+import { planDeepSeekReasoningRecovery } from '../src/providers/deepseek-reasoning-recovery';
+import { createProviderStateReference } from '../src/providers/provider-state';
+import { resolveOpenAIReasoningReplayMode } from '../src/utils/reasoning-effort';
+
+function rejection(message: string, status = 400): unknown {
+  return { response: { status, data: { error: { message } } } };
+}
+
+function toolExchange(providerState?: Message['providerState']): Message[] {
+  return [
+    { role: 'user', content: 'find cats' },
+    {
+      role: 'assistant',
+      content: null,
+      tool_calls: [{
+        id: 'call_1',
+        type: 'function',
+        function: { name: 'lookup', arguments: '{"q":"cats"}' },
+      }],
+      ...(providerState ? {
+        providerContent: [
+          { type: 'openai_reasoning', reasoning_content: 'opaque chain' },
+          { type: 'tool_use', id: 'call_1', name: 'lookup', input: { q: 'cats' } },
+        ],
+        providerState,
+      } : {}),
+    },
+    { role: 'tool', tool_call_id: 'call_1', name: 'lookup', content: 'cats found' },
+    { role: 'user', content: 'continue' },
+  ];
+}
+
+const v4Config = {
+  provider: 'openai' as const,
+  apiUrl: 'https://api.deepseek.com/v1',
+  model: 'deepseek-v4-flash',
+  openaiApiMode: 'chat_completions' as const,
+};
+
+test('DeepSeek replay defaults distinguish legacy reasoner from current thinking models', () => {
+  assert.equal(resolveOpenAIReasoningReplayMode(v4Config), 'include');
+  assert.equal(resolveOpenAIReasoningReplayMode({
+    apiUrl: 'https://api.deepseek.com/v1',
+    model: 'deepseek-reasoner',
+  }), 'omit');
+  assert.equal(resolveOpenAIReasoningReplayMode({
+    apiUrl: 'https://api.openai.com/v1',
+    model: 'gpt-5.6-sol',
+  }), undefined);
+});
+
+test('explicit rejection can switch a current DeepSeek request to omit replay', () => {
+  const state = createProviderStateReference({
+    apiType: 'openai-chat-completions',
+    endpoint: 'https://api.deepseek.com/v1/chat/completions',
+    model: 'deepseek-v4-flash',
+  });
+  const messages = toolExchange(state);
+  const plan = planDeepSeekReasoningRecovery({
+    error: rejection('Unknown field reasoning_content: parameter is not allowed'),
+    config: v4Config,
+    messages,
+    currentMode: undefined,
+  });
+
+  assert.equal(plan?.action, 'reasoning_replay_omit');
+  assert.equal(plan?.replayMode, 'omit');
+  assert.equal(plan?.messages, messages);
+});
+
+test('legacy reasoner can switch to include replay when the endpoint explicitly requires it', () => {
+  const config = { ...v4Config, model: 'deepseek-reasoner' };
+  const state = createProviderStateReference({
+    apiType: 'openai-chat-completions',
+    endpoint: 'https://api.deepseek.com/v1/chat/completions',
+    model: 'deepseek-reasoner',
+  });
+  const messages = toolExchange(state);
+  const plan = planDeepSeekReasoningRecovery({
+    error: rejection('reasoning_content must be passed back for thinking mode tool calls'),
+    config,
+    messages,
+    currentMode: undefined,
+  });
+
+  assert.equal(plan?.action, 'reasoning_replay_include');
+  assert.equal(plan?.replayMode, 'include');
+  assert.equal(plan?.messages, messages);
+});
+
+test('missing opaque reasoning degrades only the affected historical tool exchange', () => {
+  const messages = toolExchange();
+  const plan = planDeepSeekReasoningRecovery({
+    error: rejection('reasoning_content is required and was missing'),
+    config: v4Config,
+    messages,
+    currentMode: undefined,
+  });
+
+  assert.equal(plan?.action, 'reasoning_history_degrade');
+  assert.equal(plan?.degradedExchanges, 1);
+  assert.deepEqual(plan?.messages.map(message => message.role), ['user', 'user', 'user']);
+  assert.match(String(plan?.messages[1].content), /cats found/);
+  assert.equal(plan?.messages.some(message => message.tool_calls?.length), false);
+  assert.equal(plan?.messages.some(message => message.role === 'tool'), false);
+});
+
+test('bare rejections, unrelated providers, and non-request statuses never trigger repair', () => {
+  for (const input of [
+    { error: rejection('bad request'), config: v4Config },
+    { error: rejection('reasoning_content is required', 503), config: v4Config },
+    { error: rejection('reasoning_content is required'), config: { ...v4Config, model: 'gpt-test', apiUrl: 'https://api.openai.com/v1' } },
+    { error: rejection('reasoning_content is required'), config: { ...v4Config, provider: 'anthropic' as const } },
+  ]) {
+    assert.equal(planDeepSeekReasoningRecovery({
+      ...input,
+      messages: toolExchange(),
+      currentMode: undefined,
+    }), undefined);
+  }
+});

--- a/tests/model-attempt-lifecycle.test.ts
+++ b/tests/model-attempt-lifecycle.test.ts
@@ -145,6 +145,106 @@ test('repairs malformed tool exchanges before invocation and records the preflig
   });
 });
 
+test('recovers once when DeepSeek explicitly requires missing reasoning history', async () => {
+  const service = createTestService({
+    apiUrl: 'https://api.deepseek.com/v1',
+    model: 'deepseek-v4-flash',
+  });
+  const events: ModelAttemptEvent[] = [];
+  const providerRequests: Array<{ messages: Message[]; options: any }> = [];
+  let calls = 0;
+  (service as any).provider = {
+    chat: async (messages: Message[], _tools: unknown, options: unknown) => {
+      calls++;
+      providerRequests.push({ messages, options });
+      if (calls === 1) {
+        throw {
+          response: {
+            status: 400,
+            data: { error: { message: 'reasoning_content is required and was missing' } },
+          },
+        };
+      }
+      return { content: 'recovered after local history repair' };
+    },
+    chatStream: async () => ({ content: 'unused' }),
+  };
+  const messages: Message[] = [
+    { role: 'user', content: 'find cats' },
+    {
+      role: 'assistant',
+      content: null,
+      tool_calls: [{
+        id: 'call_1',
+        type: 'function',
+        function: { name: 'lookup', arguments: '{}' },
+      }],
+    },
+    { role: 'tool', tool_call_id: 'call_1', name: 'lookup', content: 'cats found' },
+    { role: 'user', content: 'continue' },
+  ];
+
+  const result = await service.chat(messages, undefined, {
+    modelAttemptSink: collectingSink(events),
+  });
+
+  assert.equal(result.content, 'recovered after local history repair');
+  assert.equal(calls, 2);
+  assert.equal(providerRequests[0].messages.some(message => message.tool_calls?.length), true);
+  assert.equal(providerRequests[1].messages.some(message => message.tool_calls?.length), false);
+  assert.equal(providerRequests[1].messages.some(message => message.role === 'tool'), false);
+  assert.equal(providerRequests[1].options.reasoningReplayMode, 'include');
+  assert.deepEqual(events.map(event => event.outcome), ['started', 'retrying', 'started', 'succeeded']);
+  assert.equal(events[1].retry?.recoveryAction, 'reasoning_history_degrade');
+  assert.equal(events[1].retry?.delayMs, 0);
+  assert.equal(events[0].request.messages, providerRequests[0].messages);
+  assert.equal(events[2].request.messages, providerRequests[1].messages);
+});
+
+test('DeepSeek reasoning recovery is evidence-driven and bounded to one retry', async () => {
+  const service = createTestService({
+    apiUrl: 'https://api.deepseek.com/v1',
+    model: 'deepseek-v4-flash',
+  });
+  const events: ModelAttemptEvent[] = [];
+  let calls = 0;
+  (service as any).provider = {
+    chat: async () => {
+      calls++;
+      throw {
+        response: {
+          status: 400,
+          data: { error: { message: 'reasoning_content is required and was missing' } },
+        },
+      };
+    },
+    chatStream: async () => ({ content: 'unused' }),
+  };
+  const messages: Message[] = [
+    {
+      role: 'assistant',
+      content: 'historical attempt',
+      tool_calls: [{
+        id: 'call_1',
+        type: 'function',
+        function: { name: 'lookup', arguments: '{}' },
+      }],
+    },
+    { role: 'tool', tool_call_id: 'call_1', content: 'old result' },
+    { role: 'user', content: 'continue' },
+  ];
+
+  await assert.rejects(
+    () => service.chat(messages, undefined, { modelAttemptSink: collectingSink(events) }),
+    /API错误 \(400\): reasoning_content is required and was missing/,
+  );
+
+  assert.equal(calls, 2);
+  assert.deepEqual(events.map(event => event.outcome), ['started', 'retrying', 'started', 'failed']);
+  assert.equal(events[1].retry?.recoveryAction, 'reasoning_history_degrade');
+  assert.equal(events[3].retry?.stopReason, 'non_retryable');
+});
+
 test('distinguishes a stream failure after visible output from a retryable failure', async () => {
   const service = createTestService();
   const events: ModelAttemptEvent[] = [];

--- a/tests/model-error-observability.test.ts
+++ b/tests/model-error-observability.test.ts
@@ -115,5 +115,13 @@ describe('model error observability', () => {
     assert.equal(replay.category, 'reasoning_replay_required');
     assert.equal(replay.retry_strategy, 'fix_and_retry_once');
     assert.equal(replay.recovery_action, 'repair_session');
+
+    const incompatibleReplay = classifyModelError(
+      new Error('Unknown field reasoning_content: this parameter is not allowed'),
+      noKnownFlags,
+    );
+    assert.equal(incompatibleReplay.category, 'reasoning_replay_required');
+    assert.equal(incompatibleReplay.error_code, 'reasoning_replay_incompatible');
+    assert.equal(incompatibleReplay.confidence, 'high');
   });
 });

--- a/tests/openai-provider-runtime-feedback.test.ts
+++ b/tests/openai-provider-runtime-feedback.test.ts
@@ -353,6 +353,39 @@ describe('OpenAIProvider runtime feedback boundary', () => {
     assert.equal(body.messages[0].reasoning_content, 'private deepseek chain');
   });
 
+  test('legacy deepseek-reasoner omits replay by default but accepts an evidence-driven override', () => {
+    const provider = new OpenAIProvider({
+      apiKey: 'test-key',
+      apiUrl: 'https://api.deepseek.com/v1',
+      model: 'deepseek-reasoner',
+    });
+    const message = {
+      role: 'assistant' as const,
+      content: null,
+      tool_calls: [{
+        id: 'call_1',
+        type: 'function' as const,
+        function: { name: 'lookup', arguments: '{"query":"cats"}' },
+      }],
+      providerContent: [
+        { type: 'openai_reasoning', reasoning_content: 'legacy private chain' },
+        { type: 'tool_use', id: 'call_1', name: 'lookup', input: { query: 'cats' } },
+      ],
+      providerState: (provider as any).providerStateReference('openai-chat-completions'),
+    };
+
+    const defaultBody = (provider as any).buildRequestBody([message]);
+    const repairedBody = (provider as any).buildRequestBody(
+      [message],
+      undefined,
+      false,
+      { reasoningReplayMode: 'include' },
+    );
+
+    assert.equal(defaultBody.messages[0].reasoning_content, undefined);
+    assert.equal(repairedBody.messages[0].reasoning_content, 'legacy private chain');
+  });
+
   test('does not replay DeepSeek reasoning content from another model scope', () => {
     const source = new OpenAIProvider({
       apiKey: 'test-key',


### PR DESCRIPTION
## Why

DeepSeek Chat Completions has incompatible reasoning replay dialects. Current thinking + tool-call models require `reasoning_content` on the next tool subrequest, while the legacy `deepseek-reasoner` contract rejects replayed reasoning. Treating every DeepSeek-compatible endpoint the same can turn an otherwise recoverable session into a terminal 400 and a misleading “connection error” retry message.

## What changed

- default legacy `deepseek-reasoner` to omit replay and current DeepSeek thinking models to include it
- keep exact model/API/endpoint provider-state compatibility checks from the parent stage
- recognize only explicit 400/422 evidence that reasoning must be included or omitted
- perform at most one evidence-driven opposite-dialect retry
- when required reasoning is no longer available after session restore, degrade only affected historical tool exchanges into bounded plain context
- never repair or retry a bare 400/403 through this path
- preserve exact request identity per attempt before and after recovery
- record the recovery action on model-attempt and Cache Trace lifecycle events
- explain the retry to users as a local context repair rather than a connection failure
- classify a second explicit dialect rejection with high-confidence structured diagnostics

## Validation

- `npm run build`
- 88 DeepSeek/provider/attempt/cache/message UX tests passed
- 106 shared retry/conversation/session/preflight tests passed
- full runtime suite: 1333 passed, 8 skipped; only the pre-existing PDF parser async rejection remained in the clean run
- compiled `dist` smoke used the real `AIService` and `OpenAIProvider` body builder: first wire request retained tool history, explicit 400 triggered one recovery, second wire request removed invalid structured history and succeeded
- bare request rejection remains non-retryable; repeated reasoning rejection stops after the one repair attempt

## UI

No Dashboard UI changes. CatsCompany retry text and metadata are covered by adapter tests.

## Stack

Draft base: `agent/provider-request-preflight` (#295).
