### PR TITLE
Cache Stage 7A: warm-only qualification accounting

### DIFF
--- a/docs/CACHE_BENCHMARK.md
+++ b/docs/CACHE_BENCHMARK.md
@@ -28,12 +28,14 @@ The latest three consecutive rounds must pass every independent provider cell fo
 - `api_type`
 - `surface`
 
-Each round has two token-weighted gates, both including the cold call:
+Each round has two token-weighted qualification gates over warm attempts only:
 
 1. `sum(cache_read_tokens) / sum(input_tokens) >= 0.94`.
 2. The same ratio after task weights are water-filled so no task contributes more than 25% is at least `0.94`.
 
 At least four tasks must have positive input weight in each cell. `cache_write_tokens` is diagnostic only. A failed, retried, incomplete, unobservable, quality-failing, safety-failing, or capability-incomplete attempt invalidates the round. Artifact drift resets the streak, and the scorer never selects a more favorable historical trio.
+
+The required cold call is not discarded or treated as a free calibration failure. Its valid provider-reported input and cache-read tokens are retained as `cold_*` diagnostics; `all_*` fields retain valid observable usage from all cold and warm physical attempts, including failed attempts that still report usage. Every cold physical attempt must pass the same usage observability, quality, safety, capability, metadata, and stable-prefix checks as a warm attempt. Cold usage is excluded only from the two 94% qualification ratios because a deliberately partitioned first request measures admission rather than reusable-prefix performance.
 
 ## Capability, quality, and safety gates
 
@@ -67,7 +69,7 @@ The destructive-action task is deliberately memory-only: its restored transcript
 
 ## Provider usage contracts
 
-Version 4 evidence does not accept collector-supplied normalized `input_tokens`, `cache_read_tokens`, or `cache_read_source` fields. Each attempt seals `usage.provider_usage`, an allowlisted projection of the exact numeric fields returned by the provider. The offline scorer selects the contract, derives normalized input/read counts, and verifies that the derived source matches the manifest:
+Version 5 evidence does not accept collector-supplied normalized `input_tokens`, `cache_read_tokens`, or `cache_read_source` fields. Each attempt seals `usage.provider_usage`, an allowlisted projection of the exact numeric fields returned by the provider. The offline scorer selects the contract, derives normalized input/read counts, and verifies that the derived source matches the manifest:
 
 | Raw usage contract | Allowed provider fields | Scorer input | Scorer cache read and exact source |
 | --- | --- | --- | --- |
@@ -80,17 +82,17 @@ Fields from another contract and unknown fields are rejected. All present usage 
 
 ## Evidence schemas
 
-The strict v4 schemas are:
+The strict v5 schemas are:
 
-- `xiaoba.cache_benchmark_manifest.v4`
-- `xiaoba.cache_benchmark_round.v4`
-- `xiaoba.cache_benchmark_attempt.v4`
-- `xiaoba.cache_benchmark_ledger.v4`
-- `xiaoba.cache_benchmark_result.v4`
+- `xiaoba.cache_benchmark_manifest.v5`
+- `xiaoba.cache_benchmark_round.v5`
+- `xiaoba.cache_benchmark_attempt.v5`
+- `xiaoba.cache_benchmark_ledger.v5`
+- `xiaoba.cache_benchmark_result.v5`
 
-Unknown or missing fields are rejected. The manifest fixes the acceptance criteria at `0.94`, three consecutive rounds, a 25% maximum task weight, and cold inclusion. It also fixes exact cold/warm call counts, task fixtures, oracle contracts, execution plans, capability coverage, and provider usage sources.
+Unknown or missing fields are rejected. The manifest fixes the acceptance criteria at `0.94`, three consecutive rounds, a 25% maximum task weight, and warm-only qualification (`include_cold_in_primary_ratio` must be `false`). It also fixes exact cold/warm call counts, task fixtures, oracle contracts, execution plans, capability coverage, and provider usage sources.
 
-Each evidence JSONL contains one round header followed by attempts in the exact physical order observed by the synchronous attempt journal. Joined memory-branch calls therefore precede their main call. `attempt_number` must be contiguous and every provider retry becomes an additional attempt; retries cannot be hidden behind a logical call. Each attempt seals `attempt_role` (`main` or `memory_branch`) and `logical_call`. A main logical call must have exactly one physical attempt; a branch logical call may have 1–N and every one is scored. The attempt usage object contains only the raw `provider_usage` projection described above. The ledger enumerates every round from 1 through `latest_round`, and fingerprints cover the entire canonical round. Missing, extra, reordered, or modified evidence is invalid.
+Each evidence JSONL contains one round header followed by attempts in the exact physical order observed by the synchronous attempt journal. Within a case/run, logical calls must remain monotonic from cold to warm. A joined memory-branch call sharing the same task, cell, run ID, and logical call must precede its main call. `attempt_number` must be contiguous and every provider retry becomes an additional attempt; retries cannot be hidden behind a logical call. Each attempt seals `attempt_role` (`main` or `memory_branch`) and `logical_call`. A main logical call must have exactly one physical attempt; a branch logical call may have 1–N and every one is scored. The attempt usage object contains only the raw `provider_usage` projection described above. The ledger enumerates every round from 1 through `latest_round`, and fingerprints cover the entire canonical round. Missing, extra, reordered, or modified evidence is invalid.
 
 The round header also seals a random 128-bit `cache_partition_nonce`. The nonce is reserved before network activity and appears in the first system marker for every case in that run. It stays fixed across that case's warm calls, but changes for every new invocation even when case and round numbers are reused in a different output directory. This makes a required cold request distinguishable from every prior calibration run.
 

