### PR TITLE
feat: 为服务器 Runtime 开放 SkillHub 工作区

### DIFF
--- a/src/bot-skills/deleted-skill-trash.ts
+++ b/src/bot-skills/deleted-skill-trash.ts
@@ -33,6 +33,8 @@ export interface TrashBotSkillOptions {
   installName: string;
   deletedByOwnerUid: string;
   now?: () => Date;
+  /** Test-only concurrency hook; production callers must leave this unset. */
+  beforeMove?: () => void;
 }
 
 export interface TrashBotSkillResult {
@@ -42,7 +44,7 @@ export interface TrashBotSkillResult {
 }
 
 /**
- * Creates and verifies a recoverable copy before deleting one active Skill.
+ * Atomically moves one active Skill into a verified recoverable trash entry.
  * Trash is evidence only: Runtime discovery never reads this directory.
  */
 export function trashBotSkill(options: TrashBotSkillOptions): TrashBotSkillResult {
@@ -67,31 +69,31 @@ export function trashBotSkill(options: TrashBotSkillOptions): TrashBotSkillResul
     `.tmp-${backupId}-${process.pid}-${crypto.randomBytes(8).toString('hex')}`,
   );
   const packageRoot = path.join(temporary, 'package');
-  const manifest: TrashedSkillManifest = {
-    schema: TRASH_SCHEMA,
-    backupId,
-    botId,
-    localSkillId,
-    name: String(options.name || '').trim(),
-    installName: normalizeInstallName(options.installName),
-    deletedByOwnerUid,
-    deletedAt,
-    expiresAt,
-    files,
-  };
-
-  fs.mkdirSync(packageRoot, { recursive: true });
+  let sourceMoved = false;
+  fs.mkdirSync(temporary, { recursive: false });
   try {
-    for (const file of files) {
-      const source = path.join(sourcePath, ...file.path.split('/'));
-      const target = path.join(packageRoot, ...file.path.split('/'));
-      fs.mkdirSync(path.dirname(target), { recursive: true });
-      fs.copyFileSync(source, target, fs.constants.COPYFILE_EXCL);
-      const copied = fileRecord(packageRoot, file.path);
-      if (copied.size !== file.size || copied.sha256 !== file.sha256) {
-        throw new Error(`Deleted Skill backup verification failed: ${file.path}`);
-      }
+    options.beforeMove?.();
+    // sourcePath and trashRoot both live below the same Runtime root. Moving
+    // the directory removes it from discovery atomically without recursively
+    // deleting any file that was not captured by the verified manifest.
+    fs.renameSync(sourcePath, packageRoot);
+    sourceMoved = true;
+    const movedFiles = listFiles(packageRoot);
+    if (!filesEqual(files, movedFiles) || fs.existsSync(sourcePath)) {
+      throw new Error('Skill changed while deletion was being prepared; no files were deleted.');
     }
+    const manifest: TrashedSkillManifest = {
+      schema: TRASH_SCHEMA,
+      backupId,
+      botId,
+      localSkillId,
+      name: String(options.name || '').trim(),
+      installName: normalizeInstallName(options.installName),
+      deletedByOwnerUid,
+      deletedAt,
+      expiresAt,
+      files: movedFiles,
+    };
     fs.writeFileSync(
       path.join(temporary, 'deletion.json'),
       `${JSON.stringify(manifest, null, 2)}\n`,
@@ -99,12 +101,20 @@ export function trashBotSkill(options: TrashBotSkillOptions): TrashBotSkillResul
     );
     fs.renameSync(temporary, finalPath);
     assertTrashEntry(finalPath, manifest);
-    fs.rmSync(sourcePath, { recursive: true, force: false });
     return { backupId, deletedAt, expiresAt };
   } catch (error) {
-    if (fs.existsSync(temporary)) fs.rmSync(temporary, { recursive: true, force: true });
-    // Once the verified backup has been promoted it must remain as recovery
-    // evidence even if deleting the active directory fails.
+    if (sourceMoved && fs.existsSync(packageRoot) && !fs.existsSync(sourcePath)) {
+      try {
+        fs.renameSync(packageRoot, sourcePath);
+        sourceMoved = false;
+      } catch {
+        // If restoration itself fails, preserve the temporary recovery
+        // evidence instead of recursively deleting the moved source.
+      }
+    }
+    if (!sourceMoved && fs.existsSync(temporary)) {
+      fs.rmSync(temporary, { recursive: true, force: true });
+    }
     throw error;
   }
 }

--- a/src/bot-skills/deleted-skill-trash.ts
+++ b/src/bot-skills/deleted-skill-trash.ts
@@ -1,0 +1,255 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const TRASH_SCHEMA = 'xiaoba.bot-skill-trash.v1';
+const TRASH_RETENTION_MS = 30 * 24 * 60 * 60 * 1_000;
+
+interface TrashedSkillFile {
+  path: string;
+  size: number;
+  sha256: string;
+}
+
+export interface TrashedSkillManifest {
+  schema: typeof TRASH_SCHEMA;
+  backupId: string;
+  botId: string;
+  localSkillId: string;
+  name: string;
+  installName: string;
+  deletedByOwnerUid: string;
+  deletedAt: string;
+  expiresAt: string;
+  files: TrashedSkillFile[];
+}
+
+export interface TrashBotSkillOptions {
+  runtimeRoot: string;
+  botId: string;
+  sourcePath: string;
+  localSkillId: string;
+  name: string;
+  installName: string;
+  deletedByOwnerUid: string;
+  now?: () => Date;
+}
+
+export interface TrashBotSkillResult {
+  backupId: string;
+  deletedAt: string;
+  expiresAt: string;
+}
+
+/**
+ * Creates and verifies a recoverable copy before deleting one active Skill.
+ * Trash is evidence only: Runtime discovery never reads this directory.
+ */
+export function trashBotSkill(options: TrashBotSkillOptions): TrashBotSkillResult {
+  const runtimeRoot = requireSafeDirectory(options.runtimeRoot, 'Runtime root');
+  const botId = normalizeScopedId(options.botId, 'Bot ID');
+  const sourcePath = requireSafeDirectory(options.sourcePath, 'source Skill');
+  const localSkillId = normalizeScopedId(options.localSkillId, 'local Skill ID');
+  const deletedByOwnerUid = normalizeScopedId(options.deletedByOwnerUid, 'owner UID');
+  const files = listFiles(sourcePath);
+  const now = options.now ?? (() => new Date());
+  const deletedAtDate = now();
+  if (!Number.isFinite(deletedAtDate.getTime())) throw new Error('Skill deletion time is invalid.');
+  const deletedAt = deletedAtDate.toISOString();
+  const expiresAt = new Date(deletedAtDate.getTime() + TRASH_RETENTION_MS).toISOString();
+  const backupId = crypto.randomUUID();
+  const trashRoot = ensureTrashBotRoot(runtimeRoot, botId);
+  cleanupExpiredTrash(trashRoot, deletedAtDate);
+
+  const finalPath = path.join(trashRoot, backupId);
+  const temporary = path.join(
+    trashRoot,
+    `.tmp-${backupId}-${process.pid}-${crypto.randomBytes(8).toString('hex')}`,
+  );
+  const packageRoot = path.join(temporary, 'package');
+  const manifest: TrashedSkillManifest = {
+    schema: TRASH_SCHEMA,
+    backupId,
+    botId,
+    localSkillId,
+    name: String(options.name || '').trim(),
+    installName: normalizeInstallName(options.installName),
+    deletedByOwnerUid,
+    deletedAt,
+    expiresAt,
+    files,
+  };
+
+  fs.mkdirSync(packageRoot, { recursive: true });
+  try {
+    for (const file of files) {
+      const source = path.join(sourcePath, ...file.path.split('/'));
+      const target = path.join(packageRoot, ...file.path.split('/'));
+      fs.mkdirSync(path.dirname(target), { recursive: true });
+      fs.copyFileSync(source, target, fs.constants.COPYFILE_EXCL);
+      const copied = fileRecord(packageRoot, file.path);
+      if (copied.size !== file.size || copied.sha256 !== file.sha256) {
+        throw new Error(`Deleted Skill backup verification failed: ${file.path}`);
+      }
+    }
+    fs.writeFileSync(
+      path.join(temporary, 'deletion.json'),
+      `${JSON.stringify(manifest, null, 2)}\n`,
+      { encoding: 'utf8', flag: 'wx' },
+    );
+    fs.renameSync(temporary, finalPath);
+    assertTrashEntry(finalPath, manifest);
+    fs.rmSync(sourcePath, { recursive: true, force: false });
+    return { backupId, deletedAt, expiresAt };
+  } catch (error) {
+    if (fs.existsSync(temporary)) fs.rmSync(temporary, { recursive: true, force: true });
+    // Once the verified backup has been promoted it must remain as recovery
+    // evidence even if deleting the active directory fails.
+    throw error;
+  }
+}
+
+function cleanupExpiredTrash(trashRoot: string, now: Date): void {
+  for (const entry of fs.readdirSync(trashRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory() || entry.isSymbolicLink() || entry.name.startsWith('.tmp-')) continue;
+    const entryPath = path.join(trashRoot, entry.name);
+    try {
+      const raw = JSON.parse(
+        fs.readFileSync(path.join(entryPath, 'deletion.json'), 'utf8'),
+      ) as Partial<TrashedSkillManifest>;
+      const manifest = validateManifest(raw, entry.name);
+      assertTrashEntry(entryPath, manifest);
+      if (Date.parse(manifest.expiresAt) <= now.getTime()) {
+        fs.rmSync(entryPath, { recursive: true, force: false });
+      }
+    } catch {
+      // Preserve incomplete or invalid evidence for manual recovery.
+    }
+  }
+}
+
+function assertTrashEntry(entryPath: string, expected: TrashedSkillManifest): void {
+  const actual = listFiles(path.join(requireSafeDirectory(entryPath, 'Skill trash entry'), 'package'));
+  if (!filesEqual(expected.files, actual)) {
+    throw new Error('Deleted Skill backup no longer matches its manifest.');
+  }
+}
+
+function validateManifest(
+  value: Partial<TrashedSkillManifest>,
+  directoryName: string,
+): TrashedSkillManifest {
+  if (
+    value.schema !== TRASH_SCHEMA
+    || value.backupId !== directoryName
+    || !isScopedId(value.botId)
+    || !isScopedId(value.localSkillId)
+    || !isScopedId(value.deletedByOwnerUid)
+    || typeof value.name !== 'string'
+    || normalizeInstallName(value.installName) !== value.installName
+    || !validIsoDate(value.deletedAt)
+    || !validIsoDate(value.expiresAt)
+    || !Array.isArray(value.files)
+  ) {
+    throw new Error('Deleted Skill backup manifest is invalid.');
+  }
+  return value as TrashedSkillManifest;
+}
+
+function ensureTrashBotRoot(runtimeRoot: string, botId: string): string {
+  let current = runtimeRoot;
+  for (const segment of ['data', 'bot-skills', 'trash', botId]) {
+    const child = path.join(current, segment);
+    if (!fs.existsSync(child)) {
+      try {
+        fs.mkdirSync(child, { recursive: false });
+      } catch (error: any) {
+        // Another Runtime process may have created the same safe scope first.
+        if (error?.code !== 'EEXIST') throw error;
+      }
+    }
+    current = requireSafeDirectory(child, 'Skill trash directory');
+  }
+  return current;
+}
+
+function listFiles(root: string): TrashedSkillFile[] {
+  const safeRoot = requireSafeDirectory(root, 'Skill backup source');
+  const files: TrashedSkillFile[] = [];
+  const visit = (directory: string): void => {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const absolute = path.join(directory, entry.name);
+      const relative = path.relative(safeRoot, absolute).split(path.sep).join('/');
+      const stat = fs.lstatSync(absolute);
+      if (stat.isSymbolicLink()) {
+        throw new Error(`Skill backup cannot follow a symbolic link: ${relative}`);
+      }
+      if (stat.isDirectory()) visit(absolute);
+      else if (stat.isFile()) files.push(fileRecord(safeRoot, relative));
+      else throw new Error(`Skill backup found an unsupported filesystem entry: ${relative}`);
+    }
+  };
+  visit(safeRoot);
+  return files.sort((left, right) => compareText(left.path, right.path));
+}
+
+function fileRecord(root: string, relative: string): TrashedSkillFile {
+  const bytes = fs.readFileSync(path.join(root, ...relative.split('/')));
+  return {
+    path: relative,
+    size: bytes.length,
+    sha256: crypto.createHash('sha256').update(bytes).digest('hex'),
+  };
+}
+
+function requireSafeDirectory(value: string, label: string): string {
+  const resolved = path.resolve(value);
+  if (!fs.existsSync(resolved)) throw new Error(`${label} does not exist: ${resolved}`);
+  const stat = fs.lstatSync(resolved);
+  if (stat.isSymbolicLink() || !stat.isDirectory()) {
+    throw new Error(`${label} is not a safe directory: ${resolved}`);
+  }
+  return resolved;
+}
+
+function normalizeScopedId(value: unknown, label: string): string {
+  const normalized = String(value || '').trim();
+  if (!isScopedId(normalized)) throw new Error(`Invalid ${label} for Skill trash.`);
+  return normalized;
+}
+
+function isScopedId(value: unknown): boolean {
+  const normalized = String(value || '');
+  return /^[A-Za-z0-9_.:-]{1,200}$/.test(normalized)
+    && normalized !== '.'
+    && normalized !== '..';
+}
+
+function normalizeInstallName(value: unknown): string {
+  const normalized = String(value || '').replace(/\\/g, '/').trim();
+  if (!normalized || normalized.startsWith('/') || normalized.includes('..')) {
+    throw new Error('Invalid install name for Skill trash.');
+  }
+  return normalized;
+}
+
+function validIsoDate(value: unknown): boolean {
+  const text = String(value || '');
+  try {
+    return Boolean(text && new Date(text).toISOString() === text);
+  } catch {
+    return false;
+  }
+}
+
+function filesEqual(expected: TrashedSkillFile[], actual: TrashedSkillFile[]): boolean {
+  return expected.length === actual.length && expected.every((file, index) => (
+    file.path === actual[index]?.path
+    && file.size === actual[index]?.size
+    && file.sha256 === actual[index]?.sha256
+  ));
+}
+
+function compareText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -181,14 +181,14 @@ export const CATSCOMPANY_SERVER_RUNTIME_DEVICE_CAPABILITIES: DeviceGrantOperatio
   'edit_file',
   'send_file',
   'execute_shell',
