### PR TITLE
feat(provider): add attempt-scoped retry policy

### DIFF
--- a/src/observability/cache-trace.ts
+++ b/src/observability/cache-trace.ts
@@ -42,6 +42,8 @@ export interface CacheTraceEntryV4 {
     retry_delay_ms?: number;
     retry_elapsed_ms?: number;
     retry_max_elapsed_ms?: number;
+    retry_max_delay_ms?: number;
+    retry_trigger_reason?: string;
     retry_stop_reason?: string;
   };
   request: {
@@ -221,6 +223,8 @@ export class CacheTraceObserver implements CacheTraceSink {
           ...(retry.delayMs === undefined ? {} : { retry_delay_ms: retry.delayMs }),
           retry_elapsed_ms: retry.elapsedMs,
           retry_max_elapsed_ms: retry.maxElapsedMs,
+          ...(retry.maxDelayMs === undefined ? {} : { retry_max_delay_ms: retry.maxDelayMs }),
+          ...(retry.triggerReason ? { retry_trigger_reason: retry.triggerReason } : {}),
           ...(retry.stopReason ? { retry_stop_reason: retry.stopReason } : {}),
         } : {}),
       },

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -21,6 +21,8 @@ export interface StreamRetryInfo {
   delayMs: number;
   elapsedMs: number;
   maxElapsedMs: number;
+  maxDelayMs?: number;
+  triggerReason?: string;
   status?: string | number;
   message?: string;
 }
@@ -47,6 +49,8 @@ export interface ModelAttemptRetry {
   maxRetries: number;
   elapsedMs: number;
   maxElapsedMs: number;
+  maxDelayMs?: number;
+  triggerReason?: string;
   delayMs?: number;
   stopReason?: ModelAttemptStopReason;
 }

--- a/src/utils/ai-service.ts
+++ b/src/utils/ai-service.ts
@@ -41,6 +41,12 @@ const EMPTY_RESPONSE_ERROR_CODE = 'EMPTY_MODEL_RESPONSE';
 const EMPTY_RESPONSE_MAX_RETRIES = 2;
 const EMPTY_RESPONSE_MAX_ELAPSED_MS = 2 * 60 * 1000;
 const EMPTY_RESPONSE_MAX_DELAY_MS = 2000;
+const OPAQUE_400_MAX_RETRIES = 2;
+const OPAQUE_400_MAX_ELAPSED_MS = 15 * 1000;
+const OPAQUE_400_MAX_DELAY_MS = 2000;
+const OPAQUE_403_MAX_RETRIES = 1;
+const OPAQUE_403_MAX_ELAPSED_MS = 8 * 1000;
+const OPAQUE_403_MAX_DELAY_MS = 2000;
 let modelAttemptCallSequence = 0;
 
 type ProviderKind = 'openai' | 'anthropic';