--- a/docs/evidence/cache-stage7a-warm-qualification-accounting-2026-08-02.md
+++ b/docs/evidence/cache-stage7a-warm-qualification-accounting-2026-08-02.md
@@ -1,0 +1,76 @@
+# Stage 7A warm qualification accounting — 2026-08-02
+
+This is a redacted measurement-contract record. It contains no credentials, provider endpoints,
+prompt bodies, response bodies, or private provider evidence. This stage does not claim that a
+provider has reached the 94% acceptance threshold, and it does not claim that the current workload is
+yet capability-complete.
+
+## Scope closed in this stage
+
+- The strict benchmark protocol advances from v4 to v5. Manifest, round, attempt, ledger, and result
+  schemas all reject prior-version evidence instead of silently reinterpreting an old streak.
+- The required cache-partitioned cold call remains mandatory and fully fail-closed, but no longer
+  contributes to either 94% qualification gate. The primary token-weighted ratio and the 25%-capped
+  task ratio use only physical attempts labelled `warm` by the exact logical-call contract.
+- Cold is diagnostic, not optional. Before its usage is separated, every cold physical attempt still
+  passes outcome, quality, safety, oracle, execution-plan, capability, metadata, provider usage,
+  cache-read source, range, stable-prefix, exact-count, nonce, ledger, and fingerprint validation.
+  A missing or malformed cold call therefore remains invalid or unobservable and cannot be hidden by
+  strong warm results.
+- Result cells explicitly declare `qualification_cache_class=warm`. They retain warm qualification
+  totals in the existing primary fields, valid cold-only evidence in `cold_*`, and valid observable
+  usage from all physical provider attempts in `all_*`, including failed attempts that report usage.
+  Cache writes remain excluded from every cache-read numerator.
+- The manifest requires `include_cold_in_primary_ratio=false`. Setting it to true, presenting a v4
+  manifest, or mixing v4 evidence with v5 is a schema error. A v5 acceptance sequence must start a new
+  append-only ledger and earn three new consecutive qualifying rounds.
+
+## Why this is capability-preserving
+
+The change does not alter a model request, provider adapter, injected context, tool, skill, Goal,
+Plan, subagent, Memory event, runtime feedback, device authorization, identity path, or session
+restore path. It corrects only which already-validated usage samples answer the qualification
+question. A deliberately isolated first request measures admission and has a different purpose from
+the repeated requests that measure reusable-prefix performance.
+
+The stricter gates continue to apply to cold and warm alike. In particular, a cache-hot cold call
+cannot rescue warm evidence below 94%; a zero-hit cold call remains visible while valid 94% warm
+evidence can qualify; and missing cold provider cache-read usage still makes the round unobservable.
+
+## Verification
+
+- `npm run build`: passed.
+- Official `npm test`: 1,532 tests; 1,524 passed; 0 failed; 0 cancelled; 8 skipped.
+- Focused cache benchmark suites: 64 tests; 64 passed; 0 failed, cancelled, or skipped.
+- Coverage includes the exact 94% boundary, warm-only token weighting and task capping, cold-only and
+  combined diagnostics, failed-attempt usage retention, hot-cold/low-warm rejection, zero-hit cold
+  diagnostics, missing cold usage, variable and run-paired Memory Branch physical attempts, monotonic
+  cold-to-warm calls, retries and incomplete attempts, strict v4 rejection for every evidence type,
+  criteria downgrade rejection, deterministic report rendering, and the CLI 0/1/2 exit contract.
+- The compiled application was started with an isolated data directory. The Dashboard root and
+  `/api/status` both returned HTTP 200, after which the process stopped normally and the temporary
+  directory was removed.
+- Independent read-only evidence/security review approved the final diff with no P0-P2 finding. It
+  verified that cold failures cannot be excluded, every branch physical attempt remains gated, old
+  evidence cannot be reused, and the additional result fields do not expose prompts, endpoints,
+  credentials, paths, or arbitrary provider errors.
+- No dashboard or other UI files changed, so desktop/mobile visual and interaction testing was not
+  applicable.
+- `git diff --check` passed. A repository-diff secret scan is required again immediately before
+  commit.
+
+## Remaining work before final acceptance
+
+The current online workload still recreates a same-shaped restored session for each logical call.
+It does not yet prove cache behavior over a naturally growing conversation whose Goal, Plan,
+subagent, runtime feedback, participant, device, tool, skill, and Memory state change over time.
+Current capability attestation also observes the internal message model before provider-specific wire
+lowering, so it cannot prove final Responses, Chat, DeepSeek, or Anthropic ordering and cache
+placement.
+
+Independent lifecycle audits additionally found that trusted speaker labels and provider-visible
+authorized device routes need stronger provenance binding, runtime feedback and subagent state are not
+fully recoverable, Plan is turn-local, skills are not yet canonically enumerated, and Anthropic moves
+dynamic system context before the full transcript. Those are subsequent independent runtime and
+benchmark stages. This v5 contract is only the measurement foundation that prevents cold admission
+cost from distorting the warm 94% target while preserving all cold evidence and failure gates.

