### PR TITLE
fix(checkpoint): recover stalled summary streams

### DIFF
--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -88,8 +88,10 @@ export const EMPTY_MODEL_RESPONSE_MESSAGE = '模型本轮未返回有效内容�
 export const MODEL_RECOVERY_FAILED_MESSAGE = '模型服务暂时不稳定，系统已尝试自动恢复但仍未成功，请稍后继续。';
 export const MODEL_REQUEST_FAILED_MESSAGE = '模型服务暂时不稳定，本次处理未能完成，请稍后继续。';
 export const CONTEXT_COMPACTION_START_MESSAGE = '正在压缩上下文，整理较早的对话内容。';
-export const CONTEXT_COMPACTION_COMPLETE_MESSAGE = '上下文压缩完成，继续处理当前请求。';
+export const CONTEXT_COMPACTION_GENERATED_MESSAGE = '上下文摘要已生成，正在保存检查点。';
+export const CONTEXT_COMPACTION_COMPLETE_MESSAGE = '检查点已保存，继续处理当前请求。';
 export const CONTEXT_COMPACTION_ERROR_MESSAGE = '上下文压缩失败，已保留原上下文并安全停止本轮。';
+export const LEGACY_CONTEXT_COMPACTION_ERROR_MESSAGE = '上下文压缩失败，已保留原上下文继续处理。';
 
 // ─── 接口定义 ───────────────────────────────────────────
 
