### PR TITLE
feat(agent-run): add durable run contracts and store

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "ora": "^5.4.1",
         "pdf-parse": "^1.1.1",
         "pdfjs-dist": "^4.6.82",
+        "proper-lockfile": "^4.1.2",
         "sharp": "^0.34.5"
       },
       "bin": {
@@ -7569,9 +7570,8 @@
     },
     "node_modules/proper-lockfile": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
       "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -7863,7 +7863,6 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "ora": "^5.4.1",
     "pdf-parse": "^1.1.1",
     "pdfjs-dist": "^4.6.82",
+    "proper-lockfile": "^4.1.2",
     "sharp": "^0.34.5"
   },
   "devDependencies": {

--- a/src/core/agent-run-store.ts
+++ b/src/core/agent-run-store.ts
@@ -174,7 +174,7 @@ export class AgentRunStore {
 
   update(runId: string, update: AgentRunUpdate): AgentRunRecord {
     const normalizedRunId = requireNonEmptyString(runId, 'runId');
-    this.assertHealthy();
+    this.refresh();
     const snapshot = this.records.get(normalizedRunId);
     if (!snapshot) throw new Error(`agent run not found: ${normalizedRunId}`);
 

--- a/src/core/agent-run-store.ts
+++ b/src/core/agent-run-store.ts
@@ -1,0 +1,566 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { withExclusiveFileLock } from './file-lock';
+
+import type {
+  AgentRunArtifactRef,
+  AgentRunEvent,
+  AgentRunGoalCheck,
+  AgentRunPublicProjection,
+  AgentRunRecord,
+  AgentRunStatus,
+  AgentRunSubjectRef,
+  AgentRunTriggerRef,
+} from './agent-run-types';
+
+const SCHEMA_VERSION = 1;
+const STATUSES = new Set<AgentRunStatus>([
+  'queued',
+  'active',
+  'waiting_for_input',
+  'blocked',
+  'completed',
+  'cancelled',
+]);
+
+interface AgentRunStoreState {
+  schemaVersion: 1;
+  runs: AgentRunRecord[];
+}
+
+export interface AgentRunStoreOptions {
+  filePath?: string;
+  stateFilePath?: string;
+  corruptMarkerPath?: string;
+  clock?: () => Date;
+}
+
+export type CreateAgentRunInput = Omit<
+  AgentRunRecord,
+  'createdAt' | 'updatedAt' | 'events' | 'artifacts' | 'subjects'
+> & {
+  createdAt?: string;
+  updatedAt?: string;
+  events?: AgentRunEvent[];
+  artifacts?: AgentRunArtifactRef[];
+  subjects?: AgentRunSubjectRef[];
+};
+
+export type AgentRunUpdate = Partial<AgentRunRecord> | ((record: AgentRunRecord) => AgentRunRecord | void);
+
+export class AgentRunStore {
+  private readonly stateFilePath: string;
+  private readonly corruptMarkerPath: string;
+  private readonly lockPath: string;
+  private readonly clock: () => Date;
+  private readonly records = new Map<string, AgentRunRecord>();
+  private readonly idempotencyIndex = new Map<string, string>();
+  private corrupt = false;
+
+  constructor(options: AgentRunStoreOptions | string) {
+    const normalized = typeof options === 'string' ? { filePath: options } : options;
+    const stateFilePath = normalized.stateFilePath ?? normalized.filePath;
+    if (!stateFilePath) throw new Error('AgentRunStore requires filePath or stateFilePath');
+    this.stateFilePath = stateFilePath;
+    this.corruptMarkerPath = normalized.corruptMarkerPath ?? `${stateFilePath}.corrupt`;
+    this.lockPath = `${stateFilePath}.lock`;
+    this.clock = normalized.clock ?? (() => new Date());
+    this.load();
+  }
+
+  create(input: CreateAgentRunInput): AgentRunRecord {
+    return withExclusiveFileLock(this.lockPath, () => {
+      this.reloadFromDisk();
+      this.assertHealthy();
+      const now = this.clock().toISOString();
+      const record = validateRecord({
+        ...clone(input),
+        createdAt: input.createdAt ?? now,
+        updatedAt: input.updatedAt ?? input.createdAt ?? now,
+        events: input.events ?? [],
+        artifacts: input.artifacts ?? [],
+        subjects: input.subjects ?? [],
+      });
+      const idempotencyKey = record.triggerRef.idempotencyKey;
+      if (idempotencyKey) {
+        const existingRunId = this.idempotencyIndex.get(indexKey(record.triggerRef.source, idempotencyKey));
+        if (existingRunId) return clone(this.records.get(existingRunId)!);
+      }
+      if (this.records.has(record.runId)) throw new Error(`agent run already exists: ${record.runId}`);
+
+      try {
+        this.records.set(record.runId, record);
+        this.addToIdempotencyIndex(record);
+        this.persist();
+      } catch (error) {
+        this.records.delete(record.runId);
+        this.rebuildIdempotencyIndex();
+        throw error;
+      }
+      return clone(record);
+    });
+  }
+
+  refresh(): void {
+    this.reloadFromDisk();
+    this.assertHealthy();
+  }
+
+  get(runId: string): AgentRunRecord | undefined {
+    this.assertHealthy();
+    const record = this.records.get(requireNonEmptyString(runId, 'runId'));
+    return record ? clone(record) : undefined;
+  }
+
+  list(): AgentRunRecord[] {
+    this.assertHealthy();
+    return [...this.records.values()]
+      .sort((left, right) => left.createdAt.localeCompare(right.createdAt) || left.runId.localeCompare(right.runId))
+      .map(clone);
+  }
+
+  findByIdempotencyKey(source: string, idempotencyKey: string): AgentRunRecord | undefined {
+    this.assertHealthy();
+    const runId = this.idempotencyIndex.get(indexKey(
+      requireNonEmptyString(source, 'source'),
+      requireNonEmptyString(idempotencyKey, 'idempotencyKey'),
+    ));
+    return runId ? clone(this.records.get(runId)!) : undefined;
+  }
+
+  migrateTriggerIdempotencyKey(
+    runId: string,
+    source: string,
+    expectedPreviousKey: string,
+    nextKey: string,
+  ): AgentRunRecord {
+    return withExclusiveFileLock(this.lockPath, () => {
+      this.reloadFromDisk();
+      this.assertHealthy();
+      const normalizedRunId = requireNonEmptyString(runId, 'runId');
+      const previous = this.records.get(normalizedRunId);
+      if (!previous) throw new Error(`agent run not found: ${normalizedRunId}`);
+      const normalizedSource = requireNonEmptyString(source, 'source');
+      const previousKey = requireNonEmptyString(expectedPreviousKey, 'expectedPreviousKey');
+      const normalizedNextKey = requireNonEmptyString(nextKey, 'nextKey');
+      if (previous.triggerRef.source !== normalizedSource) {
+        throw new Error(`agent run Trigger source does not match: ${normalizedRunId}`);
+      }
+      if (previous.triggerRef.idempotencyKey === normalizedNextKey) return clone(previous);
+      if (previous.triggerRef.idempotencyKey !== previousKey) {
+        throw new Error(`agent run Trigger identity changed during migration: ${normalizedRunId}`);
+      }
+      const conflictingRunId = this.idempotencyIndex.get(indexKey(normalizedSource, normalizedNextKey));
+      if (conflictingRunId && conflictingRunId !== normalizedRunId) {
+        throw new Error(`duplicate trigger idempotency key for source ${normalizedSource}`);
+      }
+      const migrated = validateRecord({
+        ...clone(previous),
+        triggerRef: { ...clone(previous.triggerRef), idempotencyKey: normalizedNextKey },
+        updatedAt: this.clock().toISOString(),
+      });
+      this.records.set(normalizedRunId, migrated);
+      this.rebuildIdempotencyIndex();
+      try {
+        this.persist();
+      } catch (error) {
+        this.records.set(normalizedRunId, previous);
+        this.rebuildIdempotencyIndex();
+        throw error;
+      }
+      return clone(migrated);
+    });
+  }
+
+  update(runId: string, update: AgentRunUpdate): AgentRunRecord {
+    const normalizedRunId = requireNonEmptyString(runId, 'runId');
+    this.assertHealthy();
+    const snapshot = this.records.get(normalizedRunId);
+    if (!snapshot) throw new Error(`agent run not found: ${normalizedRunId}`);
+
+    const working = clone(snapshot);
+    let candidate: AgentRunRecord;
+    if (typeof update === 'function') {
+      const returned = update(working);
+      candidate = returned === undefined ? working : returned;
+    } else {
+      candidate = { ...working, ...clone(update) };
+    }
+
+    return withExclusiveFileLock(this.lockPath, () => {
+      this.reloadFromDisk();
+      this.assertHealthy();
+      const previous = this.records.get(normalizedRunId);
+      if (!previous) throw new Error(`agent run not found: ${normalizedRunId}`);
+      if (JSON.stringify(previous) !== JSON.stringify(snapshot)) {
+        throw new Error(`agent run changed concurrently: ${normalizedRunId}`);
+      }
+      assertIdentityUnchanged(previous, candidate);
+      const validated = validateRecord({ ...candidate, updatedAt: this.clock().toISOString() });
+      this.records.set(normalizedRunId, validated);
+      this.rebuildIdempotencyIndex();
+      try {
+        this.persist();
+      } catch (error) {
+        this.records.set(normalizedRunId, previous);
+        this.rebuildIdempotencyIndex();
+        throw error;
+      }
+      return clone(validated);
+    });
+  }
+
+  project(runId: string): AgentRunPublicProjection | undefined {
+    const record = this.get(runId);
+    return record ? projectAgentRun(record) : undefined;
+  }
+
+  assertHealthy(): void {
+    if (this.corrupt || fs.existsSync(this.corruptMarkerPath)) {
+      this.corrupt = true;
+      throw new Error(`agent run store is corrupt and quarantined: ${this.corruptMarkerPath}`);
+    }
+  }
+
+  private reloadFromDisk(): void {
+    this.records.clear();
+    this.idempotencyIndex.clear();
+    this.corrupt = false;
+    this.load();
+  }
+
+  private load(): void {
+    if (fs.existsSync(this.corruptMarkerPath)) {
+      this.corrupt = true;
+      return;
+    }
+    if (!fs.existsSync(this.stateFilePath)) return;
+    try {
+      const parsed = JSON.parse(fs.readFileSync(this.stateFilePath, 'utf8')) as unknown;
+      const state = validateState(parsed);
+      for (const record of state.runs) this.records.set(record.runId, record);
+      this.rebuildIdempotencyIndex();
+    } catch (error) {
+      this.failClosed(error);
+    }
+  }
+
+  private failClosed(error: unknown): void {
+    this.corrupt = true;
+    fs.mkdirSync(path.dirname(this.corruptMarkerPath), { recursive: true });
+    fs.writeFileSync(this.corruptMarkerPath, JSON.stringify({
+      detectedAt: this.clock().toISOString(),
+      sourcePath: this.stateFilePath,
+      reason: error instanceof Error ? error.message : String(error),
+    }, null, 2), { encoding: 'utf8', mode: 0o600 });
+    try {
+      if (fs.existsSync(this.stateFilePath)) {
+        const suffix = this.clock().toISOString().replace(/[:.]/g, '-');
+        fs.renameSync(this.stateFilePath, `${this.stateFilePath}.corrupt-${suffix}`);
+      }
+    } catch {
+      // The marker is authoritative even when the source cannot be moved.
+    }
+  }
+
+  private persist(): void {
+    this.assertHealthy();
+    const state: AgentRunStoreState = {
+      schemaVersion: SCHEMA_VERSION,
+      runs: [...this.records.values()].map(clone),
+    };
+    fs.mkdirSync(path.dirname(this.stateFilePath), { recursive: true });
+    const temporaryPath = `${this.stateFilePath}.${process.pid}.${Date.now()}.tmp`;
+    try {
+      fs.writeFileSync(temporaryPath, JSON.stringify(state, null, 2), {
+        encoding: 'utf8',
+        mode: 0o600,
+      });
+      fs.chmodSync(temporaryPath, 0o600);
+      fs.renameSync(temporaryPath, this.stateFilePath);
+    } finally {
+      try {
+        if (fs.existsSync(temporaryPath)) fs.unlinkSync(temporaryPath);
+      } catch {
+        // A stale private temp file is safer than masking the persistence error.
+      }
+    }
+  }
+
+  private addToIdempotencyIndex(record: AgentRunRecord): void {
+    const idempotencyKey = record.triggerRef.idempotencyKey;
+    if (!idempotencyKey) return;
+    const key = indexKey(record.triggerRef.source, idempotencyKey);
+    const existing = this.idempotencyIndex.get(key);
+    if (existing && existing !== record.runId) {
+      throw new Error(`duplicate trigger idempotency key for source ${record.triggerRef.source}`);
+    }
+    this.idempotencyIndex.set(key, record.runId);
+  }
+
+  private rebuildIdempotencyIndex(): void {
+    this.idempotencyIndex.clear();
+    for (const record of this.records.values()) this.addToIdempotencyIndex(record);
+  }
+}
+
+export function projectAgentRun(record: AgentRunRecord): AgentRunPublicProjection {
+  const validated = validateRecord(record);
+  return {
+    runId: validated.runId,
+    runType: validated.runType,
+    status: validated.status,
+    initialGoal: validated.initialGoal,
+    trigger: {
+      source: validated.triggerRef.source,
+      id: validated.triggerRef.id,
+      ...(validated.triggerRef.summary ? { summary: validated.triggerRef.summary } : {}),
+    },
+    ...(validated.parentRunId ? { parentRunId: validated.parentRunId } : {}),
+    ...(validated.branchPurpose ? { branchPurpose: validated.branchPurpose } : {}),
+    createdAt: validated.createdAt,
+    updatedAt: validated.updatedAt,
+    ...(validated.lastWakeAt ? { lastWakeAt: validated.lastWakeAt } : {}),
+    ...(validated.nextWakeAt ? { nextWakeAt: validated.nextWakeAt } : {}),
+    blocked: validated.status === 'blocked' || !!validated.blocker,
+    ...(validated.lastGoalCheck ? {
+      lastGoalCheck: {
+        checkedAt: validated.lastGoalCheck.checkedAt,
+        complete: validated.lastGoalCheck.complete,
+        capabilitiesExhausted: validated.lastGoalCheck.capabilitiesExhausted,
+        hasNextAction: !!validated.lastGoalCheck.nextAction,
+        hasBlocker: !!validated.lastGoalCheck.blocker,
+        hasStopCondition: !!validated.lastGoalCheck.stopCondition,
+      },
+    } : {}),
+    events: validated.events.map(event => ({
+      ...(event.eventId ? { eventId: event.eventId } : {}),
+      type: event.type,
+      summary: publicEventSummary(event),
+      createdAt: event.createdAt,
+    })),
+    artifacts: validated.artifacts.map(artifact => ({
+      artifactId: artifact.artifactId,
+      kind: artifact.kind,
+      label: artifact.label,
+      createdAt: artifact.createdAt,
+    })),
+    subjects: validated.subjects.map(subject => ({
+      kind: subject.kind,
+      id: subject.id,
+      ...(subject.label ? { label: subject.label } : {}),
+    })),
+  };
+}
+
+const PUBLIC_EVENT_TYPES = new Set(['progress']);
+const PRIVATE_EVENT_SUMMARIES: Readonly<Record<string, string>> = {
+  supervisor_config: 'Supervisor configuration recorded',
+  supervisor_input: 'Run input recorded',
+  supervisor_context: 'Run context recorded',
+  supervisor_final: 'Agent final recorded',
+  goal_checked: 'Goal Check recorded',
+};
+
+function publicEventSummary(event: AgentRunEvent): string {
+  if (PUBLIC_EVENT_TYPES.has(event.type)) return event.summary;
+  return PRIVATE_EVENT_SUMMARIES[event.type] ?? 'Event details hidden';
+}
+
+export const toPublicAgentRunProjection = projectAgentRun;
+export const projectAgentRunRecord = projectAgentRun;
+
+export function validateAgentRunGoalCheck(value: unknown): AgentRunGoalCheck {
+  const object = requireObject(value, 'goal check');
+  const complete = requireBoolean(object.complete, 'lastGoalCheck.complete');
+  const check: AgentRunGoalCheck = {
+    checkedAt: requireTimestamp(object.checkedAt, 'lastGoalCheck.checkedAt'),
+    complete,
+    capabilitiesExhausted: requireBoolean(
+      object.capabilitiesExhausted,
+      'lastGoalCheck.capabilitiesExhausted',
+    ),
+    summary: requireNonEmptyString(object.summary, 'lastGoalCheck.summary'),
+    ...(optionalString(object.nextAction) ? { nextAction: optionalString(object.nextAction) } : {}),
+    ...(optionalString(object.blocker) ? { blocker: optionalString(object.blocker) } : {}),
+    ...(optionalString(object.stopCondition) ? { stopCondition: optionalString(object.stopCondition) } : {}),
+    ...(object.nextWakeAt !== undefined
+      ? { nextWakeAt: requireTimestamp(object.nextWakeAt, 'lastGoalCheck.nextWakeAt') }
+      : {}),
+  };
+  if (!complete && !check.nextAction && !check.blocker) {
+    throw new Error('incomplete goal check requires nextAction or blocker');
+  }
+  if (!complete && !check.stopCondition) {
+    throw new Error('incomplete goal check requires stopCondition');
+  }
+  return check;
+}
+
+export const validateGoalCheck = validateAgentRunGoalCheck;
+
+function validateState(value: unknown): AgentRunStoreState {
+  if (Array.isArray(value)) return { schemaVersion: 1, runs: validateRuns(value) };
+  const object = requireObject(value, 'agent run store state');
+  if (object.schemaVersion !== SCHEMA_VERSION) throw new Error('unsupported agent run store schema version');
+  return { schemaVersion: 1, runs: validateRuns(object.runs) };
+}
+
+function validateRuns(value: unknown): AgentRunRecord[] {
+  if (!Array.isArray(value)) throw new Error('agent run store runs must be an array');
+  const seen = new Set<string>();
+  const idempotencyKeys = new Set<string>();
+  return value.map((entry, index) => {
+    const record = validateRecord(entry, `runs[${index}]`);
+    if (seen.has(record.runId)) throw new Error(`duplicate agent run id: ${record.runId}`);
+    seen.add(record.runId);
+    const key = record.triggerRef.idempotencyKey
+      ? indexKey(record.triggerRef.source, record.triggerRef.idempotencyKey)
+      : undefined;
+    if (key && idempotencyKeys.has(key)) throw new Error('duplicate trigger idempotency key');
+    if (key) idempotencyKeys.add(key);
+    return record;
+  });
+}
+
+function validateRecord(value: unknown, field = 'agent run'): AgentRunRecord {
+  const object = requireObject(value, field);
+  const triggerRef = validateTriggerRef(object.triggerRef, `${field}.triggerRef`);
+  const events = requireArray(object.events, `${field}.events`).map((event, index) =>
+    validateEvent(event, `${field}.events[${index}]`));
+  const artifacts = requireArray(object.artifacts, `${field}.artifacts`).map((artifact, index) =>
+    validateArtifact(artifact, `${field}.artifacts[${index}]`));
+  const subjects = requireArray(object.subjects, `${field}.subjects`).map((subject, index) =>
+    validateSubject(subject, `${field}.subjects[${index}]`));
+  const status = object.status;
+  if (typeof status !== 'string' || !STATUSES.has(status as AgentRunStatus)) {
+    throw new Error(`${field}.status is invalid`);
+  }
+  return {
+    runId: requireNonEmptyString(object.runId, `${field}.runId`),
+    runType: requireNonEmptyString(object.runType, `${field}.runType`),
+    triggerRef,
+    sessionKey: requireNonEmptyString(object.sessionKey, `${field}.sessionKey`),
+    initialGoal: requireNonEmptyString(object.initialGoal, `${field}.initialGoal`),
+    status: status as AgentRunStatus,
+    ...(optionalString(object.parentRunId) ? { parentRunId: optionalString(object.parentRunId) } : {}),
+    ...(optionalString(object.branchPurpose) ? { branchPurpose: optionalString(object.branchPurpose) } : {}),
+    createdAt: requireTimestamp(object.createdAt, `${field}.createdAt`),
+    updatedAt: requireTimestamp(object.updatedAt, `${field}.updatedAt`),
+    ...(object.lastWakeAt !== undefined
+      ? { lastWakeAt: requireTimestamp(object.lastWakeAt, `${field}.lastWakeAt`) }
+      : {}),
+    ...(object.nextWakeAt !== undefined
+      ? { nextWakeAt: requireTimestamp(object.nextWakeAt, `${field}.nextWakeAt`) }
+      : {}),
+    ...(optionalString(object.blocker) ? { blocker: optionalString(object.blocker) } : {}),
+    ...(object.lastGoalCheck !== undefined
+      ? { lastGoalCheck: validateAgentRunGoalCheck(object.lastGoalCheck) }
+      : {}),
+    events,
+    artifacts,
+    subjects,
+  };
+}
+
+function validateTriggerRef(value: unknown, field: string): AgentRunTriggerRef {
+  const object = requireObject(value, field);
+  return {
+    source: requireNonEmptyString(object.source, `${field}.source`),
+    id: requireNonEmptyString(object.id, `${field}.id`),
+    ...(optionalString(object.idempotencyKey)
+      ? { idempotencyKey: optionalString(object.idempotencyKey) }
+      : {}),
+    ...(optionalString(object.actor) ? { actor: optionalString(object.actor) } : {}),
+    ...(optionalString(object.summary) ? { summary: optionalString(object.summary) } : {}),
+  };
+}
+
+function validateEvent(value: unknown, field: string): AgentRunEvent {
+  const object = requireObject(value, field);
+  return {
+    ...(optionalString(object.eventId) ? { eventId: optionalString(object.eventId) } : {}),
+    type: requireNonEmptyString(object.type, `${field}.type`),
+    summary: requireNonEmptyString(object.summary, `${field}.summary`),
+    createdAt: requireTimestamp(object.createdAt, `${field}.createdAt`),
+  };
+}
+
+function validateArtifact(value: unknown, field: string): AgentRunArtifactRef {
+  const object = requireObject(value, field);
+  return {
+    artifactId: requireNonEmptyString(object.artifactId, `${field}.artifactId`),
+    kind: requireNonEmptyString(object.kind, `${field}.kind`),
+    label: requireNonEmptyString(object.label, `${field}.label`),
+    ref: requireNonEmptyString(object.ref, `${field}.ref`),
+    createdAt: requireTimestamp(object.createdAt, `${field}.createdAt`),
+  };
+}
+
+function validateSubject(value: unknown, field: string): AgentRunSubjectRef {
+  const object = requireObject(value, field);
+  return {
+    kind: requireNonEmptyString(object.kind, `${field}.kind`),
+    id: requireNonEmptyString(object.id, `${field}.id`),
+    ...(optionalString(object.ref) ? { ref: optionalString(object.ref) } : {}),
+    ...(optionalString(object.label) ? { label: optionalString(object.label) } : {}),
+  };
+}
+
+function assertIdentityUnchanged(previous: AgentRunRecord, candidate: AgentRunRecord): void {
+  const immutable: Array<keyof AgentRunRecord> = [
+    'runId',
+    'runType',
+    'triggerRef',
+    'sessionKey',
+    'initialGoal',
+    'parentRunId',
+    'createdAt',
+  ];
+  for (const field of immutable) {
+    if (JSON.stringify(previous[field]) !== JSON.stringify(candidate[field])) {
+      throw new Error(`agent run identity field is immutable: ${field}`);
+    }
+  }
+}
+
+function indexKey(source: string, idempotencyKey: string): string {
+  return `${source}\u0000${idempotencyKey}`;
+}
+
+function requireObject(value: unknown, field: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error(`${field} must be an object`);
+  return value as Record<string, unknown>;
+}
+
+function requireArray(value: unknown, field: string): unknown[] {
+  if (!Array.isArray(value)) throw new Error(`${field} must be an array`);
+  return value;
+}
+
+function requireNonEmptyString(value: unknown, field: string): string {
+  const normalized = optionalString(value);
+  if (!normalized) throw new Error(`${field} is required`);
+  return normalized;
+}
+
+function optionalString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  return value.trim() || undefined;
+}
+
+function requireBoolean(value: unknown, field: string): boolean {
+  if (typeof value !== 'boolean') throw new Error(`${field} must be a boolean`);
+  return value;
+}
+
+function requireTimestamp(value: unknown, field: string): string {
+  const text = requireNonEmptyString(value, field);
+  const milliseconds = Date.parse(text);
+  if (!Number.isFinite(milliseconds)) throw new Error(`${field} must be an ISO-8601 timestamp`);
+  return new Date(milliseconds).toISOString();
+}
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}

--- a/src/core/agent-run-types.ts
+++ b/src/core/agent-run-types.ts
@@ -1,0 +1,126 @@
+export type AgentRunStatus =
+  | 'queued'
+  | 'active'
+  | 'waiting_for_input'
+  | 'blocked'
+  | 'completed'
+  | 'cancelled';
+
+export interface AgentRunTriggerRef {
+  source: string;
+  id: string;
+  idempotencyKey?: string;
+  actor?: string;
+  summary?: string;
+}
+
+export interface AgentRunGoalCheck {
+  checkedAt: string;
+  complete: boolean;
+  capabilitiesExhausted: boolean;
+  summary: string;
+  nextAction?: string;
+  blocker?: string;
+  stopCondition?: string;
+  nextWakeAt?: string;
+}
+
+export interface AgentRunEvent {
+  eventId?: string;
+  type: string;
+  summary: string;
+  createdAt: string;
+}
+
+export interface AgentRunArtifactRef {
+  artifactId: string;
+  kind: string;
+  label: string;
+  ref: string;
+  createdAt: string;
+}
+
+export interface AgentRunSubjectRef {
+  kind: string;
+  id: string;
+  ref?: string;
+  label?: string;
+}
+
+export interface AgentRunRecord {
+  runId: string;
+  runType: string;
+  triggerRef: AgentRunTriggerRef;
+  sessionKey: string;
+  initialGoal: string;
+  status: AgentRunStatus;
+  parentRunId?: string;
+  branchPurpose?: string;
+  createdAt: string;
+  updatedAt: string;
+  lastWakeAt?: string;
+  nextWakeAt?: string;
+  blocker?: string;
+  lastGoalCheck?: AgentRunGoalCheck;
+  events: AgentRunEvent[];
+  artifacts: AgentRunArtifactRef[];
+  subjects: AgentRunSubjectRef[];
+}
+
+export interface AgentRunGoalCheckProjection {
+  checkedAt: string;
+  complete: boolean;
+  capabilitiesExhausted: boolean;
+  hasNextAction: boolean;
+  hasBlocker: boolean;
+  hasStopCondition: boolean;
+}
+
+export interface AgentRunEventProjection {
+  eventId?: string;
+  type: string;
+  summary: string;
+  createdAt: string;
+}
+
+export interface AgentRunArtifactProjection {
+  artifactId: string;
+  kind: string;
+  label: string;
+  createdAt: string;
+}
+
+export interface AgentRunSubjectProjection {
+  kind: string;
+  id: string;
+  label?: string;
+}
+
+export interface AgentRunPublicProjection {
+  runId: string;
+  runType: string;
+  status: AgentRunStatus;
+  initialGoal: string;
+  trigger: {
+    source: string;
+    id: string;
+    summary?: string;
+  };
+  parentRunId?: string;
+  branchPurpose?: string;
+  createdAt: string;
+  updatedAt: string;
+  lastWakeAt?: string;
+  nextWakeAt?: string;
+  blocked: boolean;
+  lastGoalCheck?: AgentRunGoalCheckProjection;
+  events: AgentRunEventProjection[];
+  artifacts: AgentRunArtifactProjection[];
+  subjects: AgentRunSubjectProjection[];
+}
+
+export type TriggerRef = AgentRunTriggerRef;
+export type GoalCheck = AgentRunGoalCheck;
+export type Event = AgentRunEvent;
+export type ArtifactRef = AgentRunArtifactRef;
+export type SubjectRef = AgentRunSubjectRef;

--- a/src/core/file-lock.ts
+++ b/src/core/file-lock.ts
@@ -1,0 +1,145 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+interface ProperLockOptions {
+  realpath: boolean;
+  lockfilePath: string;
+  stale: number;
+  update: number | boolean;
+  retries?: number | { retries: number; factor: number; minTimeout: number; maxTimeout: number; randomize: boolean };
+}
+interface ProperLockfile {
+  lock(file: string, options: ProperLockOptions): Promise<() => Promise<void>>;
+  lockSync(file: string, options: ProperLockOptions): () => void;
+}
+
+const properLockfile = require('proper-lockfile') as ProperLockfile;
+const RETRY_MS = 10;
+const STALE_MS = 60_000;
+
+/** Synchronous cross-process mutex for short persistence critical sections. */
+export function withExclusiveFileLock<T>(lockPath: string, operation: () => T): T {
+  prepare(lockPath);
+  let release: (() => void) | undefined;
+  for (;;) {
+    try {
+      release = properLockfile.lockSync(lockPath, options(lockPath, false));
+      break;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ELOCKED') throw error;
+      sleep(RETRY_MS);
+    }
+  }
+  try {
+    return operation();
+  } finally {
+    release();
+  }
+}
+
+export interface ExclusiveFileLockContext {
+  /** True when another owner held the lock before this caller acquired it. */
+  contended: boolean;
+}
+
+/** Cross-process mutex with a renewed lease for Goal drafting and wake work. */
+export async function withExclusiveFileLockAsync<T>(
+  lockPath: string,
+  operation: (context: ExclusiveFileLockContext) => Promise<T>,
+): Promise<T> {
+  prepare(lockPath);
+  let contended = false;
+  let sawOwner = false;
+  let lastObservedLockMtime: number | undefined;
+  let release: (() => Promise<void>) | undefined;
+  let lastLockedError: unknown;
+  for (let attempt = 0; attempt <= 12_000; attempt += 1) {
+    // Re-check compatibility on every retry: a legacy file may become stale
+    // while this caller waits. A stale directory is recovered by
+    // proper-lockfile itself, but sampling it lets us distinguish takeover
+    // (no winning wake) from a live owner that released (duplicate wake).
+    const recoveredLegacyFile = recoverStaleLegacyFile(lockPath);
+    const sampledLock = sampleLockPath(lockPath);
+    if (sampledLock?.kind === 'file') {
+      // proper-lockfile expects a directory at lockfilePath and may throw
+      // ENOTDIR while a legacy file ages into staleness. Wait for and migrate
+      // that representation ourselves instead of passing it to the library.
+      sawOwner = true;
+      lastObservedLockMtime = sampledLock.mtimeMs;
+      if (attempt === 12_000) throw new Error(`Timed out waiting for legacy lock ${lockPath}`);
+      await delay(RETRY_MS);
+      continue;
+    }
+    try {
+      release = await properLockfile.lock(lockPath, options(lockPath, true));
+      const staleTakeover = recoveredLegacyFile
+        || sampledLock?.stale === true
+        || (lastObservedLockMtime !== undefined && Date.now() - lastObservedLockMtime > staleMs());
+      contended = sawOwner && !staleTakeover;
+      break;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ELOCKED') throw error;
+      lastLockedError = error;
+      sawOwner = true;
+      if (sampledLock) lastObservedLockMtime = sampledLock.mtimeMs;
+      if (attempt === 12_000) throw lastLockedError;
+      await delay(RETRY_MS);
+    }
+  }
+  if (!release) throw lastLockedError || new Error(`Failed to acquire lock ${lockPath}`);
+  try {
+    return await operation({ contended });
+  } finally {
+    await release();
+  }
+}
+
+function options(lockPath: string, asynchronous: boolean): ProperLockOptions {
+  return {
+    realpath: false,
+    lockfilePath: lockPath,
+    stale: staleMs(),
+    update: asynchronous ? staleMs() / 3 : false,
+  };
+}
+
+function prepare(lockPath: string): void {
+  fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+  recoverStaleLegacyFile(lockPath);
+}
+
+function recoverStaleLegacyFile(lockPath: string): boolean {
+  try {
+    const stat = fs.statSync(lockPath);
+    if (!stat.isFile() || Date.now() - stat.mtimeMs <= staleMs()) return false;
+    fs.unlinkSync(lockPath);
+    return true;
+  } catch {
+    // Missing paths and racing recovery attempts are expected.
+    return false;
+  }
+}
+
+function sampleLockPath(lockPath: string): { kind: 'file' | 'directory' | 'other'; mtimeMs: number; stale: boolean } | undefined {
+  try {
+    const stat = fs.statSync(lockPath);
+    const kind = stat.isFile() ? 'file' : stat.isDirectory() ? 'directory' : 'other';
+    return { kind, mtimeMs: stat.mtimeMs, stale: Date.now() - stat.mtimeMs > staleMs() };
+  } catch {
+    return undefined;
+  }
+}
+
+function staleMs(): number {
+  const configured = Number(process.env.XIAOBA_FILE_LOCK_STALE_MS);
+  return Number.isFinite(configured) && configured >= 2_000 ? configured : STALE_MS;
+}
+
+function sleep(milliseconds: number): void {
+  const shared = new Int32Array(new SharedArrayBuffer(4));
+  Atomics.wait(shared, 0, 0, milliseconds);
+}
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, milliseconds));
+}

