### PR TITLE
fix(catsco): dedupe recovered Artifact task delivery

### DIFF
--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -159,6 +159,8 @@ const NATIVE_FEISHU_CONTEXT_PAGE_SIZE = 100;
 const BACKGROUND_SUBAGENT_COMPLETION_MAX_ITEMS = 6;
 const DEVICE_REGISTRATION_REFRESH_MS = 120_000;
 const DEVICE_RPC_DEFAULT_TTL_MS = 60_000;
+const ARTIFACT_TASK_RECEIPT_TTL_MS = 24 * 60 * 60 * 1_000;
+const ARTIFACT_TASK_RECEIPT_MAX_ENTRIES = 4_096;
 const HIDDEN_CATS_TOOL_PROGRESS = new Set([
   'send_text',
   'send_file',
@@ -440,6 +442,8 @@ export class CatsCompanyBot {
   private taskStatusTasks = new Map<string, Promise<void>>();
   /** Tracks the visible user turn for cancellation and retry handling. */
   private activeConversationTasks = new Map<string, ActiveConversationTask>();
+  /** Bounds one-shot Artifact task receipts so server recovery can safely replay a turn. */
+  private artifactTaskReceipts = new Map<string, number>();
   /** Covers message parsing, cloud restore, attachment download, commands, and the model turn. */
   private activeMessageHandlers = 0;
   /** Invalidates queued or in-flight pre-turn hydration after /clear. */
@@ -1440,6 +1444,11 @@ export class CatsCompanyBot {
     const msg = this.parseMessage(ctx);
     if (!msg) return;
 
+    if (!this.acceptArtifactTaskReceipt(msg.artifactTaskRef)) {
+      Logger.info(`[CatsCompany] 忽略重复 Artifact task 投递: topic=${msg.topic}, seq=${msg.seq || 0}`);
+      return;
+    }
+
     const key = msg.envelope.sessionKey;
 
     this.activeMessageHandlers += 1;
@@ -1448,6 +1457,25 @@ export class CatsCompanyBot {
     } finally {
       this.activeMessageHandlers = Math.max(0, this.activeMessageHandlers - 1);
     }
+  }
+
+  private acceptArtifactTaskReceipt(taskRef?: string, now = Date.now()): boolean {
+    if (!taskRef) return true;
+    const receipts = this.artifactTaskReceipts ??= new Map<string, number>();
+    const receivedAt = receipts.get(taskRef);
+    if (receivedAt !== undefined && now - receivedAt < ARTIFACT_TASK_RECEIPT_TTL_MS) {
+      return false;
+    }
+    for (const [ref, seenAt] of receipts) {
+      if (now - seenAt >= ARTIFACT_TASK_RECEIPT_TTL_MS) receipts.delete(ref);
+    }
+    receipts.set(taskRef, now);
+    while (receipts.size > ARTIFACT_TASK_RECEIPT_MAX_ENTRIES) {
+      const oldest = receipts.keys().next().value as string | undefined;
+      if (!oldest) break;
+      receipts.delete(oldest);
+    }
+    return true;
   }
 
   private registerSubAgentPlatformCallbacks(

--- a/tests/catscompany-execution-scope-flow.test.ts
+++ b/tests/catscompany-execution-scope-flow.test.ts
@@ -1283,6 +1283,65 @@ describe('CatsCompany execution scope flow', () => {
     assert.doesNotMatch(JSON.stringify(handledTurns[0].userMessage), /atr_[A-Za-z0-9_-]{43}/);
   });
 
+  test('executes a replayed Artifact task ref only once', async () => {
+    const { bot, handledTurns } = createHarness();
+    const ref = `atr_${'r'.repeat(43)}`;
+    const message = {
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      text: '来自「项目风险台账」：分析选中的风险',
+      content: '来自「项目风险台账」：分析选中的风险',
+      metadata: {
+        ...canonicalMetadata('usr7', 'p2p_7_43'),
+        artifact_task_ref: ref,
+      },
+      isGroup: false,
+      seq: 12,
+    };
+
+    await (bot as any).onMessage(message);
+    await (bot as any).onMessage({ ...message, seq: 12 });
+
+    assert.equal(handledTurns.length, 1);
+    assert.equal(handledTurns[0].options.artifactTaskRef, ref);
+  });
+
+  test('deduplicates an Artifact task replay while its first turn is still running', async () => {
+    const harness = createHarness();
+    const ref = `atr_${'s'.repeat(43)}`;
+    let releaseTurn!: () => void;
+    let turnStarted!: () => void;
+    const turnStartedPromise = new Promise<void>(resolve => { turnStarted = resolve; });
+    const turnGate = new Promise<void>(resolve => { releaseTurn = resolve; });
+    harness.session.handleMessage = async (userMessage: unknown, options: any) => {
+      harness.handledTurns.push({ userMessage, options });
+      turnStarted();
+      await turnGate;
+      return { visibleToUser: false, text: '' };
+    };
+    const message = {
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      text: '来自「项目风险台账」：分析选中的风险',
+      content: '来自「项目风险台账」：分析选中的风险',
+      metadata: {
+        ...canonicalMetadata('usr7', 'p2p_7_43'),
+        artifact_task_ref: ref,
+      },
+      isGroup: false,
+      seq: 12,
+    };
+
+    const first = (harness.bot as any).onMessage(message);
+    await turnStartedPromise;
+    await (harness.bot as any).onMessage({ ...message, seq: 12 });
+    assert.equal(harness.handledTurns.length, 1);
+
+    releaseTurn();
+    await first;
+    assert.equal(harness.handledTurns.length, 1);
+  });
+
   test('keeps ordinary queued input out of an active Artifact task turn', async () => {
     const harness = createHarness();
     const taskRef = `atr_${'u'.repeat(43)}`;


### PR DESCRIPTION
## What changed
- deduplicate trusted Artifact task replays by `artifact_task_ref` before starting or queueing a model turn
- keep the receipt ledger bounded (24h TTL, 4096 entries)
- cover sequential and in-flight replay cases

## Why
CatsCompany Runtime 0.2 can recover an expired delivery claim by replaying the same persisted message after a server crash. If the original message had already reached the Agent before CatsCompany crashed, the replay must not start a second execution.

This is intentionally scoped to server-canonical Artifact task messages; ordinary CatsCo messages are unchanged.

## Tests
- `node --import tsx --test tests/catscompany-execution-scope-flow.test.ts` (43/43 passed)
- five CatsCompany-facing suites (127/127 passed)
- TypeScript `tsc --noEmit` passed
- full runtime suite reached 1680 passes; its unrelated Tianyi worker-image shell-path test fails on this Windows runner because `/bin/bash` cannot resolve the generated temp path. The failing test and package inputs are unchanged from the base commit.

## Dependency
Paired with buildsense-ai/cats-company#369, which performs the recovered replay and converges the persistent Run to delivered.