### PR TITLE
ci: isolate paired skills contract runtime data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,4 +165,6 @@ jobs:
         working-directory: XiaoBa-CLI
         env:
           CATSCOMPANY_REPO: ../cats-company
+          XIAOBA_TEST_SANDBOX_ROOT: ${{ runner.temp }}
+          XIAOBA_USER_DATA_DIR: ${{ runner.temp }}/xiaoba-catsco-skills
         run: npm run test:cross-repo:catsco-skills


### PR DESCRIPTION
## Summary

- Configure the paired BotDefinition Skills contract job with an isolated runtime data directory.
- Explicitly allow the GitHub runner temporary root under the Node test safety boundary.
- Restore the red PR #302 paired-contract check without weakening production path protections.

## Validation

- XiaoBa paired TypeScript contract tests: 21 passed, 0 failed.
- Reproduced with a simulated runner temp path outside the OS default temp directory.
- Independent read-only review: APPROVE.
- `git diff --check`.

## Stack

- Base: #302 (`agent/cache-architecture-validation`).
- This is an isolated baseline CI fix before cache benchmark truth and observability work.