### PR TITLE
fix: run verified SkillHub scripts from CatsCo chat

### DIFF
--- a/src/bot-skills/trusted-script-execution.ts
+++ b/src/bot-skills/trusted-script-execution.ts
@@ -1,0 +1,257 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { FileBotDefinitionRepository } from '../bot-definition/repository';
+import type { BotSkillRef } from '../bot-definition/types';
+import { readSkillHubInstallMarker } from '../skillhub/install-marker';
+import type { ToolExecutionContext } from '../types/tool';
+import { PathResolver } from '../utils/path-resolver';
+import { readBotSkillLocalMarker, scanLocalBotSkill } from './local-manifest';
+
+export interface TrustedBotSkillScriptInvocation {
+  scriptPath: string;
+  args: string[];
+  skillId: string;
+  skillName: string;
+  version: string;
+}
+
+export type TrustedBotSkillScriptDecision =
+  | { ok: true; invocation: TrustedBotSkillScriptInvocation }
+  | { ok: false; reason: string };
+
+/**
+ * Resolve the deliberately narrow compatibility path for script-backed formal
+ * Bot Skills. The model still calls execute_shell, but accepted commands never
+ * reach a shell: ShellTool spawns the verified Node entrypoint directly.
+ */
+export function resolveTrustedBotSkillScriptInvocation(
+  command: unknown,
+  context: ToolExecutionContext,
+  options: { cwd?: unknown; target?: unknown } = {},
+): TrustedBotSkillScriptDecision {
+  if (!isTrustedLocalCatsCoRuntime(context)) {
+    return denied('The current CatsCo turn is not a trusted local Bot runtime.');
+  }
+  if (stringValue(options.target)) {
+    return denied('Verified Bot Skill scripts can only run on the current Bot body, without a target override.');
+  }
+
+  const tokens = tokenizeDirectCommand(command);
+  if (!tokens || tokens.length < 2 || !isNodeCommand(tokens[0])) {
+    return denied('The command is not one direct Node.js script invocation.');
+  }
+
+  const executionDirectory = resolveExecutionDirectory(options.cwd, context.workingDirectory);
+  if (!executionDirectory) {
+    return denied('The command working directory is missing or unavailable.');
+  }
+  const scriptPath = path.resolve(executionDirectory, tokens[1]);
+  if (!['.js', '.cjs', '.mjs'].includes(path.extname(scriptPath).toLowerCase())) {
+    return denied('The requested entrypoint is not a JavaScript file.');
+  }
+
+  const skillsRoot = path.resolve(PathResolver.getSkillsPath());
+  const relative = path.relative(skillsRoot, scriptPath);
+  const segments = relative.split(path.sep).filter(Boolean);
+  if (
+    !relative
+    || relative.startsWith('..')
+    || path.isAbsolute(relative)
+    || segments.length < 3
+    || segments[1] !== 'scripts'
+  ) {
+    return denied('The requested entrypoint is outside an installed Bot Skill scripts directory.');
+  }
+
+  const skillDir = path.join(skillsRoot, segments[0]);
+  if (!isSafeRegularFileWithin(skillDir, scriptPath)) {
+    return denied('The requested Skill entrypoint is missing, unsafe, or linked outside its package.');
+  }
+
+  const installMarker = readSkillHubInstallMarker(skillDir);
+  const localMarker = readBotSkillLocalMarker(skillDir);
+  if (!isCompleteVerifiedInstallMarker(installMarker) || !localMarker?.reference) {
+    return denied('The Skill is not a verified SkillHub package materialized for the current Bot.');
+  }
+
+  let scanned;
+  try {
+    scanned = scanLocalBotSkill(skillDir, skillsRoot);
+  } catch {
+    return denied('The installed Skill package failed local integrity validation.');
+  }
+  const reference = scanned.reference;
+  if (!reference || !sameSkillReference(reference, localMarker.reference)) {
+    return denied('The installed Skill package no longer matches its cloud-bound content hash.');
+  }
+  if (
+    installMarker.skillId !== reference.skillId
+    || installMarker.version !== reference.version
+    || installMarker.installName !== segments[0]
+  ) {
+    return denied('The SkillHub install identity does not match the Bot-bound Skill reference.');
+  }
+
+  const agentId = stringValue(context.executionScope?.agentId);
+  const definition = readActiveBotDefinition(agentId);
+  if (!definition?.skills?.some(candidate => sameSkillReference(candidate, reference))) {
+    return denied('The verified Skill is not enabled in the current Bot definition.');
+  }
+
+  return {
+    ok: true,
+    invocation: {
+      scriptPath,
+      args: [scriptPath, ...tokens.slice(2)],
+      skillId: reference.skillId,
+      skillName: installMarker.name,
+      version: reference.version,
+    },
+  };
+}
+
+function isTrustedLocalCatsCoRuntime(context: ToolExecutionContext): boolean {
+  if (context.deviceRpcReceiver) return false;
+  const scope = context.executionScope;
+  const localDevice = context.localDeviceGrant;
+  if (
+    !scope
+    || scope.source !== 'catscompany'
+    || scope.identityTrust !== 'server_canonical'
+    || !scope.isTrusted
+    || !localDevice
+    || localDevice.source !== 'catscompany'
+  ) {
+    return false;
+  }
+  const ownerSelf = sameIdentity(scope.actorUserId, localDevice.ownerUserId)
+    && (!scope.deviceOwnerUserId || sameIdentity(scope.deviceOwnerUserId, localDevice.ownerUserId));
+  const agentLocalBody = Boolean(scope.agentBodyId && scope.agentBodyId === localDevice.bodyId);
+  return ownerSelf || agentLocalBody;
+}
+
+function readActiveBotDefinition(agentId: string) {
+  if (!agentId) return undefined;
+  try {
+    const repository = new FileBotDefinitionRepository({ runtimeRoot: PathResolver.getRuntimeDataRoot() });
+    return repository.readCache(agentId) ?? repository.readCanonical(agentId);
+  } catch {
+    return undefined;
+  }
+}
+
+function tokenizeDirectCommand(value: unknown): string[] | null {
+  if (typeof value !== 'string' || !value.trim()) return null;
+  const tokens: string[] = [];
+  let current = '';
+  let quote: 'single' | 'double' | undefined;
+  let tokenStarted = false;
+
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index];
+    if (quote) {
+      const closing = quote === 'single' ? "'" : '"';
+      if (character === closing) {
+        quote = undefined;
+        tokenStarted = true;
+        continue;
+      }
+      if (character === '\\' && value[index + 1] === closing) {
+        current += closing;
+        tokenStarted = true;
+        index += 1;
+        continue;
+      }
+      current += character;
+      tokenStarted = true;
+      continue;
+    }
+
+    if (/\s/.test(character)) {
+      if (tokenStarted) {
+        tokens.push(current);
+        current = '';
+        tokenStarted = false;
+      }
+      continue;
+    }
+    if (character === "'") {
+      quote = 'single';
+      tokenStarted = true;
+      continue;
+    }
+    if (character === '"') {
+      quote = 'double';
+      tokenStarted = true;
+      continue;
+    }
+    current += character;
+    tokenStarted = true;
+  }
+
+  if (quote) return null;
+  if (tokenStarted) tokens.push(current);
+  return tokens;
+}
+
+function isNodeCommand(value: string): boolean {
+  const name = path.basename(value).toLowerCase();
+  return name === 'node' || name === 'node.exe';
+}
+
+function resolveExecutionDirectory(value: unknown, fallback: string): string | undefined {
+  if (value !== undefined && value !== null && typeof value !== 'string') return undefined;
+  const requested = stringValue(value) || fallback;
+  const resolved = path.isAbsolute(requested) ? path.resolve(requested) : path.resolve(fallback, requested);
+  try {
+    return fs.statSync(resolved).isDirectory() ? resolved : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isSafeRegularFileWithin(root: string, candidate: string): boolean {
+  try {
+    const rootStat = fs.lstatSync(root);
+    const candidateStat = fs.lstatSync(candidate);
+    if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) return false;
+    if (!candidateStat.isFile() || candidateStat.isSymbolicLink()) return false;
+    const realRoot = fs.realpathSync(root);
+    const realCandidate = fs.realpathSync(candidate);
+    const relative = path.relative(realRoot, realCandidate);
+    return Boolean(relative) && !relative.startsWith('..') && !path.isAbsolute(relative);
+  } catch {
+    return false;
+  }
+}
+
+function isCompleteVerifiedInstallMarker(value: ReturnType<typeof readSkillHubInstallMarker>): value is NonNullable<typeof value> {
+  return Boolean(
+    value
+    && /^[a-f0-9]{64}$/i.test(stringValue(value.packageChecksumSha256))
+    && value.signature?.algorithm === 'ed25519'
+    && stringValue(value.signature.keyId)
+    && stringValue(value.signature.signature),
+  );
+}
+
+function sameSkillReference(left: BotSkillRef, right: BotSkillRef): boolean {
+  return left.source === 'skillhub'
+    && right.source === 'skillhub'
+    && left.skillId === right.skillId
+    && left.version === right.version
+    && left.contentHash === right.contentHash;
+}
+
+function sameIdentity(left: unknown, right: unknown): boolean {
+  const normalizedLeft = stringValue(left).toLowerCase();
+  return Boolean(normalizedLeft && normalizedLeft === stringValue(right).toLowerCase());
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function denied(reason: string): TrustedBotSkillScriptDecision {
+  return { ok: false, reason };
+}

--- a/src/tools/bash-tool.ts
+++ b/src/tools/bash-tool.ts
@@ -67,6 +67,7 @@ export class ShellTool implements Tool {
       'Windows 目标上 command 会作为 PowerShell 脚本执行，可直接写多行 PowerShell，无需再套一层 powershell -Command。',
       '命令从当前目录启动；每次调用都是新的 shell 进程，只有最终当前目录会保留到后续工具调用。',
       '环境变量、alias、函数和已激活虚拟环境不会自动跨调用保留；需要时在同一条 command 中显式设置。',
+      'CatsCo 聊天只允许直接运行当前 Bot 已启用且完整性校验通过的 SkillHub Node 脚本；请用 write_file 创建运行目录和输入文件，不要拼接 shell 命令。',
     ].join('\n'),
     parameters: {
       type: 'object',
@@ -126,10 +127,13 @@ export class ShellTool implements Tool {
       toolName: this.definition.name,
       operation: 'execute_shell',
       target: args.target,
+      command,
+      cwd,
     });
     if (!route.ok) {
       return { ok: false, errorCode: route.errorCode, message: route.message };
     }
+    const trustedSkillScript = route.mode === 'local' ? route.trustedSkillScript : undefined;
     const remoteResult = await executeRouteIfRemote(context, route, 'execute_shell', 'execute_shell', args);
     if (remoteResult) return remoteResult;
 
@@ -163,21 +167,33 @@ export class ShellTool implements Tool {
       env: process.env,
       probeVersion: false,
     });
-    const wrapped = this.wrapCommandWithDirectoryProbe(command);
+    const wrapped = trustedSkillScript ? undefined : this.wrapCommandWithDirectoryProbe(command);
 
     try {
-      const { stdout, stderr } = await this.executeWrappedCommand(
-        wrapped,
-        executionDirectory.directory,
-        runtimeEnvironment.env,
-        timeout,
-        context.abortSignal,
-      );
+      const { stdout, stderr } = trustedSkillScript
+        ? await this.executeTrustedSkillScript(
+          trustedSkillScript.args,
+          executionDirectory.directory,
+          runtimeEnvironment,
+          timeout,
+          context.abortSignal,
+        )
+        : await this.executeWrappedCommand(
+          wrapped!,
+          executionDirectory.directory,
+          runtimeEnvironment.env,
+          timeout,
+          context.abortSignal,
+        );
 
-      const parsedStdout = this.extractDirectoryProbe(stdout || '', wrapped.marker);
-      const parsedStderr = this.extractDirectoryProbe(stderr || '', wrapped.marker);
+      const parsedStdout = wrapped
+        ? this.extractDirectoryProbe(stdout || '', wrapped.marker)
+        : { output: stdout || '' };
+      const parsedStderr = wrapped
+        ? this.extractDirectoryProbe(stderr || '', wrapped.marker)
+        : { output: stderr || '' };
       const cwdAfter = this.updateCurrentDirectory(
-        this.readDirectoryProbe(wrapped) || parsedStdout.directory || parsedStderr.directory,
+        (wrapped ? this.readDirectoryProbe(wrapped) : undefined) || parsedStdout.directory || parsedStderr.directory,
         context,
         cwdBefore,
       ) || cwdBefore;
@@ -223,10 +239,14 @@ export class ShellTool implements Tool {
       };
     } catch (error: any) {
       const executionTime = Date.now() - startTime;
-      const parsedStdout = this.extractDirectoryProbe(error.stdout || '', wrapped.marker);
-      const parsedStderr = this.extractDirectoryProbe(error.stderr || '', wrapped.marker);
+      const parsedStdout = wrapped
+        ? this.extractDirectoryProbe(error.stdout || '', wrapped.marker)
+        : { output: String(error.stdout || '') };
+      const parsedStderr = wrapped
+        ? this.extractDirectoryProbe(error.stderr || '', wrapped.marker)
+        : { output: String(error.stderr || '') };
       const cwdAfter = this.updateCurrentDirectory(
-        this.readDirectoryProbe(wrapped) || parsedStdout.directory || parsedStderr.directory,
+        (wrapped ? this.readDirectoryProbe(wrapped) : undefined) || parsedStdout.directory || parsedStderr.directory,
         context,
         cwdBefore,
       ) || cwdBefore;
@@ -280,8 +300,95 @@ export class ShellTool implements Tool {
         }),
       };
     } finally {
-      this.cleanupWrappedCommand(wrapped);
+      if (wrapped) this.cleanupWrappedCommand(wrapped);
     }
