### PR TITLE
fix: retry transient Responses failures consistently

### DIFF
--- a/src/providers/openai-provider.ts
+++ b/src/providers/openai-provider.ts
@@ -1076,6 +1076,8 @@ export class OpenAIProvider implements AIProvider {
     const providerType = String(details?.type || '').trim();
     const code = providerCode || providerType;
     const statusByCode: Record<string, number> = {
+      internal_error: 500,
+      internal_server_error: 500,
       server_error: 500,
       rate_limit_exceeded: 429,
       overloaded_error: 529,
@@ -1571,23 +1573,40 @@ export class OpenAIProvider implements AIProvider {
 
   private async normalizeProviderErrorResponse(error: unknown): Promise<unknown> {
     const response = (error as any)?.response;
-    const data = response?.data;
-    if (!response || !isReadableErrorStream(data)) return error;
+    if (!response) return error;
 
-    const text = await readProviderErrorStream(data);
-    const normalizedData = parseProviderErrorBody(text);
-    try {
-      response.data = normalizedData;
-    } catch {
+    let normalizedData = response.data;
+    if (isReadableErrorStream(normalizedData)) {
+      const text = await readProviderErrorStream(normalizedData);
+      normalizedData = parseProviderErrorBody(text);
       try {
-        Object.defineProperty(error as object, 'response', {
-          value: { ...response, data: normalizedData },
-          configurable: true,
-          writable: true,
-        });
+        response.data = normalizedData;
       } catch {
-        // Error normalization is best-effort and must never replace the provider failure.
+        try {
+          Object.defineProperty(error as object, 'response', {
+            value: { ...response, data: normalizedData },
+            configurable: true,
+            writable: true,
+          });
+        } catch {
+          // Error normalization is best-effort and must never replace the provider failure.
+        }
       }
+    }
+
+    const mutableError = error as any;
+    const normalizedStatus = Number(response.status ?? normalizedData?.status ?? normalizedData?.status_code);
+    const details = normalizedData?.error && typeof normalizedData.error === 'object'
+      ? normalizedData.error
+      : normalizedData;
+    const providerCode = typeof details?.code === 'string' ? details.code.trim() : '';
+    const providerType = typeof details?.type === 'string' ? details.type.trim() : '';
+    try {
+      if (Number.isFinite(normalizedStatus) && normalizedStatus > 0) mutableError.status = normalizedStatus;
+      if (providerCode && !mutableError.providerCode) mutableError.providerCode = providerCode;
+      if (providerType && !mutableError.providerType) mutableError.providerType = providerType;
+    } catch {
+      // Preserve the original provider error when it is non-extensible.
     }
     return error;
   }

--- a/src/utils/ai-service.ts
+++ b/src/utils/ai-service.ts
@@ -46,6 +46,8 @@ const EMPTY_RESPONSE_MAX_RETRIES = 2;
 const EMPTY_RESPONSE_MAX_ELAPSED_MS = 2 * 60 * 1000;
 const EMPTY_RESPONSE_MAX_DELAY_MS = 2000;
 const TRANSIENT_PROVIDER_CODES = new Set([
+  'internal_error',
+  'internal_server_error',
   'stream_read_error',
   'upstream_error',
   'server_is_overloaded',
@@ -426,6 +428,10 @@ export class AIService {
     const status = error?.response?.status || error?.status;
     if (typeof status === 'number') {
       return status;
+    }
+    if (typeof status === 'string' && /^\d{3}$/.test(status.trim())) {
+      const parsed = Number(status);
+      return Number.isFinite(parsed) ? parsed : null;
     }
     const text = String(error?.message || error || '');
     const match = text.match(/(?:API错误|HTTP|status(?:\s*code)?)\s*[\(:= ]\s*(\d{3})\b/i);

--- a/tests/ai-service.test.ts
+++ b/tests/ai-service.test.ts
@@ -407,6 +407,8 @@ test('AIService still retries transient load balancer failures', async () => {
 
 test('AIService retries Responses semantic transient codes and types', async () => {
   const semanticFailures = [
+    { code: 'internal_error' },
+    { code: 'internal_server_error' },
     { code: 'stream_read_error' },
     { code: 'upstream_error' },
     { type: 'server_is_overloaded' },

--- a/tests/conversation-runner-abort-signal.test.ts
+++ b/tests/conversation-runner-abort-signal.test.ts
@@ -225,6 +225,85 @@ test('ConversationRunner executes a tool only once after a transient model retry
   assert.equal(toolExecutions, 1);
 });
 
+test('ConversationRunner does not repeat a completed tool when the following model request retries', async () => {
+  const service = new AIService({
+    provider: 'openai',
+    apiUrl: 'https://primary.example.test/v1',
+    apiKey: 'primary-key',
+    model: 'primary-model',
+    openaiApiMode: 'responses',
+  });
+  let modelCalls = 0;
+  (service as any).provider = {
+    chat: async () => {
+      modelCalls += 1;
+      if (modelCalls === 1) {
+        return {
+          content: '',
+          toolCalls: [{
+            id: 'call_once_before_retry',
+            type: 'function',
+            function: {
+              name: 'read_file',
+              arguments: JSON.stringify({ file_path: 'a.txt' }),
+            },
+          }],
+        };
+      }
+      if (modelCalls === 2) {
+        throw Object.assign(new Error('terminal Responses failure'), {
+          code: 'internal_server_error',
+          error: {
+            code: 'internal_server_error',
+            message: 'websocket: close 1006 (abnormal closure): unexpected EOF',
+          },
+        });
+      }
+      return {
+        content: 'done',
+        toolCalls: [],
+        usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+      };
+    },
+  };
+  (service as any).sleepWithAbort = async () => {};
+
+  let toolExecutions = 0;
+  const toolExecutor: ToolExecutor = {
+    getToolDefinitions() {
+      return [{
+        name: 'read_file',
+        description: 'Read a file',
+        parameters: {
+          type: 'object',
+          properties: { file_path: { type: 'string' } },
+          required: ['file_path'],
+        },
+      }];
+    },
+    async executeTool(toolCall: ToolCall): Promise<ToolResult> {
+      toolExecutions += 1;
+      return {
+        role: 'tool',
+        tool_call_id: toolCall.id,
+        name: toolCall.function.name,
+        content: 'file content',
+        ok: true,
+      };
+    },
+  };
+  const runner = new ConversationRunner(service, toolExecutor, {
+    stream: false,
+    enableCompression: false,
+  });
+
+  const result = await runner.run([{ role: 'user', content: 'read it' }]);
+
+  assert.equal(result.response, 'done');
+  assert.equal(modelCalls, 3);
+  assert.equal(toolExecutions, 1);
+});
+
 async function waitFor(predicate: () => boolean, maxAttempts = 50): Promise<void> {
   for (let i = 0; i < maxAttempts; i++) {
     if (predicate()) return;

--- a/tests/openai-provider-responses.test.ts
+++ b/tests/openai-provider-responses.test.ts
@@ -574,6 +574,37 @@ describe('OpenAIProvider Responses API mode', () => {
     }
   });
 
+  test('maps an internal_server_error terminal failure to a retryable HTTP status', async () => {
+    const originalPost = axios.post;
+    (axios as any).post = async () => ({
+      data: Readable.from([sse({
+        type: 'response.failed',
+        response: {
+          id: 'resp_internal_failure',
+          status: 'failed',
+          error: {
+            code: 'internal_server_error',
+            message: 'websocket: close 1006 (abnormal closure): unexpected EOF',
+          },
+        },
+      })]),
+    });
+
+    try {
+      await assert.rejects(
+        createProvider().chatStream([{ role: 'user', content: 'hello' }]),
+        (error: any) => (
+          error?.code === 'internal_server_error'
+          && error?.providerCode === 'internal_server_error'
+          && error?.status === 500
+          && error?.terminalEvent === 'response.failed'
+        ),
+      );
+    } finally {
+      (axios as any).post = originalPost;
+    }
+  });
+
   test('preserves the response header request ID when a terminal failure has none', async () => {
     const originalPost = axios.post;
     (axios as any).post = async () => ({
@@ -752,6 +783,63 @@ describe('OpenAIProvider Responses API mode', () => {
       assert.equal(bodies[0].prompt_cache_key, bodies[1].prompt_cache_key);
       assert.equal(requestHeaders[0].session_id, requestHeaders[1].session_id);
       assert.equal(requestHeaders[0]['x-client-request-id'], requestHeaders[1]['x-client-request-id']);
+    } finally {
+      (axios as any).post = originalPost;
+      if (originalRetries === undefined) delete process.env.CATSCO_MODEL_RETRY_MAX_RETRIES;
+      else process.env.CATSCO_MODEL_RETRY_MAX_RETRIES = originalRetries;
+    }
+  });
+
+  test('retries a streamed Axios 502 after normalizing its error body and status', async () => {
+    const originalPost = axios.post;
+    const originalRetries = process.env.CATSCO_MODEL_RETRY_MAX_RETRIES;
+    let attempts = 0;
+    (axios as any).post = async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        throw Object.assign(new Error('Request failed with status code 502'), {
+          code: 'ERR_BAD_RESPONSE',
+          response: {
+            status: '502',
+            headers: { 'retry-after': '0' },
+            data: Readable.from([JSON.stringify({
+              error: {
+                code: 'accounting_service_unavailable',
+                message: 'relay accounting service unavailable: timed out',
+              },
+            })]),
+          },
+        });
+      }
+      return {
+        data: Readable.from([sse({
+          type: 'response.completed',
+          response: {
+            status: 'completed',
+            output: [{
+              type: 'message',
+              role: 'assistant',
+              content: [{ type: 'output_text', text: 'recovered' }],
+            }],
+          },
+        })]),
+      };
+    };
+    process.env.CATSCO_MODEL_RETRY_MAX_RETRIES = '1';
+
+    try {
+      const service = new AIService({
+        apiKey: 'test-key',
+        apiUrl: 'https://example.test/v1',
+        model: 'gpt-test',
+        provider: 'openai',
+        openaiApiMode: 'responses',
+      });
+      (service as any).sleepWithAbort = async () => {};
+      const result = await service.chatStream([{ role: 'user', content: 'hello' }]);
+
+      assert.equal(attempts, 2);
+      assert.equal(result.content, 'recovered');
     } finally {
       (axios as any).post = originalPost;
       if (originalRetries === undefined) delete process.env.CATSCO_MODEL_RETRY_MAX_RETRIES;


### PR DESCRIPTION
## Summary

- treat common Responses terminal `internal_error` and `internal_server_error` failures as bounded transient LLM failures
- normalize streamed OpenAI-compatible HTTP error bodies, status values, and provider error metadata before retry classification
- verify a completed tool is not executed again when only the following model request is retried

## Root cause

Two OpenAI Responses failure shapes were reaching the existing retry layer as non-retryable:

1. A valid `response.failed` terminal event used `internal_server_error` without a numeric HTTP status. The Responses transient classification did not include that common server-side code.
2. An Axios `ERR_BAD_RESPONSE` from a streamed 502 could carry its body as a Readable stream and its status in a non-canonical shape. Diagnostics could later report 502 while the earlier retry decision missed it.

These are caller-side normalization gaps. The change remains provider-agnostic and does not inspect Relay hosts or model names.

## Behavior

The retry scope remains the current LLM request only. It does not restart an Episode and does not add or change Tool retry behavior. Completed tool calls and results remain in the transcript; only the next model request is attempted again under the existing bounded Responses retry policy.

Explicit request, authentication, permission, context-length, billing, balance, and quota errors remain non-retryable.

## Validation

- `node node_modules/tsx/dist/cli.mjs --test tests/ai-service.test.ts tests/openai-provider-responses.test.ts tests/conversation-runner-abort-signal.test.ts` ? 59/59 passed
- `npm run build` ? passed
- `npm test` ? relevant runtime tests passed; the aggregate command remains red on this Windows host because worker-image tests require a working WSL `/bin/bash` and `pwsh`

No server deployment or configuration change is included.
