### PR TITLE
feat(runtime): add recoverable cross-process file lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "ora": "^5.4.1",
         "pdf-parse": "^1.1.1",
         "pdfjs-dist": "^4.6.82",
+        "proper-lockfile": "^4.1.2",
         "sharp": "^0.34.5"
       },
       "bin": {
@@ -7571,7 +7572,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
       "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -7863,7 +7863,6 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "ora": "^5.4.1",
     "pdf-parse": "^1.1.1",
     "pdfjs-dist": "^4.6.82",
+    "proper-lockfile": "^4.1.2",
     "sharp": "^0.34.5"
   },
   "devDependencies": {

--- a/src/core/file-lock.ts
+++ b/src/core/file-lock.ts
@@ -1,0 +1,145 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+interface ProperLockOptions {
+  realpath: boolean;
+  lockfilePath: string;
+  stale: number;
+  update: number | boolean;
+  retries?: number | { retries: number; factor: number; minTimeout: number; maxTimeout: number; randomize: boolean };
+}
+interface ProperLockfile {
+  lock(file: string, options: ProperLockOptions): Promise<() => Promise<void>>;
+  lockSync(file: string, options: ProperLockOptions): () => void;
+}
+
+const properLockfile = require('proper-lockfile') as ProperLockfile;
+const RETRY_MS = 10;
+const STALE_MS = 60_000;
+
+/** Synchronous cross-process mutex for short persistence critical sections. */
+export function withExclusiveFileLock<T>(lockPath: string, operation: () => T): T {
+  prepare(lockPath);
+  let release: (() => void) | undefined;
+  for (;;) {
+    try {
+      release = properLockfile.lockSync(lockPath, options(lockPath, false));
+      break;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ELOCKED') throw error;
+      sleep(RETRY_MS);
+    }
+  }
+  try {
+    return operation();
+  } finally {
+    release();
+  }
+}
+
+export interface ExclusiveFileLockContext {
+  /** True when another owner held the lock before this caller acquired it. */
+  contended: boolean;
+}
+
+/** Cross-process mutex with a renewed lease for Goal drafting and wake work. */
+export async function withExclusiveFileLockAsync<T>(
+  lockPath: string,
+  operation: (context: ExclusiveFileLockContext) => Promise<T>,
+): Promise<T> {
+  prepare(lockPath);
+  let contended = false;
+  let sawOwner = false;
+  let lastObservedLockMtime: number | undefined;
+  let release: (() => Promise<void>) | undefined;
+  let lastLockedError: unknown;
+  for (let attempt = 0; attempt <= 12_000; attempt += 1) {
+    // Re-check compatibility on every retry: a legacy file may become stale
+    // while this caller waits. A stale directory is recovered by
+    // proper-lockfile itself, but sampling it lets us distinguish takeover
+    // (no winning wake) from a live owner that released (duplicate wake).
+    const recoveredLegacyFile = recoverStaleLegacyFile(lockPath);
+    const sampledLock = sampleLockPath(lockPath);
+    if (sampledLock?.kind === 'file') {
+      // proper-lockfile expects a directory at lockfilePath and may throw
+      // ENOTDIR while a legacy file ages into staleness. Wait for and migrate
+      // that representation ourselves instead of passing it to the library.
+      sawOwner = true;
+      lastObservedLockMtime = sampledLock.mtimeMs;
+      if (attempt === 12_000) throw new Error(`Timed out waiting for legacy lock ${lockPath}`);
+      await delay(RETRY_MS);
+      continue;
+    }
+    try {
+      release = await properLockfile.lock(lockPath, options(lockPath, true));
+      const staleTakeover = recoveredLegacyFile
+        || sampledLock?.stale === true
+        || (lastObservedLockMtime !== undefined && Date.now() - lastObservedLockMtime > staleMs());
+      contended = sawOwner && !staleTakeover;
+      break;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ELOCKED') throw error;
+      lastLockedError = error;
+      sawOwner = true;
+      if (sampledLock) lastObservedLockMtime = sampledLock.mtimeMs;
+      if (attempt === 12_000) throw lastLockedError;
+      await delay(RETRY_MS);
+    }
+  }
+  if (!release) throw lastLockedError || new Error(`Failed to acquire lock ${lockPath}`);
+  try {
+    return await operation({ contended });
+  } finally {
+    await release();
+  }
+}
+
+function options(lockPath: string, asynchronous: boolean): ProperLockOptions {
+  return {
+    realpath: false,
+    lockfilePath: lockPath,
+    stale: staleMs(),
+    update: asynchronous ? staleMs() / 3 : false,
+  };
+}
+
+function prepare(lockPath: string): void {
+  fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+  recoverStaleLegacyFile(lockPath);
+}
+
+function recoverStaleLegacyFile(lockPath: string): boolean {
+  try {
+    const stat = fs.statSync(lockPath);
+    if (!stat.isFile() || Date.now() - stat.mtimeMs <= staleMs()) return false;
+    fs.unlinkSync(lockPath);
+    return true;
+  } catch {
+    // Missing paths and racing recovery attempts are expected.
+    return false;
+  }
+}
+
+function sampleLockPath(lockPath: string): { kind: 'file' | 'directory' | 'other'; mtimeMs: number; stale: boolean } | undefined {
+  try {
+    const stat = fs.statSync(lockPath);
+    const kind = stat.isFile() ? 'file' : stat.isDirectory() ? 'directory' : 'other';
+    return { kind, mtimeMs: stat.mtimeMs, stale: Date.now() - stat.mtimeMs > staleMs() };
+  } catch {
+    return undefined;
+  }
+}
+
+function staleMs(): number {
+  const configured = Number(process.env.XIAOBA_FILE_LOCK_STALE_MS);
+  return Number.isFinite(configured) && configured >= 2_000 ? configured : STALE_MS;
+}
+
+function sleep(milliseconds: number): void {
+  const shared = new Int32Array(new SharedArrayBuffer(4));
+  Atomics.wait(shared, 0, 0, milliseconds);
+}
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, milliseconds));
+}