-];
-
-export const CATSCOMPANY_DESKTOP_RUNTIME_DEVICE_CAPABILITIES: DeviceGrantOperation[] = [
-  ...CATSCOMPANY_SERVER_RUNTIME_DEVICE_CAPABILITIES,
   SKILLHUB_THIN_RPC_TOOLS.workspace,
   SKILLHUB_THIN_RPC_TOOLS.share,
   SKILLHUB_THIN_RPC_TOOLS.finalize,
   SKILLHUB_THIN_RPC_TOOLS.delete,
+];
+
+export const CATSCOMPANY_DESKTOP_RUNTIME_DEVICE_CAPABILITIES: DeviceGrantOperation[] = [
+  ...CATSCOMPANY_SERVER_RUNTIME_DEVICE_CAPABILITIES,
   SKILLHUB_THIN_RPC_TOOLS.switchBot,
 ];
 
@@ -510,7 +510,7 @@ export class CatsCompanyBot {
     this.deviceRegistration = deviceRegistration;
     this.skillHubThinRpc = new SkillHubThinRpcHandler({
       isShuttingDown: () => this.shuttingDown,
-      enabled: runtimeRole === 'desktop',
+      allowBotSwitch: runtimeRole === 'desktop',
     });
 
     const runtime = createCatsCompanyRuntime(config.sessionTTL);

--- a/src/catscompany/skillhub-rpc.ts
+++ b/src/catscompany/skillhub-rpc.ts
@@ -11,6 +11,7 @@ import {
 import {
   scanBotSkillWorkspace,
 } from '../bot-skills/local-manifest';
+import { trashBotSkill } from '../bot-skills/deleted-skill-trash';
 import { readSkillHubLocalMetadata } from '../skillhub/local-skill-metadata';
 import {
   shareLocalSkillForCatsCo,
@@ -56,6 +57,8 @@ export interface SkillHubThinRpcHandlerOptions {
   finalizeCurrentBotSkill?: typeof finalizeCurrentBotPublicSkillNow;
   isShuttingDown?: () => boolean;
   enabled?: boolean;
+  allowBotSwitch?: boolean;
+  now?: () => Date;
 }
 
 export class SkillHubThinRpcHandler {
@@ -64,6 +67,8 @@ export class SkillHubThinRpcHandler {
   private readonly finalizeCurrentBotSkill: typeof finalizeCurrentBotPublicSkillNow;
   private readonly isShuttingDown: () => boolean;
   private readonly enabled: boolean;
+  private readonly allowBotSwitch: boolean;
+  private readonly now: () => Date;
   private readonly completed = new Map<string, {
     fingerprint: string;
     operation: Promise<Record<string, unknown>>;
@@ -77,10 +82,14 @@ export class SkillHubThinRpcHandler {
     this.finalizeCurrentBotSkill = options.finalizeCurrentBotSkill
       ?? finalizeCurrentBotPublicSkillNow;
     this.enabled = options.enabled !== false;
+    this.allowBotSwitch = options.allowBotSwitch !== false;
+    this.now = options.now ?? (() => new Date());
   }
 
   supports(toolName: string): boolean {
-    return this.enabled && Object.values(SKILLHUB_THIN_RPC_TOOLS).includes(toolName as any);
+    return this.enabled
+      && Object.values(SKILLHUB_THIN_RPC_TOOLS).includes(toolName as any)
+      && (toolName !== SKILLHUB_THIN_RPC_TOOLS.switchBot || this.allowBotSwitch);
   }
 
   async execute(request: CatsThinToolRpcMessage): Promise<Record<string, unknown>> {
@@ -123,6 +132,9 @@ export class SkillHubThinRpcHandler {
 
   private async executeOnce(request: CatsThinToolRpcMessage): Promise<Record<string, unknown>> {
     this.assertOperational(request);
+    if (!this.supports(String(request.tool_name || ''))) {
+      throw new SkillHubThinRpcError('TOOL_NOT_FOUND', 'Unsupported SkillHub device operation.');
+    }
     const payload = recordValue(request.payload);
     const botUid = requiredText(payload.bot_uid, 'bot_uid', 160);
     if (!BOT_UID_PATTERN.test(botUid)) {
@@ -375,7 +387,7 @@ export class SkillHubThinRpcHandler {
     const localSkillId = requiredText(payload.local_skill_id, 'local_skill_id', MAX_NAME_LENGTH);
     const removed = await withCurrentBotSkillWorkspaceWrite((context) => {
       this.assertOperational(request);
-      this.assertRequestScope(request, botUid, true);
+      const scope = this.assertRequestScope(request, botUid, true);
       this.assertActiveWorkspace(botUid, context.botId, context.activeBotId);
 
       const rejected: SkillHubWorkspaceValidationFailure[] = [];
@@ -431,11 +443,21 @@ export class SkillHubThinRpcHandler {
         );
       }
 
-      fs.rmSync(realEntry, { recursive: true, force: false });
+      const backup = trashBotSkill({
+        runtimeRoot: this.runtimeRoot,
+        botId: botUid,
+        sourcePath: realEntry,
+        localSkillId,
+        name: entry.name,
+        installName: entry.installName,
+        deletedByOwnerUid: scope.ownerUid,
+        now: this.now,
+      });
       return {
         localSkillId,
         name: entry.name,
         relativePath: entry.installName,
+        ...backup,
       };
     }, { runtimeRoot: this.runtimeRoot });
 
@@ -446,6 +468,9 @@ export class SkillHubThinRpcHandler {
       name: removed.name,
       relative_path: removed.relativePath,
       deleted: true,
+      backup_id: removed.backupId,
+      deleted_at: removed.deletedAt,
+      backup_expires_at: removed.expiresAt,
     };
   }
 

--- a/tests/catscompany-runtime-device-capabilities.test.ts
+++ b/tests/catscompany-runtime-device-capabilities.test.ts
@@ -29,7 +29,7 @@ describe('CatsCompany runtime device capabilities', () => {
     );
   });
 
-  test('server runtime never advertises desktop SkillHub workspace capabilities', () => {
+  test('server runtime advertises its own SkillHub workspace but cannot switch Bots', () => {
     assert.deepEqual(CATSCOMPANY_SERVER_RUNTIME_DEVICE_CAPABILITIES, [
       'read_file',
       'resolve_common_directory',
@@ -39,9 +39,13 @@ describe('CatsCompany runtime device capabilities', () => {
       'edit_file',
       'send_file',
       'execute_shell',
+      'skillhub.localWorkspace.get',
+      'skillhub.localSkill.share',
+      'skillhub.localSkill.finalize',
+      'skillhub.localSkill.delete',
     ]);
     assert.equal(
-      capabilitiesForCatsCompanyRuntimeRole('server').some(capability => capability.startsWith('skillhub.')),
+      capabilitiesForCatsCompanyRuntimeRole('server').includes('skillhub.localBot.switch'),
       false,
     );
   });

--- a/tests/catscompany-skillhub-rpc.test.ts
+++ b/tests/catscompany-skillhub-rpc.test.ts
@@ -61,6 +61,7 @@ describe('CatsCompany SkillHub thin RPC', () => {
     handler = new SkillHubThinRpcHandler({
       runtimeRoot,
       scheduleBotSwitch: (botUid) => scheduledBotUIDs.push(botUid),
+      now: () => new Date('2026-08-24T00:00:00.000Z'),
     });
   });
 
@@ -73,6 +74,27 @@ describe('CatsCompany SkillHub thin RPC', () => {
     for (const toolName of Object.values(SKILLHUB_THIN_RPC_TOOLS)) {
       assert.equal(serverHandler.supports(toolName), false);
     }
+  });
+
+  test('server runtime supports workspace operations but never Bot switching', async () => {
+    const serverHandler = new SkillHubThinRpcHandler({
+      runtimeRoot,
+      allowBotSwitch: false,
+    });
+    assert.equal(serverHandler.supports(SKILLHUB_THIN_RPC_TOOLS.workspace), true);
+    assert.equal(serverHandler.supports(SKILLHUB_THIN_RPC_TOOLS.delete), true);
+    assert.equal(serverHandler.supports(SKILLHUB_THIN_RPC_TOOLS.switchBot), false);
+    await assert.rejects(
+      serverHandler.execute(request({
+        request_id: 'server-switch-denied',
+        tool_name: SKILLHUB_THIN_RPC_TOOLS.switchBot,
+        payload: { bot_uid: '44' },
+      })),
+      (error: unknown) => (
+        error instanceof SkillHubThinRpcError
+        && error.code === 'TOOL_NOT_FOUND'
+      ),
+    );
   });
 
   test('returns only bounded metadata for the active Bot workspace', async () => {
@@ -119,8 +141,74 @@ describe('CatsCompany SkillHub thin RPC', () => {
     assert.equal(result.schema, 'xiaoba.skillhub.local_delete.v1');
     assert.equal(result.deleted, true);
     assert.equal(result.local_skill_id, selected.localSkillId);
+    assert.equal(result.deleted_at, '2026-08-24T00:00:00.000Z');
+    assert.equal(result.backup_expires_at, '2026-09-23T00:00:00.000Z');
     assert.equal(fs.existsSync(selected.path), false);
     assert.equal(fs.existsSync(sibling.path), true);
+    const backupRoot = path.join(
+      runtimeRoot,
+      'data',
+      'bot-skills',
+      'trash',
+      '42',
+      String(result.backup_id),
+    );
+    assert.equal(
+      fs.readFileSync(path.join(backupRoot, 'package', 'SKILL.md'), 'utf8').includes('# Local Demo'),
+      true,
+    );
+    const deletion = JSON.parse(fs.readFileSync(path.join(backupRoot, 'deletion.json'), 'utf8'));
+    assert.equal(deletion.deletedByOwnerUid, '7');
+    assert.equal(deletion.localSkillId, selected.localSkillId);
+  });
+
+  test('removes only verified expired trash while keeping the active Skill delete recoverable', async () => {
+    const first = scanBotSkillWorkspace(path.join(runtimeRoot, 'skills'))[0];
+    const firstResult = await handler.execute(request({
+      request_id: 'delete-retention-first',
+      tool_name: SKILLHUB_THIN_RPC_TOOLS.delete,
+      payload: { bot_uid: '42', local_skill_id: first.localSkillId },
+    }));
+    const firstBackup = path.join(
+      runtimeRoot,
+      'data',
+      'bot-skills',
+      'trash',
+      '42',
+      String(firstResult.backup_id),
+    );
+    assert.equal(fs.existsSync(firstBackup), true);
+
+    const secondRoot = path.join(runtimeRoot, 'skills', 'second-delete');
+    fs.mkdirSync(secondRoot, { recursive: true });
+    fs.writeFileSync(path.join(secondRoot, 'SKILL.md'), [
+      '---',
+      'name: second-delete',
+      'description: Second recoverable delete',
+      '---',
+      '',
+    ].join('\n'));
+    const second = scanBotSkillWorkspace(path.join(runtimeRoot, 'skills'))[0];
+    const laterHandler = new SkillHubThinRpcHandler({
+      runtimeRoot,
+      now: () => new Date('2026-09-24T00:00:00.000Z'),
+    });
+    const secondResult = await laterHandler.execute(request({
+      request_id: 'delete-retention-second',
+      tool_name: SKILLHUB_THIN_RPC_TOOLS.delete,
+      payload: { bot_uid: '42', local_skill_id: second.localSkillId },
+    }));
+
+    assert.equal(fs.existsSync(firstBackup), false);
+    assert.equal(fs.existsSync(path.join(
+      runtimeRoot,
+      'data',
+      'bot-skills',
+      'trash',
+      '42',
+      String(secondResult.backup_id),
+    )), true);
+    assert.equal(fs.existsSync(secondRoot), false);
   });
 
   test('deletes an invalid local Skill by its existing marker identity', async () => {

--- a/tests/catscompany-skillhub-rpc.test.ts
+++ b/tests/catscompany-skillhub-rpc.test.ts
@@ -23,6 +23,7 @@ import {
   readSkillHubLocalMetadata,
 } from '../src/skillhub/local-skill-metadata';
 import { SkillHubService } from '../src/skillhub/service';
+import { trashBotSkill } from '../src/bot-skills/deleted-skill-trash';
 
 describe('CatsCompany SkillHub thin RPC', () => {
   let runtimeRoot = '';
@@ -209,6 +210,35 @@ describe('CatsCompany SkillHub thin RPC', () => {
       String(secondResult.backup_id),
     )), true);
     assert.equal(fs.existsSync(secondRoot), false);
+  });
+
+  test('restores the active Skill when a file appears after the deletion snapshot', () => {
+    const sourcePath = path.join(runtimeRoot, 'skills', 'concurrent-delete');
+    fs.mkdirSync(sourcePath, { recursive: true });
+    fs.writeFileSync(path.join(sourcePath, 'SKILL.md'), [
+      '---',
+      'name: concurrent-delete',
+      'description: Concurrent deletion regression',
+      '---',
+      '',
+    ].join('\n'));
+
+    assert.throws(() => trashBotSkill({
+      runtimeRoot,
+      botId: '42',
+      sourcePath,
+      localSkillId: 'concurrent-delete-id',
+      name: 'concurrent-delete',
+      installName: 'concurrent-delete',
+      deletedByOwnerUid: '7',
+      now: () => new Date('2026-08-24T00:00:00.000Z'),
+      beforeMove: () => {
+        fs.writeFileSync(path.join(sourcePath, 'created-during-delete.txt'), 'preserve me');
+      },
+    }), /changed while deletion was being prepared/i);
+
+    assert.equal(fs.existsSync(path.join(sourcePath, 'SKILL.md')), true);
+    assert.equal(fs.readFileSync(path.join(sourcePath, 'created-during-delete.txt'), 'utf8'), 'preserve me');
   });
 
   test('deletes an invalid local Skill by its existing marker identity', async () => {


### PR DESCRIPTION
## 目标

让运行在服务器上的 XiaoBa 为 WebApp SkillHub 提供当前 Bot 的真实工作区，并把删除改成可恢复操作。

## 主要变更

- 服务器 Runtime 声明工作区读取、分享、发布和删除 capability
- 服务器 Runtime 明确不声明、也不执行 SkillHub Bot 切换
- 删除 Skill 前先复制全部文件、逐文件校验哈希并写入删除清单
- 只有备份验证成功后才删除正式工作区目录
- 备份按 Bot 隔离，保留 30 天；后续删除时只清理已校验且过期的备份
- 删除响应返回 backup ID、删除时间和备份到期时间，供 WebApp 给出明确反馈

## 安全与兼容边界

- 仍校验本地 CatsCo Owner、目标设备、活动 Bot 和活动工作区
- 不修改 write_file、edit_file、read_file、send_file、import_file、execute_shell 或其他工具权限
- 不修改 Skill 注入、System Prompt、BotDefinition 激活和 Runtime 包下载逻辑
- 桌面 XiaoBa 原有 SkillHub 流程保持可用，并获得同样的带备份删除能力
- 对应 CatsCo PR：https://github.com/buildsense-ai/cats-company/pull/300

## 验证

- npm run build
- npm run test:skillhub-phase1：239 passed，1 个 Windows symlink 环境跳过
- CatsCompany SkillHub RPC 定向测试：35 passed
- 阶段回归继续覆盖正式 Skill 的读取、写入、编辑、搜索、导出、导入和 Shell 权限

## 发布顺序

先合并并部署 CatsCo PR #300，再合并本 PR。这样旧 WebApp 或旧 Runtime 任一侧存在时都只会安全降级。