### PR TITLE
fix(worker): wait for builder instanceID to populate; fall back on delete NotSupport

### DIFF
--- a/docs/superpowers/plans/2026-08-05-worker-image-platform-hardening.md
+++ b/docs/superpowers/plans/2026-08-05-worker-image-platform-hardening.md
@@ -9,7 +9,8 @@
 - **版本：** bump `1.4.7 → 1.4.8`（`inject-version.js v1.4.8`，commit `fbb919e` 直接推送 main；`verify-release-version` 要求三处同步已确认）
 - **发布：** 设置 repo var `CTYUN_AUTO_BAKE_WORKER_IMAGE=true`（tag 触发 bake 的前提）→ 打 `v1.4.8` tag 推送 → **Desktop Release CD**（run=25）已触发；**首次 bake**（run=1）**失败**
 - **⚠️ 首次 bake 失败根因（2026-08-06，天翼云配置前置条件）**：`ImportEcsKeypair` 报 `Ecs.OrderCheck.InvalidProjectID`——**不是代码/AK 问题**，而是子账号**缺少企业项目管理（EPS）权限**。天翼云 key pair 创建 API 的 OrderCheck **强制校验企业项目权限**，而 `CreateEcsInstance`/查询 API 不强制（所以实例创建正常、key pair 卡住）。排查链：本地同 AK 复现 → 排除 AK/节点类型/参数 → 控制台确认 default 项目 ID=0 → 发现 `ListRosProject` 403 → 子账号用户组 `catsco-cli-provisioner` 关联策略数 0 → 补加企业项目（EPS）策略后 `ImportEcsKeypair` 本地验证 **SUCCESS**。**前置条件：bake 用的天翼云子账号必须被"用户授权"关联到 default 企业项目并授予企业项目（EPS）权限**；`ros:project:list`（ListRosProject）仍 403 但不影响 bake。
-- **重试：** workflow_dispatch 重新触发 bake（run `31079403507`，2026-08-06 07:02，main + bake_image=true）运行中
+- **第二次 bake 失败（2026-08-06，run `31079403507`）→ 已定位并修复**：EPS 权限修复后 key pair 创建成功、builder 创建成功，但主流程抛 `Refusing to operate on an instance outside this bake`。**根因（已对真实 API 复现）**：天翼云实例创建后数秒内 `ListEcsInstances` 返回实例但 **`instanceID` 字段为空**（最终一致性延迟填充），`Find-BuilderInstance` 把空 ID 记为 `BuilderID` → `Assert-TemporaryBuilder` 拒绝。修复：`Find-BuilderInstance` 匹配时要求 `instanceID` 非空（为空则跳过、`Resolve-BuilderInstance` 重试）。**同时修复清理**：`Remove-Builder` 的 `--deleteEip/--deleteVolume` 在华南2（多可用区）报 `Ecs.Region.NotSupport`（已实测该区域删除实例后 EIP 自动释放）→ 改为 NotSupport 时 fallback 不带关联参数删除。新增回归场景 1016（instanceID 延迟填充 → bake 仍成功）、1017（Region.NotSupport → 删除 fallback）。
+- **重试：** 待修复合并到 main 后重新触发 bake（workflow_dispatch）
 - **测试：** `worker-image-pipeline.test.ts` 11/11、`npm run build` 通过（rebase 后本地已验证）
 - **下一步：** 等待 bake 完成 → 按下方步骤 10 验收标准在云端验收（platform 版本、fwupd mask、npm mirror、残留清理）→ 确认后删除验证用临时实例
 - **关联计划：** 应用制品更新 Part A 见 `2026-08-04-worker-artifact-update.md`（worker 更新通道与镜像烘焙并存，互为回退）

