### PR TITLE
refactor(ai): add injectable provider registry foundation

### DIFF
--- a/src/providers/provider-registry.ts
+++ b/src/providers/provider-registry.ts
@@ -1,0 +1,141 @@
+import type {
+  ChatConfig,
+  ProviderIdentity,
+  ProviderApiType,
+} from '../types';
+import { AnthropicProvider } from './anthropic-provider';
+import { OpenAIProvider } from './openai-provider';
+import type { AIProvider } from './provider';
+
+export type ProviderConfig = Omit<ChatConfig, 'provider'> & {
+  provider?: ProviderIdentity;
+};
+
+export interface ProviderRegistration {
+  id: ProviderIdentity;
+  create: (config: ProviderConfig) => AIProvider;
+  apiType: ProviderApiType | ((config: ProviderConfig) => ProviderApiType);
+  matches?: (config: ProviderConfig) => boolean;
+}
+
+export interface ProviderSelection {
+  providerId: ProviderIdentity;
+  apiType: ProviderApiType;
+  provider: AIProvider;
+}
+
+export interface ProviderRegistryOptions {
+  defaultProviderId?: ProviderIdentity;
+}
+
+/**
+ * Owns provider identity resolution, wire-protocol selection, and runtime construction.
+ * Registrations are intentionally injectable so AIService does not need provider-specific branches.
+ */
+export class ProviderRegistry {
+  private readonly registrations = new Map<ProviderIdentity, ProviderRegistration>();
+  private readonly defaultProviderId?: ProviderIdentity;
+
+  constructor(options: ProviderRegistryOptions = {}) {
+    this.defaultProviderId = options.defaultProviderId;
+  }
+
+  register(registration: ProviderRegistration): this {
+    const id = normalizeIdentifier(registration.id, 'provider identity');
+    if (this.registrations.has(id)) {
+      throw new Error(`Provider "${id}" is already registered`);
+    }
+    if (typeof registration.create !== 'function') {
+      throw new Error(`Provider "${id}" must define a factory`);
+    }
+
+    this.registrations.set(id, { ...registration, id });
+    return this;
+  }
+
+  resolveProviderId(config: ProviderConfig): ProviderIdentity {
+    if (config.provider !== undefined) {
+      const explicit = normalizeIdentifier(config.provider, 'provider identity');
+      this.requireRegistration(explicit);
+      return explicit;
+    }
+
+    for (const registration of this.registrations.values()) {
+      if (registration.matches?.(config)) return registration.id;
+    }
+
+    if (this.defaultProviderId !== undefined) {
+      const fallback = normalizeIdentifier(this.defaultProviderId, 'default provider identity');
+      this.requireRegistration(fallback);
+      return fallback;
+    }
+
+    throw new Error('Unable to resolve provider: no provider was configured or matched');
+  }
+
+  resolveApiType(providerId: ProviderIdentity, config: ProviderConfig): ProviderApiType {
+    const registration = this.requireRegistration(providerId);
+    const apiType = typeof registration.apiType === 'function'
+      ? registration.apiType(config)
+      : registration.apiType;
+    return normalizeIdentifier(apiType, `API protocol for provider "${providerId}"`) as ProviderApiType;
+  }
+
+  create(config: ProviderConfig): ProviderSelection {
+    const providerId = this.resolveProviderId(config);
+    const registration = this.requireRegistration(providerId);
+    const resolvedConfig = config.provider === providerId ? config : { ...config, provider: providerId };
+    const apiType = this.resolveApiType(providerId, resolvedConfig);
+    return {
+      providerId,
+      apiType,
+      provider: registration.create(resolvedConfig),
+    };
+  }
+
+  private requireRegistration(providerId: ProviderIdentity): ProviderRegistration {
+    const registration = this.registrations.get(providerId);
+    if (!registration) {
+      throw new Error(`Unknown provider "${providerId}"`);
+    }
+    return registration;
+  }
+}
+
+export function createDefaultProviderRegistry(): ProviderRegistry {
+  return new ProviderRegistry({ defaultProviderId: 'openai' })
+    .register({
+      id: 'anthropic',
+      matches: config => looksLikeAnthropic(config),
+      apiType: 'anthropic-messages',
+      create: config => new AnthropicProvider(config as ChatConfig),
+    })
+    .register({
+      id: 'openai',
+      apiType: resolveOpenAIApiType,
+      create: config => new OpenAIProvider(config as ChatConfig),
+    });
+}
+
+function resolveOpenAIApiType(config: ProviderConfig): ProviderApiType {
+  if (config.openaiApiMode === undefined || config.openaiApiMode === 'chat_completions') {
+    return 'openai-chat-completions';
+  }
+  if (config.openaiApiMode === 'responses') {
+    return 'openai-responses';
+  }
+  throw new Error(`Unknown API protocol "${String(config.openaiApiMode)}" for provider "openai"`);
+}
+
+function looksLikeAnthropic(config: ProviderConfig): boolean {
+  const apiUrl = (config.apiUrl || '').toLowerCase();
+  const model = (config.model || '').toLowerCase();
+  return apiUrl.includes('anthropic') || apiUrl.includes('claude') || model.includes('claude');
+}
+
+function normalizeIdentifier(value: unknown, label: string): string {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`Invalid ${label}: expected a non-empty string`);
+  }
+  return value.trim();
+}

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -1,4 +1,4 @@
-import { Message, ChatResponse } from '../types';
+import { Message, ChatResponse, type ProviderApiType, type ProviderIdentity } from '../types';
 import { ToolDefinition } from '../types/tool';
 import type { ProviderRequestPreflightSummary } from './request-preflight';
 
