### PR TITLE
feat(skillhub): report runtime skill inventory

### DIFF
--- a/src/bot-skills/runtime-inventory.ts
+++ b/src/bot-skills/runtime-inventory.ts
@@ -15,11 +15,13 @@ export interface BotRuntimeSkillInventoryEntry {
   description: string;
   relativePath: string;
   userInvocable: boolean;
-  contentHash?: string;
+  /** SHA-256 of this loaded SKILL.md file, not the SkillHub package checksum. */
+  fileHash?: string;
   skillHub?: {
     skillId: string;
     version: string;
-    contentHash?: string;
+    /** SHA-256 of the installed SkillHub package. */
+    packageChecksumSha256?: string;
   };
 }
 
@@ -27,6 +29,8 @@ export interface BotRuntimeSkillInventory {
   schema: typeof BOT_RUNTIME_SKILL_INVENTORY_SCHEMA;
   botId: string;
   observedAt: string;
+  runtimeInstanceId?: string;
+  reportSequence?: number;
   skills: BotRuntimeSkillInventoryEntry[];
   truncated?: boolean;
 }
@@ -103,7 +107,7 @@ function createRuntimeSkillInventoryEntry(skill: Skill, skillsRoot: string): Bot
     ? {
         skillId: marker.skillId,
         version: marker.version,
-        contentHash: marker.packageChecksumSha256.toLowerCase(),
+        packageChecksumSha256: marker.packageChecksumSha256.toLowerCase(),
       }
     : undefined;
   return {
@@ -111,7 +115,7 @@ function createRuntimeSkillInventoryEntry(skill: Skill, skillsRoot: string): Bot
     description: String(skill.metadata.description || '').trim(),
     relativePath,
     userInvocable: skill.metadata.userInvocable !== false,
-    ...(contentHash ? { contentHash } : {}),
+    ...(contentHash ? { fileHash: contentHash } : {}),
     ...(skillHubReference ? { skillHub: skillHubReference } : {}),
   };
 }

--- a/src/bot-skills/runtime-inventory.ts
+++ b/src/bot-skills/runtime-inventory.ts
@@ -9,6 +9,15 @@ import { readSkillHubInstallMarker } from '../skillhub/install-marker';
 export const BOT_RUNTIME_SKILL_INVENTORY_SCHEMA = 'xiaoba.bot-runtime-skills.v1';
 const INVENTORY_REQUEST_TIMEOUT_MS = 10_000;
 const MAX_RUNTIME_SKILL_INVENTORY_ENTRIES = 256;
+/** Keep headroom below CatsCo's request limit for proxies and future fields. */
+export const MAX_RUNTIME_SKILL_INVENTORY_BYTES = 120 << 10;
+const MAX_RUNTIME_SKILL_FILE_HASH_BYTES = 4 << 20;
+const MAX_RUNTIME_SKILL_NAME_BYTES = 240;
+const MAX_RUNTIME_SKILL_DESCRIPTION_BYTES = 4 << 10;
+const MAX_RUNTIME_SKILL_PATH_BYTES = 512;
+const MAX_RUNTIME_SKILL_ID_BYTES = 240;
+const MAX_RUNTIME_SKILL_VERSION_BYTES = 120;
+const MAX_RUNTIME_SKILL_RUNTIME_INSTANCE_ID_BYTES = 128;
 
 export interface BotRuntimeSkillInventoryEntry {
   name: string;
@@ -25,6 +34,25 @@ export interface BotRuntimeSkillInventoryEntry {
   };
 }
 