--- a/tests/agent-run-store.test.ts
+++ b/tests/agent-run-store.test.ts
@@ -1,0 +1,258 @@
+import { afterEach, describe, test } from 'node:test';
+import * as assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {
+  AgentRunStore,
+  projectAgentRun,
+  type CreateAgentRunInput,
+} from '../src/core/agent-run-store';
+
+const roots: string[] = [];
+const NOW = '2026-07-28T08:00:00.000Z';
+
+function makeStoreRoot(): { root: string; filePath: string } {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-agent-run-'));
+  roots.push(root);
+  return { root, filePath: path.join(root, 'agent-runs.json') };
+}
+
+function makeRun(overrides: Partial<CreateAgentRunInput> = {}): CreateAgentRunInput {
+  return {
+    runId: 'run-1',
+    runType: 'background',
+    triggerRef: {
+      source: 'scheduler',
+      id: 'trigger-1',
+      idempotencyKey: 'idem-1',
+      actor: 'private-actor',
+      summary: 'daily check',
+    },
+    sessionKey: 'private-session',
+    initialGoal: 'Finish the durable task',
+    status: 'active',
+    createdAt: NOW,
+    updatedAt: NOW,
+    events: [],
+    artifacts: [],
+    subjects: [],
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('AgentRunStore', () => {
+  test('persists atomically with private permissions and reloads records', () => {
+    const { root, filePath } = makeStoreRoot();
+    const store = new AgentRunStore({ filePath, clock: () => new Date(NOW) });
+    store.create(makeRun());
+
+    assert.equal(fs.statSync(filePath).mode & 0o777, 0o600);
+    assert.equal(fs.readdirSync(root).some(name => name.endsWith('.tmp')), false);
+    assert.doesNotThrow(() => JSON.parse(fs.readFileSync(filePath, 'utf8')));
+    assert.deepEqual(new AgentRunStore(filePath).get('run-1'), store.get('run-1'));
+  });
+
+  test('fails closed, writes a marker, and quarantines corrupt JSON', () => {
+    const { root, filePath } = makeStoreRoot();
+    fs.writeFileSync(filePath, '{not-json', { mode: 0o600 });
+
+    const store = new AgentRunStore({ filePath, clock: () => new Date(NOW) });
+    assert.equal(fs.existsSync(`${filePath}.corrupt`), true);
+    assert.equal(fs.readdirSync(root).some(name => name.startsWith('agent-runs.json.corrupt-')), true);
+    assert.throws(() => store.list(), /corrupt and quarantined/);
+    assert.throws(() => store.create(makeRun()), /corrupt and quarantined/);
+
+    fs.writeFileSync(filePath, JSON.stringify({ schemaVersion: 1, runs: [] }), { mode: 0o600 });
+    assert.throws(() => new AgentRunStore(filePath).get('run-1'), /corrupt and quarantined/);
+  });
+
+  test('indexes trigger idempotency keys and returns the original create result', () => {
+    const { filePath } = makeStoreRoot();
+    const store = new AgentRunStore({ filePath, clock: () => new Date(NOW) });
+    const first = store.create(makeRun());
+    const duplicate = store.create(makeRun({ runId: 'run-2', initialGoal: 'different request' }));
+
+    assert.equal(duplicate.runId, first.runId);
+    assert.equal(store.list().length, 1);
+    assert.equal(store.findByIdempotencyKey('scheduler', 'idem-1')?.runId, 'run-1');
+    assert.equal(new AgentRunStore(filePath).findByIdempotencyKey('scheduler', 'idem-1')?.runId, 'run-1');
+  });
+
+  test('normalizes identity before duplicate checks and never overwrites an existing Run', () => {
+    const { filePath } = makeStoreRoot();
+    const store = new AgentRunStore({ filePath, clock: () => new Date(NOW) });
+    const first = store.create(makeRun());
+
+    assert.throws(() => store.create(makeRun({
+      runId: ' run-1 ',
+      triggerRef: { source: 'other', id: 'other-trigger' },
+    })), /already exists/);
+    const duplicate = store.create(makeRun({
+      runId: 'run-2',
+      triggerRef: { source: ' scheduler ', id: 'other-trigger', idempotencyKey: ' idem-1 ' },
+    }));
+
+    assert.equal(duplicate.runId, first.runId);
+    assert.equal(store.list().length, 1);
+    assert.equal(new AgentRunStore(filePath).get('run-1')?.initialGoal, first.initialGoal);
+  });
+
+  test('migrates only the expected Trigger idempotency key and rejects conflicts', () => {
+    const { filePath } = makeStoreRoot();
+    const store = new AgentRunStore({ filePath, clock: () => new Date(NOW) });
+    store.create(makeRun());
+    assert.throws(
+      () => store.migrateTriggerIdempotencyKey('run-1', 'scheduler', 'wrong-old', 'idem-2'),
+      /identity changed during migration/,
+    );
+    const migrated = store.migrateTriggerIdempotencyKey('run-1', 'scheduler', 'idem-1', 'idem-2');
+    assert.equal(migrated.triggerRef.idempotencyKey, 'idem-2');
+    assert.equal(store.findByIdempotencyKey('scheduler', 'idem-1'), undefined);
+    assert.equal(store.findByIdempotencyKey('scheduler', 'idem-2')?.runId, 'run-1');
+    assert.equal(store.migrateTriggerIdempotencyKey('run-1', 'scheduler', 'idem-1', 'idem-2').runId, 'run-1');
+
+    store.create(makeRun({
+      runId: 'run-2',
+      triggerRef: { source: 'scheduler', id: 'trigger-2', idempotencyKey: 'idem-3' },
+      sessionKey: 'session-2',
+    }));
+    assert.throws(
+      () => store.migrateTriggerIdempotencyKey('run-1', 'scheduler', 'idem-2', 'idem-3'),
+      /duplicate trigger idempotency key/,
+    );
+    assert.equal(store.get('run-1')?.triggerRef.idempotencyKey, 'idem-2');
+  });
+
+  test('keeps identity immutable and deep-clones all values crossing the boundary', () => {
+    const { filePath } = makeStoreRoot();
+    const input = makeRun();
+    const store = new AgentRunStore({ filePath, clock: () => new Date(NOW) });
+    const created = store.create(input);
+    created.triggerRef.source = 'mutated';
+    input.triggerRef.source = 'also-mutated';
+    assert.equal(store.get('run-1')?.triggerRef.source, 'scheduler');
+
+    assert.throws(() => store.update('run-1', { sessionKey: 'other-session' }), /immutable/);
+    assert.throws(() => store.update('run-1', record => {
+      record.runType = 'other-type';
+    }), /immutable/);
+
+    const updated = store.update('run-1', {
+      status: 'blocked',
+      blocker: 'secret raw blocker',
+      lastGoalCheck: {
+        checkedAt: NOW,
+        complete: false,
+        capabilitiesExhausted: true,
+        summary: 'Cannot continue',
+        blocker: 'secret raw blocker',
+        stopCondition: 'Resume when dependency is available',
+      },
+    });
+    updated.lastGoalCheck!.blocker = 'mutated outside';
+    assert.equal(store.get('run-1')?.lastGoalCheck?.blocker, 'secret raw blocker');
+  });
+
+  test('rejects incomplete goal checks without continuation and stop condition', () => {
+    const { filePath } = makeStoreRoot();
+    const store = new AgentRunStore({ filePath, clock: () => new Date(NOW) });
+    store.create(makeRun());
+
+    assert.throws(() => store.update('run-1', {
+      lastGoalCheck: {
+        checkedAt: NOW,
+        complete: false,
+        capabilitiesExhausted: false,
+        summary: 'Not done',
+      },
+    }), /nextAction or blocker/);
+    assert.throws(() => store.update('run-1', {
+      lastGoalCheck: {
+        checkedAt: NOW,
+        complete: false,
+        capabilitiesExhausted: false,
+        summary: 'Not done',
+        nextAction: 'Keep working',
+      },
+    }), /stopCondition/);
+  });
+
+  test('projects only safe public summaries', () => {
+    const projection = projectAgentRun({
+      ...makeRun(),
+      blocker: 'raw blocker must not escape',
+      lastGoalCheck: {
+        checkedAt: NOW,
+        complete: false,
+        capabilitiesExhausted: true,
+        summary: 'goal check internal summary',
+        blocker: 'goal blocker must not escape',
+        stopCondition: 'private stop detail',
+      },
+      events: [
+        { eventId: 'evt-1', type: 'progress', summary: 'safe event summary', createdAt: NOW },
+        { eventId: 'evt-2', type: 'supervisor_input', summary: '{"text":"private operator input"}', createdAt: NOW },
+        { eventId: 'evt-3', type: 'supervisor_final', summary: '{"text":"private agent final"}', createdAt: NOW },
+        { eventId: 'evt-4', type: 'future_event', summary: 'unknown event secret', createdAt: NOW },
+      ],
+      artifacts: [{ artifactId: 'a-1', kind: 'report', label: 'Report', ref: 'file:///private', createdAt: NOW }],
+      subjects: [{ kind: 'issue', id: '42', ref: 'https://private', label: 'Issue 42' }],
+    });
+
+    assert.equal(projection.runId, 'run-1');
+    assert.equal(projection.lastGoalCheck?.complete, false);
+    assert.equal(projection.lastGoalCheck?.capabilitiesExhausted, true);
+    assert.deepEqual(projection.artifacts[0], {
+      artifactId: 'a-1', kind: 'report', label: 'Report', createdAt: NOW,
+    });
+    assert.deepEqual(projection.subjects[0], { kind: 'issue', id: '42', label: 'Issue 42' });
+    const serialized = JSON.stringify(projection);
+    for (const secret of [
+      'private-session',
+      'private-actor',
+      'file:///private',
+      'https://private',
+      'raw blocker must not escape',
+      'goal blocker must not escape',
+      'private operator input',
+      'private agent final',
+      'unknown event secret',
+    ]) assert.equal(serialized.includes(secret), false);
+  });
+  test('rejects a stale functional update instead of overwriting a concurrent change', () => {
+    const { filePath } = makeStoreRoot();
+    const firstStore = new AgentRunStore({ filePath, clock: () => new Date(NOW) });
+    firstStore.create(makeRun());
+    const staleStore = new AgentRunStore({ filePath, clock: () => new Date(NOW) });
+
+    assert.throws(() => staleStore.update('run-1', mutable => {
+      firstStore.update('run-1', { status: 'blocked', blocker: 'concurrent owner stopped the run' });
+      mutable.status = 'waiting';
+      return mutable;
+    }), /changed concurrently/);
+
+    assert.equal(new AgentRunStore(filePath).get('run-1')?.status, 'blocked');
+  });
+
+  test('reloads under lock so a stale instance update cannot erase another Run', () => {
+    const { filePath } = makeStoreRoot();
+    const firstStore = new AgentRunStore({ filePath, clock: () => new Date(NOW) });
+    const first = firstStore.create(makeRun());
+    const staleStore = new AgentRunStore({ filePath, clock: () => new Date(NOW) });
+    firstStore.create(makeRun({
+      runId: 'run-2', sessionKey: 'session-2', initialGoal: 'second immutable goal',
+      triggerRef: { source: 'query', id: 'trigger-2', idempotencyKey: 'query-2' },
+    }));
+    staleStore.update(first.runId, run => { run.status = 'active'; });
+    const reopened = new AgentRunStore({ filePath });
+    assert.equal(reopened.list().length, 2);
+    assert.equal(reopened.get('run-2')?.initialGoal, 'second immutable goal');
+  });
+
+});

--- a/tests/agent-run-store.test.ts
+++ b/tests/agent-run-store.test.ts
@@ -225,6 +225,18 @@ describe('AgentRunStore', () => {
       'unknown event secret',
     ]) assert.equal(serialized.includes(secret), false);
   });