@@ -430,9 +432,11 @@ export class AgentSession {
       if (compactionResult.compacted) {
         if (this.persistCheckpoint(compactionResult.messages)) {
           this.messages = compactionResult.messages;
+          await this.notifyContextCompaction(options.callbacks, CONTEXT_COMPACTION_COMPLETE_MESSAGE);
         } else {
           Logger.error(`[会话 ${this.key}] 恢复检查点持久化失败，停止初始化以保留原始上下文`);
           this.messages = messagesBeforeRestoreCompaction;
+          await this.notifyContextCompaction(options.callbacks, CONTEXT_COMPACTION_ERROR_MESSAGE);
           throw new CheckpointPersistenceError();
         }
       } else {
@@ -683,9 +687,11 @@ export class AgentSession {
         if (compactionResult.compacted) {
           if (this.persistCheckpoint(compactionResult.messages)) {
             this.messages = compactionResult.messages;
+            await this.notifyContextCompaction(callbacks, CONTEXT_COMPACTION_COMPLETE_MESSAGE);
           } else {
             Logger.error(`[会话 ${this.key}] 处理前检查点持久化失败，停止本轮以保留原始上下文`);
             this.messages = messagesBeforeCompaction;
+            await this.notifyContextCompaction(callbacks, CONTEXT_COMPACTION_ERROR_MESSAGE);
             throw new CheckpointPersistenceError();
           }
         } else {
@@ -1123,7 +1129,7 @@ export class AgentSession {
         sessionKey: this.key,
         reason,
         signal,
-        onStatus: this.createContextCompactionNotifier(callbacks),
+        onStatus: this.createContextCompactionNotifier(callbacks, false),
       });
       return {
         messages: compactedMessages,
@@ -1135,7 +1141,7 @@ export class AgentSession {
       phase,
       toolTokens: this.getToolDefinitionTokens(),
       signal,
-      onStatus: this.createContextCompactionNotifier(callbacks),
+      onStatus: this.createContextCompactionNotifier(callbacks, true),
     });
   }
 
@@ -1150,33 +1156,47 @@ export class AgentSession {
     return this.lifecycleManager.saveContext(durable);
   }
 
-  private createContextCompactionNotifier(callbacks?: SessionCallbacks): ((event: {
+  private createContextCompactionNotifier(
+    callbacks: SessionCallbacks | undefined,
+    stopsOnError: boolean,
+  ): ((event: {
     status: 'start' | 'complete' | 'error';
   }) => Promise<void>) | undefined {
     if (!callbacks?.onThinking) return undefined;
     return async (event) => {
-      const message = this.formatContextCompactionStatus(event);
+      const message = this.formatContextCompactionStatus(event, stopsOnError);
       if (!message) return;
-      try {
-        await callbacks.onThinking?.(message);
-      } catch (err) {
-        Logger.warning(`[会话 ${this.key}] 上下文压缩提示发送失败: ${err}`);
-      }
+      await this.notifyContextCompaction(callbacks, message);
     };
   }
 
   private formatContextCompactionStatus(event: {
     status: 'start' | 'complete' | 'error';
-  }): string {
+  }, stopsOnError: boolean): string {
     switch (event.status) {
       case 'start':
         return CONTEXT_COMPACTION_START_MESSAGE;
       case 'complete':
-        return CONTEXT_COMPACTION_COMPLETE_MESSAGE;
+        return stopsOnError
+          ? CONTEXT_COMPACTION_GENERATED_MESSAGE
+          : CONTEXT_COMPACTION_COMPLETE_MESSAGE;
       case 'error':
-        return CONTEXT_COMPACTION_ERROR_MESSAGE;
+        return stopsOnError
+          ? CONTEXT_COMPACTION_ERROR_MESSAGE
+          : LEGACY_CONTEXT_COMPACTION_ERROR_MESSAGE;
       default:
         return '';
+    }
+  }
+
+  private async notifyContextCompaction(
+    callbacks: SessionCallbacks | undefined,
+    message: string,
+  ): Promise<void> {
+    try {
+      await callbacks?.onThinking?.(message);
+    } catch (err) {
+      Logger.warning(`[会话 ${this.key}] 上下文压缩提示发送失败: ${err}`);
     }
   }
 

--- a/src/core/checkpoint-compaction.ts
+++ b/src/core/checkpoint-compaction.ts
@@ -19,6 +19,7 @@ const MIN_RETAINED_USER_TOKEN_BUDGET = 8_000;
 const MAX_RETAINED_USER_TOKEN_BUDGET = 32_000;
 const RETAINED_USER_CONTEXT_RATIO = 0.15;
 const MAX_CONTEXT_RETRY_ATTEMPTS = 6;
+const CHECKPOINT_STREAM_IDLE_TIMEOUT_MS = 120_000;
 const MAX_SUMMARY_TOOL_RESULT_CHARS = 24_000;
 const SUMMARY_TOOL_RESULT_HEAD_CHARS = 16_000;
 const SUMMARY_TOOL_RESULT_TAIL_CHARS = 4_000;
@@ -306,6 +307,8 @@ export class CheckpointCompactionCoordinator {
           { onText: text => { streamed += text; } },
           {
             signal,
+            retryProfile: 'checkpoint_summary',
+            streamIdleTimeoutMs: CHECKPOINT_STREAM_IDLE_TIMEOUT_MS,
             streamOutputMode: 'buffered',
             promptCacheContext: {
               sessionKey,

--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -818,7 +818,7 @@ export class ConversationRunner {
           if (event.status === 'start') {
             await callbacks.onThinking?.('Context is full. Creating a continuation checkpoint.');
           } else if (event.status === 'complete') {
-            await callbacks.onThinking?.('Continuation checkpoint created. Preparing to resume the same task.');
+            await callbacks.onThinking?.('Continuation summary generated. Saving the checkpoint.');
           } else {
             await callbacks.onThinking?.('Checkpoint creation failed. Stopping this turn with the original context preserved.');
           }
@@ -834,11 +834,21 @@ export class ConversationRunner {
         `[${this.sessionLabel}Turn ${turns}] continuation checkpoint persistence failed; `
         + `stopping before another model turn: ${error instanceof Error ? error.message : String(error)}`,
       );
+      try {
+        await callbacks?.onThinking?.('Checkpoint could not be saved. Stopping this turn with the original context preserved.');
+      } catch {
+        // Thinking callbacks are observational and must not replace the persistence error.
+      }
       throw new CheckpointPersistenceError(error);
     }
 
     messages.splice(0, messages.length, ...result.messages);
     this.refreshRuntimeContextForPendingInput(messages);
+    try {
+      await callbacks?.onThinking?.('Continuation checkpoint saved. Continuing the same task.');
+    } catch {
+      // Thinking callbacks are best-effort after durable persistence.
+    }
     Logger.info(
       `[${this.sessionLabel}Turn ${turns}] durable mid-turn checkpoint persisted; continuing same episode`,
     );

--- a/src/providers/openai-provider.ts
+++ b/src/providers/openai-provider.ts
@@ -27,6 +27,7 @@ const MAX_PROVIDER_ERROR_BODY_BYTES = 64 * 1024;
 const PROVIDER_ERROR_BODY_READ_TIMEOUT_MS = 2_000;
 const DEFAULT_RESPONSES_HEADERS_TIMEOUT_MS = 120_000;
 const MAX_RESPONSES_HEADERS_TIMEOUT_MS = 10 * 60 * 1000;
+const MAX_RESPONSES_STREAM_IDLE_TIMEOUT_MS = 10 * 60 * 1000;
 
 type ResponsesFailurePhase = 'headers' | 'stream' | 'terminal_event';
 
@@ -1350,6 +1351,19 @@ export class OpenAIProvider implements AIProvider {
       const decoder = new StringDecoder('utf8');
       let finalResponse: any;
       let settled = false;
+      let idleTimer: NodeJS.Timeout | undefined;
+      const streamIdleTimeoutMs = this.responsesStreamIdleTimeoutMs(options);
+
+      const clearIdleTimer = () => {
+        if (!idleTimer) return;
+        clearTimeout(idleTimer);
+        idleTimer = undefined;
+      };
+
+      const cleanup = () => {
+        clearIdleTimer();
+        options?.signal?.removeEventListener('abort', onAbort);
+      };
 
       const emitVisibleText = (text: string) => {
         if (!text) return;
@@ -1359,13 +1373,13 @@ export class OpenAIProvider implements AIProvider {
 
       const finishError = (error: Error) => {
         if (settled) return;
+        cleanup();
         if (
           !streamedVisibleText
           && !outputItems.some(Boolean)
           && this.shouldRetryWithoutExplicitAnchor(error, body)
         ) {
           settled = true;
-          options?.signal?.removeEventListener('abort', onAbort);
           this.responsesExplicitAnchorSupported = false;
           Logger.warning('Responses stream rejected the explicit S cache anchor; retrying once without it.');
           stream.destroy();
@@ -1377,6 +1391,31 @@ export class OpenAIProvider implements AIProvider {
         reject(error);
       };
       const onAbort = () => stream.destroy(createAbortError());
+
+      const armIdleWatchdog = () => {
+        if (streamIdleTimeoutMs <= 0 || settled) return;
+        clearIdleTimer();
+        idleTimer = setTimeout(() => {
+          if (settled) return;
+          const error = this.responsesStreamError(
+            `Responses API stream produced no data for ${streamIdleTimeoutMs}ms`,
+            {
+              failurePhase: 'stream',
+              terminalEvent: 'stream.idle_timeout',
+              requestId: responseRequestId,
+            },
+          );
+          Object.assign(error, {
+            name: 'ResponsesStreamIdleTimeoutError',
+            code: 'XIAOBA_RESPONSES_STREAM_IDLE_TIMEOUT',
+            providerCode: 'stream_idle_timeout',
+            status: 504,
+          });
+          stream.destroy();
+          finishError(error);
+        }, streamIdleTimeoutMs);
+      };
+
       if (options?.signal?.aborted) onAbort();
       else options?.signal?.addEventListener('abort', onAbort, { once: true });
 
@@ -1416,6 +1455,7 @@ export class OpenAIProvider implements AIProvider {
       };
 
       stream.on('data', (chunk: Buffer) => {
+        armIdleWatchdog();
         buffer += decoder.write(chunk);
         const lines = buffer.split('\n');
         buffer = lines.pop() || '';
@@ -1433,7 +1473,7 @@ export class OpenAIProvider implements AIProvider {
       });
 
       stream.on('end', () => {
-        options?.signal?.removeEventListener('abort', onAbort);
+        cleanup();
         buffer += decoder.end();
         if (settled) return;
         const tail = contentStripper.flush();
@@ -1481,7 +1521,6 @@ export class OpenAIProvider implements AIProvider {
       });
 
       stream.on('error', (error: Error) => {
-        options?.signal?.removeEventListener('abort', onAbort);
         if (isProviderAbortError(error) || options?.signal?.aborted) {
           finishError(error);
           return;
@@ -1514,6 +1553,8 @@ export class OpenAIProvider implements AIProvider {
           error,
         ));
       });
+
+      armIdleWatchdog();
     });
   }
 
@@ -1590,6 +1631,12 @@ export class OpenAIProvider implements AIProvider {
     if (!Number.isFinite(parsed)) return DEFAULT_RESPONSES_HEADERS_TIMEOUT_MS;
     if (parsed <= 0) return 0;
     return Math.min(MAX_RESPONSES_HEADERS_TIMEOUT_MS, Math.max(1, Math.floor(parsed)));
+  }
+
+  private responsesStreamIdleTimeoutMs(options?: AIRequestOptions): number {
+    const value = Number(options?.streamIdleTimeoutMs);
+    if (!Number.isFinite(value) || value <= 0) return 0;
+    return Math.min(MAX_RESPONSES_STREAM_IDLE_TIMEOUT_MS, Math.max(1, Math.floor(value)));
   }
 
   private async normalizeProviderErrorResponse(error: unknown): Promise<unknown> {

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -89,6 +89,10 @@ export interface ModelAttemptSink {
 
 export interface AIRequestOptions {
   signal?: AbortSignal;
+  /** Internal retry contract for requests that must complete before the main Agent can continue. */
+  retryProfile?: 'checkpoint_summary';
+  /** Abort a Responses stream after this many milliseconds without receiving any bytes. */
+  streamIdleTimeoutMs?: number;
   /**
    * Live mode forwards text immediately and disables transparent replay once
    * the caller has observed output. Buffered mode publishes text only after a

--- a/src/utils/ai-service.ts
+++ b/src/utils/ai-service.ts
@@ -56,6 +56,8 @@ const TRANSIENT_PROVIDER_CODES = new Set([
 const RESPONSES_TRANSIENT_MAX_RETRIES = 2;
 const TRANSIENT_HTTP_MAX_RETRIES = 2;
 const GATEWAY_TIMEOUT_MAX_RETRIES = 1;
+const CHECKPOINT_SUMMARY_MAX_RETRIES = 3;
+const CHECKPOINT_SUMMARY_GUARANTEED_RETRIES = 1;
 let modelAttemptCallSequence = 0;
 
 type ProviderKind = 'openai' | 'anthropic';
@@ -159,6 +161,7 @@ export class AIService {
         options.signal,
         undefined,
         this.createModelAttemptRun(prepared.messages, tools, false, options, prepared.summary),
+        options.retryProfile,
       );
     } catch (error: any) {
       throw this.wrapError(error);
@@ -216,6 +219,7 @@ export class AIService {
         options.signal,
         () => allowStreamRetry || (supportsBufferedRecovery ? !hasDeliveredText : !hasObservedText),
         this.createModelAttemptRun(prepared.messages, tools, true, options, prepared.summary),
+        options.retryProfile,
       );
       callbacks?.onComplete?.(result);
       return result;
@@ -468,6 +472,7 @@ export class AIService {
     signal?: AbortSignal,
     shouldRetry?: (error: any, attempt: number) => boolean,
     attemptRun?: ModelAttemptRun,
+    retryProfile?: AIRequestOptions['retryProfile'],
   ): Promise<T> {
     const startedAt = Date.now();
 
@@ -488,7 +493,7 @@ export class AIService {
         return result;
       } catch (error: any) {
         if (this.isAbortError(error) || signal?.aborted) {
-          const policy = this.resolveRetryPolicy(error);
+          const policy = this.resolveRetryPolicy(error, retryProfile);
           this.emitModelAttempt(attemptRun, attemptNumber, {
             outcome: 'cancelled',
             durationMs: Date.now() - attemptStartedAt,
@@ -504,7 +509,7 @@ export class AIService {
           throw this.createAbortError();
         }
 
-        const policy = this.resolveRetryPolicy(error);
+        const policy = this.resolveRetryPolicy(error, retryProfile);
         const retryAttempt = attempt + 1;
         const elapsedMs = Date.now() - startedAt;
         const stopReason = this.resolveRetryStopReason(
@@ -663,7 +668,10 @@ export class AIService {
     }
   }
 
-  private resolveRetryPolicy(error?: any): RetryPolicy {
+  private resolveRetryPolicy(
+    error?: any,
+    retryProfile?: AIRequestOptions['retryProfile'],
+  ): RetryPolicy {
     const policy: RetryPolicy = {
       maxElapsedMs: this.readNumberEnv(
         ['CATSCO_MODEL_RETRY_MAX_MS', 'GAUZ_MODEL_RETRY_MAX_MS'],
@@ -686,6 +694,18 @@ export class AIService {
       baseDelayMs: BASE_DELAY_MS,
       guaranteedRetries: 0,
     };
+
+    if (retryProfile === 'checkpoint_summary') {
+      const maxRetries = Math.min(policy.maxRetries, CHECKPOINT_SUMMARY_MAX_RETRIES);
+      return {
+        ...policy,
+        maxRetries,
+        // A slow first stream may consume the ordinary elapsed-time window.
+        // Checkpoints still receive one recovery attempt, while later retries
+        // remain bounded by the shared wall-clock policy.
+        guaranteedRetries: Math.min(maxRetries, CHECKPOINT_SUMMARY_GUARANTEED_RETRIES),
+      };
+    }
 
     if (this.isEmptyModelResponseError(error)) {
       return {

--- a/tests/ai-service.test.ts
+++ b/tests/ai-service.test.ts
@@ -90,6 +90,54 @@ test('AIService retries transient stream errors before any text is emitted', asy
   assert.deepStrictEqual(chunks, ['ok']);
 });
 
+test('AIService gives buffered checkpoint summaries up to three recovery retries', async () => {
+  process.env.CATSCO_MODEL_RETRY_MAX_RETRIES = '10';
+  const service = createTestService();
+  let attempts = 0;
+  const retries: Array<[number, number]> = [];
+  (service as any).provider = {
+    chat: async () => ({ content: null }),
+    chatStream: async () => {
+      attempts += 1;
+      if (attempts <= 3) {
+        throw Object.assign(new Error(`checkpoint upstream failure ${attempts}`), {
+          status: 503,
+        });
+      }
+      return { content: 'checkpoint ready' };
+    },
+  };
+  (service as any).sleepWithAbort = async () => {};
+
+  const result = await service.chatStream([], undefined, {
+    onRetry: (attempt, maxRetries) => retries.push([attempt, maxRetries]),
+  }, {
+    retryProfile: 'checkpoint_summary',
+    streamOutputMode: 'buffered',
+  });
+
+  assert.equal(result.content, 'checkpoint ready');
+  assert.equal(attempts, 4);
+  assert.deepStrictEqual(retries, [[1, 3], [2, 3], [3, 3]]);
+});
+
+test('checkpoint summary guarantees one recovery after a slow first failure', () => {
+  process.env.CATSCO_MODEL_RETRY_MAX_RETRIES = '10';
+  process.env.CATSCO_MODEL_RETRY_MAX_MS = '1000';
+  const service = createTestService();
+  (service as any).config.openaiApiMode = 'responses';
+  const error = Object.assign(new Error('stream idle timeout'), { status: 504 });
+  const policy = (service as any).resolveRetryPolicy(error, 'checkpoint_summary');
+
+  assert.equal(policy.maxRetries, 3);
+  assert.equal(policy.guaranteedRetries, 1);
+  assert.equal((service as any).resolveRetryStopReason(error, 1, policy, 300_000), undefined);
+  assert.equal(
+    (service as any).resolveRetryStopReason(error, 2, policy, 300_001),
+    'retry_window_exhausted',
+  );
+});
+
 test('AIService can keep retrying transient stream failures beyond the old short cap', async () => {
   process.env.CATSCO_MODEL_RETRY_MAX_RETRIES = '5';
   const service = createTestService();

--- a/tests/conversation-runner-checkpoint-compaction.test.ts
+++ b/tests/conversation-runner-checkpoint-compaction.test.ts
@@ -119,6 +119,7 @@ test('runner checkpoints only after a complete tool result and resumes the same 
 
 test('runner stops before another model request when checkpoint persistence fails', async () => {
   const modelRequests: Message[][] = [];
+  const thinking: string[] = [];
   const aiService = {
     chat: async (messages: Message[]) => {
       modelRequests.push(messages.map(message => ({ ...message })));
@@ -180,11 +181,18 @@ test('runner stops before another model request when checkpoint persistence fail
       role: 'user',
       content: 'inspect and continue',
       __episodeId: 'episode-main',
-    }]),
+    }], {
+      onThinking: message => {
+        thinking.push(message);
+      },
+    }),
     error => error instanceof Error && error.name === 'CheckpointPersistenceError',
   );
 
   assert.equal(modelRequests.length, 1);
+  assert.deepEqual(thinking, [
+    'Checkpoint could not be saved. Stopping this turn with the original context preserved.',
+  ]);
 });
 
 test('runner does not create a fresh checkpoint retry budget after a terminal 502', async () => {

--- a/tests/openai-provider-responses.test.ts
+++ b/tests/openai-provider-responses.test.ts
@@ -1,6 +1,6 @@
 import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
-import { Readable } from 'node:stream';
+import { PassThrough, Readable } from 'node:stream';
 import axios from 'axios';
 import { OpenAIProvider } from '../src/providers/openai-provider';
 import { AIService } from '../src/utils/ai-service';
@@ -52,6 +52,67 @@ describe('OpenAIProvider Responses API mode', () => {
     assert.equal(first.prompt_cache_key, second.prompt_cache_key);
     assert.equal(first.store, false);
     assert.deepEqual(first.include, ['reasoning.encrypted_content']);
+  });
+
+  test('fails a buffered Responses stream after its request-scoped idle deadline', async () => {
+    const originalPost = axios.post;
+    const stream = new PassThrough();
+    (axios as any).post = async () => ({ data: stream, headers: {} });
+
+    try {
+      await assert.rejects(
+        createProvider().chatStream(
+          [{ role: 'user', content: 'summarize' }],
+          undefined,
+          undefined,
+          { streamIdleTimeoutMs: 20 },
+        ),
+        (error: any) => (
+          error?.code === 'XIAOBA_RESPONSES_STREAM_IDLE_TIMEOUT'
+          && error?.status === 504
+          && error?.terminalEvent === 'stream.idle_timeout'
+        ),
+      );
+      assert.equal(stream.destroyed, true);
+    } finally {
+      (axios as any).post = originalPost;
+    }
+  });
+
+  test('resets the Responses idle deadline whenever stream bytes arrive', async () => {
+    const originalPost = axios.post;
+    const stream = new PassThrough();
+    (axios as any).post = async () => ({ data: stream, headers: {} });
+
+    const heartbeat = setTimeout(() => stream.write(': heartbeat\n\n'), 60);
+    const completion = setTimeout(() => {
+      stream.end(sse({
+        type: 'response.completed',
+        response: {
+          status: 'completed',
+          output: [{
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'ready' }],
+          }],
+        },
+      }));
+    }, 120);
+
+    try {
+      const result = await createProvider().chatStream(
+        [{ role: 'user', content: 'summarize' }],
+        undefined,
+        undefined,
+        { streamIdleTimeoutMs: 100 },
+      );
+      assert.equal(result.content, 'ready');
+    } finally {
+      clearTimeout(heartbeat);
+      clearTimeout(completion);
+      stream.destroy();
+      (axios as any).post = originalPost;
+    }
   });
 
   test('keeps dynamic system context out of cache identity and appends it as developer context', () => {

--- a/tests/session-lifecycle-manager.test.ts
+++ b/tests/session-lifecycle-manager.test.ts
@@ -597,6 +597,7 @@ describe('AgentSession lifecycle', () => {
       AgentSession,
       SessionStore,
       CONTEXT_COMPACTION_START_MESSAGE,
+      CONTEXT_COMPACTION_GENERATED_MESSAGE,
       CONTEXT_COMPACTION_COMPLETE_MESSAGE,
     } = loadSessionModules();
     SessionStore.getInstance().saveContext('catscompany:lifecycle-compact-status', [
@@ -648,8 +649,23 @@ describe('AgentSession lifecycle', () => {
     assert.deepStrictEqual(compactReasons, ['pre_turn', 'restore']);
     assert.deepStrictEqual(thinking, [
       CONTEXT_COMPACTION_START_MESSAGE,
+      CONTEXT_COMPACTION_GENERATED_MESSAGE,
       CONTEXT_COMPACTION_COMPLETE_MESSAGE,
     ]);
+  });
+
+  test('legacy compaction failure status does not claim the turn was stopped', () => {
+    const {
+      AgentSession,
+      LEGACY_CONTEXT_COMPACTION_ERROR_MESSAGE,
+    } = loadSessionModules();
+    const session = new AgentSession('catscompany:lifecycle-legacy-compact-status', buildMockServices(), 'catscompany');
+
+    assert.equal(
+      (session as any).formatContextCompactionStatus({ status: 'error' }, false),
+      LEGACY_CONTEXT_COMPACTION_ERROR_MESSAGE,
+    );
+    assert.doesNotMatch(LEGACY_CONTEXT_COMPACTION_ERROR_MESSAGE, /停止本轮/);
   });
 
   test('handleMessage strips internal error artifacts before context compaction sees them', async () => {
@@ -1206,7 +1222,9 @@ function loadSessionModules(): any {
     MODEL_TRANSIENT_ERROR_MESSAGE: require('../src/core/agent-session').MODEL_TRANSIENT_ERROR_MESSAGE,
     EMPTY_MODEL_RESPONSE_MESSAGE: require('../src/core/agent-session').EMPTY_MODEL_RESPONSE_MESSAGE,
     CONTEXT_COMPACTION_START_MESSAGE: require('../src/core/agent-session').CONTEXT_COMPACTION_START_MESSAGE,
+    CONTEXT_COMPACTION_GENERATED_MESSAGE: require('../src/core/agent-session').CONTEXT_COMPACTION_GENERATED_MESSAGE,
     CONTEXT_COMPACTION_COMPLETE_MESSAGE: require('../src/core/agent-session').CONTEXT_COMPACTION_COMPLETE_MESSAGE,
+    LEGACY_CONTEXT_COMPACTION_ERROR_MESSAGE: require('../src/core/agent-session').LEGACY_CONTEXT_COMPACTION_ERROR_MESSAGE,
     SessionStore: require('../src/utils/session-store').SessionStore,
     createSessionRoute: require('../src/core/session-router').createSessionRoute,
     createCatsCoSessionRoute: require('../src/core/session-router').createCatsCoSessionRoute,


### PR DESCRIPTION
## Summary

- give Checkpoint Summary requests a request-scoped recovery policy with up to three retries after the initial attempt
- abort a buffered Responses summary stream after 120 seconds without any bytes so a stalled connection can enter the retry path
- distinguish summary generation from durable checkpoint persistence in user-visible status, and keep legacy rollback-mode failure wording truthful

## Safety boundaries

- ordinary main-Agent requests retain their existing retry policy
- non-retryable authentication, quota, and caller-abort errors remain non-retryable
- retrying remains buffered, so abandoned summary output is never exposed or persisted
- after all retries fail, the existing safe stop from #441 still preserves the original transcript

## Verification

- targeted checkpoint/provider/session tests: 72 passed
- npm run build: passed
- npm run release:check: passed
- npm run test:skillhub-phase1: 273 passed, 3 skipped
- full runtime suite: 1685 passed, 20 skipped; 2 unrelated Windows host failures remain in the existing GrepTool cancellation timing test and a WSL /bin/bash-dependent Tianyi image test