### PR TITLE
fix(desktop): report local device identity during web connect

### DIFF
--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -3612,7 +3612,16 @@ export function createApiRouter(
       if (!code) return res.status(400).json({ error: 'code is required' });
 
       const state = trustCatsAuthStateEndpoints(getCatsAuthState(req.body || {}));
-      const login = await catsRequest('POST', state.httpBaseUrl, '/api/desktop-connect/exchange', { code }, undefined, { timeoutMs: 8000 });
+      const localConfigService = createCatsCoLocalConfigService({ runtimeRoot: runtimeDataRoot() });
+      const localDevice = localConfigService.load().device;
+      const runtimeRole = process.env.XIAOBA_RUNTIME_ROLE === 'desktop' ? 'desktop' : 'server';
+      const login = await catsRequest('POST', state.httpBaseUrl, '/api/desktop-connect/exchange', {
+        code,
+        device_id: localDevice?.deviceId || '',
+        installation_id: localDevice?.installationId || localDevice?.deviceId || '',
+        display_name: localDevice?.name || os.hostname(),
+        runtime_role: runtimeRole,
+      }, undefined, { timeoutMs: 8000 });
       const httpBaseUrl = normalizeTrustedCatsHttpBaseUrl(login.http_base_url || login.httpBaseUrl || state.httpBaseUrl || DEFAULT_CATSCO_HTTP_BASE_URL);
       const serverUrl = normalizeTrustedCatsServerUrl(login.server_url || login.serverUrl || state.serverUrl || DEFAULT_CATSCO_WS_URL);
       const nextState: CatsAuthState = {

--- a/tests/dashboard-catsco-auth-status.test.ts
+++ b/tests/dashboard-catsco-auth-status.test.ts
@@ -61,6 +61,7 @@ describe('dashboard CatsCo account status', () => {
     'CATSCOMPANY_DEVICE_ID',
     'CATSCOMPANY_BODY_ID',
     'CATSCOMPANY_INSTALLATION_ID',
+    'XIAOBA_RUNTIME_ROLE',
     'CATSCO_ALLOW_LOCAL_ENDPOINTS',
     'CATSCOMPANY_ALLOW_LOCAL_ENDPOINTS',
     'WEIXIN_TOKEN',
@@ -763,9 +764,25 @@ describe('dashboard CatsCo account status', () => {
   });
 
   test('POST /cats/desktop-connect exchanges a web login code and persists CatsCo account aliases', async () => {
+    process.env.XIAOBA_RUNTIME_ROLE = 'desktop';
+    createCatsCoLocalConfigService({ runtimeRoot: testRoot }).save({
+      version: 1,
+      device: {
+        deviceId: 'device-local',
+        bodyId: 'body-local',
+        installationId: 'install-local',
+        name: 'CK123',
+      },
+    });
     await startCatsServer((req, res) => {
       if (req.path === '/api/desktop-connect/exchange') {
-        assert.deepStrictEqual(req.body, { code: 'one-time-code' });
+        assert.deepStrictEqual(req.body, {
+          code: 'one-time-code',
+          device_id: 'device-local',
+          installation_id: 'install-local',
+          display_name: 'CK123',
+          runtime_role: 'desktop',
+        });
         return res.json({
           token: 'desktop-user-token',
           uid: 91,


### PR DESCRIPTION
## Summary
- Send the existing local device and installation identity when the desktop claims a web connection code.
- Mark Electron claims as desktop runtime claims so the web app can distinguish local desktops from server runtimes.
- Preserve the existing trust boundary: loading the claim identity does not create or persist a device ID before the server response is trusted.

## Verification
- `npx tsx --test tests/dashboard-catsco-auth-status.test.ts` (27 passed)
- `npm run build`
- Full runtime suite previously completed with 1678 passed; two unrelated timing-sensitive files passed independently.

## Compatibility
The extra exchange fields are ignored by older CatsCompany servers. Exact automatic multi-device matching requires the corresponding CatsCompany platform PR; older XiaoBa releases continue through manual device selection.