### PR TITLE
fix(ci): install mac native modules for target arch on Apple Silicon runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,13 @@ jobs:
       matrix:
         arch: [x64, arm64]
     env:
+      # Job-level override of the global NPM_INSTALL_FLAGS: force npm to install
+      # optionalDependencies for the TARGET architecture, not the runner's. The
+      # mac matrix builds on Apple Silicon runners for both x64 and arm64, so
+      # without this npm ci only fetched arm64 prebuilt natives (e.g.
+      # @img/sharp-darwin-arm64, @napi-rs/canvas-darwin-arm64), which were then
+      # packed into the x64 artifact and crashed Intel Macs on launch.
+      NPM_INSTALL_FLAGS: '--prefer-offline --no-audit --fund=false --os=darwin --cpu=${{ matrix.arch }}'
       XIAOBA_UPDATE_BASE_URL: https://github-release.tos-cn-guangzhou.volces.com/update/macos-${{ matrix.arch }}
       APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
       APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}

--- a/electron/gpu-compat.js
+++ b/electron/gpu-compat.js
@@ -1,0 +1,24 @@
+'use strict';
+
+// Decide whether the app should run without GPU-accelerated compositing.
+//
+// Default scope is intentionally narrow: only Intel Macs (darwin/x64), which
+// are the ones hitting OCLP-patched macOS with legacy NVIDIA GPUs that crash
+// the GPU process on launch. Windows, Linux and Apple Silicon keep hardware
+// acceleration.
+//
+// An explicit XIAOBA_DISABLE_GPU=1 (or "true") environment override forces
+// software rendering on every platform as a safe-mode escape hatch.
+function shouldDisableHardwareAcceleration(options = {}) {
+  const env = options.env || process.env;
+  const platform = options.platform || process.platform;
+  const arch = options.arch || process.arch;
+
+  if (env.XIAOBA_DISABLE_GPU === '1' || env.XIAOBA_DISABLE_GPU === 'true') {
+    return true;
+  }
+
+  return platform === 'darwin' && arch === 'x64';
+}
+
+module.exports = { shouldDisableHardwareAcceleration };

--- a/electron/main.js
+++ b/electron/main.js
@@ -3,6 +3,13 @@ const path = require('path');
 const fs = require('fs');
 const { normalizeUpdateError } = require('./update-errors');
 
+// Compatibility: render with software (SwiftShader) instead of GPU-accelerated
+// compositing. Intel Macs running OCLP-patched macOS with legacy NVIDIA GPUs
+// (e.g. GTX 675MX in the Late-2012 iMac) crash the GPU process on launch when
+// hardware acceleration is enabled. The dashboard UI is lightweight and does
+// not require GPU compositing.
+app.disableHardwareAcceleration();
+
 const DASHBOARD_PORT = resolveDashboardPort(process.env.XIAOBA_DASHBOARD_PORT);
 const DEEP_LINK_PROTOCOL = 'catsco';
 const TRUSTED_DEEP_LINK_BASE_ORIGINS = new Set(['https://app.catsco.cc']);
