### PR TITLE
fix(worker-image): report builder bootstrap phases

### DIFF
--- a/.github/workflows/worker-image.yml
+++ b/.github/workflows/worker-image.yml
@@ -124,8 +124,10 @@ jobs:
           endpoint="https://tos-s3-${TOS_WORKER_REGION}.volces.com"
           key="update/worker/.bake/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/$(basename "$WORKER_ARTIFACT_PATH")"
           script_key="update/worker/.bake/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/prepare-image.sh"
+          status_key="update/worker/.bake/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/bootstrap-status.json"
           echo "key=$key" >> "$GITHUB_OUTPUT"
           echo "script_key=$script_key" >> "$GITHUB_OUTPUT"
+          echo "status_key=$status_key" >> "$GITHUB_OUTPUT"
           aws s3 cp "$WORKER_ARTIFACT_PATH" "s3://${TOS_WORKER_BUCKET}/${key}" \
             --endpoint-url "$endpoint" --acl private \
             --metadata "sha256=${WORKER_ARTIFACT_SHA256}" --only-show-errors
@@ -138,11 +140,69 @@ jobs:
             --endpoint-url "$endpoint" --expires-in 21600)"
           script_url="$(aws s3 presign "s3://${TOS_WORKER_BUCKET}/${script_key}" \
             --endpoint-url "$endpoint" --expires-in 21600)"
+          status_get_url="$(aws s3 presign "s3://${TOS_WORKER_BUCKET}/${status_key}" \
+            --endpoint-url "$endpoint" --expires-in 21600)"
+          status_put_url="$(python3 - "$status_key" <<'PY'
+          import datetime
+          import hashlib
+          import hmac
+          import os
+          import sys
+          import urllib.parse
+
+          key = sys.argv[1]
+          access_key = os.environ["AWS_ACCESS_KEY_ID"]
+          secret_key = os.environ["AWS_SECRET_ACCESS_KEY"]
+          region = os.environ["TOS_WORKER_REGION"]
+          bucket = os.environ["TOS_WORKER_BUCKET"]
+          service = "s3"
+          host = f"{bucket}.tos-s3-{region}.volces.com"
+          now = datetime.datetime.now(datetime.timezone.utc)
+          amz_date = now.strftime("%Y%m%dT%H%M%SZ")
+          date_stamp = now.strftime("%Y%m%d")
+          scope = f"{date_stamp}/{region}/{service}/aws4_request"
+          credential = f"{access_key}/{scope}"
+          canonical_uri = "/" + "/".join(
+              urllib.parse.quote(part, safe="-_.~") for part in key.split("/")
+          )
+          params = {
+              "X-Amz-Algorithm": "AWS4-HMAC-SHA256",
+              "X-Amz-Credential": credential,
+              "X-Amz-Date": amz_date,
+              "X-Amz-Expires": "21600",
+              "X-Amz-SignedHeaders": "host",
+          }
+          canonical_query = urllib.parse.urlencode(sorted(params.items()), quote_via=urllib.parse.quote)
+          canonical_request = "\n".join([
+              "PUT", canonical_uri, canonical_query, f"host:{host}\n", "host", "UNSIGNED-PAYLOAD"
+          ])
+          string_to_sign = "\n".join([
+              "AWS4-HMAC-SHA256",
+              amz_date,
+              scope,
+              hashlib.sha256(canonical_request.encode()).hexdigest(),
+          ])
+
+          def sign(key_bytes, message):
+              return hmac.new(key_bytes, message.encode(), hashlib.sha256).digest()
+
+          signing_key = sign(
+              sign(sign(sign(("AWS4" + secret_key).encode(), date_stamp), region), service),
+              "aws4_request",
+          )
+          signature = hmac.new(signing_key, string_to_sign.encode(), hashlib.sha256).hexdigest()
+          print(f"https://{host}{canonical_uri}?{canonical_query}&X-Amz-Signature={signature}")
+          PY
+          )"
           echo "::add-mask::$url"
           echo "::add-mask::$script_url"
