### PR TITLE
fix(worker-image): serialize bootstrap telemetry writes

### DIFF
--- a/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
+++ b/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
@@ -1396,10 +1396,20 @@ artifact_url="`$(printf '%s' '$artifactUrlBase64' | base64 -d)"
 prepare_script_url="`$(printf '%s' '$prepareScriptUrlBase64' | base64 -d)"
 status_put_url="`$(printf '%s' '$statusPutUrlBase64' | base64 -d)"
 status_file=/run/catsco-image-bootstrap-phase
+status_lock=/run/catsco-image-bootstrap-status.lock
 heartbeat_pid=''
+acquire_status_lock() {
+  while ! mkdir "`$status_lock" 2>/dev/null; do
+    sleep 0.05
+  done
+}
+release_status_lock() {
+  rmdir "`$status_lock" 2>/dev/null || true
+}
 publish_status() {
   local state="`$1" phase_name="`$2" exit_code="`${3:-0}" line="`${4:-0}"
   [[ -n "`$status_put_url" ]] || return 0
+  acquire_status_lock
   printf '{"state":"%s","phase":"%s","exit_code":%s,"line":%s,"epoch":%s}\n' \
     "`$state" "`$phase_name" "`$exit_code" "`$line" "`$(date +%s)" >/run/catsco-image-bootstrap-status.json
   if curl --fail --silent --request PUT --connect-timeout 10 --max-time 20 \
@@ -1411,6 +1421,7 @@ publish_status() {
     # though the runner only observes the TOS object.
     echo "status publish failed (phase=`$phase_name)" >&2
   fi
+  release_status_lock
 }
 phase() {
   printf '%s\n' "`$1" | tee "`$status_file"

--- a/tests/worker-image-pipeline.test.ts
+++ b/tests/worker-image-pipeline.test.ts
@@ -1129,6 +1129,8 @@ process.exit(result.status ?? 1);
       assert.match(decodedBootstrap, /phase shutdown/);
       assert.match(decodedBootstrap, /publish_status failed/);
       assert.match(decodedBootstrap, /heartbeat &/);
+      assert.match(decodedBootstrap, /status_lock=\/run\/catsco-image-bootstrap-status\.lock/);
+      assert.match(decodedBootstrap, /acquire_status_lock\(\)/);
       assert.match(decodedBootstrap, /shutdown -h now/);
       assert.match(decodedBootstrap, new RegExp(artifactSha));
       assert.match(decodedBootstrap, /sha256sum --check --strict/);


### PR DESCRIPTION
## Root cause
The raw shell bootstrap and its background heartbeat can write the shared status JSON concurrently. The runner observed a partially written object as malformed telemetry.

## Changes
- serialize status file writes and PUTs with an atomic mkdir lock
- keep heartbeat and phase telemetry behavior unchanged

## Validation
- npm run build
- worker-image pipeline tests: 11/11
- PowerShell parse
- git diff --check

Run #21 confirmed raw userData execution; it failed only at malformed telemetry after 61 seconds.