@@ -570,6 +577,18 @@ function createWindow() {
   mainWindow.on('closed', () => {
     mainWindow = null;
   });
+
+  // Fallback for renderer crashes (e.g. software-renderer hiccups on old Intel
+  // machines): reload instead of leaving a dead window or exiting.
+  mainWindow.webContents.on('render-process-gone', (_event, details) => {
+    console.error('[desktop] renderer process gone:', details?.reason);
+    if (app.isQuitting) return;
+    setTimeout(() => {
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.reload();
+      }
+    }, 1500);
+  });
 }
 
 function isTrustedDashboardUrl(value) {
@@ -859,6 +878,12 @@ app.whenReady().then(async () => {
 
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') app.quit();
+});
+
+app.on('child-process-gone', (_event, details) => {
+  // Observability for utility/GPU crashes; hardware acceleration is disabled
+  // above, so this mainly fires for unexpected utility process failures.
+  console.error('[desktop] child process gone:', details?.type, details?.reason);
 });
 
 app.on('before-quit', () => {

--- a/electron/main.js
+++ b/electron/main.js
@@ -578,6 +578,7 @@ function createWindow() {
   });
 
   mainWindow.on('closed', () => {
+    rendererGoneGuard.dispose();
     mainWindow = null;
   });
 
@@ -590,6 +591,7 @@ function createWindow() {
     log: (message) => console.error('[desktop] renderer recovery:', message),
   });
   mainWindow.webContents.on('render-process-gone', (_event, details) => {
+    if (app.isQuitting) return;
     const outcome = rendererGoneGuard.onRenderProcessGone(details?.reason);
     if (!outcome.recovered) {
       console.error('[desktop] renderer process gone, no auto-recovery:', details?.reason, outcome.reason);

--- a/electron/main.js
+++ b/electron/main.js
@@ -2,13 +2,16 @@ const { app, BrowserWindow, Tray, Menu, nativeImage, ipcMain, dialog, shell } = 
 const path = require('path');
 const fs = require('fs');
 const { normalizeUpdateError } = require('./update-errors');
+const { shouldDisableHardwareAcceleration } = require('./gpu-compat');
+const { createRendererGoneGuard } = require('./renderer-gone');
 
-// Compatibility: render with software (SwiftShader) instead of GPU-accelerated
-// compositing. Intel Macs running OCLP-patched macOS with legacy NVIDIA GPUs
-// (e.g. GTX 675MX in the Late-2012 iMac) crash the GPU process on launch when
-// hardware acceleration is enabled. The dashboard UI is lightweight and does
-// not require GPU compositing.
-app.disableHardwareAcceleration();
+// Compatibility: render with software (SwiftShader) on Intel Macs, where
+// OCLP-patched macOS with legacy NVIDIA GPUs (e.g. GTX 675MX in the Late-2012
+// iMac) crash the GPU process on launch. Other platforms keep hardware
+// acceleration; XIAOBA_DISABLE_GPU=1 forces software rendering anywhere.
+if (shouldDisableHardwareAcceleration()) {
+  app.disableHardwareAcceleration();
+}
 
 const DASHBOARD_PORT = resolveDashboardPort(process.env.XIAOBA_DASHBOARD_PORT);
 const DEEP_LINK_PROTOCOL = 'catsco';
@@ -578,16 +581,23 @@ function createWindow() {
     mainWindow = null;
   });
 
-  // Fallback for renderer crashes (e.g. software-renderer hiccups on old Intel
-  // machines): reload instead of leaving a dead window or exiting.
+  // Bounded auto-recovery for transient renderer crashes (e.g. software-renderer
+  // hiccups on old Intel Macs). Only crashed/oom/abnormal-exit reload, at most
+  // MAX_RELOADS_IN_WINDOW times within the recovery window; unrecoverable
+  // failures surface an error dialog instead of looping forever.
+  const rendererGoneGuard = createRendererGoneGuard({
+    window: mainWindow,
+    log: (message) => console.error('[desktop] renderer recovery:', message),
+  });
   mainWindow.webContents.on('render-process-gone', (_event, details) => {
-    console.error('[desktop] renderer process gone:', details?.reason);
-    if (app.isQuitting) return;
-    setTimeout(() => {
-      if (mainWindow && !mainWindow.isDestroyed()) {
-        mainWindow.reload();
-      }
-    }, 1500);
+    const outcome = rendererGoneGuard.onRenderProcessGone(details?.reason);
+    if (!outcome.recovered) {
+      console.error('[desktop] renderer process gone, no auto-recovery:', details?.reason, outcome.reason);
+      dialog.showErrorBox('CatsCo 运行异常', '界面渲染进程异常退出，无法自动恢复，请重新打开应用。');
+    }
+  });
+  mainWindow.webContents.on('did-finish-load', () => {
+    rendererGoneGuard.reset();
   });
 }
 

--- a/electron/main.js
+++ b/electron/main.js
@@ -597,7 +597,11 @@ function createWindow() {
     }
   });
   mainWindow.webContents.on('did-finish-load', () => {
-    rendererGoneGuard.reset();
+    // Do NOT clear the retry budget immediately on load: a crash -> reload ->
+    // load loop would reset its own budget every round and bypass the cap.
+    // The guard clears it only after the page stays loaded for a stability
+    // period (30s), keeping the bounded retry effective.
+    rendererGoneGuard.onLoadFinished();
   });
 }
 

