### PR TITLE
fix(skillhub): protect local workspace from empty cloud activation

### DIFF
--- a/src/bot-skills/sync-service.ts
+++ b/src/bot-skills/sync-service.ts
@@ -321,8 +321,7 @@ export class BotSkillSyncService {
           localReadable = false;
         }
       }
-      const workspaceHasEvidence = this.workspaceExisted
-        && fs.existsSync(this.skillsRoot)
+      const workspaceHasEvidence = fs.existsSync(this.skillsRoot)
         && (!localReadable || local.length > 0 || hasWorkspaceEntries(this.skillsRoot));
       const localChanged = !localReadable || (base
         ? !localMatchesBase(local, base)

--- a/src/bot-skills/sync-service.ts
+++ b/src/bot-skills/sync-service.ts
@@ -321,9 +321,42 @@ export class BotSkillSyncService {
           localReadable = false;
         }
       }
+      const workspaceHasEvidence = this.workspaceExisted
+        && fs.existsSync(this.skillsRoot)
+        && (!localReadable || local.length > 0 || hasWorkspaceEntries(this.skillsRoot));
       const localChanged = !localReadable || (base
         ? !localMatchesBase(local, base)
-        : this.workspaceExisted && fs.existsSync(this.skillsRoot));
+        : workspaceHasEvidence);
+
+      // An explicit empty Cloud Definition is a valid deletion only when the
+      // active workspace still matches its verified Base. Without a Base, or
+      // after Local changed, replacing a non-empty workspace with an empty
+      // stage would turn a first migration / unresolved edit into silent data
+      // removal. Keep Local active and record recoverable evidence instead.
+      if (
+        cloud.skills.length === 0
+        && workspaceHasEvidence
+        && (!base || localChanged)
+      ) {
+        const snapshot = snapshotPendingBotSkillWorkspace({
+          runtimeRoot: this.runtimeRoot,
+          botId: this.botId,
+          sourcePath: this.skillsRoot,
+          recordedSourcePath: this.skillsRoot,
+          reason: base ? 'activation_local_changed' : 'activation_without_base',
+          ...(base ? { baseRevision: base.definitionRevision } : {}),
+          cloudRevision: cloud.revision,
+        });
+        return {
+          ...this.featureUnavailable(),
+          cloudRevision: cloud.revision,
+          localPendingEvidence: {
+            path: snapshot.path,
+            fingerprint: snapshot.fingerprint,
+            fileCount: snapshot.fileCount,
+          },
+        };
+      }
 
       if (
         verifiedExisting
@@ -923,7 +956,7 @@ export class BotSkillSyncService {
         this.writeRestoreJournal({ stage, backup, phase: 'backup_pending' });
         fs.renameSync(this.skillsRoot, backup);
         backedUp = true;
-        if (options.pendingSnapshot) {
+        if (options.pendingSnapshot && hasWorkspaceEntries(backup)) {
           const snapshot = snapshotPendingBotSkillWorkspace({
             runtimeRoot: this.runtimeRoot,
             botId: this.botId,
@@ -1116,6 +1149,16 @@ function botSkillRefEqual(left: BotSkillRef, right: BotSkillRef): boolean {
 function isPrivateSkillReference(skillId: string): boolean {
   const value = String(skillId || '');
   return value.startsWith('priv_') || value.startsWith('private/');
+}
+
+function hasWorkspaceEntries(workspaceRoot: string): boolean {
+  try {
+    return fs.readdirSync(workspaceRoot).length > 0;
+  } catch {
+    // If the workspace cannot be inspected, keep the conservative
+    // data-preserving behavior and treat it as containing evidence.
+    return true;
+  }
 }
 
 function comparePackageFiles(left: BotSkillPackageFile, right: BotSkillPackageFile): number {

--- a/tests/bot-skills-sync.test.ts
+++ b/tests/bot-skills-sync.test.ts
@@ -1865,6 +1865,31 @@ describe('Bot Skill Local/Base/Cloud sync', () => {
     assert.equal(readPendingSnapshotIfPresent(fixture.runtimeRoot, fixture.botId), undefined);
   });
 
+  test('activation keeps a local Skill that appears after an initially absent workspace', async () => {
+    const fixture = createFixture(roots);
+    fs.rmSync(fixture.skillsRoot, { recursive: true, force: true });
+    fixture.cloud = { revision: 1, skills: [] };
+    fixture.onCloudRead = () => {
+      writeSkill(fixture.skillsRoot, 'late-local', 'late-local', 'created during activation');
+    };
+
+    const result = await fixture.activate(false);
+
+    assert.equal(result.direction, 'feature_unavailable');
+    assert.equal(result.cloudRevision, 1);
+    assert.match(
+      fs.readFileSync(path.join(fixture.skillsRoot, 'late-local', 'SKILL.md'), 'utf8'),
+      /created during activation/,
+    );
+    const snapshot = readPendingSnapshot(fixture.runtimeRoot, fixture.botId);
+    assert.equal(result.localPendingEvidence?.path, snapshot.path);
+    assert.equal(snapshot.manifest.reason, 'activation_without_base');
+    assert.match(
+      fs.readFileSync(path.join(snapshot.path, 'package', 'late-local', 'SKILL.md'), 'utf8'),
+      /created during activation/,
+    );
+  });
+
   test('activation keeps dirty Local when Cloud explicitly becomes empty', async () => {
     const fixture = createFixture(roots);
     writeSkill(fixture.skillsRoot, 'local-a', 'local-a', 'approved local');
@@ -2176,6 +2201,7 @@ function createFixture(
     patchStatus: 200,
     publicDownloadMisses: 0,
     packageDownloads: 0,
+    onCloudRead: undefined as undefined | (() => Promise<void> | void),
     onPackageDownload: undefined as undefined | (() => Promise<void> | void),
     omitSkillsField: false,
     cloudModel: { kind: 'catalog', modelId: 'minimax-m3' } as BotDefinition['model'],
@@ -2236,6 +2262,7 @@ function createFixture(
     const url = new URL(String(input));
     const method = init?.method || 'GET';
     if (url.hostname === 'cats.test' && url.pathname === '/api/bot/definition' && method === 'GET') {
+      await fixture.onCloudRead?.();
       if (fixture.cloudReadStatus !== 200) {
         return Response.json({ error: 'cloud unavailable' }, { status: fixture.cloudReadStatus });
       }

--- a/tests/bot-skills-sync.test.ts
+++ b/tests/bot-skills-sync.test.ts
@@ -1823,6 +1823,91 @@ describe('Bot Skill Local/Base/Cloud sync', () => {
     assert.equal(snapshot.manifest.baseRevision, undefined);
   });
 
+  test('activation keeps a no-Base local workspace when the Cloud Definition is empty', async () => {
+    const fixture = createFixture(roots);
+    writeSkill(fixture.skillsRoot, 'legacy', 'legacy', 'legacy local only');
+    fixture.cloud = { revision: 1, skills: [] };
+
+    const result = await fixture.activate();
+
+    assert.equal(result.direction, 'feature_unavailable');
+    assert.equal(result.cloudRevision, 1);
+    assert.equal(fixture.uploads, 0);
+    assert.equal(fixture.patches, 0);
+    assert.match(
+      fs.readFileSync(path.join(fixture.skillsRoot, 'legacy', 'SKILL.md'), 'utf8'),
+      /legacy local only/,
+    );
+    const snapshot = readPendingSnapshot(fixture.runtimeRoot, fixture.botId);
+    assert.equal(result.localPendingEvidence?.path, snapshot.path);
+    assert.equal(snapshot.manifest.reason, 'activation_without_base');
+    assert.equal(snapshot.manifest.cloudRevision, 1);
+    assert.match(
+      fs.readFileSync(path.join(snapshot.path, 'package', 'legacy', 'SKILL.md'), 'utf8'),
+      /legacy local only/,
+    );
+  });
+
+  test('activation accepts an empty no-Base workspace when Cloud is empty', async () => {
+    const fixture = createFixture(roots);
+    fs.mkdirSync(fixture.skillsRoot, { recursive: true });
+    fixture.cloud = { revision: 1, skills: [] };
+
+    const result = await fixture.activate();
+
+    assert.notEqual(result.direction, 'feature_unavailable');
+    assert.equal(fixture.uploads, 0);
+    assert.deepStrictEqual(fixture.definitionService.read(fixture.botId)?.skills, []);
+    assert.deepStrictEqual(
+      new BotSkillBaseStore(fixture.runtimeRoot).read(fixture.botId)?.skills,
+      [],
+    );
+    assert.equal(readPendingSnapshotIfPresent(fixture.runtimeRoot, fixture.botId), undefined);
+  });
+
+  test('activation keeps dirty Local when Cloud explicitly becomes empty', async () => {
+    const fixture = createFixture(roots);
+    writeSkill(fixture.skillsRoot, 'local-a', 'local-a', 'approved local');
+    await fixture.sync();
+    fs.writeFileSync(
+      path.join(fixture.skillsRoot, 'local-a', 'SKILL.md'),
+      '---\nname: local-a\ndescription: unresolved local edit\n---\n',
+    );
+    fixture.cloud = { revision: fixture.cloud.revision + 1, skills: [] };
+    fixture.uploads = 0;
+    fixture.patches = 0;
+
+    const result = await fixture.activate();
+
+    assert.equal(result.direction, 'feature_unavailable');
+    assert.equal(fixture.uploads, 0);
+    assert.equal(fixture.patches, 0);
+    assert.match(
+      fs.readFileSync(path.join(fixture.skillsRoot, 'local-a', 'SKILL.md'), 'utf8'),
+      /unresolved local edit/,
+    );
+    const snapshot = readPendingSnapshot(fixture.runtimeRoot, fixture.botId);
+    assert.equal(snapshot.manifest.reason, 'activation_local_changed');
+    assert.equal(snapshot.manifest.baseRevision, 1);
+  });
+
+  test('activation still honors an explicit empty Cloud Definition for verified Local', async () => {
+    const fixture = createFixture(roots);
+    writeSkill(fixture.skillsRoot, 'local-a', 'local-a', 'approved local');
+    await fixture.sync();
+    fixture.cloud = { revision: fixture.cloud.revision + 1, skills: [] };
+
+    const result = await fixture.activate();
+
+    assert.equal(result.direction, 'cloud_to_local');
+    assert.equal(fs.existsSync(path.join(fixture.skillsRoot, 'local-a')), false);
+    assert.deepStrictEqual(fixture.definitionService.read(fixture.botId)?.skills, []);
+    assert.deepStrictEqual(
+      new BotSkillBaseStore(fixture.runtimeRoot).read(fixture.botId)?.skills,
+      [],
+    );
+  });
+
   test('activation can use a verified workspace while Cloud is unavailable', async () => {
     const fixture = createFixture(roots);
     writeSkill(fixture.skillsRoot, 'local-a', 'local-a', 'approved local');
@@ -2263,6 +2348,14 @@ function readPendingSnapshot(runtimeRoot: string, botId: string): {
     path: snapshotPath,
     manifest: JSON.parse(fs.readFileSync(path.join(snapshotPath, 'manifest.json'), 'utf8')),
   };
+}
+
+function readPendingSnapshotIfPresent(runtimeRoot: string, botId: string): unknown {
+  const root = path.join(runtimeRoot, 'data', 'bot-skills', 'local-pending', botId);
+  if (!fs.existsSync(root)) return undefined;
+  const directories = fs.readdirSync(root, { withFileTypes: true })
+    .filter(entry => entry.isDirectory() && !entry.name.startsWith('.tmp-'));
+  return directories.length > 0 ? readPendingSnapshot(runtimeRoot, botId) : undefined;
 }
 
 function writeFinalizeJournalFixture(input: {


### PR DESCRIPTION
## Summary
- keep a non-empty local Skill workspace active when Cloud explicitly reports `skills: []` but Local has no verified Base or contains unresolved changes
- record recoverable `local-pending` evidence instead of silently replacing Local with an empty stage
- preserve valid empty-to-empty activation and verified Cloud deletions
- snapshot files that appear while Cloud packages are downloading, without creating empty snapshots

## Safety boundary
- does not change tool permissions, shell/file access, prompt injection, or normal after-turn synchronization
- only changes Cloud-only Bot activation reconciliation for explicit empty Cloud Skill lists

## Tests
- `npx tsx --test tests/bot-skills-sync.test.ts` (55 passed)