### PR TITLE
fix: keep service stop fallback scoped to original child

### DIFF
--- a/src/dashboard/service-manager.ts
+++ b/src/dashboard/service-manager.ts
@@ -376,12 +376,15 @@ export class ServiceManager extends EventEmitter {
       this.killProcess(svc.process, true);
     } else {
       svc.expectedExit = 'stop';
-      svc.process.kill('SIGTERM');
+      const stoppingProcess = svc.process;
+      stoppingProcess.kill('SIGTERM');
 
       // 5秒后强制kill
       const forceKillTimer = setTimeout(() => {
-        if (svc.process && !svc.process.killed) {
-          svc.process.kill('SIGKILL');
+        // Never target a replacement child that started while this fallback
+        // timer was pending. This timer belongs to the original process only.
+        if (stoppingProcess.exitCode === null && stoppingProcess.signalCode === null) {
+          stoppingProcess.kill('SIGKILL');
         }
       }, 5000);
       forceKillTimer.unref?.();

--- a/tests/dashboard-service-manager.test.ts
+++ b/tests/dashboard-service-manager.test.ts
@@ -231,6 +231,28 @@ describe('dashboard service manager', () => {
     assert.equal(service?.status, 'stopped');
     assert.equal(service?.lastError, undefined);
   });
+
+  test('a delayed stop fallback cannot kill a replacement child', async () => {
+    const manager = new ServiceManager(process.cwd());
+    const serviceRecord = (manager as any).services.get('weixin');
+    serviceRecord.info.command = process.execPath;
+    serviceRecord.info.args = ['-e', "process.on('SIGTERM', () => process.exit(0)); setInterval(() => {}, 1000);"];
+
+    const firstStopped = new Promise<void>(resolve => manager.once('service-stopped', () => resolve()));
+    manager.start('weixin');
+    manager.stop('weixin');
+    await firstStopped;
+
+    serviceRecord.info.args = ['-e', "setInterval(() => {}, 1000);"];
+    manager.start('weixin');
+    const replacementPid = manager.getService('weixin')?.pid;
+    assert.ok(replacementPid);
+
+    await new Promise(resolve => setTimeout(resolve, 5_300));
+    assert.equal(manager.getService('weixin')?.status, 'running');
+    assert.equal(manager.getService('weixin')?.pid, replacementPid);
+    manager.stop('weixin');
+  });
 });
 
 function normalize(value: string): string {


### PR DESCRIPTION
## Summary
- keep the delayed SIGKILL fallback bound to the exact child targeted by stop()
- prevent a replacement CatsCompany connector from being killed by an older stop timer
- add a regression test that starts a replacement child before the fallback fires

## Validation
- node --import tsx --test tests/dashboard-service-manager.test.ts (8 passed)
- npm run build

The full runtime suite still has unrelated Windows/WSL worker-image environment failures on this host; the focused suite and build pass.