### PR TITLE
解耦 provider identity 与 wire protocol

### DIFF
--- a/src/providers/provider-registry.ts
+++ b/src/providers/provider-registry.ts
@@ -1,0 +1,132 @@
+import type {
+  BuiltInProviderId,
+  ChatConfig,
+  ProviderApiType,
+  ProviderId,
+  ProviderRuntimeConfig,
+} from '../types';
+import { AnthropicProvider } from './anthropic-provider';
+import { OpenAIProvider } from './openai-provider';
+import type { AIProvider } from './provider';
+
+export interface ProviderFactoryContext {
+  config: ProviderRuntimeConfig;
+  providerId: ProviderId;
+  apiType: ProviderApiType;
+}
+
+export interface ProviderAdapterRegistration {
+  providerId: ProviderId;
+  apiTypes: readonly ProviderApiType[];
+  defaultApiType: ProviderApiType | ((config: ProviderRuntimeConfig) => ProviderApiType);
+  create(context: ProviderFactoryContext): AIProvider;
+}
+
+export interface ProviderRegistryResult {
+  provider: AIProvider;
+  providerId: ProviderId;
+  apiType: ProviderApiType;
+}
+
+/**
+ * Separates provider identity from the wire protocol used for a request.
+ * Registrations are instance-local so tests and embedders can inject adapters
+ * without changing AIService or process-wide state.
+ */
+export class ProviderRegistry {
+  private readonly registrations = new Map<string, ProviderAdapterRegistration>();
+
+  register(registration: ProviderAdapterRegistration): this {
+    const providerId = normalizeProviderId(registration.providerId);
+    if (this.registrations.has(providerId)) {
+      throw new Error(`Provider "${providerId}" is already registered`);
+    }
+    if (registration.apiTypes.length === 0) {
+      throw new Error(`Provider "${providerId}" must declare at least one API protocol`);
+    }
+
+    const apiTypes = [...new Set(registration.apiTypes)];
+    for (const apiType of apiTypes) assertKnownApiType(apiType, providerId);
+    if (typeof registration.defaultApiType === 'string' && !apiTypes.includes(registration.defaultApiType)) {
+      throw new Error(
+        `Provider "${providerId}" default API protocol "${registration.defaultApiType}" is not supported`,
+      );
+    }
+
+    this.registrations.set(providerId, { ...registration, providerId, apiTypes });
+    return this;
+  }
+
+  create(config: ProviderRuntimeConfig): ProviderRegistryResult {
+    const providerId = this.resolveProviderId(config);
+    const registration = this.registrations.get(providerId);
+    if (!registration) {
+      const available = [...this.registrations.keys()].sort().join(', ') || '(none)';
+      throw new Error(`Unknown provider "${providerId}". Registered providers: ${available}`);
+    }
+
+    const apiType = config.providerApiType
+      ?? (typeof registration.defaultApiType === 'function'
+        ? registration.defaultApiType(config)
+        : registration.defaultApiType);
+    assertKnownApiType(apiType, providerId);
+    if (!registration.apiTypes.includes(apiType)) {
+      throw new Error(`Provider "${providerId}" does not support API protocol "${apiType}"`);
+    }
+
+    const resolvedConfig: ProviderRuntimeConfig = { ...config, provider: providerId };
+    return {
+      provider: registration.create({ config: resolvedConfig, providerId, apiType }),
+      providerId,
+      apiType,
+    };
+  }
+
+  private resolveProviderId(config: ProviderRuntimeConfig): string {
+    if (config.provider !== undefined) return normalizeProviderId(config.provider);
+    const apiUrl = (config.apiUrl || '').toLowerCase();
+    const model = (config.model || '').toLowerCase();
+    return apiUrl.includes('anthropic') || apiUrl.includes('claude') || model.includes('claude')
+      ? 'anthropic'
+      : 'openai';
+  }
+}
+
+export function createDefaultProviderRegistry(): ProviderRegistry {
+  return new ProviderRegistry()
+    .register({
+      providerId: 'openai',
+      apiTypes: ['openai-chat-completions', 'openai-responses'],
+      defaultApiType: config => config.openaiApiMode === 'responses'
+        ? 'openai-responses'
+        : 'openai-chat-completions',
+      create: ({ config, apiType }) => new OpenAIProvider({
+        ...toBuiltInChatConfig(config, 'openai'),
+        openaiApiMode: apiType === 'openai-responses' ? 'responses' : 'chat_completions',
+      }),
+    })
+    .register({
+      providerId: 'anthropic',
+      apiTypes: ['anthropic-messages'],
+      defaultApiType: 'anthropic-messages',
+      create: ({ config }) => new AnthropicProvider(toBuiltInChatConfig(config, 'anthropic')),
+    });
+}
+
+function toBuiltInChatConfig(config: ProviderRuntimeConfig, provider: BuiltInProviderId): ChatConfig {
+  const { provider: _provider, providerApiType: _providerApiType, ...chatConfig } = config;
+  return { ...chatConfig, provider };
+}
+
+function normalizeProviderId(providerId: ProviderId): string {
+  if (typeof providerId !== 'string' || providerId.trim() === '') {
+    throw new Error('Invalid provider configuration: provider must be a non-empty string');
+  }
+  return providerId.trim();
+}
+
+function assertKnownApiType(apiType: ProviderApiType, providerId: string): void {
+  if (!['anthropic-messages', 'openai-chat-completions', 'openai-responses'].includes(apiType)) {
+    throw new Error(`Provider "${providerId}" selected unknown API protocol "${String(apiType)}"`);
+  }
+}

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -1,4 +1,4 @@
-import { Message, ChatResponse } from '../types';
+import { Message, ChatResponse, type ProviderApiType, type ProviderId } from '../types';
 import { ToolDefinition } from '../types/tool';
 import type { ProviderRequestPreflightSummary } from './request-preflight';
 
