### PR TITLE
fix: preserve explicit cache fallback

### DIFF
--- a/src/providers/openai-provider.ts
+++ b/src/providers/openai-provider.ts
@@ -474,40 +474,45 @@ export class OpenAIProvider implements AIProvider {
     const prefixHashes: Partial<Record<'S' | 'A' | 'B', string>> = {};
     const breakpointDiagnostics: ResponsesBreakpointDiagnostic[] = [];
 
-    const recordBreakpoint = (label: 'S' | 'A' | 'B') => {
-      const prefixHash = this.hashWirePrefix(input);
+    const recordBreakpoint = (label: 'S' | 'A' | 'B', itemIndex: number) => {
+      if (itemIndex < 0) return;
+      const prefix = input.slice(0, itemIndex + 1);
+      const prefixHash = this.hashWirePrefix(prefix);
       breakpoints.push(label);
       prefixHashes[label] = prefixHash;
       breakpointDiagnostics.push({
         label,
         prefixHash,
-        inputItems: input.length,
-        inputTokenEstimate: estimateJsonTokens(input),
+        inputItems: prefix.length,
+        inputTokenEstimate: estimateJsonTokens(prefix),
       });
     };
 
-    if (explicitCaching) {
-      input.push(this.buildBreakpointCarrier());
-      recordBreakpoint('S');
-    }
-
     input.push(...this.convertResponsesMessages(checkpointMessages));
     input.push(...this.convertResponsesMessages(completedEpisodeMessages));
-    if (explicitCaching && completedEpisodeMessages.length > 0) {
-      input.push(this.buildBreakpointCarrier());
-      recordBreakpoint('A');
-    }
+    const historicalEnd = input.length - 1;
 
+    const completedCurrentStart = input.length;
     for (const group of completedCurrentGroups) {
       input.push(...this.convertResponsesMessages(group));
     }
-    if (explicitCaching && completedCurrentGroups.length > 0) {
-      input.push(this.buildBreakpointCarrier());
-      recordBreakpoint('B');
-    }
+    const completedCurrentEnd = input.length - 1;
 
     input.push(...this.convertResponsesMessages(transientMessages));
     input.push(...this.convertResponsesMessages(latestGroup));
+
+    if (explicitCaching) {
+      const sIndex = this.attachBreakpointToRealInputText(input, 0, input.length - 1, false);
+      const aIndex = completedEpisodeMessages.length > 0
+        ? this.attachBreakpointToRealInputText(input, 0, historicalEnd, true)
+        : -1;
+      const bIndex = completedCurrentGroups.length > 0
+        ? this.attachBreakpointToRealInputText(input, completedCurrentStart, completedCurrentEnd, true)
+        : -1;
+      recordBreakpoint('S', sIndex);
+      recordBreakpoint('A', aIndex);
+      recordBreakpoint('B', bIndex);
+    }
     return { input, breakpoints, prefixHashes, breakpointDiagnostics };
   }
 
@@ -583,15 +588,45 @@ export class OpenAIProvider implements AIProvider {
       || message.__syntheticObservation === true;
   }
 
-  private buildBreakpointCarrier(): any {
-    return {
-      role: 'system',
-      content: [{
-        type: 'input_text',
-        text: '\n',
-        prompt_cache_breakpoint: { mode: 'explicit' },
-      }],
-    };
+  private attachBreakpointToRealInputText(
+    input: any[],
+    startIndex: number,
+    endIndex: number,
+    reverse: boolean,
+  ): number {
+    if (startIndex > endIndex) return -1;
+    const step = reverse ? -1 : 1;
+    for (
+      let itemIndex = reverse ? endIndex : startIndex;
+      reverse ? itemIndex >= startIndex : itemIndex <= endIndex;
+      itemIndex += step
+    ) {
+      const item = input[itemIndex];
+      for (const field of ['content', 'output'] as const) {
+        const value = item?.[field];
+        if (typeof value === 'string' && value.length > 0) {
+          item[field] = [{
+            type: 'input_text',
+            text: value,
+            prompt_cache_breakpoint: { mode: 'explicit' },
+          }];
+          return itemIndex;
+        }
+        if (!Array.isArray(value)) continue;
+        const blocks = reverse ? [...value].reverse() : value;
+        const block = blocks.find(candidate => (
+          candidate?.type === 'input_text'
+          && typeof candidate.text === 'string'
+          && candidate.text.length > 0
+          && !candidate.prompt_cache_breakpoint
+        ));
+        if (block) {
+          block.prompt_cache_breakpoint = { mode: 'explicit' };
+          return itemIndex;
+        }
+      }
+    }
+    return -1;
   }
 
   private isDynamicCacheMessage(message: Message): boolean {

--- a/src/providers/openai-provider.ts
+++ b/src/providers/openai-provider.ts
@@ -889,14 +889,8 @@ export class OpenAIProvider implements AIProvider {
       });
     } catch (error) {
       if (!this.shouldRetryWithoutExplicitCaching(error, body)) throw error;
-      this.responsesExplicitCacheSupported = false;
-      Logger.warning('Responses endpoint rejected explicit prompt caching; retrying stream once in compatibility mode.');
-      body = this.buildResponsesRequestBody(messages, tools, true, options, true);
-      response = await axios.post(this.responsesUrl, body, {
-        headers: this.headers,
-        responseType: 'stream',
-        signal: options?.signal,
-      });
+      Logger.warning('Responses stream rejected explicit prompt caching; retrying once as a non-stream explicit request.');
+      return this.retryResponsesStreamAsNonStream(messages, tools, callbacks, options);
     }
 
     return new Promise<ChatResponse>((resolve, reject) => {
@@ -924,10 +918,9 @@ export class OpenAIProvider implements AIProvider {
         ) {
           settled = true;
           options?.signal?.removeEventListener('abort', onAbort);
-          this.responsesExplicitCacheSupported = false;
-          Logger.warning('Responses stream rejected explicit prompt caching; retrying once in compatibility mode.');
+          Logger.warning('Responses stream rejected explicit prompt caching; retrying once as a non-stream explicit request.');
           stream.destroy();
-          void this.chatStreamResponses(messages, tools, callbacks, options).then(resolve, reject);
+          void this.retryResponsesStreamAsNonStream(messages, tools, callbacks, options).then(resolve, reject);
           return;
         }
         settled = true;
@@ -1015,6 +1008,23 @@ export class OpenAIProvider implements AIProvider {
         finishError(error);
       });
     });
