### PR TITLE
feat: paginate SkillHub runtime workspaces

### DIFF
--- a/src/bot-skills/local-manifest.ts
+++ b/src/bot-skills/local-manifest.ts
@@ -21,6 +21,13 @@ export class BotSkillPackageValidationError extends Error {
   }
 }
 
+export class BotSkillWorkspaceScanLimitError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BotSkillWorkspaceScanLimitError';
+  }
+}
+
 const BOT_SKILL_LOCAL_MARKER_SCHEMA = 'xiaoba.bot-skill-local.v1';
 const SKIP_DIRECTORIES = new Set(['.git', 'node_modules']);
 const EPHEMERAL_DIRECTORIES = new Set([
@@ -77,6 +84,20 @@ export interface BotSkillWorkspaceValidationFailure {
 
 export interface ScanBotSkillWorkspaceOptions {
   onValidationFailure?: (failure: BotSkillWorkspaceValidationFailure) => void;
+  /** Optional fail-closed bounds for metadata-only callers such as paginated workspace listing. */
+  maxSkillEntries?: number;
+  maxTotalPackageBytes?: number;
+  /** Keeps content hashes but clears `files`; never use this for upload/materialization. */
+  retainPackageContents?: boolean;
+}
+
+interface BotSkillPackageByteBudget {
+  bytes: number;
+  maximum: number;
+}
+
+interface ScanLocalBotSkillOptions {
+  packageByteBudget?: BotSkillPackageByteBudget;
 }
 
 export function scanBotSkillWorkspace(
@@ -95,6 +116,10 @@ export function scanBotSkillWorkspace(
 
   const entries: LocalBotSkillManifestEntry[] = [];
   const localSkillIds = new Set<string>();
+  let discoveredSkillEntries = 0;
+  const packageByteBudget = options.maxTotalPackageBytes === undefined
+    ? undefined
+    : { bytes: 0, maximum: options.maxTotalPackageBytes };
   const visit = (current: string): void => {
     for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
       if (
@@ -107,9 +132,16 @@ export function scanBotSkillWorkspace(
       const skillDir = path.join(current, entry.name);
       assertRealPathContained(realRoot, skillDir);
       if (fs.existsSync(path.join(skillDir, 'SKILL.md'))) {
+        discoveredSkillEntries += 1;
+        if (
+          options.maxSkillEntries !== undefined
+          && discoveredSkillEntries > options.maxSkillEntries
+        ) {
+          throw new BotSkillWorkspaceScanLimitError('Bot Skill workspace contains too many Skills');
+        }
         let manifestEntry: LocalBotSkillManifestEntry;
         try {
-          manifestEntry = scanLocalBotSkill(skillDir, root);
+          manifestEntry = scanLocalBotSkill(skillDir, root, { packageByteBudget });
         } catch (error) {
           if (!(error instanceof BotSkillPackageValidationError) || !options.onValidationFailure) {
             throw error;
@@ -131,6 +163,9 @@ export function scanBotSkillWorkspace(
           visit(skillDir);
           continue;
         }
+        if (options.retainPackageContents === false) {
+          manifestEntry = { ...manifestEntry, files: [] };
+        }
         if (localSkillIds.has(manifestEntry.localSkillId)) {
           throw new Error(`Bot Skill workspace contains a duplicate localSkillId: ${manifestEntry.localSkillId}`);
         }
@@ -147,6 +182,7 @@ export function scanBotSkillWorkspace(
 export function scanLocalBotSkill(
   skillDir: string,
   workspaceRoot?: string,
+  options: ScanLocalBotSkillOptions = {},
 ): LocalBotSkillManifestEntry {
   const root = path.resolve(skillDir);
   const rootStat = fs.lstatSync(root);
@@ -163,7 +199,7 @@ export function scanLocalBotSkill(
   }
   assertRealPathContained(fs.realpathSync(root), skillFile);
   const marker = ensureBotSkillLocalMarker(root);
-  const files = collectBotSkillPackageFiles(root);
+  const files = collectBotSkillPackageFiles(root, options.packageByteBudget);
   const contentHash = computeBotSkillPackageHash(files);
   const reference = marker.reference?.contentHash === contentHash
     ? marker.reference
@@ -265,7 +301,10 @@ function ensureBotSkillLocalMarker(skillDir: string): BotSkillLocalMarker {
   return marker;
 }
 
-export function collectBotSkillPackageFiles(root: string): BotSkillPackageFile[] {
+export function collectBotSkillPackageFiles(
+  root: string,
+  aggregateBudget?: BotSkillPackageByteBudget,
+): BotSkillPackageFile[] {
   const realRoot = fs.realpathSync(root);
   const files: BotSkillPackageFile[] = [];
   let totalBytes = 0;
@@ -292,6 +331,14 @@ export function collectBotSkillPackageFiles(root: string): BotSkillPackageFile[]
         throw new BotSkillPackageValidationError(`Skill contains an unsafe path: ${relativePath}`);
       }
       const bytes = fs.readFileSync(fullPath);
+      if (aggregateBudget) {
+        aggregateBudget.bytes += bytes.length;
+        if (aggregateBudget.bytes > aggregateBudget.maximum) {
+          throw new BotSkillWorkspaceScanLimitError(
+            'Bot Skill workspace packages exceed the listing byte limit',
+          );
+        }
+      }
       if (bytes.length > MAX_SINGLE_FILE_BYTES) {
         throw new BotSkillPackageValidationError(`Skill file is too large: ${relativePath}`);
       }

--- a/src/catscompany/skillhub-rpc.ts
+++ b/src/catscompany/skillhub-rpc.ts
@@ -1,4 +1,5 @@
 import matter from 'gray-matter';
+import { createHash } from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
 import { createCatsCoLocalConfigService } from './local-config';
@@ -28,7 +29,9 @@ export const SKILLHUB_THIN_RPC_TOOLS = {
   switchBot: 'skillhub.localBot.switch',
 } as const;
 
-const MAX_SKILLS = 200;
+const DEFAULT_WORKSPACE_PAGE_SIZE = 200;
+const MAX_WORKSPACE_PAGE_SIZE = 200;
+const MAX_WORKSPACE_OFFSET = 1_000_000;
 const MAX_NAME_LENGTH = 160;
 const MAX_DESCRIPTION_LENGTH = 1_000;
 const MAX_RELATIVE_PATH_LENGTH = 500;
@@ -153,7 +156,7 @@ export class SkillHubThinRpcHandler {
 
     switch (request.tool_name) {
       case SKILLHUB_THIN_RPC_TOOLS.workspace:
-        return this.readWorkspace(botUid, request);
+        return this.readWorkspace(botUid, payload, request);
       case SKILLHUB_THIN_RPC_TOOLS.share:
         return this.shareSkill(botUid, scope.ownerUid, payload, request);
       case SKILLHUB_THIN_RPC_TOOLS.finalize:
@@ -167,8 +170,18 @@ export class SkillHubThinRpcHandler {
 
   private async readWorkspace(
     botUid: string,
+    payload: Record<string, unknown>,
     request: CatsThinToolRpcMessage,
   ): Promise<Record<string, unknown>> {
+    const pageOffset = optionalInteger(payload.offset, 'offset', 0, 0, MAX_WORKSPACE_OFFSET);
+    const pageLimit = optionalInteger(
+      payload.limit,
+      'limit',
+      DEFAULT_WORKSPACE_PAGE_SIZE,
+      1,
+      MAX_WORKSPACE_PAGE_SIZE,
+    );
+    const expectedRevision = optionalContentHash(payload.workspace_revision, 'workspace_revision');
     return withCurrentBotSkillWorkspaceWrite((context) => {
       this.assertOperational(request);
       this.assertRequestScope(request, botUid, true);
@@ -191,8 +204,7 @@ export class SkillHubThinRpcHandler {
       const listed = [
         ...entries.map(entry => ({ kind: 'valid' as const, entry })),
         ...rejected.map(entry => ({ kind: 'rejected' as const, entry })),
-      ].sort((left, right) => compareText(left.entry.localSkillId, right.entry.localSkillId))
-        .slice(0, MAX_SKILLS);
+      ].sort((left, right) => compareText(left.entry.localSkillId, right.entry.localSkillId));
       const skills = listed.map((item) => {
         if (item.kind === 'valid') {
           const { entry } = item;
@@ -223,12 +235,33 @@ export class SkillHubThinRpcHandler {
           skill_hub: presentation.metadata || {},
         };
       });
+      const workspaceRevision = createHash('sha256')
+        .update(stableSerialize(listed.map((item, index) => ({
+          skill: skills[index],
+          package_content_hash: item.kind === 'valid' ? item.entry.contentHash : '',
+        }))))
+        .digest('hex');
+      if (expectedRevision && expectedRevision !== workspaceRevision) {
+        throw new SkillHubThinRpcError(
+          'WORKSPACE_CHANGED',
+          'The local Skill workspace changed while its pages were being read. Restart the listing.',
+        );
+      }
+      const pageSkills = skills.slice(pageOffset, pageOffset + pageLimit);
+      const nextOffset = pageOffset + pageSkills.length;
+      const hasMore = nextOffset < skills.length;
       return {
         schema: 'xiaoba.skillhub.local_workspace.v1',
         bot_uid: botUid,
         active_bot_uid: context.activeBotId,
         skills_path: fs.realpathSync(context.skillsRoot),
-        skills,
+        workspace_revision: workspaceRevision,
+        total_skills: skills.length,
+        page_offset: pageOffset,
+        page_limit: pageLimit,
+        next_offset: hasMore ? nextOffset : null,
+        truncated: hasMore,
+        skills: pageSkills,
       };
     }, { runtimeRoot: this.runtimeRoot });
   }
@@ -661,6 +694,34 @@ function requiredText(value: unknown, field: string, maxLength: number): string 
     throw new SkillHubThinRpcError('INVALID_REQUEST', `${field} is invalid.`);
   }
   return text;
+}
+
+function optionalInteger(
+  value: unknown,
+  field: string,
+  fallback: number,
+  minimum: number,
+  maximum: number,
+): number {
+  if (value === undefined || value === null || value === '') return fallback;
+  const parsed = typeof value === 'number'
+    ? value
+    : typeof value === 'string' && /^(0|[1-9][0-9]*)$/.test(value.trim())
+      ? Number(value.trim())
+      : Number.NaN;
+  if (!Number.isSafeInteger(parsed) || parsed < minimum || parsed > maximum) {
+    throw new SkillHubThinRpcError('INVALID_REQUEST', `${field} is invalid.`);
+  }
+  return parsed;
+}
+
+function optionalContentHash(value: unknown, field: string): string {
+  if (value === undefined || value === null || value === '') return '';
+  const normalized = String(value).trim().toLowerCase();
+  if (!CONTENT_HASH_PATTERN.test(normalized)) {
+    throw new SkillHubThinRpcError('INVALID_REQUEST', `${field} is invalid.`);
+  }
+  return normalized;
 }
 
 function limitText(value: string, maxLength: number): string {

--- a/src/catscompany/skillhub-rpc.ts
+++ b/src/catscompany/skillhub-rpc.ts
@@ -10,6 +10,8 @@ import {
   withCurrentBotSkillWorkspaceWrite,
 } from '../bot-skills/runtime';
 import {
+  BotSkillWorkspaceScanLimitError,
+  isEphemeralSkillDirectory,
   scanBotSkillWorkspace,
 } from '../bot-skills/local-manifest';
 import { trashBotSkill } from '../bot-skills/deleted-skill-trash';
@@ -32,6 +34,15 @@ export const SKILLHUB_THIN_RPC_TOOLS = {
 const DEFAULT_WORKSPACE_PAGE_SIZE = 200;
 const MAX_WORKSPACE_PAGE_SIZE = 200;
 const MAX_WORKSPACE_OFFSET = 1_000_000;
+const MAX_WORKSPACE_SKILLS = 10_000;
+const MAX_WORKSPACE_PACKAGE_BYTES = 128 * 1024 * 1024;
+const MAX_WORKSPACE_SNAPSHOT_BYTES = 16 * 1024 * 1024;
+const MAX_WORKSPACE_SNAPSHOTS = 4;
+const WORKSPACE_SNAPSHOT_TTL_MS = 5 * 60_000;
+const MAX_REJECTED_FINGERPRINT_FILES = 10_000;
+const MAX_REJECTED_FINGERPRINT_BYTES = 32 * 1024 * 1024;
+const REJECTED_FINGERPRINT_LARGE_FILE_BYTES = 2 * 1024 * 1024;
+const REJECTED_FINGERPRINT_SAMPLE_BYTES = 64 * 1024;
 const MAX_NAME_LENGTH = 160;
 const MAX_DESCRIPTION_LENGTH = 1_000;
 const MAX_RELATIVE_PATH_LENGTH = 500;
@@ -45,6 +56,21 @@ interface SkillHubWorkspaceValidationFailure {
   installName: string;
   path: string;
   error: Error;
+}
+
+interface SkillHubWorkspaceSnapshot {
+  botUid: string;
+  activeBotUid?: string;
+  skillsRoot: string;
+  skillsPath: string;
+  revision: string;
+  skills: Array<Record<string, unknown>>;
+  createdAtMs: number;
+}
+
+interface RejectedFingerprintBudget {
+  files: number;
+  bytes: number;
 }
 
 export class SkillHubThinRpcError extends Error {
@@ -76,6 +102,7 @@ export class SkillHubThinRpcHandler {
     fingerprint: string;
     operation: Promise<Record<string, unknown>>;
   }>();
+  private readonly workspaceSnapshots = new Map<string, SkillHubWorkspaceSnapshot>();
 
   constructor(options: SkillHubThinRpcHandlerOptions = {}) {
     this.runtimeRoot = path.resolve(options.runtimeRoot ?? PathResolver.getRuntimeDataRoot());
@@ -186,42 +213,65 @@ export class SkillHubThinRpcHandler {
       this.assertOperational(request);
       this.assertRequestScope(request, botUid, true);
       this.assertActiveWorkspace(botUid, context.botId, context.activeBotId);
-      const rejected: SkillHubWorkspaceValidationFailure[] = [];
-      const entries = scanSkillHubWorkspace(context.skillsRoot, {
-        onValidationFailure: failure => rejected.push(failure),
-      }).filter((entry) => {
-        const error = validateSkillHubShareMetadata(entry.path);
-        if (!error) return true;
-        rejected.push({
-          localSkillId: entry.localSkillId,
-          name: entry.name,
-          installName: entry.installName,
-          path: entry.path,
-          error,
-        });
-        return false;
+      const nowMs = this.now().getTime();
+      this.pruneWorkspaceSnapshots(nowMs);
+      const snapshot = expectedRevision
+        ? this.readCachedWorkspaceSnapshot(expectedRevision, botUid, context.skillsRoot)
+        : this.createWorkspaceSnapshot(botUid, context.activeBotId, context.skillsRoot, nowMs);
+      if (pageOffset > snapshot.skills.length) {
+        throw new SkillHubThinRpcError('INVALID_REQUEST', 'offset is outside the workspace snapshot.');
+      }
+      const pageSkills = snapshot.skills.slice(pageOffset, pageOffset + pageLimit);
+      const nextOffset = pageOffset + pageSkills.length;
+      const hasMore = nextOffset < snapshot.skills.length;
+      return {
+        schema: 'xiaoba.skillhub.local_workspace.v1',
+        bot_uid: botUid,
+        active_bot_uid: snapshot.activeBotUid,
+        skills_path: snapshot.skillsPath,
+        workspace_revision: snapshot.revision,
+        total_skills: snapshot.skills.length,
+        page_offset: pageOffset,
+        page_limit: pageLimit,
+        next_offset: hasMore ? nextOffset : null,
+        truncated: hasMore,
+        skills: pageSkills,
+      };
+    }, { runtimeRoot: this.runtimeRoot });
+  }
+
+  private createWorkspaceSnapshot(
+    botUid: string,
+    activeBotUid: string | undefined,
+    skillsRoot: string,
+    nowMs: number,
+  ): SkillHubWorkspaceSnapshot {
+    const rejected: SkillHubWorkspaceValidationFailure[] = [];
+    const entries = scanSkillHubWorkspace(skillsRoot, {
+      onValidationFailure: failure => rejected.push(failure),
+      maxSkillEntries: MAX_WORKSPACE_SKILLS,
+      maxTotalPackageBytes: MAX_WORKSPACE_PACKAGE_BYTES,
+      retainPackageContents: false,
+    }).filter((entry) => {
+      const error = validateSkillHubShareMetadata(entry.path);
+      if (!error) return true;
+      rejected.push({
+        localSkillId: entry.localSkillId,
+        name: entry.name,
+        installName: entry.installName,
+        path: entry.path,
+        error,
       });
-      const listed = [
-        ...entries.map(entry => ({ kind: 'valid' as const, entry })),
-        ...rejected.map(entry => ({ kind: 'rejected' as const, entry })),
-      ].sort((left, right) => compareText(left.entry.localSkillId, right.entry.localSkillId));
-      const skills = listed.map((item) => {
-        if (item.kind === 'valid') {
-          const { entry } = item;
-          const presentation = readLocalSkillPresentation(entry.path);
-          return {
-            local_skill_id: limitText(entry.localSkillId, MAX_NAME_LENGTH),
-            name: limitText(entry.name, MAX_NAME_LENGTH),
-            description: limitText(presentation.description, MAX_DESCRIPTION_LENGTH),
-            relative_path: limitText(entry.installName, MAX_RELATIVE_PATH_LENGTH),
-            source: 'user',
-            can_share: !entry.reference || isPrivateSkillReference(entry.reference.skillId),
-            skill_hub: {
-              ...(presentation.metadata || {}),
-              ...(entry.reference ? { reference: entry.reference } : {}),
-            },
-          };
-        }
+      return false;
+    });
+    const listed = [
+      ...entries.map(entry => ({ kind: 'valid' as const, entry })),
+      ...rejected.map(entry => ({ kind: 'rejected' as const, entry })),
+    ].sort((left, right) => compareText(left.entry.localSkillId, right.entry.localSkillId));
+    if (listed.length > MAX_WORKSPACE_SKILLS) throw workspaceTooLargeError();
+    const rejectedFingerprintBudget: RejectedFingerprintBudget = { files: 0, bytes: 0 };
+    const skills = listed.map((item) => {
+      if (item.kind === 'valid') {
         const { entry } = item;
         const presentation = readLocalSkillPresentation(entry.path);
         return {
@@ -230,40 +280,80 @@ export class SkillHubThinRpcHandler {
           description: limitText(presentation.description, MAX_DESCRIPTION_LENGTH),
           relative_path: limitText(entry.installName, MAX_RELATIVE_PATH_LENGTH),
           source: 'user',
-          can_share: false,
-          share_error: limitText(entry.error.message, MAX_DESCRIPTION_LENGTH),
-          skill_hub: presentation.metadata || {},
+          can_share: !entry.reference || isPrivateSkillReference(entry.reference.skillId),
+          skill_hub: {
+            ...(presentation.metadata || {}),
+            ...(entry.reference ? { reference: entry.reference } : {}),
+          },
         };
-      });
-      const workspaceRevision = createHash('sha256')
-        .update(stableSerialize(listed.map((item, index) => ({
-          skill: skills[index],
-          package_content_hash: item.kind === 'valid' ? item.entry.contentHash : '',
-        }))))
-        .digest('hex');
-      if (expectedRevision && expectedRevision !== workspaceRevision) {
-        throw new SkillHubThinRpcError(
-          'WORKSPACE_CHANGED',
-          'The local Skill workspace changed while its pages were being read. Restart the listing.',
-        );
       }
-      const pageSkills = skills.slice(pageOffset, pageOffset + pageLimit);
-      const nextOffset = pageOffset + pageSkills.length;
-      const hasMore = nextOffset < skills.length;
+      const { entry } = item;
+      const presentation = readLocalSkillPresentation(entry.path);
       return {
-        schema: 'xiaoba.skillhub.local_workspace.v1',
-        bot_uid: botUid,
-        active_bot_uid: context.activeBotId,
-        skills_path: fs.realpathSync(context.skillsRoot),
-        workspace_revision: workspaceRevision,
-        total_skills: skills.length,
-        page_offset: pageOffset,
-        page_limit: pageLimit,
-        next_offset: hasMore ? nextOffset : null,
-        truncated: hasMore,
-        skills: pageSkills,
+        local_skill_id: limitText(entry.localSkillId, MAX_NAME_LENGTH),
+        name: limitText(entry.name, MAX_NAME_LENGTH),
+        description: limitText(presentation.description, MAX_DESCRIPTION_LENGTH),
+        relative_path: limitText(entry.installName, MAX_RELATIVE_PATH_LENGTH),
+        source: 'user',
+        can_share: false,
+        share_error: limitText(entry.error.message, MAX_DESCRIPTION_LENGTH),
+        skill_hub: presentation.metadata || {},
       };
-    }, { runtimeRoot: this.runtimeRoot });
+    });
+    if (Buffer.byteLength(stableSerialize(skills), 'utf8') > MAX_WORKSPACE_SNAPSHOT_BYTES) {
+      throw workspaceTooLargeError();
+    }
+    const revision = createHash('sha256')
+      .update(stableSerialize(listed.map((item, index) => ({
+        skill: skills[index],
+        package_content_hash: item.kind === 'valid'
+          ? item.entry.contentHash
+          : fingerprintRejectedSkillPackage(item.entry.path, rejectedFingerprintBudget),
+      }))))
+      .digest('hex');
+    const snapshot: SkillHubWorkspaceSnapshot = {
+      botUid,
+      activeBotUid,
+      skillsRoot: path.resolve(skillsRoot),
+      skillsPath: fs.realpathSync(skillsRoot),
+      revision,
+      skills,
+      createdAtMs: nowMs,
+    };
+    this.workspaceSnapshots.delete(revision);
+    this.workspaceSnapshots.set(revision, snapshot);
+    this.pruneWorkspaceSnapshots(nowMs);
+    return snapshot;
+  }
+
+  private readCachedWorkspaceSnapshot(
+    revision: string,
+    botUid: string,
+    skillsRoot: string,
+  ): SkillHubWorkspaceSnapshot {
+    const snapshot = this.workspaceSnapshots.get(revision);
+    if (
+      !snapshot
+      || snapshot.botUid !== botUid
+      || snapshot.skillsRoot !== path.resolve(skillsRoot)
+    ) {
+      throw new SkillHubThinRpcError(
+        'WORKSPACE_CHANGED',
+        'The local Skill workspace snapshot is no longer available. Restart the listing.',
+      );
+    }
+    return snapshot;
+  }
+
+  private pruneWorkspaceSnapshots(nowMs: number): void {
+    for (const [revision, snapshot] of this.workspaceSnapshots) {
+      if (nowMs - snapshot.createdAtMs > WORKSPACE_SNAPSHOT_TTL_MS) {
+        this.workspaceSnapshots.delete(revision);
+      }
+    }
+    while (this.workspaceSnapshots.size > MAX_WORKSPACE_SNAPSHOTS) {
+      this.workspaceSnapshots.delete(this.workspaceSnapshots.keys().next().value as string);
+    }
   }
 
   private async shareSkill(
@@ -658,6 +748,9 @@ function readLocalSkillPresentation(skillDir: string): {
 } {
   const skillFile = path.join(skillDir, 'SKILL.md');
   try {
+    if (fs.statSync(skillFile).size > REJECTED_FINGERPRINT_LARGE_FILE_BYTES) {
+      return { description: '', metadata: null };
+    }
     const parsed = matter(fs.readFileSync(skillFile, 'utf8'), {});
     return {
       description: String(parsed.data?.description || ''),
@@ -668,18 +761,88 @@ function readLocalSkillPresentation(skillDir: string): {
   }
 }
 
+function fingerprintRejectedSkillPackage(
+  skillDir: string,
+  budget: RejectedFingerprintBudget,
+): string {
+  const root = path.resolve(skillDir);
+  const evidence: Array<Record<string, unknown>> = [];
+  const visit = (current: string): void => {
+    const children = fs.readdirSync(current, { withFileTypes: true })
+      .sort((left, right) => compareText(left.name, right.name));
+    for (const child of children) {
+      if (
+        child.isDirectory()
+        && (child.name === '.git' || child.name === 'node_modules' || isEphemeralSkillDirectory(child.name))
+      ) continue;
+      const fullPath = path.join(current, child.name);
+      const relativePath = path.relative(root, fullPath).replace(/\\/g, '/');
+      const stat = fs.lstatSync(fullPath);
+      if (stat.isSymbolicLink()) {
+        evidence.push({ path: relativePath, type: 'symlink' });
+        continue;
+      }
+      if (stat.isDirectory()) {
+        evidence.push({ path: relativePath, type: 'directory' });
+        if (!fs.existsSync(path.join(fullPath, 'SKILL.md'))) visit(fullPath);
+        continue;
+      }
+      if (!stat.isFile()) continue;
+      budget.files += 1;
+      if (budget.files > MAX_REJECTED_FINGERPRINT_FILES) throw workspaceTooLargeError();
+      const sampled = readBoundedFingerprintBytes(fullPath, stat.size);
+      budget.bytes += sampled.length;
+      if (budget.bytes > MAX_REJECTED_FINGERPRINT_BYTES) throw workspaceTooLargeError();
+      evidence.push({
+        path: relativePath,
+        size: stat.size,
+        mtime_ms: stat.mtimeMs,
+        sha256: createHash('sha256').update(sampled).digest('hex'),
+        sampled: sampled.length !== stat.size,
+      });
+    }
+  };
+  visit(root);
+  return createHash('sha256').update(stableSerialize(evidence)).digest('hex');
+}
+
+function readBoundedFingerprintBytes(filePath: string, size: number): Buffer {
+  if (size <= REJECTED_FINGERPRINT_LARGE_FILE_BYTES) {
+    return fs.readFileSync(filePath);
+  }
+  const handle = fs.openSync(filePath, 'r');
+  try {
+    const head = Buffer.alloc(Math.min(REJECTED_FINGERPRINT_SAMPLE_BYTES, size));
+    fs.readSync(handle, head, 0, head.length, 0);
+    const remaining = Math.max(0, size - head.length);
+    const tail = Buffer.alloc(Math.min(REJECTED_FINGERPRINT_SAMPLE_BYTES, remaining));
+    if (tail.length > 0) fs.readSync(handle, tail, 0, tail.length, size - tail.length);
+    return Buffer.concat([head, tail]);
+  } finally {
+    fs.closeSync(handle);
+  }
+}
+
 function scanSkillHubWorkspace(
   skillsRoot: string,
   options: Parameters<typeof scanBotSkillWorkspace>[1],
 ): ReturnType<typeof scanBotSkillWorkspace> {
   try {
     return scanBotSkillWorkspace(skillsRoot, options);
-  } catch {
+  } catch (error) {
+    if (error instanceof BotSkillWorkspaceScanLimitError) throw workspaceTooLargeError();
     throw new SkillHubThinRpcError(
       'LOCAL_SKILL_INVALID',
       'The local Skill workspace could not be validated safely.',
     );
   }
+}
+
+function workspaceTooLargeError(): SkillHubThinRpcError {
+  return new SkillHubThinRpcError(
+    'WORKSPACE_TOO_LARGE',
+    'The local Skill workspace is too large to list safely.',
+  );
 }
 
 function recordValue(value: unknown): Record<string, unknown> {

--- a/tests/bot-skills-security.test.ts
+++ b/tests/bot-skills-security.test.ts
@@ -6,6 +6,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { canonicalizeBotSkillRefs } from '../src/bot-skills/canonical';
 import {
+  BotSkillWorkspaceScanLimitError,
   isPortablePackagePath,
   scanBotSkillWorkspace,
   scanLocalBotSkill,
@@ -63,6 +64,22 @@ describe('Bot Skill sync security boundaries', () => {
       fs.writeFileSync(path.join(crowdedRoot, `file-${index}.txt`), '');
     }
     assert.throws(() => scanLocalBotSkill(crowdedRoot), /too many files/i);
+  });
+
+  test('bounds aggregate workspace listing work without retaining package bodies', () => {
+    const skillRoot = createSkill(roots, 'bounded-listing');
+    const workspaceRoot = path.dirname(skillRoot);
+    assert.throws(
+      () => scanBotSkillWorkspace(workspaceRoot, { maxSkillEntries: 0 }),
+      (error: unknown) => error instanceof BotSkillWorkspaceScanLimitError,
+    );
+    assert.throws(
+      () => scanBotSkillWorkspace(workspaceRoot, { maxTotalPackageBytes: 1 }),
+      (error: unknown) => error instanceof BotSkillWorkspaceScanLimitError,
+    );
+    const [entry] = scanBotSkillWorkspace(workspaceRoot, { retainPackageContents: false });
+    assert.ok(entry?.contentHash);
+    assert.deepEqual(entry.files, []);
   });
 
   test('excludes runtime cache directories without deleting or size-checking them', () => {

--- a/tests/catscompany-skillhub-rpc.test.ts
+++ b/tests/catscompany-skillhub-rpc.test.ts
@@ -172,24 +172,75 @@ describe('CatsCompany SkillHub thin RPC', () => {
     );
   });
 
-  test('rejects a stale workspace revision and invalid pagination input', async () => {
+  test('serves later pages from one cached snapshot and refreshes only on a new listing', async () => {
     const first = await handler.execute(request({ request_id: 'workspace-revision-before-edit' }));
-    fs.appendFileSync(path.join(runtimeRoot, 'skills', 'local-demo', 'SKILL.md'), '\nUpdated after page one.\n');
+    fs.writeFileSync(path.join(runtimeRoot, 'skills', 'local-demo', 'SKILL.md'), [
+      '---',
+      'name: [unterminated',
+      'description: Still the old validation class',
+      '---',
+      '',
+    ].join('\n'));
 
+    const cached = await handler.execute(request({
+      request_id: 'workspace-revision-cached-after-edit',
+      payload: {
+        bot_uid: '42',
+        offset: 0,
+        workspace_revision: first.workspace_revision,
+      },
+    }));
+    assert.deepEqual(cached.skills, first.skills);
+    assert.equal(cached.workspace_revision, first.workspace_revision);
+
+    const refreshed = await handler.execute(request({ request_id: 'workspace-revision-new-listing' }));
+    assert.notEqual(refreshed.workspace_revision, first.workspace_revision);
+    assert.equal((refreshed.skills as Array<Record<string, unknown>>)[0]?.can_share, false);
+
+    const restartedHandler = new SkillHubThinRpcHandler({ runtimeRoot });
     await assert.rejects(
-      handler.execute(request({
-        request_id: 'workspace-revision-after-edit',
+      restartedHandler.execute(request({
+        request_id: 'workspace-revision-evicted',
         payload: {
           bot_uid: '42',
-          offset: 0,
           workspace_revision: first.workspace_revision,
         },
       })),
       (error: unknown) => error instanceof SkillHubThinRpcError && error.code === 'WORKSPACE_CHANGED',
     );
+  });
+
+  test('fingerprints rejected Skill bytes even when the visible validation error is unchanged', async () => {
+    const skillRoot = path.join(runtimeRoot, 'skills', 'broken-revision');
+    fs.mkdirSync(skillRoot, { recursive: true });
+    writeBotSkillLocalMarker(skillRoot, {
+      schema: 'xiaoba.bot-skill-local.v1',
+      localSkillId: 'broken-revision',
+    });
+    const writeBroken = (description: string) => fs.writeFileSync(path.join(skillRoot, 'SKILL.md'), [
+      '---',
+      'name: [unterminated',
+      `description: ${description}`,
+      '---',
+      '',
+    ].join('\n'));
+    writeBroken('first rejected bytes');
+    const first = await handler.execute(request({ request_id: 'rejected-revision-first' }));
+    writeBroken('later rejected byte');
+    const second = await handler.execute(request({ request_id: 'rejected-revision-second' }));
+    assert.notEqual(second.workspace_revision, first.workspace_revision);
+    const firstRejected = (first.skills as Array<Record<string, unknown>>)
+      .find(skill => skill.local_skill_id === 'broken-revision');
+    const secondRejected = (second.skills as Array<Record<string, unknown>>)
+      .find(skill => skill.local_skill_id === 'broken-revision');
+    assert.equal(firstRejected?.share_error, secondRejected?.share_error);
+  });
+
+  test('rejects invalid pagination input', async () => {
     for (const [requestID, payload] of [
       ['workspace-invalid-limit', { bot_uid: '42', limit: 201 }],
       ['workspace-invalid-offset', { bot_uid: '42', offset: -1 }],
+      ['workspace-outside-offset', { bot_uid: '42', offset: 2 }],
       ['workspace-invalid-revision', { bot_uid: '42', workspace_revision: 'not-a-hash' }],
     ] as const) {
       await assert.rejects(

--- a/tests/catscompany-skillhub-rpc.test.ts
+++ b/tests/catscompany-skillhub-rpc.test.ts
@@ -112,6 +112,91 @@ describe('CatsCompany SkillHub thin RPC', () => {
     assert.equal(skills[0].relative_path, 'local-demo');
     assert.equal(Object.prototype.hasOwnProperty.call(skills[0], 'path'), false);
     assert.equal(JSON.stringify(result).includes('# Local Demo'), false);
+    assert.match(String(result.workspace_revision), /^[0-9a-f]{64}$/);
+    assert.equal(result.total_skills, 1);
+    assert.equal(result.page_offset, 0);
+    assert.equal(result.page_limit, 200);
+    assert.equal(result.next_offset, null);
+    assert.equal(result.truncated, false);
+  });
+
+  test('paginates more than 200 workspace Skills without hiding the remainder', async () => {
+    const skillsRoot = path.join(runtimeRoot, 'skills');
+    for (let index = 0; index < 205; index += 1) {
+      const name = `bulk-${String(index).padStart(3, '0')}`;
+      const skillRoot = path.join(skillsRoot, name);
+      fs.mkdirSync(skillRoot, { recursive: true });
+      fs.writeFileSync(path.join(skillRoot, 'SKILL.md'), [
+        '---',
+        `name: ${name}`,
+        `description: Pagination fixture ${index}`,
+        '---',
+        '',
+      ].join('\n'));
+    }
+
+    const first = await handler.execute(request({
+      request_id: 'workspace-page-1',
+      payload: { bot_uid: '42', limit: 75 },
+    }));
+    assert.equal((first.skills as unknown[]).length, 75);
+    assert.equal(first.total_skills, 206);
+    assert.equal(first.page_offset, 0);
+    assert.equal(first.next_offset, 75);
+    assert.equal(first.truncated, true);
+
+    const second = await handler.execute(request({
+      request_id: 'workspace-page-2',
+      payload: {
+        bot_uid: '42',
+        offset: first.next_offset,
+        limit: 200,
+        workspace_revision: first.workspace_revision,
+      },
+    }));
+    assert.equal(second.workspace_revision, first.workspace_revision);
+    assert.equal((second.skills as unknown[]).length, 131);
+    assert.equal(second.page_offset, 75);
+    assert.equal(second.next_offset, null);
+    assert.equal(second.truncated, false);
+
+    const combined = [
+      ...(first.skills as Array<Record<string, unknown>>),
+      ...(second.skills as Array<Record<string, unknown>>),
+    ];
+    assert.equal(combined.length, 206);
+    assert.equal(new Set(combined.map(skill => skill.local_skill_id)).size, 206);
+    assert.deepEqual(
+      combined.map(skill => String(skill.local_skill_id)),
+      [...combined.map(skill => String(skill.local_skill_id))].sort(),
+    );
+  });
+
+  test('rejects a stale workspace revision and invalid pagination input', async () => {
+    const first = await handler.execute(request({ request_id: 'workspace-revision-before-edit' }));
+    fs.appendFileSync(path.join(runtimeRoot, 'skills', 'local-demo', 'SKILL.md'), '\nUpdated after page one.\n');
+
+    await assert.rejects(
+      handler.execute(request({
+        request_id: 'workspace-revision-after-edit',
+        payload: {
+          bot_uid: '42',
+          offset: 0,
+          workspace_revision: first.workspace_revision,
+        },
+      })),
+      (error: unknown) => error instanceof SkillHubThinRpcError && error.code === 'WORKSPACE_CHANGED',
+    );
+    for (const [requestID, payload] of [
+      ['workspace-invalid-limit', { bot_uid: '42', limit: 201 }],
+      ['workspace-invalid-offset', { bot_uid: '42', offset: -1 }],
+      ['workspace-invalid-revision', { bot_uid: '42', workspace_revision: 'not-a-hash' }],
+    ] as const) {
+      await assert.rejects(
+        handler.execute(request({ request_id: requestID, payload })),
+        (error: unknown) => error instanceof SkillHubThinRpcError && error.code === 'INVALID_REQUEST',
+      );
+    }
   });
 
   test('deletes only the exact local Skill selected by local_skill_id', async () => {


### PR DESCRIPTION
## 目标

修复 CatsCo SkillHub 运行工作区最多只显示 200 个 Skill 的问题。此前 Runtime 在排序后直接截断数组，超过 200 个的 Skill 并未被删除，但 WebApp 无法获知或继续读取。

## 变更

- 为 `skillhub.localWorkspace.get` 增加向后兼容的 `offset`、`limit` 和 `workspace_revision` 参数。
- 响应增加总数、当前页、下一页与截断状态；未传分页参数的旧 WebApp 仍获得原来的首屏响应。
- 使用稳定的工作区 revision 绑定多页读取；读取期间内容变化会返回 `WORKSPACE_CHANGED`，避免拼接不同时间点的数据。
- 保留单页最大 200 条的消息边界，但不再永久隐藏第 201 条及之后的 Skill。

## 安全与兼容边界

- 不改变 Skill 激活、BotDefinition、Shell、文件工具、注入或 System Prompt。
- 不提高 BotDefinition 正式 Skill 引用的独立上限；本 PR 只修复 Runtime 工作区枚举。
- 旧 WebApp 可继续使用；新 WebApp 可自动翻页。

## 验证

- `npm run build`
- `npm run test:skillhub-phase1`（270 passed，3 个 Windows symlink 场景按预期 skipped）
- `CATSCOMPANY_REPO=... npm run test:cross-repo:catsco-skills`（62 passed）
- 新增 206 个 Skill 的两页完整枚举、revision 变化与非法分页参数测试

## 发布顺序

先合并并发布本 PR，再合并 CatsCo WebApp 的自动翻页 PR。
