### PR TITLE
feat(skillhub): 增加休眠式原子激活状态 journal

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -26,6 +26,7 @@ const skillHubPhase1Tests = [
   'tests/bot-definition-skills.test.ts',
   'tests/bot-skill-workspace.test.ts',
   'tests/bot-skill-candidate-workspace.test.ts',
+  'tests/bot-skills-activation-state.test.ts',
   'tests/bot-skills-sync.test.ts',
   'tests/bot-skills-security.test.ts',
   'tests/execution-router-clean.test.ts',

--- a/src/bot-skills/activation-state.ts
+++ b/src/bot-skills/activation-state.ts
@@ -1,0 +1,496 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+import type { BotSkillRef } from '../bot-definition/types';
+import { botSkillRefsEqual, canonicalizeBotSkillRefs } from './canonical';
+import { scanBotSkillWorkspace } from './local-manifest';
+import { renameBotSkillWorkspaceSync } from './workspace-fs';
+
+const APPLIED_MARKER_SCHEMA = 'xiaoba.bot-skill-applied.v1';
+const ACTIVATION_JOURNAL_SCHEMA = 'xiaoba.bot-skill-activation-journal.v2';
+
+export type BotSkillActivationPhase =
+  | 'prepared'
+  | 'backup_moved'
+  | 'live_switched'
+  | 'catalog_switched'
+  | 'locally_applied'
+  | 'acked';
+
+export interface BotSkillActivationIdentity {
+  definitionRevision: number;
+  skillSetHash: string;
+  mutationId?: string;
+}
+
+export interface BotSkillAppliedMarker extends BotSkillActivationIdentity {
+  schema: typeof APPLIED_MARKER_SCHEMA;
+  botId: string;
+  skills: BotSkillRef[];
+  appliedAt: string;
+  runtimeBodyIdHash?: string;
+}
+
+export interface BotSkillActivationJournal extends BotSkillActivationIdentity {
+  schema: typeof ACTIVATION_JOURNAL_SCHEMA;
+  botId: string;
+  skillsRoot: string;
+  stage: string;
+  backup: string;
+  skills: BotSkillRef[];
+  phase: BotSkillActivationPhase;
+  startedAt: string;
+  updatedAt: string;
+  runtimeBodyIdHash?: string;
+}
+
+export interface BeginBotSkillActivationInput extends BotSkillActivationIdentity {
+  botId: string;
+  skillsRoot: string;
+  stage: string;
+  backup: string;
+  skills: BotSkillRef[];
+  runtimeBodyIdHash?: string;
+  startedAt?: string;
+}
+
+export type BotSkillActivationRecovery =
+  | { status: 'none' }
+  | { status: 'discarded_prepared'; journal: BotSkillActivationJournal }
+  | { status: 'restored_backup'; journal: BotSkillActivationJournal }
+  | { status: 'resume_local_apply'; journal: BotSkillActivationJournal }
+  | { status: 'retry_ack'; journal: BotSkillActivationJournal; marker: BotSkillAppliedMarker }
+  | { status: 'acked'; journal: BotSkillActivationJournal; marker: BotSkillAppliedMarker };
+
+/**
+ * Computes a stable hash for the complete BotDefinition Skill reference set.
+ * This intentionally hashes reference facts only; it is not a workspace-content
+ * hash and never includes paths or Skill source text.
+ */
+export function computeCanonicalBotSkillSetHash(skills: readonly BotSkillRef[]): string {
+  const canonical = canonicalizeBotSkillRefs(skills);
+  return crypto.createHash('sha256').update(JSON.stringify(canonical), 'utf8').digest('hex');
+}
+
+/**
+ * Durable primitives for the future Runtime activation saga. Nothing in the
+ * production sync path constructs this store yet; E1 keeps the new behavior
+ * unreachable until the dedicated activation ACK worker is implemented.
+ */
+export class BotSkillActivationStateStore {
+  private readonly runtimeRoot: string;
+  private readonly appliedRoot: string;
+  private readonly journalRoot: string;
+
+  constructor(runtimeRoot: string) {
+    this.runtimeRoot = path.resolve(runtimeRoot);
+    const stateRoot = path.join(this.runtimeRoot, 'data', 'bot-skills');
+    this.appliedRoot = path.join(stateRoot, 'applied');
+    this.journalRoot = path.join(stateRoot, 'activation-journal');
+  }
+
+  begin(input: BeginBotSkillActivationInput): BotSkillActivationJournal {
+    const value = normalizeJournal({
+      schema: ACTIVATION_JOURNAL_SCHEMA,
+      ...input,
+      phase: 'prepared',
+      startedAt: input.startedAt ?? new Date().toISOString(),
+      updatedAt: input.startedAt ?? new Date().toISOString(),
+    }, input.botId, input.skillsRoot);
+    const existing = this.readJournal(input.botId, input.skillsRoot);
+    if (existing) {
+      if (sameActivation(existing, value)) return existing;
+      throw new Error('A different Bot Skill activation is already in progress');
+    }
+    this.writeJournal(value);
+    return value;
+  }
+
+  readApplied(botId: string): BotSkillAppliedMarker | undefined {
+    const normalizedBotId = normalizeBotId(botId);
+    const filePath = path.join(this.appliedRoot, `${normalizedBotId}.json`);
+    if (!fs.existsSync(filePath)) return undefined;
+    return readJsonState(
+      filePath,
+      value => normalizeAppliedMarker(value, normalizedBotId),
+      'Bot Skill applied marker cannot be read safely',
+    );
+  }
+
+  readJournal(botId: string, skillsRoot: string): BotSkillActivationJournal | undefined {
+    const normalizedBotId = normalizeBotId(botId);
+    const filePath = path.join(this.journalRoot, `${normalizedBotId}.json`);
+    if (!fs.existsSync(filePath)) return undefined;
+    return readJsonState(
+      filePath,
+      value => normalizeJournal(value, normalizedBotId, skillsRoot),
+      'Bot Skill activation journal cannot be read safely',
+    );
+  }
+
+  advance(
+    botId: string,
+    skillsRoot: string,
+    identity: BotSkillActivationIdentity,
+    nextPhase: BotSkillActivationPhase,
+  ): BotSkillActivationJournal {
+    const journal = this.requireJournal(botId, skillsRoot, identity);
+    if (journal.phase === nextPhase) return journal;
+    if (!LEGAL_TRANSITIONS[journal.phase].includes(nextPhase)) {
+      throw new Error(`Invalid Bot Skill activation transition: ${journal.phase} -> ${nextPhase}`);
+    }
+    const next = normalizeJournal({
+      ...journal,
+      phase: nextPhase,
+      updatedAt: new Date().toISOString(),
+    }, botId, skillsRoot);
+    this.writeJournal(next);
+    return next;
+  }
+
+  recordLocallyApplied(
+    botId: string,
+    skillsRoot: string,
+    identity: BotSkillActivationIdentity,
+    appliedAt = new Date().toISOString(),
+  ): BotSkillAppliedMarker {
+    let journal = this.requireJournal(botId, skillsRoot, identity);
+    if (journal.phase !== 'catalog_switched' && journal.phase !== 'locally_applied') {
+      throw new Error(`Cannot record applied Bot Skills during phase ${journal.phase}`);
+    }
+    const marker = normalizeAppliedMarker({
+      schema: APPLIED_MARKER_SCHEMA,
+      botId: journal.botId,
+      definitionRevision: journal.definitionRevision,
+      skillSetHash: journal.skillSetHash,
+      skills: journal.skills,
+      appliedAt,
+      ...(journal.mutationId ? { mutationId: journal.mutationId } : {}),
+      ...(journal.runtimeBodyIdHash ? { runtimeBodyIdHash: journal.runtimeBodyIdHash } : {}),
+    }, journal.botId);
+    const existing = this.readApplied(journal.botId);
+    if (existing && !sameAppliedFact(existing, marker)) {
+      throw new Error('Existing Bot Skill applied marker conflicts with this activation');
+    }
+    if (!existing) this.writeApplied(marker);
+    if (journal.phase !== 'locally_applied') {
+      journal = this.advance(journal.botId, journal.skillsRoot, identity, 'locally_applied');
+    }
+    return this.readApplied(journal.botId) ?? marker;
+  }
+
+  markAcked(
+    botId: string,
+    skillsRoot: string,
+    identity: BotSkillActivationIdentity,
+  ): BotSkillActivationJournal {
+    const journal = this.requireJournal(botId, skillsRoot, identity);
+    if (journal.phase === 'acked') return journal;
+    if (journal.phase !== 'locally_applied') {
+      throw new Error(`Cannot acknowledge Bot Skill activation during phase ${journal.phase}`);
+    }
+    const marker = this.readApplied(journal.botId);
+    if (!marker || !appliedMatchesJournal(marker, journal)) {
+      throw new Error('Bot Skill activation cannot be acknowledged without its applied marker');
+    }
+    // The backup and journal are deliberately retained. A later, separately
+    // reviewed GC step may remove ACKed evidence after the retention window.
+    return this.advance(journal.botId, journal.skillsRoot, identity, 'acked');
+  }
+
+  recover(botId: string, skillsRoot: string): BotSkillActivationRecovery {
+    let journal = this.readJournal(botId, skillsRoot);
+    if (!journal) return { status: 'none' };
+    assertSafeWorkspacePathType(journal.skillsRoot, 'live');
+    assertSafeWorkspacePathType(journal.stage, 'stage');
+    assertSafeWorkspacePathType(journal.backup, 'backup');
+    const liveExists = fs.existsSync(journal.skillsRoot);
+    const stageExists = fs.existsSync(journal.stage);
+    const backupExists = fs.existsSync(journal.backup);
+
+    if (journal.phase === 'prepared') {
+      if (liveExists && backupExists) {
+        throw new Error('Prepared Bot Skill activation has ambiguous live and backup workspaces');
+      }
+      if (!liveExists && backupExists) {
+        renameBotSkillWorkspaceSync(journal.backup, journal.skillsRoot);
+        removeDirectoryIfPresent(journal.stage);
+        this.removeJournal(journal.botId);
+        return { status: 'restored_backup', journal };
+      }
+      removeDirectoryIfPresent(journal.stage);
+      this.removeJournal(journal.botId);
+      return { status: 'discarded_prepared', journal };
+    }
+
+    if (journal.phase === 'backup_moved') {
+      if (!liveExists) {
+        if (!backupExists) {
+          throw new Error('Bot Skill activation lost both live and backup workspaces');
+        }
+        renameBotSkillWorkspaceSync(journal.backup, journal.skillsRoot);
+        removeDirectoryIfPresent(journal.stage);
+        this.removeJournal(journal.botId);
+        return { status: 'restored_backup', journal };
+      }
+      if (stageExists) {
+        throw new Error('Bot Skill activation has ambiguous live and staged workspaces');
+      }
+      assertLiveMatchesJournal(journal);
+      journal = this.advance(journal.botId, journal.skillsRoot, journal, 'live_switched');
+      return { status: 'resume_local_apply', journal };
+    }
+
+    assertLiveMatchesJournal(journal);
+    if (journal.phase === 'live_switched' || journal.phase === 'catalog_switched') {
+      const marker = this.readApplied(journal.botId);
+      if (marker && appliedMatchesJournal(marker, journal)) {
+        if (journal.phase === 'live_switched') {
+          journal = this.advance(journal.botId, journal.skillsRoot, journal, 'catalog_switched');
+        }
+        journal = this.advance(journal.botId, journal.skillsRoot, journal, 'locally_applied');
+        return { status: 'retry_ack', journal, marker };
+      }
+      return { status: 'resume_local_apply', journal };
+    }
+
+    const marker = this.readApplied(journal.botId);
+    if (!marker || !appliedMatchesJournal(marker, journal)) {
+      throw new Error('Bot Skill activation journal does not match its applied marker');
+    }
+    return journal.phase === 'acked'
+      ? { status: 'acked', journal, marker }
+      : { status: 'retry_ack', journal, marker };
+  }
+
+  private requireJournal(
+    botId: string,
+    skillsRoot: string,
+    identity: BotSkillActivationIdentity,
+  ): BotSkillActivationJournal {
+    const journal = this.readJournal(botId, skillsRoot);
+    if (!journal) throw new Error('Bot Skill activation journal does not exist');
+    if (!sameIdentity(journal, identity)) {
+      throw new Error('Bot Skill activation journal identity does not match');
+    }
+    return journal;
+  }
+
+  private writeApplied(value: BotSkillAppliedMarker): void {
+    atomicWriteJson(path.join(this.appliedRoot, `${value.botId}.json`), value);
+  }
+
+  private writeJournal(value: BotSkillActivationJournal): void {
+    atomicWriteJson(path.join(this.journalRoot, `${value.botId}.json`), value);
+  }
+
+  private removeJournal(botId: string): void {
+    fs.rmSync(path.join(this.journalRoot, `${normalizeBotId(botId)}.json`), { force: true });
+  }
+}
+
+const LEGAL_TRANSITIONS: Record<BotSkillActivationPhase, BotSkillActivationPhase[]> = {
+  prepared: ['backup_moved', 'live_switched'],
+  backup_moved: ['live_switched'],
+  live_switched: ['catalog_switched'],
+  catalog_switched: ['locally_applied'],
+  locally_applied: ['acked'],
+  acked: [],
+};
+
+function normalizeAppliedMarker(value: unknown, expectedBotId: string): BotSkillAppliedMarker {
+  const input = value as Partial<BotSkillAppliedMarker> | undefined;
+  const botId = normalizeBotId(String(input?.botId || ''));
+  const skills = canonicalizeBotSkillRefs(input?.skills as BotSkillRef[]);
+  const marker: BotSkillAppliedMarker = {
+    schema: input?.schema as typeof APPLIED_MARKER_SCHEMA,
+    botId,
+    definitionRevision: Number(input?.definitionRevision),
+    skillSetHash: String(input?.skillSetHash || ''),
+    skills,
+    appliedAt: String(input?.appliedAt || ''),
+    ...(input?.mutationId ? { mutationId: String(input.mutationId) } : {}),
+    ...(input?.runtimeBodyIdHash ? { runtimeBodyIdHash: String(input.runtimeBodyIdHash) } : {}),
+  };
+  if (
+    marker.schema !== APPLIED_MARKER_SCHEMA
+    || marker.botId !== normalizeBotId(expectedBotId)
+    || !validRevision(marker.definitionRevision)
+    || !validHash(marker.skillSetHash)
+    || computeCanonicalBotSkillSetHash(marker.skills) !== marker.skillSetHash
+    || !validTimestamp(marker.appliedAt)
+    || !validOptionalIdentity(marker.mutationId)
+    || !validOptionalHash(marker.runtimeBodyIdHash)
+  ) {
+    throw new Error('Bot Skill applied marker is invalid');
+  }
+  return marker;
+}
+
+function normalizeJournal(
+  value: unknown,
+  expectedBotId: string,
+  expectedSkillsRoot: string,
+): BotSkillActivationJournal {
+  const input = value as Partial<BotSkillActivationJournal> | undefined;
+  const botId = normalizeBotId(String(input?.botId || ''));
+  const skillsRoot = path.resolve(String(input?.skillsRoot || ''));
+  const stage = path.resolve(String(input?.stage || ''));
+  const backup = path.resolve(String(input?.backup || ''));
+  const skills = canonicalizeBotSkillRefs(input?.skills as BotSkillRef[]);
+  const journal: BotSkillActivationJournal = {
+    schema: input?.schema as typeof ACTIVATION_JOURNAL_SCHEMA,
+    botId,
+    skillsRoot,
+    stage,
+    backup,
+    definitionRevision: Number(input?.definitionRevision),
+    skillSetHash: String(input?.skillSetHash || ''),
+    skills,
+    phase: input?.phase as BotSkillActivationPhase,
+    startedAt: String(input?.startedAt || ''),
+    updatedAt: String(input?.updatedAt || ''),
+    ...(input?.mutationId ? { mutationId: String(input.mutationId) } : {}),
+    ...(input?.runtimeBodyIdHash ? { runtimeBodyIdHash: String(input.runtimeBodyIdHash) } : {}),
+  };
+  if (
+    journal.schema !== ACTIVATION_JOURNAL_SCHEMA
+    || journal.botId !== normalizeBotId(expectedBotId)
+    || journal.skillsRoot !== path.resolve(expectedSkillsRoot)
+    || !validActivationWorkspacePaths(journal.skillsRoot, journal.stage, journal.backup)
+    || !validRevision(journal.definitionRevision)
+    || !validHash(journal.skillSetHash)
+    || computeCanonicalBotSkillSetHash(journal.skills) !== journal.skillSetHash
+    || !Object.prototype.hasOwnProperty.call(LEGAL_TRANSITIONS, journal.phase)
+    || !validTimestamp(journal.startedAt)
+    || !validTimestamp(journal.updatedAt)
+    || !validOptionalIdentity(journal.mutationId)
+    || !validOptionalHash(journal.runtimeBodyIdHash)
+  ) {
+    throw new Error('Bot Skill activation journal is invalid');
+  }
+  return journal;
+}
+
+function assertLiveMatchesJournal(journal: BotSkillActivationJournal): void {
+  if (!fs.existsSync(journal.skillsRoot)) {
+    throw new Error('Activated Bot Skill workspace is missing');
+  }
+  const references = scanBotSkillWorkspace(journal.skillsRoot)
+    .flatMap(entry => entry.reference ? [entry.reference] : []);
+  const actualHash = computeCanonicalBotSkillSetHash(references);
+  if (actualHash !== journal.skillSetHash || !botSkillRefsEqual(references, journal.skills)) {
+    throw new Error('Activated Bot Skill workspace does not match its journal');
+  }
+}
+
+function sameActivation(left: BotSkillActivationJournal, right: BotSkillActivationJournal): boolean {
+  return sameIdentity(left, right)
+    && left.skillsRoot === right.skillsRoot
+    && left.stage === right.stage
+    && left.backup === right.backup
+    && left.runtimeBodyIdHash === right.runtimeBodyIdHash
+    && botSkillRefsEqual(left.skills, right.skills);
+}
+
+function sameIdentity(left: BotSkillActivationIdentity, right: BotSkillActivationIdentity): boolean {
+  return left.definitionRevision === right.definitionRevision
+    && left.skillSetHash === right.skillSetHash
+    && left.mutationId === right.mutationId;
+}
+
+function sameAppliedFact(left: BotSkillAppliedMarker, right: BotSkillAppliedMarker): boolean {
+  return sameIdentity(left, right)
+    && left.botId === right.botId
+    && left.runtimeBodyIdHash === right.runtimeBodyIdHash
+    && botSkillRefsEqual(left.skills, right.skills);
+}
+
+function appliedMatchesJournal(
+  marker: BotSkillAppliedMarker,
+  journal: BotSkillActivationJournal,
+): boolean {
+  return marker.botId === journal.botId
+    && sameIdentity(marker, journal)
+    && marker.runtimeBodyIdHash === journal.runtimeBodyIdHash
+    && botSkillRefsEqual(marker.skills, journal.skills);
+}
+
+function validActivationWorkspacePaths(skillsRoot: string, stage: string, backup: string): boolean {
+  const parent = path.dirname(skillsRoot);
+  return stage !== backup
+    && stage !== skillsRoot
+    && backup !== skillsRoot
+    && path.dirname(stage) === parent
+    && path.dirname(backup) === parent
+    && path.basename(stage).startsWith('.bot-skills-stage-')
+    && path.basename(backup).startsWith('.bot-skills-backup-');
+}
+
+function validRevision(value: number): boolean {
+  return Number.isSafeInteger(value) && value >= 0;
+}
+
+function validHash(value: string): boolean {
+  return /^[a-f0-9]{64}$/.test(value);
+}
+
+function validOptionalHash(value: string | undefined): boolean {
+  return value === undefined || validHash(value);
+}
+
+function validOptionalIdentity(value: string | undefined): boolean {
+  return value === undefined || /^[A-Za-z0-9._:-]{1,160}$/.test(value);
+}
+
+function validTimestamp(value: string): boolean {
+  return Boolean(value) && Number.isFinite(Date.parse(value));
+}
+
+function normalizeBotId(botId: string): string {
+  const value = String(botId || '').trim();
+  if (!/^[A-Za-z0-9_.-]{1,160}$/.test(value)) throw new Error('Invalid Bot ID for Skill activation state');
+  return value;
+}
+
+function atomicWriteJson(filePath: string, value: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const temporary = `${filePath}.${process.pid}.${Date.now()}.${crypto.randomBytes(4).toString('hex')}.tmp`;
+  try {
+    fs.writeFileSync(temporary, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+    fs.renameSync(temporary, filePath);
+  } finally {
+    fs.rmSync(temporary, { force: true });
+  }
+}
+
+function readJsonState<T>(
+  filePath: string,
+  normalize: (value: unknown) => T,
+  message: string,
+): T {
+  try {
+    return normalize(JSON.parse(fs.readFileSync(filePath, 'utf8')));
+  } catch (error) {
+    if (error instanceof Error && (
+      error.message === 'Bot Skill applied marker is invalid'
+      || error.message === 'Bot Skill activation journal is invalid'
+      || error.message === 'Invalid Bot ID for Skill activation state'
+    )) {
+      throw error;
+    }
+    throw new Error(message);
+  }
+}
+
+function removeDirectoryIfPresent(directory: string): void {
+  if (fs.existsSync(directory)) fs.rmSync(directory, { recursive: true, force: true });
+}
+
+function assertSafeWorkspacePathType(target: string, label: string): void {
+  if (!fs.existsSync(target)) return;
+  const stat = fs.lstatSync(target);
+  if (stat.isSymbolicLink() || !stat.isDirectory()) {
+    throw new Error(`Bot Skill activation ${label} path is not a safe directory`);
+  }
+}

--- a/tests/bot-skills-activation-state.test.ts
+++ b/tests/bot-skills-activation-state.test.ts
@@ -1,0 +1,245 @@
+import { afterEach, describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { BotSkillRef } from '../src/bot-definition/types';
+import {
+  BotSkillActivationStateStore,
+  computeCanonicalBotSkillSetHash,
+} from '../src/bot-skills/activation-state';
+import {
+  scanLocalBotSkill,
+  writeBotSkillLocalMarker,
+} from '../src/bot-skills/local-manifest';
+
+describe('Bot Skill activation state v2', () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('hashes a complete reference set canonically without paths or source text', () => {
+    const a = reference('skill-a', 'v1.0.0', 'a');
+    const b = reference('skill-b', 'v2.0.0', 'b');
+    assert.equal(
+      computeCanonicalBotSkillSetHash([b, a]),
+      computeCanonicalBotSkillSetHash([a, b]),
+    );
+    assert.notEqual(
+      computeCanonicalBotSkillSetHash([a, b]),
+      computeCanonicalBotSkillSetHash([a, { ...b, version: 'v2.0.1' }]),
+    );
+  });
+
+  test('records an applied marker before ACK and retains backup evidence after ACK', () => {
+    const fixture = createFixture(roots);
+    const journal = fixture.store.begin(fixture.begin);
+    assert.equal(journal.phase, 'prepared');
+    fixture.store.advance(fixture.botId, fixture.skillsRoot, journal, 'backup_moved');
+    fixture.store.advance(fixture.botId, fixture.skillsRoot, journal, 'live_switched');
+    fixture.store.advance(fixture.botId, fixture.skillsRoot, journal, 'catalog_switched');
+    const marker = fixture.store.recordLocallyApplied(
+      fixture.botId,
+      fixture.skillsRoot,
+      journal,
+      '2026-08-25T12:00:00.000Z',
+    );
+    assert.equal(marker.definitionRevision, 12);
+    assert.equal(marker.skillSetHash, fixture.skillSetHash);
+    assert.deepStrictEqual(marker.skills, fixture.skills);
+    assert.equal(fixture.store.readJournal(fixture.botId, fixture.skillsRoot)?.phase, 'locally_applied');
+
+    fs.mkdirSync(fixture.backup, { recursive: true });
+    fixture.store.markAcked(fixture.botId, fixture.skillsRoot, journal);
+    assert.equal(fixture.store.readJournal(fixture.botId, fixture.skillsRoot)?.phase, 'acked');
+    assert.equal(fs.existsSync(fixture.backup), true);
+  });
+
+  test('rejects phase skips, conflicting activation identities, and ACK without an applied marker', () => {
+    const fixture = createFixture(roots);
+    const journal = fixture.store.begin(fixture.begin);
+    assert.throws(
+      () => fixture.store.advance(fixture.botId, fixture.skillsRoot, journal, 'locally_applied'),
+      /Invalid Bot Skill activation transition/,
+    );
+    assert.throws(
+      () => fixture.store.begin({ ...fixture.begin, definitionRevision: 13 }),
+      /different Bot Skill activation/,
+    );
+    fixture.store.advance(fixture.botId, fixture.skillsRoot, journal, 'live_switched');
+    fixture.store.advance(fixture.botId, fixture.skillsRoot, journal, 'catalog_switched');
+    assert.throws(
+      () => fixture.store.markAcked(fixture.botId, fixture.skillsRoot, journal),
+      /during phase catalog_switched/,
+    );
+  });
+
+  test('discards a prepared stage while leaving the live workspace untouched', () => {
+    const fixture = createFixture(roots);
+    fs.mkdirSync(fixture.skillsRoot, { recursive: true });
+    fs.writeFileSync(path.join(fixture.skillsRoot, 'keep.txt'), 'old live');
+    fs.mkdirSync(fixture.stage, { recursive: true });
+    fs.writeFileSync(path.join(fixture.stage, 'discard.txt'), 'not active');
+    fixture.store.begin(fixture.begin);
+
+    const result = fixture.store.recover(fixture.botId, fixture.skillsRoot);
+    assert.equal(result.status, 'discarded_prepared');
+    assert.equal(fs.readFileSync(path.join(fixture.skillsRoot, 'keep.txt'), 'utf8'), 'old live');
+    assert.equal(fs.existsSync(fixture.stage), false);
+    assert.equal(fixture.store.readJournal(fixture.botId, fixture.skillsRoot), undefined);
+  });
+
+  test('restores the backup when a crash happens after rename but before phase persistence', () => {
+    const fixture = createFixture(roots);
+    fs.mkdirSync(fixture.backup, { recursive: true });
+    fs.writeFileSync(path.join(fixture.backup, 'old.txt'), 'old live');
+    fs.mkdirSync(fixture.stage, { recursive: true });
+    fixture.store.begin(fixture.begin);
+
+    const result = fixture.store.recover(fixture.botId, fixture.skillsRoot);
+    assert.equal(result.status, 'restored_backup');
+    assert.equal(fs.readFileSync(path.join(fixture.skillsRoot, 'old.txt'), 'utf8'), 'old live');
+    assert.equal(fs.existsSync(fixture.stage), false);
+    assert.equal(fixture.store.readJournal(fixture.botId, fixture.skillsRoot), undefined);
+  });
+
+  test('recognizes a completed stage rename and resumes local metadata commit', () => {
+    const fixture = createFixture(roots);
+    adoptWorkspaceReference(fixture, writeReferencedWorkspace(fixture.skillsRoot, fixture.skills[0]));
+    fixture.store.begin(fixture.begin);
+    fixture.store.advance(fixture.botId, fixture.skillsRoot, fixture.begin, 'backup_moved');
+    fs.mkdirSync(fixture.backup, { recursive: true });
+
+    const result = fixture.store.recover(fixture.botId, fixture.skillsRoot);
+    assert.equal(result.status, 'resume_local_apply');
+    assert.equal(result.status === 'resume_local_apply' && result.journal.phase, 'live_switched');
+    assert.equal(fs.existsSync(fixture.backup), true);
+  });
+
+  test('uses a matching applied marker to recover an ACK lost after local commit', () => {
+    const fixture = createFixture(roots);
+    adoptWorkspaceReference(fixture, writeReferencedWorkspace(fixture.skillsRoot, fixture.skills[0]));
+    const journal = fixture.store.begin(fixture.begin);
+    fixture.store.advance(fixture.botId, fixture.skillsRoot, journal, 'live_switched');
+    fixture.store.advance(fixture.botId, fixture.skillsRoot, journal, 'catalog_switched');
+    fixture.store.recordLocallyApplied(fixture.botId, fixture.skillsRoot, journal);
+
+    const result = fixture.store.recover(fixture.botId, fixture.skillsRoot);
+    assert.equal(result.status, 'retry_ack');
+    assert.equal(result.status === 'retry_ack' && result.marker.definitionRevision, 12);
+  });
+
+  test('fails closed on a mismatched live workspace and preserves backup evidence', () => {
+    const fixture = createFixture(roots);
+    fixture.store.begin(fixture.begin);
+    fixture.store.advance(fixture.botId, fixture.skillsRoot, fixture.begin, 'live_switched');
+    writeReferencedWorkspace(fixture.skillsRoot, reference('other-skill', 'v1', 'z'));
+    fs.mkdirSync(fixture.backup, { recursive: true });
+    fs.writeFileSync(path.join(fixture.backup, 'old.txt'), 'recoverable');
+
+    assert.throws(
+      () => fixture.store.recover(fixture.botId, fixture.skillsRoot),
+      /does not match its journal/,
+    );
+    assert.equal(fs.readFileSync(path.join(fixture.backup, 'old.txt'), 'utf8'), 'recoverable');
+    assert.equal(fixture.store.readJournal(fixture.botId, fixture.skillsRoot)?.phase, 'live_switched');
+  });
+
+  test('rejects journal paths outside the exact live workspace parent', () => {
+    const fixture = createFixture(roots);
+    assert.throws(
+      () => fixture.store.begin({
+        ...fixture.begin,
+        stage: path.join(fixture.runtimeRoot, 'outside', '.bot-skills-stage-attack'),
+      }),
+      /activation journal is invalid/,
+    );
+  });
+
+  test('does not remove a staged path whose type is not a verified directory', () => {
+    const fixture = createFixture(roots);
+    fixture.store.begin(fixture.begin);
+    fs.writeFileSync(fixture.stage, 'must survive');
+
+    assert.throws(
+      () => fixture.store.recover(fixture.botId, fixture.skillsRoot),
+      /stage path is not a safe directory/,
+    );
+    assert.equal(fs.readFileSync(fixture.stage, 'utf8'), 'must survive');
+    assert.equal(fixture.store.readJournal(fixture.botId, fixture.skillsRoot)?.phase, 'prepared');
+  });
+});
+
+function createFixture(roots: string[]) {
+  const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'bot-skill-activation-state-'));
+  roots.push(runtimeRoot);
+  const botId = 'bot-activation-test';
+  const skillsRoot = path.join(runtimeRoot, 'skills');
+  const stage = path.join(runtimeRoot, '.bot-skills-stage-test');
+  const backup = path.join(runtimeRoot, '.bot-skills-backup-test');
+  const skills = [reference('image-skill', 'v1.2.3', 'a')];
+  const skillSetHash = computeCanonicalBotSkillSetHash(skills);
+  const store = new BotSkillActivationStateStore(runtimeRoot);
+  return {
+    runtimeRoot,
+    botId,
+    skillsRoot,
+    stage,
+    backup,
+    skills,
+    skillSetHash,
+    store,
+    begin: {
+      botId,
+      skillsRoot,
+      stage,
+      backup,
+      definitionRevision: 12,
+      skillSetHash,
+      skills,
+      mutationId: 'mutation-12',
+      runtimeBodyIdHash: crypto.createHash('sha256').update('runtime-body').digest('hex'),
+      startedAt: '2026-08-25T11:00:00.000Z',
+    },
+  };
+}
+
+function reference(skillId: string, version: string, hashSeed: string): BotSkillRef {
+  return {
+    source: 'skillhub',
+    skillId,
+    version,
+    contentHash: crypto.createHash('sha256').update(hashSeed).digest('hex'),
+  };
+}
+
+function writeReferencedWorkspace(skillsRoot: string, expected: BotSkillRef): BotSkillRef {
+  const skillDir = path.join(skillsRoot, expected.skillId);
+  fs.mkdirSync(skillDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(skillDir, 'SKILL.md'),
+    `---\nname: ${expected.skillId}\ndescription: activation state test skill\n---\n\nTest.\n`,
+    'utf8',
+  );
+  const local = scanLocalBotSkill(skillDir, skillsRoot);
+  const referenceWithActualHash = { ...expected, contentHash: local.contentHash };
+  writeBotSkillLocalMarker(skillDir, {
+    schema: 'xiaoba.bot-skill-local.v1',
+    localSkillId: `local:${expected.skillId}`,
+    reference: referenceWithActualHash,
+  });
+  return referenceWithActualHash;
+}
+
+function adoptWorkspaceReference(
+  fixture: ReturnType<typeof createFixture>,
+  actual: BotSkillRef,
+): void {
+  fixture.skills[0] = actual;
+  fixture.skillSetHash = computeCanonicalBotSkillSetHash(fixture.skills);
+  fixture.begin.skills = fixture.skills;
+  fixture.begin.skillSetHash = fixture.skillSetHash;
+}


