### PR TITLE
fix: restore reliable desktop update progress and install feedback

### DIFF
--- a/dashboard/connector.css
+++ b/dashboard/connector.css
@@ -419,6 +419,19 @@ h1 {
   white-space: pre-wrap;
   overflow-wrap: anywhere;
 }
+.update-manual-link {
+  margin: 12px 0 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: #245fc7;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 650;
+  cursor: pointer;
+}
+.update-manual-link:hover { text-decoration: underline; }
+.update-manual-link:focus-visible { outline: 2px solid #8bb3fa; outline-offset: 3px; border-radius: 2px; }
 .update-dialog-footer {
   padding: 15px 24px 20px;
   display: flex;

--- a/dashboard/connector.html
+++ b/dashboard/connector.html
@@ -246,6 +246,7 @@
 
         <p class="update-note" id="update-note">检查完成后会在这里显示更新详情。</p>
         <div class="update-error-box" id="update-error-box" role="alert" hidden></div>
+        <button class="update-manual-link" id="update-manual-link" type="button" hidden>前往发布页手动下载</button>
       </div>
 
       <footer class="update-dialog-footer">

--- a/dashboard/connector.js
+++ b/dashboard/connector.js
@@ -357,13 +357,14 @@
     if (!button) return;
     const stage = update.stage || 'idle';
     const percent = clampUpdatePercent(update.percent);
-    button.classList.toggle('update-active', stage === 'checking' || stage === 'downloading');
+    button.classList.toggle('update-active', ['checking', 'downloading', 'preparing_install'].includes(stage));
     button.classList.toggle('update-error', stage === 'error');
-    button.disabled = update.enabled === false || stage === 'installing';
+    button.disabled = update.enabled === false || stage === 'preparing_install' || stage === 'installing';
     if (stage === 'available') button.textContent = `下载 ${update.availableVersion || '新版本'}`;
     else if (stage === 'downloaded') button.textContent = '安装更新';
     else if (stage === 'checking') button.textContent = '检查中…';
     else if (stage === 'downloading') button.textContent = `下载 ${Math.round(percent)}%`;
+    else if (stage === 'preparing_install') button.textContent = '准备安装…';
     else if (stage === 'installing') button.textContent = '安装中…';
     else if (stage === 'error') button.textContent = '重试更新';
     else if (update.enabled === false) button.textContent = '开发版本';
@@ -375,6 +376,7 @@
 
   function updateButtonAriaLabel(update, percent) {
     if (update.stage === 'downloading') return `更新下载进度 ${Math.round(percent)}%`;
+    if (update.stage === 'preparing_install') return '更新已下载，macOS 正在准备安装';
     if (update.stage === 'available') return `下载 CatsCo ${update.availableVersion || '新版本'}`;
     if (update.stage === 'downloaded') return '更新已下载，打开安装确认';
     if (update.stage === 'error') return '更新失败，打开详情并重试';
@@ -463,6 +465,18 @@
           primaryDisabled: false,
           tone: 'success',
         };
+      case 'preparing_install':
+        return {
+          title: '正在准备安装',
+          subtitle: `${version} 已下载，macOS 正在准备安装程序。`,
+          label: '下载完成，正在准备安装',
+          note: '这一步由 macOS 更新服务完成，通常只需要片刻。准备完成后，安装按钮会自动出现。',
+          footer: 'Connector 会继续运行，请稍候',
+          secondary: '隐藏到后台',
+          primary: '准备中…',
+          primaryDisabled: true,
+          tone: 'active',
+        };
       case 'installing':
         return {
           title: '正在安装更新',
@@ -521,10 +535,10 @@
     const stage = update.stage || (update.enabled === false ? 'disabled' : 'idle');
     const normalized = { ...update, stage };
     const meta = updateDialogMeta(normalized);
-    const percent = stage === 'downloaded' || stage === 'installing' ? 100 : clampUpdatePercent(update.percent);
-    const progressVisible = ['checking', 'downloading', 'downloaded', 'installing'].includes(stage)
+    const percent = ['preparing_install', 'downloaded', 'installing'].includes(stage) ? 100 : clampUpdatePercent(update.percent);
+    const progressVisible = ['checking', 'downloading', 'preparing_install', 'downloaded', 'installing'].includes(stage)
       || (stage === 'error' && Number(update.transferred || 0) > 0);
-    const versionVisible = Boolean(update.availableVersion) || ['available', 'downloading', 'downloaded', 'installing'].includes(stage);
+    const versionVisible = Boolean(update.availableVersion) || ['available', 'downloading', 'preparing_install', 'downloaded', 'installing'].includes(stage);
 
     setText('update-title', meta.title);
     setText('update-subtitle', meta.subtitle);
@@ -557,7 +571,15 @@
       const total = Number(update.total || 0);
       $('update-size').textContent = total > 0 ? `${formatUpdateBytes(transferred)} / ${formatUpdateBytes(total)}` : '等待下载信息';
       $('update-speed').textContent = Number(update.bytesPerSecond || 0) > 0 ? `${formatUpdateBytes(update.bytesPerSecond)}/s` : '';
-      $('update-remaining').textContent = stage === 'downloading' ? formatUpdateRemaining(update) : stage === 'downloaded' ? '可以安装' : '';
+      $('update-remaining').textContent = stage === 'downloading'
+        ? formatUpdateRemaining(update)
+        : stage === 'preparing_install'
+          ? '正在准备安装'
+          : stage === 'downloaded'
+            ? '可以安装'
+            : stage === 'installing'
+              ? '正在启动安装'
+              : '';
     }
 
     const error = $('update-error-box');
@@ -566,6 +588,11 @@
     error.textContent = stage === 'error'
       ? [update.lastError?.reason || update.reason || 'UPDATE_ERROR', errorMessage].filter(Boolean).join('\n')
       : '';
+
+    const manualLink = $('update-manual-link');
+    const manualLinkVisible = Boolean(update.releasePageUrl) && ['preparing_install', 'error'].includes(stage);
+    manualLink.hidden = !manualLinkVisible;
+    manualLink.textContent = stage === 'preparing_install' ? '准备时间较长？手动下载' : '前往发布页手动下载';
 
     $('update-secondary-action').textContent = meta.secondary;
     $('update-primary-action').textContent = meta.primary;
@@ -584,7 +611,7 @@
   }
 
   function isUpdatePollingStage(stage) {
-    return stage === 'checking' || stage === 'downloading' || stage === 'installing';
+    return stage === 'checking' || stage === 'downloading' || stage === 'preparing_install' || stage === 'installing';
   }
 
   function syncUpdatePolling() {
@@ -606,7 +633,9 @@
       if (!result.ok) return;
       state.update = result.value || {};
       renderUpdate();
-      if (!($('update-dialog')?.open) && previousStage === 'downloading' && ['downloaded', 'error'].includes(state.update.stage)) {
+      if (!($('update-dialog')?.open)
+        && ['downloading', 'preparing_install', 'installing'].includes(previousStage)
+        && ['downloaded', 'error'].includes(state.update.stage)) {
         openUpdateDialog();
       }
     })();
@@ -1121,11 +1150,27 @@
     state.update = { ...(state.update || {}), stage: 'installing', message: 'Quitting and installing update...' };
     renderUpdate();
     try {
-      await request('/update/install', { method: 'POST', body: '{}' });
+      const result = await request('/update/install', { method: 'POST', body: '{}' });
+      state.update = { ...(state.update || {}), ...(result || {}) };
+      renderUpdate();
     } catch (error) {
       setUpdateActionError(error, 'UPDATE_INSTALL_FAILED');
+    } finally {
       state.updateActionBusy = false;
       renderUpdate();
+    }
+  }
+
+  async function openManualUpdatePage() {
+    if (!state.update?.releasePageUrl) return;
+    try {
+      if (window.catscoDesktop?.openReleasePage) {
+        await window.catscoDesktop.openReleasePage();
+      } else {
+        window.open(state.update.releasePageUrl, '_blank', 'noopener,noreferrer');
+      }
+    } catch (error) {
+      showToast(`无法打开发布页：${humanError(error)}`);
     }
   }
 
