### PR TITLE
feat(worker): image lifecycle - keep 6 worker images, auto-prune after bake

### DIFF
--- a/.github/workflows/worker-image.yml
+++ b/.github/workflows/worker-image.yml
@@ -404,6 +404,12 @@ jobs:
         # blocks the freshly baked image (the primary deliverable). 30 minutes
         # covers the worst case where many stale images accumulated (each
         # delete can take up to a few minutes to confirm).
+        #
+        # SAFETY: Prune refuses to run without CTYUN_WORKER_PROTECTED_IMAGE_IDS —
+        # the image(s) still referenced by the production launch template (or
+        # a pinned rollback target) must be declared so auto-cleanup can never
+        # delete an image that new workers still need. Configure the repo var
+        # before relying on automatic cleanup.
         if: ${{ steps.bake.outcome == 'success' }}
         timeout-minutes: 30
         continue-on-error: true
@@ -413,12 +419,14 @@ jobs:
           CTYUN_SK: ${{ secrets.CTYUN_SK }}
           WORKER_REGION_ID: ${{ vars.CTYUN_WORKER_REGION_ID }}
           WORKER_PROJECT_ID: ${{ vars.CTYUN_WORKER_PROJECT_ID }}
+          WORKER_PROTECTED_IMAGE_IDS: ${{ vars.CTYUN_WORKER_PROTECTED_IMAGE_IDS }}
         run: |
           ./ops/ctyun-worker-image/Manage-WorkerImages.ps1 `
             -Action Prune `
             -Keep 6 `
             -RegionID $env:WORKER_REGION_ID `
-            -ProjectID $env:WORKER_PROJECT_ID
+            -ProjectID $env:WORKER_PROJECT_ID `
+            -ProtectedImageIDs $env:WORKER_PROTECTED_IMAGE_IDS
 
       - name: Reconcile this attempt after a failed bake
         if: ${{ always() && steps.bake.outcome != 'success' }}

--- a/.github/workflows/worker-image.yml
+++ b/.github/workflows/worker-image.yml
@@ -398,6 +398,24 @@ jobs:
             -SubnetID $env:WORKER_SUBNET_ID `
             -SecurityGroupID $env:WORKER_SECURITY_GROUP_ID
 
+      - name: Prune old worker images
+        # Keep the latest 6 worker images after a successful bake; cleaning up
+        # old images is housekeeping, so a prune failure only warns and never
+        # blocks the freshly baked image (the primary deliverable).
+        if: ${{ steps.bake.outcome == 'success' }}
+        timeout-minutes: 10
+        continue-on-error: true
+        shell: pwsh
+        env:
+          CTYUN_AK: ${{ secrets.CTYUN_AK }}
+          CTYUN_SK: ${{ secrets.CTYUN_SK }}
+          WORKER_REGION_ID: ${{ vars.CTYUN_WORKER_REGION_ID }}
+        run: |
+          ./ops/ctyun-worker-image/Manage-WorkerImages.ps1 `
+            -Action Prune `
+            -Keep 6 `
+            -RegionID $env:WORKER_REGION_ID
+
       - name: Reconcile this attempt after a failed bake
         if: ${{ always() && steps.bake.outcome != 'success' }}
         timeout-minutes: 45

--- a/.github/workflows/worker-image.yml
+++ b/.github/workflows/worker-image.yml
@@ -401,20 +401,24 @@ jobs:
       - name: Prune old worker images
         # Keep the latest 6 worker images after a successful bake; cleaning up
         # old images is housekeeping, so a prune failure only warns and never
-        # blocks the freshly baked image (the primary deliverable).
+        # blocks the freshly baked image (the primary deliverable). 30 minutes
+        # covers the worst case where many stale images accumulated (each
+        # delete can take up to a few minutes to confirm).
         if: ${{ steps.bake.outcome == 'success' }}
-        timeout-minutes: 10
+        timeout-minutes: 30
         continue-on-error: true
         shell: pwsh
         env:
           CTYUN_AK: ${{ secrets.CTYUN_AK }}
           CTYUN_SK: ${{ secrets.CTYUN_SK }}
           WORKER_REGION_ID: ${{ vars.CTYUN_WORKER_REGION_ID }}
+          WORKER_PROJECT_ID: ${{ vars.CTYUN_WORKER_PROJECT_ID }}
         run: |
           ./ops/ctyun-worker-image/Manage-WorkerImages.ps1 `
             -Action Prune `
             -Keep 6 `
-            -RegionID $env:WORKER_REGION_ID
+            -RegionID $env:WORKER_REGION_ID `
+            -ProjectID $env:WORKER_PROJECT_ID
 
       - name: Reconcile this attempt after a failed bake
         if: ${{ always() && steps.bake.outcome != 'success' }}

--- a/docs/superpowers/plans/2026-08-07-worker-cloud-control-image-lifecycle.md
+++ b/docs/superpowers/plans/2026-08-07-worker-cloud-control-image-lifecycle.md
@@ -26,22 +26,22 @@
 **目标：** 私有 `catsco-worker-*` 镜像**最多保留 6 个**；bake 成功后自动清理更旧的；提供"取最新镜像"能力供部署/控制面使用；支持列出历史镜像供回滚选择。
 
 ### A1. 镜像保留与自动清理
-- [ ] **步骤 A1-1：清理逻辑设计**
-  - 在 bake **成功后**（result=created/reused/recovered 后）自动触发 `Invoke-CleanupOldWorkerImages`（幂等，可独立调用）。
+- [x] **步骤 A1-1：清理逻辑设计**（2026-08-07）
+  - 在 bake **成功后**自动触发清理（幂等，可独立调用）。
   - 规则：列出私有镜像 `catsco-worker-*`（`ims ListImage --imageVisibilityCode 0`），按 `createdTime` 排序，**保留最新 6 个**，删除更旧的。
-  - **安全（fail-closed）**：只删名称以 `catsco-worker-` 开头且带 `bake` label 的镜像；删除前连续空读确认；删除失败聚合报告（沿用 `Invoke-ExactBakeCleanup` 模式）。
-  - 触发：bake workflow 成功步骤后调用；也支持独立 `workflow_dispatch` / 本地命令。
-- [ ] **步骤 A1-2：测试**
-  - fake `ims ListImage/DeleteImage` 支持多镜像排序；场景：6 个内不删、第 7 个起删最旧、删除失败 fail-closed 报告。
-- [ ] **步骤 A1-3：实现 + 验证**
-  - `New-CatsCoWorkerImage.ps1` 新增 `Invoke-CleanupOldWorkerImages`（或独立 `ops/ctyun-worker-image/cleanup-old-images.ps1`）；`worker-image.yml` 成功路径接入；`npm run build` + 测试全绿。
+  - **安全（fail-closed）**：只删名称以 `catsco-worker-` 开头且带 `bake` label 的镜像；删除前连续空读确认（用 `ListImage` 全量过滤，不用 `GetImageDetail`——实测其对私有镜像偶发 NotFound）；删除失败聚合报告。
+  - 触发：`worker-image.yml` bake 成功步骤后自动调用（`continue-on-error`，清理失败仅告警不阻塞镜像产出）。
+- [x] **步骤 A1-2：测试**（`tests/manage-worker-images.test.ts`）
+  - fake `ims ListImage/DeleteImage` 支持多镜像排序；场景：List 只列带 bake label 的 `catsco-worker-*`、Latest 输出最新、Prune 6 删最旧 2、≤6 不删、删除失败 fail-closed 且其它照常删、非 worker/无 bake label 镜像永不删。
+- [x] **步骤 A1-3：实现 + 验证**
+  - 新建 `ops/ctyun-worker-image/Manage-WorkerImages.ps1`（`-Action List/Latest/Prune -Keep 6`）；`worker-image.yml` bake 成功后接入 `Prune -Keep 6`；`npm run build` + 测试 12/12 全绿。
 
 ### A2. 部署/控制面取最新镜像
-- [ ] **步骤 A2-1：`resolve-latest-worker-image` 脚本**
-  - 列出 `catsco-worker-*` 私有镜像，按 `labels.bake`/`createdTime` 取最新（即最后 bake 的），输出 `imageID`。
+- [x] **步骤 A2-1：`resolve-latest-worker-image`**（`Manage-WorkerImages.ps1 -Action Latest`）
+  - 列出 `catsco-worker-*` 私有镜像，按 `createdTime`（降序，id 兜底）取最新，输出 `imageID`。
   - 部署脚本 / 控制面（Part B）用它创建新 worker。
-- [ ] **步骤 A2-2：历史镜像列表（供回滚选择）**
-  - 提供 `list-worker-images` 输出 `imageID / version / commit / createdTime`，控制面据此展示"镜像回滚"可选列表（保留 6 个内的历史镜像）。
+- [x] **步骤 A2-2：历史镜像列表（供回滚选择）**（`Manage-WorkerImages.ps1 -Action List`）
+  - 输出 `imageID / name / version / commit / createdTime / status`，控制面据此展示"镜像回滚"可选列表（保留 6 个内的历史镜像）。
 
 ---
 

--- a/ops/ctyun-worker-image/Manage-WorkerImages.ps1
+++ b/ops/ctyun-worker-image/Manage-WorkerImages.ps1
@@ -33,6 +33,9 @@ Set-StrictMode -Version Latest
 # Do not turn stderr writes from a successful external command into a thrown
 # ErrorRecord under $ErrorActionPreference = 'Stop'.
 $PSNativeCommandUseErrorActionPreference = $false
+# ProjectID 空值兜底：显式传入空串（例如 workflow 里 var 未配置）时回退默认
+# "0"，保证与 bake 作用域（New-CatsCoWorkerImage.ps1 默认 ProjectID 0）一致。
+if ([string]::IsNullOrEmpty($ProjectID)) { $ProjectID = "0" }
 
 function Invoke-Ctyun {
     param([Parameter(Mandatory = $true)][string[]]$Arguments)
@@ -42,7 +45,10 @@ function Invoke-Ctyun {
         if ($LASTEXITCODE -ne 0) {
             throw "ctyun-cli failed with exit code $LASTEXITCODE`n$($raw -join "`n")"
         }
