### PR TITLE
feat: fail over CatsCo app endpoint to .cn

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,8 @@ CATSCOMPANY_VISION_FALLBACK_MAX_TOKENS=4096
 # In the desktop app, the CatsCo page can fill these values after login/binding.
 CATSCO_HTTP_BASE_URL=https://app.catsco.cc
 CATSCO_SERVER_URL=wss://app.catsco.cc/v0/channels
+# The runtime keeps app.catsco.cc as the primary endpoint and automatically
+# retries network failures through the allow-listed app.catsco.cn endpoint.
 CATSCO_API_KEY=
 # Optional owner-provisioned, body/installation-bound credential for the
 # second-stage Skill mutation grant protocol. This is not a Bot API key.

--- a/dashboard/connector.html
+++ b/dashboard/connector.html
@@ -54,7 +54,7 @@
               </label>
               <div class="form-actions">
                 <button class="button button-primary" id="login-button" type="submit">登录并连接</button>
-                <a class="text-link external-link" href="https://app.catsco.cc" target="_blank" rel="noopener noreferrer">注册或在网页端登录</a>
+                <a class="text-link external-link" id="webapp-login-link" href="https://app.catsco.cc" target="_blank" rel="noopener noreferrer">注册或在网页端登录</a>
               </div>
               <p class="form-error" id="login-error" role="alert"></p>
             </form>

--- a/dashboard/connector.js
+++ b/dashboard/connector.js
@@ -137,6 +137,13 @@
     if (node) node.textContent = value == null || value === '' ? '—' : String(value);
   };
 