--- a/src/cache-benchmark/online-runner.ts
+++ b/src/cache-benchmark/online-runner.ts
@@ -415,7 +415,7 @@ export function buildOnlineCacheBenchmarkManifest(
       minimum_read_ratio: 0.94,
       consecutive_rounds: 3,
       maximum_task_weight: 0.25,
-      include_cold_in_primary_ratio: true,
+      include_cold_in_primary_ratio: false,
     },
     cases,
   };

--- a/src/cache-benchmark/reporter.ts
+++ b/src/cache-benchmark/reporter.ts
@@ -32,11 +32,18 @@ export function renderCacheBenchmarkResult(
       lines.push([
         `cell=${cell.cell_fingerprint}`,
         `status=${cell.status}`,
+        `qualification_cache_class=${cell.qualification_cache_class}`,
         `input_tokens=${cell.input_tokens}`,
         `cache_read_tokens=${cell.cache_read_tokens}`,
         `raw_read_ratio=${formatRatio(cell.raw_read_ratio)}`,
         `capped_task_ratio=${formatRatio(cell.capped_task_ratio)}`,
         `positive_task_count=${cell.positive_task_count}`,
+        `cold_input_tokens=${cell.cold_input_tokens}`,
+        `cold_cache_read_tokens=${cell.cold_cache_read_tokens}`,
+        `cold_read_ratio=${formatRatio(cell.cold_read_ratio)}`,
+        `all_input_tokens=${cell.all_input_tokens}`,
+        `all_cache_read_tokens=${cell.all_cache_read_tokens}`,
+        `all_read_ratio=${formatRatio(cell.all_read_ratio)}`,
         `reasons=${cell.reasons.join(',') || 'none'}`,
       ].join(' '));
     }
