### PR TITLE
feat(skillhub): 接入可信 Runtime 授权协议

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,9 @@ CATSCOMPANY_VISION_FALLBACK_MAX_TOKENS=4096
 CATSCO_HTTP_BASE_URL=https://app.catsco.cc
 CATSCO_SERVER_URL=wss://app.catsco.cc/v0/channels
 CATSCO_API_KEY=
+# Optional owner-provisioned, body/installation-bound credential for the
+# second-stage Skill mutation grant protocol. This is not a Bot API key.
+CATSCO_RUNTIME_CREDENTIAL=
 CATSCO_BOT_UID=
 CATSCO_USER_TOKEN=
 CATSCO_USER_UID=

--- a/src/catscompany/client.ts
+++ b/src/catscompany/client.ts
@@ -858,16 +858,23 @@ export class CatsClient extends EventEmitter {
       throw new CatsSendError('ack', `Skill mutation grant request_id already pending: ${requestID}`, 409);
     }
     const msgId = `${++this.msgId}`;
+    // Keep the client request boundary explicit. Runtime identity and grant
+    // fields are server-issued result fields and must never be injectable by
+    // callers through an `as any` or plain JavaScript object.
     const message: CatsSkillMutationGrantMessage = {
-      ...request,
+      request_id: requestID,
       client_request_id: clientRequestID,
       source_topic_id: sourceTopicID,
+      source_message_id: request.source_message_id,
       local_skill_id: localSkillID,
+      operation: request.operation,
       candidate_content_hash: candidateHash,
+      candidate_size_bytes: request.candidate_size_bytes,
+      expected_definition_revision: request.expected_definition_revision,
       ...(expectedPreviousHash ? { expected_previous_content_hash: expectedPreviousHash } : {}),
+      ...(request.before_reference ? { before_reference: request.before_reference } : {}),
       id: msgId,
       type: 'request',
-      request_id: requestID,
     };
     const resultPromise = new Promise<CatsSkillMutationGrantMessage>((resolve, reject) => {
       const timer = setTimeout(() => {

--- a/src/catscompany/client.ts
+++ b/src/catscompany/client.ts
@@ -10,8 +10,11 @@ export type { UploadResult } from './upload';
 export interface CatsClientConfig {
   serverUrl: string;
   apiKey: string;
+  botUid?: string;
   bodyId?: string;
   installationId?: string;
+  runtimeCredential?: string;
+  runtimeCredentialExpiresAt?: number;
   deviceRegistration?: CatsDeviceRegistration;
   httpBaseUrl?: string;
   connectTimeoutMs?: number;
@@ -81,6 +84,42 @@ export interface CatsThinToolRpcMessage {
   error?: CatsDeviceRpcError;
   created_at?: number;
   expires_at?: number;
+}
+
+export interface CatsSkillMutationGrantMessage {
+  id?: string;
+  type: 'request' | 'result';
+  request_id: string;
+  client_request_id?: string;
+  source_topic_id?: string;
+  source_message_id?: number;
+  local_skill_id?: string;
+  operation?: 'create' | 'replace';
+  candidate_content_hash?: string;
+  candidate_size_bytes?: number;
+  expected_definition_revision?: number;
+  expected_previous_content_hash?: string;
+  before_reference?: Record<string, unknown>;
+  grant?: string;
+  expires_at?: number;
+  actor_user_id?: string;
+  agent_id?: string;
+  runtime_body_id?: string;
+  error?: CatsDeviceRpcError;
+}
+
+export interface CatsSkillMutationGrantRequest {
+  request_id?: string;
+  client_request_id: string;
+  source_topic_id: string;
+  source_message_id: number;
+  local_skill_id: string;
+  operation: 'create' | 'replace';
+  candidate_content_hash: string;
+  candidate_size_bytes: number;
+  expected_definition_revision: number;
+  expected_previous_content_hash?: string;
+  before_reference?: Record<string, unknown>;
 }
 
 export interface MessageContext {
@@ -210,6 +249,7 @@ export class CatsClient extends EventEmitter {
   private pendingAcks = new Map<string, PendingAck>();
   private pendingDeviceRpc = new Map<string, PendingDeviceRpc>();
   private pendingThinToolRpc = new Map<string, PendingThinToolRpc>();
+  private pendingSkillMutationGrants = new Map<string, PendingSkillMutationGrant>();
   private pingTimer: NodeJS.Timeout | null = null;
   private pongTimer: NodeJS.Timeout | null = null;
   private connectTimer: NodeJS.Timeout | null = null;
@@ -247,6 +287,16 @@ export class CatsClient extends EventEmitter {
       process.env.CATSCOMPANY_INSTALLATION_ID,
       bodyId,
     );
+    const configuredCredentialExpiresAt = Number(this.config.runtimeCredentialExpiresAt);
+    const configuredRuntimeCredential = !Number.isFinite(configuredCredentialExpiresAt)
+      || configuredCredentialExpiresAt > Date.now()
+      ? this.config.runtimeCredential
+      : undefined;
+    const runtimeCredential = firstNonEmpty(
+      configuredRuntimeCredential,
+      process.env.CATSCO_RUNTIME_CREDENTIAL,
+      process.env.CATSCOMPANY_RUNTIME_CREDENTIAL,
+    );
 
     Logger.info(`[CatsCompany] 正在连接: ${this.config.serverUrl}, apiKey=${maskSecret(this.config.apiKey)}, bodyId=${bodyId}`);
     this.supportsClientMessageDedupe = false;
@@ -256,6 +306,7 @@ export class CatsClient extends EventEmitter {
         'X-API-Key': this.config.apiKey,
         'X-CatsCo-Body-ID': bodyId,
         'X-CatsCo-Installation-ID': installationId,
+        ...(runtimeCredential ? { 'X-CatsCo-Runtime-Credential': runtimeCredential } : {}),
       },
     });
     this.startConnectTimeout(bodyId);
@@ -306,6 +357,10 @@ export class CatsClient extends EventEmitter {
       this.rejectPendingThinToolRpc(new CatsSendError(
         'timeout',
         'WebSocket closed before receiving Thin Tool RPC result'
+      ));
+      this.rejectPendingSkillMutationGrants(new CatsSendError(
+        'timeout',
+        'WebSocket closed before receiving a Skill mutation grant result'
       ));
       if (!this.closed) this.scheduleReconnect();
     });
@@ -359,6 +414,8 @@ export class CatsClient extends EventEmitter {
       this.handleDeviceRpcMessage(msg.device_rpc);
     } else if (msg.thin_tool_rpc) {
       this.handleThinToolRpcMessage(msg.thin_tool_rpc);
+    } else if (msg.skill_mutation_grant) {
+      this.handleSkillMutationGrantMessage(msg.skill_mutation_grant);
     } else if (msg.data) {
       Logger.info(
         `[CatsCompany] 收到消息: topic=${msg.data.topic || '-'}, ` +
@@ -459,6 +516,49 @@ export class CatsClient extends EventEmitter {
       return;
     }
     this.emit('thin_tool_rpc_request', message);
+  }
+
+  private handleSkillMutationGrantMessage(raw: any): void {
+    const message = normalizeSkillMutationGrantMessage(raw);
+    if (!message) {
+      Logger.warning('[CatsCompany] Received an invalid Skill mutation grant message; ignored');
+      return;
+    }
+    if (message.type !== 'result') return;
+    const pending = this.pendingSkillMutationGrants.get(message.request_id);
+    if (pending) {
+      clearTimeout(pending.timer);
+      this.pendingSkillMutationGrants.delete(message.request_id);
+      if (
+        !message.error
+        && (
+          message.client_request_id !== pending.request.client_request_id
+          || !this.skillMutationGrantResultMatchesRuntime(message)
+        )
+      ) {
+        pending.reject(new CatsSendError(
+          'ack',
+          `Skill mutation grant ${message.request_id} result does not match the pending candidate`,
+          409,
+        ));
+      } else {
+        pending.resolve(message);
+      }
+    }
+    this.emit('skill_mutation_grant_result', message);
+  }
+
+  private skillMutationGrantResultMatchesRuntime(message: CatsSkillMutationGrantMessage): boolean {
+    const expectedAgentID = normalizeCatsUID(this.config.botUid);
+    const expectedBodyID = firstNonEmpty(
+      this.config.bodyId,
+      process.env.CATSCO_BODY_ID,
+      process.env.CATSCOMPANY_BODY_ID,
+      process.env.CATSCO_DEVICE_ID,
+      process.env.CATSCOMPANY_DEVICE_ID,
+    );
+    return (!expectedAgentID || normalizeCatsUID(message.agent_id) === expectedAgentID)
+      && (!expectedBodyID || message.runtime_body_id === expectedBodyID);
   }
 
   private resolvePendingDeviceRpc(
@@ -727,6 +827,74 @@ export class CatsClient extends EventEmitter {
     Logger.info(`[CatsCompany][thin_tool_rpc] result acked by server: request=${requestID}, msg=${msgId}`);
   }
 
+  async requestSkillMutationGrant(
+    request: CatsSkillMutationGrantRequest,
+    timeoutMs = 15_000,
+  ): Promise<CatsSkillMutationGrantMessage> {
+    const requestID = String(request.request_id || buildSkillMutationGrantRequestID()).trim();
+    const clientRequestID = String(request.client_request_id || '').trim();
+    const sourceTopicID = String(request.source_topic_id || '').trim();
+    const localSkillID = String(request.local_skill_id || '').trim();
+    const candidateHash = String(request.candidate_content_hash || '').trim().toLowerCase();
+    const expectedPreviousHash = String(request.expected_previous_content_hash || '').trim().toLowerCase();
+    if (
+      !requestID
+      || !clientRequestID
+      || !sourceTopicID
+      || !Number.isSafeInteger(request.source_message_id)
+      || request.source_message_id <= 0
+      || !localSkillID
+      || (request.operation !== 'create' && request.operation !== 'replace')
+      || !/^[a-f0-9]{64}$/.test(candidateHash)
+      || !Number.isSafeInteger(request.candidate_size_bytes)
+      || request.candidate_size_bytes <= 0
+      || !Number.isSafeInteger(request.expected_definition_revision)
+      || request.expected_definition_revision < 0
+      || (expectedPreviousHash !== '' && !/^[a-f0-9]{64}$/.test(expectedPreviousHash))
+    ) {
+      throw new Error('Skill mutation grant request is invalid');
+    }
+    if (this.pendingSkillMutationGrants.has(requestID)) {
+      throw new CatsSendError('ack', `Skill mutation grant request_id already pending: ${requestID}`, 409);
+    }
+    const msgId = `${++this.msgId}`;
+    const message: CatsSkillMutationGrantMessage = {
+      ...request,
+      client_request_id: clientRequestID,
+      source_topic_id: sourceTopicID,
+      local_skill_id: localSkillID,
+      candidate_content_hash: candidateHash,
+      ...(expectedPreviousHash ? { expected_previous_content_hash: expectedPreviousHash } : {}),
+      id: msgId,
+      type: 'request',
+      request_id: requestID,
+    };
+    const resultPromise = new Promise<CatsSkillMutationGrantMessage>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pendingSkillMutationGrants.delete(requestID);
+        reject(new CatsSendError(
+          'timeout',
+          `Skill mutation grant ${requestID} did not receive a result in ${timeoutMs}ms`,
+        ));
+      }, timeoutMs);
+      this.pendingSkillMutationGrants.set(requestID, { request: message, resolve, reject, timer });
+    });
+    try {
+      // CatsCo returns a direct skill_mutation_grant result rather than a
+      // separate ctrl ack, so this path intentionally waits only for that
+      // candidate-bound response.
+      this.sendOrThrow({ skill_mutation_grant: message });
+    } catch (error) {
+      const pending = this.pendingSkillMutationGrants.get(requestID);
+      if (pending) {
+        clearTimeout(pending.timer);
+        this.pendingSkillMutationGrants.delete(requestID);
+      }
+      throw error;
+    }
+    return resultPromise;
+  }
+
   private sendEnvelopeWithAck(
     msgId: string,
     envelope: Record<string, unknown>,
@@ -893,6 +1061,14 @@ export class CatsClient extends EventEmitter {
     }
   }
 
+  private rejectPendingSkillMutationGrants(err: Error): void {
+    for (const [requestID, pending] of this.pendingSkillMutationGrants.entries()) {
+      clearTimeout(pending.timer);
+      this.pendingSkillMutationGrants.delete(requestID);
+      pending.reject(err);
+    }
+  }
+
   private forceReconnect(reason: string): void {
     Logger.warning(`[CatsCompany] ${reason}，主动重建 WebSocket 连接`);
     if (this.ws?.readyState === WebSocket.OPEN || this.ws?.readyState === WebSocket.CONNECTING) {
@@ -1023,6 +1199,60 @@ interface PendingThinToolRpc {
   timer: NodeJS.Timeout;
   acknowledged: boolean;
   result?: CatsThinToolRpcMessage;
+}
+
+interface PendingSkillMutationGrant {
+  request: CatsSkillMutationGrantMessage;
+  resolve: (message: CatsSkillMutationGrantMessage) => void;
+  reject: (err: Error) => void;
+  timer: NodeJS.Timeout;
+}
+
+function normalizeSkillMutationGrantMessage(raw: any): CatsSkillMutationGrantMessage | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const type = String(raw.type || '').trim();
+  const requestID = String(raw.request_id || '').trim();
+  if (type !== 'result' || !requestID) return undefined;
+  const message = { ...raw, type, request_id: requestID } as CatsSkillMutationGrantMessage;
+  if (message.error) {
+    const code = String(message.error.code || '').trim();
+    const text = String(message.error.message || '').trim();
+    if (!code || !text) return undefined;
+    message.error = { code, message: text };
+  } else {
+    const grant = String(message.grant || '').trim();
+    const clientRequestID = String(message.client_request_id || '').trim();
+    const actorUserID = String(message.actor_user_id || '').trim();
+    const agentID = String(message.agent_id || '').trim();
+    const runtimeBodyID = String(message.runtime_body_id || '').trim();
+    const expiresAt = Number(message.expires_at);
+    if (
+      !grant
+      || !clientRequestID
+      || !actorUserID
+      || !agentID
+      || !runtimeBodyID
+      || !Number.isFinite(expiresAt)
+      || expiresAt <= Date.now()
+    ) {
+      return undefined;
+    }
+    message.grant = grant;
+    message.client_request_id = clientRequestID;
+    message.actor_user_id = actorUserID;
+    message.agent_id = agentID;
+    message.runtime_body_id = runtimeBodyID;
+    message.expires_at = expiresAt;
+  }
+  return message;
+}
+
+function buildSkillMutationGrantRequestID(): string {
+  return `skill_mutation_grant_${crypto.randomUUID()}`;
+}
+
+function normalizeCatsUID(value: unknown): string {
+  return String(value || '').trim().replace(/^usr(?=\d+$)/i, '');
 }
 
 function inferHttpBaseUrl(serverUrl: string): string | undefined {

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -3,6 +3,8 @@ import {
   MessageContext,
   type CatsAgentContextMessage,
   type CatsDeviceRpcMessage,
+  type CatsSkillMutationGrantMessage,
+  type CatsSkillMutationGrantRequest,
   type CatsThinToolRpcMessage,
 } from './client';
 import { CatsCompanyConfig, ParsedCatsMessage, CatsFileInfo, type CatsCompanyRuntimeRole } from './types';
@@ -489,8 +491,11 @@ export class CatsCompanyBot {
     this.bot = new CatsClient({
       serverUrl: config.serverUrl,
       apiKey: config.apiKey,
+      botUid: config.botUid,
       bodyId: config.bodyId,
       installationId: config.installationId,
+      runtimeCredential: config.runtimeCredential,
+      runtimeCredentialExpiresAt: config.runtimeCredentialExpiresAt,
       deviceRegistration,
       httpBaseUrl: config.httpBaseUrl,
     });
@@ -604,6 +609,21 @@ export class CatsCompanyBot {
       && this.cloudSessionRestorePromises.size === 0
       && this.subAgentCompletionBatches.size === 0
       && this.sessionManager.isIdle();
+  }
+
+  /**
+   * Internal SDK boundary for the future dedicated mutation tool. This does
+   * not expose a model tool or write a Skill by itself; it only requests the
+   * candidate-bound authorization established by CatsCo.
+   */
+  requestSkillMutationGrant(
+    request: CatsSkillMutationGrantRequest,
+    timeoutMs?: number,
+  ): Promise<CatsSkillMutationGrantMessage> {
+    if (this.shuttingDown) {
+      return Promise.reject(new Error('CatsCo Runtime is shutting down'));
+    }
+    return this.bot.requestSkillMutationGrant(request, timeoutMs);
   }
 
   private async registerCurrentDevice(): Promise<void> {

--- a/src/catscompany/runtime-config.ts
+++ b/src/catscompany/runtime-config.ts
@@ -115,6 +115,11 @@ export function resolveCatsCoRuntimeConfig(
   );
   const serverUrl = firstNonEmpty(explicitServerUrl, config.catscompany?.serverUrl, auth.serverUrl);
   const rawApiKey = firstNonEmpty(auth.apiKey, config.catscompany?.apiKey);
+  const runtimeCredential = firstNonEmpty(
+    effectiveEnv.CATSCO_RUNTIME_CREDENTIAL,
+    effectiveEnv.CATSCOMPANY_RUNTIME_CREDENTIAL,
+    config.catscompany?.runtimeCredential,
+  );
   const httpBaseUrl = normalizeBaseUrl(
     firstNonEmpty(explicitHttpBaseUrl, config.catscompany?.httpBaseUrl, auth.httpBaseUrl),
     DEFAULT_CATSCO_HTTP_BASE_URL,
@@ -146,6 +151,7 @@ export function resolveCatsCoRuntimeConfig(
       botUid,
       bodyId,
       installationId,
+      runtimeCredential,
       ownerUserId,
       deviceName: localConfig.device?.name,
       runtimeRole,

--- a/src/catscompany/runtime-credential.ts
+++ b/src/catscompany/runtime-credential.ts
@@ -1,0 +1,114 @@
+import type { CatsCompanyConfig } from './types';
+import type { CatsCoAuthSnapshot } from './local-config';
+
+const RUNTIME_CREDENTIAL_SCOPE = 'skill_mutation:grant';
+const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
+
+export interface CatsCoRuntimeCredential {
+  botUid: string;
+  bodyId: string;
+  installationId: string;
+  scopes: string[];
+  credential: string;
+  expiresAt: number;
+}
+
+export interface IssueCatsCoRuntimeCredentialOptions {
+  httpBaseUrl: string;
+  userToken: string;
+  botUid: string;
+  bodyId: string;
+  installationId: string;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}
+
+export async function issueCatsCoRuntimeCredential(
+  options: IssueCatsCoRuntimeCredentialOptions,
+): Promise<CatsCoRuntimeCredential> {
+  const fetchImpl = options.fetchImpl || fetch;
+  const userToken = String(options.userToken || '').trim();
+  const botUid = String(options.botUid || '').trim();
+  const bodyId = String(options.bodyId || '').trim();
+  const installationId = String(options.installationId || '').trim();
+  if (!userToken || !/^\d+$/.test(botUid) || Number(botUid) <= 0 || !bodyId || !installationId) {
+    throw new Error('CatsCo Runtime credential request is missing a trusted owner or Runtime binding.');
+  }
+  const base = String(options.httpBaseUrl || '').trim().replace(/\/+$/, '');
+  if (!base) throw new Error('CatsCo Runtime credential endpoint is missing.');
+  const timeoutMs = Number.isFinite(options.timeoutMs) && Number(options.timeoutMs) > 0
+    ? Number(options.timeoutMs)
+    : DEFAULT_REQUEST_TIMEOUT_MS;
+  const response = await fetchImpl(`${base}/api/bots/runtime-credential`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${userToken}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: JSON.stringify({
+      bot_uid: Number(botUid),
+      body_id: bodyId,
+      installation_id: installationId,
+    }),
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (response.status !== 201) {
+    const detail = (await response.text().catch(() => '')).trim().slice(0, 200);
+    throw new Error(`CatsCo Runtime credential request failed: ${response.status}${detail ? ` ${detail}` : ''}`);
+  }
+  const payload = await response.json() as Record<string, unknown>;
+  const responseBotUid = String(payload.bot_uid || '').trim();
+  const responseBodyId = String(payload.body_id || '').trim();
+  const responseInstallationId = String(payload.installation_id || '').trim();
+  const credential = String(payload.credential || '').trim();
+  const expiresAt = Number(payload.expires_at);
+  const scopes = Array.isArray(payload.scopes)
+    ? payload.scopes.map(scope => String(scope || '').trim()).filter(Boolean)
+    : [];
+  if (
+    responseBotUid !== botUid
+    || responseBodyId !== bodyId
+    || responseInstallationId !== installationId
+    || !credential
+    || !Number.isFinite(expiresAt)
+    || expiresAt <= Date.now()
+    || !scopes.includes(RUNTIME_CREDENTIAL_SCOPE)
+  ) {
+    throw new Error('CatsCo returned an invalid Runtime credential binding.');
+  }
+  return { botUid, bodyId, installationId, scopes, credential, expiresAt };
+}
+
+export async function provisionCatsCoRuntimeCredential(
+  config: CatsCompanyConfig,
+  auth: CatsCoAuthSnapshot,
+  options: Pick<IssueCatsCoRuntimeCredentialOptions, 'fetchImpl' | 'timeoutMs'> = {},
+): Promise<CatsCompanyConfig> {
+  if (String(config.runtimeCredential || '').trim()) return config;
+  const userToken = String(auth.token || '').trim();
+  const actorUid = String(auth.uid || '').trim();
+  const ownerUid = String(config.ownerUserId || '').trim();
+  const botUid = String(config.botUid || '').trim();
+  const bodyId = String(config.bodyId || '').trim();
+  const installationId = String(config.installationId || config.bodyId || '').trim();
+  // Automatic provisioning is deliberately owner-only. Server runtimes that
+  // do not keep a human session use the explicit CATSCO_RUNTIME_CREDENTIAL
+  // configuration path instead.
+  if (!userToken || !actorUid || !ownerUid || actorUid !== ownerUid || !botUid || !bodyId || !installationId) {
+    return config;
+  }
+  const issued = await issueCatsCoRuntimeCredential({
+    httpBaseUrl: config.httpBaseUrl || 'https://app.catsco.cc',
+    userToken,
+    botUid,
+    bodyId,
+    installationId,
+    ...options,
+  });
+  return {
+    ...config,
+    runtimeCredential: issued.credential,
+    runtimeCredentialExpiresAt: issued.expiresAt,
+  };
+}

--- a/src/catscompany/types.ts
+++ b/src/catscompany/types.ts
@@ -17,6 +17,14 @@ export interface CatsCompanyConfig {
   bodyId?: string;
   /** 当前安装/设备 ID，默认与 bodyId 相同 */
   installationId?: string;
+  /**
+   * Owner-provisioned credential for the concrete Runtime body/installation.
+   * This is separate from the Bot API key and currently grants only the right
+   * to request a candidate-bound Skill mutation grant.
+   */
+  runtimeCredential?: string;
+  /** Expiry of an automatically provisioned Runtime credential, in Unix milliseconds. */
+  runtimeCredentialExpiresAt?: number;
   /** 当前本机设备归属的 CatsCo 用户 uid，用于区分本地自用与外部委托 */
   ownerUserId?: string;
   /** 用户可见设备名，用于 Dashboard 展示和服务端设备选择 */

--- a/src/commands/catscompany.ts
+++ b/src/commands/catscompany.ts
@@ -19,6 +19,7 @@ import { CloudBotModelRuntimeReloadController } from '../bot-definition/runtime-
 import { createBotDefinitionSyncService } from '../bot-definition/service';
 import { resolveRunnableCloudDefinition } from '../bot-definition/cloud-sync';
 import { getPromptReconcileCoordinator } from '../bot-definition/prompt-sync';
+import { provisionCatsCoRuntimeCredential } from '../catscompany/runtime-credential';
 
 const CONNECTOR_OWNER_POLL_MS = 2000;
 const CLOUD_MODEL_POLL_MS = 5000;
@@ -63,7 +64,7 @@ export async function catscompanyCommand(): Promise<void> {
     config: resolvedRuntime.connector,
   };
 
-  const connectorConfig = resolved.config;
+  let connectorConfig = resolved.config;
   if (!connectorConfig) {
     Logger.error(`CatsCo 配置缺失：${resolved.missing.join(', ') || 'unknown'}。`);
     Logger.error('请先在 Dashboard 登录 CatsCo 并选择/绑定机器人，或设置兼容环境变量。');
@@ -93,6 +94,19 @@ export async function catscompanyCommand(): Promise<void> {
     Logger.warning('已跳过第二条 CatsCo WebSocket 连接，避免同一设备重复连接互相挤下线。');
     process.exitCode = 2;
     return;
+  }
+
+  try {
+    const provisioned = await provisionCatsCoRuntimeCredential(connectorConfig, resolvedRuntime.auth);
+    if (provisioned.runtimeCredential && !connectorConfig.runtimeCredential) {
+      Logger.info('CatsCo Runtime 已取得受限 Skill mutation grant 凭证。');
+    }
+    connectorConfig = provisioned;
+  } catch (error) {
+    // Backward compatibility is intentional: an old/unavailable CatsCo server
+    // must not take ordinary chat offline. Without the separate credential the
+    // connection remains unable to request a Skill mutation grant.
+    Logger.warning(`CatsCo Runtime 凭证暂不可用，继续以只读 Skill 权限连接: ${errorMessage(error)}`);
   }
 
   let bot = new CatsCompanyBot(connectorConfig);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -102,6 +102,7 @@ export interface ChatConfig {
   catscompany?: {
     serverUrl?: string;
     apiKey?: string;
+    runtimeCredential?: string;
     httpBaseUrl?: string;
     sessionTTL?: number;
   };

--- a/tests/catsco-runtime-config.test.ts
+++ b/tests/catsco-runtime-config.test.ts
@@ -54,6 +54,7 @@ describe('CatsCo runtime config resolver', () => {
         CATSCO_HTTP_BASE_URL: 'https://env.example',
         CATSCO_API_KEY: 'env-api-key',
         CATSCO_BOT_UID: 'bot-env',
+        CATSCO_RUNTIME_CREDENTIAL: 'runtime-credential-env',
       },
     });
 
@@ -63,6 +64,7 @@ describe('CatsCo runtime config resolver', () => {
     assert.equal(resolved.connector?.bodyId, 'body-typed');
     assert.equal(resolved.connector?.installationId, 'install-typed');
     assert.equal(resolved.connector?.runtimeRole, 'server');
+    assert.equal(resolved.connector?.runtimeCredential, 'runtime-credential-env');
     assert.equal(resolved.auth.token, 'env-user-token');
     assert.equal(resolved.auth.uid, 'user-typed');
     assert.equal(resolved.auth.botUid, 'bot-typed');

--- a/tests/catscompany-client-body-id.test.ts
+++ b/tests/catscompany-client-body-id.test.ts
@@ -18,6 +18,8 @@ describe('CatsCompany client body identity', () => {
     'CATSCOMPANY_DEVICE_ID',
     'CATSCO_INSTALLATION_ID',
     'CATSCOMPANY_INSTALLATION_ID',
+    'CATSCO_RUNTIME_CREDENTIAL',
+    'CATSCOMPANY_RUNTIME_CREDENTIAL',
   ];
   const originalEnv: Record<string, string | undefined> = {};
 
@@ -82,6 +84,7 @@ describe('CatsCompany client body identity', () => {
       apiKey: 'cc-test-key',
       bodyId: 'body-test',
       installationId: 'install-test',
+      runtimeCredential: 'runtime-credential-test',
     });
     client.on('error', () => undefined);
 
@@ -92,6 +95,139 @@ describe('CatsCompany client body identity', () => {
     assert.equal(headers['x-api-key'], 'cc-test-key');
     assert.equal(headers['x-catsco-body-id'], 'body-test');
     assert.equal(headers['x-catsco-installation-id'], 'install-test');
+    assert.equal(headers['x-catsco-runtime-credential'], 'runtime-credential-test');
+  });
+
+  test('does not send the privileged Runtime header when no credential is configured', async () => {
+    clearIdentityEnv();
+    const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    servers.push(server);
+    await new Promise<void>(resolve => server.once('listening', resolve));
+    const headersPromise = new Promise<Record<string, string | string[] | undefined>>(resolve => {
+      server.once('connection', (socket, request) => {
+        resolve(request.headers);
+        socket.close();
+      });
+    });
+    const address = server.address() as AddressInfo;
+    const client = new CatsClient({
+      serverUrl: `ws://127.0.0.1:${address.port}`,
+      apiKey: 'cc-test-key',
+      botUid: '42',
+      bodyId: 'body-test',
+      installationId: 'install-test',
+    });
+    client.on('error', () => undefined);
+    client.connect();
+    const headers = await headersPromise;
+    client.disconnect();
+    assert.equal(headers['x-catsco-runtime-credential'], undefined);
+  });
+
+  test('does not let an expired auto-provisioned credential take ordinary chat offline', async () => {
+    clearIdentityEnv();
+    const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    servers.push(server);
+    await new Promise<void>(resolve => server.once('listening', resolve));
+    const headersPromise = new Promise<Record<string, string | string[] | undefined>>(resolve => {
+      server.once('connection', (socket, request) => {
+        resolve(request.headers);
+        socket.close();
+      });
+    });
+    const address = server.address() as AddressInfo;
+    const client = new CatsClient({
+      serverUrl: `ws://127.0.0.1:${address.port}`,
+      apiKey: 'cc-test-key',
+      bodyId: 'body-test',
+      installationId: 'install-test',
+      runtimeCredential: 'expired-runtime-credential',
+      runtimeCredentialExpiresAt: Date.now() - 1,
+    });
+    client.on('error', () => undefined);
+    client.connect();
+    const headers = await headersPromise;
+    client.disconnect();
+    assert.equal(headers['x-api-key'], 'cc-test-key');
+    assert.equal(headers['x-catsco-runtime-credential'], undefined);
+  });
+
+  test('requests a candidate-bound Skill mutation grant and matches the server result', async () => {
+    clearIdentityEnv();
+    const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    servers.push(server);
+    await new Promise<void>(resolve => server.once('listening', resolve));
+    const requestPromise = new Promise<any>(resolve => {
+      server.once('connection', socket => {
+        socket.on('message', data => {
+          const message = JSON.parse(data.toString());
+          if (message.hi) {
+            socket.send(JSON.stringify({
+              ctrl: { code: 200, params: { build: 'catscompany', uid: 42, name: 'Bot' } },
+            }));
+            return;
+          }
+          if (!message.skill_mutation_grant) return;
+          resolve(message.skill_mutation_grant);
+          socket.send(JSON.stringify({
+            skill_mutation_grant: {
+              id: message.skill_mutation_grant.id,
+              type: 'result',
+              request_id: message.skill_mutation_grant.request_id,
+              client_request_id: message.skill_mutation_grant.client_request_id,
+              grant: 'candidate-bound-grant',
+              expires_at: Date.now() + 60_000,
+              actor_user_id: 'usr7',
+              agent_id: 'usr42',
+              runtime_body_id: 'body-test',
+            },
+          }));
+        });
+      });
+    });
+    const address = server.address() as AddressInfo;
+    const client = new CatsClient({
+      serverUrl: `ws://127.0.0.1:${address.port}`,
+      apiKey: 'cc-test-key',
+      botUid: '42',
+      bodyId: 'body-test',
+      installationId: 'install-test',
+      runtimeCredential: 'runtime-credential-test',
+    });
+    client.on('error', () => undefined);
+    const ready = new Promise<void>(resolve => client.once('ready', () => resolve()));
+    client.connect();
+    await withTimeout(ready);
+
+    const resultPromise = client.requestSkillMutationGrant({
+      client_request_id: 'candidate-request-1',
+      source_topic_id: 'p2p_7_42',
+      source_message_id: 101,
+      local_skill_id: 'review-pr',
+      operation: 'replace',
+      candidate_content_hash: 'a'.repeat(64),
+      candidate_size_bytes: 2048,
+      expected_definition_revision: 9,
+      expected_previous_content_hash: 'b'.repeat(64),
+      before_reference: {
+        source: 'skillhub',
+        skillId: 'private-review-pr',
+        version: '1.0.0',
+        contentHash: 'b'.repeat(64),
+      },
+    });
+    const request = await withTimeout(requestPromise);
+    const result = await withTimeout(resultPromise);
+    client.disconnect();
+
+    assert.equal(request.type, 'request');
+    assert.equal(request.client_request_id, 'candidate-request-1');
+    assert.equal(request.runtime_body_id, undefined);
+    assert.equal(request.actor_user_id, undefined);
+    assert.equal(result.grant, 'candidate-bound-grant');
+    assert.equal(result.actor_user_id, 'usr7');
+    assert.equal(result.agent_id, 'usr42');
+    assert.equal(result.runtime_body_id, 'body-test');
   });
 
   test('fails before connecting when body id is missing', () => {

--- a/tests/catscompany-client-body-id.test.ts
+++ b/tests/catscompany-client-body-id.test.ts
@@ -230,6 +230,81 @@ describe('CatsCompany client body identity', () => {
     assert.equal(result.runtime_body_id, 'body-test');
   });
 
+  test('does not forward server-issued identity fields from an untyped request', async () => {
+    clearIdentityEnv();
+    const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    servers.push(server);
+    await new Promise<void>(resolve => server.once('listening', resolve));
+    const requestPromise = new Promise<any>(resolve => {
+      server.once('connection', socket => {
+        socket.on('message', data => {
+          const message = JSON.parse(data.toString());
+          if (message.hi) {
+            socket.send(JSON.stringify({
+              ctrl: { code: 200, params: { build: 'catscompany', uid: 42, name: 'Bot' } },
+            }));
+            return;
+          }
+          if (!message.skill_mutation_grant) return;
+          resolve(message.skill_mutation_grant);
+          socket.send(JSON.stringify({
+            skill_mutation_grant: {
+              id: message.skill_mutation_grant.id,
+              type: 'result',
+              request_id: message.skill_mutation_grant.request_id,
+              client_request_id: message.skill_mutation_grant.client_request_id,
+              grant: 'candidate-bound-grant',
+              expires_at: Date.now() + 60_000,
+              actor_user_id: 'usr7',
+              agent_id: 'usr42',
+              runtime_body_id: 'body-test',
+            },
+          }));
+        });
+      });
+    });
+    const address = server.address() as AddressInfo;
+    const client = new CatsClient({
+      serverUrl: `ws://127.0.0.1:${address.port}`,
+      apiKey: 'cc-test-key',
+      botUid: '42',
+      bodyId: 'body-test',
+      installationId: 'install-test',
+      runtimeCredential: 'runtime-credential-test',
+    });
+    client.on('error', () => undefined);
+    const ready = new Promise<void>(resolve => client.once('ready', () => resolve()));
+    client.connect();
+    await withTimeout(ready);
+
+    const resultPromise = client.requestSkillMutationGrant({
+      client_request_id: 'candidate-request-2',
+      source_topic_id: 'p2p_7_42',
+      source_message_id: 102,
+      local_skill_id: 'review-pr',
+      operation: 'replace',
+      candidate_content_hash: 'c'.repeat(64),
+      candidate_size_bytes: 1024,
+      expected_definition_revision: 10,
+      ...( {
+        actor_user_id: 'forged-actor',
+        agent_id: 'forged-agent',
+        runtime_body_id: 'forged-body',
+        grant: 'forged-grant',
+        expires_at: Date.now() + 86_400_000,
+      } as any),
+    } as any);
+    const request = await withTimeout(requestPromise);
+    await withTimeout(resultPromise);
+    client.disconnect();
+
+    assert.equal(request.actor_user_id, undefined);
+    assert.equal(request.agent_id, undefined);
+    assert.equal(request.runtime_body_id, undefined);
+    assert.equal(request.grant, undefined);
+    assert.equal(request.expires_at, undefined);
+  });
+
   test('fails before connecting when body id is missing', () => {
     clearIdentityEnv();
     const client = new CatsClient({

--- a/tests/catscompany-runtime-credential.test.ts
+++ b/tests/catscompany-runtime-credential.test.ts
@@ -1,0 +1,122 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import {
+  issueCatsCoRuntimeCredential,
+  provisionCatsCoRuntimeCredential,
+} from '../src/catscompany/runtime-credential';
+import type { CatsCompanyConfig } from '../src/catscompany/types';
+import type { CatsCoAuthSnapshot } from '../src/catscompany/local-config';
+
+describe('CatsCo Runtime credential provisioning', () => {
+  const config: CatsCompanyConfig = {
+    serverUrl: 'wss://app.catsco.cc/v0/channels',
+    httpBaseUrl: 'https://app.catsco.cc',
+    apiKey: 'bot-api-key',
+    botUid: '42',
+    bodyId: 'body-prod-1',
+    installationId: 'install-prod-1',
+    ownerUserId: '7',
+  };
+  const auth: CatsCoAuthSnapshot = {
+    token: 'owner-user-token',
+    uid: '7',
+    httpBaseUrl: 'https://app.catsco.cc',
+    serverUrl: 'wss://app.catsco.cc/v0/channels',
+  };
+
+  test('issues an owner-authorized credential for the exact Runtime binding', async () => {
+    let captured: { url: string; init?: RequestInit } | undefined;
+    const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+      captured = { url: String(input), init };
+      return new Response(JSON.stringify({
+        bot_uid: 42,
+        body_id: 'body-prod-1',
+        installation_id: 'install-prod-1',
+        scopes: ['skill_mutation:grant'],
+        credential: 'runtime-credential',
+        expires_at: Date.now() + 86_400_000,
+      }), { status: 201, headers: { 'Content-Type': 'application/json' } });
+    }) as typeof fetch;
+
+    const issued = await issueCatsCoRuntimeCredential({
+      httpBaseUrl: 'https://app.catsco.cc/',
+      userToken: 'owner-user-token',
+      botUid: '42',
+      bodyId: 'body-prod-1',
+      installationId: 'install-prod-1',
+      fetchImpl,
+    });
+
+    assert.equal(captured?.url, 'https://app.catsco.cc/api/bots/runtime-credential');
+    assert.equal((captured?.init?.headers as Record<string, string>).Authorization, 'Bearer owner-user-token');
+    assert.deepEqual(JSON.parse(String(captured?.init?.body)), {
+      bot_uid: 42,
+      body_id: 'body-prod-1',
+      installation_id: 'install-prod-1',
+    });
+    assert.equal(issued.credential, 'runtime-credential');
+    assert.deepEqual(issued.scopes, ['skill_mutation:grant']);
+  });
+
+  test('rejects a credential response bound to another Runtime', async () => {
+    const fetchImpl = (async () => new Response(JSON.stringify({
+      bot_uid: 42,
+      body_id: 'body-other',
+      installation_id: 'install-prod-1',
+      scopes: ['skill_mutation:grant'],
+      credential: 'runtime-credential',
+      expires_at: Date.now() + 86_400_000,
+    }), { status: 201, headers: { 'Content-Type': 'application/json' } })) as typeof fetch;
+
+    await assert.rejects(
+      issueCatsCoRuntimeCredential({
+        httpBaseUrl: 'https://app.catsco.cc',
+        userToken: 'owner-user-token',
+        botUid: '42',
+        bodyId: 'body-prod-1',
+        installationId: 'install-prod-1',
+        fetchImpl,
+      }),
+      /invalid Runtime credential binding/,
+    );
+  });
+
+  test('automatically provisions only for the locally authenticated owner', async () => {
+    let requests = 0;
+    const fetchImpl = (async () => {
+      requests += 1;
+      return new Response(JSON.stringify({
+        bot_uid: 42,
+        body_id: 'body-prod-1',
+        installation_id: 'install-prod-1',
+        scopes: ['skill_mutation:grant'],
+        credential: 'runtime-credential',
+        expires_at: Date.now() + 86_400_000,
+      }), { status: 201, headers: { 'Content-Type': 'application/json' } });
+    }) as typeof fetch;
+
+    const provisioned = await provisionCatsCoRuntimeCredential(config, auth, { fetchImpl });
+    const friend = await provisionCatsCoRuntimeCredential(config, { ...auth, uid: '8' }, { fetchImpl });
+
+    assert.equal(provisioned.runtimeCredential, 'runtime-credential');
+    assert.ok(Number(provisioned.runtimeCredentialExpiresAt) > Date.now());
+    assert.equal(friend.runtimeCredential, undefined);
+    assert.equal(requests, 1);
+  });
+
+  test('preserves an explicitly provisioned server credential without an owner session', async () => {
+    let requested = false;
+    const explicit = { ...config, runtimeCredential: 'server-managed-credential' };
+    const result = await provisionCatsCoRuntimeCredential(explicit, {
+      httpBaseUrl: 'https://app.catsco.cc',
+      serverUrl: 'wss://app.catsco.cc/v0/channels',
+    }, {
+      fetchImpl: (async () => {
+        requested = true;
+        throw new Error('should not request');
+      }) as typeof fetch,
+    });
+    assert.equal(result, explicit);
+    assert.equal(requested, false);
+  });
+});


### PR DESCRIPTION
## 背景

CatsCo 已在 #232 合并 Bot Runtime 凭据签发接口与 `skill_mutation_grant` WebSocket 授权协议。本 PR 接入 XiaoBa 侧的可信 Runtime 身份和授权请求能力，为下一片“候选 Skill 构建/写入”建立 SDK 边界。

## 本次修改

- 桌面端已登录账号为 Bot owner 时，启动 connector 自动申请绑定当前 Bot、body、installation 的受限 Runtime 凭据；服务器 Runtime 也可通过 `CATSCO_RUNTIME_CREDENTIAL` 显式配置。
- WebSocket 握手仅在存在有效凭据时携带 `X-CatsCo-Runtime-Credential`。
- 新增候选 Skill 的 `skill_mutation_grant` 请求/结果协议，校验候选哈希、Definition revision、client request、目标 Bot 与 Runtime body，拒绝串候选、串 Bot、串运行体的结果。
- 凭据申请失败或自动凭据过期时降级为无写授权连接，普通聊天与第一阶段 SkillHub 能力继续工作。
- 为后续专用 mutation 工具提供内部 SDK 方法，但本 PR 不向模型注册工具。

## 明确边界

本 PR **不会**：

- 修改 system prompt、Skill 注入或缓存逻辑；
- 生成、上传、激活或覆盖任何 Skill；
- 写 BotDefinition 或 mutation 记录；
- 启用 `shared_live`。

## 安全性

- 自动签发只在本地登录用户与绑定 owner 一致时发起，CatsCo 服务端仍负责最终 owner 校验。
- actor、Bot、Runtime 身份均由服务端授权结果给出；客户端请求不能自行注入这些身份字段。
- Runtime 凭据不写入本地配置、不输出到日志，且与 Bot/body/installation 绑定。
- 自动凭据过期后重连不再携带它，避免第二阶段授权失效影响普通聊天。

## 验证

- `npm run build`：通过
- Runtime 凭据、WebSocket grant、运行配置定向测试：33/33 通过
- 第一阶段 Bot Skill 同步、SkillHub RPC、Runtime capabilities 等回归：114/114 通过
- `git diff --check`：通过

补充：本机执行全量 `npm test` 时，既有 `update-worker-artifact` 用例因环境缺少 `jq` 失败，另一个既有图片流水线用例长时间不退出；与本 PR 变更无关，GitHub Actions 将在完整 CI 环境继续验证。