+  function getCatsCoWebAppUrl() {
+    const configured = String(state.cats?.httpBaseUrl || '').trim().replace(/\/+$/, '');
+    return configured === 'https://app.catsco.cn' || configured === 'https://app.catsco.cc'
+      ? configured
+      : 'https://app.catsco.cc';
+  }
+
   async function request(path, init = {}) {
     const headers = new Headers(init.headers || {});
     headers.set('Accept', 'application/json');
@@ -265,6 +272,8 @@
     $('progress-list').hidden = view.key !== 'connecting';
     $('error-card').hidden = view.key !== 'error';
     $('webapp-button').hidden = view.key !== 'ready';
+    $('webapp-button').href = getCatsCoWebAppUrl();
+    $('webapp-login-link').href = getCatsCoWebAppUrl();
     $('logout-button').hidden = view.key === 'auth' || (!cats.connected && !cats.tokenPresent);
     $('retry-button').hidden = view.key !== 'error';
     $('close-hint').hidden = view.key !== 'ready';
@@ -289,9 +298,9 @@
   async function openWebAppFromDashboard() {
     try {
       if (window.catscoDesktop?.openWebApp) {
-        await window.catscoDesktop.openWebApp();
+        await window.catscoDesktop.openWebApp(getCatsCoWebAppUrl());
       } else {
-        window.open('https://app.catsco.cc', '_blank', 'noopener,noreferrer');
+        window.open(getCatsCoWebAppUrl(), '_blank', 'noopener,noreferrer');
       }
     } finally {
       await window.catscoDesktop?.hideWindow?.();

--- a/electron/main.js
+++ b/electron/main.js
@@ -20,8 +20,11 @@ if (shouldDisableHardwareAcceleration()) {
 
 const DASHBOARD_PORT = resolveDashboardPort(process.env.XIAOBA_DASHBOARD_PORT);
 const DEEP_LINK_PROTOCOL = 'catsco';
-const TRUSTED_DEEP_LINK_BASE_ORIGINS = new Set(['https://app.catsco.cc']);
-const CATSCO_WEBAPP_URL = 'https://app.catsco.cc';
+const TRUSTED_DEEP_LINK_BASE_ORIGINS = new Set(['https://app.catsco.cc', 'https://app.catsco.cn']);
+// Keep .cc canonical. CATSCO_WEBAPP_URL is an explicit operator override for
+// migration/testing; endpoint failover for API and WebSocket traffic happens
+// inside the runtime client.
+const CATSCO_WEBAPP_URL = normalizeCatsCoWebAppUrl(process.env.CATSCO_WEBAPP_URL);
 let mainWindow = null;
 let tray = null;
 let autoUpdater = null;
@@ -59,6 +62,12 @@ function resolveDashboardPort(value) {
   const port = Number.parseInt(text, 10);
   if (port < 1 || port > 65535) return 3800;
   return port;
+}
+
+function normalizeCatsCoWebAppUrl(value) {
+  const text = String(value || '').trim().replace(/\/+$/, '');
+  if (text === 'https://app.catsco.cn' || text === 'https://app.catsco.cc') return text;
+  return 'https://app.catsco.cc';
 }
 
 function applyConfiguredUserDataPath() {
@@ -646,7 +655,7 @@ function createWindow() {
     }
     try {
       const target = new URL(url);
-      if (target.protocol === 'https:' && target.origin === 'https://app.catsco.cc') {
+      if (target.protocol === 'https:' && TRUSTED_DEEP_LINK_BASE_ORIGINS.has(target.origin)) {
         void shell.openExternal(target.toString());
       }
     } catch (_error) {
@@ -746,10 +755,10 @@ ipcMain.handle('catsco:hide-window', async (event) => {
   return true;
 });
 
-ipcMain.handle('catsco:open-webapp', async (event) => {
+ipcMain.handle('catsco:open-webapp', async (event, requestedUrl) => {
   const owner = BrowserWindow.fromWebContents(event.sender);
   if (owner !== mainWindow) return false;
-  await shell.openExternal(CATSCO_WEBAPP_URL);
+  await shell.openExternal(normalizeCatsCoWebAppUrl(requestedUrl || CATSCO_WEBAPP_URL));
   return true;
 });
 

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -2,6 +2,6 @@ const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('catscoDesktop', {
   selectFiles: () => ipcRenderer.invoke('catsco:select-files'),
-  openWebApp: () => ipcRenderer.invoke('catsco:open-webapp'),
+  openWebApp: (url) => ipcRenderer.invoke('catsco:open-webapp', url),
   hideWindow: () => ipcRenderer.invoke('catsco:hide-window'),
 });

--- a/src/bot-definition/cloud-client.ts
+++ b/src/bot-definition/cloud-client.ts
@@ -11,6 +11,7 @@ import {
   type BotSkillRef,
   type CustomBotModelDefinition,
 } from './types';
+import { catsCoHttpBaseUrlCandidates, isCatsCoNetworkFailure } from '../catscompany/endpoint-failover';
 
 const CLOUD_MODEL_REQUEST_TIMEOUT_MS = 10_000;
 
@@ -425,18 +426,32 @@ async function cloudDefinitionRequest(
   const httpBaseUrl = String(options.auth.httpBaseUrl || '').trim().replace(/\/+$/, '');
   if (!credential || !httpBaseUrl) return undefined;
 
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), CLOUD_MODEL_REQUEST_TIMEOUT_MS);
+  const candidates = catsCoHttpBaseUrlCandidates(httpBaseUrl);
+  let response: Response | undefined;
+  let lastError: unknown;
   try {
-    const response = await (options.fetchImpl ?? fetch)(`${httpBaseUrl}${apiPath}`, {
-      method,
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: authMode === 'owner' ? `Bearer ${credential}` : `ApiKey ${credential}`,
-      },
-      body: body === undefined ? undefined : JSON.stringify(body),
-      signal: controller.signal,
-    });
+    for (const candidate of candidates) {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), CLOUD_MODEL_REQUEST_TIMEOUT_MS);
+      try {
+        response = await (options.fetchImpl ?? fetch)(`${candidate}${apiPath}`, {
+          method,
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: authMode === 'owner' ? `Bearer ${credential}` : `ApiKey ${credential}`,
+          },
+          body: body === undefined ? undefined : JSON.stringify(body),
+          signal: controller.signal,
+        });
+        break;
+      } catch (error) {
+        lastError = error;
+        if (!isCatsCoNetworkFailure(error) || candidate === candidates[candidates.length - 1]) throw error;
+      } finally {
+        clearTimeout(timeout);
+      }
+    }
+    if (!response) throw lastError || new Error('CatsCo cloud endpoint unavailable');
     if ([404, 405, 501].includes(response.status)) return undefined;
     const text = await response.text();
     let data: any = {};
@@ -453,9 +468,7 @@ async function cloudDefinitionRequest(
       throw error;
     }
     return data;
-  } finally {
-    clearTimeout(timeout);
-  }
+  } finally {}
 }
 
 async function cloudModelRequest(
@@ -468,18 +481,32 @@ async function cloudModelRequest(
   const httpBaseUrl = String(options.auth.httpBaseUrl || '').trim().replace(/\/+$/, '');
   if (!apiKey || !httpBaseUrl) return undefined;
 
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), CLOUD_MODEL_REQUEST_TIMEOUT_MS);
+  const candidates = catsCoHttpBaseUrlCandidates(httpBaseUrl);
+  let response: Response | undefined;
+  let lastError: unknown;
   try {
-    const response = await (options.fetchImpl ?? fetch)(`${httpBaseUrl}${apiPath}`, {
-      method,
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `ApiKey ${apiKey}`,
-      },
-      body: body === undefined ? undefined : JSON.stringify(body),
-      signal: controller.signal,
-    });
+    for (const candidate of candidates) {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), CLOUD_MODEL_REQUEST_TIMEOUT_MS);
+      try {
+        response = await (options.fetchImpl ?? fetch)(`${candidate}${apiPath}`, {
+          method,
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `ApiKey ${apiKey}`,
+          },
+          body: body === undefined ? undefined : JSON.stringify(body),
+          signal: controller.signal,
+        });
+        break;
+      } catch (error) {
+        lastError = error;
+        if (!isCatsCoNetworkFailure(error) || candidate === candidates[candidates.length - 1]) throw error;
+      } finally {
+        clearTimeout(timeout);
+      }
+    }
+    if (!response) throw lastError || new Error('CatsCo cloud endpoint unavailable');
     if ([404, 405, 501].includes(response.status)) return undefined;
     const text = await response.text();
     let data: any = {};