### PR DESCRIPTION
## 目标

实现 Runtime 原子激活 E1 的持久状态基础：本地 applied marker、activation journal v2、canonical Skill 集合哈希和按 phase 的崩溃恢复判定。

本 PR 默认不可达：现有 Runtime sync/activation 不会构造或调用新 store。它只为后续专用 activation ACK worker 提供经过测试的底层原语，不改变当前用户体验。

## 变更

- 新增 `BotSkillActivationStateStore`
  - `data/bot-skills/applied/<botId>.json` 的非敏感 applied 事实
  - `data/bot-skills/activation-journal/<botId>.json` 的 v2 journal
  - 绑定 Bot、Definition revision、完整 Skill 引用集合哈希、可选 MutationID 和 Runtime body 安全哈希
- 新增 canonical Skill set hash
  - 对完整引用集合稳定排序后哈希
  - 不包含路径、Skill 正文、token 或 API Key
- 新增严格 phase 状态机
  - `prepared -> backup_moved -> live_switched -> catalog_switched -> locally_applied -> acked`
  - applied marker 必须在成功 ACK 之前存在
  - ACK 后仍保留 journal 与 backup，后续独立 GC 才能按保留策略清理
- 新增崩溃恢复基础
  - prepared stage 安全丢弃
  - active rename 后、phase 落盘前可从 backup 恢复
  - stage 已切换时验证 live set hash 后继续本地提交
  - `locally_applied` 可识别为幂等补 ACK
  - live/journal 不一致、路径越界、非目录/符号链接状态均失败关闭，不删除恢复证据
