### PR TITLE
fix(connector): reset stale account bindings and improve launch UX

### DIFF
--- a/dashboard/connector.css
+++ b/dashboard/connector.css
@@ -543,8 +543,8 @@ h1 {
 .management-page[hidden] { display: none; }
 .management-page.active { display: flex; flex-direction: column; }
 .section-heading { flex: 0 0 auto; display: flex; align-items: center; justify-content: space-between; gap: 16px; }
-.section-heading strong, .recovery-row strong, .danger-zone strong { display: block; font-size: 15px; }
-.section-heading small, .recovery-row small, .danger-zone small { display: block; margin-top: 3px; color: var(--muted); font-size: 12px; line-height: 1.45; }
+.section-heading strong, .recovery-row strong { display: block; font-size: 15px; }
+.section-heading small, .recovery-row small { display: block; margin-top: 3px; color: var(--muted); font-size: 12px; line-height: 1.45; }
 
 .channel-list { margin-top: 13px; display: grid; gap: 10px; }
 .channel-card { padding: 14px 15px; border: 1px solid var(--line); border-radius: 9px; background: #fbfcfe; }
@@ -611,7 +611,6 @@ h1 {
 
 .recovery-list { display: grid; border-top: 1px solid var(--line); }
 .recovery-row { min-height: 68px; padding: 11px 0; display: flex; align-items: center; justify-content: space-between; gap: 18px; border-bottom: 1px solid var(--line); }
-.danger-zone { margin-top: 22px; padding: 14px; display: flex; align-items: center; justify-content: space-between; gap: 18px; border: 1px solid #efc7c3; border-radius: 9px; background: var(--red-soft); }
 
 .toast { position: fixed; right: 20px; bottom: 18px; max-width: 360px; padding: 11px 14px; border-radius: 8px; background: #1b2433; color: white; box-shadow: 0 8px 24px rgba(19, 29, 45, .2); font-size: 13px; }
 
@@ -650,7 +649,7 @@ h1 {
   }
   .primary-panel { overflow: auto; }
   .management-view { min-height: 430px; flex: 0 0 auto; }
-  .channel-main, .recovery-row, .danger-zone { align-items: flex-start; }
+  .channel-main, .recovery-row { align-items: flex-start; }
 }
 
 /* Connecting is transient, so it should read as a compact progress state and

--- a/dashboard/connector.html
+++ b/dashboard/connector.html
@@ -72,6 +72,7 @@
 
             <div class="hero-actions" id="hero-actions">
               <a class="button button-primary external-link" id="webapp-button" href="https://app.catsco.cc" target="_blank" rel="noopener noreferrer" hidden>打开 CatsCo WebApp</a>
+              <button class="button button-danger" id="logout-button" type="button" hidden>退出账号</button>
               <button class="button button-secondary" id="retry-button" type="button" hidden>重新连接</button>
             </div>
             <p class="close-hint" id="close-hint" hidden>可以直接关闭此窗口，Connector 会继续在后台运行。</p>
@@ -141,10 +142,6 @@
                     <div><strong>Turn Errors</strong><small>查看最近的回合错误和失败原因。</small></div>
                     <a class="button button-quiet" href="/turn-errors.html" target="_blank" rel="noopener">打开</a>
                   </article>
-                </div>
-                <div class="danger-zone">
-                  <div><strong>退出本机 CatsCo 账号</strong><small>退出后会停止这台电脑上的 Connector。</small></div>
-                  <button class="button button-danger" id="logout-button" type="button">退出账号</button>
                 </div>
               </section>
             </div>

--- a/dashboard/connector.js
+++ b/dashboard/connector.js
@@ -265,6 +265,7 @@
     $('progress-list').hidden = view.key !== 'connecting';
     $('error-card').hidden = view.key !== 'error';
     $('webapp-button').hidden = view.key !== 'ready';
+    $('logout-button').hidden = view.key === 'auth' || (!cats.connected && !cats.tokenPresent);
     $('retry-button').hidden = view.key !== 'error';
     $('close-hint').hidden = view.key !== 'ready';
 
@@ -326,12 +327,14 @@
   }
 
   function renderError(view) {
+    const title = view.title || '自动连接未完成';
+    const detail = humanError(view.error || '请重新连接，或打开本地管理查看日志。');
     setText('status-label', 'Connector 需要处理');
     setText('hero-title', '连接未完成');
     setText('hero-copy', '本地资料没有被删除。处理下面的问题后可以继续重试。');
-    setText('error-title', view.title || '自动连接未完成');
-    setText('error-copy', view.error || '请重新连接，或展开高级诊断查看日志。');
-    setNotice(view.title || 'Connector 连接异常', 'error');
+    setText('error-title', title);
+    setText('error-copy', detail);
+    setNotice(`${title}：${detail}`, 'error');
   }
 
   function markStep(name, status) {
@@ -1148,6 +1151,7 @@
     const message = String(error?.message || error || '未知错误');
     if (/password mismatch/i.test(message)) return '账号或密码错误，请重试。';
     if (/user not found/i.test(message)) return '没有找到这个 CatsCo 账号。';
+    if (/not your bot/i.test(message)) return '当前账号无权使用原 Agent（not your bot），请切换到当前账号拥有的 Agent。';
     if (/failed to fetch|network/i.test(message)) return '暂时无法连接 CatsCo，请检查网络。';
     return message;
   }

--- a/electron/main.js
+++ b/electron/main.js
@@ -38,8 +38,12 @@ if (!gotSingleInstanceLock) {
   app.quit();
 } else {
   app.on('second-instance', (_event, argv) => {
+    const hasDeepLink = (argv || []).some(isCatsCoDeepLink);
     enqueueDeepLinkFromArgv(argv);
-    showMainWindow();
+    if (hasDeepLink) showMainWindow();
+    else void handleDesktopLaunch().catch((error) => {
+      console.error('[Electron] Failed to handle desktop launch:', error);
+    });
   });
 }
 
@@ -145,6 +149,17 @@ async function shouldShowDashboardAtStartup() {
     // Fail open to the Dashboard if the local status check cannot complete.
     return true;
   }
+}
+
+async function handleDesktopLaunch() {
+  if (!dashboardServerReady || await shouldShowDashboardAtStartup()) {
+    showMainWindow();
+    return 'dashboard';
+  }
+  // Electron delegates HTTPS URLs to the operating system, so this opens the
+  // user's configured default browser rather than an embedded app window.
+  await shell.openExternal(CATSCO_WEBAPP_URL);
+  return 'webapp';
 }
 
 function isCatsCoDeepLink(value) {
@@ -953,7 +968,7 @@ app.whenReady().then(async () => {
     dashboardServerReady = true;
     createApplicationMenu();
     createTray();
-    if (await shouldShowDashboardAtStartup()) createWindow();
+    await handleDesktopLaunch();
     enqueueDeepLinkFromArgv(process.argv);
     scheduleDeepLinkDrain();
     

--- a/src/catscompany/client.ts
+++ b/src/catscompany/client.ts
@@ -210,6 +210,21 @@ function firstNonEmpty(...values: Array<string | undefined>): string {
   return '';
 }
 
+function oneLine(value: unknown, fallback = '-'): string {
+  const text = String(value || '').replace(/\s+/g, ' ').trim();
+  return text ? text.slice(0, 240) : fallback;
+}
+
+function classifyDisconnectCause(forcedCause: string, transportError: string, closeCode: number): string {
+  if (forcedCause) return forcedCause;
+  const httpStatus = transportError.match(/Unexpected server response:\s*(\d{3})/i)?.[1];
+  if (httpStatus) return `upgrade_http_${httpStatus}`;
+  const networkCode = transportError.match(/\b(ECONNRESET|ECONNREFUSED|ETIMEDOUT|ENOTFOUND|EAI_AGAIN|EPIPE)\b/i)?.[1];
+  if (networkCode) return networkCode.toLowerCase();
+  if (transportError) return 'transport_error';
+  return closeCode === 1000 ? 'normal_close' : 'abnormal_close';
+}
+
 export class CatsSendError extends Error {
   public readonly clientMsgID?: string;
   public readonly retryableWithHttp: boolean;
@@ -256,6 +271,11 @@ export class CatsClient extends EventEmitter {
   private readyTimer: NodeJS.Timeout | null = null;
   private reconnectTimer: NodeJS.Timeout | null = null;
   private reconnectAttempts = 0;
+  private connectionOpenedAt = 0;
+  private readyAt = 0;
+  private lastActivityAt = 0;
+  private disconnectCause = '';
+  private lastTransportError = '';
   private subscribedTopics = new Set<string>();
   private supportsClientMessageDedupe = false;
   public supportsThinToolRpc = false;
@@ -301,6 +321,11 @@ export class CatsClient extends EventEmitter {
     Logger.info(`[CatsCompany] 正在连接: ${this.config.serverUrl}, apiKey=${maskSecret(this.config.apiKey)}, bodyId=${bodyId}`);
     this.supportsClientMessageDedupe = false;
     this.supportsThinToolRpc = false;
+    this.connectionOpenedAt = 0;
+    this.readyAt = 0;
+    this.lastActivityAt = 0;
+    this.disconnectCause = '';
+    this.lastTransportError = '';
     this.ws = new WebSocket(this.config.serverUrl, {
       headers: {
         'X-API-Key': this.config.apiKey,
@@ -312,6 +337,8 @@ export class CatsClient extends EventEmitter {
     this.startConnectTimeout(bodyId);
 
     this.ws.on('open', () => {
+      this.connectionOpenedAt = Date.now();
+      this.lastActivityAt = this.connectionOpenedAt;
       this.clearConnectTimeout();
       this.awaitingReady = true;
       this.startReadyTimeout();
@@ -327,23 +354,43 @@ export class CatsClient extends EventEmitter {
     });
 
     this.ws.on('message', (data: Buffer) => {
+      this.lastActivityAt = Date.now();
       this.resetPongTimer();
       const msg = JSON.parse(data.toString());
       this.handleMessage(msg);
     });
 
     this.ws.on('pong', () => {
+      this.lastActivityAt = Date.now();
       this.resetPongTimer();
     });
 
-    this.ws.on('error', (err: Error) => this.emit('error', err));
+    this.ws.on('error', (err: Error) => {
+      const errorCode = String((err as any)?.code || (err as any)?.cause?.code || '').trim();
+      this.lastTransportError = oneLine(errorCode ? `${errorCode}: ${err.message}` : err.message);
+      this.emit('error', err);
+    });
     this.ws.on('close', (code: number, reason: Buffer) => {
-      Logger.warning(`[CatsCompany] WebSocket 已关闭: code=${code}, reason=${reason.toString() || '-'}`);
+      const closedAt = Date.now();
+      const connectedAt = this.readyAt || this.connectionOpenedAt;
+      const connectedForMs = connectedAt ? Math.max(0, closedAt - connectedAt) : 0;
+      const lastActivityAgoMs = this.lastActivityAt ? Math.max(0, closedAt - this.lastActivityAt) : 0;
+      const cause = classifyDisconnectCause(this.disconnectCause, this.lastTransportError, code);
+      Logger.warning(
+        `[CatsCompany] WebSocket 已关闭: code=${code}, reason=${oneLine(reason.toString())}, ` +
+        `cause=${cause}, connectedForMs=${connectedForMs}, lastActivityAgoMs=${lastActivityAgoMs}, ` +
+        `error=${oneLine(this.lastTransportError)}`,
+      );
       this.clearConnectTimeout();
       this.clearReadyTimeout();
       this.awaitingReady = false;
       this.stopHeartbeat();
       this.ws = null;
+      this.connectionOpenedAt = 0;
+      this.readyAt = 0;
+      this.lastActivityAt = 0;
+      this.disconnectCause = '';
+      this.lastTransportError = '';
       this.rejectPendingAcks(new CatsSendError(
         'timeout',
         'WebSocket 在收到 CatsCompany 服务器确认前关闭',
@@ -372,6 +419,8 @@ export class CatsClient extends EventEmitter {
         this.awaitingReady = false;
         this.clearReadyTimeout();
         this.reconnectAttempts = 0;
+        this.readyAt = Date.now();
+        this.lastActivityAt = this.readyAt;
         this.uid = String(msg.ctrl.params?.uid || 'bot');
         this.name = String(msg.ctrl.params?.name || 'CatsCo');
         Logger.info(
@@ -1089,6 +1138,7 @@ export class CatsClient extends EventEmitter {
     this.connectTimer = setTimeout(() => {
       if (this.ws?.readyState !== WebSocket.CONNECTING) return;
       Logger.warning(`[CatsCompany] WebSocket 连接握手超时 ${timeoutMs}ms，主动重建连接: bodyId=${bodyId}`);
+      this.disconnectCause = 'connect_timeout';
       this.ws.terminate();
     }, timeoutMs);
     (this.connectTimer as any).unref?.();
@@ -1106,6 +1156,7 @@ export class CatsClient extends EventEmitter {
     this.readyTimer = setTimeout(() => {
       if (!this.awaitingReady || this.ws?.readyState !== WebSocket.OPEN) return;
       Logger.warning(`[CatsCompany] CatsCompany 握手确认超时 ${timeoutMs}ms，主动重建 WebSocket 连接`);
+      this.disconnectCause = 'ready_timeout';
       this.ws.terminate();
     }, timeoutMs);
     (this.readyTimer as any).unref?.();
@@ -1135,6 +1186,7 @@ export class CatsClient extends EventEmitter {
     if (this.pongTimer) clearTimeout(this.pongTimer);
     this.pongTimer = setTimeout(() => {
       Logger.warning('[CatsCompany] 心跳超时，断开连接');
+      this.disconnectCause = 'heartbeat_timeout';
       this.ws?.terminate();
     }, 90000);
   }
@@ -1178,6 +1230,7 @@ export class CatsClient extends EventEmitter {
 
   disconnect(): void {
     this.closed = true;
+    this.disconnectCause = 'client_shutdown';
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;

--- a/src/catscompany/local-config.ts
+++ b/src/catscompany/local-config.ts
@@ -65,6 +65,12 @@ export const DEFAULT_CATSCO_HTTP_BASE_URL = 'https://app.catsco.cc';
 export const DEFAULT_CATSCO_WS_URL = 'wss://app.catsco.cc/v0/channels';
 
 const CONFIG_VERSION = 1;
+const BOT_BINDING_ENV_KEYS = [
+  'CATSCO_BOT_UID',
+  'CATSCO_API_KEY',
+  'CATSCOMPANY_BOT_UID',
+  'CATSCOMPANY_API_KEY',
+];
 
 function firstNonEmpty(...values: unknown[]): string | undefined {
   for (const value of values) {
@@ -320,6 +326,11 @@ export class CatsCoLocalConfigService {
     const displayName = String(login.display_name || login.username || state.displayName || username || '').trim();
     const token = String(login.token || state.token || '').trim();
     const config = this.load();
+    const bindingOwnerUid = firstNonEmpty(config.currentBot?.boundByUserUid, config.account?.uid);
+    const accountChanged = Boolean(uid && bindingOwnerUid && bindingOwnerUid !== uid);
+    const removedBindingKeys = accountChanged
+      ? removeEnvKeys(this.runtimeRoot, this.env, BOT_BINDING_ENV_KEYS)
+      : [];
     this.save({
       ...config,
       endpoints: {
@@ -333,9 +344,10 @@ export class CatsCoLocalConfigService {
         username,
         displayName,
       } : config.account,
+      currentBot: accountChanged ? undefined : config.currentBot,
     });
 
-    return writeEnvUpdates(this.runtimeRoot, this.env, {
+    const updatedAccountKeys = writeEnvUpdates(this.runtimeRoot, this.env, {
       CATSCO_HTTP_BASE_URL: state.httpBaseUrl,
       CATSCO_SERVER_URL: state.serverUrl,
       CATSCO_USER_TOKEN: token,
@@ -349,6 +361,7 @@ export class CatsCoLocalConfigService {
       CATSCOMPANY_USER_NAME: username,
       CATSCOMPANY_USER_DISPLAY_NAME: displayName,
     });
+    return Array.from(new Set([...removedBindingKeys, ...updatedAccountKeys]));
   }
 
   ensureDeviceId(): string {

--- a/src/dashboard/cats-connector-autostart.ts
+++ b/src/dashboard/cats-connector-autostart.ts
@@ -91,6 +91,15 @@ export class CatsConnectorAutoStart {
     options: { force?: boolean } = {},
   ): CatsConnectorBootstrapSnapshot {
     this.generation += 1;
+    if (trigger !== 'logout') {
+      this.setSnapshot({
+        stage: 'connecting',
+        trigger,
+        message: '正在应用新的账号或 Agent 并重新连接',
+        error: undefined,
+        startedAt: new Date().toISOString(),
+      });
+    }
     return this.schedule(trigger, delayMs, options);
   }
 

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -680,10 +680,13 @@ function sanitizeCatsUsernamePart(value: string): string {
 
 function isOwnedCatsBot(bot: any, userUid?: string): boolean {
   if (!bot || typeof bot !== 'object') return false;
-  if (bot.is_owner === false || String(bot.relation || '').toLowerCase() === 'friend') return false;
-  const ownerUid = String(bot.owner_id || bot.owner_uid || '').trim();
   const expectedOwnerUid = String(userUid || '').trim();
-  return !ownerUid || !expectedOwnerUid || ownerUid === expectedOwnerUid;
+  if (!expectedOwnerUid) return false;
+  const relation = String(bot.relation || '').trim().toLowerCase();
+  if (bot.is_owner === false || relation === 'friend') return false;
+  const ownerUid = String(bot.owner_id || bot.owner_uid || '').trim();
+  if (ownerUid && ownerUid !== expectedOwnerUid) return false;
+  return ownerUid === expectedOwnerUid || bot.is_owner === true || relation === 'owner';
 }
 
 function ensureCatsDeviceId(): string {

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -678,6 +678,14 @@ function sanitizeCatsUsernamePart(value: string): string {
   return value.toLowerCase().replace(/[^a-z0-9_]/g, '_').replace(/_+/g, '_').replace(/^_+|_+$/g, '');
 }
 
+function isOwnedCatsBot(bot: any, userUid?: string): boolean {
+  if (!bot || typeof bot !== 'object') return false;
+  if (bot.is_owner === false || String(bot.relation || '').toLowerCase() === 'friend') return false;
+  const ownerUid = String(bot.owner_id || bot.owner_uid || '').trim();
+  const expectedOwnerUid = String(userUid || '').trim();
+  return !ownerUid || !expectedOwnerUid || ownerUid === expectedOwnerUid;
+}
+
 function ensureCatsDeviceId(): string {
   return createCatsCoLocalConfigService({ runtimeRoot: runtimeDataRoot() }).ensureDeviceId();
 }
@@ -3405,6 +3413,13 @@ export function createApiRouter(
       config: ConfigManager.getConfigReadonly(),
     });
     const state = runtime.auth;
+    const localBot = runtime.localConfig.currentBot;
+    const visibleBot = Boolean(
+      state.uid
+      && state.botUid
+      && localBot?.uid === state.botUid
+      && localBot.boundByUserUid === state.uid,
+    ) ? localBot : null;
     const service = serviceManager.getService('catscompany');
     const tokenPresent = Boolean(state.token);
     let connected = false;
@@ -3483,10 +3498,10 @@ export function createApiRouter(
       authError,
       user,
       botUid: state.botUid || null,
-      bot: runtime.localConfig.currentBot ? {
-        uid: runtime.localConfig.currentBot.uid,
-        name: runtime.localConfig.currentBot.name || '',
-        username: runtime.localConfig.currentBot.username || '',
+      bot: visibleBot ? {
+        uid: visibleBot.uid,
+        name: visibleBot.name || '',
+        username: visibleBot.username || '',
       } : null,
       device: runtime.localConfig.device || null,
       bodyStatus,
@@ -3701,7 +3716,8 @@ export function createApiRouter(
       if (!userUid) return res.status(500).json({ error: 'CatsCo user uid missing' });
 
       const botsResponse = await catsRequest('GET', state.httpBaseUrl, '/api/bots', undefined, state.token);
-      const bots = Array.isArray(botsResponse?.bots) ? botsResponse.bots : [];
+      const bots = (Array.isArray(botsResponse?.bots) ? botsResponse.bots : [])
+        .filter((bot: any) => isOwnedCatsBot(bot, userUid));
       const deviceId = ensureCatsDeviceId();
       const deviceName = String(req.body?.deviceName || os.hostname() || 'current-device').trim();
       const preferredUsername = sanitizeCatsUsernamePart(String(req.body?.botUsername || `catsco_${userUid}_${deviceId}`))
@@ -3836,8 +3852,12 @@ export function createApiRouter(
       if (!state.token) return res.status(401).json({ error: 'CatsCo user token is missing' });
 
       const data = await catsRequest('GET', state.httpBaseUrl, '/api/bots', undefined, state.token);
-      const bots = Array.isArray(data?.bots) ? data.bots : [];
-      const currentBotUid = state.botUid || '';
+      const userUid = String(state.uid || '').trim();
+      const bots = (Array.isArray(data?.bots) ? data.bots : [])
+        .filter((bot: any) => isOwnedCatsBot(bot, userUid));
+      const currentBotUid = bots.some((bot: any) => String(bot.id || bot.uid || '') === String(state.botUid || ''))
+        ? state.botUid || ''
+        : '';
       const formattedBots = bots.map((bot: any) => ({
         uid: String(bot.id || bot.uid || ''),
         username: String(bot.username || ''),
@@ -3905,6 +3925,9 @@ export function createApiRouter(
       const bots = Array.isArray(data?.bots) ? data.bots : [];
       const targetBot = bots.find((bot: any) => String(bot.id || bot.uid || '') === botUid);
       if (!targetBot) return res.status(404).json({ error: 'Bot not found' });
+      if (!isOwnedCatsBot(targetBot, userUid)) {
+        return res.status(403).json({ error: '当前账号只能将自己拥有的 Agent 绑定到本机 Connector' });
+      }
 
       const apiKey = await getCatsBotApiKey(state, botUid, targetBot);
       const relayState: CatsAuthState = {
@@ -4011,6 +4034,9 @@ export function createApiRouter(
       const bots = Array.isArray(data?.bots) ? data.bots : [];
       const targetBot = bots.find((bot: any) => String(bot.id || bot.uid || '') === botUid);
       if (!targetBot) return res.status(404).json({ error: 'Bot not found' });
+      if (!isOwnedCatsBot(targetBot, userUid)) {
+        return res.status(403).json({ error: '当前账号只能切换到自己拥有的 Agent' });
+      }
 
       const previousWeixinStatus = getWeixinChannelStatus({
         runtimeRoot: runtimeDataRoot(),
@@ -4041,6 +4067,8 @@ export function createApiRouter(
           result.warnings.push(`Agent 已切换，但微信服务停止失败：${String(error?.message || error)}`);
         }
       }
+
+      options.catsConnectorAutoStart?.invalidateAndSchedule('switch-bot', 0, { force: true });
 
       res.json({
         ok: true,

--- a/tests/dashboard-catsco-auth-status.test.ts
+++ b/tests/dashboard-catsco-auth-status.test.ts
@@ -678,6 +678,11 @@ describe('dashboard CatsCo account status', () => {
               owner_id: 77,
             },
             {
+              uid: 198,
+              username: 'unknown-owner',
+              display_name: 'Unknown Owner',
+            },
+            {
               uid: 199,
               username: 'laomocun',
               display_name: '烙馍村村长',
@@ -695,7 +700,7 @@ describe('dashboard CatsCo account status', () => {
       'CATSCO_SERVER_URL=wss://app.catsco.cc/v0/channels',
       'CATSCO_USER_TOKEN=arrow-token',
       'CATSCO_USER_UID=88',
-      'CATSCO_BOT_UID=188',
+      'CATSCO_BOT_UID=198',
     ]);
 
     const response = await fetch(`${dashboardBaseUrl}/api/cats/bots`);
@@ -979,7 +984,7 @@ describe('dashboard CatsCo account status', () => {
     assert.equal(data.service.status, 'running');
   });
 
-  test('POST /cats/setup ignores a stale friend bot and reuses an Agent owned by the current account', async () => {
+  test('POST /cats/setup ignores stale friend and unknown-owner bots, then reuses an owned Agent', async () => {
     if (dashboardServer) {
       await close(dashboardServer);
       dashboardServer = undefined;
@@ -1022,6 +1027,12 @@ describe('dashboard CatsCo account status', () => {
             relation: 'friend',
             owner_id: 77,
           }, {
+            id: 198,
+            uid: 198,
+            username: 'unknown-owner-agent',
+            display_name: 'Unknown Owner Agent',
+            api_key: 'unknown-owner-agent-key',
+          }, {
             id: 199,
             uid: 199,
             username: 'existing-agent',
@@ -1053,8 +1064,8 @@ describe('dashboard CatsCo account status', () => {
       'CATSCO_USER_UID=88',
       'CATSCO_USER_NAME=fresh',
       'CATSCO_USER_DISPLAY_NAME=Fresh User',
-      'CATSCO_BOT_UID=188',
-      'CATSCO_API_KEY=old-friend-agent-key',
+      'CATSCO_BOT_UID=198',
+      'CATSCO_API_KEY=unknown-owner-agent-key',
       'GAUZ_LLM_PROVIDER=anthropic',
       'GAUZ_LLM_API_BASE=https://model.example.test/v1/messages',
       'GAUZ_LLM_API_KEY=sk-test',
@@ -1119,8 +1130,8 @@ describe('dashboard CatsCo account status', () => {
       if (req.path === '/api/bots' && req.method === 'GET') {
         return res.json({
           bots: [
-            { uid: 188, username: 'first-agent', display_name: 'First Agent', api_key: 'first-agent-key' },
-            { uid: 199, username: 'last-agent', display_name: 'Last Agent', api_key: 'last-agent-key' },
+            { uid: 188, username: 'first-agent', display_name: 'First Agent', api_key: 'first-agent-key', owner_id: 88 },
+            { uid: 199, username: 'last-agent', display_name: 'Last Agent', api_key: 'last-agent-key', owner_id: 88 },
           ],
         });
       }
@@ -1224,8 +1235,8 @@ describe('dashboard CatsCo account status', () => {
       if (req.path === '/api/bots' && req.method === 'GET') {
         return res.json({
           bots: [
-            { uid: 188, username: 'old-agent', display_name: 'Old Agent', api_key: 'old-agent-key' },
-            { uid: 199, username: 'new-agent', display_name: 'New Agent', api_key: 'new-agent-key' },
+            { uid: 188, username: 'old-agent', display_name: 'Old Agent', api_key: 'old-agent-key', owner_id: 88 },
+            { uid: 199, username: 'new-agent', display_name: 'New Agent', api_key: 'new-agent-key', owner_id: 88 },
           ],
         });
       }
@@ -1346,7 +1357,7 @@ describe('dashboard CatsCo account status', () => {
       }
       if (req.path === '/api/bots' && req.method === 'GET') {
         return res.json({
-          bots: [{ uid: 199, username: 'target-agent', display_name: 'Target Agent', api_key: 'target-agent-key' }],
+          bots: [{ uid: 199, username: 'target-agent', display_name: 'Target Agent', api_key: 'target-agent-key', owner_id: 88 }],
         });
       }
       if (req.path === '/api/friends/request' || req.path === '/api/friends/accept') {
@@ -1480,7 +1491,7 @@ describe('dashboard CatsCo account status', () => {
       }
       if (req.path === '/api/bots' && req.method === 'GET') {
         return res.json({
-          bots: [{ uid: 188, username: 'catsco_88', display_name: 'CatsCo Existing', api_key: 'cats-agent-key' }],
+          bots: [{ uid: 188, username: 'catsco_88', display_name: 'CatsCo Existing', api_key: 'cats-agent-key', owner_id: 88 }],
         });
       }
       if (req.path === '/api/friends/request' || req.path === '/api/friends/accept') {
@@ -1625,7 +1636,7 @@ describe('dashboard CatsCo account status', () => {
         return res.json({ uid: 88, username: 'fresh', display_name: 'Fresh User' });
       }
       if (req.path === '/api/bots' && req.method === 'GET') {
-        return res.json({ bots: [{ uid: 188, username: 'catsco_88', display_name: 'CatsCo', api_key: 'cats-agent-key' }] });
+        return res.json({ bots: [{ uid: 188, username: 'catsco_88', display_name: 'CatsCo', api_key: 'cats-agent-key', owner_id: 88 }] });
       }
       if (req.path === '/api/friends/request' || req.path === '/api/friends/accept') {
         return res.json({ ok: true });
@@ -1740,7 +1751,7 @@ describe('dashboard CatsCo account status', () => {
         return res.json({ uid: 88, username: 'fresh', display_name: 'Fresh User' });
       }
       if (req.path === '/api/bots' && req.method === 'GET') {
-        return res.json({ bots: [{ uid: 188, username: 'catsco_88', display_name: 'CatsCo', api_key: 'cats-agent-key' }] });
+        return res.json({ bots: [{ uid: 188, username: 'catsco_88', display_name: 'CatsCo', api_key: 'cats-agent-key', owner_id: 88 }] });
       }
       if (req.path === '/api/friends/request' || req.path === '/api/friends/accept') {
         return res.json({ ok: true });

--- a/tests/dashboard-catsco-auth-status.test.ts
+++ b/tests/dashboard-catsco-auth-status.test.ts
@@ -557,6 +557,24 @@ describe('dashboard CatsCo account status', () => {
   });
 
   test('POST /cats/auth/login writes both CatsCo and CatsCompany env aliases', async () => {
+    createCatsCoLocalConfigService({ runtimeRoot: testRoot }).save({
+      version: 1,
+      account: { token: 'old-token', uid: '66', username: 'old-user', displayName: 'Old User' },
+      currentBot: {
+        uid: '166',
+        name: 'Old Agent',
+        username: 'old-agent',
+        apiKey: 'old-agent-key',
+        boundByUserUid: '66',
+        bindingSource: 'test',
+      },
+    });
+    writeEnv([
+      'CATSCO_BOT_UID=166',
+      'CATSCO_API_KEY=old-agent-key',
+      'CATSCOMPANY_BOT_UID=166',
+      'CATSCOMPANY_API_KEY=old-agent-key',
+    ]);
     await startCatsServer((req, res) => {
       if (req.path === '/api/auth/login') {
         assert.deepStrictEqual(req.body, {
@@ -598,6 +616,94 @@ describe('dashboard CatsCo account status', () => {
     const persisted = createCatsCoLocalConfigService({ runtimeRoot: testRoot }).load();
     assert.equal(persisted.account?.token, 'new-user-token');
     assert.equal(persisted.account?.uid, '77');
+    assert.equal(persisted.currentBot, undefined);
+    assert.equal(env.CATSCO_BOT_UID, undefined);
+    assert.equal(env.CATSCO_API_KEY, undefined);
+    assert.equal(env.CATSCOMPANY_BOT_UID, undefined);
+    assert.equal(env.CATSCOMPANY_API_KEY, undefined);
+  });
+
+  test('GET /cats/status does not expose an Agent that belongs to the previous account', async () => {
+    await startCatsServer((req, res) => {
+      if (req.path === '/api/me') {
+        return res.json({ uid: 88, username: 'arrowhaken', display_name: 'arrowhaken' });
+      }
+      if (req.path === '/api/bots/body-status') {
+        return res.json({ body_id: '', active: false });
+      }
+      return res.status(404).json({ error: 'not found' });
+    });
+    createCatsCoLocalConfigService({ runtimeRoot: testRoot }).save({
+      version: 1,
+      endpoints: { httpBaseUrl: catsBaseUrl, serverUrl: 'wss://app.catsco.cc/v0/channels' },
+      account: { token: 'arrow-token', uid: '88', username: 'arrowhaken', displayName: 'arrowhaken' },
+      currentBot: {
+        uid: '188',
+        name: 'David',
+        username: 'david',
+        apiKey: 'david-key',
+        boundByUserUid: '77',
+        bindingSource: 'old-account',
+      },
+    });
+    writeEnv([
+      `CATSCO_HTTP_BASE_URL=${catsBaseUrl}`,
+      'CATSCO_SERVER_URL=wss://app.catsco.cc/v0/channels',
+      'CATSCO_USER_TOKEN=arrow-token',
+      'CATSCO_USER_UID=88',
+      'CATSCO_BOT_UID=188',
+      'CATSCO_API_KEY=david-key',
+    ]);
+
+    const response = await fetch(`${dashboardBaseUrl}/api/cats/status`);
+    const data = await response.json() as any;
+
+    assert.equal(response.status, 200);
+    assert.equal(data.user.username, 'arrowhaken');
+    assert.equal(data.botUid, null);
+    assert.equal(data.bot, null);
+  });
+
+  test('GET /cats/bots only offers Agents owned by the current account', async () => {
+    await startCatsServer((req, res) => {
+      if (req.path === '/api/bots') {
+        return res.json({
+          bots: [
+            {
+              uid: 188,
+              username: 'david',
+              display_name: 'David',
+              is_owner: false,
+              relation: 'friend',
+              owner_id: 77,
+            },
+            {
+              uid: 199,
+              username: 'laomocun',
+              display_name: '烙馍村村长',
+              is_owner: true,
+              relation: 'owner',
+              owner_id: 88,
+            },
+          ],
+        });
+      }
+      return res.status(404).json({ error: 'not found' });
+    });
+    writeEnv([
+      `CATSCO_HTTP_BASE_URL=${catsBaseUrl}`,
+      'CATSCO_SERVER_URL=wss://app.catsco.cc/v0/channels',
+      'CATSCO_USER_TOKEN=arrow-token',
+      'CATSCO_USER_UID=88',
+      'CATSCO_BOT_UID=188',
+    ]);
+
+    const response = await fetch(`${dashboardBaseUrl}/api/cats/bots`);
+    const data = await response.json() as any;
+
+    assert.equal(response.status, 200);
+    assert.deepStrictEqual(data.bots.map((bot: any) => bot.uid), ['199']);
+    assert.equal(data.currentBotUid, '');
   });
 
   test('POST /cats/auth/register requests a persistent token after registration', async () => {
@@ -873,7 +979,7 @@ describe('dashboard CatsCo account status', () => {
     assert.equal(data.service.status, 'running');
   });
 
-  test('POST /cats/setup reuses an existing owned bot instead of creating a default bot', async () => {
+  test('POST /cats/setup ignores a stale friend bot and reuses an Agent owned by the current account', async () => {
     if (dashboardServer) {
       await close(dashboardServer);
       dashboardServer = undefined;
@@ -909,9 +1015,21 @@ describe('dashboard CatsCo account status', () => {
           bots: [{
             id: 188,
             uid: 188,
+            username: 'old-friend-agent',
+            display_name: 'Old Friend Agent',
+            api_key: 'old-friend-agent-key',
+            is_owner: false,
+            relation: 'friend',
+            owner_id: 77,
+          }, {
+            id: 199,
+            uid: 199,
             username: 'existing-agent',
             display_name: 'Existing Agent',
             api_key: 'existing-agent-key',
+            is_owner: true,
+            relation: 'owner',
+            owner_id: 88,
           }],
         });
       }
@@ -935,12 +1053,14 @@ describe('dashboard CatsCo account status', () => {
       'CATSCO_USER_UID=88',
       'CATSCO_USER_NAME=fresh',
       'CATSCO_USER_DISPLAY_NAME=Fresh User',
+      'CATSCO_BOT_UID=188',
+      'CATSCO_API_KEY=old-friend-agent-key',
       'GAUZ_LLM_PROVIDER=anthropic',
       'GAUZ_LLM_API_BASE=https://model.example.test/v1/messages',
       'GAUZ_LLM_API_KEY=sk-test',
       'GAUZ_LLM_MODEL=test-model',
     ]);
-    seedVerifiedEmptyBotSkillWorkspace(testRoot, '188');
+    seedVerifiedEmptyBotSkillWorkspace(testRoot, '199');
 
     const response = await fetch(`${dashboardBaseUrl}/api/cats/setup`, {
       method: 'POST',
@@ -958,9 +1078,9 @@ describe('dashboard CatsCo account status', () => {
     assert.equal(response.status, 200, text);
     assert.equal(data.ok, true);
     assert.equal(data.botSelectionSource, 'first-owned-bot');
-    assert.equal(data.bot.uid, '188');
+    assert.equal(data.bot.uid, '199');
     assert.equal(data.bot.display_name, 'Existing Agent');
-    assert.equal(env.CATSCO_BOT_UID, '188');
+    assert.equal(env.CATSCO_BOT_UID, '199');
     assert.equal(env.CATSCO_API_KEY, 'existing-agent-key');
     assert.equal(createBotCalls, 0);
   });

--- a/tests/dashboard-connector.test.ts
+++ b/tests/dashboard-connector.test.ts
@@ -35,8 +35,12 @@ test('Connector lets an authenticated user switch the Agent bound to this comput
   assert.doesNotMatch(script, /\/cats\/create-bot/);
   assert.match(styles, /\.agent-switch-dialog/);
   assert.match(html, /id="logout-dialog"/);
+  assert.match(html, /hero-actions[\s\S]*id="webapp-button"[\s\S]*id="logout-button"/);
+  assert.doesNotMatch(html, /class="danger-zone"/);
   assert.doesNotMatch(script, /window\.confirm\(/);
   assert.match(script, /login-account'\)\?\.focus/);
+  assert.match(script, /当前账号无权使用原 Agent（not your bot）/);
+  assert.match(script, /setNotice\(`\$\{title\}：\$\{detail\}`/);
 });
 
 test('Connector local management restores channels and gives logs a full workspace', () => {
@@ -390,6 +394,32 @@ test('loopback bootstrap requests include the configured Dashboard API key', asy
     await controller.run('startup');
     assert.equal(headers.length, 1);
     assert.equal(headers[0].get('X-API-Key'), 'dashboard-test-key');
+  } finally {
+    rmSync(runtimeRoot, { recursive: true, force: true });
+  }
+});
+
+test('account or Agent transition clears a stale bootstrap error immediately', async () => {
+  const runtimeRoot = createRuntimeConfig('catsco-connector-transition-', {
+    version: 1,
+    account: { token: 'test-user-token', uid: 'usr-test' },
+    preferences: { autoConnect: true },
+  });
+  try {
+    const controller = new CatsConnectorAutoStart({
+      port: 3800,
+      runtimeRoot,
+      fetchImpl: async () => jsonResponse({ error: 'not your bot' }, 403),
+    });
+    const failed = await controller.run('login');
+    assert.equal(failed.stage, 'error');
+    assert.equal(failed.error, 'not your bot');
+
+    const transition = controller.invalidateAndSchedule('switch-bot', 10_000, { force: true });
+    assert.equal(transition.stage, 'connecting');
+    assert.equal(transition.trigger, 'switch-bot');
+    assert.equal(transition.error, undefined);
+    controller.stop();
   } finally {
     rmSync(runtimeRoot, { recursive: true, force: true });
   }

--- a/tests/electron-main-dashboard-url.test.ts
+++ b/tests/electron-main-dashboard-url.test.ts
@@ -96,10 +96,13 @@ test('electron sends trusted CatsCo links to the system browser', () => {
   assert.match(electronMain, /return \{ action: 'deny' \}/);
 });
 
-test('electron keeps authenticated startup in the tray and shows the Dashboard when login is required', () => {
+test('electron opens the default WebApp for authenticated launches and shows Dashboard when login is required', () => {
   assert.match(electronMain, /async function shouldShowDashboardAtStartup\(\)/);
   assert.match(electronMain, /if \(!readStoredCatsCoSession\(\)\) return true/);
-  assert.match(electronMain, /if \(await shouldShowDashboardAtStartup\(\)\) createWindow\(\)/);
+  assert.match(electronMain, /async function handleDesktopLaunch\(\)/);
+  assert.match(electronMain, /await shell\.openExternal\(CATSCO_WEBAPP_URL\)/);
+  assert.match(electronMain, /await handleDesktopLaunch\(\)/);
+  assert.match(electronMain, /else void handleDesktopLaunch\(\)/);
   assert.match(electronMain, /ipcMain\.handle\('catsco:hide-window'/);
 });
 


### PR DESCRIPTION
## Summary

- place the Connector logout action beside the CatsCo WebApp action
- open CatsCo in the operating system default browser on authenticated desktop launches
- clear stale Agent credentials when the CatsCo account changes
- restrict automatic setup and Agent switching to bots owned by the current account
- clear stale bootstrap errors during account or Agent transitions and surface `not your bot` clearly
- add structured WebSocket disconnect diagnostics for HTTP upgrade failures, timeouts, and abnormal closes

## Root cause

CatsCo `/api/bots` includes both owned bots and friend bots. Connector setup previously reused the locally remembered bot UID against the unfiltered response, so a bot from the previous account could still match as a friend and then fail API-key access with `not your bot`. The bootstrap snapshot also retained that old error after a successful manual Agent switch.

## Validation

- `npm run build`
- 74 focused Dashboard, Electron, account-session, and WebSocket tests passed
- runtime suite: 1627 passed, 11 skipped
- two unrelated worker-artifact shell tests fail on this Windows machine because `jq` is not installed
- manually verified with `npm run electron:dev`