### PR TITLE
fix(skillhub): retry transient workspace renames

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -1,8 +1,28 @@
 # Skills 目录说明
 
-## 统一的 Skill 管理
+## 仓库资源与运行时工作区
 
-所有 Skills 统一存放在项目根目录的 `skills/` 文件夹中。
+项目根目录的 `skills/` 是跟随代码发布的 seed/template Skill 资源目录，不是
+Electron 开发版或打包版默认使用的用户 Skill 工作区。
+
+当前生效目录由运行时 userData 决定：
+
+- Electron 开发版：`<项目根目录>/.dev-user-data/skills`；
+- Electron 打包版：`<Electron app.getPath('userData')>/skills`；
+- CLI/服务器：`<XIAOBA_USER_DATA_DIR>/skills`，也可以由 `XIAOBA_SKILLS_DIR` 显式覆盖；
+- 未设置任何 userData 环境变量的原始 CLI 才会回退到 `<cwd>/skills`。
+
+不要在运行 Electron 版时通过编辑仓库根目录 `skills/` 来判断当前 Agent 的
+Skill 状态。WebApp 的“本地工作区”会显示真正生效的绝对路径。
+
+## 按 Bot 隔离
+
+运行时只有当前 Bot 占用 `<userData>/skills` 这个活动入口。切换 Bot 时：
+
+- 上一个 Bot 的工作区停放到 `<userData>/data/bot-skills/workspaces/<botId>`；
+- 目标 Bot 的工作区再移回 `<userData>/skills`；
+- `sync-base/<botId>.json` 是同步基线清单，不是完整文件备份；
+- `local-pending/<botId>/...` 才是需要人工处理时保留的可恢复快照。
 
 ## 目录结构
 
@@ -37,7 +57,7 @@ catsco skill install-github owner/repo
 catsco skill install-github obra/superpowers
 ```
 
-Skill 会被克隆到 `skills/` 目录。
+Skill 会被克隆到当前运行时的 `skills/` 工作区。
 
 ### 查看 Skill 详情
 
@@ -58,7 +78,8 @@ catsco skill remove <skill-name> -f
 
 ## 手动添加 Skill
 
-直接在 `skills/` 目录下创建文件夹，每个 Skill 包含一个 `SKILL.md` 文件：
+直接在当前运行时 `skills/` 工作区下创建文件夹，每个 Skill 包含一个
+`SKILL.md` 文件：
 
 ```
 skills/
@@ -82,7 +103,7 @@ invocable: user
 
 ## 注意事项
 
-- ✅ 所有 Skills 统一在 `skills/` 目录
+- ✅ 当前 Bot 的 Skills 统一从当前运行时 `skills/` 工作区加载
 - ✅ 每个 Skill 一个独立文件夹
 - ✅ 必须包含 `SKILL.md` 文件
 - ✅ 支持从 GitHub 直接安装
@@ -91,7 +112,8 @@ invocable: user
 
 ## 迁移现有 Skills
 
