### PR TITLE
feat: make desktop connector tray-first

### DIFF
--- a/dashboard/connector.css
+++ b/dashboard/connector.css
@@ -33,9 +33,9 @@ button, a { -webkit-tap-highlight-color: transparent; }
 }
 
 .connector-window {
-  width: min(1080px, 100%);
-  height: min(700px, 100%);
-  min-width: 720px;
+  width: min(780px, 100%);
+  height: min(520px, 100%);
+  min-width: 0;
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -44,6 +44,61 @@ button, a { -webkit-tap-highlight-color: transparent; }
   background: var(--surface);
   box-shadow: 0 16px 44px rgba(25, 42, 70, .09);
 }
+
+body[data-view="ready"] .app-shell { padding: 10px; }
+body[data-view="ready"] .connector-window { border-radius: 12px; }
+body[data-view="ready"] .topbar { height: 58px; flex-basis: 58px; padding: 0 18px; }
+body[data-view="ready"] .brand { gap: 10px; }
+body[data-view="ready"] .brand img { width: 34px; height: 34px; }
+body[data-view="ready"] .brand strong { font-size: 17px; }
+body[data-view="ready"] .brand span { font-size: 12px; }
+body[data-view="ready"] .top-actions #refresh-button { min-height: 34px; padding: 0 12px; font-size: 13px; }
+body[data-view="ready"] .notice { min-height: 36px; margin: 10px 16px 0; padding: 7px 11px; font-size: 13px; }
+body[data-view="ready"] .main-grid { padding: 10px 12px 12px; grid-template-columns: minmax(0, 1fr) 250px; gap: 10px; }
+body[data-view="ready"] .primary-panel { padding: 18px 22px 10px; border-radius: 10px; }
+body[data-view="ready"] .summary-panel { padding: 2px 14px; border-radius: 10px; }
+body[data-view="ready"] .status-line { gap: 8px; font-size: 15px; }
+body[data-view="ready"] h1 { margin-top: 16px; font-size: 34px; letter-spacing: 0; }
+body[data-view="ready"] .hero-copy { margin: 9px 0 18px; font-size: 14px; line-height: 1.5; }
+body[data-view="ready"] .hero-actions .button { min-height: 36px; padding: 0 13px; font-size: 13px; }
+body[data-view="ready"] .close-hint { margin-top: 9px; font-size: 12px; }
+body[data-view="ready"] .summary-card { padding: 12px 2px; }
+body[data-view="ready"] .summary-card > span,
+body[data-view="ready"] .summary-card div > span,
+body[data-view="ready"] .summary-card-heading > span { font-size: 12px; }
+body[data-view="ready"] .summary-card > strong,
+body[data-view="ready"] .summary-card div > strong { margin-top: 4px; font-size: 16px; }
+body[data-view="ready"] .summary-card > small { margin-top: 2px; font-size: 11px; }
+body[data-view="ready"] .summary-action { min-height: 26px; padding: 0 8px; font-size: 11px; }
+body[data-view="ready"] .management-entry { min-height: 39px; margin-top: 8px; }
+body[data-view="ready"] .management-entry strong { font-size: 13px; }
+body[data-view="ready"] .management-entry small { font-size: 11px; }
+
+/* The login screen is an entry point, not a second dashboard. Keep it in one
+   compact column so the form is fully visible without nested scrollbars. */
+body[data-view="auth"] .topbar { height: 58px; flex-basis: 58px; padding: 0 18px; }
+body[data-view="auth"] .brand { gap: 10px; }
+body[data-view="auth"] .brand img { width: 34px; height: 34px; }
+body[data-view="auth"] .brand strong { font-size: 17px; }
+body[data-view="auth"] .brand span { font-size: 12px; }
+body[data-view="auth"] .top-actions #refresh-button { min-height: 34px; padding: 0 12px; font-size: 13px; }
+body[data-view="auth"] .notice { min-height: 36px; margin: 10px 16px 0; padding: 7px 11px; font-size: 13px; }
+body[data-view="auth"] .main-grid { grid-template-columns: minmax(0, 1fr); padding: 10px 14px 14px; overflow: hidden; }
+body[data-view="auth"] .summary-panel,
+body[data-view="auth"] .management-entry { display: none; }
+body[data-view="auth"] .primary-panel { padding: 18px 24px 16px; overflow: visible; }
+body[data-view="auth"] .primary-content { overflow: visible; justify-content: flex-start; }
+body[data-view="auth"] .status-line { gap: 8px; font-size: 15px; }
+body[data-view="auth"] h1 { margin-top: 14px; font-size: 38px; letter-spacing: 0; }
+body[data-view="auth"] .hero-copy { margin: 8px 0 14px; font-size: 15px; line-height: 1.5; }
+body[data-view="auth"] .login-card { width: 100%; padding: 14px; gap: 10px; }
+body[data-view="auth"] .form-heading strong { font-size: 16px; }
+body[data-view="auth"] .form-heading span { margin-top: 2px; font-size: 12px; }
+body[data-view="auth"] .login-card label span { margin-bottom: 4px; font-size: 12px; }
+body[data-view="auth"] .login-card input { height: 36px; font-size: 13px; }
+body[data-view="auth"] .form-actions { gap: 8px; }
+body[data-view="auth"] .form-actions .button { min-height: 36px; padding: 0 14px; font-size: 13px; }
+body[data-view="auth"] .text-link { font-size: 12px; }
 
 .topbar {
   height: 76px;
@@ -231,6 +286,8 @@ h1 {
   box-shadow: 0 24px 70px rgba(18, 31, 52, .24);
 }
 .agent-switch-dialog::backdrop { background: rgba(24, 32, 51, .34); }
+.logout-dialog { width: min(460px, calc(100vw - 40px)); }
+.logout-dialog-body { color: var(--muted); font-size: 14px; line-height: 1.65; }
 .agent-switch-shell { min-height: 0; max-height: inherit; display: flex; flex-direction: column; }
 .agent-switch-header { padding: 22px 24px 17px; display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; border-bottom: 1px solid var(--line); }
 .agent-switch-header h2 { margin: 0; font-size: 22px; line-height: 1.25; }
@@ -379,6 +436,7 @@ h1 {
 .channel-name { display: block; font-size: 16px; }
 .channel-meta { display: block; margin-top: 2px; color: var(--muted); font-size: 12px; }
 .channel-actions { display: flex; align-items: center; gap: 8px; }
+.channel-actions .button { min-width: 64px; flex: 0 0 auto; white-space: nowrap; }
 .channel-error { margin: 10px 0 0 20px; color: var(--red); font-size: 12px; }
 .empty-state { padding: 38px 16px; border: 1px dashed #d3dae5; border-radius: 9px; color: var(--muted); text-align: center; font-size: 13px; }
 
@@ -474,6 +532,39 @@ h1 {
   .management-view { min-height: 430px; flex: 0 0 auto; }
   .channel-main, .recovery-row, .danger-zone { align-items: flex-start; }
 }
+
+/* Connecting is transient, so it should read as a compact progress state and
+   never expose the full dashboard's nested scroll areas. */
+body[data-view="connecting"] .app-shell { padding: 10px; }
+body[data-view="connecting"] .topbar { height: 58px; flex-basis: 58px; padding: 0 18px; }
+body[data-view="connecting"] .brand { gap: 10px; }
+body[data-view="connecting"] .brand img { width: 34px; height: 34px; }
+body[data-view="connecting"] .brand strong { font-size: 17px; }
+body[data-view="connecting"] .brand span { font-size: 12px; }
+body[data-view="connecting"] .top-actions #refresh-button { min-height: 34px; padding: 0 12px; font-size: 13px; }
+body[data-view="connecting"] .notice { min-height: 36px; margin: 10px 16px 0; padding: 7px 11px; font-size: 13px; }
+body[data-view="connecting"] .main-grid { padding: 10px 12px 12px; grid-template-columns: minmax(0, 1fr) 250px; gap: 10px; overflow: hidden; }
+body[data-view="connecting"] .primary-panel { padding: 16px 22px 10px; border-radius: 10px; overflow: hidden; }
+body[data-view="connecting"] .primary-content { overflow: hidden; justify-content: flex-start; }
+body[data-view="connecting"] .status-line { gap: 8px; font-size: 15px; }
+body[data-view="connecting"] h1 { margin: 12px 0 0; font-size: 32px; line-height: 1.2; letter-spacing: 0; }
+body[data-view="connecting"] .hero-copy { margin: 7px 0 12px; font-size: 14px; line-height: 1.45; }
+body[data-view="connecting"] .progress-list { width: 100%; margin: 0; }
+body[data-view="connecting"] .progress-list li { min-height: 48px; padding: 8px 13px; gap: 10px; }
+body[data-view="connecting"] .progress-list strong { font-size: 14px; }
+body[data-view="connecting"] .progress-list small { margin-top: 1px; font-size: 12px; }
+body[data-view="connecting"] .summary-panel { padding: 2px 14px; border-radius: 10px; overflow: hidden; }
+body[data-view="connecting"] .summary-card { padding: 12px 2px; }
+body[data-view="connecting"] .summary-card > span,
+body[data-view="connecting"] .summary-card div > span,
+body[data-view="connecting"] .summary-card-heading > span { font-size: 12px; }
+body[data-view="connecting"] .summary-card > strong,
+body[data-view="connecting"] .summary-card div > strong { margin-top: 4px; font-size: 16px; }
+body[data-view="connecting"] .summary-card > small { margin-top: 2px; font-size: 11px; }
+body[data-view="connecting"] .summary-action { min-height: 26px; padding: 0 8px; font-size: 11px; }
+body[data-view="connecting"] .management-entry { min-height: 39px; margin-top: 8px; }
+body[data-view="connecting"] .management-entry strong { font-size: 13px; }
+body[data-view="connecting"] .management-entry small { font-size: 11px; }
 
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after { animation: none !important; transition: none !important; }

--- a/dashboard/connector.html
+++ b/dashboard/connector.html
@@ -205,6 +205,25 @@
     </form>
   </dialog>
 
+  <dialog class="agent-switch-dialog logout-dialog" id="logout-dialog" aria-labelledby="logout-title">
+    <form method="dialog" class="agent-switch-shell">
+      <header class="agent-switch-header">
+        <div>
+          <h2 id="logout-title">退出 CatsCo 账号</h2>
+          <p>退出后，这台电脑上的 Connector 会停止运行。</p>
+        </div>
+        <button class="dialog-close" id="logout-close" type="submit" value="cancel" aria-label="关闭">×</button>
+      </header>
+      <div class="agent-switch-body logout-dialog-body">
+        确定要退出当前账号吗？之后需要重新登录才能让 WebApp 使用这台电脑。
+      </div>
+      <footer class="agent-switch-footer">
+        <button class="button button-quiet" id="logout-cancel" type="submit" value="cancel">取消</button>
+        <button class="button button-danger" id="logout-confirm" type="button">退出账号</button>
+      </footer>
+    </form>
+  </dialog>
+
   <div class="toast" id="toast" role="status" hidden></div>
   <script src="connector.js"></script>
 </body>

--- a/dashboard/connector.js
+++ b/dashboard/connector.js
@@ -109,6 +109,8 @@
     update: {},
     refreshInFlight: null,
     loginBusy: false,
+    openWebAppAfterLogin: false,
+    logoutBusy: false,
     actionBusy: false,
     fullPollTimer: null,
     bootstrapPollTimer: null,
@@ -269,6 +271,27 @@
     if (view.key === 'error') renderError(view);
     renderUpdate();
     syncPolling(view.key);
+    maybeOpenWebAppAfterLogin(view.key);
+  }
+
+  function maybeOpenWebAppAfterLogin(viewKey) {
+    if (viewKey !== 'ready' || !state.openWebAppAfterLogin) return;
+    state.openWebAppAfterLogin = false;
+    window.setTimeout(() => {
+      void openWebAppFromDashboard();
+    }, 250);
+  }
+
+  async function openWebAppFromDashboard() {
+    try {
+      if (window.catscoDesktop?.openWebApp) {
+        await window.catscoDesktop.openWebApp();
+      } else {
+        window.open('https://app.catsco.cc', '_blank', 'noopener,noreferrer');
+      }
+    } finally {
+      await window.catscoDesktop?.hideWindow?.();
+    }
   }
 
   function renderAuth(view) {
@@ -359,6 +382,7 @@
       await request('/cats/auth/login', { method: 'POST', body: JSON.stringify({ account, password }) });
       $('login-password').value = '';
       await request('/cats/bootstrap', { method: 'POST', body: JSON.stringify({ trigger: 'login' }) });
+      state.openWebAppAfterLogin = true;
       state.bootstrap = { stage: 'connecting', message: '登录成功，正在自动连接这台电脑' };
       await refresh({ force: true });
     } catch (error) {
@@ -738,16 +762,32 @@
     }
   }
 
+  function openLogoutDialog() {
+    if (state.logoutBusy) return;
+    $('logout-dialog').showModal();
+  }
+
   async function logout() {
-    if (!window.confirm('退出后，本机 Connector 会停止。确定退出这个 CatsCo 账号吗？')) return;
+    if (state.logoutBusy) return;
+    state.logoutBusy = true;
+    $('logout-confirm').disabled = true;
+    $('logout-confirm').textContent = '正在退出…';
     try {
       await request('/cats/auth/logout', { method: 'POST', body: '{}' });
+      $('logout-dialog').close();
+      closeManagement();
       state.cats = {};
       state.bootstrap = { stage: 'waiting_for_login' };
       await refresh({ force: true });
-      closeManagement();
+      window.requestAnimationFrame(() => {
+        $('login-account')?.focus({ preventScroll: true });
+      });
     } catch (error) {
       showToast(`退出失败：${humanError(error)}`);
+    } finally {
+      state.logoutBusy = false;
+      $('logout-confirm').disabled = false;
+      $('logout-confirm').textContent = '退出账号';
     }
   }
 
@@ -801,10 +841,18 @@
   }
 
   $('login-form').addEventListener('submit', login);
