### PR TITLE
Stage 6: harden device authorization snapshots and routing

### DIFF
--- a/docs/evidence/cache-stage6-device-authorization-snapshots-2026-08-02.md
+++ b/docs/evidence/cache-stage6-device-authorization-snapshots-2026-08-02.md
@@ -1,0 +1,77 @@
+# Stage 6 device authorization snapshots and remote routing — 2026-08-02
+
+This is a redacted capability and security record. It contains no credentials, provider endpoints,
+prompt bodies, response bodies, device identifiers from a live account, or private CatsCo traffic.
+This stage does not claim progress toward the 94% cache acceptance threshold.
+
+## Scope closed in this stage
+
+- Canonical CatsCo `device_grants` is represented as a complete, scope-bound snapshot. Presence is
+  significant: empty, revoked, all-invalid, and malformed containers clear prior device authority.
+  A missing field remains backward-compatible and does not invent an update.
+- Pending messages atomically replace device grants instead of unioning them. Higher revisions win,
+  delayed lower revisions cannot restore old permissions, semantically identical equal revisions are
+  idempotent across grant/operation ordering, and true equal-revision conflicts fail closed.
+- When a versioned snapshot is followed by an unversioned snapshot, ordering cannot be proven, so
+  authority is cleared rather than retaining a potentially broader grant. Local file grants remain a
+  separate additive capability and are not affected by device-authority replacement.
+- Runtime target routes are discovery hints only. Named participants and `speaker_default` must also
+  resolve an active, unexpired, server-canonical grant bound to the current session, topic, actor,
+  agent, owner, device, and requested operation. Dispatch repeats the authorization and validates the
+  exact tool/operation pair, preventing a resolved route from being forged or mutated later.
+- Group capability is preserved: a different participant's device remains usable only through the
+  existing server-canonical `channel_identity_link` delegation path. Ordinary cross-user grants and
+  Thin RPC envelopes are rejected.
+- Thin Tool RPC now uses a distinct `thin_tool_rpc_authority_v1` capability. The source exposes the
+  strict transport only after server negotiation, and the target advertises the same capability in
+  device registration. Without that end-to-end contract, routing falls back to negotiated Device RPC
+  or fails before remote execution.
+- Authority-v1 requests and results bind protocol version, grant, session/topic, actor/owner, identity
+  source, agent, device, operation, and tool. Missing, stripped, expired, mismatched, unsupported, or
+  overlong envelopes are rejected at the receiver before tool execution and at the source before a
+  result is accepted.
+- The receiver keeps a bounded replay cache with in-flight protection and a five-minute tombstone.
+  Concurrent or repeated delivery of the
+  same request ID and canonical envelope reuses one execution; a conflicting envelope is rejected,
+  and cache saturation fails closed without evicting an unexpired request that could then run twice.
+
+## Compatibility behavior
+
+- Legacy servers advertising only `thin_tool_rpc` do not receive authority-v1 Thin requests. If they
+  advertise `device_rpc`, the already validated route uses that transport; otherwise the request is
+  reported unavailable before a remote side effect.
+- A legacy source sent to a new receiver, or a server that strips authority-v1 fields, is rejected
+  before local file or shell tools execute.
+- The new-source/old-target ambiguous-success case is excluded by the authority-v1 server contract:
+  the feature means the server routes only to a target that advertised the same device capability.
+- Existing first-party Cats messages with a canonical grants array keep their full supported
+  operations. The fail-closed cases are limited to contradictory, malformed, stale, or unverifiably
+  ordered authority.
+
+## Verification
+
+- `npm run build`: passed.
+- Official `npm test`: 1,524 tests; 1,516 passed; 0 failed; 0 cancelled; 8 skipped.
+- Coverage includes explicit empty and malformed revocation, atomic downscope, expired replacement,
+  delayed and unversioned ordering, equal-revision idempotence/conflict, group delegation, route and
+  dispatch revalidation, old/new/stripped Thin protocol cases, Device RPC fallback, complete result
+  binding, concurrent/replayed/conflicting request IDs, and a long execution crossing its original
+  request expiry without losing the in-flight replay tombstone.
+- The compiled application was started with an isolated data directory. The Dashboard root and
+  `/api/status` both returned HTTP 200, after which the process stopped normally and the temporary
+  directory was removed.
+- Independent read-only snapshot review approved the final snapshot/queue implementation with no
+  residual P0-P2 finding. Independent route/RPC review identified cross-user receiver validation,
+  mixed-version execution ambiguity, and replay lifecycle gaps; after correction and re-testing, it
+  also approved the final implementation with no residual P0-P2 finding.
+- No dashboard or other UI files changed, so desktop/mobile visual and interaction testing was not
+  applicable.
+- `git diff --check` and a repository-diff secret scan are required again immediately before commit.
+
+## Cache relevance and remaining work
+
+This stage secures a core capability that future cache benchmarks must exercise, but it intentionally
+does not reshape provider-visible prompts or use provider cache-read usage as evidence. Later benchmark
+stages must vary device authorization, participant targeting, revocation, fallback transport, and
+session recovery while preserving a stable cacheable prefix. Cold diagnostics must remain separate
+from three consecutive warm qualification rounds.