+  }
+
+  private executeTrustedSkillScript(
+    args: string[],
+    cwd: string,
+    runtimeEnvironment: ReturnType<typeof resolveRuntimeEnvironment>,
+    timeout: number,
+    signal?: AbortSignal,
+  ): Promise<ShellOutput> {
+    const executable = runtimeEnvironment.binaries.node.executable;
+    if (!executable) {
+      return Promise.reject(new Error('The verified Skill requires Node.js, but no trusted Node.js runtime is available.'));
+    }
+    if (signal?.aborted) {
+      return Promise.reject(new Error('Command aborted by user'));
+    }
+
+    return new Promise((resolve, reject) => {
+      const child = spawn(executable, args, {
+        cwd,
+        env: runtimeEnvironment.env,
+        windowsHide: true,
+        shell: false,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      const stdoutChunks: Buffer[] = [];
+      const stderrChunks: Buffer[] = [];
+      const maxBuffer = 10 * 1024 * 1024;
+      let stdoutBytes = 0;
+      let stderrBytes = 0;
+      let settled = false;
+
+      const finish = (fn: () => void) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        signal?.removeEventListener('abort', abortHandler);
+        fn();
+      };
+      const decode = (chunks: Buffer[]) => process.platform === 'win32'
+        ? this.decodeWindowsOutput(Buffer.concat(chunks))
+        : Buffer.concat(chunks).toString('utf8');
+      const fail = (error: any) => {
+        finish(() => {
+          try { child.kill(); } catch {}
+          error.stdout = decode(stdoutChunks);
+          error.stderr = decode(stderrChunks);
+          reject(error);
+        });
+      };
+      const timer = setTimeout(() => {
+        const error: any = new Error(`Command timed out after ${timeout}ms`);
+        error.killed = true;
+        error.signal = 'SIGTERM';
+        fail(error);
+      }, timeout);
+      const abortHandler = () => fail(new Error('Command aborted by user'));
+      signal?.addEventListener('abort', abortHandler, { once: true });
+
+      child.stdout?.on('data', (chunk: Buffer) => {
+        const buffer = Buffer.from(chunk);
+        stdoutBytes += buffer.length;
+        if (stdoutBytes > maxBuffer) return fail(new Error(`stdout maxBuffer exceeded (${maxBuffer} bytes)`));
+        stdoutChunks.push(buffer);
+      });
+      child.stderr?.on('data', (chunk: Buffer) => {
+        const buffer = Buffer.from(chunk);
+        stderrBytes += buffer.length;
+        if (stderrBytes > maxBuffer) return fail(new Error(`stderr maxBuffer exceeded (${maxBuffer} bytes)`));
+        stderrChunks.push(buffer);
+      });
+      child.on('error', fail);
+      child.on('close', (code: number | null, closeSignal: NodeJS.Signals | null) => {
+        if (settled) return;
+        const stdout = decode(stdoutChunks);
+        const stderr = decode(stderrChunks);
+        finish(() => {
+          if (code === 0) return resolve({ stdout, stderr });
+          const error: any = new Error(`Command failed with exit code ${code}`);
+          error.code = code ?? undefined;
+          error.signal = closeSignal ?? undefined;
+          error.stdout = stdout;
+          error.stderr = stderr;
+          reject(error);
+        });
+      });
+    });
   }
 
   private wrapCommandWithDirectoryProbe(command: string): WrappedCommand {

--- a/src/tools/execution-router.ts
+++ b/src/tools/execution-router.ts
@@ -4,11 +4,21 @@ import { normalizeTargetText } from '../catscompany/runtime-context';
 import { executeRemoteDeviceRpcTool } from './device-rpc-tool';
 import { TOOL_TARGET_CONTEXT_PREFIX, TOOL_TARGET_CONTEXT_SUFFIX } from './tool-target-context';
 import { isChatTriggeredContext } from '../bot-skills/formal-workspace-policy';
+import {
+  resolveTrustedBotSkillScriptInvocation,
+  type TrustedBotSkillScriptInvocation,
+} from '../bot-skills/trusted-script-execution';
 
 export type ExecutionTargetId = 'agent_self' | string;
 
 export type ExecutionRoute =
-  | { ok: true; mode: 'local'; target: ExecutionTargetId; label: string }
+  | {
+      ok: true;
+      mode: 'local';
+      target: ExecutionTargetId;
+      label: string;
+      trustedSkillScript?: TrustedBotSkillScriptInvocation;
+    }
   | {
       ok: true;
       mode: 'remote';
@@ -47,14 +57,28 @@ export function resolveExecutionRoute(
     toolName: string;
     operation: DeviceGrantOperation;
     target?: unknown;
+    command?: unknown;
+    cwd?: unknown;
   },
 ): ExecutionRoute {
+  let trustedSkillScript: TrustedBotSkillScriptInvocation | undefined;
   if (options.operation === 'execute_shell' && isChatTriggeredContext(context)) {
-    return {
-      ok: false,
-      errorCode: 'PERMISSION_DENIED',
-      message: 'Chat-triggered shell execution is disabled until an isolated Skill candidate workspace is available.',
-    };
+    const decision = resolveTrustedBotSkillScriptInvocation(options.command, context, {
+      cwd: options.cwd,
+      target: options.target,
+    });
+    if (!decision.ok) {
+      return {
+        ok: false,
+        errorCode: 'PERMISSION_DENIED',
+        message: [
+          'CatsCo chat can only execute a verified SkillHub script directly.',
+          'Use write_file to create run files and parent directories, then call execute_shell with one direct node "<skill>/scripts/<entry>.mjs" command.',
+          'Arbitrary commands, shell chaining, target overrides, and unverified Skill scripts remain disabled.',
+        ].join('\n'),
+      };
+    }
+    trustedSkillScript = decision.invocation;
   }
 
   if (context.deviceRpcReceiver) {
@@ -70,6 +94,7 @@ export function resolveExecutionRoute(
       mode: 'local',
       target: 'agent_self',
       label: findTargetLabel(context, 'agent_self') || 'XiaoBa local computer',
+      ...(trustedSkillScript ? { trustedSkillScript } : {}),
     };
   }
 

--- a/tests/catscompany-device-rpc-tools.test.ts
+++ b/tests/catscompany-device-rpc-tools.test.ts
@@ -467,7 +467,7 @@ describe('CatsCompany Device RPC file tools', () => {
     assert.ok(captured.result);
     assert.equal(captured.result.result, undefined);
     assert.equal(captured.result.error.code, 'PERMISSION_DENIED');
-    assert.match(String(captured.result.error.message), /isolated Skill candidate workspace/);
+    assert.match(String(captured.result.error.message), /verified SkillHub script/);
   });
 
   test('rejects Device RPC requests for another target device', async () => {

--- a/tests/execution-router-clean.test.ts
+++ b/tests/execution-router-clean.test.ts
@@ -188,7 +188,7 @@ test('chat-triggered execute_shell is denied before local or remote execution', 
 
   assert.equal(result.ok, false);
   assert.equal(result.ok ? '' : result.errorCode, 'PERMISSION_DENIED');
-  assert.match(result.ok ? '' : result.message, /isolated Skill candidate workspace/);
+  assert.match(result.ok ? '' : result.message, /verified SkillHub script/);
   assert.equal(rpcCalls, 0);
 });
 

--- a/tests/trusted-bot-skill-script-execution.test.ts
+++ b/tests/trusted-bot-skill-script-execution.test.ts
@@ -1,0 +1,205 @@
+import { after, before, describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { FileBotDefinitionRepository } from '../src/bot-definition/repository';
+import type { BotSkillRef } from '../src/bot-definition/types';
+import {
+  scanLocalBotSkill,
+  writeBotSkillLocalMarker,
+} from '../src/bot-skills/local-manifest';
+import { resolveTrustedBotSkillScriptInvocation } from '../src/bot-skills/trusted-script-execution';
+import { writeSkillHubInstallMarker } from '../src/skillhub/install-marker';
+import { ShellTool } from '../src/tools/bash-tool';
+import type { ToolExecutionContext } from '../src/types/tool';
+
+describe('trusted Bot Skill script execution', () => {
+  let root: string;
+  let runtimeRoot: string;
+  let workspaceRoot: string;
+  let skillDir: string;
+  let scriptPath: string;
+  let reference: BotSkillRef;
+  const previousUserData = process.env.XIAOBA_USER_DATA_DIR;
+
+  before(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'trusted-bot-skill-script-'));
+    runtimeRoot = path.join(root, 'runtime');
+    workspaceRoot = path.join(runtimeRoot, 'work');
+    skillDir = path.join(runtimeRoot, 'skills', 'verified-image-skill');
+    scriptPath = path.join(skillDir, 'scripts', 'run.mjs');
+    fs.mkdirSync(path.dirname(scriptPath), { recursive: true });
+    fs.mkdirSync(workspaceRoot, { recursive: true });
+    process.env.XIAOBA_USER_DATA_DIR = runtimeRoot;
+
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'), [
+      '---',
+      'name: verified-image-skill',
+      'description: test fixture',
+      '---',
+      '# Verified image skill',
+      '',
+    ].join('\n'), 'utf8');
+    fs.writeFileSync(scriptPath, [
+      "import fs from 'node:fs';",
+      "const output = process.argv[2];",
+      "fs.writeFileSync(output, JSON.stringify(process.argv.slice(3)), 'utf8');",
+      "console.log('verified-skill-ok');",
+      '',
+    ].join('\n'), 'utf8');
+    writeSkillHubInstallMarker(skillDir, {
+      source: 'skillhub',
+      userId: 'skillhub-user-1',
+      skillId: 'publisher/verified-image-skill',
+      name: 'Verified image skill',
+      installName: 'verified-image-skill',
+      version: '1.0.0',
+      packageChecksumSha256: 'a'.repeat(64),
+      signature: {
+        algorithm: 'ed25519',
+        keyId: 'skillhub-test-key',
+        signature: 'signed-package-fixture',
+      },
+      packageUrl: 'https://skillhub.example/package.skillpkg',
+      installedAt: new Date(0).toISOString(),
+    });
+    const initial = scanLocalBotSkill(skillDir, path.dirname(skillDir));
+    reference = {
+      source: 'skillhub',
+      skillId: 'publisher/verified-image-skill',
+      version: '1.0.0',
+      contentHash: initial.contentHash,
+    };
+    writeBotSkillLocalMarker(skillDir, {
+      schema: 'xiaoba.bot-skill-local.v1',
+      localSkillId: initial.localSkillId,
+      reference,
+      origin: { skillId: reference.skillId, version: reference.version },
+    });
+    new FileBotDefinitionRepository({ runtimeRoot }).writeCache({
+      schema: 'xiaoba.bot-definition.v1',
+      botId: 'bot-1',
+      model: { kind: 'catalog', modelId: 'test-model' },
+      skills: [reference],
+    });
+  });
+
+  after(() => {
+    if (previousUserData === undefined) delete process.env.XIAOBA_USER_DATA_DIR;
+    else process.env.XIAOBA_USER_DATA_DIR = previousUserData;
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('runs the current Bot verified SkillHub Node entrypoint without a shell', async () => {
+    const output = path.join(workspaceRoot, 'direct-run.json');
+    const command = `node "${scriptPath}" "${output}" "hello world"`;
+    const decision = resolveTrustedBotSkillScriptInvocation(command, catsContext());
+    assert.equal(decision.ok, true);
+
+    const result = await new ShellTool().execute({ command }, catsContext());
+    assert.equal(result.ok, true);
+    assert.match(result.ok ? String(result.content) : '', /verified-skill-ok/);
+    assert.deepEqual(JSON.parse(fs.readFileSync(output, 'utf8')), ['hello world']);
+  });
+
+  test('keeps shell metacharacters inert by passing them as direct process arguments', async () => {
+    const output = path.join(workspaceRoot, 'inert-arguments.json');
+    const injected = path.join(workspaceRoot, 'must-not-exist.txt');
+    const command = `node "${scriptPath}" "${output}" safe ; node -e "require('fs').writeFileSync('${injected.replace(/\\/g, '\\\\')}', 'bad')"`;
+
+    const result = await new ShellTool().execute({ command }, catsContext());
+    assert.equal(result.ok, true);
+    assert.equal(fs.existsSync(injected), false);
+    assert.deepEqual(JSON.parse(fs.readFileSync(output, 'utf8')).slice(0, 2), ['safe', ';']);
+  });
+
+  test('rejects arbitrary chat shell with actionable Skill workflow guidance', async () => {
+    const result = await new ShellTool().execute({
+      command: 'New-Item -ItemType Directory -Path work\\run',
+    }, catsContext());
+
+    assert.equal(result.ok, false);
+    assert.equal(result.ok ? '' : result.errorCode, 'PERMISSION_DENIED');
+    assert.match(result.ok ? '' : result.message, /write_file/);
+    assert.match(result.ok ? '' : result.message, /one direct node/i);
+  });
+
+  test('rejects Node scripts outside the verified current Bot Skill package', async () => {
+    const externalScript = path.join(workspaceRoot, 'external.mjs');
+    fs.writeFileSync(externalScript, "console.log('must not run');\n", 'utf8');
+    const decision = resolveTrustedBotSkillScriptInvocation(
+      `node "${externalScript}"`,
+      catsContext(),
+    );
+
+    assert.equal(decision.ok, false);
+    assert.match(decision.ok ? '' : decision.reason, /outside an installed Bot Skill/);
+    const result = await new ShellTool().execute({ command: `node "${externalScript}"` }, catsContext());
+    assert.equal(result.ok, false);
+    assert.equal(result.ok ? '' : result.errorCode, 'PERMISSION_DENIED');
+  });
+
+  test('rejects target overrides even for a verified current Bot Skill script', async () => {
+    const command = `node "${scriptPath}" "${path.join(workspaceRoot, 'remote.json')}"`;
+    const decision = resolveTrustedBotSkillScriptInvocation(command, catsContext(), { target: 'Alice' });
+
+    assert.equal(decision.ok, false);
+    assert.match(decision.ok ? '' : decision.reason, /without a target override/);
+    const result = await new ShellTool().execute({ command, target: 'Alice' }, catsContext());
+    assert.equal(result.ok, false);
+    assert.equal(result.ok ? '' : result.errorCode, 'PERMISSION_DENIED');
+  });
+
+  test('rejects a verified package that is not enabled for the active Bot', async () => {
+    const command = `node "${scriptPath}" "${path.join(workspaceRoot, 'wrong-bot.json')}"`;
+    const decision = resolveTrustedBotSkillScriptInvocation(command, catsContext({
+      executionScope: {
+        ...catsContext().executionScope!,
+        agentId: 'bot-2',
+      },
+    }));
+    assert.equal(decision.ok, false);
+    assert.match(decision.ok ? '' : decision.reason, /current Bot definition/);
+  });
+
+  test('fails closed after an installed Skill script is modified locally', async () => {
+    fs.appendFileSync(scriptPath, '// tampered\n', 'utf8');
+    const command = `node "${scriptPath}" "${path.join(workspaceRoot, 'tampered.json')}"`;
+    const decision = resolveTrustedBotSkillScriptInvocation(command, catsContext());
+
+    assert.equal(decision.ok, false);
+    assert.match(decision.ok ? '' : decision.reason, /content hash/);
+    const result = await new ShellTool().execute({ command }, catsContext());
+    assert.equal(result.ok, false);
+    assert.equal(result.ok ? '' : result.errorCode, 'PERMISSION_DENIED');
+  });
+
+  function catsContext(overrides: Partial<ToolExecutionContext> = {}): ToolExecutionContext {
+    return {
+      workingDirectory: workspaceRoot,
+      workspaceRoot,
+      conversationHistory: [],
+      surface: 'catscompany',
+      executionScope: {
+        source: 'catscompany',
+        sessionKey: 'session-1',
+        topicId: 'topic-1',
+        topicType: 'p2p',
+        actorUserId: 'user-1',
+        agentId: 'bot-1',
+        agentBodyId: 'body-1',
+        identityTrust: 'server_canonical',
+        isTrusted: true,
+      },
+      localDeviceGrant: {
+        kind: 'local_device_grant',
+        source: 'catscompany',
+        bodyId: 'body-1',
+        installationId: 'installation-1',
+        ownerUserId: 'user-1',
+      },
+      ...overrides,
+    };
+  }
+});


### PR DESCRIPTION
## What changed

- allow CatsCo chat to run a Node entrypoint only when it belongs to a verified SkillHub package enabled on the current Bot
- verify the SkillHub install marker, Bot-bound reference, active Bot definition, package content hash, local runtime identity, and script path before execution
- spawn the trusted Node entrypoint directly with `shell: false`; shell metacharacters remain inert arguments
- keep arbitrary shell commands, remote target overrides, external scripts, tampered packages, and inactive Bot Skills blocked
- return actionable guidance to use `write_file` for run directories and input files before invoking a Skill script

## Root cause

The formal Skill workspace hardening added in `e97474a` intentionally blocked every chat-triggered `execute_shell` call. Script-backed SkillHub packages such as `image-asset-generator` therefore installed and loaded successfully but could never run their bundled scripts from CatsCo WebApp conversations.

## User impact

A newly connected local Bot can now run its current verified script-backed SkillHub Skills without exposing general-purpose shell execution to WebApp chat. Existing CLI shell behavior is unchanged.

## Validation

- `npm run build`
- 39 focused execution, Device RPC, and formal Skill workspace tests passed
- real installed `arrowhaken/image-asset-generator@1.0.0` resolved as a valid current-Bot script package
- full runtime suite: 1598 passed, 10 skipped; 2 unrelated worker updater tests require `jq`, which is not installed in this Windows environment
