### PR TITLE
构建：随正式版本发布云员工应用制品

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -390,6 +390,11 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.VOLC_TOS_SECRET_ACCESS_KEY }}
       AWS_EC2_METADATA_DISABLED: 'true'
     steps:
+      - name: Checkout release retention scripts
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
       - name: Verify CDN publishing credentials
         shell: bash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'v*'
 
+concurrency:
+  group: desktop-release-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   NODE_VERSION: '20'
   NPM_INSTALL_FLAGS: '--prefer-offline --no-audit --fund=false'
@@ -547,27 +551,98 @@ jobs:
           WORKER_PREFIX="update/worker/${WORKER_VERSION}"
           IMMUTABLE_PRIVATE_CACHE_CONTROL="private, max-age=31536000, immutable"
 
-          while IFS= read -r -d '' file; do
+          retry() {
+            local max_attempts="$1"
+            shift
+            local attempt=1
+            until "$@"; do
+              if [ "$attempt" -ge "$max_attempts" ]; then
+                return 1
+              fi
+              sleep $((attempt * 2))
+              attempt=$((attempt + 1))
+            done
+          }
+
+          publish_immutable_worker_file() {
+            local file="$1"
+            local name key local_sha local_size head remote_sha remote_size
             name="$(basename "$file")"
             key="${WORKER_PREFIX}/${name}"
-            aws s3 cp "$file" "s3://${TOS_WORKER_BUCKET}/${key}" \
-              --endpoint-url "$WORKER_ENDPOINT_URL" \
-              --acl private \
-              --cache-control "$IMMUTABLE_PRIVATE_CACHE_CONTROL" \
-              --only-show-errors
-            aws s3api head-object \
+            local_sha="$(sha256sum "$file" | awk '{print $1}')"
+            local_size="$(stat --format='%s' "$file")"
+
+            if head="$(retry 4 aws s3api head-object \
               --bucket "$TOS_WORKER_BUCKET" \
               --key "$key" \
               --endpoint-url "$WORKER_ENDPOINT_URL" \
-              >/dev/null
-          done < <(find release-worker -maxdepth 1 -type f -print0)
+              --output json 2>/dev/null)"; then
+              remote_sha="$(jq -r '.Metadata.sha256 // ""' <<<"$head")"
+              remote_size="$(jq -r '.ContentLength // -1' <<<"$head")"
+              if [ "$remote_sha" != "$local_sha" ] || [ "$remote_size" != "$local_size" ]; then
+                echo "Refusing to overwrite immutable worker artifact with different content: $key"
+                return 1
+              fi
+              echo "Worker artifact already published with matching identity: $key"
+              return 0
+            fi
+
+            retry 4 aws s3 cp "$file" "s3://${TOS_WORKER_BUCKET}/${key}" \
+              --endpoint-url "$WORKER_ENDPOINT_URL" \
+              --acl private \
+              --cache-control "$IMMUTABLE_PRIVATE_CACHE_CONTROL" \
+              --metadata "sha256=$local_sha" \
+              --only-show-errors
+
+            head="$(retry 4 aws s3api head-object \
+              --bucket "$TOS_WORKER_BUCKET" \
+              --key "$key" \
+              --endpoint-url "$WORKER_ENDPOINT_URL" \
+              --output json)"
+            remote_sha="$(jq -r '.Metadata.sha256 // ""' <<<"$head")"
+            remote_size="$(jq -r '.ContentLength // -1' <<<"$head")"
+            [ "$remote_sha" = "$local_sha" ] && [ "$remote_size" = "$local_size" ] || {
+              echo "Worker artifact verification failed after upload: $key"
+              return 1
+            }
+          }
+
+          mapfile -d '' worker_payloads < <(
+            find release-worker -maxdepth 1 -type f ! -name manifest.json -print0 | sort -z
+          )
+          [ "${#worker_payloads[@]}" -ge 2 ] || {
+            echo "Expected worker payload and checksum before publishing manifest"
+            exit 1
+          }
+          test -f release-worker/manifest.json
+
+          # The manifest is the release commit marker. Payloads must be present
+          # and verified first so an interrupted upload never exposes a usable
+          # update that is missing its archive.
+          for file in "${worker_payloads[@]}"; do
+            publish_immutable_worker_file "$file"
+          done
+          publish_immutable_worker_file release-worker/manifest.json
 
           MANIFEST_URL="https://${TOS_WORKER_BUCKET}.tos-${TOS_WORKER_REGION}.volces.com/${WORKER_PREFIX}/manifest.json"
-          anonymous_status="$(curl --silent --output /dev/null --write-out '%{http_code}' "$MANIFEST_URL")"
-          if [ "$anonymous_status" != "403" ] && [ "$anonymous_status" != "404" ]; then
-            echo "Private worker manifest unexpectedly returned HTTP ${anonymous_status} to an anonymous request"
+          verify_private_manifest() {
+            local anonymous_status
+            anonymous_status="$(curl --silent --show-error --output /dev/null \
+              --write-out '%{http_code}' --connect-timeout 15 --max-time 60 "$MANIFEST_URL")" || return 1
+            if [ "$anonymous_status" = "403" ] || [ "$anonymous_status" = "404" ]; then
+              return 0
+            fi
+            if [ "$anonymous_status" = "200" ]; then
+              echo "Private worker manifest is publicly readable"
+              return 2
+            fi
+            echo "Anonymous privacy probe returned transient HTTP $anonymous_status"
+            return 1
+          }
+          retry 4 verify_private_manifest || {
+            echo "Private worker manifest privacy verification failed"
             exit 1
-          fi
+          }
 
       - name: Expose replicated payloads in Guangzhou bucket
         run: |