-如果你之前的 Skills 在其他位置（如 `.xiaoba/skills/` 或 `~/.xiaoba/skills/`），请手动移动到 `skills/` 目录：
+如果你之前的 Skills 在其他位置（如 `.xiaoba/skills/` 或 `~/.xiaoba/skills/`），请手动移动到
+当前运行时的 `skills/` 工作区：
 
 ```bash
 # 示例：迁移 .xiaoba/skills/ 中的 Skills

--- a/src/bot-skills/sync-service.ts
+++ b/src/bot-skills/sync-service.ts
@@ -27,6 +27,7 @@ import {
   writeBotSkillLocalMarker,
 } from './local-manifest';
 import { BotPrivateSkillClient } from './private-package-client';
+import { renameBotSkillWorkspaceSync } from './workspace-fs';
 import type {
   BotSkillPackage,
   BotSkillPackageFile,
@@ -189,7 +190,7 @@ export class BotSkillSyncService {
       throw new Error('Interrupted Bot Skill restore has ambiguous active and backup workspaces');
     }
     if (!fs.existsSync(journal.skillsRoot) && fs.existsSync(journal.backup)) {
-      fs.renameSync(journal.backup, journal.skillsRoot);
+      renameBotSkillWorkspaceSync(journal.backup, journal.skillsRoot);
     }
     if (fs.existsSync(journal.stage)) fs.rmSync(journal.stage, { recursive: true, force: true });
     fs.rmSync(journalPath, { force: true });
@@ -953,7 +954,7 @@ export class BotSkillSyncService {
       if (fs.existsSync(this.skillsRoot)) {
         await options.validateScope?.();
         this.writeRestoreJournal({ stage, backup, phase: 'backup_pending' });
-        fs.renameSync(this.skillsRoot, backup);
+        renameBotSkillWorkspaceSync(this.skillsRoot, backup);
         backedUp = true;
         if (options.pendingSnapshot && hasWorkspaceEntries(backup)) {
           const snapshot = snapshotPendingBotSkillWorkspace({
@@ -973,7 +974,7 @@ export class BotSkillSyncService {
       }
       this.writeRestoreJournal({ stage, backup, phase: 'backed_up' });
       this.writeRestoreJournal({ stage, backup, phase: 'activation_pending' });
-      fs.renameSync(stage, this.skillsRoot);
+      renameBotSkillWorkspaceSync(stage, this.skillsRoot);
       activatedStage = true;
       this.writeRestoreJournal({ stage, backup, phase: 'activated' });
       this.acceptCloudDefinition(cloud);
@@ -1002,7 +1003,7 @@ export class BotSkillSyncService {
         fs.rmSync(this.skillsRoot, { recursive: true, force: true });
       }
       if (backedUp && fs.existsSync(backup) && !fs.existsSync(this.skillsRoot)) {
-        fs.renameSync(backup, this.skillsRoot);
+        renameBotSkillWorkspaceSync(backup, this.skillsRoot);
       }
       if (activatedStage) {
         try {

--- a/src/bot-skills/workspace-fs.ts
+++ b/src/bot-skills/workspace-fs.ts
@@ -1,0 +1,52 @@
+import * as fs from 'fs';
+
+const DEFAULT_MAX_RETRIES = 8;
+const DEFAULT_RETRY_DELAY_MS = 50;
+const TRANSIENT_RENAME_ERROR_CODES = new Set(['EBUSY', 'EACCES', 'EPERM']);
+
+export interface RenameBotSkillWorkspaceOptions {
+  maxRetries?: number;
+  retryDelayMs?: number;
+  renameSync?: typeof fs.renameSync;
+  waitSync?: (milliseconds: number) => void;
+}
+
+/**
+ * Retries whole-workspace directory renames that can fail briefly on Windows
+ * while antivirus, indexing, or another reader is releasing a file handle.
+ * Callers still own their restore/switch journals and fail-closed rollback.
+ */
+export function renameBotSkillWorkspaceSync(
+  sourcePath: string,
+  targetPath: string,
+  options: RenameBotSkillWorkspaceOptions = {},
+): void {
+  const maxRetries = nonNegativeInteger(options.maxRetries, DEFAULT_MAX_RETRIES);
+  const retryDelayMs = nonNegativeInteger(options.retryDelayMs, DEFAULT_RETRY_DELAY_MS);
+  const renameSync = options.renameSync ?? fs.renameSync;
+  const waitSync = options.waitSync ?? blockFor;
+  let retry = 0;
+
+  while (true) {
+    try {
+      renameSync(sourcePath, targetPath);
+      return;
+    } catch (error: any) {
+      if (!TRANSIENT_RENAME_ERROR_CODES.has(String(error?.code || '')) || retry >= maxRetries) {
+        throw error;
+      }
+      retry += 1;
+      waitSync(retryDelayMs * retry);
+    }
+  }
+}
+
+function blockFor(milliseconds: number): void {
+  if (milliseconds <= 0) return;
+  const signal = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+  Atomics.wait(signal, 0, 0, milliseconds);
+}
+
+function nonNegativeInteger(value: number | undefined, fallback: number): number {
+  return Number.isInteger(value) && Number(value) >= 0 ? Number(value) : fallback;
+}

--- a/src/bot-skills/workspace.ts
+++ b/src/bot-skills/workspace.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import { renameBotSkillWorkspaceSync } from './workspace-fs';
 
 interface BotSkillWorkspaceState {
   schema: 'xiaoba.bot-skill-workspace.v1';
@@ -54,7 +55,7 @@ export class BotSkillWorkspaceService {
       }
       if (fs.existsSync(parked)) {
         fs.mkdirSync(path.dirname(this.activeRoot), { recursive: true });
-        fs.renameSync(parked, this.activeRoot);
+        renameBotSkillWorkspaceSync(parked, this.activeRoot);
         this.writeState({ schema: WORKSPACE_SCHEMA, activeBotId: targetBotId });
         return {
           botId: targetBotId,
@@ -96,7 +97,7 @@ export class BotSkillWorkspaceService {
     try {
       fs.mkdirSync(this.parkedRoot, { recursive: true });
       if (fs.existsSync(this.activeRoot)) {
-        fs.renameSync(this.activeRoot, previousParked);
+        renameBotSkillWorkspaceSync(this.activeRoot, previousParked);
         previousParkedNow = true;
       }
       this.writeState({
@@ -107,7 +108,7 @@ export class BotSkillWorkspaceService {
       });
       const targetExisted = fs.existsSync(targetParked);
       if (targetExisted) {
-        fs.renameSync(targetParked, this.activeRoot);
+        renameBotSkillWorkspaceSync(targetParked, this.activeRoot);
       }
       this.writeState({ schema: WORKSPACE_SCHEMA, activeBotId: targetBotId });
       return {
@@ -119,7 +120,7 @@ export class BotSkillWorkspaceService {
       };
     } catch (error) {
       if (!fs.existsSync(this.activeRoot) && previousParkedNow && fs.existsSync(previousParked)) {
-        fs.renameSync(previousParked, this.activeRoot);
+        renameBotSkillWorkspaceSync(previousParked, this.activeRoot);
       }
       this.writeState({ schema: WORKSPACE_SCHEMA, activeBotId: previousBotId });
       throw error;
@@ -137,12 +138,12 @@ export class BotSkillWorkspaceService {
     }
     if (fs.existsSync(this.activeRoot)) {
       fs.mkdirSync(this.parkedRoot, { recursive: true });
-      fs.renameSync(this.activeRoot, targetParked);
+      renameBotSkillWorkspaceSync(this.activeRoot, targetParked);
     }
     if (!fs.existsSync(previousParked)) {
       throw new Error(`Cannot rollback Bot Skill workspace because previous workspace is missing: ${previousParked}`);
     }
-    fs.renameSync(previousParked, this.activeRoot);
+    renameBotSkillWorkspaceSync(previousParked, this.activeRoot);
     this.writeState({ schema: WORKSPACE_SCHEMA, activeBotId: activation.previousBotId });
   }
 
@@ -160,7 +161,7 @@ export class BotSkillWorkspaceService {
         return;
       }
       if (fs.existsSync(previousParked)) {
-        fs.renameSync(previousParked, this.activeRoot);
+        renameBotSkillWorkspaceSync(previousParked, this.activeRoot);
         this.writeState({ schema: WORKSPACE_SCHEMA, activeBotId: previousBotId });
         return;
       }
@@ -174,12 +175,12 @@ export class BotSkillWorkspaceService {
       return;
     }
     if (fs.existsSync(targetParked)) {
-      fs.renameSync(targetParked, this.activeRoot);
+      renameBotSkillWorkspaceSync(targetParked, this.activeRoot);
       this.writeState({ schema: WORKSPACE_SCHEMA, activeBotId: targetBotId });
       return;
     }
     if (fs.existsSync(previousParked)) {
-      fs.renameSync(previousParked, this.activeRoot);
+      renameBotSkillWorkspaceSync(previousParked, this.activeRoot);
       this.writeState({ schema: WORKSPACE_SCHEMA, activeBotId: previousBotId });
       return;
     }

--- a/tests/bot-skill-workspace.test.ts
+++ b/tests/bot-skill-workspace.test.ts
@@ -4,6 +4,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { BotSkillWorkspaceService } from '../src/bot-skills/workspace';
+import { renameBotSkillWorkspaceSync } from '../src/bot-skills/workspace-fs';
 import { withBotSkillWorkspaceLock } from '../src/bot-skills/lock';
 import { BotSkillSyncService } from '../src/bot-skills/sync-service';
 
@@ -38,6 +39,51 @@ describe('per-Bot Skill workspace switching', () => {
     assert.equal(fs.readFileSync(path.join(active, 'a.txt'), 'utf8'), 'bot a');
     service.activate('bot-b');
     assert.equal(fs.readFileSync(path.join(active, 'b.txt'), 'utf8'), 'bot b');
+  });
+
+  test('retries a transient Windows-style workspace rename with bounded backoff', () => {
+    const waits: number[] = [];
+    let attempts = 0;
+    renameBotSkillWorkspaceSync('source', 'target', {
+      maxRetries: 3,
+      retryDelayMs: 25,
+      renameSync: (() => {
+        attempts += 1;
+        if (attempts < 3) throw Object.assign(new Error('temporarily locked'), { code: 'EPERM' });
+      }) as typeof fs.renameSync,
+      waitSync: milliseconds => waits.push(milliseconds),
+    });
+
+    assert.equal(attempts, 3);
+    assert.deepEqual(waits, [25, 50]);
+  });
+
+  test('stops after bounded retries and preserves the original rename error', () => {
+    const original = Object.assign(new Error('still locked'), { code: 'EBUSY' });
+    let attempts = 0;
+    assert.throws(() => renameBotSkillWorkspaceSync('source', 'target', {
+      maxRetries: 2,
+      retryDelayMs: 0,
+      renameSync: (() => {
+        attempts += 1;
+        throw original;
+      }) as typeof fs.renameSync,
+      waitSync: () => {},
+    }), error => error === original);
+    assert.equal(attempts, 3);
+  });
+
+  test('does not retry a non-transient workspace rename failure', () => {
+    const original = Object.assign(new Error('source missing'), { code: 'ENOENT' });
+    let attempts = 0;
+    assert.throws(() => renameBotSkillWorkspaceSync('source', 'target', {
+      renameSync: (() => {
+        attempts += 1;
+        throw original;
+      }) as typeof fs.renameSync,
+      waitSync: () => assert.fail('non-transient failures must not wait'),
+    }), error => error === original);
+    assert.equal(attempts, 1);
   });
 
   test('recovers a crash before the previous workspace was parked without misattributing it', () => {


### PR DESCRIPTION
## 问题

Windows 上杀毒、索引或读文件句柄短暂未释放时，Bot Skill 工作区目录重命名可能返回 EPERM/EBUSY/EACCES，导致云端工作区恢复中止并继续使用本地缓存。

## 修改

- 只对完整 Skill 工作区目录的重命名增加有界重试和线性退避。
- 保留现有事务日志、失败回滚和 fail-closed 行为；非瞬时错误或重试耗尽后仍抛出原始错误。
- 补充瞬时失败、持续失败和非瞬时失败测试。
- 更新 Skills 文档，区分仓库 seed 目录、开发版/打包版运行时目录，以及不同 Bot 的活动/停放工作区。

## 风险边界

- 不修改 Skill 注入逻辑。
- 不修改 read/write/edit/send/import/shell 等工具权限。
- 不改变云端空列表保护、版本或发布流程。

## 验证

- `npm run build`
- `npx tsx --test tests/bot-skill-workspace.test.ts tests/bot-skills-sync.test.ts`（68/68）
- `npm run test:skillhub-phase1`（228/228）