### PR TITLE
ci(worker-image): fix cloud CLI bootstrap

### DIFF
--- a/.github/workflows/worker-image.yml
+++ b/.github/workflows/worker-image.yml
@@ -117,7 +117,8 @@ jobs:
             --output "$tosutil_zip"
           echo "${TOSUTIL_LINUX_AMD64_SHA256}  $tosutil_zip" | sha256sum --check --strict
           unzip -q "$tosutil_zip" -d "$package_dir/tosutil"
-          tosutil_bin="$(find "$package_dir/tosutil" -type f -name tosutil -perm -u+x | head -n 1)"
+          # GitHub's release ZIP does not preserve the executable bit.
+          tosutil_bin="$(find "$package_dir/tosutil" -type f -name tosutil | head -n 1)"
           test -n "$tosutil_bin"
 
           ctyun_package="$package_dir/ctyun-cli.tar.gz"
@@ -673,7 +674,10 @@ jobs:
             -ProtectedImageIDs $env:WORKER_PROTECTED_IMAGE_IDS
 
       - name: Reconcile this attempt after a failed bake
-        if: ${{ always() && steps.bake.outcome != 'success' }}
+        if: >-
+          ${{ always() &&
+              (steps.bake.outcome == 'failure' ||
+               steps.bake.outcome == 'cancelled') }}
         timeout-minutes: 45
         shell: pwsh
         env:

--- a/tests/worker-image-pipeline.test.ts
+++ b/tests/worker-image-pipeline.test.ts
@@ -607,7 +607,9 @@ describe("Tianyi Cloud worker image pipeline", () => {
     assert.match(workflow, /-BakeTimeoutMinutes 150/);
     assert.match(workflow, /-CleanupTimeoutMinutes 40/);
     assert.match(workflow, /-Mode Cleanup/);
-    assert.match(workflow, /steps\.bake\.outcome != 'success'/);
+    assert.match(workflow, /steps\.bake\.outcome == 'failure'/);
+    assert.match(workflow, /steps\.bake\.outcome == 'cancelled'/);
+    assert.doesNotMatch(workflow, /steps\.bake\.outcome != 'success'/);
     assert.match(workflow, /actions: read/);
     assert.match(workflow, /Find interrupted image runs/);
     assert.match(workflow, /per_page=100&page=\$page/);
@@ -645,6 +647,11 @@ describe("Tianyi Cloud worker image pipeline", () => {
     );
     assert.match(workflow, /TOS_JS_SDK_VERSION: 2\.9\.1/);
     assert.match(workflow, /Install pinned cloud CLIs/);
+    assert.match(
+      workflow,
+      /find "\$package_dir\/tosutil" -type f -name tosutil \| head -n 1/,
+    );
+    assert.doesNotMatch(workflow, /-name tosutil -perm -u\+x/);
     assert.match(workflow, /tosutil stat "tos:\/\/\$\{upload_bucket\}"/);
     assert.match(workflow, /tosutil cp "\$WORKER_ARTIFACT_PATH"/);
     assert.match(workflow, /artifact upload start: bytes=/);


### PR DESCRIPTION
## Summary
- locate tosutil by filename because the upstream ZIP does not preserve the executable bit; installation still applies mode 0755
- run current-attempt cloud cleanup only when the bake step actually failed or was cancelled, avoiding a misleading cleanup failure on pre-bake setup errors

## Evidence
Run #17 verified the tosutil ZIP checksum and unzip before failing at the executable-bit filter. No artifact was built or uploaded and no builder was created.

## Verification
- node --test --require tsx/cjs tests/worker-image-pipeline.test.ts
- workflow YAML parse via js-yaml
- git diff --check