### PR TITLE
fix: preserve model progress across transient 504 failures

### DIFF
--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -83,6 +83,8 @@ export const BUSY_MESSAGE = '正在处理上一条消息，请稍候...';
 export const ERROR_MESSAGE = '本次处理未能完成，请稍后再试。';
 export const MODEL_TIMEOUT_MESSAGE = '模型响应超时，本轮上下文已保留，请稍后继续。';
 export const MODEL_TRANSIENT_ERROR_MESSAGE = '模型服务暂时不可用，请稍后再试。';
+export const MODEL_STREAM_INTERRUPTED_MESSAGE = '模型服务在输出过程中中断，已持久化保存已完成内容和工具结果。你可以直接说“继续”，我会从当前进度接上。';
+export const MODEL_STREAM_INTERRUPTED_MEMORY_ONLY_MESSAGE = '模型服务在输出过程中中断。当前进程仍保留已完成内容和工具结果，但未能写入持久存储；请在当前会话直接说“继续”，重启后可能无法恢复。';
 export const EMPTY_MODEL_RESPONSE_MESSAGE = '模型本轮未返回有效内容，请重新发送上一条消息；若仍失败，请切换模型或稍后再试。';
 export const CONTEXT_COMPACTION_START_MESSAGE = '正在压缩上下文，整理较早的对话内容。';
 export const CONTEXT_COMPACTION_COMPLETE_MESSAGE = '上下文压缩完成，继续处理当前请求。';
@@ -728,7 +730,7 @@ export class AgentSession {
         }
 
         const recoveredMessages = this.getPartialMessagesFromError(err);
-        const partialProgressPreserved = recoveredMessages
+        const partialProgressInMemory = recoveredMessages
           ? this.hasRecoverablePartialProgress(recoveredMessages)
           : false;
         if (recoveredMessages) {
@@ -758,6 +760,25 @@ export class AgentSession {
         });
         const diagnostics = classified.diagnostics;
         const retry = diagnostics.retry;
