### PR TITLE
ci(worker-image): preflight bootstrap telemetry

### DIFF
--- a/.github/workflows/worker-image.yml
+++ b/.github/workflows/worker-image.yml
@@ -312,6 +312,23 @@ jobs:
             echo "error: TOS SDK did not return a valid presigned PUT URL" >&2
             exit 1
           fi
+          # Exercise the exact heartbeat PUT/GET path before creating a billed
+          # builder. This turns a bad signature, endpoint, or permission into
+          # a fast staging failure instead of a five-minute bootstrap timeout.
+          probe_payload='{"state":"probe","phase":"runner-status-preflight","exit_code":0,"line":0}'
+          curl --fail --silent --show-error --request PUT \
+            --connect-timeout 10 --max-time 20 --retry 2 --retry-all-errors \
+            --data-binary "$probe_payload" "$status_put_url" >/dev/null
+          probe_readback="$(curl --fail --silent --show-error \
+            --connect-timeout 10 --max-time 20 --retry 2 --retry-all-errors \
+            --header 'Cache-Control: no-cache' "$status_get_url")"
+          if ! jq -e '.state == "probe" and .phase == "runner-status-preflight"' \
+              <<<"$probe_readback" >/dev/null; then
+            echo "error: heartbeat PUT/GET preflight returned unexpected payload" >&2
+            exit 1
+          fi
+          tosutil rm "tos://${TOS_WORKER_BUCKET}/${status_key}" -f \
+            -conf="$TOSUTIL_GZ_CONFIG"
           echo "::add-mask::$url"
           echo "::add-mask::$script_url"
           echo "::add-mask::$status_get_url"

--- a/tests/worker-image-pipeline.test.ts
+++ b/tests/worker-image-pipeline.test.ts
@@ -667,6 +667,10 @@ describe("Tianyi Cloud worker image pipeline", () => {
     assert.match(workflow, /tosutil presign/);
     assert.match(workflow, /method: "PUT"/);
     assert.match(workflow, /TOS SDK did not return a valid presigned PUT URL/);
+    assert.match(workflow, /runner-status-preflight/);
+    assert.match(workflow, /heartbeat PUT\/GET preflight/);
+    assert.match(workflow, /probe_readback/);
+    assert.match(workflow, /tosutil rm "tos:\/\/\$\{TOS_WORKER_BUCKET\}\/\$\{status_key\}"/);
     assert.match(workflow, /bootstrap-status\.json/);
     assert.match(workflow, /-acl=private/);
     assert.match(workflow, /Remove staged private artifact/);


### PR DESCRIPTION
Validate the exact presigned heartbeat PUT and GET path before creating a billed Tianyi builder. The staging step writes a probe payload, reads and verifies it, then removes it so the builder starts with an empty status key. This turns signing, endpoint, or permission failures into a fast staging error instead of a five-minute bootstrap timeout. Verified with focused worker-image tests 11/11, YAML parse, and diff check.