--- a/electron/renderer-gone.js
+++ b/electron/renderer-gone.js
@@ -1,0 +1,72 @@
+'use strict';
+
+// Reasons that represent a transient renderer crash worth one bounded retry
+// window. Unrecoverable reasons (launch-failed, integrity-failure, killed,
+// clean-exit) must never trigger an auto-reload loop.
+const RECOVERABLE_REASONS = new Set(['crashed', 'oom', 'abnormal-exit']);
+
+// Stop auto-recovering after MAX_RELOADS_IN_WINDOW reloads within a rolling
+// RECOVERY_WINDOW_MS window. A successful did-finish-load resets the budget.
+const MAX_RELOADS_IN_WINDOW = 2;
+const RECOVERY_WINDOW_MS = 30_000;
+const RELOAD_DELAY_MS = 1_500;
+
+function isRecoverableRendererGoneReason(reason) {
+  return RECOVERABLE_REASONS.has(reason);
+}
+
+// Bounded auto-recovery guard for the renderer process. Pure logic with all
+// side effects injectable so it can be unit-tested without Electron.
+function createRendererGoneGuard(options = {}) {
+  const now = options.now || (() => Date.now());
+  const scheduleReload = options.scheduleReload || ((fn, delay) => setTimeout(fn, delay));
+  const clearReload = options.clearReload || ((timer) => clearTimeout(timer));
+  const reloadWindow = options.reloadWindow || ((win) => win.reload());
+  const log = options.log || (() => {});
+
+  let windowRef = options.window || null;
+  let reloadTimestamps = [];
+  let pendingTimer = null;
+
+  function reset() {
+    reloadTimestamps = [];
+  }
+
+  function onRenderProcessGone(reason) {
+    if (!isRecoverableRendererGoneReason(reason)) {
+      log(`renderer gone reason is not auto-recoverable: ${reason}`);
+      return { recovered: false, reason: 'unrecoverable' };
+    }
+
+    const timestamp = now();
+    reloadTimestamps = reloadTimestamps.filter((ts) => timestamp - ts < RECOVERY_WINDOW_MS);
+    if (reloadTimestamps.length >= MAX_RELOADS_IN_WINDOW) {
+      log('renderer retry budget exhausted within recovery window');
+      return { recovered: false, reason: 'retries-exhausted' };
+    }
+
+    const target = windowRef;
+    if (pendingTimer !== null) clearReload(pendingTimer);
+    pendingTimer = scheduleReload(() => {
+      pendingTimer = null;
+      // Only touch the window instance captured at schedule time; if it was
+      // destroyed and a new window was created, do not reload the replacement.
+      if (target && !target.isDestroyed()) {
+        reloadTimestamps.push(now());
+        reloadWindow(target);
+      }
+    }, RELOAD_DELAY_MS);
+    return { recovered: true, reason: 'scheduled' };
+  }
+
+  return { onRenderProcessGone, reset };
+}
+
+module.exports = {
+  RECOVERABLE_REASONS,
+  MAX_RELOADS_IN_WINDOW,
+  RECOVERY_WINDOW_MS,
+  RELOAD_DELAY_MS,
+  isRecoverableRendererGoneReason,
+  createRendererGoneGuard,
+};

