### PR TITLE
fix(worker-image): bake builders without public IP

### DIFF
--- a/.github/workflows/worker-image.yml
+++ b/.github/workflows/worker-image.yml
@@ -24,6 +24,8 @@ env:
   NODE_VERSION: "22.23.1"
   CTYUN_CLI_VERSION: v0.1.1
   CTYUN_CLI_PACKAGE_SHA256: 93272c3fd377a6f642a89cb326fa2f4a3d2fab7dfc9587e49906527230b767fa
+  TOS_WORKER_BUCKET: catsco-worker-release
+  TOS_WORKER_REGION: cn-guangzhou
 
 jobs:
   image:
@@ -97,6 +99,45 @@ jobs:
           artifact="${artifacts[0]}"
           echo "path=$artifact" >> "$GITHUB_OUTPUT"
           echo "sha256=$(sha256sum "$artifact" | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+
+      - name: Stage private artifact for the builder
+        id: artifact_transport
+        timeout-minutes: 15
+        shell: bash
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.VOLC_TOS_WORKER_PUBLISH_ACCESS_KEY_ID || secrets.VOLC_TOS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.VOLC_TOS_WORKER_PUBLISH_SECRET_ACCESS_KEY || secrets.VOLC_TOS_SECRET_ACCESS_KEY }}
+          WORKER_ARTIFACT_PATH: ${{ steps.artifact_meta.outputs.path }}
+          WORKER_ARTIFACT_SHA256: ${{ steps.artifact_meta.outputs.sha256 }}
+        run: |
+          set -euo pipefail
+          if ! command -v aws >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y awscli
+          fi
+          aws configure set default.s3.addressing_style virtual
+          endpoint="https://tos-s3-${TOS_WORKER_REGION}.volces.com"
+          key="update/worker/.bake/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/$(basename "$WORKER_ARTIFACT_PATH")"
+          script_key="update/worker/.bake/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/prepare-image.sh"
+          echo "key=$key" >> "$GITHUB_OUTPUT"
+          echo "script_key=$script_key" >> "$GITHUB_OUTPUT"
+          aws s3 cp "$WORKER_ARTIFACT_PATH" "s3://${TOS_WORKER_BUCKET}/${key}" \
+            --endpoint-url "$endpoint" --acl private \
+            --metadata "sha256=${WORKER_ARTIFACT_SHA256}" --only-show-errors
+          script_sha="$(sha256sum ops/ctyun-worker-image/prepare-image.sh | awk '{print $1}')"
+          aws s3 cp ops/ctyun-worker-image/prepare-image.sh \
+            "s3://${TOS_WORKER_BUCKET}/${script_key}" \
+            --endpoint-url "$endpoint" --acl private \
+            --metadata "sha256=${script_sha}" --only-show-errors
+          url="$(aws s3 presign "s3://${TOS_WORKER_BUCKET}/${key}" \
+            --endpoint-url "$endpoint" --expires-in 21600)"
+          script_url="$(aws s3 presign "s3://${TOS_WORKER_BUCKET}/${script_key}" \
+            --endpoint-url "$endpoint" --expires-in 21600)"
+          echo "::add-mask::$url"
+          echo "::add-mask::$script_url"
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+          echo "script_url=$script_url" >> "$GITHUB_OUTPUT"
+          echo "script_sha256=$script_sha" >> "$GITHUB_OUTPUT"
 
       - name: Install pinned Tianyi Cloud CLI package
         timeout-minutes: 3
@@ -378,12 +419,18 @@ jobs:
           WORKER_SECURITY_GROUP_ID: ${{ vars.CTYUN_WORKER_SECURITY_GROUP_ID }}
           WORKER_ARTIFACT_PATH: ${{ steps.artifact_meta.outputs.path }}
           WORKER_ARTIFACT_SHA256: ${{ steps.artifact_meta.outputs.sha256 }}
