### PR TITLE
ci(worker-image): keep cleanup output compact

### DIFF
--- a/.github/workflows/worker-image.yml
+++ b/.github/workflows/worker-image.yml
@@ -422,7 +422,7 @@ jobs:
               esac
             done
             if [[ "$(jq 'length' <<<"$bake_attempts")" -gt 0 ]]; then
-              filtered="$(jq --argjson run "$run" --argjson attempts "$bake_attempts" \
+              filtered="$(jq -c --argjson run "$run" --argjson attempts "$bake_attempts" \
                 '. + [$run + {bake_attempts: $attempts}]' <<<"$filtered")"
             fi
           done < <(jq -c '.[]' <<<"$interrupted")

--- a/tests/worker-image-pipeline.test.ts
+++ b/tests/worker-image-pipeline.test.ts
@@ -622,6 +622,7 @@ describe("Tianyi Cloud worker image pipeline", () => {
     assert.match(workflow, /success\|skipped/);
     assert.match(workflow, /retaining fail-safe cleanup/);
     assert.match(workflow, /bake_attempts/);
+    assert.match(workflow, /filtered="\$\(jq -c --argjson run/);
     assert.match(workflow, /foreach \(\$attempt in \$bakeAttempts\)/);
     assert.match(workflow, /foreach \(\$previousAttempt in 1\.\./);
     assert.match(workflow, /Historical image cleanup needs manual attention/);


### PR DESCRIPTION
Fix the cleanup filter output for GitHub Actions. jq pretty-printed the filtered interrupted-run JSON, so writing runs=... to GITHUB_OUTPUT failed with Invalid format and prevented the bake from starting. Use jq -c and add a regression assertion. Verified focused worker-image pipeline tests 11/11, YAML parse, and diff check.