### PR TITLE
fix: 修复 Skill 列表序列化并收紧本地分享范围

### DIFF
--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -3277,7 +3277,7 @@ export function createApiRouter(
     try {
       const localSkillManager = new SkillManager();
       await localSkillManager.loadSkills();
-      const activeSkills = localSkillManager.getAllSkills().map(skillToDashboardPayload);
+      const activeSkills = await Promise.all(localSkillManager.getAllSkills().map(skillToDashboardPayload));
       const disabledSkills = findAllDisabledSkills(PathResolver.getSkillsPath());
       res.json([...activeSkills, ...disabledSkills]);
     } catch (e: any) {

--- a/src/dashboard/routes/skillhub.ts
+++ b/src/dashboard/routes/skillhub.ts
@@ -147,7 +147,7 @@ export function registerSkillHubRoutes(router: Router, options: SkillHubRouteOpt
 
   router.post('/skillhub/developer/share-local-skill', async (req, res) => {
     try {
-      res.status(201).json(await serviceFrom(req.body).shareLocalSkill(req.body || {}));
+      res.status(201).json(await shareLocalSkill(req.body || {}, options));
     } catch (error: any) {
       sendSkillHubError(res, error);
     }
@@ -155,7 +155,7 @@ export function registerSkillHubRoutes(router: Router, options: SkillHubRouteOpt
 
   router.post('/skillhub/share-local-skill', async (req, res) => {
     try {
-      res.status(201).json(await serviceFrom(req.body).shareLocalSkill(req.body || {}));
+      res.status(201).json(await shareLocalSkill(req.body || {}, options));
     } catch (error: any) {
       sendSkillHubError(res, error);
     }
@@ -192,6 +192,63 @@ export function registerSkillHubRoutes(router: Router, options: SkillHubRouteOpt
       sendSkillHubError(res, error);
     }
   });
+}
+
+async function shareLocalSkill(input: any, options: SkillHubRouteOptions): Promise<any> {
+  const expectedBotUid = String(input?.expectedBotUid || '').trim();
+  const expectedUserUid = String(input?.expectedUserUid || '').trim();
+  if (Boolean(expectedBotUid) !== Boolean(expectedUserUid)) {
+    throw skillHubConflict(
+      'expectedBotUid and expectedUserUid must be provided together.',
+      'skillhub.share_scope_incomplete',
+    );
+  }
+
+  // Preserve the existing Dashboard flow when no explicit WebApp scope is
+  // supplied. The WebApp bridge always sends both values and gets the stricter
+  // account/workspace checks below.
+  if (!expectedBotUid) return serviceFrom(input).shareLocalSkill(input);
+  if (!options.getCatsCoAuth) {
+    const error: any = new Error('CatsCo SkillHub login is not configured');
+    error.status = 501;
+    error.code = 'skillhub.catsco_exchange_unavailable';
+    throw error;
+  }
+
+  const cats = await options.getCatsCoAuth();
+  const actualUserUid = String(cats.user?.uid || '').trim();
+  if (actualUserUid !== expectedUserUid) {
+    throw skillHubConflict(
+      'The local CatsCo account changed before the Skill was shared.',
+      'skillhub.share_user_changed',
+    );
+  }
+
+  return withCurrentBotSkillWorkspaceWrite(async (context) => {
+    assertExpectedLocalSkillShareScope(expectedBotUid, context.botId, context.activeBotId);
+    const result = await serviceFrom(input).shareLocalSkill(input);
+    return { ...result, botUid: expectedBotUid };
+  });
+}
+
+export function assertExpectedLocalSkillShareScope(
+  expectedBotUid: string,
+  configuredBotUid?: string,
+  activeBotUid?: string,
+): void {
+  if (configuredBotUid !== expectedBotUid || activeBotUid !== expectedBotUid) {
+    throw skillHubConflict(
+      'The active Bot Skill workspace changed before the Skill was shared.',
+      'skillhub.share_bot_changed',
+    );
+  }
+}
+
+function skillHubConflict(message: string, code: string): Error {
+  const error: any = new Error(message);
+  error.status = 409;
+  error.code = code;
+  return error;
 }
 
 function serviceFrom(_input?: any): SkillHubService {

--- a/src/dashboard/routes/skillhub.ts
+++ b/src/dashboard/routes/skillhub.ts
@@ -215,9 +215,11 @@ async function shareLocalSkill(input: any, options: SkillHubRouteOptions): Promi
     throw error;
   }
 
-  const cats = await options.getCatsCoAuth();
-  const actualUserUid = String(cats.user?.uid || '').trim();
-  if (actualUserUid !== expectedUserUid) {
+  // Keep the existing fast-fail behavior for an already changed CatsCo
+  // account. This check is only a preflight; the identity is exchanged and
+  // checked again inside the workspace lock immediately before upload.
+  const preflightCats = await options.getCatsCoAuth();
+  if (String(preflightCats.user?.uid || '').trim() !== expectedUserUid) {
     throw skillHubConflict(
       'The local CatsCo account changed before the Skill was shared.',
       'skillhub.share_user_changed',
@@ -226,7 +228,26 @@ async function shareLocalSkill(input: any, options: SkillHubRouteOptions): Promi
 
   return withCurrentBotSkillWorkspaceWrite(async (context) => {
     assertExpectedLocalSkillShareScope(expectedBotUid, context.botId, context.activeBotId);
-    const result = await serviceFrom(input).shareLocalSkill(input);
+    // WebApp shares must not reuse the process-wide SkillHub cookie. Re-exchange
+    // the current CatsCo identity inside the workspace lock and keep the
+    // resulting SkillHub session in memory for this request only.
+    const cats = await options.getCatsCoAuth!();
+    const service = serviceFrom(input, { sessionScope: 'memory' });
+    const skillHubAuth = await service.loginWithCatsCo(cats);
+    const actualUserUid = String(skillHubAuth.catsCo?.uid || '').trim();
+    if (!actualUserUid) {
+      throw skillHubConflict(
+        'SkillHub did not return the CatsCo identity for the exchanged session.',
+        'skillhub.share_identity_unavailable',
+      );
+    }
+    if (actualUserUid !== expectedUserUid) {
+      throw skillHubConflict(
+        'The local CatsCo account changed before the Skill was shared.',
+        'skillhub.share_user_changed',
+      );
+    }
+    const result = await service.shareLocalSkill(input);
     return { ...result, botUid: expectedBotUid };
   });
 }
@@ -251,8 +272,8 @@ function skillHubConflict(message: string, code: string): Error {
   return error;
 }
 
-function serviceFrom(_input?: any): SkillHubService {
-  return new SkillHubService();
+function serviceFrom(_input?: any, options: { sessionScope?: 'persistent' | 'memory' } = {}): SkillHubService {
+  return new SkillHubService(options);
 }
 
 function sendSkillHubError(res: any, error: any): void {

--- a/src/skillhub/client.ts
+++ b/src/skillhub/client.ts
@@ -12,6 +12,7 @@ import type {
 export interface SkillHubClientOptions {
   baseUrl?: string;
   timeoutMs?: number;
+  sessionScope?: 'persistent' | 'memory';
 }
 
 export interface SkillHubRegisterInput {
@@ -46,7 +47,9 @@ export class SkillHubClient {
 
   constructor(options: SkillHubClientOptions = {}) {
     this.config = loadSkillHubConfig({ baseUrl: options.baseUrl });
-    this.sessionStore = new SkillHubSessionStore(this.config);
+    this.sessionStore = options.sessionScope === 'memory'
+      ? SkillHubSessionStore.memory(this.config)
+      : new SkillHubSessionStore(this.config);
     this.timeoutMs = options.timeoutMs ?? 15_000;
   }
 
@@ -85,8 +88,12 @@ export class SkillHubClient {
   }
 
   async loginWithCatsCo(input: SkillHubCatsCoExchangeInput): Promise<SkillHubAuthState> {
-    await this.request('POST', '/api/auth/catsco-exchange', input);
-    return this.status();
+    const exchange = await this.request<any>('POST', '/api/auth/catsco-exchange', input);
+    const auth = await this.status();
+    return {
+      ...auth,
+      catsCo: exchange?.catsCo,
+    };
   }
 
   async logout(): Promise<{ ok: true }> {

--- a/src/skillhub/service.ts
+++ b/src/skillhub/service.ts
@@ -29,7 +29,7 @@ import type {
 export class SkillHubService {
   private readonly client: SkillHubClient;
 
-  constructor(options: { baseUrl?: string } = {}) {
+  constructor(options: { baseUrl?: string; sessionScope?: 'persistent' | 'memory' } = {}) {
     this.client = new SkillHubClient(options);
   }
 

--- a/src/skillhub/session-store.ts
+++ b/src/skillhub/session-store.ts
@@ -17,7 +17,16 @@ interface StoredSkillHubSession {
 }
 
 export class SkillHubSessionStore {
-  constructor(private readonly config: SkillHubConfig) {}
+  private memorySession: StoredSkillHubSession | null = null;
+
+  constructor(
+    private readonly config: SkillHubConfig,
+    private readonly options: { sessionFile?: string | null } = {},
+  ) {}
+
+  static memory(config: SkillHubConfig): SkillHubSessionStore {
+    return new SkillHubSessionStore(config, { sessionFile: null });
+  }
 
   getBaseUrl(): string {
     return this.read()?.baseUrl || this.config.baseUrl;
@@ -59,15 +68,22 @@ export class SkillHubSessionStore {
   }
 
   clear(): void {
-    if (fs.existsSync(this.config.sessionFile)) {
-      fs.rmSync(this.config.sessionFile, { force: true });
+    if (this.options.sessionFile === null) {
+      this.memorySession = null;
+      return;
+    }
+    const sessionFile = this.options.sessionFile || this.config.sessionFile;
+    if (fs.existsSync(sessionFile)) {
+      fs.rmSync(sessionFile, { force: true });
     }
   }
 
   private read(): StoredSkillHubSession | null {
-    if (!fs.existsSync(this.config.sessionFile)) return null;
+    if (this.options.sessionFile === null) return this.memorySession;
+    const sessionFile = this.options.sessionFile || this.config.sessionFile;
+    if (!fs.existsSync(sessionFile)) return null;
     try {
-      const parsed = JSON.parse(fs.readFileSync(this.config.sessionFile, 'utf-8')) as StoredSkillHubSession;
+      const parsed = JSON.parse(fs.readFileSync(sessionFile, 'utf-8')) as StoredSkillHubSession;
       if (!parsed || !Array.isArray(parsed.cookies)) return null;
       return parsed;
     } catch {
@@ -76,8 +92,13 @@ export class SkillHubSessionStore {
   }
 
   private write(session: StoredSkillHubSession): void {
-    fs.mkdirSync(path.dirname(this.config.sessionFile), { recursive: true });
-    fs.writeFileSync(this.config.sessionFile, `${JSON.stringify(session, null, 2)}\n`, 'utf-8');
+    if (this.options.sessionFile === null) {
+      this.memorySession = session;
+      return;
+    }
+    const sessionFile = this.options.sessionFile || this.config.sessionFile;
+    fs.mkdirSync(path.dirname(sessionFile), { recursive: true });
+    fs.writeFileSync(sessionFile, `${JSON.stringify(session, null, 2)}\n`, 'utf-8');
   }
 }
 

--- a/src/skillhub/types.ts
+++ b/src/skillhub/types.ts
@@ -15,6 +15,11 @@ export interface SkillHubAuthState {
   authenticated: boolean;
   baseUrl: string;
   user?: SkillHubUser;
+  catsCo?: {
+    uid?: string;
+    username?: string;
+    displayName?: string;
+  };
   roles: string[];
   permissions: string[];
   developerProfile?: any;

--- a/tests/dashboard-skillhub-connected-api.test.ts
+++ b/tests/dashboard-skillhub-connected-api.test.ts
@@ -8,6 +8,8 @@ import express from 'express';
 import type { Server } from 'http';
 import { createApiRouter } from '../src/dashboard/routes/api';
 import { assertExpectedLocalSkillShareScope } from '../src/dashboard/routes/skillhub';
+import { BotSkillWorkspaceService } from '../src/bot-skills/workspace';
+import { createCatsCoLocalConfigService } from '../src/catscompany/local-config';
 import { loadSkillHubConfig } from '../src/skillhub/config';
 import { CATSCO_SKILLHUB_ROOT_PUBLIC_KEYS, SkillHubTrustedRootKey } from '../src/skillhub/trusted-keys';
 
@@ -22,6 +24,7 @@ describe('dashboard connected SkillHub API', () => {
   let maliciousServer: Server | undefined;
   let dashboardBaseUrl: string;
   let cloudBaseUrl: string;
+  let lastShareCookie = '';
 
   beforeEach(async () => {
     originalCwd = process.cwd();
@@ -31,6 +34,7 @@ describe('dashboard connected SkillHub API', () => {
     process.chdir(testRoot);
     process.env.XIAOBA_SKILLS_DIR = path.join(testRoot, 'skills');
     fs.mkdirSync(path.join(testRoot, 'skills'), { recursive: true });
+    lastShareCookie = '';
   });
 
   afterEach(async () => {
@@ -201,6 +205,73 @@ describe('dashboard connected SkillHub API', () => {
     assert.equal(share.body.code, 'skillhub.share_user_changed');
   });
 
+  test('uses a request-scoped CatsCo SkillHub session when a persisted cookie belongs to another account', async () => {
+    const skillRoot = path.join(testRoot, 'skills', 'scoped-demo');
+    fs.mkdirSync(skillRoot, { recursive: true });
+    fs.writeFileSync(path.join(skillRoot, 'SKILL.md'), [
+      '---',
+      'name: scoped-demo',
+      'description: Request scoped share demo',
+      '---',
+      '',
+      '# Scoped Demo',
+      '',
+    ].join('\n'));
+
+    const fixture = createFixture();
+    await startCatsCo();
+    await startCloud(fixture);
+    process.env.CATSCO_SKILLHUB_BASE_URL = cloudBaseUrl;
+    process.env.CATSCO_HTTP_BASE_URL = serverBaseUrl(catsServer!);
+    process.env.CATSCO_USER_TOKEN = 'cats-token';
+    process.env.CATSCO_USER_UID = '116';
+    process.env.CATSCO_USER_NAME = 'lin';
+    process.env.CATSCO_USER_DISPLAY_NAME = 'Lin';
+    createCatsCoLocalConfigService({ runtimeRoot: testRoot, env: process.env }).save({
+      version: 1,
+      endpoints: {
+        httpBaseUrl: serverBaseUrl(catsServer!),
+        serverUrl: 'ws://127.0.0.1/unused',
+      },
+      account: {
+        token: 'cats-token',
+        uid: '116',
+        username: 'lin',
+        displayName: 'Lin',
+      },
+      currentBot: {
+        uid: '218',
+        apiKey: 'bot-key',
+        boundByUserUid: '116',
+        bindingSource: 'test',
+      },
+    });
+    new BotSkillWorkspaceService(testRoot, path.join(testRoot, 'skills')).activate('218');
+    await startDashboard();
+
+    // Simulate another Dashboard tab switching the persisted SkillHub session.
+    const login = await post('/api/skillhub/auth/login', {
+      email: 'demo@example.com',
+      password: 'passw0rd!!',
+    });
+    assert.equal(login.status, 200);
+    const sessionPath = path.join(testRoot, 'data/skillhub/session.json');
+    const persistedBefore = fs.readFileSync(sessionPath, 'utf8');
+    assert.match(persistedBefore, /dashboard-session/);
+
+    const share = await post('/api/skillhub/share-local-skill', {
+      skillName: 'scoped-demo',
+      expectedBotUid: '218',
+      expectedUserUid: '116',
+    });
+    assert.equal(share.status, 201);
+    assert.equal(share.body.ok, true);
+    assert.equal(share.body.botUid, '218');
+    assert.match(lastShareCookie, /catsco_session=catsco-exchange-session/);
+    assert.doesNotMatch(lastShareCookie, /dashboard-session/);
+    assert.equal(fs.readFileSync(sessionPath, 'utf8'), persistedBefore);
+  });
+
   test('uses the official SkillHub cloud by default', () => {
     delete process.env.CATSCO_SKILLHUB_BASE_URL;
     assert.equal(loadSkillHubConfig().baseUrl, 'https://skillhub.catsco.fun:19990');
@@ -286,6 +357,7 @@ describe('dashboard connected SkillHub API', () => {
         roles: ['user', 'developer'],
         permissions: ['submission.create'],
         developerProfile: { namespace: 'lin' },
+        catsCo: { uid: '116', username: 'lin', displayName: 'Lin' },
       });
     });
     app.get('/api/auth/me', (req, res) => {
@@ -317,6 +389,7 @@ describe('dashboard connected SkillHub API', () => {
       });
     });
     app.post('/api/skills/share', (req, res) => {
+      lastShareCookie = req.header('cookie') || '';
       const manifest = {
         ...req.body.manifest,
         id: `lin/${req.body.manifest.name}`,

--- a/tests/dashboard-skillhub-connected-api.test.ts
+++ b/tests/dashboard-skillhub-connected-api.test.ts
@@ -7,6 +7,7 @@ import * as path from 'path';
 import express from 'express';
 import type { Server } from 'http';
 import { createApiRouter } from '../src/dashboard/routes/api';
+import { assertExpectedLocalSkillShareScope } from '../src/dashboard/routes/skillhub';
 import { loadSkillHubConfig } from '../src/skillhub/config';
 import { CATSCO_SKILLHUB_ROOT_PUBLIC_KEYS, SkillHubTrustedRootKey } from '../src/skillhub/trusted-keys';
 
@@ -182,9 +183,39 @@ describe('dashboard connected SkillHub API', () => {
     assert.equal(fs.existsSync(path.join(testRoot, 'data/skillhub/session.json')), true);
   });
 
+  test('rejects a WebApp share when the local CatsCo account changed', async () => {
+    await startCatsCo();
+    process.env.CATSCO_HTTP_BASE_URL = serverBaseUrl(catsServer!);
+    process.env.CATSCO_USER_TOKEN = 'cats-token';
+    process.env.CATSCO_USER_UID = '116';
+    process.env.CATSCO_USER_NAME = 'lin';
+    process.env.CATSCO_USER_DISPLAY_NAME = 'Lin';
+    await startDashboard();
+
+    const share = await post('/api/skillhub/share-local-skill', {
+      skillName: 'quick-demo',
+      expectedBotUid: '218',
+      expectedUserUid: '999',
+    });
+    assert.equal(share.status, 409);
+    assert.equal(share.body.code, 'skillhub.share_user_changed');
+  });
+
   test('uses the official SkillHub cloud by default', () => {
     delete process.env.CATSCO_SKILLHUB_BASE_URL;
     assert.equal(loadSkillHubConfig().baseUrl, 'https://skillhub.catsco.fun:19990');
+  });
+
+  test('rejects a WebApp share when the configured or active Bot changed', () => {
+    assert.doesNotThrow(() => assertExpectedLocalSkillShareScope('218', '218', '218'));
+    assert.throws(
+      () => assertExpectedLocalSkillShareScope('218', '573', '573'),
+      (error: any) => error?.status === 409 && error?.code === 'skillhub.share_bot_changed',
+    );
+    assert.throws(
+      () => assertExpectedLocalSkillShareScope('218', '218', '573'),
+      (error: any) => error?.status === 409 && error?.code === 'skillhub.share_bot_changed',
+    );
   });
 
   test('ignores request-supplied SkillHub baseUrl overrides', async () => {


### PR DESCRIPTION
## 背景与目的

CatsCo WebApp 的本地 SkillHub 联调需要通过 XiaoBa Dashboard 读取当前工作区中的真实 Skill，并把用户选择的本地 Skill 分享到全局 SkillHub。真实测试中发现两个需要在 XiaoBa 侧修复的问题：

1. `/api/store` 返回类似 `[{}, {}]`，WebApp 无法展示 Skill 名称、描述、路径和 SkillHub 元数据；
2. WebApp 检查本地账号和 Bot 后，到实际上传之间，其他 Dashboard 标签页仍可能切换 SkillHub 账号或 Bot，导致校验身份、上传身份和绑定目标不一致。

## 根因

`skillToDashboardPayload()` 是异步函数，但 `/api/store` 原本使用普通 `map()` 后直接把 Promise 数组交给 `res.json()`。Promise 被 JSON 序列化后变成空对象。

原分享接口只接收 `skillName`，没有把 WebApp 当前用户和 Bot 作为请求前置条件；同时，实际上传使用的是全局 `data/skillhub/session.json` 中的 SkillHub Cookie。该 Cookie 可以被另一个 Dashboard 标签页改写，因此仅校验 CatsCo `/api/me` 的 UID，无法保证真正上传所使用的 SkillHub 会话属于同一账号。

## 本 PR 做了什么

### 1. 修复 `/api/store` 异步序列化

使用 `Promise.all()` 等待所有 Skill 完成 Dashboard payload 转换后再返回，确保接口包含完整的名称、描述、路径、来源和 SkillHub 元数据。

### 2. 为 WebApp 本地分享增加账号和工作区范围校验

WebApp 分享请求同时携带：

- `expectedUserUid`
- `expectedBotUid`

XiaoBa 会：

- 要求两个字段成对出现；
- 先通过当前 CatsCo 登录状态快速校验用户 UID；
- 在 Bot Skill 工作区锁内检查已配置 Bot 和实际激活工作区都等于 `expectedBotUid`；
- 在锁内重新读取当前 CatsCo 登录状态；
- 使用请求范围内的 SkillHub client 和内存 Cookie 会话重新执行 CatsCo exchange；
- 使用 exchange 返回的 CatsCo UID 再次核对 `expectedUserUid`；
- 身份缺失、不匹配或 Bot 已变化时返回 409，拒绝上传；
- 上传成功后返回 `botUid`，供 WebApp 在自动绑定 BotDefinition 前再次核验。

### 3. 隔离实际上传使用的 SkillHub 会话

WebApp 受限分享不再读取或修改全局 `data/skillhub/session.json`。本次 exchange 得到的 Cookie 只保存在该请求的内存会话中，并由同一个 client 完成后续 `/api/auth/me` 和 `/api/skills/share` 请求。

因此，即使另一个 Dashboard 标签页把全局 SkillHub Cookie 切换到其他账号，本次上传也不会串号，同时不会改变另一个标签页的持久化登录状态。

没有携带 `expectedUserUid + expectedBotUid` 的现有 Dashboard 分享流程保持原样，避免影响已有用户。

## 用户与开发影响

- `/api/store` 返回完整的本地 Skill 信息；
- 现有 XiaoBa Dashboard 保持原有使用方式；
- CatsCo WebApp 开发桥接可以展示当前 Bot 的本地 Skills，并执行分享联调；
- 跨标签页切换账号或 Bot 时，受限分享会被安全终止，或继续使用本次请求重新交换得到的正确 SkillHub 会话；
- 不修改 BotDefinition 数据结构，也不修改 Local / Base / Cloud 同步协议。

## 验证结果

- `npm run build`：通过；
- SkillHub、Bot Skill workspace writer lock、Bot Skill sync 相关定向测试：39 项全部通过；
- 新增回归测试：预先把全局 SkillHub Cookie 切换到其他账号，确认上传只携带本次 CatsCo exchange 的 Cookie，并且 `session.json` 内容完全不变；
- `git diff --check`：通过；
- GitHub CI `Build and runtime tests`：通过；
- GitHub CI `CatsCo cross-repo smoke and e2e`：通过；
- GitHub CI `CatsCo/XiaoBa BotDefinition Skills paired contract tests`：通过。

## 当前边界

- 本 PR 不新增远端 SkillHub 服务端接口；
- 不修改 BotDefinition 数据结构；
- 不修改 Local / Base / Cloud 同步逻辑；
- 不改变未携带预期用户和 Bot 范围的 Dashboard 分享流程；
- 不提交 `prompt-overrides/`、`tmp/`、`work/` 或本地 Skill 元数据等运行时文件；
- 本 PR 保持开放，由团队重新审阅后决定是否合并。

## 后续

CatsCo 侧继续负责正式 SkillHub 目录代理、WebApp BotDefinition Skills 管理及本地联调入口。正式 WebApp 与用户设备的长期连接后续通过 Connector / device RPC 等安全通道实现。
