### PR TITLE
feat: add Connector Agent switching

### DIFF
--- a/dashboard/connector.css
+++ b/dashboard/connector.css
@@ -85,7 +85,7 @@ button, a { -webkit-tap-highlight-color: transparent; }
   transition: border-color 120ms ease, background 120ms ease;
 }
 .button:hover { border-color: #aeb9ca; background: #f8fafc; }
-.button:focus-visible, input:focus-visible, summary:focus-visible {
+.button:focus-visible, .summary-action:focus-visible, .dialog-close:focus-visible, input:focus-visible, summary:focus-visible {
   outline: 3px solid rgba(47, 111, 237, .22);
   outline-offset: 2px;
 }
@@ -202,7 +202,58 @@ h1 {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+.summary-card-heading { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.summary-card-heading > span { color: var(--muted); font-size: 14px; }
+.summary-action {
+  min-height: 28px;
+  padding: 0 9px;
+  border: 1px solid #d4dbe6;
+  border-radius: 7px;
+  background: #fff;
+  color: #3269c7;
+  font-size: 12px;
+  font-weight: 650;
+  cursor: pointer;
+}
+.summary-action:hover { border-color: #aeb9ca; background: #f8fafc; }
+.summary-action:disabled { color: #a3adbc; cursor: default; opacity: .72; }
 .compact-card { display: flex; align-items: center; justify-content: space-between; gap: 14px; }
+
+.agent-switch-dialog {
+  width: min(560px, calc(100vw - 40px));
+  max-height: min(680px, calc(100vh - 40px));
+  padding: 0;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: #fff;
+  color: var(--ink);
+  box-shadow: 0 24px 70px rgba(18, 31, 52, .24);
+}
+.agent-switch-dialog::backdrop { background: rgba(24, 32, 51, .34); }
+.agent-switch-shell { min-height: 0; max-height: inherit; display: flex; flex-direction: column; }
+.agent-switch-header { padding: 22px 24px 17px; display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; border-bottom: 1px solid var(--line); }
+.agent-switch-header h2 { margin: 0; font-size: 22px; line-height: 1.25; }
+.agent-switch-header p { margin: 5px 0 0; color: var(--muted); font-size: 13px; line-height: 1.5; }
+.dialog-close { width: 34px; height: 34px; flex: 0 0 auto; border: 1px solid var(--line); border-radius: 8px; background: #fff; color: var(--muted); font-size: 23px; line-height: 1; cursor: pointer; }
+.dialog-close:hover { border-color: #aeb9ca; color: var(--ink); background: #f8fafc; }
+.agent-switch-body { min-height: 0; padding: 18px 24px; overflow: auto; }
+.agent-switch-intro { margin: 0 0 14px; color: var(--muted); font-size: 13px; line-height: 1.6; }
+.agent-list { display: grid; gap: 9px; }
+.agent-list-state { padding: 34px 16px; border: 1px dashed #d3dae5; border-radius: 9px; color: var(--muted); text-align: center; font-size: 13px; }
+.agent-option { min-height: 66px; padding: 12px 14px; display: flex; align-items: center; gap: 12px; border: 1px solid var(--line); border-radius: 9px; background: #fff; cursor: pointer; }
+.agent-option:hover { border-color: #b9c7da; background: #fbfcfe; }
+.agent-option.selected { border-color: #8eb1f5; background: var(--blue-soft); box-shadow: 0 0 0 1px #8eb1f5 inset; }
+.agent-option input { width: 16px; height: 16px; flex: 0 0 auto; accent-color: var(--blue); }
+.agent-option-copy { min-width: 0; flex: 1 1 auto; }
+.agent-option-copy strong, .agent-option-copy small { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.agent-option-copy strong { font-size: 15px; }
+.agent-option-copy small { margin-top: 3px; color: var(--muted); font-size: 12px; }
+.current-badge { flex: 0 0 auto; padding: 3px 7px; border-radius: 999px; background: #e8f7f1; color: #087253; font-size: 11px; font-weight: 650; }
+.agent-switch-warning, .agent-switch-error { margin: 14px 0 0; padding: 10px 12px; border-radius: 8px; font-size: 12px; line-height: 1.55; }
+.agent-switch-warning { border: 1px solid #efddb9; background: var(--orange-soft); color: #7a521a; }
+.agent-switch-error { border: 1px solid #efc7c3; background: var(--red-soft); color: #a33a35; }
+.agent-switch-footer { padding: 15px 24px 20px; display: flex; align-items: center; justify-content: flex-end; gap: 10px; border-top: 1px solid var(--line); }
 
 .login-card {
   width: min(620px, 100%);

--- a/dashboard/connector.html
+++ b/dashboard/connector.html
@@ -157,8 +157,11 @@
             <strong id="account-name">—</strong>
             <small id="account-meta">等待登录</small>
           </article>
-          <article class="summary-card">
-            <span>当前 Agent</span>
+          <article class="summary-card agent-summary-card">
+            <div class="summary-card-heading">
+              <span>当前 Agent</span>
+              <button class="summary-action" id="agent-switch-open" type="button" disabled>切换</button>
+            </div>
             <strong id="agent-name">—</strong>
             <small id="agent-meta">登录后自动准备</small>
           </article>
@@ -175,6 +178,33 @@
       </div>
     </section>
   </main>
+
+  <dialog class="agent-switch-dialog" id="agent-switch-dialog" aria-labelledby="agent-switch-title">
+    <form method="dialog" class="agent-switch-shell">
+      <header class="agent-switch-header">
+        <div>
+          <h2 id="agent-switch-title">切换 Agent</h2>
+          <p>选择使用这台电脑本地工具、文件和桌面能力的 Agent。</p>
+        </div>
+        <button class="dialog-close" id="agent-switch-close" type="submit" value="cancel" aria-label="关闭">×</button>
+      </header>
+
+      <div class="agent-switch-body">
+        <p class="agent-switch-intro">一台电脑同一时间连接一个 Agent。切换时 Connector 会短暂重启，云端模型、Prompt 和 Skills 会同步到本机。</p>
+        <div class="agent-list" id="agent-list" role="radiogroup" aria-label="可用 Agent">
+          <div class="agent-list-state">正在读取 Agent……</div>
+        </div>
+        <p class="agent-switch-warning" id="agent-switch-warning" hidden></p>
+        <p class="agent-switch-error" id="agent-switch-error" role="alert" hidden></p>
+      </div>
+
+      <footer class="agent-switch-footer">
+        <button class="button button-quiet" id="agent-switch-cancel" type="submit" value="cancel">取消</button>
+        <button class="button button-primary" id="agent-switch-confirm" type="button" disabled>切换并重新连接</button>
+      </footer>
+    </form>
+  </dialog>
+
   <div class="toast" id="toast" role="status" hidden></div>
   <script src="connector.js"></script>
 </body>

--- a/dashboard/connector.js
+++ b/dashboard/connector.js
@@ -116,6 +116,11 @@
     managementTab: 'services',
     config: {},
     weixinBinding: {},
+    agents: [],
+    selectedAgentUid: '',
+    agentListLoading: false,
+    agentSwitchBusy: false,
+    agentSwitchError: '',
     serviceActionBusy: new Set(),
     logPollTimer: null,
     weixinPollTimer: null,
@@ -248,6 +253,8 @@
     setText('device-name', deviceName);
     setText('device-meta', cats.device?.bodyId ? `设备 ${shortId(cats.device.bodyId)}` : '本地工具与文件');
     setText('app-version', state.app.version || '—');
+    const switchButton = $('agent-switch-open');
+    switchButton.disabled = !cats.connected || state.agentSwitchBusy;
 
     $('login-form').hidden = view.key !== 'auth';
     $('progress-list').hidden = view.key !== 'connecting';
@@ -378,6 +385,108 @@
     } finally {
       state.actionBusy = false;
       setBusyButtons(false);
+    }
+  }
+
+  async function openAgentSwitch() {
+    if (!state.cats?.connected || state.agentSwitchBusy) return;
+    const dialog = $('agent-switch-dialog');
+    state.agentListLoading = true;
+    state.agentSwitchError = '';
+    state.agents = [];
+    state.selectedAgentUid = state.cats.botUid || '';
+    renderAgentSwitch();
+    dialog.showModal();
+    const [agents, binding] = await Promise.all([
+      settled('/cats/bots'),
+      settled('/weixin/channel-binding'),
+    ]);
+    state.agentListLoading = false;
+    if (agents.ok) {
+      state.agents = Array.isArray(agents.value?.bots) ? agents.value.bots : [];
+      state.selectedAgentUid = agents.value?.currentBotUid || state.cats.botUid || '';
+    } else {
+      state.agentSwitchError = `无法读取 Agent：${humanError(agents.error)}`;
+    }
+    if (binding.ok) state.weixinBinding = binding.value || {};
+    renderAgentSwitch();
+  }
+
+  function closeAgentSwitch() {
+    if (state.agentSwitchBusy) return;
+    const dialog = $('agent-switch-dialog');
+    if (dialog.open) dialog.close();
+    state.agentSwitchError = '';
+  }
+
+  function renderAgentSwitch() {
+    const list = $('agent-list');
+    const currentUid = String(state.cats?.botUid || '');
+    if (state.agentListLoading) {
+      list.innerHTML = '<div class="agent-list-state">正在读取 Agent……</div>';
+    } else if (state.agents.length === 0 && !state.agentSwitchError) {
+      list.innerHTML = '<div class="agent-list-state">当前账号下没有可切换的 Agent。</div>';
+    } else {
+      list.innerHTML = state.agents.map((agent) => {
+        const uid = String(agent.uid || '');
+        const selected = uid === state.selectedAgentUid;
+        const current = uid === currentUid;
+        const name = agent.display_name || agent.username || `Agent ${shortId(uid)}`;
+        const meta = agent.username || shortId(uid);
+        return `<label class="agent-option${selected ? ' selected' : ''}">
+          <input type="radio" name="agent-switch" value="${escapeHtml(uid)}" ${selected ? 'checked' : ''} ${state.agentSwitchBusy ? 'disabled' : ''}>
+          <span class="agent-option-copy"><strong>${escapeHtml(name)}</strong><small>${escapeHtml(meta)}</small></span>
+          ${current ? '<span class="current-badge">当前</span>' : ''}
+        </label>`;
+      }).join('');
+    }
+
+    const selected = state.agents.find((agent) => String(agent.uid || '') === state.selectedAgentUid);
+    const selectedName = selected?.display_name || selected?.username || '所选 Agent';
+    const boundWeixinUid = String(state.weixinBinding?.binding?.agentUid || '');
+    const needsWeixinRebind = Boolean(boundWeixinUid && state.selectedAgentUid && boundWeixinUid !== state.selectedAgentUid);
+    const warning = $('agent-switch-warning');
+    warning.hidden = !needsWeixinRebind;
+    if (needsWeixinRebind) {
+      warning.textContent = `微信当前绑定在其他 Agent。切换到“${selectedName}”后，微信服务会停止；如需使用微信，请为新 Agent 重新扫码。`;
+    }
+
+    const error = $('agent-switch-error');
+    error.hidden = !state.agentSwitchError;
+    error.textContent = state.agentSwitchError;
+    const confirm = $('agent-switch-confirm');
+    confirm.disabled = state.agentListLoading || state.agentSwitchBusy || !selected || state.selectedAgentUid === currentUid;
+    confirm.textContent = state.agentSwitchBusy ? '正在切换…' : '切换并重新连接';
+    $('agent-switch-close').disabled = state.agentSwitchBusy;
+    $('agent-switch-cancel').disabled = state.agentSwitchBusy;
+  }
+
+  async function switchAgent() {
+    const targetUid = String(state.selectedAgentUid || '');
+    if (!targetUid || targetUid === String(state.cats?.botUid || '') || state.agentSwitchBusy) return;
+    const target = state.agents.find((agent) => String(agent.uid || '') === targetUid);
+    state.agentSwitchBusy = true;
+    state.agentSwitchError = '';
+    renderAgentSwitch();
+    render();
+    try {
+      const result = await request('/cats/switch-bot', {
+        method: 'POST',
+        body: JSON.stringify({ botUid: targetUid }),
+      });
+      state.bootstrap = { stage: 'connecting', message: `正在连接 Agent“${target?.display_name || target?.username || shortId(targetUid)}”` };
+      if ($('agent-switch-dialog').open) $('agent-switch-dialog').close();
+      render();
+      await new Promise((resolve) => setTimeout(resolve, 700));
+      await refresh({ force: true });
+      showToast(result.weixinStopped ? 'Agent 已切换；微信服务已停止，请重新扫码后启动' : 'Agent 已切换并重新连接');
+    } catch (error) {
+      state.agentSwitchError = `切换失败：${humanError(error)}`;
+      renderAgentSwitch();
+    } finally {
+      state.agentSwitchBusy = false;
+      renderAgentSwitch();
+      render();
     }
   }
 
@@ -698,6 +807,21 @@
   $('logout-button').addEventListener('click', logout);
   $('update-button').addEventListener('click', checkUpdate);
   $('management-open').addEventListener('click', () => { void openManagement(); });
+  $('agent-switch-open').addEventListener('click', () => { void openAgentSwitch(); });
+  $('agent-switch-close').addEventListener('click', (event) => {
+    event.preventDefault();
+    closeAgentSwitch();
+  });
+  $('agent-switch-confirm').addEventListener('click', () => { void switchAgent(); });
+  $('agent-list').addEventListener('change', (event) => {
+    if (event.target?.name !== 'agent-switch') return;
+    state.selectedAgentUid = event.target.value;
+    state.agentSwitchError = '';
+    renderAgentSwitch();
+  });
+  $('agent-switch-dialog').addEventListener('cancel', (event) => {
+    if (state.agentSwitchBusy) event.preventDefault();
+  });
   $('management-back').addEventListener('click', closeManagement);
   $('services-refresh').addEventListener('click', refreshManagementData);
   $('logs-refresh').addEventListener('click', loadLogs);

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -4012,6 +4012,10 @@ export function createApiRouter(
       const targetBot = bots.find((bot: any) => String(bot.id || bot.uid || '') === botUid);
       if (!targetBot) return res.status(404).json({ error: 'Bot not found' });
 
+      const previousWeixinStatus = getWeixinChannelStatus({
+        runtimeRoot: runtimeDataRoot(),
+        env: process.env,
+      });
       const apiKey = await getCatsBotApiKey(state, botUid, targetBot);
       const result = await commitCatsBotBindingAndStartConnector(serviceManager, state, {
         userUid,
@@ -4024,6 +4028,19 @@ export function createApiRouter(
         bindingSource: 'explicit-switch',
       });
       const botName = String(targetBot.display_name || targetBot.username || 'Bot');
+      const weixinRequiresRebind = Boolean(
+        previousWeixinStatus.binding?.agentUid
+        && previousWeixinStatus.binding.agentUid !== botUid,
+      );
+      let weixinStopped = false;
+      if (weixinRequiresRebind && serviceManager.getService('weixin')?.status === 'running') {
+        try {
+          serviceManager.stop('weixin');
+          weixinStopped = true;
+        } catch (error: any) {
+          result.warnings.push(`Agent 已切换，但微信服务停止失败：${String(error?.message || error)}`);
+        }
+      }
 
       res.json({
         ok: true,
@@ -4039,8 +4056,10 @@ export function createApiRouter(
         preflight: result.preflight,
         connectorStarted: result.connectorStarted,
         connectorRestarted: result.connectorRestarted,
+        weixinRequiresRebind,
+        weixinStopped,
         warnings: result.warnings.length > 0 ? result.warnings : undefined,
-        message: `已切换到机器人 "${botName}"`,
+        message: `已切换到 Agent "${botName}"`,
       });
     } catch (e: any) {
       const payload = catsErrorResponse(e);

--- a/tests/dashboard-catsco-auth-status.test.ts
+++ b/tests/dashboard-catsco-auth-status.test.ts
@@ -13,6 +13,7 @@ import { createBotDefinitionSyncService } from '../src/bot-definition/service';
 import { resolveActiveBotLLMConfig } from '../src/bot-definition/llm-config-resolver';
 import { BOT_CATALOG_MODEL_RUNTIME_SCHEMA, BOT_DEFINITION_SCHEMA } from '../src/bot-definition/types';
 import { BotSkillBaseStore } from '../src/bot-skills/base-store';
+import { saveChannelBindings } from '../src/dashboard/weixin-channel-binding';
 
 describe('dashboard CatsCo account status', () => {
   let testRoot: string;
@@ -62,6 +63,11 @@ describe('dashboard CatsCo account status', () => {
     'CATSCOMPANY_INSTALLATION_ID',
     'CATSCO_ALLOW_LOCAL_ENDPOINTS',
     'CATSCOMPANY_ALLOW_LOCAL_ENDPOINTS',
+    'WEIXIN_TOKEN',
+    'WEIXIN_BOUND_AGENT_UID',
+    'WEIXIN_BOUND_AGENT_NAME',
+    'WEIXIN_BOUND_BODY_ID',
+    'WEIXIN_BOUND_BY_USER_UID',
   ];
   const originalEnv: Record<string, string | undefined> = {};
 
@@ -1047,6 +1053,144 @@ describe('dashboard CatsCo account status', () => {
     assert.equal(env.CATSCO_BOT_UID, '199');
     assert.equal(env.CATSCO_API_KEY, 'last-agent-key');
     assert.equal(createBotCalls, 0);
+  });
+
+  test('POST /cats/switch-bot persists the selected Agent and stops Weixin when it needs rebinding', async () => {
+    if (dashboardServer) {
+      await close(dashboardServer);
+      dashboardServer = undefined;
+    }
+
+    const catsService = {
+      name: 'catscompany',
+      label: 'CatsCo agent',
+      command: process.execPath,
+      args: [],
+      status: 'running',
+    };
+    const weixinService = {
+      name: 'weixin',
+      label: '微信机器人',
+      command: process.execPath,
+      args: [],
+      status: 'running',
+    };
+    let connectorRestarted = 0;
+    let weixinStopped = 0;
+    const dashboardApp = express();
+    dashboardApp.use(express.json());
+    dashboardApp.use('/api', createApiRouter({
+      getAll: () => [catsService, weixinService],
+      getService: (name: string) => name === 'catscompany' ? catsService : name === 'weixin' ? weixinService : undefined,
+      restart: (name: string) => {
+        assert.equal(name, 'catscompany');
+        connectorRestarted += 1;
+        return catsService;
+      },
+      stop: (name: string) => {
+        assert.equal(name, 'weixin');
+        weixinStopped += 1;
+        weixinService.status = 'stopped';
+        return weixinService;
+      },
+    } as any));
+    dashboardServer = await listen(dashboardApp);
+    dashboardBaseUrl = serverBaseUrl(dashboardServer);
+
+    await startCatsServer((req, res) => {
+      if (req.path === '/api/me') {
+        return res.json({ uid: 88, username: 'owner', display_name: 'Owner' });
+      }
+      if (req.path === '/api/bots' && req.method === 'GET') {
+        return res.json({
+          bots: [
+            { uid: 188, username: 'old-agent', display_name: 'Old Agent', api_key: 'old-agent-key' },
+            { uid: 199, username: 'new-agent', display_name: 'New Agent', api_key: 'new-agent-key' },
+          ],
+        });
+      }
+      if (req.path === '/api/friends/request') return res.json({ ok: true });
+      if (req.path === '/api/friends/accept') {
+        assert.equal(req.header('authorization'), 'ApiKey new-agent-key');
+        return res.json({ ok: true });
+      }
+      return res.status(404).json({ error: 'not found' });
+    });
+
+    createCatsCoLocalConfigService({ runtimeRoot: testRoot }).save({
+      version: 1,
+      account: { token: 'user-token', uid: '88', username: 'owner', displayName: 'Owner' },
+      currentBot: {
+        uid: '188',
+        name: 'Old Agent',
+        username: 'old-agent',
+        apiKey: 'old-agent-key',
+        boundByUserUid: '88',
+        bindingSource: 'test',
+      },
+      device: { deviceId: 'device-1', bodyId: 'body-1', installationId: 'install-1' },
+      endpoints: { httpBaseUrl: catsBaseUrl, serverUrl: 'wss://app.catsco.cc/v0/channels' },
+    });
+    saveChannelBindings(testRoot, {
+      version: 1,
+      weixin: {
+        channel: 'weixin',
+        agentUid: '188',
+        agentName: 'Old Agent',
+        bodyId: 'body-1',
+        boundByUserUid: '88',
+        tokenHash: 'test-token-hash',
+        tokenLast4: '1234',
+        legacyEnvKey: 'WEIXIN_TOKEN',
+        createdAt: new Date(0).toISOString(),
+        updatedAt: new Date(0).toISOString(),
+      },
+    });
+    writeEnv([
+      `CATSCO_HTTP_BASE_URL=${catsBaseUrl}`,
+      'CATSCO_SERVER_URL=wss://app.catsco.cc/v0/channels',
+      'CATSCO_USER_TOKEN=user-token',
+      'CATSCO_USER_UID=88',
+      'CATSCO_BOT_UID=188',
+      'CATSCO_API_KEY=old-agent-key',
+      'GAUZ_LLM_PROVIDER=anthropic',
+      'GAUZ_LLM_API_BASE=https://model.example.test/v1/messages',
+      'GAUZ_LLM_API_KEY=sk-test',
+      'GAUZ_LLM_MODEL=test-model',
+      'WEIXIN_TOKEN=weixin-token-1234',
+    ]);
+    new FileBotDefinitionRepository({ runtimeRoot: testRoot }).writeCanonical({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: '199',
+      model: {
+        kind: 'custom',
+        protocol: 'openai-responses',
+        apiBase: 'https://model.example.test/v1',
+        model: 'test-model',
+        apiKey: 'sk-test',
+        contextWindowTokens: 128_000,
+      },
+    });
+    seedVerifiedEmptyBotSkillWorkspace(testRoot, '199');
+
+    const response = await fetch(`${dashboardBaseUrl}/api/cats/switch-bot`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ botUid: '199' }),
+    });
+    const text = await response.text();
+    const data = JSON.parse(text) as any;
+    const localConfig = createCatsCoLocalConfigService({ runtimeRoot: testRoot }).load();
+
+    assert.equal(response.status, 200, text);
+    assert.equal(data.ok, true);
+    assert.equal(data.bot.uid, '199');
+    assert.equal(data.weixinRequiresRebind, true);
+    assert.equal(data.weixinStopped, true);
+    assert.equal(connectorRestarted, 1);
+    assert.equal(weixinStopped, 1);
+    assert.equal(localConfig.currentBot?.uid, '199');
+    assert.equal(localConfig.currentBot?.bindingSource, 'explicit-switch');
   });
 
   test('POST /cats/bind-bot restores the active binding when target preflight is blocked', async () => {

--- a/tests/dashboard-connector.test.ts
+++ b/tests/dashboard-connector.test.ts
@@ -13,7 +13,7 @@ const script = readFileSync(join(dashboardDir, 'connector.js'), 'utf-8');
 const styles = readFileSync(join(dashboardDir, 'connector.css'), 'utf-8');
 const serverSource = readFileSync(join(process.cwd(), 'src/dashboard/server.ts'), 'utf-8');
 
-test('real Connector Dashboard exposes four runtime states without local Bot management', () => {
+test('real Connector Dashboard exposes four runtime states without local Bot creation', () => {
   assert.match(html, /CatsCo Connector/);
   assert.match(html, /登录并连接/);
   assert.match(html, /正在连接这台电脑/);
@@ -22,7 +22,18 @@ test('real Connector Dashboard exposes four runtime states without local Bot man
   assert.match(html, /可以直接关闭此窗口/);
   assert.doesNotMatch(html, /打开旧版控制台/);
   assert.doesNotMatch(html, /CONNECT THIS COMPUTER|READY FOR CATSCO/);
-  assert.doesNotMatch(html, /创建 Bot|选择 Bot|模型选择|System Prompt|Skill Hub|聊天输入/);
+  assert.doesNotMatch(html, /创建 Bot|模型选择|System Prompt|Skill Hub|聊天输入/);
+});
+
+test('Connector lets an authenticated user switch the Agent bound to this computer', () => {
+  assert.match(html, /id="agent-switch-open"[^>]*>切换/);
+  assert.match(html, /切换 Agent/);
+  assert.match(html, /一台电脑同一时间连接一个 Agent/);
+  assert.match(script, /settled\('\/cats\/bots'\)/);
+  assert.match(script, /request\('\/cats\/switch-bot'/);
+  assert.match(script, /微信服务会停止/);
+  assert.doesNotMatch(script, /\/cats\/create-bot/);
+  assert.match(styles, /\.agent-switch-dialog/);
 });
 
 test('Connector local management restores channels and gives logs a full workspace', () => {


### PR DESCRIPTION
## What changed

- add a compact **切换** action to the Connector's current Agent summary
- load the signed-in user's existing CatsCo Agents in a focused selection dialog
- switch the local binding through the existing `/api/cats/switch-bot` lifecycle and reconnect the Connector
- keep first-run auto-provisioning unchanged; the Dashboard still does not create or manage Bots
- stop a running Weixin service when its binding belongs to the previous Agent, and tell the user to re-authorize it
- add UI contract and API regression coverage

## Why

The reduced Connector automatically selected one Agent at login, but removed every way to change that selection. Because one local Connector serves one Agent at a time, another existing Agent could not use this computer's desktop, files, or local tools.

## User impact

Users can now switch this computer from the currently bound Agent to another existing Agent. The selection persists for future launches. Connector restart and Weixin re-authorization implications are shown before switching.

## Validation

- `npm run build`
- 42 focused Dashboard/CatsCo/Weixin tests passed
- visual checks at 1080×700 and 800×520, including long Agent names and a scrollable short-height dialog
- full runtime suite: 1581 passed, 10 skipped; 2 Worker updater tests initially failed because `jq` was absent from the Windows test environment
- installed a temporary pinned `jq` executable outside the repository and reran the affected file: 4 passed, 5 skipped, 0 failed
