### PR TITLE
fix(bot-definition): follow cloud context window for catalog models

### DIFF
--- a/src/bot-definition/activation.ts
+++ b/src/bot-definition/activation.ts
@@ -302,6 +302,7 @@ export async function prepareBoundBotDefinition(
             botId,
             modelId: cloudSelection.modelId,
             reasoningEffort: cloudSelection.reasoningEffort,
+            contextWindowTokens: cloudSelection.contextWindowTokens,
             existingRuntime: runtime ?? definitionService.readCatalogRuntime(botId),
             auth,
             fetchImpl: options.fetchImpl,
@@ -320,6 +321,7 @@ export async function prepareBoundBotDefinition(
                 botId,
                 modelId: cloudSelection.modelId,
                 reasoningEffort: cloudSelection.reasoningEffort,
+                contextWindowTokens: cloudSelection.contextWindowTokens,
                 existingRuntime: runtime,
                 auth,
                 fetchImpl: options.fetchImpl,
@@ -336,12 +338,19 @@ export async function prepareBoundBotDefinition(
             }
           }
           if (
-            cloudSelection.reasoningEffort
-            && effectiveRuntime.reasoningEffort !== cloudSelection.reasoningEffort
+            (cloudSelection.reasoningEffort
+              && effectiveRuntime.reasoningEffort !== cloudSelection.reasoningEffort)
+            || (cloudSelection.contextWindowTokens !== undefined
+              && effectiveRuntime.contextWindowTokens !== cloudSelection.contextWindowTokens)
           ) {
             definitionService.storeCloudCatalogRuntime({
               ...effectiveRuntime,
-              reasoningEffort: cloudSelection.reasoningEffort,
+              ...(cloudSelection.reasoningEffort
+                ? { reasoningEffort: cloudSelection.reasoningEffort }
+                : {}),
+              ...(cloudSelection.contextWindowTokens !== undefined
+                ? { contextWindowTokens: cloudSelection.contextWindowTokens }
+                : {}),
             });
           }
         }

--- a/src/bot-definition/cloud-client.ts
+++ b/src/bot-definition/cloud-client.ts
@@ -18,6 +18,12 @@ export interface CloudBotModelSelection {
   kind?: 'catalog' | 'custom' | 'local';
   modelId: string;
   reasoningEffort?: ReasoningEffort;
+  /**
+   * Cloud-authoritative context window for catalog selections. Optional so
+   * older servers (or custom models) continue to work; when present the
+   * device-local profile must not override it.
+   */
+  contextWindowTokens?: number;
   revision: number;
   customModel?: CustomBotModelDefinition;
   definition?: BotDefinition;
@@ -57,6 +63,9 @@ export async function pullCloudBotModelSelection(
         modelId: model.modelId,
         revision: definitionSnapshot.revision,
         definition: definitionSnapshot.definition,
+        ...(model.kind === 'catalog' && model.contextWindowTokens
+          ? { contextWindowTokens: model.contextWindowTokens }
+          : {}),
         ...(model.reasoningEffort ? { reasoningEffort: model.reasoningEffort } : {}),
       };
   }
@@ -101,7 +110,15 @@ export async function pullLegacyCloudBotModelSelection(
       ...(reasoningEffort ? { reasoningEffort } : {}),
     };
   }
