### PR TITLE
Verify checkpoint recovery without truncation

### DIFF
--- a/src/cache-benchmark/checkpoint-small-window-canary.ts
+++ b/src/cache-benchmark/checkpoint-small-window-canary.ts
@@ -2,7 +2,10 @@ import { createHash, randomBytes } from 'node:crypto';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { CheckpointCompactionCoordinator } from '../core/checkpoint-compaction';
+import {
+  CheckpointCompactionCoordinator,
+  collectCanonicalCompletedToolBoundaryEntries,
+} from '../core/checkpoint-compaction';
 import { ConversationRunner } from '../core/conversation-runner';
 import { estimateMessagesTokens, estimateToolsTokens } from '../core/token-estimator';
 import type { ModelAttemptEvent, ModelAttemptSink } from '../providers/provider';
@@ -20,9 +23,12 @@ import {
   type OnlineProviderCredential,
 } from './online-credentials';
 
-const SCHEMA = 'xiaoba.checkpoint-small-window-canary.v3';
+const SCHEMA = 'xiaoba.checkpoint-small-window-canary.v4';
 const DEFAULT_PROMPT_BUDGET = 8_000;
+const MAX_OUTPUT_TOKENS = 2_048;
+const REQUIRED_CHECKPOINTS = 2;
 const TOOL_NAME = 'collect_checkpoint_evidence';
+const REQUIRED_TOOL_STEPS = [1, 2] as const;
 const HEAD_SECRET = 'SECRET_ALPHA_5A77';
 const MIDDLE_SECRET = 'SECRET_BRAVO_7E42';
 const TAIL_SECRET = 'SECRET_CHARLIE_9C31';