@@ -1197,6 +1242,7 @@
   $('update-close').addEventListener('click', closeUpdateDialog);
   $('update-secondary-action').addEventListener('click', closeUpdateDialog);
   $('update-primary-action').addEventListener('click', handleUpdatePrimaryAction);
+  $('update-manual-link').addEventListener('click', () => { void openManualUpdatePage(); });
   $('update-dialog').addEventListener('cancel', (event) => {
     if (state.update?.stage === 'installing') event.preventDefault();
   });

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,7 +1,18 @@
-const { app, BrowserWindow, Tray, Menu, nativeImage, ipcMain, dialog, shell } = require('electron');
+const {
+  app,
+  BrowserWindow,
+  Tray,
+  Menu,
+  nativeImage,
+  ipcMain,
+  dialog,
+  shell,
+  autoUpdater: nativeAutoUpdater,
+} = require('electron');
 const path = require('path');
 const fs = require('fs');
-const { normalizeUpdateError } = require('./update-errors');
+const { createUpdateController } = require('./update-controller');
+const { createUpdateLogger } = require('./update-log');
 const { shouldDisableHardwareAcceleration } = require('./gpu-compat');
 const { createRendererGoneGuard } = require('./renderer-gone');
 
@@ -25,6 +36,7 @@ const TRUSTED_DEEP_LINK_BASE_ORIGINS = new Set([
   'https://app.catsco.cn',
 ]);
 const CATSCO_WEBAPP_URL = 'https://app.catsco.cc';
+const DEFAULT_RELEASE_PAGE_URL = 'https://github.com/buildsense-ai/XiaoBa-CLI/releases/latest';
 let mainWindow = null;
 let tray = null;
 let autoUpdater = null;
@@ -340,10 +352,11 @@ function resolveReleasePageUrl() {
       return `https://github.com/${publishConfig.owner}/${publishConfig.repo}/releases/latest`;
     }
   } catch (_error) {
-    return null;
+    // Packaged builds can omit the full publish section. The stable release
+    // page still provides a safe manual fallback when automatic install fails.
   }
 
