### PR TITLE
修复无效 Skill 阻塞其他 Skill 发布收尾

### DIFF
--- a/src/bot-skills/sync-service.ts
+++ b/src/bot-skills/sync-service.ts
@@ -22,6 +22,8 @@ import {
   computeBotSkillPackageHash,
   readBotSkillLocalMarker,
   scanBotSkillWorkspace,
+  type BotSkillWorkspaceValidationFailure,
+  type ScanBotSkillWorkspaceOptions,
   writeBotSkillLocalMarker,
 } from './local-manifest';
 import { BotPrivateSkillClient } from './private-package-client';
@@ -109,6 +111,11 @@ interface BotSkillFinalizeJournal {
   previousSkill: string;
   nextSkill: string;
   previousMarker: string;
+}
+
+interface PublicFinalizeLocalManifest {
+  entries: LocalBotSkillManifestEntry[];
+  rejectedLocalSkillIds: ReadonlySet<string>;
 }
 
 export class BotSkillSyncService {
@@ -291,7 +298,8 @@ export class BotSkillSyncService {
     await options.validateScope?.();
     this.recoverInterruptedFinalizes(initialCloud);
     const base = this.baseStore.read(this.botId);
-    const local = this.readLocalManifest();
+    const localSnapshot = this.readLocalManifestForPublicFinalize(localSkillId);
+    const local = localSnapshot.entries;
     const selected = local.find(entry => (
       entry.localSkillId === localSkillId && entry.name === skillName
     ));
@@ -301,7 +309,7 @@ export class BotSkillSyncService {
     }
 
     const packageValue = await this.waitForPublicPackage(reference, options);
-    const refreshed = this.readLocalManifest().find(entry => (
+    const refreshed = this.readLocalManifestForPublicFinalize(localSkillId).entries.find(entry => (
       entry.localSkillId === localSkillId && entry.name === skillName
     ));
     if (!refreshed || refreshed.contentHash !== selected.contentHash) {
@@ -313,7 +321,7 @@ export class BotSkillSyncService {
     if (!currentCloud?.definition || !currentCloud.skills.some(item => botSkillRefEqual(item, reference))) {
       throw new Error('The public Skill reference was removed from BotDefinition during finalization.');
     }
-    const readyToWrite = this.readLocalManifest().find(entry => (
+    const readyToWrite = this.readLocalManifestForPublicFinalize(localSkillId).entries.find(entry => (
       entry.localSkillId === localSkillId && entry.name === skillName
     ));
     if (!readyToWrite || readyToWrite.contentHash !== refreshed.contentHash) {
@@ -356,7 +364,8 @@ export class BotSkillSyncService {
         },
       });
 
-      const updatedLocal = this.readLocalManifest();
+      const updatedSnapshot = this.readLocalManifestForPublicFinalize(localSkillId);
+      const updatedLocal = updatedSnapshot.entries;
       const updated = updatedLocal.find(entry => entry.localSkillId === localSkillId);
       if (
         !updated
@@ -369,6 +378,7 @@ export class BotSkillSyncService {
       await options.validateScope?.();
       const result = await this.pushLocal(updatedLocal, currentCloud, base, {
         requiredCloudReference: reference,
+        preserveBaseLocalSkillIds: updatedSnapshot.rejectedLocalSkillIds,
         validateScope: options.validateScope,
       });
       try {
@@ -496,14 +506,31 @@ export class BotSkillSyncService {
     };
   }
 
-  private readLocalManifest(): LocalBotSkillManifestEntry[] {
+  private readLocalManifest(
+    options: ScanBotSkillWorkspaceOptions = {},
+  ): LocalBotSkillManifestEntry[] {
     if (!fs.existsSync(this.skillsRoot)) {
       if (this.workspaceExisted) {
         throw new Error('The active Bot Skill workspace disappeared unexpectedly.');
       }
       return [];
     }
-    return scanBotSkillWorkspace(this.skillsRoot);
+    return scanBotSkillWorkspace(this.skillsRoot, options);
+  }
+
+  private readLocalManifestForPublicFinalize(
+    selectedLocalSkillId: string,
+  ): PublicFinalizeLocalManifest {
+    const rejected: BotSkillWorkspaceValidationFailure[] = [];
+    const entries = this.readLocalManifest({
+      onValidationFailure: failure => rejected.push(failure),
+    });
+    const selectedFailure = rejected.find(entry => entry.localSkillId === selectedLocalSkillId);
+    if (selectedFailure) throw selectedFailure.error;
+    return {
+      entries,
+      rejectedLocalSkillIds: new Set(rejected.map(entry => entry.localSkillId)),
+    };
   }
 
   private async pushLocal(
@@ -511,6 +538,7 @@ export class BotSkillSyncService {
     initialCloud: CloudBotSkills,
     base: BotSkillSyncBase | undefined,
     options: {
+      preserveBaseLocalSkillIds?: ReadonlySet<string>;
       requiredCloudReference?: BotSkillRef;
       validateScope?: () => Promise<void> | void;
     } = {},
@@ -522,7 +550,10 @@ export class BotSkillSyncService {
       throw new Error('The public Skill reference is no longer present in BotDefinition.');
     }
     const previousByLocalID = new Map(base?.skills.map(entry => [entry.localSkillId, entry]) ?? []);
-    const nextEntries: BotSkillSyncBaseEntry[] = [];
+    const nextEntries: BotSkillSyncBaseEntry[] = (base?.skills ?? []).filter(entry => (
+      options.preserveBaseLocalSkillIds?.has(entry.localSkillId)
+      && initialCloud.skills.some(reference => botSkillRefEqual(reference, entry.reference))
+    ));
     const pendingMarkers: Array<{
       path: string;
       marker: Parameters<typeof writeBotSkillLocalMarker>[1];
@@ -582,6 +613,9 @@ export class BotSkillSyncService {
         ...(entry.origin ? { origin: entry.origin } : {}),
       });
     }
+    nextEntries.sort((left, right) => (
+      left.localSkillId < right.localSkillId ? -1 : left.localSkillId > right.localSkillId ? 1 : 0
+    ));
     await options.validateScope?.();
     const refs = canonicalizeBotSkillRefs(nextEntries.map(entry => entry.reference));
     if (

--- a/tests/bot-skills-sync.test.ts
+++ b/tests/bot-skills-sync.test.ts
@@ -190,6 +190,101 @@ describe('Bot Skill Local/Base/Cloud sync', () => {
     assert.equal(fixture.uploads, uploadsBeforeFinalize + 1);
   });
 
+  test('finalizes a public Skill while preserving an unrelated rejected managed Skill', async () => {
+    const fixture = createFixture(roots);
+    writeSkill(fixture.skillsRoot, 'blocked-existing', 'blocked-existing', 'initial safe content');
+    await fixture.sync();
+
+    const baseBefore = new BotSkillBaseStore(fixture.runtimeRoot).read(fixture.botId);
+    const blockedBefore = baseBefore?.skills.find(entry => entry.name === 'blocked-existing');
+    assert.ok(blockedBefore);
+    const blockedRoot = path.join(fixture.skillsRoot, 'blocked-existing');
+    const blockedScript = path.join(blockedRoot, 'scripts', 'publish-html-directory.mjs');
+    fs.mkdirSync(path.dirname(blockedScript), { recursive: true });
+    fs.writeFileSync(blockedScript, 'const apiToken = "sk-proj-12345678901234567890";\n');
+
+    writeSkill(fixture.skillsRoot, 'shared-new', 'shared-new', 'share this globally');
+    const target = scanLocalBotSkill(path.join(fixture.skillsRoot, 'shared-new'));
+    const metadata = {
+      author: 'alice',
+      version: '1.0.0',
+      uploadedAt: '2026-08-14T00:00:00.000Z',
+    };
+    const publicRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-public-package-'));
+    roots.push(publicRoot);
+    writeSkill(publicRoot, 'shared-new', 'shared-new', 'share this globally');
+    const publicSkillFile = path.join(publicRoot, 'shared-new', 'SKILL.md');
+    fs.writeFileSync(
+      publicSkillFile,
+      applySkillHubLocalMetadata(fs.readFileSync(publicSkillFile, 'utf8'), metadata),
+      'utf8',
+    );
+    const canonicalPublic = scanLocalBotSkill(path.join(publicRoot, 'shared-new'));
+    const publicReference = {
+      source: 'skillhub' as const,
+      skillId: 'alice/shared-new',
+      version: metadata.version,
+      contentHash: canonicalPublic.contentHash,
+    };
+    const publicPackage: BotSkillPackage = {
+      schema: 'catsco.private-skill-package.v1',
+      source: 'public',
+      reference: {
+        skillId: publicReference.skillId,
+        version: publicReference.version,
+      },
+      localSkillId: target.localSkillId,
+      name: target.name,
+      contentHash: canonicalPublic.contentHash,
+      createdAt: metadata.uploadedAt,
+      origin: {
+        skillId: publicReference.skillId,
+        version: publicReference.version,
+      },
+      files: canonicalPublic.files,
+    };
+    delete (publicPackage as Partial<BotSkillPackage>).schema;
+    fixture.packages.set(refKey(publicReference), publicPackage);
+    fixture.cloud = {
+      revision: fixture.cloud.revision + 1,
+      skills: [...fixture.cloud.skills, publicReference],
+    };
+
+    const uploadsBeforeFinalize = fixture.uploads;
+    const finalized = await fixture.finalize({
+      localSkillId: target.localSkillId,
+      skillName: target.name,
+      reference: publicReference,
+    });
+
+    assert.equal(finalized.direction, 'local_to_cloud');
+    assert.equal(fixture.uploads, uploadsBeforeFinalize);
+    assert.equal(fs.existsSync(blockedScript), true);
+    assert.equal(fixture.cloud.skills.some(skill => (
+      skill.skillId === blockedBefore.reference.skillId
+      && skill.version === blockedBefore.reference.version
+      && skill.contentHash === blockedBefore.reference.contentHash
+    )), true);
+    assert.equal(fixture.cloud.skills.some(skill => (
+      skill.skillId === publicReference.skillId
+      && skill.version === publicReference.version
+      && skill.contentHash === publicReference.contentHash
+    )), true);
+    const baseAfter = new BotSkillBaseStore(fixture.runtimeRoot).read(fixture.botId);
+    assert.deepEqual(
+      baseAfter?.skills.find(entry => entry.localSkillId === blockedBefore.localSkillId),
+      blockedBefore,
+    );
+    assert.deepEqual(
+      readBotSkillLocalMarker(path.join(fixture.skillsRoot, 'shared-new'))?.reference,
+      publicReference,
+    );
+    assert.deepEqual(
+      readSkillHubLocalMetadata(path.join(fixture.skillsRoot, 'shared-new', 'SKILL.md')),
+      metadata,
+    );
+  });
+
   test('rolls back Local and Base when the public ref disappears at the final cloud CAS', async () => {
     const fixture = createFixture(roots);
     writeSkill(fixture.skillsRoot, 'shared', 'shared', 'same canonical body');

--- a/tests/electron-main-dashboard-url.test.ts
+++ b/tests/electron-main-dashboard-url.test.ts
@@ -38,6 +38,22 @@ test('electron changes cwd to userData before reading close-to-tray menu prefere
   assert.match(electronMain, /close-to-tray preferences are read from process\.cwd\(\)\/\.xiaoba\/catsco\.json/);
 });
 
+test('packaged electron binds the runtime and active Skills directory to app userData', () => {
+  const userDataReadIndex = electronMain.indexOf("const userDataPath = app.getPath('userData')");
+  const runtimeBindingIndex = electronMain.indexOf('process.env.XIAOBA_USER_DATA_DIR = userDataPath');
+  const skillsBindingIndex = electronMain.indexOf("process.env.XIAOBA_SKILLS_DIR = skillsPath");
+  const chdirIndex = electronMain.indexOf('process.chdir(userDataPath)');
+
+  assert.notEqual(userDataReadIndex, -1);
+  assert.notEqual(runtimeBindingIndex, -1);
+  assert.notEqual(skillsBindingIndex, -1);
+  assert.notEqual(chdirIndex, -1);
+  assert.equal(userDataReadIndex < runtimeBindingIndex, true);
+  assert.equal(runtimeBindingIndex < skillsBindingIndex, true);
+  assert.equal(skillsBindingIndex < chdirIndex, true);
+  assert.match(electronMain, /const skillsPath = path\.join\(userDataPath, 'skills'\)/);
+});
+
 test('electron tray uses app icons and notifies after background hide', () => {
   assert.match(electronMain, /function createTrayIcon\(\)/);
   assert.match(electronMain, /build-resources\/icon\.ico/);

--- a/tests/path-resolver-boundaries.test.ts
+++ b/tests/path-resolver-boundaries.test.ts
@@ -26,6 +26,22 @@ describe('PathResolver runtime data boundary', () => {
     assert.equal(PathResolver.getRuntimeDataRoot(env, testRoot), userDataRoot);
   });
 
+  test('packaged Electron userData resolves to the active Skills directory', () => {
+    const previousUserData = process.env.XIAOBA_USER_DATA_DIR;
+    const previousSkills = process.env.XIAOBA_SKILLS_DIR;
+    const userDataRoot = path.join(testRoot, 'packaged-user-data');
+    try {
+      process.env.XIAOBA_USER_DATA_DIR = userDataRoot;
+      delete process.env.XIAOBA_SKILLS_DIR;
+      assert.equal(PathResolver.getSkillsPath(), path.join(userDataRoot, 'skills'));
+    } finally {
+      if (previousUserData === undefined) delete process.env.XIAOBA_USER_DATA_DIR;
+      else process.env.XIAOBA_USER_DATA_DIR = previousUserData;
+      if (previousSkills === undefined) delete process.env.XIAOBA_SKILLS_DIR;
+      else process.env.XIAOBA_SKILLS_DIR = previousSkills;
+    }
+  });
+
   test('legacy runtime root remains a data-only compatibility input', () => {
     const legacyDataRoot = path.join(testRoot, 'legacy-data');
     const env = {


### PR DESCRIPTION
## 背景

一个有效本地 Skill 已上传到 SkillHub 并绑定 BotDefinition 后，XiaoBa 在发布收尾阶段会再次严格扫描整个本地 Skills 工作区。只要目录中另一个无关 Skill 未通过敏感内容校验，本次有效 Skill 的收尾也会失败，出现“已分享并绑定，但本地工作区暂未完成对齐”的错误。

这不是要放宽安全规则，而是要避免无关 Skill 相互阻塞。

## 本次改动

- 发布收尾改为按目标 Skill 校验：
  - 当前正在发布的 Skill 仍必须完整通过原有校验；
  - 其他校验失败的 Skill 不再阻塞目标 Skill 的收尾。
- 对其他已由同步系统管理、但当前校验失败的 Skill：
  - 不上传其内容；
  - 不修改其本地文件；
  - 仅在对应引用仍存在于当前 BotDefinition 时保留原 Base/Cloud 引用，避免误删。
- 增加回归测试，覆盖“一个无效 Skill 与另一个有效待发布 Skill 同时存在”的场景。
- 增加正式打包版路径回归测试，验证 Electron `userData` 会绑定为运行时数据根目录，实际 Skills 目录为 `<userData>/skills`。

## 打包版路径链路

1. 正式 Electron 应用启动时读取 `app.getPath('userData')`。
2. 将其写入 `XIAOBA_USER_DATA_DIR`，并把 `XIAOBA_SKILLS_DIR` 设为 `<userData>/skills`。
3. `PathResolver.getSkillsPath()` 返回该真实目录。
4. SkillHub RPC 返回当前工作区实际使用的 `skillsRoot`，并通过 `realpath` 规范化后交给 WebApp 展示。

开发版使用仓库下的 `.dev-user-data/skills`；正式打包版使用操作系统分配给 CatsCo 的 Electron userData 目录，不依赖安装目录或源码目录。

## 验证

- `node --import tsx --test tests/bot-skills-sync.test.ts tests/electron-main-dashboard-url.test.ts tests/path-resolver-boundaries.test.ts`：48 项全部通过。
- `npm run build`：通过。

## 安全与行为边界

- 不放宽任何敏感内容或凭证扫描规则。
- 目标 Skill 自身校验失败时仍会被阻止发布。
- 不修改 Skill 注入、Skill 加载或模型上下文逻辑。
- 不改变开发版 `.dev-user-data` 的既有设计。