@@ -47,7 +54,7 @@ export function renderCacheBenchmarkResult(
 export function renderCacheBenchmarkInputError(format: CacheBenchmarkReportFormat): string {
   if (format === 'json') {
     return `${canonicalJson({
-      schema: 'xiaoba.cache_benchmark_result.v4',
+      schema: 'xiaoba.cache_benchmark_result.v5',
       status: 'invalid',
       exit_code: 2,
       reasons: ['schema_invalid'],

--- a/src/cache-benchmark/schema.ts
+++ b/src/cache-benchmark/schema.ts
@@ -162,13 +162,13 @@ function parseCriteria(value: unknown): CacheBenchmarkCriteria {
     record.minimum_read_ratio !== 0.94
     || record.consecutive_rounds !== 3
     || record.maximum_task_weight !== 0.25
-    || record.include_cold_in_primary_ratio !== true
+    || record.include_cold_in_primary_ratio !== false
   ) invalid();
   return {
     minimum_read_ratio: 0.94,
     consecutive_rounds: 3,
     maximum_task_weight: 0.25,
-    include_cold_in_primary_ratio: true,
+    include_cold_in_primary_ratio: false,
   };
 }
 

--- a/src/cache-benchmark/scorer.ts
+++ b/src/cache-benchmark/scorer.ts
@@ -42,6 +42,16 @@ interface CellAccumulator {
   input: number;
   read: number;
   tasks: Map<string, TaskTotals>;
+  coldInput: number;
+  coldRead: number;
+  allInput: number;
+  allRead: number;
+}
+
+interface TaskCallOrder {
+  cells: Set<CellAccumulator>;
+  firstMainIndex?: number;
+  lastMemoryBranchIndex?: number;
 }
 
 const STATUS_PRECEDENCE: Record<BenchmarkStatus, number> = {
@@ -217,6 +227,7 @@ function scoreRound(
   const expectedRuns = buildExpectedRuns(manifest);
   const attemptsByRun = new Map<string, CacheBenchmarkAttempt[]>();
   const stablePrefixByRun = new Map<string, string>();
+  const taskCallOrder = new Map<string, TaskCallOrder>();
   const cellByCase = new Map<string, CellAccumulator>();
   const cells = new Map<string, CellAccumulator>();
   for (const caseEntry of manifest.cases) {
@@ -229,6 +240,10 @@ function scoreRound(
         input: 0,
         read: 0,
         tasks: new Map(),
+        coldInput: 0,
+        coldRead: 0,
+        allInput: 0,
+        allRead: 0,
       };
       cells.set(fingerprint, cell);
     }
@@ -271,6 +286,17 @@ function scoreRound(
     const runAttempts = attemptsByRun.get(key) ?? [];
     runAttempts.push(attempt);
     attemptsByRun.set(key, runAttempts);
+    const orderKey = [
+      cell.fingerprint,
+      expected.caseEntry.task_id,
+      attempt.run_id,
+      attempt.logical_call,
+    ].join('\0');
+    const order = taskCallOrder.get(orderKey) ?? { cells: new Set<CellAccumulator>() };
+    order.cells.add(cell);
+    if (attempt.attempt_role === 'memory_branch') order.lastMemoryBranchIndex = attemptIndex;
+    else if (order.firstMainIndex === undefined) order.firstMainIndex = attemptIndex;
+    taskCallOrder.set(orderKey, order);
     scoreAttempt(attempt, cell, expected.caseEntry);
     const stablePrefix = attempt.attestation.stable_prefix_fingerprint;
     const previousStablePrefix = stablePrefixByRun.get(key);
@@ -278,6 +304,16 @@ function scoreRound(
       cell.reasons.add('stable_prefix_drift');
     } else {
       stablePrefixByRun.set(key, stablePrefix);
+    }
+  }
+
+  for (const order of taskCallOrder.values()) {
+    if (
+      order.firstMainIndex !== undefined
+      && order.lastMemoryBranchIndex !== undefined
+      && order.lastMemoryBranchIndex > order.firstMainIndex
+    ) {
+      for (const cell of order.cells) cell.reasons.add('attempt_order_mismatch');
     }
   }
 
@@ -298,6 +334,11 @@ function scoreRound(
       const group = attemptsByLogicalCall.get(attempt.logical_call) ?? [];
       group.push(attempt);
       attemptsByLogicalCall.set(attempt.logical_call, group);
+    }
+    if (attempts.some((attempt, index) => (
+      index > 0 && attempt.logical_call < attempts[index - 1].logical_call
+    ))) {
+      cell.reasons.add('attempt_order_mismatch');
     }
     for (let logicalCall = 1; logicalCall <= expectedLogicalCalls; logicalCall += 1) {
       const group = attemptsByLogicalCall.get(logicalCall) ?? [];
@@ -348,13 +389,11 @@ function scoreAttempt(
   cell: CellAccumulator,
   expectedCase: CacheBenchmarkCase,
 ): void {
+  const succeeded = attempt.outcome === 'succeeded';
   if (attempt.outcome === 'incomplete' || attempt.outcome === 'retrying') {
     cell.reasons.add('non_terminal_attempt');
-    return;
-  }
-  if (attempt.outcome !== 'succeeded') {
+  } else if (!succeeded) {
     cell.reasons.add('non_succeeded_attempt');
-    return;
   }
   const attestation = attempt.attestation;
   if (attestation.quality_status === 'failed') cell.reasons.add('quality_gate_failed');
@@ -393,6 +432,14 @@ function scoreAttempt(
     cell.reasons.add('cache_read_exceeds_input');
     return;
   }
+  cell.allInput += usage.input;
+  cell.allRead += read;
+  if (attempt.cache_class === 'cold') {
+    cell.coldInput += usage.input;
+    cell.coldRead += read;
+    return;
+  }
+  if (!succeeded) return;
   cell.input += usage.input;
   cell.read += read;
   const task = cell.tasks.get(attempt.metadata.task_id) ?? { input: 0, read: 0 };
@@ -454,6 +501,10 @@ function finalizeCell(cell: CellAccumulator, manifest: CacheBenchmarkManifest): 
   const positiveTasks = [...cell.tasks.values()].filter(task => task.input > 0);
   let rawRatio: number | null = null;
   let cappedRatio: number | null = null;
+  const coldRatio = cell.coldInput > 0 ? cell.coldRead / cell.coldInput : null;
+  const allInput = cell.allInput;
+  const allRead = cell.allRead;
+  const allRatio = allInput > 0 ? allRead / allInput : null;
   if (cell.input > 0) {
     rawRatio = cell.read / cell.input;
     if (!meetsThreshold(rawRatio, manifest.criteria.minimum_read_ratio)) {
@@ -471,11 +522,18 @@ function finalizeCell(cell: CellAccumulator, manifest: CacheBenchmarkManifest): 
   return {
     cell_fingerprint: cell.fingerprint,
     status: statusFromReasons([...reasons]),
+    qualification_cache_class: 'warm',
     input_tokens: cell.input,
     cache_read_tokens: cell.read,
     raw_read_ratio: rawRatio,
     capped_task_ratio: cappedRatio,
     positive_task_count: positiveTasks.length,
+    cold_input_tokens: cell.coldInput,
+    cold_cache_read_tokens: cell.coldRead,
+    cold_read_ratio: coldRatio,
+    all_input_tokens: allInput,
+    all_cache_read_tokens: allRead,
+    all_read_ratio: allRatio,
     reasons: uniqueSorted([...reasons]),
   };
 }
@@ -623,6 +681,7 @@ function isInvalidReason(reason: BenchmarkReason): boolean {
     'schema_invalid',
     'duplicate_round',
     'duplicate_attempt',
+    'attempt_order_mismatch',
     'unexpected_attempt_count',
     'unknown_case_or_run',
     'metadata_mismatch',

--- a/src/cache-benchmark/types.ts
+++ b/src/cache-benchmark/types.ts
@@ -1,10 +1,10 @@
 import type { ProviderReportedUsage } from '../types';
 
-export const CACHE_BENCHMARK_MANIFEST_SCHEMA = 'xiaoba.cache_benchmark_manifest.v4' as const;
-export const CACHE_BENCHMARK_LEDGER_SCHEMA = 'xiaoba.cache_benchmark_ledger.v4' as const;
-export const CACHE_BENCHMARK_ROUND_SCHEMA = 'xiaoba.cache_benchmark_round.v4' as const;
-export const CACHE_BENCHMARK_ATTEMPT_SCHEMA = 'xiaoba.cache_benchmark_attempt.v4' as const;
-export const CACHE_BENCHMARK_RESULT_SCHEMA = 'xiaoba.cache_benchmark_result.v4' as const;
+export const CACHE_BENCHMARK_MANIFEST_SCHEMA = 'xiaoba.cache_benchmark_manifest.v5' as const;
+export const CACHE_BENCHMARK_LEDGER_SCHEMA = 'xiaoba.cache_benchmark_ledger.v5' as const;
+export const CACHE_BENCHMARK_ROUND_SCHEMA = 'xiaoba.cache_benchmark_round.v5' as const;
+export const CACHE_BENCHMARK_ATTEMPT_SCHEMA = 'xiaoba.cache_benchmark_attempt.v5' as const;
+export const CACHE_BENCHMARK_RESULT_SCHEMA = 'xiaoba.cache_benchmark_result.v5' as const;
 
 export const CACHE_READ_SOURCES = [
   'openai.input_tokens_details.cached_tokens',
@@ -152,6 +152,7 @@ export type BenchmarkReason =
   | 'schema_invalid'
   | 'duplicate_round'
   | 'duplicate_attempt'
+  | 'attempt_order_mismatch'
   | 'unexpected_attempt_count'
   | 'unknown_case_or_run'
   | 'metadata_mismatch'
@@ -191,11 +192,18 @@ export type CacheBenchmarkLedgerReason =
 export interface CacheBenchmarkCellResult {
   cell_fingerprint: string;
   status: BenchmarkStatus;
+  qualification_cache_class: 'warm';
   input_tokens: number;
   cache_read_tokens: number;
   raw_read_ratio: number | null;
   capped_task_ratio: number | null;
   positive_task_count: number;
+  cold_input_tokens: number;
+  cold_cache_read_tokens: number;
+  cold_read_ratio: number | null;
+  all_input_tokens: number;
+  all_cache_read_tokens: number;
+  all_read_ratio: number | null;
   reasons: BenchmarkReason[];
 }
 

--- a/tests/cache-benchmark-online-foundation.test.ts
+++ b/tests/cache-benchmark-online-foundation.test.ts
@@ -74,6 +74,7 @@ test('online manifest counts the production memory branch for every capped task'
   const credential = loadOnlineProviderCredentials(file)[0];
   const manifest = buildOnlineCacheBenchmarkManifest(credential, 24);
 
+  assert.equal(manifest.criteria.include_cold_in_primary_ratio, false);
   assert.equal(manifest.cases.length, 8);
   assert.equal(new Set(manifest.cases.map(entry => entry.task_id)).size, 4);
   assert.equal(manifest.cases.filter(entry => entry.execution_role === 'main').length, 4);

--- a/tests/cache-benchmark.test.ts
+++ b/tests/cache-benchmark.test.ts
@@ -15,6 +15,7 @@ import {
   fingerprintCanonical,
   fingerprintManifest,
   fingerprintRoundEvidence,
+  parseLedgerJson,
   parseManifestJson,
   parseRoundJsonl,
   renderCacheBenchmarkResult,
@@ -41,10 +42,17 @@ describe('cache benchmark evidence scorer', () => {
     assert.equal(result.status, 'passed');
     assert.equal(result.exit_code, 0);
     assert.deepEqual(result.qualifying_rounds, [1, 2, 3]);
-    assert.equal(result.rounds[0].cells[0].input_tokens, 2000);
-    assert.equal(result.rounds[0].cells[0].cache_read_tokens, 1880);
+    assert.equal(result.rounds[0].cells[0].qualification_cache_class, 'warm');
+    assert.equal(result.rounds[0].cells[0].input_tokens, 1000);
+    assert.equal(result.rounds[0].cells[0].cache_read_tokens, 940);
     assert.equal(result.rounds[0].cells[0].raw_read_ratio, 0.94);
     assert.equal(result.rounds[0].cells[0].capped_task_ratio, 0.94);
+    assert.equal(result.rounds[0].cells[0].cold_input_tokens, 1000);
+    assert.equal(result.rounds[0].cells[0].cold_cache_read_tokens, 940);
+    assert.equal(result.rounds[0].cells[0].cold_read_ratio, 0.94);
+    assert.equal(result.rounds[0].cells[0].all_input_tokens, 2000);
+    assert.equal(result.rounds[0].cells[0].all_cache_read_tokens, 1880);
+    assert.equal(result.rounds[0].cells[0].all_read_ratio, 0.94);
   });
 
   test('passes the exact 94% water-filled boundary across many uneven tasks', () => {
@@ -98,7 +106,55 @@ describe('cache benchmark evidence scorer', () => {
     assert.equal(result.rounds[0].cells[0].cache_read_tokens, 0);
   });
 
-  test('treats a missing provider cache-read value as unobservable', () => {
+  test('keeps cold usage observable as diagnostics but qualifies on warm attempts only', () => {
+    const manifest = fixtureManifest();
+    const rounds = [1, 2, 3].map(round => buildRound(manifest, round, attempt => {
+      if (attempt.cache_class === 'cold') setProviderUsage(attempt, 250, 0);
+    }));
+    const result = scoreRounds(manifest, rounds);
+    const cell = result.rounds[0].cells[0];
+
+    assert.equal(result.status, 'passed');
+    assert.equal(cell.qualification_cache_class, 'warm');
+    assert.equal(cell.raw_read_ratio, 0.94);
+    assert.equal(cell.cold_input_tokens, 1000);
+    assert.equal(cell.cold_cache_read_tokens, 0);
+    assert.equal(cell.cold_read_ratio, 0);
+    assert.equal(cell.all_read_ratio, 0.47);
+  });
+
+  test('does not let a cache-hot cold diagnostic rescue warm evidence below 94%', () => {
+    const manifest = fixtureManifest();
+    const rounds = [1, 2, 3].map(round => buildRound(manifest, round, attempt => {
+      setProviderUsage(attempt, 250, attempt.cache_class === 'cold' ? 250 : 234);
+    }));
+    const result = scoreRounds(manifest, rounds);
+
+    assert.equal(result.status, 'failed');
+    assert.equal(result.rounds[0].cells[0].cold_read_ratio, 1);
+    assert.equal(result.rounds[0].cells[0].raw_read_ratio, 0.936);
+    assert.ok(result.reasons.includes('minimum_read_ratio_not_met'));
+  });
+
+  test('retains valid provider usage from failed physical attempts in diagnostics only', () => {
+    const manifest = fixtureManifest();
+    const rounds = [1, 2, 3].map(round => buildRound(manifest, round));
+    rounds[2].attempts[1].outcome = 'failed';
+    setProviderUsage(rounds[2].attempts[1], 300, 120);
+    const result = scoreRounds(manifest, rounds);
+    const cell = result.rounds[2].cells[0];
+
+    assert.equal(result.status, 'invalid');
+    assert.ok(result.reasons.includes('non_succeeded_attempt'));
+    assert.equal(cell.input_tokens, 750);
+    assert.equal(cell.cache_read_tokens, 705);
+    assert.equal(cell.cold_input_tokens, 1000);
+    assert.equal(cell.cold_cache_read_tokens, 940);
+    assert.equal(cell.all_input_tokens, 2050);
+    assert.equal(cell.all_cache_read_tokens, 1765);
+  });
+
+  test('keeps a missing cold provider cache-read value unobservable', () => {
     const manifest = fixtureManifest();
     const rounds = [1, 2, 3].map(round => buildRound(manifest, round));
     setProviderUsage(rounds[2].attempts[0], 250, undefined);
@@ -222,13 +278,76 @@ describe('cache benchmark evidence scorer', () => {
         extra.attempt_number = evidence.attempts.length + 1;
         evidence.attempts.push(extra);
       }
+      const branchAttempts = evidence.attempts
+        .filter(attempt => attempt.case_id === manifest.cases[2].case_id)
+        .sort((left, right) => left.logical_call - right.logical_call);
+      evidence.attempts = [
+        ...evidence.attempts.filter(attempt => attempt.case_id !== manifest.cases[2].case_id),
+        ...branchAttempts,
+      ];
+      evidence.attempts.forEach((attempt, index) => { attempt.attempt_number = index + 1; });
     }
     const result = scoreRounds(manifest, rounds);
 
     assert.equal(result.status, 'passed');
-    assert.equal(result.rounds[0].cells[0].input_tokens, 2750);
-    assert.equal(result.rounds[0].cells[0].cache_read_tokens, 2585);
+    assert.equal(result.rounds[0].cells[0].input_tokens, 1500);
+    assert.equal(result.rounds[0].cells[0].cache_read_tokens, 1410);
     assert.equal(result.rounds[0].cells[0].raw_read_ratio, 0.94);
+    assert.equal(result.rounds[0].cells[0].cold_input_tokens, 1250);
+    assert.equal(result.rounds[0].cells[0].cold_cache_read_tokens, 1175);
+  });
+
+  test('invalidates joined memory-branch evidence recorded after its main attempt', () => {
+    const manifest = fixtureManifest();
+    manifest.cases[1].task_id = manifest.cases[0].task_id;
+    manifest.cases[1].execution_role = 'memory_branch';
+    manifest.cases[1].runs[0].run_id = manifest.cases[0].runs[0].run_id;
+    const result = scoreRounds(manifest, [1, 2, 3].map(round => buildRound(manifest, round)));
+
+    assert.equal(result.status, 'invalid');
+    assert.ok(result.reasons.includes('attempt_order_mismatch'));
+  });
+
+  test('accepts multiple paired runs without comparing one run branch to another run main', () => {
+    const manifest = fixtureManifest();
+    const main = manifest.cases[0];
+    const branch = manifest.cases[1];
+    branch.task_id = main.task_id;
+    branch.execution_role = 'memory_branch';
+    branch.runs[0].run_id = main.runs[0].run_id;
+    main.runs.push({ ...main.runs[0], run_id: 'run-1-second' });
+    branch.runs.push({ ...branch.runs[0], run_id: 'run-1-second' });
+    const rounds = [1, 2, 3].map(roundNumber => {
+      const round = buildRound(manifest, roundNumber);
+      const paired = round.attempts.filter(attempt => attempt.metadata.task_id === main.task_id);
+      const other = round.attempts.filter(attempt => attempt.metadata.task_id !== main.task_id);
+      paired.sort((left, right) => (
+        left.run_id.localeCompare(right.run_id)
+        || left.logical_call - right.logical_call
+        || (left.attempt_role === right.attempt_role ? 0 : left.attempt_role === 'memory_branch' ? -1 : 1)
+      ));
+      round.attempts = [...paired, ...other];
+      round.attempts.forEach((attempt, index) => { attempt.attempt_number = index + 1; });
+      return round;
+    });
+    const result = scoreRounds(manifest, rounds);
+
+    assert.equal(result.rounds[0].reasons.includes('attempt_order_mismatch'), false);
+  });
+
+  test('invalidates a warm logical call recorded before its cold call', () => {
+    const manifest = fixtureManifest();
+    const rounds = [1, 2, 3].map(roundNumber => {
+      const round = buildRound(manifest, roundNumber);
+      [round.attempts[0], round.attempts[1]] = [round.attempts[1], round.attempts[0]];
+      round.attempts[0].attempt_number = 1;
+      round.attempts[1].attempt_number = 2;
+      return round;
+    });
+    const result = scoreRounds(manifest, rounds);
+
+    assert.equal(result.status, 'invalid');
+    assert.ok(result.reasons.includes('attempt_order_mismatch'));
   });
 
   test('rejects cache-cold evidence that reuses a prior round nonce', () => {
@@ -532,6 +651,40 @@ describe('cache benchmark evidence scorer', () => {
     ));
   });
 
+  test('rejects all v4 evidence schemas and any attempt to include cold usage in the primary ratio', () => {
+    const legacy = structuredClone(fixtureManifest()) as any;
+    legacy.schema = 'xiaoba.cache_benchmark_manifest.v4';
+    assert.throws(() => parseManifestJson(JSON.stringify(legacy)));
+
+    const coldIncluded = structuredClone(fixtureManifest()) as any;
+    coldIncluded.criteria.include_cold_in_primary_ratio = true;
+    assert.throws(() => parseManifestJson(JSON.stringify(coldIncluded)));
+
+    const round = buildRound(fixtureManifest(), 1);
+    const legacyRound = structuredClone(round) as any;
+    legacyRound.header.schema = 'xiaoba.cache_benchmark_round.v4';
+    assert.throws(() => parseRoundJsonl(roundToJsonl(legacyRound)));
+
+    const legacyAttempt = structuredClone(round) as any;
+    legacyAttempt.attempts[0].schema = 'xiaoba.cache_benchmark_attempt.v4';
+    assert.throws(() => parseRoundJsonl(roundToJsonl(legacyAttempt)));
+
+    const legacyLedger = structuredClone(buildLedger(fixtureManifest(), [round])) as any;
+    legacyLedger.schema = 'xiaoba.cache_benchmark_ledger.v4';
+    assert.throws(() => parseLedgerJson(JSON.stringify(legacyLedger)));
+  });
+
+  test('renders warm qualification and cold diagnostics without ambiguity', () => {
+    const manifest = fixtureManifest();
+    const result = scoreRounds(manifest, [1, 2, 3].map(round => buildRound(manifest, round)));
+    const report = renderCacheBenchmarkResult(result, 'text');
+
+    assert.match(report, /qualification_cache_class=warm/);
+    assert.match(report, /input_tokens=1000 cache_read_tokens=940/);
+    assert.match(report, /cold_input_tokens=1000 cold_cache_read_tokens=940 cold_read_ratio=0\.940000/);
+    assert.match(report, /all_input_tokens=2000 all_cache_read_tokens=1880 all_read_ratio=0\.940000/);
+  });
+
   test('accepts namespaced model IDs but rejects endpoint-shaped provider identities', () => {
     const manifest = fixtureManifest();
     manifest.cases[0].model = 'vendor/model-a';
@@ -610,7 +763,7 @@ describe('cache benchmark CLI safety', () => {
     assert.equal(passing.stdout.includes(directory), false);
 
     const failingRounds = [1, 2, 3].map(round => buildRound(manifest, round));
-    setProviderUsage(failingRounds[2].attempts[0], 250, 234);
+    setProviderUsage(failingRounds[2].attempts[1], 250, 234);
     const failingPaths = writeRoundFiles(directory, failingRounds, 'fail');
     const failingLedgerPath = writeLedger(directory, manifest, failingRounds, 'fail');
     const failing = spawnCli(manifestPath, failingLedgerPath, failingPaths);
@@ -726,7 +879,7 @@ function buildRound(
     for (const run of entry.runs) {
       for (const cacheClass of ['cold', 'warm'] as const) {
         const attempt: CacheBenchmarkAttempt = {
-          schema: 'xiaoba.cache_benchmark_attempt.v4',
+          schema: 'xiaoba.cache_benchmark_attempt.v5',
           suite_id: manifest.suite_id,
           round,
           attempt_number: attempts.length + 1,
@@ -779,7 +932,7 @@ function buildRound(
   }
   return {
     header: {
-      schema: 'xiaoba.cache_benchmark_round.v4',
+      schema: 'xiaoba.cache_benchmark_round.v5',
       suite_id: manifest.suite_id,
       round,
       cache_partition_nonce: round.toString(16).padStart(32, '0'),
@@ -807,7 +960,7 @@ function buildLedger(
 ): CacheBenchmarkLedger {
   const ordered = [...rounds].sort((left, right) => left.header.round - right.header.round);
   return {
-    schema: 'xiaoba.cache_benchmark_ledger.v4',
+    schema: 'xiaoba.cache_benchmark_ledger.v5',
     suite_id: manifest.suite_id,
     latest_round: ordered[ordered.length - 1]?.header.round ?? 1,
     rounds: ordered.map(round => ({

--- a/tests/fixtures/cache-benchmark/manifest.json
+++ b/tests/fixtures/cache-benchmark/manifest.json
@@ -1,11 +1,11 @@
 {
-  "schema": "xiaoba.cache_benchmark_manifest.v4",
+  "schema": "xiaoba.cache_benchmark_manifest.v5",
   "suite_id": "cache-truth-v1",
   "criteria": {
     "minimum_read_ratio": 0.94,
     "consecutive_rounds": 3,
     "maximum_task_weight": 0.25,
-    "include_cold_in_primary_ratio": true
+    "include_cold_in_primary_ratio": false
   },
   "cases": [
     {


### PR DESCRIPTION
## Summary
- advance strict cache benchmark evidence schemas from v4 to v5
- qualify the 94% gates on validated warm attempts only while retaining cold and all-attempt provider usage diagnostics
- keep cold calls mandatory and fail-closed across quality, safety, capability, usage, fingerprint, nonce, and exact-count checks
- enforce run-paired Memory Branch ordering and monotonic cold-to-warm logical calls
- document the measurement contract and remaining natural-growth/provider-wire work

## Verification
- `npm run build`
- focused cache benchmark suites: 64 passed, 0 failed
- full runtime suite: 1,532 total; 1,524 passed; 0 failed; 0 cancelled; 8 skipped
- compiled Dashboard smoke: `/` and `/api/status` returned HTTP 200
- two independent read-only final reviews: no P0-P2
- diff secret scan clean; no UI files changed

## Scope note
This PR is a measurement-contract stage. It does not claim that any provider has reached 94% or that the current repeated-session workload is final capability-complete evidence.