### PR TITLE
fix Responses cache continuity and diagnostics

### DIFF
--- a/scripts/responses-cache-large-tool-canary.ts
+++ b/scripts/responses-cache-large-tool-canary.ts
@@ -1,0 +1,137 @@
+import { AIService } from '../src/utils/ai-service';
+import type { Message } from '../src/types';
+import type { ToolDefinition } from '../src/types/tool';
+
+const sessionKey = process.env.XIAOBA_CACHE_CANARY_SESSION
+  || `responses-cache-large-tool-${Date.now()}`;
+const largeChars = readPositiveInteger(process.env.XIAOBA_CACHE_CANARY_LARGE_CHARS, 64_000);
+
+const service = new AIService({
+  provider: 'openai',
+  openaiApiMode: 'responses',
+  ...(process.env.XIAOBA_CACHE_CANARY_API_KEY
+    ? { apiKey: process.env.XIAOBA_CACHE_CANARY_API_KEY }
+    : {}),
+  ...(process.env.XIAOBA_CACHE_CANARY_API_URL
+    ? { apiUrl: process.env.XIAOBA_CACHE_CANARY_API_URL }
+    : {}),
+  ...(process.env.XIAOBA_CACHE_CANARY_MODEL
+    ? { model: process.env.XIAOBA_CACHE_CANARY_MODEL }
+    : {}),
+  maxTokens: 64,
+  temperature: 0,
+});
+
+const tools: ToolDefinition[] = [{
+  name: 'read_file',
+  description: 'Read a file and return its contents.',
+  parameters: {
+    type: 'object',
+    properties: {
+      file_path: { type: 'string' },
+    },
+    required: ['file_path'],
+  },
+}];
+
+const stableInstructions = Array.from({ length: 280 }, (_, index) => (
+  `Stable cache canary instruction ${index + 1}: preserve the exact prior transcript and inspect tool evidence.`
+)).join('\n');
+const smallOutput = Array.from({ length: 40 }, (_, index) => (
+  `${index + 1}: small read result line used to establish a normal cached prefix.`
+)).join('\n');
+const largeOutput = Array.from({ length: Math.max(1, Math.ceil(largeChars / 96)) }, (_, index) => (
+  `${index + 1}: large read result evidence ${String(index).padStart(6, '0')} `
+  + 'abcdefghijklmnopqrstuvwxyz 0123456789 cache-prefix-continuity'
+)).join('\n').slice(0, largeChars);
+
+const smallMessages: Message[] = [
+  { role: 'system', content: stableInstructions },
+  { role: 'user', content: 'Run the cache canary and acknowledge the read_file evidence.' },
+  toolCall('canary-small-call', 'canary-small.txt'),
+  {
+    role: 'tool',
+    name: 'read_file',
+    tool_call_id: 'canary-small-call',
+    content: smallOutput,
+  },
+];
+const largeMessages: Message[] = [
+  ...smallMessages,
+  toolCall('canary-large-call', 'canary-large.txt'),
+  {
+    role: 'tool',
+    name: 'read_file',
+    tool_call_id: 'canary-large-call',
+    content: largeOutput,
+  },
+];
+
+const options = {
+  promptCacheContext: {
+    sessionKey,
+    phase: 'normal' as const,
+    explicitCaching: false,
+  },
+};
+
+async function main(): Promise<void> {
+  const results = [];
+  results.push(await run('small_cold', smallMessages));
+  results.push(await run('small_repeat', smallMessages));
+  results.push(await run('large_first', largeMessages));
+  results.push(await run('large_repeat', largeMessages));
+
+  process.stdout.write(`${JSON.stringify({
+    session_key: sessionKey,
+    large_chars: largeOutput.length,
+    results,
+  }, null, 2)}\n`);
+}
+
+async function run(label: string, messages: Message[]) {
+  let streamedChars = 0;
+  const response = await service.chatStream(
+    cloneForRequest(messages),
+    cloneForRequest(tools),
+    { onText: text => { streamedChars += text.length; } },
+    cloneForRequest(options),
+  );
+  return {
+    label,
+    input_tokens: response.usage?.promptTokens ?? null,
+    cached_tokens: response.usage?.cachedReadTokens ?? null,
+    cache_write_tokens: response.usage?.cachedWriteTokens ?? null,
+    completion_tokens: response.usage?.completionTokens ?? null,
+    streamed_chars: streamedChars,
+  };
+}
+
+function cloneForRequest<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function toolCall(id: string, filePath: string): Message {
+  return {
+    role: 'assistant',
+    content: null,
+    tool_calls: [{
+      id,
+      type: 'function',
+      function: {
+        name: 'read_file',
+        arguments: JSON.stringify({ file_path: filePath }),
+      },
+    }],
+  };
+}
+
+function readPositiveInteger(value: string | undefined, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+void main().catch(error => {
+  process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/src/core/checkpoint-compaction.ts
+++ b/src/core/checkpoint-compaction.ts
@@ -234,6 +234,7 @@ export class CheckpointCompactionCoordinator {
     const summary = await this.generateContinuationSummary(
       exactTail.summarySource,
       request.phase,
+      request.sessionKey,
       request.signal,
     );
     const remoteContextWatermarks = collectRemoteContextWatermarks(durable);
@@ -259,6 +260,7 @@ export class CheckpointCompactionCoordinator {
   private async generateContinuationSummary(
     sourceMessages: Message[],
     phase: CheckpointCompactionPhase,
+    sessionKey: string,
     signal?: AbortSignal,
   ): Promise<string> {
     let attemptMessages = prepareSummarySourceMessages(sourceMessages);
@@ -280,7 +282,14 @@ export class CheckpointCompactionCoordinator {
           promptMessages,
           undefined,
           { onText: text => { streamed += text; } },
-          { signal },
+          {
+            signal,
+            promptCacheContext: {
+              sessionKey,
+              phase,
+              explicitCaching: false,
+            },
+          },
         );
         if (response.usage) {
           Metrics.recordAICall('stream', response.usage);

--- a/src/core/sub-agent-session.ts
+++ b/src/core/sub-agent-session.ts
@@ -10,6 +10,8 @@ import { Logger } from '../utils/logger';
 import { SubAgentEventType, SubAgentRuntimeEvent } from './sub-agent-events';
 import { readRequiredPromptFile, renderPromptTemplate } from '../utils/prompt-template';
 import type { ToolExecutionConfirmationRequest, ToolExecutionConfirmationResult, ToolExecutionContext } from '../types/tool';
+import { resolveModelContextWindow } from '../utils/model-context-window';
+import { CheckpointCompactionCoordinator } from './checkpoint-compaction';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -284,10 +286,23 @@ export class SubAgentSession {
       enabledToolNames: this.allowedTools,
     });
 
+    const modelConfig = typeof (this.aiService as any).getConfig === 'function'
+      ? (this.aiService as any).getConfig()
+      : {};
+    const contextWindow = resolveModelContextWindow(modelConfig);
+    const checkpointCompactionCoordinator = new CheckpointCompactionCoordinator(
+      this.aiService,
+      { maxContextTokens: contextWindow.promptBudgetTokens },
+    );
+
     // 创建独立的 ConversationRunner（不注入 channel，子智能体不直接和用户通信）
     const runner = new ConversationRunner(this.aiService, toolManager, {
       maxTurns: this.options.maxTurns,
-      enableCompression: true,
+      // Keep subagents on the same durable checkpoint compaction path as the
+      // main agent. The legacy runner compressor did not carry sessionKey into
+      // its summary request and created an unscoped Responses cache namespace.
+      enableCompression: false,
+      checkpointCompactionCoordinator,
       shouldContinue: () => !this.stopped,
       toolExecutionContext: {
         ...delegatedToolContext,

--- a/src/core/sub-agent-session.ts
+++ b/src/core/sub-agent-session.ts
@@ -11,7 +11,10 @@ import { SubAgentEventType, SubAgentRuntimeEvent } from './sub-agent-events';
 import { readRequiredPromptFile, renderPromptTemplate } from '../utils/prompt-template';
 import type { ToolExecutionConfirmationRequest, ToolExecutionConfirmationResult, ToolExecutionContext } from '../types/tool';
 import { resolveModelContextWindow } from '../utils/model-context-window';
-import { CheckpointCompactionCoordinator } from './checkpoint-compaction';
+import {
+  CheckpointCompactionCoordinator,
+  isCheckpointCompactionEnabled,
+} from './checkpoint-compaction';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -290,18 +293,21 @@ export class SubAgentSession {
       ? (this.aiService as any).getConfig()
       : {};
     const contextWindow = resolveModelContextWindow(modelConfig);
-    const checkpointCompactionCoordinator = new CheckpointCompactionCoordinator(
-      this.aiService,
-      { maxContextTokens: contextWindow.promptBudgetTokens },
-    );
+    const useCheckpointCompaction = isCheckpointCompactionEnabled();
+    const checkpointCompactionCoordinator = useCheckpointCompaction
+      ? new CheckpointCompactionCoordinator(
+        this.aiService,
+        { maxContextTokens: contextWindow.promptBudgetTokens },
+      )
+      : undefined;
 
     // 创建独立的 ConversationRunner（不注入 channel，子智能体不直接和用户通信）
     const runner = new ConversationRunner(this.aiService, toolManager, {
       maxTurns: this.options.maxTurns,
-      // Keep subagents on the same durable checkpoint compaction path as the
-      // main agent. The legacy runner compressor did not carry sessionKey into
-      // its summary request and created an unscoped Responses cache namespace.
-      enableCompression: false,
+      // Match the main-session rollout switch: checkpoint compaction is the
+      // default, while the explicit rollback flag restores the legacy runner
+      // compressor for both main agents and subagents.
+      enableCompression: !useCheckpointCompaction,
       checkpointCompactionCoordinator,
       shouldContinue: () => !this.stopped,
       toolExecutionContext: {

--- a/src/providers/openai-provider.ts
+++ b/src/providers/openai-provider.ts
@@ -21,18 +21,36 @@ const MAX_PROVIDER_ERROR_BODY_BYTES = 64 * 1024;
 const PROVIDER_ERROR_BODY_READ_TIMEOUT_MS = 2_000;
 
 interface ResponsesBreakpointDiagnostic {
-  label: 'S' | 'A' | 'B';
+  label: 'S';
   prefixHash: string;
   inputItems: number;
   inputTokenEstimate: number;
 }
 
+interface ResponsesImplicitBreakpointDiagnostic {
+  kind: 'user' | 'tool';
+  itemType: string;
+  inputItems: number;
+  prefixHash: string;
+  prefixTokenEstimate: number;
+}
+
 interface ResponsesInputLayout {
   input: any[];
-  breakpoints: Array<'S' | 'A' | 'B'>;
-  prefixHashes: Partial<Record<'S' | 'A' | 'B', string>>;
+  breakpoints: Array<'S'>;
+  prefixHashes: Partial<Record<'S', string>>;
   breakpointDiagnostics: ResponsesBreakpointDiagnostic[];
+  durableItems: number;
+  transientItems: number;
 }
+
+const RESPONSES_SESSION_ANCHOR = [
+  '[session_protocol]',
+  'The following input replays the durable XiaoBa session in chronological order.',
+  'Tool calls and tool results must remain paired and ordered.',
+  'Request-local context, when present, is appended after the durable session.',
+  '[/session_protocol]',
+].join('\n');
 
 /**
  * OpenAI Provider
@@ -49,7 +67,7 @@ export class OpenAIProvider implements AIProvider {
   private maxTokens: number;
   private reasoningEffort: ChatConfig['reasoningEffort'];
   private openaiApiMode: ChatConfig['openaiApiMode'];
-  private responsesExplicitCacheSupported: boolean | undefined;
+  private responsesExplicitAnchorSupported: boolean | undefined;
 
   constructor(config: ChatConfig) {
     this.apiUrl = config.apiUrl!;
@@ -409,6 +427,26 @@ export class OpenAIProvider implements AIProvider {
     options?: AIRequestOptions,
     forceCompatibility = false,
   ): any {
+    const logicalBody = this.buildResponsesLogicalRequestBody(
+      messages,
+      tools,
+      options,
+      forceCompatibility,
+      stream,
+    );
+    return {
+      ...logicalBody,
+      stream,
+    };
+  }
+
+  private buildResponsesLogicalRequestBody(
+    messages: Message[],
+    tools?: ToolDefinition[],
+    options?: AIRequestOptions,
+    forceCompatibility = false,
+    stream = false,
+  ): any {
     const instructions = messages
       .filter(message => message.role === 'system' && !this.isDynamicCacheMessage(message))
       .filter(message => !this.isLegacyCheckpointBoundary(message))
@@ -416,20 +454,18 @@ export class OpenAIProvider implements AIProvider {
       .filter(Boolean)
       .join('\n\n');
     const responseTools = this.buildCanonicalResponsesTools(tools ?? []);
-    const explicitCaching = !forceCompatibility
-      && this.responsesExplicitCacheSupported !== false
+    const explicitAnchor = !forceCompatibility
+      && this.responsesExplicitAnchorSupported !== false
       && options?.promptCacheContext?.explicitCaching === true
       && this.supportsExplicitPromptCaching();
     const layout = this.buildResponsesInput(
       messages,
-      options?.promptCacheContext,
-      explicitCaching,
+      explicitAnchor,
     );
     const body: any = {
       model: this.model,
       input: layout.input,
       max_output_tokens: this.maxTokens,
-      stream,
       store: false,
       prompt_cache_key: this.buildPromptCacheKey(
         instructions,
@@ -441,7 +477,6 @@ export class OpenAIProvider implements AIProvider {
     if (instructions) body.instructions = instructions;
     if (Number.isFinite(this.temperature)) body.temperature = this.temperature;
     if (responseTools.length > 0) body.tools = responseTools;
-    if (explicitCaching) body.prompt_cache_options = { mode: 'explicit' };
     body.include = ['reasoning.encrypted_content'];
     this.applyResponsesReasoningOptions(body);
     this.logResponsesCacheLayout(
@@ -449,8 +484,10 @@ export class OpenAIProvider implements AIProvider {
       instructions,
       responseTools,
       layout,
-      explicitCaching,
+      explicitAnchor,
       options?.promptCacheContext,
+      body,
+      stream,
     );
     return body;
   }
@@ -465,38 +502,24 @@ export class OpenAIProvider implements AIProvider {
 
   private buildResponsesInput(
     messages: Message[],
-    cacheContext?: AIRequestOptions['promptCacheContext'],
-    explicitCaching = false,
+    explicitAnchor = false,
   ): ResponsesInputLayout {
     const requestMessages = messages.filter(message => (
       !this.isLegacyCheckpointBoundary(message)
       && !(message.role === 'system' && !this.isDynamicCacheMessage(message))
     ));
-    const currentEpisodeId = cacheContext?.currentEpisodeId;
     const transientMessages = requestMessages.filter(message => this.isTurnDeltaMessage(message));
+    const transientReplayMessages = transientMessages.filter(message => message.__syntheticObservation === true);
+    const transientDeveloperMessages = transientMessages.filter(message => message.__syntheticObservation !== true);
     const durableMessages = requestMessages.filter(message => !this.isTurnDeltaMessage(message));
     const checkpointMessages = durableMessages.filter(message => message.__checkpointSummary === true);
     const chronologicalMessages = durableMessages.filter(message => message.__checkpointSummary !== true);
-    const inferredGroups = currentEpisodeId
-      ? []
-      : this.groupResponsesExchanges(chronologicalMessages);
-    const completedEpisodeMessages = currentEpisodeId
-      ? chronologicalMessages.filter(message => message.__episodeId !== currentEpisodeId)
-      : inferredGroups.slice(0, -1).flat();
-    const currentEpisodeMessages = currentEpisodeId
-      ? chronologicalMessages.filter(message => message.__episodeId === currentEpisodeId)
-      : [];
-    const currentGroups = this.groupResponsesExchanges(currentEpisodeMessages);
-    const latestGroup = currentEpisodeId
-      ? (currentGroups[currentGroups.length - 1] || [])
-      : (inferredGroups[inferredGroups.length - 1] || []);
-    const completedCurrentGroups = currentEpisodeId ? currentGroups.slice(0, -1) : [];
     const input: any[] = [];
-    const breakpoints: Array<'S' | 'A' | 'B'> = [];
-    const prefixHashes: Partial<Record<'S' | 'A' | 'B', string>> = {};
+    const breakpoints: Array<'S'> = [];
+    const prefixHashes: Partial<Record<'S', string>> = {};
     const breakpointDiagnostics: ResponsesBreakpointDiagnostic[] = [];
 
-    const recordBreakpoint = (label: 'S' | 'A' | 'B') => {
+    const recordBreakpoint = (label: 'S') => {
       const prefixHash = this.hashWirePrefix(input);
       breakpoints.push(label);
       prefixHashes[label] = prefixHash;
@@ -508,36 +531,35 @@ export class OpenAIProvider implements AIProvider {
       });
     };
 
-    if (explicitCaching) {
-      input.push(this.buildBreakpointCarrier());
+    if (explicitAnchor) {
+      input.push(this.buildResponsesSessionAnchor());
       recordBreakpoint('S');
     }
 
     input.push(...this.convertResponsesMessages(checkpointMessages));
-    input.push(...this.convertResponsesMessages(completedEpisodeMessages));
-    if (explicitCaching && completedEpisodeMessages.length > 0) {
-      input.push(this.buildBreakpointCarrier());
-      recordBreakpoint('A');
-    }
-
-    for (const group of completedCurrentGroups) {
-      input.push(...this.convertResponsesMessages(group));
-    }
-    if (explicitCaching && completedCurrentGroups.length > 0) {
-      input.push(this.buildBreakpointCarrier());
-      recordBreakpoint('B');
-    }
-
-    input.push(...this.convertResponsesMessages(transientMessages));
-    input.push(...this.convertResponsesMessages(latestGroup));
-    return { input, breakpoints, prefixHashes, breakpointDiagnostics };
+    input.push(...this.convertResponsesMessages(chronologicalMessages));
+    const stableInputItems = input.length;
+    const durableItems = stableInputItems - (explicitAnchor ? 1 : 0);
+    input.push(...this.convertResponsesMessages(transientReplayMessages));
+    input.push(...this.convertResponsesMessages(transientDeveloperMessages, true));
+    return {
+      input,
+      breakpoints,
+      prefixHashes,
+      breakpointDiagnostics,
+      durableItems,
+      transientItems: input.length - stableInputItems,
+    };
   }
 
-  private convertResponsesMessages(messages: Message[]): any[] {
+  private convertResponsesMessages(messages: Message[], transientProjection = false): any[] {
     const input: any[] = [];
     for (const message of messages) {
       if (message.role === 'system') {
-        input.push({ role: 'system', content: this.responsesMessageContent(message.content) });
+        input.push({
+          role: transientProjection ? 'developer' : 'system',
+          content: this.responsesMessageContent(message.content),
+        });
         continue;
       }
       if (message.role === 'tool') {
@@ -571,33 +593,12 @@ export class OpenAIProvider implements AIProvider {
         }
         continue;
       }
-      input.push({ role: message.role, content: this.responsesMessageContent(message.content) });
+      input.push({
+        role: transientProjection ? 'developer' : message.role,
+        content: this.responsesMessageContent(message.content),
+      });
     }
     return input;
-  }
-
-  private groupResponsesExchanges(messages: Message[]): Message[][] {
-    const groups: Message[][] = [];
-    for (let index = 0; index < messages.length;) {
-      const message = messages[index];
-      if (message.role === 'assistant' && message.tool_calls?.length) {
-        const expected = new Set(message.tool_calls.map(call => call.id));
-        const group = [message];
-        index++;
-        while (index < messages.length && messages[index].role === 'tool') {
-          const tool = messages[index];
-          group.push(tool);
-          if (tool.tool_call_id) expected.delete(tool.tool_call_id);
-          index++;
-          if (expected.size === 0) break;
-        }
-        groups.push(group);
-        continue;
-      }
-      groups.push([message]);
-      index++;
-    }
-    return groups;
   }
 
   private isTurnDeltaMessage(message: Message): boolean {
@@ -607,12 +608,12 @@ export class OpenAIProvider implements AIProvider {
       || message.__syntheticObservation === true;
   }
 
-  private buildBreakpointCarrier(): any {
+  private buildResponsesSessionAnchor(): any {
     return {
-      role: 'system',
+      role: 'developer',
       content: [{
         type: 'input_text',
-        text: '\n',
+        text: RESPONSES_SESSION_ANCHOR,
         prompt_cache_breakpoint: { mode: 'explicit' },
       }],
     };
@@ -701,11 +702,20 @@ export class OpenAIProvider implements AIProvider {
   }
 
   private supportsExplicitPromptCaching(): boolean {
+    const configuredMode = String(process.env.XIAOBA_RESPONSES_EXPLICIT_CACHE || 'auto')
+      .trim()
+      .toLowerCase();
+    if (['0', 'false', 'off', 'no', 'disabled'].includes(configuredMode)) return false;
+
     const match = this.model.trim().toLowerCase().match(/^gpt-(\d+)(?:\.(\d+))?(?:[-_:]|$)/);
     if (!match) return false;
     const major = Number(match[1]);
     const minor = Number(match[2] || 0);
-    return major > 5 || (major === 5 && minor >= 6);
+    const supportedModel = major > 5 || (major === 5 && minor >= 6);
+    if (!supportedModel) return false;
+
+    if (['1', 'true', 'on', 'yes', 'force', 'enabled'].includes(configuredMode)) return true;
+    return this.isOfficialOpenAIResponsesEndpoint();
   }
 
   private hashWirePrefix(value: unknown): string {
@@ -719,11 +729,21 @@ export class OpenAIProvider implements AIProvider {
     layout: ResponsesInputLayout,
     explicit: boolean,
     cacheContext?: AIRequestOptions['promptCacheContext'],
+    logicalBody?: any,
+    stream = false,
   ): void {
-    Logger.runtimeEvent('INFO', `responses_cache_layout mode=${explicit ? 'explicit' : 'compatibility'} breakpoints=${layout.breakpoints.join(',') || 'none'}`, {
+    const mode = explicit ? 'implicit_with_explicit_s' : 'implicit';
+    const implicitDiagnostics = this.buildResponsesImplicitBreakpointDiagnostics(
+      instructions,
+      tools,
+      layout.input,
+    );
+    Logger.runtimeEvent('INFO', `responses_cache_layout mode=${mode} breakpoints=${layout.breakpoints.join(',') || 'none'}`, {
       type: 'responses_cache_layout',
       payload: {
-        mode: explicit ? 'explicit' : 'compatibility',
+        mode,
+        stream,
+        transport: stream ? 'sse' : 'json',
         phase: cacheContext?.phase || 'normal',
         session_hash: this.hashWirePrefix(cacheContext?.sessionKey || 'unscoped'),
         cache_key_hash: this.hashWirePrefix(cacheKey),
@@ -733,9 +753,70 @@ export class OpenAIProvider implements AIProvider {
         breakpoint_sequence: layout.breakpoints,
         prefix_hashes: layout.prefixHashes,
         breakpoint_diagnostics: layout.breakpointDiagnostics,
+        implicit_candidate_count: implicitDiagnostics.candidateCount,
+        implicit_candidates: implicitDiagnostics.candidates,
+        implicit_latest_prefix_hash: implicitDiagnostics.latestPrefixHash,
+        implicit_trailing_items: implicitDiagnostics.trailingItems,
         input_items: layout.input.length,
+        durable_items: layout.durableItems,
+        transient_items: layout.transientItems,
+        logical_body_hash: this.hashWirePrefix(logicalBody || {}),
       },
     });
+  }
+
+  private buildResponsesImplicitBreakpointDiagnostics(
+    instructions: string,
+    tools: any[],
+    input: any[],
+  ): {
+      candidateCount: number;
+      candidates: ResponsesImplicitBreakpointDiagnostic[];
+      latestPrefixHash?: string;
+      trailingItems: number;
+    } {
+    const prefixHash = createHash('sha256');
+    prefixHash.update(JSON.stringify({
+      model: this.model,
+      instructions,
+      tools,
+    }));
+    let prefixTokenEstimate = estimateJsonTokens({ instructions, tools });
+    const candidates: ResponsesImplicitBreakpointDiagnostic[] = [];
+    let candidateCount = 0;
+
+    for (let index = 0; index < input.length; index++) {
+      const item = input[index];
+      prefixHash.update('\u0000');
+      prefixHash.update(JSON.stringify(item));
+      prefixTokenEstimate += estimateJsonTokens(item);
+      const kind = this.responsesImplicitBreakpointKind(item);
+      if (!kind) continue;
+      candidateCount++;
+      candidates.push({
+        kind,
+        itemType: String(item?.type || item?.role || 'unknown'),
+        inputItems: index + 1,
+        prefixHash: prefixHash.copy().digest('hex').slice(0, 16),
+        prefixTokenEstimate,
+      });
+      if (candidates.length > 80) candidates.shift();
+    }
+
+    const latest = candidates.at(-1);
+    return {
+      candidateCount,
+      candidates,
+      ...(latest ? { latestPrefixHash: latest.prefixHash } : {}),
+      trailingItems: latest ? input.length - latest.inputItems : input.length,
+    };
+  }
+
+  private responsesImplicitBreakpointKind(item: any): 'user' | 'tool' | undefined {
+    if (item?.role === 'user') return 'user';
+    const type = String(item?.type || '');
+    if (type.endsWith('_call_output') || type === 'tool_search_output') return 'tool';
+    return undefined;
   }
 
   private logResponsesCacheUsage(
@@ -744,10 +825,11 @@ export class OpenAIProvider implements AIProvider {
     explicit: boolean,
   ): void {
     if (!usage) return;
-    Logger.runtimeEvent('INFO', `responses_cache_usage mode=${explicit ? 'explicit' : 'compatibility'} cached=${usage.cachedReadTokens ?? 0} written=${usage.cachedWriteTokens ?? 0}`, {
+    const mode = explicit ? 'implicit_with_explicit_s' : 'implicit';
+    Logger.runtimeEvent('INFO', `responses_cache_usage mode=${mode} cached=${usage.cachedReadTokens ?? 0} written=${usage.cachedWriteTokens ?? 0}`, {
       type: 'responses_cache_usage',
       payload: {
-        mode: explicit ? 'explicit' : 'compatibility',
+        mode,
         cache_key_hash: this.hashWirePrefix(cacheKey),
         input_tokens: usage.promptTokens,
         cached_tokens: usage.cachedReadTokens ?? 0,
@@ -874,9 +956,9 @@ export class OpenAIProvider implements AIProvider {
     try {
       response = await this.postProviderRequest(this.responsesUrl, body, false, options);
     } catch (error) {
-      if (!this.shouldRetryWithoutExplicitCaching(error, body)) throw error;
-      this.responsesExplicitCacheSupported = false;
-      Logger.warning('Responses endpoint rejected explicit prompt caching; retrying once in compatibility mode.');
+      if (!this.shouldRetryWithoutExplicitAnchor(error, body)) throw error;
+      this.responsesExplicitAnchorSupported = false;
+      Logger.warning('Responses endpoint rejected the explicit S cache anchor; retrying once without it.');
       body = this.buildResponsesRequestBody(messages, tools, false, options, true);
       response = await this.postProviderRequest(this.responsesUrl, body, false, options);
     }
@@ -884,7 +966,7 @@ export class OpenAIProvider implements AIProvider {
     const failure = this.responsesFailureError(response.data);
     if (failure) throw failure;
     const result = this.parseResponsesResponse(response.data);
-    this.logResponsesCacheUsage(body.prompt_cache_key, result.usage, Boolean(body.prompt_cache_options));
+    this.logResponsesCacheUsage(body.prompt_cache_key, result.usage, this.hasResponsesExplicitAnchor(body));
     return result;
   }
 
@@ -903,9 +985,9 @@ export class OpenAIProvider implements AIProvider {
     try {
       response = await this.postProviderRequest(this.responsesUrl, body, true, options);
     } catch (error) {
-      if (!this.shouldRetryWithoutExplicitCaching(error, body)) throw error;
-      this.responsesExplicitCacheSupported = false;
-      Logger.warning('Responses endpoint rejected explicit prompt caching; retrying stream once in compatibility mode.');
+      if (!this.shouldRetryWithoutExplicitAnchor(error, body)) throw error;
+      this.responsesExplicitAnchorSupported = false;
+      Logger.warning('Responses endpoint rejected the explicit S cache anchor; retrying stream once without it.');
       body = this.buildResponsesRequestBody(messages, tools, true, options, true);
       response = await this.postProviderRequest(this.responsesUrl, body, true, options);
     }
@@ -931,12 +1013,12 @@ export class OpenAIProvider implements AIProvider {
         if (
           !streamedVisibleText
           && !outputItems.some(Boolean)
-          && this.shouldRetryWithoutExplicitCaching(error, body)
+          && this.shouldRetryWithoutExplicitAnchor(error, body)
         ) {
           settled = true;
           options?.signal?.removeEventListener('abort', onAbort);
-          this.responsesExplicitCacheSupported = false;
-          Logger.warning('Responses stream rejected explicit prompt caching; retrying once in compatibility mode.');
+          this.responsesExplicitAnchorSupported = false;
+          Logger.warning('Responses stream rejected the explicit S cache anchor; retrying once without it.');
           stream.destroy();
           void this.chatStreamResponses(messages, tools, callbacks, options).then(resolve, reject);
           return;
@@ -1015,7 +1097,7 @@ export class OpenAIProvider implements AIProvider {
           result.content = this.visibleMessageContent({ content: streamedVisibleText });
         }
         ContextDebugLogger.dumpSdkBoundary('after', undefined, { response: finalResponse });
-        this.logResponsesCacheUsage(body.prompt_cache_key, result.usage, Boolean(body.prompt_cache_options));
+        this.logResponsesCacheUsage(body.prompt_cache_key, result.usage, this.hasResponsesExplicitAnchor(body));
         settled = true;
         callbacks?.onComplete?.(result);
         resolve(result);
@@ -1082,8 +1164,8 @@ export class OpenAIProvider implements AIProvider {
     return error;
   }
 
-  private shouldRetryWithoutExplicitCaching(error: unknown, body: any): boolean {
-    if (!body?.prompt_cache_options) return false;
+  private shouldRetryWithoutExplicitAnchor(error: unknown, body: any): boolean {
+    if (!this.hasResponsesExplicitAnchor(body)) return false;
     if (/^(?:1|true|yes|on)$/i.test(String(process.env.XIAOBA_RESPONSES_EXPLICIT_CACHE_STRICT || '').trim())) {
       return false;
     }
@@ -1097,6 +1179,18 @@ export class OpenAIProvider implements AIProvider {
       && detail.includes('prompt cache')
       && /unsupported|not supported|unknown|invalid|extra|unrecognized/.test(detail);
   }
+
+  private hasResponsesExplicitAnchor(body: any): boolean {
+    return countPromptCacheBreakpoints(body) > 0;
+  }
+}
+
+function countPromptCacheBreakpoints(value: unknown): number {
+  if (!value || typeof value !== 'object') return 0;
+  if (Array.isArray(value)) return value.reduce((sum, item) => sum + countPromptCacheBreakpoints(item), 0);
+  const record = value as Record<string, unknown>;
+  return (record.prompt_cache_breakpoint ? 1 : 0)
+    + Object.values(record).reduce<number>((sum, item) => sum + countPromptCacheBreakpoints(item), 0);
 }
 
 type ReadableErrorStream = {

--- a/src/providers/openai-provider.ts
+++ b/src/providers/openai-provider.ts
@@ -42,6 +42,18 @@ interface ResponsesInputLayout {
   breakpointDiagnostics: ResponsesBreakpointDiagnostic[];
   durableItems: number;
   transientItems: number;
+  transientReplayItems: number;
+  transientDeveloperItems: number;
+}
+
+interface ResponsesWireItemDiagnostic {
+  index: number;
+  segment: 'anchor' | 'durable' | 'transient_replay' | 'transient_developer';
+  role?: string;
+  type?: string;
+  marker?: string;
+  hash: string;
+  tokenEstimate: number;
 }
 
 const RESPONSES_SESSION_ANCHOR = [
@@ -68,6 +80,7 @@ export class OpenAIProvider implements AIProvider {
   private reasoningEffort: ChatConfig['reasoningEffort'];
   private openaiApiMode: ChatConfig['openaiApiMode'];
   private responsesExplicitAnchorSupported: boolean | undefined;
+  private responsesTraceSequence = 0;
 
   constructor(config: ChatConfig) {
     this.apiUrl = config.apiUrl!;
@@ -427,17 +440,24 @@ export class OpenAIProvider implements AIProvider {
     options?: AIRequestOptions,
     forceCompatibility = false,
   ): any {
+    const requestTraceId = this.nextResponsesTraceId();
     const logicalBody = this.buildResponsesLogicalRequestBody(
       messages,
       tools,
       options,
       forceCompatibility,
       stream,
+      requestTraceId,
     );
-    return {
+    const body = {
       ...logicalBody,
       stream,
     };
+    Object.defineProperty(body, '__xiaobaResponsesTraceId', {
+      value: requestTraceId,
+      enumerable: false,
+    });
+    return body;
   }
 
   private buildResponsesLogicalRequestBody(
@@ -446,6 +466,7 @@ export class OpenAIProvider implements AIProvider {
     options?: AIRequestOptions,
     forceCompatibility = false,
     stream = false,
+    requestTraceId?: string,
   ): any {
     const instructions = messages
       .filter(message => message.role === 'system' && !this.isDynamicCacheMessage(message))
@@ -488,6 +509,7 @@ export class OpenAIProvider implements AIProvider {
       options?.promptCacheContext,
       body,
       stream,
+      requestTraceId,
     );
     return body;
   }
@@ -540,8 +562,10 @@ export class OpenAIProvider implements AIProvider {
     input.push(...this.convertResponsesMessages(chronologicalMessages));
     const stableInputItems = input.length;
     const durableItems = stableInputItems - (explicitAnchor ? 1 : 0);
-    input.push(...this.convertResponsesMessages(transientReplayMessages));
-    input.push(...this.convertResponsesMessages(transientDeveloperMessages, true));
+    const transientReplayInput = this.convertResponsesMessages(transientReplayMessages);
+    const transientDeveloperInput = this.convertResponsesMessages(transientDeveloperMessages, true);
+    input.push(...transientReplayInput);
+    input.push(...transientDeveloperInput);
     return {
       input,
       breakpoints,
@@ -549,6 +573,8 @@ export class OpenAIProvider implements AIProvider {
       breakpointDiagnostics,
       durableItems,
       transientItems: input.length - stableInputItems,
+      transientReplayItems: transientReplayInput.length,
+      transientDeveloperItems: transientDeveloperInput.length,
     };
   }
 
@@ -722,6 +748,55 @@ export class OpenAIProvider implements AIProvider {
     return createHash('sha256').update(JSON.stringify(value)).digest('hex').slice(0, 16);
   }
 
+  private nextResponsesTraceId(): string {
+    this.responsesTraceSequence++;
+    return `${Date.now().toString(36)}-${this.responsesTraceSequence.toString(36)}`;
+  }
+
+  private responsesTraceId(body: any): string | undefined {
+    const value = body?.__xiaobaResponsesTraceId;
+    return typeof value === 'string' ? value : undefined;
+  }
+
+  private responsesWireItemMarker(item: any): string | undefined {
+    const content = item?.content ?? item?.output;
+    const text = typeof content === 'string'
+      ? content
+      : Array.isArray(content)
+        ? content.find(block => block?.type === 'input_text' && typeof block?.text === 'string')?.text
+        : undefined;
+    const marker = typeof text === 'string' ? text.match(/^\[[^\]\r\n]{1,80}\]/)?.[0] : undefined;
+    return marker;
+  }
+
+  private buildResponsesWireItemDiagnostics(
+    layout: ResponsesInputLayout,
+    explicit: boolean,
+  ): ResponsesWireItemDiagnostic[] {
+    const anchorItems = explicit ? 1 : 0;
+    const durableEnd = anchorItems + layout.durableItems;
+    const replayEnd = durableEnd + layout.transientReplayItems;
+    return layout.input.map((item, index) => {
+      const segment: ResponsesWireItemDiagnostic['segment'] = index < anchorItems
+        ? 'anchor'
+        : index < durableEnd
+          ? 'durable'
+          : index < replayEnd
+            ? 'transient_replay'
+            : 'transient_developer';
+      const marker = segment === 'durable' ? undefined : this.responsesWireItemMarker(item);
+      return {
+        index,
+        segment,
+        ...(item?.role ? { role: String(item.role) } : {}),
+        ...(item?.type ? { type: String(item.type) } : {}),
+        ...(marker ? { marker } : {}),
+        hash: this.hashWirePrefix(item),
+        tokenEstimate: estimateJsonTokens(item),
+      };
+    });
+  }
+
   private logResponsesCacheLayout(
     cacheKey: string,
     instructions: string,
@@ -731,6 +806,7 @@ export class OpenAIProvider implements AIProvider {
     cacheContext?: AIRequestOptions['promptCacheContext'],
     logicalBody?: any,
     stream = false,
+    requestTraceId?: string,
   ): void {
     const mode = explicit ? 'implicit_with_explicit_s' : 'implicit';
     const implicitDiagnostics = this.buildResponsesImplicitBreakpointDiagnostics(
@@ -738,10 +814,15 @@ export class OpenAIProvider implements AIProvider {
       tools,
       layout.input,
     );
+    const itemDiagnostics = this.buildResponsesWireItemDiagnostics(layout, explicit);
+    const stableInputItems = (explicit ? 1 : 0) + layout.durableItems;
+    const durableInput = layout.input.slice(0, stableInputItems);
+    const transientInput = layout.input.slice(stableInputItems);
     Logger.runtimeEvent('INFO', `responses_cache_layout mode=${mode} breakpoints=${layout.breakpoints.join(',') || 'none'}`, {
       type: 'responses_cache_layout',
       payload: {
         mode,
+        request_trace_id: requestTraceId,
         stream,
         transport: stream ? 'sse' : 'json',
         phase: cacheContext?.phase || 'normal',
@@ -760,7 +841,13 @@ export class OpenAIProvider implements AIProvider {
         input_items: layout.input.length,
         durable_items: layout.durableItems,
         transient_items: layout.transientItems,
-        logical_body_hash: this.hashWirePrefix(logicalBody || {}),
+        transient_replay_items: layout.transientReplayItems,
+        transient_developer_items: layout.transientDeveloperItems,
+        durable_input_hash: this.hashWirePrefix(durableInput),
+        transient_input_hash: this.hashWirePrefix(transientInput),
+        final_input_hash: this.hashWirePrefix(layout.input),
+        input_item_diagnostics: itemDiagnostics,
+        logical_body_hash: this.hashWirePrefix({ ...(logicalBody || {}), stream }),
       },
     });
   }
@@ -820,20 +907,42 @@ export class OpenAIProvider implements AIProvider {
   }
 
   private logResponsesCacheUsage(
-    cacheKey: string,
+    body: any,
     usage: ChatResponse['usage'],
     explicit: boolean,
+    rawUsage?: any,
+    response?: any,
+    headers?: any,
   ): void {
     if (!usage) return;
     const mode = explicit ? 'implicit_with_explicit_s' : 'implicit';
+    const details = rawUsage?.input_tokens_details;
+    const detailKeys = details && typeof details === 'object' ? Object.keys(details).sort() : [];
+    const headerValue = (name: string): string | undefined => {
+      const value = headers?.get?.(name) ?? headers?.[name] ?? headers?.[name.toLowerCase()];
+      return typeof value === 'string' && value ? value : undefined;
+    };
     Logger.runtimeEvent('INFO', `responses_cache_usage mode=${mode} cached=${usage.cachedReadTokens ?? 0} written=${usage.cachedWriteTokens ?? 0}`, {
       type: 'responses_cache_usage',
       payload: {
         mode,
-        cache_key_hash: this.hashWirePrefix(cacheKey),
+        request_trace_id: this.responsesTraceId(body),
+        cache_key_hash: this.hashWirePrefix(body?.prompt_cache_key || ''),
+        logical_body_hash: this.hashWirePrefix(body || {}),
         input_tokens: usage.promptTokens,
         cached_tokens: usage.cachedReadTokens ?? 0,
         cache_write_tokens: usage.cachedWriteTokens ?? 0,
+        usage_input_detail_keys: detailKeys,
+        cache_write_tokens_present: detailKeys.includes('cache_write_tokens'),
+        response_id_hash: response?.id ? this.hashWirePrefix(response.id) : undefined,
+        response_model: typeof response?.model === 'string' ? response.model : undefined,
+        service_tier: typeof response?.service_tier === 'string' ? response.service_tier : undefined,
+        upstream_request_id_hash: (() => {
+          const requestId = headerValue('x-request-id')
+            || headerValue('openai-request-id')
+            || headerValue('x-openai-request-id');
+          return requestId ? this.hashWirePrefix(requestId) : undefined;
+        })(),
       },
     });
   }
@@ -966,7 +1075,14 @@ export class OpenAIProvider implements AIProvider {
     const failure = this.responsesFailureError(response.data);
     if (failure) throw failure;
     const result = this.parseResponsesResponse(response.data);
-    this.logResponsesCacheUsage(body.prompt_cache_key, result.usage, this.hasResponsesExplicitAnchor(body));
+    this.logResponsesCacheUsage(
+      body,
+      result.usage,
+      this.hasResponsesExplicitAnchor(body),
+      response.data?.usage,
+      response.data,
+      response.headers,
+    );
     return result;
   }
 
@@ -1097,7 +1213,14 @@ export class OpenAIProvider implements AIProvider {
           result.content = this.visibleMessageContent({ content: streamedVisibleText });
         }
         ContextDebugLogger.dumpSdkBoundary('after', undefined, { response: finalResponse });
-        this.logResponsesCacheUsage(body.prompt_cache_key, result.usage, this.hasResponsesExplicitAnchor(body));
+        this.logResponsesCacheUsage(
+          body,
+          result.usage,
+          this.hasResponsesExplicitAnchor(body),
+          finalResponse?.usage,
+          finalResponse,
+          response.headers,
+        );
         settled = true;
         callbacks?.onComplete?.(result);
         resolve(result);

--- a/src/providers/openai-provider.ts
+++ b/src/providers/openai-provider.ts
@@ -757,7 +757,7 @@ export class OpenAIProvider implements AIProvider {
   }
 
   private supportsExplicitPromptCaching(): boolean {
-    const configuredMode = String(process.env.XIAOBA_RESPONSES_EXPLICIT_CACHE || 'auto')
+    const configuredMode = String(process.env.XIAOBA_RESPONSES_EXPLICIT_CACHE || 'off')
       .trim()
       .toLowerCase();
     if (['0', 'false', 'off', 'no', 'disabled'].includes(configuredMode)) return false;
@@ -770,7 +770,7 @@ export class OpenAIProvider implements AIProvider {
     if (!supportedModel) return false;
 
     if (['1', 'true', 'on', 'yes', 'force', 'enabled'].includes(configuredMode)) return true;
-    return this.isOfficialOpenAIResponsesEndpoint();
+    return configuredMode === 'auto' && this.isOfficialOpenAIResponsesEndpoint();
   }
 
   private hashWirePrefix(value: unknown): string {

--- a/src/providers/openai-provider.ts
+++ b/src/providers/openai-provider.ts
@@ -229,6 +229,35 @@ export class OpenAIProvider implements AIProvider {
   }
 
   /**
+   * Build Responses-only headers following Pi's OpenAI compatibility convention.
+   * The relay may use these stable values for session-affine routing. We keep
+   * the behavior off for the native OpenAI endpoint unless explicitly forced.
+   */
+  private responsesHeaders(options?: AIRequestOptions): Record<string, string> {
+    const headers: Record<string, string> = { ...this.headers };
+    const sessionKey = options?.promptCacheContext?.sessionKey;
+    if (!sessionKey || sessionKey === 'unknown' || sessionKey === 'unscoped' || !this.isResponsesSessionAffinityEnabled()) {
+      return headers;
+    }
+
+    const affinity = `xiaoba-${createHash('sha256').update(sessionKey).digest('hex').slice(0, 32)}`;
+    // Pi's OpenAI Responses compatibility mode uses the same stable session
+    // value for these two relay-recognized headers.
+    headers.session_id = affinity;
+    headers['x-client-request-id'] = affinity;
+    return headers;
+  }
+
+  private isResponsesSessionAffinityEnabled(): boolean {
+    const configured = String(process.env.XIAOBA_RESPONSES_SESSION_AFFINITY || 'auto')
+      .trim()
+      .toLowerCase();
+    if (configured === 'off' || configured === 'false' || configured === 'disabled') return false;
+    if (configured === 'on' || configured === 'force') return true;
+    return !this.isOfficialOpenAIResponsesEndpoint();
+  }
+
+  /**
    * 普通调用
    */
   async chat(messages: Message[], tools?: ToolDefinition[], options?: AIRequestOptions): Promise<ChatResponse> {
@@ -846,6 +875,15 @@ export class OpenAIProvider implements AIProvider {
         durable_input_hash: this.hashWirePrefix(durableInput),
         transient_input_hash: this.hashWirePrefix(transientInput),
         final_input_hash: this.hashWirePrefix(layout.input),
+        session_affinity_enabled: Boolean(
+          cacheContext?.sessionKey
+          && cacheContext.sessionKey !== 'unknown'
+          && cacheContext.sessionKey !== 'unscoped'
+          && this.isResponsesSessionAffinityEnabled(),
+        ),
+        session_affinity_hash: cacheContext?.sessionKey
+          ? this.hashWirePrefix(`xiaoba-${createHash('sha256').update(cacheContext.sessionKey).digest('hex').slice(0, 32)}`)
+          : undefined,
         input_item_diagnostics: itemDiagnostics,
         logical_body_hash: this.hashWirePrefix({ ...(logicalBody || {}), stream }),
       },
@@ -1063,13 +1101,17 @@ export class OpenAIProvider implements AIProvider {
     });
     let response;
     try {
-      response = await this.postProviderRequest(this.responsesUrl, body, false, options);
+      response = await this.postProviderRequest(
+        this.responsesUrl, body, false, options, this.responsesHeaders(options),
+      );
     } catch (error) {
       if (!this.shouldRetryWithoutExplicitAnchor(error, body)) throw error;
       this.responsesExplicitAnchorSupported = false;
       Logger.warning('Responses endpoint rejected the explicit S cache anchor; retrying once without it.');
       body = this.buildResponsesRequestBody(messages, tools, false, options, true);
-      response = await this.postProviderRequest(this.responsesUrl, body, false, options);
+      response = await this.postProviderRequest(
+        this.responsesUrl, body, false, options, this.responsesHeaders(options),
+      );
     }
     ContextDebugLogger.dumpSdkBoundary('after', undefined, { response: response.data });
     const failure = this.responsesFailureError(response.data);
@@ -1099,13 +1141,17 @@ export class OpenAIProvider implements AIProvider {
     });
     let response;
     try {
-      response = await this.postProviderRequest(this.responsesUrl, body, true, options);
+      response = await this.postProviderRequest(
+        this.responsesUrl, body, true, options, this.responsesHeaders(options),
+      );
     } catch (error) {
       if (!this.shouldRetryWithoutExplicitAnchor(error, body)) throw error;
       this.responsesExplicitAnchorSupported = false;
       Logger.warning('Responses endpoint rejected the explicit S cache anchor; retrying stream once without it.');
       body = this.buildResponsesRequestBody(messages, tools, true, options, true);
-      response = await this.postProviderRequest(this.responsesUrl, body, true, options);
+      response = await this.postProviderRequest(
+        this.responsesUrl, body, true, options, this.responsesHeaders(options),
+      );
     }
 
     return new Promise<ChatResponse>((resolve, reject) => {
@@ -1250,10 +1296,11 @@ export class OpenAIProvider implements AIProvider {
     body: any,
     stream: boolean,
     options?: AIRequestOptions,
+    headers: Record<string, string> = this.headers,
   ): Promise<any> {
     try {
       return await axios.post(url, body, {
-        headers: this.headers,
+        headers,
         ...(stream ? { responseType: 'stream' as const } : {}),
         signal: options?.signal,
       });

--- a/src/providers/openai-provider.ts
+++ b/src/providers/openai-provider.ts
@@ -985,6 +985,62 @@ export class OpenAIProvider implements AIProvider {
     });
   }
 
+  /**
+   * Responses-only upload-boundary diagnostics.
+   *
+   * This is intentionally hash/metadata based: it records the exact logical
+   * body immediately before axios serializes and uploads it, without writing
+   * Authorization or full prompt contents to the normal session log.
+   */
+  private logResponsesWireRequest(
+    body: any,
+    options: AIRequestOptions | undefined,
+    stream: boolean,
+    headers: Record<string, string>,
+  ): void {
+    if (String(process.env.XIAOBA_RESPONSES_WIRE_DEBUG || '').trim().toLowerCase() !== 'true') {
+      return;
+    }
+    const input = Array.isArray(body?.input) ? body.input : [];
+    const itemDiagnostics = input.map((item: any, index: number) => ({
+      index,
+      type: typeof item?.type === 'string' ? item.type : undefined,
+      role: typeof item?.role === 'string' ? item.role : undefined,
+      call_id: typeof item?.call_id === 'string' ? this.hashWirePrefix(item.call_id) : undefined,
+      hash: this.hashWirePrefix(item),
+      token_estimate: estimateJsonTokens(item),
+    }));
+    const sessionKey = options?.promptCacheContext?.sessionKey || 'unscoped';
+    const affinityHeader = headers['x-client-request-id'] || headers.session_id || '';
+    Logger.runtimeEvent('INFO', 'responses_wire_request before_upload', {
+      type: 'responses_wire_request',
+      payload: {
+        stage: 'before_upload',
+        request_trace_id: this.responsesTraceId(body),
+        stream,
+        transport: stream ? 'sse' : 'json',
+        phase: options?.promptCacheContext?.phase || 'normal',
+        api_mode: 'responses',
+        session_hash: this.hashWirePrefix(sessionKey),
+        session_affinity_enabled: Boolean(
+          sessionKey !== 'unknown'
+          && sessionKey !== 'unscoped'
+          && this.isResponsesSessionAffinityEnabled(),
+        ),
+        session_affinity_header_hash: affinityHeader ? this.hashWirePrefix(affinityHeader) : undefined,
+        client_request_id_hash: headers['x-client-request-id']
+          ? this.hashWirePrefix(headers['x-client-request-id'])
+          : undefined,
+        session_id_hash: headers.session_id ? this.hashWirePrefix(headers.session_id) : undefined,
+        prompt_cache_key_hash: this.hashWirePrefix(body?.prompt_cache_key || ''),
+        wire_body_hash: this.hashWirePrefix(body || {}),
+        input_items: input.length,
+        input_hash: this.hashWirePrefix(input),
+        input_item_diagnostics: itemDiagnostics,
+      },
+    });
+  }
+
   private applyResponsesReasoningOptions(body: any): void {
     const effort = this.reasoningEffort;
     if (!effort || effort === 'default') return;
@@ -1099,18 +1155,22 @@ export class OpenAIProvider implements AIProvider {
       apiUrl: this.responsesUrl,
       body,
     });
+    const requestHeaders = this.responsesHeaders(options);
+    this.logResponsesWireRequest(body, options, false, requestHeaders);
     let response;
     try {
       response = await this.postProviderRequest(
-        this.responsesUrl, body, false, options, this.responsesHeaders(options),
+        this.responsesUrl, body, false, options, requestHeaders,
       );
     } catch (error) {
       if (!this.shouldRetryWithoutExplicitAnchor(error, body)) throw error;
       this.responsesExplicitAnchorSupported = false;
       Logger.warning('Responses endpoint rejected the explicit S cache anchor; retrying once without it.');
       body = this.buildResponsesRequestBody(messages, tools, false, options, true);
+      const retryHeaders = this.responsesHeaders(options);
+      this.logResponsesWireRequest(body, options, false, retryHeaders);
       response = await this.postProviderRequest(
-        this.responsesUrl, body, false, options, this.responsesHeaders(options),
+        this.responsesUrl, body, false, options, retryHeaders,
       );
     }
     ContextDebugLogger.dumpSdkBoundary('after', undefined, { response: response.data });
@@ -1139,18 +1199,22 @@ export class OpenAIProvider implements AIProvider {
       apiUrl: this.responsesUrl,
       body,
     });
+    const requestHeaders = this.responsesHeaders(options);
+    this.logResponsesWireRequest(body, options, true, requestHeaders);
     let response;
     try {
       response = await this.postProviderRequest(
-        this.responsesUrl, body, true, options, this.responsesHeaders(options),
+        this.responsesUrl, body, true, options, requestHeaders,
       );
     } catch (error) {
       if (!this.shouldRetryWithoutExplicitAnchor(error, body)) throw error;
       this.responsesExplicitAnchorSupported = false;
       Logger.warning('Responses endpoint rejected the explicit S cache anchor; retrying stream once without it.');
       body = this.buildResponsesRequestBody(messages, tools, true, options, true);
+      const retryHeaders = this.responsesHeaders(options);
+      this.logResponsesWireRequest(body, options, true, retryHeaders);
       response = await this.postProviderRequest(
-        this.responsesUrl, body, true, options, this.responsesHeaders(options),
+        this.responsesUrl, body, true, options, retryHeaders,
       );
     }
 

--- a/tests/openai-provider-explicit-cache.test.ts
+++ b/tests/openai-provider-explicit-cache.test.ts
@@ -130,6 +130,37 @@ test('Responses cache key is isolated by session without exposing the session id
   assert.doesNotMatch(first.prompt_cache_key, /session-alpha/);
 });
 
+test('Responses relay uses Pi-style stable session affinity headers without exposing the session id', () => {
+  const original = process.env.XIAOBA_RESPONSES_SESSION_AFFINITY;
+  delete process.env.XIAOBA_RESPONSES_SESSION_AFFINITY;
+  try {
+    const headers = (provider() as any).responsesHeaders(context);
+    assert.match(headers.session_id, /^xiaoba-[a-f0-9]{32}$/);
+    assert.equal(headers['x-client-request-id'], headers.session_id);
+    assert.doesNotMatch(headers.session_id, /session-alpha/);
+
+    const officialHeaders = (explicitProvider() as any).responsesHeaders(context);
+    assert.equal(officialHeaders.session_id, undefined);
+    assert.equal(officialHeaders['x-client-request-id'], undefined);
+  } finally {
+    if (original === undefined) delete process.env.XIAOBA_RESPONSES_SESSION_AFFINITY;
+    else process.env.XIAOBA_RESPONSES_SESSION_AFFINITY = original;
+  }
+});
+
+test('Responses session affinity can be disabled without changing the cache body', () => {
+  const original = process.env.XIAOBA_RESPONSES_SESSION_AFFINITY;
+  process.env.XIAOBA_RESPONSES_SESSION_AFFINITY = 'off';
+  try {
+    const headers = (provider() as any).responsesHeaders(context);
+    assert.equal(headers.session_id, undefined);
+    assert.equal(headers['x-client-request-id'], undefined);
+  } finally {
+    if (original === undefined) delete process.env.XIAOBA_RESPONSES_SESSION_AFFINITY;
+    else process.env.XIAOBA_RESPONSES_SESSION_AFFINITY = original;
+  }
+});
+
 test('Responses streaming and non-streaming requests share the same logical cache body', () => {
   const messages: Message[] = [
     { role: 'system', content: 'stable system' },

--- a/tests/openai-provider-explicit-cache.test.ts
+++ b/tests/openai-provider-explicit-cache.test.ts
@@ -444,7 +444,7 @@ test('HTTP stream errors are read before explicit cache compatibility is evaluat
     };
   };
   try {
-    const instance = provider();
+    const instance = explicitProvider();
     const result = await instance.chatStream(
       [{ role: 'user', content: 'hello', __episodeId: 'episode-2' }],
       [],
@@ -453,8 +453,9 @@ test('HTTP stream errors are read before explicit cache compatibility is evaluat
     );
     assert.equal(result.content, 'OK');
     assert.equal(bodies.length, 2);
-    assert.deepEqual(bodies[0].prompt_cache_options, { mode: 'explicit' });
+    assert.equal(countBreakpoints(bodies[0].input), 1);
     assert.equal(bodies[1].prompt_cache_options, undefined);
+    assert.equal(countBreakpoints(bodies[1].input), 0);
   } finally {
     (axios as any).post = originalPost;
   }

--- a/tests/openai-provider-explicit-cache.test.ts
+++ b/tests/openai-provider-explicit-cache.test.ts
@@ -15,6 +15,15 @@ function provider(): OpenAIProvider {
   });
 }
 
+function explicitProvider(): OpenAIProvider {
+  return new OpenAIProvider({
+    apiKey: 'test-key',
+    apiUrl: 'https://api.openai.com/v1',
+    model: 'gpt-5.6-sol',
+    openaiApiMode: 'responses',
+  });
+}
+
 const context = {
   promptCacheContext: {
     sessionKey: 'session-alpha',
@@ -38,7 +47,7 @@ function circularErrorStream(payload: unknown): Readable {
   return stream;
 }
 
-test('Responses explicit cache emits one S, A, and latest B without persisting markers', () => {
+test('Responses cache omits the S carrier on custom endpoints and appends transient developer context', () => {
   const messages: Message[] = [
     { role: 'system', content: 'stable system' },
     { role: 'system', content: '[transient_skills_list]\n- lookup', __cacheScope: 'stable' },
@@ -59,16 +68,17 @@ test('Responses explicit cache emits one S, A, and latest B without persisting m
   ];
 
   const body = (provider() as any).buildResponsesRequestBody(messages, [], false, context);
-  assert.deepEqual(body.prompt_cache_options, { mode: 'explicit' });
+  assert.equal(body.prompt_cache_options, undefined);
   assert.match(body.instructions, /stable system/);
   assert.match(body.instructions, /transient_skills_list/);
   assert.doesNotMatch(body.instructions, /transient_plan_status/);
-  assert.equal(countBreakpoints(body.input), 3);
-  assert.equal(body.input[0].role, 'system');
-  assert.equal(body.input.at(-3).role, 'system');
-  assert.match(String(body.input.at(-3).content), /transient_plan_status/);
-  assert.equal(body.input.at(-2).type, 'function_call');
-  assert.equal(body.input.at(-1).type, 'function_call_output');
+  assert.equal(countBreakpoints(body.input), 0);
+  assert.equal(body.input[0].role, 'user');
+  assert.equal(body.input[0].content, 'old task');
+  assert.equal(body.input.at(-1).role, 'developer');
+  assert.match(String(body.input.at(-1).content), /transient_plan_status/);
+  assert.equal(body.input.at(-3).type, 'function_call');
+  assert.equal(body.input.at(-2).type, 'function_call_output');
   assert.equal(messages.some(message => (message as any).prompt_cache_breakpoint), false);
 });
 
@@ -102,14 +112,12 @@ test('Responses keeps a continuation checkpoint before its retained historical e
     .map((item: any, index: number) => countBreakpoints(item) > 0 ? index : -1)
     .filter((index: number) => index >= 0);
 
-  assert.equal(breakpointIndexes.length, 3);
-  assert.ok(breakpointIndexes[0] < checkpointIndex);
+  assert.equal(breakpointIndexes.length, 0);
   assert.ok(checkpointIndex < oldEvidenceIndex);
-  assert.ok(oldEvidenceIndex < breakpointIndexes[1]);
-  assert.ok(breakpointIndexes[1] < rootIndex);
-  assert.ok(rootIndex < breakpointIndexes[2]);
-  assert.ok(breakpointIndexes[2] < planIndex);
-  assert.ok(planIndex < callIndex);
+  assert.ok(oldEvidenceIndex < rootIndex);
+  assert.ok(rootIndex < callIndex);
+  assert.ok(callIndex < planIndex);
+  assert.equal(body.input[planIndex].role, 'developer');
 });
 
 test('Responses cache key is isolated by session without exposing the session id', () => {
@@ -120,6 +128,57 @@ test('Responses cache key is isolated by session without exposing the session id
   });
   assert.notEqual(first.prompt_cache_key, second.prompt_cache_key);
   assert.doesNotMatch(first.prompt_cache_key, /session-alpha/);
+});
+
+test('Responses streaming and non-streaming requests share the same logical cache body', () => {
+  const messages: Message[] = [
+    { role: 'system', content: 'stable system' },
+    { role: 'user', content: 'current request', __episodeId: 'episode-2' },
+    { role: 'system', content: '[transient_plan_status]\nstep two', __cacheScope: 'dynamic' },
+  ];
+  const nonStreaming = (provider() as any).buildResponsesRequestBody(messages, [], false, context);
+  const streaming = (provider() as any).buildResponsesRequestBody(messages, [], true, context);
+  const { stream: nonStreamingFlag, ...nonStreamingLogicalBody } = nonStreaming;
+  const { stream: streamingFlag, ...streamingLogicalBody } = streaming;
+
+  assert.equal(nonStreamingFlag, false);
+  assert.equal(streamingFlag, true);
+  assert.deepEqual(streamingLogicalBody, nonStreamingLogicalBody);
+});
+
+test('Responses keeps synthetic observation calls paired after durable history', () => {
+  const messages: Message[] = [
+    { role: 'system', content: 'stable system' },
+    { role: 'system', content: '[transient_plan_status]\nstep two', __cacheScope: 'dynamic' },
+    { role: 'user', content: 'current request', __episodeId: 'episode-2' },
+    {
+      role: 'assistant',
+      content: null,
+      __syntheticObservation: true,
+      tool_calls: [{
+        id: 'synthetic-observation-1',
+        type: 'function',
+        function: { name: 'runtime_observation', arguments: '{"source":"subagent"}' },
+      }],
+    },
+    {
+      role: 'tool',
+      content: 'late observation',
+      tool_call_id: 'synthetic-observation-1',
+      __syntheticObservation: true,
+    },
+  ];
+
+  const body = (provider() as any).buildResponsesRequestBody(messages, [], false, context);
+  const durableUserIndex = body.input.findIndex((item: any) => item.content === 'current request');
+  const callIndex = body.input.findIndex((item: any) => item.type === 'function_call');
+  const outputIndex = body.input.findIndex((item: any) => item.type === 'function_call_output');
+  const planIndex = body.input.findIndex((item: any) => String(item.content).includes('transient_plan_status'));
+
+  assert.ok(durableUserIndex < callIndex);
+  assert.ok(callIndex < outputIndex);
+  assert.ok(outputIndex < planIndex);
+  assert.equal(body.input[planIndex].role, 'developer');
 });
 
 test('Responses breakpoints never rewrite parallel function calls or outputs', () => {
@@ -148,13 +207,13 @@ test('Responses breakpoints never rewrite parallel function calls or outputs', (
   ));
 
   assert.ok(callA < callB && callB < outputA && outputA < outputB);
-  assert.ok(outputB < boundaryAfterTools);
+  assert.equal(boundaryAfterTools, -1);
   assert.equal(body.input[outputA].output, 'result-a');
   assert.equal(body.input[outputB].output, 'result-b');
   assert.equal(JSON.stringify(messages).includes('prompt_cache_breakpoint'), false);
 });
 
-test('Responses emits only the latest completed-turn breakpoint', () => {
+test('Responses custom endpoints do not inject a fixed session breakpoint', () => {
   const messages: Message[] = [
     { role: 'system', content: 'stable system' },
     { role: 'user', content: 'root task', __episodeId: 'episode-2', __episodeInputKind: 'root' },
@@ -171,9 +230,36 @@ test('Responses emits only the latest completed-turn breakpoint', () => {
   const secondTurnIndex = body.input.findIndex((item: any) => item.content === 'second turn');
   const latestEventIndex = body.input.findIndex((item: any) => item.content === 'latest event');
 
-  assert.equal(breakpointIndexes.length, 2);
-  assert.ok(secondTurnIndex < breakpointIndexes[1]);
-  assert.ok(breakpointIndexes[1] < latestEventIndex);
+  assert.equal(breakpointIndexes.length, 0);
+  assert.ok(secondTurnIndex < latestEventIndex);
+});
+
+test('Responses auto mode only emits the explicit S anchor for the official OpenAI endpoint', () => {
+  const messages: Message[] = [{ role: 'user', content: 'hello', __episodeId: 'episode-2' }];
+  const customBody = (provider() as any).buildResponsesRequestBody(messages, [], false, context);
+  const officialBody = (explicitProvider() as any).buildResponsesRequestBody(messages, [], false, context);
+
+  assert.equal(countBreakpoints(customBody.input), 0);
+  assert.equal(countBreakpoints(officialBody.input), 1);
+  assert.equal(customBody.input[0].content, 'hello');
+  assert.equal(officialBody.input[0].role, 'developer');
+});
+
+test('Responses explicit cache can be forced on a custom endpoint', () => {
+  const originalMode = process.env.XIAOBA_RESPONSES_EXPLICIT_CACHE;
+  process.env.XIAOBA_RESPONSES_EXPLICIT_CACHE = 'force';
+  try {
+    const body = (provider() as any).buildResponsesRequestBody(
+      [{ role: 'user', content: 'hello', __episodeId: 'episode-2' }],
+      [],
+      false,
+      context,
+    );
+    assert.equal(countBreakpoints(body.input), 1);
+  } finally {
+    if (originalMode === undefined) delete process.env.XIAOBA_RESPONSES_EXPLICIT_CACHE;
+    else process.env.XIAOBA_RESPONSES_EXPLICIT_CACHE = originalMode;
+  }
 });
 
 test('Responses explicit cache is not sent to older models', () => {
@@ -191,6 +277,22 @@ test('Responses explicit cache is not sent to older models', () => {
   );
   assert.equal(body.prompt_cache_options, undefined);
   assert.equal(countBreakpoints(body.input), 0);
+});
+
+test('Responses-only projection does not change Chat Completions roles', () => {
+  const chatProvider = new OpenAIProvider({
+    apiKey: 'test-key',
+    apiUrl: 'https://relay.example/v1',
+    model: 'gpt-5.6-sol',
+    openaiApiMode: 'chat_completions',
+  });
+  const body = (chatProvider as any).buildRequestBody([
+    { role: 'system', content: '[transient_plan_status]\nstep two', __cacheScope: 'dynamic' },
+    { role: 'user', content: 'hello', __injected: true },
+  ], [], false);
+
+  assert.deepEqual(body.messages.map((message: any) => message.role), ['system', 'user']);
+  assert.equal(JSON.stringify(body.messages).includes('developer'), false);
 });
 
 test('legacy checkpoint boundary is filtered but ordinary discussion is preserved', () => {
@@ -217,12 +319,16 @@ test('unsupported explicit fields retry once and pin the provider to compatibili
     return { data: { status: 'completed', output: [] } };
   };
   try {
-    const instance = provider();
+    const instance = explicitProvider();
     await instance.chat([{ role: 'user', content: 'hello', __episodeId: 'episode-2' }], [], context);
     assert.equal(bodies.length, 2);
-    assert.deepEqual(bodies[0].prompt_cache_options, { mode: 'explicit' });
+    assert.equal(countBreakpoints(bodies[0].input), 1);
     assert.equal(bodies[1].prompt_cache_options, undefined);
     assert.equal(countBreakpoints(bodies[1].input), 0);
+    assert.deepEqual(bodies[0].input.slice(1), bodies[1].input);
+    const { input: _firstInput, ...firstTransportBody } = bodies[0];
+    const { input: _secondInput, ...secondTransportBody } = bodies[1];
+    assert.deepEqual(firstTransportBody, secondTransportBody);
   } finally {
     (axios as any).post = originalPost;
   }
@@ -260,7 +366,7 @@ test('streamed unsupported explicit fields retry once in compatibility mode', as
     };
   };
   try {
-    const instance = provider();
+    const instance = explicitProvider();
     const result = await instance.chatStream(
       [{ role: 'user', content: 'hello', __episodeId: 'episode-2' }],
       [],
@@ -269,7 +375,7 @@ test('streamed unsupported explicit fields retry once in compatibility mode', as
     );
     assert.equal(result.content, 'OK');
     assert.equal(bodies.length, 2);
-    assert.deepEqual(bodies[0].prompt_cache_options, { mode: 'explicit' });
+    assert.equal(countBreakpoints(bodies[0].input), 1);
     assert.equal(bodies[1].prompt_cache_options, undefined);
     assert.equal(countBreakpoints(bodies[1].input), 0);
     assert.deepEqual(callbackErrors, []);
@@ -466,10 +572,17 @@ test('explicit cache retry inspection never throws for circular non-stream error
   data.self = data;
   const instance = provider();
   assert.doesNotThrow(() => {
-    assert.equal((instance as any).shouldRetryWithoutExplicitCaching({
+    assert.equal((instance as any).shouldRetryWithoutExplicitAnchor({
       response: { status: 500, data },
     }, {
-      prompt_cache_options: { mode: 'explicit' },
+      input: [{
+        role: 'developer',
+        content: [{
+          type: 'input_text',
+          text: 'anchor',
+          prompt_cache_breakpoint: { mode: 'explicit' },
+        }],
+      }],
     }), false);
   });
 });
@@ -494,7 +607,7 @@ test('strict explicit cache mode surfaces streamed rejection without fallback', 
     };
   };
   try {
-    const instance = provider();
+    const instance = explicitProvider();
     await assert.rejects(
       instance.chatStream(
         [{ role: 'user', content: 'hello', __episodeId: 'episode-2' }],
@@ -505,7 +618,7 @@ test('strict explicit cache mode surfaces streamed rejection without fallback', 
       /prompt_cache_breakpoint is not supported/i,
     );
     assert.equal(bodies.length, 1);
-    assert.deepEqual(bodies[0].prompt_cache_options, { mode: 'explicit' });
+    assert.equal(countBreakpoints(bodies[0].input), 1);
   } finally {
     if (originalStrict === undefined) delete process.env.XIAOBA_RESPONSES_EXPLICIT_CACHE_STRICT;
     else process.env.XIAOBA_RESPONSES_EXPLICIT_CACHE_STRICT = originalStrict;
@@ -534,7 +647,7 @@ test('Responses cache usage is recorded without prompt content', async () => {
     const usage = events.find(event => event.type === 'responses_cache_usage');
     assert.ok(usage);
     assert.deepEqual(usage.payload, {
-      mode: 'explicit',
+      mode: 'implicit',
       cache_key_hash: usage.payload.cache_key_hash,
       input_tokens: 1200,
       cached_tokens: 900,

--- a/tests/openai-provider-explicit-cache.test.ts
+++ b/tests/openai-provider-explicit-cache.test.ts
@@ -265,15 +265,32 @@ test('Responses custom endpoints do not inject a fixed session breakpoint', () =
   assert.ok(secondTurnIndex < latestEventIndex);
 });
 
-test('Responses auto mode only emits the explicit S anchor for the official OpenAI endpoint', () => {
+test('Responses explicit cache is disabled by default on custom and official endpoints', () => {
   const messages: Message[] = [{ role: 'user', content: 'hello', __episodeId: 'episode-2' }];
   const customBody = (provider() as any).buildResponsesRequestBody(messages, [], false, context);
   const officialBody = (explicitProvider() as any).buildResponsesRequestBody(messages, [], false, context);
 
   assert.equal(countBreakpoints(customBody.input), 0);
-  assert.equal(countBreakpoints(officialBody.input), 1);
+  assert.equal(countBreakpoints(officialBody.input), 0);
   assert.equal(customBody.input[0].content, 'hello');
-  assert.equal(officialBody.input[0].role, 'developer');
+  assert.equal(officialBody.input[0].content, 'hello');
+});
+
+test('Responses explicit cache auto mode remains an opt-in for the official OpenAI endpoint', () => {
+  const originalMode = process.env.XIAOBA_RESPONSES_EXPLICIT_CACHE;
+  process.env.XIAOBA_RESPONSES_EXPLICIT_CACHE = 'auto';
+  try {
+    const messages: Message[] = [{ role: 'user', content: 'hello', __episodeId: 'episode-2' }];
+    const customBody = (provider() as any).buildResponsesRequestBody(messages, [], false, context);
+    const officialBody = (explicitProvider() as any).buildResponsesRequestBody(messages, [], false, context);
+
+    assert.equal(countBreakpoints(customBody.input), 0);
+    assert.equal(countBreakpoints(officialBody.input), 1);
+    assert.equal(officialBody.input[0].role, 'developer');
+  } finally {
+    if (originalMode === undefined) delete process.env.XIAOBA_RESPONSES_EXPLICIT_CACHE;
+    else process.env.XIAOBA_RESPONSES_EXPLICIT_CACHE = originalMode;
+  }
 });
 
 test('Responses explicit cache can be forced on a custom endpoint', () => {
@@ -339,7 +356,9 @@ test('legacy checkpoint boundary is filtered but ordinary discussion is preserve
 
 test('unsupported explicit fields retry once and pin the provider to compatibility mode', async () => {
   const originalPost = axios.post;
+  const originalMode = process.env.XIAOBA_RESPONSES_EXPLICIT_CACHE;
   const bodies: any[] = [];
+  process.env.XIAOBA_RESPONSES_EXPLICIT_CACHE = 'on';
   (axios as any).post = async (_url: string, body: any) => {
     bodies.push(body);
     if (bodies.length === 1) {
@@ -361,14 +380,18 @@ test('unsupported explicit fields retry once and pin the provider to compatibili
     const { input: _secondInput, ...secondTransportBody } = bodies[1];
     assert.deepEqual(firstTransportBody, secondTransportBody);
   } finally {
+    if (originalMode === undefined) delete process.env.XIAOBA_RESPONSES_EXPLICIT_CACHE;
+    else process.env.XIAOBA_RESPONSES_EXPLICIT_CACHE = originalMode;
     (axios as any).post = originalPost;
   }
 });
 
 test('streamed unsupported explicit fields retry once in compatibility mode', async () => {
   const originalPost = axios.post;
+  const originalMode = process.env.XIAOBA_RESPONSES_EXPLICIT_CACHE;
   const bodies: any[] = [];
   const callbackErrors: Error[] = [];
+  process.env.XIAOBA_RESPONSES_EXPLICIT_CACHE = 'on';
   (axios as any).post = async (_url: string, body: any) => {
     bodies.push(body);
     if (bodies.length === 1) {
@@ -411,13 +434,17 @@ test('streamed unsupported explicit fields retry once in compatibility mode', as
     assert.equal(countBreakpoints(bodies[1].input), 0);
     assert.deepEqual(callbackErrors, []);
   } finally {
+    if (originalMode === undefined) delete process.env.XIAOBA_RESPONSES_EXPLICIT_CACHE;
+    else process.env.XIAOBA_RESPONSES_EXPLICIT_CACHE = originalMode;
     (axios as any).post = originalPost;
   }
 });
 
 test('HTTP stream errors are read before explicit cache compatibility is evaluated', async () => {
   const originalPost = axios.post;
+  const originalMode = process.env.XIAOBA_RESPONSES_EXPLICIT_CACHE;
   const bodies: any[] = [];
+  process.env.XIAOBA_RESPONSES_EXPLICIT_CACHE = 'on';
   (axios as any).post = async (_url: string, body: any) => {
     bodies.push(body);
     if (bodies.length === 1) {
@@ -457,6 +484,8 @@ test('HTTP stream errors are read before explicit cache compatibility is evaluat
     assert.equal(bodies[1].prompt_cache_options, undefined);
     assert.equal(countBreakpoints(bodies[1].input), 0);
   } finally {
+    if (originalMode === undefined) delete process.env.XIAOBA_RESPONSES_EXPLICIT_CACHE;
+    else process.env.XIAOBA_RESPONSES_EXPLICIT_CACHE = originalMode;
     (axios as any).post = originalPost;
   }
 });
@@ -621,8 +650,10 @@ test('explicit cache retry inspection never throws for circular non-stream error
 
 test('strict explicit cache mode surfaces streamed rejection without fallback', async () => {
   const originalPost = axios.post;
+  const originalMode = process.env.XIAOBA_RESPONSES_EXPLICIT_CACHE;
   const originalStrict = process.env.XIAOBA_RESPONSES_EXPLICIT_CACHE_STRICT;
   const bodies: any[] = [];
+  process.env.XIAOBA_RESPONSES_EXPLICIT_CACHE = 'on';
   process.env.XIAOBA_RESPONSES_EXPLICIT_CACHE_STRICT = '1';
   (axios as any).post = async (_url: string, body: any) => {
     bodies.push(body);
@@ -652,6 +683,8 @@ test('strict explicit cache mode surfaces streamed rejection without fallback', 
     assert.equal(bodies.length, 1);
     assert.equal(countBreakpoints(bodies[0].input), 1);
   } finally {
+    if (originalMode === undefined) delete process.env.XIAOBA_RESPONSES_EXPLICIT_CACHE;
+    else process.env.XIAOBA_RESPONSES_EXPLICIT_CACHE = originalMode;
     if (originalStrict === undefined) delete process.env.XIAOBA_RESPONSES_EXPLICIT_CACHE_STRICT;
     else process.env.XIAOBA_RESPONSES_EXPLICIT_CACHE_STRICT = originalStrict;
     (axios as any).post = originalPost;

--- a/tests/openai-provider-explicit-cache.test.ts
+++ b/tests/openai-provider-explicit-cache.test.ts
@@ -646,13 +646,15 @@ test('Responses cache usage is recorded without prompt content', async () => {
     await provider().chat([{ role: 'user', content: 'hello', __episodeId: 'episode-2' }], [], context);
     const usage = events.find(event => event.type === 'responses_cache_usage');
     assert.ok(usage);
-    assert.deepEqual(usage.payload, {
-      mode: 'implicit',
-      cache_key_hash: usage.payload.cache_key_hash,
-      input_tokens: 1200,
-      cached_tokens: 900,
-      cache_write_tokens: 200,
-    });
+    assert.equal(usage.payload.mode, 'implicit');
+    assert.equal(typeof usage.payload.request_trace_id, 'string');
+    assert.equal(typeof usage.payload.cache_key_hash, 'string');
+    assert.equal(typeof usage.payload.logical_body_hash, 'string');
+    assert.equal(usage.payload.input_tokens, 1200);
+    assert.equal(usage.payload.cached_tokens, 900);
+    assert.equal(usage.payload.cache_write_tokens, 200);
+    assert.deepEqual(usage.payload.usage_input_detail_keys, ['cache_write_tokens', 'cached_tokens']);
+    assert.equal(usage.payload.cache_write_tokens_present, true);
     assert.equal(JSON.stringify(usage).includes('hello'), false);
   } finally {
     (axios as any).post = originalPost;

--- a/tests/openai-provider-responses.test.ts
+++ b/tests/openai-provider-responses.test.ts
@@ -4,6 +4,7 @@ import { Readable } from 'node:stream';
 import axios from 'axios';
 import { OpenAIProvider } from '../src/providers/openai-provider';
 import { AIService } from '../src/utils/ai-service';
+import { Logger } from '../src/utils/logger';
 import type { Message } from '../src/types';
 import type { ToolDefinition } from '../src/types/tool';
 
@@ -52,7 +53,7 @@ describe('OpenAIProvider Responses API mode', () => {
     assert.deepEqual(first.include, ['reasoning.encrypted_content']);
   });
 
-  test('keeps dynamic system context out of cache identity and places it before the latest event', () => {
+  test('keeps dynamic system context out of cache identity and appends it as developer context', () => {
     const provider = createProvider();
     const first = (provider as any).buildResponsesRequestBody([
       { role: 'system', content: 'Stable policy.' },
@@ -69,13 +70,83 @@ describe('OpenAIProvider Responses API mode', () => {
     assert.equal(second.instructions, 'Stable policy.');
     assert.equal(first.prompt_cache_key, second.prompt_cache_key);
     assert.deepEqual(first.input, [
-      { role: 'system', content: '[transient_plan_status]\nstep one' },
       { role: 'user', content: 'first question' },
+      { role: 'developer', content: '[transient_plan_status]\nstep one' },
     ]);
     assert.deepEqual(second.input, [
-      { role: 'system', content: '[transient_plan_status]\nstep two' },
       { role: 'user', content: 'another question' },
+      { role: 'developer', content: '[transient_plan_status]\nstep two' },
     ]);
+  });
+
+  test('logs implicit user and tool breakpoint prefixes from the actual Responses input', () => {
+    const provider = createProvider();
+    const originalRuntimeEvent = Logger.runtimeEvent;
+    const events: any[] = [];
+    (Logger as any).runtimeEvent = (_level: string, _message: string, event: any) => events.push(event);
+    try {
+      const commonMessages: Message[] = [
+        { role: 'system', content: 'Stable policy.' },
+        { role: 'user', content: 'use the tool' },
+        {
+          role: 'assistant',
+          content: null,
+          tool_calls: [{
+            id: 'call-1',
+            type: 'function',
+            function: { name: 'lookup', arguments: '{"query":"one"}' },
+          }],
+        },
+        { role: 'tool', tool_call_id: 'call-1', content: 'first result' },
+      ];
+
+      (provider as any).buildResponsesRequestBody([
+        ...commonMessages,
+        { role: 'system', content: '[transient_plan_status]\nstep one', __cacheScope: 'dynamic' },
+      ], [lookupTool]);
+      (provider as any).buildResponsesRequestBody([
+        ...commonMessages,
+        { role: 'system', content: '[transient_plan_status]\nstep two', __cacheScope: 'dynamic' },
+      ], [lookupTool]);
+      (provider as any).buildResponsesRequestBody([
+        ...commonMessages,
+        {
+          role: 'assistant',
+          content: null,
+          tool_calls: [{
+            id: 'call-2',
+            type: 'function',
+            function: { name: 'lookup', arguments: '{"query":"two"}' },
+          }],
+        },
+        { role: 'tool', tool_call_id: 'call-2', content: 'second result' },
+        { role: 'system', content: '[transient_plan_status]\nstep three', __cacheScope: 'dynamic' },
+      ], [lookupTool]);
+
+      const layouts = events.filter(event => event.type === 'responses_cache_layout');
+      assert.equal(layouts.length, 3);
+      assert.equal(layouts[0].payload.stream, false);
+      assert.equal(layouts[0].payload.transport, 'json');
+      assert.deepEqual(
+        layouts[0].payload.implicit_candidates.map((candidate: any) => candidate.kind),
+        ['user', 'tool'],
+      );
+      assert.equal(layouts[0].payload.implicit_trailing_items, 1);
+      assert.equal(
+        layouts[0].payload.implicit_latest_prefix_hash,
+        layouts[1].payload.implicit_latest_prefix_hash,
+      );
+      assert.equal(
+        layouts[2].payload.implicit_candidates.some((candidate: any) => (
+          candidate.prefixHash === layouts[1].payload.implicit_latest_prefix_hash
+        )),
+        true,
+      );
+      assert.equal(JSON.stringify(layouts).includes('first result'), false);
+      assert.equal(JSON.stringify(layouts).includes('step one'), false);
+    } finally {
+      (Logger as any).runtimeEvent = originalRuntimeEvent;
+    }
   });
 
   test('keeps plan, subagent, runner, and device changes out of cache identity', () => {
@@ -100,8 +171,8 @@ describe('OpenAIProvider Responses API mode', () => {
       ], [lookupTool]);
 
       assert.equal(first.prompt_cache_key, second.prompt_cache_key);
-      assert.equal(first.input[0].role, 'system');
-      assert.equal(first.input[0].content, firstDynamic);
+      assert.equal(first.input.at(-1).role, 'developer');
+      assert.equal(first.input.at(-1).content, firstDynamic);
     }
 
     const changedStable = (provider as any).buildResponsesRequestBody([

--- a/tests/subagent-checkpoint-compaction.test.ts
+++ b/tests/subagent-checkpoint-compaction.test.ts
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import test from 'node:test';
+import { ConversationRunner } from '../src/core/conversation-runner';
+import { SubAgentSession } from '../src/core/sub-agent-session';
+
+test('SubAgentSession follows the main-session checkpoint compaction rollout switch', async () => {
+  const originalFlag = process.env.XIAOBA_CHECKPOINT_COMPACTION_ENABLED;
+  const originalRun = ConversationRunner.prototype.run;
+  const observed: Array<{ enableCompression: boolean; checkpointCoordinator: boolean }> = [];
+
+  (ConversationRunner.prototype as any).run = async function runMock(messages: any[]) {
+    observed.push({
+      enableCompression: Boolean((this as any).enableCompression),
+      checkpointCoordinator: Boolean((this as any).checkpointCompactionCoordinator),
+    });
+    return {
+      response: 'done',
+      finalResponseVisible: true,
+      messages,
+      newMessages: [],
+    };
+  };
+
+  const runSession = async (id: string) => {
+    const workingDirectory = fs.mkdtempSync(path.join(os.tmpdir(), `xiaoba-${id}-`));
+    const session = new SubAgentSession(id, {
+      getConfig: () => ({ contextWindowTokens: 256_000 }),
+    } as any, {
+      getSkill() { return undefined; },
+      loadSkills: async () => {},
+    } as any, {
+      agentType: 'explorer',
+      taskDescription: 'verify compaction mode',
+      userMessage: 'verify compaction mode',
+      workingDirectory,
+    });
+    try {
+      await session.run();
+    } finally {
+      await session.close();
+      fs.rmSync(workingDirectory, { recursive: true, force: true });
+    }
+  };
+
+  try {
+    delete process.env.XIAOBA_CHECKPOINT_COMPACTION_ENABLED;
+    await runSession('sub-checkpoint-default');
+
+    process.env.XIAOBA_CHECKPOINT_COMPACTION_ENABLED = 'false';
+    await runSession('sub-checkpoint-legacy');
+
+    assert.deepEqual(observed, [
+      { enableCompression: false, checkpointCoordinator: true },
+      { enableCompression: true, checkpointCoordinator: false },
+    ]);
+  } finally {
+    ConversationRunner.prototype.run = originalRun;
+    if (originalFlag === undefined) delete process.env.XIAOBA_CHECKPOINT_COMPACTION_ENABLED;
+    else process.env.XIAOBA_CHECKPOINT_COMPACTION_ENABLED = originalFlag;
+  }
+});


### PR DESCRIPTION
## Summary

- use Pi-style implicit Responses caching with stable session-scoped `prompt_cache_key`
- add optional Responses relay session affinity via stable `session_id` and `x-client-request-id`
- keep transient developer context after durable history so prior user/tool prefixes remain reusable
- log hash-only cache layout and final pre-upload wire diagnostics without prompt or authorization contents
- preserve the original session key through checkpoint compaction summary requests
- move Subagent compression onto the same CheckpointCompaction path as the main agent
- add a reproducible large tool-output Responses cache canary driven by environment variables

## Why

Long Responses sessions and Subagent continuations showed occasional complete cache misses even when the durable prefix appeared unchanged. Some Subagent compaction requests could also fall back to an unscoped cache namespace. These changes preserve stable cache identity and add wire-level diagnostics so application-side prefix changes can be distinguished from relay or upstream cache behavior.

## Impact

- OpenAI Responses sessions retain a stable cache namespace across normal turns and checkpoint compaction.
- Subagents no longer use the legacy runner-level compressor.
- Anthropic and non-Responses provider layouts are unchanged.
- Wire diagnostics are opt-in through `XIAOBA_RESPONSES_WIRE_DEBUG=true`.
- Session affinity remains configurable through `XIAOBA_RESPONSES_SESSION_AFFINITY`.

## Validation

- `npm run build`
- Responses cache tests: 24 passed
- `npm test`: 1399 passed, 0 failed, 5 skipped
- `git diff --check`

This branch is rebased directly onto the current `buildsense-ai/XiaoBa-CLI` `main` at `cd66b3a` and intentionally does not include PR325.