@@ -494,7 +521,5 @@ async function cloudModelRequest(
       throw new Error(String(data?.error || data?.message || `CatsCo cloud model request failed: ${response.status}`));
     }
     return data;
-  } finally {
-    clearTimeout(timeout);
-  }
+  } finally {}
 }

--- a/src/catscompany/client.ts
+++ b/src/catscompany/client.ts
@@ -4,6 +4,7 @@ import { EventEmitter } from 'events';
 import crypto from 'crypto';
 import { Logger } from '../utils/logger';
 import { uploadCatsLocalFile, type UploadResult } from './upload';
+import { fallbackCatsCoHttpBaseUrl, fallbackCatsCoServerUrl, isCatsCoNetworkFailure } from './endpoint-failover';
 
 export type { UploadResult } from './upload';
 
@@ -280,6 +281,7 @@ export class CatsClient extends EventEmitter {
   private supportsClientMessageDedupe = false;
   public supportsThinToolRpc = false;
   private awaitingReady = false;
+  private endpointFailoverApplied = false;
 
   public uid = '';
   public name = '';
@@ -368,6 +370,7 @@ export class CatsClient extends EventEmitter {
     this.ws.on('error', (err: Error) => {
       const errorCode = String((err as any)?.code || (err as any)?.cause?.code || '').trim();
       this.lastTransportError = oneLine(errorCode ? `${errorCode}: ${err.message}` : err.message);
+      this.applyEndpointFailover(err);
       this.emit('error', err);
     });
     this.ws.on('close', (code: number, reason: Buffer) => {
@@ -383,6 +386,9 @@ export class CatsClient extends EventEmitter {
       );
       this.clearConnectTimeout();
       this.clearReadyTimeout();
+      if (this.disconnectCause === 'connect_timeout' || this.disconnectCause === 'heartbeat_timeout') {
+        this.applyEndpointFailover(Object.assign(new Error(this.disconnectCause), { code: 'ETIMEDOUT' }));
+      }
       this.awaitingReady = false;
       this.stopHeartbeat();
       this.ws = null;
@@ -647,7 +653,7 @@ export class CatsClient extends EventEmitter {
       url.searchParams.set('before_id', String(options.beforeId));
     }
 
-    const res = await fetch(url, {
+    const res = await this.fetchHttp(url.pathname + url.search, {
       headers: {
         Authorization: `ApiKey ${this.config.apiKey}`,
         'User-Agent': CATSCOMPANY_CLIENT_UA,
@@ -994,8 +1000,7 @@ export class CatsClient extends EventEmitter {
   }
 
   private async acceptFriendRequest(userId: number): Promise<void> {
-    const httpBaseUrl = this.config.httpBaseUrl || 'https://app.catsco.cc';
-    const res = await fetch(`${httpBaseUrl}/api/friends/accept`, {
+    const res = await this.fetchHttp('/api/friends/accept', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -1024,7 +1029,7 @@ export class CatsClient extends EventEmitter {
   }
 
   async registerDevice(registration: CatsDeviceRegistration): Promise<unknown> {
-    const res = await fetch(`${this.httpBaseUrl()}/api/devices/register`, {
+    const res = await this.fetchHttp('/api/devices/register', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -1215,6 +1220,17 @@ export class CatsClient extends EventEmitter {
     }, delay);
   }
 
+  private applyEndpointFailover(error: unknown): void {
+    if (this.endpointFailoverApplied || !isCatsCoNetworkFailure(error)) return;
+    const fallbackServerUrl = fallbackCatsCoServerUrl(this.config.serverUrl);
+    const fallbackHttpBaseUrl = fallbackCatsCoHttpBaseUrl(this.config.httpBaseUrl || inferHttpBaseUrl(this.config.serverUrl));
+    if (!fallbackServerUrl && !fallbackHttpBaseUrl) return;
+    if (fallbackServerUrl) this.config.serverUrl = fallbackServerUrl;
+    if (fallbackHttpBaseUrl) this.config.httpBaseUrl = fallbackHttpBaseUrl;
+    this.endpointFailoverApplied = true;
+    Logger.warning('[CatsCompany] app.catsco.cc 网络不可用，已切换备用 app.catsco.cn endpoint');
+  }
+
   private resubscribeTopics(): void {
     if (this.subscribedTopics.size > 0) {
       Logger.info(`[CatsCompany] 重新订阅 ${this.subscribedTopics.size} 个会话`);
@@ -1226,6 +1242,24 @@ export class CatsClient extends EventEmitter {
 
   private httpBaseUrl(): string {
     return this.config.httpBaseUrl || inferHttpBaseUrl(this.config.serverUrl) || 'https://app.catsco.cc';
+  }
+
+  private async fetchHttp(pathname: string, init: RequestInit): Promise<Response> {
+    const candidates = [this.httpBaseUrl(), fallbackCatsCoHttpBaseUrl(this.httpBaseUrl())].filter(
+      (value, index, all): value is string => Boolean(value) && all.indexOf(value) === index,
+    );
+    let lastError: any;
+    for (const candidate of candidates) {
+      try {
+        return await fetch(`${candidate.replace(/\/+$/, '')}${pathname}`, init);
+      } catch (error: any) {
+        lastError = error;
+        if (!isCatsCoNetworkFailure(error) || candidate === candidates[candidates.length - 1]) throw error;
+        this.config.httpBaseUrl = candidate.replace('app.catsco.cc', 'app.catsco.cn');
+        Logger.warning('[CatsCompany] HTTP 请求切换备用 app.catsco.cn endpoint');
+      }
+    }
+    throw lastError || new Error('CatsCo HTTP endpoint unavailable');
   }
 
   disconnect(): void {

--- a/src/catscompany/endpoint-failover.ts
+++ b/src/catscompany/endpoint-failover.ts
@@ -1,0 +1,58 @@
+/**
+ * CatsCo production endpoint policy.
+ *
+ * app.catsco.cc remains the canonical endpoint. app.catsco.cn is an
+ * explicitly allow-listed recovery endpoint for the migration period; it is
+ * never derived from arbitrary user input.
+ */
+export const PRIMARY_CATSCO_HTTP_BASE_URL = 'https://app.catsco.cc';
+export const FALLBACK_CATSCO_HTTP_BASE_URL = 'https://app.catsco.cn';
+export const PRIMARY_CATSCO_WS_URL = 'wss://app.catsco.cc/v0/channels';
+export const FALLBACK_CATSCO_WS_URL = 'wss://app.catsco.cn/v0/channels';
+
+function replaceOrigin(value: unknown, fromOrigin: string, toOrigin: string): string | undefined {
+  const text = String(value || '').trim();
+  if (!text) return undefined;
+  try {
+    const url = new URL(text);
+    if (url.origin !== fromOrigin) return undefined;
+    url.hostname = new URL(toOrigin).hostname;
+    url.protocol = new URL(toOrigin).protocol;
+    url.port = new URL(toOrigin).port;
+    return url.toString().replace(/\/$/, '');
+  } catch {
+    return undefined;
+  }
+}
+
+export function fallbackCatsCoHttpBaseUrl(value: unknown): string | undefined {
+  const fallback = replaceOrigin(value, PRIMARY_CATSCO_HTTP_BASE_URL, FALLBACK_CATSCO_HTTP_BASE_URL);
+  return fallback ? fallback.replace(/\/$/, '') : undefined;
+}
+
+export function fallbackCatsCoServerUrl(value: unknown): string | undefined {
+  return replaceOrigin(value, PRIMARY_CATSCO_WS_URL.replace('/v0/channels', ''), FALLBACK_CATSCO_WS_URL.replace('/v0/channels', ''));
+}
+
+export function catsCoHttpBaseUrlCandidates(value: unknown): string[] {
+  const primary = String(value || '').trim().replace(/\/+$/, '');
+  if (!primary) return [];
+  const fallback = fallbackCatsCoHttpBaseUrl(primary);
+  return fallback && fallback !== primary ? [primary, fallback] : [primary];
+}
+
+export function catsCoServerUrlCandidates(value: unknown): string[] {
+  const primary = String(value || '').trim().replace(/\/+$/, '');
+  if (!primary) return [];
+  const fallback = fallbackCatsCoServerUrl(primary);
+  return fallback && fallback !== primary ? [primary, fallback] : [primary];
+}
+
+export function isCatsCoNetworkFailure(error: any): boolean {
+  const code = String(error?.cause?.code || error?.code || '').trim();
+  const message = String(error?.cause?.message || error?.message || '').trim();
+  return error?.name === 'AbortError'
+    || !Number.isFinite(Number(error?.status))
+      && (/ENOTFOUND|EAI_AGAIN|ECONNREFUSED|ETIMEDOUT|UND_ERR|ECONNRESET|EHOSTUNREACH|ENETUNREACH/i.test(code)
+        || /getaddrinfo|timed?out|timeout|socket|network|fetch failed|connect/i.test(message));
+}

--- a/src/catscompany/message-sender.ts
+++ b/src/catscompany/message-sender.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { Logger } from '../utils/logger';
 import { RuntimePlanSnapshot } from '../core/plan-runtime';
+import { catsCoHttpBaseUrlCandidates, isCatsCoNetworkFailure } from './endpoint-failover';
 
 const MAX_MSG_LENGTH = 4000;
 const IDEAL_REPLY_SEGMENT_LENGTH = 520;
@@ -153,16 +154,26 @@ export class MessageSender {
 
   private async sendViaHttp(body: CatsSendBody): Promise<{ seq_id: number }> {
     try {
-      const url = `${this.baseUrl}/api/messages/send`;
-      const res = await fetch(url, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `ApiKey ${this.apiKey}`,
-        },
-        body: JSON.stringify(body),
-        signal: AbortSignal.timeout(10000),
-      });
+      let res: Response | undefined;
+      const bases = catsCoHttpBaseUrlCandidates(this.baseUrl);
+      for (const base of bases) {
+        try {
+          res = await fetch(`${base}/api/messages/send`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': `ApiKey ${this.apiKey}`,
+            },
+            body: JSON.stringify(body),
+            signal: AbortSignal.timeout(10000),
+          });
+          break;
+        } catch (error: any) {
+          if (!isCatsCoNetworkFailure(error) || base === bases[bases.length - 1]) throw error;
+          Logger.warning('[CatsCompany] HTTP 消息兜底切换备用 app.catsco.cn endpoint');
+        }
+      }
+      if (!res) throw new Error('CatsCo HTTP endpoint unavailable');
 
       if (!res.ok) {
         const errText = await res.text();

--- a/src/catscompany/upload.ts
+++ b/src/catscompany/upload.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { Readable } from 'stream';
 import { Logger } from '../utils/logger';
+import { catsCoHttpBaseUrlCandidates, isCatsCoNetworkFailure } from './endpoint-failover';
 
 export type CatsUploadType = 'image' | 'file';
 
@@ -58,9 +59,8 @@ export async function uploadCatsLocalFile(options: {
     throw new Error(`不是可上传的文件: ${resolvedPath}`);
   }
 
-  const httpBaseUrl = options.httpBaseUrl.replace(/\/$/, '');
+  const httpBaseUrls = catsCoHttpBaseUrlCandidates(options.httpBaseUrl.replace(/\/$/, ''));
   const uploadType = options.type || inferCatsUploadType(resolvedPath);
-  const url = `${httpBaseUrl}/api/upload?type=${uploadType}`;
   const filename = path.basename(resolvedPath);
   const mimeType = MIME_BY_EXT[path.extname(filename).toLowerCase()] || 'application/octet-stream';
   const boundary = `----CatsCoFormBoundary${crypto.randomBytes(16).toString('hex')}`;
@@ -88,18 +88,30 @@ export async function uploadCatsLocalFile(options: {
   try {
     Logger.info(`[CatsCompany] 开始上传文件: ${filename}, type=${uploadType}, size=${stat.size} bytes, mime=${mimeType}`);
 
-    const requestInit: RequestInit & { duplex?: 'half' } = {
-      method: 'POST',
-      headers: {
-        Authorization: options.authHeader,
-        'Content-Type': `multipart/form-data; boundary=${boundary}`,
-        'Content-Length': String(contentLength),
-      },
-      body: Readable.from(multipartBody()) as any,
-      duplex: 'half',
-      signal: AbortSignal.timeout(options.timeoutMs || uploadTimeoutMs(stat.size)),
-    };
-    const res = await fetch(url, requestInit);
+    let res: Response | undefined;
+    let lastError: any;
+    for (const baseUrl of httpBaseUrls) {
+      const requestInit: RequestInit & { duplex?: 'half' } = {
+        method: 'POST',
+        headers: {
+          Authorization: options.authHeader,
+          'Content-Type': `multipart/form-data; boundary=${boundary}`,
+          'Content-Length': String(contentLength),
+        },
+        body: Readable.from(multipartBody()) as any,
+        duplex: 'half',
+        signal: AbortSignal.timeout(options.timeoutMs || uploadTimeoutMs(stat.size)),
+      };
+      try {
+        res = await fetch(`${baseUrl}/api/upload?type=${uploadType}`, requestInit);
+        break;
+      } catch (error: any) {
+        lastError = error;
+        if (!isCatsCoNetworkFailure(error) || baseUrl === httpBaseUrls[httpBaseUrls.length - 1]) throw error;
+        Logger.warning(`[CatsCompany] ${baseUrl} 上传链路不可用，切换备用域名 app.catsco.cn`);
+      }
+    }
+    if (!res) throw lastError || new Error('upload endpoint unavailable');
 
     if (!res.ok) {
       const errorText = await res.text();

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -105,13 +105,26 @@ import {
   bindWeixinChannelToCurrentAgent,
   getWeixinChannelStatus,
 } from '../weixin-channel-binding';
+import {
+  FALLBACK_CATSCO_HTTP_BASE_URL,
+  FALLBACK_CATSCO_WS_URL,
+  catsCoHttpBaseUrlCandidates,
+  isCatsCoNetworkFailure,
+} from '../../catscompany/endpoint-failover';
 // import { ReportGenerator } from '../../utils/report-generator';
 // import { LogUploader } from '../../utils/log-uploader';
 
 const DEFAULT_CATSCO_HTTP_BASE_URL = 'https://app.catsco.cc';
 const DEFAULT_CATSCO_WS_URL = 'wss://app.catsco.cc/v0/channels';
-const TRUSTED_CATSCO_HTTP_ORIGINS = new Set([new URL(DEFAULT_CATSCO_HTTP_BASE_URL).origin]);
+const TRUSTED_CATSCO_HTTP_ORIGINS = new Set([
+  new URL(DEFAULT_CATSCO_HTTP_BASE_URL).origin,
+  new URL(FALLBACK_CATSCO_HTTP_BASE_URL).origin,
+]);
 const TRUSTED_CATSCO_WS_URL = new URL(DEFAULT_CATSCO_WS_URL);
+const TRUSTED_CATSCO_WS_ORIGINS = new Set([
+  TRUSTED_CATSCO_WS_URL.origin,
+  new URL(FALLBACK_CATSCO_WS_URL).origin,
+]);
 const BUNDLED_SKILL_MARKER = '.xiaoba-bundled-skill.json';
 const SYSTEM_SKILL_DIRS = new Set<string>();
 const PROMPT_EDITOR_SKILL_NAME = 'catsco-prompt-editor';
@@ -327,7 +340,7 @@ function normalizeTrustedCatsServerUrl(value: unknown): string {
   }
 
   const pathname = url.pathname.replace(/\/+$/, '') || '/';
-  if (url.origin === TRUSTED_CATSCO_WS_URL.origin && pathname === TRUSTED_CATSCO_WS_URL.pathname) {
+  if (TRUSTED_CATSCO_WS_ORIGINS.has(url.origin) && pathname === TRUSTED_CATSCO_WS_URL.pathname) {
     return `${url.protocol}//${url.host}${pathname}`;
   }
   if (canUseLocalCatsCoEndpoint() && isLoopbackHost(url.hostname)) {
@@ -553,29 +566,36 @@ async function catsRequest(
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
   if (token) headers.Authorization = `Bearer ${token}`;
 
-  const controller = options.timeoutMs ? new AbortController() : undefined;
-  const timeout = controller
-    ? setTimeout(() => controller.abort(), options.timeoutMs)
-    : undefined;
-  let response: Response;
-
-  try {
-    response = await fetch(`${httpBaseUrl}${apiPath}`, {
-      method,
-      headers,
-      body: body === undefined ? undefined : JSON.stringify(body),
-      signal: controller?.signal,
-    });
-  } catch (error: any) {
-    if (error?.name === 'AbortError') {
-      const timeoutError = new Error(`连接 CatsCo/CatsCompany 服务 ${hostLabel(httpBaseUrl)} 超时`);
-      (timeoutError as any).status = 408;
-      throw timeoutError;
+  const candidates = catsCoHttpBaseUrlCandidates(httpBaseUrl);
+  let response: Response | undefined;
+  let lastNetworkError: Error | undefined;
+  for (const candidate of candidates) {
+    const controller = options.timeoutMs ? new AbortController() : undefined;
+    const timeout = controller
+      ? setTimeout(() => controller.abort(), options.timeoutMs)
+      : undefined;
+    try {
+      response = await fetch(`${candidate}${apiPath}`, {
+        method,
+        headers,
+        body: body === undefined ? undefined : JSON.stringify(body),
+        signal: controller?.signal,
+      });
+      break;
+    } catch (error: any) {
+      const normalized = error?.name === 'AbortError'
+        ? Object.assign(new Error(`连接 CatsCo/CatsCompany 服务 ${hostLabel(candidate)} 超时`), { status: 408 })
+        : createCatsNetworkError(error, candidate);
+      if (!isCatsCoNetworkFailure(error) || candidate === candidates[candidates.length - 1]) {
+        throw normalized;
+      }
+      lastNetworkError = normalized;
+      Logger.warning(`[CatsCo] ${hostLabel(candidate)} 不可用，切换备用域名 app.catsco.cn`);
+    } finally {
+      if (timeout) clearTimeout(timeout);
     }
-    throw createCatsNetworkError(error, httpBaseUrl);
-  } finally {
-    if (timeout) clearTimeout(timeout);
   }
+  if (!response) throw lastNetworkError || createCatsNetworkError(new Error('no endpoint'), httpBaseUrl);
 
   const text = await response.text();
   let data: any = {};
@@ -644,14 +664,27 @@ async function catsApiKeyRequest(
   apiKey: string,
   body?: unknown,
 ): Promise<any> {
-  const response = await fetch(`${httpBaseUrl}${apiPath}`, {
-    method,
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `ApiKey ${apiKey}`,
-    },
-    body: body === undefined ? undefined : JSON.stringify(body),
-  });
+  let response: Response | undefined;
+  let lastError: Error | undefined;
+  const candidates = catsCoHttpBaseUrlCandidates(httpBaseUrl);
+  for (const candidate of candidates) {
+    try {
+      response = await fetch(`${candidate}${apiPath}`, {
+        method,
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `ApiKey ${apiKey}`,
+        },
+        body: body === undefined ? undefined : JSON.stringify(body),
+      });
+      break;
+    } catch (error: any) {
+      lastError = createCatsNetworkError(error, candidate);
+      if (!isCatsCoNetworkFailure(error) || candidate === candidates[candidates.length - 1]) throw lastError;
+      Logger.warning(`[CatsCo] ${hostLabel(candidate)} 不可用，切换备用域名 app.catsco.cn`);
+    }
+  }
+  if (!response) throw lastError || createCatsNetworkError(new Error('no endpoint'), httpBaseUrl);
 
   const text = await response.text();
   let data: any = {};

--- a/tests/catsco-endpoint-failover.test.ts
+++ b/tests/catsco-endpoint-failover.test.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  FALLBACK_CATSCO_HTTP_BASE_URL,
+  FALLBACK_CATSCO_WS_URL,
+  PRIMARY_CATSCO_HTTP_BASE_URL,
+  catsCoHttpBaseUrlCandidates,
+  catsCoServerUrlCandidates,
+  fallbackCatsCoHttpBaseUrl,
+  fallbackCatsCoServerUrl,
+  isCatsCoNetworkFailure,
+} from '../src/catscompany/endpoint-failover';
+
+test('keeps cc canonical and derives only the explicit cn fallback', () => {
+  assert.equal(fallbackCatsCoHttpBaseUrl(PRIMARY_CATSCO_HTTP_BASE_URL), FALLBACK_CATSCO_HTTP_BASE_URL);
+  assert.equal(fallbackCatsCoServerUrl('wss://app.catsco.cc/v0/channels'), FALLBACK_CATSCO_WS_URL);
+  assert.deepEqual(catsCoHttpBaseUrlCandidates(PRIMARY_CATSCO_HTTP_BASE_URL), [
+    PRIMARY_CATSCO_HTTP_BASE_URL,
+    FALLBACK_CATSCO_HTTP_BASE_URL,
+  ]);
+  assert.deepEqual(catsCoServerUrlCandidates('wss://app.catsco.cc/v0/channels'), [
+    'wss://app.catsco.cc/v0/channels',
+    FALLBACK_CATSCO_WS_URL,
+  ]);
+});
+
+test('does not derive a fallback for arbitrary endpoints', () => {
+  assert.equal(fallbackCatsCoHttpBaseUrl('https://example.test'), undefined);
+  assert.equal(fallbackCatsCoServerUrl('wss://example.test/v0/channels'), undefined);
+  assert.deepEqual(catsCoHttpBaseUrlCandidates('https://example.test'), ['https://example.test']);
+});
+
+test('only network failures are eligible for failover', () => {
+  assert.equal(isCatsCoNetworkFailure(Object.assign(new Error('fetch failed'), { code: 'ECONNRESET' })), true);
+  assert.equal(isCatsCoNetworkFailure(Object.assign(new Error('bad credentials'), { status: 401 })), false);
+});

--- a/tests/electron-main-dashboard-url.test.ts
+++ b/tests/electron-main-dashboard-url.test.ts
@@ -89,7 +89,7 @@ test('electron registers catsco deep links and forwards connect codes to the loc
 
 test('electron sends trusted CatsCo links to the system browser', () => {
   assert.match(electronMain, /setWindowOpenHandler/);
-  assert.match(electronMain, /target\.origin === 'https:\/\/app\.catsco\.cc'/);
+  assert.match(electronMain, /TRUSTED_DEEP_LINK_BASE_ORIGINS\.has\(target\.origin\)/);
   assert.match(electronMain, /shell\.openExternal\(target\.toString\(\)\)/);
   assert.match(electronMain, /ipcMain\.handle\('catsco:open-webapp'/);
   assert.match(electronMain, /label: '打开 CatsCo WebApp'/);


### PR DESCRIPTION
Keeps app.catsco.cc as the canonical endpoint. XiaoBa retries only transport failures through the allow-listed app.catsco.cn endpoint; authentication and application errors do not fail over. Also accepts the .cn origin for desktop deep links and WebApp links during migration.