### PR TITLE
fix(runtime): enable log upload by default

### DIFF
--- a/src/runtime/runtime-profile.ts
+++ b/src/runtime/runtime-profile.ts
@@ -42,6 +42,7 @@ export interface RuntimeProfile {
 export const DEFAULT_RUNTIME_TOOL_NAMES = [...DEFAULT_TOOL_NAMES];
 const DEFAULT_RUNTIME_TOOL_NAME_SET = new Set<string>(DEFAULT_RUNTIME_TOOL_NAMES);
 const LEGACY_DISABLED_RUNTIME_TOOL_NAME_SET = new Set<string>(['prompt_mode']);
+const DEFAULT_RUNTIME_UPLOAD_ENABLED = true;
 
 export interface RuntimeProfileValidationIssue {
   path: string;
@@ -89,7 +90,7 @@ export function resolveDefaultRuntimeProfile(
     },
     logging: {
       sessionEvents: options.logging?.sessionEvents ?? true,
-      uploadEnabled: options.logging?.uploadEnabled,
+      uploadEnabled: options.logging?.uploadEnabled ?? DEFAULT_RUNTIME_UPLOAD_ENABLED,
     },
   };
 }

--- a/tests/dashboard-runtime-config.test.ts
+++ b/tests/dashboard-runtime-config.test.ts
@@ -90,6 +90,7 @@ describe('dashboard runtime config snapshot', () => {
       snapshot.tools.enabled.find(tool => tool.name === 'send_text')?.transcriptMode,
       'outbound_message',
     );
+    assert.equal(snapshot.logging.upload.enabled, true);
     assert.equal(
       snapshot.tools.enabled.find(tool => tool.name === 'send_file')?.transcriptMode,
       'outbound_file',

--- a/tests/runtime-profile.test.ts
+++ b/tests/runtime-profile.test.ts
@@ -48,6 +48,7 @@ describe('RuntimeProfile', () => {
     assert.deepStrictEqual(profile.tools.enabled, getCurrentToolManagerNames());
     assert.equal(profile.skills.enabled, true);
     assert.equal(profile.logging.sessionEvents, true);
+    assert.equal(profile.logging.uploadEnabled, true);
   });
 
   test('uses runtime identity and surface from env without mutating process env', () => {


### PR DESCRIPTION
## Summary
- enable log upload in the default runtime profile
- keep explicit runtime profile overrides intact
- cover the default in RuntimeProfile and dashboard snapshot tests

## Validation
- `pnpm exec tsx --test tests/runtime-profile.test.ts tests/dashboard-runtime-config.test.ts`
- `pnpm build`