+          WORKER_ARTIFACT_URL: ${{ steps.artifact_transport.outputs.url }}
+          WORKER_PREPARE_SCRIPT_URL: ${{ steps.artifact_transport.outputs.script_url }}
+          WORKER_PREPARE_SCRIPT_SHA256: ${{ steps.artifact_transport.outputs.script_sha256 }}
         run: |
           ./ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1 `
             -Mode Create `
             -SourceRef $env:GITHUB_SHA `
             -ArtifactPath $env:WORKER_ARTIFACT_PATH `
             -ArtifactSha256 $env:WORKER_ARTIFACT_SHA256 `
+            -ArtifactUrl $env:WORKER_ARTIFACT_URL `
+            -PrepareScriptUrl $env:WORKER_PREPARE_SCRIPT_URL `
+            -PrepareScriptSha256 $env:WORKER_PREPARE_SCRIPT_SHA256 `
             -BuildNumber $env:GITHUB_RUN_NUMBER `
             -BuildAttempt $env:GITHUB_RUN_ATTEMPT `
             -BuildIdentity $env:GITHUB_RUN_ID `
@@ -460,3 +507,25 @@ jobs:
             -VpcID $env:WORKER_VPC_ID `
             -SubnetID $env:WORKER_SUBNET_ID `
             -SecurityGroupID $env:WORKER_SECURITY_GROUP_ID
+
+      - name: Remove staged private artifact
+        if: ${{ always() && steps.artifact_transport.outputs.key != '' }}
+        timeout-minutes: 10
+        shell: bash
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.VOLC_TOS_WORKER_PUBLISH_ACCESS_KEY_ID || secrets.VOLC_TOS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.VOLC_TOS_WORKER_PUBLISH_SECRET_ACCESS_KEY || secrets.VOLC_TOS_SECRET_ACCESS_KEY }}
+          STAGED_ARTIFACT_KEY: ${{ steps.artifact_transport.outputs.key }}
+          STAGED_SCRIPT_KEY: ${{ steps.artifact_transport.outputs.script_key }}
+        run: |
+          set -euo pipefail
+          endpoint="https://tos-s3-${TOS_WORKER_REGION}.volces.com"
+          for key in "$STAGED_ARTIFACT_KEY" "$STAGED_SCRIPT_KEY"; do
+            aws s3 rm "s3://${TOS_WORKER_BUCKET}/${key}" \
+              --endpoint-url "$endpoint" --only-show-errors
+            if aws s3api head-object --bucket "$TOS_WORKER_BUCKET" \
+              --key "$key" --endpoint-url "$endpoint" >/dev/null 2>&1; then
+              echo "staged bake object still exists after cleanup: $key" >&2
+              exit 1
+            fi
+          done

--- a/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
+++ b/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
@@ -29,20 +29,17 @@ param(
     [string]$ImageName = "",
     [string]$ArtifactPath = "",
     [string]$ArtifactSha256 = "",
+    [string]$ArtifactUrl = "",
+    [string]$PrepareScriptUrl = "",
+    [string]$PrepareScriptSha256 = "",
     [string]$BuildNumber = "",
     [string]$BuildAttempt = "1",
     [string]$BuildIdentity = "",
     [string]$BootDiskType = "SATA",
     [ValidateRange(40, 2048)]
     [int]$BootDiskSize = 40,
-    [ValidateRange(1, 300)]
-    [int]$BuilderBandwidth = 5,
     [ValidateRange(10, 120)]
     [int]$TimeoutMinutes = 50,
-    [ValidateRange(10, 90)]
-    [int]$RemoteBuildTimeoutMinutes = 45,
-    [ValidateRange(10, 60)]
-    [int]$ArtifactTransferTimeoutMinutes = 30,
     [ValidateRange(60, 300)]
     [int]$BakeTimeoutMinutes = 240,
     [ValidateRange(10, 90)]
@@ -62,7 +59,6 @@ Set-StrictMode -Version Latest
 $script:BuilderID = ""
 $script:BuilderName = ""
 $script:BuilderResourceID = ""
-$script:BuilderIP = ""
 $script:BuilderCreateAttempted = $false
 $script:KeyPairName = ""
 $script:KeyPairID = ""
@@ -367,40 +363,6 @@ function Wait-ForInstance {
         Start-Sleep -Seconds 8
     }
     throw "Timed out waiting for builder state: $($States -join ', ')"
-}
-
-function Wait-ForSsh {
-    param(
-        [Parameter(Mandatory = $true)][string]$IP,
-        [Parameter(Mandatory = $true)][string]$PrivateKey,
-        [Parameter(Mandatory = $true)][string]$KnownHosts
-    )
-
-    $deadline = Get-BoundedDeadline `
-        -RequestedSeconds (12 * 60) `
-        -Phase "temporary builder SSH wait"
-    while ((Get-Date) -lt $deadline) {
-        # Match the reported status text instead of the exit code of
-        # `cloud-init status --wait`: Tianyi's Ubuntu images finish
-        # cloud-init in a done state yet return exit code 2 (module error)
-        # from --wait, which would fail every SSH probe even though the system
-        # is fully usable. `cloud-init status` prints 'status: done' in that
-        # case, so grep on it; still requires SSH + root key auth to succeed.
-        & ssh `
-            -i $PrivateKey `
-            -o BatchMode=yes `
-            -o ConnectTimeout=6 `
-            -o ServerAliveInterval=15 `
-            -o ServerAliveCountMax=3 `
-            -o StrictHostKeyChecking=accept-new `
-            -o "UserKnownHostsFile=$KnownHosts" `
-            "root@$IP" "cloud-init status 2>/dev/null | grep -q '^status: done'" 2>$null
-        if ($LASTEXITCODE -eq 0) {
-            return
-        }
-        Start-Sleep -Seconds 8
-    }
-    throw "Timed out waiting for SSH on temporary builder"
 }
 
 function Get-Image {
@@ -994,7 +956,7 @@ if (-not (Get-Command "git" -ErrorAction SilentlyContinue)) {
     throw "Missing required command: git"
 }
 if ($Mode -in @("Create", "Cleanup")) {
-    foreach ($command in @("ctyun-cli", "ssh", "scp", "ssh-keygen", "timeout")) {
+    foreach ($command in @("ctyun-cli", "ssh-keygen", "timeout")) {
         if (-not (Get-Command $command -ErrorAction SilentlyContinue)) {
             throw "Missing required command: $command"
         }
@@ -1082,6 +1044,25 @@ if ($ArtifactPath) {
 } elseif ($ArtifactSha256) {
     throw "ArtifactSha256 cannot be used without ArtifactPath"
 }
+if ($Mode -eq "Create") {
+    $artifactUri = $null
+    if (
+        -not [Uri]::TryCreate($ArtifactUrl, [UriKind]::Absolute, [ref]$artifactUri) -or
+        $artifactUri.Scheme -ne "https"
+    ) {
+        throw "ArtifactUrl must be an absolute HTTPS URL in Create mode"
+    }
+    $prepareScriptUri = $null
+    if (
+        -not [Uri]::TryCreate($PrepareScriptUrl, [UriKind]::Absolute, [ref]$prepareScriptUri) -or
+        $prepareScriptUri.Scheme -ne "https"
+    ) {
+        throw "PrepareScriptUrl must be an absolute HTTPS URL in Create mode"
+    }
+    if ($PrepareScriptSha256 -notmatch "^[0-9a-fA-F]{64}$") {
+        throw "PrepareScriptSha256 must be a SHA-256 hex digest in Create mode"
+    }
+}
 
 $plan = [ordered]@{
     mode = $Mode
@@ -1101,6 +1082,7 @@ $plan = [ordered]@{
     securityGroupID = $SecurityGroupID
     bootDisk = "$BootDiskType $BootDiskSize GiB"
     artifactSource = $(if ($resolvedArtifactPath) { "local source-free CI artifact" } else { "not supplied in plan mode" })
+    builderNetwork = "private subnet with cloud-init artifact pull"
     mutatesExistingWorkers = $false
 }
 $plan | ConvertTo-Json
@@ -1162,8 +1144,6 @@ $script:TemporaryRoot = Join-Path ([IO.Path]::GetTempPath()) "catsco-image-$([gu
 New-Item -ItemType Directory -Path $script:TemporaryRoot | Out-Null
 $privateKey = Join-Path $script:TemporaryRoot "builder-rsa"
 $publicKeyPath = "$privateKey.pub"
-$knownHosts = Join-Path $script:TemporaryRoot "known_hosts"
-$remoteBuildScript = Join-Path $script:TemporaryRoot "build-image.sh"
 $primaryFailure = $null
 $cleanupFailure = $null
 $result = $null
@@ -1238,6 +1218,40 @@ try {
         throw "Temporary builder name is already in use: $script:BuilderName"
     }
 
+    $artifactUrlBase64 = [Convert]::ToBase64String(
+        [Text.Encoding]::UTF8.GetBytes($ArtifactUrl)
+    )
+    $prepareScriptUrlBase64 = [Convert]::ToBase64String(
+        [Text.Encoding]::UTF8.GetBytes($PrepareScriptUrl)
+    )
+    $artifactName = "catsco-worker-$releaseId-linux-x64.tar.gz"
+    $bootstrap = @"
+#!/usr/bin/env bash
+set -Eeuo pipefail
+exec > >(tee -a /var/log/catsco-image-build.log) 2>&1
+artifact_url="`$(printf '%s' '$artifactUrlBase64' | base64 -d)"
+prepare_script_url="`$(printf '%s' '$prepareScriptUrlBase64' | base64 -d)"
+curl --fail --silent --show-error --location --retry 8 --retry-all-errors \
+  "`$prepare_script_url" --output /tmp/prepare-image.sh
+printf '%s  %s\n' '$($PrepareScriptSha256.ToLowerInvariant())' /tmp/prepare-image.sh | sha256sum --check --strict
+chmod 700 /tmp/prepare-image.sh
+curl --fail --silent --show-error --location --retry 8 --retry-all-errors \
+  "`$artifact_url" --output '/tmp/$artifactName'
+bash /tmp/prepare-image.sh \
+  --artifact '/tmp/$artifactName' \
+  --sha256 '$ArtifactSha256' \
+  --version '$version' \
+  --commit '$commit'
+rm -f '/tmp/$artifactName'
+bash /tmp/prepare-image.sh --finalize
+sync
+shutdown -h now
+"@
+    $userData = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($bootstrap))
+    if ($userData.Length -gt 16384) {
+        throw "Generated builder userData exceeds Tianyi Cloud's 16384-character limit"
+    }
+
     $createResponse = Invoke-Ctyun @(
         "ecs", "CreateEcsInstance",
         "--regionID", $RegionID,
@@ -1256,12 +1270,9 @@ try {
         "--networkCardList", "[{`"isMaster`":true,`"subnetID`":`"$SubnetID`"}]",
         "--secGroupList", "[`"$SecurityGroupID`"]",
         "--keyPairID", $script:KeyPairID,
+        "--userData", $userData,
         "--onDemand", "true",
-        "--extIP", "1",
-        "--bandwidth", "$BuilderBandwidth",
-        "--ipVersion", "ipv4",
-        "--lineType", "standalone",
-        "--demandBillingType", "upflowc",
+        "--extIP", "0",
         "--monitorService", "false",
         "--securityProduct", "false",
         "--trustInstance", "false",
@@ -1284,84 +1295,9 @@ try {
     }
     Assert-TemporaryBuilder $builder
 
-    $builder = Wait-ForInstance -States @("running", "active") -RequireIP
-    $script:BuilderIP = [string]$builder.floatingIP
-    Wait-ForSsh -IP $script:BuilderIP -PrivateKey $privateKey -KnownHosts $knownHosts
-
-    $artifactName = "catsco-worker-$releaseId-linux-x64.tar.gz"
-    $remoteScriptContent = @"
-#!/usr/bin/env bash
-set -Eeuo pipefail
-ARTIFACT='/tmp/$artifactName'
-bash /tmp/prepare-image.sh \
-  --artifact "`$ARTIFACT" \
-  --sha256 '$ArtifactSha256' \
-  --version '$version' \
-  --commit '$commit'
-rm -f "`$ARTIFACT"
-bash /tmp/prepare-image.sh --finalize
-"@
-    [IO.File]::WriteAllText(
-        $remoteBuildScript,
-        $remoteScriptContent,
-        [Text.UTF8Encoding]::new($false)
-    )
-
-    $sshOptions = @(
-        "-i", $privateKey,
-        "-o", "BatchMode=yes",
-        "-o", "ConnectTimeout=10",
-        "-o", "ServerAliveInterval=15",
-        "-o", "ServerAliveCountMax=3",
-        "-o", "StrictHostKeyChecking=accept-new",
-        "-o", "UserKnownHostsFile=$knownHosts"
-    )
-    $artifactTransferTimeoutSeconds = Get-BoundedTimeoutSeconds `
-        -RequestedSeconds ($ArtifactTransferTimeoutMinutes * 60) `
-        -Phase "worker artifact transfer"
-    Invoke-External -Command "timeout" -Arguments (@(
-        "--signal=TERM",
-        "--kill-after=30s",
-        "$($artifactTransferTimeoutSeconds)s",
-        "scp"
-    ) + $sshOptions + @(
-        $resolvedArtifactPath,
-        "root@$($script:BuilderIP):/tmp/$artifactName"
-    ))
-    $scriptTransferTimeoutSeconds = Get-BoundedTimeoutSeconds `
-        -RequestedSeconds (5 * 60) `
-        -Phase "image preparation script transfer"
-    Invoke-External -Command "timeout" -Arguments (@(
-        "--signal=TERM",
-        "--kill-after=30s",
-        "$($scriptTransferTimeoutSeconds)s",
-        "scp"
-    ) + $sshOptions + @(
-        "$PSScriptRoot/prepare-image.sh",
-        $remoteBuildScript,
-        "root@$($script:BuilderIP):/tmp/"
-    ))
-    $remoteBuildTimeoutSeconds = Get-BoundedTimeoutSeconds `
-        -RequestedSeconds (($RemoteBuildTimeoutMinutes + 3) * 60) `
-        -Phase "remote image preparation"
-    Invoke-External -Command "timeout" -Arguments (@(
-        "--signal=TERM",
-        "--kill-after=150s",
-        "$($remoteBuildTimeoutSeconds)s",
-        "ssh"
-    ) + $sshOptions + @(
-        "root@$($script:BuilderIP)",
-        "chmod 700 /tmp/build-image.sh /tmp/prepare-image.sh && timeout --signal=TERM --kill-after=120s $($RemoteBuildTimeoutMinutes)m bash /tmp/build-image.sh"
-    ))
-
-    $builder = Resolve-BuilderInstance
-    Assert-TemporaryBuilder $builder
-    Invoke-Ctyun @(
-        "ecs", "StopEcsInstance",
-        "--regionID", $RegionID,
-        "--instanceID", $script:BuilderID,
-        "--force", "false"
-    ) | Out-Null
+    # cloud-init powers off only after artifact verification, preparation and
+    # finalization all succeed. A failed bootstrap stays running, times out,
+    # and is removed by the existing compensating cleanup path.
     Wait-ForInstance -States @("stopped", "shutoff") | Out-Null
 
     $script:ImageCreateAttempted = $true

--- a/ops/ctyun-worker-image/README.md
+++ b/ops/ctyun-worker-image/README.md
@@ -10,9 +10,11 @@ session, skill installation, or runtime `.env`.
 - Only stable `vX.Y.Z` tags whose commit is contained in `main` may bake an
   image automatically. Manual runs are restricted to `main` and default to
   not baking until the operator explicitly checks the input.
-- The source-free worker artifact stays on the GitHub runner and is copied
-  directly to the disposable builder over SSH. It is never uploaded to TOS,
-  a public release bucket, or a GitHub Actions artifact.
+- The source-free worker artifact and pinned preparation script are staged as
+  private, per-run TOS objects with short-lived signed URLs. The private
+  builder downloads them through cloud-init, and the workflow deletes both
+  objects after the bake. They are never public or retained as GitHub Actions
+  artifacts.
 - A Tianyi Cloud private ECS image is baked only for a stable release selected
   for provisioning, or when the base OS/system dependencies change.
 - `CTYUN_AUTO_BAKE_WORKER_IMAGE=true` makes every stable tag bake an image;
@@ -88,8 +90,9 @@ after the worker has claimed its bot identity.
 ## Local Bake
 
 `New-CatsCoWorkerImage.ps1` defaults to plan mode. Execute mode creates a new
-temporary on-demand ECS named `catsco-img-*`, copies in a checked source-free
-artifact, stops that temporary instance, and creates a uniquely named
+temporary on-demand ECS named `catsco-img-*` without a public IP. Cloud-init
+downloads the checked source-free artifact through a short-lived private URL,
+prepares the system, powers the builder off, and creates a uniquely named
 `catsco-bake-*` image. After the image is active and its source builder has been
 verified, the script publishes it under the stable `catsco-worker-*` name with
 a pending bake marker, deletes the builder and its temporary key pair, and only
@@ -116,12 +119,14 @@ pwsh ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1 `
   -SecurityGroupID '<security-group-id>'
 ```
 
-Run the same command with `-Mode Create`, `-ArtifactPath`, and
-`-ArtifactSha256` only after reviewing the plan. The machine running it needs
-`ctyun-cli`, Git, OpenSSH, SCP, `ssh-keygen`, and GNU `timeout`.
+Run the same command with `-Mode Create`, `-ArtifactPath`,
+`-ArtifactSha256`, `-ArtifactUrl`, `-PrepareScriptUrl`, and
+`-PrepareScriptSha256` only after reviewing the plan. Both URLs must be HTTPS
+and remain valid until cloud-init downloads the inputs. The
+machine running it needs `ctyun-cli`, Git, `ssh-keygen`, and GNU `timeout`.
 
-The builder verifies the artifact checksum again before extracting it. Remote
-transfer, preparation, and every Tianyi Cloud API call have hard timeouts. The
+The builder verifies the artifact checksum again before extracting it. Builder
+preparation and every Tianyi Cloud API call have hard timeouts. The
 whole bake also has a deadline separate from its cleanup deadline, while the
 GitHub job keeps additional time in reserve for compensating cleanup. The script resolves a newly
 ordered instance by both the order resource ID and its exact temporary name,

--- a/tests/worker-image-pipeline.test.ts
+++ b/tests/worker-image-pipeline.test.ts
@@ -536,32 +536,21 @@ describe("Tianyi Cloud worker image pipeline", () => {
     );
   });
 
-  test("remote transfer and image preparation cannot run indefinitely", () => {
-    assert.match(imageOrchestrator, /ArtifactTransferTimeoutMinutes/);
-    assert.match(imageOrchestrator, /RemoteBuildTimeoutMinutes/);
+  test("private builder bootstrap is bounded and does not require inbound SSH", () => {
     assert.match(imageOrchestrator, /ApiTimeoutSeconds/);
     assert.match(
       imageOrchestrator,
       /"timeout"[\s\S]*?"ctyun-cli"/,
     );
-    assert.match(imageOrchestrator, /ServerAliveInterval=15/);
-    assert.match(imageOrchestrator, /--kill-after=120s/);
-    // Wait-ForSsh must probe via the reported status text, not the exit code
-    // of `cloud-init status --wait` (Tianyi Ubuntu images return exit code 2
-    // from --wait even when status is done).
-    assert.match(
-      imageOrchestrator,
-      /cloud-init status 2>\/dev\/null \| grep -q '\^status: done'/,
-    );
-    // The probe must not invoke `cloud-init status --wait` as the remote
-    // command (only the explanatory comment may mention it).
-    assert.doesNotMatch(
-      imageOrchestrator,
-      /"root@\$IP"[^"]*cloud-init status --wait/,
-    );
+    assert.match(imageOrchestrator, /"--extIP", "0"/);
+    assert.match(imageOrchestrator, /"--userData", \$userData/);
+    assert.match(imageOrchestrator, /userData exceeds Tianyi Cloud's 16384-character limit/);
+    assert.match(imageOrchestrator, /curl --fail --silent --show-error/);
+    assert.match(imageOrchestrator, /shutdown -h now/);
+    assert.doesNotMatch(imageOrchestrator, /Wait-ForSsh|\bscp\b|"--extIP", "1"/);
   });
 
-  test("workflow is restricted, secret-scoped, and never publishes the artifact", () => {
+  test("workflow is restricted and stages only a temporary private artifact", () => {
     assert.match(workflow, /\^v\[0-9\]\+\\\.\[0-9\]\+\\\.\[0-9\]\+\$/);
     assert.match(workflow, /github\.ref == 'refs\/heads\/main'/);
     assert.match(workflow, /default: false/);
@@ -576,6 +565,9 @@ describe("Tianyi Cloud worker image pipeline", () => {
       /WORKER_ARTIFACT_PATH: \$\{\{ steps\.artifact_meta\.outputs\.path \}\}/,
     );
     assert.match(workflow, /-ArtifactPath \$env:WORKER_ARTIFACT_PATH/);
+    assert.match(workflow, /-ArtifactUrl \$env:WORKER_ARTIFACT_URL/);
+    assert.match(workflow, /-PrepareScriptUrl \$env:WORKER_PREPARE_SCRIPT_URL/);
+    assert.match(workflow, /-PrepareScriptSha256 \$env:WORKER_PREPARE_SCRIPT_SHA256/);
     assert.match(workflow, /-BuildNumber \$env:GITHUB_RUN_NUMBER/);
     assert.match(workflow, /-BuildIdentity \$env:GITHUB_RUN_ID/);
     assert.match(workflow, /timeout-minutes: 360/);
@@ -603,10 +595,12 @@ describe("Tianyi Cloud worker image pipeline", () => {
       workflow,
       /steps\.prior_runs\.outputs\.runs[\s\S]*INTERRUPTED_RUNS_JSON/,
     );
-    assert.doesNotMatch(
-      workflow,
-      /TOS_|aws s3|presign|upload-artifact|public-read/,
-    );
+    assert.match(workflow, /Stage private artifact for the builder/);
+    assert.match(workflow, /aws s3 presign/);
+    assert.match(workflow, /--acl private/);
+    assert.match(workflow, /Remove staged private artifact/);
+    assert.match(workflow, /aws s3 rm/);
+    assert.doesNotMatch(workflow, /public-read|upload-artifact/);
     assert.doesNotMatch(workflow, /^    env:\s*\n\s+CTYUN_AK:/m);
     assert.match(
       workflow,
@@ -704,6 +698,10 @@ if (operation === "ims ListImage") {
 } else if (operation === "ecs CreateEcsInstance") {
   state.instanceExists = true;
   state.instanceName = value("--instanceName");
+  state.instanceStatus = "stopped";
+  state.createExtIP = value("--extIP");
+  state.createUserData = value("--userData");
+  state.createHadBandwidth = args.includes("--bandwidth");
   returnObj = { masterResourceID: "resource-1" };
 } else if (operation === "ecs ListEcsInstances") {
   if (state.listInstancesFailures > 0) {
@@ -747,8 +745,6 @@ if (operation === "ims ListImage") {
         }]
       : [],
   };
-} else if (operation === "ecs StopEcsInstance") {
-  state.instanceStatus = "stopped";
 } else if (operation === "ims CreateImage") {
   state.imageExists = true;
   state.imageName = value("--imageName");
@@ -839,28 +835,6 @@ fs.writeFileSync(output + ".pub", "ssh-rsa AAAA catsco-test");
       );
       writeCommand(
         sandbox,
-        "ssh",
-        `
-import fs from "node:fs";
-const args = process.argv.slice(2);
-const probeFile = process.env.FAKE_SSH_PROBE;
-if (probeFile && args.includes("cloud-init")) {
-  // Simulate Tianyi Ubuntu images where 'cloud-init status --wait' returns
-  // exit 2 (module error) while the system is usable; Wait-ForSsh must probe
-  // via 'cloud-init status | grep done' and succeed on the last read.
-  let n = 0;
-  try { n = Number(fs.readFileSync(probeFile, "utf8") || "0"); } catch {}
-  if (n > 0) {
-    fs.writeFileSync(probeFile, String(n - 1));
-    process.exit(2);
-  }
-}
-process.exit(0);
-`,
-      );
-      writeCommand(sandbox, "scp", "process.exit(0);");
-      writeCommand(
-        sandbox,
         "timeout",
         `
 import { spawnSync } from "node:child_process";
@@ -899,6 +873,12 @@ process.exit(result.status ?? 1);
             artifactPath,
             "-ArtifactSha256",
             artifactSha,
+            "-ArtifactUrl",
+            "https://example.test/private-worker?signature=test",
+            "-PrepareScriptUrl",
+            "https://example.test/prepare-image.sh?signature=test",
+            "-PrepareScriptSha256",
+            crypto.createHash("sha256").update("prepare-image").digest("hex"),
             "-BuildNumber",
             buildNumber,
             "-BuildAttempt",
@@ -934,9 +914,6 @@ process.exit(result.status ?? 1);
               FAKE_CTYUN_STATE: statePath,
               FAKE_CTYUN_LOG: logPath,
               FAKE_CTYUN_SCENARIO: scenario,
-              // Optional SSH cloud-init probe failure counter (absent file =
-              // no failures). Scenarios write an initial count to it.
-              FAKE_SSH_PROBE: path.join(sandbox, "ssh-probe"),
             },
           },
         );
@@ -1021,6 +998,17 @@ process.exit(result.status ?? 1);
       assert.equal(finalState.imageExists, false);
       assert.equal(finalState.instanceName, "catsco-img-000999-01");
       assert.equal(finalState.instanceStatus, "stopped");
+      assert.equal(finalState.createExtIP, "0");
+      assert.equal(finalState.createHadBandwidth, false);
+      assert.ok(finalState.createUserData.length <= 16384);
+      const bootstrap = Buffer.from(finalState.createUserData, "base64").toString("utf8");
+      assert.match(bootstrap, /curl --fail --silent --show-error/);
+      assert.match(bootstrap, /shutdown -h now/);
+      assert.match(bootstrap, new RegExp(artifactSha));
+      assert.match(bootstrap, /sha256sum --check --strict/);
+      assert.doesNotMatch(bootstrap, /example\.test\/private-worker/);
+      assert.doesNotMatch(bootstrap, /example\.test\/prepare-image/);
+      assert.doesNotMatch(bootstrap, /\bscp\b|\bssh\b/);
       assert.equal(finalState.imageSourceServerID, "instance-1");
       assert.match(
         finalState.imageName,
@@ -1739,43 +1727,6 @@ process.exit(result.status ?? 1);
       // bake path, just like the instance and key pair.
       assert.equal(notSupportState.imageExists, false);
 
-      // Tianyi Ubuntu images finish cloud-init in a 'done' state but
-      // 'cloud-init status --wait' returns exit code 2 (module error), which
-      // used to fail every Wait-ForSsh probe and time out the bake. Wait-ForSsh
-      // now greps the reported status text instead, so the bake proceeds as
-      // soon as SSH + root key auth work.
-      fs.writeFileSync(path.join(sandbox, "ssh-probe"), "2");
-      fs.writeFileSync(logPath, "");
-      fs.writeFileSync(
-        statePath,
-        JSON.stringify({
-          instanceExists: false,
-          keyExists: false,
-          keyPairName: "",
-          imageExists: false,
-          imageName: "",
-          imageDescription: "",
-          imageSourceServerID: "",
-          imageStatus: "error",
-          instanceName: "",
-          instanceStatus: "running",
-        }),
-      );
-      const sshProbeResult = runBake(
-        "1018",
-        "catsco-worker-sshprobe",
-        "success",
-      );
-      assert.equal(
-        sshProbeResult.status,
-        0,
-        `${sshProbeResult.stdout}\n${sshProbeResult.stderr}`,
-      );
-      assert.match(sshProbeResult.stdout, /"result":\s*"created"/);
-      const sshProbeState = JSON.parse(fs.readFileSync(statePath, "utf8"));
-      assert.equal(sshProbeState.imageExists, true);
-      assert.equal(sshProbeState.instanceExists, false);
-      assert.equal(sshProbeState.keyExists, false);
     } finally {
       fs.rmSync(sandbox, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

- create temporary bake builders with `extIP=0` in the private subnet
- use cloud-init to download a pinned preparation script and the checked artifact through short-lived private TOS URLs
- power off the builder only after checksum verification, preparation, and finalization succeed
- delete both staged TOS objects in an always-run cleanup step
- preserve strict builder/image/key-pair ownership and compensating cleanup

## Why

The v1.4.9 artifact workflow succeeded, but the image bake failed at ECS creation with `Ecs.Order.ProcFailed` because the Huainan 2 public IP quota was exhausted. The builder did not reach `CreateImage`.

## Verification

- `node --import tsx --test tests/worker-image-pipeline.test.ts` (11/11)
- PowerShell parse check
- workflow YAML parse check
- `git diff --check`

No production bake was started by this PR.
