### PR TITLE
fix(catscompany): keep web task follow-ups in the active episode

### DIFF
--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -423,6 +423,13 @@ function shouldHydrateCatsCompanyGroupContext(
   return !sourceChannel || isNativeFeishuGroupTrigger(message);
 }
 
+function isTwoMemberWebGroup(message: Pick<ParsedCatsMessage, 'chatType' | 'metadata' | 'memberCount'>): boolean {
+  const memberCount = Number(message.memberCount);
+  return message.chatType === 'group'
+    && !String(message.metadata?.source_channel || '').trim()
+    && Number.isSafeInteger(memberCount) && memberCount > 0 && memberCount <= 2;
+}
+
 /**
  * CatsCompanyBot 主类
  * 初始化官方 SDK，注册事件，编排消息处理流程
@@ -1818,11 +1825,7 @@ export class CatsCompanyBot {
       const previousCursor = session.getRemoteContextCursor(cursorKey);
       const nextCursor = Math.max(previousCursor, msg.seq);
       const cursorUpdate = { source: cursorKey, cursor: nextCursor };
-      const memberCount = Number(msg.memberCount);
-      const sourceChannel = typeof msg.metadata?.source_channel === 'string'
-        ? msg.metadata.source_channel.trim()
-        : '';
-      if (!sourceChannel && Number.isFinite(memberCount) && memberCount > 0 && memberCount <= 2) {
+      if (isTwoMemberWebGroup(msg)) {
         if (!session.saveRemoteContextCursor(cursorKey, nextCursor)) {
           throw new Error('remote context cursor could not be persisted');
         }
@@ -3229,12 +3232,26 @@ export class CatsCompanyBot {
       if ((item.clearGeneration ?? expectedClearGeneration) !== expectedClearGeneration) break;
       if ((item.stopGeneration ?? expectedStopGeneration) !== expectedStopGeneration) break;
       if (item.source === 'subagent_feedback') break;
-      if (item.nativeFeishuContext) break;
+      // A one-user/one-bot web task has no external group history to hydrate.
+      // Keep its follow-ups in the active episode, while native/large groups
+      // still wait for the separate durable-context hydration boundary.
+      if (item.nativeFeishuContext && !isTwoMemberWebGroup(item.nativeFeishuContext.message)) break;
       // An Artifact task owns a distinct run/task correlation. Do not fold it
       // into the currently executing turn as ordinary follow-up text.
       if (item.artifactTaskRef) break;
       if (!this.canMergeQueuedMessage(currentScope, item.executionScope)) break;
       userMessages.push(item);
+    }
+    const pendingGroupMessages = userMessages.filter(item => item.nativeFeishuContext);
+    if (pendingGroupMessages.length > 0) {
+      const session = this.sessionManager.get(sessionKey);
+      const cursorKey = 'catscompany.agent_context';
+      const nextCursor = Math.max(session?.getRemoteContextCursor(cursorKey) || 0,
+        ...pendingGroupMessages.map(item => item.seq));
+      if (!session?.saveRemoteContextCursor(cursorKey, nextCursor)) {
+        Logger.warning(`[${sessionKey}] 追加消息的群上下文游标未能持久化，保留排队输入`);
+        return null;
+      }
     }
     const remainingMessages = queue.slice(firstRemainingIndex);
     if (remainingMessages.length > 0) {

--- a/tests/catscompany-execution-scope-flow.test.ts
+++ b/tests/catscompany-execution-scope-flow.test.ts
@@ -203,6 +203,72 @@ function createHarness(options: {
 }
 
 describe('CatsCompany execution scope flow', () => {
+  test('feeds a two-member web task follow-up into the active pending-input provider', async () => {
+    const harness = createHarness();
+    const topic = 'grp_80';
+    let started!: () => void;
+    let release!: () => void;
+    const startedPromise = new Promise<void>(resolve => { started = resolve; });
+    const gate = new Promise<void>(resolve => { release = resolve; });
+    let consume!: () => unknown;
+    harness.session.handleMessage = async (userMessage: unknown, options: any) => {
+      harness.handledTurns.push({userMessage, options});
+      consume = options.pendingUserInputProvider;
+      started();
+      await gate;
+      return {visibleToUser: false, text: ''};
+    };
+    const message = (text: string, seq: number) => ({
+      topic, senderId: 'usr7', text, content: text, isGroup: true, memberCount: 2, seq,
+      metadata: canonicalMetadata('usr7', topic),
+    });
+    const original = harness.bot.onMessage(message('original task', 20));
+    await startedPromise;
+    try {
+      await harness.bot.onMessage(message('web task follow-up', 21));
+      const pending: any = consume();
+      assert.match(String(pending?.content ?? pending), /web task follow-up/);
+      assert.equal(harness.session.getRemoteContextCursor(), 21);
+      assert.equal(harness.bot.messageQueue.has(expectedCatsCoSessionKey('usr7',topic)), false);
+    } finally {
+      release();
+      await original;
+    }
+    assert.equal(harness.handledTurns.length, 1);
+  });
+
+  test('retains pending web task input when its context cursor cannot be saved', async () => {
+    const harness = createHarness({busy: true});
+    const topic = 'grp_80';
+    const key = expectedCatsCoSessionKey('usr7',topic);
+    await harness.bot.onMessage({
+      topic, senderId: 'usr7', text: 'queued follow-up', content: 'queued follow-up',
+      isGroup: true, memberCount: 2, seq: 21, metadata: canonicalMetadata('usr7', topic),
+    });
+    harness.session.saveRemoteContextCursor = () => false;
+    const queued = harness.bot.messageQueue.get(key)[0];
+    assert.equal(harness.bot.consumeQueuedUserInput(key, queued.executionScope), null);
+    assert.equal(harness.bot.messageQueue.get(key).length, 1);
+    harness.session.saveRemoteContextCursor = () => true;
+    const pending = harness.bot.consumeQueuedUserInput(key, queued.executionScope);
+    assert.match(String(pending?.content ?? pending), /queued follow-up/);
+  });
+
+  test('keeps web groups with other or unknown members behind history hydration', async () => {
+    for (const memberCount of [3, undefined]) {
+      const harness = createHarness({busy: true});
+      const topic = 'grp_80';
+      const key = expectedCatsCoSessionKey('usr7',topic);
+      await harness.bot.onMessage({
+        topic, senderId: 'usr7', text: 'group follow-up', content: 'group follow-up',
+        isGroup: true, memberCount, mentions: ['usr43'], seq: 21, metadata: canonicalMetadata('usr7', topic),
+      });
+      const queued = harness.bot.messageQueue.get(key)[0];
+      assert.equal(harness.bot.consumeQueuedUserInput(key, queued.executionScope), null);
+      assert.equal(harness.bot.messageQueue.get(key).length, 1);
+    }
+  });
+
   test('/stop discards queued follow-ups and permits only new work afterwards', async () => {
     const harness = createHarness({ busy: true });
     const topic = 'p2p_7_43';


### PR DESCRIPTION
Live browser acceptance of #450 exposed a separate regression in ordinary web assistant tasks. These tasks are two-member groups. Every web group message carries a context-hydration marker, so the pending-input provider rejected its follow-up even though the existing hydration code skips external-history fetching for a two-member web task. The browser produced BASELINE_DONE, then started another task/run and processed the queued follow-up from Turn 1.

Allow compatible follow-ups for two-member web groups into the active episode and persist their context cursor before removing them from the queue. If cursor persistence fails, retain the input for the existing hydration path. Native channels, groups with more or unknown members, different execution scopes, and Artifact tasks keep their existing boundaries.

Validation: 149 relevant tests pass, including new active-provider, cursor failure, and group-boundary regressions; TypeScript build passes. The first two new tests failed before the fix. Live browser acceptance with the real production website and a local MiniMax M3 runtime is in progress. This complements https://github.com/buildsense-ai/cats-company/pull/405 and https://github.com/buildsense-ai/XiaoBa-CLI/pull/450 .