- 把 E1 测试加入 `test:skillhub-phase1`

## 安全与兼容边界

- 没有接入生产 sync、Runtime 启动、聊天、WebApp 或模型工具
- 没有修改 `read_file`、`write_file`、`edit_file`、`send_file`、`import_file`、`execute_shell`
- 没有修改正式 Skill 执行、工具 schema、注入、System Prompt 或缓存边界
- 没有修改现有工作区切换、发布、删除或权限逻辑
- E1 合并后用户行为保持不变；后续 E3 需独立 PR 才能接入专用 ACK worker

## 验证

- E1 activation-state：10 passed
- BotDefinition + Skill sync + E1：71 passed
- `npm run build`：通过
- `npm run test:skillhub-phase1`：256 passed，1 个 Windows symlink 能力 skip
- `npm test`：1652 total / 1639 passed / 11 skipped；本机仅 2 个既有 Worker updater 测试因缺少 `jq` 失败，和本 PR 无关，GitHub Linux Runtime CI 负责最终验证

## 后续顺序

1. 先合并本 PR
2. 再做 CatsCo E2 专用 activation ACK（默认 feature flag 关闭）
3. E2 合并后做 XiaoBa E3 ACK worker，将本 PR 的 `locally_applied` journal 接入远程幂等 ACK
