### PR TITLE
feat: add explicit Responses cache boundaries

### DIFF
--- a/prompts/checkpoint-compact-system.md
+++ b/prompts/checkpoint-compact-system.md
@@ -1,5 +1,7 @@
 You are performing a CONTEXT CHECKPOINT COMPACTION. Create a durable handoff summary for another language model.
 
+The source below contains only older history that will not be retained verbatim. A deterministic exact tail of recent complete user, assistant, and tool exchanges will be appended after this checkpoint. Do not duplicate that unseen exact tail, and do not create a nested checkpoint.
+
 Include:
 - The user's original objective and latest corrections or constraints
 - Current progress and key decisions already made
@@ -17,4 +19,5 @@ Rules:
 - Do not guess missing evidence. Say what must be reread, searched, or reverified.
 - Do not include hidden reasoning or chain-of-thought.
 - Remove greetings, repetition, and bulky raw tool output that can be retrieved again.
+- Merge facts from any prior checkpoint into this single current checkpoint instead of embedding one summary inside another.
 - Return only the concise handoff summary.

--- a/src/core/checkpoint-compaction.ts
+++ b/src/core/checkpoint-compaction.ts
@@ -18,7 +18,6 @@ const DEFAULT_COMPACTION_THRESHOLD = 0.8;
 const MIN_RETAINED_USER_TOKEN_BUDGET = 8_000;
 const MAX_RETAINED_USER_TOKEN_BUDGET = 32_000;
 const RETAINED_USER_CONTEXT_RATIO = 0.15;
-const DEFAULT_RETAINED_CONTEXT_MESSAGE_LIMIT = 8;
 const MAX_CONTEXT_RETRY_ATTEMPTS = 6;
 const MAX_SUMMARY_TOOL_RESULT_CHARS = 24_000;
 const SUMMARY_TOOL_RESULT_HEAD_CHARS = 16_000;
