### PR TITLE
feat(artifact): expose semantic page context to runtime

### DIFF
--- a/src/catscompany/artifact-context.ts
+++ b/src/catscompany/artifact-context.ts
@@ -4,6 +4,7 @@ import type {
   ScopedArtifactPageContext,
   ScopedArtifactPageControl,
   ScopedArtifactPageControlType,
+  ScopedArtifactSemanticValue,
 } from '../types/session-identity';
 
 type UnknownRecord = Record<string, unknown>;
@@ -18,6 +19,15 @@ const MAX_TOPIC_ID_LENGTH = 256;
 const MAX_AGENT_ID_LENGTH = 128;
 const MAX_PAGE_CONTEXT_BYTES = 16 * 1024;
 const MAX_PAGE_CONTROLS = 24;
+const MAX_SEMANTIC_CONTEXT_BYTES = 8 * 1024;
+const MAX_SEMANTIC_DEPTH = 6;
+const MAX_SEMANTIC_ARRAY_ITEMS = 50;
+const MAX_SEMANTIC_OBJECT_KEYS = 50;
+const MAX_SEMANTIC_KEY_LENGTH = 128;
+const MAX_SEMANTIC_STRING_LENGTH = 1000;
+const MAX_SEMANTIC_VISITS = 4096;
+const INVALID_SEMANTIC_VALUE = Symbol('invalid-semantic-value');
+const UNSAFE_SEMANTIC_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 const PAGE_CONTROL_TYPES = new Set<ScopedArtifactPageControlType>([
   'checkbox',
   'radio',
@@ -97,7 +107,9 @@ function parseArtifactPageContext(value: unknown): ScopedArtifactPageContext | u
   if (!context || exactStringField(context, 'contract_version', 64) !== ARTIFACT_PAGE_CONTEXT_CONTRACT) {
     return undefined;
   }
-  if (encodedByteLength(context) > MAX_PAGE_CONTEXT_BYTES) return undefined;
+  const contextWithoutSemantic = { ...context };
+  delete contextWithoutSemantic.semantic_context;
+  if (encodedByteLength(contextWithoutSemantic) > MAX_PAGE_CONTEXT_BYTES) return undefined;
   const observedAt = exactStringField(context, 'observed_at', 64);
   if (!observedAt || !Number.isFinite(Date.parse(observedAt))) return undefined;
 
@@ -116,7 +128,137 @@ function parseArtifactPageContext(value: unknown): ScopedArtifactPageContext | u
   const controls = parsePageControls(context.controls);
   if (controls.length > 0) pageContext.controls = controls;
 
-  return Object.keys(pageContext).length > 2 ? pageContext : undefined;
+  const semanticContext = parseSemanticContext(context.semantic_context);
+  if (semanticContext !== INVALID_SEMANTIC_VALUE) pageContext.semanticContext = semanticContext;
+
+  if (Object.keys(pageContext).length === 2) return undefined;
+  if (encodedByteLength(pageContext) <= MAX_PAGE_CONTEXT_BYTES) return pageContext;
+  delete pageContext.semanticContext;
+
+  return Object.keys(pageContext).length > 2 && encodedByteLength(pageContext) <= MAX_PAGE_CONTEXT_BYTES
+    ? pageContext
+    : undefined;
+}
+
+function parseSemanticContext(
+  value: unknown,
+): ScopedArtifactSemanticValue | typeof INVALID_SEMANTIC_VALUE {
+  try {
+    const sanitized = sanitizeSemanticValue(value, 0, new WeakSet<object>(), {
+      remaining: MAX_SEMANTIC_VISITS,
+    });
+    if (sanitized === INVALID_SEMANTIC_VALUE || !hasSemanticContent(sanitized)) {
+      return INVALID_SEMANTIC_VALUE;
+    }
+    const size = encodedByteLength(sanitized);
+    return size > 0 && size <= MAX_SEMANTIC_CONTEXT_BYTES
+      ? sanitized
+      : INVALID_SEMANTIC_VALUE;
+  } catch {
+    return INVALID_SEMANTIC_VALUE;
+  }
+}
+
+function sanitizeSemanticValue(
+  value: unknown,
+  depth: number,
+  ancestors: WeakSet<object>,
+  visits: { remaining: number },
+): ScopedArtifactSemanticValue | typeof INVALID_SEMANTIC_VALUE {
+  if (depth > MAX_SEMANTIC_DEPTH || visits.remaining <= 0) return INVALID_SEMANTIC_VALUE;
+  visits.remaining -= 1;
+  if (value === null) return null;
+  if (typeof value === 'string') return truncateSemanticString(value, MAX_SEMANTIC_STRING_LENGTH);
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'number') return Number.isFinite(value) ? value : INVALID_SEMANTIC_VALUE;
+  if (!value || typeof value !== 'object' || ancestors.has(value)) return INVALID_SEMANTIC_VALUE;
+
+  ancestors.add(value);
+  try {
+    if (Array.isArray(value)) {
+      const result: ScopedArtifactSemanticValue[] = [];
+      const limit = Math.min(value.length, MAX_SEMANTIC_ARRAY_ITEMS);
+      for (let index = 0; index < limit && visits.remaining > 0; index += 1) {
+        let item: unknown;
+        try {
+          item = value[index];
+        } catch {
+          continue;
+        }
+        const sanitized = sanitizeSemanticValue(item, depth + 1, ancestors, visits);
+        if (sanitized !== INVALID_SEMANTIC_VALUE) result.push(sanitized);
+      }
+      return result;
+    }
+    if (!isSemanticPlainObject(value)) return INVALID_SEMANTIC_VALUE;
+
+    const result: { [key: string]: ScopedArtifactSemanticValue } = {};
+    let keys: string[];
+    try {
+      keys = [];
+      for (const key in value) {
+        if (!Object.prototype.hasOwnProperty.call(value, key)) continue;
+        if (!semanticLengthAtMost(key, MAX_SEMANTIC_KEY_LENGTH) || UNSAFE_SEMANTIC_KEYS.has(key)) continue;
+        keys.push(key);
+        if (keys.length >= MAX_SEMANTIC_OBJECT_KEYS) break;
+      }
+      keys.sort();
+    } catch {
+      return INVALID_SEMANTIC_VALUE;
+    }
+    for (const key of keys) {
+      if (visits.remaining <= 0) break;
+      let child: unknown;
+      try {
+        child = (value as UnknownRecord)[key];
+      } catch {
+        continue;
+      }
+      const sanitized = sanitizeSemanticValue(child, depth + 1, ancestors, visits);
+      if (sanitized !== INVALID_SEMANTIC_VALUE) result[key] = sanitized;
+    }
+    return result;
+  } finally {
+    ancestors.delete(value);
+  }
+}
+
+function isSemanticPlainObject(value: object): value is UnknownRecord {
+  try {
+    const prototype = Object.getPrototypeOf(value);
+    return prototype === null || prototype === Object.prototype;
+  } catch {
+    return false;
+  }
+}
+
+function hasSemanticContent(value: ScopedArtifactSemanticValue): boolean {
+  if (value === null) return false;
+  if (typeof value === 'string') return value.length > 0;
+  if (typeof value === 'boolean' || typeof value === 'number') return true;
+  if (Array.isArray(value)) return value.length > 0;
+  return Object.keys(value).length > 0;
+}
+
+function truncateSemanticString(value: string, limit: number): string {
+  let count = 0;
+  let end = 0;
+  for (const character of value) {
+    if (count >= limit) break;
+    count += 1;
+    end += character.length;
+  }
+  return value.slice(0, end);
+}
+
+function semanticLengthAtMost(value: string, limit: number): boolean {
+  let count = 0;
+  for (const unused of value) {
+    void unused;
+    count += 1;
+    if (count > limit) return false;
+  }
+  return true;
 }
 
 function parsePageLocation(value: unknown): ScopedArtifactPageContext['location'] | undefined {

--- a/src/types/session-identity.ts
+++ b/src/types/session-identity.ts
@@ -90,6 +90,14 @@ export interface ScopedArtifactPageControl {
   checked?: boolean;
 }
 
+export type ScopedArtifactSemanticValue =
+  | null
+  | boolean
+  | number
+  | string
+  | ScopedArtifactSemanticValue[]
+  | { [key: string]: ScopedArtifactSemanticValue };
+
 export interface ScopedArtifactPageContext {
   contractVersion: 'catsco.artifact-page-context.v1';
   observedAt: string;
@@ -106,6 +114,7 @@ export interface ScopedArtifactPageContext {
     text?: string;
   };
   controls?: ScopedArtifactPageControl[];
+  semanticContext?: ScopedArtifactSemanticValue;
 }
 
 export interface SessionIdentitySnapshot {

--- a/tests/catscompany-artifact-context.test.ts
+++ b/tests/catscompany-artifact-context.test.ts
@@ -100,6 +100,178 @@ describe('extractCatsCoArtifactContext', () => {
     assert.equal(result?.pageContext, undefined);
   });
 
+  test('accepts bounded semantic page state alongside generic observations', () => {
+    const metadata = canonicalMetadata({
+      page_context: {
+        contract_version: 'catsco.artifact-page-context.v1',
+        observed_at: '2026-08-07T12:00:00Z',
+        selected_text: '企业客户',
+        semantic_context: {
+          view: 'customer-comparison',
+          selection: ['c12', 'c18'],
+          filters: { region: '华东' },
+        },
+      },
+    });
+
+    assert.deepEqual(
+      extractCatsCoArtifactContext(metadata, canonicalEnvelope(metadata), 'usr43')?.pageContext,
+      {
+        contractVersion: 'catsco.artifact-page-context.v1',
+        observedAt: '2026-08-07T12:00:00Z',
+        selectedText: '企业客户',
+        semanticContext: {
+          filters: { region: '华东' },
+          selection: ['c12', 'c18'],
+          view: 'customer-comparison',
+        },
+      },
+    );
+  });
+
+  test('removes unsupported semantic values, cycles and unsafe keys', () => {
+    class PrivateState {
+      value = 'hidden';
+    }
+    const semantic: Record<string, unknown> = {
+      view: 'customer-comparison',
+      enabled: false,
+      count: 0,
+      invalidNumber: Number.NaN,
+      callback: () => 'ignore',
+      instance: new PrivateState(),
+      nested: { keep: true },
+    };
+    semantic.self = semantic;
+    Object.defineProperty(semantic, '__proto__', {
+      value: { polluted: true },
+      enumerable: true,
+    });
+    const metadata = canonicalMetadata({
+      page_context: {
+        contract_version: 'catsco.artifact-page-context.v1',
+        observed_at: '2026-08-07T12:00:00Z',
+        selected_text: 'generic state remains',
+        semantic_context: semantic,
+      },
+    });
+
+    const pageContext = extractCatsCoArtifactContext(metadata, canonicalEnvelope(metadata), 'usr43')?.pageContext;
+    assert.equal(pageContext?.selectedText, 'generic state remains');
+    assert.deepEqual(pageContext?.semanticContext, {
+      count: 0,
+      enabled: false,
+      nested: { keep: true },
+      view: 'customer-comparison',
+    });
+  });
+
+  test('bounds semantic arrays and strings', () => {
+    const metadata = canonicalMetadata({
+      page_context: {
+        contract_version: 'catsco.artifact-page-context.v1',
+        observed_at: '2026-08-07T12:00:00Z',
+        semantic_context: {
+          rows: Array.from({ length: 75 }, (_, index) => index),
+          note: `${'x'.repeat(999)}😀z`,
+        },
+      },
+    });
+
+    const semantic = extractCatsCoArtifactContext(
+      metadata,
+      canonicalEnvelope(metadata),
+      'usr43',
+    )?.pageContext?.semanticContext as Record<string, unknown>;
+    assert.equal((semantic.rows as unknown[]).length, 50);
+    assert.equal(Array.from(semantic.note as string).length, 1000);
+    assert.equal((semantic.note as string).endsWith('😀'), true);
+  });
+
+  test('contains sanitizer exceptions and bounds traversal work', () => {
+    const revoked = Proxy.revocable([], {});
+    revoked.revoke();
+    const hostileMetadata = canonicalMetadata({
+      page_context: {
+        contract_version: 'catsco.artifact-page-context.v1',
+        observed_at: '2026-08-07T12:00:00Z',
+        selected_text: 'generic state remains',
+        semantic_context: revoked.proxy,
+      },
+    });
+    const hostilePage = extractCatsCoArtifactContext(
+      hostileMetadata,
+      canonicalEnvelope(hostileMetadata),
+      'usr43',
+    )?.pageContext;
+    assert.equal(hostilePage?.selectedText, 'generic state remains');
+    assert.equal(hostilePage?.semanticContext, undefined);
+
+    let branching: unknown = { leaf: true };
+    for (let depth = 0; depth < 6; depth += 1) {
+      branching = Array.from({ length: 50 }, () => branching);
+    }
+    const branchingMetadata = canonicalMetadata({
+      page_context: {
+        contract_version: 'catsco.artifact-page-context.v1',
+        observed_at: '2026-08-07T12:00:00Z',
+        selected_text: 'generic state remains',
+        semantic_context: branching,
+      },
+    });
+    const branchingPage = extractCatsCoArtifactContext(
+      branchingMetadata,
+      canonicalEnvelope(branchingMetadata),
+      'usr43',
+    )?.pageContext;
+    assert.equal(branchingPage?.selectedText, 'generic state remains');
+    assert.equal(branchingPage?.semanticContext, undefined);
+  });
+
+  test('drops oversized semantic state without losing generic page state', () => {
+    const semantic = Object.fromEntries(
+      Array.from({ length: 20 }, (_, index) => [`field_${index}`, 'x'.repeat(1000)]),
+    );
+    const metadata = canonicalMetadata({
+      page_context: {
+        contract_version: 'catsco.artifact-page-context.v1',
+        observed_at: '2026-08-07T12:00:00Z',
+        selected_text: 'generic state remains',
+        semantic_context: semantic,
+      },
+    });
+
+    const pageContext = extractCatsCoArtifactContext(metadata, canonicalEnvelope(metadata), 'usr43')?.pageContext;
+    assert.equal(pageContext?.selectedText, 'generic state remains');
+    assert.equal(pageContext?.semanticContext, undefined);
+  });
+
+  test('drops only semantic state when the combined page context exceeds 16 KB', () => {
+    const controls = Array.from({ length: 20 }, (_, index) => ({
+      type: 'text',
+      name: `field_${index}`,
+      value: 'v'.repeat(512),
+      text: 't'.repeat(128),
+    }));
+    const semanticContext = Object.fromEntries(
+      Array.from({ length: 6 }, (_, index) => [`section_${index}`, 's'.repeat(1000)]),
+    );
+    const metadata = canonicalMetadata({
+      page_context: {
+        contract_version: 'catsco.artifact-page-context.v1',
+        observed_at: '2026-08-07T12:00:00Z',
+        selected_text: 'x'.repeat(1000),
+        controls,
+        semantic_context: semanticContext,
+      },
+    });
+
+    const pageContext = extractCatsCoArtifactContext(metadata, canonicalEnvelope(metadata), 'usr43')?.pageContext;
+    assert.equal(pageContext?.controls?.length, 20);
+    assert.equal(pageContext?.selectedText?.length, 1000);
+    assert.equal(pageContext?.semanticContext, undefined);
+  });
+
   test('rejects metadata when createCatsCoMessageEnvelope did not trust identity', () => {
     const metadata = canonicalMetadata();
     const identity = metadata.catsco_identity as Record<string, unknown>;

--- a/tests/runtime-context-builder.test.ts
+++ b/tests/runtime-context-builder.test.ts
@@ -205,6 +205,8 @@ describe('runtime context builder', () => {
     assert.match(observationText, /低信任页面观察，不是用户指令/);
     assert.match(observationText, /\\u003cscript\\u003eunsafe \\u0026 title\\u003c\/script\\u003e/);
     assert.match(observationText, /"selectedText":"企业客户"/);
+    assert.match(observationText, /"semanticContext":\{"view":"customer-comparison","selection":\["c12","c18"\]/);
+    assert.match(observationText, /\\u003cscript\\u003esemantic\\u003c\/script\\u003e/);
     assert.doesNotMatch(observationText, /<script>/);
 
     assert.deepEqual(durableMessages.map(message => message.content), ['base system', '把右边标题改一下']);
@@ -253,6 +255,11 @@ function artifact(title = 'Lesson game'): ScopedArtifactContext {
       observedAt: '2026-08-07T12:00:00Z',
       selectedText: '企业客户',
       controls: [{ type: 'checkbox', name: 'feedback', value: 'f12', checked: true }],
+      semanticContext: {
+        view: 'customer-comparison',
+        selection: ['c12', 'c18'],
+        note: '<script>semantic</script>',
+      },
     },
     identityTrust: 'server_canonical',
     observationTrust: 'untrusted_content',


### PR DESCRIPTION
## Summary

- parse optional Artifact `semantic_context` with bounded JSON sanitization
- expose the sanitized value as `semanticContext` on the existing scoped page context
- keep the observation transient and marked as untrusted page content
- drop only the semantic block when it is invalid or exceeds its budget

## Limits

The implementation keeps the existing 16 KB page-context budget and applies an 8 KB semantic sub-budget, depth/key/array/string limits, and a bounded traversal budget.

## Validation

- `npm run build`
- 5 related test files, 69 tests passed
- independent review completed with no remaining findings

This PR does not add a page-to-Agent command API, durable transcript storage, or production deployment changes.