### PR TITLE
feat(skillhub): add isolated Bot Skill candidate workspace

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -25,6 +25,7 @@ const skillHubPhase1Tests = [
   'tests/catscompany-skillhub-rpc.test.ts',
   'tests/bot-definition-skills.test.ts',
   'tests/bot-skill-workspace.test.ts',
+  'tests/bot-skill-candidate-workspace.test.ts',
   'tests/bot-skills-sync.test.ts',
   'tests/bot-skills-security.test.ts',
   'tests/execution-router-clean.test.ts',

--- a/src/bot-skills/candidate-workspace.ts
+++ b/src/bot-skills/candidate-workspace.ts
@@ -1,0 +1,448 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  BOT_SKILL_LOCAL_MARKER_FILE,
+  collectBotSkillPackageFiles,
+  computeBotSkillPackageHash,
+  isPortablePackagePath,
+  readBotSkillLocalMarker,
+  scanLocalBotSkill,
+  writeBotSkillLocalMarker,
+} from './local-manifest';
+import type { BotSkillLocalMarker, LocalBotSkillManifestEntry } from './types';
+import { renameBotSkillWorkspaceSync } from './workspace-fs';
+
+const CANDIDATE_SCHEMA = 'xiaoba.bot-skill-candidate.v1';
+const CANDIDATE_FILE = 'candidate.json';
+const PACKAGE_DIRECTORY = 'package';
+const SCOPED_ID_PATTERN = /^[A-Za-z0-9_-][A-Za-z0-9_.-]{0,159}$/;
+
+export interface CreateBotSkillCandidateOptions {
+  runtimeRoot: string;
+  botId: string;
+  mutationId: string;
+  sourceSkillPath: string;
+  installName?: string;
+  now?: () => Date;
+}
+
+export interface BotSkillCandidateManifest {
+  schema: typeof CANDIDATE_SCHEMA;
+  botId: string;
+  mutationId: string;
+  state: 'prepared';
+  localSkillId: string;
+  installName: string;
+  contentHash: string;
+  markerHash: string;
+  fileCount: number;
+  createdAt: string;
+}
+
+export interface BotSkillCandidate {
+  path: string;
+  packagePath: string;
+  manifest: BotSkillCandidateManifest;
+  skill: LocalBotSkillManifestEntry;
+  deduplicated: boolean;
+}
+
+export interface BotSkillCandidateRecoveryEntry {
+  path: string;
+  mutationId?: string;
+  status: 'ready' | 'incomplete' | 'invalid';
+  candidate?: BotSkillCandidate;
+  error?: string;
+}
+
+/**
+ * Creates an isolated copy of one Skill for a future mutation workflow.
+ *
+ * This module is deliberately not registered with the model, Runtime startup,
+ * BotDefinition activation, or the existing file/Shell tools. Candidate files
+ * therefore cannot affect the active Skill workspace until a later, explicit
+ * and separately reviewed promotion workflow is introduced.
+ */
+export function createBotSkillCandidate(
+  options: CreateBotSkillCandidateOptions,
+): BotSkillCandidate {
+  const runtimeRoot = requireSafeDirectory(options.runtimeRoot, 'Runtime root');
+  const botId = normalizeScopedId(options.botId, 'Bot ID');
+  const mutationId = normalizeScopedId(options.mutationId, 'mutation ID');
+  const sourceSkillPath = requireSafeDirectory(options.sourceSkillPath, 'source Skill');
+  assertSafeTree(sourceSkillPath, 'source Skill');
+  const skillFile = path.join(sourceSkillPath, 'SKILL.md');
+  if (!fs.existsSync(skillFile) || !fs.lstatSync(skillFile).isFile()) {
+    throw new Error('Bot Skill candidate source is missing a safe SKILL.md.');
+  }
+
+  const files = collectBotSkillPackageFiles(sourceSkillPath);
+  if (!files.some(file => file.path === 'SKILL.md')) {
+    throw new Error('Bot Skill candidate source is missing SKILL.md.');
+  }
+  const contentHash = computeBotSkillPackageHash(files);
+  const installName = normalizeInstallName(options.installName ?? path.basename(sourceSkillPath));
+  const sourceMarker = readBotSkillLocalMarker(sourceSkillPath);
+  if (!sourceMarker && fs.existsSync(path.join(sourceSkillPath, BOT_SKILL_LOCAL_MARKER_FILE))) {
+    throw new Error('Source Skill local marker cannot be read safely.');
+  }
+  if (sourceMarker && !validLocalSkillId(sourceMarker.localSkillId)) {
+    throw new Error('Source Skill has an invalid local Skill ID for candidate workspace.');
+  }
+  const candidatesRoot = ensureCandidateRoot(runtimeRoot);
+  const botRoot = ensureSafeChildDirectory(candidatesRoot, botId);
+  const finalPath = path.join(botRoot, mutationId);
+
+  if (fs.existsSync(finalPath)) {
+    return assertExistingCandidateMatches(
+      finalPath,
+      botId,
+      mutationId,
+      installName,
+      contentHash,
+      sourceMarker?.localSkillId,
+    );
+  }
+
+  const localSkillId = sourceMarker?.localSkillId ?? crypto.randomUUID();
+  if (!validLocalSkillId(localSkillId)) {
+    throw new Error('Source Skill has an invalid local Skill ID for candidate workspace.');
+  }
+  const marker: BotSkillLocalMarker = {
+    schema: 'xiaoba.bot-skill-local.v1',
+    localSkillId,
+    ...(sourceMarker?.reference?.contentHash === contentHash
+      ? { reference: sourceMarker.reference }
+      : {}),
+    ...(sourceMarker?.origin ? { origin: sourceMarker.origin } : {}),
+  };
+  const createdAt = (options.now ?? (() => new Date()))().toISOString();
+  const manifest: BotSkillCandidateManifest = {
+    schema: CANDIDATE_SCHEMA,
+    botId,
+    mutationId,
+    state: 'prepared',
+    localSkillId,
+    installName,
+    contentHash,
+    markerHash: hashMarker(marker),
+    fileCount: files.length,
+    createdAt,
+  };
+  const temporary = path.join(
+    botRoot,
+    `.tmp-${mutationId}-${process.pid}-${crypto.randomBytes(8).toString('hex')}`,
+  );
+  const packagePath = path.join(temporary, PACKAGE_DIRECTORY, ...installName.split('/'));
+
+  fs.mkdirSync(packagePath, { recursive: true });
+  try {
+    for (const file of files) {
+      const target = path.join(packagePath, ...file.path.split('/'));
+      fs.mkdirSync(path.dirname(target), { recursive: true });
+      const bytes = Buffer.from(file.contentBase64, 'base64');
+      fs.writeFileSync(target, bytes, { flag: 'wx' });
+    }
+    writeBotSkillLocalMarker(packagePath, marker);
+    const copied = scanLocalBotSkill(packagePath, path.join(temporary, PACKAGE_DIRECTORY));
+    if (
+      copied.contentHash !== contentHash
+      || copied.localSkillId !== localSkillId
+      || copied.installName !== installName
+      || copied.files.length !== files.length
+    ) {
+      throw new Error('Bot Skill candidate verification failed before activation.');
+    }
+    fs.writeFileSync(
+      path.join(temporary, CANDIDATE_FILE),
+      `${JSON.stringify(manifest, null, 2)}\n`,
+      { encoding: 'utf8', flag: 'wx' },
+    );
+    renameBotSkillWorkspaceSync(temporary, finalPath);
+    return inspectBotSkillCandidate({ runtimeRoot, botId, mutationId, deduplicated: false });
+  } catch (error) {
+    if (fs.existsSync(temporary)) fs.rmSync(temporary, { recursive: true, force: true });
+    if (fs.existsSync(finalPath)) {
+      return assertExistingCandidateMatches(
+        finalPath,
+        botId,
+        mutationId,
+        installName,
+        contentHash,
+        sourceMarker?.localSkillId,
+      );
+    }
+    throw error;
+  }
+}
+
+export function inspectBotSkillCandidate(options: {
+  runtimeRoot: string;
+  botId: string;
+  mutationId: string;
+  deduplicated?: boolean;
+}): BotSkillCandidate {
+  const runtimeRoot = requireSafeDirectory(options.runtimeRoot, 'Runtime root');
+  const botId = normalizeScopedId(options.botId, 'Bot ID');
+  const mutationId = normalizeScopedId(options.mutationId, 'mutation ID');
+  const botRoot = requireCandidateBotRoot(runtimeRoot, botId);
+  const candidatePath = path.join(botRoot, mutationId);
+  const safeCandidatePath = requireSafeDirectory(candidatePath, 'Bot Skill candidate');
+  assertSafeTree(safeCandidatePath, 'Bot Skill candidate');
+  const manifest = readCandidateManifest(safeCandidatePath, botId, mutationId);
+  const packagePath = path.join(
+    safeCandidatePath,
+    PACKAGE_DIRECTORY,
+    ...manifest.installName.split('/'),
+  );
+  const marker = readBotSkillLocalMarker(packagePath);
+  if (!marker) {
+    throw new Error('Bot Skill candidate marker cannot be read safely.');
+  }
+  const skill = scanLocalBotSkill(packagePath, path.join(safeCandidatePath, PACKAGE_DIRECTORY));
+  if (
+    skill.localSkillId !== manifest.localSkillId
+    || skill.installName !== manifest.installName
+    || skill.contentHash !== manifest.contentHash
+    || hashMarker(marker) !== manifest.markerHash
+    || skill.files.length !== manifest.fileCount
+  ) {
+    throw new Error('Bot Skill candidate no longer matches its verified manifest.');
+  }
+  return {
+    path: safeCandidatePath,
+    packagePath,
+    manifest,
+    skill,
+    deduplicated: options.deduplicated ?? false,
+  };
+}
+
+/** Reports interrupted/invalid candidates without deleting evidence. */
+export function recoverBotSkillCandidates(
+  runtimeRootValue: string,
+  botIdValue: string,
+): BotSkillCandidateRecoveryEntry[] {
+  const runtimeRoot = requireSafeDirectory(runtimeRootValue, 'Runtime root');
+  const botId = normalizeScopedId(botIdValue, 'Bot ID');
+  const botRoot = candidatePathFor(runtimeRoot, botId);
+  if (!fs.existsSync(botRoot)) return [];
+  requireCandidateBotRoot(runtimeRoot, botId);
+
+  return fs.readdirSync(botRoot, { withFileTypes: true })
+    .filter(entry => entry.isDirectory() || entry.isSymbolicLink())
+    .sort((left, right) => compareText(left.name, right.name))
+    .map(entry => {
+      const entryPath = path.join(botRoot, entry.name);
+      if (entry.isSymbolicLink()) {
+        return { path: entryPath, status: 'invalid', error: 'Candidate entry is a symbolic link.' };
+      }
+      if (entry.name.startsWith('.tmp-')) {
+        return { path: entryPath, status: 'incomplete' };
+      }
+      try {
+        const mutationId = normalizeScopedId(entry.name, 'mutation ID');
+        const candidate = inspectBotSkillCandidate({ runtimeRoot, botId, mutationId });
+        return { path: entryPath, mutationId, status: 'ready', candidate };
+      } catch (error) {
+        return {
+          path: entryPath,
+          mutationId: entry.name,
+          status: 'invalid',
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    });
+}
+
+/** Removes only one fully verified candidate. Invalid evidence is preserved. */
+export function discardBotSkillCandidate(options: {
+  runtimeRoot: string;
+  botId: string;
+  mutationId: string;
+}): boolean {
+  const runtimeRoot = requireSafeDirectory(options.runtimeRoot, 'Runtime root');
+  const botId = normalizeScopedId(options.botId, 'Bot ID');
+  const mutationId = normalizeScopedId(options.mutationId, 'mutation ID');
+  const botRoot = candidatePathFor(runtimeRoot, botId);
+  if (!fs.existsSync(botRoot)) return false;
+  requireCandidateBotRoot(runtimeRoot, botId);
+  const candidatePath = path.join(botRoot, mutationId);
+  if (!fs.existsSync(candidatePath)) return false;
+  inspectBotSkillCandidate({ runtimeRoot, botId, mutationId });
+  fs.rmSync(candidatePath, { recursive: true, force: false });
+  return true;
+}
+
+function assertExistingCandidateMatches(
+  candidatePath: string,
+  botId: string,
+  mutationId: string,
+  installName: string,
+  contentHash: string,
+  expectedLocalSkillId?: string,
+): BotSkillCandidate {
+  const runtimeRoot = runtimeRootFromCandidatePath(candidatePath);
+  const existing = inspectBotSkillCandidate({
+    runtimeRoot,
+    botId,
+    mutationId,
+    deduplicated: true,
+  });
+  if (
+    existing.manifest.installName !== installName
+    || existing.manifest.contentHash !== contentHash
+    || (expectedLocalSkillId !== undefined
+      && existing.manifest.localSkillId !== expectedLocalSkillId)
+  ) {
+    throw new Error('Bot Skill candidate mutation ID already exists with different content.');
+  }
+  return existing;
+}
+
+function readCandidateManifest(
+  candidatePath: string,
+  botId: string,
+  mutationId: string,
+): BotSkillCandidateManifest {
+  const manifestPath = path.join(candidatePath, CANDIDATE_FILE);
+  let value: Partial<BotSkillCandidateManifest>;
+  try {
+    value = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as Partial<BotSkillCandidateManifest>;
+  } catch {
+    throw new Error('Bot Skill candidate manifest cannot be read safely.');
+  }
+  if (
+    value.schema !== CANDIDATE_SCHEMA
+    || value.botId !== botId
+    || value.mutationId !== mutationId
+    || value.state !== 'prepared'
+    || !validLocalSkillId(value.localSkillId)
+    || normalizeInstallName(value.installName) !== value.installName
+    || !/^[a-f0-9]{64}$/.test(String(value.contentHash || ''))
+    || !/^[a-f0-9]{64}$/.test(String(value.markerHash || ''))
+    || !Number.isInteger(value.fileCount)
+    || Number(value.fileCount) <= 0
+    || !validIsoDate(value.createdAt)
+  ) {
+    throw new Error('Bot Skill candidate manifest is invalid.');
+  }
+  return value as BotSkillCandidateManifest;
+}
+
+function ensureCandidateRoot(runtimeRoot: string): string {
+  let current = runtimeRoot;
+  for (const segment of ['data', 'bot-skills', 'candidates']) {
+    current = ensureSafeChildDirectory(current, segment);
+  }
+  return current;
+}
+
+function ensureSafeChildDirectory(parent: string, name: string): string {
+  const child = path.join(parent, name);
+  if (!fs.existsSync(child)) {
+    try {
+      fs.mkdirSync(child, { recursive: false });
+    } catch (error: any) {
+      // A second Runtime process may have created the same safe scope first.
+      if (error?.code !== 'EEXIST') throw error;
+    }
+  }
+  return requireSafeDirectory(child, 'Bot Skill candidate directory');
+}
+
+function requireCandidateBotRoot(runtimeRoot: string, botId: string): string {
+  let current = runtimeRoot;
+  for (const segment of ['data', 'bot-skills', 'candidates', botId]) {
+    current = path.join(current, segment);
+    requireSafeDirectory(current, 'Bot Skill candidate directory');
+  }
+  return current;
+}
+
+function candidatePathFor(runtimeRoot: string, botId: string, mutationId?: string): string {
+  return path.join(
+    runtimeRoot,
+    'data',
+    'bot-skills',
+    'candidates',
+    botId,
+    ...(mutationId ? [mutationId] : []),
+  );
+}
+
+function runtimeRootFromCandidatePath(candidatePath: string): string {
+  return path.resolve(candidatePath, '..', '..', '..', '..', '..');
+}
+
+function requireSafeDirectory(value: string, label: string): string {
+  const resolved = path.resolve(value);
+  if (!fs.existsSync(resolved)) throw new Error(`${label} does not exist: ${resolved}`);
+  const stat = fs.lstatSync(resolved);
+  if (stat.isSymbolicLink() || !stat.isDirectory()) {
+    throw new Error(`${label} is not a safe directory: ${resolved}`);
+  }
+  return resolved;
+}
+
+function assertSafeTree(root: string, label: string): void {
+  const visit = (directory: string): void => {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const absolute = path.join(directory, entry.name);
+      const stat = fs.lstatSync(absolute);
+      if (stat.isSymbolicLink()) throw new Error(`${label} contains a symbolic link: ${entry.name}`);
+      if (stat.isDirectory()) visit(absolute);
+      else if (!stat.isFile()) throw new Error(`${label} contains an unsupported filesystem entry.`);
+    }
+  };
+  visit(root);
+}
+
+function normalizeScopedId(value: string, label: string): string {
+  const normalized = String(value || '').trim();
+  if (
+    !SCOPED_ID_PATTERN.test(normalized)
+    || normalized === '.'
+    || normalized === '..'
+    || !isPortablePackagePath(normalized)
+  ) {
+    throw new Error(`Invalid ${label} for Bot Skill candidate workspace.`);
+  }
+  return normalized;
+}
+
+function normalizeInstallName(value: string | undefined): string {
+  const normalized = String(value || '').replace(/\\/g, '/').trim();
+  if (!isPortablePackagePath(normalized)) {
+    throw new Error('Invalid install name for Bot Skill candidate workspace.');
+  }
+  return normalized;
+}
+
+function validLocalSkillId(value: unknown): boolean {
+  return /^[A-Za-z0-9._:-]{1,200}$/.test(String(value || ''));
+}
+
+function validIsoDate(value: unknown): boolean {
+  const text = String(value || '');
+  try {
+    return Boolean(text && new Date(text).toISOString() === text);
+  } catch {
+    return false;
+  }
+}
+
+function hashMarker(marker: BotSkillLocalMarker): string {
+  const normalized: BotSkillLocalMarker = {
+    schema: 'xiaoba.bot-skill-local.v1',
+    localSkillId: marker.localSkillId,
+    ...(marker.reference ? { reference: marker.reference } : {}),
+    ...(marker.origin ? { origin: marker.origin } : {}),
+  };
+  return crypto.createHash('sha256').update(JSON.stringify(normalized)).digest('hex');
+}
+
+function compareText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}

