### PR TITLE
Stage 4: stabilize synthetic observation wire identity

### DIFF
--- a/docs/evidence/cache-stage4-synthetic-observation-wire-identity-2026-08-02.md
+++ b/docs/evidence/cache-stage4-synthetic-observation-wire-identity-2026-08-02.md
@@ -1,0 +1,85 @@
+# Stage 4 synthetic-observation wire identity calibration — 2026-08-02
+
+This is a redacted calibration record, not cache acceptance evidence. It contains no credentials,
+provider endpoints, prompt bodies, response bodies, or memory-record contents. The authoritative
+raw evidence remains in private repository-external benchmark directories.
+
+## Scope closed in this stage
+
+- Synthetic observations keep their unique internal observation and branch provenance for audit,
+  attestation, and correlation, but those random lifecycle identifiers no longer enter the
+  provider-visible tool-call ID.
+- The provider-visible ID is derived from the complete model-visible synthetic pair: canonical tool
+  arguments plus tool output. Equivalent visible observations therefore serialize identically
+  across different internal branch IDs, while visible content changes produce a different ID.
+- A stable request-local ordinal preserves unique assistant/tool pairing when equivalent
+  observations arrive in separate tool-loop drains. Existing tool-call and tool-result IDs in the
+  growing request are both considered, so request preflight cannot discard a later pair as a
+  duplicate.
+- The same identity rule is covered through OpenAI Responses and Chat serialization. DeepSeek v4
+  continues to lower the valid synthetic pair to its supported Chat envelope without exposing
+  internal provenance.
+
+## Rejected prefix-placement experiments
+
+Two broader placement experiments were tested and then fully reverted before the final candidate.
+They are retained as negative calibration evidence:
+
+| experiment | behavior | NewCLI cache-read / input | raw ratio | capped-task ratio | disposition |
+| --- | --- | ---: | ---: | ---: | --- |
+| absolute epoch prefix | moved typed epoch system context ahead of the durable transcript | 45,056 / 119,990 | 37.55% | 36.64% | reverted |
+| episode-boundary epoch | kept typed epoch context at the core-inserted episode boundary | 39,936 / 104,132 | 38.35% | 37.62% | reverted |
+
+The first arrangement also has a structural defect independent of the noisy live ratio: changing
+an epoch event at the start of the next logical call invalidates the durable transcript prefix. The
+second arrangement preserves more cross-call prefix but cannot preserve the complete prior tool
+history. Neither is the append-only lifecycle required for final acceptance.
+
+## Final-candidate real calibration
+
+Both providers ran the real four-task Goal/Memory workload with one required cold logical call and
+one warm logical call per task. Every physical Memory Branch attempt remains in token-weighted
+scoring. Cache-read values below come only from the provider usage fields bound by the manifest.
+
+| run | artifact | physical attempts | cache-read / input | raw ratio | capped-task ratio | capability / quality / safety | result |
+| --- | --- | ---: | ---: | ---: | ---: | --- | --- |
+| NewCLI v2 | `sha256:5a0c7ea4...` | 34 | 41,984 / 112,719 | 37.25% | 35.98% | passed / passed / passed | ratio failure |
+| DeepSeek v2 | `sha256:5a0c7ea4...` | 38 | 97,920 / 157,930 | 62.00% | 61.15% | passed / failed / passed | diagnostic failure |
+| DeepSeek v3 | `sha256:5a0c7ea4...` | 37 | 98,688 / 152,342 | 64.78% | 63.56% | passed / passed / passed | ratio failure |
+
+NewCLI's final-candidate split was 23,552 / 61,763 (38.13%) for main attempts and
+18,432 / 50,956 (36.17%) for Memory Branch attempts. DeepSeek v3 was 29,568 / 71,245
+(41.50%) for main attempts and 69,120 / 81,097 (85.23%) for Memory Branch attempts.
+
+DeepSeek v2 is intentionally retained as a failed sample. In one warm non-memory task, the Memory
+Branch broadened its search, selected the unrelated authorized archive record, and published it;
+the branch quality oracle rejected all seven physical attempts in that logical call. The linked
+main answer still passed, but the scorer correctly failed the whole round. An unchanged-artifact v3
+rerun suppressed irrelevant memory in that task and passed every capability, quality, and safety
+attestation. This failure/rerun pair demonstrates that the gate records model retrieval drift rather
+than hiding it.
+
+The usage sources were `openai.input_tokens_details.cached_tokens` for NewCLI Responses and
+`openai.prompt_tokens_details.cached_tokens` for the DeepSeek-compatible Chat endpoint. The final
+artifact fingerprint was
+`sha256:5a0c7ea4385df2902fa895a04dbce8a035bee2e337a59289921c447792481142`.
+
+## Verification
+
+- Targeted synthetic observation, ConversationRunner, provider serialization, DeepSeek lowering,
+  and preflight coverage: 72 tests passed.
+- `npm run build`: passed.
+- Official `npm test`: 1,489 tests; 1,481 passed; 0 failed; 0 cancelled; 8 skipped.
+- Independent read-only review rechecked digest coverage, cross-drain uniqueness, retry and restore
+  behavior, provider lowering, internal attestation provenance, and the request-preflight boundary.
+  It found no blocker.
+- No dashboard or other UI files changed, so desktop/mobile visual testing was not applicable.
+
+## What this stage does not claim
+
+This stage removes one random provider-visible prefix contaminant; it does not claim a measurable
+single-round ratio improvement or meet the 94% acceptance threshold. The short one-warm-call
+calibration remains dominated by required cold calls, provider cache admission variance, and
+growing Memory Branch tool loops. The next stage must introduce an append-only lifecycle event
+stream for durable memory/runtime/state events and add naturally growing detached and real-project
+workloads before collecting three consecutive acceptance rounds per provider.

