### PR TITLE
feat(skillhub): 支持 WebApp 安全操作本地 Skill 工作区

### DIFF
--- a/src/bot-skills/local-manifest.ts
+++ b/src/bot-skills/local-manifest.ts
@@ -13,6 +13,14 @@ import type {
 } from './types';
 
 export const BOT_SKILL_LOCAL_MARKER_FILE = '.xiaoba-bot-skill.json';
+
+export class BotSkillPackageValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BotSkillPackageValidationError';
+  }
+}
+
 const BOT_SKILL_LOCAL_MARKER_SCHEMA = 'xiaoba.bot-skill-local.v1';
 const SKIP_DIRECTORIES = new Set(['.git', 'node_modules']);
 const FORBIDDEN_CREDENTIAL_DIRECTORIES = new Set(['.ssh', '.aws', '.kube', '.gnupg']);
@@ -110,7 +118,7 @@ export function scanLocalBotSkill(
   }
   assertRealPathContained(fs.realpathSync(root), skillFile);
   const marker = ensureBotSkillLocalMarker(root);
-  const files = collectPackageFiles(root);
+  const files = collectBotSkillPackageFiles(root);
   const contentHash = computeBotSkillPackageHash(files);
   const reference = marker.reference?.contentHash === contentHash
     ? marker.reference
@@ -192,7 +200,7 @@ function ensureBotSkillLocalMarker(skillDir: string): BotSkillLocalMarker {
   return marker;
 }
 
