### PR TITLE
fix(skillhub): 仅确认真正应用的 Definition revision

### DIFF
--- a/src/bot-definition/activation.ts
+++ b/src/bot-definition/activation.ts
@@ -49,7 +49,11 @@ export interface PreparedBoundBotDefinition {
   sync?: BotDefinitionSyncResult;
   initializedDefault: boolean;
   materializedCatalogRuntime: boolean;
+  /** @deprecated Use appliedCloudRevision for new activation decisions. */
   cloudRevision?: number;
+  observedCloudRevision?: number;
+  desiredCloudRevision?: number;
+  appliedCloudRevision?: number;
   cloudSelection?: CloudBotModelSelection;
   cloudApplyError?: string;
   skillSync?: PreparedBoundBotSkills;
@@ -219,7 +223,24 @@ export async function prepareBoundBotDefinition(
               definitionService,
             });
         definition = definitionService.read(botId) ?? definition;
-        const appliedRevision = skillSync?.sync?.cloudRevision ?? cloudSnapshot.revision;
+        const desiredRevision = cloudSnapshot.revision;
+        const observedRevision = skillSync?.sync?.observedRevision ?? desiredRevision;
+        const skillApplyStatus = skillSync?.sync?.applyStatus;
+        const skippedSkillsAreAbsent = (
+          options.prepareSkills === false
+          && cloudSnapshot.definition?.skills === undefined
+        );
+        const targetRevisionApplied = skippedSkillsAreAbsent || Boolean(
+          skillSync
+          && (skillApplyStatus === 'applied' || skillApplyStatus === 'already_applied')
+          && skillSync.sync?.desiredRevision === desiredRevision
+          && skillSync.sync?.observedRevision === desiredRevision
+          && skillSync.sync?.appliedRevision === desiredRevision
+        );
+        const appliedRevision = targetRevisionApplied ? desiredRevision : undefined;
+        const cloudApplyError = targetRevisionApplied
+          ? undefined
+          : botSkillActivationDeferredError(skillSync?.sync?.errorCode);
         definitionService.clearLegacyModelConfigurationWhenReady(definition);
         if (
           options.acknowledgeCloudSelection !== false
@@ -228,7 +249,8 @@ export async function prepareBoundBotDefinition(
           try {
             await acknowledgeCloudBotDefinition(
               { botId, auth, fetchImpl: options.fetchImpl },
-              appliedRevision,
+              desiredRevision,
+              cloudApplyError,
             );
           } catch (error) {
             Logger.warning(`CatsCo BotDefinition apply acknowledgement failed: ${errorMessage(error)}`);
@@ -240,14 +262,19 @@ export async function prepareBoundBotDefinition(
           sync,
           initializedDefault: initializedDefaultFromEmpty,
           materializedCatalogRuntime,
-          cloudRevision: appliedRevision,
+          observedCloudRevision: observedRevision,
+          desiredCloudRevision: desiredRevision,
+          ...(appliedRevision !== undefined
+            ? { cloudRevision: appliedRevision, appliedCloudRevision: appliedRevision }
+            : {}),
+          ...(cloudApplyError ? { cloudApplyError } : {}),
           ...(skillSync ? { skillSync } : {}),
           cloudSelection: definition.model.kind === 'custom'
             ? {
               kind: 'custom',
               modelId: definition.model.model,
               customModel: definition.model,
-              revision: appliedRevision,
+              revision: desiredRevision,
               definition,
             }
             : {
@@ -256,7 +283,7 @@ export async function prepareBoundBotDefinition(
               ...(definition.model.reasoningEffort
                 ? { reasoningEffort: definition.model.reasoningEffort }
                 : {}),
-              revision: appliedRevision,
+              revision: desiredRevision,
               definition,
             },
         };
@@ -554,8 +581,19 @@ export async function prepareBoundBotDefinition(
     initializedDefault,
     materializedCatalogRuntime,
     ...(cloudSelection ? { cloudSelection } : {}),
+    ...(cloudSelection
+      ? {
+          observedCloudRevision: cloudSelection.revision,
+          desiredCloudRevision: cloudSelection.revision,
+        }
+      : {}),
     ...(cloudApplyError ? { cloudApplyError } : {}),
-    ...(cloudSelectionApplied && cloudSelection ? { cloudRevision: cloudSelection.revision } : {}),
+    ...(cloudSelectionApplied && cloudSelection
+      ? {
+          cloudRevision: cloudSelection.revision,
+          appliedCloudRevision: cloudSelection.revision,
+        }
+      : {}),
     ...(skillSync ? { skillSync } : {}),
   };
 }
@@ -568,6 +606,11 @@ function catalogCapabilitiesNeedRefresh(runtime: BotCatalogModelRuntime): boolea
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function botSkillActivationDeferredError(errorCode?: string): string {
+  const code = String(errorCode || 'skill_revision_not_applied').trim();
+  return `Bot Skill activation was deferred (${code}).`;
 }
 
 function scheduleBundledDefaultPromptSnapshot(options: {

--- a/src/bot-skills/sync-service.ts
+++ b/src/bot-skills/sync-service.ts
@@ -44,10 +44,22 @@ export type BotSkillSyncDirection =
   | 'cloud_to_local'
   | 'feature_unavailable';
 
+export type BotSkillApplyStatus =
+  | 'applied'
+  | 'already_applied'
+  | 'deferred'
+  | 'failed';
+
 export interface BotSkillSyncResult {
   botId: string;
   direction: BotSkillSyncDirection;
+  /** @deprecated Use observedRevision for new activation decisions. */
   cloudRevision?: number;
+  observedRevision?: number;
+  desiredRevision?: number;
+  appliedRevision?: number;
+  applyStatus: BotSkillApplyStatus;
+  errorCode?: string;
   skills: BotSkillRef[];
   localPendingEvidence?: {
     path: string;
@@ -249,6 +261,10 @@ export class BotSkillSyncService {
           botId: this.botId,
           direction: 'none',
           cloudRevision: cloud.revision,
+          observedRevision: cloud.revision,
+          desiredRevision: cloud.revision,
+          appliedRevision: cloud.revision,
+          applyStatus: 'already_applied',
           skills: cloud.skills,
         };
       }
@@ -265,6 +281,10 @@ export class BotSkillSyncService {
       botId: this.botId,
       direction: 'none',
       cloudRevision: cloud.revision,
+      observedRevision: cloud.revision,
+      desiredRevision: cloud.revision,
+      appliedRevision: cloud.revision,
+      applyStatus: 'already_applied',
       skills: cloud.skills,
     };
   }
@@ -301,14 +321,25 @@ export class BotSkillSyncService {
       try {
         cloud = await pullCloudBotSkills(this.cloudOptions);
       } catch (error) {
-        if (verifiedExisting) return this.featureUnavailable();
+        if (verifiedExisting) {
+          return this.featureUnavailable({
+            appliedRevision: base!.definitionRevision,
+            errorCode: 'cloud_unavailable',
+          });
+        }
         throw new BotSkillCloudRestoreError(
           `Bot Skill activation requires Cloud or a verified local workspace: ${errorMessage(error)}`,
           { cause: error },
         );
       }
       if (!cloud?.definition) {
-        if (verifiedExisting) return this.featureUnavailable();
+        if (verifiedExisting) {
+          return this.featureUnavailable({
+            ...(cloud ? { observedRevision: cloud.revision } : {}),
+            appliedRevision: base!.definitionRevision,
+            errorCode: 'cloud_definition_unavailable',
+          });
+        }
         throw new BotSkillCloudRestoreError(
           'Bot Skill activation requires a canonical Cloud BotDefinition.',
         );
@@ -348,7 +379,11 @@ export class BotSkillSyncService {
           cloudRevision: cloud.revision,
         });
         return {
-          ...this.featureUnavailable(),
+          ...this.featureUnavailable({
+            observedRevision: cloud.revision,
+            desiredRevision: cloud.revision,
+            errorCode: 'local_workspace_unverified',
+          }),
           cloudRevision: cloud.revision,
           localPendingEvidence: {
             path: snapshot.path,
@@ -370,6 +405,10 @@ export class BotSkillSyncService {
           botId: this.botId,
           direction: 'none',
           cloudRevision: cloud.revision,
+          observedRevision: cloud.revision,
+          desiredRevision: cloud.revision,
+          appliedRevision: cloud.revision,
+          applyStatus: 'already_applied',
           skills: cloud.skills,
         };
       }
@@ -628,10 +667,20 @@ export class BotSkillSyncService {
     }
   }
 
-  private featureUnavailable(): BotSkillSyncResult {
+  private featureUnavailable(options: {
+    observedRevision?: number;
+    desiredRevision?: number;
+    appliedRevision?: number;
+    errorCode?: string;
+  } = {}): BotSkillSyncResult {
     return {
       botId: this.botId,
       direction: 'feature_unavailable',
+      applyStatus: 'deferred',
+      ...(options.observedRevision !== undefined
+        ? { cloudRevision: options.observedRevision }
+        : {}),
+      ...options,
       skills: this.definitionService.read(this.botId)?.skills ?? [],
     };
   }
@@ -805,6 +854,10 @@ export class BotSkillSyncService {
       botId: this.botId,
       direction: 'local_to_cloud',
       cloudRevision: cloud.revision,
+      observedRevision: cloud.revision,
+      desiredRevision: cloud.revision,
+      appliedRevision: cloud.revision,
+      applyStatus: 'applied',
       skills: cloud.skills,
     };
   }
@@ -1020,6 +1073,10 @@ export class BotSkillSyncService {
       botId: this.botId,
       direction: 'cloud_to_local',
       cloudRevision: cloud.revision,
+      observedRevision: cloud.revision,
+      desiredRevision: cloud.revision,
+      appliedRevision: cloud.revision,
+      applyStatus: 'applied',
       skills: cloud.skills,
       ...(localPendingEvidence ? { localPendingEvidence } : {}),
     };

--- a/tests/bot-definition-activation.test.ts
+++ b/tests/bot-definition-activation.test.ts
@@ -15,6 +15,7 @@ import {
 } from '../src/bot-definition/repository';
 import { resolveActiveBotLLMConfig } from '../src/bot-definition/llm-config-resolver';
 import { BOT_DEFINITION_SCHEMA } from '../src/bot-definition/types';
+import { BotSkillBaseStore } from '../src/bot-skills/base-store';
 
 describe('BotDefinition activation', () => {
   const roots: string[] = [];
@@ -371,6 +372,212 @@ describe('BotDefinition activation', () => {
     assert.equal(resolveActiveBotLLMConfig({ runtimeRoot, env })?.config.model, 'MiniMax-M3');
     assert.equal(requests.some(item => item.includes('/api/bots/definition/model')), false);
     assert.equal(requests.includes('POST /api/bot/definition/ack'), true);
+  });
+
+  test('reports a deferred Definition apply instead of success when an unverified local Skill workspace is preserved', async () => {
+    const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-definition-skill-deferred-runtime-'));
+    const simulatedCloudRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-definition-skill-deferred-cloud-'));
+    roots.push(runtimeRoot, simulatedCloudRoot);
+    const env = {} as NodeJS.ProcessEnv;
+    createCatsCoLocalConfigService({ runtimeRoot, env }).save({
+      version: 1,
+      endpoints: { httpBaseUrl: 'https://cats.example.test', serverUrl: 'wss://cats.example.test/v0/channels' },
+      account: { token: 'owner-token', uid: '7', displayName: 'Alice' },
+      currentBot: { uid: '43', apiKey: 'bot-api-key', boundByUserUid: '7', bindingSource: 'test' },
+    });
+    const localSkillRoot = path.join(runtimeRoot, 'skills', 'local-preserve');
+    fs.mkdirSync(localSkillRoot, { recursive: true });
+    fs.writeFileSync(
+      path.join(localSkillRoot, 'SKILL.md'),
+      '---\nname: local-preserve\ndescription: Preserve this local Skill during activation.\n---\n',
+    );
+    const cloudDefinition = {
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: '43',
+      model: {
+        kind: 'custom' as const,
+        protocol: 'openai-responses' as const,
+        apiBase: 'https://models.example.test/v1',
+        apiKey: 'sk-cloud-model',
+        model: 'cloud-model',
+        contextWindowTokens: 256_000,
+        maxTokens: 8192,
+      },
+      prompt: { selected: 'custom' as const, customSystemPrompt: 'Cloud prompt.' },
+      skills: [],
+    };
+    let ackBody: any;
+    const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(String(input));
+      const method = init?.method || 'GET';
+      if (url.pathname === '/api/bot/definition' && method === 'GET') {
+        return Response.json({ configured: true, revision: 7, definition: cloudDefinition });
+      }
+      if (url.pathname === '/api/bot/definition/ack' && method === 'POST') {
+        ackBody = JSON.parse(String(init?.body));
+        return Response.json({ status: 'failed' });
+      }
+      if (url.pathname === '/api/bot/definition/default-prompt' && method === 'PUT') {
+        return Response.json({ status: 'stored' });
+      }
+      return Response.json({ error: `unexpected ${method} ${url.pathname}` }, { status: 500 });
+    }) as typeof fetch;
+
+    const prepared = await prepareBoundBotDefinition({
+      runtimeRoot,
+      simulatedCloudRoot,
+      env,
+      fetchImpl,
+    });
+
+    assert.equal(prepared?.observedCloudRevision, 7);
+    assert.equal(prepared?.desiredCloudRevision, 7);
+    assert.equal(prepared?.appliedCloudRevision, undefined);
+    assert.equal(prepared?.cloudRevision, undefined);
+    assert.match(prepared?.cloudApplyError || '', /local_workspace_unverified/);
+    assert.equal(prepared?.skillSync?.sync?.applyStatus, 'deferred');
+    assert.equal(prepared?.skillSync?.sync?.appliedRevision, undefined);
+    assert.deepStrictEqual(ackBody, {
+      revision: 7,
+      error: 'Bot Skill activation was deferred (local_workspace_unverified).',
+    });
+    assert.equal(fs.existsSync(path.join(localSkillRoot, 'SKILL.md')), true);
+  });
+
+  test('success-acks a unified Definition only after its complete Skill revision is verified locally', async () => {
+    const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-definition-skill-applied-runtime-'));
+    const simulatedCloudRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-definition-skill-applied-cloud-'));
+    roots.push(runtimeRoot, simulatedCloudRoot);
+    const env = {} as NodeJS.ProcessEnv;
+    createCatsCoLocalConfigService({ runtimeRoot, env }).save({
+      version: 1,
+      endpoints: { httpBaseUrl: 'https://cats.example.test', serverUrl: 'wss://cats.example.test/v0/channels' },
+      account: { token: 'owner-token', uid: '7', displayName: 'Alice' },
+      currentBot: { uid: '43', apiKey: 'bot-api-key', boundByUserUid: '7', bindingSource: 'test' },
+    });
+    const cloudDefinition = {
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: '43',
+      model: {
+        kind: 'custom' as const,
+        protocol: 'openai-responses' as const,
+        apiBase: 'https://models.example.test/v1',
+        apiKey: 'sk-cloud-model',
+        model: 'cloud-model',
+        contextWindowTokens: 256_000,
+        maxTokens: 8192,
+      },
+      prompt: { selected: 'custom' as const, customSystemPrompt: 'Cloud prompt.' },
+      skills: [],
+    };
+    let ackBody: any;
+    const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(String(input));
+      const method = init?.method || 'GET';
+      if (url.pathname === '/api/bot/definition' && method === 'GET') {
+        return Response.json({ configured: true, revision: 7, definition: cloudDefinition });
+      }
+      if (url.pathname === '/api/bot/definition/ack' && method === 'POST') {
+        ackBody = JSON.parse(String(init?.body));
+        return Response.json({ status: 'applied' });
+      }
+      if (url.pathname === '/api/bot/definition/default-prompt' && method === 'PUT') {
+        return Response.json({ status: 'stored' });
+      }
+      return Response.json({ error: `unexpected ${method} ${url.pathname}` }, { status: 500 });
+    }) as typeof fetch;
+
+    const prepared = await prepareBoundBotDefinition({
+      runtimeRoot,
+      simulatedCloudRoot,
+      env,
+      fetchImpl,
+    });
+
+    assert.equal(prepared?.observedCloudRevision, 7);
+    assert.equal(prepared?.desiredCloudRevision, 7);
+    assert.equal(prepared?.appliedCloudRevision, 7);
+    assert.equal(prepared?.cloudRevision, 7);
+    assert.equal(prepared?.cloudApplyError, undefined);
+    assert.equal(prepared?.skillSync?.sync?.applyStatus, 'applied');
+    assert.equal(prepared?.skillSync?.sync?.appliedRevision, 7);
+    assert.deepStrictEqual(ackBody, { revision: 7 });
+  });
+
+  test('does not success-ack when the activation Skill recheck loses Cloud after a verified local Base', async () => {
+    const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-definition-skill-recheck-runtime-'));
+    const simulatedCloudRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-definition-skill-recheck-cloud-'));
+    roots.push(runtimeRoot, simulatedCloudRoot);
+    const env = {} as NodeJS.ProcessEnv;
+    createCatsCoLocalConfigService({ runtimeRoot, env }).save({
+      version: 1,
+      endpoints: { httpBaseUrl: 'https://cats.example.test', serverUrl: 'wss://cats.example.test/v0/channels' },
+      account: { token: 'owner-token', uid: '7', displayName: 'Alice' },
+      currentBot: { uid: '43', apiKey: 'bot-api-key', boundByUserUid: '7', bindingSource: 'test' },
+    });
+    fs.mkdirSync(path.join(runtimeRoot, 'skills'), { recursive: true });
+    new BotSkillBaseStore(runtimeRoot).write({
+      schema: 'xiaoba.bot-skill-sync-base.v2',
+      botId: '43',
+      definitionRevision: 7,
+      skills: [],
+      updatedAt: new Date().toISOString(),
+    });
+    const cloudDefinition = {
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: '43',
+      model: {
+        kind: 'custom' as const,
+        protocol: 'openai-responses' as const,
+        apiBase: 'https://models.example.test/v1',
+        apiKey: 'sk-cloud-model',
+        model: 'cloud-model',
+        contextWindowTokens: 256_000,
+        maxTokens: 8192,
+      },
+      prompt: { selected: 'custom' as const, customSystemPrompt: 'Cloud prompt.' },
+      skills: [],
+    };
+    let definitionReads = 0;
+    let ackBody: any;
+    const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(String(input));
+      const method = init?.method || 'GET';
+      if (url.pathname === '/api/bot/definition' && method === 'GET') {
+        definitionReads += 1;
+        if (definitionReads === 1) {
+          return Response.json({ configured: true, revision: 7, definition: cloudDefinition });
+        }
+        return Response.json({ error: 'temporary outage' }, { status: 503 });
+      }
+      if (url.pathname === '/api/bot/definition/ack' && method === 'POST') {
+        ackBody = JSON.parse(String(init?.body));
+        return Response.json({ status: 'failed' });
+      }
+      if (url.pathname === '/api/bot/definition/default-prompt' && method === 'PUT') {
+        return Response.json({ status: 'stored' });
+      }
+      return Response.json({ error: `unexpected ${method} ${url.pathname}` }, { status: 500 });
+    }) as typeof fetch;
+
+    const prepared = await prepareBoundBotDefinition({
+      runtimeRoot,
+      simulatedCloudRoot,
+      env,
+      fetchImpl,
+    });
+
+    assert.equal(prepared?.observedCloudRevision, 7);
+    assert.equal(prepared?.desiredCloudRevision, 7);
+    assert.equal(prepared?.appliedCloudRevision, undefined);
+    assert.equal(prepared?.cloudRevision, undefined);
+    assert.match(prepared?.cloudApplyError || '', /cloud_unavailable/);
+    assert.equal(prepared?.skillSync?.sync?.applyStatus, 'deferred');
+    assert.equal(prepared?.skillSync?.sync?.appliedRevision, 7);
+    assert.deepStrictEqual(ackBody, {
+      revision: 7,
+      error: 'Bot Skill activation was deferred (cloud_unavailable).',
+    });
   });
 
   test('applies and acknowledges a cloud-selected model after its local runtime is ready', async () => {

--- a/tests/bot-skills-sync.test.ts
+++ b/tests/bot-skills-sync.test.ts
@@ -1880,6 +1880,11 @@ describe('Bot Skill Local/Base/Cloud sync', () => {
 
     assert.equal(result.direction, 'feature_unavailable');
     assert.equal(result.cloudRevision, 1);
+    assert.equal(result.observedRevision, 1);
+    assert.equal(result.desiredRevision, 1);
+    assert.equal(result.appliedRevision, undefined);
+    assert.equal(result.applyStatus, 'deferred');
+    assert.equal(result.errorCode, 'local_workspace_unverified');
     assert.equal(fixture.uploads, 0);
     assert.equal(fixture.patches, 0);
     assert.match(
@@ -1925,6 +1930,10 @@ describe('Bot Skill Local/Base/Cloud sync', () => {
 
     assert.equal(result.direction, 'feature_unavailable');
     assert.equal(result.cloudRevision, 1);
+    assert.equal(result.observedRevision, 1);
+    assert.equal(result.desiredRevision, 1);
+    assert.equal(result.appliedRevision, undefined);
+    assert.equal(result.applyStatus, 'deferred');
     assert.match(
       fs.readFileSync(path.join(fixture.skillsRoot, 'late-local', 'SKILL.md'), 'utf8'),
       /created during activation/,
@@ -1953,6 +1962,9 @@ describe('Bot Skill Local/Base/Cloud sync', () => {
     const result = await fixture.activate();
 
     assert.equal(result.direction, 'feature_unavailable');
+    assert.equal(result.applyStatus, 'deferred');
+    assert.equal(result.appliedRevision, undefined);
+    assert.equal(result.errorCode, 'local_workspace_unverified');
     assert.equal(fixture.uploads, 0);
     assert.equal(fixture.patches, 0);
     assert.match(
@@ -1973,6 +1985,10 @@ describe('Bot Skill Local/Base/Cloud sync', () => {
     const result = await fixture.activate();
 
     assert.equal(result.direction, 'cloud_to_local');
+    assert.equal(result.applyStatus, 'applied');
+    assert.equal(result.observedRevision, 2);
+    assert.equal(result.desiredRevision, 2);
+    assert.equal(result.appliedRevision, 2);
     assert.equal(fs.existsSync(path.join(fixture.skillsRoot, 'local-a')), false);
     assert.deepStrictEqual(fixture.definitionService.read(fixture.botId)?.skills, []);
     assert.deepStrictEqual(
@@ -1992,6 +2008,9 @@ describe('Bot Skill Local/Base/Cloud sync', () => {
     const result = await fixture.activate();
 
     assert.equal(result.direction, 'feature_unavailable');
+    assert.equal(result.applyStatus, 'deferred');
+    assert.equal(result.appliedRevision, 1);
+    assert.equal(result.errorCode, 'cloud_unavailable');
     assert.equal(fixture.uploads, 0);
     assert.equal(fixture.patches, 0);
     assert.match(


### PR DESCRIPTION
## 目标

修正 BotDefinition 激活回执语义：Runtime 只有在完整 Skill revision 已在本地验证并应用后，才会上报成功 ACK。

## 变更

- 为 Bot Skill 同步结果拆分 observed、desired、applied revision，并增加明确的 apply status。
- 保留 cloudRevision 兼容字段，但不再用“看见的云端 revision”冒充“已应用 revision”。
- 本地工作区需要保留、云端二次复核失败或激活被延后时，上报失败状态，不推进 applied revision。
- 已完整应用或已验证一致时，继续按原流程成功 ACK。
- 不修改文件工具、Shell、Skill 执行、注入或 System Prompt。

## 风险边界

- 不新增模型工具或入口。
- 不改变 Skill 工作区目录、发布、删除或运行权限。
- 不收紧 read_file、write_file、edit_file、send_file、import_file、execute_shell。

## 验证

- npm run build
- npx tsx --test tests/bot-definition-activation.test.ts
- npx tsx --test tests/bot-skills-sync.test.ts tests/bot-definition-activation.test.ts（78/78）
- npm run test:skillhub-phase1（246 passed，1 个 Windows symlink 条件跳过）
- npm test：1642 项中 1628 passed、11 skipped；1 个随机端口用例单独重跑通过，2 个 Worker updater 用例因本机缺少 jq 失败，与本改动无关。

## 重点回归

- #390 场景保留本地 Skill，且不会发送成功 ACK。
- 第二次云端读取失败时，即使旧 Base 可信，也不会把新 revision 标为 applied。
- 正常完整应用路径仍发送无 error 的成功 ACK。
