### PR TITLE
feat: 增加 Runtime Skill 激活 ACK worker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,9 @@ CATSCO_API_KEY=
 # Optional owner-provisioned, body/installation-bound credential for the
 # second-stage Skill mutation grant protocol. This is not a Bot API key.
 CATSCO_RUNTIME_CREDENTIAL=
+# E3 Runtime activation ACK worker. Keep false until CatsCo E2 is deployed,
+# the target Bot UID is allowlisted, and a credential with the ACK scope exists.
+XIAOBA_SKILL_MUTATION_ACTIVATION_ACK_WORKER_ENABLED=false
 CATSCO_BOT_UID=
 CATSCO_USER_TOKEN=
 CATSCO_USER_UID=

--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,10 @@ CATSCO_API_KEY=
 # Optional owner-provisioned, body/installation-bound credential for the
 # second-stage Skill mutation grant protocol. This is not a Bot API key.
 CATSCO_RUNTIME_CREDENTIAL=
+# Separate body/installation-bound credential issued with both
+# skill_mutation:grant and skill_mutation:activation_ack. Never reuse an older
+# grant-only credential for the ACK worker.
+CATSCO_RUNTIME_ACTIVATION_ACK_CREDENTIAL=
 # E3 Runtime activation ACK worker. Keep false until CatsCo E2 is deployed,
 # the target Bot UID is allowlisted, and a credential with the ACK scope exists.
 XIAOBA_SKILL_MUTATION_ACTIVATION_ACK_WORKER_ENABLED=false

