### PR TITLE
fix(worker-image): separate builder and image projects

### DIFF
--- a/.github/workflows/worker-image.yml
+++ b/.github/workflows/worker-image.yml
@@ -220,6 +220,7 @@ jobs:
           INTERRUPTED_RUNS_JSON: ${{ steps.prior_runs.outputs.runs }}
           WORKER_REGION_ID: ${{ vars.CTYUN_WORKER_REGION_ID }}
           WORKER_PROJECT_ID: ${{ vars.CTYUN_WORKER_PROJECT_ID }}
+          WORKER_IMAGE_PROJECT_ID: ${{ vars.CTYUN_IMAGE_PROJECT_ID || '0' }}
           WORKER_AZ_NAME: ${{ vars.CTYUN_WORKER_AZ_NAME }}
           WORKER_BASE_IMAGE_ID: ${{ vars.CTYUN_WORKER_BASE_IMAGE_ID }}
           WORKER_FLAVOR_ID: ${{ vars.CTYUN_WORKER_FLAVOR_ID }}
@@ -230,6 +231,9 @@ jobs:
           $runs = @($env:INTERRUPTED_RUNS_JSON | ConvertFrom-Json)
           if ([string]::IsNullOrWhiteSpace($env:WORKER_PROJECT_ID)) {
             throw 'CTYUN_WORKER_PROJECT_ID is required for interrupted image cleanup'
+          }
+          if ([string]::IsNullOrWhiteSpace($env:WORKER_IMAGE_PROJECT_ID)) {
+            throw 'CTYUN_IMAGE_PROJECT_ID is required for interrupted image cleanup'
           }
           $recentRuns = [Collections.Generic.List[object]]::new()
           $historicalRuns = [Collections.Generic.List[object]]::new()
@@ -268,7 +272,8 @@ jobs:
               '-CleanupTimeoutMinutes', [string]$cleanupTimeoutMinutes,
               '-ApiTimeoutSeconds', [string]$apiTimeoutSeconds,
               '-RegionID', $env:WORKER_REGION_ID,
-              '-ProjectID', $env:WORKER_PROJECT_ID,
+              '-BuilderProjectID', $env:WORKER_PROJECT_ID,
+              '-ImageProjectID', $env:WORKER_IMAGE_PROJECT_ID,
               '-AzName', $env:WORKER_AZ_NAME,
               '-BaseImageID', $env:WORKER_BASE_IMAGE_ID,
               '-FlavorID', $env:WORKER_FLAVOR_ID,
@@ -356,6 +361,7 @@ jobs:
           CTYUN_SK: ${{ secrets.CTYUN_SK }}
           WORKER_REGION_ID: ${{ vars.CTYUN_WORKER_REGION_ID }}
           WORKER_PROJECT_ID: ${{ vars.CTYUN_WORKER_PROJECT_ID }}
+          WORKER_IMAGE_PROJECT_ID: ${{ vars.CTYUN_IMAGE_PROJECT_ID || '0' }}
           WORKER_AZ_NAME: ${{ vars.CTYUN_WORKER_AZ_NAME }}
           WORKER_BASE_IMAGE_ID: ${{ vars.CTYUN_WORKER_BASE_IMAGE_ID }}
           WORKER_FLAVOR_ID: ${{ vars.CTYUN_WORKER_FLAVOR_ID }}
@@ -366,6 +372,9 @@ jobs:
           $currentAttempt = [int]$env:GITHUB_RUN_ATTEMPT
           if ([string]::IsNullOrWhiteSpace($env:WORKER_PROJECT_ID)) {
             throw 'CTYUN_WORKER_PROJECT_ID is required for rerun cleanup'
+          }
+          if ([string]::IsNullOrWhiteSpace($env:WORKER_IMAGE_PROJECT_ID)) {
+            throw 'CTYUN_IMAGE_PROJECT_ID is required for rerun cleanup'
           }
           $rerunDeadline = [DateTimeOffset]::UtcNow.AddMinutes(45)
           $rerunFailures = [Collections.Generic.List[string]]::new()
@@ -390,7 +399,8 @@ jobs:
               '-CleanupTimeoutMinutes', '15',
               '-ApiTimeoutSeconds', '90',
               '-RegionID', $env:WORKER_REGION_ID,