@@ -26,7 +26,7 @@ export interface StreamRetryInfo {
   message?: string;
 }
 
-export type ModelAttemptApiType = 'anthropic-messages' | 'openai-chat-completions' | 'openai-responses';
+export type ModelAttemptApiType = ProviderApiType;
 export type ModelAttemptOutcome = 'started' | 'succeeded' | 'retrying' | 'failed' | 'cancelled';
 export type ModelAttemptStopReason =
   | 'non_retryable'
@@ -67,7 +67,7 @@ export interface ModelAttemptEvent {
   attemptNumber: number;
   timestamp: string;
   outcome: ModelAttemptOutcome;
-  provider: 'openai' | 'anthropic';
+  provider: ProviderIdentity;
   model: string;
   apiType: ModelAttemptApiType;
   stream: boolean;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,6 +3,8 @@ export type ContentBlock =
   | { type: 'image'; source: { type: 'base64'; media_type: 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp'; data: string } };
 
 export type ProviderContentBlock = Record<string, unknown> & { type: string };
+export type BuiltInProviderIdentity = 'openai' | 'anthropic';
+export type ProviderIdentity = BuiltInProviderIdentity | (string & {});
 export type ProviderApiType = 'anthropic-messages' | 'openai-chat-completions' | 'openai-responses';
 
 /** Opaque scope that prevents provider-only replay state crossing model/API boundaries. */
@@ -91,7 +93,7 @@ export interface ChatConfig {
     timeoutMs?: number;
     maxTokens?: number;
   };
-  provider?: 'openai' | 'anthropic';
+  provider?: BuiltInProviderIdentity;
   feishu?: {
     appId?: string;
     appSecret?: string;

--- a/src/utils/ai-service.ts
+++ b/src/utils/ai-service.ts
@@ -1,4 +1,10 @@
-import { Message, ChatConfig, ChatResponse } from '../types';
+import {
+  Message,
+  ChatConfig,
+  ChatResponse,
+  type ProviderIdentity,
+  type ProviderApiType,
+} from '../types';
 import { ConfigManager } from './config';
 import { ToolDefinition } from '../types/tool';
 import {
@@ -10,8 +16,11 @@ import {
   StreamCallbacks,
   StreamRetryInfo,
 } from '../providers/provider';
-import { AnthropicProvider } from '../providers/anthropic-provider';
-import { OpenAIProvider } from '../providers/openai-provider';
+import {
+  createDefaultProviderRegistry,
+  ProviderRegistry,
+  type ProviderConfig,
+} from '../providers/provider-registry';
 import {
   prepareProviderRequestMessages,
   type ProviderRequestPreflightSummary,
@@ -47,8 +56,6 @@ const EMPTY_RESPONSE_MAX_ELAPSED_MS = 2 * 60 * 1000;
 const EMPTY_RESPONSE_MAX_DELAY_MS = 2000;
 let modelAttemptCallSequence = 0;
 
-type ProviderKind = 'openai' | 'anthropic';
-
 interface RetryPolicy {
   maxRetries: number;
   maxElapsedMs: number;
@@ -67,68 +74,52 @@ interface ModelAttemptRun {
 }
 
 export class AIService {
-  private config: ChatConfig;
+  private config: ProviderConfig;
   private provider: AIProvider;
+  private providerRegistry: ProviderRegistry;
+  private providerIdentity: ProviderIdentity;
+  private providerApiType: ProviderApiType;
 
-  constructor(overrides?: Partial<ChatConfig>) {
+  constructor(
+    overrides?: Partial<ProviderConfig>,
+    providerRegistry: ProviderRegistry = createDefaultProviderRegistry(),
+  ) {
+    this.providerRegistry = providerRegistry;
     this.config = this.withResolvedContextWindow(this.withResolvedProvider({
       ...ConfigManager.getConfig(),
       ...(overrides || {})
     }));
-    this.provider = this.createProvider(this.config);
+    const selection = this.providerRegistry.create(this.config);
+    this.provider = selection.provider;
+    this.providerIdentity = selection.providerId;
+    this.providerApiType = selection.apiType;
   }
 
-  getConfig(): ChatConfig {
+  getConfig(): ProviderConfig {
     return { ...this.config };
   }
 
-  /**
-   * 根据配置创建对应的 Provider
-   */
-  private createProvider(config: ChatConfig): AIProvider {
-    if (config.provider === 'anthropic') {
-      return new AnthropicProvider(config);
-    } else {
-      return new OpenAIProvider(config);
-    }
-  }
-
   isToolCallingSupported(): boolean {
-    return isPrimaryModelToolCallingCapable(this.config);
+    return isPrimaryModelToolCallingCapable(this.config as ChatConfig);
   }
 
   /**
    * 自动补全 provider
    */
-  private withResolvedProvider(config: ChatConfig): ChatConfig {
+  private withResolvedProvider(config: ProviderConfig): ProviderConfig {
     return {
       ...config,
-      provider: this.resolveProvider(config),
+      provider: this.providerRegistry.resolveProviderId(config),
     };
   }
 
-  private withResolvedContextWindow(config: ChatConfig): ChatConfig {
+  private withResolvedContextWindow(config: ProviderConfig): ProviderConfig {
     const contextWindowTokens = config.contextWindowTokens
-      ?? resolveModelContextWindow(config).contextWindowTokens;
+      ?? resolveModelContextWindow(config as ChatConfig).contextWindowTokens;
     return {
       ...config,
       contextWindowTokens,
     };
-  }
-
-  private resolveProvider(config: Partial<ChatConfig>): ProviderKind {
-    if (config.provider === 'openai' || config.provider === 'anthropic') {
-      return config.provider;
-    }
-
-    const apiUrl = (config.apiUrl || '').toLowerCase();
-    const model = (config.model || '').toLowerCase();
-
-    if (apiUrl.includes('anthropic') || apiUrl.includes('claude') || model.includes('claude')) {
-      return 'anthropic';
-    }
-
-    return 'openai';
   }
 
   /**
@@ -567,13 +558,9 @@ export class AIService {
       attemptNumber,
       timestamp: new Date().toISOString(),
       outcome: fields.outcome,
-      provider: this.config.provider as ProviderKind,
+      provider: this.providerIdentity,
       model: this.config.model || 'unknown',
-      apiType: this.config.provider === 'anthropic'
-        ? 'anthropic-messages'
-        : this.config.openaiApiMode === 'responses'
-          ? 'openai-responses'
-          : 'openai-chat-completions',
+      apiType: this.providerApiType,
       stream: run.stream,
       ...(run.context ? { context: run.context } : {}),
       request: {

--- a/tests/provider-registry.test.ts
+++ b/tests/provider-registry.test.ts
@@ -1,0 +1,113 @@
+import { test } from 'node:test';
+import * as assert from 'node:assert';
+import type { ChatConfig, ChatResponse, ProviderApiType } from '../src/types';
+import type { AIProvider, StreamCallbacks } from '../src/providers/provider';
+import {
+  createDefaultProviderRegistry,
+  ProviderRegistry,
+  type ProviderConfig,
+} from '../src/providers/provider-registry';
+import { AIService } from '../src/utils/ai-service';
+
+test('default registry preserves built-in provider and wire protocol mappings', () => {
+  const registry = createDefaultProviderRegistry();
+  const openAIConfig: ChatConfig = {
+    apiKey: 'test-key',
+    apiUrl: 'https://api.openai.com/v1',
+    model: 'gpt-4o',
+  };
+
+  assert.equal(registry.resolveProviderId(openAIConfig), 'openai');
+  assert.equal(registry.resolveApiType('openai', openAIConfig), 'openai-chat-completions');
+  assert.equal(
+    registry.resolveApiType('openai', { ...openAIConfig, openaiApiMode: 'responses' }),
+    'openai-responses',
+  );
+
+  const anthropicConfig: ChatConfig = {
+    apiKey: 'test-key',
+    apiUrl: 'https://api.anthropic.com',
+    model: 'claude-sonnet-4-20250514',
+  };
+  assert.equal(registry.resolveProviderId(anthropicConfig), 'anthropic');
+  assert.equal(registry.resolveApiType('anthropic', anthropicConfig), 'anthropic-messages');
+});
+
+test('AIService selects an injected custom provider without provider-specific branches', async () => {
+  const response: ChatResponse = { content: 'custom response' };
+  let constructedWith: ProviderConfig | undefined;
+  const customProvider: AIProvider = {
+    chat: async () => response,
+    chatStream: async (_messages, _tools, callbacks?: StreamCallbacks) => {
+      callbacks?.onText?.('custom response');
+      return response;
+    },
+  };
+  const registry = new ProviderRegistry()
+    .register({
+      id: 'test-custom',
+      apiType: 'openai-chat-completions',
+      create: config => {
+        constructedWith = config;
+        return customProvider;
+      },
+    });
+  const service = new AIService({
+    provider: 'test-custom',
+    apiKey: 'test-key',
+    apiUrl: 'https://custom.example.test/v1',
+    model: 'custom-model',
+  }, registry);
+  const attemptEvents: any[] = [];
+
+  const result = await service.chat([{ role: 'user', content: 'hello' }], undefined, {
+    modelAttemptSink: { observe: event => { attemptEvents.push(event); } },
+  });
+
+  assert.equal(result, response);
+  assert.equal(constructedWith?.provider, 'test-custom');
+  assert.equal(service.getConfig().provider, 'test-custom');
+  assert.equal(attemptEvents[0].provider, 'test-custom');
+  assert.equal(attemptEvents[0].apiType, 'openai-chat-completions');
+  assert.equal(attemptEvents[attemptEvents.length - 1].outcome, 'succeeded');
+});
+
+test('registry rejects unknown provider configuration with a clear error', () => {
+  assert.throws(
+    () => new AIService({
+      provider: 'missing-provider',
+      apiKey: 'test-key',
+      apiUrl: 'https://missing.example.test/v1',
+      model: 'missing-model',
+    }, createDefaultProviderRegistry()),
+    /Unknown provider "missing-provider"/,
+  );
+});
+
+test('registry rejects invalid built-in and custom protocol configuration', () => {
+  const invalidOpenAIConfig = {
+    provider: 'openai',
+    apiKey: 'test-key',
+    apiUrl: 'https://api.openai.com/v1',
+    model: 'gpt-4o',
+    openaiApiMode: 'legacy-completions',
+  } as unknown as ChatConfig;
+
+  assert.throws(
+    () => createDefaultProviderRegistry().create(invalidOpenAIConfig),
+    /Unknown API protocol "legacy-completions" for provider "openai"/,
+  );
+
+  const invalidCustomRegistry = new ProviderRegistry().register({
+    id: 'invalid-custom',
+    apiType: () => '   ' as ProviderApiType,
+    create: () => ({
+      chat: async () => ({ content: 'unused' }),
+      chatStream: async () => ({ content: 'unused' }),
+    }),
+  });
+  assert.throws(
+    () => invalidCustomRegistry.create({ provider: 'invalid-custom' }),
+    /Invalid API protocol for provider "invalid-custom": expected a non-empty string/,
+  );
+});


### PR DESCRIPTION
## Summary

- introduce an injectable provider registry/factory that owns provider identity resolution, wire protocol selection, and provider construction
- remove direct OpenAI/Anthropic construction and protocol branches from `AIService`
- keep built-in OpenAI chat-completions, OpenAI Responses, and Anthropic Messages mappings while allowing a test-only custom provider registration
- fail deterministically for unknown providers and invalid protocol configuration

## Design

This is the bounded foundation only. Provider identity is represented separately from the existing wire API protocol type. The registry selects a provider registration, resolves its protocol, and constructs the runtime provider. Existing request preflight, retries, model-attempt events, prompt-cache behavior, tool calls, response types, and provider-state handling remain in their current layers.

No pi dependency is added, and this does not rewrite the unified streaming/message event schema.

## Base

- task base SHA: `8cad010adef4c0eb572c3a52cb5f3a18d3da2585`

## Verification

- `npm run build`
- `XIAOBA_USER_DATA_DIR=<temporary directory> npx tsx --test tests/ai-service.test.ts tests/provider-registry.test.ts tests/openai-provider-responses.test.ts tests/anthropic-provider-runtime-feedback.test.ts`
- result: 54 tests passed, 0 failed
- `git diff --check`
- declared write-scope check passed

## Residual risks

- custom providers in this foundation must map to one of the three existing wire protocols; adding a new protocol remains future work
- no live provider API calls were made; compatibility evidence is build plus targeted unit/runtime tests