--- a/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
+++ b/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
@@ -259,7 +259,15 @@ function Find-BuilderInstance {
     foreach ($query in $queries) {
         $response = Invoke-Ctyun $query
         foreach ($candidate in @(Get-ResponseItems -Response $response -Name "results")) {
+            # A just-created instance is returned by the provider with a valid
+            # name and resourceID but an EMPTY instanceID for a few seconds
+            # (eventual consistency). Claiming it would record an empty
+            # BuilderID and immediately fail Assert-TemporaryBuilder with
+            # 'outside this bake', so only accept candidates whose immutable
+            # instanceID is already populated; Resolve-BuilderInstance retries
+            # until it appears.
             if (
+                [string]$candidate.instanceID -and
                 [string]$candidate.instanceName -eq $script:BuilderName -and
                 (
                     -not $script:BuilderResourceID -or
@@ -580,14 +588,30 @@ function Remove-Builder {
     }
     Assert-TemporaryBuilder $instance
     Write-Host "Deleting temporary builder $script:BuilderID"
-    Invoke-Ctyun @(
-        "ecs", "DeleteEcsInstance",
-        "--regionID", $RegionID,
-        "--instanceID", $script:BuilderID,
-        "--clientToken", ([guid]::NewGuid().ToString()),
-        "--deleteEip", "true",
-        "--deleteVolume", "true"
-    ) | Out-Null
+    try {
+        Invoke-Ctyun @(
+            "ecs", "DeleteEcsInstance",
+            "--regionID", $RegionID,
+            "--instanceID", $script:BuilderID,
+            "--clientToken", ([guid]::NewGuid().ToString()),
+            "--deleteEip", "true",
+            "--deleteVolume", "true"
+        ) | Out-Null
+    } catch {
+        # Multi-AZ resource pools (e.g. cn-huanan2) reject releasing associated
+        # resources at delete time (Ecs.Region.NotSupport). In those pools the
+        # EIP is released automatically when the instance is unsubscribed, so
+        # retry the plain delete instead of leaking the billed ECS.
+        if ($_.Exception.Message -notmatch "NotSupport") {
+            throw
+        }
+        Invoke-Ctyun @(
+            "ecs", "DeleteEcsInstance",
+            "--regionID", $RegionID,
+            "--instanceID", $script:BuilderID,
+            "--clientToken", ([guid]::NewGuid().ToString())
+        ) | Out-Null
+    }
 
     $deadline = Get-BoundedDeadline `
         -RequestedSeconds (8 * 60) `

--- a/tests/worker-image-pipeline.test.ts
+++ b/tests/worker-image-pipeline.test.ts
@@ -721,6 +721,12 @@ if (operation === "ims ListImage") {
   const instanceVisible =
     state.instanceExists && !(state.instanceHiddenReads > 0);
   if (state.instanceHiddenReads > 0) state.instanceHiddenReads -= 1;
+  // A just-created instance is returned with an empty instanceID for the
+  // first reads (eventual consistency), mirroring the real Tianyi API where
+  // Find-BuilderInstance must skip such candidates and retry instead of
+  // recording an empty BuilderID.
+  const instanceIDEmpty = state.instanceIDEmptyReads > 0;
+  if (state.instanceIDEmptyReads > 0) state.instanceIDEmptyReads -= 1;
   returnObj = {
     results:
       instanceVisible &&
@@ -728,7 +734,7 @@ if (operation === "ims ListImage") {
       (!requestedID || requestedID === instanceID) &&
       (!requestedName || requestedName === state.instanceName)
       ? [{
-          instanceID,
+          instanceID: instanceIDEmpty ? "" : instanceID,
           resourceID: "resource-1",
           instanceName: state.instanceName,
           instanceStatus: state.instanceStatus,
@@ -785,6 +791,20 @@ if (operation === "ims ListImage") {
     state.imageExists = false;
   }
 } else if (operation === "ecs DeleteEcsInstance") {
+  if (args.includes("--deleteEip") && state.deleteEipNotSupported) {
+    // Multi-AZ pools (e.g. cn-huanan2) reject releasing associated resources
+    // at delete time (Ecs.Region.NotSupport). The orchestrator must retry the
+    // plain delete instead of leaking the billed ECS.
+    fs.writeFileSync(statePath, JSON.stringify(state));
+    process.stdout.write(JSON.stringify({
+      statusCode: 900,
+      message: "ERROR",
+      description: "The region does not support unsubscribing/deleting instance to release associated resources",
+      errorCode: "Ecs.Region.NotSupport",
+      returnObj: {},
+    }));
+    process.exit(0);
+  }
   state.instanceExists = false;
 } else if (operation === "ecs DeleteEcsKeypair") {
   state.keyExists = false;
@@ -1604,6 +1624,93 @@ process.exit(result.status ?? 1);
         fs.readFileSync(statePath, "utf8"),
       );
       assert.equal(discoveryErrorState.keyExists, false);
+
+      // A just-created builder is returned with an empty instanceID for the
+      // first reads (Tianyi eventual consistency, reproduced against the real
+      // API). Find-BuilderInstance must skip the empty-ID candidate and retry;
+      // recording an empty BuilderID would make Assert-TemporaryBuilder reject
+      // the bake with 'outside this bake'.
+      fs.writeFileSync(logPath, "");
+      fs.writeFileSync(
+        statePath,
+        JSON.stringify({
+          instanceExists: false,
+          keyExists: false,
+          keyPairName: "",
+          imageExists: false,
+          imageName: "",
+          imageDescription: "",
+          imageSourceServerID: "",
+          imageStatus: "error",
+          instanceName: "",
+          instanceStatus: "running",
+          instanceIDEmptyReads: 2, // first 2 ListEcsInstances reads: empty ID
+        }),
+      );
+      const emptyIdResult = runBake(
+        "1016",
+        "catsco-worker-emptyid",
+        "success",
+      );
+      assert.equal(
+        emptyIdResult.status,
+        0,
+        `${emptyIdResult.stdout}\n${emptyIdResult.stderr}`,
+      );
+      assert.match(emptyIdResult.stdout, /"result":\s*"created"/);
+      const emptyIdCalls = fs.readFileSync(logPath, "utf8");
+      assert.ok(
+        (emptyIdCalls.match(/ecs ListEcsInstances/g) || []).length >= 3,
+        `expected Find-BuilderInstance to retry past empty-ID reads\n${emptyIdCalls}`,
+      );
+      const emptyIdState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+      assert.equal(emptyIdState.imageExists, true);
+      assert.equal(emptyIdState.instanceExists, false);
+      assert.equal(emptyIdState.keyExists, false);
+
+      // Multi-AZ pools reject deleting an ECS while releasing associated
+      // resources (Ecs.Region.NotSupport, reproduced against cn-huanan2).
+      // Remove-Builder must fall back to a plain delete so the failed-bake
+      // path still cleans up the billed builder.
+      const notSupportBuildNumber = "1017";
+      const notSupportBakeId = "001017-01";
+      fs.writeFileSync(logPath, "");
+      fs.writeFileSync(
+        statePath,
+        JSON.stringify({
+          instanceExists: false,
+          keyExists: false,
+          keyPairName: "",
+          imageExists: false,
+          imageName: "",
+          imageDescription: "",
+          imageSourceServerID: "",
+          imageStatus: "error",
+          instanceName: "",
+          instanceStatus: "running",
+          deleteEipNotSupported: true,
+        }),
+      );
+      const notSupportResult = runBake(
+        notSupportBuildNumber,
+        "catsco-worker-notsupport",
+      );
+      // Image creation fails by design (default scenario); the point is that
+      // cleanup still succeeds despite the Region.NotSupport delete error.
+      assert.notEqual(notSupportResult.status, 0);
+      const notSupportCalls = fs.readFileSync(logPath, "utf8");
+      assert.ok(
+        (notSupportCalls.match(/ecs DeleteEcsInstance/g) || []).length >= 2,
+        `expected DeleteEcsInstance fallback after NotSupport\n${notSupportCalls}`,
+      );
+      const notSupportState = JSON.parse(
+        fs.readFileSync(statePath, "utf8"),
+      );
+      assert.equal(notSupportState.instanceExists, false);
+      assert.equal(notSupportState.keyExists, false);
+      // The error-status image is removed by Remove-FailedImage on the failed
+      // bake path, just like the instance and key pair.
+      assert.equal(notSupportState.imageExists, false);
     } finally {
       fs.rmSync(sandbox, { recursive: true, force: true });
     }


### PR DESCRIPTION
Second real bake (v1.4.8) failed with \Refusing to operate on an instance outside this bake\ after the EPS-permission fix. Root cause reproduced against the real Tianyi API: a just-created instance is returned for a few seconds with an **empty instanceID** (eventual consistency), and \Find-BuilderInstance\ recorded it as \BuilderID\, so \Assert-TemporaryBuilder\ rejected the bake.

**Fixes**
1. \Find-BuilderInstance\ only claims candidates whose \instanceID\ is populated; \Resolve-BuilderInstance\ retries until it appears.
2. \Remove-Builder\ retries a plain \DeleteEcsInstance\ when \--deleteEip/--deleteVolume\ is rejected with \Ecs.Region.NotSupport\ (multi-AZ pools like cn-huanan2; EIP is released automatically there).

**Tests** — worker-image-pipeline 11/11 + build green. New scenarios: 1016 (bake succeeds past empty-ID reads), 1017 (cleanup falls back after NotSupport).