### PR TITLE
fix(worker-image): tolerate transient telemetry reads

### DIFF
--- a/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
+++ b/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
@@ -132,6 +132,39 @@ function Wait-PollInterval {
     Start-Sleep -Seconds $seconds
 }
 
+function Convert-BootstrapResponseContent {
+    param([AllowNull()][object]$Content)
+
+    if ($null -eq $Content) {
+        return ""
+    }
+    if ($Content -is [byte[]]) {
+        $payload = [Text.Encoding]::UTF8.GetString([byte[]]$Content)
+    } else {
+        $payload = [string]$Content
+    }
+    # Some object stores return a UTF-8 BOM even when the object was written
+    # without one. ConvertFrom-Json accepts whitespace, but not a BOM prefix.
+    return $payload.TrimStart([char]0xFEFF)
+}
+
+function Write-BootstrapPayloadDiagnostic {
+    param(
+        [AllowNull()][object]$Content,
+        [Parameter(Mandatory = $true)][int]$Attempt
+    )
+
+    $payload = Convert-BootstrapResponseContent -Content $Content
+    $bytes = [Text.Encoding]::UTF8.GetBytes($payload)
+    $hash = ([Security.Cryptography.SHA256]::Create()).ComputeHash($bytes)
+    $hex = (-join ($bytes | Select-Object -First 32 | ForEach-Object { $_.ToString("x2") }))
+    $type = if ($null -eq $Content) { "null" } else { $Content.GetType().FullName }
+    Write-BakeProgress -Phase "builder-bootstrap-read" -Detail (
+        "parse_attempt={0} content_type={1} bytes={2} sha256={3} prefix_hex={4}" -f
+        $Attempt, $type, $bytes.Length, (-join ($hash | ForEach-Object { $_.ToString("x2") })), $hex
+    ) -Force
+}
+
 function Test-BootstrapStatus {
     if ([string]::IsNullOrWhiteSpace($BootstrapStatusGetUrl)) {
         return
@@ -143,16 +176,38 @@ function Test-BootstrapStatus {
     }
 
     $payload = ""
-    try {
-        $response = Invoke-WebRequest `
-            -Uri $BootstrapStatusGetUrl `
-            -Method Get `
-            -TimeoutSec 15 `
-            -Headers @{ "Cache-Control" = "no-cache" }
-        $payload = [string]$response.Content
-    } catch {
-        # A status object does not exist until cloud-init starts. Network and
-        # 404 failures are handled by the bounded missing/stale checks below.
+    $status = $null
+    $responseContent = $null
+    $malformed = $false
+    for ($attempt = 1; $attempt -le 3; $attempt++) {
+        $responseContent = $null
+        try {
+            $response = Invoke-WebRequest `
+                -Uri $BootstrapStatusGetUrl `
+                -Method Get `
+                -TimeoutSec 15 `
+                -Headers @{ "Cache-Control" = "no-cache" }
+            $responseContent = $response.Content
+            $payload = Convert-BootstrapResponseContent -Content $responseContent
+        } catch {
+            $payload = ""
+        }
+
+        if ([string]::IsNullOrWhiteSpace($payload)) {
+            $malformed = $false
+            break
+        }
+        try {
+            $status = $payload | ConvertFrom-Json
+            $malformed = $false
+            break
+        } catch {
+            $malformed = $true
+            Write-BootstrapPayloadDiagnostic -Content $responseContent -Attempt $attempt
+            if ($attempt -lt 3) {
+                Start-Sleep -Seconds 1
+            }
+        }
     }
 
     if (-not [string]::IsNullOrWhiteSpace($payload)) {
@@ -160,9 +215,7 @@ function Test-BootstrapStatus {
             $script:LastBootstrapPayload = $payload
             $script:LastBootstrapUpdateAt = $now
         }
-        try {
-            $status = $payload | ConvertFrom-Json
-        } catch {
+        if ($malformed -or $null -eq $status) {
             throw "Builder bootstrap returned malformed status telemetry"
         }
         $state = ([string]$status.state).ToLowerInvariant()

--- a/tests/worker-image-pipeline.test.ts
+++ b/tests/worker-image-pipeline.test.ts
@@ -565,6 +565,13 @@ describe("Tianyi Cloud worker image pipeline", () => {
     assert.match(imageOrchestrator, /Builder bootstrap failed/);
     assert.match(imageOrchestrator, /Builder bootstrap heartbeat is stale/);
     assert.match(imageOrchestrator, /Builder bootstrap status is unreachable or stale/);
+    assert.match(imageOrchestrator, /Convert-BootstrapResponseContent/);
+    assert.match(imageOrchestrator, /UTF8\.GetString\(\[byte\[\]\]\$Content\)/);
+    assert.match(imageOrchestrator, /TrimStart\(\[char\]0xFEFF\)/);
+    assert.match(imageOrchestrator, /parse_attempt=/);
+    assert.match(imageOrchestrator, /prefix_hex=/);
+    assert.match(imageOrchestrator, /for \(\$attempt = 1; \$attempt -le 3; \$attempt\+\+\)/);
+    assert.match(imageOrchestrator, /Start-Sleep -Seconds 1/);
     assert.match(imageOrchestrator, /-MonitorBootstrap/);
     assert.match(imageOrchestrator, /shutdown -h now/);
     assert.doesNotMatch(imageOrchestrator, /Wait-ForSsh|\bscp\b|"--extIP", "1"/);
@@ -573,6 +580,95 @@ describe("Tianyi Cloud worker image pipeline", () => {
     assert.match(imagePreparer, /image_phase kernel-upgrade/);
     assert.match(imagePreparer, /image_phase worker-validate/);
     assert.match(workflow, /CTYUN_WORKER_BASE_IMAGE_HARDENED/);
+  });
+
+  test("bootstrap telemetry decodes UTF-8 content and retries transient malformed reads", () => {
+    const helperStart = imageOrchestrator.indexOf(
+      "function Convert-BootstrapResponseContent",
+    );
+    const helperEnd = imageOrchestrator.indexOf(
+      "function Invoke-External",
+      helperStart,
+    );
+    assert.ok(helperStart >= 0 && helperEnd > helperStart);
+
+    const sandbox = fs.mkdtempSync(
+      path.join(os.tmpdir(), "catsco-bootstrap-telemetry-"),
+    );
+    try {
+      const harnessPath = path.join(sandbox, "telemetry-test.ps1");
+      fs.writeFileSync(
+        harnessPath,
+        `${imageOrchestrator.slice(helperStart, helperEnd)}
+function Write-BakeProgress {
+    param([string]$Phase, [string]$Detail = "", [switch]$Force)
+    $script:Diagnostics.Add("$Phase $Detail")
+}
+function Start-Sleep { param([int]$Seconds) }
+function Invoke-WebRequest {
+    $index = [Math]::Min($script:RequestCount, $script:Responses.Count - 1)
+    $content = $script:Responses[$index]
+    $script:RequestCount++
+    return [pscustomobject]@{ Content = $content }
+}
+function Reset-Monitor([object[]]$Responses) {
+    $script:Responses = $Responses
+    $script:RequestCount = 0
+    $script:Diagnostics = [Collections.Generic.List[string]]::new()
+    $script:BootstrapMonitorStartedAt = $null
+    $script:LastBootstrapPayload = ""
+    $script:LastBootstrapUpdateAt = $null
+    $script:LastBootstrapPhase = ""
+    $script:StartedAt = Get-Date
+    $script:LastProgressAt = [DateTime]::MinValue
+    $script:OperationDeadline = $null
+    $script:CleanupDeadline = $null
+    $script:InCleanup = $false
+    $global:BootstrapStatusGetUrl = "https://example.test/status"
+    $global:BootstrapStaleSeconds = 60
+    $global:BootstrapStartTimeoutMinutes = 5
+}
+
+$valid = '{"state":"running","phase":"download-worker-artifact","exit_code":0,"line":0}'
+if ((Convert-BootstrapResponseContent -Content $valid) -ne $valid) {
+    throw "string telemetry changed during decoding"
+}
+$withBom = [byte[]]([Text.Encoding]::UTF8.GetPreamble() + [Text.Encoding]::UTF8.GetBytes($valid))
+if ((Convert-BootstrapResponseContent -Content $withBom) -ne $valid) {
+    throw "byte telemetry or BOM was not decoded"
+}
+
+Reset-Monitor -Responses @('{"state":', [Text.Encoding]::UTF8.GetBytes($valid))
+Test-BootstrapStatus
+if ($script:RequestCount -ne 2 -or $script:LastBootstrapPhase -ne 'download-worker-artifact') {
+    throw "transient malformed telemetry did not recover"
+}
+if (-not ($script:Diagnostics -match 'content_type=System.String')) {
+    throw "malformed telemetry diagnostic was not emitted"
+}
+
+Reset-Monitor -Responses @('{"state":')
+$failure = $null
+try { Test-BootstrapStatus } catch { $failure = $_.Exception.Message }
+if ($script:RequestCount -ne 3 -or $failure -ne 'Builder bootstrap returned malformed status telemetry') {
+    throw "persistent malformed telemetry was not bounded to three reads"
+}
+`,
+        "utf8",
+      );
+      const result = spawnSync(
+        "pwsh",
+        ["-NoProfile", "-NonInteractive", "-File", harnessPath],
+        { cwd: root, encoding: "utf8", timeout: 30_000 },
+      );
+      assert.equal(
+        result.status,
+        0,
+        `telemetry harness failed\n${result.stdout}\n${result.stderr}`,
+      );
+    } finally {
+      fs.rmSync(sandbox, { recursive: true, force: true });
+    }
   });
 
   test("workflow is restricted and stages only a temporary private artifact", () => {


### PR DESCRIPTION
## Summary
- decode bootstrap status response content explicitly as UTF-8 when PowerShell returns bytes
- strip a leading UTF-8 BOM and retry malformed object reads up to three times
- emit credential-safe diagnostics (type, byte length, SHA-256, prefix hex) before a persistent failure
- add behavioral coverage for strings, byte arrays, BOM, transient truncation, and bounded persistent failure

## Validation
- npm run build
- node --test --require tsx/cjs tests/worker-image-pipeline.test.ts (12/12)
- PowerShell parser validation
- git diff --check