-        $response = $raw | ConvertFrom-Json
+        # Join lines before parsing: ConvertFrom-Json on a multi-line JSON
+        # array would otherwise parse line by line (same as bake's
+        # Invoke-External -Capture).
+        $response = ($raw -join "`n") | ConvertFrom-Json
         if ([string]$response.statusCode -ne "800") {
             throw (
                 "Tianyi Cloud API failed: $([string]$response.errorCode) " +

--- a/ops/ctyun-worker-image/Manage-WorkerImages.ps1
+++ b/ops/ctyun-worker-image/Manage-WorkerImages.ps1
@@ -47,9 +47,51 @@ function Invoke-Ctyun {
     param([Parameter(Mandatory = $true)][string[]]$Arguments)
 
     try {
-        $raw = & timeout '--signal=TERM' '--kill-after=15s' '90s' ctyun-cli @Arguments '--output' 'json' 2>&1
-        if ($LASTEXITCODE -ne 0) {
-            throw "ctyun-cli failed with exit code $LASTEXITCODE`n$($raw -join "`n")"
+        if ($IsWindows) {
+            # Windows PowerShell 7：系统 timeout.exe 不支持 GNU --signal/--kill-after，
+            # 直接调用会 `ERROR: Invalid syntax`。改用 .NET Process + ArgumentList
+            # 做 90s 超时（超时终止进程）。ArgumentList 正确处理参数引用，且兼容
+            # PATH 里的 .cmd（测试 fake）与 .exe（真实 ctyun-cli）。
+            # Get-Command 可能返回多个（fake .cmd + 真实 .exe 等）：取 PATH 第一个
+            $cmd = @(Get-Command 'ctyun-cli' -CommandType Application -ErrorAction SilentlyContinue)[0]
+            if (-not $cmd) { throw "ctyun-cli not found on PATH" }
+            $psi = [System.Diagnostics.ProcessStartInfo]::new()
+            $psi.RedirectStandardOutput = $true
+            $psi.RedirectStandardError = $true
+            $psi.UseShellExecute = $false
+            $source = $cmd.Source
+            if ($source -match '\.(cmd|bat)$') {
+                # .cmd/.bat 需要 cmd.exe /c 包装（CreateProcess 不能直接跑）
+                $psi.FileName = $env:ComSpec
+                [void]$psi.ArgumentList.Add('/d')
+                [void]$psi.ArgumentList.Add('/s')
+                [void]$psi.ArgumentList.Add('/c')
+                [void]$psi.ArgumentList.Add($source)
+            } else {
+                $psi.FileName = $source
+            }
+            foreach ($a in $Arguments) { [void]$psi.ArgumentList.Add($a) }
+            [void]$psi.ArgumentList.Add('--output')
+            [void]$psi.ArgumentList.Add('json')
+            $proc = [System.Diagnostics.Process]::Start($psi)
+            $outTask = $proc.StandardOutput.ReadToEndAsync()
+            $errTask = $proc.StandardError.ReadToEndAsync()
+            if (-not $proc.WaitForExit(90000)) {
+                $proc.Kill()
+                throw "ctyun-cli timed out after 90s"
+            }
+            $out = $outTask.GetAwaiter().GetResult()
+            $err = $errTask.GetAwaiter().GetResult()
+            if ($proc.ExitCode -ne 0) {
+                throw "ctyun-cli failed with exit code $($proc.ExitCode)`n$err"
+            }
+            $raw = @($out -split "`r?`n")
+        } else {
+            # Linux（GitHub Actions / bake CI）：GNU timeout 可用
+            $raw = & timeout '--signal=TERM' '--kill-after=15s' '90s' ctyun-cli @Arguments '--output' 'json' 2>&1
+            if ($LASTEXITCODE -ne 0) {
+                throw "ctyun-cli failed with exit code $LASTEXITCODE`n$($raw -join "`n")"
+            }
         }
         # Join lines before parsing: ConvertFrom-Json on a multi-line JSON
         # array would otherwise parse line by line (same as bake's

--- a/ops/ctyun-worker-image/Manage-WorkerImages.ps1
+++ b/ops/ctyun-worker-image/Manage-WorkerImages.ps1
@@ -9,6 +9,10 @@ Worker 私有镜像生命周期管理（与 New-CatsCoWorkerImage.ps1 配套）�
             不在第 1 页导致的误判），确认超时可配（-ConfirmTimeoutMinutes），
             失败 fail-closed 聚合报告
 
+  安全（Prune）：必须有 -ProtectedImageIDs（逗号分隔）声明生产 launch template
+  等仍引用的镜像，自动清理才会执行；受保护镜像即使超过保留数也绝不删除。
+  未配置保护列表但有需要删除的旧镜像时，Prune 拒绝执行（fail-closed）。
+
 凭据：复用 ctyun-cli（环境变量 CTYUN_AK/CTYUN_SK 或 ~/.ctyun-cli.yaml），与 bake 一致。
 #>
 [CmdletBinding()]
@@ -25,7 +29,9 @@ param(
     [int]$Keep = 6,
 
     [ValidateRange(1, 30)]
-    [int]$ConfirmTimeoutMinutes = 3
+    [int]$ConfirmTimeoutMinutes = 3,
+
+    [string]$ProtectedImageIDs = ""
 )
 
 $ErrorActionPreference = "Stop"
@@ -152,8 +158,31 @@ if ($sorted.Count -le $Keep) {
     exit 0
 }
 
-$toDelete = @($sorted | Select-Object -Skip $Keep)
-Write-Host "Pruning $($toDelete.Count) old worker image(s), keeping latest $Keep"
+# 受保护镜像：生产 launch template / 回滚 / 分批发布仍引用的镜像，绝不删除。
+# 有需要删除的旧镜像时必须显式声明保护列表（fail-closed），防止自动清理
+# 误删生产仍在使用的镜像。
+$protected = @(
+    $ProtectedImageIDs -split ',' |
+        ForEach-Object { $_.Trim() } |
+        Where-Object { $_ -ne "" }
+)
+if ($protected.Count -eq 0) {
+    throw (
+        "Refusing to auto-prune: no protected image IDs configured. " +
+        "Set -ProtectedImageIDs to the production launch-template image(s) " +
+        "before enabling automatic cleanup."
+    )
+}
+
+$toDelete = @(
+    @($sorted | Select-Object -Skip $Keep) |
+        Where-Object { $protected -notcontains [string]$_.imageID }
+)
+if ($toDelete.Count -eq 0) {
+    Write-Host "All would-be-pruned images are protected; nothing to delete"
+    exit 0
+}
+Write-Host "Pruning $($toDelete.Count) old worker image(s), keeping latest $Keep ($($protected.Count) protected)"
 $failures = [Collections.Generic.List[string]]::new()
 foreach ($img in $toDelete) {
     $imageID = [string](Get-Prop -Obj $img -Name "imageID")

--- a/ops/ctyun-worker-image/Manage-WorkerImages.ps1
+++ b/ops/ctyun-worker-image/Manage-WorkerImages.ps1
@@ -5,7 +5,9 @@ Worker 私有镜像生命周期管理（与 New-CatsCoWorkerImage.ps1 配套）�
   -List   : 列出全部 catsco-worker-* 私有镜像（imageID/name/version/commit/createdTime）
   -Latest : 输出最新 bake 的 worker 镜像 imageID（供部署/控制面取最新镜像）
   -Prune  : 保留最新 N 个（默认 6），删除更旧的（带 bake label 的 catsco-worker-*），
-            删除需连续空读确认，失败 fail-closed 聚合报告
+            删除需连续空读确认（按 --imageName 精确过滤，避免 >200 张时最旧镜像
+            不在第 1 页导致的误判），确认超时可配（-ConfirmTimeoutMinutes），
+            失败 fail-closed 聚合报告
 
 凭据：复用 ctyun-cli（环境变量 CTYUN_AK/CTYUN_SK 或 ~/.ctyun-cli.yaml），与 bake 一致。
 #>
@@ -20,27 +22,37 @@ param(
     [string]$Action = "List",
 
     [ValidateRange(1, 50)]
-    [int]$Keep = 6
+    [int]$Keep = 6,
+
+    [ValidateRange(1, 30)]
+    [int]$ConfirmTimeoutMinutes = 3
 )
 
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
+# Do not turn stderr writes from a successful external command into a thrown
+# ErrorRecord under $ErrorActionPreference = 'Stop'.
+$PSNativeCommandUseErrorActionPreference = $false
 
 function Invoke-Ctyun {
     param([Parameter(Mandatory = $true)][string[]]$Arguments)
 
-    $raw = & timeout '--signal=TERM' '--kill-after=15s' '90s' ctyun-cli @Arguments '--output' 'json' 2>&1
-    if ($LASTEXITCODE -ne 0) {
-        throw "ctyun-cli failed with exit code $LASTEXITCODE`n$($raw -join "`n")"
+    try {
+        $raw = & timeout '--signal=TERM' '--kill-after=15s' '90s' ctyun-cli @Arguments '--output' 'json' 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            throw "ctyun-cli failed with exit code $LASTEXITCODE`n$($raw -join "`n")"
+        }
+        $response = $raw | ConvertFrom-Json
+        if ([string]$response.statusCode -ne "800") {
+            throw (
+                "Tianyi Cloud API failed: $([string]$response.errorCode) " +
+                "$([string]$response.message) $([string]$response.description)"
+            )
+        }
+        return $response
+    } catch {
+        throw "ctyun-cli call failed ($($Arguments -join ' ')): $($_.Exception.Message)"
     }
-    $response = $raw | ConvertFrom-Json
-    if ([string]$response.statusCode -ne "800") {
-        throw (
-            "Tianyi Cloud API failed: $([string]$response.errorCode) " +
-            "$([string]$response.message) $([string]$response.description)"
-        )
-    }
-    return $response
 }
 
 function Get-ImageItems {
@@ -48,11 +60,28 @@ function Get-ImageItems {
     return @($Response.returnObj.images)
 }
 
+# Defensive property access: returns "" when the object or property is absent,
+# which keeps StrictMode from crashing on hand-made / unlabeled images.
+function Get-Prop {
+    param($Obj, [string]$Name)
+    if ($null -eq $Obj) { return "" }
+    $prop = $Obj.PSObject.Properties[$Name]
+    if ($null -eq $prop) { return "" }
+    return $prop.Value
+}
+
+function Get-PropLong {
+    param($Obj, [string]$Name)
+    $raw = Get-Prop -Obj $Obj -Name $Name
+    if ($raw -is [string] -and $raw.Trim() -eq "") { return [long]0 }
+    return [long]$raw
+}
+
 function Get-LabelValue {
     param($Labels, [string]$Key)
-    $match = @($Labels | Where-Object { [string]$_.labelKey -eq $Key }) | Select-Object -First 1
+    $match = @($Labels | Where-Object { [string](Get-Prop -Obj $_ -Name "labelKey") -eq $Key }) | Select-Object -First 1
     if (-not $match) { return "" }
-    return [string]$match.labelValue
+    return [string](Get-Prop -Obj $match -Name "labelValue")
 }
 
 # --- 分页拉取全部私有镜像 ---
@@ -76,30 +105,30 @@ do {
 # --- 过滤本 bake 通道的 worker 镜像：名称前缀 + bake label ---
 $workerImages = @(
     $all | Where-Object {
-        [string]$_.imageName -like "catsco-worker-*" -and
-        (Get-LabelValue -Labels $_.labels -Key "bake") -ne ""
+        [string](Get-Prop -Obj $_ -Name "imageName") -like "catsco-worker-*" -and
+        (Get-LabelValue -Labels (Get-Prop -Obj $_ -Name "labels") -Key "bake") -ne ""
     }
 )
 
 # --- 最新在前（createdTime 降序，id 兜底） ---
 $sorted = @(
     $workerImages | Sort-Object `
-        @{ Expression = { [long]$_.createdTime }; Descending = $true }, `
-        @{ Expression = { [string]$_.imageID }; Descending = $true }
+        @{ Expression = { Get-PropLong -Obj $_ -Name "createdTime" }; Descending = $true }, `
+        @{ Expression = { [string](Get-Prop -Obj $_ -Name "imageID") }; Descending = $true }
 )
 
 if ($Action -eq "List") {
     $rows = foreach ($img in $sorted) {
         [pscustomobject]@{
-            imageID     = [string]$img.imageID
-            name        = [string]$img.imageName
-            version     = Get-LabelValue -Labels $img.labels -Key "version"
-            commit      = Get-LabelValue -Labels $img.labels -Key "commit"
-            createdTime = [long]$img.createdTime
-            status      = [string]$img.imageStatus
+            imageID     = [string](Get-Prop -Obj $img -Name "imageID")
+            name        = [string](Get-Prop -Obj $img -Name "imageName")
+            version     = Get-LabelValue -Labels (Get-Prop -Obj $img -Name "labels") -Key "version"
+            commit      = Get-LabelValue -Labels (Get-Prop -Obj $img -Name "labels") -Key "commit"
+            createdTime = Get-PropLong -Obj $img -Name "createdTime"
+            status      = [string](Get-Prop -Obj $img -Name "imageStatus")
         }
     }
-    $rows | ConvertTo-Json
+    ConvertTo-Json -InputObject @($rows)
     exit 0
 }
 
@@ -121,8 +150,8 @@ $toDelete = @($sorted | Select-Object -Skip $Keep)
 Write-Host "Pruning $($toDelete.Count) old worker image(s), keeping latest $Keep"
 $failures = [Collections.Generic.List[string]]::new()
 foreach ($img in $toDelete) {
-    $imageID = [string]$img.imageID
-    $imageName = [string]$img.imageName
+    $imageID = [string](Get-Prop -Obj $img -Name "imageID")
+    $imageName = [string](Get-Prop -Obj $img -Name "imageName")
     try {
         Write-Host "Deleting old worker image $imageID ($imageName)"
         Invoke-Ctyun @(
@@ -131,9 +160,10 @@ foreach ($img in $toDelete) {
             "--imageID", $imageID
         ) | Out-Null
 
-        # 删除确认：连续空读（ListImage 全量过滤，不用 GetImageDetail——
-        # 实测 GetImageDetail 对私有镜像偶发 NotFound 而 ListImage 可靠）
-        $deleteDeadline = (Get-Date).AddMinutes(3)
+        # 删除确认：按 --imageName 精确过滤（不用 GetImageDetail——实测对私有
+        # 镜像偶发 NotFound 而 ListImage 可靠）。按名称过滤而不是第 1 页全量，
+        # 避免私有镜像总数 > 200 时最旧镜像不在第 1 页导致的误判"已删除"。
+        $deleteDeadline = (Get-Date).AddMinutes($ConfirmTimeoutMinutes)
         $confirmed = $false
         while ((Get-Date) -lt $deleteDeadline) {
             $checkResp = Invoke-Ctyun @(
@@ -141,12 +171,13 @@ foreach ($img in $toDelete) {
                 "--regionID", $RegionID,
                 "--projectID", $ProjectID,
                 "--imageVisibilityCode", "0",
+                "--imageName", $imageName,
                 "--pageNo", "1",
                 "--pageSize", "200"
             )
             $still = @(
                 @(Get-ImageItems $checkResp) |
-                    Where-Object { [string]$_.imageID -eq $imageID }
+                    Where-Object { [string](Get-Prop -Obj $_ -Name "imageID") -eq $imageID }
             )
             if (@($still).Count -eq 0) {
                 $confirmed = $true
@@ -155,7 +186,7 @@ foreach ($img in $toDelete) {
             Start-Sleep -Seconds 10
         }
         if (-not $confirmed) {
-            throw "Could not confirm deletion of $imageID"
+            throw "Could not confirm deletion of $imageID within $ConfirmTimeoutMinutes minute(s)"
         }
     } catch {
         $failures.Add("image $imageID ($imageName): $($_.Exception.Message)")

--- a/ops/ctyun-worker-image/Manage-WorkerImages.ps1
+++ b/ops/ctyun-worker-image/Manage-WorkerImages.ps1
@@ -1,0 +1,168 @@
+<# Manage-WorkerImages.ps1
+
+Worker 私有镜像生命周期管理（与 New-CatsCoWorkerImage.ps1 配套）：
+
+  -List   : 列出全部 catsco-worker-* 私有镜像（imageID/name/version/commit/createdTime）
+  -Latest : 输出最新 bake 的 worker 镜像 imageID（供部署/控制面取最新镜像）
+  -Prune  : 保留最新 N 个（默认 6），删除更旧的（带 bake label 的 catsco-worker-*），
+            删除需连续空读确认，失败 fail-closed 聚合报告
+
+凭据：复用 ctyun-cli（环境变量 CTYUN_AK/CTYUN_SK 或 ~/.ctyun-cli.yaml），与 bake 一致。
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$RegionID,
+
+    [string]$ProjectID = "0",
+
+    [ValidateSet("List", "Latest", "Prune")]
+    [string]$Action = "List",
+
+    [ValidateRange(1, 50)]
+    [int]$Keep = 6
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+function Invoke-Ctyun {
+    param([Parameter(Mandatory = $true)][string[]]$Arguments)
+
+    $raw = & timeout '--signal=TERM' '--kill-after=15s' '90s' ctyun-cli @Arguments '--output' 'json' 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "ctyun-cli failed with exit code $LASTEXITCODE`n$($raw -join "`n")"
+    }
+    $response = $raw | ConvertFrom-Json
+    if ([string]$response.statusCode -ne "800") {
+        throw (
+            "Tianyi Cloud API failed: $([string]$response.errorCode) " +
+            "$([string]$response.message) $([string]$response.description)"
+        )
+    }
+    return $response
+}
+
+function Get-ImageItems {
+    param($Response)
+    return @($Response.returnObj.images)
+}
+
+function Get-LabelValue {
+    param($Labels, [string]$Key)
+    $match = @($Labels | Where-Object { [string]$_.labelKey -eq $Key }) | Select-Object -First 1
+    if (-not $match) { return "" }
+    return [string]$match.labelValue
+}
+
+# --- 分页拉取全部私有镜像 ---
+$all = [Collections.Generic.List[object]]::new()
+$page = 1
+do {
+    $resp = Invoke-Ctyun @(
+        "ims", "ListImage",
+        "--regionID", $RegionID,
+        "--projectID", $ProjectID,
+        "--imageVisibilityCode", "0",
+        "--pageNo", "$page",
+        "--pageSize", "200"
+    )
+    $items = @(Get-ImageItems $resp)
+    if ($items.Count -gt 0) { $items | ForEach-Object { $all.Add($_) } }
+    $totalPage = [int]($resp.returnObj.totalPage)
+    $page++
+} while ($page -le $totalPage)
+
+# --- 过滤本 bake 通道的 worker 镜像：名称前缀 + bake label ---
+$workerImages = @(
+    $all | Where-Object {
+        [string]$_.imageName -like "catsco-worker-*" -and
+        (Get-LabelValue -Labels $_.labels -Key "bake") -ne ""
+    }
+)
+
+# --- 最新在前（createdTime 降序，id 兜底） ---
+$sorted = @(
+    $workerImages | Sort-Object `
+        @{ Expression = { [long]$_.createdTime }; Descending = $true }, `
+        @{ Expression = { [string]$_.imageID }; Descending = $true }
+)
+
+if ($Action -eq "List") {
+    $rows = foreach ($img in $sorted) {
+        [pscustomobject]@{
+            imageID     = [string]$img.imageID
+            name        = [string]$img.imageName
+            version     = Get-LabelValue -Labels $img.labels -Key "version"
+            commit      = Get-LabelValue -Labels $img.labels -Key "commit"
+            createdTime = [long]$img.createdTime
+            status      = [string]$img.imageStatus
+        }
+    }
+    $rows | ConvertTo-Json
+    exit 0
+}
+
+if ($Action -eq "Latest") {
+    if ($sorted.Count -eq 0) {
+        throw "No worker images found in region $RegionID"
+    }
+    Write-Output ([string]$sorted[0].imageID)
+    exit 0
+}
+
+# --- Prune ---
+if ($sorted.Count -le $Keep) {
+    Write-Host "No worker image cleanup needed ($($sorted.Count) image(s), keep $Keep)"
+    exit 0
+}
+
+$toDelete = @($sorted | Select-Object -Skip $Keep)
+Write-Host "Pruning $($toDelete.Count) old worker image(s), keeping latest $Keep"
+$failures = [Collections.Generic.List[string]]::new()
+foreach ($img in $toDelete) {
+    $imageID = [string]$img.imageID
+    $imageName = [string]$img.imageName
+    try {
+        Write-Host "Deleting old worker image $imageID ($imageName)"
+        Invoke-Ctyun @(
+            "ims", "DeleteImage",
+            "--regionID", $RegionID,
+            "--imageID", $imageID
+        ) | Out-Null
+
+        # 删除确认：连续空读（ListImage 全量过滤，不用 GetImageDetail——
+        # 实测 GetImageDetail 对私有镜像偶发 NotFound 而 ListImage 可靠）
+        $deleteDeadline = (Get-Date).AddMinutes(3)
+        $confirmed = $false
+        while ((Get-Date) -lt $deleteDeadline) {
+            $checkResp = Invoke-Ctyun @(
+                "ims", "ListImage",
+                "--regionID", $RegionID,
+                "--projectID", $ProjectID,
+                "--imageVisibilityCode", "0",
+                "--pageNo", "1",
+                "--pageSize", "200"
+            )
+            $still = @(
+                @(Get-ImageItems $checkResp) |
+                    Where-Object { [string]$_.imageID -eq $imageID }
+            )
+            if (@($still).Count -eq 0) {
+                $confirmed = $true
+                break
+            }
+            Start-Sleep -Seconds 10
+        }
+        if (-not $confirmed) {
+            throw "Could not confirm deletion of $imageID"
+        }
+    } catch {
+        $failures.Add("image $imageID ($imageName): $($_.Exception.Message)")
+    }
+}
+
+if ($failures.Count -gt 0) {
+    throw "Worker image cleanup failed:`n$($failures -join "`n")"
+}
+Write-Host "Worker image cleanup complete"

--- a/ops/ctyun-worker-image/README.md
+++ b/ops/ctyun-worker-image/README.md
@@ -21,12 +21,13 @@ session, skill installation, or runtime `.env`.
   `/opt/catsco/current/worker-release.json` and `/etc/catsco-image.json`.
 - `Manage-WorkerImages.ps1` automates housekeeping: `-Action Prune` keeps the
   newest 6 `catsco-worker-*` images (bake-labeled) and deletes older ones
-  (fail-closed, deletion confirmed by name-scoped reads). It does **not**
-  check the production launch template reference — if the provisioning
-  template still points at an image older than the newest 6, pin the template
-  to a recent image first or prune manually. As a manual safety rule keep the
-  newest two active images plus the image currently referenced by the
-  production launch template.
+  (fail-closed, deletion confirmed by name-scoped reads). **Prune protects
+  production references via `-ProtectedImageIDs`**: the image(s) still
+  referenced by the production launch template (or a pinned rollback target)
+  are never deleted even when older than `-Keep`, and if deletion is needed
+  but no protected list is provided Prune refuses to run (fail-closed). The
+  GitHub workflow passes the repo variable `CTYUN_WORKER_PROTECTED_IMAGE_IDS`
+  (see “Protected image list maintenance” below).
 
 This avoids rebuilding a large system disk for documentation-only or emergency
 application releases while still allowing new workers to start without GitHub.
@@ -37,15 +38,39 @@ application releases while still allowing new workers to start without GitHub.
 (created by `New-CatsCoWorkerImage.ps1`):
 
 - `-Action List`   : list all bake-channel images
-  (`imageID/name/version/commit/createdTime/status`), newest first
-- `-Action Latest` : print the newest imageID (used by deployment / the cloud
-  control plane to pick the latest image)
+  (`imageID/name/version/commit/createdTime/status`), newest first.
+  > **Contract note**: this PowerShell output (pretty JSON) is for CI / humans
+  > on the bake toolchain. The cats-company control plane (`/api/cloud-workers`)
+  > runs on a Linux image **without PowerShell**; its image contract is the
+  > bash `list-worker-images.sh` (TSV, one image per line) from the
+  > cats-company B4-1 scripts. Do not point `CATSCO_WORKER_IMAGES_SCRIPT` at
+  > this `.ps1`.
+- `-Action Latest` : print the newest imageID (used by deployment to pick the
+  latest image)
 - `-Action Prune`  : keep the newest `-Keep` images (default 6) and delete
   older bake-labeled `catsco-worker-*` images; each deletion is confirmed by a
-  name-scoped `ListImage` read, and failures fail closed
+  name-scoped `ListImage` read, and failures fail closed.
+  Requires `-ProtectedImageIDs` (comma-separated) when there are images to
+  delete — protected images are never deleted.
 
 CI runs `Prune -Keep 6` after every successful bake (`continue-on-error`,
-30-minute budget).
+30-minute budget), passing `$env:WORKER_PROTECTED_IMAGE_IDS` (repo var
+`CTYUN_WORKER_PROTECTED_IMAGE_IDS`).
+
+### Protected image list maintenance
+
+- **What to put in it**: the `imageID` currently referenced by the production
+  launch template, plus any pinned rollback/staged-rollout target. The script
+  only verifies the list is non-empty; it does not auto-discover the template
+  reference, so keep it in sync when the template moves.
+- **Local invocation**: `./Manage-WorkerImages.ps1 -Action Prune -Keep 6
+  -RegionID <region> -ProjectID 0 -ProtectedImageIDs
+  "<imageID1>,<imageID2>"`.
+- **Rotating / emergency**: after a bake that becomes the new production
+  reference, update the repo var to the new `imageID` (Settings → Variables),
+  then the next bake’s Prune can safely clean older images. To disable
+  automatic pruning entirely, remove the variable — Prune will refuse to
+  delete (fail-closed) instead of guessing.
 
 ## Layout
 

--- a/ops/ctyun-worker-image/README.md
+++ b/ops/ctyun-worker-image/README.md
@@ -19,11 +19,33 @@ session, skill installation, or runtime `.env`.
   changing it to `false` is the emergency cost and incident kill switch.
 - The application version and full Git commit are stored in both
   `/opt/catsco/current/worker-release.json` and `/etc/catsco-image.json`.
-- Keep the newest two active images plus the image currently referenced by the
-  production launch template. Deactivate older images before deleting them.
+- `Manage-WorkerImages.ps1` automates housekeeping: `-Action Prune` keeps the
+  newest 6 `catsco-worker-*` images (bake-labeled) and deletes older ones
+  (fail-closed, deletion confirmed by name-scoped reads). It does **not**
+  check the production launch template reference — if the provisioning
+  template still points at an image older than the newest 6, pin the template
+  to a recent image first or prune manually. As a manual safety rule keep the
+  newest two active images plus the image currently referenced by the
+  production launch template.
 
 This avoids rebuilding a large system disk for documentation-only or emergency
 application releases while still allowing new workers to start without GitHub.
+
+## Image Lifecycle Management
+
+`Manage-WorkerImages.ps1` manages the private `catsco-worker-*` image set
+(created by `New-CatsCoWorkerImage.ps1`):
+
+- `-Action List`   : list all bake-channel images
+  (`imageID/name/version/commit/createdTime/status`), newest first
+- `-Action Latest` : print the newest imageID (used by deployment / the cloud
+  control plane to pick the latest image)
+- `-Action Prune`  : keep the newest `-Keep` images (default 6) and delete
+  older bake-labeled `catsco-worker-*` images; each deletion is confirmed by a
+  name-scoped `ListImage` read, and failures fail closed
+
+CI runs `Prune -Keep 6` after every successful bake (`continue-on-error`,
+30-minute budget).
 
 ## Layout
 

--- a/tests/manage-worker-images.test.ts
+++ b/tests/manage-worker-images.test.ts
@@ -13,6 +13,76 @@ const managePath = path.join(
   "Manage-WorkerImages.ps1",
 );
 
+// Shared fake ctyun-cli. Supports real pagination (--pageNo/--pageSize with
+// totalPage), delayed deletes (deleteDelayRounds: image stays visible for N
+// more ListImage reads), and delete failures (deleteFailures).
+const FAKE_CTYUN_CLI = `
+import fs from "node:fs";
+const statePath = process.env.FAKE_IMG_STATE;
+const logPath = process.env.FAKE_IMG_LOG;
+const args = process.argv.slice(2);
+const operation = args.slice(0, 2).join(" ");
+const state = JSON.parse(fs.readFileSync(statePath, "utf8"));
+const value = flag => {
+  const index = args.indexOf(flag);
+  return index >= 0 ? args[index + 1] : "";
+};
+fs.appendFileSync(logPath, operation + "\\n");
+let returnObj = {};
+if (operation === "ims ListImage") {
+  if (state.deletePending) {
+    for (const id of Object.keys(state.deletePending)) {
+      const rounds = state.deletePending[id];
+      if (rounds <= 1) {
+        state.images = state.images.filter(img => img.imageID !== id);
+        delete state.deletePending[id];
+      } else {
+        state.deletePending[id] = rounds - 1;
+      }
+    }
+  }
+  const requestedName = value("--imageName");
+  const pageNo = parseInt(value("--pageNo") || "1", 10);
+  const pageSize = parseInt(value("--pageSize") || "200", 10);
+  let list = state.images.filter(img => !requestedName || img.imageName === requestedName);
+  const total = list.length;
+  const start = (pageNo - 1) * pageSize;
+  returnObj = {
+    images: list.slice(start, start + pageSize).map(img => JSON.parse(JSON.stringify(img))),
+    totalPage: Math.ceil(total / pageSize),
+  };
+} else if (operation === "ims DeleteImage") {
+  const id = value("--imageID");
+  if (state.deleteFailures && state.deleteFailures.includes(id)) {
+    fs.writeFileSync(statePath, JSON.stringify(state));
+    process.stdout.write(JSON.stringify({
+      statusCode: 900,
+      message: "ERROR",
+      description: "fake delete error",
+      errorCode: "ims.DeleteImage.Failed",
+      returnObj: {},
+    }));
+    process.exit(0);
+  }
+  if (state.deleteDelayRounds && state.deleteDelayRounds[id] > 0) {
+    state.deletePending = state.deletePending || {};
+    state.deletePending[id] = state.deleteDelayRounds[id];
+  } else {
+    state.images = state.images.filter(img => img.imageID !== id);
+  }
+} else {
+  process.stderr.write("unexpected fake operation: " + operation + "\\n");
+  process.exit(2);
+}
+fs.writeFileSync(statePath, JSON.stringify(state));
+process.stdout.write(JSON.stringify({
+  statusCode: 800,
+  message: "SUCCESS",
+  description: "success",
+  returnObj,
+}));
+`;
+
 test("worker image lifecycle: list, latest, and prune keeps N (default 6)", () => {
   const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "catsco-img-mgmt-"));
   try {
@@ -52,53 +122,7 @@ test("worker image lifecycle: list, latest, and prune keeps N (default 6)", () =
       fs.writeFileSync(`${p}.cmd`, `@echo off\r\nnode "%~dp0${name}" %*\r\n`);
     };
 
-    writeCommand("ctyun-cli", `
-import fs from "node:fs";
-const statePath = process.env.FAKE_IMG_STATE;
-const logPath = process.env.FAKE_IMG_LOG;
-const args = process.argv.slice(2);
-const operation = args.slice(0, 2).join(" ");
-const state = JSON.parse(fs.readFileSync(statePath, "utf8"));
-const value = flag => {
-  const index = args.indexOf(flag);
-  return index >= 0 ? args[index + 1] : "";
-};
-fs.appendFileSync(logPath, operation + "\\n");
-let returnObj = {};
-if (operation === "ims ListImage") {
-  const requestedName = value("--imageName");
-  returnObj = {
-    images: state.images
-      .filter(img => !requestedName || img.imageName === requestedName)
-      .map(img => JSON.parse(JSON.stringify(img))),
-    totalPage: 1,
-  };
-} else if (operation === "ims DeleteImage") {
-  const id = value("--imageID");
-  if (state.deleteFailures && state.deleteFailures.includes(id)) {
-    fs.writeFileSync(statePath, JSON.stringify(state));
-    process.stdout.write(JSON.stringify({
-      statusCode: 900,
-      message: "ERROR",
-      description: "fake delete error",
-      errorCode: "ims.DeleteImage.Failed",
-      returnObj: {},
-    }));
-    process.exit(0);
-  }
-  state.images = state.images.filter(img => img.imageID !== id);
-} else {
-  process.stderr.write("unexpected fake operation: " + operation + "\\n");
-  process.exit(2);
-}
-fs.writeFileSync(statePath, JSON.stringify(state));
-process.stdout.write(JSON.stringify({
-  statusCode: 800,
-  message: "SUCCESS",
-  description: "success",
-  returnObj,
-}));
-`);
+    writeCommand("ctyun-cli", FAKE_CTYUN_CLI);
 
     writeCommand("timeout", `
 import { spawnSync } from "node:child_process";
@@ -116,7 +140,7 @@ const result = spawnSync(
 process.exit(result.status ?? 1);
 `);
 
-    const runScript = (action: string, extra: string[] = []) =>
+    const runScript = (action: string, extra: string[] = [], timeoutMs = 60_000) =>
       spawnSync(
         "pwsh",
         [
@@ -132,7 +156,7 @@ process.exit(result.status ?? 1);
         {
           cwd: root,
           encoding: "utf8",
-          timeout: 60_000,
+          timeout: timeoutMs,
           env: {
             ...process.env,
             PATH: `${bin}${path.delimiter}${process.env.PATH || ""}`,
@@ -221,5 +245,145 @@ process.exit(result.status ?? 1);
     assert.ok(!failState.images.some((i: any) => i.imageID === "img-02"));
   } finally {
     fs.rmSync(sandbox, { recursive: true, force: true });
+  }
+});
+
+function buildSandbox(prefix: string) {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const statePath = path.join(sandbox, "state.json");
+  const logPath = path.join(sandbox, "calls.log");
+  const bin = path.join(sandbox, "bin");
+  fs.mkdirSync(bin);
+
+  const writeCommand = (name: string, body: string) => {
+    const p = path.join(bin, name);
+    fs.writeFileSync(p, `#!/usr/bin/env node\n${body.trim()}\n`);
+    fs.chmodSync(p, 0o755);
+    fs.writeFileSync(`${p}.cmd`, `@echo off\r\nnode "%~dp0${name}" %*\r\n`);
+  };
+  writeCommand("ctyun-cli", FAKE_CTYUN_CLI);
+  writeCommand("timeout", `
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+const args = process.argv.slice(2);
+const durationIndex = args.findIndex(arg => !arg.startsWith("-"));
+if (durationIndex < 0 || !args[durationIndex + 1]) process.exit(2);
+const command = args[durationIndex + 1];
+const commandPath = path.join(path.dirname(process.argv[1]), command);
+const result = spawnSync(
+  process.execPath,
+  [commandPath, ...args.slice(durationIndex + 2)],
+  { stdio: "inherit" },
+);
+process.exit(result.status ?? 1);
+`);
+
+  const writeState = (images: any[], overrides: Record<string, unknown> = {}) => {
+    fs.writeFileSync(statePath, JSON.stringify({ images, ...overrides }));
+  };
+  const runScript = (action: string, extra: string[] = [], timeoutMs = 60_000) =>
+    spawnSync(
+      "pwsh",
+      [
+        "-NoProfile",
+        "-NonInteractive",
+        "-File",
+        managePath,
+        "-RegionID",
+        "region-test",
+        ...(action ? ["-Action", action] : []),
+        ...extra,
+      ],
+      {
+        cwd: root,
+        encoding: "utf8",
+        timeout: timeoutMs,
+        env: {
+          ...process.env,
+          PATH: `${bin}${path.delimiter}${process.env.PATH || ""}`,
+          FAKE_IMG_STATE: statePath,
+          FAKE_IMG_LOG: logPath,
+        },
+      },
+    );
+  return { sandbox, statePath, logPath, writeState, runScript };
+}
+
+test("worker image lifecycle: multi-round confirm, pagination, and confirm timeout", () => {
+  const sb = buildSandbox("catsco-img-mgmt2-");
+  try {
+    const workerImages = (n: number) =>
+      Array.from({ length: n }, (_, i) => ({
+        imageID: `img-${String(i + 1).padStart(3, "0")}`,
+        imageName: `catsco-worker-1-0-${i}`,
+        imageStatus: "active",
+        createdTime: 1000000 + i,
+        labels: [{ labelKey: "bake", labelValue: `b${i}` }],
+      }));
+
+    // --- Pagination: 205 images span 2 pages (pageSize 200) ---
+    sb.writeState(workerImages(205));
+    const listRes = sb.runScript("List");
+    assert.equal(listRes.status, 0, `${listRes.stdout}\n${listRes.stderr}`);
+    const listed = JSON.parse(listRes.stdout);
+    assert.equal(listed.length, 205, "List must paginate through all images");
+
+    // --- Multi-round confirm: img-01 stays visible for 2 more reads ---
+    const eight = workerImages(8);
+    sb.writeState(eight, { deleteDelayRounds: { "img-001": 3 } });
+    fs.rmSync(sb.logPath, { force: true });
+    const pruneRes = sb.runScript("Prune", ["-Keep", "6"]);
+    assert.equal(pruneRes.status, 0, `${pruneRes.stdout}\n${pruneRes.stderr}`);
+    const pruned = JSON.parse(fs.readFileSync(sb.statePath, "utf8"));
+    assert.ok(!pruned.images.some((i: any) => i.imageID === "img-001"), "delayed image must still be removed");
+    assert.ok(!pruned.images.some((i: any) => i.imageID === "img-002"));
+    const calls = fs.readFileSync(sb.logPath, "utf8");
+    assert.ok(
+      (calls.match(/ims ListImage/g) || []).length >= 4,
+      `expected several confirmation reads, got:\n${calls}`,
+    );
+
+    // --- Confirm timeout: image never disappears -> fail closed ---
+    sb.writeState(eight, { deleteDelayRounds: { "img-001": 100 } });
+    fs.rmSync(sb.logPath, { force: true });
+    const timeoutRes = sb.runScript("Prune", ["-Keep", "6", "-ConfirmTimeoutMinutes", "1"], 120_000);
+    assert.notEqual(timeoutRes.status, 0, `expected failure:\n${timeoutRes.stdout}\n${timeoutRes.stderr}`);
+    // PowerShell wraps long error lines (CRLF + ANSI codes), so match the
+    // stable substrings instead of the full "Could not confirm deletion" text.
+    assert.match(timeoutRes.stderr, /confirm deletion/);
+    assert.match(timeoutRes.stderr, /img-001/);
+    const afterTimeout = JSON.parse(fs.readFileSync(sb.statePath, "utf8"));
+    assert.ok(afterTimeout.images.some((i: any) => i.imageID === "img-001"), "unconfirmed image must be kept");
+  } finally {
+    fs.rmSync(sb.sandbox, { recursive: true, force: true });
+  }
+});
+
+test("worker image lifecycle: empty list and missing labels are safe", () => {
+  const sb = buildSandbox("catsco-img-mgmt3-");
+  try {
+    // Empty list prints a valid empty JSON array.
+    sb.writeState([]);
+    const emptyRes = sb.runScript("List");
+    assert.equal(emptyRes.status, 0, `${emptyRes.stdout}\n${emptyRes.stderr}`);
+    assert.equal(emptyRes.stdout.trim(), "[]");
+
+    // A worker-prefixed image without any labels must not crash under
+    // StrictMode; it is simply not part of the bake channel.
+    sb.writeState([
+      { imageID: "img-nolabels", imageName: "catsco-worker-manual", imageStatus: "active", createdTime: 100 },
+      { imageID: "img-ok", imageName: "catsco-worker-1-4-8-a", imageStatus: "active", createdTime: 200, labels: [{ labelKey: "bake", labelValue: "b" }] },
+    ]);
+    const listRes = sb.runScript("List");
+    assert.equal(listRes.status, 0, `${listRes.stdout}\n${listRes.stderr}`);
+    const listed = JSON.parse(listRes.stdout);
+    assert.equal(listed.length, 1);
+    assert.equal(listed[0].imageID, "img-ok");
+
+    // Prune also survives missing labels (nothing to delete here).
+    const pruneRes = sb.runScript("Prune", ["-Keep", "1"]);
+    assert.equal(pruneRes.status, 0, `${pruneRes.stdout}\n${pruneRes.stderr}`);
+  } finally {
+    fs.rmSync(sb.sandbox, { recursive: true, force: true });
   }
 });

--- a/tests/manage-worker-images.test.ts
+++ b/tests/manage-worker-images.test.ts
@@ -1,0 +1,225 @@
+import { test } from "node:test";
+import * as assert from "node:assert";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const root = path.resolve(__dirname, "..");
+const managePath = path.join(
+  root,
+  "ops",
+  "ctyun-worker-image",
+  "Manage-WorkerImages.ps1",
+);
+
+test("worker image lifecycle: list, latest, and prune keeps N (default 6)", () => {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "catsco-img-mgmt-"));
+  try {
+    const statePath = path.join(sandbox, "state.json");
+    const logPath = path.join(sandbox, "calls.log");
+    const bin = path.join(sandbox, "bin");
+    fs.mkdirSync(bin);
+
+    const images = [
+      // 8 worker images, newest first by createdTime
+      { imageID: "img-08", imageName: "catsco-worker-1-4-8-x", imageStatus: "active", createdTime: 800000008, labels: [{ labelKey: "bake", labelValue: "b8" }, { labelKey: "version", labelValue: "1.4.8" }, { labelKey: "commit", labelValue: "c8" }] },
+      { imageID: "img-07", imageName: "catsco-worker-1-4-8-y", imageStatus: "active", createdTime: 800000007, labels: [{ labelKey: "bake", labelValue: "b7" }, { labelKey: "version", labelValue: "1.4.8" }, { labelKey: "commit", labelValue: "c7" }] },
+      { imageID: "img-06", imageName: "catsco-worker-1-4-7-a", imageStatus: "active", createdTime: 800000006, labels: [{ labelKey: "bake", labelValue: "b6" }, { labelKey: "version", labelValue: "1.4.7" }, { labelKey: "commit", labelValue: "c6" }] },
+      { imageID: "img-05", imageName: "catsco-worker-1-4-7-b", imageStatus: "active", createdTime: 800000005, labels: [{ labelKey: "bake", labelValue: "b5" }, { labelKey: "version", labelValue: "1.4.7" }, { labelKey: "commit", labelValue: "c5" }] },
+      { imageID: "img-04", imageName: "catsco-worker-1-4-6-a", imageStatus: "active", createdTime: 800000004, labels: [{ labelKey: "bake", labelValue: "b4" }, { labelKey: "version", labelValue: "1.4.6" }, { labelKey: "commit", labelValue: "c4" }] },
+      { imageID: "img-03", imageName: "catsco-worker-1-4-6-b", imageStatus: "active", createdTime: 800000003, labels: [{ labelKey: "bake", labelValue: "b3" }, { labelKey: "version", labelValue: "1.4.6" }, { labelKey: "commit", labelValue: "c3" }] },
+      { imageID: "img-02", imageName: "catsco-worker-1-4-5-a", imageStatus: "active", createdTime: 800000002, labels: [{ labelKey: "bake", labelValue: "b2" }, { labelKey: "version", labelValue: "1.4.5" }, { labelKey: "commit", labelValue: "c2" }] },
+      { imageID: "img-01", imageName: "catsco-worker-1-4-5-b", imageStatus: "active", createdTime: 800000001, labels: [{ labelKey: "bake", labelValue: "b1" }, { labelKey: "version", labelValue: "1.4.5" }, { labelKey: "commit", labelValue: "c1" }] },
+      // unrelated private image with bake label -> must never be pruned
+      { imageID: "img-other", imageName: "catsco-unrelated-base", imageStatus: "active", createdTime: 900000000, labels: [{ labelKey: "bake", labelValue: "bx" }] },
+      // worker-prefixed but NO bake label -> not part of this bake channel
+      { imageID: "img-nobake", imageName: "catsco-worker-manual", imageStatus: "active", createdTime: 950000000, labels: [] },
+    ];
+
+    const writeState = (overrides: Record<string, unknown> = {}) => {
+      fs.writeFileSync(
+        statePath,
+        JSON.stringify({ images, ...overrides }),
+      );
+    };
+    writeState();
+
+    const writeCommand = (name: string, body: string) => {
+      const p = path.join(bin, name);
+      fs.writeFileSync(p, `#!/usr/bin/env node\n${body.trim()}\n`);
+      fs.chmodSync(p, 0o755);
+      fs.writeFileSync(`${p}.cmd`, `@echo off\r\nnode "%~dp0${name}" %*\r\n`);
+    };
+
+    writeCommand("ctyun-cli", `
+import fs from "node:fs";
+const statePath = process.env.FAKE_IMG_STATE;
+const logPath = process.env.FAKE_IMG_LOG;
+const args = process.argv.slice(2);
+const operation = args.slice(0, 2).join(" ");
+const state = JSON.parse(fs.readFileSync(statePath, "utf8"));
+const value = flag => {
+  const index = args.indexOf(flag);
+  return index >= 0 ? args[index + 1] : "";
+};
+fs.appendFileSync(logPath, operation + "\\n");
+let returnObj = {};
+if (operation === "ims ListImage") {
+  const requestedName = value("--imageName");
+  returnObj = {
+    images: state.images
+      .filter(img => !requestedName || img.imageName === requestedName)
+      .map(img => JSON.parse(JSON.stringify(img))),
+    totalPage: 1,
+  };
+} else if (operation === "ims DeleteImage") {
+  const id = value("--imageID");
+  if (state.deleteFailures && state.deleteFailures.includes(id)) {
+    fs.writeFileSync(statePath, JSON.stringify(state));
+    process.stdout.write(JSON.stringify({
+      statusCode: 900,
+      message: "ERROR",
+      description: "fake delete error",
+      errorCode: "ims.DeleteImage.Failed",
+      returnObj: {},
+    }));
+    process.exit(0);
+  }
+  state.images = state.images.filter(img => img.imageID !== id);
+} else {
+  process.stderr.write("unexpected fake operation: " + operation + "\\n");
+  process.exit(2);
+}
+fs.writeFileSync(statePath, JSON.stringify(state));
+process.stdout.write(JSON.stringify({
+  statusCode: 800,
+  message: "SUCCESS",
+  description: "success",
+  returnObj,
+}));
+`);
+
+    writeCommand("timeout", `
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+const args = process.argv.slice(2);
+const durationIndex = args.findIndex(arg => !arg.startsWith("-"));
+if (durationIndex < 0 || !args[durationIndex + 1]) process.exit(2);
+const command = args[durationIndex + 1];
+const commandPath = path.join(path.dirname(process.argv[1]), command);
+const result = spawnSync(
+  process.execPath,
+  [commandPath, ...args.slice(durationIndex + 2)],
+  { stdio: "inherit" },
+);
+process.exit(result.status ?? 1);
+`);
+
+    const runScript = (action: string, extra: string[] = []) =>
+      spawnSync(
+        "pwsh",
+        [
+          "-NoProfile",
+          "-NonInteractive",
+          "-File",
+          managePath,
+          "-RegionID",
+          "region-test",
+          ...(action ? ["-Action", action] : []),
+          ...extra,
+        ],
+        {
+          cwd: root,
+          encoding: "utf8",
+          timeout: 60_000,
+          env: {
+            ...process.env,
+            PATH: `${bin}${path.delimiter}${process.env.PATH || ""}`,
+            FAKE_IMG_STATE: statePath,
+            FAKE_IMG_LOG: logPath,
+          },
+        },
+      );
+
+    // --- List: only catsco-worker-* with bake label, newest first ---
+    fs.rmSync(logPath, { force: true });
+    const listResult = runScript("List");
+    assert.equal(
+      listResult.status,
+      0,
+      `${listResult.stdout}\n${listResult.stderr}`,
+    );
+    const listed = JSON.parse(listResult.stdout);
+    assert.equal(listed.length, 8);
+    assert.equal(listed[0].imageID, "img-08");
+    assert.equal(listed[7].imageID, "img-01");
+    assert.equal(listed[0].version, "1.4.8");
+    assert.equal(listed[0].commit, "c8");
+    assert.ok(!listed.some((i: any) => i.imageID === "img-other"));
+    assert.ok(!listed.some((i: any) => i.imageID === "img-nobake"));
+
+    // --- Latest: newest worker image id ---
+    const latestResult = runScript("Latest");
+    assert.equal(
+      latestResult.status,
+      0,
+      `${latestResult.stdout}\n${latestResult.stderr}`,
+    );
+    assert.equal(latestResult.stdout.trim(), "img-08");
+
+    // --- Prune 6: deletes the 2 oldest, keeps 6 ---
+    writeState();
+    fs.rmSync(logPath, { force: true });
+    const pruneResult = runScript("Prune", ["-Keep", "6"]);
+    assert.equal(
+      pruneResult.status,
+      0,
+      `${pruneResult.stdout}\n${pruneResult.stderr}`,
+    );
+    const calls = fs.readFileSync(logPath, "utf8");
+    assert.match(calls, /ims DeleteImage/);
+    const prunedState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+    const remaining = prunedState.images.filter((i: any) =>
+      i.imageName.startsWith("catsco-worker-") &&
+      i.labels.some((l: any) => l.labelKey === "bake"),
+    );
+    assert.equal(remaining.length, 6);
+    assert.ok(!remaining.some((i: any) => i.imageID === "img-01"));
+    assert.ok(!remaining.some((i: any) => i.imageID === "img-02"));
+    // unrelated and no-bake images untouched
+    assert.ok(prunedState.images.some((i: any) => i.imageID === "img-other"));
+    assert.ok(prunedState.images.some((i: any) => i.imageID === "img-nobake"));
+
+    // --- Prune 6 with only 5 -> nothing to delete ---
+    writeState({
+      images: images.slice(0, 5),
+    });
+    fs.rmSync(logPath, { force: true });
+    const noOpResult = runScript("Prune", ["-Keep", "6"]);
+    assert.equal(
+      noOpResult.status,
+      0,
+      `${noOpResult.stdout}\n${noOpResult.stderr}`,
+    );
+    const noOpCalls = fs.readFileSync(logPath, "utf8");
+    assert.doesNotMatch(noOpCalls, /ims DeleteImage/);
+
+    // --- Prune with a delete failure -> fail closed, keeps others ---
+    writeState({ deleteFailures: ["img-01"] });
+    fs.rmSync(logPath, { force: true });
+    const failResult = runScript("Prune", ["-Keep", "6"]);
+    assert.notEqual(failResult.status, 0);
+    assert.match(failResult.stderr, /Worker image cleanup failed/);
+    const failCalls = fs.readFileSync(logPath, "utf8");
+    assert.ok(
+      (failCalls.match(/ims DeleteImage/g) || []).length >= 2,
+      `expected the other delete to proceed\n${failCalls}`,
+    );
+    const failState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+    assert.ok(failState.images.some((i: any) => i.imageID === "img-01"));
+    assert.ok(!failState.images.some((i: any) => i.imageID === "img-02"));
+  } finally {
+    fs.rmSync(sandbox, { recursive: true, force: true });
+  }
+});

--- a/tests/manage-worker-images.test.ts
+++ b/tests/manage-worker-images.test.ts
@@ -192,10 +192,10 @@ process.exit(result.status ?? 1);
     );
     assert.equal(latestResult.stdout.trim(), "img-08");
 
-    // --- Prune 6: deletes the 2 oldest, keeps 6 ---
+    // --- Prune 6: deletes the 2 oldest, keeps 6 (protected list declared) ---
     writeState();
     fs.rmSync(logPath, { force: true });
-    const pruneResult = runScript("Prune", ["-Keep", "6"]);
+    const pruneResult = runScript("Prune", ["-Keep", "6", "-ProtectedImageIDs", "img-000"]);
     assert.equal(
       pruneResult.status,
       0,
@@ -232,7 +232,7 @@ process.exit(result.status ?? 1);
     // --- Prune with a delete failure -> fail closed, keeps others ---
     writeState({ deleteFailures: ["img-01"] });
     fs.rmSync(logPath, { force: true });
-    const failResult = runScript("Prune", ["-Keep", "6"]);
+    const failResult = runScript("Prune", ["-Keep", "6", "-ProtectedImageIDs", "img-000"]);
     assert.notEqual(failResult.status, 0);
     assert.match(failResult.stderr, /Worker image cleanup failed/);
     const failCalls = fs.readFileSync(logPath, "utf8");
@@ -332,7 +332,7 @@ test("worker image lifecycle: multi-round confirm, pagination, and confirm timeo
     const eight = workerImages(8);
     sb.writeState(eight, { deleteDelayRounds: { "img-001": 3 } });
     fs.rmSync(sb.logPath, { force: true });
-    const pruneRes = sb.runScript("Prune", ["-Keep", "6"]);
+    const pruneRes = sb.runScript("Prune", ["-Keep", "6", "-ProtectedImageIDs", "img-000"]);
     assert.equal(pruneRes.status, 0, `${pruneRes.stdout}\n${pruneRes.stderr}`);
     const pruned = JSON.parse(fs.readFileSync(sb.statePath, "utf8"));
     assert.ok(!pruned.images.some((i: any) => i.imageID === "img-001"), "delayed image must still be removed");
@@ -346,7 +346,7 @@ test("worker image lifecycle: multi-round confirm, pagination, and confirm timeo
     // --- Confirm timeout: image never disappears -> fail closed ---
     sb.writeState(eight, { deleteDelayRounds: { "img-001": 100 } });
     fs.rmSync(sb.logPath, { force: true });
-    const timeoutRes = sb.runScript("Prune", ["-Keep", "6", "-ConfirmTimeoutMinutes", "1"], 120_000);
+    const timeoutRes = sb.runScript("Prune", ["-Keep", "6", "-ConfirmTimeoutMinutes", "1", "-ProtectedImageIDs", "img-000"], 120_000);
     assert.notEqual(timeoutRes.status, 0, `expected failure:\n${timeoutRes.stdout}\n${timeoutRes.stderr}`);
     // PowerShell wraps long error lines (CRLF + ANSI codes), so match the
     // stable substrings instead of the full "Could not confirm deletion" text.
@@ -383,6 +383,46 @@ test("worker image lifecycle: empty list and missing labels are safe", () => {
     // Prune also survives missing labels (nothing to delete here).
     const pruneRes = sb.runScript("Prune", ["-Keep", "1"]);
     assert.equal(pruneRes.status, 0, `${pruneRes.stdout}\n${pruneRes.stderr}`);
+  } finally {
+    fs.rmSync(sb.sandbox, { recursive: true, force: true });
+  }
+});
+
+test("worker image lifecycle: prune protects production-referenced images", () => {
+  const sb = buildSandbox("catsco-img-mgmt4-");
+  try {
+    const eight = Array.from({ length: 8 }, (_, i) => ({
+      imageID: `img-${String(i + 1).padStart(3, "0")}`,
+      imageName: `catsco-worker-1-0-${i}`,
+      imageStatus: "active",
+      createdTime: 1000000 + i,
+      labels: [{ labelKey: "bake", labelValue: `b${i}` }],
+    }));
+
+    // --- protected oldest image survives prune ---
+    sb.writeState(eight, {});
+    fs.rmSync(sb.logPath, { force: true });
+    const r = sb.runScript("Prune", ["-Keep", "6", "-ProtectedImageIDs", "img-001"]);
+    assert.equal(r.status, 0, `${r.stdout}\n${r.stderr}`);
+    const state = JSON.parse(fs.readFileSync(sb.statePath, "utf8"));
+    const remaining = state.images.filter((i: any) => i.labels?.some((l: any) => l.labelKey === "bake"));
+    assert.ok(remaining.some((i: any) => i.imageID === "img-001"), "protected img-001 must survive");
+    assert.ok(!remaining.some((i: any) => i.imageID === "img-002"), "img-002 (not protected) must be pruned");
+
+    // --- all would-be-pruned protected -> nothing to delete ---
+    sb.writeState(eight, {});
+    fs.rmSync(sb.logPath, { force: true });
+    const r2 = sb.runScript("Prune", ["-Keep", "6", "-ProtectedImageIDs", "img-001,img-002"]);
+    assert.equal(r2.status, 0, `${r2.stdout}\n${r2.stderr}`);
+    assert.doesNotMatch(fs.readFileSync(sb.logPath, "utf8"), /ims DeleteImage/);
+
+    // --- no protected list configured -> refuse (fail closed) ---
+    sb.writeState(eight, {});
+    fs.rmSync(sb.logPath, { force: true });
+    const r3 = sb.runScript("Prune", ["-Keep", "6"]);
+    assert.notEqual(r3.status, 0, `expected refusal:\n${r3.stdout}\n${r3.stderr}`);
+    assert.match(r3.stderr, /no protected image IDs configured/);
+    assert.doesNotMatch(fs.readFileSync(sb.logPath, "utf8"), /ims DeleteImage/);
   } finally {
     fs.rmSync(sb.sandbox, { recursive: true, force: true });
   }


### PR DESCRIPTION
Part of \2026-08-07-worker-cloud-control-image-lifecycle\ (module A).

**What**
- New \ops/ctyun-worker-image/Manage-WorkerImages.ps1\:
  - \-Action List\: worker images (catsco-worker-* with bake label), newest first, with imageID/name/version/commit/createdTime/status.
  - \-Action Latest\: emits the newest worker image id for deploy / control-plane.
  - \-Action Prune -Keep 6\: deletes older images; fail-closed, consecutive-empty-read confirmation via ListImage (GetImageDetail is unreliable for private images); only catsco-worker-* with a bake label is ever touched.
- \worker-image.yml\: runs \Prune -Keep 6\ after a successful bake (continue-on-error: housekeeping never blocks the fresh image).
- \	ests/manage-worker-images.test.ts\: list/latest/prune, <=6 no-op, delete-failure fail-closed, unrelated/no-bake images never deleted.

**Validation**: worker-image-pipeline + manage-worker-images **12/12** green; \
pm run build\ green; ps1 parses.