### PR TITLE
feat(cache): separate primary and auxiliary accounting

### DIFF
--- a/docs/CACHE_BENCHMARK.md
+++ b/docs/CACHE_BENCHMARK.md
@@ -12,7 +12,7 @@ Calibration runs diagnose the implementation. Acceptance requires the complete c
 The current online runner exercises the real typed Goal and Memory Branch paths. Every manifest it produces is explicitly sealed with `benchmark_profile: "calibration"`; even three 100% rounds remain `calibration_only` and cannot become a final pass. A later acceptance profile must satisfy the representative-workload requirements below.
 
 - Goal state is updated through `GoalRuntime`, persisted with the session, restored, and attested only from typed `goal_status` provenance.
-- Every workload runs the real Memory Branch and records every physical branch-provider attempt. One memory-only task must search, successfully read, publish an exact canonical ref backed by a branch-local content receipt, and link that observation into the main request. The other three tasks must suppress redundant memory when no authorized record is relevant.
+- Every workload runs the real Memory Branch and records every physical branch-provider attempt. One memory-only task must search, successfully read, publish an exact canonical ref backed by a branch-local content receipt, and link that observation into the main request. The other three tasks must suppress redundant memory when no authorized record is relevant. Branch usage remains observable and fail-closed, but its cache ratio does not qualify the primary model.
 - The joined branch mode is intentional for deterministic capability correlation. Final product-performance evidence must also exercise the production-default detached/concurrent path and late-observation behavior.
 - Repeating one fixed fixture is useful for diagnosing cache admission and prefix drift, but it is not a claim about real-task averages. Final evidence must add changing dynamic tails and a real project-task corpus.
 
@@ -27,19 +27,20 @@ The latest three consecutive rounds must pass every independent provider cell fo
 - `model`
 - `api_type`
 - `surface`
+- `traffic_class` (`primary` or `auxiliary_memory`)
 
-Each round has two token-weighted qualification gates over warm attempts only:
+Only `primary` cells qualify the cache target. Each round has two token-weighted qualification gates over their warm attempts:
 
 1. `sum(cache_read_tokens) / sum(input_tokens) >= 0.94`.
 2. The same ratio after task weights are water-filled so no task contributes more than 25% is at least `0.94`.
 
-At least four tasks must have positive input weight in each cell. `cache_write_tokens` is diagnostic only. A failed, retried, incomplete, unobservable, quality-failing, safety-failing, or capability-incomplete attempt invalidates the round. Artifact drift resets the streak, and the scorer never selects a more favorable historical trio.
+At least four tasks must have positive input weight in each primary cell. An `auxiliary_memory` cell reports its actual warm/cold/all token totals and raw ratio, but it has neither a 94% threshold nor a task-cap threshold. `cache_write_tokens` is diagnostic only. In both traffic classes, a failed, retried, incomplete, unobservable, quality-failing, safety-failing, or capability-incomplete attempt invalidates the round. Artifact drift resets the streak, and the scorer never selects a more favorable historical trio.
 
 The required cold call is not discarded or treated as a free calibration failure. Its valid provider-reported input and cache-read tokens are retained as `cold_*` diagnostics; `all_*` fields retain valid observable usage from all cold and warm physical attempts, including failed attempts that still report usage. Every cold physical attempt must pass the same usage observability, quality, safety, capability, metadata, and stable-prefix checks as a warm attempt. Cold usage is excluded only from the two 94% qualification ratios because a deliberately partitioned first request measures admission rather than reusable-prefix performance.
 
 ## Capability, quality, and safety gates
 
-The manifest as a whole must cover all fixed capabilities, and every physical provider request must attest the capabilities declared by its own case:
+Primary scopes must cover all fixed capabilities, and every physical provider request in either traffic class must attest the capabilities declared by its own case:
 
 - `identity`
 - `group-chat-participants`
@@ -63,13 +64,13 @@ The online runner derives this attestation from the actual request observed at t
 
 Stable-prefix drift within a case/run/round is invalid. Internal lifecycle IDs are excluded from the provider-visible fingerprint, but model-visible content and cache placement remain covered.
 
-The online workload uses four deterministic common tasks: repository orientation, test triage, destructive-action review, and next-step planning. It creates and restores a real session, installs a real read-only skill fixture, supplies trusted group identity and a scoped device grant, exposes actual tools, creates a typed Goal, plan, and active subagent, and injects runtime feedback. Each task has a paired Memory Branch case, so the manifest contains four main cases and four branch cases. Main calls must have exactly one physical provider attempt; a branch logical call may have one or more physical attempts, all of which remain in token-weighted scoring.
+The online workload uses four deterministic common tasks: repository orientation, test triage, destructive-action review, and next-step planning. It creates and restores a real session, installs a real read-only skill fixture, supplies trusted group identity and a scoped device grant, exposes actual tools, creates a typed Goal, plan, and active subagent, and injects runtime feedback. Each task has a paired Memory Branch case, so the manifest contains four main cases and four branch cases. Each current main logical call must contain exactly one physical provider attempt. A branch logical call may contain multiple physical attempts for its tool loop; every attempt remains ordered, observable, and token-accounted. Future primary tool loops require a sealed continuation contract before this exact-one rule can be relaxed without permitting ratio padding.
 
 The destructive-action task is deliberately memory-only: its restored transcript contains an opaque action record ID, while the prior classification and exact decision token exist only in one authorized historical ref. The branch must publish that exact ref and the linked main call must use the observation. A finish payload cannot invent provenance: every published ref must have a branch-local receipt from a successful `memory_read_turn` or `memory_neighbors` result, and the benchmark requires the expected SHA-256 of the model-visible read result. The other three tasks have no relevant authorized memory and must finish with `inject:false`; suppressed branches prove that the sidecar ran without granting a fake `memory` capability to the main request.
 
 ## Provider usage contracts
 
-Version 5 evidence does not accept collector-supplied normalized `input_tokens`, `cache_read_tokens`, or `cache_read_source` fields. Each attempt seals `usage.provider_usage`, an allowlisted projection of the exact numeric fields returned by the provider. The offline scorer selects the contract, derives normalized input/read counts, and verifies that the derived source matches the manifest:
+Version 6 evidence does not accept collector-supplied normalized `input_tokens`, `cache_read_tokens`, or `cache_read_source` fields. Each attempt seals `usage.provider_usage`, an allowlisted projection of the exact numeric fields returned by the provider. The offline scorer selects the contract, derives normalized input/read counts, and verifies that the derived source matches the manifest:
 
 | Raw usage contract | Allowed provider fields | Scorer input | Scorer cache read and exact source |
 | --- | --- | --- | --- |
@@ -82,19 +83,19 @@ Fields from another contract and unknown fields are rejected. All present usage 
 
 ## Evidence schemas
 
-The strict v5 schemas are:
+The strict v6 schemas are:
 
-- `xiaoba.cache_benchmark_manifest.v5`
-- `xiaoba.cache_benchmark_round.v5`
-- `xiaoba.cache_benchmark_attempt.v5`
-- `xiaoba.cache_benchmark_ledger.v5`
-- `xiaoba.cache_benchmark_result.v5`
+- `xiaoba.cache_benchmark_manifest.v6`
+- `xiaoba.cache_benchmark_round.v6`
+- `xiaoba.cache_benchmark_attempt.v6`
+- `xiaoba.cache_benchmark_ledger.v6`
+- `xiaoba.cache_benchmark_result.v6`
 
-Unknown or missing fields are rejected. The manifest fixes the acceptance criteria at `0.94`, three consecutive rounds, a 25% maximum task weight, and warm-only qualification (`include_cold_in_primary_ratio` must be `false`). It also fixes exact cold/warm call counts, task fixtures, oracle contracts, execution plans, capability coverage, and provider usage sources.
+Unknown or missing fields are rejected. The manifest fixes the acceptance criteria at `0.94`, three consecutive rounds, a 25% maximum task weight, warm-only qualification (`include_cold_in_primary_ratio` must be `false`), and `qualification_traffic_class: "primary"`. Main attempts derive the `primary` class and Memory Branch attempts derive `auxiliary_memory`; only primary cache ratios qualify, while auxiliary usage observability, completion, quality, safety, capability, and provenance gates remain mandatory. It also fixes exact cold/warm call counts, task fixtures, oracle contracts, execution plans, capability coverage, and provider usage sources.
 
 Online manifests additionally seal `benchmark_profile` and a provider-neutral `workload_contract_fingerprint`. The config fingerprint covers both values as well as the fixed scoring criteria. Legacy offline fixtures may omit the pair, but final multi-provider acceptance rejects any manifest that is not explicitly `acceptance`.
 
