### PR TITLE
fix(skillhub): 在分享前识别并隔离无效本地 Skill

### DIFF
--- a/src/bot-skills/local-manifest.ts
+++ b/src/bot-skills/local-manifest.ts
@@ -126,7 +126,7 @@ export function scanBotSkillWorkspace(
           }
           const marker = readBotSkillLocalMarker(skillDir);
           if (!marker) throw error;
-          const name = readLocalSkillName(skillDir);
+          const name = readLocalSkillNameForValidationFailure(skillDir);
           if (localSkillIds.has(marker.localSkillId)) {
             throw new Error(`Bot Skill workspace contains a duplicate localSkillId: ${marker.localSkillId}`);
           }
@@ -199,7 +199,18 @@ function readLocalSkillName(skillDir: string): string {
     const parsed = matter(fs.readFileSync(path.join(skillDir, 'SKILL.md'), 'utf8'), {});
     return String(parsed.data?.name || fallback).trim() || fallback;
   } catch {
-    return fallback;
+    throw new BotSkillPackageValidationError(
+      'SKILL.md format is invalid. Check its YAML frontmatter and try again.',
+    );
+  }
+}
+
+function readLocalSkillNameForValidationFailure(skillDir: string): string {
+  try {
+    return readLocalSkillName(skillDir);
+  } catch (error) {
+    if (!(error instanceof BotSkillPackageValidationError)) throw error;
+    return path.basename(skillDir);
   }
 }
 

--- a/src/bot-skills/local-manifest.ts
+++ b/src/bot-skills/local-manifest.ts
@@ -126,8 +126,7 @@ export function scanBotSkillWorkspace(
           }
           const marker = readBotSkillLocalMarker(skillDir);
           if (!marker) throw error;
-          const parsed = matter(fs.readFileSync(path.join(skillDir, 'SKILL.md'), 'utf8'));
-          const name = String(parsed.data?.name || path.basename(skillDir)).trim() || path.basename(skillDir);
+          const name = readLocalSkillName(skillDir);
           if (localSkillIds.has(marker.localSkillId)) {
             throw new Error(`Bot Skill workspace contains a duplicate localSkillId: ${marker.localSkillId}`);
           }