@@ -50,6 +56,7 @@ interface RetryPolicy {
   maxElapsedMs: number;
   baseDelayMs: number;
   maxDelayMs: number;
+  triggerReason: string;
 }
 
 interface ModelAttemptRun {
@@ -281,6 +288,10 @@ export class AIService {
       return true;
     }
 
+    if (this.isOpaqueHttpError(error, 400) || this.isOpaqueHttpError(error, 403)) {
+      return true;
+    }
+
     // HTTP 状态码可重试
     const status = this.extractStatus(error);
     if (status && RETRYABLE_STATUS_CODES.has(status)) {
@@ -324,11 +335,38 @@ export class AIService {
 
   private isKnownNonRetryableProviderError(error: any): boolean {
     const status = this.extractStatus(error);
-    if (status && [400, 401, 403, 404, 413, 422].includes(status)) {
+    if (status && [401, 404, 413, 422].includes(status)) {
       return true;
     }
 
-    const message = [
+    const message = this.providerErrorText(error);
+    if (status === 400 && this.hasDiagnostic400Evidence(message)) return true;
+    if (status === 403 && this.hasDiagnostic403Evidence(message)) return true;
+
+    return /insufficient[_\s-]?quota|quota[_\s-]?exceeded|billing|(?:insufficient|low|exhausted)[_\s-]?(?:credit|balance)|(?:credit|balance)[_\s-]?(?:exhausted|insufficient|too low)|账户余额|余额不足|额度不足|额度已用尽|context length|maximum context|max(?:imum)? tokens?|prompt too long|invalid[_\s-]?request|invalid[_\s-]?api[_\s-]?key|unauthorized|forbidden|permission denied|model .*not found|model_not_found|tool schema|schema is invalid|content policy|safety/i
+      .test(message);
+  }
+
+  private isOpaqueHttpError(error: any, expectedStatus: 400 | 403): boolean {
+    if (this.extractStatus(error) !== expectedStatus) return false;
+    const message = this.providerErrorText(error);
+    return expectedStatus === 400
+      ? !this.hasDiagnostic400Evidence(message)
+      : !this.hasDiagnostic403Evidence(message);
+  }
+
+  private hasDiagnostic400Evidence(message: string): boolean {
+    return /invalid[_\s-]?(?:request|parameter|input|argument|payload|schema|json)|(?:request|parameter|input|argument|payload|schema|json)[_\s-]?invalid|bad[_\s-]?request|tool[_\s-]?schema|malformed|unexpected token|context length|maximum context|max(?:imum)? tokens?|prompt too long|content policy|safety|reasoning[_\s-]?(?:content|text).{0,80}(?:required|missing|must|expected|not passed back)|thinking mode.{0,80}reasoning/i
+      .test(message);
+  }
+
+  private hasDiagnostic403Evidence(message: string): boolean {
+    return /invalid[_\s-]?api[_\s-]?key|unauthorized|forbidden|(?:authentication|authorization|auth)[_\s-]?(?:error|failed|denied)|permission[_\s-]?denied|access[_\s-]?denied|not authorized|insufficient[_\s-]?(?:scope|permission)|model[_\s-]?access[_\s-]?(?:denied|forbidden)|(?:do not|does not|don't|doesn't|no) have access|model .{0,50}not (?:allowed|available|authorized|accessible)/i
+      .test(message);
+  }
+
+  private providerErrorText(error: any): string {
+    return [
       error?.response?.data?.error?.code,
       error?.response?.data?.error?.type,
       error?.response?.data?.error?.message,
@@ -338,9 +376,6 @@ export class AIService {
       error?.error?.message,
       error?.message,
     ].filter(Boolean).join(' ');
-
-    return /insufficient[_\s-]?quota|quota[_\s-]?exceeded|billing|(?:insufficient|low|exhausted)[_\s-]?(?:credit|balance)|(?:credit|balance)[_\s-]?(?:exhausted|insufficient|too low)|账户余额|余额不足|额度不足|额度已用尽|context length|maximum context|max(?:imum)? tokens?|prompt too long|invalid[_\s-]?request|invalid[_\s-]?api[_\s-]?key|unauthorized|forbidden|permission denied|model .*not found|model_not_found|tool schema|schema is invalid|content policy|safety/i
-      .test(message);
   }
 
   /**
@@ -416,6 +451,8 @@ export class AIService {
               maxRetries: policy.maxRetries,
               elapsedMs: Date.now() - startedAt,
               maxElapsedMs: policy.maxElapsedMs,
+              maxDelayMs: policy.maxDelayMs,
+              triggerReason: policy.triggerReason,
               stopReason: 'aborted',
             },
           });
@@ -439,6 +476,8 @@ export class AIService {
             max_retries: policy.maxRetries,
             elapsed_ms: elapsedMs,
             max_elapsed_ms: policy.maxElapsedMs,
+            max_delay_ms: policy.maxDelayMs,
+            trigger_reason: policy.triggerReason,
             stop_reason: stopReason,
           }, {
             call_id: attemptRun?.callId,
@@ -455,6 +494,8 @@ export class AIService {
               maxRetries: policy.maxRetries,
               elapsedMs,
               maxElapsedMs: policy.maxElapsedMs,
+              maxDelayMs: policy.maxDelayMs,
+              triggerReason: policy.triggerReason,
               stopReason,
             },
           });
@@ -473,6 +514,8 @@ export class AIService {
             delayMs: delay,
             elapsedMs,
             maxElapsedMs: policy.maxElapsedMs,
+            maxDelayMs: policy.maxDelayMs,
+            triggerReason: policy.triggerReason,
           },
         });
 
@@ -483,6 +526,8 @@ export class AIService {
           delayMs: delay,
           elapsedMs,
           maxElapsedMs: policy.maxElapsedMs,
+          maxDelayMs: policy.maxDelayMs,
+          triggerReason: policy.triggerReason,
           status,
           message: this.extractErrorMessage(error),
         };
@@ -594,6 +639,7 @@ export class AIService {
         MAX_CONFIGURABLE_RETRY_DURATION_MS,
       ),
       baseDelayMs: BASE_DELAY_MS,
+      triggerReason: this.resolveRetryTriggerReason(error),
     };
 
     if (this.isEmptyModelResponseError(error)) {
@@ -602,6 +648,26 @@ export class AIService {
         maxRetries: Math.min(policy.maxRetries, EMPTY_RESPONSE_MAX_RETRIES),
         maxElapsedMs: Math.min(policy.maxElapsedMs, EMPTY_RESPONSE_MAX_ELAPSED_MS),
         maxDelayMs: Math.min(policy.maxDelayMs, EMPTY_RESPONSE_MAX_DELAY_MS),
+      };
+    }
+
+    if (this.isOpaqueHttpError(error, 400)) {
+      return {
+        ...policy,
+        maxRetries: Math.min(policy.maxRetries, OPAQUE_400_MAX_RETRIES),
+        maxElapsedMs: Math.min(policy.maxElapsedMs, OPAQUE_400_MAX_ELAPSED_MS),
+        maxDelayMs: Math.min(policy.maxDelayMs, OPAQUE_400_MAX_DELAY_MS),
+        triggerReason: 'opaque_http_400',
+      };
+    }
+
+    if (this.isOpaqueHttpError(error, 403)) {
+      return {
+        ...policy,
+        maxRetries: Math.min(policy.maxRetries, OPAQUE_403_MAX_RETRIES),
+        maxElapsedMs: Math.min(policy.maxElapsedMs, OPAQUE_403_MAX_ELAPSED_MS),
+        maxDelayMs: Math.min(policy.maxDelayMs, OPAQUE_403_MAX_DELAY_MS),
+        triggerReason: 'opaque_http_403',
       };
     }
 
@@ -615,6 +681,18 @@ export class AIService {
       maxElapsedMs: Math.min(policy.maxElapsedMs, SHORT_NETWORK_MAX_ELAPSED_MS),
       maxDelayMs: Math.min(policy.maxDelayMs, SHORT_NETWORK_MAX_DELAY_MS),
     };
+  }
+
+  private resolveRetryTriggerReason(error: any): string {
+    if (this.isAbortError(error)) return 'aborted';
+    if (this.isEmptyModelResponseError(error)) return 'empty_model_response';
+    const status = this.extractStatus(error);
+    if (status) return `http_${status}`;
+    const code = this.extractErrorCode(error);
+    if (code) return `transport_${code.toLowerCase()}`;
+    if (error?.error?.type === 'overloaded_error') return 'provider_overloaded';
+    if (/timeout|timed out/i.test(String(error?.message || ''))) return 'transport_timeout';
+    return this.isRetryable(error) ? 'retryable_transport' : 'provider_rejected';
   }
 
   private resolveRetryDelayMs(error: any, retryAttempt: number, policy: RetryPolicy, elapsedMs: number): number {

--- a/src/utils/model-error-observability.ts
+++ b/src/utils/model-error-observability.ts
@@ -23,6 +23,8 @@ export interface ModelRetrySummary {
   max_retries: number;
   elapsed_ms: number;
   max_elapsed_ms: number;
+  max_delay_ms?: number;
+  trigger_reason?: string;
   stop_reason: RetryStopReason;
 }
 
@@ -275,6 +277,8 @@ function normalizeRetrySummary(input: ModelRetrySummary): ModelRetrySummary {
     max_retries: nonNegativeInteger(input.max_retries),
     elapsed_ms: nonNegativeInteger(input.elapsed_ms),
     max_elapsed_ms: nonNegativeInteger(input.max_elapsed_ms),
+    ...(input.max_delay_ms === undefined ? {} : { max_delay_ms: nonNegativeInteger(input.max_delay_ms) }),
+    ...(safeText(input.trigger_reason) ? { trigger_reason: safeText(input.trigger_reason) } : {}),
     stop_reason: input.stop_reason || 'unknown',
   };
 }

--- a/tests/ai-service.test.ts
+++ b/tests/ai-service.test.ts
@@ -87,6 +87,8 @@ test('AIService retries transient stream errors before any text is emitted', asy
   assert.deepStrictEqual(retries, [[1, 14]]);
   assert.equal(retryInfos[0].status, 503);
   assert.equal(retryInfos[0].maxElapsedMs, 5 * 60 * 1000);
+  assert.equal(retryInfos[0].maxDelayMs, 30_000);
+  assert.equal(retryInfos[0].triggerReason, 'http_503');
   assert.deepStrictEqual(chunks, ['ok']);
 });
 
@@ -339,6 +341,113 @@ test('AIService does not retry quota exhaustion even when provider uses HTTP 429
     () => service.chat([]),
     /API错误 \(429\): quota exceeded/,
   );
+  assert.equal(attempts, 1);
+});
+
+test('AIService retries an opaque 400 with a short bounded policy', async () => {
+  const service = createTestService();
+  let attempts = 0;
+  const retries: any[] = [];
+  const opaque400 = Object.assign(new Error('Request failed with status code 400'), {
+    response: { status: 400, headers: { 'retry-after': '0' } },
+  });
+  (service as any).sleepWithAbort = async () => undefined;
+  (service as any).provider = {
+    chat: async () => {
+      attempts += 1;
+      if (attempts === 1) throw opaque400;
+      return { content: 'recovered' };
+    },
+    chatStream: async () => ({ content: null }),
+  };
+
+  const result = await service.chat([], undefined, {
+    modelAttemptSink: {
+      observe: event => {
+        if (event.outcome === 'retrying') retries.push(event.retry);
+      },
+    },
+  });
+
+  assert.deepStrictEqual(result, { content: 'recovered' });
+  assert.equal(attempts, 2);
+  assert.equal(retries[0].maxRetries, 2);
+  assert.equal(retries[0].maxElapsedMs, 15_000);
+  assert.equal(retries[0].maxDelayMs, 2_000);
+  assert.equal(retries[0].triggerReason, 'opaque_http_400');
+});
+
+test('AIService does not retry a diagnostic invalid-request 400', async () => {
+  const service = createTestService();
+  let attempts = 0;
+  const invalidRequest = Object.assign(new Error('Request failed with status code 400'), {
+    response: {
+      status: 400,
+      data: { error: { type: 'invalid_request_error', message: 'tool schema is invalid' } },
+    },
+  });
+  (service as any).provider = {
+    chat: async () => {
+      attempts += 1;
+      throw invalidRequest;
+    },
+    chatStream: async () => ({ content: null }),
+  };
+
+  await assert.rejects(() => service.chat([]), /API错误 \(400\): tool schema is invalid/);
+  assert.equal(attempts, 1);
+});
+
+test('AIService retries an opaque 403 only once with a short budget', async () => {
+  const service = createTestService();
+  let attempts = 0;
+  const opaque403 = Object.assign(new Error('Request failed with status code 403'), {
+    response: { status: 403, headers: { 'retry-after': '0' } },
+  });
+  (service as any).sleepWithAbort = async () => undefined;
+  (service as any).provider = {
+    chat: async () => {
+      attempts += 1;
+      throw opaque403;
+    },
+    chatStream: async () => ({ content: null }),
+  };
+
+  let wrapped: unknown;
+  try {
+    await service.chat([]);
+  } catch (error) {
+    wrapped = error;
+  }
+
+  const diagnostics = readModelErrorDiagnostics(wrapped);
+  assert.equal(attempts, 2);
+  assert.equal(diagnostics?.retry?.retry_count, 1);
+  assert.equal(diagnostics?.retry?.max_retries, 1);
+  assert.equal(diagnostics?.retry?.max_elapsed_ms, 8_000);
+  assert.equal(diagnostics?.retry?.max_delay_ms, 2_000);
+  assert.equal(diagnostics?.retry?.trigger_reason, 'opaque_http_403');
+  assert.equal(diagnostics?.retry?.stop_reason, 'retry_limit_exhausted');
+});
+
+test('AIService does not retry a diagnostic permission 403', async () => {
+  const service = createTestService();
+  let attempts = 0;
+  const denied = Object.assign(new Error('Request failed with status code 403'), {
+    response: {
+      status: 403,
+      data: { error: { code: 'insufficient_scope' } },
+    },
+  });
+  (service as any).provider = {
+    chat: async () => {
+      attempts += 1;
+      throw denied;
+    },
+    chatStream: async () => ({ content: null }),
+  };
+
+  await assert.rejects(() => service.chat([]), /API错误 \(403\): Request failed with status code 403/);
   assert.equal(attempts, 1);
 });
 

--- a/tests/cache-trace-monitoring.test.ts
+++ b/tests/cache-trace-monitoring.test.ts
@@ -142,8 +142,16 @@ test('observer writes retry recovery as two correlated attempts and preserves ca
       outcome: 'retrying',
       attemptNumber: 1,
       attemptId: 'call-1:1',
-      error: Object.assign(new Error('temporary 503'), { response: { status: 503 } }),
-      retry: { retryNumber: 1, maxRetries: 2, elapsedMs: 5, maxElapsedMs: 1000, delayMs: 10 },
+      error: Object.assign(new Error('Request failed with status code 400'), { response: { status: 400 } }),
+      retry: {
+        retryNumber: 1,
+        maxRetries: 2,
+        elapsedMs: 5,
+        maxElapsedMs: 1000,
+        maxDelayMs: 2000,
+        triggerReason: 'opaque_http_400',
+        delayMs: 10,
+      },
     }));
     observer.observe(attemptEvent({ outcome: 'started', attemptNumber: 2, attemptId: 'call-1:2' }));
     observer.observe(attemptEvent({
@@ -156,10 +164,13 @@ test('observer writes retry recovery as two correlated attempts and preserves ca
 
     const files = listTraceFiles(dir);
     assert.equal(files.length, 2);
-    assert.equal(fs.readFileSync(files[0], 'utf8').trim().split(/\r?\n/).length, 2);
+    const retryLines = fs.readFileSync(files[0], 'utf8').trim().split(/\r?\n/).map(line => JSON.parse(line));
+    assert.equal(retryLines.length, 2);
+    assert.equal(retryLines[1].lifecycle.retry_trigger_reason, 'opaque_http_400');
+    assert.equal(retryLines[1].lifecycle.retry_max_delay_ms, 2000);
     const store = await readCacheTraceStore(dir);
     assert.deepEqual(store.records.map(record => record.outcome), ['retrying', 'succeeded']);
-    assert.equal(store.records[0].httpStatus, 503);
+    assert.equal(store.records[0].httpStatus, 400);
     assert.equal(store.records[1].usage.cacheReadTokens, 4);
     assert.equal(store.sessions[0].calls, 1);
     assert.equal(store.sessions[0].retriedCalls, 1);

--- a/tests/model-attempt-lifecycle.test.ts
+++ b/tests/model-attempt-lifecycle.test.ts
@@ -75,7 +75,41 @@ test('records every provider retry as a correlated attempt lifecycle', async () 
   assert.equal(events[0].context?.episodeNumber, 4);
   assert.equal(events[1].retry?.retryNumber, 1);
   assert.equal(events[1].retry?.delayMs, 0);
+  assert.equal(events[1].retry?.triggerReason, 'http_503');
+  assert.equal(events[1].retry?.maxDelayMs, 30_000);
   assert.equal(events[3].response?.usage?.cachedReadTokens, 60);
+});
+
+test('records an opaque provider rejection retry as a new physical attempt', async () => {
+  const service = createTestService();
+  const events: ModelAttemptEvent[] = [];
+  let calls = 0;
+  (service as any).sleepWithAbort = async () => undefined;
+  (service as any).provider = {
+    chat: async () => {
+      calls += 1;
+      if (calls === 1) {
+        throw Object.assign(new Error('Request failed with status code 400'), {
+          response: { status: 400, headers: { 'retry-after': '0' } },
+        });
+      }
+      return { content: 'recovered' };
+    },
+    chatStream: async () => ({ content: 'unused' }),
+  };
+
+  await service.chat([], undefined, { modelAttemptSink: collectingSink(events) });
+
+  assert.deepEqual(events.map(event => event.outcome), ['started', 'retrying', 'started', 'succeeded']);
+  assert.equal(new Set(events.map(event => event.callId)).size, 1);
+  assert.deepEqual(events.map(event => event.attemptNumber), [1, 1, 2, 2]);
+  assert.equal(events[0].attemptId, events[1].attemptId);
+  assert.equal(events[2].attemptId, events[3].attemptId);
+  assert.notEqual(events[0].attemptId, events[2].attemptId);
+  assert.equal(events[1].retry?.triggerReason, 'opaque_http_400');
+  assert.equal(events[1].retry?.maxRetries, 2);
+  assert.equal(events[1].retry?.maxElapsedMs, 15_000);
+  assert.equal(events[1].retry?.maxDelayMs, 2_000);
 });
 
 test('records a non-retryable provider rejection as the terminal attempt', async () => {


### PR DESCRIPTION
## Summary
- make every physical provider retry start a fresh attempt lifecycle
- classify retry triggers and expose the effective retry budget in attempt diagnostics and Cache Trace
- keep diagnostic 400/403 failures terminal while allowing short, bounded retries for opaque 400/403 responses
- preserve interruption diagnostics and per-attempt tracing from #291

## Retry policy
- opaque HTTP 400: at most 2 retries, 15s elapsed budget, 2s max delay
- opaque HTTP 403: at most 1 retry, 8s elapsed budget, 2s max delay
- ordinary retryable failures such as HTTP 503 retain the existing bounded policy
- diagnostic invalid/schema/context/safety/reasoning-incompatibility 400 responses do not retry
- diagnostic auth/permission/scope/model-access 403 responses do not retry
- HTTP 401, 404, 413, and 422 do not retry

## Stack and scope
- based on `codex/turn-error-observability` (#291)
- intended to sit after the #293/#290/#291 recovery and observability chain
- does not include #296 or broad provider-recovery changes
- remains orthogonal to evidence-based, one-time reasoning-dialect recovery

## Validation
- TypeScript: `tsc --noEmit`
- focused tests: 40 passed, 0 failed
- `git diff --check origin/codex/turn-error-observability...HEAD`