### PR TITLE
修复云端本地模型回退同步

### DIFF
--- a/src/bot-definition/activation.ts
+++ b/src/bot-definition/activation.ts
@@ -124,6 +124,26 @@ export async function prepareBoundBotDefinition(
           cloudSnapshot = await cloudDefinitionSync.pull(botId, auth) ?? cloudSnapshot;
         }
 
+        if (
+          cloudSnapshot.definition?.model.kind === 'local'
+          && !definitionService.read(botId)
+        ) {
+          const runtime = await provisionCatsRelayCatalogRuntime({
+            botId,
+            modelId: DEFAULT_CATSCO_RELAY_MODEL_ID,
+            auth,
+            fetchImpl: options.fetchImpl,
+          });
+          definitionService.storeCatalogRuntime(runtime);
+          sync = definitionService.updateModel(botId, {
+            kind: 'catalog',
+            modelId: DEFAULT_CATSCO_RELAY_MODEL_ID,
+          });
+          localDefinition = sync.definition;
+          initializedDefaultFromEmpty = true;
+          cloudSnapshot = await cloudDefinitionSync.pull(botId, auth) ?? cloudSnapshot;
+        }
+
         let definition = definitionService.read(botId);
         if (!definition) throw new Error('CatsCo cloud BotDefinition did not produce a local cache.');
         definitionService.clearCloudModelOverride(botId);

