### PR TITLE
fix(dashboard): embed cache trace monitor as SPA page with back navigation

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -5306,7 +5306,7 @@
       <a class="nav-item" onclick="switchPage('prompts')" data-page="prompts">
         <span class="nav-icon">#</span> <span>提示词</span>
       </a>
-      <a class="nav-item" href="cache-trace.html">
+      <a class="nav-item" onclick="switchPage('cache-trace')" data-page="cache-trace">
         <span class="nav-icon">%</span> <span>缓存监控</span>
       </a>
       <a class="nav-item" onclick="switchPage('companion')" data-page="companion">
@@ -5554,6 +5554,23 @@
         <div class="prompt-workbench" id="prompt-workbench">
           <div class="loading">加载提示词...</div>
         </div>
+      </div>
+
+      <!-- Page: Cache Trace -->
+      <div class="page" id="page-cache-trace">
+        <div class="settings-header">
+          <div class="settings-heading">
+            <div class="settings-kicker">Diagnostics</div>
+            <div class="section-title" style="margin-bottom:0">缓存命中监控</div>
+            <div class="settings-meta">缓存命中率与重试诊断（内部工具）。</div>
+          </div>
+          <div class="settings-actions">
+            <button class="btn" onclick="switchPage('services')">← 返回</button>
+          </div>
+        </div>
+        <iframe id="cache-trace-frame" src="cache-trace.html"
+          style="width:100%;height:calc(100vh - 240px);min-height:520px;border:1px solid var(--border);border-radius:14px;background:#07101f"
+          title="缓存命中监控"></iframe>
       </div>
 
       <!-- Page: Chat -->
@@ -5892,7 +5909,7 @@
     let appReadinessSnapshot = {};
     let appReadinessLoaded = false;
     let appReadinessError = '';
-    const pageTitles = { services:'Agent Hub', branches:'Branch Runtime', store:'SkillHub', prompts:'Prompt Lab', companion:'Companion Hub', chat:'CatsCo' };
+    const pageTitles = { services:'Agent Hub', branches:'Branch Runtime', store:'SkillHub', prompts:'Prompt Lab', companion:'Companion Hub', chat:'CatsCo', 'cache-trace':'缓存命中监控' };
     let catsAuthMode = 'login';
     let catsState = {};
     let catsNextAction = 'none';

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -5568,7 +5568,7 @@
             <button class="btn" onclick="switchPage('services')">← 返回</button>
           </div>
         </div>
-        <iframe id="cache-trace-frame" src="cache-trace.html"
+        <iframe id="cache-trace-frame" data-src="cache-trace.html"
           style="width:100%;height:calc(100vh - 240px);min-height:520px;border:1px solid var(--border);border-radius:14px;background:#07101f"
           title="缓存命中监控"></iframe>
       </div>
@@ -6817,6 +6817,12 @@
       } else if (name === 'services') {
         fetchStatus();
         refreshSettingsPage();
+      } else if (name === 'cache-trace') {
+        const frame = document.getElementById('cache-trace-frame');
+        if (frame) {
+          if (!frame.getAttribute('src')) frame.src = frame.dataset.src;
+          else frame.contentWindow && frame.contentWindow.location.reload();
+        }
       }
     }
 

--- a/tests/cache-trace-monitoring.test.ts
+++ b/tests/cache-trace-monitoring.test.ts
@@ -285,7 +285,10 @@ test('dashboard exposes a discoverable cache trace page', () => {
   const root = path.resolve(__dirname, '..');
   const index = fs.readFileSync(path.join(root, 'dashboard', 'index.html'), 'utf8');
   const page = fs.readFileSync(path.join(root, 'dashboard', 'cache-trace.html'), 'utf8');
-  assert.match(index, /href="cache-trace\.html"/);
+  assert.match(index, /onclick="switchPage\('cache-trace'\)" data-page="cache-trace"/);
+  assert.match(index, /id="page-cache-trace"/);
+  assert.match(index, /id="cache-trace-frame"/);
+  assert.match(index, /data-src="cache-trace\.html"/);
   assert.match(page, /缓存命中监控/);
   assert.match(page, /catsco\.dashboardApiKey/);
   assert.match(page, /采集 Cache Trace/);


### PR DESCRIPTION
## 问题

侧边栏的「缓存监控」入口用 `<a href="cache-trace.html">` 整页跳转：

- 点击后浏览器**完全替换** dashboard SPA（CatsCo、智能体中心、Branch、Skills、提示词、伙伴中心全部消失），只剩 cache-trace.html 独立页面
- 独立页面**没有返回 dashboard 的导航/按钮**，点进去后无法回到主界面（"卡住、其他界面全没了"）

## 修复

将缓存监控改为 **SPA 内嵌页面**：

- 侧边栏入口 `href="cache-trace.html"` → `onclick="switchPage('cache-trace')"` + `data-page="cache-trace"`（不再整页跳转，侧边栏与其他界面保留）
- 新增 `<div class="page" id="page-cache-trace">`：头部（Diagnostics / 缓存命中监控）+ **「← 返回」按钮**（回到智能体中心）+ `<iframe src="cache-trace.html">` 内嵌原监控页
- `pageTitles` 增加 `cache-trace` 映射，topbar 标题正确显示「缓存命中监控」

## 验证

浏览器实测完整链路：

1. 侧边栏点击「缓存监控」→ 内嵌页面切换，侧边栏/悬浮伙伴等其余界面保留
2. iframe 加载 cache-trace.html 成功，API 数据正常返回
3. 点击「← 返回」→ 回到智能体中心（Agent Hub）