+  }
+
+  private async retryResponsesStreamAsNonStream(
+    messages: Message[],
+    tools?: ToolDefinition[],
+    callbacks?: StreamCallbacks,
+    options?: AIRequestOptions,
+  ): Promise<ChatResponse> {
+    try {
+      const result = await this.chatResponses(messages, tools, options);
+      if (result.content) callbacks?.onText?.(result.content);
+      callbacks?.onComplete?.(result);
+      return result;
+    } catch (error: any) {
+      callbacks?.onError?.(error);
+      throw error;
+    }
   }
 
   private buildOpenAIProviderContent(message: any): Pick<ChatResponse, 'providerContent'> {

--- a/tests/openai-provider-explicit-cache.test.ts
+++ b/tests/openai-provider-explicit-cache.test.ts
@@ -222,13 +222,15 @@ test('unsupported explicit fields retry once and pin the provider to compatibili
   }
 });
 
-test('streamed unsupported explicit fields retry once in compatibility mode', async () => {
+test('streamed explicit rejection retries once as non-stream explicit and retries streaming next turn', async () => {
   const originalPost = axios.post;
   const bodies: any[] = [];
   const callbackErrors: Error[] = [];
+  const callbackText: string[] = [];
+  const callbackCompletions: any[] = [];
   (axios as any).post = async (_url: string, body: any) => {
     bodies.push(body);
-    if (bodies.length === 1) {
+    if (body.stream) {
       return {
         data: Readable.from([
           `data: ${JSON.stringify({
@@ -242,31 +244,102 @@ test('streamed unsupported explicit fields retry once in compatibility mode', as
       };
     }
     return {
-      data: Readable.from([
-        `data: ${JSON.stringify({
-          type: 'response.completed',
-          response: {
-            status: 'completed',
-            output: [{ type: 'message', content: [{ type: 'output_text', text: 'OK' }] }],
-          },
-        })}\n\n`,
-      ]),
+      data: {
+        status: 'completed',
+        output: [{ type: 'message', content: [{ type: 'output_text', text: 'OK' }] }],
+      },
     };
   };
   try {
     const instance = provider();
+    const callbacks = {
+      onText: (text: string) => callbackText.push(text),
+      onComplete: (result: any) => callbackCompletions.push(result),
+      onError: (error: Error) => callbackErrors.push(error),
+    };
     const result = await instance.chatStream(
       [{ role: 'user', content: 'hello', __episodeId: 'episode-2' }],
       [],
-      { onError: error => callbackErrors.push(error) },
+      callbacks,
       context,
     );
     assert.equal(result.content, 'OK');
     assert.equal(bodies.length, 2);
+    assert.equal(bodies[0].stream, true);
+    assert.equal(bodies[1].stream, false);
     assert.deepEqual(bodies[0].prompt_cache_options, { mode: 'explicit' });
-    assert.equal(bodies[1].prompt_cache_options, undefined);
-    assert.equal(countBreakpoints(bodies[1].input), 0);
+    assert.deepEqual(bodies[1].prompt_cache_options, { mode: 'explicit' });
+    assert.equal(countBreakpoints(bodies[0].input), 1);
+    assert.equal(countBreakpoints(bodies[1].input), 1);
+    assert.deepEqual(callbackText, ['OK']);
+    assert.equal(callbackCompletions.length, 1);
     assert.deepEqual(callbackErrors, []);
+
+    await instance.chatStream(
+      [{ role: 'user', content: 'next', __episodeId: 'episode-2' }],
+      [],
+      undefined,
+      context,
+    );
+    assert.equal(bodies.length, 4);
+    assert.equal(bodies[2].stream, true);
+    assert.deepEqual(bodies[2].prompt_cache_options, { mode: 'explicit' });
+    assert.equal(countBreakpoints(bodies[2].input), 1);
+    assert.equal(bodies[3].stream, false);
+    assert.deepEqual(bodies[3].prompt_cache_options, { mode: 'explicit' });
+  } finally {
+    (axios as any).post = originalPost;
+  }
+});
+
+test('non-stream explicit fallback preserves tool calls for the existing tool loop', async () => {
+  const originalPost = axios.post;
+  const bodies: any[] = [];
+  const callbackText: string[] = [];
+  (axios as any).post = async (_url: string, body: any) => {
+    bodies.push(body);
+    if (body.stream) {
+      return {
+        data: Readable.from([
+          `data: ${JSON.stringify({
+            type: 'response.failed',
+            response: {
+              status: 'failed',
+              error: { message: 'prompt_cache_breakpoint is not supported on this model' },
+            },
+          })}\n\n`,
+        ]),
+      };
+    }
+    return {
+      data: {
+        status: 'completed',
+        output: [{
+          type: 'function_call',
+          call_id: 'call-fallback',
+          name: 'lookup',
+          arguments: '{"id":"one"}',
+        }],
+      },
+    };
+  };
+  try {
+    const result = await provider().chatStream(
+      [{ role: 'user', content: 'lookup one', __episodeId: 'episode-2' }],
+      [{ name: 'lookup', description: 'Lookup an item', parameters: { type: 'object' } }],
+      { onText: text => callbackText.push(text) },
+      context,
+    );
+    assert.equal(bodies.length, 2);
+    assert.equal(bodies[1].stream, false);
+    assert.deepEqual(bodies[1].prompt_cache_options, { mode: 'explicit' });
+    assert.equal(result.content, null);
+    assert.deepEqual(result.toolCalls, [{
+      id: 'call-fallback',
+      type: 'function',
+      function: { name: 'lookup', arguments: '{"id":"one"}' },
+    }]);
+    assert.deepEqual(callbackText, []);
   } finally {
     (axios as any).post = originalPost;
   }

--- a/tests/openai-provider-explicit-cache.test.ts
+++ b/tests/openai-provider-explicit-cache.test.ts
@@ -32,6 +32,34 @@ function countBreakpoints(value: unknown): number {
     + Object.values(record).reduce((sum, item) => sum + countBreakpoints(item), 0);
 }
 
+function breakpointTexts(value: unknown): string[] {
+  if (!value || typeof value !== 'object') return [];
+  if (Array.isArray(value)) return value.flatMap(item => breakpointTexts(item));
+  const record = value as Record<string, unknown>;
+  const current = record.prompt_cache_breakpoint && record.type === 'input_text'
+    ? [String(record.text ?? '')]
+    : [];
+  return current.concat(Object.values(record).flatMap(item => breakpointTexts(item)));
+}
+
+function countInputTextBlocks(value: unknown): number {
+  if (!value || typeof value !== 'object') return 0;
+  if (Array.isArray(value)) return value.reduce((sum, item) => sum + countInputTextBlocks(item), 0);
+  const record = value as Record<string, unknown>;
+  return (record.type === 'input_text' ? 1 : 0)
+    + Object.values(record).reduce((sum, item) => sum + countInputTextBlocks(item), 0);
+}
+
+function itemText(item: any): string {
+  const value = item?.content ?? item?.output;
+  if (typeof value === 'string') return value;
+  if (!Array.isArray(value)) return '';
+  return value
+    .filter((block: any) => block?.type === 'input_text')
+    .map((block: any) => String(block.text ?? ''))
+    .join('');
+}
+
 test('Responses explicit cache emits one S, A, and latest B without persisting markers', () => {
   const messages: Message[] = [
     { role: 'system', content: 'stable system' },
@@ -52,15 +80,21 @@ test('Responses explicit cache emits one S, A, and latest B without persisting m
     { role: 'system', content: '[transient_plan_status]\nstep two', __cacheScope: 'dynamic' },
   ];
 
+  const bodyWithoutCache = (provider() as any).buildResponsesRequestBody(messages, [], false, {
+    promptCacheContext: { ...context.promptCacheContext, explicitCaching: false },
+  });
   const body = (provider() as any).buildResponsesRequestBody(messages, [], false, context);
   assert.deepEqual(body.prompt_cache_options, { mode: 'explicit' });
   assert.match(body.instructions, /stable system/);
   assert.match(body.instructions, /transient_skills_list/);
   assert.doesNotMatch(body.instructions, /transient_plan_status/);
   assert.equal(countBreakpoints(body.input), 3);
-  assert.equal(body.input[0].role, 'system');
+  assert.equal(body.input.length, bodyWithoutCache.input.length);
+  assert.equal(countInputTextBlocks(body.input), 3);
+  assert.deepEqual(breakpointTexts(body.input), ['old task', 'old answer', 'first result']);
+  assert.equal(body.input.some((item: any) => item.role === 'system' && countBreakpoints(item) > 0), false);
   assert.equal(body.input.at(-3).role, 'system');
-  assert.match(String(body.input.at(-3).content), /transient_plan_status/);
+  assert.match(itemText(body.input.at(-3)), /transient_plan_status/);
   assert.equal(body.input.at(-2).type, 'function_call');
   assert.equal(body.input.at(-1).type, 'function_call_output');
   assert.equal(messages.some(message => (message as any).prompt_cache_breakpoint), false);
@@ -87,21 +121,21 @@ test('Responses keeps a continuation checkpoint before its retained historical e
   ];
 
   const body = (provider() as any).buildResponsesRequestBody(messages, [], false, context);
-  const checkpointIndex = body.input.findIndex((item: any) => item.content === 'CONTINUATION_CHECKPOINT');
-  const oldEvidenceIndex = body.input.findIndex((item: any) => item.content === 'retained old evidence');
-  const rootIndex = body.input.findIndex((item: any) => item.content === 'current root task');
-  const planIndex = body.input.findIndex((item: any) => String(item.content).includes('transient_plan_status'));
+  const checkpointIndex = body.input.findIndex((item: any) => itemText(item) === 'CONTINUATION_CHECKPOINT');
+  const oldEvidenceIndex = body.input.findIndex((item: any) => itemText(item) === 'retained old evidence');
+  const rootIndex = body.input.findIndex((item: any) => itemText(item) === 'current root task');
+  const planIndex = body.input.findIndex((item: any) => itemText(item).includes('transient_plan_status'));
   const callIndex = body.input.findIndex((item: any) => item.type === 'function_call' && item.call_id === 'call-current');
   const breakpointIndexes = body.input
     .map((item: any, index: number) => countBreakpoints(item) > 0 ? index : -1)
     .filter((index: number) => index >= 0);
 
   assert.equal(breakpointIndexes.length, 3);
-  assert.ok(breakpointIndexes[0] < checkpointIndex);
+  assert.equal(breakpointIndexes[0], checkpointIndex);
   assert.ok(checkpointIndex < oldEvidenceIndex);
-  assert.ok(oldEvidenceIndex < breakpointIndexes[1]);
+  assert.equal(breakpointIndexes[1], body.input.findIndex((item: any) => itemText(item) === 'retained old answer'));
   assert.ok(breakpointIndexes[1] < rootIndex);
-  assert.ok(rootIndex < breakpointIndexes[2]);
+  assert.equal(breakpointIndexes[2], rootIndex);
   assert.ok(breakpointIndexes[2] < planIndex);
   assert.ok(planIndex < callIndex);
 });
@@ -137,14 +171,13 @@ test('Responses breakpoints never rewrite parallel function calls or outputs', (
   const callB = body.input.findIndex((item: any) => item.type === 'function_call' && item.call_id === 'call-b');
   const outputA = body.input.findIndex((item: any) => item.type === 'function_call_output' && item.call_id === 'call-a');
   const outputB = body.input.findIndex((item: any) => item.type === 'function_call_output' && item.call_id === 'call-b');
-  const boundaryAfterTools = body.input.findIndex((item: any, index: number) => (
-    index > outputB && countBreakpoints(item) > 0
-  ));
-
   assert.ok(callA < callB && callB < outputA && outputA < outputB);
-  assert.ok(outputB < boundaryAfterTools);
-  assert.equal(body.input[outputA].output, 'result-a');
-  assert.equal(body.input[outputB].output, 'result-b');
+  assert.equal(countBreakpoints(body.input[callA]), 0);
+  assert.equal(countBreakpoints(body.input[callB]), 0);
+  assert.equal(countBreakpoints(body.input[outputA]), 0);
+  assert.equal(countBreakpoints(body.input[outputB]), 1);
+  assert.equal(itemText(body.input[outputA]), 'result-a');
+  assert.equal(itemText(body.input[outputB]), 'result-b');
   assert.equal(JSON.stringify(messages).includes('prompt_cache_breakpoint'), false);
 });
 
@@ -162,11 +195,11 @@ test('Responses emits only the latest completed-turn breakpoint', () => {
   const breakpointIndexes = body.input
     .map((item: any, index: number) => countBreakpoints(item) > 0 ? index : -1)
     .filter((index: number) => index >= 0);
-  const secondTurnIndex = body.input.findIndex((item: any) => item.content === 'second turn');
-  const latestEventIndex = body.input.findIndex((item: any) => item.content === 'latest event');
+  const secondTurnIndex = body.input.findIndex((item: any) => itemText(item) === 'second turn');
+  const latestEventIndex = body.input.findIndex((item: any) => itemText(item) === 'latest event');
 
   assert.equal(breakpointIndexes.length, 2);
-  assert.ok(secondTurnIndex < breakpointIndexes[1]);
+  assert.equal(breakpointIndexes[1], secondTurnIndex);
   assert.ok(breakpointIndexes[1] < latestEventIndex);
 });
 


### PR DESCRIPTION
## Summary
- retry rejected Responses streams as non-stream requests while preserving explicit cache options and S/A/B boundaries
- avoid permanently disabling explicit caching so the next turn can attempt streaming again
- preserve text callbacks and tool-call responses through the existing `ChatResponse` flow

## Test plan
- [x] `node --import tsx --test tests/openai-provider-explicit-cache.test.ts`
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)