@@ -739,3 +814,82 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release edit "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --draft=false
+
+      - name: Prune old Guangzhou desktop releases
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          TARGET_ENDPOINT_URL="https://tos-s3-${TOS_TARGET_REGION}.volces.com"
+          RETENTION_DIR="$(mktemp -d)"
+          trap 'rm -rf "$RETENTION_DIR"' EXIT
+
+          retry() {
+            local max_attempts="$1"
+            shift
+            local attempt=1
+            until "$@"; do
+              if [ "$attempt" -ge "$max_attempts" ]; then
+                return 1
+              fi
+              sleep $((attempt * 3))
+              attempt=$((attempt + 1))
+            done
+          }
+
+          list_releases() {
+            aws s3api list-objects-v2 \
+              --bucket "$TOS_TARGET_BUCKET" \
+              --prefix update/ \
+              --endpoint-url "$TARGET_ENDPOINT_URL" \
+              --output json > "$1"
+          }
+
+          retry 4 list_releases "$RETENTION_DIR/before.json"
+          node scripts/plan-release-retention.mjs \
+            --listing "$RETENTION_DIR/before.json" \
+            --metadata release-win/latest.yml \
+            --metadata release-linux/latest-linux.yml \
+            --metadata release-mac/x64/latest-mac.yml \
+            --metadata release-mac/arm64/latest-mac.yml \
+            --keep-versions 3 \
+            --min-age-days 30 \
+            --max-delete-objects 80 \
+            > "$RETENTION_DIR/plan.json"
+
+          jq '{policy, protectedVersions, deleteVersions, deferredVersions, totals}' "$RETENTION_DIR/plan.json"
+          delete_count="$(jq -r '.totals.deleteObjects' "$RETENTION_DIR/plan.json")"
+          if [ "$delete_count" -eq 0 ]; then
+            echo "No old Guangzhou desktop release objects are eligible for deletion"
+            exit 0
+          fi
+
+          jq '{Objects: [.deleteObjects[] | {Key: .key}], Quiet: false}' \
+            "$RETENTION_DIR/plan.json" > "$RETENTION_DIR/delete.json"
+
+          delete_batch() {
+            aws s3api delete-objects \
+              --bucket "$TOS_TARGET_BUCKET" \
+              --delete "file://$RETENTION_DIR/delete.json" \
+              --endpoint-url "$TARGET_ENDPOINT_URL" \
+              --output json > "$RETENTION_DIR/delete-result.json" \
+              && jq -e '(.Errors // []) | length == 0' "$RETENTION_DIR/delete-result.json" >/dev/null
+          }
+          retry 3 delete_batch
+
+          verify_deleted() {
+            list_releases "$RETENTION_DIR/after.json" || return 1
+            jq -n -e \
+              --slurpfile plan "$RETENTION_DIR/plan.json" \
+              --slurpfile after "$RETENTION_DIR/after.json" '
+                ($plan[0].deleteObjects | map(.key)) as $deleted
+                | ($after[0].Contents // [] | map(.Key)) as $remaining
+                | [$deleted[] | select(. as $key | $remaining | index($key))] | length == 0
+              ' >/dev/null
+          }
+          retry 4 verify_deleted || {
+            echo "One or more old release objects still exist after the delete request"
+            exit 1
+          }
+
+          echo "Deleted $delete_count old release objects; current metadata and the newest three versions were preserved"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -320,8 +320,48 @@ jobs:
             release/*.deb
             release/latest-linux.yml
 
+  build-worker:
+    needs: release-preflight
+    runs-on: ubuntu-24.04
+    env:
+      NODE_VERSION: "22.23.1"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --prefer-offline --no-audit --fund=false
+
+      - name: Build deterministic worker artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          raw_manifest="$RUNNER_TEMP/worker-build-manifest.json"
+          npm run --silent worker:artifact > "$raw_manifest"
+          artifact="$(jq -r '.artifactPath' "$raw_manifest")"
+          test -f "$artifact"
+          jq --arg artifact_file "$(basename "$artifact")" \
+            'del(.artifactPath) + {artifactFile: $artifact_file}' \
+            "$raw_manifest" > release/worker/manifest.json
+
+      - name: Upload worker artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: worker-release
+          if-no-files-found: error
+          path: |
+            release/worker/*.tar.gz
+            release/worker/*.sha256
+            release/worker/manifest.json
+
   release:
-    needs: [build-mac, build-win, build-linux]
+    needs: [build-mac, build-win, build-linux, build-worker]
     runs-on: ubuntu-latest
     environment: release-prod
     permissions:
@@ -368,6 +408,12 @@ jobs:
         with:
           name: linux-release
           path: release-linux
+
+      - name: Download worker artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: worker-release
+          path: release-worker
 
       - name: Verify collected macOS release artifacts
         shell: bash
@@ -424,6 +470,9 @@ jobs:
               release-mac/arm64/*)
                 printf 'update/macos-arm64/%s\n' "$name"
                 ;;
+              release-worker/*)
+                printf 'update/worker/%s/%s\n' "${GITHUB_REF_NAME#v}" "$name"
+                ;;
               *)
                 printf 'update/%s\n' "$name"
                 ;;
@@ -441,7 +490,7 @@ jobs:
             target_key="$(target_key_for_file "$file")"
             upload_source_file "$file" "$target_key"
             replicated_keys+=("$target_key")
-          done < <(find release-mac release-win release-linux -type f -print0)
+          done < <(find release-mac release-win release-linux release-worker -type f -print0)
 
           printf '%s\n' "${replicated_keys[@]}" > replicated-keys.txt
 
@@ -519,6 +568,7 @@ jobs:
             release-mac/arm64/latest-mac-arm64.yml
             release-win/*
             release-linux/*
+            release-worker/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -355,6 +355,7 @@ jobs:
         with:
           name: worker-release
           if-no-files-found: error
+          retention-days: 7
           path: |
             release/worker/*.tar.gz
             release/worker/*.sha256
@@ -369,10 +370,14 @@ jobs:
     env:
       VOLC_TOS_ACCESS_KEY_ID: ${{ secrets.VOLC_TOS_ACCESS_KEY_ID }}
       VOLC_TOS_SECRET_ACCESS_KEY: ${{ secrets.VOLC_TOS_SECRET_ACCESS_KEY }}
+      VOLC_TOS_WORKER_PUBLISH_ACCESS_KEY_ID: ${{ secrets.VOLC_TOS_WORKER_PUBLISH_ACCESS_KEY_ID || secrets.VOLC_TOS_ACCESS_KEY_ID }}
+      VOLC_TOS_WORKER_PUBLISH_SECRET_ACCESS_KEY: ${{ secrets.VOLC_TOS_WORKER_PUBLISH_SECRET_ACCESS_KEY || secrets.VOLC_TOS_SECRET_ACCESS_KEY }}
       TOS_SOURCE_BUCKET: github-hk
       TOS_SOURCE_REGION: cn-hongkong
       TOS_TARGET_BUCKET: github-release
       TOS_TARGET_REGION: cn-guangzhou
+      TOS_WORKER_BUCKET: catsco-worker-release
+      TOS_WORKER_REGION: cn-guangzhou
       XIAOBA_UPDATE_BASE_URL: https://github-release.tos-cn-guangzhou.volces.com/update
       AWS_ACCESS_KEY_ID: ${{ secrets.VOLC_TOS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.VOLC_TOS_SECRET_ACCESS_KEY }}
@@ -384,6 +389,8 @@ jobs:
           set -euo pipefail
           : "${VOLC_TOS_ACCESS_KEY_ID:?VOLC_TOS_ACCESS_KEY_ID is required}"
           : "${VOLC_TOS_SECRET_ACCESS_KEY:?VOLC_TOS_SECRET_ACCESS_KEY is required}"
+          : "${VOLC_TOS_WORKER_PUBLISH_ACCESS_KEY_ID:?worker publish access key is required}"
+          : "${VOLC_TOS_WORKER_PUBLISH_SECRET_ACCESS_KEY:?worker publish secret key is required}"
 
       - name: Download macOS x64 artifacts
         uses: actions/download-artifact@v4
@@ -470,9 +477,6 @@ jobs:
               release-mac/arm64/*)
                 printf 'update/macos-arm64/%s\n' "$name"
                 ;;
-              release-worker/*)
-                printf 'update/worker/%s/%s\n' "${GITHUB_REF_NAME#v}" "$name"
-                ;;
               *)
                 printf 'update/%s\n' "$name"
                 ;;
@@ -490,7 +494,7 @@ jobs:
             target_key="$(target_key_for_file "$file")"
             upload_source_file "$file" "$target_key"
             replicated_keys+=("$target_key")
-          done < <(find release-mac release-win release-linux release-worker -type f -print0)
+          done < <(find release-mac release-win release-linux -type f -print0)
 
           printf '%s\n' "${replicated_keys[@]}" > replicated-keys.txt
 
@@ -530,6 +534,41 @@ jobs:
             wait_for_target_object "$key"
           done < replicated-keys.txt
 
+      - name: Publish private worker artifacts to Guangzhou bucket
+        shell: bash
+        env:
+          AWS_ACCESS_KEY_ID: ${{ env.VOLC_TOS_WORKER_PUBLISH_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ env.VOLC_TOS_WORKER_PUBLISH_SECRET_ACCESS_KEY }}
+        run: |
+          set -euo pipefail
+
+          WORKER_ENDPOINT_URL="https://tos-s3-${TOS_WORKER_REGION}.volces.com"
+          WORKER_VERSION="${GITHUB_REF_NAME#v}"
+          WORKER_PREFIX="update/worker/${WORKER_VERSION}"
+          IMMUTABLE_PRIVATE_CACHE_CONTROL="private, max-age=31536000, immutable"
+
+          while IFS= read -r -d '' file; do
+            name="$(basename "$file")"
+            key="${WORKER_PREFIX}/${name}"
+            aws s3 cp "$file" "s3://${TOS_WORKER_BUCKET}/${key}" \
+              --endpoint-url "$WORKER_ENDPOINT_URL" \
+              --acl private \
+              --cache-control "$IMMUTABLE_PRIVATE_CACHE_CONTROL" \
+              --only-show-errors
+            aws s3api head-object \
+              --bucket "$TOS_WORKER_BUCKET" \
+              --key "$key" \
+              --endpoint-url "$WORKER_ENDPOINT_URL" \
+              >/dev/null
+          done < <(find release-worker -maxdepth 1 -type f -print0)
+
+          MANIFEST_URL="https://${TOS_WORKER_BUCKET}.tos-${TOS_WORKER_REGION}.volces.com/${WORKER_PREFIX}/manifest.json"
+          anonymous_status="$(curl --silent --output /dev/null --write-out '%{http_code}' "$MANIFEST_URL")"
+          if [ "$anonymous_status" != "403" ] && [ "$anonymous_status" != "404" ]; then
+            echo "Private worker manifest unexpectedly returned HTTP ${anonymous_status} to an anonymous request"
+            exit 1
+          fi
+
       - name: Expose replicated payloads in Guangzhou bucket
         run: |
           set -euo pipefail
@@ -568,7 +607,6 @@ jobs:
             release-mac/arm64/latest-mac-arm64.yml
             release-win/*
             release-linux/*
-            release-worker/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -347,7 +347,10 @@ jobs:
         run: |
           set -euo pipefail
           raw_manifest="$RUNNER_TEMP/worker-build-manifest.json"
-          npm run --silent worker:artifact > "$raw_manifest"
+          npm run --silent worker:artifact -- --manifest-output "$raw_manifest"
+          jq -e '
+            .artifactPath | type == "string" and length > 0
+          ' "$raw_manifest" >/dev/null
           artifact="$(jq -r '.artifactPath' "$raw_manifest")"
           test -f "$artifact"
           jq --arg artifact_file "$(basename "$artifact")" \

--- a/.github/workflows/worker-app-update.yml
+++ b/.github/workflows/worker-app-update.yml
@@ -50,7 +50,11 @@ jobs:
       - name: Build deterministic worker artifact
         run: |
           mkdir -p release/worker
-          node scripts/build-linux-worker-artifact.mjs > release/worker/build-manifest.json
+          node scripts/build-linux-worker-artifact.mjs \
+            --manifest-output release/worker/build-manifest.json
+          jq -e '
+            .artifactPath | type == "string" and length > 0
+          ' release/worker/build-manifest.json >/dev/null
       # P2 guard: only strict vX.Y.Z release tags may reach production workers
       # (e.g. v1.0.8-fork-volc-dual-bucket-fix-... must never deploy).
       - name: Validate release tag is strict SemVer

--- a/docs/worker-artifact-update.md
+++ b/docs/worker-artifact-update.md
@@ -108,6 +108,16 @@ node scripts/deploy-worker-artifact.mjs \
 镜像负责系统/运行时底座；应用制品负责 worker 侧应用层迭代。二者并存，
 制品更新失败可回退到镜像内旧版本。
 
+## 稳定版本发布与懒加载
+
+- 正式 `vX.Y.Z` tag 的桌面发布工作流同时构建 Linux worker 制品，并发布到
+  `update/worker/<version>/`；目录包含 tar.gz、SHA256 和 `manifest.json`。
+- worker 镜像仍负责预装发布时的应用版本。已有 worker 选择其他版本时，控制面
+  只下载当前 worker 本地缺失的制品；已经存在于 `/opt/catsco/releases` 的版本
+  直接切换软链接复用。
+- 更新、回滚都保留 `/srv/catsco-agent`。重置走镜像重建，是独立操作并会清空
+  worker 本地数据。
+
 ## 相关文件
 
 - `scripts/update-worker-artifact.sh` — worker 侧更新/状态/回滚脚本

--- a/scripts/build-linux-worker-artifact.mjs
+++ b/scripts/build-linux-worker-artifact.mjs
@@ -82,6 +82,7 @@ try {
       "package-lock.json",
       "package.json",
       "prompts",
+      "scripts/update-worker-artifact.sh",
       "skills",
     ],
     options.archiveSource,

--- a/scripts/build-linux-worker-artifact.mjs
+++ b/scripts/build-linux-worker-artifact.mjs
@@ -44,6 +44,17 @@ const artifactPath = path.resolve(
   options.output ||
     path.join(outputDir, `catsco-worker-${releaseId}-linux-x64.tar.gz`),
 );
+const manifestOutputPath = options.manifestOutput
+  ? path.resolve(options.manifestOutput)
+  : "";
+if (
+  manifestOutputPath === artifactPath ||
+  manifestOutputPath === `${artifactPath}.sha256`
+) {
+  throw new Error(
+    "Manifest output must not overwrite the worker artifact or checksum",
+  );
+}
 
 if (process.platform !== "linux" || process.arch !== "x64") {
   throw new Error(
@@ -156,9 +167,17 @@ try {
     `${sha256}  ${path.basename(artifactPath)}\n`,
     "utf8",
   );
-  process.stdout.write(
-    `${JSON.stringify({ ...manifest, artifactPath, sha256 }, null, 2)}\n`,
-  );
+  const buildManifest = `${JSON.stringify(
+    { ...manifest, artifactPath, sha256 },
+    null,
+    2,
+  )}\n`;
+  if (manifestOutputPath) {
+    fs.mkdirSync(path.dirname(manifestOutputPath), { recursive: true });
+    fs.writeFileSync(manifestOutputPath, buildManifest, "utf8");
+  } else {
+    process.stdout.write(buildManifest);
+  }
 } finally {
   fs.rmSync(stagingRoot, { recursive: true, force: true });
 }
@@ -169,7 +188,7 @@ function parseArgs(args) {
     const arg = args[index];
     if (arg === "--help" || arg === "-h") {
       process.stdout.write(
-        "Usage: node scripts/build-linux-worker-artifact.mjs [--root PATH] [--output PATH] [--output-dir PATH] [--version VERSION] [--commit SHA] [--archive-source]\n",
+        "Usage: node scripts/build-linux-worker-artifact.mjs [--root PATH] [--output PATH] [--output-dir PATH] [--manifest-output PATH] [--version VERSION] [--commit SHA] [--archive-source]\n",
       );
       process.exit(0);
     }
@@ -181,6 +200,7 @@ function parseArgs(args) {
       "--root": "root",
       "--output": "output",
       "--output-dir": "outputDir",
+      "--manifest-output": "manifestOutput",
       "--version": "version",
       "--commit": "commit",
     }[arg];

--- a/scripts/plan-release-retention.mjs
+++ b/scripts/plan-release-retention.mjs
@@ -1,0 +1,176 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import yaml from 'js-yaml';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const RELEASE_PATTERNS = [
+  /^update\/CatsCo-(.+)-win\.exe(?:\.blockmap)?$/,
+  /^update\/CatsCo-(.+)-linux\.(?:AppImage|deb)(?:\.blockmap)?$/,
+  /^update\/macos-(x64|arm64)\/CatsCo-(.+)-mac-\1\.(?:dmg|zip)(?:\.blockmap)?$/,
+];
+
+function releaseVersionForKey(key) {
+  for (const pattern of RELEASE_PATTERNS) {
+    const match = pattern.exec(String(key || ''));
+    if (match) return match.length === 2 ? match[1] : match[2];
+  }
+  return '';
+}
+
+function parseVersion(value) {
+  const match = /^(\d+(?:\.\d+)*)(?:-([0-9A-Za-z.-]+))?$/.exec(String(value || ''));
+  if (!match) return null;
+  return {
+    numbers: match[1].split('.').map((part) => Number.parseInt(part, 10)),
+    prerelease: match[2] || '',
+  };
+}
+
+export function compareReleaseVersions(left, right) {
+  const a = parseVersion(left);
+  const b = parseVersion(right);
+  if (!a || !b) return String(left).localeCompare(String(right), 'en', { numeric: true });
+  const width = Math.max(a.numbers.length, b.numbers.length);
+  for (let index = 0; index < width; index += 1) {
+    const diff = (a.numbers[index] || 0) - (b.numbers[index] || 0);
+    if (diff !== 0) return diff;
+  }
+  if (a.prerelease === b.prerelease) return 0;
+  if (!a.prerelease) return 1;
+  if (!b.prerelease) return -1;
+  return a.prerelease.localeCompare(b.prerelease, 'en', { numeric: true });
+}
+
+function metadataVersions(documents) {
+  const versions = new Set();
+  for (const document of documents) {
+    const parsed = yaml.load(document);
+    if (parsed && typeof parsed === 'object' && typeof parsed.version === 'string') {
+      versions.add(parsed.version.trim());
+    }
+  }
+  return versions;
+}
+
+function groupReleaseObjects(objects) {
+  const groups = new Map();
+  const ignoredKeys = [];
+  for (const object of objects) {
+    const key = String(object?.Key || '');
+    const version = releaseVersionForKey(key);
+    if (!version) {
+      ignoredKeys.push(key);
+      continue;
+    }
+    const row = {
+      key,
+      version,
+      size: Number(object?.Size || 0),
+      lastModified: String(object?.LastModified || ''),
+    };
+    if (!groups.has(version)) groups.set(version, []);
+    groups.get(version).push(row);
+  }
+  return { groups, ignoredKeys };
+}
+
+export function buildReleaseRetentionPlan({
+  objects,
+  metadataDocuments = [],
+  keepVersions = 3,
+  minAgeDays = 30,
+  maxDeleteObjects = 80,
+  now = Date.now(),
+}) {
+  if (!Array.isArray(objects)) throw new Error('objects must be an array');
+  if (!Number.isInteger(keepVersions) || keepVersions < 1) throw new Error('keepVersions must be at least 1');
+  if (!Number.isFinite(minAgeDays) || minAgeDays < 1) throw new Error('minAgeDays must be at least 1');
+  if (!Number.isInteger(maxDeleteObjects) || maxDeleteObjects < 1) throw new Error('maxDeleteObjects must be at least 1');
+
+  const { groups, ignoredKeys } = groupReleaseObjects(objects);
+  const versions = [...groups.keys()].sort(compareReleaseVersions).reverse();
+  const protectedVersions = metadataVersions(metadataDocuments);
+  versions.slice(0, keepVersions).forEach((version) => protectedVersions.add(version));
+
+  const cutoff = now - minAgeDays * DAY_MS;
+  const eligible = versions
+    .filter((version) => !protectedVersions.has(version))
+    .map((version) => {
+      const rows = groups.get(version);
+      const timestamps = rows.map((row) => Date.parse(row.lastModified));
+      const fullyOlderThanCutoff = timestamps.every((stamp) => Number.isFinite(stamp) && stamp < cutoff);
+      return { version, rows, fullyOlderThanCutoff };
+    })
+    .filter((group) => group.fullyOlderThanCutoff)
+    .sort((left, right) => compareReleaseVersions(left.version, right.version));
+
+  const deleteObjects = [];
+  const deleteVersions = [];
+  const deferredVersions = [];
+  for (const group of eligible) {
+    if (deleteObjects.length + group.rows.length > maxDeleteObjects) {
+      deferredVersions.push(group.version);
+      continue;
+    }
+    deleteVersions.push(group.version);
+    deleteObjects.push(...group.rows.sort((a, b) => a.key.localeCompare(b.key)));
+  }
+
+  return {
+    generatedAt: new Date(now).toISOString(),
+    policy: { keepVersions, minAgeDays, maxDeleteObjects },
+    protectedVersions: [...protectedVersions].sort(compareReleaseVersions).reverse(),
+    deleteVersions,
+    deferredVersions,
+    deleteObjects,
+    ignoredKeys,
+    totals: {
+      knownVersions: versions.length,
+      knownObjects: [...groups.values()].reduce((total, rows) => total + rows.length, 0),
+      deleteObjects: deleteObjects.length,
+      deleteBytes: deleteObjects.reduce((total, row) => total + row.size, 0),
+    },
+  };
+}
+
+function parseArgs(argv) {
+  const options = { metadata: [] };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const value = argv[index + 1];
+    if (arg === '--listing') options.listing = value;
+    else if (arg === '--metadata') options.metadata.push(value);
+    else if (arg === '--keep-versions') options.keepVersions = Number(value);
+    else if (arg === '--min-age-days') options.minAgeDays = Number(value);
+    else if (arg === '--max-delete-objects') options.maxDeleteObjects = Number(value);
+    else throw new Error(`unknown argument: ${arg}`);
+    index += 1;
+  }
+  if (!options.listing) throw new Error('--listing is required');
+  return options;
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const listing = JSON.parse(fs.readFileSync(options.listing, 'utf8'));
+  const metadataDocuments = options.metadata.map((file) => fs.readFileSync(file, 'utf8'));
+  const plan = buildReleaseRetentionPlan({
+    objects: listing.Contents || [],
+    metadataDocuments,
+    keepVersions: options.keepVersions ?? 3,
+    minAgeDays: options.minAgeDays ?? 30,
+    maxDeleteObjects: options.maxDeleteObjects ?? 80,
+  });
+  process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`release retention planning failed: ${error.message}`);
+    process.exitCode = 1;
+  }
+}

--- a/tests/release-retention-plan.test.ts
+++ b/tests/release-retention-plan.test.ts
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildReleaseRetentionPlan,
+  compareReleaseVersions,
+} from '../scripts/plan-release-retention.mjs';
+
+const now = Date.parse('2026-08-17T00:00:00Z');
+const oldDate = '2026-06-01T00:00:00Z';
+
+function object(Key: string, LastModified = oldDate, Size = 10) {
+  return { Key, LastModified, Size };
+}
+
+function release(version: string, modified = oldDate) {
+  return [
+    object(`update/CatsCo-${version}-win.exe`, modified),
+    object(`update/CatsCo-${version}-win.exe.blockmap`, modified),
+    object(`update/CatsCo-${version}-linux.AppImage`, modified),
+    object(`update/macos-x64/CatsCo-${version}-mac-x64.dmg`, modified),
+    object(`update/macos-arm64/CatsCo-${version}-mac-arm64.zip`, modified),
+  ];
+}
+
+test('semantic versions sort numerically', () => {
+  assert.equal(compareReleaseVersions('1.10.0', '1.9.9') > 0, true);
+  assert.equal(compareReleaseVersions('1.4.8', '1.4.8-beta.1') > 0, true);
+});
+
+test('protects current metadata and the newest three complete releases', () => {
+  const plan = buildReleaseRetentionPlan({
+    objects: [
+      ...release('1.0.1'),
+      ...release('1.1.0'),
+      ...release('1.4.6'),
+      ...release('1.4.7'),
+      ...release('1.4.8'),
+      object('update/latest.yml'),
+      object('update/worker/1.4.8/manifest.json'),
+    ],
+    metadataDocuments: ['version: 1.4.8\npath: CatsCo-1.4.8-win.exe\n'],
+    keepVersions: 3,
+    minAgeDays: 30,
+    maxDeleteObjects: 80,
+    now,
+  });
+
+  assert.deepEqual(plan.protectedVersions, ['1.4.8', '1.4.7', '1.4.6']);
+  assert.deepEqual(plan.deleteVersions, ['1.0.1', '1.1.0']);
+  assert.equal(plan.deleteObjects.length, 10);
+  assert.equal(plan.deleteObjects.some((row) => row.key.includes('1.4.8')), false);
+  assert.deepEqual(plan.ignoredKeys.sort(), ['update/latest.yml', 'update/worker/1.4.8/manifest.json']);
+});
+
+test('does not delete a release with any recently republished artifact', () => {
+  const rows = release('1.0.1');
+  rows[2] = object(rows[2].Key, '2026-08-10T00:00:00Z');
+  const plan = buildReleaseRetentionPlan({
+    objects: [...rows, ...release('1.4.6'), ...release('1.4.7'), ...release('1.4.8')],
+    metadataDocuments: ['version: 1.4.8\n'],
+    keepVersions: 3,
+    minAgeDays: 30,
+    maxDeleteObjects: 80,
+    now,
+  });
+  assert.deepEqual(plan.deleteVersions, []);
+});
+
+test('deletion cap never splits a release group', () => {
+  const plan = buildReleaseRetentionPlan({
+    objects: [
+      ...release('1.0.0'),
+      ...release('1.0.1'),
+      ...release('1.4.6'),
+      ...release('1.4.7'),
+      ...release('1.4.8'),
+    ],
+    metadataDocuments: ['version: 1.4.8\n'],
+    keepVersions: 3,
+    minAgeDays: 30,
+    maxDeleteObjects: 5,
+    now,
+  });
+  assert.deepEqual(plan.deleteVersions, ['1.0.0']);
+  assert.deepEqual(plan.deferredVersions, ['1.0.1']);
+  assert.equal(plan.deleteObjects.length, 5);
+});

--- a/tests/worker-app-update-workflow.test.ts
+++ b/tests/worker-app-update-workflow.test.ts
@@ -66,6 +66,18 @@ test("worker app update workflow serializes deployments and uses a prod environm
   assert.match(workflow, /cancel-in-progress: false/);
 });
 
+test("worker build manifest is isolated from command stdout", () => {
+  assert.match(
+    workflow,
+    /build-linux-worker-artifact\.mjs \\\s*--manifest-output release\/worker\/build-manifest\.json/,
+  );
+  assert.doesNotMatch(
+    workflow,
+    /build-linux-worker-artifact\.mjs > release\/worker\/build-manifest\.json/,
+  );
+  assert.match(workflow, /jq -e '[\s\S]*?' release\/worker\/build-manifest\.json/);
+});
+
 test("worker app update workflow pins runner and node toolchain", () => {
   assert.match(workflow, /runs-on: ubuntu-24\.04/);
   assert.match(workflow, /NODE_VERSION: ["']22\.23\.1["']/);

--- a/tests/worker-release-artifact-workflow.test.ts
+++ b/tests/worker-release-artifact-workflow.test.ts
@@ -17,9 +17,27 @@ test('stable releases publish a versioned worker artifact and manifest', () => {
   assert.match(releaseWorkflow, /build-worker:/);
   assert.match(releaseWorkflow, /npm run --silent worker:artifact/);
   assert.match(releaseWorkflow, /release\/worker\/manifest\.json/);
-  assert.match(releaseWorkflow, /release-worker\/\*/);
-  assert.match(releaseWorkflow, /update\/worker\/%s\/%s/);
+  assert.match(releaseWorkflow, /path: release-worker/);
+  assert.match(releaseWorkflow, /find release-worker -maxdepth 1 -type f -print0/);
+  assert.match(releaseWorkflow, /TOS_WORKER_BUCKET: catsco-worker-release/);
+  assert.match(releaseWorkflow, /VOLC_TOS_WORKER_PUBLISH_ACCESS_KEY_ID/);
+  assert.match(releaseWorkflow, /retention-days: 7/);
+  assert.match(releaseWorkflow, /WORKER_PREFIX="update\/worker\/\$\{WORKER_VERSION\}"/);
+  assert.match(releaseWorkflow, /--acl private/);
+  assert.match(releaseWorkflow, /Private worker manifest unexpectedly returned HTTP/);
   assert.match(releaseWorkflow, /needs: \[build-mac, build-win, build-linux, build-worker\]/);