@@ -37,6 +36,7 @@ export interface CheckpointCompactionCoordinatorOptions {
 export interface CheckpointCompactionRequest {
   sessionKey: string;
   phase: CheckpointCompactionPhase;
+  episodeId?: string;
   toolTokens?: number;
   signal?: AbortSignal;
   onStatus?: (event: CheckpointCompactionStatusEvent) => void | Promise<void>;
@@ -92,10 +92,13 @@ export class CheckpointCompactionCoordinator {
       DEFAULT_COMPACTION_THRESHOLD,
     );
     this.retainedUserTokenBudget = Math.max(
-      1_000,
-      Math.floor(
-        options.retainedUserTokenBudget
-        ?? defaultRetainedUserTokenBudget(this.maxContextTokens),
+      256,
+      Math.min(
+        Math.floor(this.maxContextTokens * 0.5),
+        Math.floor(
+          options.retainedUserTokenBudget
+          ?? defaultRetainedUserTokenBudget(this.maxContextTokens),
+        ),
       ),
     );
   }
@@ -145,6 +148,9 @@ export class CheckpointCompactionCoordinator {
 
     try {
       const result = await this.compact(messages, request, usage);
+      if (result === messages) {
+        return { messages, compacted: false, ...usage };
+      }
       await this.emitStatus(request, {
         status: 'complete',
         sessionKey: request.sessionKey,
@@ -162,7 +168,7 @@ export class CheckpointCompactionCoordinator {
         'INFO',
         `[${request.sessionKey}] checkpoint_compaction phase=${request.phase} `
         + `summary_sha256=${audit.summarySha256} retained_root=${audit.retainedRootCount} `
-        + `retained_pending=${audit.retainedPendingCount}`,
+        + `retained_pending=${audit.retainedPendingCount} exact_tail_groups=${audit.exactTailGroupCount}`,
         {
           type: 'checkpoint_compaction',
           payload: {
@@ -176,6 +182,8 @@ export class CheckpointCompactionCoordinator {
             retained_root_count: audit.retainedRootCount,
             retained_pending_count: audit.retainedPendingCount,
             retained_user_evidence_count: audit.retainedUserEvidenceCount,
+            exact_tail_group_count: audit.exactTailGroupCount,
+            exact_tail_tokens: audit.exactTailTokens,
           },
         },
       );
@@ -213,32 +221,22 @@ export class CheckpointCompactionCoordinator {
       return messages;
     }
 
-    const summary = await this.generateContinuationSummary(
+    const activeEpisodeId = request.episodeId || findLatestEpisodeId(sessionMessages);
+    const exactTail = selectExactTail(
       sessionMessages,
+      activeEpisodeId,
+      this.retainedUserTokenBudget,
+    );
+    if (exactTail.summarySource.length === 0) {
+      return messages;
+    }
+
+    const summary = await this.generateContinuationSummary(
+      exactTail.summarySource,
       request.phase,
       request.signal,
     );
-    const retainedContext = selectRetainedContextMessages(
-      sessionMessages,
-      request.phase,
-      this.retainedUserTokenBudget,
-    );
     const remoteContextWatermarks = collectRemoteContextWatermarks(durable);
-    const activeEpisodeId = findLatestEpisodeId(sessionMessages);
-    const stableBoundary = findLastStableBoundary(sessionMessages);
-
-    const boundary: Message = {
-      role: 'system',
-      content: [
-        CHECKPOINT_COMPACTION_BOUNDARY_PREFIX,
-        `phase=${request.phase}`,
-        activeEpisodeId ? `episode=${activeEpisodeId}` : '',
-        stableBoundary ? `last_stable=${stableBoundary}` : '',
-        `tokens_before=${usage.usedTokens}`,
-      ].filter(Boolean).join(' '),
-      __checkpointBoundary: true,
-      __checkpointPhase: request.phase,
-    };
     const summaryMessage: Message = {
       role: 'user',
       content: `${CHECKPOINT_SUMMARY_PREFIX}\n\n${summary}`,
@@ -252,9 +250,8 @@ export class CheckpointCompactionCoordinator {
 
     return [
       ...stableSystemMessages,
-      boundary,
       summaryMessage,
-      ...retainedContext,
+      ...exactTail.retained,
       ...transient,
     ];
   }
@@ -413,92 +410,208 @@ export function splitDurableAndTransient(messages: Message[]): {
   return { durable, transient };
 }
 
-function selectRetainedContextMessages(
-  messages: Message[],
-  phase: CheckpointCompactionPhase,
-  tokenBudget: number,
-): Message[] {
-  const latestEpisodeId = findLatestEpisodeId(messages);
-  if (phase === 'mid_turn' && latestEpisodeId) {
-    return selectMidTurnUserMessages(messages, latestEpisodeId, tokenBudget);
-  }
-  const candidates = messages.filter(message => {
-    if (isCheckpointSummary(message)) return false;
-    if (message.role === 'user') return true;
-    return message.role === 'assistant'
-      && !message.tool_calls?.length
-      && typeof message.content === 'string'
-      && message.content.trim().length > 0;
-  });
-
-  const selected: Message[] = [];
-  let usedTokens = 0;
-  for (let index = candidates.length - 1; index >= 0; index--) {
-    if (selected.length >= DEFAULT_RETAINED_CONTEXT_MESSAGE_LIMIT) break;
-    const candidate = candidates[index];
-    const candidateTokens = estimateMessagesTokens([candidate]);
-    const remainingTokens = tokenBudget - usedTokens;
-    if (candidateTokens > remainingTokens) {
-      if (selected.length === 0 && candidate.role === 'user') {
-        const evidence = buildUserInputEvidence(candidate, remainingTokens);
-        if (evidence) {
-          selected.unshift(evidence);
-          usedTokens += estimateMessagesTokens([evidence]);
-        }
-      }
-      continue;
-    }
-    selected.unshift(candidate);
-    usedTokens += candidateTokens;
-  }
-  return selected;
+interface ExactTailGroup {
+  start: number;
+  end: number;
+  messages: Message[];
+  hasToolExchange: boolean;
+  hasUserInput: boolean;
+  belongsToActiveEpisode: boolean;
 }
 
-function selectMidTurnUserMessages(
-  messages: Message[],
-  episodeId: string,
-  tokenBudget: number,
-): Message[] {
-  const episodeInputs = messages.filter(message => (
-    !isCheckpointSummary(message)
-    && message.role === 'user'
-    && message.__episodeId === episodeId
-  ));
-  if (episodeInputs.length === 0) return [];
+interface ExactTailSelection {
+  retained: Message[];
+  summarySource: Message[];
+}
 
-  const root = episodeInputs.find(message => message.__episodeInputKind === 'root')
-    ?? episodeInputs[0];
-  const laterInputs = episodeInputs.filter(message => message !== root);
-  const retainedBySource = new Map<Message, Message>();
+interface SelectedExactTailGroup {
+  messages: Message[];
+  sourceIndexes: number[];
+}
+
+function selectExactTail(
+  messages: Message[],
+  activeEpisodeId: string | undefined,
+  tokenBudget: number,
+): ExactTailSelection {
+  const groups = buildExactTailGroups(messages, activeEpisodeId)
+    .filter(group => !group.messages.some(isCheckpointSummary));
+  const candidates = [...groups].sort((left, right) => {
+    const leftPriority = exactTailPriority(left);
+    const rightPriority = exactTailPriority(right);
+    return leftPriority - rightPriority || right.end - left.end;
+  });
+  const selected = new Map<ExactTailGroup, SelectedExactTailGroup>();
   let usedTokens = 0;
 
-  const add = (message: Message): void => {
-    const remainingTokens = tokenBudget - usedTokens;
-    if (remainingTokens < 128) return;
-    const messageTokens = estimateMessagesTokens([message]);
-    if (messageTokens <= remainingTokens) {
-      retainedBySource.set(message, message);
-      usedTokens += messageTokens;
-      return;
+  for (const group of candidates) {
+    const remaining = tokenBudget - usedTokens;
+    if (remaining < 128) break;
+    let retainedGroup = group.messages;
+    let groupTokens = estimateMessagesTokens(retainedGroup);
+    let sourceIndexes = indexesForGroup(group);
+    if (groupTokens > remaining) {
+      const recentAssistant = recentAssistantFromOversizedOrdinaryExchange(group);
+      if (recentAssistant && estimateMessagesTokens([recentAssistant]) <= remaining) {
+        retainedGroup = [recentAssistant];
+        groupTokens = estimateMessagesTokens(retainedGroup);
+        sourceIndexes = [group.end];
+      } else {
+        retainedGroup = buildBoundedExactGroup(group.messages, remaining);
+        groupTokens = estimateMessagesTokens(retainedGroup);
+      }
     }
-    const evidence = buildUserInputEvidence(message, remainingTokens);
-    if (!evidence) return;
-    retainedBySource.set(message, evidence);
-    usedTokens += estimateMessagesTokens([evidence]);
-  };
-
-  // The root objective always wins. Repeated short follow-ups must never evict it.
-  add(root);
-  // Prefer the latest corrections when the episode's user input itself exceeds
-  // the retained budget. The returned messages are restored to chronological order.
-  for (let index = laterInputs.length - 1; index >= 0; index--) {
-    add(laterInputs[index]);
+    if (retainedGroup.length === 0 || groupTokens > remaining) continue;
+    selected.set(group, { messages: retainedGroup, sourceIndexes });
+    usedTokens += groupTokens;
   }
 
-  return episodeInputs.flatMap(message => {
-    const retained = retainedBySource.get(message);
-    return retained ? [retained] : [];
+  // A checkpoint must summarize at least one older source group. If the exact
+  // tail swallowed the entire transcript, move the oldest retained group back
+  // into the summary source instead of reporting a no-op compaction.
+  const selectedSourceCount = [...selected.values()]
+    .reduce((total, value) => total + value.sourceIndexes.length, 0);
+  if (selectedSourceCount === messages.length && groups.length > 0) {
+    const oldestSelected = [...selected.keys()].sort((left, right) => left.start - right.start)[0];
+    selected.delete(oldestSelected);
+  }
+
+  const selectedIndexes = new Set<number>();
+  const retained: Message[] = [];
+  for (const group of [...selected.keys()].sort((left, right) => left.start - right.start)) {
+    const selection = selected.get(group)!;
+    for (const index of selection.sourceIndexes) selectedIndexes.add(index);
+    retained.push(...selection.messages);
+  }
+  return {
+    retained,
+    summarySource: messages.filter((_, index) => !selectedIndexes.has(index)),
+  };
+}
+
+function indexesForGroup(group: ExactTailGroup): number[] {
+  return Array.from({ length: group.end - group.start + 1 }, (_, offset) => group.start + offset);
+}
+
+function recentAssistantFromOversizedOrdinaryExchange(group: ExactTailGroup): Message | undefined {
+  if (group.messages.length !== 2) return undefined;
+  const [user, assistant] = group.messages;
+  if (user.role !== 'user' || assistant.role !== 'assistant' || assistant.tool_calls?.length) {
+    return undefined;
+  }
+  return assistant;
+}
+
+function buildExactTailGroups(
+  messages: Message[],
+  activeEpisodeId?: string,
+): ExactTailGroup[] {
+  const groups: ExactTailGroup[] = [];
+  for (let index = 0; index < messages.length;) {
+    const start = index;
+    const first = messages[index];
+    if (first.role === 'user') {
+      index++;
+      if (index < messages.length
+        && messages[index].role === 'assistant'
+        && !messages[index].tool_calls?.length) {
+        index++;
+      }
+    } else if (first.role === 'assistant' && first.tool_calls?.length) {
+      const expected = new Set(first.tool_calls.map(call => call.id));
+      index++;
+      while (index < messages.length && messages[index].role === 'tool') {
+        if (messages[index].tool_call_id) expected.delete(messages[index].tool_call_id!);
+        index++;
+        if (expected.size === 0) break;
+      }
+    } else {
+      index++;
+    }
+    const groupMessages = messages.slice(start, index);
+    groups.push({
+      start,
+      end: index - 1,
+      messages: groupMessages,
+      hasToolExchange: groupMessages.some(message => message.role === 'tool'),
+      hasUserInput: groupMessages.some(message => message.role === 'user'),
+      belongsToActiveEpisode: Boolean(
+        activeEpisodeId
+        && groupMessages.some(message => message.__episodeId === activeEpisodeId),
+      ),
+    });
+  }
+  return groups;
+}
+
+function exactTailPriority(group: ExactTailGroup): number {
+  if (group.belongsToActiveEpisode && group.hasToolExchange) return 0;
+  if (group.belongsToActiveEpisode && group.hasUserInput) return 1;
+  return 2;
+}
+
+function buildBoundedExactGroup(messages: Message[], maxTokens: number): Message[] {
+  if (maxTokens < 128) return [];
+  const perMessageBudget = Math.max(96, Math.floor(maxTokens / Math.max(1, messages.length)));
+  const bounded = messages.map(message => {
+    if (message.role === 'tool' && typeof message.content === 'string') {
+      return estimateMessagesTokens([message]) <= perMessageBudget
+        ? message
+        : buildToolResultEvidence(message, perMessageBudget);
+    }
+    if (message.role !== 'user') return message;
+    const messageTokens = estimateMessagesTokens([message]);
+    if (messageTokens <= perMessageBudget) {
+      return message;
+    }
+    return buildUserInputEvidence(
+      message,
+      perMessageBudget,
+    ) || message;
   });
+  return estimateMessagesTokens(bounded) <= maxTokens ? bounded : [];
+}
+
+function buildToolResultEvidence(message: Message, maxTokens: number): Message {
+  const raw = typeof message.content === 'string' ? message.content : '';
+  const hash = createHash('sha256').update(raw).digest('hex');
+  let materialChars = Math.min(raw.length, Math.max(64, Math.floor(maxTokens * 1.2)));
+
+  while (materialChars >= 32) {
+    const headChars = Math.max(24, Math.floor(materialChars * 0.75));
+    const tailChars = Math.max(8, materialChars - headChars);
+    const evidence: Message = {
+      ...message,
+      content: [
+        CHECKPOINT_TOOL_EVIDENCE_PREFIX,
+        message.name ? `tool_name: ${message.name}` : '',
+        message.tool_call_id ? `tool_call_id: ${message.tool_call_id}` : '',
+        `original_chars: ${raw.length}`,
+        `sha256: ${hash}`,
+        'omission: bounded exact-tail evidence; re-run the tool before relying on omitted details.',
+        '',
+        'head:',
+        raw.slice(0, headChars),
+        '',
+        'tail:',
+        raw.slice(-tailChars),
+      ].filter(part => part !== '').join('\n'),
+    };
+    if (estimateMessagesTokens([evidence]) <= maxTokens) return evidence;
+    materialChars = Math.floor(materialChars * 0.65);
+  }
+
+  return {
+    ...message,
+    content: [
+      CHECKPOINT_TOOL_EVIDENCE_PREFIX,
+      message.name ? `tool_name: ${message.name}` : '',
+      message.tool_call_id ? `tool_call_id: ${message.tool_call_id}` : '',
+      `original_chars: ${raw.length}`,
+      `sha256: ${hash}`,
+      'omission: tool output exceeded the exact-tail evidence budget; re-run before use.',
+    ].filter(part => part !== '').join('\n'),
+  };
 }
 
 function buildUserInputEvidence(message: Message, maxTokens: number): Message | undefined {
@@ -564,8 +677,14 @@ function buildCompactionAudit(
   retainedRootCount: number;
   retainedPendingCount: number;
   retainedUserEvidenceCount: number;
+  exactTailGroupCount: number;
+  exactTailTokens: number;
 } {
   const summary = messages.find(message => message.__checkpointSummary);
+  const summaryIndex = messages.findIndex(message => message.__checkpointSummary);
+  const exactTail = summaryIndex < 0
+    ? []
+    : messages.slice(summaryIndex + 1).filter(message => !isTransientMessage(message));
   const summaryText = typeof summary?.content === 'string' ? summary.content : '';
   return {
     summaryChars: summaryText.length,
@@ -576,24 +695,14 @@ function buildCompactionAudit(
       typeof message.content === 'string'
       && message.content.startsWith(CHECKPOINT_USER_INPUT_EVIDENCE_PREFIX)
     )).length,
+    exactTailGroupCount: buildExactTailGroups(exactTail).length,
+    exactTailTokens: estimateMessagesTokens(exactTail),
   };
 }
 
 function findLatestEpisodeId(messages: Message[]): string | undefined {
   for (let index = messages.length - 1; index >= 0; index--) {
     if (messages[index].__episodeId) return messages[index].__episodeId;
-  }
-  return undefined;
-}
-
-function findLastStableBoundary(messages: Message[]): string | undefined {
-  for (let index = messages.length - 1; index >= 0; index--) {
-    const message = messages[index];
-    if (message.role !== 'tool') continue;
-    return [
-      message.name ? `tool:${message.name}` : 'tool',
-      message.tool_call_id ? `call:${message.tool_call_id}` : '',
-    ].filter(Boolean).join(',');
   }
   return undefined;
 }

--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -419,6 +419,7 @@ export class ConversationRunner {
           const assistantMessage: Message = {
             role: 'assistant',
             content: MODEL_IMAGE_SAFETY_MESSAGE,
+            ...(this.episodeId ? { __episodeId: this.episodeId } : {}),
           };
           messages.push(assistantMessage);
           newMessages.push(assistantMessage);
@@ -500,7 +501,11 @@ export class ConversationRunner {
         Logger.info(`[${this.sessionLabel}Turn ${turns}] AI最终回复: ${ConversationRunner.truncateForLog(visibleContent, 300)}`);
 
         if (visibleContent) {
-          const finalAssistantMessage: Message = { role: 'assistant', content: visibleContent };
+          const finalAssistantMessage: Message = {
+            role: 'assistant',
+            content: visibleContent,
+            ...(this.episodeId ? { __episodeId: this.episodeId } : {}),
+          };
           messages.push(finalAssistantMessage);
           newMessages.push(finalAssistantMessage);
         }
@@ -767,6 +772,7 @@ export class ConversationRunner {
     const result = await this.checkpointCompactionCoordinator.compactIfNeeded(messages, {
       sessionKey: this.toolExecutionContext?.sessionId || this.sessionLabel.trim() || 'runner',
       phase: 'mid_turn',
+      episodeId: this.episodeId,
       toolTokens: estimateToolsTokens(tools),
       signal: this.toolExecutionContext?.abortSignal,
       onStatus: callbacks?.onThinking
@@ -917,6 +923,7 @@ export class ConversationRunner {
       ...(providerContent?.length
         ? { providerContent }
         : {}),
+      ...(this.episodeId ? { __episodeId: this.episodeId } : {}),
     };
 
     if (assistant.content || assistant.tool_calls?.length) {
@@ -951,6 +958,7 @@ export class ConversationRunner {
           ],
           tool_call_id: record.result.tool_call_id,
           name: record.result.name,
+          ...(this.episodeId ? { __episodeId: this.episodeId } : {}),
         });
       } else {
         // 正常的 tool result
@@ -959,15 +967,24 @@ export class ConversationRunner {
           content: record.toolContent,
           tool_call_id: record.result.tool_call_id,
           name: record.result.name,
+          ...(this.episodeId ? { __episodeId: this.episodeId } : {}),
         });
 
         // 插入额外消息（如图片）
         if (record.newMessages) {
-          messages.push(...record.newMessages);
+          messages.push(...record.newMessages.map(message => ({
+            ...message,
+            ...(message.__episodeId || !this.episodeId ? {} : { __episodeId: this.episodeId }),
+          })));
         }
       }
     }
 
+    if (this.episodeId) {
+      for (const message of messages) {
+        if (!message.__episodeId) message.__episodeId = this.episodeId;
+      }
+    }
     return messages;
   }
 
@@ -1426,6 +1443,12 @@ export class ConversationRunner {
   ) {
     const requestOptions = {
       signal: this.toolExecutionContext?.abortSignal,
+      promptCacheContext: {
+        sessionKey: this.toolExecutionContext?.sessionId || 'unknown',
+        ...(this.episodeId ? { currentEpisodeId: this.episodeId } : {}),
+        phase: 'normal' as const,
+        explicitCaching: true,
+      },
     };
     try {
       if (this.stream) {

--- a/src/core/turn-context-builder.ts
+++ b/src/core/turn-context-builder.ts
@@ -73,7 +73,7 @@ export class TurnContextBuilder {
       await params.skillRuntime.reloadSkills();
       const skillsListMsg = params.skillRuntime.buildSkillsListMessage();
       if (skillsListMsg) {
-        this.insertBeforeLastUser(contextMessages, { ...skillsListMsg, __cacheScope: 'dynamic' });
+        this.insertBeforeLastUser(contextMessages, { ...skillsListMsg, __cacheScope: 'stable' });
       }
     }
 
@@ -130,6 +130,7 @@ export class TurnContextBuilder {
         '如果 late_previous_turn 与当前用户输入冲突，以当前用户输入为准。',
         '如果它说明上一轮回答有遗漏且当前仍在同一话题，可以简短补充或修正；否则保持安静。',
       ].join('\n'),
+      __cacheScope: 'stable',
     });
   }
 

--- a/src/providers/openai-provider.ts
+++ b/src/providers/openai-provider.ts
@@ -1031,6 +1031,9 @@ export class OpenAIProvider implements AIProvider {
 
   private shouldRetryWithoutExplicitCaching(error: unknown, body: any): boolean {
     if (!body?.prompt_cache_options) return false;
+    if (/^(?:1|true|yes|on)$/i.test(String(process.env.XIAOBA_RESPONSES_EXPLICIT_CACHE_STRICT || '').trim())) {
+      return false;
+    }
     const status = Number((error as any)?.response?.status ?? (error as any)?.status);
     const data = (error as any)?.response?.data;
     const detail = `${(error as any)?.message || ''} ${typeof data === 'string' ? data : JSON.stringify(data || {})}`.toLowerCase();

--- a/src/providers/openai-provider.ts
+++ b/src/providers/openai-provider.ts
@@ -453,14 +453,16 @@ export class OpenAIProvider implements AIProvider {
     const currentEpisodeId = cacheContext?.currentEpisodeId;
     const transientMessages = requestMessages.filter(message => this.isTurnDeltaMessage(message));
     const durableMessages = requestMessages.filter(message => !this.isTurnDeltaMessage(message));
+    const checkpointMessages = durableMessages.filter(message => message.__checkpointSummary === true);
+    const chronologicalMessages = durableMessages.filter(message => message.__checkpointSummary !== true);
     const inferredGroups = currentEpisodeId
       ? []
-      : this.groupResponsesExchanges(durableMessages);
+      : this.groupResponsesExchanges(chronologicalMessages);
     const completedEpisodeMessages = currentEpisodeId
-      ? durableMessages.filter(message => message.__episodeId !== currentEpisodeId)
+      ? chronologicalMessages.filter(message => message.__episodeId !== currentEpisodeId)
       : inferredGroups.slice(0, -1).flat();
     const currentEpisodeMessages = currentEpisodeId
-      ? durableMessages.filter(message => message.__episodeId === currentEpisodeId)
+      ? chronologicalMessages.filter(message => message.__episodeId === currentEpisodeId)
       : [];
     const currentGroups = this.groupResponsesExchanges(currentEpisodeMessages);
     const latestGroup = currentEpisodeId
@@ -489,6 +491,7 @@ export class OpenAIProvider implements AIProvider {
       recordBreakpoint('S');
     }
 
+    input.push(...this.convertResponsesMessages(checkpointMessages));
     input.push(...this.convertResponsesMessages(completedEpisodeMessages));
     if (explicitCaching && completedEpisodeMessages.length > 0) {
       input.push(this.buildBreakpointCarrier());

--- a/src/providers/openai-provider.ts
+++ b/src/providers/openai-provider.ts
@@ -13,6 +13,22 @@ import {
   supportsReasoningSwitch,
 } from '../utils/reasoning-effort';
 import { openAIApiModeOrDefault } from '../utils/openai-api-mode';
+import { Logger } from '../utils/logger';
+import { estimateJsonTokens } from '../core/token-estimator';
+
+interface ResponsesBreakpointDiagnostic {
+  label: 'S' | 'A' | 'B';
+  prefixHash: string;
+  inputItems: number;
+  inputTokenEstimate: number;
+}
+
+interface ResponsesInputLayout {
+  input: any[];
+  breakpoints: Array<'S' | 'A' | 'B'>;
+  prefixHashes: Partial<Record<'S' | 'A' | 'B', string>>;
+  breakpointDiagnostics: ResponsesBreakpointDiagnostic[];
+}
 
 /**
  * OpenAI Provider
@@ -29,6 +45,7 @@ export class OpenAIProvider implements AIProvider {
   private maxTokens: number;
   private reasoningEffort: ChatConfig['reasoningEffort'];
   private openaiApiMode: ChatConfig['openaiApiMode'];
+  private responsesExplicitCacheSupported: boolean | undefined;
 
   constructor(config: ChatConfig) {
     this.apiUrl = config.apiUrl!;
@@ -363,27 +380,56 @@ export class OpenAIProvider implements AIProvider {
     });
   }
 
-  private buildResponsesRequestBody(messages: Message[], tools?: ToolDefinition[], stream = false): any {
+  private buildResponsesRequestBody(
+    messages: Message[],
+    tools?: ToolDefinition[],
+    stream = false,
+    options?: AIRequestOptions,
+    forceCompatibility = false,
+  ): any {
     const instructions = messages
       .filter(message => message.role === 'system' && !this.isDynamicCacheMessage(message))
+      .filter(message => !this.isLegacyCheckpointBoundary(message))
       .map(message => this.contentAsText(message.content))
       .filter(Boolean)
       .join('\n\n');
     const responseTools = this.buildCanonicalResponsesTools(tools ?? []);
+    const explicitCaching = !forceCompatibility
+      && this.responsesExplicitCacheSupported !== false
+      && options?.promptCacheContext?.explicitCaching === true
+      && this.supportsExplicitPromptCaching();
+    const layout = this.buildResponsesInput(
+      messages,
+      options?.promptCacheContext,
+      explicitCaching,
+    );
     const body: any = {
       model: this.model,
-      input: this.buildResponsesInput(messages),
+      input: layout.input,
       max_output_tokens: this.maxTokens,
       stream,
       store: false,
-      prompt_cache_key: this.buildPromptCacheKey(instructions, responseTools),
+      prompt_cache_key: this.buildPromptCacheKey(
+        instructions,
+        responseTools,
+        options?.promptCacheContext?.sessionKey,
+      ),
     };
 
     if (instructions) body.instructions = instructions;
     if (Number.isFinite(this.temperature)) body.temperature = this.temperature;
     if (responseTools.length > 0) body.tools = responseTools;
+    if (explicitCaching) body.prompt_cache_options = { mode: 'explicit' };
     body.include = ['reasoning.encrypted_content'];
     this.applyResponsesReasoningOptions(body);
+    this.logResponsesCacheLayout(
+      body.prompt_cache_key,
+      instructions,
+      responseTools,
+      layout,
+      explicitCaching,
+      options?.promptCacheContext,
+    );
     return body;
   }
 
@@ -395,16 +441,81 @@ export class OpenAIProvider implements AIProvider {
     }
   }
 
-  private buildResponsesInput(messages: Message[]): any[] {
+  private buildResponsesInput(
+    messages: Message[],
+    cacheContext?: AIRequestOptions['promptCacheContext'],
+    explicitCaching = false,
+  ): ResponsesInputLayout {
+    const requestMessages = messages.filter(message => (
+      !this.isLegacyCheckpointBoundary(message)
+      && !(message.role === 'system' && !this.isDynamicCacheMessage(message))
+    ));
+    const currentEpisodeId = cacheContext?.currentEpisodeId;
+    const transientMessages = requestMessages.filter(message => this.isTurnDeltaMessage(message));
+    const durableMessages = requestMessages.filter(message => !this.isTurnDeltaMessage(message));
+    const inferredGroups = currentEpisodeId
+      ? []
+      : this.groupResponsesExchanges(durableMessages);
+    const completedEpisodeMessages = currentEpisodeId
+      ? durableMessages.filter(message => message.__episodeId !== currentEpisodeId)
+      : inferredGroups.slice(0, -1).flat();
+    const currentEpisodeMessages = currentEpisodeId
+      ? durableMessages.filter(message => message.__episodeId === currentEpisodeId)
+      : [];
+    const currentGroups = this.groupResponsesExchanges(currentEpisodeMessages);
+    const latestGroup = currentEpisodeId
+      ? (currentGroups[currentGroups.length - 1] || [])
+      : (inferredGroups[inferredGroups.length - 1] || []);
+    const completedCurrentGroups = currentEpisodeId ? currentGroups.slice(0, -1) : [];
     const input: any[] = [];
-    const dynamicSystemMessages: Message[] = [];
+    const breakpoints: Array<'S' | 'A' | 'B'> = [];
+    const prefixHashes: Partial<Record<'S' | 'A' | 'B', string>> = {};
+    const breakpointDiagnostics: ResponsesBreakpointDiagnostic[] = [];
 
+    const recordBreakpoint = (label: 'S' | 'A' | 'B') => {
+      const prefixHash = this.hashWirePrefix(input);
+      breakpoints.push(label);
+      prefixHashes[label] = prefixHash;
+      breakpointDiagnostics.push({
+        label,
+        prefixHash,
+        inputItems: input.length,
+        inputTokenEstimate: estimateJsonTokens(input),
+      });
+    };
+
+    if (explicitCaching) {
+      input.push(this.buildBreakpointCarrier());
+      recordBreakpoint('S');
+    }
+
+    input.push(...this.convertResponsesMessages(completedEpisodeMessages));
+    if (explicitCaching && completedEpisodeMessages.length > 0) {
+      input.push(this.buildBreakpointCarrier());
+      recordBreakpoint('A');
+    }
+
+    const firstBreakpointGroup = Math.max(0, completedCurrentGroups.length - 2);
+    for (const [groupIndex, group] of completedCurrentGroups.entries()) {
+      input.push(...this.convertResponsesMessages(group));
+      if (explicitCaching && groupIndex >= firstBreakpointGroup) {
+        input.push(this.buildBreakpointCarrier());
+        recordBreakpoint('B');
+      }
+    }
+
+    input.push(...this.convertResponsesMessages(transientMessages));
+    input.push(...this.convertResponsesMessages(latestGroup));
+    return { input, breakpoints, prefixHashes, breakpointDiagnostics };
+  }
+
+  private convertResponsesMessages(messages: Message[]): any[] {
+    const input: any[] = [];
     for (const message of messages) {
       if (message.role === 'system') {
-        if (this.isDynamicCacheMessage(message)) dynamicSystemMessages.push(message);
+        input.push({ role: 'system', content: this.responsesMessageContent(message.content) });
         continue;
       }
-
       if (message.role === 'tool') {
         if (!message.tool_call_id) continue;
         input.push({
@@ -414,7 +525,6 @@ export class OpenAIProvider implements AIProvider {
         });
         continue;
       }
-
       if (message.role === 'assistant' && message.tool_calls?.length) {
         const replayItems = (message.providerContent || [])
           .filter(item => this.isResponsesReplayItem(item))
@@ -423,7 +533,6 @@ export class OpenAIProvider implements AIProvider {
           input.push(...replayItems);
           continue;
         }
-
         const text = this.contentAsText(message.content);
         if (text) input.push({ role: 'assistant', content: text });
         for (const toolCall of message.tool_calls) {
@@ -436,28 +545,66 @@ export class OpenAIProvider implements AIProvider {
         }
         continue;
       }
-
-      input.push({
-        role: message.role,
-        content: this.responsesMessageContent(message.content),
-      });
+      input.push({ role: message.role, content: this.responsesMessageContent(message.content) });
     }
-
-    for (const message of dynamicSystemMessages) {
-      input.push({
-        role: 'system',
-        content: this.responsesMessageContent(message.content),
-      });
-    }
-
     return input;
+  }
+
+  private groupResponsesExchanges(messages: Message[]): Message[][] {
+    const groups: Message[][] = [];
+    for (let index = 0; index < messages.length;) {
+      const message = messages[index];
+      if (message.role === 'assistant' && message.tool_calls?.length) {
+        const expected = new Set(message.tool_calls.map(call => call.id));
+        const group = [message];
+        index++;
+        while (index < messages.length && messages[index].role === 'tool') {
+          const tool = messages[index];
+          group.push(tool);
+          if (tool.tool_call_id) expected.delete(tool.tool_call_id);
+          index++;
+          if (expected.size === 0) break;
+        }
+        groups.push(group);
+        continue;
+      }
+      groups.push([message]);
+      index++;
+    }
+    return groups;
+  }
+
+  private isTurnDeltaMessage(message: Message): boolean {
+    return this.isDynamicCacheMessage(message)
+      || message.__injected === true
+      || message.__runtimeFeedback === true
+      || message.__syntheticObservation === true;
+  }
+
+  private buildBreakpointCarrier(): any {
+    return {
+      role: 'system',
+      content: [{
+        type: 'input_text',
+        text: '\n',
+        prompt_cache_breakpoint: { mode: 'explicit' },
+      }],
+    };
   }
 
   private isDynamicCacheMessage(message: Message): boolean {
     if (message.__cacheScope === 'dynamic') return true;
     if (message.__cacheScope === 'stable') return false;
     if (message.role !== 'system' || typeof message.content !== 'string') return false;
-    return /^\[(?:transient_[^\]]+|compact_boundary)\]/.test(message.content);
+    return /^\[(?:transient_[^\]]+|compact_boundary|checkpoint_compaction_boundary)\]/.test(message.content);
+  }
+
+  private isLegacyCheckpointBoundary(message: Message): boolean {
+    return message.__checkpointBoundary === true || (
+      message.role === 'system'
+      && typeof message.content === 'string'
+      && /^\[(?:checkpoint_compaction_boundary|compact_boundary)\]/.test(message.content)
+    );
   }
 
   private buildCanonicalResponsesTools(tools: ToolDefinition[]): any[] {
@@ -513,17 +660,74 @@ export class OpenAIProvider implements AIProvider {
     ].includes(String(item.type || '')));
   }
 
-  private buildPromptCacheKey(instructions: string, tools: any[]): string {
+  private buildPromptCacheKey(instructions: string, tools: any[], sessionKey?: string): string {
     const digest = createHash('sha256')
       .update(JSON.stringify({
-        identityVersion: 'responses-cache-v2',
+        identityVersion: 'responses-cache-v3',
         model: this.model,
+        session: createHash('sha256').update(sessionKey || 'unscoped').digest('hex').slice(0, 24),
         instructions,
         tools,
       }))
       .digest('hex')
       .slice(0, 48);
     return `catsco-${digest}`;
+  }
+
+  private supportsExplicitPromptCaching(): boolean {
+    const match = this.model.trim().toLowerCase().match(/^gpt-(\d+)(?:\.(\d+))?(?:[-_:]|$)/);
+    if (!match) return false;
+    const major = Number(match[1]);
+    const minor = Number(match[2] || 0);
+    return major > 5 || (major === 5 && minor >= 6);
+  }
+
+  private hashWirePrefix(value: unknown): string {
+    return createHash('sha256').update(JSON.stringify(value)).digest('hex').slice(0, 16);
+  }
+
+  private logResponsesCacheLayout(
+    cacheKey: string,
+    instructions: string,
+    tools: any[],
+    layout: ResponsesInputLayout,
+    explicit: boolean,
+    cacheContext?: AIRequestOptions['promptCacheContext'],
+  ): void {
+    Logger.runtimeEvent('INFO', `responses_cache_layout mode=${explicit ? 'explicit' : 'compatibility'} breakpoints=${layout.breakpoints.join(',') || 'none'}`, {
+      type: 'responses_cache_layout',
+      payload: {
+        mode: explicit ? 'explicit' : 'compatibility',
+        phase: cacheContext?.phase || 'normal',
+        session_hash: this.hashWirePrefix(cacheContext?.sessionKey || 'unscoped'),
+        cache_key_hash: this.hashWirePrefix(cacheKey),
+        instructions_hash: this.hashWirePrefix(instructions),
+        tools_hash: this.hashWirePrefix(tools),
+        stable_core_token_estimate: estimateJsonTokens({ instructions, tools }),
+        breakpoint_sequence: layout.breakpoints,
+        prefix_hashes: layout.prefixHashes,
+        breakpoint_diagnostics: layout.breakpointDiagnostics,
+        input_items: layout.input.length,
+      },
+    });
+  }
+
+  private logResponsesCacheUsage(
+    cacheKey: string,
+    usage: ChatResponse['usage'],
+    explicit: boolean,
+  ): void {
+    if (!usage) return;
+    Logger.runtimeEvent('INFO', `responses_cache_usage mode=${explicit ? 'explicit' : 'compatibility'} cached=${usage.cachedReadTokens ?? 0} written=${usage.cachedWriteTokens ?? 0}`, {
+      type: 'responses_cache_usage',
+      payload: {
+        mode: explicit ? 'explicit' : 'compatibility',
+        cache_key_hash: this.hashWirePrefix(cacheKey),
+        input_tokens: usage.promptTokens,
+        cached_tokens: usage.cachedReadTokens ?? 0,
+        cache_write_tokens: usage.cachedWriteTokens ?? 0,
+      },
+    });
   }
 
   private applyResponsesReasoningOptions(body: any): void {
@@ -634,19 +838,33 @@ export class OpenAIProvider implements AIProvider {
     tools?: ToolDefinition[],
     options?: AIRequestOptions,
   ): Promise<ChatResponse> {
-    const body = this.buildResponsesRequestBody(messages, tools, false);
+    let body = this.buildResponsesRequestBody(messages, tools, false, options);
     ContextDebugLogger.dumpSdkBoundary('before', undefined, {
       apiUrl: this.responsesUrl,
       body,
     });
-    const response = await axios.post(this.responsesUrl, body, {
-      headers: this.headers,
-      signal: options?.signal,
-    });
+    let response;
+    try {
+      response = await axios.post(this.responsesUrl, body, {
+        headers: this.headers,
+        signal: options?.signal,
+      });
+    } catch (error) {
+      if (!this.shouldRetryWithoutExplicitCaching(error, body)) throw error;
+      this.responsesExplicitCacheSupported = false;
+      Logger.warning('Responses endpoint rejected explicit prompt caching; retrying once in compatibility mode.');
+      body = this.buildResponsesRequestBody(messages, tools, false, options, true);
+      response = await axios.post(this.responsesUrl, body, {
+        headers: this.headers,
+        signal: options?.signal,
+      });
+    }
     ContextDebugLogger.dumpSdkBoundary('after', undefined, { response: response.data });
     const failure = this.responsesFailureError(response.data);
     if (failure) throw failure;
-    return this.parseResponsesResponse(response.data);
+    const result = this.parseResponsesResponse(response.data);
+    this.logResponsesCacheUsage(body.prompt_cache_key, result.usage, Boolean(body.prompt_cache_options));
+    return result;
   }
 
   private async chatStreamResponses(
@@ -655,16 +873,29 @@ export class OpenAIProvider implements AIProvider {
     callbacks?: StreamCallbacks,
     options?: AIRequestOptions,
   ): Promise<ChatResponse> {
-    const body = this.buildResponsesRequestBody(messages, tools, true);
+    let body = this.buildResponsesRequestBody(messages, tools, true, options);
     ContextDebugLogger.dumpSdkBoundary('before', undefined, {
       apiUrl: this.responsesUrl,
       body,
     });
-    const response = await axios.post(this.responsesUrl, body, {
-      headers: this.headers,
-      responseType: 'stream',
-      signal: options?.signal,
-    });
+    let response;
+    try {
+      response = await axios.post(this.responsesUrl, body, {
+        headers: this.headers,
+        responseType: 'stream',
+        signal: options?.signal,
+      });
+    } catch (error) {
+      if (!this.shouldRetryWithoutExplicitCaching(error, body)) throw error;
+      this.responsesExplicitCacheSupported = false;
+      Logger.warning('Responses endpoint rejected explicit prompt caching; retrying stream once in compatibility mode.');
+      body = this.buildResponsesRequestBody(messages, tools, true, options, true);
+      response = await axios.post(this.responsesUrl, body, {
+        headers: this.headers,
+        responseType: 'stream',
+        signal: options?.signal,
+      });
+    }
 
     return new Promise<ChatResponse>((resolve, reject) => {
       const stream = response.data;
@@ -758,6 +989,7 @@ export class OpenAIProvider implements AIProvider {
           result.content = this.visibleMessageContent({ content: streamedVisibleText });
         }
         ContextDebugLogger.dumpSdkBoundary('after', undefined, { response: finalResponse });
+        this.logResponsesCacheUsage(body.prompt_cache_key, result.usage, Boolean(body.prompt_cache_options));
         settled = true;
         callbacks?.onComplete?.(result);
         resolve(result);
@@ -779,6 +1011,17 @@ export class OpenAIProvider implements AIProvider {
     return {
       providerContent: buildOpenAIProviderContentFromToolCalls(toolCalls, reasoningContent),
     };
+  }
+
+  private shouldRetryWithoutExplicitCaching(error: unknown, body: any): boolean {
+    if (!body?.prompt_cache_options) return false;
+    const status = Number((error as any)?.response?.status ?? (error as any)?.status);
+    if (status !== 400) return false;
+    const data = (error as any)?.response?.data;
+    const detail = `${(error as any)?.message || ''} ${typeof data === 'string' ? data : JSON.stringify(data || {})}`.toLowerCase();
+    return detail.includes('prompt_cache_breakpoint')
+      || detail.includes('prompt_cache_options')
+      || (detail.includes('prompt cache') && /unsupported|unknown|invalid|extra/.test(detail));
   }
 }
 

--- a/src/providers/openai-provider.ts
+++ b/src/providers/openai-provider.ts
@@ -918,6 +918,19 @@ export class OpenAIProvider implements AIProvider {
 
       const finishError = (error: Error) => {
         if (settled) return;
+        if (
+          !streamedVisibleText
+          && !outputItems.some(Boolean)
+          && this.shouldRetryWithoutExplicitCaching(error, body)
+        ) {
+          settled = true;
+          options?.signal?.removeEventListener('abort', onAbort);
+          this.responsesExplicitCacheSupported = false;
+          Logger.warning('Responses stream rejected explicit prompt caching; retrying once in compatibility mode.');
+          stream.destroy();
+          void this.chatStreamResponses(messages, tools, callbacks, options).then(resolve, reject);
+          return;
+        }
         settled = true;
         callbacks?.onError?.(error);
         reject(error);
@@ -1019,12 +1032,14 @@ export class OpenAIProvider implements AIProvider {
   private shouldRetryWithoutExplicitCaching(error: unknown, body: any): boolean {
     if (!body?.prompt_cache_options) return false;
     const status = Number((error as any)?.response?.status ?? (error as any)?.status);
-    if (status !== 400) return false;
     const data = (error as any)?.response?.data;
     const detail = `${(error as any)?.message || ''} ${typeof data === 'string' ? data : JSON.stringify(data || {})}`.toLowerCase();
-    return detail.includes('prompt_cache_breakpoint')
-      || detail.includes('prompt_cache_options')
-      || (detail.includes('prompt cache') && /unsupported|unknown|invalid|extra/.test(detail));
+    if (detail.includes('prompt_cache_breakpoint') || detail.includes('prompt_cache_options')) {
+      return /unsupported|not supported|unknown|invalid|extra|unrecognized/.test(detail);
+    }
+    return (status === 400 || status === 422)
+      && detail.includes('prompt cache')
+      && /unsupported|not supported|unknown|invalid|extra|unrecognized/.test(detail);
   }
 }
 

--- a/src/providers/openai-provider.ts
+++ b/src/providers/openai-provider.ts
@@ -498,13 +498,12 @@ export class OpenAIProvider implements AIProvider {
       recordBreakpoint('A');
     }
 
-    const firstBreakpointGroup = Math.max(0, completedCurrentGroups.length - 2);
-    for (const [groupIndex, group] of completedCurrentGroups.entries()) {
+    for (const group of completedCurrentGroups) {
       input.push(...this.convertResponsesMessages(group));
-      if (explicitCaching && groupIndex >= firstBreakpointGroup) {
-        input.push(this.buildBreakpointCarrier());
-        recordBreakpoint('B');
-      }
+    }
+    if (explicitCaching && completedCurrentGroups.length > 0) {
+      input.push(this.buildBreakpointCarrier());
+      recordBreakpoint('B');
     }
 
     input.push(...this.convertResponsesMessages(transientMessages));

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -27,6 +27,14 @@ export interface StreamRetryInfo {
 
 export interface AIRequestOptions {
   signal?: AbortSignal;
+  promptCacheContext?: PromptCacheContext;
+}
+
+export interface PromptCacheContext {
+  sessionKey: string;
+  currentEpisodeId?: string;
+  phase: 'normal' | 'pre_turn' | 'mid_turn' | 'restore';
+  explicitCaching: boolean;
 }
 
 /**

--- a/tests/checkpoint-compaction-256k-scenario.test.ts
+++ b/tests/checkpoint-compaction-256k-scenario.test.ts
@@ -86,7 +86,7 @@ test('256K pre-turn scenario compacts old completed history and restores large h
   const afterTokens = estimateMessagesTokens(result.messages) + TOOL_SCHEMA_TOKENS;
 
   assert.equal(result.compacted, true);
-  assert.ok(afterTokens < promptBudgetTokens * 0.2);
+  assert.ok(afterTokens < promptBudgetTokens * 0.25);
   assert.ok(result.messages.some(message =>
     String(message.content).includes('Most recent user correction.')));
   assert.equal(result.messages.some(message =>
@@ -138,14 +138,12 @@ test('256K mid-turn scenario waits for tool completion and keeps the active requ
   const afterTokens = estimateMessagesTokens(result.messages) + TOOL_SCHEMA_TOKENS;
 
   assert.equal(result.compacted, true);
-  assert.ok(afterTokens < promptBudgetTokens * 0.2);
+  assert.ok(afterTokens < promptBudgetTokens * 0.25);
   assert.ok(result.messages.some(message =>
     String(message.content).includes('Active long-task objective.')));
-  assert.equal(result.messages.some(message => message.role === 'tool'), false);
+  assert.equal(result.messages.some(message => message.role === 'tool'), true);
   const summaryInputTool = requests[0].find(message => message.role === 'tool');
-  assert.ok(summaryInputTool);
-  assert.match(String(summaryInputTool.content), /\[checkpoint_tool_evidence\]/);
-  assert.match(String(summaryInputTool.content), /call-complete/);
+  assert.equal(summaryInputTool, undefined);
 });
 
 test('256K restore scenario creates a checkpoint that requires runtime re-verification', async () => {

--- a/tests/checkpoint-compaction.test.ts
+++ b/tests/checkpoint-compaction.test.ts
@@ -2,7 +2,6 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import type { Message } from '../src/types';
 import {
-  CHECKPOINT_COMPACTION_BOUNDARY_PREFIX,
   CHECKPOINT_SUMMARY_PREFIX,
   CheckpointCompactionCoordinator,
   buildCheckpointCompactionPrompt,
@@ -43,7 +42,6 @@ test('checkpoint compaction switch defaults on and supports explicit rollback', 
     XIAOBA_CHECKPOINT_COMPACTION_ENABLED: 'false',
   } as NodeJS.ProcessEnv), false);
 });
-
 test('checkpoint compaction preserves stable system and transient runtime messages', async () => {
   const { service } = createService(() => [
     'Objective: finish the active task.',
@@ -94,20 +92,15 @@ test('checkpoint compaction preserves stable system and transient runtime messag
 
   assert.equal(result.compacted, true);
   assert.equal(result.messages[0].content, 'stable system prompt');
-  assert.ok(result.messages.some(message =>
-    String(message.content).startsWith(CHECKPOINT_COMPACTION_BOUNDARY_PREFIX)));
+  assert.equal(result.messages.some(message => message.__checkpointBoundary), false);
   assert.ok(result.messages.some(message =>
     String(message.content).startsWith(CHECKPOINT_SUMMARY_PREFIX)));
   assert.ok(result.messages.some(message => message.content === transient.content));
-  assert.equal(result.messages.some(message => message.role === 'tool'), false);
-  assert.equal(
-    result.messages.some(message => String(message.content).includes('tool evidence')),
-    false,
-  );
+  assert.equal(result.messages.some(message => message.role === 'tool'), true);
+  assert.equal(result.messages.some(message => String(message.content).includes('tool evidence')), true);
   const summaryIndex = result.messages.findIndex(message => message.__checkpointSummary);
-  const retainedUserIndex = result.messages.findIndex(message =>
-    message.role === 'user' && String(message.content).includes('original objective'));
-  assert.ok(summaryIndex >= 0 && retainedUserIndex > summaryIndex);
+  assert.ok(summaryIndex >= 0);
+  assert.match(String(result.messages[summaryIndex].content), /finish the active task/i);
 });
 
 test('a later checkpoint summarizes the prior checkpoint instead of forgetting it', async () => {
@@ -207,7 +200,7 @@ test('checkpoint prompt distinguishes pre-turn, mid-turn, and restored history',
 });
 
 test('mid-turn checkpoint always retains the root before repeated short follow-ups', async () => {
-  const { service } = createService(() => 'continue from the root and latest corrections');
+  const { service, requests } = createService(() => 'continue from the root and latest corrections');
   const coordinator = new CheckpointCompactionCoordinator(service, {
     maxContextTokens: 1_000,
     compactionThreshold: 0.5,
@@ -256,17 +249,21 @@ test('mid-turn checkpoint always retains the root before repeated short follow-u
   const retainedInputs = result.messages.filter(message => (
     message.role === 'user' && !message.__checkpointSummary
   ));
-  assert.equal(retainedInputs[0]?.content, root.content);
+  assert.ok(requests[0].some(message => message.content === root.content));
+  assert.ok(result.messages.some(message => message.__checkpointSummary));
   assert.ok(retainedInputs.some(message => (
     String(message.content).includes('LATEST_CORRECTION')
   )));
   assert.equal(retainedInputs.filter(message => message.__episodeInputKind === 'pending').length, 7);
-  assert.equal(result.messages.some(message => message.role === 'tool'), false);
-  assert.equal(result.messages.some(message => message.tool_calls?.length), false);
+  assert.equal(result.messages.some(message => message.role === 'tool'), true);
+  assert.equal(result.messages.some(message => message.tool_calls?.length), true);
 });
 
-test('oversized episode root becomes explicit bounded evidence instead of disappearing', async () => {
-  const { service } = createService(() => 'summary includes the complete oversized objective');
+test('oversized episode root is summarized instead of silently disappearing', async () => {
+  const { service, requests } = createService(() => [
+    'Objective: inspect D:\\work\\project at port 18088.',
+    'Constraint: never delete the source directory.',
+  ].join('\n'));
   const coordinator = new CheckpointCompactionCoordinator(service, {
     maxContextTokens: 2_000,
     compactionThreshold: 0.5,
@@ -291,18 +288,14 @@ test('oversized episode root becomes explicit bounded evidence instead of disapp
   });
 
   assert.equal(result.compacted, true);
-  const retainedRoot = result.messages.find(message => (
-    message.__episodeInputKind === 'root' && !message.__checkpointSummary
-  ));
-  assert.ok(retainedRoot);
-  assert.match(String(retainedRoot.content), /\[checkpoint_user_input_evidence\]/);
-  assert.match(String(retainedRoot.content), /sha256: [a-f0-9]{64}/);
-  assert.match(String(retainedRoot.content), /ROOT_HEAD/);
-  assert.match(String(retainedRoot.content), /ROOT_TAIL/);
-  assert.ok(estimateRetainedTextLength(retainedRoot) < oversizedRoot.length);
+  assert.ok(requests[0].some(message => String(message.content).includes('ROOT_HEAD')));
+  const checkpoint = result.messages.find(message => message.__checkpointSummary);
+  assert.match(String(checkpoint?.content), /D:\\work\\project/);
+  assert.match(String(checkpoint?.content), /never delete/);
+  assert.equal(result.messages.some(message => message.__checkpointBoundary), false);
 });
 
-test('checkpoint summary bounds a giant tool result without mutating durable evidence', async () => {
+test('checkpoint exact tail bounds a giant tool result without duplicating it into the summary', async () => {
   const { service, requests } = createService(() => 'bounded tool evidence summary');
   const coordinator = new CheckpointCompactionCoordinator(service, {
     maxContextTokens: 1_000,
@@ -331,19 +324,14 @@ test('checkpoint summary bounds a giant tool result without mutating durable evi
   });
 
   assert.equal(result.compacted, true);
-  const summaryToolMessage = requests[0].find(message => message.role === 'tool');
-  assert.ok(summaryToolMessage);
-  assert.match(String(summaryToolMessage.content), /\[checkpoint_tool_evidence\]/);
-  assert.match(String(summaryToolMessage.content), /tool_call_id: call-giant/);
-  assert.match(String(summaryToolMessage.content), /HEAD_MARKER/);
-  assert.match(String(summaryToolMessage.content), /TAIL_MARKER/);
-  assert.ok(String(summaryToolMessage.content).length < rawToolResult.length);
+  assert.equal(requests[0].some(message => message.role === 'tool'), false);
+  const retainedToolMessage = result.messages.find(message => message.role === 'tool');
+  assert.ok(retainedToolMessage);
+  assert.match(String(retainedToolMessage.content), /\[checkpoint_tool_evidence\]/);
+  assert.match(String(retainedToolMessage.content), /tool_call_id: call-giant/);
+  assert.match(String(retainedToolMessage.content), /HEAD_MARKER/);
+  assert.match(String(retainedToolMessage.content), /TAIL_MARKER/);
+  assert.ok(String(retainedToolMessage.content).length < rawToolResult.length);
   assert.equal(toolMessage.content, rawToolResult);
   assert.equal(messages[1].content, rawToolResult);
 });
-
-function estimateRetainedTextLength(message: Message): number {
-  return typeof message.content === 'string'
-    ? message.content.length
-    : JSON.stringify(message.content).length;
-}

--- a/tests/openai-provider-explicit-cache.test.ts
+++ b/tests/openai-provider-explicit-cache.test.ts
@@ -1,0 +1,194 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import axios from 'axios';
+import { OpenAIProvider } from '../src/providers/openai-provider';
+import type { Message } from '../src/types';
+import { Logger } from '../src/utils/logger';
+
+function provider(): OpenAIProvider {
+  return new OpenAIProvider({
+    apiKey: 'test-key',
+    apiUrl: 'https://relay.example/v1',
+    model: 'gpt-5.6-sol',
+    openaiApiMode: 'responses',
+  });
+}
+
+const context = {
+  promptCacheContext: {
+    sessionKey: 'session-alpha',
+    currentEpisodeId: 'episode-2',
+    phase: 'normal' as const,
+    explicitCaching: true,
+  },
+};
+
+function countBreakpoints(value: unknown): number {
+  if (!value || typeof value !== 'object') return 0;
+  if (Array.isArray(value)) return value.reduce((sum, item) => sum + countBreakpoints(item), 0);
+  const record = value as Record<string, unknown>;
+  return (record.prompt_cache_breakpoint ? 1 : 0)
+    + Object.values(record).reduce((sum, item) => sum + countBreakpoints(item), 0);
+}
+
+test('Responses explicit cache emits S, A, and advancing B boundaries without persisting markers', () => {
+  const messages: Message[] = [
+    { role: 'system', content: 'stable system' },
+    { role: 'system', content: '[transient_skills_list]\n- lookup', __cacheScope: 'stable' },
+    { role: 'user', content: 'old task', __episodeId: 'episode-1' },
+    { role: 'assistant', content: 'old answer', __episodeId: 'episode-1' },
+    { role: 'user', content: 'root task', __episodeId: 'episode-2', __episodeInputKind: 'root' },
+    {
+      role: 'assistant', content: null, __episodeId: 'episode-2',
+      tool_calls: [{ id: 'call-1', type: 'function', function: { name: 'lookup', arguments: '{}' } }],
+    },
+    { role: 'tool', content: 'first result', tool_call_id: 'call-1', __episodeId: 'episode-2' },
+    {
+      role: 'assistant', content: null, __episodeId: 'episode-2',
+      tool_calls: [{ id: 'call-2', type: 'function', function: { name: 'lookup', arguments: '{}' } }],
+    },
+    { role: 'tool', content: 'second result', tool_call_id: 'call-2', __episodeId: 'episode-2' },
+    { role: 'system', content: '[transient_plan_status]\nstep two', __cacheScope: 'dynamic' },
+  ];
+
+  const body = (provider() as any).buildResponsesRequestBody(messages, [], false, context);
+  assert.deepEqual(body.prompt_cache_options, { mode: 'explicit' });
+  assert.match(body.instructions, /stable system/);
+  assert.match(body.instructions, /transient_skills_list/);
+  assert.doesNotMatch(body.instructions, /transient_plan_status/);
+  assert.equal(countBreakpoints(body.input), 4);
+  assert.equal(body.input[0].role, 'system');
+  assert.equal(body.input.at(-3).role, 'system');
+  assert.match(String(body.input.at(-3).content), /transient_plan_status/);
+  assert.equal(body.input.at(-2).type, 'function_call');
+  assert.equal(body.input.at(-1).type, 'function_call_output');
+  assert.equal(messages.some(message => (message as any).prompt_cache_breakpoint), false);
+});
+
+test('Responses cache key is isolated by session without exposing the session id', () => {
+  const messages: Message[] = [{ role: 'system', content: 'stable' }, { role: 'user', content: 'hello' }];
+  const first = (provider() as any).buildResponsesRequestBody(messages, [], false, context);
+  const second = (provider() as any).buildResponsesRequestBody(messages, [], false, {
+    promptCacheContext: { ...context.promptCacheContext, sessionKey: 'session-beta' },
+  });
+  assert.notEqual(first.prompt_cache_key, second.prompt_cache_key);
+  assert.doesNotMatch(first.prompt_cache_key, /session-alpha/);
+});
+
+test('Responses breakpoints never rewrite parallel function calls or outputs', () => {
+  const messages: Message[] = [
+    { role: 'system', content: 'stable system' },
+    { role: 'user', content: 'root task', __episodeId: 'episode-2', __episodeInputKind: 'root' },
+    {
+      role: 'assistant', content: null, __episodeId: 'episode-2',
+      tool_calls: [
+        { id: 'call-a', type: 'function', function: { name: 'lookup', arguments: '{"id":"a"}' } },
+        { id: 'call-b', type: 'function', function: { name: 'lookup', arguments: '{"id":"b"}' } },
+      ],
+    },
+    { role: 'tool', content: 'result-a', tool_call_id: 'call-a', __episodeId: 'episode-2' },
+    { role: 'tool', content: 'result-b', tool_call_id: 'call-b', __episodeId: 'episode-2' },
+    { role: 'assistant', content: 'finished', __episodeId: 'episode-2' },
+  ];
+
+  const body = (provider() as any).buildResponsesRequestBody(messages, [], false, context);
+  const callA = body.input.findIndex((item: any) => item.type === 'function_call' && item.call_id === 'call-a');
+  const callB = body.input.findIndex((item: any) => item.type === 'function_call' && item.call_id === 'call-b');
+  const outputA = body.input.findIndex((item: any) => item.type === 'function_call_output' && item.call_id === 'call-a');
+  const outputB = body.input.findIndex((item: any) => item.type === 'function_call_output' && item.call_id === 'call-b');
+  const boundaryAfterTools = body.input.findIndex((item: any, index: number) => (
+    index > outputB && countBreakpoints(item) > 0
+  ));
+
+  assert.ok(callA < callB && callB < outputA && outputA < outputB);
+  assert.ok(outputB < boundaryAfterTools);
+  assert.equal(body.input[outputA].output, 'result-a');
+  assert.equal(body.input[outputB].output, 'result-b');
+  assert.equal(JSON.stringify(messages).includes('prompt_cache_breakpoint'), false);
+});
+
+test('Responses explicit cache is not sent to older models', () => {
+  const oldProvider = new OpenAIProvider({
+    apiKey: 'test-key',
+    apiUrl: 'https://relay.example/v1',
+    model: 'gpt-5.5-sol',
+    openaiApiMode: 'responses',
+  });
+  const body = (oldProvider as any).buildResponsesRequestBody(
+    [{ role: 'user', content: 'hello', __episodeId: 'episode-2' }],
+    [],
+    false,
+    context,
+  );
+  assert.equal(body.prompt_cache_options, undefined);
+  assert.equal(countBreakpoints(body.input), 0);
+});
+
+test('legacy checkpoint boundary is filtered but ordinary discussion is preserved', () => {
+  const messages: Message[] = [
+    { role: 'system', content: '[checkpoint_compaction_boundary]\nphase=mid_turn' },
+    { role: 'user', content: 'Please explain checkpoint_compaction_boundary behavior.', __episodeId: 'episode-2' },
+  ];
+  const body = (provider() as any).buildResponsesRequestBody(messages, [], false, context);
+  const serialized = JSON.stringify(body.input);
+  assert.doesNotMatch(serialized, /phase=mid_turn/);
+  assert.match(serialized, /Please explain checkpoint_compaction_boundary behavior/);
+});
+
+test('unsupported explicit fields retry once and pin the provider to compatibility mode', async () => {
+  const originalPost = axios.post;
+  const bodies: any[] = [];
+  (axios as any).post = async (_url: string, body: any) => {
+    bodies.push(body);
+    if (bodies.length === 1) {
+      throw Object.assign(new Error('unknown field prompt_cache_options'), {
+        response: { status: 400, data: { error: { message: 'prompt_cache_breakpoint is unsupported' } } },
+      });
+    }
+    return { data: { status: 'completed', output: [] } };
+  };
+  try {
+    const instance = provider();
+    await instance.chat([{ role: 'user', content: 'hello', __episodeId: 'episode-2' }], [], context);
+    assert.equal(bodies.length, 2);
+    assert.deepEqual(bodies[0].prompt_cache_options, { mode: 'explicit' });
+    assert.equal(bodies[1].prompt_cache_options, undefined);
+    assert.equal(countBreakpoints(bodies[1].input), 0);
+  } finally {
+    (axios as any).post = originalPost;
+  }
+});
+
+test('Responses cache usage is recorded without prompt content', async () => {
+  const originalPost = axios.post;
+  const originalRuntimeEvent = Logger.runtimeEvent;
+  const events: any[] = [];
+  (axios as any).post = async () => ({
+    data: {
+      status: 'completed',
+      output: [],
+      usage: {
+        input_tokens: 1200,
+        output_tokens: 20,
+        input_tokens_details: { cached_tokens: 900, cache_write_tokens: 200 },
+      },
+    },
+  });
+  (Logger as any).runtimeEvent = (_level: string, _message: string, event: any) => events.push(event);
+  try {
+    await provider().chat([{ role: 'user', content: 'hello', __episodeId: 'episode-2' }], [], context);
+    const usage = events.find(event => event.type === 'responses_cache_usage');
+    assert.ok(usage);
+    assert.deepEqual(usage.payload, {
+      mode: 'explicit',
+      cache_key_hash: usage.payload.cache_key_hash,
+      input_tokens: 1200,
+      cached_tokens: 900,
+      cache_write_tokens: 200,
+    });
+    assert.equal(JSON.stringify(usage).includes('hello'), false);
+  } finally {
+    (axios as any).post = originalPost;
+    (Logger as any).runtimeEvent = originalRuntimeEvent;
+  }
+});

--- a/tests/openai-provider-explicit-cache.test.ts
+++ b/tests/openai-provider-explicit-cache.test.ts
@@ -32,7 +32,7 @@ function countBreakpoints(value: unknown): number {
     + Object.values(record).reduce((sum, item) => sum + countBreakpoints(item), 0);
 }
 
-test('Responses explicit cache emits S, A, and advancing B boundaries without persisting markers', () => {
+test('Responses explicit cache emits one S, A, and latest B without persisting markers', () => {
   const messages: Message[] = [
     { role: 'system', content: 'stable system' },
     { role: 'system', content: '[transient_skills_list]\n- lookup', __cacheScope: 'stable' },
@@ -57,7 +57,7 @@ test('Responses explicit cache emits S, A, and advancing B boundaries without pe
   assert.match(body.instructions, /stable system/);
   assert.match(body.instructions, /transient_skills_list/);
   assert.doesNotMatch(body.instructions, /transient_plan_status/);
-  assert.equal(countBreakpoints(body.input), 4);
+  assert.equal(countBreakpoints(body.input), 3);
   assert.equal(body.input[0].role, 'system');
   assert.equal(body.input.at(-3).role, 'system');
   assert.match(String(body.input.at(-3).content), /transient_plan_status/);
@@ -146,6 +146,28 @@ test('Responses breakpoints never rewrite parallel function calls or outputs', (
   assert.equal(body.input[outputA].output, 'result-a');
   assert.equal(body.input[outputB].output, 'result-b');
   assert.equal(JSON.stringify(messages).includes('prompt_cache_breakpoint'), false);
+});
+
+test('Responses emits only the latest completed-turn breakpoint', () => {
+  const messages: Message[] = [
+    { role: 'system', content: 'stable system' },
+    { role: 'user', content: 'root task', __episodeId: 'episode-2', __episodeInputKind: 'root' },
+    { role: 'assistant', content: 'first turn', __episodeId: 'episode-2' },
+    { role: 'user', content: 'continue', __episodeId: 'episode-2' },
+    { role: 'assistant', content: 'second turn', __episodeId: 'episode-2' },
+    { role: 'user', content: 'latest event', __episodeId: 'episode-2' },
+  ];
+
+  const body = (provider() as any).buildResponsesRequestBody(messages, [], false, context);
+  const breakpointIndexes = body.input
+    .map((item: any, index: number) => countBreakpoints(item) > 0 ? index : -1)
+    .filter((index: number) => index >= 0);
+  const secondTurnIndex = body.input.findIndex((item: any) => item.content === 'second turn');
+  const latestEventIndex = body.input.findIndex((item: any) => item.content === 'latest event');
+
+  assert.equal(breakpointIndexes.length, 2);
+  assert.ok(secondTurnIndex < breakpointIndexes[1]);
+  assert.ok(breakpointIndexes[1] < latestEventIndex);
 });
 
 test('Responses explicit cache is not sent to older models', () => {

--- a/tests/openai-provider-explicit-cache.test.ts
+++ b/tests/openai-provider-explicit-cache.test.ts
@@ -250,6 +250,45 @@ test('streamed unsupported explicit fields retry once in compatibility mode', as
   }
 });
 
+test('strict explicit cache mode surfaces streamed rejection without fallback', async () => {
+  const originalPost = axios.post;
+  const originalStrict = process.env.XIAOBA_RESPONSES_EXPLICIT_CACHE_STRICT;
+  const bodies: any[] = [];
+  process.env.XIAOBA_RESPONSES_EXPLICIT_CACHE_STRICT = '1';
+  (axios as any).post = async (_url: string, body: any) => {
+    bodies.push(body);
+    return {
+      data: Readable.from([
+        `data: ${JSON.stringify({
+          type: 'response.failed',
+          response: {
+            status: 'failed',
+            error: { message: 'prompt_cache_breakpoint is not supported on this model' },
+          },
+        })}\n\n`,
+      ]),
+    };
+  };
+  try {
+    const instance = provider();
+    await assert.rejects(
+      instance.chatStream(
+        [{ role: 'user', content: 'hello', __episodeId: 'episode-2' }],
+        [],
+        undefined,
+        context,
+      ),
+      /prompt_cache_breakpoint is not supported/i,
+    );
+    assert.equal(bodies.length, 1);
+    assert.deepEqual(bodies[0].prompt_cache_options, { mode: 'explicit' });
+  } finally {
+    if (originalStrict === undefined) delete process.env.XIAOBA_RESPONSES_EXPLICIT_CACHE_STRICT;
+    else process.env.XIAOBA_RESPONSES_EXPLICIT_CACHE_STRICT = originalStrict;
+    (axios as any).post = originalPost;
+  }
+});
+
 test('Responses cache usage is recorded without prompt content', async () => {
   const originalPost = axios.post;
   const originalRuntimeEvent = Logger.runtimeEvent;

--- a/tests/openai-provider-explicit-cache.test.ts
+++ b/tests/openai-provider-explicit-cache.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { Readable } from 'node:stream';
 import test from 'node:test';
 import axios from 'axios';
 import { OpenAIProvider } from '../src/providers/openai-provider';
@@ -194,6 +195,56 @@ test('unsupported explicit fields retry once and pin the provider to compatibili
     assert.deepEqual(bodies[0].prompt_cache_options, { mode: 'explicit' });
     assert.equal(bodies[1].prompt_cache_options, undefined);
     assert.equal(countBreakpoints(bodies[1].input), 0);
+  } finally {
+    (axios as any).post = originalPost;
+  }
+});
+
+test('streamed unsupported explicit fields retry once in compatibility mode', async () => {
+  const originalPost = axios.post;
+  const bodies: any[] = [];
+  const callbackErrors: Error[] = [];
+  (axios as any).post = async (_url: string, body: any) => {
+    bodies.push(body);
+    if (bodies.length === 1) {
+      return {
+        data: Readable.from([
+          `data: ${JSON.stringify({
+            type: 'response.failed',
+            response: {
+              status: 'failed',
+              error: { message: 'prompt_cache_breakpoint is not supported on this model' },
+            },
+          })}\n\n`,
+        ]),
+      };
+    }
+    return {
+      data: Readable.from([
+        `data: ${JSON.stringify({
+          type: 'response.completed',
+          response: {
+            status: 'completed',
+            output: [{ type: 'message', content: [{ type: 'output_text', text: 'OK' }] }],
+          },
+        })}\n\n`,
+      ]),
+    };
+  };
+  try {
+    const instance = provider();
+    const result = await instance.chatStream(
+      [{ role: 'user', content: 'hello', __episodeId: 'episode-2' }],
+      [],
+      { onError: error => callbackErrors.push(error) },
+      context,
+    );
+    assert.equal(result.content, 'OK');
+    assert.equal(bodies.length, 2);
+    assert.deepEqual(bodies[0].prompt_cache_options, { mode: 'explicit' });
+    assert.equal(bodies[1].prompt_cache_options, undefined);
+    assert.equal(countBreakpoints(bodies[1].input), 0);
+    assert.deepEqual(callbackErrors, []);
   } finally {
     (axios as any).post = originalPost;
   }

--- a/tests/openai-provider-explicit-cache.test.ts
+++ b/tests/openai-provider-explicit-cache.test.ts
@@ -65,6 +65,46 @@ test('Responses explicit cache emits S, A, and advancing B boundaries without pe
   assert.equal(messages.some(message => (message as any).prompt_cache_breakpoint), false);
 });
 
+test('Responses keeps a continuation checkpoint before its retained historical evidence', () => {
+  const messages: Message[] = [
+    { role: 'system', content: 'stable system' },
+    {
+      role: 'user',
+      content: 'CONTINUATION_CHECKPOINT',
+      __checkpointSummary: true,
+      __episodeId: 'episode-2',
+    },
+    { role: 'user', content: 'retained old evidence', __episodeId: 'episode-1' },
+    { role: 'assistant', content: 'retained old answer', __episodeId: 'episode-1' },
+    { role: 'user', content: 'current root task', __episodeId: 'episode-2', __episodeInputKind: 'root' },
+    {
+      role: 'assistant', content: null, __episodeId: 'episode-2',
+      tool_calls: [{ id: 'call-current', type: 'function', function: { name: 'lookup', arguments: '{}' } }],
+    },
+    { role: 'tool', content: 'latest result', tool_call_id: 'call-current', __episodeId: 'episode-2' },
+    { role: 'system', content: '[transient_plan_status]\ncurrent step', __cacheScope: 'dynamic' },
+  ];
+
+  const body = (provider() as any).buildResponsesRequestBody(messages, [], false, context);
+  const checkpointIndex = body.input.findIndex((item: any) => item.content === 'CONTINUATION_CHECKPOINT');
+  const oldEvidenceIndex = body.input.findIndex((item: any) => item.content === 'retained old evidence');
+  const rootIndex = body.input.findIndex((item: any) => item.content === 'current root task');
+  const planIndex = body.input.findIndex((item: any) => String(item.content).includes('transient_plan_status'));
+  const callIndex = body.input.findIndex((item: any) => item.type === 'function_call' && item.call_id === 'call-current');
+  const breakpointIndexes = body.input
+    .map((item: any, index: number) => countBreakpoints(item) > 0 ? index : -1)
+    .filter((index: number) => index >= 0);
+
+  assert.equal(breakpointIndexes.length, 3);
+  assert.ok(breakpointIndexes[0] < checkpointIndex);
+  assert.ok(checkpointIndex < oldEvidenceIndex);
+  assert.ok(oldEvidenceIndex < breakpointIndexes[1]);
+  assert.ok(breakpointIndexes[1] < rootIndex);
+  assert.ok(rootIndex < breakpointIndexes[2]);
+  assert.ok(breakpointIndexes[2] < planIndex);
+  assert.ok(planIndex < callIndex);
+});
+
 test('Responses cache key is isolated by session without exposing the session id', () => {
   const messages: Message[] = [{ role: 'system', content: 'stable' }, { role: 'user', content: 'hello' }];
   const first = (provider() as any).buildResponsesRequestBody(messages, [], false, context);

--- a/tests/openai-provider-responses.test.ts
+++ b/tests/openai-provider-responses.test.ts
@@ -52,7 +52,7 @@ describe('OpenAIProvider Responses API mode', () => {
     assert.deepEqual(first.include, ['reasoning.encrypted_content']);
   });
 
-  test('keeps dynamic system context out of cache identity and appends it to input', () => {
+  test('keeps dynamic system context out of cache identity and places it before the latest event', () => {
     const provider = createProvider();
     const first = (provider as any).buildResponsesRequestBody([
       { role: 'system', content: 'Stable policy.' },
@@ -69,12 +69,12 @@ describe('OpenAIProvider Responses API mode', () => {
     assert.equal(second.instructions, 'Stable policy.');
     assert.equal(first.prompt_cache_key, second.prompt_cache_key);
     assert.deepEqual(first.input, [
-      { role: 'user', content: 'first question' },
       { role: 'system', content: '[transient_plan_status]\nstep one' },
+      { role: 'user', content: 'first question' },
     ]);
     assert.deepEqual(second.input, [
-      { role: 'user', content: 'another question' },
       { role: 'system', content: '[transient_plan_status]\nstep two' },
+      { role: 'user', content: 'another question' },
     ]);
   });
 
@@ -100,8 +100,8 @@ describe('OpenAIProvider Responses API mode', () => {
       ], [lookupTool]);
 
       assert.equal(first.prompt_cache_key, second.prompt_cache_key);
-      assert.equal(first.input.at(-1).role, 'system');
-      assert.equal(first.input.at(-1).content, firstDynamic);
+      assert.equal(first.input[0].role, 'system');
+      assert.equal(first.input[0].content, firstDynamic);
     }
 
     const changedStable = (provider as any).buildResponsesRequestBody([


### PR DESCRIPTION
## What changed

- Add request-only OpenAI Responses cache boundaries for the stable core, completed episodes, and completed turns.
- Isolate cache keys by session while keeping raw session and bot identifiers out of the key.
- Move stable runtime-observation rules and the normalized Skill catalog into `instructions`; keep turn-specific runtime state immediately before the latest real event.
- Retry once without explicit cache fields when an OpenAI-compatible relay explicitly rejects them.
- Replace semantic checkpoint-boundary messages with structured diagnostics only.
- Keep a deterministic exact tail of complete recent message/tool exchanges and summarize only older history.
- Keep tool call/result pairs intact, including parallel calls and bounded evidence for oversized outputs.
- Leave legacy tool-result folding disabled on the checkpoint path.

## Why

Long tool-heavy episodes previously relied on history rewriting and semantic boundary markers. That reduced continuation quality and repeatedly changed cacheable prefixes. This PR makes checkpoint compaction the primary continuation mechanism and adds explicit, request-only cache boundaries without changing the persisted Session format.

## Compatibility

- Explicit caching is enabled only for GPT-5.6-or-newer Responses model names.
- Relays that reject the explicit fields fall back once and remain in compatibility mode for that provider instance.
- Legacy checkpoint boundary messages are ignored during request assembly but existing Session files are not rewritten.
- The old compaction/folding implementation remains available as a short-term rollback path.

## Verification

- `npm test`: 1298 tests, 1293 passed, 5 skipped, 0 failed
- `npm run build`
- Focused Responses and checkpoint-compaction regression suite
- `git diff --check`

Reference: https://developers.openai.com/api/docs/guides/prompt-caching