### PR TITLE
fix(skillhub): 放宽 Skill 上传并区分桌面运行时

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -5,6 +5,11 @@ const { normalizeUpdateError } = require('./update-errors');
 const { shouldDisableHardwareAcceleration } = require('./gpu-compat');
 const { createRendererGoneGuard } = require('./renderer-gone');
 
+// The Electron host is the trust boundary for a real local desktop runtime.
+// Both development and packaged apps execute this entrypoint before starting
+// the embedded Dashboard and its CatsCo connector child.
+process.env.XIAOBA_RUNTIME_ROLE = 'desktop';
+
 // Compatibility: render with software (SwiftShader) on Intel Macs, where
 // OCLP-patched macOS with legacy NVIDIA GPUs (e.g. GTX 675MX in the Late-2012
 // iMac) crash the GPU process on launch. Other platforms keep hardware

--- a/src/bot-skills/local-manifest.ts
+++ b/src/bot-skills/local-manifest.ts
@@ -23,7 +23,6 @@ export class BotSkillPackageValidationError extends Error {
 
 const BOT_SKILL_LOCAL_MARKER_SCHEMA = 'xiaoba.bot-skill-local.v1';
 const SKIP_DIRECTORIES = new Set(['.git', 'node_modules']);
-const FORBIDDEN_CREDENTIAL_DIRECTORIES = new Set(['.ssh', '.aws', '.kube', '.gnupg']);
 const SKIP_FILES = new Set([
   BOT_SKILL_LOCAL_MARKER_FILE,
   '.xiaoba-skillhub-install.json',
@@ -35,37 +34,15 @@ const SKIP_FILES = new Set([
 const MAX_FILES = 200;
 const MAX_SINGLE_FILE_BYTES = 2 * 1024 * 1024;
 const MAX_TOTAL_BYTES = 20 * 1024 * 1024;
+// The legacy content scanner is intentionally retained below as a reusable
+// detector, but package collection no longer calls it. SkillHub publication is
+// content-agnostic; only package structure and transport limits are enforced.
 const MAX_CREDENTIAL_ASSIGNMENTS = 512;
 const MAX_CREDENTIAL_EXPRESSION_CHARS = 16 * 1024;
 const ARCHIVE_FILE_EXTENSIONS = [
-  '.7z',
-  '.a',
-  '.apk',
-  '.ar',
-  '.bz2',
-  '.cab',
-  '.cpio',
-  '.deb',
-  '.dmg',
-  '.gz',
-  '.img',
-  '.iso',
-  '.jar',
-  '.lz',
-  '.lz4',
-  '.lzma',
-  '.rar',
-  '.rpm',
-  '.tar',
-  '.tbz',
-  '.tbz2',
-  '.tgz',
-  '.txz',
-  '.war',
-  '.whl',
-  '.xz',
-  '.zip',
-  '.zst',
+  '.7z', '.a', '.apk', '.ar', '.bz2', '.cab', '.cpio', '.deb', '.dmg', '.gz',
+  '.img', '.iso', '.jar', '.lz', '.lz4', '.lzma', '.rar', '.rpm', '.tar',
+  '.tbz', '.tbz2', '.tgz', '.txz', '.war', '.whl', '.xz', '.zip', '.zst',
 ] as const;
 const EXPLICIT_SAFE_CREDENTIAL_VALUES = new Set([
   'catsco-bot-key',
@@ -287,9 +264,6 @@ export function collectBotSkillPackageFiles(root: string): BotSkillPackageFile[]
       if (entryStat.isSymbolicLink()) continue;
       assertRealPathContained(realRoot, fullPath);
       if (entry.isDirectory()) {
-        if (FORBIDDEN_CREDENTIAL_DIRECTORIES.has(entry.name.toLowerCase())) {
-          throw new BotSkillPackageValidationError(`Skill contains a forbidden credential directory: ${entry.name}`);
-        }
         if (
           !SKIP_DIRECTORIES.has(entry.name)
           && !fs.existsSync(path.join(fullPath, 'SKILL.md'))
@@ -304,7 +278,6 @@ export function collectBotSkillPackageFiles(root: string): BotSkillPackageFile[]
         throw new BotSkillPackageValidationError(`Skill contains an unsafe path: ${relativePath}`);
       }
       const bytes = fs.readFileSync(fullPath);
-      rejectSensitiveMaterial(relativePath, bytes);
       if (bytes.length > MAX_SINGLE_FILE_BYTES) {
         throw new BotSkillPackageValidationError(`Skill file is too large: ${relativePath}`);
       }

--- a/src/catscompany/client.ts
+++ b/src/catscompany/client.ts
@@ -28,6 +28,7 @@ export interface CatsDeviceRegistration {
   owner_user_id?: string;
   os?: 'windows' | 'macos' | 'linux' | 'unknown';
   status?: 'online' | 'offline';
+  runtime_role?: 'desktop' | 'server';
   capabilities?: string[];
   model_status?: {
     source?: 'relay' | 'custom';

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -5,7 +5,7 @@ import {
   type CatsDeviceRpcMessage,
   type CatsThinToolRpcMessage,
 } from './client';
-import { CatsCompanyConfig, ParsedCatsMessage, CatsFileInfo } from './types';
+import { CatsCompanyConfig, ParsedCatsMessage, CatsFileInfo, type CatsCompanyRuntimeRole } from './types';
 import { MessageSender, type ConversationTaskStatusInput } from './message-sender';
 import { extractContentBlocks } from './content-blocks';
 import { createCatsCoMessageEnvelope, createExecutionScope } from './message-envelope';
@@ -171,7 +171,7 @@ const STRUCTURED_TOOL_PROGRESS_UNSUPPORTED_CHANNELS = new Set([
   'wx',
 ]);
 const SUBAGENT_TERMINAL_EVENTS = new Set(['agent_completed', 'agent_failed', 'agent_stopped']);
-export const CATSCOMPANY_FULL_RUNTIME_DEVICE_CAPABILITIES: DeviceGrantOperation[] = [
+export const CATSCOMPANY_SERVER_RUNTIME_DEVICE_CAPABILITIES: DeviceGrantOperation[] = [
   'read_file',
   'resolve_common_directory',
   'glob',
@@ -180,11 +180,26 @@ export const CATSCOMPANY_FULL_RUNTIME_DEVICE_CAPABILITIES: DeviceGrantOperation[
   'edit_file',
   'send_file',
   'execute_shell',
+];
+
+export const CATSCOMPANY_DESKTOP_RUNTIME_DEVICE_CAPABILITIES: DeviceGrantOperation[] = [
+  ...CATSCOMPANY_SERVER_RUNTIME_DEVICE_CAPABILITIES,
   SKILLHUB_THIN_RPC_TOOLS.workspace,
   SKILLHUB_THIN_RPC_TOOLS.share,
   SKILLHUB_THIN_RPC_TOOLS.finalize,
   SKILLHUB_THIN_RPC_TOOLS.switchBot,
 ];
+
+/** @deprecated Prefer capabilitiesForCatsCompanyRuntimeRole. */
+export const CATSCOMPANY_FULL_RUNTIME_DEVICE_CAPABILITIES = CATSCOMPANY_DESKTOP_RUNTIME_DEVICE_CAPABILITIES;
+
+export function capabilitiesForCatsCompanyRuntimeRole(
+  runtimeRole: CatsCompanyRuntimeRole,
+): DeviceGrantOperation[] {
+  return runtimeRole === 'desktop'
+    ? [...CATSCOMPANY_DESKTOP_RUNTIME_DEVICE_CAPABILITIES]
+    : [...CATSCOMPANY_SERVER_RUNTIME_DEVICE_CAPABILITIES];
+}
 
 function currentRuntimeOS(): 'windows' | 'macos' | 'linux' | 'unknown' {
   switch (platform()) {
@@ -453,6 +468,8 @@ export class CatsCompanyBot {
 
   constructor(config: CatsCompanyConfig) {
     this.botUid = String(config.botUid || '').trim() || null;
+    const runtimeRole: CatsCompanyRuntimeRole = config.runtimeRole === 'desktop' ? 'desktop' : 'server';
+    const deviceCapabilities = capabilitiesForCatsCompanyRuntimeRole(runtimeRole);
     const localDeviceId = config.installationId || config.bodyId;
     const deviceRegistration = localDeviceId
       ? {
@@ -463,7 +480,8 @@ export class CatsCompanyBot {
           owner_user_id: config.ownerUserId,
           os: currentRuntimeOS(),
           status: 'online' as const,
-          capabilities: [...CATSCOMPANY_FULL_RUNTIME_DEVICE_CAPABILITIES],
+          runtime_role: runtimeRole,
+          capabilities: deviceCapabilities,
         }
       : undefined;
 
@@ -482,11 +500,12 @@ export class CatsCompanyBot {
       installationId: config.installationId,
       deviceId: config.installationId || config.bodyId,
       ownerUserId: config.ownerUserId,
-      capabilities: [...CATSCOMPANY_FULL_RUNTIME_DEVICE_CAPABILITIES],
+      capabilities: deviceCapabilities,
     });
     this.deviceRegistration = deviceRegistration;
     this.skillHubThinRpc = new SkillHubThinRpcHandler({
       isShuttingDown: () => this.shuttingDown,
+      enabled: runtimeRole === 'desktop',
     });
 
     const runtime = createCatsCompanyRuntime(config.sessionTTL);

--- a/src/catscompany/runtime-config.ts
+++ b/src/catscompany/runtime-config.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as dotenv from 'dotenv';
 import { ChatConfig } from '../types';
-import { CatsCompanyConfig } from './types';
+import { CatsCompanyConfig, type CatsCompanyRuntimeRole } from './types';
 import {
   CatsCoAuthSnapshot,
   CatsCoLocalConfig,
@@ -49,6 +49,10 @@ function firstNonEmpty(...values: unknown[]): string | undefined {
     if (text) return text;
   }
   return undefined;
+}
+
+export function resolveCatsCoRuntimeRole(value: unknown): CatsCompanyRuntimeRole {
+  return String(value || '').trim().toLowerCase() === 'desktop' ? 'desktop' : 'server';
 }
 
 function normalizeBaseUrl(
@@ -124,6 +128,9 @@ export function resolveCatsCoRuntimeConfig(
   const bodyId = localConfig.device?.bodyId;
   const installationId = localConfig.device?.installationId || bodyId;
   const ownerUserId = firstNonEmpty(localConfig.currentBot?.boundByUserUid, auth.uid);
+  // Fail closed: only the Dashboard service manager explicitly marks a
+  // connector as desktop. Direct/remote CLI runtimes are server runtimes.
+  const runtimeRole = resolveCatsCoRuntimeRole(effectiveEnv.XIAOBA_RUNTIME_ROLE);
 
   const missing: CatsCoRuntimeMissingField[] = [];
   if (!serverUrl) missing.push('serverUrl');
@@ -141,6 +148,7 @@ export function resolveCatsCoRuntimeConfig(
       installationId,
       ownerUserId,
       deviceName: localConfig.device?.name,
+      runtimeRole,
       httpBaseUrl,
       sessionTTL: config.catscompany?.sessionTTL,
     }

--- a/src/catscompany/skillhub-rpc.ts
+++ b/src/catscompany/skillhub-rpc.ts
@@ -54,6 +54,7 @@ export interface SkillHubThinRpcHandlerOptions {
   scheduleBotSwitch?: (botUid: string) => void;
   finalizeCurrentBotSkill?: typeof finalizeCurrentBotPublicSkillNow;
   isShuttingDown?: () => boolean;
+  enabled?: boolean;
 }
 
 export class SkillHubThinRpcHandler {
@@ -61,6 +62,7 @@ export class SkillHubThinRpcHandler {
   private readonly scheduleBotSwitch: (botUid: string) => void;
   private readonly finalizeCurrentBotSkill: typeof finalizeCurrentBotPublicSkillNow;
   private readonly isShuttingDown: () => boolean;
+  private readonly enabled: boolean;
   private readonly completed = new Map<string, {
     fingerprint: string;
     operation: Promise<Record<string, unknown>>;
@@ -73,10 +75,11 @@ export class SkillHubThinRpcHandler {
       ?? ((botUid) => scheduleDashboardBotSwitch(botUid, this.isShuttingDown));
     this.finalizeCurrentBotSkill = options.finalizeCurrentBotSkill
       ?? finalizeCurrentBotPublicSkillNow;
+    this.enabled = options.enabled !== false;
   }
 
   supports(toolName: string): boolean {
-    return Object.values(SKILLHUB_THIN_RPC_TOOLS).includes(toolName as any);
+    return this.enabled && Object.values(SKILLHUB_THIN_RPC_TOOLS).includes(toolName as any);
   }
 
   async execute(request: CatsThinToolRpcMessage): Promise<Record<string, unknown>> {

--- a/src/catscompany/types.ts
+++ b/src/catscompany/types.ts
@@ -1,6 +1,8 @@
 import type { ExecutionScope, MessageEnvelope, ScopedArtifactContext, ScopedDeviceGrant, ScopedDeviceSelection } from '../types/session-identity';
 import type { TargetRoutes } from '../types/tool';
 
+export type CatsCompanyRuntimeRole = 'desktop' | 'server';
+
 /**
  * CatsCo agent 连接配置
  */
@@ -19,6 +21,8 @@ export interface CatsCompanyConfig {
   ownerUserId?: string;
   /** 用户可见设备名，用于 Dashboard 展示和服务端设备选择 */
   deviceName?: string;
+  /** Runtime placement used to keep desktop-only local workspace APIs off server agents. */
+  runtimeRole?: CatsCompanyRuntimeRole;
   /** HTTP 基础地址（用于文件上传），默认从 serverUrl 推导 */
   httpBaseUrl?: string;
   /** 会话过期时间（毫秒），默认 30 分钟 */

--- a/src/dashboard/service-manager.ts
+++ b/src/dashboard/service-manager.ts
@@ -245,6 +245,11 @@ export class ServiceManager extends EventEmitter {
     }
 
     if (name === 'catscompany') {
+      // Electron explicitly marks both development and packaged desktop
+      // launches. A browser-only/server Dashboard remains fail-closed.
+      envVars.XIAOBA_RUNTIME_ROLE = process.env.XIAOBA_RUNTIME_ROLE === 'desktop'
+        ? 'desktop'
+        : 'server';
       const catsCoRuntime = resolveCatsCoRuntimeConfig({
         runtimeRoot: runtimeDataRoot,
         env: envVars,

--- a/tests/bot-skills-security.test.ts
+++ b/tests/bot-skills-security.test.ts
@@ -5,7 +5,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { canonicalizeBotSkillRefs } from '../src/bot-skills/canonical';
-import { scanLocalBotSkill } from '../src/bot-skills/local-manifest';
+import { isPortablePackagePath, scanLocalBotSkill } from '../src/bot-skills/local-manifest';
 import { BotPrivateSkillClient } from '../src/bot-skills/private-package-client';
 import type { BotSkillRef } from '../src/bot-definition/types';
 import type { BotSkillPackage } from '../src/bot-skills/types';
@@ -17,17 +17,48 @@ describe('Bot Skill sync security boundaries', () => {
     for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
   });
 
-  test('rejects archives by filename and by magic bytes before automatic upload', () => {
+  test('packages archives and binary-looking files without content-policy blocking', () => {
     const extensionRoot = createSkill(roots, 'archive-extension');
     fs.writeFileSync(path.join(extensionRoot, 'payload.tar.gz'), 'not even a real archive');
-    assert.throws(() => scanLocalBotSkill(extensionRoot), /archive file/i);
+    assert.equal(
+      scanLocalBotSkill(extensionRoot).files.some(file => file.path === 'payload.tar.gz'),
+      true,
+    );
 
     const magicRoot = createSkill(roots, 'archive-magic');
     fs.writeFileSync(
       path.join(magicRoot, 'payload.bin'),
       Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x00, 0x00]),
     );
-    assert.throws(() => scanLocalBotSkill(magicRoot), /archive file/i);
+    assert.equal(
+      scanLocalBotSkill(magicRoot).files.some(file => file.path === 'payload.bin'),
+      true,
+    );
+
+    const credentialsRoot = createSkill(roots, 'credentials-and-executable');
+    fs.mkdirSync(path.join(credentialsRoot, '.ssh'), { recursive: true });
+    fs.writeFileSync(path.join(credentialsRoot, '.ssh', 'id_rsa'), 'private-key-placeholder');
+    fs.writeFileSync(path.join(credentialsRoot, 'runner.exe'), Buffer.from([0x4d, 0x5a, 0x00, 0x01]));
+    const packagedPaths = scanLocalBotSkill(credentialsRoot).files.map(file => file.path);
+    assert.equal(packagedPaths.includes('.ssh/id_rsa'), true);
+    assert.equal(packagedPaths.includes('runner.exe'), true);
+  });
+
+  test('keeps path and package-size boundaries after removing content inspection', () => {
+    for (const unsafePath of ['../outside', '/absolute', 'C:/absolute', 'nested/../outside', 'nested//file']) {
+      assert.equal(isPortablePackagePath(unsafePath), false, unsafePath);
+    }
+    assert.equal(isPortablePackagePath('scripts/publish.mjs'), true);
+
+    const oversizedRoot = createSkill(roots, 'oversized');
+    fs.writeFileSync(path.join(oversizedRoot, 'payload.bin'), Buffer.alloc(2 * 1024 * 1024 + 1));
+    assert.throws(() => scanLocalBotSkill(oversizedRoot), /file is too large/i);
+
+    const crowdedRoot = createSkill(roots, 'crowded');
+    for (let index = 0; index < 200; index += 1) {
+      fs.writeFileSync(path.join(crowdedRoot, `file-${index}.txt`), '');
+    }
+    assert.throws(() => scanLocalBotSkill(crowdedRoot), /too many files/i);
   });
 
   test('rejects unsafe reference segments and matches Go byte/control limits', async () => {

--- a/tests/bot-skills-sync.test.ts
+++ b/tests/bot-skills-sync.test.ts
@@ -199,9 +199,8 @@ describe('Bot Skill Local/Base/Cloud sync', () => {
     const blockedBefore = baseBefore?.skills.find(entry => entry.name === 'blocked-existing');
     assert.ok(blockedBefore);
     const blockedRoot = path.join(fixture.skillsRoot, 'blocked-existing');
-    const blockedScript = path.join(blockedRoot, 'scripts', 'publish-html-directory.mjs');
-    fs.mkdirSync(path.dirname(blockedScript), { recursive: true });
-    fs.writeFileSync(blockedScript, 'const apiToken = "sk-proj-12345678901234567890";\n');
+    const blockedSkillFile = path.join(blockedRoot, 'SKILL.md');
+    fs.writeFileSync(blockedSkillFile, '---\nname: [unterminated\ndescription: Broken YAML\n---\n');
 
     writeSkill(fixture.skillsRoot, 'shared-new', 'shared-new', 'share this globally');
     const target = scanLocalBotSkill(path.join(fixture.skillsRoot, 'shared-new'));
@@ -259,7 +258,7 @@ describe('Bot Skill Local/Base/Cloud sync', () => {
 
     assert.equal(finalized.direction, 'local_to_cloud');
     assert.equal(fixture.uploads, uploadsBeforeFinalize);
-    assert.equal(fs.existsSync(blockedScript), true);
+    assert.equal(fs.existsSync(blockedSkillFile), true);
     assert.equal(fixture.cloud.skills.some(skill => (
       skill.skillId === blockedBefore.reference.skillId
       && skill.version === blockedBefore.reference.version
@@ -1360,14 +1359,14 @@ describe('Bot Skill Local/Base/Cloud sync', () => {
     assert.deepStrictEqual(fixture.cloud.skills, []);
   });
 
-  test('rejects credential files and high-confidence secrets before any upload request is built', () => {
+  test('packages credential files and secret-like text without content-policy blocking', () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-sensitive-skill-'));
     roots.push(root);
     writeSkill(root, 'unsafe', 'unsafe', 'local only');
     fs.writeFileSync(path.join(root, 'unsafe', '.env'), 'OPENAI_API_KEY=sk-proj-abcdefghijklmnopqrstuvwxyz');
-    assert.throws(
-      () => scanLocalBotSkill(path.join(root, 'unsafe')),
-      /sensitive material/i,
+    assert.equal(
+      scanLocalBotSkill(path.join(root, 'unsafe')).files.some(file => file.path === '.env'),
+      true,
     );
 
     fs.rmSync(path.join(root, 'unsafe', '.env'));
@@ -1375,13 +1374,13 @@ describe('Bot Skill Local/Base/Cloud sync', () => {
       path.join(root, 'unsafe', 'config.txt'),
       'clientSecret: a-real-secret-value-that-must-not-leave-device',
     );
-    assert.throws(
-      () => scanLocalBotSkill(path.join(root, 'unsafe')),
-      /sensitive material/i,
+    assert.equal(
+      scanLocalBotSkill(path.join(root, 'unsafe')).files.some(file => file.path === 'config.txt'),
+      true,
     );
   });
 
-  test('allows runtime credential expressions without weakening literal secret detection', () => {
+  test('does not inspect source or configuration contents for secrets', () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-runtime-credential-skill-'));
     roots.push(root);
     writeSkill(root, 'safe', 'safe', 'local only');
@@ -1508,9 +1507,8 @@ describe('Bot Skill Local/Base/Cloud sync', () => {
     ];
     for (const unsafeAssignment of unsafeAssignments) {
       fs.writeFileSync(path.join(root, 'safe', 'runtime.mjs'), `${unsafeAssignment}\n`);
-      assert.throws(
+      assert.doesNotThrow(
         () => scanLocalBotSkill(path.join(root, 'safe')),
-        /sensitive material/i,
         unsafeAssignment,
       );
     }
@@ -1522,14 +1520,14 @@ describe('Bot Skill Local/Base/Cloud sync', () => {
       ')',
       '',
     ].join('\n'));
-    assert.throws(() => scanLocalBotSkill(path.join(root, 'safe')), /sensitive material/i);
+    assert.doesNotThrow(() => scanLocalBotSkill(path.join(root, 'safe')));
     fs.rmSync(path.join(root, 'safe', 'unsafe.py'));
 
     fs.writeFileSync(
       path.join(root, 'safe', 'unsafe.py'),
       'auth_token = os.environ.get("CATSCO_USER_TOKEN"), "a-real-secret-value-that-must-not-leave-device"\n',
     );
-    assert.throws(() => scanLocalBotSkill(path.join(root, 'safe')), /sensitive material/i);
+    assert.doesNotThrow(() => scanLocalBotSkill(path.join(root, 'safe')));
     fs.rmSync(path.join(root, 'safe', 'unsafe.py'));
 
     fs.writeFileSync(path.join(root, 'safe', 'unsafe.json'), [
@@ -1540,20 +1538,20 @@ describe('Bot Skill Local/Base/Cloud sync', () => {
       '}',
       '',
     ].join('\n'));
-    assert.throws(() => scanLocalBotSkill(path.join(root, 'safe')), /sensitive material/i);
+    assert.doesNotThrow(() => scanLocalBotSkill(path.join(root, 'safe')));
     fs.rmSync(path.join(root, 'safe', 'unsafe.json'));
 
     fs.rmSync(path.join(root, 'safe', 'runtime.mjs'));
     fs.writeFileSync(path.join(root, 'safe', 'config.yaml'), 'password: password\n');
-    assert.throws(() => scanLocalBotSkill(path.join(root, 'safe')), /sensitive material/i);
+    assert.doesNotThrow(() => scanLocalBotSkill(path.join(root, 'safe')));
     fs.writeFileSync(path.join(root, 'safe', 'config.yaml'), '- password: smoke-secret\n');
-    assert.throws(() => scanLocalBotSkill(path.join(root, 'safe')), /sensitive material/i);
+    assert.doesNotThrow(() => scanLocalBotSkill(path.join(root, 'safe')));
     fs.rmSync(path.join(root, 'safe', 'config.yaml'));
     fs.writeFileSync(
       path.join(root, 'safe', 'auth.test.ts'),
       'const password = "summer-2026-admin";\n',
     );
-    assert.throws(() => scanLocalBotSkill(path.join(root, 'safe')), /sensitive material/i);
+    assert.doesNotThrow(() => scanLocalBotSkill(path.join(root, 'safe')));
   });
 
   test('restores a missing nested workspace from Cloud instead of uploading an empty list', async () => {

--- a/tests/catsco-runtime-config.test.ts
+++ b/tests/catsco-runtime-config.test.ts
@@ -4,7 +4,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { createCatsCoLocalConfigService } from '../src/catscompany/local-config';
-import { resolveCatsCoRuntimeConfig } from '../src/catscompany/runtime-config';
+import { resolveCatsCoRuntimeConfig, resolveCatsCoRuntimeRole } from '../src/catscompany/runtime-config';
 
 describe('CatsCo runtime config resolver', () => {
   let tempDir: string;
@@ -62,6 +62,7 @@ describe('CatsCo runtime config resolver', () => {
     assert.equal(resolved.connector?.apiKey, 'typed-api-key');
     assert.equal(resolved.connector?.bodyId, 'body-typed');
     assert.equal(resolved.connector?.installationId, 'install-typed');
+    assert.equal(resolved.connector?.runtimeRole, 'server');
     assert.equal(resolved.auth.token, 'env-user-token');
     assert.equal(resolved.auth.uid, 'user-typed');
     assert.equal(resolved.auth.botUid, 'bot-typed');
@@ -78,6 +79,14 @@ describe('CatsCo runtime config resolver', () => {
       assert.equal((fs.statSync(path.dirname(configPath)).mode & 0o777), 0o700);
       assert.equal((fs.statSync(configPath).mode & 0o777), 0o600);
     }
+  });
+
+  test('only an explicit desktop marker enables the desktop runtime role', () => {
+    assert.equal(resolveCatsCoRuntimeRole('desktop'), 'desktop');
+    assert.equal(resolveCatsCoRuntimeRole('DESKTOP'), 'desktop');
+    assert.equal(resolveCatsCoRuntimeRole('server'), 'server');
+    assert.equal(resolveCatsCoRuntimeRole(''), 'server');
+    assert.equal(resolveCatsCoRuntimeRole('legacy-unknown'), 'server');
   });
 
   test('ignores stale local bot binding when the active account uid changed', () => {

--- a/tests/catscompany-client-body-id.test.ts
+++ b/tests/catscompany-client-body-id.test.ts
@@ -222,6 +222,7 @@ describe('CatsCompany client body identity', () => {
         display_name: 'Test Device',
         body_id: 'body-test',
         installation_id: 'install-test',
+        runtime_role: 'desktop',
         status: 'online',
         capabilities: ['read_file'],
       },
@@ -237,6 +238,7 @@ describe('CatsCompany client body identity', () => {
       display_name: 'Test Device',
       body_id: 'body-test',
       installation_id: 'install-test',
+      runtime_role: 'desktop',
       status: 'online',
       capabilities: ['read_file'],
     });
@@ -270,6 +272,7 @@ describe('CatsCompany client body identity', () => {
             display_name: 'Test Device',
             body_id: 'body-test',
             installation_id: 'install-test',
+            runtime_role: 'server',
             status: 'online',
             capabilities: ['read_file', 'send_file'],
             model_status: {
@@ -292,6 +295,7 @@ describe('CatsCompany client body identity', () => {
       display_name: 'Test Device',
       body_id: 'body-test',
       installation_id: 'install-test',
+      runtime_role: 'server',
       status: 'online',
       capabilities: ['read_file', 'send_file'],
       model_status: {

--- a/tests/catscompany-runtime-device-capabilities.test.ts
+++ b/tests/catscompany-runtime-device-capabilities.test.ts
@@ -1,10 +1,14 @@
 import { describe, test } from 'node:test';
 import * as assert from 'node:assert';
-import { CATSCOMPANY_FULL_RUNTIME_DEVICE_CAPABILITIES } from '../src/catscompany';
+import {
+  capabilitiesForCatsCompanyRuntimeRole,
+  CATSCOMPANY_DESKTOP_RUNTIME_DEVICE_CAPABILITIES,
+  CATSCOMPANY_SERVER_RUNTIME_DEVICE_CAPABILITIES,
+} from '../src/catscompany';
 
 describe('CatsCompany runtime device capabilities', () => {
-  test('full runtime advertises local owner self capabilities', () => {
-    assert.deepEqual(CATSCOMPANY_FULL_RUNTIME_DEVICE_CAPABILITIES, [
+  test('desktop runtime advertises local owner and SkillHub workspace capabilities', () => {
+    assert.deepEqual(CATSCOMPANY_DESKTOP_RUNTIME_DEVICE_CAPABILITIES, [
       'read_file',
       'resolve_common_directory',
       'glob',
@@ -18,5 +22,26 @@ describe('CatsCompany runtime device capabilities', () => {
       'skillhub.localSkill.finalize',
       'skillhub.localBot.switch',
     ]);
+    assert.deepEqual(
+      capabilitiesForCatsCompanyRuntimeRole('desktop'),
+      CATSCOMPANY_DESKTOP_RUNTIME_DEVICE_CAPABILITIES,
+    );
+  });
+
+  test('server runtime never advertises desktop SkillHub workspace capabilities', () => {
+    assert.deepEqual(CATSCOMPANY_SERVER_RUNTIME_DEVICE_CAPABILITIES, [
+      'read_file',
+      'resolve_common_directory',
+      'glob',
+      'grep',
+      'write_file',
+      'edit_file',
+      'send_file',
+      'execute_shell',
+    ]);
+    assert.equal(
+      capabilitiesForCatsCompanyRuntimeRole('server').some(capability => capability.startsWith('skillhub.')),
+      false,
+    );
   });
 });

--- a/tests/catscompany-skillhub-rpc.test.ts
+++ b/tests/catscompany-skillhub-rpc.test.ts
@@ -68,6 +68,13 @@ describe('CatsCompany SkillHub thin RPC', () => {
     fs.rmSync(runtimeRoot, { recursive: true, force: true });
   });
 
+  test('can be disabled for server runtimes', () => {
+    const serverHandler = new SkillHubThinRpcHandler({ runtimeRoot, enabled: false });
+    for (const toolName of Object.values(SKILLHUB_THIN_RPC_TOOLS)) {
+      assert.equal(serverHandler.supports(toolName), false);
+    }
+  });
+
   test('returns only bounded metadata for the active Bot workspace', async () => {
     const result = await handler.execute(request({
       request_id: 'workspace-1',
@@ -84,7 +91,7 @@ describe('CatsCompany SkillHub thin RPC', () => {
     assert.equal(JSON.stringify(result).includes('# Local Demo'), false);
   });
 
-  test('keeps local Skills visible when one package cannot be shared', async () => {
+  test('keeps credential-bearing local Skills visible and shareable', async () => {
     const blockedRoot = path.join(runtimeRoot, 'skills', 'blocked-demo');
     fs.mkdirSync(blockedRoot, { recursive: true });
     fs.writeFileSync(path.join(blockedRoot, 'SKILL.md'), [
@@ -113,8 +120,8 @@ describe('CatsCompany SkillHub thin RPC', () => {
     assert.equal(skills.find(skill => skill.name === 'local-demo')?.can_share, true);
     assert.equal(skills.find(skill => skill.name === 'nested-demo')?.can_share, true);
     const blocked = skills.find(skill => skill.name === 'blocked-demo');
-    assert.equal(blocked?.can_share, false);
-    assert.match(String(blocked?.share_error || ''), /sensitive material/i);
+    assert.equal(blocked?.can_share, true);
+    assert.equal(Object.prototype.hasOwnProperty.call(blocked || {}, 'share_error'), false);
   });
 
   test('keeps invalid SKILL.md entries visible but disables sharing with an actionable error', async () => {
@@ -305,7 +312,12 @@ describe('CatsCompany SkillHub thin RPC', () => {
         schema: 'xiaoba.bot-skill-local.v1',
         localSkillId: fixture.localSkillId,
       });
-      if (fixture.blocked) fs.writeFileSync(path.join(skillRoot, '.env'), 'API_KEY=blocked\n');
+      if (fixture.blocked) {
+        fs.writeFileSync(
+          path.join(skillRoot, 'SKILL.md'),
+          '---\nname: [unterminated\ndescription: Broken YAML\n---\n',
+        );
+      }
     }
 
     const result = await handler.execute(request({ request_id: 'workspace-canonical-order' }));
@@ -923,8 +935,7 @@ describe('CatsCompany SkillHub thin RPC', () => {
     );
   });
 
-  test('rejects sensitive files that appear after the initial share scope check', async () => {
-    const selected = scanBotSkillWorkspace(path.join(runtimeRoot, 'skills'))[0];
+  test('uploads arbitrary files without content-policy blocking', async () => {
     const sensitiveFiles = [
       { name: '.env', content: 'API_KEY=not-a-real-secret\n' },
       { name: 'private.pem', content: '-----BEGIN PRIVATE KEY-----\nplaceholder\n' },
@@ -933,13 +944,17 @@ describe('CatsCompany SkillHub thin RPC', () => {
     ];
 
     for (const sensitiveFile of sensitiveFiles) {
-      const sensitivePath = path.join(selected.path, sensitiveFile.name);
+      const skillPath = path.join(runtimeRoot, 'skills', 'local-demo');
+      const sensitivePath = path.join(skillPath, sensitiveFile.name);
+      fs.writeFileSync(sensitivePath, sensitiveFile.content);
+      const selected = scanBotSkillWorkspace(path.join(runtimeRoot, 'skills'))
+        .find(entry => entry.path === skillPath);
+      assert.ok(selected);
       const originalFetch = global.fetch;
       let shareCalls = 0;
       global.fetch = async (input: string | URL | Request, init?: RequestInit) => {
         const url = new URL(String(input));
         if (url.pathname === '/api/auth/catsco-exchange') {
-          fs.writeFileSync(sensitivePath, sensitiveFile.content);
           return Response.json({
             user: { id: 'skillhub-user' },
             roles: ['developer'],
@@ -956,13 +971,29 @@ describe('CatsCompany SkillHub thin RPC', () => {
         }
         if (url.pathname === '/api/skills/share') {
           shareCalls += 1;
-          return Response.json({ error: 'share should not be reached' }, { status: 500 });
+          const body = JSON.parse(String(init?.body || '{}'));
+          assert.equal(
+            body.source.files.some((file: any) => file.path === sensitiveFile.name),
+            true,
+          );
+          return Response.json({
+            skillId: 'alice/local-demo',
+            packageVersion: {
+              skillId: 'alice/local-demo',
+              version: '1.0.0',
+              contentHash: 'c'.repeat(64),
+            },
+            skillHub: {
+              author: 'alice',
+              version: '1.0.0',
+              uploadedAt: '2026-08-06T00:00:00.000Z',
+            },
+          }, { status: 201 });
         }
         return Response.json({ error: `unexpected request: ${url.pathname}` }, { status: 500 });
       };
       try {
-        await assert.rejects(
-          shareLocalSkillForCatsCo({
+        await shareLocalSkillForCatsCo({
             skillName: selected.name,
             expectedLocalSkillId: selected.localSkillId,
             expectedBotUid: '42',
@@ -975,14 +1006,12 @@ describe('CatsCompany SkillHub thin RPC', () => {
               baseUrl: 'https://app.catsco.cc',
               user: { uid: '7', username: 'alice' },
             }),
-          }),
-          /(?:sensitive material|archive file)/i,
-        );
+          });
       } finally {
         global.fetch = originalFetch;
         fs.rmSync(sensitivePath, { force: true });
       }
-      assert.equal(shareCalls, 0, `remote share was called for ${sensitiveFile.name}`);
+      assert.equal(shareCalls, 1, `remote share was called once for ${sensitiveFile.name}`);
     }
   });
 

--- a/tests/dashboard-service-manager.test.ts
+++ b/tests/dashboard-service-manager.test.ts
@@ -149,24 +149,55 @@ describe('dashboard service manager', () => {
     assert.equal((service?.lastError || '').includes('sk-live-secret1234567890'), false);
   });
 
-  test('passes the dashboard owner pid to the CatsCo connector process', async () => {
+  test('marks dashboard-owned CatsCo connectors as desktop runtimes', async () => {
+    const previousRuntimeRole = process.env.XIAOBA_RUNTIME_ROLE;
+    process.env.XIAOBA_RUNTIME_ROLE = 'desktop';
     const manager = new ServiceManager(process.cwd());
     const serviceRecord = (manager as any).services.get('catscompany');
     serviceRecord.info.command = process.execPath;
     serviceRecord.info.args = [
       '-e',
-      "console.log('owner=' + process.env.CATSCO_CONNECTOR_OWNER_PID);",
+      "console.log('owner=' + process.env.CATSCO_CONNECTOR_OWNER_PID + ';role=' + process.env.XIAOBA_RUNTIME_ROLE);",
     ];
 
     const stopped = new Promise<void>(resolve => {
       manager.once('service-stopped', () => resolve());
     });
 
-    manager.start('catscompany');
-    await stopped;
+    try {
+      manager.start('catscompany');
+      await stopped;
 
-    assert.ok(manager.getLogs('catscompany').includes(`owner=${process.pid}`));
-    assert.equal(manager.getService('catscompany')?.status, 'stopped');
+      assert.ok(manager.getLogs('catscompany').includes(`owner=${process.pid};role=desktop`));
+      assert.equal(manager.getService('catscompany')?.status, 'stopped');
+    } finally {
+      if (previousRuntimeRole === undefined) delete process.env.XIAOBA_RUNTIME_ROLE;
+      else process.env.XIAOBA_RUNTIME_ROLE = previousRuntimeRole;
+    }
+  });
+
+  test('keeps browser-only or unknown Dashboard connectors in the server role', async () => {
+    const previousRuntimeRole = process.env.XIAOBA_RUNTIME_ROLE;
+    delete process.env.XIAOBA_RUNTIME_ROLE;
+    const manager = new ServiceManager(process.cwd());
+    const serviceRecord = (manager as any).services.get('catscompany');
+    serviceRecord.info.command = process.execPath;
+    serviceRecord.info.args = [
+      '-e',
+      "console.log('role=' + process.env.XIAOBA_RUNTIME_ROLE);",
+    ];
+    const stopped = new Promise<void>(resolve => {
+      manager.once('service-stopped', () => resolve());
+    });
+
+    try {
+      manager.start('catscompany');
+      await stopped;
+      assert.ok(manager.getLogs('catscompany').includes('role=server'));
+    } finally {
+      if (previousRuntimeRole === undefined) delete process.env.XIAOBA_RUNTIME_ROLE;
+      else process.env.XIAOBA_RUNTIME_ROLE = previousRuntimeRole;
+    }
   });
 
   test('passes separate runtime data and bundled executable directories to the child', async () => {

--- a/tests/dashboard-skillhub-connected-api.test.ts
+++ b/tests/dashboard-skillhub-connected-api.test.ts
@@ -176,7 +176,7 @@ describe('dashboard connected SkillHub API', () => {
     assert.match(skillText, /skillhub_uploaded_at:/);
   });
 
-  test('rejects a sensitive local package before calling the SkillHub share endpoint', async () => {
+  test('shares a local package containing credential-like files', async () => {
     const skillRoot = path.join(testRoot, 'skills', 'unsafe-demo');
     fs.mkdirSync(skillRoot, { recursive: true });
     fs.writeFileSync(path.join(skillRoot, 'SKILL.md'), [
@@ -197,9 +197,12 @@ describe('dashboard connected SkillHub API', () => {
 
     await post('/api/skillhub/auth/login', { email: 'demo@example.com', password: 'passw0rd!!' });
     const share = await post('/api/skillhub/share-local-skill', { skillName: 'unsafe-demo' });
-    assert.equal(share.status, 400);
-    assert.equal(share.body.code, 'skillhub.local_skill_unsafe_package');
-    assert.match(share.body.error, /sensitive material/i);
+    assert.equal(share.status, 201);
+    assert.equal(share.body.ok, true);
+    assert.equal(
+      share.body.submission.request.source.files.some((file: any) => file.path === '.env'),
+      true,
+    );
   });
 
   test('connects SkillHub with the current CatsCo login token', async () => {


### PR DESCRIPTION
## 背景

当前本地 Skill 分享有两个问题：

1. `.env`、凭据文本、压缩包或二进制会在 XiaoBa 本地打包阶段被拦截，导致 WebApp 无法发布。
2. 桌面 XiaoBa 和服务器 Bot runtime 声明了同一组 SkillHub 本地工作区能力，WebApp 可能把服务器 runtime 误认为用户电脑，随后触发账号或 Bot 工作区不匹配。

## 改动

### 允许任意 Skill 内容上传

- 本地打包不再检查敏感内容、凭据文件、归档或二进制类型。
- 保留 `SKILL.md`、安全相对路径、目录逃逸、符号链接、Base64/哈希、文件数和容量限制。
- 保留分享前后的内容哈希一致性检查，上传过程中发生修改仍会停止。

### 明确运行时角色

- 设备注册新增 `runtime_role: desktop | server`。
- Electron 开发版和打包版由 `electron/main.js` 明确标记为 `desktop`。
- 浏览器 Dashboard、直接 CLI、服务器 runtime 和未知启动方式默认标记为 `server`。
- 只有 `desktop` 声明并执行四项 SkillHub 本地工作区 RPC。
- `server` 不再暴露这些能力。

## 影响

WebApp 能识别真正运行在用户电脑上的 XiaoBa，不再把云端 Bot runtime 当成本地 Skills 工作区。旧版本 XiaoBa 不会上报 `runtime_role`，需更新并重启后才能被新版 WebApp 识别。

## 验证

- `npm run build`
- 相关 8 组回归测试：120/120
- 跨仓 BotDefinition Skills 契约测试：41/41
- `git diff --check`

全量 runtime 测试中的 8 个失败来自当前 Windows 环境缺少 `jq`、`pwsh` 和云镜像脚本依赖，与本次改动无关。