### PR TITLE
fix(skillhub): 停止每轮对话后隐式回写 Bot Skills

### DIFF
--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -61,7 +61,6 @@ import {
   reconcileCurrentBotPromptBeforeTurn,
   scheduleCurrentBotPromptReconcile,
 } from '../bot-definition/prompt-sync';
-import { scheduleCurrentBotSkillSync } from '../bot-skills/runtime';
 import { collectRemoteContextWatermarks } from './remote-context-watermarks';
 import {
   CheckpointCompactionCoordinator,
@@ -104,8 +103,6 @@ export interface AgentServices {
   };
   toolManager: ToolManager;
   skillManager: SkillManager;
-  /** Optional test seam for the after-turn Bot Skill workspace sync scheduler. */
-  afterTurnSkillSyncScheduler?: () => void;
 }
 
 export type SystemPromptProvider = () => Promise<string> | string;
@@ -834,7 +831,6 @@ export class AgentSession {
       } finally {
         this.planRuntime.clear();
         scheduleCurrentBotPromptReconcile();
-        (this.services.afterTurnSkillSyncScheduler ?? scheduleCurrentBotSkillSync)();
         this.busy = false;
         this.activeAbortController = null;
       }

--- a/tests/agent-session-abort-signal.test.ts
+++ b/tests/agent-session-abort-signal.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { AgentSession } from '../src/core/agent-session';
 
-test('AgentSession schedules Bot Skill workspace sync after a completed turn', async () => {
+test('AgentSession does not implicitly sync the Bot Skill workspace after a completed turn', async () => {
   let scheduledSyncs = 0;
   const session = new AgentSession('user:after-turn-skill-sync', buildMockServices({
     afterTurnSkillSyncScheduler() {
@@ -19,7 +19,7 @@ test('AgentSession schedules Bot Skill workspace sync after a completed turn', a
   const result = await session.handleMessage('update the current Skill');
 
   assert.equal(result.text, 'done');
-  assert.equal(scheduledSyncs, 1);
+  assert.equal(scheduledSyncs, 0);
 });
 
 test('AgentSession requestInterrupt aborts an in-flight model request', async () => {


### PR DESCRIPTION
## 背景

当前 `AgentSession` 会在每一轮对话结束时无条件调度 Bot Skill 工作区同步。只要 Agent 或其他本地操作改动了正式 `skills` 目录，下一轮结束就可能隐式上传私有版本并改写 BotDefinition；这绕过了第二阶段计划中的身份校验、版本事务、CAS 和原子激活边界。

## 本次修改

- 移除每轮对话结束后的隐式 Bot Skill 同步调度；
- 移除仅为该隐式调度保留的 `AgentServices` 测试注入口；
- 将回归测试改为明确验证：正常完成一轮对话不会自动同步正式 Skill 工作区。

## 保持不变

- 用户明确点击“发布并添加”等显式 SkillHub 操作仍按原链路执行；
- 现有显式安装、发布和 BotDefinition Skills 接口不变；
- 不修改 System Prompt、工具 definition、Skill 注入顺序或 Prompt Cache；
- 本 PR 不开放 `shared_live`，只是第二阶段 Phase A 的第一项安全收敛。

## 验证

- `npm run build`：通过；
- `npx tsx --test tests/agent-session-abort-signal.test.ts tests/bot-skills-sync.test.ts tests/skillhub-subscription.test.ts tests/dashboard-skillhub-connected-api.test.ts`：72/72 通过；
- 完整 `npm test` 已执行：1573 项中 1554 通过、10 跳过；9 项失败均来自本机缺少 `jq` / `pwsh`、云镜像脚本环境及 Node `bad port` 环境用例，与本次两个改动文件无关。

## 后续

后续 PR 再分别处理 Cloud-only reconcile、正式 Skill 工作区 fail-closed 和原子激活，避免把安全边界与模型可见工具文案混在同一个审阅单元。