### PR TITLE
ops: add worker artifact backfill workflow

### DIFF
--- a/.github/workflows/worker-artifact-backfill.yml
+++ b/.github/workflows/worker-artifact-backfill.yml
@@ -1,0 +1,126 @@
+name: Backfill Worker Application Artifact
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_ref:
+        description: Existing stable tag or commit to build (for example v1.4.8)
+        required: true
+        type: string
+      version:
+        description: Published application version (must match the source package version)
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: worker-artifact-backfill-${{ inputs.version }}
+  cancel-in-progress: false
+
+env:
+  NODE_VERSION: "22.23.1"
+  TOS_WORKER_BUCKET: catsco-worker-release
+  TOS_WORKER_REGION: cn-guangzhou
+
+jobs:
+  publish:
+    name: Build and publish worker ${{ inputs.version }}
+    runs-on: ubuntu-24.04
+    environment: release-prod
+    steps:
+      - name: Checkout requested source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          ref: ${{ inputs.source_ref }}
+          fetch-depth: 0
+
+      - name: Validate source and version
+        shell: bash
+        env:
+          REQUESTED_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          [[ "$REQUESTED_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          [[ "${GITHUB_REF_NAME}" == "main" ]]
+          actual="$(node -p "require('./package.json').version")"
+          [[ "$actual" == "$REQUESTED_VERSION" ]] || {
+            echo "package version $actual does not match requested $REQUESTED_VERSION" >&2
+            exit 1
+          }
+          git merge-base --is-ancestor HEAD origin/main || {
+            echo "requested source is not contained in main" >&2
+            exit 1
+          }
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Build deterministic worker artifact
+        run: |
+          npm ci --prefer-offline --no-audit --fund=false
+          mkdir -p release/worker
+          npm run --silent worker:artifact -- --manifest-output release/worker/build-manifest.json
+          test "$(node -p "require('./package.json').version")" = "${{ inputs.version }}"
+
+      - name: Install AWS CLI
+        run: |
+          if ! command -v aws >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y awscli
+          fi
+          aws configure set default.s3.addressing_style virtual
+
+      - name: Publish immutable worker artifact
+        shell: bash
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.VOLC_TOS_WORKER_PUBLISH_ACCESS_KEY_ID || secrets.VOLC_TOS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.VOLC_TOS_WORKER_PUBLISH_SECRET_ACCESS_KEY || secrets.VOLC_TOS_SECRET_ACCESS_KEY }}
+          REQUESTED_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          endpoint="https://tos-s3-${TOS_WORKER_REGION}.volces.com"
+          prefix="update/worker/${REQUESTED_VERSION}"
+          artifact="$(find release/worker -maxdepth 1 -type f -name '*.tar.gz' -print -quit)"
+          checksum="${artifact}.sha256"
+          test -f "$artifact" -a -f "$checksum"
+          sha="$(sha256sum "$artifact" | awk '{print $1}')"
+          grep -F "$sha" "$checksum" >/dev/null
+
+          manifest="$(mktemp)"
+          jq --arg artifactFile "$(basename "$artifact")" \
+             'del(.artifactPath) + {artifactFile: $artifactFile}' \
+             release/worker/build-manifest.json > "$manifest"
+
+          publish() {
+            local file="$1" key="$2"
+            local local_sha remote_sha remote_size local_size
+            local_sha="$(sha256sum "$file" | awk '{print $1}')"
+            local_size="$(stat --format='%s' "$file")"
+            if remote="$(aws s3api head-object --bucket "$TOS_WORKER_BUCKET" --key "$key" --endpoint-url "$endpoint" --output json 2>/dev/null)"; then
+              remote_sha="$(jq -r '.Metadata.sha256 // ""' <<<"$remote")"
+              remote_size="$(jq -r '.ContentLength // -1' <<<"$remote")"
+              [[ "$remote_sha" == "$local_sha" && "$remote_size" == "$local_size" ]] || {
+                echo "refusing to overwrite immutable object: $key" >&2
+                exit 1
+              }
+              return
+            fi
+            aws s3 cp "$file" "s3://${TOS_WORKER_BUCKET}/${key}" \
+              --endpoint-url "$endpoint" --acl private \
+              --cache-control 'private, max-age=31536000, immutable' \
+              --metadata "sha256=$local_sha" --only-show-errors
+            remote="$(aws s3api head-object --bucket "$TOS_WORKER_BUCKET" --key "$key" --endpoint-url "$endpoint" --output json)"
+            remote_sha="$(jq -r '.Metadata.sha256 // ""' <<<"$remote")"
+            remote_size="$(jq -r '.ContentLength // -1' <<<"$remote")"
+            [[ "$remote_sha" == "$local_sha" && "$remote_size" == "$local_size" ]]
+          }
+
+          publish "$artifact" "$prefix/$(basename "$artifact")"
+          publish "$checksum" "$prefix/$(basename "$checksum")"
+          publish "$manifest" "$prefix/manifest.json"
+          echo "published worker artifact version=${REQUESTED_VERSION} sha=${sha}"


### PR DESCRIPTION
## Purpose\nAdd a protected manual workflow to rebuild and publish a historical worker application artifact (for example v1.4.8) into the private TOS catalog.\n\n## Safety\n- Requires explicit source ref and version inputs.\n- Validates package version and source ancestry.\n- Publishes immutable objects with SHA-256 and size verification.\n- Refuses to overwrite an existing object with different content.\n\nThis restores real rollback catalog entries without fabricating versions or changing production worker state.