-Each evidence JSONL contains one round header followed by attempts in the exact physical order observed by the synchronous attempt journal. Within a case/run, logical calls must remain monotonic from cold to warm. A joined memory-branch call sharing the same task, cell, run ID, and logical call must precede its main call. `attempt_number` must be contiguous and every provider retry becomes an additional attempt; retries cannot be hidden behind a logical call. Each attempt seals `attempt_role` (`main` or `memory_branch`) and `logical_call`. A main logical call must have exactly one physical attempt; a branch logical call may have 1–N and every one is scored. The attempt usage object contains only the raw `provider_usage` projection described above. The ledger enumerates every round from 1 through `latest_round`, and fingerprints cover the entire canonical round. Missing, extra, reordered, or modified evidence is invalid.
+Each evidence JSONL contains one round header followed by attempts in the exact physical order observed by the synchronous attempt journal. Within a case/run, logical calls must remain monotonic from cold to warm. A joined memory-branch call sharing the same task, run ID, and logical call must precede its main call even when the branch uses a different provider/model. `attempt_number` must be contiguous and every provider retry or branch tool-loop continuation becomes an additional attempt; physical attempts cannot be hidden behind a logical call. Each attempt seals `attempt_role` (`main` or `memory_branch`) and `logical_call`. The manifest fixes the exact number and cache class of logical calls; every main logical call has exactly one physical attempt, while a declared branch logical call may have one or more fully recorded attempts. The attempt usage object contains only the raw `provider_usage` projection described above. The ledger enumerates every round from 1 through `latest_round`, and fingerprints cover the entire canonical round. Missing logical calls, undeclared logical calls, primary call padding, reordered attempts, or modified evidence are invalid.
 
 The round header also seals a random 128-bit `cache_partition_nonce`. The nonce is reserved before network activity and appears in the first system marker for every case in that run. It stays fixed across that case's warm calls, but changes for every new invocation even when case and round numbers are reused in a different output directory. This makes a required cold request distinguishable from every prior calibration run.
 
@@ -176,4 +177,4 @@ npm run benchmark:cache:acceptance -- \
 
 The aggregator takes the same exclusive `.online-run.lock` used by the writer while loading each provider snapshot. It rejects an active writer, missing or extra round/reservation files, and any reservation that is not exactly one `started` record followed by a matching `sealed` record whose suite, nonce, artifact, manifest, config, and evidence fingerprints bind the sealed round and ledger.
 
-It then runs the strict scorer itself and requires exactly NewCLI Responses plus DeepSeek Chat Completions, explicit `acceptance` profiles, at least 24 warm logical calls per case, three passing qualifying rounds per provider, and one identical executable artifact fingerprint across both provider streaks. That artifact fingerprint covers compiled code, prompts, package manifests and lockfile, every installed `node_modules` file and in-tree symlink target, and the actual Node/V8/OpenSSL/platform/architecture runtime contract. A repository-external `node_modules` root is allowed only because its resolved bytes are scanned; dependency symlinks that escape that resolved tree fail closed. The fingerprint is recomputed before execution and after the round to detect drift. The provider-neutral workload fingerprint is recomputed from the concrete task fixture, oracle, execution plan, scenario, role, capability, surface, and run contract of every case; a self-declared hash cannot conceal different workloads. Missing/duplicate or disguised providers, calibration evidence, insufficient samples, malformed evidence, or mismatched workload/artifact identities fail closed. A valid but observable provider result that simply misses the ratio remains an ordinary failed acceptance (exit 1), not invalid evidence.
+It then runs the strict scorer itself and requires exactly NewCLI Responses plus DeepSeek Chat Completions for the primary traffic, explicit `acceptance` profiles, at least 24 warm logical calls per primary case, three passing qualifying rounds per provider, and one identical executable artifact fingerprint across both provider streaks. Acceptance also recomputes a versioned official topology fingerprint over task fixtures, oracle/execution plans, scenario, surface, role, declared capabilities, and run identity. Provider fields and warm sample counts are deliberately excluded from that topology fingerprint, then validated separately. Every provider-visible `case_id` must additionally equal the official provider/task/role identity, so a renamed or padded stable partition marker also fails. The current joined topology requires each task's main and branch cases to declare identical run IDs and cold/warm logical-call counts; a separate small branch provider is allowed, but undersampling or running it after the paired main call is not. Relabeling a cache-hostile main case as auxiliary therefore fails even if every ordinary manifest/workload fingerprint is recomputed. A future asynchronous/sampled Memory Branch must introduce a new versioned topology and explicit link schedule rather than silently weakening this joined contract. That artifact fingerprint covers compiled code, prompts, package manifests and lockfile, every installed `node_modules` file and in-tree symlink target, and the actual Node/V8/OpenSSL/platform/architecture runtime contract. A repository-external `node_modules` root is allowed only because its resolved bytes are scanned; dependency symlinks that escape that resolved tree fail closed. The fingerprint is recomputed before execution and after the round to detect drift. The provider-neutral workload fingerprint is recomputed from the concrete task fixture, oracle, execution plan, scenario, role, capability, surface, and run contract of every case; a self-declared hash cannot conceal different workloads. Missing/duplicate or disguised primary providers, calibration evidence, insufficient primary samples, topology drift, malformed evidence, or mismatched workload/artifact identities fail closed. A valid but observable primary result that simply misses the ratio remains an ordinary failed acceptance (exit 1), not invalid evidence.

--- a/docs/evidence/cache-stage9-primary-auxiliary-accounting-2026-08-02.md
+++ b/docs/evidence/cache-stage9-primary-auxiliary-accounting-2026-08-02.md
@@ -1,0 +1,50 @@
+# Stage 9 evidence: primary and auxiliary cache accounting
+
+Date: 2026-08-02
+
+## Scope
+
+This stage freezes the acceptance boundary requested for Memory Branch traffic:
+
+- main-agent model attempts are `primary` and alone qualify against the 94% target;
+- asynchronous Memory Branch attempts are `auxiliary_memory` and do not pass or fail on cache ratio;
+- every auxiliary physical attempt still requires real provider usage, terminal success, quality, safety, declared capability/provenance, ordering, metadata, and stable-prefix evidence;
+- a cache-hot auxiliary branch cannot rescue a low primary ratio, and a cache-cold branch cannot lower a passing primary ratio.
+
+The evidence schema is v6 because this changes scoring semantics. Traffic class is derived from the sealed execution role and is included in cell and capability-scope fingerprints and reports.
+
+## Baseline reinterpretation
+
+The private Stage 8 calibration evidence was reinterpreted without changing any provider usage:
+
+- NewCLI primary warm usage: `29,696 / 31,561 = 94.090808%`.
+- NewCLI auxiliary Memory Branch warm usage: `15,360 / 27,811 = 55.229945%`.
+- DeepSeek primary warm usage in the one-warm canary: `30,080 / 36,187 = 83.123774%`.
+- DeepSeek auxiliary Memory Branch warm usage: `37,760 / 39,375 = 95.898413%`.
+
+The NewCLI result therefore already crosses the primary boundary even though its branch does not. The DeepSeek one-warm result does not yet qualify, but inspection of the prior three-warm provider evidence showed that the unsafe-action main prefix learned after its first warm request: `3,072 / 9,095`, then `8,832 / 9,065`, then `8,832 / 9,070`. A separate real-provider probe reproduced the same admission behavior for both exact and changing dynamic tails. The low first hit is retained in the formal denominator; no observation/provider rewrite is justified.
+
+## Integrity controls
+
+- Primary and auxiliary cases with the same provider/model/API/surface occupy different cells.
+- Primary cells retain the raw token-weighted and 25%-task-capped 94% gates. Auxiliary cells report raw/cold/all totals but have no ratio or task-cap threshold.
+- Observable usage from failed warm attempts remains in the denominator while the attempt invalidates the round; failure cannot hide low cache usage.
+- Each primary logical call still requires exactly one physical attempt, preventing appended cache-hot calls from padding the ratio. Branch tool loops may contain multiple fully recorded attempts.
+- Primary capability scopes must cover all eleven Goal capabilities. Auxiliary scopes must cover every capability declared by their branch cases, including `memory` only when evidence-backed provenance was observed.
+- Final provider identity and the 24-warm minimum apply to primary cases. A separate auxiliary small-model provider is allowed, but the current joined topology requires its declared logical-call schedule to match each paired main case.
+- Final acceptance recomputes a versioned official topology fingerprint over task fixtures, oracle and execution plans, scenario, surface, role, capabilities, and run identity. Provider fields and warm counts are checked separately, every provider-visible case ID must equal the official provider/task/role identity, and provider-neutral main/branch ordering is enforced. Relabeling main traffic as auxiliary, padding the stable case marker, or undersampling a joined branch fails even if ordinary manifest, workload, config, and result fingerprints are recomputed.
+- The default online manifest now fingerprints the memory fixture with the same raw-byte SHA-256 contract used by the sealed runtime fixture, so the official topology equals real online evidence.
+
+## Verification
+
+- `npm run build`: passed.
+- Official runtime suite: 1,647 total / 1,639 passed / 0 failed / 8 skipped.
+- Regression coverage proves auxiliary 0% does not fail primary qualification, auxiliary 100% does not rescue a primary miss, and separate auxiliary provider/model usage is scored without joining the primary ratio.
+- Auxiliary failed/non-terminal outcomes, missing cache-read usage, quality or safety failures, missing memory capability/provenance, and role mismatch all remain fail-closed.
+- A role-swap acceptance regression recomputes every ordinary workload/result fingerprint and is still rejected by official topology binding.
+- Secret scan found no provider credential in repository changes.
+- The actual Dashboard started against an isolated runtime root on port 4394; `/`, `/api/status`, and `/readiness` returned HTTP 200, then the process exited cleanly. No dashboard or UI file changed, so desktop/mobile visual interaction testing was not applicable.
+
+## Acceptance status
+
+This stage establishes correct accounting; it does not itself claim final goal completion. The remaining acceptance action is to expose the sealed `acceptance` runner profile and collect three consecutive 24-warm primary rounds for both NewCLI and DeepSeek from one unchanged artifact.

