### PR TITLE
fix: honor cloud relay catalog protocol metadata

### DIFF
--- a/src/bot-definition/activation.ts
+++ b/src/bot-definition/activation.ts
@@ -1,6 +1,7 @@
 import { createCatsCoLocalConfigService, type CatsCoAuthSnapshot } from '../catscompany/local-config';
 import {
   provisionCatsRelayCatalogRuntime,
+  retargetCatsRelayCatalogRuntime,
   refreshCatsRelayCatalogRuntimeCapabilities,
   validateCatsRelayCatalogRuntimeCredential,
   RelayCredentialRejectedError,
@@ -161,38 +162,39 @@ export async function prepareBoundBotDefinition(
         if (definition.model.kind === 'catalog') {
           const runtime = definitionService.readCatalogRuntime(botId);
           const cloudContextWindowTokens = definition.model.contextWindowTokens;
-          if (!runtime || !catalogRuntimeMatchesModelId(runtime, definition.model.modelId)) {
+          const cloudCatalogRuntime = definition.model.catalogRuntime;
+          if (!runtime || !catalogRuntimeMatchesModelId(runtime, definition.model.modelId, cloudCatalogRuntime)) {
             const materialized = await provisionCatsRelayCatalogRuntime({
               botId,
               modelId: definition.model.modelId,
               reasoningEffort: definition.model.reasoningEffort,
               contextWindowTokens: cloudContextWindowTokens,
+              catalogRuntime: cloudCatalogRuntime,
               existingRuntime: runtime,
               auth,
               fetchImpl: options.fetchImpl,
             });
             definitionService.storeCatalogRuntime(materialized);
             materializedCatalogRuntime = true;
-          } else if (
-            (cloudContextWindowTokens !== undefined
-              && runtime.contextWindowTokens !== cloudContextWindowTokens)
-            || (definition.model.reasoningEffort
-              && runtime.reasoningEffort !== definition.model.reasoningEffort)
-          ) {
-            // 云端配置权威：已匹配的 runtime 只更新窗口/推理强度，
-            // 不重新物化凭据（对齐旧协议 cloudSelection 分支的行为）。
-            definitionService.storeCatalogRuntime({
-              ...runtime,
-              ...(cloudContextWindowTokens !== undefined
-                ? { contextWindowTokens: cloudContextWindowTokens }
-                : {}),
-              ...(definition.model.reasoningEffort
-                ? { reasoningEffort: definition.model.reasoningEffort }
-                : {}),
-            });
-          } else if (catalogCapabilitiesNeedRefresh(runtime)) {
-            const refreshed = await refreshCatsRelayCatalogRuntimeCapabilities(runtime, options.fetchImpl ?? fetch);
-            if (refreshed !== runtime) definitionService.storeCatalogRuntime(refreshed);
+          } else {
+            // Keep the credential, but reconcile all non-secret catalog
+            // metadata from CatsCompany. This repairs older runtimes that
+            // persisted OpenAI Chat mode and prevents local metadata drift.
+            const reconciled = retargetCatsRelayCatalogRuntime(
+              runtime,
+              definition.model.modelId,
+              definition.model.reasoningEffort ?? runtime.reasoningEffort,
+              cloudContextWindowTokens ?? runtime.contextWindowTokens,
+              runtime.ownerUid,
+              cloudCatalogRuntime,
+            );
+            if (JSON.stringify(reconciled) !== JSON.stringify(runtime)) {
+              definitionService.storeCatalogRuntime(reconciled);
+            }
+            if (catalogCapabilitiesNeedRefresh(reconciled)) {
+              const refreshed = await refreshCatsRelayCatalogRuntimeCapabilities(reconciled, options.fetchImpl ?? fetch);
+              if (refreshed !== reconciled) definitionService.storeCatalogRuntime(refreshed);
+            }
           }
         }
         const promptCoordinator = getPromptReconcileCoordinator({
@@ -417,22 +419,16 @@ export async function prepareBoundBotDefinition(
               throw error;
             }
           }
-          if (
-            (cloudSelection.reasoningEffort
-              && effectiveRuntime.reasoningEffort !== cloudSelection.reasoningEffort)
-            || (cloudSelection.contextWindowTokens !== undefined
-              && effectiveRuntime.contextWindowTokens !== cloudSelection.contextWindowTokens)
-          ) {
-            definitionService.storeCloudCatalogRuntime({
-              ...effectiveRuntime,
-              ...(cloudSelection.reasoningEffort
-                ? { reasoningEffort: cloudSelection.reasoningEffort }
-                : {}),
-              ...(cloudSelection.contextWindowTokens !== undefined
-                ? { contextWindowTokens: cloudSelection.contextWindowTokens }
-                : {}),
-              ...(cloudSelection.catalogRuntime ? { catalogRuntime: cloudSelection.catalogRuntime } : {}),
-            });
+          const reconciledRuntime = retargetCatsRelayCatalogRuntime(
+            effectiveRuntime,
+            cloudSelection.modelId,
+            cloudSelection.reasoningEffort ?? effectiveRuntime.reasoningEffort,
+            cloudSelection.contextWindowTokens ?? effectiveRuntime.contextWindowTokens,
+            effectiveRuntime.ownerUid,
+            cloudSelection.catalogRuntime,
+          );
+          if (JSON.stringify(reconciledRuntime) !== JSON.stringify(effectiveRuntime)) {
+            definitionService.storeCloudCatalogRuntime(reconciledRuntime);
           }
         }
         sync = definitionService.acceptCloud(botId, cloudModel);

--- a/src/bot-definition/llm-config-resolver.ts
+++ b/src/bot-definition/llm-config-resolver.ts
@@ -2,6 +2,8 @@ import * as path from 'path';
 import { createCatsCoLocalConfigService } from '../catscompany/local-config';
 import type { ChatConfig } from '../types';
 import { PathResolver } from '../utils/path-resolver';
+import { isCatsRelayApiBase } from '../utils/catsco-domains';
+import { findRelayModelProfile } from '../utils/relay-model-profiles';
 import {
   FileBotCatalogModelRuntimeRepository,
   FileBotCloudCatalogModelRuntimeRepository,
@@ -9,7 +11,7 @@ import {
   FileBotDefinitionRepository,
 } from './repository';
 import { catalogRuntimeMatchesModelId } from './service';
-import type { CustomBotModelDefinition } from './types';
+import type { BotCatalogModelRuntime, CustomBotModelDefinition } from './types';
 
 export type BotLLMConfigSource = 'custom_definition' | 'catalog_runtime';
 
@@ -66,6 +68,19 @@ export function customModelDefinitionToConfig(
   });
 }
 
+function catalogRuntimeToConfig(runtime: BotCatalogModelRuntime): ResolvedBotLLMConfig['config'] {
+  const profile = isCatsRelayApiBase(runtime.apiBase)
+    ? findRelayModelProfile(runtime.modelId ?? runtime.model)
+    : undefined;
+  const openaiApiMode = runtime.provider === 'openai'
+    ? profile?.openaiApiMode ?? runtime.openaiApiMode
+    : runtime.openaiApiMode;
+  return modelRuntimeToConfig({
+    ...runtime,
+    ...(openaiApiMode ? { openaiApiMode } : {}),
+  });
+}
+
 /**
  * Resolves the effective model for a bound bot without consulting legacy .env
  * as the decision source. Legacy values are used once only to migrate missing
@@ -105,6 +120,6 @@ export function resolveActiveBotLLMConfig(
   return {
     botId,
     source: 'catalog_runtime',
-    config: modelRuntimeToConfig(runtime),
+    config: catalogRuntimeToConfig(runtime),
   };
 }

--- a/src/bot-definition/service.ts
+++ b/src/bot-definition/service.ts
@@ -295,7 +295,11 @@ export function catalogRuntimeMatchesModelId(
   if (!relayModelIdsMatch(runtime.modelId, modelId)) return false;
   const profile = relayModelProfileFromRuntimeDescriptor(modelId, descriptor)
     ?? findRelayModelProfile(modelId);
-  return !profile || relayModelIdsMatch(runtime.model, profile.id);
+  // A cloud descriptor may intentionally use a relay-facing model name that
+  // has no local profile. Compare against that authoritative name rather than
+  // the catalog id, otherwise dynamic models are needlessly re-materialized.
+  const expectedModel = descriptor?.model ?? profile?.model ?? profile?.id;
+  return !expectedModel || relayModelIdsMatch(runtime.model, expectedModel);
 }
 
 function normalizeBotModelDefinition(model: BotModelDefinition): BotModelDefinition {

--- a/src/catscompany/relay-model-bootstrap.ts
+++ b/src/catscompany/relay-model-bootstrap.ts
@@ -69,6 +69,7 @@ export async function provisionCatsRelayCatalogRuntime(
         options.reasoningEffort,
         options.contextWindowTokens,
         ownerUid,
+        options.catalogRuntime,
       );
       await validateCatsRelayCatalogRuntimeCredential(retargeted, fetchImpl);
       return retargeted;
@@ -146,10 +147,15 @@ export function retargetCatsRelayCatalogRuntime(
     // 带进新模型。云端下发优先，否则使用新模型 profile 的标准窗口。
     contextWindowTokens: contextWindowTokens ?? profile.contextWindowTokens,
     reasoningEffort: reasoningEffort ?? 'high',
+    // A cloud runtime descriptor is authoritative. Without one, retain the
+    // discovered local capabilities while still correcting known catalog
+    // protocol metadata (for example old GPT/DeepSeek Chat runtimes).
     openaiApiMode: profile.openaiApiMode ?? 'chat_completions',
-    capabilities: existing.capabilities ?? { ...profile.capabilities },
-    capabilitiesSource: existing.capabilitiesSource ?? 'static',
-    ...(existing.capabilitiesCheckedAt ? { capabilitiesCheckedAt: existing.capabilitiesCheckedAt } : {}),
+    capabilities: catalogRuntime ? { ...profile.capabilities } : existing.capabilities ?? { ...profile.capabilities },
+    capabilitiesSource: catalogRuntime ? 'relay-models' : existing.capabilitiesSource ?? 'static',
+    ...(catalogRuntime
+      ? { capabilitiesCheckedAt: new Date().toISOString() }
+      : existing.capabilitiesCheckedAt ? { capabilitiesCheckedAt: existing.capabilitiesCheckedAt } : {}),
   };
 }
 

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -38,6 +38,7 @@ import {
   DEFAULT_CATSCO_RELAY_MODEL_ID,
   RELAY_MODEL_PROFILES,
   findRelayModelProfile,
+  relayModelProfileFromRuntimeDescriptor,
   relayModelProviderBaseUrl,
   relayModelProviderProtocolLabel,
   relayModelProviderSdkLabel,
@@ -217,6 +218,8 @@ interface RelayModelConfig {
   model: string;
   family?: string;
   provider: RelayModelProvider;
+  /** Cloud catalog authority for OpenAI-compatible models. */
+  openaiApiMode?: OpenAIApiMode;
   protocol: string;
   baseUrl: string;
   sdkLabel: string;
@@ -1024,16 +1027,29 @@ function optionalBoolean(value: unknown): boolean | undefined {
 }
 
 function normalizeRelayModelConfig(item: any, config: any, index: number): RelayModelConfig | null {
-  const rawModel = canonicalRelayModelName(item?.model);
+  const cloudProfile = relayModelProfileFromRuntimeDescriptor(item?.id, item?.runtime);
+  const rawModel = canonicalRelayModelName(item?.runtime?.model ?? item?.model ?? item?.id);
   if (!rawModel) return null;
-  const profile = findRelayModelProfile(rawModel);
+  const profile = cloudProfile ?? findRelayModelProfile(rawModel) ?? findRelayModelProfile(item?.id);
   const model = profile?.model || rawModel;
-  const provider = explicitRelayProvider(item)
+  const provider = cloudProfile?.preferredProvider
+    ?? explicitRelayProvider(item)
     ?? profile?.preferredProvider
     ?? normalizeRelayProvider(item?.provider ?? item?.protocol);
+  const rawOpenAIApiMode = item?.runtime?.openaiApiMode
+    ?? item?.runtime?.openai_api_mode
+    ?? item?.openai_api_mode
+    ?? item?.openaiApiMode;
+  const openaiApiMode = provider === 'openai'
+    ? (rawOpenAIApiMode === 'responses' || rawOpenAIApiMode === 'chat_completions'
+      ? rawOpenAIApiMode
+      : profile?.openaiApiMode ?? 'responses')
+    : undefined;
   const protocol = relayModelProviderProtocolLabel(provider);
   const baseUrl = relayEndpointForProtocol(config, provider);
-  const contextWindowTokens = parsePositiveInteger(item?.context_window_tokens)
+  const contextWindowTokens = parsePositiveInteger(item?.runtime?.contextWindowTokens)
+    ?? parsePositiveInteger(item?.runtime?.context_window_tokens)
+    ?? parsePositiveInteger(item?.context_window_tokens)
     ?? parsePositiveInteger(item?.contextWindowTokens)
     ?? profile?.contextWindowTokens
     ?? resolveKnownModelContextWindowTokens(model);
@@ -1043,6 +1059,7 @@ function normalizeRelayModelConfig(item: any, config: any, index: number): Relay
     model,
     family: String(item?.family || profile?.family || '').trim() || undefined,
     provider,
+    openaiApiMode,
     protocol,
     baseUrl,
     sdkLabel: relayModelProviderSdkLabel(provider),
@@ -1061,6 +1078,9 @@ function fallbackRelayModelCatalog(config: any): RelayModelConfig[] {
     model: profile.model,
     family: profile.family,
     provider: profile.preferredProvider,
+    openaiApiMode: profile.preferredProvider === 'openai'
+      ? profile.openaiApiMode ?? 'responses'
+      : undefined,
     protocol: relayModelProviderProtocolLabel(profile.preferredProvider),
     baseUrl: relayEndpointForProtocol(config, profile.preferredProvider),
     sdkLabel: relayModelProviderSdkLabel(profile.preferredProvider),
@@ -1209,6 +1229,7 @@ function relayModelPayload(model: RelayModelConfig): Record<string, unknown> {
     model: model.model,
     family: model.family,
     provider: model.provider,
+    openai_api_mode: model.openaiApiMode,
     protocol: model.protocol,
     base_url: model.baseUrl,
     sdk_label: model.sdkLabel,
@@ -1767,7 +1788,9 @@ function writeRelayModelStartupConfig(
     apiKey,
     contextWindowTokens: model.contextWindowTokens ?? resolveKnownModelContextWindowTokens(model.model),
     reasoningEffort: relayReasoningEffortOrHigh(options.reasoningEffort ?? currentRelayReasoningEffort()),
-    openaiApiMode: 'chat_completions',
+    openaiApiMode: model.provider === 'openai'
+      ? model.openaiApiMode ?? 'responses'
+      : 'chat_completions',
   };
   const result = writeDashboardEnvAndProcess({
     ...modelProfileUpdates(RELAY_MODEL_ENV_KEYS, profile),
@@ -1798,7 +1821,9 @@ function selectedRelayCatalogRuntime(
     model: model.model,
     contextWindowTokens: model.contextWindowTokens ?? resolveKnownModelContextWindowTokens(model.model) ?? 200_000,
     reasoningEffort,
-    openaiApiMode: 'chat_completions',
+    openaiApiMode: model.provider === 'openai'
+      ? model.openaiApiMode ?? 'responses'
+      : 'chat_completions',
     capabilities: model.capabilities ? {
       ...(model.capabilities.vision !== undefined ? { vision: model.capabilities.vision } : {}),
       ...(model.capabilities.tool_calling !== undefined ? { toolCalling: model.capabilities.tool_calling } : {}),
@@ -2451,7 +2476,9 @@ export function createApiRouter(
         model: selected.model,
         contextWindowTokens: selected.contextWindowTokens ?? 200_000,
         reasoningEffort,
-        openaiApiMode: 'chat_completions',
+        openaiApiMode: selected.provider === 'openai'
+          ? selected.openaiApiMode ?? 'responses'
+          : 'chat_completions',
         capabilities: {
           toolCalling: true,
           ...(selected.capabilities?.vision !== undefined ? { vision: selected.capabilities.vision } : {}),

--- a/tests/bot-definition-activation.test.ts
+++ b/tests/bot-definition-activation.test.ts
@@ -1462,6 +1462,59 @@ describe('BotDefinition activation', () => {
     assert.equal(resolveActiveBotLLMConfig({ runtimeRoot, env })?.config.model, 'MiniMax-M3');
   });
 
+  test('repairs a legacy CatsCo catalog runtime that persisted OpenAI Chat mode', () => {
+    const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-legacy-relay-mode-runtime-'));
+    roots.push(runtimeRoot);
+    const env = {} as NodeJS.ProcessEnv;
+    createCatsCoLocalConfigService({ runtimeRoot, env }).save({
+      version: 1,
+      account: { token: 'user-token', uid: '7' },
+      currentBot: { uid: '43', apiKey: 'bot-api-key', boundByUserUid: '7', bindingSource: 'test' },
+    });
+    new FileBotDefinitionRepository({ runtimeRoot }).writeCache({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: '43',
+      model: { kind: 'catalog', modelId: 'gpt-5.6-sol' },
+    });
+    new FileBotCatalogModelRuntimeRepository({ runtimeRoot }).write({
+      schema: 'xiaoba.bot-catalog-model-runtime.v1',
+      botId: '43',
+      modelId: 'gpt-5.6-sol',
+      provider: 'openai',
+      apiBase: 'https://relay.catsco.cc/v1',
+      apiKey: 'sk-legacy-relay',
+      model: 'gpt-5.6-sol',
+      contextWindowTokens: 256000,
+      openaiApiMode: 'chat_completions',
+    });
+
+    const resolved = resolveActiveBotLLMConfig({ runtimeRoot, env });
+    assert.equal(resolved?.source, 'catalog_runtime');
+    assert.equal(resolved?.config.openaiApiMode, 'responses');
+  });
+
+  test('keeps explicit Chat mode for custom models on the CatsCo Relay endpoint', () => {
+    const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-custom-relay-chat-runtime-'));
+    roots.push(runtimeRoot);
+    const env = {} as NodeJS.ProcessEnv;
+    createCatsCoLocalConfigService({ runtimeRoot, env }).save({
+      version: 1,
+      currentBot: { uid: '44', apiKey: 'bot-api-key', boundByUserUid: '7', bindingSource: 'test' },
+    });
+    new FileBotDefinitionRepository({ runtimeRoot }).writeCache({
+      schema: BOT_DEFINITION_SCHEMA,
+      botId: '44',
+      model: {
+        kind: 'custom', protocol: 'openai-chat-completions', apiBase: 'https://relay.catsco.cc/v1',
+        model: 'manual-model', apiKey: 'sk-custom', contextWindowTokens: 128000,
+      },
+    });
+
+    const resolved = resolveActiveBotLLMConfig({ runtimeRoot, env });
+    assert.equal(resolved?.source, 'custom_definition');
+    assert.equal(resolved?.config.openaiApiMode, 'chat_completions');
+  });
+
   test('re-materializes the cloud catalog runtime when the cached credential is rejected but a login token exists', async () => {
     const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-steady-rejected-runtime-'));
     const simulatedCloudRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-steady-rejected-canonical-'));

--- a/tests/dashboard-settings-api.test.ts
+++ b/tests/dashboard-settings-api.test.ts
@@ -1201,7 +1201,7 @@ describe('dashboard typed settings API', () => {
     }
   });
 
-  test('POST /cats/relay/model-config/apply writes selected relay model with CatsCo Anthropic settings', async () => {
+  test('POST /cats/relay/model-config/apply uses cloud-authoritative Responses metadata for a relay catalog model', async () => {
     const catsApp = express();
     catsApp.use(express.json());
     catsApp.get('/api/relay/config', (req, res) => {
@@ -1232,6 +1232,14 @@ describe('dashboard typed settings API', () => {
             provider: 'openai',
             protocol: 'OpenAI-compatible',
             base_url: 'https://relay.catsco.cc/v1',
+            runtime: {
+              catalogModelId: 'deepseek-v4-flash',
+              model: 'deepseek-v4-flash',
+              provider: 'openai',
+              contextWindowTokens: 1000000,
+              openaiApiMode: 'responses',
+              capabilities: { vision: true, toolCalling: true, streaming: true },
+            },
             enabled: true,
             quota_class: 'flash-low',
           },
@@ -1278,14 +1286,17 @@ describe('dashboard typed settings API', () => {
       assert.equal(data.selectedModel.id, 'deepseek-v4-flash');
       assert.equal(data.selectedModel.base_url, 'https://relay.catsco.cc/v1');
       assert.equal(data.selectedModel.sdk_label, 'OpenAI SDK');
+      assert.equal(data.selectedModel.openai_api_mode, 'responses');
       assert.equal(parsed.GAUZ_LLM_PROVIDER, 'openai');
       assert.equal(parsed.GAUZ_LLM_API_BASE, 'https://relay.catsco.cc/v1');
       assert.equal(parsed.GAUZ_LLM_MODEL, 'deepseek-v4-flash');
       assert.equal(parsed.GAUZ_LLM_CONTEXT_WINDOW_TOKENS, '1000000');
       assert.equal(parsed.GAUZ_LLM_REASONING_EFFORT, 'max');
       assert.equal(parsed.GAUZ_LLM_API_KEY, 'sk-bf-openai-compatible');
+      assert.equal(parsed.GAUZ_LLM_OPENAI_API_MODE, 'responses');
       assert.equal(parsed.CATSCO_RELAY_LLM_CONTEXT_WINDOW_TOKENS, '1000000');
       assert.equal(parsed.CATSCO_RELAY_LLM_REASONING_EFFORT, 'max');
+      assert.equal(parsed.CATSCO_RELAY_LLM_OPENAI_API_MODE, 'responses');
       assert.equal(parsed.CATSCO_RELAY_LLM_VISION_CAPABLE, 'true');
       assert.equal(parsed.CATSCO_RELAY_LLM_TOOL_CALLING_CAPABLE, 'true');
       assert.equal(data.selectedModel.context_window_tokens, 1000000);


### PR DESCRIPTION
## Summary\n- use cloud catalog runtime metadata as the authority for Relay model protocol and model fields\n- default OpenAI catalog selections to Responses only when the cloud omits the mode\n- repair legacy CatsCo catalog runtimes persisted with Chat mode\n- preserve explicit Chat mode for manually configured custom models\n\n## Validation\n- 102 focused TypeScript tests passed\n- 
pm run build passed\n- local fallback behavior remains covered for older cloud responses\n\nRelated: buildsense-ai/cats-company# (cloud catalog endpoint change)