--- a/tests/file-lock.test.ts
+++ b/tests/file-lock.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, test } from 'node:test';
+import * as assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { withExclusiveFileLockAsync } from '../src/core/file-lock';
+
+const roots: string[] = [];
+afterEach(() => { for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true }); });
+
+describe('file lock', () => {
+  test('renews a live asynchronous lease beyond the stale threshold', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'file-lock-')); roots.push(root);
+    const lockPath = path.join(root, 'goal.lock');
+    const previous = process.env.XIAOBA_FILE_LOCK_STALE_MS;
+    process.env.XIAOBA_FILE_LOCK_STALE_MS = '2000';
+    let release!: () => void;
+    let entered!: () => void;
+    const enteredPromise = new Promise<void>(resolve => { entered = resolve; });
+    const gate = new Promise<void>(resolve => { release = resolve; });
+    let secondEntered = false;
+    try {
+      const first = withExclusiveFileLockAsync(lockPath, async ({ contended }) => {
+        assert.equal(contended, false);
+        entered();
+        await gate;
+      });
+      await enteredPromise;
+      await new Promise(resolve => setTimeout(resolve, 2500));
+      const second = withExclusiveFileLockAsync(lockPath, async ({ contended }) => {
+        assert.equal(contended, true);
+        secondEntered = true;
+      });
+      await new Promise(resolve => setTimeout(resolve, 100));
+      assert.equal(secondEntered, false);
+      release();
+      await Promise.all([first, second]);
+      assert.equal(secondEntered, true);
+      assert.equal(fs.existsSync(lockPath), false);
+    } finally {
+      if (previous === undefined) delete process.env.XIAOBA_FILE_LOCK_STALE_MS;
+      else process.env.XIAOBA_FILE_LOCK_STALE_MS = previous;
+    }
+  });
+
+  test('serializes two contenders recovering the same stale lock directory', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'file-lock-')); roots.push(root);
+    const lockPath = path.join(root, 'stale.lock');
+    fs.mkdirSync(lockPath);
+    const old = new Date(Date.now() - 120_000);
+    fs.utimesSync(lockPath, old, old);
+    let active = 0;
+    let overlap = false;
+    const operation = () => withExclusiveFileLockAsync(lockPath, async () => {
+      active += 1;
+      if (active > 1) overlap = true;
+      await new Promise(resolve => setTimeout(resolve, 30));
+      active -= 1;
+    });
+    await Promise.all([operation(), operation()]);
+    assert.equal(overlap, false);
+    assert.equal(fs.existsSync(lockPath), false);
+  });
+
+  test('recovers an old malformed lock left before owner metadata was written', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'file-lock-')); roots.push(root);
+    const lockPath = path.join(root, 'orphan.lock');
+    fs.writeFileSync(lockPath, '');
+    const old = new Date(Date.now() - 120_000);
+    fs.utimesSync(lockPath, old, old);
+    let entered = false;
+    await withExclusiveFileLockAsync(lockPath, async () => { entered = true; });
+    assert.equal(entered, true);
+    assert.equal(fs.existsSync(lockPath), false);
+  });
+
+  test('treats a directory that becomes stale while waiting as recovery, not a duplicate owner', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'file-lock-')); roots.push(root);
+    const lockPath = path.join(root, 'late-stale-directory.lock');
+    const previous = process.env.XIAOBA_FILE_LOCK_STALE_MS;
+    process.env.XIAOBA_FILE_LOCK_STALE_MS = '2000';
+    fs.mkdirSync(lockPath);
+    const almostStale = new Date(Date.now() - 1700);
+    fs.utimesSync(lockPath, almostStale, almostStale);
+    try {
+      let context: { contended: boolean } | undefined;
+      await withExclusiveFileLockAsync(lockPath, async acquired => { context = acquired; });
+      assert.deepEqual(context, { contended: false });
+      assert.equal(fs.existsSync(lockPath), false);
+    } finally {
+      if (previous === undefined) delete process.env.XIAOBA_FILE_LOCK_STALE_MS;
+      else process.env.XIAOBA_FILE_LOCK_STALE_MS = previous;
+    }
+  });
+
+  test('retries a legacy file lock that becomes stale while waiting', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'file-lock-')); roots.push(root);
+    const lockPath = path.join(root, 'late-stale-file.lock');
+    const previous = process.env.XIAOBA_FILE_LOCK_STALE_MS;
+    process.env.XIAOBA_FILE_LOCK_STALE_MS = '2000';
+    fs.writeFileSync(lockPath, 'legacy lock');
+    const almostStale = new Date(Date.now() - 1700);
+    fs.utimesSync(lockPath, almostStale, almostStale);
+    try {
+      let context: { contended: boolean } | undefined;
+      await withExclusiveFileLockAsync(lockPath, async acquired => { context = acquired; });
+      assert.deepEqual(context, { contended: false });
+      assert.equal(fs.existsSync(lockPath), false);
+    } finally {
+      if (previous === undefined) delete process.env.XIAOBA_FILE_LOCK_STALE_MS;
+      else process.env.XIAOBA_FILE_LOCK_STALE_MS = previous;
+    }
+  });
+});


### PR DESCRIPTION
## 做了什么重要事情

新增可恢复的跨进程文件锁，并覆盖以下运行时边界：

- 为长时间异步任务续租，避免健康运行的任务被误判为陈旧锁。
- 在锁目录、元数据不完整、旧格式锁和等待期间过期等情况下安全恢复。
- 通过专项测试验证两个竞争者不会因陈旧锁恢复而重叠执行。

## 为什么需要提交这个 PR

Agent Run、Review 和 Inspection 等运行时会共享持久化状态。没有可靠的跨进程锁时，长任务可能被误清理，陈旧锁可能永久阻塞恢复流程，多个执行者也可能同时写入并互相覆盖状态。

该改动边界独立、可复用，并且不包含 runtime-sync 分支中不相关的行为变化，因此应作为单独 PR 审查和回滚。

## 验证

- npm run build
- node --import tsx --test tests/file-lock.test.ts
- 5 个专项测试全部通过

## 来源与基线

- PR head：CatsCo-Albert:XiaoBa-CLI 的 pr/recoverable-file-lock-buildsense-forkbase
- 目标：buildsense-ai:XiaoBa-CLI 的 main
