### PR TITLE
test(skillhub): 固化第一阶段回归门禁

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,10 +42,36 @@ jobs:
       - name: Runtime tests
         run: npm test
 
+  skillhub-phase1-regression:
+    name: SkillHub phase 1 mandatory regression
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout XiaoBa-CLI
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --prefer-offline --no-audit --fund=false
+
+      - name: Build
+        run: npm run build
+
+      - name: Phase 1 compatibility tests
+        run: npm run test:skillhub-phase1
+
   cross-repo-catsco:
     name: CatsCo cross-repo smoke and e2e
     runs-on: ubuntu-latest
-    needs: runtime
+    needs:
+      - runtime
+      - skillhub-phase1-regression
     services:
       postgres:
         image: postgres:18-alpine
@@ -128,7 +154,9 @@ jobs:
   cross-repo-catsco-skills:
     name: CatsCo/XiaoBa BotDefinition Skills paired contract tests
     runs-on: ubuntu-latest
-    needs: runtime
+    needs:
+      - runtime
+      - skillhub-phase1-regression
     timeout-minutes: 15
 
     steps:

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "watch": "tsc --watch",
     "test": "node scripts/run-tests.mjs runtime",
     "test:runtime": "node scripts/run-tests.mjs runtime",
+    "test:skillhub-phase1": "node scripts/run-tests.mjs skillhub-phase1",
     "test:cross-repo:catsco-skills": "node scripts/cross-repo-catsco-skills-smoke.mjs",
     "test:legacy": "node scripts/run-tests.mjs legacy",
     "test:all": "node scripts/run-tests.mjs all",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -19,6 +19,26 @@ const legacyTests = [
   'tests/tool-gateway-catsco.test.ts',
 ];
 
+const skillHubPhase1Tests = [
+  'tests/skillhub-phase1-compatibility.test.ts',
+  'tests/dashboard-skillhub-connected-api.test.ts',
+  'tests/catscompany-skillhub-rpc.test.ts',
+  'tests/bot-definition-skills.test.ts',
+  'tests/bot-skill-workspace.test.ts',
+  'tests/bot-skills-sync.test.ts',
+  'tests/bot-skills-security.test.ts',
+  'tests/execution-router-clean.test.ts',
+  'tests/trusted-bot-skill-script-execution.test.ts',
+  'tests/tool-result-read-file-local-grants.test.ts',
+  'tests/tool-result-read-tool.test.ts',
+  'tests/tool-result-send-file-tool.test.ts',
+  'tests/tool-result-write-tool.test.ts',
+  'tests/glob-tool.test.ts',
+  'tests/import-file.test.ts',
+  'tests/catscompany-device-rpc-tools.test.ts',
+  'tests/safety.test.ts',
+];
+
 const args = process.argv.slice(2);
 const suite = args.find(arg => !arg.startsWith('--')) || 'runtime';
 const listOnly = args.includes('--list');
@@ -33,6 +53,7 @@ const runtimeTests = allTests.filter(file => !legacySet.has(file));
 
 const suites = {
   runtime: runtimeTests,
+  'skillhub-phase1': skillHubPhase1Tests,
   legacy: legacyTests,
   all: allTests,
 };