-              '-ProjectID', $env:WORKER_PROJECT_ID,
+              '-BuilderProjectID', $env:WORKER_PROJECT_ID,
+              '-ImageProjectID', $env:WORKER_IMAGE_PROJECT_ID,
               '-AzName', $env:WORKER_AZ_NAME,
               '-BaseImageID', $env:WORKER_BASE_IMAGE_ID,
               '-FlavorID', $env:WORKER_FLAVOR_ID,
@@ -422,6 +432,7 @@ jobs:
           CTYUN_SK: ${{ secrets.CTYUN_SK }}
           WORKER_REGION_ID: ${{ vars.CTYUN_WORKER_REGION_ID }}
           WORKER_PROJECT_ID: ${{ vars.CTYUN_WORKER_PROJECT_ID }}
+          WORKER_IMAGE_PROJECT_ID: ${{ vars.CTYUN_IMAGE_PROJECT_ID || '0' }}
           WORKER_AZ_NAME: ${{ vars.CTYUN_WORKER_AZ_NAME }}
           WORKER_BASE_IMAGE_ID: ${{ vars.CTYUN_WORKER_BASE_IMAGE_ID }}
           WORKER_FLAVOR_ID: ${{ vars.CTYUN_WORKER_FLAVOR_ID }}
@@ -436,6 +447,9 @@ jobs:
         run: |
           if ([string]::IsNullOrWhiteSpace($env:WORKER_PROJECT_ID)) {
             throw 'CTYUN_WORKER_PROJECT_ID is required for image bake'
+          }
+          if ([string]::IsNullOrWhiteSpace($env:WORKER_IMAGE_PROJECT_ID)) {
+            throw 'CTYUN_IMAGE_PROJECT_ID is required for image bake'
           }
           ./ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1 `
             -Mode Create `
@@ -452,7 +466,8 @@ jobs:
             -CleanupTimeoutMinutes 40 `
             -ApiTimeoutSeconds 90 `
             -RegionID $env:WORKER_REGION_ID `
-            -ProjectID $env:WORKER_PROJECT_ID `
+            -BuilderProjectID $env:WORKER_PROJECT_ID `
+            -ImageProjectID $env:WORKER_IMAGE_PROJECT_ID `
             -AzName $env:WORKER_AZ_NAME `
             -BaseImageID $env:WORKER_BASE_IMAGE_ID `
             -FlavorID $env:WORKER_FLAVOR_ID `
@@ -480,14 +495,14 @@ jobs:
           CTYUN_AK: ${{ secrets.CTYUN_AK }}
           CTYUN_SK: ${{ secrets.CTYUN_SK }}
           WORKER_REGION_ID: ${{ vars.CTYUN_WORKER_REGION_ID }}
-          WORKER_PROJECT_ID: ${{ vars.CTYUN_WORKER_PROJECT_ID }}
+          WORKER_IMAGE_PROJECT_ID: ${{ vars.CTYUN_IMAGE_PROJECT_ID || '0' }}
           WORKER_PROTECTED_IMAGE_IDS: ${{ vars.CTYUN_WORKER_PROTECTED_IMAGE_IDS }}
         run: |
           ./ops/ctyun-worker-image/Manage-WorkerImages.ps1 `
             -Action Prune `
             -Keep 6 `
             -RegionID $env:WORKER_REGION_ID `
-            -ProjectID $env:WORKER_PROJECT_ID `
+            -ProjectID $env:WORKER_IMAGE_PROJECT_ID `
             -ProtectedImageIDs $env:WORKER_PROTECTED_IMAGE_IDS
 
       - name: Reconcile this attempt after a failed bake
@@ -499,6 +514,7 @@ jobs:
           CTYUN_SK: ${{ secrets.CTYUN_SK }}
           WORKER_REGION_ID: ${{ vars.CTYUN_WORKER_REGION_ID }}
           WORKER_PROJECT_ID: ${{ vars.CTYUN_WORKER_PROJECT_ID }}
+          WORKER_IMAGE_PROJECT_ID: ${{ vars.CTYUN_IMAGE_PROJECT_ID || '0' }}
           WORKER_AZ_NAME: ${{ vars.CTYUN_WORKER_AZ_NAME }}
           WORKER_BASE_IMAGE_ID: ${{ vars.CTYUN_WORKER_BASE_IMAGE_ID }}
           WORKER_FLAVOR_ID: ${{ vars.CTYUN_WORKER_FLAVOR_ID }}
@@ -508,6 +524,9 @@ jobs:
         run: |
           if ([string]::IsNullOrWhiteSpace($env:WORKER_PROJECT_ID)) {
             throw 'CTYUN_WORKER_PROJECT_ID is required for failed-bake cleanup'
+          }
+          if ([string]::IsNullOrWhiteSpace($env:WORKER_IMAGE_PROJECT_ID)) {
+            throw 'CTYUN_IMAGE_PROJECT_ID is required for failed-bake cleanup'
           }
           ./ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1 `
             -Mode Cleanup `
@@ -520,7 +539,8 @@ jobs:
             -ApiTimeoutSeconds 90 `
             -WaitForLateResources `
             -RegionID $env:WORKER_REGION_ID `
