### PR TITLE
fix: atomically publish reloaded Skill maps

### DIFF
--- a/src/skills/skill-manager.ts
+++ b/src/skills/skill-manager.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import { Skill } from '../types/skill';
 import { PathResolver } from '../utils/path-resolver';
 import { SkillParser } from './skill-parser';
@@ -35,6 +36,10 @@ export class SkillManager {
    */
   private async loadSkillsFromPath(basePath: string): Promise<Map<string, Skill> | undefined> {
     try {
+      if (!fs.statSync(basePath).isDirectory()) {
+        return undefined;
+      }
+
       const skillFiles = PathResolver.findSkillFiles(basePath);
       const nextSkills = new Map<string, Skill>();
 
@@ -45,6 +50,13 @@ export class SkillManager {
         } catch (error: any) {
           Logger.warning(`Failed to load skill from ${filePath}: ${error.message}`);
         }
+      }
+
+      // findSkillFiles() intentionally returns [] for a missing path. Recheck
+      // the root so a directory removed during the scan is not mistaken for a
+      // successfully empty Skill workspace.
+      if (!fs.statSync(basePath).isDirectory()) {
+        return undefined;
       }
 
       return nextSkills;

--- a/src/skills/skill-manager.ts
+++ b/src/skills/skill-manager.ts
@@ -19,31 +19,38 @@ export class SkillManager {
    * 加载所有 skills（只从统一目录加载）
    */
   async loadSkills(): Promise<void> {
-    this.skills.clear();
-
     const skillsPath = PathResolver.getSkillsPath();
-    
+
     // 从统一的 skills 目录加载
-    await this.loadSkillsFromPath(skillsPath);
+    const nextSkills = await this.loadSkillsFromPath(skillsPath);
+    if (nextSkills) {
+      // Readers keep seeing the previous complete snapshot while files are
+      // enumerated and parsed. Publish the new snapshot in one assignment.
+      this.skills = nextSkills;
+    }
   }
 
   /**
    * 从指定路径加载 skills
    */
-  private async loadSkillsFromPath(basePath: string): Promise<void> {
+  private async loadSkillsFromPath(basePath: string): Promise<Map<string, Skill> | undefined> {
     try {
       const skillFiles = PathResolver.findSkillFiles(basePath);
+      const nextSkills = new Map<string, Skill>();
 
       for (const filePath of skillFiles) {
         try {
           const skill = SkillParser.parse(filePath);
-          this.skills.set(skill.metadata.name, skill);
+          nextSkills.set(skill.metadata.name, skill);
         } catch (error: any) {
           Logger.warning(`Failed to load skill from ${filePath}: ${error.message}`);
         }
       }
+
+      return nextSkills;
     } catch (error: any) {
       // 目录不存在或无法访问，静默处理
+      return undefined;
     }
   }
 

--- a/tests/skill-manager-atomic-load.test.ts
+++ b/tests/skill-manager-atomic-load.test.ts
@@ -88,6 +88,18 @@ describe('SkillManager atomic loading', () => {
     assert.deepEqual(skillNames(manager), ['stable-skill']);
   });
 
+  test('keeps the previous complete map when the Skill directory disappears', async () => {
+    writeSkill(skillsPath, 'stable-skill', 'Stable skill');
+    const manager = new SkillManager();
+    await manager.loadSkills();
+
+    fs.rmSync(skillsPath, { recursive: true, force: true });
+    await manager.loadSkills();
+
+    assert.equal(fs.existsSync(skillsPath), false);
+    assert.deepEqual(skillNames(manager), ['stable-skill']);
+  });
+
   test('publishes an empty map when the Skill directory is successfully empty', async () => {
     writeSkill(skillsPath, 'removed-skill', 'Removed skill');
     const manager = new SkillManager();

--- a/tests/skill-manager-atomic-load.test.ts
+++ b/tests/skill-manager-atomic-load.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { SkillManager } from '../src/skills/skill-manager';
+import { SkillParser } from '../src/skills/skill-parser';
+import { PathResolver } from '../src/utils/path-resolver';
+
+describe('SkillManager atomic loading', () => {
+  let testRoot: string;
+  let skillsPath: string;
+  let originalSkillsEnv: string | undefined;
+
+  beforeEach(() => {
+    originalSkillsEnv = process.env.XIAOBA_SKILLS_DIR;
+    testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-skill-manager-'));
+    skillsPath = path.join(testRoot, 'skills');
+    process.env.XIAOBA_SKILLS_DIR = skillsPath;
+  });
+
+  afterEach(() => {
+    if (originalSkillsEnv === undefined) delete process.env.XIAOBA_SKILLS_DIR;
+    else process.env.XIAOBA_SKILLS_DIR = originalSkillsEnv;
+    fs.rmSync(testRoot, { recursive: true, force: true });
+  });
+
+  test('publishes the next complete Skill map in one assignment', async () => {
+    writeSkill(skillsPath, 'old-skill', 'Old skill');
+    const manager = new SkillManager();
+    await manager.loadSkills();
+
+    fs.rmSync(path.join(skillsPath, 'old-skill'), { recursive: true, force: true });
+    writeSkill(skillsPath, 'new-a', 'New skill A');
+    writeSkill(skillsPath, 'new-b', 'New skill B');
+
+    const originalParse = SkillParser.parse;
+    let parseCount = 0;
+    let visibleDuringSecondParse: string[] | undefined;
+    SkillParser.parse = ((filePath: string) => {
+      parseCount += 1;
+      if (parseCount === 2) {
+        visibleDuringSecondParse = skillNames(manager);
+      }
+      return originalParse.call(SkillParser, filePath);
+    }) as typeof SkillParser.parse;
+
+    try {
+      await manager.loadSkills();
+    } finally {
+      SkillParser.parse = originalParse;
+    }
+
+    assert.deepEqual(visibleDuringSecondParse, ['old-skill']);
+    assert.deepEqual(skillNames(manager), ['new-a', 'new-b']);
+  });
+
+  test('skips an invalid Skill while atomically publishing the valid set', async () => {
+    writeSkill(skillsPath, 'old-skill', 'Old skill');
+    const manager = new SkillManager();
+    await manager.loadSkills();
+
+    fs.rmSync(path.join(skillsPath, 'old-skill'), { recursive: true, force: true });
+    writeSkill(skillsPath, 'valid-skill', 'Valid skill');
+    writeInvalidSkill(skillsPath, 'invalid-skill');
+
+    await manager.loadSkills();
+
+    assert.deepEqual(skillNames(manager), ['valid-skill']);
+  });
+
+  test('keeps the previous complete map when directory enumeration fails', async () => {
+    writeSkill(skillsPath, 'stable-skill', 'Stable skill');
+    const manager = new SkillManager();
+    await manager.loadSkills();
+
+    const originalFindSkillFiles = PathResolver.findSkillFiles;
+    PathResolver.findSkillFiles = (() => {
+      throw new Error('simulated directory read failure');
+    }) as typeof PathResolver.findSkillFiles;
+
+    try {
+      await manager.loadSkills();
+    } finally {
+      PathResolver.findSkillFiles = originalFindSkillFiles;
+    }
+
+    assert.deepEqual(skillNames(manager), ['stable-skill']);
+  });
+
+  test('publishes an empty map when the Skill directory is successfully empty', async () => {
+    writeSkill(skillsPath, 'removed-skill', 'Removed skill');
+    const manager = new SkillManager();
+    await manager.loadSkills();
+
+    fs.rmSync(skillsPath, { recursive: true, force: true });
+    fs.mkdirSync(skillsPath, { recursive: true });
+    await manager.loadSkills();
+
+    assert.deepEqual(skillNames(manager), []);
+  });
+});
+
+function writeSkill(skillsPath: string, name: string, description: string): void {
+  const skillDir = path.join(skillsPath, name);
+  fs.mkdirSync(skillDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(skillDir, 'SKILL.md'),
+    ['---', `name: ${name}`, `description: ${description}`, '---', '', `Use ${name}.`].join('\n'),
+    'utf-8',
+  );
+}
+
+function writeInvalidSkill(skillsPath: string, name: string): void {
+  const skillDir = path.join(skillsPath, name);
+  fs.mkdirSync(skillDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(skillDir, 'SKILL.md'),
+    ['---', `name: ${name}`, '---', '', `Use ${name}.`].join('\n'),
+    'utf-8',
+  );
+}
+
+function skillNames(manager: SkillManager): string[] {
+  return manager.getAllSkills().map(skill => skill.metadata.name).sort();
+}


### PR DESCRIPTION
## 目标

- Skill 重新加载时先在独立 `nextSkills` Map 中完成目录枚举和解析
- 全部处理完成后一次性替换共享 Map，避免读者看到空集合或半套集合
- 目录扫描失败时保留上一套完整 Skill 集合
- 保持原有兼容语义：单个无效 Skill 仍跳过并告警，成功读取到空目录仍发布空集合

## 安全与兼容边界

- 不修改 Bot Skill 工作区、同步、激活或 ACK 流程
- 不修改 `read_file`、`write_file`、`edit_file`、`send_file`、`import_file`、`execute_shell` 等工具权限
- 不修改 Skill 内容、模型注入、System Prompt 或用户可见文案
- 不启用任何第二阶段功能开关

## 验证

- `npm run build`
- `npx tsx --test tests/skill-manager-atomic-load.test.ts tests/session-skill-runtime.test.ts tests/skill-tool-direct-content.test.ts`：9 passed
- `npm run test:skillhub-phase1`：257 passed，1 skipped，0 failed
- `npm run test:cross-repo:catsco-skills`：62 passed，0 failed
- `npm test`：1651 passed，11 skipped；2 个既有环境失败均因本机缺少 `jq`，与本 PR 无关

## 新增回归覆盖

- 解析下一套 Skill 时，读取者仍看到上一套完整集合
- 单个 Skill 解析失败时，只发布其余有效 Skill
- 目录枚举失败时保留上一套集合
- 成功读取到空目录时仍可按既有语义清空集合