--- a/tests/skillhub-phase1-compatibility.test.ts
+++ b/tests/skillhub-phase1-compatibility.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { ToolExecutionContext } from '../src/types/tool';
+import { EditTool } from '../src/tools/edit-tool';
+import { GlobTool } from '../src/tools/glob-tool';
+import { GrepTool } from '../src/tools/grep-tool';
+import { uploadImportFileSource } from '../src/tools/import-file-tool';
+import { ReadTool } from '../src/tools/read-tool';
+import { SendFileTool } from '../src/tools/send-file-tool';
+import { ShellTool } from '../src/tools/bash-tool';
+import { WriteTool } from '../src/tools/write-tool';
+
+let runtimeRoot = '';
+let skillsRoot = '';
+let skillFile = '';
+let originalUserDataDir: string | undefined;
+
+beforeEach(() => {
+  runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-phase1-compat-'));
+  skillsRoot = path.join(runtimeRoot, 'skills');
+  skillFile = path.join(skillsRoot, 'phase1-compat', 'SKILL.md');
+  fs.mkdirSync(path.dirname(skillFile), { recursive: true });
+  fs.writeFileSync(skillFile, '# Phase 1\ncompat-before\n', 'utf8');
+  originalUserDataDir = process.env.XIAOBA_USER_DATA_DIR;
+  process.env.XIAOBA_USER_DATA_DIR = runtimeRoot;
+});
+
+afterEach(() => {
+  if (originalUserDataDir === undefined) delete process.env.XIAOBA_USER_DATA_DIR;
+  else process.env.XIAOBA_USER_DATA_DIR = originalUserDataDir;
+  fs.rmSync(runtimeRoot, { recursive: true, force: true });
+});
+
+test('CatsCo chat keeps formal Skill read, write, edit, search, export, import, and shell access', async () => {
+  let sentPath = '';
+  const context: ToolExecutionContext = {
+    workingDirectory: runtimeRoot,
+    workspaceRoot: runtimeRoot,
+    conversationHistory: [],
+    sessionId: 'session:v2:catscompany:p2p:p2p_7_42:agent:usr42',
+    surface: 'catscompany',
+    executionScope: {
+      source: 'catscompany',
+      sessionKey: 'session:v2:catscompany:p2p:p2p_7_42:agent:usr42',
+      topicId: 'p2p_7_42',
+      topicType: 'p2p',
+      actorUserId: 'usr7',
+      agentId: 'usr42',
+      agentBodyId: 'body-42',
+      identityTrust: 'server_canonical',
+      isTrusted: true,
+    },
+    localDeviceGrant: {
+      kind: 'catscompany_body',
+      source: 'catscompany',
+      ownerUserId: 'usr42',
+      bodyId: 'body-42',
+      installationId: 'install-42',
+      deviceId: 'install-42',
+      createdAt: Date.now(),
+    },
+    channel: {
+      chatId: 'p2p_7_42',
+      reply: async () => undefined,
+      sendFile: async (_chatId, filePath) => {
+        sentPath = filePath;
+      },
+    },
+  };
+
+  const writeResult = await new WriteTool().execute({
+    file_path: skillFile,
+    content: '# Phase 1\ncompat-written\n',
+  }, context);
+  assert.equal(writeResult.ok, true);
+
+  const editResult = await new EditTool().execute({
+    file_path: skillFile,
+    old_string: 'compat-written',
+    new_string: 'compat-edited',
+  }, context);
+  assert.equal(editResult.ok, true);
+
+  const readResult = await new ReadTool().execute({ file_path: skillFile }, context);
+  assert.equal(readResult.ok, true);
+  assert.match(readResult.ok ? readResult.content as string : '', /compat-edited/);
+
+  const globResult = await new GlobTool().execute({
+    path: skillsRoot,
+    pattern: '**/SKILL.md',
+  }, context);
+  assert.equal(globResult.ok, true);
+  assert.match(globResult.ok ? globResult.content as string : '', /phase1-compat/);
+
+  const grepResult = await new GrepTool().execute({
+    path: skillsRoot,
+    pattern: 'compat-edited',
+    output_mode: 'content',
+  }, context);
+  assert.equal(grepResult.ok, true);
+  assert.match(grepResult.ok ? grepResult.content as string : '', /compat-edited/);
+
+  const sendResult = await new SendFileTool().execute({
+    file_path: skillFile,
+    file_name: 'SKILL.md',
+  }, context);
+  assert.equal(sendResult.ok, true);
+  assert.equal(sentPath, skillFile);
+
+  const importResult = await uploadImportFileSource({
+    file_path: skillFile,
+    file_name: 'SKILL.md',
+  }, context, async (filePath, fileName) => ({
+    url: 'https://app.catsco.cc/uploads/phase1-skill',
+    name: fileName,
+    size: fs.statSync(filePath).size,
+  }));
+  assert.equal(importResult.ok, true);
+
+  const shellResult = await new ShellTool().execute({
+    command: `node -e "console.log('phase1-shell-ok')"`,
+  }, context);
+  assert.equal(shellResult.ok, true);
+  assert.match(shellResult.ok ? shellResult.content as string : '', /phase1-shell-ok/);
+});


### PR DESCRIPTION
## 变更内容

新增 npm run test:skillhub-phase1，将第一阶段已经验证过的 SkillHub、BotDefinition、工作区和 CatsCo 聊天工具权限行为固化为独立门禁。

## 为什么需要

第二阶段会继续增加云端 mutation、Runtime 授权和工作区能力。该门禁用于防止后续改动再次关闭第一阶段已交付的 read/write/edit/glob/grep/send/import、普通 Shell、SkillHub 分享/安装/删除和可信脚本能力。

## CI 变化

- 新增独立的 skillhub-phase1-regression CI job。
- 两个跨仓 required check 显式依赖该 job，门禁失败时不会误报通过。
- 新增 CatsCo 聊天上下文直接操作正式 skills 目录的兼容回归覆盖。

## 验证

- npm run build
- npm run test:skillhub-phase1：220/220 通过
- 完整 npm test：1596 通过；2 个失败均为 Windows 缺少 jq 的既有 worker updater 测试，与本次变更无关。

本 PR 只增加测试和 CI 保护，不修改生产权限策略。