### PR TITLE
fix(catscompany): fence queued input and late replies after stop

### DIFF
--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -1336,10 +1336,14 @@ export class CatsCompanyBot {
     const callbackGeneration = opts?.sessionKey
       ? opts.clearGeneration ?? this.getSessionClearGeneration(opts.sessionKey)
       : undefined;
+    const callbackStopGeneration = opts?.sessionKey
+      ? this.getSessionStopGeneration(opts.sessionKey)
+      : undefined;
     const isStaleCallback = (): boolean => Boolean(
       this.shuttingDown
       || (opts?.sessionKey
-        && callbackGeneration !== this.getSessionClearGeneration(opts.sessionKey)),
+        && (callbackGeneration !== this.getSessionClearGeneration(opts.sessionKey)
+          || callbackStopGeneration !== this.getSessionStopGeneration(opts.sessionKey))),
     );
     return {
       onRetry: async (attempt, maxRetries, info) => {
@@ -1507,6 +1511,15 @@ export class CatsCompanyBot {
   }
 
   private async processParsedMessage(msg: ParsedCatsMessage, key: string): Promise<void> {
+    // Stop is control input: it must reach the same boundary as the web button
+    // before any asynchronous history restore or ordinary message queueing.
+    if (/^\/stop(?:\s|$)/i.test(msg.text)) {
+      this.stopSessionExecution(key);
+      await this.sender.reply(msg.topic, '正在停止当前请求...').catch((err: any) => {
+        Logger.warning(`停止提示发送失败: ${err?.message || err}`);
+      });
+      return;
+    }
     const entryClearGeneration = this.getSessionClearGeneration(key);
     const entryStopGeneration = this.getSessionStopGeneration(key);
     const nativeFeishuTrigger = shouldHydrateCatsCompanyGroupContext(msg);
@@ -1677,6 +1690,7 @@ export class CatsCompanyBot {
         runtimeFeedback,
         nativeFeishuContext,
         clearGeneration: entryClearGeneration,
+        stopGeneration: entryStopGeneration,
       });
       this.messageQueue.set(key, queue);
       Logger.info(`[${key}] 主会话忙，消息已入队 (队列长度: ${queue.length})`);
@@ -1704,7 +1718,7 @@ export class CatsCompanyBot {
           key,
         );
       }
-      if (shouldProcess) {
+      if (shouldProcess && entryStopGeneration === this.getSessionStopGeneration(key)) {
         task = this.beginConversationTask(key, msg.topic, msg.artifactTaskRef);
         if (!task) {
           // Shutdown barrier at the call site: never start the model after
@@ -1740,7 +1754,8 @@ export class CatsCompanyBot {
           }),
         });
 
-        if (entryClearGeneration === this.getSessionClearGeneration(key)) {
+        if (entryClearGeneration === this.getSessionClearGeneration(key)
+          && entryStopGeneration === this.getSessionStopGeneration(key)) {
           // Shutdown fence: destroy() may have timed out its quiesce wait and
           // returned while this model turn was still in flight. Never deliver a
           // late user reply after the connector is gone.
@@ -1760,11 +1775,12 @@ export class CatsCompanyBot {
           }
           this.finishConversationTask(key, task, this.taskStatusForResult(result, replyDelivered));
         } else {
-          Logger.info(`[${key}] clear 后忽略旧 turn 的返回`);
+          Logger.info(`[${key}] clear/stop 后忽略旧 turn 的返回`);
         }
       }
     } catch (err: any) {
-      if (entryClearGeneration === this.getSessionClearGeneration(key)) {
+      if (entryClearGeneration === this.getSessionClearGeneration(key)
+        && entryStopGeneration === this.getSessionStopGeneration(key)) {
         this.finishConversationTask(key, task, {
           state: 'failed',
           summary: '任务执行失败',
@@ -1772,7 +1788,7 @@ export class CatsCompanyBot {
         });
         throw err;
       }
-      Logger.info(`[${key}] clear 后忽略旧 turn 的异常`);
+      Logger.info(`[${key}] clear/stop 后忽略旧 turn 的异常`);
     } finally {
       this.releaseSessionExecution(key);
       stopTypingHeartbeat();
@@ -2907,6 +2923,10 @@ export class CatsCompanyBot {
       botUid: this.botUid,
     });
     const key = envelope.sessionKey;
+    this.stopSessionExecution(key);
+  }
+
+  private stopSessionExecution(key: string): void {
     const stopGeneration = this.bumpSessionStopGeneration(key);
     // Stop is a boundary for queued input. Messages received afterwards get
     // the new generation and can start a fresh turn normally.
@@ -3207,6 +3227,7 @@ export class CatsCompanyBot {
     for (; firstRemainingIndex < queue.length; firstRemainingIndex++) {
       const item = queue[firstRemainingIndex];
       if ((item.clearGeneration ?? expectedClearGeneration) !== expectedClearGeneration) break;
+      if ((item.stopGeneration ?? expectedStopGeneration) !== expectedStopGeneration) break;
       if (item.source === 'subagent_feedback') break;
       if (item.nativeFeishuContext) break;
       // An Artifact task owns a distinct run/task correlation. Do not fold it

--- a/tests/catscompany-execution-scope-flow.test.ts
+++ b/tests/catscompany-execution-scope-flow.test.ts
@@ -203,6 +203,102 @@ function createHarness(options: {
 }
 
 describe('CatsCompany execution scope flow', () => {
+  test('/stop discards queued follow-ups and permits only new work afterwards', async () => {
+    const harness = createHarness({ busy: true });
+    const topic = 'p2p_7_43';
+    const key = expectedCatsCoSessionKey('usr7', topic);
+    const message = (text: string, seq: number) => ({
+      topic, senderId: 'usr7', text, content: text, isGroup: false, seq,
+      metadata: canonicalMetadata('usr7', topic),
+    });
+    let interrupts = 0;
+    (harness.session as any).requestInterrupt = () => { interrupts++; };
+    harness.session.handleCommand = async () => {
+      (harness.session as any).requestInterrupt();
+      return { handled: true, reply: '正在停止当前请求...' };
+    };
+    await harness.bot.onMessage(message('follow-up before stop', 20));
+    assert.equal(harness.bot.messageQueue.get(key)?.length, 1);
+    await harness.bot.onMessage(message('/stop', 21));
+    harness.session.setBusy(false);
+    await harness.bot.drainMessageQueue(key);
+    assert.equal(interrupts, 1);
+    assert.equal(harness.handledTurns.length, 0);
+    assert.equal(harness.bot.messageQueue.has(key), false);
+    await harness.bot.onMessage(message('fresh request after stop', 22));
+    assert.equal(harness.handledTurns.length, 1);
+    assert.match(String(harness.handledTurns[0].userMessage), /fresh request/);
+  });
+
+  test('/stop interrupts without waiting for cloud history restoration', async () => {
+    const harness = createHarness({ busy: true });
+    let interrupts = 0;
+    (harness.session as any).requestInterrupt = () => { interrupts++; };
+    harness.bot.ensureCloudSessionRestored = async () => {
+      throw new Error('stop must not restore history');
+    };
+    await harness.bot.onMessage({
+      topic: 'p2p_7_43', senderId: 'usr7', text: '/stop', content: '/stop',
+      isGroup: false, seq: 21, metadata: canonicalMetadata('usr7', 'p2p_7_43'),
+    });
+    assert.equal(interrupts, 1);
+    assert.equal(harness.handledTurns.length, 0);
+  });
+
+  test('stop fences late text and progress callbacks but allows fresh callbacks', async () => {
+    const harness = createHarness();
+    const topic = 'p2p_7_43';
+    const key = expectedCatsCoSessionKey('usr7', topic);
+    (harness.session as any).requestInterrupt = () => {};
+    const callbacks = harness.bot.buildSessionCallbacks(topic, { sessionKey: key });
+    harness.bot.handleCancelMessage({ topic, senderId: 'usr7', isGroup: false });
+    await callbacks.onAssistantText('stale reply after stop');
+    await callbacks.onThinking('stale thinking after stop');
+    await callbacks.onToolStart('read_file', 'old-tool', {});
+    await callbacks.onToolEnd('read_file', 'old-tool', 'old result');
+    assert.deepEqual(harness.replies, []);
+    assert.deepEqual(harness.progressEvents, []);
+    const fresh = harness.bot.buildSessionCallbacks(topic, { sessionKey: key });
+    await fresh.onAssistantText('fresh reply');
+    assert.deepEqual(harness.replies, ['fresh reply']);
+  });
+
+  test('cancelled root work cannot deliver a late final reply or consume post-stop input', async () => {
+    const harness = createHarness();
+    const topic = 'p2p_7_43';
+    let started!: () => void;
+    let release!: () => void;
+    const startedPromise = new Promise<void>(resolve => { started = resolve; });
+    const gate = new Promise<void>(resolve => { release = resolve; });
+    let oldPending: (() => unknown) | undefined;
+    harness.session.handleMessage = async (userMessage: unknown, options: any) => {
+      harness.handledTurns.push({ userMessage, options });
+      if (harness.handledTurns.length === 1) {
+        oldPending = options.pendingUserInputProvider;
+        started();
+        await gate;
+        return { visibleToUser: true, text: 'late old final reply' };
+      }
+      return { visibleToUser: true, text: 'fresh final reply' };
+    };
+    (harness.session as any).requestInterrupt = () => {};
+    const message = (text: string, seq: number) => ({
+      topic, senderId: 'usr7', text, content: text, isGroup: false, seq,
+      metadata: canonicalMetadata('usr7', topic),
+    });
+    const original = harness.bot.onMessage(message('original task', 20));
+    await startedPromise;
+    await harness.bot.onMessage(message('old queued input', 21));
+    await harness.bot.onMessage({ ...message('', 0), type: 'stream_cancel' });
+    await harness.bot.onMessage(message('new input after stop', 22));
+    assert.equal(oldPending?.(), null);
+    release();
+    await original;
+    assert.equal(harness.handledTurns.length, 2);
+    assert.match(String(harness.handledTurns[1].userMessage), /new input after stop/);
+    assert.deepEqual(harness.replies, ['fresh final reply']);
+  });
+
   test('drops an unmentioned large-group message before cloud restore or session creation', async () => {
     const { bot, handledTurns, sessionKeys } = createHarness();
     let restoreCalls = 0;


### PR DESCRIPTION
Stopping an active CatsCompany request must discard follow-ups received before the stop and suppress output from the cancelled work. `/stop` currently bypasses the adapter's stop generation/queue cleanup and waits for cloud history restoration; late root replies and registered progress/text callbacks also ignore stop generations. This can make an interrupted request appear to resume.

Route `/stop` and the web cancel event through the same stop boundary, tag queued user input with its generation, and fence model startup, root results/errors, and callbacks after stop. Input sent after stopping can run normally. Ordinary compatible follow-ups still enter the same episode at turn boundaries; Artifact task, execution-scope, and native Feishu context boundaries remain intact.

Validation: 146 tests passed across execution-scope flow, content blocks, pending-input runner, and session lifecycle suites; TypeScript build passed. New regressions cover queued input cancellation, stop during history restoration, stale callbacks, late root results, and fresh input after stop. The first three regressions failed before this patch.

This extends the stop-boundary fix in fbf0caeebb504901f246cdfc6d34326eabbeaab9. Saturday's reported incident last week cannot be conclusively attributed without its runtime version/logs. No production deployment was performed.

Companion web fix: https://github.com/buildsense-ai/cats-company/pull/405

CI on 07c9f3ca73598c91e3fe465d5e79227fac437f27 completed successfully: https://github.com/buildsense-ai/XiaoBa-CLI/actions/runs/34073943609 . Runtime, SkillHub, and paired BotDefinition Skills contract tests ran successfully. The legacy cross-repo smoke/e2e job skipped its actual test steps because the scripts are absent; this is not evidence of a passing live stop flow.