+          echo "::add-mask::$status_get_url"
+          echo "::add-mask::$status_put_url"
           echo "url=$url" >> "$GITHUB_OUTPUT"
           echo "script_url=$script_url" >> "$GITHUB_OUTPUT"
           echo "script_sha256=$script_sha" >> "$GITHUB_OUTPUT"
+          echo "status_get_url=$status_get_url" >> "$GITHUB_OUTPUT"
+          echo "status_put_url=$status_put_url" >> "$GITHUB_OUTPUT"
 
       - name: Install pinned Tianyi Cloud CLI package
         timeout-minutes: 3
@@ -449,6 +509,8 @@ jobs:
           WORKER_ARTIFACT_URL: ${{ steps.artifact_transport.outputs.url }}
           WORKER_PREPARE_SCRIPT_URL: ${{ steps.artifact_transport.outputs.script_url }}
           WORKER_PREPARE_SCRIPT_SHA256: ${{ steps.artifact_transport.outputs.script_sha256 }}
+          WORKER_BOOTSTRAP_STATUS_GET_URL: ${{ steps.artifact_transport.outputs.status_get_url }}
+          WORKER_BOOTSTRAP_STATUS_PUT_URL: ${{ steps.artifact_transport.outputs.status_put_url }}
         run: |
           if ([string]::IsNullOrWhiteSpace($env:WORKER_PROJECT_ID)) {
             throw 'CTYUN_WORKER_PROJECT_ID is required for image bake'
@@ -464,6 +526,8 @@ jobs:
             -ArtifactUrl $env:WORKER_ARTIFACT_URL `
             -PrepareScriptUrl $env:WORKER_PREPARE_SCRIPT_URL `
             -PrepareScriptSha256 $env:WORKER_PREPARE_SCRIPT_SHA256 `
+            -BootstrapStatusGetUrl $env:WORKER_BOOTSTRAP_STATUS_GET_URL `
+            -BootstrapStatusPutUrl $env:WORKER_BOOTSTRAP_STATUS_PUT_URL `
             -BuildNumber $env:GITHUB_RUN_NUMBER `
             -BuildAttempt $env:GITHUB_RUN_ATTEMPT `
             -BuildIdentity $env:GITHUB_RUN_ID `
@@ -563,10 +627,11 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.VOLC_TOS_WORKER_PUBLISH_SECRET_ACCESS_KEY || secrets.VOLC_TOS_SECRET_ACCESS_KEY }}
           STAGED_ARTIFACT_KEY: ${{ steps.artifact_transport.outputs.key }}
           STAGED_SCRIPT_KEY: ${{ steps.artifact_transport.outputs.script_key }}
+          STAGED_STATUS_KEY: ${{ steps.artifact_transport.outputs.status_key }}
         run: |
           set -euo pipefail
           endpoint="https://tos-s3-${TOS_WORKER_REGION}.volces.com"
-          for key in "$STAGED_ARTIFACT_KEY" "$STAGED_SCRIPT_KEY"; do
+          for key in "$STAGED_ARTIFACT_KEY" "$STAGED_SCRIPT_KEY" "$STAGED_STATUS_KEY"; do
             aws s3 rm "s3://${TOS_WORKER_BUCKET}/${key}" \
               --endpoint-url "$endpoint" --only-show-errors
             if aws s3api head-object --bucket "$TOS_WORKER_BUCKET" \