-function collectPackageFiles(root: string): BotSkillPackageFile[] {
+export function collectBotSkillPackageFiles(root: string): BotSkillPackageFile[] {
   const realRoot = fs.realpathSync(root);
   const files: BotSkillPackageFile[] = [];
   let totalBytes = 0;
@@ -205,7 +213,7 @@ function collectPackageFiles(root: string): BotSkillPackageFile[] {
       assertRealPathContained(realRoot, fullPath);
       if (entry.isDirectory()) {
         if (FORBIDDEN_CREDENTIAL_DIRECTORIES.has(entry.name.toLowerCase())) {
-          throw new Error(`Skill contains a forbidden credential directory: ${entry.name}`);
+          throw new BotSkillPackageValidationError(`Skill contains a forbidden credential directory: ${entry.name}`);
         }
         if (
           !SKIP_DIRECTORIES.has(entry.name)
@@ -218,22 +226,26 @@ function collectPackageFiles(root: string): BotSkillPackageFile[] {
       if (!entry.isFile() || SKIP_FILES.has(entry.name)) continue;
       const relativePath = path.relative(root, fullPath).replace(/\\/g, '/');
       if (!isPortablePackagePath(relativePath)) {
-        throw new Error(`Skill contains an unsafe path: ${relativePath}`);
+        throw new BotSkillPackageValidationError(`Skill contains an unsafe path: ${relativePath}`);
       }
       const bytes = fs.readFileSync(fullPath);
       rejectSensitiveMaterial(relativePath, bytes);
       if (bytes.length > MAX_SINGLE_FILE_BYTES) {
-        throw new Error(`Skill file is too large: ${relativePath}`);
+        throw new BotSkillPackageValidationError(`Skill file is too large: ${relativePath}`);
       }
       totalBytes += bytes.length;
-      if (totalBytes > MAX_TOTAL_BYTES) throw new Error('Skill package is too large');
+      if (totalBytes > MAX_TOTAL_BYTES) {
+        throw new BotSkillPackageValidationError('Skill package is too large');
+      }
       files.push({
         path: relativePath,
         size: bytes.length,
         sha256: sha256(bytes),
         contentBase64: bytes.toString('base64'),
       });
-      if (files.length > MAX_FILES) throw new Error('Skill package contains too many files');
+      if (files.length > MAX_FILES) {
+        throw new BotSkillPackageValidationError('Skill package contains too many files');
+      }
     }
   };
   visit(root);
@@ -243,7 +255,9 @@ function collectPackageFiles(root: string): BotSkillPackageFile[] {
 function rejectSensitiveMaterial(filePath: string, bytes: Buffer): void {
   const name = path.posix.basename(filePath).toLowerCase();
   if (isArchiveFile(name, bytes)) {
-    throw new Error(`Skill contains an archive file and cannot be uploaded automatically: ${filePath}`);
+    throw new BotSkillPackageValidationError(
+      `Skill contains an archive file and cannot be uploaded automatically: ${filePath}`,
+    );
   }
   if (
     name === '.env'
@@ -253,7 +267,9 @@ function rejectSensitiveMaterial(filePath: string, bytes: Buffer): void {
     || /\.(?:exe|dll|so|dylib|msi|apk|appimage)$/i.test(name)
     || containsHighConfidenceSecret(bytes)
   ) {
-    throw new Error(`Skill contains sensitive material and cannot be uploaded: ${filePath}`);
+    throw new BotSkillPackageValidationError(
+      `Skill contains sensitive material and cannot be uploaded: ${filePath}`,
+    );
   }
 }
 
@@ -372,7 +388,7 @@ export function isPortablePackagePath(value: string): boolean {
 function assertRealPathContained(realRoot: string, candidate: string): void {
   const realCandidate = fs.realpathSync(candidate);
   if (realCandidate !== realRoot && !realCandidate.startsWith(`${realRoot}${path.sep}`)) {
-    throw new Error(`Skill path escaped its workspace: ${candidate}`);
+    throw new BotSkillPackageValidationError('Skill path escaped its workspace.');
   }
 }
 

--- a/src/bot-skills/private-package-client.ts
+++ b/src/bot-skills/private-package-client.ts
@@ -81,13 +81,18 @@ export class BotPrivateSkillClient {
     };
   }
 
-  async download(reference: BotSkillRef): Promise<BotSkillPackage> {
+  async download(
+    reference: BotSkillRef,
+    options: { timeoutMs?: number } = {},
+  ): Promise<BotSkillPackage> {
     const expected = parsePackageReference(reference);
     const skillId = encodeReferencePath(expected.skillId);
     const version = encodeURIComponent(expected.version);
     const response = await this.request(
       'GET',
       `/api/bot/skill-packages/${skillId}/versions/${version}`,
+      undefined,
+      options,
     );
     const packageValue = validateDownloadedPackage(response, expected);
     if (packageValue.contentHash !== reference.contentHash) {
@@ -148,11 +153,20 @@ export class BotPrivateSkillClient {
     return target;
   }
 
-  private async request(method: string, apiPath: string, body?: unknown): Promise<any> {
+  private async request(
+    method: string,
+    apiPath: string,
+    body?: unknown,
+    options: { timeoutMs?: number } = {},
+  ): Promise<any> {
     const apiKey = String(this.auth.apiKey || '').trim();
     if (!apiKey) throw new Error('CatsCo Bot API key is required for private Skill sync.');
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), PRIVATE_PACKAGE_TIMEOUT_MS);
+    const timeoutMs = Math.max(1, Math.min(
+      Number(options.timeoutMs ?? PRIVATE_PACKAGE_TIMEOUT_MS),
+      PRIVATE_PACKAGE_TIMEOUT_MS,
+    ));
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
     try {
       const response = await this.fetchImpl(`${this.baseUrl}${apiPath}`, {
         method,

--- a/src/bot-skills/runtime.ts
+++ b/src/bot-skills/runtime.ts
@@ -13,6 +13,8 @@ import { withBotSkillWorkspaceLock } from './lock';
 import {
   BotSkillCloudRestoreError,
   BotSkillSyncService,
+  type FinalizePublicBotSkillInput,
+  type FinalizePublicBotSkillOptions,
   type BotSkillSyncResult,
 } from './sync-service';
 import {
@@ -143,39 +145,12 @@ export function scheduleCurrentBotSkillSync(): void {
   currentBotSyncPending = true;
   if (currentBotSyncRunning) return;
   currentBotSyncRunning = true;
-  const run = async (): Promise<void> => {
-    const runtimeRoot = path.resolve(PathResolver.getRuntimeDataRoot());
-    await withBotSkillWorkspaceLock(runtimeRoot, async () => {
-      const configService = createCatsCoLocalConfigService({ runtimeRoot });
-      const localConfig = configService.load();
-      const botId = String(localConfig.currentBot?.uid || '').trim();
-      if (!botId) return;
-
-      const activeRoot = PathResolver.getRuntimeDataRoot() === runtimeRoot
-        ? PathResolver.getSkillsPath()
-        : path.join(runtimeRoot, 'skills');
-      const workspace = new BotSkillWorkspaceService(runtimeRoot, activeRoot);
-      if (workspace.getActiveBotId() !== botId) return;
-      BotSkillSyncService.recoverInterruptedRestore(runtimeRoot, botId, activeRoot);
-
-      const definitionService = createBotDefinitionSyncService({ runtimeRoot });
-      await new BotSkillSyncService({
-        runtimeRoot,
-        botId,
-        auth: configService.getAuthState(),
-        skillsRoot: workspace.getActivePath(),
-        workspaceExisted: true,
-        definitionService,
-      }).sync();
-    });
-  };
-
   void (async () => {
     try {
       while (currentBotSyncPending) {
         currentBotSyncPending = false;
         try {
-          await run();
+          await syncCurrentBotSkillsNow();
         } catch (error) {
           Logger.warning(`Bot Skill cloud sync failed; local workspace is preserved: ${errorMessage(error)}`);
         }
@@ -185,6 +160,63 @@ export function scheduleCurrentBotSkillSync(): void {
       if (currentBotSyncPending) scheduleCurrentBotSkillSync();
     }
   })();
+}
+
+export async function syncCurrentBotSkillsNow(): Promise<BotSkillSyncResult | undefined> {
+  const runtimeRoot = path.resolve(PathResolver.getRuntimeDataRoot());
+  return withBotSkillWorkspaceLock(runtimeRoot, async () => {
+    const configService = createCatsCoLocalConfigService({ runtimeRoot });
+    const localConfig = configService.load();
+    const botId = String(localConfig.currentBot?.uid || '').trim();
+    if (!botId) return undefined;
+
+    const activeRoot = PathResolver.getRuntimeDataRoot() === runtimeRoot
+      ? PathResolver.getSkillsPath()
+      : path.join(runtimeRoot, 'skills');
+    const workspace = new BotSkillWorkspaceService(runtimeRoot, activeRoot);
+    if (workspace.getActiveBotId() !== botId) return undefined;
+    BotSkillSyncService.recoverInterruptedRestore(runtimeRoot, botId, activeRoot);
+
+    const definitionService = createBotDefinitionSyncService({ runtimeRoot });
+    return new BotSkillSyncService({
+      runtimeRoot,
+      botId,
+      auth: configService.getAuthState(),
+      skillsRoot: workspace.getActivePath(),
+      workspaceExisted: true,
+      definitionService,
+    }).sync();
+  });
+}
+
+export interface FinalizeCurrentBotPublicSkillOptions
+  extends FinalizePublicBotSkillOptions, CurrentBotSkillWorkspaceWriteOptions {}
+
+export async function finalizeCurrentBotPublicSkillNow(
+  botId: string,
+  input: FinalizePublicBotSkillInput,
+  options: FinalizeCurrentBotPublicSkillOptions = {},
+): Promise<BotSkillSyncResult> {
+  const runtimeRoot = path.resolve(options.runtimeRoot ?? PathResolver.getRuntimeDataRoot());
+  return withCurrentBotSkillWorkspaceWrite(async (context) => {
+    if (context.botId !== botId || context.activeBotId !== botId) {
+      throw new Error('The selected Bot workspace is not active on this device.');
+    }
+    await options.validateScope?.();
+    const configService = createCatsCoLocalConfigService({ runtimeRoot });
+    const definitionService = createBotDefinitionSyncService({ runtimeRoot });
+    return new BotSkillSyncService({
+      runtimeRoot,
+      botId,
+      auth: configService.getAuthState(),
+      skillsRoot: context.skillsRoot,
+      workspaceExisted: true,
+      definitionService,
+    }).finalizePublicSkill(input, options);
+  }, {
+    runtimeRoot,
+    lockWaitMs: options.lockWaitMs,
+  });
 }
 
 function errorMessage(error: unknown): string {

--- a/src/bot-skills/sync-service.ts
+++ b/src/bot-skills/sync-service.ts
@@ -288,6 +288,7 @@ export class BotSkillSyncService {
     );
     const initialCloud = await pullCloudBotSkills(this.cloudOptions);
     if (!initialCloud) throw new Error('Bot Skill cloud sync is unavailable for public finalization.');
+    await options.validateScope?.();
     this.recoverInterruptedFinalizes(initialCloud);
     const base = this.baseStore.read(this.botId);
     const local = this.readLocalManifest();
@@ -319,6 +320,10 @@ export class BotSkillSyncService {
       throw new Error('The selected local Skill changed before public finalization could be committed.');
     }
 
+    // Keep the final local journal/file write behind the same lifecycle fence as
+    // the cloud checks. Once this synchronous block starts, no JS shutdown hook
+    // can interleave between its individual filesystem writes.
+    await options.validateScope?.();
     const skillFile = path.join(readyToWrite.path, 'SKILL.md');
     const markerFile = path.join(readyToWrite.path, BOT_SKILL_LOCAL_MARKER_FILE);
     const previousSkill = fs.readFileSync(skillFile, 'utf8');
@@ -364,6 +369,7 @@ export class BotSkillSyncService {
       await options.validateScope?.();
       const result = await this.pushLocal(updatedLocal, currentCloud, base, {
         requiredCloudReference: reference,
+        validateScope: options.validateScope,
       });
       try {
         this.removeFinalizeJournal(localSkillId);
@@ -504,7 +510,10 @@ export class BotSkillSyncService {
     local: LocalBotSkillManifestEntry[],
     initialCloud: CloudBotSkills,
     base: BotSkillSyncBase | undefined,
-    options: { requiredCloudReference?: BotSkillRef } = {},
+    options: {
+      requiredCloudReference?: BotSkillRef;
+      validateScope?: () => Promise<void> | void;
+    } = {},
   ): Promise<BotSkillSyncResult> {
     if (
       options.requiredCloudReference
@@ -540,6 +549,7 @@ export class BotSkillSyncService {
         reference = entry.reference;
       }
       if (!reference) {
+        await options.validateScope?.();
         const uploaded = await this.privateClient.upsert(entry);
         if (uploaded.contentHash !== entry.contentHash) {
           throw new Error(`SkillHub returned a mismatched content hash for ${entry.name}`);
@@ -572,15 +582,18 @@ export class BotSkillSyncService {
         ...(entry.origin ? { origin: entry.origin } : {}),
       });
     }
+    await options.validateScope?.();
     const refs = canonicalizeBotSkillRefs(nextEntries.map(entry => entry.reference));
     if (
       base
       && !botSkillRefsEqual(initialCloud.skills, base.skills.map(entry => entry.reference))
     ) {
+      await options.validateScope?.();
       this.writeConflictSnapshot(initialCloud, refs);
     }
     let cloud = initialCloud;
     try {
+      await options.validateScope?.();
       cloud = await replaceCloudBotSkills(this.cloudOptions, cloud, refs);
     } catch (error) {
       if (!(error instanceof BotSkillsCloudConflictError)) throw error;
@@ -593,11 +606,14 @@ export class BotSkillSyncService {
         throw new Error('The public Skill reference was removed from BotDefinition during finalization.');
       }
       if (!base || !botSkillRefsEqual(latest.skills, base.skills.map(entry => entry.reference))) {
+        await options.validateScope?.();
         this.writeConflictSnapshot(latest, refs);
       }
       // The current single-device contract explicitly protects local changes.
+      await options.validateScope?.();
       cloud = await replaceCloudBotSkills(this.cloudOptions, latest, refs);
     }
+    await options.validateScope?.();
     for (const item of pendingMarkers) {
       writeBotSkillLocalMarker(item.path, item.marker);
     }

--- a/src/bot-skills/sync-service.ts
+++ b/src/bot-skills/sync-service.ts
@@ -1,6 +1,7 @@
 import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
+import matter from 'gray-matter';
 import type { CatsCoAuthSnapshot } from '../catscompany/local-config';
 import {
   createBotDefinitionSyncService,
@@ -17,6 +18,8 @@ import {
 } from './cloud-client';
 import { BotSkillBaseStore } from './base-store';
 import {
+  BOT_SKILL_LOCAL_MARKER_FILE,
+  computeBotSkillPackageHash,
   readBotSkillLocalMarker,
   scanBotSkillWorkspace,
   writeBotSkillLocalMarker,
@@ -24,10 +27,12 @@ import {
 import { BotPrivateSkillClient } from './private-package-client';
 import type {
   BotSkillPackage,
+  BotSkillPackageFile,
   BotSkillSyncBase,
   BotSkillSyncBaseEntry,
   LocalBotSkillManifestEntry,
 } from './types';
+import { applySkillHubLocalMetadata } from '../skillhub/local-skill-metadata';
 
 export type BotSkillSyncDirection =
   | 'none'
@@ -55,6 +60,19 @@ export interface BotSkillSyncServiceOptions {
   privateClient?: BotPrivateSkillClient;
 }
 
+export interface FinalizePublicBotSkillInput {
+  localSkillId: string;
+  skillName: string;
+  reference: BotSkillRef;
+}
+
+export interface FinalizePublicBotSkillOptions {
+  publicationWaitMs?: number;
+  pollDelayMs?: number;
+  sleep?: (delayMs: number) => Promise<void>;
+  validateScope?: () => Promise<void> | void;
+}
+
 export class BotSkillCloudRestoreError extends Error {
   constructor(message: string, options?: { cause?: unknown }) {
     super(message);
@@ -78,6 +96,21 @@ interface BotSkillRestoreJournal {
     | 'committed';
 }
 
+interface BotSkillFinalizeJournal {
+  schema: 'xiaoba.bot-skill-finalize-journal.v1';
+  botId: string;
+  skillsRoot: string;
+  skillPath: string;
+  localSkillId: string;
+  skillName: string;
+  previousContentHash: string;
+  nextContentHash: string;
+  reference: BotSkillRef;
+  previousSkill: string;
+  nextSkill: string;
+  previousMarker: string;
+}
+
 export class BotSkillSyncService {
   private readonly runtimeRoot: string;
   private readonly botId: string;
@@ -91,7 +124,7 @@ export class BotSkillSyncService {
   constructor(options: BotSkillSyncServiceOptions) {
     this.runtimeRoot = path.resolve(options.runtimeRoot);
     this.botId = String(options.botId || '').trim();
-    if (!/^[A-Za-z0-9_.-]+$/.test(this.botId)) throw new Error('Invalid Bot ID for Skill sync');
+    if (!/^[A-Za-z0-9_.-]{1,160}$/.test(this.botId)) throw new Error('Invalid Bot ID for Skill sync');
     this.skillsRoot = path.resolve(options.skillsRoot ?? path.join(this.runtimeRoot, 'skills'));
     this.workspaceExisted = options.workspaceExisted;
     this.cloudOptions = {
@@ -156,7 +189,7 @@ export class BotSkillSyncService {
       this.skillsRoot,
     );
     const base = this.baseStore.read(this.botId);
-    const local = this.readLocalManifest();
+    let local = this.readLocalManifest();
     let cloud: CloudBotSkills | undefined;
     try {
       cloud = await pullCloudBotSkills(this.cloudOptions);
@@ -168,6 +201,9 @@ export class BotSkillSyncService {
       if (!fs.existsSync(this.skillsRoot)) fs.mkdirSync(this.skillsRoot, { recursive: true });
       return this.featureUnavailable();
     }
+
+    this.recoverInterruptedFinalizes(cloud);
+    local = this.readLocalManifest();
 
     if (!cloud.definition) {
       if (!this.workspaceExisted && base?.skills.length) {
@@ -219,6 +255,233 @@ export class BotSkillSyncService {
     };
   }
 
+  /**
+   * Completes the second phase of sharing a local Skill. CatsCo has already
+   * bound the public reference to BotDefinition; this method proves that the
+   * published package is downloadable and still matches the selected local
+   * Skill before making local/Base agree with that public reference.
+   */
+  async finalizePublicSkill(
+    input: FinalizePublicBotSkillInput,
+    options: FinalizePublicBotSkillOptions = {},
+  ): Promise<BotSkillSyncResult> {
+    const localSkillId = String(input.localSkillId || '').trim();
+    const skillName = String(input.skillName || '').trim();
+    const reference = input.reference;
+    if (!/^[A-Za-z0-9._:-]{1,160}$/.test(localSkillId)) {
+      throw new Error('A valid local Skill ID is required for public finalization.');
+    }
+    if (
+      reference?.source !== 'skillhub'
+      || !String(reference.skillId || '').trim()
+      || isPrivateSkillReference(reference.skillId)
+      || !String(reference.version || '').trim()
+      || !/^[a-f0-9]{64}$/.test(String(reference.contentHash || ''))
+    ) {
+      throw new Error('A valid public SkillHub reference is required for finalization.');
+    }
+
+    BotSkillSyncService.recoverInterruptedRestore(
+      this.runtimeRoot,
+      this.botId,
+      this.skillsRoot,
+    );
+    const initialCloud = await pullCloudBotSkills(this.cloudOptions);
+    if (!initialCloud) throw new Error('Bot Skill cloud sync is unavailable for public finalization.');
+    this.recoverInterruptedFinalizes(initialCloud);
+    const base = this.baseStore.read(this.botId);
+    const local = this.readLocalManifest();
+    const selected = local.find(entry => (
+      entry.localSkillId === localSkillId && entry.name === skillName
+    ));
+    if (!selected) throw new Error('The selected local Skill no longer exists or changed identity.');
+    if (!initialCloud.definition || !initialCloud.skills.some(item => botSkillRefEqual(item, reference))) {
+      throw new Error('The public Skill reference is not present in the current BotDefinition.');
+    }
+
+    const packageValue = await this.waitForPublicPackage(reference, options);
+    const refreshed = this.readLocalManifest().find(entry => (
+      entry.localSkillId === localSkillId && entry.name === skillName
+    ));
+    if (!refreshed || refreshed.contentHash !== selected.contentHash) {
+      throw new Error('The selected local Skill changed while its public package was being published.');
+    }
+    const nextSkillMarkdown = publishedSkillMarkdown(refreshed, packageValue);
+    await options.validateScope?.();
+    const currentCloud = await pullCloudBotSkills(this.cloudOptions);
+    if (!currentCloud?.definition || !currentCloud.skills.some(item => botSkillRefEqual(item, reference))) {
+      throw new Error('The public Skill reference was removed from BotDefinition during finalization.');
+    }
+    const readyToWrite = this.readLocalManifest().find(entry => (
+      entry.localSkillId === localSkillId && entry.name === skillName
+    ));
+    if (!readyToWrite || readyToWrite.contentHash !== refreshed.contentHash) {
+      throw new Error('The selected local Skill changed before public finalization could be committed.');
+    }
+
+    const skillFile = path.join(readyToWrite.path, 'SKILL.md');
+    const markerFile = path.join(readyToWrite.path, BOT_SKILL_LOCAL_MARKER_FILE);
+    const previousSkill = fs.readFileSync(skillFile, 'utf8');
+    const previousMarker = fs.readFileSync(markerFile, 'utf8');
+    const previousMarkerValue = readBotSkillLocalMarker(readyToWrite.path);
+    const journal: BotSkillFinalizeJournal = {
+      schema: 'xiaoba.bot-skill-finalize-journal.v1',
+      botId: this.botId,
+      skillsRoot: this.skillsRoot,
+      skillPath: readyToWrite.path,
+      localSkillId,
+      skillName,
+      previousContentHash: readyToWrite.contentHash,
+      nextContentHash: reference.contentHash,
+      reference,
+      previousSkill,
+      nextSkill: nextSkillMarkdown,
+      previousMarker,
+    };
+    try {
+      this.writeFinalizeJournal(journal);
+      writeTextFileAtomically(skillFile, nextSkillMarkdown);
+      writeBotSkillLocalMarker(readyToWrite.path, {
+        schema: 'xiaoba.bot-skill-local.v1',
+        localSkillId,
+        reference,
+        origin: previousMarkerValue?.origin ?? readyToWrite.origin ?? {
+          skillId: reference.skillId,
+          version: reference.version,
+        },
+      });
+
+      const updatedLocal = this.readLocalManifest();
+      const updated = updatedLocal.find(entry => entry.localSkillId === localSkillId);
+      if (
+        !updated
+        || updated.contentHash !== reference.contentHash
+        || !updated.reference
+        || !botSkillRefEqual(updated.reference, reference)
+      ) {
+        throw new Error('The local Skill does not match the published SkillHub package.');
+      }
+      await options.validateScope?.();
+      const result = await this.pushLocal(updatedLocal, currentCloud, base, {
+        requiredCloudReference: reference,
+      });
+      try {
+        this.removeFinalizeJournal(localSkillId);
+      } catch {
+        // A committed journal safely rolls forward and will be removed on next sync.
+      }
+      return result;
+    } catch (error) {
+      try {
+        writeTextFileAtomically(skillFile, previousSkill);
+        writeTextFileAtomically(markerFile, previousMarker);
+        this.removeFinalizeJournal(localSkillId);
+      } catch (rollbackError) {
+        throw new Error(
+          `The public Skill failed local verification and rollback failed: ${errorMessage(rollbackError)}`,
+        );
+      }
+      throw error;
+    }
+  }
+
+  private recoverInterruptedFinalizes(cloud: CloudBotSkills): void {
+    const directory = finalizeJournalDirectory(this.runtimeRoot, this.botId);
+    if (!fs.existsSync(directory)) return;
+    const journals = fs.readdirSync(directory, { withFileTypes: true })
+      .filter(entry => entry.isFile() && entry.name.endsWith('.json'))
+      .map(entry => readFinalizeJournal(
+        path.join(directory, entry.name),
+        this.runtimeRoot,
+        this.botId,
+        this.skillsRoot,
+      ));
+    for (const journal of journals) {
+      const current = this.readLocalManifest().find(entry => (
+        entry.localSkillId === journal.localSkillId
+      ));
+      if (!current) {
+        // A deletion after the interruption is a local user decision. Let the
+        // regular Base rules decide whether it propagates or is restored.
+        this.removeFinalizeJournal(journal.localSkillId);
+        continue;
+      }
+      const markerFile = path.join(current.path, BOT_SKILL_LOCAL_MARKER_FILE);
+      const cloudHasReference = cloud.skills.some(item => botSkillRefEqual(item, journal.reference));
+      const identityChanged = current.name !== journal.skillName
+        || path.resolve(current.path) !== journal.skillPath;
+      const writePublicMarker = (): void => {
+        const previousMarker = JSON.parse(journal.previousMarker) as {
+          origin?: { skillId: string; version: string };
+        };
+        writeBotSkillLocalMarker(current.path, {
+          schema: 'xiaoba.bot-skill-local.v1',
+          localSkillId: journal.localSkillId,
+          reference: journal.reference,
+          origin: previousMarker.origin ?? current.origin ?? {
+            skillId: journal.reference.skillId,
+            version: journal.reference.version,
+          },
+        });
+      };
+      if (identityChanged) {
+        // A rename or move after the interruption wins over the pending finalize.
+        writeTextFileAtomically(markerFile, journal.previousMarker);
+      } else if (current.contentHash === journal.nextContentHash && cloudHasReference) {
+        writePublicMarker();
+      } else if (current.contentHash === journal.previousContentHash) {
+        if (cloudHasReference) {
+          writeTextFileAtomically(path.join(current.path, 'SKILL.md'), journal.nextSkill);
+          const rolledForward = this.readLocalManifest().find(entry => (
+            entry.localSkillId === journal.localSkillId && entry.name === journal.skillName
+          ));
+          if (!rolledForward || rolledForward.contentHash !== journal.nextContentHash) {
+            writeTextFileAtomically(path.join(current.path, 'SKILL.md'), journal.previousSkill);
+            writeTextFileAtomically(markerFile, journal.previousMarker);
+            this.removeFinalizeJournal(journal.localSkillId);
+            throw new Error('Interrupted public Skill finalization could not be rolled forward safely.');
+          }
+          writePublicMarker();
+        } else {
+          writeTextFileAtomically(markerFile, journal.previousMarker);
+        }
+      } else if (current.contentHash === journal.nextContentHash) {
+        writeTextFileAtomically(path.join(current.path, 'SKILL.md'), journal.previousSkill);
+        writeTextFileAtomically(markerFile, journal.previousMarker);
+        const rolledBack = this.readLocalManifest().find(entry => (
+          entry.localSkillId === journal.localSkillId && entry.name === journal.skillName
+        ));
+        if (!rolledBack || rolledBack.contentHash !== journal.previousContentHash) {
+          throw new Error('Interrupted public Skill finalization could not be rolled back safely.');
+        }
+      } else {
+        // A user edit after the interruption wins. Restore only the internal marker
+        // so the edited workspace is uploaded as a new private snapshot normally.
+        writeTextFileAtomically(markerFile, journal.previousMarker);
+      }
+      this.removeFinalizeJournal(journal.localSkillId);
+    }
+  }
+
+  private writeFinalizeJournal(journal: BotSkillFinalizeJournal): void {
+    const filePath = finalizeJournalPath(this.runtimeRoot, this.botId, journal.localSkillId);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    writeTextFileAtomically(filePath, `${JSON.stringify(journal, null, 2)}\n`);
+  }
+
+  private removeFinalizeJournal(localSkillId: string): void {
+    const filePath = finalizeJournalPath(this.runtimeRoot, this.botId, localSkillId);
+    fs.rmSync(filePath, { force: true });
+    const directory = path.dirname(filePath);
+    try {
+      if (fs.existsSync(directory) && fs.readdirSync(directory).length === 0) {
+        fs.rmdirSync(directory);
+      }
+    } catch {
+      // An empty journal directory is harmless, and another finalization may use it.
+    }
+  }
+
   private featureUnavailable(): BotSkillSyncResult {
     return {
       botId: this.botId,
@@ -241,21 +504,40 @@ export class BotSkillSyncService {
     local: LocalBotSkillManifestEntry[],
     initialCloud: CloudBotSkills,
     base: BotSkillSyncBase | undefined,
+    options: { requiredCloudReference?: BotSkillRef } = {},
   ): Promise<BotSkillSyncResult> {
+    if (
+      options.requiredCloudReference
+      && !initialCloud.skills.some(item => botSkillRefEqual(item, options.requiredCloudReference!))
+    ) {
+      throw new Error('The public Skill reference is no longer present in BotDefinition.');
+    }
     const previousByLocalID = new Map(base?.skills.map(entry => [entry.localSkillId, entry]) ?? []);
     const nextEntries: BotSkillSyncBaseEntry[] = [];
+    const pendingMarkers: Array<{
+      path: string;
+      marker: Parameters<typeof writeBotSkillLocalMarker>[1];
+    }> = [];
     for (const entry of local) {
       const previous = previousByLocalID.get(entry.localSkillId);
       let reference: BotSkillRef | undefined;
-      if (previous?.contentHash === entry.contentHash) {
-        reference = previous.reference;
-      } else if (entry.reference) {
+      const markerChanged = Boolean(
+        entry.reference
+        && (!previous || !botSkillRefEqual(entry.reference, previous.reference)),
+      );
+      if (entry.reference && markerChanged) {
         try {
           const existing = await this.privateClient.download(entry.reference);
           if (existing.contentHash === entry.contentHash) reference = entry.reference;
         } catch (error: any) {
           if (![400, 404].includes(Number(error?.status))) throw error;
+          if (!isPrivateSkillReference(entry.reference.skillId)) throw error;
         }
+      }
+      if (!reference && previous?.contentHash === entry.contentHash) {
+        reference = previous.reference;
+      } else if (!reference && entry.reference && !markerChanged) {
+        reference = entry.reference;
       }
       if (!reference) {
         const uploaded = await this.privateClient.upsert(entry);
@@ -269,13 +551,16 @@ export class BotSkillSyncService {
         };
       }
       const marker = readBotSkillLocalMarker(entry.path);
-      writeBotSkillLocalMarker(entry.path, {
-        schema: 'xiaoba.bot-skill-local.v1',
-        localSkillId: entry.localSkillId,
-        reference,
-        origin: marker?.origin ?? entry.origin ?? {
-          skillId: reference.skillId,
-          version: reference.version,
+      pendingMarkers.push({
+        path: entry.path,
+        marker: {
+          schema: 'xiaoba.bot-skill-local.v1',
+          localSkillId: entry.localSkillId,
+          reference,
+          origin: marker?.origin ?? entry.origin ?? {
+            skillId: reference.skillId,
+            version: reference.version,
+          },
         },
       });
       nextEntries.push({
@@ -301,11 +586,20 @@ export class BotSkillSyncService {
       if (!(error instanceof BotSkillsCloudConflictError)) throw error;
       const latest = await pullCloudBotSkills(this.cloudOptions);
       if (!latest) throw error;
+      if (
+        options.requiredCloudReference
+        && !latest.skills.some(item => botSkillRefEqual(item, options.requiredCloudReference!))
+      ) {
+        throw new Error('The public Skill reference was removed from BotDefinition during finalization.');
+      }
       if (!base || !botSkillRefsEqual(latest.skills, base.skills.map(entry => entry.reference))) {
         this.writeConflictSnapshot(latest, refs);
       }
       // The current single-device contract explicitly protects local changes.
       cloud = await replaceCloudBotSkills(this.cloudOptions, latest, refs);
+    }
+    for (const item of pendingMarkers) {
+      writeBotSkillLocalMarker(item.path, item.marker);
     }
     this.acceptCloudDefinition(cloud);
     this.writeBase(cloud, nextEntries);
@@ -315,6 +609,49 @@ export class BotSkillSyncService {
       cloudRevision: cloud.revision,
       skills: cloud.skills,
     };
+  }
+
+  private async waitForPublicPackage(
+    reference: BotSkillRef,
+    options: FinalizePublicBotSkillOptions,
+  ): Promise<BotSkillPackage> {
+    const publicationWaitMs = Math.max(0, Math.min(
+      Number(options.publicationWaitMs ?? 45_000),
+      120_000,
+    ));
+    const pollDelayMs = Math.max(25, Math.min(Number(options.pollDelayMs ?? 500), 5_000));
+    const sleep = options.sleep ?? (delayMs => new Promise(resolve => setTimeout(resolve, delayMs)));
+    const deadline = Date.now() + publicationWaitMs;
+    let lastError: unknown;
+    let firstAttempt = true;
+    while (true) {
+      await options.validateScope?.();
+      const remainingMs = deadline - Date.now();
+      if (!firstAttempt && remainingMs <= 0) break;
+      firstAttempt = false;
+      try {
+        const packageValue = await this.privateClient.download(reference, {
+          timeoutMs: Math.max(1, Math.min(10_000, remainingMs > 0 ? remainingMs : 1)),
+        });
+        if (
+          packageValue.source !== 'public'
+          || packageValue.contentHash !== reference.contentHash
+        ) {
+          throw new Error('SkillHub returned a package that does not match the public reference.');
+        }
+        return packageValue;
+      } catch (error: any) {
+        lastError = error;
+        if (Number(error?.status) !== 404) throw error;
+        if (Date.now() >= deadline) break;
+      }
+      await sleep(Math.min(pollDelayMs, Math.max(0, deadline - Date.now())));
+    }
+    const error = new Error('The public Skill package is not ready yet. Please retry finalization.');
+    (error as Error & { code?: string; status?: number; cause?: unknown }).code = 'PUBLIC_SKILL_NOT_READY';
+    (error as Error & { code?: string; status?: number; cause?: unknown }).status = 409;
+    (error as Error & { code?: string; status?: number; cause?: unknown }).cause = lastError;
+    throw error;
   }
 
   private async restoreCloud(cloud: CloudBotSkills): Promise<BotSkillSyncResult> {
@@ -508,6 +845,72 @@ export class BotSkillSyncService {
   }
 }
 
+function publishedSkillMarkdown(
+  local: LocalBotSkillManifestEntry,
+  packageValue: BotSkillPackage,
+): string {
+  const publishedSkillFile = packageValue.files.find(file => file.path === 'SKILL.md');
+  const localSkillFile = local.files.find(file => file.path === 'SKILL.md');
+  if (!publishedSkillFile || !localSkillFile) {
+    throw new Error('The public or local Skill package is missing SKILL.md.');
+  }
+  const publishedMarkdown = Buffer.from(publishedSkillFile.contentBase64, 'base64').toString('utf8');
+  const metadata = matter(publishedMarkdown).data;
+  const author = String(metadata?.skillhub_author || '').trim();
+  const version = String(metadata?.skillhub_version || '').trim();
+  const uploadedAt = String(metadata?.skillhub_uploaded_at || '').trim();
+  if (!author || !version || !uploadedAt) {
+    throw new Error('The public Skill package is missing SkillHub publication metadata.');
+  }
+
+  const localMarkdown = Buffer.from(localSkillFile.contentBase64, 'base64').toString('utf8');
+  const nextMarkdown = applySkillHubLocalMetadata(localMarkdown, {
+    author,
+    version,
+    uploadedAt,
+  });
+  const nextBytes = Buffer.from(nextMarkdown.replace(/\r\n/g, '\n'), 'utf8');
+  const candidateFiles: BotSkillPackageFile[] = local.files.map(file => {
+    if (file.path !== 'SKILL.md') return file;
+    return {
+      path: file.path,
+      size: nextBytes.length,
+      sha256: crypto.createHash('sha256').update(nextBytes).digest('hex'),
+      contentBase64: nextBytes.toString('base64'),
+    };
+  });
+  const expected = [...packageValue.files].sort(comparePackageFiles);
+  const candidate = [...candidateFiles].sort(comparePackageFiles);
+  if (
+    candidate.length !== expected.length
+    || candidate.some((file, index) => (
+      file.path !== expected[index]?.path
+      || file.size !== expected[index]?.size
+      || file.sha256 !== expected[index]?.sha256
+    ))
+    || computeBotSkillPackageHash(candidate) !== packageValue.contentHash
+  ) {
+    throw new Error('The selected local Skill changed after it was shared.');
+  }
+  return nextBytes.toString('utf8');
+}
+
+function botSkillRefEqual(left: BotSkillRef, right: BotSkillRef): boolean {
+  return left.source === right.source
+    && left.skillId === right.skillId
+    && left.version === right.version
+    && left.contentHash === right.contentHash;
+}
+
+function isPrivateSkillReference(skillId: string): boolean {
+  const value = String(skillId || '');
+  return value.startsWith('priv_') || value.startsWith('private/');
+}
+
+function comparePackageFiles(left: BotSkillPackageFile, right: BotSkillPackageFile): number {
+  return left.path < right.path ? -1 : left.path > right.path ? 1 : 0;
+}
+
 function localMatchesBase(
   local: LocalBotSkillManifestEntry[],
   base: BotSkillSyncBase,
@@ -523,6 +926,101 @@ function localMatchesBase(
       && previous.installName === entry.installName
     );
   });
+}
+
+function finalizeJournalDirectory(runtimeRoot: string, botId: string): string {
+  return path.join(
+    path.resolve(runtimeRoot),
+    'data',
+    'bot-skills',
+    'finalize-journal',
+    String(botId).trim(),
+  );
+}
+
+function finalizeJournalPath(runtimeRoot: string, botId: string, localSkillId: string): string {
+  return path.join(
+    finalizeJournalDirectory(runtimeRoot, botId),
+    `${String(localSkillId).trim()}.json`,
+  );
+}
+
+function readFinalizeJournal(
+  filePath: string,
+  runtimeRoot: string,
+  botId: string,
+  skillsRoot: string,
+): BotSkillFinalizeJournal {
+  let value: BotSkillFinalizeJournal;
+  try {
+    value = JSON.parse(fs.readFileSync(filePath, 'utf8')) as BotSkillFinalizeJournal;
+  } catch {
+    throw new Error('Bot Skill finalize journal cannot be read safely');
+  }
+  const expectedRoot = path.resolve(skillsRoot);
+  const skillPath = path.resolve(String(value.skillPath || ''));
+  const relativeSkillPath = path.relative(expectedRoot, skillPath);
+  let previousMarker: any;
+  try {
+    previousMarker = JSON.parse(String(value.previousMarker || ''));
+  } catch {
+    throw new Error('Bot Skill finalize journal contains an invalid previous marker');
+  }
+  if (
+    value.schema !== 'xiaoba.bot-skill-finalize-journal.v1'
+    || value.botId !== String(botId).trim()
+    || path.resolve(value.skillsRoot || '') !== expectedRoot
+    || !/^[A-Za-z0-9._:-]{1,160}$/.test(String(value.localSkillId || ''))
+    || String(value.skillName || '').trim().length === 0
+    || String(value.skillName || '').length > 256
+    || relativeSkillPath === ''
+    || relativeSkillPath.startsWith(`..${path.sep}`)
+    || relativeSkillPath === '..'
+    || path.isAbsolute(relativeSkillPath)
+    || !/^[a-f0-9]{64}$/.test(String(value.previousContentHash || ''))
+    || !/^[a-f0-9]{64}$/.test(String(value.nextContentHash || ''))
+    || !validFinalizeReference(value.reference)
+    || typeof value.previousSkill !== 'string'
+    || value.previousSkill.length > 2 * 1024 * 1024
+    || typeof value.nextSkill !== 'string'
+    || value.nextSkill.length > 2 * 1024 * 1024
+    || typeof value.previousMarker !== 'string'
+    || value.previousMarker.length > 64 * 1024
+    || previousMarker?.schema !== 'xiaoba.bot-skill-local.v1'
+    || previousMarker?.localSkillId !== value.localSkillId
+    || path.resolve(filePath) !== finalizeJournalPath(runtimeRoot, botId, value.localSkillId)
+  ) {
+    throw new Error('Bot Skill finalize journal is invalid');
+  }
+  return {
+    ...value,
+    skillsRoot: expectedRoot,
+    skillPath,
+  };
+}
+
+function validFinalizeReference(reference: BotSkillRef | undefined): reference is BotSkillRef {
+  return Boolean(
+    reference
+    && reference.source === 'skillhub'
+    && String(reference.skillId || '').length > 0
+    && String(reference.skillId || '').length <= 256
+    && !isPrivateSkillReference(reference.skillId)
+    && String(reference.version || '').length > 0
+    && String(reference.version || '').length <= 128
+    && /^[a-f0-9]{64}$/.test(String(reference.contentHash || '')),
+  );
+}
+
+function writeTextFileAtomically(filePath: string, content: string): void {
+  const temporary = `${filePath}.${process.pid}.${Date.now()}.${crypto.randomBytes(4).toString('hex')}.tmp`;
+  try {
+    fs.writeFileSync(temporary, content, 'utf8');
+    fs.renameSync(temporary, filePath);
+  } catch (error) {
+    fs.rmSync(temporary, { force: true });
+    throw error;
+  }
 }
 
 function restoreJournalPath(runtimeRoot: string, botId: string): string {

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -486,7 +486,9 @@ export class CatsCompanyBot {
       capabilities: [...CATSCOMPANY_FULL_RUNTIME_DEVICE_CAPABILITIES],
     });
     this.deviceRegistration = deviceRegistration;
-    this.skillHubThinRpc = new SkillHubThinRpcHandler();
+    this.skillHubThinRpc = new SkillHubThinRpcHandler({
+      isShuttingDown: () => this.shuttingDown,
+    });
 
     const runtime = createCatsCompanyRuntime(config.sessionTTL);
     this.runtime = runtime;
@@ -742,7 +744,7 @@ export class CatsCompanyBot {
     if (!requestID) return;
     Logger.info(`[CatsCompany][thin_tool_rpc] target received request: request=${requestID}, tool=${request.tool_name || ''}, targetOwner=${request.target_owner_user_id || ''}, targetDevice=${request.target_device_id || ''}, device=${request.device_id || ''}`);
 
-    if (this.skillHubThinRpc?.supports(String(request.tool_name || ''))) {
+    if (this.skillHubThinRpc.supports(String(request.tool_name || ''))) {
       await this.handleSkillHubThinToolRpcRequest(request);
       return;
     }

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -742,7 +742,7 @@ export class CatsCompanyBot {
     if (!requestID) return;
     Logger.info(`[CatsCompany][thin_tool_rpc] target received request: request=${requestID}, tool=${request.tool_name || ''}, targetOwner=${request.target_owner_user_id || ''}, targetDevice=${request.target_device_id || ''}, device=${request.device_id || ''}`);
 
-    if (this.skillHubThinRpc.supports(String(request.tool_name || ''))) {
+    if (this.skillHubThinRpc?.supports(String(request.tool_name || ''))) {
       await this.handleSkillHubThinToolRpcRequest(request);
       return;
     }
@@ -800,6 +800,10 @@ export class CatsCompanyBot {
         code: caught instanceof SkillHubThinRpcError ? caught.code : 'SKILLHUB_OPERATION_FAILED',
         message: caught?.message || 'SkillHub device operation failed.',
       };
+    }
+    if (this.shuttingDown) {
+      Logger.info(`[CatsCompany][thin_tool_rpc] destroy started, dropping SkillHub RPC result: request=${request.request_id}`);
+      return;
     }
     try {
       await this.bot.sendThinToolRpcResult({

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -72,6 +72,11 @@ import {
   CatsCompanyCloudSessionRestorer,
   type CloudSessionRestoreResult,
 } from './cloud-session-restore';
+import {
+  SkillHubThinRpcError,
+  SkillHubThinRpcHandler,
+  SKILLHUB_THIN_RPC_TOOLS,
+} from './skillhub-rpc';
 
 interface PendingAttachment {
   fileName: string;
@@ -173,6 +178,10 @@ export const CATSCOMPANY_FULL_RUNTIME_DEVICE_CAPABILITIES: DeviceGrantOperation[
   'edit_file',
   'send_file',
   'execute_shell',
+  SKILLHUB_THIN_RPC_TOOLS.workspace,
+  SKILLHUB_THIN_RPC_TOOLS.share,
+  SKILLHUB_THIN_RPC_TOOLS.finalize,
+  SKILLHUB_THIN_RPC_TOOLS.switchBot,
 ];
 
 function currentRuntimeOS(): 'windows' | 'macos' | 'linux' | 'unknown' {
@@ -441,6 +450,7 @@ export class CatsCompanyBot {
     capabilities: string[];
     model_status?: ReturnType<typeof resolveCatsDeviceModelStatus>;
   };
+  private readonly skillHubThinRpc: SkillHubThinRpcHandler;
 
   constructor(config: CatsCompanyConfig) {
     this.botUid = String(config.botUid || '').trim() || null;
@@ -476,6 +486,7 @@ export class CatsCompanyBot {
       capabilities: [...CATSCOMPANY_FULL_RUNTIME_DEVICE_CAPABILITIES],
     });
     this.deviceRegistration = deviceRegistration;
+    this.skillHubThinRpc = new SkillHubThinRpcHandler();
 
     const runtime = createCatsCompanyRuntime(config.sessionTTL);
     this.runtime = runtime;
@@ -731,6 +742,11 @@ export class CatsCompanyBot {
     if (!requestID) return;
     Logger.info(`[CatsCompany][thin_tool_rpc] target received request: request=${requestID}, tool=${request.tool_name || ''}, targetOwner=${request.target_owner_user_id || ''}, targetDevice=${request.target_device_id || ''}, device=${request.device_id || ''}`);
 
+    if (this.skillHubThinRpc.supports(String(request.tool_name || ''))) {
+      await this.handleSkillHubThinToolRpcRequest(request);
+      return;
+    }
+
     let result: ToolExecutionResult;
     try {
       result = await this.executeLocalThinToolRpcTool(request);
@@ -771,6 +787,32 @@ export class CatsCompanyBot {
       Logger.info(`[CatsCompany][thin_tool_rpc] target sent result: request=${requestID}, tool=${request.tool_name || ''}, ok=${result.ok}`);
     } catch (err: any) {
       Logger.warning(`[CatsCompany] Thin Tool RPC result send failed: request=${requestID}, error=${err?.message || err}`);
+    }
+  }
+
+  private async handleSkillHubThinToolRpcRequest(request: CatsThinToolRpcMessage): Promise<void> {
+    let result: Record<string, unknown> | undefined;
+    let error: { code: string; message: string } | undefined;
+    try {
+      result = await this.skillHubThinRpc.execute(request);
+    } catch (caught: any) {
+      error = {
+        code: caught instanceof SkillHubThinRpcError ? caught.code : 'SKILLHUB_OPERATION_FAILED',
+        message: caught?.message || 'SkillHub device operation failed.',
+      };
+    }
+    try {
+      await this.bot.sendThinToolRpcResult({
+        request_id: request.request_id,
+        target_owner_user_id: request.target_owner_user_id,
+        target_device_id: request.target_device_id,
+        device_id: this.localDeviceGrant?.deviceId || request.device_id || request.target_device_id,
+        tool_name: request.tool_name,
+        result: error ? undefined : result,
+        error,
+      });
+    } catch (caught: any) {
+      Logger.warning(`[CatsCompany] SkillHub Thin Tool RPC result send failed: request=${request.request_id}, error=${caught?.message || caught}`);
     }
   }
 

--- a/src/catscompany/skillhub-rpc.ts
+++ b/src/catscompany/skillhub-rpc.ts
@@ -39,12 +39,14 @@ export interface SkillHubThinRpcHandlerOptions {
   runtimeRoot?: string;
   scheduleBotSwitch?: (botUid: string) => void;
   finalizeCurrentBotSkill?: typeof finalizeCurrentBotPublicSkillNow;
+  isShuttingDown?: () => boolean;
 }
 
 export class SkillHubThinRpcHandler {
   private readonly runtimeRoot: string;
   private readonly scheduleBotSwitch: (botUid: string) => void;
   private readonly finalizeCurrentBotSkill: typeof finalizeCurrentBotPublicSkillNow;
+  private readonly isShuttingDown: () => boolean;
   private readonly completed = new Map<string, {
     fingerprint: string;
     operation: Promise<Record<string, unknown>>;
@@ -52,7 +54,9 @@ export class SkillHubThinRpcHandler {
 
   constructor(options: SkillHubThinRpcHandlerOptions = {}) {
     this.runtimeRoot = path.resolve(options.runtimeRoot ?? PathResolver.getRuntimeDataRoot());
-    this.scheduleBotSwitch = options.scheduleBotSwitch ?? scheduleDashboardBotSwitch;
+    this.isShuttingDown = options.isShuttingDown ?? (() => false);
+    this.scheduleBotSwitch = options.scheduleBotSwitch
+      ?? ((botUid) => scheduleDashboardBotSwitch(botUid, this.isShuttingDown));
     this.finalizeCurrentBotSkill = options.finalizeCurrentBotSkill
       ?? finalizeCurrentBotPublicSkillNow;
   }
@@ -62,7 +66,7 @@ export class SkillHubThinRpcHandler {
   }
 
   async execute(request: CatsThinToolRpcMessage): Promise<Record<string, unknown>> {
-    this.assertFreshRequest(request);
+    this.assertOperational(request);
     const requestID = String(request.request_id || '').trim();
     if (!requestID) throw new SkillHubThinRpcError('INVALID_REQUEST', 'request_id is required.');
     const fingerprint = requestFingerprint(request);
@@ -95,7 +99,7 @@ export class SkillHubThinRpcHandler {
   }
 
   private async executeOnce(request: CatsThinToolRpcMessage): Promise<Record<string, unknown>> {
-    this.assertFreshRequest(request);
+    this.assertOperational(request);
     const payload = recordValue(request.payload);
     const botUid = requiredText(payload.bot_uid, 'bot_uid', 160);
     if (!BOT_UID_PATTERN.test(botUid)) {
@@ -129,7 +133,7 @@ export class SkillHubThinRpcHandler {
     request: CatsThinToolRpcMessage,
   ): Promise<Record<string, unknown>> {
     return withCurrentBotSkillWorkspaceWrite((context) => {
-      this.assertFreshRequest(request);
+      this.assertOperational(request);
       this.assertRequestScope(request, botUid, true);
       this.assertActiveWorkspace(botUid, context.botId, context.activeBotId);
       const entries = scanBotSkillWorkspace(context.skillsRoot).slice(0, MAX_SKILLS);
@@ -200,7 +204,7 @@ export class SkillHubThinRpcHandler {
         };
       },
       validateScope: (context) => {
-        this.assertFreshRequest(request);
+        this.assertOperational(request);
         this.assertRequestScope(request, botUid, true);
         this.assertActiveWorkspace(botUid, context.botId, context.activeBotId);
       },
@@ -254,7 +258,7 @@ export class SkillHubThinRpcHandler {
           Math.min(45_000, Number(request.expires_at || 0) - Date.now() - 1_000),
         ),
         validateScope: () => {
-          this.assertFreshRequest(request);
+          this.assertOperational(request);
           this.assertRequestScope(request, botUid, true);
         },
       });
@@ -292,6 +296,16 @@ export class SkillHubThinRpcHandler {
     };
   }
 
+  private assertOperational(request: CatsThinToolRpcMessage): void {
+    if (this.isShuttingDown()) {
+      throw new SkillHubThinRpcError(
+        'SHUTTING_DOWN',
+        'The XiaoBa device is shutting down. Retry the SkillHub operation after it reconnects.',
+      );
+    }
+    this.assertFreshRequest(request);
+  }
+
   private assertFreshRequest(request: CatsThinToolRpcMessage): void {
     const expiresAt = Number(request.expires_at || 0);
     if (!Number.isFinite(expiresAt) || expiresAt <= Date.now()) {
@@ -327,8 +341,12 @@ export class SkillHubThinRpcHandler {
   }
 }
 
-export function scheduleDashboardBotSwitch(botUid: string): void {
+export function scheduleDashboardBotSwitch(
+  botUid: string,
+  isShuttingDown: () => boolean = () => false,
+): void {
   const timer = setTimeout(() => {
+    if (isShuttingDown()) return;
     void requestDashboardBotSwitch(botUid).catch((error) => {
       Logger.warning(`SkillHub remote Bot switch failed: ${error?.message || String(error)}`);
     });

--- a/src/catscompany/skillhub-rpc.ts
+++ b/src/catscompany/skillhub-rpc.ts
@@ -1,0 +1,408 @@
+import matter from 'gray-matter';
+import * as fs from 'fs';
+import * as path from 'path';
+import { createCatsCoLocalConfigService } from './local-config';
+import type { CatsThinToolRpcMessage } from './client';
+import {
+  finalizeCurrentBotPublicSkillNow,
+  withCurrentBotSkillWorkspaceWrite,
+} from '../bot-skills/runtime';
+import { scanBotSkillWorkspace } from '../bot-skills/local-manifest';
+import { readSkillHubLocalMetadata } from '../skillhub/local-skill-metadata';
+import { shareLocalSkillForCatsCo } from '../skillhub/local-share';
+import { PathResolver } from '../utils/path-resolver';
+import { Logger } from '../utils/logger';
+
+export const SKILLHUB_THIN_RPC_TOOLS = {
+  workspace: 'skillhub.localWorkspace.get',
+  share: 'skillhub.localSkill.share',
+  finalize: 'skillhub.localSkill.finalize',
+  switchBot: 'skillhub.localBot.switch',
+} as const;
+
+const MAX_SKILLS = 200;
+const MAX_NAME_LENGTH = 160;
+const MAX_DESCRIPTION_LENGTH = 1_000;
+const MAX_RELATIVE_PATH_LENGTH = 500;
+const MAX_COMPLETED_REQUESTS = 256;
+const BOT_UID_PATTERN = /^[A-Za-z0-9_.-]{1,160}$/;
+const CONTENT_HASH_PATTERN = /^[0-9a-f]{64}$/;
+
+export class SkillHubThinRpcError extends Error {
+  constructor(public readonly code: string, message: string) {
+    super(message);
+    this.name = 'SkillHubThinRpcError';
+  }
+}
+
+export interface SkillHubThinRpcHandlerOptions {
+  runtimeRoot?: string;
+  scheduleBotSwitch?: (botUid: string) => void;
+  finalizeCurrentBotSkill?: typeof finalizeCurrentBotPublicSkillNow;
+}
+
+export class SkillHubThinRpcHandler {
+  private readonly runtimeRoot: string;
+  private readonly scheduleBotSwitch: (botUid: string) => void;
+  private readonly finalizeCurrentBotSkill: typeof finalizeCurrentBotPublicSkillNow;
+  private readonly completed = new Map<string, {
+    fingerprint: string;
+    operation: Promise<Record<string, unknown>>;
+  }>();
+
+  constructor(options: SkillHubThinRpcHandlerOptions = {}) {
+    this.runtimeRoot = path.resolve(options.runtimeRoot ?? PathResolver.getRuntimeDataRoot());
+    this.scheduleBotSwitch = options.scheduleBotSwitch ?? scheduleDashboardBotSwitch;
+    this.finalizeCurrentBotSkill = options.finalizeCurrentBotSkill
+      ?? finalizeCurrentBotPublicSkillNow;
+  }
+
+  supports(toolName: string): boolean {
+    return Object.values(SKILLHUB_THIN_RPC_TOOLS).includes(toolName as any);
+  }
+
+  async execute(request: CatsThinToolRpcMessage): Promise<Record<string, unknown>> {
+    this.assertFreshRequest(request);
+    const requestID = String(request.request_id || '').trim();
+    if (!requestID) throw new SkillHubThinRpcError('INVALID_REQUEST', 'request_id is required.');
+    const fingerprint = requestFingerprint(request);
+    const existing = this.completed.get(requestID);
+    if (existing) {
+      if (existing.fingerprint !== fingerprint) {
+        throw new SkillHubThinRpcError(
+          'REQUEST_ID_CONFLICT',
+          'request_id was already used for a different SkillHub operation.',
+        );
+      }
+      const payload = recordValue(request.payload);
+      const botUid = requiredText(payload.bot_uid, 'bot_uid', 160);
+      if (!BOT_UID_PATTERN.test(botUid)) {
+        throw new SkillHubThinRpcError('INVALID_BOT_UID', 'bot_uid is invalid.');
+      }
+      this.assertRequestScope(
+        request,
+        botUid,
+        request.tool_name !== SKILLHUB_THIN_RPC_TOOLS.switchBot,
+      );
+      return existing.operation;
+    }
+    const operation = this.executeOnce(request);
+    this.completed.set(requestID, { fingerprint, operation });
+    while (this.completed.size > MAX_COMPLETED_REQUESTS) {
+      this.completed.delete(this.completed.keys().next().value as string);
+    }
+    return operation;
+  }
+
+  private async executeOnce(request: CatsThinToolRpcMessage): Promise<Record<string, unknown>> {
+    this.assertFreshRequest(request);
+    const payload = recordValue(request.payload);
+    const botUid = requiredText(payload.bot_uid, 'bot_uid', 160);
+    if (!BOT_UID_PATTERN.test(botUid)) {
+      throw new SkillHubThinRpcError('INVALID_BOT_UID', 'bot_uid is invalid.');
+    }
+    const scope = this.assertRequestScope(request, botUid, request.tool_name !== SKILLHUB_THIN_RPC_TOOLS.switchBot);
+
+    if (request.tool_name === SKILLHUB_THIN_RPC_TOOLS.switchBot) {
+      this.scheduleBotSwitch(botUid);
+      return {
+        schema: 'xiaoba.skillhub.bot_switch.v1',
+        bot_uid: botUid,
+        switching: true,
+      };
+    }
+
+    switch (request.tool_name) {
+      case SKILLHUB_THIN_RPC_TOOLS.workspace:
+        return this.readWorkspace(botUid, request);
+      case SKILLHUB_THIN_RPC_TOOLS.share:
+        return this.shareSkill(botUid, scope.ownerUid, payload, request);
+      case SKILLHUB_THIN_RPC_TOOLS.finalize:
+        return this.finalizeSkill(botUid, payload, request);
+      default:
+        throw new SkillHubThinRpcError('TOOL_NOT_FOUND', 'Unsupported SkillHub device operation.');
+    }
+  }
+
+  private async readWorkspace(
+    botUid: string,
+    request: CatsThinToolRpcMessage,
+  ): Promise<Record<string, unknown>> {
+    return withCurrentBotSkillWorkspaceWrite((context) => {
+      this.assertFreshRequest(request);
+      this.assertRequestScope(request, botUid, true);
+      this.assertActiveWorkspace(botUid, context.botId, context.activeBotId);
+      const entries = scanBotSkillWorkspace(context.skillsRoot).slice(0, MAX_SKILLS);
+      const skills = entries.map((entry) => {
+        const parsed = matter(fs.readFileSync(path.join(entry.path, 'SKILL.md'), 'utf8'));
+        const metadata = readSkillHubLocalMetadata(path.join(entry.path, 'SKILL.md'));
+        return {
+          local_skill_id: limitText(entry.localSkillId, MAX_NAME_LENGTH),
+          name: limitText(entry.name, MAX_NAME_LENGTH),
+          description: limitText(String(parsed.data?.description || ''), MAX_DESCRIPTION_LENGTH),
+          relative_path: limitText(entry.installName, MAX_RELATIVE_PATH_LENGTH),
+          source: 'user',
+          can_share: !entry.reference || isPrivateSkillReference(entry.reference.skillId),
+          skill_hub: {
+            ...(metadata || {}),
+            ...(entry.reference ? { reference: entry.reference } : {}),
+          },
+        };
+      });
+      return {
+        schema: 'xiaoba.skillhub.local_workspace.v1',
+        bot_uid: botUid,
+        active_bot_uid: context.activeBotId,
+        skills_path: fs.realpathSync(context.skillsRoot),
+        skills,
+      };
+    }, { runtimeRoot: this.runtimeRoot });
+  }
+
+  private async shareSkill(
+    botUid: string,
+    ownerUid: string,
+    payload: Record<string, unknown>,
+    request: CatsThinToolRpcMessage,
+  ): Promise<Record<string, unknown>> {
+    const localSkillId = requiredText(payload.local_skill_id, 'local_skill_id', MAX_NAME_LENGTH);
+    const skillName = requiredText(payload.skill_name, 'skill_name', MAX_NAME_LENGTH);
+    await withCurrentBotSkillWorkspaceWrite((context) => {
+      this.assertActiveWorkspace(botUid, context.botId, context.activeBotId);
+      const entry = scanBotSkillWorkspace(context.skillsRoot).find((candidate) => (
+        candidate.localSkillId === localSkillId && candidate.name === skillName
+      ));
+      if (!entry) {
+        throw new SkillHubThinRpcError('LOCAL_SKILL_NOT_FOUND', 'The selected local Skill no longer exists.');
+      }
+    }, { runtimeRoot: this.runtimeRoot });
+
+    const configService = createCatsCoLocalConfigService({ runtimeRoot: this.runtimeRoot });
+    const result = await shareLocalSkillForCatsCo({
+      skillName,
+      expectedLocalSkillId: localSkillId,
+      expectedBotUid: botUid,
+      expectedUserUid: ownerUid,
+      confirmVersionPublish: payload.confirm_publish === true,
+    }, {
+      writeLocalMetadata: false,
+      runtimeRoot: this.runtimeRoot,
+      getCatsCoAuth: () => {
+        const auth = configService.getAuthState();
+        return {
+          token: String(auth.token || ''),
+          baseUrl: auth.httpBaseUrl,
+          user: {
+            uid: auth.uid,
+            username: auth.username,
+            displayName: auth.displayName,
+          },
+        };
+      },
+      validateScope: (context) => {
+        this.assertFreshRequest(request);
+        this.assertRequestScope(request, botUid, true);
+        this.assertActiveWorkspace(botUid, context.botId, context.activeBotId);
+      },
+    });
+    return {
+      schema: 'xiaoba.skillhub.local_share.v1',
+      bot_uid: botUid,
+      skill: {
+        id: String(result?.skill?.id || ''),
+        name: skillName,
+      },
+      latest_version: String(result?.latestVersion || ''),
+      content_hash: String(result?.contentHash || '').toLowerCase(),
+      skill_hub: result?.skillHub ? {
+        author: String(result.skillHub.author || ''),
+        version: String(result.skillHub.version || ''),
+        uploaded_at: String(result.skillHub.uploadedAt || ''),
+      } : {},
+      requires_confirmation: Boolean(result?.requiresConfirmation),
+    };
+  }
+
+  private async finalizeSkill(
+    botUid: string,
+    payload: Record<string, unknown>,
+    request: CatsThinToolRpcMessage,
+  ): Promise<Record<string, unknown>> {
+    const localSkillId = requiredText(payload.local_skill_id, 'local_skill_id', MAX_NAME_LENGTH);
+    const skillName = requiredText(payload.skill_name, 'skill_name', MAX_NAME_LENGTH);
+    const skillId = requiredText(payload.skill_id, 'skill_id', MAX_RELATIVE_PATH_LENGTH);
+    const version = requiredText(payload.version, 'version', MAX_NAME_LENGTH);
+    const contentHash = requiredText(payload.content_hash, 'content_hash', 64).toLowerCase();
+    if (!CONTENT_HASH_PATTERN.test(contentHash)) {
+      throw new SkillHubThinRpcError('INVALID_CONTENT_HASH', 'content_hash is invalid.');
+    }
+    let result;
+    try {
+      result = await this.finalizeCurrentBotSkill(botUid, {
+        localSkillId,
+        skillName,
+        reference: {
+          source: 'skillhub',
+          skillId,
+          version,
+          contentHash,
+        },
+      }, {
+        runtimeRoot: this.runtimeRoot,
+        publicationWaitMs: Math.max(
+          0,
+          Math.min(45_000, Number(request.expires_at || 0) - Date.now() - 1_000),
+        ),
+        validateScope: () => {
+          this.assertFreshRequest(request);
+          this.assertRequestScope(request, botUid, true);
+        },
+      });
+    } catch (error: any) {
+      if (error instanceof SkillHubThinRpcError) throw error;
+      throw new SkillHubThinRpcError(
+        String(error?.code || 'SKILLHUB_FINALIZE_FAILED'),
+        error?.message || 'The public Skill could not be finalized.',
+      );
+    }
+    if (result.botId !== botUid) {
+      throw new SkillHubThinRpcError(
+        'BOT_NOT_ACTIVE',
+        'The selected Bot workspace changed before finalization completed.',
+      );
+    }
+    const matched = result?.skills?.some((reference) => (
+      reference.skillId === skillId
+      && reference.version === version
+      && reference.contentHash === contentHash
+    ));
+    if (!matched) {
+      throw new SkillHubThinRpcError(
+        'BOT_DEFINITION_NOT_READY',
+        'The public Skill reference is not present in the current BotDefinition yet.',
+      );
+    }
+    return {
+      schema: 'xiaoba.skillhub.local_finalize.v1',
+      bot_uid: botUid,
+      skill_id: skillId,
+      version,
+      content_hash: contentHash,
+      direction: result?.direction || 'none',
+    };
+  }
+
+  private assertFreshRequest(request: CatsThinToolRpcMessage): void {
+    const expiresAt = Number(request.expires_at || 0);
+    if (!Number.isFinite(expiresAt) || expiresAt <= Date.now()) {
+      throw new SkillHubThinRpcError('REQUEST_EXPIRED', 'The SkillHub device request has expired.');
+    }
+  }
+
+  private assertRequestScope(
+    request: CatsThinToolRpcMessage,
+    botUid: string,
+    requireActiveBot: boolean,
+  ): { ownerUid: string; deviceId: string } {
+    const config = createCatsCoLocalConfigService({ runtimeRoot: this.runtimeRoot }).load();
+    const ownerUid = String(config.currentBot?.boundByUserUid || config.account?.uid || '').trim();
+    if (!ownerUid || normalizeUid(request.target_owner_user_id) !== normalizeUid(ownerUid)) {
+      throw new SkillHubThinRpcError('OWNER_MISMATCH', 'The local CatsCo account does not match this request.');
+    }
+    const deviceId = String(config.device?.deviceId || config.device?.installationId || '').trim();
+    const requestDeviceId = String(request.target_device_id || request.device_id || '').trim();
+    if (!deviceId || requestDeviceId !== deviceId) {
+      throw new SkillHubThinRpcError('DEVICE_MISMATCH', 'The request targets a different XiaoBa device.');
+    }
+    if (requireActiveBot && String(config.currentBot?.uid || '').trim() !== botUid) {
+      throw new SkillHubThinRpcError('BOT_NOT_ACTIVE', 'The selected Bot is not active on this XiaoBa device.');
+    }
+    return { ownerUid, deviceId };
+  }
+
+  private assertActiveWorkspace(botUid: string, configuredBotUid?: string, activeBotUid?: string): void {
+    if (configuredBotUid !== botUid || activeBotUid !== botUid) {
+      throw new SkillHubThinRpcError('BOT_NOT_ACTIVE', 'The selected Bot workspace is not active on this device.');
+    }
+  }
+}
+
+export function scheduleDashboardBotSwitch(botUid: string): void {
+  const timer = setTimeout(() => {
+    void requestDashboardBotSwitch(botUid).catch((error) => {
+      Logger.warning(`SkillHub remote Bot switch failed: ${error?.message || String(error)}`);
+    });
+  }, 1_000);
+  timer.unref?.();
+}
+
+export async function requestDashboardBotSwitch(
+  botUid: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<void> {
+  const numericPort = Number(process.env.XIAOBA_DASHBOARD_PORT || 3800);
+  const port = Number.isSafeInteger(numericPort) && numericPort > 0 && numericPort <= 65535
+    ? numericPort
+    : 3800;
+  const apiKey = String(process.env.DASHBOARD_API_KEY || '').trim();
+  const response = await fetchImpl(`http://127.0.0.1:${port}/api/cats/switch-bot`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+    },
+    body: JSON.stringify({ botUid }),
+  });
+  if (!response.ok) {
+    throw new Error(`Dashboard rejected the Bot switch (HTTP ${response.status}).`);
+  }
+}
+
+function recordValue(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+function requiredText(value: unknown, field: string, maxLength: number): string {
+  const text = String(value || '').trim();
+  if (!text || text.length > maxLength || text.includes('\0')) {
+    throw new SkillHubThinRpcError('INVALID_REQUEST', `${field} is invalid.`);
+  }
+  return text;
+}
+
+function limitText(value: string, maxLength: number): string {
+  const text = String(value || '');
+  return text.length <= maxLength ? text : text.slice(0, maxLength);
+}
+
+function normalizeUid(value: unknown): string {
+  return String(value || '').trim().replace(/^usr/i, '');
+}
+
+function isPrivateSkillReference(skillId: string): boolean {
+  const value = String(skillId || '');
+  return value.startsWith('priv_') || value.startsWith('private/');
+}
+
+function requestFingerprint(request: CatsThinToolRpcMessage): string {
+  return stableSerialize({
+    target_owner_user_id: normalizeUid(request.target_owner_user_id),
+    target_device_id: String(request.target_device_id || request.device_id || '').trim(),
+    tool_name: String(request.tool_name || '').trim(),
+    payload: recordValue(request.payload),
+    expires_at: Number(request.expires_at || 0),
+  });
+}
+
+function stableSerialize(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableSerialize).join(',')}]`;
+  if (value && typeof value === 'object') {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, item]) => `${JSON.stringify(key)}:${stableSerialize(item)}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value) ?? 'null';
+}

--- a/src/dashboard/routes/skillhub.ts
+++ b/src/dashboard/routes/skillhub.ts
@@ -4,16 +4,12 @@ import {
   scheduleCurrentBotSkillSync,
   withCurrentBotSkillWorkspaceWrite,
 } from '../../bot-skills/runtime';
+import {
+  shareLocalSkillForCatsCo,
+  type SkillHubCatsCoAuthPayload,
+} from '../../skillhub/local-share';
 
-export interface SkillHubCatsCoAuthPayload {
-  token: string;
-  baseUrl: string;
-  user?: {
-    uid?: string;
-    username?: string;
-    displayName?: string;
-  };
-}
+export { assertExpectedLocalSkillShareScope } from '../../skillhub/local-share';
 
 export interface SkillHubRouteOptions {
   getCatsCoAuth?: () => Promise<SkillHubCatsCoAuthPayload> | SkillHubCatsCoAuthPayload;
@@ -147,7 +143,7 @@ export function registerSkillHubRoutes(router: Router, options: SkillHubRouteOpt
 
   router.post('/skillhub/developer/share-local-skill', async (req, res) => {
     try {
-      res.status(201).json(await shareLocalSkill(req.body || {}, options));
+      res.status(201).json(await shareLocalSkillForCatsCo(req.body || {}, options));
     } catch (error: any) {
       sendSkillHubError(res, error);
     }
@@ -155,7 +151,7 @@ export function registerSkillHubRoutes(router: Router, options: SkillHubRouteOpt
 
   router.post('/skillhub/share-local-skill', async (req, res) => {
     try {
-      res.status(201).json(await shareLocalSkill(req.body || {}, options));
+      res.status(201).json(await shareLocalSkillForCatsCo(req.body || {}, options));
     } catch (error: any) {
       sendSkillHubError(res, error);
     }
@@ -192,84 +188,6 @@ export function registerSkillHubRoutes(router: Router, options: SkillHubRouteOpt
       sendSkillHubError(res, error);
     }
   });
-}
-
-async function shareLocalSkill(input: any, options: SkillHubRouteOptions): Promise<any> {
-  const expectedBotUid = String(input?.expectedBotUid || '').trim();
-  const expectedUserUid = String(input?.expectedUserUid || '').trim();
-  if (Boolean(expectedBotUid) !== Boolean(expectedUserUid)) {
-    throw skillHubConflict(
-      'expectedBotUid and expectedUserUid must be provided together.',
-      'skillhub.share_scope_incomplete',
-    );
-  }
-
-  // Preserve the existing Dashboard flow when no explicit WebApp scope is
-  // supplied. The WebApp bridge always sends both values and gets the stricter
-  // account/workspace checks below.
-  if (!expectedBotUid) return serviceFrom(input).shareLocalSkill(input);
-  if (!options.getCatsCoAuth) {
-    const error: any = new Error('CatsCo SkillHub login is not configured');
-    error.status = 501;
-    error.code = 'skillhub.catsco_exchange_unavailable';
-    throw error;
-  }
-
-  // Keep the existing fast-fail behavior for an already changed CatsCo
-  // account. This check is only a preflight; the identity is exchanged and
-  // checked again inside the workspace lock immediately before upload.
-  const preflightCats = await options.getCatsCoAuth();
-  if (String(preflightCats.user?.uid || '').trim() !== expectedUserUid) {
-    throw skillHubConflict(
-      'The local CatsCo account changed before the Skill was shared.',
-      'skillhub.share_user_changed',
-    );
-  }
-
-  return withCurrentBotSkillWorkspaceWrite(async (context) => {
-    assertExpectedLocalSkillShareScope(expectedBotUid, context.botId, context.activeBotId);
-    // WebApp shares must not reuse the process-wide SkillHub cookie. Re-exchange
-    // the current CatsCo identity inside the workspace lock and keep the
-    // resulting SkillHub session in memory for this request only.
-    const cats = await options.getCatsCoAuth!();
-    const service = serviceFrom(input, { sessionScope: 'memory' });
-    const skillHubAuth = await service.loginWithCatsCo(cats);
-    const actualUserUid = String(skillHubAuth.catsCo?.uid || '').trim();
-    if (!actualUserUid) {
-      throw skillHubConflict(
-        'SkillHub did not return the CatsCo identity for the exchanged session.',
-        'skillhub.share_identity_unavailable',
-      );
-    }
-    if (actualUserUid !== expectedUserUid) {
-      throw skillHubConflict(
-        'The local CatsCo account changed before the Skill was shared.',
-        'skillhub.share_user_changed',
-      );
-    }
-    const result = await service.shareLocalSkill(input);
-    return { ...result, botUid: expectedBotUid };
-  });
-}
-
-export function assertExpectedLocalSkillShareScope(
-  expectedBotUid: string,
-  configuredBotUid?: string,
-  activeBotUid?: string,
-): void {
-  if (configuredBotUid !== expectedBotUid || activeBotUid !== expectedBotUid) {
-    throw skillHubConflict(
-      'The active Bot Skill workspace changed before the Skill was shared.',
-      'skillhub.share_bot_changed',
-    );
-  }
-}
-
-function skillHubConflict(message: string, code: string): Error {
-  const error: any = new Error(message);
-  error.status = 409;
-  error.code = code;
-  return error;
 }
 
 function serviceFrom(_input?: any, options: { sessionScope?: 'persistent' | 'memory' } = {}): SkillHubService {

--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -32,6 +32,7 @@ export async function startDashboard(
   const app = express();
   const envPackaged = /^(1|true|yes)$/i.test(process.env.XIAOBA_IS_PACKAGED || '');
   const projectRoot = controllers.projectRoot || (envPackaged ? process.env.XIAOBA_APP_ROOT : undefined) || process.cwd();
+  process.env.XIAOBA_DASHBOARD_PORT = String(port);
   const serviceManager = new ServiceManager(projectRoot);
 
   app.use(express.json({ limit: '25mb' }));

--- a/src/skillhub/local-share.ts
+++ b/src/skillhub/local-share.ts
@@ -1,0 +1,133 @@
+import {
+  withCurrentBotSkillWorkspaceWrite,
+  type CurrentBotSkillWorkspaceWriteContext,
+} from '../bot-skills/runtime';
+import { scanBotSkillWorkspace } from '../bot-skills/local-manifest';
+import { SkillHubService } from './service';
+
+export interface SkillHubCatsCoAuthPayload {
+  token: string;
+  baseUrl: string;
+  user?: {
+    uid?: string;
+    username?: string;
+    displayName?: string;
+  };
+}
+
+export interface ShareLocalSkillForCatsCoOptions {
+  getCatsCoAuth?: () => Promise<SkillHubCatsCoAuthPayload> | SkillHubCatsCoAuthPayload;
+  writeLocalMetadata?: boolean;
+  runtimeRoot?: string;
+  validateScope?: (
+    context: CurrentBotSkillWorkspaceWriteContext,
+  ) => Promise<void> | void;
+}
+
+export async function shareLocalSkillForCatsCo(
+  input: any,
+  options: ShareLocalSkillForCatsCoOptions = {},
+): Promise<any> {
+  const expectedBotUid = String(input?.expectedBotUid || '').trim();
+  const expectedUserUid = String(input?.expectedUserUid || '').trim();
+  const expectedLocalSkillId = String(input?.expectedLocalSkillId || '').trim();
+  const skillName = String(input?.skillName || input?.skill || input?.name || '').trim();
+  if (Boolean(expectedBotUid) !== Boolean(expectedUserUid)) {
+    throw skillHubConflict(
+      'expectedBotUid and expectedUserUid must be provided together.',
+      'skillhub.share_scope_incomplete',
+    );
+  }
+
+  if (!expectedBotUid) {
+    return new SkillHubService().shareLocalSkill(input, {
+      writeLocalMetadata: options.writeLocalMetadata,
+    });
+  }
+  if (!options.getCatsCoAuth) {
+    const error: any = new Error('CatsCo SkillHub login is not configured');
+    error.status = 501;
+    error.code = 'skillhub.catsco_exchange_unavailable';
+    throw error;
+  }
+
+  const preflightCats = await options.getCatsCoAuth();
+  if (String(preflightCats.user?.uid || '').trim() !== expectedUserUid) {
+    throw skillHubConflict(
+      'The local CatsCo account changed before the Skill was shared.',
+      'skillhub.share_user_changed',
+    );
+  }
+
+  return withCurrentBotSkillWorkspaceWrite(async (context) => {
+    assertExpectedLocalSkillShareScope(expectedBotUid, context.botId, context.activeBotId);
+    await options.validateScope?.(context);
+    const selectedSkill = expectedLocalSkillId
+      ? scanBotSkillWorkspace(context.skillsRoot).find((candidate) => (
+        candidate.localSkillId === expectedLocalSkillId && candidate.name === skillName
+      ))
+      : undefined;
+    if (expectedLocalSkillId) {
+      if (!selectedSkill) {
+        throw skillHubConflict(
+          'The selected local Skill changed before it could be shared.',
+          'skillhub.share_local_skill_changed',
+        );
+      }
+    }
+    const cats = await options.getCatsCoAuth!();
+    const service = new SkillHubService({ sessionScope: 'memory' });
+    const skillHubAuth = await service.loginWithCatsCo(cats);
+    const actualUserUid = String(skillHubAuth.catsCo?.uid || '').trim();
+    if (!actualUserUid) {
+      throw skillHubConflict(
+        'SkillHub did not return the CatsCo identity for the exchanged session.',
+        'skillhub.share_identity_unavailable',
+      );
+    }
+    if (actualUserUid !== expectedUserUid) {
+      throw skillHubConflict(
+        'The local CatsCo account changed before the Skill was shared.',
+        'skillhub.share_user_changed',
+      );
+    }
+    const result = await service.shareLocalSkill(input, {
+      writeLocalMetadata: options.writeLocalMetadata,
+      ...(selectedSkill ? { localSkillPath: selectedSkill.path } : {}),
+    });
+    if (selectedSkill) {
+      const currentSkill = scanBotSkillWorkspace(context.skillsRoot).find((candidate) => (
+        candidate.localSkillId === selectedSkill.localSkillId
+        && candidate.name === selectedSkill.name
+      ));
+      if (!currentSkill || currentSkill.contentHash !== selectedSkill.contentHash) {
+        throw skillHubConflict(
+          'The selected local Skill changed while it was being shared.',
+          'skillhub.share_local_skill_changed',
+        );
+      }
+    }
+    await options.validateScope?.(context);
+    return { ...result, botUid: expectedBotUid };
+  }, { runtimeRoot: options.runtimeRoot });
+}
+
+export function assertExpectedLocalSkillShareScope(
+  expectedBotUid: string,
+  configuredBotUid?: string,
+  activeBotUid?: string,
+): void {
+  if (configuredBotUid !== expectedBotUid || activeBotUid !== expectedBotUid) {
+    throw skillHubConflict(
+      'The active Bot Skill workspace changed before the Skill was shared.',
+      'skillhub.share_bot_changed',
+    );
+  }
+}
+
+function skillHubConflict(message: string, code: string): Error {
+  const error: any = new Error(message);
+  error.status = 409;
+  error.code = code;
+  return error;
+}

--- a/src/skillhub/local-share.ts
+++ b/src/skillhub/local-share.ts
@@ -1,8 +1,10 @@
+import * as path from 'path';
 import {
   withCurrentBotSkillWorkspaceWrite,
   type CurrentBotSkillWorkspaceWriteContext,
 } from '../bot-skills/runtime';
 import { scanBotSkillWorkspace } from '../bot-skills/local-manifest';
+import { writeSkillHubLocalMetadata } from './local-skill-metadata';
 import { SkillHubService } from './service';
 
 export interface SkillHubCatsCoAuthPayload {
@@ -92,7 +94,7 @@ export async function shareLocalSkillForCatsCo(
       );
     }
     const result = await service.shareLocalSkill(input, {
-      writeLocalMetadata: options.writeLocalMetadata,
+      writeLocalMetadata: false,
       ...(selectedSkill ? { localSkillPath: selectedSkill.path } : {}),
     });
     if (selectedSkill) {
@@ -108,6 +110,10 @@ export async function shareLocalSkillForCatsCo(
       }
     }
     await options.validateScope?.(context);
+    if (result?.skillHub && options.writeLocalMetadata !== false) {
+      const localSkillPath = selectedSkill?.path || String(result?.skill?.path || '').trim();
+      writeSkillHubLocalMetadata(path.join(localSkillPath, 'SKILL.md'), result.skillHub);
+    }
     return { ...result, botUid: expectedBotUid };
   }, { runtimeRoot: options.runtimeRoot });
 }

--- a/src/skillhub/local-share.ts
+++ b/src/skillhub/local-share.ts
@@ -97,6 +97,7 @@ export async function shareLocalSkillForCatsCo(
       writeLocalMetadata: false,
       ...(selectedSkill ? { localSkillPath: selectedSkill.path } : {}),
     });
+    let revalidatedSkill = selectedSkill;
     if (selectedSkill) {
       const currentSkill = scanBotSkillWorkspace(context.skillsRoot).find((candidate) => (
         candidate.localSkillId === selectedSkill.localSkillId
@@ -108,10 +109,11 @@ export async function shareLocalSkillForCatsCo(
           'skillhub.share_local_skill_changed',
         );
       }
+      revalidatedSkill = currentSkill;
     }
     await options.validateScope?.(context);
     if (result?.skillHub && options.writeLocalMetadata !== false) {
-      const localSkillPath = selectedSkill?.path || String(result?.skill?.path || '').trim();
+      const localSkillPath = revalidatedSkill?.path || String(result?.skill?.path || '').trim();
       writeSkillHubLocalMetadata(path.join(localSkillPath, 'SKILL.md'), result.skillHub);
     }
     return { ...result, botUid: expectedBotUid };

--- a/src/skillhub/service.ts
+++ b/src/skillhub/service.ts
@@ -1,6 +1,10 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { createCatsCoLocalConfigService } from '../catscompany/local-config';
+import {
+  BotSkillPackageValidationError,
+  collectBotSkillPackageFiles,
+} from '../bot-skills/local-manifest';
 import { SkillParser } from '../skills/skill-parser';
 import type { Skill } from '../types/skill';
 import { PathResolver } from '../utils/path-resolver';
@@ -256,7 +260,19 @@ export class SkillHubService {
 
     const { skill } = localSkill;
     const localPath = path.dirname(skill.filePath);
-    const files = collectSkillSourceFiles(localPath);
+    let files: Array<{ path: string; contentBase64: string }>;
+    try {
+      files = collectBotSkillPackageFiles(localPath).map(({ path: filePath, contentBase64 }) => ({
+        path: filePath,
+        contentBase64,
+      }));
+    } catch (caught: any) {
+      if (!(caught instanceof BotSkillPackageValidationError)) throw caught;
+      const error: any = new Error(caught?.message || 'Local Skill package is unsafe to share.');
+      error.status = 400;
+      error.code = 'skillhub.local_skill_unsafe_package';
+      throw error;
+    }
     if (!files.length) {
       const error: any = new Error('Local skill package has no shareable files.');
       error.status = 400;

--- a/src/skillhub/service.ts
+++ b/src/skillhub/service.ts
@@ -231,7 +231,10 @@ export class SkillHubService {
     });
   }
 
-  async shareLocalSkill(input: any): Promise<any> {
+  async shareLocalSkill(
+    input: any,
+    options: { writeLocalMetadata?: boolean; localSkillPath?: string } = {},
+  ): Promise<any> {
     const skillName = String(input.skillName || input.skill || input.name || '').trim();
     if (!skillName) {
       const error: any = new Error('skillName required');
@@ -240,7 +243,9 @@ export class SkillHubService {
       throw error;
     }
 
-    const localSkill = findLocalShareableSkill(skillName);
+    const localSkill = options.localSkillPath
+      ? findLocalShareableSkillAtPath(options.localSkillPath, skillName)
+      : findLocalShareableSkill(skillName);
     if (!localSkill) {
       const available = listLocalSkillNames().join(', ');
       const error: any = new Error(`Local skill not found: ${skillName}${available ? `. Available skills: ${available}` : ''}`);
@@ -278,14 +283,19 @@ export class SkillHubService {
       },
     });
     const skillHubMetadata = skillHubMetadataFromShareResponse(submission);
-    if (skillHubMetadata) {
+    if (skillHubMetadata && options.writeLocalMetadata !== false) {
       writeSkillHubLocalMetadata(skill.filePath, skillHubMetadata);
     }
 
     return {
       ok: true,
       skill: {
-        id: submission?.skill?.skillId || submission?.upload?.skillId || submission?.submission?.normalizedManifest?.id || skill.metadata.name,
+        id: submission?.skillId
+          || submission?.skill?.skillId
+          || submission?.upload?.skillId
+          || submission?.packageVersion?.skillId
+          || submission?.submission?.normalizedManifest?.id
+          || skill.metadata.name,
         name: skill.metadata.name,
         description: skill.metadata.description,
         path: localPath,
@@ -293,8 +303,15 @@ export class SkillHubService {
       submission: submission?.submission || submission,
       existing: submission?.existing,
       requiresConfirmation: submission?.requiresConfirmation,
-      latestVersion: submission?.latestVersion,
-      contentHash: submission?.contentHash,
+      latestVersion: submission?.latestVersion
+        || submission?.skill?.latestVersion
+        || submission?.skill?.version
+        || submission?.upload?.version
+        || submission?.packageVersion?.latestVersion
+        || submission?.packageVersion?.version
+        || skillHubMetadata?.version,
+      contentHash: submission?.contentHash || submission?.packageVersion?.contentHash,
+      skillHub: skillHubMetadata,
     };
   }
 
@@ -349,6 +366,10 @@ function normalizeRegistryEntryVersion(entry: SkillHubRegistryEntry | undefined,
 const SOURCE_SKIP_DIRS = new Set([
   '.git',
   'node_modules',
+  '.ssh',
+  '.aws',
+  '.kube',
+  '.gnupg',
 ]);
 const SOURCE_SKIP_FILES = new Set([
   'skill.json',
@@ -356,26 +377,46 @@ const SOURCE_SKIP_FILES = new Set([
   'SBOM.json',
   '.xiaoba-bundled-skill.json',
   '.xiaoba-skillhub-install.json',
+  '.xiaoba-bot-skill.json',
 ]);
 const MAX_SOURCE_FILES = 200;
 const MAX_SOURCE_TOTAL_BYTES = 20 * 1024 * 1024;
 const MAX_SOURCE_SINGLE_FILE_BYTES = 2 * 1024 * 1024;
 
 function collectSkillSourceFiles(localPath: string): Array<{ path: string; contentBase64: string }> {
-  const root = path.resolve(String(localPath || '').trim());
-  if (!root || !fs.existsSync(root)) return [];
-  const stat = fs.statSync(root);
+  const inputPath = String(localPath || '').trim();
+  if (!inputPath) return [];
+  const root = path.resolve(inputPath);
+  if (!fs.existsSync(root)) return [];
+  const stat = fs.lstatSync(root);
+  if (stat.isSymbolicLink()) {
+    throw skillSourceLimitError(
+      'A symbolic link cannot be shared as a Skill package.',
+      'skillhub.local_skill_unsafe_link',
+      400,
+    );
+  }
   const baseDir = stat.isDirectory() ? root : path.dirname(root);
-  const files = stat.isDirectory() ? walk(baseDir) : [root];
+  const files = (stat.isDirectory() ? walk(baseDir) : [root]).sort();
   let total = 0;
   const result: Array<{ path: string; contentBase64: string }> = [];
 
   for (const filePath of files) {
-    if (result.length >= MAX_SOURCE_FILES) break;
-    const fileStat = fs.statSync(filePath);
-    if (!fileStat.isFile() || fileStat.size > MAX_SOURCE_SINGLE_FILE_BYTES) continue;
+    const fileStat = fs.lstatSync(filePath);
+    if (fileStat.isSymbolicLink() || !fileStat.isFile()) continue;
+    if (fileStat.size > MAX_SOURCE_SINGLE_FILE_BYTES) {
+      throw skillSourceLimitError(
+        `Skill file exceeds the ${MAX_SOURCE_SINGLE_FILE_BYTES}-byte sharing limit.`,
+        'skillhub.local_skill_file_too_large',
+      );
+    }
     total += fileStat.size;
-    if (total > MAX_SOURCE_TOTAL_BYTES) break;
+    if (total > MAX_SOURCE_TOTAL_BYTES) {
+      throw skillSourceLimitError(
+        `Skill package exceeds the ${MAX_SOURCE_TOTAL_BYTES}-byte sharing limit.`,
+        'skillhub.local_skill_package_too_large',
+      );
+    }
     const relative = path.relative(baseDir, filePath).replace(/\\/g, '/');
     if (!isSafePackagePath(relative)) continue;
     result.push({
@@ -391,18 +432,30 @@ function walk(dir: string): string[] {
   const result: string[] = [];
   const visit = (current: string): void => {
     for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
-      if (result.length >= MAX_SOURCE_FILES) return;
       if (entry.isSymbolicLink()) continue;
       const fullPath = path.join(current, entry.name);
       if (entry.isDirectory()) {
         if (!SOURCE_SKIP_DIRS.has(entry.name)) visit(fullPath);
       } else if (entry.isFile() && !SOURCE_SKIP_FILES.has(entry.name)) {
         result.push(fullPath);
+        if (result.length > MAX_SOURCE_FILES) {
+          throw skillSourceLimitError(
+            `Skill package exceeds the ${MAX_SOURCE_FILES}-file sharing limit.`,
+            'skillhub.local_skill_too_many_files',
+          );
+        }
       }
     }
   };
   visit(dir);
   return result;
+}
+
+function skillSourceLimitError(message: string, code: string, status = 413): Error {
+  const error: any = new Error(message);
+  error.status = status;
+  error.code = code;
+  return error;
 }
 
 function isSafePackagePath(packagePath: string): boolean {
@@ -470,18 +523,43 @@ function splitWords(text: string): string[] {
 }
 
 function findLocalShareableSkill(skillName: string): { skill: Skill } | undefined {
+  const matches: Skill[] = [];
   for (const skillFile of listLocalSkillFiles()) {
     try {
       const skill = SkillParser.parse(skillFile);
       const dirName = path.basename(path.dirname(skillFile));
       if (skill.metadata.name === skillName || dirName === skillName) {
-        return { skill };
+        matches.push(skill);
       }
     } catch {
       // Ignore broken local skills so one bad folder does not block sharing others.
     }
   }
-  return undefined;
+  if (matches.length > 1) {
+    const error: any = new Error(`Multiple local Skills match "${skillName}". Select one by its local Skill ID.`);
+    error.status = 409;
+    error.code = 'skillhub.local_skill_ambiguous';
+    throw error;
+  }
+  return matches[0] ? { skill: matches[0] } : undefined;
+}
+
+function findLocalShareableSkillAtPath(
+  localSkillPath: string,
+  skillName: string,
+): { skill: Skill } | undefined {
+  const root = path.resolve(String(localSkillPath || '').trim());
+  if (!root || !fs.existsSync(root)) return undefined;
+  const rootStat = fs.lstatSync(root);
+  const skillFile = path.join(root, 'SKILL.md');
+  if (rootStat.isSymbolicLink() || !rootStat.isDirectory() || !fs.existsSync(skillFile)) {
+    return undefined;
+  }
+  const skillStat = fs.lstatSync(skillFile);
+  if (skillStat.isSymbolicLink() || !skillStat.isFile()) return undefined;
+  const skill = SkillParser.parse(skillFile);
+  const dirName = path.basename(root);
+  return skill.metadata.name === skillName || dirName === skillName ? { skill } : undefined;
 }
 
 function listLocalSkillNames(): string[] {

--- a/src/skillhub/service.ts
+++ b/src/skillhub/service.ts
@@ -435,7 +435,12 @@ function walk(dir: string): string[] {
       if (entry.isSymbolicLink()) continue;
       const fullPath = path.join(current, entry.name);
       if (entry.isDirectory()) {
-        if (!SOURCE_SKIP_DIRS.has(entry.name)) visit(fullPath);
+        if (
+          !SOURCE_SKIP_DIRS.has(entry.name)
+          && !fs.existsSync(path.join(fullPath, 'SKILL.md'))
+        ) {
+          visit(fullPath);
+        }
       } else if (entry.isFile() && !SOURCE_SKIP_FILES.has(entry.name)) {
         result.push(fullPath);
         if (result.length > MAX_SOURCE_FILES) {

--- a/src/types/session-identity.ts
+++ b/src/types/session-identity.ts
@@ -97,7 +97,11 @@ export type DeviceGrantOperation =
   | 'glob'
   | 'grep'
   | 'browser_control'
-  | 'desktop_control';
+  | 'desktop_control'
+  | 'skillhub.localWorkspace.get'
+  | 'skillhub.localSkill.share'
+  | 'skillhub.localSkill.finalize'
+  | 'skillhub.localBot.switch';
 
 export interface ScopedLocalDeviceGrant {
   kind: 'catscompany_body';

--- a/tests/bot-skills-sync.test.ts
+++ b/tests/bot-skills-sync.test.ts
@@ -7,12 +7,18 @@ import { createBotDefinitionSyncService } from '../src/bot-definition/service';
 import type { BotDefinition, BotSkillRef } from '../src/bot-definition/types';
 import { BotSkillBaseStore } from '../src/bot-skills/base-store';
 import {
+  BOT_SKILL_LOCAL_MARKER_FILE,
   readBotSkillLocalMarker,
+  scanBotSkillWorkspace,
   scanLocalBotSkill,
 } from '../src/bot-skills/local-manifest';
 import { BotSkillSyncService } from '../src/bot-skills/sync-service';
 import type { BotSkillPackage, LocalBotSkillManifestEntry } from '../src/bot-skills/types';
 import { readSkillHubInstallMarker } from '../src/skillhub/install-marker';
+import {
+  applySkillHubLocalMetadata,
+  readSkillHubLocalMetadata,
+} from '../src/skillhub/local-skill-metadata';
 
 describe('Bot Skill Local/Base/Cloud sync', () => {
   const roots: string[] = [];
@@ -59,6 +65,875 @@ describe('Bot Skill Local/Base/Cloud sync', () => {
     );
     assert.equal(readSkillHubInstallMarker(path.join(fixture.skillsRoot, 'cloud-b'))?.skillId, external.reference.skillId);
     assert.equal(new BotSkillBaseStore(fixture.runtimeRoot).read(fixture.botId)?.definitionRevision, 2);
+  });
+
+  test('keeps a public reference after replacing the private sync copy of a local Skill', async () => {
+    const fixture = createFixture(roots);
+    writeSkill(fixture.skillsRoot, 'local-a', 'local-a', 'share this publicly');
+    await fixture.sync();
+
+    const privateReference = fixture.cloud.skills[0];
+    const privatePackage = fixture.packages.get(refKey(privateReference));
+    assert.ok(privatePackage);
+    const publicReference = { skillId: 'alice/local-a', version: '1.0.0' };
+    const publicPackage: BotSkillPackage = {
+      ...privatePackage,
+      reference: publicReference,
+      origin: publicReference,
+    };
+    delete (publicPackage as Partial<BotSkillPackage>).schema;
+    fixture.packages.set(refKey(publicReference), publicPackage);
+    fixture.cloud = {
+      revision: fixture.cloud.revision + 1,
+      skills: [{
+        source: 'skillhub',
+        ...publicReference,
+        contentHash: privatePackage.contentHash,
+      }],
+    };
+
+    const finalized = await fixture.sync();
+    assert.equal(finalized.direction, 'cloud_to_local');
+    assert.equal(
+      readBotSkillLocalMarker(path.join(fixture.skillsRoot, 'local-a'))?.reference?.skillId,
+      'alice/local-a',
+    );
+    assert.equal(
+      readSkillHubInstallMarker(path.join(fixture.skillsRoot, 'local-a'))?.skillId,
+      'alice/local-a',
+    );
+
+    const repeated = await fixture.sync();
+    assert.equal(repeated.direction, 'none');
+    assert.deepStrictEqual(fixture.cloud.skills, [{
+      source: 'skillhub',
+      ...publicReference,
+      contentHash: privatePackage.contentHash,
+    }]);
+  });
+
+  test('promotes a new local Skill to its public reference without privately uploading it', async () => {
+    const fixture = createFixture(roots);
+    writeSkill(fixture.skillsRoot, 'existing', 'existing', 'already in Base');
+    await fixture.sync();
+    writeSkill(fixture.skillsRoot, 'shared-new', 'shared-new', 'share this globally');
+    writeSkill(fixture.skillsRoot, 'other-new', 'other-new', 'keep this private');
+
+    const target = scanLocalBotSkill(path.join(fixture.skillsRoot, 'shared-new'));
+    const metadata = {
+      author: 'alice',
+      version: '1.0.0',
+      uploadedAt: '2026-08-05T00:00:00.000Z',
+    };
+    const publicRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-public-package-'));
+    roots.push(publicRoot);
+    writeSkill(publicRoot, 'shared-new', 'shared-new', 'share this globally');
+    const publicSkillFile = path.join(publicRoot, 'shared-new', 'SKILL.md');
+    fs.writeFileSync(
+      publicSkillFile,
+      applySkillHubLocalMetadata(fs.readFileSync(publicSkillFile, 'utf8'), metadata),
+      'utf8',
+    );
+    const canonicalPublic = scanLocalBotSkill(path.join(publicRoot, 'shared-new'));
+    const publicReference = {
+      source: 'skillhub' as const,
+      skillId: 'alice/shared-new',
+      version: metadata.version,
+      contentHash: canonicalPublic.contentHash,
+    };
+    const publicPackage: BotSkillPackage = {
+      schema: 'catsco.private-skill-package.v1',
+      source: 'public',
+      reference: {
+        skillId: publicReference.skillId,
+        version: publicReference.version,
+      },
+      localSkillId: target.localSkillId,
+      name: target.name,
+      contentHash: canonicalPublic.contentHash,
+      createdAt: metadata.uploadedAt,
+      origin: {
+        skillId: publicReference.skillId,
+        version: publicReference.version,
+      },
+      files: canonicalPublic.files,
+    };
+    delete (publicPackage as Partial<BotSkillPackage>).schema;
+    fixture.packages.set(refKey(publicReference), publicPackage);
+    fixture.cloud = {
+      revision: fixture.cloud.revision + 1,
+      skills: [...fixture.cloud.skills, publicReference],
+    };
+
+    const uploadsBeforeFinalize = fixture.uploads;
+    const finalized = await fixture.finalize({
+      localSkillId: target.localSkillId,
+      skillName: target.name,
+      reference: publicReference,
+    });
+
+    assert.equal(finalized.direction, 'local_to_cloud');
+    assert.equal(fixture.uploads, uploadsBeforeFinalize + 1, 'only the unrelated new Skill is private-uploaded');
+    assert.equal(fixture.cloud.skills.some(skill => skill.skillId === publicReference.skillId), true);
+    assert.equal(fixture.cloud.skills.some(skill => (
+      skill.skillId.startsWith('private/')
+      && fixture.packages.get(refKey(skill))?.localSkillId === target.localSkillId
+    )), false);
+    assert.deepEqual(readSkillHubLocalMetadata(path.join(fixture.skillsRoot, 'shared-new', 'SKILL.md')), metadata);
+    assert.deepEqual(
+      readBotSkillLocalMarker(path.join(fixture.skillsRoot, 'shared-new'))?.reference,
+      publicReference,
+    );
+
+    const repeated = await fixture.sync();
+    assert.equal(repeated.direction, 'none');
+    assert.equal(fixture.uploads, uploadsBeforeFinalize + 1);
+  });
+
+  test('rolls back Local and Base when the public ref disappears at the final cloud CAS', async () => {
+    const fixture = createFixture(roots);
+    writeSkill(fixture.skillsRoot, 'shared', 'shared', 'same canonical body');
+    const skillFile = path.join(fixture.skillsRoot, 'shared', 'SKILL.md');
+    const metadata = {
+      author: 'alice',
+      version: '1.0.0',
+      uploadedAt: '2026-08-06T00:00:00.000Z',
+    };
+    fs.writeFileSync(
+      skillFile,
+      applySkillHubLocalMetadata(fs.readFileSync(skillFile, 'utf8'), metadata),
+      'utf8',
+    );
+    await fixture.sync();
+    const target = scanLocalBotSkill(path.join(fixture.skillsRoot, 'shared'));
+    const privateReference = fixture.cloud.skills[0];
+    const privatePackage = fixture.packages.get(refKey(privateReference));
+    assert.ok(privatePackage);
+    const publicReference = {
+      source: 'skillhub' as const,
+      skillId: 'alice/shared',
+      version: metadata.version,
+      contentHash: target.contentHash,
+    };
+    const publicPackage: BotSkillPackage = {
+      ...privatePackage,
+      source: 'public',
+      reference: { skillId: publicReference.skillId, version: publicReference.version },
+      origin: { skillId: publicReference.skillId, version: publicReference.version },
+    };
+    delete (publicPackage as Partial<BotSkillPackage>).schema;
+    fixture.packages.set(refKey(publicReference), publicPackage);
+    fixture.cloud = {
+      revision: fixture.cloud.revision + 1,
+      skills: [publicReference],
+    };
+    const markerFile = path.join(target.path, '.xiaoba-bot-skill.json');
+    const previousSkill = fs.readFileSync(skillFile, 'utf8');
+    const previousMarker = fs.readFileSync(markerFile, 'utf8');
+    const previousBase = new BotSkillBaseStore(fixture.runtimeRoot).read(fixture.botId);
+    fixture.conflictNextPatch = true;
+    fixture.removeSkillsOnConflict = true;
+
+    await assert.rejects(
+      fixture.finalize({
+        localSkillId: target.localSkillId,
+        skillName: target.name,
+        reference: publicReference,
+      }),
+      /removed from BotDefinition during finalization/i,
+    );
+
+    assert.equal(fs.readFileSync(skillFile, 'utf8'), previousSkill);
+    assert.equal(fs.readFileSync(markerFile, 'utf8'), previousMarker);
+    assert.deepEqual(new BotSkillBaseStore(fixture.runtimeRoot).read(fixture.botId), previousBase);
+    assert.deepEqual(fixture.cloud.skills, []);
+  });
+
+  test('leaves local files and markers unchanged when public package verification fails', async () => {
+    const fixture = createFixture(roots);
+    writeSkill(fixture.skillsRoot, 'existing', 'existing', 'already in Base');
+    await fixture.sync();
+    writeSkill(fixture.skillsRoot, 'shared-new', 'shared-new', 'local body');
+    const target = scanLocalBotSkill(path.join(fixture.skillsRoot, 'shared-new'));
+    const skillFile = path.join(target.path, 'SKILL.md');
+    const markerFile = path.join(target.path, '.xiaoba-bot-skill.json');
+    const previousSkill = fs.readFileSync(skillFile, 'utf8');
+    const previousMarker = fs.readFileSync(markerFile, 'utf8');
+
+    const publicRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-public-mismatch-'));
+    roots.push(publicRoot);
+    writeSkill(publicRoot, 'shared-new', 'shared-new', 'different published body');
+    const publicSkillFile = path.join(publicRoot, 'shared-new', 'SKILL.md');
+    const metadata = {
+      author: 'alice',
+      version: '1.0.0',
+      uploadedAt: '2026-08-05T00:00:00.000Z',
+    };
+    fs.writeFileSync(
+      publicSkillFile,
+      applySkillHubLocalMetadata(fs.readFileSync(publicSkillFile, 'utf8'), metadata),
+      'utf8',
+    );
+    const canonicalPublic = scanLocalBotSkill(path.join(publicRoot, 'shared-new'));
+    const reference = {
+      source: 'skillhub' as const,
+      skillId: 'alice/shared-new',
+      version: metadata.version,
+      contentHash: canonicalPublic.contentHash,
+    };
+    const publicPackage: BotSkillPackage = {
+      schema: 'catsco.private-skill-package.v1',
+      source: 'public',
+      reference: { skillId: reference.skillId, version: reference.version },
+      localSkillId: target.localSkillId,
+      name: target.name,
+      contentHash: reference.contentHash,
+      createdAt: metadata.uploadedAt,
+      files: canonicalPublic.files,
+    };
+    delete (publicPackage as Partial<BotSkillPackage>).schema;
+    fixture.packages.set(refKey(reference), publicPackage);
+    fixture.cloud = {
+      revision: fixture.cloud.revision + 1,
+      skills: [...fixture.cloud.skills, reference],
+    };
+
+    await assert.rejects(
+      fixture.finalize({
+        localSkillId: target.localSkillId,
+        skillName: target.name,
+        reference,
+      }),
+      /changed after it was shared/i,
+    );
+    assert.equal(fs.readFileSync(skillFile, 'utf8'), previousSkill);
+    assert.equal(fs.readFileSync(markerFile, 'utf8'), previousMarker);
+  });
+
+  test('does not overwrite a local edit made while the public package is becoming ready', async () => {
+    const fixture = createFixture(roots);
+    writeSkill(fixture.skillsRoot, 'existing', 'existing', 'already in Base');
+    await fixture.sync();
+    writeSkill(fixture.skillsRoot, 'shared-new', 'shared-new', 'original local body');
+    const target = scanLocalBotSkill(path.join(fixture.skillsRoot, 'shared-new'));
+    const metadata = {
+      author: 'alice',
+      version: '1.0.0',
+      uploadedAt: '2026-08-05T00:00:00.000Z',
+    };
+    const publicRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-public-race-'));
+    roots.push(publicRoot);
+    writeSkill(publicRoot, 'shared-new', 'shared-new', 'original local body');
+    const publicSkillFile = path.join(publicRoot, 'shared-new', 'SKILL.md');
+    fs.writeFileSync(
+      publicSkillFile,
+      applySkillHubLocalMetadata(fs.readFileSync(publicSkillFile, 'utf8'), metadata),
+      'utf8',
+    );
+    const canonicalPublic = scanLocalBotSkill(path.join(publicRoot, 'shared-new'));
+    const reference = {
+      source: 'skillhub' as const,
+      skillId: 'alice/shared-new',
+      version: metadata.version,
+      contentHash: canonicalPublic.contentHash,
+    };
+    const publicPackage: BotSkillPackage = {
+      schema: 'catsco.private-skill-package.v1',
+      source: 'public',
+      reference: { skillId: reference.skillId, version: reference.version },
+      localSkillId: target.localSkillId,
+      name: target.name,
+      contentHash: reference.contentHash,
+      createdAt: metadata.uploadedAt,
+      files: canonicalPublic.files,
+    };
+    delete (publicPackage as Partial<BotSkillPackage>).schema;
+    fixture.packages.set(refKey(reference), publicPackage);
+    fixture.cloud = {
+      revision: fixture.cloud.revision + 1,
+      skills: [...fixture.cloud.skills, reference],
+    };
+    const skillFile = path.join(target.path, 'SKILL.md');
+    const markerFile = path.join(target.path, '.xiaoba-bot-skill.json');
+    const previousMarker = fs.readFileSync(markerFile, 'utf8');
+    let scopeChecks = 0;
+
+    await assert.rejects(
+      fixture.finalize({
+        localSkillId: target.localSkillId,
+        skillName: target.name,
+        reference,
+      }, {
+        validateScope: () => {
+          scopeChecks += 1;
+          if (scopeChecks === 1) {
+            fs.writeFileSync(skillFile, skillText('shared-new', 'edited while publishing'));
+          }
+        },
+      }),
+      /changed while its public package was being published/i,
+    );
+    assert.match(fs.readFileSync(skillFile, 'utf8'), /edited while publishing/);
+    assert.equal(fs.readFileSync(markerFile, 'utf8'), previousMarker);
+  });
+
+  test('rechecks BotDefinition after publication wait and refuses a concurrently removed public reference', async () => {
+    const fixture = createFixture(roots);
+    writeSkill(fixture.skillsRoot, 'shared-new', 'shared-new', 'share this globally');
+    const target = scanLocalBotSkill(path.join(fixture.skillsRoot, 'shared-new'));
+    const metadata = {
+      author: 'alice',
+      version: '1.0.0',
+      uploadedAt: '2026-08-06T00:00:00.000Z',
+    };
+    const publicRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-public-removed-'));
+    roots.push(publicRoot);
+    writeSkill(publicRoot, 'shared-new', 'shared-new', 'share this globally');
+    const publicSkillFile = path.join(publicRoot, 'shared-new', 'SKILL.md');
+    fs.writeFileSync(
+      publicSkillFile,
+      applySkillHubLocalMetadata(fs.readFileSync(publicSkillFile, 'utf8'), metadata),
+    );
+    const published = scanLocalBotSkill(path.join(publicRoot, 'shared-new'));
+    const reference = {
+      source: 'skillhub' as const,
+      skillId: 'alice/shared-new',
+      version: metadata.version,
+      contentHash: published.contentHash,
+    };
+    const publicPackage: BotSkillPackage = {
+      schema: 'catsco.private-skill-package.v1',
+      source: 'public',
+      reference: { skillId: reference.skillId, version: reference.version },
+      localSkillId: target.localSkillId,
+      name: target.name,
+      contentHash: reference.contentHash,
+      createdAt: metadata.uploadedAt,
+      files: published.files,
+    };
+    delete (publicPackage as Partial<BotSkillPackage>).schema;
+    fixture.packages.set(refKey(reference), publicPackage);
+    fixture.cloud = { revision: 1, skills: [reference] };
+    const skillFile = path.join(target.path, 'SKILL.md');
+    const markerFile = path.join(target.path, '.xiaoba-bot-skill.json');
+    const previousSkill = fs.readFileSync(skillFile, 'utf8');
+    const previousMarker = fs.readFileSync(markerFile, 'utf8');
+    let scopeChecks = 0;
+
+    await assert.rejects(
+      fixture.finalize({
+        localSkillId: target.localSkillId,
+        skillName: target.name,
+        reference,
+      }, {
+        validateScope: () => {
+          scopeChecks += 1;
+          if (scopeChecks === 2) {
+            fixture.cloud = { revision: 2, skills: [] };
+          }
+        },
+      }),
+      /removed from BotDefinition during finalization/i,
+    );
+    assert.equal(fs.readFileSync(skillFile, 'utf8'), previousSkill);
+    assert.equal(fs.readFileSync(markerFile, 'utf8'), previousMarker);
+    assert.deepEqual(fixture.cloud.skills, []);
+  });
+
+  test('promotes a public marker over a same-hash private Base reference', async () => {
+    const fixture = createFixture(roots);
+    writeSkill(fixture.skillsRoot, 'shared-existing', 'shared-existing', 'same canonical body');
+    const skillFile = path.join(fixture.skillsRoot, 'shared-existing', 'SKILL.md');
+    const metadata = {
+      author: 'alice',
+      version: '1.0.0',
+      uploadedAt: '2026-08-06T00:00:00.000Z',
+    };
+    fs.writeFileSync(
+      skillFile,
+      applySkillHubLocalMetadata(fs.readFileSync(skillFile, 'utf8'), metadata),
+    );
+    await fixture.sync();
+    const target = scanLocalBotSkill(path.join(fixture.skillsRoot, 'shared-existing'));
+    const privateReference = fixture.cloud.skills[0];
+    const reference = {
+      source: 'skillhub' as const,
+      skillId: 'alice/shared-existing',
+      version: metadata.version,
+      contentHash: target.contentHash,
+    };
+    const publicPackage: BotSkillPackage = {
+      schema: 'catsco.private-skill-package.v1',
+      source: 'public',
+      reference: { skillId: reference.skillId, version: reference.version },
+      localSkillId: target.localSkillId,
+      name: target.name,
+      contentHash: target.contentHash,
+      createdAt: metadata.uploadedAt,
+      files: target.files,
+    };
+    delete (publicPackage as Partial<BotSkillPackage>).schema;
+    fixture.packages.set(refKey(reference), publicPackage);
+    fixture.cloud = {
+      revision: fixture.cloud.revision + 1,
+      skills: [privateReference, reference],
+    };
+
+    const result = await fixture.finalize({
+      localSkillId: target.localSkillId,
+      skillName: target.name,
+      reference,
+    });
+    assert.equal(result.direction, 'local_to_cloud');
+    assert.deepEqual(fixture.cloud.skills, [reference]);
+    assert.deepEqual(
+      new BotSkillBaseStore(fixture.runtimeRoot).read(fixture.botId)?.skills[0].reference,
+      reference,
+    );
+    assert.deepEqual(readBotSkillLocalMarker(target.path)?.reference, reference);
+    assert.equal(fs.existsSync(path.join(
+      fixture.runtimeRoot,
+      'data',
+      'bot-skills',
+      'finalize-journal',
+      fixture.botId,
+      `${target.localSkillId}.json`,
+    )), false);
+  });
+
+  test('recovers a public reference after a crash between SKILL.md and marker writes', async () => {
+    const fixture = createFixture(roots);
+    writeSkill(fixture.skillsRoot, 'crash-recovery', 'crash-recovery', 'published body');
+    await fixture.sync();
+    const beforeCrash = scanLocalBotSkill(path.join(fixture.skillsRoot, 'crash-recovery'));
+    const metadata = {
+      author: 'alice',
+      version: '1.0.0',
+      uploadedAt: '2026-08-06T00:00:00.000Z',
+    };
+    const skillFile = path.join(beforeCrash.path, 'SKILL.md');
+    const previousSkill = fs.readFileSync(skillFile, 'utf8');
+    const previousMarker = fs.readFileSync(
+      path.join(beforeCrash.path, BOT_SKILL_LOCAL_MARKER_FILE),
+      'utf8',
+    );
+    fs.writeFileSync(
+      skillFile,
+      applySkillHubLocalMetadata(previousSkill, metadata),
+      'utf8',
+    );
+    const afterSkillWrite = scanLocalBotSkill(beforeCrash.path);
+    assert.equal(afterSkillWrite.reference, undefined);
+    const publicReference = {
+      source: 'skillhub' as const,
+      skillId: 'alice/crash-recovery',
+      version: metadata.version,
+      contentHash: afterSkillWrite.contentHash,
+    };
+    const publicPackage: BotSkillPackage = {
+      schema: 'catsco.private-skill-package.v1',
+      source: 'public',
+      reference: { skillId: publicReference.skillId, version: publicReference.version },
+      localSkillId: `public-${'a'.repeat(64)}`,
+      name: afterSkillWrite.name,
+      contentHash: afterSkillWrite.contentHash,
+      createdAt: metadata.uploadedAt,
+      files: afterSkillWrite.files,
+    };
+    delete (publicPackage as Partial<BotSkillPackage>).schema;
+    fixture.packages.set(refKey(publicReference), publicPackage);
+    fixture.cloud = {
+      revision: fixture.cloud.revision + 1,
+      skills: [publicReference],
+    };
+    const journalPath = writeFinalizeJournalFixture({
+      runtimeRoot: fixture.runtimeRoot,
+      skillsRoot: fixture.skillsRoot,
+      botId: fixture.botId,
+      before: beforeCrash,
+      after: afterSkillWrite,
+      reference: publicReference,
+      previousSkill,
+      previousMarker,
+    });
+    const uploadsBeforeRecovery = fixture.uploads;
+
+    const recovered = await fixture.sync();
+
+    assert.equal(recovered.direction, 'local_to_cloud');
+    assert.equal(fixture.uploads, uploadsBeforeRecovery);
+    assert.deepEqual(fixture.cloud.skills, [publicReference]);
+    assert.deepEqual(readBotSkillLocalMarker(beforeCrash.path)?.reference, publicReference);
+    assert.deepEqual(
+      new BotSkillBaseStore(fixture.runtimeRoot).read(fixture.botId)?.skills[0].reference,
+      publicReference,
+    );
+    assert.equal(fs.existsSync(journalPath), false);
+  });
+
+  test('rolls back an interrupted public finalize when its cloud reference was removed', async () => {
+    const fixture = createFixture(roots);
+    writeSkill(fixture.skillsRoot, 'crash-rollback', 'crash-rollback', 'original body');
+    await fixture.sync();
+    const beforeCrash = scanLocalBotSkill(path.join(fixture.skillsRoot, 'crash-rollback'));
+    const skillFile = path.join(beforeCrash.path, 'SKILL.md');
+    const markerFile = path.join(beforeCrash.path, BOT_SKILL_LOCAL_MARKER_FILE);
+    const previousSkill = fs.readFileSync(skillFile, 'utf8');
+    const previousMarker = fs.readFileSync(markerFile, 'utf8');
+    fs.writeFileSync(skillFile, applySkillHubLocalMetadata(previousSkill, {
+      author: 'alice',
+      version: '1.0.0',
+      uploadedAt: '2026-08-06T00:00:00.000Z',
+    }), 'utf8');
+    const afterSkillWrite = scanLocalBotSkill(beforeCrash.path);
+    const removedReference = {
+      source: 'skillhub' as const,
+      skillId: 'alice/crash-rollback',
+      version: '1.0.0',
+      contentHash: afterSkillWrite.contentHash,
+    };
+    const journalPath = writeFinalizeJournalFixture({
+      runtimeRoot: fixture.runtimeRoot,
+      skillsRoot: fixture.skillsRoot,
+      botId: fixture.botId,
+      before: beforeCrash,
+      after: afterSkillWrite,
+      reference: removedReference,
+      previousSkill,
+      previousMarker,
+    });
+    const uploadsBeforeRecovery = fixture.uploads;
+
+    const recovered = await fixture.sync();
+
+    assert.equal(recovered.direction, 'none');
+    assert.equal(fs.readFileSync(skillFile, 'utf8'), previousSkill);
+    assert.equal(fs.readFileSync(markerFile, 'utf8'), previousMarker);
+    assert.equal(fixture.uploads, uploadsBeforeRecovery);
+    assert.equal(fs.existsSync(journalPath), false);
+  });
+
+  test('rolls forward a pre-write finalize without Base instead of uploading private', async () => {
+    const fixture = createFixture(roots);
+    writeSkill(fixture.skillsRoot, 'pre-write', 'pre-write', 'published body');
+    await fixture.sync();
+    const before = scanLocalBotSkill(path.join(fixture.skillsRoot, 'pre-write'));
+    const skillFile = path.join(before.path, 'SKILL.md');
+    const previousSkill = fs.readFileSync(skillFile, 'utf8');
+    const previousMarker = fs.readFileSync(
+      path.join(before.path, BOT_SKILL_LOCAL_MARKER_FILE),
+      'utf8',
+    );
+    const nextSkill = applySkillHubLocalMetadata(previousSkill, {
+      author: 'alice',
+      version: '1.0.0',
+      uploadedAt: '2026-08-06T00:00:00.000Z',
+    });
+    fs.writeFileSync(skillFile, nextSkill, 'utf8');
+    const after = scanLocalBotSkill(before.path);
+    fs.writeFileSync(skillFile, previousSkill, 'utf8');
+    const reference = {
+      source: 'skillhub' as const,
+      skillId: 'alice/pre-write',
+      version: '1.0.0',
+      contentHash: after.contentHash,
+    };
+    const publicPackage: BotSkillPackage = {
+      schema: 'catsco.private-skill-package.v1',
+      source: 'public',
+      reference: { skillId: reference.skillId, version: reference.version },
+      localSkillId: `public-${'c'.repeat(64)}`,
+      name: after.name,
+      contentHash: after.contentHash,
+      createdAt: '2026-08-06T00:00:00.000Z',
+      files: after.files,
+    };
+    delete (publicPackage as Partial<BotSkillPackage>).schema;
+    fixture.packages.set(refKey(reference), publicPackage);
+    fixture.cloud = { revision: fixture.cloud.revision + 1, skills: [reference] };
+    const journalPath = writeFinalizeJournalFixture({
+      runtimeRoot: fixture.runtimeRoot,
+      skillsRoot: fixture.skillsRoot,
+      botId: fixture.botId,
+      before,
+      after,
+      reference,
+      previousSkill,
+      nextSkill,
+      previousMarker,
+    });
+    fs.rmSync(path.join(
+      fixture.runtimeRoot,
+      'data',
+      'bot-skills',
+      'sync-base',
+      `${fixture.botId}.json`,
+    ));
+    const uploadsBeforeRecovery = fixture.uploads;
+
+    await fixture.sync();
+
+    assert.equal(fixture.uploads, uploadsBeforeRecovery);
+    assert.equal(fs.readFileSync(skillFile, 'utf8'), nextSkill);
+    assert.deepEqual(readBotSkillLocalMarker(before.path)?.reference, reference);
+    assert.deepEqual(fixture.cloud.skills, [reference]);
+    assert.deepEqual(
+      new BotSkillBaseStore(fixture.runtimeRoot).read(fixture.botId)?.skills[0].reference,
+      reference,
+    );
+    assert.equal(fs.existsSync(journalPath), false);
+  });
+
+  test('does not attach a recovered public reference to an identical local sibling', async () => {
+    const fixture = createFixture(roots);
+    writeSkill(fixture.skillsRoot, 'selected-copy', 'duplicate-name', 'same body');
+    writeSkill(fixture.skillsRoot, 'other-copy', 'duplicate-name', 'same body');
+    await fixture.sync();
+    const initial = scanBotSkillWorkspace(fixture.skillsRoot);
+    const selectedBefore = initial.find(entry => entry.installName === 'selected-copy');
+    const otherBefore = initial.find(entry => entry.installName === 'other-copy');
+    assert.ok(selectedBefore);
+    assert.ok(otherBefore);
+    const baseBefore = new BotSkillBaseStore(fixture.runtimeRoot).read(fixture.botId);
+    const selectedBase = baseBefore?.skills.find(entry => entry.localSkillId === selectedBefore.localSkillId);
+    const otherBase = baseBefore?.skills.find(entry => entry.localSkillId === otherBefore.localSkillId);
+    assert.ok(selectedBase);
+    assert.ok(otherBase);
+    const selectedSkillFile = path.join(selectedBefore.path, 'SKILL.md');
+    const selectedPreviousSkill = fs.readFileSync(selectedSkillFile, 'utf8');
+    const selectedPreviousMarker = fs.readFileSync(
+      path.join(selectedBefore.path, BOT_SKILL_LOCAL_MARKER_FILE),
+      'utf8',
+    );
+
+    const metadata = {
+      author: 'alice',
+      version: '1.0.0',
+      uploadedAt: '2026-08-06T00:00:00.000Z',
+    };
+    for (const entry of [selectedBefore, otherBefore]) {
+      const skillFile = path.join(entry.path, 'SKILL.md');
+      fs.writeFileSync(
+        skillFile,
+        applySkillHubLocalMetadata(fs.readFileSync(skillFile, 'utf8'), metadata),
+        'utf8',
+      );
+    }
+    const selectedAfter = scanLocalBotSkill(selectedBefore.path);
+    const otherAfter = scanLocalBotSkill(otherBefore.path);
+    assert.equal(selectedAfter.contentHash, otherAfter.contentHash);
+    const publicReference = {
+      source: 'skillhub' as const,
+      skillId: 'alice/duplicate-name',
+      version: metadata.version,
+      contentHash: selectedAfter.contentHash,
+    };
+    const publicPackage: BotSkillPackage = {
+      schema: 'catsco.private-skill-package.v1',
+      source: 'public',
+      reference: { skillId: publicReference.skillId, version: publicReference.version },
+      localSkillId: `public-${'b'.repeat(64)}`,
+      name: selectedAfter.name,
+      contentHash: selectedAfter.contentHash,
+      createdAt: metadata.uploadedAt,
+      files: selectedAfter.files,
+    };
+    delete (publicPackage as Partial<BotSkillPackage>).schema;
+    fixture.packages.set(refKey(publicReference), publicPackage);
+    fixture.cloud = {
+      revision: fixture.cloud.revision + 1,
+      skills: [publicReference, otherBase.reference],
+    };
+    writeFinalizeJournalFixture({
+      runtimeRoot: fixture.runtimeRoot,
+      skillsRoot: fixture.skillsRoot,
+      botId: fixture.botId,
+      before: selectedBefore,
+      after: selectedAfter,
+      reference: publicReference,
+      previousSkill: selectedPreviousSkill,
+      previousMarker: selectedPreviousMarker,
+    });
+    const uploadsBeforeRecovery = fixture.uploads;
+
+    await fixture.sync();
+
+    assert.deepEqual(readBotSkillLocalMarker(selectedAfter.path)?.reference, publicReference);
+    const otherReference = readBotSkillLocalMarker(otherAfter.path)?.reference;
+    assert.ok(otherReference);
+    assert.notEqual(otherReference.skillId, publicReference.skillId);
+    assert.equal(fixture.uploads, uploadsBeforeRecovery + 1);
+    assert.equal(fixture.cloud.skills.some(reference => reference.skillId === publicReference.skillId), true);
+    assert.equal(fixture.cloud.skills.some(reference => reference.skillId === otherReference.skillId), true);
+  });
+
+  test('lets local rename, move, and delete win over an interrupted finalize', async t => {
+    for (const action of ['rename', 'move', 'delete'] as const) {
+      await t.test(action, async () => {
+        const fixture = createFixture(roots);
+        const originalName = `journal-${action}`;
+        writeSkill(fixture.skillsRoot, originalName, originalName, 'original body');
+        await fixture.sync();
+        const before = scanLocalBotSkill(path.join(fixture.skillsRoot, originalName));
+        const skillFile = path.join(before.path, 'SKILL.md');
+        const previousSkill = fs.readFileSync(skillFile, 'utf8');
+        const previousMarker = fs.readFileSync(
+          path.join(before.path, BOT_SKILL_LOCAL_MARKER_FILE),
+          'utf8',
+        );
+        const nextSkill = applySkillHubLocalMetadata(previousSkill, {
+          author: 'alice',
+          version: '1.0.0',
+          uploadedAt: '2026-08-06T00:00:00.000Z',
+        });
+        fs.writeFileSync(skillFile, nextSkill, 'utf8');
+        const after = scanLocalBotSkill(before.path);
+        const reference = {
+          source: 'skillhub' as const,
+          skillId: `alice/${originalName}`,
+          version: '1.0.0',
+          contentHash: after.contentHash,
+        };
+        fixture.cloud = { revision: fixture.cloud.revision + 1, skills: [reference] };
+        const journalPath = writeFinalizeJournalFixture({
+          runtimeRoot: fixture.runtimeRoot,
+          skillsRoot: fixture.skillsRoot,
+          botId: fixture.botId,
+          before,
+          after,
+          reference,
+          previousSkill,
+          nextSkill,
+          previousMarker,
+        });
+        let expectedPath = before.path;
+        if (action === 'rename') {
+          fs.writeFileSync(
+            skillFile,
+            nextSkill.replace(`name: ${originalName}`, `name: ${originalName}-renamed`),
+            'utf8',
+          );
+        } else if (action === 'move') {
+          expectedPath = `${before.path}-moved`;
+          fs.renameSync(before.path, expectedPath);
+        } else {
+          fs.rmSync(before.path, { recursive: true, force: true });
+        }
+        const uploadsBeforeRecovery = fixture.uploads;
+
+        await fixture.sync();
+
+        assert.equal(fs.existsSync(journalPath), false);
+        assert.equal(fixture.cloud.skills.some(item => item.skillId === reference.skillId), false);
+        if (action === 'delete') {
+          assert.equal(scanBotSkillWorkspace(fixture.skillsRoot).length, 0);
+          assert.equal(fixture.uploads, uploadsBeforeRecovery);
+          return;
+        }
+        const current = scanBotSkillWorkspace(fixture.skillsRoot).find(entry => (
+          entry.localSkillId === before.localSkillId
+        ));
+        assert.ok(current);
+        assert.equal(current.path, expectedPath);
+        assert.equal(current.name, action === 'rename' ? `${originalName}-renamed` : originalName);
+        assert.equal(fixture.uploads, uploadsBeforeRecovery + 1);
+      });
+    }
+  });
+
+  test('waits for a delayed public package and times out without changing Local or Base', async () => {
+    const fixture = createFixture(roots);
+    writeSkill(fixture.skillsRoot, 'shared-delay', 'shared-delay', 'delayed package');
+    const target = scanLocalBotSkill(path.join(fixture.skillsRoot, 'shared-delay'));
+    const metadata = {
+      author: 'alice',
+      version: '1.0.0',
+      uploadedAt: '2026-08-06T00:00:00.000Z',
+    };
+    const publicRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-public-delay-'));
+    roots.push(publicRoot);
+    writeSkill(publicRoot, 'shared-delay', 'shared-delay', 'delayed package');
+    const publicSkillFile = path.join(publicRoot, 'shared-delay', 'SKILL.md');
+    fs.writeFileSync(
+      publicSkillFile,
+      applySkillHubLocalMetadata(fs.readFileSync(publicSkillFile, 'utf8'), metadata),
+    );
+    const published = scanLocalBotSkill(path.join(publicRoot, 'shared-delay'));
+    const reference = {
+      source: 'skillhub' as const,
+      skillId: 'alice/shared-delay',
+      version: metadata.version,
+      contentHash: published.contentHash,
+    };
+    const publicPackage: BotSkillPackage = {
+      schema: 'catsco.private-skill-package.v1',
+      source: 'public',
+      reference: { skillId: reference.skillId, version: reference.version },
+      localSkillId: target.localSkillId,
+      name: target.name,
+      contentHash: reference.contentHash,
+      createdAt: metadata.uploadedAt,
+      files: published.files,
+    };
+    delete (publicPackage as Partial<BotSkillPackage>).schema;
+    fixture.packages.set(refKey(reference), publicPackage);
+    fixture.cloud = { revision: 1, skills: [reference] };
+    fixture.publicDownloadMisses = 1;
+
+    const ready = await fixture.finalize({
+      localSkillId: target.localSkillId,
+      skillName: target.name,
+      reference,
+    }, { publicationWaitMs: 100, pollDelayMs: 25 });
+    assert.equal(ready.direction, 'local_to_cloud');
+    assert.deepEqual(readBotSkillLocalMarker(target.path)?.reference, reference);
+
+    const timeoutFixture = createFixture(roots);
+    writeSkill(timeoutFixture.skillsRoot, 'shared-timeout', 'shared-timeout', 'never ready');
+    const timeoutTarget = scanLocalBotSkill(path.join(timeoutFixture.skillsRoot, 'shared-timeout'));
+    const timeoutRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-public-timeout-'));
+    roots.push(timeoutRoot);
+    writeSkill(timeoutRoot, 'shared-timeout', 'shared-timeout', 'never ready');
+    const timeoutSkillFile = path.join(timeoutRoot, 'shared-timeout', 'SKILL.md');
+    fs.writeFileSync(
+      timeoutSkillFile,
+      applySkillHubLocalMetadata(fs.readFileSync(timeoutSkillFile, 'utf8'), metadata),
+    );
+    const timeoutPublished = scanLocalBotSkill(path.join(timeoutRoot, 'shared-timeout'));
+    const timeoutReference = {
+      source: 'skillhub' as const,
+      skillId: 'alice/shared-timeout',
+      version: metadata.version,
+      contentHash: timeoutPublished.contentHash,
+    };
+    const timeoutPackage: BotSkillPackage = {
+      schema: 'catsco.private-skill-package.v1',
+      source: 'public',
+      reference: { skillId: timeoutReference.skillId, version: timeoutReference.version },
+      localSkillId: timeoutTarget.localSkillId,
+      name: timeoutTarget.name,
+      contentHash: timeoutReference.contentHash,
+      createdAt: metadata.uploadedAt,
+      files: timeoutPublished.files,
+    };
+    delete (timeoutPackage as Partial<BotSkillPackage>).schema;
+    timeoutFixture.packages.set(refKey(timeoutReference), timeoutPackage);
+    timeoutFixture.cloud = { revision: 1, skills: [timeoutReference] };
+    timeoutFixture.publicDownloadMisses = 100;
+    const previousSkill = fs.readFileSync(path.join(timeoutTarget.path, 'SKILL.md'), 'utf8');
+    const previousMarker = fs.readFileSync(path.join(timeoutTarget.path, '.xiaoba-bot-skill.json'), 'utf8');
+
+    await assert.rejects(
+      timeoutFixture.finalize({
+        localSkillId: timeoutTarget.localSkillId,
+        skillName: timeoutTarget.name,
+        reference: timeoutReference,
+      }, { publicationWaitMs: 30, pollDelayMs: 25 }),
+      (error: any) => error?.code === 'PUBLIC_SKILL_NOT_READY',
+    );
+    assert.equal(fs.readFileSync(path.join(timeoutTarget.path, 'SKILL.md'), 'utf8'), previousSkill);
+    assert.equal(fs.readFileSync(path.join(timeoutTarget.path, '.xiaoba-bot-skill.json'), 'utf8'), previousMarker);
+    assert.equal(new BotSkillBaseStore(timeoutFixture.runtimeRoot).read(timeoutFixture.botId), undefined);
   });
 
   test('protects a local edit when Local and Cloud both changed and retries one Definition revision conflict', async () => {
@@ -447,8 +1322,10 @@ function createFixture(
     uploads: 0,
     patches: 0,
     conflictNextPatch: false,
+    removeSkillsOnConflict: false,
     cloudReadStatus: 200,
     patchStatus: 200,
+    publicDownloadMisses: 0,
     omitSkillsField: false,
     cloudModel: { kind: 'catalog', modelId: 'minimax-m3' } as BotDefinition['model'],
     cloudPrompt: { selected: 'default' } as NonNullable<BotDefinition['prompt']>,
@@ -466,6 +1343,28 @@ function createFixture(
       skillHubBaseUrl: 'https://hub.test',
       definitionService,
     }).sync(),
+    finalize: async (input: {
+      localSkillId: string;
+      skillName: string;
+      reference: BotSkillRef;
+    }, options: {
+      validateScope?: () => Promise<void> | void;
+      publicationWaitMs?: number;
+      pollDelayMs?: number;
+    } = {}) => new BotSkillSyncService({
+      runtimeRoot,
+      skillsRoot,
+      botId,
+      workspaceExisted: true,
+      auth: {
+        apiKey: 'bot-key',
+        httpBaseUrl: 'https://cats.test',
+        serverUrl: 'wss://cats.test',
+      },
+      fetchImpl,
+      skillHubBaseUrl: 'https://hub.test',
+      definitionService,
+    }).finalizePublicSkill(input, { publicationWaitMs: 0, ...options }),
   };
 
   async function fetchImpl(input: string | URL | Request, init?: RequestInit): Promise<Response> {
@@ -506,6 +1405,7 @@ function createFixture(
         fixture.cloud = {
           ...fixture.cloud,
           revision: fixture.cloud.revision + 1,
+          ...(fixture.removeSkillsOnConflict ? { skills: [] } : {}),
         };
         return Response.json(
           { error: 'stale', currentRevision: fixture.cloud.revision },
@@ -554,6 +1454,10 @@ function createFixture(
         url.pathname.includes(item.reference.version)
         && url.pathname.includes(item.reference.skillId.split('/').at(-1) || '')
       ));
+      if (packageValue?.source === 'public' && fixture.publicDownloadMisses > 0) {
+        fixture.publicDownloadMisses -= 1;
+        return Response.json({ error: 'not ready' }, { status: 404 });
+      }
       return packageValue
         ? Response.json(packageValue)
         : Response.json({ error: 'not found' }, { status: 404 });
@@ -562,6 +1466,43 @@ function createFixture(
   }
 
   return fixture;
+}
+
+function writeFinalizeJournalFixture(input: {
+  runtimeRoot: string;
+  skillsRoot: string;
+  botId: string;
+  before: LocalBotSkillManifestEntry;
+  after: LocalBotSkillManifestEntry;
+  reference: BotSkillRef;
+  previousSkill: string;
+  nextSkill?: string;
+  previousMarker: string;
+}): string {
+  const journalDirectory = path.join(
+    input.runtimeRoot,
+    'data',
+    'bot-skills',
+    'finalize-journal',
+    input.botId,
+  );
+  fs.mkdirSync(journalDirectory, { recursive: true });
+  const journalPath = path.join(journalDirectory, `${input.after.localSkillId}.json`);
+  fs.writeFileSync(journalPath, `${JSON.stringify({
+    schema: 'xiaoba.bot-skill-finalize-journal.v1',
+    botId: input.botId,
+    skillsRoot: input.skillsRoot,
+    skillPath: input.after.path,
+    localSkillId: input.after.localSkillId,
+    skillName: input.after.name,
+    previousContentHash: input.before.contentHash,
+    nextContentHash: input.after.contentHash,
+    reference: input.reference,
+    previousSkill: input.previousSkill,
+    nextSkill: input.nextSkill ?? fs.readFileSync(path.join(input.after.path, 'SKILL.md'), 'utf8'),
+    previousMarker: input.previousMarker,
+  }, null, 2)}\n`, 'utf8');
+  return journalPath;
 }
 
 function writeSkill(root: string, directory: string, name: string, body: string): void {

--- a/tests/bot-skills-sync.test.ts
+++ b/tests/bot-skills-sync.test.ts
@@ -366,7 +366,7 @@ describe('Bot Skill Local/Base/Cloud sync', () => {
       }, {
         validateScope: () => {
           scopeChecks += 1;
-          if (scopeChecks === 1) {
+          if (scopeChecks === 2) {
             fs.writeFileSync(skillFile, skillText('shared-new', 'edited while publishing'));
           }
         },
@@ -428,7 +428,7 @@ describe('Bot Skill Local/Base/Cloud sync', () => {
       }, {
         validateScope: () => {
           scopeChecks += 1;
-          if (scopeChecks === 2) {
+          if (scopeChecks === 3) {
             fixture.cloud = { revision: 2, skills: [] };
           }
         },
@@ -499,6 +499,76 @@ describe('Bot Skill Local/Base/Cloud sync', () => {
       fixture.botId,
       `${target.localSkillId}.json`,
     )), false);
+  });
+
+  test('halts a real public finalize before its cloud CAS when shutdown starts during package validation', async () => {
+    const fixture = createFixture(roots);
+    writeSkill(fixture.skillsRoot, 'shutdown-finalize', 'shutdown-finalize', 'published body');
+    const skillFile = path.join(fixture.skillsRoot, 'shutdown-finalize', 'SKILL.md');
+    const metadata = {
+      author: 'alice',
+      version: '1.0.0',
+      uploadedAt: '2026-08-06T00:00:00.000Z',
+    };
+    fs.writeFileSync(
+      skillFile,
+      applySkillHubLocalMetadata(fs.readFileSync(skillFile, 'utf8'), metadata),
+    );
+    await fixture.sync();
+    const target = scanLocalBotSkill(path.join(fixture.skillsRoot, 'shutdown-finalize'));
+    const privateReference = fixture.cloud.skills[0];
+    const publicReference = {
+      source: 'skillhub' as const,
+      skillId: 'alice/shutdown-finalize',
+      version: metadata.version,
+      contentHash: target.contentHash,
+    };
+    const publicPackage: BotSkillPackage = {
+      schema: 'catsco.private-skill-package.v1',
+      source: 'public',
+      reference: { skillId: publicReference.skillId, version: publicReference.version },
+      localSkillId: target.localSkillId,
+      name: target.name,
+      contentHash: target.contentHash,
+      createdAt: metadata.uploadedAt,
+      files: target.files,
+    };
+    delete (publicPackage as Partial<BotSkillPackage>).schema;
+    fixture.packages.set(refKey(publicReference), publicPackage);
+    fixture.cloud = {
+      revision: fixture.cloud.revision + 1,
+      skills: [privateReference, publicReference],
+    };
+    fixture.packageDownloads = 0;
+    const previousSkill = fs.readFileSync(skillFile, 'utf8');
+    const markerFile = path.join(target.path, BOT_SKILL_LOCAL_MARKER_FILE);
+    const previousMarker = fs.readFileSync(markerFile, 'utf8');
+    const previousBase = new BotSkillBaseStore(fixture.runtimeRoot).read(fixture.botId);
+    const previousCloud = structuredClone(fixture.cloud);
+    const previousPatches = fixture.patches;
+    let shuttingDown = false;
+
+    await assert.rejects(
+      fixture.finalize({
+        localSkillId: target.localSkillId,
+        skillName: target.name,
+        reference: publicReference,
+      }, {
+        validateScope: () => {
+          // The first public download is publication readiness; the second is
+          // pushLocal's marker verification. Shutdown starts during that await.
+          if (fixture.packageDownloads >= 2) shuttingDown = true;
+          if (shuttingDown) throw new Error('connector shutdown');
+        },
+      }),
+      /connector shutdown/i,
+    );
+
+    assert.equal(fs.readFileSync(skillFile, 'utf8'), previousSkill);
+    assert.equal(fs.readFileSync(markerFile, 'utf8'), previousMarker);
+    assert.deepEqual(new BotSkillBaseStore(fixture.runtimeRoot).read(fixture.botId), previousBase);
+    assert.deepEqual(fixture.cloud, previousCloud);
+    assert.equal(fixture.patches, previousPatches);
   });
 
   test('recovers a public reference after a crash between SKILL.md and marker writes', async () => {
@@ -1326,6 +1396,7 @@ function createFixture(
     cloudReadStatus: 200,
     patchStatus: 200,
     publicDownloadMisses: 0,
+    packageDownloads: 0,
     omitSkillsField: false,
     cloudModel: { kind: 'catalog', modelId: 'minimax-m3' } as BotDefinition['model'],
     cloudPrompt: { selected: 'default' } as NonNullable<BotDefinition['prompt']>,
@@ -1450,6 +1521,7 @@ function createFixture(
     }
     if (url.hostname === 'hub.test' && method === 'GET') {
       assert.equal(new Headers(init?.headers).get('X-CatsCo-Bot-Id'), botId);
+      fixture.packageDownloads += 1;
       const packageValue = [...fixture.packages.values()].find(item => (
         url.pathname.includes(item.reference.version)
         && url.pathname.includes(item.reference.skillId.split('/').at(-1) || '')

--- a/tests/catscompany-device-rpc-tools.test.ts
+++ b/tests/catscompany-device-rpc-tools.test.ts
@@ -595,6 +595,7 @@ describe('CatsCompany Device RPC file tools', () => {
         captured.result = result;
       },
     };
+    bot.skillHubThinRpc = { supports: () => false };
     bot.executeLocalThinToolRpcTool = async () => {
       bot.shuttingDown = true;
       return { ok: true, content: 'executed' };

--- a/tests/catscompany-device-rpc-tools.test.ts
+++ b/tests/catscompany-device-rpc-tools.test.ts
@@ -614,4 +614,36 @@ describe('CatsCompany Device RPC file tools', () => {
 
     assert.equal(captured.result, undefined, 'late thin-tool RPC result must not be sent after shutdown started');
   });
+
+  test('drops a late SkillHub thin-tool RPC result when shutdown starts during execution', async () => {
+    const captured: { result?: any } = {};
+    const bot = Object.create(CatsCompanyBot.prototype) as any;
+    bot.shuttingDown = false;
+    bot.bot = {
+      sendThinToolRpcResult: async (result: any) => {
+        captured.result = result;
+      },
+    };
+    bot.skillHubThinRpc = {
+      supports: () => true,
+      execute: async () => {
+        bot.shuttingDown = true;
+        return { bot_uid: '42' };
+      },
+    };
+
+    await bot.handleThinToolRpcRequest({
+      type: 'request',
+      request_id: 'rpc-late-skillhub-1',
+      tool_name: 'skillhub.localWorkspace.get',
+      target_owner_user_id: 'usr7',
+      target_device_id: 'install-remote',
+      device_id: 'install-device',
+      payload: { bot_uid: '42' },
+      created_at: Date.now(),
+      expires_at: Date.now() + 60_000,
+    } as any);
+
+    assert.equal(captured.result, undefined, 'late SkillHub RPC result must not be sent after shutdown started');
+  });
 });

--- a/tests/catscompany-runtime-device-capabilities.test.ts
+++ b/tests/catscompany-runtime-device-capabilities.test.ts
@@ -13,6 +13,10 @@ describe('CatsCompany runtime device capabilities', () => {
       'edit_file',
       'send_file',
       'execute_shell',
+      'skillhub.localWorkspace.get',
+      'skillhub.localSkill.share',
+      'skillhub.localSkill.finalize',
+      'skillhub.localBot.switch',
     ]);
   });
 });

--- a/tests/catscompany-skillhub-rpc.test.ts
+++ b/tests/catscompany-skillhub-rpc.test.ts
@@ -14,7 +14,10 @@ import { BotSkillWorkspaceService } from '../src/bot-skills/workspace';
 import { shareLocalSkillForCatsCo } from '../src/skillhub/local-share';
 import { scanBotSkillWorkspace } from '../src/bot-skills/local-manifest';
 import { writeBotSkillLocalMarker } from '../src/bot-skills/local-manifest';
-import { applySkillHubLocalMetadata } from '../src/skillhub/local-skill-metadata';
+import {
+  applySkillHubLocalMetadata,
+  readSkillHubLocalMetadata,
+} from '../src/skillhub/local-skill-metadata';
 
 describe('CatsCompany SkillHub thin RPC', () => {
   let runtimeRoot = '';
@@ -238,6 +241,7 @@ describe('CatsCompany SkillHub thin RPC', () => {
     assert.equal((shareResult?.skill as Record<string, unknown>)?.id, 'alice/local-demo');
     assert.equal(shareResult?.latest_version, '2.0.0');
     assert.equal(shareResult?.content_hash, 'a'.repeat(64));
+    assert.equal(readSkillHubLocalMetadata(path.join(selected.path, 'SKILL.md')), null);
   });
 
   test('rejects a Bot switch when the local Dashboard returns a non-success status', async () => {
@@ -272,6 +276,75 @@ describe('CatsCompany SkillHub thin RPC', () => {
       }),
       (error: any) => error?.code === 'skillhub.share_local_skill_changed',
     );
+  });
+
+  test('writes share metadata only after revalidating the selected local Skill and scope', async () => {
+    const selected = scanBotSkillWorkspace(path.join(runtimeRoot, 'skills'))[0];
+    const skillFile = path.join(selected.path, 'SKILL.md');
+    const metadata = {
+      author: 'alice',
+      version: '1.0.0',
+      uploadedAt: '2026-08-06T00:00:00.000Z',
+    };
+    const originalFetch = global.fetch;
+    let scopeValidations = 0;
+    global.fetch = async (input: string | URL | Request) => {
+      const url = new URL(String(input));
+      if (url.pathname === '/api/auth/catsco-exchange') {
+        return Response.json({
+          user: { id: 'skillhub-user' },
+          roles: ['developer'],
+          permissions: [],
+          catsCo: { uid: '7', username: 'alice', displayName: 'Alice' },
+        });
+      }
+      if (url.pathname === '/api/auth/me') {
+        return Response.json({
+          user: { id: 'skillhub-user' },
+          roles: ['developer'],
+          permissions: [],
+        });
+      }
+      if (url.pathname === '/api/skills/share') {
+        return Response.json({
+          skillId: 'alice/local-demo',
+          packageVersion: {
+            skillId: 'alice/local-demo',
+            version: metadata.version,
+            contentHash: 'b'.repeat(64),
+          },
+          skillHub: metadata,
+        }, { status: 201 });
+      }
+      return Response.json({ error: 'unexpected request' }, { status: 500 });
+    };
+    let result: Record<string, any>;
+    try {
+      result = await shareLocalSkillForCatsCo({
+        skillName: selected.name,
+        expectedLocalSkillId: selected.localSkillId,
+        expectedBotUid: '42',
+        expectedUserUid: '7',
+      }, {
+        runtimeRoot,
+        getCatsCoAuth: () => ({
+          token: 'user-token',
+          baseUrl: 'https://app.catsco.cc',
+          user: { uid: '7', username: 'alice' },
+        }),
+        validateScope: () => {
+          scopeValidations += 1;
+          assert.equal(readSkillHubLocalMetadata(skillFile), null);
+        },
+      });
+    } finally {
+      global.fetch = originalFetch;
+    }
+
+    assert.equal(scopeValidations, 2);
+    assert.equal(result.botUid, '42');
+    assert.deepEqual(result.skillHub, metadata);
+    assert.deepEqual(readSkillHubLocalMetadata(skillFile), metadata);
   });
 
   test('finalizes only when sync still belongs to the requested Bot', async () => {

--- a/tests/catscompany-skillhub-rpc.test.ts
+++ b/tests/catscompany-skillhub-rpc.test.ts
@@ -371,6 +371,69 @@ describe('CatsCompany SkillHub thin RPC', () => {
     );
   });
 
+  test('rejects sensitive files that appear after the initial share scope check', async () => {
+    const selected = scanBotSkillWorkspace(path.join(runtimeRoot, 'skills'))[0];
+    const sensitiveFiles = [
+      { name: '.env', content: 'API_KEY=not-a-real-secret\n' },
+      { name: 'private.pem', content: '-----BEGIN PRIVATE KEY-----\nplaceholder\n' },
+      { name: 'archive.zip', content: Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x00, 0x00]) },
+      { name: 'config.txt', content: 'access_token=ghp_123456789012345678901234567890\n' },
+    ];
+
+    for (const sensitiveFile of sensitiveFiles) {
+      const sensitivePath = path.join(selected.path, sensitiveFile.name);
+      const originalFetch = global.fetch;
+      let shareCalls = 0;
+      global.fetch = async (input: string | URL | Request, init?: RequestInit) => {
+        const url = new URL(String(input));
+        if (url.pathname === '/api/auth/catsco-exchange') {
+          fs.writeFileSync(sensitivePath, sensitiveFile.content);
+          return Response.json({
+            user: { id: 'skillhub-user' },
+            roles: ['developer'],
+            permissions: [],
+            catsCo: { uid: '7', username: 'alice', displayName: 'Alice' },
+          });
+        }
+        if (url.pathname === '/api/auth/me') {
+          return Response.json({
+            user: { id: 'skillhub-user' },
+            roles: ['developer'],
+            permissions: [],
+          });
+        }
+        if (url.pathname === '/api/skills/share') {
+          shareCalls += 1;
+          return Response.json({ error: 'share should not be reached' }, { status: 500 });
+        }
+        return Response.json({ error: `unexpected request: ${url.pathname}` }, { status: 500 });
+      };
+      try {
+        await assert.rejects(
+          shareLocalSkillForCatsCo({
+            skillName: selected.name,
+            expectedLocalSkillId: selected.localSkillId,
+            expectedBotUid: '42',
+            expectedUserUid: '7',
+          }, {
+            writeLocalMetadata: false,
+            runtimeRoot,
+            getCatsCoAuth: () => ({
+              token: 'user-token',
+              baseUrl: 'https://app.catsco.cc',
+              user: { uid: '7', username: 'alice' },
+            }),
+          }),
+          /(?:sensitive material|archive file)/i,
+        );
+      } finally {
+        global.fetch = originalFetch;
+        fs.rmSync(sensitivePath, { force: true });
+      }
+      assert.equal(shareCalls, 0, `remote share was called for ${sensitiveFile.name}`);
+    }
+  });
+
   test('finalizes only when sync still belongs to the requested Bot', async () => {
     const localEntry = scanBotSkillWorkspace(path.join(runtimeRoot, 'skills'))[0];
     const reference = {

--- a/tests/catscompany-skillhub-rpc.test.ts
+++ b/tests/catscompany-skillhub-rpc.test.ts
@@ -1,0 +1,390 @@
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { createCatsCoLocalConfigService } from '../src/catscompany/local-config';
+import {
+  SkillHubThinRpcError,
+  SkillHubThinRpcHandler,
+  SKILLHUB_THIN_RPC_TOOLS,
+  requestDashboardBotSwitch,
+} from '../src/catscompany/skillhub-rpc';
+import { BotSkillWorkspaceService } from '../src/bot-skills/workspace';
+import { shareLocalSkillForCatsCo } from '../src/skillhub/local-share';
+import { scanBotSkillWorkspace } from '../src/bot-skills/local-manifest';
+import { writeBotSkillLocalMarker } from '../src/bot-skills/local-manifest';
+import { applySkillHubLocalMetadata } from '../src/skillhub/local-skill-metadata';
+
+describe('CatsCompany SkillHub thin RPC', () => {
+  let runtimeRoot = '';
+  let scheduledBotUIDs: string[] = [];
+  let handler: SkillHubThinRpcHandler;
+
+  beforeEach(() => {
+    runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-skillhub-rpc-'));
+    const skillsRoot = path.join(runtimeRoot, 'skills');
+    fs.mkdirSync(path.join(skillsRoot, 'local-demo'), { recursive: true });
+    fs.writeFileSync(path.join(skillsRoot, 'local-demo', 'SKILL.md'), [
+      '---',
+      'name: local-demo',
+      'description: Local demo description',
+      '---',
+      '',
+      '# Local Demo',
+      '',
+    ].join('\n'));
+    new BotSkillWorkspaceService(runtimeRoot, skillsRoot).activate('42');
+    createCatsCoLocalConfigService({ runtimeRoot }).save({
+      version: 1,
+      account: { token: 'user-token', uid: '7', username: 'alice' },
+      currentBot: {
+        uid: '42',
+        apiKey: 'bot-key',
+        boundByUserUid: '7',
+      },
+      device: {
+        deviceId: 'alice-device',
+        bodyId: 'alice-device',
+        installationId: 'alice-device',
+      },
+    });
+    scheduledBotUIDs = [];
+    handler = new SkillHubThinRpcHandler({
+      runtimeRoot,
+      scheduleBotSwitch: (botUid) => scheduledBotUIDs.push(botUid),
+    });
+  });
+
+  afterEach(() => {
+    fs.rmSync(runtimeRoot, { recursive: true, force: true });
+  });
+
+  test('returns only bounded metadata for the active Bot workspace', async () => {
+    const result = await handler.execute(request({
+      request_id: 'workspace-1',
+      tool_name: SKILLHUB_THIN_RPC_TOOLS.workspace,
+    }));
+    assert.equal(result.schema, 'xiaoba.skillhub.local_workspace.v1');
+    assert.equal(result.bot_uid, '42');
+    assert.equal(result.skills_path, path.join(runtimeRoot, 'skills'));
+    const skills = result.skills as Array<Record<string, unknown>>;
+    assert.equal(skills.length, 1);
+    assert.equal(skills[0].name, 'local-demo');
+    assert.equal(skills[0].relative_path, 'local-demo');
+    assert.equal(Object.prototype.hasOwnProperty.call(skills[0], 'path'), false);
+    assert.equal(JSON.stringify(result).includes('# Local Demo'), false);
+  });
+
+  test('rejects another owner, device, inactive Bot, and expired requests', async () => {
+    await assert.rejects(
+      handler.execute(request({ request_id: 'owner', target_owner_user_id: 'usr8' })),
+      (error: any) => error instanceof SkillHubThinRpcError && error.code === 'OWNER_MISMATCH',
+    );
+    await assert.rejects(
+      handler.execute(request({ request_id: 'device', target_device_id: 'other-device' })),
+      (error: any) => error instanceof SkillHubThinRpcError && error.code === 'DEVICE_MISMATCH',
+    );
+    await assert.rejects(
+      handler.execute(request({ request_id: 'bot', payload: { bot_uid: '44' } })),
+      (error: any) => error instanceof SkillHubThinRpcError && error.code === 'BOT_NOT_ACTIVE',
+    );
+    await assert.rejects(
+      handler.execute(request({ request_id: 'expired', expires_at: Date.now() - 1 })),
+      (error: any) => error instanceof SkillHubThinRpcError && error.code === 'REQUEST_EXPIRED',
+    );
+  });
+
+  test('schedules an explicit Bot switch once for a replayed request', async () => {
+    const switchRequest = request({
+      request_id: 'switch-1',
+      tool_name: SKILLHUB_THIN_RPC_TOOLS.switchBot,
+      payload: { bot_uid: '44' },
+    });
+    const first = await handler.execute(switchRequest);
+    const second = await handler.execute(switchRequest);
+    assert.equal(first.switching, true);
+    assert.deepEqual(second, first);
+    assert.deepEqual(scheduledBotUIDs, ['44']);
+  });
+
+  test('rejects reuse of one request ID for a different operation', async () => {
+    await handler.execute(request({ request_id: 'reused-request' }));
+    await assert.rejects(
+      handler.execute(request({
+        request_id: 'reused-request',
+        tool_name: SKILLHUB_THIN_RPC_TOOLS.switchBot,
+        payload: { bot_uid: '44' },
+      })),
+      (error: any) => error instanceof SkillHubThinRpcError && error.code === 'REQUEST_ID_CONFLICT',
+    );
+  });
+
+  test('revalidates the current local owner before returning a cached RPC result', async () => {
+    const replayed = request({ request_id: 'owner-replay' });
+    await handler.execute(replayed);
+    const configService = createCatsCoLocalConfigService({ runtimeRoot });
+    const config = configService.load();
+    configService.save({
+      ...config,
+      account: { ...config.account, uid: '8' },
+      currentBot: { ...config.currentBot!, boundByUserUid: '8' },
+    });
+    await assert.rejects(
+      handler.execute(replayed),
+      (error: any) => error instanceof SkillHubThinRpcError && error.code === 'OWNER_MISMATCH',
+    );
+  });
+
+  test('marks a previously public Skill shareable again after local edits', async () => {
+    const entry = scanBotSkillWorkspace(path.join(runtimeRoot, 'skills'))[0];
+    const skillFile = path.join(entry.path, 'SKILL.md');
+    fs.writeFileSync(skillFile, applySkillHubLocalMetadata(fs.readFileSync(skillFile, 'utf8'), {
+      author: 'alice',
+      version: '1.0.0',
+      uploadedAt: '2026-08-06T00:00:00.000Z',
+    }));
+    const canonical = scanBotSkillWorkspace(path.join(runtimeRoot, 'skills'))[0];
+    writeBotSkillLocalMarker(canonical.path, {
+      schema: 'xiaoba.bot-skill-local.v1',
+      localSkillId: canonical.localSkillId,
+      reference: {
+        source: 'skillhub',
+        skillId: 'alice/local-demo',
+        version: '1.0.0',
+        contentHash: canonical.contentHash,
+      },
+      origin: { skillId: 'alice/local-demo', version: '1.0.0' },
+    });
+    fs.appendFileSync(skillFile, '\nLocal edit\n');
+
+    const result = await handler.execute(request({ request_id: 'workspace-edited-public' }));
+    const skills = result.skills as Array<Record<string, unknown>>;
+    assert.equal(skills[0].can_share, true);
+  });
+
+  test('shares the exact local Skill selected by local_skill_id when names collide', async () => {
+    const secondRoot = path.join(runtimeRoot, 'skills', 'second-demo');
+    fs.mkdirSync(secondRoot, { recursive: true });
+    fs.writeFileSync(path.join(secondRoot, 'SKILL.md'), [
+      '---',
+      'name: local-demo',
+      'description: Second local demo',
+      '---',
+      '',
+      '# Second Local Demo',
+      '',
+    ].join('\n'));
+    const selected = scanBotSkillWorkspace(path.join(runtimeRoot, 'skills'))
+      .find(entry => entry.installName === 'second-demo');
+    assert.ok(selected);
+    const originalFetch = global.fetch;
+    let uploadedSkill = '';
+    let shareResult: Record<string, unknown> | undefined;
+    global.fetch = async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(String(input));
+      if (url.pathname === '/api/auth/catsco-exchange') {
+        return Response.json({
+          user: { id: 'skillhub-user' },
+          roles: ['developer'],
+          permissions: [],
+          catsCo: { uid: '7', username: 'alice', displayName: 'Alice' },
+        });
+      }
+      if (url.pathname === '/api/auth/me') {
+        return Response.json({
+          user: { id: 'skillhub-user' },
+          roles: ['developer'],
+          permissions: [],
+        });
+      }
+      if (url.pathname === '/api/skills/share') {
+        const body = JSON.parse(String(init?.body || '{}'));
+        assert.equal(body.confirmVersionPublish, true);
+        const skillFile = body.source.files.find((file: any) => file.path === 'SKILL.md');
+        uploadedSkill = Buffer.from(skillFile.contentBase64, 'base64').toString('utf8');
+        return Response.json({
+          skillId: 'alice/local-demo',
+          packageVersion: {
+            skillId: 'alice/local-demo',
+            version: '2.0.0',
+            contentHash: 'a'.repeat(64),
+          },
+          skillHub: {
+            author: 'alice',
+            version: '2.0.0',
+            uploadedAt: '2026-08-06T00:00:00.000Z',
+          },
+        }, { status: 201 });
+      }
+      return Response.json({ error: 'unexpected request' }, { status: 500 });
+    };
+    try {
+      shareResult = await handler.execute(request({
+        request_id: 'share-second-demo',
+        tool_name: SKILLHUB_THIN_RPC_TOOLS.share,
+        payload: {
+          bot_uid: '42',
+          local_skill_id: selected.localSkillId,
+          skill_name: selected.name,
+          confirm_publish: true,
+        },
+      }));
+    } finally {
+      global.fetch = originalFetch;
+    }
+    assert.match(uploadedSkill, /# Second Local Demo/);
+    assert.doesNotMatch(uploadedSkill, /# Local Demo/);
+    assert.equal((shareResult?.skill as Record<string, unknown>)?.id, 'alice/local-demo');
+    assert.equal(shareResult?.latest_version, '2.0.0');
+    assert.equal(shareResult?.content_hash, 'a'.repeat(64));
+  });
+
+  test('rejects a Bot switch when the local Dashboard returns a non-success status', async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    await assert.rejects(
+      requestDashboardBotSwitch('44', async (url, init) => {
+        calls.push({ url: String(url), init });
+        return new Response('', { status: 503 });
+      }),
+      /HTTP 503/,
+    );
+    assert.equal(calls.length, 1);
+    assert.match(calls[0].url, /^http:\/\/127\.0\.0\.1:\d+\/api\/cats\/switch-bot$/);
+    assert.deepEqual(JSON.parse(String(calls[0].init?.body)), { botUid: '44' });
+  });
+
+  test('revalidates the local Skill identity while holding the upload lock', async () => {
+    await assert.rejects(
+      shareLocalSkillForCatsCo({
+        skillName: 'local-demo',
+        expectedLocalSkillId: 'replaced-local-skill',
+        expectedBotUid: '42',
+        expectedUserUid: '7',
+      }, {
+        writeLocalMetadata: false,
+        runtimeRoot,
+        getCatsCoAuth: () => ({
+          token: 'user-token',
+          baseUrl: 'https://app.catsco.cc',
+          user: { uid: '7', username: 'alice' },
+        }),
+      }),
+      (error: any) => error?.code === 'skillhub.share_local_skill_changed',
+    );
+  });
+
+  test('finalizes only when sync still belongs to the requested Bot', async () => {
+    const localEntry = scanBotSkillWorkspace(path.join(runtimeRoot, 'skills'))[0];
+    const reference = {
+      source: 'skillhub' as const,
+      skillId: 'alice/local-demo',
+      version: '1.0.0',
+      contentHash: 'd'.repeat(64),
+    };
+    const finalizeHandler = new SkillHubThinRpcHandler({
+      runtimeRoot,
+      finalizeCurrentBotSkill: async (botUid, input, options) => {
+        assert.equal(botUid, '42');
+        assert.equal(input.localSkillId, localEntry.localSkillId);
+        assert.equal(input.skillName, localEntry.name);
+        assert.deepEqual(input.reference, reference);
+        await options.validateScope?.();
+        return {
+          botId: '42',
+          direction: 'local_to_cloud',
+          skills: [reference],
+        };
+      },
+    });
+    const result = await finalizeHandler.execute(request({
+      request_id: 'finalize-ok',
+      tool_name: SKILLHUB_THIN_RPC_TOOLS.finalize,
+      payload: {
+        bot_uid: '42',
+        local_skill_id: localEntry.localSkillId,
+        skill_name: localEntry.name,
+        skill_id: reference.skillId,
+        version: reference.version,
+        content_hash: reference.contentHash,
+      },
+    }));
+    assert.equal(result.direction, 'local_to_cloud');
+
+    const switchedHandler = new SkillHubThinRpcHandler({
+      runtimeRoot,
+      finalizeCurrentBotSkill: async () => ({
+        botId: '43',
+        direction: 'none',
+        skills: [reference],
+      }),
+    });
+    await assert.rejects(
+      switchedHandler.execute(request({
+        request_id: 'finalize-switched',
+        tool_name: SKILLHUB_THIN_RPC_TOOLS.finalize,
+        payload: {
+          bot_uid: '42',
+          local_skill_id: localEntry.localSkillId,
+          skill_name: localEntry.name,
+          skill_id: reference.skillId,
+          version: reference.version,
+          content_hash: reference.contentHash,
+        },
+      })),
+      (error: any) => error instanceof SkillHubThinRpcError && error.code === 'BOT_NOT_ACTIVE',
+    );
+  });
+
+  test('stops finalization when the device request expires during publication wait', async () => {
+    const localEntry = scanBotSkillWorkspace(path.join(runtimeRoot, 'skills'))[0];
+    const reference = {
+      source: 'skillhub' as const,
+      skillId: 'alice/local-demo',
+      version: '1.0.0',
+      contentHash: 'e'.repeat(64),
+    };
+    const expiringHandler = new SkillHubThinRpcHandler({
+      runtimeRoot,
+      finalizeCurrentBotSkill: async (_botUid, _input, options) => {
+        await new Promise(resolve => setTimeout(resolve, 20));
+        await options.validateScope?.();
+        return {
+          botId: '42',
+          direction: 'local_to_cloud',
+          skills: [reference],
+        };
+      },
+    });
+    await assert.rejects(
+      expiringHandler.execute(request({
+        request_id: 'finalize-expired-during-wait',
+        tool_name: SKILLHUB_THIN_RPC_TOOLS.finalize,
+        expires_at: Date.now() + 5,
+        payload: {
+          bot_uid: '42',
+          local_skill_id: localEntry.localSkillId,
+          skill_name: localEntry.name,
+          skill_id: reference.skillId,
+          version: reference.version,
+          content_hash: reference.contentHash,
+        },
+      })),
+      (error: any) => error instanceof SkillHubThinRpcError && error.code === 'REQUEST_EXPIRED',
+    );
+  });
+
+  function request(overrides: Record<string, any> = {}): any {
+    return {
+      type: 'request',
+      request_id: 'request-1',
+      target_owner_user_id: 'usr7',
+      target_device_id: 'alice-device',
+      device_id: 'alice-device',
+      tool_name: SKILLHUB_THIN_RPC_TOOLS.workspace,
+      payload: { bot_uid: '42' },
+      expires_at: Date.now() + 30_000,
+      ...overrides,
+    };
+  }
+});

--- a/tests/catscompany-skillhub-rpc.test.ts
+++ b/tests/catscompany-skillhub-rpc.test.ts
@@ -178,11 +178,24 @@ describe('CatsCompany SkillHub thin RPC', () => {
       '# Second Local Demo',
       '',
     ].join('\n'));
+    const nestedRoot = path.join(secondRoot, 'nested-skill');
+    fs.mkdirSync(nestedRoot, { recursive: true });
+    fs.writeFileSync(path.join(nestedRoot, 'SKILL.md'), [
+      '---',
+      'name: nested-skill',
+      'description: Independent nested Skill',
+      '---',
+      '',
+      '# Nested Skill',
+      '',
+    ].join('\n'));
+    fs.writeFileSync(path.join(nestedRoot, 'secret.txt'), 'must not be uploaded with the parent');
     const selected = scanBotSkillWorkspace(path.join(runtimeRoot, 'skills'))
       .find(entry => entry.installName === 'second-demo');
     assert.ok(selected);
     const originalFetch = global.fetch;
     let uploadedSkill = '';
+    let uploadedPaths: string[] = [];
     let shareResult: Record<string, unknown> | undefined;
     global.fetch = async (input: string | URL | Request, init?: RequestInit) => {
       const url = new URL(String(input));
@@ -204,6 +217,7 @@ describe('CatsCompany SkillHub thin RPC', () => {
       if (url.pathname === '/api/skills/share') {
         const body = JSON.parse(String(init?.body || '{}'));
         assert.equal(body.confirmVersionPublish, true);
+        uploadedPaths = body.source.files.map((file: any) => String(file.path));
         const skillFile = body.source.files.find((file: any) => file.path === 'SKILL.md');
         uploadedSkill = Buffer.from(skillFile.contentBase64, 'base64').toString('utf8');
         return Response.json({
@@ -238,6 +252,7 @@ describe('CatsCompany SkillHub thin RPC', () => {
     }
     assert.match(uploadedSkill, /# Second Local Demo/);
     assert.doesNotMatch(uploadedSkill, /# Local Demo/);
+    assert.equal(uploadedPaths.some(file => file.startsWith('nested-skill/')), false);
     assert.equal((shareResult?.skill as Record<string, unknown>)?.id, 'alice/local-demo');
     assert.equal(shareResult?.latest_version, '2.0.0');
     assert.equal(shareResult?.content_hash, 'a'.repeat(64));
@@ -281,6 +296,7 @@ describe('CatsCompany SkillHub thin RPC', () => {
   test('writes share metadata only after revalidating the selected local Skill and scope', async () => {
     const selected = scanBotSkillWorkspace(path.join(runtimeRoot, 'skills'))[0];
     const skillFile = path.join(selected.path, 'SKILL.md');
+    const movedSkillPath = path.join(runtimeRoot, 'skills', 'moved-local-demo');
     const metadata = {
       author: 'alice',
       version: '1.0.0',
@@ -306,6 +322,7 @@ describe('CatsCompany SkillHub thin RPC', () => {
         });
       }
       if (url.pathname === '/api/skills/share') {
+        fs.renameSync(selected.path, movedSkillPath);
         return Response.json({
           skillId: 'alice/local-demo',
           packageVersion: {
@@ -334,7 +351,10 @@ describe('CatsCompany SkillHub thin RPC', () => {
         }),
         validateScope: () => {
           scopeValidations += 1;
-          assert.equal(readSkillHubLocalMetadata(skillFile), null);
+          const currentSkillFile = fs.existsSync(skillFile)
+            ? skillFile
+            : path.join(movedSkillPath, 'SKILL.md');
+          assert.equal(readSkillHubLocalMetadata(currentSkillFile), null);
         },
       });
     } finally {
@@ -344,7 +364,11 @@ describe('CatsCompany SkillHub thin RPC', () => {
     assert.equal(scopeValidations, 2);
     assert.equal(result.botUid, '42');
     assert.deepEqual(result.skillHub, metadata);
-    assert.deepEqual(readSkillHubLocalMetadata(skillFile), metadata);
+    assert.equal(fs.existsSync(skillFile), false);
+    assert.deepEqual(
+      readSkillHubLocalMetadata(path.join(movedSkillPath, 'SKILL.md')),
+      metadata,
+    );
   });
 
   test('finalizes only when sync still belongs to the requested Bot', async () => {
@@ -445,6 +469,50 @@ describe('CatsCompany SkillHub thin RPC', () => {
       })),
       (error: any) => error instanceof SkillHubThinRpcError && error.code === 'REQUEST_EXPIRED',
     );
+  });
+
+  test('stops finalization writes when connector shutdown starts during the operation', async () => {
+    const localEntry = scanBotSkillWorkspace(path.join(runtimeRoot, 'skills'))[0];
+    const reference = {
+      source: 'skillhub' as const,
+      skillId: 'alice/local-demo',
+      version: '1.0.0',
+      contentHash: 'f'.repeat(64),
+    };
+    let shuttingDown = false;
+    let writes = 0;
+    const shutdownHandler = new SkillHubThinRpcHandler({
+      runtimeRoot,
+      isShuttingDown: () => shuttingDown,
+      finalizeCurrentBotSkill: async (_botUid, _input, options) => {
+        await Promise.resolve();
+        shuttingDown = true;
+        await options.validateScope?.();
+        writes += 1;
+        return {
+          botId: '42',
+          direction: 'local_to_cloud',
+          skills: [reference],
+        };
+      },
+    });
+
+    await assert.rejects(
+      shutdownHandler.execute(request({
+        request_id: 'finalize-shutdown',
+        tool_name: SKILLHUB_THIN_RPC_TOOLS.finalize,
+        payload: {
+          bot_uid: '42',
+          local_skill_id: localEntry.localSkillId,
+          skill_name: localEntry.name,
+          skill_id: reference.skillId,
+          version: reference.version,
+          content_hash: reference.contentHash,
+        },
+      })),
+      (error: any) => error instanceof SkillHubThinRpcError && error.code === 'SHUTTING_DOWN',
+    );
+    assert.equal(writes, 0);
   });
 
   function request(overrides: Record<string, any> = {}): any {

--- a/tests/dashboard-skillhub-connected-api.test.ts
+++ b/tests/dashboard-skillhub-connected-api.test.ts
@@ -138,6 +138,9 @@ describe('dashboard connected SkillHub API', () => {
     fs.writeFileSync(path.join(testRoot, 'skills', 'quick-demo', 'SBOM.json'), '{}\n');
     fs.writeFileSync(path.join(testRoot, 'skills', 'quick-demo', '.xiaoba-bundled-skill.json'), '{}\n');
     fs.writeFileSync(path.join(testRoot, 'skills', 'quick-demo', '.xiaoba-skillhub-install.json'), '{}\n');
+    fs.writeFileSync(path.join(testRoot, 'skills', 'quick-demo', '.xiaoba-bot-skill.json'), '{}\n');
+    fs.mkdirSync(path.join(testRoot, 'skills', 'quick-demo', '.ssh'), { recursive: true });
+    fs.writeFileSync(path.join(testRoot, 'skills', 'quick-demo', '.ssh', 'id_test'), 'private\n');
 
     const fixture = createFixture();
     await startCloud(fixture);
@@ -150,6 +153,12 @@ describe('dashboard connected SkillHub API', () => {
     assert.equal(share.body.ok, true);
     assert.equal(share.body.skill.id, 'lin/quick-demo');
     assert.equal(share.body.skill.name, 'quick-demo');
+    assert.equal(share.body.latestVersion, '1.0.0');
+    assert.deepEqual(share.body.skillHub, {
+      author: 'lin',
+      version: '1.0.0',
+      uploadedAt: '2026-05-28T00:00:00.000Z',
+    });
     assert.equal(share.body.submission.request.quickShare, true);
     assert.equal(share.body.submission.request.manifest.id, 'quick-demo');
     assert.equal(share.body.submission.request.manifest.name, 'quick-demo');
@@ -162,6 +171,8 @@ describe('dashboard connected SkillHub API', () => {
     assert.equal(uploadedPaths.includes('SBOM.json'), false);
     assert.equal(uploadedPaths.includes('.xiaoba-bundled-skill.json'), false);
     assert.equal(uploadedPaths.includes('.xiaoba-skillhub-install.json'), false);
+    assert.equal(uploadedPaths.includes('.xiaoba-bot-skill.json'), false);
+    assert.equal(uploadedPaths.some((value: string) => value.startsWith('.ssh/')), false);
     const skillText = fs.readFileSync(path.join(testRoot, 'skills', 'quick-demo', 'SKILL.md'), 'utf8');
     assert.match(skillText, /skillhub_author:\s+["']?lin["']?/);
     assert.match(skillText, /skillhub_version:\s+["']?1\.0\.0["']?/);

--- a/tests/dashboard-skillhub-connected-api.test.ts
+++ b/tests/dashboard-skillhub-connected-api.test.ts
@@ -139,8 +139,6 @@ describe('dashboard connected SkillHub API', () => {
     fs.writeFileSync(path.join(testRoot, 'skills', 'quick-demo', '.xiaoba-bundled-skill.json'), '{}\n');
     fs.writeFileSync(path.join(testRoot, 'skills', 'quick-demo', '.xiaoba-skillhub-install.json'), '{}\n');
     fs.writeFileSync(path.join(testRoot, 'skills', 'quick-demo', '.xiaoba-bot-skill.json'), '{}\n');
-    fs.mkdirSync(path.join(testRoot, 'skills', 'quick-demo', '.ssh'), { recursive: true });
-    fs.writeFileSync(path.join(testRoot, 'skills', 'quick-demo', '.ssh', 'id_test'), 'private\n');
 
     const fixture = createFixture();
     await startCloud(fixture);
@@ -172,11 +170,36 @@ describe('dashboard connected SkillHub API', () => {
     assert.equal(uploadedPaths.includes('.xiaoba-bundled-skill.json'), false);
     assert.equal(uploadedPaths.includes('.xiaoba-skillhub-install.json'), false);
     assert.equal(uploadedPaths.includes('.xiaoba-bot-skill.json'), false);
-    assert.equal(uploadedPaths.some((value: string) => value.startsWith('.ssh/')), false);
     const skillText = fs.readFileSync(path.join(testRoot, 'skills', 'quick-demo', 'SKILL.md'), 'utf8');
     assert.match(skillText, /skillhub_author:\s+["']?lin["']?/);
     assert.match(skillText, /skillhub_version:\s+["']?1\.0\.0["']?/);
     assert.match(skillText, /skillhub_uploaded_at:/);
+  });
+
+  test('rejects a sensitive local package before calling the SkillHub share endpoint', async () => {
+    const skillRoot = path.join(testRoot, 'skills', 'unsafe-demo');
+    fs.mkdirSync(skillRoot, { recursive: true });
+    fs.writeFileSync(path.join(skillRoot, 'SKILL.md'), [
+      '---',
+      'name: unsafe-demo',
+      'description: Unsafe demo skill',
+      '---',
+      '',
+      '# Unsafe Demo',
+      '',
+    ].join('\n'));
+    fs.writeFileSync(path.join(skillRoot, '.env'), 'API_KEY=not-a-real-secret\n');
+
+    const fixture = createFixture();
+    await startCloud(fixture);
+    process.env.CATSCO_SKILLHUB_BASE_URL = cloudBaseUrl;
+    await startDashboard();
+
+    await post('/api/skillhub/auth/login', { email: 'demo@example.com', password: 'passw0rd!!' });
+    const share = await post('/api/skillhub/share-local-skill', { skillName: 'unsafe-demo' });
+    assert.equal(share.status, 400);
+    assert.equal(share.body.code, 'skillhub.local_skill_unsafe_package');
+    assert.match(share.body.error, /sensitive material/i);
   });
 
   test('connects SkillHub with the current CatsCo login token', async () => {


### PR DESCRIPTION
## 为什么做

CatsCo WebApp 的生产 SkillHub 页面需要安全地查看和操作用户电脑上的 XiaoBa Skill 工作区。WebApp 不能直接访问 `localhost`，因此 XiaoBa 需要在现有 CatsCo WebSocket 连接上提供一层很薄、权限明确的 SkillHub RPC，并把分享结果继续纳入既有 BotDefinition 与 Local/Base/Cloud 同步逻辑。

本 PR 是 CatsCo WebApp 侧配套实现。它不改变 Dashboard 现有用户入口，也不引入新的云端数据模型。

## 做了什么

### 设备能力与 RPC

- XiaoBa 注册四项专用 capability：
  - `skillhub.localWorkspace.get`
  - `skillhub.localSkill.share`
  - `skillhub.localSkill.finalize`
  - `skillhub.localBot.switch`
- 新增专用 RPC handler，校验 owner、device、当前登录身份、Bot、活动工作区、请求过期时间和 request ID 指纹。
- 重放相同请求返回缓存结果；同一 request ID 携带不同操作或 payload 会被拒绝。
- 工作区响应只返回有界元数据和真实 Skills 路径，不返回本地文件正文。

### 本地 Skill 分享

- 使用 `local_skill_id + skill_name + 锁内真实路径` 精确选择 Skill，同名目录不会分享错目标。
- 分享前重新校验当前 owner、活动 Bot 和 Skill 身份。
- 上传排除本地 marker、生成文件和凭据目录，并拒绝高置信度密钥、Token、`.env`、归档文件及超限内容。
- 支持已发布 Skill 的新版本确认，把 `confirm_publish` 正确透传为 SkillHub 的 `confirmVersionPublish`。
- 兼容 SkillHub “版本已精确存在”响应中的顶层 `skillId` 及 `packageVersion.skillId/version/contentHash`，断线重试不会回退为错误的本地名称。

### Bot 切换与 Local/Base/Cloud

- Bot 切换复用现有 Dashboard 激活接口和两阶段工作区切换；本地接口非 2xx 会明确失败。
- public finalize 会等待公共包可下载，逐文件校验并计算 canonical workspace hash。
- finalize 前后重复检查活动 Bot、本地内容、云端 BotDefinition 和请求有效期，防止等待期间的本地编辑、云端删除或 revision 冲突覆盖用户数据。
- public marker 优先于同 hash 的 private Base；已发布内容本地再次编辑后恢复为可分享状态。
- 增加 finalize journal，覆盖正文/marker/Base 写入之间的崩溃窗口：
  - 云端仍有精确公共引用时安全前滚；
  - 云端已删除引用时回滚；
  - 本地改名、移动、删除或继续编辑时以用户操作为准；
  - Base 丢失也不会把公共引用重新上传成 private；
  - 同内容的多个本地 Skill 只按 `localSkillId` 恢复，不会串绑。

## 安全与一致性

- 只接受 CatsCo 已授权的四项 SkillHub RPC，不复用通用 shell/file 工具权限。
- 每次执行和返回缓存结果前都重新验证本地 owner；Bot 与当前工作区必须匹配。
- 分享与 finalize 使用锁内二次校验，避免页面选择后目录被替换。
- 公共引用必须包含精确 `skillId + version + 64 位 contentHash`，并与实际下载包一致。
- BotDefinition 更新继续使用现有 revision CAS；并发修改时不静默覆盖。

## 测试

- `npm test`：1423 项中 1418 passed、5 skipped、0 failed。
- `npm run build`：通过。
- Skill 同步与 Thin RPC 定向测试：43 项全部通过。
- `git diff --check`：通过。
- 已覆盖同名 Skill 精确选择、秘密扫描、确认发布、exact-existing 响应、请求重放/过期、Bot 切换失败、发布等待、本地编辑、云端删除、CAS 冲突、public/private 优先级、无 Base 崩溃恢复、改名/移动/删除和相同内容副本隔离。

## 依赖与部署顺序（必须遵守）

本 PR 保持 Draft，依赖 CatsCo 配套 PR 先完成部署：

1. 先合并 CatsCo PR。
2. 确认 CatsCo 后端所有实例已更新，旧节点清零。
3. 再将本 PR 转为 Ready、完成审核并发布 XiaoBa。
4. 新版 XiaoBa 发布后，CatsCo 不应单独回滚到旧鉴权逻辑。

原因：旧 CatsCo 节点不知道这四项 RPC 的用户、Bot owner 和设备 capability 授权，因此 XiaoBa 不能先上线。

## 已知限制

- 本 PR 不删除 Dashboard SkillHub；待 WebApp 真实链路稳定后再由后续任务决定下线节奏。
- 旧 Connector Token 不会自动扩权，需要重新配对；普通新版 XiaoBa 会重新注册完整 capability。
- 本 PR 不包含 WebApp 视觉重排，也不修改 SkillHub 服务端。

## 下一步

- 等待 CatsCo 配套 PR 审核、合并并完成全实例部署。
- 使用真实账号验证：选择自有 Bot、读取本地路径、切换 Bot、分享新 Skill、发布已有 Skill 新版本、绑定 BotDefinition、重启后同步。
- 端到端验收通过后再把本 PR 转为 Ready。
