### PR TITLE
fix(runtime): preserve classified model failures across channels

### DIFF
--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -46,7 +46,6 @@ import { parseSessionKeyV2 } from './session-router';
 import {
   classifyModelError,
   isModelImageSafetyError,
-  type ModelErrorCategory,
 } from '../utils/model-error-classifier';
 import {
   readModelErrorDiagnostics,
@@ -1350,12 +1349,11 @@ export class AgentSession {
   private formatRelayBudgetErrorReply(error: any): string | null {
     const text = safeErrorText(error);
     const status = this.extractErrorStatus(error);
-    return (
-      status === 402
+    const isBudgetError = status === 402
       || /api错误\s*\(402\)|status(?:\s*code)?\s*[:=]?\s*402\b|http(?:\s*status)?\s*[:=]?\s*402\b|payment[_\s-]?required/i.test(text)
       || /budget exceeded|quota exceeded|insufficient quota|insufficient balance|credits? exhausted|monthly budget|model budget|relay budget/i.test(text)
-      || /额度.{0,12}(不足|用完|耗尽|超限|达到上限|已用尽)|余额不足|已达.*额度上限/.test(text)
-    );
+      || /额度.{0,12}(不足|用完|耗尽|超限|达到上限|已用尽)|余额不足|已达.*额度上限/.test(text);
+    return isBudgetError ? '当前模型额度不足，请检查模型额度或切换模型后重试。' : null;
   }
 
   private extractErrorStatus(error: any): number | null {

--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -67,6 +67,8 @@ import {
   isCheckpointCompactionEnabled,
 } from './checkpoint-compaction';
 import { estimateToolsTokens } from './token-estimator';
+import { resolveSessionSurface } from './session-surface';
+import { getPetService } from '../pet/pet-service';
 import type { SessionRuntimeLogEvent, TurnErrorPayload } from '../utils/session-log-schema';
 
 export type { RuntimeFeedbackInput, RuntimeFeedbackOptions } from './runtime-feedback-inbox';
@@ -76,6 +78,26 @@ export interface DurableRemoteContextEntry {
   id: number;
   role?: 'user' | 'assistant';
   content: string;
+}
+
+function safeErrorProperty(error: unknown, property: PropertyKey): unknown {
+  if (!error || (typeof error !== 'object' && typeof error !== 'function')) return undefined;
+  try {
+    return Reflect.get(error, property);
+  } catch {
+    return undefined;
+  }
+}
+
+function safeErrorText(error: unknown): string {
+  const message = safeErrorProperty(error, 'message');
+  if (typeof message === 'string' && message) return message;
+  try {
+    const text = String(error ?? '');
+    return text || 'unknown error';
+  } catch {
+    return 'unknown error';
+  }
 }
 
 export const BUSY_MESSAGE = '正在处理上一条消息，请稍候...';
@@ -653,7 +675,7 @@ export class AgentSession {
         await reconcileCurrentBotPromptBeforeTurn();
         await this.refreshSystemPromptIfNeeded(lifecycleGeneration, this.activeAbortController.signal);
       } catch (error: any) {
-        Logger.warning(`[会话 ${this.key}] Prompt 热加载失败，继续使用上一版: ${error?.message || error}`);
+        Logger.warning(`[会话 ${this.key}] Prompt 热加载失败，继续使用上一版: ${safeErrorText(error)}`);
       }
 
       try {
@@ -722,7 +744,12 @@ export class AgentSession {
         }
         this.messages = result.messages;
         failurePhase = 'result_persistence';
-        this.lifecycleManager.saveContext(this.messages);
+        if (!this.lifecycleManager.saveContext(this.messages)) {
+          throw new Error('Completed turn context persistence failed');
+        }
+        if (result.visibleToUser) {
+          this.recordCompletedTurnEvents();
+        }
         return { ...result, taskOutcome: 'completed' };
       } catch (err: any) {
         if (this.isAbortError(err) || this.interruptRequested || this.activeAbortController.signal.aborted) {
@@ -733,7 +760,7 @@ export class AgentSession {
         }
 
         const recoveredMessages = this.getPartialMessagesFromError(err);
-        const partialProgressPreserved = recoveredMessages
+        const hasRecoverablePartialProgress = recoveredMessages
           ? this.hasRecoverablePartialProgress(recoveredMessages)
           : false;
         if (recoveredMessages) {
@@ -741,14 +768,16 @@ export class AgentSession {
         }
 
         // 识别多模态相关错误
-        const errorMsg = err.message || String(err);
+        const errorMsg = safeErrorText(err);
         const isImageSafetyError = isModelImageSafetyError(err);
         const isVisionError = !isImageSafetyError && errorMsg.match(/image|vision|multimodal|media_type|base64.*not supported/i);
         const isModelTimeoutError = this.isModelTimeoutError(err);
         const isTransientProviderError = this.isTransientProviderError(err);
         const isEmptyModelResponseError = this.isEmptyModelResponseError(err);
-        const isRelayBudgetError = this.isRelayBudgetError(err);
-        const closestDiagnostics = readModelErrorDiagnostics(err);
+        const relayBudgetErrorReply = this.formatRelayBudgetErrorReply(err);
+        const isRelayBudgetError = relayBudgetErrorReply !== null;
+        const closestDiagnostics = readModelErrorDiagnostics(err)
+          ?? readModelErrorDiagnostics(safeErrorProperty(err, 'cause'));
         const classified = classifyModelError(err, {
           isImageSafetyError,
           isRelayBudgetError,
@@ -763,6 +792,28 @@ export class AgentSession {
         });
         const diagnostics = classified.diagnostics;
         const retry = diagnostics.retry;
+        let baseErrorReply = classified.user_message;
+        if (relayBudgetErrorReply) {
+          baseErrorReply = relayBudgetErrorReply;
+        } else if (classified.category === 'transient') {
+          baseErrorReply = this.formatTransientProviderErrorReply();
+        }
+
+        // Keep internal failure context out of future prompts while persisting all durable progress.
+        this.messages.push({
+          role: 'assistant',
+          content: this.formatErrorContextMessage(err, {
+            isModelTimeoutError,
+            isImageSafetyError,
+            isTransientProviderError,
+            isEmptyModelResponseError,
+          }),
+          __internalErrorArtifact: true,
+        });
+        this.messages = stripAssistantArtifactsFromMessages(this.turnContextBuilder.removeTransientMessages(this.messages));
+        const contextPersisted = this.persistFailedTurnContext();
+        const partialProgressPreserved = hasRecoverablePartialProgress && contextPersisted;
+
         const errorPayload: TurnErrorPayload = {
           error_code: classified.error_code,
           category: classified.category,
@@ -790,6 +841,8 @@ export class AgentSession {
           retry_stop_reason: retry?.stop_reason ?? 'unknown',
           retry_elapsed_ms: retry?.elapsed_ms ?? 0,
           turn_elapsed_ms: Date.now() - turnStartedAt,
+          context_persisted: contextPersisted,
+          recoverable_partial_progress: hasRecoverablePartialProgress,
           partial_progress_preserved: partialProgressPreserved,
           episode_id: diagnostics.attempt?.episode_id,
           model_call_id: diagnostics.attempt?.call_id,
@@ -797,7 +850,7 @@ export class AgentSession {
           model_attempt_number: diagnostics.attempt?.attempt_number,
         };
 
-        // 只有真正退出本轮并返回 taskOutcome=failed 的路径才写 turn_error。
+        // Only terminal failures produce a turn_error, after persistence state is known.
         Logger.error(
           `[会话 ${this.key}] 处理中断: ${diagnostics.error_summary}`,
           {
@@ -806,26 +859,13 @@ export class AgentSession {
           } as SessionRuntimeLogEvent,
         );
 
-        const errorReply = this.formatClassifiedErrorReply(
-          classified.category,
-          classified.user_message,
-          retry?.retry_count ?? 0,
-        );
-
-        // 添加错误回复到上下文，保持对话连贯性
-        this.messages.push({
-          role: 'assistant',
-          content: this.formatErrorContextMessage(err, {
-            isModelTimeoutError,
-            isImageSafetyError,
-            isTransientProviderError,
-            isEmptyModelResponseError,
-          }),
-          __internalErrorArtifact: true,
+        const errorReply = this.formatClassifiedErrorReply(baseErrorReply, {
+          retryCount: retry?.retry_count ?? 0,
+          retryObserved: Boolean(retry),
+          retryStopReason: retry?.stop_reason,
+          contextPersisted,
+          hasRecoverablePartialProgress,
         });
-        this.messages = stripAssistantArtifactsFromMessages(this.turnContextBuilder.removeTransientMessages(this.messages));
-        this.lifecycleManager.saveContext(this.messages);
-
         return { text: errorReply, visibleToUser: true, taskOutcome: 'failed' };
       } finally {
         this.planRuntime.clear();
@@ -1168,6 +1208,17 @@ export class AgentSession {
     }
   }
 
+  private recordCompletedTurnEvents(): void {
+    const surface = resolveSessionSurface(this.key, this.sessionType);
+    for (const eventType of ['message_completed', 'task_completed'] as const) {
+      getPetService().recordEvent({
+        event_type: eventType,
+        session_id: this.key,
+        metadata: { surface },
+      });
+    }
+  }
+
   private stopSubAgents(reason: string): void {
     const result = SubAgentManager.getInstance().stopAllForParent(this.key, reason);
     if (result.stopped > 0) {
@@ -1182,14 +1233,60 @@ export class AgentSession {
     if (idx >= 0) this.messages.splice(idx, 1);
   }
 
+  private safeErrorText(error: unknown): string {
+    return safeErrorText(error);
+  }
+
+  private persistFailedTurnContext(): boolean {
+    try {
+      return this.lifecycleManager.saveContext(this.messages);
+    } catch (error) {
+      Logger.error(`[会话 ${this.key}] 失败上下文持久化异常: ${this.safeErrorText(error)}`);
+      return false;
+    }
+  }
+
+  private formatClassifiedErrorReply(
+    baseMessage: string,
+    state: {
+      retryCount: number;
+      retryObserved: boolean;
+      retryStopReason?: string;
+      contextPersisted: boolean;
+      hasRecoverablePartialProgress: boolean;
+    },
+  ): string {
+    const details: string[] = [baseMessage];
+    if (state.retryCount > 0) {
+      details.push(`系统已自动重试 ${state.retryCount} 次，仍未恢复。`);
+    } else if (state.retryObserved) {
+      details.push(state.retryStopReason === 'stream_output_started'
+        ? '因本轮已开始输出，为避免重复内容，系统未自动重试。'
+        : '系统未执行自动重试。');
+    } else {
+      details.push('本次未记录到自动重试。');
+    }
+
+    if (state.hasRecoverablePartialProgress && state.contextPersisted) {
+      details.push('已完成的工具结果和上下文已保存，可直接说“继续”。');
+    } else if (state.hasRecoverablePartialProgress) {
+      details.push('本轮已有部分进度，但持久化失败；当前进程内可继续，重启后可能丢失。');
+    } else if (state.contextPersisted) {
+      details.push('对话上下文已保存，但本轮没有可恢复的部分进度。');
+    } else {
+      details.push('上下文持久化失败，重启后本轮内容可能丢失。');
+    }
+    return details.join('');
+  }
+
   private isAbortError(error: any): boolean {
-    return error?.name === 'AbortError'
-      || error?.code === 'ERR_CANCELED'
-      || /请求已取消|aborted|aborterror|canceled|cancelled/i.test(String(error?.message || ''));
+    return safeErrorProperty(error, 'name') === 'AbortError'
+      || safeErrorProperty(error, 'code') === 'ERR_CANCELED'
+      || /请求已取消|aborted|aborterror|canceled|cancelled/i.test(safeErrorText(error));
   }
 
   private getPartialMessagesFromError(error: AgentTurnRunError): Message[] | null {
-    const partialMessages = error?.partialMessages;
+    const partialMessages = safeErrorProperty(error, 'partialMessages');
     if (!Array.isArray(partialMessages) || partialMessages.length === 0) {
       return null;
     }
@@ -1206,14 +1303,27 @@ export class AgentSession {
     }
     if (rootIndex < 0) return false;
     const episodeId = messages[rootIndex].__episodeId;
-    return messages.slice(rootIndex + 1).some(message =>
-      (!episodeId || message.__episodeId === episodeId)
-      && (message.role === 'tool' || message.role === 'assistant')
+    const episodeMessages = messages.slice(rootIndex + 1).filter(message =>
+      !episodeId || message.__episodeId === episodeId
     );
+    const issuedToolCallIds = new Set(
+      episodeMessages
+        .filter(message => message.role === 'assistant')
+        .flatMap(message => message.tool_calls ?? [])
+        .map(toolCall => String(toolCall.id || '').trim())
+        .filter(Boolean),
+    );
+    return episodeMessages.some(message => {
+      const toolCallId = String(message.tool_call_id || '').trim();
+      return message.role === 'tool'
+        && message.__toolExecutionSucceeded === true
+        && Boolean(toolCallId)
+        && issuedToolCallIds.has(toolCallId);
+    });
   }
 
   private isModelTimeoutError(error: any): boolean {
-    const text = String(error?.message || error || '');
+    const text = safeErrorText(error);
     return /API错误\s*\(504\)|request_timed_out|request timed out|default_request_timeout_in_seconds|upstream request timeout|gateway timeout/i.test(text);
   }
 
@@ -1223,20 +1333,22 @@ export class AgentSession {
       return true;
     }
 
-    const text = String(error?.message || error || '');
+    const text = safeErrorText(error);
     return /unknown error,\s*520|overloaded_error|service unavailable|bad gateway|gateway timeout|upstream (?:error|timeout)|MaxRetriesExceededError|Connection error|ECONNRESET|ETIMEDOUT|EAI_AGAIN|fetch failed|socket hang up|network error|premature close/i.test(text);
   }
 
   private isEmptyModelResponseError(error: any): boolean {
-    const code = String(error?.code || error?.cause?.code || '').toUpperCase();
+    const rawCode = safeErrorProperty(error, 'code')
+      || safeErrorProperty(safeErrorProperty(error, 'cause'), 'code');
+    const code = typeof rawCode === 'string' ? rawCode.toUpperCase() : '';
     if (code === 'EMPTY_MODEL_RESPONSE') {
       return true;
     }
-    return /模型未返回有效内容|模型返回了空响应/i.test(String(error?.message || error || ''));
+    return /模型未返回有效内容|模型返回了空响应/i.test(safeErrorText(error));
   }
 
-  private isRelayBudgetError(error: any): boolean {
-    const text = String(error?.message || error || '');
+  private formatRelayBudgetErrorReply(error: any): string | null {
+    const text = safeErrorText(error);
     const status = this.extractErrorStatus(error);
     return (
       status === 402
@@ -1247,10 +1359,12 @@ export class AgentSession {
   }
 
   private extractErrorStatus(error: any): number | null {
-    const status = error?.status || error?.response?.status || error?.error?.status;
+    const status = safeErrorProperty(error, 'status')
+      || safeErrorProperty(safeErrorProperty(error, 'response'), 'status')
+      || safeErrorProperty(safeErrorProperty(error, 'error'), 'status');
     if (typeof status === 'number') return status;
 
-    const text = String(error?.message || error || '');
+    const text = safeErrorText(error);
     const match = text.match(/(?:API错误|HTTP|status(?:\s*code)?)\s*[\(:= ]\s*(\d{3})\b/i);
     if (!match) return null;
     const parsed = Number(match[1]);
@@ -1273,21 +1387,11 @@ export class AgentSession {
     return provider || null;
   }
 
-  private formatClassifiedErrorReply(
-    category: ModelErrorCategory,
-    fallback: string,
-    retryCount: number,
-  ): string {
-    if (
-      category === 'image_safety'
-      || category === 'vision_unsupported'
-      || category === 'input_too_large'
-    ) {
-      return fallback;
-    }
-    return retryCount > 0
-      ? MODEL_RECOVERY_FAILED_MESSAGE
-      : MODEL_REQUEST_FAILED_MESSAGE;
+  private formatTransientProviderErrorReply(): string {
+    const model = this.currentModelName();
+    return model
+      ? `当前模型 ${model} 的服务临时异常，刚才这次请求没有完成。你可以稍后重试，或临时切换到其他模型继续。`
+      : MODEL_TRANSIENT_ERROR_MESSAGE;
   }
 
   private formatErrorContextMessage(
@@ -1299,18 +1403,18 @@ export class AgentSession {
       isEmptyModelResponseError?: boolean;
     },
   ): string {
-    const detail = this.sanitizeErrorMessage(error?.message || String(error));
+    const detail = this.sanitizeErrorMessage(safeErrorText(error));
     if (flags.isModelTimeoutError) {
-      return `[处理中断: 模型中转请求超时。已保留本轮已完成的工具结果和上下文；如果用户要求继续，请基于当前上下文继续，避免重复已经完成的工具步骤。错误摘要: ${detail}]`;
+      return `[处理中断: 模型中转请求超时。失败处理将尝试持久化本轮上下文，是否成功以持久化结果为准。错误摘要: ${detail}]`;
     }
     if (flags.isImageSafetyError) {
-      return `[处理中断: 上游模型拒绝了当前对话中的图片。已保留本轮已完成的上下文；如果用户要求继续，请提示用户删除或更换相关图片，或新开对话后继续。错误摘要: ${detail}]`;
+      return `[处理中断: 上游模型拒绝了当前对话中的图片。请提示用户删除或更换相关图片，或新开对话后继续。错误摘要: ${detail}]`;
     }
     if (flags.isTransientProviderError) {
-      return `[处理中断: 模型服务临时异常或上游网关错误。已保留本轮上下文；如果用户要求继续，请从当前状态继续，不要重复已经完成的工具步骤。错误摘要: ${detail}]`;
+      return `[处理中断: 模型服务临时异常或上游网关错误。失败处理将尝试持久化本轮上下文，是否成功以持久化结果为准。错误摘要: ${detail}]`;
     }
     if (flags.isEmptyModelResponseError) {
-      return `[处理中断: 模型未返回正文或工具调用，自动重试后仍未恢复。已保留本轮上下文；如果用户重试，请正常处理上一条请求。错误摘要: ${detail}]`;
+      return `[处理中断: 模型未返回正文或工具调用。失败处理将尝试持久化本轮上下文，是否成功以持久化结果为准。错误摘要: ${detail}]`;
     }
     return `[处理失败: ${detail}]`;
   }

--- a/src/core/agent-turn-controller.ts
+++ b/src/core/agent-turn-controller.ts
@@ -28,7 +28,6 @@ import { resolveSessionSurface } from './session-surface';
 import { TurnContextBuilder } from './turn-context-builder';
 import { TurnLogRecorder } from './turn-log-recorder';
 import { PlanRuntime } from './plan-runtime';
-import { getPetService } from '../pet/pet-service';
 import {
   buildSyntheticObservationLifecycleEvent,
   describeSyntheticObservationForLog,
@@ -97,6 +96,46 @@ export interface RunAgentTurnResult {
 
 export interface AgentTurnRunError extends Error {
   partialMessages?: Message[];
+}
+
+/**
+ * Carries recoverable turn messages without mutating a provider-owned error.
+ * Provider errors may be frozen, proxied, or expose throwing property setters.
+ */
+export class AgentTurnExecutionError extends Error implements AgentTurnRunError {
+  readonly partialMessages: Message[];
+
+  constructor(cause: unknown, partialMessages: Message[]) {
+    super(safeErrorMessage(cause));
+    this.name = 'AgentTurnExecutionError';
+    try {
+      Object.defineProperty(this, 'cause', {
+        value: cause,
+        configurable: true,
+        writable: false,
+        enumerable: false,
+      });
+    } catch {
+      // The wrapper remains useful even if cause cannot be attached.
+    }
+    this.partialMessages = partialMessages;
+  }
+}
+
+function safeErrorMessage(error: unknown): string {
+  try {
+    if (error instanceof Error && typeof error.message === 'string' && error.message) {
+      return error.message;
+    }
+  } catch {
+    // Fall through to a stable message.
+  }
+  try {
+    const text = String(error ?? '');
+    return text || 'Agent turn failed';
+  } catch {
+    return 'Agent turn failed';
+  }
 }
 
 export interface AgentTurnControllerOptions {
@@ -208,7 +247,7 @@ export class AgentTurnController {
       const partialMessages = this.options.turnContextBuilder.removeTransientMessages(turnContext.messages);
       this.replaceBase64Images(partialMessages);
       if (partialMessages.length > 0) {
-        (error as AgentTurnRunError).partialMessages = partialMessages;
+        throw new AgentTurnExecutionError(error, partialMessages);
       }
       throw error;
     } finally {
@@ -237,11 +276,6 @@ export class AgentTurnController {
     const finalResponseVisible = result.finalResponseVisible && params.suppressFinalResponse !== true;
     if (result.finalResponseVisible && params.suppressFinalResponse === true) {
       Logger.info(`[${this.options.sessionKey}] runtime observation final response suppressed: ${params.runtimeObservationSource || 'unknown'}`);
-    }
-
-    if (finalResponseVisible) {
-      this.recordPetTurnCompletion('message_completed');
-      this.recordPetTurnCompletion('task_completed');
     }
 
     return {
@@ -488,13 +522,4 @@ export class AgentTurnController {
     }
   }
 
-  private recordPetTurnCompletion(eventType: 'message_completed' | 'task_completed'): void {
-    getPetService().recordEvent({
-      event_type: eventType,
-      session_id: this.options.sessionKey,
-      metadata: {
-        surface: resolveSessionSurface(this.options.sessionKey, this.options.sessionType),
-      },
-    });
-  }
 }

--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -1002,6 +1002,7 @@ export class ConversationRunner {
           ],
           tool_call_id: record.result.tool_call_id,
           name: record.result.name,
+          __toolExecutionSucceeded: record.result.ok === true && !record.result.errorCode,
           ...(this.episodeId ? { __episodeId: this.episodeId } : {}),
         });
       } else {
@@ -1011,6 +1012,7 @@ export class ConversationRunner {
           content: record.toolContent,
           tool_call_id: record.result.tool_call_id,
           name: record.result.name,
+          __toolExecutionSucceeded: record.result.ok === true && !record.result.errorCode,
           ...(this.episodeId ? { __episodeId: this.episodeId } : {}),
         });
 

--- a/src/feishu/index.ts
+++ b/src/feishu/index.ts
@@ -442,17 +442,13 @@ export class FeishuBot {
         Logger.info(`[${sessionKey}] 主会话竞态忙碌，子智能体反馈已入队`);
         return;
       }
-      if (result.taskOutcome === 'failed') {
+      if (result.visibleToUser && (result.taskOutcome === 'failed' || result.taskOutcome === 'cancelled')) {
         await this.sender.reply(chatId, result.text);
       }
       await this.drainMessageQueue(sessionKey);
     } finally {
       this.clearPendingAnswerBySession(sessionKey);
     }
-    if (result.visibleToUser && (result.taskOutcome === 'failed' || result.taskOutcome === 'cancelled')) {
-      await this.sender.reply(chatId, result.text);
-    }
-    await this.drainMessageQueue(sessionKey);
   }
 
   private enqueueSubAgentFeedback(

--- a/src/feishu/index.ts
+++ b/src/feishu/index.ts
@@ -383,18 +383,21 @@ export class FeishuBot {
       isGroup,
     });
 
-    try {
-      const result = await session.handleMessage(userText, {
-        channel,
-        sessionRoute: route,
-        executionScope: createExecutionScopeFromRoute(route),
-        runtimeFeedback,
-      });
-      if (result.text === BUSY_MESSAGE || result.taskOutcome === 'failed') {
-        await this.sender.reply(msg.chatId, result.text);
-      }
-    } finally {
-      this.clearPendingAnswerBySession(key);
+    const result = await session.handleMessage(userText, {
+      channel,
+      sessionRoute: route,
+      executionScope: createExecutionScopeFromRoute(route),
+      runtimeFeedback,
+    });
+    if (result.text === BUSY_MESSAGE) {
+      const queue = this.messageQueue.get(key) ?? [];
+      queue.unshift({ userText, chatId: msg.chatId, senderId: msg.senderId, sessionRoute: route, source: 'user', runtimeFeedback });
+      this.messageQueue.set(key, queue);
+      Logger.info(`[${key}] 主消息处理遇到竞态忙碌，已重新入队`);
+      return;
+    }
+    if (result.visibleToUser && (result.taskOutcome === 'failed' || result.taskOutcome === 'cancelled')) {
+      await this.sender.reply(msg.chatId, result.text);
     }
 
     // 处理忙时排队的消息
@@ -446,6 +449,10 @@ export class FeishuBot {
     } finally {
       this.clearPendingAnswerBySession(sessionKey);
     }
+    if (result.visibleToUser && (result.taskOutcome === 'failed' || result.taskOutcome === 'cancelled')) {
+      await this.sender.reply(chatId, result.text);
+    }
+    await this.drainMessageQueue(sessionKey);
   }
 
   private enqueueSubAgentFeedback(
@@ -487,26 +494,29 @@ export class FeishuBot {
     });
     const executionScope = createExecutionScopeFromRoute(msg.sessionRoute);
 
-    try {
-      const result = msg.source === 'subagent_feedback'
-        ? await session.handleRuntimeObservation(msg.userText, {
-          channel,
-          sessionRoute: msg.sessionRoute,
-          executionScope,
-          source: 'subagent_result',
-          suppressFinalResponse: shouldSuppressSubAgentObservationReply(msg.userText),
-        })
-        : await session.handleMessage(msg.userText, {
-          channel,
-          sessionRoute: msg.sessionRoute,
-          executionScope,
-          runtimeFeedback: msg.runtimeFeedback,
-        });
-      if (result.taskOutcome === 'failed') {
-        await this.sender.reply(msg.chatId, result.text);
-      }
-    } finally {
-      this.clearPendingAnswerBySession(sessionKey);
+    const result = msg.source === 'subagent_feedback'
+      ? await session.handleRuntimeObservation(msg.userText, {
+        channel,
+        sessionRoute: msg.sessionRoute,
+        executionScope,
+        source: 'subagent_result',
+        suppressFinalResponse: shouldSuppressSubAgentObservationReply(msg.userText),
+      })
+      : await session.handleMessage(msg.userText, {
+        channel,
+        sessionRoute: msg.sessionRoute,
+        executionScope,
+        runtimeFeedback: msg.runtimeFeedback,
+      });
+    if (result.text === BUSY_MESSAGE) {
+      const pending = this.messageQueue.get(sessionKey) ?? [];
+      pending.unshift(msg);
+      this.messageQueue.set(sessionKey, pending);
+      Logger.info(`[${sessionKey}] 排队消息处理遇到竞态忙碌，已重新入队`);
+      return;
+    }
+    if (result.visibleToUser && (result.taskOutcome === 'failed' || result.taskOutcome === 'cancelled')) {
+      await this.sender.reply(msg.chatId, result.text);
     }
 
     // 处理期间可能又有新消息入队，递归排空

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -28,6 +28,10 @@ export interface Message {
   }>;
   tool_call_id?: string;
   name?: string;
+  /** Historical tool result was normalized once and must not be rewritten by later prompt-budget passes. */
+  __toolResultStable?: boolean;
+  /** Internal evidence that this tool result came from a successful execution. Never sent to providers. */
+  __toolExecutionSucceeded?: boolean;
   /** 标记由 injectContext 注入的消息，用于滑动窗口清理 */
   __injected?: boolean;
   /**

--- a/src/utils/ai-service.ts
+++ b/src/utils/ai-service.ts
@@ -56,6 +56,37 @@ const TRANSIENT_PROVIDER_CODES = new Set([
 const RESPONSES_TRANSIENT_MAX_RETRIES = 2;
 const TRANSIENT_HTTP_MAX_RETRIES = 2;
 const GATEWAY_TIMEOUT_MAX_RETRIES = 1;
+
+
+function safeErrorProperty(value: unknown, property: PropertyKey): unknown {
+  if (value === null || value === undefined || (typeof value !== 'object' && typeof value !== 'function')) {
+    return undefined;
+  }
+  try {
+    return Reflect.get(value, property);
+  } catch {
+    return undefined;
+  }
+}
+
+function safeErrorPath(value: unknown, ...properties: PropertyKey[]): unknown {
+  let current = value;
+  for (const property of properties) {
+    current = safeErrorProperty(current, property);
+    if (current === undefined || current === null) return current;
+  }
+  return current;
+}
+
+function safeErrorString(value: unknown, fallback = ''): string {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') return String(value);
+  try {
+    return String(value ?? fallback);
+  } catch {
+    return fallback;
+  }
+}
 let modelAttemptCallSequence = 0;
 
 type ProviderKind = 'openai' | 'anthropic';
@@ -359,7 +390,7 @@ export class AIService {
       return true;
     }
 
-    const message = String(error?.message || '');
+    const message = safeErrorString(safeErrorProperty(error, 'message'));
     const hasRetryableStatusText =
       /(?:API错误|HTTP|status(?:\s*code)?|response status)\s*[\(:= ]\s*(?:408|429|500|502|503|504|520|524|529)\b/i.test(message)
       || /^\s*(?:408|429|500|502|503|504|520|524|529)\b/.test(message);
@@ -371,7 +402,7 @@ export class AIService {
     }
 
     // Anthropic SDK overloaded_error
-    if (error?.error?.type === 'overloaded_error') {
+    if (safeErrorPath(error, 'error', 'type') === 'overloaded_error') {
       return true;
     }
 
@@ -385,15 +416,15 @@ export class AIService {
     }
 
     const message = [
-      error?.response?.data?.error?.code,
-      error?.response?.data?.error?.type,
-      error?.response?.data?.error?.message,
-      error?.response?.data?.message,
-      error?.error?.code,
-      error?.error?.type,
-      error?.error?.message,
-      error?.message,
-    ].filter(Boolean).join(' ');
+      safeErrorPath(error, 'response', 'data', 'error', 'code'),
+      safeErrorPath(error, 'response', 'data', 'error', 'type'),
+      safeErrorPath(error, 'response', 'data', 'error', 'message'),
+      safeErrorPath(error, 'response', 'data', 'message'),
+      safeErrorPath(error, 'error', 'code'),
+      safeErrorPath(error, 'error', 'type'),
+      safeErrorPath(error, 'error', 'message'),
+      safeErrorProperty(error, 'message'),
+    ].filter(Boolean).map(value => safeErrorString(value)).join(' ');
 
     return /insufficient[_\s-]?quota|quota[_\s-]?exceeded|billing|(?:insufficient|low|exhausted)[_\s-]?(?:credit|balance)|(?:credit|balance)[_\s-]?(?:exhausted|insufficient|too low)|账户余额|余额不足|额度不足|额度已用尽|context length|maximum context|max(?:imum)? tokens?|prompt too long|invalid[_\s-]?request|invalid[_\s-]?api[_\s-]?key|unauthorized|forbidden|permission denied|model .*not found|model_not_found|tool schema|schema is invalid|content policy|safety/i
       .test(message);
@@ -425,7 +456,7 @@ export class AIService {
    * 从错误中提取 HTTP 状态码
    */
   private extractStatus(error: any): number | null {
-    const status = error?.response?.status || error?.status;
+    const status = safeErrorPath(error, 'response', 'status') || safeErrorProperty(error, 'status');
     if (typeof status === 'number') {
       return status;
     }
@@ -434,6 +465,7 @@ export class AIService {
       return Number.isFinite(parsed) ? parsed : null;
     }
     const text = String(error?.message || error || '');
+    const text = safeErrorString(safeErrorProperty(error, 'message'), safeErrorString(error));
     const match = text.match(/(?:API错误|HTTP|status(?:\s*code)?)\s*[\(:= ]\s*(\d{3})\b/i);
     if (match) {
       const parsed = Number(match[1]);
@@ -446,12 +478,14 @@ export class AIService {
    * 从错误中提取 Retry-After 头（秒）
    */
   private getRetryAfter(error: any): number | null {
-    const retryAfter = error?.response?.headers?.['retry-after'] || error?.headers?.['retry-after'];
+    const retryAfter = safeErrorPath(error, 'response', 'headers', 'retry-after')
+      || safeErrorPath(error, 'headers', 'retry-after');
     if (retryAfter) {
-      const seconds = parseInt(retryAfter, 10);
+      const retryAfterText = safeErrorString(retryAfter);
+      const seconds = parseInt(retryAfterText, 10);
       if (!isNaN(seconds)) return seconds;
 
-      const dateMs = Date.parse(String(retryAfter));
+      const dateMs = Date.parse(retryAfterText);
       if (Number.isFinite(dateMs)) {
         return Math.max(0, Math.ceil((dateMs - Date.now()) / 1000));
       }
@@ -754,15 +788,19 @@ export class AIService {
   }
 
   private extractErrorMessage(error: any): string {
-    return error?.response?.data?.error?.message
-      || error?.response?.data?.message
-      || error?.error?.message
-      || error?.message
-      || String(error);
+    return safeErrorString(
+      safeErrorPath(error, 'response', 'data', 'error', 'message')
+        || safeErrorPath(error, 'response', 'data', 'message')
+        || safeErrorPath(error, 'error', 'message')
+        || safeErrorProperty(error, 'message'),
+      safeErrorString(error, 'Unknown provider error'),
+    );
   }
 
   private extractErrorCode(error: any): string {
-    return String(error?.code || error?.cause?.code || '').toUpperCase();
+    return safeErrorString(
+      safeErrorProperty(error, 'code') || safeErrorPath(error, 'cause', 'code'),
+    ).toUpperCase();
   }
 
   private isEmptyModelResponseError(error: any): boolean {
@@ -794,7 +832,7 @@ export class AIService {
     try {
       await callbacks?.onRetry?.(attempt, maxRetries, info);
     } catch (error: any) {
-      Logger.warning(`重试提示回调失败: ${error?.message || error}`);
+      Logger.warning(`重试提示回调失败: ${safeErrorString(safeErrorProperty(error, 'message'), safeErrorString(error))}`);
     }
   }
 
@@ -823,9 +861,9 @@ export class AIService {
   }
 
   private isAbortError(error: any): boolean {
-    return error?.name === 'AbortError'
-      || error?.code === 'ERR_CANCELED'
-      || /aborted|aborterror|canceled|cancelled/i.test(String(error?.message || ''));
+    return safeErrorProperty(error, 'name') === 'AbortError'
+      || safeErrorProperty(error, 'code') === 'ERR_CANCELED'
+      || /aborted|aborterror|canceled|cancelled/i.test(safeErrorString(safeErrorProperty(error, 'message')));
   }
 
   private createAbortError(): Error {

--- a/src/utils/ai-service.ts
+++ b/src/utils/ai-service.ts
@@ -464,7 +464,6 @@ export class AIService {
       const parsed = Number(status);
       return Number.isFinite(parsed) ? parsed : null;
     }
-    const text = String(error?.message || error || '');
     const text = safeErrorString(safeErrorProperty(error, 'message'), safeErrorString(error));
     const match = text.match(/(?:API错误|HTTP|status(?:\s*code)?)\s*[\(:= ]\s*(\d{3})\b/i);
     if (match) {

--- a/src/utils/model-error-classifier.ts
+++ b/src/utils/model-error-classifier.ts
@@ -8,9 +8,7 @@ export const MODEL_IMAGE_SAFETY_MESSAGE =
   '模型拒绝了当前对话里的某张图片，可能触发了上游图片安全策略。本轮已停止；请删除或更换这张图片，或新开对话后继续。';
 
 export function isModelImageSafetyError(error: unknown): boolean {
-  const text = String(
-    error instanceof Error ? error.message : error ?? '',
-  );
+  const text = safeErrorText(error);
 
   const hasSafetyCode = /input[\s_-]*new[\s_-]*sensitive/i.test(text)
     || /sensitive/i.test(text);
@@ -19,6 +17,19 @@ export function isModelImageSafetyError(error: unknown): boolean {
     || /messages\[\d+\][^{}]{0,180}content\[\d+\][^{}]{0,180}image/i.test(text);
 
   return hasSafetyCode && hasImageEvidence;
+}
+
+function safeErrorText(error: unknown): string {
+  if (!error || (typeof error !== 'object' && typeof error !== 'function')) {
+    try { return String(error ?? ''); } catch { return ''; }
+  }
+  try {
+    const message = Reflect.get(error, 'message');
+    if (typeof message === 'string' && message) return message;
+  } catch {
+    // Continue with a stable fallback for hostile error objects.
+  }
+  try { return String(error); } catch { return ''; }
 }
 
 export type ModelErrorCategory =
@@ -133,36 +144,37 @@ export function classifyModelError(
   if (known.isEmptyResponse) return result('empty_response', 'empty_model_response', 'high', 'transport', 'retry_same_context');
   if (known.isTransient) return result('transient', 'transient_provider_error', 'high', 'transport', 'retry_later');
 
-  if (/reasoning[_\s-]?(?:content|text).{0,80}(must be passed back|must be echoed|not passed back|required|expected)/i.test(evidence)
+  if (/signal_reasoning_replay_required/i.test(evidence)
+    || /reasoning[_\s-]?(?:content|text).{0,80}(must be passed back|must be echoed|not passed back|required|expected)/i.test(evidence)
     || /thinking mode.{0,80}reasoning/i.test(evidence)) {
     return result('reasoning_replay_required', 'reasoning_replay_required', 'high', 'fix_and_retry_once', 'repair_session');
   }
 
   if (status === 401
-    || /invalid[_\s-]?api[_\s-]?key|unauthorized|authentication (?:failed|error)|invalid[_\s-]?token/i.test(evidence)) {
+    || /signal_auth_invalid|invalid[_\s-]?api[_\s-]?key|unauthorized|authentication (?:failed|error)|invalid[_\s-]?token/i.test(evidence)) {
     return result('auth_invalid', 'auth_invalid', 'high', 'none', 'fix_configuration');
   }
 
-  if (/forbidden|permission denied|access denied|not authorized|insufficient[_\s-]?permissions?/i.test(evidence)) {
+  if (/signal_access_denied|forbidden|permission[_\s-]?denied|access[_\s-]?denied|not authorized|insufficient[_\s-]?permissions?/i.test(evidence)) {
     return result('access_denied', 'access_denied', 'high', 'none', 'fix_configuration');
   }
 
   if (status === 404
-    || /model[_\s-]?not[_\s-]?found|endpoint[_\s-]?not[_\s-]?found|unknown model|no such model/i.test(evidence)) {
+    || /signal_model_or_endpoint_missing|model[_\s-]?not[_\s-]?found|endpoint[_\s-]?not[_\s-]?found|unknown model|no such model/i.test(evidence)) {
     return result('model_or_endpoint_missing', 'model_or_endpoint_missing', 'high', 'none', 'fix_configuration');
   }
 
   if (status === 413
-    || /context length|maximum context|context window|prompt too long|token limit|too many tokens/i.test(evidence)) {
+    || /signal_input_too_large|context length|maximum context|context window|prompt too long|token limit|too many tokens/i.test(evidence)) {
     return result('input_too_large', 'input_too_large', 'high', 'fix_and_retry_once', 'reduce_input');
   }
 
-  if (status === 429 || /rate limit|too many requests/i.test(evidence)) {
+  if (status === 429 || /signal_rate_limited|rate limit|too many requests/i.test(evidence)) {
     return result('rate_limited', 'provider_rate_limited', 'high', 'transport', 'retry_later');
   }
 
   if (status === 422
-    || /invalid[_\s-]?request|tool schema|schema is invalid|invalid (?:parameter|input|argument)|malformed|invalid json/i.test(evidence)) {
+    || /signal_request_invalid|invalid[_\s-]?request|tool schema|schema is invalid|invalid (?:parameter|input|argument)|malformed|invalid json/i.test(evidence)) {
     return result('request_invalid', 'request_invalid', 'high', 'none', 'investigate');
   }
 

--- a/src/utils/model-error-observability.ts
+++ b/src/utils/model-error-observability.ts
@@ -1,5 +1,4 @@
 import { createHash } from 'crypto';
-import { sanitizeProviderErrorMessageForLog } from './provider-error-log-sanitizer';
 
 export type ModelErrorPhase =
   | 'pre_turn_compaction'
@@ -120,37 +119,51 @@ function captureModelErrorDiagnosticsUnsafe(
   error: any,
   context: Partial<Pick<ModelErrorDiagnostics, 'provider' | 'model' | 'phase'>>,
 ): ModelErrorDiagnostics {
-  const existing = readModelErrorDiagnostics(error);
-  const responseError = error?.response?.data?.error;
-  const nestedError = error?.error;
+  const wrapperDiagnostics = readModelErrorDiagnostics(error);
+  const cause = safeRead(error, 'cause');
+  const causeDiagnostics = readModelErrorDiagnostics(cause);
+  const existing = wrapperDiagnostics ?? causeDiagnostics;
+  const responseError = safePath(error, 'response', 'data', 'error');
+  const nestedError = safeRead(error, 'error');
   const httpStatus = firstNumber(
     existing?.http_status,
-    error?.response?.status,
-    error?.status,
-    nestedError?.status,
-    extractStatusFromText(error?.message),
+    safePath(error, 'response', 'status'),
+    safeRead(error, 'status'),
+    safeRead(nestedError, 'status'),
+    causeDiagnostics?.http_status,
+    safePath(cause, 'response', 'status'),
+    safeRead(cause, 'status'),
+    extractStatusFromText(safeRead(error, 'message')),
+    extractStatusFromText(safeRead(cause, 'message')),
   );
   const providerCode = firstText(
     existing?.provider_code,
-    responseError?.code,
-    error?.response?.data?.code,
-    nestedError?.code,
+    safeRead(responseError, 'code'),
+    safePath(error, 'response', 'data', 'code'),
+    safeRead(nestedError, 'code'),
+    causeDiagnostics?.provider_code,
+    safePath(cause, 'response', 'data', 'error', 'code'),
+    safeRead(cause, 'code'),
   );
-  const transportCode = firstText(error?.code, error?.cause?.code);
+  const transportCode = firstText(safeRead(error, 'code'), safeRead(cause, 'code'));
   const providerType = firstText(
     existing?.provider_type,
-    responseError?.type,
-    error?.response?.data?.type,
-    nestedError?.type,
+    safeRead(responseError, 'type'),
+    safePath(error, 'response', 'data', 'type'),
+    safeRead(nestedError, 'type'),
+    causeDiagnostics?.provider_type,
+    safePath(cause, 'response', 'data', 'error', 'type'),
   );
   const requestId = firstText(
     existing?.request_id,
-    error?.response?.data?.request_id,
-    responseError?.request_id,
-    error?.request_id,
-    error?.requestId,
-    error?.response?.headers?.['x-request-id'],
-    error?.headers?.['x-request-id'],
+    safePath(error, 'response', 'data', 'request_id'),
+    safeRead(responseError, 'request_id'),
+    safeRead(error, 'request_id'),
+    safeRead(error, 'requestId'),
+    safePath(error, 'response', 'headers', 'x-request-id'),
+    safePath(error, 'headers', 'x-request-id'),
+    causeDiagnostics?.request_id,
+    safePath(cause, 'response', 'headers', 'x-request-id'),
   );
   const responseId = firstText(
     existing?.response_id,
@@ -161,14 +174,27 @@ function captureModelErrorDiagnosticsUnsafe(
   const terminalEvent = firstText(existing?.terminal_event, error?.terminalEvent);
   const failurePhase = firstText(existing?.failure_phase, error?.failurePhase);
   const sourceMessage = firstText(
-    responseError?.message,
-    error?.response?.data?.message,
-    nestedError?.message,
-    error?.message,
+    safeRead(responseError, 'message'),
+    safePath(error, 'response', 'data', 'message'),
+    safeRead(nestedError, 'message'),
+    safeRead(error, 'message'),
+    causeDiagnostics?.error_summary,
+    safeRead(cause, 'message'),
     error,
   ) || 'unknown error';
-  const errorSummary = sanitizeProviderErrorMessageForLog(sourceMessage);
-  const errorName = firstText(existing?.error_name, error?.name);
+  const errorName = firstText(
+    wrapperDiagnostics?.error_name,
+    causeDiagnostics?.error_name,
+    safeRead(error, 'name'),
+    safeRead(cause, 'name'),
+  );
+  const errorSummary = buildSafeErrorSummary({
+    sourceMessage,
+    httpStatus,
+    providerCode: providerCode ?? transportCode,
+    providerType,
+    errorName,
+  });
   const stack = captureStackDiagnostics(error);
   const origin = existing?.origin ?? inferErrorOrigin({
     httpStatus,
@@ -247,29 +273,39 @@ export function buildModelErrorFingerprint(input: {
 }
 
 function normalizeDiagnostics(input: ModelErrorDiagnostics): ModelErrorDiagnostics {
+  const providerCode = canonicalDiagnosticToken(input.provider_code);
+  const providerType = canonicalDiagnosticToken(input.provider_type);
+  const errorName = canonicalDiagnosticToken(input.error_name);
+  const errorSummary = buildSafeErrorSummary({
+    sourceMessage: input.error_summary || 'unknown error',
+    httpStatus: input.http_status,
+    providerCode,
+    providerType,
+    errorName,
+  });
   return {
     ...(safeText(input.provider) && { provider: safeText(input.provider) }),
     ...(safeText(input.model) && { model: safeText(input.model) }),
     ...(input.phase && { phase: input.phase }),
     ...(input.origin && { origin: input.origin }),
     ...(typeof input.http_status === 'number' && { http_status: input.http_status }),
-    ...(safeText(input.provider_code) && { provider_code: safeText(input.provider_code) }),
-    ...(safeText(input.provider_type) && { provider_type: safeText(input.provider_type) }),
-    ...(safeText(input.request_id) && { request_id: safeText(input.request_id) }),
+    ...(providerCode && { provider_code: providerCode }),
+    ...(providerType && { provider_type: providerType }),
+    ...(hashedIdentifier(input.request_id, 'request') && { request_id: hashedIdentifier(input.request_id, 'request') }),
     ...(safeText(input.response_id) && { response_id: safeText(input.response_id) }),
     ...(safeText(input.terminal_event) && { terminal_event: safeText(input.terminal_event) }),
     ...(safeText(input.failure_phase) && { failure_phase: safeText(input.failure_phase) }),
-    ...(safeText(input.error_name) && { error_name: safeText(input.error_name) }),
+    ...(errorName && { error_name: errorName }),
     ...(safeText(input.top_frame) && { top_frame: safeText(input.top_frame) }),
     ...(safeText(input.stack_fingerprint) && { stack_fingerprint: safeText(input.stack_fingerprint) }),
-    error_summary: sanitizeProviderErrorMessageForLog(input.error_summary || 'unknown error'),
+    error_summary: errorSummary,
     fingerprint: safeText(input.fingerprint) || buildModelErrorFingerprint({
       provider: input.provider,
       model: input.model,
       http_status: input.http_status,
-      provider_code: input.provider_code,
-      provider_type: input.provider_type,
-      error_summary: input.error_summary || 'unknown error',
+      provider_code: providerCode,
+      provider_type: providerType,
+      error_summary: errorSummary,
     }),
     ...(input.retry && { retry: normalizeRetrySummary(input.retry) }),
     ...(input.attempt && { attempt: normalizeAttemptReference(input.attempt) }),
@@ -300,11 +336,33 @@ function nonNegativeInteger(value: number): number {
   return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
 }
 
+function safeRead(value: unknown, property: PropertyKey): any {
+  if (!value || (typeof value !== 'object' && typeof value !== 'function')) return undefined;
+  try {
+    return Reflect.get(value, property);
+  } catch {
+    return undefined;
+  }
+}
+
+function safePath(value: unknown, ...properties: PropertyKey[]): unknown {
+  let current = value;
+  for (const property of properties) {
+    current = safeRead(current, property);
+    if (current === undefined || current === null) return current;
+  }
+  return current;
+}
+
 function safeText(value: unknown): string | undefined {
   if (value === undefined || value === null) return undefined;
-  const normalized = String(value).replace(/\s+/g, ' ').trim();
-  if (!normalized) return undefined;
-  return normalized.slice(0, MAX_STRUCTURED_FIELD_LENGTH);
+  try {
+    const normalized = String(value).replace(/\s+/g, ' ').trim();
+    if (!normalized) return undefined;
+    return normalized.slice(0, MAX_STRUCTURED_FIELD_LENGTH);
+  } catch {
+    return undefined;
+  }
 }
 
 function firstText(...values: unknown[]): string | undefined {
@@ -323,19 +381,74 @@ function firstNumber(...values: unknown[]): number | undefined {
 }
 
 function extractStatusFromText(value: unknown): number | undefined {
-  const match = String(value || '').match(/(?:API错误|HTTP|status(?:\s*code)?)\s*[\(:= ]\s*(\d{3})\b/i);
+  const match = (safeText(value) || '').match(/(?:API错误|HTTP|status(?:\s*code)?)\s*[\(:= ]\s*(\d{3})\b/i);
   if (!match) return undefined;
   const parsed = Number(match[1]);
   return Number.isFinite(parsed) ? parsed : undefined;
 }
 
+function canonicalDiagnosticToken(value: unknown): string | undefined {
+  const normalized = safeText(value)?.toLowerCase();
+  if (!normalized || !/^[a-z][a-z0-9._-]{0,63}$/.test(normalized)) return undefined;
+  if (/(?:secret|token|password|credential|api[_-]?key|authorization)/i.test(normalized)) return undefined;
+  return normalized;
+}
+
+function hashedIdentifier(value: unknown, prefix: string): string | undefined {
+  const normalized = safeText(value);
+  if (!normalized) return undefined;
+  const alreadyHashed = normalized.startsWith(`${prefix}_`)
+    && normalized.length === prefix.length + 13
+    && /^[a-f0-9]{12}$/.test(normalized.slice(prefix.length + 1));
+  if (alreadyHashed) return normalized;
+  return `${prefix}_${createHash('sha256').update(normalized).digest('hex').slice(0, 12)}`;
+}
+
+function buildSafeErrorSummary(input: {
+  sourceMessage: unknown;
+  httpStatus?: number;
+  providerCode?: string;
+  providerType?: string;
+  errorName?: string;
+}): string {
+  const source = safeText(input.sourceMessage)?.toLowerCase() || '';
+  const parts: string[] = [];
+  if (typeof input.httpStatus === 'number') parts.push(`http_${input.httpStatus}`);
+  for (const match of source.matchAll(/\bsignal_(reasoning_replay_required|auth_invalid|access_denied|model_or_endpoint_missing|input_too_large|rate_limited|request_invalid|timeout|transport_error|empty_response|image_safety)\b/g)) {
+    parts.push(`signal_${match[1]}`);
+  }
+  const code = canonicalDiagnosticToken(input.providerCode);
+  const type = canonicalDiagnosticToken(input.providerType);
+  const name = canonicalDiagnosticToken(input.errorName);
+  if (code) parts.push(`code_${code}`);
+  if (type) parts.push(`type_${type}`);
+  if (name && name !== 'error') parts.push(`name_${name}`);
+
+  const signals: Array<[RegExp, string]> = [
+    [/reasoning[_\s-]?(?:content|text).{0,80}(?:must be passed back|must be echoed|not passed back|required|expected)|thinking mode.{0,80}reasoning/i, 'reasoning_replay_required'],
+    [/invalid[_\s-]?api[_\s-]?key|unauthorized|authentication (?:failed|error)|invalid[_\s-]?token/i, 'auth_invalid'],
+    [/forbidden|permission denied|access denied|not authorized|insufficient[_\s-]?permissions?/i, 'access_denied'],
+    [/model[_\s-]?not[_\s-]?found|endpoint[_\s-]?not[_\s-]?found|unknown model|no such model/i, 'model_or_endpoint_missing'],
+    [/context length|maximum context|context window|prompt too long|token limit|too many tokens/i, 'input_too_large'],
+    [/rate limit|too many requests/i, 'rate_limited'],
+    [/invalid[_\s-]?request|tool schema|schema is invalid|invalid (?:parameter|input|argument)|malformed|invalid json/i, 'request_invalid'],
+    [/request_timed_out|request timed out|gateway timeout|etimedout|timeout/i, 'timeout'],
+    [/econnreset|econnrefused|enotfound|eai_again|connection error/i, 'transport_error'],
+    [/empty_model_response|未返回有效内容|没有正文或工具调用/i, 'empty_response'],
+    [/input[_\s-]*new[_\s-]*sensitive|image is sensitive/i, 'image_safety'],
+  ];
+  for (const [pattern, signal] of signals) {
+    if (pattern.test(source)) parts.push(`signal_${signal}`);
+  }
+  return Array.from(new Set(parts)).join(' ') || 'unknown_error';
+}
+
 function safeFallbackErrorSummary(error: unknown): string {
   try {
-    return sanitizeProviderErrorMessageForLog(
-      error instanceof Error ? error.message : String(error ?? 'unknown error'),
-    );
+    const sourceMessage = error instanceof Error ? error.message : String(error ?? 'unknown error');
+    return buildSafeErrorSummary({ sourceMessage });
   } catch {
-    return 'unknown error';
+    return 'unknown_error';
   }
 }
 

--- a/src/utils/model-error-observability.ts
+++ b/src/utils/model-error-observability.ts
@@ -167,12 +167,12 @@ function captureModelErrorDiagnosticsUnsafe(
   );
   const responseId = firstText(
     existing?.response_id,
-    error?.responseId,
-    error?.response_id,
-    responseError?.response_id,
+    safeRead(error, 'responseId'),
+    safeRead(error, 'response_id'),
+    safeRead(responseError, 'response_id'),
   );
-  const terminalEvent = firstText(existing?.terminal_event, error?.terminalEvent);
-  const failurePhase = firstText(existing?.failure_phase, error?.failurePhase);
+  const terminalEvent = firstText(existing?.terminal_event, safeRead(error, 'terminalEvent'));
+  const failurePhase = firstText(existing?.failure_phase, safeRead(error, 'failurePhase'));
   const sourceMessage = firstText(
     safeRead(responseError, 'message'),
     safePath(error, 'response', 'data', 'message'),

--- a/src/utils/session-log-schema.ts
+++ b/src/utils/session-log-schema.ts
@@ -92,6 +92,8 @@ export interface TurnErrorPayload {
   retry_stop_reason?: string;
   retry_elapsed_ms?: number;
   turn_elapsed_ms?: number;
+  context_persisted?: boolean;
+  recoverable_partial_progress?: boolean;
   partial_progress_preserved?: boolean;
   episode_id?: string;
   model_call_id?: string;

--- a/src/weixin/index.ts
+++ b/src/weixin/index.ts
@@ -286,7 +286,21 @@ export class WeixinBot {
       executionScope: createExecutionScopeFromRoute(route),
       runtimeFeedback,
     });
-    if (result.text === BUSY_MESSAGE || result.taskOutcome === 'failed') {
+    if (result.text === BUSY_MESSAGE) {
+      const queue = this.messageQueue.get(sessionKey) ?? [];
+      queue.unshift({
+        userText,
+        chatId: route.topicId,
+        userId,
+        sessionRoute: route,
+        source: 'user',
+        runtimeFeedback,
+      });
+      this.messageQueue.set(sessionKey, queue);
+      Logger.info(`[${sessionKey}] 主消息处理遇到竞态忙碌，已重新入队`);
+      return;
+    }
+    if (result.visibleToUser && (result.taskOutcome === 'failed' || result.taskOutcome === 'cancelled')) {
       await channel.reply(route.topicId, result.text);
     }
     await this.drainMessageQueue(sessionKey);
@@ -320,7 +334,7 @@ export class WeixinBot {
       this.enqueueSubAgentFeedback(sessionKey, chatId, userId, text, route);
       return;
     }
-    if (result.taskOutcome === 'failed') {
+    if (result.visibleToUser && (result.taskOutcome === 'failed' || result.taskOutcome === 'cancelled')) {
       await channel.reply(chatId, result.text);
     }
     await this.drainMessageQueue(sessionKey);
@@ -378,7 +392,14 @@ export class WeixinBot {
         runtimeFeedback: msg.runtimeFeedback,
       });
 
-    if (result.taskOutcome === 'failed') {
+    if (result.text === BUSY_MESSAGE) {
+      const pending = this.messageQueue.get(sessionKey) ?? [];
+      pending.unshift(msg);
+      this.messageQueue.set(sessionKey, pending);
+      Logger.info(`[${sessionKey}] 排队消息处理遇到竞态忙碌，已重新入队`);
+      return;
+    }
+    if (result.visibleToUser && (result.taskOutcome === 'failed' || result.taskOutcome === 'cancelled')) {
       await channel.reply(msg.chatId, result.text);
     }
     await this.drainMessageQueue(sessionKey);

--- a/tests/ai-service.test.ts
+++ b/tests/ai-service.test.ts
@@ -601,7 +601,8 @@ test('AIService preserves provider fields and non-retryable stop reason on wrapp
   assert.equal(diagnostics?.phase, 'model_request');
   assert.equal(diagnostics?.provider_code, 'invalid_tool_schema');
   assert.equal(diagnostics?.provider_type, 'invalid_request_error');
-  assert.equal(diagnostics?.request_id, 'req_schema_1');
+  assert.match(diagnostics?.request_id || '', /^request_[a-f0-9]{12}$/);
+  assert.notEqual(diagnostics?.request_id, 'req_schema_1');
   assert.equal(diagnostics?.retry?.attempt_count, 1);
   assert.equal(diagnostics?.retry?.retry_count, 0);
   assert.equal(diagnostics?.retry?.stop_reason, 'non_retryable');
@@ -668,6 +669,39 @@ test('AIService records when stream output prevents an otherwise retryable reque
   assert.equal(diagnostics?.retry?.attempt_count, 1);
   assert.equal(diagnostics?.retry?.retry_count, 0);
   assert.equal(diagnostics?.retry?.stop_reason, 'stream_output_started');
+});
+
+
+test('AIService safely wraps a provider error with hostile getters', async () => {
+  process.env.CATSCO_MODEL_RETRY_MAX_RETRIES = '0';
+  const service = createTestService();
+  const hostile = new Proxy(Object.freeze({}), {
+    get(_target, property) {
+      if (property === 'message' || property === 'response' || property === 'error'
+        || property === 'cause' || property === 'code' || property === 'name'
+        || property === 'status' || property === 'headers') {
+        throw new Error(`hostile getter: ${String(property)}`);
+      }
+      return undefined;
+    },
+    getPrototypeOf() {
+      throw new Error('hostile prototype');
+    },
+  });
+  (service as any).provider = {
+    chat: async () => { throw hostile; },
+    chatStream: async () => { throw hostile; },
+  };
+
+  await assert.rejects(
+    () => service.chat([]),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /^请求失败:/);
+      assert.doesNotMatch(error.message, /hostile getter|hostile prototype/);
+      return true;
+    },
+  );
 });
 
 function createTestService(): AIService {

--- a/tests/anthropic-provider-runtime-feedback.test.ts
+++ b/tests/anthropic-provider-runtime-feedback.test.ts
@@ -23,6 +23,12 @@ describe('AnthropicProvider runtime feedback boundary', () => {
         __injected: true,
       } as any,
       {
+        role: 'tool',
+        content: 'successful internal tool result',
+        tool_call_id: 'call-internal',
+        __toolExecutionSucceeded: true,
+      } as any,
+      {
         role: 'user',
         content: '[运行时反馈] weixin.media_download\n错误: 媒体下载不完整',
         __injected: true,
@@ -40,10 +46,18 @@ describe('AnthropicProvider runtime feedback boundary', () => {
     assert.equal(transformed.system, 'system');
     assert.deepStrictEqual(transformed.messages, [{
       role: 'user',
-      content: '[运行时反馈] weixin.media_download\n错误: 媒体下载不完整',
+      content: [{
+        type: 'tool_result',
+        tool_use_id: 'call-internal',
+        content: 'successful internal tool result',
+      }, {
+        type: 'text',
+        text: '[运行时反馈] weixin.media_download\n错误: 媒体下载不完整',
+      }],
     }]);
     assert.equal(JSON.stringify(transformed).includes('__injected'), false);
     assert.equal(JSON.stringify(transformed).includes('__runtimeFeedback'), false);
+    assert.equal(JSON.stringify(transformed).includes('__toolExecutionSucceeded'), false);
     assert.equal(JSON.stringify(transformed).includes('__runtimeObservation'), false);
     assert.equal(JSON.stringify(transformed).includes('__episodeId'), false);
     assert.equal(JSON.stringify(transformed).includes('__episodeInputKind'), false);

--- a/tests/conversation-runner-transcript-normalization.test.ts
+++ b/tests/conversation-runner-transcript-normalization.test.ts
@@ -1262,6 +1262,7 @@ test('runner records outbound file sends as normal tool_result transcript for la
       content: sentFileResult,
       tool_call_id: 'call_file',
       name: 'send_file',
+      __toolExecutionSucceeded: true,
     },
     'the model should see send_file as a normal tool_result immediately after its assistant tool_call',
   );
@@ -1372,12 +1373,14 @@ test('runner keeps repeated send_file calls in the same assistant response as le
         content: sentFileResult,
         tool_call_id: 'call_file_1',
         name: 'send_file',
+        __toolExecutionSucceeded: true,
       },
       {
         role: 'tool',
         content: sentFileResult,
         tool_call_id: 'call_file_2',
         name: 'send_file',
+        __toolExecutionSucceeded: true,
       },
     ],
     'each send_file result should immediately follow the assistant message that requested it',

--- a/tests/feishu-session-route.test.ts
+++ b/tests/feishu-session-route.test.ts
@@ -2,6 +2,7 @@ import { describe, test } from 'node:test';
 import * as assert from 'node:assert';
 import { FeishuBot } from '../src/feishu';
 import { SubAgentManager } from '../src/core/sub-agent-manager';
+import { BUSY_MESSAGE } from '../src/core/agent-session';
 
 describe('Feishu SessionRoute V2', () => {
   test('routes private messages through a Feishu V2 session key', async () => {
@@ -68,38 +69,165 @@ describe('Feishu SessionRoute V2', () => {
       SubAgentManager.getInstance().unregisterPlatformCallbacks('session:v2:feishu:group:oc_group');
     }
   });
-
-  test('delivers classified failed replies without relying on the legacy fallback text', async () => {
+  test('sends a classified failed result instead of collapsing it to ERROR_MESSAGE', async () => {
+    const sentTexts: string[] = [];
     const bot = createHarness({
+      sentTexts,
+      result: { visibleToUser: true, text: '模型访问凭证无效。', taskOutcome: 'failed' },
       message: {
-        messageId: 'msg-error',
-        chatId: 'shared',
-        chatType: 'p2p',
-        senderId: 'shared',
-        text: '继续',
-        mentionBot: false,
-        msgType: 'text',
+        messageId: 'msg-failed', chatId: 'private', chatType: 'p2p', senderId: 'private',
+        text: 'hello', mentionBot: true, msgType: 'text',
       },
     });
-    bot.sessionResult = {
-      visibleToUser: true,
-      text: '模型服务暂时不可用，请稍后再试。',
-      taskOutcome: 'failed',
-    };
-
     try {
       await (bot as any).onMessage({});
-
-      assert.deepEqual(bot.replies, [
-        { chatId: 'shared', text: '模型服务暂时不可用，请稍后再试。' },
-      ]);
+      assert.deepEqual(sentTexts, ['模型访问凭证无效。']);
     } finally {
-      SubAgentManager.getInstance().unregisterPlatformCallbacks('session:v2:feishu:p2p:shared');
+      SubAgentManager.getInstance().unregisterPlatformCallbacks('session:v2:feishu:p2p:private');
     }
   });
+
+  test('requeues a direct racing BUSY user message and sends the later failure once', async () => {
+    const sentTexts: string[] = [];
+    const bot = createHarness({
+      sentTexts,
+      results: [
+        { visibleToUser: true, text: BUSY_MESSAGE },
+        { visibleToUser: true, text: '模型请求超时。', taskOutcome: 'failed' },
+      ],
+      message: {
+        messageId: 'msg-direct-race', chatId: 'oc_direct_race', chatType: 'group', senderId: 'ou_direct_race',
+        text: 'direct racing user text', mentionBot: true, msgType: 'text',
+      },
+    });
+    const sessionKey = 'session:v2:feishu:group:oc_direct_race';
+    try {
+      await (bot as any).onMessage({});
+      assert.equal(bot.messageQueue.get(sessionKey)?.[0]?.userText, 'direct racing user text');
+      assert.deepEqual(sentTexts, []);
+
+      await (bot as any).drainMessageQueue(sessionKey);
+      assert.equal(bot.messageQueue.has(sessionKey), false);
+      assert.deepEqual(sentTexts, ['模型请求超时。']);
+    } finally {
+      SubAgentManager.getInstance().unregisterPlatformCallbacks(sessionKey);
+    }
+  });
+
+  test('sends a queued classified failure exactly once', async () => {
+    const sentTexts: string[] = [];
+    const bot = createHarness({
+      busy: true,
+      sentTexts,
+      result: { visibleToUser: true, text: '模型请求参数无效。', taskOutcome: 'failed' },
+      message: {
+        messageId: 'msg-queued-failed', chatId: 'oc_failed', chatType: 'group', senderId: 'ou_failed',
+        text: '@bot 继续', mentionBot: true, msgType: 'text',
+      },
+    });
+    const sessionKey = 'session:v2:feishu:group:oc_failed';
+    try {
+      await (bot as any).onMessage({});
+      bot.sessionBusy = false;
+      await (bot as any).drainMessageQueue(sessionKey);
+      assert.deepEqual(sentTexts, ['模型请求参数无效。']);
+    } finally {
+      SubAgentManager.getInstance().unregisterPlatformCallbacks(sessionKey);
+    }
+  });
+
+  test('sends a subagent classified failure exactly once', async () => {
+    const sentTexts: string[] = [];
+    const bot = createHarness({
+      sentTexts,
+      runtimeResult: { visibleToUser: true, text: '模型服务暂时不可用。', taskOutcome: 'failed' },
+      message: {
+        messageId: 'unused', chatId: 'private', chatType: 'p2p', senderId: 'private',
+        text: 'unused', mentionBot: false, msgType: 'text',
+      },
+    });
+    await (bot as any).handleSubAgentFeedback(
+      'session:v2:feishu:p2p:private',
+      'private',
+      'private',
+      'subagent result',
+    );
+    assert.deepEqual(sentTexts, ['模型服务暂时不可用。']);
+  });
+
+  test('queues busy subagent feedback and later sends its classified failure once', async () => {
+    const sentTexts: string[] = [];
+    const bot = createHarness({
+      busy: true,
+      sentTexts,
+      runtimeResult: { visibleToUser: true, text: '模型超时，请稍后重试。', taskOutcome: 'failed' },
+      message: { messageId: 'unused', chatId: 'private', chatType: 'p2p', senderId: 'private', text: '', mentionBot: false, msgType: 'text' },
+    });
+    const sessionKey = 'session:v2:feishu:p2p:private';
+    await (bot as any).handleSubAgentFeedback(sessionKey, 'private', 'private', 'subagent result');
+    assert.equal(bot.messageQueue.get(sessionKey)?.[0]?.source, 'subagent_feedback');
+    bot.sessionBusy = false;
+    await (bot as any).drainMessageQueue(sessionKey);
+    assert.deepEqual(sentTexts, ['模型超时，请稍后重试。']);
+  });
+
+  test('requeues a racing BUSY subagent result and sends the later failure once', async () => {
+    const sentTexts: string[] = [];
+    const bot = createHarness({
+      sentTexts,
+      runtimeResults: [
+        { visibleToUser: true, text: BUSY_MESSAGE },
+        { visibleToUser: true, text: '模型权限不足。', taskOutcome: 'failed' },
+      ],
+      message: { messageId: 'unused', chatId: 'private', chatType: 'p2p', senderId: 'private', text: '', mentionBot: false, msgType: 'text' },
+    });
+    const sessionKey = 'session:v2:feishu:p2p:private';
+    await (bot as any).handleSubAgentFeedback(sessionKey, 'private', 'private', 'subagent result');
+    assert.equal(bot.messageQueue.get(sessionKey)?.[0]?.source, 'subagent_feedback');
+    await (bot as any).drainMessageQueue(sessionKey);
+    assert.deepEqual(sentTexts, ['模型权限不足。']);
+  });
+
+
+  test('requeues a racing BUSY queued user message and sends the later failure once', async () => {
+    const sentTexts: string[] = [];
+    const bot = createHarness({
+      sentTexts,
+      results: [
+        { visibleToUser: true, text: BUSY_MESSAGE },
+        { visibleToUser: true, text: '模型请求超时。', taskOutcome: 'failed' },
+      ],
+      message: { messageId: 'queued-race', chatId: 'oc_race', chatType: 'group', senderId: 'ou_race', text: 'queued user text', mentionBot: true, msgType: 'text' },
+    });
+    const sessionKey = 'session:v2:feishu:group:oc_race';
+    bot.sessionBusy = true;
+    try {
+      await (bot as any).onMessage({});
+      bot.sessionBusy = false;
+      await (bot as any).drainMessageQueue(sessionKey);
+      assert.equal(bot.messageQueue.get(sessionKey)?.length, 1);
+      assert.equal(bot.messageQueue.get(sessionKey)?.[0]?.userText, 'queued user text');
+      assert.deepEqual(sentTexts, []);
+
+      await (bot as any).drainMessageQueue(sessionKey);
+      assert.equal(bot.messageQueue.has(sessionKey), false);
+      assert.deepEqual(sentTexts, ['模型请求超时。']);
+    } finally {
+      SubAgentManager.getInstance().unregisterPlatformCallbacks(sessionKey);
+    }
+  });
+
 });
 
-function createHarness(options: { busy?: boolean; message: any }): any {
+function createHarness(options: {
+  busy?: boolean;
+  message: any;
+  result?: any;
+  results?: any[];
+  runtimeResult?: any;
+  runtimeResults?: any[];
+  sentTexts?: string[];
+}): any {
   const bot = Object.create(FeishuBot.prototype) as any;
   bot.sessionBusy = options.busy ?? false;
   bot.createdSessions = [] as string[];
@@ -121,11 +249,11 @@ function createHarness(options: { busy?: boolean; message: any }): any {
     handleCommand: async () => ({ handled: false }),
     handleMessage: async (userText: string, handleOptions: any) => {
       bot.handledTurns.push({ userText, options: handleOptions });
-      return bot.sessionResult;
+      return options.results?.shift() ?? options.result ?? { visibleToUser: false, text: '' };
     },
     handleRuntimeObservation: async (userText: string, handleOptions: any) => {
       bot.handledTurns.push({ userText, options: handleOptions });
-      return { visibleToUser: false, text: '' };
+      return options.runtimeResults?.shift() ?? options.runtimeResult ?? { visibleToUser: false, text: '' };
     },
   };
   bot.sessionManager = {
@@ -135,9 +263,7 @@ function createHarness(options: { busy?: boolean; message: any }): any {
     },
   };
   bot.sender = {
-    reply: async (chatId: string, text: string) => {
-      bot.replies.push({ chatId, text });
-    },
+    reply: async (_chatId: string, text: string) => { options.sentTexts?.push(text); },
     downloadFile: async () => null,
     fetchMergeForwardTexts: async () => '',
     sendFile: async () => undefined,

--- a/tests/model-error-observability.test.ts
+++ b/tests/model-error-observability.test.ts
@@ -54,7 +54,8 @@ describe('model error observability', () => {
     assert.equal(diagnostics.http_status, 400);
     assert.equal(diagnostics.provider_code, 'invalid_request_error');
     assert.equal(diagnostics.provider_type, 'invalid_request_error');
-    assert.equal(diagnostics.request_id, 'req_body_123');
+    assert.match(diagnostics.request_id || '', /^request_[a-f0-9]{12}$/);
+    assert.notEqual(diagnostics.request_id, 'req_body_123');
     assert.equal(diagnostics.origin, 'provider');
     assert.equal(diagnostics.retry?.attempt_count, 3);
     assert.equal(diagnostics.retry?.retry_count, 2);
@@ -65,8 +66,8 @@ describe('model error observability', () => {
       attempt_number: 3,
       episode_id: 'episode-456',
     });
-    assert.match(diagnostics.error_summary, /sk-\[redacted\]/);
-    assert.doesNotMatch(diagnostics.error_summary, /secret-value/);
+    assert.match(diagnostics.error_summary, /signal_request_invalid/);
+    assert.doesNotMatch(diagnostics.error_summary, /secret-value|tool schema invalid/);
     assert.match(diagnostics.fingerprint, /^[a-f0-9]{16}$/);
   });
 
@@ -116,4 +117,51 @@ describe('model error observability', () => {
     assert.equal(replay.retry_strategy, 'fix_and_retry_once');
     assert.equal(replay.recovery_action, 'repair_session');
   });
+  test('does not log free-form provider fields, request ids, credentials, or echoed user text', () => {
+    const diagnostics = captureModelErrorDiagnostics(Object.assign(new Error('echoed user text: my private medical note'), {
+      response: {
+        status: 400,
+        data: {
+          request_id: 'req-private-user-123',
+          error: {
+            code: 'sk-secret-value-123456 echoed user text',
+            type: 'credential=super-secret echoed user text',
+            message: 'invalid request: echoed user text: my private medical note',
+          },
+        },
+      },
+    }));
+    assert.equal(diagnostics.provider_code, undefined);
+    assert.equal(diagnostics.provider_type, undefined);
+    assert.match(diagnostics.request_id || '', /^request_[a-f0-9]{12}$/);
+    assert.match(diagnostics.error_summary, /http_400/);
+    assert.match(diagnostics.error_summary, /signal_request_invalid/);
+    assert.doesNotMatch(JSON.stringify(diagnostics), /private medical note|super-secret|sk-secret-value|req-private-user-123/);
+  });
+
+  test('does not execute throwing error getters while capturing diagnostics', () => {
+    const hostile = new Proxy(Object.freeze({}), {
+      get(_target, property) {
+        if (property === 'message' || property === 'response' || property === 'cause') {
+          throw new Error('getter should not escape diagnostics');
+        }
+        return undefined;
+      },
+      getPrototypeOf() { throw new Error('prototype access should not escape diagnostics'); },
+    });
+    const diagnostics = captureModelErrorDiagnostics(hostile, { phase: 'agent_turn' });
+    assert.equal(diagnostics.origin, 'runtime');
+    assert.equal(typeof diagnostics.error_summary, 'string');
+    assert.match(diagnostics.fingerprint, /^[a-f0-9]{16}$/);
+  });
+
+  test('classifies the safe cause carried by a partial-turn wrapper', () => {
+    const cause = Object.assign(new Error('API错误 (504): request timed out'), { status: 504 });
+    const wrapped = new Error(cause.message);
+    Object.defineProperty(wrapped, 'cause', { value: cause, enumerable: false });
+    const classified = classifyModelError(wrapped, { ...noKnownFlags, isTimeout: true });
+    assert.equal(classified.category, 'timeout');
+    assert.equal(classified.diagnostics.http_status, 504);
+  });
+
 });

--- a/tests/openai-provider-runtime-feedback.test.ts
+++ b/tests/openai-provider-runtime-feedback.test.ts
@@ -42,6 +42,7 @@ describe('OpenAIProvider runtime feedback boundary', () => {
         name: 'send_text',
         content: 'ok',
         __runtimeFeedback: true,
+        __toolExecutionSucceeded: true,
       } as any,
     ];
 
@@ -53,6 +54,7 @@ describe('OpenAIProvider runtime feedback boundary', () => {
     assert.equal(JSON.stringify(body.messages).includes('__injected'), false);
     assert.equal(JSON.stringify(body.messages).includes('__cacheScope'), false);
     assert.equal(JSON.stringify(body.messages).includes('__runtimeFeedback'), false);
+    assert.equal(JSON.stringify(body.messages).includes('__toolExecutionSucceeded'), false);
     assert.equal(JSON.stringify(body.messages).includes('__runtimeObservation'), false);
     assert.equal(JSON.stringify(body.messages).includes('__episodeId'), false);
     assert.equal(JSON.stringify(body.messages).includes('__episodeInputKind'), false);

--- a/tests/session-lifecycle-manager.test.ts
+++ b/tests/session-lifecycle-manager.test.ts
@@ -592,6 +592,22 @@ describe('AgentSession lifecycle', () => {
     );
   });
 
+  test('does not report completion or emit completion events when completed-turn persistence fails', async () => {
+    const { AgentSession } = loadSessionModules();
+    const session = new AgentSession('catscompany:lifecycle-completed-save-failure', buildMockServices(), 'catscompany');
+    session.setSystemPromptProvider(() => 'system prompt');
+    let completionEvents = 0;
+    (session as any).recordCompletedTurnEvents = () => { completionEvents += 1; };
+    (session as any).lifecycleManager.saveContext = () => false;
+
+    const result = await session.handleMessage('autosave user');
+
+    assert.equal(result.taskOutcome, 'failed');
+    assert.equal(result.visibleToUser, true);
+    assert.match(result.text, /持久化失败/);
+    assert.equal(completionEvents, 0);
+  });
+
   test('handleMessage surfaces restored-history compaction as thinking status', async () => {
     const {
       AgentSession,
@@ -732,7 +748,9 @@ describe('AgentSession lifecycle', () => {
 
     const result = await session.handleMessage('read notes then continue');
 
-    assert.equal(result.text, '模型服务暂时不稳定，本次处理未能完成，请稍后继续。');
+    assert.match(result.text, new RegExp(`^${MODEL_TIMEOUT_MESSAGE}`));
+    assert.match(result.text, /本次未记录到自动重试/);
+    assert.match(result.text, /已完成的工具结果和上下文已保存/);
     assert.equal(aiCalls, 2);
 
     const retainedMessages = (session as any).messages as any[];
@@ -750,6 +768,13 @@ describe('AgentSession lifecycle', () => {
       typeof message.content === 'string'
       && message.content.includes('模型中转请求超时')
     ), false);
+
+    const logPath = (session as any).sessionTurnLogger.getLogFilePath();
+    const entries = fs.readFileSync(logPath, 'utf8').split(/\r?\n/).filter(Boolean).map(line => JSON.parse(line));
+    const turnError = entries.find(entry => entry?.event?.type === 'turn_error');
+    assert.equal(turnError?.event?.payload.context_persisted, true);
+    assert.equal(turnError?.event?.payload.recoverable_partial_progress, true);
+    assert.equal(turnError?.event?.payload.partial_progress_preserved, true);
 
     const restored = SessionStore.getInstance().loadContext('catscompany:lifecycle-timeout-recovery');
     assert.equal(restored.some(message => message.content === 'notes content'), true);
@@ -808,7 +833,8 @@ describe('AgentSession lifecycle', () => {
 
     const result = await session.handleMessage('continue');
 
-    assert.equal(result.text, '模型服务暂时不稳定，本次处理未能完成，请稍后继续。');
+    assert.match(result.text, /模型拒绝了本轮请求格式/);
+    assert.doesNotMatch(result.text, /额度不足|补充额度/);
   });
 
   test('handleMessage surfaces transient provider failures without leaking raw upstream payload', async () => {
@@ -890,7 +916,10 @@ describe('AgentSession lifecycle', () => {
 
     const result = await session.handleMessage('继续上一条');
 
-    assert.equal(result.text, '模型服务暂时不稳定，本次处理未能完成，请稍后继续。');
+    assert.match(result.text, new RegExp(`^${EMPTY_MODEL_RESPONSE_MESSAGE}`));
+    assert.match(result.text, /本次未记录到自动重试/);
+    assert.match(result.text, /重新发送上一条消息/);
+    assert.match(result.text, /切换模型或稍后再试/);
     assert.doesNotMatch(result.text, /EMPTY_MODEL_RESPONSE|请求失败/);
   });
 
@@ -953,7 +982,8 @@ describe('AgentSession lifecycle', () => {
     const result = await session.handleMessage('继续');
 
     assert.equal(result.taskOutcome, 'failed');
-    assert.equal(result.text, '模型服务暂时不稳定，系统已尝试自动恢复但仍未成功，请稍后继续。');
+    assert.match(result.text, /上游模型拒绝了本轮请求/);
+    assert.match(result.text, /已自动重试 2 次/);
     const logPath = (session as any).sessionTurnLogger.getLogFilePath();
     const entries = fs.readFileSync(logPath, 'utf8')
       .split(/\r?\n/)
@@ -975,7 +1005,119 @@ describe('AgentSession lifecycle', () => {
     assert.equal(turnErrors[0].event.payload.model_attempt_number, 3);
     assert.equal(turnErrors[0].event.payload.episode_id, 'episode-interrupted');
     assert.match(turnErrors[0].event.payload.error_fingerprint, /^[a-f0-9]{16}$/);
-    assert.equal(typeof turnErrors[0].event.payload.partial_progress_preserved, 'boolean');
+    assert.equal(turnErrors[0].event.payload.context_persisted, true);
+    assert.equal(turnErrors[0].event.payload.recoverable_partial_progress, false);
+    assert.equal(turnErrors[0].event.payload.partial_progress_preserved, false);
+  });
+
+
+  test('does not claim completed tool progress was preserved when persistence fails', async () => {
+    const { AgentSession } = loadSessionModules();
+    const session = new AgentSession(
+      'catscompany:lifecycle-persistence-failure',
+      buildMockServices(),
+      'catscompany',
+    );
+    session.setSystemPromptProvider(() => 'system prompt');
+    const episodeId = 'episode-persistence-failure';
+    const providerError = Object.assign(new Error('API错误 (504): request timed out'), {
+      status: 504,
+      partialMessages: [
+        { role: 'system', content: 'system prompt' },
+        {
+          role: 'user',
+          content: '继续',
+          __episodeId: episodeId,
+          __episodeInputKind: 'root',
+        },
+        {
+          role: 'assistant',
+          content: null,
+          __episodeId: episodeId,
+          tool_calls: [{
+            id: 'call-read',
+            type: 'function',
+            function: { name: 'read_file', arguments: '{}' },
+          }],
+        },
+        {
+          role: 'tool',
+          content: 'tool result',
+          name: 'read_file',
+          tool_call_id: 'call-read',
+          __toolExecutionSucceeded: true,
+          __episodeId: episodeId,
+        },
+      ],
+    });
+    (session as any).turnController.run = async () => { throw providerError; };
+    (session as any).lifecycleManager.saveContext = () => false;
+
+    const result = await session.handleMessage('继续');
+    assert.match(result.text, /模型中转请求超时/);
+    assert.match(result.text, /本轮已有部分进度，但持久化失败/);
+    assert.doesNotMatch(result.text, /已经保留上下文|已保存，可直接说/);
+    const logPath = (session as any).sessionTurnLogger.getLogFilePath();
+    const entries = fs.readFileSync(logPath, 'utf8').split(/\r?\n/).filter(Boolean).map(line => JSON.parse(line));
+    const turnError = entries.find(entry => entry?.event?.type === 'turn_error');
+    assert.equal(turnError?.event?.payload.context_persisted, false);
+    assert.equal(turnError?.event?.payload.recoverable_partial_progress, true);
+    assert.equal(turnError?.event?.payload.partial_progress_preserved, false);
+  });
+
+  test('requires a paired successful tool result before reporting recoverable progress', () => {
+    const { AgentSession } = loadSessionModules();
+    const session = new AgentSession(
+      'catscompany:lifecycle-tool-progress-evidence',
+      buildMockServices(),
+      'catscompany',
+    );
+    const root = { role: 'user', content: '继续', __episodeId: 'episode-tool', __episodeInputKind: 'root' };
+    const assistant = {
+      role: 'assistant', content: null, __episodeId: 'episode-tool',
+      tool_calls: [{ id: 'call-ok', type: 'function', function: { name: 'read_file', arguments: '{}' } }],
+    };
+    const successful = {
+      role: 'tool', content: 'ok', tool_call_id: 'call-ok', name: 'read_file',
+      __episodeId: 'episode-tool', __toolExecutionSucceeded: true,
+    };
+    const failed = { ...successful, __toolExecutionSucceeded: false };
+    const orphan = { ...successful, tool_call_id: 'call-orphan' };
+    assert.equal((session as any).hasRecoverablePartialProgress([root, assistant, successful]), true);
+    assert.equal((session as any).hasRecoverablePartialProgress([root, assistant, failed]), false);
+    assert.equal((session as any).hasRecoverablePartialProgress([root, assistant, orphan]), false);
+    assert.equal((session as any).hasRecoverablePartialProgress([root, successful]), false);
+  });
+
+  test('returns a classified failure when an error exposes throwing getters', async () => {
+    const { AgentSession } = loadSessionModules();
+    const session = new AgentSession(
+      'catscompany:lifecycle-hostile-error',
+      buildMockServices(),
+      'catscompany',
+    );
+    session.setSystemPromptProvider(() => 'system prompt');
+    const hostileError = new Proxy(Object.freeze({}), {
+      get(_target, property) {
+        if (property === 'message' || property === 'response' || property === 'cause' || property === 'partialMessages') {
+          throw new Error('hostile getter must not escape handleMessage');
+        }
+        if (property === 'code') {
+          return { toString() { throw new Error('hostile code conversion must not escape handleMessage'); } };
+        }
+        return undefined;
+      },
+      getPrototypeOf() {
+        throw new Error('hostile prototype must not escape handleMessage');
+      },
+    });
+    (session as any).turnController.run = async () => { throw hostileError; };
+
+    const result = await session.handleMessage('继续');
+    assert.equal(result.taskOutcome, 'failed');
+    assert.equal(result.visibleToUser, true);
+    assert.match(result.text, /未识别的异常/);
+    assert.doesNotMatch(result.text, /hostile getter must not escape/);
   });
 
   test('cleanup persists without invoking hidden AI wakeup checks', async () => {

--- a/tests/session-lifecycle-manager.test.ts
+++ b/tests/session-lifecycle-manager.test.ts
@@ -695,7 +695,7 @@ describe('AgentSession lifecycle', () => {
   });
 
   test('handleMessage preserves completed tool context when model relay times out', async () => {
-    const { AgentSession, SessionStore } = loadSessionModules();
+    const { AgentSession, SessionStore, MODEL_TIMEOUT_MESSAGE } = loadSessionModules();
     let aiCalls = 0;
     const toolCall = {
       id: 'call_read',
@@ -800,7 +800,8 @@ describe('AgentSession lifecycle', () => {
 
     const result = await session.handleMessage('continue');
 
-    assert.equal(result.text, '模型服务暂时不稳定，本次处理未能完成，请稍后继续。');
+    assert.match(result.text, /当前模型额度不足/);
+    assert.match(result.text, /检查模型额度或切换模型/);
     assert.doesNotMatch(result.text, /model budget exceeded|API错误/i);
   });
 
@@ -817,7 +818,8 @@ describe('AgentSession lifecycle', () => {
 
     const result = await session.handleMessage('continue');
 
-    assert.equal(result.text, '模型服务暂时不稳定，本次处理未能完成，请稍后继续。');
+    assert.match(result.text, /当前模型额度不足/);
+    assert.match(result.text, /检查模型额度或切换模型/);
   });
 
   test('handleMessage does not treat unrelated 402 text as relay budget exhaustion', async () => {
@@ -833,7 +835,7 @@ describe('AgentSession lifecycle', () => {
 
     const result = await session.handleMessage('continue');
 
-    assert.match(result.text, /模型拒绝了本轮请求格式/);
+    assert.match(result.text, /模型未能处理本次请求/);
     assert.doesNotMatch(result.text, /额度不足|补充额度/);
   });
 
@@ -853,7 +855,8 @@ describe('AgentSession lifecycle', () => {
 
     const result = await session.handleMessage('continue');
 
-    assert.equal(result.text, '模型服务暂时不稳定，本次处理未能完成，请稍后继续。');
+    assert.match(result.text, /当前模型 MiniMax-M3 的服务临时异常/);
+    assert.match(result.text, /稍后重试|切换到其他模型/);
     assert.doesNotMatch(result.text, /unknown error|request_id|API错误|520/);
   });
 
@@ -870,7 +873,7 @@ describe('AgentSession lifecycle', () => {
 
     const result = await session.handleMessage('继续');
 
-    assert.equal(result.text, '模型服务暂时不稳定，本次处理未能完成，请稍后继续。');
+    assert.match(result.text, /当前请求较多，请稍等片刻再试/);
     assert.doesNotMatch(result.text, /429|状态码|错误编号/);
   });
 
@@ -896,12 +899,13 @@ describe('AgentSession lifecycle', () => {
 
     const result = await session.handleMessage('继续');
 
-    assert.equal(result.text, '模型服务暂时不稳定，系统已尝试自动恢复但仍未成功，请稍后继续。');
+    assert.match(result.text, /模型服务暂时不可用/);
+    assert.match(result.text, /已自动重试 1 次/);
     assert.doesNotMatch(result.text, /503|状态码|错误编号/);
   });
 
   test('handleMessage tells the user how to recover after empty model responses are exhausted', async () => {
-    const { AgentSession } = loadSessionModules();
+    const { AgentSession, EMPTY_MODEL_RESPONSE_MESSAGE } = loadSessionModules();
     const session = new AgentSession('catscompany:lifecycle-empty-model-response', buildMockServices({
       aiService: {
         async chatStream() {
@@ -939,7 +943,8 @@ describe('AgentSession lifecycle', () => {
 
     const result = await session.handleMessage('继续');
 
-    assert.equal(result.text, '模型服务暂时不稳定，本次处理未能完成，请稍后继续。');
+    assert.match(result.text, /当前模型 gpt-5\.5 的服务临时异常/);
+    assert.match(result.text, /稍后重试|切换到其他模型/);
     assert.doesNotMatch(result.text, /API错误|状态码|503/);
   });
 
@@ -982,7 +987,7 @@ describe('AgentSession lifecycle', () => {
     const result = await session.handleMessage('继续');
 
     assert.equal(result.taskOutcome, 'failed');
-    assert.match(result.text, /上游模型拒绝了本轮请求/);
+    assert.match(result.text, /模型未能处理本次请求/);
     assert.match(result.text, /已自动重试 2 次/);
     const logPath = (session as any).sessionTurnLogger.getLogFilePath();
     const entries = fs.readFileSync(logPath, 'utf8')
@@ -1054,7 +1059,7 @@ describe('AgentSession lifecycle', () => {
     (session as any).lifecycleManager.saveContext = () => false;
 
     const result = await session.handleMessage('继续');
-    assert.match(result.text, /模型中转请求超时/);
+    assert.match(result.text, /模型响应超时/);
     assert.match(result.text, /本轮已有部分进度，但持久化失败/);
     assert.doesNotMatch(result.text, /已经保留上下文|已保存，可直接说/);
     const logPath = (session as any).sessionTurnLogger.getLogFilePath();
@@ -1116,7 +1121,7 @@ describe('AgentSession lifecycle', () => {
     const result = await session.handleMessage('继续');
     assert.equal(result.taskOutcome, 'failed');
     assert.equal(result.visibleToUser, true);
-    assert.match(result.text, /未识别的异常/);
+    assert.match(result.text, /本次处理未能完成，请稍后再试/);
     assert.doesNotMatch(result.text, /hostile getter must not escape/);
   });
 

--- a/tests/weixin-session-route.test.ts
+++ b/tests/weixin-session-route.test.ts
@@ -2,6 +2,7 @@ import { describe, test } from 'node:test';
 import * as assert from 'node:assert';
 import { WeixinBot } from '../src/weixin';
 import { SubAgentManager } from '../src/core/sub-agent-manager';
+import { BUSY_MESSAGE } from '../src/core/agent-session';
 
 describe('Weixin SessionRoute V2', () => {
   test('routes messages through a Weixin V2 key while preserving the outbound user id', async () => {
@@ -84,51 +85,175 @@ describe('Weixin SessionRoute V2', () => {
       SubAgentManager.getInstance().unregisterPlatformCallbacks('session:v2:weixin:p2p:shared');
     }
   });
-
-  test('delivers classified failed replies without relying on the legacy fallback text', async () => {
+  test('sends a classified failed result instead of collapsing it to ERROR_MESSAGE', async () => {
     const sentTexts: Array<{ userId: string; text: string; contextToken?: string; fromUserId?: string }> = [];
     const bot = createHarness({
       sentTexts,
+      result: { visibleToUser: true, text: '当前模型的访问凭证无效。', taskOutcome: 'failed' },
       parsed: {
-        message_id: 'wx-msg-error',
-        from: { id: 'shared' },
-        chat: { id: 'wx-bot' },
-        text: '继续',
-        context_token: 'ctx-token',
+        message_id: 'wx-msg-failed', from: { id: 'user-failed' }, chat: { id: 'wx-bot' },
+        text: 'hello', context_token: 'ctx-failed',
       },
     });
-    bot.sessionResult = {
-      visibleToUser: true,
-      text: '模型响应超时，本轮上下文已保留，请稍后继续。',
-      taskOutcome: 'failed',
-    };
-
     try {
       await (bot as any).handleMessage({
-        message_type: 0,
-        message_id: 'wx-msg-error',
-        from_user_id: 'shared',
-        to_user_id: 'wx-bot',
-        context_token: 'ctx-token',
+        message_type: 0, message_id: 'wx-msg-failed', from_user_id: 'user-failed',
+        to_user_id: 'wx-bot', context_token: 'ctx-failed',
       });
-
-      assert.deepEqual(sentTexts, [
-        {
-          userId: 'shared',
-          text: '模型响应超时，本轮上下文已保留，请稍后继续。',
-          contextToken: 'ctx-token',
-          fromUserId: 'wx-bot',
-        },
-      ]);
+      assert.deepEqual(sentTexts.map(entry => entry.text), ['当前模型的访问凭证无效。']);
     } finally {
-      SubAgentManager.getInstance().unregisterPlatformCallbacks('session:v2:weixin:p2p:shared');
+      SubAgentManager.getInstance().unregisterPlatformCallbacks('session:v2:weixin:p2p:user-failed');
     }
   });
+
+  test('requeues a direct racing BUSY user message and sends the later failure once', async () => {
+    const sentTexts: Array<{ userId: string; text: string; contextToken?: string; fromUserId?: string }> = [];
+    const bot = createHarness({
+      sentTexts,
+      results: [
+        { visibleToUser: true, text: BUSY_MESSAGE },
+        { visibleToUser: true, text: '模型请求超时。', taskOutcome: 'failed' },
+      ],
+      parsed: {
+        message_id: 'wx-direct-race', from: { id: 'direct-race-user' }, chat: { id: 'wx-bot' },
+        text: 'direct racing user text', context_token: 'ctx-direct-race',
+      },
+    });
+    const sessionKey = 'session:v2:weixin:p2p:direct-race-user';
+    try {
+      await (bot as any).handleMessage({
+        message_type: 0, message_id: 'wx-direct-race', from_user_id: 'direct-race-user',
+        to_user_id: 'wx-bot', context_token: 'ctx-direct-race',
+      });
+      assert.equal(bot.messageQueue.get(sessionKey)?.[0]?.userText, 'direct racing user text');
+      assert.deepEqual(sentTexts, []);
+
+      await (bot as any).drainMessageQueue(sessionKey);
+      assert.equal(bot.messageQueue.has(sessionKey), false);
+      assert.deepEqual(sentTexts.map(entry => entry.text), ['模型请求超时。']);
+    } finally {
+      SubAgentManager.getInstance().unregisterPlatformCallbacks(sessionKey);
+    }
+  });
+
+  test('sends a queued classified failure exactly once', async () => {
+    const sentTexts: Array<{ userId: string; text: string; contextToken?: string; fromUserId?: string }> = [];
+    const bot = createHarness({
+      busy: true,
+      sentTexts,
+      result: { visibleToUser: true, text: '模型请求参数无效。', taskOutcome: 'failed' },
+      parsed: {
+        message_id: 'wx-msg-queued-failed', from: { id: 'queued-user' }, chat: { id: 'wx-bot' },
+        text: '继续', context_token: 'ctx-queued',
+      },
+    });
+    const sessionKey = 'session:v2:weixin:p2p:queued-user';
+    try {
+      await (bot as any).handleMessage({
+        message_type: 0, message_id: 'wx-msg-queued-failed', from_user_id: 'queued-user',
+        to_user_id: 'wx-bot', context_token: 'ctx-queued',
+      });
+      bot.sessionBusy = false;
+      await (bot as any).drainMessageQueue(sessionKey);
+      assert.deepEqual(sentTexts.map(entry => entry.text), ['模型请求参数无效。']);
+    } finally {
+      SubAgentManager.getInstance().unregisterPlatformCallbacks(sessionKey);
+    }
+  });
+
+  test('sends a subagent classified failure exactly once', async () => {
+    const sentTexts: Array<{ userId: string; text: string; contextToken?: string; fromUserId?: string }> = [];
+    const bot = createHarness({
+      sentTexts,
+      runtimeResult: { visibleToUser: true, text: '模型服务暂时不可用。', taskOutcome: 'failed' },
+      parsed: {
+        message_id: 'unused', from: { id: 'subagent-user' }, chat: { id: 'wx-bot' },
+        text: 'unused', context_token: 'ctx-subagent',
+      },
+    });
+    await (bot as any).handleSubAgentFeedback(
+      'session:v2:weixin:p2p:subagent-user',
+      'subagent-user',
+      'subagent-user',
+      'subagent result',
+    );
+    assert.deepEqual(sentTexts.map(entry => entry.text), ['模型服务暂时不可用。']);
+  });
+
+  test('queues busy subagent feedback and later sends its classified failure once', async () => {
+    const sentTexts: Array<{ userId: string; text: string; contextToken?: string; fromUserId?: string }> = [];
+    const bot = createHarness({
+      busy: true,
+      sentTexts,
+      runtimeResult: { visibleToUser: true, text: '模型超时，请稍后重试。', taskOutcome: 'failed' },
+      parsed: { message_id: 'unused', from: { id: 'subagent-user' }, chat: { id: 'wx-bot' }, text: '', context_token: 'ctx-subagent' },
+    });
+    const sessionKey = 'session:v2:weixin:p2p:subagent-user';
+    await (bot as any).handleSubAgentFeedback(sessionKey, 'subagent-user', 'subagent-user', 'subagent result');
+    assert.equal(bot.messageQueue.get(sessionKey)?.[0]?.source, 'subagent_feedback');
+    bot.sessionBusy = false;
+    await (bot as any).drainMessageQueue(sessionKey);
+    assert.deepEqual(sentTexts.map(entry => entry.text), ['模型超时，请稍后重试。']);
+  });
+
+  test('requeues a racing BUSY subagent result and sends the later failure once', async () => {
+    const sentTexts: Array<{ userId: string; text: string; contextToken?: string; fromUserId?: string }> = [];
+    const bot = createHarness({
+      sentTexts,
+      runtimeResults: [
+        { visibleToUser: true, text: BUSY_MESSAGE },
+        { visibleToUser: true, text: '模型权限不足。', taskOutcome: 'failed' },
+      ],
+      parsed: { message_id: 'unused', from: { id: 'subagent-user' }, chat: { id: 'wx-bot' }, text: '', context_token: 'ctx-subagent' },
+    });
+    const sessionKey = 'session:v2:weixin:p2p:subagent-user';
+    await (bot as any).handleSubAgentFeedback(sessionKey, 'subagent-user', 'subagent-user', 'subagent result');
+    assert.equal(bot.messageQueue.get(sessionKey)?.[0]?.source, 'subagent_feedback');
+    await (bot as any).drainMessageQueue(sessionKey);
+    assert.deepEqual(sentTexts.map(entry => entry.text), ['模型权限不足。']);
+  });
+
+
+  test('requeues a racing BUSY queued user message and sends the later failure once', async () => {
+    const sentTexts: Array<{ userId: string; text: string; contextToken?: string; fromUserId?: string }> = [];
+    const bot = createHarness({
+      sentTexts,
+      results: [
+        { visibleToUser: true, text: BUSY_MESSAGE },
+        { visibleToUser: true, text: '模型请求超时。', taskOutcome: 'failed' },
+      ],
+      parsed: { message_id: 'wx-race', from: { id: 'race-user' }, chat: { id: 'wx-bot' }, text: 'queued user text', context_token: 'ctx-race' },
+    });
+    const sessionKey = 'session:v2:weixin:p2p:race-user';
+    bot.sessionBusy = true;
+    try {
+      await (bot as any).handleMessage({
+        message_type: 0, message_id: 'wx-race', from_user_id: 'race-user',
+        to_user_id: 'wx-bot', context_token: 'ctx-race',
+      });
+      bot.sessionBusy = false;
+      await (bot as any).drainMessageQueue(sessionKey);
+      assert.equal(bot.messageQueue.get(sessionKey)?.length, 1);
+      assert.equal(bot.messageQueue.get(sessionKey)?.[0]?.userText, 'queued user text');
+      assert.deepEqual(sentTexts, []);
+
+      await (bot as any).drainMessageQueue(sessionKey);
+      assert.equal(bot.messageQueue.has(sessionKey), false);
+      assert.deepEqual(sentTexts.map(entry => entry.text), ['模型请求超时。']);
+    } finally {
+      SubAgentManager.getInstance().unregisterPlatformCallbacks(sessionKey);
+    }
+  });
+
 });
 
 function createHarness(options: {
   busy?: boolean;
   parsed: any;
+  result?: any;
+  results?: any[];
+  runtimeResult?: any;
+  runtimeResults?: any[];
   sentTexts?: Array<{ userId: string; text: string; contextToken?: string; fromUserId?: string }>;
 }): any {
   const bot = Object.create(WeixinBot.prototype) as any;
@@ -148,11 +273,11 @@ function createHarness(options: {
     isBusy: () => bot.sessionBusy,
     handleMessage: async (userText: string, handleOptions: any) => {
       bot.handledTurns.push({ userText, options: handleOptions });
-      return bot.sessionResult;
+      return options.results?.shift() ?? options.result ?? { visibleToUser: false, text: '' };
     },
     handleRuntimeObservation: async (userText: string, handleOptions: any) => {
       bot.handledTurns.push({ userText, options: handleOptions });
-      return { visibleToUser: false, text: '' };
+      return options.runtimeResults?.shift() ?? options.runtimeResult ?? { visibleToUser: false, text: '' };
     },
   };
   bot.sessionManager = {


### PR DESCRIPTION
## 做了什么重要事情

让分类后的模型失败在主会话、飞书和微信通道中保持一致，并把终止失败作为可恢复、可审计的运行时状态持久化：

- 模型失败不再被通道层统一折叠为模糊的兜底错误。
- 保存已完成的工具结果和对话上下文，并明确告诉用户是否可以继续。
- 持久化重试次数、停止原因、provider 请求信息、错误指纹和失败阶段。
- 只为真正终止的失败记录一个结构化 turn_error，避免重复或误报完成。
- 安全读取 hostile getters，避免错误对象本身再次打断失败处理。

## 为什么需要提交这个 PR

模型请求失败时，用户不仅需要知道失败类型，还需要知道自动重试是否发生、已完成的工具进度是否保存、重启后是否能够恢复。若失败只停留在内存或被通道改写成统一文案，恢复、审计和线上排障都会丢失关键上下文。

该改动把失败分类、持久化、通道投递和结构化诊断作为一个完整闭环提交，避免只改其中一层导致语义不一致。

## 验证

- npm run build
- 8 个专项测试文件
- 155 项测试全部通过，0 失败
- 测试使用清除 XIAOBA_USER_DATA_DIR、CATSCO_USER_DATA_DIR、XIAOBA_ELECTRON_USER_DATA_DIR 和 XIAOBA_RUNTIME_ROOT 的干净环境运行

此前一次复核中出现的 9 项生命周期失败是验证命令注入外部用户数据目录造成的环境污染；按测试原生的 process.cwd 隔离方式重跑后，AgentSession 生命周期 43 项测试全部通过。代码工作树未发生额外修改。

## 来源与基线

- PR head：CatsCo-Albert:XiaoBa-CLI 的 pr/model-failure-persistence-buildsense
- head SHA：d4c40d982c1df1d6a8b37c5403415bbcdfd33168
- 目标：buildsense-ai:XiaoBa-CLI 的 main