+interface LegacyBotRuntimeSkillInventory {
+  schema: typeof BOT_RUNTIME_SKILL_INVENTORY_SCHEMA;
+  botId: string;
+  observedAt: string;
+  skills: Array<{
+    name: string;
+    description: string;
+    relativePath: string;
+    userInvocable: boolean;
+    contentHash?: string;
+    skillHub?: {
+      skillId: string;
+      version: string;
+      contentHash?: string;
+    };
+  }>;
+  truncated?: boolean;
+}
+
 export interface BotRuntimeSkillInventory {
   schema: typeof BOT_RUNTIME_SKILL_INVENTORY_SCHEMA;
   botId: string;
@@ -33,6 +61,11 @@ export interface BotRuntimeSkillInventory {
   reportSequence?: number;
   skills: BotRuntimeSkillInventoryEntry[];
   truncated?: boolean;
+}
+
+export interface BotRuntimeSkillInventoryRuntimeMetadata {
+  runtimeInstanceId?: string;
+  reportSequence?: number;
 }
 
 export interface ReportBotRuntimeSkillInventoryOptions {
@@ -44,21 +77,65 @@ export interface ReportBotRuntimeSkillInventoryOptions {
   fetchImpl?: typeof fetch;
 }
 
-export function createBotRuntimeSkillInventory(
+export async function createBotRuntimeSkillInventory(
   botId: string,
   skills: readonly Skill[],
   now: () => Date = () => new Date(),
-): BotRuntimeSkillInventory {
+  runtime: BotRuntimeSkillInventoryRuntimeMetadata = {},
+): Promise<BotRuntimeSkillInventory> {
   const skillsRoot = path.resolve(PathResolver.getSkillsPath());
-  const allEntries = skills.map((skill) => createRuntimeSkillInventoryEntry(skill, skillsRoot))
-    .sort((left, right) => left.name.localeCompare(right.name));
-  const entries = allEntries.slice(0, MAX_RUNTIME_SKILL_INVENTORY_ENTRIES);
-  return {
+  const runtimeInstanceId = String(runtime.runtimeInstanceId || '').trim();
+  const reportSequence = Number(runtime.reportSequence || 0);
+  const validRuntimeInstanceId = validRuntimeText(
+    runtimeInstanceId,
+    MAX_RUNTIME_SKILL_RUNTIME_INSTANCE_ID_BYTES,
+    false,
+  );
+  const sortedSkills = [...skills].sort((left, right) => (
+    String(left.metadata.name || '').trim().localeCompare(String(right.metadata.name || '').trim())
+  ));
+  const allEntries: Array<{ entry: BotRuntimeSkillInventoryEntry; degraded: boolean }> = [];
+  for (const skill of sortedSkills.slice(0, MAX_RUNTIME_SKILL_INVENTORY_ENTRIES)) {
+    const entry = await createRuntimeSkillInventoryEntry(skill, skillsRoot);
+    if (entry) allEntries.push(entry);
+  }
+  allEntries.sort((left, right) => left.entry.name.localeCompare(right.entry.name));
+
+  const base: Omit<BotRuntimeSkillInventory, 'skills' | 'truncated'> = {
     schema: BOT_RUNTIME_SKILL_INVENTORY_SCHEMA,
     botId: String(botId || '').trim(),
     observedAt: now().toISOString(),
+    ...(validRuntimeInstanceId
+      ? { runtimeInstanceId }
+      : {}),
+    ...(Number.isSafeInteger(reportSequence) && reportSequence > 0 && validRuntimeInstanceId
+      ? { reportSequence }
+      : {}),
+  };
+  const entries: BotRuntimeSkillInventoryEntry[] = [];
+  let truncated = sortedSkills.length > MAX_RUNTIME_SKILL_INVENTORY_ENTRIES
+    || allEntries.length !== Math.min(sortedSkills.length, MAX_RUNTIME_SKILL_INVENTORY_ENTRIES);
+  for (const { entry: candidate, degraded } of allEntries.slice(0, MAX_RUNTIME_SKILL_INVENTORY_ENTRIES)) {
+    const fitted = fitRuntimeSkillInventoryEntry(base, entries, candidate);
+    if (!fitted) {
+      truncated = true;
+      continue;
+    }
+    if (degraded || JSON.stringify(fitted) !== JSON.stringify(candidate)) truncated = true;
+    entries.push(fitted);
+  }
+
+  // The fitting loop reserves the truncation marker. Keep this defensive
+  // guard in case the envelope changes later.
+  while (serializedInventoryBytes({ ...base, skills: entries, ...(truncated ? { truncated: true } : {}) }) > MAX_RUNTIME_SKILL_INVENTORY_BYTES) {
+    if (entries.length === 0) break;
+    entries.pop();
+    truncated = true;
+  }
+  return {
+    ...base,
     skills: entries,
-    ...(allEntries.length > entries.length ? { truncated: true } : {}),
+    ...(truncated ? { truncated: true } : {}),
   };
 }
 
@@ -71,21 +148,29 @@ export async function reportBotRuntimeSkillInventory(
   if (!botId || !apiKey || !httpBaseUrl) return false;
 
   const inventory = options.inventory ?? createBotRuntimeSkillInventory(botId, options.skills, options.now);
+  const resolvedInventory = await inventory;
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), INVENTORY_REQUEST_TIMEOUT_MS);
   try {
-    const response = await (options.fetchImpl ?? fetch)(`${httpBaseUrl}/api/bot/skills/inventory`, {
+    const send = (body: unknown) => (options.fetchImpl ?? fetch)(`${httpBaseUrl}/api/bot/skills/inventory`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         Authorization: `ApiKey ${apiKey}`,
       },
-      body: JSON.stringify(inventory),
+      body: JSON.stringify(body),
       signal: controller.signal,
     });
+    let response = await send(resolvedInventory);
     // Older CatsCo deployments intentionally remain compatible until their
     // server is upgraded. Other failures are caller-observable for logging.
     if ([404, 405, 501].includes(response.status)) return false;
+    if (response.status === 400 || response.status === 422) {
+      // The first v1 server used contentHash and did not know the runtime
+      // instance/sequence fields. Retry once with that exact legacy shape.
+      response = await send(toLegacyRuntimeSkillInventory(resolvedInventory));
+      if ([404, 405, 501].includes(response.status)) return false;
+    }
     if (!response.ok) {
       throw new Error(`CatsCo runtime Skill inventory request failed: ${response.status}`);
     }
@@ -95,29 +180,40 @@ export async function reportBotRuntimeSkillInventory(
   }
 }
 
-function createRuntimeSkillInventoryEntry(skill: Skill, skillsRoot: string): BotRuntimeSkillInventoryEntry {
+async function createRuntimeSkillInventoryEntry(
+  skill: Skill,
+  skillsRoot: string,
+): Promise<{ entry: BotRuntimeSkillInventoryEntry; degraded: boolean } | undefined> {
   const skillFile = path.resolve(skill.filePath);
   const relativePath = relativePathInside(skillsRoot, skillFile);
+  const name = String(skill.metadata.name || '').trim();
+  if (!validRuntimeText(name, MAX_RUNTIME_SKILL_NAME_BYTES, false)
+    || !validRuntimeRelativePath(relativePath)) return undefined;
   const skillDir = path.dirname(skillFile);
   const marker = readSkillHubInstallMarker(skillDir);
-  const contentHash = fileSHA256(skillFile);
+  const fileHash = await fileSHA256(skillFile);
+  const skillHubID = String(marker?.skillId || '').trim();
+  const skillHubVersion = String(marker?.version || '').trim();
+  const packageChecksumSha256 = String(marker?.packageChecksumSha256 || '').trim().toLowerCase();
   const skillHubReference = marker
-    && isValidSkillHubReference(marker.skillId, marker.version)
-    && /^[a-f0-9]{64}$/.test(String(marker.packageChecksumSha256 || '').toLowerCase())
+    && isValidSkillHubReference(skillHubID, skillHubVersion)
+    && /^[a-f0-9]{64}$/.test(packageChecksumSha256)
     ? {
-        skillId: marker.skillId,
-        version: marker.version,
-        packageChecksumSha256: marker.packageChecksumSha256.toLowerCase(),
+        skillId: skillHubID,
+        version: skillHubVersion,
+        packageChecksumSha256,
       }
     : undefined;
-  return {
-    name: String(skill.metadata.name || '').trim(),
-    description: String(skill.metadata.description || '').trim(),
+  const originalDescription = sanitizeRuntimeDescription(String(skill.metadata.description || '').trim());
+  const description = truncateUtf8(originalDescription, MAX_RUNTIME_SKILL_DESCRIPTION_BYTES);
+  return { entry: {
+    name,
+    description,
     relativePath,
     userInvocable: skill.metadata.userInvocable !== false,
-    ...(contentHash ? { fileHash: contentHash } : {}),
+    ...(fileHash.value ? { fileHash: fileHash.value } : {}),
     ...(skillHubReference ? { skillHub: skillHubReference } : {}),
-  };
+  }, degraded: description !== originalDescription || Boolean(fileHash.exceededLimit) };
 }
 
 function isValidSkillHubReference(skillId: string, version: string): boolean {
@@ -127,11 +223,15 @@ function isValidSkillHubReference(skillId: string, version: string): boolean {
     normalizedID
     && normalizedVersion
     && !normalizedID.split('/').some(part => !part || part === '.' || part === '..')
+    && Buffer.byteLength(normalizedID, 'utf8') <= MAX_RUNTIME_SKILL_ID_BYTES
+    && Buffer.byteLength(normalizedVersion, 'utf8') <= MAX_RUNTIME_SKILL_VERSION_BYTES
     && !normalizedID.includes('\\')
+    && !normalizedVersion.includes('/')
+    && !normalizedVersion.includes('\\')
     && normalizedVersion !== '.'
     && normalizedVersion !== '..'
-    && !/[\u0000-\u001f\u007f]/.test(normalizedID)
-    && !/[\u0000-\u001f\u007f]/.test(normalizedVersion),
+    && !/\p{Cc}/u.test(normalizedID)
+    && !/\p{Cc}/u.test(normalizedVersion),
   );
 }
 
@@ -145,10 +245,133 @@ function relativePathInside(root: string, candidate: string): string {
   return relative;
 }
 
-function fileSHA256(filePath: string): string | undefined {
+function validRuntimeText(value: string, maxBytes: number, allowEmpty: boolean): boolean {
+  return (allowEmpty || value.length > 0)
+    && Buffer.byteLength(value, 'utf8') <= maxBytes
+    && !/\p{Cc}/u.test(value);
+}
+
+function sanitizeRuntimeDescription(value: string): string {
+  return value.replace(/\p{Cc}/gu, ' ').replace(/\s+/g, ' ').trim();
+}
+
+function validRuntimeRelativePath(value: string): boolean {
+  if (!validRuntimeText(value, MAX_RUNTIME_SKILL_PATH_BYTES, false)
+    || value.startsWith('/')
+    || value.includes('\\')
+    || path.posix.isAbsolute(value)
+    || /^[A-Za-z]:/.test(value)) return false;
+  return value.split('/').every((part) => part && part !== '.' && part !== '..');
+}
+
+function truncateUtf8(value: string, maxBytes: number): string {
+  if (Buffer.byteLength(value, 'utf8') <= maxBytes) return value;
+  let length = 0;
+  let result = '';
+  for (const character of value) {
+    const characterBytes = Buffer.byteLength(character, 'utf8');
+    if (length + characterBytes > maxBytes) break;
+    result += character;
+    length += characterBytes;
+  }
+  return result;
+}
+
+function serializedInventoryBytes(value: unknown): number {
+  return Buffer.byteLength(JSON.stringify(value), 'utf8');
+}
+
+function fitRuntimeSkillInventoryEntry(
+  base: Omit<BotRuntimeSkillInventory, 'skills' | 'truncated'>,
+  existing: BotRuntimeSkillInventoryEntry[],
+  candidate: BotRuntimeSkillInventoryEntry,
+): BotRuntimeSkillInventoryEntry | undefined {
+  const variants = [
+    candidate,
+    withoutPackageChecksum(candidate),
+    withoutFileHash(candidate),
+    withoutFileHash(withoutPackageChecksum(candidate)),
+  ];
+  for (const variant of variants) {
+    if (serializedInventoryBytes({ ...base, skills: [...existing, variant], truncated: true }) <= MAX_RUNTIME_SKILL_INVENTORY_BYTES) {
+      return variant;
+    }
+  }
+  for (const variant of variants) {
+    const descriptionBytes = Buffer.byteLength(variant.description, 'utf8');
+    let low = 0;
+    let high = descriptionBytes;
+    let best: BotRuntimeSkillInventoryEntry | undefined;
+    while (low <= high) {
+      const middle = Math.floor((low + high) / 2);
+      const fitted = { ...variant, description: truncateUtf8(variant.description, middle) };
+      if (serializedInventoryBytes({ ...base, skills: [...existing, fitted], truncated: true }) <= MAX_RUNTIME_SKILL_INVENTORY_BYTES) {
+        best = fitted;
+        low = middle + 1;
+      } else {
+        high = middle - 1;
+      }
+    }
+    if (best) return best;
+  }
+  return undefined;
+}
+
+function withoutPackageChecksum(entry: BotRuntimeSkillInventoryEntry): BotRuntimeSkillInventoryEntry {
+  if (!entry.skillHub?.packageChecksumSha256) return entry;
+  const { packageChecksumSha256: _checksum, ...skillHub } = entry.skillHub;
+  return { ...entry, skillHub };
+}
+
+function withoutFileHash(entry: BotRuntimeSkillInventoryEntry): BotRuntimeSkillInventoryEntry {
+  if (!entry.fileHash) return entry;
+  const { fileHash: _fileHash, ...rest } = entry;
+  return rest;
+}
+
+function toLegacyRuntimeSkillInventory(inventory: BotRuntimeSkillInventory): LegacyBotRuntimeSkillInventory {
+  return {
+    schema: inventory.schema,
+    botId: inventory.botId,
+    observedAt: inventory.observedAt,
+    skills: inventory.skills.map((entry) => ({
+      name: entry.name,
+      description: entry.description,
+      relativePath: entry.relativePath,
+      userInvocable: entry.userInvocable,
+      ...(entry.fileHash ? { contentHash: entry.fileHash } : {}),
+      ...(entry.skillHub ? {
+        skillHub: {
+          skillId: entry.skillHub.skillId,
+          version: entry.skillHub.version,
+          ...(entry.skillHub.packageChecksumSha256
+            ? { contentHash: entry.skillHub.packageChecksumSha256 }
+            : {}),
+        },
+      } : {}),
+    })),
+    ...(inventory.truncated ? { truncated: true } : {}),
+  };
+}
+
+async function fileSHA256(filePath: string): Promise<{ value?: string; exceededLimit?: boolean }> {
+  let stream: fs.ReadStream | undefined;
+  let bytesRead = 0;
   try {
-    return crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+    const hash = crypto.createHash('sha256');
+    stream = fs.createReadStream(filePath);
+    for await (const chunk of stream) {
+      const buffer = chunk as Buffer;
+      bytesRead += buffer.length;
+      if (bytesRead > MAX_RUNTIME_SKILL_FILE_HASH_BYTES) {
+        stream.destroy();
+        return { exceededLimit: true };
+      }
+      hash.update(buffer);
+    }
+    return { value: hash.digest('hex') };
   } catch {
-    return undefined;
+    stream?.destroy();
+    return {};
   }
 }

--- a/src/bot-skills/runtime-inventory.ts
+++ b/src/bot-skills/runtime-inventory.ts
@@ -1,0 +1,150 @@
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { CatsCoAuthSnapshot } from '../catscompany/local-config';
+import type { Skill } from '../types/skill';
+import { PathResolver } from '../utils/path-resolver';
+import { readSkillHubInstallMarker } from '../skillhub/install-marker';
+
+export const BOT_RUNTIME_SKILL_INVENTORY_SCHEMA = 'xiaoba.bot-runtime-skills.v1';
+const INVENTORY_REQUEST_TIMEOUT_MS = 10_000;
+const MAX_RUNTIME_SKILL_INVENTORY_ENTRIES = 256;
+
+export interface BotRuntimeSkillInventoryEntry {
+  name: string;
+  description: string;
+  relativePath: string;
+  userInvocable: boolean;
+  contentHash?: string;
+  skillHub?: {
+    skillId: string;
+    version: string;
+    contentHash?: string;
+  };
+}
+
+export interface BotRuntimeSkillInventory {
+  schema: typeof BOT_RUNTIME_SKILL_INVENTORY_SCHEMA;
+  botId: string;
+  observedAt: string;
+  skills: BotRuntimeSkillInventoryEntry[];
+  truncated?: boolean;
+}
+
+export interface ReportBotRuntimeSkillInventoryOptions {
+  botId: string;
+  auth: Pick<CatsCoAuthSnapshot, 'apiKey' | 'httpBaseUrl'>;
+  skills: readonly Skill[];
+  inventory?: BotRuntimeSkillInventory;
+  now?: () => Date;
+  fetchImpl?: typeof fetch;
+}
+
+export function createBotRuntimeSkillInventory(
+  botId: string,
+  skills: readonly Skill[],
+  now: () => Date = () => new Date(),
+): BotRuntimeSkillInventory {
+  const skillsRoot = path.resolve(PathResolver.getSkillsPath());
+  const allEntries = skills.map((skill) => createRuntimeSkillInventoryEntry(skill, skillsRoot))
+    .sort((left, right) => left.name.localeCompare(right.name));
+  const entries = allEntries.slice(0, MAX_RUNTIME_SKILL_INVENTORY_ENTRIES);
+  return {
+    schema: BOT_RUNTIME_SKILL_INVENTORY_SCHEMA,
+    botId: String(botId || '').trim(),
+    observedAt: now().toISOString(),
+    skills: entries,
+    ...(allEntries.length > entries.length ? { truncated: true } : {}),
+  };
+}
+
+export async function reportBotRuntimeSkillInventory(
+  options: ReportBotRuntimeSkillInventoryOptions,
+): Promise<boolean> {
+  const botId = String(options.botId || '').trim();
+  const apiKey = String(options.auth.apiKey || '').trim();
+  const httpBaseUrl = String(options.auth.httpBaseUrl || '').trim().replace(/\/+$/, '');
+  if (!botId || !apiKey || !httpBaseUrl) return false;
+
+  const inventory = options.inventory ?? createBotRuntimeSkillInventory(botId, options.skills, options.now);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), INVENTORY_REQUEST_TIMEOUT_MS);
+  try {
+    const response = await (options.fetchImpl ?? fetch)(`${httpBaseUrl}/api/bot/skills/inventory`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `ApiKey ${apiKey}`,
+      },
+      body: JSON.stringify(inventory),
+      signal: controller.signal,
+    });
+    // Older CatsCo deployments intentionally remain compatible until their
+    // server is upgraded. Other failures are caller-observable for logging.
+    if ([404, 405, 501].includes(response.status)) return false;
+    if (!response.ok) {
+      throw new Error(`CatsCo runtime Skill inventory request failed: ${response.status}`);
+    }
+    return true;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function createRuntimeSkillInventoryEntry(skill: Skill, skillsRoot: string): BotRuntimeSkillInventoryEntry {
+  const skillFile = path.resolve(skill.filePath);
+  const relativePath = relativePathInside(skillsRoot, skillFile);
+  const skillDir = path.dirname(skillFile);
+  const marker = readSkillHubInstallMarker(skillDir);
+  const contentHash = fileSHA256(skillFile);
+  const skillHubReference = marker
+    && isValidSkillHubReference(marker.skillId, marker.version)
+    && /^[a-f0-9]{64}$/.test(String(marker.packageChecksumSha256 || '').toLowerCase())
+    ? {
+        skillId: marker.skillId,
+        version: marker.version,
+        contentHash: marker.packageChecksumSha256.toLowerCase(),
+      }
+    : undefined;
+  return {
+    name: String(skill.metadata.name || '').trim(),
+    description: String(skill.metadata.description || '').trim(),
+    relativePath,
+    userInvocable: skill.metadata.userInvocable !== false,
+    ...(contentHash ? { contentHash } : {}),
+    ...(skillHubReference ? { skillHub: skillHubReference } : {}),
+  };
+}
+
+function isValidSkillHubReference(skillId: string, version: string): boolean {
+  const normalizedID = String(skillId || '').trim();
+  const normalizedVersion = String(version || '').trim();
+  return Boolean(
+    normalizedID
+    && normalizedVersion
+    && !normalizedID.split('/').some(part => !part || part === '.' || part === '..')
+    && !normalizedID.includes('\\')
+    && normalizedVersion !== '.'
+    && normalizedVersion !== '..'
+    && !/[\u0000-\u001f\u007f]/.test(normalizedID)
+    && !/[\u0000-\u001f\u007f]/.test(normalizedVersion),
+  );
+}
+
+function relativePathInside(root: string, candidate: string): string {
+  const relative = path.relative(root, candidate).replace(/\\/g, '/');
+  if (!relative || relative.startsWith('../') || path.isAbsolute(relative)) {
+    // A skill created by a local generated-capability registry may not sit in
+    // the active Skills root. Never leak that absolute runtime location.
+    return `external/${path.basename(candidate)}`;
+  }
+  return relative;
+}
+
+function fileSHA256(filePath: string): string | undefined {
+  try {
+    return crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+  } catch {
+    return undefined;
+  }
+}

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -1,3 +1,4 @@
+import type { BotRuntimeSkillInventory } from '../bot-skills/runtime-inventory';
 import {
   CatsClient,
   MessageContext,
@@ -82,7 +83,6 @@ import {
   createBotRuntimeSkillInventory,
   reportBotRuntimeSkillInventory,
 } from '../bot-skills/runtime-inventory';
-import type { BotRuntimeSkillInventory } from '../bot-skills/runtime-inventory';
 import {
   inferCatsCompanyHttpBaseUrl,
   resolveRuntimeSkillInventoryHttpBaseUrl,
@@ -468,7 +468,6 @@ export class CatsCompanyBot {
   private readonly runtimeSkillInventoryAuth: { apiKey: string; httpBaseUrl: string };
   private readonly runtimeSkillInventoryInstanceID = randomUUID();
   private runtimeSkillInventoryReportSequence = 0;
-  private runtimeSkillInventory?: BotRuntimeSkillInventory;
   private runtimeSkillInventoryReportInFlight?: Promise<void>;
   private runtimeSkillInventoryReportPending = false;
   private runtimeSkillInventoryReportTimer?: ReturnType<typeof setTimeout>;
@@ -713,12 +712,10 @@ export class CatsCompanyBot {
           reportSequence: this.runtimeSkillInventoryReportSequence + 1,
         },
       );
-      this.runtimeSkillInventory = inventory;
       return inventory;
     } catch (error: any) {
       // Inventory is observability only. A broken registry or unreadable skill
       // must never prevent the Agent from starting or serving messages.
-      this.runtimeSkillInventory = undefined;
       Logger.warning(`CatsCo runtime Skill inventory 刷新失败，继续运行 Agent: ${error?.message || error}`);
       return undefined;
     }

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -82,6 +82,15 @@ import {
   createBotRuntimeSkillInventory,
   reportBotRuntimeSkillInventory,
 } from '../bot-skills/runtime-inventory';
+import {
+  inferCatsCompanyHttpBaseUrl,
+  resolveRuntimeSkillInventoryHttpBaseUrl,
+} from './runtime-inventory-endpoint';
+
+export {
+  inferCatsCompanyHttpBaseUrl,
+  resolveRuntimeSkillInventoryHttpBaseUrl,
+} from './runtime-inventory-endpoint';
 
 interface PendingAttachment {
   fileName: string;
@@ -404,28 +413,6 @@ function shouldHydrateCatsCompanyGroupContext(
 }
 
 /**
- * Derive the HTTP API origin used by runtime inventory reporting.
- *
- * This helper deliberately fails closed. The inventory request carries the
- * Bot API key, so an unparseable or unsupported WebSocket endpoint must never
- * fall back to a public default origin and potentially disclose credentials.
- */
-export function inferCatsCompanyHttpBaseUrl(serverUrl: string): string | undefined {
-  try {
-    const url = new URL(serverUrl);
-    if (url.protocol === 'ws:') url.protocol = 'http:';
-    else if (url.protocol === 'wss:') url.protocol = 'https:';
-    else if (url.protocol !== 'http:' && url.protocol !== 'https:') return undefined;
-    url.pathname = '';
-    url.search = '';
-    url.hash = '';
-    return url.toString().replace(/\/$/, '');
-  } catch {
-    return undefined;
-  }
-}
-
-/**
  * CatsCompanyBot 主类
  * 初始化官方 SDK，注册事件，编排消息处理流程
  * 连接、握手、重连与连接层错误处理都归 SDK 负责，runtime 不在这里兜底。
@@ -478,9 +465,12 @@ export class CatsCompanyBot {
   };
   private readonly skillHubThinRpc: SkillHubThinRpcHandler;
   private readonly runtimeSkillInventoryAuth: { apiKey: string; httpBaseUrl: string };
+  private readonly runtimeSkillInventoryInstanceID = randomUUID();
+  private runtimeSkillInventoryReportSequence = 0;
   private runtimeSkillInventory?: ReturnType<typeof createBotRuntimeSkillInventory>;
   private runtimeSkillInventoryReportInFlight?: Promise<void>;
   private runtimeSkillInventoryReportPending = false;
+  private runtimeSkillInventoryReportTimer?: ReturnType<typeof setTimeout>;
   private runtimeSkillInventoryHeartbeatTimer?: ReturnType<typeof setInterval>;
 
   constructor(config: CatsCompanyConfig) {
@@ -523,18 +513,23 @@ export class CatsCompanyBot {
     this.runtimeSkillInventoryAuth = {
       apiKey: config.apiKey,
       // An empty value intentionally disables inventory reporting when the
-      // configured server URL cannot be trusted/parsed. Other connector
-      // traffic retains its existing endpoint resolution behavior.
-      httpBaseUrl: config.httpBaseUrl || inferCatsCompanyHttpBaseUrl(config.serverUrl) || '',
+      // configured endpoint is not a valid same-origin HTTP counterpart of
+      // the connected WebSocket. Other connector traffic keeps its legacy
+      // endpoint resolution behavior.
+      httpBaseUrl: resolveRuntimeSkillInventoryHttpBaseUrl(
+        config.serverUrl,
+        config.httpBaseUrl,
+      ) || '',
     };
 
     const runtime = createCatsCompanyRuntime(config.sessionTTL);
     this.runtime = runtime;
     this.runtimeProfile = runtime.profile;
     this.agentServices = runtime.services;
-    this.agentServices.onSkillsReloaded = async () => {
-      this.refreshRuntimeSkillInventory();
-      await this.reportRuntimeSkillInventory();
+    this.agentServices.onSkillsReloaded = () => {
+      // Inventory is observability only. Coalesce it onto a later event-loop
+      // turn, so a SkillHub mutation never waits for file hashing or network.
+      this.scheduleRuntimeSkillInventoryReport();
     };
     this.cloudSessionRestorer = new CatsCompanyCloudSessionRestorer(this.bot, this.agentServices.aiService);
     const { toolManager } = this.agentServices;
@@ -559,7 +554,6 @@ export class CatsCompanyBot {
 
     // 加载 skills
     await this.runtime.loadSkills();
-    this.refreshRuntimeSkillInventory();
 
     // 注册事件
     this.bot.on('ready', (info: { uid: string; name: string }) => {
@@ -575,7 +569,7 @@ export class CatsCompanyBot {
       });
       this.startDeviceRegistrationRefresh();
       this.startRuntimeSkillInventoryHeartbeat();
-      void this.reportRuntimeSkillInventory();
+      this.scheduleRuntimeSkillInventoryReport();
     });
 
     this.bot.on('message', async (ctx: MessageContext) => {
@@ -679,7 +673,7 @@ export class CatsCompanyBot {
   private startRuntimeSkillInventoryHeartbeat(): void {
     this.stopRuntimeSkillInventoryHeartbeat();
     this.runtimeSkillInventoryHeartbeatTimer = setInterval(() => {
-      void this.reportRuntimeSkillInventory();
+      this.scheduleRuntimeSkillInventoryReport();
     }, RUNTIME_SKILL_INVENTORY_HEARTBEAT_MS);
     (this.runtimeSkillInventoryHeartbeatTimer as any).unref?.();
   }
@@ -690,6 +684,21 @@ export class CatsCompanyBot {
     this.runtimeSkillInventoryHeartbeatTimer = undefined;
   }
 
+  private scheduleRuntimeSkillInventoryReport(): void {
+    if (this.shuttingDown || this.runtimeSkillInventoryReportTimer) return;
+    this.runtimeSkillInventoryReportTimer = setTimeout(() => {
+      this.runtimeSkillInventoryReportTimer = undefined;
+      if (!this.shuttingDown) void this.reportRuntimeSkillInventory();
+    }, 0);
+    (this.runtimeSkillInventoryReportTimer as any).unref?.();
+  }
+
+  private stopScheduledRuntimeSkillInventoryReport(): void {
+    if (!this.runtimeSkillInventoryReportTimer) return;
+    clearTimeout(this.runtimeSkillInventoryReportTimer);
+    this.runtimeSkillInventoryReportTimer = undefined;
+  }
+
   private refreshRuntimeSkillInventory(): void {
     const botID = String(this.botUid || '').trim();
     if (!botID) return;
@@ -698,6 +707,8 @@ export class CatsCompanyBot {
         botID,
         this.agentServices.skillManager.getAllSkills(),
       );
+      this.runtimeSkillInventory.runtimeInstanceId = this.runtimeSkillInventoryInstanceID;
+      this.runtimeSkillInventory.reportSequence = this.runtimeSkillInventoryReportSequence + 1;
     } catch (error: any) {
       // Inventory is observability only. A broken registry or unreadable skill
       // must never prevent the Agent from starting or serving messages.
@@ -715,6 +726,7 @@ export class CatsCompanyBot {
     this.refreshRuntimeSkillInventory();
     if (!this.runtimeSkillInventory) return;
     const inventory = this.runtimeSkillInventory;
+    this.runtimeSkillInventoryReportSequence = Number(inventory.reportSequence || 0);
     const report = (async () => {
       try {
         const accepted = await reportBotRuntimeSkillInventory({
@@ -3273,6 +3285,7 @@ export class CatsCompanyBot {
     this.connectorReady = false;
     this.stopDeviceRegistrationRefresh();
     this.stopRuntimeSkillInventoryHeartbeat();
+    this.stopScheduledRuntimeSkillInventoryReport();
     // 原子停止：在第一个 await 之前显式取消排队用户工作、子任务批量定时器与云恢复，
     // 保证 shutdown 开始后 drainMessageQueue / beginConversationTask 不再消费或新建任务。
     this.pendingAttachments.clear();

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -78,6 +78,10 @@ import {
   SkillHubThinRpcHandler,
   SKILLHUB_THIN_RPC_TOOLS,
 } from './skillhub-rpc';
+import {
+  createBotRuntimeSkillInventory,
+  reportBotRuntimeSkillInventory,
+} from '../bot-skills/runtime-inventory';
 
 interface PendingAttachment {
   fileName: string;
@@ -155,6 +159,7 @@ const SUBAGENT_FALLBACK_MAX_DELIVERY_ATTEMPTS = 3;
 const NATIVE_FEISHU_CONTEXT_PAGE_SIZE = 100;
 const BACKGROUND_SUBAGENT_COMPLETION_MAX_ITEMS = 6;
 const DEVICE_REGISTRATION_REFRESH_MS = 120_000;
+const RUNTIME_SKILL_INVENTORY_HEARTBEAT_MS = 5 * 60_000;
 const DEVICE_RPC_DEFAULT_TTL_MS = 60_000;
 const HIDDEN_CATS_TOOL_PROGRESS = new Set([
   'send_text',
@@ -399,6 +404,28 @@ function shouldHydrateCatsCompanyGroupContext(
 }
 
 /**
+ * Derive the HTTP API origin used by runtime inventory reporting.
+ *
+ * This helper deliberately fails closed. The inventory request carries the
+ * Bot API key, so an unparseable or unsupported WebSocket endpoint must never
+ * fall back to a public default origin and potentially disclose credentials.
+ */
+export function inferCatsCompanyHttpBaseUrl(serverUrl: string): string | undefined {
+  try {
+    const url = new URL(serverUrl);
+    if (url.protocol === 'ws:') url.protocol = 'http:';
+    else if (url.protocol === 'wss:') url.protocol = 'https:';
+    else if (url.protocol !== 'http:' && url.protocol !== 'https:') return undefined;
+    url.pathname = '';
+    url.search = '';
+    url.hash = '';
+    return url.toString().replace(/\/$/, '');
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * CatsCompanyBot 主类
  * 初始化官方 SDK，注册事件，编排消息处理流程
  * 连接、握手、重连与连接层错误处理都归 SDK 负责，runtime 不在这里兜底。
@@ -450,6 +477,11 @@ export class CatsCompanyBot {
     model_status?: ReturnType<typeof resolveCatsDeviceModelStatus>;
   };
   private readonly skillHubThinRpc: SkillHubThinRpcHandler;
+  private readonly runtimeSkillInventoryAuth: { apiKey: string; httpBaseUrl: string };
+  private runtimeSkillInventory?: ReturnType<typeof createBotRuntimeSkillInventory>;
+  private runtimeSkillInventoryReportInFlight?: Promise<void>;
+  private runtimeSkillInventoryReportPending = false;
+  private runtimeSkillInventoryHeartbeatTimer?: ReturnType<typeof setInterval>;
 
   constructor(config: CatsCompanyConfig) {
     this.botUid = String(config.botUid || '').trim() || null;
@@ -488,11 +520,22 @@ export class CatsCompanyBot {
     this.skillHubThinRpc = new SkillHubThinRpcHandler({
       isShuttingDown: () => this.shuttingDown,
     });
+    this.runtimeSkillInventoryAuth = {
+      apiKey: config.apiKey,
+      // An empty value intentionally disables inventory reporting when the
+      // configured server URL cannot be trusted/parsed. Other connector
+      // traffic retains its existing endpoint resolution behavior.
+      httpBaseUrl: config.httpBaseUrl || inferCatsCompanyHttpBaseUrl(config.serverUrl) || '',
+    };
 
     const runtime = createCatsCompanyRuntime(config.sessionTTL);
     this.runtime = runtime;
     this.runtimeProfile = runtime.profile;
     this.agentServices = runtime.services;
+    this.agentServices.onSkillsReloaded = async () => {
+      this.refreshRuntimeSkillInventory();
+      await this.reportRuntimeSkillInventory();
+    };
     this.cloudSessionRestorer = new CatsCompanyCloudSessionRestorer(this.bot, this.agentServices.aiService);
     const { toolManager } = this.agentServices;
 
@@ -516,6 +559,7 @@ export class CatsCompanyBot {
 
     // 加载 skills
     await this.runtime.loadSkills();
+    this.refreshRuntimeSkillInventory();
 
     // 注册事件
     this.bot.on('ready', (info: { uid: string; name: string }) => {
@@ -530,6 +574,8 @@ export class CatsCompanyBot {
         Logger.warning(`CatsCo 设备注册失败，继续保持聊天连接: ${err?.message || err}`);
       });
       this.startDeviceRegistrationRefresh();
+      this.startRuntimeSkillInventoryHeartbeat();
+      void this.reportRuntimeSkillInventory();
     });
 
     this.bot.on('message', async (ctx: MessageContext) => {
@@ -628,6 +674,70 @@ export class CatsCompanyBot {
     if (!this.deviceRegistrationTimer) return;
     clearInterval(this.deviceRegistrationTimer);
     this.deviceRegistrationTimer = undefined;
+  }
+
+  private startRuntimeSkillInventoryHeartbeat(): void {
+    this.stopRuntimeSkillInventoryHeartbeat();
+    this.runtimeSkillInventoryHeartbeatTimer = setInterval(() => {
+      void this.reportRuntimeSkillInventory();
+    }, RUNTIME_SKILL_INVENTORY_HEARTBEAT_MS);
+    (this.runtimeSkillInventoryHeartbeatTimer as any).unref?.();
+  }
+
+  private stopRuntimeSkillInventoryHeartbeat(): void {
+    if (!this.runtimeSkillInventoryHeartbeatTimer) return;
+    clearInterval(this.runtimeSkillInventoryHeartbeatTimer);
+    this.runtimeSkillInventoryHeartbeatTimer = undefined;
+  }
+
+  private refreshRuntimeSkillInventory(): void {
+    const botID = String(this.botUid || '').trim();
+    if (!botID) return;
+    try {
+      this.runtimeSkillInventory = createBotRuntimeSkillInventory(
+        botID,
+        this.agentServices.skillManager.getAllSkills(),
+      );
+    } catch (error: any) {
+      // Inventory is observability only. A broken registry or unreadable skill
+      // must never prevent the Agent from starting or serving messages.
+      this.runtimeSkillInventory = undefined;
+      Logger.warning(`CatsCo runtime Skill inventory 刷新失败，继续运行 Agent: ${error?.message || error}`);
+    }
+  }
+
+  private async reportRuntimeSkillInventory(): Promise<void> {
+    if (this.shuttingDown) return;
+    if (this.runtimeSkillInventoryReportInFlight) {
+      this.runtimeSkillInventoryReportPending = true;
+      return this.runtimeSkillInventoryReportInFlight;
+    }
+    this.refreshRuntimeSkillInventory();
+    if (!this.runtimeSkillInventory) return;
+    const inventory = this.runtimeSkillInventory;
+    const report = (async () => {
+      try {
+        const accepted = await reportBotRuntimeSkillInventory({
+          botId: inventory.botId,
+          auth: this.runtimeSkillInventoryAuth,
+          skills: [],
+          inventory,
+        });
+        void accepted;
+      } catch (error: any) {
+        // Inventory is observability only. A temporarily unavailable CatsCo
+        // API must never block an Agent from serving chat traffic.
+        Logger.warning(`CatsCo runtime Skill inventory 上报失败，稍后重试: ${error?.message || error}`);
+      } finally {
+        this.runtimeSkillInventoryReportInFlight = undefined;
+        if (this.runtimeSkillInventoryReportPending && !this.shuttingDown) {
+          this.runtimeSkillInventoryReportPending = false;
+          void this.reportRuntimeSkillInventory();
+        }
+      }
+    })();
+    this.runtimeSkillInventoryReportInFlight = report;
+    await report;
   }
 
   private buildDeviceRpcTransport(): DeviceRpcTransport {
@@ -3162,6 +3272,7 @@ export class CatsCompanyBot {
     this.shuttingDown = true;
     this.connectorReady = false;
     this.stopDeviceRegistrationRefresh();
+    this.stopRuntimeSkillInventoryHeartbeat();
     // 原子停止：在第一个 await 之前显式取消排队用户工作、子任务批量定时器与云恢复，
     // 保证 shutdown 开始后 drainMessageQueue / beginConversationTask 不再消费或新建任务。
     this.pendingAttachments.clear();

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -82,6 +82,7 @@ import {
   createBotRuntimeSkillInventory,
   reportBotRuntimeSkillInventory,
 } from '../bot-skills/runtime-inventory';
+import type { BotRuntimeSkillInventory } from '../bot-skills/runtime-inventory';
 import {
   inferCatsCompanyHttpBaseUrl,
   resolveRuntimeSkillInventoryHttpBaseUrl,
@@ -467,7 +468,7 @@ export class CatsCompanyBot {
   private readonly runtimeSkillInventoryAuth: { apiKey: string; httpBaseUrl: string };
   private readonly runtimeSkillInventoryInstanceID = randomUUID();
   private runtimeSkillInventoryReportSequence = 0;
-  private runtimeSkillInventory?: ReturnType<typeof createBotRuntimeSkillInventory>;
+  private runtimeSkillInventory?: BotRuntimeSkillInventory;
   private runtimeSkillInventoryReportInFlight?: Promise<void>;
   private runtimeSkillInventoryReportPending = false;
   private runtimeSkillInventoryReportTimer?: ReturnType<typeof setTimeout>;
@@ -699,21 +700,27 @@ export class CatsCompanyBot {
     this.runtimeSkillInventoryReportTimer = undefined;
   }
 
-  private refreshRuntimeSkillInventory(): void {
+  private async refreshRuntimeSkillInventory(): Promise<BotRuntimeSkillInventory | undefined> {
     const botID = String(this.botUid || '').trim();
-    if (!botID) return;
+    if (!botID) return undefined;
     try {
-      this.runtimeSkillInventory = createBotRuntimeSkillInventory(
+      const inventory = await createBotRuntimeSkillInventory(
         botID,
         this.agentServices.skillManager.getAllSkills(),
+        () => new Date(),
+        {
+          runtimeInstanceId: this.runtimeSkillInventoryInstanceID,
+          reportSequence: this.runtimeSkillInventoryReportSequence + 1,
+        },
       );
-      this.runtimeSkillInventory.runtimeInstanceId = this.runtimeSkillInventoryInstanceID;
-      this.runtimeSkillInventory.reportSequence = this.runtimeSkillInventoryReportSequence + 1;
+      this.runtimeSkillInventory = inventory;
+      return inventory;
     } catch (error: any) {
       // Inventory is observability only. A broken registry or unreadable skill
       // must never prevent the Agent from starting or serving messages.
       this.runtimeSkillInventory = undefined;
       Logger.warning(`CatsCo runtime Skill inventory 刷新失败，继续运行 Agent: ${error?.message || error}`);
+      return undefined;
     }
   }
 
@@ -723,12 +730,11 @@ export class CatsCompanyBot {
       this.runtimeSkillInventoryReportPending = true;
       return this.runtimeSkillInventoryReportInFlight;
     }
-    this.refreshRuntimeSkillInventory();
-    if (!this.runtimeSkillInventory) return;
-    const inventory = this.runtimeSkillInventory;
-    this.runtimeSkillInventoryReportSequence = Number(inventory.reportSequence || 0);
     const report = (async () => {
       try {
+        const inventory = await this.refreshRuntimeSkillInventory();
+        if (this.shuttingDown || !inventory) return;
+        this.runtimeSkillInventoryReportSequence = Number(inventory.reportSequence || 0);
         const accepted = await reportBotRuntimeSkillInventory({
           botId: inventory.botId,
           auth: this.runtimeSkillInventoryAuth,

--- a/src/catscompany/runtime-config.ts
+++ b/src/catscompany/runtime-config.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_CATSCO_WS_URL,
   createCatsCoLocalConfigService,
 } from './local-config';
+import { inferCatsCompanyHttpBaseUrl } from './runtime-inventory-endpoint';
 
 export type CatsCoRuntimeMissingField = 'serverUrl' | 'apiKey' | 'bodyId';
 
@@ -92,30 +93,41 @@ export function resolveCatsCoRuntimeConfig(
   const service = createCatsCoLocalConfigService({ runtimeRoot, env: effectiveEnv });
   let localConfig = service.load();
   let auth = service.getAuthState(options.overrides || {});
-  if (options.migrateLegacyEnvBinding && migrateLegacyEnvBinding(service, localConfig, auth)) {
+
+  const resolveEndpoints = (): { serverUrl: string | undefined; httpBaseUrl: string } => {
+    const explicitServerUrl = firstNonEmpty(
+      options.overrides?.serverUrl,
+      effectiveEnv.CATSCO_SERVER_URL,
+      effectiveEnv.CATSCOMPANY_SERVER_URL,
+      localConfig.endpoints?.serverUrl,
+    );
+    const explicitHttpBaseUrl = firstNonEmpty(
+      options.overrides?.httpBaseUrl,
+      effectiveEnv.CATSCO_HTTP_BASE_URL,
+      effectiveEnv.CATSCOMPANY_HTTP_BASE_URL,
+      localConfig.endpoints?.httpBaseUrl,
+    );
+    const serverUrl = firstNonEmpty(explicitServerUrl, config.catscompany?.serverUrl, auth.serverUrl);
+    const requestedHttpBaseUrl = firstNonEmpty(explicitHttpBaseUrl, config.catscompany?.httpBaseUrl);
+    const httpBaseUrl = normalizeBaseUrl(
+      requestedHttpBaseUrl || inferCatsCompanyHttpBaseUrl(serverUrl || '') || auth.httpBaseUrl,
+      DEFAULT_CATSCO_HTTP_BASE_URL,
+      { upgradeCatsCoHttp: true },
+    );
+    return { serverUrl, httpBaseUrl };
+  };
+
+  let { serverUrl, httpBaseUrl } = resolveEndpoints();
+  if (options.migrateLegacyEnvBinding && migrateLegacyEnvBinding(service, localConfig, {
+    ...auth,
+    serverUrl: serverUrl || auth.serverUrl,
+    httpBaseUrl,
+  })) {
     localConfig = service.load();
     auth = service.getAuthState(options.overrides || {});
+    ({ serverUrl, httpBaseUrl } = resolveEndpoints());
   }
-
-  const explicitServerUrl = firstNonEmpty(
-    options.overrides?.serverUrl,
-    effectiveEnv.CATSCO_SERVER_URL,
-    effectiveEnv.CATSCOMPANY_SERVER_URL,
-    localConfig.endpoints?.serverUrl,
-  );
-  const explicitHttpBaseUrl = firstNonEmpty(
-    options.overrides?.httpBaseUrl,
-    effectiveEnv.CATSCO_HTTP_BASE_URL,
-    effectiveEnv.CATSCOMPANY_HTTP_BASE_URL,
-    localConfig.endpoints?.httpBaseUrl,
-  );
-  const serverUrl = firstNonEmpty(explicitServerUrl, config.catscompany?.serverUrl, auth.serverUrl);
   const rawApiKey = firstNonEmpty(auth.apiKey, config.catscompany?.apiKey);
-  const httpBaseUrl = normalizeBaseUrl(
-    firstNonEmpty(explicitHttpBaseUrl, config.catscompany?.httpBaseUrl, auth.httpBaseUrl),
-    DEFAULT_CATSCO_HTTP_BASE_URL,
-    { upgradeCatsCoHttp: true },
-  );
   const proposedBotBinding = Boolean(options.overrides?.botUid && options.overrides?.apiKey);
   const confirmedLocalBotBinding = hasConfirmedLocalBotBinding(localConfig, auth.uid);
   const rawBotUid = auth.botUid;

--- a/src/catscompany/runtime-inventory-endpoint.ts
+++ b/src/catscompany/runtime-inventory-endpoint.ts
@@ -1,0 +1,49 @@
+/**
+ * Derive the HTTP origin used by the optional runtime-Skill inventory report.
+ *
+ * This request carries a Bot API key, so endpoint resolution deliberately
+ * fails closed. URL credentials are rejected as well, because a failed
+ * request must never surface those credentials through error handling or logs.
+ */
+export function inferCatsCompanyHttpBaseUrl(serverUrl: string): string | undefined {
+  try {
+    const url = new URL(serverUrl);
+    if (url.username || url.password) return undefined;
+    if (url.protocol === 'ws:') url.protocol = 'http:';
+    else if (url.protocol === 'wss:') url.protocol = 'https:';
+    else if (url.protocol !== 'http:' && url.protocol !== 'https:') return undefined;
+    url.pathname = '';
+    url.search = '';
+    url.hash = '';
+    return url.toString().replace(/\/$/, '');
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Select the HTTP origin for an inventory report. An omitted HTTP endpoint is
+ * safely derived from the connected WebSocket; an explicit endpoint must be
+ * same-origin with that WebSocket before the Bot API key may be sent.
+ */
+export function resolveRuntimeSkillInventoryHttpBaseUrl(
+  serverUrl: string,
+  configuredHttpBaseUrl?: string,
+): string | undefined {
+  const inferred = inferCatsCompanyHttpBaseUrl(serverUrl);
+  if (!inferred) return undefined;
+  const configured = String(configuredHttpBaseUrl || '').trim();
+  if (!configured) return inferred;
+  try {
+    const url = new URL(configured);
+    if (url.username || url.password) return undefined;
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return undefined;
+    url.pathname = '';
+    url.search = '';
+    url.hash = '';
+    const normalized = url.toString().replace(/\/$/, '');
+    return normalized === inferred ? normalized : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -104,6 +104,8 @@ export interface AgentServices {
   };
   toolManager: ToolManager;
   skillManager: SkillManager;
+  /** Optional runtime hook invoked after SkillHub mutates and reloads Skills. */
+  onSkillsReloaded?: () => Promise<void> | void;
   /** Optional test seam for the after-turn Bot Skill workspace sync scheduler. */
   afterTurnSkillSyncScheduler?: () => void;
 }

--- a/src/core/agent-turn-controller.ts
+++ b/src/core/agent-turn-controller.ts
@@ -53,6 +53,7 @@ export interface AgentTurnServices {
   };
   toolManager: ToolManager;
   skillManager: SkillManager;
+  onSkillsReloaded?: () => Promise<void> | void;
 }
 
 export interface AgentTurnCallbacks {
@@ -312,6 +313,9 @@ export class AgentTurnController {
           runtimeServices: {
             aiService: this.options.services.aiService,
             skillManager: this.options.services.skillManager,
+            ...(this.options.services.onSkillsReloaded
+              ? { onSkillsReloaded: this.options.services.onSkillsReloaded }
+              : {}),
           },
           abortSignal: options.abortSignal,
           channel: options.channel,

--- a/src/runtime/adapter-runtime.ts
+++ b/src/runtime/adapter-runtime.ts
@@ -46,15 +46,19 @@ export function createAdapterRuntime(options: AdapterRuntimeOptions): AdapterRun
     sessionManagerOptions: {
       ttl: options.sessionTTL,
       systemPromptProviderFactory,
-      skillReloadHandler: createSkillLoader(services, options.skillLoadMode ?? 'warn'),
+      // A session refresh runs on every turn when the transient Skills list is
+      // injected. Keep the observer for explicit mutations/startup loads, but
+      // do not invoke it on this hot path.
+      skillReloadHandler: createSkillLoader(services, options.skillLoadMode ?? 'warn', false),
     },
-    loadSkills: createSkillLoader(services, options.skillLoadMode ?? 'warn'),
+    loadSkills: createSkillLoader(services, options.skillLoadMode ?? 'warn', true),
   };
 }
 
 function createSkillLoader(
   services: AgentServices,
   mode: AdapterSkillLoadMode,
+  notifyObserver: boolean,
 ): () => Promise<void> {
   return async () => {
     if (mode === 'fail-fast') {
@@ -64,9 +68,8 @@ function createSkillLoader(
       await RuntimeFactory.loadSkills(services.skillManager);
     }
     // Read the hook from the shared service object at call time. Adapters can
-    // attach lifecycle observers after constructing the runtime bundle, while
-    // every reload path still gets the same notification.
-    await services.onSkillsReloaded?.();
+    // attach lifecycle observers after constructing the runtime bundle.
+    if (notifyObserver) await services.onSkillsReloaded?.();
   };
 }
 

--- a/src/runtime/adapter-runtime.ts
+++ b/src/runtime/adapter-runtime.ts
@@ -56,14 +56,18 @@ function createSkillLoader(
   services: AgentServices,
   mode: AdapterSkillLoadMode,
 ): () => Promise<void> {
-  if (mode === 'fail-fast') {
-    return async () => {
+  return async () => {
+    if (mode === 'fail-fast') {
       await services.skillManager.loadSkills();
       Logger.info(`已加载 ${services.skillManager.getAllSkills().length} 个 skills`);
-    };
-  }
-
-  return () => RuntimeFactory.loadSkills(services.skillManager);
+    } else {
+      await RuntimeFactory.loadSkills(services.skillManager);
+    }
+    // Read the hook from the shared service object at call time. Adapters can
+    // attach lifecycle observers after constructing the runtime bundle, while
+    // every reload path still gets the same notification.
+    await services.onSkillsReloaded?.();
+  };
 }
 
 function createPromptProviderFactory(

--- a/src/runtime/adapter-runtime.ts
+++ b/src/runtime/adapter-runtime.ts
@@ -1,3 +1,5 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import {
   AgentServices,
   SystemPromptProvider,
@@ -10,6 +12,7 @@ import {
 } from './runtime-profile';
 import { resolveRuntimeProfileFromConfig } from './runtime-profile-config';
 import { RuntimeFactory } from './runtime-factory';
+import { SKILLHUB_INSTALL_MARKER_FILE } from '../skillhub/install-marker';
 
 export type AdapterPromptSnapshotMode = 'fixed' | 'mutable-identity';
 export type AdapterSkillLoadMode = 'warn' | 'fail-fast';
@@ -29,6 +32,12 @@ export interface AdapterRuntimeBundle {
   loadSkills: () => Promise<void>;
 }
 
+type SkillLoadNotificationMode = 'await-observer' | 'background-on-change';
+
+interface SkillLoadState {
+  signature?: string;
+}
+
 export function createAdapterRuntime(options: AdapterRuntimeOptions): AdapterRuntimeBundle {
   const { profile } = resolveRuntimeProfileFromConfig({
     surface: options.surface,
@@ -39,6 +48,7 @@ export function createAdapterRuntime(options: AdapterRuntimeOptions): AdapterRun
     profile,
     options.promptSnapshotMode ?? 'fixed',
   );
+  const skillLoadState: SkillLoadState = {};
 
   return {
     profile,
@@ -46,19 +56,30 @@ export function createAdapterRuntime(options: AdapterRuntimeOptions): AdapterRun
     sessionManagerOptions: {
       ttl: options.sessionTTL,
       systemPromptProviderFactory,
-      // A session refresh runs on every turn when the transient Skills list is
-      // injected. Keep the observer for explicit mutations/startup loads, but
-      // do not invoke it on this hot path.
-      skillReloadHandler: createSkillLoader(services, options.skillLoadMode ?? 'warn', false),
+      // Every turn reloads the transient Skills list. Only a real inventory
+      // change notifies the runtime, and that observer is never awaited on
+      // this chat-critical path.
+      skillReloadHandler: createSkillLoader(
+        services,
+        options.skillLoadMode ?? 'warn',
+        skillLoadState,
+        'background-on-change',
+      ),
     },
-    loadSkills: createSkillLoader(services, options.skillLoadMode ?? 'warn', true),
+    loadSkills: createSkillLoader(
+      services,
+      options.skillLoadMode ?? 'warn',
+      skillLoadState,
+      'await-observer',
+    ),
   };
 }
 
 function createSkillLoader(
   services: AgentServices,
   mode: AdapterSkillLoadMode,
-  notifyObserver: boolean,
+  state: SkillLoadState,
+  notificationMode: SkillLoadNotificationMode,
 ): () => Promise<void> {
   return async () => {
     if (mode === 'fail-fast') {
@@ -67,10 +88,61 @@ function createSkillLoader(
     } else {
       await RuntimeFactory.loadSkills(services.skillManager);
     }
+    const changed = updateSkillLoadSignature(services, state);
     // Read the hook from the shared service object at call time. Adapters can
     // attach lifecycle observers after constructing the runtime bundle.
-    if (notifyObserver) await services.onSkillsReloaded?.();
+    if (notificationMode === 'await-observer') {
+      await services.onSkillsReloaded?.();
+    } else if (changed) {
+      notifySkillsReloadedInBackground(services);
+    }
   };
+}
+
+function updateSkillLoadSignature(services: AgentServices, state: SkillLoadState): boolean {
+  const signature = JSON.stringify(
+    services.skillManager.getAllSkills().map((skill) => {
+      const filePath = String(skill.filePath || '');
+      return {
+        name: String(skill.metadata.name || '').trim(),
+        description: String(skill.metadata.description || '').trim(),
+        userInvocable: skill.metadata.userInvocable !== false,
+        filePath,
+        skillFileRevision: fileRevision(filePath),
+        skillHubMarkerRevision: filePath
+          ? fileRevision(path.join(path.dirname(filePath), SKILLHUB_INSTALL_MARKER_FILE))
+          : '',
+      };
+    }).sort((left, right) => (
+      `${left.name}\u0000${left.filePath}`.localeCompare(`${right.name}\u0000${right.filePath}`)
+    )),
+  );
+  const changed = state.signature !== signature;
+  state.signature = signature;
+  return changed;
+}
+
+// SkillManager has already synchronously parsed SKILL.md for this reload. The
+// cheap stat revisions also cover content and SkillHub package-marker updates
+// without adding file hashing or network work to the chat-critical path.
+function fileRevision(filePath: string): string {
+  if (!filePath) return '';
+  try {
+    const stat = fs.statSync(filePath);
+    return `${stat.size}:${stat.mtimeMs}:${stat.ctimeMs}`;
+  } catch {
+    return '';
+  }
+}
+
+function notifySkillsReloadedInBackground(services: AgentServices): void {
+  const observer = services.onSkillsReloaded;
+  if (!observer) return;
+  void Promise.resolve()
+    .then(() => observer())
+    .catch((error: unknown) => {
+    Logger.warning(`Skills 重新加载后的后台观察失败: ${error instanceof Error ? error.message : String(error)}`);
+    });
 }
 
 function createPromptProviderFactory(

--- a/src/tools/skillhub-tool.ts
+++ b/src/tools/skillhub-tool.ts
@@ -105,6 +105,7 @@ export class SkillHubTool implements Tool {
             () => this.subscriptions.subscribe(skillId),
           );
           await context.runtimeServices?.skillManager.loadSkills();
+          await context.runtimeServices?.onSkillsReloaded?.();
           scheduleCurrentBotSkillSync();
           return {
             ok: true,
@@ -116,6 +117,7 @@ export class SkillHubTool implements Tool {
           () => this.subscriptions.unsubscribe(skillId),
         );
         await context.runtimeServices?.skillManager.loadSkills();
+        await context.runtimeServices?.onSkillsReloaded?.();
         scheduleCurrentBotSkillSync();
         return {
           ok: true,

--- a/src/types/tool.ts
+++ b/src/types/tool.ts
@@ -188,6 +188,8 @@ export type FeishuChannelCallbacks = ChannelCallbacks;
 export interface RuntimeToolServices {
   aiService: AIService;
   skillManager: SkillManager;
+  /** Lets a connected runtime publish a fresh Skill inventory after a mutation reload. */
+  onSkillsReloaded?: () => Promise<void> | void;
 }
 
 export type ToolRiskLevel = 'low' | 'medium' | 'high';

--- a/tests/adapter-runtime.test.ts
+++ b/tests/adapter-runtime.test.ts
@@ -198,18 +198,51 @@ describe('adapter runtime', () => {
     );
   });
 
-  test('does not notify observers on per-turn skill refreshes', async () => {
+  test('notifies at startup and only schedules a per-turn observer after Skills change', async () => {
+    writeTestSkill('adapter-runtime-demo');
     const runtime = createAdapterRuntime({ surface: 'catscompany' });
     let notifications = 0;
     runtime.services.onSkillsReloaded = () => {
       notifications += 1;
     };
 
-    await runtime.sessionManagerOptions.skillReloadHandler?.();
-    assert.equal(notifications, 0);
-
     await runtime.loadSkills();
     assert.equal(notifications, 1);
+
+    await runtime.sessionManagerOptions.skillReloadHandler?.();
+    assert.equal(notifications, 1);
+
+    fs.appendFileSync(
+      path.join(process.cwd(), 'skills', 'adapter-runtime-demo', 'SKILL.md'),
+      '\nUpdated runtime instructions.',
+      'utf-8',
+    );
+    runtime.services.onSkillsReloaded = () => {
+      notifications += 1;
+      return new Promise<void>(() => {});
+    };
+    await runtime.sessionManagerOptions.skillReloadHandler?.();
+    await Promise.resolve();
+    assert.equal(notifications, 2);
+
+    fs.writeFileSync(
+      path.join(process.cwd(), 'skills', 'adapter-runtime-demo', '.xiaoba-skillhub-install.json'),
+      JSON.stringify({
+        source: 'skillhub',
+        skillId: 'test/adapter-runtime-demo',
+        name: 'adapter-runtime-demo',
+        installName: 'adapter-runtime-demo',
+        version: '1.0.0',
+        packageChecksumSha256: '0'.repeat(64),
+      }),
+      'utf-8',
+    );
+    runtime.services.onSkillsReloaded = () => {
+      notifications += 1;
+    };
+    await runtime.sessionManagerOptions.skillReloadHandler?.();
+    await Promise.resolve();
+    assert.equal(notifications, 3);
   });
 });
 

--- a/tests/adapter-runtime.test.ts
+++ b/tests/adapter-runtime.test.ts
@@ -197,6 +197,20 @@ describe('adapter runtime', () => {
       /fail reload failure/,
     );
   });
+
+  test('does not notify observers on per-turn skill refreshes', async () => {
+    const runtime = createAdapterRuntime({ surface: 'catscompany' });
+    let notifications = 0;
+    runtime.services.onSkillsReloaded = () => {
+      notifications += 1;
+    };
+
+    await runtime.sessionManagerOptions.skillReloadHandler?.();
+    assert.equal(notifications, 0);
+
+    await runtime.loadSkills();
+    assert.equal(notifications, 1);
+  });
 });
 
 function writeTestSkill(name: string): void {

--- a/tests/bot-runtime-skill-inventory.test.ts
+++ b/tests/bot-runtime-skill-inventory.test.ts
@@ -1,0 +1,124 @@
+import assert from 'node:assert/strict';
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import {
+  createBotRuntimeSkillInventory,
+  reportBotRuntimeSkillInventory,
+} from '../src/bot-skills/runtime-inventory';
+import { inferCatsCompanyHttpBaseUrl } from '../src/catscompany';
+import type { Skill } from '../src/types/skill';
+
+describe('Bot runtime Skill inventory', () => {
+  let runtimeRoot: string;
+  let previousSkillsDir: string | undefined;
+
+  beforeEach(() => {
+    runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-runtime-skill-inventory-'));
+    previousSkillsDir = process.env.XIAOBA_SKILLS_DIR;
+    process.env.XIAOBA_SKILLS_DIR = path.join(runtimeRoot, 'skills');
+  });
+
+  afterEach(() => {
+    if (previousSkillsDir === undefined) delete process.env.XIAOBA_SKILLS_DIR;
+    else process.env.XIAOBA_SKILLS_DIR = previousSkillsDir;
+    fs.rmSync(runtimeRoot, { recursive: true, force: true });
+  });
+
+  test('reports loaded Skills with a relative path and never exposes its runtime root', () => {
+    const skillDir = path.join(process.env.XIAOBA_SKILLS_DIR!, 'tools', 'review');
+    const skillPath = path.join(skillDir, 'SKILL.md');
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(skillPath, '---\nname: review\ndescription: Review code changes\n---\nReview.', 'utf8');
+    fs.writeFileSync(path.join(skillDir, '.xiaoba-skillhub-install.json'), JSON.stringify({
+      source: 'skillhub',
+      skillId: 'tools/review',
+      name: 'review',
+      installName: 'review',
+      version: '1.0.0',
+      packageChecksumSha256: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+    }));
+    const skills: Skill[] = [{
+      metadata: { name: 'review', description: 'Review code changes', userInvocable: true },
+      content: 'Review.',
+      filePath: skillPath,
+    }];
+
+    const inventory = createBotRuntimeSkillInventory('42', skills, () => new Date('2026-08-12T06:00:00.000Z'));
+
+    assert.deepEqual(inventory, {
+      schema: 'xiaoba.bot-runtime-skills.v1',
+      botId: '42',
+      observedAt: '2026-08-12T06:00:00.000Z',
+      skills: [{
+        name: 'review',
+        description: 'Review code changes',
+        relativePath: 'tools/review/SKILL.md',
+        userInvocable: true,
+        contentHash: crypto.createHash('sha256').update(fs.readFileSync(skillPath)).digest('hex'),
+        skillHub: {
+          skillId: 'tools/review',
+          version: '1.0.0',
+          contentHash: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+        },
+      }],
+    });
+    assert.doesNotMatch(JSON.stringify(inventory), new RegExp(runtimeRoot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  });
+
+  test('uses Bot API-key authentication and tolerates older CatsCo servers', async () => {
+    const requests: Array<{ url: string; authorization: string; body: unknown }> = [];
+    const inventory = createBotRuntimeSkillInventory('42', [], () => new Date('2026-08-12T06:00:00.000Z'));
+    const accepted = await reportBotRuntimeSkillInventory({
+      botId: '42',
+      auth: { apiKey: 'cc_test_key', httpBaseUrl: 'https://cats.example.test/' },
+      skills: [],
+      inventory,
+      fetchImpl: (async (input, init) => {
+        requests.push({
+          url: String(input),
+          authorization: String((init?.headers as Record<string, string>)?.Authorization || ''),
+          body: init?.body ? JSON.parse(String(init.body)) : undefined,
+        });
+        return Response.json({ ok: true });
+      }) as typeof fetch,
+    });
+
+    assert.equal(accepted, true);
+    assert.deepEqual(requests, [{
+      url: 'https://cats.example.test/api/bot/skills/inventory',
+      authorization: 'ApiKey cc_test_key',
+      body: inventory,
+    }]);
+
+    const legacy = await reportBotRuntimeSkillInventory({
+      botId: '42',
+      auth: { apiKey: 'cc_test_key', httpBaseUrl: 'https://cats.example.test' },
+      skills: [],
+      fetchImpl: (async () => new Response('', { status: 404 })) as typeof fetch,
+    });
+    assert.equal(legacy, false);
+  });
+
+  test('fails closed when deriving the inventory endpoint from an invalid server URL', async () => {
+    assert.equal(inferCatsCompanyHttpBaseUrl('not a URL'), undefined);
+    assert.equal(inferCatsCompanyHttpBaseUrl('ftp://cats.example.test/v0/channels'), undefined);
+    assert.equal(inferCatsCompanyHttpBaseUrl('wss://cats.example.test/v0/channels?token=secret'), 'https://cats.example.test');
+
+    const requests: string[] = [];
+    const accepted = await reportBotRuntimeSkillInventory({
+      botId: '42',
+      auth: { apiKey: 'cc_test_key', httpBaseUrl: inferCatsCompanyHttpBaseUrl('not a URL') || '' },
+      skills: [],
+      fetchImpl: (async (input) => {
+        requests.push(String(input));
+        return Response.json({ ok: true });
+      }) as typeof fetch,
+    });
+
+    assert.equal(accepted, false);
+    assert.deepEqual(requests, []);
+  });
+});

--- a/tests/bot-runtime-skill-inventory.test.ts
+++ b/tests/bot-runtime-skill-inventory.test.ts
@@ -6,6 +6,7 @@ import * as path from 'node:path';
 import { afterEach, beforeEach, describe, test } from 'node:test';
 import {
   createBotRuntimeSkillInventory,
+  MAX_RUNTIME_SKILL_INVENTORY_BYTES,
   reportBotRuntimeSkillInventory,
 } from '../src/bot-skills/runtime-inventory';
 import {
@@ -14,6 +15,8 @@ import {
 } from '../src/catscompany';
 import { resolveCatsCoRuntimeConfig } from '../src/catscompany/runtime-config';
 import type { Skill } from '../src/types/skill';
+
+const testSkillHash = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
 
 describe('Bot runtime Skill inventory', () => {
   let runtimeRoot: string;
@@ -31,7 +34,7 @@ describe('Bot runtime Skill inventory', () => {
     fs.rmSync(runtimeRoot, { recursive: true, force: true });
   });
 
-  test('reports loaded Skills with a relative path and never exposes its runtime root', () => {
+  test('reports loaded Skills with a relative path and never exposes its runtime root', async () => {
     const skillDir = path.join(process.env.XIAOBA_SKILLS_DIR!, 'tools', 'review');
     const skillPath = path.join(skillDir, 'SKILL.md');
     fs.mkdirSync(skillDir, { recursive: true });
@@ -50,7 +53,7 @@ describe('Bot runtime Skill inventory', () => {
       filePath: skillPath,
     }];
 
-    const inventory = createBotRuntimeSkillInventory('42', skills, () => new Date('2026-08-12T06:00:00.000Z'));
+    const inventory = await createBotRuntimeSkillInventory('42', skills, () => new Date('2026-08-12T06:00:00.000Z'));
 
     assert.deepEqual(inventory, {
       schema: 'xiaoba.bot-runtime-skills.v1',
@@ -74,7 +77,7 @@ describe('Bot runtime Skill inventory', () => {
 
   test('uses Bot API-key authentication and tolerates older CatsCo servers', async () => {
     const requests: Array<{ url: string; authorization: string; body: unknown }> = [];
-    const inventory = createBotRuntimeSkillInventory('42', [], () => new Date('2026-08-12T06:00:00.000Z'));
+    const inventory = await createBotRuntimeSkillInventory('42', [], () => new Date('2026-08-12T06:00:00.000Z'));
     const accepted = await reportBotRuntimeSkillInventory({
       botId: '42',
       auth: { apiKey: 'cc_test_key', httpBaseUrl: 'https://cats.example.test/' },
@@ -97,13 +100,89 @@ describe('Bot runtime Skill inventory', () => {
       body: inventory,
     }]);
 
+    const legacySkillDir = path.join(process.env.XIAOBA_SKILLS_DIR!, 'legacy');
+    const legacySkillPath = path.join(legacySkillDir, 'SKILL.md');
+    fs.mkdirSync(legacySkillDir, { recursive: true });
+    fs.writeFileSync(legacySkillPath, 'legacy skill', 'utf8');
+    fs.writeFileSync(path.join(legacySkillDir, '.xiaoba-skillhub-install.json'), JSON.stringify({
+      source: 'skillhub',
+      skillId: 'tools/legacy',
+      name: 'legacy',
+      installName: 'legacy',
+      version: '1.0.0',
+      packageChecksumSha256: testSkillHash,
+    }));
+    const inventoryWithV1Extensions = await createBotRuntimeSkillInventory('42', [{
+      metadata: { name: 'legacy', description: 'Legacy compatibility fixture', userInvocable: true },
+      content: '',
+      filePath: legacySkillPath,
+    }], () => new Date('2026-08-12T06:00:00.000Z'), {
+      runtimeInstanceId: 'runtime-a',
+      reportSequence: 7,
+    });
+    const legacyRequests: Array<Record<string, any>> = [];
     const legacy = await reportBotRuntimeSkillInventory({
       botId: '42',
       auth: { apiKey: 'cc_test_key', httpBaseUrl: 'https://cats.example.test' },
-      skills: [],
-      fetchImpl: (async () => new Response('', { status: 404 })) as typeof fetch,
+      inventory: inventoryWithV1Extensions,
+      fetchImpl: (async (_input, init) => {
+        legacyRequests.push(JSON.parse(String(init?.body || '{}')) as Record<string, any>);
+        return new Response('', { status: legacyRequests.length === 1 ? 400 : 200 });
+      }) as typeof fetch,
     });
-    assert.equal(legacy, false);
+    assert.equal(legacy, true);
+    assert.equal(legacyRequests.length, 2);
+    assert.equal(legacyRequests[0].runtimeInstanceId, 'runtime-a');
+    assert.equal(legacyRequests[0].reportSequence, 7);
+    assert.ok(legacyRequests[0].skills[0].fileHash);
+    assert.equal(legacyRequests[0].skills[0].skillHub.packageChecksumSha256, testSkillHash);
+    assert.equal('runtimeInstanceId' in legacyRequests[1], false);
+    assert.equal('reportSequence' in legacyRequests[1], false);
+    assert.equal(legacyRequests[1].skills[0].contentHash, legacyRequests[0].skills[0].fileHash);
+    assert.equal('fileHash' in legacyRequests[1].skills[0], false);
+    assert.equal(legacyRequests[1].skills[0].skillHub.contentHash, testSkillHash);
+    assert.equal('packageChecksumSha256' in legacyRequests[1].skills[0].skillHub, false);
+  });
+
+  test('fits inventory to a UTF-8 byte budget and marks degraded entries', async () => {
+    const skillDir = path.join(process.env.XIAOBA_SKILLS_DIR!, 'large');
+    const skillPath = path.join(skillDir, 'SKILL.md');
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(skillPath, 'x'.repeat(1024), 'utf8');
+    const inventory = await createBotRuntimeSkillInventory('42', [{
+      metadata: { name: 'large', description: '猫'.repeat(10_000), userInvocable: true },
+      content: '',
+      filePath: skillPath,
+    }], () => new Date('2026-08-12T06:00:00.000Z'));
+    assert.equal(inventory.truncated, true);
+    assert.ok(Buffer.byteLength(JSON.stringify(inventory), 'utf8') <= MAX_RUNTIME_SKILL_INVENTORY_BYTES);
+    assert.ok(inventory.skills.length <= 1);
+    if (inventory.skills[0]) {
+      assert.ok(Buffer.byteLength(inventory.skills[0].description, 'utf8') <= 4096);
+    }
+  });
+
+  test('skips hashing an oversized SKILL.md without dropping its safe metadata', async () => {
+    const skillDir = path.join(process.env.XIAOBA_SKILLS_DIR!, 'oversized');
+    const skillPath = path.join(skillDir, 'SKILL.md');
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(skillPath, 'x'.repeat((4 << 20) + 1), 'utf8');
+    const inventory = await createBotRuntimeSkillInventory('42', [{
+      metadata: { name: 'oversized', description: 'Large but valid', userInvocable: true },
+      content: '',
+      filePath: skillPath,
+    }]);
+
+    assert.equal(inventory.truncated, true);
+    assert.deepEqual(inventory.skills.map((skill) => ({
+      name: skill.name,
+      relativePath: skill.relativePath,
+      fileHash: skill.fileHash,
+    })), [{
+      name: 'oversized',
+      relativePath: 'oversized/SKILL.md',
+      fileHash: undefined,
+    }]);
   });
 
   test('fails closed when deriving the inventory endpoint from an invalid server URL', async () => {

--- a/tests/bot-runtime-skill-inventory.test.ts
+++ b/tests/bot-runtime-skill-inventory.test.ts
@@ -8,7 +8,11 @@ import {
   createBotRuntimeSkillInventory,
   reportBotRuntimeSkillInventory,
 } from '../src/bot-skills/runtime-inventory';
-import { inferCatsCompanyHttpBaseUrl } from '../src/catscompany';
+import {
+  inferCatsCompanyHttpBaseUrl,
+  resolveRuntimeSkillInventoryHttpBaseUrl,
+} from '../src/catscompany';
+import { resolveCatsCoRuntimeConfig } from '../src/catscompany/runtime-config';
 import type { Skill } from '../src/types/skill';
 
 describe('Bot runtime Skill inventory', () => {
@@ -57,11 +61,11 @@ describe('Bot runtime Skill inventory', () => {
         description: 'Review code changes',
         relativePath: 'tools/review/SKILL.md',
         userInvocable: true,
-        contentHash: crypto.createHash('sha256').update(fs.readFileSync(skillPath)).digest('hex'),
+        fileHash: crypto.createHash('sha256').update(fs.readFileSync(skillPath)).digest('hex'),
         skillHub: {
           skillId: 'tools/review',
           version: '1.0.0',
-          contentHash: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+          packageChecksumSha256: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
         },
       }],
     });
@@ -120,5 +124,55 @@ describe('Bot runtime Skill inventory', () => {
 
     assert.equal(accepted, false);
     assert.deepEqual(requests, []);
+  });
+
+  test('does not send the Bot API key to a default or cross-origin HTTP endpoint', () => {
+    assert.equal(
+      resolveRuntimeSkillInventoryHttpBaseUrl(
+        'wss://self-hosted.example/v0/channels',
+        'https://app.catsco.cc',
+      ),
+      undefined,
+    );
+    assert.equal(
+      resolveRuntimeSkillInventoryHttpBaseUrl(
+        'wss://self-hosted.example/v0/channels',
+        'https://self-hosted.example/',
+      ),
+      'https://self-hosted.example',
+    );
+    assert.equal(
+      resolveRuntimeSkillInventoryHttpBaseUrl('ws://127.0.0.1:6061/v0/channels'),
+      'http://127.0.0.1:6061',
+    );
+    assert.equal(
+      resolveRuntimeSkillInventoryHttpBaseUrl('wss://user:password@cats.example.test/v0/channels'),
+      undefined,
+    );
+    assert.equal(
+      resolveRuntimeSkillInventoryHttpBaseUrl(
+        'wss://cats.example.test/v0/channels',
+        'https://user:password@cats.example.test',
+      ),
+      undefined,
+    );
+  });
+
+  test('derives a self-hosted HTTP API origin when only the WebSocket endpoint is configured', () => {
+    const resolved = resolveCatsCoRuntimeConfig({
+      runtimeRoot,
+      env: {
+        CATSCO_SERVER_URL: 'wss://self-hosted.example/v0/channels',
+        CATSCO_USER_TOKEN: 'user-token',
+        CATSCO_USER_UID: 'user-42',
+        CATSCO_BOT_UID: 'bot-42',
+        CATSCO_API_KEY: 'cc_test_key',
+      },
+      migrateLegacyEnvBinding: true,
+    });
+
+    assert.equal(resolved.connector?.serverUrl, 'wss://self-hosted.example/v0/channels');
+    assert.equal(resolved.connector?.httpBaseUrl, 'https://self-hosted.example');
+    assert.equal(resolved.auth.httpBaseUrl, 'https://self-hosted.example');
   });
 });


### PR DESCRIPTION
## What changed

- Builds the runtime Skill inventory from the live `SkillManager.getAllSkills()` result.
- Reports a bounded, sanitized snapshot to CatsCo using the Bot API key and a same-origin HTTP endpoint derived from the connected WebSocket.
- Reports on startup, on changed Skill reloads, and every five minutes; report work is background-only and does not block a chat turn.
- Adds monotonic runtime-instance sequencing, legacy v1 `contentHash` fallback, bounded file/package hashing, and shutdown/coalescing safeguards.

## Why

The WebApp previously had no way to distinguish server-Agent Skills that are actually loaded from configured SkillHub references or browser-local files. This adds the runtime-side half of that telemetry path.

## User impact

After the companion CatsCo change is deployed, SkillHub can show the server Agent's real loaded Skills without sending absolute paths, `SKILL.md` contents, hashes, or credentials to viewers.

## Companion change

Requires the CatsCo server/WebApp Draft PR: https://github.com/buildsense-ai/cats-company/pull/221

## Validation

- `npm run build`
- `npx tsx --test tests/bot-runtime-skill-inventory.test.ts tests/adapter-runtime.test.ts` — 15 passed

## Known boundary

Same-process delayed reports are ordered by `runtimeInstanceId` and `reportSequence`. Selecting the authoritative snapshot among multiple simultaneous Agent processes sharing one Bot still requires a future server-side lease/generation mechanism.
