### PR TITLE
fix(cache): shard prompt cache by virtual employee

### DIFF
--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -4,6 +4,7 @@ import type { TargetRoutes } from '../types/tool';
 import { AIService } from '../utils/ai-service';
 import { ToolCall, ToolDefinition, ToolExecutionContext, ToolExecutor, ToolResult, ToolTranscriptMode } from '../types/tool';
 import { AIRequestOptions, StreamCallbacks, StreamRetryInfo } from '../providers/provider';
+import { buildPromptCacheScopeKey } from '../providers/prompt-cache-scope';
 import { Logger } from '../utils/logger';
 import { isRateLimitErrorCode } from '../utils/rate-limit-error';
 import { Metrics } from '../utils/metrics';
@@ -1495,6 +1496,10 @@ export class ConversationRunner {
       } : {}),
       promptCacheContext: {
         sessionKey: this.toolExecutionContext?.sessionId || 'unknown',
+        cacheScopeKey: buildPromptCacheScopeKey(
+          this.toolExecutionContext?.sessionId,
+          this.toolExecutionContext?.executionScope,
+        ),
         ...(this.episodeId ? { currentEpisodeId: this.episodeId } : {}),
         phase: 'normal' as const,
         explicitCaching: true,

--- a/src/providers/openai-provider.ts
+++ b/src/providers/openai-provider.ts
@@ -531,7 +531,7 @@ export class OpenAIProvider implements AIProvider {
       prompt_cache_key: this.buildPromptCacheKey(
         instructions,
         responseTools,
-        options?.promptCacheContext?.sessionKey,
+        options?.promptCacheContext?.cacheScopeKey || options?.promptCacheContext?.sessionKey,
       ),
     };
 
@@ -753,12 +753,12 @@ export class OpenAIProvider implements AIProvider {
     ].includes(String(item.type || '')));
   }
 
-  private buildPromptCacheKey(instructions: string, tools: any[], sessionKey?: string): string {
+  private buildPromptCacheKey(instructions: string, tools: any[], cacheScopeKey?: string): string {
     const digest = createHash('sha256')
       .update(JSON.stringify({
         identityVersion: 'responses-cache-v3',
         model: this.model,
-        session: createHash('sha256').update(sessionKey || 'unscoped').digest('hex').slice(0, 24),
+        scope: createHash('sha256').update(cacheScopeKey || 'unscoped').digest('hex').slice(0, 24),
         instructions,
         tools,
       }))

--- a/src/providers/prompt-cache-scope.ts
+++ b/src/providers/prompt-cache-scope.ts
@@ -1,0 +1,24 @@
+import { createHash } from 'crypto';
+import type { ExecutionScope } from '../types/session-identity';
+
+export const PROMPT_CACHE_SHARD_COUNT = 8;
+
+function normalize(value: unknown): string {
+  return String(value || '').trim().toLowerCase();
+}
+
+function shortHash(value: string): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, 16);
+}
+
+/** Stable virtual-employee identity with bounded per-user shards. */
+export function buildPromptCacheScopeKey(
+  sessionKey: string | undefined,
+  scope?: Pick<ExecutionScope, 'agentId' | 'agentBodyId' | 'actorUserId'>,
+): string {
+  const employee = normalize(scope?.agentId) || normalize(scope?.agentBodyId);
+  if (!employee) return `session:${shortHash(normalize(sessionKey) || 'unscoped')}`;
+  const actor = normalize(scope?.actorUserId) || 'unknown-actor';
+  const shard = Number.parseInt(shortHash(actor).slice(0, 8), 16) % PROMPT_CACHE_SHARD_COUNT;
+  return `employee:${shortHash(employee)}:shard:${shard}`;
+}

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -103,6 +103,7 @@ export interface AIRequestOptions {
 
 export interface PromptCacheContext {
   sessionKey: string;
+  cacheScopeKey?: string;
   currentEpisodeId?: string;
   phase: 'normal' | 'pre_turn' | 'mid_turn' | 'restore';
   explicitCaching: boolean;

--- a/tests/openai-provider-explicit-cache.test.ts
+++ b/tests/openai-provider-explicit-cache.test.ts
@@ -130,6 +130,22 @@ test('Responses cache key is isolated by session without exposing the session id
   assert.doesNotMatch(first.prompt_cache_key, /session-alpha/);
 });
 
+test('Responses cache scope can be shared while relay affinity remains session-specific', () => {
+  const messages: Message[] = [{ role: 'system', content: 'stable' }, { role: 'user', content: 'hello' }];
+  const firstContext = {
+    promptCacheContext: { ...context.promptCacheContext, cacheScopeKey: 'employee:42:shard:3' },
+  };
+  const secondContext = {
+    promptCacheContext: { ...context.promptCacheContext, sessionKey: 'session-beta', cacheScopeKey: 'employee:42:shard:3' },
+  };
+  const first = (provider() as any).buildResponsesRequestBody(messages, [], false, firstContext);
+  const second = (provider() as any).buildResponsesRequestBody(messages, [], false, secondContext);
+  assert.equal(first.prompt_cache_key, second.prompt_cache_key);
+  const firstHeaders = (provider() as any).responsesHeaders(firstContext);
+  const secondHeaders = (provider() as any).responsesHeaders(secondContext);
+  assert.notEqual(firstHeaders.session_id, secondHeaders.session_id);
+});
+
 test('Responses relay uses Pi-style stable session affinity headers without exposing the session id', () => {
   const original = process.env.XIAOBA_RESPONSES_SESSION_AFFINITY;
   delete process.env.XIAOBA_RESPONSES_SESSION_AFFINITY;

--- a/tests/prompt-cache-scope.test.ts
+++ b/tests/prompt-cache-scope.test.ts
@@ -1,0 +1,30 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildPromptCacheScopeKey, PROMPT_CACHE_SHARD_COUNT } from '../src/providers/prompt-cache-scope';
+
+test('prompt cache scope is stable for an employee and bounded by user shards', () => {
+  const first = buildPromptCacheScopeKey('session:one', {
+    agentId: 'employee-42',
+    actorUserId: 'user-a',
+  });
+  const same = buildPromptCacheScopeKey('session:two', {
+    agentId: 'employee-42',
+    actorUserId: 'user-a',
+  });
+  assert.equal(first, same);
+  assert.match(first, /^employee:[a-f0-9]{16}:shard:[0-7]$/);
+  assert.equal(PROMPT_CACHE_SHARD_COUNT, 8);
+});
+
+test('different employees do not share a prompt cache scope', () => {
+  const first = buildPromptCacheScopeKey('session:one', { agentId: 'employee-42', actorUserId: 'user-a' });
+  const second = buildPromptCacheScopeKey('session:two', { agentId: 'employee-43', actorUserId: 'user-a' });
+  assert.notEqual(first, second);
+});
+
+test('legacy sessions remain isolated when no employee identity exists', () => {
+  const first = buildPromptCacheScopeKey('session:one');
+  const second = buildPromptCacheScopeKey('session:two');
+  assert.notEqual(first, second);
+  assert.match(first, /^session:[a-f0-9]{16}$/);
+});


### PR DESCRIPTION
## Summary\n- keep per-conversation Relay session affinity\n- derive stable prompt cache scope from virtual employee identity\n- bound busy employee traffic to 8 user-derived cache shards\n- preserve scope for sub-agents through inherited execution scope\n\n## Verification\n- npm run build\n- 59 targeted Responses/cache tests pass\n\nProduction rollout should use the existing worker artifact workflow with its automatic rollback and post-deploy health checks.