### PR TITLE
perf(worker-image): add live bake telemetry and hardened-base fast path

### DIFF
--- a/.github/workflows/worker-image.yml
+++ b/.github/workflows/worker-image.yml
@@ -26,6 +26,11 @@ env:
   CTYUN_CLI_PACKAGE_SHA256: 93272c3fd377a6f642a89cb326fa2f4a3d2fab7dfc9587e49906527230b767fa
   TOS_WORKER_BUCKET: catsco-worker-release
   TOS_WORKER_REGION: cn-guangzhou
+  # Set this repository variable only after WORKER_BASE_IMAGE_ID points at a
+  # previously baked image that passed the platform hardening gates. The
+  # preparer still verifies the contract and falls back to a full upgrade when
+  # the claim is stale.
+  WORKER_BASE_IMAGE_HARDENED: ${{ vars.CTYUN_WORKER_BASE_IMAGE_HARDENED || 'false' }}
 
 jobs:
   image:
@@ -465,6 +470,7 @@ jobs:
             -BakeTimeoutMinutes 150 `
             -CleanupTimeoutMinutes 40 `
             -ApiTimeoutSeconds 90 `
+            -BaseImageHardened:($env:WORKER_BASE_IMAGE_HARDENED -eq 'true') `
             -RegionID $env:WORKER_REGION_ID `
             -BuilderProjectID $env:WORKER_PROJECT_ID `
             -ImageProjectID $env:WORKER_IMAGE_PROJECT_ID `

--- a/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
+++ b/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
@@ -56,6 +56,9 @@ param(
     [int]$LateResourceWaitSeconds = 120,
     [ValidateRange(0, 60)]
     [int]$PollIntervalSeconds = 0,
+    [ValidateRange(5, 300)]
+    [int]$ProgressIntervalSeconds = 30,
+    [switch]$BaseImageHardened,
     [switch]$WaitForLateResources
 )
 
@@ -81,6 +84,32 @@ $script:BakeDescription = ""
 $script:OperationDeadline = $null
 $script:CleanupDeadline = $null
 $script:InCleanup = $false
+$script:StartedAt = Get-Date
+$script:LastProgressAt = $script:StartedAt
+
+function Write-BakeProgress {
+    param(
+        [Parameter(Mandatory = $true)][string]$Phase,
+        [string]$Detail = "",
+        [switch]$Force
+    )
+
+    $now = Get-Date
+    if (-not $Force -and (($now - $script:LastProgressAt).TotalSeconds -lt $ProgressIntervalSeconds)) {
+        return
+    }
+    $script:LastProgressAt = $now
+    $elapsed = [int][Math]::Floor(($now - $script:StartedAt).TotalSeconds)
+    $deadline = Get-ActiveDeadline
+    $remaining = if ($deadline) {
+        [Math]::Max(0, [int][Math]::Floor(($deadline - $now).TotalSeconds))
+    } else {
+        -1
+    }
+    $suffix = if ([string]::IsNullOrWhiteSpace($Detail)) { "" } else { " $Detail" }
+    Write-Host ("{0} bake-progress phase={1} elapsed_s={2} remaining_s={3}{4}" -f `
+        $now.ToUniversalTime().ToString("o"), $Phase, $elapsed, $remaining, $suffix)
+}
 
 function Wait-PollInterval {
     param([Parameter(Mandatory = $true)][int]$DefaultSeconds)
@@ -153,6 +182,13 @@ function Get-ResponseItems {
 function Invoke-Ctyun {
     param([Parameter(Mandatory = $true)][string[]]$Arguments)
 
+    $operation = if ($Arguments.Count -ge 2) {
+        "$($Arguments[0])/$($Arguments[1])"
+    } else {
+        ($Arguments -join "/")
+    }
+    Write-BakeProgress -Phase "api-start" -Detail "operation=$operation" -Force
+    $apiStartedAt = Get-Date
     $timeoutSeconds = Get-BoundedTimeoutSeconds `
         -RequestedSeconds $ApiTimeoutSeconds `
         -Phase "Tianyi Cloud API call"
@@ -174,6 +210,8 @@ function Invoke-Ctyun {
         $description = Get-PropertyValue -InputObject $response -Name "description"
         throw "Tianyi Cloud API failed: $errorCode $message $description"
     }
+    Write-BakeProgress -Phase "api-ok" -Detail ("operation={0} duration_ms={1}" -f `
+        $operation, [int][Math]::Round(((Get-Date) - $apiStartedAt).TotalMilliseconds)) -Force
     return $response
 }
 
@@ -373,7 +411,7 @@ function Wait-ForInstance {
         Assert-TemporaryBuilder $instance
         $state = ([string]$instance.instanceStatus).ToLowerInvariant()
         $ip = [string]$instance.floatingIP
-        Write-Host "builder state=$state ip=$ip"
+        Write-BakeProgress -Phase "builder-wait" -Detail ("state={0} ip_present={1}" -f $state, (-not [string]::IsNullOrWhiteSpace($ip))) -Force
         if ($States -contains $state -and (-not $RequireIP -or $ip)) {
             return $instance
         }
@@ -1173,6 +1211,7 @@ $cleanupFailure = $null
 $result = $null
 
 try {
+    Write-BakeProgress -Phase "prepare" -Detail "creating temporary key pair and builder" -Force
     Invoke-External -Command "ssh-keygen" -Arguments @(
         "-q", "-t", "rsa", "-b", "3072",
         "-N", "",
@@ -1226,6 +1265,7 @@ try {
     if (-not $script:KeyPairID) {
         throw "Imported key pair could not be resolved"
     }
+    Write-BakeProgress -Phase "keypair-imported" -Detail "key_pair_id=$script:KeyPairID" -Force
 
     $existingBuilderResponse = Invoke-Ctyun @(
         "ecs", "ListEcsInstances",
@@ -1248,10 +1288,12 @@ try {
     $prepareScriptUrlBase64 = [Convert]::ToBase64String(
         [Text.Encoding]::UTF8.GetBytes($PrepareScriptUrl)
     )
+    $baseImageHardenedValue = $BaseImageHardened.IsPresent.ToString().ToLowerInvariant()
     $artifactName = "catsco-worker-$releaseId-linux-x64.tar.gz"
     $bootstrapScript = @"
 #!/usr/bin/env bash
 set -Eeuo pipefail
+export CATSCO_BASE_IMAGE_HARDENED='$baseImageHardenedValue'
 exec > >(tee -a /var/log/catsco-image-build.log) 2>&1
 artifact_url="`$(printf '%s' '$artifactUrlBase64' | base64 -d)"
 prepare_script_url="`$(printf '%s' '$prepareScriptUrlBase64' | base64 -d)"
@@ -1344,17 +1386,20 @@ runcmd:
         throw "CreateEcsInstance did not return masterResourceID"
     }
     $script:BuilderCreateAttempted = $true
+    Write-BakeProgress -Phase "builder-created" -Detail "builder_name=$script:BuilderName resource_id=$script:BuilderResourceID" -Force
 
     $builder = Resolve-BuilderInstance -WaitSeconds ($TimeoutMinutes * 60)
     if (-not $builder) {
         throw "Timed out resolving the temporary builder instance"
     }
     Assert-TemporaryBuilder $builder
+    Write-BakeProgress -Phase "builder-resolved" -Detail "builder_id=$script:BuilderID" -Force
 
     # cloud-init powers off only after artifact verification, preparation and
     # finalization all succeed. A failed bootstrap stays running, times out,
     # and is removed by the existing compensating cleanup path.
     Wait-ForInstance -States @("stopped", "shutoff") | Out-Null
+    Write-BakeProgress -Phase "builder-stopped" -Detail "cloud-init completed; starting image capture" -Force
 
     $script:ImageCreateAttempted = $true
     $imageResponse = Invoke-Ctyun @(
@@ -1375,6 +1420,7 @@ runcmd:
     if (-not $script:ImageID) {
         throw "CreateImage did not return an image ID"
     }
+    Write-BakeProgress -Phase "image-capture-started" -Detail "image_id=$script:ImageID" -Force
 
     $deadline = Get-BoundedDeadline `
         -RequestedSeconds ($TimeoutMinutes * 60) `
@@ -1385,7 +1431,7 @@ runcmd:
             throw "Private image disappeared during creation"
         }
         $status = ([string]$currentImage.imageStatus).ToLowerInvariant()
-        Write-Host "image state=$status progress=$($currentImage.taskProgress)"
+        Write-BakeProgress -Phase "image-capture" -Detail ("state={0} progress={1}" -f $status, $currentImage.taskProgress) -Force
         if ($status -eq "active") {
             if ([string]$currentImage.sourceServerID -ne $script:BuilderID) {
                 throw (
@@ -1406,6 +1452,7 @@ runcmd:
                 -PublishedDescription $bakeDescription
             $script:ImageActive = $true
             $script:Completed = $true
+            Write-BakeProgress -Phase "image-capture-active" -Detail "image_id=$script:ImageID" -Force
             $result = [ordered]@{
                 result = "created"
                 imageID = $script:ImageID
@@ -1427,10 +1474,12 @@ runcmd:
     }
 } catch {
     $primaryFailure = $_.Exception.Message
+    Write-BakeProgress -Phase "failed" -Detail $primaryFailure -Force
 } finally {
     $script:InCleanup = $true
     $script:CleanupDeadline = (Get-Date).AddMinutes($CleanupTimeoutMinutes)
     try {
+        Write-BakeProgress -Phase "cleanup-start" -Detail "failure=$(-not $script:Completed)" -Force
         Remove-TemporaryResources `
             -Failure:(-not $script:Completed) `
             -WaitForLate:$WaitForLateResources

--- a/ops/ctyun-worker-image/README.md
+++ b/ops/ctyun-worker-image/README.md
@@ -178,6 +178,28 @@ Installed Debian package versions are recorded in
 The resulting system image is not a TOS object. `CreateImage` writes it to the
 Tianyi Cloud private image repository for the configured region and account.
 
+### Progress monitoring and bake speed
+
+The orchestrator emits timestamped `bake-progress` lines to the GitHub Actions
+log. They include the current phase, elapsed seconds, remaining deadline, API
+operation latency, builder state, and image capture progress. This makes a
+stalled API call or a builder that never shuts down distinguishable from a
+slow image capture while the run is still active. The builder has no public IP,
+so its private cloud-init log is intentionally not exposed to the internet;
+the phase and output files remain inside the temporary builder and are erased
+when the image is finalized.
+
+The expensive part of a cold bake is the platform hardening in
+`prepare-image.sh` (apt, systemd/glibc, and kernel updates). For faster repeat
+bakes, first publish a worker image that has passed those gates, point
+`CTYUN_WORKER_BASE_IMAGE_ID` at that image, and set the repository variable
+`CTYUN_WORKER_BASE_IMAGE_HARDENED=true`. The workflow passes that claim to the
+builder, which still verifies package versions, masks, and a bootable kernel;
+if any check fails it automatically performs the full hardening path. Leave the
+variable unset/`false` for a stock Ubuntu base. This turns later application
+release bakes into a short artifact/install plus image-capture operation without
+weakening the fail-closed safety check.
+
 ## Managed Worker Updates
 
 Workers must not receive Tianyi Cloud account credentials. CatsCompany's

--- a/ops/ctyun-worker-image/README.md
+++ b/ops/ctyun-worker-image/README.md
@@ -87,6 +87,14 @@ The image ships with `catsco-agent.service` disabled. Provisioning must inject a
 short-lived bootstrap credential into the data root and enable the service only
 after the worker has claimed its bot identity.
 
+The current cloud image also installs `/etc/sudoers.d/catsco-agent` with
+`catsco-agent ALL=(ALL:ALL) NOPASSWD: ALL`, validated by `visudo`. This is an
+intentional broad first-stage capability for one-click cloud agents: any Agent
+tool execution can become root without a password. Treat the worker as a fully
+privileged dedicated VM and do not co-host unrelated workloads. A later
+hardening pass should replace this rule with the smallest command/service
+aliases that real workloads require.
+
 ## Local Bake
 
 `New-CatsCoWorkerImage.ps1` defaults to plan mode. Execute mode creates a new

--- a/ops/ctyun-worker-image/prepare-image.sh
+++ b/ops/ctyun-worker-image/prepare-image.sh
@@ -86,6 +86,39 @@ export DEBIAN_FRONTEND=noninteractive
 # must block the bake. Shipping an image that silently carries the buggy
 # systemd/glibc/kernel combo is worse than failing the workflow so it can retry.
 
+# A hardened base image can be reused for many worker releases. Avoid running
+# apt/dpkg and kernel package work on every bake when the base already carries
+# the exact platform contract below. The checks are deliberately conservative:
+# any missing package, mask, version, or bootable kernel falls back to the full
+# fail-closed hardening path.
+platform_hardening_ready() {
+  local systemd_version glibc_version systemd_status glibc_status package
+  systemd_version="$(dpkg-query -W -f='${Version}' systemd 2>/dev/null || true)"
+  glibc_version="$(dpkg-query -W -f='${Version}' libc6 2>/dev/null || true)"
+  systemd_status="$(dpkg-query -W -f='${db:Status-Abbrev}' systemd 2>/dev/null || true)"
+  glibc_status="$(dpkg-query -W -f='${db:Status-Abbrev}' libc6 2>/dev/null || true)"
+  dpkg --compare-versions "$systemd_version" ge "255.4-1ubuntu8.16" || return 1
+  dpkg --compare-versions "$glibc_version" ge "2.39-0ubuntu8.8" || return 1
+  [[ "${systemd_status//[[:space:]]/}" == "ii" ]] || return 1
+  [[ "${glibc_status//[[:space:]]/}" == "ii" ]] || return 1
+  for package in \
+    ca-certificates curl git jq poppler-utils ripgrep sudo unzip zip \
+    linux-generic linux-image-generic; do
+    [[ "$(dpkg-query -W -f='${db:Status-Abbrev}' "$package" 2>/dev/null || true)" == ii* ]] || return 1
+  done
+  command -v update-grub >/dev/null 2>&1 || return 1
+  ls -1 /boot/vmlinuz-* >/dev/null 2>&1 || return 1
+  for unit in fwupd.service fwupd-refresh.service fwupd-refresh.timer; do
+    [[ "$(readlink "/etc/systemd/system/$unit" 2>/dev/null || true)" == "/dev/null" ]] || return 1
+  done
+  return 0
+}
+
+if [[ "${CATSCO_BASE_IMAGE_HARDENED:-false}" == "true" ]] && platform_hardening_ready; then
+  printf 'platform_hardening=already-satisfied\n'
+else
+  printf 'platform_hardening=upgrade-required\n'
+
 # 1. Repair corrupted dpkg file lists ("missing final newline") BEFORE any
 #    apt/dpkg transaction. These images can ship broken
 #    /var/lib/dpkg/info/*.list files that abort the very first apt or dpkg call
@@ -221,6 +254,7 @@ fi
 KERNEL_VERSION="$(uname -r 2>/dev/null || true)"
 printf 'platform_systemd=%s glibc=%s kernel=%s\n' \
   "$SYSTEMD_VERSION" "$GLIBC_VERSION" "$KERNEL_VERSION"
+fi
 
 # 5. Pre-configure the China-region npm mirror. Direct registry.npmjs.org from
 #    Tianyi/华南 hosts is slow and has produced truncated/corrupted tarballs

--- a/ops/ctyun-worker-image/prepare-image.sh
+++ b/ops/ctyun-worker-image/prepare-image.sh
@@ -269,6 +269,16 @@ id catsco-agent >/dev/null 2>&1 || useradd \
   --shell /bin/bash \
   catsco-agent
 
+# Cloud workers currently need unrestricted host administration from Agent
+# tool calls. Keep the grant explicit and independently removable so it can be
+# narrowed to command aliases later without changing the service identity.
+cat >/etc/sudoers.d/catsco-agent <<'EOF'
+catsco-agent ALL=(ALL:ALL) NOPASSWD: ALL
+EOF
+chmod 0440 /etc/sudoers.d/catsco-agent
+visudo -cf /etc/sudoers.d/catsco-agent >/dev/null || \
+  die "catsco-agent sudoers validation failed"
+
 # Service-user npm mirror config (survives finalize; the finalize cleanup list
 # deliberately keeps .npmrc so first-boot npm never needs manual setup).
 mkdir -p /srv/catsco-agent

--- a/tests/worker-image-pipeline.test.ts
+++ b/tests/worker-image-pipeline.test.ts
@@ -59,6 +59,12 @@ describe("Tianyi Cloud worker image pipeline", () => {
       /runtime\/node\/bin\/node .*dist\/index\.js catsco/,
     );
     assert.match(imagePreparer, /catsco-image-packages\.txt/);
+    assert.match(
+      imagePreparer,
+      /catsco-agent ALL=\(ALL:ALL\) NOPASSWD: ALL/,
+    );
+    assert.match(imagePreparer, /chmod 0440 \/etc\/sudoers\.d\/catsco-agent/);
+    assert.match(imagePreparer, /visudo -cf \/etc\/sudoers\.d\/catsco-agent/);
   });
 
   test("finalization removes worker identity and machine identity before imaging", () => {

--- a/tests/worker-image-pipeline.test.ts
+++ b/tests/worker-image-pipeline.test.ts
@@ -538,6 +538,9 @@ describe("Tianyi Cloud worker image pipeline", () => {
 
   test("private builder bootstrap is bounded and does not require inbound SSH", () => {
     assert.match(imageOrchestrator, /ApiTimeoutSeconds/);
+    assert.match(imageOrchestrator, /ProgressIntervalSeconds/);
+    assert.match(imageOrchestrator, /bake-progress/);
+    assert.match(imageOrchestrator, /CATSCO_BASE_IMAGE_HARDENED/);
     assert.match(
       imageOrchestrator,
       /"timeout"[\s\S]*?"ctyun-cli"/,
@@ -553,6 +556,8 @@ describe("Tianyi Cloud worker image pipeline", () => {
     assert.match(imageOrchestrator, /phase shutdown/);
     assert.match(imageOrchestrator, /shutdown -h now/);
     assert.doesNotMatch(imageOrchestrator, /Wait-ForSsh|\bscp\b|"--extIP", "1"/);
+    assert.match(imagePreparer, /platform_hardening=already-satisfied/);
+    assert.match(workflow, /CTYUN_WORKER_BASE_IMAGE_HARDENED/);
   });
 
   test("workflow is restricted and stages only a temporary private artifact", () => {


### PR DESCRIPTION
## Summary
- emit timestamped bake-progress phase, API latency, builder state, and image capture progress lines in Actions logs
- allow a previously hardened base image to skip repeated apt/systemd/glibc/kernel work after independent contract verification
- grant the cloud catsco-agent service temporary NOPASSWD sudo, with visudo validation (follow-up will narrow this to least privilege)

## Verification
- bash -n ops/ctyun-worker-image/prepare-image.sh
- npx tsx --test --test-name-pattern='image keeps immutable|private builder bootstrap|PowerShell image orchestrator parses' tests/worker-image-pipeline.test.ts
- npx tsx --test --test-name-pattern='platform hardening' tests/worker-image-pipeline.test.ts

The current stuck bake run 32436230808 was canceled separately; the next main run should reconcile its resources before baking.