### PR TITLE
feat: sync cloud catalog runtime metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# XiaoBa-CLI Agent Instructions
+
+## Web and account acceptance
+
+For every web test or acceptance check that involves an account or user experience,
+create a separate internal test account and run the real user flow from a real
+authenticated web session. Verify page state, requests, and resulting service state,
+not only mocks or direct API calls. After verification, remove the test account and
+all related bots, keys, entitlements, and other test data, and clean up browser
+artifacts and temporary branches. Never reuse a production user's account for
+automated acceptance unless the user explicitly authorizes that specific test.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,3 +9,19 @@ not only mocks or direct API calls. After verification, remove the test account 
 all related bots, keys, entitlements, and other test data, and clean up browser
 artifacts and temporary branches. Never reuse a production user's account for
 automated acceptance unless the user explicitly authorizes that specific test.
+
+## Required account and user-experience acceptance
+
+Any change whose acceptance involves an account, entitlement, payment, cloud worker,
+or other user-facing web workflow must be tested end to end from a real authenticated
+browser session. Create a separate internal test account through an approved internal
+admin/API path (or seed it in the isolated test store), grant only the minimum test
+entitlements, and verify the actual page state, network requests, backend records, and
+resulting service state. Do not treat mocked requests, unit tests, or direct database
+assertions as a substitute for the real browser flow.
+
+After the test, remove the test account and every related bot/worker, virtual key,
+provider key, quota, package entitlement, payment/test record, and other generated
+data. Delete browser screenshots, traces, storage state, temporary worktrees, and
+branches created for the test. Record the cleanup result and stop immediately if a
+production account or resource could be affected.

