### PR TITLE
feat(provider): migrate Responses replay state

### DIFF
--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -524,7 +524,16 @@ export class ConversationRunner {
         Logger.info(`[${this.sessionLabel}Turn ${turns}] AI最终回复: ${ConversationRunner.truncateForLog(visibleContent, 300)}`);
 
         if (visibleContent) {
-          const finalAssistantMessage: Message = { role: 'assistant', content: visibleContent };
+          const finalAssistantMessage: Message = {
+            role: 'assistant',
+            content: visibleContent,
+            ...(response.providerContent?.length
+              ? {
+                  providerContent: response.providerContent,
+                  providerState: response.providerState,
+                }
+              : {}),
+          };
           messages.push(finalAssistantMessage);
           newMessages.push(finalAssistantMessage);
         }

--- a/src/providers/openai-provider.ts
+++ b/src/providers/openai-provider.ts
@@ -433,7 +433,7 @@ export class OpenAIProvider implements AIProvider {
         continue;
       }
 
-      if (message.role === 'assistant' && message.tool_calls?.length) {
+      if (message.role === 'assistant') {
         const replayItems = (this.canReplayProviderContent(message, 'openai-responses')
           ? message.providerContent || []
           : [])
@@ -441,12 +441,21 @@ export class OpenAIProvider implements AIProvider {
           .map(item => JSON.parse(JSON.stringify(item)));
         if (replayItems.length > 0) {
           input.push(...replayItems);
-          continue;
         }
 
+        const hasReplayedMessage = replayItems.some(item => item.type === 'message');
+        const replayedCallIds = new Set(
+          replayItems
+            .filter(item => item.type === 'function_call')
+            .map(item => String(item.call_id || ''))
+            .filter(Boolean),
+        );
         const text = this.contentAsText(message.content);
-        if (text) input.push({ role: 'assistant', content: text });
-        for (const toolCall of message.tool_calls) {
+        if (text && !hasReplayedMessage) {
+          input.push({ role: 'assistant', content: text });
+        }
+        for (const toolCall of message.tool_calls ?? []) {
+          if (replayedCallIds.has(toolCall.id)) continue;
           input.push({
             type: 'function_call',
             call_id: toolCall.id,
@@ -636,8 +645,11 @@ export class OpenAIProvider implements AIProvider {
     const stopReason = response?.status === 'incomplete'
       ? incompleteReason === 'max_output_tokens' ? 'length' : incompleteReason || 'incomplete'
       : toolCalls.length > 0 ? 'tool_calls' : response?.status || undefined;
-    const providerContent = toolCalls.length > 0
-      ? output.filter((item: any) => this.isResponsesReplayItem(item)).map((item: any) => JSON.parse(JSON.stringify(item)))
+    const replayItems = output.filter((item: any) =>
+      this.isResponsesReplayItem(item) && (item?.type !== 'message' || toolCalls.length > 0),
+    );
+    const providerContent = replayItems.length > 0
+      ? replayItems.map((item: any) => JSON.parse(JSON.stringify(item)))
       : undefined;
 
     return {

--- a/src/providers/request-preflight.ts
+++ b/src/providers/request-preflight.ts
@@ -126,7 +126,7 @@ export function prepareProviderRequestMessages(
       const callsChanged = retainedCalls.length !== message.tool_calls.length;
       const replayMismatch = Boolean(
         message.providerContent?.length
-        && !providerReplayMatchesToolCalls(message.providerContent, retainedCalls),
+        && !providerReplayMatchesToolCalls(message.providerContent, retainedCalls, message.providerState),
       );
       if (callsChanged || replayMismatch) {
         if (message.providerContent?.length || message.providerState) {
@@ -200,7 +200,9 @@ function hasVisibleContent(message: Message): boolean {
 function providerReplayMatchesToolCalls(
   blocks: NonNullable<Message['providerContent']>,
   toolCalls: ToolCall[],
+  providerState: Message['providerState'],
 ): boolean {
+  const allowMissingCalls = providerState?.apiType === 'openai-responses';
   const canonical = new Map(toolCalls.map(toolCall => [toolCall.id, {
     name: toolCall.function.name,
     arguments: stableArguments(toolCall.function.arguments),
@@ -216,7 +218,7 @@ function providerReplayMatchesToolCalls(
         ? safeString(block.call_id)
         : '';
     if (!id) continue;
-    if (replay.has(id)) return false;
+    if (replay.has(id) || !canonical.has(id)) return false;
     replay.set(id, {
       name: safeString(block.name),
       arguments: type === 'tool_use'
@@ -225,10 +227,10 @@ function providerReplayMatchesToolCalls(
     });
   }
 
-  if (replay.size !== canonical.size) return false;
-  for (const [id, call] of canonical) {
-    const item = replay.get(id);
-    if (!item || item.name !== call.name || item.arguments !== call.arguments) return false;
+  if (!allowMissingCalls && replay.size !== canonical.size) return false;
+  for (const [id, item] of replay) {
+    const call = canonical.get(id);
+    if (!call || item.name !== call.name || item.arguments !== call.arguments) return false;
   }
   return true;
 }

--- a/tests/conversation-runner-transcript-normalization.test.ts
+++ b/tests/conversation-runner-transcript-normalization.test.ts
@@ -468,6 +468,48 @@ test('runner keeps Responses reasoning and matching function calls in the tool t
   assert.deepEqual(secondRequestAssistant?.providerState, providerState);
 });
 
+test('runner keeps pure-text Responses reasoning and state for the next live request', async () => {
+  const reasoning = {
+    type: 'reasoning',
+    id: 'rs_text_1',
+    encrypted_content: 'opaque-pure-text-state',
+    summary: [],
+  };
+  const providerState = {
+    schema: 'xiaoba.provider_state.v1' as const,
+    apiType: 'openai-responses' as const,
+    model: 'gpt-test',
+    endpointFingerprint: '0123456789abcdef',
+  };
+  const mock = createMockAI([
+    {
+      ...makeFinalResponse('first answer'),
+      providerContent: [reasoning],
+      providerState,
+    },
+    makeFinalResponse('second answer'),
+  ]);
+  const runner = new ConversationRunner(mock.aiService, new MockToolExecutor([], {}), {
+    stream: false,
+    enableCompression: false,
+  });
+
+  const first = await runner.run([{ role: 'user', content: 'first question' }]);
+  const firstAssistant = first.messages.find(message => message.role === 'assistant');
+  assert.deepEqual(firstAssistant?.providerContent, [reasoning]);
+  assert.deepEqual(firstAssistant?.providerState, providerState);
+
+  await runner.run([
+    ...first.messages,
+    { role: 'user', content: 'follow up' },
+  ]);
+  const secondRequestAssistant = mock.getReceivedMessages()[1]
+    .find(message => message.role === 'assistant');
+
+  assert.deepEqual(secondRequestAssistant?.providerContent, [reasoning]);
+  assert.deepEqual(secondRequestAssistant?.providerState, providerState);
+});
+
 test('runner injects tool target context into provider transcript only', async () => {
   const responses = [
     makeToolResponse(makeToolCall('call_1', 'execute_shell', { command: 'echo ok' })),

--- a/tests/openai-provider-responses.test.ts
+++ b/tests/openai-provider-responses.test.ts
@@ -319,6 +319,196 @@ describe('OpenAIProvider Responses API mode', () => {
     }
   });
 
+  test('replays reasoning from a provider-compatible pure-text assistant turn', async () => {
+    const originalPost = axios.post;
+    const bodies: any[] = [];
+    const reasoning = {
+      type: 'reasoning',
+      id: 'reasoning_text_1',
+      status: 'completed',
+      encrypted_content: 'opaque-pure-text-state',
+      summary: [],
+    };
+    (axios as any).post = async (_url: string, body: any) => {
+      bodies.push(body);
+      return {
+        data: bodies.length === 1
+          ? {
+              status: 'completed',
+              output: [
+                reasoning,
+                {
+                  type: 'message',
+                  role: 'assistant',
+                  content: [{ type: 'output_text', text: 'first answer' }],
+                },
+              ],
+            }
+          : {
+              status: 'completed',
+              output: [{
+                type: 'message',
+                role: 'assistant',
+                content: [{ type: 'output_text', text: 'second answer' }],
+              }],
+            },
+      };
+    };
+
+    try {
+      const provider = createProvider();
+      const first = await provider.chat([{ role: 'user', content: 'first question' }]);
+      await provider.chat([
+        { role: 'user', content: 'first question' },
+        {
+          role: 'assistant',
+          content: first.content,
+          providerContent: first.providerContent,
+          providerState: first.providerState,
+        },
+        { role: 'user', content: 'follow up' },
+      ]);
+
+      assert.deepEqual(first.providerContent, [reasoning]);
+      assert.deepEqual(bodies[1].input, [
+        { role: 'user', content: 'first question' },
+        reasoning,
+        { role: 'assistant', content: 'first answer' },
+        { role: 'user', content: 'follow up' },
+      ]);
+    } finally {
+      (axios as any).post = originalPost;
+    }
+  });
+
+  test('isolates pure-text Responses replay across models', () => {
+    const source = createProvider();
+    const target = new OpenAIProvider({
+      apiKey: 'test-key',
+      apiUrl: 'https://api.openai.com/v1',
+      model: 'gpt-other',
+      openaiApiMode: 'responses',
+    });
+    const body = (target as any).buildResponsesRequestBody([
+      {
+        role: 'assistant',
+        content: 'portable answer',
+        providerContent: [{ type: 'reasoning', id: 'rs_foreign', encrypted_content: 'opaque' }],
+        providerState: (source as any).providerStateReference('openai-responses'),
+      },
+    ]);
+
+    assert.deepEqual(body.input, [{ role: 'assistant', content: 'portable answer' }]);
+  });
+
+  test('preserves native item order when a Responses turn has visible text and a tool call', async () => {
+    const originalPost = axios.post;
+    const bodies: any[] = [];
+    const reasoning = {
+      type: 'reasoning',
+      id: 'reasoning_mixed_1',
+      status: 'completed',
+      encrypted_content: 'opaque-mixed-state',
+      summary: [],
+    };
+    const message = {
+      type: 'message',
+      role: 'assistant',
+      content: [{ type: 'output_text', text: 'I will look that up.' }],
+    };
+    const functionCall = {
+      type: 'function_call',
+      id: 'fc_mixed_1',
+      call_id: 'call_1',
+      name: 'lookup',
+      arguments: '{"query":"cats"}',
+    };
+    (axios as any).post = async (_url: string, body: any) => {
+      bodies.push(body);
+      return {
+        data: bodies.length === 1
+          ? { status: 'completed', output: [reasoning, message, functionCall] }
+          : {
+              status: 'completed',
+              output: [{
+                type: 'message',
+                role: 'assistant',
+                content: [{ type: 'output_text', text: 'The result is ready.' }],
+              }],
+            },
+      };
+    };
+
+    try {
+      const provider = createProvider();
+      const first = await provider.chat([{ role: 'user', content: 'look it up' }], [lookupTool]);
+      assert.equal(first.content, 'I will look that up.');
+      assert.deepEqual(first.toolCalls, [{
+        id: 'call_1',
+        type: 'function',
+        function: { name: 'lookup', arguments: '{"query":"cats"}' },
+      }]);
+
+      await provider.chat([
+        { role: 'user', content: 'look it up' },
+        {
+          role: 'assistant',
+          content: first.content,
+          tool_calls: first.toolCalls,
+          providerContent: first.providerContent,
+          providerState: first.providerState,
+        },
+        { role: 'tool', tool_call_id: 'call_1', content: 'found cats' },
+      ], [lookupTool]);
+
+      assert.deepEqual(bodies[1].input, [
+        { role: 'user', content: 'look it up' },
+        reasoning,
+        message,
+        functionCall,
+        { type: 'function_call_output', call_id: 'call_1', output: 'found cats' },
+      ]);
+    } finally {
+      (axios as any).post = originalPost;
+    }
+  });
+
+  test('reconstructs canonical function calls when compatible replay only contains reasoning', () => {
+    const provider = createProvider();
+    const reasoning = {
+      type: 'reasoning',
+      id: 'reasoning_tool_1',
+      status: 'completed',
+      encrypted_content: 'opaque-tool-state',
+      summary: [],
+    };
+    const body = (provider as any).buildResponsesRequestBody([
+      {
+        role: 'assistant',
+        content: null,
+        tool_calls: [{
+          id: 'call_1',
+          type: 'function',
+          function: { name: 'lookup', arguments: '{"query":"cats"}' },
+        }],
+        providerContent: [reasoning],
+        providerState: (provider as any).providerStateReference('openai-responses'),
+      },
+      { role: 'tool', tool_call_id: 'call_1', content: 'found cats' },
+    ], [lookupTool]);
+
+    assert.deepEqual(body.input, [
+      reasoning,
+      {
+        type: 'function_call',
+        call_id: 'call_1',
+        name: 'lookup',
+        arguments: '{"query":"cats"}',
+      },
+      { type: 'function_call_output', call_id: 'call_1', output: 'found cats' },
+    ]);
+  });
+
   test('replays provider function calls and CatsCo tool results', async () => {
     const originalPost = axios.post;
     const bodies: any[] = [];

--- a/tests/provider-request-preflight.test.ts
+++ b/tests/provider-request-preflight.test.ts
@@ -101,6 +101,31 @@ test('preflight falls back from mismatched opaque replay without losing canonica
   assert.deepEqual(result.summary?.issueCodes, ['provider_replay_mismatch']);
 });
 
+test('reasoning-only replay remains compatible and leaves canonical call reconstruction to the provider', () => {
+  const messages: Message[] = [
+    {
+      role: 'assistant',
+      content: null,
+      tool_calls: [toolCall('call_1')],
+      providerContent: [
+        { type: 'reasoning', id: 'rs_1', encrypted_content: 'opaque' },
+      ],
+      providerState: {
+        schema: 'xiaoba.provider_state.v1',
+        apiType: 'openai-responses',
+        model: 'gpt-test',
+        endpointFingerprint: '0123456789abcdef',
+      },
+    },
+    { role: 'tool', tool_call_id: 'call_1', content: 'ok' },
+  ];
+
+  const result = prepareProviderRequestMessages(messages);
+
+  assert.equal(result.messages, messages);
+  assert.equal(result.summary, undefined);
+});
+
 test('matching opaque replay survives normalized JSON argument comparison', () => {
   const messages: Message[] = [
     {

--- a/tests/session-lifecycle-manager.test.ts
+++ b/tests/session-lifecycle-manager.test.ts
@@ -433,6 +433,43 @@ describe('AgentSession lifecycle', () => {
     assert.doesNotMatch(raw, /private openai tool result/);
   });
 
+  test('session persistence strips Responses reasoning and provider state for model-portable restore', () => {
+    const { SessionStore } = loadSessionModules();
+    SessionStore.getInstance().saveContext('user:lifecycle-responses-reasoning', [
+      { role: 'user', content: 'first question' },
+      {
+        role: 'assistant',
+        content: 'public answer',
+        providerContent: [{
+          type: 'reasoning',
+          id: 'reasoning_1',
+          encrypted_content: 'private Responses reasoning',
+          summary: [],
+        }],
+        providerState: {
+          schema: 'xiaoba.provider_state.v1',
+          apiType: 'openai-responses',
+          model: 'secret-responses-model',
+          endpointFingerprint: 'fedcba9876543210',
+        },
+      },
+    ]);
+
+    const restored = SessionStore.getInstance().loadContext('user:lifecycle-responses-reasoning');
+    const raw = fs.readFileSync(
+      path.join(testRoot, 'data', 'sessions', 'user_lifecycle-responses-reasoning.jsonl'),
+      'utf-8',
+    );
+
+    assert.deepStrictEqual(restored.map((message: any) => message.content), [
+      'first question',
+      'public answer',
+    ]);
+    assert.equal(restored.some((message: any) => Array.isArray(message.providerContent)), false);
+    assert.equal(restored.some((message: any) => message.providerState), false);
+    assert.doesNotMatch(raw, /private Responses reasoning|reasoning_1|secret-responses-model|providerState/);
+  });
+
   test('loading legacy sessions migrates provider replay hidden thinking off disk', async () => {
     const { SessionStore } = loadSessionModules();
     const sessionFile = path.join(testRoot, 'data', 'sessions', 'user_lifecycle-legacy-provider-replay.jsonl');


### PR DESCRIPTION
## Summary
- migrate OpenAI Responses replay state onto the provider preflight stack
- replay plain-text Responses reasoning without duplicating the native assistant message
- reconstruct missing canonical `function_call` items only when matching calls are absent
- isolate replay by provider/model/API/endpoint compatibility
- preserve provider-private reasoning/state in memory while excluding it from persisted sessions

## Preflight integration
- based on `agent/provider-request-preflight` (#295)
- relaxes missing-call preflight only for compatible `openai-responses` replay state
- extra, unknown, duplicate, or mismatched calls still use the existing fallback
- does not broadly rewrite conversation history
- does not include #296 or cache/context-tail work from #317

## Coverage
- plain-text reasoning replay
- tool-turn replay and canonical call reconstruction
- mixed message/tool item ordering
- cross-model and cross-endpoint isolation
- session persistence sanitization

## Validation
- TypeScript: `tsc --noEmit`
- focused tests: 101 passed, 0 failed
- `git diff --check origin/agent/provider-request-preflight...HEAD`

## Migration gate
#288 must remain open until this migration PR is validated and the release state is confirmed. Only then should #288 be closed and marked as functionally migrated.