+
+        // Persist the recovered draft before reporting whether it survives a restart.
+        // The in-memory draft remains usable even when the durable write fails.
+        this.messages.push({
+          role: 'assistant',
+          content: this.formatErrorContextMessage(err, {
+            isModelTimeoutError,
+            isImageSafetyError,
+            isTransientProviderError,
+            isEmptyModelResponseError,
+          }),
+          __internalErrorArtifact: true,
+        });
+        this.messages = stripAssistantArtifactsFromMessages(this.turnContextBuilder.removeTransientMessages(this.messages));
+        const contextPersisted = this.lifecycleManager.saveContext(this.messages);
+        const partialProgressPersistence: 'none' | 'memory_only' | 'durable' = partialProgressInMemory
+          ? contextPersisted ? 'durable' : 'memory_only'
+          : 'none';
+
         const errorPayload: TurnErrorPayload = {
           error_code: classified.error_code,
           category: classified.category,
@@ -782,7 +803,8 @@ export class AgentSession {
           retry_stop_reason: retry?.stop_reason ?? 'unknown',
           retry_elapsed_ms: retry?.elapsed_ms ?? 0,
           turn_elapsed_ms: Date.now() - turnStartedAt,
-          partial_progress_preserved: partialProgressPreserved,
+          partial_progress_preserved: partialProgressInMemory,
+          partial_progress_persistence: partialProgressPersistence,
           episode_id: diagnostics.attempt?.episode_id,
           model_call_id: diagnostics.attempt?.call_id,
           model_attempt_id: diagnostics.attempt?.attempt_id,
@@ -801,22 +823,13 @@ export class AgentSession {
         const errorReply = this.formatClassifiedErrorReply(
           classified.category,
           classified.user_message,
-          retry?.retry_count ?? 0,
+          {
+            retryCount: retry?.retry_count ?? 0,
+            maxRetries: retry?.max_retries,
+            stopReason: retry?.stop_reason ?? 'unknown',
+            partialProgressPersistence,
+          },
         );
-
-        // 添加错误回复到上下文，保持对话连贯性
-        this.messages.push({
-          role: 'assistant',
-          content: this.formatErrorContextMessage(err, {
-            isModelTimeoutError,
-            isImageSafetyError,
-            isTransientProviderError,
-            isEmptyModelResponseError,
-          }),
-          __internalErrorArtifact: true,
-        });
-        this.messages = stripAssistantArtifactsFromMessages(this.turnContextBuilder.removeTransientMessages(this.messages));
-        this.lifecycleManager.saveContext(this.messages);
 
         return { text: errorReply, visibleToUser: true, taskOutcome: 'failed' };
       } finally {
@@ -1269,21 +1282,50 @@ export class AgentSession {
   private formatClassifiedErrorReply(
     category: ModelErrorCategory,
     fallback: string,
-    retryCount: number,
+    retry: {
+      retryCount: number;
+      maxRetries?: number;
+      stopReason: string;
+      partialProgressPersistence: 'none' | 'memory_only' | 'durable';
+    },
   ): string {
-    if (retryCount <= 0) return fallback;
-    switch (category) {
-      case 'timeout':
-        return '模型响应超时，系统已自动重试，但仍未完成。本轮上下文已保留，请稍后继续。';
-      case 'transient':
-        return '模型服务暂时不可用，系统已自动重试，但仍未恢复，请稍后再试。';
-      case 'rate_limited':
-        return '当前请求较多，系统已自动重试，但仍未恢复，请稍等片刻再试。';
-      case 'empty_response':
-        return '模型本轮未返回有效内容，系统已自动重试但仍未恢复。请重新发送上一条消息；若仍失败，请切换模型或稍后再试。';
-      default:
-        return fallback;
+    if (retry.stopReason === 'stream_output_started' && retry.partialProgressPersistence !== 'none') {
+      return retry.partialProgressPersistence === 'durable'
+        ? MODEL_STREAM_INTERRUPTED_MESSAGE
+        : MODEL_STREAM_INTERRUPTED_MEMORY_ONLY_MESSAGE;
     }
+
+    if (retry.retryCount > 0) {
+      switch (category) {
+        case 'timeout':
+          return '模型响应超时，系统已自动重试，但仍未完成。本轮上下文已保留，请稍后继续。';
+        case 'transient':
+          return '模型服务暂时不可用，系统已自动重试，但仍未恢复，请稍后再试。';
+        case 'rate_limited':
+          return '当前请求较多，系统已自动重试，但仍未恢复，请稍等片刻再试。';
+        case 'empty_response':
+          return '模型本轮未返回有效内容，系统已自动重试但仍未恢复。请重新发送上一条消息；若仍失败，请切换模型或稍后再试。';
+        default:
+          return fallback;
+      }
+    }
+
+    if (retry.maxRetries === 0 && retry.stopReason === 'retry_limit_exhausted') {
+      switch (category) {
+        case 'timeout':
+          return '模型响应超时；当前自动重试上限为 0，因此未执行自动重试。请稍后继续。';
+        case 'transient':
+          return '模型服务暂时不可用；当前自动重试上限为 0，因此未执行自动重试。请稍后再试。';
+        case 'rate_limited':
+          return '当前请求较多；当前自动重试上限为 0，因此未执行自动重试。请稍等片刻再试。';
+        default:
+          return fallback;
+      }
+    }
+
+    // non_retryable, retry_window_exhausted and unknown do not prove that a
+    // retry occurred, so retain the classifier's safe fallback message.
+    return fallback;
   }
 
   private formatErrorContextMessage(

--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -79,6 +79,7 @@ function normalizeToolName(name: string): string {
 const MIN_MESSAGE_BUDGET = 2000;
 const OVERFLOW_REDUCTION_RATIO = 0.6;
 const MAX_EMPTY_MAX_TOKEN_RECOVERIES = 1;
+const PARTIAL_STREAM_TEXT = Symbol.for('xiaoba.partial-stream-text');
 const EMPTY_MAX_TOKENS_MESSAGE = '模型这轮输出达到了 max_tokens 上限，但没有生成可见回复或工具调用。已保留当前上下文；请回复“继续”，我会从刚才的位置继续推进。';
 const REPLAY_ARTIFACT_ONLY_MESSAGE = '模型工具调用回放异常，这轮没有生成可见回复。上下文已保留；你可以直接说“继续”，我会从这里接上。';
 export const PROMPT_BUDGET_TRIM_MESSAGE = '当前上下文超过模型窗口，已裁剪较早的历史内容以继续处理。';
@@ -423,6 +424,16 @@ export class ConversationRunner {
       try {
         response = await this.requestModelResponse(requestMessages, requestTools, turns, callbacks);
       } catch (error: any) {
+        const partialStreamText = this.readPartialStreamText(error);
+        if (partialStreamText) {
+          const assistantDraft: Message = {
+            role: 'assistant',
+            content: partialStreamText,
+            ...(this.episodeId ? { __episodeId: this.episodeId } : {}),
+          };
+          messages.push(assistantDraft);
+          newMessages.push(assistantDraft);
+        }
         this.runObservation(() => this.promptTraceLogger.recordError(turns, error));
         if (this.isMessageSurface() && isModelImageSafetyError(error)) {
           if (!this.suppressFinalResponse && this.toolExecutionContext?.channel && this.toolExecutionContext?.surface !== 'catscompany') {
@@ -1467,6 +1478,31 @@ export class ConversationRunner {
     episodeNumber: number,
     callbacks?: RunnerCallbacks,
   ) {
+    let partialStreamText = '';
+    const streamCallbacks = (): StreamCallbacks => ({
+      onText: (text) => {
+        partialStreamText += text;
+        callbacks?.onText?.(text);
+      },
+      onRetry: (attempt, maxRetries, info) => {
+        // A retry starts a new replay attempt. Never persist output from an
+        // abandoned attempt as if it belonged to the final interrupted one.
+        partialStreamText = '';
+        return callbacks?.onRetry?.(attempt, maxRetries, info);
+      },
+    });
+    const preservePartialStreamText = (error: unknown): void => {
+      if (!partialStreamText || !error || (typeof error !== 'object' && typeof error !== 'function')) return;
+      try {
+        Object.defineProperty(error, PARTIAL_STREAM_TEXT, {
+          value: partialStreamText,
+          configurable: true,
+          enumerable: false,
+        });
+      } catch {
+        // Partial progress is best-effort and must never replace the provider error.
+      }
+    };
     const requestOptions: AIRequestOptions = {
       signal: this.toolExecutionContext?.abortSignal,
       ...(this.cacheTraceSink ? {
@@ -1487,15 +1523,12 @@ export class ConversationRunner {
     };
     try {
       if (this.stream) {
-        const streamCallbacks: StreamCallbacks = {
-          onText: (text) => callbacks?.onText?.(text),
-          onRetry: (attempt, maxRetries, info) => callbacks?.onRetry?.(attempt, maxRetries, info),
-        };
-        return await this.aiService.chatStream(messages, activeTools, streamCallbacks, requestOptions);
+        return await this.aiService.chatStream(messages, activeTools, streamCallbacks(), requestOptions);
       }
       return await this.aiService.chat(messages, activeTools, requestOptions);
     } catch (error: any) {
-      if (!this.isPromptTooLongError(error)) {
+      if (!this.isPromptTooLongError(error) || partialStreamText) {
+        preservePartialStreamText(error);
         throw error;
       }
 
@@ -1506,14 +1539,25 @@ export class ConversationRunner {
         await callbacks.onThinking(PROMPT_BUDGET_TRIM_MESSAGE);
       }
 
-      if (this.stream) {
-        const streamCallbacks: StreamCallbacks = {
-          onText: (text) => callbacks?.onText?.(text),
-          onRetry: (attempt, maxRetries, info) => callbacks?.onRetry?.(attempt, maxRetries, info),
-        };
-        return await this.aiService.chatStream(messages, activeTools, streamCallbacks, requestOptions);
+      try {
+        if (this.stream) {
+          return await this.aiService.chatStream(messages, activeTools, streamCallbacks(), requestOptions);
+        }
+        return await this.aiService.chat(messages, activeTools, requestOptions);
+      } catch (retryError) {
+        preservePartialStreamText(retryError);
+        throw retryError;
       }
-      return await this.aiService.chat(messages, activeTools, requestOptions);
+    }
+  }
+
+  private readPartialStreamText(error: unknown): string {
+    if (!error || (typeof error !== 'object' && typeof error !== 'function')) return '';
+    try {
+      const value = (error as Record<symbol, unknown>)[PARTIAL_STREAM_TEXT];
+      return typeof value === 'string' ? value : '';
+    } catch {
+      return '';
     }
   }
 

--- a/src/observability/turn-error-reader.ts
+++ b/src/observability/turn-error-reader.ts
@@ -30,6 +30,7 @@ export interface TurnErrorRecord {
   retry_elapsed_ms: number;
   turn_elapsed_ms: number;
   partial_progress_preserved: boolean;
+  partial_progress_persistence: 'none' | 'memory_only' | 'durable';
   episode_id: string;
   model_call_id: string;
   model_attempt_id: string;
@@ -174,6 +175,7 @@ function toTurnErrorRecord(entry: any, sourceFile: string, sourceLine: number): 
     retry_elapsed_ms: safeInteger(payload.retry_elapsed_ms, 0),
     turn_elapsed_ms: safeInteger(payload.turn_elapsed_ms, 0),
     partial_progress_preserved: payload.partial_progress_preserved === true,
+    partial_progress_persistence: normalizePartialProgressPersistence(payload),
     episode_id: safeText(payload.episode_id),
     model_call_id: safeText(payload.model_call_id),
     model_attempt_id: safeText(payload.model_attempt_id),
@@ -181,6 +183,12 @@ function toTurnErrorRecord(entry: any, sourceFile: string, sourceLine: number): 
     source_file: sourceFile,
     source_line: sourceLine,
   };
+}
+
+function normalizePartialProgressPersistence(payload: any): TurnErrorRecord['partial_progress_persistence'] {
+  const value = safeText(payload?.partial_progress_persistence);
+  if (value === 'durable' || value === 'memory_only' || value === 'none') return value;
+  return payload?.partial_progress_preserved === true ? 'memory_only' : 'none';
 }
 
 function aggregate(records: TurnErrorRecord[], keyOf: (record: TurnErrorRecord) => string): TurnErrorAggregate[] {

--- a/src/utils/session-log-schema.ts
+++ b/src/utils/session-log-schema.ts
@@ -89,7 +89,10 @@ export interface TurnErrorPayload {
   retry_stop_reason?: string;
   retry_elapsed_ms?: number;
   turn_elapsed_ms?: number;
+  /** True when recoverable progress remains available in the current process. */
   partial_progress_preserved?: boolean;
+  /** Whether that progress also survived the durable session write. */
+  partial_progress_persistence?: 'none' | 'memory_only' | 'durable';
   episode_id?: string;
   model_call_id?: string;
   model_attempt_id?: string;

--- a/tests/agent-session-abort-signal.test.ts
+++ b/tests/agent-session-abort-signal.test.ts
@@ -1,6 +1,13 @@
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
 import test from 'node:test';
-import { AgentSession } from '../src/core/agent-session';
+import {
+  AgentSession,
+  MODEL_STREAM_INTERRUPTED_MEMORY_ONLY_MESSAGE,
+  MODEL_STREAM_INTERRUPTED_MESSAGE,
+  MODEL_TIMEOUT_MESSAGE,
+} from '../src/core/agent-session';
+import { attachRetrySummary } from '../src/utils/model-error-observability';
 
 test('AgentSession schedules Bot Skill workspace sync after a completed turn', async () => {
   let scheduledSyncs = 0;
@@ -20,6 +27,213 @@ test('AgentSession schedules Bot Skill workspace sync after a completed turn', a
 
   assert.equal(result.text, 'done');
   assert.equal(scheduledSyncs, 1);
+});
+
+test('AgentSession preserves partial stream text and offers continuation after a 504 interruption', async () => {
+  const session = new AgentSession('user:partial-stream-504', buildMockServices({
+    aiService: {
+      getConfig() { return { provider: 'openai', model: 'primary-model' }; },
+      async chatStream(_messages: any[], _tools: any[], callbacks: any) {
+        callbacks?.onText?.('已经完成的部分');
+        const error = Object.assign(new Error('API错误 (504): gateway timeout'), { status: 504 });
+        attachRetrySummary(error, {
+          attempt_count: 1,
+          retry_count: 0,
+          max_retries: 14,
+          elapsed_ms: 10,
+          max_elapsed_ms: 300000,
+          stop_reason: 'stream_output_started',
+        });
+        throw error;
+      },
+    },
+  }), 'catscompany');
+  session.setSystemPromptProvider(() => 'system prompt');
+
+  const result = await session.handleMessage('执行一个会流中断的任务');
+
+  assert.equal(result.text, MODEL_STREAM_INTERRUPTED_MESSAGE);
+  assert.equal(result.taskOutcome, 'failed');
+  assert.equal((session as any).messages.some((message: any) => message.content === '已经完成的部分'), true);
+});
+
+test('AgentSession reports memory-only recovery when the partial draft cannot be persisted', async () => {
+  const session = new AgentSession('user:partial-stream-memory-only', buildMockServices({
+    aiService: {
+      getConfig() { return { provider: 'openai', model: 'primary-model' }; },
+      async chatStream(_messages: any[], _tools: any[], callbacks: any) {
+        callbacks?.onText?.('仅内存保留的部分');
+        const error = Object.assign(new Error('API错误 (504): gateway timeout'), { status: 504 });
+        attachRetrySummary(error, {
+          attempt_count: 1,
+          retry_count: 0,
+          max_retries: 14,
+          elapsed_ms: 10,
+          max_elapsed_ms: 300000,
+          stop_reason: 'stream_output_started',
+        });
+        throw error;
+      },
+    },
+  }), 'catscompany');
+  session.setSystemPromptProvider(() => 'system prompt');
+  (session as any).lifecycleManager.saveContext = () => false;
+
+  const result = await session.handleMessage('执行一个无法落盘的流中断任务');
+
+  assert.equal(result.text, MODEL_STREAM_INTERRUPTED_MEMORY_ONLY_MESSAGE);
+  assert.equal((session as any).messages.some((message: any) => message.content === '仅内存保留的部分'), true);
+  const logPath = (session as any).sessionTurnLogger.getLogFilePath();
+  const turnError = fs.readFileSync(logPath, 'utf8')
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map(line => JSON.parse(line))
+    .find(entry => entry?.event?.type === 'turn_error');
+  assert.equal(turnError.event.payload.partial_progress_preserved, true);
+  assert.equal(turnError.event.payload.partial_progress_persistence, 'memory_only');
+});
+
+test('AgentSession only claims automatic retries when retry_count is positive', async () => {
+  const cases = [
+    { stopReason: 'non_retryable', expected: MODEL_TIMEOUT_MESSAGE },
+    { stopReason: 'retry_window_exhausted', expected: MODEL_TIMEOUT_MESSAGE },
+    { stopReason: 'unknown', expected: MODEL_TIMEOUT_MESSAGE },
+  ] as const;
+
+  for (const testCase of cases) {
+    const session = new AgentSession(`user:no-retry-claim:${testCase.stopReason}`, buildMockServices({
+      aiService: {
+        getConfig() { return { provider: 'openai', model: 'primary-model' }; },
+        async chatStream() {
+          const error = Object.assign(new Error('API错误 (504): gateway timeout'), { status: 504 });
+          attachRetrySummary(error, {
+            attempt_count: 1,
+            retry_count: 0,
+            max_retries: 14,
+            elapsed_ms: 300000,
+            max_elapsed_ms: 300000,
+            stop_reason: testCase.stopReason,
+          });
+          throw error;
+        },
+      },
+    }), 'catscompany');
+    session.setSystemPromptProvider(() => 'system prompt');
+
+    const result = await session.handleMessage(`验证 ${testCase.stopReason}`);
+
+    assert.equal(result.text, testCase.expected);
+    assert.doesNotMatch(result.text, /自动重试/);
+  }
+
+  const retriedSession = new AgentSession('user:positive-retry-claim', buildMockServices({
+    aiService: {
+      getConfig() { return { provider: 'openai', model: 'primary-model' }; },
+      async chatStream() {
+        const error = Object.assign(new Error('API错误 (504): gateway timeout'), { status: 504 });
+        attachRetrySummary(error, {
+          attempt_count: 3,
+          retry_count: 2,
+          max_retries: 2,
+          elapsed_ms: 100,
+          max_elapsed_ms: 300000,
+          stop_reason: 'retry_limit_exhausted',
+        });
+        throw error;
+      },
+    },
+  }), 'catscompany');
+  retriedSession.setSystemPromptProvider(() => 'system prompt');
+
+  const retriedResult = await retriedSession.handleMessage('验证真实重试次数');
+  assert.match(retriedResult.text, /已自动重试/);
+});
+
+test('AgentSession persists only the final attempt draft after an explicit stream replay', async () => {
+  const session = new AgentSession('user:stream-replay-final-draft', buildMockServices({
+    aiService: {
+      getConfig() { return { provider: 'openai', model: 'primary-model' }; },
+      async chatStream(_messages: any[], _tools: any[], callbacks: any) {
+        callbacks?.onText?.('作废草稿');
+        await callbacks?.onRetry?.(1, 1, { attempt: 1, maxRetries: 1 });
+        callbacks?.onText?.('末次草稿');
+        const error = Object.assign(new Error('API错误 (504): gateway timeout'), { status: 504 });
+        attachRetrySummary(error, {
+          attempt_count: 2,
+          retry_count: 1,
+          max_retries: 1,
+          elapsed_ms: 20,
+          max_elapsed_ms: 300000,
+          stop_reason: 'stream_output_started',
+        });
+        throw error;
+      },
+    },
+  }), 'catscompany');
+  session.setSystemPromptProvider(() => 'system prompt');
+
+  const result = await session.handleMessage('执行一次完整流重试');
+  const persistedContents = (session as any).messages.map((message: any) => message.content);
+
+  assert.equal(result.text, MODEL_STREAM_INTERRUPTED_MESSAGE);
+  assert.equal(persistedContents.includes('末次草稿'), true);
+  assert.equal(persistedContents.includes('作废草稿'), false);
+});
+
+test('AgentSession does not replay a premature close after visible stream text', async () => {
+  let calls = 0;
+  const session = new AgentSession('user:premature-close-after-text', buildMockServices({
+    aiService: {
+      getConfig() { return { provider: 'openai', model: 'primary-model' }; },
+      async chatStream(_messages: any[], _tools: any[], callbacks: any) {
+        calls += 1;
+        callbacks?.onText?.('已输出内容');
+        const error = Object.assign(new Error('premature close'), { code: 'ERR_STREAM_PREMATURE_CLOSE' });
+        attachRetrySummary(error, {
+          attempt_count: 1,
+          retry_count: 0,
+          max_retries: 14,
+          elapsed_ms: 10,
+          max_elapsed_ms: 300000,
+          stop_reason: 'stream_output_started',
+        });
+        throw error;
+      },
+    },
+  }), 'catscompany');
+  session.setSystemPromptProvider(() => 'system prompt');
+
+  const result = await session.handleMessage('执行一个会提前关闭的流');
+
+  assert.equal(calls, 1);
+  assert.equal(result.text, MODEL_STREAM_INTERRUPTED_MESSAGE);
+  assert.equal((session as any).messages.some((message: any) => message.content === '已输出内容'), true);
+});
+
+test('AgentSession explains when a 504 was not retried because the retry limit is zero', async () => {
+  const session = new AgentSession('user:zero-retry-504', buildMockServices({
+    aiService: {
+      getConfig() { return { provider: 'openai', model: 'primary-model' }; },
+      async chatStream() {
+        const error = Object.assign(new Error('API错误 (504): gateway timeout'), { status: 504 });
+        attachRetrySummary(error, {
+          attempt_count: 1,
+          retry_count: 0,
+          max_retries: 0,
+          elapsed_ms: 0,
+          max_elapsed_ms: 300000,
+          stop_reason: 'retry_limit_exhausted',
+        });
+        throw error;
+      },
+    },
+  }), 'catscompany');
+  session.setSystemPromptProvider(() => 'system prompt');
+
+  const result = await session.handleMessage('执行一个不重试的任务');
+
+  assert.match(result.text, /当前自动重试上限为 0，因此未执行自动重试/);
+  assert.equal(result.taskOutcome, 'failed');
 });
 
 test('AgentSession requestInterrupt aborts an in-flight model request', async () => {

--- a/tests/ai-service.test.ts
+++ b/tests/ai-service.test.ts
@@ -90,6 +90,39 @@ test('AIService retries transient stream errors before any text is emitted', asy
   assert.deepStrictEqual(chunks, ['ok']);
 });
 
+test('AIService retries a 504 before text and records the final attempt counts', async () => {
+  process.env.CATSCO_MODEL_RETRY_MAX_RETRIES = '1';
+  const service = createTestService();
+  let attempts = 0;
+  (service as any).sleepWithAbort = async () => undefined;
+  (service as any).provider = {
+    chat: async () => ({ content: 'unused' }),
+    chatStream: async (_messages: unknown, _tools: unknown, callbacks?: StreamCallbacks) => {
+      attempts += 1;
+      if (attempts === 1) {
+        throw Object.assign(new Error('gateway timeout'), {
+          response: { status: 504, headers: { 'retry-after': '0' }, data: { message: 'gateway timeout' } },
+        });
+      }
+      callbacks?.onText?.('recovered');
+      return { content: 'recovered' };
+    },
+  };
+
+  const attemptEvents: any[] = [];
+  const result = await service.chatStream([], undefined, undefined, {
+    modelAttemptSink: { observe: event => { attemptEvents.push(event); } },
+  });
+
+  assert.equal(result.content, 'recovered');
+  assert.equal(attempts, 2);
+  assert.deepStrictEqual(
+    attemptEvents.map(event => [event.attemptNumber, event.outcome]),
+    [[1, 'started'], [1, 'retrying'], [2, 'started'], [2, 'succeeded']],
+  );
+  assert.equal(attemptEvents[1].retry.retryNumber, 1);
+});
+
 test('AIService can keep retrying transient stream failures beyond the old short cap', async () => {
   process.env.CATSCO_MODEL_RETRY_MAX_RETRIES = '5';
   const service = createTestService();
@@ -538,6 +571,44 @@ test('AIService records retry exhaustion on the final wrapped error', async () =
   assert.equal(diagnostics?.retry?.retry_count, 1);
   assert.equal(diagnostics?.retry?.max_retries, 1);
   assert.equal(diagnostics?.retry?.stop_reason, 'retry_limit_exhausted');
+});
+
+test('AIService preserves a circular 504 error while emitting cycle-safe diagnostics', async () => {
+  process.env.CATSCO_MODEL_RETRY_MAX_RETRIES = '0';
+  const service = createTestService();
+  const request: any = {};
+  const socket: any = { request };
+  request.socket = socket;
+  const rawError = Object.assign(new Error('gateway timeout'), {
+    response: {
+      status: 504,
+      headers: { 'x-request-id': 'req-circular-504' },
+      data: { error: { type: 'gateway_timeout', message: 'gateway timeout' } },
+    },
+    request,
+  });
+  (service as any).provider = {
+    chat: async () => { throw rawError; },
+    chatStream: async () => ({ content: 'unused' }),
+  };
+
+  let wrapped: unknown;
+  try {
+    await service.chat([]);
+  } catch (error) {
+    wrapped = error;
+  }
+
+  const diagnostics = readModelErrorDiagnostics(wrapped);
+  assert.equal((wrapped as any).status, 504);
+  assert.equal((wrapped as any).cause, rawError);
+  assert.equal(diagnostics?.http_status, 504);
+  assert.equal(diagnostics?.request_id, 'req-circular-504');
+  assert.equal(diagnostics?.retry?.attempt_count, 1);
+  assert.equal(diagnostics?.retry?.retry_count, 0);
+  assert.equal(diagnostics?.retry?.max_retries, 0);
+  assert.equal(diagnostics?.retry?.stop_reason, 'retry_limit_exhausted');
+  assert.doesNotThrow(() => JSON.stringify(diagnostics));
 });
 
 test('AIService records when stream output prevents an otherwise retryable request', async () => {

--- a/tests/turn-error-reader.test.ts
+++ b/tests/turn-error-reader.test.ts
@@ -39,6 +39,7 @@ describe('turn error reader', () => {
         retry_count: 2,
         retry_stop_reason: 'retry_limit_exhausted',
         partial_progress_preserved: true,
+        partial_progress_persistence: 'durable',
         episode_id: 'episode-reader',
         model_call_id: 'call-reader',
         model_attempt_id: 'call-reader:3',
@@ -98,10 +99,32 @@ describe('turn error reader', () => {
     assert.equal(report.recent[0].source_line, 2);
     assert.equal(report.recent[0].model_attempt_id, '');
     assert.equal(report.recent[0].model_attempt_number, 0);
+    assert.equal(report.recent[0].partial_progress_persistence, 'none');
+    assert.equal(report.recent[1].partial_progress_persistence, 'durable');
     assert.equal(report.recent[1].model_call_id, 'call-reader');
     assert.equal(report.recent[1].model_attempt_id, 'call-reader:3');
     assert.equal(report.recent[1].model_attempt_number, 3);
     assert.equal(report.recent[1].episode_id, 'episode-reader');
+  });
+
+  test('treats legacy preserved progress as memory-only rather than durable', () => {
+    fs.writeFileSync(path.join(root, 'legacy-progress.jsonl'), `${runtimeEntry(
+      '2026-08-02T10:00:00.000Z',
+      {
+        category: 'transient',
+        error_code: 'transient_provider_error',
+        partial_progress_preserved: true,
+      },
+    )}\n`);
+
+    const report = readTurnErrorReport({
+      logsRoot: root,
+      days: 7,
+      now: new Date('2026-08-03T00:00:00.000Z'),
+    });
+
+    assert.equal(report.recent[0].partial_progress_preserved, true);
+    assert.equal(report.recent[0].partial_progress_persistence, 'memory_only');
   });
 
   test('returns an empty report when the log root does not exist', () => {


### PR DESCRIPTION
## Summary

This draft PR now contains only the XiaoBa-CLI partial-progress recovery increment on top of merged PR #331 (`cd66b3a`). It does not change cats-company.

It addresses the reviewed failure boundary where a transient provider/gateway interruption occurs after visible stream output: preserve the final attempt draft, avoid unsafe whole-stream replay, retain PR #331 classification and circular-error fixes, and tell the user whether recovered progress is durable or only available in memory.

## Rebase and ownership

- Rebasing is complete. Head commit `38a4f0398338cf3e466876daf474308b9dd078f6` has parent `cd66b3a10301c546e57b344c22f5a8eebbee4f64`.
- PR #331 remains authoritative for provider HTTP stream normalization, circular explicit-cache inspection safety, `classifyModelError`, and safe category messages.
- This PR does not modify `src/providers/openai-provider.ts`, `src/utils/model-error-classifier.ts`, `src/feishu/index.ts`, or `src/weixin/index.ts` relative to current main.
- No cats-company files are changed. Existing evidence still does not identify cats-company as the source of the text-model 504.

## What changed

- Capture visible text from the final failed stream attempt and attach it to the existing error with a non-enumerable Symbol.
- Restore that text as the current episode’s assistant draft so a user-driven “continue” can resume from preserved progress.
- Clear abandoned draft text at each explicit full-stream retry boundary, preventing stale attempts from being persisted as the final draft.
- Prevent prompt-too-long emergency replay after visible output, including premature-close cases, to avoid duplicate text and side effects.
- Keep the existing retry/backoff behavior unchanged: no global `GAUZ_STREAM_RETRY`, no new replay policy, no changes to jitter or `Retry-After`.

## Review fixes applied

### Retry provenance

- User copy claims an automatic retry only when `retry_count > 0`.
- `non_retryable`, `retry_window_exhausted`, and `unknown` with `retry_count = 0` retain PR #331’s classifier fallback and do not claim a retry occurred.
- A zero retry limit is mentioned only when `max_retries = 0` and `stop_reason = retry_limit_exhausted`.
- `stream_output_started` is handled as partial-progress recovery rather than retry exhaustion.

### Persistence truthfulness

- `partial_progress_preserved` now explicitly means recoverable progress exists in the current process.
- New `partial_progress_persistence` records `none`, `memory_only`, or `durable`.
- The session write is attempted before the turn-error event and user message are finalized.
- Durable success says the draft was persisted.
- `saveContext() = false` produces a memory-only warning that explicitly says restart recovery is not guaranteed.
- Legacy logs with `partial_progress_preserved = true` but no new status are interpreted as `memory_only`, never assumed durable.

## Classification compatibility

The PR #331 categories and safe messages remain intact, including:

- `rate_limited`
- `auth_invalid`
- `access_denied`
- `model_or_endpoint_missing`
- `input_too_large`
- `request_invalid`
- `provider_rejected`
- `reasoning_replay_required`
- `unexpected`

## Verification

Executed after semantic rebase and review fixes:

- `npm run build` — passed.
- Provider stream, explicit-cache circular safety, AIService retry, model-attempt, observability, sanitizer, cache-trace, and turn-error reader suites — 83 tests passed, 0 failed.
- AgentSession lifecycle suite — 39 tests passed, 0 failed.
- CatsCompany, Feishu, and Weixin task-outcome and delivery-path suites — 62 tests passed, 0 failed.
- Earlier focused AgentSession/AIService/reader run — 49 tests passed, 0 failed.
- `git diff --check` — passed.

The reviewer-provided full runtime baseline showed the same five environment-isolation failures on the prior PR head and current main. This PR does not claim the repository-wide runner is green until GitHub checks establish that result.

## Remaining disclosed limit

PR #331 contains an internal explicit-cache compatibility retry inside the OpenAI provider. That retry is not an AIService attempt and therefore is not reflected in AIService `retry_count`. This PR does not claim that `retry_count = 0` means no retry of any kind occurred; it only avoids claiming that an automatic retry occurred unless the structured AIService retry metadata confirms it. Changing provider-level attempt accounting is outside this partial-progress increment.

The pre-existing prompt-too-long recovery still models its trimmed retry as a separate model call. Preserving a cross-call first-error/second-error diagnostic chain remains a bounded follow-up and is not required for the partial-progress behavior in this PR.

## Review request

Please re-review these points:

1. The PR is now a clean increment on PR #331 rather than an alternate classification implementation.
2. Retry copy is driven by `retry_count` and explicit stop provenance without inferring retries from configured limits.
3. Durable and memory-only recovery are distinguished in both logs and user copy.
4. Final-attempt draft preservation, replay suppression, circular/provider normalization, and channel task outcomes remain compatible.
5. Confirm whether GitHub checks and the current diff satisfy the gate for moving the PR from Draft to Ready.

## Incident evidence still needed

This code change does not identify the production 504 source. Closing the original incident still requires 2–3 real samples with bot/session IDs, precise timestamps, deployed commit, effective retry configuration, `has_streamed_text`, retry stop reason, provider or relay request ID, upstream response headers, and the first circular-serialization stack frame.
