### PR TITLE
fix: await PDF parser cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "gray-matter": "^4.0.3",
         "inquirer": "^8.2.7",
         "ora": "^5.4.1",
-        "pdf-parse": "^1.1.1",
         "pdfjs-dist": "^4.6.82",
         "sharp": "^0.34.5"
       },
@@ -6898,12 +6897,6 @@
         "node": ">=10.5.0"
       }
     },
-    "node_modules/node-ensure": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
-      "integrity": "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==",
-      "license": "MIT"
-    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -7352,28 +7345,6 @@
       "optional": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/pdf-parse": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.1.tgz",
-      "integrity": "sha512-v6ZJ/efsBpGrGGknjtq9J/oC8tZWq0KWL5vQrk2GlzLEQPUDB1ex+13Rmidl1neNN358Jn9EHZw5y07FFtaC7A==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^3.1.0",
-        "node-ensure": "^0.0.0"
-      },
-      "engines": {
-        "node": ">=6.8.1"
-      }
-    },
-    "node_modules/pdf-parse/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
       }
     },
     "node_modules/pdfjs-dist": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "gray-matter": "^4.0.3",
     "inquirer": "^8.2.7",
     "ora": "^5.4.1",
-    "pdf-parse": "^1.1.1",
     "pdfjs-dist": "^4.6.82",
     "sharp": "^0.34.5"
   },

--- a/src/tools/read-tool.ts
+++ b/src/tools/read-tool.ts
@@ -37,21 +37,12 @@ const PDF_VISUAL_INTENT_PATTERNS = [
   /\b(image|photo|picture|screenshot|scan|scanned|signature|handwriting|stamp|seal|layout|table|chart|diagram|visual)\b/i,
 ];
 