--- a/tests/bot-skill-candidate-workspace.test.ts
+++ b/tests/bot-skill-candidate-workspace.test.ts
@@ -1,0 +1,272 @@
+import { afterEach, describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  createBotSkillCandidate,
+  discardBotSkillCandidate,
+  inspectBotSkillCandidate,
+  recoverBotSkillCandidates,
+} from '../src/bot-skills/candidate-workspace';
+
+describe('isolated Bot Skill candidate workspace', () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('creates and verifies an atomic candidate without changing the active workspace', () => {
+    const root = createRuntimeRoot(roots);
+    const active = createSkill(path.join(root, 'skills'), 'formal-skill', 'formal');
+    const source = createSkill(path.join(root, 'source'), 'draft-skill', 'candidate');
+    const activeBefore = treeFingerprint(path.join(root, 'skills'));
+
+    const candidate = createBotSkillCandidate({
+      runtimeRoot: root,
+      botId: 'bot-a',
+      mutationId: 'mutation-1',
+      sourceSkillPath: source,
+      now: () => new Date('2026-08-23T00:00:00.000Z'),
+    });
+
+    assert.equal(candidate.manifest.state, 'prepared');
+    assert.equal(candidate.manifest.installName, 'draft-skill');
+    assert.equal(candidate.skill.name, 'draft-skill');
+    assert.equal(fs.readFileSync(path.join(candidate.packagePath, 'body.txt'), 'utf8'), 'candidate');
+    assert.deepEqual(treeFingerprint(path.join(root, 'skills')), activeBefore);
+    assert.equal(fs.readFileSync(path.join(active, 'body.txt'), 'utf8'), 'formal');
+    assert.equal(fs.existsSync(path.join(source, '.xiaoba-bot-skill.json')), false);
+  });
+
+  test('is idempotent for the same mutation and rejects conflicting content', () => {
+    const root = createRuntimeRoot(roots);
+    const source = createSkill(path.join(root, 'source'), 'draft-skill', 'one');
+    const first = createBotSkillCandidate({
+      runtimeRoot: root,
+      botId: 'bot-a',
+      mutationId: 'mutation-1',
+      sourceSkillPath: source,
+    });
+    const second = createBotSkillCandidate({
+      runtimeRoot: root,
+      botId: 'bot-a',
+      mutationId: 'mutation-1',
+      sourceSkillPath: source,
+    });
+    assert.equal(first.path, second.path);
+    assert.equal(second.deduplicated, true);
+
+    fs.writeFileSync(path.join(source, 'body.txt'), 'two');
+    assert.throws(() => createBotSkillCandidate({
+      runtimeRoot: root,
+      botId: 'bot-a',
+      mutationId: 'mutation-1',
+      sourceSkillPath: source,
+    }), /already exists with different content/i);
+  });
+
+  test('does not deduplicate a different local Skill identity with identical files', () => {
+    const root = createRuntimeRoot(roots);
+    const firstSource = createSkill(path.join(root, 'source-a'), 'draft-skill', 'same');
+    const secondSource = createSkill(path.join(root, 'source-b'), 'draft-skill', 'same');
+    writeMarker(firstSource, 'local-one');
+    writeMarker(secondSource, 'local-two');
+    createBotSkillCandidate({
+      runtimeRoot: root, botId: 'bot-a', mutationId: 'one', sourceSkillPath: firstSource,
+    });
+    assert.throws(() => createBotSkillCandidate({
+      runtimeRoot: root, botId: 'bot-a', mutationId: 'one', sourceSkillPath: secondSource,
+    }), /already exists with different content/i);
+  });
+
+  test('isolates candidates by Bot and mutation', () => {
+    const root = createRuntimeRoot(roots);
+    const source = createSkill(path.join(root, 'source'), 'draft-skill', 'candidate');
+    const botAOne = createBotSkillCandidate({
+      runtimeRoot: root, botId: 'bot-a', mutationId: 'one', sourceSkillPath: source,
+    });
+    const botATwo = createBotSkillCandidate({
+      runtimeRoot: root, botId: 'bot-a', mutationId: 'two', sourceSkillPath: source,
+    });
+    const botBOne = createBotSkillCandidate({
+      runtimeRoot: root, botId: 'bot-b', mutationId: 'one', sourceSkillPath: source,
+    });
+    assert.notEqual(botAOne.path, botATwo.path);
+    assert.notEqual(botAOne.path, botBOne.path);
+    assert.equal(inspectBotSkillCandidate({ runtimeRoot: root, botId: 'bot-b', mutationId: 'one' }).skill.name, 'draft-skill');
+  });
+
+  test('rejects unsafe identifiers, install paths, and source symlinks', (t) => {
+    const root = createRuntimeRoot(roots);
+    const source = createSkill(path.join(root, 'source'), 'draft-skill', 'candidate');
+    for (const botId of ['..', '.', 'bot/other', 'C:\\bot', 'bot.', 'CON']) {
+      assert.throws(() => createBotSkillCandidate({
+        runtimeRoot: root, botId, mutationId: 'one', sourceSkillPath: source,
+      }), /invalid Bot ID/i);
+    }
+    for (const mutationId of ['..', '.', 'one/two', 'C:\\mutation', 'mutation.', 'NUL']) {
+      assert.throws(() => createBotSkillCandidate({
+        runtimeRoot: root, botId: 'bot-a', mutationId, sourceSkillPath: source,
+      }), /invalid mutation ID/i);
+    }
+    assert.throws(() => createBotSkillCandidate({
+      runtimeRoot: root,
+      botId: 'bot-a',
+      mutationId: 'one',
+      sourceSkillPath: source,
+      installName: '../escape',
+    }), /invalid install name/i);
+
+    const outside = path.join(root, 'outside.txt');
+    fs.writeFileSync(outside, 'outside');
+    const link = path.join(source, 'linked.txt');
+    try {
+      fs.symlinkSync(outside, link, 'file');
+    } catch (error: any) {
+      if (process.platform === 'win32' && ['EPERM', 'EACCES', 'UNKNOWN'].includes(String(error?.code))) {
+        t.skip('Windows symlink creation is unavailable for this user');
+        return;
+      }
+      throw error;
+    }
+    assert.throws(() => createBotSkillCandidate({
+      runtimeRoot: root, botId: 'bot-a', mutationId: 'two', sourceSkillPath: source,
+    }), /symbolic link/i);
+  });
+
+  test('reports interrupted and corrupt candidates without deleting evidence', () => {
+    const root = createRuntimeRoot(roots);
+    const source = createSkill(path.join(root, 'source'), 'draft-skill', 'candidate');
+    const valid = createBotSkillCandidate({
+      runtimeRoot: root, botId: 'bot-a', mutationId: 'ready', sourceSkillPath: source,
+    });
+    const botRoot = path.dirname(valid.path);
+    const interrupted = path.join(botRoot, '.tmp-interrupted');
+    const corrupt = path.join(botRoot, 'corrupt');
+    fs.mkdirSync(interrupted);
+    fs.mkdirSync(corrupt);
+    fs.writeFileSync(path.join(corrupt, 'candidate.json'), '{broken');
+
+    const recovery = recoverBotSkillCandidates(root, 'bot-a');
+    assert.deepEqual(recovery.map(entry => entry.status), ['incomplete', 'invalid', 'ready']);
+    assert.equal(fs.existsSync(interrupted), true);
+    assert.equal(fs.existsSync(corrupt), true);
+    assert.equal(fs.existsSync(valid.path), true);
+  });
+
+  test('discard removes only the exact verified candidate', () => {
+    const root = createRuntimeRoot(roots);
+    const active = createSkill(path.join(root, 'skills'), 'formal-skill', 'formal');
+    const source = createSkill(path.join(root, 'source'), 'draft-skill', 'candidate');
+    const first = createBotSkillCandidate({
+      runtimeRoot: root, botId: 'bot-a', mutationId: 'one', sourceSkillPath: source,
+    });
+    const sibling = createBotSkillCandidate({
+      runtimeRoot: root, botId: 'bot-a', mutationId: 'two', sourceSkillPath: source,
+    });
+
+    assert.equal(discardBotSkillCandidate({ runtimeRoot: root, botId: 'bot-a', mutationId: 'one' }), true);
+    assert.equal(fs.existsSync(first.path), false);
+    assert.equal(fs.existsSync(sibling.path), true);
+    assert.equal(fs.readFileSync(path.join(active, 'body.txt'), 'utf8'), 'formal');
+    assert.equal(discardBotSkillCandidate({ runtimeRoot: root, botId: 'bot-a', mutationId: 'one' }), false);
+  });
+
+  test('refuses to discard invalid evidence', () => {
+    const root = createRuntimeRoot(roots);
+    const source = createSkill(path.join(root, 'source'), 'draft-skill', 'candidate');
+    const candidate = createBotSkillCandidate({
+      runtimeRoot: root, botId: 'bot-a', mutationId: 'one', sourceSkillPath: source,
+    });
+    fs.writeFileSync(path.join(candidate.packagePath, 'body.txt'), 'tampered');
+    assert.throws(() => discardBotSkillCandidate({
+      runtimeRoot: root, botId: 'bot-a', mutationId: 'one',
+    }), /no longer matches/i);
+    assert.equal(fs.existsSync(candidate.path), true);
+  });
+
+  test('detects candidate provenance marker tampering', () => {
+    const root = createRuntimeRoot(roots);
+    const source = createSkill(path.join(root, 'source'), 'draft-skill', 'candidate');
+    const candidate = createBotSkillCandidate({
+      runtimeRoot: root, botId: 'bot-a', mutationId: 'one', sourceSkillPath: source,
+    });
+    writeMarker(candidate.packagePath, candidate.manifest.localSkillId, {
+      skillId: 'owner/other-skill',
+      version: 'v1',
+    });
+    assert.throws(() => inspectBotSkillCandidate({
+      runtimeRoot: root, botId: 'bot-a', mutationId: 'one',
+    }), /no longer matches/i);
+    assert.equal(fs.existsSync(candidate.path), true);
+  });
+
+  test('inspection does not recreate a missing candidate marker', () => {
+    const root = createRuntimeRoot(roots);
+    const source = createSkill(path.join(root, 'source'), 'draft-skill', 'candidate');
+    const candidate = createBotSkillCandidate({
+      runtimeRoot: root, botId: 'bot-a', mutationId: 'one', sourceSkillPath: source,
+    });
+    const markerPath = path.join(candidate.packagePath, '.xiaoba-bot-skill.json');
+    fs.rmSync(markerPath);
+    assert.throws(() => inspectBotSkillCandidate({
+      runtimeRoot: root, botId: 'bot-a', mutationId: 'one',
+    }), /marker cannot be read safely/i);
+    assert.equal(fs.existsSync(markerPath), false);
+  });
+
+  test('refuses a corrupt source marker instead of assigning a new identity', () => {
+    const root = createRuntimeRoot(roots);
+    const source = createSkill(path.join(root, 'source'), 'draft-skill', 'candidate');
+    const markerPath = path.join(source, '.xiaoba-bot-skill.json');
+    fs.writeFileSync(markerPath, '{broken');
+    assert.throws(() => createBotSkillCandidate({
+      runtimeRoot: root, botId: 'bot-a', mutationId: 'one', sourceSkillPath: source,
+    }), /source Skill local marker cannot be read safely/i);
+    assert.equal(fs.readFileSync(markerPath, 'utf8'), '{broken');
+  });
+});
+
+function createRuntimeRoot(roots: string[]): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-skill-candidate-'));
+  roots.push(root);
+  return root;
+}
+
+function createSkill(parent: string, name: string, body: string): string {
+  const root = path.join(parent, name);
+  fs.mkdirSync(root, { recursive: true });
+  fs.writeFileSync(path.join(root, 'SKILL.md'), `---\nname: ${name}\ndescription: candidate test\n---\n`);
+  fs.writeFileSync(path.join(root, 'body.txt'), body);
+  return root;
+}
+
+function writeMarker(
+  skillRoot: string,
+  localSkillId: string,
+  origin?: { skillId: string; version: string },
+): void {
+  fs.writeFileSync(path.join(skillRoot, '.xiaoba-bot-skill.json'), `${JSON.stringify({
+    schema: 'xiaoba.bot-skill-local.v1',
+    localSkillId,
+    ...(origin ? { origin } : {}),
+  })}\n`);
+}
+
+function treeFingerprint(root: string): Array<{ path: string; content: string }> {
+  const files: Array<{ path: string; content: string }> = [];
+  const visit = (directory: string): void => {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const absolute = path.join(directory, entry.name);
+      if (entry.isDirectory()) visit(absolute);
+      else if (entry.isFile()) files.push({
+        path: path.relative(root, absolute).replace(/\\/g, '/'),
+        content: fs.readFileSync(absolute).toString('base64'),
+      });
+    }
+  };
+  visit(root);
+  return files.sort((left, right) => left.path.localeCompare(right.path));
+}


