### PR TITLE
fix(skillhub): keep runtime artifacts from blocking Bot Skill restore

### DIFF
--- a/src/bot-skills/local-manifest.ts
+++ b/src/bot-skills/local-manifest.ts
@@ -23,6 +23,13 @@ export class BotSkillPackageValidationError extends Error {
 
 const BOT_SKILL_LOCAL_MARKER_SCHEMA = 'xiaoba.bot-skill-local.v1';
 const SKIP_DIRECTORIES = new Set(['.git', 'node_modules']);
+const EPHEMERAL_DIRECTORIES = new Set([
+  '.cache',
+  '.mypy_cache',
+  '.pytest_cache',
+  '.ruff_cache',
+  '__pycache__',
+]);
 const SKIP_FILES = new Set([
   BOT_SKILL_LOCAL_MARKER_FILE,
   '.xiaoba-skillhub-install.json',
@@ -90,7 +97,13 @@ export function scanBotSkillWorkspace(
   const localSkillIds = new Set<string>();
   const visit = (current: string): void => {
     for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
-      if (!entry.isDirectory() || entry.isSymbolicLink() || entry.name.startsWith('.')) continue;
+      if (
+        !entry.isDirectory()
+        || entry.isSymbolicLink()
+        || entry.name.startsWith('.')
+        || SKIP_DIRECTORIES.has(entry.name)
+        || isEphemeralSkillDirectory(entry.name)
+      ) continue;
       const skillDir = path.join(current, entry.name);
       assertRealPathContained(realRoot, skillDir);
       if (fs.existsSync(path.join(skillDir, 'SKILL.md'))) {
@@ -115,7 +128,7 @@ export function scanBotSkillWorkspace(
             path: skillDir,
             error,
           });
-          if (!SKIP_DIRECTORIES.has(entry.name)) visit(skillDir);
+          visit(skillDir);
           continue;
         }
         if (localSkillIds.has(manifestEntry.localSkillId)) {
@@ -124,7 +137,7 @@ export function scanBotSkillWorkspace(
         localSkillIds.add(manifestEntry.localSkillId);
         entries.push(manifestEntry);
       }
-      if (!SKIP_DIRECTORIES.has(entry.name)) visit(skillDir);
+      visit(skillDir);
     }
   };
   visit(root);
@@ -266,6 +279,7 @@ export function collectBotSkillPackageFiles(root: string): BotSkillPackageFile[]
       if (entry.isDirectory()) {
         if (
           !SKIP_DIRECTORIES.has(entry.name)
+          && !isEphemeralSkillDirectory(entry.name)
           && !fs.existsSync(path.join(fullPath, 'SKILL.md'))
         ) {
           visit(fullPath);
@@ -298,6 +312,15 @@ export function collectBotSkillPackageFiles(root: string): BotSkillPackageFile[]
   };
   visit(root);
   return files.sort((left, right) => compareText(left.path, right.path));
+}
+
+/**
+ * Runtime caches belong to the live Skill workspace, but not to the portable
+ * Skill package. They remain on disk for the running Skill and are excluded
+ * only from hashing, BotDefinition sync, and SkillHub publication.
+ */
+export function isEphemeralSkillDirectory(directoryName: string): boolean {
+  return EPHEMERAL_DIRECTORIES.has(directoryName);
 }
 
 function rejectSensitiveMaterial(filePath: string, bytes: Buffer): void {

--- a/src/bot-skills/private-package-client.ts
+++ b/src/bot-skills/private-package-client.ts
@@ -110,11 +110,16 @@ export class BotPrivateSkillClient {
       ? safeSkillDirectoryName(packageValue.name)
       : normalizePreferredInstallName(preferredInstallName);
     let target = safeJoin(skillsRoot, installName);
-    if (fs.existsSync(target) && !preferredInstallName) {
-      installName = `${installName.slice(0, 60)}-${packageValue.localSkillId.slice(-12)}`;
+    if (portableInstallPathOccupied(skillsRoot, installName)) {
+      const fallbackName = safeSkillDirectoryName(packageValue.name);
+      const suffix = crypto.createHash('sha256')
+        .update(packageValue.localSkillId, 'utf8')
+        .digest('hex')
+        .slice(0, 12);
+      installName = `${fallbackName.slice(0, 60)}-${suffix}`;
       target = safeJoin(skillsRoot, installName);
     }
-    if (fs.existsSync(target)) {
+    if (portableInstallPathOccupied(skillsRoot, installName)) {
       throw new Error(`Duplicate Skill install directory in cloud workspace: ${installName}`);
     }
     fs.mkdirSync(target, { recursive: true });
@@ -332,6 +337,22 @@ function safeJoin(root: string, relative: string): string {
     throw new Error(`Skill package path escaped its target: ${relative}`);
   }
   return target;
+}
+
+function portableInstallPathOccupied(root: string, relative: string): boolean {
+  let current = path.resolve(root);
+  const segments = relative.replace(/\\/g, '/').normalize('NFC').split('/');
+  for (let index = 0; index < segments.length; index += 1) {
+    if (!fs.existsSync(current) || !fs.lstatSync(current).isDirectory()) return false;
+    const key = segments[index].normalize('NFC').toLowerCase();
+    const match = fs.readdirSync(current, { withFileTypes: true }).find(entry => (
+      entry.name.normalize('NFC').toLowerCase() === key
+    ));
+    if (!match) return false;
+    if (index < segments.length - 1 && !match.isDirectory()) return true;
+    current = path.join(current, match.name);
+  }
+  return true;
 }
 
 function sha256(value: Buffer): string {

--- a/src/skillhub/local-skill-metadata.ts
+++ b/src/skillhub/local-skill-metadata.ts
@@ -2,6 +2,7 @@ import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
 import matter from 'gray-matter';
+import { isEphemeralSkillDirectory } from '../bot-skills/local-manifest';
 
 export interface SkillHubLocalMetadata {
   author?: string;
@@ -95,7 +96,10 @@ function walkSkillFiles(root: string): string[] {
       if (entry.isSymbolicLink()) continue;
       const fullPath = path.join(current, entry.name);
       if (entry.isDirectory()) {
-        if (!SOURCE_SKIP_DIRS.has(entry.name)) visit(fullPath);
+        if (
+          !SOURCE_SKIP_DIRS.has(entry.name)
+          && !isEphemeralSkillDirectory(entry.name)
+        ) visit(fullPath);
       } else if (entry.isFile() && !GENERATED_PACKAGE_FILES.has(entry.name)) {
         result.push(fullPath);
       }

--- a/src/skillhub/service.ts
+++ b/src/skillhub/service.ts
@@ -4,6 +4,7 @@ import { createCatsCoLocalConfigService } from '../catscompany/local-config';
 import {
   BotSkillPackageValidationError,
   collectBotSkillPackageFiles,
+  isEphemeralSkillDirectory,
 } from '../bot-skills/local-manifest';
 import { SkillParser } from '../skills/skill-parser';
 import type { Skill } from '../types/skill';
@@ -470,6 +471,7 @@ function walk(dir: string): string[] {
       if (entry.isDirectory()) {
         if (
           !SOURCE_SKIP_DIRS.has(entry.name)
+          && !isEphemeralSkillDirectory(entry.name)
           && !fs.existsSync(path.join(fullPath, 'SKILL.md'))
         ) {
           visit(fullPath);

--- a/tests/bot-skills-security.test.ts
+++ b/tests/bot-skills-security.test.ts
@@ -5,7 +5,11 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { canonicalizeBotSkillRefs } from '../src/bot-skills/canonical';
-import { isPortablePackagePath, scanLocalBotSkill } from '../src/bot-skills/local-manifest';
+import {
+  isPortablePackagePath,
+  scanBotSkillWorkspace,
+  scanLocalBotSkill,
+} from '../src/bot-skills/local-manifest';
 import { BotPrivateSkillClient } from '../src/bot-skills/private-package-client';
 import type { BotSkillRef } from '../src/bot-definition/types';
 import type { BotSkillPackage } from '../src/bot-skills/types';
@@ -59,6 +63,34 @@ describe('Bot Skill sync security boundaries', () => {
       fs.writeFileSync(path.join(crowdedRoot, `file-${index}.txt`), '');
     }
     assert.throws(() => scanLocalBotSkill(crowdedRoot), /too many files/i);
+  });
+
+  test('excludes runtime cache directories without deleting or size-checking them', () => {
+    const skillRoot = createSkill(roots, 'runtime-cache');
+    const cachePaths = [
+      path.join(skillRoot, '.cache', 'quant_cache.db'),
+      path.join(skillRoot, '.mypy_cache', 'state.bin'),
+      path.join(skillRoot, '.ruff_cache', 'state.bin'),
+      path.join(skillRoot, '__pycache__', 'module.pyc'),
+      path.join(skillRoot, '.pytest_cache', 'state.bin'),
+    ];
+    for (const cachePath of cachePaths) {
+      fs.mkdirSync(path.dirname(cachePath), { recursive: true });
+      fs.writeFileSync(cachePath, Buffer.alloc(2 * 1024 * 1024 + 1));
+    }
+    fs.writeFileSync(
+      path.join(skillRoot, '__pycache__', 'SKILL.md'),
+      '---\nname: cached-copy\ndescription: must not become a workspace Skill\n---\n',
+    );
+
+    const first = scanLocalBotSkill(skillRoot);
+    assert.deepEqual(first.files.map(file => file.path), ['SKILL.md']);
+    assert.equal(cachePaths.every(cachePath => fs.existsSync(cachePath)), true);
+    assert.equal(scanBotSkillWorkspace(path.dirname(skillRoot)).length, 1);
+
+    fs.writeFileSync(cachePaths[0], Buffer.from('runtime cache changed'));
+    const second = scanLocalBotSkill(skillRoot);
+    assert.equal(second.contentHash, first.contentHash);
   });
 
   test('rejects unsafe reference segments and matches Go byte/control limits', async () => {
@@ -120,6 +152,76 @@ describe('Bot Skill sync security boundaries', () => {
     const installed = await client.materialize(packageValue('CON'), skillsRoot);
     assert.match(path.basename(installed), /^skill-[a-f0-9]{16}$/);
     assert.equal(fs.existsSync(path.join(installed, 'SKILL.md')), true);
+  });
+
+  test('uses a deterministic suffix when a preferred install directory is already occupied', async () => {
+    const skillsRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-skill-materialize-'));
+    roots.push(skillsRoot);
+    const client = createClient(async () => Response.json({}));
+    const firstPackage = packageValue('shared-name');
+    const secondPackage = {
+      ...packageValue('shared-name'),
+      reference: { skillId: 'private/shared-name-second', version: 'v1' },
+      localSkillId: 'local:shared-name-second',
+    };
+
+    const first = await client.materialize(firstPackage, skillsRoot, 'shared-name');
+    const second = await client.materialize(secondPackage, skillsRoot, 'shared-name');
+
+    assert.equal(first, path.join(skillsRoot, 'shared-name'));
+    const suffix = crypto.createHash('sha256')
+      .update(secondPackage.localSkillId, 'utf8')
+      .digest('hex')
+      .slice(0, 12);
+    assert.equal(second, path.join(skillsRoot, `shared-name-${suffix}`));
+    assert.equal(fs.existsSync(path.join(first, 'SKILL.md')), true);
+    assert.equal(fs.existsSync(path.join(second, 'SKILL.md')), true);
+  });
+
+  test('treats install directory names case-insensitively on every host platform', async () => {
+    const skillsRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-skill-materialize-'));
+    roots.push(skillsRoot);
+    const client = createClient(async () => Response.json({}));
+    const firstPackage = packageValue('Shared-Name');
+    const secondPackage = {
+      ...packageValue('shared-name'),
+      reference: { skillId: 'private/shared-name-second', version: 'v1' },
+      localSkillId: 'local-shared-name-second',
+    };
+
+    const first = await client.materialize(firstPackage, skillsRoot, 'Shared-Name');
+    const second = await client.materialize(secondPackage, skillsRoot, 'shared-name');
+
+    assert.equal(first, path.join(skillsRoot, 'Shared-Name'));
+    assert.notEqual(second, path.join(skillsRoot, 'shared-name'));
+    assert.equal(fs.existsSync(path.join(first, 'SKILL.md')), true);
+    assert.equal(fs.existsSync(path.join(second, 'SKILL.md')), true);
+  });
+
+  test('treats canonically equivalent install directory names as occupied on every host platform', async () => {
+    const skillsRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-skill-materialize-'));
+    roots.push(skillsRoot);
+    const client = createClient(async () => Response.json({}));
+    const composedName = 'caf\u00e9-skill';
+    const decomposedName = 'cafe\u0301-skill';
+    const firstPackage = {
+      ...packageValue(composedName),
+      reference: { skillId: 'private/cafe-skill-first', version: 'v1' },
+      localSkillId: 'local-cafe-skill-first',
+    };
+    const secondPackage = {
+      ...packageValue(decomposedName),
+      reference: { skillId: 'private/cafe-skill-second', version: 'v1' },
+      localSkillId: 'local-cafe-skill-second',
+    };
+
+    const first = await client.materialize(firstPackage, skillsRoot, composedName);
+    const second = await client.materialize(secondPackage, skillsRoot, decomposedName);
+
+    assert.equal(first, path.join(skillsRoot, composedName));
+    assert.notEqual(second, path.join(skillsRoot, decomposedName));
+    assert.equal(fs.existsSync(path.join(first, 'SKILL.md')), true);
+    assert.equal(fs.existsSync(path.join(second, 'SKILL.md')), true);
   });
 
   test('rejects a package whose verified hash differs from the Definition reference', async () => {

--- a/tests/bot-skills-sync.test.ts
+++ b/tests/bot-skills-sync.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, test } from 'node:test';
 import * as assert from 'node:assert';
+import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -101,6 +102,53 @@ describe('Bot Skill Local/Base/Cloud sync', () => {
     );
     assert.equal(readSkillHubInstallMarker(path.join(fixture.skillsRoot, 'cloud-b'))?.skillId, external.reference.skillId);
     assert.equal(new BotSkillBaseStore(fixture.runtimeRoot).read(fixture.botId)?.definitionRevision, 2);
+  });
+
+  test('restores all cloud Skills when a legacy preferred directory collides with a newer package', async () => {
+    const fixture = createFixture(roots);
+    writeSkill(fixture.skillsRoot, 'shared-name', 'shared-name', 'legacy private package');
+    await fixture.sync();
+
+    const privateReference = fixture.cloud.skills[0];
+    const privatePackage = fixture.packages.get(refKey(privateReference));
+    assert.ok(privatePackage);
+    const publicPackage = createPackage(
+      roots,
+      'published-copy',
+      'shared-name',
+      'new public package',
+    );
+    publicPackage.source = 'public';
+    publicPackage.reference = { skillId: 'alice/shared-name', version: '1.0.0' };
+    fixture.packages.set(refKey(publicPackage.reference), publicPackage);
+    fixture.cloud = {
+      revision: fixture.cloud.revision + 1,
+      skills: [definitionRef(publicPackage), privateReference],
+    };
+
+    const restored = await fixture.sync();
+
+    assert.equal(restored.direction, 'cloud_to_local');
+    assert.equal(scanBotSkillWorkspace(fixture.skillsRoot).length, 2);
+    assert.match(
+      fs.readFileSync(path.join(fixture.skillsRoot, 'shared-name', 'SKILL.md'), 'utf8'),
+      /new public package/,
+    );
+    const privateFallback = `shared-name-${crypto.createHash('sha256')
+      .update(privatePackage.localSkillId, 'utf8')
+      .digest('hex')
+      .slice(0, 12)}`;
+    assert.match(
+      fs.readFileSync(path.join(fixture.skillsRoot, privateFallback, 'SKILL.md'), 'utf8'),
+      /legacy private package/,
+    );
+    assert.deepEqual(
+      new BotSkillBaseStore(fixture.runtimeRoot).read(fixture.botId)?.skills
+        .map(entry => entry.reference.skillId)
+        .sort(),
+      fixture.cloud.skills.map(entry => entry.skillId).sort(),
+    );
+    assert.equal((await fixture.sync()).direction, 'none');
   });
 
   test('keeps a public reference after replacing the private sync copy of a local Skill', async () => {

--- a/tests/dashboard-settings-api.test.ts
+++ b/tests/dashboard-settings-api.test.ts
@@ -1286,11 +1286,11 @@ describe('dashboard typed settings API', () => {
       assert.equal(parsed.GAUZ_LLM_API_KEY, 'sk-bf-openai-compatible');
       assert.equal(parsed.CATSCO_RELAY_LLM_CONTEXT_WINDOW_TOKENS, '1000000');
       assert.equal(parsed.CATSCO_RELAY_LLM_REASONING_EFFORT, 'max');
-      assert.equal(parsed.CATSCO_RELAY_LLM_VISION_CAPABLE, 'false');
+      assert.equal(parsed.CATSCO_RELAY_LLM_VISION_CAPABLE, 'true');
       assert.equal(parsed.CATSCO_RELAY_LLM_TOOL_CALLING_CAPABLE, 'true');
       assert.equal(data.selectedModel.context_window_tokens, 1000000);
       assert.equal(data.selectedModel.context_label, '1M');
-      assert.equal(data.selectedModel.capabilities.vision, false);
+      assert.equal(data.selectedModel.capabilities.vision, true);
       assert.equal(data.selectedModel.capabilities.tool_calling, true);
       assert.equal(text.includes('sk-bf-openai-compatible'), false);
     } finally {

--- a/tests/model-capabilities.test.ts
+++ b/tests/model-capabilities.test.ts
@@ -61,7 +61,7 @@ describe('model capabilities', () => {
       [
         { model: 'MiniMax-M2.7', provider: 'anthropic', vision: false, context: 204_800 },
         { model: 'MiniMax-M3', provider: 'anthropic', vision: true, context: 1_000_000 },
-        { model: 'deepseek-v4-flash', provider: 'anthropic', vision: false, context: 1_000_000 },
+        { model: 'deepseek-v4-flash', provider: 'anthropic', vision: true, context: 1_000_000 },
         { model: 'gpt-5.6-terra', provider: 'openai', vision: true, context: 256_000 },
         { model: 'gpt-5.6-sol', provider: 'openai', vision: true, context: 256_000 },
         { model: 'gpt-5.6-luna', provider: 'openai', vision: true, context: 256_000 },

--- a/tests/skillhub-local-metadata.test.ts
+++ b/tests/skillhub-local-metadata.test.ts
@@ -89,4 +89,33 @@ describe('SkillHub local metadata', () => {
       fs.rmSync(root, { recursive: true, force: true });
     }
   });
+
+  test('keeps local publication state stable when runtime caches change', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-skillhub-cache-hash-'));
+    try {
+      const skillDir = path.join(root, 'demo');
+      fs.mkdirSync(skillDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(skillDir, 'SKILL.md'),
+        '---\nname: demo\ndescription: Runtime cache hash test\n---\n',
+      );
+      const before = computeLocalSkillContentHash(skillDir);
+      for (const directory of [
+        '.cache',
+        '.mypy_cache',
+        '.pytest_cache',
+        '.ruff_cache',
+        '__pycache__',
+      ]) {
+        const cacheFile = path.join(skillDir, directory, 'runtime.bin');
+        fs.mkdirSync(path.dirname(cacheFile), { recursive: true });
+        fs.writeFileSync(cacheFile, Buffer.alloc(2 * 1024 * 1024 + 1));
+      }
+
+      assert.equal(computeLocalSkillContentHash(skillDir), before);
+      assert.equal(fs.existsSync(path.join(skillDir, '.cache', 'runtime.bin')), true);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## 问题

生产运行体的 BotDefinition 已包含生图 Skill，但整个 Cloud → Runtime 工作区恢复被两个运行时细节阻断：

- Skill 运行产生的 `.cache/quant_cache.db` 超过单文件包上限，导致同步扫描失败。
- 历史私有引用与公开引用复用了同一安装目录名，导致原子恢复因目录碰撞整体失败；一个冲突会连带阻止其他 Skill 落地。

## 修改

- 将 `.cache`、`.mypy_cache`、`.pytest_cache`、`.ruff_cache`、`__pycache__` 视为运行时临时目录：保留在真实工作区供 Skill 使用，但不进入 BotDefinition 同步包、SkillHub 发布包或本地发布状态哈希。
- 工作区发现阶段同步忽略这些目录，避免缓存中的 `SKILL.md` 被识别成独立 Skill。
- Cloud 恢复遇到安装目录碰撞时，使用 `localSkillId` 的 SHA-256 短哈希生成稳定、Windows 安全的备用目录名。
- 在所有平台按大小写不敏感和 NFC 规范化检测目录占用，使 Linux 服务器与 Windows 客户端行为一致。
- 以独立 test-only commit 补齐当前 main 在启用 DeepSeek Relay 视觉能力后遗漏的两处断言，不改变模型运行逻辑。

## 安全与兼容边界

- 不删除任何运行时缓存文件，只从可移植版本内容和哈希中排除。
- 不改变现有 stage → 校验 → 原子切换/回滚流程。
- 不改变 `read_file`、`write_file`、`edit_file`、`send_file`、`import_file`、Shell 或受信任 Skill 脚本权限。
- 不改变注入、System Prompt 或 BotDefinition 写入权限。
- 本 PR 避免“一个同名冲突拖垮整个工作区”。如果两个包的 `SKILL.md name` 也完全相同，Runtime 的确定性优先级与历史引用清理仍需后续单独治理。

## 验证

- `npm run build`
- Skill 修复定向测试：72/72 通过
- DeepSeek Relay 断言定向测试：53/53 通过
- `npm run test:skillhub-phase1`：246 通过，1 项因当前 Windows 用户无法创建 symlink 而跳过
- 两位独立子代理复审通过：缓存排除一致性、跨平台路径安全和原子恢复未发现阻断问题

## 部署说明

本 PR 合并后仍需更新并重启目标服务器 XiaoBa 才会生效。本 PR 不直接修改生产服务器数据。