### PR TITLE
fix(skillhub): 修复快速切换 Bot 时的工作区竞态

### DIFF
--- a/src/bot-skills/runtime.ts
+++ b/src/bot-skills/runtime.ts
@@ -49,6 +49,18 @@ export interface CurrentBotSkillWorkspaceWriteOptions {
   lockWaitMs?: number;
 }
 
+export class BotSkillWorkspaceChangingError extends Error {
+  readonly code = 'WORKSPACE_SWITCHING';
+
+  constructor(
+    public readonly activeBotId: string,
+    public readonly targetBotId: string,
+  ) {
+    super(`Bot Skill workspace ownership is changing (${activeBotId} -> ${targetBotId}); retry the write.`);
+    this.name = 'BotSkillWorkspaceChangingError';
+  }
+}
+
 /**
  * Serializes every writer of the active Skill directory with Bot activation,
  * restore, rollback, and after-turn sync. The ownership snapshot is captured
@@ -244,8 +256,6 @@ function assertCurrentBotSkillWorkspaceIsWritable(
   context: CurrentBotSkillWorkspaceWriteContext,
 ): void {
   if (context.botId && context.activeBotId && context.botId !== context.activeBotId) {
-    throw new Error(
-      `Bot Skill workspace ownership is changing (${context.activeBotId} -> ${context.botId}); retry the write.`,
-    );
+    throw new BotSkillWorkspaceChangingError(context.activeBotId, context.botId);
   }
 }

--- a/src/catscompany/skillhub-rpc.ts
+++ b/src/catscompany/skillhub-rpc.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import { createCatsCoLocalConfigService } from './local-config';
 import type { CatsThinToolRpcMessage } from './client';
 import {
+  BotSkillWorkspaceChangingError,
   finalizeCurrentBotPublicSkillNow,
   withCurrentBotSkillWorkspaceWrite,
 } from '../bot-skills/runtime';
@@ -103,7 +104,12 @@ export class SkillHubThinRpcHandler {
       );
       return existing.operation;
     }
-    const operation = this.executeOnce(request);
+    const operation = this.executeOnce(request).catch((error) => {
+      if (error instanceof BotSkillWorkspaceChangingError) {
+        throw new SkillHubThinRpcError(error.code, error.message);
+      }
+      throw error;
+    });
     this.completed.set(requestID, { fingerprint, operation });
     while (this.completed.size > MAX_COMPLETED_REQUESTS) {
       this.completed.delete(this.completed.keys().next().value as string);
@@ -404,14 +410,79 @@ export function scheduleDashboardBotSwitch(
   botUid: string,
   isShuttingDown: () => boolean = () => false,
 ): void {
-  const timer = setTimeout(() => {
-    if (isShuttingDown()) return;
-    void requestDashboardBotSwitch(botUid).catch((error) => {
-      Logger.warning(`SkillHub remote Bot switch failed: ${error?.message || String(error)}`);
-    });
-  }, 1_000);
-  timer.unref?.();
+  dashboardBotSwitchScheduler.schedule(botUid, isShuttingDown);
 }
+
+interface PendingDashboardBotSwitch {
+  botUid: string;
+  isShuttingDown: () => boolean;
+}
+
+export class DashboardBotSwitchScheduler {
+  private pending?: PendingDashboardBotSwitch;
+  private timer?: ReturnType<typeof setTimeout>;
+  private running = false;
+  private runningBotUid = '';
+
+  constructor(
+    private readonly requestSwitch: (botUid: string) => Promise<void> = requestDashboardBotSwitch,
+    private readonly delayMs = 1_000,
+  ) {}
+
+  schedule(botUid: string, isShuttingDown: () => boolean = () => false): void {
+    const target = String(botUid || '').trim();
+    if (!target || isShuttingDown()) return;
+    if (this.running && this.runningBotUid === target) {
+      this.pending = undefined;
+      return;
+    }
+    if (this.pending?.botUid === target) {
+      // Refresh the connector lifecycle fence without extending the debounce.
+      this.pending = { botUid: target, isShuttingDown };
+      return;
+    }
+
+    this.pending = {
+      botUid: target,
+      isShuttingDown,
+    };
+    if (!this.running) this.arm();
+  }
+
+  private arm(): void {
+    if (this.timer) clearTimeout(this.timer);
+    this.timer = setTimeout(() => {
+      this.timer = undefined;
+      void this.drain();
+    }, this.delayMs);
+    this.timer.unref?.();
+  }
+
+  private async drain(): Promise<void> {
+    if (this.running) return;
+    const next = this.pending;
+    this.pending = undefined;
+    if (!next) return;
+    if (next.isShuttingDown()) {
+      if (this.pending) this.arm();
+      return;
+    }
+
+    this.running = true;
+    this.runningBotUid = next.botUid;
+    try {
+      await this.requestSwitch(next.botUid);
+    } catch (error: any) {
+      Logger.warning(`SkillHub remote Bot switch failed: ${error?.message || String(error)}`);
+    } finally {
+      this.running = false;
+      this.runningBotUid = '';
+      if (this.pending) this.arm();
+    }
+  }
+}
+
+const dashboardBotSwitchScheduler = new DashboardBotSwitchScheduler();
 
 export async function requestDashboardBotSwitch(
   botUid: string,

--- a/tests/bot-skills-writer-lock.test.ts
+++ b/tests/bot-skills-writer-lock.test.ts
@@ -5,6 +5,10 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { createCatsCoLocalConfigService } from '../src/catscompany/local-config';
 import { withBotSkillWorkspaceLock } from '../src/bot-skills/lock';
+import {
+  BotSkillWorkspaceChangingError,
+  withCurrentBotSkillWorkspaceWrite,
+} from '../src/bot-skills/runtime';
 import { BotSkillWorkspaceService } from '../src/bot-skills/workspace';
 import { bootstrapDefaultSkillHubSkills } from '../src/skillhub/default-skill-bootstrap';
 import { SkillHubTool } from '../src/tools/skillhub-tool';
@@ -164,6 +168,17 @@ describe('Bot Skill workspace writer lock', () => {
       currentBot: { uid: 'bot-b', apiKey: 'bot-b-key' },
     });
     let called = false;
+
+    await assert.rejects(
+      withCurrentBotSkillWorkspaceWrite(() => undefined, { runtimeRoot }),
+      (error: unknown) => (
+        error instanceof BotSkillWorkspaceChangingError
+        && error.code === 'WORKSPACE_SWITCHING'
+        && error.activeBotId === 'bot-a'
+        && error.targetBotId === 'bot-b'
+      ),
+    );
+
     const tool = new SkillHubTool(
       { search: async () => ({ skills: [] }) },
       {

--- a/tests/catscompany-skillhub-rpc.test.ts
+++ b/tests/catscompany-skillhub-rpc.test.ts
@@ -5,6 +5,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { createCatsCoLocalConfigService } from '../src/catscompany/local-config';
 import {
+  DashboardBotSwitchScheduler,
   SkillHubThinRpcError,
   SkillHubThinRpcHandler,
   SKILLHUB_THIN_RPC_TOOLS,
@@ -345,6 +346,31 @@ describe('CatsCompany SkillHub thin RPC', () => {
     assert.deepEqual(scheduledBotUIDs, ['44']);
   });
 
+  test('reports an in-progress workspace handoff as a retryable RPC state', async () => {
+    createCatsCoLocalConfigService({ runtimeRoot }).save({
+      version: 1,
+      account: { token: 'user-token', uid: '7', username: 'alice' },
+      currentBot: { uid: '44', apiKey: 'bot-44-key', boundByUserUid: '7' },
+      device: {
+        deviceId: 'alice-device',
+        bodyId: 'alice-device',
+        installationId: 'alice-device',
+      },
+    });
+
+    await assert.rejects(
+      handler.execute(request({
+        request_id: 'workspace-switching',
+        payload: { bot_uid: '44' },
+      })),
+      (error: unknown) => (
+        error instanceof SkillHubThinRpcError
+        && error.code === 'WORKSPACE_SWITCHING'
+        && /ownership is changing \(42 -> 44\)/i.test(error.message)
+      ),
+    );
+  });
+
   test('rejects reuse of one request ID for a different operation', async () => {
     await handler.execute(request({ request_id: 'reused-request' }));
     await assert.rejects(
@@ -515,6 +541,114 @@ describe('CatsCompany SkillHub thin RPC', () => {
     assert.equal(calls.length, 1);
     assert.match(calls[0].url, /^http:\/\/127\.0\.0\.1:\d+\/api\/cats\/switch-bot$/);
     assert.deepEqual(JSON.parse(String(calls[0].init?.body)), { botUid: '44' });
+  });
+
+  test('coalesces delayed Bot switch intents so the latest selection wins', async () => {
+    const calls: string[] = [];
+    const scheduler = new DashboardBotSwitchScheduler(async (botUid) => {
+      calls.push(botUid);
+    }, 5);
+
+    scheduler.schedule('575');
+    scheduler.schedule('412');
+    scheduler.schedule('412');
+    await delay(30);
+
+    assert.deepEqual(calls, ['412']);
+  });
+
+  test('serializes a newer Bot switch behind an in-flight switch', async () => {
+    const calls: string[] = [];
+    let releaseFirst!: () => void;
+    const first = new Promise<void>(resolve => { releaseFirst = resolve; });
+    let concurrent = 0;
+    let maxConcurrent = 0;
+    const scheduler = new DashboardBotSwitchScheduler(async (botUid) => {
+      calls.push(botUid);
+      concurrent += 1;
+      maxConcurrent = Math.max(maxConcurrent, concurrent);
+      if (botUid === '575') await first;
+      concurrent -= 1;
+    }, 5);
+
+    scheduler.schedule('575');
+    await delay(15);
+    scheduler.schedule('412');
+    releaseFirst();
+    await delay(40);
+
+    assert.deepEqual(calls, ['575', '412']);
+    assert.equal(maxConcurrent, 1);
+  });
+
+  test('cancels an opposite queued switch when the latest target is already in flight', async () => {
+    const calls: string[] = [];
+    let releaseFirst!: () => void;
+    const first = new Promise<void>(resolve => { releaseFirst = resolve; });
+    const scheduler = new DashboardBotSwitchScheduler(async (botUid) => {
+      calls.push(botUid);
+      if (botUid === '575') await first;
+    }, 5);
+
+    scheduler.schedule('575');
+    await delay(15);
+    scheduler.schedule('412');
+    scheduler.schedule('575');
+    releaseFirst();
+    await delay(30);
+
+    assert.deepEqual(calls, ['575']);
+  });
+
+  test('refreshes a coalesced switch with the latest connector lifecycle', async () => {
+    const calls: string[] = [];
+    const scheduler = new DashboardBotSwitchScheduler(async (botUid) => {
+      calls.push(botUid);
+    }, 5);
+
+    let oldConnectorShuttingDown = false;
+    scheduler.schedule('575', () => oldConnectorShuttingDown);
+    oldConnectorShuttingDown = true;
+    scheduler.schedule('575', () => false);
+    await delay(30);
+
+    assert.deepEqual(calls, ['575']);
+  });
+
+  test('does not postpone a pending switch when the same target is repeated', async () => {
+    const calls: string[] = [];
+    const scheduler = new DashboardBotSwitchScheduler(async (botUid) => {
+      calls.push(botUid);
+    }, 20);
+
+    scheduler.schedule('575');
+    await delay(8);
+    scheduler.schedule('575');
+    await delay(8);
+    scheduler.schedule('575');
+    await delay(12);
+
+    assert.deepEqual(calls, ['575']);
+  });
+
+  test('does not drain a queued switch after application shutdown begins', async () => {
+    const calls: string[] = [];
+    let releaseFirst!: () => void;
+    const first = new Promise<void>(resolve => { releaseFirst = resolve; });
+    let shuttingDown = false;
+    const scheduler = new DashboardBotSwitchScheduler(async (botUid) => {
+      calls.push(botUid);
+      if (botUid === '575') await first;
+    }, 5);
+
+    scheduler.schedule('575');
+    await delay(15);
+    scheduler.schedule('412', () => shuttingDown);
+    shuttingDown = true;
+    releaseFirst();
+    await delay(40);
+
+    assert.deepEqual(calls, ['575']);
   });
 
   test('revalidates the local Skill identity while holding the upload lock', async () => {
@@ -995,6 +1129,10 @@ describe('CatsCompany SkillHub thin RPC', () => {
     );
     assert.equal(writes, 0);
   });
+
+  function delay(milliseconds: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, milliseconds));
+  }
 
   function request(overrides: Record<string, any> = {}): any {
     return {


### PR DESCRIPTION
## 背景

在 WebApp 能力库中快速切换 Bot 时，本地 XiaoBa 会同时经历工作区交接和 CatsCo 连接器重启。此前存在三个竞态：

1. 工作区归属正在切换时只返回普通失败，WebApp 无法识别为可重试状态；
2. 1 秒延迟执行的旧切换可能在用户已经选择其他 Bot 后继续执行；
3. 多标签页或连续选择会排入相反切换，产生 `575 -> 412`、`412 -> 575` 往返。

最终表现为“Bot Skill workspace ownership is changing”或设备暂时无路由，手动刷新后又能恢复。

## 本次修改

- 新增结构化错误 `WORKSPACE_SWITCHING`，保留 active/target Bot 信息；
- Thin RPC 将工作区交接映射为稳定、可重试的错误码；
- 增加 Bot 切换调度器：
  - 延迟窗口内最后一次选择生效；
  - 相同目标合并但不重复延后计时；
  - 相反切换串行执行；
  - 最新目标已经在执行时取消过时的待执行目标；
  - 应用真正关闭后不继续执行待办；
- 保持现有 owner、device、Bot scope 校验不变。

## 注入与缓存边界

本 PR 没有修改 System Prompt、Skill loader、Skill 内容、工具 definition 或模型消息，不改变模型可见输入和 prompt cache key。Bot 切换本身仍会重启 CatsCo 连接器，这是既有运行生命周期行为。

## 验证

- `npx tsx --test tests/bot-skills-writer-lock.test.ts tests/catscompany-skillhub-rpc.test.ts`：33/33 通过；
- 上述聚焦套件连续重复运行通过；
- `npm run build`：通过；
- `git diff --check`：通过。

## 跨仓关系

配套 CatsCo WebApp PR [#192](https://github.com/buildsense-ai/cats-company/pull/192) 会识别 `WORKSPACE_SWITCHING`、恢复短暂路由丢失并限制跨重启补提次数。建议先合并并部署本 PR，再合并 CatsCo PR；CatsCo PR 同时兼容旧 XiaoBa 的精确错误文本。
