### PR TITLE
test(bot-skills): remove wall-clock retry flake

### DIFF
--- a/tests/bot-skills-sync.test.ts
+++ b/tests/bot-skills-sync.test.ts
@@ -1212,11 +1212,21 @@ describe('Bot Skill Local/Base/Cloud sync', () => {
     fixture.cloud = { revision: 1, skills: [reference] };
     fixture.publicDownloadMisses = 1;
 
+    const sleepDelays: number[] = [];
     const ready = await fixture.finalize({
       localSkillId: target.localSkillId,
       skillName: target.name,
       reference,
-    }, { publicationWaitMs: 100, pollDelayMs: 25 });
+    }, {
+      publicationWaitMs: 1_000,
+      pollDelayMs: 25,
+      // The retry contract is about observing a later package, not whether a
+      // loaded CI worker schedules a 25 ms timer before a 100 ms wall-clock deadline.
+      sleep: async delayMs => { sleepDelays.push(delayMs); },
+    });
+    assert.deepEqual(sleepDelays, [25]);
+    assert.ok(fixture.packageDownloads >= 2);
+    assert.equal(fixture.publicDownloadMisses, 0);
     assert.equal(ready.direction, 'local_to_cloud');
     assert.deepEqual(readBotSkillLocalMarker(target.path)?.reference, reference);
 
@@ -2309,6 +2319,7 @@ function createFixture(
       validateScope?: () => Promise<void> | void;
       publicationWaitMs?: number;
       pollDelayMs?: number;
+      sleep?: (delayMs: number) => Promise<void>;
     } = {}) => new BotSkillSyncService({
       runtimeRoot,
       skillsRoot,


### PR DESCRIPTION
## Summary

- remove the wall-clock race from the delayed public package retry test
- inject a deterministic sleep function for the successful retry path
- keep the real timeout path covered by the existing timeout scenario
- assert that a retry occurred and the public package became available

## Root cause

The test used a 100 ms publication deadline and a real 25 ms timer to model:

1. first package download returns 404
2. wait 25 ms
3. second download succeeds

Under the full runtime test load, request and timer scheduling could exceed the
100 ms wall-clock deadline before the second attempt. The production code then
correctly returned `PUBLIC_SKILL_NOT_READY`, making the test flaky.

This was a test timing issue, not a production BotSkill sync race.

## Testing

- targeted delayed-package test repeated 50 times: 50/50 passed
- full `bot-skills-sync.test.ts` repeated 10 times: 57/57 passed on every run
- build passed
- the full runtime suite no longer reports the BotSkill sync failure

The remaining worker-image failures are unrelated Windows/WSL temporary-path
environment issues.