### PR TITLE
fix: clean up connector account transitions

### DIFF
--- a/dashboard/connector.html
+++ b/dashboard/connector.html
@@ -46,7 +46,7 @@
               </div>
               <label>
                 <span>账号</span>
-                <input id="login-account" name="account" autocomplete="username" placeholder="用户名或邮箱" required>
+                <input id="login-account" name="account" autocomplete="username" placeholder="请用邮箱登录" required>
               </label>
               <label>
                 <span>密码</span>

--- a/dashboard/connector.js
+++ b/dashboard/connector.js
@@ -758,7 +758,17 @@
     const selected = state.agents.find((agent) => String(agent.uid || '') === state.selectedAgentUid);
     const selectedName = selected?.display_name || selected?.username || '所选 Agent';
     const boundWeixinUid = String(state.weixinBinding?.binding?.agentUid || '');
-    const needsWeixinRebind = Boolean(boundWeixinUid && state.selectedAgentUid && boundWeixinUid !== state.selectedAgentUid);
+    const currentAccountUid = String(state.cats?.user?.uid || '');
+    const boundWeixinOwnerUid = String(state.weixinBinding?.binding?.boundByUserUid || '');
+    const bindingBelongsToCurrentAccount = !boundWeixinOwnerUid
+      || !currentAccountUid
+      || boundWeixinOwnerUid === currentAccountUid;
+    const needsWeixinRebind = Boolean(
+      bindingBelongsToCurrentAccount
+      && boundWeixinUid
+      && state.selectedAgentUid
+      && boundWeixinUid !== state.selectedAgentUid,
+    );
     const warning = $('agent-switch-warning');
     warning.hidden = !needsWeixinRebind;
     if (needsWeixinRebind) {

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -2195,10 +2195,19 @@ function activateCatsCompanyConnector(
   }
 }
 