--- a/src/bot-definition/cloud-client.ts
+++ b/src/bot-definition/cloud-client.ts
@@ -4,7 +4,7 @@ import type { ReasoningEffort } from '../types';
 import { canonicalizeBotSkillRefs } from '../bot-skills/canonical';
 import {
   BOT_DEFINITION_SCHEMA,
-  type BotDefinition,
+  type CloudBotDefinition,
   type BotModelDefinition,
   type BotPromptDefinition,
   type BotSkillRef,
@@ -26,13 +26,13 @@ export interface CloudBotModelSelection {
   contextWindowTokens?: number;
   revision: number;
   customModel?: CustomBotModelDefinition;
-  definition?: BotDefinition;
+  definition?: CloudBotDefinition;
 }
 
 export interface CloudBotDefinitionSnapshot {
   configured: boolean;
   revision: number;
-  definition?: BotDefinition;
+  definition?: CloudBotDefinition;
   runtime?: Record<string, unknown>;
 }
 
@@ -49,7 +49,14 @@ export async function pullCloudBotModelSelection(
   if (definitionSnapshot) {
     if (!definitionSnapshot.configured || !definitionSnapshot.definition) return undefined;
     const model = definitionSnapshot.definition.model;
-    return model.kind === 'custom'
+    return model.kind === 'local'
+      ? {
+        kind: 'local',
+        modelId: 'local',
+        revision: definitionSnapshot.revision,
+        definition: definitionSnapshot.definition,
+      }
+      : model.kind === 'custom'
       ? {
         kind: 'custom',
         modelId: model.model,
@@ -292,9 +299,15 @@ function parseCloudBotDefinitionSnapshot(
   }
   const rawModel = raw.model as Record<string, unknown> | undefined;
   const kind = String(rawModel?.kind || '').trim().toLowerCase();
-  let model: BotModelDefinition;
+  let model: CloudBotDefinition['model'];
   if (kind === 'custom') {
     model = parseCloudCustomModel(rawModel);
+  } else if (kind === 'local') {
+    const modelId = String(rawModel?.modelId || '').trim().toLowerCase();
+    if (modelId && modelId !== 'local') {
+      throw new Error('CatsCo cloud returned an invalid local BotDefinition.');
+    }
+    model = { kind: 'local', modelId: 'local' };
   } else if (!kind || kind === 'catalog') {
     const modelId = String(rawModel?.modelId || '').trim();
     const rawReasoning = String(rawModel?.reasoningEffort || '').trim();

--- a/src/bot-definition/cloud-sync.ts
+++ b/src/bot-definition/cloud-sync.ts
@@ -10,7 +10,12 @@ import {
   type CloudBotDefinitionSnapshot,
 } from './cloud-client';
 import { createBotDefinitionSyncService, type BotDefinitionSyncService } from './service';
-import type { BotDefinition, BotModelDefinition, BotPromptDefinition } from './types';
+import type {
+  BotDefinition,
+  BotModelDefinition,
+  BotPromptDefinition,
+  CloudBotDefinition,
+} from './types';
 
 const CLOUD_SYNC_STATE_SCHEMA = 'xiaoba.bot-definition-cloud-sync.v1';
 
@@ -27,6 +32,14 @@ export interface BotDefinitionCloudSyncOptions {
   env?: NodeJS.ProcessEnv;
   definitionService?: BotDefinitionSyncService;
   fetchImpl?: typeof fetch;
+}
+
+export function resolveRunnableCloudDefinition(
+  definition: CloudBotDefinition,
+  local?: BotDefinition,
+): BotDefinition | undefined {
+  if (definition.model.kind !== 'local') return definition as BotDefinition;
+  return local ? { ...definition, model: local.model } : undefined;
 }
 
 /**
@@ -285,9 +298,11 @@ export class BotDefinitionCloudSyncService {
     return snapshot;
   }
 
-  private acceptCloudDefinition(definition: BotDefinition): void {
+  private acceptCloudDefinition(definition: CloudBotDefinition): void {
     const local = this.definitionService.read(definition.botId);
-    const { skills: _cloudSkills, ...portableDefinition } = definition;
+    const runnable = resolveRunnableCloudDefinition(definition, local);
+    if (!runnable) return;
+    const { skills: _cloudSkills, ...portableDefinition } = runnable;
     this.definitionService.acceptCanonical({
       ...portableDefinition,
       ...(local?.skills !== undefined ? { skills: local.skills } : {}),

--- a/src/bot-definition/types.ts
+++ b/src/bot-definition/types.ts
@@ -38,6 +38,16 @@ export interface CustomBotModelDefinition {
 
 export type BotModelDefinition = CatalogBotModelDefinition | CustomBotModelDefinition;
 
+/**
+ * Cloud-only handoff marker. It means the device keeps its current runnable
+ * model while the remaining portable fields continue to sync from CatsCompany.
+ * It must never replace the runnable model in the local Definition cache.
+ */
+export interface LocalBotModelHandoffDefinition {
+  kind: 'local';
+  modelId: 'local';
+}
+
 export interface BotPromptDefinition {
   selected: 'default' | 'custom';
   customSystemPrompt?: string;
@@ -60,6 +70,10 @@ export interface BotDefinition {
   model: BotModelDefinition;
   prompt?: BotPromptDefinition;
   skills?: BotSkillRef[];
+}
+
+export interface CloudBotDefinition extends Omit<BotDefinition, 'model'> {
+  model: BotModelDefinition | LocalBotModelHandoffDefinition;
 }
 
 export interface LocalModelProfile {

--- a/src/bot-skills/cloud-client.ts
+++ b/src/bot-skills/cloud-client.ts
@@ -3,14 +3,14 @@ import {
   patchCloudBotDefinitionSkills,
   pullCloudBotDefinition,
 } from '../bot-definition/cloud-client';
-import type { BotDefinition, BotSkillRef } from '../bot-definition/types';
+import type { BotSkillRef, CloudBotDefinition } from '../bot-definition/types';
 import { canonicalizeBotSkillRefs } from './canonical';
 
 export interface CloudBotSkills {
   botId: string;
   skills: BotSkillRef[];
   revision: number;
-  definition?: BotDefinition;
+  definition?: CloudBotDefinition;
   updatedAt?: string;
 }
 

--- a/src/bot-skills/sync-service.ts
+++ b/src/bot-skills/sync-service.ts
@@ -7,7 +7,7 @@ import {
   createBotDefinitionSyncService,
   type BotDefinitionSyncService,
 } from '../bot-definition/service';
-import type { BotSkillRef } from '../bot-definition/types';
+import type { BotDefinition, BotSkillRef } from '../bot-definition/types';
 import { canonicalizeBotSkillRefs, botSkillRefsEqual } from './canonical';
 import {
   BotSkillsCloudConflictError,
@@ -857,7 +857,10 @@ export class BotSkillSyncService {
       this.definitionService.updateSkills(this.botId, cloud.skills);
       return;
     }
-    this.definitionService.acceptCanonical(cloud.definition);
+    if (cloud.definition.model.kind === 'local') {
+      throw new Error('CatsCo cloud local handoff requires an existing runnable local BotDefinition.');
+    }
+    this.definitionService.acceptCanonical(cloud.definition as BotDefinition);
   }
 }
 

--- a/src/commands/catscompany.ts
+++ b/src/commands/catscompany.ts
@@ -17,6 +17,7 @@ import {
 } from '../bot-definition/cloud-client';
 import { CloudBotModelRuntimeReloadController } from '../bot-definition/runtime-reload';
 import { createBotDefinitionSyncService } from '../bot-definition/service';
+import { resolveRunnableCloudDefinition } from '../bot-definition/cloud-sync';
 import { getPromptReconcileCoordinator } from '../bot-definition/prompt-sync';
 
 const CONNECTOR_OWNER_POLL_MS = 2000;
@@ -370,8 +371,10 @@ async function applyCloudBotDefinitionSelection(
     definitionService,
   });
   const previousPrompt = promptCoordinator.captureActiveSnapshot();
+  const effectiveIncoming = resolveRunnableCloudDefinition(incoming, previousDefinition);
   const modelChanged = !previousDefinition
-    || JSON.stringify(previousDefinition.model) !== JSON.stringify(incoming.model);
+    || !effectiveIncoming
+    || JSON.stringify(previousDefinition.model) !== JSON.stringify(effectiveIncoming.model);
 
   if (modelChanged && (!options.canApply() || !options.currentBot().isIdleForRuntimeReload())) {
     return 'deferred';
@@ -403,7 +406,7 @@ async function applyCloudBotDefinitionSelection(
   let prepared: Awaited<ReturnType<typeof prepareBoundBotDefinition>>;
   let appliedSelection = options.selection;
   try {
-    definitionService.acceptCanonical(incoming);
+    if (effectiveIncoming) definitionService.acceptCanonical(effectiveIncoming);
     prepared = await prepareBoundBotDefinition({
       runtimeRoot: options.runtimeRoot,
       botId: options.botId,

--- a/tests/bot-definition-activation.test.ts
+++ b/tests/bot-definition-activation.test.ts
@@ -293,6 +293,76 @@ describe('BotDefinition activation', () => {
     );
   });
 
+  test('keeps cloud management local on a fresh device while preparing a runnable default', async () => {
+    const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-local-handoff-fresh-runtime-'));
+    const simulatedCloudRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-local-handoff-fresh-cloud-'));
+    roots.push(runtimeRoot, simulatedCloudRoot);
+    const env = {} as NodeJS.ProcessEnv;
+    createCatsCoLocalConfigService({ runtimeRoot, env }).save({
+      version: 1,
+      endpoints: { httpBaseUrl: 'https://cats.example.test', serverUrl: 'wss://cats.example.test/v0/channels' },
+      account: { token: 'owner-token', uid: '7', displayName: 'Alice' },
+      currentBot: {
+        uid: '43', apiKey: 'bot-api-key', boundByUserUid: '7', bindingSource: 'test',
+      },
+    });
+
+    const requests: string[] = [];
+    const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(String(input));
+      const method = init?.method || 'GET';
+      requests.push(`${method} ${url.pathname}`);
+      if (url.pathname === '/api/bot/definition' && method === 'GET') {
+        return Response.json({
+          uid: 43,
+          configured: true,
+          revision: 3,
+          definition: {
+            schema: BOT_DEFINITION_SCHEMA,
+            botId: '43',
+            model: { kind: 'local', modelId: 'local' },
+            prompt: { selected: 'custom', customSystemPrompt: 'Keep this cloud prompt.' },
+          },
+        });
+      }
+      if (url.pathname === '/api/relay/config') {
+        return Response.json({
+          self_service_enabled: true,
+          base_url: 'https://relay.example.test',
+          endpoints: [{ protocol: 'Anthropic-compatible', base_url: 'https://relay.example.test/anthropic' }],
+        });
+      }
+      if (url.pathname === '/api/relay/key') {
+        return Response.json({ key: { state: 'active', key: 'sk-local-device-relay' } });
+      }
+      if (url.pathname === '/v1/models') {
+        return Response.json({ data: [{ id: 'MiniMax-M3', capabilities: { vision: true } }] });
+      }
+      if (url.pathname === '/api/bot/definition/ack' && method === 'POST') {
+        return Response.json({ status: 'applied' });
+      }
+      return Response.json({ error: `unexpected ${method} ${url.pathname}` }, { status: 404 });
+    }) as typeof fetch;
+
+    const prepared = await prepareBoundBotDefinition({
+      runtimeRoot,
+      simulatedCloudRoot,
+      env,
+      fetchImpl,
+      prepareSkills: false,
+    });
+
+    assert.deepStrictEqual(prepared?.definition.model, { kind: 'catalog', modelId: 'minimax-m3' });
+    assert.deepStrictEqual(prepared?.definition.prompt, {
+      selected: 'custom',
+      customSystemPrompt: 'Keep this cloud prompt.',
+    });
+    assert.equal(prepared?.initializedDefault, true);
+    assert.equal(resolveActiveBotLLMConfig({ runtimeRoot, env })?.config.model, 'MiniMax-M3');
+    assert.equal(requests.some(item => item.includes('/api/bots/definition/model')), false);
+    assert.equal(requests.includes('POST /api/bot/definition/ack'), true);
+  });
+
   test('applies and acknowledges a cloud-selected model after its local runtime is ready', async () => {
     const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-cloud-model-runtime-'));
     const simulatedCloudRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-cloud-model-canonical-'));

--- a/tests/bot-definition-cloud-sync.test.ts
+++ b/tests/bot-definition-cloud-sync.test.ts
@@ -142,6 +142,66 @@ describe('BotDefinition cloud synchronization', () => {
     });
   });
 
+  test('applies cloud prompt during a local handoff without replacing the runnable model', async () => {
+    const runtimeRoot = makeRoot();
+    const definitionService = createBotDefinitionSyncService({ runtimeRoot, env: {} });
+    definitionService.publish('43', definition('gpt-5.6-sol').model);
+    definitionService.updatePrompt('43', { selected: 'default' });
+    const sync = new BotDefinitionCloudSyncService({
+      runtimeRoot,
+      env: {},
+      definitionService,
+      fetchImpl: (async () => Response.json({
+        uid: 43,
+        configured: true,
+        revision: 7,
+        definition: {
+          schema: 'xiaoba.bot-definition.v1',
+          botId: '43',
+          model: { kind: 'local', modelId: 'local' },
+          prompt: { selected: 'custom', customSystemPrompt: 'Cloud prompt, local model.' },
+        },
+      })) as typeof fetch,
+    });
+
+    const snapshot = await sync.pull('43', auth);
+    const cached = definitionService.read('43');
+
+    assert.deepStrictEqual(snapshot?.definition?.model, { kind: 'local', modelId: 'local' });
+    assert.deepStrictEqual(cached?.model, { kind: 'catalog', modelId: 'gpt-5.6-sol' });
+    assert.deepStrictEqual(cached?.prompt, {
+      selected: 'custom',
+      customSystemPrompt: 'Cloud prompt, local model.',
+    });
+  });
+
+  test('does not persist a local handoff marker when this device has no runnable model yet', async () => {
+    const runtimeRoot = makeRoot();
+    const definitionService = createBotDefinitionSyncService({ runtimeRoot, env: {} });
+    const sync = new BotDefinitionCloudSyncService({
+      runtimeRoot,
+      env: {},
+      definitionService,
+      fetchImpl: (async () => Response.json({
+        uid: 43,
+        configured: true,
+        revision: 3,
+        definition: {
+          schema: 'xiaoba.bot-definition.v1',
+          botId: '43',
+          model: { kind: 'local', modelId: 'local' },
+          prompt: { selected: 'default' },
+        },
+      })) as typeof fetch,
+    });
+
+    const snapshot = await sync.pull('43', auth);
+
+    assert.deepStrictEqual(snapshot?.definition?.model, { kind: 'local', modelId: 'local' });
+    assert.equal(definitionService.read('43'), undefined);
+    assert.equal(sync.readState('43').revision, 3);
+  });
+
   test('keeps a failed local update pending and retries it later', async () => {
     const runtimeRoot = makeRoot();
     const definitionService = createBotDefinitionSyncService({ runtimeRoot, env: {} });

--- a/tests/cloud-bot-model-client.test.ts
+++ b/tests/cloud-bot-model-client.test.ts
@@ -173,6 +173,36 @@ describe('cloud bot model client local handoff', () => {
     assert.deepStrictEqual(selection, { kind: 'local', modelId: 'local', revision: 7 });
   });
 
+  test('reads a canonical local handoff without treating it as an invalid catalog model', async () => {
+    const selection = await pullCloudBotModelSelection({
+      botId: '43',
+      auth,
+      fetchImpl: (async () => Response.json({
+        uid: 43,
+        configured: true,
+        revision: 8,
+        definition: {
+          schema: 'xiaoba.bot-definition.v1',
+          botId: '43',
+          model: { kind: 'local', modelId: 'local' },
+          prompt: { selected: 'default' },
+        },
+      })) as typeof fetch,
+    });
+
+    assert.deepStrictEqual(selection, {
+      kind: 'local',
+      modelId: 'local',
+      revision: 8,
+      definition: {
+        schema: 'xiaoba.bot-definition.v1',
+        botId: '43',
+        model: { kind: 'local', modelId: 'local' },
+        prompt: { selected: 'default' },
+      },
+    });
+  });
+
   test('keeps an untouched revision zero configuration as local-only state', async () => {
     const selection = await pullCloudBotModelSelection({
       botId: '43',


### PR DESCRIPTION
## 问题

CatsCompany 的历史本地模型 handoff 可能通过完整 BotDefinition 接口返回 `model.kind = local`。CatsCo 此前只识别 catalog/custom，会把它误判为无效 catalog 定义并每分钟报警；直接把 `local` 写入本地 Definition 又会覆盖可运行模型。

配套服务端 PR：buildsense-ai/cats-company#171

## 修改

- 将 `local` 定义为云端控制信号，而不是可运行模型。
- 解析完整 BotDefinition 中的 local handoff，并保留设备当前 catalog/custom 模型。
- 云端 prompt/skills 继续按原链路同步，不把 local 占位写进本地运行缓存。
- 运行中只更新 prompt/skills 时不重启 connector。
- 全新设备没有本地 Definition 时准备默认本地模型，但不反向覆盖云端 local 状态。
- skills 同步和模型轮询补齐 local 类型边界及失败保护。

## 用户影响

worker 不再持续输出“云端模型目录无效”；已有模型、凭据、上下文窗口不会被 local handoff 覆盖，catalog/custom 和旧 model-config 协议保持原行为。

## 验证

- `npm run build`
- BotDefinition activation / cloud sync / cloud client / skills / runtime reload / cloud coverage：54 项通过
- 覆盖已有 catalog、自定义模型、新设备、prompt 合并、skills、ACK、运行中轮询和错误回滚。