--- a/src/bot-definition/activation.ts
+++ b/src/bot-definition/activation.ts
@@ -371,15 +371,17 @@ export async function prepareBoundBotDefinition(
         const cloudModel = {
           kind: 'catalog' as const,
           modelId: cloudSelection.modelId,
+          ...(cloudSelection.catalogRuntime ? { catalogRuntime: cloudSelection.catalogRuntime } : {}),
           ...(cloudSelection.reasoningEffort ? { reasoningEffort: cloudSelection.reasoningEffort } : {}),
         };
         const runtime = definitionService.readCloudCatalogRuntime(botId);
-        if (!runtime || !catalogRuntimeMatchesModelId(runtime, cloudSelection.modelId)) {
+        if (!runtime || !catalogRuntimeMatchesModelId(runtime, cloudSelection.modelId, cloudSelection.catalogRuntime)) {
           const materialized = await provisionCatsRelayCatalogRuntime({
             botId,
             modelId: cloudSelection.modelId,
             reasoningEffort: cloudSelection.reasoningEffort,
             contextWindowTokens: cloudSelection.contextWindowTokens,
+            catalogRuntime: cloudSelection.catalogRuntime,
             existingRuntime: runtime ?? definitionService.readCatalogRuntime(botId),
             auth,
             fetchImpl: options.fetchImpl,
@@ -399,6 +401,7 @@ export async function prepareBoundBotDefinition(
                 modelId: cloudSelection.modelId,
                 reasoningEffort: cloudSelection.reasoningEffort,
                 contextWindowTokens: cloudSelection.contextWindowTokens,
+                catalogRuntime: cloudSelection.catalogRuntime,
                 existingRuntime: runtime,
                 auth,
                 fetchImpl: options.fetchImpl,
@@ -428,6 +431,7 @@ export async function prepareBoundBotDefinition(
               ...(cloudSelection.contextWindowTokens !== undefined
                 ? { contextWindowTokens: cloudSelection.contextWindowTokens }
                 : {}),
+              ...(cloudSelection.catalogRuntime ? { catalogRuntime: cloudSelection.catalogRuntime } : {}),
             });
           }
         }

--- a/src/bot-definition/cloud-client.ts
+++ b/src/bot-definition/cloud-client.ts
@@ -403,6 +403,7 @@ function parseCloudCatalogRuntime(value: unknown): RelayModelRuntimeDescriptor |
     : undefined;
   if (provider === 'openai' && !openaiApiMode) return undefined;
   return {
+    ...(String(input.catalogModelId || '').trim() ? { catalogModelId: String(input.catalogModelId).trim() } : {}),
     model,
     provider,
     contextWindowTokens,

--- a/src/bot-definition/cloud-client.ts
+++ b/src/bot-definition/cloud-client.ts
@@ -3,6 +3,7 @@ import { createHash } from 'crypto';
 import { normalizeReasoningEffort } from '../utils/reasoning-effort';
 import type { ReasoningEffort } from '../types';
 import { canonicalizeBotSkillRefs } from '../bot-skills/canonical';
+import type { RelayModelRuntimeDescriptor } from '../utils/relay-model-profiles';
 import {
   BOT_DEFINITION_SCHEMA,
   type CloudBotDefinition,
@@ -25,6 +26,7 @@ export interface CloudBotModelSelection {
    * device-local profile must not override it.
    */
   contextWindowTokens?: number;
+  catalogRuntime?: RelayModelRuntimeDescriptor;
   revision: number;
   customModel?: CustomBotModelDefinition;
   definition?: CloudBotDefinition;
@@ -79,6 +81,9 @@ export async function pullCloudBotModelSelection(
         definition: definitionSnapshot.definition,
         ...(model.kind === 'catalog' && model.contextWindowTokens
           ? { contextWindowTokens: model.contextWindowTokens }
+          : {}),
+        ...(model.kind === 'catalog' && model.catalogRuntime
+          ? { catalogRuntime: model.catalogRuntime }
           : {}),
         ...(model.reasoningEffort ? { reasoningEffort: model.reasoningEffort } : {}),
       };
@@ -341,6 +346,7 @@ function parseCloudBotDefinitionSnapshot(
     const rawReasoning = String(rawModel?.reasoningEffort || '').trim();
     const reasoningEffort = rawReasoning ? normalizeReasoningEffort(rawReasoning) : undefined;
     const contextWindowTokens = parseCloudContextWindowTokens(rawModel?.contextWindowTokens);
+    const catalogRuntime = parseCloudCatalogRuntime(rawModel?.catalogRuntime);
     if (!modelId || (rawReasoning && !reasoningEffort)) {
       throw new Error('CatsCo cloud returned an invalid catalog BotDefinition.');
     }
@@ -348,6 +354,7 @@ function parseCloudBotDefinitionSnapshot(
       kind: 'catalog',
       modelId,
       ...(contextWindowTokens !== undefined ? { contextWindowTokens } : {}),
+      ...(catalogRuntime ? { catalogRuntime } : {}),
       ...(reasoningEffort ? { reasoningEffort } : {}),
     };
   } else {
@@ -374,6 +381,37 @@ function parseCloudBotDefinitionSnapshot(
     ...(response?.runtime && typeof response.runtime === 'object'
       ? { runtime: response.runtime as Record<string, unknown> }
       : {}),
+  };
+}
+
+function parseCloudCatalogRuntime(value: unknown): RelayModelRuntimeDescriptor | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const input = value as Record<string, unknown>;
+  const provider = input.provider === 'anthropic' || input.provider === 'openai' ? input.provider : undefined;
+  const model = String(input.model || '').trim();
+  const contextWindowTokens = Number(input.contextWindowTokens);
+  const rawCapabilities = input.capabilities;
+  if (!provider || !model || !Number.isInteger(contextWindowTokens)
+    || contextWindowTokens < 1_024 || contextWindowTokens > 4_000_000
+    || !rawCapabilities || typeof rawCapabilities !== 'object') return undefined;
+  const capabilities = rawCapabilities as Record<string, unknown>;
+  if (typeof capabilities.vision !== 'boolean'
+    || typeof capabilities.toolCalling !== 'boolean'
+    || typeof capabilities.streaming !== 'boolean') return undefined;
+  const openaiApiMode = input.openaiApiMode === 'responses' || input.openaiApiMode === 'chat_completions'
+    ? input.openaiApiMode
+    : undefined;
+  if (provider === 'openai' && !openaiApiMode) return undefined;
+  return {
+    model,
+    provider,
+    contextWindowTokens,
+    ...(provider === 'openai' ? { openaiApiMode } : {}),
+    capabilities: {
+      vision: capabilities.vision,
+      toolCalling: capabilities.toolCalling,
+      streaming: capabilities.streaming,
+    },
   };
 }
 

--- a/src/bot-definition/service.ts
+++ b/src/bot-definition/service.ts
@@ -6,6 +6,7 @@ import { canonicalizeBotSkillRefs } from '../bot-skills/canonical';
 import { createCatsCoLocalConfigService } from '../catscompany/local-config';
 import { normalizeOpenAIApiMode } from '../utils/openai-api-mode';
 import { normalizeReasoningEffort } from '../utils/reasoning-effort';
+import { relayModelProfileFromRuntimeDescriptor, type RelayModelRuntimeDescriptor } from '../utils/relay-model-profiles';
 import {
   canonicalRelayModelId,
   findRelayModelProfile,
@@ -288,9 +289,11 @@ export function catalogRuntimeFromLocalProfile(
 export function catalogRuntimeMatchesModelId(
   runtime: Pick<BotCatalogModelRuntime, 'modelId' | 'model'>,
   modelId: string,
+  descriptor?: RelayModelRuntimeDescriptor,
 ): boolean {
   if (!relayModelIdsMatch(runtime.modelId, modelId)) return false;
-  const profile = findRelayModelProfile(modelId);
+  const profile = relayModelProfileFromRuntimeDescriptor(modelId, descriptor)
+    ?? findRelayModelProfile(modelId);
   return !profile || relayModelIdsMatch(runtime.model, profile.id);
 }
 

--- a/src/bot-definition/types.ts
+++ b/src/bot-definition/types.ts
@@ -1,4 +1,5 @@
 import type { OpenAIApiMode, ReasoningEffort } from '../types';
+import type { RelayModelRuntimeDescriptor } from '../utils/relay-model-profiles';
 
 export const BOT_DEFINITION_SCHEMA = 'xiaoba.bot-definition.v1';
 export const BOT_CATALOG_MODEL_RUNTIME_SCHEMA = 'xiaoba.bot-catalog-model-runtime.v1';
@@ -18,6 +19,8 @@ export interface CatalogBotModelDefinition {
    * the catalog cannot drift from what devices actually send upstream.
    */
   contextWindowTokens?: number;
+  /** Cloud-authoritative non-secret runtime metadata for dynamic catalog models. */
+  catalogRuntime?: RelayModelRuntimeDescriptor;
 }
 
 /**

--- a/src/catscompany/relay-model-bootstrap.ts
+++ b/src/catscompany/relay-model-bootstrap.ts
@@ -1,6 +1,8 @@
 import type { CatsCoAuthSnapshot } from './local-config';
 import {
   findRelayModelProfile,
+  relayModelProfileFromRuntimeDescriptor,
+  type RelayModelRuntimeDescriptor,
   relayModelProviderBaseUrl,
   type RelayModelProvider,
 } from '../utils/relay-model-profiles';
@@ -23,6 +25,7 @@ export interface CatsRelayBootstrapOptions {
   contextWindowTokens?: number;
   existingRuntime?: BotCatalogModelRuntime;
   fetchImpl?: typeof fetch;
+  catalogRuntime?: RelayModelRuntimeDescriptor;
 }
 
 type RuntimeCapabilities = NonNullable<BotCatalogModelRuntime['capabilities']>;
@@ -40,7 +43,8 @@ export async function provisionCatsRelayCatalogRuntime(
   const token = String(options.auth.token || '').trim();
   const httpBaseUrl = String(options.auth.httpBaseUrl || '').trim().replace(/\/+$/, '');
   const ownerUid = relayOwnerUid(options.auth);
-  const profile = findRelayModelProfile(modelId);
+  const profile = relayModelProfileFromRuntimeDescriptor(modelId, options.catalogRuntime)
+    ?? findRelayModelProfile(modelId);
   if (!botId) throw new Error('Cannot initialize a catalog model without botId.');
   if (!profile) throw new Error(`Unknown CatsCo relay model: ${modelId}`);
   if (token && options.auth.uid && options.auth.ownerUid && options.auth.uid !== options.auth.ownerUid) {
@@ -121,8 +125,10 @@ export function retargetCatsRelayCatalogRuntime(
   reasoningEffort?: ReasoningEffort,
   contextWindowTokens?: number,
   ownerUid?: string,
+  catalogRuntime?: RelayModelRuntimeDescriptor,
 ): BotCatalogModelRuntime {
-  const profile = findRelayModelProfile(modelId);
+  const profile = relayModelProfileFromRuntimeDescriptor(modelId, catalogRuntime)
+    ?? findRelayModelProfile(modelId);
   if (!profile) throw new Error(`Unknown CatsCo relay model: ${modelId}`);
   const apiKey = String(existing.apiKey || '').trim();
   if (!apiKey) throw new Error('Existing CatsCo relay runtime does not contain a reusable credential.');

--- a/src/utils/relay-model-profiles.ts
+++ b/src/utils/relay-model-profiles.ts
@@ -1,4 +1,4 @@
-export type RelayModelFamily = 'minimax' | 'deepseek' | 'glm' | 'gpt';
+export type RelayModelFamily = 'catalog' | 'minimax' | 'deepseek' | 'glm' | 'gpt';
 export type RelayModelProvider = 'anthropic' | 'openai';
 
 export const RELAY_MODEL_BASE_URLS: Record<RelayModelProvider, string> = {
@@ -81,7 +81,7 @@ export function relayModelProfileFromRuntimeDescriptor(
     id,
     label: id,
     model,
-    family: 'gpt',
+    family: 'catalog',
     quotaClass: id,
     preferredProvider: provider,
     ...(provider === 'openai' ? { openaiApiMode } : {}),

--- a/src/utils/relay-model-profiles.ts
+++ b/src/utils/relay-model-profiles.ts
@@ -36,6 +36,66 @@ export interface RelayModelProfile {
   capabilities: RelayModelCapabilities;
 }
 
+/** Non-secret catalog metadata supplied by CatsCompany for dynamic models. */
+export interface RelayModelRuntimeDescriptor {
+  model: string;
+  provider: RelayModelProvider;
+  contextWindowTokens: number;
+  openaiApiMode?: 'chat_completions' | 'responses';
+  capabilities: RelayModelCapabilities;
+}
+
+/**
+ * Converts cloud catalog metadata into a safe local profile. Endpoints and
+ * credentials are intentionally absent: they are still selected by the
+ * authenticated Relay config/key flow.
+ */
+export function relayModelProfileFromRuntimeDescriptor(
+  modelId: unknown,
+  descriptor: unknown,
+): RelayModelProfile | undefined {
+  const id = normalizeModelName(modelId);
+  if (!id || !descriptor || typeof descriptor !== 'object') return undefined;
+  const input = descriptor as Record<string, unknown>;
+  const model = String(input.model || '').trim();
+  const provider = input.provider === 'anthropic' || input.provider === 'openai'
+    ? input.provider
+    : undefined;
+  const contextWindowTokens = Number(input.contextWindowTokens);
+  const capabilities = input.capabilities as Record<string, unknown> | undefined;
+  const openaiApiMode = input.openaiApiMode === 'responses' || input.openaiApiMode === 'chat_completions'
+    ? input.openaiApiMode
+    : undefined;
+  if (!model || !provider || !Number.isInteger(contextWindowTokens)
+    || contextWindowTokens < 1_024 || contextWindowTokens > 4_000_000
+    || !capabilities || typeof capabilities.toolCalling !== 'boolean'
+    || typeof capabilities.streaming !== 'boolean'
+    || typeof capabilities.vision !== 'boolean'
+    || (provider === 'openai' && !openaiApiMode)) {
+    return undefined;
+  }
+  // A catalog descriptor can only describe the selected public model. Do not
+  // allow it to retarget a runtime to a different model identifier.
+  if (normalizeModelName(model) !== id) return undefined;
+  return {
+    id,
+    label: id,
+    model,
+    family: 'gpt',
+    quotaClass: id,
+    preferredProvider: provider,
+    ...(provider === 'openai' ? { openaiApiMode } : {}),
+    contextWindowTokens,
+    modelsDevProvider: '',
+    modelsDevModel: model,
+    capabilities: {
+      toolCalling: capabilities.toolCalling,
+      vision: capabilities.vision,
+      streaming: capabilities.streaming,
+    },
+  };
+}
+
 // Vision capabilities mirror the first-party provider entries in models.dev.
 // Relay input modalities may override them at runtime.
 export const RELAY_MODEL_PROFILES: RelayModelProfile[] = [

--- a/src/utils/relay-model-profiles.ts
+++ b/src/utils/relay-model-profiles.ts
@@ -1,4 +1,4 @@
-export type RelayModelFamily = 'minimax' | 'deepseek' | 'gpt';
+export type RelayModelFamily = 'minimax' | 'deepseek' | 'glm' | 'gpt';
 export type RelayModelProvider = 'anthropic' | 'openai';
 
 export const RELAY_MODEL_BASE_URLS: Record<RelayModelProvider, string> = {
@@ -86,6 +86,24 @@ export const RELAY_MODEL_PROFILES: RelayModelProfile[] = [
       // Relay rewrites image requests to DeepSeek's
       // deepseek-v4-flash-vision-exp sibling while keeping this public model
       // id stable for quotas and runtime configuration.
+      vision: true,
+      streaming: true,
+    },
+  },
+  {
+    id: 'glm-5.3-flash',
+    label: 'GLM 5.3 Flash',
+    model: 'glm-5.3-flash',
+    family: 'glm',
+    quotaClass: 'glm-5.3-flash',
+    preferredProvider: 'anthropic',
+    contextWindowTokens: 1_000_000,
+    // models.dev uses the Zhipu provider slug for GLM metadata. Relay's
+    // catalog remains authoritative when this capability fallback is absent.
+    modelsDevProvider: 'zhipuai',
+    modelsDevModel: 'glm-5.3-flash',
+    capabilities: {
+      toolCalling: true,
       vision: true,
       streaming: true,
     },

--- a/src/utils/relay-model-profiles.ts
+++ b/src/utils/relay-model-profiles.ts
@@ -38,6 +38,7 @@ export interface RelayModelProfile {
 
 /** Non-secret catalog metadata supplied by CatsCompany for dynamic models. */
 export interface RelayModelRuntimeDescriptor {
+  catalogModelId?: string;
   model: string;
   provider: RelayModelProvider;
   contextWindowTokens: number;
@@ -58,6 +59,7 @@ export function relayModelProfileFromRuntimeDescriptor(
   if (!id || !descriptor || typeof descriptor !== 'object') return undefined;
   const input = descriptor as Record<string, unknown>;
   const model = String(input.model || '').trim();
+  const catalogModelId = String(input.catalogModelId || '').trim().toLowerCase();
   const provider = input.provider === 'anthropic' || input.provider === 'openai'
     ? input.provider
     : undefined;
@@ -66,7 +68,9 @@ export function relayModelProfileFromRuntimeDescriptor(
   const openaiApiMode = input.openaiApiMode === 'responses' || input.openaiApiMode === 'chat_completions'
     ? input.openaiApiMode
     : undefined;
-  if (!model || !provider || !Number.isInteger(contextWindowTokens)
+  if (!model || model.length > 256 || /[\u0000-\u001f\u007f]/.test(model)
+    || (catalogModelId && catalogModelId !== id)
+    || !provider || !Number.isInteger(contextWindowTokens)
     || contextWindowTokens < 1_024 || contextWindowTokens > 4_000_000
     || !capabilities || typeof capabilities.toolCalling !== 'boolean'
     || typeof capabilities.streaming !== 'boolean'
@@ -74,11 +78,9 @@ export function relayModelProfileFromRuntimeDescriptor(
     || (provider === 'openai' && !openaiApiMode)) {
     return undefined;
   }
-  // A catalog descriptor can only describe the selected public model. Do not
-  // allow it to retarget a runtime to a different model identifier.
-  if (normalizeModelName(model) !== id) return undefined;
   return {
     id,
+    ...(catalogModelId ? { catalogModelId } : {}),
     label: id,
     model,
     family: 'catalog',

--- a/tests/catscompany-relay-model-bootstrap.test.ts
+++ b/tests/catscompany-relay-model-bootstrap.test.ts
@@ -5,8 +5,21 @@ import {
   refreshCatsRelayCatalogRuntimeCapabilities,
   retargetCatsRelayCatalogRuntime,
 } from '../src/catscompany/relay-model-bootstrap';
+import { relayModelProfileFromRuntimeDescriptor } from '../src/utils/relay-model-profiles';
 
 describe('CatsCo default relay model bootstrap', () => {
+  test('accepts a new cloud catalog model without a shipped local profile', () => {
+    const profile = relayModelProfileFromRuntimeDescriptor('new-model-2026', {
+      model: 'new-model-2026',
+      provider: 'anthropic',
+      contextWindowTokens: 128_000,
+      capabilities: { vision: false, toolCalling: true, streaming: true },
+    });
+    assert.equal(profile?.id, 'new-model-2026');
+    assert.equal(profile?.preferredProvider, 'anthropic');
+    assert.equal(profile?.contextWindowTokens, 128_000);
+  });
+
   test('materializes GLM 5.3 Flash from the cloud catalog with max reasoning', async () => {
     const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
       const url = new URL(String(input));

--- a/tests/catscompany-relay-model-bootstrap.test.ts
+++ b/tests/catscompany-relay-model-bootstrap.test.ts
@@ -10,7 +10,8 @@ import { relayModelProfileFromRuntimeDescriptor } from '../src/utils/relay-model
 describe('CatsCo default relay model bootstrap', () => {
   test('accepts a new cloud catalog model without a shipped local profile', () => {
     const profile = relayModelProfileFromRuntimeDescriptor('new-model-2026', {
-      model: 'new-model-2026',
+      catalogModelId: 'new-model-2026',
+      model: 'provider-new-model',
       provider: 'anthropic',
       contextWindowTokens: 128_000,
       capabilities: { vision: false, toolCalling: true, streaming: true },
@@ -18,6 +19,7 @@ describe('CatsCo default relay model bootstrap', () => {
     assert.equal(profile?.id, 'new-model-2026');
     assert.equal(profile?.preferredProvider, 'anthropic');
     assert.equal(profile?.contextWindowTokens, 128_000);
+    assert.equal(profile?.model, 'provider-new-model');
   });
 
   test('materializes GLM 5.3 Flash from the cloud catalog with max reasoning', async () => {

--- a/tests/catscompany-relay-model-bootstrap.test.ts
+++ b/tests/catscompany-relay-model-bootstrap.test.ts
@@ -7,6 +7,52 @@ import {
 } from '../src/catscompany/relay-model-bootstrap';
 
 describe('CatsCo default relay model bootstrap', () => {
+  test('materializes GLM 5.3 Flash from the cloud catalog with max reasoning', async () => {
+    const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(String(input));
+      if (url.pathname === '/api/relay/config') {
+        return Response.json({
+          base_url: 'https://relay.example.test',
+          self_service_enabled: true,
+          endpoints: [{ protocol: 'Anthropic-compatible', base_url: 'https://relay.example.test/anthropic' }],
+          models: [{ id: 'glm-5.3-flash', enabled: true }],
+        });
+      }
+      if (url.pathname === '/api/relay/key' && init?.method === 'GET') {
+        return Response.json({ key: { key: 'sk-glm-test-key', state: 'active' } });
+      }
+      if (url.pathname === '/v1/models') {
+        return Response.json({ data: [{
+          id: 'glm-5.3-flash',
+          capabilities: { vision: true, tool_calling: true, streaming: true },
+        }] });
+      }
+      return new Response(JSON.stringify({ error: 'unexpected request' }), { status: 500 });
+    }) as typeof fetch;
+
+    const runtime = await provisionCatsRelayCatalogRuntime({
+      botId: 'bot-glm',
+      modelId: 'glm-5.3-flash',
+      reasoningEffort: 'max',
+      auth: {
+        token: 'user-token',
+        uid: 'user-1',
+        displayName: 'Alice',
+        httpBaseUrl: 'https://cats.example.test',
+        serverUrl: 'wss://cats.example.test/v0/channels',
+      },
+      fetchImpl,
+    });
+
+    assert.equal(runtime.modelId, 'glm-5.3-flash');
+    assert.equal(runtime.model, 'glm-5.3-flash');
+    assert.equal(runtime.provider, 'anthropic');
+    assert.equal(runtime.apiBase, 'https://relay.example.test/anthropic');
+    assert.equal(runtime.reasoningEffort, 'max');
+    assert.equal(runtime.contextWindowTokens, 1_000_000);
+    assert.deepStrictEqual(runtime.capabilities, { vision: true, toolCalling: true, streaming: true });
+  });
+
   test('materializes MiniMax M3 and creates a relay key for a fresh device', async () => {
     const requests: Array<{ path: string; method?: string }> = [];
     const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {

--- a/tests/cloud-bot-model-client.test.ts
+++ b/tests/cloud-bot-model-client.test.ts
@@ -53,6 +53,37 @@ describe('cloud bot model client local handoff', () => {
     });
   });
 
+  test('reads non-secret runtime metadata for a cloud-added catalog model', async () => {
+    const snapshot = await pullCloudBotDefinition({
+      botId: '43',
+      auth,
+      fetchImpl: (async () => Response.json({
+        uid: 43,
+        configured: true,
+        revision: 8,
+        definition: {
+          schema: 'xiaoba.bot-definition.v1',
+          botId: '43',
+          model: {
+            kind: 'catalog',
+            modelId: 'new-model-2026',
+            catalogRuntime: {
+              model: 'new-model-2026',
+              provider: 'anthropic',
+              contextWindowTokens: 128000,
+              capabilities: { vision: false, toolCalling: true, streaming: true },
+            },
+          },
+        },
+      })) as typeof fetch,
+    });
+
+    assert.equal(snapshot?.definition?.model.kind, 'catalog');
+    if (snapshot?.definition?.model.kind !== 'catalog') throw new Error('expected catalog model');
+    assert.equal(snapshot.definition.model.catalogRuntime?.model, 'new-model-2026');
+    assert.equal(snapshot.definition.model.catalogRuntime?.provider, 'anthropic');
+  });
+
   test('restores a cloud custom model and preserves custom prompt text exactly', async () => {
     const snapshot = await pullCloudBotDefinition({
       botId: '43',

--- a/tests/model-capabilities.test.ts
+++ b/tests/model-capabilities.test.ts
@@ -62,6 +62,7 @@ describe('model capabilities', () => {
         { model: 'MiniMax-M2.7', provider: 'anthropic', vision: false, context: 204_800 },
         { model: 'MiniMax-M3', provider: 'anthropic', vision: true, context: 1_000_000 },
         { model: 'deepseek-v4-flash', provider: 'anthropic', vision: true, context: 1_000_000 },
+        { model: 'glm-5.3-flash', provider: 'anthropic', vision: true, context: 1_000_000 },
         { model: 'gpt-5.6-terra', provider: 'openai', vision: true, context: 256_000 },
         { model: 'gpt-5.6-sol', provider: 'openai', vision: true, context: 256_000 },
         { model: 'gpt-5.6-luna', provider: 'openai', vision: true, context: 256_000 },
@@ -70,6 +71,12 @@ describe('model capabilities', () => {
     assert.strictEqual(findRelayModelProfile('minimax-m3')?.capabilities.vision, true);
     assert.strictEqual(findRelayModelProfile('MiniMax-M2.7')?.capabilities.vision, false);
     assert.strictEqual(findRelayModelProfile('gpt-5.6-terra')?.openaiApiMode, 'responses');
+    assert.strictEqual(findRelayModelProfile('GLM-5.3-FLASH')?.family, 'glm');
+    assert.deepStrictEqual(findRelayModelProfile('glm-5.3-flash')?.capabilities, {
+      toolCalling: true,
+      vision: true,
+      streaming: true,
+    });
   });
 
   test('keeps relay tool calling enabled for public MiniMax and DeepSeek models', () => {


### PR DESCRIPTION
## What changed\n- consume non-secret catalogRuntime metadata from CatsCompany BotDefinition\n- dynamically materialize new catalog models without adding a XiaoBa profile per model\n- retain static profiles only as offline/backward-compatible fallback\n- validate provider, model identity, context window and capabilities before use\n- keep Relay endpoint and credentials device-local\n- add real-account web acceptance and cleanup rule to AGENTS.md\n\n## Verification\n- npm run build\n- npx tsx --test tests/model-capabilities.test.ts tests/catscompany-relay-model-bootstrap.test.ts tests/cloud-bot-model-client.test.ts tests/anthropic-provider-runtime-feedback.test.ts\n- CI: Build/runtime, SkillHub, cross-repo smoke/e2e, paired contract tests all pass\n\nRequires CatsCompany PR #344 for cloud metadata publication.