### PR TITLE
feat: scope Artifact task refs to the current turn

### DIFF
--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -103,6 +103,7 @@ interface QueuedMessage {
   seq: number;
   executionScope: ParsedCatsMessage['executionScope'];
   artifactContextRef?: string;
+  artifactTaskRef?: string;
   deviceGrants?: ScopedDeviceGrant[];
   deviceSelection?: ScopedDeviceSelection;
   targetRoutes?: TargetRoutes;
@@ -120,6 +121,7 @@ interface QueuedMessage {
 interface ActiveConversationTask {
   runID: string;
   topic: string;
+  artifactTaskRef?: string;
   finished: boolean;
 }
 
@@ -1624,6 +1626,7 @@ export class CatsCompanyBot {
         seq: msg.seq,
         executionScope: msg.executionScope,
         artifactContextRef: msg.artifactContextRef,
+        artifactTaskRef: msg.artifactTaskRef,
         deviceGrants: msg.deviceGrants,
         deviceSelection: msg.deviceSelection,
         targetRoutes: msg.targetRoutes,
@@ -1661,7 +1664,7 @@ export class CatsCompanyBot {
         );
       }
       if (shouldProcess) {
-        task = this.beginConversationTask(key, msg.topic);
+        task = this.beginConversationTask(key, msg.topic, msg.artifactTaskRef);
         if (!task) {
           // Shutdown barrier at the call site: never start the model after
           // destroy() even when a pre-turn await resumed afterwards.
@@ -1672,6 +1675,7 @@ export class CatsCompanyBot {
           sessionRoute,
           executionScope: msg.executionScope,
           artifactContextRef: msg.artifactContextRef,
+          artifactTaskRef: msg.artifactTaskRef,
           localDeviceGrant: this.localDeviceGrant,
           deviceGrants: msg.deviceGrants,
           deviceSelection: msg.deviceSelection,
@@ -1850,7 +1854,11 @@ export class CatsCompanyBot {
     return true;
   }
 
-  private beginConversationTask(sessionKey: string, topic: string): ActiveConversationTask | undefined {
+  private beginConversationTask(
+    sessionKey: string,
+    topic: string,
+    artifactTaskRef?: string,
+  ): ActiveConversationTask | undefined {
     // Shutdown barrier: shutdown 开始后禁止创建新任务（不发 running），
     // 避免 shutdown snapshot 之后出现孤儿任务（排队消息在 drain 中被丢弃而非留下无终态任务）。
     if (this.shuttingDown) return undefined;
@@ -1861,6 +1869,7 @@ export class CatsCompanyBot {
     const task: ActiveConversationTask = {
       runID: `xiaoba-${Date.now().toString(36)}-${randomUUID().slice(0, 8)}`,
       topic,
+      artifactTaskRef,
       finished: false,
     };
     tasks.set(sessionKey, task);
@@ -1896,7 +1905,11 @@ export class CatsCompanyBot {
     task: ActiveConversationTask,
     status: Omit<ConversationTaskStatusInput, 'run_id'>,
   ): void {
-    const payload: ConversationTaskStatusInput = { run_id: task.runID, ...status };
+    const payload: ConversationTaskStatusInput = {
+      run_id: task.runID,
+      ...(task.artifactTaskRef ? { artifact_task_ref: task.artifactTaskRef } : {}),
+      ...status,
+    };
     const statusTasks = this.taskStatusTasks ??= new Map<string, Promise<void>>();
     const previous = statusTasks.get(task.topic) ?? Promise.resolve();
     const next = previous
@@ -2156,6 +2169,7 @@ export class CatsCompanyBot {
       envelope,
       executionScope,
       artifactContextRef: envelope.artifactContextRef,
+      artifactTaskRef: envelope.artifactTaskRef,
       deviceGrants: extractCatsCoDeviceGrants(ctx.metadata, executionScope),
       deviceSelection: extractCatsCoDeviceSelection(ctx.metadata, executionScope),
       targetRoutes,
@@ -2954,7 +2968,7 @@ export class CatsCompanyBot {
         // Shutdown barrier: destroy() may have started while queued work ran.
         if (this.shuttingDown) return;
         if (msg.source === 'user') {
-          task = this.beginConversationTask(sessionKey, msg.topic);
+          task = this.beginConversationTask(sessionKey, msg.topic, msg.artifactTaskRef);
           if (!task) return;
         }
         const result = msg.source === 'subagent_feedback'
@@ -2979,6 +2993,7 @@ export class CatsCompanyBot {
             channel,
             executionScope: msg.executionScope,
             artifactContextRef: msg.artifactContextRef,
+            artifactTaskRef: msg.artifactTaskRef,
             localDeviceGrant: this.localDeviceGrant,
             deviceGrants: msg.deviceGrants,
             deviceSelection: msg.deviceSelection,
@@ -3090,6 +3105,9 @@ export class CatsCompanyBot {
       if ((item.clearGeneration ?? expectedClearGeneration) !== expectedClearGeneration) break;
       if (item.source === 'subagent_feedback') break;
       if (item.nativeFeishuContext) break;
+      // An Artifact task owns a distinct run/task correlation. Do not fold it
+      // into the currently executing turn as ordinary follow-up text.
+      if (item.artifactTaskRef) break;
       if (!this.canMergeQueuedMessage(currentScope, item.executionScope)) break;
       userMessages.push(item);
     }

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -1684,7 +1684,12 @@ export class CatsCompanyBot {
           thinToolRpc: this.maybeBuildThinToolRpcTransport(),
           localFileGrants,
           runtimeFeedback,
-          pendingUserInputProvider: () => this.consumeQueuedUserInput(key, msg.executionScope, entryClearGeneration),
+          pendingUserInputProvider: () => this.consumeQueuedUserInput(
+            key,
+            msg.executionScope,
+            entryClearGeneration,
+            msg.artifactTaskRef,
+          ),
           callbacks: this.buildSessionCallbacks(msg.topic, {
             sessionKey: key,
             senderId: msg.senderId,
@@ -3002,7 +3007,12 @@ export class CatsCompanyBot {
             thinToolRpc: this.maybeBuildThinToolRpcTransport(),
             runtimeFeedback: msg.runtimeFeedback,
             localFileGrants: msg.localFileGrants,
-            pendingUserInputProvider: () => this.consumeQueuedUserInput(sessionKey, msg.executionScope, clearGeneration),
+            pendingUserInputProvider: () => this.consumeQueuedUserInput(
+              sessionKey,
+              msg.executionScope,
+              clearGeneration,
+              msg.artifactTaskRef,
+            ),
             callbacks: this.buildSessionCallbacks(msg.topic, {
               sessionKey,
               senderId: msg.senderId,
@@ -3093,11 +3103,15 @@ export class CatsCompanyBot {
     sessionKey: string,
     currentScope?: ParsedCatsMessage['executionScope'],
     expectedClearGeneration = this.getSessionClearGeneration(sessionKey),
+    currentArtifactTaskRef?: string,
   ): string | ContentBlock[] | PendingUserInput | null {
     const queue = this.messageQueue.get(sessionKey);
     if (!queue || queue.length === 0) return null;
 
     if (expectedClearGeneration !== this.getSessionClearGeneration(sessionKey)) return null;
+    // Artifact tasks own a one-shot ToolExecutionContext. Ordinary input must
+    // remain queued until that task turn releases its run/task correlation.
+    if (currentArtifactTaskRef) return null;
     const userMessages: QueuedMessage[] = [];
     let firstRemainingIndex = 0;
     for (; firstRemainingIndex < queue.length; firstRemainingIndex++) {

--- a/src/catscompany/message-envelope.ts
+++ b/src/catscompany/message-envelope.ts
@@ -5,6 +5,7 @@ import {
   createSessionRoute,
 } from '../core/session-router';
 import { normalizeArtifactContextRef } from '../utils/artifact-context-ref';
+import { normalizeArtifactTaskRef } from '../utils/artifact-task-ref';
 
 type UnknownRecord = Record<string, unknown>;
 
@@ -93,6 +94,10 @@ export function createCatsCoMessageEnvelope(input: CatsCoEnvelopeInput): Message
     && sameCatsCoUserId(canonicalAgentId, safeString(input.botUid))
     ? normalizeArtifactContextRef(metadata?.artifact_context_ref)
     : undefined;
+  const artifactTaskRef = isCanonicalTrusted
+    && sameCatsCoUserId(canonicalAgentId, safeString(input.botUid))
+    ? normalizeArtifactTaskRef(metadata?.artifact_task_ref)
+    : undefined;
   const legacyCleanupKey = buildCatsCoSessionKey(resolvedTopicType, topicId, actorUserId);
   const legacyRestoreKey = legacyCleanupKey;
   const route = createSessionRoute({
@@ -137,6 +142,7 @@ export function createCatsCoMessageEnvelope(input: CatsCoEnvelopeInput): Message
     identitySource: isCanonicalTrusted ? 'metadata.catsco_identity' : undefined,
     warnings: warnings.length > 0 ? warnings : undefined,
     artifactContextRef,
+    artifactTaskRef,
   };
 }
 

--- a/src/catscompany/message-sender.ts
+++ b/src/catscompany/message-sender.ts
@@ -12,6 +12,7 @@ export type ConversationTaskState = 'running' | 'completed' | 'failed' | 'cancel
 
 export interface ConversationTaskStatusInput {
   run_id: string;
+  artifact_task_ref?: string;
   state: ConversationTaskState;
   summary: string;
   error?: string;

--- a/src/catscompany/types.ts
+++ b/src/catscompany/types.ts
@@ -73,6 +73,8 @@ export interface ParsedCatsMessage {
   executionScope: ExecutionScope;
   /** 仅当前 turn 有效的 opaque Artifact context ref。 */
   artifactContextRef?: string;
+  /** 仅当前 turn 有效的 opaque Artifact task ref。 */
+  artifactTaskRef?: string;
   /** 服务端签发的当前 turn 用户设备授权 */
   deviceGrants?: ScopedDeviceGrant[];
   /** 服务端为当前 turn 选择的用户设备，或要求先选择设备 */

--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -137,6 +137,8 @@ export interface HandleMessageOptions {
   executionScope?: ExecutionScope;
   /** 当前 turn 的短期 Artifact context ref；不进入模型消息或持久历史。 */
   artifactContextRef?: string;
+  /** 当前 turn 的短期 Artifact task ref；不进入模型消息或持久历史。 */
+  artifactTaskRef?: string;
   /** 当前本机运行体授权，例如 CatsCo body/device 绑定。 */
   localDeviceGrant?: ScopedLocalDeviceGrant;
   /** 当前 turn 已授权的用户设备资源。 */
@@ -586,6 +588,7 @@ export class AgentSession {
       let sessionRoute: SessionRoute | undefined;
       let executionScope: ExecutionScope | undefined;
       let artifactContextRef: string | undefined;
+      let artifactTaskRef: string | undefined;
       let localDeviceGrant: ScopedLocalDeviceGrant | undefined;
       let deviceGrants: ScopedDeviceGrant[] | undefined;
       let deviceSelection: ScopedDeviceSelection | undefined;
@@ -602,6 +605,7 @@ export class AgentSession {
           || 'sessionRoute' in callbacksOrOptions
           || 'executionScope' in callbacksOrOptions
           || 'artifactContextRef' in callbacksOrOptions
+          || 'artifactTaskRef' in callbacksOrOptions
           || 'localDeviceGrant' in callbacksOrOptions
           || 'deviceGrants' in callbacksOrOptions
           || 'deviceSelection' in callbacksOrOptions
@@ -620,6 +624,7 @@ export class AgentSession {
           sessionRoute = opts.sessionRoute;
           executionScope = opts.executionScope;
           artifactContextRef = opts.artifactContextRef;
+          artifactTaskRef = opts.artifactTaskRef;
           localDeviceGrant = opts.localDeviceGrant;
           deviceGrants = opts.deviceGrants;
           deviceSelection = opts.deviceSelection;
@@ -706,6 +711,7 @@ export class AgentSession {
           sessionRoute,
           executionScope,
           artifactContextRef,
+          artifactTaskRef,
           localDeviceGrant,
           deviceGrants,
           deviceSelection,

--- a/src/core/agent-turn-controller.ts
+++ b/src/core/agent-turn-controller.ts
@@ -81,6 +81,7 @@ export interface RunAgentTurnParams {
   sessionRoute?: SessionRoute;
   executionScope?: ExecutionScope;
   artifactContextRef?: string;
+  artifactTaskRef?: string;
   localDeviceGrant?: ScopedLocalDeviceGrant;
   deviceGrants?: ScopedDeviceGrant[];
   deviceSelection?: ScopedDeviceSelection;
@@ -187,6 +188,7 @@ export class AgentTurnController {
         channel: params.channel,
         executionScope: params.executionScope,
         artifactContextRef: params.artifactContextRef,
+        artifactTaskRef: params.artifactTaskRef,
         localDeviceGrant: params.localDeviceGrant,
         deviceGrants: params.deviceGrants,
         deviceSelection: params.deviceSelection,
@@ -330,6 +332,7 @@ export class AgentTurnController {
     channel?: ChannelCallbacks;
     executionScope?: ExecutionScope;
     artifactContextRef?: string;
+    artifactTaskRef?: string;
     localDeviceGrant?: ScopedLocalDeviceGrant;
     deviceGrants?: ScopedDeviceGrant[];
     deviceSelection?: ScopedDeviceSelection;
@@ -381,6 +384,7 @@ export class AgentTurnController {
           channel: options.channel,
           executionScope: options.executionScope,
           artifactContextRef: options.artifactContextRef,
+          artifactTaskRef: options.artifactTaskRef,
           localDeviceGrant: options.localDeviceGrant,
           deviceGrants: options.deviceGrants,
           deviceSelection: options.deviceSelection,

--- a/src/tools/bash-tool.ts
+++ b/src/tools/bash-tool.ts
@@ -7,6 +7,7 @@ import * as path from 'path';
 import { Tool, ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '../types/tool';
 import { Logger } from '../utils/logger';
 import { withArtifactContextRefEnvironment } from '../utils/artifact-context-ref';
+import { withArtifactTaskRefEnvironment } from '../utils/artifact-task-ref';
 import { resolveRuntimeEnvironment } from '../utils/runtime-environment';
 import { isToolAllowed, isBashCommandAllowed } from '../utils/safety';
 import { executeRouteIfRemote, resolveExecutionRoute, targetParameterDescription } from './execution-router';
@@ -167,9 +168,12 @@ export class ShellTool implements Tool {
       env: process.env,
       probeVersion: false,
     });
-    const commandEnvironment = withArtifactContextRefEnvironment(
-      runtimeEnvironment.env,
-      context.artifactContextRef,
+    const commandEnvironment = withArtifactTaskRefEnvironment(
+      withArtifactContextRefEnvironment(
+        runtimeEnvironment.env,
+        context.artifactContextRef,
+      ),
+      context.artifactTaskRef,
     );
     const scopedRuntimeEnvironment = {
       ...runtimeEnvironment,

--- a/src/types/session-identity.ts
+++ b/src/types/session-identity.ts
@@ -31,6 +31,8 @@ export interface MessageEnvelope {
   warnings?: string[];
   /** Opaque, short-lived Artifact context reference from a trusted live envelope. */
   artifactContextRef?: string;
+  /** Opaque, short-lived Artifact task reference from a trusted live envelope. */
+  artifactTaskRef?: string;
 }
 
 export interface ExecutionScope {

--- a/src/types/tool.ts
+++ b/src/types/tool.ts
@@ -271,6 +271,8 @@ export interface ToolExecutionContext {
   localFileGrants?: ScopedLocalFileGrant[];
   /** 当前 turn 的短期 Artifact context ref；只供本机工具子进程临时读取。 */
   artifactContextRef?: string;
+  /** 当前 turn 的短期 Artifact task ref；只供本机工具子进程临时读取。 */
+  artifactTaskRef?: string;
 }
 
 /**

--- a/src/utils/artifact-task-ref.ts
+++ b/src/utils/artifact-task-ref.ts
@@ -1,0 +1,27 @@
+export const CATSCO_ARTIFACT_TASK_REF_ENV = 'CATSCO_ARTIFACT_TASK_REF';
+
+const ARTIFACT_TASK_REF_PATTERN = /^atr_[A-Za-z0-9_-]{43}$/;
+
+export function normalizeArtifactTaskRef(value: unknown): string | undefined {
+  if (typeof value !== 'string' || value !== value.trim() || !ARTIFACT_TASK_REF_PATTERN.test(value)) {
+    return undefined;
+  }
+  return value;
+}
+
+export function withArtifactTaskRefEnvironment(
+  environment: NodeJS.ProcessEnv,
+  taskRef: unknown,
+): NodeJS.ProcessEnv {
+  const next = { ...environment };
+  for (const key of Object.keys(next)) {
+    if (key.toUpperCase() === CATSCO_ARTIFACT_TASK_REF_ENV) {
+      delete next[key];
+    }
+  }
+  const normalized = normalizeArtifactTaskRef(taskRef);
+  if (normalized) {
+    next[CATSCO_ARTIFACT_TASK_REF_ENV] = normalized;
+  }
+  return next;
+}

--- a/tests/agent-turn-execution-scope.test.ts
+++ b/tests/agent-turn-execution-scope.test.ts
@@ -20,6 +20,8 @@ test('AgentSession accepts executionScope in HandleMessageOptions', () => {
   assert.match(agentSessionSource, /localFileGrants\s*=\s*opts\.localFileGrants/);
   assert.match(agentSessionSource, /artifactContextRef\?:\s*string/);
   assert.match(agentSessionSource, /artifactContextRef\s*=\s*opts\.artifactContextRef/);
+  assert.match(agentSessionSource, /artifactTaskRef\?:\s*string/);
+  assert.match(agentSessionSource, /artifactTaskRef\s*=\s*opts\.artifactTaskRef/);
 });
 
 test('AgentTurnController forwards executionScope into ToolExecutionContext', () => {
@@ -37,6 +39,8 @@ test('AgentTurnController forwards executionScope into ToolExecutionContext', ()
   assert.match(agentTurnSource, /localFileGrants:\s*options\.localFileGrants/);
   assert.match(agentTurnSource, /artifactContextRef:\s*params\.artifactContextRef/);
   assert.match(agentTurnSource, /artifactContextRef:\s*options\.artifactContextRef/);
+  assert.match(agentTurnSource, /artifactTaskRef:\s*params\.artifactTaskRef/);
+  assert.match(agentTurnSource, /artifactTaskRef:\s*options\.artifactTaskRef/);
 });
 
 test('ToolExecutionContext exposes executionScope for future ToolGateway checks', () => {
@@ -45,6 +49,7 @@ test('ToolExecutionContext exposes executionScope for future ToolGateway checks'
   assert.match(toolTypesSource, /deviceGrants\?:\s*ScopedDeviceGrant\[\]/);
   assert.match(toolTypesSource, /localFileGrants\?:\s*ScopedLocalFileGrant\[\]/);
   assert.match(toolTypesSource, /artifactContextRef\?:\s*string/);
+  assert.match(toolTypesSource, /artifactTaskRef\?:\s*string/);
 });
 
 test('AgentTurnController image history replacement can preserve opaque attachment references', () => {

--- a/tests/artifact-context-agent-session.integration.test.ts
+++ b/tests/artifact-context-agent-session.integration.test.ts
@@ -13,14 +13,16 @@ import type { Message } from '../src/types';
 
 const ARTIFACT_REF = `acr_${'a'.repeat(43)}`;
 const ARTIFACT_REF_PATTERN = /acr_[A-Za-z0-9_-]{43}/;
+const ARTIFACT_TASK_REF = `atr_${'t'.repeat(43)}`;
+const ARTIFACT_TASK_REF_PATTERN = /atr_[A-Za-z0-9_-]{43}/;
 
-describe('Artifact context ref AgentSession integration', { concurrency: false }, () => {
-  test('scopes a canonical ref to the current local turn only', async () => {
+describe('Artifact refs AgentSession integration', { concurrency: false }, () => {
+  test('scopes canonical context and task refs to the current local turn only', async () => {
     const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-artifact-ref-session-'));
     const originalCwd = process.cwd();
     process.chdir(workspace);
 
-    const firstEnvelope = envelopeForTurn(1, ARTIFACT_REF);
+    const firstEnvelope = envelopeForTurn(1, ARTIFACT_REF, ARTIFACT_TASK_REF);
     const firstRoute = routeForEnvelope(firstEnvelope);
     const providerRequests: Message[][] = [];
     const toolResults: string[] = [];
@@ -29,14 +31,16 @@ describe('Artifact context ref AgentSession integration', { concurrency: false }
 
     const localProbe = [
       'node -e "',
-      "const v=process.env.CATSCO_ARTIFACT_CONTEXT_REF||'';",
-      "process.stdout.write(v==='acr_'+'a'.repeat(43)?'active':v?'stale':'missing')",
+      "const c=process.env.CATSCO_ARTIFACT_CONTEXT_REF||'';",
+      "const t=process.env.CATSCO_ARTIFACT_TASK_REF||'';",
+      "process.stdout.write(c==='acr_'+'a'.repeat(43)&&t==='atr_'+'t'.repeat(43)?'active':c||t?'stale':'missing')",
       '"',
     ].join('');
     const missingProbe = [
       'node -e "',
-      "const v=process.env.CATSCO_ARTIFACT_CONTEXT_REF||'';",
-      "process.stdout.write(v?'unexpected':'missing')",
+      "const c=process.env.CATSCO_ARTIFACT_CONTEXT_REF||'';",
+      "const t=process.env.CATSCO_ARTIFACT_TASK_REF||'';",
+      "process.stdout.write(c||t?'unexpected':'missing')",
       '"',
     ].join('');
 
@@ -88,6 +92,7 @@ describe('Artifact context ref AgentSession integration', { concurrency: false }
         conversationHistory: [],
         surface: 'catscompany',
         artifactContextRef: ARTIFACT_REF,
+        artifactTaskRef: ARTIFACT_TASK_REF,
         targetRoutes: buildTargetRoutes([{
           userId: 'usr8',
           userName: 'Alice',
@@ -101,8 +106,11 @@ describe('Artifact context ref AgentSession integration', { concurrency: false }
           executeTool: async request => {
             remoteRequests.push(request);
             assert.doesNotMatch(JSON.stringify(request), ARTIFACT_REF_PATTERN);
+            assert.doesNotMatch(JSON.stringify(request), ARTIFACT_TASK_REF_PATTERN);
             assert.equal('artifactContextRef' in request.args, false);
+            assert.equal('artifactTaskRef' in request.args, false);
             assert.equal('CATSCO_ARTIFACT_CONTEXT_REF' in request.args, false);
+            assert.equal('CATSCO_ARTIFACT_TASK_REF' in request.args, false);
             return { ok: true, content: 'remote missing' };
           },
         },
@@ -116,8 +124,10 @@ describe('Artifact context ref AgentSession integration', { concurrency: false }
       assert.equal(providerRequests.length, 4);
       for (const request of providerRequests) {
         assert.doesNotMatch(JSON.stringify(request), ARTIFACT_REF_PATTERN);
+        assert.doesNotMatch(JSON.stringify(request), ARTIFACT_TASK_REF_PATTERN);
       }
       assert.doesNotMatch(JSON.stringify((session as any).messages), ARTIFACT_REF_PATTERN);
+      assert.doesNotMatch(JSON.stringify((session as any).messages), ARTIFACT_TASK_REF_PATTERN);
     } finally {
       await session.cleanup();
       process.chdir(originalCwd);
@@ -126,7 +136,11 @@ describe('Artifact context ref AgentSession integration', { concurrency: false }
   });
 });
 
-function envelopeForTurn(seq: number, artifactContextRef?: string): MessageEnvelope {
+function envelopeForTurn(
+  seq: number,
+  artifactContextRef?: string,
+  artifactTaskRef?: string,
+): MessageEnvelope {
   return createCatsCoMessageEnvelope({
     topic: 'p2p_701_743',
     senderId: 'usr701',
@@ -135,6 +149,7 @@ function envelopeForTurn(seq: number, artifactContextRef?: string): MessageEnvel
     botUid: 'usr743',
     metadata: {
       ...(artifactContextRef ? { artifact_context_ref: artifactContextRef } : {}),
+      ...(artifactTaskRef ? { artifact_task_ref: artifactTaskRef } : {}),
       catsco_identity: {
         actor: { user_id: 'usr701' },
         agent: { agent_id: 'usr743', body_id: 'body-main' },
@@ -168,6 +183,7 @@ function turnOptions(envelope: MessageEnvelope, overrides: Record<string, unknow
   return {
     sessionRoute: route,
     artifactContextRef: envelope.artifactContextRef,
+    artifactTaskRef: envelope.artifactTaskRef,
     localDeviceGrant: {
       kind: 'catscompany_body',
       source: 'catscompany',

--- a/tests/artifact-task-ref-scope.test.ts
+++ b/tests/artifact-task-ref-scope.test.ts
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { ShellTool } from '../src/tools/bash-tool';
+import {
+  CATSCO_ARTIFACT_TASK_REF_ENV,
+  normalizeArtifactTaskRef,
+  withArtifactTaskRefEnvironment,
+} from '../src/utils/artifact-task-ref';
+
+const firstRef = `atr_${'a'.repeat(43)}`;
+const secondRef = `atr_${'b'.repeat(43)}`;
+
+describe('Artifact task ref tool scope', () => {
+  test('normalizes only the opaque task ref contract', () => {
+    assert.equal(normalizeArtifactTaskRef(firstRef), firstRef);
+    assert.equal(normalizeArtifactTaskRef(` ${firstRef}`), undefined);
+    assert.equal(normalizeArtifactTaskRef('atr_short'), undefined);
+    assert.equal(normalizeArtifactTaskRef(`acr_${'a'.repeat(43)}`), undefined);
+    assert.equal(normalizeArtifactTaskRef(42), undefined);
+  });
+
+  test('copies the child environment, replaces inherited refs, and never mutates the parent', () => {
+    const parent = {
+      PATH: 'test-path',
+      catsco_artifact_task_ref: firstRef,
+    };
+
+    const withCurrent = withArtifactTaskRefEnvironment(parent, secondRef);
+    const withoutCurrent = withArtifactTaskRefEnvironment(parent, undefined);
+
+    assert.notEqual(withCurrent, parent);
+    assert.equal(withCurrent[CATSCO_ARTIFACT_TASK_REF_ENV], secondRef);
+    assert.equal(withoutCurrent[CATSCO_ARTIFACT_TASK_REF_ENV], undefined);
+    assert.equal(parent.catsco_artifact_task_ref, firstRef);
+  });
+
+  test('injects the ref only into the local shell child process and scrubs stale parent state', async () => {
+    const previous = process.env[CATSCO_ARTIFACT_TASK_REF_ENV];
+    process.env[CATSCO_ARTIFACT_TASK_REF_ENV] = firstRef;
+    const command = `node -e "process.stdout.write(process.env.${CATSCO_ARTIFACT_TASK_REF_ENV} || 'missing')"`;
+
+    try {
+      const shell = new ShellTool();
+      const withCurrent = await shell.execute({ command }, {
+        workingDirectory: process.cwd(),
+        conversationHistory: [],
+        artifactTaskRef: secondRef,
+      });
+      const withoutCurrent = await shell.execute({ command }, {
+        workingDirectory: process.cwd(),
+        conversationHistory: [],
+      });
+
+      assert.equal(withCurrent.ok, true);
+      assert.match(String(withCurrent.ok ? withCurrent.content : withCurrent.message), new RegExp(secondRef));
+      assert.equal(withoutCurrent.ok, true);
+      assert.match(String(withoutCurrent.ok ? withoutCurrent.content : withoutCurrent.message), /missing/);
+      assert.doesNotMatch(String(withoutCurrent.ok ? withoutCurrent.content : withoutCurrent.message), new RegExp(firstRef));
+      assert.equal(process.env[CATSCO_ARTIFACT_TASK_REF_ENV], firstRef);
+    } finally {
+      if (previous === undefined) delete process.env[CATSCO_ARTIFACT_TASK_REF_ENV];
+      else process.env[CATSCO_ARTIFACT_TASK_REF_ENV] = previous;
+    }
+  });
+});

--- a/tests/catscompany-content-blocks.test.ts
+++ b/tests/catscompany-content-blocks.test.ts
@@ -373,6 +373,7 @@ describe('CatsCo content blocks', () => {
 
   test('publishes ordered running and completed states for a CatsCo user turn', async () => {
     const { bot, session, taskStatuses } = createProcessHarness();
+    const artifactTaskRef = `atr_${'s'.repeat(43)}`;
     session.handleMessage = async () => ({ visibleToUser: true, text: '处理完成' });
 
     await (bot as any).processParsedMessage({
@@ -382,6 +383,7 @@ describe('CatsCo content blocks', () => {
       seq: 10,
       text: '请完成这个任务',
       rawContent: '请完成这个任务',
+      artifactTaskRef,
     }, 'cc_user:usr1');
     await new Promise(resolve => setTimeout(resolve, 0));
 
@@ -393,6 +395,8 @@ describe('CatsCo content blocks', () => {
       ],
     );
     assert.strictEqual(taskStatuses[0].status.run_id, taskStatuses[1].status.run_id);
+    assert.strictEqual(taskStatuses[0].status.artifact_task_ref, artifactTaskRef);
+    assert.strictEqual(taskStatuses[1].status.artifact_task_ref, artifactTaskRef);
   });
 
   test('finishes active task status before disconnecting during shutdown', async () => {

--- a/tests/catscompany-execution-scope-flow.test.ts
+++ b/tests/catscompany-execution-scope-flow.test.ts
@@ -1283,6 +1283,80 @@ describe('CatsCompany execution scope flow', () => {
     assert.doesNotMatch(JSON.stringify(handledTurns[0].userMessage), /atr_[A-Za-z0-9_-]{43}/);
   });
 
+  test('keeps ordinary queued input out of an active Artifact task turn', async () => {
+    const harness = createHarness();
+    const taskRef = `atr_${'u'.repeat(43)}`;
+    const taskStatuses: any[] = [];
+    let releaseTaskTurn!: () => void;
+    let taskTurnStarted!: () => void;
+    const taskTurnStartedPromise = new Promise<void>(resolve => { taskTurnStarted = resolve; });
+    const taskTurnGate = new Promise<void>(resolve => { releaseTaskTurn = resolve; });
+    let pendingInputProvider: (() => unknown) | undefined;
+
+    harness.bot.sender.sendTaskStatus = async (_topic: string, status: any) => {
+      taskStatuses.push(status);
+    };
+    harness.session.handleMessage = async (userMessage: unknown, options: any) => {
+      harness.handledTurns.push({ userMessage, options });
+      if (harness.handledTurns.length === 1) {
+        pendingInputProvider = options.pendingUserInputProvider;
+        taskTurnStarted();
+        await taskTurnGate;
+      }
+      return { visibleToUser: false, text: '' };
+    };
+
+    const taskTurn = harness.bot.onMessage({
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      text: '来自「项目风险台账」：分析选中的风险',
+      content: '来自「项目风险台账」：分析选中的风险',
+      metadata: {
+        ...canonicalMetadata('usr7', 'p2p_7_43'),
+        artifact_task_ref: taskRef,
+      },
+      isGroup: false,
+      seq: 12,
+    });
+    await taskTurnStartedPromise;
+
+    await harness.bot.onMessage({
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      text: '顺便再检查一下普通风险项',
+      content: '顺便再检查一下普通风险项',
+      metadata: canonicalMetadata('usr7', 'p2p_7_43'),
+      isGroup: false,
+      seq: 13,
+    });
+
+    assert.equal(pendingInputProvider?.(), null);
+    const queued = harness.bot.messageQueue.get(expectedCatsCoSessionKey('usr7', 'p2p_7_43'));
+    assert.equal(queued?.length, 1);
+    assert.equal(queued?.[0].artifactTaskRef, undefined);
+
+    releaseTaskTurn();
+    await taskTurn;
+    await Promise.all(Array.from(harness.bot.taskStatusTasks?.values?.() || []));
+
+    assert.equal(harness.handledTurns.length, 2);
+    assert.equal(harness.handledTurns[0].options.artifactTaskRef, taskRef);
+    assert.equal(harness.handledTurns[1].options.artifactTaskRef, undefined);
+    assert.equal('artifactTaskRef' in harness.handledTurns[1].options.executionScope, false);
+    assert.match(String(harness.handledTurns[1].userMessage), /普通风险项/);
+    assert.equal(harness.bot.messageQueue.has(expectedCatsCoSessionKey('usr7', 'p2p_7_43')), false);
+
+    const taskRunIDs = new Set(taskStatuses
+      .filter(status => status.artifact_task_ref === taskRef)
+      .map(status => status.run_id));
+    const ordinaryRunIDs = new Set(taskStatuses
+      .filter(status => !status.artifact_task_ref)
+      .map(status => status.run_id));
+    assert.equal(taskRunIDs.size, 1);
+    assert.equal(ordinaryRunIDs.size, 1);
+    assert.notEqual([...taskRunIDs][0], [...ordinaryRunIDs][0]);
+  });
+
   test('does not merge queued CatsCo group input from another actor into the current actor scope', () => {
     const { bot } = createHarness();
     const aliceScope = createExecutionScope(createCatsCoMessageEnvelope({

--- a/tests/catscompany-execution-scope-flow.test.ts
+++ b/tests/catscompany-execution-scope-flow.test.ts
@@ -1259,6 +1259,30 @@ describe('CatsCompany execution scope flow', () => {
     assert.doesNotMatch(JSON.stringify(handledTurns[0].userMessage), /acr_[A-Za-z0-9_-]{43}/);
   });
 
+  test('forwards a trusted Artifact task ref only through current turn options', async () => {
+    const { bot, handledTurns } = createHarness();
+    const ref = `atr_${'t'.repeat(43)}`;
+    const metadata = {
+      ...canonicalMetadata('usr7', 'p2p_7_43'),
+      artifact_task_ref: ref,
+    };
+
+    await (bot as any).onMessage({
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      text: '来自「项目风险台账」：分析选中的风险',
+      content: '来自「项目风险台账」：分析选中的风险',
+      metadata,
+      isGroup: false,
+      seq: 12,
+    });
+
+    assert.equal(handledTurns.length, 1);
+    assert.equal(handledTurns[0].options.artifactTaskRef, ref);
+    assert.equal('artifactTaskRef' in handledTurns[0].options.executionScope, false);
+    assert.doesNotMatch(JSON.stringify(handledTurns[0].userMessage), /atr_[A-Za-z0-9_-]{43}/);
+  });
+
   test('does not merge queued CatsCo group input from another actor into the current actor scope', () => {
     const { bot } = createHarness();
     const aliceScope = createExecutionScope(createCatsCoMessageEnvelope({
@@ -1296,6 +1320,32 @@ describe('CatsCompany execution scope flow', () => {
     const pendingForBob = (bot as any).consumeQueuedUserInput(bobScope.sessionKey, bobScope);
     assert.equal(pendingForBob, 'bob follow-up');
     assert.equal(bot.messageQueue.has(bobScope.sessionKey), false);
+  });
+
+  test('keeps a queued Artifact task for its own run instead of merging it into active input', () => {
+    const { bot } = createHarness();
+    const scope = createExecutionScope(createCatsCoMessageEnvelope({
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      text: 'first',
+      metadata: canonicalMetadata('usr7', 'p2p_7_43'),
+      botUid: 'usr43',
+    }));
+    const taskRef = `atr_${'q'.repeat(43)}`;
+
+    bot.messageQueue.set(scope.sessionKey, [{
+      userMessage: '来自「项目风险台账」：生成处理方案',
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      seq: 13,
+      executionScope: scope,
+      artifactTaskRef: taskRef,
+      receivedAt: Date.now(),
+      source: 'user',
+    }]);
+
+    assert.equal((bot as any).consumeQueuedUserInput(scope.sessionKey, scope), null);
+    assert.equal(bot.messageQueue.get(scope.sessionKey)?.[0].artifactTaskRef, taskRef);
   });
 
   test('preserves device grants when queued CatsCompany user input is merged', () => {

--- a/tests/catscompany-message-envelope.test.ts
+++ b/tests/catscompany-message-envelope.test.ts
@@ -9,6 +9,7 @@ import {
 describe('CatsCompany MessageEnvelope and ExecutionScope', () => {
   test('accepts an opaque Artifact context ref only from a trusted canonical envelope', () => {
     const ref = `acr_${'a'.repeat(43)}`;
+    const taskRef = `atr_${'t'.repeat(43)}`;
     const canonical = createCatsCoMessageEnvelope({
       topic: 'p2p_7_43',
       senderId: 'usr7',
@@ -17,6 +18,7 @@ describe('CatsCompany MessageEnvelope and ExecutionScope', () => {
       botUid: 'usr43',
       metadata: {
         artifact_context_ref: ref,
+        artifact_task_ref: taskRef,
         catsco_identity: {
           actor: { user_id: 'usr7' },
           agent: { agent_id: 'usr43', body_id: 'body-main' },
@@ -32,6 +34,7 @@ describe('CatsCompany MessageEnvelope and ExecutionScope', () => {
       text: 'spoofed',
       metadata: {
         artifact_context_ref: ref,
+        artifact_task_ref: taskRef,
         catsco_identity: {
           actor: { user_id: 'usr999' },
           agent: { agent_id: 'usr43', body_id: 'body-main' },
@@ -47,6 +50,7 @@ describe('CatsCompany MessageEnvelope and ExecutionScope', () => {
       text: 'malformed',
       metadata: {
         artifact_context_ref: 'acr_too-short',
+        artifact_task_ref: 'atr_too-short',
         catsco_identity: {
           actor: { user_id: 'usr7' },
           agent: { agent_id: 'usr43', body_id: 'body-main' },
@@ -63,6 +67,7 @@ describe('CatsCompany MessageEnvelope and ExecutionScope', () => {
       botUid: 'usr43',
       metadata: {
         artifact_context_ref: ref,
+        artifact_task_ref: taskRef,
         catsco_identity: {
           actor: { user_id: 'usr7' },
           agent: { agent_id: 'usr99', body_id: 'body-other' },
@@ -78,6 +83,7 @@ describe('CatsCompany MessageEnvelope and ExecutionScope', () => {
       text: 'missing current bot',
       metadata: {
         artifact_context_ref: ref,
+        artifact_task_ref: taskRef,
         catsco_identity: {
           actor: { user_id: 'usr7' },
           agent: { agent_id: 'usr43', body_id: 'body-main' },
@@ -88,12 +94,18 @@ describe('CatsCompany MessageEnvelope and ExecutionScope', () => {
     });
 
     assert.equal(canonical.artifactContextRef, ref);
+    assert.equal(canonical.artifactTaskRef, taskRef);
     assert.equal(spoofed.artifactContextRef, undefined);
+    assert.equal(spoofed.artifactTaskRef, undefined);
     assert.equal(malformed.artifactContextRef, undefined);
+    assert.equal(malformed.artifactTaskRef, undefined);
     assert.equal(wrongAgent.identityTrust, 'server_canonical');
     assert.equal(wrongAgent.artifactContextRef, undefined);
+    assert.equal(wrongAgent.artifactTaskRef, undefined);
     assert.equal(missingCurrentBot.artifactContextRef, undefined);
+    assert.equal(missingCurrentBot.artifactTaskRef, undefined);
     assert.equal('artifactContextRef' in createExecutionScope(canonical), false);
+    assert.equal('artifactTaskRef' in createExecutionScope(canonical), false);
   });
 
   test('keeps two p2p users scoped separately when they message the same agent', () => {

--- a/tests/catscompany-message-sender.test.ts
+++ b/tests/catscompany-message-sender.test.ts
@@ -15,6 +15,7 @@ describe('CatsCompany MessageSender retry behavior', () => {
 
     await sender.sendTaskStatus('p2p_1_2', {
       run_id: 'run-1',
+      artifact_task_ref: `atr_${'a'.repeat(43)}`,
       state: 'running',
       summary: '正在处理请求',
     });
@@ -23,6 +24,7 @@ describe('CatsCompany MessageSender retry behavior', () => {
     assert.equal(sent[0].type, 'task_status');
     assert.deepEqual(sent[0].content, {
       run_id: 'run-1',
+      artifact_task_ref: `atr_${'a'.repeat(43)}`,
       state: 'running',
       summary: '正在处理请求',
     });

--- a/tests/subagent-runtime-events.test.ts
+++ b/tests/subagent-runtime-events.test.ts
@@ -676,6 +676,7 @@ describe('subagent runtime events', () => {
         sessionId: 'session:v2:catscompany:p2p:p2p_7_43:agent:usr43',
         surface: 'catscompany',
         artifactContextRef: `acr_${'a'.repeat(43)}`,
+        artifactTaskRef: `atr_${'t'.repeat(43)}`,
         executionScope: {
           source: 'catscompany',
           sessionKey: 'session:v2:catscompany:p2p:p2p_7_43:agent:usr43',
@@ -705,6 +706,7 @@ describe('subagent runtime events', () => {
       assert.equal(capturedDelegatedContext.executionScope?.sessionKey, 'session:v2:catscompany:p2p:p2p_7_43:agent:usr43');
       assert.equal(capturedDelegatedContext.localDeviceGrant?.bodyId, 'body-main');
       assert.equal('artifactContextRef' in capturedDelegatedContext, false);
+      assert.equal('artifactTaskRef' in capturedDelegatedContext, false);
     } finally {
       (SubAgentManager as any).getInstance = originalGetInstance;
     }


### PR DESCRIPTION
## Summary
- accept the canonical Artifact task reference carried by CatsCo message envelopes
- preserve it only for the matching queued user turn
- expose it only to the local execute_shell child as CATSCO_ARTIFACT_TASK_REF
- scrub stale inherited refs and keep them out of model history, execution scope, subagents, and remote devices
- correlate run-status updates with the originating task

## Verification
- npm run build
- focused Artifact/CatsCo/runtime regression suite: 149 tests passed
- git diff --check origin/main...HEAD

## Integration
Pairs with buildsense-ai/cats-company#325 and cloud-html-artifact 1.4.0.