### PR TITLE
fix: recover transient Responses stream failures

### DIFF
--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -287,10 +287,7 @@ function formatModelRetryThinking(attempt: number, maxRetries: number, info?: St
   const retryIn = info && info.delayMs >= 1000
     ? `，约 ${Math.ceil(info.delayMs / 1000)} 秒后继续`
     : '';
-  const status = info?.status && info.status !== 'unknown'
-    ? `（${info.status}）`
-    : '';
-  return `模型连接异常${status}，正在重试 ${attempt}/${maxRetries}${retryIn}...`;
+  return `模型连接不稳定，正在自动恢复 ${attempt}/${maxRetries}${retryIn}...`;
 }
 
 function isActiveSubAgentStatusForUi(status?: SubAgentInfo['status']): boolean {

--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -84,6 +84,8 @@ export const ERROR_MESSAGE = '本次处理未能完成，请稍后再试。';
 export const MODEL_TIMEOUT_MESSAGE = '模型响应超时，本轮上下文已保留，请稍后继续。';
 export const MODEL_TRANSIENT_ERROR_MESSAGE = '模型服务暂时不可用，请稍后再试。';
 export const EMPTY_MODEL_RESPONSE_MESSAGE = '模型本轮未返回有效内容，请重新发送上一条消息；若仍失败，请切换模型或稍后再试。';
+export const MODEL_RECOVERY_FAILED_MESSAGE = '模型服务暂时不稳定，系统已尝试自动恢复但仍未成功，请稍后继续。';
+export const MODEL_REQUEST_FAILED_MESSAGE = '模型服务暂时不稳定，本次处理未能完成，请稍后继续。';
 export const CONTEXT_COMPACTION_START_MESSAGE = '正在压缩上下文，整理较早的对话内容。';
 export const CONTEXT_COMPACTION_COMPLETE_MESSAGE = '上下文压缩完成，继续处理当前请求。';
 export const CONTEXT_COMPACTION_ERROR_MESSAGE = '上下文压缩失败，已保留原上下文继续处理。';
@@ -773,6 +775,9 @@ export class AgentSession {
           provider_code: diagnostics.provider_code,
           provider_type: diagnostics.provider_type,
           provider_request_id: diagnostics.request_id,
+          provider_response_id: diagnostics.response_id,
+          terminal_event: diagnostics.terminal_event,
+          provider_failure_phase: diagnostics.failure_phase,
           error_fingerprint: diagnostics.fingerprint,
           stack_fingerprint: diagnostics.stack_fingerprint,
           top_frame: diagnostics.top_frame,
@@ -1271,19 +1276,16 @@ export class AgentSession {
     fallback: string,
     retryCount: number,
   ): string {
-    if (retryCount <= 0) return fallback;
-    switch (category) {
-      case 'timeout':
-        return '模型响应超时，系统已自动重试，但仍未完成。本轮上下文已保留，请稍后继续。';
-      case 'transient':
-        return '模型服务暂时不可用，系统已自动重试，但仍未恢复，请稍后再试。';
-      case 'rate_limited':
-        return '当前请求较多，系统已自动重试，但仍未恢复，请稍等片刻再试。';
-      case 'empty_response':
-        return '模型本轮未返回有效内容，系统已自动重试但仍未恢复。请重新发送上一条消息；若仍失败，请切换模型或稍后再试。';
-      default:
-        return fallback;
+    if (
+      category === 'image_safety'
+      || category === 'vision_unsupported'
+      || category === 'input_too_large'
+    ) {
+      return fallback;
     }
+    return retryCount > 0
+      ? MODEL_RECOVERY_FAILED_MESSAGE
+      : MODEL_REQUEST_FAILED_MESSAGE;
   }
 
   private formatErrorContextMessage(

--- a/src/core/checkpoint-compaction.ts
+++ b/src/core/checkpoint-compaction.ts
@@ -284,6 +284,7 @@ export class CheckpointCompactionCoordinator {
           { onText: text => { streamed += text; } },
           {
             signal,
+            streamOutputMode: 'buffered',
             promptCacheContext: {
               sessionKey,
               phase,

--- a/src/core/context-compressor.ts
+++ b/src/core/context-compressor.ts
@@ -426,7 +426,7 @@ export class ContextCompressor {
         {
           onText: (text) => { fullContent += text; },
         },
-        { signal: options.signal },
+        { signal: options.signal, streamOutputMode: 'buffered' },
       );
       const rawSummary = fullContent;
 

--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -1484,12 +1484,13 @@ export class ConversationRunner {
         phase: 'normal' as const,
         explicitCaching: true,
       },
+      streamOutputMode: callbacks?.onText ? 'live' as const : 'buffered' as const,
     };
     try {
       if (this.stream) {
         const streamCallbacks: StreamCallbacks = {
-          onText: (text) => callbacks?.onText?.(text),
           onRetry: (attempt, maxRetries, info) => callbacks?.onRetry?.(attempt, maxRetries, info),
+          ...(callbacks?.onText ? { onText: callbacks.onText } : {}),
         };
         return await this.aiService.chatStream(messages, activeTools, streamCallbacks, requestOptions);
       }
@@ -1508,8 +1509,8 @@ export class ConversationRunner {
 
       if (this.stream) {
         const streamCallbacks: StreamCallbacks = {
-          onText: (text) => callbacks?.onText?.(text),
           onRetry: (attempt, maxRetries, info) => callbacks?.onRetry?.(attempt, maxRetries, info),
+          ...(callbacks?.onText ? { onText: callbacks.onText } : {}),
         };
         return await this.aiService.chatStream(messages, activeTools, streamCallbacks, requestOptions);
       }

--- a/src/observability/turn-error-reader.ts
+++ b/src/observability/turn-error-reader.ts
@@ -20,6 +20,9 @@ export interface TurnErrorRecord {
   provider_code: string;
   provider_type: string;
   provider_request_id: string;
+  provider_response_id: string;
+  terminal_event: string;
+  provider_failure_phase: string;
   error_fingerprint: string;
   stack_fingerprint: string;
   top_frame: string;
@@ -164,6 +167,9 @@ function toTurnErrorRecord(entry: any, sourceFile: string, sourceLine: number): 
     provider_code: safeText(payload.provider_code),
     provider_type: safeText(payload.provider_type),
     provider_request_id: safeText(payload.provider_request_id),
+    provider_response_id: safeText(payload.provider_response_id),
+    terminal_event: safeText(payload.terminal_event),
+    provider_failure_phase: safeText(payload.provider_failure_phase),
     error_fingerprint: safeText(payload.error_fingerprint),
     stack_fingerprint: safeText(payload.stack_fingerprint),
     top_frame: safeText(payload.top_frame),

--- a/src/providers/openai-provider.ts
+++ b/src/providers/openai-provider.ts
@@ -28,6 +28,7 @@ interface ResponsesFailureMetadata {
   failurePhase?: ResponsesFailurePhase;
   terminalEvent?: string;
   responseId?: string;
+  requestId?: string;
 }
 
 interface ResponsesBreakpointDiagnostic {
@@ -1093,7 +1094,12 @@ export class OpenAIProvider implements AIProvider {
       || details?.response_id
       || '',
     ).trim();
-    const requestId = String(details?.request_id || response?.request_id || '').trim();
+    const requestId = String(
+      details?.request_id
+      || response?.request_id
+      || metadata.requestId
+      || '',
+    ).trim();
     return Object.assign(
       new Error(String(details?.message || 'Responses API request failed')),
       {
@@ -1120,15 +1126,48 @@ export class OpenAIProvider implements AIProvider {
       type: 'stream_error',
       message,
     };
+    const { requestId, ...failureMetadata } = metadata;
     return Object.assign(new Error(message), {
       code: details.code,
       providerCode: details.code,
       providerType: details.type,
       status: 502,
       error: details,
-      ...metadata,
-      ...(cause ? { cause } : {}),
+      ...failureMetadata,
+      ...(requestId ? { request_id: requestId } : {}),
+      ...(cause !== undefined ? { cause } : {}),
     });
+  }
+
+  private responsesRequestIdFromHeaders(headers: any): string | undefined {
+    for (const name of ['x-request-id', 'request-id', 'openai-request-id', 'x-openai-request-id']) {
+      let value: unknown;
+      try {
+        value = headers?.get?.(name) ?? headers?.[name] ?? headers?.[name.toLowerCase()];
+      } catch {
+        // Some Axios-compatible header implementations can throw for unknown keys.
+      }
+      if (value === undefined && headers && typeof headers === 'object') {
+        const matchingKey = Object.keys(headers).find(key => key.toLowerCase() === name);
+        if (matchingKey) value = headers[matchingKey];
+      }
+      if (Array.isArray(value)) value = value[0];
+      const requestId = typeof value === 'string' ? value.trim() : '';
+      if (requestId) return requestId;
+    }
+    return undefined;
+  }
+
+  private isStructuredResponsesStreamError(error: any): boolean {
+    return [
+      error?.code,
+      error?.status,
+      error?.response?.status,
+      error?.providerCode,
+      error?.providerType,
+      error?.error?.code,
+      error?.error?.type,
+    ].some(value => value !== undefined && value !== null && String(value).trim() !== '');
   }
 
   private parseResponsesUsage(usage: any): ChatResponse['usage'] {
@@ -1227,10 +1266,12 @@ export class OpenAIProvider implements AIProvider {
       );
     }
     ContextDebugLogger.dumpSdkBoundary('after', undefined, { response: response.data });
+    const responseRequestId = this.responsesRequestIdFromHeaders(response.headers);
     const failure = this.responsesFailureError(response.data, {
       failurePhase: 'terminal_event',
       terminalEvent: response.data?.status === 'failed' ? 'response.failed' : undefined,
       responseId: response.data?.id,
+      requestId: responseRequestId,
     });
     if (failure) throw failure;
     const result = this.parseResponsesResponse(response.data);
@@ -1274,6 +1315,8 @@ export class OpenAIProvider implements AIProvider {
         this.responsesUrl, body, true, options, retryHeaders,
       );
     }
+
+    const responseRequestId = this.responsesRequestIdFromHeaders(response.headers);
 
     return new Promise<ChatResponse>((resolve, reject) => {
       const stream = response.data;
@@ -1334,6 +1377,7 @@ export class OpenAIProvider implements AIProvider {
         if (event?.type === 'response.failed' || event?.type === 'error') {
           const failure = this.responsesFailureError(event?.response || {
             status: 'failed',
+            request_id: event?.request_id,
             error: event?.error || {
               code: event?.code,
               message: event?.message,
@@ -1342,6 +1386,7 @@ export class OpenAIProvider implements AIProvider {
             failurePhase: 'terminal_event',
             terminalEvent: event?.type,
             responseId: event?.response?.id || event?.response_id,
+            requestId: responseRequestId,
           });
           finishError(failure || new Error('Responses API request failed'));
         }
@@ -1373,7 +1418,11 @@ export class OpenAIProvider implements AIProvider {
         if (!finalResponse) {
           finishError(this.responsesStreamError(
             'Responses API stream ended without a terminal response',
-            { failurePhase: 'stream', terminalEvent: 'stream.end' },
+            {
+              failurePhase: 'stream',
+              terminalEvent: 'stream.end',
+              requestId: responseRequestId,
+            },
           ));
           return;
         }
@@ -1381,6 +1430,7 @@ export class OpenAIProvider implements AIProvider {
           failurePhase: 'terminal_event',
           terminalEvent: finalResponse?.status === 'failed' ? 'response.failed' : undefined,
           responseId: finalResponse?.id,
+          requestId: responseRequestId,
         });
         if (failure) {
           finishError(failure);
@@ -1413,11 +1463,33 @@ export class OpenAIProvider implements AIProvider {
           finishError(error);
           return;
         }
-        Object.assign(error, {
-          failurePhase: 'stream',
-          terminalEvent: 'stream.error',
-        });
-        finishError(error);
+        if (this.isStructuredResponsesStreamError(error)) {
+          const existingRequestId = String(
+            (error as any)?.request_id
+            || (error as any)?.requestId
+            || (error as any)?.error?.request_id
+            || (error as any)?.response?.request_id
+            || (error as any)?.response?.data?.request_id
+            || (error as any)?.response?.data?.error?.request_id
+            || '',
+          ).trim();
+          Object.assign(error, {
+            failurePhase: 'stream',
+            terminalEvent: 'stream.error',
+            ...(!existingRequestId && responseRequestId ? { request_id: responseRequestId } : {}),
+          });
+          finishError(error);
+          return;
+        }
+        finishError(this.responsesStreamError(
+          error?.message || 'Responses API stream read failed',
+          {
+            failurePhase: 'stream',
+            terminalEvent: 'stream.error',
+            requestId: responseRequestId,
+          },
+          error,
+        ));
       });
     });
   }

--- a/src/providers/openai-provider.ts
+++ b/src/providers/openai-provider.ts
@@ -19,6 +19,16 @@ import { createProviderStateReference, isProviderStateCompatible } from './provi
 
 const MAX_PROVIDER_ERROR_BODY_BYTES = 64 * 1024;
 const PROVIDER_ERROR_BODY_READ_TIMEOUT_MS = 2_000;
+const DEFAULT_RESPONSES_HEADERS_TIMEOUT_MS = 120_000;
+const MAX_RESPONSES_HEADERS_TIMEOUT_MS = 10 * 60 * 1000;
+
+type ResponsesFailurePhase = 'headers' | 'stream' | 'terminal_event';
+
+interface ResponsesFailureMetadata {
+  failurePhase?: ResponsesFailurePhase;
+  terminalEvent?: string;
+  responseId?: string;
+}
 
 interface ResponsesBreakpointDiagnostic {
   label: 'S';
@@ -1053,29 +1063,72 @@ export class OpenAIProvider implements AIProvider {
     };
   }
 
-  private responsesFailureError(response: any): Error | undefined {
+  private responsesFailureError(
+    response: any,
+    metadata: ResponsesFailureMetadata = {},
+  ): Error | undefined {
     if (response?.status !== 'failed' && !response?.error) return undefined;
     const details = response?.error && typeof response.error === 'object'
       ? response.error
       : { message: response?.error };
-    const code = String(details?.code || details?.type || '').trim();
+    const providerCode = String(details?.code || '').trim();
+    const providerType = String(details?.type || '').trim();
+    const code = providerCode || providerType;
     const statusByCode: Record<string, number> = {
       server_error: 500,
       rate_limit_exceeded: 429,
       overloaded_error: 529,
+      stream_read_error: 502,
+      upstream_error: 502,
+      server_is_overloaded: 503,
+      service_unavailable_error: 503,
     };
     const explicitStatus = Number(details?.status ?? details?.status_code ?? response?.status_code);
     const status = Number.isFinite(explicitStatus) && explicitStatus > 0
       ? explicitStatus
-      : statusByCode[code];
+      : statusByCode[providerCode] ?? statusByCode[providerType];
+    const responseId = String(
+      metadata.responseId
+      || response?.id
+      || details?.response_id
+      || '',
+    ).trim();
+    const requestId = String(details?.request_id || response?.request_id || '').trim();
     return Object.assign(
       new Error(String(details?.message || 'Responses API request failed')),
       {
         ...(code ? { code } : {}),
+        ...(providerCode ? { providerCode } : {}),
+        ...(providerType ? { providerType } : {}),
         ...(status ? { status } : {}),
+        ...(requestId ? { request_id: requestId } : {}),
+        ...(responseId ? { responseId } : {}),
+        ...(metadata.failurePhase ? { failurePhase: metadata.failurePhase } : {}),
+        ...(metadata.terminalEvent ? { terminalEvent: metadata.terminalEvent } : {}),
         error: details,
       },
     );
+  }
+
+  private responsesStreamError(
+    message: string,
+    metadata: ResponsesFailureMetadata,
+    cause?: unknown,
+  ): Error {
+    const details = {
+      code: 'stream_read_error',
+      type: 'stream_error',
+      message,
+    };
+    return Object.assign(new Error(message), {
+      code: details.code,
+      providerCode: details.code,
+      providerType: details.type,
+      status: 502,
+      error: details,
+      ...metadata,
+      ...(cause ? { cause } : {}),
+    });
   }
 
   private parseResponsesUsage(usage: any): ChatResponse['usage'] {
@@ -1174,7 +1227,11 @@ export class OpenAIProvider implements AIProvider {
       );
     }
     ContextDebugLogger.dumpSdkBoundary('after', undefined, { response: response.data });
-    const failure = this.responsesFailureError(response.data);
+    const failure = this.responsesFailureError(response.data, {
+      failurePhase: 'terminal_event',
+      terminalEvent: response.data?.status === 'failed' ? 'response.failed' : undefined,
+      responseId: response.data?.id,
+    });
     if (failure) throw failure;
     const result = this.parseResponsesResponse(response.data);
     this.logResponsesCacheUsage(
@@ -1277,7 +1334,14 @@ export class OpenAIProvider implements AIProvider {
         if (event?.type === 'response.failed' || event?.type === 'error') {
           const failure = this.responsesFailureError(event?.response || {
             status: 'failed',
-            error: event?.error || { message: event?.message },
+            error: event?.error || {
+              code: event?.code,
+              message: event?.message,
+            },
+          }, {
+            failurePhase: 'terminal_event',
+            terminalEvent: event?.type,
+            responseId: event?.response?.id || event?.response_id,
           });
           finishError(failure || new Error('Responses API request failed'));
         }
@@ -1307,10 +1371,17 @@ export class OpenAIProvider implements AIProvider {
         const tail = contentStripper.flush();
         emitVisibleText(tail);
         if (!finalResponse) {
-          finishError(new Error('Responses API stream ended without a terminal response'));
+          finishError(this.responsesStreamError(
+            'Responses API stream ended without a terminal response',
+            { failurePhase: 'stream', terminalEvent: 'stream.end' },
+          ));
           return;
         }
-        const failure = this.responsesFailureError(finalResponse);
+        const failure = this.responsesFailureError(finalResponse, {
+          failurePhase: 'terminal_event',
+          terminalEvent: finalResponse?.status === 'failed' ? 'response.failed' : undefined,
+          responseId: finalResponse?.id,
+        });
         if (failure) {
           finishError(failure);
           return;
@@ -1338,6 +1409,14 @@ export class OpenAIProvider implements AIProvider {
 
       stream.on('error', (error: Error) => {
         options?.signal?.removeEventListener('abort', onAbort);
+        if (isProviderAbortError(error) || options?.signal?.aborted) {
+          finishError(error);
+          return;
+        }
+        Object.assign(error, {
+          failurePhase: 'stream',
+          terminalEvent: 'stream.error',
+        });
         finishError(error);
       });
     });
@@ -1362,17 +1441,60 @@ export class OpenAIProvider implements AIProvider {
     options?: AIRequestOptions,
     headers: Record<string, string> = this.headers,
   ): Promise<any> {
+    const headersTimeoutMs = stream && url === this.responsesUrl
+      ? this.responsesHeadersTimeoutMs()
+      : 0;
+    const watchdogController = headersTimeoutMs > 0 ? new AbortController() : undefined;
+    let watchdogTimedOut = false;
+    let watchdogTimer: NodeJS.Timeout | undefined;
+    const onUserAbort = () => watchdogController?.abort();
+    if (watchdogController && options?.signal) {
+      if (options.signal.aborted) watchdogController.abort();
+      else options.signal.addEventListener('abort', onUserAbort, { once: true });
+    }
+    if (watchdogController) {
+      watchdogTimer = setTimeout(() => {
+        watchdogTimedOut = true;
+        watchdogController.abort();
+      }, headersTimeoutMs);
+    }
+
     try {
       return await axios.post(url, body, {
         headers,
         ...(stream ? { responseType: 'stream' as const } : {}),
-        signal: options?.signal,
+        signal: watchdogController?.signal ?? options?.signal,
       });
     } catch (error) {
+      if (watchdogTimedOut) {
+        throw Object.assign(
+          new Error(`Responses API did not return headers within ${headersTimeoutMs}ms`),
+          {
+            name: 'ResponsesHeadersTimeoutError',
+            code: 'XIAOBA_RESPONSES_HEADERS_TIMEOUT',
+            status: 504,
+            providerCode: 'headers_timeout',
+            failurePhase: 'headers' as const,
+            cause: error,
+          },
+        );
+      }
       if (options?.signal?.aborted || isProviderAbortError(error)) throw error;
       const normalizedError = await this.normalizeProviderErrorResponse(error);
       throw normalizedError;
+    } finally {
+      if (watchdogTimer) clearTimeout(watchdogTimer);
+      options?.signal?.removeEventListener('abort', onUserAbort);
     }
+  }
+
+  private responsesHeadersTimeoutMs(): number {
+    const raw = String(process.env.XIAOBA_RESPONSES_HEADERS_TIMEOUT_MS || '').trim();
+    if (!raw) return DEFAULT_RESPONSES_HEADERS_TIMEOUT_MS;
+    const parsed = Number(raw);
+    if (!Number.isFinite(parsed)) return DEFAULT_RESPONSES_HEADERS_TIMEOUT_MS;
+    if (parsed <= 0) return 0;
+    return Math.min(MAX_RESPONSES_HEADERS_TIMEOUT_MS, Math.max(1, Math.floor(parsed)));
   }
 
   private async normalizeProviderErrorResponse(error: unknown): Promise<unknown> {

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -89,6 +89,12 @@ export interface ModelAttemptSink {
 
 export interface AIRequestOptions {
   signal?: AbortSignal;
+  /**
+   * Live mode forwards text immediately and disables transparent replay once
+   * the caller has observed output. Buffered mode publishes text only after a
+   * provider attempt completes, so a failed attempt can be retried safely.
+   */
+  streamOutputMode?: 'live' | 'buffered';
   /** Optional best-effort observer; it can never alter request control flow. */
   modelAttemptSink?: ModelAttemptSink;
   modelAttemptContext?: ModelAttemptContext;

--- a/src/utils/ai-service.ts
+++ b/src/utils/ai-service.ts
@@ -45,6 +45,15 @@ const EMPTY_RESPONSE_ERROR_CODE = 'EMPTY_MODEL_RESPONSE';
 const EMPTY_RESPONSE_MAX_RETRIES = 2;
 const EMPTY_RESPONSE_MAX_ELAPSED_MS = 2 * 60 * 1000;
 const EMPTY_RESPONSE_MAX_DELAY_MS = 2000;
+const TRANSIENT_PROVIDER_CODES = new Set([
+  'stream_read_error',
+  'upstream_error',
+  'server_is_overloaded',
+  'service_unavailable_error',
+]);
+const RESPONSES_TRANSIENT_MAX_RETRIES = 2;
+const TRANSIENT_HTTP_MAX_RETRIES = 2;
+const GATEWAY_TIMEOUT_MAX_RETRIES = 1;
 let modelAttemptCallSequence = 0;
 
 type ProviderKind = 'openai' | 'anthropic';
@@ -54,6 +63,7 @@ interface RetryPolicy {
   maxElapsedMs: number;
   baseDelayMs: number;
   maxDelayMs: number;
+  guaranteedRetries: number;
 }
 
 interface ModelAttemptRun {
@@ -170,19 +180,39 @@ export class AIService {
 
     const allowStreamRetry = process.env.GAUZ_STREAM_RETRY === 'true';
     const prepared = this.prepareProviderRequest(messages);
-    let hasStreamedText = false;
-    const providerCallbacks = this.createProviderStreamCallbacks(callbacks, () => {
-      hasStreamedText = true;
-    });
+    const supportsBufferedRecovery = this.isResponsesMode();
+    const streamOutputMode = supportsBufferedRecovery
+      ? options.streamOutputMode ?? (callbacks?.onText ? 'live' : 'buffered')
+      : 'live';
+    let hasObservedText = false;
+    let hasDeliveredText = false;
 
     try {
       const result = await this.withRetry(
-        async () => this.requireUsableResponse(
-          await this.provider.chatStream(prepared.messages, tools, providerCallbacks, options),
-        ),
+        async () => {
+          const bufferedChunks: string[] = [];
+          const providerCallbacks = this.createProviderStreamCallbacks(text => {
+            hasObservedText = true;
+            if (streamOutputMode === 'buffered') {
+              bufferedChunks.push(text);
+              return;
+            }
+            if (callbacks?.onText) {
+              callbacks.onText(text);
+              hasDeliveredText = true;
+            }
+          });
+          const response = this.requireUsableResponse(
+            await this.provider.chatStream(prepared.messages, tools, providerCallbacks, options),
+          );
+          if (streamOutputMode === 'buffered' && bufferedChunks.length > 0) {
+            callbacks?.onText?.(bufferedChunks.join(''));
+          }
+          return response;
+        },
         callbacks,
         options.signal,
-        () => allowStreamRetry || !hasStreamedText,
+        () => allowStreamRetry || (supportsBufferedRecovery ? !hasDeliveredText : !hasObservedText),
         this.createModelAttemptRun(prepared.messages, tools, true, options, prepared.summary),
       );
       callbacks?.onComplete?.(result);
@@ -194,15 +224,14 @@ export class AIService {
     }
   }
 
-  private createProviderStreamCallbacks(callbacks?: StreamCallbacks, onTextObserved?: () => void): StreamCallbacks | undefined {
-    if (!callbacks) {
+  private createProviderStreamCallbacks(onText?: (text: string) => void): StreamCallbacks | undefined {
+    if (!onText) {
       return undefined;
     }
 
     return {
       onText: (text: string) => {
-        if (text) onTextObserved?.();
-        callbacks.onText?.(text);
+        if (text) onText(text);
       },
     };
   }
@@ -294,6 +323,10 @@ export class AIService {
       return false;
     }
 
+    if (this.isResponsesMode() && this.isSemanticTransientProviderError(error)) {
+      return true;
+    }
+
     if (this.isKnownNonRetryableProviderError(error)) {
       return false;
     }
@@ -362,6 +395,28 @@ export class AIService {
 
     return /insufficient[_\s-]?quota|quota[_\s-]?exceeded|billing|(?:insufficient|low|exhausted)[_\s-]?(?:credit|balance)|(?:credit|balance)[_\s-]?(?:exhausted|insufficient|too low)|账户余额|余额不足|额度不足|额度已用尽|context length|maximum context|max(?:imum)? tokens?|prompt too long|invalid[_\s-]?request|invalid[_\s-]?api[_\s-]?key|unauthorized|forbidden|permission denied|model .*not found|model_not_found|tool schema|schema is invalid|content policy|safety/i
       .test(message);
+  }
+
+  private isSemanticTransientProviderError(error: any): boolean {
+    return this.extractProviderSemanticCodes(error)
+      .some(code => TRANSIENT_PROVIDER_CODES.has(code));
+  }
+
+  private extractProviderSemanticCodes(error: any): string[] {
+    return [
+      error?.providerCode,
+      error?.providerType,
+      error?.response?.data?.error?.code,
+      error?.response?.data?.error?.type,
+      error?.response?.data?.code,
+      error?.response?.data?.type,
+      error?.error?.code,
+      error?.error?.type,
+      error?.code,
+      error?.type,
+    ]
+      .filter(value => typeof value === 'string' && value.trim())
+      .map(value => String(value).trim().toLowerCase());
   }
 
   /**
@@ -497,7 +552,10 @@ export class AIService {
           },
         });
 
-        const status = this.extractStatus(error) || this.extractErrorCode(error) || 'unknown';
+        const status = this.extractStatus(error)
+          || this.extractErrorCode(error)
+          || this.extractProviderSemanticCodes(error)[0]
+          || 'unknown';
         const retryInfo: StreamRetryInfo = {
           attempt: retryAttempt,
           maxRetries: policy.maxRetries,
@@ -529,7 +587,9 @@ export class AIService {
     if (!this.isRetryable(error)) return 'non_retryable';
     if (shouldRetry?.(error, retryAttempt) === false) return 'stream_output_started';
     if (retryAttempt > policy.maxRetries) return 'retry_limit_exhausted';
-    if (elapsedMs >= policy.maxElapsedMs) return 'retry_window_exhausted';
+    if (elapsedMs >= policy.maxElapsedMs && retryAttempt > policy.guaranteedRetries) {
+      return 'retry_window_exhausted';
+    }
     return undefined;
   }
 
@@ -618,6 +678,7 @@ export class AIService {
         MAX_CONFIGURABLE_RETRY_DURATION_MS,
       ),
       baseDelayMs: BASE_DELAY_MS,
+      guaranteedRetries: 0,
     };
 
     if (this.isEmptyModelResponseError(error)) {
@@ -626,6 +687,28 @@ export class AIService {
         maxRetries: Math.min(policy.maxRetries, EMPTY_RESPONSE_MAX_RETRIES),
         maxElapsedMs: Math.min(policy.maxElapsedMs, EMPTY_RESPONSE_MAX_ELAPSED_MS),
         maxDelayMs: Math.min(policy.maxDelayMs, EMPTY_RESPONSE_MAX_DELAY_MS),
+      };
+    }
+
+    if (this.isResponsesMode() && this.isGatewayTimeoutError(error)) {
+      return {
+        ...policy,
+        maxRetries: Math.min(policy.maxRetries, GATEWAY_TIMEOUT_MAX_RETRIES),
+        guaranteedRetries: Math.min(policy.maxRetries, GATEWAY_TIMEOUT_MAX_RETRIES),
+      };
+    }
+
+    if (this.isResponsesMode() && this.isSemanticTransientProviderError(error)) {
+      return {
+        ...policy,
+        maxRetries: Math.min(policy.maxRetries, RESPONSES_TRANSIENT_MAX_RETRIES),
+      };
+    }
+
+    if (this.isResponsesMode() && [502, 503, 529].includes(this.extractStatus(error) ?? 0)) {
+      return {
+        ...policy,
+        maxRetries: Math.min(policy.maxRetries, TRANSIENT_HTTP_MAX_RETRIES),
       };
     }
 
@@ -646,7 +729,9 @@ export class AIService {
     const rawDelay = retryAfter !== null
       ? retryAfter * 1000
       : Math.min(policy.maxDelayMs, policy.baseDelayMs * Math.pow(2, retryAttempt - 1)) + Math.random() * 500;
-    const remainingMs = Math.max(0, policy.maxElapsedMs - elapsedMs);
+    const remainingMs = elapsedMs >= policy.maxElapsedMs && retryAttempt <= policy.guaranteedRetries
+      ? policy.maxDelayMs
+      : Math.max(0, policy.maxElapsedMs - elapsedMs);
     return Math.max(0, Math.min(rawDelay, remainingMs));
   }
 
@@ -680,6 +765,18 @@ export class AIService {
 
   private isShortNetworkRetryError(error: any): boolean {
     return SHORT_NETWORK_RETRY_CODES.has(this.extractErrorCode(error));
+  }
+
+  private isGatewayTimeoutError(error: any): boolean {
+    const code = this.extractErrorCode(error);
+    return this.extractStatus(error) === 504
+      || code === 'XIAOBA_RESPONSES_HEADERS_TIMEOUT'
+      || code === 'UND_ERR_HEADERS_TIMEOUT';
+  }
+
+  private isResponsesMode(): boolean {
+    return this.config.provider === 'openai'
+      && this.config.openaiApiMode === 'responses';
   }
 
   private async notifyRetry(

--- a/src/utils/model-error-observability.ts
+++ b/src/utils/model-error-observability.ts
@@ -42,6 +42,9 @@ export interface ModelErrorDiagnostics {
   provider_code?: string;
   provider_type?: string;
   request_id?: string;
+  response_id?: string;
+  terminal_event?: string;
+  failure_phase?: string;
   error_name?: string;
   top_frame?: string;
   stack_fingerprint?: string;
@@ -149,6 +152,14 @@ function captureModelErrorDiagnosticsUnsafe(
     error?.response?.headers?.['x-request-id'],
     error?.headers?.['x-request-id'],
   );
+  const responseId = firstText(
+    existing?.response_id,
+    error?.responseId,
+    error?.response_id,
+    responseError?.response_id,
+  );
+  const terminalEvent = firstText(existing?.terminal_event, error?.terminalEvent);
+  const failurePhase = firstText(existing?.failure_phase, error?.failurePhase);
   const sourceMessage = firstText(
     responseError?.message,
     error?.response?.data?.message,
@@ -175,6 +186,9 @@ function captureModelErrorDiagnosticsUnsafe(
     provider_code: providerCode ?? transportCode,
     provider_type: providerType,
     request_id: requestId,
+    response_id: responseId,
+    terminal_event: terminalEvent,
+    failure_phase: failurePhase,
     error_name: errorName,
     top_frame: existing?.top_frame ?? stack.topFrame,
     stack_fingerprint: existing?.stack_fingerprint ?? stack.fingerprint,
@@ -242,6 +256,9 @@ function normalizeDiagnostics(input: ModelErrorDiagnostics): ModelErrorDiagnosti
     ...(safeText(input.provider_code) && { provider_code: safeText(input.provider_code) }),
     ...(safeText(input.provider_type) && { provider_type: safeText(input.provider_type) }),
     ...(safeText(input.request_id) && { request_id: safeText(input.request_id) }),
+    ...(safeText(input.response_id) && { response_id: safeText(input.response_id) }),
+    ...(safeText(input.terminal_event) && { terminal_event: safeText(input.terminal_event) }),
+    ...(safeText(input.failure_phase) && { failure_phase: safeText(input.failure_phase) }),
     ...(safeText(input.error_name) && { error_name: safeText(input.error_name) }),
     ...(safeText(input.top_frame) && { top_frame: safeText(input.top_frame) }),
     ...(safeText(input.stack_fingerprint) && { stack_fingerprint: safeText(input.stack_fingerprint) }),

--- a/src/utils/session-log-schema.ts
+++ b/src/utils/session-log-schema.ts
@@ -80,6 +80,9 @@ export interface TurnErrorPayload {
   provider_code?: string;
   provider_type?: string;
   provider_request_id?: string;
+  provider_response_id?: string;
+  terminal_event?: string;
+  provider_failure_phase?: string;
   error_fingerprint?: string;
   stack_fingerprint?: string;
   top_frame?: string;

--- a/tests/ai-service.test.ts
+++ b/tests/ai-service.test.ts
@@ -102,7 +102,7 @@ test('AIService can keep retrying transient stream failures beyond the old short
       if (attempts <= 4) {
         throw Object.assign(new Error(`temporary stream failure ${attempts}`), {
           response: {
-            status: 503,
+            status: 500,
             headers: { 'retry-after': '0' },
             data: { message: 'temporary stream failure' },
           },
@@ -160,6 +160,43 @@ test('AIService does not retry stream errors after visible text is emitted', asy
   assert.equal(errors.length, 1);
   assert.deepStrictEqual(retries, []);
   assert.deepStrictEqual(chunks, ['partial']);
+});
+
+test('AIService retries buffered stream failures without publishing abandoned text', async () => {
+  process.env.CATSCO_MODEL_RETRY_MAX_RETRIES = '1';
+  const service = createTestService();
+  (service as any).config.openaiApiMode = 'responses';
+  let attempts = 0;
+  const finalResponse: ChatResponse = { content: 'recovered' };
+  (service as any).provider = {
+    chat: async () => ({ content: null }),
+    chatStream: async (_messages: unknown, _tools: unknown, callbacks?: StreamCallbacks) => {
+      attempts += 1;
+      callbacks?.onText?.(attempts === 1 ? 'abandoned draft' : 'recovered');
+      if (attempts === 1) {
+        throw Object.assign(new Error('stream interrupted'), {
+          code: 'stream_read_error',
+          error: { code: 'stream_read_error', type: 'stream_error' },
+        });
+      }
+      return finalResponse;
+    },
+  };
+  (service as any).sleepWithAbort = async () => {};
+
+  const chunks: string[] = [];
+  const retries: number[] = [];
+  const result = await service.chatStream([], undefined, {
+    onText: text => chunks.push(text),
+    onRetry: attempt => retries.push(attempt),
+  }, {
+    streamOutputMode: 'buffered',
+  });
+
+  assert.equal(result, finalResponse);
+  assert.equal(attempts, 2);
+  assert.deepStrictEqual(chunks, ['recovered']);
+  assert.deepStrictEqual(retries, [1]);
 });
 
 test('AIService still honors explicit full stream retry opt-in', async () => {
@@ -366,6 +403,72 @@ test('AIService still retries transient load balancer failures', async () => {
 
   assert.deepStrictEqual(result, { content: 'ok' });
   assert.equal(attempts, 2);
+});
+
+test('AIService retries Responses semantic transient codes and types', async () => {
+  const semanticFailures = [
+    { code: 'stream_read_error' },
+    { code: 'upstream_error' },
+    { type: 'server_is_overloaded' },
+    { type: 'service_unavailable_error' },
+  ];
+
+  for (const semantic of semanticFailures) {
+    process.env.CATSCO_MODEL_RETRY_MAX_RETRIES = '1';
+    const service = createTestService();
+    (service as any).config.openaiApiMode = 'responses';
+    let attempts = 0;
+    (service as any).provider = {
+      chat: async () => {
+        attempts += 1;
+        if (attempts === 1) {
+          throw Object.assign(new Error('semantic provider failure'), {
+            ...semantic,
+            error: { ...semantic, message: 'semantic provider failure' },
+          });
+        }
+        return { content: 'ok' };
+      },
+      chatStream: async () => ({ content: null }),
+    };
+    (service as any).sleepWithAbort = async () => {};
+
+    const result = await service.chat([]);
+    assert.equal(result.content, 'ok');
+    assert.equal(attempts, 2, JSON.stringify(semantic));
+  }
+});
+
+test('AIService guarantees one recovery attempt after a first 504 exhausts the retry window', () => {
+  process.env.CATSCO_MODEL_RETRY_MAX_RETRIES = '14';
+  process.env.CATSCO_MODEL_RETRY_MAX_MS = '1000';
+  const service = createTestService();
+  (service as any).config.openaiApiMode = 'responses';
+  const gatewayTimeout = Object.assign(new Error('gateway timeout'), { status: 504 });
+  const policy = (service as any).resolveRetryPolicy(gatewayTimeout);
+
+  assert.equal(policy.maxRetries, 1);
+  assert.equal(policy.guaranteedRetries, 1);
+  assert.equal(
+    (service as any).resolveRetryStopReason(gatewayTimeout, 1, policy, 300_000),
+    undefined,
+  );
+  assert.equal(
+    (service as any).resolveRetryStopReason(gatewayTimeout, 2, policy, 301_000),
+    'retry_limit_exhausted',
+  );
+  assert.ok((service as any).resolveRetryDelayMs(gatewayTimeout, 1, policy, 300_000) > 0);
+});
+
+test('AIService bounds Responses gateway retries without changing other API modes', () => {
+  process.env.CATSCO_MODEL_RETRY_MAX_RETRIES = '14';
+  const responsesService = createTestService();
+  (responsesService as any).config.openaiApiMode = 'responses';
+  const chatCompletionsService = createTestService();
+  const unavailable = Object.assign(new Error('service unavailable'), { status: 503 });
+
+  assert.equal((responsesService as any).resolveRetryPolicy(unavailable).maxRetries, 2);
+  assert.equal((chatCompletionsService as any).resolveRetryPolicy(unavailable).maxRetries, 14);
 });
 
 test('AIService uses a short retry policy for likely custom endpoint configuration errors', () => {

--- a/tests/catscompany-content-blocks.test.ts
+++ b/tests/catscompany-content-blocks.test.ts
@@ -166,7 +166,7 @@ describe('CatsCo content blocks', () => {
     assert.equal(replies.length, 0);
     assert.equal(sentThinking.length, 1);
     assert.equal(sentThinking[0].topic, 'p2p_retry');
-    assert.equal(sentThinking[0].text, '模型连接异常（503），正在重试 3/14，约 8 秒后继续...');
+    assert.equal(sentThinking[0].text, '模型连接不稳定，正在自动恢复 3/14，约 8 秒后继续...');
     assert.equal(sentThinking[0].metadata.model_retry, true);
     assert.equal(sentThinking[0].metadata.delay_ms, 8000);
   });

--- a/tests/conversation-runner-abort-signal.test.ts
+++ b/tests/conversation-runner-abort-signal.test.ts
@@ -41,6 +41,34 @@ test('ConversationRunner passes AbortSignal to streamed model requests', async (
   assert.equal(observedSignal?.aborted, true);
 });
 
+test('ConversationRunner marks non-live surfaces as buffered without creating a no-op text callback', async () => {
+  const observations: Array<{ callbacks: any; options: any }> = [];
+  const aiService = {
+    async chatStream(_messages: Message[], _tools: ToolDefinition[], callbacks: any, options: any = {}) {
+      observations.push({ callbacks, options });
+      return { content: 'done', toolCalls: [] };
+    },
+  };
+
+  const bufferedRunner = new ConversationRunner(aiService as any, new EmptyToolExecutor(), {
+    enableCompression: false,
+  });
+  await bufferedRunner.run([{ role: 'user', content: 'buffered' }]);
+
+  const liveRunner = new ConversationRunner(aiService as any, new EmptyToolExecutor(), {
+    enableCompression: false,
+  });
+  await liveRunner.run(
+    [{ role: 'user', content: 'live' }],
+    { onText: () => undefined },
+  );
+
+  assert.equal(observations[0].options.streamOutputMode, 'buffered');
+  assert.equal(observations[0].callbacks.onText, undefined);
+  assert.equal(observations[1].options.streamOutputMode, 'live');
+  assert.equal(typeof observations[1].callbacks.onText, 'function');
+});
+
 test('ConversationRunner reuses AbortSignal after prompt-too-long trim retry', async () => {
   const controller = new AbortController();
   const observedSignals: Array<AbortSignal | undefined> = [];

--- a/tests/openai-provider-responses.test.ts
+++ b/tests/openai-provider-responses.test.ts
@@ -327,8 +327,14 @@ describe('OpenAIProvider Responses API mode', () => {
     const originalPost = axios.post;
     (axios as any).post = async () => ({
       data: {
+        id: 'resp_failed_1',
         status: 'failed',
-        error: { code: 'server_error', message: 'upstream unavailable' },
+        error: {
+          code: 'upstream_error',
+          type: 'server_error',
+          message: 'upstream unavailable',
+          request_id: 'req_failed_1',
+        },
       },
     });
 
@@ -337,8 +343,12 @@ describe('OpenAIProvider Responses API mode', () => {
         createProvider().chat([{ role: 'user', content: 'hello' }]),
         (error: any) => (
           error?.message === 'upstream unavailable'
-          && error?.code === 'server_error'
-          && error?.status === 500
+          && error?.code === 'upstream_error'
+          && error?.providerCode === 'upstream_error'
+          && error?.providerType === 'server_error'
+          && error?.status === 502
+          && error?.responseId === 'resp_failed_1'
+          && error?.request_id === 'req_failed_1'
         ),
       );
     } finally {
@@ -520,6 +530,264 @@ describe('OpenAIProvider Responses API mode', () => {
       assert.equal(result.usage?.cachedReadTokens, 8);
     } finally {
       (axios as any).post = originalPost;
+    }
+  });
+
+  test('preserves structured metadata from a terminal response.failed event', async () => {
+    const originalPost = axios.post;
+    (axios as any).post = async () => ({
+      data: Readable.from([
+        sse({
+          type: 'response.failed',
+          response: {
+            id: 'resp_stream_failed',
+            status: 'failed',
+            error: {
+              code: 'stream_read_error',
+              type: 'upstream_error',
+              message: 'relay stream failed',
+              request_id: 'req_stream_failed',
+            },
+          },
+        }),
+      ]),
+    });
+
+    try {
+      await assert.rejects(
+        createProvider().chatStream([{ role: 'user', content: 'hello' }]),
+        (error: any) => (
+          error?.code === 'stream_read_error'
+          && error?.providerCode === 'stream_read_error'
+          && error?.providerType === 'upstream_error'
+          && error?.responseId === 'resp_stream_failed'
+          && error?.request_id === 'req_stream_failed'
+          && error?.terminalEvent === 'response.failed'
+          && error?.failurePhase === 'terminal_event'
+        ),
+      );
+    } finally {
+      (axios as any).post = originalPost;
+    }
+  });
+
+  test('treats a terminal error event as a structured Responses failure', async () => {
+    const originalPost = axios.post;
+    (axios as any).post = async () => ({
+      data: Readable.from([
+        sse({
+          type: 'error',
+          code: 'service_unavailable_error',
+          message: 'temporarily unavailable',
+        }),
+      ]),
+    });
+
+    try {
+      await assert.rejects(
+        createProvider().chatStream([{ role: 'user', content: 'hello' }]),
+        (error: any) => (
+          error?.code === 'service_unavailable_error'
+          && error?.status === 503
+          && error?.terminalEvent === 'error'
+          && error?.failurePhase === 'terminal_event'
+        ),
+      );
+    } finally {
+      (axios as any).post = originalPost;
+    }
+  });
+
+  test('retries the same streaming Responses request after a transient terminal failure', async () => {
+    const originalPost = axios.post;
+    const originalRetries = process.env.CATSCO_MODEL_RETRY_MAX_RETRIES;
+    const bodies: any[] = [];
+    const requestHeaders: any[] = [];
+    (axios as any).post = async (_url: string, body: any, config: any) => {
+      bodies.push(body);
+      requestHeaders.push(config.headers);
+      return {
+        data: bodies.length === 1
+          ? Readable.from([sse({
+              type: 'response.failed',
+              response: {
+                status: 'failed',
+                error: { code: 'upstream_error', message: 'try again' },
+              },
+            })])
+          : Readable.from([sse({
+              type: 'response.completed',
+              response: {
+                status: 'completed',
+                output: [{
+                  type: 'message',
+                  role: 'assistant',
+                  content: [{ type: 'output_text', text: 'recovered' }],
+                }],
+              },
+            })]),
+      };
+    };
+    process.env.CATSCO_MODEL_RETRY_MAX_RETRIES = '1';
+
+    try {
+      const service = new AIService({
+        apiKey: 'test-key',
+        apiUrl: 'https://example.test/v1',
+        model: 'gpt-test',
+        provider: 'openai',
+        openaiApiMode: 'responses',
+      });
+      (service as any).sleepWithAbort = async () => {};
+      const result = await service.chatStream(
+        [{ role: 'user', content: 'hello' }],
+        undefined,
+        undefined,
+        {
+          promptCacheContext: {
+            sessionKey: 'catscompany:test-session',
+            phase: 'normal',
+            explicitCaching: false,
+          },
+        },
+      );
+
+      assert.equal(result.content, 'recovered');
+      assert.equal(bodies.length, 2);
+      assert.equal(bodies[0].stream, true);
+      assert.equal(bodies[1].stream, true);
+      assert.equal(bodies[0].prompt_cache_key, bodies[1].prompt_cache_key);
+      assert.equal(requestHeaders[0].session_id, requestHeaders[1].session_id);
+      assert.equal(requestHeaders[0]['x-client-request-id'], requestHeaders[1]['x-client-request-id']);
+    } finally {
+      (axios as any).post = originalPost;
+      if (originalRetries === undefined) delete process.env.CATSCO_MODEL_RETRY_MAX_RETRIES;
+      else process.env.CATSCO_MODEL_RETRY_MAX_RETRIES = originalRetries;
+    }
+  });
+
+  test('does not expose abandoned function calls when a stream ends before its terminal event', async () => {
+    const originalPost = axios.post;
+    const originalRetries = process.env.CATSCO_MODEL_RETRY_MAX_RETRIES;
+    let attempts = 0;
+    (axios as any).post = async () => {
+      attempts += 1;
+      return {
+        data: attempts === 1
+          ? Readable.from([sse({
+              type: 'response.output_item.done',
+              output_index: 0,
+              item: {
+                type: 'function_call',
+                call_id: 'abandoned_call',
+                name: 'lookup',
+                arguments: '{"query":"abandoned"}',
+              },
+            })])
+          : Readable.from([sse({
+              type: 'response.completed',
+              response: {
+                status: 'completed',
+                output: [{
+                  type: 'function_call',
+                  call_id: 'recovered_call',
+                  name: 'lookup',
+                  arguments: '{"query":"recovered"}',
+                }],
+              },
+            })]),
+      };
+    };
+    process.env.CATSCO_MODEL_RETRY_MAX_RETRIES = '1';
+
+    try {
+      const service = new AIService({
+        apiKey: 'test-key',
+        apiUrl: 'https://example.test/v1',
+        model: 'gpt-test',
+        provider: 'openai',
+        openaiApiMode: 'responses',
+      });
+      (service as any).sleepWithAbort = async () => {};
+      const result = await service.chatStream(
+        [{ role: 'user', content: 'use a tool' }],
+        [lookupTool],
+        undefined,
+        { streamOutputMode: 'buffered' },
+      );
+
+      assert.equal(attempts, 2);
+      assert.deepEqual(result.toolCalls?.map(call => call.id), ['recovered_call']);
+      assert.equal(JSON.stringify(result.providerContent).includes('abandoned_call'), false);
+    } finally {
+      (axios as any).post = originalPost;
+      if (originalRetries === undefined) delete process.env.CATSCO_MODEL_RETRY_MAX_RETRIES;
+      else process.env.CATSCO_MODEL_RETRY_MAX_RETRIES = originalRetries;
+    }
+  });
+
+  test('aborts a Responses attempt when response headers exceed the watchdog', async () => {
+    const originalPost = axios.post;
+    const originalTimeout = process.env.XIAOBA_RESPONSES_HEADERS_TIMEOUT_MS;
+    let capturedSignal: AbortSignal | undefined;
+    (axios as any).post = async (_url: string, _body: any, config: any) => {
+      capturedSignal = config.signal;
+      return await new Promise((_resolve, reject) => {
+        config.signal.addEventListener('abort', () => {
+          reject(Object.assign(new Error('canceled'), { name: 'CanceledError', code: 'ERR_CANCELED' }));
+        }, { once: true });
+      });
+    };
+    process.env.XIAOBA_RESPONSES_HEADERS_TIMEOUT_MS = '5';
+
+    try {
+      await assert.rejects(
+        createProvider().chatStream([{ role: 'user', content: 'hello' }]),
+        (error: any) => (
+          error?.code === 'XIAOBA_RESPONSES_HEADERS_TIMEOUT'
+          && error?.status === 504
+          && error?.failurePhase === 'headers'
+        ),
+      );
+      assert.equal(capturedSignal?.aborted, true);
+    } finally {
+      (axios as any).post = originalPost;
+      if (originalTimeout === undefined) delete process.env.XIAOBA_RESPONSES_HEADERS_TIMEOUT_MS;
+      else process.env.XIAOBA_RESPONSES_HEADERS_TIMEOUT_MS = originalTimeout;
+    }
+  });
+
+  test('cleans up the Responses header watchdog after headers arrive', async () => {
+    const originalPost = axios.post;
+    const originalTimeout = process.env.XIAOBA_RESPONSES_HEADERS_TIMEOUT_MS;
+    let capturedSignal: AbortSignal | undefined;
+    (axios as any).post = async (_url: string, _body: any, config: any) => {
+      capturedSignal = config.signal;
+      return {
+        data: Readable.from([sse({
+          type: 'response.completed',
+          response: {
+            status: 'completed',
+            output: [{
+              type: 'message',
+              role: 'assistant',
+              content: [{ type: 'output_text', text: 'ok' }],
+            }],
+          },
+        })]),
+      };
+    };
+    process.env.XIAOBA_RESPONSES_HEADERS_TIMEOUT_MS = '5';
+
+    try {
+      const result = await createProvider().chatStream([{ role: 'user', content: 'hello' }]);
+      await new Promise(resolve => setTimeout(resolve, 15));
+      assert.equal(result.content, 'ok');
+      assert.equal(capturedSignal?.aborted, false);
+    } finally {
+      (axios as any).post = originalPost;
+      if (originalTimeout === undefined) delete process.env.XIAOBA_RESPONSES_HEADERS_TIMEOUT_MS;
+      else process.env.XIAOBA_RESPONSES_HEADERS_TIMEOUT_MS = originalTimeout;
     }
   });
 

--- a/tests/openai-provider-responses.test.ts
+++ b/tests/openai-provider-responses.test.ts
@@ -5,6 +5,7 @@ import axios from 'axios';
 import { OpenAIProvider } from '../src/providers/openai-provider';
 import { AIService } from '../src/utils/ai-service';
 import { Logger } from '../src/utils/logger';
+import { captureModelErrorDiagnostics } from '../src/utils/model-error-observability';
 import type { Message } from '../src/types';
 import type { ToolDefinition } from '../src/types/tool';
 
@@ -336,6 +337,7 @@ describe('OpenAIProvider Responses API mode', () => {
           request_id: 'req_failed_1',
         },
       },
+      headers: { 'X-Request-Id': 'req_header_fallback' },
     });
 
     try {
@@ -551,6 +553,7 @@ describe('OpenAIProvider Responses API mode', () => {
           },
         }),
       ]),
+      headers: { 'x-request-id': 'req_header_fallback' },
     });
 
     try {
@@ -564,6 +567,41 @@ describe('OpenAIProvider Responses API mode', () => {
           && error?.request_id === 'req_stream_failed'
           && error?.terminalEvent === 'response.failed'
           && error?.failurePhase === 'terminal_event'
+        ),
+      );
+    } finally {
+      (axios as any).post = originalPost;
+    }
+  });
+
+  test('preserves the response header request ID when a terminal failure has none', async () => {
+    const originalPost = axios.post;
+    (axios as any).post = async () => ({
+      data: Readable.from([
+        sse({
+          type: 'response.failed',
+          response: {
+            id: 'resp_header_only',
+            status: 'failed',
+            error: {
+              code: 'upstream_error',
+              type: 'server_error',
+              message: 'upstream unavailable',
+            },
+          },
+        }),
+      ]),
+      headers: {
+        get: (name: string) => name === 'x-request-id' ? 'req_header_only' : undefined,
+      },
+    });
+
+    try {
+      await assert.rejects(
+        createProvider().chatStream([{ role: 'user', content: 'hello' }]),
+        (error: any) => (
+          error?.request_id === 'req_header_only'
+          && captureModelErrorDiagnostics(error).request_id === 'req_header_only'
         ),
       );
     } finally {
@@ -591,6 +629,61 @@ describe('OpenAIProvider Responses API mode', () => {
           && error?.status === 503
           && error?.terminalEvent === 'error'
           && error?.failurePhase === 'terminal_event'
+        ),
+      );
+    } finally {
+      (axios as any).post = originalPost;
+    }
+  });
+
+  test('normalizes an unstructured Readable error with its cause and header request ID', async () => {
+    const originalPost = axios.post;
+    const sourceError = new Error('socket stream interrupted');
+    (axios as any).post = async () => ({
+      data: Readable.from((async function* () {
+        throw sourceError;
+      })()),
+      headers: { 'x-request-id': 'req_stream_error' },
+    });
+
+    try {
+      await assert.rejects(
+        createProvider().chatStream([{ role: 'user', content: 'hello' }]),
+        (error: any) => (
+          error?.code === 'stream_read_error'
+          && error?.providerCode === 'stream_read_error'
+          && error?.providerType === 'stream_error'
+          && error?.status === 502
+          && error?.cause === sourceError
+          && error?.request_id === 'req_stream_error'
+          && error?.failurePhase === 'stream'
+          && error?.terminalEvent === 'stream.error'
+        ),
+      );
+    } finally {
+      (axios as any).post = originalPost;
+    }
+  });
+
+  test('preserves structured Readable transport errors while adding stream metadata', async () => {
+    const originalPost = axios.post;
+    const sourceError = Object.assign(new Error('connection reset'), { code: 'ECONNRESET' });
+    (axios as any).post = async () => ({
+      data: Readable.from((async function* () {
+        throw sourceError;
+      })()),
+      headers: { 'x-request-id': 'req_structured_stream_error' },
+    });
+
+    try {
+      await assert.rejects(
+        createProvider().chatStream([{ role: 'user', content: 'hello' }]),
+        (error: any) => (
+          error === sourceError
+          && error?.code === 'ECONNRESET'
+          && error?.request_id === 'req_structured_stream_error'
+          && error?.failurePhase === 'stream'
+          && error?.terminalEvent === 'stream.error'
         ),
       );
     } finally {
@@ -659,6 +752,64 @@ describe('OpenAIProvider Responses API mode', () => {
       assert.equal(bodies[0].prompt_cache_key, bodies[1].prompt_cache_key);
       assert.equal(requestHeaders[0].session_id, requestHeaders[1].session_id);
       assert.equal(requestHeaders[0]['x-client-request-id'], requestHeaders[1]['x-client-request-id']);
+    } finally {
+      (axios as any).post = originalPost;
+      if (originalRetries === undefined) delete process.env.CATSCO_MODEL_RETRY_MAX_RETRIES;
+      else process.env.CATSCO_MODEL_RETRY_MAX_RETRIES = originalRetries;
+    }
+  });
+
+  test('retries an unstructured Readable error without publishing abandoned text', async () => {
+    const originalPost = axios.post;
+    const originalRetries = process.env.CATSCO_MODEL_RETRY_MAX_RETRIES;
+    let attempts = 0;
+    (axios as any).post = async () => {
+      attempts += 1;
+      return {
+        data: attempts === 1
+          ? Readable.from((async function* () {
+              yield sse({ type: 'response.output_text.delta', delta: 'abandoned' });
+              throw new Error('socket stream interrupted');
+            })())
+          : Readable.from([
+              sse({ type: 'response.output_text.delta', delta: 'recovered' }),
+              sse({
+                type: 'response.completed',
+                response: {
+                  status: 'completed',
+                  output: [{
+                    type: 'message',
+                    role: 'assistant',
+                    content: [{ type: 'output_text', text: 'recovered' }],
+                  }],
+                },
+              }),
+            ]),
+        headers: { 'x-request-id': `req_attempt_${attempts}` },
+      };
+    };
+    process.env.CATSCO_MODEL_RETRY_MAX_RETRIES = '1';
+
+    try {
+      const service = new AIService({
+        apiKey: 'test-key',
+        apiUrl: 'https://example.test/v1',
+        model: 'gpt-test',
+        provider: 'openai',
+        openaiApiMode: 'responses',
+      });
+      (service as any).sleepWithAbort = async () => {};
+      const delivered: string[] = [];
+      const result = await service.chatStream(
+        [{ role: 'user', content: 'hello' }],
+        undefined,
+        { onText: text => delivered.push(text) },
+        { streamOutputMode: 'buffered' },
+      );
+
+      assert.equal(attempts, 2);
+      assert.equal(result.content, 'recovered');
+      assert.deepEqual(delivered, ['recovered']);
     } finally {
       (axios as any).post = originalPost;
       if (originalRetries === undefined) delete process.env.CATSCO_MODEL_RETRY_MAX_RETRIES;

--- a/tests/session-lifecycle-manager.test.ts
+++ b/tests/session-lifecycle-manager.test.ts
@@ -679,7 +679,7 @@ describe('AgentSession lifecycle', () => {
   });
 
   test('handleMessage preserves completed tool context when model relay times out', async () => {
-    const { AgentSession, SessionStore, MODEL_TIMEOUT_MESSAGE } = loadSessionModules();
+    const { AgentSession, SessionStore } = loadSessionModules();
     let aiCalls = 0;
     const toolCall = {
       id: 'call_read',
@@ -732,7 +732,7 @@ describe('AgentSession lifecycle', () => {
 
     const result = await session.handleMessage('read notes then continue');
 
-    assert.equal(result.text, MODEL_TIMEOUT_MESSAGE);
+    assert.equal(result.text, '模型服务暂时不稳定，本次处理未能完成，请稍后继续。');
     assert.equal(aiCalls, 2);
 
     const retainedMessages = (session as any).messages as any[];
@@ -775,7 +775,7 @@ describe('AgentSession lifecycle', () => {
 
     const result = await session.handleMessage('continue');
 
-    assert.equal(result.text, '当前模型暂时无法继续调用，请切换模型或联系管理员。');
+    assert.equal(result.text, '模型服务暂时不稳定，本次处理未能完成，请稍后继续。');
     assert.doesNotMatch(result.text, /model budget exceeded|API错误/i);
   });
 
@@ -792,7 +792,7 @@ describe('AgentSession lifecycle', () => {
 
     const result = await session.handleMessage('continue');
 
-    assert.equal(result.text, '当前模型暂时无法继续调用，请切换模型或联系管理员。');
+    assert.equal(result.text, '模型服务暂时不稳定，本次处理未能完成，请稍后继续。');
   });
 
   test('handleMessage does not treat unrelated 402 text as relay budget exhaustion', async () => {
@@ -808,7 +808,7 @@ describe('AgentSession lifecycle', () => {
 
     const result = await session.handleMessage('continue');
 
-    assert.equal(result.text, '模型未能处理本次请求，请重新发送；持续失败时请联系管理员。');
+    assert.equal(result.text, '模型服务暂时不稳定，本次处理未能完成，请稍后继续。');
   });
 
   test('handleMessage surfaces transient provider failures without leaking raw upstream payload', async () => {
@@ -827,7 +827,7 @@ describe('AgentSession lifecycle', () => {
 
     const result = await session.handleMessage('continue');
 
-    assert.equal(result.text, '模型服务暂时不可用，请稍后再试。');
+    assert.equal(result.text, '模型服务暂时不稳定，本次处理未能完成，请稍后继续。');
     assert.doesNotMatch(result.text, /unknown error|request_id|API错误|520/);
   });
 
@@ -844,7 +844,7 @@ describe('AgentSession lifecycle', () => {
 
     const result = await session.handleMessage('继续');
 
-    assert.equal(result.text, '当前请求较多，请稍等片刻再试。');
+    assert.equal(result.text, '模型服务暂时不稳定，本次处理未能完成，请稍后继续。');
     assert.doesNotMatch(result.text, /429|状态码|错误编号/);
   });
 
@@ -870,12 +870,12 @@ describe('AgentSession lifecycle', () => {
 
     const result = await session.handleMessage('继续');
 
-    assert.equal(result.text, '模型服务暂时不可用，系统已自动重试，但仍未恢复，请稍后再试。');
+    assert.equal(result.text, '模型服务暂时不稳定，系统已尝试自动恢复但仍未成功，请稍后继续。');
     assert.doesNotMatch(result.text, /503|状态码|错误编号/);
   });
 
   test('handleMessage tells the user how to recover after empty model responses are exhausted', async () => {
-    const { AgentSession, EMPTY_MODEL_RESPONSE_MESSAGE } = loadSessionModules();
+    const { AgentSession } = loadSessionModules();
     const session = new AgentSession('catscompany:lifecycle-empty-model-response', buildMockServices({
       aiService: {
         async chatStream() {
@@ -890,9 +890,7 @@ describe('AgentSession lifecycle', () => {
 
     const result = await session.handleMessage('继续上一条');
 
-    assert.equal(result.text, EMPTY_MODEL_RESPONSE_MESSAGE);
-    assert.match(result.text, /重新发送上一条消息/);
-    assert.match(result.text, /切换模型或稍后再试/);
+    assert.equal(result.text, '模型服务暂时不稳定，本次处理未能完成，请稍后继续。');
     assert.doesNotMatch(result.text, /EMPTY_MODEL_RESPONSE|请求失败/);
   });
 
@@ -912,7 +910,7 @@ describe('AgentSession lifecycle', () => {
 
     const result = await session.handleMessage('继续');
 
-    assert.equal(result.text, '模型服务暂时不可用，请稍后再试。');
+    assert.equal(result.text, '模型服务暂时不稳定，本次处理未能完成，请稍后继续。');
     assert.doesNotMatch(result.text, /API错误|状态码|503/);
   });
 
@@ -955,7 +953,7 @@ describe('AgentSession lifecycle', () => {
     const result = await session.handleMessage('继续');
 
     assert.equal(result.taskOutcome, 'failed');
-    assert.equal(result.text, '模型未能处理本次请求，请稍后再试。');
+    assert.equal(result.text, '模型服务暂时不稳定，系统已尝试自动恢复但仍未成功，请稍后继续。');
     const logPath = (session as any).sessionTurnLogger.getLogFilePath();
     const entries = fs.readFileSync(logPath, 'utf8')
       .split(/\r?\n/)


### PR DESCRIPTION
## What changed

- distinguish provider text that was merely received from text actually delivered to a live user surface
- buffer Responses text for non-live surfaces and discard partial output from failed physical attempts before retrying
- classify `stream_read_error`, `upstream_error`, `server_is_overloaded`, and `service_unavailable_error` as bounded transient Responses failures
- add a configurable Responses response-header watchdog (`XIAOBA_RESPONSES_HEADERS_TIMEOUT_MS`, default 120 seconds)
- guarantee one bounded recovery attempt for a Responses 504 even when the first request consumed the previous retry window
- preserve Responses provider code/type, response ID, request ID, terminal SSE event, and failure phase in structured diagnostics
- retain user-visible retry progress while hiding internal status codes, and consolidate ordinary terminal failure replies

## Root cause

ConversationRunner always supplied an `onText` wrapper even when the active CatsCompany surface had no live text consumer. AIService therefore treated any provider delta as user-visible output and refused to replay a failed stream. In addition, several Responses terminal error codes were not part of the structured retry classification, and a first 504 could consume the entire retry window before a recovery attempt was allowed.

## Behavior and compatibility

- every recovery attempt remains a streaming `/v1/responses` request; there is no non-stream fallback
- the logical request body, `prompt_cache_key`, and session-affinity headers remain stable across retries
- abandoned output items are not exposed to ConversationRunner, so tools from failed attempts cannot execute
- buffered recovery and bounded gateway policies are scoped to OpenAI Responses mode; Anthropic and Chat Completions retain their prior stream replay behavior
- image/vision and exhausted context-size failures keep actionable user guidance; ordinary provider/configuration failures use one safe user-facing presentation

## Validation

- `npm run build`
- 105 focused AIService, Responses provider, ConversationRunner, CatsCompany, and diagnostics tests passed
- 39 AgentSession lifecycle tests passed
- full runtime suite: 1,477 passed; 3 unrelated Tianyi worker-image tests failed because this Windows host has neither `pwsh` nor a usable WSL `/bin/bash`

## Evidence boundary

This fixes XiaoBa-side recovery and observability gaps. It does not claim to eliminate upstream relay failures or provide byte-level SSE resume; recovery restarts the same logical streaming sampling request.
