### PR TITLE
feat(domain): accept CatsCo cn endpoints alongside cc

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -20,7 +20,10 @@ if (shouldDisableHardwareAcceleration()) {
 
 const DASHBOARD_PORT = resolveDashboardPort(process.env.XIAOBA_DASHBOARD_PORT);
 const DEEP_LINK_PROTOCOL = 'catsco';
-const TRUSTED_DEEP_LINK_BASE_ORIGINS = new Set(['https://app.catsco.cc']);
+const TRUSTED_DEEP_LINK_BASE_ORIGINS = new Set([
+  'https://app.catsco.cc',
+  'https://app.catsco.cn',
+]);
 const CATSCO_WEBAPP_URL = 'https://app.catsco.cc';
 let mainWindow = null;
 let tray = null;
@@ -646,7 +649,7 @@ function createWindow() {
     }
     try {
       const target = new URL(url);
-      if (target.protocol === 'https:' && target.origin === 'https://app.catsco.cc') {
+      if (target.protocol === 'https:' && TRUSTED_DEEP_LINK_BASE_ORIGINS.has(target.origin)) {
         void shell.openExternal(target.toString());
       }
     } catch (_error) {

--- a/src/bot-definition/service.ts
+++ b/src/bot-definition/service.ts
@@ -6,6 +6,7 @@ import { canonicalizeBotSkillRefs } from '../bot-skills/canonical';
 import { createCatsCoLocalConfigService } from '../catscompany/local-config';
 import { normalizeOpenAIApiMode } from '../utils/openai-api-mode';
 import { normalizeReasoningEffort } from '../utils/reasoning-effort';
+import { isCatsRelayApiBase } from '../utils/catsco-domains';
 import { relayModelProfileFromRuntimeDescriptor, type RelayModelRuntimeDescriptor } from '../utils/relay-model-profiles';
 import {
   canonicalRelayModelId,
@@ -130,7 +131,7 @@ function isRelayProfile(profile: Record<string, string | undefined>): boolean {
   if (profile.CATSCO_MODEL_SOURCE === 'relay') return true;
   if (profile.CATSCO_MODEL_SOURCE === 'custom') return false;
   const apiBase = firstNonEmpty(profile.CATSCO_RELAY_LLM_API_BASE, profile.GAUZ_LLM_API_BASE) || '';
-  return apiBase.toLowerCase().includes('relay.catsco.cc');
+  return isCatsRelayApiBase(apiBase);
 }
 
 /**

--- a/src/catscompany/local-config.ts
+++ b/src/catscompany/local-config.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as dotenv from 'dotenv';
 import { randomUUID } from 'crypto';
+import { CATSCO_APP_HTTP_ORIGINS } from '../utils/catsco-domains';
 
 export interface CatsCoLocalAccount {
   token: string;
@@ -90,7 +91,7 @@ function normalizeBaseUrl(
   if (options.upgradeCatsCoHttp) {
     try {
       const url = new URL(text);
-      if (url.protocol === 'http:' && url.hostname === 'app.catsco.cc') {
+      if (url.protocol === 'http:' && CATSCO_APP_HTTP_ORIGINS.has(`https://${url.hostname}`)) {
         url.protocol = 'https:';
         return url.toString().replace(/\/+$/, '');
       }

--- a/src/catscompany/model-status.ts
+++ b/src/catscompany/model-status.ts
@@ -1,4 +1,5 @@
 import { ConfigManager } from '../utils/config';
+import { isCatsRelayApiBase } from '../utils/catsco-domains';
 
 export interface CatsDeviceModelStatus {
   source: 'relay' | 'custom';
@@ -24,14 +25,6 @@ function firstNonEmpty(...values: Array<string | undefined>): string {
     if (text) return text;
   }
   return '';
-}
-
-function isCatsRelayApiBase(value: string): boolean {
-  try {
-    return new URL(value).hostname.toLowerCase() === 'relay.catsco.cc';
-  } catch {
-    return value.toLowerCase().includes('relay.catsco.cc');
-  }
 }
 
 export function resolveCatsDeviceModelStatus(options: ModelStatusOptions = {}): CatsDeviceModelStatus | undefined {

--- a/src/catscompany/runtime-config.ts
+++ b/src/catscompany/runtime-config.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_CATSCO_WS_URL,
   createCatsCoLocalConfigService,
 } from './local-config';
+import { CATSCO_APP_HTTP_ORIGINS } from '../utils/catsco-domains';
 
 export type CatsCoRuntimeMissingField = 'serverUrl' | 'apiKey' | 'bodyId';
 
@@ -65,7 +66,7 @@ function normalizeBaseUrl(
   if (options.upgradeCatsCoHttp) {
     try {
       const url = new URL(text);
-      if (url.protocol === 'http:' && url.hostname === 'app.catsco.cc') {
+      if (url.protocol === 'http:' && CATSCO_APP_HTTP_ORIGINS.has(`https://${url.hostname}`)) {
         url.protocol = 'https:';
         return url.toString().replace(/\/+$/, '');
       }

--- a/src/dashboard/readiness.ts
+++ b/src/dashboard/readiness.ts
@@ -10,6 +10,7 @@ import { readDashboardEnvFile } from './settings';
 import { resolveCatsCoRuntimeConfig } from '../catscompany/runtime-config';
 import { getWeixinChannelStatus } from './weixin-channel-binding';
 import { resolveActiveBotLLMConfig } from '../bot-definition/llm-config-resolver';
+import { isCatsRelayApiBase } from '../utils/catsco-domains';
 
 export type DashboardReadinessStatus = 'ready' | 'warning' | 'blocked';
 export type DashboardReadinessCheckStatus = 'pass' | 'warning' | 'fail';
@@ -599,10 +600,9 @@ function isCatsRelayModelConfigured(
   if (provider !== 'anthropic' && provider !== 'openai') return false;
 
   try {
-    const parsed = new URL(apiBase);
-    return parsed.hostname.toLowerCase() === 'relay.catsco.cc';
+    return isCatsRelayApiBase(apiBase);
   } catch {
-    return apiBase.toLowerCase().includes('relay.catsco.cc');
+    return false;
   }
 }
 

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -54,6 +54,7 @@ import {
 } from '../../runtime/runtime-profile-editor';
 import { inferCatsUploadType, uploadCatsLocalFile } from '../../catscompany/upload';
 import { createCatsCoLocalConfigService } from '../../catscompany/local-config';
+import { CATSCO_APP_HTTP_ORIGINS, isCatsRelayApiBase, isCatsCoWebSocketEndpoint } from '../../utils/catsco-domains';
 import { catalogRuntimeMatchesModelId, createBotDefinitionSyncService } from '../../bot-definition/service';
 import { prepareBoundBotDefinition } from '../../bot-definition/activation';
 import { createBotDefinitionCloudSyncService } from '../../bot-definition/cloud-sync';
@@ -110,8 +111,7 @@ import {
 
 const DEFAULT_CATSCO_HTTP_BASE_URL = 'https://app.catsco.cc';
 const DEFAULT_CATSCO_WS_URL = 'wss://app.catsco.cc/v0/channels';
-const TRUSTED_CATSCO_HTTP_ORIGINS = new Set([new URL(DEFAULT_CATSCO_HTTP_BASE_URL).origin]);
-const TRUSTED_CATSCO_WS_URL = new URL(DEFAULT_CATSCO_WS_URL);
+const TRUSTED_CATSCO_HTTP_ORIGINS = CATSCO_APP_HTTP_ORIGINS;
 const BUNDLED_SKILL_MARKER = '.xiaoba-bundled-skill.json';
 const SYSTEM_SKILL_DIRS = new Set<string>();
 const PROMPT_EDITOR_SKILL_NAME = 'catsco-prompt-editor';
@@ -327,7 +327,7 @@ function normalizeTrustedCatsServerUrl(value: unknown): string {
   }
 
   const pathname = url.pathname.replace(/\/+$/, '') || '/';
-  if (url.origin === TRUSTED_CATSCO_WS_URL.origin && pathname === TRUSTED_CATSCO_WS_URL.pathname) {
+  if (isCatsCoWebSocketEndpoint(url.toString()) && pathname === '/v0/channels') {
     return `${url.protocol}//${url.host}${pathname}`;
   }
   if (canUseLocalCatsCoEndpoint() && isLoopbackHost(url.hostname)) {
@@ -1220,16 +1220,6 @@ function relayModelPayload(model: RelayModelConfig): Record<string, unknown> {
     context_label: model.contextWindowTokens ? formatContextWindowTokens(model.contextWindowTokens) : undefined,
     capabilities: model.capabilities,
   };
-}
-
-function isCatsRelayApiBase(value: unknown): boolean {
-  const text = String(value || '').trim();
-  if (!text) return false;
-  try {
-    return new URL(text).hostname.toLowerCase() === 'relay.catsco.cc';
-  } catch {
-    return text.toLowerCase().includes('relay.catsco.cc');
-  }
 }
 
 function writeDashboardEnvAndProcess(updates: Record<string, string | undefined>): { updated: string[]; cleared: string[] } {

--- a/src/dashboard/settings.ts
+++ b/src/dashboard/settings.ts
@@ -4,6 +4,7 @@ import * as dotenv from 'dotenv';
 import type { ChatConfig, OpenAIApiMode, ReasoningEffort } from '../types';
 import { REASONING_EFFORT_OPTIONS, normalizeReasoningEffort, reasoningEffortOrDefault } from '../utils/reasoning-effort';
 import { OPENAI_API_MODE_OPTIONS, openAIApiModeOrDefault } from '../utils/openai-api-mode';
+import { isCatsRelayApiBase } from '../utils/catsco-domains';
 
 export type DashboardSettingType = 'enum' | 'string' | 'url' | 'secret';
 export type SecretSettingAction = 'keep' | 'replace' | 'clear';
@@ -239,16 +240,6 @@ const MODEL_SOURCE_ENV_KEY = 'CATSCO_MODEL_SOURCE';
 
 function isModelSetting(id: string): boolean {
   return id.startsWith('model.');
-}
-
-function isCatsRelayApiBase(value: unknown): boolean {
-  const text = String(value || '').trim();
-  if (!text) return false;
-  try {
-    return new URL(text).hostname.toLowerCase() === 'relay.catsco.cc';
-  } catch {
-    return text.toLowerCase().includes('relay.catsco.cc');
-  }
 }
 
 function modelSettingDisplayValue(

--- a/src/providers/output-limits.ts
+++ b/src/providers/output-limits.ts
@@ -1,4 +1,5 @@
 import { ChatConfig } from '../types';
+import { isCatsRelayApiBase } from '../utils/catsco-domains';
 
 const DEFAULT_MAX_TOKENS = 8192;
 const DEFAULT_RELAY_MAX_TOKENS = 32768;
@@ -10,7 +11,7 @@ export function resolveMaxTokens(config: ChatConfig): number {
   } else {
     const apiUrl = (config.apiUrl || '').toLowerCase();
     const model = (config.model || '').toLowerCase();
-    maxTokens = apiUrl.includes('relay.catsco.cc') || model.includes('minimax-m2.7') || model.includes('minimax-m3')
+    maxTokens = isCatsRelayApiBase(apiUrl) || model.includes('minimax-m2.7') || model.includes('minimax-m3')
       ? DEFAULT_RELAY_MAX_TOKENS
       : DEFAULT_MAX_TOKENS;
   }

--- a/src/utils/catsco-domains.ts
+++ b/src/utils/catsco-domains.ts
@@ -32,7 +32,7 @@ export function isCatsCoWebSocketEndpoint(value: unknown): boolean {
     const url = new URL(text);
     const pathname = url.pathname.replace(/\/+$/, '') || '/';
     const appOrigin = `https://${url.host}`;
-    return ['ws:', 'wss:'].includes(url.protocol)
+    return url.protocol === 'wss:'
       && CATSCO_APP_HTTP_ORIGINS.has(appOrigin)
       && pathname === CATSCO_WS_PATH;
   } catch {

--- a/src/utils/catsco-domains.ts
+++ b/src/utils/catsco-domains.ts
@@ -1,0 +1,51 @@
+/**
+ * Domain compatibility helpers. The .cc endpoints remain the defaults for
+ * existing installations, while the .cn endpoints are accepted during the
+ * migration window.
+ */
+export const CATSCO_APP_HTTP_ORIGINS = new Set([
+  'https://app.catsco.cc',
+  'https://app.catsco.cn',
+]);
+
+export const CATSCO_RELAY_ORIGINS = new Set([
+  'https://relay.catsco.cc',
+  'https://relay.catsco.cn',
+]);
+
+const CATSCO_WS_PATH = '/v0/channels';
+
+export function isCatsCoAppHttpOrigin(value: unknown): boolean {
+  const text = String(value || '').trim();
+  if (!text) return false;
+  try {
+    return CATSCO_APP_HTTP_ORIGINS.has(new URL(text).origin);
+  } catch {
+    return false;
+  }
+}
+
+export function isCatsCoWebSocketEndpoint(value: unknown): boolean {
+  const text = String(value || '').trim();
+  if (!text) return false;
+  try {
+    const url = new URL(text);
+    const pathname = url.pathname.replace(/\/+$/, '') || '/';
+    const appOrigin = `https://${url.host}`;
+    return ['ws:', 'wss:'].includes(url.protocol)
+      && CATSCO_APP_HTTP_ORIGINS.has(appOrigin)
+      && pathname === CATSCO_WS_PATH;
+  } catch {
+    return false;
+  }
+}
+
+export function isCatsRelayApiBase(value: unknown): boolean {
+  const text = String(value || '').trim();
+  if (!text) return false;
+  try {
+    return CATSCO_RELAY_ORIGINS.has(new URL(text).origin);
+  } catch {
+    return false;
+  }
+}

--- a/src/utils/model-capabilities.ts
+++ b/src/utils/model-capabilities.ts
@@ -1,6 +1,7 @@
 import { ChatConfig } from '../types';
 import { findRelayModelProfile } from './relay-model-profiles';
 import { probeVisionCapability, type VisionCapabilityState, type VisionProbeOptions } from './model-vision-probe';
+import { isCatsRelayApiBase } from './catsco-domains';
 
 const KNOWN_TEXT_ONLY_MODEL_PATTERNS = [
   /^deepseek-(?:chat|reasoner|v4-flash)$/i,
@@ -38,7 +39,7 @@ export function isPrimaryModelVisionCapable(config: Pick<ChatConfig, 'apiUrl' | 
   const apiUrl = (config.apiUrl || '').toLowerCase();
   const model = (config.model || '').trim();
   const modelKey = model.toLowerCase();
-  const isRelay = apiUrl.includes('relay.catsco.cc');
+  const isRelay = isCatsRelayApiBase(apiUrl);
   if (isRelay) {
     const relayProfile = findRelayModelProfile(model);
     if (relayProfile?.capabilities.vision !== undefined) {
@@ -74,7 +75,7 @@ export async function resolvePrimaryModelVisionCapability(
   const apiUrl = (config.apiUrl || '').toLowerCase();
   const model = (config.model || '').trim();
   const modelKey = model.toLowerCase();
-  if (apiUrl.includes('relay.catsco.cc')) {
+  if (isCatsRelayApiBase(apiUrl)) {
     const relayProfile = findRelayModelProfile(model);
     if (relayProfile?.capabilities.vision !== undefined) {
       return relayProfile.capabilities.vision ? 'supported' : 'unsupported';
@@ -102,7 +103,7 @@ export async function resolvePrimaryModelVisionCapability(
 export function isPrimaryModelToolCallingCapable(config: Pick<ChatConfig, 'apiUrl' | 'model' | 'provider' | 'modelCapabilities'>): boolean {
   if (config.modelCapabilities?.toolCalling !== undefined) return config.modelCapabilities.toolCalling;
   const apiUrl = (config.apiUrl || '').toLowerCase();
-  if (apiUrl.includes('relay.catsco.cc')) {
+  if (isCatsRelayApiBase(apiUrl)) {
     const relayProfile = findRelayModelProfile(config.model);
     if (relayProfile) {
       return relayProfile.capabilities.toolCalling;

--- a/src/utils/model-context-window.ts
+++ b/src/utils/model-context-window.ts
@@ -1,6 +1,7 @@
 import { ChatConfig } from '../types';
 import { resolveMaxTokens } from '../providers/output-limits';
 import { RELAY_MODEL_PROFILES } from './relay-model-profiles';
+import { isCatsRelayApiBase } from './catsco-domains';
 
 export interface ModelContextWindowSpec {
   id: string;
@@ -89,7 +90,7 @@ export function isCatsRelayModelConfig(
 ): boolean {
   const apiUrl = String(config.apiUrl || '').trim().toLowerCase();
   if (apiUrl) {
-    return apiUrl.includes('relay.catsco.cc');
+    return isCatsRelayApiBase(apiUrl);
   }
   const source = String(env.CATSCO_MODEL_SOURCE || '').trim().toLowerCase();
   if (source === 'relay') return true;

--- a/tests/catsco-domains.test.ts
+++ b/tests/catsco-domains.test.ts
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  isCatsCoAppHttpOrigin,
+  isCatsCoWebSocketEndpoint,
+  isCatsRelayApiBase,
+} from '../src/utils/catsco-domains';
+
+test('accepts both CatsCo app domains while rejecting lookalikes', () => {
+  assert.equal(isCatsCoAppHttpOrigin('https://app.catsco.cc'), true);
+  assert.equal(isCatsCoAppHttpOrigin('https://app.catsco.cn/path'), true);
+  assert.equal(isCatsCoAppHttpOrigin('https://evil-app.catsco.cn'), false);
+  assert.equal(isCatsCoAppHttpOrigin('http://app.catsco.cn'), false);
+});
+
+test('accepts both production websocket endpoints with the canonical path', () => {
+  assert.equal(isCatsCoWebSocketEndpoint('wss://app.catsco.cc/v0/channels'), true);
+  assert.equal(isCatsCoWebSocketEndpoint('wss://app.catsco.cn/v0/channels/'), true);
+  assert.equal(isCatsCoWebSocketEndpoint('wss://app.catsco.cn/v1/channels'), false);
+  assert.equal(isCatsCoWebSocketEndpoint('wss://evil.catsco.cn/v0/channels'), false);
+});
+
+test('classifies both Relay domains independent of endpoint path', () => {
+  assert.equal(isCatsRelayApiBase('https://relay.catsco.cc/v1'), true);
+  assert.equal(isCatsRelayApiBase('https://relay.catsco.cn/anthropic/v1/messages'), true);
+  assert.equal(isCatsRelayApiBase('https://relay.catsco.cn.evil.example/v1'), false);
+  assert.equal(isCatsRelayApiBase('not-a-url/https://relay.catsco.cn/v1'), false);
+});

--- a/tests/catsco-domains.test.ts
+++ b/tests/catsco-domains.test.ts
@@ -16,6 +16,7 @@ test('accepts both CatsCo app domains while rejecting lookalikes', () => {
 test('accepts both production websocket endpoints with the canonical path', () => {
   assert.equal(isCatsCoWebSocketEndpoint('wss://app.catsco.cc/v0/channels'), true);
   assert.equal(isCatsCoWebSocketEndpoint('wss://app.catsco.cn/v0/channels/'), true);
+  assert.equal(isCatsCoWebSocketEndpoint('ws://app.catsco.cn/v0/channels'), false);
   assert.equal(isCatsCoWebSocketEndpoint('wss://app.catsco.cn/v1/channels'), false);
   assert.equal(isCatsCoWebSocketEndpoint('wss://evil.catsco.cn/v0/channels'), false);
 });

--- a/tests/electron-main-dashboard-url.test.ts
+++ b/tests/electron-main-dashboard-url.test.ts
@@ -81,6 +81,7 @@ test('electron registers catsco deep links and forwards connect codes to the loc
   assert.match(electronMain, /TRUSTED_DEEP_LINK_BASE_ORIGINS/);
   assert.match(electronMain, /function trustedDeepLinkBase\(value\)/);
   assert.match(electronMain, /https:\/\/app\.catsco\.cc/);
+  assert.match(electronMain, /https:\/\/app\.catsco\.cn/);
   assert.match(electronMain, /\/cats\/desktop-connect/);
   assert.match(electronMain, /\/cats\/bootstrap/);
   assert.match(electronMain, /'X-API-Key': dashboardApiKey/);
@@ -89,7 +90,8 @@ test('electron registers catsco deep links and forwards connect codes to the loc
 
 test('electron sends trusted CatsCo links to the system browser', () => {
   assert.match(electronMain, /setWindowOpenHandler/);
-  assert.match(electronMain, /target\.origin === 'https:\/\/app\.catsco\.cc'/);
+  assert.match(electronMain, /TRUSTED_DEEP_LINK_BASE_ORIGINS\.has\(target\.origin\)/);
+  assert.match(electronMain, /https:\/\/app\.catsco\.cn/);
   assert.match(electronMain, /shell\.openExternal\(target\.toString\(\)\)/);
   assert.match(electronMain, /ipcMain\.handle\('catsco:open-webapp'/);
   assert.match(electronMain, /label: '打开 CatsCo WebApp'/);


### PR DESCRIPTION
## Summary\n- keep existing .cc endpoints as defaults\n- accept app.catsco.cn and relay.catsco.cn during migration\n- centralize app/WS/Relay domain checks and preserve strict URL validation\n- allow Electron deep links from both app domains\n- add boundary tests for valid and lookalike domains\n\n## Verification\n- npm exec -- tsc --noEmit\n- node --import tsx --test tests/catsco-domains.test.ts\n- related runtime tests: 37 passed\n\nNo production defaults, deployment configuration, or merges are included in this PR.