### PR TITLE
feat: add leased turn Skill snapshots

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -26,6 +26,7 @@ const skillHubPhase1Tests = [
   'tests/bot-definition-skills.test.ts',
   'tests/bot-skill-workspace.test.ts',
   'tests/bot-skill-candidate-workspace.test.ts',
+  'tests/turn-skill-snapshot.test.ts',
   'tests/bot-skills-activation-state.test.ts',
   'tests/bot-skills-sync.test.ts',
   'tests/bot-skills-security.test.ts',

--- a/src/skills/skill-manager.ts
+++ b/src/skills/skill-manager.ts
@@ -9,18 +9,18 @@ import { Logger } from '../utils/logger';
  */
 export class SkillManager {
   private skills: Map<string, Skill>;
-  private skillsPath: string;
+  private readonly fixedSkillsPath?: string;
 
-  constructor() {
+  constructor(skillsPath?: string) {
     this.skills = new Map();
-    this.skillsPath = PathResolver.getSkillsPath();
+    this.fixedSkillsPath = skillsPath;
   }
 
   /**
    * 加载所有 skills（只从统一目录加载）
    */
   async loadSkills(): Promise<void> {
-    const skillsPath = PathResolver.getSkillsPath();
+    const skillsPath = this.fixedSkillsPath ?? PathResolver.getSkillsPath();
 
     // 从统一的 skills 目录加载
     const nextSkills = await this.loadSkillsFromPath(skillsPath);

--- a/src/skills/turn-skill-snapshot.ts
+++ b/src/skills/turn-skill-snapshot.ts
@@ -361,8 +361,13 @@ export class TurnSkillSnapshotStore {
 
 function scanWorkspaceTree(rootValue: string): WorkspaceTree {
   const root = path.resolve(rootValue);
-  if (!fs.existsSync(root)) return buildWorkspaceTree([], []);
-  const rootStat = fs.lstatSync(root);
+  let rootStat: fs.Stats;
+  try {
+    rootStat = fs.lstatSync(root);
+  } catch (error: any) {
+    if (error?.code === 'ENOENT') return buildWorkspaceTree([], []);
+    throw error;
+  }
   if (rootStat.isSymbolicLink() || !rootStat.isDirectory()) {
     throw new Error(`Skill workspace is not a safe directory: ${root}`);
   }

--- a/src/skills/turn-skill-snapshot.ts
+++ b/src/skills/turn-skill-snapshot.ts
@@ -1,0 +1,660 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+import { withBotSkillWorkspaceLock } from '../bot-skills/lock';
+import { renameBotSkillWorkspaceSync } from '../bot-skills/workspace-fs';
+
+const SNAPSHOT_SCHEMA = 'xiaoba.turn-skill-snapshot.v1';
+const LEASE_SCHEMA = 'xiaoba.turn-skill-snapshot-lease.v1';
+const USAGE_SCHEMA = 'xiaoba.turn-skill-snapshot-usage.v1';
+const SNAPSHOT_FILE = 'snapshot.json';
+const SNAPSHOT_DIRECTORY = 'skills';
+const DEFAULT_GC_MIN_AGE_MS = 24 * 60 * 60_000;
+const SNAPSHOT_ID_PATTERN = /^[a-f0-9]{64}$/;
+const LEASE_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+interface SnapshotFileEntry {
+  path: string;
+  size: number;
+  sha256: string;
+  mode: number;
+}
+
+interface ScannedSnapshotFile extends SnapshotFileEntry {
+  sourcePath: string;
+}
+
+interface WorkspaceTree {
+  directories: string[];
+  files: ScannedSnapshotFile[];
+  contentHash: string;
+  totalBytes: number;
+}
+
+interface TurnSkillSnapshotManifest {
+  schema: typeof SNAPSHOT_SCHEMA;
+  snapshotId: string;
+  revision: string;
+  directories: string[];
+  files: SnapshotFileEntry[];
+  fileCount: number;
+  totalBytes: number;
+  createdAt: string;
+}
+
+interface TurnSkillSnapshotLeaseRecord {
+  schema: typeof LEASE_SCHEMA;
+  snapshotId: string;
+  leaseId: string;
+  pid: number;
+  createdAt: string;
+}
+
+export interface TurnSkillSnapshotDescriptor {
+  snapshotId: string;
+  revision: string;
+  rootPath: string;
+  fileCount: number;
+  totalBytes: number;
+  createdAt: string;
+  deduplicated: boolean;
+}
+
+export interface TurnSkillSnapshotStoreOptions {
+  runtimeRoot: string;
+  skillsRoot?: string;
+  now?: () => Date;
+}
+
+export interface TurnSkillSnapshotGcOptions {
+  minAgeMs?: number;
+}
+
+export interface TurnSkillSnapshotGcResult {
+  removed: string[];
+  preservedLeased: string[];
+  preservedRecent: string[];
+  preservedInvalid: string[];
+}
+
+/**
+ * One reference-counted claim on an immutable turn Skill snapshot.
+ *
+ * This class is not wired into the active conversation path yet. A later,
+ * separately reviewed change will pass leases through ToolExecutionContext.
+ */
+export class TurnSkillSnapshotLease {
+  private released = false;
+
+  constructor(
+    private readonly store: TurnSkillSnapshotStore,
+    private readonly leaseId: string,
+    readonly snapshot: TurnSkillSnapshotDescriptor,
+  ) {}
+
+  /** Creates an independent child lease for background/sub-agent work. */
+  async retain(): Promise<TurnSkillSnapshotLease> {
+    if (this.released) throw new Error('Cannot retain a released turn Skill snapshot lease.');
+    return this.store.retainSnapshot(this.snapshot.snapshotId);
+  }
+
+  /** Idempotently releases only this claim. */
+  async release(): Promise<void> {
+    if (this.released) return;
+    await this.store.releaseLease(this.snapshot.snapshotId, this.leaseId);
+    this.released = true;
+  }
+}
+
+/**
+ * Content-addressed immutable snapshots of the complete active Skill tree.
+ *
+ * Publication and garbage collection share the Bot Skill workspace lock with
+ * activation. Snapshot objects are written to a temporary sibling, verified,
+ * and atomically renamed. Persistent per-process lease files keep GC safe even
+ * when more than one Runtime process shares the same userData directory.
+ */
+export class TurnSkillSnapshotStore {
+  private readonly runtimeRoot: string;
+  private readonly skillsRoot: string;
+  private readonly now: () => Date;
+
+  constructor(options: TurnSkillSnapshotStoreOptions) {
+    this.runtimeRoot = requireSafeDirectory(options.runtimeRoot, 'Runtime root');
+    this.skillsRoot = path.resolve(options.skillsRoot ?? path.join(this.runtimeRoot, 'skills'));
+    const plannedStoreRoot = path.join(this.runtimeRoot, 'data', 'bot-skills', 'turn-snapshots');
+    if (containsPath(this.skillsRoot, plannedStoreRoot)) {
+      throw new Error('Skill workspace cannot contain the turn Skill snapshot store.');
+    }
+    this.now = options.now ?? (() => new Date());
+  }
+
+  async acquire(): Promise<TurnSkillSnapshotLease> {
+    return withBotSkillWorkspaceLock(this.runtimeRoot, () => {
+      const storeRoot = this.ensureStoreRoot();
+      const tree = scanWorkspaceTree(this.skillsRoot);
+      const published = this.publishSnapshot(storeRoot, tree);
+      this.writeUsage(storeRoot, published.snapshotId);
+      return this.createLease(storeRoot, published);
+    });
+  }
+
+  async inspect(snapshotIdValue: string): Promise<TurnSkillSnapshotDescriptor> {
+    return withBotSkillWorkspaceLock(this.runtimeRoot, () => {
+      const storeRoot = this.ensureStoreRoot();
+      return this.inspectSnapshot(storeRoot, normalizeSnapshotId(snapshotIdValue), false);
+    });
+  }
+
+  async collectGarbage(
+    options: TurnSkillSnapshotGcOptions = {},
+  ): Promise<TurnSkillSnapshotGcResult> {
+    const minAgeMs = nonNegativeDuration(options.minAgeMs, DEFAULT_GC_MIN_AGE_MS);
+    return withBotSkillWorkspaceLock(this.runtimeRoot, () => {
+      const storeRoot = this.ensureStoreRoot();
+      const result: TurnSkillSnapshotGcResult = {
+        removed: [],
+        preservedLeased: [],
+        preservedRecent: [],
+        preservedInvalid: [],
+      };
+      const objectsRoot = path.join(storeRoot, 'objects');
+      for (const entry of fs.readdirSync(objectsRoot, { withFileTypes: true })) {
+        if (!entry.isDirectory() || entry.isSymbolicLink() || entry.name.startsWith('.tmp-')) {
+          continue;
+        }
+        if (!SNAPSHOT_ID_PATTERN.test(entry.name)) {
+          result.preservedInvalid.push(entry.name);
+          continue;
+        }
+        let snapshot: TurnSkillSnapshotDescriptor;
+        try {
+          snapshot = this.inspectSnapshot(storeRoot, entry.name, false);
+        } catch {
+          result.preservedInvalid.push(entry.name);
+          continue;
+        }
+        const leaseState = inspectLeases(storeRoot, entry.name);
+        if (leaseState.invalid || leaseState.live > 0) {
+          result.preservedLeased.push(entry.name);
+          continue;
+        }
+        const lastUsedAt = readLastUsedAt(storeRoot, snapshot);
+        if (this.now().getTime() - lastUsedAt < minAgeMs) {
+          result.preservedRecent.push(entry.name);
+          continue;
+        }
+        removeSnapshotArtifacts(storeRoot, entry.name);
+        result.removed.push(entry.name);
+      }
+      return result;
+    });
+  }
+
+  async retainSnapshot(snapshotIdValue: string): Promise<TurnSkillSnapshotLease> {
+    return withBotSkillWorkspaceLock(this.runtimeRoot, () => {
+      const storeRoot = this.ensureStoreRoot();
+      const snapshot = this.inspectSnapshot(
+        storeRoot,
+        normalizeSnapshotId(snapshotIdValue),
+        true,
+      );
+      this.writeUsage(storeRoot, snapshot.snapshotId);
+      return this.createLease(storeRoot, snapshot);
+    });
+  }
+
+  async releaseLease(snapshotIdValue: string, leaseIdValue: string): Promise<void> {
+    const snapshotId = normalizeSnapshotId(snapshotIdValue);
+    const leaseId = normalizeLeaseId(leaseIdValue);
+    await withBotSkillWorkspaceLock(this.runtimeRoot, () => {
+      const storeRoot = this.ensureStoreRoot();
+      const leaseRoot = path.join(storeRoot, 'leases', snapshotId);
+      if (!fs.existsSync(leaseRoot)) return;
+      requireSafeDirectory(leaseRoot, 'turn Skill snapshot lease directory');
+      const leasePath = path.join(leaseRoot, `${leaseId}.json`);
+      if (!fs.existsSync(leasePath)) return;
+      const record = readLeaseRecord(leasePath, snapshotId, leaseId);
+      if (record.pid !== process.pid) {
+        throw new Error('Cannot release a turn Skill snapshot lease owned by another process.');
+      }
+      fs.rmSync(leasePath, { force: false });
+      if (fs.readdirSync(leaseRoot).length === 0) fs.rmdirSync(leaseRoot);
+    });
+  }
+
+  private ensureStoreRoot(): string {
+    let current = this.runtimeRoot;
+    for (const segment of ['data', 'bot-skills', 'turn-snapshots']) {
+      current = ensureSafeChildDirectory(current, segment);
+    }
+    for (const segment of ['objects', 'leases', 'usage']) {
+      ensureSafeChildDirectory(current, segment);
+    }
+    return current;
+  }
+
+  private publishSnapshot(
+    storeRoot: string,
+    tree: WorkspaceTree,
+  ): TurnSkillSnapshotDescriptor {
+    const objectsRoot = path.join(storeRoot, 'objects');
+    const finalPath = path.join(objectsRoot, tree.contentHash);
+    if (fs.existsSync(finalPath)) {
+      return this.inspectSnapshot(storeRoot, tree.contentHash, true);
+    }
+
+    const temporary = path.join(
+      objectsRoot,
+      `.tmp-${tree.contentHash}-${process.pid}-${crypto.randomBytes(8).toString('hex')}`,
+    );
+    const snapshotRoot = path.join(temporary, SNAPSHOT_DIRECTORY);
+    fs.mkdirSync(snapshotRoot, { recursive: true });
+    try {
+      for (const directory of tree.directories) {
+        fs.mkdirSync(path.join(snapshotRoot, ...directory.split('/')), { recursive: true });
+      }
+      for (const file of tree.files) {
+        const target = path.join(snapshotRoot, ...file.path.split('/'));
+        fs.mkdirSync(path.dirname(target), { recursive: true });
+        fs.copyFileSync(file.sourcePath, target, fs.constants.COPYFILE_EXCL);
+        if (process.platform !== 'win32') fs.chmodSync(target, file.mode);
+      }
+
+      const copied = scanWorkspaceTree(snapshotRoot);
+      if (copied.contentHash !== tree.contentHash) {
+        throw new Error('Turn Skill snapshot changed while it was being copied.');
+      }
+      const createdAt = this.now().toISOString();
+      const manifest: TurnSkillSnapshotManifest = {
+        schema: SNAPSHOT_SCHEMA,
+        snapshotId: tree.contentHash,
+        revision: tree.contentHash,
+        directories: tree.directories,
+        files: tree.files.map(({ path: filePath, size, sha256, mode }) => ({
+          path: filePath,
+          size,
+          sha256,
+          mode,
+        })),
+        fileCount: tree.files.length,
+        totalBytes: tree.totalBytes,
+        createdAt,
+      };
+      fs.writeFileSync(
+        path.join(temporary, SNAPSHOT_FILE),
+        `${JSON.stringify(manifest, null, 2)}\n`,
+        { encoding: 'utf8', flag: 'wx' },
+      );
+      renameBotSkillWorkspaceSync(temporary, finalPath);
+      return descriptorFromManifest(finalPath, manifest, false);
+    } catch (error) {
+      if (fs.existsSync(temporary)) fs.rmSync(temporary, { recursive: true, force: true });
+      if (fs.existsSync(finalPath)) {
+        return this.inspectSnapshot(storeRoot, tree.contentHash, true);
+      }
+      throw error;
+    }
+  }
+
+  private inspectSnapshot(
+    storeRoot: string,
+    snapshotId: string,
+    deduplicated: boolean,
+  ): TurnSkillSnapshotDescriptor {
+    const objectPath = path.join(storeRoot, 'objects', snapshotId);
+    const safeObjectPath = requireSafeDirectory(objectPath, 'turn Skill snapshot object');
+    const manifest = readSnapshotManifest(safeObjectPath, snapshotId);
+    const snapshotRoot = requireSafeDirectory(
+      path.join(safeObjectPath, SNAPSHOT_DIRECTORY),
+      'turn Skill snapshot tree',
+    );
+    const scanned = scanWorkspaceTree(snapshotRoot);
+    if (
+      scanned.contentHash !== manifest.snapshotId
+      || scanned.contentHash !== manifest.revision
+      || scanned.files.length !== manifest.fileCount
+      || scanned.totalBytes !== manifest.totalBytes
+      || !sameDirectories(scanned.directories, manifest.directories)
+      || !sameFiles(scanned.files, manifest.files)
+    ) {
+      throw new Error('Turn Skill snapshot no longer matches its verified manifest.');
+    }
+    return descriptorFromManifest(safeObjectPath, manifest, deduplicated);
+  }
+
+  private createLease(
+    storeRoot: string,
+    snapshot: TurnSkillSnapshotDescriptor,
+  ): TurnSkillSnapshotLease {
+    const leaseId = crypto.randomUUID();
+    const leaseRoot = ensureSafeChildDirectory(
+      path.join(storeRoot, 'leases'),
+      snapshot.snapshotId,
+    );
+    const record: TurnSkillSnapshotLeaseRecord = {
+      schema: LEASE_SCHEMA,
+      snapshotId: snapshot.snapshotId,
+      leaseId,
+      pid: process.pid,
+      createdAt: this.now().toISOString(),
+    };
+    fs.writeFileSync(
+      path.join(leaseRoot, `${leaseId}.json`),
+      `${JSON.stringify(record, null, 2)}\n`,
+      { encoding: 'utf8', flag: 'wx' },
+    );
+    return new TurnSkillSnapshotLease(this, leaseId, snapshot);
+  }
+
+  private writeUsage(storeRoot: string, snapshotId: string): void {
+    const usagePath = path.join(storeRoot, 'usage', `${snapshotId}.json`);
+    const temporary = `${usagePath}.${process.pid}.${crypto.randomBytes(6).toString('hex')}.tmp`;
+    fs.writeFileSync(temporary, `${JSON.stringify({
+      schema: USAGE_SCHEMA,
+      snapshotId,
+      lastUsedAt: this.now().toISOString(),
+    }, null, 2)}\n`, { encoding: 'utf8', flag: 'wx' });
+    fs.renameSync(temporary, usagePath);
+  }
+}
+
+function scanWorkspaceTree(rootValue: string): WorkspaceTree {
+  const root = path.resolve(rootValue);
+  if (!fs.existsSync(root)) return buildWorkspaceTree([], []);
+  const rootStat = fs.lstatSync(root);
+  if (rootStat.isSymbolicLink() || !rootStat.isDirectory()) {
+    throw new Error(`Skill workspace is not a safe directory: ${root}`);
+  }
+  const realRoot = fs.realpathSync(root);
+  const directories: string[] = [];
+  const files: ScannedSnapshotFile[] = [];
+  const visit = (directory: string): void => {
+    const entries = fs.readdirSync(directory, { withFileTypes: true })
+      .sort((left, right) => compareText(left.name, right.name));
+    for (const entry of entries) {
+      const absolute = path.join(directory, entry.name);
+      const stat = fs.lstatSync(absolute);
+      if (entry.isSymbolicLink() || stat.isSymbolicLink()) {
+        throw new Error(`Skill workspace contains a symbolic link: ${toRelative(root, absolute)}`);
+      }
+      assertRealPathContained(realRoot, absolute);
+      const relative = toRelative(root, absolute);
+      if (entry.isDirectory() && stat.isDirectory()) {
+        directories.push(relative);
+        visit(absolute);
+        continue;
+      }
+      if (!entry.isFile() || !stat.isFile()) {
+        throw new Error(`Skill workspace contains an unsupported entry: ${relative}`);
+      }
+      const bytes = fs.readFileSync(absolute);
+      files.push({
+        path: relative,
+        sourcePath: absolute,
+        size: bytes.length,
+        sha256: sha256(bytes),
+        mode: stat.mode & 0o777,
+      });
+    }
+  };
+  visit(root);
+  return buildWorkspaceTree(directories, files);
+}
+
+function buildWorkspaceTree(
+  directories: string[],
+  files: ScannedSnapshotFile[],
+): WorkspaceTree {
+  const sortedDirectories = [...directories].sort(compareText);
+  const sortedFiles = [...files].sort((left, right) => compareText(left.path, right.path));
+  const hashInput = {
+    directories: sortedDirectories,
+    files: sortedFiles.map(({ path: filePath, size, sha256: fileHash, mode }) => ({
+      path: filePath,
+      size,
+      sha256: fileHash,
+      mode,
+    })),
+  };
+  return {
+    directories: sortedDirectories,
+    files: sortedFiles,
+    contentHash: sha256(Buffer.from(JSON.stringify(hashInput), 'utf8')),
+    totalBytes: sortedFiles.reduce((total, file) => total + file.size, 0),
+  };
+}
+
+function readSnapshotManifest(
+  objectPath: string,
+  snapshotId: string,
+): TurnSkillSnapshotManifest {
+  let value: Partial<TurnSkillSnapshotManifest>;
+  try {
+    value = JSON.parse(fs.readFileSync(path.join(objectPath, SNAPSHOT_FILE), 'utf8'));
+  } catch {
+    throw new Error('Turn Skill snapshot manifest cannot be read safely.');
+  }
+  if (
+    value.schema !== SNAPSHOT_SCHEMA
+    || value.snapshotId !== snapshotId
+    || value.revision !== snapshotId
+    || !Array.isArray(value.directories)
+    || !Array.isArray(value.files)
+    || !Number.isInteger(value.fileCount)
+    || Number(value.fileCount) < 0
+    || !Number.isSafeInteger(value.totalBytes)
+    || Number(value.totalBytes) < 0
+    || !validIsoDate(value.createdAt)
+  ) {
+    throw new Error('Turn Skill snapshot manifest is invalid.');
+  }
+  return value as TurnSkillSnapshotManifest;
+}
+
+function readLeaseRecord(
+  leasePath: string,
+  snapshotId: string,
+  leaseId: string,
+): TurnSkillSnapshotLeaseRecord {
+  let value: Partial<TurnSkillSnapshotLeaseRecord>;
+  try {
+    value = JSON.parse(fs.readFileSync(leasePath, 'utf8'));
+  } catch {
+    throw new Error('Turn Skill snapshot lease cannot be read safely.');
+  }
+  if (
+    value.schema !== LEASE_SCHEMA
+    || value.snapshotId !== snapshotId
+    || value.leaseId !== leaseId
+    || !Number.isInteger(value.pid)
+    || Number(value.pid) <= 0
+    || !validIsoDate(value.createdAt)
+  ) {
+    throw new Error('Turn Skill snapshot lease is invalid.');
+  }
+  return value as TurnSkillSnapshotLeaseRecord;
+}
+
+function inspectLeases(
+  storeRoot: string,
+  snapshotId: string,
+): { live: number; invalid: boolean } {
+  const leaseRoot = path.join(storeRoot, 'leases', snapshotId);
+  if (!fs.existsSync(leaseRoot)) return { live: 0, invalid: false };
+  try {
+    requireSafeDirectory(leaseRoot, 'turn Skill snapshot lease directory');
+  } catch {
+    return { live: 0, invalid: true };
+  }
+  let live = 0;
+  let invalid = false;
+  for (const entry of fs.readdirSync(leaseRoot, { withFileTypes: true })) {
+    const match = /^([0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})\.json$/
+      .exec(entry.name);
+    if (!entry.isFile() || entry.isSymbolicLink() || !match) {
+      invalid = true;
+      continue;
+    }
+    const leasePath = path.join(leaseRoot, entry.name);
+    try {
+      const record = readLeaseRecord(leasePath, snapshotId, match[1]);
+      if (isProcessAlive(record.pid)) {
+        live += 1;
+      } else {
+        fs.rmSync(leasePath, { force: false });
+      }
+    } catch {
+      invalid = true;
+    }
+  }
+  if (!invalid && live === 0 && fs.readdirSync(leaseRoot).length === 0) {
+    fs.rmdirSync(leaseRoot);
+  }
+  return { live, invalid };
+}
+
+function readLastUsedAt(
+  storeRoot: string,
+  snapshot: TurnSkillSnapshotDescriptor,
+): number {
+  try {
+    const value = JSON.parse(
+      fs.readFileSync(path.join(storeRoot, 'usage', `${snapshot.snapshotId}.json`), 'utf8'),
+    ) as { schema?: string; snapshotId?: string; lastUsedAt?: string };
+    if (
+      value.schema === USAGE_SCHEMA
+      && value.snapshotId === snapshot.snapshotId
+      && validIsoDate(value.lastUsedAt)
+    ) {
+      return Date.parse(value.lastUsedAt!);
+    }
+  } catch {
+    // A missing/corrupt usage record never changes snapshot validity.
+  }
+  return Date.parse(snapshot.createdAt);
+}
+
+function removeSnapshotArtifacts(storeRoot: string, snapshotId: string): void {
+  const objectPath = path.resolve(storeRoot, 'objects', snapshotId);
+  const objectsRoot = path.resolve(storeRoot, 'objects');
+  assertDirectChild(objectsRoot, objectPath);
+  fs.rmSync(objectPath, { recursive: true, force: false });
+  fs.rmSync(path.join(storeRoot, 'usage', `${snapshotId}.json`), { force: true });
+}
+
+function descriptorFromManifest(
+  objectPath: string,
+  manifest: TurnSkillSnapshotManifest,
+  deduplicated: boolean,
+): TurnSkillSnapshotDescriptor {
+  return {
+    snapshotId: manifest.snapshotId,
+    revision: manifest.revision,
+    rootPath: path.join(objectPath, SNAPSHOT_DIRECTORY),
+    fileCount: manifest.fileCount,
+    totalBytes: manifest.totalBytes,
+    createdAt: manifest.createdAt,
+    deduplicated,
+  };
+}
+
+function sameDirectories(left: string[], right: string[]): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function sameFiles(left: ScannedSnapshotFile[], right: SnapshotFileEntry[]): boolean {
+  return JSON.stringify(left.map(({ path: filePath, size, sha256: fileHash, mode }) => ({
+    path: filePath,
+    size,
+    sha256: fileHash,
+    mode,
+  }))) === JSON.stringify(right);
+}
+
+function ensureSafeChildDirectory(parentValue: string, name: string): string {
+  const parent = requireSafeDirectory(parentValue, 'turn Skill snapshot parent directory');
+  const child = path.join(parent, name);
+  if (!fs.existsSync(child)) {
+    try {
+      fs.mkdirSync(child, { recursive: false });
+    } catch (error: any) {
+      if (error?.code !== 'EEXIST') throw error;
+    }
+  }
+  return requireSafeDirectory(child, 'turn Skill snapshot directory');
+}
+
+function requireSafeDirectory(value: string, label: string): string {
+  const resolved = path.resolve(value);
+  const stat = fs.lstatSync(resolved);
+  if (stat.isSymbolicLink() || !stat.isDirectory()) {
+    throw new Error(`${label} is not a safe directory.`);
+  }
+  return resolved;
+}
+
+function assertRealPathContained(realRoot: string, candidate: string): void {
+  const realCandidate = fs.realpathSync(candidate);
+  const relative = path.relative(realRoot, realCandidate);
+  if (relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative))) return;
+  throw new Error('Skill workspace entry escapes its root.');
+}
+
+function assertDirectChild(parent: string, child: string): void {
+  const relative = path.relative(parent, child);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative) || relative.includes(path.sep)) {
+    throw new Error('Refusing to remove a turn Skill snapshot outside the object store.');
+  }
+}
+
+function containsPath(parentValue: string, candidateValue: string): boolean {
+  const relative = path.relative(path.resolve(parentValue), path.resolve(candidateValue));
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+function toRelative(root: string, candidate: string): string {
+  const relative = path.relative(root, candidate);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error('Skill workspace entry escapes its root.');
+  }
+  return relative.split(path.sep).join('/');
+}
+
+function normalizeSnapshotId(value: string): string {
+  const snapshotId = String(value || '').trim();
+  if (!SNAPSHOT_ID_PATTERN.test(snapshotId)) throw new Error('Invalid turn Skill snapshot ID.');
+  return snapshotId;
+}
+
+function normalizeLeaseId(value: string): string {
+  const leaseId = String(value || '').trim().toLowerCase();
+  if (!LEASE_ID_PATTERN.test(leaseId)) throw new Error('Invalid turn Skill snapshot lease ID.');
+  return leaseId;
+}
+
+function isProcessAlive(pid: number): boolean {
+  if (pid === process.pid) return true;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error: any) {
+    return error?.code !== 'ESRCH';
+  }
+}
+
+function validIsoDate(value: unknown): value is string {
+  return typeof value === 'string' && Number.isFinite(Date.parse(value));
+}
+
+function nonNegativeDuration(value: number | undefined, fallback: number): number {
+  return Number.isFinite(value) && Number(value) >= 0 ? Number(value) : fallback;
+}
+
+function compareText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function sha256(bytes: Buffer): string {
+  return crypto.createHash('sha256').update(bytes).digest('hex');
+}

--- a/tests/turn-skill-snapshot.test.ts
+++ b/tests/turn-skill-snapshot.test.ts
@@ -130,6 +130,26 @@ describe('turn Skill snapshot store', () => {
     assert.equal(fs.readFileSync(outside, 'utf8'), 'outside');
   });
 
+  test('rejects a dangling workspace-root link instead of publishing an empty revision', async (t) => {
+    const root = createRuntimeRoot(roots);
+    const missingTarget = path.join(root, 'missing-skills-target');
+    const skillsRoot = path.join(root, 'skills-link');
+    try {
+      fs.symlinkSync(missingTarget, skillsRoot, 'dir');
+    } catch (error: any) {
+      if (process.platform === 'win32' && ['EPERM', 'EACCES', 'UNKNOWN'].includes(String(error?.code))) {
+        t.skip('Windows symlink creation is unavailable for this user');
+        return;
+      }
+      throw error;
+    }
+
+    const store = new TurnSkillSnapshotStore({ runtimeRoot: root, skillsRoot });
+    await assert.rejects(() => store.acquire(), /not a safe directory/i);
+    assert.equal(fs.lstatSync(skillsRoot).isSymbolicLink(), true);
+    assert.equal(fs.existsSync(missingTarget), false);
+  });
+
   test('detects snapshot tampering and preserves the evidence from GC', async () => {
     const root = createRuntimeRoot(roots);
     const skillsRoot = path.join(root, 'skills');

--- a/tests/turn-skill-snapshot.test.ts
+++ b/tests/turn-skill-snapshot.test.ts
@@ -1,0 +1,210 @@
+import { afterEach, describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { SkillManager } from '../src/skills/skill-manager';
+import { TurnSkillSnapshotStore } from '../src/skills/turn-skill-snapshot';
+
+describe('turn Skill snapshot store', () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('publishes an immutable full-tree snapshot without changing the live workspace', async () => {
+    const root = createRuntimeRoot(roots);
+    const skillsRoot = path.join(root, 'skills');
+    writeSkill(skillsRoot, 'image-skill', 'before');
+    fs.mkdirSync(path.join(skillsRoot, 'image-skill', 'assets', 'empty'), { recursive: true });
+    const before = treeFingerprint(skillsRoot);
+    const store = new TurnSkillSnapshotStore({ runtimeRoot: root, skillsRoot });
+
+    const lease = await store.acquire();
+    assert.deepEqual(treeFingerprint(skillsRoot), before);
+    fs.writeFileSync(path.join(skillsRoot, 'image-skill', 'body.txt'), 'after');
+
+    assert.deepEqual(treeFingerprint(skillsRoot).filter(item => item.path !== 'image-skill/body.txt'),
+      before.filter(item => item.path !== 'image-skill/body.txt'));
+    assert.equal(
+      fs.readFileSync(path.join(lease.snapshot.rootPath, 'image-skill', 'body.txt'), 'utf8'),
+      'before',
+    );
+    assert.equal(fs.existsSync(path.join(lease.snapshot.rootPath, 'image-skill', 'assets', 'empty')), true);
+    await lease.release();
+  });
+
+  test('deduplicates identical content and creates a new revision after a local edit', async () => {
+    const root = createRuntimeRoot(roots);
+    const skillsRoot = path.join(root, 'skills');
+    writeSkill(skillsRoot, 'stable-skill', 'one');
+    const store = new TurnSkillSnapshotStore({ runtimeRoot: root, skillsRoot });
+
+    const first = await store.acquire();
+    const second = await store.acquire();
+    assert.equal(first.snapshot.snapshotId, second.snapshot.snapshotId);
+    assert.equal(first.snapshot.deduplicated, false);
+    assert.equal(second.snapshot.deduplicated, true);
+
+    fs.writeFileSync(path.join(skillsRoot, 'stable-skill', 'body.txt'), 'two');
+    const third = await store.acquire();
+    assert.notEqual(third.snapshot.snapshotId, first.snapshot.snapshotId);
+    assert.equal(third.snapshot.deduplicated, false);
+
+    await first.release();
+    await second.release();
+    await third.release();
+  });
+
+  test('retained child leases protect a snapshot until every claimant releases it', async () => {
+    const root = createRuntimeRoot(roots);
+    const skillsRoot = path.join(root, 'skills');
+    writeSkill(skillsRoot, 'background-skill', 'one');
+    let now = new Date('2026-08-26T00:00:00.000Z');
+    const store = new TurnSkillSnapshotStore({ runtimeRoot: root, skillsRoot, now: () => now });
+    const parent = await store.acquire();
+    const child = await parent.retain();
+    await parent.release();
+    now = new Date('2026-08-28T00:00:00.000Z');
+
+    const whileChildRuns = await store.collectGarbage({ minAgeMs: 0 });
+    assert.deepEqual(whileChildRuns.preservedLeased, [child.snapshot.snapshotId]);
+    assert.equal(fs.existsSync(child.snapshot.rootPath), true);
+
+    await child.release();
+    const afterChild = await store.collectGarbage({ minAgeMs: 0 });
+    assert.deepEqual(afterChild.removed, [child.snapshot.snapshotId]);
+    assert.equal(fs.existsSync(child.snapshot.rootPath), false);
+  });
+
+  test('keeps recent unleased snapshots until the GC age threshold expires', async () => {
+    const root = createRuntimeRoot(roots);
+    const skillsRoot = path.join(root, 'skills');
+    writeSkill(skillsRoot, 'recent-skill', 'one');
+    let now = new Date('2026-08-26T00:00:00.000Z');
+    const store = new TurnSkillSnapshotStore({ runtimeRoot: root, skillsRoot, now: () => now });
+    const lease = await store.acquire();
+    const snapshotId = lease.snapshot.snapshotId;
+    await lease.release();
+
+    now = new Date('2026-08-26T00:30:00.000Z');
+    const recent = await store.collectGarbage({ minAgeMs: 60 * 60_000 });
+    assert.deepEqual(recent.preservedRecent, [snapshotId]);
+    now = new Date('2026-08-26T02:00:00.000Z');
+    const expired = await store.collectGarbage({ minAgeMs: 60 * 60_000 });
+    assert.deepEqual(expired.removed, [snapshotId]);
+  });
+
+  test('supports an absent Skill workspace as a verified empty revision', async () => {
+    const root = createRuntimeRoot(roots);
+    const store = new TurnSkillSnapshotStore({
+      runtimeRoot: root,
+      skillsRoot: path.join(root, 'missing-skills'),
+    });
+    const lease = await store.acquire();
+    assert.equal(lease.snapshot.fileCount, 0);
+    assert.equal(lease.snapshot.totalBytes, 0);
+    assert.deepEqual(fs.readdirSync(lease.snapshot.rootPath), []);
+    await lease.release();
+  });
+
+  test('rejects workspace links instead of snapshotting content outside the root', async (t) => {
+    const root = createRuntimeRoot(roots);
+    const skillsRoot = path.join(root, 'skills');
+    writeSkill(skillsRoot, 'safe-skill', 'one');
+    const outside = path.join(root, 'outside.txt');
+    fs.writeFileSync(outside, 'outside');
+    try {
+      fs.symlinkSync(outside, path.join(skillsRoot, 'safe-skill', 'outside-link'), 'file');
+    } catch (error: any) {
+      if (process.platform === 'win32' && ['EPERM', 'EACCES', 'UNKNOWN'].includes(String(error?.code))) {
+        t.skip('Windows symlink creation is unavailable for this user');
+        return;
+      }
+      throw error;
+    }
+
+    const store = new TurnSkillSnapshotStore({ runtimeRoot: root, skillsRoot });
+    await assert.rejects(() => store.acquire(), /symbolic link/i);
+    assert.equal(fs.readFileSync(outside, 'utf8'), 'outside');
+  });
+
+  test('detects snapshot tampering and preserves the evidence from GC', async () => {
+    const root = createRuntimeRoot(roots);
+    const skillsRoot = path.join(root, 'skills');
+    writeSkill(skillsRoot, 'audited-skill', 'one');
+    const store = new TurnSkillSnapshotStore({ runtimeRoot: root, skillsRoot });
+    const lease = await store.acquire();
+    const snapshotId = lease.snapshot.snapshotId;
+    await lease.release();
+    fs.writeFileSync(path.join(lease.snapshot.rootPath, 'audited-skill', 'body.txt'), 'tampered');
+
+    await assert.rejects(() => store.inspect(snapshotId), /no longer matches/i);
+    const gc = await store.collectGarbage({ minAgeMs: 0 });
+    assert.deepEqual(gc.preservedInvalid, [snapshotId]);
+    assert.equal(fs.existsSync(lease.snapshot.rootPath), true);
+  });
+
+  test('loads a fixed snapshot root without changing the default SkillManager behavior', async () => {
+    const root = createRuntimeRoot(roots);
+    const firstRoot = path.join(root, 'first');
+    const secondRoot = path.join(root, 'second');
+    writeSkill(firstRoot, 'first-skill', 'one');
+    writeSkill(secondRoot, 'second-skill', 'two');
+    const manager = new SkillManager(firstRoot);
+    const previousSkillsDirectory = process.env.XIAOBA_SKILLS_DIR;
+
+    try {
+      await manager.loadSkills();
+      process.env.XIAOBA_SKILLS_DIR = secondRoot;
+      await manager.reload();
+
+      assert.deepEqual(manager.getAllSkills().map(skill => skill.metadata.name), ['first-skill']);
+    } finally {
+      if (previousSkillsDirectory === undefined) delete process.env.XIAOBA_SKILLS_DIR;
+      else process.env.XIAOBA_SKILLS_DIR = previousSkillsDirectory;
+    }
+  });
+
+  test('rejects a workspace configuration that would recursively snapshot the store', () => {
+    const root = createRuntimeRoot(roots);
+    assert.throws(() => new TurnSkillSnapshotStore({
+      runtimeRoot: root,
+      skillsRoot: root,
+    }), /cannot contain the turn Skill snapshot store/i);
+  });
+});
+
+function createRuntimeRoot(roots: string[]): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-turn-snapshot-'));
+  roots.push(root);
+  return root;
+}
+
+function writeSkill(skillsRoot: string, name: string, body: string): string {
+  const skillRoot = path.join(skillsRoot, name);
+  fs.mkdirSync(skillRoot, { recursive: true });
+  fs.writeFileSync(
+    path.join(skillRoot, 'SKILL.md'),
+    `---\nname: ${name}\ndescription: Turn snapshot test Skill\n---\n`,
+  );
+  fs.writeFileSync(path.join(skillRoot, 'body.txt'), body);
+  return skillRoot;
+}
+
+function treeFingerprint(root: string): Array<{ path: string; content: string }> {
+  const files: Array<{ path: string; content: string }> = [];
+  const visit = (directory: string): void => {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const absolute = path.join(directory, entry.name);
+      if (entry.isDirectory()) visit(absolute);
+      else if (entry.isFile()) files.push({
+        path: path.relative(root, absolute).replace(/\\/g, '/'),
+        content: fs.readFileSync(absolute).toString('base64'),
+      });
+    }
+  };
+  visit(root);
+  return files.sort((left, right) => left.path.localeCompare(right.path));
+}


### PR DESCRIPTION
## 目标

为后续“同一轮对话固定使用同一份 Skill 版本”提供默认不接入现有运行链路的底层设施。

## 本 PR 包含

- 对完整正式 Skill 工作区生成内容寻址快照，本地未同步修改也计入 revision
- 临时目录复制、完整内容复验、原子 rename 发布
- 相同内容去重，不同内容生成新 revision
- 主任务/后台子任务可独立 retain/release 的持久租约
- GC 保留活动租约、近期快照和损坏证据，只清理已验证且过期的无租约对象
- `SkillManager` 可显式绑定固定只读快照根目录；默认构造行为保持不变

## 安全与兼容边界

- 本 PR **没有**接入 AgentTurnController、TurnContextBuilder、SkillTool 或子 Agent
- 不改变正式 `skills` 路径，不移动、不删除、不写入正式 Skill 工作区
- 不改变 `read_file`、`write_file`、`edit_file`、`send_file`、`import_file`、`execute_shell`
- 不改变可信 Skill 脚本直执行逻辑
- 不改变 Skill 注入内容、位置或 System Prompt
- 新代码在当前运行时默认不可达；运行链路接入会放在后续独立 PR 中审阅

## 验证

- `npm run build`
- 新增/定向测试：13 passed，1 skipped（Windows 当前账户无符号链接权限）
- `npm run test:skillhub-phase1`：265 passed，2 skipped，0 failed
- 完整 Runtime：1660 passed，12 skipped；2 个既有 worker 更新脚本测试因本机缺少 `jq` 失败，与本 PR 无调用关系

## 后续顺序

1. 先审阅并合并本 PR（E5-A）
2. 后续 E5-B 再把快照租约接入对话、SkillTool、可信脚本与子 Agent 生命周期
3. E5-B 必须单独验证同轮稳定、新轮更新和第一阶段完整权限兼容