+  $('webapp-button').addEventListener('click', (event) => {
+    event.preventDefault();
+    void openWebAppFromDashboard();
+  });
   $('refresh-button').addEventListener('click', () => refresh({ force: true }));
   $('retry-button').addEventListener('click', retry);
   $('diagnostic-retry').addEventListener('click', retry);
-  $('logout-button').addEventListener('click', logout);
+  $('logout-button').addEventListener('click', openLogoutDialog);
+  $('logout-confirm').addEventListener('click', () => { void logout(); });
+  $('logout-dialog').addEventListener('cancel', (event) => {
+    if (state.logoutBusy) event.preventDefault();
+  });
   $('update-button').addEventListener('click', checkUpdate);
   $('management-open').addEventListener('click', () => { void openManagement(); });
   $('agent-switch-open').addEventListener('click', () => { void openAgentSwitch(); });

--- a/electron/main.js
+++ b/electron/main.js
@@ -21,6 +21,7 @@ if (shouldDisableHardwareAcceleration()) {
 const DASHBOARD_PORT = resolveDashboardPort(process.env.XIAOBA_DASHBOARD_PORT);
 const DEEP_LINK_PROTOCOL = 'catsco';
 const TRUSTED_DEEP_LINK_BASE_ORIGINS = new Set(['https://app.catsco.cc']);
+const CATSCO_WEBAPP_URL = 'https://app.catsco.cc';
 let mainWindow = null;
 let tray = null;
 let autoUpdater = null;
@@ -112,6 +113,37 @@ function showMainWindow() {
     mainWindow.focus();
   } else {
     createWindow();
+  }
+}
+
+function readStoredCatsCoSession() {
+  try {
+    const configPath = path.join(process.cwd(), '.xiaoba', 'catsco.json');
+    if (!fs.existsSync(configPath)) return null;
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    const token = String(config?.account?.token || '').trim();
+    const uid = String(config?.account?.uid || '').trim();
+    return token && uid ? { token, uid } : null;
+  } catch (_error) {
+    return null;
+  }
+}
+
+async function shouldShowDashboardAtStartup() {
+  if (process.env.XIAOBA_SHOW_DASHBOARD === '1') return true;
+  if (!readStoredCatsCoSession()) return true;
+
+  try {
+    const dashboardApiKey = String(process.env.DASHBOARD_API_KEY || '').trim();
+    const response = await fetch(`http://127.0.0.1:${DASHBOARD_PORT}/api/cats/status`, {
+      headers: dashboardApiKey ? { 'X-API-Key': dashboardApiKey } : {},
+    });
+    if (!response.ok) return true;
+    const status = await response.json();
+    return status?.authStatus !== 'valid' || status?.connected !== true;
+  } catch (_error) {
+    // Fail open to the Dashboard if the local status check cannot complete.
+    return true;
   }
 }
 