--- a/src/bot-skills/activation-ack-worker.ts
+++ b/src/bot-skills/activation-ack-worker.ts
@@ -51,7 +51,7 @@ export interface BotSkillActivationAckWorkerOptions {
   botId: string;
   bodyId: string;
   installationId: string;
-  runtimeCredential: string;
+  activationAckCredential: string;
   httpBaseUrl: string;
   stateStore?: BotSkillActivationAckStateStore;
   fetchImpl?: typeof fetch;
@@ -72,7 +72,7 @@ export class BotSkillActivationAckWorker {
   private readonly botId: string;
   private readonly skillsRoot: string;
   private readonly bodyIdHash: string;
-  private readonly runtimeCredential: string;
+  private readonly activationAckCredential: string;
   private readonly endpointBase: string;
   private readonly pollIntervalMs: number;
   private readonly requestTimeoutMs: number;
@@ -87,8 +87,8 @@ export class BotSkillActivationAckWorker {
     this.botId = normalizePositiveInt64(options.botId, 'Bot ID');
     const bodyId = normalizeRuntimeIdentity(options.bodyId, 'body ID');
     normalizeRuntimeIdentity(options.installationId, 'installation ID');
-    this.runtimeCredential = String(options.runtimeCredential || '').trim();
-    if (!this.runtimeCredential) throw new Error('Runtime credential is required for Skill activation ACK');
+    this.activationAckCredential = String(options.activationAckCredential || '').trim();
+    if (!this.activationAckCredential) throw new Error('Dedicated Runtime credential is required for Skill activation ACK');
     this.endpointBase = normalizeHttpBaseUrl(options.httpBaseUrl);
     this.skillsRoot = String(options.skillsRoot || '').trim();
     if (!this.skillsRoot) throw new Error('Skill workspace is required for activation ACK');
@@ -167,7 +167,7 @@ export class BotSkillActivationAckWorker {
         {
           method: 'POST',
           headers: {
-            'X-CatsCo-Runtime-Credential': this.runtimeCredential,
+            'X-CatsCo-Runtime-Credential': this.activationAckCredential,
             'Content-Type': 'application/json',
             Accept: 'application/json',
           },

--- a/src/bot-skills/activation-ack-worker.ts
+++ b/src/bot-skills/activation-ack-worker.ts
@@ -1,0 +1,302 @@
+import * as crypto from 'crypto';
+import type {
+  BotSkillActivationIdentity,
+  BotSkillActivationJournal,
+  BotSkillActivationAckInspection,
+} from './activation-state';
+import { BotSkillActivationStateStore } from './activation-state';
+
+const DEFAULT_POLL_INTERVAL_MS = 5_000;
+const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
+const MAX_RETRY_DELAY_MS = 5 * 60_000;
+const MAX_INT64 = 9_223_372_036_854_775_807n;
+
+export type BotSkillActivationAckWarningCode =
+  | 'STATE_INVALID'
+  | 'MUTATION_ID_INVALID'
+  | 'RUNTIME_IDENTITY_MISMATCH'
+  | 'CREDENTIAL_REJECTED'
+  | 'ACK_NOT_AVAILABLE'
+  | 'ACTIVATION_FACT_CONFLICT'
+  | 'ACK_RETRYABLE'
+  | 'ACK_RESPONSE_INVALID';
+
+export type BotSkillActivationAckPollStatus =
+  | 'idle'
+  | 'local_apply_pending'
+  | 'already_acked'
+  | 'backoff'
+  | 'acked'
+  | 'retry_scheduled'
+  | 'blocked';
+
+export interface BotSkillActivationAckPollResult {
+  status: BotSkillActivationAckPollStatus;
+  warningCode?: BotSkillActivationAckWarningCode;
+  mutationId?: string;
+}
+
+interface BotSkillActivationAckStateStore {
+  inspectForAck(botId: string, skillsRoot: string): BotSkillActivationAckInspection;
+  markAcked(
+    botId: string,
+    skillsRoot: string,
+    identity: BotSkillActivationIdentity,
+  ): BotSkillActivationJournal;
+}
+
+export interface BotSkillActivationAckWorkerOptions {
+  runtimeRoot: string;
+  skillsRoot: string;
+  botId: string;
+  bodyId: string;
+  installationId: string;
+  runtimeCredential: string;
+  httpBaseUrl: string;
+  stateStore?: BotSkillActivationAckStateStore;
+  fetchImpl?: typeof fetch;
+  pollIntervalMs?: number;
+  requestTimeoutMs?: number;
+  now?: () => number;
+  onWarning?: (code: BotSkillActivationAckWarningCode) => void;
+}
+
+/**
+ * E3 only closes the remote acknowledgement half of the activation saga.
+ * It never stages, installs, removes, or reloads a Skill. The E1 journal and
+ * applied marker must already prove that the complete revision is live.
+ */
+export class BotSkillActivationAckWorker {
+  private readonly stateStore: BotSkillActivationAckStateStore;
+  private readonly fetchImpl: typeof fetch;
+  private readonly botId: string;
+  private readonly skillsRoot: string;
+  private readonly bodyIdHash: string;
+  private readonly runtimeCredential: string;
+  private readonly endpointBase: string;
+  private readonly pollIntervalMs: number;
+  private readonly requestTimeoutMs: number;
+  private readonly now: () => number;
+  private readonly onWarning?: (code: BotSkillActivationAckWarningCode) => void;
+  private timer?: ReturnType<typeof setInterval>;
+  private inFlight?: Promise<BotSkillActivationAckPollResult>;
+  private failures = 0;
+  private nextAttemptAt = 0;
+
+  constructor(options: BotSkillActivationAckWorkerOptions) {
+    this.botId = normalizePositiveInt64(options.botId, 'Bot ID');
+    const bodyId = normalizeRuntimeIdentity(options.bodyId, 'body ID');
+    normalizeRuntimeIdentity(options.installationId, 'installation ID');
+    this.runtimeCredential = String(options.runtimeCredential || '').trim();
+    if (!this.runtimeCredential) throw new Error('Runtime credential is required for Skill activation ACK');
+    this.endpointBase = normalizeHttpBaseUrl(options.httpBaseUrl);
+    this.skillsRoot = String(options.skillsRoot || '').trim();
+    if (!this.skillsRoot) throw new Error('Skill workspace is required for activation ACK');
+    this.bodyIdHash = crypto.createHash('sha256').update(bodyId, 'utf8').digest('hex');
+    this.stateStore = options.stateStore ?? new BotSkillActivationStateStore(options.runtimeRoot);
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.pollIntervalMs = positiveDuration(options.pollIntervalMs, DEFAULT_POLL_INTERVAL_MS);
+    this.requestTimeoutMs = positiveDuration(options.requestTimeoutMs, DEFAULT_REQUEST_TIMEOUT_MS);
+    this.now = options.now ?? Date.now;
+    this.onWarning = options.onWarning;
+  }
+
+  start(): void {
+    if (this.timer) return;
+    void this.pollOnce();
+    this.timer = setInterval(() => void this.pollOnce(), this.pollIntervalMs);
+    (this.timer as any).unref?.();
+  }
+
+  async stop(): Promise<void> {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = undefined;
+    }
+    await this.inFlight;
+  }
+
+  pollOnce(): Promise<BotSkillActivationAckPollResult> {
+    if (this.inFlight) return this.inFlight;
+    const run = this.pollOnceInternal().catch(() => this.block('STATE_INVALID'));
+    this.inFlight = run;
+    void run.finally(() => {
+      if (this.inFlight === run) this.inFlight = undefined;
+    });
+    return run;
+  }
+
+  private async pollOnceInternal(): Promise<BotSkillActivationAckPollResult> {
+    if (this.now() < this.nextAttemptAt) return { status: 'backoff' };
+    let recovery: BotSkillActivationAckInspection;
+    try {
+      recovery = this.stateStore.inspectForAck(this.botId, this.skillsRoot);
+    } catch {
+      return this.block('STATE_INVALID');
+    }
+    switch (recovery.status) {
+    case 'none':
+      this.resetBackoff();
+      return { status: 'idle' };
+    case 'not_ready':
+      this.resetBackoff();
+      return { status: 'local_apply_pending' };
+    case 'acked':
+      this.resetBackoff();
+      return { status: 'already_acked', mutationId: recovery.journal.mutationId };
+    case 'retry_ack':
+      return this.acknowledge(recovery.journal);
+    }
+  }
+
+  private async acknowledge(journal: BotSkillActivationJournal): Promise<BotSkillActivationAckPollResult> {
+    let mutationId: string;
+    try {
+      mutationId = normalizePositiveInt64(journal.mutationId, 'mutation ID');
+    } catch {
+      return this.block('MUTATION_ID_INVALID');
+    }
+    if (!journal.runtimeBodyIdHash || journal.runtimeBodyIdHash !== this.bodyIdHash) {
+      return this.block('RUNTIME_IDENTITY_MISMATCH', mutationId);
+    }
+
+    let response: Response;
+    try {
+      response = await this.fetchImpl(
+        `${this.endpointBase}/api/bot/skill-mutations/${mutationId}/activation`,
+        {
+          method: 'POST',
+          headers: {
+            'X-CatsCo-Runtime-Credential': this.runtimeCredential,
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+          },
+          body: JSON.stringify({
+            appliedDefinitionRevision: journal.definitionRevision,
+            skillSetHash: journal.skillSetHash,
+            result: 'applied',
+          }),
+          signal: AbortSignal.timeout(this.requestTimeoutMs),
+        },
+      );
+    } catch {
+      return this.retry('ACK_RETRYABLE', mutationId);
+    }
+
+    if (response.status !== 200) {
+      if (response.status === 401 || response.status === 403) {
+        return this.retry('CREDENTIAL_REJECTED', mutationId);
+      }
+      if (response.status === 404) return this.retry('ACK_NOT_AVAILABLE', mutationId);
+      if (response.status === 409) return this.block('ACTIVATION_FACT_CONFLICT', mutationId);
+      if (response.status === 408 || response.status === 425 || response.status === 429 || response.status >= 500) {
+        return this.retry('ACK_RETRYABLE', mutationId);
+      }
+      return this.block('ACK_RESPONSE_INVALID', mutationId);
+    }
+
+    let payload: Record<string, unknown>;
+    try {
+      payload = await response.json() as Record<string, unknown>;
+    } catch {
+      return this.retry('ACK_RESPONSE_INVALID', mutationId);
+    }
+    if (
+      normalizeResponseID(payload.mutation_id) !== mutationId
+      || payload.status !== 'active'
+      || Number(payload.applied_definition_revision) !== journal.definitionRevision
+    ) {
+      return this.block('ACK_RESPONSE_INVALID', mutationId);
+    }
+
+    try {
+      this.stateStore.markAcked(this.botId, this.skillsRoot, journal);
+    } catch {
+      return this.block('STATE_INVALID', mutationId);
+    }
+    this.resetBackoff();
+    return { status: 'acked', mutationId };
+  }
+
+  private retry(
+    warningCode: BotSkillActivationAckWarningCode,
+    mutationId?: string,
+  ): BotSkillActivationAckPollResult {
+    this.failures += 1;
+    const delay = Math.min(
+      this.pollIntervalMs * (2 ** Math.min(this.failures - 1, 10)),
+      MAX_RETRY_DELAY_MS,
+    );
+    this.nextAttemptAt = this.now() + delay;
+    if (this.failures === 1 || this.failures % 12 === 0) this.notifyWarning(warningCode);
+    return { status: 'retry_scheduled', warningCode, mutationId };
+  }
+
+  private block(
+    warningCode: BotSkillActivationAckWarningCode,
+    mutationId?: string,
+  ): BotSkillActivationAckPollResult {
+    this.failures += 1;
+    this.nextAttemptAt = this.now() + MAX_RETRY_DELAY_MS;
+    if (this.failures === 1 || this.failures % 12 === 0) this.notifyWarning(warningCode);
+    return { status: 'blocked', warningCode, mutationId };
+  }
+
+  private resetBackoff(): void {
+    this.failures = 0;
+    this.nextAttemptAt = 0;
+  }
+
+  private notifyWarning(code: BotSkillActivationAckWarningCode): void {
+    try {
+      this.onWarning?.(code);
+    } catch {
+      // Observability hooks must never break acknowledgement retry semantics.
+    }
+  }
+}
+
+export function isBotSkillActivationAckWorkerEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return String(env.XIAOBA_SKILL_MUTATION_ACTIVATION_ACK_WORKER_ENABLED || '').trim().toLowerCase() === 'true';
+}
+
+function normalizePositiveInt64(value: unknown, label: string): string {
+  const normalized = String(value || '').trim();
+  if (!/^[1-9]\d{0,18}$/.test(normalized)) throw new Error(`${label} is invalid`);
+  const parsed = BigInt(normalized);
+  if (parsed > MAX_INT64) throw new Error(`${label} is invalid`);
+  return normalized;
+}
+
+function normalizeRuntimeIdentity(value: unknown, label: string): string {
+  const normalized = String(value || '').trim();
+  if (!normalized || normalized.length > 128 || /[\r\n\0]/.test(normalized)) {
+    throw new Error(`Runtime ${label} is invalid`);
+  }
+  return normalized;
+}
+
+function normalizeHttpBaseUrl(value: unknown): string {
+  const normalized = String(value || '').trim().replace(/\/+$/, '');
+  const parsed = new URL(normalized);
+  if ((parsed.protocol !== 'https:' && parsed.protocol !== 'http:') || parsed.username || parsed.password) {
+    throw new Error('CatsCo HTTP endpoint is invalid');
+  }
+  return normalized;
+}
+
+function normalizeResponseID(value: unknown): string {
+  if (typeof value === 'number' && Number.isSafeInteger(value) && value > 0) return String(value);
+  if (typeof value === 'string') {
+    try {
+      return normalizePositiveInt64(value, 'response mutation ID');
+    } catch {
+      return '';
+    }
+  }
+  return '';
+}
+
+function positiveDuration(value: number | undefined, fallback: number): number {
+  return Number.isFinite(value) && Number(value) > 0 ? Number(value) : fallback;
+}

--- a/src/bot-skills/activation-state.ts
+++ b/src/bot-skills/activation-state.ts
@@ -62,6 +62,12 @@ export type BotSkillActivationRecovery =
   | { status: 'retry_ack'; journal: BotSkillActivationJournal; marker: BotSkillAppliedMarker }
   | { status: 'acked'; journal: BotSkillActivationJournal; marker: BotSkillAppliedMarker };
 
+export type BotSkillActivationAckInspection =
+  | { status: 'none' }
+  | { status: 'not_ready'; journal: BotSkillActivationJournal }
+  | { status: 'retry_ack'; journal: BotSkillActivationJournal; marker: BotSkillAppliedMarker }
+  | { status: 'acked'; journal: BotSkillActivationJournal; marker: BotSkillAppliedMarker };
+
 /**
  * Computes a stable hash for the complete BotDefinition Skill reference set.
  * This intentionally hashes reference facts only; it is not a workspace-content
@@ -261,6 +267,29 @@ export class BotSkillActivationStateStore {
     return journal.phase === 'acked'
       ? { status: 'acked', journal, marker }
       : { status: 'retry_ack', journal, marker };
+  }
+
+  /**
+   * Read-only E3 boundary. Unlike recover(), this never removes a stage,
+   * restores a backup, advances a phase, or writes any workspace state. It
+   * only proves whether an already locally_applied activation may be ACKed.
+   */
+  inspectForAck(botId: string, skillsRoot: string): BotSkillActivationAckInspection {
+    const journal = this.readJournal(botId, skillsRoot);
+    if (!journal) return { status: 'none' };
+    if (journal.phase !== 'locally_applied' && journal.phase !== 'acked') {
+      return { status: 'not_ready', journal };
+    }
+    const marker = this.readApplied(journal.botId);
+    if (!marker || !appliedMatchesJournal(marker, journal)) {
+      throw new Error('Bot Skill activation journal does not match its applied marker');
+    }
+    if (journal.phase === 'acked') return { status: 'acked', journal, marker };
+    assertSafeWorkspacePathType(journal.skillsRoot, 'live');
+    assertSafeWorkspacePathType(journal.stage, 'stage');
+    assertSafeWorkspacePathType(journal.backup, 'backup');
+    assertLiveMatchesJournal(journal);
+    return { status: 'retry_ack', journal, marker };
   }
 
   private requireJournal(

--- a/src/catscompany/runtime-config.ts
+++ b/src/catscompany/runtime-config.ts
@@ -120,6 +120,19 @@ export function resolveCatsCoRuntimeConfig(
     effectiveEnv.CATSCOMPANY_RUNTIME_CREDENTIAL,
     config.catscompany?.runtimeCredential,
   );
+  const explicitRuntimeActivationAckCredential = firstNonEmpty(
+    effectiveEnv.CATSCO_RUNTIME_ACTIVATION_ACK_CREDENTIAL,
+    effectiveEnv.CATSCOMPANY_RUNTIME_ACTIVATION_ACK_CREDENTIAL,
+  );
+  const runtimeActivationAckCredential = firstNonEmpty(
+    explicitRuntimeActivationAckCredential,
+    config.catscompany?.runtimeActivationAckCredential,
+  );
+  // An explicitly managed server credential has its own server-side expiry.
+  // Only attach local expiry metadata to an automatically provisioned token.
+  const runtimeActivationAckCredentialExpiresAt = explicitRuntimeActivationAckCredential
+    ? undefined
+    : config.catscompany?.runtimeActivationAckCredentialExpiresAt;
   const httpBaseUrl = normalizeBaseUrl(
     firstNonEmpty(explicitHttpBaseUrl, config.catscompany?.httpBaseUrl, auth.httpBaseUrl),
     DEFAULT_CATSCO_HTTP_BASE_URL,
@@ -152,6 +165,8 @@ export function resolveCatsCoRuntimeConfig(
       bodyId,
       installationId,
       runtimeCredential,
+      runtimeActivationAckCredential,
+      runtimeActivationAckCredentialExpiresAt,
       ownerUserId,
       deviceName: localConfig.device?.name,
       runtimeRole,

--- a/src/catscompany/runtime-credential.ts
+++ b/src/catscompany/runtime-credential.ts
@@ -1,7 +1,8 @@
 import type { CatsCompanyConfig } from './types';
 import type { CatsCoAuthSnapshot } from './local-config';
 
-const RUNTIME_CREDENTIAL_SCOPE = 'skill_mutation:grant';
+export const CATSCO_RUNTIME_MUTATION_GRANT_SCOPE = 'skill_mutation:grant';
+export const CATSCO_RUNTIME_ACTIVATION_ACK_SCOPE = 'skill_mutation:activation_ack';
 const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
 
 export interface CatsCoRuntimeCredential {
@@ -19,6 +20,7 @@ export interface IssueCatsCoRuntimeCredentialOptions {
   botUid: string;
   bodyId: string;
   installationId: string;
+  scopes?: string[];
   fetchImpl?: typeof fetch;
   timeoutMs?: number;
 }
@@ -31,6 +33,7 @@ export async function issueCatsCoRuntimeCredential(
   const botUid = String(options.botUid || '').trim();
   const bodyId = String(options.bodyId || '').trim();
   const installationId = String(options.installationId || '').trim();
+  const requestedScopes = normalizeRequestedScopes(options.scopes);
   if (!userToken || !/^\d+$/.test(botUid) || Number(botUid) <= 0 || !bodyId || !installationId) {
     throw new Error('CatsCo Runtime credential request is missing a trusted owner or Runtime binding.');
   }
@@ -50,6 +53,7 @@ export async function issueCatsCoRuntimeCredential(
       bot_uid: Number(botUid),
       body_id: bodyId,
       installation_id: installationId,
+      ...(options.scopes ? { scopes: requestedScopes } : {}),
     }),
     signal: AbortSignal.timeout(timeoutMs),
   });
@@ -73,7 +77,11 @@ export async function issueCatsCoRuntimeCredential(
     || !credential
     || !Number.isFinite(expiresAt)
     || expiresAt <= Date.now()
-    || !scopes.includes(RUNTIME_CREDENTIAL_SCOPE)
+    || !requestedScopes.every(scope => scopes.includes(scope))
+    || scopes.some(scope => (
+      scope !== CATSCO_RUNTIME_MUTATION_GRANT_SCOPE
+      && scope !== CATSCO_RUNTIME_ACTIVATION_ACK_SCOPE
+    ))
   ) {
     throw new Error('CatsCo returned an invalid Runtime credential binding.');
   }
@@ -83,7 +91,7 @@ export async function issueCatsCoRuntimeCredential(
 export async function provisionCatsCoRuntimeCredential(
   config: CatsCompanyConfig,
   auth: CatsCoAuthSnapshot,
-  options: Pick<IssueCatsCoRuntimeCredentialOptions, 'fetchImpl' | 'timeoutMs'> = {},
+  options: Pick<IssueCatsCoRuntimeCredentialOptions, 'fetchImpl' | 'timeoutMs' | 'scopes'> = {},
 ): Promise<CatsCompanyConfig> {
   if (String(config.runtimeCredential || '').trim()) return config;
   const userToken = String(auth.token || '').trim();
@@ -111,4 +119,27 @@ export async function provisionCatsCoRuntimeCredential(
     runtimeCredential: issued.credential,
     runtimeCredentialExpiresAt: issued.expiresAt,
   };
+}
+
+function normalizeRequestedScopes(input: string[] | undefined): string[] {
+  if (input === undefined) return [CATSCO_RUNTIME_MUTATION_GRANT_SCOPE];
+  const scopes = input.map(value => String(value || '').trim());
+  const allowed = new Set([
+    CATSCO_RUNTIME_MUTATION_GRANT_SCOPE,
+    CATSCO_RUNTIME_ACTIVATION_ACK_SCOPE,
+  ]);
+  if (
+    scopes.length === 0
+    || !scopes.includes(CATSCO_RUNTIME_MUTATION_GRANT_SCOPE)
+    || new Set(scopes).size !== scopes.length
+    || scopes.some(scope => !allowed.has(scope))
+  ) {
+    throw new Error('CatsCo Runtime credential request contains invalid scopes.');
+  }
+  return [
+    CATSCO_RUNTIME_MUTATION_GRANT_SCOPE,
+    ...(scopes.includes(CATSCO_RUNTIME_ACTIVATION_ACK_SCOPE)
+      ? [CATSCO_RUNTIME_ACTIVATION_ACK_SCOPE]
+      : []),
+  ];
 }

--- a/src/catscompany/runtime-credential.ts
+++ b/src/catscompany/runtime-credential.ts
@@ -93,7 +93,15 @@ export async function provisionCatsCoRuntimeCredential(
   auth: CatsCoAuthSnapshot,
   options: Pick<IssueCatsCoRuntimeCredentialOptions, 'fetchImpl' | 'timeoutMs' | 'scopes'> = {},
 ): Promise<CatsCompanyConfig> {
-  if (String(config.runtimeCredential || '').trim()) return config;
+  const requestedScopes = normalizeRequestedScopes(options.scopes);
+  const needsActivationAck = requestedScopes.includes(CATSCO_RUNTIME_ACTIVATION_ACK_SCOPE);
+  const existingGrantCredential = String(config.runtimeCredential || '').trim();
+  if (
+    (!needsActivationAck && existingGrantCredential)
+    || (needsActivationAck && getUsableCatsCoRuntimeActivationAckCredential(config))
+  ) {
+    return config;
+  }
   const userToken = String(auth.token || '').trim();
   const actorUid = String(auth.uid || '').trim();
   const ownerUid = String(config.ownerUserId || '').trim();
@@ -101,8 +109,9 @@ export async function provisionCatsCoRuntimeCredential(
   const bodyId = String(config.bodyId || '').trim();
   const installationId = String(config.installationId || config.bodyId || '').trim();
   // Automatic provisioning is deliberately owner-only. Server runtimes that
-  // do not keep a human session use the explicit CATSCO_RUNTIME_CREDENTIAL
-  // configuration path instead.
+  // do not keep a human session use the explicit credential configuration
+  // paths instead. In particular, an old grant-only credential is never
+  // guessed to contain the activation ACK scope.
   if (!userToken || !actorUid || !ownerUid || actorUid !== ownerUid || !botUid || !bodyId || !installationId) {
     return config;
   }
@@ -116,9 +125,29 @@ export async function provisionCatsCoRuntimeCredential(
   });
   return {
     ...config,
-    runtimeCredential: issued.credential,
-    runtimeCredentialExpiresAt: issued.expiresAt,
+    ...(!existingGrantCredential ? {
+      runtimeCredential: issued.credential,
+      runtimeCredentialExpiresAt: issued.expiresAt,
+    } : {}),
+    ...(needsActivationAck ? {
+      runtimeActivationAckCredential: issued.credential,
+      runtimeActivationAckCredentialExpiresAt: issued.expiresAt,
+    } : {}),
   };
+}
+
+export function getUsableCatsCoRuntimeActivationAckCredential(
+  config: Pick<
+    CatsCompanyConfig,
+    'runtimeActivationAckCredential' | 'runtimeActivationAckCredentialExpiresAt'
+  >,
+  now = Date.now(),
+): string | undefined {
+  const credential = String(config.runtimeActivationAckCredential || '').trim();
+  if (!credential) return undefined;
+  const expiresAt = Number(config.runtimeActivationAckCredentialExpiresAt);
+  if (Number.isFinite(expiresAt) && expiresAt <= now) return undefined;
+  return credential;
 }
 
 function normalizeRequestedScopes(input: string[] | undefined): string[] {

--- a/src/catscompany/types.ts
+++ b/src/catscompany/types.ts
@@ -19,13 +19,20 @@ export interface CatsCompanyConfig {
   installationId?: string;
   /**
    * Owner-provisioned credential for the concrete Runtime body/installation.
-   * This is separate from the Bot API key and currently grants only the right
-   * to request a candidate-bound Skill mutation grant. A separately reviewed
-   * canary may also include the activation ACK scope; old credentials do not.
+   * This is separate from the Bot API key and grants only the right to request
+   * a candidate-bound Skill mutation grant.
    */
   runtimeCredential?: string;
   /** Expiry of an automatically provisioned Runtime credential, in Unix milliseconds. */
   runtimeCredentialExpiresAt?: number;
+  /**
+   * Dedicated credential explicitly issued with the activation ACK scope.
+   * The ACK worker must never fall back to runtimeCredential because old
+   * Runtime credentials are grant-only and must not be silently upgraded.
+   */
+  runtimeActivationAckCredential?: string;
+  /** Expiry of an automatically provisioned activation ACK credential. */
+  runtimeActivationAckCredentialExpiresAt?: number;
   /** 当前本机设备归属的 CatsCo 用户 uid，用于区分本地自用与外部委托 */
   ownerUserId?: string;
   /** 用户可见设备名，用于 Dashboard 展示和服务端设备选择 */

--- a/src/catscompany/types.ts
+++ b/src/catscompany/types.ts
@@ -20,7 +20,8 @@ export interface CatsCompanyConfig {
   /**
    * Owner-provisioned credential for the concrete Runtime body/installation.
    * This is separate from the Bot API key and currently grants only the right
-   * to request a candidate-bound Skill mutation grant.
+   * to request a candidate-bound Skill mutation grant. A separately reviewed
+   * canary may also include the activation ACK scope; old credentials do not.
    */
   runtimeCredential?: string;
   /** Expiry of an automatically provisioned Runtime credential, in Unix milliseconds. */

--- a/src/commands/catscompany.ts
+++ b/src/commands/catscompany.ts
@@ -22,6 +22,7 @@ import { getPromptReconcileCoordinator } from '../bot-definition/prompt-sync';
 import {
   CATSCO_RUNTIME_ACTIVATION_ACK_SCOPE,
   CATSCO_RUNTIME_MUTATION_GRANT_SCOPE,
+  getUsableCatsCoRuntimeActivationAckCredential,
   provisionCatsCoRuntimeCredential,
 } from '../catscompany/runtime-credential';
 import {
@@ -107,17 +108,23 @@ export async function catscompanyCommand(): Promise<void> {
   }
 
   try {
+    const hadGrantCredential = Boolean(String(connectorConfig.runtimeCredential || '').trim());
+    const hadActivationAckCredential = Boolean(
+      getUsableCatsCoRuntimeActivationAckCredential(connectorConfig),
+    );
     const provisioned = await provisionCatsCoRuntimeCredential(connectorConfig, resolvedRuntime.auth, {
       ...(activationAckWorkerEnabled ? {
         scopes: [CATSCO_RUNTIME_MUTATION_GRANT_SCOPE, CATSCO_RUNTIME_ACTIVATION_ACK_SCOPE],
       } : {}),
     });
-    if (provisioned.runtimeCredential && !connectorConfig.runtimeCredential) {
-      Logger.info(
-        activationAckWorkerEnabled
-          ? 'CatsCo Runtime 已取得受限 Skill mutation grant + activation ACK 凭证。'
-          : 'CatsCo Runtime 已取得受限 Skill mutation grant 凭证。',
-      );
+    if (
+      activationAckWorkerEnabled
+      && !hadActivationAckCredential
+      && getUsableCatsCoRuntimeActivationAckCredential(provisioned)
+    ) {
+      Logger.info('CatsCo Runtime 已取得独立的 Skill activation ACK 凭证。');
+    } else if (!hadGrantCredential && provisioned.runtimeCredential) {
+      Logger.info('CatsCo Runtime 已取得受限 Skill mutation grant 凭证。');
     }
     connectorConfig = provisioned;
   } catch (error) {
@@ -180,11 +187,11 @@ export async function catscompanyCommand(): Promise<void> {
     const auth = createCatsCoLocalConfigService({ runtimeRoot }).getAuthState();
     const modelBotId = String(preparedBot?.botId || connectorConfig.botUid || '').trim();
     if (activationAckWorkerEnabled) {
-      const credential = String(connectorConfig.runtimeCredential || '').trim();
+      const activationAckCredential = getUsableCatsCoRuntimeActivationAckCredential(connectorConfig);
       const connectorBotId = String(connectorConfig.botUid || '').trim();
       const installationId = String(connectorConfig.installationId || connectorConfig.bodyId || '').trim();
-      if (!credential) {
-        Logger.warning('Skill activation ACK worker 未启动：当前 Runtime 没有带专用 scope 的凭据；普通聊天继续可用。');
+      if (!activationAckCredential) {
+        Logger.warning('Skill activation ACK worker 未启动：当前 Runtime 没有可用的专用 ACK 凭据；不会复用旧 grant-only 凭据，普通聊天继续可用。');
       } else if (!connectorBotId || (modelBotId && modelBotId !== connectorBotId)) {
         Logger.warning('Skill activation ACK worker 未启动：本地 BotDefinition 与连接 Bot 身份不一致；普通聊天继续可用。');
       } else {
@@ -195,7 +202,7 @@ export async function catscompanyCommand(): Promise<void> {
             botId: connectorBotId,
             bodyId: connectorConfig.bodyId || '',
             installationId,
-            runtimeCredential: credential,
+            activationAckCredential,
             httpBaseUrl: connectorConfig.httpBaseUrl || resolvedRuntime.auth.httpBaseUrl,
             onWarning: code => Logger.warning(skillActivationAckWarning(code)),
           });

--- a/src/commands/catscompany.ts
+++ b/src/commands/catscompany.ts
@@ -19,7 +19,16 @@ import { CloudBotModelRuntimeReloadController } from '../bot-definition/runtime-
 import { createBotDefinitionSyncService } from '../bot-definition/service';
 import { resolveRunnableCloudDefinition } from '../bot-definition/cloud-sync';
 import { getPromptReconcileCoordinator } from '../bot-definition/prompt-sync';
-import { provisionCatsCoRuntimeCredential } from '../catscompany/runtime-credential';
+import {
+  CATSCO_RUNTIME_ACTIVATION_ACK_SCOPE,
+  CATSCO_RUNTIME_MUTATION_GRANT_SCOPE,
+  provisionCatsCoRuntimeCredential,
+} from '../catscompany/runtime-credential';
+import {
+  BotSkillActivationAckWorker,
+  isBotSkillActivationAckWorkerEnabled,
+  type BotSkillActivationAckWarningCode,
+} from '../bot-skills/activation-ack-worker';
 
 const CONNECTOR_OWNER_POLL_MS = 2000;
 const CLOUD_MODEL_POLL_MS = 5000;
@@ -63,6 +72,7 @@ export async function catscompanyCommand(): Promise<void> {
     missing: resolvedRuntime.missing,
     config: resolvedRuntime.connector,
   };
+  const activationAckWorkerEnabled = isBotSkillActivationAckWorkerEnabled(process.env);
 
   let connectorConfig = resolved.config;
   if (!connectorConfig) {
@@ -97,9 +107,17 @@ export async function catscompanyCommand(): Promise<void> {
   }
 
   try {
-    const provisioned = await provisionCatsCoRuntimeCredential(connectorConfig, resolvedRuntime.auth);
+    const provisioned = await provisionCatsCoRuntimeCredential(connectorConfig, resolvedRuntime.auth, {
+      ...(activationAckWorkerEnabled ? {
+        scopes: [CATSCO_RUNTIME_MUTATION_GRANT_SCOPE, CATSCO_RUNTIME_ACTIVATION_ACK_SCOPE],
+      } : {}),
+    });
     if (provisioned.runtimeCredential && !connectorConfig.runtimeCredential) {
-      Logger.info('CatsCo Runtime 已取得受限 Skill mutation grant 凭证。');
+      Logger.info(
+        activationAckWorkerEnabled
+          ? 'CatsCo Runtime 已取得受限 Skill mutation grant + activation ACK 凭证。'
+          : 'CatsCo Runtime 已取得受限 Skill mutation grant 凭证。',
+      );
     }
     connectorConfig = provisioned;
   } catch (error) {
@@ -115,6 +133,7 @@ export async function catscompanyCommand(): Promise<void> {
   let cloudModelWatchTimer: NodeJS.Timeout | null = null;
   let cloudModelReloadPromise: Promise<void> | null = null;
   let pendingCloudModelAck: PendingCloudModelAck | null = null;
+  let skillActivationAckWorker: BotSkillActivationAckWorker | null = null;
   let shuttingDown = false;
 
   // 优雅退出
@@ -131,6 +150,7 @@ export async function catscompanyCommand(): Promise<void> {
     }
     try {
       await cloudModelReloadPromise;
+      await skillActivationAckWorker?.stop();
       await stopRuntimeCommandSupport();
       await bot.destroy();
     } finally {
@@ -159,6 +179,34 @@ export async function catscompanyCommand(): Promise<void> {
     await startRuntimeCommandSupport();
     const auth = createCatsCoLocalConfigService({ runtimeRoot }).getAuthState();
     const modelBotId = String(preparedBot?.botId || connectorConfig.botUid || '').trim();
+    if (activationAckWorkerEnabled) {
+      const credential = String(connectorConfig.runtimeCredential || '').trim();
+      const connectorBotId = String(connectorConfig.botUid || '').trim();
+      const installationId = String(connectorConfig.installationId || connectorConfig.bodyId || '').trim();
+      if (!credential) {
+        Logger.warning('Skill activation ACK worker 未启动：当前 Runtime 没有带专用 scope 的凭据；普通聊天继续可用。');
+      } else if (!connectorBotId || (modelBotId && modelBotId !== connectorBotId)) {
+        Logger.warning('Skill activation ACK worker 未启动：本地 BotDefinition 与连接 Bot 身份不一致；普通聊天继续可用。');
+      } else {
+        try {
+          skillActivationAckWorker = new BotSkillActivationAckWorker({
+            runtimeRoot,
+            skillsRoot: PathResolver.getSkillsPath(),
+            botId: connectorBotId,
+            bodyId: connectorConfig.bodyId || '',
+            installationId,
+            runtimeCredential: credential,
+            httpBaseUrl: connectorConfig.httpBaseUrl || resolvedRuntime.auth.httpBaseUrl,
+            onWarning: code => Logger.warning(skillActivationAckWarning(code)),
+          });
+          skillActivationAckWorker.start();
+          Logger.info('Skill activation ACK worker 已按灰度开关启动；仅处理 E1 locally_applied journal。');
+        } catch {
+          skillActivationAckWorker = null;
+          Logger.warning('Skill activation ACK worker 配置无效，已保持关闭；普通聊天继续可用。');
+        }
+      }
+    }
     if (preparedBot?.cloudSelection) {
       const initialApplyError = preparedBot.cloudApplyError || '';
       try {
@@ -272,6 +320,27 @@ interface PendingCloudModelAck {
   selection: CloudBotModelSelection;
   applyError: string;
   attempts: number;
+}
+
+function skillActivationAckWarning(code: BotSkillActivationAckWarningCode): string {
+  switch (code) {
+  case 'CREDENTIAL_REJECTED':
+    return 'Skill activation ACK 凭据未被 CatsCo 接受，将退避重试；普通聊天不受影响。';
+  case 'ACK_NOT_AVAILABLE':
+    return 'CatsCo 尚未为当前 Bot 开放 Skill activation ACK，将退避重试；普通聊天不受影响。';
+  case 'ACK_RETRYABLE':
+    return 'Skill activation ACK 暂时无法送达，将退避重试；本地已应用能力保持不变。';
+  case 'ACTIVATION_FACT_CONFLICT':
+    return 'Skill activation ACK 与服务端 mutation 事实冲突，已停止快速重试并保留 journal。';
+  case 'RUNTIME_IDENTITY_MISMATCH':
+    return 'Skill activation journal 不属于当前 Runtime body，已拒绝上报并保留证据。';
+  case 'MUTATION_ID_INVALID':
+    return 'Skill activation journal 缺少有效 MutationID，已拒绝上报并保留证据。';
+  case 'STATE_INVALID':
+    return 'Skill activation journal、applied marker 或正式工作区验证失败，已拒绝上报并保留证据。';
+  case 'ACK_RESPONSE_INVALID':
+    return 'Skill activation ACK 响应与本地事实不一致，已拒绝确认并保留 journal。';
+  }
 }
 
 async function applyCloudModelRuntimeSelection(

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -103,6 +103,8 @@ export interface ChatConfig {
     serverUrl?: string;
     apiKey?: string;
     runtimeCredential?: string;
+    runtimeActivationAckCredential?: string;
+    runtimeActivationAckCredentialExpiresAt?: number;
     httpBaseUrl?: string;
     sessionTTL?: number;
   };

--- a/tests/bot-skills-activation-ack-worker.test.ts
+++ b/tests/bot-skills-activation-ack-worker.test.ts
@@ -221,7 +221,7 @@ function createWorker(
     botId: '42',
     bodyId: 'body-prod-1',
     installationId: 'install-prod-1',
-    runtimeCredential: 'runtime-credential',
+    activationAckCredential: 'runtime-credential',
     httpBaseUrl: 'https://app.catsco.cc/',
     stateStore: fixture.store,
     pollIntervalMs: 5_000,

--- a/tests/bot-skills-activation-ack-worker.test.ts
+++ b/tests/bot-skills-activation-ack-worker.test.ts
@@ -1,0 +1,240 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as crypto from 'node:crypto';
+import type {
+  BotSkillAppliedMarker,
+  BotSkillActivationAckInspection,
+  BotSkillActivationJournal,
+} from '../src/bot-skills/activation-state';
+import {
+  BotSkillActivationAckWorker,
+  isBotSkillActivationAckWorkerEnabled,
+} from '../src/bot-skills/activation-ack-worker';
+
+describe('Bot Skill activation ACK worker E3', () => {
+  test('is disabled unless the dedicated flag is explicitly true', () => {
+    assert.equal(isBotSkillActivationAckWorkerEnabled({}), false);
+    assert.equal(isBotSkillActivationAckWorkerEnabled({
+      XIAOBA_SKILL_MUTATION_ACTIVATION_ACK_WORKER_ENABLED: 'false',
+    }), false);
+    assert.equal(isBotSkillActivationAckWorkerEnabled({
+      XIAOBA_SKILL_MUTATION_ACTIVATION_ACK_WORKER_ENABLED: ' TRUE ',
+    }), true);
+  });
+
+  test('ACKs only a locally applied journal and persists acked after an exact response', async () => {
+    const fixture = createFixture();
+    let captured: { url: string; init?: RequestInit } | undefined;
+    const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+      captured = { url: String(input), init };
+      return activationResponse(fixture.journal);
+    }) as typeof fetch;
+    const worker = createWorker(fixture, { fetchImpl });
+
+    const result = await worker.pollOnce();
+
+    assert.deepEqual(result, { status: 'acked', mutationId: '101' });
+    assert.equal(fixture.markAckedCalls, 1);
+    assert.equal(captured?.url, 'https://app.catsco.cc/api/bot/skill-mutations/101/activation');
+    const headers = captured?.init?.headers as Record<string, string>;
+    assert.equal(headers['X-CatsCo-Runtime-Credential'], 'runtime-credential');
+    assert.equal(headers['X-API-Key'], undefined);
+    assert.deepEqual(JSON.parse(String(captured?.init?.body)), {
+      appliedDefinitionRevision: 12,
+      skillSetHash: fixture.journal.skillSetHash,
+      result: 'applied',
+    });
+    assert.equal(String(captured?.init?.body).includes('body-prod-1'), false);
+    assert.equal(String(captured?.init?.body).includes('skillsRoot'), false);
+  });
+
+  test('retries a lost ACK with backoff and relies on server idempotency', async () => {
+    const fixture = createFixture();
+    let now = 1_000;
+    let requests = 0;
+    const fetchImpl = (async () => {
+      requests += 1;
+      if (requests === 1) throw new Error('network unavailable');
+      return activationResponse(fixture.journal, true);
+    }) as typeof fetch;
+    const worker = createWorker(fixture, { fetchImpl, now: () => now });
+
+    assert.deepEqual(await worker.pollOnce(), {
+      status: 'retry_scheduled', warningCode: 'ACK_RETRYABLE', mutationId: '101',
+    });
+    assert.equal(fixture.markAckedCalls, 0);
+    assert.equal((await worker.pollOnce()).status, 'backoff');
+    assert.equal(requests, 1);
+
+    now += 5_000;
+    assert.equal((await worker.pollOnce()).status, 'acked');
+    assert.equal(requests, 2);
+    assert.equal(fixture.markAckedCalls, 1);
+  });
+
+  test('coalesces concurrent polls into one Runtime-authenticated ACK request', async () => {
+    const fixture = createFixture();
+    let requests = 0;
+    let release!: (response: Response) => void;
+    const response = new Promise<Response>(resolve => { release = resolve; });
+    const worker = createWorker(fixture, {
+      fetchImpl: (async () => {
+        requests += 1;
+        return response;
+      }) as typeof fetch,
+    });
+
+    const first = worker.pollOnce();
+    const second = worker.pollOnce();
+    assert.equal(first, second);
+    release(activationResponse(fixture.journal));
+    assert.equal((await first).status, 'acked');
+    assert.equal((await second).status, 'acked');
+    assert.equal(requests, 1);
+    assert.equal(fixture.markAckedCalls, 1);
+  });
+
+  test('never marks acked when Runtime identity or server facts conflict', async () => {
+    const wrongBody = createFixture({ runtimeBodyIdHash: crypto.createHash('sha256').update('other-body').digest('hex') });
+    let requests = 0;
+    const identityWorker = createWorker(wrongBody, {
+      fetchImpl: (async () => {
+        requests += 1;
+        return activationResponse(wrongBody.journal);
+      }) as typeof fetch,
+    });
+    assert.deepEqual(await identityWorker.pollOnce(), {
+      status: 'blocked', warningCode: 'RUNTIME_IDENTITY_MISMATCH', mutationId: '101',
+    });
+    assert.equal(requests, 0);
+    assert.equal(wrongBody.markAckedCalls, 0);
+
+    const conflict = createFixture();
+    const conflictWorker = createWorker(conflict, {
+      fetchImpl: (async () => new Response('{}', { status: 409 })) as typeof fetch,
+    });
+    assert.deepEqual(await conflictWorker.pollOnce(), {
+      status: 'blocked', warningCode: 'ACTIVATION_FACT_CONFLICT', mutationId: '101',
+    });
+    assert.equal(conflict.markAckedCalls, 0);
+
+    const wrongResponse = createFixture();
+    const wrongResponseWorker = createWorker(wrongResponse, {
+      fetchImpl: (async () => new Response(JSON.stringify({
+        mutation_id: 101,
+        status: 'active',
+        applied_definition_revision: 13,
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } })) as typeof fetch,
+    });
+    assert.deepEqual(await wrongResponseWorker.pollOnce(), {
+      status: 'blocked', warningCode: 'ACK_RESPONSE_INVALID', mutationId: '101',
+    });
+    assert.equal(wrongResponse.markAckedCalls, 0);
+  });
+
+  test('does not ACK a journal that still needs local apply or has invalid evidence', async () => {
+    const pending = createFixture({ recoveryStatus: 'resume_local_apply' });
+    let requests = 0;
+    const pendingWorker = createWorker(pending, {
+      fetchImpl: (async () => {
+        requests += 1;
+        return activationResponse(pending.journal);
+      }) as typeof fetch,
+    });
+    assert.deepEqual(await pendingWorker.pollOnce(), { status: 'local_apply_pending' });
+    assert.equal(requests, 0);
+
+    const invalid = createFixture({ recoverError: true });
+    const invalidWorker = createWorker(invalid, {
+      fetchImpl: (async () => {
+        requests += 1;
+        return activationResponse(invalid.journal);
+      }) as typeof fetch,
+    });
+    assert.deepEqual(await invalidWorker.pollOnce(), {
+      status: 'blocked', warningCode: 'STATE_INVALID', mutationId: undefined,
+    });
+    assert.equal(requests, 0);
+  });
+});
+
+interface FixtureOptions {
+  runtimeBodyIdHash?: string;
+  recoveryStatus?: 'retry_ack' | 'resume_local_apply';
+  recoverError?: boolean;
+}
+
+function createFixture(options: FixtureOptions = {}) {
+  const bodyIdHash = options.runtimeBodyIdHash
+    ?? crypto.createHash('sha256').update('body-prod-1').digest('hex');
+  const journal: BotSkillActivationJournal = {
+    schema: 'xiaoba.bot-skill-activation-journal.v2' as BotSkillActivationJournal['schema'],
+    botId: '42',
+    skillsRoot: 'C:\\runtime\\skills',
+    stage: 'C:\\runtime\\.bot-skills-stage-101',
+    backup: 'C:\\runtime\\.bot-skills-backup-101',
+    skills: [],
+    phase: options.recoveryStatus === 'resume_local_apply' ? 'live_switched' : 'locally_applied',
+    definitionRevision: 12,
+    skillSetHash: crypto.createHash('sha256').update('[]').digest('hex'),
+    mutationId: '101',
+    runtimeBodyIdHash: bodyIdHash,
+    startedAt: '2026-08-26T00:00:00.000Z',
+    updatedAt: '2026-08-26T00:00:01.000Z',
+  };
+  const marker: BotSkillAppliedMarker = {
+    schema: 'xiaoba.bot-skill-applied.v1' as BotSkillAppliedMarker['schema'],
+    botId: journal.botId,
+    definitionRevision: journal.definitionRevision,
+    skillSetHash: journal.skillSetHash,
+    mutationId: journal.mutationId,
+    runtimeBodyIdHash: journal.runtimeBodyIdHash,
+    skills: journal.skills,
+    appliedAt: '2026-08-26T00:00:01.000Z',
+  };
+  const fixture = {
+    journal,
+    markAckedCalls: 0,
+    store: {
+      inspectForAck(): BotSkillActivationAckInspection {
+        if (options.recoverError) throw new Error('unsafe path should not be exposed');
+        return options.recoveryStatus === 'resume_local_apply'
+          ? { status: 'not_ready', journal }
+          : { status: 'retry_ack', journal, marker };
+      },
+      markAcked(): BotSkillActivationJournal {
+        fixture.markAckedCalls += 1;
+        return { ...journal, phase: 'acked' };
+      },
+    },
+  };
+  return fixture;
+}
+
+function createWorker(
+  fixture: ReturnType<typeof createFixture>,
+  overrides: Partial<ConstructorParameters<typeof BotSkillActivationAckWorker>[0]> = {},
+): BotSkillActivationAckWorker {
+  return new BotSkillActivationAckWorker({
+    runtimeRoot: 'C:\\runtime',
+    skillsRoot: fixture.journal.skillsRoot,
+    botId: '42',
+    bodyId: 'body-prod-1',
+    installationId: 'install-prod-1',
+    runtimeCredential: 'runtime-credential',
+    httpBaseUrl: 'https://app.catsco.cc/',
+    stateStore: fixture.store,
+    pollIntervalMs: 5_000,
+    ...overrides,
+  });
+}
+
+function activationResponse(journal: BotSkillActivationJournal, idempotent = false): Response {
+  return new Response(JSON.stringify({
+    mutation_id: 101,
+    status: 'active',
+    applied_definition_revision: journal.definitionRevision,
+    desired_definition_revision: journal.definitionRevision,
+    idempotent,
+  }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+}

--- a/tests/bot-skills-activation-state.test.ts
+++ b/tests/bot-skills-activation-state.test.ts
@@ -56,6 +56,8 @@ describe('Bot Skill activation state v2', () => {
     fixture.store.markAcked(fixture.botId, fixture.skillsRoot, journal);
     assert.equal(fixture.store.readJournal(fixture.botId, fixture.skillsRoot)?.phase, 'acked');
     assert.equal(fs.existsSync(fixture.backup), true);
+    fs.rmSync(fixture.skillsRoot, { recursive: true, force: true });
+    assert.equal(fixture.store.inspectForAck(fixture.botId, fixture.skillsRoot).status, 'acked');
   });
 
   test('rejects phase skips, conflicting activation identities, and ACK without an applied marker', () => {
@@ -130,6 +132,22 @@ describe('Bot Skill activation state v2', () => {
     const result = fixture.store.recover(fixture.botId, fixture.skillsRoot);
     assert.equal(result.status, 'retry_ack');
     assert.equal(result.status === 'retry_ack' && result.marker.definitionRevision, 12);
+  });
+
+  test('inspects ACK readiness without recovering or changing earlier phases', () => {
+    const fixture = createFixture(roots);
+    fs.mkdirSync(fixture.skillsRoot, { recursive: true });
+    fs.writeFileSync(path.join(fixture.skillsRoot, 'keep.txt'), 'old live');
+    fs.mkdirSync(fixture.stage, { recursive: true });
+    fs.writeFileSync(path.join(fixture.stage, 'keep-stage.txt'), 'not active');
+    fixture.store.begin(fixture.begin);
+
+    const result = fixture.store.inspectForAck(fixture.botId, fixture.skillsRoot);
+
+    assert.equal(result.status, 'not_ready');
+    assert.equal(fixture.store.readJournal(fixture.botId, fixture.skillsRoot)?.phase, 'prepared');
+    assert.equal(fs.existsSync(fixture.stage), true);
+    assert.equal(fs.readFileSync(path.join(fixture.skillsRoot, 'keep.txt'), 'utf8'), 'old live');
   });
 
   test('fails closed on a mismatched live workspace and preserves backup evidence', () => {

--- a/tests/catsco-runtime-config.test.ts
+++ b/tests/catsco-runtime-config.test.ts
@@ -55,6 +55,7 @@ describe('CatsCo runtime config resolver', () => {
         CATSCO_API_KEY: 'env-api-key',
         CATSCO_BOT_UID: 'bot-env',
         CATSCO_RUNTIME_CREDENTIAL: 'runtime-credential-env',
+        CATSCO_RUNTIME_ACTIVATION_ACK_CREDENTIAL: 'activation-ack-credential-env',
       },
     });
 
@@ -65,6 +66,7 @@ describe('CatsCo runtime config resolver', () => {
     assert.equal(resolved.connector?.installationId, 'install-typed');
     assert.equal(resolved.connector?.runtimeRole, 'server');
     assert.equal(resolved.connector?.runtimeCredential, 'runtime-credential-env');
+    assert.equal(resolved.connector?.runtimeActivationAckCredential, 'activation-ack-credential-env');
     assert.equal(resolved.auth.token, 'env-user-token');
     assert.equal(resolved.auth.uid, 'user-typed');
     assert.equal(resolved.auth.botUid, 'bot-typed');

--- a/tests/catscompany-runtime-credential.test.ts
+++ b/tests/catscompany-runtime-credential.test.ts
@@ -3,6 +3,7 @@ import * as assert from 'node:assert';
 import {
   CATSCO_RUNTIME_ACTIVATION_ACK_SCOPE,
   CATSCO_RUNTIME_MUTATION_GRANT_SCOPE,
+  getUsableCatsCoRuntimeActivationAckCredential,
   issueCatsCoRuntimeCredential,
   provisionCatsCoRuntimeCredential,
 } from '../src/catscompany/runtime-credential';
@@ -155,6 +156,62 @@ describe('CatsCo Runtime credential provisioning', () => {
     assert.ok(Number(provisioned.runtimeCredentialExpiresAt) > Date.now());
     assert.equal(friend.runtimeCredential, undefined);
     assert.equal(requests, 1);
+  });
+
+  test('reissues a dedicated ACK credential instead of reusing an existing grant-only credential', async () => {
+    let requests = 0;
+    const existing = {
+      ...config,
+      runtimeCredential: 'existing-grant-only-credential',
+      runtimeCredentialExpiresAt: Date.now() + 86_400_000,
+    };
+    const provisioned = await provisionCatsCoRuntimeCredential(existing, auth, {
+      scopes: [CATSCO_RUNTIME_MUTATION_GRANT_SCOPE, CATSCO_RUNTIME_ACTIVATION_ACK_SCOPE],
+      fetchImpl: (async () => {
+        requests += 1;
+        return new Response(JSON.stringify({
+          bot_uid: 42,
+          body_id: 'body-prod-1',
+          installation_id: 'install-prod-1',
+          scopes: [CATSCO_RUNTIME_MUTATION_GRANT_SCOPE, CATSCO_RUNTIME_ACTIVATION_ACK_SCOPE],
+          credential: 'dedicated-activation-ack-credential',
+          expires_at: Date.now() + 86_400_000,
+        }), { status: 201, headers: { 'Content-Type': 'application/json' } });
+      }) as typeof fetch,
+    });
+
+    assert.equal(requests, 1);
+    assert.equal(provisioned.runtimeCredential, 'existing-grant-only-credential');
+    assert.equal(
+      getUsableCatsCoRuntimeActivationAckCredential(provisioned),
+      'dedicated-activation-ack-credential',
+    );
+  });
+
+  test('fails closed on a server with only an existing grant-only credential', async () => {
+    let requests = 0;
+    const existing = { ...config, runtimeCredential: 'server-grant-only-credential' };
+    const provisioned = await provisionCatsCoRuntimeCredential(existing, {
+      httpBaseUrl: 'https://app.catsco.cc',
+      serverUrl: 'wss://app.catsco.cc/v0/channels',
+    }, {
+      scopes: [CATSCO_RUNTIME_MUTATION_GRANT_SCOPE, CATSCO_RUNTIME_ACTIVATION_ACK_SCOPE],
+      fetchImpl: (async () => {
+        requests += 1;
+        throw new Error('must not request without an owner session');
+      }) as typeof fetch,
+    });
+
+    assert.equal(provisioned, existing);
+    assert.equal(requests, 0);
+    assert.equal(getUsableCatsCoRuntimeActivationAckCredential(provisioned), undefined);
+  });
+
+  test('refuses to start from an expired dedicated ACK credential', () => {
+    assert.equal(getUsableCatsCoRuntimeActivationAckCredential({
+      runtimeActivationAckCredential: 'expired-activation-ack-credential',
+      runtimeActivationAckCredentialExpiresAt: 1_000,
+    }, 1_001), undefined);
   });
 
   test('preserves an explicitly provisioned server credential without an owner session', async () => {

--- a/tests/catscompany-runtime-credential.test.ts
+++ b/tests/catscompany-runtime-credential.test.ts
@@ -1,6 +1,8 @@
 import { describe, test } from 'node:test';
 import * as assert from 'node:assert';
 import {
+  CATSCO_RUNTIME_ACTIVATION_ACK_SCOPE,
+  CATSCO_RUNTIME_MUTATION_GRANT_SCOPE,
   issueCatsCoRuntimeCredential,
   provisionCatsCoRuntimeCredential,
 } from '../src/catscompany/runtime-credential';
@@ -76,6 +78,57 @@ describe('CatsCo Runtime credential provisioning', () => {
         bodyId: 'body-prod-1',
         installationId: 'install-prod-1',
         fetchImpl,
+      }),
+      /invalid Runtime credential binding/,
+    );
+  });
+
+  test('requests activation ACK scope only when explicitly enabled and verifies the response', async () => {
+    let requestBody: Record<string, unknown> | undefined;
+    const fetchImpl = (async (_input: string | URL | Request, init?: RequestInit) => {
+      requestBody = JSON.parse(String(init?.body));
+      return new Response(JSON.stringify({
+        bot_uid: 42,
+        body_id: 'body-prod-1',
+        installation_id: 'install-prod-1',
+        scopes: [CATSCO_RUNTIME_MUTATION_GRANT_SCOPE, CATSCO_RUNTIME_ACTIVATION_ACK_SCOPE],
+        credential: 'runtime-credential-with-ack',
+        expires_at: Date.now() + 86_400_000,
+      }), { status: 201, headers: { 'Content-Type': 'application/json' } });
+    }) as typeof fetch;
+
+    const issued = await issueCatsCoRuntimeCredential({
+      httpBaseUrl: 'https://app.catsco.cc',
+      userToken: 'owner-user-token',
+      botUid: '42',
+      bodyId: 'body-prod-1',
+      installationId: 'install-prod-1',
+      scopes: [CATSCO_RUNTIME_MUTATION_GRANT_SCOPE, CATSCO_RUNTIME_ACTIVATION_ACK_SCOPE],
+      fetchImpl,
+    });
+
+    assert.deepEqual(requestBody?.scopes, [
+      CATSCO_RUNTIME_MUTATION_GRANT_SCOPE,
+      CATSCO_RUNTIME_ACTIVATION_ACK_SCOPE,
+    ]);
+    assert.deepEqual(issued.scopes, requestBody?.scopes);
+
+    await assert.rejects(
+      issueCatsCoRuntimeCredential({
+        httpBaseUrl: 'https://app.catsco.cc',
+        userToken: 'owner-user-token',
+        botUid: '42',
+        bodyId: 'body-prod-1',
+        installationId: 'install-prod-1',
+        scopes: [CATSCO_RUNTIME_MUTATION_GRANT_SCOPE, CATSCO_RUNTIME_ACTIVATION_ACK_SCOPE],
+        fetchImpl: (async () => new Response(JSON.stringify({
+          bot_uid: 42,
+          body_id: 'body-prod-1',
+          installation_id: 'install-prod-1',
+          scopes: [CATSCO_RUNTIME_MUTATION_GRANT_SCOPE],
+          credential: 'grant-only-credential',
+          expires_at: Date.now() + 86_400_000,
+        }), { status: 201, headers: { 'Content-Type': 'application/json' } })) as typeof fetch,
       }),
       /invalid Runtime credential binding/,
     );


### PR DESCRIPTION
## 目标

增加第二阶段 E3 Runtime 激活 ACK worker：只有 Runtime 已经完成本地原子应用、且 E1 journal 与 applied marker、正式 Skill 工作区三者一致时，才向 CatsCo 回报该 mutation 已生效。

## 安全与兼容边界

- 新 worker 由 `XIAOBA_SKILL_MUTATION_ACTIVATION_ACK_WORKER_ENABLED` 控制，默认 `false`
- 只读检查 E1 证据；不会创建 stage、切换目录、恢复 backup、安装或删除 Skill
- 只处理 `locally_applied` journal；准备中或证据不一致时拒绝 ACK
- Runtime body 身份不一致、MutationID 无效、服务端事实冲突时保留 journal 并停止快速重试
- 网络错误、限流和服务暂不可用使用有上限的指数退避；普通聊天继续运行
- 不发送 Bot API key、body ID、安装路径或 Skill 源内容
- 没有修改文件读写/编辑、Shell、可信 Skill 执行、注入或 System Prompt 逻辑

## 凭证边界

- ACK worker 只接受独立 `runtimeActivationAckCredential` / `CATSCO_RUNTIME_ACTIVATION_ACK_CREDENTIAL`
- 不会回退复用既有 grant-only `runtimeCredential`
- Owner 有登录态且只有旧凭证时，重新签发并校验包含 ACK scope 的专用凭证
- 无 Owner 会话的服务器只有旧凭证或专用凭证过期时，拒绝启动 worker，普通聊天继续

## 实现

- 新增 read-only `inspectForAck`，与会恢复/推进状态的 `recover` 严格分离
- 新增 ACK worker、精确响应校验、并发轮询合并和幂等重试
- Runtime credential 可显式申请 `skill_mutation:activation_ack`；默认调用仍保持原 grant-only 请求
- worker 只在开关开启、Bot 身份一致且可用的专用 ACK credential 存在时启动

## 验证

- `npm run build`：通过
- E3、凭证和配置定向测试：34/34 通过
- `npm run test:skillhub-phase1`：257 通过、1 个 Windows symlink 条件跳过、0 失败
- CatsCo/XiaoBa 跨仓契约：62/62 通过
- `npm test`：1647 通过、11 跳过；仅 2 个既有 Worker artifact 测试因本机缺少 Linux `jq` 失败，与本 PR 改动无关
- GitHub Build/runtime、第一阶段门禁、BotDefinition paired contract、跨仓 smoke/e2e：全部通过

## 发布顺序

1. CatsCo E2 PR #321 已合并并通过 CI
2. 本 PR 保持默认开关关闭后合并
3. 在后续 E4 本地原子应用入口完成并单独评审前，不开启生产灰度
