### PR TITLE
fix(worker-image): use raw shell user data on Tianyi

### DIFF
--- a/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
+++ b/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
@@ -1391,6 +1391,7 @@ try {
 set -Eeuo pipefail
 export CATSCO_BASE_IMAGE_HARDENED='$baseImageHardenedValue'
 exec > >(tee -a /var/log/catsco-image-build.log) 2>&1
+date -Is > /run/catsco-image-bootstrap-started
 artifact_url="`$(printf '%s' '$artifactUrlBase64' | base64 -d)"
 prepare_script_url="`$(printf '%s' '$prepareScriptUrlBase64' | base64 -d)"
 status_put_url="`$(printf '%s' '$statusPutUrlBase64' | base64 -d)"
@@ -1465,28 +1466,11 @@ phase shutdown
 publish_status succeeded shutdown
 shutdown -h now
 "@
-    # Tianyi's cloud-init images are more reliable when userData is an
-    # explicit cloud-config document. Keep the actual bootstrap as a decoded
-    # file and invoke it through runcmd so a valid shell shebang is not left
-    # to provider-specific userData handling.
-    $bootstrapBase64 = [Convert]::ToBase64String(
-        [Text.Encoding]::UTF8.GetBytes($bootstrapScript)
-    )
-    $cloudConfig = @"
-#cloud-config
-output:
-  all: '| tee -a /var/log/catsco-image-cloud-init-output.log'
-bootcmd:
-  - [ /bin/sh, -c, "date -Is > /run/catsco-image-bootstrap-started" ]
-write_files:
-  - path: /usr/local/sbin/catsco-image-bootstrap.sh
-    encoding: b64
-    permissions: '0700'
-    content: $bootstrapBase64
-runcmd:
-  - [ /bin/bash, /usr/local/sbin/catsco-image-bootstrap.sh ]
-"@
-    $userData = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($cloudConfig))
+    # Tianyi's Ubuntu 24.04 public image executes raw shebang userData but did
+    # not execute an equivalent #cloud-config document in a live no-public-IP
+    # probe. Pass the bootstrap script directly so cloud-init's shell handler
+    # owns the execution path that the platform actually supports.
+    $userData = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($bootstrapScript))
     if ($userData.Length -gt 16384) {
         throw "Generated builder userData exceeds Tianyi Cloud's 16384-character limit"
     }

--- a/ops/ctyun-worker-image/README.md
+++ b/ops/ctyun-worker-image/README.md
@@ -16,8 +16,12 @@ session, skill installation, or runtime `.env`.
   builder downloads them through cloud-init, and the workflow deletes all three
   objects after the bake. They are never public or retained as GitHub Actions
   artifacts.
-- The builder receives only short-lived signed URLs. It writes its current
-  bootstrap phase every 30 seconds to the per-run status object; the runner
+- The builder receives only short-lived signed URLs. Tianyi's Ubuntu 24.04
+  image is given a Base64-encoded raw `#!/usr/bin/env bash` userData script; a
+  live no-public-IP probe confirmed this path executes and powers off, while
+  the same bootstrap wrapped as `#cloud-config` was stored by the API but never
+  executed. The script writes its current bootstrap phase every 30 seconds to
+  the per-run status object; the runner
   prints phase changes live and fails early when bootstrap reports an error,
   does not start, or stops heartbeating. No long-lived TOS credential is placed
   on the builder.

--- a/tests/worker-image-pipeline.test.ts
+++ b/tests/worker-image-pipeline.test.ts
@@ -1114,14 +1114,13 @@ process.exit(result.status ?? 1);
       assert.equal(finalState.createExtIP, "0");
       assert.equal(finalState.createHadBandwidth, false);
       assert.ok(finalState.createUserData.length <= 16384);
-      const bootstrap = Buffer.from(finalState.createUserData, "base64").toString("utf8");
-      assert.match(bootstrap, /#cloud-config/);
-      assert.match(bootstrap, /write_files:/);
-      assert.match(bootstrap, /runcmd:/);
-      assert.match(bootstrap, /catsco-image-bootstrap\.sh/);
-      const contentMatch = bootstrap.match(/    content: ([A-Za-z0-9+/=]+)\n/);
-      assert.ok(contentMatch, "cloud-config must contain base64 bootstrap content");
-      const decodedBootstrap = Buffer.from(contentMatch[1], "base64").toString("utf8");
+      const decodedBootstrap = Buffer.from(
+        finalState.createUserData,
+        "base64",
+      ).toString("utf8");
+      assert.match(decodedBootstrap, /^#!\/usr\/bin\/env bash/);
+      assert.doesNotMatch(decodedBootstrap, /#cloud-config/);
+      assert.match(decodedBootstrap, /catsco-image-bootstrap-started/);
       assert.match(decodedBootstrap, /curl_common=\(--fail --silent --show-error/);
       assert.match(decodedBootstrap, /--ipv4/);
       assert.match(decodedBootstrap, /--connect-timeout 20/);
@@ -1133,10 +1132,10 @@ process.exit(result.status ?? 1);
       assert.match(decodedBootstrap, /shutdown -h now/);
       assert.match(decodedBootstrap, new RegExp(artifactSha));
       assert.match(decodedBootstrap, /sha256sum --check --strict/);
-      assert.doesNotMatch(bootstrap, /example\.test\/private-worker/);
-      assert.doesNotMatch(bootstrap, /example\.test\/prepare-image/);
-      assert.doesNotMatch(bootstrap, /example\.test\/bootstrap-status/);
-      assert.doesNotMatch(bootstrap, /\bscp\b|\bssh\b/);
+      assert.doesNotMatch(decodedBootstrap, /example\.test\/private-worker/);
+      assert.doesNotMatch(decodedBootstrap, /example\.test\/prepare-image/);
+      assert.doesNotMatch(decodedBootstrap, /example\.test\/bootstrap-status/);
+      assert.doesNotMatch(decodedBootstrap, /\bscp\b|\bssh\b/);
       assert.equal(finalState.imageSourceServerID, "instance-1");
       assert.match(
         finalState.imageName,


### PR DESCRIPTION
## Root cause
The Ubuntu 24.04 public image stores cloud-config userData but does not execute it. A no-public-IP probe with the exact worker image confirmed that raw shebang userData executes and powers off.

## Changes
- pass the existing bootstrap directly as Base64 raw shell userData
- preserve heartbeat, artifact verification, and shutdown behavior
- update lifecycle assertions and bake documentation

## Validation
- raw userData cloud probe: executed and stopped in about 1 minute
- npm run build
- worker-image pipeline tests: 11/11
- PowerShell parse
- workflow YAML parse
- git diff --check