@@ -563,10 +595,10 @@ function stopDashboardServer() {
 
 function createWindow() {
   mainWindow = new BrowserWindow({
-    width: 1080,
-    height: 720,
-    minWidth: 900,
-    minHeight: 600,
+    width: 780,
+    height: 560,
+    minWidth: 680,
+    minHeight: 480,
     title: 'CatsCo Connector',
     titleBarStyle: 'hiddenInset',
     backgroundColor: '#edf3ef',
@@ -690,6 +722,20 @@ ipcMain.handle('catsco:select-files', async (event) => {
       }
     })
     .filter(Boolean);
+});
+
+ipcMain.handle('catsco:hide-window', async (event) => {
+  const owner = BrowserWindow.fromWebContents(event.sender);
+  if (owner !== mainWindow) return false;
+  owner.hide();
+  return true;
+});
+
+ipcMain.handle('catsco:open-webapp', async (event) => {
+  const owner = BrowserWindow.fromWebContents(event.sender);
+  if (owner !== mainWindow) return false;
+  await shell.openExternal(CATSCO_WEBAPP_URL);
+  return true;
 });
 
 function getRuntimeDataRootForMenu() {
@@ -820,6 +866,7 @@ function createTray() {
 
   const contextMenu = Menu.buildFromTemplate([
     { label: '打开 CatsCo Connector', click: showMainWindow },
+    { label: '打开 CatsCo WebApp', click: () => shell.openExternal(CATSCO_WEBAPP_URL) },
     { type: 'separator' },
     { label: '退出 CatsCo', click: () => { app.isQuitting = true; app.quit(); }} ,
   ]);
@@ -905,8 +952,8 @@ app.whenReady().then(async () => {
     await startServer();
     dashboardServerReady = true;
     createApplicationMenu();
-    createWindow();
     createTray();
+    if (await shouldShowDashboardAtStartup()) createWindow();
     enqueueDeepLinkFromArgv(process.argv);
     scheduleDeepLinkDrain();
     

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -2,4 +2,6 @@ const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('catscoDesktop', {
   selectFiles: () => ipcRenderer.invoke('catsco:select-files'),
+  openWebApp: () => ipcRenderer.invoke('catsco:open-webapp'),
+  hideWindow: () => ipcRenderer.invoke('catsco:hide-window'),
 });

--- a/tests/dashboard-connector.test.ts
+++ b/tests/dashboard-connector.test.ts
@@ -34,6 +34,9 @@ test('Connector lets an authenticated user switch the Agent bound to this comput
   assert.match(script, /微信服务会停止/);
   assert.doesNotMatch(script, /\/cats\/create-bot/);
   assert.match(styles, /\.agent-switch-dialog/);
+  assert.match(html, /id="logout-dialog"/);
+  assert.doesNotMatch(script, /window\.confirm\(/);
+  assert.match(script, /login-account'\)\?\.focus/);
 });
 
 test('Connector local management restores channels and gives logs a full workspace', () => {
@@ -62,6 +65,9 @@ test('Connector client uses real lifecycle APIs and remains syntax-valid', () =>
   assert.match(script, /cats\.chatReady/);
   assert.match(script, /service\.status === 'running'/);
   assert.match(script, /bodyStatus\?\.state !== 'offline'/);
+  assert.match(script, /webapp-button.*addEventListener\('click'/s);
+  assert.match(script, /openWebAppFromDashboard/);
+  assert.match(styles, /\.channel-actions \.button[\s\S]*white-space: nowrap/);
 });
 
 test('Connector Dashboard is the real root and uses a viewport-bound desktop layout', () => {
@@ -70,6 +76,8 @@ test('Connector Dashboard is the real root and uses a viewport-bound desktop lay
   assert.match(styles, /body\[data-view="ready"\]/);
   assert.match(styles, /html, body \{[^}]*height: 100%[^}]*overflow: hidden/s);
   assert.match(styles, /@media \(max-height: 700px\)/);
+  assert.match(styles, /body\[data-view="connecting"\] \.primary-panel[\s\S]*overflow: hidden/);
+  assert.match(styles, /body\[data-view="connecting"\] \.progress-list[\s\S]*width: 100%/);
 });
 
 test('background bootstrap waits for login without making network requests', async () => {

--- a/tests/electron-main-dashboard-url.test.ts
+++ b/tests/electron-main-dashboard-url.test.ts
@@ -11,8 +11,8 @@ test('electron opens the local dashboard through stable IPv4 loopback', () => {
 });
 
 test('electron opens Connector in a compact desktop-sized window', () => {
-  assert.match(electronMain, /new BrowserWindow\(\{\s*width: 1080,\s*height: 720,/);
-  assert.match(electronMain, /minWidth: 900,\s*minHeight: 600,/);
+  assert.match(electronMain, /new BrowserWindow\(\{\s*width: 780,\s*height: 560,/);
+  assert.match(electronMain, /minWidth: 680,\s*minHeight: 480,/);
 });
 
 test('electron keeps close-to-tray as the fixed Connector window behavior', () => {
@@ -91,7 +91,16 @@ test('electron sends trusted CatsCo links to the system browser', () => {
   assert.match(electronMain, /setWindowOpenHandler/);
   assert.match(electronMain, /target\.origin === 'https:\/\/app\.catsco\.cc'/);
   assert.match(electronMain, /shell\.openExternal\(target\.toString\(\)\)/);
+  assert.match(electronMain, /ipcMain\.handle\('catsco:open-webapp'/);
+  assert.match(electronMain, /label: '打开 CatsCo WebApp'/);
   assert.match(electronMain, /return \{ action: 'deny' \}/);
+});
+
+test('electron keeps authenticated startup in the tray and shows the Dashboard when login is required', () => {
+  assert.match(electronMain, /async function shouldShowDashboardAtStartup\(\)/);
+  assert.match(electronMain, /if \(!readStoredCatsCoSession\(\)\) return true/);
+  assert.match(electronMain, /if \(await shouldShowDashboardAtStartup\(\)\) createWindow\(\)/);
+  assert.match(electronMain, /ipcMain\.handle\('catsco:hide-window'/);
 });
 
 test('electron opens trusted local diagnostics in a separate sandboxed window', () => {


### PR DESCRIPTION
## What changed

- Make the Electron desktop app tray-first for authenticated users.
- Show the Connector window only when login is required or the local connection needs attention.
- Add trusted WebApp opening through the Electron main process and hide the Dashboard after opening it.
- Compact ready and connecting layouts so transient states fit without nested scrollbars.
- Keep channel action labels on one line.
- Replace the blocking logout confirmation with an in-app dialog and restore focus to the login account field after logout.
- Add tray menu access to the CatsCo WebApp.

## Why

The Dashboard is a local connector, not the primary chat surface. Users should normally work in the CatsCo WebApp while XiaoBa stays available from the system tray. Login, connection recovery, local channel management, and Agent switching remain available when the Connector window is opened.

## Validation

- `npm run build`
- `npx tsx --test tests/dashboard-connector.test.ts tests/electron-main-dashboard-url.test.ts` (24 passing)
- `git diff --check`
