### PR TITLE
docs: remove routable infrastructure address from public notes

### DIFF
--- a/docs/superpowers/plans/2026-08-05-worker-image-platform-hardening.md
+++ b/docs/superpowers/plans/2026-08-05-worker-image-platform-hardening.md
@@ -154,7 +154,7 @@
   5. 镜像内 `catsco-agent.service` 为 disabled（首次供给由控制面启用）；无临时 key pair/builder 残留（`ecs GetEcsKeypairDetails` 查询 `catsco-img-key-*` 为空）
   6. 确认后删除验证用临时实例，避免计费残留
 
-  **验收结果（2026-08-07 实测，验证实例 IP 203.32.69.72）：**
+  **验收结果（2026-08-07 实测，验证实例地址已从公开记录中省略）：**
   1. ✅ bake 日志 `platform_systemd=255.4-1ubuntu8.16 glibc=2.39-0ubuntu8.8 kernel=6.8.0-90-generic` + `image_prepared=yes` + `finalized=yes` + `result: created`
   2. ✅ `readlink fwupd.service/fwupd-refresh.service/fwupd-refresh.timer` 均 = `/dev/null`；`systemctl is-system-running` = `running`
   3. ✅ `/root/.npmrc` 与 `/srv/catsco-agent/.npmrc` = `registry=https://registry.npmmirror.com`；`systemctl cat catsco-agent.service` 含 `NPM_CONFIG_REGISTRY=https://registry.npmmirror.com`

--- a/tests/worker-image-pipeline.test.ts
+++ b/tests/worker-image-pipeline.test.ts
@@ -17,6 +17,16 @@ describe("Tianyi Cloud worker image pipeline", () => {
   );
   const imageOrchestrator = fs.readFileSync(imageOrchestratorPath, "utf8");
   const workflow = read(".github/workflows/worker-image.yml");
+  const hardeningPlan = read(
+    "docs/superpowers/plans/2026-08-05-worker-image-platform-hardening.md",
+  );
+
+  test("public operations notes do not contain a real routable IPv4 address", () => {
+    assert.doesNotMatch(
+      hardeningPlan,
+      /\b(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-5])(?:\.\d{1,3}){3}\b/,
+    );
+  });
 
   test("artifact is source-free and reproducible for one commit", () => {
     assert.match(artifactBuilder, /git\(sourceRoot, \[["']ls-files["']/);


### PR DESCRIPTION
## Summary\n- remove the real validation instance IPv4 address from public operations notes\n- add a regression test preventing routable IPv4 addresses in that note\n\n## Verification\n- npx tsx --test tests/worker-image-pipeline.test.ts\n