### PR TITLE
feat: bind Skill execution to turn snapshots

### DIFF
--- a/src/bot-skills/trusted-script-execution.ts
+++ b/src/bot-skills/trusted-script-execution.ts
@@ -5,7 +5,12 @@ import type { BotSkillRef } from '../bot-definition/types';
 import { readSkillHubInstallMarker } from '../skillhub/install-marker';
 import type { ToolExecutionContext } from '../types/tool';
 import { PathResolver } from '../utils/path-resolver';
-import { readBotSkillLocalMarker, scanLocalBotSkill } from './local-manifest';
+import { TurnSkillSnapshotLease } from '../skills/turn-skill-snapshot';
+import {
+  collectBotSkillPackageFiles,
+  computeBotSkillPackageHash,
+  readBotSkillLocalMarker,
+} from './local-manifest';
 
 export interface TrustedBotSkillScriptInvocation {
   scriptPath: string;
@@ -50,7 +55,11 @@ export function resolveTrustedBotSkillScriptInvocation(
     return denied('The requested entrypoint is not a JavaScript file.');
   }
 
-  const skillsRoot = path.resolve(PathResolver.getSkillsPath());
+  const skillsRoot = path.resolve(
+    context.turnSkillSnapshot instanceof TurnSkillSnapshotLease
+      ? context.turnSkillSnapshot.snapshot.rootPath
+      : PathResolver.getSkillsPath(),
+  );
   const relative = path.relative(skillsRoot, scriptPath);
   const segments = relative.split(path.sep).filter(Boolean);
   if (
@@ -74,14 +83,16 @@ export function resolveTrustedBotSkillScriptInvocation(
     return denied('The Skill is not a verified SkillHub package materialized for the current Bot.');
   }
 
-  let scanned;
+  let contentHash: string;
   try {
-    scanned = scanLocalBotSkill(skillDir, skillsRoot);
+    // Snapshot trees are immutable. Validate the copied package without the
+    // legacy scanner's marker-creation side effect.
+    contentHash = computeBotSkillPackageHash(collectBotSkillPackageFiles(skillDir));
   } catch {
     return denied('The installed Skill package failed local integrity validation.');
   }
-  const reference = scanned.reference;
-  if (!reference || !sameSkillReference(reference, localMarker.reference)) {
+  const reference = localMarker.reference;
+  if (reference.contentHash !== contentHash) {
     return denied('The installed Skill package no longer matches its cloud-bound content hash.');
   }
   if (

--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -12,6 +12,7 @@ import * as path from 'path';
 import { AIService } from '../utils/ai-service';
 import { ToolManager } from '../tools/tool-manager';
 import { SkillManager } from '../skills/skill-manager';
+import type { TurnSkillSnapshotStore } from '../skills/turn-skill-snapshot';
 import {
   ChannelCallbacks,
   DeviceRpcTransport,
@@ -102,6 +103,8 @@ export interface AgentServices {
   };
   toolManager: ToolManager;
   skillManager: SkillManager;
+  /** Optional so tests and embedded legacy runtimes keep their existing path. */
+  turnSkillSnapshotStore?: TurnSkillSnapshotStore;
 }
 
 export type SystemPromptProvider = () => Promise<string> | string;

--- a/src/core/agent-turn-controller.ts
+++ b/src/core/agent-turn-controller.ts
@@ -21,6 +21,10 @@ import { AIService } from '../utils/ai-service';
 import { ToolManager } from '../tools/tool-manager';
 import { SkillManager } from '../skills/skill-manager';
 import { SessionSkillRuntime } from '../skills/session-skill-runtime';
+import {
+  TurnSkillSnapshotLease,
+  TurnSkillSnapshotStore,
+} from '../skills/turn-skill-snapshot';
 import { Logger } from '../utils/logger';
 import { Metrics } from '../utils/metrics';
 import { ConversationRunner, RunnerCallbacks, PendingUserInputProvider } from './conversation-runner';
@@ -52,6 +56,7 @@ export interface AgentTurnServices {
   };
   toolManager: ToolManager;
   skillManager: SkillManager;
+  turnSkillSnapshotStore?: TurnSkillSnapshotStore;
 }
 
 export interface AgentTurnCallbacks {
@@ -142,114 +147,172 @@ export class AgentTurnController {
       this.expireMemoryBranch(previousCarryoverMemoryBranch, 'branch_agents_disabled');
     }
 
-    params.messages.push({
-      role: 'user',
-      content: params.input,
-      __episodeId: episodeId,
-      __episodeInputKind: 'root',
-      ...(params.runtimeObservationSource && {
-        __runtimeObservation: true,
-        runtimeObservationSource: params.runtimeObservationSource,
-      }),
-    });
-
-    const turnContext = await this.options.turnContextBuilder.build({
-      sessionKey: this.options.sessionKey,
-      sessionType: this.options.sessionType,
-      sessionRoute: params.sessionRoute ?? this.options.sessionRoute,
-      executionScope: params.executionScope,
-      localDeviceGrant: params.localDeviceGrant,
-      deviceGrants: params.deviceGrants,
-      deviceSelection: params.deviceSelection,
-      targetRoutes: params.targetRoutes,
-      localFileGrants: params.localFileGrants,
-      durableMessages: params.messages,
-      runtimeFeedback: params.runtimeFeedback,
-      skillRuntime: this.options.skillRuntime,
-      planRuntime: this.options.planRuntime,
-    });
-
-    const currentMemoryBranch = this.startMemorySidecarIfEnabled({
-      turnNumber,
-      input: params.input,
-      messages: params.messages,
-      abortSignal: params.abortSignal,
-    });
-
-    const runner = this.createRunner({
-      channel: params.channel,
-      executionScope: params.executionScope,
-      artifactContextRef: params.artifactContextRef,
-      localDeviceGrant: params.localDeviceGrant,
-      deviceGrants: params.deviceGrants,
-      deviceSelection: params.deviceSelection,
-      deviceRpc: params.deviceRpc,
-      thinToolRpc: params.thinToolRpc,
-      targetRoutes: params.targetRoutes,
-      localFileGrants: params.localFileGrants,
-      executionContext: turnContext.executionContext,
-      pendingUserInputProvider: params.pendingUserInputProvider,
-      confirmToolExecution: params.callbacks?.confirmToolExecution,
-      episodeId,
-      syntheticObservationProvider: () => this.drainMemoryObservations(
-        carryoverMemoryBranch,
-        currentMemoryBranch,
-      ),
-      abortSignal: params.abortSignal,
-      suppressFinalResponse: params.suppressFinalResponse,
-      shouldContinue: params.shouldContinue,
-    });
-
-    let result;
+    const turnSkills = await this.prepareTurnSkills();
     try {
-      result = await runner.run(turnContext.messages, this.toRunnerCallbacks(params.callbacks));
-      this.markEpisodeMessages(result.newMessages, episodeId);
-    } catch (error: any) {
-      const partialMessages = this.options.turnContextBuilder.removeTransientMessages(turnContext.messages);
-      this.replaceBase64Images(partialMessages);
-      if (partialMessages.length > 0) {
-        (error as AgentTurnRunError).partialMessages = partialMessages;
+      params.messages.push({
+        role: 'user',
+        content: params.input,
+        __episodeId: episodeId,
+        __episodeInputKind: 'root',
+        ...(params.runtimeObservationSource && {
+          __runtimeObservation: true,
+          runtimeObservationSource: params.runtimeObservationSource,
+        }),
+      });
+
+      const turnContext = await this.options.turnContextBuilder.build({
+        sessionKey: this.options.sessionKey,
+        sessionType: this.options.sessionType,
+        sessionRoute: params.sessionRoute ?? this.options.sessionRoute,
+        executionScope: params.executionScope,
+        localDeviceGrant: params.localDeviceGrant,
+        deviceGrants: params.deviceGrants,
+        deviceSelection: params.deviceSelection,
+        targetRoutes: params.targetRoutes,
+        localFileGrants: params.localFileGrants,
+        durableMessages: params.messages,
+        runtimeFeedback: params.runtimeFeedback,
+        skillRuntime: turnSkills.skillRuntime,
+        planRuntime: this.options.planRuntime,
+      });
+
+      const currentMemoryBranch = this.startMemorySidecarIfEnabled({
+        turnNumber,
+        input: params.input,
+        messages: params.messages,
+        abortSignal: params.abortSignal,
+      });
+
+      const runner = this.createRunner({
+        channel: params.channel,
+        executionScope: params.executionScope,
+        artifactContextRef: params.artifactContextRef,
+        localDeviceGrant: params.localDeviceGrant,
+        deviceGrants: params.deviceGrants,
+        deviceSelection: params.deviceSelection,
+        deviceRpc: params.deviceRpc,
+        thinToolRpc: params.thinToolRpc,
+        targetRoutes: params.targetRoutes,
+        localFileGrants: params.localFileGrants,
+        executionContext: turnContext.executionContext,
+        pendingUserInputProvider: params.pendingUserInputProvider,
+        confirmToolExecution: params.callbacks?.confirmToolExecution,
+        episodeId,
+        syntheticObservationProvider: () => this.drainMemoryObservations(
+          carryoverMemoryBranch,
+          currentMemoryBranch,
+        ),
+        abortSignal: params.abortSignal,
+        suppressFinalResponse: params.suppressFinalResponse,
+        shouldContinue: params.shouldContinue,
+        skillManager: turnSkills.skillManager,
+        turnSkillSnapshot: turnSkills.snapshotLease,
+      });
+
+      let result;
+      try {
+        result = await runner.run(turnContext.messages, this.toRunnerCallbacks(params.callbacks));
+        this.markEpisodeMessages(result.newMessages, episodeId);
+      } catch (error: any) {
+        const partialMessages = this.options.turnContextBuilder.removeTransientMessages(turnContext.messages);
+        this.replaceBase64Images(partialMessages);
+        if (partialMessages.length > 0) {
+          (error as AgentTurnRunError).partialMessages = partialMessages;
+        }
+        throw error;
+      } finally {
+        this.expireMemoryBranch(carryoverMemoryBranch, 'carryover_ttl_expired');
+        if (result && currentMemoryBranch && this.shouldCarryMemoryBranch(currentMemoryBranch)) {
+          this.memoryBranchCarryover = currentMemoryBranch;
+        } else {
+          this.expireMemoryBranch(currentMemoryBranch, result ? 'current_branch_consumed' : 'turn_failed');
+        }
       }
-      throw error;
+      const nextMessages = this.options.turnContextBuilder.removeTransientMessages(result.messages);
+
+      const metrics = Metrics.getSummary();
+      this.logMetrics(metrics);
+
+      this.replaceBase64Images(nextMessages);
+
+      this.options.turnLogRecorder.recordTurn({
+        userInput: params.input,
+        result,
+        tokens: { prompt: metrics.totalPromptTokens, completion: metrics.totalCompletionTokens },
+        runtimeFeedback: turnContext.runtimeFeedbackForLog,
+        runtimeObservationSource: params.runtimeObservationSource,
+      });
+
+      const finalResponseVisible = result.finalResponseVisible && params.suppressFinalResponse !== true;
+      if (result.finalResponseVisible && params.suppressFinalResponse === true) {
+        Logger.info(`[${this.options.sessionKey}] runtime observation final response suppressed: ${params.runtimeObservationSource || 'unknown'}`);
+      }
+
+      if (finalResponseVisible) {
+        this.recordPetTurnCompletion('message_completed');
+        this.recordPetTurnCompletion('task_completed');
+      }
+
+      return {
+        text: finalResponseVisible ? (result.response || EMPTY_FINAL_RESPONSE_MESSAGE) : '',
+        visibleToUser: finalResponseVisible,
+        newMessages: result.newMessages,
+        messages: nextMessages,
+      };
     } finally {
-      this.expireMemoryBranch(carryoverMemoryBranch, 'carryover_ttl_expired');
-      if (result && currentMemoryBranch && this.shouldCarryMemoryBranch(currentMemoryBranch)) {
-        this.memoryBranchCarryover = currentMemoryBranch;
-      } else {
-        this.expireMemoryBranch(currentMemoryBranch, result ? 'current_branch_consumed' : 'turn_failed');
+      if (turnSkills.snapshotLease) {
+        try {
+          await turnSkills.snapshotLease.release();
+        } catch (error: any) {
+          Logger.warning(`[${this.options.sessionKey}] Turn Skill 快照租约释放失败: ${error.message}`);
+        }
       }
     }
-    const nextMessages = this.options.turnContextBuilder.removeTransientMessages(result.messages);
+  }
 
-    const metrics = Metrics.getSummary();
-    this.logMetrics(metrics);
-
-    this.replaceBase64Images(nextMessages);
-
-    this.options.turnLogRecorder.recordTurn({
-      userInput: params.input,
-      result,
-      tokens: { prompt: metrics.totalPromptTokens, completion: metrics.totalCompletionTokens },
-      runtimeFeedback: turnContext.runtimeFeedbackForLog,
-      runtimeObservationSource: params.runtimeObservationSource,
-    });
-
-    const finalResponseVisible = result.finalResponseVisible && params.suppressFinalResponse !== true;
-    if (result.finalResponseVisible && params.suppressFinalResponse === true) {
-      Logger.info(`[${this.options.sessionKey}] runtime observation final response suppressed: ${params.runtimeObservationSource || 'unknown'}`);
+  private async prepareTurnSkills(): Promise<{
+    skillManager: SkillManager;
+    skillRuntime: SessionSkillRuntime;
+    snapshotLease?: TurnSkillSnapshotLease;
+  }> {
+    const store = this.options.services.turnSkillSnapshotStore;
+    if (!store) {
+      return {
+        skillManager: this.options.services.skillManager,
+        skillRuntime: this.options.skillRuntime,
+      };
     }
 
-    if (finalResponseVisible) {
-      this.recordPetTurnCompletion('message_completed');
-      this.recordPetTurnCompletion('task_completed');
+    let snapshotLease: TurnSkillSnapshotLease | undefined;
+    try {
+      snapshotLease = await store.acquire();
+      const skillManager = new SkillManager(snapshotLease.snapshot.rootPath);
+      await skillManager.loadSkills();
+      Logger.info(
+        `[${this.options.sessionKey}] Turn Skill 快照已绑定: ${snapshotLease.snapshot.revision.slice(0, 12)}`,
+      );
+      return {
+        skillManager,
+        skillRuntime: new SessionSkillRuntime(skillManager, this.options.sessionKey),
+        snapshotLease,
+      };
+    } catch (error: any) {
+      if (snapshotLease) {
+        try {
+          await snapshotLease.release();
+        } catch (releaseError: any) {
+          Logger.warning(`[${this.options.sessionKey}] 无效 Turn Skill 快照租约释放失败: ${releaseError.message}`);
+        }
+      }
+      // Preserve all existing runtime capabilities if snapshot preparation is
+      // unavailable. Successful snapshot turns remain revision-stable; this
+      // exceptional path deliberately matches the pre-snapshot behaviour.
+      Logger.warning(`[${this.options.sessionKey}] Turn Skill 快照准备失败，继续使用兼容路径: ${error.message}`);
+      return {
+        skillManager: this.options.services.skillManager,
+        skillRuntime: this.options.skillRuntime,
+      };
     }
-
-    return {
-      text: finalResponseVisible ? (result.response || EMPTY_FINAL_RESPONSE_MESSAGE) : '',
-      visibleToUser: finalResponseVisible,
-      newMessages: result.newMessages,
-      messages: nextMessages,
-    };
   }
 
   private createEpisodeId(turnNumber: number): string {
@@ -282,6 +345,8 @@ export class AgentTurnController {
     abortSignal?: AbortSignal;
     suppressFinalResponse?: boolean;
     shouldContinue: () => boolean;
+    skillManager: SkillManager;
+    turnSkillSnapshot?: TurnSkillSnapshotLease;
   }): ConversationRunner {
     const surface = resolveSessionSurface(this.options.sessionKey, this.options.sessionType);
     return new ConversationRunner(
@@ -309,8 +374,9 @@ export class AgentTurnController {
           planRuntime: this.options.planRuntime,
           runtimeServices: {
             aiService: this.options.services.aiService,
-            skillManager: this.options.services.skillManager,
+            skillManager: options.skillManager,
           },
+          turnSkillSnapshot: options.turnSkillSnapshot,
           abortSignal: options.abortSignal,
           channel: options.channel,
           executionScope: options.executionScope,

--- a/src/core/sub-agent-manager.ts
+++ b/src/core/sub-agent-manager.ts
@@ -15,6 +15,7 @@ import {
   SubAgentRuntimeEvent,
 } from './sub-agent-events';
 import { randomUUID } from 'crypto';
+import type { TurnSkillSnapshotLease } from '../skills/turn-skill-snapshot';
 
 // ─── 平台回调注册 ───────────────────────────────────────
 
@@ -41,6 +42,8 @@ export interface SpawnSubAgentRequest {
   subAgentPrompt?: string;
   allowParentQuestions?: boolean;
   delegatedToolContext?: SubAgentSpawnOptions['delegatedToolContext'];
+  /** Parent turn lease; manager retains an independent child claim on spawn. */
+  turnSkillSnapshot?: TurnSkillSnapshotLease;
   allowedTools?: readonly string[];
   maxTurns?: number;
   taskDescription: string;
@@ -163,7 +166,7 @@ export class SubAgentManager {
     const toolScope = request.toolScope;
     const subAgentPrompt = request.subAgentPrompt?.trim();
     const allowParentQuestions = request.allowParentQuestions;
-    const delegatedToolContext = request.delegatedToolContext;
+    const baseDelegatedToolContext = request.delegatedToolContext;
     const allowedTools = request.allowedTools;
     const maxTurns = request.maxTurns;
     const taskDescription = request.taskDescription.trim();
@@ -205,6 +208,16 @@ export class SubAgentManager {
       return { error: '平台回调未注册，无法派遣子智能体' };
     }
 
+    let childSnapshotLease: TurnSkillSnapshotLease | undefined;
+    try {
+      childSnapshotLease = await request.turnSkillSnapshot?.retain();
+    } catch (error: any) {
+      return { error: `无法为子智能体保留当前 Turn Skill 快照: ${error.message}` };
+    }
+    const delegatedToolContext = childSnapshotLease
+      ? { ...baseDelegatedToolContext, turnSkillSnapshot: childSnapshotLease }
+      : baseDelegatedToolContext;
+
     const options: SubAgentSpawnOptions = {
       displayName,
       agentType: requestedAgentType,
@@ -228,7 +241,13 @@ export class SubAgentManager {
       },
     };
 
-    const session = new SubAgentSession(id, aiService, skillManager, options);
+    let session: SubAgentSession;
+    try {
+      session = new SubAgentSession(id, aiService, skillManager, options);
+    } catch (error: any) {
+      await releaseTurnSkillSnapshotLease(childSnapshotLease, id);
+      return { error: `子智能体初始化失败: ${error.message}` };
+    }
     this.subAgents.set(id, session);
     this.parentMap.set(id, parentSessionKey);
     this.dedupeKeyByAgent.set(id, dedupeKey);
@@ -250,8 +269,12 @@ export class SubAgentManager {
         session.resultSummary = `执行失败: ${err?.message || err}`;
         Logger.error(`[SubAgentManager] ${id} 未捕获失败: ${err?.message || err}`);
       })
-      .finally(() => {
-        void this.finalizeSession(parentSessionKey, id, session, platform, taskDescription);
+      .finally(async () => {
+        await releaseTurnSkillSnapshotLease(childSnapshotLease, id);
+        await this.finalizeSession(parentSessionKey, id, session, platform, taskDescription);
+      })
+      .catch(error => {
+        Logger.error(`[SubAgentManager] ${id} 收尾失败: ${error?.message || error}`);
       });
 
     Logger.info(`[SubAgentManager] 派遣 ${id} 执行 "${skillName || displayAgentType}" (父会话: ${parentSessionKey})`);
@@ -866,6 +889,18 @@ function normalizeDedupeValue(value: unknown): unknown {
     output[key] = normalizeDedupeValue((value as Record<string, unknown>)[key]);
   }
   return output;
+}
+
+async function releaseTurnSkillSnapshotLease(
+  lease: TurnSkillSnapshotLease | undefined,
+  subAgentId: string,
+): Promise<void> {
+  if (!lease) return;
+  try {
+    await lease.release();
+  } catch (error: any) {
+    Logger.warning(`[SubAgentManager] ${subAgentId} Turn Skill 快照租约释放失败: ${error.message}`);
+  }
 }
 
 function normalizeDedupeTools(tools?: readonly string[]): string[] {

--- a/src/runtime/runtime-factory.ts
+++ b/src/runtime/runtime-factory.ts
@@ -1,5 +1,6 @@
 import { AgentServices, AgentSession, SystemPromptProvider } from '../core/agent-session';
 import { SkillManager } from '../skills/skill-manager';
+import { TurnSkillSnapshotStore } from '../skills/turn-skill-snapshot';
 import { ToolManager } from '../tools/tool-manager';
 import { AIService } from '../utils/ai-service';
 import { resolveActiveBotLLMConfig } from '../bot-definition/llm-config-resolver';
@@ -8,6 +9,7 @@ import { Logger } from '../utils/logger';
 import { PromptManager } from '../utils/prompt-manager';
 import { PromptComposer } from './prompt-composer';
 import { composeSessionSystemPromptProvider } from '../core/session-system-prompt';
+import { PathResolver } from '../utils/path-resolver';
 import {
   RuntimeProfile,
   assertValidRuntimeProfile,
@@ -86,6 +88,7 @@ export class RuntimeFactory {
         enabledToolNames: profile.tools.enabled,
       }),
       skillManager: new SkillManager(),
+      turnSkillSnapshotStore: this.createTurnSkillSnapshotStore(),
     };
   }
 
@@ -117,6 +120,24 @@ export class RuntimeFactory {
       }
     } catch (error: any) {
       Logger.warning(`Skills 加载失败: ${error.message}`);
+    }
+  }
+
+  private static createTurnSkillSnapshotStore(): TurnSkillSnapshotStore | undefined {
+    // Keep the new consistency boundary unreachable by default until the
+    // staged Skill write/activation path has completed canary verification.
+    // This avoids changing any existing Skill editing or tool permission flow.
+    if (process.env.XIAOBA_TURN_SKILL_SNAPSHOT_ENABLED !== '1') return undefined;
+    try {
+      return new TurnSkillSnapshotStore({
+        runtimeRoot: PathResolver.getRuntimeDataRoot(),
+        skillsRoot: PathResolver.getSkillsPath(),
+      });
+    } catch (error: any) {
+      // Snapshotting is a consistency enhancement. A damaged or unusual legacy
+      // data root must not disable chat, tools, or the existing live Skill path.
+      Logger.warning(`Turn Skill 快照初始化失败，继续使用兼容路径: ${error.message}`);
+      return undefined;
     }
   }
 

--- a/src/skills/turn-skill-snapshot.ts
+++ b/src/skills/turn-skill-snapshot.ts
@@ -80,8 +80,8 @@ export interface TurnSkillSnapshotGcResult {
 /**
  * One reference-counted claim on an immutable turn Skill snapshot.
  *
- * This class is not wired into the active conversation path yet. A later,
- * separately reviewed change will pass leases through ToolExecutionContext.
+ * Runtime code passes this opaque lease through ToolExecutionContext. It is
+ * generated locally and is never part of model-provided tool arguments.
  */
 export class TurnSkillSnapshotLease {
   private released = false;

--- a/src/tools/skill-tool.ts
+++ b/src/tools/skill-tool.ts
@@ -43,21 +43,22 @@ export class SkillTool implements Tool {
     const { skill: skillName, args: skillArgs = '' } = args;
 
     try {
+      const skillManager = this.resolveSkillManager(context);
       // 特殊命令：reload
       if (skillName === 'reload' || skillName === '__reload__') {
-        await this.skillManager.loadSkills();
-        const count = this.skillManager.getAllSkills().length;
+        await skillManager.loadSkills();
+        const count = skillManager.getAllSkills().length;
         return { ok: true, content: `已重新加载 ${count} 个 skills` };
       }
 
       // 加载所有 skills
-      await this.skillManager.loadSkills();
+      await skillManager.loadSkills();
 
       // 获取指定的 skill
-      const skill = this.skillManager.getSkill(skillName);
+      const skill = skillManager.getSkill(skillName);
 
       if (!skill) {
-        const availableSkills = this.skillManager.getAllSkills()
+        const availableSkills = skillManager.getAllSkills()
           .map(s => s.metadata.name)
           .join(', ');
         this.recordPetEvent('skill_failed', skillName, context, {
@@ -110,6 +111,14 @@ export class SkillTool implements Tool {
       Logger.error(`Skill 执行失败: ${error.message}`);
       return { ok: false, errorCode: 'TOOL_EXECUTION_ERROR', message: `Skill 执行失败: ${error.message}` };
     }
+  }
+
+  private resolveSkillManager(context: ToolExecutionContext): SkillManager {
+    if (!context.turnSkillSnapshot) return this.skillManager;
+    if (!context.runtimeServices?.skillManager) {
+      throw new Error('Turn Skill 快照缺少对应的运行时 SkillManager。');
+    }
+    return context.runtimeServices.skillManager;
   }
 
   private recordPetEvent(

--- a/src/tools/spawn-subagent-tool.ts
+++ b/src/tools/spawn-subagent-tool.ts
@@ -120,6 +120,7 @@ export class SpawnSubagentTool implements Tool {
         subAgentPrompt,
         allowParentQuestions,
         delegatedToolContext: buildDelegatedSubAgentToolContext(context),
+        turnSkillSnapshot: context.turnSkillSnapshot,
         allowedTools: allowedToolsResult.value,
         maxTurns: maxTurnsResult.value,
         taskDescription,

--- a/src/types/tool.ts
+++ b/src/types/tool.ts
@@ -9,6 +9,7 @@ import type {
 import type { PlanRuntime, RuntimePlanSnapshot } from '../core/plan-runtime';
 import type { AIService } from '../utils/ai-service';
 import type { SkillManager } from '../skills/skill-manager';
+import type { TurnSkillSnapshotLease } from '../skills/turn-skill-snapshot';
 
 /**
  * 工具参数定义
@@ -228,6 +229,12 @@ export interface ToolExecutionContext {
   confirmToolExecution?: (request: ToolExecutionConfirmationRequest) => Promise<ToolExecutionConfirmationResult>;
   /** 当前 runtime 已创建的共享服务，供调度类工具复用，避免重复初始化 */
   runtimeServices?: RuntimeToolServices;
+  /**
+   * Runtime-generated lease for the immutable Skill tree bound to this turn.
+   * This is internal execution state: it is never accepted from model tool
+   * arguments or a remote device request.
+   */
+  turnSkillSnapshot?: TurnSkillSnapshotLease;
   /** 平台通道回调（飞书/CatsCompany 等聊天会话时由平台层注入） */
   channel?: ChannelCallbacks;
   /** 当前 turn 的可信执行身份；后续 ToolGateway/设备授权会基于它做权限判断。 */

--- a/tests/runtime-factory.test.ts
+++ b/tests/runtime-factory.test.ts
@@ -5,6 +5,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { AgentSession } from '../src/core/agent-session';
 import { SkillManager } from '../src/skills/skill-manager';
+import { TurnSkillSnapshotStore } from '../src/skills/turn-skill-snapshot';
 import { ToolManager } from '../src/tools/tool-manager';
 import { AIService } from '../src/utils/ai-service';
 import { RuntimeFactory } from '../src/runtime/runtime-factory';
@@ -270,6 +271,32 @@ describe('RuntimeFactory', () => {
     assert.ok(services.skillManager instanceof SkillManager);
     assert.equal((services.toolManager as any).workingDirectory, path.resolve(testRoot));
     assert.deepStrictEqual(services.skillManager.getAllSkills(), []);
+  });
+
+  test('keeps turn Skill snapshots off by default and enables them only for an explicit canary', () => {
+    const previousEnabled = process.env.XIAOBA_TURN_SKILL_SNAPSHOT_ENABLED;
+    const previousUserData = process.env.XIAOBA_USER_DATA_DIR;
+    process.env.XIAOBA_USER_DATA_DIR = testRoot;
+    const profile = resolveDefaultRuntimeProfile({ surface: 'cli', workingDirectory: testRoot });
+
+    try {
+      delete process.env.XIAOBA_TURN_SKILL_SNAPSHOT_ENABLED;
+      const compatible = RuntimeFactory.createServicesSync(profile);
+      assert.equal(compatible.turnSkillSnapshotStore, undefined);
+
+      process.env.XIAOBA_TURN_SKILL_SNAPSHOT_ENABLED = '1';
+      const canary = RuntimeFactory.createServicesSync(profile);
+      assert.ok(canary.turnSkillSnapshotStore instanceof TurnSkillSnapshotStore);
+      assert.deepEqual(
+        canary.toolManager.getToolDefinitions().map(definition => definition.name),
+        compatible.toolManager.getToolDefinitions().map(definition => definition.name),
+      );
+    } finally {
+      if (previousEnabled === undefined) delete process.env.XIAOBA_TURN_SKILL_SNAPSHOT_ENABLED;
+      else process.env.XIAOBA_TURN_SKILL_SNAPSHOT_ENABLED = previousEnabled;
+      if (previousUserData === undefined) delete process.env.XIAOBA_USER_DATA_DIR;
+      else process.env.XIAOBA_USER_DATA_DIR = previousUserData;
+    }
   });
 
   test('creates reusable system prompt providers from a profile snapshot', async () => {

--- a/tests/skill-tool-direct-content.test.ts
+++ b/tests/skill-tool-direct-content.test.ts
@@ -4,6 +4,8 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { SkillTool } from '../src/tools/skill-tool';
+import { SkillManager } from '../src/skills/skill-manager';
+import { TurnSkillSnapshotStore } from '../src/skills/turn-skill-snapshot';
 
 describe('skill tool direct content mode', () => {
   let testRoot: string;
@@ -64,6 +66,46 @@ describe('skill tool direct content mode', () => {
     assert.equal(result.ok, true);
     assert.match(String(result.content), /已重新加载 1 个 skills/);
     assert.doesNotMatch(String(result.content), /__reload_skills__/);
+  });
+
+  test('uses one immutable Skill revision within a turn and observes edits on the next turn', async () => {
+    const skillsRoot = path.join(testRoot, 'skills');
+    const skillFile = path.join(skillsRoot, 'lin', 'demo', 'SKILL.md');
+    const store = new TurnSkillSnapshotStore({ runtimeRoot: testRoot, skillsRoot });
+    const firstLease = await store.acquire();
+    const firstManager = new SkillManager(firstLease.snapshot.rootPath);
+    await firstManager.loadSkills();
+    fs.writeFileSync(skillFile, fs.readFileSync(skillFile, 'utf8').replace('Use $0', 'Changed $0'), 'utf8');
+
+    const tool = new SkillTool();
+    const firstContext = {
+      workingDirectory: testRoot,
+      conversationHistory: [],
+      runtimeServices: { aiService: {} as any, skillManager: firstManager },
+      turnSkillSnapshot: firstLease,
+    };
+    const first = await tool.execute({ skill: 'demo' }, firstContext);
+    const reloaded = await tool.execute({ skill: 'reload' }, firstContext);
+    const stillFirst = await tool.execute({ skill: 'demo' }, firstContext);
+
+    assert.equal(first.ok, true);
+    assert.equal(reloaded.ok, true);
+    assert.match(String(first.content), /Use demo/);
+    assert.match(String(stillFirst.content), /Use demo/);
+    assert.doesNotMatch(String(stillFirst.content), /Changed demo/);
+    await firstLease.release();
+
+    const secondLease = await store.acquire();
+    const secondManager = new SkillManager(secondLease.snapshot.rootPath);
+    await secondManager.loadSkills();
+    const second = await tool.execute({ skill: 'demo' }, {
+      ...firstContext,
+      runtimeServices: { aiService: {} as any, skillManager: secondManager },
+      turnSkillSnapshot: secondLease,
+    });
+    assert.equal(second.ok, true);
+    assert.match(String(second.content), /Changed demo/);
+    await secondLease.release();
   });
 });
 

--- a/tests/subagent-runtime-events.test.ts
+++ b/tests/subagent-runtime-events.test.ts
@@ -595,6 +595,49 @@ describe('subagent runtime events', () => {
     }
   });
 
+  test('spawn_subagent forwards the opaque parent turn Skill snapshot lease to the manager', async () => {
+    const originalGetInstance = SubAgentManager.getInstance;
+    const snapshotLease = { marker: 'turn-snapshot-lease' };
+    let capturedRequest: any;
+    (SubAgentManager as any).getInstance = () => ({
+      spawn(_parentSessionKey: string, request: any) {
+        capturedRequest = request;
+        return {
+          id: 'sub-snapshot',
+          agentType: 'worker',
+          skillName: 'worker',
+          toolScope: 'read_only',
+          allowedTools: request.allowedTools,
+          taskDescription: request.taskDescription,
+          status: 'running',
+          createdAt: Date.now(),
+          progressLog: [],
+          outputFiles: [],
+        };
+      },
+    });
+
+    try {
+      const result = await new SpawnSubagentTool().execute({
+        agent_type: 'worker',
+        allowed_tools: ['read_file'],
+        task: 'inspect snapshot',
+        context: 'inspect snapshot',
+      }, {
+        workingDirectory: process.cwd(),
+        conversationHistory: [],
+        sessionId: 'cc_user:snapshot',
+        runtimeServices: { aiService: {} as any, skillManager: {} as any },
+        turnSkillSnapshot: snapshotLease as any,
+      });
+
+      assert.equal(result.ok, true);
+      assert.equal(capturedRequest.turnSkillSnapshot, snapshotLease);
+    } finally {
+      (SubAgentManager as any).getInstance = originalGetInstance;
+    }
+  });
+
   test('CatsCo device-scoped spawn_subagent does not add a channel-specific tool whitelist', async () => {
     const originalGetInstance = SubAgentManager.getInstance;
     let capturedAllowedTools: unknown;
@@ -1273,6 +1316,79 @@ describe('subagent runtime events', () => {
       assert.equal(manager.listByParent(parentSessionKey).filter(info => info.status === 'running').length, 4);
     } finally {
       for (const finishRun of finishRuns) finishRun();
+      SubAgentSession.prototype.run = originalRun;
+      for (const info of manager.listByParent(parentSessionKey)) {
+        (manager as any).subAgents.delete(info.id);
+        (manager as any).completedSubAgents.delete(info.id);
+        (manager as any).parentMap.delete(info.id);
+        (manager as any).displayNameByAgent.delete(info.id);
+        (manager as any).dedupeKeyByAgent.delete(info.id);
+      }
+      manager.unregisterPlatformCallbacks(parentSessionKey);
+    }
+  });
+
+  test('manager retains one child Skill snapshot lease and releases it after background completion', async () => {
+    const manager = SubAgentManager.getInstance();
+    const parentSessionKey = `test-parent:${Date.now()}:snapshot-lease`;
+    let finishRun: (() => void) | undefined;
+    let retainCount = 0;
+    let releaseCount = 0;
+    const childLease = {
+      release: async () => { releaseCount += 1; },
+    };
+    const parentLease = {
+      retain: async () => {
+        retainCount += 1;
+        return childLease;
+      },
+    };
+    manager.registerPlatformCallbacks(parentSessionKey, {
+      injectMessage: async () => undefined,
+      onSubAgentEvent: async () => undefined,
+    });
+    const originalRun = SubAgentSession.prototype.run;
+    (SubAgentSession.prototype as any).run = async function runMock() {
+      await new Promise<void>(resolve => { finishRun = resolve; });
+      this.status = 'completed';
+      this.completedAt = Date.now();
+      this.resultSummary = 'done';
+    };
+
+    try {
+      const request = {
+        agentType: 'worker' as const,
+        taskDescription: 'snapshot background task',
+        userMessage: 'snapshot background task',
+        turnSkillSnapshot: parentLease as any,
+      };
+      const first = await manager.spawn(
+        parentSessionKey,
+        request,
+        process.cwd(),
+        {} as any,
+        { getSkill: () => undefined } as any,
+      );
+      assert.ok(!('error' in first));
+      assert.equal(retainCount, 1);
+      assert.equal(releaseCount, 0);
+
+      const duplicate = await manager.spawn(
+        parentSessionKey,
+        request,
+        process.cwd(),
+        {} as any,
+        { getSkill: () => undefined } as any,
+      );
+      assert.ok(!('error' in duplicate));
+      assert.equal(duplicate.reusedExisting, true);
+      assert.equal(retainCount, 1, 'deduplicated spawns must not retain another lease');
+
+      assert.ok(finishRun);
+      finishRun();
+      await waitFor(() => releaseCount === 1);
+    } finally {
+      finishRun?.();
       SubAgentSession.prototype.run = originalRun;
       for (const info of manager.listByParent(parentSessionKey)) {
         (manager as any).subAgents.delete(info.id);

--- a/tests/trusted-bot-skill-script-execution.test.ts
+++ b/tests/trusted-bot-skill-script-execution.test.ts
@@ -11,6 +11,7 @@ import {
 } from '../src/bot-skills/local-manifest';
 import { resolveTrustedBotSkillScriptInvocation } from '../src/bot-skills/trusted-script-execution';
 import { writeSkillHubInstallMarker } from '../src/skillhub/install-marker';
+import { TurnSkillSnapshotStore } from '../src/skills/turn-skill-snapshot';
 import { ShellTool } from '../src/tools/bash-tool';
 import type { ToolExecutionContext } from '../src/types/tool';
 
@@ -159,6 +160,38 @@ describe('trusted Bot Skill script execution', () => {
     }));
     assert.equal(decision.ok, false);
     assert.match(decision.ok ? '' : decision.reason, /current Bot definition/);
+  });
+
+  test('keeps trusted script resolution on the turn snapshot after the live package changes', async () => {
+    const store = new TurnSkillSnapshotStore({
+      runtimeRoot,
+      skillsRoot: path.join(runtimeRoot, 'skills'),
+    });
+    const lease = await store.acquire();
+    const snapshotScript = path.join(
+      lease.snapshot.rootPath,
+      'verified-image-skill',
+      'scripts',
+      'run.mjs',
+    );
+    fs.appendFileSync(scriptPath, '// changed after turn start\n', 'utf8');
+
+    try {
+      const snapshotDecision = resolveTrustedBotSkillScriptInvocation(
+        `node "${snapshotScript}" "${path.join(workspaceRoot, 'snapshot.json')}"`,
+        catsContext({ turnSkillSnapshot: lease }),
+      );
+      const liveDecision = resolveTrustedBotSkillScriptInvocation(
+        `node "${scriptPath}" "${path.join(workspaceRoot, 'live-changed.json')}"`,
+        catsContext(),
+      );
+
+      assert.equal(snapshotDecision.ok, true);
+      assert.equal(liveDecision.ok, false);
+      assert.match(liveDecision.ok ? '' : liveDecision.reason, /content hash/);
+    } finally {
+      await lease.release();
+    }
   });
 
   test('falls back to the ordinary shell after an installed Skill script is modified locally', async () => {

--- a/tests/turn-skill-snapshot.test.ts
+++ b/tests/turn-skill-snapshot.test.ts
@@ -4,7 +4,10 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { SkillManager } from '../src/skills/skill-manager';
+import { SessionSkillRuntime } from '../src/skills/session-skill-runtime';
 import { TurnSkillSnapshotStore } from '../src/skills/turn-skill-snapshot';
+import { AgentTurnController } from '../src/core/agent-turn-controller';
+import { PlanRuntime } from '../src/core/plan-runtime';
 
 describe('turn Skill snapshot store', () => {
   const roots: string[] = [];
@@ -185,6 +188,127 @@ describe('turn Skill snapshot store', () => {
       if (previousSkillsDirectory === undefined) delete process.env.XIAOBA_SKILLS_DIR;
       else process.env.XIAOBA_SKILLS_DIR = previousSkillsDirectory;
     }
+  });
+
+  test('binds one snapshot to a complete turn, releases it, and uses a new revision next turn', async () => {
+    const root = createRuntimeRoot(roots);
+    const skillsRoot = path.join(root, 'skills');
+    const skillRoot = writeSkill(skillsRoot, 'turn-bound-skill', 'one');
+    const liveManager = new SkillManager(skillsRoot);
+    await liveManager.loadSkills();
+    const store = new TurnSkillSnapshotStore({ runtimeRoot: root, skillsRoot });
+    const observedBodies: string[] = [];
+    const observedSnapshotIds: string[] = [];
+    let buildCount = 0;
+    const turnContextBuilder = {
+      build: async (params: any) => {
+        await params.skillRuntime.reloadSkills();
+        buildCount += 1;
+        if (buildCount === 1) {
+          fs.writeFileSync(path.join(skillRoot, 'body.txt'), 'two');
+        }
+        return {
+          messages: params.durableMessages,
+          runtimeFeedbackForLog: [],
+        };
+      },
+      removeTransientMessages: (messages: any[]) => messages,
+    };
+    const controller = new AgentTurnController({
+      sessionKey: 'turn-snapshot-test',
+      services: {
+        aiService: {} as any,
+        toolManager: {} as any,
+        skillManager: liveManager,
+        turnSkillSnapshotStore: store,
+      },
+      skillRuntime: new SessionSkillRuntime(liveManager, 'turn-snapshot-test'),
+      planRuntime: new PlanRuntime(),
+      turnContextBuilder: turnContextBuilder as any,
+      turnLogRecorder: { recordTurn: () => undefined } as any,
+      workspaceRoot: root,
+      getCurrentDirectory: () => root,
+      updateCurrentDirectory: () => undefined,
+    });
+    (controller as any).createRunner = (options: any) => ({
+      run: async (messages: any[]) => {
+        const skill = options.skillManager.getSkill('turn-bound-skill');
+        assert.ok(skill);
+        observedBodies.push(fs.readFileSync(path.join(path.dirname(skill.filePath), 'body.txt'), 'utf8'));
+        observedSnapshotIds.push(options.turnSkillSnapshot.snapshot.snapshotId);
+        return {
+          response: 'ok',
+          finalResponseVisible: false,
+          newMessages: [],
+          messages,
+        };
+      },
+    });
+    const messages: any[] = [];
+
+    await controller.run({ input: 'first', messages, runtimeFeedback: [], shouldContinue: () => true });
+    await controller.run({ input: 'second', messages, runtimeFeedback: [], shouldContinue: () => true });
+
+    assert.deepEqual(observedBodies, ['one', 'two']);
+    assert.notEqual(observedSnapshotIds[0], observedSnapshotIds[1]);
+    const gc = await store.collectGarbage({ minAgeMs: 0 });
+    assert.deepEqual(gc.removed.sort(), [...observedSnapshotIds].sort());
+  });
+
+  test('releases the turn snapshot on both context errors and cancelled model runs', async () => {
+    const root = createRuntimeRoot(roots);
+    const skillsRoot = path.join(root, 'skills');
+    writeSkill(skillsRoot, 'failed-turn-skill', 'one');
+    const liveManager = new SkillManager(skillsRoot);
+    await liveManager.loadSkills();
+    const store = new TurnSkillSnapshotStore({ runtimeRoot: root, skillsRoot });
+    const controller = new AgentTurnController({
+      sessionKey: 'turn-snapshot-failure-test',
+      services: {
+        aiService: {} as any,
+        toolManager: {} as any,
+        skillManager: liveManager,
+        turnSkillSnapshotStore: store,
+      },
+      skillRuntime: new SessionSkillRuntime(liveManager, 'turn-snapshot-failure-test'),
+      planRuntime: new PlanRuntime(),
+      turnContextBuilder: {
+        build: async () => { throw new Error('context failed'); },
+        removeTransientMessages: (messages: any[]) => messages,
+      } as any,
+      turnLogRecorder: { recordTurn: () => undefined } as any,
+      workspaceRoot: root,
+      getCurrentDirectory: () => root,
+      updateCurrentDirectory: () => undefined,
+    });
+
+    await assert.rejects(
+      () => controller.run({ input: 'fail', messages: [], runtimeFeedback: [], shouldContinue: () => true }),
+      /context failed/,
+    );
+    const gc = await store.collectGarbage({ minAgeMs: 0 });
+    assert.equal(gc.removed.length, 1);
+
+    (controller as any).options.turnContextBuilder = {
+      build: async (params: any) => ({
+        messages: params.durableMessages,
+        runtimeFeedbackForLog: [],
+      }),
+      removeTransientMessages: (messages: any[]) => messages,
+    };
+    (controller as any).createRunner = () => ({
+      run: async () => {
+        const error = new Error('turn cancelled');
+        error.name = 'AbortError';
+        throw error;
+      },
+    });
+    await assert.rejects(
+      () => controller.run({ input: 'cancel', messages: [], runtimeFeedback: [], shouldContinue: () => false }),
+      /turn cancelled/,
+    );
+    const cancelledGc = await store.collectGarbage({ minAgeMs: 0 });
+    assert.equal(cancelledGc.removed.length, 1);
   });
 
   test('rejects a workspace configuration that would recursively snapshot the store', () => {


### PR DESCRIPTION
## 目标

把 E5-A 的不可变 Skill 树快照接入一次完整 turn，使同一轮中的上下文、`skill` 工具、可信 Skill 脚本与后台子 Agent 使用同一个内容 revision；本轮结束或后台任务结束后释放租约，下一轮才观察新的正式 Skill 内容。

## 实现

- `AgentTurnController` 在 turn 开始时获取快照，并在成功、异常或取消路径统一释放
- `SessionSkillRuntime`、`SkillTool` 与可信 Skill 脚本解析统一使用该快照根目录
- 子 Agent 继承并独立 retain 同一快照；去重派发不重复持有，后台完成后释放
- 可信脚本对快照执行只读完整性校验，不在不可变快照内补写 marker
- 快照准备异常时保留原有运行路径，不锁住聊天、文件工具或 Shell

## 安全与兼容边界

- 默认关闭；只有显式设置 `XIAOBA_TURN_SKILL_SNAPSHOT_ENABLED=1` 才接入运行链路
- 未增加、删除或修改任何模型工具 schema
- 未修改文件读写、导入导出、Shell、可信脚本授权、注入或 System Prompt 权限
- 未开启候选工作区提交、mutation 模型工具或 `shared_live`
- 先合并代码并保持不可达，后续再以测试 Bot 单独 canary，避免重演 #365 的提前收紧

## 验证

- `npm run build`
- E5-B 定向：72 passed，2 个 Windows symlink 能力不足 skip
- `npm run test:skillhub-phase1`：268 passed，3 个 Windows symlink skip
- `npm run test:cross-repo:catsco-skills`：62 passed
- 完整 Runtime 并发运行中，一个既有 Grep 取消时序用例偶发失败，末尾既有 ReadTool 子进程未退出；二者单文件重跑分别 22/22、18/18 通过

## 发布顺序

1. 评审并合并本 PR，保持开关默认关闭
2. GitHub required checks 全绿后，仅在测试 Bot 设置开关做 canary
3. 验证同轮旧 revision、新轮新 revision、取消/异常与子 Agent 后台任务
4. canary 稳定后再讨论默认启用；本 PR 不直接改变生产行为
