### PR TITLE
test: protect cache trace attempt isolation

### DIFF
--- a/tests/cache-trace-monitoring.test.ts
+++ b/tests/cache-trace-monitoring.test.ts
@@ -129,6 +129,71 @@ test('reader accepts legacy JSON and v4 JSONL while resetting diff on a model sw
   }
 });
 
+test('observer keeps interleaved attempts isolated by attempt id and file', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-cache-interleaved-'));
+  try {
+    const observer = new CacheTraceObserver({
+      sessionId: 'cache:interleaved',
+      traceDir: dir,
+      env: { XIAOBA_CACHE_TRACE: 'true', XIAOBA_CACHE_TRACE_CONTENT: 'true' },
+    });
+    observer.observe(attemptEvent({
+      outcome: 'started',
+      callId: 'call-A',
+      attemptId: 'call-A:1',
+      context: { sessionId: 'cache:interleaved', episodeId: 'episode-A', episodeNumber: 1 },
+      request: { messages: [{ role: 'user', content: 'marker-A' }], tools: [] },
+    }));
+    observer.observe(attemptEvent({
+      outcome: 'started',
+      callId: 'call-B',
+      attemptId: 'call-B:1',
+      context: { sessionId: 'cache:interleaved', episodeId: 'episode-B', episodeNumber: 2 },
+      request: { messages: [{ role: 'user', content: 'marker-B' }], tools: [] },
+    }));
+    observer.observe(attemptEvent({
+      outcome: 'succeeded',
+      callId: 'call-B',
+      attemptId: 'call-B:1',
+      context: { sessionId: 'cache:interleaved', episodeId: 'episode-B', episodeNumber: 2 },
+      request: { messages: [{ role: 'user', content: 'marker-B' }], tools: [] },
+      response: { content: 'response-B', usage: { promptTokens: 202, completionTokens: 2, totalTokens: 204, cachedReadTokens: 22 } },
+    }));
+    observer.observe(attemptEvent({
+      outcome: 'succeeded',
+      callId: 'call-A',
+      attemptId: 'call-A:1',
+      context: { sessionId: 'cache:interleaved', episodeId: 'episode-A', episodeNumber: 1 },
+      request: { messages: [{ role: 'user', content: 'marker-A' }], tools: [] },
+      response: { content: 'response-A', usage: { promptTokens: 101, completionTokens: 1, totalTokens: 102, cachedReadTokens: 11 } },
+    }));
+    await observer.drain();
+
+    const files = listTraceFiles(dir);
+    assert.equal(files.length, 2);
+    const observed = new Map<string, { callId: string; attemptId: string; cachedReadTokens: number }>();
+    for (const file of files) {
+      const lines = fs.readFileSync(file, 'utf8').trim().split(/\r?\n/).map(line => JSON.parse(line));
+      assert.equal(lines.length, 2);
+      assert.deepEqual(lines.map(line => line.lifecycle.outcome), ['started', 'succeeded']);
+      assert.equal(new Set(lines.map(line => line.lifecycle.call_id)).size, 1);
+      assert.equal(new Set(lines.map(line => line.lifecycle.attempt_id)).size, 1);
+      assert.equal(lines[0].request.request_sha256, lines[1].request.request_sha256);
+      assert.equal(lines[1].request.request_snapshot, undefined);
+      const marker = String(lines[0].request.request_snapshot.messages[0].content);
+      observed.set(marker, {
+        callId: lines[0].lifecycle.call_id,
+        attemptId: lines[0].lifecycle.attempt_id,
+        cachedReadTokens: lines[1].response_usage.cache_read_tokens,
+      });
+    }
+    assert.deepEqual(observed.get('marker-A'), { callId: 'call-A', attemptId: 'call-A:1', cachedReadTokens: 11 });
+    assert.deepEqual(observed.get('marker-B'), { callId: 'call-B', attemptId: 'call-B:1', cachedReadTokens: 22 });
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('observer writes retry recovery as two correlated attempts and preserves cache usage', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-cache-write-'));
   try {

--- a/tests/model-attempt-lifecycle.test.ts
+++ b/tests/model-attempt-lifecycle.test.ts
@@ -78,6 +78,227 @@ test('records every provider retry as a correlated attempt lifecycle', async () 
   assert.equal(events[3].response?.usage?.cachedReadTokens, 60);
 });
 
+test('isolates interleaved concurrent calls and retry recovery on a shared service', async () => {
+  process.env.CATSCO_MODEL_RETRY_MAX_RETRIES = '1';
+  const service = createTestService({ openaiApiMode: 'responses' });
+  const events: ModelAttemptEvent[] = [];
+  const gates = new Map<string, Array<ReturnType<typeof deferred<ChatResponse>>>>();
+  (service as any).sleepWithAbort = async () => undefined;
+  (service as any).provider = {
+    chat: async (messages: Message[]) => {
+      const marker = String(messages[0]?.content || '');
+      const gate = deferred<ChatResponse>();
+      const markerGates = gates.get(marker) || [];
+      markerGates.push(gate);
+      gates.set(marker, markerGates);
+      return gate.promise;
+    },
+    chatStream: async () => ({ content: 'unused' }),
+  };
+  const sink = collectingSink(events);
+
+  const callA = service.chat([{ role: 'user', content: 'marker-A' }], undefined, {
+    modelAttemptSink: sink,
+    modelAttemptContext: { episodeId: 'episode-A', episodeNumber: 1 },
+  });
+  const callB = service.chat([{ role: 'user', content: 'marker-B' }], undefined, {
+    modelAttemptSink: sink,
+    modelAttemptContext: { episodeId: 'episode-B', episodeNumber: 2 },
+  });
+
+  await waitUntil(() => (gates.get('marker-A')?.length ?? 0) === 1 && (gates.get('marker-B')?.length ?? 0) === 1);
+  gates.get('marker-A')![0].reject(Object.assign(new Error('temporary outage'), {
+    response: { status: 503, headers: { 'retry-after': '0' } },
+  }));
+  await waitUntil(() => (gates.get('marker-A')?.length ?? 0) === 2);
+  gates.get('marker-B')![0].resolve({
+    content: 'response-B',
+    usage: { promptTokens: 202, completionTokens: 2, totalTokens: 204, cachedReadTokens: 22 },
+  });
+  await new Promise(resolve => setImmediate(resolve));
+  gates.get('marker-A')![1].resolve({
+    content: 'response-A',
+    usage: { promptTokens: 101, completionTokens: 1, totalTokens: 102, cachedReadTokens: 11 },
+  });
+
+  const [responseA, responseB] = await Promise.all([callA, callB]);
+  assert.equal(responseA.content, 'response-A');
+  assert.equal(responseB.content, 'response-B');
+  assert.deepEqual(events.map(event => `${event.outcome}:${event.request.messages[0]?.content}`), [
+    'started:marker-A',
+    'started:marker-B',
+    'retrying:marker-A',
+    'started:marker-A',
+    'succeeded:marker-B',
+    'succeeded:marker-A',
+  ]);
+
+  const eventsA = events.filter(event => event.request.messages[0]?.content === 'marker-A');
+  const eventsB = events.filter(event => event.request.messages[0]?.content === 'marker-B');
+  assert.equal(new Set(events.map(event => event.callId)).size, 2);
+  assert.equal(new Set(eventsA.map(event => event.callId)).size, 1);
+  assert.equal(new Set(eventsB.map(event => event.callId)).size, 1);
+  assert.notEqual(eventsA[0].callId, eventsB[0].callId);
+  assert.deepEqual(eventsA.map(event => event.outcome), ['started', 'retrying', 'started', 'succeeded']);
+  assert.equal(eventsA[0].attemptId, eventsA[1].attemptId);
+  assert.equal(eventsA[2].attemptId, eventsA[3].attemptId);
+  assert.notEqual(eventsA[0].attemptId, eventsA[2].attemptId);
+  assert.equal(eventsA[3].response?.usage?.cachedReadTokens, 11);
+  assert.equal(eventsA.every(event => event.context?.episodeId === 'episode-A'), true);
+  assert.deepEqual(eventsB.map(event => event.outcome), ['started', 'succeeded']);
+  assert.equal(eventsB[0].attemptId, eventsB[1].attemptId);
+  assert.equal(eventsB[1].response?.usage?.cachedReadTokens, 22);
+  assert.equal(eventsB.every(event => event.context?.episodeId === 'episode-B'), true);
+});
+
+test('isolates an interleaved terminal failure from a sibling success', async () => {
+  process.env.CATSCO_MODEL_RETRY_MAX_RETRIES = '0';
+  const service = createTestService();
+  const events: ModelAttemptEvent[] = [];
+  const gates = new Map<string, ReturnType<typeof deferred<ChatResponse>>>();
+  (service as any).provider = {
+    chat: async (messages: Message[]) => {
+      const marker = String(messages[0]?.content || '');
+      const gate = deferred<ChatResponse>();
+      gates.set(marker, gate);
+      return gate.promise;
+    },
+    chatStream: async () => ({ content: 'unused' }),
+  };
+  const sink = collectingSink(events);
+
+  const callA = service.chat([{ role: 'user', content: 'failed-A' }], undefined, {
+    modelAttemptSink: sink,
+    modelAttemptContext: { episodeId: 'failed-episode-A', episodeNumber: 7 },
+  });
+  const callB = service.chat([{ role: 'user', content: 'succeeded-B' }], undefined, {
+    modelAttemptSink: sink,
+    modelAttemptContext: { episodeId: 'succeeded-episode-B', episodeNumber: 8 },
+  });
+  const callARejection = assert.rejects(
+    callA,
+    /API错误 \(400\): invalid request A/,
+  );
+
+  await waitUntil(() => gates.size === 2);
+  gates.get('failed-A')!.reject(Object.assign(new Error('invalid request A'), {
+    response: { status: 400 },
+  }));
+  await waitUntil(() => events.some(event => event.outcome === 'failed'));
+  gates.get('succeeded-B')!.resolve({
+    content: 'response-B',
+    usage: { promptTokens: 505, completionTokens: 5, totalTokens: 510, cachedReadTokens: 55 },
+  });
+
+  await callARejection;
+  const responseB = await callB;
+  assert.equal(responseB.content, 'response-B');
+  assert.deepEqual(events.map(event => `${event.outcome}:${event.request.messages[0]?.content}`), [
+    'started:failed-A',
+    'started:succeeded-B',
+    'failed:failed-A',
+    'succeeded:succeeded-B',
+  ]);
+
+  const eventsA = events.filter(event => event.request.messages[0]?.content === 'failed-A');
+  const eventsB = events.filter(event => event.request.messages[0]?.content === 'succeeded-B');
+  assert.equal(new Set(events.map(event => event.callId)).size, 2);
+  assert.equal(new Set(eventsA.map(event => event.attemptId)).size, 1);
+  assert.equal(new Set(eventsB.map(event => event.attemptId)).size, 1);
+  assert.notEqual(eventsA[0].callId, eventsB[0].callId);
+  assert.equal(eventsA[1].retry?.stopReason, 'non_retryable');
+  assert.equal(eventsA[1].error instanceof Error, true);
+  assert.equal(eventsA.every(event => event.context?.episodeId === 'failed-episode-A'), true);
+  assert.equal(eventsB[1].response?.usage?.cachedReadTokens, 55);
+  assert.equal(eventsB.every(event => event.context?.episodeId === 'succeeded-episode-B'), true);
+});
+
+test('isolates interleaved streaming calls and callbacks on a shared service', async () => {
+  const service = createTestService();
+  const events: ModelAttemptEvent[] = [];
+  const gates = new Map<string, ReturnType<typeof deferred<ChatResponse>>>();
+  const providerCallbacks = new Map<string, StreamCallbacks | undefined>();
+  (service as any).provider = {
+    chat: async () => ({ content: 'unused' }),
+    chatStream: async (messages: Message[], _tools: ToolDefinition[], callbacks?: StreamCallbacks) => {
+      const marker = String(messages[0]?.content || '');
+      const gate = deferred<ChatResponse>();
+      gates.set(marker, gate);
+      providerCallbacks.set(marker, callbacks);
+      return gate.promise;
+    },
+  };
+  const chunksA: string[] = [];
+  const chunksB: string[] = [];
+  const sink = collectingSink(events);
+
+  const callA = service.chatStream(
+    [{ role: 'user', content: 'stream-A' }],
+    undefined,
+    { onText: chunk => { chunksA.push(chunk); } },
+    { modelAttemptSink: sink, modelAttemptContext: { episodeId: 'stream-episode-A' } },
+  );
+  const callB = service.chatStream(
+    [{ role: 'user', content: 'stream-B' }],
+    undefined,
+    { onText: chunk => { chunksB.push(chunk); } },
+    { modelAttemptSink: sink, modelAttemptContext: { episodeId: 'stream-episode-B' } },
+  );
+
+  await waitUntil(() => gates.size === 2);
+  providerCallbacks.get('stream-B')?.onText?.('chunk-B');
+  gates.get('stream-B')!.resolve({
+    content: 'response-stream-B',
+    usage: { promptTokens: 404, completionTokens: 4, totalTokens: 408, cachedReadTokens: 44 },
+  });
+  await new Promise(resolve => setImmediate(resolve));
+  providerCallbacks.get('stream-A')?.onText?.('chunk-A');
+  gates.get('stream-A')!.resolve({
+    content: 'response-stream-A',
+    usage: { promptTokens: 303, completionTokens: 3, totalTokens: 306, cachedReadTokens: 33 },
+  });
+
+  const [responseA, responseB] = await Promise.all([callA, callB]);
+  assert.equal(responseA.content, 'response-stream-A');
+  assert.equal(responseB.content, 'response-stream-B');
+  assert.deepEqual(chunksA, ['chunk-A']);
+  assert.deepEqual(chunksB, ['chunk-B']);
+  assert.deepEqual(events.map(event => `${event.outcome}:${event.request.messages[0]?.content}`), [
+    'started:stream-A',
+    'started:stream-B',
+    'succeeded:stream-B',
+    'succeeded:stream-A',
+  ]);
+  assert.equal(new Set(events.map(event => event.callId)).size, 2);
+  for (const marker of ['stream-A', 'stream-B']) {
+    const markerEvents = events.filter(event => event.request.messages[0]?.content === marker);
+    assert.deepEqual(markerEvents.map(event => event.outcome), ['started', 'succeeded']);
+    assert.equal(new Set(markerEvents.map(event => event.callId)).size, 1);
+    assert.equal(new Set(markerEvents.map(event => event.attemptId)).size, 1);
+    assert.equal(markerEvents.every(event => event.stream), true);
+    assert.equal(markerEvents[1].response?.usage?.cachedReadTokens, marker === 'stream-A' ? 33 : 44);
+    assert.equal(markerEvents.every(event => event.context?.episodeId === `stream-episode-${marker.at(-1)}`), true);
+  }
+});
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((next, fail) => {
+    resolve = next;
+    reject = fail;
+  });
+  return { promise, resolve, reject };
+}
+
+async function waitUntil(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 50; attempt++) {
+    if (predicate()) return;
+    await new Promise(resolve => setImmediate(resolve));
+  }
+  throw new Error('timed out waiting for concurrent provider invocation');
+}
+
 test('records a non-retryable provider rejection as the terminal attempt', async () => {
   process.env.CATSCO_MODEL_RETRY_MAX_RETRIES = '0';
   const service = createTestService();


### PR DESCRIPTION
## Summary

- Add regression coverage for interleaved provider attempts on a shared `AIService` and provider.
- Protect retry recovery, terminal failure, streaming callbacks/chunks, usage attribution, episode context, request markers, and per-attempt JSONL lifecycle cleanup.
- Keep product code unchanged because the current architecture already scopes lifecycle state to each call and attempt; the smallest safe change is a tests-only guard.

## Validation

- Project-native isolated targeted suite: 22/22 pass.
- TypeScript build: pass.
- Official runtime suite on this branch: 1376 tests, 1362 pass, 6 fail, 0 cancelled, 8 skipped.
- Untouched `origin/main` under the same fixed PATH: 1372 tests, 1358 pass, the exact same 6 host-dependent prompt/Reader failures, 0 cancelled, 8 skipped.
- `git diff --check`: pass.
- Independent focused review: APPROVE, no findings.

The four-test count delta is entirely from this commit, and all four added tests pass. No new failing or cancelled test was observed relative to the baseline.

## Why this matters

Cache qualification and token-weighted hit rate depend on every provider attempt retaining its own request kind/origin, marker, episode, usage, and terminal outcome. These tests prevent concurrent attempts from silently cross-attributing those fields and corrupting the cache-trace dashboard's data foundation.