@@ -179,8 +178,7 @@ export function scanLocalBotSkill(
   const reference = marker.reference?.contentHash === contentHash
     ? marker.reference
     : undefined;
-  const parsed = matter(fs.readFileSync(skillFile, 'utf8'));
-  const name = String(parsed.data?.name || path.basename(root)).trim() || path.basename(root);
+  const name = readLocalSkillName(root);
   return {
     localSkillId: marker.localSkillId,
     name,
@@ -193,6 +191,16 @@ export function scanLocalBotSkill(
     ...(reference ? { reference } : {}),
     ...(marker.origin ? { origin: marker.origin } : {}),
   };
+}
+
+function readLocalSkillName(skillDir: string): string {
+  const fallback = path.basename(skillDir);
+  try {
+    const parsed = matter(fs.readFileSync(path.join(skillDir, 'SKILL.md'), 'utf8'), {});
+    return String(parsed.data?.name || fallback).trim() || fallback;
+  } catch {
+    return fallback;
+  }
 }
 
 export function readBotSkillLocalMarker(skillDir: string): BotSkillLocalMarker | undefined {

--- a/src/catscompany/skillhub-rpc.ts
+++ b/src/catscompany/skillhub-rpc.ts
@@ -11,7 +11,10 @@ import {
   scanBotSkillWorkspace,
 } from '../bot-skills/local-manifest';
 import { readSkillHubLocalMetadata } from '../skillhub/local-skill-metadata';
-import { shareLocalSkillForCatsCo } from '../skillhub/local-share';
+import {
+  shareLocalSkillForCatsCo,
+  validateSkillHubShareMetadata,
+} from '../skillhub/local-share';
 import { PathResolver } from '../utils/path-resolver';
 import { Logger } from '../utils/logger';
 
@@ -147,7 +150,7 @@ export class SkillHubThinRpcHandler {
       this.assertRequestScope(request, botUid, true);
       this.assertActiveWorkspace(botUid, context.botId, context.activeBotId);
       const rejected: SkillHubWorkspaceValidationFailure[] = [];
-      const entries = scanBotSkillWorkspace(context.skillsRoot, {
+      const entries = scanSkillHubWorkspace(context.skillsRoot, {
         onValidationFailure: failure => rejected.push(failure),
       }).filter((entry) => {
         const error = validateSkillHubShareMetadata(entry.path);
@@ -217,7 +220,7 @@ export class SkillHubThinRpcHandler {
     await withCurrentBotSkillWorkspaceWrite((context) => {
       this.assertActiveWorkspace(botUid, context.botId, context.activeBotId);
       const rejected: SkillHubWorkspaceValidationFailure[] = [];
-      const entry = scanBotSkillWorkspace(context.skillsRoot, {
+      const entry = scanSkillHubWorkspace(context.skillsRoot, {
         onValidationFailure: failure => rejected.push(failure),
       }).find((candidate) => (
         candidate.localSkillId === localSkillId && candidate.name === skillName
@@ -432,21 +435,6 @@ export async function requestDashboardBotSwitch(
   }
 }
 
-function validateSkillHubShareMetadata(skillDir: string): Error | undefined {
-  try {
-    const skillFile = path.join(skillDir, 'SKILL.md');
-    const parsed = matter(fs.readFileSync(skillFile, 'utf8'), {});
-    if (!parsed.data?.name || !parsed.data?.description) {
-      return new Error(
-        'SKILL.md 缺少必填字段 name 或 description。请在文件顶部的 YAML frontmatter 中补全后重试。',
-      );
-    }
-    return undefined;
-  } catch {
-    return new Error('SKILL.md 格式无效。请检查文件顶部的 YAML frontmatter 后重试。');
-  }
-}
-
 function readLocalSkillPresentation(skillDir: string): {
   description: string;
   metadata: ReturnType<typeof readSkillHubLocalMetadata>;
@@ -460,6 +448,20 @@ function readLocalSkillPresentation(skillDir: string): {
     };
   } catch {
     return { description: '', metadata: null };
+  }
+}
+
+function scanSkillHubWorkspace(
+  skillsRoot: string,
+  options: Parameters<typeof scanBotSkillWorkspace>[1],
+): ReturnType<typeof scanBotSkillWorkspace> {
+  try {
+    return scanBotSkillWorkspace(skillsRoot, options);
+  } catch {
+    throw new SkillHubThinRpcError(
+      'LOCAL_SKILL_INVALID',
+      'The local Skill workspace could not be validated safely.',
+    );
   }
 }
 

--- a/src/catscompany/skillhub-rpc.ts
+++ b/src/catscompany/skillhub-rpc.ts
@@ -9,7 +9,6 @@ import {
 } from '../bot-skills/runtime';
 import {
   scanBotSkillWorkspace,
-  type BotSkillWorkspaceValidationFailure,
 } from '../bot-skills/local-manifest';
 import { readSkillHubLocalMetadata } from '../skillhub/local-skill-metadata';
 import { shareLocalSkillForCatsCo } from '../skillhub/local-share';
@@ -30,6 +29,14 @@ const MAX_RELATIVE_PATH_LENGTH = 500;
 const MAX_COMPLETED_REQUESTS = 256;
 const BOT_UID_PATTERN = /^[A-Za-z0-9_.-]{1,160}$/;
 const CONTENT_HASH_PATTERN = /^[0-9a-f]{64}$/;
+
+interface SkillHubWorkspaceValidationFailure {
+  localSkillId: string;
+  name: string;
+  installName: string;
+  path: string;
+  error: Error;
+}
 
 export class SkillHubThinRpcError extends Error {
   constructor(public readonly code: string, message: string) {
@@ -139,9 +146,20 @@ export class SkillHubThinRpcHandler {
       this.assertOperational(request);
       this.assertRequestScope(request, botUid, true);
       this.assertActiveWorkspace(botUid, context.botId, context.activeBotId);
-      const rejected: BotSkillWorkspaceValidationFailure[] = [];
+      const rejected: SkillHubWorkspaceValidationFailure[] = [];
       const entries = scanBotSkillWorkspace(context.skillsRoot, {
         onValidationFailure: failure => rejected.push(failure),
+      }).filter((entry) => {
+        const error = validateSkillHubShareMetadata(entry.path);
+        if (!error) return true;
+        rejected.push({
+          localSkillId: entry.localSkillId,
+          name: entry.name,
+          installName: entry.installName,
+          path: entry.path,
+          error,
+        });
+        return false;
       });
       const listed = [
         ...entries.map(entry => ({ kind: 'valid' as const, entry })),
@@ -151,33 +169,31 @@ export class SkillHubThinRpcHandler {
       const skills = listed.map((item) => {
         if (item.kind === 'valid') {
           const { entry } = item;
-          const parsed = matter(fs.readFileSync(path.join(entry.path, 'SKILL.md'), 'utf8'));
-          const metadata = readSkillHubLocalMetadata(path.join(entry.path, 'SKILL.md'));
+          const presentation = readLocalSkillPresentation(entry.path);
           return {
             local_skill_id: limitText(entry.localSkillId, MAX_NAME_LENGTH),
             name: limitText(entry.name, MAX_NAME_LENGTH),
-            description: limitText(String(parsed.data?.description || ''), MAX_DESCRIPTION_LENGTH),
+            description: limitText(presentation.description, MAX_DESCRIPTION_LENGTH),
             relative_path: limitText(entry.installName, MAX_RELATIVE_PATH_LENGTH),
             source: 'user',
             can_share: !entry.reference || isPrivateSkillReference(entry.reference.skillId),
             skill_hub: {
-              ...(metadata || {}),
+              ...(presentation.metadata || {}),
               ...(entry.reference ? { reference: entry.reference } : {}),
             },
           };
         }
         const { entry } = item;
-        const parsed = matter(fs.readFileSync(path.join(entry.path, 'SKILL.md'), 'utf8'));
-        const metadata = readSkillHubLocalMetadata(path.join(entry.path, 'SKILL.md'));
+        const presentation = readLocalSkillPresentation(entry.path);
         return {
           local_skill_id: limitText(entry.localSkillId, MAX_NAME_LENGTH),
           name: limitText(entry.name, MAX_NAME_LENGTH),
-          description: limitText(String(parsed.data?.description || ''), MAX_DESCRIPTION_LENGTH),
+          description: limitText(presentation.description, MAX_DESCRIPTION_LENGTH),
           relative_path: limitText(entry.installName, MAX_RELATIVE_PATH_LENGTH),
           source: 'user',
           can_share: false,
           share_error: limitText(entry.error.message, MAX_DESCRIPTION_LENGTH),
-          skill_hub: metadata || {},
+          skill_hub: presentation.metadata || {},
         };
       });
       return {
@@ -200,13 +216,24 @@ export class SkillHubThinRpcHandler {
     const skillName = requiredText(payload.skill_name, 'skill_name', MAX_NAME_LENGTH);
     await withCurrentBotSkillWorkspaceWrite((context) => {
       this.assertActiveWorkspace(botUid, context.botId, context.activeBotId);
+      const rejected: SkillHubWorkspaceValidationFailure[] = [];
       const entry = scanBotSkillWorkspace(context.skillsRoot, {
-        onValidationFailure: () => {},
+        onValidationFailure: failure => rejected.push(failure),
       }).find((candidate) => (
         candidate.localSkillId === localSkillId && candidate.name === skillName
       ));
       if (!entry) {
+        const invalid = rejected.find(candidate => (
+          candidate.localSkillId === localSkillId && candidate.name === skillName
+        ));
+        if (invalid) {
+          throw new SkillHubThinRpcError('LOCAL_SKILL_INVALID', invalid.error.message);
+        }
         throw new SkillHubThinRpcError('LOCAL_SKILL_NOT_FOUND', 'The selected local Skill no longer exists.');
+      }
+      const validationError = validateSkillHubShareMetadata(entry.path);
+      if (validationError) {
+        throw new SkillHubThinRpcError('LOCAL_SKILL_INVALID', validationError.message);
       }
     }, { runtimeRoot: this.runtimeRoot });
 
@@ -402,6 +429,37 @@ export async function requestDashboardBotSwitch(
   });
   if (!response.ok) {
     throw new Error(`Dashboard rejected the Bot switch (HTTP ${response.status}).`);
+  }
+}
+
+function validateSkillHubShareMetadata(skillDir: string): Error | undefined {
+  try {
+    const skillFile = path.join(skillDir, 'SKILL.md');
+    const parsed = matter(fs.readFileSync(skillFile, 'utf8'), {});
+    if (!parsed.data?.name || !parsed.data?.description) {
+      return new Error(
+        'SKILL.md 缺少必填字段 name 或 description。请在文件顶部的 YAML frontmatter 中补全后重试。',
+      );
+    }
+    return undefined;
+  } catch {
+    return new Error('SKILL.md 格式无效。请检查文件顶部的 YAML frontmatter 后重试。');
+  }
+}
+
+function readLocalSkillPresentation(skillDir: string): {
+  description: string;
+  metadata: ReturnType<typeof readSkillHubLocalMetadata>;
+} {
+  const skillFile = path.join(skillDir, 'SKILL.md');
+  try {
+    const parsed = matter(fs.readFileSync(skillFile, 'utf8'), {});
+    return {
+      description: String(parsed.data?.description || ''),
+      metadata: readSkillHubLocalMetadata(skillFile),
+    };
+  } catch {
+    return { description: '', metadata: null };
   }
 }
 

--- a/src/skillhub/local-share.ts
+++ b/src/skillhub/local-share.ts
@@ -1,4 +1,6 @@
+import * as fs from 'fs';
 import * as path from 'path';
+import matter from 'gray-matter';
 import {
   withCurrentBotSkillWorkspaceWrite,
   type CurrentBotSkillWorkspaceWriteContext,
@@ -19,6 +21,7 @@ export interface SkillHubCatsCoAuthPayload {
 
 export interface ShareLocalSkillForCatsCoOptions {
   getCatsCoAuth?: () => Promise<SkillHubCatsCoAuthPayload> | SkillHubCatsCoAuthPayload;
+  createSkillHubService?: () => Pick<SkillHubService, 'loginWithCatsCo' | 'shareLocalSkill'>;
   writeLocalMetadata?: boolean;
   runtimeRoot?: string;
   validateScope?: (
@@ -64,15 +67,44 @@ export async function shareLocalSkillForCatsCo(
   return withCurrentBotSkillWorkspaceWrite(async (context) => {
     assertExpectedLocalSkillShareScope(expectedBotUid, context.botId, context.activeBotId);
     await options.validateScope?.(context);
-    const selectedSkill = expectedLocalSkillId
-      ? scanBotSkillWorkspace(context.skillsRoot, {
-        onValidationFailure: () => {},
-      }).find((candidate) => (
-        candidate.localSkillId === expectedLocalSkillId && candidate.name === skillName
-      ))
-      : undefined;
+    const rejected: Array<{ localSkillId: string; error: Error }> = [];
+    let selectedSkill;
+    try {
+      selectedSkill = expectedLocalSkillId
+        ? scanBotSkillWorkspace(context.skillsRoot, {
+          onValidationFailure: failure => rejected.push(failure),
+        }).find(candidate => candidate.localSkillId === expectedLocalSkillId)
+        : undefined;
+    } catch {
+      throw skillHubConflict(
+        'The selected local Skill could not be validated safely.',
+        'skillhub.share_local_skill_invalid',
+      );
+    }
     if (expectedLocalSkillId) {
+      const rejectedSkill = rejected.find(candidate => (
+        candidate.localSkillId === expectedLocalSkillId
+      ));
+      if (rejectedSkill) {
+        throw skillHubConflict(
+          rejectedSkill.error.message,
+          'skillhub.share_local_skill_invalid',
+        );
+      }
       if (!selectedSkill) {
+        throw skillHubConflict(
+          'The selected local Skill changed before it could be shared.',
+          'skillhub.share_local_skill_changed',
+        );
+      }
+      const metadataError = validateSkillHubShareMetadata(selectedSkill.path);
+      if (metadataError) {
+        throw skillHubConflict(
+          metadataError.message,
+          'skillhub.share_local_skill_invalid',
+        );
+      }
+      if (selectedSkill.name !== skillName) {
         throw skillHubConflict(
           'The selected local Skill changed before it could be shared.',
           'skillhub.share_local_skill_changed',
@@ -80,7 +112,14 @@ export async function shareLocalSkillForCatsCo(
       }
     }
     const cats = await options.getCatsCoAuth!();
-    const service = new SkillHubService({ sessionScope: 'memory' });
+    if (String(cats.user?.uid || '').trim() !== expectedUserUid) {
+      throw skillHubConflict(
+        'The local CatsCo account changed before the Skill was shared.',
+        'skillhub.share_user_changed',
+      );
+    }
+    const service = options.createSkillHubService?.()
+      ?? new SkillHubService({ sessionScope: 'memory' });
     const skillHubAuth = await service.loginWithCatsCo(cats);
     const actualUserUid = String(skillHubAuth.catsCo?.uid || '').trim();
     if (!actualUserUid) {
@@ -101,12 +140,20 @@ export async function shareLocalSkillForCatsCo(
     });
     let revalidatedSkill = selectedSkill;
     if (selectedSkill) {
-      const currentSkill = scanBotSkillWorkspace(context.skillsRoot, {
-        onValidationFailure: () => {},
-      }).find((candidate) => (
-        candidate.localSkillId === selectedSkill.localSkillId
-        && candidate.name === selectedSkill.name
-      ));
+      let currentSkill;
+      try {
+        currentSkill = scanBotSkillWorkspace(context.skillsRoot, {
+          onValidationFailure: () => {},
+        }).find((candidate) => (
+          candidate.localSkillId === selectedSkill.localSkillId
+          && candidate.name === selectedSkill.name
+        ));
+      } catch {
+        throw skillHubConflict(
+          'The selected local Skill could not be validated safely.',
+          'skillhub.share_local_skill_invalid',
+        );
+      }
       if (!currentSkill || currentSkill.contentHash !== selectedSkill.contentHash) {
         throw skillHubConflict(
           'The selected local Skill changed while it was being shared.',
@@ -122,6 +169,28 @@ export async function shareLocalSkillForCatsCo(
     }
     return { ...result, botUid: expectedBotUid };
   }, { runtimeRoot: options.runtimeRoot });
+}
+
+export function validateSkillHubShareMetadata(skillDir: string): Error | undefined {
+  try {
+    const skillFile = path.join(skillDir, 'SKILL.md');
+    const parsed = matter(fs.readFileSync(skillFile, 'utf8'), {});
+    const name = parsed.data?.name;
+    const description = parsed.data?.description;
+    if (
+      typeof name !== 'string'
+      || !name.trim()
+      || typeof description !== 'string'
+      || !description.trim()
+    ) {
+      return new Error(
+        'SKILL.md 缺少有效的必填字段 name 或 description。请在文件顶部的 YAML frontmatter 中填写非空文本后重试。',
+      );
+    }
+    return undefined;
+  } catch {
+    return new Error('SKILL.md 格式无效。请检查文件顶部的 YAML frontmatter 后重试。');
+  }
 }
 
 export function assertExpectedLocalSkillShareScope(

--- a/src/skillhub/local-share.ts
+++ b/src/skillhub/local-share.ts
@@ -177,6 +177,9 @@ export function validateSkillHubShareMetadata(skillDir: string): Error | undefin
     const parsed = matter(fs.readFileSync(skillFile, 'utf8'), {});
     const name = parsed.data?.name;
     const description = parsed.data?.description;
+    if (typeof name === 'string' && name.trim() && name !== name.trim()) {
+      return new Error('SKILL.md 的 name 不能包含首尾空格。请移除多余空格后重试。');
+    }
     if (
       typeof name !== 'string'
       || !name.trim()

--- a/src/skillhub/service.ts
+++ b/src/skillhub/service.ts
@@ -247,9 +247,14 @@ export class SkillHubService {
       throw error;
     }
 
-    const localSkill = options.localSkillPath
-      ? findLocalShareableSkillAtPath(options.localSkillPath, skillName)
-      : findLocalShareableSkill(skillName);
+    let localSkill;
+    try {
+      localSkill = options.localSkillPath
+        ? findLocalShareableSkillAtPath(options.localSkillPath, skillName)
+        : findLocalShareableSkill(skillName);
+    } catch {
+      throw localSkillValidationFailed();
+    }
     if (!localSkill) {
       const available = listLocalSkillNames().join(', ');
       const error: any = new Error(`Local skill not found: ${skillName}${available ? `. Available skills: ${available}` : ''}`);
@@ -267,11 +272,13 @@ export class SkillHubService {
         contentBase64,
       }));
     } catch (caught: any) {
-      if (!(caught instanceof BotSkillPackageValidationError)) throw caught;
-      const error: any = new Error(caught?.message || 'Local Skill package is unsafe to share.');
-      error.status = 400;
-      error.code = 'skillhub.local_skill_unsafe_package';
-      throw error;
+      if (caught instanceof BotSkillPackageValidationError) {
+        const error: any = new Error(caught?.message || 'Local Skill package is unsafe to share.');
+        error.status = 400;
+        error.code = 'skillhub.local_skill_unsafe_package';
+        throw error;
+      }
+      throw localSkillValidationFailed();
     }
     if (!files.length) {
       const error: any = new Error('Local skill package has no shareable files.');
@@ -350,6 +357,13 @@ export class SkillHubService {
     error.status = 404;
     throw error;
   }
+}
+
+function localSkillValidationFailed(): Error {
+  const error: any = new Error('The selected local Skill could not be validated safely.');
+  error.status = 400;
+  error.code = 'skillhub.local_skill_invalid';
+  return error;
 }
 
 function assertRegistryEntryMatchesRequest(

--- a/src/skillhub/service.ts
+++ b/src/skillhub/service.ts
@@ -252,7 +252,10 @@ export class SkillHubService {
       localSkill = options.localSkillPath
         ? findLocalShareableSkillAtPath(options.localSkillPath, skillName)
         : findLocalShareableSkill(skillName);
-    } catch {
+    } catch (caught: any) {
+      if (caught?.code === 'skillhub.local_skill_ambiguous' && caught?.status === 409) {
+        throw caught;
+      }
       throw localSkillValidationFailed();
     }
     if (!localSkill) {

--- a/tests/bot-skills-sync.test.ts
+++ b/tests/bot-skills-sync.test.ts
@@ -1242,6 +1242,29 @@ describe('Bot Skill Local/Base/Cloud sync', () => {
     assert.deepStrictEqual(fixture.definitionService.read(fixture.botId)?.skills, previousSkills);
   });
 
+  test('rejects malformed SKILL.md before private upload or BotDefinition update', async () => {
+    const fixture = createFixture(roots);
+    const skillRoot = path.join(fixture.skillsRoot, 'malformed');
+    fs.mkdirSync(skillRoot, { recursive: true });
+    fs.writeFileSync(path.join(skillRoot, 'SKILL.md'), [
+      '---',
+      'name: [unterminated',
+      'description: Broken YAML',
+      '---',
+      '',
+    ].join('\n'));
+
+    assert.throws(
+      () => scanBotSkillWorkspace(fixture.skillsRoot),
+      /SKILL\.md format is invalid/i,
+    );
+    await assert.rejects(fixture.sync(), /SKILL\.md format is invalid/i);
+    assert.equal(fixture.uploads, 0);
+    assert.equal(fixture.patches, 0);
+    assert.equal(fixture.definitionService.read(fixture.botId)?.skills, undefined);
+    assert.deepStrictEqual(fixture.cloud.skills, []);
+  });
+
   test('rejects credential files and high-confidence secrets before any upload request is built', () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-sensitive-skill-'));
     roots.push(root);

--- a/tests/catscompany-skillhub-rpc.test.ts
+++ b/tests/catscompany-skillhub-rpc.test.ts
@@ -224,6 +224,61 @@ describe('CatsCompany SkillHub thin RPC', () => {
     }
   });
 
+  test('rejects a Skill name with surrounding whitespace before CatsCo authentication', async () => {
+    const skillRoot = path.join(runtimeRoot, 'skills', 'whitespace-name');
+    fs.mkdirSync(skillRoot, { recursive: true });
+    fs.writeFileSync(path.join(skillRoot, 'SKILL.md'), [
+      '---',
+      'name: " demo "',
+      'description: Valid description',
+      '---',
+      '',
+    ].join('\n'));
+
+    const metadataError = validateSkillHubShareMetadata(skillRoot);
+    assert.ok(metadataError);
+    assert.match(metadataError.message, /name.*首尾空格/);
+    const workspace = await handler.execute(request({ request_id: 'workspace-whitespace-name' }));
+    const entry = (workspace.skills as Array<Record<string, unknown>>)
+      .find(skill => skill.relative_path === 'whitespace-name');
+    assert.ok(entry?.local_skill_id);
+    assert.equal(entry.name, 'demo');
+    assert.equal(entry.can_share, false);
+
+    const originalFetch = global.fetch;
+    let authExchangeCalls = 0;
+    let remoteRequestCount = 0;
+    global.fetch = async (input: string | URL | Request) => {
+      remoteRequestCount += 1;
+      if (new URL(String(input)).pathname === '/api/auth/catsco-exchange') {
+        authExchangeCalls += 1;
+      }
+      return Response.json({ error: 'unexpected request' }, { status: 500 });
+    };
+    try {
+      await assert.rejects(
+        handler.execute(request({
+          request_id: 'share-whitespace-name',
+          tool_name: SKILLHUB_THIN_RPC_TOOLS.share,
+          payload: {
+            bot_uid: '42',
+            local_skill_id: entry.local_skill_id,
+            skill_name: entry.name,
+            confirm_publish: true,
+          },
+        })),
+        (error: any) => (
+          error instanceof SkillHubThinRpcError
+          && error.code === 'LOCAL_SKILL_INVALID'
+        ),
+      );
+    } finally {
+      global.fetch = originalFetch;
+    }
+    assert.equal(authExchangeCalls, 0);
+    assert.equal(remoteRequestCount, 0);
+  });
+
   test('sorts valid and rejected local Skills by the complete canonical ID', async () => {
     const skillsRoot = path.join(runtimeRoot, 'skills');
     writeBotSkillLocalMarker(path.join(skillsRoot, 'local-demo'), {

--- a/tests/catscompany-skillhub-rpc.test.ts
+++ b/tests/catscompany-skillhub-rpc.test.ts
@@ -112,6 +112,55 @@ describe('CatsCompany SkillHub thin RPC', () => {
     assert.match(String(blocked?.share_error || ''), /sensitive material/i);
   });
 
+  test('keeps invalid SKILL.md entries visible but disables sharing with an actionable error', async () => {
+    const invalidRoot = path.join(runtimeRoot, 'skills', 'test_8_7');
+    const malformedRoot = path.join(runtimeRoot, 'skills', 'broken_yaml');
+    fs.mkdirSync(invalidRoot, { recursive: true });
+    fs.mkdirSync(malformedRoot, { recursive: true });
+    fs.writeFileSync(
+      path.join(invalidRoot, 'SKILL.md'),
+      '# Test Skill\n\nThis file has no YAML name or description.\n',
+    );
+    fs.writeFileSync(
+      path.join(malformedRoot, 'SKILL.md'),
+      '---\nname: [unterminated\ndescription: Broken YAML\n---\n',
+    );
+
+    const compatibilityScan = scanBotSkillWorkspace(path.join(runtimeRoot, 'skills'));
+    assert.equal(compatibilityScan.length, 3);
+
+    const result = await handler.execute(request({ request_id: 'workspace-with-invalid-skill' }));
+    const skills = result.skills as Array<Record<string, unknown>>;
+    assert.equal(skills.length, 3);
+    assert.equal(skills.find(skill => skill.name === 'local-demo')?.can_share, true);
+    const invalid = skills.find(skill => skill.name === 'test_8_7');
+    assert.ok(invalid?.local_skill_id);
+    assert.equal(invalid?.can_share, false);
+    assert.match(String(invalid?.share_error || ''), /name.*description.*YAML frontmatter/i);
+    const malformed = skills.find(skill => skill.name === 'broken_yaml');
+    assert.ok(malformed?.local_skill_id);
+    assert.equal(malformed?.can_share, false);
+    assert.match(String(malformed?.share_error || ''), /SKILL\.md.*格式无效.*YAML frontmatter/i);
+
+    await assert.rejects(
+      handler.execute(request({
+        request_id: 'share-invalid-skill',
+        tool_name: SKILLHUB_THIN_RPC_TOOLS.share,
+        payload: {
+          bot_uid: '42',
+          local_skill_id: invalid?.local_skill_id,
+          skill_name: 'test_8_7',
+          confirm_publish: true,
+        },
+      })),
+      (error: any) => (
+        error instanceof SkillHubThinRpcError
+        && error.code === 'LOCAL_SKILL_INVALID'
+        && /name.*description.*YAML frontmatter/i.test(error.message)
+      ),
+    );
+  });
+
   test('sorts valid and rejected local Skills by the complete canonical ID', async () => {
     const skillsRoot = path.join(runtimeRoot, 'skills');
     writeBotSkillLocalMarker(path.join(skillsRoot, 'local-demo'), {

--- a/tests/catscompany-skillhub-rpc.test.ts
+++ b/tests/catscompany-skillhub-rpc.test.ts
@@ -11,13 +11,17 @@ import {
   requestDashboardBotSwitch,
 } from '../src/catscompany/skillhub-rpc';
 import { BotSkillWorkspaceService } from '../src/bot-skills/workspace';
-import { shareLocalSkillForCatsCo } from '../src/skillhub/local-share';
+import {
+  shareLocalSkillForCatsCo,
+  validateSkillHubShareMetadata,
+} from '../src/skillhub/local-share';
 import { scanBotSkillWorkspace } from '../src/bot-skills/local-manifest';
 import { writeBotSkillLocalMarker } from '../src/bot-skills/local-manifest';
 import {
   applySkillHubLocalMetadata,
   readSkillHubLocalMetadata,
 } from '../src/skillhub/local-skill-metadata';
+import { SkillHubService } from '../src/skillhub/service';
 
 describe('CatsCompany SkillHub thin RPC', () => {
   let runtimeRoot = '';
@@ -126,8 +130,10 @@ describe('CatsCompany SkillHub thin RPC', () => {
       '---\nname: [unterminated\ndescription: Broken YAML\n---\n',
     );
 
-    const compatibilityScan = scanBotSkillWorkspace(path.join(runtimeRoot, 'skills'));
-    assert.equal(compatibilityScan.length, 3);
+    assert.throws(
+      () => scanBotSkillWorkspace(path.join(runtimeRoot, 'skills')),
+      /SKILL\.md format is invalid/i,
+    );
 
     const result = await handler.execute(request({ request_id: 'workspace-with-invalid-skill' }));
     const skills = result.skills as Array<Record<string, unknown>>;
@@ -140,7 +146,7 @@ describe('CatsCompany SkillHub thin RPC', () => {
     const malformed = skills.find(skill => skill.name === 'broken_yaml');
     assert.ok(malformed?.local_skill_id);
     assert.equal(malformed?.can_share, false);
-    assert.match(String(malformed?.share_error || ''), /SKILL\.md.*格式无效.*YAML frontmatter/i);
+    assert.match(String(malformed?.share_error || ''), /SKILL\.md format is invalid.*YAML frontmatter/i);
 
     await assert.rejects(
       handler.execute(request({
@@ -159,6 +165,63 @@ describe('CatsCompany SkillHub thin RPC', () => {
         && /name.*description.*YAML frontmatter/i.test(error.message)
       ),
     );
+  });
+
+  test('returns LOCAL_SKILL_INVALID for non-string or blank share metadata', async () => {
+    const skillRoot = path.join(runtimeRoot, 'skills', 'metadata-validation');
+    fs.mkdirSync(skillRoot, { recursive: true });
+    const invalidValues = [
+      { label: 'blank', yaml: '"   "' },
+      { label: 'number', yaml: '123' },
+      { label: 'array', yaml: '[value]' },
+      { label: 'object', yaml: '{ value: text }' },
+    ];
+
+    for (const field of ['name', 'description'] as const) {
+      for (const invalid of invalidValues) {
+        const metadata = {
+          name: 'valid-name',
+          description: 'Valid description',
+          [field]: invalid.yaml,
+        };
+        fs.writeFileSync(path.join(skillRoot, 'SKILL.md'), [
+          '---',
+          `name: ${metadata.name}`,
+          `description: ${metadata.description}`,
+          '---',
+          '',
+        ].join('\n'));
+        const error = validateSkillHubShareMetadata(skillRoot);
+        assert.ok(error, `${field} accepted ${invalid.label}`);
+        assert.match(error.message, /name.*description.*非空文本/i);
+
+        const requestSuffix = `${field}-${invalid.label}`;
+        const workspace = await handler.execute(request({
+          request_id: `workspace-invalid-${requestSuffix}`,
+        }));
+        const entry = (workspace.skills as Array<Record<string, unknown>>)
+          .find(skill => skill.relative_path === 'metadata-validation');
+        assert.ok(entry?.local_skill_id);
+        assert.equal(entry?.can_share, false);
+        await assert.rejects(
+          handler.execute(request({
+            request_id: `share-invalid-${requestSuffix}`,
+            tool_name: SKILLHUB_THIN_RPC_TOOLS.share,
+            payload: {
+              bot_uid: '42',
+              local_skill_id: entry.local_skill_id,
+              skill_name: entry.name,
+              confirm_publish: true,
+            },
+          })),
+          (rpcError: any) => (
+            rpcError instanceof SkillHubThinRpcError
+            && rpcError.code === 'LOCAL_SKILL_INVALID'
+            && /name.*description.*非空文本/i.test(rpcError.message)
+          ),
+        );
+      }
+    }
   });
 
   test('sorts valid and rejected local Skills by the complete canonical ID', async () => {
@@ -417,6 +480,180 @@ describe('CatsCompany SkillHub thin RPC', () => {
       }),
       (error: any) => error?.code === 'skillhub.share_local_skill_changed',
     );
+  });
+
+  test('revalidates malformed YAML under the upload lock before authentication', async () => {
+    const selected = scanBotSkillWorkspace(path.join(runtimeRoot, 'skills'))[0];
+    await handler.execute(request({ request_id: 'metadata-first-lock' }));
+    fs.writeFileSync(path.join(selected.path, 'SKILL.md'), [
+      '---',
+      'name: [unterminated',
+      'description: Broken YAML',
+      '---',
+      '',
+    ].join('\n'));
+    let localAuthReads = 0;
+    let authExchangeCalls = 0;
+    let uploadCalls = 0;
+
+    await assert.rejects(
+      shareLocalSkillForCatsCo({
+        skillName: selected.name,
+        expectedLocalSkillId: selected.localSkillId,
+        expectedBotUid: '42',
+        expectedUserUid: '7',
+      }, {
+        writeLocalMetadata: false,
+        runtimeRoot,
+        getCatsCoAuth: () => {
+          localAuthReads += 1;
+          return {
+            token: 'user-token',
+            baseUrl: 'https://app.catsco.cc',
+            user: { uid: '7', username: 'alice' },
+          };
+        },
+        createSkillHubService: () => ({
+          loginWithCatsCo: async () => {
+            authExchangeCalls += 1;
+            throw new Error('remote authentication should not be reached');
+          },
+          shareLocalSkill: async () => {
+            uploadCalls += 1;
+            throw new Error('remote upload should not be reached');
+          },
+        }),
+      }),
+      (error: any) => (
+        error?.code === 'skillhub.share_local_skill_invalid'
+        && /SKILL\.md format is invalid.*YAML frontmatter/i.test(error.message)
+        && !error.message.includes(runtimeRoot)
+      ),
+    );
+    assert.equal(localAuthReads, 1);
+    assert.equal(authExchangeCalls, 0);
+    assert.equal(uploadCalls, 0);
+  });
+
+  test('redacts local paths when locked workspace scanning fails before authentication', async () => {
+    const selected = scanBotSkillWorkspace(path.join(runtimeRoot, 'skills'))[0];
+    fs.writeFileSync(path.join(selected.path, '.xiaoba-bot-skill.json'), '{ invalid json');
+    let authExchangeCalls = 0;
+    let uploadCalls = 0;
+
+    await assert.rejects(
+      handler.execute(request({
+        request_id: 'share-invalid-marker',
+        tool_name: SKILLHUB_THIN_RPC_TOOLS.share,
+        payload: {
+          bot_uid: '42',
+          local_skill_id: selected.localSkillId,
+          skill_name: selected.name,
+          confirm_publish: true,
+        },
+      })),
+      (error: any) => (
+        error instanceof SkillHubThinRpcError
+        && error.code === 'LOCAL_SKILL_INVALID'
+        && error.message === 'The local Skill workspace could not be validated safely.'
+        && !error.message.includes(runtimeRoot)
+        && !error.message.includes(selected.path)
+      ),
+    );
+
+    await assert.rejects(
+      shareLocalSkillForCatsCo({
+        skillName: selected.name,
+        expectedLocalSkillId: selected.localSkillId,
+        expectedBotUid: '42',
+        expectedUserUid: '7',
+      }, {
+        writeLocalMetadata: false,
+        runtimeRoot,
+        getCatsCoAuth: () => ({
+          token: 'user-token',
+          baseUrl: 'https://app.catsco.cc',
+          user: { uid: '7', username: 'alice' },
+        }),
+        createSkillHubService: () => ({
+          loginWithCatsCo: async () => {
+            authExchangeCalls += 1;
+            throw new Error('remote authentication should not be reached');
+          },
+          shareLocalSkill: async () => {
+            uploadCalls += 1;
+            throw new Error('remote upload should not be reached');
+          },
+        }),
+      }),
+      (error: any) => (
+        error?.code === 'skillhub.share_local_skill_invalid'
+        && error.message === 'The selected local Skill could not be validated safely.'
+        && !error.message.includes(runtimeRoot)
+        && !error.message.includes(selected.path)
+      ),
+    );
+    assert.equal(authExchangeCalls, 0);
+    assert.equal(uploadCalls, 0);
+  });
+
+  test('redacts malformed YAML introduced during authentication before quick share', async () => {
+    const selected = scanBotSkillWorkspace(path.join(runtimeRoot, 'skills'))[0];
+    const productionService = new SkillHubService({
+      baseUrl: 'http://127.0.0.1:1',
+      sessionScope: 'memory',
+    });
+    let authExchangeCalls = 0;
+    let localSharePreparations = 0;
+
+    await assert.rejects(
+      shareLocalSkillForCatsCo({
+        skillName: selected.name,
+        expectedLocalSkillId: selected.localSkillId,
+        expectedBotUid: '42',
+        expectedUserUid: '7',
+      }, {
+        writeLocalMetadata: false,
+        runtimeRoot,
+        getCatsCoAuth: () => ({
+          token: 'user-token',
+          baseUrl: 'https://app.catsco.cc',
+          user: { uid: '7', username: 'alice' },
+        }),
+        createSkillHubService: () => ({
+          loginWithCatsCo: async () => {
+            authExchangeCalls += 1;
+            fs.writeFileSync(path.join(selected.path, 'SKILL.md'), [
+              '---',
+              'name: [unterminated',
+              'description: Broken during authentication',
+              '---',
+              '',
+            ].join('\n'));
+            return {
+              authenticated: true,
+              baseUrl: 'https://skillhub.example.test',
+              roles: [],
+              permissions: [],
+              catsCo: { uid: '7', username: 'alice', displayName: 'Alice' },
+            };
+          },
+          shareLocalSkill: async (input, options) => {
+            localSharePreparations += 1;
+            return productionService.shareLocalSkill(input, options);
+          },
+        }),
+      }),
+      (error: any) => (
+        error?.code === 'skillhub.local_skill_invalid'
+        && error?.status === 400
+        && error.message === 'The selected local Skill could not be validated safely.'
+        && !error.message.includes(runtimeRoot)
+        && !error.message.includes(selected.path)
+      ),
+    );
+    assert.equal(authExchangeCalls, 1);
+    assert.equal(localSharePreparations, 1);
   });
 
   test('writes share metadata only after revalidating the selected local Skill and scope', async () => {

--- a/tests/skillhub-service-install.test.ts
+++ b/tests/skillhub-service-install.test.ts
@@ -43,6 +43,17 @@ describe('SkillHub connected install service', () => {
   });
 
   test('preserves the actionable ambiguity error for same-name local Skills', async () => {
+    let requestCount = 0;
+    const app = express();
+    app.use((_req, res) => {
+      requestCount += 1;
+      res.status(500).json({ error: 'unexpected request' });
+    });
+    server = await listen(app);
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('server did not bind');
+    process.env.CATSCO_SKILLHUB_BASE_URL = `http://127.0.0.1:${address.port}`;
+
     for (const directory of ['first-review', 'second-review']) {
       const skillRoot = path.join(testRoot, 'skills', directory);
       fs.mkdirSync(skillRoot, { recursive: true });
@@ -65,6 +76,7 @@ describe('SkillHub connected install service', () => {
         && /Select one by its local Skill ID/i.test(error.message)
       ),
     );
+    assert.equal(requestCount, 0);
   });
 
   test('logs in, persists session cookie, verifies package, and installs skill files', async () => {

--- a/tests/skillhub-service-install.test.ts
+++ b/tests/skillhub-service-install.test.ts
@@ -42,6 +42,31 @@ describe('SkillHub connected install service', () => {
     if (fs.existsSync(testRoot)) fs.rmSync(testRoot, { recursive: true, force: true });
   });
 
+  test('preserves the actionable ambiguity error for same-name local Skills', async () => {
+    for (const directory of ['first-review', 'second-review']) {
+      const skillRoot = path.join(testRoot, 'skills', directory);
+      fs.mkdirSync(skillRoot, { recursive: true });
+      fs.writeFileSync(path.join(skillRoot, 'SKILL.md'), [
+        '---',
+        'name: review-pr',
+        `description: ${directory} review Skill`,
+        '---',
+        '',
+        '# Review PR',
+        '',
+      ].join('\n'));
+    }
+
+    await assert.rejects(
+      new SkillHubService().shareLocalSkill({ skillName: 'review-pr' }),
+      (error: any) => (
+        error?.code === 'skillhub.local_skill_ambiguous'
+        && error?.status === 409
+        && /Select one by its local Skill ID/i.test(error.message)
+      ),
+    );
+  });
+
   test('logs in, persists session cookie, verifies package, and installs skill files', async () => {
     const fixture = createFixture();
     CATSCO_SKILLHUB_ROOT_PUBLIC_KEYS.push(fixture.rootTrust);


### PR DESCRIPTION
## 背景与原因

用户在本地 Skills 目录中新建了一个 `SKILL.md`，但文件顶部没有填写公共 Skill 分享所需的 `name` 和 `description`。现有实现扫描工作区时会使用文件夹名兜底，因此页面仍显示“分享到 SkillHub”按钮；真正点击分享后才由严格解析器拒绝，并把包含本机绝对路径的英文错误直接展示给用户。

这会造成两个问题：

- 页面把实际上无法分享的 Skill 标记成可分享；
- 一个损坏的 YAML 或缺少字段的 Skill，可能影响同一工作区中其他正常 Skill 的读取体验。

## 本 PR 做了什么

1. 在 CatsCo SkillHub 工作区 RPC 中校验本地 `SKILL.md` 的 YAML frontmatter。
2. 缺少 `name` 或 `description` 时，保留该 Skill 卡片，但返回 `can_share: false` 和明确的中文 `share_error`。
3. YAML 格式损坏时安全降级到文件夹名，避免一个坏 Skill 阻断整个本地工作区。
4. 即使绕过页面直接发起分享请求，也会在认证和上传前返回 `LOCAL_SKILL_INVALID`。
5. 避免 `gray-matter` 失败缓存造成“损坏 YAML 被二次误判为缺字段”。
6. 保持通用 Bot Skill scanner 的历史兼容行为：严格的公共分享格式要求只作用于 SkillHub RPC，不会扩散到 Local/Base/Cloud 同步、旧私有 Skill 或云端恢复流程。

## 用户侧效果

- 正常 Skill 的扫描和分享行为不变；
- 无效 Skill 仍然可见，不会让其他 Skill 消失；
- 无效 Skill 不再出现可点击的分享入口；
- XiaoBa 返回可操作的中文修复原因，不再泄露本机绝对路径。

## 测试

- CatsCompany SkillHub RPC、Bot Skill 同步与安全测试：56/56 通过；
- TypeScript 构建通过；
- XiaoBa runtime 全量测试：1496 项中 1489 通过、5 项跳过；
- 剩余 2 项失败均来自当前 Windows 环境缺少 PowerShell 7 的 `pwsh`，且已在未修改的 `main` 上得到相同结果，与本 PR 无关。

## 跨仓与下一步

CatsCo WebApp 还需要消费 `share_error` 并在不可分享卡片中展示完整中文原因。该展示层修改已经在本地独立完成，但由于正在审阅的 CatsCo PR #162 同样修改了 `skillhub-view.jsx`，本 PR 不混入 CatsCo 代码。

建议顺序：

1. 审阅并合并本 PR；
2. 等 CatsCo #162 合并；
3. 将本地 CatsCo 展示提交更新到最新 `main`，重新跑完整前端测试后再单独提 PR；
4. 两侧部署后，用缺字段、损坏 YAML 和正常 Skill 三种本地目录进行一次真实联调。