+  test('refreshes a stale instance before computing an update', () => {
+    const { filePath } = makeStoreRoot();
+    const staleStore = new AgentRunStore({ filePath, clock: () => new Date(NOW) });
+    const creator = new AgentRunStore({ filePath, clock: () => new Date(NOW) });
+    creator.create(makeRun());
+
+    const updated = staleStore.update('run-1', { status: 'queued' });
+
+    assert.equal(updated.status, 'queued');
+    assert.equal(new AgentRunStore(filePath).get('run-1')?.status, 'queued');
+  });
+
   test('rejects a stale functional update instead of overwriting a concurrent change', () => {
     const { filePath } = makeStoreRoot();
     const firstStore = new AgentRunStore({ filePath, clock: () => new Date(NOW) });

--- a/tests/file-lock.test.ts
+++ b/tests/file-lock.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, test } from 'node:test';
+import * as assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { withExclusiveFileLockAsync } from '../src/core/file-lock';
+
+const roots: string[] = [];
+afterEach(() => { for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true }); });
+
+describe('file lock', () => {
+  test('renews a live asynchronous lease beyond the stale threshold', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'file-lock-')); roots.push(root);
+    const lockPath = path.join(root, 'goal.lock');
+    const previous = process.env.XIAOBA_FILE_LOCK_STALE_MS;
+    process.env.XIAOBA_FILE_LOCK_STALE_MS = '2000';
+    let release!: () => void;
+    let entered!: () => void;
+    const enteredPromise = new Promise<void>(resolve => { entered = resolve; });
+    const gate = new Promise<void>(resolve => { release = resolve; });
+    let secondEntered = false;
+    try {
+      const first = withExclusiveFileLockAsync(lockPath, async ({ contended }) => {
+        assert.equal(contended, false);
+        entered();
+        await gate;
+      });
+      await enteredPromise;
+      await new Promise(resolve => setTimeout(resolve, 2500));
+      const second = withExclusiveFileLockAsync(lockPath, async ({ contended }) => {
+        assert.equal(contended, true);
+        secondEntered = true;
+      });
+      await new Promise(resolve => setTimeout(resolve, 100));
+      assert.equal(secondEntered, false);
+      release();
+      await Promise.all([first, second]);
+      assert.equal(secondEntered, true);
+      assert.equal(fs.existsSync(lockPath), false);
+    } finally {
+      if (previous === undefined) delete process.env.XIAOBA_FILE_LOCK_STALE_MS;
+      else process.env.XIAOBA_FILE_LOCK_STALE_MS = previous;
+    }
+  });
+
+  test('serializes two contenders recovering the same stale lock directory', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'file-lock-')); roots.push(root);
+    const lockPath = path.join(root, 'stale.lock');
+    fs.mkdirSync(lockPath);
+    const old = new Date(Date.now() - 120_000);
+    fs.utimesSync(lockPath, old, old);
+    let active = 0;
+    let overlap = false;
+    const operation = () => withExclusiveFileLockAsync(lockPath, async () => {
+      active += 1;
+      if (active > 1) overlap = true;
+      await new Promise(resolve => setTimeout(resolve, 30));
+      active -= 1;
+    });
+    await Promise.all([operation(), operation()]);
+    assert.equal(overlap, false);
+    assert.equal(fs.existsSync(lockPath), false);
+  });
+
+  test('recovers an old malformed lock left before owner metadata was written', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'file-lock-')); roots.push(root);
+    const lockPath = path.join(root, 'orphan.lock');
+    fs.writeFileSync(lockPath, '');
+    const old = new Date(Date.now() - 120_000);
+    fs.utimesSync(lockPath, old, old);
+    let entered = false;
+    await withExclusiveFileLockAsync(lockPath, async () => { entered = true; });
+    assert.equal(entered, true);
+    assert.equal(fs.existsSync(lockPath), false);
+  });
+
+  test('treats a directory that becomes stale while waiting as recovery, not a duplicate owner', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'file-lock-')); roots.push(root);
+    const lockPath = path.join(root, 'late-stale-directory.lock');
+    const previous = process.env.XIAOBA_FILE_LOCK_STALE_MS;
+    process.env.XIAOBA_FILE_LOCK_STALE_MS = '2000';
+    fs.mkdirSync(lockPath);
+    const almostStale = new Date(Date.now() - 1700);
+    fs.utimesSync(lockPath, almostStale, almostStale);
+    try {
+      let context: { contended: boolean } | undefined;
+      await withExclusiveFileLockAsync(lockPath, async acquired => { context = acquired; });
+      assert.deepEqual(context, { contended: false });
+      assert.equal(fs.existsSync(lockPath), false);
+    } finally {
+      if (previous === undefined) delete process.env.XIAOBA_FILE_LOCK_STALE_MS;
+      else process.env.XIAOBA_FILE_LOCK_STALE_MS = previous;
+    }
+  });
+
+  test('retries a legacy file lock that becomes stale while waiting', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'file-lock-')); roots.push(root);
+    const lockPath = path.join(root, 'late-stale-file.lock');
+    const previous = process.env.XIAOBA_FILE_LOCK_STALE_MS;
+    process.env.XIAOBA_FILE_LOCK_STALE_MS = '2000';
+    fs.writeFileSync(lockPath, 'legacy lock');
+    const almostStale = new Date(Date.now() - 1700);
+    fs.utimesSync(lockPath, almostStale, almostStale);
+    try {
+      let context: { contended: boolean } | undefined;
+      await withExclusiveFileLockAsync(lockPath, async acquired => { context = acquired; });
+      assert.deepEqual(context, { contended: false });
+      assert.equal(fs.existsSync(lockPath), false);
+    } finally {
+      if (previous === undefined) delete process.env.XIAOBA_FILE_LOCK_STALE_MS;
+      else process.env.XIAOBA_FILE_LOCK_STALE_MS = previous;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

First dependency layer for #319. This adds the generic Agent Run contracts, durable local Run store, safe public projection, and cross-process file locking required by later Goal Check and Supervisor PRs.

## Included

- immutable Run, Trigger, Goal Check, event, artifact, and subject contracts
- atomic private-permission JSON persistence with corruption quarantine
- source-scoped Trigger idempotency and explicit migration
- optimistic conflict rejection for functional updates
- cross-process synchronous and renewable asynchronous locks
- fail-closed public event projection: only explicit progress summaries are public
- `proper-lockfile` as a production dependency

## Excluded

- Goal Check model evaluator
- Supervisor and AgentSession execution
- CLI commands
- Board
- Inspection/Review adapters and Dashboard integration
- Anthropic/checkpoint-compaction work

## Verification

- `node --import tsx --test tests/agent-run-store.test.ts` — 10 passed
- `node --import tsx --test tests/file-lock.test.ts` — 5 passed
- `npm run build` — passed
- production-only dependency install can load `proper-lockfile`
- `git diff --check` — passed

## Review fixes already applied

- normalize identities before duplicate checks
- rollback record and index mutations together
- reject stale functional updates instead of overwriting concurrent changes
- hide unknown event types by default
- chmod the temporary file before the atomic rename commit point

Part 1 of the dependency-ordered Agent Run stack tracked in #319.