--- a/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
+++ b/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
@@ -34,6 +34,8 @@ param(
     [string]$ArtifactUrl = "",
     [string]$PrepareScriptUrl = "",
     [string]$PrepareScriptSha256 = "",
+    [string]$BootstrapStatusPutUrl = "",
+    [string]$BootstrapStatusGetUrl = "",
     [string]$BuildNumber = "",
     [string]$BuildAttempt = "1",
     [string]$BuildIdentity = "",
@@ -58,6 +60,10 @@ param(
     [int]$PollIntervalSeconds = 0,
     [ValidateRange(5, 300)]
     [int]$ProgressIntervalSeconds = 30,
+    [ValidateRange(1, 30)]
+    [int]$BootstrapStartTimeoutMinutes = 5,
+    [ValidateRange(60, 1800)]
+    [int]$BootstrapStaleSeconds = 180,
     [switch]$BaseImageHardened,
     [switch]$WaitForLateResources
 )
@@ -86,6 +92,10 @@ $script:CleanupDeadline = $null
 $script:InCleanup = $false
 $script:StartedAt = Get-Date
 $script:LastProgressAt = $script:StartedAt
+$script:BootstrapMonitorStartedAt = $null
+$script:LastBootstrapPayload = ""
+$script:LastBootstrapUpdateAt = $null
+$script:LastBootstrapPhase = ""
 
 function Write-BakeProgress {
     param(
@@ -120,6 +130,74 @@ function Wait-PollInterval {
         $DefaultSeconds
     }
     Start-Sleep -Seconds $seconds
+}
+
+function Test-BootstrapStatus {
+    if ([string]::IsNullOrWhiteSpace($BootstrapStatusGetUrl)) {
+        return
+    }
+
+    $now = Get-Date
+    if (-not $script:BootstrapMonitorStartedAt) {
+        $script:BootstrapMonitorStartedAt = $now
+    }
+
+    $payload = ""
+    try {
+        $response = Invoke-WebRequest `
+            -Uri $BootstrapStatusGetUrl `
+            -Method Get `
+            -TimeoutSec 15 `
+            -Headers @{ "Cache-Control" = "no-cache" }
+        $payload = [string]$response.Content
+    } catch {
+        # A status object does not exist until cloud-init starts. Network and
+        # 404 failures are handled by the bounded missing/stale checks below.
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($payload)) {
+        if ($payload -ne $script:LastBootstrapPayload) {
+            $script:LastBootstrapPayload = $payload
+            $script:LastBootstrapUpdateAt = $now
+        }
+        try {
+            $status = $payload | ConvertFrom-Json
+        } catch {
+            throw "Builder bootstrap returned malformed status telemetry"
+        }
+        $state = ([string]$status.state).ToLowerInvariant()
+        $phase = [string]$status.phase
+        if ($state -notin @("running", "succeeded", "failed") -or [string]::IsNullOrWhiteSpace($phase)) {
+            throw "Builder bootstrap returned invalid status telemetry"
+        }
+        $age = [Math]::Max(0, [int](($now - $script:LastBootstrapUpdateAt).TotalSeconds))
+        if ($phase -ne $script:LastBootstrapPhase -or $state -ne "running") {
+            Write-BakeProgress -Phase "builder-bootstrap" -Detail ("state={0} phase={1} heartbeat_age_s={2}" -f $state, $phase, $age) -Force
+            $script:LastBootstrapPhase = $phase
+        }
+        if ($state -eq "failed") {
+            $exitCode = [string]$status.exit_code
+            $line = [string]$status.line
+            throw "Builder bootstrap failed: phase=$phase exit_code=$exitCode line=$line"
+        }
+        if ($age -gt $BootstrapStaleSeconds) {
+            throw "Builder bootstrap heartbeat is stale: phase=$phase age_seconds=$age"
+        }
+        return
+    }
+
+    if ($script:LastBootstrapUpdateAt) {
+        $staleSeconds = [int](($now - $script:LastBootstrapUpdateAt).TotalSeconds)
+        if ($staleSeconds -gt $BootstrapStaleSeconds) {
+            throw "Builder bootstrap status is unreachable or stale: phase=$script:LastBootstrapPhase age_seconds=$staleSeconds"
+        }
+        return
+    }
+
+    $missingSeconds = [int](($now - $script:BootstrapMonitorStartedAt).TotalSeconds)
+    if ($missingSeconds -gt ($BootstrapStartTimeoutMinutes * 60)) {
+        throw "Builder bootstrap did not publish initial status within $BootstrapStartTimeoutMinutes minutes"
+    }
 }
 
 function Invoke-External {
@@ -400,7 +478,8 @@ function Wait-ForInstance {
     param(
         [Parameter(Mandatory = $true)]
         [string[]]$States,
-        [switch]$RequireIP
+        [switch]$RequireIP,
+        [switch]$MonitorBootstrap
     )
 
     $deadline = Get-BoundedDeadline `
@@ -414,6 +493,9 @@ function Wait-ForInstance {
         Write-BakeProgress -Phase "builder-wait" -Detail ("state={0} ip_present={1}" -f $state, (-not [string]::IsNullOrWhiteSpace($ip))) -Force
         if ($States -contains $state -and (-not $RequireIP -or $ip)) {
             return $instance
+        }
+        if ($MonitorBootstrap) {
+            Test-BootstrapStatus
         }
         Wait-PollInterval -DefaultSeconds 8
     }
@@ -1122,6 +1204,17 @@ if ($Mode -eq "Create") {
     if ($PrepareScriptSha256 -notmatch "^[0-9a-fA-F]{64}$") {
         throw "PrepareScriptSha256 must be a SHA-256 hex digest in Create mode"
     }
+    if ([string]::IsNullOrWhiteSpace($BootstrapStatusPutUrl) -ne [string]::IsNullOrWhiteSpace($BootstrapStatusGetUrl)) {
+        throw "BootstrapStatusPutUrl and BootstrapStatusGetUrl must be supplied together"
+    }
+    foreach ($statusUrl in @($BootstrapStatusPutUrl, $BootstrapStatusGetUrl)) {
+        if (-not [string]::IsNullOrWhiteSpace($statusUrl)) {
+            $statusUri = $null
+            if (-not [Uri]::TryCreate($statusUrl, [UriKind]::Absolute, [ref]$statusUri) -or $statusUri.Scheme -ne "https") {
+                throw "Bootstrap status URLs must be absolute HTTPS URLs in Create mode"
+            }
+        }
+    }
 }
 
 $plan = [ordered]@{
@@ -1288,6 +1381,9 @@ try {
     $prepareScriptUrlBase64 = [Convert]::ToBase64String(
         [Text.Encoding]::UTF8.GetBytes($PrepareScriptUrl)
     )
+    $statusPutUrlBase64 = [Convert]::ToBase64String(
+        [Text.Encoding]::UTF8.GetBytes($BootstrapStatusPutUrl)
+    )
     $baseImageHardenedValue = $BaseImageHardened.IsPresent.ToString().ToLowerInvariant()
     $artifactName = "catsco-worker-$releaseId-linux-x64.tar.gz"
     $bootstrapScript = @"
@@ -1297,12 +1393,49 @@ export CATSCO_BASE_IMAGE_HARDENED='$baseImageHardenedValue'
 exec > >(tee -a /var/log/catsco-image-build.log) 2>&1
 artifact_url="`$(printf '%s' '$artifactUrlBase64' | base64 -d)"
 prepare_script_url="`$(printf '%s' '$prepareScriptUrlBase64' | base64 -d)"
-phase() {
-  printf '%s %s\n' "`$(date -Is)" "`$1" | tee /run/catsco-image-bootstrap-phase
+status_put_url="`$(printf '%s' '$statusPutUrlBase64' | base64 -d)"
+status_file=/run/catsco-image-bootstrap-phase
+heartbeat_pid=''
+publish_status() {
+  local state="`$1" phase_name="`$2" exit_code="`${3:-0}" line="`${4:-0}"
+  [[ -n "`$status_put_url" ]] || return 0
+  printf '{"state":"%s","phase":"%s","exit_code":%s,"line":%s,"epoch":%s}\n' \
+    "`$state" "`$phase_name" "`$exit_code" "`$line" "`$(date +%s)" >/run/catsco-image-bootstrap-status.json
+  curl --fail --silent --request PUT --connect-timeout 10 --max-time 20 \
+    --retry 2 --retry-all-errors --data-binary @/run/catsco-image-bootstrap-status.json \
+    "`$status_put_url" >/dev/null 2>&1 || true
 }
+phase() {
+  printf '%s\n' "`$1" | tee "`$status_file"
+  publish_status running "`$1"
+}
+heartbeat() {
+  while true; do
+    current_phase="`$(cat "`$status_file" 2>/dev/null || printf bootstrap-start)"
+    publish_status running "`$current_phase"
+    sleep 30
+  done
+}
+finish() {
+  rc=`$?
+  trap - EXIT
+  if [[ -n "`$heartbeat_pid" ]]; then
+    kill "`$heartbeat_pid" >/dev/null 2>&1 || true
+    wait "`$heartbeat_pid" 2>/dev/null || true
+  fi
+  if [[ `$rc -ne 0 ]]; then
+    current_phase="`$(cat "`$status_file" 2>/dev/null || printf bootstrap-start)"
+    publish_status failed "`$current_phase" "`$rc" "`${BASH_LINENO[0]:-0}"
+  fi
+  exit "`$rc"
+}
+trap finish EXIT
 curl_common=(--fail --silent --show-error --location --ipv4 \
   --connect-timeout 20 --max-time 900 --retry 8 --retry-all-errors \
   --retry-delay 5 --retry-max-time 1800)
+phase bootstrap-start
+heartbeat &
+heartbeat_pid=`$!
 phase download-prepare-script
 curl "`${curl_common[@]}" \
   "`$prepare_script_url" --output /tmp/prepare-image.sh
@@ -1312,6 +1445,7 @@ phase download-worker-artifact
 curl "`${curl_common[@]}" \
   "`$artifact_url" --output '/tmp/$artifactName'
 phase prepare-worker-artifact
+CATSCO_IMAGE_PHASE_FILE="`$status_file" \
 bash /tmp/prepare-image.sh \
   --artifact '/tmp/$artifactName' \
   --sha256 '$ArtifactSha256' \
@@ -1319,9 +1453,10 @@ bash /tmp/prepare-image.sh \
   --commit '$commit'
 rm -f '/tmp/$artifactName'
 phase finalize-worker-image
-bash /tmp/prepare-image.sh --finalize
+CATSCO_IMAGE_PHASE_FILE="`$status_file" bash /tmp/prepare-image.sh --finalize
 sync
 phase shutdown
+publish_status succeeded shutdown
 shutdown -h now
 "@
     # Tianyi's cloud-init images are more reliable when userData is an
@@ -1396,9 +1531,9 @@ runcmd:
     Write-BakeProgress -Phase "builder-resolved" -Detail "builder_id=$script:BuilderID" -Force
 
     # cloud-init powers off only after artifact verification, preparation and
-    # finalization all succeed. A failed bootstrap stays running, times out,
-    # and is removed by the existing compensating cleanup path.
-    Wait-ForInstance -States @("stopped", "shutoff") | Out-Null
+    # finalization all succeed. Failed or stale bootstrap telemetry aborts this
+    # wait early and enters the existing compensating cleanup path.
+    Wait-ForInstance -States @("stopped", "shutoff") -MonitorBootstrap | Out-Null
     Write-BakeProgress -Phase "builder-stopped" -Detail "cloud-init completed; starting image capture" -Force
 
     $script:ImageCreateAttempted = $true

--- a/ops/ctyun-worker-image/README.md
+++ b/ops/ctyun-worker-image/README.md
@@ -10,11 +10,17 @@ session, skill installation, or runtime `.env`.
 - Only stable `vX.Y.Z` tags whose commit is contained in `main` may bake an
   image automatically. Manual runs are restricted to `main` and default to
   not baking until the operator explicitly checks the input.
-- The source-free worker artifact and pinned preparation script are staged as
+- The source-free worker artifact, pinned preparation script, and per-run
+  bootstrap status object are staged as
   private, per-run TOS objects with short-lived signed URLs. The private
-  builder downloads them through cloud-init, and the workflow deletes both
+  builder downloads them through cloud-init, and the workflow deletes all three
   objects after the bake. They are never public or retained as GitHub Actions
   artifacts.
+- The builder receives only short-lived signed URLs. It writes its current
+  bootstrap phase every 30 seconds to the per-run status object; the runner
+  prints phase changes live and fails early when bootstrap reports an error,
+  does not start, or stops heartbeating. No long-lived TOS credential is placed
+  on the builder.
 - A Tianyi Cloud private ECS image is baked only for a stable release selected
   for provisioning, or when the base OS/system dependencies change.
 - `CTYUN_AUTO_BAKE_WORKER_IMAGE=true` makes every stable tag bake an image;

--- a/ops/ctyun-worker-image/prepare-image.sh
+++ b/ops/ctyun-worker-image/prepare-image.sh
@@ -20,6 +20,13 @@ die() {
   exit 1
 }
 
+image_phase() {
+  if [[ -n "${CATSCO_IMAGE_PHASE_FILE:-}" ]]; then
+    printf '%s\n' "$1" >"$CATSCO_IMAGE_PHASE_FILE"
+  fi
+  printf 'image_phase=%s\n' "$1"
+}
+
 while (($#)); do
   case "$1" in
     --artifact) ARTIFACT="${2:-}"; shift 2 ;;
@@ -39,6 +46,7 @@ if [[ -z "${CATSCO_PREPARE_SKIP_ROOT_CHECK:-}" ]]; then
 fi
 
 if [[ $FINALIZE -eq 1 ]]; then
+  image_phase finalize-cleanup
   systemctl disable --now catsco-agent.service 2>/dev/null || true
   rm -rf \
     /srv/catsco-agent/.env \
@@ -76,6 +84,7 @@ ACTUAL_SHA256="$(sha256sum "$ARTIFACT" | awk '{print $1}')"
 [[ "${ACTUAL_SHA256,,}" == "${SHA256,,}" ]] || die "artifact checksum mismatch"
 
 export DEBIAN_FRONTEND=noninteractive
+image_phase platform-check
 
 # --- Platform hardening (encoded from deploy-catsco-linux-agent skill, 2026-08) ---
 # Every fault below was hit on live Tianyi workers provisioned from the same base
@@ -118,6 +127,7 @@ if [[ "${CATSCO_BASE_IMAGE_HARDENED:-false}" == "true" ]] && platform_hardening_
   printf 'platform_hardening=already-satisfied\n'
 else
   printf 'platform_hardening=upgrade-required\n'
+  image_phase platform-repair
 
 # 1. Repair corrupted dpkg file lists ("missing final newline") BEFORE any
 #    apt/dpkg transaction. These images can ship broken
@@ -133,7 +143,9 @@ if ! dpkg --configure -a >/tmp/catsco-dpkg-configure-first.log 2>&1; then
   die "dpkg configuration failed after file-list repair; see /tmp/catsco-dpkg-configure-first.log"
 fi
 
+image_phase apt-update
 apt-get update || die "apt-get update failed"
+image_phase base-packages
 apt-get install -y --no-install-recommends \
   ca-certificates \
   curl \
@@ -163,6 +175,7 @@ mask_unit() {
     die "failed to mask $unit (expected /etc/systemd/system/$unit -> /dev/null); refusing to bake an unhardened image"
   fi
 }
+image_phase systemd-preflight
 mask_unit fwupd.service
 mask_unit fwupd-refresh.service
 mask_unit fwupd-refresh.timer
@@ -178,6 +191,7 @@ timeout 30 systemctl reset-failed fwupd-refresh.service >/dev/null 2>&1 || true
 #    finish dpkg configuration, retry with the minimal set, and then VERIFY the
 #    installed versions with dpkg --compare-versions. Failing to reach the
 #    known-safe versions blocks the bake.
+image_phase platform-upgrade
 if ! apt-get install --only-upgrade -y \
   systemd \
   systemd-sysv \
@@ -208,6 +222,7 @@ fi
 # instead of being silently tolerated — producing an image with an unconfigured
 # dpkg database is not acceptable, and a hung manager is already bounded by the
 # outer timeouts.
+image_phase dpkg-finalize
 if ! dpkg --configure -a >/tmp/catsco-dpkg-configure-final.log 2>&1; then
   die "dpkg database not fully configured after platform upgrade; see /tmp/catsco-dpkg-configure-final.log"
 fi
@@ -235,6 +250,7 @@ fi
 #    non-empty bootable kernel image actually exists under /boot and that grub
 #    is regenerated; the running kernel is not a reliable signal because the
 #    bake never reboots.
+image_phase kernel-upgrade
 if ! apt-get install -y --no-install-recommends \
   linux-generic linux-image-generic \
   >/tmp/catsco-kernel-upgrade.log 2>&1; then
@@ -260,6 +276,7 @@ fi
 #    Tianyi/华南 hosts is slow and has produced truncated/corrupted tarballs
 #    (e.g. TS1127 from a truncated lib.es2017.string.d.ts). Set it for both the
 #    service user and root so the first npm ci/install never needs manual setup.
+image_phase worker-install
 printf 'registry=https://registry.npmmirror.com\n' >/root/.npmrc
 chmod 0644 /root/.npmrc
 id catsco-agent >/dev/null 2>&1 || useradd \
@@ -358,6 +375,7 @@ EOF
 systemctl daemon-reload >/dev/null 2>&1 || true
 systemctl disable --now catsco-agent.service 2>/dev/null || true
 
+image_phase worker-validate
 sudo -u catsco-agent -- bash -c '
   cd /opt/catsco/current
   runtime/node/bin/node -e '\''require("sharp"); const canvas = require("@napi-rs/canvas"); canvas.createCanvas(2, 2); require("deasync")'\''
@@ -365,6 +383,7 @@ sudo -u catsco-agent -- bash -c '
   runtime/node/bin/npm --version >/dev/null
 '
 
+image_phase provenance
 dpkg-query -W -f='${Package}\t${Version}\n' | LC_ALL=C sort >/etc/catsco-image-packages.txt
 chmod 0644 /etc/catsco-image-packages.txt
 

--- a/tests/worker-image-pipeline.test.ts
+++ b/tests/worker-image-pipeline.test.ts
@@ -560,9 +560,18 @@ describe("Tianyi Cloud worker image pipeline", () => {
     assert.match(imageOrchestrator, /phase\(\) \{/);
     assert.match(imageOrchestrator, /phase download-prepare-script/);
     assert.match(imageOrchestrator, /phase shutdown/);
+    assert.match(imageOrchestrator, /publish_status failed/);
+    assert.match(imageOrchestrator, /heartbeat_age_s/);
+    assert.match(imageOrchestrator, /Builder bootstrap failed/);
+    assert.match(imageOrchestrator, /Builder bootstrap heartbeat is stale/);
+    assert.match(imageOrchestrator, /Builder bootstrap status is unreachable or stale/);
+    assert.match(imageOrchestrator, /-MonitorBootstrap/);
     assert.match(imageOrchestrator, /shutdown -h now/);
     assert.doesNotMatch(imageOrchestrator, /Wait-ForSsh|\bscp\b|"--extIP", "1"/);
     assert.match(imagePreparer, /platform_hardening=already-satisfied/);
+    assert.match(imagePreparer, /image_phase platform-upgrade/);
+    assert.match(imagePreparer, /image_phase kernel-upgrade/);
+    assert.match(imagePreparer, /image_phase worker-validate/);
     assert.match(workflow, /CTYUN_WORKER_BASE_IMAGE_HARDENED/);
   });
 
@@ -584,6 +593,8 @@ describe("Tianyi Cloud worker image pipeline", () => {
     assert.match(workflow, /-ArtifactUrl \$env:WORKER_ARTIFACT_URL/);
     assert.match(workflow, /-PrepareScriptUrl \$env:WORKER_PREPARE_SCRIPT_URL/);
     assert.match(workflow, /-PrepareScriptSha256 \$env:WORKER_PREPARE_SCRIPT_SHA256/);
+    assert.match(workflow, /-BootstrapStatusGetUrl \$env:WORKER_BOOTSTRAP_STATUS_GET_URL/);
+    assert.match(workflow, /-BootstrapStatusPutUrl \$env:WORKER_BOOTSTRAP_STATUS_PUT_URL/);
     assert.match(workflow, /-BuildNumber \$env:GITHUB_RUN_NUMBER/);
     assert.match(workflow, /-BuildIdentity \$env:GITHUB_RUN_ID/);
     assert.match(workflow, /WORKER_PROJECT_ID: \$\{\{ vars\.CTYUN_WORKER_PROJECT_ID \}\}/);
@@ -619,9 +630,12 @@ describe("Tianyi Cloud worker image pipeline", () => {
     );
     assert.match(workflow, /Stage private artifact for the builder/);
     assert.match(workflow, /aws s3 presign/);
+    assert.match(workflow, /bootstrap-status\.json/);
+    assert.match(workflow, /X-Amz-SignedHeaders/);
     assert.match(workflow, /--acl private/);
     assert.match(workflow, /Remove staged private artifact/);
     assert.match(workflow, /aws s3 rm/);
+    assert.match(workflow, /STAGED_STATUS_KEY/);
     assert.doesNotMatch(workflow, /public-read|upload-artifact/);
     assert.doesNotMatch(workflow, /^    env:\s*\n\s+CTYUN_AK:/m);
     assert.match(
@@ -901,6 +915,10 @@ process.exit(result.status ?? 1);
             "https://example.test/prepare-image.sh?signature=test",
             "-PrepareScriptSha256",
             crypto.createHash("sha256").update("prepare-image").digest("hex"),
+            "-BootstrapStatusGetUrl",
+            "https://example.test/bootstrap-status.json?signature=get-test",
+            "-BootstrapStatusPutUrl",
+            "https://example.test/bootstrap-status.json?signature=put-test",
             "-BuildNumber",
             buildNumber,
             "-BuildAttempt",
@@ -1041,11 +1059,14 @@ process.exit(result.status ?? 1);
       assert.match(decodedBootstrap, /--max-time 900/);
       assert.match(decodedBootstrap, /phase download-prepare-script/);
       assert.match(decodedBootstrap, /phase shutdown/);
+      assert.match(decodedBootstrap, /publish_status failed/);
+      assert.match(decodedBootstrap, /heartbeat &/);
       assert.match(decodedBootstrap, /shutdown -h now/);
       assert.match(decodedBootstrap, new RegExp(artifactSha));
       assert.match(decodedBootstrap, /sha256sum --check --strict/);
       assert.doesNotMatch(bootstrap, /example\.test\/private-worker/);
       assert.doesNotMatch(bootstrap, /example\.test\/prepare-image/);
+      assert.doesNotMatch(bootstrap, /example\.test\/bootstrap-status/);
       assert.doesNotMatch(bootstrap, /\bscp\b|\bssh\b/);
       assert.equal(finalState.imageSourceServerID, "instance-1");
       assert.match(


### PR DESCRIPTION
## Summary
- publish per-run builder bootstrap phase heartbeats through a private TOS status object
- fail early when bootstrap reports an error, never starts, or stops heartbeating
- report apt/systemd/kernel/worker preparation phases in live bake logs and clean all status artifacts

## Validation
- npm run build
- npx tsx --test tests/worker-image-pipeline.test.ts (11/11)
- PowerShell and bash syntax checks
- runtime suite: 1586 passed; 6 existing local baseline failures (missing pdf-parse fixtures and grep abort timing)