-            -ProjectID $env:WORKER_PROJECT_ID `
+            -BuilderProjectID $env:WORKER_PROJECT_ID `
+            -ImageProjectID $env:WORKER_IMAGE_PROJECT_ID `
             -AzName $env:WORKER_AZ_NAME `
             -BaseImageID $env:WORKER_BASE_IMAGE_ID `
             -FlavorID $env:WORKER_FLAVOR_ID `

--- a/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
+++ b/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
@@ -24,7 +24,9 @@ param(
     [Parameter(Mandatory = $true)]
     [string]$SecurityGroupID,
 
-    [string]$ProjectID = "0",
+    [Alias("ProjectID")]
+    [string]$BuilderProjectID = "0",
+    [string]$ImageProjectID = "0",
     [string]$SourceRef = "HEAD",
     [string]$ImageName = "",
     [string]$ArtifactPath = "",
@@ -393,7 +395,7 @@ function Find-ImageByName {
         "--regionID", $RegionID,
         "--imageVisibilityCode", "0",
         "--imageName", $Name,
-        "--projectID", $ProjectID,
+        "--projectID", $ImageProjectID,
         "--pageNo", "1",
         "--pageSize", "200"
     )
@@ -623,7 +625,7 @@ function Remove-KeyPair {
         $details = Invoke-Ctyun @(
             "ecs", "GetEcsKeypairDetails",
             "--regionID", $RegionID,
-            "--projectID", $ProjectID,
+            "--projectID", $BuilderProjectID,
             "--keyPairName", $script:KeyPairName,
             "--pageNo", "1",
             "--pageSize", "10"
@@ -681,7 +683,7 @@ function Remove-KeyPair {
         $details = Invoke-Ctyun @(
             "ecs", "GetEcsKeypairDetails",
             "--regionID", $RegionID,
-            "--projectID", $ProjectID,
+            "--projectID", $BuilderProjectID,
             "--keyPairName", $script:KeyPairName,
             "--pageNo", "1",
             "--pageSize", "10"
@@ -896,7 +898,7 @@ function Invoke-ExactBakeCleanup {
                 $keyDetails = Invoke-Ctyun @(
                     "ecs", "GetEcsKeypairDetails",
                     "--regionID", $RegionID,
-                    "--projectID", $ProjectID,
+                    "--projectID", $BuilderProjectID,
                     "--keyPairName", $script:KeyPairName,
                     "--pageNo", "1",
                     "--pageSize", "10"
@@ -1073,6 +1075,8 @@ $plan = [ordered]@{
     temporaryImageName = $script:ImageWorkName
     bakeID = $script:BakeID
     builderName = $script:BuilderName
+    builderProjectID = $BuilderProjectID
+    imageProjectID = $ImageProjectID
     regionID = $RegionID
     azName = $AzName
     baseImageID = $BaseImageID
@@ -1159,7 +1163,7 @@ try {
     $existingKeyPairResponse = Invoke-Ctyun @(
         "ecs", "GetEcsKeypairDetails",
         "--regionID", $RegionID,
-        "--projectID", $ProjectID,
+        "--projectID", $BuilderProjectID,
         "--keyPairName", $script:KeyPairName,
         "--pageNo", "1",
         "--pageSize", "10"
@@ -1175,7 +1179,7 @@ try {
     Invoke-Ctyun @(
         "ecs", "ImportEcsKeypair",
         "--regionID", $RegionID,
-        "--projectID", $ProjectID,
+        "--projectID", $BuilderProjectID,
         "--keyPairName", $script:KeyPairName,
         "--keyPairDescription", "Temporary CatsCo image builder",
         "--publicKey", $publicKey
@@ -1188,7 +1192,7 @@ try {
     $keyPairResponse = Invoke-Ctyun @(
         "ecs", "GetEcsKeypairDetails",
         "--regionID", $RegionID,
-        "--projectID", $ProjectID,
+        "--projectID", $BuilderProjectID,
         "--keyPairName", $script:KeyPairName,
         "--pageNo", "1",
         "--pageSize", "10"
@@ -1276,7 +1280,7 @@ runcmd:
     $createResponse = Invoke-Ctyun @(
         "ecs", "CreateEcsInstance",
         "--regionID", $RegionID,
-        "--projectID", $ProjectID,
+        "--projectID", $BuilderProjectID,
         "--clientToken", ([guid]::NewGuid().ToString()),
         "--azName", $AzName,
         "--displayName", $script:BuilderName,
@@ -1325,7 +1329,7 @@ runcmd:
     $imageResponse = Invoke-Ctyun @(
         "ims", "CreateImage",
         "--regionID", $RegionID,
-        "--projectID", $ProjectID,
+        "--projectID", $ImageProjectID,
         "--instanceID", $script:BuilderID,
         "--imageName", $script:ImageWorkName,
         "--description", $bakeDescription,

--- a/ops/ctyun-worker-image/README.md
+++ b/ops/ctyun-worker-image/README.md
@@ -125,11 +125,13 @@ Run the same command with `-Mode Create`, `-ArtifactPath`,
 and remain valid until cloud-init downloads the inputs. The
 machine running it needs `ctyun-cli`, Git, `ssh-keygen`, and GNU `timeout`.
 
-The bake must use the same Tianyi enterprise project as the virtual-worker
-network/NAT resources. Set `CTYUN_WORKER_PROJECT_ID` in the protected release
-environment and pass it as `-ProjectID`; do not use a virtual-worker/bot ID as
-the project ID. Builders intentionally use `-extIP 0` and rely on the selected
-private subnet's NAT gateway for HTTPS downloads.
+The builder project and private-image project are explicit, independent
+inputs. Set `CTYUN_WORKER_PROJECT_ID` / `-BuilderProjectID` for the temporary
+ECS, key pair, VPC, subnet, and NAT scope. Set `CTYUN_IMAGE_PROJECT_ID` /
+`-ImageProjectID` for private-image lookup and creation. They may be the same
+project (the current production layout) but must not be confused with a
+virtual-worker/bot ID. Builders intentionally use `-extIP 0` and rely on the
+selected private subnet's NAT gateway for HTTPS downloads.
 
 The builder verifies the artifact checksum again before extracting it. Builder
 preparation and every Tianyi Cloud API call have hard timeouts. The

--- a/tests/worker-image-pipeline.test.ts
+++ b/tests/worker-image-pipeline.test.ts
@@ -571,8 +571,11 @@ describe("Tianyi Cloud worker image pipeline", () => {
     assert.match(workflow, /-BuildNumber \$env:GITHUB_RUN_NUMBER/);
     assert.match(workflow, /-BuildIdentity \$env:GITHUB_RUN_ID/);
     assert.match(workflow, /WORKER_PROJECT_ID: \$\{\{ vars\.CTYUN_WORKER_PROJECT_ID \}\}/);
-    assert.match(workflow, /-ProjectID \$env:WORKER_PROJECT_ID/);
+    assert.match(workflow, /WORKER_IMAGE_PROJECT_ID: \$\{\{ vars\.CTYUN_IMAGE_PROJECT_ID \|\| '0' \}\}/);
+    assert.match(workflow, /-BuilderProjectID \$env:WORKER_PROJECT_ID/);
+    assert.match(workflow, /-ImageProjectID \$env:WORKER_IMAGE_PROJECT_ID/);
     assert.match(workflow, /CTYUN_WORKER_PROJECT_ID is required/);
+    assert.match(workflow, /CTYUN_IMAGE_PROJECT_ID is required/);
     assert.match(workflow, /timeout-minutes: 360/);
     assert.match(workflow, /-BakeTimeoutMinutes 150/);
     assert.match(workflow, /-CleanupTimeoutMinutes 40/);


### PR DESCRIPTION
## Summary
- separate the temporary ECS/key-pair enterprise project from the private-image project
- pass both projects through bake, interrupted-run reconciliation, rerun cleanup, and failed-bake cleanup
- keep image pruning scoped to CTYUN_IMAGE_PROJECT_ID
- document extIP=0/NAT and the two project scopes

Production currently sets both IDs to the virtual-worker enterprise project, while retaining separate parameters so the scopes cannot be accidentally conflated again.

## Validation
- PowerShell parse check
- git diff --check
- npm run build
- worker-image lifecycle test executed to completion locally