### PR TITLE
ci(release): install retention planner dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -395,6 +395,15 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Setup Node.js for release retention planner
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Install release planner dependencies
+        run: npm ci --ignore-scripts ${{ env.NPM_INSTALL_FLAGS }}
+
       - name: Verify CDN publishing credentials
         shell: bash
         run: |


### PR DESCRIPTION
Fix the v1.4.9 release failure: the release job invokes scripts/plan-release-retention.mjs, which imports js-yaml, without installing npm dependencies. Set up Node 20 with npm cache and run npm ci before the retention planner. Based on latest upstream/main.