### PR TITLE
Integrate runtime profiles and validate provider caches

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # CatsCo local runtime configuration.
-# Copy this file to .env when running from source. The packaged desktop app
-# creates a user-local .env from this template on first launch.
+# Copy this file to the active Data Root as .env when running from source
+# (default: ~/.xiaoba/.env). The packaged desktop app creates a user-local .env
+# from this template on first launch.
 
 # Main LLM provider. Supported values: anthropic, openai.
 GAUZ_LLM_PROVIDER=anthropic

--- a/README.md
+++ b/README.md
@@ -183,6 +183,26 @@ node dist/index.js chat --interactive
 
 本地 Agent 不要求部署 CatsCo Platform。
 
+源代码目录、Agent 工作目录和运行数据目录彼此独立。CLI 默认把登录配置、会话和日志保存在 `~/.xiaoba`，不会因为切换 Git worktree 而变化。启动时会打印三个目录；也可以显式选择实验 profile：
+
+```bash
+node dist/index.js --profile cache-baseline data status
+node dist/index.js --profile cache-baseline chat --interactive
+```
+
+需要完全指定目录时使用 `--data-dir` 或进程环境变量 `XIAOBA_USER_DATA_DIR`。两者必须在启动命令或 shell 中设置，不能只写在目标目录自己的 `.env` 中：
+
+```bash
+XIAOBA_USER_DATA_DIR=/Users/me/.xiaoba-dev/profiles/default node dist/index.js dashboard
+```
+
+从旧版仓库内 Data Dir 迁移前可先预览；迁移只复制已知运行数据，不覆盖冲突文件，也不删除来源：
+
+```bash
+node dist/index.js --data-dir /Users/me/.xiaoba-dev/profiles/default data migrate --from /path/to/old/XiaoBa-CLI
+node dist/index.js --data-dir /Users/me/.xiaoba-dev/profiles/default data migrate --from /path/to/old/XiaoBa-CLI --apply
+```
+
 ### 连接 CatsCo Platform
 
 ```bash

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -2038,6 +2038,90 @@
       margin-bottom: 20px;
     }
 
+    .runtime-identity-card {
+      margin-bottom: 20px;
+      padding: 18px 20px;
+      border-radius: 22px;
+      background: linear-gradient(135deg, rgba(25, 30, 54, 0.96), rgba(40, 55, 91, 0.94));
+      color: #fff;
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      box-shadow: 0 18px 42px rgba(27, 35, 64, 0.18);
+    }
+
+    .runtime-identity-head {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      margin-bottom: 14px;
+    }
+
+    .runtime-identity-title {
+      font-size: 15px;
+      font-weight: 800;
+    }
+
+    .runtime-identity-badges {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+      gap: 6px;
+    }
+
+    .runtime-identity-badge {
+      padding: 5px 9px;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.1);
+      color: rgba(255, 255, 255, 0.82);
+      font-size: 11px;
+      font-weight: 700;
+    }
+
+    .runtime-identity-grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 10px;
+    }
+
+    .runtime-identity-item {
+      min-width: 0;
+      padding: 11px 12px;
+      border-radius: 14px;
+      background: rgba(255, 255, 255, 0.07);
+      border: 1px solid rgba(255, 255, 255, 0.07);
+    }
+
+    .runtime-identity-label {
+      margin-bottom: 6px;
+      color: rgba(255, 255, 255, 0.56);
+      font-size: 10px;
+      font-weight: 800;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .runtime-identity-path {
+      color: rgba(255, 255, 255, 0.94);
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      font-size: 11px;
+      line-height: 1.5;
+      overflow-wrap: anywhere;
+    }
+
+    .runtime-identity-copy {
+      border: 0;
+      background: rgba(255, 255, 255, 0.1);
+      color: rgba(255, 255, 255, 0.86);
+      padding: 6px 9px;
+      border-radius: 10px;
+      font: inherit;
+      font-size: 11px;
+      font-weight: 700;
+      cursor: pointer;
+    }
+
+    .runtime-identity-copy:hover { background: rgba(255, 255, 255, 0.17); }
+
     .status-card,
     .service-card {
       border-radius: 22px;
@@ -2746,6 +2830,8 @@
         grid-template-columns: 1fr;
         gap: 6px;
       }
+
+      .runtime-identity-grid { grid-template-columns: 1fr; }
     }
 
     @media (max-width: 640px) {
@@ -2768,6 +2854,20 @@
 
       body::after {
         left: -80px;
+      }
+
+      .runtime-identity-card { padding: 16px; }
+      .runtime-identity-head {
+        align-items: flex-start;
+        flex-direction: column;
+      }
+      .runtime-identity-badges {
+        justify-content: flex-start;
+        width: 100%;
+      }
+      .runtime-identity-badge {
+        max-width: 100%;
+        overflow-wrap: anywhere;
       }
 
       .topbar {
@@ -5334,6 +5434,18 @@
           </div>
           <button class="btn btn-primary" onclick="fetchStatus()">刷新状态</button>
         </div>
+        <section class="runtime-identity-card" id="runtime-identity-card" aria-label="当前运行目录">
+          <div class="runtime-identity-head">
+            <div class="runtime-identity-title">当前运行目录</div>
+            <div class="runtime-identity-badges" id="runtime-identity-badges"><span class="runtime-identity-badge">正在读取...</span></div>
+          </div>
+          <div class="runtime-identity-grid">
+            <div class="runtime-identity-item"><div class="runtime-identity-label">Data Root</div><div class="runtime-identity-path" id="runtime-data-root">正在读取...</div></div>
+            <div class="runtime-identity-item"><div class="runtime-identity-label">Code Root</div><div class="runtime-identity-path" id="runtime-code-root">正在读取...</div></div>
+            <div class="runtime-identity-item"><div class="runtime-identity-label">Workspace Root</div><div class="runtime-identity-path" id="runtime-workspace-root">正在读取...</div></div>
+          </div>
+          <div style="display:flex;justify-content:flex-end;margin-top:10px"><button class="runtime-identity-copy" id="copy-runtime-data-root" onclick="copyRuntimeDataRoot()">复制 Data Root</button></div>
+        </section>
         <div class="services-grid robot-grid" id="services-grid"><div class="loading">加载中...</div></div>
 
         <div class="settings-header" style="margin-top:28px">
@@ -7476,12 +7588,45 @@
 
     function renderStatus(d) {
       const grid = document.getElementById('status-grid');
+      renderRuntimeIdentity(d.runtimeIdentity || {});
       if (!grid) return;
       grid.innerHTML =
         '<div class="status-card"><div class="label">Version</div><div class="value">'+escapeHtml(d.version||'-')+'</div></div>'+
         '<div class="status-card"><div class="label">Runtime</div><div class="value">'+escapeHtml(d.platform||'-')+'</div><div class="readiness-summary">Host: '+escapeHtml(d.hostname||'-')+'</div></div>'+
         '<div class="status-card"><div class="label">Model</div><div class="value">'+escapeHtml(d.model||'-')+'</div><div class="readiness-summary">'+escapeHtml(d.provider||'-')+'</div></div>'+
         '<div class="status-card"><div class="label">Skills Path</div><div class="value" style="font-size:12px;word-break:break-all">'+escapeHtml(d.skillsPath||'-')+'</div></div>';
+    }
+
+    function renderRuntimeIdentity(identity) {
+      const dataRoot = document.getElementById('runtime-data-root');
+      const codeRoot = document.getElementById('runtime-code-root');
+      const workspaceRoot = document.getElementById('runtime-workspace-root');
+      const badges = document.getElementById('runtime-identity-badges');
+      if(dataRoot)dataRoot.textContent=identity.dataRoot||'-';
+      if(codeRoot)codeRoot.textContent=identity.codeRoot||'-';
+      if(workspaceRoot)workspaceRoot.textContent=identity.workspaceRoot||'-';
+      if(badges){
+        const code=identity.code||{};
+        const revision=code.commit?((code.branch||'detached')+'@'+String(code.commit).slice(0,8)):'no-git';
+        badges.innerHTML='<span class="runtime-identity-badge">profile: '+escapeHtml(identity.profile||'default')+'</span>'+
+          '<span class="runtime-identity-badge">'+escapeHtml(revision)+(code.dirty?' · dirty':'')+'</span>';
+      }
+    }
+
+    async function copyRuntimeDataRoot(){
+      const value=document.getElementById('runtime-data-root')?.textContent||'';
+      const button=document.getElementById('copy-runtime-data-root');
+      if(!value||value==='-'||value==='正在读取...')return;
+      try{
+        await copyTextToClipboard(value);
+        if(button)button.textContent='已复制';
+        pulsePetState('success','Data Root 已复制',1200);
+      }catch(error){
+        if(button)button.textContent='复制失败';
+        pulsePetState('error','Data Root 复制失败',1800);
+      }finally{
+        setTimeout(()=>{if(button)button.textContent='复制 Data Root';},1400);
+      }
     }
 
     function renderReadiness(data) {

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -5263,9 +5263,43 @@
         position: static;
         width: 100%;
         min-height: auto;
-        padding: 12px;
+        padding: 8px 12px;
         border-right: 0;
         border-bottom: 1px solid var(--border);
+        flex-direction: row;
+        align-items: center;
+        gap: 8px;
+        overflow-x: auto;
+      }
+
+      body:not(.chat-active) .sidebar-brand {
+        flex: 0 0 32px;
+        width: 32px;
+        margin: 0;
+        padding: 0;
+      }
+
+      body:not(.chat-active) .sidebar-brand-icon {
+        width: 32px;
+        height: 32px;
+      }
+
+      body:not(.chat-active) .sidebar-nav {
+        flex: 1 0 auto;
+        flex-direction: row;
+        gap: 4px;
+      }
+
+      body:not(.chat-active) .nav-item {
+        flex: 0 0 40px;
+        width: 40px;
+        min-height: 40px;
+        justify-content: center;
+        padding: 8px;
+      }
+
+      body:not(.chat-active) .sidebar-footer {
+        display: none;
       }
 
       body:not(.chat-active) .main-wrapper {

--- a/docs/ANTHROPIC_PROMPT_CACHE_CANARY.md
+++ b/docs/ANTHROPIC_PROMPT_CACHE_CANARY.md
@@ -5,16 +5,16 @@ the same stable system prefix and use different dynamic system suffixes.
 
 ## Safety boundary
 
-The script always targets `https://api.anthropic.com`; a relay URL cannot be configured. It emits
-only:
+The script defaults to `https://api.anthropic.com`. A compatible endpoint requires both an explicit
+API base and `ANTHROPIC_CANARY_ALLOW_COMPATIBLE=true`. It emits only:
 
 - the request and message IDs;
 - the model and API path;
 - SHA-256 hashes of the stable and dynamic system blocks;
 - input, cache creation/read, and output token usage.
 
-Prompt bodies and credentials are never written to the evidence record. Error output is limited to
-the error type, HTTP status, and request ID.
+Prompt bodies and credentials are never written to the evidence record. Compatible endpoint origins
+are replaced with a hash. Error output is limited to the error type, HTTP status, and request ID.
 
 ## Run
 
@@ -31,6 +31,16 @@ npm run canary:anthropic-prompt-cache -- \
 The command makes two billable API requests. The output file is created with owner-only
 permissions. Inspect the record before attaching it to an issue or pull request; do not attach
 environment files or debug logs.
+
+To probe a compatible endpoint, also set:
+
+```bash
+ANTHROPIC_CANARY_API_BASE=https://... \
+ANTHROPIC_CANARY_ALLOW_COMPATIBLE=true
+```
+
+Passing proves only that endpoint/model pair. XiaoBa keeps compatible Anthropic cache markers
+disabled until an explicit per-endpoint capability mechanism is implemented.
 
 ## Interpret
 

