### PR TITLE
fix: support historical worker artifact builder

### DIFF
--- a/.github/workflows/worker-artifact-backfill.yml
+++ b/.github/workflows/worker-artifact-backfill.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           npm ci --prefer-offline --no-audit --fund=false
           mkdir -p release/worker
-          npm run --silent worker:artifact -- --manifest-output release/worker/build-manifest.json
+          npm run --silent worker:artifact > release/worker/build-manifest.json
           test "$(node -p "require('./package.json').version")" = "${{ inputs.version }}"
 
       - name: Install AWS CLI


### PR DESCRIPTION
The v1.4.8 worker builder predates --manifest-output. Capture its JSON stdout instead so the backfill workflow supports the historical tag without changing the deterministic artifact.