### PR TITLE
chore(release): bump version to v1.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xiaoba-cli",
-  "version": "1.4.9",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xiaoba-cli",
-      "version": "1.4.9",
+      "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xiaoba-cli",
-  "version": "1.4.9",
+  "version": "1.5.0",
   "description": "CatsCo - local agent runtime and dashboard",
   "main": "electron/main.js",
   "bin": {


### PR DESCRIPTION
Bump the checked-in XiaoBa version from 1.4.9 to 1.5.0 before creating the stable v1.5.0 tag. Updates package.json and the root package-lock.json version fields only.

Validation:
- npm run release:verify-version -- v1.5.0 (passed via direct script invocation)
- npm run release:check (passed)
- npm run build (passed)
- npm test (1607 tests: 1591 passed, 14 skipped, 2 Windows-host-only failures because local WSL /bin/bash is unavailable and the Tianyi image lifecycle mock encountered an occupied-image state; GitHub Ubuntu CI is the merge gate)