### PR TITLE
fix(skillhub): Bot 激活时仅以云端 Definition 收敛 Skill

### DIFF
--- a/src/bot-definition/activation.ts
+++ b/src/bot-definition/activation.ts
@@ -224,7 +224,6 @@ export async function prepareBoundBotDefinition(
         if (
           options.acknowledgeCloudSelection !== false
           && cloudSnapshot.configured
-          && !skillSync?.localPreservedAfterError
         ) {
           try {
             await acknowledgeCloudBotDefinition(

--- a/src/bot-skills/pending-snapshot.ts
+++ b/src/bot-skills/pending-snapshot.ts
@@ -1,0 +1,216 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface BotSkillPendingSnapshotOptions {
+  runtimeRoot: string;
+  botId: string;
+  sourcePath: string;
+  recordedSourcePath?: string;
+  reason:
+    | 'activation_local_changed'
+    | 'activation_without_base'
+    | 'activation_cloud_reconcile';
+  baseRevision?: number;
+  cloudRevision: number;
+  now?: () => Date;
+}
+
+export interface BotSkillPendingSnapshotResult {
+  path: string;
+  fingerprint: string;
+  fileCount: number;
+  deduplicated: boolean;
+}
+
+interface PendingSnapshotFile {
+  path: string;
+  size: number;
+  sha256: string;
+}
+
+interface PendingSnapshotManifest {
+  schema: 'xiaoba.bot-skill-local-pending.v1';
+  botId: string;
+  sourcePath: string;
+  reason: BotSkillPendingSnapshotOptions['reason'];
+  detectedAt: string;
+  fingerprint: string;
+  cloudRevision: number;
+  baseRevision?: number;
+  files: PendingSnapshotFile[];
+}
+
+/**
+ * Preserves a complete local Skill workspace before Cloud-authoritative
+ * activation replaces it. The snapshot is evidence only and is never loaded
+ * as an active Skill workspace.
+ */
+export function snapshotPendingBotSkillWorkspace(
+  options: BotSkillPendingSnapshotOptions,
+): BotSkillPendingSnapshotResult {
+  const runtimeRoot = path.resolve(options.runtimeRoot);
+  const sourcePath = path.resolve(options.sourcePath);
+  const recordedSourcePath = path.resolve(options.recordedSourcePath ?? sourcePath);
+  const botId = normalizeBotId(options.botId);
+  const files = listWorkspaceFiles(sourcePath);
+  const fingerprint = pendingFingerprint({
+    botId,
+    sourcePath: recordedSourcePath,
+    reason: options.reason,
+    ...(options.baseRevision !== undefined ? { baseRevision: options.baseRevision } : {}),
+    cloudRevision: options.cloudRevision,
+    files,
+  });
+  const root = path.join(runtimeRoot, 'data', 'bot-skills', 'local-pending', botId);
+  const existing = findExistingSnapshot(root, fingerprint);
+  if (existing) return { path: existing, fingerprint, fileCount: files.length, deduplicated: true };
+
+  const detectedAt = (options.now ?? (() => new Date()))().toISOString();
+  const directoryName = `${detectedAt.replace(/[:.]/g, '-')}-${fingerprint}`;
+  const finalPath = path.join(root, directoryName);
+  const temporary = path.join(root, `.tmp-${process.pid}-${crypto.randomBytes(8).toString('hex')}`);
+  const packageRoot = path.join(temporary, 'package');
+  const manifest: PendingSnapshotManifest = {
+    schema: 'xiaoba.bot-skill-local-pending.v1',
+    botId,
+    sourcePath: recordedSourcePath,
+    reason: options.reason,
+    detectedAt,
+    fingerprint,
+    cloudRevision: options.cloudRevision,
+    ...(options.baseRevision !== undefined ? { baseRevision: options.baseRevision } : {}),
+    files,
+  };
+
+  fs.mkdirSync(packageRoot, { recursive: true });
+  try {
+    for (const file of files) {
+      const source = path.join(sourcePath, ...file.path.split('/'));
+      const target = path.join(packageRoot, ...file.path.split('/'));
+      fs.mkdirSync(path.dirname(target), { recursive: true });
+      fs.copyFileSync(source, target, fs.constants.COPYFILE_EXCL);
+      const copied = fileRecord(packageRoot, file.path);
+      if (copied.size !== file.size || copied.sha256 !== file.sha256) {
+        throw new Error(`Bot Skill pending snapshot verification failed: ${file.path}`);
+      }
+    }
+    fs.writeFileSync(
+      path.join(temporary, 'manifest.json'),
+      `${JSON.stringify(manifest, null, 2)}\n`,
+      { encoding: 'utf8', flag: 'wx' },
+    );
+    fs.mkdirSync(root, { recursive: true });
+    fs.renameSync(temporary, finalPath);
+    return { path: finalPath, fingerprint, fileCount: files.length, deduplicated: false };
+  } catch (error) {
+    if (fs.existsSync(temporary)) fs.rmSync(temporary, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+function listWorkspaceFiles(root: string): PendingSnapshotFile[] {
+  if (!fs.existsSync(root)) return [];
+  const rootStats = fs.lstatSync(root);
+  if (rootStats.isSymbolicLink()) {
+    throw new Error('Bot Skill pending snapshot cannot follow a symbolic link at its root.');
+  }
+  if (!rootStats.isDirectory()) throw new Error('Bot Skill workspace is not a directory.');
+
+  const files: PendingSnapshotFile[] = [];
+  const visit = (directory: string): void => {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const absolute = path.join(directory, entry.name);
+      const relative = path.relative(root, absolute).split(path.sep).join('/');
+      const stats = fs.lstatSync(absolute);
+      if (stats.isSymbolicLink()) {
+        throw new Error(`Bot Skill pending snapshot cannot follow a symbolic link: ${relative}`);
+      }
+      if (stats.isDirectory()) visit(absolute);
+      else if (stats.isFile()) files.push(fileRecord(root, relative));
+      else throw new Error(`Bot Skill pending snapshot found an unsupported file: ${relative}`);
+    }
+  };
+  visit(root);
+  return files.sort((left, right) => compareText(left.path, right.path));
+}
+
+function fileRecord(root: string, relative: string): PendingSnapshotFile {
+  const absolute = path.join(root, ...relative.split('/'));
+  const bytes = fs.readFileSync(absolute);
+  return { path: relative, size: bytes.length, sha256: sha256(bytes) };
+}
+
+function findExistingSnapshot(root: string, fingerprint: string): string | undefined {
+  if (!fs.existsSync(root)) return undefined;
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    if (!entry.isDirectory() || entry.name.startsWith('.tmp-')) continue;
+    const candidate = path.join(root, entry.name);
+    try {
+      const manifest = JSON.parse(
+        fs.readFileSync(path.join(candidate, 'manifest.json'), 'utf8'),
+      ) as Partial<PendingSnapshotManifest>;
+      const packageFiles = listWorkspaceFiles(path.join(candidate, 'package'));
+      if (
+        manifest.schema === 'xiaoba.bot-skill-local-pending.v1'
+        && manifest.fingerprint === fingerprint
+        && Array.isArray(manifest.files)
+        && snapshotFilesEqual(manifest.files, packageFiles)
+        && pendingFingerprint({
+          botId: String(manifest.botId || ''),
+          sourcePath: String(manifest.sourcePath || ''),
+          reason: manifest.reason as PendingSnapshotManifest['reason'],
+          ...(manifest.baseRevision !== undefined ? { baseRevision: manifest.baseRevision } : {}),
+          cloudRevision: Number(manifest.cloudRevision),
+          files: packageFiles,
+        }) === fingerprint
+      ) return candidate;
+    } catch {
+      // Invalid old evidence must not suppress creation of a verified snapshot.
+    }
+  }
+  return undefined;
+}
+
+function pendingFingerprint(
+  value: Pick<
+    PendingSnapshotManifest,
+    'botId' | 'sourcePath' | 'reason' | 'baseRevision' | 'cloudRevision' | 'files'
+  >,
+): string {
+  return sha256(Buffer.from(JSON.stringify({
+    botId: value.botId,
+    sourcePath: value.sourcePath,
+    reason: value.reason,
+    ...(value.baseRevision !== undefined ? { baseRevision: value.baseRevision } : {}),
+    cloudRevision: value.cloudRevision,
+    files: value.files,
+  })));
+}
+
+function snapshotFilesEqual(
+  expected: PendingSnapshotFile[],
+  actual: PendingSnapshotFile[],
+): boolean {
+  return expected.length === actual.length && expected.every((file, index) => (
+    file?.path === actual[index]?.path
+    && file?.size === actual[index]?.size
+    && file?.sha256 === actual[index]?.sha256
+  ));
+}
+
+function normalizeBotId(value: string): string {
+  const botId = String(value || '').trim();
+  if (!/^[A-Za-z0-9_.-]{1,160}$/.test(botId)) {
+    throw new Error('Invalid Bot ID for pending Skill evidence.');
+  }
+  return botId;
+}
+
+function sha256(value: Buffer): string {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function compareText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}

--- a/src/bot-skills/runtime.ts
+++ b/src/bot-skills/runtime.ts
@@ -33,7 +33,6 @@ export interface PrepareBoundBotSkillsOptions {
 export interface PreparedBoundBotSkills {
   sync?: BotSkillSyncResult;
   workspaceExisted: boolean;
-  localPreservedAfterError?: string;
   activation: BotSkillWorkspaceActivation;
 }
 
@@ -89,16 +88,18 @@ export async function prepareBoundBotSkills(
 ): Promise<PreparedBoundBotSkills> {
   const runtimeRoot = path.resolve(options.runtimeRoot);
   return withBotSkillWorkspaceLock(runtimeRoot, async () => {
-    const activeRoot = PathResolver.getRuntimeDataRoot() === runtimeRoot
-      ? PathResolver.getSkillsPath()
-      : path.join(runtimeRoot, 'skills');
-    const workspace = new BotSkillWorkspaceService(runtimeRoot, activeRoot);
-    const activeBotId = workspace.getActiveBotId();
-    if (activeBotId) {
-      BotSkillSyncService.recoverInterruptedRestore(runtimeRoot, activeBotId, activeRoot);
-    }
-    const activation = workspace.activate(options.botId);
+    let workspace: BotSkillWorkspaceService | undefined;
+    let activation: BotSkillWorkspaceActivation | undefined;
     try {
+      const activeRoot = PathResolver.getRuntimeDataRoot() === runtimeRoot
+        ? PathResolver.getSkillsPath()
+        : path.join(runtimeRoot, 'skills');
+      workspace = new BotSkillWorkspaceService(runtimeRoot, activeRoot);
+      const activeBotId = workspace.getActiveBotId();
+      if (activeBotId) {
+        BotSkillSyncService.recoverInterruptedRestore(runtimeRoot, activeBotId, activeRoot);
+      }
+      activation = workspace.activate(options.botId);
       const sync = await new BotSkillSyncService({
         runtimeRoot,
         botId: options.botId,
@@ -107,26 +108,26 @@ export async function prepareBoundBotSkills(
         workspaceExisted: activation.existed,
         fetchImpl: options.fetchImpl,
         definitionService: options.definitionService,
-      }).sync();
+      }).reconcileActivationFromCloudOnly();
       return { sync, workspaceExisted: activation.existed, activation };
     } catch (error) {
-      const message = errorMessage(error);
-      if (activation.existed && !(error instanceof BotSkillCloudRestoreError)) {
-        Logger.warning(`Bot Skill 云同步暂时失败，继续使用本地工作区: ${message}`);
-        return {
-          workspaceExisted: true,
-          localPreservedAfterError: message,
-          activation,
-        };
-      }
-      try {
-        workspace.rollback(activation);
-      } catch (rollbackError) {
-        throw new Error(
-          `Bot Skill 云端恢复失败，且工作区回滚失败: ${message}; ${errorMessage(rollbackError)}`,
+      const failure = error instanceof BotSkillCloudRestoreError
+        ? error
+        : new BotSkillCloudRestoreError(
+          `Bot Skill activation failed closed: ${errorMessage(error)}`,
+          { cause: error },
         );
+      if (workspace && activation) {
+        try {
+          workspace.rollback(activation);
+        } catch (rollbackError) {
+          throw new BotSkillCloudRestoreError(
+            `Bot Skill cloud restore failed and workspace rollback also failed: ${errorMessage(failure)}; ${errorMessage(rollbackError)}`,
+            { cause: rollbackError },
+          );
+        }
       }
-      throw error;
+      throw failure;
     }
   });
 }

--- a/src/bot-skills/sync-service.ts
+++ b/src/bot-skills/sync-service.ts
@@ -35,6 +35,7 @@ import type {
   LocalBotSkillManifestEntry,
 } from './types';
 import { applySkillHubLocalMetadata } from '../skillhub/local-skill-metadata';
+import { snapshotPendingBotSkillWorkspace } from './pending-snapshot';
 
 export type BotSkillSyncDirection =
   | 'none'
@@ -47,6 +48,11 @@ export interface BotSkillSyncResult {
   direction: BotSkillSyncDirection;
   cloudRevision?: number;
   skills: BotSkillRef[];
+  localPendingEvidence?: {
+    path: string;
+    fingerprint: string;
+    fileCount: number;
+  };
 }
 
 export interface BotSkillSyncServiceOptions {
@@ -260,6 +266,97 @@ export class BotSkillSyncService {
       cloudRevision: cloud.revision,
       skills: cloud.skills,
     };
+  }
+
+  /**
+   * Reconciles the formal Skill workspace while a Bot is being activated.
+   * Cloud BotDefinition is the only authority in this path: local changes are
+   * preserved as evidence and are never uploaded or written back to Cloud.
+   */
+  async reconcileActivationFromCloudOnly(): Promise<BotSkillSyncResult> {
+    try {
+      BotSkillSyncService.recoverInterruptedRestore(
+        this.runtimeRoot,
+        this.botId,
+        this.skillsRoot,
+      );
+      const base = this.baseStore.read(this.botId);
+      let local: LocalBotSkillManifestEntry[] = [];
+      let localReadable = true;
+      try {
+        local = this.readLocalManifest();
+      } catch {
+        localReadable = false;
+      }
+      const verifiedExisting = Boolean(
+        localReadable
+        && this.workspaceExisted
+        && fs.existsSync(this.skillsRoot)
+        && base
+        && localMatchesBase(local, base),
+      );
+
+      let cloud: CloudBotSkills | undefined;
+      try {
+        cloud = await pullCloudBotSkills(this.cloudOptions);
+      } catch (error) {
+        if (verifiedExisting) return this.featureUnavailable();
+        throw new BotSkillCloudRestoreError(
+          `Bot Skill activation requires Cloud or a verified local workspace: ${errorMessage(error)}`,
+          { cause: error },
+        );
+      }
+      if (!cloud?.definition) {
+        if (verifiedExisting) return this.featureUnavailable();
+        throw new BotSkillCloudRestoreError(
+          'Bot Skill activation requires a canonical Cloud BotDefinition.',
+        );
+      }
+
+      if (localReadable) {
+        try {
+          this.recoverInterruptedFinalizes(cloud);
+          local = this.readLocalManifest();
+        } catch {
+          localReadable = false;
+        }
+      }
+      const localChanged = !localReadable || (base
+        ? !localMatchesBase(local, base)
+        : this.workspaceExisted && fs.existsSync(this.skillsRoot));
+
+      if (
+        verifiedExisting
+        && !localChanged
+        && base
+        && botSkillRefsEqual(cloud.skills, base.skills.map(entry => entry.reference))
+      ) {
+        this.acceptCloudDefinition(cloud);
+        if (cloud.revision !== base.definitionRevision) this.writeBase(cloud, base.skills);
+        return {
+          botId: this.botId,
+          direction: 'none',
+          cloudRevision: cloud.revision,
+          skills: cloud.skills,
+        };
+      }
+
+      return this.restoreCloud(cloud, {
+        preserveUnmanaged: false,
+        pendingSnapshot: {
+          reason: localChanged
+            ? base ? 'activation_local_changed' : 'activation_without_base'
+            : 'activation_cloud_reconcile',
+          ...(base ? { baseRevision: base.definitionRevision } : {}),
+        },
+      });
+    } catch (error) {
+      if (error instanceof BotSkillCloudRestoreError) throw error;
+      throw new BotSkillCloudRestoreError(
+        `Bot Skill Cloud-only activation failed: ${errorMessage(error)}`,
+        { cause: error },
+      );
+    }
   }
 
   /**
@@ -704,9 +801,21 @@ export class BotSkillSyncService {
     throw error;
   }
 
-  private async restoreCloud(cloud: CloudBotSkills): Promise<BotSkillSyncResult> {
+  private async restoreCloud(
+    cloud: CloudBotSkills,
+    options: {
+      preserveUnmanaged?: boolean;
+      validateScope?: () => Promise<void> | void;
+      pendingSnapshot?: {
+        reason: 'activation_local_changed'
+          | 'activation_without_base'
+          | 'activation_cloud_reconcile';
+        baseRevision?: number;
+      };
+    } = {},
+  ): Promise<BotSkillSyncResult> {
     try {
-      return await this.restoreCloudUnchecked(cloud);
+      return await this.restoreCloudUnchecked(cloud, options);
     } catch (error) {
       if (error instanceof BotSkillCloudRestoreError) throw error;
       throw new BotSkillCloudRestoreError(
@@ -716,17 +825,30 @@ export class BotSkillSyncService {
     }
   }
 
-  private async restoreCloudUnchecked(cloud: CloudBotSkills): Promise<BotSkillSyncResult> {
+  private async restoreCloudUnchecked(
+    cloud: CloudBotSkills,
+    options: {
+      preserveUnmanaged?: boolean;
+      validateScope?: () => Promise<void> | void;
+      pendingSnapshot?: {
+        reason: 'activation_local_changed'
+          | 'activation_without_base'
+          | 'activation_cloud_reconcile';
+        baseRevision?: number;
+      };
+    },
+  ): Promise<BotSkillSyncResult> {
     const parent = path.dirname(this.skillsRoot);
     const operationID = `${process.pid}-${Date.now()}-${crypto.randomBytes(5).toString('hex')}`;
     const stage = path.join(parent, `.bot-skills-stage-${operationID}`);
     const backup = path.join(parent, `.bot-skills-backup-${operationID}`);
     const packages: BotSkillPackage[] = [];
-    const previousManagedRoots = fs.existsSync(this.skillsRoot)
+    const previousManagedRoots = fs.existsSync(this.skillsRoot) && options.preserveUnmanaged !== false
       ? scanBotSkillWorkspace(this.skillsRoot).map(entry => path.resolve(entry.path))
       : [];
     const previousDefinition = this.definitionService.read(this.botId);
     let entries: BotSkillSyncBaseEntry[] = [];
+    let localPendingEvidence: BotSkillSyncResult['localPendingEvidence'];
     let backedUp = false;
     let activatedStage = false;
     fs.mkdirSync(stage, { recursive: true });
@@ -739,6 +861,7 @@ export class BotSkillSyncService {
         ]),
       );
       for (const reference of cloud.skills) {
+        await options.validateScope?.();
         const packageValue = await this.privateClient.download(reference);
         await this.privateClient.materialize(
           packageValue,
@@ -767,7 +890,7 @@ export class BotSkillSyncService {
       if (!botSkillRefsEqual(restoredRefs, cloud.skills)) {
         throw new Error('Restored Bot Skill workspace does not match its cloud Definition.');
       }
-      if (fs.existsSync(this.skillsRoot)) {
+      if (fs.existsSync(this.skillsRoot) && options.preserveUnmanaged !== false) {
         copyUnmanagedWorkspaceContent(
           this.skillsRoot,
           stage,
@@ -778,9 +901,25 @@ export class BotSkillSyncService {
       }
 
       if (fs.existsSync(this.skillsRoot)) {
+        await options.validateScope?.();
         this.writeRestoreJournal({ stage, backup, phase: 'backup_pending' });
         fs.renameSync(this.skillsRoot, backup);
         backedUp = true;
+        if (options.pendingSnapshot) {
+          const snapshot = snapshotPendingBotSkillWorkspace({
+            runtimeRoot: this.runtimeRoot,
+            botId: this.botId,
+            sourcePath: backup,
+            recordedSourcePath: this.skillsRoot,
+            ...options.pendingSnapshot,
+            cloudRevision: cloud.revision,
+          });
+          localPendingEvidence = {
+            path: snapshot.path,
+            fingerprint: snapshot.fingerprint,
+            fileCount: snapshot.fileCount,
+          };
+        }
       }
       this.writeRestoreJournal({ stage, backup, phase: 'backed_up' });
       this.writeRestoreJournal({ stage, backup, phase: 'activation_pending' });
@@ -831,6 +970,7 @@ export class BotSkillSyncService {
       direction: 'cloud_to_local',
       cloudRevision: cloud.revision,
       skills: cloud.skills,
+      ...(localPendingEvidence ? { localPendingEvidence } : {}),
     };
   }
 

--- a/tests/bot-definition-activation.test.ts
+++ b/tests/bot-definition-activation.test.ts
@@ -96,6 +96,7 @@ describe('BotDefinition activation', () => {
       simulatedCloudRoot,
       env,
       fetchImpl,
+      prepareSkills: false,
     });
 
     assert.equal(prepared?.botId, 'bot-bravo');
@@ -117,7 +118,6 @@ describe('BotDefinition activation', () => {
       'GET /api.json',
       'GET /v1/models',
       'PUT /api/bot/definition/default-prompt',
-      'GET /api/bot/definition',
     ]);
   });
 
@@ -283,6 +283,7 @@ describe('BotDefinition activation', () => {
       simulatedCloudRoot,
       env,
       fetchImpl,
+      prepareSkills: false,
     });
 
     assert.equal(prepared?.cloudRevision, 2);
@@ -911,7 +912,13 @@ describe('BotDefinition activation', () => {
       return Response.json({ error: 'unexpected request' }, { status: 500 });
     }) as typeof fetch;
 
-    const prepared = await prepareBoundBotDefinition({ runtimeRoot, simulatedCloudRoot, env, fetchImpl });
+    const prepared = await prepareBoundBotDefinition({
+      runtimeRoot,
+      simulatedCloudRoot,
+      env,
+      fetchImpl,
+      prepareSkills: false,
+    });
     assert.deepStrictEqual(prepared?.definition.model, previous);
     assert.equal(prepared?.cloudRevision, undefined);
   });
@@ -959,7 +966,13 @@ describe('BotDefinition activation', () => {
       return Response.json({ error: 'unexpected request' }, { status: 500 });
     }) as typeof fetch;
 
-    const prepared = await prepareBoundBotDefinition({ runtimeRoot, simulatedCloudRoot, env, fetchImpl });
+    const prepared = await prepareBoundBotDefinition({
+      runtimeRoot,
+      simulatedCloudRoot,
+      env,
+      fetchImpl,
+      prepareSkills: false,
+    });
 
     assert.deepStrictEqual(prepared?.definition.model, customModel);
     assert.equal(prepared?.cloudRevision, undefined);

--- a/tests/bot-skills-sync.test.ts
+++ b/tests/bot-skills-sync.test.ts
@@ -12,8 +12,11 @@ import {
   scanBotSkillWorkspace,
   scanLocalBotSkill,
 } from '../src/bot-skills/local-manifest';
-import { BotSkillSyncService } from '../src/bot-skills/sync-service';
+import { prepareBoundBotSkills } from '../src/bot-skills/runtime';
+import { BotSkillCloudRestoreError, BotSkillSyncService } from '../src/bot-skills/sync-service';
+import { snapshotPendingBotSkillWorkspace } from '../src/bot-skills/pending-snapshot';
 import type { BotSkillPackage, LocalBotSkillManifestEntry } from '../src/bot-skills/types';
+import { BotSkillWorkspaceService } from '../src/bot-skills/workspace';
 import { readSkillHubInstallMarker } from '../src/skillhub/install-marker';
 import {
   applySkillHubLocalMetadata,
@@ -25,6 +28,36 @@ describe('Bot Skill Local/Base/Cloud sync', () => {
 
   afterEach(() => {
     for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('fails closed when activation service construction rejects an existing workspace', async () => {
+    const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'bot-skill-runtime-fail-closed-'));
+    roots.push(runtimeRoot);
+    const botId = 'bot-active';
+    const skillsRoot = path.join(runtimeRoot, 'skills');
+    const dirtyFile = path.join(skillsRoot, 'dirty', 'SKILL.md');
+    fs.mkdirSync(path.dirname(dirtyFile), { recursive: true });
+    fs.writeFileSync(dirtyFile, 'dirty local workspace');
+    new BotSkillWorkspaceService(runtimeRoot, skillsRoot).activate(botId);
+
+    await assert.rejects(
+      prepareBoundBotSkills({
+        runtimeRoot,
+        botId,
+        auth: {
+          httpBaseUrl: 'https://app.catsco.cc',
+          serverUrl: 'wss://app.catsco.cc/v0/channels',
+          botUid: 'bot-other',
+          apiKey: 'bot-api-key',
+        },
+        definitionService: createBotDefinitionSyncService({ runtimeRoot }),
+      }),
+      (error: unknown) => (
+        error instanceof BotSkillCloudRestoreError
+        && /failed closed/.test(error.message)
+      ),
+    );
+    assert.equal(fs.readFileSync(dirtyFile, 'utf8'), 'dirty local workspace');
   });
 
   test('uploads local edits, keeps the Base stable, and restores cloud-only changes atomically', async () => {
@@ -1652,6 +1685,289 @@ describe('Bot Skill Local/Base/Cloud sync', () => {
       previousBase,
     );
   });
+  test('activation snapshots dirty Local and restores Cloud without uploading', async () => {
+    const fixture = createFixture(roots);
+    writeSkill(fixture.skillsRoot, 'local-a', 'local-a', 'approved local');
+    await fixture.sync();
+    fixture.uploads = 0;
+    fixture.patches = 0;
+    fs.writeFileSync(
+      path.join(fixture.skillsRoot, 'local-a', 'SKILL.md'),
+      '---\nname: local-a\ndescription: unapproved local edit\n---\n',
+    );
+
+    const result = await fixture.activate();
+
+    assert.equal(result.direction, 'cloud_to_local');
+    assert.equal(fixture.uploads, 0);
+    assert.equal(fixture.patches, 0);
+    assert.match(
+      fs.readFileSync(path.join(fixture.skillsRoot, 'local-a', 'SKILL.md'), 'utf8'),
+      /approved local/,
+    );
+    const snapshot = readPendingSnapshot(fixture.runtimeRoot, fixture.botId);
+    assert.equal(result.localPendingEvidence?.path, snapshot.path);
+    assert.equal(result.localPendingEvidence?.fileCount, snapshot.manifest.files.length);
+    assert.equal(snapshot.manifest.reason, 'activation_local_changed');
+    assert.match(
+      fs.readFileSync(path.join(snapshot.path, 'package', 'local-a', 'SKILL.md'), 'utf8'),
+      /unapproved local edit/,
+    );
+  });
+
+  test('activation preserves a no-Base legacy workspace before materializing Cloud', async () => {
+    const fixture = createFixture(roots);
+    writeSkill(fixture.skillsRoot, 'legacy', 'legacy', 'legacy local only');
+    const cloudPackage = createPackage(roots, 'cloud-a', 'cloud-a', 'canonical cloud');
+    fixture.packages.set(refKey(cloudPackage.reference), cloudPackage);
+    fixture.cloud = { revision: 1, skills: [definitionRef(cloudPackage)] };
+
+    await fixture.activate();
+
+    assert.equal(fixture.uploads, 0);
+    assert.equal(fixture.patches, 0);
+    assert.equal(fs.existsSync(path.join(fixture.skillsRoot, 'legacy')), false);
+    assert.match(
+      fs.readFileSync(path.join(fixture.skillsRoot, 'cloud-a', 'SKILL.md'), 'utf8'),
+      /canonical cloud/,
+    );
+    const snapshot = readPendingSnapshot(fixture.runtimeRoot, fixture.botId);
+    assert.equal(snapshot.manifest.reason, 'activation_without_base');
+    assert.equal(snapshot.manifest.baseRevision, undefined);
+  });
+
+  test('activation can use a verified workspace while Cloud is unavailable', async () => {
+    const fixture = createFixture(roots);
+    writeSkill(fixture.skillsRoot, 'local-a', 'local-a', 'approved local');
+    await fixture.sync();
+    fixture.cloudReadStatus = 503;
+    fixture.uploads = 0;
+    fixture.patches = 0;
+
+    const result = await fixture.activate();
+
+    assert.equal(result.direction, 'feature_unavailable');
+    assert.equal(fixture.uploads, 0);
+    assert.equal(fixture.patches, 0);
+    assert.match(
+      fs.readFileSync(path.join(fixture.skillsRoot, 'local-a', 'SKILL.md'), 'utf8'),
+      /approved local/,
+    );
+  });
+
+  test('activation fails closed for an unverified workspace while Cloud is unavailable', async () => {
+    const fixture = createFixture(roots);
+    writeSkill(fixture.skillsRoot, 'local-only', 'local-only', 'not canonical');
+    fixture.cloudReadStatus = 503;
+
+    await assert.rejects(
+      fixture.activate(false),
+      /requires Cloud or a verified local workspace/i,
+    );
+    assert.equal(fixture.uploads, 0);
+    assert.equal(fixture.patches, 0);
+    assert.match(
+      fs.readFileSync(path.join(fixture.skillsRoot, 'local-only', 'SKILL.md'), 'utf8'),
+      /not canonical/,
+    );
+  });
+
+  test('activation preserves malformed Local evidence before restoring canonical Cloud', async () => {
+    const fixture = createFixture(roots);
+    writeSkill(fixture.skillsRoot, 'broken', 'broken', 'will become malformed');
+    fs.writeFileSync(path.join(fixture.skillsRoot, 'broken', 'SKILL.md'), 'not valid frontmatter');
+    const cloudPackage = createPackage(roots, 'cloud-a', 'cloud-a', 'canonical cloud');
+    fixture.packages.set(refKey(cloudPackage.reference), cloudPackage);
+    fixture.cloud = { revision: 1, skills: [definitionRef(cloudPackage)] };
+
+    await fixture.activate();
+
+    const snapshot = readPendingSnapshot(fixture.runtimeRoot, fixture.botId);
+    assert.match(
+      fs.readFileSync(path.join(snapshot.path, 'package', 'broken', 'SKILL.md'), 'utf8'),
+      /not valid frontmatter/,
+    );
+    assert.match(
+      fs.readFileSync(path.join(fixture.skillsRoot, 'cloud-a', 'SKILL.md'), 'utf8'),
+      /canonical cloud/,
+    );
+  });
+
+  test('activation snapshots Local when both Local and Cloud changed, then uses Cloud', async () => {
+    const fixture = createFixture(roots);
+    writeSkill(fixture.skillsRoot, 'local-a', 'local-a', 'approved local');
+    await fixture.sync();
+    fs.writeFileSync(
+      path.join(fixture.skillsRoot, 'local-a', 'SKILL.md'),
+      '---\nname: local-a\ndescription: unapproved local edit\n---\n',
+    );
+    const cloudPackage = createPackage(roots, 'cloud-b', 'cloud-b', 'owner approved cloud');
+    fixture.packages.set(refKey(cloudPackage.reference), cloudPackage);
+    fixture.cloud = { revision: 2, skills: [definitionRef(cloudPackage)] };
+    fixture.uploads = 0;
+    fixture.patches = 0;
+
+    await fixture.activate();
+
+    assert.equal(fixture.uploads, 0);
+    assert.equal(fixture.patches, 0);
+    assert.equal(fs.existsSync(path.join(fixture.skillsRoot, 'local-a')), false);
+    assert.match(
+      fs.readFileSync(path.join(fixture.skillsRoot, 'cloud-b', 'SKILL.md'), 'utf8'),
+      /owner approved cloud/,
+    );
+    assert.equal(readPendingSnapshot(fixture.runtimeRoot, fixture.botId).manifest.cloudRevision, 2);
+  });
+
+  test('activation snapshots a dirty parked workspace when switching back to its Bot', async () => {
+    const fixture = createFixture(roots);
+    writeSkill(fixture.skillsRoot, 'local-a', 'local-a', 'approved local');
+    await fixture.sync();
+    const workspace = new BotSkillWorkspaceService(fixture.runtimeRoot, fixture.skillsRoot);
+    workspace.activate(fixture.botId);
+    fs.writeFileSync(
+      path.join(fixture.skillsRoot, 'local-a', 'SKILL.md'),
+      '---\nname: local-a\ndescription: parked unapproved edit\n---\n',
+    );
+    workspace.activate('bot-b');
+    const returning = workspace.activate(fixture.botId);
+    assert.equal(returning.existed, true);
+    fixture.uploads = 0;
+    fixture.patches = 0;
+
+    await fixture.activate(returning.existed);
+
+    assert.equal(fixture.uploads, 0);
+    assert.equal(fixture.patches, 0);
+    assert.match(
+      fs.readFileSync(path.join(fixture.skillsRoot, 'local-a', 'SKILL.md'), 'utf8'),
+      /approved local/,
+    );
+    const snapshot = readPendingSnapshot(fixture.runtimeRoot, fixture.botId);
+    assert.match(
+      fs.readFileSync(path.join(snapshot.path, 'package', 'local-a', 'SKILL.md'), 'utf8'),
+      /parked unapproved edit/,
+    );
+  });
+
+  test('activation snapshots unscanned workspace files before a Cloud change removes them', async () => {
+    const fixture = createFixture(roots);
+    writeSkill(fixture.skillsRoot, 'local-a', 'local-a', 'approved local');
+    await fixture.sync();
+    fs.writeFileSync(path.join(fixture.skillsRoot, 'README.md'), 'local operator notes');
+    fs.mkdirSync(path.join(fixture.skillsRoot, '.drafts'), { recursive: true });
+    fs.writeFileSync(path.join(fixture.skillsRoot, '.drafts', 'idea.md'), 'recoverable draft');
+    const cloudPackage = createPackage(roots, 'cloud-b', 'cloud-b', 'canonical cloud');
+    fixture.packages.set(refKey(cloudPackage.reference), cloudPackage);
+    fixture.cloud = { revision: 2, skills: [definitionRef(cloudPackage)] };
+
+    await fixture.activate();
+
+    assert.equal(fs.existsSync(path.join(fixture.skillsRoot, 'README.md')), false);
+    const snapshot = readPendingSnapshot(fixture.runtimeRoot, fixture.botId);
+    assert.equal(snapshot.manifest.reason, 'activation_cloud_reconcile');
+    assert.equal(
+      fs.readFileSync(path.join(snapshot.path, 'package', 'README.md'), 'utf8'),
+      'local operator notes',
+    );
+    assert.equal(
+      fs.readFileSync(path.join(snapshot.path, 'package', '.drafts', 'idea.md'), 'utf8'),
+      'recoverable draft',
+    );
+  });
+
+  test('activation snapshots files created while Cloud packages are downloading', async () => {
+    const fixture = createFixture(roots);
+    fs.rmSync(fixture.skillsRoot, { recursive: true, force: true });
+    const cloudPackage = createPackage(roots, 'cloud-a', 'cloud-a', 'canonical cloud');
+    fixture.packages.set(refKey(cloudPackage.reference), cloudPackage);
+    fixture.cloud = { revision: 1, skills: [definitionRef(cloudPackage)] };
+    fixture.onPackageDownload = () => {
+      fs.mkdirSync(fixture.skillsRoot, { recursive: true });
+      fs.writeFileSync(path.join(fixture.skillsRoot, 'late-draft.md'), 'created during download');
+      fixture.onPackageDownload = undefined;
+    };
+
+    await fixture.activate(false);
+
+    assert.equal(fs.existsSync(path.join(fixture.skillsRoot, 'late-draft.md')), false);
+    const snapshot = readPendingSnapshot(fixture.runtimeRoot, fixture.botId);
+    assert.equal(snapshot.manifest.sourcePath, fixture.skillsRoot);
+    assert.equal(
+      fs.readFileSync(path.join(snapshot.path, 'package', 'late-draft.md'), 'utf8'),
+      'created during download',
+    );
+  });
+
+  test('activation fails closed for malformed Local while Cloud is unavailable', async () => {
+    const fixture = createFixture(roots);
+    writeSkill(fixture.skillsRoot, 'broken', 'broken', 'will become malformed');
+    fs.writeFileSync(path.join(fixture.skillsRoot, 'broken', 'SKILL.md'), 'not valid frontmatter');
+    fixture.cloudReadStatus = 503;
+
+    await assert.rejects(
+      fixture.activate(),
+      /requires Cloud or a verified local workspace/i,
+    );
+    assert.equal(
+      fs.readFileSync(path.join(fixture.skillsRoot, 'broken', 'SKILL.md'), 'utf8'),
+      'not valid frontmatter',
+    );
+  });
+
+  test('pending evidence dedupe rejects a snapshot whose package was corrupted', () => {
+    const fixture = createFixture(roots);
+    fs.writeFileSync(path.join(fixture.skillsRoot, 'README.md'), 'original evidence');
+    const first = snapshotPendingBotSkillWorkspace({
+      runtimeRoot: fixture.runtimeRoot,
+      botId: fixture.botId,
+      sourcePath: fixture.skillsRoot,
+      reason: 'activation_cloud_reconcile',
+      cloudRevision: 1,
+      now: () => new Date('2026-08-11T01:00:00.000Z'),
+    });
+    fs.writeFileSync(path.join(first.path, 'package', 'README.md'), 'corrupted evidence');
+
+    const second = snapshotPendingBotSkillWorkspace({
+      runtimeRoot: fixture.runtimeRoot,
+      botId: fixture.botId,
+      sourcePath: fixture.skillsRoot,
+      reason: 'activation_cloud_reconcile',
+      cloudRevision: 1,
+      now: () => new Date('2026-08-11T01:00:01.000Z'),
+    });
+
+    assert.equal(second.deduplicated, false);
+    assert.notEqual(second.path, first.path);
+    assert.equal(
+      fs.readFileSync(path.join(second.path, 'package', 'README.md'), 'utf8'),
+      'original evidence',
+    );
+  });
+
+  test('pending evidence refuses a workspace root symbolic link', () => {
+    const fixture = createFixture(roots);
+    const external = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-bot-skills-external-'));
+    roots.push(external);
+    fs.writeFileSync(path.join(external, 'secret.txt'), 'must not be copied');
+    fs.rmSync(fixture.skillsRoot, { recursive: true, force: true });
+    fs.symlinkSync(external, fixture.skillsRoot, process.platform === 'win32' ? 'junction' : 'dir');
+
+    assert.throws(
+      () => snapshotPendingBotSkillWorkspace({
+        runtimeRoot: fixture.runtimeRoot,
+        botId: fixture.botId,
+        sourcePath: fixture.skillsRoot,
+        reason: 'activation_cloud_reconcile',
+        cloudRevision: 1,
+      }),
+      /symbolic link at its root/i,
+    );
+    assert.equal(
+      fs.existsSync(path.join(fixture.runtimeRoot, 'data', 'bot-skills', 'local-pending')),
+      false,
+    );
+  });
 });
 
 function createFixture(
@@ -1688,6 +2004,7 @@ function createFixture(
     patchStatus: 200,
     publicDownloadMisses: 0,
     packageDownloads: 0,
+    onPackageDownload: undefined as undefined | (() => Promise<void> | void),
     omitSkillsField: false,
     cloudModel: { kind: 'catalog', modelId: 'minimax-m3' } as BotDefinition['model'],
     cloudPrompt: { selected: 'default' } as NonNullable<BotDefinition['prompt']>,
@@ -1705,6 +2022,20 @@ function createFixture(
       skillHubBaseUrl: 'https://hub.test',
       definitionService,
     }).sync(),
+    activate: async (workspaceExisted = true) => new BotSkillSyncService({
+      runtimeRoot,
+      skillsRoot,
+      botId,
+      workspaceExisted,
+      auth: {
+        apiKey: 'bot-key',
+        httpBaseUrl: 'https://cats.test',
+        serverUrl: 'wss://cats.test',
+      },
+      fetchImpl,
+      skillHubBaseUrl: 'https://hub.test',
+      definitionService,
+    }).reconcileActivationFromCloudOnly(),
     finalize: async (input: {
       localSkillId: string;
       skillName: string;
@@ -1813,6 +2144,7 @@ function createFixture(
     if (url.hostname === 'hub.test' && method === 'GET') {
       assert.equal(new Headers(init?.headers).get('X-CatsCo-Bot-Id'), botId);
       fixture.packageDownloads += 1;
+      await fixture.onPackageDownload?.();
       const packageValue = [...fixture.packages.values()].find(item => (
         url.pathname.includes(item.reference.version)
         && url.pathname.includes(item.reference.skillId.split('/').at(-1) || '')
@@ -1829,6 +2161,21 @@ function createFixture(
   }
 
   return fixture;
+}
+
+function readPendingSnapshot(runtimeRoot: string, botId: string): {
+  path: string;
+  manifest: any;
+} {
+  const root = path.join(runtimeRoot, 'data', 'bot-skills', 'local-pending', botId);
+  const directories = fs.readdirSync(root, { withFileTypes: true })
+    .filter(entry => entry.isDirectory() && !entry.name.startsWith('.tmp-'));
+  assert.equal(directories.length, 1);
+  const snapshotPath = path.join(root, directories[0].name);
+  return {
+    path: snapshotPath,
+    manifest: JSON.parse(fs.readFileSync(path.join(snapshotPath, 'manifest.json'), 'utf8')),
+  };
 }
 
 function writeFinalizeJournalFixture(input: {

--- a/tests/dashboard-catsco-auth-status.test.ts
+++ b/tests/dashboard-catsco-auth-status.test.ts
@@ -12,6 +12,7 @@ import { FileBotCatalogModelRuntimeRepository, FileBotDefinitionRepository } fro
 import { createBotDefinitionSyncService } from '../src/bot-definition/service';
 import { resolveActiveBotLLMConfig } from '../src/bot-definition/llm-config-resolver';
 import { BOT_CATALOG_MODEL_RUNTIME_SCHEMA, BOT_DEFINITION_SCHEMA } from '../src/bot-definition/types';
+import { BotSkillBaseStore } from '../src/bot-skills/base-store';
 
 describe('dashboard CatsCo account status', () => {
   let testRoot: string;
@@ -353,7 +354,7 @@ describe('dashboard CatsCo account status', () => {
         contextWindowTokens: 256_000,
       },
     });
-    fs.mkdirSync(path.join(testRoot, 'skills'), { recursive: true });
+    seedVerifiedEmptyBotSkillWorkspace(testRoot, '320');
 
     const service = {
       name: 'catscompany',
@@ -830,6 +831,7 @@ describe('dashboard CatsCo account status', () => {
       'CATSCO_USER_NAME=fresh',
       'CATSCO_USER_DISPLAY_NAME=Fresh User',
     ]);
+    seedVerifiedEmptyBotSkillWorkspace(testRoot, '188');
 
     const response = await fetch(`${dashboardBaseUrl}/api/cats/setup`, {
       method: 'POST',
@@ -932,6 +934,7 @@ describe('dashboard CatsCo account status', () => {
       'GAUZ_LLM_API_KEY=sk-test',
       'GAUZ_LLM_MODEL=test-model',
     ]);
+    seedVerifiedEmptyBotSkillWorkspace(testRoot, '188');
 
     const response = await fetch(`${dashboardBaseUrl}/api/cats/setup`, {
       method: 'POST',
@@ -1021,6 +1024,7 @@ describe('dashboard CatsCo account status', () => {
       'GAUZ_LLM_API_KEY=sk-test',
       'GAUZ_LLM_MODEL=test-model',
     ]);
+    seedVerifiedEmptyBotSkillWorkspace(testRoot, '199');
 
     const response = await fetch(`${dashboardBaseUrl}/api/cats/setup`, {
       method: 'POST',
@@ -1115,6 +1119,7 @@ describe('dashboard CatsCo account status', () => {
       contextWindowTokens: 200000,
       reasoningEffort: 'high',
     });
+    seedVerifiedEmptyBotSkillWorkspace(testRoot, '199');
 
     const response = await fetch(`${dashboardBaseUrl}/api/cats/bind-bot`, {
       method: 'POST',
@@ -1276,6 +1281,7 @@ describe('dashboard CatsCo account status', () => {
       botId: '188',
       model: { kind: 'catalog', modelId: 'minimax-m2.7' },
     });
+    seedVerifiedEmptyBotSkillWorkspace(testRoot, '188');
 
     const response = await fetch(`${dashboardBaseUrl}/api/cats/bind-bot`, {
       method: 'POST',
@@ -1408,6 +1414,7 @@ describe('dashboard CatsCo account status', () => {
       botId: '188',
       model: { kind: 'catalog', modelId: 'minimax-m2.7' },
     });
+    seedVerifiedEmptyBotSkillWorkspace(testRoot, '188');
 
     const response = await fetch(`${dashboardBaseUrl}/api/cats/setup`, {
       method: 'POST',
@@ -1583,6 +1590,17 @@ describe('dashboard CatsCo account status', () => {
     fs.writeFileSync(path.join(testRoot, '.env'), `${lines.join('\n')}\n`);
   }
 });
+
+function seedVerifiedEmptyBotSkillWorkspace(runtimeRoot: string, botId: string): void {
+  fs.mkdirSync(path.join(runtimeRoot, 'skills'), { recursive: true });
+  new BotSkillBaseStore(runtimeRoot).write({
+    schema: 'xiaoba.bot-skill-sync-base.v2',
+    botId,
+    definitionRevision: 0,
+    skills: [],
+    updatedAt: new Date(0).toISOString(),
+  });
+}
 
 function listen(app: express.Express): Promise<Server> {
   return new Promise(resolve => {


### PR DESCRIPTION
## 背景

第二阶段 A 阶段要求把 Bot 启动/切换时的正式 Skill 工作区收敛为 **Cloud-only**。此前 `prepareBoundBotSkills()` 复用通用 Local/Base/Cloud 双向同步，激活过程中如果发现本地变化，仍可能把本地内容上传到私有 Skill 存储并回写 BotDefinition；这与“云端是正式版本唯一权威”的新边界冲突。

本 PR 是 A2，专门修改激活路径；合并顺序应为：**先合并 #363，再合并本 PR**。

## 主要改动

- Bot 启动或切换时改用 Cloud-only reconcile：
  - 只读取云端 BotDefinition 并恢复正式 Skill；
  - 激活流程不再执行私有 Skill 上传，也不 PATCH 云端 Skills；
  - Local 与 Cloud 同时变化时始终以 Cloud 为正式运行版本。
- 覆盖本地工作区前保存完整证据：
  - 目录：`data/bot-skills/local-pending/<botId>/<timestamp>-<fingerprint>/`；
  - 保存 `manifest.json` 与完整 `package/`；
  - 逐文件校验大小和 SHA-256；
  - 损坏的历史快照不会被误判为可复用；
  - 拒绝跟随符号链接/Junction，避免越界复制。
- 云端不可用时 fail-closed：
  - 只有与 Base 完全一致、可验证的既有工作区可以暂时继续运行；
  - 无 Base、本地已修改、内容畸形或新工作区都会停止激活；
  - 激活失败时回滚 Bot 工作区切换，保留原始本地内容。
- Cloud 恢复正式工作区时不再混入未受 BotDefinition 管理的本地文件；这些内容只保留在 pending evidence 中。
- 更新旧的模型/账号路由测试，使其明确提供“已验证的空 Skill 工作区”或跳过与测试主题无关的 Skill 激活。

## 行为边界

- `local-pending` 当前只是可恢复证据，不会被加载为运行 Skill，也不会自动上传。
- 本 PR 不修改 System Prompt、模型可见工具说明、Skill 注入顺序或 Prompt cache。
- 通用同步函数仍保留给现有显式流程；后续 A3 会继续收紧正式工作区的通用写入口。

## 验证

- `npm run build`：通过
- 相关跨模块测试：137/137 通过
- Cloud-only / 快照专项测试覆盖：
  - dirty Local、Local/Cloud 同时变化；
  - 无 Base 的旧工作区；
  - Cloud outage 下 verified / unverified 分流；
  - 停放 Bot 切回、下载期间并发新增文件；
  - 畸形 Skill、损坏快照去重、符号链接；
  - 工作区切换和构造失败回滚。
- 全量测试：1,586 项，1,567 通过、10 跳过、9 失败；8 项为本机缺少 `jq`/`pwsh` 等既有云镜像测试环境，另 1 项并发端口用例单独重跑通过。未发现本 PR 引入的真实失败。