### PR DESCRIPTION
## 目标

为第二阶段的 Skill 修改流程提供一个默认不可达、与正式 Skill 工作区隔离的候选区基础设施。

本 PR 只建立内部存储与校验能力，不把它接入聊天、模型工具、Runtime 启动或 BotDefinition 激活。

## 实现

- 候选路径：`userData/data/bot-skills/candidates/<botId>/<mutationId>`
- 通过“临时目录 → 内容/marker 校验 → 原子改名”创建候选副本
- 复用现有 Skill 包路径、大小、YAML 和内容哈希规则
- 同一个 mutation 支持幂等重试；内容或本地 Skill 身份不同则拒绝复用
- 按 Bot 和 mutation 隔离
- 只读检查候选完整性，不在检查时自动修复或补写 marker
- 恢复扫描只报告 ready / incomplete / invalid，不自动删除证据
- 删除只允许精确删除一个已完整验证的候选

## 现有能力隔离

- 不修改正式 `skills` 工作区
- 不修改 `write_file`、`edit_file`、`read_file`、`send_file`、`import_file` 或 `execute_shell`
- 不修改注入、System Prompt、tool schema、BotDefinition 激活或同步逻辑
- 不注册任何新模型工具或 WebApp 入口

因此，合并后现有用户不会看到新入口，第一阶段功能和当前 Skill 执行路径保持不变。

## 验证

- `npm run build`：通过
- `npm run test:skillhub-phase1`：238 passed，1 skipped
  - 跳过项仅为当前 Windows 测试账户没有创建符号链接权限
- 全仓 Runtime 回归：1626 项中 1613 passed、11 skipped；2 项因本机缺少 `jq` 失败，均属于未改动的 worker artifact updater 测试

新增测试覆盖正式工作区不变、Bot/mutation 隔离、幂等与冲突、Windows 路径边界、损坏/中断证据保留、marker 完整性和精确删除。