-interface PdfParseOptions {
-  max?: number;
-  version?: string;
-  pagerender?: (pageData: any) => Promise<string>;
-}
-
-interface PdfParseResult {
+interface PdfTextExtractionResult {
   numpages?: number;
   numrender?: number;
   text?: string;
   info?: Record<string, unknown>;
 }
-
-type PdfParse = (dataBuffer: Buffer, options?: PdfParseOptions) => Promise<PdfParseResult>;
-const pdfParse: PdfParse = require('pdf-parse');
 
 interface TextReadOptions {
   offset?: unknown;
@@ -555,38 +546,74 @@ export class ReadTool implements Tool {
     ];
   }
 
-  private async extractPdfText(absolutePath: string, selection: PdfPageSelection): Promise<PdfParseResult> {
-    const data = fs.readFileSync(absolutePath);
+  private async extractPdfText(
+    absolutePath: string,
+    selection: PdfPageSelection,
+  ): Promise<PdfTextExtractionResult> {
+    const pdfjs = await this.loadPdfJsModule();
+    const data = new Uint8Array(fs.readFileSync(absolutePath));
+    const loadingTask = pdfjs.getDocument({
+      data,
+      disableWorker: true,
+      useSystemFonts: true,
+    });
     const selectedPages = selection.selectedPages;
-    const options: PdfParseOptions = {
-      max: selection.maxPageToRender,
-      pagerender: async (pageData: any) => {
-        const pageNumber = typeof pageData?.pageIndex === 'number' ? pageData.pageIndex + 1 : undefined;
-        if (selectedPages && pageNumber && !selectedPages.has(pageNumber)) return '';
+    let doc: any;
+    try {
+      doc = await loadingTask.promise;
+    } catch (error) {
+      try {
+        await loadingTask.destroy();
+      } catch {
+        // Preserve the parser error; cleanup failure is secondary evidence.
+      }
+      throw error;
+    }
+    try {
+      const pageNumbers = selectedPages
+        ? Array.from(selectedPages).filter(page => page <= doc.numPages).sort((a, b) => a - b)
+        : Array.from(
+            { length: Math.min(selection.maxPageToRender, doc.numPages) },
+            (_, index) => index + 1,
+          );
+      const pages: string[] = [];
+      for (const pageNumber of pageNumbers) {
+        const pageData = await doc.getPage(pageNumber);
+        try {
+          const textContent = await pageData.getTextContent({
+            normalizeWhitespace: false,
+            disableCombineTextItems: false,
+          });
 
-        const textContent = await pageData.getTextContent({
-          normalizeWhitespace: false,
-          disableCombineTextItems: false,
-        });
-
-        let lastY: number | undefined;
-        let text = '';
-        for (const item of textContent.items || []) {
-          const value = typeof item?.str === 'string' ? item.str : '';
-          const y = Array.isArray(item?.transform) ? item.transform[5] : undefined;
-          if (!value) continue;
-          if (lastY === undefined || y === lastY) {
-            text += value;
-          } else {
-            text += `\n${value}`;
+          let lastY: number | undefined;
+          let text = '';
+          for (const item of textContent.items || []) {
+            const value = typeof item?.str === 'string' ? item.str : '';
+            const y = Array.isArray(item?.transform) ? item.transform[5] : undefined;
+            if (!value) continue;
+            if (lastY === undefined || y === lastY) {
+              text += value;
+            } else {
+              text += `\n${value}`;
+            }
+            lastY = y;
           }
-          lastY = y;
+          pages.push(text);
+        } finally {
+          pageData.cleanup?.();
         }
-        return text;
-      },
-    };
+      }
 
-    return pdfParse(data, options);
+      return {
+        numpages: doc.numPages,
+        numrender: pageNumbers.length,
+        text: pages.join('\n\n'),
+      };
+    } finally {
+      // pdf-parse 1.x dropped this Promise, causing late unhandled rejections
+      // under concurrent reads. Always wait for PDF.js workers/resources here.
+      await doc.destroy();
+    }
   }
 
   private getPdfRenderedImagePages(selection: PdfPageSelection, totalPages?: number): number[] {
@@ -620,6 +647,24 @@ export class ReadTool implements Tool {
       throw new Error('@napi-rs/canvas createCanvas is unavailable');
     }
     return canvasModule;
+  }
+
+  private installPdfCanvasGlobals(canvasModule: any): void {
+    const globalScope = globalThis as any;
+    if (!globalScope.DOMMatrix && canvasModule.DOMMatrix) globalScope.DOMMatrix = canvasModule.DOMMatrix;
+    if (!globalScope.DOMPoint && canvasModule.DOMPoint) globalScope.DOMPoint = canvasModule.DOMPoint;
+    if (!globalScope.DOMRect && canvasModule.DOMRect) globalScope.DOMRect = canvasModule.DOMRect;
+    if (!globalScope.ImageData && canvasModule.ImageData) globalScope.ImageData = canvasModule.ImageData;
+    if (!globalScope.Path2D && canvasModule.Path2D) globalScope.Path2D = canvasModule.Path2D;
+  }
+
+  private async loadPdfJsModule(): Promise<any> {
+    try {
+      this.installPdfCanvasGlobals(this.loadPdfCanvasModule());
+    } catch {
+      // Text extraction does not need canvas; rendering reports its own error.
+    }
+    return dynamicImport('pdfjs-dist/legacy/build/pdf.mjs');
   }
 
   private createPdfCanvasFactory(canvasModule: any): any {
@@ -660,14 +705,8 @@ export class ReadTool implements Tool {
     tempDir: string,
   ): Promise<RenderedPdfPage[]> {
     const canvasModule = this.loadPdfCanvasModule();
-    const globalScope = globalThis as any;
-    if (!globalScope.DOMMatrix && canvasModule.DOMMatrix) globalScope.DOMMatrix = canvasModule.DOMMatrix;
-    if (!globalScope.DOMPoint && canvasModule.DOMPoint) globalScope.DOMPoint = canvasModule.DOMPoint;
-    if (!globalScope.DOMRect && canvasModule.DOMRect) globalScope.DOMRect = canvasModule.DOMRect;
-    if (!globalScope.ImageData && canvasModule.ImageData) globalScope.ImageData = canvasModule.ImageData;
-    if (!globalScope.Path2D && canvasModule.Path2D) globalScope.Path2D = canvasModule.Path2D;
-
-    const pdfjs = await dynamicImport('pdfjs-dist/legacy/build/pdf.mjs');
+    this.installPdfCanvasGlobals(canvasModule);
+    const pdfjs = await this.loadPdfJsModule();
     const canvasFactory = this.createPdfCanvasFactory(canvasModule);
     const data = new Uint8Array(fs.readFileSync(absolutePath));
     const loadingTask = pdfjs.getDocument({

--- a/tests/tool-result-read-tool.test.ts
+++ b/tests/tool-result-read-tool.test.ts
@@ -52,6 +52,61 @@ function writeVectorOnlyPdf(filePath: string): void {
   fs.writeFileSync(filePath, body, 'ascii');
 }
 
+function writeTextPdf(filePath: string, pageCount = 14): void {
+  const fontId = 3 + pageCount * 2;
+  const pageIds = Array.from({ length: pageCount }, (_, index) => 3 + index * 2);
+  const objects = new Map<number, Buffer>();
+  objects.set(1, Buffer.from('1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n', 'ascii'));
+  objects.set(2, Buffer.from(
+    `2 0 obj\n<< /Type /Pages /Kids [${pageIds.map(id => `${id} 0 R`).join(' ')}] /Count ${pageCount} >>\nendobj\n`,
+    'ascii',
+  ));
+  for (let index = 0; index < pageCount; index++) {
+    const pageId = pageIds[index];
+    const contentId = pageId + 1;
+    const pageText = index === 0
+      ? 'Trace-based Just-in-Time Type Specialization'
+      : index === 1
+        ? 'Every compiled trace belongs to page two'
+        : `Generated PDF page ${index + 1}`;
+    const stream = `BT\n/F1 16 Tf\n36 720 Td\n(${pageText}) Tj\nET`;
+    objects.set(pageId, Buffer.from(
+      `${pageId} 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 ${fontId} 0 R >> >> /Contents ${contentId} 0 R >>\nendobj\n`,
+      'ascii',
+    ));
+    objects.set(contentId, Buffer.from(
+      `${contentId} 0 obj\n<< /Length ${Buffer.byteLength(stream, 'ascii')} >>\nstream\n${stream}\nendstream\nendobj\n`,
+      'ascii',
+    ));
+  }
+  objects.set(fontId, Buffer.from(
+    `${fontId} 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n`,
+    'ascii',
+  ));
+
+  const chunks: Buffer[] = [Buffer.from('%PDF-1.4\n', 'ascii')];
+  const offsets: number[] = [];
+  for (let id = 1; id <= fontId; id++) {
+    offsets[id] = Buffer.concat(chunks).length;
+    chunks.push(objects.get(id)!);
+  }
+  const body = Buffer.concat(chunks);
+  const xref = [
+    `xref\n0 ${fontId + 1}`,
+    '0000000000 65535 f ',
+    ...Array.from({ length: fontId }, (_, index) => (
+      `${String(offsets[index + 1]).padStart(10, '0')} 00000 n `
+    )),
+    'trailer',
+    `<< /Size ${fontId + 1} /Root 1 0 R >>`,
+    'startxref',
+    String(body.length),
+    '%%EOF',
+    '',
+  ].join('\n');
+  fs.writeFileSync(filePath, Buffer.concat([body, Buffer.from(xref, 'ascii')]));
+}
+
 function writeInlineImagePdf(filePath: string): void {
   const inlineImageData = Buffer.from([
     255, 255, 255,
@@ -230,14 +285,8 @@ describe('ReadTool - ToolExecutionResult', () => {
   });
 
   test('PDF 文件会提取正文文本', async () => {
-    const fixturePath = path.join(
-      path.dirname(require.resolve('pdf-parse')),
-      'test',
-      'data',
-      '01-valid.pdf',
-    );
     const filePath = path.join(testRoot, 'fixture.pdf');
-    fs.copyFileSync(fixturePath, filePath);
+    writeTextPdf(filePath);
 
     const result = await tool.execute({ file_path: filePath, pages: '1' }, context);
 
@@ -251,15 +300,24 @@ describe('ReadTool - ToolExecutionResult', () => {
     assert.ok(!content.includes('不再做 PDF 全文解析'));
   });
 
+  test('并发 PDF 文本提取等待各自清理完成', async () => {
+    const filePath = path.join(testRoot, 'concurrent-fixture.pdf');
+    writeTextPdf(filePath);
+
+    const results = await Promise.all(Array.from({ length: 8 }, () => (
+      tool.execute({ file_path: filePath, pages: '1' }, context)
+    )));
+
+    assert.equal(results.length, 8);
+    for (const result of results) {
+      assert.strictEqual(result.ok, true);
+      assert.ok(String(result.content).includes('Trace-based'));
+    }
+  });
+
   test('PDF 默认只读取前若干页并提示继续读取', async () => {
-    const fixturePath = path.join(
-      path.dirname(require.resolve('pdf-parse')),
-      'test',
-      'data',
-      '01-valid.pdf',
-    );
     const filePath = path.join(testRoot, 'fixture-default.pdf');
-    fs.copyFileSync(fixturePath, filePath);
+    writeTextPdf(filePath);
 
     const result = await tool.execute({ file_path: filePath }, context);
 
@@ -274,14 +332,8 @@ describe('ReadTool - ToolExecutionResult', () => {
   });
 
   test('PDF pages 参数只返回指定页内容', async () => {
-    const fixturePath = path.join(
-      path.dirname(require.resolve('pdf-parse')),
-      'test',
-      'data',
-      '01-valid.pdf',
-    );
     const filePath = path.join(testRoot, 'fixture-page-filter.pdf');
-    fs.copyFileSync(fixturePath, filePath);
+    writeTextPdf(filePath);
 
     const result = await tool.execute({ file_path: filePath, pages: '2' }, context);
 
@@ -329,14 +381,8 @@ describe('ReadTool - ToolExecutionResult', () => {
       process.env.CATSCOMPANY_READER_API_URL = `http://127.0.0.1:${address.port}`;
       process.env.CATSCOMPANY_API_KEY = 'cats-reader-test-key';
 
-      const fixturePath = path.join(
-        path.dirname(require.resolve('pdf-parse')),
-        'test',
-        'data',
-        '01-valid.pdf',
-      );
       const filePath = path.join(testRoot, 'fixture-visual-supplement.pdf');
-      fs.copyFileSync(fixturePath, filePath);
+      writeTextPdf(filePath, 1);
       context = {
         ...context,
         conversationHistory: [{ role: 'user', content: '请读取这个 PDF，并检查有没有签名、印章和版式问题' }],


### PR DESCRIPTION
## Summary
- replace the legacy pdf-parse 1.x text path with the already-shipped PDF.js 4.6 runtime
- await document destruction in finally and clean up failed loading tasks without masking the parser error
- share PDF.js canvas globals with the rendering path
- remove the obsolete pdf-parse runtime dependency and generate deterministic PDF fixtures in tests
- add an eight-way concurrent extraction regression

## Why
The old dependency called doc.destroy without awaiting its Promise. Under the full concurrent runtime suite this produced a late unhandled bad XRef rejection after the owning test completed. The same race could affect concurrent Agent PDF reads.

## Verification
- npm run build
- PDF read-tool file: 16 passed, including eight concurrent extractions
- full runtime suite run three times after the core fix, with the final dependency-clean result: 1364 passed, 8 skipped, 0 failed
- CLI startup/help smoke test

## Stack
Depends on #300.