### PR TITLE
默认关闭 Branch Agent，并仅迁移一次旧配置

### DIFF
--- a/src/core/branch-agent-config.ts
+++ b/src/core/branch-agent-config.ts
@@ -4,11 +4,11 @@ import type { ChatConfig, OpenAIApiMode, ReasoningEffort } from '../types';
 import { PathResolver } from '../utils/path-resolver';
 import {
   hasLegacyBranchAgentSwitch,
-  resolveLegacyBranchAgentsEnabled,
 } from './branch-agent-settings';
 
-export const BRANCH_AGENT_CONFIG_SCHEMA = 'xiaoba.branch-agents.v1';
+export const BRANCH_AGENT_CONFIG_SCHEMA = 'xiaoba.branch-agents.v2';
 export const BRANCH_AGENT_CONFIG_FILE = 'branch-agents.json';
+const LEGACY_BRANCH_AGENT_CONFIG_SCHEMA = 'xiaoba.branch-agents.v1';
 
 export type BranchModelSource = 'inherit' | 'catalog' | 'custom';
 
@@ -58,7 +58,7 @@ export function loadBranchAgentConfig(options: BranchAgentConfigOptions = {}): B
   if (!fs.existsSync(configPath)) {
     const env = options.env ?? process.env;
     if (!hasLegacyBranchAgentSwitch(env)) return defaultBranchAgentConfig();
-    const migrated = defaultBranchAgentConfig(resolveLegacyBranchAgentsEnabled(env));
+    const migrated = defaultBranchAgentConfig();
     try {
       return saveInitialBranchAgentConfig(migrated, runtimeRoot);
     } catch (error: any) {
@@ -74,7 +74,12 @@ export function loadBranchAgentConfig(options: BranchAgentConfigOptions = {}): B
   const fallback = defaultBranchAgentConfig();
 
   try {
-    return readBranchAgentConfigFile(configPath, fallback);
+    const parsed = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    const normalized = normalizeBranchAgentConfig(parsed, fallback);
+    if (parsed?.schema === LEGACY_BRANCH_AGENT_CONFIG_SCHEMA) {
+      normalized.branches.memorySearch.enabled = false;
+    }
+    return normalized;
   } catch {
     return fallback;
   }
@@ -116,7 +121,7 @@ export function resolveMemoryBranchModelOverride(config: BranchAgentConfig): Par
   };
 }
 