--- a/src/catscompany/client.ts
+++ b/src/catscompany/client.ts
@@ -71,9 +71,23 @@ export interface CatsThinToolRpcMessage {
   id?: string;
   type: 'request' | 'result';
   request_id: string;
+  authority_version?: string;
   target_owner_user_id?: string;
   target_device_id?: string;
+  grant_id?: string;
+  session_key?: string;
+  topic_id?: string;
+  topic_type?: string;
+  actor_user_id?: string;
+  owner_user_id?: string;
+  identity_source?: string;
+  agent_id?: string;
+  agent_body_id?: string;
+  operation?: string;
   device_id?: string;
+  device_display_name?: string;
+  device_body_id?: string;
+  device_installation_id?: string;
   tool_name?: string;
   payload?: Record<string, unknown>;
   result?: unknown;
@@ -217,7 +231,10 @@ export class CatsClient extends EventEmitter {
   private reconnectAttempts = 0;
   private subscribedTopics = new Set<string>();
   private supportsClientMessageDedupe = false;
+  public supportsDeviceRpc = false;
   public supportsThinToolRpc = false;
+  /** Server guarantee: routes authority-v1 requests only to targets advertising the same capability. */
+  public supportsThinToolRpcAuthorityV1 = false;
   private awaitingReady = false;
 
   public uid = '';
@@ -249,7 +266,9 @@ export class CatsClient extends EventEmitter {
 
     Logger.info(`[CatsCompany] 正在连接: ${this.config.serverUrl}, apiKey=${maskSecret(this.config.apiKey)}, bodyId=${bodyId}`);
     this.supportsClientMessageDedupe = false;
+    this.supportsDeviceRpc = false;
     this.supportsThinToolRpc = false;
+    this.supportsThinToolRpcAuthorityV1 = false;
     this.ws = new WebSocket(this.config.serverUrl, {
       headers: {
         'X-API-Key': this.config.apiKey,
@@ -327,13 +346,18 @@ export class CatsClient extends EventEmitter {
         if (this.supportsClientMessageDedupe) {
           Logger.info('[CatsCompany] 服务端支持 client_msg_id 幂等发送');
         }
-        if (Array.isArray(msg.ctrl.params?.features) && msg.ctrl.params.features.includes('device_rpc')) {
+        const features = Array.isArray(msg.ctrl.params?.features) ? msg.ctrl.params.features : [];
+        this.supportsDeviceRpc = features.includes('device_rpc');
+        if (this.supportsDeviceRpc) {
           Logger.info('[CatsCompany] 服务端支持 device_rpc 远程设备传输');
         }
-        this.supportsThinToolRpc = Array.isArray(msg.ctrl.params?.features)
-          && msg.ctrl.params.features.includes('thin_tool_rpc');
+        this.supportsThinToolRpc = features.includes('thin_tool_rpc');
         if (this.supportsThinToolRpc) {
           Logger.info('[CatsCompany] 服务端支持 thin_tool_rpc 轻量工具传输');
+        }
+        this.supportsThinToolRpcAuthorityV1 = features.includes('thin_tool_rpc_authority_v1');
+        if (this.supportsThinToolRpcAuthorityV1) {
+          Logger.info('[CatsCompany] 服务端支持 thin_tool_rpc_authority_v1 端到端授权协议');
         }
         this.emit('ready', { uid: this.uid, name: this.name });
         this.autoAcceptFriendRequests().catch(console.error);
@@ -1108,9 +1132,22 @@ function deviceRpcResultMatchesPending(result: CatsDeviceRpcMessage, request: Ca
 }
 
 function thinToolRpcResultMatchesPending(result: CatsThinToolRpcMessage, request: CatsThinToolRpcMessage): boolean {
-  return deviceRpcPresentFieldMatches(result.target_owner_user_id, request.target_owner_user_id)
+  return deviceRpcPresentFieldMatches(result.authority_version, request.authority_version)
+    && deviceRpcPresentFieldMatches(result.target_owner_user_id, request.target_owner_user_id)
     && deviceRpcPresentFieldMatches(result.target_device_id, request.target_device_id)
-    && deviceRpcPresentFieldMatches(result.device_id, request.target_device_id)
+    && deviceRpcPresentFieldMatches(result.grant_id, request.grant_id)
+    && deviceRpcPresentFieldMatches(result.session_key, request.session_key)
+    && deviceRpcPresentFieldMatches(result.topic_id, request.topic_id)
+    && deviceRpcPresentFieldMatches(result.topic_type, request.topic_type)
+    && deviceRpcPresentFieldMatches(result.actor_user_id, request.actor_user_id)
+    && deviceRpcPresentFieldMatches(result.owner_user_id, request.owner_user_id)
+    && deviceRpcPresentFieldMatches(result.identity_source, request.identity_source)
+    && deviceRpcPresentFieldMatches(result.agent_id, request.agent_id)
+    && deviceRpcPresentFieldMatches(result.agent_body_id, request.agent_body_id)
+    && deviceRpcPresentFieldMatches(result.operation, request.operation)
+    && deviceRpcPresentFieldMatches(result.device_id, request.device_id || request.target_device_id)
+    && deviceRpcPresentFieldMatches(result.device_body_id, request.device_body_id)
+    && deviceRpcPresentFieldMatches(result.device_installation_id, request.device_installation_id)
     && deviceRpcPresentFieldMatches(result.tool_name, request.tool_name);
 }
 

--- a/src/catscompany/device-grants.ts
+++ b/src/catscompany/device-grants.ts
@@ -6,8 +6,10 @@ import type {
   MessageSource,
   MessageTopicType,
   ScopedDeviceGrant,
+  ScopedDeviceGrantSnapshot,
 } from '../types/session-identity';
 import { isDelegatedDeviceGrant } from '../core/device-grants';
+import { Logger } from '../utils/logger';
 
 type UnknownRecord = Record<string, unknown>;
 
@@ -15,21 +17,49 @@ export function extractCatsCoDeviceGrants(
   metadata: Record<string, unknown> | undefined,
   scope: ExecutionScope,
 ): ScopedDeviceGrant[] | undefined {
+  const snapshot = extractCatsCoDeviceGrantSnapshot(metadata, scope);
+  return snapshot && snapshot.grants.length > 0 ? snapshot.grants : undefined;
+}
+
+/** Preserve explicit empty/revoked/invalid lists as a fail-closed snapshot. */
+export function extractCatsCoDeviceGrantSnapshot(
+  metadata: Record<string, unknown> | undefined,
+  scope: ExecutionScope,
+): ScopedDeviceGrantSnapshot | undefined {
   if (scope.identityTrust !== 'server_canonical') return undefined;
   const identity = asRecord(metadata?.catsco_identity);
   const permissions = asRecord(identity?.permissions);
   if (stringField(permissions, 'source') !== 'server_canonical_message') return undefined;
 
-  const rawGrants = arrayField(identity, 'device_grants')
-    ?? arrayField(permissions, 'device_grants');
-  if (!rawGrants || rawGrants.length === 0) return undefined;
+  const identityHasGrants = hasOwn(identity, 'device_grants');
+  const permissionsHasGrants = hasOwn(permissions, 'device_grants');
+  if (!identityHasGrants && !permissionsHasGrants) return undefined;
+  const rawValue = identityHasGrants
+    ? identity!.device_grants
+    : permissions!.device_grants;
+  const rawGrants = Array.isArray(rawValue) ? rawValue : [];
+  if (!Array.isArray(rawValue)) {
+    Logger.warning('[CatsCompany] canonical device_grants is present but is not an array; cleared device authority');
+  }
 
   const grants = rawGrants
     .map(normalizeDeviceGrant)
     .filter((grant): grant is ScopedDeviceGrant => Boolean(grant))
     .filter(grant => grantMatchesScope(grant, scope));
 
-  return grants.length > 0 ? grants : undefined;
+  return pruneUndefined({
+    kind: 'user_device_grant_snapshot',
+    source: scope.source,
+    sessionKey: scope.sessionKey,
+    topicId: scope.topicId,
+    topicType: scope.topicType,
+    actorUserId: scope.actorUserId,
+    agentId: scope.agentId,
+    agentBodyId: scope.agentBodyId,
+    identityTrust: scope.identityTrust,
+    revision: normalizeRevision(scope.channelSeq),
+    grants,
+  }) as ScopedDeviceGrantSnapshot;
 }
 
 function normalizeDeviceGrant(value: unknown): ScopedDeviceGrant | undefined {
@@ -132,9 +162,8 @@ function asRecord(value: unknown): UnknownRecord | undefined {
   return value as UnknownRecord;
 }
 
-function arrayField(record: UnknownRecord | undefined, key: string): unknown[] | undefined {
-  const value = record?.[key];
-  return Array.isArray(value) ? value : undefined;
+function hasOwn(record: UnknownRecord | undefined, key: string): boolean {
+  return Boolean(record && Object.prototype.hasOwnProperty.call(record, key));
 }
 
 function stringField(record: UnknownRecord | undefined, key: string): string | undefined {
@@ -152,6 +181,11 @@ function numberField(record: UnknownRecord, key: string): number | undefined {
     if (Number.isFinite(parsed) && parsed >= 0) return parsed;
   }
   return undefined;
+}
+
+function normalizeRevision(value: unknown): number | undefined {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value <= 0) return undefined;
+  return value;
 }
 
 function pruneUndefined<T>(value: T): T {

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -11,7 +11,8 @@ import { extractContentBlocks } from './content-blocks';
 import { createCatsCoMessageEnvelope, createExecutionScope } from './message-envelope';
 import { logCatsCoExecutionContextDiagnostics } from './execution-context-diagnostics';
 import { createCatsCoAttachmentGrant, createCatsCoLocalDeviceGrant } from './local-file-grants';
-import { extractCatsCoDeviceGrants } from './device-grants';
+import { extractCatsCoDeviceGrantSnapshot } from './device-grants';
+import { deviceGrantSnapshotCanonicalValue } from '../core/device-grants';
 import { extractCatsCoDeviceSelection } from './device-selection';
 import { extractCatsCoRuntimeContext } from './runtime-context';
 import { MessageSessionManager } from '../core/message-session-manager';
@@ -30,9 +31,9 @@ import { ChannelCallbacks, DeviceRpcTransport, TargetRoutes, ThinToolRpcTranspor
 import { ContentBlock } from '../types';
 import type { PendingUserInput } from '../core/conversation-runner';
 import type { StreamRetryInfo } from '../providers/provider';
-import type { DeviceGrantOperation, ExecutionScope, ScopedDeviceGrant, ScopedDeviceSelection, ScopedLocalDeviceGrant, ScopedLocalFileGrant } from '../types/session-identity';
+import type { DeviceGrantOperation, ExecutionScope, ScopedDeviceGrant, ScopedDeviceGrantSnapshot, ScopedDeviceSelection, ScopedLocalDeviceGrant, ScopedLocalFileGrant } from '../types/session-identity';
 import { AdapterRuntimeBundle, createAdapterRuntime } from '../runtime/adapter-runtime';
-import { randomUUID } from 'crypto';
+import { createHash, randomUUID } from 'crypto';
 import { hostname, platform } from 'os';
 import { ConfigManager } from '../utils/config';
 import { resolvePrimaryModelVisionCapability } from '../utils/model-capabilities';
@@ -96,6 +97,7 @@ interface QueuedMessage {
   seq: number;
   executionScope: ParsedCatsMessage['executionScope'];
   deviceGrants?: ScopedDeviceGrant[];
+  deviceGrantSnapshot?: ScopedDeviceGrantSnapshot;
   deviceSelection?: ScopedDeviceSelection;
   targetRoutes?: TargetRoutes;
   localFileGrants?: ScopedLocalFileGrant[];
@@ -141,6 +143,13 @@ interface BackgroundSubAgentCompletionBatch {
   timer?: ReturnType<typeof setTimeout>;
 }
 
+interface ThinToolRpcReplayEntry {
+  fingerprint: string;
+  retainUntil: number;
+  settled: boolean;
+  execution: Promise<ToolExecutionResult>;
+}
+
 const TYPING_HEARTBEAT_INTERVAL_MS = 5_000;
 const BACKGROUND_SUBAGENT_COMPLETION_DEBOUNCE_MS = 1_500;
 const BACKGROUND_SUBAGENT_COMPLETION_MAX_DELAY_MS = 15_000;
@@ -149,6 +158,8 @@ const NATIVE_FEISHU_CONTEXT_PAGE_SIZE = 100;
 const BACKGROUND_SUBAGENT_COMPLETION_MAX_ITEMS = 6;
 const DEVICE_REGISTRATION_REFRESH_MS = 120_000;
 const DEVICE_RPC_DEFAULT_TTL_MS = 60_000;
+const THIN_TOOL_RPC_REPLAY_CACHE_MAX = 512;
+export const CATSCOMPANY_THIN_TOOL_RPC_AUTHORITY_CAPABILITY = 'thin_tool_rpc_authority_v1';
 const HIDDEN_CATS_TOOL_PROGRESS = new Set([
   'send_text',
   'send_file',
@@ -204,6 +215,31 @@ function summarizeThinToolRpcArgs(args: any): string {
   } catch {
     return String(summary);
   }
+}
+
+function thinToolRpcRequestFingerprint(request: CatsThinToolRpcMessage): string {
+  const {
+    id: _id,
+    type: _type,
+    request_id: _requestID,
+    result: _result,
+    error: _error,
+    ...authorityAndPayload
+  } = request;
+  return createHash('sha256')
+    .update(JSON.stringify(canonicalJsonValue(authorityAndPayload)))
+    .digest('hex');
+}
+
+function canonicalJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalJsonValue);
+  if (!value || typeof value !== 'object') return value;
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .filter(([, item]) => item !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, item]) => [key, canonicalJsonValue(item)]),
+  );
 }
 
 function speakerNameFromMetadata(msg: Pick<ParsedCatsMessage, 'metadata' | 'senderId'>): string {
@@ -262,6 +298,16 @@ function stringField(record: Record<string, unknown> | undefined, key: string): 
   if (typeof value !== 'string') return undefined;
   const text = value.trim();
   return text || undefined;
+}
+
+function sameCatsCoIdentityId(left: unknown, right: unknown): boolean {
+  const normalize = (value: unknown) => String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/^usr[_:-]?/, '');
+  const normalizedLeft = normalize(left);
+  const normalizedRight = normalize(right);
+  return Boolean(normalizedLeft && normalizedRight && normalizedLeft === normalizedRight);
 }
 
 function shouldHideCatsToolProgress(toolName: string): boolean {
@@ -430,6 +476,8 @@ export class CatsCompanyBot {
   private subAgentEventRoutes = new Map<string, SubAgentEventRoute>();
   /** no-wait 子 Agent 完成后的批量回流，避免逐条唤醒主模型刷屏 */
   private subAgentCompletionBatches = new Map<string, BackgroundSubAgentCompletionBatch>();
+  /** Bounded at-most-once execution state for authority-v1 delivery retries. */
+  private thinToolRpcReplayCache = new Map<string, ThinToolRpcReplayEntry>();
   /** Bot 自身的 uid，用于过滤自己发出的消息 */
   private botUid: string | null = null;
   private connectorReady = false;
@@ -460,7 +508,10 @@ export class CatsCompanyBot {
           owner_user_id: config.ownerUserId,
           os: currentRuntimeOS(),
           status: 'online' as const,
-          capabilities: [...CATSCOMPANY_FULL_RUNTIME_DEVICE_CAPABILITIES],
+          capabilities: [
+            ...CATSCOMPANY_FULL_RUNTIME_DEVICE_CAPABILITIES,
+            CATSCOMPANY_THIN_TOOL_RPC_AUTHORITY_CAPABILITY,
+          ],
         }
       : undefined;
 
@@ -675,12 +726,18 @@ export class CatsCompanyBot {
     };
   }
 
+  private maybeBuildDeviceRpcTransport(): DeviceRpcTransport | undefined {
+    return this.bot?.supportsDeviceRpc ? this.buildDeviceRpcTransport() : undefined;
+  }
+
   private buildThinToolRpcTransport(): ThinToolRpcTransport {
     return {
       executeTool: async ({
         targetOwnerUserId,
         targetDeviceId,
         toolName,
+        operation,
+        grant,
         args,
         timeoutMs = DEVICE_RPC_DEFAULT_TTL_MS,
       }) => {
@@ -693,14 +750,29 @@ export class CatsCompanyBot {
           };
         }
         const requestID = `thin_tool_rpc_${randomUUID()}`;
+        const expiresAt = Math.min(grant.expiresAt, Date.now() + timeoutMs);
         Logger.info(`[CatsCompany][thin_tool_rpc] executeTool request: request=${requestID}, tool=${toolName}, targetOwner=${targetOwnerUserId}, targetDevice=${targetDeviceId}, args=${summarizeThinToolRpcArgs(args)}`);
         const response = await this.bot.sendThinToolRpcRequest({
           request_id: requestID,
+          authority_version: 'v1',
           target_owner_user_id: targetOwnerUserId,
           target_device_id: targetDeviceId,
+          grant_id: grant.grantId,
+          session_key: grant.sessionKey,
+          topic_id: grant.topicId,
+          topic_type: grant.topicType,
+          actor_user_id: grant.actorUserId,
+          owner_user_id: grant.ownerUserId,
+          identity_source: grant.identitySource,
+          agent_id: grant.agentId,
+          agent_body_id: grant.agentBodyId,
+          operation,
+          device_id: grant.deviceId,
+          device_body_id: grant.deviceBodyId,
+          device_installation_id: grant.deviceInstallationId,
           tool_name: toolName,
           payload: { args },
-          expires_at: Date.now() + timeoutMs,
+          expires_at: expiresAt,
         }, timeoutMs);
         Logger.info(`[CatsCompany][thin_tool_rpc] executeTool response: request=${requestID}, tool=${toolName}, hasError=${Boolean(response.error)}, hasResult=${Boolean(response.result)}`);
 
@@ -718,7 +790,7 @@ export class CatsCompanyBot {
   }
 
   private maybeBuildThinToolRpcTransport(): ThinToolRpcTransport | undefined {
-    return this.bot?.supportsThinToolRpc ? this.buildThinToolRpcTransport() : undefined;
+    return this.bot?.supportsThinToolRpcAuthorityV1 ? this.buildThinToolRpcTransport() : undefined;
   }
 
   private async handleThinToolRpcRequest(request: CatsThinToolRpcMessage): Promise<void> {
@@ -727,17 +799,60 @@ export class CatsCompanyBot {
     Logger.info(`[CatsCompany][thin_tool_rpc] target received request: request=${requestID}, tool=${request.tool_name || ''}, targetOwner=${request.target_owner_user_id || ''}, targetDevice=${request.target_device_id || ''}, device=${request.device_id || ''}`);
 
     let result: ToolExecutionResult;
-    try {
-      result = await this.executeLocalThinToolRpcTool(request);
-      Logger.info(`[CatsCompany][thin_tool_rpc] target executed request: request=${requestID}, tool=${request.tool_name || ''}, ok=${result.ok}, errorCode=${result.ok ? '' : (result.errorCode || '')}`);
-    } catch (error: any) {
+    const validationError = this.validateThinToolRpcRequest(request);
+    if (validationError) {
       result = {
         ok: false,
-        errorCode: 'TOOL_EXECUTION_ERROR',
-        message: `Thin tool RPC execution error: ${error?.message || error || 'unknown error'}`,
-        retryable: false,
+        errorCode: this.mapDeviceRpcToolErrorCode(validationError.code),
+        message: validationError.message,
       };
-      Logger.warning(`[CatsCompany][thin_tool_rpc] target execution threw: request=${requestID}, tool=${request.tool_name || ''}, error=${error?.message || error}`);
+    } else {
+      const now = Date.now();
+      const cache = this.thinToolRpcReplayCache ??= new Map<string, ThinToolRpcReplayEntry>();
+      for (const [cachedID, entry] of cache) {
+        if (entry.settled && entry.retainUntil <= now) cache.delete(cachedID);
+      }
+      const fingerprint = thinToolRpcRequestFingerprint(request);
+      const existing = cache.get(requestID);
+      if (existing && existing.fingerprint !== fingerprint) {
+        result = {
+          ok: false,
+          errorCode: 'PERMISSION_DENIED',
+          message: 'Thin tool RPC request_id was replayed with a conflicting authority envelope or payload.',
+        };
+      } else {
+        let execution = existing?.execution;
+        if (!execution && cache.size >= THIN_TOOL_RPC_REPLAY_CACHE_MAX) {
+          result = {
+            ok: false,
+            errorCode: 'TOOL_EXECUTION_ERROR',
+            message: 'Thin tool RPC replay cache is at capacity; request was not executed.',
+            retryable: true,
+          };
+        } else {
+          if (!execution) {
+            execution = this.executeAuthorizedThinToolRpcOnce(request);
+            const entry: ThinToolRpcReplayEntry = {
+              fingerprint,
+              retainUntil: Math.max(request.expires_at as number, now + 300_000),
+              settled: false,
+              execution,
+            };
+            cache.set(requestID, entry);
+            const settleEntry = () => {
+              entry.retainUntil = Math.max(entry.retainUntil, Date.now() + 300_000);
+              entry.settled = true;
+            };
+            execution.then(
+              settleEntry,
+              settleEntry,
+            );
+          } else {
+            Logger.info(`[CatsCompany][thin_tool_rpc] replay reused cached execution: request=${requestID}`);
+          }
+          result = await execution;
+        }
+      }
     }
 
     const error = result.ok
@@ -750,9 +865,22 @@ export class CatsCompanyBot {
     try {
       await this.bot.sendThinToolRpcResult({
         request_id: requestID,
+        authority_version: request.authority_version,
         target_owner_user_id: request.target_owner_user_id,
         target_device_id: request.target_device_id,
+        grant_id: request.grant_id,
+        session_key: request.session_key,
+        topic_id: request.topic_id,
+        topic_type: request.topic_type,
+        actor_user_id: request.actor_user_id,
+        owner_user_id: request.owner_user_id,
+        identity_source: request.identity_source,
+        agent_id: request.agent_id,
+        agent_body_id: request.agent_body_id,
+        operation: request.operation,
         device_id: this.localDeviceGrant?.deviceId || request.device_id || request.target_device_id,
+        device_body_id: this.localDeviceGrant?.bodyId || request.device_body_id,
+        device_installation_id: this.localDeviceGrant?.installationId || request.device_installation_id,
         tool_name: request.tool_name,
         result: error ? undefined : normalizeDeviceRpcToolResultForTransport(result),
         error,
@@ -763,12 +891,29 @@ export class CatsCompanyBot {
     }
   }
 
+  private async executeAuthorizedThinToolRpcOnce(request: CatsThinToolRpcMessage): Promise<ToolExecutionResult> {
+    try {
+      const result = await this.executeLocalThinToolRpcTool(request);
+      Logger.info(`[CatsCompany][thin_tool_rpc] target executed request: request=${request.request_id}, tool=${request.tool_name || ''}, ok=${result.ok}, errorCode=${result.ok ? '' : (result.errorCode || '')}`);
+      return result;
+    } catch (error: any) {
+      Logger.warning(`[CatsCompany][thin_tool_rpc] target execution threw: request=${request.request_id}, tool=${request.tool_name || ''}, error=${error?.message || error}`);
+      return {
+        ok: false,
+        errorCode: 'TOOL_EXECUTION_ERROR',
+        message: `Thin tool RPC execution error: ${error?.message || error || 'unknown error'}`,
+        retryable: false,
+      };
+    }
+  }
+
   private async executeLocalThinToolRpcTool(request: CatsThinToolRpcMessage): Promise<ToolExecutionResult> {
     const toolName = String(request.tool_name || '').trim();
-    if (!toolName) {
-      return { ok: false, errorCode: 'TOOL_NOT_FOUND', message: 'Thin tool RPC request missing tool_name.' };
+    const operation = this.normalizeDeviceRpcOperation(request.operation);
+    if (!operation || !isRemoteDeviceRpcTool(toolName, operation)) {
+      return { ok: false, errorCode: 'PERMISSION_DENIED', message: 'Thin tool RPC tool/operation pair is not allowed.' };
     }
-    const context = this.buildThinToolRpcToolContext(request);
+    const context = this.buildDeviceRpcToolContext(request, operation);
     const args = this.extractDeviceRpcToolArgs(request.payload);
     let result: ToolExecutionResult;
     switch (toolName) {
@@ -805,38 +950,9 @@ export class CatsCompanyBot {
     }
     return annotateToolExecutionResultWithTargetContext(result, context, {
       toolName,
-      operation: this.normalizeDeviceRpcOperation(toolName) || 'read_file',
-      cwd: this.resolveDeviceRpcTargetContextCwd(this.normalizeDeviceRpcOperation(toolName) || 'read_file', args, context.workingDirectory),
+      operation,
+      cwd: this.resolveDeviceRpcTargetContextCwd(operation, args, context.workingDirectory),
     });
-  }
-
-  private buildThinToolRpcToolContext(request: CatsThinToolRpcMessage): ToolExecutionContext {
-    const workingDirectory = this.runtimeProfile?.workingDirectory || this.runtime?.profile?.workingDirectory || process.cwd();
-    return {
-      workingDirectory,
-      workspaceRoot: workingDirectory,
-      conversationHistory: [],
-      surface: 'catscompany',
-      permissionProfile: 'relaxed',
-      localDeviceGrant: this.localDeviceGrant,
-      deviceRpcReceiver: true,
-      executionContext: {
-        schema: 'xiaoba.execution_context.v1',
-        conversation: {
-          type: 'p2p',
-          currentSpeaker: { id: String(request.target_owner_user_id || 'remote_user'), role: 'user' },
-          participants: [],
-        },
-        executionTargets: [{
-          id: 'agent_self',
-          label: this.localDeviceGrant?.deviceId || this.localDeviceGrant?.bodyId || 'current thin tool RPC receiver',
-          kind: 'agent_self',
-          status: 'ready',
-          cwd: workingDirectory,
-        }],
-        defaultTarget: 'agent_self',
-      },
-    };
   }
 
   private async handleDeviceRpcRequest(request: CatsDeviceRpcMessage): Promise<void> {
@@ -1065,6 +1181,79 @@ export class CatsCompanyBot {
     }
     if (typeof request.expires_at === 'number' && Date.now() > request.expires_at) {
       return { code: 'request_expired', message: 'Device RPC request has expired.' };
+    }
+    return undefined;
+  }
+
+  private validateThinToolRpcRequest(request: CatsThinToolRpcMessage): { code: string; message: string } | undefined {
+    if (!this.bot?.supportsThinToolRpcAuthorityV1) {
+      return { code: 'unsupported_operation', message: 'Thin tool RPC authority-v1 was not negotiated with the server.' };
+    }
+    if (!this.localDeviceGrant) {
+      return { code: 'device_not_bound', message: 'Current runtime is not bound to a CatsCo local device.' };
+    }
+    const operation = this.normalizeDeviceRpcOperation(request.operation);
+    const toolName = String(request.tool_name || '').trim();
+    if (!operation || !isRemoteDeviceRpcTool(toolName, operation)) {
+      return { code: 'unsupported_operation', message: 'Thin tool RPC tool/operation pair is not allowed.' };
+    }
+    const requiredFields: Array<[keyof CatsThinToolRpcMessage, string]> = [
+      ['authority_version', 'authority_version'],
+      ['grant_id', 'grant_id'],
+      ['session_key', 'session_key'],
+      ['topic_id', 'topic_id'],
+      ['topic_type', 'topic_type'],
+      ['actor_user_id', 'actor_user_id'],
+      ['owner_user_id', 'owner_user_id'],
+      ['identity_source', 'identity_source'],
+      ['target_owner_user_id', 'target_owner_user_id'],
+      ['target_device_id', 'target_device_id'],
+      ['device_id', 'device_id'],
+      ['operation', 'operation'],
+      ['tool_name', 'tool_name'],
+    ];
+    for (const [field, label] of requiredFields) {
+      if (!String(request[field] || '').trim()) {
+        return { code: 'invalid_request', message: `Thin tool RPC request missing ${label}.` };
+      }
+    }
+    if (request.authority_version !== 'v1') {
+      return { code: 'invalid_request', message: 'Thin tool RPC request has an unsupported authority_version.' };
+    }
+    if (request.topic_type !== 'p2p' && request.topic_type !== 'group') {
+      return { code: 'invalid_request', message: 'Thin tool RPC request has an invalid topic_type.' };
+    }
+    if (
+      !sameCatsCoIdentityId(request.target_owner_user_id, request.owner_user_id)
+      || !sameCatsCoIdentityId(request.target_owner_user_id, this.localDeviceGrant.ownerUserId)
+    ) {
+      return { code: 'target_owner_mismatch', message: 'Thin tool RPC target owner does not match this local runtime.' };
+    }
+    if (
+      !sameCatsCoIdentityId(request.actor_user_id, request.owner_user_id)
+      && String(request.identity_source || '').trim() !== 'channel_identity_link'
+    ) {
+      return {
+        code: 'permission_denied',
+        message: 'Thin tool RPC cross-user authority requires a server-canonical channel identity link.',
+      };
+    }
+    if (String(request.target_device_id || '').trim() !== String(request.device_id || '').trim()) {
+      return { code: 'target_device_mismatch', message: 'Thin tool RPC target device does not match the authorized device.' };
+    }
+    const targetError = this.validateDeviceRpcTarget(request);
+    if (targetError) return targetError;
+
+    const expiresAt = request.expires_at;
+    const now = Date.now();
+    if (typeof expiresAt !== 'number' || !Number.isFinite(expiresAt)) {
+      return { code: 'invalid_request', message: 'Thin tool RPC request missing a finite expires_at.' };
+    }
+    if (expiresAt <= now) {
+      return { code: 'request_expired', message: 'Thin tool RPC request has expired.' };
+    }
+    if (expiresAt > now + 300_000) {
+      return { code: 'invalid_request', message: 'Thin tool RPC request expiry exceeds the maximum forwarding window.' };
     }
     return undefined;
   }
@@ -1514,6 +1703,7 @@ export class CatsCompanyBot {
         seq: msg.seq,
         executionScope: msg.executionScope,
         deviceGrants: msg.deviceGrants,
+        deviceGrantSnapshot: msg.deviceGrantSnapshot,
         deviceSelection: msg.deviceSelection,
         targetRoutes: msg.targetRoutes,
         localFileGrants,
@@ -1557,9 +1747,10 @@ export class CatsCompanyBot {
           executionScope: msg.executionScope,
           localDeviceGrant: this.localDeviceGrant,
           deviceGrants: msg.deviceGrants,
+          deviceGrantSnapshot: msg.deviceGrantSnapshot,
           deviceSelection: msg.deviceSelection,
           targetRoutes: msg.targetRoutes,
-          deviceRpc: this.buildDeviceRpcTransport(),
+          deviceRpc: this.maybeBuildDeviceRpcTransport(),
           thinToolRpc: this.maybeBuildThinToolRpcTransport(),
           localFileGrants,
           runtimeFeedback,
@@ -1986,6 +2177,7 @@ export class CatsCompanyBot {
       botUid: this.botUid,
     });
     const executionScope = createExecutionScope(envelope);
+    const deviceGrantSnapshot = extractCatsCoDeviceGrantSnapshot(ctx.metadata, executionScope);
     const targetRoutes = extractCatsCoRuntimeContext(ctx.metadata);
     if (targetRoutes?.routes?.length) {
       Logger.info(`[CatsCompany][xiaoba_runtime] parsed target routes: topic=${ctx.topic}, sender=${ctx.senderId}, routes=${targetRoutes.routes.map(route => `${route.userName || route.userId || '?'}:${route.ownerUserId}/${route.deviceId}/${route.os}`).join(', ')}`);
@@ -2005,7 +2197,10 @@ export class CatsCompanyBot {
       metadata: ctx.metadata,
       envelope,
       executionScope,
-      deviceGrants: extractCatsCoDeviceGrants(ctx.metadata, executionScope),
+      deviceGrants: deviceGrantSnapshot && deviceGrantSnapshot.grants.length > 0
+        ? deviceGrantSnapshot.grants
+        : undefined,
+      deviceGrantSnapshot,
       deviceSelection: extractCatsCoDeviceSelection(ctx.metadata, executionScope),
       targetRoutes,
       file: files[0],
@@ -2077,7 +2272,7 @@ export class CatsCompanyBot {
         suppressFinalResponse,
         executionScope,
         localDeviceGrant: this.localDeviceGrant,
-        deviceRpc: this.buildDeviceRpcTransport(),
+        deviceRpc: this.maybeBuildDeviceRpcTransport(),
         thinToolRpc: this.maybeBuildThinToolRpcTransport(),
       });
       if (clearGeneration !== this.getSessionClearGeneration(sessionKey)) {
@@ -2240,7 +2435,7 @@ export class CatsCompanyBot {
         suppressFinalResponse: false,
         executionScope: batch.executionScope,
         localDeviceGrant: this.localDeviceGrant,
-        deviceRpc: this.buildDeviceRpcTransport(),
+        deviceRpc: this.maybeBuildDeviceRpcTransport(),
         thinToolRpc: this.maybeBuildThinToolRpcTransport(),
       });
       if (batch.clearGeneration !== this.getSessionClearGeneration(sessionKey)) {
@@ -2766,7 +2961,7 @@ export class CatsCompanyBot {
             localDeviceGrant: this.localDeviceGrant,
             deviceSelection: msg.deviceSelection,
             targetRoutes: msg.targetRoutes,
-            deviceRpc: this.buildDeviceRpcTransport(),
+            deviceRpc: this.maybeBuildDeviceRpcTransport(),
             thinToolRpc: this.maybeBuildThinToolRpcTransport(),
           })
           : await session.handleMessage(msg.userMessage, {
@@ -2774,9 +2969,10 @@ export class CatsCompanyBot {
             executionScope: msg.executionScope,
             localDeviceGrant: this.localDeviceGrant,
             deviceGrants: msg.deviceGrants,
+            deviceGrantSnapshot: msg.deviceGrantSnapshot,
             deviceSelection: msg.deviceSelection,
             targetRoutes: msg.targetRoutes,
-            deviceRpc: this.buildDeviceRpcTransport(),
+            deviceRpc: this.maybeBuildDeviceRpcTransport(),
             thinToolRpc: this.maybeBuildThinToolRpcTransport(),
             runtimeFeedback: msg.runtimeFeedback,
             localFileGrants: msg.localFileGrants,
@@ -2893,14 +3089,24 @@ export class CatsCompanyBot {
     Logger.info(`[${sessionKey}] 合并 ${messages.length} 条处理期间新到的用户消息`);
     const content = this.mergeQueuedMessages(messages);
     const localFileGrants = messages.flatMap(item => item.localFileGrants || []);
-    const deviceGrants = messages.flatMap(item => item.deviceGrants || []);
+    const deviceGrantSnapshot = this.selectNewestQueuedDeviceGrantSnapshot(messages);
+    const legacyDeviceGrants = deviceGrantSnapshot
+      ? undefined
+      : [...messages].reverse().find(item => item.deviceGrants !== undefined)?.deviceGrants;
     const deviceSelection = [...messages].reverse().find(item => item.deviceSelection)?.deviceSelection;
     const targetRoutes = [...messages].reverse().find(item => item.targetRoutes)?.targetRoutes;
-    if (localFileGrants.length === 0 && deviceGrants.length === 0 && !deviceSelection && !targetRoutes) return content;
+    if (
+      localFileGrants.length === 0
+      && !deviceGrantSnapshot
+      && legacyDeviceGrants === undefined
+      && !deviceSelection
+      && !targetRoutes
+    ) return content;
     return {
       content,
       localFileGrants: localFileGrants.length > 0 ? localFileGrants : undefined,
-      deviceGrants: deviceGrants.length > 0 ? deviceGrants : undefined,
+      deviceGrants: legacyDeviceGrants,
+      deviceGrantSnapshot,
       deviceSelection,
       targetRoutes,
     };
@@ -2918,6 +3124,43 @@ export class CatsCompanyBot {
       && currentScope.agentId === queuedScope.agentId
       && currentScope.agentBodyId === queuedScope.agentBodyId
       && currentScope.identityTrust === queuedScope.identityTrust;
+  }
+
+  private selectNewestQueuedDeviceGrantSnapshot(
+    messages: QueuedMessage[],
+  ): ScopedDeviceGrantSnapshot | undefined {
+    let selected: ScopedDeviceGrantSnapshot | undefined;
+    for (const message of messages) {
+      const incoming = message.deviceGrantSnapshot;
+      if (!incoming) continue;
+      if (!selected) {
+        selected = incoming;
+        continue;
+      }
+      const currentRevision = selected.revision;
+      const incomingRevision = incoming.revision;
+      if (currentRevision !== undefined && incomingRevision !== undefined) {
+        if (incomingRevision < currentRevision) continue;
+        if (incomingRevision > currentRevision) {
+          selected = incoming;
+          continue;
+        }
+        if (deviceGrantSnapshotCanonicalValue(selected) !== deviceGrantSnapshotCanonicalValue(incoming)) {
+          selected = { ...incoming, grants: [] };
+        }
+        continue;
+      }
+      if (incomingRevision !== undefined) {
+        selected = incoming;
+        continue;
+      }
+      if (currentRevision !== undefined) {
+        selected = { ...incoming, revision: currentRevision, grants: [] };
+        continue;
+      }
+      selected = incoming;
+    }
+    return selected;
   }
 
   private mergeQueuedMessages(messages: QueuedMessage[]): string | ContentBlock[] {

--- a/src/catscompany/types.ts
+++ b/src/catscompany/types.ts
@@ -1,4 +1,10 @@
-import type { ExecutionScope, MessageEnvelope, ScopedDeviceGrant, ScopedDeviceSelection } from '../types/session-identity';
+import type {
+  ExecutionScope,
+  MessageEnvelope,
+  ScopedDeviceGrant,
+  ScopedDeviceGrantSnapshot,
+  ScopedDeviceSelection,
+} from '../types/session-identity';
 import type { TargetRoutes } from '../types/tool';
 
 /**
@@ -53,6 +59,8 @@ export interface ParsedCatsMessage {
   executionScope: ExecutionScope;
   /** 服务端签发的当前 turn 用户设备授权 */
   deviceGrants?: ScopedDeviceGrant[];
+  /** 显式存在的完整授权快照；空 grants 表示撤销旧授权。 */
+  deviceGrantSnapshot?: ScopedDeviceGrantSnapshot;
   /** 服务端为当前 turn 选择的用户设备，或要求先选择设备 */
   deviceSelection?: ScopedDeviceSelection;
   targetRoutes?: TargetRoutes;

--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -2,6 +2,7 @@ import { Message } from '../types';
 import type {
   ExecutionScope,
   ScopedDeviceGrant,
+  ScopedDeviceGrantSnapshot,
   ScopedDeviceSelection,
   ScopedLocalDeviceGrant,
   ScopedLocalFileGrant,
@@ -152,6 +153,8 @@ export interface HandleMessageOptions {
   localDeviceGrant?: ScopedLocalDeviceGrant;
   /** 当前 turn 已授权的用户设备资源。 */
   deviceGrants?: ScopedDeviceGrant[];
+  /** 当前 turn 显式携带的完整设备授权快照。 */
+  deviceGrantSnapshot?: ScopedDeviceGrantSnapshot;
   /** 服务端为当前 turn 选定的用户设备。 */
   deviceSelection?: ScopedDeviceSelection;
   /** 当前 turn 可用的远程设备 RPC 通道。 */
@@ -631,6 +634,7 @@ export class AgentSession {
       let executionScope: ExecutionScope | undefined;
       let localDeviceGrant: ScopedLocalDeviceGrant | undefined;
       let deviceGrants: ScopedDeviceGrant[] | undefined;
+      let deviceGrantSnapshot: ScopedDeviceGrantSnapshot | undefined;
       let deviceSelection: ScopedDeviceSelection | undefined;
       let deviceRpc: DeviceRpcTransport | undefined;
       let thinToolRpc: ThinToolRpcTransport | undefined;
@@ -646,6 +650,7 @@ export class AgentSession {
           || 'executionScope' in callbacksOrOptions
           || 'localDeviceGrant' in callbacksOrOptions
           || 'deviceGrants' in callbacksOrOptions
+          || 'deviceGrantSnapshot' in callbacksOrOptions
           || 'deviceSelection' in callbacksOrOptions
           || 'deviceRpc' in callbacksOrOptions
           || 'thinToolRpc' in callbacksOrOptions
@@ -663,6 +668,7 @@ export class AgentSession {
           executionScope = opts.executionScope;
           localDeviceGrant = opts.localDeviceGrant;
           deviceGrants = opts.deviceGrants;
+          deviceGrantSnapshot = opts.deviceGrantSnapshot;
           deviceSelection = opts.deviceSelection;
           deviceRpc = opts.deviceRpc;
           thinToolRpc = opts.thinToolRpc;
@@ -748,6 +754,7 @@ export class AgentSession {
           executionScope,
           localDeviceGrant,
           deviceGrants,
+          deviceGrantSnapshot,
           deviceSelection,
           deviceRpc,
           thinToolRpc,

--- a/src/core/agent-turn-controller.ts
+++ b/src/core/agent-turn-controller.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'crypto';
 import type {
   ExecutionScope,
   ScopedDeviceGrant,
+  ScopedDeviceGrantSnapshot,
   ScopedDeviceSelection,
   ScopedLocalDeviceGrant,
   ScopedLocalFileGrant,
@@ -84,6 +85,7 @@ export interface RunAgentTurnParams {
   executionScope?: ExecutionScope;
   localDeviceGrant?: ScopedLocalDeviceGrant;
   deviceGrants?: ScopedDeviceGrant[];
+  deviceGrantSnapshot?: ScopedDeviceGrantSnapshot;
   deviceSelection?: ScopedDeviceSelection;
   deviceRpc?: DeviceRpcTransport;
   thinToolRpc?: ThinToolRpcTransport;
@@ -212,6 +214,7 @@ export class AgentTurnController {
         executionScope: params.executionScope,
         localDeviceGrant: params.localDeviceGrant,
         deviceGrants: params.deviceGrants,
+        deviceGrantSnapshot: params.deviceGrantSnapshot,
         deviceSelection: params.deviceSelection,
         deviceRpc: params.deviceRpc,
         thinToolRpc: params.thinToolRpc,
@@ -304,6 +307,7 @@ export class AgentTurnController {
     executionScope?: ExecutionScope;
     localDeviceGrant?: ScopedLocalDeviceGrant;
     deviceGrants?: ScopedDeviceGrant[];
+    deviceGrantSnapshot?: ScopedDeviceGrantSnapshot;
     deviceSelection?: ScopedDeviceSelection;
     deviceRpc?: DeviceRpcTransport;
     thinToolRpc?: ThinToolRpcTransport;
@@ -351,6 +355,7 @@ export class AgentTurnController {
           executionScope: options.executionScope,
           localDeviceGrant: options.localDeviceGrant,
           deviceGrants: options.deviceGrants,
+          deviceGrantSnapshot: options.deviceGrantSnapshot,
           deviceSelection: options.deviceSelection,
           deviceRpc: options.deviceRpc,
           thinToolRpc: options.thinToolRpc,

--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -1,10 +1,16 @@
 import { Message, ContentBlock, ChatConfig, ChatResponse } from '../types';
-import type { ScopedDeviceGrant, ScopedDeviceSelection, ScopedLocalFileGrant } from '../types/session-identity';
+import type {
+  ScopedDeviceGrant,
+  ScopedDeviceGrantSnapshot,
+  ScopedDeviceSelection,
+  ScopedLocalFileGrant,
+} from '../types/session-identity';
 import type { TargetRoutes } from '../types/tool';
 import { AIService } from '../utils/ai-service';
 import { ToolCall, ToolDefinition, ToolExecutionContext, ToolExecutor, ToolResult, ToolTranscriptMode } from '../types/tool';
 import { AIRequestOptions, StreamCallbacks, StreamRetryInfo } from '../providers/provider';
 import { Logger } from '../utils/logger';
+import { deviceGrantSnapshotCanonicalValue } from './device-grants';
 import { isRateLimitErrorCode } from '../utils/rate-limit-error';
 import { Metrics } from '../utils/metrics';
 import { ContextCompressor } from './context-compressor';
@@ -141,6 +147,9 @@ export interface RunResult {
 
 export interface PendingUserInput {
   content: string | ContentBlock[];
+  /** Complete replacement snapshot. Empty grants explicitly revoke prior authority. */
+  deviceGrantSnapshot?: ScopedDeviceGrantSnapshot;
+  /** Legacy pending-input compatibility; treated as a complete replacement, never a union. */
   deviceGrants?: ScopedDeviceGrant[];
   deviceSelection?: ScopedDeviceSelection;
   targetRoutes?: TargetRoutes;
@@ -733,15 +742,12 @@ export class ConversationRunner {
 
     const content = isPendingUserInput(pending) ? pending.content : pending;
     let shouldRefreshRuntimeContext = false;
-    if (isPendingUserInput(pending) && pending.deviceGrants?.length) {
-      this.toolExecutionContext = {
-        ...(this.toolExecutionContext || {}),
-        deviceGrants: [
-          ...(this.toolExecutionContext?.deviceGrants || []),
-          ...pending.deviceGrants,
-        ],
-      };
-      shouldRefreshRuntimeContext = true;
+    if (isPendingUserInput(pending)) {
+      const deviceGrantSnapshot = pending.deviceGrantSnapshot
+        ?? this.buildLegacyPendingDeviceGrantSnapshot(pending.deviceGrants);
+      if (deviceGrantSnapshot && this.applyPendingDeviceGrantSnapshot(deviceGrantSnapshot)) {
+        shouldRefreshRuntimeContext = true;
+      }
     }
     if (isPendingUserInput(pending) && pending.deviceSelection) {
       this.toolExecutionContext = {
@@ -884,6 +890,107 @@ export class ConversationRunner {
         epoch: this.episodeId,
       }));
     }
+  }
+
+  private buildLegacyPendingDeviceGrantSnapshot(
+    grants: ScopedDeviceGrant[] | undefined,
+  ): ScopedDeviceGrantSnapshot | undefined {
+    if (grants === undefined) return undefined;
+    const scope = this.toolExecutionContext?.executionScope;
+    if (!scope) return undefined;
+    return {
+      kind: 'user_device_grant_snapshot',
+      source: scope.source,
+      sessionKey: scope.sessionKey,
+      topicId: scope.topicId,
+      topicType: scope.topicType,
+      actorUserId: scope.actorUserId,
+      agentId: scope.agentId,
+      agentBodyId: scope.agentBodyId,
+      identityTrust: scope.identityTrust,
+      grants: [...grants],
+    };
+  }
+
+  private applyPendingDeviceGrantSnapshot(snapshot: ScopedDeviceGrantSnapshot): boolean {
+    const scope = this.toolExecutionContext?.executionScope;
+    if (!scope) return false;
+    const current = this.toolExecutionContext?.deviceGrantSnapshot;
+    const currentRevision = current?.revision;
+    const incomingRevision = snapshot.revision;
+
+    if (
+      currentRevision !== undefined
+      && incomingRevision !== undefined
+      && incomingRevision < currentRevision
+    ) {
+      Logger.warning(
+        `[${this.sessionLabel}] ignored stale device grant snapshot revision=${incomingRevision} current=${currentRevision}`,
+      );
+      return false;
+    }
+
+    const scopeMatches = snapshot.identityTrust === 'server_canonical'
+      && scope.identityTrust === 'server_canonical'
+      && scope.isTrusted
+      && snapshot.source === scope.source
+      && snapshot.sessionKey === scope.sessionKey
+      && snapshot.topicId === scope.topicId
+      && snapshot.topicType === scope.topicType
+      && snapshot.actorUserId === scope.actorUserId
+      && snapshot.agentId === scope.agentId
+      && snapshot.agentBodyId === scope.agentBodyId;
+    let nextSnapshot = scopeMatches
+      ? { ...snapshot, grants: [...snapshot.grants] }
+      : this.deviceGrantSnapshotForCurrentScope([], incomingRevision);
+
+    if (currentRevision !== undefined && incomingRevision === undefined) {
+      if (nextSnapshot.grants.length > 0) {
+        Logger.warning(
+          `[${this.sessionLabel}] unversioned device grant snapshot followed revision=${currentRevision}; cleared authority`,
+        );
+      }
+      nextSnapshot = this.deviceGrantSnapshotForCurrentScope([], currentRevision);
+    }
+
+    if (currentRevision !== undefined && incomingRevision === currentRevision && current) {
+      if (deviceGrantSnapshotCanonicalValue(current) === deviceGrantSnapshotCanonicalValue(nextSnapshot)) {
+        return false;
+      }
+      Logger.warning(
+        `[${this.sessionLabel}] conflicting device grant snapshot revision=${currentRevision}; cleared authority`,
+      );
+      nextSnapshot = this.deviceGrantSnapshotForCurrentScope([], currentRevision);
+    } else if (!scopeMatches) {
+      Logger.warning(`[${this.sessionLabel}] rejected device grant snapshot outside the current execution scope`);
+    }
+
+    this.toolExecutionContext = {
+      ...(this.toolExecutionContext || {}),
+      deviceGrants: [...nextSnapshot.grants],
+      deviceGrantSnapshot: nextSnapshot,
+    };
+    return true;
+  }
+
+  private deviceGrantSnapshotForCurrentScope(
+    grants: ScopedDeviceGrant[],
+    revision?: number,
+  ): ScopedDeviceGrantSnapshot {
+    const scope = this.toolExecutionContext!.executionScope!;
+    return {
+      kind: 'user_device_grant_snapshot',
+      source: scope.source,
+      sessionKey: scope.sessionKey,
+      topicId: scope.topicId,
+      topicType: scope.topicType,
+      actorUserId: scope.actorUserId,
+      agentId: scope.agentId,
+      agentBodyId: scope.agentBodyId,
+      identityTrust: scope.identityTrust,
+      revision,
+      grants,
+    };
   }
 
   private injectSyntheticObservations(messages: Message[], turn: number): void {

--- a/src/core/device-grants.ts
+++ b/src/core/device-grants.ts
@@ -5,6 +5,7 @@ import type {
   ExecutionScope,
   MessageSource,
   ScopedDeviceGrant,
+  ScopedDeviceGrantSnapshot,
   UserDevice,
   UserDeviceStatus,
 } from '../types/session-identity';
@@ -53,6 +54,44 @@ export function isDelegatedDeviceGrant(grant: Pick<ScopedDeviceGrant, 'identityT
   return grant.identityTrust === 'server_canonical'
     && grant.ownerUserId !== grant.actorUserId
     && DELEGATED_DEVICE_GRANT_IDENTITY_SOURCES.has(String(grant.identitySource || ''));
+}
+
+/** Stable equality key for idempotence/conflict checks; grant and operation ordering is non-semantic. */
+export function deviceGrantSnapshotCanonicalValue(snapshot: ScopedDeviceGrantSnapshot): string {
+  const grants = snapshot.grants
+    .map(grant => [
+      grant.grantId,
+      grant.status,
+      grant.identityTrust,
+      grant.identitySource || '',
+      grant.deviceId,
+      grant.deviceDisplayName || '',
+      grant.deviceBodyId || '',
+      grant.deviceInstallationId || '',
+      grant.ownerUserId,
+      grant.sessionKey,
+      grant.topicId,
+      grant.topicType,
+      grant.actorUserId,
+      grant.agentId || '',
+      grant.agentBodyId || '',
+      [...grant.operations].sort(),
+      grant.createdAt,
+      grant.expiresAt,
+    ])
+    .sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)));
+  return JSON.stringify([
+    snapshot.source,
+    snapshot.sessionKey,
+    snapshot.topicId,
+    snapshot.topicType,
+    snapshot.actorUserId,
+    snapshot.agentId || '',
+    snapshot.agentBodyId || '',
+    snapshot.identityTrust,
+    snapshot.revision ?? null,
+    grants,
+  ]);
 }
 
 export function createUserDevice(input: CreateUserDeviceInput): UserDevice | undefined {

--- a/src/tools/execution-router.ts
+++ b/src/tools/execution-router.ts
@@ -1,7 +1,8 @@
 import type { DeviceGrantOperation, ScopedDeviceGrant } from '../types/session-identity';
 import type { TargetRoute, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import { normalizeTargetText } from '../catscompany/runtime-context';
-import { executeRemoteDeviceRpcTool } from './device-rpc-tool';
+import { resolveDeviceGrant } from '../core/device-grants';
+import { executeRemoteDeviceRpcTool, isRemoteDeviceRpcTool } from './device-rpc-tool';
 import { TOOL_TARGET_CONTEXT_PREFIX, TOOL_TARGET_CONTEXT_SUFFIX } from './tool-target-context';
 
 export type ExecutionTargetId = 'agent_self' | string;
@@ -13,8 +14,8 @@ export type ExecutionRoute =
       mode: 'remote';
       target: ExecutionTargetId;
       label: string;
-      grant?: ScopedDeviceGrant;
-      targetOwnerUserId?: string;
+      grant: ScopedDeviceGrant;
+      targetOwnerUserId: string;
       targetDeviceId: string;
       targetDeviceDisplayName?: string;
       targetDeviceBodyId?: string;
@@ -66,11 +67,17 @@ export function resolveExecutionRoute(
 
   const runtimeRoute = findRuntimeTargetRoute(context, target);
   if (runtimeRoute.ok) {
-    if (!context.thinToolRpc) {
+    const authorization = authorizeRemoteTarget(context, {
+      operation: options.operation,
+      deviceId: runtimeRoute.route.deviceId,
+      ownerUserId: runtimeRoute.route.ownerUserId,
+    });
+    if (!authorization.ok) return authorization;
+    if (!context.thinToolRpc && !context.deviceRpc) {
       return {
         ok: false,
         errorCode: 'TARGET_UNAVAILABLE',
-        message: `Target "${target}" matched ${runtimeRoute.route.label}, but this runtime has no thin tool RPC transport.`,
+        message: `Target "${target}" matched ${runtimeRoute.route.label}, but this runtime has no negotiated authority-v1 Thin RPC or Device RPC transport.`,
       };
     }
     return {
@@ -78,9 +85,12 @@ export function resolveExecutionRoute(
       mode: 'remote',
       target,
       label: runtimeRoute.route.label,
-      targetOwnerUserId: runtimeRoute.route.ownerUserId,
-      targetDeviceId: runtimeRoute.route.deviceId,
+      grant: authorization.grant,
+      targetOwnerUserId: authorization.grant.ownerUserId,
+      targetDeviceId: authorization.grant.deviceId,
       targetDeviceDisplayName: runtimeRoute.route.label,
+      targetDeviceBodyId: authorization.grant.deviceBodyId,
+      targetDeviceInstallationId: authorization.grant.deviceInstallationId,
     };
   }
   if (runtimeRoute.reason === 'not_found' || runtimeRoute.reason === 'ambiguous') {
@@ -115,19 +125,26 @@ export function resolveExecutionRoute(
     };
   }
 
+  const authorization = authorizeRemoteTarget(context, {
+    operation: options.operation,
+    deviceId: remote.deviceId,
+    ownerUserId: remote.ownerUserId,
+  });
+  if (!authorization.ok) return authorization;
+
   if (!context.deviceRpc) {
-    if (context.thinToolRpc && remote.ownerUserId) {
+    if (context.thinToolRpc) {
       return {
         ok: true,
         mode: 'remote',
         target,
         label: remote.displayName || findTargetLabel(context, 'speaker_default') || 'current speaker device',
-        grant: remote.grant,
-        targetOwnerUserId: remote.ownerUserId,
-        targetDeviceId: remote.deviceId,
+        grant: authorization.grant,
+        targetOwnerUserId: authorization.grant.ownerUserId,
+        targetDeviceId: authorization.grant.deviceId,
         targetDeviceDisplayName: remote.displayName,
-        targetDeviceBodyId: remote.bodyId,
-        targetDeviceInstallationId: remote.installationId,
+        targetDeviceBodyId: authorization.grant.deviceBodyId,
+        targetDeviceInstallationId: authorization.grant.deviceInstallationId,
       };
     }
     return {
@@ -142,12 +159,12 @@ export function resolveExecutionRoute(
     mode: 'remote',
     target,
     label: remote.displayName || findTargetLabel(context, 'speaker_default') || 'current speaker device',
-    grant: remote.grant,
-    targetOwnerUserId: remote.ownerUserId,
-    targetDeviceId: remote.deviceId,
+    grant: authorization.grant,
+    targetOwnerUserId: authorization.grant.ownerUserId,
+    targetDeviceId: authorization.grant.deviceId,
     targetDeviceDisplayName: remote.displayName,
-    targetDeviceBodyId: remote.bodyId,
-    targetDeviceInstallationId: remote.installationId,
+    targetDeviceBodyId: authorization.grant.deviceBodyId,
+    targetDeviceInstallationId: authorization.grant.deviceInstallationId,
   };
 }
 
@@ -159,13 +176,38 @@ export async function executeRouteIfRemote(
   args: Record<string, unknown>,
 ): Promise<ToolExecutionResult | undefined> {
   if (!route.ok || route.mode !== 'remote') return undefined;
-  if (context.thinToolRpc && route.targetOwnerUserId) {
+  if (!isRemoteDeviceRpcTool(toolName, operation)) {
+    return {
+      ok: false,
+      errorCode: 'PERMISSION_DENIED',
+      message: `Remote route does not allow tool/operation pair ${toolName}/${operation}.`,
+    };
+  }
+  const authorization = authorizeRemoteTarget(context, {
+    operation,
+    deviceId: route.targetDeviceId,
+    ownerUserId: route.targetOwnerUserId,
+  });
+  if (!authorization.ok) {
+    return {
+      ok: false,
+      errorCode: authorization.errorCode,
+      message: authorization.message,
+    };
+  }
+  const grant = authorization.grant;
+  if (context.thinToolRpc) {
     const result = await context.thinToolRpc.executeTool({
-      targetOwnerUserId: route.targetOwnerUserId,
-      targetDeviceId: route.targetDeviceId,
+      targetOwnerUserId: grant.ownerUserId,
+      targetDeviceId: grant.deviceId,
       toolName,
+      operation,
+      grant,
       args: stripExecutionTargetArg(args),
-      timeoutMs: toolName === 'send_file' || toolName === 'import_file' ? 300_000 : undefined,
+      timeoutMs: remainingGrantTimeoutMs(
+        grant,
+        toolName === 'send_file' || toolName === 'import_file' ? 300_000 : undefined,
+      ),
     });
     return attachRouteTargetContext(
       stripRemoteToolTargetContext(result),
@@ -180,11 +222,11 @@ export async function executeRouteIfRemote(
   const result = await executeRemoteDeviceRpcTool(context, {
     ok: true,
     mode: 'remote',
-    grant: route.grant,
-    targetDeviceId: route.targetDeviceId,
+    grant,
+    targetDeviceId: grant.deviceId,
     targetDeviceDisplayName: route.targetDeviceDisplayName,
-    targetDeviceBodyId: route.targetDeviceBodyId,
-    targetDeviceInstallationId: route.targetDeviceInstallationId,
+    targetDeviceBodyId: grant.deviceBodyId,
+    targetDeviceInstallationId: grant.deviceInstallationId,
   }, toolName, operation, stripExecutionTargetArg(args));
   if (!result) return result;
   return attachRouteTargetContext(
@@ -278,6 +320,68 @@ function findTargetLabel(context: ToolExecutionContext, target: ExecutionTargetI
   }
   return targets.find(item => item.id === 'speaker_default')?.label
     || targets.find(item => item.kind === 'participant' && item.userId === context.executionContext?.conversation.currentSpeaker.id)?.label;
+}
+
+function authorizeRemoteTarget(
+  context: ToolExecutionContext,
+  options: {
+    operation: DeviceGrantOperation;
+    deviceId: string;
+    ownerUserId?: string;
+  },
+): ({ ok: true; grant: ScopedDeviceGrant } | Extract<ExecutionRoute, { ok: false }>) {
+  const scope = context.executionScope;
+  if (
+    context.surface !== 'catscompany'
+    || !scope
+    || scope.source !== 'catscompany'
+    || scope.identityTrust !== 'server_canonical'
+    || !scope.isTrusted
+  ) {
+    return {
+      ok: false,
+      errorCode: 'PERMISSION_DENIED',
+      message: 'Remote device routing requires the current server-canonical CatsCo execution scope.',
+    };
+  }
+  const decision = resolveDeviceGrant(context, {
+    operation: options.operation,
+    deviceId: options.deviceId,
+  });
+  if (!decision.ok) return decision;
+  if (decision.grant.identityTrust !== 'server_canonical') {
+    return {
+      ok: false,
+      errorCode: 'PERMISSION_DENIED',
+      message: 'Remote device routing requires a server-canonical device grant.',
+    };
+  }
+  if (options.ownerUserId && !sameCatsCoUserId(decision.grant.ownerUserId, options.ownerUserId)) {
+    return {
+      ok: false,
+      errorCode: 'PERMISSION_DENIED',
+      message: 'The current device grant owner does not match the requested runtime route owner.',
+    };
+  }
+  return { ok: true, grant: decision.grant };
+}
+
+function sameCatsCoUserId(left: string | undefined, right: string | undefined): boolean {
+  const normalize = (value: string | undefined) => String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/^usr[_:-]?/, '');
+  const normalizedLeft = normalize(left);
+  const normalizedRight = normalize(right);
+  return Boolean(normalizedLeft && normalizedRight && normalizedLeft === normalizedRight);
+}
+
+function remainingGrantTimeoutMs(grant: ScopedDeviceGrant, requested?: number): number {
+  const remaining = Math.max(1, grant.expiresAt - Date.now());
+  const requestedTimeout = typeof requested === 'number' && Number.isFinite(requested) && requested > 0
+    ? requested
+    : 60_000;
+  return Math.max(1, Math.min(remaining, requestedTimeout));
 }
 
 function findRuntimeTargetRoute(context: ToolExecutionContext, target: string): (

--- a/src/types/session-identity.ts
+++ b/src/types/session-identity.ts
@@ -148,6 +148,26 @@ export interface ScopedDeviceGrant {
   expiresAt: number;
 }
 
+/**
+ * Complete device-authority state carried by one trusted channel message.
+ * Presence is significant: an empty grants array revokes every prior grant
+ * for this scope. The snapshot is runtime authority and is never restored
+ * from transcript history.
+ */
+export interface ScopedDeviceGrantSnapshot {
+  kind: 'user_device_grant_snapshot';
+  source: MessageSource;
+  sessionKey: string;
+  topicId: string;
+  topicType: MessageTopicType;
+  actorUserId: string;
+  agentId?: string;
+  agentBodyId?: string;
+  identityTrust: IdentityTrustLevel;
+  revision?: number;
+  grants: ScopedDeviceGrant[];
+}
+
 export interface DeviceSelectionCandidate {
   deviceId: string;
   displayName?: string;

--- a/src/types/tool.ts
+++ b/src/types/tool.ts
@@ -2,6 +2,7 @@ import { ContentBlock } from './index';
 import type {
   ExecutionScope,
   ScopedDeviceGrant,
+  ScopedDeviceGrantSnapshot,
   ScopedDeviceSelection,
   ScopedLocalDeviceGrant,
   ScopedLocalFileGrant,
@@ -125,6 +126,8 @@ export interface ThinToolRpcRequest {
   targetOwnerUserId: string;
   targetDeviceId: string;
   toolName: string;
+  operation: ScopedDeviceGrant['operations'][number];
+  grant: ScopedDeviceGrant;
   args: Record<string, unknown>;
   timeoutMs?: number;
 }
@@ -236,6 +239,8 @@ export interface ToolExecutionContext {
   localDeviceGrant?: ScopedLocalDeviceGrant;
   /** 当前 turn 已授权的用户设备资源，供未来远程设备工具校验。 */
   deviceGrants?: ScopedDeviceGrant[];
+  /** 当前 turn 的完整设备授权快照；仅用于同一 run 内的单调替换。 */
+  deviceGrantSnapshot?: ScopedDeviceGrantSnapshot;
   /** 服务端为当前 turn 选定的用户设备，或明确要求先选择设备。 */
   deviceSelection?: ScopedDeviceSelection;
   /** CatsCo 远程设备 RPC 通道。工具只能通过窄接口请求后端选定设备执行。 */

--- a/tests/catscompany-client-body-id.test.ts
+++ b/tests/catscompany-client-body-id.test.ts
@@ -538,7 +538,6 @@ describe('CatsCompany client body identity', () => {
       client.once('ready', () => resolve());
       client.connect();
     });
-
     await assert.rejects(
       () => client.sendDeviceRpcRequest({
         request_id: 'rpc-early-result-nack',
@@ -671,6 +670,8 @@ describe('CatsCompany client body identity', () => {
       client.once('ready', () => resolve());
       client.connect();
     });
+    assert.equal(client.supportsThinToolRpc, true);
+    assert.equal(client.supportsThinToolRpcAuthorityV1, false);
 
     await assert.rejects(
       () => client.sendThinToolRpcRequest({
@@ -701,7 +702,7 @@ describe('CatsCompany client body identity', () => {
               params: {
                 build: 'catscompany',
                 ver: '0.1.0',
-                features: ['client_msg_id', 'thin_tool_rpc'],
+                features: ['client_msg_id', 'thin_tool_rpc', 'thin_tool_rpc_authority_v1'],
                 uid: 'usr42',
                 name: 'Agent',
               },
@@ -715,6 +716,10 @@ describe('CatsCompany client body identity', () => {
             thin_tool_rpc: {
               type: 'result',
               request_id: msg.thin_tool_rpc.request_id,
+              target_owner_user_id: msg.thin_tool_rpc.target_owner_user_id,
+              target_device_id: msg.thin_tool_rpc.target_device_id,
+              device_id: msg.thin_tool_rpc.device_id,
+              tool_name: msg.thin_tool_rpc.tool_name,
               result: { ok: true },
             },
           }));
@@ -734,12 +739,24 @@ describe('CatsCompany client body identity', () => {
       client.once('ready', () => resolve());
       client.connect();
     });
+    assert.equal(client.supportsThinToolRpcAuthorityV1, true);
 
     await assert.rejects(
       () => client.sendThinToolRpcRequest({
         request_id: 'thin-missing-scope',
+        authority_version: 'v1',
         target_owner_user_id: 'usr7',
         target_device_id: 'install-test',
+        grant_id: 'grant-1',
+        session_key: 'session:v2:catscompany:p2p:p2p_7_42:agent:usr42',
+        topic_id: 'p2p_7_42',
+        topic_type: 'p2p',
+        actor_user_id: 'usr7',
+        owner_user_id: 'usr7',
+        identity_source: 'catsco_identity.permissions.device_grants',
+        agent_id: 'usr42',
+        operation: 'read_file',
+        device_id: 'install-test',
         tool_name: 'read_file',
         payload: { args: { file_path: '/tmp/a.txt' } },
       }),

--- a/tests/catscompany-device-rpc-tools.test.ts
+++ b/tests/catscompany-device-rpc-tools.test.ts
@@ -7,7 +7,12 @@ import { CatsCompanyBot } from '../src/catscompany';
 import type { CatsDeviceRpcMessage, CatsThinToolRpcMessage } from '../src/catscompany/client';
 import type { ScopedDeviceGrant } from '../src/types/session-identity';
 
-function botWithDevice(captured: { result?: any; uploaded?: { path: string; type: string; bytes: Buffer } }): any {
+function botWithDevice(captured: {
+  result?: any;
+  thinResult?: any;
+  thinResults?: any[];
+  uploaded?: { path: string; type: string; bytes: Buffer };
+}): any {
   const bot = Object.create(CatsCompanyBot.prototype) as any;
   bot.localDeviceGrant = {
     kind: 'catscompany_body',
@@ -19,8 +24,15 @@ function botWithDevice(captured: { result?: any; uploaded?: { path: string; type
     createdAt: Date.now(),
   };
   bot.bot = {
+    supportsDeviceRpc: true,
+    supportsThinToolRpc: true,
+    supportsThinToolRpcAuthorityV1: true,
     sendDeviceRpcResult: async (result: any) => {
       captured.result = result;
+    },
+    sendThinToolRpcResult: async (result: any) => {
+      captured.thinResult = result;
+      captured.thinResults?.push(result);
     },
     uploadFile: async (filePath: string, type: string) => {
       const bytes = fs.readFileSync(filePath);
@@ -82,6 +94,33 @@ function serverGrant(overrides: Partial<ScopedDeviceGrant> = {}): ScopedDeviceGr
     operations: ['read_file', 'resolve_common_directory', 'glob', 'grep', 'execute_shell'],
     createdAt: Date.now(),
     expiresAt: Date.now() + 60_000,
+    ...overrides,
+  };
+}
+
+function thinRequest(overrides: Partial<CatsThinToolRpcMessage> = {}): CatsThinToolRpcMessage {
+  return {
+    type: 'request',
+    request_id: 'thin-import-file-1',
+    authority_version: 'v1',
+    target_owner_user_id: 'usr7',
+    target_device_id: 'install-device',
+    grant_id: 'grant-thin-1',
+    session_key: 'session:v2:catscompany:p2p:p2p_7_43:agent:usr43',
+    topic_id: 'p2p_7_43',
+    topic_type: 'p2p',
+    actor_user_id: 'usr7',
+    owner_user_id: 'usr7',
+    identity_source: 'metadata.catsco_identity',
+    agent_id: 'usr43',
+    agent_body_id: 'body-agent',
+    operation: 'send_file',
+    device_id: 'install-device',
+    device_body_id: 'body-device',
+    device_installation_id: 'install-device',
+    tool_name: 'import_file',
+    expires_at: Date.now() + 60_000,
+    payload: {},
     ...overrides,
   };
 }
@@ -245,6 +284,38 @@ describe('CatsCompany Device RPC file tools', () => {
     assert.equal(captured[0].timeoutMs, 12_345);
   });
 
+  test('forwards the validated grant envelope through thin tool RPC', async () => {
+    let captured: any;
+    const bot = Object.create(CatsCompanyBot.prototype) as any;
+    bot.bot = {
+      sendThinToolRpcRequest: async (payload: any, timeoutMs: number) => {
+        captured = { payload, timeoutMs };
+        return { type: 'result', request_id: payload.request_id, result: { ok: true, content: 'ok' } };
+      },
+    };
+    const grant = serverGrant({ deviceId: 'install-device', deviceInstallationId: 'install-device' });
+    const result = await bot.buildThinToolRpcTransport().executeTool({
+      targetOwnerUserId: grant.ownerUserId,
+      targetDeviceId: grant.deviceId,
+      toolName: 'read_file',
+      operation: 'read_file',
+      grant,
+      args: { file_path: 'notes.txt' },
+      timeoutMs: 12_345,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(captured.payload.authority_version, 'v1');
+    assert.equal(captured.payload.grant_id, grant.grantId);
+    assert.equal(captured.payload.session_key, grant.sessionKey);
+    assert.equal(captured.payload.actor_user_id, grant.actorUserId);
+    assert.equal(captured.payload.owner_user_id, grant.ownerUserId);
+    assert.equal(captured.payload.operation, 'read_file');
+    assert.equal(captured.payload.device_id, grant.deviceId);
+    assert.ok(captured.payload.expires_at <= grant.expiresAt);
+    assert.equal(captured.timeoutMs, 12_345);
+  });
+
   test('executes resolve_common_directory on the target local device and returns a normalized result', async () => {
     const captured: { result?: any } = {};
     const bot = botWithDevice(captured);
@@ -295,15 +366,9 @@ describe('CatsCompany Device RPC file tools', () => {
     const filePath = path.join(dir, 'original.bin');
     const original = Buffer.from([0, 255, 1, 2, 3, 128]);
     fs.writeFileSync(filePath, original);
-    const request: CatsThinToolRpcMessage = {
-      type: 'request',
-      request_id: 'thin-import-file-1',
-      target_owner_user_id: 'usr7',
-      target_device_id: 'install-device',
-      device_id: 'install-device',
-      tool_name: 'import_file',
+    const request = thinRequest({
       payload: { args: { file_path: filePath, file_name: 'download.bin' } },
-    };
+    });
 
     const result = await bot.executeLocalThinToolRpcTool(request);
 
@@ -317,6 +382,156 @@ describe('CatsCompany Device RPC file tools', () => {
       size: original.length,
       type: 'file',
     });
+  });
+
+  test('fails closed for malformed, mismatched, expired, or unsupported thin RPC authority', () => {
+    const bot = botWithDevice({});
+    assert.equal(bot.validateThinToolRpcRequest(thinRequest()), undefined);
+
+    const cases: Array<[string, Partial<CatsThinToolRpcMessage>, RegExp]> = [
+      ['missing grant', { grant_id: undefined }, /grant_id/],
+      ['wrong owner', { target_owner_user_id: 'usr8' }, /owner/],
+      ['undelegated cross-user actor', { actor_user_id: 'usr8' }, /channel identity link/],
+      ['wrong device', { target_device_id: 'other-device' }, /device/],
+      ['expired', { expires_at: Date.now() - 1 }, /expired/],
+      ['long expiry', { expires_at: Date.now() + 600_000 }, /expiry/],
+      ['wrong operation', { operation: 'read_file' }, /pair/],
+      ['unsupported tool', { tool_name: 'spawn_subagent' }, /pair/],
+    ];
+    for (const [name, overrides, pattern] of cases) {
+      const result = bot.validateThinToolRpcRequest(thinRequest(overrides));
+      assert.ok(result, name);
+      assert.match(result.message, pattern, name);
+    }
+  });
+
+  test('accepts only channel-linked group delegation at the thin RPC receiver', async () => {
+    const captured: { thinResult?: any } = {};
+    const bot = botWithDevice(captured);
+    const groupDelegation = thinRequest({
+      request_id: 'thin-group-delegation',
+      session_key: 'session:v2:catscompany:group:room_7:agent:usr43',
+      topic_id: 'room_7',
+      topic_type: 'group',
+      actor_user_id: 'usr8',
+      identity_source: 'channel_identity_link',
+      operation: 'resolve_common_directory',
+      tool_name: 'resolve_common_directory',
+      payload: { args: { directory: 'home' } },
+    });
+
+    assert.equal(bot.validateThinToolRpcRequest(groupDelegation), undefined);
+    await bot.handleThinToolRpcRequest(groupDelegation);
+    assert.equal(captured.thinResult?.error, undefined);
+    assert.equal(captured.thinResult?.result?.ok, true);
+  });
+
+  test('does not expose or execute strict Thin RPC across an unnegotiated or stripped protocol', async () => {
+    const captured: { thinResults?: any[] } = { thinResults: [] };
+    const bot = botWithDevice(captured);
+    let executions = 0;
+    bot.executeLocalThinToolRpcTool = async () => {
+      executions += 1;
+      return { ok: true, content: 'must not execute' };
+    };
+
+    bot.bot.supportsThinToolRpcAuthorityV1 = false;
+    assert.equal(bot.maybeBuildThinToolRpcTransport(), undefined);
+    assert.ok(bot.maybeBuildDeviceRpcTransport());
+    await bot.handleThinToolRpcRequest(thinRequest({ request_id: 'thin-unnegotiated' }));
+
+    bot.bot.supportsThinToolRpcAuthorityV1 = true;
+    await bot.handleThinToolRpcRequest(thinRequest({
+      request_id: 'thin-legacy-source',
+      authority_version: undefined,
+    }));
+    await bot.handleThinToolRpcRequest(thinRequest({
+      request_id: 'thin-server-stripped',
+      grant_id: undefined,
+    }));
+
+    assert.equal(executions, 0);
+    assert.equal(captured.thinResults?.length, 3);
+    assert.ok(captured.thinResults?.every(item => item.error));
+  });
+
+  test('executes one Thin RPC request_id at most once and rejects conflicting replay', async () => {
+    const captured: { thinResults?: any[] } = { thinResults: [] };
+    const bot = botWithDevice(captured);
+    let executions = 0;
+    bot.executeLocalThinToolRpcTool = async () => {
+      executions += 1;
+      return { ok: true, content: 'executed once' };
+    };
+    const original = thinRequest({
+      request_id: 'thin-replay-once',
+      payload: { args: { directory: 'home' } },
+    });
+
+    await Promise.all([
+      bot.handleThinToolRpcRequest(original),
+      bot.handleThinToolRpcRequest({ ...original }),
+    ]);
+    await bot.handleThinToolRpcRequest({
+      ...original,
+      payload: { args: { directory: 'temp' } },
+    });
+
+    assert.equal(executions, 1);
+    assert.equal(captured.thinResults?.length, 3);
+    assert.equal(captured.thinResults?.[0]?.result?.ok, true);
+    assert.equal(captured.thinResults?.[1]?.result?.ok, true);
+    assert.match(String(captured.thinResults?.[2]?.error?.message), /conflicting/);
+  });
+
+  test('keeps Thin RPC replay protection in flight and for five minutes after a long execution settles', async () => {
+    const captured: { thinResults?: any[] } = { thinResults: [] };
+    const bot = botWithDevice(captured);
+    let executions = 0;
+    const realDateNow = Date.now;
+    let fakeNow = 1_000_000;
+    Date.now = () => fakeNow;
+    let finishExecution: (() => void) | undefined;
+    const executionGate = new Promise<void>(resolve => {
+      finishExecution = resolve;
+    });
+    bot.executeLocalThinToolRpcTool = async () => {
+      executions += 1;
+      await executionGate;
+      return { ok: true, content: 'long execution finished' };
+    };
+    const original = thinRequest({
+      request_id: 'thin-inflight-expiry',
+      expires_at: fakeNow + 100,
+      payload: { args: { command: 'long-running-operation' } },
+    });
+
+    try {
+      const firstDelivery = bot.handleThinToolRpcRequest(original);
+      fakeNow += 200;
+      await bot.handleThinToolRpcRequest({
+        ...original,
+        expires_at: fakeNow + 60_000,
+      });
+
+      fakeNow += 300_001;
+      finishExecution?.();
+      await firstDelivery;
+
+      await bot.handleThinToolRpcRequest({
+        ...original,
+        expires_at: fakeNow + 60_000,
+      });
+
+      assert.equal(executions, 1);
+      assert.equal(captured.thinResults?.length, 3);
+      assert.match(String(captured.thinResults?.[0]?.error?.message), /conflicting/);
+      assert.equal(captured.thinResults?.[1]?.result?.ok, true);
+      assert.match(String(captured.thinResults?.[2]?.error?.message), /conflicting/);
+    } finally {
+      Date.now = realDateNow;
+      finishExecution?.();
+    }
   });
 
   test('accepts import_file through authorized Device RPC and returns upload metadata', async () => {

--- a/tests/catscompany-execution-scope-flow.test.ts
+++ b/tests/catscompany-execution-scope-flow.test.ts
@@ -1136,6 +1136,8 @@ describe('CatsCompany execution scope flow', () => {
     assert.equal(handledTurns[0].options.deviceGrants?.length, 1);
     assert.equal(handledTurns[0].options.deviceGrants[0].deviceId, 'alice-laptop');
     assert.deepEqual(handledTurns[0].options.deviceGrants[0].operations, ['read_file', 'send_file']);
+    assert.equal(handledTurns[0].options.deviceGrantSnapshot?.revision, 12);
+    assert.equal(handledTurns[0].options.deviceGrantSnapshot?.grants.length, 1);
   });
 
   test('passes group device grants into CatsCompany session turn', async () => {
@@ -1228,6 +1230,26 @@ describe('CatsCompany execution scope flow', () => {
 
     assert.equal(handledTurns.length, 1);
     assert.equal(handledTurns[0].options.deviceGrants, undefined);
+    assert.deepEqual(handledTurns[0].options.deviceGrantSnapshot?.grants, []);
+  });
+
+  test('preserves an explicit empty canonical device grant snapshot as revocation', async () => {
+    const { bot, handledTurns } = createHarness();
+
+    await (bot as any).onMessage({
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      text: '撤销设备授权',
+      content: '撤销设备授权',
+      metadata: metadataWithDeviceGrants('usr7', 'p2p_7_43', []),
+      isGroup: false,
+      seq: 13,
+    });
+
+    assert.equal(handledTurns.length, 1);
+    assert.equal(handledTurns[0].options.deviceGrants, undefined);
+    assert.equal(handledTurns[0].options.deviceGrantSnapshot?.revision, 12);
+    assert.deepEqual(handledTurns[0].options.deviceGrantSnapshot?.grants, []);
   });
 
   test('does not merge queued CatsCo group input from another actor into the current actor scope', () => {
@@ -1295,6 +1317,177 @@ describe('CatsCompany execution scope flow', () => {
     assert.equal(pending.content, '补充读取文件');
     assert.equal(pending.deviceGrants.length, 1);
     assert.equal(pending.deviceGrants[0].deviceId, 'alice-laptop');
+  });
+
+  test('uses only the latest queued device grant snapshot and preserves empty revocation', () => {
+    const { bot } = createHarness();
+    const scope = createExecutionScope(createCatsCoMessageEnvelope({
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      text: 'first',
+      metadata: canonicalMetadata('usr7', 'p2p_7_43'),
+      botUid: 'usr43',
+    }));
+    const snapshot = (revision: number, grants: unknown[]) => ({
+      kind: 'user_device_grant_snapshot',
+      source: scope.source,
+      sessionKey: scope.sessionKey,
+      topicId: scope.topicId,
+      topicType: scope.topicType,
+      actorUserId: scope.actorUserId,
+      agentId: scope.agentId,
+      agentBodyId: scope.agentBodyId,
+      identityTrust: scope.identityTrust,
+      revision,
+      grants,
+    });
+    bot.messageQueue.set(scope.sessionKey, [{
+      userMessage: '先授权',
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      seq: 13,
+      executionScope: scope,
+      deviceGrantSnapshot: snapshot(13, [deviceGrant()]),
+      receivedAt: Date.now(),
+      source: 'user',
+    }, {
+      userMessage: '再撤销',
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      seq: 14,
+      executionScope: scope,
+      deviceGrantSnapshot: snapshot(14, []),
+      receivedAt: Date.now() + 1,
+      source: 'user',
+    }, {
+      userMessage: '延迟到达的旧授权',
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      seq: 15,
+      executionScope: scope,
+      deviceGrantSnapshot: snapshot(12, [deviceGrant()]),
+      receivedAt: Date.now() + 2,
+      source: 'user',
+    }, {
+      userMessage: '同 revision 的冲突授权',
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      seq: 16,
+      executionScope: scope,
+      deviceGrantSnapshot: snapshot(14, [deviceGrant()]),
+      receivedAt: Date.now() + 3,
+      source: 'user',
+    }]);
+
+    const pending = (bot as any).consumeQueuedUserInput(scope.sessionKey, scope);
+    assert.equal(pending.deviceGrants, undefined);
+    assert.equal(pending.deviceGrantSnapshot.revision, 14);
+    assert.deepEqual(pending.deviceGrantSnapshot.grants, []);
+  });
+
+  test('keeps equal-revision queued snapshots idempotent across grant and operation ordering', () => {
+    const { bot } = createHarness();
+    const scope = createExecutionScope(createCatsCoMessageEnvelope({
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      text: 'first',
+      metadata: canonicalMetadata('usr7', 'p2p_7_43'),
+      botUid: 'usr43',
+    }));
+    const first = deviceGrant();
+    const second = deviceGrant({
+      grantId: 'device-grant-2',
+      deviceId: 'alice-tablet',
+      operations: ['glob', 'read_file'],
+    });
+    const snapshot = (grants: unknown[]) => ({
+      kind: 'user_device_grant_snapshot',
+      source: scope.source,
+      sessionKey: scope.sessionKey,
+      topicId: scope.topicId,
+      topicType: scope.topicType,
+      actorUserId: scope.actorUserId,
+      agentId: scope.agentId,
+      agentBodyId: scope.agentBodyId,
+      identityTrust: scope.identityTrust,
+      revision: 20,
+      grants,
+    });
+    bot.messageQueue.set(scope.sessionKey, [{
+      userMessage: '第一个排序',
+      topic: scope.topicId,
+      senderId: scope.actorUserId,
+      seq: 20,
+      executionScope: scope,
+      deviceGrantSnapshot: snapshot([first, second]),
+      receivedAt: Date.now(),
+      source: 'user',
+    }, {
+      userMessage: '同义不同排序',
+      topic: scope.topicId,
+      senderId: scope.actorUserId,
+      seq: 21,
+      executionScope: scope,
+      deviceGrantSnapshot: snapshot([
+        { ...second, operations: [...second.operations].reverse() },
+        { ...first, operations: [...first.operations].reverse() },
+      ]),
+      receivedAt: Date.now() + 1,
+      source: 'user',
+    }]);
+
+    const pending = (bot as any).consumeQueuedUserInput(scope.sessionKey, scope);
+    assert.equal(pending.deviceGrantSnapshot.revision, 20);
+    assert.deepEqual(pending.deviceGrantSnapshot.grants, [first, second]);
+  });
+
+  test('clears queued authority when an unversioned snapshot follows versioned grants', () => {
+    const { bot } = createHarness();
+    const scope = createExecutionScope(createCatsCoMessageEnvelope({
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      text: 'first',
+      metadata: canonicalMetadata('usr7', 'p2p_7_43'),
+      botUid: 'usr43',
+    }));
+    const snapshot = (revision: number | undefined, grants: unknown[]) => ({
+      kind: 'user_device_grant_snapshot',
+      source: scope.source,
+      sessionKey: scope.sessionKey,
+      topicId: scope.topicId,
+      topicType: scope.topicType,
+      actorUserId: scope.actorUserId,
+      agentId: scope.agentId,
+      agentBodyId: scope.agentBodyId,
+      identityTrust: scope.identityTrust,
+      revision,
+      grants,
+    });
+    const broad = deviceGrant({ operations: ['read_file', 'execute_shell'] });
+    const narrow = deviceGrant({ operations: ['read_file'] });
+    bot.messageQueue.set(scope.sessionKey, [{
+      userMessage: '有序的广授权',
+      topic: scope.topicId,
+      senderId: scope.actorUserId,
+      seq: 30,
+      executionScope: scope,
+      deviceGrantSnapshot: snapshot(30, [broad]),
+      receivedAt: Date.now(),
+      source: 'user',
+    }, {
+      userMessage: '无法证明顺序的缩权',
+      topic: scope.topicId,
+      senderId: scope.actorUserId,
+      seq: 31,
+      executionScope: scope,
+      deviceGrantSnapshot: snapshot(undefined, [narrow]),
+      receivedAt: Date.now() + 1,
+      source: 'user',
+    }]);
+
+    const pending = (bot as any).consumeQueuedUserInput(scope.sessionKey, scope);
+    assert.equal(pending.deviceGrantSnapshot.revision, 30);
+    assert.deepEqual(pending.deviceGrantSnapshot.grants, []);
   });
 
   test('preserves latest device selection when queued CatsCompany user input is merged', () => {

--- a/tests/catscompany-runtime-device-capabilities.test.ts
+++ b/tests/catscompany-runtime-device-capabilities.test.ts
@@ -1,6 +1,9 @@
 import { describe, test } from 'node:test';
 import * as assert from 'node:assert';
-import { CATSCOMPANY_FULL_RUNTIME_DEVICE_CAPABILITIES } from '../src/catscompany';
+import {
+  CATSCOMPANY_FULL_RUNTIME_DEVICE_CAPABILITIES,
+  CATSCOMPANY_THIN_TOOL_RPC_AUTHORITY_CAPABILITY,
+} from '../src/catscompany';
 
 describe('CatsCompany runtime device capabilities', () => {
   test('full runtime advertises local owner self capabilities', () => {
@@ -14,5 +17,12 @@ describe('CatsCompany runtime device capabilities', () => {
       'send_file',
       'execute_shell',
     ]);
+  });
+
+  test('advertises the authority-v1 protocol separately from grant operations', () => {
+    assert.equal(CATSCOMPANY_THIN_TOOL_RPC_AUTHORITY_CAPABILITY, 'thin_tool_rpc_authority_v1');
+    assert.equal(CATSCOMPANY_FULL_RUNTIME_DEVICE_CAPABILITIES.includes(
+      CATSCOMPANY_THIN_TOOL_RPC_AUTHORITY_CAPABILITY as any,
+    ), false);
   });
 });

--- a/tests/conversation-runner-pending-input.test.ts
+++ b/tests/conversation-runner-pending-input.test.ts
@@ -2,11 +2,18 @@ import { describe, test } from 'node:test';
 import * as assert from 'node:assert';
 import * as path from 'path';
 import { ConversationRunner } from '../src/core/conversation-runner';
+import { resolveDeviceGrant } from '../src/core/device-grants';
+import { extractCatsCoDeviceGrantSnapshot } from '../src/catscompany/device-grants';
 import { TRANSIENT_RUNTIME_CONTEXT_PREFIX } from '../src/core/runtime-context-builder';
 import { TRANSIENT_PENDING_USER_INPUT_PREFIX } from '../src/core/pending-user-input-boundary';
 import { TurnContextBuilder } from '../src/core/turn-context-builder';
 import { Message } from '../src/types';
-import type { ExecutionScope, ScopedDeviceGrant, ScopedLocalFileGrant } from '../src/types/session-identity';
+import type {
+  ExecutionScope,
+  ScopedDeviceGrant,
+  ScopedDeviceGrantSnapshot,
+  ScopedLocalFileGrant,
+} from '../src/types/session-identity';
 import { ToolCall, ToolDefinition, ToolExecutionContext, ToolExecutor, ToolResult } from '../src/types/tool';
 
 const usage = { promptTokens: 1, completionTokens: 1, totalTokens: 2 };
@@ -93,6 +100,23 @@ function deviceGrant(deviceId: string): ScopedDeviceGrant {
     operations: ['read_file'],
     createdAt: now,
     expiresAt: now + 60_000,
+  };
+}
+
+function deviceGrantSnapshot(revision: number, grants: ScopedDeviceGrant[]): ScopedDeviceGrantSnapshot {
+  const executionScope = scope();
+  return {
+    kind: 'user_device_grant_snapshot',
+    source: executionScope.source,
+    sessionKey: executionScope.sessionKey,
+    topicId: executionScope.topicId,
+    topicType: executionScope.topicType,
+    actorUserId: executionScope.actorUserId,
+    agentId: executionScope.agentId,
+    agentBodyId: executionScope.agentBodyId,
+    identityTrust: executionScope.identityTrust,
+    revision,
+    grants,
   };
 }
 
@@ -292,7 +316,7 @@ describe('ConversationRunner pending input', () => {
     assert.deepEqual(contexts[1]?.localFileGrants, [initialGrant, pendingGrant]);
   });
 
-  test('merges pending device grants into later tool execution context without clearing existing grants', async () => {
+  test('atomically replaces pending device grants instead of retaining stale authority', async () => {
     const requests: Message[][] = [];
     const aiService = {
       chat: async (messages: Message[]) => {
@@ -351,13 +375,14 @@ describe('ConversationRunner pending input', () => {
         surface: 'catscompany',
         executionScope: scope(),
         deviceGrants: [initialGrant],
+        deviceGrantSnapshot: deviceGrantSnapshot(10, [initialGrant]),
       },
       pendingUserInputProvider: () => {
         if (pendingUsed) return null;
         pendingUsed = true;
         return {
           content: 'new device grant while busy',
-          deviceGrants: [pendingGrant],
+          deviceGrantSnapshot: deviceGrantSnapshot(11, [pendingGrant]),
         };
       },
     });
@@ -367,7 +392,7 @@ describe('ConversationRunner pending input', () => {
     assert.equal(result.response, 'done');
     assert.equal(contexts.length, 2);
     assert.deepEqual(contexts[0]?.deviceGrants, [initialGrant]);
-    assert.deepEqual(contexts[1]?.deviceGrants, [initialGrant, pendingGrant]);
+    assert.deepEqual(contexts[1]?.deviceGrants, [pendingGrant]);
 
     const refreshedContext = requests[1].find(isRuntimeContextMessage);
     assert.ok(refreshedContext);
@@ -378,7 +403,164 @@ describe('ConversationRunner pending input', () => {
     assert.doesNotMatch(refreshedContext.content as string, /install:device-/);
     assert.doesNotMatch(refreshedContext.content as string, /body-main/);
   });
+
+  test('treats an explicit empty snapshot as immediate revocation', async () => {
+    const broad = { ...deviceGrant('device-main'), operations: ['read_file', 'execute_shell'] as const };
+    const contexts = await capturePendingDeviceGrantContexts(
+      deviceGrantSnapshot(20, [broad]),
+      deviceGrantSnapshot(21, []),
+    );
+
+    assert.deepEqual(contexts[0]?.deviceGrants, [broad]);
+    assert.deepEqual(contexts[1]?.deviceGrants, []);
+    assert.equal(resolveDeviceGrant({
+      executionScope: scope(),
+      deviceGrants: contexts[1]?.deviceGrants,
+    }, { operation: 'execute_shell', deviceId: 'device-main' }).ok, false);
+  });
+
+  test('treats a malformed canonical device_grants container as pending-loop revocation', async () => {
+    const broad = { ...deviceGrant('device-main'), operations: ['read_file', 'execute_shell'] as const };
+    const malformed = extractCatsCoDeviceGrantSnapshot({
+      catsco_identity: {
+        permissions: { source: 'server_canonical_message' },
+        device_grants: { unexpected: 'object' },
+      },
+    }, scope());
+    assert.ok(malformed);
+    assert.deepEqual(malformed.grants, []);
+
+    const contexts = await capturePendingDeviceGrantContexts(
+      deviceGrantSnapshot(22, [broad]),
+      malformed,
+    );
+    assert.deepEqual(contexts[1]?.deviceGrants, []);
+    assert.equal(resolveDeviceGrant({
+      executionScope: scope(),
+      deviceGrants: contexts[1]?.deviceGrants,
+    }, { operation: 'execute_shell', deviceId: 'device-main' }).ok, false);
+  });
+
+  test('downscopes atomically and ignores a delayed lower revision', async () => {
+    const broad = { ...deviceGrant('device-main'), operations: ['read_file', 'execute_shell'] as const };
+    const narrow = { ...broad, operations: ['read_file'] as const };
+    const downscoped = await capturePendingDeviceGrantContexts(
+      deviceGrantSnapshot(30, [broad]),
+      deviceGrantSnapshot(31, [narrow]),
+    );
+    assert.deepEqual(downscoped[1]?.deviceGrants, [narrow]);
+    assert.equal(resolveDeviceGrant({
+      executionScope: scope(),
+      deviceGrants: downscoped[1]?.deviceGrants,
+    }, { operation: 'execute_shell', deviceId: 'device-main' }).ok, false);
+    assert.equal(resolveDeviceGrant({
+      executionScope: scope(),
+      deviceGrants: downscoped[1]?.deviceGrants,
+    }, { operation: 'read_file', deviceId: 'device-main' }).ok, true);
+
+    const expired = { ...narrow, expiresAt: Date.now() - 1 };
+    const expiredReplacement = await capturePendingDeviceGrantContexts(
+      deviceGrantSnapshot(32, [broad]),
+      deviceGrantSnapshot(33, [expired]),
+    );
+    assert.deepEqual(expiredReplacement[1]?.deviceGrants, [expired]);
+    assert.equal(resolveDeviceGrant({
+      executionScope: scope(),
+      deviceGrants: expiredReplacement[1]?.deviceGrants,
+    }, { operation: 'read_file', deviceId: 'device-main' }).ok, false);
+
+    const delayed = await capturePendingDeviceGrantContexts(
+      deviceGrantSnapshot(40, [narrow]),
+      deviceGrantSnapshot(39, [broad]),
+    );
+    assert.deepEqual(delayed[1]?.deviceGrants, [narrow]);
+
+    const unversionedNarrow = deviceGrantSnapshot(41, [narrow]);
+    delete unversionedNarrow.revision;
+    const unknownOrder = await capturePendingDeviceGrantContexts(
+      deviceGrantSnapshot(41, [broad]),
+      unversionedNarrow,
+    );
+    assert.deepEqual(unknownOrder[1]?.deviceGrants, []);
+  });
+
+  test('fails closed when the same authorization revision carries conflicting grants', async () => {
+    const initial = deviceGrant('device-main');
+    const idempotentSnapshot = deviceGrantSnapshot(50, [initial]);
+    const idempotent = await capturePendingDeviceGrantContexts(
+      idempotentSnapshot,
+      { ...idempotentSnapshot, grants: [{ ...initial }] },
+    );
+    assert.deepEqual(idempotent[1]?.deviceGrants, [initial]);
+
+    const conflict = deviceGrant('device-other');
+    const contexts = await capturePendingDeviceGrantContexts(
+      deviceGrantSnapshot(51, [initial]),
+      deviceGrantSnapshot(51, [conflict]),
+    );
+    assert.deepEqual(contexts[1]?.deviceGrants, []);
+  });
 });
+
+async function capturePendingDeviceGrantContexts(
+  initialSnapshot: ScopedDeviceGrantSnapshot,
+  pendingSnapshot: ScopedDeviceGrantSnapshot,
+): Promise<Array<Partial<ToolExecutionContext> | undefined>> {
+  let requestCount = 0;
+  const aiService = {
+    chat: async () => {
+      requestCount += 1;
+      if (requestCount <= 2) {
+        return {
+          content: null,
+          toolCalls: [{
+            id: `call_${requestCount}`,
+            type: 'function',
+            function: { name: 'noop', arguments: '{}' },
+          }],
+          usage,
+        };
+      }
+      return { content: 'done', toolCalls: [], usage };
+    },
+  } as any;
+  const contexts: Array<Partial<ToolExecutionContext> | undefined> = [];
+  const executor: ToolExecutor = {
+    getToolDefinitions: () => [{
+      name: 'noop',
+      description: 'noop',
+      parameters: { type: 'object', properties: {} },
+    }],
+    executeTool: async (toolCall, _history, contextOverrides) => {
+      contexts.push(contextOverrides);
+      return {
+        tool_call_id: toolCall.id,
+        role: 'tool',
+        name: toolCall.function.name,
+        content: 'ok',
+        ok: true,
+      };
+    },
+  };
+  let pendingUsed = false;
+  const runner = new ConversationRunner(aiService, executor, {
+    stream: false,
+    toolExecutionContext: {
+      sessionId: 'cc_user:usr7',
+      surface: 'catscompany',
+      executionScope: scope(),
+      deviceGrants: [...initialSnapshot.grants],
+      deviceGrantSnapshot: initialSnapshot,
+    },
+    pendingUserInputProvider: () => {
+      if (pendingUsed) return null;
+      pendingUsed = true;
+      return { content: 'authorization changed while busy', deviceGrantSnapshot: pendingSnapshot };
+    },
+  });
+  await runner.run([{ role: 'user', content: 'run a tool' }]);
+  return contexts;
+}
 
 function isRuntimeContextMessage(message: Message): boolean {
   return message.role === 'system'

--- a/tests/execution-router-clean.test.ts
+++ b/tests/execution-router-clean.test.ts
@@ -32,15 +32,17 @@ function catsContext(overrides: Partial<ToolExecutionContext> = {}): ToolExecuti
       status: 'active',
       identityTrust: 'server_canonical',
       identitySource: 'lightweight_test',
-      deviceId: 'dev-user-85',
+      deviceId: 'dev-alice-win',
       deviceDisplayName: 'usr85 device',
+      deviceBodyId: 'body-alice-win',
+      deviceInstallationId: 'install-alice-win',
       ownerUserId: 'usr85',
       sessionKey: 'session:v2:catscompany:p2p:p2p_85_320:agent:usr320',
       topicId: 'p2p_85_320',
       topicType: 'p2p',
       actorUserId: 'usr85',
       agentId: 'usr320',
-      operations: ['glob'],
+      operations: ['read_file', 'send_file', 'glob', 'execute_shell'],
       createdAt: Date.now(),
       expiresAt: Date.now() + 60_000,
     }],
@@ -139,6 +141,158 @@ test('username target routes through Thin Tool RPC, strips target args, and owns
   assert.doesNotMatch(String(result?.ok && result.content), /target: agent_self/);
 });
 
+test('named runtime target falls back to negotiated Device RPC when authority-v1 Thin RPC is unavailable', async () => {
+  let deviceCalls = 0;
+  const context = catsContext({
+    thinToolRpc: undefined,
+    deviceRpc: {
+      executeTool: async request => {
+        deviceCalls += 1;
+        assert.equal(request.targetDeviceId, 'dev-alice-win');
+        return { ok: true, content: 'device fallback ok' };
+      },
+    },
+  });
+  const route = resolveExecutionRoute(context, {
+    toolName: 'glob',
+    operation: 'glob',
+    target: 'Alice',
+  });
+  assert.equal(route.ok, true);
+
+  const result = await executeRouteIfRemote(
+    context,
+    route,
+    'glob',
+    'glob',
+    { path: '.', pattern: '*' },
+  );
+  assert.equal(deviceCalls, 1);
+  assert.equal(result?.ok, true);
+  assert.equal(result?.ok && result.content, 'device fallback ok');
+});
+
+test('runtime target routes are discovery hints and cannot authorize a remote operation', () => {
+  const baseline = catsContext();
+  const baseGrant = baseline.deviceGrants![0];
+  const cases: Array<[string, Partial<ToolExecutionContext>]> = [
+    ['missing grant', { deviceGrants: [] }],
+    ['revoked grant', { deviceGrants: [{ ...baseGrant, status: 'revoked' }] }],
+    ['expired grant', { deviceGrants: [{ ...baseGrant, expiresAt: Date.now() - 1 }] }],
+    ['wrong operation', { deviceGrants: [{ ...baseGrant, operations: ['read_file'] }] }],
+    ['wrong actor', { deviceGrants: [{ ...baseGrant, actorUserId: 'usr-other', ownerUserId: 'usr-other' }] }],
+    ['legacy grant', { deviceGrants: [{ ...baseGrant, identityTrust: 'legacy_context' }] }],
+  ];
+
+  for (const [name, overrides] of cases) {
+    const route = resolveExecutionRoute(catsContext(overrides), {
+      toolName: 'glob',
+      operation: 'glob',
+      target: 'Alice',
+    });
+    assert.equal(route.ok, false, name);
+    if (!route.ok) assert.equal(route.errorCode, 'PERMISSION_DENIED', name);
+  }
+
+  const wrongOwnerRoute = buildTargetRoutes([{
+    userId: 'usr-other',
+    userName: 'Alice',
+    ownerUserId: 'usr-other',
+    deviceId: baseGrant.deviceId,
+    label: 'Alice 的电脑',
+    os: 'windows',
+    status: 'ready',
+  }]);
+  const wrongOwner = resolveExecutionRoute(catsContext({ targetRoutes: wrongOwnerRoute }), {
+    toolName: 'glob',
+    operation: 'glob',
+    target: 'Alice',
+  });
+  assert.equal(wrongOwner.ok, false);
+});
+
+test('server-canonical group delegation still authorizes the named participant device', () => {
+  const context = catsContext();
+  const delegatedGrant = {
+    ...context.deviceGrants![0],
+    identitySource: 'channel_identity_link',
+    ownerUserId: 'usr99',
+    sessionKey: 'session:v2:catscompany:group:room_7:agent:usr320',
+    topicId: 'room_7',
+    topicType: 'group' as const,
+  };
+  const groupContext = catsContext({
+    executionScope: {
+      ...context.executionScope!,
+      sessionKey: delegatedGrant.sessionKey,
+      topicId: delegatedGrant.topicId,
+      topicType: delegatedGrant.topicType,
+    },
+    deviceGrants: [delegatedGrant],
+    thinToolRpc: {
+      executeTool: async () => ({ ok: true, content: 'delegated remote ok' }),
+    },
+    targetRoutes: buildTargetRoutes([{
+      userId: 'usr99',
+      userName: 'Bob',
+      ownerUserId: 'usr99',
+      deviceId: delegatedGrant.deviceId,
+      label: 'Bob 的电脑',
+      os: 'windows',
+      status: 'ready',
+    }]),
+  });
+
+  const route = resolveExecutionRoute(groupContext, {
+    toolName: 'glob',
+    operation: 'glob',
+    target: 'Bob',
+  });
+
+  assert.equal(route.ok, true);
+  assert.equal(route.ok && route.mode, 'remote');
+  assert.equal(route.ok && route.mode === 'remote' && route.targetOwnerUserId, 'usr99');
+});
+
+test('remote dispatch revalidates authority and tool/operation pairing', async () => {
+  let rpcCalls = 0;
+  const authorized = catsContext({
+    thinToolRpc: {
+      executeTool: async () => {
+        rpcCalls += 1;
+        return { ok: true, content: 'unexpected' };
+      },
+    },
+  });
+  const resolved = resolveExecutionRoute(authorized, {
+    toolName: 'glob',
+    operation: 'glob',
+    target: 'Alice',
+  });
+  assert.equal(resolved.ok, true);
+
+  const mismatched = await executeRouteIfRemote(
+    authorized,
+    resolved,
+    'execute_shell',
+    'glob',
+    { command: 'echo no' },
+  );
+  assert.equal(mismatched?.ok, false);
+  assert.equal(rpcCalls, 0);
+
+  const forgedContext = { ...authorized, deviceGrants: [] };
+  const forged = await executeRouteIfRemote(
+    forgedContext,
+    resolved,
+    'glob',
+    'glob',
+    { path: '.', pattern: '*' },
+  );
+  assert.equal(forged?.ok, false);
+  assert.equal(rpcCalls, 0);
+});
+
 test('legacy speaker_default fallback still uses Device RPC when runtime routes are unavailable', async () => {
   let capturedArgs: Record<string, unknown> | undefined;
   const context = catsContext({
@@ -146,7 +300,7 @@ test('legacy speaker_default fallback still uses Device RPC when runtime routes 
     deviceRpc: {
       executeTool: async request => {
         capturedArgs = request.args;
-        assert.equal(request.targetDeviceId, 'dev-user-85');
+        assert.equal(request.targetDeviceId, 'dev-alice-win');
         return { ok: true, content: 'legacy remote ok' };
       },
     },

--- a/tests/glob-tool.test.ts
+++ b/tests/glob-tool.test.ts
@@ -106,6 +106,16 @@ describe('GlobTool', () => {
     let forwardedRequest: DeviceRpcToolRequest | undefined;
     const ctx = context();
     ctx.surface = 'catscompany';
+    ctx.executionScope = {
+      source: 'catscompany',
+      sessionKey: 'session:v2:catscompany:p2p:topic:agent:agent-1',
+      topicId: 'topic',
+      topicType: 'p2p',
+      actorUserId: 'speaker-user',
+      agentId: 'agent-1',
+      identityTrust: 'server_canonical',
+      isTrusted: true,
+    };
     ctx.deviceSelection = selectedDevice(['glob']);
     ctx.deviceGrants = [deviceGrant(['glob'])];
     ctx.deviceRpc = {

--- a/tests/import-file.test.ts
+++ b/tests/import-file.test.ts
@@ -56,6 +56,8 @@ describe('import_file remote routing', () => {
       workingDirectory: process.cwd(),
       conversationHistory: [],
       surface: 'catscompany',
+      executionScope: executionScope(),
+      deviceGrants: [deviceGrantFor(route)],
       targetRoutes: {
         routes: [route],
         byName: new Map([['lin', [route]]]),
@@ -112,16 +114,8 @@ describe('import_file remote routing', () => {
       workingDirectory: process.cwd(),
       conversationHistory: [],
       surface: 'catscompany',
-      executionScope: {
-        source: 'catscompany',
-        sessionKey: 'session-1',
-        topicId: 'p2p_7_43',
-        topicType: 'p2p',
-        actorUserId: 'usr7',
-        agentId: 'usr43',
-        identityTrust: 'server_canonical',
-        isTrusted: true,
-      },
+      executionScope: executionScope(),
+      deviceGrants: [deviceGrantFor(route)],
       targetRoutes: {
         routes: [route],
         byName: new Map([['lin', [route]]]),
@@ -165,7 +159,7 @@ describe('import_file remote routing', () => {
     assert.equal(rpcRequest.toolName, 'import_file');
     assert.equal(rpcRequest.targetOwnerUserId, 'usr7');
     assert.equal(rpcRequest.targetDeviceId, 'lin-laptop');
-    assert.equal(rpcRequest.timeoutMs, 300_000);
+    assert.ok(rpcRequest.timeoutMs > 0 && rpcRequest.timeoutMs <= 300_000);
     assert.deepEqual(rpcRequest.args, {
       file_path: 'C:\\Users\\Lin\\Desktop\\报价单.xlsx',
       file_name: '报价单.xlsx',
@@ -187,4 +181,40 @@ describe('import_file remote routing', () => {
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function executionScope() {
+  return {
+    source: 'catscompany' as const,
+    sessionKey: 'session-1',
+    topicId: 'p2p_7_43',
+    topicType: 'p2p' as const,
+    actorUserId: 'usr7',
+    agentId: 'usr43',
+    identityTrust: 'server_canonical' as const,
+    isTrusted: true,
+  };
+}
+
+function deviceGrantFor(route: TargetRoute) {
+  const now = Date.now();
+  return {
+    kind: 'user_device_grant' as const,
+    source: 'catscompany' as const,
+    grantId: `grant:${route.deviceId}`,
+    status: 'active' as const,
+    identityTrust: 'server_canonical' as const,
+    identitySource: 'metadata.catsco_identity',
+    deviceId: route.deviceId,
+    deviceDisplayName: route.label,
+    ownerUserId: route.ownerUserId,
+    sessionKey: 'session-1',
+    topicId: 'p2p_7_43',
+    topicType: 'p2p' as const,
+    actorUserId: 'usr7',
+    agentId: 'usr43',
+    operations: ['send_file' as const],
+    createdAt: now,
+    expiresAt: now + 300_000,
+  };
 }

--- a/tests/remote-media-read.test.ts
+++ b/tests/remote-media-read.test.ts
@@ -89,6 +89,7 @@ function createRemoteMediaContext(fileName: string): {
     status: 'ready',
   };
   const rpcCalls: Array<{ toolName: string; args: Record<string, unknown> }> = [];
+  const now = Date.now();
 
   return {
     importedPath,
@@ -98,6 +99,33 @@ function createRemoteMediaContext(fileName: string): {
       workspaceRoot: root,
       conversationHistory: [],
       surface: 'catscompany',
+      executionScope: {
+        source: 'catscompany',
+        sessionKey: 'session:remote-media',
+        topicId: 'p2p_alice_agent',
+        topicType: 'p2p',
+        actorUserId: 'usr-alice',
+        identityTrust: 'server_canonical',
+        isTrusted: true,
+      },
+      deviceGrants: [{
+        kind: 'user_device_grant',
+        source: 'catscompany',
+        grantId: 'grant:alice-device',
+        status: 'active',
+        identityTrust: 'server_canonical',
+        identitySource: 'metadata.catsco_identity',
+        deviceId: route.deviceId,
+        deviceDisplayName: route.label,
+        ownerUserId: route.ownerUserId,
+        sessionKey: 'session:remote-media',
+        topicId: 'p2p_alice_agent',
+        topicType: 'p2p',
+        actorUserId: 'usr-alice',
+        operations: ['read_file', 'send_file'],
+        createdAt: now,
+        expiresAt: now + 300_000,
+      }],
       targetRoutes: {
         routes: [route],
         byName: new Map([['alice', [route]]]),


### PR DESCRIPTION
## Summary
- replace pending device authority with complete, revision-aware snapshots that preserve explicit revocation
- require canonical grant authorization at route resolution and dispatch while preserving channel-linked group delegation
- negotiate thin_tool_rpc_authority_v1, fall back to Device RPC safely, and bind the complete authority envelope
- add bounded in-flight and post-settlement replay protection for remote side effects

## Verification
- npm run build
- npm test: 1524 tests, 1516 passed, 0 failed, 8 skipped
- isolated compiled Dashboard smoke: root and /api/status returned HTTP 200
- two independent read-only reviews: no residual P0-P2 findings
- no UI files changed; visual testing not applicable

## Evidence
- docs/evidence/cache-stage6-device-authorization-snapshots-2026-08-02.md

Stacked on Stage 5 / PR #309. This stage secures capability coverage and does not claim the 94% cache target.