-  return { kind: 'catalog', modelId, revision, ...(reasoningEffort ? { reasoningEffort } : {}) };
+  return {
+    kind: 'catalog',
+    modelId,
+    revision,
+    ...(parseCloudContextWindowTokens(response?.desired?.context_window_tokens) !== undefined
+      ? { contextWindowTokens: parseCloudContextWindowTokens(response?.desired?.context_window_tokens) }
+      : {}),
+    ...(reasoningEffort ? { reasoningEffort } : {}),
+  };
 }
 
 export async function pullCloudBotDefinition(
@@ -282,12 +299,14 @@ function parseCloudBotDefinitionSnapshot(
     const modelId = String(rawModel?.modelId || '').trim();
     const rawReasoning = String(rawModel?.reasoningEffort || '').trim();
     const reasoningEffort = rawReasoning ? normalizeReasoningEffort(rawReasoning) : undefined;
+    const contextWindowTokens = parseCloudContextWindowTokens(rawModel?.contextWindowTokens);
     if (!modelId || (rawReasoning && !reasoningEffort)) {
       throw new Error('CatsCo cloud returned an invalid catalog BotDefinition.');
     }
     model = {
       kind: 'catalog',
       modelId,
+      ...(contextWindowTokens !== undefined ? { contextWindowTokens } : {}),
       ...(reasoningEffort ? { reasoningEffort } : {}),
     };
   } else {
@@ -315,6 +334,11 @@ function parseCloudBotDefinitionSnapshot(
       ? { runtime: response.runtime as Record<string, unknown> }
       : {}),
   };
+}
+
+function parseCloudContextWindowTokens(value: unknown): number | undefined {
+  const tokens = Number(value);
+  return Number.isInteger(tokens) && tokens > 0 ? tokens : undefined;
 }
 
 function parseCloudPromptDefinition(value: unknown): BotPromptDefinition | undefined {

--- a/src/bot-definition/types.ts
+++ b/src/bot-definition/types.ts
@@ -12,6 +12,12 @@ export interface CatalogBotModelDefinition {
   kind: 'catalog';
   modelId: string;
   reasoningEffort?: ReasoningEffort;
+  /**
+   * Cloud-authoritative context window for the catalog model when the server
+   * ships it. When present it must win over any device-local profile value so
+   * the catalog cannot drift from what devices actually send upstream.
+   */
+  contextWindowTokens?: number;
 }
 
 /**

--- a/src/catscompany/relay-model-bootstrap.ts
+++ b/src/catscompany/relay-model-bootstrap.ts
@@ -16,6 +16,11 @@ export interface CatsRelayBootstrapOptions {
   modelId: string;
   auth: CatsCoAuthSnapshot;
   reasoningEffort?: ReasoningEffort;
+  /**
+   * Cloud-authoritative context window for the catalog model. When provided it
+   * must win over the local profile so the device follows the catalog.
+   */
+  contextWindowTokens?: number;
   existingRuntime?: BotCatalogModelRuntime;
   fetchImpl?: typeof fetch;
 }
@@ -55,6 +60,7 @@ export async function provisionCatsRelayCatalogRuntime(
         options.existingRuntime,
         profile.id,
         options.reasoningEffort,
+        options.contextWindowTokens,
       );
       await validateCatsRelayCatalogRuntimeCredential(retargeted, fetchImpl);
       return retargeted;
