### PR TITLE
fix(catscompany): finish active conversation tasks on shutdown

### DIFF
--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -526,11 +526,19 @@ export class CatsCompanyBot {
     });
 
     this.bot.on('device_rpc_request', async (request: CatsDeviceRpcMessage) => {
-      await this.handleDeviceRpcRequest(request);
+      // Shutdown fence: destroy() 开始后拒绝新的设备 RPC，避免在销毁窗口内
+      // 继续执行本地 write_file/edit_file/execute_shell 等副作用工具。
+      // runTrackedConversationWork 让已进入的 RPC 工作计入 in-flight 计数，
+      // destroy() 的 quiesce 会等待它完成（review 2026-08-06）。
+      if (this.shuttingDown) return;
+      await this.runTrackedConversationWork(() => this.handleDeviceRpcRequest(request));
     });
 
     this.bot.on('thin_tool_rpc_request', async (request: CatsThinToolRpcMessage) => {
-      await this.handleThinToolRpcRequest(request);
+      // Shutdown fence: 与 device_rpc_request 一致，拒绝销毁窗口内的新
+      // thin-tool RPC，并将已进入的工作纳入 quiescence 等待。
+      if (this.shuttingDown) return;
+      await this.runTrackedConversationWork(() => this.handleThinToolRpcRequest(request));
     });
 
     this.bot.on('error', (err: Error) => {
@@ -717,6 +725,8 @@ export class CatsCompanyBot {
   }
 
   private async handleThinToolRpcRequest(request: CatsThinToolRpcMessage): Promise<void> {
+    // Shutdown fence: destroy() 开始后不再执行新的 thin-tool RPC 工具。
+    if (this.shuttingDown) return;
     const requestID = request.request_id;
     if (!requestID) return;
     Logger.info(`[CatsCompany][thin_tool_rpc] target received request: request=${requestID}, tool=${request.tool_name || ''}, targetOwner=${request.target_owner_user_id || ''}, targetDevice=${request.target_device_id || ''}, device=${request.device_id || ''}`);
@@ -742,6 +752,12 @@ export class CatsCompanyBot {
           message: result.message,
         };
 
+    // Shutdown fence: 工具执行期间 destroy() 可能已开始（quiesce 超时后继续），
+    // 此时连接即将断开，不再发送迟到结果（review 2026-08-06）。
+    if (this.shuttingDown) {
+      Logger.info(`[CatsCompany][thin_tool_rpc] destroy 已开始，丢弃 RPC 结果: request=${requestID}`);
+      return;
+    }
     try {
       await this.bot.sendThinToolRpcResult({
         request_id: requestID,
@@ -835,6 +851,8 @@ export class CatsCompanyBot {
   }
 
   private async handleDeviceRpcRequest(request: CatsDeviceRpcMessage): Promise<void> {
+    // Shutdown fence: destroy() 开始后不再执行新的设备 RPC 工具。
+    if (this.shuttingDown) return;
     const requestID = request.request_id;
     if (!requestID) return;
 
@@ -859,6 +877,12 @@ export class CatsCompanyBot {
           message: result.message,
         });
 
+    // Shutdown fence: 工具执行期间 destroy() 可能已开始（quiesce 超时后继续），
+    // 此时连接即将断开，不再发送迟到结果（review 2026-08-06）。
+    if (this.shuttingDown) {
+      Logger.info(`[CatsCompany] destroy 已开始，丢弃 Device RPC 结果: request=${requestID}`);
+      return;
+    }
     try {
       await this.bot.sendDeviceRpcResult({
         request_id: requestID,

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -1577,6 +1577,13 @@ export class CatsCompanyBot {
         });
 
         if (entryClearGeneration === this.getSessionClearGeneration(key)) {
+          // Shutdown fence: destroy() may have timed out its quiesce wait and
+          // returned while this model turn was still in flight. Never deliver a
+          // late user reply after the connector is gone.
+          if (this.shuttingDown) {
+            Logger.info(`[${key}] destroy 已开始，丢弃迟到的用户回合结果`);
+            return;
+          }
           // 最终文本回复
           let replyDelivered = true;
           if (result.visibleToUser && result.text) {
@@ -2128,6 +2135,11 @@ export class CatsCompanyBot {
       });
       if (clearGeneration !== this.getSessionClearGeneration(sessionKey)) {
         Logger.info(`[${sessionKey}] clear 后忽略旧子智能体反馈结果`);
+      } else if (this.shuttingDown) {
+        // Shutdown fence: destroy() may have timed out its quiesce wait and
+        // returned while this sub-agent feedback model turn was still in
+        // flight. Do not deliver a reply, do not requeue, do not mark handled.
+        Logger.info(`[${sessionKey}] destroy 已开始，丢弃迟到的子智能体反馈结果`);
       } else if (result.text === BUSY_MESSAGE) {
         this.enqueueSubAgentFeedback(sessionKey, topic, senderId, text, executionScope, 0, clearGeneration);
         Logger.info(`[${sessionKey}] 主会话竞态忙碌，子智能体反馈已入队`);
@@ -2301,6 +2313,11 @@ export class CatsCompanyBot {
       });
       if (batch.clearGeneration !== this.getSessionClearGeneration(sessionKey)) {
         Logger.info(`[${sessionKey}] clear 后忽略旧批量子任务回流结果`);
+      } else if (this.shuttingDown) {
+        // Shutdown fence: destroy() may have timed out its quiesce wait and
+        // returned while this completion-batch model turn was still in flight.
+        // Do not deliver a reply, do not requeue, do not mark handled.
+        Logger.info(`[${sessionKey}] destroy 已开始，丢弃迟到的批量回流结果`);
       } else if (result.text === BUSY_MESSAGE) {
         const pendingBatch = this.subAgentCompletionBatches.get(sessionKey);
         if (pendingBatch && pendingBatch !== batch) {
@@ -2853,6 +2870,11 @@ export class CatsCompanyBot {
           });
         if (clearGeneration !== this.getSessionClearGeneration(sessionKey)) {
           Logger.info(`[${sessionKey}] clear 后忽略已出队旧消息的返回`);
+        } else if (this.shuttingDown) {
+          // Shutdown fence: destroy() may have timed out its quiesce wait and
+          // returned while this queued model turn was still in flight. Do not
+          // deliver a reply or requeue after the connector is gone.
+          Logger.info(`[${sessionKey}] destroy 已开始，丢弃迟到出队消息的结果`);
         } else if (result.text === BUSY_MESSAGE) {
           const pending = this.messageQueue.get(sessionKey) ?? [];
           pending.unshift(msg);
@@ -3038,6 +3060,12 @@ export class CatsCompanyBot {
       if (batch.timer) clearTimeout(batch.timer);
     }
     this.subAgentCompletionBatches.clear();
+    // Interrupt every busy session before quiescing. requestInterrupt() aborts
+    // the session's active model turn (AbortController), so an in-flight
+    // handleMessage / handleRuntimeObservation returns a cancellation instead of
+    // running past the 3s quiesce budget and delivering side effects after the
+    // connector is gone (review 2026-08-05).
+    (this.sessionManager as any)?.interruptAll?.('connector shutdown');
     // Quiesce in-flight handlers so pre-turn awaits (attachment download /
     // cloud restore / hydration) that resume after shutdown cannot start the
     // model (review 2026-08-05).

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -426,6 +426,7 @@ export class CatsCompanyBot {
   /** Bot 自身的 uid，用于过滤自己发出的消息 */
   private botUid: string | null = null;
   private connectorReady = false;
+  private shuttingDown = false;
   private runtime: AdapterRuntimeBundle;
   private runtimeProfile: AdapterRuntimeBundle['profile'];
   private localDeviceGrant?: ScopedLocalDeviceGrant;
@@ -520,6 +521,7 @@ export class CatsCompanyBot {
     });
 
     this.bot.on('message', async (ctx: MessageContext) => {
+      if (this.shuttingDown) return;
       await this.onMessage(ctx);
     });
 
@@ -1797,6 +1799,29 @@ export class CatsCompanyBot {
     return { state: 'completed', summary: '任务已完成' };
   }
 
+  private async finishActiveConversationTasksForShutdown(timeoutMs = 3_000): Promise<void> {
+    const activeTasks = Array.from(this.activeConversationTasks.entries());
+    for (const [sessionKey, task] of activeTasks) {
+      this.finishConversationTask(sessionKey, task, {
+        state: 'stale',
+        summary: 'Agent 正在重启，本次任务已自动中止，可重新发送',
+        error: 'connector shutdown before terminal task status',
+      });
+    }
+
+    const pending = Array.from(this.taskStatusTasks.values());
+    if (pending.length === 0) return;
+
+    let timeout: NodeJS.Timeout | undefined;
+    await Promise.race([
+      Promise.allSettled(pending),
+      new Promise<void>(resolve => {
+        timeout = setTimeout(resolve, Math.max(1, timeoutMs));
+      }),
+    ]);
+    if (timeout) clearTimeout(timeout);
+  }
+
   private releaseSessionExecution(sessionKey: string): void {
     this.sessionExecutionReservations?.delete(sessionKey);
   }
@@ -2950,10 +2975,13 @@ export class CatsCompanyBot {
    * 停止机器人
    */
   async destroy(): Promise<void> {
+    if (this.shuttingDown) return;
+    this.shuttingDown = true;
     this.connectorReady = false;
     this.stopDeviceRegistrationRefresh();
-    this.bot.disconnect();
     await this.sessionManager.destroy();
+    await this.finishActiveConversationTasksForShutdown();
+    this.bot.disconnect();
     this.pendingAttachments.clear();
     this.messageQueue.clear();
     this.sessionExecutionReservations?.clear();

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -1720,7 +1720,10 @@ export class CatsCompanyBot {
     return true;
   }
 
-  private beginConversationTask(sessionKey: string, topic: string): ActiveConversationTask {
+  private beginConversationTask(sessionKey: string, topic: string): ActiveConversationTask | undefined {
+    // Shutdown barrier: shutdown 开始后禁止创建新任务（不发 running），
+    // 避免 shutdown snapshot 之后出现孤儿任务（排队消息在 drain 中被丢弃而非留下无终态任务）。
+    if (this.shuttingDown) return undefined;
     const tasks = this.activeConversationTasks ??= new Map<string, ActiveConversationTask>();
     const active = tasks.get(sessionKey);
     if (active && !active.finished) return active;
@@ -2671,6 +2674,8 @@ export class CatsCompanyBot {
    * 排空消息队列：将忙时积压的消息合并为一条，一次性处理
    */
   private async drainMessageQueue(sessionKey: string): Promise<void> {
+    // Shutdown barrier: destroy() 开始后禁止消费队列，排队用户工作不得再启动新任务。
+    if (this.shuttingDown) return;
     const queue = this.messageQueue.get(sessionKey);
     if (!queue || queue.length === 0) return;
 
@@ -2979,9 +2984,8 @@ export class CatsCompanyBot {
     this.shuttingDown = true;
     this.connectorReady = false;
     this.stopDeviceRegistrationRefresh();
-    await this.sessionManager.destroy();
-    await this.finishActiveConversationTasksForShutdown();
-    this.bot.disconnect();
+    // 原子停止：在第一个 await 之前显式取消排队用户工作、子任务批量定时器与云恢复，
+    // 保证 shutdown 开始后 drainMessageQueue / beginConversationTask 不再消费或新建任务。
     this.pendingAttachments.clear();
     this.messageQueue.clear();
     this.sessionExecutionReservations?.clear();
@@ -2993,6 +2997,17 @@ export class CatsCompanyBot {
       if (batch.timer) clearTimeout(batch.timer);
     }
     this.subAgentCompletionBatches.clear();
+    await this.sessionManager.destroy();
+    await this.finishActiveConversationTasksForShutdown();
+    this.bot.disconnect();
+    // 兜底重扫：在飞 handler quiesce 后再扫一次，捕获 snapshot 之后才注册的孤儿任务（幂等）。
+    for (const [sessionKey, task] of Array.from(this.activeConversationTasks.entries())) {
+      this.finishConversationTask(sessionKey, task, {
+        state: 'stale',
+        summary: 'Agent 正在重启，本次任务已自动中止，可重新发送',
+        error: 'connector shutdown before terminal task status',
+      });
+    }
     Logger.info('CatsCo agent 已停止');
   }
 

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -3042,6 +3042,11 @@ export class CatsCompanyBot {
     // cloud restore / hydration) that resume after shutdown cannot start the
     // model (review 2026-08-05).
     await this.waitForActiveHandlersToQuiesce();
+    // Stop any still-running sub-agents up front. Their own model turns do not
+    // pass through runTrackedConversationWork (they run inside the agent
+    // session), so an active sub-agent could otherwise keep calling the model
+    // during the destroy window until sessionManager.destroy() cascades a stop.
+    SubAgentManager.getInstance().shutdown('connector shutdown');
     await this.sessionManager.destroy();
     await this.finishActiveConversationTasksForShutdown();
     this.bot.disconnect();

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -2162,8 +2162,14 @@ export class CatsCompanyBot {
       }
     } catch (err: any) {
       if (clearGeneration === this.getSessionClearGeneration(sessionKey)) {
-        this.enqueueSubAgentFeedback(sessionKey, topic, senderId, text, executionScope, 1, clearGeneration);
-        Logger.warning(`[${sessionKey}] 子智能体反馈执行异常，已入队重试: ${err?.message || err}`);
+        // Shutdown fence: destroy() 已开始时不再入队重试，避免在已清空/销毁的
+        // 队列中留下不可消费的内存条目（与 batch/queue 的 catch 对齐）。
+        if (this.shuttingDown) {
+          Logger.info(`[${sessionKey}] destroy 已开始，跳过子智能体反馈失败重试`);
+        } else {
+          this.enqueueSubAgentFeedback(sessionKey, topic, senderId, text, executionScope, 1, clearGeneration);
+          Logger.warning(`[${sessionKey}] 子智能体反馈执行异常，已入队重试: ${err?.message || err}`);
+        }
       }
 
     } finally {

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -2044,9 +2044,25 @@ export class CatsCompanyBot {
   }
 
   /**
-   * 处理子智能体反馈注入
+   * 处理子智能体反馈注入。
+   *
+   * 入口统一收口到 shutdown fence + in-flight 计数：子智能体完成回调可能在
+   * destroy() 开始后才触发，这里必须保证它既不能启动新的模型回合，也要被
+   * destroy() 的 quiesce 等待（见 runTrackedConversationWork）。
    */
   private async handleSubAgentFeedback(
+    sessionKey: string,
+    topic: string,
+    senderId: string,
+    text: string,
+    executionScope?: ParsedCatsMessage['executionScope'],
+    clearGeneration = this.getSessionClearGeneration(sessionKey),
+  ): Promise<void> {
+    await this.runTrackedConversationWork(() =>
+      this.handleSubAgentFeedbackInner(sessionKey, topic, senderId, text, executionScope, clearGeneration));
+  }
+
+  private async handleSubAgentFeedbackInner(
     sessionKey: string,
     topic: string,
     senderId: string,
@@ -2214,7 +2230,17 @@ export class CatsCompanyBot {
     this.subAgentCompletionBatches.set(sessionKey, batch);
   }
 
+  /**
+   * 批量回流子智能体完成结果。同样经统一 shutdown fence + in-flight 计数收口：
+   * completion-batch timer 可能在 destroy() 开始后才触发，这里必须保证既不能
+   * 启动新的模型回合，也要被 destroy() 的 quiesce 等待。
+   */
   private async flushSubAgentCompletionBatch(sessionKey: string, force = false): Promise<void> {
+    await this.runTrackedConversationWork(() =>
+      this.flushSubAgentCompletionBatchInner(sessionKey, force));
+  }
+
+  private async flushSubAgentCompletionBatchInner(sessionKey: string, force = false): Promise<void> {
     const batch = this.subAgentCompletionBatches.get(sessionKey);
     if (!batch || batch.items.size === 0) return;
     if (batch.clearGeneration !== this.getSessionClearGeneration(sessionKey)) {
@@ -2527,6 +2553,8 @@ export class CatsCompanyBot {
     channelSource?: string,
     sessionKey?: string,
   ): Promise<void> {
+    // Shutdown fence: destroy() 开始后不再向外部发送子智能体运行时事件。
+    if (this.shuttingDown) return;
     const subAgentId = String(event?.subAgentId || info?.id || '');
     if (!subAgentId) return;
 
@@ -3037,6 +3065,24 @@ export class CatsCompanyBot {
     const deadline = Date.now() + timeoutMs;
     while (this.activeMessageHandlers > 0 && Date.now() < deadline) {
       await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+  }
+
+  /**
+   * Runs a unit of conversation work under the shutdown fence and the shared
+   * in-flight handler count, so destroy() both fences new work and quiesces
+   * work that already started. Every path that can start a model turn (user
+   * turns, queued drains, sub-agent completion feedback and completion-batch
+   * flushes) must enter through here; destroy() waits for this counter.
+   */
+  private async runTrackedConversationWork<T>(work: () => Promise<T>): Promise<T | undefined> {
+    // Shutdown fence: no new model work may start after destroy() begins.
+    if (this.shuttingDown) return undefined;
+    this.activeMessageHandlers += 1;
+    try {
+      return await work();
+    } finally {
+      this.activeMessageHandlers = Math.max(0, this.activeMessageHandlers - 1);
     }
   }
 

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -1215,8 +1215,9 @@ export class CatsCompanyBot {
       ? opts.clearGeneration ?? this.getSessionClearGeneration(opts.sessionKey)
       : undefined;
     const isStaleCallback = (): boolean => Boolean(
-      opts?.sessionKey
-      && callbackGeneration !== this.getSessionClearGeneration(opts.sessionKey),
+      this.shuttingDown
+      || (opts?.sessionKey
+        && callbackGeneration !== this.getSessionClearGeneration(opts.sessionKey)),
     );
     return {
       onRetry: async (attempt, maxRetries, info) => {
@@ -2342,6 +2343,12 @@ export class CatsCompanyBot {
     } catch (err: any) {
       Logger.warning(`后台子任务批量回流失败: ${err.message}`);
       if (batch.clearGeneration !== this.getSessionClearGeneration(sessionKey)) return;
+      // Shutdown fence: destroy() 已开始时不发兜底通知、不重试入队，避免越过
+      // 销毁边界继续产生副作用。
+      if (this.shuttingDown) {
+        Logger.info(`[${sessionKey}] destroy 已开始，跳过批量回流失败兜底`);
+        return;
+      }
       const fallback = this.formatSubAgentCompletionNotice(items, activeSubAgents.length);
       let fallbackDelivered = false;
       if (fallback) {
@@ -2908,6 +2915,10 @@ export class CatsCompanyBot {
       const attempts = (msg.attempts ?? 0) + 1;
       if (clearGeneration !== this.getSessionClearGeneration(sessionKey)) {
         Logger.info(`[${sessionKey}] clear 后不再重试已出队的旧消息`);
+      } else if (this.shuttingDown) {
+        // Shutdown fence: destroy() 已开始时不再重试或发送错误提示，避免越过
+        // 销毁边界继续产生副作用。
+        Logger.info(`[${sessionKey}] destroy 已开始，跳过队列消息失败重试`);
       } else if (attempts <= 2) {
         const pending = this.messageQueue.get(sessionKey) ?? [];
         pending.unshift({ ...msg, attempts });

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -1499,6 +1499,11 @@ export class CatsCompanyBot {
       }
       : undefined;
 
+    // Shutdown barrier after pre-turn awaits (cloud restore / attachment
+    // download / hydration): if destroy() started meanwhile, drop this turn and
+    // never enter the model path (review 2026-08-05).
+    if (this.shuttingDown) return;
+
     if (!this.tryReserveSessionExecution(key, session)) {
       const queue = this.messageQueue.get(key) ?? [];
       queue.push({
@@ -1545,6 +1550,11 @@ export class CatsCompanyBot {
       }
       if (shouldProcess) {
         task = this.beginConversationTask(key, msg.topic);
+        if (!task) {
+          // Shutdown barrier at the call site: never start the model after
+          // destroy() even when a pre-turn await resumed afterwards.
+          return;
+        }
         const result = await session.handleMessage(userMessage, {
           channel,
           sessionRoute,
@@ -2770,8 +2780,11 @@ export class CatsCompanyBot {
         );
       }
       if (shouldProcess) {
+        // Shutdown barrier: destroy() may have started while queued work ran.
+        if (this.shuttingDown) return;
         if (msg.source === 'user') {
           task = this.beginConversationTask(sessionKey, msg.topic);
+          if (!task) return;
         }
         const result = msg.source === 'subagent_feedback'
           ? await session.handleRuntimeObservation(msg.userMessage as string, {
@@ -2997,6 +3010,10 @@ export class CatsCompanyBot {
       if (batch.timer) clearTimeout(batch.timer);
     }
     this.subAgentCompletionBatches.clear();
+    // Quiesce in-flight handlers so pre-turn awaits (attachment download /
+    // cloud restore / hydration) that resume after shutdown cannot start the
+    // model (review 2026-08-05).
+    await this.waitForActiveHandlersToQuiesce();
     await this.sessionManager.destroy();
     await this.finishActiveConversationTasksForShutdown();
     this.bot.disconnect();
@@ -3009,6 +3026,18 @@ export class CatsCompanyBot {
       });
     }
     Logger.info('CatsCo agent 已停止');
+  }
+
+  /**
+   * Waits (with a bounded timeout) for in-flight message handlers to finish so
+   * destroy() can take a final snapshot after pre-turn awaits have quiesced.
+   */
+  private async waitForActiveHandlersToQuiesce(timeoutMs = 3000): Promise<void> {
+    if (this.activeMessageHandlers <= 0) return;
+    const deadline = Date.now() + timeoutMs;
+    while (this.activeMessageHandlers > 0 && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
   }
 
   private enqueuePendingAttachment(sessionKey: string, attachment: PendingAttachment): number {

--- a/src/catscompany/message-sender.ts
+++ b/src/catscompany/message-sender.ts
@@ -10,7 +10,7 @@ const MAX_REPLY_SEGMENT_LENGTH = 1200;
 
 type CatsMessageType = 'thinking' | 'tool_use' | 'tool_result' | 'runtime_plan' | 'task_status' | 'text' | 'image' | 'file';
 
-export type ConversationTaskState = 'running' | 'completed' | 'failed' | 'cancelled';
+export type ConversationTaskState = 'running' | 'completed' | 'failed' | 'cancelled' | 'stale';
 
 export interface ConversationTaskStatusInput {
   run_id: string;

--- a/src/core/message-session-manager.ts
+++ b/src/core/message-session-manager.ts
@@ -176,4 +176,16 @@ export class MessageSessionManager {
     this.sessions.clear();
     MessageSessionManager.managers.delete(this.sessionType);
   }
+
+  /**
+   * 中断所有会话当前在飞的模型回合（requestInterrupt 会 abort 会话的
+   * activeAbortController，让 handleMessage / handleRuntimeObservation 尽快
+   * 返回取消结果）。用于 connector shutdown：quiesce 之前显式中断，避免在飞
+   * 模型回合跨越销毁边界继续落地结果。
+   */
+  interruptAll(reason = 'connector shutdown'): void {
+    for (const session of this.sessions.values()) {
+      session.requestInterrupt();
+    }
+  }
 }

--- a/tests/catscompany-content-blocks.test.ts
+++ b/tests/catscompany-content-blocks.test.ts
@@ -406,6 +406,65 @@ describe('CatsCo content blocks', () => {
     assert.strictEqual(bot.activeConversationTasks.size, 0);
   });
 
+  test('queued work must not start after the shutdown snapshot (delayed status send)', async () => {
+    const { bot, taskStatuses, handledTurns } = createProcessHarness();
+    const order: string[] = [];
+    const releaseStatuses: Array<() => void> = [];
+
+    bot.shuttingDown = false;
+    bot.connectorReady = true;
+    // 1 个 active task（会进入 shutdown snapshot，被标 stale）
+    bot.activeConversationTasks = new Map([
+      ['cc_user:usr1', { runID: 'run-active', topic: 'p2p_1_2', finished: false }],
+    ]);
+    bot.taskStatusTasks = new Map();
+    // 1 个排队用户消息（shutdown 开始后不得启动）
+    bot.messageQueue.set('cc_user:usr1', [{
+      userMessage: '关闭后不应启动的排队消息',
+      topic: 'p2p_1_2',
+      senderId: 'usr1',
+      seq: 11,
+      receivedAt: Date.now(),
+      source: 'user',
+      runtimeFeedback: [],
+    }]);
+
+    // 延迟 sendTaskStatus：阻塞 stale 投递让 destroy() 卡在 wait，
+    // 给在飞 turn 的 tail drain 留出执行窗口。
+    bot.sender.sendTaskStatus = async (topic: string, status: any) => {
+      order.push(`status:${status.state}`);
+      taskStatuses.push({ topic, status });
+      await new Promise<void>((resolve) => { releaseStatuses.push(resolve); });
+    };
+    bot.sessionManager = { destroy: async () => { order.push('sessions-destroyed'); } };
+    bot.bot = { disconnect: () => { order.push('socket-disconnected'); } };
+
+    const destroyPromise = bot.destroy();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    // 模拟在飞 turn 返回后的 finally/tail drain：此时 shutdown 已开始
+    await (bot as any).drainMessageQueue('cc_user:usr1');
+    releaseStatuses.forEach((resolve) => resolve());
+    await destroyPromise;
+
+    // shutdown 开始后不得再出现 running / completed 状态
+    assert.deepStrictEqual(
+      taskStatuses.map(({ status }) => status.state),
+      ['stale'],
+    );
+    // 排队消息不得被实际处理
+    assert.strictEqual(handledTurns.length, 0);
+    // 排队工作被显式清除
+    assert.strictEqual(bot.messageQueue.has('cc_user:usr1'), false);
+    // activeConversationTasks 保持为空
+    assert.strictEqual(bot.activeConversationTasks.size, 0);
+    // destroy 顺序保持
+    assert.deepStrictEqual(order, [
+      'sessions-destroyed',
+      'status:stale',
+      'socket-disconnected',
+    ]);
+  });
+
   test('marks the task as failed when the final CatsCo reply cannot be delivered', async () => {
     const { bot, session, taskStatuses } = createProcessHarness();
     session.handleMessage = async () => ({ visibleToUser: true, text: '处理完成' });

--- a/tests/catscompany-content-blocks.test.ts
+++ b/tests/catscompany-content-blocks.test.ts
@@ -1763,6 +1763,72 @@ describe('CatsCo content blocks', () => {
       (manager as any).resultNotifyOnObservation.delete(subAgentId);
     }
   });
+
+  test('destroy drops a subagent feedback result that lands after the quiesce timeout', async () => {
+    // 回归：模型回合超过 quiesce 3s 预算时，destroy() 超时返回；随后模型结果
+    // 落地时必须被 shutdown fence 丢弃（不 reply、不入队、不 mark handled），
+    // 不能越过销毁边界继续产生副作用。
+    const { bot, runtimeObservations, replies, session } = createProcessHarness();
+    const manager = SubAgentManager.getInstance();
+    const sessionKey = 'session:v2:catscompany:p2p:p2p_38_110:agent:usr43';
+    const subAgentId = 'sub-dddddddd-dddd-4ddd-8ddd-dddddddddddd';
+    const observation = `[子agent1 已完成]\nID：${subAgentId}\n结果摘要：审查完成`;
+    const order: string[] = [];
+    let releaseObservation: (() => void) | undefined;
+    const observationGate = new Promise<void>((resolve) => { releaseObservation = resolve; });
+    session.handleRuntimeObservation = async (text: string, options: any) => {
+      runtimeObservations.push({ text, options });
+      await observationGate;
+      return { visibleToUser: true, text: '不应在 destroy 返回后落地的回流结果' };
+    };
+    bot.shuttingDown = false;
+    bot.activeMessageHandlers = 0;
+    bot.sessionExecutionReservations = new Set();
+    bot.taskStatusTasks = new Map();
+    bot.activeConversationTasks = new Map();
+    bot.sessionManager = {
+      getOrCreate: () => session,
+      get: () => session,
+      interruptAll: () => { order.push('interrupt-all'); },
+      destroy: async () => { order.push('sessions-destroyed'); },
+    };
+    bot.bot = { disconnect: () => { order.push('socket-disconnected'); } };
+    // 模拟 quiesce 预算耗尽：destroy 不再等待 in-flight handler，直接收尾返回。
+    (bot as any).waitForActiveHandlersToQuiesce = async () => {};
+
+    (manager as any).parentMap.set(subAgentId, sessionKey);
+    (manager as any).resultNotifyOnObservation.add(subAgentId);
+    try {
+      // 子智能体回流在 destroy 之前进入模型回合并挂起。
+      const feedbackPromise = (bot as any).handleSubAgentFeedback(
+        sessionKey,
+        'p2p_38_110',
+        'usr38',
+        observation,
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      assert.strictEqual(bot.activeMessageHandlers, 1);
+
+      // destroy 超时返回（quiesce 被 mock 为立即结束），connector 已断开。
+      const destroyPromise = bot.destroy();
+      await destroyPromise;
+      assert.deepStrictEqual(order, ['interrupt-all', 'sessions-destroyed', 'socket-disconnected']);
+      assert.strictEqual(bot.activeMessageHandlers, 1, 'in-flight handler 仍在跑');
+
+      // 模型回合随后返回：结果必须被 shutdown fence 丢弃。
+      releaseObservation?.();
+      await feedbackPromise;
+
+      assert.strictEqual(runtimeObservations.length, 1);
+      assert.deepStrictEqual(replies, [], 'destroy 返回后不得发送回复');
+      assert.strictEqual(bot.activeMessageHandlers, 0);
+      // 未 mark handled：sub-agent 结果没有在 shutdown 后被标记为已消费。
+      assert.equal((manager as any).resultNotifyOnObservation.has(subAgentId), true);
+    } finally {
+      (manager as any).parentMap.delete(subAgentId);
+      (manager as any).resultNotifyOnObservation.delete(subAgentId);
+    }
+  });
 });
 
 function escapeRegExp(value: string): string {

--- a/tests/catscompany-content-blocks.test.ts
+++ b/tests/catscompany-content-blocks.test.ts
@@ -465,6 +465,53 @@ describe('CatsCo content blocks', () => {
     ]);
   });
 
+  test('in-flight pre-turn download does not start the model after destroy', async () => {
+    const { bot, session, taskStatuses, handledTurns } = createProcessHarness();
+    bot.shuttingDown = false;
+    bot.connectorReady = true;
+    bot.activeConversationTasks = new Map();
+    bot.taskStatusTasks = new Map();
+    bot.activeMessageHandlers = 1; // 模拟一个 in-flight handler
+
+    // 附件下载是 pre-turn await：handler 会暂停在 downloadFile 上
+    let releaseDownload: (() => void) | undefined;
+    const downloadGate = new Promise<void>((resolve) => { releaseDownload = resolve; });
+    bot.sender.downloadFile = async () => {
+      await downloadGate;
+      return 'C:\\tmp\\catsco-test\\a.png';
+    };
+    bot.sessionManager = { getOrCreate: () => session, get: () => session };
+
+    const turnPromise = (bot as any).processParsedMessage({
+      topic: 'p2p_1_2',
+      chatType: 'p2p',
+      senderId: 'usr1',
+      seq: 12,
+      text: '看看附件',
+      rawContent: '看看附件',
+      files: [{ url: '/uploads/images/a.png', fileName: 'a.png', type: 'image' }],
+    }, 'cc_user:usr1');
+    // handler 进入下载暂停
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // shutdown 在下载期间开始
+    bot.bot = { disconnect: () => {} };
+    bot.sessionManager.destroy = async () => {};
+    const destroyPromise = bot.destroy();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // 释放下载 → 旧 handler 恢复，但不得进入模型路径
+    releaseDownload?.();
+    await turnPromise;
+    bot.activeMessageHandlers = 0; // handler 完成
+    await destroyPromise;
+
+    // 模型从未被调用，也没有任何 running/terminal 状态
+    assert.strictEqual(handledTurns.length, 0);
+    assert.deepStrictEqual(taskStatuses.map(({ status }) => status.state), []);
+    assert.strictEqual(bot.activeConversationTasks.size, 0);
+  });
+
   test('marks the task as failed when the final CatsCo reply cannot be delivered', async () => {
     const { bot, session, taskStatuses } = createProcessHarness();
     session.handleMessage = async () => ({ visibleToUser: true, text: '处理完成' });

--- a/tests/catscompany-content-blocks.test.ts
+++ b/tests/catscompany-content-blocks.test.ts
@@ -1635,6 +1635,119 @@ describe('CatsCo content blocks', () => {
     assert.strictEqual(replies.length, 1);
     assert.match(replies[0].text, /子 agent 结果处理失败/);
   });
+
+  test('subagent completion feedback does not start the model after destroy', async () => {
+    const { bot, runtimeObservations, session } = createProcessHarness();
+    const sessionKey = 'session:v2:catscompany:p2p:p2p_38_110:agent:usr43';
+    session.handleRuntimeObservation = async (text: string, options: any) => {
+      runtimeObservations.push({ text, options });
+      return { visibleToUser: true, text: '不应出现在 destroy 之后' };
+    };
+    bot.shuttingDown = true;
+    bot.activeMessageHandlers = 0;
+    bot.sessionExecutionReservations = new Set();
+    bot.taskStatusTasks = new Map();
+
+    await (bot as any).handleSubAgentFeedback(
+      sessionKey,
+      'p2p_38_110',
+      'usr38',
+      '[子agent1 已完成]\n任务：审查\n结果摘要：审查完成',
+    );
+
+    assert.deepStrictEqual(runtimeObservations, []);
+    assert.strictEqual(bot.activeMessageHandlers, 0);
+  });
+
+  test('subagent completion batch flush does not start the model after destroy', async () => {
+    const { bot, runtimeObservations, session } = createProcessHarness();
+    const sessionKey = 'session:v2:catscompany:p2p:p2p_38_110:agent:usr43';
+    session.handleRuntimeObservation = async (text: string, options: any) => {
+      runtimeObservations.push({ text, options });
+      return { visibleToUser: true, text: '不应出现在 destroy 之后' };
+    };
+    bot.shuttingDown = true;
+    bot.activeMessageHandlers = 0;
+    bot.sessionExecutionReservations = new Set();
+    bot.taskStatusTasks = new Map();
+    // 预置一个 completion batch（模拟 destroy 开始前已积累的批量回流）
+    bot.subAgentCompletionBatches.set(sessionKey, {
+      topic: 'p2p_38_110',
+      senderId: 'usr38',
+      channelSource: undefined,
+      executionScope: undefined,
+      firstAt: Date.now(),
+      clearGeneration: 0,
+      items: new Map([['item-1', {
+        id: 'item-1',
+        displayName: '子agent1',
+        task: '审查',
+        observation: '[子agent1 已完成]\n结果摘要：审查完成',
+        status: 'completed',
+      }]]),
+    });
+
+    await (bot as any).flushSubAgentCompletionBatch(sessionKey, true);
+
+    assert.deepStrictEqual(runtimeObservations, []);
+    assert.strictEqual(bot.activeMessageHandlers, 0);
+    // destroy 开始后 batch 未被消费，仍留在 map 中由 destroy 统一清理
+    assert.ok(bot.subAgentCompletionBatches.has(sessionKey));
+  });
+
+  test('destroy waits for in-flight subagent completion feedback before finalizing', async () => {
+    const { bot, runtimeObservations, session } = createProcessHarness();
+    const manager = SubAgentManager.getInstance();
+    const sessionKey = 'session:v2:catscompany:p2p:p2p_38_110:agent:usr43';
+    const subAgentId = 'sub-cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+    const observation = `[子agent1 已完成]\nID：${subAgentId}\n结果摘要：审查完成`;
+    const order: string[] = [];
+    let releaseObservation: (() => void) | undefined;
+    const observationGate = new Promise<void>((resolve) => { releaseObservation = resolve; });
+    session.handleRuntimeObservation = async (text: string, options: any) => {
+      runtimeObservations.push({ text, options });
+      await observationGate;
+      return { visibleToUser: true, text: '回流完成' };
+    };
+    bot.shuttingDown = false;
+    bot.activeMessageHandlers = 0;
+    bot.sessionExecutionReservations = new Set();
+    bot.taskStatusTasks = new Map();
+    bot.activeConversationTasks = new Map();
+    bot.sessionManager = {
+      getOrCreate: () => session,
+      get: () => session,
+      destroy: async () => { order.push('sessions-destroyed'); },
+    };
+    bot.bot = { disconnect: () => { order.push('socket-disconnected'); } };
+
+    (manager as any).parentMap.set(subAgentId, sessionKey);
+    (manager as any).resultNotifyOnObservation.add(subAgentId);
+    try {
+      // 子智能体回流在 destroy 之前已进入（暂停在 handleRuntimeObservation）
+      const feedbackPromise = (bot as any).handleSubAgentFeedback(
+        sessionKey,
+        'p2p_38_110',
+        'usr38',
+        observation,
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      assert.strictEqual(bot.activeMessageHandlers, 1);
+
+      // destroy 开始：必须等待 in-flight 回流完成后再 disconnect
+      const destroyPromise = bot.destroy();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      releaseObservation?.();
+      await Promise.all([feedbackPromise, destroyPromise]);
+
+      assert.strictEqual(runtimeObservations.length, 1);
+      assert.deepStrictEqual(order, ['sessions-destroyed', 'socket-disconnected']);
+      assert.strictEqual(bot.activeMessageHandlers, 0);
+    } finally {
+      (manager as any).parentMap.delete(subAgentId);
+      (manager as any).resultNotifyOnObservation.delete(subAgentId);
+    }
+  });
 });
 
 function escapeRegExp(value: string): string {

--- a/tests/catscompany-content-blocks.test.ts
+++ b/tests/catscompany-content-blocks.test.ts
@@ -1638,7 +1638,12 @@ describe('CatsCo content blocks', () => {
 
   test('subagent completion feedback does not start the model after destroy', async () => {
     const { bot, runtimeObservations, session } = createProcessHarness();
+    const manager = SubAgentManager.getInstance();
     const sessionKey = 'session:v2:catscompany:p2p:p2p_38_110:agent:usr43';
+    const subAgentId = 'sub-aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+    // notify 场景：observation 带 ID 且 resultNotifyOnObservation 命中，必然走
+    // handleRuntimeObservation 模型分支。若 fence 失效，本测试必然失败。
+    const observation = `[子agent1 已完成]\nID：${subAgentId}\n结果摘要：审查完成`;
     session.handleRuntimeObservation = async (text: string, options: any) => {
       runtimeObservations.push({ text, options });
       return { visibleToUser: true, text: '不应出现在 destroy 之后' };
@@ -1648,15 +1653,22 @@ describe('CatsCo content blocks', () => {
     bot.sessionExecutionReservations = new Set();
     bot.taskStatusTasks = new Map();
 
-    await (bot as any).handleSubAgentFeedback(
-      sessionKey,
-      'p2p_38_110',
-      'usr38',
-      '[子agent1 已完成]\n任务：审查\n结果摘要：审查完成',
-    );
+    (manager as any).parentMap.set(subAgentId, sessionKey);
+    (manager as any).resultNotifyOnObservation.add(subAgentId);
+    try {
+      await (bot as any).handleSubAgentFeedback(
+        sessionKey,
+        'p2p_38_110',
+        'usr38',
+        observation,
+      );
 
-    assert.deepStrictEqual(runtimeObservations, []);
-    assert.strictEqual(bot.activeMessageHandlers, 0);
+      assert.deepStrictEqual(runtimeObservations, []);
+      assert.strictEqual(bot.activeMessageHandlers, 0);
+    } finally {
+      (manager as any).parentMap.delete(subAgentId);
+      (manager as any).resultNotifyOnObservation.delete(subAgentId);
+    }
   });
 
   test('subagent completion batch flush does not start the model after destroy', async () => {
@@ -1734,9 +1746,12 @@ describe('CatsCo content blocks', () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
       assert.strictEqual(bot.activeMessageHandlers, 1);
 
-      // destroy 开始：必须等待 in-flight 回流完成后再 disconnect
+      // destroy 开始：必须等待 in-flight 回流完成后再 disconnect。
       const destroyPromise = bot.destroy();
       await new Promise((resolve) => setTimeout(resolve, 0));
+      // 在释放回流之前，destroy 必须仍在 quiesce 等待，不得提前 disconnect /
+      // 销毁 session（否则等待语义不成立）。
+      assert.deepStrictEqual(order, [], `destroy finalized before in-flight subagent feedback: ${order.join(',')}`);
       releaseObservation?.();
       await Promise.all([feedbackPromise, destroyPromise]);
 

--- a/tests/catscompany-content-blocks.test.ts
+++ b/tests/catscompany-content-blocks.test.ts
@@ -360,6 +360,52 @@ describe('CatsCo content blocks', () => {
     assert.strictEqual(taskStatuses[0].status.run_id, taskStatuses[1].status.run_id);
   });
 
+  test('finishes active task status before disconnecting during shutdown', async () => {
+    const { bot, taskStatuses } = createProcessHarness();
+    const order: string[] = [];
+    bot.shuttingDown = false;
+    bot.connectorReady = true;
+    bot.activeConversationTasks = new Map([
+      ['cc_user:usr1', {
+        runID: 'run-shutdown',
+        topic: 'p2p_1_2',
+        finished: false,
+      }],
+    ]);
+    bot.taskStatusTasks = new Map();
+    bot.sender.sendTaskStatus = async (topic: string, status: any) => {
+      order.push(`status:${status.state}`);
+      taskStatuses.push({ topic, status });
+    };
+    bot.sessionManager = {
+      destroy: async () => {
+        order.push('sessions-destroyed');
+      },
+    };
+    bot.bot = {
+      disconnect: () => {
+        order.push('socket-disconnected');
+      },
+    };
+
+    await bot.destroy();
+
+    assert.deepStrictEqual(order, [
+      'sessions-destroyed',
+      'status:stale',
+      'socket-disconnected',
+    ]);
+    assert.deepStrictEqual(
+      taskStatuses.map(({ topic, status }) => ({
+        topic,
+        runID: status.run_id,
+        state: status.state,
+      })),
+      [{ topic: 'p2p_1_2', runID: 'run-shutdown', state: 'stale' }],
+    );
+    assert.strictEqual(bot.activeConversationTasks.size, 0);
+  });
+
   test('marks the task as failed when the final CatsCo reply cannot be delivered', async () => {
     const { bot, session, taskStatuses } = createProcessHarness();
     session.handleMessage = async () => ({ visibleToUser: true, text: '处理完成' });

--- a/tests/catscompany-content-blocks.test.ts
+++ b/tests/catscompany-content-blocks.test.ts
@@ -171,6 +171,41 @@ describe('CatsCo content blocks', () => {
     assert.equal(sentThinking[0].metadata.delay_ms, 8000);
   });
 
+  test('session callbacks do not emit progress after destroy', async () => {
+    // 回归：destroy() 已开始时，模型流式/进度回调（assistant text、thinking、
+    // tool start/end、retry）不得再向外部发送任何内容（review 2026-08-05）。
+    const { bot, replies, sentThinking, sentTexts, toolUses, toolResults } = createProcessHarness();
+    const callbacks = (bot as any).buildSessionCallbacks('p2p_shutdown');
+
+    // 正常路径先验证一次能发送（确认 callbacks 本身可用）。
+    await callbacks.onAssistantText('正常流式文本');
+    assert.equal(replies.length, 1);
+    assert.equal(replies[0].topic, 'p2p_shutdown');
+    assert.equal(replies[0].text, '正常流式文本');
+
+    // destroy 已开始：所有回调必须静默。
+    bot.shuttingDown = true;
+    await callbacks.onAssistantText('destroy 后不应出现的流式文本');
+    await callbacks.onThinking('destroy 后不应出现的思考');
+    await callbacks.onRetry(1, 2, {
+      attempt: 1,
+      maxRetries: 2,
+      delayMs: 1000,
+      elapsedMs: 1000,
+      maxElapsedMs: 60000,
+      status: 500,
+      message: 'upstream error',
+    });
+    await callbacks.onToolStart('execute_shell', 'tool-1', { command: 'echo hi' });
+    await callbacks.onToolEnd('execute_shell', 'tool-1', 'done');
+
+    assert.equal(replies.length, 1, 'destroy 后不得发送 assistant text');
+    assert.equal(sentThinking.length, 0, 'destroy 后不得发送 thinking');
+    assert.equal(sentTexts.length, 0);
+    assert.equal(toolUses.length, 0, 'destroy 后不得发送 tool use');
+    assert.equal(toolResults.length, 0, 'destroy 后不得发送 tool result');
+  });
+
   test('parses text and multiple attachments from one CatsCompany message', () => {
     const bot = Object.create(CatsCompanyBot.prototype);
 

--- a/tests/catscompany-device-rpc-tools.test.ts
+++ b/tests/catscompany-device-rpc-tools.test.ts
@@ -483,4 +483,135 @@ describe('CatsCompany Device RPC file tools', () => {
     assert.equal(captured.result.result, undefined);
     assert.equal(captured.result.error.code, 'target_device_mismatch');
   });
+
+  test('rejects new Device RPC requests once shutdown has started (P1 regression)', async () => {
+    // Review 2026-08-06: shuttingDown=true must fence both the listener and the
+    // handler so a remote request cannot execute write_file/edit_file/execute_shell
+    // on the machine during the destroy window.
+    const captured: { result?: any } = {};
+    let executed = 0;
+    const bot = Object.create(CatsCompanyBot.prototype) as any;
+    bot.shuttingDown = true;
+    bot.localDeviceGrant = {
+      kind: 'catscompany_body',
+      source: 'catscompany',
+      ownerUserId: 'usr7',
+      bodyId: 'body-device',
+      installationId: 'install-device',
+      deviceId: 'install-device',
+      createdAt: Date.now(),
+    };
+    bot.bot = {
+      sendDeviceRpcResult: async (result: any) => {
+        captured.result = result;
+      },
+    };
+    bot.executeLocalDeviceRpcTool = async () => {
+      executed += 1;
+      return { ok: true, content: 'should-not-run' };
+    };
+
+    await bot.handleDeviceRpcRequest(request({
+      request_id: 'rpc-shutdown-1',
+      operation: 'write_file',
+      tool_name: 'write_file',
+      payload: { args: { file_path: path.join(testRoot, 'tmp', 'shutdown-write.txt'), content: 'nope' } },
+    }));
+
+    assert.equal(executed, 0, 'device RPC tool must not execute after shutdown started');
+    assert.equal(captured.result, undefined, 'device RPC result must not be sent after shutdown started');
+  });
+
+  test('rejects new thin-tool RPC requests once shutdown has started (P1 regression)', async () => {
+    const captured: { result?: any } = {};
+    let executed = 0;
+    const bot = Object.create(CatsCompanyBot.prototype) as any;
+    bot.shuttingDown = true;
+    bot.bot = {
+      sendThinToolRpcResult: async (result: any) => {
+        captured.result = result;
+      },
+    };
+    bot.executeLocalThinToolRpcTool = async () => {
+      executed += 1;
+      return { ok: true, content: 'should-not-run' };
+    };
+
+    await bot.handleThinToolRpcRequest({
+      type: 'request',
+      request_id: 'rpc-shutdown-t1',
+      tool_name: 'write_file',
+      target_owner_user_id: 'usr7',
+      target_device_id: 'install-remote',
+      device_id: 'install-device',
+      payload: { args: { file_path: 'x', content: 'nope' } },
+      created_at: Date.now(),
+      expires_at: Date.now() + 60_000,
+    } as any);
+
+    assert.equal(executed, 0, 'thin-tool RPC tool must not execute after shutdown started');
+    assert.equal(captured.result, undefined, 'thin-tool RPC result must not be sent after shutdown started');
+  });
+
+  test('drops a late Device RPC result when shutdown starts during execution', async () => {
+    const captured: { result?: any } = {};
+    const bot = Object.create(CatsCompanyBot.prototype) as any;
+    bot.shuttingDown = false;
+    bot.localDeviceGrant = {
+      kind: 'catscompany_body',
+      source: 'catscompany',
+      ownerUserId: 'usr7',
+      bodyId: 'body-device',
+      installationId: 'install-device',
+      deviceId: 'install-device',
+      createdAt: Date.now(),
+    };
+    bot.bot = {
+      sendDeviceRpcResult: async (result: any) => {
+        captured.result = result;
+      },
+    };
+    bot.executeLocalDeviceRpcTool = async () => {
+      // destroy() 在工具执行期间开始（quiesce 超时后继续）。
+      bot.shuttingDown = true;
+      return { ok: true, content: 'executed' };
+    };
+
+    await bot.handleDeviceRpcRequest(request({
+      request_id: 'rpc-late-1',
+      operation: 'read_file',
+      tool_name: 'read_file',
+    }));
+
+    assert.equal(captured.result, undefined, 'late device RPC result must not be sent after shutdown started');
+  });
+
+  test('drops a late thin-tool RPC result when shutdown starts during execution', async () => {
+    const captured: { result?: any } = {};
+    const bot = Object.create(CatsCompanyBot.prototype) as any;
+    bot.shuttingDown = false;
+    bot.bot = {
+      sendThinToolRpcResult: async (result: any) => {
+        captured.result = result;
+      },
+    };
+    bot.executeLocalThinToolRpcTool = async () => {
+      bot.shuttingDown = true;
+      return { ok: true, content: 'executed' };
+    };
+
+    await bot.handleThinToolRpcRequest({
+      type: 'request',
+      request_id: 'rpc-late-t1',
+      tool_name: 'read_file',
+      target_owner_user_id: 'usr7',
+      target_device_id: 'install-remote',
+      device_id: 'install-device',
+      payload: { args: { file_path: 'x' } },
+      created_at: Date.now(),
+      expires_at: Date.now() + 60_000,
+    } as any);
+
+    assert.equal(captured.result, undefined, 'late thin-tool RPC result must not be sent after shutdown started');
+  });
 });


### PR DESCRIPTION
## 概述

CatsCo 连接器（CatsCompanyBot）在**关闭/重启时**把进行中的会话任务标记为 `stale`，避免任务永远卡在 running。与 cats-company PR #141（服务端断连兜底）配套，覆盖两类场景。

## 改动内容

- `src/catscompany/index.ts`：
  - 新增 `shuttingDown` 标志，关闭期间忽略新消息
  - 新增 `finishActiveConversationTasksForShutdown(timeoutMs=3000)`：把进行中的会话任务统一标记为 `stale`（"Agent 正在重启，本次任务已自动中止，可重新发送"），并等状态发送完成（带超时）
  - 调整 `destroy()` 顺序：**先销毁会话 → 发 stale 状态 → 最后断开 ws**（原来一上来就断连，任务会卡在 running）
  - `destroy()` 幂等（重复调用直接返回）
- `src/catscompany/message-sender.ts`：`ConversationTaskState` 新增 `'stale'`
- 新增测试：验证关闭顺序、stale 状态发送、任务清理

## 与 cats-company 的配合（PR #141）
| 场景 | XiaoBa（本 PR） | cats-company #141（服务端） |
|---|---|---|
| 正常重启/关闭 | ✅ 主动标 stale | — |
| 意外断连/崩溃/被强杀 | — | 90s 兜底标 stale |

## 验证
- `npm run build` 通过
- 全量 `npm test`：1359 tests / 0 fail
- 真实进程冒烟：`destroy()` 顺序 `sessions → status:stale ×2 → disconnect`、幂等、任务清除 ✅
- 已同步最新 main（含 #287、#307、#321）并合并
