### PR TITLE
fix(catsco): terminate revoked topic runtimes

### DIFF
--- a/src/catscompany/client.ts
+++ b/src/catscompany/client.ts
@@ -139,6 +139,13 @@ export interface MessageContext {
   memberCount?: number; // 群成员数；用于运行时在创建 session 前兜底门控
 }
 
+export type GroupLifecycleKind = 'access_revoked' | 'disbanded';
+
+export interface GroupLifecycleEvent {
+  topic: string;
+  kind: GroupLifecycleKind;
+}
+
 export interface CatsAgentContextMessage {
   id: number;
   seq_id: number;
@@ -440,9 +447,7 @@ export class CatsClient extends EventEmitter {
         if (this.supportsThinToolRpc) {
           Logger.info('[CatsCompany] 服务端支持 thin_tool_rpc 轻量工具传输');
         }
-        this.emit('ready', { uid: this.uid, name: this.name });
-        this.autoAcceptFriendRequests().catch(console.error);
-        this.resubscribeTopics();
+        void this.finishReadyHandshake();
       } else if (msg.ctrl.id) {
         const pending = this.pendingAcks.get(msg.ctrl.id);
         if (pending) {
@@ -500,9 +505,59 @@ export class CatsClient extends EventEmitter {
         if (fromUserId) {
           this.acceptFriendRequest(fromUserId).catch(console.error);
         }
+      } else if (msg.pres.what === 'group_access_revoked' || msg.pres.what === 'group_disbanded') {
+        const topic = String(msg.pres.topic || msg.pres.src || '').trim();
+        if (topic.startsWith('grp_')) {
+          this.subscribedTopics.delete(topic);
+          this.emit('group_lifecycle', {
+            topic,
+            kind: msg.pres.what === 'group_disbanded' ? 'disbanded' : 'access_revoked',
+          } satisfies GroupLifecycleEvent);
+        }
       } else if (msg.pres.what && msg.pres.what !== 'on' && msg.pres.what !== 'off') {
         Logger.info(`[CatsCompany] 收到 presence: what=${msg.pres.what}, src=${msg.pres.src || '-'}`);
       }
+    }
+  }
+
+  private async finishReadyHandshake(): Promise<void> {
+    if ([...this.subscribedTopics].some(topic => topic.startsWith('grp_'))) {
+      await this.reconcileAccessibleGroupTopics();
+    }
+    this.emit('ready', { uid: this.uid, name: this.name });
+    this.autoAcceptFriendRequests().catch(console.error);
+    this.resubscribeTopics();
+  }
+
+  /**
+   * Reconciles only tracked group topics. A failed list request is fail-open:
+   * transient network errors must never terminate healthy local work.
+   */
+  async reconcileAccessibleGroupTopics(): Promise<void> {
+    try {
+      const res = await fetch(`${this.httpBaseUrl()}/api/conversations`, {
+        headers: { Authorization: `ApiKey ${this.config.apiKey}` },
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!res.ok) {
+        throw new Error(`CatsCompany conversation reconciliation failed: HTTP ${res.status}`);
+      }
+      const payload = await res.json() as { conversations?: Array<{ id?: string; is_group?: boolean }> };
+      const accessibleGroups = new Set(
+        (payload.conversations || [])
+          .filter(item => item?.is_group === true && String(item.id || '').startsWith('grp_'))
+          .map(item => String(item.id)),
+      );
+      for (const topic of [...this.subscribedTopics]) {
+        if (!topic.startsWith('grp_') || accessibleGroups.has(topic)) continue;
+        this.subscribedTopics.delete(topic);
+        this.emit('group_lifecycle', {
+          topic,
+          kind: 'access_revoked',
+        } satisfies GroupLifecycleEvent);
+      }
+    } catch (error: any) {
+      Logger.warning(`CatsCompany 群会话权限核对失败，保留当前订阅: ${error?.message || error}`);
     }
   }
 

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -114,7 +114,6 @@ interface QueuedMessage {
   runtimeFeedback?: RuntimeFeedbackInput[];
   nativeFeishuContext?: NativeFeishuContextHydration;
   clearGeneration?: number;
-  attempts?: number;
   deliveryOnly?: boolean;
   /** Immutable text produced by an already-completed model turn. */
   deliveryText?: string;
@@ -2324,7 +2323,7 @@ export class CatsCompanyBot {
     }
 
     if (!this.tryReserveSessionExecution(sessionKey, session)) {
-      this.enqueueSubAgentFeedback(sessionKey, topic, senderId, text, executionScope, 0, clearGeneration);
+      this.enqueueSubAgentFeedback(sessionKey, topic, senderId, text, executionScope, clearGeneration);
       Logger.info(`[${sessionKey}] 主会话忙，子智能体反馈已入队`);
       return;
     }
@@ -2361,7 +2360,7 @@ export class CatsCompanyBot {
         // flight. Do not deliver a reply, do not requeue, do not mark handled.
         Logger.info(`[${sessionKey}] destroy 已开始，丢弃迟到的子智能体反馈结果`);
       } else if (result.text === BUSY_MESSAGE) {
-        this.enqueueSubAgentFeedback(sessionKey, topic, senderId, text, executionScope, 0, clearGeneration);
+        this.enqueueSubAgentFeedback(sessionKey, topic, senderId, text, executionScope, clearGeneration);
         Logger.info(`[${sessionKey}] 主会话竞态忙碌，子智能体反馈已入队`);
       } else {
         subAgentManager.markResultObservationHandledForParent(sessionKey, text);
@@ -2417,7 +2416,6 @@ export class CatsCompanyBot {
     senderId: string,
     text: string,
     executionScope?: ParsedCatsMessage['executionScope'],
-    attempts = 0,
     clearGeneration = this.getSessionClearGeneration(sessionKey),
   ): void {
     const queue = this.messageQueue.get(sessionKey) ?? [];
@@ -2434,7 +2432,6 @@ export class CatsCompanyBot {
       receivedAt: Date.now(),
       source: 'subagent_feedback',
       clearGeneration,
-      attempts,
     });
     this.messageQueue.set(sessionKey, queue);
   }
@@ -3243,7 +3240,6 @@ export class CatsCompanyBot {
         }
       }
     } catch (err: any) {
-      const attempts = (msg.attempts ?? 0) + 1;
       if (clearGeneration !== this.getSessionClearGeneration(sessionKey)) {
         Logger.info(`[${sessionKey}] clear 后不再重试已出队的旧消息`);
       } else if (this.shuttingDown) {
@@ -3263,19 +3259,16 @@ export class CatsCompanyBot {
           executionScope: msg.executionScope,
           clearGeneration,
         });
-      } else if (attempts <= 2) {
-        const pending = this.messageQueue.get(sessionKey) ?? [];
-        pending.unshift({ ...msg, attempts });
-        this.messageQueue.set(sessionKey, pending);
-        retryLater = true;
-        Logger.warning(`[${sessionKey}] 队列消息执行异常，保留等待重试: ${err?.message || err}`);
       } else {
-          this.finishConversationTask(sessionKey, task, {
-            state: 'failed',
-            summary: '任务执行失败',
-            error: '任务执行失败',
-          });
-          Logger.error(`[${sessionKey}] 队列消息连续执行失败，停止重试: ${err?.message || err}`);
+        // Once a queued user turn has entered handleMessage(), the model work
+        // is never recreated by the business queue. AIService owns bounded
+        // retries inside that one request; this layer only closes the task.
+        this.finishConversationTask(sessionKey, task, {
+          state: 'failed',
+          summary: '任务执行失败',
+          error: '任务执行失败',
+        });
+        Logger.error(`[${sessionKey}] 队列消息执行失败，不重新进入模型: ${err?.message || err}`);
         if (clearGeneration === this.getSessionClearGeneration(sessionKey)) {
           await this.sender.reply(msg.topic, '处理消息时出错，请稍后重试。').catch(() => undefined);
         }

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -1,6 +1,7 @@
 import {
   CatsClient,
   MessageContext,
+  type GroupLifecycleEvent,
   type CatsAgentContextMessage,
   type CatsDeviceRpcMessage,
   type CatsSkillMutationGrantMessage,
@@ -20,6 +21,7 @@ import { MessageSessionManager } from '../core/message-session-manager';
 import {
   AgentServices,
   BUSY_MESSAGE,
+  type HandleMessageResult,
   type DurableRemoteContextEntry,
   RuntimeFeedbackInput,
   SessionCallbacks,
@@ -38,7 +40,7 @@ import { randomUUID } from 'crypto';
 import { hostname, platform } from 'os';
 import { ConfigManager } from '../utils/config';
 import { resolvePrimaryModelVisionCapability } from '../utils/model-capabilities';
-import { createCatsCoSessionRoute } from '../core/session-router';
+import { buildLegacyCatsCoSessionKey, createCatsCoSessionRoute } from '../core/session-router';
 import { ReadTool } from '../tools/read-tool';
 import { GlobTool } from '../tools/glob-tool';
 import { GrepTool } from '../tools/grep-tool';
@@ -114,7 +116,21 @@ interface QueuedMessage {
   clearGeneration?: number;
   attempts?: number;
   deliveryOnly?: boolean;
+  /** Immutable text produced by an already-completed model turn. */
+  deliveryText?: string;
+  /** Original observations represented by deliveryText; never processed by the model again. */
+  deliveryObservations?: string[];
   deliveryAttempts?: number;
+}
+
+interface DeliveryEnvelope {
+  sessionKey: string;
+  topic: string;
+  senderId: string;
+  text: string;
+  observations: string[];
+  executionScope?: ParsedCatsMessage['executionScope'];
+  clearGeneration: number;
 }
 
 interface ActiveConversationTask {
@@ -124,6 +140,7 @@ interface ActiveConversationTask {
 }
 
 interface SubAgentEventRoute {
+  sessionKey?: string;
   topic: string;
   channelSource?: string;
 }
@@ -148,6 +165,12 @@ interface BackgroundSubAgentCompletionBatch {
   items: Map<string, BackgroundSubAgentCompletionItem>;
   timer?: ReturnType<typeof setTimeout>;
 }
+
+export type TopicTerminationReason =
+  | 'access_revoked'
+  | 'group_disbanded'
+  | 'topic_forbidden'
+  | 'topic_not_found';
 
 const TYPING_HEARTBEAT_INTERVAL_MS = 5_000;
 const BACKGROUND_SUBAGENT_COMPLETION_DEBOUNCE_MS = 1_500;
@@ -432,6 +455,8 @@ export class CatsCompanyBot {
   private pendingAttachments = new Map<string, PendingAttachment[]>();
   /** 主会话忙时的消息队列，key = sessionKey */
   private messageQueue = new Map<string, QueuedMessage[]>();
+  /** Retry timers that may wake one message queue after a delivery failure. */
+  private messageQueueDrainTimers = new Map<string, Set<ReturnType<typeof setTimeout>>>();
   /** Serializes history hydration and all model turns for one CatsCo session. */
   private sessionExecutionReservations = new Set<string>();
   /** Serializes auxiliary status events so a terminal state cannot overtake its running state. */
@@ -448,6 +473,10 @@ export class CatsCompanyBot {
   private subAgentEventRoutes = new Map<string, SubAgentEventRoute>();
   /** no-wait 子 Agent 完成后的批量回流，避免逐条唤醒主模型刷屏 */
   private subAgentCompletionBatches = new Map<string, BackgroundSubAgentCompletionBatch>();
+  /** Serializes idempotent per-topic termination and fences immediate re-invites. */
+  private topicTerminationTasks = new Map<string, Promise<void>>();
+  /** Remains set after cleanup so duplicate revoke/disband events are no-ops. */
+  private terminatedTopicKeys = new Set<string>();
   /** Bot 自身的 uid，用于过滤自己发出的消息 */
   private botUid: string | null = null;
   private connectorReady = false;
@@ -499,7 +528,12 @@ export class CatsCompanyBot {
       httpBaseUrl: config.httpBaseUrl,
     });
 
-    this.sender = new MessageSender(this.bot, config.httpBaseUrl, config.apiKey);
+    this.sender = new MessageSender(this.bot, config.httpBaseUrl, config.apiKey, {
+      onTopicAccessRevoked: (topic, status) => this.terminateTopic(
+        topic,
+        status === 404 ? 'topic_not_found' : 'topic_forbidden',
+      ),
+    });
     this.localDeviceGrant = createCatsCoLocalDeviceGrant({
       bodyId: config.bodyId,
       installationId: config.installationId,
@@ -561,6 +595,14 @@ export class CatsCompanyBot {
       await this.onMessage(ctx);
     });
 
+    this.bot.on('group_lifecycle', async (event: GroupLifecycleEvent) => {
+      if (this.shuttingDown) return;
+      await this.terminateTopic(
+        event.topic,
+        event.kind === 'disbanded' ? 'group_disbanded' : 'access_revoked',
+      );
+    });
+
     this.bot.on('device_rpc_request', async (request: CatsDeviceRpcMessage) => {
       // Shutdown fence: destroy() 开始后拒绝新的设备 RPC，避免在销毁窗口内
       // 继续执行本地 write_file/edit_file/execute_shell 等副作用工具。
@@ -607,6 +649,7 @@ export class CatsCompanyBot {
       && Array.from(this.messageQueue.values()).every(queue => queue.length === 0)
       && this.cloudSessionRestorePromises.size === 0
       && this.subAgentCompletionBatches.size === 0
+      && (this.topicTerminationTasks?.size ?? 0) === 0
       && this.sessionManager.isIdle();
   }
 
@@ -1439,6 +1482,12 @@ export class CatsCompanyBot {
     if (!msg) return;
 
     const key = msg.envelope.sessionKey;
+    const pendingTermination = this.topicTerminationTasks?.get(key);
+    if (pendingTermination) await pendingTermination;
+    // A server-delivered message after termination is authoritative evidence
+    // that this bot was re-invited. It starts a fresh generation; no old work
+    // survives because terminateTopic already advanced the generation fence.
+    this.terminatedTopicKeys?.delete(key);
 
     this.activeMessageHandlers += 1;
     try {
@@ -1892,6 +1941,63 @@ export class CatsCompanyBot {
     });
   }
 
+  /**
+   * Owns every runtime side effect associated with one CatsCompany group.
+   * The generation is bumped synchronously before any await so late model,
+   * queue and child-agent callbacks become inert immediately.
+   */
+  private terminateTopic(topic: string, reason: TopicTerminationReason): Promise<void> {
+    const normalizedTopic = String(topic || '').trim();
+    if (!normalizedTopic.startsWith('grp_')) return Promise.resolve();
+    const sessionKey = buildLegacyCatsCoSessionKey('group', normalizedTopic, '');
+    const terminationTasks = this.topicTerminationTasks ??= new Map<string, Promise<void>>();
+    const existing = terminationTasks.get(sessionKey);
+    if (existing) return existing;
+    const terminatedTopicKeys = this.terminatedTopicKeys ??= new Set<string>();
+    if (terminatedTopicKeys.has(sessionKey)) return Promise.resolve();
+    terminatedTopicKeys.add(sessionKey);
+
+    this.bumpSessionClearGeneration(sessionKey);
+    this.pendingAttachments.delete(sessionKey);
+    this.messageQueue.delete(sessionKey);
+    this.clearMessageQueueDrainTimers(sessionKey);
+    this.sessionExecutionReservations.delete(sessionKey);
+
+    const restoreController = this.cloudSessionRestoreAbortControllers.get(sessionKey);
+    restoreController?.abort();
+    this.cloudSessionRestoreAbortControllers.delete(sessionKey);
+    this.cloudSessionRestorePromises.delete(sessionKey);
+
+    const batch = this.subAgentCompletionBatches.get(sessionKey);
+    if (batch?.timer) clearTimeout(batch.timer);
+    this.subAgentCompletionBatches.delete(sessionKey);
+
+    const subAgentManager = SubAgentManager.getInstance();
+    for (const [subAgentID, route] of this.subAgentEventRoutes) {
+      if (route.sessionKey === sessionKey || route.topic === normalizedTopic) {
+        this.subAgentEventRoutes.delete(subAgentID);
+      }
+    }
+    subAgentManager.stopAllForParent(sessionKey, `CatsCompany Topic 已终止: ${reason}`);
+
+    this.sessionManager.get(sessionKey)?.requestInterrupt();
+    this.cancelConversationTask(sessionKey, 'Topic 权限已结束，任务已停止');
+
+    const termination = this.sessionManager
+      .terminate(sessionKey, `CatsCompany Topic 已终止: ${reason}`)
+      .catch((error: any) => {
+        Logger.warning(`[${sessionKey}] Topic 终止清理失败: ${error?.message || error}`);
+      })
+      .finally(() => {
+        if (terminationTasks.get(sessionKey) === termination) {
+          terminationTasks.delete(sessionKey);
+        }
+      });
+    terminationTasks.set(sessionKey, termination);
+    Logger.warning(`[${sessionKey}] Topic 生命周期已终止: reason=${reason}`);
+    return termination;
+  }
+
   private enqueueConversationTaskStatus(
     task: ActiveConversationTask,
     status: Omit<ConversationTaskStatusInput, 'run_id'>,
@@ -2232,7 +2338,7 @@ export class CatsCompanyBot {
     };
 
     try {
-      const result = await session.handleRuntimeObservation(text, {
+      const result = await this.processObservationOnce(() => session.handleRuntimeObservation(text, {
         channel,
         callbacks: suppressFinalResponse ? undefined : this.buildSessionCallbacks(topic, {
           sessionKey,
@@ -2246,7 +2352,7 @@ export class CatsCompanyBot {
         localDeviceGrant: this.localDeviceGrant,
         deviceRpc: this.buildDeviceRpcTransport(),
         thinToolRpc: this.maybeBuildThinToolRpcTransport(),
-      });
+      }));
       if (clearGeneration !== this.getSessionClearGeneration(sessionKey)) {
         Logger.info(`[${sessionKey}] clear 后忽略旧子智能体反馈结果`);
       } else if (this.shuttingDown) {
@@ -2259,18 +2365,21 @@ export class CatsCompanyBot {
         Logger.info(`[${sessionKey}] 主会话竞态忙碌，子智能体反馈已入队`);
       } else {
         subAgentManager.markResultObservationHandledForParent(sessionKey, text);
-        if (result.text.startsWith('处理消息时出错:')) {
-          try {
-            await this.sender.reply(topic, result.text);
-          } catch (err: any) {
-            Logger.warning(`错误消息发送失败: ${err.message}`);
-          }
-        } else if (result.visibleToUser && result.text) {
-          try {
-            await this.sender.reply(topic, result.text);
-          } catch (err: any) {
-            Logger.warning(`子智能体结果回复发送失败: ${err.message}`);
-          }
+        const deliveryText = result.text.startsWith('处理消息时出错:')
+          ? result.text
+          : result.visibleToUser && result.text
+            ? result.text
+            : '';
+        if (deliveryText) {
+          await this.deliverEnvelope({
+            sessionKey,
+            topic,
+            senderId,
+            text: deliveryText,
+            observations: [text],
+            executionScope,
+            clearGeneration,
+          });
         }
       }
     } catch (err: any) {
@@ -2280,8 +2389,17 @@ export class CatsCompanyBot {
         if (this.shuttingDown) {
           Logger.info(`[${sessionKey}] destroy 已开始，跳过子智能体反馈失败重试`);
         } else {
-          this.enqueueSubAgentFeedback(sessionKey, topic, senderId, text, executionScope, 1, clearGeneration);
-          Logger.warning(`[${sessionKey}] 子智能体反馈执行异常，已入队重试: ${err?.message || err}`);
+          subAgentManager.markResultObservationHandledForParent(sessionKey, text);
+          Logger.warning(`[${sessionKey}] 子智能体反馈整合失败，改为固化结果投递: ${err?.message || err}`);
+          await this.deliverEnvelope({
+            sessionKey,
+            topic,
+            senderId,
+            text: `后台子任务已完成，但结果整合失败。原始结果仍可通过 check_subagent 查看。`,
+            observations: [text],
+            executionScope,
+            clearGeneration,
+          });
         }
       }
 
@@ -2319,6 +2437,61 @@ export class CatsCompanyBot {
       attempts,
     });
     this.messageQueue.set(sessionKey, queue);
+  }
+
+  /**
+   * The computation half of sub-agent result handling. Keeping this as an
+   * explicit boundary makes it impossible for delivery retries to accidentally
+   * call the model again.
+   */
+  private async processObservationOnce(
+    run: () => Promise<HandleMessageResult>,
+  ): Promise<HandleMessageResult> {
+    return run();
+  }
+
+  /**
+   * Deliver immutable output from an already-completed model turn. A failed
+   * network send queues this exact envelope; the queue is delivery-only and
+   * therefore cannot re-enter handleRuntimeObservation().
+   */
+  private async deliverEnvelope(envelope: DeliveryEnvelope): Promise<void> {
+    if (this.shuttingDown
+      || envelope.clearGeneration !== this.getSessionClearGeneration(envelope.sessionKey)) {
+      return;
+    }
+
+    try {
+      await this.sender.reply(envelope.topic, envelope.text);
+      return;
+    } catch (err: any) {
+      if (this.shuttingDown
+        || envelope.clearGeneration !== this.getSessionClearGeneration(envelope.sessionKey)) {
+        return;
+      }
+      Logger.warning(`[${envelope.sessionKey}] 固化结果投递失败，改为仅投递重试: ${err?.message || err}`);
+    }
+
+    const queue = this.messageQueue.get(envelope.sessionKey) ?? [];
+    queue.push({
+      userMessage: envelope.observations.join('\n\n'),
+      topic: envelope.topic,
+      senderId: envelope.senderId,
+      seq: 0,
+      executionScope: envelope.executionScope ?? createExecutionScope(createCatsCoMessageEnvelope({
+        topic: envelope.topic,
+        senderId: envelope.senderId,
+        text: envelope.text,
+      })),
+      receivedAt: Date.now(),
+      source: 'subagent_feedback',
+      clearGeneration: envelope.clearGeneration,
+      deliveryOnly: true,
+      deliveryText: envelope.text,
+      deliveryObservations: envelope.observations,
+      deliveryAttempts: 1,
+    });
+    this.messageQueue.set(envelope.sessionKey, queue);
   }
 
   private scheduleSubAgentCompletionBatch(
@@ -2416,7 +2589,7 @@ export class CatsCompanyBot {
       });
       stopTypingHeartbeat = this.startTypingHeartbeat(batch.topic);
 
-      const result = await session.handleRuntimeObservation(observation, {
+      const result = await this.processObservationOnce(() => session.handleRuntimeObservation(observation, {
         channel,
         callbacks: this.buildSessionCallbacks(batch.topic, {
           sessionKey,
@@ -2430,7 +2603,7 @@ export class CatsCompanyBot {
         localDeviceGrant: this.localDeviceGrant,
         deviceRpc: this.buildDeviceRpcTransport(),
         thinToolRpc: this.maybeBuildThinToolRpcTransport(),
-      });
+      }));
       if (batch.clearGeneration !== this.getSessionClearGeneration(sessionKey)) {
         Logger.info(`[${sessionKey}] clear 后忽略旧批量子任务回流结果`);
       } else if (this.shuttingDown) {
@@ -2453,10 +2626,22 @@ export class CatsCompanyBot {
           manager.markResultObservationHandledForParent(sessionKey, item.observation);
         }
 
+        let deliveryText = '';
         if (result.text.startsWith('处理消息时出错:')) {
-          await this.sender.reply(batch.topic, result.text);
+          deliveryText = result.text;
         } else if (result.visibleToUser && result.text) {
-          await this.sender.reply(batch.topic, result.text);
+          deliveryText = result.text;
+        }
+        if (deliveryText) {
+          await this.deliverEnvelope({
+            sessionKey,
+            topic: batch.topic,
+            senderId: batch.senderId,
+            text: deliveryText,
+            observations: items.map(item => item.observation),
+            executionScope: batch.executionScope,
+            clearGeneration: batch.clearGeneration,
+          });
         }
       }
     } catch (err: any) {
@@ -2469,28 +2654,22 @@ export class CatsCompanyBot {
         return;
       }
       const fallback = this.formatSubAgentCompletionNotice(items, activeSubAgents.length);
-      let fallbackDelivered = false;
-      if (fallback) {
-        try {
-          await this.sender.reply(batch.topic, fallback);
-          for (const item of items) {
-            manager.markResultObservationHandledForParent(sessionKey, item.observation);
-          }
-          fallbackDelivered = true;
-        } catch (sendErr: any) {
-          Logger.warning(`后台子任务兜底通知发送失败: ${sendErr.message}`);
-        }
+      // The observation turn already failed once. Freeze a deterministic
+      // envelope and never recreate the batch: delivery retries must not call
+      // the model again.
+      for (const item of items) {
+        manager.markResultObservationHandledForParent(sessionKey, item.observation);
       }
-      if (!fallbackDelivered && batch.clearGeneration === this.getSessionClearGeneration(sessionKey)) {
-        const pendingBatch = this.subAgentCompletionBatches.get(sessionKey);
-        if (pendingBatch && pendingBatch !== batch) {
-          for (const [itemKey, item] of batch.items) pendingBatch.items.set(itemKey, item);
-          pendingBatch.firstAt = Math.min(pendingBatch.firstAt, batch.firstAt);
-          this.rescheduleSubAgentCompletionBatch(sessionKey, pendingBatch);
-        } else {
-          this.subAgentCompletionBatches.set(sessionKey, batch);
-          this.rescheduleSubAgentCompletionBatch(sessionKey, batch);
-        }
+      if (fallback) {
+        await this.deliverEnvelope({
+          sessionKey,
+          topic: batch.topic,
+          senderId: batch.senderId,
+          text: fallback,
+          observations: items.map(item => item.observation),
+          executionScope: batch.executionScope,
+          clearGeneration: batch.clearGeneration,
+        });
       }
     } finally {
       this.releaseSessionExecution(sessionKey);
@@ -2703,7 +2882,7 @@ export class CatsCompanyBot {
 
     const eventType = String(event?.type || '');
     if (eventType === 'agent_spawned') {
-      this.subAgentEventRoutes.set(subAgentId, { topic, channelSource });
+      this.subAgentEventRoutes.set(subAgentId, { sessionKey, topic, channelSource });
     }
     const route = this.subAgentEventRoutes.get(subAgentId);
     const eventTopic = route?.topic || topic;
@@ -2851,6 +3030,27 @@ export class CatsCompanyBot {
     };
   }
 
+  private scheduleMessageQueueDrain(sessionKey: string, delayMs: number): void {
+    const timerRegistry = this.messageQueueDrainTimers ??= new Map<string, Set<ReturnType<typeof setTimeout>>>();
+    const timers = timerRegistry.get(sessionKey) ?? new Set<ReturnType<typeof setTimeout>>();
+    let timer: ReturnType<typeof setTimeout>;
+    timer = setTimeout(() => {
+      timers.delete(timer);
+      if (timers.size === 0) timerRegistry.delete(sessionKey);
+      void this.drainMessageQueue(sessionKey);
+    }, delayMs);
+    timer.unref?.();
+    timers.add(timer);
+    timerRegistry.set(sessionKey, timers);
+  }
+
+  private clearMessageQueueDrainTimers(sessionKey: string): void {
+    const timers = this.messageQueueDrainTimers?.get(sessionKey);
+    if (!timers) return;
+    for (const timer of timers) clearTimeout(timer);
+    this.messageQueueDrainTimers.delete(sessionKey);
+  }
+
   /**
    * 排空消息队列：将忙时积压的消息合并为一条，一次性处理
    */
@@ -2871,7 +3071,7 @@ export class CatsCompanyBot {
     }
 
     const subAgentManager = SubAgentManager.getInstance();
-    const queuedResultObservationHandling = msg.source === 'subagent_feedback'
+    const queuedResultObservationHandling = msg.source === 'subagent_feedback' && !msg.deliveryOnly
       ? subAgentManager.getResultObservationHandlingForParent(sessionKey, msg.userMessage as string)
       : 'silent';
     if (queuedResultObservationHandling === 'drop') {
@@ -2884,6 +3084,7 @@ export class CatsCompanyBot {
 
     const session = this.sessionManager.getOrCreate(sessionKey);
     const suppressSubAgentFinalResponse = msg.source === 'subagent_feedback'
+      && !msg.deliveryOnly
       && queuedResultObservationHandling !== 'notify'
       && shouldSuppressSubAgentObservationReply(msg.userMessage as string);
     if (suppressSubAgentFinalResponse) {
@@ -2903,10 +3104,13 @@ export class CatsCompanyBot {
     if (msg.source === 'subagent_feedback' && msg.deliveryOnly) {
       queue.shift();
       if (queue.length === 0) this.messageQueue.delete(sessionKey);
-      const fallback = `后台子任务已完成，但暂时无法写入主会话上下文：\n\n${String(msg.userMessage)}`;
+      const fallback = msg.deliveryText
+        ?? `后台子任务已完成，但暂时无法写入主会话上下文：\n\n${String(msg.userMessage)}`;
       try {
         await this.sender.reply(msg.topic, fallback);
-        subAgentManager.markResultObservationHandledForParent(sessionKey, msg.userMessage as string);
+        for (const observation of msg.deliveryObservations ?? [String(msg.userMessage)]) {
+          subAgentManager.markResultObservationHandledForParent(sessionKey, observation);
+        }
         await this.drainMessageQueue(sessionKey);
       } catch (err: any) {
         const deliveryAttempts = (msg.deliveryAttempts ?? 0) + 1;
@@ -2917,8 +3121,7 @@ export class CatsCompanyBot {
           this.messageQueue.set(sessionKey, pending);
           const retryDelay = BACKGROUND_SUBAGENT_COMPLETION_DEBOUNCE_MS * (2 ** (deliveryAttempts - 1));
           Logger.warning(`[${sessionKey}] 子智能体结果兜底通知发送失败，将在 ${retryDelay}ms 后重试: ${err?.message || err}`);
-          const timer = setTimeout(() => void this.drainMessageQueue(sessionKey), retryDelay);
-          timer.unref?.();
+          this.scheduleMessageQueueDrain(sessionKey, retryDelay);
         } else {
           Logger.error(`[${sessionKey}] 子智能体结果兜底通知连续失败 ${deliveryAttempts} 次，已停止重试: ${err?.message || err}`);
         }
@@ -2958,7 +3161,7 @@ export class CatsCompanyBot {
           if (!task) return;
         }
         const result = msg.source === 'subagent_feedback'
-          ? await session.handleRuntimeObservation(msg.userMessage as string, {
+          ? await this.processObservationOnce(() => session.handleRuntimeObservation(msg.userMessage as string, {
             channel,
             callbacks: suppressSubAgentFinalResponse ? undefined : this.buildSessionCallbacks(msg.topic, {
               sessionKey,
@@ -2974,7 +3177,7 @@ export class CatsCompanyBot {
             targetRoutes: msg.targetRoutes,
             deviceRpc: this.buildDeviceRpcTransport(),
             thinToolRpc: this.maybeBuildThinToolRpcTransport(),
-          })
+          }))
           : await session.handleMessage(msg.userMessage, {
             channel,
             executionScope: msg.executionScope,
@@ -3010,25 +3213,33 @@ export class CatsCompanyBot {
           Logger.info(`[${sessionKey}] 队列执行遇到竞态忙碌，消息保留等待重试`);
         } else {
           let replyDelivered = true;
-          if (result.text.startsWith('处理消息时出错:')) {
+          const deliveryText = result.text.startsWith('处理消息时出错:')
+            ? result.text
+            : result.visibleToUser && result.text
+              ? result.text
+              : '';
+          if (msg.source === 'subagent_feedback') {
+            subAgentManager.markResultObservationHandledForParent(sessionKey, msg.userMessage as string);
+          }
+          if (deliveryText && msg.source === 'subagent_feedback') {
+            await this.deliverEnvelope({
+              sessionKey,
+              topic: msg.topic,
+              senderId: msg.senderId,
+              text: deliveryText,
+              observations: [String(msg.userMessage)],
+              executionScope: msg.executionScope,
+              clearGeneration,
+            });
+          } else if (deliveryText) {
             try {
-              await this.sender.reply(msg.topic, result.text);
-            } catch (err: any) {
-              replyDelivered = false;
-              Logger.warning(`错误消息发送失败: ${err.message}`);
-            }
-          } else if (result.visibleToUser && result.text) {
-            try {
-              await this.sender.reply(msg.topic, result.text);
+              await this.sender.reply(msg.topic, deliveryText);
             } catch (err: any) {
               replyDelivered = false;
               Logger.warning(`队列消息回复发送失败: ${err.message}`);
             }
           }
           this.finishConversationTask(sessionKey, task, this.taskStatusForResult(result, replyDelivered));
-          if (msg.source === 'subagent_feedback') {
-            subAgentManager.markResultObservationHandledForParent(sessionKey, msg.userMessage as string);
-          }
         }
       }
     } catch (err: any) {
@@ -3039,6 +3250,19 @@ export class CatsCompanyBot {
         // Shutdown fence: destroy() 已开始时不再重试或发送错误提示，避免越过
         // 销毁边界继续产生副作用。
         Logger.info(`[${sessionKey}] destroy 已开始，跳过队列消息失败重试`);
+      } else if (msg.source === 'subagent_feedback') {
+        // A sub-agent observation is computed at most once. If computation
+        // fails, freeze a deterministic notice and retry only its delivery.
+        subAgentManager.markResultObservationHandledForParent(sessionKey, msg.userMessage as string);
+        await this.deliverEnvelope({
+          sessionKey,
+          topic: msg.topic,
+          senderId: msg.senderId,
+          text: `后台子任务已完成，但结果整合失败。原始结果仍可通过 check_subagent 查看。`,
+          observations: [String(msg.userMessage)],
+          executionScope: msg.executionScope,
+          clearGeneration,
+        });
       } else if (attempts <= 2) {
         const pending = this.messageQueue.get(sessionKey) ?? [];
         pending.unshift({ ...msg, attempts });
@@ -3052,12 +3276,7 @@ export class CatsCompanyBot {
             error: '任务执行失败',
           });
           Logger.error(`[${sessionKey}] 队列消息连续执行失败，停止重试: ${err?.message || err}`);
-        if (msg.source === 'subagent_feedback') {
-          const pending = this.messageQueue.get(sessionKey) ?? [];
-          pending.unshift({ ...msg, attempts, deliveryOnly: true });
-          this.messageQueue.set(sessionKey, pending);
-          retryLater = true;
-        } else if (clearGeneration === this.getSessionClearGeneration(sessionKey)) {
+        if (clearGeneration === this.getSessionClearGeneration(sessionKey)) {
           await this.sender.reply(msg.topic, '处理消息时出错，请稍后重试。').catch(() => undefined);
         }
       }
@@ -3067,8 +3286,7 @@ export class CatsCompanyBot {
     }
 
     if (retryLater) {
-      const timer = setTimeout(() => void this.drainMessageQueue(sessionKey), 100);
-      timer.unref?.();
+      this.scheduleMessageQueueDrain(sessionKey, 100);
       return;
     }
     await this.drainMessageQueue(sessionKey);
@@ -3186,8 +3404,12 @@ export class CatsCompanyBot {
     // 保证 shutdown 开始后 drainMessageQueue / beginConversationTask 不再消费或新建任务。
     this.pendingAttachments.clear();
     this.messageQueue.clear();
+    for (const sessionKey of this.messageQueueDrainTimers?.keys() ?? []) {
+      this.clearMessageQueueDrainTimers(sessionKey);
+    }
     this.sessionExecutionReservations?.clear();
     this.sessionClearGenerations?.clear();
+    this.terminatedTopicKeys?.clear();
     for (const controller of this.cloudSessionRestoreAbortControllers?.values() ?? []) controller.abort();
     this.cloudSessionRestoreAbortControllers?.clear();
     this.subAgentEventRoutes.clear();
@@ -3205,6 +3427,8 @@ export class CatsCompanyBot {
     // cloud restore / hydration) that resume after shutdown cannot start the
     // model (review 2026-08-05).
     await this.waitForActiveHandlersToQuiesce();
+    await Promise.allSettled([...(this.topicTerminationTasks?.values() ?? [])]);
+    this.topicTerminationTasks?.clear();
     // Stop any still-running sub-agents up front. Their own model turns do not
     // pass through runTrackedConversationWork (they run inside the agent
     // session), so an active sub-agent could otherwise keep calling the model

--- a/src/catscompany/message-sender.ts
+++ b/src/catscompany/message-sender.ts
@@ -19,6 +19,10 @@ export interface ConversationTaskStatusInput {
   error?: string;
 }
 
+export interface MessageSenderOptions {
+  onTopicAccessRevoked?: (topic: string, status: 403 | 404) => void | Promise<void>;
+}
+
 interface CatsSendBody {
   topic_id: string;
   client_msg_id?: string;
@@ -107,7 +111,12 @@ export class MessageSender {
   private readonly baseUrl: string;
   private readonly apiKey: string;
 
-  constructor(private bot: CatsClient, baseUrl?: string, apiKey?: string) {
+  constructor(
+    private bot: CatsClient,
+    baseUrl?: string,
+    apiKey?: string,
+    private readonly options: MessageSenderOptions = {},
+  ) {
     this.baseUrl = baseUrl || 'https://app.catsco.cc';
     this.apiKey = apiKey || '';
   }
@@ -133,6 +142,9 @@ export class MessageSender {
       const seq = await this.bot.sendStructuredMessage(body);
       return { seq_id: seq };
     } catch (err: any) {
+      if (err instanceof CatsSendError && err.kind === 'ack' && (err.code === 403 || err.code === 404)) {
+        await this.notifyTopicAccessRevoked(topic, err.code);
+      }
       if (err instanceof CatsSendError && (err.kind === 'transport' || err.retryableWithHttp)) {
         if (err.clientMsgID) {
           body.client_msg_id = err.clientMsgID;
@@ -166,6 +178,9 @@ export class MessageSender {
 
       if (!res.ok) {
         const errText = await res.text();
+        if (res.status === 403 || res.status === 404) {
+          await this.notifyTopicAccessRevoked(body.topic_id, res.status);
+        }
         throw new Error(describeHttpFailure(res.status, errText));
       }
 
@@ -174,6 +189,14 @@ export class MessageSender {
     } catch (err: any) {
       Logger.error(`HTTP 兜底发送失败（${describeMessage(body)}）：${describeHttpException(err)}`);
       throw err;
+    }
+  }
+
+  private async notifyTopicAccessRevoked(topic: string, status: 403 | 404): Promise<void> {
+    try {
+      await this.options.onTopicAccessRevoked?.(topic, status);
+    } catch (error: any) {
+      Logger.warning(`[${topic}] Topic 权限终止回调失败: ${error?.message || error}`);
     }
   }
 

--- a/src/core/message-session-manager.ts
+++ b/src/core/message-session-manager.ts
@@ -29,6 +29,7 @@ export class MessageSessionManager {
   private static managers = new Map<string, MessageSessionManager>();
   private sessions = new Map<string, AgentSession>();
   private destroying = new Set<string>();
+  private terminationTasks = new Map<string, Promise<void>>();
   private cleanupTimer: ReturnType<typeof setInterval> | null = null;
   private ttl: number;
   private contextInjector: ((session: AgentSession) => void) | null = null;
@@ -115,6 +116,39 @@ export class MessageSessionManager {
     return true;
   }
 
+  /**
+   * Terminates one live session without deleting its persisted history.
+   * The caller owns platform queues/timers; this method owns the AgentSession
+   * and its child-agent cleanup.
+   */
+  async terminate(input: SessionKeyInput, reason = '会话生命周期结束'): Promise<void> {
+    const { key } = this.normalizeSessionInput(input);
+    const existing = this.terminationTasks.get(key);
+    if (existing) return existing;
+    if (this.destroying.has(key)) return;
+
+    const session = this.sessions.get(key);
+    this.destroying.add(key);
+    this.sessions.delete(key);
+    const task = Promise.resolve().then(async () => {
+      try {
+        SubAgentManager.getInstance().stopAllForParent(key, reason);
+        if (!session) return;
+        session.requestInterrupt();
+        await session.cleanup({
+          stopSubAgents: true,
+          subAgentStopReason: reason,
+        });
+        session.runWithLogContext(() => Logger.info(`会话已终止: ${key}, reason=${reason}`));
+      } finally {
+        this.destroying.delete(key);
+        this.terminationTasks.delete(key);
+      }
+    });
+    this.terminationTasks.set(key, task);
+    return task;
+  }
+
   private normalizeSessionInput(input: SessionKeyInput): { key: string; route?: SessionRoute } {
     if (isSessionRoute(input)) {
       return { key: input.sessionKey, route: input };
@@ -161,6 +195,8 @@ export class MessageSessionManager {
       clearInterval(this.cleanupTimer);
       this.cleanupTimer = null;
     }
+
+    await Promise.allSettled(this.terminationTasks.values());
 
     // 保存所有活跃会话
     const cleanupPromises = Array.from(this.sessions.values()).map(session =>

--- a/src/utils/ai-service.ts
+++ b/src/utils/ai-service.ts
@@ -24,6 +24,7 @@ import {
   attachRetrySummary,
   captureModelErrorDiagnostics,
 } from './model-error-observability';
+import { createHash } from 'crypto';
 
 /**
  * AI 服务 - 统一的 AI 调用入口
@@ -79,6 +80,8 @@ interface ModelAttemptRun {
 }
 
 export class AIService {
+  /** Process-wide: one rejected credential must stop every runtime using it. */
+  private static readonly openAuthCircuits = new Set<string>();
   private config: ChatConfig;
   private provider: AIProvider;
 
@@ -150,6 +153,7 @@ export class AIService {
     if (!this.config.apiKey) {
       throw new Error('API密钥未配置。请先运行: catsco config');
     }
+    this.assertAuthCircuitClosed();
 
     const prepared = this.prepareProviderRequest(messages);
     try {
@@ -161,6 +165,7 @@ export class AIService {
         this.createModelAttemptRun(prepared.messages, tools, false, options, prepared.summary),
       );
     } catch (error: any) {
+      this.openAuthCircuitIfRejected(error);
       throw this.wrapError(error);
     }
   }
@@ -179,6 +184,7 @@ export class AIService {
     if (!this.config.apiKey) {
       throw new Error('API密钥未配置。请先运行: catsco config');
     }
+    this.assertAuthCircuitClosed();
 
     const allowStreamRetry = process.env.GAUZ_STREAM_RETRY === 'true';
     const prepared = this.prepareProviderRequest(messages);
@@ -220,6 +226,7 @@ export class AIService {
       callbacks?.onComplete?.(result);
       return result;
     } catch (error: any) {
+      this.openAuthCircuitIfRejected(error);
       const wrapped = this.wrapError(error);
       callbacks?.onError?.(wrapped);
       throw wrapped;
@@ -236,6 +243,44 @@ export class AIService {
         if (text) onText(text);
       },
     };
+  }
+
+  private authCircuitKey(): string {
+    return createHash('sha256')
+      .update(`${this.config.provider ?? ''}\0${this.config.apiUrl ?? ''}\0${this.config.apiKey ?? ''}`)
+      .digest('hex');
+  }
+
+  private assertAuthCircuitClosed(): void {
+    if (!AIService.openAuthCircuits.has(this.authCircuitKey())) return;
+    const error = new Error('模型认证已被上游拒绝；认证熔断已打开，请更新凭据并重建运行时。');
+    (error as Error & { status?: number; code?: string }).status = 401;
+    (error as Error & { status?: number; code?: string }).code = 'AUTH_CIRCUIT_OPEN';
+    throw error;
+  }
+
+  private openAuthCircuitIfRejected(error: any): void {
+    const status = this.extractStatus(error);
+    if (status !== null) {
+      if (status !== 401) return;
+    } else {
+      const message = [
+        error?.response?.data?.error?.code,
+        error?.response?.data?.error?.type,
+        error?.response?.data?.error?.message,
+        error?.error?.code,
+        error?.error?.type,
+        error?.error?.message,
+        error?.code,
+        error?.message,
+      ].filter(Boolean).join(' ');
+      if (!/auth(?:entication)?[_\s-]?(?:invalid|error|failed)|invalid[_\s-]?api[_\s-]?key|unauthorized/i.test(message)) {
+        return;
+      }
+    }
+
+    AIService.openAuthCircuits.add(this.authCircuitKey());
+    Logger.error(`模型认证熔断已打开 | Provider: ${this.config.provider} | Model: ${this.config.model}`);
   }
 
   private prepareProviderRequest(messages: Message[]): ReturnType<typeof prepareProviderRequestMessages> {

--- a/tests/ai-service.test.ts
+++ b/tests/ai-service.test.ts
@@ -670,6 +670,56 @@ test('AIService records when stream output prevents an otherwise retryable reque
   assert.equal(diagnostics?.retry?.stop_reason, 'stream_output_started');
 });
 
+test('AIService opens a process-wide auth circuit after the first 401', async () => {
+  const config = {
+    provider: 'openai' as const,
+    apiUrl: 'https://auth-circuit.example.test/v1',
+    apiKey: 'auth-circuit-unique-key',
+    model: 'auth-circuit-model',
+  };
+  let providerCalls = 0;
+  const rejectedProvider = {
+    chat: async () => {
+      providerCalls += 1;
+      throw Object.assign(new Error('invalid api key'), { status: 401 });
+    },
+    chatStream: async () => ({ content: 'unused' }),
+  };
+
+  const first = new AIService(config);
+  (first as any).provider = rejectedProvider;
+  await assert.rejects(() => first.chat([]), /API错误 \(401\)/);
+
+  const second = new AIService(config);
+  (second as any).provider = rejectedProvider;
+  await assert.rejects(() => second.chat([]), /认证熔断已打开/);
+  assert.equal(providerCalls, 1, 'open circuit must reject locally without another provider call');
+});
+
+test('AIService does not open the auth circuit for transient 502 failures', async () => {
+  const service = new AIService({
+    provider: 'openai',
+    apiUrl: 'https://transient-circuit.example.test/v1',
+    apiKey: 'transient-circuit-unique-key',
+    model: 'transient-circuit-model',
+  });
+  let providerCalls = 0;
+  (service as any).provider = {
+    chat: async () => {
+      providerCalls += 1;
+      if (providerCalls <= 3) {
+        throw Object.assign(new Error('bad gateway'), { status: 502 });
+      }
+      return { content: 'recovered' };
+    },
+    chatStream: async () => ({ content: 'unused' }),
+  };
+
+  const result = await service.chat([]);
+  assert.equal(result.content, 'recovered');
+  assert.ok(providerCalls > 1, 'transient failures should keep the bounded provider retry path');
+});
+
 function createTestService(): AIService {
   return new AIService({
     provider: 'openai',

--- a/tests/catscompany-content-blocks.test.ts
+++ b/tests/catscompany-content-blocks.test.ts
@@ -1491,10 +1491,12 @@ describe('CatsCo content blocks', () => {
     assert.deepStrictEqual(replies, []);
   });
 
-  test('keeps a completion batch when both model回流 and fallback delivery fail', async () => {
+  test('freezes one delivery envelope when model integration and delivery fail', async () => {
     const { bot, session } = createProcessHarness();
     const sessionKey = 'session:v2:catscompany:p2p:p2p_38_110:agent:usr43';
+    let modelCalls = 0;
     session.handleRuntimeObservation = async () => {
+      modelCalls += 1;
       throw new Error('model observation failed');
     };
     bot.sender.reply = async () => {
@@ -1509,11 +1511,41 @@ describe('CatsCo content blocks', () => {
     );
     await (bot as any).flushSubAgentCompletionBatch(sessionKey, true);
 
-    const retained = bot.subAgentCompletionBatches.get(sessionKey);
-    assert.ok(retained);
-    assert.equal(retained.items.size, 1);
-    if (retained.timer) clearTimeout(retained.timer);
-    bot.subAgentCompletionBatches.delete(sessionKey);
+    assert.equal(modelCalls, 1, 'delivery failure must never recreate the model observation');
+    assert.equal(bot.subAgentCompletionBatches.has(sessionKey), false);
+    const retained = bot.messageQueue.get(sessionKey);
+    assert.equal(retained?.length, 1);
+    assert.equal(retained?.[0].deliveryOnly, true);
+    assert.match(retained?.[0].deliveryText ?? '', /后台子任务已回传/);
+  });
+
+  test('delivery-only subagent envelopes stop after three total send attempts', async () => {
+    const { bot, session } = createProcessHarness();
+    const sessionKey = 'session:v2:catscompany:p2p:p2p_38_110:agent:usr43';
+    let modelCalls = 0;
+    let deliveryCalls = 0;
+    session.handleRuntimeObservation = async () => {
+      modelCalls += 1;
+      return { visibleToUser: true, text: '固化后的结果' };
+    };
+    bot.sender.reply = async () => {
+      deliveryCalls += 1;
+      throw new Error('network unavailable');
+    };
+
+    await bot.handleSubAgentFeedback(
+      sessionKey,
+      'p2p_38_110',
+      'usr38',
+      '[子agent1 已完成]\n任务：审查\n结果摘要：审查完成',
+    );
+    await bot.flushSubAgentCompletionBatch(sessionKey, true);
+    await bot.drainMessageQueue(sessionKey);
+
+    assert.equal(modelCalls, 1);
+    assert.equal(deliveryCalls, 3);
+    assert.equal(bot.messageQueue.has(sessionKey), false);
+    assert.equal(bot.subAgentCompletionBatches.has(sessionKey), false);
   });
 
   test('drops an in-flight completion batch result when clear advances its generation', async () => {

--- a/tests/catscompany-execution-scope-flow.test.ts
+++ b/tests/catscompany-execution-scope-flow.test.ts
@@ -542,13 +542,12 @@ describe('CatsCompany execution scope flow', () => {
     assert.equal(harness.bot.messageQueue.has(sessionKey), false);
   });
 
-  test('retries direct subagent feedback through the queue after a rejected call', async () => {
+  test('does not re-enter the model after a rejected direct subagent observation', async () => {
     const harness = createHarness();
     let calls = 0;
     harness.session.handleRuntimeObservation = async () => {
       calls++;
-      if (calls === 1) throw new Error('transient observation failure');
-      return { visibleToUser: false, text: '' };
+      throw new Error('transient observation failure');
     };
 
     await harness.bot.handleSubAgentFeedback(
@@ -559,11 +558,12 @@ describe('CatsCompany execution scope flow', () => {
       createExecutionScope(createCatsCoMessageEnvelope({ topic: 'grp_80', senderId: 'usr8', text: 'observation' })),
     );
 
-    assert.equal(calls, 2);
+    assert.equal(calls, 1);
+    assert.match(harness.replies.at(-1) || '', /check_subagent/);
     assert.equal(harness.bot.messageQueue.has('cc_group:grp_80'), false);
   });
 
-  test('falls back to a user-visible subagent result after model injection retries are exhausted', async () => {
+  test('falls back to a user-visible envelope after one failed model integration', async () => {
     const harness = createHarness();
     let calls = 0;
     harness.session.handleRuntimeObservation = async () => {
@@ -582,8 +582,8 @@ describe('CatsCompany execution scope flow', () => {
     await harness.bot.drainMessageQueue(sessionKey);
     await harness.bot.drainMessageQueue(sessionKey);
 
-    assert.equal(calls, 3);
-    assert.match(harness.replies.at(-1) || '', /需要保留的普通 observation/);
+    assert.equal(calls, 1);
+    assert.match(harness.replies.at(-1) || '', /check_subagent/);
     assert.equal(harness.bot.messageQueue.has(sessionKey), false);
   });
 

--- a/tests/catscompany-execution-scope-flow.test.ts
+++ b/tests/catscompany-execution-scope-flow.test.ts
@@ -512,14 +512,12 @@ describe('CatsCompany execution scope flow', () => {
     assert.equal(handledTurns[0].options.artifactContextRef, ref);
   });
 
-  test('keeps a drained user message queued when the session call rejects once', async () => {
+  test('does not re-enter the model when a drained user turn rejects', async () => {
     const harness = createHarness({ busy: true });
     let calls = 0;
-    harness.session.handleMessage = async (userMessage: unknown, options: any) => {
+    harness.session.handleMessage = async () => {
       calls++;
-      if (calls === 1) throw new Error('transient session failure');
-      harness.handledTurns.push({ userMessage, options });
-      return { visibleToUser: false, text: '' };
+      throw new Error('session failure after model entry');
     };
 
     await harness.bot.onMessage({
@@ -534,12 +532,11 @@ describe('CatsCompany execution scope flow', () => {
     harness.session.setBusy(false);
     const sessionKey = 'session:v2:catscompany:p2p:p2p_8_43:agent:usr43';
     await harness.bot.drainMessageQueue(sessionKey);
-    assert.equal(harness.bot.messageQueue.get(sessionKey)?.length, 1);
-
     await harness.bot.drainMessageQueue(sessionKey);
-    assert.equal(calls, 2);
-    assert.equal(harness.handledTurns.length, 1);
+
+    assert.equal(calls, 1);
     assert.equal(harness.bot.messageQueue.has(sessionKey), false);
+    assert.match(harness.replies.at(-1) || '', /处理消息时出错/);
   });
 
   test('does not re-enter the model after a rejected direct subagent observation', async () => {

--- a/tests/catscompany-group-lifecycle.test.ts
+++ b/tests/catscompany-group-lifecycle.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import { CatsClient, type GroupLifecycleEvent } from '../src/catscompany/client';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function createClient(): CatsClient {
+  return new CatsClient({
+    serverUrl: 'ws://127.0.0.1:1',
+    httpBaseUrl: 'https://app.example.test',
+    apiKey: 'cc-test-key',
+    bodyId: 'body-test',
+  });
+}
+
+describe('CatsCompany group lifecycle', () => {
+  test('forwards access-revoked and disbanded presence events', () => {
+    const client = createClient();
+    const events: GroupLifecycleEvent[] = [];
+    client.on('group_lifecycle', event => events.push(event));
+    (client as any).subscribedTopics.add('grp_revoked');
+    (client as any).subscribedTopics.add('grp_disbanded');
+
+    (client as any).handleMessage({
+      pres: { what: 'group_access_revoked', topic: 'grp_revoked', src: 'grp_revoked' },
+    });
+    (client as any).handleMessage({
+      pres: { what: 'group_disbanded', topic: 'grp_disbanded', src: 'grp_disbanded' },
+    });
+
+    assert.deepEqual(events, [
+      { topic: 'grp_revoked', kind: 'access_revoked' },
+      { topic: 'grp_disbanded', kind: 'disbanded' },
+    ]);
+    assert.equal((client as any).subscribedTopics.size, 0);
+  });
+
+  test('reconnect reconciliation terminates only inaccessible tracked groups', async () => {
+    const client = createClient();
+    const events: GroupLifecycleEvent[] = [];
+    client.on('group_lifecycle', event => events.push(event));
+    (client as any).subscribedTopics.add('grp_still_member');
+    (client as any).subscribedTopics.add('grp_removed_while_offline');
+    (client as any).subscribedTopics.add('p2p_1_2');
+    globalThis.fetch = (async () => Response.json({
+      conversations: [
+        { id: 'grp_still_member', is_group: true },
+        { id: 'p2p_1_2', is_group: false },
+      ],
+    })) as any;
+
+    await client.reconcileAccessibleGroupTopics();
+
+    assert.deepEqual(events, [
+      { topic: 'grp_removed_while_offline', kind: 'access_revoked' },
+    ]);
+    assert.deepEqual(
+      [...(client as any).subscribedTopics].sort(),
+      ['grp_still_member', 'p2p_1_2'],
+    );
+  });
+
+  test('reconciliation is fail-open when the conversation list is unavailable', async () => {
+    const client = createClient();
+    const events: GroupLifecycleEvent[] = [];
+    client.on('group_lifecycle', event => events.push(event));
+    (client as any).subscribedTopics.add('grp_keep_on_network_error');
+    globalThis.fetch = (async () => {
+      throw new Error('network unavailable');
+    }) as any;
+
+    await client.reconcileAccessibleGroupTopics();
+
+    assert.deepEqual(events, []);
+    assert.equal((client as any).subscribedTopics.has('grp_keep_on_network_error'), true);
+  });
+});

--- a/tests/catscompany-message-sender.test.ts
+++ b/tests/catscompany-message-sender.test.ts
@@ -108,6 +108,51 @@ describe('CatsCompany MessageSender retry behavior', () => {
       globalThis.fetch = originalFetch;
     }
   });
+
+  test('terminates the topic immediately on a websocket 403 without HTTP retry', async () => {
+    const revoked: Array<{ topic: string; status: number }> = [];
+    let fetchCalled = false;
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      fetchCalled = true;
+      throw new Error('must not use HTTP fallback');
+    }) as any;
+    try {
+      const sender = new MessageSender({
+        sendStructuredMessage: async () => {
+          throw new CatsSendError('ack', 'forbidden', 403);
+        },
+      } as any, 'https://app.example.test', 'cc_test', {
+        onTopicAccessRevoked: async (topic, status) => revoked.push({ topic, status }),
+      });
+
+      await assert.rejects(() => sender.sendText('grp_revoked', 'hello'), /forbidden/);
+      assert.deepEqual(revoked, [{ topic: 'grp_revoked', status: 403 }]);
+      assert.equal(fetchCalled, false);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test('terminates the topic when HTTP fallback returns 404', async () => {
+    const revoked: Array<{ topic: string; status: number }> = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => new Response('missing', { status: 404 })) as any;
+    try {
+      const sender = new MessageSender({
+        sendStructuredMessage: async () => {
+          throw new CatsSendError('transport', 'socket not open');
+        },
+      } as any, 'https://app.example.test', 'cc_test', {
+        onTopicAccessRevoked: async (topic, status) => revoked.push({ topic, status }),
+      });
+
+      await assert.rejects(() => sender.sendText('grp_missing', 'hello'), /目标会话或接口不存在/);
+      assert.deepEqual(revoked, [{ topic: 'grp_missing', status: 404 }]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });
 
 describe('CatsCompany MessageSender reply segmentation', () => {

--- a/tests/catscompany-topic-termination.test.ts
+++ b/tests/catscompany-topic-termination.test.ts
@@ -1,0 +1,74 @@
+import { test } from 'node:test';
+import * as assert from 'node:assert';
+import { CatsCompanyBot } from '../src/catscompany';
+
+test('terminateTopic is idempotent and fences every topic-owned runtime side effect', async () => {
+  const bot = Object.create(CatsCompanyBot.prototype) as any;
+  const topic = 'grp_lifecycle_test';
+  const sessionKey = `cc_group:${topic}`;
+  let interruptCalls = 0;
+  let terminateCalls = 0;
+  let releaseTermination!: () => void;
+  const terminationGate = new Promise<void>(resolve => { releaseTermination = resolve; });
+  const restoreController = new AbortController();
+  const batchTimer = setTimeout(() => undefined, 60_000);
+  batchTimer.unref?.();
+  const deliveryTimer = setTimeout(() => undefined, 60_000);
+  deliveryTimer.unref?.();
+
+  bot.topicTerminationTasks = new Map();
+  bot.terminatedTopicKeys = new Set();
+  bot.sessionClearGenerations = new Map([[sessionKey, 7]]);
+  bot.pendingAttachments = new Map([[sessionKey, [{ fileName: 'old.zip' }]]]);
+  bot.messageQueue = new Map([[sessionKey, [{ userMessage: 'old queued work' }]]]);
+  bot.messageQueueDrainTimers = new Map([[sessionKey, new Set([deliveryTimer])]]);
+  bot.sessionExecutionReservations = new Set([sessionKey]);
+  bot.cloudSessionRestoreAbortControllers = new Map([[sessionKey, restoreController]]);
+  bot.cloudSessionRestorePromises = new Map([[sessionKey, Promise.resolve({ status: 'restored' })]]);
+  bot.subAgentCompletionBatches = new Map([[sessionKey, {
+    timer: batchTimer,
+    items: new Map([['old', { observation: 'old result' }]]),
+  }]]);
+  bot.subAgentEventRoutes = new Map([
+    ['completed-child', { sessionKey, topic }],
+    ['other-topic-child', { sessionKey: 'cc_group:grp_other', topic: 'grp_other' }],
+  ]);
+  bot.activeConversationTasks = new Map();
+  bot.taskStatusTasks = new Map();
+  bot.sessionManager = {
+    get: () => ({ requestInterrupt: () => { interruptCalls += 1; } }),
+    terminate: async () => {
+      terminateCalls += 1;
+      await terminationGate;
+    },
+  };
+
+  const first = bot.terminateTopic(topic, 'access_revoked');
+  const duplicateWhileRunning = bot.terminateTopic(topic, 'topic_forbidden');
+  assert.strictEqual(first, duplicateWhileRunning);
+  assert.equal(bot.sessionClearGenerations.get(sessionKey), 8);
+  assert.equal(restoreController.signal.aborted, true);
+  assert.equal(bot.pendingAttachments.has(sessionKey), false);
+  assert.equal(bot.messageQueue.has(sessionKey), false);
+  assert.equal(bot.messageQueueDrainTimers.has(sessionKey), false);
+  assert.equal(bot.sessionExecutionReservations.has(sessionKey), false);
+  assert.equal(bot.cloudSessionRestorePromises.has(sessionKey), false);
+  assert.equal(bot.subAgentCompletionBatches.has(sessionKey), false);
+  assert.equal(bot.subAgentEventRoutes.has('completed-child'), false);
+  assert.equal(bot.subAgentEventRoutes.has('other-topic-child'), true);
+  assert.equal(interruptCalls, 1);
+  assert.equal(terminateCalls, 1);
+
+  releaseTermination();
+  await first;
+  await bot.terminateTopic(topic, 'group_disbanded');
+  assert.equal(bot.sessionClearGenerations.get(sessionKey), 8, 'late duplicate event is a no-op');
+  assert.equal(terminateCalls, 1);
+
+  // A newly delivered server message is the re-invite boundary. The old
+  // generation remains fenced while the topic can create fresh work.
+  bot.terminatedTopicKeys.delete(sessionKey);
+  await bot.terminateTopic(topic, 'access_revoked');
+  assert.equal(bot.sessionClearGenerations.get(sessionKey), 9);
+  assert.equal(terminateCalls, 2);
+});

--- a/tests/message-session-manager.test.ts
+++ b/tests/message-session-manager.test.ts
@@ -238,6 +238,33 @@ describe('MessageSessionManager', () => {
     }
   });
 
+  test('terminates one session idempotently without deleting its persisted history', async () => {
+    const { MessageSessionManager, SessionStore } = loadSessionManagerModules();
+    const manager = new MessageSessionManager(buildMockServices(), 'terminate-one-test');
+    const key = 'cc_group:grp_termination_test';
+    const session = manager.getOrCreate(key);
+    let interruptCalls = 0;
+    let cleanupCalls = 0;
+    (session as any).requestInterrupt = () => { interruptCalls += 1; };
+    (session as any).cleanup = async () => { cleanupCalls += 1; };
+    SessionStore.getInstance().saveContext(key, [{ role: 'user', content: '保留的历史' }]);
+
+    try {
+      await Promise.all([
+        manager.terminate(key, 'group access revoked'),
+        manager.terminate(key, 'duplicate event'),
+      ]);
+
+      assert.equal(interruptCalls, 1);
+      assert.equal(cleanupCalls, 1);
+      assert.equal(manager.get(key), null);
+      assert.equal(SessionStore.getInstance().loadContext(key)[0]?.content, '保留的历史');
+      assert.notEqual(manager.getOrCreate(key), session, 'a re-invite creates a fresh runtime');
+    } finally {
+      await manager.destroy();
+    }
+  });
+
   test('ttl cleanup saves expired sessions without hidden AI wakeup', async () => {
     const { MessageSessionManager, SessionStore } = loadSessionManagerModules();
     let aiCalls = 0;


### PR DESCRIPTION
## Summary

- add one idempotent Topic termination boundary that advances the generation fence before cleanup
- stop active model work, cloud restore, child agents, message queues, completion batches, delivery timers, event routes, and the live session while preserving history
- split sub-agent result computation from immutable envelope delivery so send retries never re-enter the model
- terminate immediately on CatsCompany topic 403/404, consume group lifecycle events, and reconcile tracked groups after reconnect
- open a process-wide per-credential model auth circuit after 401/auth_invalid; a changed key creates a fresh runtime key

## Safety invariants

- a sub-agent observation is processed by the model at most once
- immutable delivery is attempted at most three times total
- duplicate revoke/disband signals are no-ops
- late callbacks from a terminated generation are discarded
- failed conversation reconciliation is fail-open
- this PR does not implement Relay Key refresh

## Verification

- `npm run build` — pass
- `npm run release:check` — pass
- `npm run test:skillhub-phase1` — 246 pass, 1 platform skip
- lifecycle/auth/delivery targeted suites — pass, including provider call count strictly equal to 1 after a 401 and after repeated topic delivery failures
- `npm test` — 1634 pass, 15 skip; one unrelated local-environment failure because this Windows host has no WSL `/bin/bash` for the Tianyi image-pipeline shell assertion

## Pairing and rollout

Companion CatsCompany PR will emit authoritative `group_access_revoked` presence events. This XiaoBa PR is intentionally backward compatible and should merge first. Deployment and the one-time real group fault simulation remain pending after both PRs pass CI and review.

Companion server PR: buildsense-ai/cats-company#317.