-function persistCatsUserSession(state: CatsAuthState, login: any, previousUidOverride?: string): void {
+function persistCatsUserSession(
+  serviceManager: ServiceManager,
+  state: CatsAuthState,
+  login: any,
+  previousUidOverride?: string,
+): void {
   const previousUid = String(previousUidOverride ?? state.uid ?? '').trim();
   const nextUid = String(login.uid || '').trim();
   if (previousUid && nextUid && previousUid !== nextUid) {
+    const weixin = serviceManager.getService('weixin');
+    if (weixin?.status === 'running') {
+      serviceManager.stop('weixin');
+    }
     clearWeixinChannelBinding(runtimeDataRoot(), process.env);
   }
   createCatsCoLocalConfigService({ runtimeRoot: runtimeDataRoot() }).persistAccountSession(state, login);
@@ -3575,7 +3584,7 @@ export function createApiRouter(
         password,
         persistent: true,
       }, undefined, { timeoutMs: 10000 });
-      persistCatsUserSession(state, login);
+      persistCatsUserSession(serviceManager, state, login);
       options.catsConnectorAutoStart?.invalidateAndSchedule('register', 0, { force: true });
       res.json({
         ok: true,
@@ -3605,7 +3614,7 @@ export function createApiRouter(
         undefined,
         { timeoutMs: 10000 },
       );
-      persistCatsUserSession(state, login);
+      persistCatsUserSession(serviceManager, state, login);
       options.catsConnectorAutoStart?.invalidateAndSchedule('login', 0, { force: true });
       res.json({
         ok: true,
@@ -3662,7 +3671,7 @@ export function createApiRouter(
         httpBaseUrl,
         serverUrl,
       };
-      persistCatsUserSession(nextState, login, state.uid);
+      persistCatsUserSession(serviceManager, nextState, login, state.uid);
       // Electron also requests an immediate bootstrap. The delayed safety run
       // covers other deep-link clients and is coalesced by the controller.
       options.catsConnectorAutoStart?.invalidateAndSchedule('desktop-connect', 1000);

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -105,6 +105,7 @@ import {
   BindWeixinChannelResult,
   WeixinChannelStatus,
   bindWeixinChannelToCurrentAgent,
+  clearWeixinChannelBinding,
   getWeixinChannelStatus,
 } from '../weixin-channel-binding';
 // import { ReportGenerator } from '../../utils/report-generator';
@@ -117,6 +118,7 @@ const BUNDLED_SKILL_MARKER = '.xiaoba-bundled-skill.json';
 const SYSTEM_SKILL_DIRS = new Set<string>();
 const PROMPT_EDITOR_SKILL_NAME = 'catsco-prompt-editor';
 const MODELS_DEV_DASHBOARD_WAIT_MS = 250;
+const DEFAULT_LOCAL_CONNECTOR_AGENT_NAME = '本机 Connector';
 
 function runtimeDataRoot(): string {
   return PathResolver.getRuntimeDataRoot();
@@ -2193,7 +2195,12 @@ function activateCatsCompanyConnector(
   }
 }
 
-function persistCatsUserSession(state: CatsAuthState, login: any): void {
+function persistCatsUserSession(state: CatsAuthState, login: any, previousUidOverride?: string): void {
+  const previousUid = String(previousUidOverride ?? state.uid ?? '').trim();
+  const nextUid = String(login.uid || '').trim();
+  if (previousUid && nextUid && previousUid !== nextUid) {
+    clearWeixinChannelBinding(runtimeDataRoot(), process.env);
+  }
   createCatsCoLocalConfigService({ runtimeRoot: runtimeDataRoot() }).persistAccountSession(state, login);
 }
 
@@ -3618,6 +3625,11 @@ export function createApiRouter(
     if (connector?.status === 'running') {
       serviceManager.stop('catscompany');
     }
+    const weixin = serviceManager.getService('weixin');
+    if (weixin?.status === 'running') {
+      serviceManager.stop('weixin');
+    }
+    clearWeixinChannelBinding(runtimeDataRoot(), process.env);
     const removed = createCatsCoLocalConfigService({ runtimeRoot: runtimeDataRoot() }).clearAccount();
     options.catsConnectorAutoStart?.invalidateAndSchedule('logout');
     res.json({ ok: true, removed });
@@ -3650,7 +3662,7 @@ export function createApiRouter(
         httpBaseUrl,
         serverUrl,
       };
-      persistCatsUserSession(nextState, login);
+      persistCatsUserSession(nextState, login, state.uid);
       // Electron also requests an immediate bootstrap. The delayed safety run
       // covers other deep-link clients and is coalesced by the controller.
       options.catsConnectorAutoStart?.invalidateAndSchedule('desktop-connect', 1000);
@@ -3748,10 +3760,9 @@ export function createApiRouter(
       const bots = (Array.isArray(botsResponse?.bots) ? botsResponse.bots : [])
         .filter((bot: any) => isOwnedCatsBot(bot, userUid));
       const deviceId = ensureCatsDeviceId();
-      const deviceName = String(req.body?.deviceName || os.hostname() || 'current-device').trim();
       const preferredUsername = sanitizeCatsUsernamePart(String(req.body?.botUsername || `catsco_${userUid}_${deviceId}`))
         || `catsco_${userUid}_${deviceId.replace(/[^a-zA-Z0-9_]/g, '_')}`;
-      const preferredName = String(req.body?.botDisplayName || `CatsCo (${deviceName})`).trim() || `CatsCo (${deviceName})`;
+      const preferredName = String(req.body?.botDisplayName || DEFAULT_LOCAL_CONNECTOR_AGENT_NAME).trim() || DEFAULT_LOCAL_CONNECTOR_AGENT_NAME;
       let botSelectionSource: 'last-used' | 'first-owned-bot' | 'created-default' = 'first-owned-bot';
       let bot = state.botUid
         ? bots.find((item: any) => String(item.id || item.uid || '') === String(state.botUid))
@@ -3912,8 +3923,7 @@ export function createApiRouter(
       if (!userUid) return res.status(500).json({ error: 'CatsCo user uid missing' });
 
       const deviceId = ensureCatsDeviceId();
-      const deviceName = String(req.body?.deviceName || os.hostname() || 'current-device').trim();
-      const displayName = String(req.body?.botDisplayName || `CatsCo (${deviceName})`).trim() || `CatsCo (${deviceName})`;
+      const displayName = String(req.body?.botDisplayName || DEFAULT_LOCAL_CONNECTOR_AGENT_NAME).trim() || DEFAULT_LOCAL_CONNECTOR_AGENT_NAME;
       const usernameBase = String(req.body?.botUsername || `catsco_${userUid}_${deviceId}`).trim();
       const username = sanitizeCatsUsernamePart(usernameBase) || `catsco_${userUid}_${deviceId.replace(/[^a-zA-Z0-9_]/g, '_')}`;
 

--- a/src/dashboard/weixin-channel-binding.ts
+++ b/src/dashboard/weixin-channel-binding.ts
@@ -82,6 +82,45 @@ export function saveChannelBindings(runtimeRoot: string, data: ChannelBindingsFi
   chmodOwnerOnly(bindingPath);
 }
 
+const WEIXIN_BINDING_ENV_KEYS = [
+  'WEIXIN_TOKEN',
+  'WEIXIN_BOUND_AGENT_UID',
+  'WEIXIN_BOUND_AGENT_NAME',
+  'WEIXIN_BOUND_BODY_ID',
+  'WEIXIN_BOUND_BY_USER_UID',
+] as const;
+
+/**
+ * Remove the account-scoped Weixin binding from the local runtime. A binding
+ * must not survive CatsCo logout: otherwise the next account can see a stale
+ * Agent-mismatch warning and the old token may be reused accidentally.
+ */
+export function clearWeixinChannelBinding(
+  runtimeRoot = process.cwd(),
+  env: NodeJS.ProcessEnv = process.env,
+): string[] {
+  const existing = loadChannelBindings(runtimeRoot);
+  if (existing.weixin) {
+    const next = { ...existing };
+    delete next.weixin;
+    saveChannelBindings(runtimeRoot, next);
+  }
+
+  const envPath = path.join(runtimeRoot, '.env');
+  const envUpdates = Object.fromEntries(WEIXIN_BINDING_ENV_KEYS.map(key => [key, undefined])) as Record<string, undefined>;
+  const envResult = fs.existsSync(envPath)
+    ? writeDashboardEnvUpdates(runtimeRoot, envUpdates)
+    : { updated: [], cleared: [] };
+  for (const key of WEIXIN_BINDING_ENV_KEYS) {
+    delete env[key];
+  }
+
+  return Array.from(new Set([
+    ...(existing.weixin ? [resolveChannelBindingsPath(runtimeRoot)] : []),
+    ...envResult.cleared,
+  ]));
+}
+
 export function currentWeixinAgent(runtime: CatsCoRuntimeConfigResolution): WeixinCurrentAgentSnapshot | undefined {
   const bot = runtime.localConfig.currentBot;
   if (!runtime.bodyConfigured || !bot?.uid) return undefined;

--- a/tests/dashboard-catsco-auth-status.test.ts
+++ b/tests/dashboard-catsco-auth-status.test.ts
@@ -115,6 +115,35 @@ describe('dashboard CatsCo account status', () => {
     }
   });
 
+  async function useRunningWeixinService(): Promise<{ stopCalls: string[] }> {
+    if (dashboardServer) {
+      await close(dashboardServer);
+      dashboardServer = undefined;
+    }
+    const service = {
+      name: 'weixin',
+      label: 'Weixin service',
+      command: process.execPath,
+      args: [],
+      status: 'running',
+    };
+    const stopCalls: string[] = [];
+    const app = express();
+    app.use(express.json());
+    app.use('/api', createApiRouter({
+      getAll: () => [service],
+      getService: (name: string) => (name === 'weixin' ? service : undefined),
+      stop: (name: string) => {
+        stopCalls.push(name);
+        service.status = 'stopped';
+        return service;
+      },
+    } as any));
+    dashboardServer = await listen(app);
+    dashboardBaseUrl = serverBaseUrl(dashboardServer);
+    return { stopCalls };
+  }
+
   test('GET /cats/status treats rejected CatsCompany token as logged out', async () => {
     await startCatsServer((req, res) => {
       if (req.path === '/api/me') {
@@ -558,6 +587,7 @@ describe('dashboard CatsCo account status', () => {
   });
 
   test('POST /cats/auth/login writes both CatsCo and CatsCompany env aliases', async () => {
+    const { stopCalls } = await useRunningWeixinService();
     createCatsCoLocalConfigService({ runtimeRoot: testRoot }).save({
       version: 1,
       account: { token: 'old-token', uid: '66', username: 'old-user', displayName: 'Old User' },
@@ -622,6 +652,7 @@ describe('dashboard CatsCo account status', () => {
     assert.equal(env.CATSCO_API_KEY, undefined);
     assert.equal(env.CATSCOMPANY_BOT_UID, undefined);
     assert.equal(env.CATSCOMPANY_API_KEY, undefined);
+    assert.deepStrictEqual(stopCalls, ['weixin']);
   });
 
   test('GET /cats/status does not expose an Agent that belongs to the previous account', async () => {
@@ -764,9 +795,11 @@ describe('dashboard CatsCo account status', () => {
   });
 
   test('POST /cats/desktop-connect exchanges a web login code and persists CatsCo account aliases', async () => {
+    const { stopCalls } = await useRunningWeixinService();
     process.env.XIAOBA_RUNTIME_ROLE = 'desktop';
     createCatsCoLocalConfigService({ runtimeRoot: testRoot }).save({
       version: 1,
+      account: { token: 'old-token', uid: '66', username: 'old-user', displayName: 'Old User' },
       device: {
         deviceId: 'device-local',
         bodyId: 'body-local',
@@ -813,6 +846,7 @@ describe('dashboard CatsCo account status', () => {
     assert.equal(env.CATSCOMPANY_USER_TOKEN, 'desktop-user-token');
     assert.equal(env.CATSCO_USER_UID, '91');
     assert.equal(env.CATSCOMPANY_USER_DISPLAY_NAME, 'Desktop User');
+    assert.deepStrictEqual(stopCalls, ['weixin']);
   });
 
   test('POST /cats/desktop-connect rejects an untrusted requested base before exchange', async () => {

--- a/tests/dashboard-catsco-auth-status.test.ts
+++ b/tests/dashboard-catsco-auth-status.test.ts
@@ -890,6 +890,7 @@ describe('dashboard CatsCo account status', () => {
     dashboardServer = await listen(dashboardApp);
     dashboardBaseUrl = serverBaseUrl(dashboardServer);
 
+    let createdBotDisplayName = '';
     await startCatsServer((req, res) => {
       if (req.path === '/api/me') {
         assert.equal(req.header('authorization'), 'Bearer user-token');
@@ -899,6 +900,7 @@ describe('dashboard CatsCo account status', () => {
         return res.json({ bots: [] });
       }
       if (req.path === '/api/bots' && req.method === 'POST') {
+        createdBotDisplayName = String(req.body.display_name || '');
         return res.json({
           uid: 188,
           username: req.body.username,
@@ -984,6 +986,7 @@ describe('dashboard CatsCo account status', () => {
     assert.equal(response.status, 200, text);
     assert.equal(data.ok, true);
     assert.equal(data.botSelectionSource, 'created-default');
+    assert.equal(createdBotDisplayName, '本机 Connector');
     assert.equal(data.relayModelSetup.ok, true);
     assert.equal(data.relayModelSetup.model, 'MiniMax-M3');
     assert.equal(data.relayModelSetup.reasoningEffort, 'high');

--- a/tests/dashboard-connector.test.ts
+++ b/tests/dashboard-connector.test.ts
@@ -16,6 +16,7 @@ const serverSource = readFileSync(join(process.cwd(), 'src/dashboard/server.ts')
 test('real Connector Dashboard exposes four runtime states without local Bot creation', () => {
   assert.match(html, /CatsCo Connector/);
   assert.match(html, /登录并连接/);
+  assert.match(html, /placeholder="请用邮箱登录"/);
   assert.match(html, /正在连接这台电脑/);
   assert.match(script, /这台电脑已连接/);
   assert.match(html, /自动连接未完成/);
@@ -40,6 +41,7 @@ test('Connector lets an authenticated user switch the Agent bound to this comput
   assert.doesNotMatch(script, /window\.confirm\(/);
   assert.match(script, /login-account'\)\?\.focus/);
   assert.match(script, /当前账号无权使用原 Agent（not your bot）/);
+  assert.match(script, /bindingBelongsToCurrentAccount/);
   assert.match(script, /setNotice\(`\$\{title\}：\$\{detail\}`/);
 });
 

--- a/tests/dashboard-weixin-channel-binding.test.ts
+++ b/tests/dashboard-weixin-channel-binding.test.ts
@@ -7,6 +7,7 @@ import * as dotenv from 'dotenv';
 import express from 'express';
 import type { Server } from 'node:http';
 import { createApiRouter } from '../src/dashboard/routes/api';
+import { clearWeixinChannelBinding, loadChannelBindings, saveChannelBindings } from '../src/dashboard/weixin-channel-binding';
 
 describe('dashboard weixin agent channel binding', () => {
   let testRoot: string;
@@ -79,6 +80,45 @@ describe('dashboard weixin agent channel binding', () => {
     assert.equal(response.status, 409);
     assert.match(data.error, /agent/);
     assert.equal(data.channelStatus.configured, false);
+  });
+
+  test('clears the persisted Weixin binding and environment on account cleanup', () => {
+    saveChannelBindings(testRoot, {
+      version: 1,
+      weixin: {
+        channel: 'weixin',
+        agentUid: 'old-agent',
+        agentName: 'Old Agent',
+        boundByUserUid: 'old-user',
+        tokenHash: 'hash',
+        tokenLast4: '1234',
+        legacyEnvKey: 'WEIXIN_TOKEN',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+    });
+    fs.writeFileSync(path.join(testRoot, '.env'), [
+      'WEIXIN_TOKEN=secret-token',
+      'WEIXIN_BOUND_AGENT_UID=old-agent',
+      'WEIXIN_BOUND_AGENT_NAME=Old Agent',
+      'WEIXIN_BOUND_BODY_ID=old-body',
+      'WEIXIN_BOUND_BY_USER_UID=old-user',
+      'CATSCO_USER_UID=next-user',
+    ].join('\n'), 'utf-8');
+    process.env.WEIXIN_TOKEN = 'secret-token';
+    process.env.WEIXIN_BOUND_AGENT_UID = 'old-agent';
+
+    const cleared = clearWeixinChannelBinding(testRoot, process.env);
+
+    assert.equal(loadChannelBindings(testRoot).weixin, undefined);
+    const env = dotenv.parse(fs.readFileSync(path.join(testRoot, '.env'), 'utf-8'));
+    for (const key of ['WEIXIN_TOKEN', 'WEIXIN_BOUND_AGENT_UID', 'WEIXIN_BOUND_AGENT_NAME', 'WEIXIN_BOUND_BODY_ID', 'WEIXIN_BOUND_BY_USER_UID']) {
+      assert.equal(env[key], undefined, `${key} should be removed from .env`);
+      assert.equal(process.env[key], undefined, `${key} should be removed from process.env`);
+    }
+    assert.equal(env.CATSCO_USER_UID, 'next-user');
+    assert.ok(cleared.some(item => item.endsWith('channel-bindings.json')));
+    assert.ok(cleared.includes('WEIXIN_TOKEN'));
   });
 
   test('confirmed qrcode binds Weixin channel to the current agent without returning token', async () => {


### PR DESCRIPTION
## Summary
- rename the auto-created local Agent to `本机 Connector` instead of exposing the computer hostname
- clear account-scoped Weixin bindings and environment variables on logout and CatsCo account transitions
- avoid showing stale Weixin rebind warnings from another account in the Agent switch dialog
- update the login placeholder to `请用邮箱登录`

## Verification
- `npm run build`
- `node --import tsx --test tests/dashboard-weixin-channel-binding.test.ts tests/dashboard-catsco-auth-status.test.ts tests/dashboard-connector.test.ts`
- 47 tests passed

## Notes
- Existing Agents are not renamed; the new default name applies to newly auto-created local Connector Agents.
- The Electron binary reinstall used for local testing was confined to ignored `node_modules` files and is not part of this PR.