+});
+
+test('worker artifacts never enter the public release paths', () => {
+  const publicSourceUpload = releaseWorkflow.match(
+    /- name: Upload release payloads to Hong Kong source bucket[\s\S]*?- name: Wait for Guangzhou bucket replication/,
+  )?.[0] || '';
+  const githubRelease = releaseWorkflow.match(
+    /- name: Create draft GitHub Release[\s\S]*?- name: Publish latest metadata/,
+  )?.[0] || '';
+
+  assert.doesNotMatch(publicSourceUpload, /release-worker/);
+  assert.doesNotMatch(githubRelease, /release-worker/);
 });
 
 test('worker artifacts carry the updater used by the cloud control plane', () => {

--- a/tests/worker-release-artifact-workflow.test.ts
+++ b/tests/worker-release-artifact-workflow.test.ts
@@ -22,6 +22,7 @@ test('stable releases publish a versioned worker artifact and manifest', () => {
   assert.match(releaseWorkflow, /TOS_WORKER_BUCKET: catsco-worker-release/);
   assert.match(releaseWorkflow, /VOLC_TOS_WORKER_PUBLISH_ACCESS_KEY_ID/);
   assert.match(releaseWorkflow, /retention-days: 7/);
+  assert.match(releaseWorkflow, /aws configure set default\.s3\.addressing_style virtual/);
   assert.match(releaseWorkflow, /WORKER_PREFIX="update\/worker\/\$\{WORKER_VERSION\}"/);
   assert.match(releaseWorkflow, /--acl private/);
   assert.match(releaseWorkflow, /Private worker manifest unexpectedly returned HTTP/);

--- a/tests/worker-release-artifact-workflow.test.ts
+++ b/tests/worker-release-artifact-workflow.test.ts
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+const root = process.cwd();
+const releaseWorkflow = fs.readFileSync(
+  path.join(root, '.github', 'workflows', 'release.yml'),
+  'utf8',
+);
+const artifactBuilder = fs.readFileSync(
+  path.join(root, 'scripts', 'build-linux-worker-artifact.mjs'),
+  'utf8',
+);
+
+test('stable releases publish a versioned worker artifact and manifest', () => {
+  assert.match(releaseWorkflow, /build-worker:/);
+  assert.match(releaseWorkflow, /npm run --silent worker:artifact/);
+  assert.match(releaseWorkflow, /release\/worker\/manifest\.json/);
+  assert.match(releaseWorkflow, /release-worker\/\*/);
+  assert.match(releaseWorkflow, /update\/worker\/%s\/%s/);
+  assert.match(releaseWorkflow, /needs: \[build-mac, build-win, build-linux, build-worker\]/);
+});
+
+test('worker artifacts carry the updater used by the cloud control plane', () => {
+  assert.match(artifactBuilder, /scripts\/update-worker-artifact\.sh/);
+});

--- a/tests/worker-release-artifact-workflow.test.ts
+++ b/tests/worker-release-artifact-workflow.test.ts
@@ -15,7 +15,11 @@ const artifactBuilder = fs.readFileSync(
 
 test('stable releases publish a versioned worker artifact and manifest', () => {
   assert.match(releaseWorkflow, /build-worker:/);
-  assert.match(releaseWorkflow, /npm run --silent worker:artifact/);
+  assert.match(releaseWorkflow, /npm run --silent worker:artifact -- --manifest-output "\$raw_manifest"/);
+  assert.doesNotMatch(releaseWorkflow, /worker:artifact > "\$raw_manifest"/);
+  assert.match(artifactBuilder, /"--manifest-output": "manifestOutput"/);
+  assert.match(artifactBuilder, /fs\.writeFileSync\(manifestOutputPath, buildManifest/);
+  assert.match(artifactBuilder, /process\.stdout\.write\(buildManifest\)/);
   assert.match(releaseWorkflow, /release\/worker\/manifest\.json/);
   assert.match(releaseWorkflow, /path: release-worker/);
   assert.match(releaseWorkflow, /find release-worker -maxdepth 1 -type f ! -name manifest\.json -print0/);

--- a/tests/worker-release-artifact-workflow.test.ts
+++ b/tests/worker-release-artifact-workflow.test.ts
@@ -36,6 +36,17 @@ test('stable releases publish a versioned worker artifact and manifest', () => {
 });
 
 test('desktop releases are pruned only after publication with bounded retention', () => {
+  const releaseJob = releaseWorkflow.match(/\r?\n  release:\r?\n[\s\S]*$/)?.[0] || '';
+
+  assert.match(
+    releaseJob,
+    /- name: Checkout release retention scripts\s+uses: actions\/checkout@v4\s+with:\s+persist-credentials: false/,
+  );
+  assert.ok(
+    releaseJob.indexOf('Checkout release retention scripts')
+      < releaseJob.indexOf('Prune old Guangzhou desktop releases'),
+    'release checkout must run before the retention planner',
+  );
   assert.match(releaseWorkflow, /group: desktop-release-\$\{\{ github\.ref \}\}/);
   assert.match(releaseWorkflow, /- name: Publish GitHub Release[\s\S]*?- name: Prune old Guangzhou desktop releases/);
   assert.match(releaseWorkflow, /--keep-versions 3/);

--- a/tests/worker-release-artifact-workflow.test.ts
+++ b/tests/worker-release-artifact-workflow.test.ts
@@ -18,15 +18,28 @@ test('stable releases publish a versioned worker artifact and manifest', () => {
   assert.match(releaseWorkflow, /npm run --silent worker:artifact/);
   assert.match(releaseWorkflow, /release\/worker\/manifest\.json/);
   assert.match(releaseWorkflow, /path: release-worker/);
-  assert.match(releaseWorkflow, /find release-worker -maxdepth 1 -type f -print0/);
+  assert.match(releaseWorkflow, /find release-worker -maxdepth 1 -type f ! -name manifest\.json -print0/);
   assert.match(releaseWorkflow, /TOS_WORKER_BUCKET: catsco-worker-release/);
   assert.match(releaseWorkflow, /VOLC_TOS_WORKER_PUBLISH_ACCESS_KEY_ID/);
   assert.match(releaseWorkflow, /retention-days: 7/);
   assert.match(releaseWorkflow, /aws configure set default\.s3\.addressing_style virtual/);
   assert.match(releaseWorkflow, /WORKER_PREFIX="update\/worker\/\$\{WORKER_VERSION\}"/);
   assert.match(releaseWorkflow, /--acl private/);
-  assert.match(releaseWorkflow, /Private worker manifest unexpectedly returned HTTP/);
+  assert.match(releaseWorkflow, /publish_immutable_worker_file release-worker\/manifest\.json/);
+  assert.match(releaseWorkflow, /Refusing to overwrite immutable worker artifact/);
+  assert.match(releaseWorkflow, /Private worker manifest privacy verification failed/);
   assert.match(releaseWorkflow, /needs: \[build-mac, build-win, build-linux, build-worker\]/);
+});
+
+test('desktop releases are pruned only after publication with bounded retention', () => {
+  assert.match(releaseWorkflow, /group: desktop-release-\$\{\{ github\.ref \}\}/);
+  assert.match(releaseWorkflow, /- name: Publish GitHub Release[\s\S]*?- name: Prune old Guangzhou desktop releases/);
+  assert.match(releaseWorkflow, /--keep-versions 3/);
+  assert.match(releaseWorkflow, /--min-age-days 30/);
+  assert.match(releaseWorkflow, /--max-delete-objects 80/);
+  assert.match(releaseWorkflow, /scripts\/plan-release-retention\.mjs/);
+  assert.match(releaseWorkflow, /delete-objects/);
+  assert.match(releaseWorkflow, /One or more old release objects still exist/);
 });
 
 test('worker artifacts never enter the public release paths', () => {


### PR DESCRIPTION
## 改动

- 正式 `vX.Y.Z` 发布同时在 Linux runner 构建确定性 worker 应用制品。
- worker 制品仅上传到广州私有 TOS 桶 `catsco-worker-release/update/worker/<version>/`，不进入公开安装包桶和 GitHub Release。
- tar.gz、SHA256 和标准化 manifest 均保持私有 ACL；发布后额外验证匿名读取为 403/404。
- 发布使用独立的 worker publish Secret 名称；现有 TOS Secret 只作为迁移兜底。
- GitHub Actions 中间 worker 制品仅保留 7 天。
- worker 制品内携带对应版本的更新器，供 CatsCompany 云控制面按版本安装。

## 用户影响

为云虚拟员工提供可选择版本的更新与回滚基础；不改变现有桌面安装包构建和自动更新路径。

## 验证

- `npm run build`
- `npx tsx --test tests/worker-release-artifact-workflow.test.ts`
- 真实 TOS 烟测：鉴权下载 SHA256 一致，匿名访问返回 403
- 旧香港/广州公开桶 `update/worker/` 存量均为 0
- GitHub CI：runtime、cross-repo smoke/e2e、paired contract tests 全部通过
- `git diff --check`

## 发布顺序

先合并本 PR；再发布正式 tag，确认私有桶 manifest 和制品存在且匿名不可读；最后上线配套 CatsCompany 控制面。
