### PR TITLE
fix(skillhub): 阻止通用工具直接访问正式 Skill 工作区

### DIFF
--- a/src/bot-skills/formal-workspace-policy.ts
+++ b/src/bot-skills/formal-workspace-policy.ts
@@ -90,7 +90,20 @@ function existingRestoreWorkingPaths(): string[] {
 
 function isRestoreWorkingPath(candidatePath: string): boolean {
   const parent = path.dirname(PathResolver.getSkillsPath());
-  const relative = path.relative(parent, path.resolve(candidatePath));
+  if (isRestoreWorkingPathWithin(parent, candidatePath)) return true;
+
+  // A generic tool may reach a restore directory through a symlink/junction
+  // whose lexical path no longer carries the protected prefix. Resolve the
+  // longest existing prefix on both sides so aliases and not-yet-created
+  // children remain inside the same fail-closed boundary.
+  return isRestoreWorkingPathWithin(
+    realPathWithMissingTail(parent),
+    realPathWithMissingTail(candidatePath),
+  );
+}
+
+function isRestoreWorkingPathWithin(parentPath: string, candidatePath: string): boolean {
+  const relative = path.relative(path.resolve(parentPath), path.resolve(candidatePath));
   if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return false;
   const first = relative.split(path.sep)[0];
   return first.startsWith('.bot-skills-stage-') || first.startsWith('.bot-skills-backup-');

--- a/src/bot-skills/formal-workspace-policy.ts
+++ b/src/bot-skills/formal-workspace-policy.ts
@@ -1,0 +1,142 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import type { ToolExecutionContext } from '../types/tool';
+import { PathResolver } from '../utils/path-resolver';
+
+export type FormalBotSkillAccess = 'read' | 'write';
+
+export type FormalBotSkillAccessDecision =
+  | { ok: true }
+  | { ok: false; reason: string };
+
+/**
+ * Formal Bot Skills are materialized Cloud state. Generic tools never write
+ * them. Chat-triggered tools also cannot read or export their source; local
+ * CLI use remains readable for development and recovery.
+ */
+export function checkFormalBotSkillPathAccess(
+  context: ToolExecutionContext,
+  candidatePath: string,
+  access: FormalBotSkillAccess,
+): FormalBotSkillAccessDecision {
+  const resolved = path.resolve(candidatePath);
+  if (!isFormalBotSkillPath(resolved)) return { ok: true };
+  if (access === 'read' && !isChatTriggeredContext(context)) return { ok: true };
+  return {
+    ok: false,
+    reason: access === 'write'
+      ? 'Formal Bot Skills are Cloud-managed and cannot be changed by generic tools.'
+      : 'Chat-triggered tools cannot read or export formal Bot Skill source files.',
+  };
+}
+
+/**
+ * A broad chat search may contain a protected subtree even though the search
+ * root itself is outside it. Callers must filter each traversed path instead
+ * of sending the root to an unfiltered external search process.
+ */
+export function requiresFormalBotSkillSearchFiltering(
+  context: ToolExecutionContext,
+  searchRoot: string,
+): boolean {
+  if (!isChatTriggeredContext(context)) return false;
+  const resolved = path.resolve(searchRoot);
+  return formalBotSkillSearchPaths().some(candidate => pathsIntersect(resolved, candidate));
+}
+
+export function isChatTriggeredContext(context: ToolExecutionContext): boolean {
+  return Boolean(
+    context.deviceRpcReceiver
+    || context.surface === 'catscompany'
+    || context.executionScope?.source === 'catscompany',
+  );
+}
+
+function isFormalBotSkillPath(candidatePath: string): boolean {
+  const candidate = path.resolve(candidatePath);
+  if (formalBotSkillPaths().some(root => pathContains(root, candidate))) return true;
+  return isRestoreWorkingPath(candidate);
+}
+
+function formalBotSkillPaths(): string[] {
+  const runtimeRoot = PathResolver.getRuntimeDataRoot();
+  return uniquePaths([
+    PathResolver.getSkillsPath(),
+    path.join(runtimeRoot, 'data', 'bot-skills'),
+  ]);
+}
+
+function formalBotSkillSearchPaths(): string[] {
+  return [
+    ...formalBotSkillPaths(),
+    ...existingRestoreWorkingPaths(),
+  ];
+}
+
+function existingRestoreWorkingPaths(): string[] {
+  const parent = path.dirname(PathResolver.getSkillsPath());
+  if (!fs.existsSync(parent)) return [];
+  try {
+    return fs.readdirSync(parent, { withFileTypes: true })
+      .filter(entry => (
+        entry.isDirectory()
+        && (entry.name.startsWith('.bot-skills-stage-') || entry.name.startsWith('.bot-skills-backup-'))
+      ))
+      .map(entry => path.join(parent, entry.name));
+  } catch {
+    return [];
+  }
+}
+
+function isRestoreWorkingPath(candidatePath: string): boolean {
+  const parent = path.dirname(PathResolver.getSkillsPath());
+  const relative = path.relative(parent, path.resolve(candidatePath));
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return false;
+  const first = relative.split(path.sep)[0];
+  return first.startsWith('.bot-skills-stage-') || first.startsWith('.bot-skills-backup-');
+}
+
+function pathsIntersect(left: string, right: string): boolean {
+  return pathContains(left, right) || pathContains(right, left);
+}
+
+function pathContains(parentPath: string, candidatePath: string): boolean {
+  const parent = comparablePath(parentPath);
+  const candidate = comparablePath(candidatePath);
+  if (candidate === parent || candidate.startsWith(`${parent}${path.sep}`)) return true;
+
+  const realParent = comparablePath(realPathWithMissingTail(parentPath));
+  const realCandidate = comparablePath(realPathWithMissingTail(candidatePath));
+  return realCandidate === realParent || realCandidate.startsWith(`${realParent}${path.sep}`);
+}
+
+function realPathWithMissingTail(value: string): string {
+  const resolved = path.resolve(value);
+  let existing = resolved;
+  const tail: string[] = [];
+  while (!fs.existsSync(existing)) {
+    const parent = path.dirname(existing);
+    if (parent === existing) return resolved;
+    tail.unshift(path.basename(existing));
+    existing = parent;
+  }
+  try {
+    return path.join(fs.realpathSync.native(existing), ...tail);
+  } catch {
+    return resolved;
+  }
+}
+
+function uniquePaths(values: string[]): string[] {
+  const result = new Map<string, string>();
+  for (const value of values) {
+    const resolved = path.resolve(value);
+    result.set(comparablePath(resolved), resolved);
+  }
+  return [...result.values()];
+}
+
+function comparablePath(value: string): string {
+  const resolved = path.resolve(value);
+  return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
+}

--- a/src/tools/edit-tool.ts
+++ b/src/tools/edit-tool.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import { isToolAllowed, isPathAllowed } from '../utils/safety';
+import { checkFormalBotSkillPathAccess } from '../bot-skills/formal-workspace-policy';
 import { formatCatsCoVisiblePath } from './tool-gateway';
 import { executeRouteIfRemote, resolveExecutionRoute, targetParameterDescription } from './execution-router';
 
@@ -65,6 +66,11 @@ export class EditTool implements Tool {
     const absolutePath = path.isAbsolute(file_path)
       ? file_path
       : path.join(context.workingDirectory, file_path);
+
+    const formalAccess = checkFormalBotSkillPathAccess(context, absolutePath, 'write');
+    if (!formalAccess.ok) {
+      return { ok: false, errorCode: 'PERMISSION_DENIED', message: formalAccess.reason };
+    }
 
     const pathPermission = isPathAllowed(absolutePath, context.workingDirectory);
     if (!pathPermission.allowed) {

--- a/src/tools/execution-router.ts
+++ b/src/tools/execution-router.ts
@@ -3,6 +3,7 @@ import type { TargetRoute, ToolExecutionContext, ToolExecutionResult } from '../
 import { normalizeTargetText } from '../catscompany/runtime-context';
 import { executeRemoteDeviceRpcTool } from './device-rpc-tool';
 import { TOOL_TARGET_CONTEXT_PREFIX, TOOL_TARGET_CONTEXT_SUFFIX } from './tool-target-context';
+import { isChatTriggeredContext } from '../bot-skills/formal-workspace-policy';
 
 export type ExecutionTargetId = 'agent_self' | string;
 
@@ -48,6 +49,14 @@ export function resolveExecutionRoute(
     target?: unknown;
   },
 ): ExecutionRoute {
+  if (options.operation === 'execute_shell' && isChatTriggeredContext(context)) {
+    return {
+      ok: false,
+      errorCode: 'PERMISSION_DENIED',
+      message: 'Chat-triggered shell execution is disabled until an isolated Skill candidate workspace is available.',
+    };
+  }
+
   if (context.deviceRpcReceiver) {
     return { ok: true, mode: 'local', target: 'speaker_default', label: 'current Device RPC receiver' };
   }

--- a/src/tools/glob-tool.ts
+++ b/src/tools/glob-tool.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { glob } from 'glob';
 import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import { isReadPathAllowed } from '../utils/safety';
+import { checkFormalBotSkillPathAccess } from '../bot-skills/formal-workspace-policy';
 import { formatCatsCoVisiblePath, isCatsCoToolGatewayContext } from './tool-gateway';
 import { executeRouteIfRemote, resolveExecutionRoute, targetParameterDescription } from './execution-router';
 
@@ -148,6 +149,11 @@ export class GlobTool implements Tool {
       ? (path.isAbsolute(searchPath) ? searchPath : path.join(context.workingDirectory, searchPath))
       : context.workingDirectory;
 
+    const formalRootAccess = checkFormalBotSkillPathAccess(context, cwd, 'read');
+    if (!formalRootAccess.ok) {
+      return { ok: false, errorCode: 'PERMISSION_DENIED', message: formalRootAccess.reason };
+    }
+
     const pathPermission = isReadPathAllowed(cwd, context.workingDirectory);
     if (!pathPermission.allowed) {
       return { ok: false, errorCode: 'PERMISSION_DENIED', message: `Execution blocked: ${pathPermission.reason}` };
@@ -174,6 +180,12 @@ export class GlobTool implements Tool {
         windowsPathsNoEscape: process.platform === 'win32',
       });
       for (const match of matches) {
+        const formalAccess = checkFormalBotSkillPathAccess(
+          context,
+          path.join(cwd, String(match)),
+          'read',
+        );
+        if (!formalAccess.ok) continue;
         const normalized = normalizeRelativePath(String(match));
         if (!matchedPaths.has(normalized)) matchedPaths.set(normalized, new Set());
         matchedPaths.get(normalized)!.add(candidatePattern);

--- a/src/tools/grep-tool.ts
+++ b/src/tools/grep-tool.ts
@@ -4,6 +4,10 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import { isReadPathAllowed } from '../utils/safety';
+import {
+  checkFormalBotSkillPathAccess,
+  requiresFormalBotSkillSearchFiltering,
+} from '../bot-skills/formal-workspace-policy';
 import { formatCatsCoVisiblePath, redactCatsCoVisiblePath } from './tool-gateway';
 import { executeRouteIfRemote, resolveExecutionRoute, targetParameterDescription } from './execution-router';
 
@@ -125,6 +129,11 @@ export class GrepTool implements Tool {
       ? (path.isAbsolute(searchPath) ? searchPath : path.join(context.workingDirectory, searchPath))
       : context.workingDirectory;
 
+    const formalRootAccess = checkFormalBotSkillPathAccess(context, resolvedSearchPath, 'read');
+    if (!formalRootAccess.ok) {
+      return { ok: false, errorCode: 'PERMISSION_DENIED', message: formalRootAccess.reason };
+    }
+
     const pathPermission = isReadPathAllowed(resolvedSearchPath, context.workingDirectory);
     if (!pathPermission.allowed) {
       return { ok: false, errorCode: 'PERMISSION_DENIED', message: `执行被阻止: ${pathPermission.reason}` };
@@ -132,11 +141,17 @@ export class GrepTool implements Tool {
     const visibleSearchPath = formatCatsCoVisiblePath(context, searchPath || '.', { preserveRelative: true });
 
     // 按优先级尝试各个 fallback
-    const fallbacks = [
-      { name: 'ripgrep (rg)', fn: () => this.executeWithRipgrep(args, resolvedSearchPath, context, visibleSearchPath) },
-      { name: 'system grep', fn: () => this.executeWithSystemGrep(args, resolvedSearchPath, context, visibleSearchPath) },
-      { name: 'Node.js glob', fn: () => this.executeWithNodeJS(args, resolvedSearchPath, context, visibleSearchPath) },
-    ];
+    const nodeFallback = {
+      name: 'Node.js glob',
+      fn: () => this.executeWithNodeJS(args, resolvedSearchPath, context, visibleSearchPath),
+    };
+    const fallbacks = requiresFormalBotSkillSearchFiltering(context, resolvedSearchPath)
+      ? [nodeFallback]
+      : [
+          { name: 'ripgrep (rg)', fn: () => this.executeWithRipgrep(args, resolvedSearchPath, context, visibleSearchPath) },
+          { name: 'system grep', fn: () => this.executeWithSystemGrep(args, resolvedSearchPath, context, visibleSearchPath) },
+          nodeFallback,
+        ];
 
     let lastError: Error | null = null;
 
@@ -242,6 +257,7 @@ export class GrepTool implements Tool {
 
   private async executeWithNodeJS(args: any, searchPath: string, context: ToolExecutionContext, visibleSearchPath?: string): Promise<FallbackResult> {
     const { pattern, glob: globPattern, case_insensitive = false, output_mode = 'files' } = args;
+    const filterFormalPaths = requiresFormalBotSkillSearchFiltering(context, searchPath);
     const escapeRegex = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     const regex = new RegExp(escapeRegex(pattern), case_insensitive ? 'i' : '');
     const globRegex = globPattern
@@ -255,6 +271,7 @@ export class GrepTool implements Tool {
 
     const searchFile = async (fullPath: string, fileName: string): Promise<void> => {
       ensureNotAborted();
+      if (filterFormalPaths && !checkFormalBotSkillPathAccess(context, fullPath, 'read').ok) return;
       if (globRegex && !globRegex.test(fileName)) return;
       try {
         const lines = (await fs.promises.readFile(fullPath, {
@@ -275,6 +292,7 @@ export class GrepTool implements Tool {
 
     const walkDir = async (dir: string): Promise<void> => {
       ensureNotAborted();
+      if (filterFormalPaths && !checkFormalBotSkillPathAccess(context, dir, 'read').ok) return;
       let entries: fs.Dirent[];
       try {
         entries = await fs.promises.readdir(dir, { withFileTypes: true });

--- a/src/tools/import-file-tool.ts
+++ b/src/tools/import-file-tool.ts
@@ -8,6 +8,7 @@ import type {
   UploadedFileResult,
 } from '../types/tool';
 import { Logger } from '../utils/logger';
+import { checkFormalBotSkillPathAccess } from '../bot-skills/formal-workspace-policy';
 import { resolveToolPath } from '../utils/tool-path-resolver';
 import {
   buildExecutionRouteTargetContext,
@@ -188,6 +189,10 @@ export async function uploadImportFileSource(
   if (!validation.ok) return validation;
 
   const resolved = resolveToolPath(validation.filePath, context);
+  const formalAccess = checkFormalBotSkillPathAccess(context, resolved.absolutePath, 'read');
+  if (!formalAccess.ok) {
+    return { ok: false, errorCode: 'PERMISSION_DENIED', message: formalAccess.reason };
+  }
   if (!resolved.exists) {
     return {
       ok: false,

--- a/src/tools/read-tool.ts
+++ b/src/tools/read-tool.ts
@@ -12,6 +12,7 @@ import { resolvePrimaryModelVisionCapability } from '../utils/model-capabilities
 import { analyzeImageWithReaderProxy, ReaderProxyResult } from '../utils/reader-proxy';
 import { analyzeImageWithVisionFallback } from '../utils/vision-fallback-provider';
 import { Logger } from '../utils/logger';
+import { checkFormalBotSkillPathAccess } from '../bot-skills/formal-workspace-policy';
 import { formatPathForLog } from '../utils/log-redaction';
 import { resolveLocalFileAccess, resolveLocalFileReference } from './local-file-gateway';
 import { formatCatsCoVisiblePath } from './tool-gateway';
@@ -246,6 +247,11 @@ export class ReadTool implements Tool {
       displayPath = formatCatsCoVisiblePath(context, displayPath, { preserveRelative: true });
       visiblePath = formatCatsCoVisiblePath(context, visiblePath);
       visibleInputPath = formatCatsCoVisiblePath(context, file_path);
+    }
+
+    const formalAccess = checkFormalBotSkillPathAccess(context, absolutePath, 'read');
+    if (!formalAccess.ok) {
+      return { ok: false, errorCode: 'PERMISSION_DENIED', message: formalAccess.reason };
     }
 
     if (!fs.existsSync(absolutePath)) {

--- a/src/tools/send-file-tool.ts
+++ b/src/tools/send-file-tool.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import { Logger } from '../utils/logger';
+import { checkFormalBotSkillPathAccess } from '../bot-skills/formal-workspace-policy';
 import { resolveToolPath } from '../utils/tool-path-resolver';
 import { resolveLocalFileAccess, resolveLocalFileReference } from './local-file-gateway';
 import { resolveOutboundTarget } from './outbound-gateway';
@@ -114,6 +115,11 @@ export class SendFileTool implements Tool {
       }
       displayPath = formatCatsCoVisiblePath(context, displayPath, { preserveRelative: true });
       visibleInputPath = displayPath;
+    }
+
+    const formalAccess = checkFormalBotSkillPathAccess(context, absolutePath, 'read');
+    if (!formalAccess.ok) {
+      return { ok: false, errorCode: 'PERMISSION_DENIED', message: formalAccess.reason };
     }
 
     if (!fs.existsSync(absolutePath)) {

--- a/src/tools/write-tool.ts
+++ b/src/tools/write-tool.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import { Logger } from '../utils/logger';
+import { checkFormalBotSkillPathAccess } from '../bot-skills/formal-workspace-policy';
 import { isToolAllowed, isPathAllowed } from '../utils/safety';
 import { formatCatsCoVisiblePath } from './tool-gateway';
 import { executeRouteIfRemote, resolveExecutionRoute, targetParameterDescription } from './execution-router';
@@ -57,6 +58,11 @@ export class WriteTool implements Tool {
     const absolutePath = path.isAbsolute(file_path)
       ? file_path
       : path.join(context.workingDirectory, file_path);
+
+    const formalAccess = checkFormalBotSkillPathAccess(context, absolutePath, 'write');
+    if (!formalAccess.ok) {
+      return { ok: false, errorCode: 'PERMISSION_DENIED', message: formalAccess.reason };
+    }
 
     const pathPermission = isPathAllowed(absolutePath, context.workingDirectory);
     if (!pathPermission.allowed) {

--- a/tests/catscompany-device-rpc-tools.test.ts
+++ b/tests/catscompany-device-rpc-tools.test.ts
@@ -450,7 +450,7 @@ describe('CatsCompany Device RPC file tools', () => {
     assert.equal(fs.readFileSync(filePath, 'utf8'), 'nope');
   });
 
-  test('executes shell Device RPC operations on the selected local device', async () => {
+  test('rejects shell Device RPC operations on the selected local device', async () => {
     const captured: { result?: any } = {};
     const bot = botWithDevice(captured);
     const command = process.platform === 'win32'
@@ -465,9 +465,9 @@ describe('CatsCompany Device RPC file tools', () => {
     }));
 
     assert.ok(captured.result);
-    assert.equal(captured.result.error, undefined);
-    assert.equal(captured.result.result.ok, true);
-    assert.match(String(captured.result.result.content), /rpc-shell-ok/);
+    assert.equal(captured.result.result, undefined);
+    assert.equal(captured.result.error.code, 'PERMISSION_DENIED');
+    assert.match(String(captured.result.error.message), /isolated Skill candidate workspace/);
   });
 
   test('rejects Device RPC requests for another target device', async () => {

--- a/tests/execution-router-clean.test.ts
+++ b/tests/execution-router-clean.test.ts
@@ -170,14 +170,12 @@ test('legacy speaker_default fallback still uses Device RPC when runtime routes 
   assert.deepEqual(capturedArgs, { path: 'C:\\Users\\Alice\\Desktop', pattern: '*' });
 });
 
-test('remote execute_shell routes before local dangerous command checks', async () => {
-  let capturedCommand = '';
+test('chat-triggered execute_shell is denied before local or remote execution', async () => {
+  let rpcCalls = 0;
   const context = catsContext({
     thinToolRpc: {
-      executeTool: async request => {
-        capturedCommand = String(request.args.command || '');
-        assert.equal(request.toolName, 'execute_shell');
-        assert.equal(request.targetDeviceId, 'dev-alice-win');
+      executeTool: async () => {
+        rpcCalls += 1;
         return { ok: true, content: 'remote shell ok' };
       },
     },
@@ -188,10 +186,24 @@ test('remote execute_shell routes before local dangerous command checks', async 
     target: 'Alice',
   }, context);
 
-  assert.equal(result.ok, true);
-  assert.equal(result.ok && result.content, 'remote shell ok');
-  assert.equal(capturedCommand, 'Remove-Item -Recurse -Force C:\\Temp\\xiaoba-routing-test');
-  assert.match(result.targetContext || '', /target: Alice/);
+  assert.equal(result.ok, false);
+  assert.equal(result.ok ? '' : result.errorCode, 'PERMISSION_DENIED');
+  assert.match(result.ok ? '' : result.message, /isolated Skill candidate workspace/);
+  assert.equal(rpcCalls, 0);
+});
+
+test('local CLI execute_shell remains available', () => {
+  const route = resolveExecutionRoute({
+    workingDirectory: process.cwd(),
+    conversationHistory: [],
+    surface: 'cli',
+  }, {
+    toolName: 'execute_shell',
+    operation: 'execute_shell',
+  });
+
+  assert.equal(route.ok, true);
+  assert.equal(route.ok && route.mode, 'local');
 });
 
 test('Device RPC receiver always executes locally and does not route again', () => {

--- a/tests/formal-bot-skill-workspace.test.ts
+++ b/tests/formal-bot-skill-workspace.test.ts
@@ -24,7 +24,10 @@ describe('formal Bot Skill workspace boundary', () => {
   let safeFile: string;
   let dataFile: string;
   let stageFile: string;
+  let backupFile: string;
   let aliasRoot: string;
+  let stageAliasRoot: string;
+  let backupAliasRoot: string;
   const previousEnv = {
     userData: process.env.XIAOBA_USER_DATA_DIR,
     skills: process.env.XIAOBA_SKILLS_DIR,
@@ -38,17 +41,24 @@ describe('formal Bot Skill workspace boundary', () => {
     safeFile = path.join(workspaceRoot, 'src', 'safe.ts');
     dataFile = path.join(runtimeRoot, 'data', 'bot-skills', 'bot-1', 'base.json');
     stageFile = path.join(runtimeRoot, '.bot-skills-stage-test', 'secret-skill', 'SKILL.md');
+    backupFile = path.join(runtimeRoot, '.bot-skills-backup-test', 'secret-skill', 'SKILL.md');
     aliasRoot = path.join(workspaceRoot, 'linked-skills');
+    stageAliasRoot = path.join(workspaceRoot, 'linked-stage');
+    backupAliasRoot = path.join(workspaceRoot, 'linked-backup');
 
     fs.mkdirSync(path.dirname(skillFile), { recursive: true });
     fs.mkdirSync(path.dirname(safeFile), { recursive: true });
     fs.mkdirSync(path.dirname(dataFile), { recursive: true });
     fs.mkdirSync(path.dirname(stageFile), { recursive: true });
+    fs.mkdirSync(path.dirname(backupFile), { recursive: true });
     fs.writeFileSync(skillFile, 'shared-boundary-marker\nformal source\n', 'utf8');
     fs.writeFileSync(safeFile, 'export const marker = "shared-boundary-marker";\n', 'utf8');
     fs.writeFileSync(dataFile, '{"skill":"secret-skill"}\n', 'utf8');
     fs.writeFileSync(stageFile, 'staged formal source\n', 'utf8');
+    fs.writeFileSync(backupFile, 'backup formal source\n', 'utf8');
     fs.symlinkSync(skillsRoot, aliasRoot, process.platform === 'win32' ? 'junction' : 'dir');
+    fs.symlinkSync(path.dirname(path.dirname(stageFile)), stageAliasRoot, process.platform === 'win32' ? 'junction' : 'dir');
+    fs.symlinkSync(path.dirname(path.dirname(backupFile)), backupAliasRoot, process.platform === 'win32' ? 'junction' : 'dir');
 
     process.env.XIAOBA_USER_DATA_DIR = runtimeRoot;
     delete process.env.XIAOBA_SKILLS_DIR;
@@ -69,6 +79,9 @@ describe('formal Bot Skill workspace boundary', () => {
     assert.equal(checkFormalBotSkillPathAccess(cli, dataFile, 'write').ok, false);
     assert.equal(checkFormalBotSkillPathAccess(cli, stageFile, 'write').ok, false);
     assert.equal(checkFormalBotSkillPathAccess(cli, path.join(aliasRoot, 'secret-skill', 'SKILL.md'), 'write').ok, false);
+    assert.equal(checkFormalBotSkillPathAccess(cli, path.join(stageAliasRoot, 'secret-skill', 'SKILL.md'), 'write').ok, false);
+    assert.equal(checkFormalBotSkillPathAccess(cli, path.join(backupAliasRoot, 'secret-skill', 'SKILL.md'), 'write').ok, false);
+    assert.equal(checkFormalBotSkillPathAccess(cli, path.join(stageAliasRoot, 'new-skill', 'SKILL.md'), 'write').ok, false);
     assert.equal(checkFormalBotSkillPathAccess(cli, safeFile, 'write').ok, true);
 
     assert.equal(checkFormalBotSkillPathAccess(cli, skillFile, 'read').ok, true);
@@ -94,6 +107,22 @@ describe('formal Bot Skill workspace boundary', () => {
     assert.equal(edit.ok, false);
     assert.equal(edit.ok ? '' : edit.errorCode, 'PERMISSION_DENIED');
     assert.equal(fs.readFileSync(skillFile, 'utf8'), before);
+  });
+
+  test('stage and backup aliases cannot bypass read or write tool boundaries', async () => {
+    for (const [aliasFile, expected] of [
+      [path.join(stageAliasRoot, 'secret-skill', 'SKILL.md'), 'staged formal source\n'],
+      [path.join(backupAliasRoot, 'secret-skill', 'SKILL.md'), 'backup formal source\n'],
+    ] as const) {
+      const read = await new ReadTool().execute({ file_path: aliasFile }, catsContext());
+      assert.equal(read.ok, false);
+      assert.equal(read.ok ? '' : read.errorCode, 'PERMISSION_DENIED');
+
+      const write = await new WriteTool().execute({ file_path: aliasFile, content: 'mutated through alias' }, cliContext());
+      assert.equal(write.ok, false);
+      assert.equal(write.ok ? '' : write.errorCode, 'PERMISSION_DENIED');
+      assert.equal(fs.readFileSync(aliasFile, 'utf8'), expected);
+    }
   });
 
   test('CLI can inspect formal Skills but CatsCo read and send paths cannot', async () => {

--- a/tests/formal-bot-skill-workspace.test.ts
+++ b/tests/formal-bot-skill-workspace.test.ts
@@ -1,0 +1,206 @@
+import { after, before, describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  checkFormalBotSkillPathAccess,
+  requiresFormalBotSkillSearchFiltering,
+} from '../src/bot-skills/formal-workspace-policy';
+import { EditTool } from '../src/tools/edit-tool';
+import { GlobTool } from '../src/tools/glob-tool';
+import { GrepTool } from '../src/tools/grep-tool';
+import { uploadImportFileSource } from '../src/tools/import-file-tool';
+import { ReadTool } from '../src/tools/read-tool';
+import { SendFileTool } from '../src/tools/send-file-tool';
+import { WriteTool } from '../src/tools/write-tool';
+import type { ToolExecutionContext } from '../src/types/tool';
+
+describe('formal Bot Skill workspace boundary', () => {
+  let workspaceRoot: string;
+  let runtimeRoot: string;
+  let skillsRoot: string;
+  let skillFile: string;
+  let safeFile: string;
+  let dataFile: string;
+  let stageFile: string;
+  let aliasRoot: string;
+  const previousEnv = {
+    userData: process.env.XIAOBA_USER_DATA_DIR,
+    skills: process.env.XIAOBA_SKILLS_DIR,
+  };
+
+  before(() => {
+    workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'formal-skill-boundary-'));
+    runtimeRoot = path.join(workspaceRoot, '.dev-user-data');
+    skillsRoot = path.join(runtimeRoot, 'skills');
+    skillFile = path.join(skillsRoot, 'secret-skill', 'SKILL.md');
+    safeFile = path.join(workspaceRoot, 'src', 'safe.ts');
+    dataFile = path.join(runtimeRoot, 'data', 'bot-skills', 'bot-1', 'base.json');
+    stageFile = path.join(runtimeRoot, '.bot-skills-stage-test', 'secret-skill', 'SKILL.md');
+    aliasRoot = path.join(workspaceRoot, 'linked-skills');
+
+    fs.mkdirSync(path.dirname(skillFile), { recursive: true });
+    fs.mkdirSync(path.dirname(safeFile), { recursive: true });
+    fs.mkdirSync(path.dirname(dataFile), { recursive: true });
+    fs.mkdirSync(path.dirname(stageFile), { recursive: true });
+    fs.writeFileSync(skillFile, 'shared-boundary-marker\nformal source\n', 'utf8');
+    fs.writeFileSync(safeFile, 'export const marker = "shared-boundary-marker";\n', 'utf8');
+    fs.writeFileSync(dataFile, '{"skill":"secret-skill"}\n', 'utf8');
+    fs.writeFileSync(stageFile, 'staged formal source\n', 'utf8');
+    fs.symlinkSync(skillsRoot, aliasRoot, process.platform === 'win32' ? 'junction' : 'dir');
+
+    process.env.XIAOBA_USER_DATA_DIR = runtimeRoot;
+    delete process.env.XIAOBA_SKILLS_DIR;
+  });
+
+  after(() => {
+    restoreEnv('XIAOBA_USER_DATA_DIR', previousEnv.userData);
+    restoreEnv('XIAOBA_SKILLS_DIR', previousEnv.skills);
+    fs.rmSync(workspaceRoot, { recursive: true, force: true });
+  });
+
+  test('recognizes formal, working-copy, missing-child, and symlinked paths', () => {
+    const cli = cliContext();
+    const cats = catsContext();
+
+    assert.equal(checkFormalBotSkillPathAccess(cli, skillFile, 'write').ok, false);
+    assert.equal(checkFormalBotSkillPathAccess(cli, path.join(skillsRoot, 'new-skill', 'SKILL.md'), 'write').ok, false);
+    assert.equal(checkFormalBotSkillPathAccess(cli, dataFile, 'write').ok, false);
+    assert.equal(checkFormalBotSkillPathAccess(cli, stageFile, 'write').ok, false);
+    assert.equal(checkFormalBotSkillPathAccess(cli, path.join(aliasRoot, 'secret-skill', 'SKILL.md'), 'write').ok, false);
+    assert.equal(checkFormalBotSkillPathAccess(cli, safeFile, 'write').ok, true);
+
+    assert.equal(checkFormalBotSkillPathAccess(cli, skillFile, 'read').ok, true);
+    assert.equal(checkFormalBotSkillPathAccess(cats, skillFile, 'read').ok, false);
+    assert.equal(checkFormalBotSkillPathAccess({ ...cli, deviceRpcReceiver: true }, skillFile, 'read').ok, false);
+    assert.equal(requiresFormalBotSkillSearchFiltering(cats, workspaceRoot), true);
+    assert.equal(requiresFormalBotSkillSearchFiltering(cli, workspaceRoot), false);
+  });
+
+  test('generic write and edit tools cannot mutate formal Skills', async () => {
+    const newFile = path.join(skillsRoot, 'new-skill', 'SKILL.md');
+    const write = await new WriteTool().execute({ file_path: newFile, content: 'new' }, cliContext());
+    assert.equal(write.ok, false);
+    assert.equal(write.ok ? '' : write.errorCode, 'PERMISSION_DENIED');
+    assert.equal(fs.existsSync(newFile), false);
+
+    const before = fs.readFileSync(skillFile, 'utf8');
+    const edit = await new EditTool().execute({
+      file_path: skillFile,
+      old_string: 'formal source',
+      new_string: 'mutated source',
+    }, cliContext());
+    assert.equal(edit.ok, false);
+    assert.equal(edit.ok ? '' : edit.errorCode, 'PERMISSION_DENIED');
+    assert.equal(fs.readFileSync(skillFile, 'utf8'), before);
+  });
+
+  test('CLI can inspect formal Skills but CatsCo read and send paths cannot', async () => {
+    const cliRead = await new ReadTool().execute({ file_path: skillFile }, cliContext());
+    assert.equal(cliRead.ok, true);
+    assert.match(cliRead.ok ? String(cliRead.content) : '', /formal source/);
+
+    const catsRead = await new ReadTool().execute({ file_path: skillFile }, catsContext());
+    assert.equal(catsRead.ok, false);
+    assert.equal(catsRead.ok ? '' : catsRead.errorCode, 'PERMISSION_DENIED');
+    assert.match(catsRead.ok ? '' : catsRead.message, /cannot read or export/);
+
+    let sends = 0;
+    const send = await new SendFileTool().execute({ file_path: skillFile, file_name: 'SKILL.md' }, catsContext({
+      channel: {
+        chatId: 'chat-1',
+        reply: async () => {},
+        sendFile: async () => { sends += 1; },
+      },
+    }));
+    assert.equal(send.ok, false);
+    assert.equal(send.ok ? '' : send.errorCode, 'PERMISSION_DENIED');
+    assert.equal(sends, 0);
+  });
+
+  test('broad CatsCo glob and grep keep project results while filtering formal Skill sources', async () => {
+    const glob = await new GlobTool().execute({
+      pattern: '**/*.{md,ts}',
+      path: workspaceRoot,
+      include_hidden: true,
+    }, catsContext());
+    assert.equal(glob.ok, true);
+    assert.match(glob.ok ? String(glob.content) : '', /src\/safe\.ts/);
+    assert.doesNotMatch(glob.ok ? String(glob.content) : '', /secret-skill|SKILL\.md/);
+
+    const grep = await new GrepTool().execute({
+      pattern: 'shared-boundary-marker',
+      path: workspaceRoot,
+      output_mode: 'files',
+    }, catsContext());
+    assert.equal(grep.ok, true);
+    assert.match(grep.ok ? String(grep.content) : '', /src\/safe\.ts/);
+    assert.doesNotMatch(grep.ok ? String(grep.content) : '', /secret-skill|SKILL\.md/);
+
+    const direct = await new GrepTool().execute({
+      pattern: 'shared-boundary-marker',
+      path: skillsRoot,
+      output_mode: 'files',
+    }, catsContext());
+    assert.equal(direct.ok, false);
+    assert.equal(direct.ok ? '' : direct.errorCode, 'PERMISSION_DENIED');
+  });
+
+  test('Device RPC import cannot upload a formal Skill source file', async () => {
+    let uploads = 0;
+    const result = await uploadImportFileSource({
+      file_path: skillFile,
+      file_name: 'SKILL.md',
+    }, {
+      ...cliContext(),
+      deviceRpcReceiver: true,
+    }, async () => {
+      uploads += 1;
+      return { url: '/uploads/SKILL.md', name: 'SKILL.md', size: 1, type: 'file' };
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.ok ? '' : result.errorCode, 'PERMISSION_DENIED');
+    assert.equal(uploads, 0);
+  });
+
+  function cliContext(): ToolExecutionContext {
+    return {
+      workingDirectory: workspaceRoot,
+      workspaceRoot,
+      conversationHistory: [],
+      surface: 'cli',
+    };
+  }
+
+  function catsContext(overrides: Partial<ToolExecutionContext> = {}): ToolExecutionContext {
+    return {
+      ...cliContext(),
+      surface: 'catscompany',
+      executionScope: {
+        source: 'catscompany',
+        sessionKey: 'session-1',
+        topicId: 'topic-1',
+        topicType: 'p2p',
+        actorUserId: 'user-1',
+        agentId: 'bot-1',
+        identityTrust: 'server_canonical',
+        isTrusted: true,
+      },
+      localDeviceGrant: {
+        kind: 'local_device_grant',
+        source: 'catscompany',
+        bodyId: 'body-1',
+        installationId: 'installation-1',
+        ownerUserId: 'user-1',
+      } as ToolExecutionContext['localDeviceGrant'],
+      ...overrides,
+    };
+  }
+});
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}


### PR DESCRIPTION
## 背景

第二阶段 A 需要先把“正式 Bot Skill 工作区”收紧为云端管理的运行态副本，避免 Agent 在普通聊天或通用文件工具中绕过 SkillHub 发布流程，直接改写、读取或导出正式 Skill 源码。

这是 A3，语义合并顺序为：

1. #363 停止每轮对话后隐式回写（已合并）
2. #364 Bot 激活仅以云端 Definition 收敛
3. 本 PR 正式工作区 fail-closed

## 本次改动

- 新增统一的正式 Skill 路径策略，保护：
  - 当前运行时 `skills` 目录；
  - `data/bot-skills` 中的 Base/状态数据；
  - `.bot-skills-stage-*`、`.bot-skills-backup-*` 临时恢复目录；
  - 通过 symlink/junction 指向上述目录的别名路径；
  - 正式目录下尚未创建的子路径。
- `write_file`、`edit_file` 无论从 CLI 还是聊天触发，都不能写入正式 Skill 工作区。
- CatsCo 聊天触发的 `read_file`、`send_file`、`import_file` 不能读取或导出正式 Skill 源文件。
- CatsCo 聊天触发的 `execute_shell` 暂时关闭；等后续独立候选工作区和专用 Skill 变更工具完成后再恢复受控操作。
- `glob`/`grep` 直接指向正式目录时拒绝；搜索整个代码仓时只过滤正式 Skill 子树，不会因为开发版 `.dev-user-data/skills` 位于仓库内而让普通代码检索整体失效。
- 本机 CLI 仍允许只读检查正式 Skill，便于开发和故障恢复。
- 显式 SkillHub 发布、添加和同步接口不受影响。

## 安全边界

- 没有修改工具定义文本、system prompt、注入顺序或缓存逻辑。
- 没有引入新的自动同步或隐式上传。
- 本 PR 只收紧通用工具对正式 Skill 工作区的访问；正式变更仍必须走后续受控 Skill 流程。

## 验证

- `npm run build`：通过。
- 定向工具与 Device RPC 回归：109/109 通过。
- `npm test`：1579 项中 1561 通过；剩余 8 项均为当前 Windows 测试机缺少 `jq`、`pwsh`/天翼云镜像测试依赖造成的既有环境失败，与本 PR 无关。
- 覆盖：直接路径、未创建子路径、Base 数据目录、stage/backup、junction、CLI 只读、CatsCo 读/发/导入拒绝、宽范围 grep/glob 过滤、Device RPC Shell 拒绝。

## 审阅提示

请重点确认：

1. A 阶段暂时关闭 CatsCo Shell 的产品影响是否符合预期；
2. 宽范围代码搜索采用 Node 遍历过滤正式子树，未把整个开发仓库误判为不可搜索；
3. 本 PR 应在 #364 之后合并。