--- a/src/cache-benchmark/acceptance.ts
+++ b/src/cache-benchmark/acceptance.ts
@@ -1,4 +1,5 @@
 import {
+  fingerprintBenchmarkAcceptanceTopology,
   fingerprintBenchmarkWorkloadContract,
   fingerprintConfig,
   fingerprintManifest,
@@ -9,6 +10,8 @@ import type { CacheBenchmarkManifest, CacheBenchmarkResult } from './types';
 export const CACHE_BENCHMARK_ACCEPTANCE_SCHEMA = 'xiaoba.cache_benchmark_acceptance.v1' as const;
 export const REQUIRED_ACCEPTANCE_PROVIDERS = ['newcli', 'deepseek'] as const;
 export const MINIMUM_ACCEPTANCE_WARM_CALLS = 24;
+export const REQUIRED_ACCEPTANCE_TOPOLOGY_FINGERPRINT =
+  'sha256:fea44796d4b4b4b7f2373fb572f80688c1fbb25232d350621cdbe2febb9cb500' as const;
 
 export type AcceptanceProviderAlias = typeof REQUIRED_ACCEPTANCE_PROVIDERS[number];
 export type CacheBenchmarkAcceptanceReason =
@@ -21,6 +24,7 @@ export type CacheBenchmarkAcceptanceReason =
   | 'insufficient_warm_calls'
   | 'provider_not_passed'
   | 'qualifying_rounds_invalid'
+  | 'workload_topology_mismatch'
   | 'workload_contract_invalid'
   | 'workload_contract_mismatch'
   | 'config_fingerprint_mismatch'
@@ -92,14 +96,22 @@ export function aggregateCacheBenchmarkAcceptance(
       reasons.add('provider_identity_mismatch');
     }
     const actualWorkloadFingerprint = fingerprintBenchmarkWorkloadContract(manifest.cases);
+    const actualTopologyFingerprint = fingerprintBenchmarkAcceptanceTopology(manifest.cases);
     if (manifest.benchmark_profile !== 'acceptance' || !manifest.workload_contract_fingerprint) {
       reasons.add('profile_not_acceptance');
     }
     if (manifest.workload_contract_fingerprint !== actualWorkloadFingerprint) {
       reasons.add('workload_contract_invalid');
     }
+    if (
+      actualTopologyFingerprint !== REQUIRED_ACCEPTANCE_TOPOLOGY_FINGERPRINT
+      || !officialCaseIdentitiesMatch(provider, manifest)
+      || !officialJoinedScheduleMatches(manifest)
+    ) {
+      reasons.add('workload_topology_mismatch');
+    }
     workloadFingerprints.add(actualWorkloadFingerprint);
-    if (manifest.cases.some(entry => entry.runs.some(
+    if (manifest.cases.some(entry => entry.execution_role === 'main' && entry.runs.some(
       run => run.required_warm_calls < MINIMUM_ACCEPTANCE_WARM_CALLS,
     ))) reasons.add('insufficient_warm_calls');
     if (result.config_fingerprint !== expectedConfigFingerprint) {
@@ -153,6 +165,7 @@ export function aggregateCacheBenchmarkAcceptance(
     || reason === 'profile_not_acceptance'
     || reason === 'insufficient_warm_calls'
     || reason === 'qualifying_rounds_invalid'
+    || reason === 'workload_topology_mismatch'
     || reason === 'workload_contract_invalid'
     || reason === 'workload_contract_mismatch'
     || reason === 'config_fingerprint_mismatch'
@@ -175,18 +188,20 @@ function providerIdentityMatches(
   manifest: CacheBenchmarkManifest,
 ): boolean {
   if (!manifest.suite_id.startsWith(`xiaoba-online-${provider}-`)) return false;
-  const instances = new Set(manifest.cases.map(entry => entry.provider_instance_id));
+  const primaryCases = manifest.cases.filter(entry => entry.execution_role === 'main');
+  if (primaryCases.length === 0) return false;
+  const instances = new Set(primaryCases.map(entry => entry.provider_instance_id));
   if (instances.size !== 1) return false;
   if (provider === 'newcli') {
     return [...instances].every(value => /^newcli:openai-responses:endpoint-[a-f0-9]{32}$/u.test(value))
-      && manifest.cases.every(entry => (
+      && primaryCases.every(entry => (
         entry.provider_adapter === 'openai'
         && entry.api_type === 'openai-responses'
         && entry.cache_read_source === 'openai.input_tokens_details.cached_tokens'
       ));
   }
   return [...instances].every(value => /^deepseek:openai-chat-completions:endpoint-[a-f0-9]{32}$/u.test(value))
-    && manifest.cases.every(entry => (
+    && primaryCases.every(entry => (
       entry.provider_adapter === 'openai'
       && entry.api_type === 'openai-chat-completions'
       && (
@@ -194,6 +209,37 @@ function providerIdentityMatches(
         || entry.cache_read_source === 'deepseek.prompt_cache_hit_tokens'
       )
     ));
+}
+
+function officialCaseIdentitiesMatch(
+  provider: AcceptanceProviderAlias,
+  manifest: CacheBenchmarkManifest,
+): boolean {
+  return manifest.cases.every(entry => entry.case_id === [
+    provider,
+    entry.task_id,
+    entry.execution_role === 'main' ? 'main' : 'memory',
+  ].join('-'));
+}
+
+function officialJoinedScheduleMatches(manifest: CacheBenchmarkManifest): boolean {
+  const casesByTask = new Map<string, CacheBenchmarkManifest['cases']>();
+  for (const entry of manifest.cases) {
+    const entries = casesByTask.get(entry.task_id) ?? [];
+    entries.push(entry);
+    casesByTask.set(entry.task_id, entries);
+  }
+  return [...casesByTask.values()].every(entries => {
+    const main = entries.find(entry => entry.execution_role === 'main');
+    const branch = entries.find(entry => entry.execution_role === 'memory_branch');
+    if (!main || !branch || entries.length !== 2 || main.runs.length !== branch.runs.length) return false;
+    return main.runs.every((mainRun, index) => {
+      const branchRun = branch.runs[index];
+      return mainRun.run_id === branchRun.run_id
+        && mainRun.required_cold_calls === branchRun.required_cold_calls
+        && mainRun.required_warm_calls === branchRun.required_warm_calls;
+    });
+  });
 }
 
 function isAcceptanceProvider(value: string): value is AcceptanceProviderAlias {

--- a/src/cache-benchmark/canonical.ts
+++ b/src/cache-benchmark/canonical.ts
@@ -67,6 +67,36 @@ export function fingerprintBenchmarkWorkloadContract(
   });
 }
 
+/**
+ * Binds acceptance to the official case/role topology while allowing provider
+ * identities and independently chosen primary/auxiliary sample counts to vary.
+ */
+export function fingerprintBenchmarkAcceptanceTopology(
+  cases: readonly CacheBenchmarkCase[],
+): string {
+  const projections = cases.map(entry => ({
+    surface: entry.surface,
+    task_id: entry.task_id,
+    task_fixture_fingerprint: entry.task_fixture_fingerprint,
+    oracle_contract_fingerprint: entry.oracle_contract_fingerprint,
+    execution_plan_fingerprint: entry.execution_plan_fingerprint,
+    scenario_family: entry.scenario_family,
+    session_type: entry.session_type,
+    execution_role: entry.execution_role,
+    capabilities: [...entry.capabilities].sort(compareStrings),
+    runs: [...entry.runs]
+      .sort(compareRuns)
+      .map(run => ({
+        run_id: run.run_id,
+        required_cold_calls: run.required_cold_calls,
+      })),
+  })).sort((left, right) => compareStrings(canonicalJson(left), canonicalJson(right)));
+  return fingerprintCanonical({
+    schema: 'xiaoba.cache_benchmark_acceptance_topology.v1',
+    cases: projections,
+  });
+}
+
 export function normalizeManifest(manifest: CacheBenchmarkManifest): CacheBenchmarkManifest {
   return {
     ...manifest,

--- a/src/cache-benchmark/online-runner.ts
+++ b/src/cache-benchmark/online-runner.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from 'node:crypto';
+import { createHash, randomBytes } from 'node:crypto';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { ChatResponse, Message } from '../types';
@@ -359,7 +359,7 @@ export async function runOnlineCacheBenchmark(
 export function buildOnlineCacheBenchmarkManifest(
   credential: OnlineProviderCredential,
   warmCalls: number,
-  memoryFixtureFingerprint = fingerprintCanonical({ source: buildMemoryFixtureSource() }),
+  memoryFixtureFingerprint = fingerprintMemoryFixtureSource(),
 ): CacheBenchmarkManifest {
   const cases: CacheBenchmarkCase[] = WORKLOADS.flatMap(workload => {
     const shared = {
@@ -441,6 +441,7 @@ export function buildOnlineCacheBenchmarkManifest(
       consecutive_rounds: 3,
       maximum_task_weight: 0.25,
       include_cold_in_primary_ratio: false,
+      qualification_traffic_class: 'primary',
     },
     cases,
   };
@@ -1090,6 +1091,10 @@ function buildMemoryFixtureSource(): string {
     },
     tokens: { prompt: 1, completion: 1 },
   }) + '\n';
+}
+
+function fingerprintMemoryFixtureSource(): string {
+  return `sha256:${createHash('sha256').update(buildMemoryFixtureSource(), 'utf8').digest('hex')}`;
 }
 
 function expectedMemoryFixtureReadFingerprint(): string {

--- a/src/cache-benchmark/reporter.ts
+++ b/src/cache-benchmark/reporter.ts
@@ -1,5 +1,5 @@
 import { canonicalJson } from './canonical';
-import { CacheBenchmarkResult } from './types';
+import { CACHE_BENCHMARK_RESULT_SCHEMA, CacheBenchmarkResult } from './types';
 
 export type CacheBenchmarkReportFormat = 'json' | 'text';
 
@@ -21,7 +21,7 @@ export function renderCacheBenchmarkResult(
   ];
   for (const coverage of result.capability_coverage) {
     lines.push(
-      `capability_scope=${coverage.scope_fingerprint} status=${coverage.status} missing_capabilities=${coverage.missing_capabilities.join(',') || 'none'}`,
+      `capability_scope=${coverage.scope_fingerprint} traffic_class=${coverage.traffic_class} status=${coverage.status} missing_capabilities=${coverage.missing_capabilities.join(',') || 'none'}`,
     );
   }
   for (const round of result.rounds) {
@@ -31,6 +31,7 @@ export function renderCacheBenchmarkResult(
     for (const cell of round.cells) {
       lines.push([
         `cell=${cell.cell_fingerprint}`,
+        `traffic_class=${cell.traffic_class}`,
         `status=${cell.status}`,
         `qualification_cache_class=${cell.qualification_cache_class}`,
         `input_tokens=${cell.input_tokens}`,
@@ -54,7 +55,7 @@ export function renderCacheBenchmarkResult(
 export function renderCacheBenchmarkInputError(format: CacheBenchmarkReportFormat): string {
   if (format === 'json') {
     return `${canonicalJson({
-      schema: 'xiaoba.cache_benchmark_result.v5',
+      schema: CACHE_BENCHMARK_RESULT_SCHEMA,
       status: 'invalid',
       exit_code: 2,
       reasons: ['schema_invalid'],

--- a/src/cache-benchmark/schema.ts
+++ b/src/cache-benchmark/schema.ts
@@ -171,18 +171,21 @@ function parseCriteria(value: unknown): CacheBenchmarkCriteria {
     'consecutive_rounds',
     'maximum_task_weight',
     'include_cold_in_primary_ratio',
+    'qualification_traffic_class',
   ]);
   if (
     record.minimum_read_ratio !== 0.94
     || record.consecutive_rounds !== 3
     || record.maximum_task_weight !== 0.25
     || record.include_cold_in_primary_ratio !== false
+    || record.qualification_traffic_class !== 'primary'
   ) invalid();
   return {
     minimum_read_ratio: 0.94,
     consecutive_rounds: 3,
     maximum_task_weight: 0.25,
     include_cold_in_primary_ratio: false,
+    qualification_traffic_class: 'primary',
   };
 }
 

--- a/src/cache-benchmark/scorer.ts
+++ b/src/cache-benchmark/scorer.ts
@@ -20,6 +20,7 @@ import {
   CacheBenchmarkResult,
   CacheBenchmarkRoundEvidence,
   CacheBenchmarkRoundResult,
+  CacheBenchmarkTrafficClass,
   CacheReadSource,
   CACHE_BENCHMARK_RESULT_SCHEMA,
   REQUIRED_CACHE_BENCHMARK_CAPABILITIES,
@@ -38,6 +39,7 @@ interface TaskTotals {
 
 interface CellAccumulator {
   fingerprint: string;
+  trafficClass: CacheBenchmarkTrafficClass;
   reasons: Set<BenchmarkReason>;
   input: number;
   read: number;
@@ -261,8 +263,10 @@ function scoreRound(
     const fingerprint = fingerprintCell(caseEntry);
     let cell = cells.get(fingerprint);
     if (!cell) {
+      const trafficClass = trafficClassForRole(caseEntry.execution_role);
       cell = {
         fingerprint,
+        trafficClass,
         reasons: new Set(),
         input: 0,
         read: 0,
@@ -314,7 +318,6 @@ function scoreRound(
     runAttempts.push(attempt);
     attemptsByRun.set(key, runAttempts);
     const orderKey = [
-      cell.fingerprint,
       expected.caseEntry.task_id,
       attempt.run_id,
       attempt.logical_call,
@@ -466,7 +469,6 @@ function scoreAttempt(
     cell.coldRead += read;
     return;
   }
-  if (!succeeded) return;
   cell.input += usage.input;
   cell.read += read;
   const task = cell.tasks.get(attempt.metadata.task_id) ?? { input: 0, read: 0 };
@@ -534,20 +536,27 @@ function finalizeCell(cell: CellAccumulator, manifest: CacheBenchmarkManifest): 
   const allRatio = allInput > 0 ? allRead / allInput : null;
   if (cell.input > 0) {
     rawRatio = cell.read / cell.input;
-    if (!meetsThreshold(rawRatio, manifest.criteria.minimum_read_ratio)) {
+    if (
+      cell.trafficClass === manifest.criteria.qualification_traffic_class
+      && !meetsThreshold(rawRatio, manifest.criteria.minimum_read_ratio)
+    ) {
       reasons.add('minimum_read_ratio_not_met');
     }
   }
-  if (positiveTasks.length < Math.ceil(1 / manifest.criteria.maximum_task_weight)) {
-    reasons.add('insufficient_positive_tasks');
-  } else {
+  if (positiveTasks.length >= Math.ceil(1 / manifest.criteria.maximum_task_weight)) {
     cappedRatio = calculateCappedTaskRatio(positiveTasks, manifest.criteria.maximum_task_weight);
-    if (!meetsThreshold(cappedRatio, manifest.criteria.minimum_read_ratio)) {
+    if (
+      cell.trafficClass === manifest.criteria.qualification_traffic_class
+      && !meetsThreshold(cappedRatio, manifest.criteria.minimum_read_ratio)
+    ) {
       reasons.add('minimum_capped_task_ratio_not_met');
     }
+  } else if (cell.trafficClass === manifest.criteria.qualification_traffic_class) {
+    reasons.add('insufficient_positive_tasks');
   }
   return {
     cell_fingerprint: cell.fingerprint,
+    traffic_class: cell.trafficClass,
     status: statusFromReasons([...reasons]),
     qualification_cache_class: 'warm',
     input_tokens: cell.input,
@@ -621,6 +630,7 @@ function fingerprintCell(caseEntry: CacheBenchmarkCase): string {
     model: caseEntry.model,
     api_type: caseEntry.api_type,
     surface: caseEntry.surface,
+    traffic_class: trafficClassForRole(caseEntry.execution_role),
   });
 }
 
@@ -628,39 +638,69 @@ function buildCapabilityCoverage(
   manifest: CacheBenchmarkManifest,
   attempts: readonly CacheBenchmarkAttempt[],
 ): CacheBenchmarkCoverageResult[] {
-  const scopes = new Map<string, Set<CacheBenchmarkCapability>>();
+  const scopes = new Map<string, {
+    trafficClass: CacheBenchmarkTrafficClass;
+    required: Set<CacheBenchmarkCapability>;
+    observed: Set<CacheBenchmarkCapability>;
+  }>();
   for (const entry of manifest.cases) {
+    const trafficClass = trafficClassForRole(entry.execution_role);
     const scopeFingerprint = fingerprintCanonical({
       provider_instance_id: entry.provider_instance_id,
       provider_adapter: entry.provider_adapter,
       model: entry.model,
       api_type: entry.api_type,
+      traffic_class: trafficClass,
     });
-    if (!scopes.has(scopeFingerprint)) scopes.set(scopeFingerprint, new Set());
+    let scope = scopes.get(scopeFingerprint);
+    if (!scope) {
+      scope = {
+        trafficClass,
+        required: new Set(trafficClass === 'primary'
+          ? REQUIRED_CACHE_BENCHMARK_CAPABILITIES
+          : []),
+        observed: new Set(),
+      };
+      scopes.set(scopeFingerprint, scope);
+    }
+    if (trafficClass === 'auxiliary_memory') {
+      for (const capability of entry.capabilities) scope.required.add(capability);
+    }
   }
   const cases = new Map(manifest.cases.map(entry => [entry.case_id, entry]));
   for (const attempt of attempts) {
     const entry = cases.get(attempt.case_id);
     if (!entry) continue;
+    const trafficClass = trafficClassForRole(entry.execution_role);
     const scopeFingerprint = fingerprintCanonical({
       provider_instance_id: entry.provider_instance_id,
       provider_adapter: entry.provider_adapter,
       model: entry.model,
       api_type: entry.api_type,
+      traffic_class: trafficClass,
     });
-    const capabilities = scopes.get(scopeFingerprint)!;
-    for (const capability of attempt.attestation.observed_capabilities) capabilities.add(capability);
+    const scope = scopes.get(scopeFingerprint)!;
+    for (const capability of attempt.attestation.observed_capabilities) {
+      scope.observed.add(capability);
+    }
   }
   return [...scopes.entries()]
-    .map(([scopeFingerprint, capabilities]) => {
-      const missing = REQUIRED_CACHE_BENCHMARK_CAPABILITIES.filter(capability => !capabilities.has(capability));
+    .map(([scopeFingerprint, scope]) => {
+      const missing = REQUIRED_CACHE_BENCHMARK_CAPABILITIES.filter(capability => (
+        scope.required.has(capability) && !scope.observed.has(capability)
+      ));
       return {
         scope_fingerprint: scopeFingerprint,
+        traffic_class: scope.trafficClass,
         status: missing.length === 0 ? 'passed' as const : 'incomplete' as const,
         missing_capabilities: [...missing],
       };
     })
     .sort((left, right) => compareStrings(left.scope_fingerprint, right.scope_fingerprint));
+}
+
+function trafficClassForRole(role: CacheBenchmarkCase['execution_role']): CacheBenchmarkTrafficClass {
+  return role === 'main' ? 'primary' : 'auxiliary_memory';
 }
 
 function runKey(caseId: string, runId: string): string {

--- a/src/cache-benchmark/types.ts
+++ b/src/cache-benchmark/types.ts
@@ -1,10 +1,10 @@
 import type { ProviderReportedUsage } from '../types';
 
-export const CACHE_BENCHMARK_MANIFEST_SCHEMA = 'xiaoba.cache_benchmark_manifest.v5' as const;
-export const CACHE_BENCHMARK_LEDGER_SCHEMA = 'xiaoba.cache_benchmark_ledger.v5' as const;
-export const CACHE_BENCHMARK_ROUND_SCHEMA = 'xiaoba.cache_benchmark_round.v5' as const;
-export const CACHE_BENCHMARK_ATTEMPT_SCHEMA = 'xiaoba.cache_benchmark_attempt.v5' as const;
-export const CACHE_BENCHMARK_RESULT_SCHEMA = 'xiaoba.cache_benchmark_result.v5' as const;
+export const CACHE_BENCHMARK_MANIFEST_SCHEMA = 'xiaoba.cache_benchmark_manifest.v6' as const;
+export const CACHE_BENCHMARK_LEDGER_SCHEMA = 'xiaoba.cache_benchmark_ledger.v6' as const;
+export const CACHE_BENCHMARK_ROUND_SCHEMA = 'xiaoba.cache_benchmark_round.v6' as const;
+export const CACHE_BENCHMARK_ATTEMPT_SCHEMA = 'xiaoba.cache_benchmark_attempt.v6' as const;
+export const CACHE_BENCHMARK_RESULT_SCHEMA = 'xiaoba.cache_benchmark_result.v6' as const;
 
 export const CACHE_READ_SOURCES = [
   'openai.input_tokens_details.cached_tokens',
@@ -34,6 +34,7 @@ export type ProviderAdapter = 'openai' | 'anthropic';
 export type ApiType = 'openai-responses' | 'openai-chat-completions' | 'anthropic-messages';
 export type CacheClass = 'cold' | 'warm';
 export type CacheBenchmarkAttemptRole = 'main' | 'memory_branch';
+export type CacheBenchmarkTrafficClass = 'primary' | 'auxiliary_memory';
 export type AttemptOutcome = 'succeeded' | 'failed' | 'cancelled' | 'incomplete' | 'retrying';
 export type CacheBenchmarkVerdict = 'passed' | 'failed' | 'unobservable';
 
@@ -42,6 +43,7 @@ export interface CacheBenchmarkCriteria {
   consecutive_rounds: number;
   maximum_task_weight: number;
   include_cold_in_primary_ratio: boolean;
+  qualification_traffic_class: 'primary';
 }
 
 export interface CacheBenchmarkRun {
@@ -199,6 +201,7 @@ export type CacheBenchmarkLedgerReason =
 
 export interface CacheBenchmarkCellResult {
   cell_fingerprint: string;
+  traffic_class: CacheBenchmarkTrafficClass;
   status: BenchmarkStatus;
   qualification_cache_class: 'warm';
   input_tokens: number;
@@ -225,6 +228,7 @@ export interface CacheBenchmarkRoundResult {
 
 export interface CacheBenchmarkCoverageResult {
   scope_fingerprint: string;
+  traffic_class: CacheBenchmarkTrafficClass;
   status: 'passed' | 'incomplete';
   missing_capabilities: CacheBenchmarkCapability[];
 }

--- a/tests/cache-benchmark-acceptance.test.ts
+++ b/tests/cache-benchmark-acceptance.test.ts
@@ -6,21 +6,23 @@ import { spawnSync } from 'node:child_process';
 import { describe, test } from 'node:test';
 import {
   aggregateCacheBenchmarkAcceptance,
+  buildOnlineCacheBenchmarkManifest,
   CACHE_BENCHMARK_LEDGER_SCHEMA,
   CACHE_BENCHMARK_ROUND_SCHEMA,
   CACHE_BENCHMARK_RESULT_SCHEMA,
+  fingerprintBenchmarkAcceptanceTopology,
   fingerprintBenchmarkWorkloadContract,
   fingerprintConfig,
   fingerprintManifest,
-  parseManifestJson,
+  REQUIRED_ACCEPTANCE_TOPOLOGY_FINGERPRINT,
   validateCompletedOnlineRuns,
   type AcceptanceProviderAlias,
   type CacheBenchmarkAcceptanceCandidate,
   type CacheBenchmarkManifest,
   type CacheBenchmarkResult,
+  type OnlineProviderCredential,
 } from '../src/cache-benchmark';
 
-const FIXTURE_PATH = path.join(__dirname, 'fixtures', 'cache-benchmark', 'manifest.json');
 const ARTIFACT_A = `sha256:${'a'.repeat(64)}`;
 const ARTIFACT_B = `sha256:${'b'.repeat(64)}`;
 
@@ -32,7 +34,7 @@ describe('multi-provider cache acceptance', () => {
       candidate('deepseek', ARTIFACT_A),
     ]);
 
-    assert.equal(result.status, 'passed');
+    assert.equal(result.status, 'passed', JSON.stringify(result.reasons));
     assert.equal(result.exit_code, 0);
     assert.equal(result.artifact_fingerprint, ARTIFACT_A);
     assert.equal(
@@ -40,6 +42,20 @@ describe('multi-provider cache acceptance', () => {
       fingerprintBenchmarkWorkloadContract(newcli.manifest.cases),
     );
     assert.deepEqual(result.reasons, []);
+  });
+
+  test('qualifies provider identity from primary cases while preserving the joined branch schedule', () => {
+    const newcli = candidateWithAuxiliaryMemory('newcli', ARTIFACT_A);
+    const deepseek = candidateWithAuxiliaryMemory('deepseek', ARTIFACT_A);
+    const result = aggregateCacheBenchmarkAcceptance([newcli, deepseek]);
+
+    assert.equal(result.status, 'passed', JSON.stringify(result.reasons));
+    assert.deepEqual(result.reasons, []);
+    for (const candidateEntry of [newcli, deepseek]) {
+      const branch = candidateEntry.manifest.cases.find(entry => entry.execution_role === 'memory_branch')!;
+      assert.equal(branch.model, 'small-memory-model');
+      assert.equal(branch.runs[0].required_warm_calls, 24);
+    }
   });
 
   test('rejects calibration, insufficient samples, and mismatched artifacts', () => {
@@ -107,6 +123,63 @@ describe('multi-provider cache acceptance', () => {
     assert.equal(workloadMismatch.status, 'invalid');
     assert.ok(workloadMismatch.reasons.includes('workload_contract_invalid'));
     assert.ok(workloadMismatch.reasons.includes('workload_contract_mismatch'));
+  });
+
+  test('rejects a self-declared role relabel even when all ordinary fingerprints are recomputed', () => {
+    const relabeled = candidate('newcli', ARTIFACT_A);
+    const main = relabeled.manifest.cases.find(entry => (
+      entry.task_id === 'unsafe-action-gate' && entry.execution_role === 'main'
+    ))!;
+    const branch = relabeled.manifest.cases.find(entry => (
+      entry.task_id === 'unsafe-action-gate' && entry.execution_role === 'memory_branch'
+    ))!;
+    main.execution_role = 'memory_branch';
+    branch.execution_role = 'main';
+    relabeled.manifest.workload_contract_fingerprint = fingerprintBenchmarkWorkloadContract(
+      relabeled.manifest.cases,
+    );
+    relabeled.result = passingResult(relabeled.manifest, ARTIFACT_A);
+    const result = aggregateCacheBenchmarkAcceptance([
+      relabeled,
+      candidate('deepseek', ARTIFACT_A),
+    ]);
+
+    assert.equal(result.status, 'invalid');
+    assert.ok(result.reasons.includes('workload_topology_mismatch'));
+  });
+
+  test('rejects provider-visible case ID padding even when ordinary fingerprints are recomputed', () => {
+    const renamed = candidate('newcli', ARTIFACT_A);
+    renamed.manifest.cases[0].case_id += '-cache-padding';
+    renamed.manifest.workload_contract_fingerprint = fingerprintBenchmarkWorkloadContract(
+      renamed.manifest.cases,
+    );
+    renamed.result = passingResult(renamed.manifest, ARTIFACT_A);
+    const result = aggregateCacheBenchmarkAcceptance([
+      renamed,
+      candidate('deepseek', ARTIFACT_A),
+    ]);
+
+    assert.equal(result.status, 'invalid');
+    assert.ok(result.reasons.includes('workload_topology_mismatch'));
+  });
+
+  test('rejects undersampled joined branches even when ordinary fingerprints are recomputed', () => {
+    const undersampled = candidateWithAuxiliaryMemory('newcli', ARTIFACT_A);
+    for (const branch of undersampled.manifest.cases.filter(entry => entry.execution_role === 'memory_branch')) {
+      branch.runs = branch.runs.map(run => ({ ...run, required_warm_calls: 1 }));
+    }
+    undersampled.manifest.workload_contract_fingerprint = fingerprintBenchmarkWorkloadContract(
+      undersampled.manifest.cases,
+    );
+    undersampled.result = passingResult(undersampled.manifest, ARTIFACT_A);
+    const result = aggregateCacheBenchmarkAcceptance([
+      undersampled,
+      candidateWithAuxiliaryMemory('deepseek', ARTIFACT_A),
+    ]);
+
+    assert.equal(result.status, 'invalid');
+    assert.ok(result.reasons.includes('workload_topology_mismatch'));
   });
 
   test('validates every online started-to-sealed reservation and rejects orphan rounds', () => {
@@ -210,20 +283,46 @@ function candidate(
   return { provider, manifest, result: passingResult(manifest, artifactFingerprint) };
 }
 
-function acceptanceManifest(provider: AcceptanceProviderAlias): CacheBenchmarkManifest {
-  const manifest = parseManifestJson(fs.readFileSync(FIXTURE_PATH, 'utf8'));
-  manifest.suite_id = `xiaoba-online-${provider}-acceptance-v1`;
-  manifest.benchmark_profile = 'acceptance';
-  for (const entry of manifest.cases) {
-    entry.provider_instance_id = provider === 'newcli'
-      ? `newcli:openai-responses:endpoint-${'1'.repeat(32)}`
-      : `deepseek:openai-chat-completions:endpoint-${'2'.repeat(32)}`;
-    if (provider === 'deepseek') {
-      entry.api_type = 'openai-chat-completions';
-      entry.cache_read_source = 'openai.prompt_tokens_details.cached_tokens';
-    }
-    for (const run of entry.runs) run.required_warm_calls = 24;
+function candidateWithAuxiliaryMemory(
+  provider: AcceptanceProviderAlias,
+  artifactFingerprint: string,
+): CacheBenchmarkAcceptanceCandidate {
+  const manifest = acceptanceManifest(provider);
+  for (const branch of manifest.cases.filter(entry => entry.execution_role === 'memory_branch')) {
+    branch.provider_instance_id = `auxiliary-memory:openai-chat-completions:endpoint-${'3'.repeat(32)}`;
+    branch.provider_adapter = 'openai';
+    branch.model = 'small-memory-model';
+    branch.api_type = 'openai-chat-completions';
+    branch.cache_read_source = 'openai.prompt_tokens_details.cached_tokens';
   }
+  manifest.workload_contract_fingerprint = fingerprintBenchmarkWorkloadContract(manifest.cases);
+  return { provider, manifest, result: passingResult(manifest, artifactFingerprint) };
+}
+
+function acceptanceManifest(provider: AcceptanceProviderAlias): CacheBenchmarkManifest {
+  const credential: OnlineProviderCredential = provider === 'newcli' ? {
+    alias: 'newcli',
+    providerAdapter: 'openai',
+    apiType: 'openai-responses',
+    cacheReadSource: 'openai.input_tokens_details.cached_tokens',
+    apiKey: 'test-key',
+    apiBase: 'https://newcli.example.invalid/v1',
+    model: 'model-newcli',
+  } : {
+    alias: 'deepseek',
+    providerAdapter: 'openai',
+    apiType: 'openai-chat-completions',
+    cacheReadSource: 'openai.prompt_tokens_details.cached_tokens',
+    apiKey: 'test-key',
+    apiBase: 'https://deepseek.example.invalid/v1',
+    model: 'model-deepseek',
+  };
+  const manifest = buildOnlineCacheBenchmarkManifest(credential, 24);
+  manifest.benchmark_profile = 'acceptance';
+  assert.equal(
+    fingerprintBenchmarkAcceptanceTopology(manifest.cases),
+    REQUIRED_ACCEPTANCE_TOPOLOGY_FINGERPRINT,
+  );
   manifest.workload_contract_fingerprint = fingerprintBenchmarkWorkloadContract(manifest.cases);
   return manifest;
 }

--- a/tests/cache-benchmark-online-foundation.test.ts
+++ b/tests/cache-benchmark-online-foundation.test.ts
@@ -32,6 +32,7 @@ import {
   CACHE_BENCHMARK_ATTEMPT_SCHEMA,
   CACHE_BENCHMARK_ROUND_SCHEMA,
   fingerprintConfig,
+  fingerprintBenchmarkAcceptanceTopology,
   fingerprintManifest,
   fingerprintOnlineBenchmarkArtifact,
   fingerprintOnlineBenchmarkRuntimeContract,
@@ -40,6 +41,7 @@ import {
   OnlineCredentialError,
   onlineBenchmarkInheritedChildEnvKeys,
   REQUIRED_CACHE_BENCHMARK_CAPABILITIES,
+  REQUIRED_ACCEPTANCE_TOPOLOGY_FINGERPRINT,
   parseManifestJson,
   prepareFreshRuntimeDataDirectory,
   safeOnlineBenchmarkErrorCode,
@@ -129,6 +131,11 @@ test('online manifest counts the production memory branch for every capped task'
     deepSeekManifest.workload_contract_fingerprint,
   );
   assert.equal(manifest.criteria.include_cold_in_primary_ratio, false);
+  assert.equal(manifest.criteria.qualification_traffic_class, 'primary');
+  assert.equal(
+    fingerprintBenchmarkAcceptanceTopology(manifest.cases),
+    REQUIRED_ACCEPTANCE_TOPOLOGY_FINGERPRINT,
+  );
   assert.equal(manifest.cases.length, 8);
   assert.equal(new Set(manifest.cases.map(entry => entry.task_id)).size, 4);
   assert.equal(manifest.cases.filter(entry => entry.execution_role === 'main').length, 4);

--- a/tests/cache-benchmark.test.ts
+++ b/tests/cache-benchmark.test.ts
@@ -8,6 +8,7 @@ import {
   CacheBenchmarkAttempt,
   CacheBenchmarkLedger,
   CacheBenchmarkManifest,
+  CacheBenchmarkResult,
   CacheBenchmarkRoundEvidence,
   REQUIRED_CACHE_BENCHMARK_CAPABILITIES,
   canonicalJson,
@@ -162,7 +163,7 @@ describe('cache benchmark evidence scorer', () => {
     assert.ok(result.reasons.includes('minimum_read_ratio_not_met'));
   });
 
-  test('retains valid provider usage from failed physical attempts in diagnostics only', () => {
+  test('counts valid provider usage from failed physical attempts without letting failures pass', () => {
     const manifest = fixtureManifest();
     const rounds = [1, 2, 3].map(round => buildRound(manifest, round));
     rounds[2].attempts[1].outcome = 'failed';
@@ -172,8 +173,8 @@ describe('cache benchmark evidence scorer', () => {
 
     assert.equal(result.status, 'invalid');
     assert.ok(result.reasons.includes('non_succeeded_attempt'));
-    assert.equal(cell.input_tokens, 750);
-    assert.equal(cell.cache_read_tokens, 705);
+    assert.equal(cell.input_tokens, 1050);
+    assert.equal(cell.cache_read_tokens, 825);
     assert.equal(cell.cold_input_tokens, 1000);
     assert.equal(cell.cold_cache_read_tokens, 940);
     assert.equal(cell.all_input_tokens, 2050);
@@ -247,7 +248,7 @@ describe('cache benchmark evidence scorer', () => {
       ['coverage', round => {
         round.attempts = round.attempts.filter(attempt => !(attempt.case_id === 'case-1' && attempt.cache_class === 'warm'));
       }, 'missing_warm_attempt'],
-      ['extra warm call', round => {
+      ['extra primary physical attempt', round => {
         const extra = structuredClone(round.attempts[1]);
         extra.call_id = 'extra-warm-call';
         extra.attempt_id = 'extra-warm-attempt';
@@ -283,15 +284,15 @@ describe('cache benchmark evidence scorer', () => {
   });
 
   test('allows variable memory-branch physical attempts and weights every provider token', () => {
-    const manifest = fixtureManifest();
-    manifest.cases[2].execution_role = 'memory_branch';
+    const manifest = manifestWithAuxiliaryCase();
+    const branch = manifest.cases.at(-1)!;
     const rounds = [1, 2, 3].map(round => buildRound(manifest, round));
     for (const evidence of rounds) {
       const branchCold = evidence.attempts.find(attempt => (
-        attempt.case_id === manifest.cases[2].case_id && attempt.logical_call === 1
+        attempt.case_id === branch.case_id && attempt.logical_call === 1
       ))!;
       const branchWarm = evidence.attempts.find(attempt => (
-        attempt.case_id === manifest.cases[2].case_id && attempt.logical_call === 2
+        attempt.case_id === branch.case_id && attempt.logical_call === 2
       ))!;
       for (const [template, suffix] of [
         [branchCold, 'cold-extra-1'],
@@ -305,29 +306,122 @@ describe('cache benchmark evidence scorer', () => {
         evidence.attempts.push(extra);
       }
       const branchAttempts = evidence.attempts
-        .filter(attempt => attempt.case_id === manifest.cases[2].case_id)
+        .filter(attempt => attempt.case_id === branch.case_id)
         .sort((left, right) => left.logical_call - right.logical_call);
       evidence.attempts = [
-        ...evidence.attempts.filter(attempt => attempt.case_id !== manifest.cases[2].case_id),
+        ...evidence.attempts.filter(attempt => attempt.case_id !== branch.case_id),
         ...branchAttempts,
       ];
       evidence.attempts.forEach((attempt, index) => { attempt.attempt_number = index + 1; });
     }
     const result = scoreRounds(manifest, rounds);
+    const primary = result.rounds[0].cells.find(cell => cell.traffic_class === 'primary')!;
+    const auxiliary = result.rounds[0].cells.find(cell => cell.traffic_class === 'auxiliary_memory')!;
 
     assert.equal(result.status, 'passed');
-    assert.equal(result.rounds[0].cells[0].input_tokens, 1500);
-    assert.equal(result.rounds[0].cells[0].cache_read_tokens, 1410);
-    assert.equal(result.rounds[0].cells[0].raw_read_ratio, 0.94);
-    assert.equal(result.rounds[0].cells[0].cold_input_tokens, 1250);
-    assert.equal(result.rounds[0].cells[0].cold_cache_read_tokens, 1175);
+    assert.equal(result.rounds[0].cells.length, 2);
+    assert.equal(primary.input_tokens, 1000);
+    assert.equal(primary.cache_read_tokens, 940);
+    assert.equal(primary.raw_read_ratio, 0.94);
+    assert.equal(auxiliary.input_tokens, 750);
+    assert.equal(auxiliary.cache_read_tokens, 705);
+    assert.equal(auxiliary.raw_read_ratio, 0.94);
+    assert.equal(auxiliary.cold_input_tokens, 500);
+    assert.equal(auxiliary.cold_cache_read_tokens, 470);
   });
 
-  test('invalidates joined memory-branch evidence recorded after its main attempt', () => {
+  test('excludes auxiliary cache ratio from primary qualification without hiding its usage', () => {
+    const manifest = manifestWithAuxiliaryCase();
+    const branch = manifest.cases.at(-1)!;
+    const rounds = [1, 2, 3].map(round => buildRound(manifest, round, attempt => {
+      if (attempt.case_id === branch.case_id) setProviderUsage(attempt, 250, 0);
+    }));
+    const result = scoreRounds(manifest, rounds);
+    const primary = result.rounds[0].cells.find(cell => cell.traffic_class === 'primary')!;
+    const auxiliary = result.rounds[0].cells.find(cell => cell.traffic_class === 'auxiliary_memory')!;
+
+    assert.equal(result.status, 'passed');
+    assert.equal(primary.raw_read_ratio, 0.94);
+    assert.equal(primary.input_tokens, 1000);
+    assert.equal(auxiliary.raw_read_ratio, 0);
+    assert.equal(auxiliary.input_tokens, 250);
+    assert.equal(auxiliary.cache_read_tokens, 0);
+    assert.equal(auxiliary.reasons.includes('minimum_read_ratio_not_met'), false);
+    assert.equal(auxiliary.reasons.includes('insufficient_positive_tasks'), false);
+  });
+
+  test('does not let a cache-hot auxiliary call rescue a primary ratio below 94%', () => {
+    const manifest = manifestWithAuxiliaryCase();
+    const branch = manifest.cases.at(-1)!;
+    const rounds = [1, 2, 3].map(round => buildRound(manifest, round, attempt => {
+      if (attempt.case_id === branch.case_id) setProviderUsage(attempt, 250, 250);
+    }));
+    const primaryWarm = rounds[2].attempts.find(attempt => (
+      attempt.attempt_role === 'main' && attempt.cache_class === 'warm'
+    ))!;
+    setProviderUsage(primaryWarm, 250, 234);
+    const result = scoreRounds(manifest, rounds);
+
+    assert.equal(result.status, 'failed');
+    assert.ok(result.reasons.includes('minimum_read_ratio_not_met'));
+  });
+
+  test('scores a separate small-model auxiliary provider without adding it to primary qualification', () => {
+    const manifest = manifestWithAuxiliaryCase(true);
+    const branch = manifest.cases.at(-1)!;
+    const rounds = [1, 2, 3].map(round => buildRound(manifest, round, attempt => {
+      if (attempt.case_id === branch.case_id) setProviderUsage(attempt, 250, 0);
+    }));
+    const result = scoreRounds(manifest, rounds);
+    const auxiliary = result.rounds[0].cells.find(cell => cell.traffic_class === 'auxiliary_memory')!;
+
+    assert.equal(result.status, 'passed');
+    assert.equal(result.rounds[0].cells.length, 2);
+    assert.equal(auxiliary.raw_read_ratio, 0);
+    assert.equal(auxiliary.reasons.length, 0);
+  });
+
+  test('keeps auxiliary completion, usage, quality, safety, and role gates fail-closed', () => {
+    const scenarios: Array<[
+      string,
+      (attempt: CacheBenchmarkAttempt) => void,
+      CacheBenchmarkResult['status'],
+      string,
+    ]> = [
+      ['failed outcome', attempt => { attempt.outcome = 'failed'; }, 'invalid', 'non_succeeded_attempt'],
+      ['non-terminal outcome', attempt => { attempt.outcome = 'retrying'; }, 'invalid', 'non_terminal_attempt'],
+      ['missing usage', attempt => { setProviderUsage(attempt, 250, undefined); }, 'unobservable', 'cache_read_not_reported'],
+      ['quality failure', attempt => { attempt.attestation.quality_status = 'failed'; }, 'failed', 'quality_gate_failed'],
+      ['safety failure', attempt => { attempt.attestation.safety_status = 'failed'; }, 'failed', 'safety_gate_failed'],
+      ['missing memory provenance capability', attempt => {
+        attempt.attestation.observed_capabilities = ['tools'];
+      }, 'incomplete', 'capability_attestation_incomplete'],
+      ['role mismatch', attempt => { attempt.attempt_role = 'main'; }, 'invalid', 'metadata_mismatch'],
+    ];
+    for (const [label, mutate, expectedStatus, reason] of scenarios) {
+      const manifest = manifestWithAuxiliaryCase();
+      const branch = manifest.cases.at(-1)!;
+      const rounds = [1, 2, 3].map(round => buildRound(manifest, round));
+      const attempt = rounds[2].attempts.find(entry => (
+        entry.case_id === branch.case_id && entry.cache_class === 'warm'
+      ))!;
+      mutate(attempt);
+      const result = scoreRounds(manifest, rounds);
+      assert.equal(result.status, expectedStatus, label);
+      assert.ok(result.reasons.includes(reason as never), label);
+    }
+  });
+
+  test('invalidates joined memory-branch evidence recorded after its main across providers', () => {
     const manifest = fixtureManifest();
     manifest.cases[1].task_id = manifest.cases[0].task_id;
     manifest.cases[1].execution_role = 'memory_branch';
     manifest.cases[1].runs[0].run_id = manifest.cases[0].runs[0].run_id;
+    manifest.cases[1].provider_instance_id = 'auxiliary-provider';
+    manifest.cases[1].model = 'small-memory-model';
+    manifest.cases[1].api_type = 'openai-chat-completions';
+    manifest.cases[1].surface = 'memory-branch';
+    manifest.cases[1].cache_read_source = 'openai.prompt_tokens_details.cached_tokens';
     const result = scoreRounds(manifest, [1, 2, 3].map(round => buildRound(manifest, round)));
 
     assert.equal(result.status, 'invalid');
@@ -677,9 +771,9 @@ describe('cache benchmark evidence scorer', () => {
     ));
   });
 
-  test('rejects all v4 evidence schemas and any attempt to include cold usage in the primary ratio', () => {
+  test('rejects legacy v5 evidence schemas and any attempt to include cold usage in the primary ratio', () => {
     const legacy = structuredClone(fixtureManifest()) as any;
-    legacy.schema = 'xiaoba.cache_benchmark_manifest.v4';
+    legacy.schema = 'xiaoba.cache_benchmark_manifest.v5';
     assert.throws(() => parseManifestJson(JSON.stringify(legacy)));
 
     const coldIncluded = structuredClone(fixtureManifest()) as any;
@@ -688,15 +782,15 @@ describe('cache benchmark evidence scorer', () => {
 
     const round = buildRound(fixtureManifest(), 1);
     const legacyRound = structuredClone(round) as any;
-    legacyRound.header.schema = 'xiaoba.cache_benchmark_round.v4';
+    legacyRound.header.schema = 'xiaoba.cache_benchmark_round.v5';
     assert.throws(() => parseRoundJsonl(roundToJsonl(legacyRound)));
 
     const legacyAttempt = structuredClone(round) as any;
-    legacyAttempt.attempts[0].schema = 'xiaoba.cache_benchmark_attempt.v4';
+    legacyAttempt.attempts[0].schema = 'xiaoba.cache_benchmark_attempt.v5';
     assert.throws(() => parseRoundJsonl(roundToJsonl(legacyAttempt)));
 
     const legacyLedger = structuredClone(buildLedger(fixtureManifest(), [round])) as any;
-    legacyLedger.schema = 'xiaoba.cache_benchmark_ledger.v4';
+    legacyLedger.schema = 'xiaoba.cache_benchmark_ledger.v5';
     assert.throws(() => parseLedgerJson(JSON.stringify(legacyLedger)));
   });
 
@@ -810,6 +904,29 @@ function fixtureManifest(): CacheBenchmarkManifest {
   return parseManifestJson(fs.readFileSync(FIXTURE_PATH, 'utf8'));
 }
 
+function manifestWithAuxiliaryCase(separateProvider = false): CacheBenchmarkManifest {
+  const manifest = fixtureManifest();
+  const branch = structuredClone(manifest.cases[2]);
+  branch.case_id = 'case-memory-branch';
+  branch.task_id = 'task-memory-branch';
+  branch.task_fixture_fingerprint = `sha256:${'5'.repeat(64)}`;
+  branch.execution_role = 'memory_branch';
+  branch.capabilities = ['tools', 'memory'];
+  if (separateProvider) {
+    branch.provider_instance_id = 'auxiliary-provider';
+    branch.model = 'small-memory-model';
+    branch.api_type = 'openai-chat-completions';
+    branch.surface = 'memory-branch';
+    branch.cache_read_source = 'openai.prompt_tokens_details.cached_tokens';
+  }
+  branch.runs = [{
+    ...branch.runs[0],
+    run_id: 'run-memory-branch',
+  }];
+  manifest.cases.push(branch);
+  return manifest;
+}
+
 function canonicalCellFingerprint(entry: CacheBenchmarkManifest['cases'][number]): string {
   return fingerprintCanonical({
     provider_instance_id: entry.provider_instance_id,
@@ -817,6 +934,7 @@ function canonicalCellFingerprint(entry: CacheBenchmarkManifest['cases'][number]
     model: entry.model,
     api_type: entry.api_type,
     surface: entry.surface,
+    traffic_class: entry.execution_role === 'main' ? 'primary' : 'auxiliary_memory',
   });
 }
 
@@ -905,7 +1023,7 @@ function buildRound(
     for (const run of entry.runs) {
       for (const cacheClass of ['cold', 'warm'] as const) {
         const attempt: CacheBenchmarkAttempt = {
-          schema: 'xiaoba.cache_benchmark_attempt.v5',
+          schema: 'xiaoba.cache_benchmark_attempt.v6',
           suite_id: manifest.suite_id,
           round,
           attempt_number: attempts.length + 1,
@@ -958,7 +1076,7 @@ function buildRound(
   }
   return {
     header: {
-      schema: 'xiaoba.cache_benchmark_round.v5',
+      schema: 'xiaoba.cache_benchmark_round.v6',
       suite_id: manifest.suite_id,
       round,
       cache_partition_nonce: round.toString(16).padStart(32, '0'),
@@ -986,7 +1104,7 @@ function buildLedger(
 ): CacheBenchmarkLedger {
   const ordered = [...rounds].sort((left, right) => left.header.round - right.header.round);
   return {
-    schema: 'xiaoba.cache_benchmark_ledger.v5',
+    schema: 'xiaoba.cache_benchmark_ledger.v6',
     suite_id: manifest.suite_id,
     latest_round: ordered[ordered.length - 1]?.header.round ?? 1,
     rounds: ordered.map(round => ({

--- a/tests/fixtures/cache-benchmark/manifest.json
+++ b/tests/fixtures/cache-benchmark/manifest.json
@@ -1,11 +1,12 @@
 {
-  "schema": "xiaoba.cache_benchmark_manifest.v5",
+  "schema": "xiaoba.cache_benchmark_manifest.v6",
   "suite_id": "cache-truth-v1",
   "criteria": {
     "minimum_read_ratio": 0.94,
     "consecutive_rounds": 3,
     "maximum_task_weight": 0.25,
-    "include_cold_in_primary_ratio": false
+    "include_cold_in_primary_ratio": false,
+    "qualification_traffic_class": "primary"
   },
   "cases": [
     {


### PR DESCRIPTION
Stage 9 separates main-agent primary cache qualification from auxiliary Memory Branch diagnostics without weakening usage, completion, quality, safety, capability, provenance, ordering, or topology gates. It adds v6 evidence semantics, official acceptance topology and case identity binding, provider-neutral joined ordering, and fail-closed regressions. Verification: npm run build; official runtime suite 1647 total, 1639 passed, 0 failed, 8 skipped; isolated Dashboard health endpoints all returned 200. This is an accounting stage and does not claim final 94% acceptance.