### PR TITLE
ci(worker-image): avoid repeated historical cleanup scans

### DIFF
--- a/.github/workflows/worker-image.yml
+++ b/.github/workflows/worker-image.yml
@@ -11,6 +11,11 @@ on:
         required: false
         type: boolean
         default: false
+      reconcile_history:
+        description: Also audit failed image runs older than 24 hours before baking
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -345,10 +350,12 @@ jobs:
         shell: bash
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          RECONCILE_HISTORICAL_RUNS: ${{ inputs.reconcile_history || false }}
         run: |
           set -euo pipefail
           responses="$(mktemp)"
           trap 'rm -f "$responses"' EXIT
+          historical_cutoff_epoch="$(date -u -d '24 hours ago' +%s)"
           page=1
           while :; do
             response="$(curl --fail --silent --show-error --location \
@@ -387,6 +394,13 @@ jobs:
           while IFS= read -r run; do
             run_id="$(jq -r '.run_id' <<<"$run")"
             run_attempt="$(jq -r '.attempt' <<<"$run")"
+            run_updated_at="$(jq -r '.updated_at' <<<"$run")"
+            run_updated_epoch="$(date -u -d "$run_updated_at" +%s)"
+            if [[ "$RECONCILE_HISTORICAL_RUNS" != "true" ]] &&
+                (( run_updated_epoch < historical_cutoff_epoch )); then
+              echo "skip historical cloud cleanup: run=$run_id updated_at=$run_updated_at (use reconcile_history for an explicit audit)"
+              continue
+            fi
             bake_attempts='[]'
             for attempt in $(seq 1 "$run_attempt"); do
               jobs_url="https://api.github.com/repos/$GITHUB_REPOSITORY/actions/runs/$run_id/attempts/$attempt/jobs?per_page=100"
@@ -408,8 +422,21 @@ jobs:
                 ]
                 | first // "unknown"
               ' <<<"$jobs")"
+              cleanup_conclusion="$(jq -r '
+                [
+                  .jobs[]?.steps[]?
+                  | select(.name == "Reconcile this attempt after a failed bake")
+                  | .conclusion
+                ]
+                | first // "unknown"
+              ' <<<"$jobs")"
               case "$bake_conclusion" in
                 failure|cancelled|timed_out|unknown)
+                  if [[ "$cleanup_conclusion" == "success" ]]; then
+                    echo "skip cloud cleanup: run=$run_id attempt=$attempt bake_step=$bake_conclusion reconciliation_step=success"
+                    continue
+                  fi
+                  echo "retain cloud cleanup: run=$run_id attempt=$attempt bake_step=$bake_conclusion reconciliation_step=$cleanup_conclusion"
                   bake_attempts="$(jq --argjson attempt "$attempt" '. + [$attempt]' <<<"$bake_attempts")"
                   ;;
                 success|skipped)

--- a/ops/ctyun-worker-image/README.md
+++ b/ops/ctyun-worker-image/README.md
@@ -176,10 +176,15 @@ before PowerShell can enter `finally`, including failures that would otherwise
 be hidden behind a later unsuccessful reconciliation run. Cleanup failures
 from runs updated in the last 30 minutes block a new bake, with a bounded
 45-minute strict-recovery budget. A rerun applies the same bounded strict policy
-to all of its previous attempts. Older conflicts are attempted independently
-with a 120-second per-attempt cap and a 10-minute total budget, surfaced as
-workflow warnings and in the job summary, and left for manual reconciliation
-instead of permanently blocking all future image releases.
+to all of its previous attempts. Failed runs from the preceding 24 hours are
+attempted independently with a 120-second per-attempt cap and a 10-minute total
+budget, surfaced as workflow warnings and in the job summary, and left for
+manual reconciliation instead of permanently blocking all future image
+releases. Older runs are not rescanned on every release; use the manual
+`reconcile_history` workflow input for an explicit full-history audit. Attempts
+whose failed bake was already followed by a successful compensating cleanup are
+also skipped, so a known-clean run cannot add the same discovery wait to every
+later bake.
 
 The workflow also pins both GitHub Actions by commit and verifies the exact
 Tianyi CLI package SHA-256 before installing it; it does not execute a remote

--- a/tests/worker-image-pipeline.test.ts
+++ b/tests/worker-image-pipeline.test.ts
@@ -612,12 +612,23 @@ describe("Tianyi Cloud worker image pipeline", () => {
     assert.doesNotMatch(workflow, /steps\.bake\.outcome != 'success'/);
     assert.match(workflow, /actions: read/);
     assert.match(workflow, /Find interrupted image runs/);
+    assert.match(workflow, /reconcile_history:/);
+    assert.match(workflow, /RECONCILE_HISTORICAL_RUNS/);
+    assert.match(workflow, /date -u -d '24 hours ago'/);
+    assert.match(workflow, /skip historical cloud cleanup:/);
     assert.match(workflow, /per_page=100&page=\$page/);
     assert.match(workflow, /page=\$\(\(page \+ 1\)\)/);
     assert.match(workflow, /jq -cs --arg current/);
     assert.match(workflow, /foreach \(\$run in \$runs\)/);
     assert.match(workflow, /actions\/runs\/\$run_id\/attempts\/\$attempt\/jobs/);
     assert.match(workflow, /select\(\.name == "Bake private ECS image"\)/);
+    assert.match(
+      workflow,
+      /select\(\.name == "Reconcile this attempt after a failed bake"\)/,
+    );
+    assert.match(workflow, /cleanup_conclusion/);
+    assert.match(workflow, /reconciliation_step=success/);
+    assert.match(workflow, /retain cloud cleanup:/);
     assert.match(workflow, /failure\|cancelled\|timed_out\|unknown/);
     assert.match(workflow, /success\|skipped/);
     assert.match(workflow, /retaining fail-safe cleanup/);


### PR DESCRIPTION
## Summary
- skip failed bake attempts whose compensating cleanup already succeeded
- automatically audit only the previous 24 hours during normal bakes
- retain an explicit reconcile_history input for full-history audits

## Validation
- npm run build
- worker-image pipeline tests
- workflow YAML parse
- git diff --check