-function defaultBranchAgentConfig(enabled = true): BranchAgentConfig {
+function defaultBranchAgentConfig(enabled = false): BranchAgentConfig {
   return {
     schema: BRANCH_AGENT_CONFIG_SCHEMA,
     branches: {
@@ -179,6 +184,7 @@ function readBranchAgentConfigFile(configPath: string, fallback: BranchAgentConf
 
 function normalizeBranchAgentConfig(input: any, fallback: BranchAgentConfig): BranchAgentConfig {
   const memory = input?.schema === BRANCH_AGENT_CONFIG_SCHEMA
+    || input?.schema === LEGACY_BRANCH_AGENT_CONFIG_SCHEMA
     ? input?.branches?.memorySearch
     : undefined;
   const model = normalizeModel(memory?.model) ?? fallback.branches.memorySearch.model;

--- a/tests/branch-agent-config.test.ts
+++ b/tests/branch-agent-config.test.ts
@@ -7,6 +7,7 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { pathToFileURL } from 'node:url';
 import {
+  BRANCH_AGENT_CONFIG_SCHEMA,
   BRANCH_AGENT_CONFIG_FILE,
   loadBranchAgentConfig,
   resolveMemoryBranchModelOverride,
@@ -29,20 +30,20 @@ function tempRoot(): string {
 }
 
 describe('Branch agent device config', () => {
-  test('defaults Memory Search to enabled and following the primary model', () => {
+  test('defaults Memory Search to disabled and following the primary model', () => {
     const root = tempRoot();
     const config = loadBranchAgentConfig({ runtimeRoot: root, env: {} });
-    assert.equal(config.branches.memorySearch.enabled, true);
+    assert.equal(config.branches.memorySearch.enabled, false);
     assert.deepEqual(config.branches.memorySearch.model, { kind: 'inherit' });
     assert.equal(resolveMemoryBranchModelOverride(config), undefined);
     assert.equal(fs.existsSync(path.join(root, BRANCH_AGENT_CONFIG_FILE)), false);
   });
 
-  test('migrates the legacy Branch switch only when the device config is first created', () => {
+  test('disables the legacy Branch switch when the device config is first created', () => {
     const root = tempRoot();
     const migrated = loadBranchAgentConfig({
       runtimeRoot: root,
-      env: { XIAOBA_BRANCH_AGENTS_ENABLED: 'false' },
+      env: { XIAOBA_BRANCH_AGENTS_ENABLED: 'true' },
     });
     assert.equal(migrated.branches.memorySearch.enabled, false);
     const reloaded = loadBranchAgentConfig({
@@ -50,6 +51,79 @@ describe('Branch agent device config', () => {
       env: { XIAOBA_BRANCH_AGENTS_ENABLED: 'true' },
     });
     assert.equal(reloaded.branches.memorySearch.enabled, false);
+  });
+
+  test('concurrent v1 readers do not write or overwrite later manual enablement', async () => {
+    const root = tempRoot();
+    const configPath = path.join(root, BRANCH_AGENT_CONFIG_FILE);
+    const legacyFile = JSON.stringify({
+      schema: 'xiaoba.branch-agents.v1',
+      branches: {
+        memorySearch: {
+          enabled: true,
+          model: {
+            kind: 'custom',
+            provider: 'openai',
+            apiBase: 'https://models.example.test/v1',
+            apiKey: 'branch-secret',
+            model: 'branch-model',
+            contextWindowTokens: 256_000,
+            capabilities: { toolCalling: true },
+          },
+          customDraft: {
+            kind: 'custom',
+            provider: 'anthropic',
+            apiBase: 'https://draft.example.test/v1',
+            apiKey: 'draft-secret',
+            model: 'draft-model',
+            contextWindowTokens: 128_000,
+            capabilities: { toolCalling: true },
+          },
+        },
+      },
+    });
+    fs.writeFileSync(configPath, legacyFile, 'utf-8');
+
+    const moduleUrl = pathToFileURL(path.join(process.cwd(), 'src/core/branch-agent-config.ts')).href;
+    const script = [
+      `const imported = await import(${JSON.stringify(moduleUrl)});`,
+      'const branchConfig = imported.default ?? imported;',
+      'const config = branchConfig.loadBranchAgentConfig({ runtimeRoot: process.env.BRANCH_TEST_ROOT, env: {} });',
+      'process.stdout.write(String(config.branches.memorySearch.enabled));',
+    ].join('\n');
+    const childOptions = {
+      cwd: process.cwd(),
+      env: { ...process.env, BRANCH_TEST_ROOT: root },
+    };
+    const readers = await Promise.all(Array.from({ length: 6 }, () => execFileAsync(
+      process.execPath,
+      ['--import', 'tsx', '--input-type=module', '--eval', script],
+      childOptions,
+    )));
+    assert.deepEqual(readers.map(result => result.stdout), Array(6).fill('false'));
+    assert.equal(fs.readFileSync(configPath, 'utf-8'), legacyFile);
+
+    const migrated = loadBranchAgentConfig({ runtimeRoot: root, env: {} });
+    assert.equal(migrated.schema, BRANCH_AGENT_CONFIG_SCHEMA);
+    assert.equal(migrated.branches.memorySearch.enabled, false);
+    const model = migrated.branches.memorySearch.model;
+    assert.equal(model.kind, 'custom');
+    assert.ok(model.kind === 'custom');
+    assert.equal(model.apiKey, 'branch-secret');
+    assert.equal(migrated.branches.memorySearch.customDraft?.apiKey, 'draft-secret');
+
+    migrated.branches.memorySearch.enabled = true;
+    saveBranchAgentConfig(migrated, { runtimeRoot: root });
+    const reloaded = loadBranchAgentConfig({ runtimeRoot: root, env: {} });
+    assert.equal(JSON.parse(fs.readFileSync(configPath, 'utf-8')).schema, BRANCH_AGENT_CONFIG_SCHEMA);
+    assert.equal(reloaded.branches.memorySearch.enabled, true);
+    assert.equal(reloaded.branches.memorySearch.customDraft?.apiKey, 'draft-secret');
+    const postSaveReader = await execFileAsync(
+      process.execPath,
+      ['--import', 'tsx', '--input-type=module', '--eval', script],
+      childOptions,
+    );
+    assert.equal(postSaveReader.stdout, 'true');
   });
 
   test('migrates the old Memory sidecar switch and then ignores both legacy switches', () => {
@@ -138,7 +212,7 @@ describe('Branch agent device config', () => {
         XIAOBA_MEMORY_SIDECAR_ENABLED: 'false',
       },
     });
-    assert.equal(config.branches.memorySearch.enabled, true);
+    assert.equal(config.branches.memorySearch.enabled, false);
     assert.equal(config.branches.memorySearch.model.kind, 'inherit');
   });
 

--- a/tests/dashboard-branch-agents-api.test.ts
+++ b/tests/dashboard-branch-agents-api.test.ts
@@ -68,7 +68,7 @@ describe('Dashboard Branch agent API', () => {
     const text = await response.text();
     const data = JSON.parse(text) as any;
     assert.equal(response.status, 200);
-    assert.equal(data.enabled, true);
+    assert.equal(data.enabled, false);
     assert.equal(data.modelSource, 'inherit');
     assert.equal(typeof data.primary.model, 'string');
     assert.equal(data.custom.apiKeyPresent, false);


### PR DESCRIPTION
## 人话说明

本版本发布后，Branch Agent 默认关闭一次：

- 新用户、新配置默认关闭；
- 旧版已有 `branch-agents.json` 且原来开启的用户，读取旧配置时在内存中视为关闭；
- 旧 Branch 的模型、API 配置和自定义草稿全部保留；
- 用户之后从 Dashboard 手动开启并保存为 `v2`，后续启动会保持开启；
- 主 Agent 和其他配置不受影响。

## 实现

- 将配置 schema 从 `xiaoba.branch-agents.v1` 升为 `v2`。
- 读取旧 `v1` 时规范化为内存中的 `v2` 结构，并强制 `enabled=false`，但不在 load 路径写回文件。
- 用户首次从 Dashboard 修改 Branch 配置时，复用正常保存路径持久化为 `v2`。
- 避免多个启动进程读取同一份 `v1` 后，由迟到的迁移写入覆盖用户刚保存的 `v2 enabled=true`。
- 没有配置文件但存在旧环境开关时，创建关闭状态的新配置；旧环境开关不再决定新配置是否开启。

## 验证

- `npx tsx --test tests/branch-agent-config.test.ts tests/dashboard-branch-agents-api.test.ts`：21 passed
- `npm run build`：通过
- GitHub CI：Build and runtime tests、CatsCo cross-repo smoke/e2e、BotDefinition Skills paired contract tests 全部通过