--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -897,7 +897,9 @@ export class ConversationRunner {
     }
     if (observations.length === 0) return;
 
-    const syntheticMessages = buildSyntheticObservationMessages(observations);
+    const syntheticMessages = buildSyntheticObservationMessages(observations, {
+      existingMessages: messages,
+    });
     messages.push(...syntheticMessages);
     Logger.info(
       `[${this.sessionLabel}Turn ${turn}] injected ${observations.length} synthetic runtime observation(s): `

--- a/src/core/synthetic-observation.ts
+++ b/src/core/synthetic-observation.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { createHash, randomUUID } from 'crypto';
 import { Message } from '../types';
 import { annotateContextMessage } from './context-lifecycle';
 
@@ -103,11 +103,34 @@ export class InMemorySyntheticObservationQueue implements SyntheticObservationQu
 
 export function buildSyntheticObservationMessages(
   observations: SyntheticObservation[],
+  options: { existingMessages?: readonly Message[] } = {},
 ): Message[] {
   const messages: Message[] = [];
+  const usedToolCallIds = collectToolCallIds(options.existingMessages || []);
   for (const observation of observations) {
     const id = observation.id || stableObservationId(observation);
-    const toolCallId = `synthetic-${observation.source}-${id}`;
+    const toolArguments = JSON.stringify({
+      source: observation.source,
+      status: observation.status,
+      relevance: observation.relevance,
+      timing: resolveObservationTiming(observation),
+      confidence: observation.confidence,
+    });
+    const toolOutput = formatSyntheticObservation(observation);
+    const visiblePayloadDigest = createHash('sha256')
+      .update(toolArguments)
+      .update('\0')
+      .update(toolOutput)
+      .digest('hex')
+      .slice(0, 20);
+    // Provider-visible IDs participate in exact-prefix cache identity. Keep
+    // them deterministic for equivalent visible observations while retaining
+    // the unique internal observation/branch IDs below for audit correlation.
+    const toolCallIdPrefix = `synthetic-${observation.source}-${visiblePayloadDigest}`;
+    let ordinal = 1;
+    while (usedToolCallIds.has(`${toolCallIdPrefix}-${ordinal}`)) ordinal++;
+    const toolCallId = `${toolCallIdPrefix}-${ordinal}`;
+    usedToolCallIds.add(toolCallId);
     const provenance = observationProvenance(observation);
     messages.push(annotateContextMessage({
       role: 'assistant',
@@ -117,13 +140,7 @@ export function buildSyntheticObservationMessages(
         type: 'function',
         function: {
           name: SYNTHETIC_OBSERVATION_TOOL_NAME,
-          arguments: JSON.stringify({
-            source: observation.source,
-            status: observation.status,
-            relevance: observation.relevance,
-            timing: resolveObservationTiming(observation),
-            confidence: observation.confidence,
-          }),
+          arguments: toolArguments,
         },
       }],
       __syntheticObservation: true,
@@ -138,7 +155,7 @@ export function buildSyntheticObservationMessages(
       role: 'tool',
       name: SYNTHETIC_OBSERVATION_TOOL_NAME,
       tool_call_id: toolCallId,
-      content: formatSyntheticObservation(observation),
+      content: toolOutput,
       __syntheticObservation: true,
       syntheticObservationId: id,
       ...(provenance ? { syntheticObservationProvenance: provenance } : {}),
@@ -149,6 +166,19 @@ export function buildSyntheticObservationMessages(
     }));
   }
   return messages;
+}
+
+function collectToolCallIds(messages: readonly Message[]): Set<string> {
+  const ids = new Set<string>();
+  for (const message of messages) {
+    for (const toolCall of message.tool_calls || []) {
+      const id = toolCall.id?.trim();
+      if (id) ids.add(id);
+    }
+    const resultId = message.tool_call_id?.trim();
+    if (resultId) ids.add(resultId);
+  }
+  return ids;
 }
 
 function observationProvenance(

--- a/tests/conversation-runner-synthetic-observation.test.ts
+++ b/tests/conversation-runner-synthetic-observation.test.ts
@@ -4,6 +4,7 @@ import { ConversationRunner } from '../src/core/conversation-runner';
 import { SYNTHETIC_OBSERVATION_TOOL_NAME, SyntheticObservation } from '../src/core/synthetic-observation';
 import { ChatResponse, Message } from '../src/types';
 import { ToolCall, ToolDefinition, ToolExecutor, ToolResult } from '../src/types/tool';
+import { prepareProviderRequestMessages } from '../src/providers/request-preflight';
 
 const usage = { promptTokens: 1, completionTokens: 1, totalTokens: 2 };
 
@@ -22,9 +23,9 @@ function makeToolCall(id: string): ToolCall {
   };
 }
 
-function makeObservation(): SyntheticObservation {
+function makeObservation(id = 'memory-ready'): SyntheticObservation {
   return {
-    id: 'memory-ready',
+    id,
     source: 'memory',
     status: 'completed',
     relevance: 'medium',
@@ -111,5 +112,40 @@ describe('ConversationRunner synthetic observations', () => {
       2,
       'matching synthetic pair is injected exactly once',
     );
+  });
+
+  test('keeps equivalent observations from separate loop drains provider-valid and uniquely paired', async () => {
+    const received: Message[][] = [];
+    const responses: ChatResponse[] = [
+      { content: null, toolCalls: [makeToolCall('call_1')], usage },
+      { content: null, toolCalls: [makeToolCall('call_2')], usage },
+      { content: 'done', toolCalls: [], usage },
+    ];
+    const aiService = {
+      chat: async (messages: Message[]) => {
+        received.push(cloneMessages(messages));
+        return responses[received.length - 1];
+      },
+    } as any;
+    let providerCalls = 0;
+    const runner = new ConversationRunner(aiService, new NoopToolExecutor(), {
+      stream: false,
+      enableCompression: false,
+      syntheticObservationProvider: () => {
+        providerCalls += 1;
+        if (providerCalls === 1) return [makeObservation('internal-one')];
+        if (providerCalls === 2) return [makeObservation('internal-two')];
+        return [];
+      },
+    });
+
+    await runner.run([{ role: 'user', content: 'deploy it' }]);
+
+    const syntheticCalls = received[2]
+      .filter(message => message.__syntheticObservation && message.role === 'assistant')
+      .map(message => message.tool_calls?.[0].id);
+    assert.equal(syntheticCalls.length, 2);
+    assert.notEqual(syntheticCalls[0], syntheticCalls[1]);
+    assert.equal(prepareProviderRequestMessages(received[2]).summary, undefined);
   });
 });

--- a/tests/openai-provider-responses.test.ts
+++ b/tests/openai-provider-responses.test.ts
@@ -4,6 +4,7 @@ import { Readable } from 'node:stream';
 import axios from 'axios';
 import { OpenAIProvider } from '../src/providers/openai-provider';
 import { AIService } from '../src/utils/ai-service';
+import { buildSyntheticObservationMessages } from '../src/core/synthetic-observation';
 import type { Message } from '../src/types';
 import type { ToolDefinition } from '../src/types/tool';
 
@@ -36,6 +37,38 @@ function createCompatibleProvider(): OpenAIProvider {
 }
 
 describe('OpenAIProvider Responses API mode', () => {
+  test('keeps equivalent synthetic observation wire input stable across internal branch ids', () => {
+    const provider = createProvider();
+    const build = (suffix: string) => {
+      const first = buildSyntheticObservationMessages([{
+        id: `observation-one-${suffix}`,
+        source: 'memory',
+        status: 'completed',
+        relevance: 'high',
+        summary: 'Equivalent visible memory result.',
+        metadata: { branchType: 'memory', branchId: `branch-one-${suffix}` },
+      }]);
+      const second = buildSyntheticObservationMessages([{
+        id: `observation-two-${suffix}`,
+        source: 'memory',
+        status: 'completed',
+        relevance: 'high',
+        summary: 'Equivalent visible memory result.',
+        metadata: { branchType: 'memory', branchId: `branch-two-${suffix}` },
+      }], { existingMessages: first });
+      return (provider as any).buildResponsesRequestBody([
+        { role: 'user', content: 'current question' },
+        ...first,
+        ...second,
+      ]).input;
+    };
+
+    const first = build('a');
+    const second = build('b');
+    assert.deepEqual(first, second);
+    assert.notEqual(first[1].call_id, first[3].call_id);
+  });
+
   test('builds Responses input and a stable prompt cache key', () => {
     const provider = createProvider();
     const first = (provider as any).buildResponsesRequestBody([

--- a/tests/openai-provider-runtime-feedback.test.ts
+++ b/tests/openai-provider-runtime-feedback.test.ts
@@ -3,9 +3,46 @@ import * as assert from 'node:assert';
 import { Readable } from 'node:stream';
 import axios from 'axios';
 import { OpenAIProvider } from '../src/providers/openai-provider';
+import { buildSyntheticObservationMessages } from '../src/core/synthetic-observation';
 import { Message } from '../src/types';
 
 describe('OpenAIProvider runtime feedback boundary', () => {
+  test('keeps equivalent Chat observation wire messages stable across internal branch ids', () => {
+    const provider = new OpenAIProvider({
+      apiKey: 'test-key',
+      apiUrl: 'https://api.deepseek.com',
+      model: 'deepseek-test',
+    });
+    const build = (suffix: string) => {
+      const first = buildSyntheticObservationMessages([{
+        id: `observation-one-${suffix}`,
+        source: 'memory',
+        status: 'completed',
+        relevance: 'high',
+        summary: 'Equivalent visible memory result.',
+        metadata: { branchType: 'memory', branchId: `branch-one-${suffix}` },
+      }]);
+      const second = buildSyntheticObservationMessages([{
+        id: `observation-two-${suffix}`,
+        source: 'memory',
+        status: 'completed',
+        relevance: 'high',
+        summary: 'Equivalent visible memory result.',
+        metadata: { branchType: 'memory', branchId: `branch-two-${suffix}` },
+      }], { existingMessages: first });
+      return (provider as any).buildRequestBody([
+        { role: 'user', content: 'current question' },
+        ...first,
+        ...second,
+      ]).messages;
+    };
+
+    const first = build('a');
+    const second = build('b');
+    assert.deepStrictEqual(first, second);
+    assert.notEqual(first[1].tool_calls[0].id, first[3].tool_calls[0].id);
+  });
+
   test('strips internal injected fields before building SDK messages', () => {
     const provider = new OpenAIProvider({
       apiKey: 'test-key',

--- a/tests/synthetic-observation.test.ts
+++ b/tests/synthetic-observation.test.ts
@@ -9,6 +9,7 @@ import {
   SyntheticObservation,
   withSyntheticObservationTiming,
 } from '../src/core/synthetic-observation';
+import { prepareProviderRequestMessages } from '../src/providers/request-preflight';
 import { TurnContextBuilder } from '../src/core/turn-context-builder';
 import { Message } from '../src/types';
 
@@ -53,6 +54,61 @@ describe('synthetic observations', () => {
     assert.match(String(messages[1].content), /Earlier session decided/);
     assert.match(String(messages[1].content), /Decision: keep dashboard filters compact/);
     assert.match(String(messages[1].content), /timing: current_turn/);
+  });
+
+  test('keeps provider-visible pair ids stable across different internal ids and provenance', () => {
+    const first = buildSyntheticObservationMessages([{
+      ...observation('internal-one'),
+      metadata: { branchType: 'memory', branchId: 'branch-one' },
+    }]);
+    const second = buildSyntheticObservationMessages([{
+      ...observation('internal-two'),
+      metadata: { branchType: 'memory', branchId: 'branch-two' },
+    }]);
+
+    assert.equal(first[0].tool_calls?.[0].id, second[0].tool_calls?.[0].id);
+    assert.equal(first[1].tool_call_id, second[1].tool_call_id);
+    assert.equal(first[0].syntheticObservationId, 'internal-one');
+    assert.equal(second[0].syntheticObservationId, 'internal-two');
+    assert.deepEqual(first[0].syntheticObservationProvenance, {
+      branchType: 'memory',
+      branchId: 'branch-one',
+    });
+    assert.deepEqual(second[0].syntheticObservationProvenance, {
+      branchType: 'memory',
+      branchId: 'branch-two',
+    });
+  });
+
+  test('changes provider-visible pair ids when visible content changes', () => {
+    const first = buildSyntheticObservationMessages([observation('internal-one')]);
+    const second = buildSyntheticObservationMessages([{
+      ...observation('internal-two'),
+      summary: 'A different model-visible memory summary.',
+    }]);
+
+    assert.notEqual(first[0].tool_calls?.[0].id, second[0].tool_calls?.[0].id);
+  });
+
+  test('assigns deterministic unique ordinals across separate drains in one growing request', () => {
+    const firstBatch = buildSyntheticObservationMessages([observation('internal-one')]);
+    const secondBatch = buildSyntheticObservationMessages([observation('internal-two')], {
+      existingMessages: firstBatch,
+    });
+    const combined = [...firstBatch, ...secondBatch];
+    const replayFirstBatch = buildSyntheticObservationMessages([observation('different-internal-one')]);
+    const replaySecondBatch = buildSyntheticObservationMessages([observation('different-internal-two')], {
+      existingMessages: replayFirstBatch,
+    });
+    const firstIds = [firstBatch[0].tool_calls?.[0].id, secondBatch[0].tool_calls?.[0].id];
+    const secondIds = [replayFirstBatch[0].tool_calls?.[0].id, replaySecondBatch[0].tool_calls?.[0].id];
+
+    assert.notEqual(firstIds[0], firstIds[1]);
+    assert.deepEqual(firstIds, secondIds);
+    assert.equal(firstBatch[1].tool_call_id, firstIds[0]);
+    assert.equal(secondBatch[1].tool_call_id, firstIds[1]);
+    assert.equal(prepareProviderRequestMessages(combined).summary, undefined);
+    assert.equal(prepareProviderRequestMessages(combined).messages.length, 4);
   });
 
   test('queue drains once, dedupes ids, and discards after cancellation', () => {


### PR DESCRIPTION
## Summary

- separate provider-visible synthetic observation IDs from random internal observation and branch IDs
- derive stable wire IDs from complete model-visible arguments and output
- preserve unique deterministic pairing across separate tool-loop drains
- add Responses, Chat, preflight, runner, and cross-batch regression coverage
- record rejected prefix-placement experiments and redacted provider-truth calibration

## Verification

- npm run build
- npm test: 1,489 tests; 1,481 passed; 0 failed; 0 cancelled; 8 skipped
- targeted provider/lowering/preflight coverage: 72 passed
- independent read-only final review: passed
- NewCLI and DeepSeek real provider calibration retained externally; cache-read counted only from provider usage

## Status

This is a staged calibration PR, not final 94% acceptance. Capability, quality, safety, and provider compatibility pass on the final candidate; the next stage will implement append-only lifecycle events and representative growing workloads.