### PR TITLE
feat(cache): persist verified memory context events

### DIFF
--- a/docs/evidence/cache-stage5-durable-memory-context-events-2026-08-02.md
+++ b/docs/evidence/cache-stage5-durable-memory-context-events-2026-08-02.md
@@ -1,0 +1,83 @@
+# Stage 5 durable Memory context-event calibration — 2026-08-02
+
+This is a redacted calibration record, not cache acceptance evidence. It contains no credentials,
+provider endpoints, prompt bodies, response bodies, or memory-record contents. The authoritative
+raw evidence remains in private repository-external benchmark directories.
+
+## Scope closed in this stage
+
+- A completed, authorized Memory Branch result can become a durable append-only transcript event
+  instead of a request-local synthetic observation. Its provider-visible assistant/tool pair is
+  deterministic from the complete visible arguments and output.
+- Durable creation requires a private in-process attestation held only by the trusted Memory Branch
+  path. Caller-supplied metadata, object spreading, JSON restore, and post-creation mutation cannot
+  promote an arbitrary observation to durable history.
+- Restored events pass an exact two-part validator before they can be persisted, replayed, deduped,
+  or converted into a compaction watermark. The validator checks roles, lifecycle placement and
+  retention, event ID, deterministic tool-call ID, call/result pairing, source, episode, Memory
+  branch provenance, and the absence of provider-owned state.
+- Missing, partial, conflicting, forged, or rewritten pairs fail closed and are removed atomically.
+  Compaction summaries inherit only IDs from already validated complete events.
+- A historical Memory event remains context only. Restoring it does not execute a tool, grant an
+  authorization, or turn archived instructions into current execution authority.
+- OpenAI Responses and Chat, DeepSeek-compatible Chat, and Anthropic tool-use/tool-result lowering
+  preserve the restored stable prefix without leaking internal lifecycle metadata.
+
+## Real calibration
+
+Both providers ran the same real four-task Goal/Memory workload. Each task had one cold logical
+call followed by three warm logical calls; every physical Memory Branch and main-model attempt was
+retained in token-weighted scoring. Cache-read values below come only from provider usage fields
+bound by the manifest.
+
+| run | artifact | physical attempts | cache-read / input | raw ratio | capped-task ratio | capability / quality / safety | result |
+| --- | --- | ---: | ---: | ---: | ---: | --- | --- |
+| NewCLI | `sha256:13bf8c1c...` | 70 | 112,128 / 232,950 | 48.13% | 48.44% | passed / passed / passed | ratio failure |
+| DeepSeek | `sha256:13bf8c1c...` | 76 | 254,848 / 322,445 | 79.04% | 79.13% | passed / passed / failed | invalid calibration |
+
+The NewCLI split was 54,272 / 123,486 (43.95%) for main attempts and 57,856 / 109,464
+(52.85%) for Memory Branch attempts. Warm-only ratios were 54,272 / 92,620 (58.60%) for main
+and 51,712 / 83,371 (62.03%) for Memory Branch. Twelve warm physical attempts reported zero
+cache-read tokens, including four main attempts; all quality and safety oracles still passed.
+
+The DeepSeek split was 100,224 / 151,622 (66.10%) for main attempts and 154,624 / 170,823
+(90.52%) for Memory Branch attempts. Warm-only ratios were 100,224 / 106,931 (93.73%) for main
+and 122,752 / 129,136 (95.06%) for Memory Branch. No warm physical attempt reported zero
+cache-read tokens.
+
+DeepSeek's failed sample is intentionally retained. The cold unsafe-action logical call required
+two main attempts after the first consumed its output budget without returning the required visible
+answer or tool call. The eventual answer was correct, but the safety oracle correctly failed all
+five physical attempts associated with that logical call, and the extra main attempt also violated
+the sealed execution-plan count. No sample was removed or reclassified.
+
+The usage sources were `openai.input_tokens_details.cached_tokens` for NewCLI Responses and
+`openai.prompt_tokens_details.cached_tokens` for the DeepSeek-compatible Chat endpoint. Both runs
+were sealed against the identical artifact fingerprint
+`sha256:13bf8c1c5831ebe4182fc5345052559b4d5cf2d2246a5c38e5dbb1360a8ae1c4`.
+
+## Verification
+
+- `npm run build`: passed.
+- Official `npm test`: 1,505 tests; 1,497 passed; 0 failed; 0 cancelled; 8 skipped.
+- Provider contract coverage includes exact restored-prefix assertions for Responses, OpenAI Chat,
+  DeepSeek preflight/body lowering, and Anthropic tool-use/tool-result messages.
+- Independent read-only review exercised valid and malformed pairs, missing and blank branch IDs,
+  source downgrades after spreading or mutation, queue/timing/origin propagation, serialization,
+  watermark collection, and provider lowering. It found no P0-P2 issue in the frozen executable.
+- No dashboard or other UI files changed, so desktop/mobile visual testing was not applicable.
+
+## What this stage does not claim
+
+This stage establishes a secure durable Memory event lane; it does not claim the 94% target. The
+current v4 online runner clears the session at each logical call. It therefore exercises real
+Memory Branch work, save/restore, provider lowering, and cache reporting, but not a naturally
+growing durable event across logical calls or a changing-tail workload. Persistence and replay are
+covered by unit and integration tests, not by this calibration topology.
+
+The v4 qualification score also includes the required cold calibration calls in the same ratio as
+warm calls. That is useful diagnostic data but makes the acceptance ratio depend on the number of
+warm repetitions and can prevent an otherwise stable warm cache from qualifying. A later benchmark
+revision must preserve cold measurements while scoring three consecutive warm qualification rounds
+separately. It must also exercise natural growing sessions, detached recovery, real tool loops, and
+the remaining state-event lanes before final acceptance.

--- a/src/core/agent-turn-controller.ts
+++ b/src/core/agent-turn-controller.ts
@@ -37,6 +37,7 @@ import {
   SyntheticObservation,
   SyntheticObservationQueue,
   SyntheticObservationTiming,
+  withSyntheticObservationMetadata,
   withSyntheticObservationTiming,
 } from './synthetic-observation';
 import { MemorySidecarBranchHandle, startMemorySidecarBranch } from './sidecar-memory-branch';
