### PR TITLE
fix: 云端模型为权威，设备本地配置不再推送覆盖云端

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -9028,6 +9028,11 @@
         +'</div>';
     }
 
+    function isCloudOverrideActive(){
+      const cloud=catsState&&catsState.cloudModelOverride||null;
+      return Boolean(cloud && cloud.kind!=='local');
+    }
+
     function relayModelChoiceHtml(model, activeId, catsConnected, context='settings'){
       const id=String(model.id||model.model||'');
       const active=id===activeId;
@@ -9038,7 +9043,7 @@
         && typeof deepseekReasoningEffortLabel==='function'
         && typeof relayReasoningEffortValue==='function';
       const reasoningMeta=canShowReasoningMeta && modelSupportsReasoningSwitch(model)?' · 推理 '+deepseekReasoningEffortLabel(relayReasoningEffortValue()):'';
-      const disabled=relayActionBusy() || (context!=='chat' && !catsConnected);
+      const disabled=relayActionBusy() || (context!=='chat' && !catsConnected) || isCloudOverrideActive();
       const reasoningControl=typeof relayModelReasoningControlHtml==='function'?relayModelReasoningControlHtml(model, context):'';
       return '<div class="relay-model-choice'+(active?' active':'')+'">'
         +'<button class="relay-model-main" type="button" data-relay-model-id="'+escapeHtml(id)+'" data-relay-model-context="'+escapeHtml(context)+'" '+(disabled?'disabled':'')+' onclick="enableCatsRelayModelFromButton(this)">'
@@ -9064,7 +9069,7 @@
         ? '自定义配置 · 上下文 '+contextLabel+' · '+(provider==='openai'?'OpenAI SDK':'Anthropic SDK')+apiModeMeta+reasoningMeta
         : '去设置填写 endpoint / key';
       return '<div class="relay-model-choice '+(active?' active':'')+(configured?'':' needs-config')+'">'
-        +'<button class="relay-model-main" type="button" data-custom-startup-action="true" data-custom-startup-context="'+escapeHtml(context)+'" '+(relayActionBusy()?'disabled':'')+' onclick="enableCustomStartupModelFromButton(this)">'
+        +'<button class="relay-model-main" type="button" data-custom-startup-action="true" data-custom-startup-context="'+escapeHtml(context)+'" '+(relayActionBusy() || isCloudOverrideActive()?'disabled':'')+' onclick="enableCustomStartupModelFromButton(this)">'
         +'<span class="relay-model-label">自定义模型</span>'
         +'<span class="relay-model-name">'+escapeHtml(model)+'</span>'
         +'<span class="relay-model-meta">'+escapeHtml(meta)+'</span>'
@@ -9441,6 +9446,10 @@
 
     function enableCatsRelayModelFromButton(button, options={}){
       const context=button?.dataset?.relayModelContext || 'settings';
+      if(isCloudOverrideActive()){
+        setRelayModelApplyStatus('当前由云端模型覆盖，切回 webapp 的“设备本地配置”后才能启用本地模型。','warning',context);
+        return;
+      }
       if(!isCatsLoggedIn() && context==='chat'){
         pendingStartupSource='relay';
         pendingRelayModelId=button?.dataset?.relayModelId || selectedRelayModelId();
@@ -9459,6 +9468,10 @@
 
     function enableCustomStartupModelFromButton(button, options={}){
       const context=button?.dataset?.customStartupContext || 'chat';
+      if(isCloudOverrideActive()){
+        setRelayModelApplyStatus('当前由云端模型覆盖，切回 webapp 的“设备本地配置”后才能启用本地模型。','warning',context);
+        return;
+      }
       if(!isCatsLoggedIn() && isCustomStartupConfigured()){
         pendingStartupSource='custom';
         pendingRelayModelId='';

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -64,6 +64,7 @@ import {
   modelRuntimeToConfig,
   resolveActiveBotLLMConfig,
 } from '../../bot-definition/llm-config-resolver';
+import { pullCloudBotModelSelection } from '../../bot-definition/cloud-client';
 import {
   BOT_CATALOG_MODEL_RUNTIME_SCHEMA,
   type BotCatalogModelRuntime,
@@ -3449,17 +3450,24 @@ export function createApiRouter(
     const bodyBlocking = bodyStatus.state === 'conflict' || bodyStatus.state === 'auth_error';
     const chatReady = connected && runtime.bodyConfigured && !bodyBlocking;
     const boundBotId = String(state.botUid || '').trim();
-    const cloudDefinition = boundBotId
-      ? createBotDefinitionSyncService({ runtimeRoot: runtimeDataRoot() }).readCloudModelOverride(boundBotId)
-      : undefined;
-    const cloudModelOverride = cloudDefinition ? {
-      kind: cloudDefinition.model.kind,
-      modelId: cloudDefinition.model.kind === 'catalog' ? cloudDefinition.model.modelId : 'custom',
-      model: cloudDefinition.model.kind === 'catalog'
-        ? cloudDefinition.model.modelId
-        : cloudDefinition.model.model,
-      reasoningEffort: cloudDefinition.model.reasoningEffort || '',
-    } : null;
+    // 云端模型以 CatsCompany 服务端配置为权威。直接拉取云端当前选择，
+    // 而不是读取本地 override 文件（新契约下成功应用后本地 override 会被清除）。
+    let cloudModelOverride: Record<string, unknown> | null = null;
+    if (boundBotId && state.token) {
+      try {
+        const cloudSelection = await pullCloudBotModelSelection({ botId: boundBotId, auth: state });
+        if (cloudSelection && cloudSelection.kind !== 'local') {
+          cloudModelOverride = {
+            kind: cloudSelection.kind ?? 'catalog',
+            modelId: cloudSelection.modelId,
+            model: cloudSelection.modelId,
+            reasoningEffort: cloudSelection.reasoningEffort || '',
+          };
+        }
+      } catch (error) {
+        Logger.warning(`CatsCo 云端模型状态拉取失败，本地面板按无云端覆盖展示: ${sanitizeCatsErrorMessage(error instanceof Error ? error.message : String(error))}`);
+      }
+    }
 
     res.json({
       connected,
@@ -4128,11 +4136,14 @@ export function createApiRouter(
         definitionService.storeCatalogRuntime(
           selectedRelayCatalogRuntime(botId, selectedModel, ensured.plainKey, reasoningEffort),
         );
-        botDefinitionSync = await syncBoundBotModelToCloud(botId, {
+        // “启动模型”面板 = 设备本地配置：只更新本地 Definition，不推送云端。
+        // 云端模型以 webapp 设置为权威，设备不得用本地选择覆盖云端配置。
+        const localResult = definitionService.updateModel(botId, {
           kind: 'catalog',
           modelId: selectedModel.id,
           reasoningEffort,
         });
+        botDefinitionSync = toBotDefinitionSyncPayload(localResult) ?? undefined;
       }
       const restartInfo = activateCatsCompanyConnector(serviceManager, {
         startIfStopped: req.body?.activateConnector === true || req.body?.startConnector === true,

--- a/tests/dashboard-catsco-auth-status.test.ts
+++ b/tests/dashboard-catsco-auth-status.test.ts
@@ -432,13 +432,28 @@ describe('dashboard CatsCo account status', () => {
 
   test('GET /cats/status reports ready chat only after a confirmed local body binding', async () => {
     await startCatsServer((req, res) => {
-      assert.equal(req.header('authorization'), 'Bearer valid-user-token');
       if (req.path === '/api/me') {
+        assert.equal(req.header('authorization'), 'Bearer valid-user-token');
         return res.json({ uid: 42, username: 'webuser', display_name: 'Web User' });
       }
       if (req.path === '/api/bots/body-status') {
+        assert.equal(req.header('authorization'), 'Bearer valid-user-token');
         assert.equal(req.query.uid, '110');
         return res.json({ body_id: 'body-local', active: true });
+      }
+      if (req.path === '/api/bot/definition') {
+        assert.equal(req.header('authorization'), 'ApiKey agent-api-key');
+        return res.json({
+          configured: true,
+          revision: 3,
+          definition: {
+            schema: 'xiaoba.bot-definition.v1',
+            botId: '110',
+            model: { kind: 'catalog', modelId: 'gpt-5.6-sol', reasoningEffort: 'high' },
+            prompt: { selected: 'default' },
+            skills: [],
+          },
+        });
       }
       return res.status(404).json({ error: 'not found' });
     });
@@ -467,11 +482,6 @@ describe('dashboard CatsCo account status', () => {
         bodyId: 'body-local',
         installationId: 'body-local',
       },
-    });
-    createBotDefinitionSyncService({ runtimeRoot: testRoot }).acceptCloud('110', {
-      kind: 'catalog',
-      modelId: 'gpt-5.6-sol',
-      reasoningEffort: 'high',
     });
 
     const response = await fetch(`${dashboardBaseUrl}/api/cats/status`);

--- a/tests/dashboard-productization-html.test.ts
+++ b/tests/dashboard-productization-html.test.ts
@@ -290,6 +290,7 @@ test('relay model cards render SDK labels from model payloads', () => {
       .replace(/'/g, '&#039;'),
     formatModelContextLabel: (tokens: unknown, fallback: unknown) => fallback || `${tokens} tokens`,
     relayActionBusy: () => false,
+    isCloudOverrideActive: () => false,
     String,
   }) as (
     model: Record<string, unknown>,

--- a/tests/dashboard-settings-api.test.ts
+++ b/tests/dashboard-settings-api.test.ts
@@ -1706,6 +1706,105 @@ describe('dashboard typed settings API', () => {
     }
   });
 
+  test('POST /cats/relay/model-config/apply with a bound bot updates only local config and never pushes to the cloud', async () => {
+    const catsApp = express();
+    catsApp.use(express.json());
+    let cloudPatchCount = 0;
+    catsApp.get('/api/relay/config', (_req, res) => {
+      res.json({
+        base_url: 'https://relay.catsco.cc',
+        default_model: 'MiniMax-M2.7',
+        self_service_enabled: true,
+        endpoints: [
+          { protocol: 'Anthropic-compatible', base_url: 'https://relay.catsco.cc/anthropic' },
+        ],
+        models: [
+          {
+            id: 'minimax-m3',
+            label: 'MiniMax M3',
+            model: 'MiniMax-M3',
+            provider: 'anthropic',
+            enabled: true,
+            default: true,
+          },
+        ],
+      });
+    });
+    catsApp.get('/api/relay/key', (_req, res) => {
+      res.json({ configured: false });
+    });
+    catsApp.post('/api/relay/key', (_req, res) => {
+      res.json({
+        key: {
+          id: 'vk-local-only',
+          name: 'CatsCo user 38',
+          prefix: 'sk-bf-lo',
+          state: 'active',
+          key: 'sk-bf-local-only-secret',
+        },
+      });
+    });
+    catsApp.patch('/api/bots/definition/model', (_req, res) => {
+      cloudPatchCount += 1;
+      res.json({ revision: 99 });
+    });
+    const catsServer = await listen(catsApp);
+    const catsAddress = catsServer.address();
+    if (!catsAddress || typeof catsAddress === 'string') throw new Error('cats server did not bind');
+
+    try {
+      process.env.CATSCO_USER_TOKEN = 'user-token';
+      process.env.CATSCO_USER_UID = '38';
+      process.env.CATSCO_BOT_UID = '110';
+      process.env.CATSCO_API_KEY = 'cats_svc_test';
+      process.env.CATSCO_SERVER_URL = 'wss://app.catsco.cc/v0/channels';
+      process.env.CATSCO_HTTP_BASE_URL = `http://127.0.0.1:${catsAddress.port}`;
+      createCatsCoLocalConfigService({ runtimeRoot: testRoot }).save({
+        version: 1,
+        endpoints: {
+          httpBaseUrl: `http://127.0.0.1:${catsAddress.port}`,
+          serverUrl: 'wss://app.catsco.cc/v0/channels',
+        },
+        account: { token: 'user-token', uid: '38' },
+        currentBot: {
+          uid: '110',
+          name: 'CatsCo',
+          username: 'catsco_38',
+          apiKey: 'cats_svc_test',
+          boundByUserUid: '38',
+          bindingSource: 'test',
+        },
+        device: {
+          deviceId: 'body-local-only',
+          bodyId: 'body-local-only',
+          installationId: 'body-local-only',
+        },
+      });
+
+      const response = await fetch(`${baseUrl}/api/cats/relay/model-config/apply`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ modelId: 'minimax-m3' }),
+      });
+      const text = await response.text();
+      const data = JSON.parse(text) as any;
+      const runtime = new FileBotCatalogModelRuntimeRepository({ runtimeRoot: testRoot }).read('110');
+      const definition = new FileBotDefinitionRepository({ runtimeRoot: testRoot }).readCache('110');
+
+      assert.equal(response.status, 200, text);
+      assert.equal(data.model, 'MiniMax-M3');
+      assert.equal(runtime?.modelId, 'minimax-m3');
+      assert.equal(runtime?.model, 'MiniMax-M3');
+      assert.equal(definition?.model.kind, 'catalog');
+      assert.equal(definition?.model.modelId, 'minimax-m3');
+      // 设备本地配置绝不允许覆盖云端：本地模型切换不得推送到云端（云端以 webapp 设置为权威）。
+      assert.equal(cloudPatchCount, 0);
+      assert.equal(text.includes('sk-bf-local-only-secret'), false);
+    } finally {
+      await new Promise<void>(resolve => catsServer.close(() => resolve()));
+    }
+  });
+
   test('POST /cats/relay/model-config/apply rejects unknown relay model ids before key changes', async () => {
     const catsApp = express();
     catsApp.use(express.json());


### PR DESCRIPTION
## 问题

用户发现"云端模型覆盖本地"方向反了：在 XiaoBa 桌面端 Dashboard 的「启动模型」面板切换本地模型时，会把本地模型**推送到云端**（syncBoundBotModelToCloud → PATCH /api/bots/definition/model），覆盖用户在 webapp 上设置的云端模型（例如云端设为 MiniMax M3，被本地 GPT-5.6 Terra 覆盖）。

另外，webapp 设置云端模型后，桌面端 Dashboard「启动模型」面板本应显示"使用云端模型/云端当前覆盖"窗口，但因该窗口依赖本地 override 文件（新契约下成功应用云端定义后 override 会被清除），导致窗口不再显示，用户误以为云端覆盖功能丢失。

## 正确语义

- **云端模型（webapp 设置）= 服务端权威**，设备 XiaoBa 通过轮询自动跟随，Dashboard 显示「云端 · xxx」+「云端当前覆盖」窗口。
- **设备本地配置（webapp 的"设备本地配置"，或桌面端「启动模型」面板）= 仅本机生效**，不得推送覆盖云端。

## 改动

1. `src/dashboard/routes/api.ts` /cats/relay/model-config/apply：绑定 bot 后只更新本地 Definition 与 catalog runtime，**移除 syncBoundBotModelToCloud 推送**，本地切换不再覆盖云端。
2. `src/dashboard/routes/api.ts` /cats/status：cloudModelOverride 改为实时拉取云端配置（pullCloudBotModelSelection），而非读取本地 override 文件；云端配置 active 时 Dashboard 恢复显示「云端当前覆盖」窗口。
3. `dashboard/index.html`：新增 isCloudOverrideActive()；云端覆盖 active 时禁用本地 relay/自定义模型切换，并提示"切回 webapp 的『设备本地配置』"。

## 测试

- 全量：1359 通过，0 失败（5 skipped）。
- 新增测试：绑定 bot 时 apply 只改本地、**断言云端 PATCH 从未被调用**；更新 /cats/status 云端覆盖来源测试（改为拉云端配置）；HTML 提取测试注入 isCloudOverrideActive 依赖。
