### PR TITLE
fix(checkpoint): stop repeated retries after terminal failure

### DIFF
--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -64,6 +64,7 @@ import {
 import { collectRemoteContextWatermarks } from './remote-context-watermarks';
 import {
   CheckpointCompactionCoordinator,
+  CheckpointPersistenceError,
   type CheckpointCompactionPhase,
   isCheckpointCompactionEnabled,
 } from './checkpoint-compaction';
@@ -88,7 +89,7 @@ export const MODEL_RECOVERY_FAILED_MESSAGE = '模型服务暂时不稳定，系�
 export const MODEL_REQUEST_FAILED_MESSAGE = '模型服务暂时不稳定，本次处理未能完成，请稍后继续。';
 export const CONTEXT_COMPACTION_START_MESSAGE = '正在压缩上下文，整理较早的对话内容。';
 export const CONTEXT_COMPACTION_COMPLETE_MESSAGE = '上下文压缩完成，继续处理当前请求。';
-export const CONTEXT_COMPACTION_ERROR_MESSAGE = '上下文压缩失败，已保留原上下文继续处理。';
+export const CONTEXT_COMPACTION_ERROR_MESSAGE = '上下文压缩失败，已保留原上下文并安全停止本轮。';
 
 // ─── 接口定义 ───────────────────────────────────────────
 
@@ -430,8 +431,9 @@ export class AgentSession {
         if (this.persistCheckpoint(compactionResult.messages)) {
           this.messages = compactionResult.messages;
         } else {
-          Logger.warning(`[会话 ${this.key}] 恢复检查点持久化失败，保留原始上下文`);
+          Logger.error(`[会话 ${this.key}] 恢复检查点持久化失败，停止初始化以保留原始上下文`);
           this.messages = messagesBeforeRestoreCompaction;
+          throw new CheckpointPersistenceError();
         }
       } else {
         this.messages = compactionResult.messages;
@@ -682,8 +684,9 @@ export class AgentSession {
           if (this.persistCheckpoint(compactionResult.messages)) {
             this.messages = compactionResult.messages;
           } else {
-            Logger.warning(`[会话 ${this.key}] 处理前检查点持久化失败，保留原始上下文`);
+            Logger.error(`[会话 ${this.key}] 处理前检查点持久化失败，停止本轮以保留原始上下文`);
             this.messages = messagesBeforeCompaction;
+            throw new CheckpointPersistenceError();
           }
         } else {
           this.messages = compactionResult.messages;

--- a/src/core/checkpoint-compaction.ts
+++ b/src/core/checkpoint-compaction.ts
@@ -63,6 +63,23 @@ export interface CheckpointCompactionResult {
   usagePercent: number;
 }
 
+export class CheckpointPersistenceError extends Error {
+  constructor(cause?: unknown) {
+    super('Continuation checkpoint could not be persisted; the current turn was stopped before another model request.');
+    this.name = 'CheckpointPersistenceError';
+    if (cause === undefined) return;
+    try {
+      Object.defineProperty(this, 'cause', {
+        value: cause,
+        configurable: true,
+        enumerable: false,
+      });
+    } catch {
+      // The stable error message is sufficient on runtimes without Error.cause.
+    }
+  }
+}
+
 export function isCheckpointCompactionEnabled(
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
@@ -200,7 +217,12 @@ export class CheckpointCompactionCoordinator {
         `[${request.sessionKey}] checkpoint compaction failed `
         + `phase=${request.phase}: ${describeError(error)}`,
       );
-      return { messages, compacted: false, ...usage };
+      // AIService owns the bounded provider retry policy for this checkpoint
+      // request. Once that policy is exhausted, returning the unchanged
+      // transcript would let the runner execute another tool and create a new
+      // checkpoint request with a fresh retry budget. Propagate the terminal
+      // failure instead so the current episode stops at this safe boundary.
+      throw error;
     }
   }
 

--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -8,7 +8,10 @@ import { Logger } from '../utils/logger';
 import { isRateLimitErrorCode } from '../utils/rate-limit-error';
 import { Metrics } from '../utils/metrics';
 import { ContextCompressor } from './context-compressor';
-import type { CheckpointCompactionCoordinator } from './checkpoint-compaction';
+import {
+  CheckpointPersistenceError,
+  type CheckpointCompactionCoordinator,
+} from './checkpoint-compaction';
 import { estimateMessagesTokens, estimateToolsTokens } from './token-estimator';
 import {
   buildExplicitPlanRequestHintIfUseful,
@@ -817,7 +820,7 @@ export class ConversationRunner {
           } else if (event.status === 'complete') {
             await callbacks.onThinking?.('Continuation checkpoint created. Preparing to resume the same task.');
           } else {
-            await callbacks.onThinking?.('Checkpoint creation failed. Continuing with the original context.');
+            await callbacks.onThinking?.('Checkpoint creation failed. Stopping this turn with the original context preserved.');
           }
         }
         : undefined,
@@ -827,11 +830,11 @@ export class ConversationRunner {
     try {
       await this.onCompactionCheckpoint?.(result.messages);
     } catch (error) {
-      Logger.warning(
+      Logger.error(
         `[${this.sessionLabel}Turn ${turns}] continuation checkpoint persistence failed; `
-        + `keeping original transcript: ${error instanceof Error ? error.message : String(error)}`,
+        + `stopping before another model turn: ${error instanceof Error ? error.message : String(error)}`,
       );
-      return;
+      throw new CheckpointPersistenceError(error);
     }
 
     messages.splice(0, messages.length, ...result.messages);

--- a/tests/checkpoint-compaction.test.ts
+++ b/tests/checkpoint-compaction.test.ts
@@ -166,10 +166,14 @@ test('restore checkpoint explicitly marks runtime state for re-verification', as
   assert.match(prompt, /processes, ports, files, devices/i);
 });
 
-test('checkpoint failure preserves the original transcript for emergency fallback', async () => {
+test('checkpoint failure preserves the transcript and propagates after provider retries are exhausted', async () => {
+  const providerError = Object.assign(
+    new Error('API错误 (502): Responses API stream ended without a terminal response'),
+    { status: 502 },
+  );
   const service = {
     chatStream: async () => {
-      throw new Error('provider unavailable');
+      throw providerError;
     },
   } as any;
   const coordinator = new CheckpointCompactionCoordinator(service, {
@@ -180,14 +184,19 @@ test('checkpoint failure preserves the original transcript for emergency fallbac
     { role: 'user', content: largeText('must not be lost') },
   ];
 
-  const result = await coordinator.compactIfNeeded(messages, {
-    sessionKey: 'failure-session',
-    phase: 'pre_turn',
-  });
+  const statuses: string[] = [];
+  await assert.rejects(
+    coordinator.compactIfNeeded(messages, {
+      sessionKey: 'failure-session',
+      phase: 'pre_turn',
+      onStatus: event => { statuses.push(event.status); },
+    }),
+    error => error === providerError,
+  );
 
-  assert.equal(result.compacted, false);
-  assert.equal(result.messages, messages);
-  assert.equal(result.messages[0].content, messages[0].content);
+  assert.deepEqual(statuses, ['start', 'error']);
+  assert.equal(messages.length, 1);
+  assert.match(String(messages[0].content), /must not be lost/);
 });
 
 test('checkpoint prompt distinguishes pre-turn, mid-turn, and restored history', () => {

--- a/tests/conversation-runner-checkpoint-compaction.test.ts
+++ b/tests/conversation-runner-checkpoint-compaction.test.ts
@@ -117,7 +117,7 @@ test('runner checkpoints only after a complete tool result and resumes the same 
   assert.equal(JSON.stringify(modelRequests).includes(legacyArtifactSentinel), false);
 });
 
-test('runner keeps the original transcript when checkpoint persistence fails', async () => {
+test('runner stops before another model request when checkpoint persistence fails', async () => {
   const modelRequests: Message[][] = [];
   const aiService = {
     chat: async (messages: Message[]) => {
@@ -175,14 +175,81 @@ test('runner keeps the original transcript when checkpoint persistence fails', a
     },
   });
 
-  const result = await runner.run([{
-    role: 'user',
-    content: 'inspect and continue',
-    __episodeId: 'episode-main',
-  }]);
+  await assert.rejects(
+    runner.run([{
+      role: 'user',
+      content: 'inspect and continue',
+      __episodeId: 'episode-main',
+    }]),
+    error => error instanceof Error && error.name === 'CheckpointPersistenceError',
+  );
 
-  assert.equal(result.response, 'continued with original transcript');
-  assert.ok(modelRequests[1].some(message =>
-    message.role === 'tool' && message.content === 'verified tool evidence'));
-  assert.equal(modelRequests[1].some(message => message.__checkpointSummary), false);
+  assert.equal(modelRequests.length, 1);
+});
+
+test('runner does not create a fresh checkpoint retry budget after a terminal 502', async () => {
+  let modelRequests = 0;
+  let toolExecutions = 0;
+  let checkpointRequests = 0;
+  const aiService = {
+    chat: async () => {
+      modelRequests++;
+      return {
+        content: null,
+        toolCalls: [{
+          id: `call-${modelRequests}`,
+          type: 'function',
+          function: { name: 'inspect', arguments: '{}' },
+        }],
+        usage,
+      };
+    },
+  } as any;
+  const tool: ToolDefinition = {
+    name: 'inspect',
+    description: 'inspect',
+    parameters: { type: 'object', properties: {} },
+  };
+  const executor: ToolExecutor = {
+    getToolDefinitions: () => [tool],
+    executeTool: async (call: ToolCall): Promise<ToolResult> => {
+      toolExecutions++;
+      return {
+        role: 'tool',
+        tool_call_id: call.id,
+        name: call.function.name,
+        content: 'verified tool evidence',
+        ok: true,
+      };
+    },
+  };
+  const terminalError = Object.assign(
+    new Error('API错误 (502): Responses API stream ended without a terminal response'),
+    { status: 502 },
+  );
+  const coordinator = {
+    compactIfNeeded: async () => {
+      checkpointRequests++;
+      throw terminalError;
+    },
+  } as any;
+  const runner = new ConversationRunner(aiService, executor, {
+    stream: false,
+    episodeId: 'episode-502',
+    checkpointCompactionCoordinator: coordinator,
+    onCompactionCheckpoint: async () => undefined,
+  });
+
+  await assert.rejects(
+    runner.run([{
+      role: 'user',
+      content: 'inspect repeatedly',
+      __episodeId: 'episode-502',
+    }]),
+    error => error === terminalError,
+  );
+
+  assert.equal(modelRequests, 1);
+  assert.equal(toolExecutions, 1);
+  assert.equal(checkpointRequests, 1);
 });


### PR DESCRIPTION
## Problem

The blocking continuation checkpoint can exhaust its bounded provider retries (for example, a terminal Responses API 502), return the unchanged transcript, and let the main agent continue to another tool boundary. That next boundary creates a fresh checkpoint request with a fresh retry budget, so one episode can show repeated `Context is full` / checkpoint failures.

This is the old synchronous checkpoint path introduced by #272. It is independent of the unmerged asynchronous Branch Summary work in #418.

## Fix

- Preserve the original transcript but propagate a terminal checkpoint failure after `AIService` exhausts its existing bounded retry policy.
- Stop the current turn before another main-model or tool iteration can reopen the checkpoint retry budget.
- Treat checkpoint persistence failure as terminal for the turn instead of continuing from an unpersisted summary.
- Update visible status text to state that the current turn stopped safely.

No new retry loop is added. `AIService` remains the single owner of bounded transport retries.

## Regression evidence

The terminal-502 regression asserts exactly:

- main model requests: 1
- tool executions: 1
- checkpoint requests: 1
- no next-tool re-entry

## Verification

- `npm run build` — passed
- targeted checkpoint tests — 12 passed
- lifecycle + 256K checkpoint scenarios — 51 passed
- `npm run release:check` — passed
- `npm run test:skillhub-phase1` — 273 passed, 3 skipped
- `npm test` — 1682 passed, 20 skipped; one unrelated Windows-host failure because WSL `/bin/bash` is unavailable in `worker-image-pipeline.test.ts`