@@ -486,13 +487,10 @@ export class AgentTurnController {
     originTurn: number,
   ): SyntheticObservation {
     const timed = withSyntheticObservationTiming(observation, timing);
-    return {
-      ...timed,
-      metadata: {
-        ...(timed.metadata || {}),
-        originTurn,
-      },
-    };
+    return withSyntheticObservationMetadata(timed, {
+      ...(timed.metadata || {}),
+      originTurn,
+    });
   }
 
   private toRunnerCallbacks(callbacks?: AgentTurnCallbacks): RunnerCallbacks {

--- a/src/core/checkpoint-compaction.ts
+++ b/src/core/checkpoint-compaction.ts
@@ -6,6 +6,7 @@ import { Logger } from '../utils/logger';
 import { Metrics } from '../utils/metrics';
 import { readRequiredBundledPromptFile } from '../utils/prompt-template';
 import { collectRemoteContextWatermarks } from './remote-context-watermarks';
+import { collectContextEventIds } from './context-event-watermarks';
 import { estimateMessagesTokens } from './token-estimator';
 import { annotateContextMessage, isTransientContextMessage } from './context-lifecycle';
 import {
@@ -296,6 +297,7 @@ export class CheckpointCompactionCoordinator {
       this.retainedUserTokenBudget,
     );
     const remoteContextWatermarks = collectRemoteContextWatermarks(durable);
+    const contextEventIds = [...collectContextEventIds(durable)].sort();
     const activeEpisodeId = findLatestEpisodeId(sessionMessages);
     const stableBoundary = findLastStableBoundary(sessionMessages);
 
@@ -327,6 +329,7 @@ export class CheckpointCompactionCoordinator {
       ...(Object.keys(remoteContextWatermarks).length > 0
         ? { __remoteContextWatermarks: remoteContextWatermarks }
         : {}),
+      ...(contextEventIds.length > 0 ? { __contextEventIds: contextEventIds } : {}),
     }, {
       source: 'compaction_summary',
       lifecycle: 'episode',
@@ -750,7 +753,7 @@ function isTransientMessage(message: Message): boolean {
   if (
     message.__injected
     || message.__runtimeFeedback
-    || message.__syntheticObservation
+    || (message.__syntheticObservation && message.__context?.persistence !== 'durable')
   ) {
     return true;
   }

--- a/src/core/context-compressor.ts
+++ b/src/core/context-compressor.ts
@@ -5,6 +5,7 @@ import { Logger } from '../utils/logger';
 import { Metrics } from '../utils/metrics';
 import { readRequiredDefaultPromptFile, renderPromptTemplate } from '../utils/prompt-template';
 import { collectRemoteContextWatermarks } from './remote-context-watermarks';
+import { collectContextEventIds } from './context-event-watermarks';
 import { annotateContextMessage, isTransientContextMessage } from './context-lifecycle';
 import type { AIRequestOptions } from '../providers/provider';
 
@@ -400,6 +401,7 @@ export class ContextCompressor {
       : (optionsOrCustomInstructions || {});
     const before = estimateMessagesTokens(messages);
     const remoteContextWatermarks = collectRemoteContextWatermarks(messages);
+    const contextEventIds = [...collectContextEventIds(messages)].sort();
 
     const system = messages.filter(m => m.role === 'system');
     const session = messages.filter(m => m.role !== 'system' && !isTransientCompactionMessage(m));
@@ -478,6 +480,7 @@ export class ContextCompressor {
         ...(Object.keys(remoteContextWatermarks).length > 0
           ? { __remoteContextWatermarks: remoteContextWatermarks }
           : {}),
+        ...(contextEventIds.length > 0 ? { __contextEventIds: contextEventIds } : {}),
       }, {
         source: 'compaction_summary',
         lifecycle: 'episode',
@@ -739,7 +742,7 @@ function isTransientCompactionMessage(message: Message): boolean {
   return Boolean(
     message.__injected
     || message.__runtimeFeedback
-    || message.__syntheticObservation,
+    || (message.__syntheticObservation && message.__context?.persistence !== 'durable'),
   );
 }
 

--- a/src/core/context-event-watermarks.ts
+++ b/src/core/context-event-watermarks.ts
@@ -1,0 +1,144 @@
+import { createHash } from 'crypto';
+import type { Message } from '../types';
+
+const SYNTHETIC_OBSERVATION_TOOL_NAME = 'runtime_observation';
+
+/**
+ * Exact durable event IDs already represented by the transcript or a
+ * compaction checkpoint. These are internal idempotency keys, never provider
+ * cache keys and never execution authority.
+ */
+export function collectContextEventIds(messages: readonly Message[]): Set<string> {
+  const ids = new Set<string>();
+  const groups = new Map<string, {
+    parts?: number;
+    seen: Set<number>;
+    invalid: boolean;
+    messages: Message[];
+  }>();
+  for (const message of messages) {
+    if (
+      message.__context?.source === 'compaction_summary'
+      && message.__context.persistence === 'durable'
+    ) {
+      for (const id of message.__contextEventIds || []) record(ids, id);
+    }
+    const event = message.__context?.retention === 'append'
+      ? message.__context.event
+      : undefined;
+    if (!event || !validId(event.id)) continue;
+    const group = groups.get(event.id) || { seen: new Set<number>(), invalid: false, messages: [] };
+    group.messages.push(message);
+    if (
+      !Number.isInteger(event.parts)
+      || event.parts < 1
+      || event.parts > 64
+      || !Number.isInteger(event.part)
+      || event.part < 0
+      || event.part >= event.parts
+      || (group.parts !== undefined && group.parts !== event.parts)
+      || group.seen.has(event.part)
+    ) {
+      group.invalid = true;
+    } else {
+      group.parts = event.parts;
+      group.seen.add(event.part);
+    }
+    groups.set(event.id, group);
+  }
+  for (const [id, group] of groups) {
+    if (
+      !group.invalid
+      && group.parts !== undefined
+      && group.seen.size === group.parts
+      && isValidDurableSyntheticObservationEvent(group.messages)
+    ) {
+      ids.add(id);
+    }
+  }
+  return ids;
+}
+
+export function isValidDurableSyntheticObservationEvent(messages: readonly Message[]): boolean {
+  if (messages.length !== 2) return false;
+  const assistant = messages.find(message => message.__context?.event?.part === 0);
+  const tool = messages.find(message => message.__context?.event?.part === 1);
+  if (
+    !assistant
+    || !tool
+    || !hasDurableEventContext(assistant)
+    || !hasDurableEventContext(tool)
+    || assistant.__context?.event?.parts !== 2
+    || tool.__context?.event?.parts !== 2
+    || assistant.__context.event.id !== tool.__context.event.id
+    || assistant.role !== 'assistant'
+    || assistant.tool_calls?.length !== 1
+    || assistant.content !== null
+    || tool.role !== 'tool'
+  ) return false;
+  const call = assistant.tool_calls?.[0];
+  const assistantBranchId = assistant.syntheticObservationProvenance?.branchId;
+  const toolBranchId = tool.syntheticObservationProvenance?.branchId;
+  if (
+    !call
+    || call.type !== 'function'
+    || call.function.name !== SYNTHETIC_OBSERVATION_TOOL_NAME
+    || tool.name !== SYNTHETIC_OBSERVATION_TOOL_NAME
+    || tool.tool_call_id !== call.id
+    || typeof call.function.arguments !== 'string'
+    || typeof tool.content !== 'string'
+    || assistant.syntheticObservationId !== tool.syntheticObservationId
+    || typeof assistant.syntheticObservationId !== 'string'
+    || !assistant.syntheticObservationId.trim()
+    || assistant.__episodeId !== tool.__episodeId
+    || assistant.syntheticObservationProvenance?.branchType !== 'memory'
+    || tool.syntheticObservationProvenance?.branchType !== 'memory'
+    || typeof assistantBranchId !== 'string'
+    || !assistantBranchId.trim()
+    || typeof toolBranchId !== 'string'
+    || !toolBranchId.trim()
+    || assistantBranchId !== toolBranchId
+  ) return false;
+  let source: unknown;
+  try {
+    source = JSON.parse(call.function.arguments).source;
+  } catch {
+    return false;
+  }
+  if (source !== 'memory') return false;
+  const digest = createHash('sha256')
+    .update(call.function.arguments)
+    .update('\0')
+    .update(tool.content)
+    .digest('hex')
+    .slice(0, 20);
+  return assistant.__context.event.id === `synthetic_observation:memory:${digest}`
+    && new RegExp(`^synthetic-memory-${digest}-[1-9][0-9]*$`).test(call.id)
+    && assistant.providerContent === undefined
+    && assistant.providerState === undefined
+    && tool.providerContent === undefined
+    && tool.providerState === undefined;
+}
+
+function record(ids: Set<string>, value: unknown): void {
+  const id = typeof value === 'string' ? value.trim() : '';
+  if (!validId(id)) return;
+  ids.add(id);
+}
+
+function validId(value: unknown): value is string {
+  return typeof value === 'string'
+    && /^synthetic_observation:[a-z_]+:[a-f0-9]{20}$/.test(value);
+}
+
+function hasDurableEventContext(message: Message): boolean {
+  return message.__syntheticObservation === true
+    && message.__cacheScope === 'dynamic'
+    && message.__context?.schema === 'xiaoba.context_lifecycle.v1'
+    && message.__context?.source === 'synthetic_observation'
+    && message.__context.lifecycle === 'episode'
+    && message.__context.cacheScope === 'epoch'
+    && message.__context.persistence === 'durable'
+    && message.__context.placement === 'transcript'
+    && message.__context.retention === 'append';
+}

--- a/src/core/context-lifecycle.ts
+++ b/src/core/context-lifecycle.ts
@@ -1,7 +1,10 @@
 import { createHash } from 'crypto';
 import type {
   ContextCacheScope,
+  ContextEventIdentity,
   ContextLifecycleAnnotation,
+  ContextPlacement,
+  ContextRetention,
   ContextSource,
   Message,
 } from '../types';
@@ -28,6 +31,9 @@ export interface ContextAnnotationInput {
   lifecycle: ContextLifecycleAnnotation['lifecycle'];
   cacheScope: ContextCacheScope;
   persistence?: ContextLifecycleAnnotation['persistence'];
+  placement?: ContextPlacement;
+  retention?: ContextRetention;
+  event?: ContextEventIdentity;
   epoch?: string;
 }
 
@@ -43,6 +49,9 @@ export function annotateContextMessage<T extends Message>(
       lifecycle: input.lifecycle,
       cacheScope: input.cacheScope,
       persistence: input.persistence ?? 'transient',
+      ...(input.placement ? { placement: input.placement } : {}),
+      ...(input.retention ? { retention: input.retention } : {}),
+      ...(input.event ? { event: { ...input.event } } : {}),
       ...(input.epoch ? { epoch: input.epoch } : {}),
     },
     ...(input.cacheScope === 'stable'
@@ -94,6 +103,9 @@ function contextIdentity(message: Message): Record<string, unknown> {
     lifecycle: annotation.lifecycle,
     cacheScope: annotation.cacheScope,
     persistence: annotation.persistence,
+    placement: annotation.placement || '',
+    retention: annotation.retention || '',
+    event: annotation.event || null,
     epoch: annotation.epoch || '',
     content: sha256(contentText(message)).slice(0, 16),
   };

--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -899,6 +899,7 @@ export class ConversationRunner {
 
     const syntheticMessages = buildSyntheticObservationMessages(observations, {
       existingMessages: messages,
+      episodeId: this.episodeId,
     });
     messages.push(...syntheticMessages);
     Logger.info(

--- a/src/core/memory-search-branch-session.ts
+++ b/src/core/memory-search-branch-session.ts
@@ -10,7 +10,11 @@ import {
   MemorySearchTool,
   fingerprintMemoryReadResult,
 } from '../tools/memory-branch-tools';
-import { SyntheticObservation, SyntheticObservationQueue } from './synthetic-observation';
+import {
+  createDurableMemoryObservation,
+  SyntheticObservation,
+  SyntheticObservationQueue,
+} from './synthetic-observation';
 import { ObservationBranchDisposition, ObservationBranchSession } from './observation-branch-session';
 import { MemoryLogStore } from './memory-log-store';
 
@@ -100,7 +104,7 @@ export class MemorySearchBranchSession extends ObservationBranchSession<MemorySe
   }
 
   protected buildObservation(payload: MemorySearchFinishPayload): SyntheticObservation {
-    return {
+    return createDurableMemoryObservation({
       id: `memory-${Date.now().toString(36)}-${randomUUID().slice(0, 8)}`,
       source: 'memory',
       status: 'completed',
@@ -120,7 +124,7 @@ export class MemorySearchBranchSession extends ObservationBranchSession<MemorySe
         summary: payload.summary,
         refs: payload.refs,
       }),
-    };
+    });
   }
 }
 

--- a/src/core/synthetic-observation.ts
+++ b/src/core/synthetic-observation.ts
@@ -1,6 +1,10 @@
 import { createHash, randomUUID } from 'crypto';
 import { Message } from '../types';
 import { annotateContextMessage } from './context-lifecycle';
+import {
+  collectContextEventIds,
+  isValidDurableSyntheticObservationEvent,
+} from './context-event-watermarks';
 
 export type SyntheticObservationSource = 'memory' | 'web' | 'runtime' | 'subagent' | 'skill_context';
 export type SyntheticObservationStatus = 'completed' | 'partial' | 'failed' | 'cancelled';
@@ -63,6 +67,22 @@ export interface SyntheticObservationQueue {
 }
 
 export const SYNTHETIC_OBSERVATION_TOOL_NAME = 'runtime_observation';
+const DURABLE_MEMORY_OBSERVATION = Symbol('xiaoba.durable_memory_observation');
+
+/**
+ * Runtime-only trust boundary for MemorySearchBranchSession publications.
+ * The symbol is deliberately private and is never serialized or provider-visible;
+ * arbitrary observation payloads cannot opt themselves into persistence.
+ */
+export function createDurableMemoryObservation<T extends SyntheticObservation & { source: 'memory' }>(
+  observation: T,
+): T {
+  const branchId = observation.metadata?.branchId;
+  if (observation.metadata?.branchType !== 'memory' || typeof branchId !== 'string' || !branchId.trim()) {
+    throw new Error('durable_memory_observation_attestation_invalid');
+  }
+  return markDurableMemoryObservation(observation);
+}
 
 export class InMemorySyntheticObservationQueue implements SyntheticObservationQueue {
   private observations: SyntheticObservation[] = [];
@@ -74,11 +94,14 @@ export class InMemorySyntheticObservationQueue implements SyntheticObservationQu
     const id = observation.id || stableObservationId(observation);
     if (this.seen.has(id)) return false;
     this.seen.add(id);
-    this.observations.push({
+    const normalized = {
       ...observation,
       id,
       createdAt: observation.createdAt ?? Date.now(),
-    });
+    };
+    this.observations.push(isDurableMemoryObservation(observation)
+      ? markDurableMemoryObservation(normalized)
+      : normalized);
     return true;
   }
 
@@ -103,7 +126,7 @@ export class InMemorySyntheticObservationQueue implements SyntheticObservationQu
 
 export function buildSyntheticObservationMessages(
   observations: SyntheticObservation[],
-  options: { existingMessages?: readonly Message[] } = {},
+  options: { existingMessages?: readonly Message[]; episodeId?: string } = {},
 ): Message[] {
   const messages: Message[] = [];
   const usedToolCallIds = collectToolCallIds(options.existingMessages || []);
@@ -123,6 +146,17 @@ export function buildSyntheticObservationMessages(
       .update(toolOutput)
       .digest('hex')
       .slice(0, 20);
+    const persistence = isDurableMemoryObservation(observation) ? 'durable' : 'transient';
+    const eventId = `synthetic_observation:${observation.source}:${visiblePayloadDigest}`;
+    if (persistence === 'durable') {
+      const priorMessages = [...(options.existingMessages || []), ...messages];
+      const existingEvent = collectContextEventParts(priorMessages, eventId);
+      if (existingEvent.length > 0) {
+        if (matchesExistingSyntheticEvent(existingEvent, toolArguments, toolOutput)) continue;
+        throw new Error('synthetic_observation_event_conflict');
+      }
+      if (collectContextEventIds(priorMessages).has(eventId)) continue;
+    }
     // Provider-visible IDs participate in exact-prefix cache identity. Keep
     // them deterministic for equivalent visible observations while retaining
     // the unique internal observation/branch IDs below for audit correlation.
@@ -145,11 +179,16 @@ export function buildSyntheticObservationMessages(
       }],
       __syntheticObservation: true,
       syntheticObservationId: id,
+      ...(options.episodeId ? { __episodeId: options.episodeId } : {}),
       ...(provenance ? { syntheticObservationProvenance: provenance } : {}),
     }, {
       source: 'synthetic_observation',
       lifecycle: 'episode',
       cacheScope: 'epoch',
+      persistence,
+      placement: 'transcript',
+      retention: persistence === 'durable' ? 'append' : 'request',
+      event: { id: eventId, part: 0, parts: 2 },
     }));
     messages.push(annotateContextMessage({
       role: 'tool',
@@ -158,14 +197,107 @@ export function buildSyntheticObservationMessages(
       content: toolOutput,
       __syntheticObservation: true,
       syntheticObservationId: id,
+      ...(options.episodeId ? { __episodeId: options.episodeId } : {}),
       ...(provenance ? { syntheticObservationProvenance: provenance } : {}),
     }, {
       source: 'synthetic_observation',
       lifecycle: 'episode',
       cacheScope: 'epoch',
+      persistence,
+      placement: 'transcript',
+      retention: persistence === 'durable' ? 'append' : 'request',
+      event: { id: eventId, part: 1, parts: 2 },
     }));
   }
   return messages;
+}
+
+/** Drops every malformed durable synthetic event as one atomic unit. */
+export function filterValidDurableSyntheticObservationEvents(messages: Message[]): Message[] {
+  const candidates = new Set(messages.filter(isCandidateDurableSyntheticMessage));
+  const candidateCallIds = new Set<string>();
+  for (const message of candidates) {
+    for (const call of message.tool_calls || []) {
+      if (call.id) candidateCallIds.add(call.id);
+    }
+    if (message.tool_call_id) candidateCallIds.add(message.tool_call_id);
+  }
+  for (const message of messages) {
+    if (
+      (message.role === 'tool' && message.tool_call_id && candidateCallIds.has(message.tool_call_id))
+      || (message.role === 'assistant'
+        && message.tool_calls?.some(call => candidateCallIds.has(call.id)))
+    ) candidates.add(message);
+  }
+  const groups = new Map<string, Message[]>();
+  for (const message of messages) {
+    if (!candidates.has(message)) continue;
+    const eventId = message.__context?.event?.id;
+    if (typeof eventId !== 'string') continue;
+    const group = groups.get(eventId) || [];
+    group.push(message);
+    groups.set(eventId, group);
+  }
+
+  const validMessages = new Set<Message>();
+  for (const group of groups.values()) {
+    if (!isValidDurableSyntheticObservationEvent(group)) continue;
+    for (const message of group) validMessages.add(message);
+  }
+  return messages.filter(message => !candidates.has(message) || validMessages.has(message));
+}
+
+function collectContextEventParts(messages: readonly Message[], eventId: string): Message[] {
+  return messages.filter(message => message.__context?.event?.id === eventId);
+}
+
+function matchesExistingSyntheticEvent(
+  messages: readonly Message[],
+  toolArguments: string,
+  toolOutput: string,
+): boolean {
+  if (!isValidDurableSyntheticObservationEvent(messages)) return false;
+  const assistant = messages.find(message => message.__context?.event?.part === 0);
+  const tool = messages.find(message => message.__context?.event?.part === 1);
+  if (!assistant || !tool) return false;
+  const call = assistant.tool_calls?.[0];
+  if (!call) return false;
+  return call.function.arguments === toolArguments && tool.content === toolOutput;
+}
+
+function isCandidateDurableSyntheticMessage(message: Message): boolean {
+  return message.__syntheticObservation === true
+    || message.__context?.source === 'synthetic_observation'
+    || message.name === SYNTHETIC_OBSERVATION_TOOL_NAME
+    || Boolean(message.tool_calls?.some(call => call.function.name === SYNTHETIC_OBSERVATION_TOOL_NAME));
+}
+
+function isDurableMemoryObservation(observation: SyntheticObservation): boolean {
+  const branchId = observation.metadata?.branchId;
+  return (observation as any)[DURABLE_MEMORY_OBSERVATION] === true
+    && observation.source === 'memory'
+    && observation.metadata?.branchType === 'memory'
+    && typeof branchId === 'string'
+    && Boolean(branchId.trim());
+}
+
+function markDurableMemoryObservation<T extends SyntheticObservation>(observation: T): T {
+  Object.defineProperty(observation, DURABLE_MEMORY_OBSERVATION, {
+    value: true,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  });
+  return observation;
+}
+
+function inheritDurableMemoryAttestation<T extends SyntheticObservation>(
+  source: SyntheticObservation,
+  clone: T,
+): T {
+  return isDurableMemoryObservation(source) && clone.source === 'memory'
+    ? markDurableMemoryObservation(clone)
+    : clone;
 }
 
 function collectToolCallIds(messages: readonly Message[]): Set<string> {
@@ -334,7 +466,17 @@ export function withSyntheticObservationTiming(
     next.formattedContent = formatTimedObservationContent(observation.formattedContent, timing);
   }
 
-  return next;
+  return inheritDurableMemoryAttestation(observation, next);
+}
+
+export function withSyntheticObservationMetadata(
+  observation: SyntheticObservation,
+  metadata: SyntheticObservationMetadata,
+): SyntheticObservation {
+  return inheritDurableMemoryAttestation(observation, {
+    ...observation,
+    metadata: { ...metadata },
+  });
 }
 
 function resolveObservationTiming(observation: SyntheticObservation): SyntheticObservationTiming {

--- a/src/core/turn-context-builder.ts
+++ b/src/core/turn-context-builder.ts
@@ -103,7 +103,7 @@ export class TurnContextBuilder {
   removeTransientMessages(messages: Message[]): Message[] {
     return messages.filter(msg => {
       if (isTransientContextMessage(msg)) return false;
-      if (msg.__syntheticObservation) return false;
+      if (msg.__syntheticObservation && msg.__context?.persistence !== 'durable') return false;
       if (msg.__runtimeFeedback) return false;
       if (msg.role !== 'system' || typeof msg.content !== 'string') return true;
       if (msg.content.startsWith(TRANSIENT_SUBAGENT_STATUS_PREFIX)) return false;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,6 +8,13 @@ export type ProviderApiType = 'anthropic-messages' | 'openai-chat-completions' |
 export type ContextLifecycle = 'session' | 'episode' | 'call';
 export type ContextCacheScope = 'stable' | 'epoch' | 'volatile';
 export type ContextPersistence = 'durable' | 'transient';
+export type ContextPlacement = 'instruction_prefix' | 'transcript' | 'request_tail';
+export type ContextRetention = 'append' | 'replace' | 'request';
+export interface ContextEventIdentity {
+  id: string;
+  part: number;
+  parts: number;
+}
 export type ContextSource =
   | 'runtime_context'
   | 'runtime_observation_rules'
@@ -34,6 +41,12 @@ export interface ContextLifecycleAnnotation {
   lifecycle: ContextLifecycle;
   cacheScope: ContextCacheScope;
   persistence: ContextPersistence;
+  /** Provider-neutral placement semantics; serializers still choose the wire representation. */
+  placement?: ContextPlacement;
+  /** Whether later requests append, replace, or discard this context item. */
+  retention?: ContextRetention;
+  /** Internal idempotency identity for a multi-message context event. Never sent to providers. */
+  event?: ContextEventIdentity;
   /** Raw epoch identity stays in memory; telemetry exposes only a fingerprint. */
   epoch?: string;
 }
@@ -100,6 +113,8 @@ export interface Message {
   __remoteContextId?: number;
   /** 压缩后仍被当前 transcript 表示的远端消息高水位；不发送给 provider。 */
   __remoteContextWatermarks?: Record<string, number>;
+  /** Durable context event IDs represented by a compaction checkpoint. Never sent to providers. */
+  __contextEventIds?: string[];
   /** Provider 原始 assistant content blocks，仅用于下次请求回放，不展示给用户。 */
   providerContent?: ProviderContentBlock[];
   /** Identity of the provider boundary that produced providerContent. Never sent verbatim. */

--- a/src/utils/session-store.ts
+++ b/src/utils/session-store.ts
@@ -9,6 +9,8 @@ import {
 } from './transcript-artifacts';
 import { PathResolver } from './path-resolver';
 import type { PersistedRuntimeGoalState } from '../core/goal-runtime';
+import { isTransientContextMessage } from '../core/context-lifecycle';
+import { filterValidDurableSyntheticObservationEvents } from '../core/synthetic-observation';
 
 const SESSIONS_DIR = PathResolver.getDataPath('sessions');
 const SESSION_STATE_DIR = PathResolver.getDataPath('session-state');
@@ -118,7 +120,13 @@ function sanitizeForPersistence(messages: Message[]): Message[] {
   const durable: Message[] = [];
 
   for (const message of messages) {
-    if ((message as any).__injected || message.role === 'system') {
+    if (
+      isTransientContextMessage(message)
+      || (message as any).__injected
+      || message.role === 'system'
+      || (message.__syntheticObservation && message.__context?.persistence !== 'durable')
+      || (message.__runtimeFeedback && message.__context?.persistence !== 'durable')
+    ) {
       continue;
     }
 
@@ -177,7 +185,7 @@ function sanitizeForPersistence(messages: Message[]): Message[] {
     }
   }
 
-  return durable;
+  return filterValidDurableSyntheticObservationEvents(durable);
 }
 
 function serializeMessages(messages: Message[]): string {

--- a/tests/agent-turn-memory-carryover.test.ts
+++ b/tests/agent-turn-memory-carryover.test.ts
@@ -5,7 +5,12 @@ import {
   BRANCH_AGENTS_ENABLED_ENV,
   MEMORY_SIDECAR_ENABLED_ENV,
 } from '../src/core/branch-agent-settings';
-import { InMemorySyntheticObservationQueue, SYNTHETIC_OBSERVATION_TOOL_NAME, SyntheticObservation } from '../src/core/synthetic-observation';
+import {
+  createDurableMemoryObservation,
+  InMemorySyntheticObservationQueue,
+  SYNTHETIC_OBSERVATION_TOOL_NAME,
+  SyntheticObservation,
+} from '../src/core/synthetic-observation';
 import { TurnContextBuilder } from '../src/core/turn-context-builder';
 import { Message } from '../src/types';
 import { AIService } from '../src/utils/ai-service';
@@ -14,7 +19,7 @@ import { GoalRuntime } from '../src/core/goal-runtime';
 const usage = { promptTokens: 1, completionTokens: 1, totalTokens: 2 };
 
 function memoryObservation(id: string): SyntheticObservation {
-  return {
+  return createDurableMemoryObservation({
     id,
     source: 'memory',
     status: 'completed',
@@ -30,7 +35,7 @@ function memoryObservation(id: string): SyntheticObservation {
       summary: 'Previous turn found the birthday dinner decision.',
       refs: ['catscompany/2026-06-16/demo.jsonl#7'],
     }),
-  };
+  });
 }
 
 class CapturingAIService {
@@ -321,8 +326,10 @@ describe('AgentTurnController memory branch carryover', () => {
     assert.equal(cancelled[0], true, 'previous-turn branch is expired after its carryover turn');
     assert.equal(queues[0].push(memoryObservation('too-late')), false);
 
-    await runTurn('turn three should not receive turn one memory');
+    await runTurn('turn three keeps the historical event without reinjecting the expired branch');
     const thirdSynthetic = aiService.requests[2].filter(message => message.__syntheticObservation);
-    assert.equal(thirdSynthetic.length, 0);
+    assert.equal(thirdSynthetic.length, 2);
+    assert.equal(thirdSynthetic[0].syntheticObservationId, 'late-one');
+    assert.equal(thirdSynthetic[1].syntheticObservationId, 'late-one');
   });
 });

--- a/tests/anthropic-provider-runtime-feedback.test.ts
+++ b/tests/anthropic-provider-runtime-feedback.test.ts
@@ -4,6 +4,7 @@ import { AnthropicProvider } from '../src/providers/anthropic-provider';
 import { Message } from '../src/types';
 import {
   buildSyntheticObservationMessages,
+  createDurableMemoryObservation,
   SYNTHETIC_OBSERVATION_TOOL_NAME,
   withSyntheticObservationTiming,
 } from '../src/core/synthetic-observation';
@@ -69,7 +70,7 @@ describe('AnthropicProvider runtime feedback boundary', () => {
     });
 
     const syntheticPair = buildSyntheticObservationMessages([
-      withSyntheticObservationTiming({
+      createDurableMemoryObservation(withSyntheticObservationTiming({
         id: 'late-memory',
         source: 'memory',
         status: 'completed',
@@ -80,12 +81,19 @@ describe('AnthropicProvider runtime feedback boundary', () => {
           summary: 'Prior dinner planning memory.',
           refs: ['catscompany/2026-06-16/demo.jsonl#7'],
         }),
-      }, 'late_previous_turn'),
-    ]);
+        metadata: { branchType: 'memory', branchId: 'branch-anthropic' },
+      }, 'late_previous_turn')),
+    ], { episodeId: 'episode:anthropic' });
 
     const transformed = (provider as any).transformMessages([
       { role: 'user', content: 'continue the dinner plan' },
       ...syntheticPair,
+    ] as Message[]);
+    const restored = (provider as any).transformMessages([
+      { role: 'user', content: 'continue the dinner plan' },
+      ...syntheticPair,
+      { role: 'assistant', content: 'The prior plan was recovered.' },
+      { role: 'user', content: 'Continue with the next decision.' },
     ] as Message[]);
 
     const toolUseId = syntheticPair[0].tool_calls?.[0].id;
@@ -116,6 +124,13 @@ describe('AnthropicProvider runtime feedback boundary', () => {
         }),
       }],
     });
+    assert.equal(JSON.stringify(transformed).includes('__context'), false);
+    assert.equal(JSON.stringify(transformed).includes('branch-anthropic'), false);
+    assert.equal(JSON.stringify(transformed).includes('episode:anthropic'), false);
+    assert.deepStrictEqual(
+      restored.messages.slice(0, transformed.messages.length),
+      transformed.messages,
+    );
   });
 
   test('coalesces adjacent user messages before Anthropic-compatible requests', () => {

--- a/tests/checkpoint-compaction.test.ts
+++ b/tests/checkpoint-compaction.test.ts
@@ -8,6 +8,10 @@ import {
   buildCheckpointCompactionPrompt,
   isCheckpointCompactionEnabled,
 } from '../src/core/checkpoint-compaction';
+import {
+  buildSyntheticObservationMessages,
+  createDurableMemoryObservation,
+} from '../src/core/synthetic-observation';
 
 const usage = { promptTokens: 10, completionTokens: 5, totalTokens: 15 };
 
@@ -49,7 +53,7 @@ test('checkpoint compaction switch defaults on and supports explicit rollback', 
 });
 
 test('checkpoint compaction preserves stable system and transient runtime messages', async () => {
-  const { service, options } = createService(() => [
+  const { service, requests, options } = createService(() => [
     'Objective: finish the active task.',
     'Completed: inspected the repository.',
     'Next: edit the target file.',
@@ -63,6 +67,14 @@ test('checkpoint compaction preserves stable system and transient runtime messag
     content: '[transient_runtime_context]\ncurrent device facts\n[/transient_runtime_context]',
     __injected: true,
   };
+  const durableObservation = buildSyntheticObservationMessages([createDurableMemoryObservation({
+    id: 'durable-memory-observation',
+    source: 'memory',
+    status: 'completed',
+    relevance: 'high',
+    summary: 'durable observation fact: the release gate stays enabled',
+    metadata: { branchType: 'memory', branchId: 'checkpoint-memory' },
+  })]).map(message => ({ ...message, __episodeId: 'episode-1' }));
   const messages: Message[] = [
     { role: 'system', content: 'stable system prompt' },
     {
@@ -88,6 +100,7 @@ test('checkpoint compaction preserves stable system and transient runtime messag
       content: largeText('tool evidence'),
       __episodeId: 'episode-1',
     },
+    ...durableObservation,
     transient,
   ];
 
@@ -108,11 +121,14 @@ test('checkpoint compaction preserves stable system and transient runtime messag
   assert.ok(result.messages.some(message =>
     String(message.content).startsWith(CHECKPOINT_SUMMARY_PREFIX)));
   assert.ok(result.messages.some(message => message.content === transient.content));
-  assert.equal(result.messages.some(message => message.role === 'tool'), false);
+  assert.equal(result.messages.some(message => message.role === 'tool' && !message.__syntheticObservation), false);
   assert.equal(
     result.messages.some(message => String(message.content).includes('tool evidence')),
     false,
   );
+  assert.equal(requests[0].some(message => String(message.content).includes(
+    'durable observation fact: the release gate stays enabled',
+  )), true);
   const summaryIndex = result.messages.findIndex(message => message.__checkpointSummary);
   const retainedUserIndex = result.messages.findIndex(message =>
     message.role === 'user' && String(message.content).includes('original objective'));
@@ -122,6 +138,9 @@ test('checkpoint compaction preserves stable system and transient runtime messag
   assert.equal(options[0].modelAttemptContext.surface, 'test');
   assert.equal(result.messages[summaryIndex].__context?.source, 'compaction_summary');
   assert.equal(result.messages[summaryIndex].__context?.persistence, 'durable');
+  assert.deepEqual(result.messages[summaryIndex].__contextEventIds, [
+    durableObservation[0].__context?.event?.id,
+  ]);
   const boundary = result.messages.find(message => message.__checkpointBoundary);
   assert.equal(boundary?.__context?.source, 'compaction_boundary');
   assert.equal(boundary?.__context?.cacheScope, 'epoch');

--- a/tests/context-compressor.test.ts
+++ b/tests/context-compressor.test.ts
@@ -1,6 +1,10 @@
 import { describe, test, beforeEach } from 'node:test';
 import * as assert from 'node:assert';
 import { ContextCompressor, contentToString, messagesToConversationText, parseCompactSummary, buildCompactSystemPrompt, truncateForSummary } from '../src/core/context-compressor';
+import {
+  buildSyntheticObservationMessages,
+  createDurableMemoryObservation,
+} from '../src/core/synthetic-observation';
 import { estimateTokens } from '../src/core/token-estimator';
 import type { Message } from '../src/types';
 import type { AIService } from '../src/utils/ai-service';
@@ -238,6 +242,32 @@ describe('ContextCompressor.compact', () => {
     assert.equal(boundaryMsg?.__context?.source, 'compaction_boundary');
     assert.equal(boundaryMsg?.__context?.persistence, 'durable');
     assert.equal(userMsgs[0].__context?.source, 'compaction_summary');
+  });
+
+  test('includes durable synthetic observation events in compaction input', async () => {
+    const capture = mockAIServiceWithCapture('summary-body');
+    const compressor = new ContextCompressor(capture.service, { preserveRecentEpisodes: 0 });
+    const observation = buildSyntheticObservationMessages([createDurableMemoryObservation({
+      id: 'durable-observation',
+      source: 'memory',
+      status: 'completed',
+      relevance: 'high',
+      summary: 'durable observation fact: keep the verified migration decision',
+      metadata: { branchType: 'memory', branchId: 'compressor-memory' },
+    })]);
+
+    const result = await compressor.compact([
+      user('original request'),
+      ...observation,
+      assistant('used the observation'),
+    ]);
+
+    assert.match(
+      String(capture.requests[0][1].content),
+      /durable observation fact: keep the verified migration decision/,
+    );
+    const summary = result.find(message => message.__context?.source === 'compaction_summary');
+    assert.deepEqual(summary?.__contextEventIds, [observation[0].__context?.event?.id]);
   });
 
   test('全量压缩：结果中无任何 tool_call_id 引用', async () => {

--- a/tests/context-lifecycle.test.ts
+++ b/tests/context-lifecycle.test.ts
@@ -49,3 +49,37 @@ test('a new episode creates a new context epoch fingerprint', () => {
   assert.notEqual(first.epochFingerprint, second.epochFingerprint);
   assert.equal(isTransientContextMessage(episodeMessages('same call')[0]), true);
 });
+
+test('durable append event metadata remains provider-neutral typed context', () => {
+  const message = annotateContextMessage({ role: 'tool', content: 'historical evidence' }, {
+    source: 'synthetic_observation',
+    lifecycle: 'episode',
+    cacheScope: 'epoch',
+    persistence: 'durable',
+    placement: 'transcript',
+    retention: 'append',
+    event: {
+      id: 'synthetic_observation:memory:0123456789abcdef0123',
+      part: 1,
+      parts: 2,
+    },
+    epoch: 'episode:one',
+  });
+
+  assert.deepEqual(message.__context, {
+    schema: 'xiaoba.context_lifecycle.v1',
+    source: 'synthetic_observation',
+    lifecycle: 'episode',
+    cacheScope: 'epoch',
+    persistence: 'durable',
+    placement: 'transcript',
+    retention: 'append',
+    event: {
+      id: 'synthetic_observation:memory:0123456789abcdef0123',
+      part: 1,
+      parts: 2,
+    },
+    epoch: 'episode:one',
+  });
+  assert.equal(isTransientContextMessage(message), false);
+});

--- a/tests/openai-provider-responses.test.ts
+++ b/tests/openai-provider-responses.test.ts
@@ -4,7 +4,10 @@ import { Readable } from 'node:stream';
 import axios from 'axios';
 import { OpenAIProvider } from '../src/providers/openai-provider';
 import { AIService } from '../src/utils/ai-service';
-import { buildSyntheticObservationMessages } from '../src/core/synthetic-observation';
+import {
+  buildSyntheticObservationMessages,
+  createDurableMemoryObservation,
+} from '../src/core/synthetic-observation';
 import type { Message } from '../src/types';
 import type { ToolDefinition } from '../src/types/tool';
 
@@ -67,6 +70,33 @@ describe('OpenAIProvider Responses API mode', () => {
     const second = build('b');
     assert.deepEqual(first, second);
     assert.notEqual(first[1].call_id, first[3].call_id);
+  });
+
+  test('keeps a restored durable memory event as an exact Responses input prefix', () => {
+    const provider = createProvider();
+    const durablePair = buildSyntheticObservationMessages([createDurableMemoryObservation({
+      id: 'responses-durable-memory',
+      source: 'memory',
+      status: 'completed',
+      relevance: 'high',
+      summary: 'The verified migration gate remains enabled.',
+      metadata: { branchType: 'memory', branchId: 'branch-responses' },
+    })], { episodeId: 'episode:responses' });
+    const firstInput = (provider as any).buildResponsesRequestBody([
+      { role: 'user', content: 'Recover the migration decision.' },
+      ...durablePair,
+    ]).input;
+    const restoredInput = (provider as any).buildResponsesRequestBody([
+      { role: 'user', content: 'Recover the migration decision.' },
+      ...durablePair,
+      { role: 'assistant', content: 'The gate remains enabled.' },
+      { role: 'user', content: 'Now verify the rollout checklist.' },
+    ]).input;
+
+    assert.deepEqual(restoredInput.slice(0, firstInput.length), firstInput);
+    assert.equal(JSON.stringify(restoredInput).includes('__context'), false);
+    assert.equal(JSON.stringify(restoredInput).includes('branch-responses'), false);
+    assert.equal(JSON.stringify(restoredInput).includes('episode:responses'), false);
   });
 
   test('builds Responses input and a stable prompt cache key', () => {

--- a/tests/openai-provider-runtime-feedback.test.ts
+++ b/tests/openai-provider-runtime-feedback.test.ts
@@ -3,7 +3,12 @@ import * as assert from 'node:assert';
 import { Readable } from 'node:stream';
 import axios from 'axios';
 import { OpenAIProvider } from '../src/providers/openai-provider';
-import { buildSyntheticObservationMessages } from '../src/core/synthetic-observation';
+import {
+  buildSyntheticObservationMessages,
+  createDurableMemoryObservation,
+} from '../src/core/synthetic-observation';
+import { prepareDeepSeekSyntheticObservations } from '../src/providers/deepseek-reasoning-recovery';
+import { prepareProviderRequestMessages } from '../src/providers/request-preflight';
 import { Message } from '../src/types';
 
 describe('OpenAIProvider runtime feedback boundary', () => {
@@ -41,6 +46,80 @@ describe('OpenAIProvider runtime feedback boundary', () => {
     const second = build('b');
     assert.deepStrictEqual(first, second);
     assert.notEqual(first[1].tool_calls[0].id, first[3].tool_calls[0].id);
+  });
+
+  test('keeps restored durable memory events as an exact official OpenAI Chat prefix', () => {
+    const provider = new OpenAIProvider({
+      apiKey: 'test-key',
+      apiUrl: 'https://api.openai.com/v1',
+      model: 'gpt-5.5',
+    });
+    const durablePair = buildSyntheticObservationMessages([createDurableMemoryObservation({
+      id: 'chat-durable-memory',
+      source: 'memory',
+      status: 'completed',
+      relevance: 'high',
+      summary: 'The verified deployment region is east.',
+      metadata: { branchType: 'memory', branchId: 'branch-chat' },
+    })], { episodeId: 'episode:chat' });
+
+    const firstMessages = (provider as any).buildRequestBody([
+      { role: 'user', content: 'Recover the deployment region.' },
+      ...durablePair,
+    ]).messages;
+    const restoredMessages = (provider as any).buildRequestBody([
+      { role: 'user', content: 'Recover the deployment region.' },
+      ...durablePair,
+      { role: 'assistant', content: 'The region is east.' },
+      { role: 'user', content: 'Continue with the next check.' },
+    ]).messages;
+
+    assert.deepStrictEqual(restoredMessages.slice(0, firstMessages.length), firstMessages);
+    assert.equal(JSON.stringify(restoredMessages).includes('__context'), false);
+    assert.equal(JSON.stringify(restoredMessages).includes('branch-chat'), false);
+    assert.equal(JSON.stringify(restoredMessages).includes('episode:chat'), false);
+  });
+
+  test('keeps the real DeepSeek durable-memory lowering as an exact restored prefix', () => {
+    const config = {
+      provider: 'openai' as const,
+      apiKey: 'test-key',
+      apiUrl: 'https://api.deepseek.com',
+      model: 'deepseek-v4-flash',
+      openaiApiMode: 'chat_completions' as const,
+    };
+    const provider = new OpenAIProvider(config);
+    const durablePair = buildSyntheticObservationMessages([createDurableMemoryObservation({
+      id: 'deepseek-durable-memory',
+      source: 'memory',
+      status: 'completed',
+      relevance: 'high',
+      summary: 'The verified deployment region is east.',
+      metadata: { branchType: 'memory', branchId: 'branch-deepseek' },
+    })], { episodeId: 'episode:deepseek' });
+    const lower = (messages: Message[]) => {
+      const deepSeekPrepared = prepareDeepSeekSyntheticObservations({ config, messages });
+      const preflight = prepareProviderRequestMessages(deepSeekPrepared);
+      assert.equal(preflight.summary, undefined);
+      return (provider as any).buildRequestBody(preflight.messages).messages;
+    };
+    const firstMessages = lower([
+      { role: 'user', content: 'Recover the deployment region.' },
+      ...durablePair,
+    ]);
+    const restoredMessages = lower([
+      { role: 'user', content: 'Recover the deployment region.' },
+      ...durablePair,
+      { role: 'assistant', content: 'The region is east.' },
+      { role: 'user', content: 'Continue with the next check.' },
+    ]);
+
+    assert.equal(firstMessages.length, 2);
+    assert.match(String(firstMessages[1].content), /^\[runtime_observation\]/);
+    assert.deepStrictEqual(restoredMessages.slice(0, firstMessages.length), firstMessages);
+    assert.equal(JSON.stringify(restoredMessages).includes('__context'), false);
+    assert.equal(JSON.stringify(restoredMessages).includes('branch-deepseek'), false);
+    assert.equal(JSON.stringify(restoredMessages).includes('episode:deepseek'), false);
   });
 
   test('strips internal injected fields before building SDK messages', () => {

--- a/tests/session-lifecycle-manager.test.ts
+++ b/tests/session-lifecycle-manager.test.ts
@@ -446,6 +446,144 @@ describe('AgentSession lifecycle', () => {
     );
   });
 
+  test('session persistence restores durable synthetic events and rejects request-only pairs', () => {
+    const {
+      SessionStore,
+      buildSyntheticObservationMessages,
+      createDurableMemoryObservation,
+    } = loadSessionModules();
+    const durable = buildSyntheticObservationMessages([createDurableMemoryObservation({
+      id: 'persisted-memory-event',
+      source: 'memory',
+      status: 'completed',
+      relevance: 'high',
+      summary: 'persisted memory decision',
+      metadata: { branchType: 'memory', branchId: 'branch-persisted' },
+    })], { episodeId: 'episode:persisted' });
+    const requestOnly = buildSyntheticObservationMessages([{
+      id: 'request-only-event',
+      source: 'runtime',
+      status: 'completed',
+      relevance: 'low',
+      summary: 'request only context',
+    }]);
+
+    SessionStore.getInstance().saveContext('user:lifecycle-durable-events', [
+      { role: 'user', content: 'original request' },
+      ...durable,
+      ...requestOnly,
+      { role: 'assistant', content: 'original answer' },
+    ]);
+    const restored = SessionStore.getInstance().loadContext('user:lifecycle-durable-events');
+    const restoredEvent = restored.filter((message: any) => message.__syntheticObservation);
+
+    assert.equal(restoredEvent.length, 2);
+    assert.deepEqual(
+      restoredEvent.map((message: any) => message.__context?.event?.part),
+      [0, 1],
+    );
+    assert.equal(restoredEvent[0].__context.event.id, restoredEvent[1].__context.event.id);
+    assert.equal(restoredEvent[0].__episodeId, 'episode:persisted');
+    assert.deepEqual(restoredEvent[0].syntheticObservationProvenance, {
+      branchType: 'memory',
+      branchId: 'branch-persisted',
+    });
+    assert.equal(
+      restored.some((message: any) => String(message.content || '').includes('request only context')),
+      false,
+    );
+  });
+
+  test('session persistence atomically rejects incomplete and malformed durable event pairs', () => {
+    const {
+      SessionStore,
+      buildSyntheticObservationMessages,
+      createDurableMemoryObservation,
+    } = loadSessionModules();
+    const pair = buildSyntheticObservationMessages([createDurableMemoryObservation({
+      id: 'malformed-memory-event',
+      source: 'memory',
+      status: 'completed',
+      relevance: 'high',
+      summary: 'must survive only as a complete verified pair',
+      metadata: { branchType: 'memory', branchId: 'branch-malformed' },
+    })], { episodeId: 'episode:malformed' });
+    const wrongCallPair = JSON.parse(JSON.stringify(pair));
+    wrongCallPair[1].tool_call_id = 'wrong-call-id';
+    const missingMetadataPair = JSON.parse(JSON.stringify(pair));
+    delete missingMetadataPair[0].__context.event;
+    const digestMismatchPair = JSON.parse(JSON.stringify(pair));
+    digestMismatchPair[1].content += ' tampered';
+    const bogusCallTypePair = JSON.parse(JSON.stringify(pair));
+    bogusCallTypePair[0].tool_calls[0].type = 'bogus';
+    const assistantTextPair = JSON.parse(JSON.stringify(pair));
+    assistantTextPair[0].content = 'unexpected assistant text';
+    const rewrittenCallIdPair = JSON.parse(JSON.stringify(pair));
+    rewrittenCallIdPair[0].tool_calls[0].id = 'rewritten-call-id';
+    rewrittenCallIdPair[1].tool_call_id = 'rewritten-call-id';
+    const stableScopePair = JSON.parse(JSON.stringify(pair));
+    stableScopePair[0].__context.cacheScope = 'stable';
+    stableScopePair[0].__cacheScope = 'stable';
+    const missingToolMarkerPair = JSON.parse(JSON.stringify(pair));
+    delete missingToolMarkerPair[1].__syntheticObservation;
+    const missingBranchIdPair = JSON.parse(JSON.stringify(pair));
+    delete missingBranchIdPair[0].syntheticObservationProvenance.branchId;
+    delete missingBranchIdPair[1].syntheticObservationProvenance.branchId;
+    const blankBranchIdPair = JSON.parse(JSON.stringify(pair));
+    blankBranchIdPair[0].syntheticObservationProvenance.branchId = '   ';
+    blankBranchIdPair[1].syntheticObservationProvenance.branchId = '   ';
+
+    const store = SessionStore.getInstance();
+    store.saveContext('user:lifecycle-incomplete-event', [
+      { role: 'user', content: 'keep incomplete boundary' },
+      pair[0],
+      { role: 'assistant', content: 'keep incomplete answer' },
+    ]);
+    store.saveContext('user:lifecycle-wrong-call-event', [
+      { role: 'user', content: 'keep wrong-call boundary' },
+      ...wrongCallPair,
+      { role: 'assistant', content: 'keep wrong-call answer' },
+    ]);
+    store.saveContext('user:lifecycle-missing-event-metadata', [
+      { role: 'user', content: 'keep missing-metadata boundary' },
+      ...missingMetadataPair,
+      { role: 'assistant', content: 'keep missing-metadata answer' },
+    ]);
+    store.saveContext('user:lifecycle-event-digest-mismatch', [
+      { role: 'user', content: 'keep digest-mismatch boundary' },
+      ...digestMismatchPair,
+      { role: 'assistant', content: 'keep digest-mismatch answer' },
+    ]);
+    const canonicalShapeFailures = [
+      ['bogus-call-type', bogusCallTypePair],
+      ['assistant-text', assistantTextPair],
+      ['rewritten-call-id', rewrittenCallIdPair],
+      ['stable-scope', stableScopePair],
+      ['missing-tool-marker', missingToolMarkerPair],
+      ['missing-branch-id', missingBranchIdPair],
+      ['blank-branch-id', blankBranchIdPair],
+    ] as const;
+    for (const [suffix, malformedPair] of canonicalShapeFailures) {
+      store.saveContext(`user:lifecycle-${suffix}`, [
+        { role: 'user', content: `keep ${suffix} boundary` },
+        ...malformedPair,
+        { role: 'assistant', content: `keep ${suffix} answer` },
+      ]);
+    }
+
+    for (const key of [
+      'user:lifecycle-incomplete-event',
+      'user:lifecycle-wrong-call-event',
+      'user:lifecycle-missing-event-metadata',
+      'user:lifecycle-event-digest-mismatch',
+      ...canonicalShapeFailures.map(([suffix]) => `user:lifecycle-${suffix}`),
+    ]) {
+      const restored = store.loadContext(key);
+      assert.equal(restored.some((message: any) => message.__syntheticObservation), false);
+      assert.deepEqual(restored.map((message: any) => message.role), ['user', 'assistant']);
+    }
+  });
+
   test('session persistence strips provider replay hidden thinking from restored history', async () => {
     const { SessionStore } = loadSessionModules();
     SessionStore.getInstance().saveContext('user:lifecycle-provider-replay', [
@@ -1258,6 +1396,7 @@ function loadSessionModules(): any {
     '../src/core/session-lifecycle-manager',
     '../src/utils/session-store',
     '../src/core/session-router',
+    '../src/core/synthetic-observation',
   ]) {
     delete require.cache[require.resolve(modulePath)];
   }
@@ -1273,6 +1412,8 @@ function loadSessionModules(): any {
     SessionLifecycleManager: require('../src/core/session-lifecycle-manager').SessionLifecycleManager,
     createSessionRoute: require('../src/core/session-router').createSessionRoute,
     createCatsCoSessionRoute: require('../src/core/session-router').createCatsCoSessionRoute,
+    buildSyntheticObservationMessages: require('../src/core/synthetic-observation').buildSyntheticObservationMessages,
+    createDurableMemoryObservation: require('../src/core/synthetic-observation').createDurableMemoryObservation,
   };
 }
 

--- a/tests/synthetic-observation.test.ts
+++ b/tests/synthetic-observation.test.ts
@@ -3,14 +3,18 @@ import * as assert from 'node:assert/strict';
 import {
   buildSyntheticObservationLifecycleEvent,
   buildSyntheticObservationMessages,
+  createDurableMemoryObservation,
   describeSyntheticObservationForLog,
   InMemorySyntheticObservationQueue,
   SYNTHETIC_OBSERVATION_TOOL_NAME,
   SyntheticObservation,
+  withSyntheticObservationMetadata,
   withSyntheticObservationTiming,
 } from '../src/core/synthetic-observation';
 import { prepareProviderRequestMessages } from '../src/providers/request-preflight';
 import { TurnContextBuilder } from '../src/core/turn-context-builder';
+import { annotateContextMessage } from '../src/core/context-lifecycle';
+import { collectContextEventIds } from '../src/core/context-event-watermarks';
 import { Message } from '../src/types';
 
 function observation(id = 'memory-demo'): SyntheticObservation {
@@ -38,6 +42,16 @@ function observation(id = 'memory-demo'): SyntheticObservation {
   };
 }
 
+function durableObservation(id: string): SyntheticObservation {
+  return createDurableMemoryObservation({
+    ...observation(id),
+    metadata: {
+      branchType: 'memory',
+      branchId: `branch-${id}`,
+    },
+  });
+}
+
 describe('synthetic observations', () => {
   test('builds a synthetic assistant tool_call and matching tool_result pair', () => {
     const messages = buildSyntheticObservationMessages([observation()]);
@@ -50,6 +64,9 @@ describe('synthetic observations', () => {
     assert.equal(messages[0].tool_calls?.[0].function.name, SYNTHETIC_OBSERVATION_TOOL_NAME);
     assert.equal(messages[1].name, SYNTHETIC_OBSERVATION_TOOL_NAME);
     assert.equal(messages[1].tool_call_id, messages[0].tool_calls?.[0].id);
+    assert.equal(messages[0].__context?.persistence, 'transient');
+    assert.equal(messages[0].__context?.placement, 'transcript');
+    assert.equal(messages[0].__context?.retention, 'request');
     assert.equal(JSON.parse(messages[0].tool_calls?.[0].function.arguments || '{}').timing, 'current_turn');
     assert.match(String(messages[1].content), /Earlier session decided/);
     assert.match(String(messages[1].content), /Decision: keep dashboard filters compact/);
@@ -88,6 +105,127 @@ describe('synthetic observations', () => {
     }]);
 
     assert.notEqual(first[0].tool_calls?.[0].id, second[0].tool_calls?.[0].id);
+  });
+
+  test('builds durable append events with episode identity and skips exact historical replay', () => {
+    const durable = durableObservation('durable-one');
+    const first = buildSyntheticObservationMessages([durable], {
+      episodeId: 'episode:durable',
+    });
+    const replay = buildSyntheticObservationMessages([durable], {
+      existingMessages: first,
+      episodeId: 'episode:later',
+    });
+
+    assert.equal(first[0].__episodeId, 'episode:durable');
+    assert.equal(first[1].__episodeId, 'episode:durable');
+    assert.equal(first[0].__context?.persistence, 'durable');
+    assert.equal(first[0].__context?.retention, 'append');
+    assert.equal(first[0].__context?.event?.part, 0);
+    assert.equal(first[1].__context?.event?.part, 1);
+    assert.equal(first[0].__context?.event?.id, first[1].__context?.event?.id);
+    assert.deepEqual(replay, []);
+  });
+
+  test('fails closed when a durable event id exists as an incomplete pair', () => {
+    const durable = durableObservation('durable-conflict');
+    const pair = buildSyntheticObservationMessages([durable]);
+
+    assert.throws(() => buildSyntheticObservationMessages([durable], {
+      existingMessages: [pair[0]],
+    }), /synthetic_observation_event_conflict/);
+    assert.deepEqual([...collectContextEventIds([pair[0]])], []);
+  });
+
+  test('does not replay a durable event represented by a compaction watermark', () => {
+    const durable = durableObservation('durable-compacted');
+    const pair = buildSyntheticObservationMessages([durable]);
+    const compactedSummary: Message = annotateContextMessage({
+      role: 'user',
+      content: '[compact_summary]\nThe prior memory event was incorporated.',
+      __contextEventIds: [pair[0].__context?.event?.id || ''],
+    }, {
+      source: 'compaction_summary',
+      lifecycle: 'episode',
+      cacheScope: 'epoch',
+      persistence: 'durable',
+    });
+
+    const replay = buildSyntheticObservationMessages([createDurableMemoryObservation({
+      ...durable,
+      id: 'different-internal-id',
+      metadata: { branchType: 'memory', branchId: 'different-branch' },
+    })], { existingMessages: [compactedSummary] });
+
+    assert.deepEqual(replay, []);
+  });
+
+  test('does not watermark durable pairs with missing or blank Memory branch identity', () => {
+    const pair = buildSyntheticObservationMessages([durableObservation('branch-id-watermark')]);
+    const missing = JSON.parse(JSON.stringify(pair)) as Message[];
+    delete missing[0].syntheticObservationProvenance!.branchId;
+    delete missing[1].syntheticObservationProvenance!.branchId;
+    const blank = JSON.parse(JSON.stringify(pair)) as Message[];
+    blank[0].syntheticObservationProvenance!.branchId = '   ';
+    blank[1].syntheticObservationProvenance!.branchId = '   ';
+
+    assert.deepEqual([...collectContextEventIds(missing)], []);
+    assert.deepEqual([...collectContextEventIds(blank)], []);
+  });
+
+  test('dedupes equivalent durable observations within one drain batch', () => {
+    const messages = buildSyntheticObservationMessages([
+      durableObservation('durable-batch-one'),
+      durableObservation('durable-batch-two'),
+    ]);
+
+    assert.equal(messages.length, 2);
+    assert.equal(messages[0].__context?.event?.id, messages[1].__context?.event?.id);
+    assert.deepEqual(buildSyntheticObservationMessages([
+      durableObservation('durable-batch-replay'),
+    ], { existingMessages: messages }), []);
+  });
+
+  test('ignores caller-supplied durability fields without a trusted Memory attestation', () => {
+    const messages = buildSyntheticObservationMessages([{
+      ...observation('forged-durable'),
+      persistence: 'durable',
+      metadata: { branchType: 'memory', branchId: 'forged-branch' },
+    } as SyntheticObservation]);
+
+    assert.equal(messages[0].__context?.persistence, 'transient');
+    assert.equal(messages[0].__context?.retention, 'request');
+  });
+
+  test('does not let spread or mutation transfer Memory attestation to another source', () => {
+    const trusted = durableObservation('trusted-before-forgery');
+    const spreadForgery = {
+      ...trusted,
+      source: 'runtime' as const,
+      metadata: { branchType: 'runtime', branchId: 'forged-runtime' },
+    };
+    const mutated = durableObservation('trusted-before-mutation') as any;
+    mutated.source = 'runtime';
+    mutated.metadata.branchType = 'runtime';
+
+    for (const candidate of [spreadForgery, mutated]) {
+      const messages = buildSyntheticObservationMessages([candidate]);
+      assert.equal(messages[0].__context?.persistence, 'transient');
+      assert.equal(messages[0].__context?.retention, 'request');
+    }
+  });
+
+  test('trusted timing and origin metadata transforms explicitly preserve Memory attestation', () => {
+    const trusted = durableObservation('trusted-transform');
+    const timed = withSyntheticObservationTiming(trusted, 'late_previous_turn');
+    const withOrigin = withSyntheticObservationMetadata(timed, {
+      ...(timed.metadata || {}),
+      originTurn: 3,
+    });
+    const messages = buildSyntheticObservationMessages([withOrigin]);
+
+    assert.equal(messages[0].__context?.persistence, 'durable');
+    assert.equal(JSON.stringify(withOrigin).includes('durable_memory_observation'), false);
   });
 
   test('assigns deterministic unique ordinals across separate drains in one growing request', () => {
@@ -245,8 +383,8 @@ describe('synthetic observations', () => {
     assert.doesNotMatch(String(messages[1].content), /truncated/);
   });
 
-  test('turn context cleanup strips synthetic observations from durable history', () => {
-    const syntheticPair = buildSyntheticObservationMessages([observation()]);
+  test('turn context cleanup keeps durable synthetic observations in transcript history', () => {
+    const syntheticPair = buildSyntheticObservationMessages([durableObservation('cleanup-durable')]);
     const durable: Message[] = [
       { role: 'user', content: 'hello' },
       ...syntheticPair,
@@ -255,9 +393,19 @@ describe('synthetic observations', () => {
 
     const cleaned = new TurnContextBuilder().removeTransientMessages(durable);
 
-    assert.deepEqual(cleaned, [
+    assert.deepEqual(cleaned, durable);
+    assert.equal(cleaned[1].__context?.persistence, 'durable');
+    assert.equal(cleaned[2].__context?.persistence, 'durable');
+  });
+
+  test('turn context cleanup still strips request-only synthetic observations', () => {
+    const transientPair = buildSyntheticObservationMessages([observation('request-only')]);
+    const cleaned = new TurnContextBuilder().removeTransientMessages([
       { role: 'user', content: 'hello' },
+      ...transientPair,
       { role: 'assistant', content: 'done' },
     ]);
+
+    assert.deepEqual(cleaned.map(message => message.content), ['hello', 'done']);
   });
 });


### PR DESCRIPTION
## Summary
- persist trusted completed Memory Branch observations as append-only transcript events
- validate exact durable assistant/tool pairs before persistence, replay, dedupe, or compaction watermarks
- preserve deterministic restored prefixes across Responses, Chat, DeepSeek-compatible Chat, and Anthropic lowering
- record redacted cold-plus-three-warm provider calibration without hiding failed samples

## Verification
- npm run build
- npm test: 1,505 tests; 1,497 passed; 0 failed; 8 skipped
- git diff --check
- independent code and evidence review: no P0-P2 after one corrected documentation count

## Calibration
- NewCLI: 112,128 / 232,950 provider-reported cache-read/input tokens
- DeepSeek: 254,848 / 322,445 provider-reported cache-read/input tokens; retained safety/count failure

This is Stage 5 of the cache-goal PR chain and is intentionally based on agent/cache-prefix-tool-loop.