### PR TITLE
fix(dashboard): restore visible update progress

### DIFF
--- a/dashboard/connector.css
+++ b/dashboard/connector.css
@@ -312,6 +312,126 @@ h1 {
 .agent-switch-error { border: 1px solid #efc7c3; background: var(--red-soft); color: #a33a35; }
 .agent-switch-footer { padding: 15px 24px 20px; display: flex; align-items: center; justify-content: flex-end; gap: 10px; border-top: 1px solid var(--line); }
 
+.update-dialog {
+  width: min(530px, calc(100vw - 40px));
+  max-height: min(620px, calc(100vh - 40px));
+  padding: 0;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: #fff;
+  color: var(--ink);
+  box-shadow: 0 24px 70px rgba(18, 31, 52, .24);
+}
+.update-dialog::backdrop { background: rgba(24, 32, 51, .34); }
+.update-dialog-shell { min-height: 0; max-height: inherit; display: flex; flex-direction: column; }
+.update-dialog-header {
+  padding: 21px 24px 17px;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+  border-bottom: 1px solid var(--line);
+}
+.update-dialog-header h2 { margin: 0; font-size: 22px; line-height: 1.25; }
+.update-dialog-header p { margin: 6px 0 0; color: var(--muted); font-size: 13px; line-height: 1.5; }
+.update-dialog-body { min-height: 0; padding: 20px 24px 22px; overflow: auto; }
+.update-stage-row { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.update-stage-copy { min-width: 0; display: flex; align-items: center; gap: 10px; }
+.update-stage-copy strong { overflow: hidden; font-size: 16px; text-overflow: ellipsis; white-space: nowrap; }
+.update-stage-dot {
+  width: 10px;
+  height: 10px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: var(--blue);
+  box-shadow: 0 0 0 5px var(--blue-soft);
+}
+.update-stage-dot.success { background: var(--green); box-shadow: 0 0 0 5px var(--green-soft); }
+.update-stage-dot.error { background: var(--red); box-shadow: 0 0 0 5px var(--red-soft); }
+.update-stage-percent {
+  flex: 0 0 auto;
+  color: #245fc7;
+  font-size: 22px;
+  font-weight: 750;
+  font-variant-numeric: tabular-nums;
+}
+.update-stage-percent.success { color: var(--green); }
+.update-stage-percent.error { color: var(--red); }
+.update-version-flow {
+  margin-top: 18px;
+  padding: 13px 15px;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 13px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: #fbfcfe;
+}
+.update-version-item span { display: block; color: var(--muted); font-size: 11px; }
+.update-version-item strong { display: block; margin-top: 3px; font-size: 15px; }
+.update-version-item:last-child { text-align: right; }
+.update-version-arrow { color: #9aa5b7; font-size: 18px; }
+.update-progress-section { margin-top: 20px; }
+.update-progress-track {
+  height: 10px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #e8edf4;
+}
+.update-progress-bar {
+  height: 100%;
+  width: 0;
+  border-radius: inherit;
+  background: var(--blue);
+  transition: width 220ms ease;
+}
+.update-progress-bar.success { background: var(--green); }
+.update-progress-bar.error { background: var(--red); }
+.update-progress-track.indeterminate .update-progress-bar { width: 38% !important; animation: update-progress-scan 1.4s ease-in-out infinite; }
+@keyframes update-progress-scan {
+  from { transform: translateX(-110%); }
+  to { transform: translateX(280%); }
+}
+.update-progress-meta {
+  min-height: 32px;
+  margin-top: 10px;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 12px;
+  color: var(--muted);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+.update-progress-meta span:nth-child(2) { text-align: center; }
+.update-progress-meta span:last-child { text-align: right; }
+.update-note { margin: 4px 0 0; color: var(--muted); font-size: 12px; line-height: 1.55; }
+.update-error-box {
+  margin-top: 16px;
+  padding: 11px 12px;
+  border: 1px solid #efc7c3;
+  border-radius: 8px;
+  background: var(--red-soft);
+  color: #983b36;
+  font-size: 12px;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+.update-dialog-footer {
+  padding: 15px 24px 20px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  border-top: 1px solid var(--line);
+}
+.update-footer-hint { color: var(--muted); font-size: 12px; line-height: 1.45; }
+.update-dialog-actions { flex: 0 0 auto; display: flex; align-items: center; gap: 9px; }
+.compact-card .button.update-active { color: #245fc7; border-color: #b7cef8; background: var(--blue-soft); }
+.compact-card .button.update-error { color: var(--red); border-color: #efc7c3; background: var(--red-soft); }
+
 .login-card {
   width: min(620px, 100%);
   padding: 18px;

--- a/dashboard/connector.html
+++ b/dashboard/connector.html
@@ -205,6 +205,62 @@
     </form>
   </dialog>
 
+  <dialog class="update-dialog" id="update-dialog" aria-labelledby="update-title">
+    <section class="update-dialog-shell">
+      <header class="update-dialog-header">
+        <div>
+          <h2 id="update-title">检查更新</h2>
+          <p id="update-subtitle">正在读取 CatsCo Desktop 的更新状态。</p>
+        </div>
+        <button class="dialog-close" id="update-close" type="button" aria-label="隐藏更新窗口">×</button>
+      </header>
+
+      <div class="update-dialog-body">
+        <div class="update-stage-row">
+          <div class="update-stage-copy">
+            <span class="update-stage-dot" id="update-stage-dot"></span>
+            <strong id="update-stage-label">正在检查可用版本</strong>
+          </div>
+          <span class="update-stage-percent" id="update-stage-percent"></span>
+        </div>
+
+        <div class="update-version-flow" id="update-version-flow">
+          <div class="update-version-item">
+            <span>当前版本</span>
+            <strong id="update-current-version">—</strong>
+          </div>
+          <span class="update-version-arrow" aria-hidden="true">→</span>
+          <div class="update-version-item">
+            <span>更新版本</span>
+            <strong id="update-available-version">—</strong>
+          </div>
+        </div>
+
+        <div class="update-progress-section" id="update-progress-section">
+          <div class="update-progress-track" id="update-progress-track" role="progressbar" aria-label="更新下载进度" aria-valuemin="0" aria-valuemax="100">
+            <div class="update-progress-bar" id="update-progress-bar"></div>
+          </div>
+          <div class="update-progress-meta">
+            <span id="update-size">等待下载信息</span>
+            <span id="update-speed"></span>
+            <span id="update-remaining"></span>
+          </div>
+        </div>
+
+        <p class="update-note" id="update-note">检查完成后会在这里显示更新详情。</p>
+        <div class="update-error-box" id="update-error-box" role="alert" hidden></div>
+      </div>
+
+      <footer class="update-dialog-footer">
+        <span class="update-footer-hint" id="update-footer-hint">当前版本不会受到影响</span>
+        <div class="update-dialog-actions">
+          <button class="button button-quiet" id="update-secondary-action" type="button">隐藏到后台</button>
+          <button class="button button-primary" id="update-primary-action" type="button" disabled>检查中…</button>
+        </div>
+      </footer>
+    </section>
+  </dialog>
+
   <dialog class="agent-switch-dialog logout-dialog" id="logout-dialog" aria-labelledby="logout-title">
     <form method="dialog" class="agent-switch-shell">
       <header class="agent-switch-header">

--- a/dashboard/connector.js
+++ b/dashboard/connector.js
@@ -126,6 +126,9 @@
     serviceActionBusy: new Set(),
     logPollTimer: null,
     weixinPollTimer: null,
+    updatePollTimer: null,
+    updateStatusInFlight: null,
+    updateActionBusy: false,
   };
 
   const $ = (id) => document.getElementById(id);
@@ -349,12 +352,267 @@
     const button = $('update-button');
     const update = state.update || {};
     if (!button) return;
-    button.disabled = update.stage === 'checking' || update.stage === 'downloading';
-    if (update.stage === 'available') button.textContent = `下载 ${update.availableVersion || '新版本'}`;
-    else if (update.stage === 'downloaded') button.textContent = '安装更新';
-    else if (update.stage === 'checking') button.textContent = '检查中…';
+    const stage = update.stage || 'idle';
+    const percent = clampUpdatePercent(update.percent);
+    button.classList.toggle('update-active', stage === 'checking' || stage === 'downloading');
+    button.classList.toggle('update-error', stage === 'error');
+    button.disabled = update.enabled === false || stage === 'installing';
+    if (stage === 'available') button.textContent = `下载 ${update.availableVersion || '新版本'}`;
+    else if (stage === 'downloaded') button.textContent = '安装更新';
+    else if (stage === 'checking') button.textContent = '检查中…';
+    else if (stage === 'downloading') button.textContent = `下载 ${Math.round(percent)}%`;
+    else if (stage === 'installing') button.textContent = '安装中…';
+    else if (stage === 'error') button.textContent = '重试更新';
     else if (update.enabled === false) button.textContent = '开发版本';
     else button.textContent = '检查更新';
+    button.setAttribute('aria-label', updateButtonAriaLabel(update, percent));
+    renderUpdateDialog();
+    syncUpdatePolling();
+  }
+
+  function updateButtonAriaLabel(update, percent) {
+    if (update.stage === 'downloading') return `更新下载进度 ${Math.round(percent)}%`;
+    if (update.stage === 'available') return `下载 CatsCo ${update.availableVersion || '新版本'}`;
+    if (update.stage === 'downloaded') return '更新已下载，打开安装确认';
+    if (update.stage === 'error') return '更新失败，打开详情并重试';
+    return $('update-button')?.textContent || '检查更新';
+  }
+
+  function clampUpdatePercent(value) {
+    const percent = Number(value || 0);
+    if (!Number.isFinite(percent)) return 0;
+    return Math.max(0, Math.min(100, percent));
+  }
+
+  function formatUpdateBytes(value) {
+    const bytes = Number(value || 0);
+    if (!Number.isFinite(bytes) || bytes <= 0) return '0 B';
+    const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+    let size = bytes;
+    let unit = 0;
+    while (size >= 1024 && unit < units.length - 1) {
+      size /= 1024;
+      unit += 1;
+    }
+    const digits = size >= 100 ? 0 : size >= 10 ? 1 : 2;
+    return `${size.toFixed(digits)} ${units[unit]}`;
+  }
+
+  function formatUpdateRemaining(update) {
+    const total = Number(update.total || 0);
+    const transferred = Number(update.transferred || 0);
+    const speed = Number(update.bytesPerSecond || 0);
+    if (!(total > transferred) || !(speed > 0)) return '正在计算剩余时间';
+    const seconds = Math.max(1, Math.ceil((total - transferred) / speed));
+    if (seconds < 60) return `预计还需 ${seconds} 秒`;
+    const minutes = Math.ceil(seconds / 60);
+    return `预计还需 ${minutes} 分钟`;
+  }
+
+  function updateDialogMeta(update) {
+    const version = update.availableVersion || '新版本';
+    switch (update.stage) {
+      case 'checking':
+        return {
+          title: '检查更新',
+          subtitle: '正在连接更新服务，请稍候。',
+          label: '正在检查可用版本',
+          note: '通常只需要几秒钟。如果网络异常，会在这里显示明确的失败原因。',
+          footer: `当前版本 ${update.currentVersion || state.app.version || '—'}`,
+          secondary: '隐藏到后台',
+          primary: '检查中…',
+          primaryDisabled: true,
+          tone: 'active',
+        };
+      case 'available':
+        return {
+          title: '发现 CatsCo 更新',
+          subtitle: `${version} 已可以下载。`,
+          label: `可以更新到 ${version}`,
+          note: '下载期间可以继续使用 CatsCo，Connector 会保持连接。',
+          footer: '下载完成后将提示你安装',
+          secondary: '稍后',
+          primary: '下载更新',
+          primaryDisabled: false,
+          tone: 'active',
+        };
+      case 'downloading':
+        return {
+          title: '正在更新 CatsCo',
+          subtitle: '更新包正在后台下载，Connector 会保持连接。',
+          label: '正在下载更新包',
+          note: '下载期间可以继续使用 CatsCo。请不要退出应用；关闭此弹窗后，可在右下角继续查看进度。',
+          footer: '校验完成后将提示你安装',
+          secondary: '隐藏到后台',
+          primary: '下载中…',
+          primaryDisabled: true,
+          tone: 'active',
+        };
+      case 'downloaded':
+        return {
+          title: '更新已准备好',
+          subtitle: `${version} 已下载并通过完整性校验。`,
+          label: '下载完成',
+          note: '安装会关闭并重新启动 CatsCo，Connector 将在重启后自动恢复连接。',
+          footer: '建议保存正在进行的工作',
+          secondary: '稍后安装',
+          primary: '安装并重启',
+          primaryDisabled: false,
+          tone: 'success',
+        };
+      case 'installing':
+        return {
+          title: '正在安装更新',
+          subtitle: 'CatsCo 即将退出并重新启动。',
+          label: '正在准备安装',
+          note: '请稍候，不要手动结束 CatsCo 进程。',
+          footer: 'Connector 会在重启后自动恢复',
+          secondary: '隐藏到后台',
+          primary: '安装中…',
+          primaryDisabled: true,
+          tone: 'active',
+        };
+      case 'error':
+        return {
+          title: '更新没有完成',
+          subtitle: '当前版本没有受到影响，你可以直接重试。',
+          label: '更新失败',
+          note: '失败不会影响当前版本，Connector 会继续正常运行。',
+          footer: `错误代码：${update.lastError?.reason || update.reason || 'UPDATE_ERROR'}`,
+          secondary: '关闭',
+          primary: '重新检查',
+          primaryDisabled: false,
+          tone: 'error',
+        };
+      case 'disabled':
+        return {
+          title: '当前环境不支持自动更新',
+          subtitle: '开发环境或当前安装方式没有启用更新器。',
+          label: '自动更新不可用',
+          note: '打包安装版会在这里显示可用更新与下载进度。',
+          footer: '无需进行任何操作',
+          secondary: '关闭',
+          primary: '不可用',
+          primaryDisabled: true,
+          tone: 'error',
+        };
+      default:
+        return {
+          title: 'CatsCo 已是最新版本',
+          subtitle: '当前没有需要安装的更新。',
+          label: '已经是最新版本',
+          note: 'CatsCo 仍会在启动后自动检查更新。',
+          footer: `当前版本 ${update.currentVersion || state.app.version || '—'}`,
+          secondary: '关闭',
+          primary: '再次检查',
+          primaryDisabled: false,
+          tone: 'success',
+        };
+    }
+  }
+
+  function renderUpdateDialog() {
+    const dialog = $('update-dialog');
+    if (!dialog) return;
+    const update = state.update || {};
+    const stage = update.stage || (update.enabled === false ? 'disabled' : 'idle');
+    const normalized = { ...update, stage };
+    const meta = updateDialogMeta(normalized);
+    const percent = stage === 'downloaded' || stage === 'installing' ? 100 : clampUpdatePercent(update.percent);
+    const progressVisible = ['checking', 'downloading', 'downloaded', 'installing'].includes(stage)
+      || (stage === 'error' && Number(update.transferred || 0) > 0);
+    const versionVisible = Boolean(update.availableVersion) || ['available', 'downloading', 'downloaded', 'installing'].includes(stage);
+
+    setText('update-title', meta.title);
+    setText('update-subtitle', meta.subtitle);
+    setText('update-stage-label', meta.label);
+    setText('update-current-version', update.currentVersion || state.app.version || '—');
+    setText('update-available-version', update.availableVersion || '—');
+    setText('update-note', meta.note);
+    setText('update-footer-hint', meta.footer);
+    $('update-version-flow').hidden = !versionVisible;
+    $('update-progress-section').hidden = !progressVisible;
+
+    const dot = $('update-stage-dot');
+    const percentNode = $('update-stage-percent');
+    const bar = $('update-progress-bar');
+    dot.className = `update-stage-dot${meta.tone === 'success' ? ' success' : meta.tone === 'error' ? ' error' : ''}`;
+    percentNode.className = `update-stage-percent${meta.tone === 'success' ? ' success' : meta.tone === 'error' ? ' error' : ''}`;
+    percentNode.textContent = progressVisible && stage !== 'checking' ? `${Math.round(percent)}%` : '';
+    bar.className = `update-progress-bar${meta.tone === 'success' ? ' success' : meta.tone === 'error' ? ' error' : ''}`;
+    bar.style.width = `${percent}%`;
+    const track = $('update-progress-track');
+    track.classList.toggle('indeterminate', stage === 'checking');
+    track.setAttribute('aria-valuenow', String(Math.round(percent)));
+
+    if (stage === 'checking') {
+      $('update-size').textContent = '正在获取版本信息';
+      $('update-speed').textContent = '';
+      $('update-remaining').textContent = '';
+    } else {
+      const transferred = Number(update.transferred || 0);
+      const total = Number(update.total || 0);
+      $('update-size').textContent = total > 0 ? `${formatUpdateBytes(transferred)} / ${formatUpdateBytes(total)}` : '等待下载信息';
+      $('update-speed').textContent = Number(update.bytesPerSecond || 0) > 0 ? `${formatUpdateBytes(update.bytesPerSecond)}/s` : '';
+      $('update-remaining').textContent = stage === 'downloading' ? formatUpdateRemaining(update) : stage === 'downloaded' ? '可以安装' : '';
+    }
+
+    const error = $('update-error-box');
+    const errorMessage = update.lastError?.message || update.error || '';
+    error.hidden = stage !== 'error';
+    error.textContent = stage === 'error'
+      ? [update.lastError?.reason || update.reason || 'UPDATE_ERROR', errorMessage].filter(Boolean).join('\n')
+      : '';
+
+    $('update-secondary-action').textContent = meta.secondary;
+    $('update-primary-action').textContent = meta.primary;
+    $('update-primary-action').disabled = meta.primaryDisabled || state.updateActionBusy;
+  }
+
+  function openUpdateDialog() {
+    const dialog = $('update-dialog');
+    renderUpdateDialog();
+    if (!dialog.open) dialog.showModal();
+  }
+
+  function closeUpdateDialog() {
+    const dialog = $('update-dialog');
+    if (dialog.open) dialog.close();
+  }
+
+  function isUpdatePollingStage(stage) {
+    return stage === 'checking' || stage === 'downloading' || stage === 'installing';
+  }
+
+  function syncUpdatePolling() {
+    if (isUpdatePollingStage(state.update?.stage)) {
+      if (!state.updatePollTimer) {
+        state.updatePollTimer = setInterval(() => { void refreshUpdateStatus(); }, 1000);
+      }
+      return;
+    }
+    if (state.updatePollTimer) clearInterval(state.updatePollTimer);
+    state.updatePollTimer = null;
+  }
+
+  async function refreshUpdateStatus() {
+    if (state.updateStatusInFlight) return state.updateStatusInFlight;
+    const previousStage = state.update?.stage;
+    const run = (async () => {
+      const result = await settled('/update/status');
+      if (!result.ok) return;
+      state.update = result.value || {};
+      renderUpdate();
+      if (!($('update-dialog')?.open) && previousStage === 'downloading' && ['downloaded', 'error'].includes(state.update.stage)) {
+        openUpdateDialog();
+      }
+    })();
+    state.updateStatusInFlight = run;
+    try {
+      await run;
+    } finally {
+      if (state.updateStatusInFlight === run) state.updateStatusInFlight = null;
+    }
   }
 
   function syncPolling(view) {
@@ -791,17 +1049,95 @@
     }
   }
 
-  async function checkUpdate() {
-    const stage = state.update?.stage;
+  function setUpdateActionError(error, fallbackReason) {
+    state.update = {
+      ...(state.update || {}),
+      stage: 'error',
+      message: humanError(error),
+      lastError: {
+        reason: error?.data?.reason || fallbackReason,
+        message: humanError(error),
+      },
+    };
+    renderUpdate();
+    openUpdateDialog();
+  }
+
+  async function startUpdateCheck() {
+    if (state.updateActionBusy) return;
+    state.updateActionBusy = true;
+    state.update = {
+      ...(state.update || {}),
+      stage: 'checking',
+      message: 'Checking for updates...',
+      lastError: null,
+    };
+    renderUpdate();
+    openUpdateDialog();
     try {
-      if (stage === 'available') state.update = await request('/update/download', { method: 'POST', body: '{}' });
-      else if (stage === 'downloaded') await request('/update/install', { method: 'POST', body: '{}' });
-      else state.update = await request('/update/check', { method: 'POST', body: '{}' });
+      state.update = await request('/update/check', { method: 'POST', body: '{}' });
       renderUpdate();
-      showToast(state.update?.message || '更新状态已刷新');
     } catch (error) {
-      showToast(`检查更新失败：${humanError(error)}`);
+      setUpdateActionError(error, 'UPDATE_CHECK_FAILED');
+    } finally {
+      state.updateActionBusy = false;
+      renderUpdate();
     }
+  }
+
+  async function startUpdateDownload() {
+    if (state.updateActionBusy) return;
+    state.updateActionBusy = true;
+    state.update = {
+      ...(state.update || {}),
+      stage: 'downloading',
+      message: 'Starting update download...',
+      percent: Number(state.update?.percent || 0),
+      bytesPerSecond: 0,
+      transferred: Number(state.update?.transferred || 0),
+      total: Number(state.update?.total || 0),
+      lastError: null,
+    };
+    renderUpdate();
+    openUpdateDialog();
+    try {
+      state.update = await request('/update/download', { method: 'POST', body: '{}' });
+      renderUpdate();
+      openUpdateDialog();
+    } catch (error) {
+      setUpdateActionError(error, 'UPDATE_DOWNLOAD_FAILED');
+    } finally {
+      state.updateActionBusy = false;
+      renderUpdate();
+    }
+  }
+
+  async function installUpdate() {
+    if (state.updateActionBusy || state.update?.stage !== 'downloaded') return;
+    state.updateActionBusy = true;
+    state.update = { ...(state.update || {}), stage: 'installing', message: 'Quitting and installing update...' };
+    renderUpdate();
+    try {
+      await request('/update/install', { method: 'POST', body: '{}' });
+    } catch (error) {
+      setUpdateActionError(error, 'UPDATE_INSTALL_FAILED');
+      state.updateActionBusy = false;
+      renderUpdate();
+    }
+  }
+
+  function handleUpdateButton() {
+    const stage = state.update?.stage || 'idle';
+    openUpdateDialog();
+    if (stage === 'available') void startUpdateDownload();
+    else if (stage === 'idle' || stage === 'error') void startUpdateCheck();
+  }
+
+  function handleUpdatePrimaryAction() {
+    const stage = state.update?.stage || 'idle';
+    if (stage === 'available') void startUpdateDownload();
+    else if (stage === 'downloaded') void installUpdate();
+    else if (stage === 'idle' || stage === 'error') void startUpdateCheck();
   }
 
   function setBusyButtons(busy) {
@@ -853,7 +1189,13 @@
   $('logout-dialog').addEventListener('cancel', (event) => {
     if (state.logoutBusy) event.preventDefault();
   });
-  $('update-button').addEventListener('click', checkUpdate);
+  $('update-button').addEventListener('click', handleUpdateButton);
+  $('update-close').addEventListener('click', closeUpdateDialog);
+  $('update-secondary-action').addEventListener('click', closeUpdateDialog);
+  $('update-primary-action').addEventListener('click', handleUpdatePrimaryAction);
+  $('update-dialog').addEventListener('cancel', (event) => {
+    if (state.update?.stage === 'installing') event.preventDefault();
+  });
   $('management-open').addEventListener('click', () => { void openManagement(); });
   $('agent-switch-open').addEventListener('click', () => { void openAgentSwitch(); });
   $('agent-switch-close').addEventListener('click', (event) => {

--- a/tests/dashboard-connector.test.ts
+++ b/tests/dashboard-connector.test.ts
@@ -54,6 +54,26 @@ test('Connector local management restores channels and gives logs a full workspa
   assert.doesNotMatch(html, /<details class="diagnostics-panel"/);
 });
 
+test('Connector restores visible desktop update progress and explicit install confirmation', () => {
+  assert.match(html, /id="update-dialog"/);
+  assert.match(html, /role="progressbar"/);
+  assert.match(html, /id="update-current-version"/);
+  assert.match(html, /id="update-available-version"/);
+  assert.match(html, /id="update-speed"/);
+  assert.match(html, /id="update-remaining"/);
+  assert.match(script, /安装并重启/);
+  assert.match(styles, /\.update-dialog::backdrop/);
+  assert.match(styles, /\.update-progress-track\.indeterminate/);
+  assert.match(styles, /\.compact-card \.button\.update-active/);
+  assert.match(script, /下载 \$\{Math\.round\(percent\)\}%/);
+  assert.match(script, /settled\('\/update\/status'\)/);
+  assert.match(script, /setInterval\(\(\) => \{ void refreshUpdateStatus\(\); \}, 1000\)/);
+  assert.match(script, /request\('\/update\/download'/);
+  assert.match(script, /request\('\/update\/install'/);
+  assert.match(script, /previousStage === 'downloading'[\s\S]*\['downloaded', 'error'\]/);
+  assert.match(script, /update-primary-action.*handleUpdatePrimaryAction/s);
+});
+
 test('Connector client uses real lifecycle APIs and remains syntax-valid', () => {
   assert.doesNotThrow(() => new vm.Script(script));
   assert.match(script, /\/cats\/bootstrap\/status/);


### PR DESCRIPTION
## Summary

- restore a visible update dialog for the simplified CatsCo Connector Dashboard
- show version transition, download percentage, transferred size, speed, and estimated remaining time
- keep progress accessible from the sidebar while downloading, and reopen the dialog when download completes or fails
- require an explicit “安装并重启” confirmation after the update package is ready
- add a regression test for the update-progress UI contract and updater API wiring

## Why

The updater backend continued to expose download progress after the Dashboard reduction, but the new Connector UI only showed a button and toast. Packaged users therefore could not tell whether an update was downloading, blocked, or stalled.

## Verification

- node --import tsx --test tests/dashboard-connector.test.ts (15/15 passed)
- npm run build (passed)
- browser lifecycle test with mocked update APIs (passed: download progress, background hide, completion reopen, install confirmation)
- npm run test:runtime (1596 passed, 10 skipped, 2 unrelated failures because jq is not installed in the Windows test environment)
- git diff --check (passed)