--- a/docs/CONTEXT_CACHE_ARCHITECTURE.md
+++ b/docs/CONTEXT_CACHE_ARCHITECTURE.md
@@ -1,0 +1,173 @@
+# XiaoBa context, cache, and recovery architecture
+
+This document is the working contract for context construction, provider lowering, prompt-cache
+behavior, compaction, and model-call recovery. It describes the code after the cache/reliability
+workstream based on `origin/main` at `b38f2f46`.
+
+## Plain-language model
+
+XiaoBa should keep the beginning of a model request stable, put frequently changing information at
+the end, and never replay provider-private state across a model or API boundary. A model call is
+prepared in four layers:
+
+```text
+durable transcript
+  -> typed session / episode / call context
+  -> structural preflight and provider-state scoping
+  -> OpenAI Responses, Chat Completions, or Anthropic wire format
+  -> one exact attempt record in Cache Trace / Turn Errors
+```
+
+Cache Trace is a development sidecar. It observes exact provider attempts but does not participate
+in request construction, retry decisions, or session persistence. Turning it off must not alter the
+wire request.
+
+## Context lifecycle contract
+
+`Message.__context` is internal metadata and is removed by provider serializers. It carries three
+orthogonal facts:
+
+- `lifecycle`: when the information may be reused (`session`, `episode`, or `call`);
+- `cacheScope`: whether it belongs to the stable prefix, one cache epoch, or only this request
+  (`stable`, `epoch`, or `volatile`);
+- `persistence`: whether it is stored in the durable transcript or rebuilt transiently.
+
+| Context source | Lifecycle | Cache scope | Persistence | Placement / reason |
+|---|---|---|---|---|
+| Core system prompt and stable tool schemas | session | stable | durable or rebuilt | Earliest prefix; changing these should intentionally invalidate the cache |
+| Runtime-observation rules and Skills list | session | stable | transient | Stable session policy before per-turn state |
+| Current execution identity, plan status, runtime feedback, subagent state | episode | epoch | transient | Same throughout one user-turn episode; changes on the next episode |
+| Pending-user-input boundary | episode | epoch | transient | Prevents queued user text from being confused with durable history |
+| Current directory, shell, branch, and request-only hints | call | volatile | transient | Last possible position; never summarized or persisted |
+| Compaction instruction | call | volatile | transient | One-off model request with cache bypass |
+| Compaction summary / boundary | session or episode | epoch | durable | Explicit durable replacement for old history; starts a new cache epoch |
+| Pruned tool-result placeholder | episode | epoch | durable | Preserves tool ID, hash, head/tail, and retrieval instructions |
+
+An internal field alone is not a provider instruction. Each provider cache policy resolves these
+annotations into its own wire dialect. Legacy prefix tags remain only as a compatibility fallback.
+
+## Provider-specific behavior
+
+| Path | Stable prefix policy | Provider-private replay | Usage normalization |
+|---|---|---|---|
+| OpenAI Responses | Stable system text and canonicalized, sorted tools; official OpenAI gets a stable `prompt_cache_key` and supported GPT-5.6 models get an explicit breakpoint | Opaque response items are replayed only when endpoint, model, and API type match | `input_tokens_details.cached_tokens` |
+| OpenAI Chat Completions | Leading stable system messages and canonicalized, sorted tools; compatible endpoints rely on their own automatic prefix cache | `reasoning_content` is replayed only inside the exact provider-state scope | OpenAI nested cached tokens plus DeepSeek `prompt_cache_hit_tokens` |
+| Anthropic Messages | On canonical Anthropic, markers are placed after stable tools, stable system text, and the latest growing conversation boundary | Signed thinking/tool blocks are replayed only inside the exact provider-state scope | `cache_read_input_tokens` and `cache_creation_input_tokens` |
+| DeepSeek Responses / Chat | Automatic exact-prefix disk cache; no OpenAI-only marker is sent | Thinking tool exchanges preserve `reasoning_content`; evidence-driven recovery retries once with the alternate replay dialect when a 400 explicitly identifies it | Responses nested cached tokens; Chat top-level cache-hit tokens |
+
+DeepSeek's cache is automatic and best-effort. Its documented cache units explain why two requests
+with different suffixes may establish a common prefix only for a third request. See the
+[DeepSeek context-caching guide](https://api-docs.deepseek.com/guides/kv_cache/). OpenAI similarly
+requires an exact shared prefix and recommends putting static content first; see
+[OpenAI prompt caching](https://developers.openai.com/api/docs/guides/prompt-caching). Anthropic's
+breakpoints have their own ordering and lifetime rules; see
+[Anthropic prompt caching](https://platform.claude.com/docs/en/build-with-claude/prompt-caching).
+
+### Cache bypass
+
+Checkpoint generation and other one-off summarization calls set `cacheMode: 'bypass'`. This removes
+explicit markers and routing keys for that request and is visible as a distinct Cache Trace
+strategy. A one-off summary should not create a paid cache entry that no later normal turn can
+reuse.
+
+## Structural legality and the former 400 failure
+
+Before every provider attempt, preflight enforces legal tool-call adjacency and repairs only the
+minimum malformed historical exchange. Provider-private blocks carry a fingerprint of API type,
+normalized endpoint, and model. Switching model, endpoint, Responses/Chat, or Anthropic/OpenAI
+therefore drops only the incompatible opaque state while retaining visible conversation content.
+
+For DeepSeek thinking tool calls, the first assistant tool-call response may include private
+`reasoning_content`. The matching tool result and private state must be replayed together. If an
+endpoint explicitly rejects the chosen dialect, XiaoBa can perform one evidence-driven replay
+repair; a generic 400 is not blindly retried as if it were transient.
+
+This is the key distinction in error handling:
+
+- transient transport/load/rate failures can retry within a bounded time window;
+- invalid credentials, quota exhaustion, context overflow, and structural 400s stop immediately or
+  enter a targeted recovery path;
+- once visible stream output has started, the request is not replayed automatically;
+- every actual provider invocation has a correlated `started` and terminal attempt event;
+- a final interrupted turn links to its provider attempt in the Turn Errors report.
+
+## Compaction and pruning
+
+XiaoBa compacts at a provider-aware prompt budget, not a single model-independent threshold. It
+reserves output space, keeps recent verbatim turns, builds an iterative durable summary, and starts
+a new cache epoch. The compaction model call itself bypasses the prompt cache.
+
+Before paying for a summary, deterministic pruning can replace sufficiently old, large tool results.
+The active mid-turn episode and the newest results are protected. A replacement retains protocol
+identity, content SHA-256, character count, a bounded head/tail preview, and an instruction to rerun
+the tool or reread the source. If pruning does not recover enough budget, normal compaction follows.
+
+Native OpenAI Responses compaction is deliberately not enabled yet. Its opaque compaction items
+cannot currently be persisted and replayed losslessly through XiaoBa's generic `Message` transcript.
+Encoding them as visible text would create a subtle correctness bug. The future prerequisite is a
+durable provider-native item algebra; see
+[OpenAI compaction](https://developers.openai.com/api/docs/guides/compaction).
+
+## Comparison with pi and OpenCode
+
+The comparison used pinned snapshots so later upstream changes do not silently change these
+conclusions:
+
+- `earendil-works/pi` at `aa0ec808b970db31822e07835a46647cb51d9d66`;
+- `anomalyco/opencode` at `32f278b48f1a495611165d8a9f1ace0b512933e2`.
+
+| Concern | pi | OpenCode | XiaoBa after this workstream |
+|---|---|---|---|
+| Provider adaptation | Dedicated adapters normalize reasoning and cache usage, including DeepSeek's top-level hit field | AI SDK plus model/provider transforms and provider options | Three explicit wire paths with scoped opaque replay and normalized cache metrics |
+| Cache affinity | Session IDs and provider-specific cache controls; one-off summaries use a fresh route and no cache retention | Stable session/request headers and sorted tools | Stable partition key, canonical tool order, provider cache plans, and request-level bypass |
+| Compaction | Turn-aware cut point, iterative structured summary, recent tail, file-operation carry-forward | Turn-aware head/tail selection, durable compaction parts, bounded recent budget | Checkpoint summary plus recent tail, durable boundary/epoch, remote watermarks, cache bypass |
+| Large tool output | Truncates tool results in summarization input | Marks old completed tool parts compacted after protecting recent turns/tokens | Deterministic durable pruning with protocol IDs, hashes, head/tail, and recovery instruction |
+| Provider metadata | Adapter-owned reasoning blocks | Part-level provider metadata is omitted when replaying under a different model | `providerState` fingerprints endpoint/model/API type and blocks cross-boundary replay |
+| Retry | Adapter retry policies | Typed API/context errors and header-aware retry delays | Typed classifier, bounded retry window, stream-output guard, exact attempt and terminal-turn records |
+| Transient context | Primarily rebuilt runtime context and extension messages | System/user parts and plugins, without a shared lifecycle taxonomy | Explicit session/episode/call + stable/epoch/volatile + durable/transient annotations |
+
+Relevant upstream code:
+
+- pi [compaction](https://github.com/earendil-works/pi/blob/aa0ec808b970db31822e07835a46647cb51d9d66/packages/agent/src/harness/compaction/compaction.ts)
+  and [OpenAI-compatible usage parsing](https://github.com/earendil-works/pi/blob/aa0ec808b970db31822e07835a46647cb51d9d66/packages/ai/src/api/openai-completions.ts);
+- OpenCode [compaction/pruning](https://github.com/anomalyco/opencode/blob/32f278b48f1a495611165d8a9f1ace0b512933e2/packages/opencode/src/session/compaction.ts),
+  [provider-metadata replay](https://github.com/anomalyco/opencode/blob/32f278b48f1a495611165d8a9f1ace0b512933e2/packages/opencode/src/session/message-v2.ts),
+  and [request preparation](https://github.com/anomalyco/opencode/blob/32f278b48f1a495611165d8a9f1ace0b512933e2/packages/opencode/src/session/llm/request.ts).
+
+## Measurement contract
+
+Cache improvements must be evaluated as repeated sequences, not screenshots of one request:
+
+1. Keep model, endpoint, tool set, stable system SHA, and cache partition fixed.
+2. Change only a typed episode/call suffix.
+3. Seed the cache, then run at least two follow-ups; some providers persist the common prefix only
+   after observing multiple requests.
+4. Compare exact attempt usage: input, cache read, cache write, fresh input, latency, retries, and
+   terminal outcome.
+5. Separately evaluate semantic retention after pruning/compaction; a high hit ratio is not useful if
+   the agent forgets required facts.
+
+Reproducible billable probes are documented in [PROVIDER_CANARIES.md](./PROVIDER_CANARIES.md).
+The local evidence for this workstream is in
+[cache-canary-2026-08-02.md](./evidence/cache-canary-2026-08-02.md).
+
+## Known boundaries and next experiments
+
+These are deliberate follow-ups, not hidden claims of completeness:
+
+1. **Anthropic-compatible cache markers**: keep them disabled until a canary proves one exact
+   endpoint/model pair. The capability should eventually be stored per endpoint fingerprint and
+   model, not as a global boolean. The available local compatible credential returned 401, so no
+   proof exists yet.
+2. **Native Responses compaction**: requires lossless persistence of provider-native response items
+   before it can replace generic summaries.
+3. **Exact token admission**: local estimation is conservative but not identical to every provider
+   tokenizer. A future count-tokens adapter could reduce premature or late compaction.
+4. **Longitudinal evaluation**: canaries are manual and billable. A scheduled job should record
+   model/endpoint fingerprints, latency, cache ROI, and semantic-retention scores without storing
+   prompts or credentials.
+5. **Trace retention**: Cache Trace and Turn Errors need an explicit age/size retention policy before
+   very long-running development profiles accumulate unbounded files.
+
+None of these justify coupling Cache Trace into the core request path. They should remain separate
+capability, persistence, and evaluation modules.

--- a/docs/PROVIDER_CANARIES.md
+++ b/docs/PROVIDER_CANARIES.md
@@ -1,0 +1,69 @@
+# Provider cache and replay canaries
+
+These scripts make real, billable requests. Build first, use dedicated low-budget credentials, and
+put credentials only in local environment variables or a local untracked launcher. Never paste a
+key into an issue, PR, test fixture, or chat.
+
+All evidence files are created with owner-only permissions. They contain hashes and usage counters,
+not prompt bodies, response text, credentials, or compatible endpoint origins.
+
+## OpenAI, compatible Responses, and DeepSeek cache
+
+The probe sends three requests with the same >=24k-character stable system prefix and different
+small suffixes. Three attempts are intentional: a provider may persist a shared prefix only after it
+has observed two related requests.
+
+```bash
+npm run build
+
+XIAOBA_CANARY_API_KEY=... \
+XIAOBA_CANARY_API_BASE=https://api.deepseek.com \
+XIAOBA_CANARY_MODEL=... \
+XIAOBA_CANARY_API_MODE=chat_completions \
+npm run canary:provider-cache -- \
+  --run \
+  --output .scratch/deepseek-chat-cache.json
+```
+
+Use `XIAOBA_CANARY_API_MODE=responses` for Responses API. A non-OpenAI/non-DeepSeek compatible
+endpoint additionally requires `XIAOBA_CANARY_ALLOW_COMPATIBLE=true`.
+
+`verdict: passed` requires a cache read after the seed attempt. A zero read with non-zero input is
+`failed_no_reuse`; missing usable counters is `unsupported_usage`.
+
+## DeepSeek thinking + tool replay
+
+This probe asks DeepSeek Chat Completions for one tool call, retains its private reasoning block,
+adds the matching tool result, and makes the continuation request.
+
+```bash
+XIAOBA_CANARY_API_KEY=... \
+XIAOBA_CANARY_API_BASE=https://api.deepseek.com \
+XIAOBA_CANARY_MODEL=... \
+npm run canary:deepseek-reasoning -- \
+  --run \
+  --output .scratch/deepseek-reasoning.json
+```
+
+`passed` means the first response produced a tool call and the structurally complete replay request
+completed. `has_reasoning: true` confirms that the private reasoning path was actually exercised.
+
+## Anthropic prompt caching
+
+```bash
+ANTHROPIC_CANARY_API_KEY=... \
+ANTHROPIC_CANARY_MODEL=... \
+npm run canary:anthropic-prompt-cache -- \
+  --run \
+  --output .scratch/anthropic-cache.json
+```
+
+For a compatible Anthropic endpoint, also set:
+
+```bash
+ANTHROPIC_CANARY_API_BASE=https://... \
+ANTHROPIC_CANARY_ALLOW_COMPATIBLE=true
+```
+
+Passing a compatible canary proves only that exact endpoint/model pair at that time. XiaoBa does not
+currently enable Anthropic cache markers on compatible endpoints automatically.

--- a/docs/evidence/cache-canary-2026-08-02.md
+++ b/docs/evidence/cache-canary-2026-08-02.md
@@ -1,0 +1,21 @@
+# Cache and provider replay evidence — 2026-08-02
+
+This record contains only redacted usage summaries. Credentials, prompts, response text, and
+compatible endpoint origins were not persisted.
+
+| Canary | Result | Evidence |
+|---|---|---|
+| OpenAI-compatible Responses, `gpt-5.6-terra` | passed | attempt 3 read 15,104 of 15,661 input tokens; attempts 1-2 read 0 |
+| Canonical DeepSeek Responses, `deepseek-v4-flash` | passed | attempts 2-3 each read 13,696 of 13,709 input tokens |
+| Canonical DeepSeek Chat Completions, same model | passed | warm-cache attempts each read 13,696 of 13,709; validates Chat cache-usage parsing |
+| Canonical DeepSeek thinking tool replay, same model | passed | first response: one tool call plus private reasoning; replay completed; second request read 384 of 464 input tokens |
+| Anthropic-compatible Messages, `claude-opus-4-6` | not run successfully | local test credential was rejected with HTTP 401; no cache capability conclusion |
+
+Interpretation:
+
+- stable-prefix placement works on the two available live provider families;
+- a two-request-only benchmark would have falsely failed the OpenAI-compatible Responses route;
+- DeepSeek `prompt_cache_hit_tokens` must be normalized or Chat cache hits disappear from Cache
+  Trace;
+- the previously failing thinking/tool replay structure completes on a real DeepSeek request;
+- Anthropic-compatible markers remain disabled until a fresh local credential can produce evidence.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "test:all": "node scripts/run-tests.mjs all",
     "test:list": "node scripts/run-tests.mjs runtime --list",
     "canary:anthropic-prompt-cache": "node scripts/anthropic-prompt-cache-canary.mjs",
+    "canary:provider-cache": "node scripts/provider-cache-canary.mjs",
+    "canary:deepseek-reasoning": "node scripts/deepseek-reasoning-canary.mjs",
     "report": "node dist/index.js chat --exec '/report'",
     "clean-logs": "node scripts/clean-logs.mjs",
     "prepare:runtime": "node scripts/prepare-runtime.mjs",

--- a/scripts/deepseek-reasoning-canary.mjs
+++ b/scripts/deepseek-reasoning-canary.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { createRequire } from 'node:module';
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const CANARY_SCHEMA = 'xiaoba.deepseek-reasoning-canary.v1';
+const CANONICAL_ORIGIN = 'https://api.deepseek.com';
+
+export function sha256(value) {
+  return createHash('sha256').update(String(value), 'utf8').digest('hex');
+}
+
+export function buildCanaryEvidence({ apiBase, model, first, second, recordedAt = new Date() }) {
+  const parsed = new URL(apiBase);
+  const canonical = parsed.origin === CANONICAL_ORIGIN;
+  const providerTypes = Array.isArray(first?.providerContent)
+    ? first.providerContent.map(item => String(item?.type || '')).filter(Boolean)
+    : [];
+  return {
+    schema: CANARY_SCHEMA,
+    recorded_at: recordedAt.toISOString(),
+    api_kind: canonical ? 'canonical-deepseek' : 'openai-compatible',
+    api_origin: canonical ? CANONICAL_ORIGIN : null,
+    api_base_sha256: sha256(parsed.href.replace(/\/+$/, '')),
+    model,
+    verdict: first?.toolCalls?.length && second ? 'passed' : 'inconclusive_no_tool_call',
+    first: {
+      stop_reason: first?.stopReason || null,
+      tool_calls: Number(first?.toolCalls?.length || 0),
+      provider_content_types: providerTypes,
+      has_reasoning: providerTypes.includes('openai_reasoning'),
+    },
+    second: second ? {
+      stop_reason: second.stopReason || null,
+      text_present: Boolean(second.content),
+      tool_calls: Number(second.toolCalls?.length || 0),
+      usage: {
+        input_tokens: Number(second.usage?.promptTokens ?? 0),
+        cache_read_tokens: Number(second.usage?.cachedReadTokens ?? 0),
+        output_tokens: Number(second.usage?.completionTokens ?? 0),
+      },
+    } : null,
+  };
+}
+
+export async function runCanary({ apiKey, apiBase, model, requestTimeoutMs = 120_000 }) {
+  const { OpenAIProvider } = require('../dist/providers/openai-provider.js');
+  const provider = new OpenAIProvider({
+    apiKey,
+    apiUrl: apiBase,
+    model,
+    maxTokens: 256,
+    openaiApiMode: 'chat_completions',
+    reasoningEffort: 'high',
+  });
+  const tool = {
+    name: 'canary_echo',
+    description: 'Return the supplied value unchanged.',
+    parameters: {
+      type: 'object',
+      properties: { value: { type: 'string' } },
+      required: ['value'],
+    },
+  };
+  const seed = [
+    { role: 'system', content: 'You are a tool replay protocol canary.' },
+    {
+      role: 'user',
+      content: 'You must call canary_echo exactly once with value ping. Do not answer directly.',
+    },
+  ];
+  const call = async messages => {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), requestTimeoutMs);
+    try {
+      return await provider.chat(messages, [tool], { signal: controller.signal });
+    } finally {
+      clearTimeout(timeout);
+    }
+  };
+
+  const first = await call(seed);
+  const toolCall = first.toolCalls?.[0];
+  if (!toolCall) return buildCanaryEvidence({ apiBase, model, first });
+  const second = await call([
+    ...seed,
+    {
+      role: 'assistant',
+      content: first.content,
+      tool_calls: first.toolCalls,
+      providerContent: first.providerContent,
+      providerState: first.providerState,
+    },
+    {
+      role: 'tool',
+      tool_call_id: toolCall.id,
+      name: toolCall.function.name,
+      content: 'ping',
+    },
+  ]);
+  return buildCanaryEvidence({ apiBase, model, first, second });
+}
+
+function parseOutputPath(args) {
+  const inline = args.find(arg => arg.startsWith('--output='));
+  if (inline) return inline.slice('--output='.length);
+  const index = args.indexOf('--output');
+  return index >= 0 ? args[index + 1] : undefined;
+}
+
+function sanitizeError(error) {
+  const source = error && typeof error === 'object' ? error : {};
+  return {
+    name: typeof source.name === 'string' ? source.name : 'Error',
+    status: Number.isFinite(Number(source.status ?? source.response?.status))
+      ? Number(source.status ?? source.response?.status)
+      : null,
+    code: typeof source.code === 'string' ? source.code : null,
+    request_id: typeof source.request_id === 'string' ? source.request_id : null,
+    provider_type: typeof source.error?.type === 'string' ? source.error.type : null,
+  };
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (!args.includes('--run')) {
+    console.error([
+      'Usage:',
+      '  XIAOBA_CANARY_API_KEY=... XIAOBA_CANARY_API_BASE=https://api.deepseek.com \\',
+      '  XIAOBA_CANARY_MODEL=... npm run canary:deepseek-reasoning -- --run',
+      '',
+      'Compatible endpoints also require XIAOBA_CANARY_ALLOW_COMPATIBLE=true.',
+      'The command makes two billable requests and records no prompt, response, or credential values.',
+    ].join('\n'));
+    process.exitCode = 2;
+    return;
+  }
+  const apiKey = process.env.XIAOBA_CANARY_API_KEY;
+  const apiBase = process.env.XIAOBA_CANARY_API_BASE;
+  const model = process.env.XIAOBA_CANARY_MODEL;
+  if (!apiKey || !apiBase || !model) {
+    console.error('XIAOBA_CANARY_API_KEY, XIAOBA_CANARY_API_BASE, and XIAOBA_CANARY_MODEL are required.');
+    process.exitCode = 2;
+    return;
+  }
+  let parsed;
+  try {
+    parsed = new URL(apiBase);
+    if (parsed.protocol !== 'https:' || parsed.username || parsed.password || parsed.search || parsed.hash) {
+      throw new Error('Unsafe API URL');
+    }
+  } catch {
+    console.error('XIAOBA_CANARY_API_BASE must be a credential-free HTTPS URL.');
+    process.exitCode = 2;
+    return;
+  }
+  if (
+    parsed.origin !== CANONICAL_ORIGIN
+    && !/^(1|true|yes)$/i.test(process.env.XIAOBA_CANARY_ALLOW_COMPATIBLE || '')
+  ) {
+    console.error('Compatible endpoints require XIAOBA_CANARY_ALLOW_COMPATIBLE=true.');
+    process.exitCode = 2;
+    return;
+  }
+
+  try {
+    const evidence = await runCanary({ apiKey, apiBase, model });
+    const serialized = `${JSON.stringify(evidence, null, 2)}\n`;
+    const outputPath = parseOutputPath(args);
+    if (outputPath) {
+      const resolved = path.resolve(outputPath);
+      fs.mkdirSync(path.dirname(resolved), { recursive: true });
+      fs.writeFileSync(resolved, serialized, { mode: 0o600 });
+      console.log(`Redacted canary evidence written to ${resolved}`);
+      return;
+    }
+    process.stdout.write(serialized);
+  } catch (error) {
+    console.error(JSON.stringify({ schema: CANARY_SCHEMA, error: sanitizeError(error) }));
+    process.exitCode = 1;
+  }
+}
+
+const invokedAsScript = process.argv[1]
+  && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url;
+if (invokedAsScript) {
+  main().catch(error => {
+    console.error(JSON.stringify({ schema: CANARY_SCHEMA, error: sanitizeError(error) }));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/provider-cache-canary.mjs
+++ b/scripts/provider-cache-canary.mjs
@@ -1,0 +1,233 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { createRequire } from 'node:module';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const CANARY_SCHEMA = 'xiaoba.provider-cache-canary.v1';
+const CANARY_MIN_STABLE_CHARS = 24_000;
+const OFFICIAL_ORIGINS = new Set(['https://api.openai.com', 'https://api.deepseek.com']);
+
+export function sha256(value) {
+  return createHash('sha256').update(String(value), 'utf8').digest('hex');
+}
+
+export function buildCapabilityProbeText(sourceText, minimumChars = CANARY_MIN_STABLE_CHARS) {
+  const source = String(sourceText || '').trim();
+  if (!source) throw new Error('Canary stable source text must not be empty.');
+  const segments = [];
+  let chars = 0;
+  while (chars < minimumChars) {
+    segments.push(source);
+    chars += source.length + 2;
+  }
+  return segments.join('\n\n');
+}
+
+export function evaluateCanaryAttempts(attempts) {
+  const laterAttempts = (attempts || []).slice(1);
+  if (laterAttempts.some(attempt => Number(attempt?.usage?.cache_read_tokens ?? 0) > 0)) {
+    return 'passed';
+  }
+  if ((attempts || []).some(attempt => Number(attempt?.usage?.input_tokens ?? 0) > 0)) {
+    return 'failed_no_reuse';
+  }
+  return 'unsupported_usage';
+}
+
+export function buildCanaryEvidence({
+  apiBase,
+  model,
+  apiMode,
+  sourceText,
+  stableText,
+  attempts,
+  recordedAt = new Date(),
+}) {
+  const parsed = new URL(apiBase);
+  const origin = parsed.origin;
+  const apiKind = origin === 'https://api.openai.com'
+    ? 'canonical-openai'
+    : origin === 'https://api.deepseek.com'
+      ? 'canonical-deepseek'
+      : 'openai-compatible';
+  return {
+    schema: CANARY_SCHEMA,
+    recorded_at: recordedAt.toISOString(),
+    api_kind: apiKind,
+    api_origin: OFFICIAL_ORIGINS.has(origin) ? origin : null,
+    api_base_sha256: sha256(parsed.href.replace(/\/+$/, '')),
+    api_mode: apiMode,
+    model,
+    source_system_sha256: sha256(sourceText),
+    stable_system_sha256: sha256(stableText),
+    stable_system_chars: stableText.length,
+    verdict: evaluateCanaryAttempts(attempts),
+    attempts,
+  };
+}
+
+export async function runCanary({
+  apiKey,
+  apiBase,
+  model,
+  apiMode = 'chat_completions',
+  stableText: sourceText,
+  maxTokens = 16,
+  requestTimeoutMs = 120_000,
+}) {
+  const { OpenAIProvider } = require('../dist/providers/openai-provider.js');
+  const stableText = buildCapabilityProbeText(sourceText);
+  const provider = new OpenAIProvider({
+    apiKey,
+    apiUrl: apiBase,
+    model,
+    maxTokens,
+    openaiApiMode: apiMode,
+  });
+  const dynamicVariants = [
+    'Cache canary suffix A. Reply with OK.',
+    'Cache canary suffix B. Reply with OK.',
+    'Cache canary suffix C. Reply with OK.',
+  ];
+  const attempts = [];
+
+  for (const dynamicText of dynamicVariants) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), requestTimeoutMs);
+    try {
+      const response = await provider.chat([
+        { role: 'system', content: stableText },
+        { role: 'user', content: dynamicText },
+      ], undefined, {
+        signal: controller.signal,
+        cachePartitionKey: `canary-${sha256(`${apiBase}\0${model}`).slice(0, 16)}`,
+      });
+      const usage = response?.usage || {};
+      attempts.push({
+        dynamic_suffix_sha256: sha256(dynamicText),
+        stop_reason: response?.stopReason || null,
+        usage: {
+          input_tokens: Number(usage.promptTokens ?? 0),
+          cache_read_tokens: Number(usage.cachedReadTokens ?? 0),
+          cache_write_tokens: Number(usage.cachedWriteTokens ?? 0),
+          output_tokens: Number(usage.completionTokens ?? 0),
+        },
+      });
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  return buildCanaryEvidence({ apiBase, model, apiMode, sourceText, stableText, attempts });
+}
+
+function parseOutputPath(args) {
+  const inline = args.find(arg => arg.startsWith('--output='));
+  if (inline) return inline.slice('--output='.length);
+  const index = args.indexOf('--output');
+  return index >= 0 ? args[index + 1] : undefined;
+}
+
+function printUsage() {
+  console.error([
+    'Usage:',
+    '  XIAOBA_CANARY_API_KEY=... XIAOBA_CANARY_API_BASE=https://... \\',
+    '  XIAOBA_CANARY_MODEL=... npm run canary:provider-cache -- --run',
+    '',
+    'Optional:',
+    '  XIAOBA_CANARY_API_MODE=chat_completions|responses',
+    '  XIAOBA_CANARY_ALLOW_COMPATIBLE=true',
+    '  XIAOBA_CANARY_MAX_TOKENS=16',
+    '',
+    'The command makes three billable requests with a deterministic >=24k-character stable prefix.',
+    'It never records prompt bodies, credentials, response text, or compatible endpoint origins.',
+  ].join('\n'));
+}
+
+function sanitizeError(error) {
+  const source = error && typeof error === 'object' ? error : {};
+  return {
+    name: typeof source.name === 'string' ? source.name : 'Error',
+    status: Number.isFinite(Number(source.status ?? source.response?.status))
+      ? Number(source.status ?? source.response?.status)
+      : null,
+    code: typeof source.code === 'string' ? source.code : null,
+    request_id: typeof source.request_id === 'string' ? source.request_id : null,
+    provider_type: typeof source.error?.type === 'string' ? source.error.type : null,
+  };
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (!args.includes('--run')) {
+    printUsage();
+    process.exitCode = 2;
+    return;
+  }
+  const apiKey = process.env.XIAOBA_CANARY_API_KEY;
+  const apiBase = process.env.XIAOBA_CANARY_API_BASE;
+  const model = process.env.XIAOBA_CANARY_MODEL;
+  const apiMode = process.env.XIAOBA_CANARY_API_MODE || 'chat_completions';
+  if (!apiKey || !apiBase || !model) {
+    console.error('XIAOBA_CANARY_API_KEY, XIAOBA_CANARY_API_BASE, and XIAOBA_CANARY_MODEL are required.');
+    process.exitCode = 2;
+    return;
+  }
+  if (!['chat_completions', 'responses'].includes(apiMode)) {
+    console.error('XIAOBA_CANARY_API_MODE must be chat_completions or responses.');
+    process.exitCode = 2;
+    return;
+  }
+  let parsed;
+  try {
+    parsed = new URL(apiBase);
+    if (parsed.protocol !== 'https:' || parsed.username || parsed.password || parsed.search || parsed.hash) {
+      throw new Error('Unsafe API URL');
+    }
+  } catch {
+    console.error('XIAOBA_CANARY_API_BASE must be a credential-free HTTPS URL.');
+    process.exitCode = 2;
+    return;
+  }
+  if (
+    !OFFICIAL_ORIGINS.has(parsed.origin)
+    && !/^(1|true|yes)$/i.test(process.env.XIAOBA_CANARY_ALLOW_COMPATIBLE || '')
+  ) {
+    console.error('Compatible endpoints require XIAOBA_CANARY_ALLOW_COMPATIBLE=true.');
+    process.exitCode = 2;
+    return;
+  }
+
+  const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+  const stableText = fs.readFileSync(path.join(scriptDir, '..', 'prompts', 'system-prompt.md'), 'utf8');
+  const maxTokens = Math.max(1, Math.min(128, Number(process.env.XIAOBA_CANARY_MAX_TOKENS || 16)));
+  try {
+    const evidence = await runCanary({ apiKey, apiBase, model, apiMode, stableText, maxTokens });
+    const serialized = `${JSON.stringify(evidence, null, 2)}\n`;
+    const outputPath = parseOutputPath(args);
+    if (outputPath) {
+      const resolved = path.resolve(outputPath);
+      fs.mkdirSync(path.dirname(resolved), { recursive: true });
+      fs.writeFileSync(resolved, serialized, { mode: 0o600 });
+      console.log(`Redacted canary evidence written to ${resolved}`);
+      return;
+    }
+    process.stdout.write(serialized);
+  } catch (error) {
+    console.error(JSON.stringify({ schema: CANARY_SCHEMA, error: sanitizeError(error) }));
+    process.exitCode = 1;
+  }
+}
+
+const invokedAsScript = process.argv[1]
+  && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url;
+if (invokedAsScript) {
+  main().catch(error => {
+    console.error(JSON.stringify({ schema: CANARY_SCHEMA, error: sanitizeError(error) }));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/test-environment.mjs
+++ b/scripts/test-environment.mjs
@@ -1,3 +1,5 @@
+import path from 'node:path';
+
 export const RUNTIME_WRITE_PATH_ENV_KEYS = Object.freeze([
   'XIAOBA_USER_DATA_DIR',
   'CATSCO_USER_DATA_DIR',
@@ -29,11 +31,14 @@ export function buildIsolatedTestEnvironment(
   if (homeDir) {
     env.HOME = homeDir;
     env.USERPROFILE = homeDir;
+    env.XIAOBA_TEST_SANDBOX_ROOT = path.dirname(homeDir);
   }
   if (tempDir) {
     env.TMPDIR = tempDir;
     env.TMP = tempDir;
     env.TEMP = tempDir;
+    env.XIAOBA_USER_DATA_DIR = path.join(tempDir, 'runtime-data');
+    env.XIAOBA_TEST_DEFAULT_DATA_DIR = env.XIAOBA_USER_DATA_DIR;
   }
   if (appRoot) env.XIAOBA_APP_ROOT = appRoot;
   if (dotenvPath) env.DOTENV_CONFIG_PATH = dotenvPath;

--- a/src/commands/data.ts
+++ b/src/commands/data.ts
@@ -1,0 +1,80 @@
+import * as path from 'path';
+import type { Command } from 'commander';
+import { Logger } from '../utils/logger';
+import { PathResolver } from '../utils/path-resolver';
+import { resolveRuntimeIdentity } from '../runtime/runtime-identity';
+import {
+  applyRuntimeDataMigration,
+  findLegacyRuntimeArtifacts,
+  planRuntimeDataMigration,
+  RuntimeDataMigrationPlan,
+} from '../runtime/data-migration';
+
+export function registerDataCommand(program: Command): void {
+  const data = program.command('data').description('Inspect or migrate XiaoBa runtime data');
+
+  data
+    .command('status', { isDefault: true })
+    .description('Show code, workspace, and runtime data roots')
+    .action(showDataStatus);
+
+  data
+    .command('migrate')
+    .description('Safely copy legacy runtime data without deleting or overwriting files')
+    .option('--from <path>', 'Legacy runtime root; defaults to the current workspace')
+    .option('--apply', 'Apply the migration; without this flag only a preview is shown')
+    .action((options: { from?: string; apply?: boolean }) => migrateData(options));
+}
+
+function showDataStatus(): void {
+  const identity = resolveRuntimeIdentity();
+  const legacyArtifacts = identity.workspaceRoot === identity.dataRoot
+    ? []
+    : findLegacyRuntimeArtifacts(identity.workspaceRoot);
+  Logger.title('Runtime Data');
+  Logger.info(`Code root: ${identity.codeRoot}`);
+  Logger.info(`Workspace root: ${identity.workspaceRoot}`);
+  Logger.info(`Data root: ${identity.dataRoot}`);
+  Logger.info(`Profile: ${identity.profile} (${identity.dataRootSource})`);
+  if (legacyArtifacts.length > 0) {
+    Logger.warning(`Legacy runtime artifacts remain in the workspace: ${legacyArtifacts.join(', ')}`);
+    Logger.info('Preview a safe copy with: catsco data migrate');
+  } else {
+    Logger.success('No legacy runtime artifacts were detected in the workspace.');
+  }
+}
+
+function migrateData(options: { from?: string; apply?: boolean }): void {
+  const sourceRoot = path.resolve(options.from || process.cwd());
+  const targetRoot = PathResolver.getRuntimeDataRoot();
+  const plan = planRuntimeDataMigration(sourceRoot, targetRoot);
+  printMigrationPlan(plan);
+
+  if (!options.apply) {
+    Logger.info('Preview only. Re-run with --apply to copy files. The source is never deleted.');
+    return;
+  }
+  const result = applyRuntimeDataMigration(plan);
+  Logger.success(`Migration copied ${result.totals.copy} files without overwriting existing data.`);
+  if (result.totals.conflict > 0) {
+    Logger.warning(`${result.totals.conflict} conflicting files were left unchanged.`);
+  }
+  Logger.info(`Migration manifest: ${result.manifestPath}`);
+}
+
+function printMigrationPlan(plan: RuntimeDataMigrationPlan): void {
+  Logger.title('Runtime Data Migration');
+  Logger.info(`Source: ${plan.sourceRoot}`);
+  Logger.info(`Target: ${plan.targetRoot}`);
+  Logger.info(`Copy: ${plan.totals.copy} files (${formatBytes(plan.copyBytes)})`);
+  Logger.info(`Already identical: ${plan.totals.same}`);
+  if (plan.totals.conflict > 0) Logger.warning(`Conflicts (will not overwrite): ${plan.totals.conflict}`);
+  if (plan.totals.unsupported > 0) Logger.warning(`Unsupported entries (will skip): ${plan.totals.unsupported}`);
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KiB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MiB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GiB`;
+}

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -15,6 +15,7 @@ import type { ChatConfig, OpenAIApiMode, ReasoningEffort } from '../../types';
 import type { ToolDefinition } from '../../types/tool';
 import { AIService } from '../../utils/ai-service';
 import { createRuntimeConfigSnapshot } from '../../runtime/runtime-config-snapshot';
+import { resolveCodeRoot, resolveRuntimeIdentity } from '../../runtime/runtime-identity';
 import {
   CUSTOM_MODEL_DEFAULT_CONTEXT_WINDOW_TOKENS,
   calculatePromptBudgetTokens,
@@ -2232,6 +2233,9 @@ export function createApiRouter(
     const config = ConfigManager.getConfigReadonly();
     const contextWindow = resolveModelContextWindow(config);
     const services = serviceManager.getAll();
+    const codeRoot = typeof (serviceManager as any).getProjectRoot === 'function'
+      ? (serviceManager as any).getProjectRoot()
+      : resolveCodeRoot();
     res.json({
       version: APP_VERSION,
       hostname: os.hostname(),
@@ -2242,6 +2246,7 @@ export function createApiRouter(
       provider: config.provider,
       contextWindow,
       skillsPath: PathResolver.getSkillsPath(),
+      runtimeIdentity: resolveRuntimeIdentity({ codeRoot }),
       services,
       authStatus: options.getAuthStatus?.() || { enabled: false, configured: false },
     });

--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -6,6 +6,7 @@ import { createApiRouter } from './routes/api';
 import { ServiceManager } from './service-manager';
 import { bootstrapDefaultSkillHubSkillsOnce } from '../skillhub/default-skill-bootstrap';
 import { createDashboardAuth } from './auth';
+import { resolveCodeRoot } from '../runtime/runtime-identity';
 
 const DEFAULT_PORT = 3800;
 const activeServers: Server[] = [];
@@ -31,7 +32,9 @@ export async function startDashboard(
 ): Promise<DashboardServerHandle> {
   const app = express();
   const envPackaged = /^(1|true|yes)$/i.test(process.env.XIAOBA_IS_PACKAGED || '');
-  const projectRoot = controllers.projectRoot || (envPackaged ? process.env.XIAOBA_APP_ROOT : undefined) || process.cwd();
+  const projectRoot = controllers.projectRoot
+    || (envPackaged ? process.env.XIAOBA_APP_ROOT : undefined)
+    || resolveCodeRoot();
   const serviceManager = new ServiceManager(projectRoot);
 
   app.use(express.json({ limit: '25mb' }));

--- a/src/dashboard/service-manager.ts
+++ b/src/dashboard/service-manager.ts
@@ -75,6 +75,10 @@ export class ServiceManager extends EventEmitter {
     this.registerBuiltinServices();
   }
 
+  getProjectRoot(): string {
+    return this.projectRoot;
+  }
+
   private isPackaged(): boolean {
     // Electron 打包版会设置 XIAOBA_APP_ROOT
     if (process.env.XIAOBA_IS_PACKAGED !== undefined) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,22 +2,39 @@
 
 import { Command } from 'commander';
 import { Logger } from './utils/logger';
-import { chatCommand } from './commands/chat';
-import { configCommand } from './commands/config';
-import { registerSkillCommand } from './commands/skill';
-import { feishuCommand } from './commands/feishu';
-import { runtimeCommand } from './commands/runtime';
 import { APP_VERSION } from './version';
+import { applyRuntimeDataOptionsFromArgv } from './runtime/runtime-data-bootstrap';
+import { findLegacyRuntimeArtifacts } from './runtime/data-migration';
+import { resolveRuntimeIdentity } from './runtime/runtime-identity';
 
-function main() {
+async function main() {
+  applyRuntimeDataOptionsFromArgv(process.argv);
+  const [
+    { chatCommand },
+    { configCommand },
+    { registerSkillCommand },
+    { feishuCommand },
+    { runtimeCommand },
+    { registerDataCommand },
+  ] = await Promise.all([
+    import('./commands/chat'),
+    import('./commands/config'),
+    import('./commands/skill'),
+    import('./commands/feishu'),
+    import('./commands/runtime'),
+    import('./commands/data'),
+  ]);
   const program = new Command();
 
   Logger.brand();
+  logRuntimeIdentity();
 
   program
     .name('catsco')
     .description('CatsCo agent CLI')
-    .version(APP_VERSION);
+    .version(APP_VERSION)
+    .option('--data-dir <path>', 'Use an explicit runtime data directory')
+    .option('--profile <name>', 'Use a named runtime data profile');
 
   program
     .command('chat')
@@ -83,12 +100,33 @@ function main() {
     .action(runtimeCommand);
 
   registerSkillCommand(program);
+  registerDataCommand(program);
 
   program.action(() => {
     chatCommand({ interactive: true });
   });
 
-  program.parse();
+  await program.parseAsync();
 }
 
-main();
+function logRuntimeIdentity(): void {
+  const identity = resolveRuntimeIdentity();
+  const codeLabel = identity.code.commit
+    ? `${identity.code.branch || 'detached'}@${identity.code.commit.slice(0, 8)}${identity.code.dirty ? ' (dirty)' : ''}`
+    : 'not a Git checkout';
+  Logger.info(`Code root: ${identity.codeRoot} · ${codeLabel}`);
+  Logger.info(`Workspace root: ${identity.workspaceRoot}`);
+  Logger.info(`Data root: ${identity.dataRoot} · profile=${identity.profile} · source=${identity.dataRootSource}`);
+  if (identity.workspaceRoot !== identity.dataRoot) {
+    const legacyArtifacts = findLegacyRuntimeArtifacts(identity.workspaceRoot);
+    if (legacyArtifacts.length > 0) {
+      Logger.warning(`Legacy runtime data detected in the workspace: ${legacyArtifacts.join(', ')}`);
+      Logger.info('Run `catsco data migrate` to preview a safe, copy-only migration.');
+    }
+  }
+}
+
+main().catch(error => {
+  Logger.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/src/pet/pet-store.ts
+++ b/src/pet/pet-store.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import { PathResolver } from '../utils/path-resolver';
 import {
   applyPetEvent,
   cleanupPetEvents,
@@ -138,13 +139,16 @@ export function resolvePetDataDir(env: NodeJS.ProcessEnv = process.env, cwd: str
   const explicit = String(env.XIAOBA_PET_DATA_DIR || '').trim();
   if (explicit) return path.isAbsolute(explicit) ? explicit : path.resolve(cwd, explicit);
 
+  // Preserve the packaged app's existing <electron-user-data>/pet location.
+  // It is already outside the code tree and changing it would make existing
+  // companion progress appear to disappear after an upgrade.
   const electronUserData = String(env.XIAOBA_ELECTRON_USER_DATA_DIR || '').trim();
   if (electronUserData) {
     const resolved = path.isAbsolute(electronUserData) ? electronUserData : path.resolve(cwd, electronUserData);
     return path.join(resolved, 'pet');
   }
 
-  return path.join(cwd, 'data', 'pet');
+  return path.join(PathResolver.getRuntimeDataRoot(env, cwd), 'data', 'pet');
 }
 
 function createDefaultStoreData(): PetStoreData {

--- a/src/providers/openai-provider.ts
+++ b/src/providers/openai-provider.ts
@@ -261,16 +261,7 @@ export class OpenAIProvider implements AIProvider {
       content: this.visibleMessageContent(message),
       toolCalls: message.tool_calls,
       stopReason: choice.finish_reason || undefined,
-      usage: usage ? {
-        promptTokens: usage.prompt_tokens ?? 0,
-        completionTokens: usage.completion_tokens ?? 0,
-        totalTokens: usage.total_tokens ?? 0,
-        cachedReadTokens: usage.prompt_tokens_details?.cached_tokens ?? 0,
-        cachedWriteTokens: usage.prompt_tokens_details?.cache_write_tokens
-          ?? usage.prompt_tokens_details?.cached_creation_tokens
-          ?? usage.prompt_tokens_details?.cache_creation_tokens
-          ?? 0,
-      } : undefined,
+      usage: this.parseChatUsage(usage),
       ...this.buildOpenAIProviderContent(message),
     };
   }
@@ -340,18 +331,7 @@ export class OpenAIProvider implements AIProvider {
             }
 
             // 提取 usage（stream_options.include_usage 时在最后一个 chunk 返回）
-            if (parsed.usage) {
-              streamUsage = {
-                promptTokens: parsed.usage.prompt_tokens ?? 0,
-                completionTokens: parsed.usage.completion_tokens ?? 0,
-                totalTokens: parsed.usage.total_tokens ?? 0,
-                cachedReadTokens: parsed.usage.prompt_tokens_details?.cached_tokens ?? 0,
-                cachedWriteTokens: parsed.usage.prompt_tokens_details?.cache_write_tokens
-                  ?? parsed.usage.prompt_tokens_details?.cached_creation_tokens
-                  ?? parsed.usage.prompt_tokens_details?.cache_creation_tokens
-                  ?? 0,
-              };
-            }
+            if (parsed.usage) streamUsage = this.parseChatUsage(parsed.usage);
 
             const delta = choice?.delta;
             if (!delta) continue;
@@ -651,6 +631,36 @@ export class OpenAIProvider implements AIProvider {
     const promptTokens = Number(usage.input_tokens ?? usage.prompt_tokens ?? 0);
     const completionTokens = Number(usage.output_tokens ?? usage.completion_tokens ?? 0);
     const cachedReadTokens = Number(details.cached_tokens ?? 0);
+    const cachedWriteTokens = Number(
+      details.cache_write_tokens
+      ?? details.cached_creation_tokens
+      ?? details.cache_creation_tokens
+      ?? 0,
+    );
+    return {
+      promptTokens,
+      completionTokens,
+      totalTokens: Number(usage.total_tokens ?? promptTokens + completionTokens),
+      cachedReadTokens,
+      cachedWriteTokens,
+    };
+  }
+
+  /**
+   * Normalize usage from OpenAI Chat Completions and compatible endpoints.
+   * DeepSeek reports cache hits in the documented top-level
+   * `prompt_cache_hit_tokens` field instead of OpenAI's nested field.
+   */
+  private parseChatUsage(usage: any): ChatResponse['usage'] {
+    if (!usage || typeof usage !== 'object') return undefined;
+    const details = usage.prompt_tokens_details || {};
+    const promptTokens = Number(usage.prompt_tokens ?? 0);
+    const completionTokens = Number(usage.completion_tokens ?? 0);
+    const cachedReadTokens = Number(
+      details.cached_tokens
+      ?? usage.prompt_cache_hit_tokens
+      ?? 0,
+    );
     const cachedWriteTokens = Number(
       details.cache_write_tokens
       ?? details.cached_creation_tokens

--- a/src/runtime/data-migration.ts
+++ b/src/runtime/data-migration.ts
@@ -1,0 +1,220 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+
+export const LEGACY_RUNTIME_ARTIFACTS = [
+  '.env',
+  '.xiaoba',
+  'branch-agents.json',
+  'config.json',
+  'data',
+  'logs',
+  'prompt-overrides',
+  'skills',
+] as const;
+
+// These are deliberately narrower than the migration allow-list. Source
+// checkouts can legitimately contain bundled data/ and skills/ directories,
+// so using those as signals would report legacy user data in every worktree.
+export const LEGACY_RUNTIME_MARKERS = [
+  '.env',
+  '.xiaoba',
+  'branch-agents.json',
+  'config.json',
+  'logs',
+  'prompt-overrides',
+  'data/sessions',
+  'data/session-state',
+  'data/session-summaries',
+  'data/catsco-log-agent-state.json',
+] as const;
+
+export type MigrationFileStatus = 'copy' | 'same' | 'conflict' | 'unsupported';
+
+export interface MigrationFilePlan {
+  relativePath: string;
+  sourcePath: string;
+  targetPath: string;
+  bytes: number;
+  status: MigrationFileStatus;
+  reason?: string;
+}
+
+export interface RuntimeDataMigrationPlan {
+  sourceRoot: string;
+  targetRoot: string;
+  files: MigrationFilePlan[];
+  missingArtifacts: string[];
+  totals: Record<MigrationFileStatus, number>;
+  copyBytes: number;
+}
+
+export interface RuntimeDataMigrationResult extends RuntimeDataMigrationPlan {
+  applied: boolean;
+  manifestPath?: string;
+}
+
+export function planRuntimeDataMigration(sourceRoot: string, targetRoot: string): RuntimeDataMigrationPlan {
+  const source = path.resolve(sourceRoot);
+  const target = path.resolve(targetRoot);
+  assertSeparateRoots(source, target);
+
+  const files: MigrationFilePlan[] = [];
+  const missingArtifacts: string[] = [];
+  for (const artifact of LEGACY_RUNTIME_ARTIFACTS) {
+    const sourcePath = path.join(source, artifact);
+    if (!fs.existsSync(sourcePath)) {
+      missingArtifacts.push(artifact);
+      continue;
+    }
+    collectMigrationFiles(sourcePath, path.join(target, artifact), artifact, files);
+  }
+
+  return summarizePlan(source, target, files, missingArtifacts);
+}
+
+export function applyRuntimeDataMigration(plan: RuntimeDataMigrationPlan): RuntimeDataMigrationResult {
+  const freshPlan = planRuntimeDataMigration(plan.sourceRoot, plan.targetRoot);
+  fs.mkdirSync(freshPlan.targetRoot, { recursive: true });
+
+  for (const file of freshPlan.files) {
+    if (file.status !== 'copy') continue;
+    fs.mkdirSync(path.dirname(file.targetPath), { recursive: true });
+    fs.copyFileSync(file.sourcePath, file.targetPath, fs.constants.COPYFILE_EXCL);
+    const sourceMode = fs.statSync(file.sourcePath).mode & 0o777;
+    fs.chmodSync(file.targetPath, file.relativePath === '.env' ? 0o600 : sourceMode);
+  }
+
+  const manifestDir = path.join(freshPlan.targetRoot, '.xiaoba', 'migrations');
+  fs.mkdirSync(manifestDir, { recursive: true });
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const manifestPath = path.join(manifestDir, `${timestamp}.json`);
+  const manifest = {
+    schema: 'xiaoba.runtime-data-migration.v1',
+    createdAt: new Date().toISOString(),
+    sourceRoot: freshPlan.sourceRoot,
+    targetRoot: freshPlan.targetRoot,
+    copied: freshPlan.files.filter(file => file.status === 'copy').map(file => file.relativePath),
+    same: freshPlan.files.filter(file => file.status === 'same').map(file => file.relativePath),
+    conflicts: freshPlan.files.filter(file => file.status === 'conflict').map(file => file.relativePath),
+    unsupported: freshPlan.files.filter(file => file.status === 'unsupported').map(file => ({
+      path: file.relativePath,
+      reason: file.reason,
+    })),
+  };
+  fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 });
+
+  return { ...freshPlan, applied: true, manifestPath };
+}
+
+export function findLegacyRuntimeArtifacts(root: string): string[] {
+  const resolved = path.resolve(root);
+  return LEGACY_RUNTIME_MARKERS.filter(artifact => fs.existsSync(path.join(resolved, artifact)));
+}
+
+function collectMigrationFiles(
+  sourcePath: string,
+  targetPath: string,
+  relativePath: string,
+  files: MigrationFilePlan[],
+): void {
+  const stat = fs.lstatSync(sourcePath);
+  if (stat.isSymbolicLink()) {
+    files.push({
+      relativePath,
+      sourcePath,
+      targetPath,
+      bytes: 0,
+      status: 'unsupported',
+      reason: 'symbolic links are not copied',
+    });
+    return;
+  }
+  if (stat.isDirectory()) {
+    for (const entry of fs.readdirSync(sourcePath).sort()) {
+      collectMigrationFiles(
+        path.join(sourcePath, entry),
+        path.join(targetPath, entry),
+        path.join(relativePath, entry),
+        files,
+      );
+    }
+    return;
+  }
+  if (!stat.isFile()) {
+    files.push({
+      relativePath,
+      sourcePath,
+      targetPath,
+      bytes: 0,
+      status: 'unsupported',
+      reason: 'only regular files are copied',
+    });
+    return;
+  }
+
+  let status: MigrationFileStatus = 'copy';
+  if (fs.existsSync(targetPath)) {
+    const targetStat = fs.lstatSync(targetPath);
+    status = targetStat.isFile() && targetStat.size === stat.size && sameFileContent(sourcePath, targetPath)
+      ? 'same'
+      : 'conflict';
+  }
+  files.push({ relativePath, sourcePath, targetPath, bytes: stat.size, status });
+}
+
+function summarizePlan(
+  sourceRoot: string,
+  targetRoot: string,
+  files: MigrationFilePlan[],
+  missingArtifacts: string[],
+): RuntimeDataMigrationPlan {
+  const totals: Record<MigrationFileStatus, number> = {
+    copy: 0,
+    same: 0,
+    conflict: 0,
+    unsupported: 0,
+  };
+  let copyBytes = 0;
+  for (const file of files) {
+    totals[file.status] += 1;
+    if (file.status === 'copy') copyBytes += file.bytes;
+  }
+  return { sourceRoot, targetRoot, files, missingArtifacts, totals, copyBytes };
+}
+
+function sameFileContent(left: string, right: string): boolean {
+  return hashFile(left) === hashFile(right);
+}
+
+function hashFile(filePath: string): string {
+  const hash = crypto.createHash('sha256');
+  const buffer = Buffer.allocUnsafe(64 * 1024);
+  const fd = fs.openSync(filePath, 'r');
+  try {
+    let bytesRead = 0;
+    do {
+      bytesRead = fs.readSync(fd, buffer, 0, buffer.length, null);
+      if (bytesRead > 0) hash.update(buffer.subarray(0, bytesRead));
+    } while (bytesRead > 0);
+  } finally {
+    fs.closeSync(fd);
+  }
+  return hash.digest('hex');
+}
+
+function assertSeparateRoots(source: string, target: string): void {
+  const sourceToTarget = path.relative(source, target);
+  const targetToSource = path.relative(target, source);
+  if (
+    source === target
+    || isInsideRelative(sourceToTarget)
+    || isInsideRelative(targetToSource)
+  ) {
+    throw new Error('Migration source and target must be separate, non-nested directories.');
+  }
+}
+
+function isInsideRelative(relative: string): boolean {
+  return relative !== '' && !relative.startsWith('..') && !path.isAbsolute(relative);
+}

--- a/src/runtime/runtime-config-snapshot.ts
+++ b/src/runtime/runtime-config-snapshot.ts
@@ -220,7 +220,7 @@ function resolveRuntimeProfileForSnapshot(options: {
     configPath: options.profileConfigPath,
     runtimeRoot: options.runtimeRoot,
     surface: options.surface,
-    workingDirectory: options.workingDirectory ?? options.runtimeRoot,
+    workingDirectory: options.workingDirectory ?? process.cwd(),
     model: {
       provider: options.config?.provider,
       apiUrl: sanitizeServerUrl(options.config?.apiUrl),

--- a/src/runtime/runtime-data-bootstrap.ts
+++ b/src/runtime/runtime-data-bootstrap.ts
@@ -1,0 +1,47 @@
+import * as path from 'path';
+import { normalizeProfileName } from '../utils/path-resolver';
+
+export interface RuntimeDataBootstrapResult {
+  dataDir?: string;
+  profile?: string;
+}
+
+/**
+ * Runtime data options must be applied before command modules are imported.
+ * Some command modules load profile configuration during module evaluation.
+ */
+export function applyRuntimeDataOptionsFromArgv(
+  argv: string[],
+  env: NodeJS.ProcessEnv = process.env,
+  cwd: string = process.cwd(),
+): RuntimeDataBootstrapResult {
+  const dataDir = readOption(argv, '--data-dir');
+  const rawProfile = readOption(argv, '--profile');
+  const profile = rawProfile === undefined ? undefined : normalizeProfileName(rawProfile);
+
+  if (dataDir !== undefined) {
+    if (!dataDir.trim()) throw new Error('--data-dir requires a non-empty path');
+    env.XIAOBA_USER_DATA_DIR = path.resolve(cwd, dataDir);
+  }
+  if (profile !== undefined) env.XIAOBA_PROFILE = profile;
+
+  return {
+    dataDir: dataDir === undefined ? undefined : env.XIAOBA_USER_DATA_DIR,
+    profile,
+  };
+}
+
+function readOption(argv: string[], name: string): string | undefined {
+  for (let index = 2; index < argv.length; index += 1) {
+    const value = argv[index];
+    if (value === name) {
+      const next = argv[index + 1];
+      if (next === undefined || next.startsWith('-')) {
+        throw new Error(`${name} requires a value`);
+      }
+      return next;
+    }
+    if (value.startsWith(`${name}=`)) return value.slice(name.length + 1);
+  }
+  return undefined;
+}

--- a/src/runtime/runtime-env.ts
+++ b/src/runtime/runtime-env.ts
@@ -1,0 +1,46 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as dotenv from 'dotenv';
+import { PathResolver } from '../utils/path-resolver';
+
+export interface RuntimeEnvLoadResult {
+  sources: string[];
+  loadedKeys: string[];
+}
+
+/**
+ * Precedence is shell/process env > Data Root .env > legacy cwd .env.
+ * DOTENV_CONFIG_PATH remains an explicit single-file override for tests and
+ * advanced launchers.
+ */
+export function loadRuntimeEnvFiles(
+  env: NodeJS.ProcessEnv = process.env,
+  cwd: string = process.cwd(),
+): RuntimeEnvLoadResult {
+  const explicit = String(env.DOTENV_CONFIG_PATH || '').trim();
+  const runtimeRoot = PathResolver.getRuntimeDataRoot(env, cwd);
+  const candidates = explicit
+    ? [path.resolve(explicit)]
+    : Array.from(new Set([
+      path.resolve(cwd, '.env'),
+      path.join(runtimeRoot, '.env'),
+    ]));
+  const originalKeys = new Set(Object.keys(env));
+  const merged: Record<string, string> = {};
+  const sources: string[] = [];
+
+  for (const filePath of candidates) {
+    if (!fs.existsSync(filePath)) continue;
+    Object.assign(merged, dotenv.parse(fs.readFileSync(filePath, 'utf8')));
+    sources.push(filePath);
+  }
+
+  const loadedKeys: string[] = [];
+  for (const [key, value] of Object.entries(merged)) {
+    if (originalKeys.has(key)) continue;
+    env[key] = value;
+    loadedKeys.push(key);
+  }
+
+  return { sources, loadedKeys };
+}

--- a/src/runtime/runtime-identity.ts
+++ b/src/runtime/runtime-identity.ts
@@ -1,0 +1,75 @@
+import * as path from 'path';
+import { spawnSync } from 'child_process';
+import { PathResolver, RuntimeDataRootSource } from '../utils/path-resolver';
+
+export interface RuntimeCodeIdentity {
+  commit?: string;
+  branch?: string;
+  dirty?: boolean;
+}
+
+export interface RuntimeIdentity {
+  codeRoot: string;
+  workspaceRoot: string;
+  dataRoot: string;
+  dataRootSource: RuntimeDataRootSource;
+  profile: string;
+  code: RuntimeCodeIdentity;
+}
+
+export interface RuntimeIdentityOptions {
+  env?: NodeJS.ProcessEnv;
+  codeRoot?: string;
+  workspaceRoot?: string;
+}
+
+export function resolveCodeRoot(env: NodeJS.ProcessEnv = process.env): string {
+  const explicit = String(env.XIAOBA_APP_ROOT || '').trim();
+  if (explicit) return path.resolve(explicit);
+  return path.resolve(__dirname, '../..');
+}
+
+export function resolveRuntimeIdentity(options: RuntimeIdentityOptions = {}): RuntimeIdentity {
+  const env = options.env ?? process.env;
+  const codeRoot = path.resolve(options.codeRoot ?? resolveCodeRoot(env));
+  const workspaceRoot = path.resolve(options.workspaceRoot ?? process.cwd());
+  const data = PathResolver.resolveRuntimeDataRoot(env, workspaceRoot);
+  return {
+    codeRoot,
+    workspaceRoot,
+    dataRoot: data.path,
+    dataRootSource: data.source,
+    profile: data.profile,
+    code: readGitIdentity(codeRoot, env),
+  };
+}
+
+function readGitIdentity(codeRoot: string, env: NodeJS.ProcessEnv): RuntimeCodeIdentity {
+  const commit = runGit(['rev-parse', 'HEAD'], codeRoot, env);
+  if (!commit) return {};
+  const branch = runGit(['branch', '--show-current'], codeRoot, env) || undefined;
+  const dirtyOutput = runGit(['status', '--porcelain', '--untracked-files=no'], codeRoot, env, true);
+  return {
+    commit,
+    branch,
+    dirty: dirtyOutput === undefined ? undefined : dirtyOutput.length > 0,
+  };
+}
+
+function runGit(
+  args: string[],
+  cwd: string,
+  env: NodeJS.ProcessEnv,
+  preserveEmpty: boolean = false,
+): string | undefined {
+  const result = spawnSync('git', args, {
+    cwd,
+    env,
+    encoding: 'utf8',
+    timeout: 1_500,
+    windowsHide: true,
+  });
+  if (result.status !== 0 || result.error) return undefined;
+  const output = String(result.stdout || '').trim();
+  return output || (preserveEmpty ? '' : undefined);
+}

--- a/src/runtime/runtime-profile-config.ts
+++ b/src/runtime/runtime-profile-config.ts
@@ -11,6 +11,7 @@ import {
 } from './runtime-profile';
 import { normalizeReasoningEffort } from '../utils/reasoning-effort';
 import { normalizeOpenAIApiMode } from '../utils/openai-api-mode';
+import { PathResolver } from '../utils/path-resolver';
 
 export const RUNTIME_PROFILE_SCHEMA_VERSION = 1;
 export const DEFAULT_RUNTIME_PROFILE_FILENAME = 'runtime-profile.json';
@@ -84,7 +85,8 @@ export function getDefaultRuntimeProfileConfigPath(
   options: Pick<ResolveRuntimeProfileFromConfigOptions, 'env' | 'runtimeRoot' | 'homeDir' | 'configPath'> = {},
 ): string {
   const env = options.env ?? process.env;
-  const runtimeRoot = options.runtimeRoot ?? process.cwd();
+  const runtimeRoot = options.runtimeRoot
+    ?? PathResolver.getRuntimeDataRoot(env, process.cwd(), options.homeDir ?? os.homedir());
   const explicitPath = options.configPath || PROFILE_PATH_ENV_KEYS
     .map(key => env[key])
     .find(value => typeof value === 'string' && value.trim().length > 0);
@@ -93,7 +95,7 @@ export function getDefaultRuntimeProfileConfigPath(
     return resolvePath(explicitPath, runtimeRoot, options.homeDir);
   }
 
-  return path.join(options.homeDir ?? os.homedir(), '.xiaoba', DEFAULT_RUNTIME_PROFILE_FILENAME);
+  return path.join(runtimeRoot, DEFAULT_RUNTIME_PROFILE_FILENAME);
 }
 
 export function loadRuntimeProfileConfigFile(

--- a/src/runtime/runtime-profile-editor.ts
+++ b/src/runtime/runtime-profile-editor.ts
@@ -88,7 +88,7 @@ export function previewRuntimeProfileEdit(
   const configDir = path.dirname(configPath);
   const baseProfile = resolveDefaultRuntimeProfile({
     env: options.env,
-    workingDirectory: options.runtimeRoot ?? process.cwd(),
+    workingDirectory: process.cwd(),
   });
   const currentFileConfig = loaded.profileConfig ?? {};
   const safeCurrentFileConfig = stripToEditableProfileConfig(currentFileConfig);

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,18 +1,13 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import * as os from 'os';
-import * as dotenv from 'dotenv';
 import { ChatConfig } from '../types';
 import { normalizeReasoningEffort } from './reasoning-effort';
 import { normalizeOpenAIApiMode } from './openai-api-mode';
 import { resolveActiveBotLLMConfig } from '../bot-definition/llm-config-resolver';
 import { PathResolver } from './path-resolver';
+import { loadRuntimeEnvFiles } from '../runtime/runtime-env';
 
-// 加载环境变量（静默模式）
-dotenv.config({ path: process.env.DOTENV_CONFIG_PATH || '.env', quiet: true });
-
-const DEFAULT_CONFIG_DIR = path.join(os.homedir(), '.xiaoba');
-const DEFAULT_CONFIG_FILE = path.join(DEFAULT_CONFIG_DIR, 'config.json');
+loadRuntimeEnvFiles();
 
 export class ConfigManager {
   private static mergeConfig(base: ChatConfig, override?: Partial<ChatConfig>): ChatConfig {
@@ -61,7 +56,9 @@ export class ConfigManager {
 
   private static getConfigFilePath(): string {
     const explicitPath = process.env.XIAOBA_CONFIG_PATH?.trim();
-    return explicitPath ? path.resolve(explicitPath) : DEFAULT_CONFIG_FILE;
+    return explicitPath
+      ? path.resolve(explicitPath)
+      : path.join(PathResolver.getRuntimeDataRoot(), 'config.json');
   }
 
   static getConfig(): ChatConfig {

--- a/src/utils/path-resolver.ts
+++ b/src/utils/path-resolver.ts
@@ -2,34 +2,90 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
 
+export type RuntimeDataRootSource =
+  | 'XIAOBA_USER_DATA_DIR'
+  | 'CATSCO_USER_DATA_DIR'
+  | 'XIAOBA_ELECTRON_USER_DATA_DIR'
+  | 'XIAOBA_RUNTIME_ROOT'
+  | 'test-workspace'
+  | 'profile'
+  | 'default';
+
+export interface RuntimeDataRootResolution {
+  path: string;
+  source: RuntimeDataRootSource;
+  profile: string;
+}
+
+const DEFAULT_PROFILE = 'default';
+const PROFILE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+
 export class PathResolver {
-  static getRuntimeDataRoot(
+  static resolveRuntimeDataRoot(
     env: NodeJS.ProcessEnv = process.env,
     cwd: string = process.cwd(),
-  ): string {
-    const explicit = [
-      env.XIAOBA_USER_DATA_DIR,
-      env.CATSCO_USER_DATA_DIR,
-      env.XIAOBA_ELECTRON_USER_DATA_DIR,
+    homeDir: string = os.homedir(),
+  ): RuntimeDataRootResolution {
+    const explicitCandidates: Array<[RuntimeDataRootSource, string | undefined]> = [
+      ['XIAOBA_USER_DATA_DIR', env.XIAOBA_USER_DATA_DIR],
+      ['CATSCO_USER_DATA_DIR', env.CATSCO_USER_DATA_DIR],
+      ['XIAOBA_ELECTRON_USER_DATA_DIR', env.XIAOBA_ELECTRON_USER_DATA_DIR],
       // Legacy data-root compatibility only. Bundled executable discovery uses
       // XIAOBA_BUNDLED_EXECUTABLES_DIR and must not write this variable.
-      env.XIAOBA_RUNTIME_ROOT,
-    ]
-      .map(value => String(value || '').trim())
-      .find(Boolean);
+      ['XIAOBA_RUNTIME_ROOT', env.XIAOBA_RUNTIME_ROOT],
+    ];
+    const explicit = explicitCandidates.find(([, value]) => String(value || '').trim());
+    const profile = normalizeProfileName(env.XIAOBA_PROFILE);
+    const defaultRoot = path.join(path.resolve(homeDir), '.xiaoba');
+    const testSandboxRoot = String(env.XIAOBA_TEST_SANDBOX_ROOT || '').trim();
+    const runnerDefaultRoot = String(env.XIAOBA_TEST_DEFAULT_DATA_DIR || '').trim();
+    const explicitIsRunnerDefault = Boolean(
+      explicit
+      && runnerDefaultRoot
+      && path.resolve(String(explicit[1]).trim()) === path.resolve(runnerDefaultRoot),
+    );
+    const isolatedTestWorkspace = env.XIAOBA_TEST_RUNNER === '1'
+      && testSandboxRoot
+      && isPathInside(path.resolve(cwd), path.resolve(testSandboxRoot))
+      && (!explicit || explicitIsRunnerDefault)
+      ? path.resolve(cwd)
+      : undefined;
+    const resolution: RuntimeDataRootResolution = isolatedTestWorkspace
+      ? { path: isolatedTestWorkspace, source: 'test-workspace', profile }
+      : explicit
+      ? {
+        path: path.resolve(String(explicit[1]).trim()),
+        source: explicit[0],
+        profile,
+      }
+      : profile === DEFAULT_PROFILE
+        ? { path: defaultRoot, source: 'default', profile }
+        : { path: path.join(defaultRoot, 'profiles', profile), source: 'profile', profile };
+
+    const allowedTestRoots = [
+      path.resolve(os.tmpdir()),
+      ...(testSandboxRoot ? [path.resolve(testSandboxRoot)] : []),
+    ];
 
     if (
-      explicit
-      && env.NODE_TEST_CONTEXT
+      env.NODE_TEST_CONTEXT
       && env.XIAOBA_ALLOW_NON_TEMP_TEST_RUNTIME_ROOT !== '1'
-      && !isPathInside(path.resolve(explicit), path.resolve(os.tmpdir()))
+      && !allowedTestRoots.some(root => isPathInside(resolution.path, root))
     ) {
       throw new Error(
-        `Refusing Node test runtime data root outside the OS temporary directory: ${path.resolve(explicit)}`,
+        `Refusing Node test runtime data root outside the OS temporary directory: ${resolution.path}`,
       );
     }
 
-    return path.resolve(explicit || cwd);
+    return resolution;
+  }
+
+  static getRuntimeDataRoot(
+    env: NodeJS.ProcessEnv = process.env,
+    cwd: string = process.cwd(),
+    homeDir: string = os.homedir(),
+  ): string {
+    return this.resolveRuntimeDataRoot(env, cwd, homeDir).path;
   }
 
   static getDataPath(...segments: string[]): string {
@@ -88,7 +144,33 @@ export class PathResolver {
   }
 }
 
+export function normalizeProfileName(value: string | undefined): string {
+  const profile = String(value || '').trim() || DEFAULT_PROFILE;
+  if (!PROFILE_PATTERN.test(profile) || profile === '.' || profile === '..') {
+    throw new Error(
+      'Invalid XiaoBa profile. Use 1-64 letters, numbers, dots, underscores, or hyphens; start with a letter or number.',
+    );
+  }
+  return profile;
+}
+
 function isPathInside(candidate: string, parent: string): boolean {
-  const relative = path.relative(parent, candidate);
+  const relative = path.relative(canonicalizeBoundaryPath(parent), canonicalizeBoundaryPath(candidate));
   return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+function canonicalizeBoundaryPath(value: string): string {
+  const missingSegments: string[] = [];
+  let cursor = path.resolve(value);
+  while (!fs.existsSync(cursor)) {
+    const parent = path.dirname(cursor);
+    if (parent === cursor) break;
+    missingSegments.unshift(path.basename(cursor));
+    cursor = parent;
+  }
+  try {
+    return path.join(fs.realpathSync(cursor), ...missingSegments);
+  } catch {
+    return path.resolve(value);
+  }
 }

--- a/src/weixin/index.ts
+++ b/src/weixin/index.ts
@@ -18,6 +18,7 @@ import {
   parseSessionKeyV2,
 } from '../core/session-router';
 import type { SessionRoute } from '../types/session-identity';
+import { PathResolver } from '../utils/path-resolver';
 
 const CHANNEL_VERSION = 'xiaoba-weixin/1.0';
 const DEFAULT_LONGPOLL_MS = 30000;
@@ -54,7 +55,7 @@ export class WeixinBot {
   constructor(private config: WeixinConfig) {
     this.handler = new MessageHandler(config.cdnBaseUrl);
     this.sender = new MessageSender(config.token, config.baseUrl, config.cdnBaseUrl);
-    this.stateDir = config.stateDir || path.join(process.cwd(), 'data', 'weixin');
+    this.stateDir = config.stateDir || PathResolver.getDataPath('weixin');
 
     const runtime = createWeixinRuntime();
     this.runtime = runtime;

--- a/tests/context-debug-logger.test.ts
+++ b/tests/context-debug-logger.test.ts
@@ -3,12 +3,13 @@ import assert from 'node:assert/strict';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { ContextDebugLogger } from '../src/utils/context-debug-logger';
+import { PathResolver } from '../src/utils/path-resolver';
 
 test('SDK debug dumps redact provider hidden thinking blocks', () => {
   const previous = process.env.CONTEXT_DEBUG;
   process.env.CONTEXT_DEBUG = 'true';
   const requestId = `redact42-${Date.now()}`;
-  const debugDir = path.resolve('logs/context-debug');
+  const debugDir = PathResolver.getLogsPath('context-debug');
 
   try {
     ContextDebugLogger.dumpSdkBoundary('before', requestId, {

--- a/tests/dashboard-runtime-config.test.ts
+++ b/tests/dashboard-runtime-config.test.ts
@@ -9,12 +9,15 @@ describe('dashboard runtime config snapshot', () => {
   let testRoot: string;
   let originalCwd: string;
   let originalSkillsEnv: string | undefined;
+  let originalUserDataDir: string | undefined;
 
   beforeEach(() => {
     originalCwd = process.cwd();
     originalSkillsEnv = process.env.XIAOBA_SKILLS_DIR;
+    originalUserDataDir = process.env.XIAOBA_USER_DATA_DIR;
     testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-runtime-config-'));
     process.chdir(testRoot);
+    process.env.XIAOBA_USER_DATA_DIR = testRoot;
     process.env.XIAOBA_SKILLS_DIR = path.join(testRoot, 'skills');
     writeSkill('snapshot-demo');
   });
@@ -23,6 +26,8 @@ describe('dashboard runtime config snapshot', () => {
     process.chdir(originalCwd);
     if (originalSkillsEnv === undefined) delete process.env.XIAOBA_SKILLS_DIR;
     else process.env.XIAOBA_SKILLS_DIR = originalSkillsEnv;
+    if (originalUserDataDir === undefined) delete process.env.XIAOBA_USER_DATA_DIR;
+    else process.env.XIAOBA_USER_DATA_DIR = originalUserDataDir;
     if (testRoot && fs.existsSync(testRoot)) {
       fs.rmSync(testRoot, { recursive: true, force: true });
     }
@@ -67,7 +72,7 @@ describe('dashboard runtime config snapshot', () => {
     assert.match(snapshot.systemPrompt.text, /你在这个平台上的名字是：Desk Assistant/);
     assert.match(snapshot.systemPrompt.text, /当前目录会在每次模型请求中作为临时上下文消息提供/);
     assert.doesNotMatch(snapshot.systemPrompt.text.replace(/\\/g, '/'), new RegExp(escapeRegExp(fs.realpathSync(testRoot).replace(/\\/g, '/'))));
-    assert.equal(snapshot.logging.sessionLogDir, path.join(fs.realpathSync(testRoot), 'logs/sessions'));
+    assert.equal(snapshot.logging.sessionLogDir, path.join(path.resolve(testRoot), 'logs/sessions'));
     assert.equal(snapshot.logging.upload.enabled, true);
     assert.equal(snapshot.logging.upload.serverUrl, 'https://logs.example.test:8000');
     assert.equal(JSON.stringify(snapshot).includes('api_key=secret'), false);

--- a/tests/dashboard-runtime-identity-html.test.ts
+++ b/tests/dashboard-runtime-identity-html.test.ts
@@ -15,4 +15,9 @@ test('dashboard visibly distinguishes data, code, and workspace roots', () => {
   assert.match(html, /copyRuntimeDataRoot/);
   assert.match(html, /已复制/);
   assert.match(html, /复制失败/);
+  assert.match(
+    html,
+    /body:not\(\.chat-active\) \.sidebar-nav \{\s*flex: 1 0 auto;\s*flex-direction: row;/,
+  );
+  assert.match(html, /body:not\(\.chat-active\) \.sidebar-footer \{\s*display: none;/);
 });

--- a/tests/dashboard-runtime-identity-html.test.ts
+++ b/tests/dashboard-runtime-identity-html.test.ts
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+test('dashboard visibly distinguishes data, code, and workspace roots', () => {
+  const html = fs.readFileSync(path.join(process.cwd(), 'dashboard', 'index.html'), 'utf8');
+
+  assert.match(html, /id="runtime-identity-card"/);
+  assert.match(html, /id="runtime-data-root"/);
+  assert.match(html, /id="runtime-code-root"/);
+  assert.match(html, /id="runtime-workspace-root"/);
+  assert.match(html, /id="copy-runtime-data-root"/);
+  assert.match(html, /profile:/);
+  assert.match(html, /copyRuntimeDataRoot/);
+  assert.match(html, /已复制/);
+  assert.match(html, /复制失败/);
+});

--- a/tests/dashboard-settings-api.test.ts
+++ b/tests/dashboard-settings-api.test.ts
@@ -355,6 +355,10 @@ describe('dashboard typed settings API', () => {
     const status = await statusResponse.json() as any;
     assert.equal(status.provider, 'anthropic');
     assert.equal(status.model, 'MiniMax-M2.7-highspeed');
+    assert.equal(status.runtimeIdentity.dataRoot, fs.realpathSync(testRoot));
+    assert.equal(status.runtimeIdentity.profile, 'default');
+    assert.equal(typeof status.runtimeIdentity.codeRoot, 'string');
+    assert.equal(typeof status.runtimeIdentity.workspaceRoot, 'string');
   });
 
   test('PUT /settings publishes the bound bot model definition without exposing its API key', async () => {

--- a/tests/deepseek-reasoning-canary.test.ts
+++ b/tests/deepseek-reasoning-canary.test.ts
@@ -1,0 +1,36 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildCanaryEvidence } from '../scripts/deepseek-reasoning-canary.mjs';
+
+test('DeepSeek reasoning canary evidence omits prompt, response, and compatible endpoint content', () => {
+  const first = {
+    content: 'secret first response',
+    stopReason: 'tool_calls',
+    toolCalls: [{ id: 'call_1' }],
+    providerContent: [
+      { type: 'openai_reasoning', reasoning_content: 'secret reasoning' },
+      { type: 'tool_use', id: 'call_1' },
+    ],
+  };
+  const second = {
+    content: 'secret final response',
+    stopReason: 'stop',
+    usage: { promptTokens: 100, cachedReadTokens: 80, completionTokens: 3 },
+  };
+  const evidence = buildCanaryEvidence({
+    apiBase: 'https://relay.secret.example/v1',
+    model: 'deepseek-test',
+    first,
+    second,
+    recordedAt: new Date('2026-08-02T00:00:00.000Z'),
+  });
+  const serialized = JSON.stringify(evidence);
+
+  assert.equal(evidence.verdict, 'passed');
+  assert.equal(evidence.first.has_reasoning, true);
+  assert.equal(evidence.second?.usage.cache_read_tokens, 80);
+  assert.equal(evidence.api_origin, null);
+  assert.equal(serialized.includes('secret first response'), false);
+  assert.equal(serialized.includes('secret reasoning'), false);
+  assert.equal(serialized.includes('relay.secret.example'), false);
+});

--- a/tests/openai-provider-runtime-feedback.test.ts
+++ b/tests/openai-provider-runtime-feedback.test.ts
@@ -516,6 +516,62 @@ describe('OpenAIProvider runtime feedback boundary', () => {
     }
   });
 
+  test('reads DeepSeek cache hits from non-stream Chat Completions usage', async () => {
+    const originalPost = axios.post;
+    (axios as any).post = async () => ({
+      data: {
+        choices: [{ message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' }],
+        usage: {
+          prompt_tokens: 120,
+          completion_tokens: 2,
+          total_tokens: 122,
+          prompt_cache_hit_tokens: 96,
+          prompt_cache_miss_tokens: 24,
+        },
+      },
+    });
+
+    try {
+      const provider = new OpenAIProvider({
+        apiKey: 'test-key',
+        apiUrl: 'https://api.deepseek.com/v1',
+        model: 'deepseek-chat',
+      });
+      const result = await provider.chat([{ role: 'user', content: 'hello' }]);
+
+      assert.equal(result.usage?.promptTokens, 120);
+      assert.equal(result.usage?.cachedReadTokens, 96);
+      assert.equal(result.usage?.cachedWriteTokens, 0);
+    } finally {
+      (axios as any).post = originalPost;
+    }
+  });
+
+  test('reads DeepSeek cache hits from streamed Chat Completions usage', async () => {
+    const originalPost = axios.post;
+    (axios as any).post = async () => ({
+      data: Readable.from([
+        'data: {"choices":[{"delta":{"content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":120,"completion_tokens":2,"total_tokens":122,"prompt_cache_hit_tokens":96,"prompt_cache_miss_tokens":24}}\n\n',
+        'data: [DONE]\n\n',
+      ]),
+    });
+
+    try {
+      const provider = new OpenAIProvider({
+        apiKey: 'test-key',
+        apiUrl: 'https://api.deepseek.com/v1',
+        model: 'deepseek-chat',
+      });
+      const result = await provider.chatStream([{ role: 'user', content: 'hello' }]);
+
+      assert.equal(result.usage?.promptTokens, 120);
+      assert.equal(result.usage?.cachedReadTokens, 96);
+      assert.equal(result.usage?.cachedWriteTokens, 0);
+    } finally {
+      (axios as any).post = originalPost;
+    }
+  });
+
   test('hides OpenAI-compatible reasoning fields and split think tags in stream responses', async () => {
     const originalPost = axios.post;
     (axios as any).post = async () => ({

--- a/tests/path-resolver-boundaries.test.ts
+++ b/tests/path-resolver-boundaries.test.ts
@@ -9,9 +9,44 @@ describe('PathResolver runtime data boundary', () => {
 
   test('bundled executables directory never becomes runtime data root', () => {
     const bundledExecutablesDir = path.join(testRoot, 'bundled-executables');
+    const homeDir = path.join(testRoot, 'home');
     const env = { XIAOBA_BUNDLED_EXECUTABLES_DIR: bundledExecutablesDir } as NodeJS.ProcessEnv;
 
-    assert.equal(PathResolver.getRuntimeDataRoot(env, testRoot), path.resolve(testRoot));
+    assert.equal(PathResolver.getRuntimeDataRoot(env, testRoot, homeDir), path.join(homeDir, '.xiaoba'));
+  });
+
+  test('named profiles use a stable directory outside the Git worktree', () => {
+    const homeDir = path.join(testRoot, 'home');
+    const env = { XIAOBA_PROFILE: 'cache-candidate' } as NodeJS.ProcessEnv;
+
+    const resolution = PathResolver.resolveRuntimeDataRoot(env, testRoot, homeDir);
+
+    assert.equal(resolution.path, path.join(homeDir, '.xiaoba', 'profiles', 'cache-candidate'));
+    assert.equal(resolution.profile, 'cache-candidate');
+    assert.equal(resolution.source, 'profile');
+  });
+
+  test('explicit data directory remains exact while profile supplies experiment identity', () => {
+    const userDataRoot = path.join(testRoot, 'experiment-data');
+    const resolution = PathResolver.resolveRuntimeDataRoot({
+      XIAOBA_USER_DATA_DIR: userDataRoot,
+      XIAOBA_PROFILE: 'baseline',
+    } as NodeJS.ProcessEnv, testRoot, path.join(testRoot, 'home'));
+
+    assert.equal(resolution.path, userDataRoot);
+    assert.equal(resolution.profile, 'baseline');
+    assert.equal(resolution.source, 'XIAOBA_USER_DATA_DIR');
+  });
+
+  test('profile names cannot escape the profile directory', () => {
+    assert.throws(
+      () => PathResolver.getRuntimeDataRoot(
+        { XIAOBA_PROFILE: '../outside' } as NodeJS.ProcessEnv,
+        testRoot,
+        path.join(testRoot, 'home'),
+      ),
+      /Invalid XiaoBa profile/,
+    );
   });
 
   test('explicit user data root wins over all compatibility roots', () => {
@@ -57,5 +92,15 @@ describe('PathResolver runtime data boundary', () => {
     } as NodeJS.ProcessEnv;
 
     assert.equal(PathResolver.getRuntimeDataRoot(env, testRoot), path.resolve(safeRoot));
+  });
+
+  test('Node tests also reject a non-temporary default home root', () => {
+    const unsafeHome = path.resolve(path.parse(testRoot).root, 'Users', 'unsafe-test-home');
+    const env = { NODE_TEST_CONTEXT: 'child-v8' } as NodeJS.ProcessEnv;
+
+    assert.throws(
+      () => PathResolver.getRuntimeDataRoot(env, testRoot, unsafeHome),
+      /Refusing Node test runtime data root outside the OS temporary directory/,
+    );
   });
 });

--- a/tests/pet-store-path.test.ts
+++ b/tests/pet-store-path.test.ts
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { resolvePetDataDir } from '../src/pet/pet-store';
+
+test('pet state follows the shared runtime data root instead of the worktree', () => {
+  const cwd = path.resolve('/tmp/xiaoba-worktree');
+  const dataRoot = path.resolve('/tmp/xiaoba-runtime-data');
+  assert.equal(
+    resolvePetDataDir({ XIAOBA_USER_DATA_DIR: dataRoot }, cwd),
+    path.join(dataRoot, 'data', 'pet'),
+  );
+});
+
+test('an explicit pet directory remains available as a compatibility override', () => {
+  const cwd = path.resolve('/tmp/xiaoba-worktree');
+  assert.equal(
+    resolvePetDataDir({ XIAOBA_PET_DATA_DIR: 'pet-experiment' }, cwd),
+    path.join(cwd, 'pet-experiment'),
+  );
+});
+
+test('the packaged app keeps its existing pet state location', () => {
+  const cwd = path.resolve('/tmp/xiaoba-worktree');
+  const electronData = path.resolve('/tmp/xiaoba-electron-data');
+  assert.equal(
+    resolvePetDataDir({ XIAOBA_ELECTRON_USER_DATA_DIR: electronData }, cwd),
+    path.join(electronData, 'pet'),
+  );
+});

--- a/tests/provider-cache-canary.test.ts
+++ b/tests/provider-cache-canary.test.ts
@@ -1,0 +1,59 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildCapabilityProbeText,
+  buildCanaryEvidence,
+  evaluateCanaryAttempts,
+  sha256,
+} from '../scripts/provider-cache-canary.mjs';
+
+describe('OpenAI-compatible provider cache canary evidence', () => {
+  test('builds the minimum stable prefix without exposing it in evidence', () => {
+    const source = 'stable secret prompt';
+    const stable = buildCapabilityProbeText(source, 100);
+    const evidence = buildCanaryEvidence({
+      apiBase: 'https://api.deepseek.com/v1',
+      model: 'deepseek-test',
+      apiMode: 'chat_completions',
+      sourceText: source,
+      stableText: stable,
+      attempts: [],
+      recordedAt: new Date('2026-08-02T00:00:00.000Z'),
+    });
+    const serialized = JSON.stringify(evidence);
+
+    assert.equal(stable.length >= 100, true);
+    assert.equal(evidence.api_kind, 'canonical-deepseek');
+    assert.equal(evidence.source_system_sha256, sha256(source));
+    assert.equal(evidence.stable_system_sha256, sha256(stable));
+    assert.equal(serialized.includes(source), false);
+    assert.equal(serialized.includes(stable), false);
+  });
+
+  test('passes only when a request after the seed reads cached tokens', () => {
+    const attempt = (input: number, read: number) => ({
+      usage: { input_tokens: input, cache_read_tokens: read },
+    });
+
+    assert.equal(evaluateCanaryAttempts([attempt(100, 0), attempt(100, 80)]), 'passed');
+    assert.equal(evaluateCanaryAttempts([attempt(100, 0), attempt(100, 0)]), 'failed_no_reuse');
+    assert.equal(evaluateCanaryAttempts([]), 'unsupported_usage');
+  });
+
+  test('redacts compatible endpoint origins', () => {
+    const evidence = buildCanaryEvidence({
+      apiBase: 'https://relay.secret.example/v1',
+      model: 'relay-model',
+      apiMode: 'responses',
+      sourceText: 'source',
+      stableText: 'stable',
+      attempts: [],
+      recordedAt: new Date('2026-08-02T00:00:00.000Z'),
+    });
+    const serialized = JSON.stringify(evidence);
+
+    assert.equal(evidence.api_kind, 'openai-compatible');
+    assert.equal(evidence.api_origin, null);
+    assert.equal(serialized.includes('relay.secret.example'), false);
+  });
+});

--- a/tests/runtime-data-bootstrap.test.ts
+++ b/tests/runtime-data-bootstrap.test.ts
@@ -1,0 +1,30 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as path from 'node:path';
+import { applyRuntimeDataOptionsFromArgv } from '../src/runtime/runtime-data-bootstrap';
+
+describe('runtime data CLI bootstrap', () => {
+  test('applies data root and profile before command modules load', () => {
+    const env = {} as NodeJS.ProcessEnv;
+    const cwd = path.resolve('/tmp/xiaoba-bootstrap');
+    const result = applyRuntimeDataOptionsFromArgv([
+      'node',
+      'xiaoba',
+      '--data-dir',
+      './runtime',
+      '--profile=cache-a',
+      'dashboard',
+    ], env, cwd);
+
+    assert.equal(env.XIAOBA_USER_DATA_DIR, path.join(cwd, 'runtime'));
+    assert.equal(env.XIAOBA_PROFILE, 'cache-a');
+    assert.deepEqual(result, { dataDir: path.join(cwd, 'runtime'), profile: 'cache-a' });
+  });
+
+  test('rejects missing option values', () => {
+    assert.throws(
+      () => applyRuntimeDataOptionsFromArgv(['node', 'xiaoba', '--data-dir'], {} as NodeJS.ProcessEnv),
+      /--data-dir requires a value/,
+    );
+  });
+});

--- a/tests/runtime-data-migration.test.ts
+++ b/tests/runtime-data-migration.test.ts
@@ -1,0 +1,70 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  applyRuntimeDataMigration,
+  findLegacyRuntimeArtifacts,
+  planRuntimeDataMigration,
+} from '../src/runtime/data-migration';
+
+describe('runtime data migration', () => {
+  test('copies known runtime artifacts without deleting the source', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-data-migration-'));
+    const source = path.join(root, 'legacy-worktree');
+    const target = path.join(root, 'profiles', 'default');
+    fs.mkdirSync(path.join(source, 'logs', 'sessions'), { recursive: true });
+    fs.mkdirSync(path.join(source, 'data'), { recursive: true });
+    fs.writeFileSync(path.join(source, '.env'), 'SECRET=test\n', 'utf8');
+    fs.writeFileSync(path.join(source, 'logs', 'sessions', 'one.jsonl'), '{}\n', 'utf8');
+    fs.writeFileSync(path.join(source, 'data', 'state.json'), '{"ok":true}\n', 'utf8');
+
+    const preview = planRuntimeDataMigration(source, target);
+    assert.equal(preview.totals.copy, 3);
+    assert.equal(fs.existsSync(target), false);
+
+    const result = applyRuntimeDataMigration(preview);
+    assert.equal(result.applied, true);
+    assert.equal(fs.readFileSync(path.join(target, '.env'), 'utf8'), 'SECRET=test\n');
+    assert.equal(fs.readFileSync(path.join(target, 'data', 'state.json'), 'utf8'), '{"ok":true}\n');
+    assert.equal(fs.existsSync(path.join(source, '.env')), true);
+    assert.equal(fs.existsSync(result.manifestPath!), true);
+    assert.equal(fs.statSync(path.join(target, '.env')).mode & 0o777, 0o600);
+  });
+
+  test('leaves conflicting target files unchanged', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-data-conflict-'));
+    const source = path.join(root, 'source');
+    const target = path.join(root, 'target');
+    fs.mkdirSync(path.join(source, 'data'), { recursive: true });
+    fs.mkdirSync(path.join(target, 'data'), { recursive: true });
+    fs.writeFileSync(path.join(source, 'data', 'state.json'), 'source', 'utf8');
+    fs.writeFileSync(path.join(target, 'data', 'state.json'), 'target', 'utf8');
+
+    const plan = planRuntimeDataMigration(source, target);
+    assert.equal(plan.totals.conflict, 1);
+    const result = applyRuntimeDataMigration(plan);
+
+    assert.equal(result.totals.conflict, 1);
+    assert.equal(fs.readFileSync(path.join(target, 'data', 'state.json'), 'utf8'), 'target');
+  });
+
+  test('rejects nested migration roots', () => {
+    assert.throws(
+      () => planRuntimeDataMigration('/tmp/xiaoba-source', '/tmp/xiaoba-source/profile'),
+      /must be separate, non-nested directories/,
+    );
+  });
+
+  test('does not mistake bundled data and skills directories for legacy user data', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-data-markers-'));
+    fs.mkdirSync(path.join(root, 'data'), { recursive: true });
+    fs.mkdirSync(path.join(root, 'skills'), { recursive: true });
+    assert.deepEqual(findLegacyRuntimeArtifacts(root), []);
+
+    fs.mkdirSync(path.join(root, 'logs'), { recursive: true });
+    fs.mkdirSync(path.join(root, 'data', 'sessions'), { recursive: true });
+    assert.deepEqual(findLegacyRuntimeArtifacts(root), ['logs', 'data/sessions']);
+  });
+});

--- a/tests/test-environment.test.ts
+++ b/tests/test-environment.test.ts
@@ -24,7 +24,11 @@ describe('test runner environment isolation', () => {
     });
 
     for (const key of RUNTIME_WRITE_PATH_ENV_KEYS) {
-      assert.equal(isolated[key], undefined, key);
+      if (key === 'XIAOBA_USER_DATA_DIR') {
+        assert.equal(isolated[key], '/tmp/xiaoba-test-tmp/runtime-data', key);
+      } else {
+        assert.equal(isolated[key], undefined, key);
+      }
       assert.ok(source[key], `source ${key} should remain unchanged`);
     }
     assert.equal(isolated.KEEP_ME, 'yes');
@@ -34,6 +38,8 @@ describe('test runner environment isolation', () => {
     assert.equal(isolated.TMP, '/tmp/xiaoba-test-tmp');
     assert.equal(isolated.TEMP, '/tmp/xiaoba-test-tmp');
     assert.equal(isolated.XIAOBA_APP_ROOT, '/workspace/xiaoba');
+    assert.equal(isolated.XIAOBA_TEST_SANDBOX_ROOT, '/tmp');
+    assert.equal(isolated.XIAOBA_TEST_DEFAULT_DATA_DIR, '/tmp/xiaoba-test-tmp/runtime-data');
     assert.equal(isolated.DOTENV_CONFIG_PATH, '/tmp/xiaoba-test-runner/.env');
     assert.equal(source.DOTENV_CONFIG_PATH, '/production/.env');
     assert.equal(isolated.NODE_ENV, 'test');


### PR DESCRIPTION
## Summary
- integrate the runtime-data separation work into the current architecture stack while preserving the modular Stage 1 commits tracked in #292
- normalize DeepSeek Chat cache-hit usage and add redacted, reproducible cache and reasoning/tool replay canaries
- document the context/cache/lifecycle architecture, pinned pi/OpenCode comparison, measurements, and known boundaries
- make the main dashboard navigation usable on a 390 px mobile viewport

## Validation
- npm test: 1,392 tests; 1,384 passed, 8 skipped, 0 failed
- npm run build
- CLI data-root smoke: default, named profile, explicit data dir, and copy-only migration preview
- desktop 1280x720 and mobile 390x844 visual checks for main dashboard, Cache Trace, and Turn Errors; refresh interactions; no browser console errors
- live OpenAI-compatible Responses cache canary: passed, 15,104 cached tokens on attempt 3
- live canonical DeepSeek Responses and Chat cache canaries: passed, 13,696 cached tokens
- live DeepSeek reasoning/tool replay canary: passed without the former 400

## Boundaries
- Anthropic-compatible live proof remains inconclusive because the available local credential returned HTTP 401; compatible cache markers remain disabled
- no runtime-data migration was applied; the preview is copy-only and leaves the source untouched
- this draft is stacked on #301 and deliberately overlaps the Stage 1 history in #292 as an integration record

Depends on #301.