-  return null;
+  return DEFAULT_RELEASE_PAGE_URL;
 }
 
 function readPackagedUpdateBaseUrl() {
@@ -367,141 +380,21 @@ function resolveUpdateBaseUrl() {
   return normalizeUrl(process.env.XIAOBA_UPDATE_BASE_URL) || readPackagedUpdateBaseUrl();
 }
 
-const updateState = {
-  enabled: Boolean(autoUpdater),
-  stage: autoUpdater ? 'idle' : 'disabled',
-  message: autoUpdater ? 'Updater is ready' : 'Updater is unavailable',
-  currentVersion: app.getVersion(),
-  availableVersion: null,
-  releaseNotes: null,
+const updateLogger = createUpdateLogger({
+  logPath: path.join(app.getPath('userData'), 'logs', 'updater.log'),
+});
+if (autoUpdater) autoUpdater.logger = updateLogger;
+
+const updateController = createUpdateController({
+  updater: autoUpdater,
+  nativeUpdater: nativeAutoUpdater,
+  app,
+  platform: process.platform,
+  currentVersion: () => app.getVersion(),
   releasePageUrl: resolveReleasePageUrl(),
   updateBaseUrl: resolveUpdateBaseUrl(),
-  percent: 0,
-  bytesPerSecond: 0,
-  transferred: 0,
-  total: 0,
-  checkedAt: null,
-  updatedAt: Date.now(),
-  isManualCheck: false,
-  lastError: null,
-};
-
-let checkInFlight = null;
-let downloadInFlight = null;
-
-function getUpdateStatusSnapshot() {
-  return { ...updateState };
-}
-
-function setUpdateState(patch) {
-  Object.assign(updateState, patch, {
-    currentVersion: app.getVersion(),
-    updatedAt: Date.now(),
-  });
-}
-
-function markUpdateError(error, fallbackReason = 'UPDATE_ERROR') {
-  const normalized = normalizeUpdateError(error, fallbackReason);
-  console.error(`[auto-update] ${normalized.reason}:`, error);
-  setUpdateState({
-    stage: 'error',
-    message: 'Update failed: ' + normalized.reason,
-    lastError: normalized,
-  });
-
-  const wrapped = new Error(normalized.message);
-  wrapped.reason = normalized.reason;
-  return wrapped;
-}
-
-const updateController = {
-  getStatus() {
-    return getUpdateStatusSnapshot();
-  },
-
-  async checkForUpdates(manual = false) {
-    if (!autoUpdater) {
-      return getUpdateStatusSnapshot();
-    }
-
-    if (checkInFlight) {
-      return checkInFlight;
-    }
-
-    setUpdateState({
-      stage: 'checking',
-      message: manual ? 'Checking for updates...' : 'Checking for updates in background...',
-      isManualCheck: Boolean(manual),
-      checkedAt: Date.now(),
-      lastError: null,
-    });
-
-    checkInFlight = autoUpdater
-      .checkForUpdates()
-      .then(() => getUpdateStatusSnapshot())
-      .catch((error) => {
-        throw markUpdateError(error, 'UPDATE_CHECK_FAILED');
-      })
-      .finally(() => {
-        checkInFlight = null;
-      });
-
-    return checkInFlight;
-  },
-
-  async downloadUpdate() {
-    if (!autoUpdater) {
-      throw markUpdateError(new Error('Updater is unavailable'), 'UPDATER_UNAVAILABLE');
-    }
-
-    if (downloadInFlight) {
-      return downloadInFlight;
-    }
-
-    if (updateState.stage !== 'available' && updateState.stage !== 'downloading') {
-      throw markUpdateError(new Error('No available update to download'), 'UPDATE_NOT_AVAILABLE');
-    }
-
-    setUpdateState({
-      stage: 'downloading',
-      message: 'Starting update download...',
-      percent: 0,
-      bytesPerSecond: 0,
-      transferred: 0,
-      total: 0,
-      lastError: null,
-    });
-
-    downloadInFlight = autoUpdater
-      .downloadUpdate()
-      .then(() => getUpdateStatusSnapshot())
-      .catch((error) => {
-        throw markUpdateError(error, 'UPDATE_DOWNLOAD_FAILED');
-      })
-      .finally(() => {
-        downloadInFlight = null;
-      });
-
-    return downloadInFlight;
-  },
-
-  installUpdate() {
-    if (!autoUpdater) {
-      throw markUpdateError(new Error('Updater is unavailable'), 'UPDATER_UNAVAILABLE');
-    }
-
-    if (updateState.stage !== 'downloaded') {
-      throw markUpdateError(new Error('Update package is not downloaded yet'), 'UPDATE_NOT_READY');
-    }
-
-    setUpdateState({
-      stage: 'installing',
-      message: 'Quitting and installing update...',
-    });
-
-    autoUpdater.quitAndInstall();
-  },
-};
+  logger: updateLogger,
+});
 function getAppRoot() {
   if (app.isPackaged) {
     return path.join(process.resourcesPath, 'app');
@@ -756,6 +649,15 @@ ipcMain.handle('catsco:open-webapp', async (event) => {
   return true;
 });
 
+ipcMain.handle('catsco:open-release-page', async (event) => {
+  const owner = BrowserWindow.fromWebContents(event.sender);
+  if (owner !== mainWindow) return false;
+  const releasePageUrl = updateController.getStatus().releasePageUrl;
+  if (!releasePageUrl) return false;
+  await shell.openExternal(releasePageUrl);
+  return true;
+});
+
 function getRuntimeDataRootForMenu() {
   return process.env.XIAOBA_USER_DATA_DIR
     || process.env.CATSCO_USER_DATA_DIR
@@ -868,7 +770,7 @@ function createApplicationMenu() {
         {
           label: '打开发布页',
           click: () => {
-            const url = updateState.releasePageUrl;
+            const url = updateController.getStatus().releasePageUrl;
             if (url) shell.openExternal(url);
           },
         },
@@ -893,74 +795,6 @@ function createTray() {
   tray.setContextMenu(contextMenu);
   tray.on('click', () => {
     showMainWindow();
-  });
-}
-
-// 闂備礁鎼ú銈夋偤閵娾晛钃熷┑鐘插暟椤╂煡鎮楅敐鍌涙珕妞ゆ劒绮欓弻锝夊煛閸屾氨浠撮梺?
-if (autoUpdater) {
-  autoUpdater.on('checking-for-update', () => {
-    setUpdateState({
-      stage: 'checking',
-      message: 'Checking for updates...',
-      checkedAt: Date.now(),
-      lastError: null,
-    });
-  });
-
-  autoUpdater.on('update-available', (info) => {
-    setUpdateState({
-      stage: 'available',
-      message: 'Update ' + (info.version || '') + ' is available',
-      availableVersion: info.version || null,
-      releaseNotes: typeof info.releaseNotes === 'string' ? info.releaseNotes : null,
-      percent: 0,
-      bytesPerSecond: 0,
-      transferred: 0,
-      total: 0,
-      lastError: null,
-    });
-  });
-
-  autoUpdater.on('update-not-available', () => {
-    setUpdateState({
-      stage: 'idle',
-      message: 'Already on the latest version',
-      availableVersion: null,
-      releaseNotes: null,
-      percent: 0,
-      bytesPerSecond: 0,
-      transferred: 0,
-      total: 0,
-      lastError: null,
-    });
-  });
-
-  autoUpdater.on('download-progress', (progress) => {
-    setUpdateState({
-      stage: 'downloading',
-      message: 'Downloading update...',
-      percent: Number(progress?.percent || 0),
-      bytesPerSecond: Number(progress?.bytesPerSecond || 0),
-      transferred: Number(progress?.transferred || 0),
-      total: Number(progress?.total || 0),
-    });
-  });
-
-  autoUpdater.on('update-downloaded', (info) => {
-    setUpdateState({
-      stage: 'downloaded',
-      message: 'Update ' + (info.version || '') + ' downloaded',
-      availableVersion: info.version || updateState.availableVersion,
-      percent: 100,
-      bytesPerSecond: 0,
-      transferred: updateState.total || updateState.transferred,
-      total: updateState.total || updateState.transferred,
-      lastError: null,
-    });
-  });
-
-  autoUpdater.on('error', (error) => {
-    markUpdateError(error, 'UPDATE_RUNTIME_ERROR');
   });
 }
 
@@ -1004,5 +838,6 @@ app.on('child-process-gone', (_event, details) => {
 
 app.on('before-quit', () => {
   app.isQuitting = true;
+  updateController.dispose();
   stopDashboardServer();
 });

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -3,5 +3,6 @@ const { contextBridge, ipcRenderer } = require('electron');
 contextBridge.exposeInMainWorld('catscoDesktop', {
   selectFiles: () => ipcRenderer.invoke('catsco:select-files'),
   openWebApp: () => ipcRenderer.invoke('catsco:open-webapp'),
+  openReleasePage: () => ipcRenderer.invoke('catsco:open-release-page'),
   hideWindow: () => ipcRenderer.invoke('catsco:hide-window'),
 });

--- a/electron/update-controller.js
+++ b/electron/update-controller.js
@@ -147,6 +147,10 @@ function createUpdateController(options) {
 
   if (updater) {
     on(updater, 'checking-for-update', () => {
+      if (DOWNLOAD_COMPLETE_STAGES.has(state.stage)) {
+        logger.info?.(`ignored checking-for-update event while state is ${state.stage}`);
+        return;
+      }
       setState({
         stage: 'checking',
         message: 'Checking for updates...',
@@ -156,6 +160,10 @@ function createUpdateController(options) {
     }, updaterListeners);
 
     on(updater, 'update-available', (info = {}) => {
+      if (DOWNLOAD_COMPLETE_STAGES.has(state.stage)) {
+        logger.info?.(`ignored update-available event while state is ${state.stage}`);
+        return;
+      }
       nativeInstallReady = platform !== 'darwin';
       setState({
         stage: 'available',
@@ -250,6 +258,10 @@ function createUpdateController(options) {
 
     async checkForUpdates(manual = false) {
       if (!updater) return snapshot();
+      if (DOWNLOAD_COMPLETE_STAGES.has(state.stage)) {
+        logger.info?.(`ignored update check while state is ${state.stage}`);
+        return snapshot();
+      }
       if (checkInFlight) return checkInFlight;
 
       setState({

--- a/electron/update-controller.js
+++ b/electron/update-controller.js
@@ -1,0 +1,355 @@
+'use strict';
+
+const { normalizeUpdateError } = require('./update-errors');
+
+const DEFAULT_PREPARATION_TIMEOUT_MS = 120_000;
+const DEFAULT_INSTALL_DELAY_MS = 250;
+const DEFAULT_INSTALL_TIMEOUT_MS = 30_000;
+const DOWNLOAD_COMPLETE_STAGES = new Set(['preparing_install', 'downloaded', 'installing']);
+
+function createUpdateController(options) {
+  const {
+    updater,
+    nativeUpdater,
+    app,
+    platform = process.platform,
+    currentVersion = () => app?.getVersion?.() || null,
+    releasePageUrl = null,
+    updateBaseUrl = null,
+    logger = console,
+    setTimeoutImpl = setTimeout,
+    clearTimeoutImpl = clearTimeout,
+    preparationTimeoutMs = DEFAULT_PREPARATION_TIMEOUT_MS,
+    installDelayMs = DEFAULT_INSTALL_DELAY_MS,
+    installTimeoutMs = DEFAULT_INSTALL_TIMEOUT_MS,
+  } = options || {};
+
+  const state = {
+    enabled: Boolean(updater),
+    stage: updater ? 'idle' : 'disabled',
+    message: updater ? 'Updater is ready' : 'Updater is unavailable',
+    currentVersion: currentVersion(),
+    availableVersion: null,
+    releaseNotes: null,
+    releasePageUrl,
+    updateBaseUrl,
+    percent: 0,
+    bytesPerSecond: 0,
+    transferred: 0,
+    total: 0,
+    checkedAt: null,
+    updatedAt: Date.now(),
+    isManualCheck: false,
+    lastError: null,
+  };
+
+  let checkInFlight = null;
+  let downloadInFlight = null;
+  let preparationTimer = null;
+  let installDelayTimer = null;
+  let installWatchdogTimer = null;
+  let nativeInstallReady = platform !== 'darwin';
+  let appQuitObserved = false;
+  let lastLoggedProgressBucket = -1;
+  const updaterListeners = [];
+  const nativeListeners = [];
+
+  function snapshot() {
+    return { ...state, lastError: state.lastError ? { ...state.lastError } : null };
+  }
+
+  function setState(patch) {
+    const previousStage = state.stage;
+    Object.assign(state, patch, {
+      currentVersion: currentVersion(),
+      updatedAt: Date.now(),
+    });
+    if (state.stage !== previousStage) {
+      logger.info?.(`state ${previousStage} -> ${state.stage}: ${state.message || ''}`);
+    }
+  }
+
+  function clearTimer(timer) {
+    if (timer) clearTimeoutImpl(timer);
+  }
+
+  function clearPreparationTimer() {
+    clearTimer(preparationTimer);
+    preparationTimer = null;
+  }
+
+  function clearInstallTimers() {
+    clearTimer(installDelayTimer);
+    clearTimer(installWatchdogTimer);
+    installDelayTimer = null;
+    installWatchdogTimer = null;
+  }
+
+  function markError(error, fallbackReason = 'UPDATE_ERROR') {
+    clearPreparationTimer();
+    clearInstallTimers();
+    const normalized = normalizeUpdateError(error, fallbackReason);
+    if (state.stage === 'error' && state.lastError?.message === normalized.message) {
+      const existing = new Error(state.lastError.message);
+      existing.reason = state.lastError.reason;
+      return existing;
+    }
+    logger.error?.(`${normalized.reason}: ${normalized.message}`);
+    setState({
+      stage: 'error',
+      message: `Update failed: ${normalized.reason}`,
+      lastError: normalized,
+    });
+
+    const wrapped = new Error(normalized.message);
+    wrapped.reason = normalized.reason;
+    return wrapped;
+  }
+
+  function startPreparationTimeout() {
+    clearPreparationTimer();
+    preparationTimer = setTimeoutImpl(() => {
+      preparationTimer = null;
+      if (state.stage !== 'preparing_install') return;
+      markError(
+        new Error('macOS timed out while preparing the downloaded update for installation'),
+        'UPDATE_INSTALL_PREPARATION_TIMEOUT',
+      );
+    }, preparationTimeoutMs);
+  }
+
+  function markDownloaded(info = {}) {
+    clearPreparationTimer();
+    setState({
+      stage: 'downloaded',
+      message: `Update ${info.version || state.availableVersion || ''} downloaded`.trim(),
+      availableVersion: info.version || state.availableVersion,
+      percent: 100,
+      bytesPerSecond: 0,
+      transferred: state.total || state.transferred,
+      total: state.total || state.transferred,
+      lastError: null,
+    });
+  }
+
+  function on(emitter, eventName, listener, collection) {
+    if (!emitter?.on) return;
+    emitter.on(eventName, listener);
+    collection.push([emitter, eventName, listener]);
+  }
+
+  function removeListeners(collection) {
+    for (const [emitter, eventName, listener] of collection) {
+      emitter.removeListener?.(eventName, listener);
+    }
+    collection.length = 0;
+  }
+
+  if (updater) {
+    on(updater, 'checking-for-update', () => {
+      setState({
+        stage: 'checking',
+        message: 'Checking for updates...',
+        checkedAt: Date.now(),
+        lastError: null,
+      });
+    }, updaterListeners);
+
+    on(updater, 'update-available', (info = {}) => {
+      nativeInstallReady = platform !== 'darwin';
+      setState({
+        stage: 'available',
+        message: `Update ${info.version || ''} is available`,
+        availableVersion: info.version || null,
+        releaseNotes: typeof info.releaseNotes === 'string' ? info.releaseNotes : null,
+        percent: 0,
+        bytesPerSecond: 0,
+        transferred: 0,
+        total: 0,
+        lastError: null,
+      });
+    }, updaterListeners);
+
+    on(updater, 'update-not-available', () => {
+      if (DOWNLOAD_COMPLETE_STAGES.has(state.stage)) return;
+      setState({
+        stage: 'idle',
+        message: 'Already on the latest version',
+        availableVersion: null,
+        releaseNotes: null,
+        percent: 0,
+        bytesPerSecond: 0,
+        transferred: 0,
+        total: 0,
+        lastError: null,
+      });
+    }, updaterListeners);
+
+    on(updater, 'download-progress', (progress = {}) => {
+      const percent = Number(progress.percent || 0);
+      setState({
+        stage: 'downloading',
+        message: 'Downloading update...',
+        percent,
+        bytesPerSecond: Number(progress.bytesPerSecond || 0),
+        transferred: Number(progress.transferred || 0),
+        total: Number(progress.total || 0),
+      });
+      const bucket = Math.floor(percent / 10);
+      if (bucket !== lastLoggedProgressBucket) {
+        lastLoggedProgressBucket = bucket;
+        logger.info?.(`download progress ${Math.round(percent)}% (${state.transferred}/${state.total})`);
+      }
+    }, updaterListeners);
+
+    on(updater, 'update-downloaded', (info = {}) => {
+      if (platform === 'darwin' && !nativeInstallReady) {
+        setState({
+          stage: 'preparing_install',
+          message: 'Download complete; macOS is preparing the update for installation...',
+          availableVersion: info.version || state.availableVersion,
+          percent: 100,
+          bytesPerSecond: 0,
+          transferred: state.total || state.transferred,
+          total: state.total || state.transferred,
+          lastError: null,
+        });
+        startPreparationTimeout();
+        return;
+      }
+      markDownloaded(info);
+    }, updaterListeners);
+
+    on(updater, 'error', (error) => {
+      markError(error, 'UPDATE_RUNTIME_ERROR');
+    }, updaterListeners);
+  }
+
+  if (platform === 'darwin' && nativeUpdater && nativeUpdater !== updater) {
+    on(nativeUpdater, 'update-downloaded', () => {
+      nativeInstallReady = true;
+      logger.info?.('macOS native updater reports the update is ready to install');
+      if (state.stage === 'preparing_install') markDownloaded();
+    }, nativeListeners);
+    on(nativeUpdater, 'error', (error) => {
+      if (state.stage === 'preparing_install' || state.stage === 'installing') {
+        markError(error, 'UPDATE_INSTALL_PREPARATION_FAILED');
+      }
+    }, nativeListeners);
+  }
+
+  const onBeforeQuit = () => {
+    appQuitObserved = true;
+    clearInstallTimers();
+    logger.info?.('application quit observed; installer handoff started');
+  };
+  on(app, 'before-quit', onBeforeQuit, nativeListeners);
+
+  return {
+    getStatus: snapshot,
+
+    async checkForUpdates(manual = false) {
+      if (!updater) return snapshot();
+      if (checkInFlight) return checkInFlight;
+
+      setState({
+        stage: 'checking',
+        message: manual ? 'Checking for updates...' : 'Checking for updates in background...',
+        isManualCheck: Boolean(manual),
+        checkedAt: Date.now(),
+        lastError: null,
+      });
+
+      checkInFlight = updater.checkForUpdates()
+        .then(snapshot)
+        .catch((error) => { throw markError(error, 'UPDATE_CHECK_FAILED'); })
+        .finally(() => { checkInFlight = null; });
+      return checkInFlight;
+    },
+
+    async downloadUpdate() {
+      if (!updater) {
+        throw markError(new Error('Updater is unavailable'), 'UPDATER_UNAVAILABLE');
+      }
+      if (downloadInFlight) return downloadInFlight;
+      if (DOWNLOAD_COMPLETE_STAGES.has(state.stage)) {
+        logger.info?.(`ignored duplicate download request while state is ${state.stage}`);
+        return snapshot();
+      }
+      if (state.stage !== 'available' && state.stage !== 'downloading') {
+        throw markError(new Error('No available update to download'), 'UPDATE_NOT_AVAILABLE');
+      }
+
+      nativeInstallReady = platform !== 'darwin';
+      lastLoggedProgressBucket = -1;
+      setState({
+        stage: 'downloading',
+        message: 'Starting update download...',
+        percent: 0,
+        bytesPerSecond: 0,
+        transferred: 0,
+        total: 0,
+        lastError: null,
+      });
+
+      downloadInFlight = updater.downloadUpdate()
+        .then(snapshot)
+        .catch((error) => { throw markError(error, 'UPDATE_DOWNLOAD_FAILED'); })
+        .finally(() => { downloadInFlight = null; });
+      return downloadInFlight;
+    },
+
+    installUpdate() {
+      if (!updater) {
+        throw markError(new Error('Updater is unavailable'), 'UPDATER_UNAVAILABLE');
+      }
+      if (state.stage === 'installing') return snapshot();
+      if (state.stage !== 'downloaded') {
+        throw markError(new Error('Update package is not ready to install yet'), 'UPDATE_NOT_READY');
+      }
+
+      appQuitObserved = false;
+      setState({
+        stage: 'installing',
+        message: 'Quitting and installing update...',
+        lastError: null,
+      });
+
+      installDelayTimer = setTimeoutImpl(() => {
+        installDelayTimer = null;
+        try {
+          logger.info?.('requesting updater quit-and-install handoff');
+          updater.quitAndInstall();
+        } catch (error) {
+          markError(error, 'UPDATE_INSTALL_FAILED');
+          return;
+        }
+
+        installWatchdogTimer = setTimeoutImpl(() => {
+          installWatchdogTimer = null;
+          if (appQuitObserved || state.stage !== 'installing') return;
+          markError(
+            new Error('The installer did not start after CatsCo requested the update handoff'),
+            'UPDATE_INSTALL_DID_NOT_START',
+          );
+        }, installTimeoutMs);
+      }, installDelayMs);
+
+      return snapshot();
+    },
+
+    dispose() {
+      clearPreparationTimer();
+      clearInstallTimers();
+      removeListeners(updaterListeners);
+      removeListeners(nativeListeners);
+    },
+  };
+}
+
+module.exports = {
+  DEFAULT_INSTALL_DELAY_MS,
+  DEFAULT_INSTALL_TIMEOUT_MS,
+  DEFAULT_PREPARATION_TIMEOUT_MS,
+  createUpdateController,
+};

--- a/electron/update-errors.js
+++ b/electron/update-errors.js
@@ -2,6 +2,7 @@
 
 const MAX_PUBLIC_UPDATE_ERROR_LENGTH = 800;
 const MISSING_MACOS_ZIP_MESSAGE = 'macOS 自动更新包缺少 ZIP 文件，请手动下载安装包，或等待维护者重新发布。';
+const UPDATE_CACHE_MOVE_MESSAGE = '更新包已下载，但无法写入安装缓存。请重启 CatsCo 后重试，或手动下载安装包。';
 
 function limitMessage(message) {
   if (message.length <= MAX_PUBLIC_UPDATE_ERROR_LENGTH) return message;
@@ -16,6 +17,13 @@ function normalizeUpdateError(error, fallbackReason = 'UPDATE_ERROR') {
     return {
       reason: 'MACOS_UPDATE_ZIP_MISSING',
       message: MISSING_MACOS_ZIP_MESSAGE,
+    };
+  }
+
+  if (errorCode === 'EXDEV' || /EXDEV|cross-device link not permitted/i.test(rawMessage)) {
+    return {
+      reason: 'UPDATE_CACHE_MOVE_FAILED',
+      message: UPDATE_CACHE_MOVE_MESSAGE,
     };
   }
 
@@ -40,5 +48,6 @@ function normalizeUpdateError(error, fallbackReason = 'UPDATE_ERROR') {
 module.exports = {
   MAX_PUBLIC_UPDATE_ERROR_LENGTH,
   MISSING_MACOS_ZIP_MESSAGE,
+  UPDATE_CACHE_MOVE_MESSAGE,
   normalizeUpdateError,
 };

--- a/electron/update-log.js
+++ b/electron/update-log.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const util = require('util');
+
+const DEFAULT_MAX_BYTES = 1024 * 1024;
+const MAX_LOG_ENTRY_LENGTH = 4000;
+
+function sanitizeUpdateLogMessage(value) {
+  return String(value || '')
+    .replace(/([?&][^=\s&]+)=([^&\s]+)/g, '$1=[REDACTED]')
+    .replace(/\b(Bearer\s+)[A-Za-z0-9._~+/=-]+/gi, '$1[REDACTED]')
+    .replace(/\b((?:token|access[_-]?token|api[_-]?key|authorization)\s*[:=]\s*)["']?[^\s,"'}]+/gi, '$1[REDACTED]')
+    .slice(0, MAX_LOG_ENTRY_LENGTH);
+}
+
+function createUpdateLogger({ logPath, maxBytes = DEFAULT_MAX_BYTES, consoleImpl = console }) {
+  const resolvedLogPath = path.resolve(logPath);
+  const previousLogPath = `${resolvedLogPath}.previous`;
+
+  function rotateIfNeeded() {
+    try {
+      if (!fs.existsSync(resolvedLogPath) || fs.statSync(resolvedLogPath).size < maxBytes) return;
+      if (fs.existsSync(previousLogPath)) fs.unlinkSync(previousLogPath);
+      fs.renameSync(resolvedLogPath, previousLogPath);
+    } catch (error) {
+      consoleImpl.warn?.('[auto-update] Failed to rotate updater log:', error);
+    }
+  }
+
+  function write(level, values) {
+    const message = sanitizeUpdateLogMessage(util.format(...values));
+    const line = `${new Date().toISOString()} [${level.toUpperCase()}] ${message}\n`;
+    try {
+      fs.mkdirSync(path.dirname(resolvedLogPath), { recursive: true });
+      rotateIfNeeded();
+      fs.appendFileSync(resolvedLogPath, line, 'utf8');
+    } catch (error) {
+      consoleImpl.warn?.('[auto-update] Failed to write updater log:', error);
+    }
+
+    const consoleMethod = level === 'error' ? 'error' : level === 'warn' ? 'warn' : 'log';
+    consoleImpl[consoleMethod]?.(`[auto-update] ${message}`);
+  }
+
+  return {
+    logPath: resolvedLogPath,
+    debug: (...values) => write('debug', values),
+    info: (...values) => write('info', values),
+    warn: (...values) => write('warn', values),
+    error: (...values) => write('error', values),
+  };
+}
+
+module.exports = {
+  DEFAULT_MAX_BYTES,
+  MAX_LOG_ENTRY_LENGTH,
+  createUpdateLogger,
+  sanitizeUpdateLogMessage,
+};

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -2784,8 +2784,8 @@ export function createApiRouter(
       });
     }
     try {
-      updateController.installUpdate();
-      return res.json({ ok: true });
+      const status = updateController.installUpdate();
+      return res.json({ ok: true, ...status });
     } catch (e: any) {
       return res.status(500).json({
         error: e?.message || String(e),

--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -14,7 +14,7 @@ export interface UpdateController {
   getStatus: () => any;
   checkForUpdates: (manual?: boolean) => Promise<any>;
   downloadUpdate: () => Promise<any>;
-  installUpdate: () => void;
+  installUpdate: () => any;
 }
 
 export interface DashboardControllers {

--- a/tests/dashboard-connector.test.ts
+++ b/tests/dashboard-connector.test.ts
@@ -65,7 +65,10 @@ test('Connector restores visible desktop update progress and explicit install co
   assert.match(html, /id="update-available-version"/);
   assert.match(html, /id="update-speed"/);
   assert.match(html, /id="update-remaining"/);
+  assert.match(html, /id="update-manual-link"/);
   assert.match(script, /安装并重启/);
+  assert.match(script, /case 'preparing_install'/);
+  assert.match(script, /openReleasePage/);
   assert.match(styles, /\.update-dialog::backdrop/);
   assert.match(styles, /\.update-progress-track\.indeterminate/);
   assert.match(styles, /\.compact-card \.button\.update-active/);
@@ -74,7 +77,7 @@ test('Connector restores visible desktop update progress and explicit install co
   assert.match(script, /setInterval\(\(\) => \{ void refreshUpdateStatus\(\); \}, 1000\)/);
   assert.match(script, /request\('\/update\/download'/);
   assert.match(script, /request\('\/update\/install'/);
-  assert.match(script, /previousStage === 'downloading'[\s\S]*\['downloaded', 'error'\]/);
+  assert.match(script, /\['downloading', 'preparing_install', 'installing'\]\.includes\(previousStage\)/);
   assert.match(script, /update-primary-action.*handleUpdatePrimaryAction/s);
 });
 

--- a/tests/electron-update-controller.test.ts
+++ b/tests/electron-update-controller.test.ts
@@ -1,0 +1,154 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import test from 'node:test';
+
+const { createUpdateController } = require('../electron/update-controller');
+
+class FakeUpdater extends EventEmitter {
+  downloadCalls = 0;
+  installCalls = 0;
+
+  async checkForUpdates() {}
+
+  async downloadUpdate() {
+    this.downloadCalls += 1;
+  }
+
+  quitAndInstall() {
+    this.installCalls += 1;
+  }
+}
+
+function createScheduler() {
+  let nextId = 1;
+  const timers = new Map<number, { callback: () => void; delay: number }>();
+  return {
+    setTimeout(callback: () => void, delay: number) {
+      const id = nextId++;
+      timers.set(id, { callback, delay });
+      return id;
+    },
+    clearTimeout(id: number) {
+      timers.delete(id);
+    },
+    run(delay: number) {
+      const match = [...timers.entries()].find(([, timer]) => timer.delay === delay);
+      assert.ok(match, `Expected a ${delay}ms timer`);
+      timers.delete(match[0]);
+      match[1].callback();
+    },
+    has(delay: number) {
+      return [...timers.values()].some((timer) => timer.delay === delay);
+    },
+  };
+}
+
+function createController(platform = 'win32') {
+  const updater = new FakeUpdater();
+  const nativeUpdater = new EventEmitter();
+  const app = new EventEmitter() as EventEmitter & { getVersion: () => string };
+  app.getVersion = () => '1.5.0';
+  const scheduler = createScheduler();
+  const controller = createUpdateController({
+    updater,
+    nativeUpdater,
+    app,
+    platform,
+    currentVersion: app.getVersion,
+    releasePageUrl: 'https://example.test/releases/latest',
+    logger: { info() {}, warn() {}, error() {}, debug() {} },
+    setTimeoutImpl: scheduler.setTimeout,
+    clearTimeoutImpl: scheduler.clearTimeout,
+  });
+  return { updater, nativeUpdater, app, scheduler, controller };
+}
+
+test('a repeated download request preserves a completed update', async () => {
+  const { updater, controller } = createController();
+  try {
+    updater.emit('update-downloaded', { version: '1.5.5' });
+    const result = await controller.downloadUpdate();
+    assert.equal(result.stage, 'downloaded');
+    assert.equal(result.availableVersion, '1.5.5');
+    assert.equal(result.lastError, null);
+    assert.equal(updater.downloadCalls, 0);
+  } finally {
+    controller.dispose();
+  }
+});
+
+test('macOS waits for the native updater before enabling installation', () => {
+  const { updater, nativeUpdater, scheduler, controller } = createController('darwin');
+  try {
+    updater.emit('update-downloaded', { version: '1.5.5' });
+    assert.equal(controller.getStatus().stage, 'preparing_install');
+    assert.equal(scheduler.has(120_000), true);
+
+    nativeUpdater.emit('update-downloaded');
+    assert.equal(controller.getStatus().stage, 'downloaded');
+    assert.equal(scheduler.has(120_000), false);
+  } finally {
+    controller.dispose();
+  }
+});
+
+test('macOS preparation timeout becomes an actionable update error', () => {
+  const { updater, scheduler, controller } = createController('darwin');
+  try {
+    updater.emit('update-downloaded', { version: '1.5.5' });
+    scheduler.run(120_000);
+    const status = controller.getStatus();
+    assert.equal(status.stage, 'error');
+    assert.equal(status.lastError.reason, 'UPDATE_INSTALL_PREPARATION_TIMEOUT');
+    assert.equal(status.releasePageUrl, 'https://example.test/releases/latest');
+  } finally {
+    controller.dispose();
+  }
+});
+
+test('macOS native preparation errors keep their specific reason', () => {
+  const { updater, nativeUpdater, controller } = createController('darwin');
+  try {
+    updater.emit('update-downloaded', { version: '1.5.5' });
+    const error = new Error('ShipIt could not prepare the update');
+    nativeUpdater.emit('error', error);
+    updater.emit('error', error);
+    assert.equal(controller.getStatus().lastError.reason, 'UPDATE_INSTALL_PREPARATION_FAILED');
+  } finally {
+    controller.dispose();
+  }
+});
+
+test('install status is returned before quit-and-install starts', () => {
+  const { updater, app, scheduler, controller } = createController();
+  try {
+    updater.emit('update-downloaded', { version: '1.5.5' });
+    const status = controller.installUpdate();
+    assert.equal(status.stage, 'installing');
+    assert.equal(updater.installCalls, 0);
+
+    scheduler.run(250);
+    assert.equal(updater.installCalls, 1);
+    assert.equal(scheduler.has(30_000), true);
+
+    app.emit('before-quit');
+    assert.equal(scheduler.has(30_000), false);
+  } finally {
+    controller.dispose();
+  }
+});
+
+test('an installer handoff that does not quit reports a visible error', () => {
+  const { updater, scheduler, controller } = createController();
+  try {
+    updater.emit('update-downloaded', { version: '1.5.5' });
+    controller.installUpdate();
+    scheduler.run(250);
+    scheduler.run(30_000);
+    const status = controller.getStatus();
+    assert.equal(status.stage, 'error');
+    assert.equal(status.lastError.reason, 'UPDATE_INSTALL_DID_NOT_START');
+  } finally {
+    controller.dispose();
+  }
+});

--- a/tests/electron-update-controller.test.ts
+++ b/tests/electron-update-controller.test.ts
@@ -5,10 +5,13 @@ import test from 'node:test';
 const { createUpdateController } = require('../electron/update-controller');
 
 class FakeUpdater extends EventEmitter {
+  checkCalls = 0;
   downloadCalls = 0;
   installCalls = 0;
 
-  async checkForUpdates() {}
+  async checkForUpdates() {
+    this.checkCalls += 1;
+  }
 
   async downloadUpdate() {
     this.downloadCalls += 1;
@@ -74,6 +77,43 @@ test('a repeated download request preserves a completed update', async () => {
     assert.equal(updater.downloadCalls, 0);
   } finally {
     controller.dispose();
+  }
+});
+
+test('a repeated update check cannot discard a downloaded update', async () => {
+  const { updater, controller } = createController();
+  try {
+    updater.emit('update-downloaded', { version: '1.5.5' });
+
+    const result = await controller.checkForUpdates(true);
+    updater.emit('checking-for-update');
+    updater.emit('update-available', { version: '1.5.5' });
+    updater.emit('update-not-available');
+
+    assert.equal(result.stage, 'downloaded');
+    assert.equal(updater.checkCalls, 0);
+    assert.equal(controller.getStatus().stage, 'downloaded');
+    assert.equal(controller.getStatus().availableVersion, '1.5.5');
+  } finally {
+    controller.dispose();
+  }
+});
+
+test('update checks preserve macOS preparation and installer handoff states', async () => {
+  const mac = createController('darwin');
+  const win = createController();
+  try {
+    mac.updater.emit('update-downloaded', { version: '1.5.5' });
+    assert.equal((await mac.controller.checkForUpdates(true)).stage, 'preparing_install');
+    assert.equal(mac.updater.checkCalls, 0);
+
+    win.updater.emit('update-downloaded', { version: '1.5.5' });
+    win.controller.installUpdate();
+    assert.equal((await win.controller.checkForUpdates(true)).stage, 'installing');
+    assert.equal(win.updater.checkCalls, 0);
+  } finally {
+    mac.controller.dispose();
+    win.controller.dispose();
   }
 });
 

--- a/tests/electron-update-errors.test.ts
+++ b/tests/electron-update-errors.test.ts
@@ -4,6 +4,7 @@ import test from 'node:test';
 const {
   MAX_PUBLIC_UPDATE_ERROR_LENGTH,
   MISSING_MACOS_ZIP_MESSAGE,
+  UPDATE_CACHE_MOVE_MESSAGE,
   normalizeUpdateError,
 } = require('../electron/update-errors');
 
@@ -27,6 +28,18 @@ test('actual checksum failures retain package validation classification', () => 
       message: 'sha512 checksum mismatch',
     },
   );
+});
+
+test('Windows cross-volume updater cache failures get an actionable classification', () => {
+  const error = Object.assign(
+    new Error("EXDEV: cross-device link not permitted, rename 'temp.exe' -> 'update.exe'"),
+    { code: 'EXDEV' },
+  );
+
+  assert.deepEqual(normalizeUpdateError(error, 'UPDATE_RUNTIME_ERROR'), {
+    reason: 'UPDATE_CACHE_MOVE_FAILED',
+    message: UPDATE_CACHE_MOVE_MESSAGE,
+  });
 });
 
 test('public updater errors are capped to a readable size', () => {

--- a/tests/electron-update-log.test.ts
+++ b/tests/electron-update-log.test.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+const { createUpdateLogger, sanitizeUpdateLogMessage } = require('../electron/update-log');
+
+test('updater logs redact credentials and URL secrets', () => {
+  const message = sanitizeUpdateLogMessage(
+    'GET https://example.test/file?token=secret&api_key=hidden Authorization: Bearer abc.def',
+  );
+  assert.doesNotMatch(message, /secret|hidden|abc\.def/);
+  assert.match(message, /\[REDACTED\]/);
+});
+
+test('updater logs are persisted and rotated within a bounded size', () => {
+  const root = mkdtempSync(join(tmpdir(), 'catsco-updater-log-'));
+  const logPath = join(root, 'logs', 'updater.log');
+  const silentConsole = { log() {}, warn() {}, error() {} };
+  try {
+    const logger = createUpdateLogger({ logPath, maxBytes: 40, consoleImpl: silentConsole });
+    logger.info('first update message long enough to rotate');
+    logger.info('second update message');
+    assert.match(readFileSync(logPath, 'utf8'), /second update message/);
+    assert.match(readFileSync(`${logPath}.previous`, 'utf8'), /first update message/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- restore visible download progress and explicit update states in the compact Connector Dashboard
- make repeated download clicks idempotent instead of starting conflicting updater work
- wait for macOS native preparation before enabling installation, with timeout and actionable fallback
- return the installing state before handing off to quitAndInstall and report stalled installer launches
- persist bounded, redacted updater diagnostics and classify cache move failures clearly

## Validation

- node --import tsx --test tests/electron-update-errors.test.ts tests/electron-update-controller.test.ts tests/electron-update-log.test.ts tests/electron-main-dashboard-url.test.ts
- npm run build
- local packaged Windows update lab: CatsCo Update Lab 1.5.5 downloaded 1.5.6, reached downloaded state, and exposed the install action successfully
- user manually verified the updated Dashboard flow

## Notes

- local update-lab artifacts and caches are not included in this PR
- the Windows lab used an isolated product name, app id, user-data directory, update feed, and E-drive cache; it did not publish a release or modify main