### PR TITLE
chore(release): bump version to v1.5.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xiaoba-cli",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xiaoba-cli",
-      "version": "1.5.4",
+      "version": "1.5.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xiaoba-cli",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "CatsCo - local agent runtime and dashboard",
   "main": "electron/main.js",
   "bin": {


### PR DESCRIPTION
Release v1.5.5.\n\n- Bump package.json and package-lock.json to 1.5.5.\n- Release CI will build desktop artifacts, worker artifact, publish TOS payloads, and verify update metadata.