--- a/electron/renderer-gone.js
+++ b/electron/renderer-gone.js
@@ -30,12 +30,30 @@ function createRendererGoneGuard(options = {}) {
   let pendingTimer = null;
   let stableTimer = null;
 
-  function reset() {
-    reloadTimestamps = [];
+  function cancelStableTimer() {
     if (stableTimer !== null) {
       clearReload(stableTimer);
       stableTimer = null;
     }
+  }
+
+  function cancelPendingReload() {
+    if (pendingTimer !== null) {
+      clearReload(pendingTimer);
+      pendingTimer = null;
+    }
+  }
+
+  function reset() {
+    reloadTimestamps = [];
+    cancelStableTimer();
+  }
+
+  // Release all pending timers. Called when the window is closed or the app is
+  // quitting so no stale reload/stability callback fires afterwards.
+  function dispose() {
+    cancelStableTimer();
+    cancelPendingReload();
   }
 
   // Called on each successful page load. Starts (or restarts) a stability
@@ -44,7 +62,7 @@ function createRendererGoneGuard(options = {}) {
   // reloads on record, so a crash -> reload -> load loop cannot reset its own
   // budget and bypass the retry cap.
   function onLoadFinished() {
-    if (stableTimer !== null) clearReload(stableTimer);
+    cancelStableTimer();
     stableTimer = scheduleReload(() => {
       stableTimer = null;
       reset();
@@ -52,6 +70,12 @@ function createRendererGoneGuard(options = {}) {
   }
 
   function onRenderProcessGone(reason) {
+    // Any renderer loss invalidates the current stability period immediately,
+    // regardless of whether the reason is recoverable. Otherwise the old
+    // stability timer could expire after a new crash and clear recent reloads,
+    // allowing more than MAX_RELOADS_IN_WINDOW reloads in one window.
+    cancelStableTimer();
+
     if (!isRecoverableRendererGoneReason(reason)) {
       log(`renderer gone reason is not auto-recoverable: ${reason}`);
       return { recovered: false, reason: 'unrecoverable' };
@@ -65,7 +89,7 @@ function createRendererGoneGuard(options = {}) {
     }
 
     const target = windowRef;
-    if (pendingTimer !== null) clearReload(pendingTimer);
+    cancelPendingReload();
     pendingTimer = scheduleReload(() => {
       pendingTimer = null;
       // Only touch the window instance captured at schedule time; if it was
@@ -78,7 +102,7 @@ function createRendererGoneGuard(options = {}) {
     return { recovered: true, reason: 'scheduled' };
   }
 
-  return { onRenderProcessGone, onLoadFinished, reset };
+  return { onRenderProcessGone, onLoadFinished, reset, dispose };
 }
 
 module.exports = {

--- a/electron/renderer-gone.js
+++ b/electron/renderer-gone.js
@@ -23,13 +23,32 @@ function createRendererGoneGuard(options = {}) {
   const clearReload = options.clearReload || ((timer) => clearTimeout(timer));
   const reloadWindow = options.reloadWindow || ((win) => win.reload());
   const log = options.log || (() => {});
+  const stableWindowMs = options.stableWindowMs || RECOVERY_WINDOW_MS;
 
   let windowRef = options.window || null;
   let reloadTimestamps = [];
   let pendingTimer = null;
+  let stableTimer = null;
 
   function reset() {
     reloadTimestamps = [];
+    if (stableTimer !== null) {
+      clearReload(stableTimer);
+      stableTimer = null;
+    }
+  }
+
+  // Called on each successful page load. Starts (or restarts) a stability
+  // timer; the retry budget is only cleared after the window has stayed loaded
+  // for stableWindowMs. Crashes within the stability period keep earlier
+  // reloads on record, so a crash -> reload -> load loop cannot reset its own
+  // budget and bypass the retry cap.
+  function onLoadFinished() {
+    if (stableTimer !== null) clearReload(stableTimer);
+    stableTimer = scheduleReload(() => {
+      stableTimer = null;
+      reset();
+    }, stableWindowMs);
   }
 
   function onRenderProcessGone(reason) {
@@ -59,7 +78,7 @@ function createRendererGoneGuard(options = {}) {
     return { recovered: true, reason: 'scheduled' };
   }
 
-  return { onRenderProcessGone, reset };
+  return { onRenderProcessGone, onLoadFinished, reset };
 }
 
 module.exports = {

--- a/tests/electron-gpu-compat.test.ts
+++ b/tests/electron-gpu-compat.test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import test from 'node:test';
+
+const require = createRequire(import.meta.url);
+const { shouldDisableHardwareAcceleration } = require('../electron/gpu-compat.js');
+
+const env = (extra = {}) => ({ ...extra });
+
+test('software rendering defaults to Intel Macs only', () => {
+  assert.equal(shouldDisableHardwareAcceleration({ platform: 'darwin', arch: 'x64', env: env() }), true);
+  assert.equal(shouldDisableHardwareAcceleration({ platform: 'darwin', arch: 'arm64', env: env() }), false);
+  assert.equal(shouldDisableHardwareAcceleration({ platform: 'win32', arch: 'x64', env: env() }), false);
+  assert.equal(shouldDisableHardwareAcceleration({ platform: 'linux', arch: 'x64', env: env() }), false);
+  assert.equal(shouldDisableHardwareAcceleration({ platform: 'win32', arch: 'arm64', env: env() }), false);
+});
+
+test('XIAOBA_DISABLE_GPU override forces software rendering on any platform', () => {
+  for (const value of ['1', 'true']) {
+    assert.equal(
+      shouldDisableHardwareAcceleration({ platform: 'win32', arch: 'x64', env: env({ XIAOBA_DISABLE_GPU: value }) }),
+      true,
+    );
+    assert.equal(
+      shouldDisableHardwareAcceleration({ platform: 'darwin', arch: 'arm64', env: env({ XIAOBA_DISABLE_GPU: value }) }),
+      true,
+    );
+  }
+  assert.equal(
+    shouldDisableHardwareAcceleration({ platform: 'win32', arch: 'x64', env: env({ XIAOBA_DISABLE_GPU: '0' }) }),
+    false,
+  );
+});

--- a/tests/electron-renderer-gone.test.ts
+++ b/tests/electron-renderer-gone.test.ts
@@ -162,6 +162,57 @@ test('reload never fires for a window that was destroyed (window replaced)', () 
   assert.equal(reloaded.length, 0);
 });
 
+test('a renderer crash cancels the pending stability timer (edge regression)', () => {
+  const { guard, timers, reloaded, fire, setNow } = makeHarness();
+  // Load completes and starts the stability timer (fires at +30s).
+  guard.onLoadFinished();
+  assert.equal(timers.length, 1);
+  // Crash mid-stability: the old stability timer must be cancelled so it can
+  // never expire after the new crash and clear the fresh reload record.
+  setNow(20_000);
+  const outcome = guard.onRenderProcessGone('crashed');
+  assert.equal(outcome.recovered, true);
+  assert.equal(timers.length, 1); // only the reload timer, stability timer gone
+  // Advance past the OLD stability deadline: nothing must reset the budget.
+  setNow(40_000);
+  fire(); // reload executes, records a timestamp at 40s
+  assert.equal(reloaded.length, 1);
+  // Second crash within 30s of the reload is still allowed.
+  setNow(40_500);
+  assert.equal(guard.onRenderProcessGone('crashed').recovered, true);
+  fire();
+  // Third crash within the rolling 30s window must be rejected.
+  setNow(41_000);
+  const third = guard.onRenderProcessGone('crashed');
+  assert.deepEqual(third, { recovered: false, reason: 'retries-exhausted' });
+  fire();
+  assert.equal(reloaded.length, 2); // never more than MAX in one window
+});
+
+test('unrecoverable renderer loss also cancels the stability timer', () => {
+  const { guard, timers } = makeHarness();
+  guard.onLoadFinished();
+  assert.equal(timers.length, 1);
+  const outcome = guard.onRenderProcessGone('launch-failed');
+  assert.deepEqual(outcome, { recovered: false, reason: 'unrecoverable' });
+  // Stability timer cancelled and no reload scheduled.
+  assert.equal(timers.length, 0);
+});
+
+test('dispose cancels pending reload and stability timers', () => {
+  const { guard, timers } = makeHarness();
+  guard.onLoadFinished();
+  guard.onRenderProcessGone('crashed'); // cancels stability, schedules reload
+  assert.equal(timers.length, 1);
+  guard.dispose();
+  assert.equal(timers.length, 0);
+  // A later crash still schedules normally after dispose.
+  const after = guard.onRenderProcessGone('crashed');
+  assert.equal(after.recovered, true);
+  guard.dispose();
+  assert.equal(timers.length, 0);
+});
+
 test('recovery window constants are sane', () => {
   assert.equal(MAX_RELOADS_IN_WINDOW, 2);
   assert.equal(RECOVERY_WINDOW_MS, 30_000);

--- a/tests/electron-renderer-gone.test.ts
+++ b/tests/electron-renderer-gone.test.ts
@@ -13,6 +13,7 @@ const {
 
 function makeHarness(overrides = {}) {
   let nowValue = 0;
+  let nextTimerId = 0;
   const timers = [];
   const reloaded = [];
   const window = overrides.window || {
@@ -23,10 +24,14 @@ function makeHarness(overrides = {}) {
     window,
     now: () => nowValue,
     scheduleReload: (fn) => {
-      timers.push(fn);
-      return timers.length;
+      nextTimerId += 1;
+      timers.push({ id: nextTimerId, fn });
+      return nextTimerId;
     },
-    clearReload: () => {},
+    clearReload: (id) => {
+      const index = timers.findIndex((timer) => timer.id === id);
+      if (index >= 0) timers.splice(index, 1);
+    },
     reloadWindow: (target) => reloaded.push(target),
     ...overrides,
   });
@@ -39,9 +44,9 @@ function makeHarness(overrides = {}) {
       nowValue = value;
     },
     fire: () => {
-      // fire the latest scheduled reload callback synchronously
-      const fn = timers.pop();
-      if (fn) fn();
+      // fire the most recently scheduled callback synchronously
+      const last = timers.pop();
+      if (last) last.fn();
     },
   };
 }
@@ -89,7 +94,7 @@ test('retry budget is bounded within the recovery window', () => {
   assert.equal(reloaded.length, MAX_RELOADS_IN_WINDOW);
 });
 
-test('retry budget resets after did-finish-load (reset)', () => {
+test('explicit reset reopens the budget', () => {
   const { guard, timers, reloaded, fire, setNow } = makeHarness();
   for (let i = 0; i < MAX_RELOADS_IN_WINDOW; i++) {
     guard.onRenderProcessGone('crashed');
@@ -100,6 +105,44 @@ test('retry budget resets after did-finish-load (reset)', () => {
   setNow(MAX_RELOADS_IN_WINDOW * 1000);
   const afterReset = guard.onRenderProcessGone('crashed');
   assert.equal(afterReset.recovered, true);
+});
+
+test('crash -> reload -> load loop cannot reset its own budget (lifecycle regression)', () => {
+  const { guard, timers, reloaded, fire, setNow } = makeHarness();
+  // Two full crash/reload/load rounds inside the 30s window.
+  for (let round = 0; round < MAX_RELOADS_IN_WINDOW; round++) {
+    setNow(round * 1000);
+    const outcome = guard.onRenderProcessGone('crashed');
+    assert.equal(outcome.recovered, true, `round ${round + 1} should schedule`);
+    fire(); // delayed reload fires and records a timestamp
+    guard.onLoadFinished(); // page loads; must NOT clear the budget
+  }
+  assert.equal(reloaded.length, MAX_RELOADS_IN_WINDOW);
+  // Third crash within the window -> budget still exhausted despite the loads.
+  setNow(MAX_RELOADS_IN_WINDOW * 1000);
+  const exhausted = guard.onRenderProcessGone('crashed');
+  assert.deepEqual(exhausted, { recovered: false, reason: 'retries-exhausted' });
+  fire();
+  assert.equal(reloaded.length, MAX_RELOADS_IN_WINDOW);
+});
+
+test('budget recovers only after a stability period without crashes', () => {
+  const { guard, timers, fire, setNow } = makeHarness();
+  // Crash -> reload -> successful load starts the stability timer.
+  guard.onRenderProcessGone('crashed');
+  fire();
+  guard.onLoadFinished();
+  assert.equal(timers.length, 1); // the stability timer
+  // Crash again within the stability period -> budget still counts.
+  setNow(5_000);
+  const withinStable = guard.onRenderProcessGone('crashed');
+  assert.equal(withinStable.recovered, true);
+  // Load again and stay stable past the 30s window -> budget resets.
+  guard.onLoadFinished();
+  setNow(40_000);
+  fire(); // stability timer fires -> reset
+  const afterStable = guard.onRenderProcessGone('crashed');
+  assert.equal(afterStable.recovered, true);
 });
 
 test('reload never fires for a window that was destroyed (window replaced)', () => {

--- a/tests/electron-renderer-gone.test.ts
+++ b/tests/electron-renderer-gone.test.ts
@@ -1,0 +1,126 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import test from 'node:test';
+
+const require = createRequire(import.meta.url);
+const {
+  MAX_RELOADS_IN_WINDOW,
+  RECOVERY_WINDOW_MS,
+  RELOAD_DELAY_MS,
+  isRecoverableRendererGoneReason,
+  createRendererGoneGuard,
+} = require('../electron/renderer-gone.js');
+
+function makeHarness(overrides = {}) {
+  let nowValue = 0;
+  const timers = [];
+  const reloaded = [];
+  const window = overrides.window || {
+    isDestroyed: () => false,
+    reload: () => reloaded.push('reload'),
+  };
+  const guard = createRendererGoneGuard({
+    window,
+    now: () => nowValue,
+    scheduleReload: (fn) => {
+      timers.push(fn);
+      return timers.length;
+    },
+    clearReload: () => {},
+    reloadWindow: (target) => reloaded.push(target),
+    ...overrides,
+  });
+  return {
+    guard,
+    timers,
+    reloaded,
+    window,
+    setNow: (value) => {
+      nowValue = value;
+    },
+    fire: () => {
+      // fire the latest scheduled reload callback synchronously
+      const fn = timers.pop();
+      if (fn) fn();
+    },
+  };
+}
+
+test('only transient crash reasons are auto-recoverable', () => {
+  for (const reason of ['crashed', 'oom', 'abnormal-exit']) {
+    assert.equal(isRecoverableRendererGoneReason(reason), true, `expected ${reason} recoverable`);
+  }
+  for (const reason of ['clean-exit', 'killed', 'launch-failed', 'integrity-failure', 'unknown', undefined]) {
+    assert.equal(isRecoverableRendererGoneReason(reason), false, `expected ${reason} unrecoverable`);
+  }
+});
+
+test('unrecoverable reasons never schedule a reload', () => {
+  const { guard, timers } = makeHarness();
+  const outcome = guard.onRenderProcessGone('launch-failed');
+  assert.deepEqual(outcome, { recovered: false, reason: 'unrecoverable' });
+  assert.equal(timers.length, 0);
+});
+
+test('a recoverable reason schedules exactly one bounded reload', () => {
+  const { guard, timers, reloaded, fire } = makeHarness();
+  const outcome = guard.onRenderProcessGone('crashed');
+  assert.deepEqual(outcome, { recovered: true, reason: 'scheduled' });
+  assert.equal(timers.length, 1);
+  fire();
+  assert.equal(reloaded.length, 1);
+});
+
+test('retry budget is bounded within the recovery window', () => {
+  const { guard, timers, reloaded, fire, setNow } = makeHarness();
+  // Two recoverable crashes inside the window -> both reload.
+  for (let i = 0; i < MAX_RELOADS_IN_WINDOW; i++) {
+    setNow(i * 1000);
+    const outcome = guard.onRenderProcessGone('oom');
+    assert.equal(outcome.recovered, true, `attempt ${i + 1} should be scheduled`);
+    fire();
+  }
+  assert.equal(reloaded.length, MAX_RELOADS_IN_WINDOW);
+  // Third crash within the window -> budget exhausted, no more reloads.
+  setNow(MAX_RELOADS_IN_WINDOW * 1000);
+  const exhausted = guard.onRenderProcessGone('oom');
+  assert.deepEqual(exhausted, { recovered: false, reason: 'retries-exhausted' });
+  fire();
+  assert.equal(reloaded.length, MAX_RELOADS_IN_WINDOW);
+});
+
+test('retry budget resets after did-finish-load (reset)', () => {
+  const { guard, timers, reloaded, fire, setNow } = makeHarness();
+  for (let i = 0; i < MAX_RELOADS_IN_WINDOW; i++) {
+    guard.onRenderProcessGone('crashed');
+    fire();
+  }
+  assert.equal(reloaded.length, MAX_RELOADS_IN_WINDOW);
+  guard.reset();
+  setNow(MAX_RELOADS_IN_WINDOW * 1000);
+  const afterReset = guard.onRenderProcessGone('crashed');
+  assert.equal(afterReset.recovered, true);
+});
+
+test('reload never fires for a window that was destroyed (window replaced)', () => {
+  let destroyed = false;
+  const capturedWindow = {
+    isDestroyed: () => destroyed,
+    reload: () => {},
+  };
+  const { guard, timers, reloaded, fire } = makeHarness({ window: capturedWindow });
+  guard.onRenderProcessGone('crashed');
+  assert.equal(timers.length, 1);
+  // The captured window is closed/destroyed before the delayed reload fires.
+  destroyed = true;
+  fire();
+  assert.equal(timers.length, 0);
+  // A destroyed window is never reloaded (the replacement window is untouched).
+  assert.equal(reloaded.length, 0);
+});
+
+test('recovery window constants are sane', () => {
+  assert.equal(MAX_RELOADS_IN_WINDOW, 2);
+  assert.equal(RECOVERY_WINDOW_MS, 30_000);
+  assert.equal(RELOAD_DELAY_MS, 1_500);
+});


### PR DESCRIPTION
## 问题

外部反馈工单 #73（app.catsco.cc 反馈面板）：Intel Mac（iMac 27" Late 2012 / GTX 675MX / OCLP Sonoma 14.8.7）下载客户端打开即闪退（云端可用）。

### 根因 1：x64 包里混入 arm64 native 模块（CI）
实测 1.4.7 x64 产物：主二进制全 x86_64，但 `@img/sharp-darwin-arm64`、`@napi-rs/canvas-darwin-arm64` 混入（无 x64 版）。build-mac matrix 都跑 Apple Silicon runner，`npm ci` 按 runner 架构装 optionalDependencies。`catscompany → read-tool → image-utils` 顶层 `import sharp` → Intel 启动崩溃。

### 根因 2：老 Intel Mac GPU 进程崩溃（OCLP + 老 NVIDIA）
Sonoma 上 GTX 675MX 无官方驱动，Electron 硬件加速下 GPU 进程易崩。

## 修复（5 个 commit）

### ad0bb9e · release.yml：按目标架构装 mac native
`NPM_INSTALL_FLAGS: '... --os=darwin --cpu=${{ matrix.arch }}'`（仅 build-mac job）。

### 786b2d9 · electron/main.js：GPU 崩溃兜底（初版）

### a5a674c · 审核修复（H1/M1）
- **M1**：`electron/gpu-compat.js` 把 `disableHardwareAcceleration()` 收窄到 darwin/x64；`XIAOBA_DISABLE_GPU=1` 任意平台强制（safe-mode）
- **H1（第一轮）**：`electron/renderer-gone.js` 有界恢复 guard——仅 crashed/oom/abnormal-exit 自动恢复；30s 窗口内最多 2 次；窗口实例捕获

### 0a04744 · 复核修复（H1 第二轮）
- `did-finish-load` 不再立即 reset；`onLoadFinished()` 启动 30s 稳定期计时器，稳定后才清空预算

### 94750f8 · 复核修复（H1 第三轮，闭环）
- **问题**：`onRenderProcessGone()` 未取消旧稳定计时器，旧计时器跨新崩溃到期会清空近期重载记录，30s 窗口仍可 >2 次重载
- **修复**：任何 renderer 消失（含不可恢复 reason）先取消稳定计时器；`cancelStableTimer()`/`cancelPendingReload()` 由 `reset`/`dispose` 共用
- **健壮性**：新增 `dispose()`（窗口 closed 调用释放所有定时器）；render-process-gone handler 加 `app.isQuitting` 门控
- **边界回归测试**：稳定期中途崩溃取消旧计时器（旧到期点不清预算，任意滚动 30s 最多 2 次重载）、不可恢复 reason 同样取消、dispose 清理定时器

## 验证

- npm `--os=darwin --cpu=x64` dry-run 选对平台包 ✅
- electron 相关测试 **25/25**（reason 门控/重试上限/生命周期回归/稳定期恢复/边界取消/dispose/GPU 矩阵/窗口替换）✅
- YAML 校验、`node --check`、`tsc --noEmit`、`git diff --check` 通过 ✅
- 本机 `electron:dev` 冒烟：Dashboard 正常启动 ✅

## 说明

- 未在真实 Late-2012 iMac/OCLP Sonoma 复现（无该设备）
- 修复影响下次发版；已发布 1.4.7 x64 包仍坏，需重发 1.4.8