@@ -26,7 +26,7 @@ export interface StreamRetryInfo {
   message?: string;
 }
 
-export type ModelAttemptApiType = 'anthropic-messages' | 'openai-chat-completions' | 'openai-responses';
+export type ModelAttemptApiType = ProviderApiType;
 export type ModelAttemptOutcome = 'started' | 'succeeded' | 'retrying' | 'failed' | 'cancelled';
 export type ModelAttemptStopReason =
   | 'non_retryable'
@@ -67,7 +67,7 @@ export interface ModelAttemptEvent {
   attemptNumber: number;
   timestamp: string;
   outcome: ModelAttemptOutcome;
-  provider: 'openai' | 'anthropic';
+  provider: ProviderId;
   model: string;
   apiType: ModelAttemptApiType;
   stream: boolean;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,6 +3,11 @@ export type ContentBlock =
   | { type: 'image'; source: { type: 'base64'; media_type: 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp'; data: string } };
 
 export type ProviderContentBlock = Record<string, unknown> & { type: string };
+/** Provider identities supported by persisted application configuration. */
+export type BuiltInProviderId = 'openai' | 'anthropic';
+/** Runtime provider identity. Registries may add identities without changing ChatConfig. */
+export type ProviderId = BuiltInProviderId | (string & {});
+/** Wire protocol identity, intentionally separate from the runtime provider identity. */
 export type ProviderApiType = 'anthropic-messages' | 'openai-chat-completions' | 'openai-responses';
 
 /** Opaque scope that prevents provider-only replay state crossing model/API boundaries. */
@@ -91,7 +96,7 @@ export interface ChatConfig {
     timeoutMs?: number;
     maxTokens?: number;
   };
-  provider?: 'openai' | 'anthropic';
+  provider?: BuiltInProviderId;
   feishu?: {
     appId?: string;
     appSecret?: string;
@@ -119,6 +124,12 @@ export interface ChatConfig {
     intervalMinutes?: number;
   };
 }
+
+/** Injectable runtime selection config, separate from persisted ChatConfig identity. */
+export type ProviderRuntimeConfig = Omit<ChatConfig, 'provider'> & {
+  provider?: ProviderId;
+  providerApiType?: ProviderApiType;
+};
 
 export interface TokenUsage {
   promptTokens: number;

--- a/src/utils/ai-service.ts
+++ b/src/utils/ai-service.ts
@@ -1,4 +1,12 @@
-import { Message, ChatConfig, ChatResponse } from '../types';
+import {
+  Message,
+  ChatConfig,
+  ChatResponse,
+  type BuiltInProviderId,
+  type ProviderApiType,
+  type ProviderId,
+  type ProviderRuntimeConfig,
+} from '../types';
 import { ConfigManager } from './config';
 import { ToolDefinition } from '../types/tool';
 import {
@@ -10,8 +18,7 @@ import {
   StreamCallbacks,
   StreamRetryInfo,
 } from '../providers/provider';
-import { AnthropicProvider } from '../providers/anthropic-provider';
-import { OpenAIProvider } from '../providers/openai-provider';
+import { createDefaultProviderRegistry, type ProviderRegistry } from '../providers/provider-registry';
 import {
   prepareProviderRequestMessages,
   type ProviderRequestPreflightSummary,
@@ -56,7 +63,9 @@ const TRANSIENT_HTTP_MAX_RETRIES = 2;
 const GATEWAY_TIMEOUT_MAX_RETRIES = 1;
 let modelAttemptCallSequence = 0;
 
-type ProviderKind = 'openai' | 'anthropic';
+function isBuiltInProviderId(providerId: ProviderId | undefined): providerId is BuiltInProviderId {
+  return providerId === 'openai' || providerId === 'anthropic';
+}
 
 interface RetryPolicy {
   maxRetries: number;
@@ -76,69 +85,54 @@ interface ModelAttemptRun {
   preflight?: ProviderRequestPreflightSummary;
 }
 
+export interface AIServiceOptions {
+  providerRegistry?: ProviderRegistry;
+}
+
 export class AIService {
   private config: ChatConfig;
   private provider: AIProvider;
+  private providerId: ProviderId;
+  private providerApiType: ProviderApiType;
 
-  constructor(overrides?: Partial<ChatConfig>) {
-    this.config = this.withResolvedContextWindow(this.withResolvedProvider({
+  constructor(overrides?: Partial<ProviderRuntimeConfig>, options: AIServiceOptions = {}) {
+    const runtimeConfig = this.withResolvedContextWindow({
       ...ConfigManager.getConfig(),
-      ...(overrides || {})
-    }));
-    this.provider = this.createProvider(this.config);
+      ...(overrides || {}),
+    });
+    const resolved = (options.providerRegistry ?? createDefaultProviderRegistry()).create(runtimeConfig);
+    const {
+      provider: _runtimeProvider,
+      providerApiType: _providerApiType,
+      ...chatConfig
+    } = runtimeConfig;
+    this.config = {
+      ...chatConfig,
+      ...(isBuiltInProviderId(resolved.providerId) ? { provider: resolved.providerId } : {}),
+    };
+    this.provider = resolved.provider;
+    this.providerId = resolved.providerId;
+    this.providerApiType = resolved.apiType;
   }
 
   getConfig(): ChatConfig {
     return { ...this.config };
   }
 
-  /**
-   * 根据配置创建对应的 Provider
-   */
-  private createProvider(config: ChatConfig): AIProvider {
-    if (config.provider === 'anthropic') {
-      return new AnthropicProvider(config);
-    } else {
-      return new OpenAIProvider(config);
-    }
-  }
-
   isToolCallingSupported(): boolean {
     return isPrimaryModelToolCallingCapable(this.config);
   }
 
-  /**
-   * 自动补全 provider
-   */
-  private withResolvedProvider(config: ChatConfig): ChatConfig {
-    return {
-      ...config,
-      provider: this.resolveProvider(config),
-    };
-  }
-
-  private withResolvedContextWindow(config: ChatConfig): ChatConfig {
+  private withResolvedContextWindow(config: ProviderRuntimeConfig): ProviderRuntimeConfig {
     const contextWindowTokens = config.contextWindowTokens
-      ?? resolveModelContextWindow(config).contextWindowTokens;
+      ?? resolveModelContextWindow({
+        ...config,
+        provider: isBuiltInProviderId(config.provider) ? config.provider : undefined,
+      }).contextWindowTokens;
     return {
       ...config,
       contextWindowTokens,
     };
-  }
-
-  private resolveProvider(config: Partial<ChatConfig>): ProviderKind {
-    if (config.provider === 'openai' || config.provider === 'anthropic') {
-      return config.provider;
-    }
-
-    const apiUrl = (config.apiUrl || '').toLowerCase();
-    const model = (config.model || '').toLowerCase();
-
-    if (apiUrl.includes('anthropic') || apiUrl.includes('claude') || model.includes('claude')) {
-      return 'anthropic';
-    }
-
-    return 'openai';
   }
 
   /**
@@ -277,7 +271,7 @@ export class AIService {
       return this.createAbortError();
     }
 
-    const provider = this.config.provider;
+    const provider = this.providerId;
     const model = this.config.model;
 
     Logger.error(
@@ -569,7 +563,7 @@ export class AIService {
 
         Logger.warning(
           `API 调用失败 (${status})，${delay.toFixed(0)}ms 后重试 (${retryAttempt}/${policy.maxRetries})... `
-          + `[${this.config.provider}/${this.config.model || 'default'}]`
+          + `[${this.providerId}/${this.config.model || 'default'}]`
         );
 
         await this.sleepWithAbort(delay, signal);
@@ -627,13 +621,9 @@ export class AIService {
       attemptNumber,
       timestamp: new Date().toISOString(),
       outcome: fields.outcome,
-      provider: this.config.provider as ProviderKind,
+      provider: this.providerId,
       model: this.config.model || 'unknown',
-      apiType: this.config.provider === 'anthropic'
-        ? 'anthropic-messages'
-        : this.config.openaiApiMode === 'responses'
-          ? 'openai-responses'
-          : 'openai-chat-completions',
+      apiType: this.providerApiType,
       stream: run.stream,
       ...(run.context ? { context: run.context } : {}),
       request: {
@@ -775,8 +765,8 @@ export class AIService {
   }
 
   private isResponsesMode(): boolean {
-    return this.config.provider === 'openai'
-      && this.config.openaiApiMode === 'responses';
+    return this.providerId === 'openai'
+      && (this.config.openaiApiMode === 'responses' || this.providerApiType === 'openai-responses');
   }
 
   private async notifyRetry(

--- a/tests/provider-registry.test.ts
+++ b/tests/provider-registry.test.ts
@@ -1,0 +1,89 @@
+import { test } from 'node:test';
+import * as assert from 'node:assert/strict';
+import type { ChatConfig, ChatResponse, ProviderRuntimeConfig } from '../src/types';
+import { AnthropicProvider } from '../src/providers/anthropic-provider';
+import { OpenAIProvider } from '../src/providers/openai-provider';
+import type { AIProvider } from '../src/providers/provider';
+import { ProviderRegistry, createDefaultProviderRegistry } from '../src/providers/provider-registry';
+import { AIService } from '../src/utils/ai-service';
+
+const baseConfig: ChatConfig = {
+  apiUrl: 'https://provider.example.test/v1',
+  apiKey: 'test-key',
+  model: 'test-model',
+};
+
+test('default registry maps provider identity to each built-in wire protocol', () => {
+  const registry = createDefaultProviderRegistry();
+
+  const chatCompletions = registry.create({ ...baseConfig, provider: 'openai' });
+  assert.equal(chatCompletions.providerId, 'openai');
+  assert.equal(chatCompletions.apiType, 'openai-chat-completions');
+  assert.ok(chatCompletions.provider instanceof OpenAIProvider);
+
+  const responses = registry.create({
+    ...baseConfig,
+    provider: 'openai',
+    openaiApiMode: 'responses',
+  });
+  assert.equal(responses.providerId, 'openai');
+  assert.equal(responses.apiType, 'openai-responses');
+  assert.ok(responses.provider instanceof OpenAIProvider);
+
+  const anthropic = registry.create({ ...baseConfig, provider: 'anthropic' });
+  assert.equal(anthropic.providerId, 'anthropic');
+  assert.equal(anthropic.apiType, 'anthropic-messages');
+  assert.ok(anthropic.provider instanceof AnthropicProvider);
+});
+
+test('default registry preserves provider inference for omitted identity', () => {
+  const registry = createDefaultProviderRegistry();
+  assert.equal(registry.create({ ...baseConfig, apiUrl: 'https://api.anthropic.com' }).providerId, 'anthropic');
+  assert.equal(registry.create({ ...baseConfig, model: 'claude-test' }).providerId, 'anthropic');
+  assert.equal(registry.create(baseConfig).providerId, 'openai');
+});
+
+test('AIService selects an injected custom provider without changing AIService', async () => {
+  const response: ChatResponse = { content: 'custom provider response' };
+  const customProvider: AIProvider = {
+    chat: async () => response,
+    chatStream: async () => response,
+  };
+  const registry = new ProviderRegistry().register({
+    providerId: 'test-custom',
+    apiTypes: ['openai-chat-completions'],
+    defaultApiType: 'openai-chat-completions',
+    create: () => customProvider,
+  });
+  const service = new AIService({ ...baseConfig, provider: 'test-custom' }, { providerRegistry: registry });
+  const events: any[] = [];
+
+  const result = await service.chat([], undefined, {
+    modelAttemptSink: { observe: event => events.push(event) },
+  });
+
+  assert.equal(result, response);
+  assert.deepEqual(events.map(event => event.outcome), ['started', 'succeeded']);
+  assert.ok(events.every(event => event.provider === 'test-custom'));
+  assert.ok(events.every(event => event.apiType === 'openai-chat-completions'));
+});
+
+test('registry fails clearly for unknown providers and invalid protocol selections', () => {
+  const registry = createDefaultProviderRegistry();
+  assert.throws(
+    () => registry.create({ ...baseConfig, provider: 'missing-provider' }),
+    /Unknown provider "missing-provider"\. Registered providers: anthropic, openai/,
+  );
+  assert.throws(
+    () => registry.create({ ...baseConfig, provider: 'anthropic', providerApiType: 'openai-responses' }),
+    /Provider "anthropic" does not support API protocol "openai-responses"/,
+  );
+  assert.throws(
+    () => registry.create({
+      ...baseConfig,
+      provider: 'openai',
+      providerApiType: 'unknown-protocol' as ProviderRuntimeConfig['providerApiType'],
+    }),
+    /Provider "openai" selected unknown API protocol "unknown-protocol"/,
+  );
+});


### PR DESCRIPTION
## Summary
- separate provider identity from wire protocol
- add injectable provider registry/factory
- preserve built-in OpenAI Chat Completions, OpenAI Responses, and Anthropic behavior

## Validation
- TypeScript check passed
- targeted tests: 68 passed, 0 failed
- npm run build passed

Commit: 6e340026de9af7693a886bb06199be9fa703f9dc