### PR TITLE
chore(release): bump version to v1.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xiaoba-cli",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xiaoba-cli",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xiaoba-cli",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "CatsCo - local agent runtime and dashboard",
   "main": "electron/main.js",
   "bin": {


### PR DESCRIPTION
Bump the checked-in application version and package lock to 1.5.1 for the desktop release. Release tag will be created only after this PR is merged.