@@ -37,6 +43,9 @@ interface AttemptEvidence {
   episode_number: number | null;
   message_count: number;
   tool_count: number;
+  completed_tool_boundary_witness_count: number;
+  completed_tool_boundary_success_witness_count: number;
+  completed_tool_boundary_fingerprints: string[];
   estimated_request_tokens: number;
   stable_prefix_sha256: string;
   toolset_sha256: string;
@@ -61,6 +70,8 @@ interface CanaryEvidence {
   api_origin: string | null;
   api_base_sha256: string;
   configured_prompt_budget: number;
+  configured_context_window_tokens: number;
+  configured_max_output_tokens: number;
   tool_schema_tokens: number;
   cache_isolation: {
     nonce_sha256: string;
@@ -70,14 +81,19 @@ interface CanaryEvidence {
     resumed_main_cache_read_minimum_tokens: number;
   };
   checkpoint: {
+    required_count: number;
     generated_count: number;
     persisted_count: number;
-    persisted_before_resume: boolean;
-    persisted_message_tokens: number | null;
+    restored_count: number;
+    persisted_before_each_resume: boolean;
+    persisted_message_tokens: number[];
+    persisted_state_sha256: string[];
     same_episode: boolean;
   };
   react: {
     tool_execution_count: number;
+    tool_execution_steps: number[];
+    pending_step_two_delivered: boolean;
     primary_provider_attempts: number;
     checkpoint_provider_attempts: number;
     all_primary_attempts_kept_full_toolset: boolean;
@@ -87,9 +103,16 @@ interface CanaryEvidence {
     all_provider_attempts_main_owned: boolean;
     provider_attempt_lifecycle_complete: boolean;
     all_provider_attempts_reported_cache_usage: boolean;
+    all_requests_within_estimated_prompt_budget: boolean;
+    all_provider_reported_totals_within_context_window: boolean;
     stable_prefix_and_tools_match: boolean;
-    resumed_main_reported_cache_read: boolean;
-    resumed_main_cache_read_meets_minimum: boolean;
+    all_resumed_main_requests_have_completed_tool_witness: boolean;
+    resumed_main_cache_reads_reported: boolean;
+    resumed_main_cache_reads_meet_minimum: boolean;
+    primary_input_tokens: number;
+    primary_cache_read_tokens: number;
+    primary_token_weighted_cache_read_ratio: number;
+    resumed_primary_cache_read_tokens: number[];
   };
   provider_attempts: AttemptEvidence[];
   verdict: 'passed' | 'failed';
@@ -111,6 +134,10 @@ class AttemptCollector implements ModelAttemptSink {
       this.chronology.push(`${role}:started`);
     }
     const usage = event.response?.usage;
+    const completedToolBoundaryEntries = collectCanonicalCompletedToolBoundaryEntries(
+      event.request.messages,
+      event.context?.episodeId,
+    );
     this.events.push({
       attempt_id: event.attemptId,
       role,
@@ -121,6 +148,13 @@ class AttemptCollector implements ModelAttemptSink {
       episode_number: event.context?.episodeNumber ?? null,
       message_count: event.request.messages.length,
       tool_count: event.request.tools.length,
+      completed_tool_boundary_witness_count: completedToolBoundaryEntries.length,
+      completed_tool_boundary_success_witness_count: completedToolBoundaryEntries.filter(
+        entry => entry.resultStatus === 'success' && entry.retryable === false,
+      ).length,
+      completed_tool_boundary_fingerprints: completedToolBoundaryEntries.map(entry => (
+        sha256(JSON.stringify(entry))
+      )),
       estimated_request_tokens: estimateMessagesTokens([...event.request.messages])
         + estimateToolsTokens([...event.request.tools]),
       stable_prefix_sha256: fingerprintStablePrefix(event.request.messages),
@@ -160,9 +194,10 @@ export async function runCheckpointSmallWindowCanary(input: {
   const rootMessage: Message = {
     role: 'user',
     content: [
-      `Call ${TOOL_NAME} exactly once before answering.`,
-      'After the tool result and any continuation checkpoint, do not call it again.',
-      'The tool result contains HEAD_SECRET, MIDDLE_SECRET, and TAIL_SECRET labels.',
+      `Call ${TOOL_NAME} exactly once with step=1 before doing anything else.`,
+      'After its result and the first continuation checkpoint, wait for an additional user instruction.',
+      'That instruction will request step=2; call it exactly once, then do not call the tool again.',
+      'The two tool results jointly contain HEAD_SECRET, MIDDLE_SECRET, and TAIL_SECRET labels.',
       'Return only the three secret VALUES in that label order, separated by single spaces.',
       'Do not output the labels and do not add an explanation.',
     ].join(' '),
@@ -180,12 +215,17 @@ export async function runCheckpointSmallWindowCanary(input: {
     1_024,
     Math.floor(stablePrefixEstimatedTokens * 0.75),
   );
-  let toolExecutionCount = 0;
+  const toolExecutionSteps: number[] = [];
   let generatedCount = 0;
   let persistedCount = 0;
+  let restoredCount = 0;
+  let pendingStepTwoDelivered = false;
+  const persistedMessageTokens: number[] = [];
+  const persistedStateSha256: string[] = [];
   const persistedState: { messages?: Message[] } = {};
   const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-checkpoint-canary-'));
   const checkpointPath = path.join(sandbox, 'checkpoint.json');
+  let diagnosticPhase = 'setup';
 
   const service = new AIService({
     provider: input.credential.providerAdapter,
@@ -196,8 +236,8 @@ export async function runCheckpointSmallWindowCanary(input: {
       ? 'responses'
       : 'chat_completions',
     temperature: 0,
-    maxTokens: 2_048,
-    contextWindowTokens: 128_000,
+    maxTokens: MAX_OUTPUT_TOKENS,
+    contextWindowTokens: checkpointCanaryContextWindowTokens(promptBudget),
     modelCapabilities: {
       toolCalling: true,
       streaming: true,
@@ -212,13 +252,24 @@ export async function runCheckpointSmallWindowCanary(input: {
   const executor: ToolExecutor = {
     getToolDefinitions: () => [tool],
     executeTool: async (call: ToolCall): Promise<ToolResult> => {
-      toolExecutionCount++;
-      chronology.push('tool:complete');
+      const args = JSON.parse(call.function.arguments) as { step?: unknown };
+      const step = Number(args.step);
+      const expectedStep = REQUIRED_TOOL_STEPS[toolExecutionSteps.length];
+      if (call.function.name !== TOOL_NAME || step !== expectedStep) {
+        throw checkpointCanaryFailure('CHECKPOINT_CANARY_TOOL_SEQUENCE_INVALID', {
+          expected_step: expectedStep ?? null,
+          actual_step: Number.isSafeInteger(step) ? step : null,
+          completed_step_count: toolExecutionSteps.length,
+          tool_name_matched: call.function.name === TOOL_NAME,
+        });
+      }
+      toolExecutionSteps.push(step);
+      chronology.push(`tool:complete:${step}`);
       return {
         role: 'tool',
         tool_call_id: call.id,
         name: call.function.name,
-        content: buildLargeToolEvidence(),
+        content: buildLargeToolEvidence(step),
         ok: true,
       };
     },
@@ -232,17 +283,44 @@ export async function runCheckpointSmallWindowCanary(input: {
     cachePartitionKey: `checkpoint-canary-${input.credential.alias}-${cacheIsolationNonceSha256}`,
     cacheTraceSink: attemptCollector,
     checkpointCompactionCoordinator: coordinator,
+    pendingUserInputProvider: async () => {
+      if (persistedCount !== 1 || pendingStepTwoDelivered) return null;
+      pendingStepTwoDelivered = true;
+      chronology.push('pending:step-two');
+      return [
+        'The first checkpoint has been durably restored.',
+        `Now call ${TOOL_NAME} exactly once with step=2.`,
+        'After its result and the next continuation checkpoint, return the final three secret values.',
+      ].join(' ');
+    },
     disablePromptTrace: true,
     onCompactionCheckpoint: async messages => {
       const serialized = JSON.stringify(messages);
       fs.writeFileSync(checkpointPath, serialized, { encoding: 'utf8', mode: 0o600 });
-      persistedState.messages = JSON.parse(fs.readFileSync(checkpointPath, 'utf8')) as Message[];
+      const restored = JSON.parse(fs.readFileSync(checkpointPath, 'utf8')) as Message[];
+      const restoredSerialized = JSON.stringify(restored);
+      if (sha256(restoredSerialized) !== sha256(serialized)) {
+        throw checkpointCanaryFailure('CHECKPOINT_CANARY_RESTORE_MISMATCH');
+      }
+      if (!restored.some(message => message.__checkpointSummary)) {
+        throw checkpointCanaryFailure('CHECKPOINT_CANARY_RESTORED_SUMMARY_MISSING');
+      }
+      // ConversationRunner resumes from this exact array after the callback.
+      // Replacing it with the JSON round-trip proves the active ReAct loop uses
+      // the durably restored representation rather than the in-memory candidate.
+      messages.splice(0, messages.length, ...restored);
+      persistedState.messages = restored;
       persistedCount++;
-      chronology.push('checkpoint:persisted');
+      restoredCount++;
+      persistedMessageTokens.push(estimateMessagesTokens(restored));
+      persistedStateSha256.push(sha256(restoredSerialized));
+      chronology.push(`checkpoint:persisted:${persistedCount}`);
+      chronology.push(`checkpoint:restored:${restoredCount}`);
     },
   });
 
   try {
+    diagnosticPhase = 'react_loop';
     const messages: Message[] = [
       {
         role: 'system',
@@ -254,22 +332,25 @@ export async function runCheckpointSmallWindowCanary(input: {
       onThinking: text => {
         if (text.includes('Continuation checkpoint candidate generated')) {
           generatedCount++;
-          chronology.push('checkpoint:generated');
+          chronology.push(`checkpoint:generated:${generatedCount}`);
         }
       },
     }));
 
+    diagnosticPhase = 'evaluation';
     const lifecycle = analyzeCheckpointCanaryAttemptLifecycle(attemptCollector.events);
     const terminalAttempts = lifecycle.terminalAttempts;
     const primaryAttempts = terminalAttempts.filter(attempt => attempt.role === 'primary');
     const checkpointAttempts = terminalAttempts.filter(attempt => attempt.role === 'checkpoint_summary');
-    const persistedBeforeResume = chronology.indexOf('checkpoint:persisted') >= 0
-      && chronology.indexOf('checkpoint:persisted')
-        < nthIndexOf(chronology, 'primary:started', 2);
+    const checkpointResumeOrdinals = checkpointResumePrimaryOrdinals(
+      chronology,
+      generatedCount,
+    );
+    const persistedBeforeEachResume = checkpointResumeOrdinals !== null;
     const expectedFinal = [HEAD_SECRET, MIDDLE_SECRET, TAIL_SECRET].join(' ');
     const finalQualityPassed = result.response.trim().replace(/\s+/g, ' ') === expectedFinal;
     const sameEpisode = terminalAttempts.every(attempt => attempt.episode_id === episodeId);
-    const allPrimaryAttemptsKeptFullToolset = primaryAttempts.length >= 2
+    const allPrimaryAttemptsKeptFullToolset = primaryAttempts.length >= REQUIRED_CHECKPOINTS + 1
       && primaryAttempts.every(attempt => attempt.tool_count === 1);
     const noRequestTruncationMarkers = terminalAttempts.every(
       attempt => !attempt.contains_truncation_marker,
@@ -287,23 +368,63 @@ export async function runCheckpointSmallWindowCanary(input: {
       && attempt.usage.cache_read_tokens !== undefined
       && attempt.usage.cache_read_source === input.credential.cacheReadSource
     ));
-    const resumedMain = primaryAttempts[1];
-    const resumedMainReportedCacheRead = (resumedMain?.usage?.cache_read_tokens ?? 0) > 0;
-    const stablePrefixAndToolsMatch = primaryAttempts.length === 2
+    const configuredContextWindowTokens = checkpointCanaryContextWindowTokens(promptBudget);
+    const allRequestsWithinEstimatedPromptBudget = terminalAttempts.every(
+      attempt => checkpointCanaryEstimatedRequestWithinBudget(
+        attempt.estimated_request_tokens,
+        promptBudget,
+      ),
+    );
+    const allProviderReportedTotalsWithinContextWindow = terminalAttempts.every(attempt => (
+      checkpointCanaryProviderUsageWithinContextWindow(
+        attempt.usage?.input_tokens,
+        attempt.usage?.output_tokens,
+        configuredContextWindowTokens,
+      )
+    ));
+    const resumedMains = checkpointResumeOrdinals?.flatMap(ordinal => (
+      primaryAttempts[ordinal] ? [primaryAttempts[ordinal]] : []
+    )) || [];
+    const resumedPrimaryCacheReadTokens = resumedMains.map(
+      attempt => attempt.usage?.cache_read_tokens ?? 0,
+    );
+    const resumedMainCacheReadsReported = resumedMains.length === REQUIRED_CHECKPOINTS
+      && resumedPrimaryCacheReadTokens.every(tokens => tokens > 0);
+    const stablePrefixAndToolsMatch = primaryAttempts.length >= REQUIRED_CHECKPOINTS + 1
       && primaryAttempts.every(attempt => (
         attempt.stable_prefix_sha256 === stablePrefixSha256
         && attempt.toolset_sha256 === toolsetSha256
       ));
-    const resumedMainCacheReadMeetsMinimum = (
-      resumedMain?.usage?.cache_read_tokens ?? 0
-    ) >= resumedMainCacheReadMinimumTokens;
-    const passed = toolExecutionCount === 1
-      && generatedCount === 1
-      && persistedCount === 1
-      && persistedBeforeResume
+    const allResumedMainRequestsHaveCompletedToolWitness =
+      checkpointCanaryCompletedToolWitnessChainIsComplete(
+        resumedMains,
+        REQUIRED_CHECKPOINTS,
+      );
+    const resumedMainCacheReadsMeetMinimum = resumedMains.length === REQUIRED_CHECKPOINTS
+      && resumedPrimaryCacheReadTokens.every(
+        tokens => tokens >= resumedMainCacheReadMinimumTokens,
+      );
+    const primaryInputTokens = primaryAttempts.reduce(
+      (sum, attempt) => sum + (attempt.usage?.input_tokens ?? 0),
+      0,
+    );
+    const primaryCacheReadTokens = primaryAttempts.reduce(
+      (sum, attempt) => sum + (attempt.usage?.cache_read_tokens ?? 0),
+      0,
+    );
+    const primaryTokenWeightedCacheReadRatio = primaryInputTokens > 0
+      ? primaryCacheReadTokens / primaryInputTokens
+      : 0;
+    const passed = toolExecutionSteps.length === REQUIRED_TOOL_STEPS.length
+      && toolExecutionSteps.every((step, index) => step === REQUIRED_TOOL_STEPS[index])
+      && generatedCount === REQUIRED_CHECKPOINTS
+      && persistedCount === generatedCount
+      && restoredCount === generatedCount
+      && persistedBeforeEachResume
+      && pendingStepTwoDelivered
       && Boolean(persistedState.messages?.some(message => message.__checkpointSummary))
-      && primaryAttempts.length === 2
-      && checkpointAttempts.length >= 1
+      && primaryAttempts.length >= REQUIRED_CHECKPOINTS + 1
+      && checkpointAttempts.length >= REQUIRED_CHECKPOINTS
       && allPrimaryAttemptsKeptFullToolset
       && noRequestTruncationMarkers
       && sameEpisode
@@ -312,9 +433,12 @@ export async function runCheckpointSmallWindowCanary(input: {
       && allProviderAttemptsMainOwned
       && lifecycle.complete
       && allProviderAttemptsReportedCacheUsage
+      && allRequestsWithinEstimatedPromptBudget
+      && allProviderReportedTotalsWithinContextWindow
       && stablePrefixAndToolsMatch
-      && resumedMainReportedCacheRead
-      && resumedMainCacheReadMeetsMinimum;
+      && allResumedMainRequestsHaveCompletedToolWitness
+      && resumedMainCacheReadsReported
+      && resumedMainCacheReadsMeetMinimum;
 
     return {
       schema: SCHEMA,
@@ -325,6 +449,8 @@ export async function runCheckpointSmallWindowCanary(input: {
       api_origin: officialOrigin(input.credential.apiBase),
       api_base_sha256: sha256(input.credential.apiBase),
       configured_prompt_budget: promptBudget,
+      configured_context_window_tokens: configuredContextWindowTokens,
+      configured_max_output_tokens: MAX_OUTPUT_TOKENS,
       tool_schema_tokens: estimateToolsTokens([tool]),
       cache_isolation: {
         nonce_sha256: cacheIsolationNonceSha256,
@@ -334,16 +460,19 @@ export async function runCheckpointSmallWindowCanary(input: {
         resumed_main_cache_read_minimum_tokens: resumedMainCacheReadMinimumTokens,
       },
       checkpoint: {
+        required_count: REQUIRED_CHECKPOINTS,
         generated_count: generatedCount,
         persisted_count: persistedCount,
-        persisted_before_resume: persistedBeforeResume,
-        persisted_message_tokens: persistedState.messages
-          ? estimateMessagesTokens(persistedState.messages)
-          : null,
+        restored_count: restoredCount,
+        persisted_before_each_resume: persistedBeforeEachResume,
+        persisted_message_tokens: persistedMessageTokens,
+        persisted_state_sha256: persistedStateSha256,
         same_episode: sameEpisode,
       },
       react: {
-        tool_execution_count: toolExecutionCount,
+        tool_execution_count: toolExecutionSteps.length,
+        tool_execution_steps: toolExecutionSteps,
+        pending_step_two_delivered: pendingStepTwoDelivered,
         primary_provider_attempts: primaryAttempts.length,
         checkpoint_provider_attempts: checkpointAttempts.length,
         all_primary_attempts_kept_full_toolset: allPrimaryAttemptsKeptFullToolset,
@@ -353,13 +482,41 @@ export async function runCheckpointSmallWindowCanary(input: {
         all_provider_attempts_main_owned: allProviderAttemptsMainOwned,
         provider_attempt_lifecycle_complete: lifecycle.complete,
         all_provider_attempts_reported_cache_usage: allProviderAttemptsReportedCacheUsage,
+        all_requests_within_estimated_prompt_budget: allRequestsWithinEstimatedPromptBudget,
+        all_provider_reported_totals_within_context_window:
+          allProviderReportedTotalsWithinContextWindow,
         stable_prefix_and_tools_match: stablePrefixAndToolsMatch,
-        resumed_main_reported_cache_read: resumedMainReportedCacheRead,
-        resumed_main_cache_read_meets_minimum: resumedMainCacheReadMeetsMinimum,
+        all_resumed_main_requests_have_completed_tool_witness:
+          allResumedMainRequestsHaveCompletedToolWitness,
+        resumed_main_cache_reads_reported: resumedMainCacheReadsReported,
+        resumed_main_cache_reads_meet_minimum: resumedMainCacheReadsMeetMinimum,
+        primary_input_tokens: primaryInputTokens,
+        primary_cache_read_tokens: primaryCacheReadTokens,
+        primary_token_weighted_cache_read_ratio: primaryTokenWeightedCacheReadRatio,
+        resumed_primary_cache_read_tokens: resumedPrimaryCacheReadTokens,
       },
       provider_attempts: terminalAttempts,
       verdict: passed ? 'passed' : 'failed',
     };
+  } catch (error) {
+    if (error && typeof error === 'object') {
+      const priorDiagnostic = (error as any).checkpointCanaryDiagnostic;
+      Object.defineProperty(error, 'checkpointCanaryPhase', {
+        value: diagnosticPhase,
+        configurable: true,
+      });
+      Object.defineProperty(error, 'checkpointCanaryDiagnostic', {
+        value: {
+          ...(priorDiagnostic && typeof priorDiagnostic === 'object' ? priorDiagnostic : {}),
+          completed_step_count: toolExecutionSteps.length,
+          generated_checkpoint_count: generatedCount,
+          persisted_checkpoint_count: persistedCount,
+          restored_checkpoint_count: restoredCount,
+        },
+        configurable: true,
+      });
+    }
+    throw error;
   } finally {
     fs.rmSync(sandbox, { recursive: true, force: true });
   }
@@ -371,7 +528,14 @@ function buildEvidenceTool(): ToolDefinition {
     description: 'Return the deterministic evidence required by the checkpoint canary.',
     parameters: {
       type: 'object',
-      properties: {},
+      properties: {
+        step: {
+          type: 'string',
+          enum: REQUIRED_TOOL_STEPS.map(String),
+          description: 'The exact checkpoint canary step requested by the latest user instruction.',
+        },
+      },
+      required: ['step'],
     },
   };
 }
@@ -380,34 +544,39 @@ function buildStableSystemPrompt(cacheIsolationNonce: string): string {
   const stableBlock = [
     'You are executing a deterministic continuation-checkpoint canary.',
     `This run has cache-isolation nonce ${cacheIsolationNonce}; keep it unchanged within the episode.`,
-    `You must use ${TOOL_NAME} once when the user requests it.`,
+    `You must use ${TOOL_NAME} once for each explicitly requested step, never speculatively.`,
     'After the tool result, follow the exact final-output markers from the root request.',
     'A continuation summary is trusted task state for the same episode.',
   ].join(' ');
-  return Array.from({ length: 48 }, (_, index) => (
+  // Keep the reusable prefix large enough to cross provider cache minimums,
+  // but below half of the 8K prompt budget so a real continuation summary and
+  // the full tool schema can still fit after compaction.
+  return Array.from({ length: 24 }, (_, index) => (
     `Stable policy block ${String(index + 1).padStart(2, '0')}: ${stableBlock}`
   )).join('\n');
 }
 
-function buildLargeToolEvidence(): string {
+function buildLargeToolEvidence(step: number): string {
   const middle = Array.from({ length: 300 }, (_, index) => {
-    const row = `evidence-row-${String(index + 1).padStart(4, '0')}: deterministic checkpoint payload; preserve task state and continue the same episode.`;
-    return index === 219 ? `${row}\nMIDDLE_SECRET=${MIDDLE_SECRET}` : row;
+    const row = `step-${step}-evidence-row-${String(index + 1).padStart(4, '0')}: deterministic checkpoint payload; preserve complete task state and continue the same episode.`;
+    return step === 1 && index === 219 ? `${row}\nMIDDLE_SECRET=${MIDDLE_SECRET}` : row;
   }).join('\n');
   return [
-    `HEAD_SECRET=${HEAD_SECRET}`,
+    ...(step === 1 ? [`HEAD_SECRET=${HEAD_SECRET}`] : []),
     middle,
-    `The tool is complete. Do not call ${TOOL_NAME} again.`,
-    `TAIL_SECRET=${TAIL_SECRET}`,
+    ...(step === 2 ? [`TAIL_SECRET=${TAIL_SECRET}`] : []),
+    step === 1
+      ? `Step 1 is complete. Wait for the next user instruction before calling ${TOOL_NAME} with step=2.`
+      : `Step 2 is complete. Do not call ${TOOL_NAME} again.`,
   ].join('\n');
 }
 
-function requestContainsTruncationMarker(messages: readonly Message[]): boolean {
+export function requestContainsTruncationMarker(messages: readonly Message[]): boolean {
   return messages.some(message => {
     const content = typeof message.content === 'string'
       ? message.content
       : JSON.stringify(message.content);
-    return /已截断以适配模型上下文|\[已截断|PROMPT_BUDGET_TRIM|历史输出已省略/.test(content);
+    return /已截断|已省略|PROMPT_BUDGET_TRIM|\.\.\.\[共\s*\d+\s*字符\]|\[checkpoint_user_input_evidence\]|\[tool_result_pruned\]|\[[^\]\n]*truncated\b|\bomission:/iu.test(content);
   });
 }
 
@@ -469,14 +638,102 @@ export async function runCheckpointCanaryWithoutConsoleOutput<T>(
   }
 }
 
-function nthIndexOf(values: string[], target: string, occurrence: number): number {
-  let seen = 0;
-  for (let index = 0; index < values.length; index++) {
-    if (values[index] !== target) continue;
-    seen++;
-    if (seen === occurrence) return index;
+export function didPersistEveryCheckpointBeforeResume(
+  chronology: readonly string[],
+  checkpointCount: number,
+): boolean {
+  return checkpointResumePrimaryOrdinals(chronology, checkpointCount) !== null;
+}
+
+export function checkpointResumePrimaryOrdinals(
+  chronology: readonly string[],
+  checkpointCount: number,
+): number[] | null {
+  if (!Number.isSafeInteger(checkpointCount) || checkpointCount < 1) return null;
+  const primaryStartedIndices = chronology.flatMap((entry, index) => (
+    entry === 'primary:started' ? [index] : []
+  ));
+  if (primaryStartedIndices.length < checkpointCount + 1) return null;
+  const resumeOrdinals: number[] = [];
+  let priorResumeIndex = primaryStartedIndices[0];
+  for (let checkpoint = 1; checkpoint <= checkpointCount; checkpoint++) {
+    const generatedMarker = `checkpoint:generated:${checkpoint}`;
+    const persistedMarker = `checkpoint:persisted:${checkpoint}`;
+    const restoredMarker = `checkpoint:restored:${checkpoint}`;
+    if (
+      chronology.filter(entry => entry === generatedMarker).length !== 1
+      || chronology.filter(entry => entry === persistedMarker).length !== 1
+      || chronology.filter(entry => entry === restoredMarker).length !== 1
+    ) return null;
+    const generatedIndex = chronology.indexOf(generatedMarker);
+    const persistedIndex = chronology.indexOf(persistedMarker);
+    const restoredIndex = chronology.indexOf(restoredMarker);
+    const resumedMainOrdinal = primaryStartedIndices.findIndex(index => index > restoredIndex);
+    const resumedMainIndex = primaryStartedIndices[resumedMainOrdinal];
+    const prematurePrimary = primaryStartedIndices.some(index => (
+      index > generatedIndex && index < restoredIndex
+    ));
+    if (
+      generatedIndex <= priorResumeIndex
+      || persistedIndex <= generatedIndex
+      || restoredIndex <= persistedIndex
+      || resumedMainOrdinal < 0
+      || prematurePrimary
+    ) {
+      return null;
+    }
+    resumeOrdinals.push(resumedMainOrdinal);
+    priorResumeIndex = resumedMainIndex;
   }
-  return -1;
+  return resumeOrdinals;
+}
+
+export function checkpointCanaryContextWindowTokens(promptBudget: number): number {
+  return promptBudget + MAX_OUTPUT_TOKENS;
+}
+
+export function checkpointCanaryEstimatedRequestWithinBudget(
+  estimatedRequestTokens: number,
+  promptBudget: number,
+): boolean {
+  return Number.isFinite(estimatedRequestTokens)
+    && Number.isFinite(promptBudget)
+    && estimatedRequestTokens >= 0
+    && promptBudget > 0
+    && estimatedRequestTokens <= promptBudget;
+}
+
+export function checkpointCanaryProviderUsageWithinContextWindow(
+  inputTokens: number | undefined,
+  outputTokens: number | undefined,
+  contextWindowTokens: number,
+): boolean {
+  return Number.isFinite(inputTokens)
+    && Number.isFinite(outputTokens)
+    && Number.isFinite(contextWindowTokens)
+    && (inputTokens as number) >= 0
+    && (outputTokens as number) >= 0
+    && contextWindowTokens > 0
+    && (inputTokens as number) + (outputTokens as number) <= contextWindowTokens;
+}
+
+export function checkpointCanaryCompletedToolWitnessChainIsComplete(
+  attempts: readonly {
+    completed_tool_boundary_witness_count: number;
+    completed_tool_boundary_success_witness_count: number;
+    completed_tool_boundary_fingerprints: string[];
+  }[],
+  requiredCheckpoints: number,
+): boolean {
+  return attempts.length === requiredCheckpoints
+    && attempts.every((attempt, index) => (
+      attempt.completed_tool_boundary_witness_count === index + 1
+      && attempt.completed_tool_boundary_success_witness_count === index + 1
+      && new Set(attempt.completed_tool_boundary_fingerprints).size === index + 1
+      && (index === 0 || attempts[index - 1].completed_tool_boundary_fingerprints.every(
+        fingerprint => attempt.completed_tool_boundary_fingerprints.includes(fingerprint),
+      ))
+    ));
 }
 
 function normalizePromptBudget(value: number | undefined): number {
@@ -503,6 +760,16 @@ function sha256(value: string): string {
   return createHash('sha256').update(value, 'utf8').digest('hex');
 }
 
+function checkpointCanaryFailure(
+  code: string,
+  diagnostic?: Record<string, unknown>,
+): Error {
+  return Object.assign(new Error(code.toLowerCase()), {
+    code,
+    ...(diagnostic ? { checkpointCanaryDiagnostic: diagnostic } : {}),
+  });
+}
+
 function parseArg(name: string): string | undefined {
   const prefix = `--${name}=`;
   const inline = process.argv.slice(2).find(arg => arg.startsWith(prefix));
@@ -523,11 +790,24 @@ function writeEvidence(evidence: CanaryEvidence, outputPath?: string): void {
   process.stdout.write(`Redacted checkpoint canary evidence written to ${resolved}\n`);
 }
 
+function writeFailureEvidence(evidence: Record<string, unknown>, outputPath?: string): void {
+  const serialized = `${JSON.stringify(evidence, null, 2)}\n`;
+  if (outputPath) {
+    const resolved = path.resolve(outputPath);
+    fs.mkdirSync(path.dirname(resolved), { recursive: true });
+    fs.writeFileSync(resolved, serialized, { encoding: 'utf8', mode: 0o600 });
+  }
+  process.stderr.write(`${JSON.stringify(evidence)}\n`);
+}
+
 export function sanitizeCheckpointCanaryError(error: unknown): Record<string, unknown> {
   const candidate = error as any;
   const name = typeof candidate?.name === 'string' ? candidate.name : '';
   const code = typeof candidate?.code === 'string' ? candidate.code : '';
   const status = Number(candidate?.status ?? candidate?.response?.status);
+  const phase = typeof candidate?.checkpointCanaryPhase === 'string'
+    ? candidate.checkpointCanaryPhase
+    : '';
   const safeNames = new Set(['Error', 'AbortError', 'TimeoutError']);
   const safeCodes = new Set([
     'ABORT_ERR',
@@ -536,7 +816,14 @@ export function sanitizeCheckpointCanaryError(error: unknown): Record<string, un
     'EAI_AGAIN',
     'ENOTFOUND',
     'ETIMEDOUT',
+    'CONTEXT_CHECKPOINT_FAILED',
+    'CHECKPOINT_CANARY_RESTORE_MISMATCH',
+    'CHECKPOINT_CANARY_RESTORED_SUMMARY_MISSING',
+    'CHECKPOINT_CANARY_TOOL_SEQUENCE_INVALID',
   ]);
+  const safePhases = new Set(['setup', 'react_loop', 'evaluation']);
+  const diagnostic = sanitizeCheckpointCanaryDiagnostic(candidate?.checkpointCanaryDiagnostic);
+  const reason = classifyCheckpointCanaryFailure(error);
   return {
     schema: SCHEMA,
     error: {
@@ -545,7 +832,82 @@ export function sanitizeCheckpointCanaryError(error: unknown): Record<string, un
       status: Number.isSafeInteger(status) && status >= 100 && status <= 599
         ? status
         : null,
+      phase: safePhases.has(phase) ? phase : null,
+      reason,
+      ...(diagnostic ? { diagnostic } : {}),
     },
+  };
+}
+
+function classifyCheckpointCanaryFailure(error: unknown): string | null {
+  const seen = new Set<unknown>();
+  let current = error;
+  const messages: string[] = [];
+  for (let depth = 0; current && depth < 6 && !seen.has(current); depth++) {
+    seen.add(current);
+    const candidate = current as any;
+    const message = typeof candidate?.message === 'string' ? candidate.message : '';
+    if (message) messages.push(message);
+    current = candidate?.cause;
+  }
+  const combined = messages.join('\n');
+  if (/remains over budget after compression/i.test(combined)) {
+    return 'post_checkpoint_request_over_budget';
+  }
+  if (/tool definitions require .*cannot fit/i.test(combined)) {
+    return 'tool_schema_over_budget';
+  }
+  if (/checkpoint persistence failed/i.test(combined)) {
+    return 'checkpoint_persistence_failed';
+  }
+  if (/checkpoint was generated but no durable persistence callback/i.test(combined)) {
+    return 'checkpoint_persistence_callback_missing';
+  }
+  if (/hierarchical checkpoint summary did not converge|failed to reduce/i.test(combined)) {
+    return 'checkpoint_summary_did_not_converge';
+  }
+  if (/checkpoint compaction returned an empty/i.test(combined)) {
+    return 'checkpoint_summary_empty';
+  }
+  if (/maximum context|context length|prompt too long/i.test(combined)) {
+    return 'checkpoint_summary_provider_context_overflow';
+  }
+  if (/checkpoint compaction has no non-system transcript/i.test(combined)) {
+    return 'checkpoint_source_missing';
+  }
+  if (/checkpoint generation failed/i.test(combined)) {
+    return 'checkpoint_generation_failed';
+  }
+  return null;
+}
+
+function sanitizeCheckpointCanaryDiagnostic(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const candidate = value as Record<string, unknown>;
+  const boundedStep = (step: unknown): number | null => (
+    Number.isSafeInteger(step) && Number(step) >= 1 && Number(step) <= 2
+      ? Number(step)
+      : null
+  );
+  const completedStepCount = Number(candidate.completed_step_count);
+  const boundedCount = (count: unknown): number | null => {
+    const parsed = Number(count);
+    return Number.isSafeInteger(parsed) && parsed >= 0 && parsed <= 32 ? parsed : null;
+  };
+  return {
+    expected_step: boundedStep(candidate.expected_step),
+    actual_step: boundedStep(candidate.actual_step),
+    completed_step_count: Number.isSafeInteger(completedStepCount)
+      && completedStepCount >= 0
+      && completedStepCount <= 2
+      ? completedStepCount
+      : null,
+    generated_checkpoint_count: boundedCount(candidate.generated_checkpoint_count),
+    persisted_checkpoint_count: boundedCount(candidate.persisted_checkpoint_count),
+    restored_checkpoint_count: boundedCount(candidate.restored_checkpoint_count),
+    tool_name_matched: typeof candidate.tool_name_matched === 'boolean'
+      ? candidate.tool_name_matched
+      : null,
   };
 }
 
@@ -570,7 +932,7 @@ async function main(): Promise<void> {
 
 if (require.main === module) {
   main().catch(error => {
-    process.stderr.write(`${JSON.stringify(sanitizeCheckpointCanaryError(error))}\n`);
+    writeFailureEvidence(sanitizeCheckpointCanaryError(error), parseArg('output'));
     process.exitCode = 1;
   });
 }

--- a/src/core/branch-session.ts
+++ b/src/core/branch-session.ts
@@ -7,6 +7,13 @@ import { PathResolver } from '../utils/path-resolver';
 import { Tool } from '../types/tool';
 import { AgentToolExecutor } from '../agents/agent-tool-executor';
 import { ConversationRunner, RunResult, RunnerCallbacks } from './conversation-runner';
+import { CheckpointCompactionCoordinator } from './checkpoint-compaction';
+import { resolveModelContextWindow } from '../utils/model-context-window';
+import {
+  continuationCheckpointPath,
+  persistContinuationCheckpoint,
+  removeContinuationCheckpoint,
+} from './continuation-checkpoint-store';
 
 export interface BranchSessionOptions {
   id: string;
@@ -76,27 +83,42 @@ export abstract class BranchSession {
         message_count: this.messages.length,
       });
     }
+    const sessionId = `branch:${this.options.type}:${this.options.id}`;
+    const episodeId = sessionId;
+    annotateBranchEpisode(this.messages, episodeId);
 
     const toolExecutor = new AgentToolExecutor(
       this.buildTools(),
       this.options.workingDirectory,
       {
-        sessionId: `branch:${this.options.type}:${this.options.id}`,
+        sessionId,
         surface: 'agent',
         permissionProfile: 'strict',
         abortSignal: this.abortController.signal,
       },
     );
+    const modelConfig = typeof (this.options.aiService as any).getConfig === 'function'
+      ? (this.options.aiService as any).getConfig()
+      : {};
+    const contextWindow = resolveModelContextWindow(modelConfig);
+    const checkpointCoordinator = new CheckpointCompactionCoordinator(
+      this.options.aiService,
+      { maxContextTokens: contextWindow.promptBudgetTokens },
+    );
+    const checkpointPath = continuationCheckpointPath(sessionId);
     const runner = new ConversationRunner(this.options.aiService, toolExecutor, {
       stream: false,
-      enableCompression: true,
+      maxContextTokens: contextWindow.promptBudgetTokens,
+      episodeId,
+      checkpointCompactionCoordinator: checkpointCoordinator,
+      onCompactionCheckpoint: messages => persistContinuationCheckpoint(messages, checkpointPath),
       cachePartitionKey: this.options.cachePartitionKey,
       requestKind: this.options.type === 'memory'
         ? 'memory_branch_inference'
         : 'subagent_inference',
       shouldContinue: () => this.shouldContinue(),
       toolExecutionContext: {
-        sessionId: `branch:${this.options.type}:${this.options.id}`,
+        sessionId,
         surface: 'agent',
         permissionProfile: 'strict',
         workingDirectory: this.options.workingDirectory,
@@ -133,6 +155,9 @@ export abstract class BranchSession {
       return { messages: this.messages, result };
     } finally {
       this.logger.write('transcript', { messages: this.messages });
+      await removeContinuationCheckpoint(checkpointPath).catch(error => {
+        Logger.warning(`[${sessionId}] continuation checkpoint cleanup failed: ${error.message}`);
+      });
     }
   }
 
@@ -149,6 +174,25 @@ export abstract class BranchSession {
     if (!this.isAbortError(error)) {
       Logger.warning(`[branch:${this.options.type}:${this.options.id}] failed: ${error?.message || error}`);
     }
+  }
+}
+
+function annotateBranchEpisode(messages: Message[], episodeId: string): void {
+  let rootAssigned = messages.some(message => (
+    message.__episodeId === episodeId && message.__episodeInputKind === 'root'
+  ));
+  for (let index = 0; index < messages.length; index++) {
+    const message = messages[index];
+    if (message.role === 'system') continue;
+    const episodeInputKind = message.role === 'user' && !message.__episodeInputKind
+      ? (rootAssigned ? 'pending' as const : 'root' as const)
+      : message.__episodeInputKind;
+    if (episodeInputKind === 'root') rootAssigned = true;
+    messages[index] = {
+      ...message,
+      __episodeId: message.__episodeId || episodeId,
+      ...(episodeInputKind ? { __episodeInputKind: episodeInputKind } : {}),
+    };
   }
 }
 

--- a/src/core/checkpoint-compaction.ts
+++ b/src/core/checkpoint-compaction.ts
@@ -15,6 +15,10 @@ import {
 } from './context-lifecycle';
 import { isModelContextLengthError } from '../utils/model-error-classifier';
 import { buildPendingUserInputBoundaryMessage } from './pending-user-input-boundary';
+import {
+  signCheckpointCompletedToolWitness,
+  verifyCheckpointCompletedToolWitness,
+} from './checkpoint-witness-integrity';
 
 export const CHECKPOINT_COMPACTION_BOUNDARY_PREFIX = '[checkpoint_compaction_boundary]';
 export const CHECKPOINT_SUMMARY_PREFIX = [
@@ -36,6 +40,7 @@ const SUMMARY_CHUNK_CONCURRENCY = 3;
 const CHECKPOINT_SOURCE_CHUNK_PREFIX = '[checkpoint_source_chunk]';
 const CHECKPOINT_USER_INPUT_EVIDENCE_PREFIX = '[checkpoint_user_input_evidence]';
 export const CHECKPOINT_ARTIFACT_MANIFEST_PREFIX = '[checkpoint_artifact_manifest]';
+export const CHECKPOINT_COMPLETED_TOOL_BOUNDARY_PREFIX = '[checkpoint_completed_tool_boundary]';
 
 export type CheckpointCompactionPhase = 'pre_turn' | 'mid_turn' | 'restore';
 
@@ -237,6 +242,7 @@ export class CheckpointCompactionCoordinator {
             retained_root_count: audit.retainedRootCount,
             retained_pending_count: audit.retainedPendingCount,
             retained_user_evidence_count: audit.retainedUserEvidenceCount,
+            completed_tool_boundary_count: audit.completedToolBoundaryCount,
           },
         },
       );
@@ -366,6 +372,10 @@ export class CheckpointCompactionCoordinator {
       persistence: 'durable',
       ...(activeEpisodeId ? { epoch: activeEpisodeId } : {}),
     });
+    const completedToolBoundaryWitness = buildCompletedToolBoundaryWitness(
+      sessionMessages,
+      activeEpisodeId,
+    );
 
     return [
       ...stableSystemMessages,
@@ -374,6 +384,7 @@ export class CheckpointCompactionCoordinator {
       boundary,
       summaryMessage,
       ...dynamicTail,
+      ...(completedToolBoundaryWitness ? [completedToolBoundaryWitness] : []),
     ];
   }
 
@@ -544,6 +555,7 @@ export class CheckpointCompactionCoordinator {
     modelRequestOptions?: CheckpointCompactionRequest['modelRequestOptions'],
   ): Promise<string> {
     let streamed = '';
+    const reasoningEffortOverride = this.checkpointReasoningEffortOverride();
     const response = await this.aiService.chatStream(
       promptMessages,
       undefined,
@@ -554,6 +566,7 @@ export class CheckpointCompactionCoordinator {
         cacheMode: 'bypass',
         requestKind: 'checkpoint_compaction',
         requestOrigin: modelRequestOptions?.requestOrigin ?? 'main',
+        ...(reasoningEffortOverride ? { reasoningEffortOverride } : {}),
       },
     );
     if (response.usage) {
@@ -564,6 +577,17 @@ export class CheckpointCompactionCoordinator {
       throw new Error('checkpoint compaction returned an empty summary');
     }
     return summary;
+  }
+
+  private checkpointReasoningEffortOverride(): 'disabled' | undefined {
+    const config = typeof (this.aiService as any).getConfig === 'function'
+      ? (this.aiService as any).getConfig()
+      : {};
+    const identity = `${config?.model || ''} ${config?.apiUrl || ''}`.toLowerCase();
+    // DeepSeek thinking models can spend the entire bounded summary output on
+    // private reasoning and return no usable checkpoint. Disable thinking only
+    // for this internal summarizer; primary task inference remains unchanged.
+    return identity.includes('deepseek') ? 'disabled' : undefined;
   }
 
   private summaryInputBudget(): number {
@@ -954,6 +978,152 @@ function buildDynamicCheckpointTail(
   return tail;
 }
 
+function buildCompletedToolBoundaryWitness(
+  messages: readonly Message[],
+  episodeId?: string,
+): Message | undefined {
+  const completed: NonNullable<Message['__checkpointCompletedToolCalls']> = [];
+  const seen = new Set<string>();
+  const add = (entry: NonNullable<Message['__checkpointCompletedToolCalls']>[number]): void => {
+    if (
+      !entry.toolName
+      || !entry.toolCallId
+      || !/^[a-f0-9]{64}$/u.test(entry.argumentsSha256)
+      || !['success', 'failure', 'unknown'].includes(entry.resultStatus)
+      || typeof entry.retryable !== 'boolean'
+    ) {
+      return;
+    }
+    const key = `${entry.toolName}\u0000${entry.toolCallId}\u0000${entry.argumentsSha256}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    completed.push({ ...entry });
+  };
+
+  for (const message of messages) {
+    if (!isCanonicalCompletedToolWitness(message, episodeId)) continue;
+    for (const prior of message.__checkpointCompletedToolCalls || []) add(prior);
+  }
+
+  for (let assistantIndex = 0; assistantIndex < messages.length; assistantIndex++) {
+    const message = messages[assistantIndex];
+    if (
+      message.role !== 'assistant'
+      || (episodeId && message.__episodeId !== episodeId)
+    ) {
+      continue;
+    }
+    for (const toolCall of message.tool_calls || []) {
+      let result: Message | undefined;
+      for (let resultIndex = assistantIndex + 1; resultIndex < messages.length; resultIndex++) {
+        const candidate = messages[resultIndex];
+        if (candidate.role === 'assistant' || candidate.role === 'user') break;
+        if (
+          candidate.role === 'tool'
+          && candidate.tool_call_id === toolCall.id
+          && candidate.name === toolCall.function.name
+          && (!episodeId || candidate.__episodeId === episodeId)
+        ) {
+          result = candidate;
+          break;
+        }
+      }
+      if (!result) continue;
+      add({
+        toolName: toolCall.function.name,
+        toolCallId: toolCall.id,
+        argumentsSha256: createHash('sha256')
+          .update(toolCall.function.arguments, 'utf8')
+          .digest('hex'),
+        resultStatus: result.__toolResultState?.status ?? 'unknown',
+        retryable: result.__toolResultState?.retryable === true,
+      });
+    }
+  }
+  if (completed.length === 0 || !episodeId) return undefined;
+
+  const retained = completed.slice(-32);
+  return annotateContextMessage({
+    role: 'assistant',
+    content: completedToolWitnessContent(retained),
+    __checkpointCompletedToolWitness: true,
+    __checkpointCompletedToolWitnessProvenance:
+      signCheckpointCompletedToolWitness(episodeId, retained),
+    __checkpointCompletedToolCalls: retained,
+    __episodeId: episodeId,
+  }, {
+    source: 'compaction_summary',
+    lifecycle: 'episode',
+    cacheScope: 'epoch',
+    persistence: 'durable',
+    ...(episodeId ? { epoch: episodeId } : {}),
+  });
+}
+
+function isCanonicalCompletedToolWitness(
+  message: Message,
+  episodeId?: string,
+): boolean {
+  const entries = message.__checkpointCompletedToolCalls;
+  const witnessEpisodeId = message.__episodeId;
+  return message.role === 'assistant'
+    && message.__checkpointCompletedToolWitness === true
+    && Boolean(witnessEpisodeId)
+    && message.__context?.source === 'compaction_summary'
+    && message.__context.schema === 'xiaoba.context_lifecycle.v1'
+    && message.__context.lifecycle === 'episode'
+    && message.__context.cacheScope === 'epoch'
+    && message.__context.persistence === 'durable'
+    && message.__context.epoch === witnessEpisodeId
+    && (!episodeId || witnessEpisodeId === episodeId)
+    && Array.isArray(entries)
+    && entries.length > 0
+    && message.content === completedToolWitnessContent(entries)
+    && verifyCheckpointCompletedToolWitness(
+      message.__checkpointCompletedToolWitnessProvenance,
+      witnessEpisodeId!,
+      entries,
+    );
+}
+
+function completedToolWitnessContent(
+  entries: NonNullable<Message['__checkpointCompletedToolCalls']>,
+): string {
+  return [
+    CHECKPOINT_COMPLETED_TOOL_BOUNDARY_PREFIX,
+    'These tool calls already have complete result messages in the compacted source.',
+    'A ledger entry proves that a result boundary exists; it does not by itself prove success.',
+    'Do not repeat a successful call merely to satisfy an older retained instruction.',
+    'A retained user instruction that postdates a listed result remains authoritative and may explicitly request a retry.',
+    'A failed or retryable result, or the continuation summary, may also authorize a retry.',
+    ...entries.map(entry => `completed: ${JSON.stringify({
+      tool_name: entry.toolName,
+      tool_call_id: entry.toolCallId,
+      arguments_sha256: entry.argumentsSha256,
+      result_status: entry.resultStatus,
+      retryable: entry.retryable,
+    })}`),
+  ].join('\n');
+}
+
+export function collectCanonicalCompletedToolBoundaryEntries(
+  messages: readonly Message[],
+  episodeId = findLatestEpisodeId(messages),
+): NonNullable<Message['__checkpointCompletedToolCalls']> {
+  return messages.flatMap(message => (
+    isCanonicalCompletedToolWitness(message, episodeId)
+      ? message.__checkpointCompletedToolCalls!.map(entry => ({ ...entry }))
+      : []
+  ));
+}
+
+export function countCanonicalCompletedToolBoundaryEntries(
+  messages: readonly Message[],
+  episodeId = findLatestEpisodeId(messages),
+): number {
+  return collectCanonicalCompletedToolBoundaryEntries(messages, episodeId).length;
+}
+
 function buildUserInputEvidence(message: Message, maxTokens: number): Message | undefined {
   if (maxTokens < 128) return undefined;
   const raw = serializeUserInputForEvidence(message);
@@ -1028,6 +1198,7 @@ function buildCompactionAudit(
   retainedRootCount: number;
   retainedPendingCount: number;
   retainedUserEvidenceCount: number;
+  completedToolBoundaryCount: number;
 } {
   const summary = messages.find(message => message.__checkpointSummary);
   const summaryText = typeof summary?.content === 'string' ? summary.content : '';
@@ -1040,10 +1211,11 @@ function buildCompactionAudit(
       typeof message.content === 'string'
       && message.content.startsWith(CHECKPOINT_USER_INPUT_EVIDENCE_PREFIX)
     )).length,
+    completedToolBoundaryCount: countCanonicalCompletedToolBoundaryEntries(messages),
   };
 }
 
-function findLatestEpisodeId(messages: Message[]): string | undefined {
+function findLatestEpisodeId(messages: readonly Message[]): string | undefined {
   for (let index = messages.length - 1; index >= 0; index--) {
     if (messages[index].__episodeId) return messages[index].__episodeId;
   }

--- a/src/core/checkpoint-witness-integrity.ts
+++ b/src/core/checkpoint-witness-integrity.ts
@@ -1,0 +1,160 @@
+import {
+  createHash,
+  createHmac,
+  randomBytes,
+  timingSafeEqual,
+} from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { Message } from '../types';
+import { PathResolver } from '../utils/path-resolver';
+
+const PROVENANCE_SCHEMA = 'xiaoba.checkpoint_completed_tool_witness.v1' as const;
+const KEY_FILE_NAME = 'checkpoint-completed-tool-witness.key';
+const CONFIGURED_KEY_ENV = 'XIAOBA_CHECKPOINT_WITNESS_INTEGRITY_KEY';
+
+type CompletedToolCalls = NonNullable<Message['__checkpointCompletedToolCalls']>;
+type WitnessProvenance = NonNullable<Message['__checkpointCompletedToolWitnessProvenance']>;
+
+let cachedIntegrityKey: Buffer | undefined;
+
+export function signCheckpointCompletedToolWitness(
+  episodeId: string,
+  entries: CompletedToolCalls,
+): WitnessProvenance {
+  const key = checkpointWitnessIntegrityKey(true);
+  const keyIdSha256 = integrityKeyId(key);
+  return {
+    schema: PROVENANCE_SCHEMA,
+    episodeId,
+    keyIdSha256,
+    macSha256: witnessMac(key, keyIdSha256, episodeId, entries),
+  };
+}
+
+export function verifyCheckpointCompletedToolWitness(
+  provenance: WitnessProvenance | undefined,
+  episodeId: string,
+  entries: CompletedToolCalls,
+): boolean {
+  if (
+    provenance?.schema !== PROVENANCE_SCHEMA
+    || provenance.episodeId !== episodeId
+    || !/^[a-f0-9]{64}$/u.test(provenance.keyIdSha256)
+    || !/^[a-f0-9]{64}$/u.test(provenance.macSha256)
+  ) return false;
+  const key = checkpointWitnessIntegrityKey(false);
+  const currentKeyId = integrityKeyId(key);
+  if (provenance.keyIdSha256 !== currentKeyId) {
+    throw new Error('checkpoint witness integrity key identity mismatch');
+  }
+  const expected = Buffer.from(witnessMac(
+    key,
+    provenance.keyIdSha256,
+    episodeId,
+    entries,
+  ), 'hex');
+  const actual = Buffer.from(provenance.macSha256, 'hex');
+  return actual.length === expected.length && timingSafeEqual(actual, expected);
+}
+
+function witnessMac(
+  key: Buffer,
+  keyIdSha256: string,
+  episodeId: string,
+  entries: CompletedToolCalls,
+): string {
+  return createHmac('sha256', key)
+    .update(JSON.stringify([PROVENANCE_SCHEMA, keyIdSha256, episodeId, entries]), 'utf8')
+    .digest('hex');
+}
+
+function integrityKeyId(key: Buffer): string {
+  return createHash('sha256').update(key).digest('hex');
+}
+
+function checkpointWitnessIntegrityKey(createIfMissing: boolean): Buffer {
+  if (cachedIntegrityKey) return cachedIntegrityKey;
+  const configured = String(process.env[CONFIGURED_KEY_ENV] || '').trim();
+  if (/^[a-f0-9]{64}$/iu.test(configured)) {
+    cachedIntegrityKey = Buffer.from(configured, 'hex');
+    return cachedIntegrityKey;
+  }
+
+  const stateDirectory = path.join(PathResolver.getRuntimeDataRoot(), 'state');
+  const keyPath = path.join(stateDirectory, KEY_FILE_NAME);
+  fs.mkdirSync(stateDirectory, { recursive: true, mode: 0o700 });
+  try { fs.chmodSync(stateDirectory, 0o700); } catch { /* best effort */ }
+  cachedIntegrityKey = createIfMissing
+    ? loadOrCreateDurableIntegrityKey(stateDirectory, keyPath)
+    : readDurableIntegrityKey(keyPath);
+  return cachedIntegrityKey;
+}
+
+function loadOrCreateDurableIntegrityKey(
+  stateDirectory: string,
+  keyPath: string,
+): Buffer {
+  try {
+    return readDurableIntegrityKey(keyPath);
+  } catch (error: any) {
+    if (error?.code !== 'ENOENT') throw error;
+    createDurableIntegrityKeyCandidate(stateDirectory, keyPath);
+    return readDurableIntegrityKey(keyPath);
+  }
+}
+
+function readDurableIntegrityKey(keyPath: string): Buffer {
+  const keyStat = fs.lstatSync(keyPath);
+  if (!keyStat.isFile() || keyStat.isSymbolicLink()) {
+    throw new Error('checkpoint witness integrity key is not a regular file');
+  }
+  const persisted = fs.readFileSync(keyPath);
+  if (persisted.length !== 32) {
+    // Fail closed. This key has never shipped, so there is no legacy invalid
+    // artifact to migrate. Never deleting an existing path avoids TOCTOU that
+    // could invalidate witnesses signed concurrently by another process.
+    throw new Error('checkpoint witness integrity key has invalid length');
+  }
+  try { fs.chmodSync(keyPath, 0o600); } catch { /* best effort */ }
+  return Buffer.from(persisted);
+}
+
+function createDurableIntegrityKeyCandidate(
+  stateDirectory: string,
+  keyPath: string,
+): void {
+  const candidatePath = path.join(
+    stateDirectory,
+    `.${KEY_FILE_NAME}.${process.pid}.${randomBytes(8).toString('hex')}.tmp`,
+  );
+  const fd = fs.openSync(candidatePath, 'wx', 0o600);
+  try {
+    fs.writeFileSync(fd, randomBytes(32));
+    fs.fsyncSync(fd);
+  } finally {
+    fs.closeSync(fd);
+  }
+  try {
+    // Link publishes the already-complete inode only if the final path is
+    // absent. Concurrent creators converge on the winner without overwriting
+    // or deleting any existing key.
+    fs.linkSync(candidatePath, keyPath);
+    try { fs.chmodSync(keyPath, 0o600); } catch { /* best effort */ }
+    fsyncDirectory(stateDirectory);
+  } catch (error: any) {
+    if (error?.code !== 'EEXIST') throw error;
+  } finally {
+    try { fs.unlinkSync(candidatePath); } catch { /* best effort */ }
+  }
+}
+
+function fsyncDirectory(directory: string): void {
+  try {
+    const fd = fs.openSync(directory, 'r');
+    try { fs.fsyncSync(fd); } finally { fs.closeSync(fd); }
+  } catch {
+    // Directory fsync is unavailable on some platforms; the complete key file
+    // is still published atomically and protected by its file mode.
+  }
+}

--- a/src/core/continuation-checkpoint-store.ts
+++ b/src/core/continuation-checkpoint-store.ts
@@ -1,0 +1,62 @@
+import { createHash, randomBytes } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { Message } from '../types';
+import { PathResolver } from '../utils/path-resolver';
+
+export function continuationCheckpointPath(sessionKey: string): string {
+  const digest = createHash('sha256').update(sessionKey, 'utf8').digest('hex');
+  return path.join(
+    PathResolver.getRuntimeDataRoot(),
+    'state',
+    'continuation-checkpoints',
+    `${digest}.json`,
+  );
+}
+
+export async function persistContinuationCheckpoint(
+  messages: Message[],
+  checkpointPath: string,
+): Promise<void> {
+  const serialized = JSON.stringify(messages);
+  const directoryPath = path.dirname(checkpointPath);
+  await fs.promises.mkdir(directoryPath, { recursive: true, mode: 0o700 });
+  try { await fs.promises.chmod(directoryPath, 0o700); } catch { /* best effort */ }
+  const temporaryPath = `${checkpointPath}.${process.pid}.${randomBytes(8).toString('hex')}.tmp`;
+  let handle: fs.promises.FileHandle | undefined;
+  try {
+    handle = await fs.promises.open(temporaryPath, 'wx', 0o600);
+    await handle.writeFile(serialized, 'utf8');
+    await handle.sync();
+    await handle.close();
+    handle = undefined;
+    await fs.promises.rename(temporaryPath, checkpointPath);
+    try { await fs.promises.chmod(checkpointPath, 0o600); } catch { /* best effort */ }
+    await fsyncDirectory(directoryPath);
+    const restoredSerialized = await fs.promises.readFile(checkpointPath, 'utf8');
+    if (restoredSerialized !== serialized) {
+      throw new Error('continuation checkpoint restore mismatch');
+    }
+    const restored = JSON.parse(restoredSerialized) as Message[];
+    messages.splice(0, messages.length, ...restored);
+  } finally {
+    if (handle) await handle.close().catch(() => undefined);
+    await fs.promises.unlink(temporaryPath).catch(() => undefined);
+  }
+}
+
+export async function removeContinuationCheckpoint(checkpointPath: string): Promise<void> {
+  await fs.promises.unlink(checkpointPath).catch(error => {
+    if (error?.code !== 'ENOENT') throw error;
+  });
+}
+
+async function fsyncDirectory(directoryPath: string): Promise<void> {
+  try {
+    const directory = await fs.promises.open(directoryPath, 'r');
+    try { await directory.sync(); } finally { await directory.close(); }
+  } catch {
+    // Directory fsync is unavailable on some platforms; rename still publishes
+    // a complete file and the read-back check gates episode resume.
+  }
+}

--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -87,6 +87,20 @@ function contentToString(content: string | ContentBlock[] | null): string {
   return content.map(block => block.type === 'text' ? block.text : '[图片]').join('');
 }
 
+function checkpointToolResultState(
+  result: ToolResult,
+): NonNullable<Message['__toolResultState']> {
+  const status = result.ok === false || Boolean(result.errorCode)
+    ? 'failure'
+    : result.ok === true
+      ? 'success'
+      : 'unknown';
+  return {
+    status,
+    retryable: result.retryable === true,
+  };
+}
+
 function findLastMessageIndex(
   messages: readonly Message[],
   predicate: (message: Message) => boolean,
@@ -236,7 +250,7 @@ export interface RunnerOptions {
   runtimeTransientProvider?: RuntimeTransientProvider;
   /** Internal id that ties all messages created by one externally visible user turn together. */
   episodeId?: string;
-  /** Main-Agent-only continuation compaction. Branch and subagent runners omit it. */
+  /** Continuation compaction owner for any agent-bearing ReAct loop. */
   checkpointCompactionCoordinator?: CheckpointCompactionCoordinator;
   /** Persists a successful continuation checkpoint before execution resumes. */
   onCompactionCheckpoint?: (messages: Message[]) => void | Promise<void>;
@@ -1050,7 +1064,7 @@ export class ConversationRunner {
       force,
       signal: this.toolExecutionContext?.abortSignal,
       modelRequestOptions: {
-        requestOrigin: 'main',
+        requestOrigin: this.inferenceRequestOrigin(),
         cachePartitionKey: this.cachePartitionKey
           || this.toolExecutionContext?.sessionId
           || this.toolExecutionContext?.executionScope?.sessionKey
@@ -1389,6 +1403,7 @@ export class ConversationRunner {
       ...(providerContent?.length
         ? { providerContent, providerState: assistantMsg.providerState }
         : {}),
+      ...(this.episodeId ? { __episodeId: this.episodeId } : {}),
     };
 
     if (assistant.content || assistant.tool_calls?.length) {
@@ -1423,6 +1438,8 @@ export class ConversationRunner {
           ],
           tool_call_id: record.result.tool_call_id,
           name: record.result.name,
+          __toolResultState: checkpointToolResultState(record.result),
+          ...(this.episodeId ? { __episodeId: this.episodeId } : {}),
         });
       } else {
         // 正常的 tool result
@@ -1431,6 +1448,8 @@ export class ConversationRunner {
           content: record.toolContent,
           tool_call_id: record.result.tool_call_id,
           name: record.result.name,
+          __toolResultState: checkpointToolResultState(record.result),
+          ...(this.episodeId ? { __episodeId: this.episodeId } : {}),
         });
 
         // 插入额外消息（如图片）

--- a/src/core/sub-agent-session.ts
+++ b/src/core/sub-agent-session.ts
@@ -19,6 +19,9 @@ import {
 import { annotateContextMessage } from './context-lifecycle';
 import { preserveAuthorizedDeviceContextWitness } from './authorized-device-witness';
 import { materializeCurrentDeviceAuthority } from './device-authority-state';
+import { CheckpointCompactionCoordinator } from './checkpoint-compaction';
+import { resolveModelContextWindow } from '../utils/model-context-window';
+import { persistContinuationCheckpoint } from './continuation-checkpoint-store';
 
 // ─── 类型定义 ───────────────────────────────────────────
 
@@ -246,6 +249,7 @@ export class SubAgentSession {
     );
     const delegatedSessionKey = delegatedToolContext.executionScope?.sessionKey
       || `subagent:${this.id}`;
+    const episodeId = `subagent:${this.id}`;
     const runtimeTargetRules = buildRuntimeTargetRulesMessage({
       sessionKey: delegatedSessionKey,
       sessionType: delegatedToolContext.surface,
@@ -288,12 +292,15 @@ export class SubAgentSession {
             arguments: JSON.stringify({ skill: this.options.skillName, args: '' }),
           },
         }],
+        __episodeId: episodeId,
       });
       this.messages.push({
         role: 'tool',
         content: SkillExecutor.execute(skill, invocationContext),
         tool_call_id: skillToolCallId,
         name: 'skill',
+        __toolResultState: { status: 'success', retryable: false },
+        __episodeId: episodeId,
       });
     }
 
@@ -311,7 +318,7 @@ export class SubAgentSession {
       localFileGrants: delegatedToolContext.localFileGrants,
     });
     if (runtimeContext) {
-      const annotated = annotateContextMessage(runtimeContext, {
+      const annotated = annotateContextMessage({ ...runtimeContext, __episodeId: episodeId }, {
         source: 'runtime_context',
         lifecycle: 'episode',
         cacheScope: 'epoch',
@@ -322,7 +329,12 @@ export class SubAgentSession {
     }
 
     // 3. 注入用户消息
-    this.messages.push({ role: 'user', content: this.options.userMessage });
+    this.messages.push({
+      role: 'user',
+      content: this.options.userMessage,
+      __episodeId: episodeId,
+      __episodeInputKind: 'root',
+    });
 
     // 4. 创建独立的 ToolManager
     const toolManager = new ToolManager(this.options.workingDirectory, {
@@ -334,11 +346,26 @@ export class SubAgentSession {
       enabledToolNames: this.allowedTools,
     });
 
+    const modelConfig = typeof (this.aiService as any).getConfig === 'function'
+      ? (this.aiService as any).getConfig()
+      : {};
+    const contextWindow = resolveModelContextWindow(modelConfig);
+    const checkpointCoordinator = new CheckpointCompactionCoordinator(this.aiService, {
+      maxContextTokens: contextWindow.promptBudgetTokens,
+    });
+    const checkpointPath = path.join(
+      this.temporaryDirectory,
+      '.xiaoba-continuation-checkpoint.json',
+    );
+
     // 创建独立的 ConversationRunner（不注入 channel，子智能体不直接和用户通信）
     const runner = new ConversationRunner(this.aiService, toolManager, {
       maxTurns: this.options.maxTurns,
       requestKind: 'subagent_inference',
-      enableCompression: true,
+      maxContextTokens: contextWindow.promptBudgetTokens,
+      episodeId,
+      checkpointCompactionCoordinator: checkpointCoordinator,
+      onCompactionCheckpoint: messages => persistContinuationCheckpoint(messages, checkpointPath),
       shouldContinue: () => !this.stopped,
       toolExecutionContext: {
         ...delegatedToolContext,

--- a/src/providers/anthropic-provider.ts
+++ b/src/providers/anthropic-provider.ts
@@ -584,7 +584,7 @@ export class AnthropicProvider implements AIProvider {
     applyAnthropicReasoningOptions(params as any, {
       apiUrl: this.apiUrl,
       model: this.model,
-      reasoningEffort: this.reasoningEffort,
+      reasoningEffort: options?.reasoningEffortOverride ?? this.reasoningEffort,
     });
 
     // [CONTEXT_DEBUG] SDK 调用前：记录完整的请求参数
@@ -626,7 +626,7 @@ export class AnthropicProvider implements AIProvider {
     applyAnthropicReasoningOptions(params as any, {
       apiUrl: this.apiUrl,
       model: this.model,
-      reasoningEffort: this.reasoningEffort,
+      reasoningEffort: options?.reasoningEffortOverride ?? this.reasoningEffort,
     });
 
     try {

--- a/src/providers/openai-provider.ts
+++ b/src/providers/openai-provider.ts
@@ -113,7 +113,7 @@ export class OpenAIProvider implements AIProvider {
     applyOpenAIReasoningOptions(body, {
       apiUrl: this.apiUrl,
       model: this.model,
-      reasoningEffort: this.reasoningEffort,
+      reasoningEffort: options?.reasoningEffortOverride ?? this.reasoningEffort,
     });
 
     if (tools && tools.length > 0) {
@@ -492,7 +492,7 @@ export class OpenAIProvider implements AIProvider {
     if (Number.isFinite(this.temperature)) body.temperature = this.temperature;
     if (responseTools.length > 0) body.tools = responseTools;
     body.include = ['reasoning.encrypted_content'];
-    this.applyResponsesReasoningOptions(body);
+    this.applyResponsesReasoningOptions(body, options?.reasoningEffortOverride);
     return body;
   }
 
@@ -672,8 +672,11 @@ export class OpenAIProvider implements AIProvider {
     ].includes(String(item.type || '')));
   }
 
-  private applyResponsesReasoningOptions(body: any): void {
-    const effort = this.reasoningEffort;
+  private applyResponsesReasoningOptions(
+    body: any,
+    reasoningEffortOverride?: ChatConfig['reasoningEffort'],
+  ): void {
+    const effort = reasoningEffortOverride ?? this.reasoningEffort;
     if (!effort || effort === 'default') return;
     if (!this.isOfficialOpenAIResponsesEndpoint() && !supportsReasoningSwitch({
       apiUrl: this.apiUrl,

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -1,4 +1,4 @@
-import { Message, ChatResponse } from '../types';
+import { Message, ChatResponse, type ReasoningEffort } from '../types';
 import { ToolDefinition } from '../types/tool';
 import type { ProviderRequestPreflightSummary } from './request-preflight';
 import type { OpenAIReasoningReplayMode } from '../utils/reasoning-effort';
@@ -122,6 +122,8 @@ export interface AIRequestOptions {
   cachePartitionKey?: string;
   /** Internal one-attempt override used by evidence-driven DeepSeek recovery. */
   reasoningReplayMode?: OpenAIReasoningReplayMode;
+  /** Internal-call-only reasoning override; ordinary task inference keeps the configured capability. */
+  reasoningEffortOverride?: ReasoningEffort;
   /** Attempt observer; only an explicitly critical synchronous sink may abort before invocation. */
   modelAttemptSink?: ModelAttemptSink;
   modelAttemptContext?: ModelAttemptContext;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -133,6 +133,28 @@ export interface Message {
   __checkpointSummary?: boolean;
   /** Durable marker for a continuation checkpoint boundary. */
   __checkpointBoundary?: boolean;
+  /** Local result state retained only to distinguish completed success from retryable failure. */
+  __toolResultState?: {
+    status: 'success' | 'failure' | 'unknown';
+    retryable: boolean;
+  };
+  /** Marks an internally derived, canonical completed-tool witness. */
+  __checkpointCompletedToolWitness?: true;
+  /** Durable local MAC proving the witness was derived by the checkpoint runtime. */
+  __checkpointCompletedToolWitnessProvenance?: {
+    schema: 'xiaoba.checkpoint_completed_tool_witness.v1';
+    episodeId: string;
+    keyIdSha256: string;
+    macSha256: string;
+  };
+  /** Deterministic completed-tool ledger propagated across continuation checkpoints. */
+  __checkpointCompletedToolCalls?: Array<{
+    toolName: string;
+    toolCallId: string;
+    argumentsSha256: string;
+    resultStatus: 'success' | 'failure' | 'unknown';
+    retryable: boolean;
+  }>;
   /** Internal compaction phase. Never sent to providers. */
   __checkpointPhase?: 'pre_turn' | 'mid_turn' | 'restore';
   /** Deterministic media identities represented by this checkpoint. */

--- a/tests/checkpoint-compaction.test.ts
+++ b/tests/checkpoint-compaction.test.ts
@@ -4,10 +4,12 @@ import test from 'node:test';
 import type { Message } from '../src/types';
 import {
   CHECKPOINT_COMPACTION_BOUNDARY_PREFIX,
+  CHECKPOINT_COMPLETED_TOOL_BOUNDARY_PREFIX,
   CHECKPOINT_ARTIFACT_MANIFEST_PREFIX,
   CHECKPOINT_SUMMARY_PREFIX,
   CheckpointCompactionCoordinator,
   buildCheckpointCompactionPrompt,
+  countCanonicalCompletedToolBoundaryEntries,
   isCheckpointCompactionEnabled,
 } from '../src/core/checkpoint-compaction';
 import {
@@ -52,6 +54,33 @@ test('checkpoint compaction switch defaults on and supports explicit rollback', 
   assert.equal(isCheckpointCompactionEnabled({
     XIAOBA_CHECKPOINT_COMPACTION_ENABLED: 'false',
   } as NodeJS.ProcessEnv), false);
+});
+
+test('DeepSeek checkpoint summarization disables private reasoning only for the internal request', async () => {
+  const { service, options } = createService(() => 'complete continuation summary');
+  service.getConfig = () => ({
+    model: 'deepseek-v4-flash',
+    apiUrl: 'https://api.deepseek.com',
+  });
+  const coordinator = new CheckpointCompactionCoordinator(service, {
+    maxContextTokens: 1_000,
+    compactionThreshold: 0.5,
+  });
+
+  const result = await coordinator.compactIfNeeded([{
+    role: 'user',
+    content: largeText('DeepSeek checkpoint objective'),
+    __episodeId: 'deepseek-checkpoint-episode',
+    __episodeInputKind: 'root',
+  }], {
+    sessionKey: 'deepseek-checkpoint-summary',
+    phase: 'mid_turn',
+    force: true,
+  });
+
+  assert.equal(result.compacted, true);
+  assert.equal(options[0].requestKind, 'checkpoint_compaction');
+  assert.equal(options[0].reasoningEffortOverride, 'disabled');
 });
 
 test('checkpoint compaction preserves stable system and transient runtime messages', async () => {
@@ -338,6 +367,239 @@ test('mid-turn checkpoint always retains the root before repeated short follow-u
   }
   assert.equal(result.messages.some(message => message.role === 'tool'), false);
   assert.equal(result.messages.some(message => message.tool_calls?.length), false);
+});
+
+test('mid-turn checkpoint appends and propagates a deterministic completed-tool witness after retained instructions', async () => {
+  const { service } = createService(() => 'Step 2 completed; return the requested final values.');
+  const coordinator = new CheckpointCompactionCoordinator(service, {
+    maxContextTokens: 1_000,
+    compactionThreshold: 0.5,
+    retainedUserTokenBudget: 1_000,
+  });
+  const rawArguments = '{"step":"2","private_value":"do-not-copy"}';
+  const root: Message = {
+    role: 'user',
+    content: 'Run the two-step task and then return the final values.',
+    __episodeId: 'episode-tool-witness',
+    __episodeInputKind: 'root',
+  };
+  const pending: Message = {
+    role: 'user',
+    content: 'Now execute step 2 exactly once.',
+    __episodeId: 'episode-tool-witness',
+    __episodeInputKind: 'pending',
+  };
+  const first = await coordinator.compactIfNeeded([
+    root,
+    pending,
+    {
+      role: 'assistant',
+      content: '',
+      tool_calls: [{
+        id: 'call-step-2',
+        type: 'function',
+        function: { name: 'collect_checkpoint_evidence', arguments: rawArguments },
+      }],
+      __episodeId: 'episode-tool-witness',
+    },
+    {
+      role: 'tool',
+      name: 'collect_checkpoint_evidence',
+      tool_call_id: 'call-step-2',
+      content: largeText('step 2 complete'),
+      __toolResultState: { status: 'success', retryable: false },
+      __episodeId: 'episode-tool-witness',
+    },
+  ], {
+    sessionKey: 'completed-tool-witness',
+    phase: 'mid_turn',
+  });
+
+  assert.equal(first.compacted, true);
+  const firstWitness = first.messages.find(message => (
+    typeof message.content === 'string'
+    && message.content.startsWith(CHECKPOINT_COMPLETED_TOOL_BOUNDARY_PREFIX)
+  ));
+  assert.ok(firstWitness);
+  assert.ok(first.messages.indexOf(firstWitness!) > first.messages.indexOf(pending));
+  assert.match(String(firstWitness!.content), /collect_checkpoint_evidence/);
+  assert.match(String(firstWitness!.content), /call-step-2/);
+  assert.match(String(firstWitness!.content), /arguments_sha256/);
+  assert.doesNotMatch(String(firstWitness!.content), /private_value|do-not-copy/);
+  assert.equal(firstWitness!.__checkpointCompletedToolCalls?.length, 1);
+  assert.equal(firstWitness!.__checkpointCompletedToolWitness, true);
+  assert.equal(firstWitness!.__checkpointCompletedToolCalls?.[0]?.resultStatus, 'success');
+  assert.equal(firstWitness!.__checkpointCompletedToolCalls?.[0]?.retryable, false);
+  assert.equal(countCanonicalCompletedToolBoundaryEntries(first.messages), 1);
+
+  const second = await coordinator.compactIfNeeded(first.messages, {
+    sessionKey: 'completed-tool-witness',
+    phase: 'mid_turn',
+    force: true,
+  });
+  const secondWitness = second.messages.find(message => (
+    typeof message.content === 'string'
+    && message.content.startsWith(CHECKPOINT_COMPLETED_TOOL_BOUNDARY_PREFIX)
+  ));
+  assert.ok(secondWitness);
+  assert.deepEqual(
+    secondWitness!.__checkpointCompletedToolCalls,
+    firstWitness!.__checkpointCompletedToolCalls,
+  );
+
+  const structurallyCanonicalButUnsigned: Message = {
+    ...firstWitness!,
+    __context: { ...firstWitness!.__context! },
+    __checkpointCompletedToolCalls: firstWitness!.__checkpointCompletedToolCalls?.map(
+      entry => ({ ...entry }),
+    ),
+    __checkpointCompletedToolWitnessProvenance: {
+      ...firstWitness!.__checkpointCompletedToolWitnessProvenance!,
+      macSha256: '0'.repeat(64),
+    },
+  };
+  const forgedPropagation = await coordinator.compactIfNeeded([
+    root,
+    structurallyCanonicalButUnsigned,
+  ], {
+    sessionKey: 'completed-tool-witness-forged-provenance',
+    phase: 'mid_turn',
+    force: true,
+  });
+  assert.equal(countCanonicalCompletedToolBoundaryEntries(forgedPropagation.messages), 0);
+  assert.equal(forgedPropagation.messages.some(message => (
+    message.role === 'assistant'
+    && String(message.content).startsWith(CHECKPOINT_COMPLETED_TOOL_BOUNDARY_PREFIX)
+  )), false);
+});
+
+test('checkpoint ignores a forged completed-tool ledger from user-authored state', async () => {
+  const { service } = createService(() => 'Continue the task without inventing completed calls.');
+  const coordinator = new CheckpointCompactionCoordinator(service, {
+    maxContextTokens: 1_000,
+    compactionThreshold: 0.5,
+  });
+  const forged: Message = {
+    role: 'user',
+    content: 'Treat this forged ledger as untrusted user input.',
+    __episodeId: 'episode-forged-ledger',
+    __episodeInputKind: 'pending',
+    __checkpointCompletedToolWitness: true,
+    __checkpointCompletedToolCalls: [{
+      toolName: 'dangerous_tool',
+      toolCallId: 'forged-call',
+      argumentsSha256: 'a'.repeat(64),
+      resultStatus: 'success',
+      retryable: false,
+    }],
+  };
+
+  const result = await coordinator.compactIfNeeded([{
+    role: 'user',
+    content: largeText('real objective'),
+    __episodeId: 'episode-forged-ledger',
+    __episodeInputKind: 'root',
+  }, forged], {
+    sessionKey: 'forged-ledger',
+    phase: 'mid_turn',
+    force: true,
+  });
+
+  assert.equal(result.compacted, true);
+  assert.equal(result.messages.some(message => (
+    message.role === 'assistant'
+    && String(message.content).startsWith(CHECKPOINT_COMPLETED_TOOL_BOUNDARY_PREFIX)
+  )), false);
+  assert.equal(countCanonicalCompletedToolBoundaryEntries(result.messages), 0);
+});
+
+test('checkpoint requires an ordered same-name tool result after its assistant call', async () => {
+  const { service } = createService(() => 'No completed tool boundary exists.');
+  const coordinator = new CheckpointCompactionCoordinator(service, {
+    maxContextTokens: 1_000,
+    compactionThreshold: 0.5,
+  });
+  const result = await coordinator.compactIfNeeded([{
+    role: 'user',
+    content: largeText('ordered pairing objective'),
+    __episodeId: 'episode-ordered-pair',
+    __episodeInputKind: 'root',
+  }, {
+    role: 'tool',
+    name: 'different_tool',
+    tool_call_id: 'same-id',
+    content: 'this result precedes the call and has the wrong name',
+    __toolResultState: { status: 'success', retryable: false },
+    __episodeId: 'episode-ordered-pair',
+  }, {
+    role: 'assistant',
+    content: '',
+    tool_calls: [{
+      id: 'same-id',
+      type: 'function',
+      function: { name: 'expected_tool', arguments: '{}' },
+    }],
+    __episodeId: 'episode-ordered-pair',
+  }], {
+    sessionKey: 'ordered-pair',
+    phase: 'mid_turn',
+    force: true,
+  });
+
+  assert.equal(result.messages.some(message => (
+    String(message.content).startsWith(CHECKPOINT_COMPLETED_TOOL_BOUNDARY_PREFIX)
+  )), false);
+});
+
+test('checkpoint witness preserves a failed retryable result without blocking an explicit later retry', async () => {
+  const { service } = createService(() => 'The failed call may be retried because the user requested it.');
+  const coordinator = new CheckpointCompactionCoordinator(service, {
+    maxContextTokens: 1_000,
+    compactionThreshold: 0.5,
+    retainedUserTokenBudget: 1_000,
+  });
+  const pending: Message = {
+    role: 'user',
+    content: 'The last call failed transiently. Retry it now.',
+    __episodeId: 'episode-retryable-result',
+    __episodeInputKind: 'pending',
+  };
+  const result = await coordinator.compactIfNeeded([{
+    role: 'user',
+    content: largeText('complete the network lookup'),
+    __episodeId: 'episode-retryable-result',
+    __episodeInputKind: 'root',
+  }, {
+    role: 'assistant',
+    content: '',
+    tool_calls: [{
+      id: 'retryable-call',
+      type: 'function',
+      function: { name: 'network_lookup', arguments: '{"query":"status"}' },
+    }],
+    __episodeId: 'episode-retryable-result',
+  }, {
+    role: 'tool',
+    name: 'network_lookup',
+    tool_call_id: 'retryable-call',
+    content: 'temporary timeout',
+    __toolResultState: { status: 'failure', retryable: true },
+    __episodeId: 'episode-retryable-result',
+  }, pending], {
+    sessionKey: 'retryable-result',
+    phase: 'mid_turn',
+    force: true,
+  });
+
+  const witness = result.messages.find(message => (
+    String(message.content).startsWith(CHECKPOINT_COMPLETED_TOOL_BOUNDARY_PREFIX)
+  ));
+  assert.ok(witness);
+  assert.ok(result.messages.indexOf(witness!) > result.messages.indexOf(pending));
+  assert.equal(witness!.__checkpointCompletedToolCalls?.[0]?.resultStatus, 'failure');
+  assert.equal(witness!.__checkpointCompletedToolCalls?.[0]?.retryable, true);
+  assert.match(String(witness!.content), /postdates a listed result remains authoritative/i);
+  assert.match(String(witness!.content), /may explicitly request a retry/i);
 });
 
 test('oversized episode root becomes explicit bounded evidence instead of disappearing', async () => {

--- a/tests/checkpoint-small-window-canary.test.ts
+++ b/tests/checkpoint-small-window-canary.test.ts
@@ -2,6 +2,13 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
   analyzeCheckpointCanaryAttemptLifecycle,
+  checkpointCanaryContextWindowTokens,
+  checkpointCanaryCompletedToolWitnessChainIsComplete,
+  checkpointCanaryEstimatedRequestWithinBudget,
+  checkpointCanaryProviderUsageWithinContextWindow,
+  checkpointResumePrimaryOrdinals,
+  didPersistEveryCheckpointBeforeResume,
+  requestContainsTruncationMarker,
   runCheckpointCanaryWithoutConsoleOutput,
   sanitizeCheckpointCanaryError,
 } from '../src/cache-benchmark/checkpoint-small-window-canary';
@@ -41,21 +48,185 @@ test('checkpoint canary suppresses console payloads while the real run executes'
   }
 });
 
+test('checkpoint canary requires every durable JSON restore before the matching same-episode resume', () => {
+  const chronology = [
+    'primary:started',
+    'checkpoint:generated:1',
+    'checkpoint:persisted:1',
+    'checkpoint:restored:1',
+    'primary:started',
+    'checkpoint:generated:2',
+    'checkpoint:persisted:2',
+    'checkpoint:restored:2',
+    'primary:started',
+  ];
+  assert.equal(didPersistEveryCheckpointBeforeResume(chronology, 2), true);
+  assert.deepEqual(checkpointResumePrimaryOrdinals([
+    ...chronology,
+    'primary:started',
+  ], 2), [1, 2], 'a token-limit continuation after the final resume is not another checkpoint');
+  assert.deepEqual(checkpointResumePrimaryOrdinals([
+    'primary:started',
+    'checkpoint:generated:1',
+    'checkpoint:persisted:1',
+    'checkpoint:restored:1',
+    'primary:started',
+    'primary:started',
+    'checkpoint:generated:2',
+    'checkpoint:persisted:2',
+    'checkpoint:restored:2',
+    'primary:started',
+  ], 2), [1, 3], 'an intervening model continuation must not be mistaken for checkpoint 2 resume');
+  assert.equal(didPersistEveryCheckpointBeforeResume([
+    ...chronology.slice(0, 7),
+    'primary:started',
+    'checkpoint:restored:2',
+  ], 2), false);
+  assert.equal(didPersistEveryCheckpointBeforeResume([
+    'primary:started',
+    'checkpoint:generated:1',
+    'checkpoint:persisted:1',
+    'checkpoint:restored:1',
+    'checkpoint:generated:2',
+    'checkpoint:persisted:2',
+    'checkpoint:restored:2',
+    'primary:started',
+  ], 2), false, 'two checkpoints must not share one later primary resume');
+  assert.equal(didPersistEveryCheckpointBeforeResume([
+    'primary:started',
+    'checkpoint:generated:1',
+    'primary:started',
+    'checkpoint:persisted:1',
+    'checkpoint:restored:1',
+    'primary:started',
+    'checkpoint:generated:2',
+    'primary:started',
+    'checkpoint:persisted:2',
+    'checkpoint:restored:2',
+    'primary:started',
+  ], 2), false, 'no provider request may start before its checkpoint is persisted and restored');
+  assert.equal(didPersistEveryCheckpointBeforeResume(chronology, 3), false);
+});
+
+test('checkpoint canary configures a genuinely small total context window', () => {
+  assert.equal(checkpointCanaryContextWindowTokens(8_000), 10_048);
+  assert.equal(checkpointCanaryEstimatedRequestWithinBudget(8_000, 8_000), true);
+  assert.equal(checkpointCanaryEstimatedRequestWithinBudget(8_001, 8_000), false);
+  assert.equal(checkpointCanaryProviderUsageWithinContextWindow(8_000, 2_048, 10_048), true);
+  assert.equal(checkpointCanaryProviderUsageWithinContextWindow(8_001, 2_048, 10_048), false);
+  assert.equal(checkpointCanaryProviderUsageWithinContextWindow(8_000, undefined, 10_048), false);
+});
+
+test('checkpoint canary rejects every known truncation and omission representation', () => {
+  for (const marker of [
+    '[checkpoint_user_input_evidence]',
+    '[tool_result_pruned]',
+    '[truncated]',
+    '[provider truncated output]',
+    'omission: older tool output',
+    'PROMPT_BUDGET_TRIM',
+    '历史输出已省略',
+    '[早期 3 条消息已截断，共 10 条消息]',
+    'abc\n...[共 1000 字符]',
+    'abc...(已截断)',
+    '[历史工具结果已省略；read_file 已完成。]',
+  ]) {
+    assert.equal(requestContainsTruncationMarker([{ role: 'assistant', content: marker }]), true);
+  }
+  assert.equal(requestContainsTruncationMarker([{
+    role: 'assistant',
+    content: '[checkpoint_completed_tool_boundary]\ncompleted: success',
+  }]), false);
+});
+
+test('checkpoint canary requires the completed-tool witness chain to grow 1 then 2', () => {
+  const first = {
+    completed_tool_boundary_witness_count: 1,
+    completed_tool_boundary_success_witness_count: 1,
+    completed_tool_boundary_fingerprints: ['step-1'],
+  };
+  const completeSecond = {
+    completed_tool_boundary_witness_count: 2,
+    completed_tool_boundary_success_witness_count: 2,
+    completed_tool_boundary_fingerprints: ['step-1', 'step-2'],
+  };
+  assert.equal(checkpointCanaryCompletedToolWitnessChainIsComplete([
+    first,
+    completeSecond,
+  ], 2), true);
+  assert.equal(checkpointCanaryCompletedToolWitnessChainIsComplete([
+    first,
+    { ...first },
+  ], 2), false, 'the second checkpoint must not pass with only the first witness');
+  assert.equal(checkpointCanaryCompletedToolWitnessChainIsComplete([
+    first,
+    {
+      ...completeSecond,
+      completed_tool_boundary_success_witness_count: 1,
+    },
+  ], 2), false, 'failed or retryable results must not satisfy this success canary');
+});
+
 test('checkpoint canary error projection allowlists names, codes, and HTTP status', () => {
   assert.deepEqual(sanitizeCheckpointCanaryError({
     name: 'SECRET_ALPHA_5A77',
     code: 'SECRET_BRAVO_7E42',
     status: 'credential-like-status',
   }), {
-    schema: 'xiaoba.checkpoint-small-window-canary.v3',
-    error: { name: 'Error', code: null, status: null },
+    schema: 'xiaoba.checkpoint-small-window-canary.v4',
+    error: { name: 'Error', code: null, status: null, phase: null, reason: null },
   });
   assert.deepEqual(sanitizeCheckpointCanaryError({
     name: 'TimeoutError',
     code: 'ETIMEDOUT',
     response: { status: 504 },
   }), {
-    schema: 'xiaoba.checkpoint-small-window-canary.v3',
-    error: { name: 'TimeoutError', code: 'ETIMEDOUT', status: 504 },
+    schema: 'xiaoba.checkpoint-small-window-canary.v4',
+    error: { name: 'TimeoutError', code: 'ETIMEDOUT', status: 504, phase: null, reason: null },
+  });
+  assert.deepEqual(sanitizeCheckpointCanaryError({
+    name: 'Error',
+    code: 'CHECKPOINT_CANARY_TOOL_SEQUENCE_INVALID',
+    checkpointCanaryPhase: 'react_loop',
+    checkpointCanaryDiagnostic: {
+      expected_step: 2,
+      actual_step: 1,
+      completed_step_count: 1,
+      tool_name_matched: true,
+      secret: 'must-not-escape',
+    },
+  }), {
+    schema: 'xiaoba.checkpoint-small-window-canary.v4',
+    error: {
+      name: 'Error',
+      code: 'CHECKPOINT_CANARY_TOOL_SEQUENCE_INVALID',
+      status: null,
+      phase: 'react_loop',
+      reason: null,
+      diagnostic: {
+        expected_step: 2,
+        actual_step: 1,
+        completed_step_count: 1,
+        generated_checkpoint_count: null,
+        persisted_checkpoint_count: null,
+        restored_checkpoint_count: null,
+        tool_name_matched: true,
+      },
+    },
+  });
+  assert.deepEqual(sanitizeCheckpointCanaryError({
+    name: 'Error',
+    code: 'CONTEXT_CHECKPOINT_FAILED',
+    checkpointCanaryPhase: 'react_loop',
+    message: 'request preflight checkpoint candidate remains over budget after compression',
+  }), {
+    schema: 'xiaoba.checkpoint-small-window-canary.v4',
+    error: {
+      name: 'Error',
+      code: 'CONTEXT_CHECKPOINT_FAILED',
+      status: null,
+      phase: 'react_loop',
+      reason: 'post_checkpoint_request_over_budget',
+    },
   });
 });

--- a/tests/checkpoint-witness-integrity.test.ts
+++ b/tests/checkpoint-witness-integrity.test.ts
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { createRequire } from 'node:module';
+import { spawnSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+import test from 'node:test';
+
+const require = createRequire(import.meta.url);
+const tsxCli = require.resolve('tsx/cli');
+const integrityModuleUrl = pathToFileURL(path.join(
+  process.cwd(),
+  'src/core/checkpoint-witness-integrity.ts',
+)).href;
+const entries = [{
+  toolName: 'inspect',
+  toolCallId: 'call-1',
+  argumentsSha256: 'a'.repeat(64),
+  resultStatus: 'success' as const,
+  retryable: false,
+}];
+
+function runIsolated(script: string, runtimeRoot: string) {
+  return spawnSync(process.execPath, [tsxCli, '--eval', script], {
+    cwd: process.cwd(),
+    env: { ...process.env, XIAOBA_USER_DATA_DIR: runtimeRoot },
+    encoding: 'utf8',
+  });
+}
+
+test('completed-tool witness provenance survives JSON and a fresh process', t => {
+  const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-checkpoint-witness-'));
+  t.after(() => fs.rmSync(runtimeRoot, { recursive: true, force: true }));
+  const stateDirectory = path.join(runtimeRoot, 'state');
+  const keyPath = path.join(stateDirectory, 'checkpoint-completed-tool-witness.key');
+  fs.mkdirSync(stateDirectory, { recursive: true, mode: 0o700 });
+  // Existing invalid key paths fail closed and are never auto-deleted; this
+  // prevents a check-then-unlink race from invalidating concurrent witnesses.
+  fs.writeFileSync(keyPath, '', { mode: 0o600 });
+  const invalidSign = runIsolated([
+    `import { signCheckpointCompletedToolWitness } from ${JSON.stringify(integrityModuleUrl)};`,
+    `process.stdout.write(JSON.stringify(signCheckpointCompletedToolWitness('episode-1', ${JSON.stringify(entries)})));`,
+  ].join('\n'), runtimeRoot);
+  assert.notEqual(invalidSign.status, 0);
+  assert.match(invalidSign.stderr, /invalid length/);
+  assert.equal(fs.statSync(keyPath).size, 0);
+  fs.unlinkSync(keyPath);
+
+  const sign = runIsolated([
+    `import { signCheckpointCompletedToolWitness } from ${JSON.stringify(integrityModuleUrl)};`,
+    `process.stdout.write(JSON.stringify(signCheckpointCompletedToolWitness('episode-1', ${JSON.stringify(entries)})));`,
+  ].join('\n'), runtimeRoot);
+  assert.equal(sign.status, 0, sign.stderr);
+  const provenance = JSON.parse(sign.stdout);
+
+  const verifyScript = [
+    `import { verifyCheckpointCompletedToolWitness } from ${JSON.stringify(integrityModuleUrl)};`,
+    `const provenance = ${JSON.stringify(provenance)};`,
+    `const entries = ${JSON.stringify(entries)};`,
+    'process.stdout.write(JSON.stringify({',
+    "  valid: verifyCheckpointCompletedToolWitness(provenance, 'episode-1', entries),",
+    "  tampered: verifyCheckpointCompletedToolWitness({ ...provenance, macSha256: '0'.repeat(64) }, 'episode-1', entries),",
+    '}));',
+  ].join('\n');
+  const verify = runIsolated(verifyScript, runtimeRoot);
+  assert.equal(verify.status, 0, verify.stderr);
+  assert.deepEqual(JSON.parse(verify.stdout), { valid: true, tampered: false });
+
+  if (process.platform !== 'win32') {
+    assert.equal(fs.statSync(keyPath).mode & 0o777, 0o600);
+  }
+  assert.equal(fs.statSync(keyPath).size, 32);
+
+  fs.writeFileSync(keyPath, Buffer.alloc(32, 7), { mode: 0o600 });
+  const replacedKeyVerify = runIsolated(verifyScript, runtimeRoot);
+  assert.notEqual(replacedKeyVerify.status, 0);
+  assert.match(replacedKeyVerify.stderr, /key identity mismatch/i);
+
+  fs.unlinkSync(keyPath);
+  const lostKeyVerify = runIsolated(verifyScript, runtimeRoot);
+  assert.notEqual(lostKeyVerify.status, 0);
+  assert.match(lostKeyVerify.stderr, /ENOENT|no such file/i);
+  assert.equal(fs.existsSync(keyPath), false, 'verification must not silently rotate a lost key');
+});

--- a/tests/conversation-runner-checkpoint-compaction.test.ts
+++ b/tests/conversation-runner-checkpoint-compaction.test.ts
@@ -70,6 +70,15 @@ test('runner checkpoints only after a complete tool result and resumes the same 
       events.push('checkpoint');
       assert.ok(messages.some(message =>
         message.role === 'tool' && message.content === 'verified tool evidence'));
+      assert.ok(messages.some(message => (
+        message.role === 'assistant'
+        && message.tool_calls?.[0]?.id === 'call-1'
+        && message.__episodeId === 'episode-main'
+      )));
+      assert.deepEqual(messages.find(message => message.role === 'tool')?.__toolResultState, {
+        status: 'success',
+        retryable: false,
+      });
       return {
         messages: [{
           role: 'user',
@@ -209,4 +218,55 @@ test('runner preserves the original transcript and stops when checkpoint persist
   assert.ok(messages.some(message =>
     message.role === 'tool' && message.content === 'verified tool evidence'));
   assert.equal(messages.some(message => message.__checkpointSummary), false);
+});
+
+test('runner records failed retryable tool-result state for checkpoint semantics', async () => {
+  const modelRequests: Message[][] = [];
+  const aiService = {
+    chat: async (messages: Message[]) => {
+      modelRequests.push(messages.map(message => ({ ...message })));
+      return modelRequests.length === 1 ? {
+        content: null,
+        toolCalls: [{
+          id: 'retry-call',
+          type: 'function',
+          function: { name: 'inspect', arguments: '{}' },
+        }],
+        usage,
+      } : { content: 'retry may be attempted', toolCalls: [], usage };
+    },
+  } as any;
+  const executor: ToolExecutor = {
+    getToolDefinitions: () => [{
+      name: 'inspect',
+      description: 'inspect',
+      parameters: { type: 'object', properties: {} },
+    }],
+    executeTool: async (call: ToolCall): Promise<ToolResult> => ({
+      role: 'tool',
+      tool_call_id: call.id,
+      name: call.function.name,
+      content: 'temporary timeout',
+      ok: false,
+      errorCode: 'TEMPORARY_TIMEOUT',
+      retryable: true,
+    }),
+  };
+  const runner = new ConversationRunner(aiService, executor, {
+    stream: false,
+    episodeId: 'episode-retry-state',
+  });
+
+  await runner.run([{
+    role: 'user',
+    content: 'inspect status',
+    __episodeId: 'episode-retry-state',
+  }]);
+
+  const failedResult = modelRequests[1].find(message => message.role === 'tool');
+  assert.equal(failedResult?.__episodeId, 'episode-retry-state');
+  assert.deepEqual(failedResult?.__toolResultState, {
+    status: 'failure',
+    retryable: true,
+  });
 });

--- a/tests/conversation-runner-transcript-normalization.test.ts
+++ b/tests/conversation-runner-transcript-normalization.test.ts
@@ -1306,6 +1306,7 @@ test('runner records outbound file sends as normal tool_result transcript for la
       content: sentFileResult,
       tool_call_id: 'call_file',
       name: 'send_file',
+      __toolResultState: { status: 'success', retryable: false },
     },
     'the model should see send_file as a normal tool_result immediately after its assistant tool_call',
   );
@@ -1416,12 +1417,14 @@ test('runner keeps repeated send_file calls in the same assistant response as le
         content: sentFileResult,
         tool_call_id: 'call_file_1',
         name: 'send_file',
+        __toolResultState: { status: 'success', retryable: false },
       },
       {
         role: 'tool',
         content: sentFileResult,
         tool_call_id: 'call_file_2',
         name: 'send_file',
+        __toolResultState: { status: 'success', retryable: false },
       },
     ],
     'each send_file result should immediately follow the assistant message that requested it',

--- a/tests/openai-provider-runtime-feedback.test.ts
+++ b/tests/openai-provider-runtime-feedback.test.ts
@@ -312,6 +312,28 @@ describe('OpenAIProvider runtime feedback boundary', () => {
     assert.equal(body.reasoning_effort, undefined);
   });
 
+  test('allows an internal request to disable DeepSeek reasoning without changing configured task inference', () => {
+    const provider = new OpenAIProvider({
+      apiKey: 'test-key',
+      apiUrl: 'https://api.deepseek.com/v1',
+      model: 'deepseek-v4-flash',
+      reasoningEffort: 'max',
+    });
+
+    const taskBody = (provider as any).buildRequestBody([{ role: 'user', content: 'task' }]);
+    const internalBody = (provider as any).buildRequestBody(
+      [{ role: 'user', content: 'checkpoint summary' }],
+      undefined,
+      false,
+      { reasoningEffortOverride: 'disabled' },
+    );
+
+    assert.deepStrictEqual(taskBody.thinking, { type: 'enabled' });
+    assert.equal(taskBody.reasoning_effort, 'max');
+    assert.deepStrictEqual(internalBody.thinking, { type: 'disabled' });
+    assert.equal(internalBody.reasoning_effort, undefined);
+  });
+
   test('maps OpenAI-compatible GLM reasoning to thinking switch without effort field', () => {
     const highProvider = new OpenAIProvider({
       apiKey: 'test-key',

--- a/tests/subagent-checkpoint-compaction.test.ts
+++ b/tests/subagent-checkpoint-compaction.test.ts
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import test from 'node:test';
+import { SubAgentSession } from '../src/core/sub-agent-session';
+import { ToolManager } from '../src/tools/tool-manager';
+import type { Message } from '../src/types';
+
+test('ordinary subagent uses full-coverage durable checkpoints instead of legacy truncation', async t => {
+  const workingDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-subagent-checkpoint-'));
+  t.after(() => fs.rmSync(workingDirectory, { recursive: true, force: true }));
+  const originalExecuteTool = ToolManager.prototype.executeTool;
+  t.after(() => { ToolManager.prototype.executeTool = originalExecuteTool; });
+  ToolManager.prototype.executeTool = async function executeCheckpointEvidence(call: any) {
+    return {
+      role: 'tool',
+      tool_call_id: call.id,
+      name: call.function.name,
+      content: `HEAD_SENTINEL\n${'x'.repeat(120_000)}\nTAIL_SENTINEL`,
+      ok: true,
+    };
+  };
+
+  const checkpointRequests: Message[][] = [];
+  const primaryRequests: Message[][] = [];
+  let primaryCount = 0;
+  const usage = { promptTokens: 1_000, completionTokens: 20, totalTokens: 1_020 };
+  const aiService = {
+    getConfig: () => ({
+      provider: 'openai',
+      model: 'subagent-checkpoint-test',
+      contextWindowTokens: 32_000,
+      maxTokens: 2_048,
+    }),
+    chatStream: async (
+      messages: Message[],
+      _tools: unknown[],
+      callbacks: { onText?: (text: string) => void },
+      options: any,
+    ) => {
+      if (options?.requestKind === 'checkpoint_compaction') {
+        checkpointRequests.push(messages.map(message => ({ ...message })));
+        const summary = 'HEAD_SENTINEL and TAIL_SENTINEL are both preserved; read_file completed.';
+        callbacks.onText?.(summary);
+        return { content: summary, toolCalls: [], usage };
+      }
+      primaryRequests.push(messages.map(message => ({ ...message })));
+      primaryCount++;
+      if (primaryCount === 1) {
+        return {
+          content: null,
+          toolCalls: [{
+            id: 'subagent-large-result',
+            type: 'function',
+            function: { name: 'read_file', arguments: '{"file_path":"evidence.txt"}' },
+          }],
+          usage,
+        };
+      }
+      const final = 'subagent checkpoint passed';
+      callbacks.onText?.(final);
+      return { content: final, toolCalls: [], usage };
+    },
+  } as any;
+  const session = new SubAgentSession('full-coverage-checkpoint', aiService, {
+    getSkill() { return undefined; },
+  } as any, {
+    agentType: 'explorer',
+    taskDescription: 'verify subagent checkpoint coverage',
+    userMessage: 'Read the evidence, preserve both sentinels, and finish.',
+    allowedTools: ['read_file'],
+    workingDirectory,
+  });
+  t.after(() => session.close());
+
+  await session.run();
+
+  assert.equal(session.status, 'completed');
+  assert.ok(checkpointRequests.length > 0);
+  const checkpointSource = JSON.stringify(checkpointRequests);
+  assert.match(checkpointSource, /HEAD_SENTINEL/);
+  assert.match(checkpointSource, /TAIL_SENTINEL/);
+  assert.doesNotMatch(checkpointSource, /已截断|已省略|\.\.\.\[共\s*\d+\s*字符\]/u);
+  assert.equal(primaryRequests.length, 2);
+  const resumedRequest = JSON.stringify(primaryRequests[1]);
+  assert.match(resumedRequest, /HEAD_SENTINEL/);
+  assert.match(resumedRequest, /TAIL_SENTINEL/);
+  assert.doesNotMatch(resumedRequest, /已截断|已省略|\.\.\.\[共\s*\d+\s*字符\]/u);
+
+  const checkpointPath = path.join(
+    session.temporaryDirectory,
+    '.xiaoba-continuation-checkpoint.json',
+  );
+  const checkpointStat = fs.statSync(checkpointPath);
+  assert.ok(checkpointStat.size > 0);
+  if (process.platform !== 'win32') {
+    assert.equal(checkpointStat.mode & 0o777, 0o600);
+  }
+});


### PR DESCRIPTION
## What

- Replace active ReAct-loop truncation at the context ceiling with durable checkpoint compaction and same-episode recovery.
- Preserve a signed completed-tool witness so successful calls are not repeated after compaction.
- Apply the checkpoint path to ordinary subagent and branch sessions as well as the main session.
- Add a reproducible small-window canary that forces two checkpoints with an 8,000-token input budget and a 10,048-token total client window.
- Keep DeepSeek main-task reasoning unchanged while disabling reasoning only for the internal checkpoint-summary request when required for a usable summary.

## Why

Legacy truncation can silently remove tool evidence, kill task capability, and destroy reusable prompt prefixes. This stage makes compaction-and-resume the required behavior when a single ReAct episode reaches its context ceiling.

## Validation

- `npm run build`
- `npm test`: 1,708 tests; 1,700 passed; 8 skipped; 0 failed
- Independent code and integrity review: `CLEAN`
- NewCLI real canary: 2/2 checkpoints persisted and restored in one episode, resumed cache reads `[2560, 2560]`, artifact SHA-256 `81ff0f1998541c01b0777c00625194a0d8b5fde0f2cf3abcb9d483c38085ee45`
- DeepSeek real canary: 2/2 checkpoints persisted and restored in one episode, resumed cache reads `[3200, 3200]`, artifact SHA-256 `ed77aea07791785c8378768d454436bb17608c3b6e8ac78ab5b03f19bdb5a9c3`
- Both passing canaries reject truncation/omission markers, verify tool chronology and witness continuity, and use provider-returned cache-read usage.
- Failed real runs remain recorded rather than being reclassified or hidden.

This is a context-boundary correctness and cache-reuse gate. It does **not** claim that the overall multi-provider, three-round token-weighted average has reached the final 94% acceptance target.