@@ -96,7 +102,7 @@ export async function provisionCatsRelayCatalogRuntime(
     apiBase: relayEndpointForProvider(relayConfig, profile.preferredProvider),
     apiKey,
     model: profile.model,
-    contextWindowTokens: profile.contextWindowTokens,
+    contextWindowTokens: options.contextWindowTokens ?? profile.contextWindowTokens,
     reasoningEffort: options.reasoningEffort ?? 'high',
     openaiApiMode: profile.openaiApiMode ?? 'chat_completions',
     capabilities,
@@ -109,6 +115,7 @@ export function retargetCatsRelayCatalogRuntime(
   existing: BotCatalogModelRuntime,
   modelId: string,
   reasoningEffort?: ReasoningEffort,
+  contextWindowTokens?: number,
 ): BotCatalogModelRuntime {
   const profile = findRelayModelProfile(modelId);
   if (!profile) throw new Error(`Unknown CatsCo relay model: ${modelId}`);
@@ -123,7 +130,7 @@ export function retargetCatsRelayCatalogRuntime(
     apiBase: retargetRelayEndpoint(existing, profile.preferredProvider),
     apiKey,
     model: profile.model,
-    contextWindowTokens: profile.contextWindowTokens,
+    contextWindowTokens: contextWindowTokens ?? existing.contextWindowTokens ?? profile.contextWindowTokens,
     reasoningEffort: reasoningEffort ?? 'high',
     openaiApiMode: profile.openaiApiMode ?? 'chat_completions',
     capabilities: existing.capabilities ?? { ...profile.capabilities },

--- a/src/utils/relay-model-profiles.ts
+++ b/src/utils/relay-model-profiles.ts
@@ -95,7 +95,10 @@ export const RELAY_MODEL_PROFILES: RelayModelProfile[] = [
     quotaClass: 'gpt-5.6',
     preferredProvider: 'openai' as const,
     openaiApiMode: 'responses' as const,
-    contextWindowTokens: 1_000_000,
+    // Keep in sync with the cloud catalog (botModelCatalog). This is only a
+    // device-local fallback: the cloud-authoritative value wins when the
+    // server ships context_window_tokens for the selection.
+    contextWindowTokens: 256_000,
     modelsDevProvider: 'openai',
     modelsDevModel: `gpt-5.6-${variant}`,
     capabilities: {

--- a/tests/bot-definition-activation.test.ts
+++ b/tests/bot-definition-activation.test.ts
@@ -112,6 +112,77 @@ describe('BotDefinition activation', () => {
     ]);
   });
 
+  test('cloud context window updates an existing catalog runtime without re-materializing', async () => {
+    const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-definition-cloud-ctx-runtime-'));
+    const simulatedCloudRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-definition-cloud-ctx-cloud-'));
+    roots.push(runtimeRoot, simulatedCloudRoot);
+    const env = { CATSCO_MODEL_SOURCE: 'relay' } as NodeJS.ProcessEnv;
+    createCatsCoLocalConfigService({ runtimeRoot, env }).save({
+      version: 1,
+      endpoints: {
+        httpBaseUrl: 'https://cats.example.test',
+        serverUrl: 'wss://cats.example.test/v0/channels',
+      },
+      account: { token: 'owner-token', uid: '7', displayName: 'Alice' },
+      currentBot: {
+        uid: '43',
+        apiKey: 'bot-api-key',
+        boundByUserUid: '7',
+        bindingSource: 'test',
+      },
+      device: { deviceId: 'device-1', bodyId: 'body-1', installationId: 'install-1' },
+    });
+
+    // 模拟旧设备：持久化的 cloud catalog runtime 是 100 万（历史漂移值）。
+    new FileBotCloudCatalogModelRuntimeRepository({ runtimeRoot }).write({
+      schema: 'xiaoba.bot-catalog-model-runtime.v1',
+      botId: '43',
+      modelId: 'gpt-5.6-sol',
+      provider: 'openai',
+      apiBase: 'https://relay.example.test/v1',
+      apiKey: 'sk-existing-relay-key',
+      model: 'gpt-5.6-sol',
+      contextWindowTokens: 1_000_000,
+      reasoningEffort: 'xhigh',
+      openaiApiMode: 'responses',
+      capabilities: { vision: true, toolCalling: true, streaming: true },
+      capabilitiesSource: 'relay-models',
+    });
+
+    const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(String(input));
+      if (url.pathname === '/v1/models' || url.pathname.endsWith('/models')) {
+        return Response.json({
+          data: [{ id: 'gpt-5.6-sol', capabilities: { vision: true, tool_calling: true, streaming: true } }],
+        });
+      }
+      return Response.json({ error: 'unexpected request' }, { status: 500 });
+    }) as typeof fetch;
+
+    // 直接走 cloudSelection 分支（不重新拉云端 definition）：
+    // 云端已下发权威 context window 256000，而设备持久化的旧 runtime 是 100 万。
+    const prepared = await prepareBoundBotDefinition({
+      runtimeRoot,
+      simulatedCloudRoot,
+      env,
+      fetchImpl,
+      cloudSelection: {
+        kind: 'catalog',
+        modelId: 'gpt-5.6-sol',
+        contextWindowTokens: 256000,
+        reasoningEffort: 'xhigh',
+        revision: 12,
+      },
+    });
+    assert.equal(prepared?.botId, '43');
+
+    const runtime = new FileBotCloudCatalogModelRuntimeRepository({ runtimeRoot }).read('43');
+    assert.equal(runtime?.modelId, 'gpt-5.6-sol');
+    assert.equal(runtime?.contextWindowTokens, 256_000);
+    assert.equal(runtime?.apiKey, 'sk-existing-relay-key');
+    assert.equal(runtime?.apiBase, 'https://relay.example.test/v1');
+  });
+
   test('uploads a local legacy Definition when the cloud bot is not configured yet', async () => {
     const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-definition-cloud-bootstrap-runtime-'));
     const simulatedCloudRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-definition-cloud-bootstrap-legacy-'));

--- a/tests/catscompany-relay-model-bootstrap.test.ts
+++ b/tests/catscompany-relay-model-bootstrap.test.ts
@@ -73,8 +73,49 @@ describe('CatsCo default relay model bootstrap', () => {
     ]);
   });
 
-  test('replaces stale GPT vision=false runtime metadata from the relay catalog', async () => {
-    const fetchImpl = (async () => Response.json({
+  test('cloud context window wins over the local profile for catalog models', async () => {
+    const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(String(input));
+      if (url.pathname === '/api/relay/config') {
+        return Response.json({
+          base_url: 'https://relay.example.test',
+          self_service_enabled: true,
+          endpoints: [{ protocol: 'OpenAI-compatible', base_url: 'https://relay.example.test/v1' }],
+        });
+      }
+      if (url.pathname === '/api/relay/key') {
+        return Response.json({ key: { key: 'sk-relay-key' } });
+      }
+      if (url.pathname === '/v1/models') {
+        return Response.json({
+          data: [{ id: 'gpt-5.6-sol', capabilities: { vision: true, tool_calling: true, streaming: true } }],
+        });
+      }
+      return new Response(JSON.stringify({ error: 'unexpected request' }), { status: 500 });
+    }) as typeof fetch;
+
+    const runtime = await provisionCatsRelayCatalogRuntime({
+      botId: 'bot-1',
+      modelId: 'gpt-5.6-sol',
+      // 模拟服务器下发权威 context window（200k），必须覆盖本地 profile 的 256k。
+      contextWindowTokens: 200_000,
+      auth: {
+        token: 'user-token',
+        uid: 'user-1',
+        displayName: 'Alice',
+        httpBaseUrl: 'https://cats.example.test',
+        serverUrl: 'wss://cats.example.test/v0/channels',
+      },
+      fetchImpl,
+    });
+
+    assert.equal(runtime.modelId, 'gpt-5.6-sol');
+    assert.equal(runtime.provider, 'openai');
+    assert.equal(runtime.apiBase, 'https://relay.example.test/v1');
+    assert.equal(runtime.contextWindowTokens, 200_000);
+  });
+
+  test('replaces stale GPT vision=false runtime metadata from the relay catalog', async () => {    const fetchImpl = (async () => Response.json({
       data: [{
         id: 'gpt-5.6-terra',
         capabilities: { vision: true, tool_calling: true, streaming: true },

--- a/tests/cloud-bot-model-client.test.ts
+++ b/tests/cloud-bot-model-client.test.ts
@@ -205,4 +205,55 @@ describe('cloud bot model client local handoff', () => {
       reasoning_effort: '',
     });
   });
+
+  test('reads cloud context window for catalog selections from BotDefinition', async () => {
+    const selection = await pullCloudBotModelSelection({
+      botId: '43',
+      auth,
+      fetchImpl: (async () => Response.json({
+        uid: 43,
+        configured: true,
+        revision: 9,
+        definition: {
+          schema: 'xiaoba.bot-definition.v1',
+          botId: '43',
+          model: { kind: 'catalog', modelId: 'gpt-5.6-sol', contextWindowTokens: 256000 },
+        },
+      })) as typeof fetch,
+    });
+
+    assert.deepStrictEqual(selection, {
+      kind: 'catalog',
+      modelId: 'gpt-5.6-sol',
+      contextWindowTokens: 256000,
+      revision: 9,
+      definition: {
+        schema: 'xiaoba.bot-definition.v1',
+        botId: '43',
+        model: { kind: 'catalog', modelId: 'gpt-5.6-sol', contextWindowTokens: 256000 },
+      },
+    });
+  });
+
+  test('reads cloud context window from the legacy model-config contract', async () => {
+    const selection = await pullCloudBotModelSelection({
+      botId: '43',
+      auth,
+      fetchImpl: (async () => Response.json({
+        uid: 43,
+        configured: true,
+        desired: {
+          kind: 'catalog', model_id: 'gpt-5.6-sol', revision: 10,
+          context_window_tokens: 256000,
+        },
+      })) as typeof fetch,
+    });
+
+    assert.deepStrictEqual(selection, {
+      kind: 'catalog',
+      modelId: 'gpt-5.6-sol',
+      contextWindowTokens: 256000,
+      revision: 10,
+    });
+  });
 });

--- a/tests/model-capabilities.test.ts
+++ b/tests/model-capabilities.test.ts
@@ -62,9 +62,9 @@ describe('model capabilities', () => {
         { model: 'MiniMax-M2.7', provider: 'anthropic', vision: false, context: 204_800 },
         { model: 'MiniMax-M3', provider: 'anthropic', vision: true, context: 1_000_000 },
         { model: 'deepseek-v4-flash', provider: 'anthropic', vision: false, context: 1_000_000 },
-        { model: 'gpt-5.6-terra', provider: 'openai', vision: true, context: 1_000_000 },
-        { model: 'gpt-5.6-sol', provider: 'openai', vision: true, context: 1_000_000 },
-        { model: 'gpt-5.6-luna', provider: 'openai', vision: true, context: 1_000_000 },
+        { model: 'gpt-5.6-terra', provider: 'openai', vision: true, context: 256_000 },
+        { model: 'gpt-5.6-sol', provider: 'openai', vision: true, context: 256_000 },
+        { model: 'gpt-5.6-luna', provider: 'openai', vision: true, context: 256_000 },
       ],
     );
     assert.strictEqual(findRelayModelProfile('minimax-m3')?.capabilities.vision, true);

--- a/tests/model-context-window.test.ts
+++ b/tests/model-context-window.test.ts
@@ -34,6 +34,16 @@ test('relay catalog models resolve to their official context windows', () => {
     model: 'deepseek-v4-flash',
     provider: 'anthropic',
   }, { CATSCO_MODEL_SOURCE: 'relay' } as NodeJS.ProcessEnv).contextWindowTokens, 1_000_000);
+
+  // GPT-5.6 family follows the cloud catalog's 256k window as the device-local
+  // fallback (the cloud ships the authoritative value when available).
+  for (const model of ['gpt-5.6-terra', 'gpt-5.6-sol', 'gpt-5.6-luna']) {
+    assert.equal(resolveModelContextWindow({
+      apiUrl: 'https://relay.catsco.cc/openai',
+      model,
+      provider: 'openai',
+    }, { CATSCO_MODEL_SOURCE: 'relay' } as NodeJS.ProcessEnv).contextWindowTokens, 256_000);
+  }
 });
 
 test('custom models keep the safe default even if the model name resembles a known relay model', () => {


### PR DESCRIPTION
### 问题

catalog 模型的 `context_window_tokens` 由**设备本地 profile** 决定（`relay-model-profiles.ts` 把 `gpt-5.6-*` 硬编码为 **100 万**），而云端 catalog 定义为 **256k**。两端漂移导致：

- 会话上下文涨到 41 万 token 只占 100 万预算 46%，**永不触发压缩**
- 超大请求被上游拒绝（403 / rate_limit / 524 / 流式截断），真实错误又被 `shouldRetryWithoutExplicitCaching` 对流对象 `JSON.stringify` 崩溃掩盖成"不好意思，刚才处理出了点问题"

**实测**：生产云端 `/api/bot/definition` 与 `/api/bot/model-config` 均未下发 `context_window_tokens`（`HAS context_window_tokens: FALSE`）；设备实际生效 runtime（`bot-cloud-catalog-model-runtime/537.json`）= 100 万；用户自定义 profile 的 256k 因走 catalog 路径未生效。

### 改动

- `cloud-client.ts`：解析云端下发的 `context_window_tokens`（BotDefinition 与 legacy model-config 两条契约）到 `CloudBotModelSelection`
- `relay-model-bootstrap.ts`：物化/重定向 catalog runtime 时**优先云端值**
- `activation.ts`：云端值变化时**更新已持久化 runtime**（不重新物化凭据）
- `relay-model-profiles.ts`：`gpt-5.6-*` 兜底对齐云端 **256k**
- 测试：两条契约解析、物化优先级、activation 更新（旧 100 万 → 256k）、profile 窗口

### 验证

- `npm test` 完整套件：1376 tests / fail 0
- 端到端（真实代码消费修改后云端真实输出）：
  - legacy 解析 → `contextWindowTokens: 256000` PASS
  - definition 解析 → `contextWindowTokens: 256000` PASS
  - bootstrap 物化 → `runtime.contextWindowTokens = 256000` PASS
  - activation 更新 → 持久化 runtime 从 100 万变 256000（凭据保留）PASS

### 配套

需与 cats-company PR（`fix/cloud-context-window-authority`：catalog 模型下发 context_window_tokens）一起部署才生效。部署后设备 runtime 收敛到 256k，超大会话触发压缩，上游不再拒绝。

### 遗留建议（另开 PR）

`openai-provider.ts` 的 `shouldRetryWithoutExplicitCaching` 对 `error.response.data`（`responseType:'stream'` 时为 IncomingMessage/TLSSocket 循环引用）直接 `JSON.stringify` 崩溃，掩盖真实上游错误——建议单独修复为安全序列化。
